### PR TITLE
remove From/Message fields from SendDialog

### DIFF
--- a/ui.cpp
+++ b/ui.cpp
@@ -1854,7 +1854,7 @@ CSendDialog::CSendDialog(wxWindow* parent, const wxString& strAddress) : CSendDi
     if (fontTmp.GetPointSize() > 9);
         fontTmp.SetPointSize(9);
     m_staticTextInstructions->SetFont(fontTmp);
-    SetSize(725, 380);
+    SetSize(725, 180);
 #endif
 
     // Set Icon
@@ -1862,42 +1862,10 @@ CSendDialog::CSendDialog(wxWindow* parent, const wxString& strAddress) : CSendDi
     iconSend.CopyFromBitmap(wxBitmap(send16noshadow_xpm));
     SetIcon(iconSend);
 
-    wxCommandEvent event;
-    OnTextAddress(event);
-
     // Fixup the tab order
     m_buttonPaste->MoveAfterInTabOrder(m_buttonCancel);
     m_buttonAddress->MoveAfterInTabOrder(m_buttonPaste);
     this->Layout();
-}
-
-void CSendDialog::OnTextAddress(wxCommandEvent& event)
-{
-    // Check mark
-    event.Skip();
-    bool fBitcoinAddress = IsValidBitcoinAddress(m_textCtrlAddress->GetValue());
-    m_bitmapCheckMark->Show(fBitcoinAddress);
-
-    // Grey out message if bitcoin address
-    bool fEnable = !fBitcoinAddress;
-    m_staticTextFrom->Enable(fEnable);
-    m_textCtrlFrom->Enable(fEnable);
-    m_staticTextMessage->Enable(fEnable);
-    m_textCtrlMessage->Enable(fEnable);
-    m_textCtrlMessage->SetBackgroundColour(wxSystemSettings::GetColour(fEnable ? wxSYS_COLOUR_WINDOW : wxSYS_COLOUR_BTNFACE));
-    if (!fEnable && fEnabledPrev)
-    {
-        strFromSave    = m_textCtrlFrom->GetValue();
-        strMessageSave = m_textCtrlMessage->GetValue();
-        m_textCtrlFrom->SetValue(_("n/a"));
-        m_textCtrlMessage->SetValue(_("Can't include a message when sending to a Bitcoin address"));
-    }
-    else if (fEnable && !fEnabledPrev)
-    {
-        m_textCtrlFrom->SetValue(strFromSave);
-        m_textCtrlMessage->SetValue(strMessageSave);
-    }
-    fEnabledPrev = fEnable;
 }
 
 void CSendDialog::OnKillFocusAmount(wxFocusEvent& event)
@@ -1993,8 +1961,6 @@ void CSendDialog::OnButtonSend(wxCommandEvent& event)
 
             // Message
             wtx.mapValue["to"] = strAddress;
-            wtx.mapValue["from"] = m_textCtrlFrom->GetValue();
-            wtx.mapValue["message"] = m_textCtrlMessage->GetValue();
 
             // Send to IP address
             CSendingDialog* pdialog = new CSendingDialog(this, addr, nValue, wtx);

--- a/ui.h
+++ b/ui.h
@@ -166,7 +166,6 @@ class CSendDialog : public CSendDialogBase
 protected:
     // Event handlers
     void OnKeyDown(wxKeyEvent& event) { HandleCtrlA(event); }
-    void OnTextAddress(wxCommandEvent& event);
     void OnKillFocusAmount(wxFocusEvent& event);
     void OnButtonAddressBook(wxCommandEvent& event);
     void OnButtonPaste(wxCommandEvent& event);

