### PR TITLE
add -printtoconsole flat

### DIFF
--- a/init.cpp
+++ b/init.cpp
@@ -210,6 +210,7 @@ bool AppInit2(int argc, char* argv[])
 
     fDebug = GetBoolArg("-debug");
 
+    fPrintToConsole = GetBoolArg("-printtoconsole");
     fPrintToDebugger = GetBoolArg("-printtodebugger");
 
     fTestNet = GetBoolArg("-testnet");


### PR DESCRIPTION
Add new command line argument "-printtoconsole" to send debugging output to the console instead of to debug.log.  The code for this was already in place, but there was no way other than editing the source and rebuilding to turn it on. 
