### PR TITLE
Fix makefile.unix to link wxWidgets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+bitcoin
+bitcoind

--- a/makefile.unix
+++ b/makefile.unix
@@ -3,17 +3,9 @@
 # file license.txt or http://www.opensource.org/licenses/mit-license.php.
 
 
-INCLUDEPATHS= \
- -I"/usr/local/include/wx-2.9" \
- -I"/usr/local/lib/wx/include/gtk2-unicode-debug-static-2.9"
+INCLUDEPATHS=$(shell wx-config --cflags)
 
-# for wxWidgets 2.9.1, add -l Xxf86vm
-WXLIBS= \
- -Wl,-Bstatic \
-   -l wx_gtk2ud-2.9 \
- -Wl,-Bdynamic \
-   -l gtk-x11-2.0 \
-   -l SM
+WXLIBS=$(shell wx-config --libs)
 
 # for boost 1.37, add -mt to the boost libraries
 LIBS= \


### PR DESCRIPTION
I tried to build bitcoin following the instructions in build-unix.txt. I suppose I should have read this line:
"The build hasn't been updated to work with wxWidgets 2.9.1 yet."

Anyway, the makefile is not very robust in specifically including wx files directly in the INCLUDEPATHS and WXLIBS. I had a bunch of build problems which were all solved by simply using the utility that comes with wx, wx-config. This utility is automatically installed by wx's 'make install', and will provide the correct command-line arguments for including and linking correctly.

I have updated the makefile to use these tools rather than hand-coding the paths. It works for me, but I haven't tested it on multiple configurations. If it works for other people (and I figure it will be much more robust in the long run), then it should be merged.

My branch also adds .gitignore, which I find useful.