--- a/uibase.cpp
+++ b/uibase.cpp
@@ -606,7 +606,7 @@ CSendDialogBase::CSendDialogBase( wxWindow* parent, wxWindowID id, const wxStrin
 	
 	fgSizer1->Add( 0, 0, 0, wxEXPAND, 5 );
 	
-	m_staticTextInstructions = new wxStaticText( this, wxID_ANY, _("Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJED9L) or IP address (e.g. 123.45.6.7)"), wxDefaultPosition, wxDefaultSize, 0 );
+	m_staticTextInstructions = new wxStaticText( this, wxID_ANY, _("Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)"), wxDefaultPosition, wxDefaultSize, 0 );
 	m_staticTextInstructions->Wrap( -1 );
 	fgSizer1->Add( m_staticTextInstructions, 0, wxTOP|wxRIGHT|wxLEFT, 5 );
 	
@@ -677,40 +677,6 @@ CSendDialogBase::CSendDialogBase( wxWindow* parent, wxWindowID id, const wxStrin
 	
 	bSizer21->Add( fgSizer1, 0, wxEXPAND|wxLEFT, 5 );
 	
-	wxBoxSizer* bSizer672;
-	bSizer672 = new wxBoxSizer( wxHORIZONTAL );
-	
-	wxBoxSizer* bSizer681;
-	bSizer681 = new wxBoxSizer( wxVERTICAL );
-	
-	m_staticTextFrom = new wxStaticText( this, wxID_ANY, _("&From:"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_staticTextFrom->Wrap( -1 );
-	bSizer681->Add( m_staticTextFrom, 0, wxBOTTOM|wxLEFT, 5 );
-	
-	m_textCtrlFrom = new wxTextCtrl( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( -1,-1 ), 0 );
-	bSizer681->Add( m_textCtrlFrom, 0, wxLEFT|wxEXPAND, 5 );
-	
-	bSizer672->Add( bSizer681, 1, wxEXPAND|wxBOTTOM|wxRIGHT|wxLEFT, 5 );
-	
-	bSizer21->Add( bSizer672, 0, wxEXPAND, 5 );
-	
-	wxBoxSizer* bSizer67;
-	bSizer67 = new wxBoxSizer( wxHORIZONTAL );
-	
-	wxBoxSizer* bSizer68;
-	bSizer68 = new wxBoxSizer( wxVERTICAL );
-	
-	m_staticTextMessage = new wxStaticText( this, wxID_ANY, _("&Message:"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_staticTextMessage->Wrap( -1 );
-	bSizer68->Add( m_staticTextMessage, 0, wxTOP|wxBOTTOM|wxLEFT, 5 );
-	
-	m_textCtrlMessage = new wxTextCtrl( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_MULTILINE );
-	bSizer68->Add( m_textCtrlMessage, 1, wxEXPAND|wxLEFT, 5 );
-	
-	bSizer67->Add( bSizer68, 1, wxEXPAND|wxBOTTOM|wxRIGHT|wxLEFT, 5 );
-	
-	bSizer21->Add( bSizer67, 1, wxEXPAND, 5 );
-	
 	wxBoxSizer* bSizer23;
 	bSizer23 = new wxBoxSizer( wxHORIZONTAL );
 	
@@ -732,13 +698,10 @@ CSendDialogBase::CSendDialogBase( wxWindow* parent, wxWindowID id, const wxStrin
 	
 	// Connect Events
 	m_textCtrlAddress->Connect( wxEVT_KEY_DOWN, wxKeyEventHandler( CSendDialogBase::OnKeyDown ), NULL, this );
-	m_textCtrlAddress->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( CSendDialogBase::OnTextAddress ), NULL, this );
 	m_buttonPaste->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( CSendDialogBase::OnButtonPaste ), NULL, this );
 	m_buttonAddress->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( CSendDialogBase::OnButtonAddressBook ), NULL, this );
 	m_textCtrlAmount->Connect( wxEVT_KEY_DOWN, wxKeyEventHandler( CSendDialogBase::OnKeyDown ), NULL, this );
 	m_textCtrlAmount->Connect( wxEVT_KILL_FOCUS, wxFocusEventHandler( CSendDialogBase::OnKillFocusAmount ), NULL, this );
-	m_textCtrlFrom->Connect( wxEVT_KEY_DOWN, wxKeyEventHandler( CSendDialogBase::OnKeyDown ), NULL, this );
-	m_textCtrlMessage->Connect( wxEVT_KEY_DOWN, wxKeyEventHandler( CSendDialogBase::OnKeyDown ), NULL, this );
 	m_buttonSend->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( CSendDialogBase::OnButtonSend ), NULL, this );
 	m_buttonCancel->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( CSendDialogBase::OnButtonCancel ), NULL, this );
 }
@@ -747,13 +710,10 @@ CSendDialogBase::~CSendDialogBase()
 {
 	// Disconnect Events
 	m_textCtrlAddress->Disconnect( wxEVT_KEY_DOWN, wxKeyEventHandler( CSendDialogBase::OnKeyDown ), NULL, this );
-	m_textCtrlAddress->Disconnect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( CSendDialogBase::OnTextAddress ), NULL, this );
 	m_buttonPaste->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( CSendDialogBase::OnButtonPaste ), NULL, this );
 	m_buttonAddress->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( CSendDialogBase::OnButtonAddressBook ), NULL, this );
 	m_textCtrlAmount->Disconnect( wxEVT_KEY_DOWN, wxKeyEventHandler( CSendDialogBase::OnKeyDown ), NULL, this );
 	m_textCtrlAmount->Disconnect( wxEVT_KILL_FOCUS, wxFocusEventHandler( CSendDialogBase::OnKillFocusAmount ), NULL, this );
-	m_textCtrlFrom->Disconnect( wxEVT_KEY_DOWN, wxKeyEventHandler( CSendDialogBase::OnKeyDown ), NULL, this );
-	m_textCtrlMessage->Disconnect( wxEVT_KEY_DOWN, wxKeyEventHandler( CSendDialogBase::OnKeyDown ), NULL, this );
 	m_buttonSend->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( CSendDialogBase::OnButtonSend ), NULL, this );
 	m_buttonCancel->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( CSendDialogBase::OnButtonCancel ), NULL, this );
 }


### PR DESCRIPTION
From/Message fields fool some users into thinking they could include a message with a transaction. This removes the feature from the GUI (but not from the code) and only shows address and amount fields in SendDialog.

edit: It also changes the displayed sample address to an invalid one so users don't send coins there.
