### PR TITLE
vastly reduce unnecessary database writes

### DIFF
--- a/net.cpp
+++ b/net.cpp
@@ -1022,7 +1022,7 @@ void ThreadOpenConnections2(void* parg)
                 {
                     foreach(PAIRTYPE(const vector<unsigned char>, CAddress)& item, mapAddresses)
                     {
-                        if (setSeed.count(item.second.ip))
+                        if (setSeed.count(item.second.ip) && item.second.nTime != 0)
                         {
                             item.second.nTime = 0;
                             CAddrDB().WriteAddress(item.second);


### PR DESCRIPTION
The code updates database for every seed node every time we make a new outgoing connection.  This isn't necessary.
