### PR TITLE
Add address to listtransactions output

### DIFF
--- a/main.h
+++ b/main.h
@@ -874,7 +874,7 @@ public:
     }
 
     void GetAmounts(int64& nGenerated, list<pair<string /* address */, int64> >& listReceived,
-                    int64& nSent, int64& nFee, string& strSentAccount) const;
+                    list<pair<string /* address */, int64> >& listSent, int64& nFee, string& strSentAccount) const;
 
     void GetAccountAmounts(const string& strAccount, int64& nGenerated, int64& nReceived, 
                            int64& nSent, int64& nFee) const;


### PR DESCRIPTION
Three changes to listtransactions:

Add address to listtransactions output.

"multisends" (non-standard, use one transaction to send to multiple addresses) generate N "category":"send" lines.

Bug fix: listtransactions wasn't reporting pay-by-IP-connection receive transactions.
