### PR TITLE
Show defaults in --help text

### DIFF
--- a/init.cpp
+++ b/init.cpp
@@ -179,10 +179,10 @@ bool AppInit2(int argc, char* argv[])
             "  -testnet         \t\t  " + _("Use the test network\n") +
             "  -rpcuser=<user>  \t  "   + _("Username for JSON-RPC connections\n") +
             "  -rpcpassword=<pw>\t  "   + _("Password for JSON-RPC connections\n") +
-            "  -rpcport=<port>  \t\t  " + _("Listen for JSON-RPC connections on <port>\n") +
+            "  -rpcport=<port>  \t\t  " + _("Listen for JSON-RPC connections on <port> (default: 8332)\n") +
             "  -rpcallowip=<ip> \t\t  " + _("Allow JSON-RPC connections from specified IP address\n") +
-            "  -rpcconnect=<ip> \t  "   + _("Send commands to node running on <ip>\n") +
-            "  -keypool=<n>     \t  "   + _("Set key pool size to <n>\n") +
+            "  -rpcconnect=<ip> \t  "   + _("Send commands to node running on <ip> (default: 127.0.0.1)\n") +
+            "  -keypool=<n>     \t  "   + _("Set key pool size to <n> (default: 100)\n") +
             "  -nolisten        \t  "   + _("Don't accept connections from outside");
 
 #ifdef USE_SSL


### PR DESCRIPTION
The --help text wasn't showing the default values for three of the options, as follows:

```
-rpcport (default: 8332)
-rpcconnect (default: 127.0.0.1)
-keypool (default: 100)
```

Edited the --help text to include the defaults.
