### PR TITLE
the -4way command line argument is broken

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -3455,7 +3455,7 @@ void BitcoinMiner()
     SetThreadPriority(THREAD_PRIORITY_LOWEST);
     bool f4WaySSE2 = Detect128BitSSE2();
     if (mapArgs.count("-4way"))
-        f4WaySSE2 = GetBoolArg(mapArgs["-4way"]);
+        f4WaySSE2 = GetBoolArg("-4way");
 
     // Each thread has its own key and counter
     CReserveKey reservekey;


### PR DESCRIPTION
Currently, 4way (SSE2) hashing is done (if supported) unless -4way is specified, in which case it isn't, due to a bug in the processing of the -4way command line argument.
