### PR TITLE
Fix statusbar color

### DIFF
--- a/uibase.cpp
+++ b/uibase.cpp
@@ -61,7 +61,6 @@ CMainFrameBase::CMainFrameBase( wxWindow* parent, wxWindowID id, const wxString&
 	m_toolBar->Realize();
 	
 	m_statusBar = this->CreateStatusBar( 1, wxST_SIZEGRIP, wxID_ANY );
-	m_statusBar->SetBackgroundColour( wxColour( 240, 240, 240 ) );
 	
 	wxBoxSizer* bSizer2;
 	bSizer2 = new wxBoxSizer( wxVERTICAL );

--- a/uiproject.fbp
+++ b/uiproject.fbp
@@ -282,7 +282,7 @@
                 </object>
             </object>
             <object class="wxStatusBar" expanded="1">
-                <property name="bg">240,240,240</property>
+                <property name="bg"></property>
                 <property name="context_help"></property>
                 <property name="enabled">1</property>
                 <property name="fg"></property>


### PR DESCRIPTION
Unset the background color for the statusbar so it will use the system default.
If only background color is set explicitly (and not also foreground), users with light-on-dark system themes get unreadable white text on light-grey background.

Could also add an explicit foreground color, but I see no reason for the barely noticeable difference in the bg color in the first place.

(I tried editing the .fbp file with the wxFormBuilder, but it ended up changing the indentation (so git thinks every line has changed), so i just edited the template and the generated file by hand.)
