### PR TITLE
-rpcssl help text

### DIFF
--- a/init.cpp
+++ b/init.cpp
@@ -189,7 +189,7 @@ bool AppInit2(int argc, char* argv[])
 #ifdef USE_SSL
         strUsage += string() +
             _("\nSSL options: (see the Bitcoin Wiki for SSL setup instructions)\n") +
-            "  -rpcssl=1                              \t  " + _("Use OpenSSL (https) for JSON-RPC connections\n") +
+            "  -rpcssl                                \t  " + _("Use OpenSSL (https) for JSON-RPC connections\n") +
             "  -rpcsslcertificatechainfile=<file.cert>\t  " + _("Server certificate file (default: server.cert)\n") +
             "  -rpcsslprivatekeyfile=<file.pem>       \t  " + _("Server private key (default: server.pem)\n") +
             "  -rpcsslciphers=<ciphers>               \t  " + _("Acceptable ciphers (default: TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!AH:!3DES:@STRENGTH)\n");


### PR DESCRIPTION
The -rpcssl command line option is a boolean, like -server, -daemon, -testnet, etc.

Specifying -rpcssl=1 is the same as just -rpcssl, as for any other boolean flag, so let's show it the same in the help text.
