### PR TITLE
Move rounding

### DIFF
--- a/rpc.cpp
+++ b/rpc.cpp
@@ -60,12 +60,16 @@ void PrintConsole(const char* format, ...)
 }
 
 
-int64 AmountFromValue(const Value& value)
+int64 AmountFromValue(const Value& value, bool bAmountRounding=true)
 {
     double dAmount = value.get_real();
     if (dAmount <= 0.0 || dAmount > 21000000.0)
         throw JSONRPCError(-3, "Invalid amount");
-    int64 nAmount = roundint64(dAmount * 100.00) * CENT;
+    int64 nAmount = 0;
+    if (bAmountRounding)
+        nAmount = roundint64(dAmount * 100.00) * CENT;
+    else
+        nAmount = roundint64(dAmount * COIN);
     if (!MoneyRange(nAmount))
         throw JSONRPCError(-3, "Invalid amount");
     return nAmount;
@@ -671,7 +675,7 @@ Value movecmd(const Array& params, bool fHelp)
 
     string strFrom = AccountFromValue(params[0]);
     string strTo = AccountFromValue(params[1]);
-    int64 nAmount = AmountFromValue(params[2]);
+    int64 nAmount = AmountFromValue(params[2], false);
     int nMinDepth = 1;
     if (params.size() > 3)
         nMinDepth = params[3].get_int();


### PR DESCRIPTION
I think it's important that the "move" command handles subcent transactions without silently rounding amounts at two decimal places.

It is common in a lot of cases to handle these small amounts (bitcoin central for example).

I want to keep using it as a second security level on bitcoin central, but right now it's not possible because the DB-tracked accounts slowly get out of sync with the bitcoin ones, and at some points transaction get rolled back because some bitcoin account does not have enough funds whereas the DB-tracked one has enough credit to complete the transaction.

If I try to move 0.001 BTC between two accounts I get a "true" returned even though I should have gotten an "Invalid amount" with the previous round-everything approach since nothing would have changed.

With this, rounding is only disabled for the "move" command.
