### PR TITLE
Fix wx-config usage

### DIFF
--- a/build-unix.txt
+++ b/build-unix.txt
@@ -29,8 +29,8 @@ or Boost 1.37: sudo apt-get install libboost1.37-dev
 
 If using Boost 1.37, append -mt to the boost libraries in the makefile.
 
-We're using wxWidgets 2.9.0, which uses UTF-8.  Don't try 2.8, it won't work.
-The build hasn't been updated to work with wxWidgets 2.9.1 yet.
+Requires wxWidgets 2.9.0 or greater, which uses UTF-8.  Don't try 2.8, it
+won't work.
 
 You need to download wxWidgets from http://www.wxwidgets.org/downloads/
 and build it yourself.  See the build instructions and configure parameters

--- a/makefile.unix
+++ b/makefile.unix
@@ -25,7 +25,7 @@ LIBS= \
 
 DEFS=-DNOPCH -DFOURWAYSSE2 -DUSE_SSL
 DEBUGFLAGS=-g -D__WXDEBUG__
-CXXFLAGS=-O2 -Wno-invalid-offsetof -Wformat $(DEBUGFLAGS) $(DEFS) $(WXINCLUDEPATHS)
+CXXFLAGS=-O2 -Wno-invalid-offsetof -Wformat $(DEBUGFLAGS) $(DEFS)
 HEADERS=headers.h strlcpy.h serialize.h uint256.h util.h key.h bignum.h base58.h \
     script.h db.h net.h irc.h main.h rpc.h uibase.h ui.h noui.h init.h
 
@@ -46,7 +46,7 @@ all: bitcoin
 
 
 obj/%.o: %.cpp $(HEADERS)
-	$(CXX) -c $(CXXFLAGS) -DGUI -o $@ $<
+	$(CXX) -c $(CXXFLAGS) $(WXINCLUDEPATHS) -DGUI -o $@ $<
 
 cryptopp/obj/%.o: cryptopp/%.cpp
 	$(CXX) -c $(CXXFLAGS) -O3 -o $@ $<

--- a/makefile.unix
+++ b/makefile.unix
@@ -2,18 +2,11 @@
 # Distributed under the MIT/X11 software license, see the accompanying
 # file license.txt or http://www.opensource.org/licenses/mit-license.php.
 
+CXX=g++
 
-INCLUDEPATHS= \
- -I"/usr/local/include/wx-2.9" \
- -I"/usr/local/lib/wx/include/gtk2-unicode-debug-static-2.9"
+WXINCLUDEPATHS:=$(shell wx-config --cppflags)
 
-# for wxWidgets 2.9.1, add -l Xxf86vm
-WXLIBS= \
- -Wl,-Bstatic \
-   -l wx_gtk2ud-2.9 \
- -Wl,-Bdynamic \
-   -l gtk-x11-2.0 \
-   -l SM
+WXLIBS:=$(shell wx-config --libs)
 
 # for boost 1.37, add -mt to the boost libraries
 LIBS= \
@@ -30,9 +23,9 @@ LIBS= \
    -l z \
    -l dl
 
-DEFS=-D__WXGTK__ -DNOPCH -DFOURWAYSSE2 -DUSE_SSL
+DEFS:=$(shell wx-config --cxxflags) -DNOPCH -DFOURWAYSSE2 -DUSE_SSL
 DEBUGFLAGS=-g -D__WXDEBUG__
-CFLAGS=-O2 -Wno-invalid-offsetof -Wformat $(DEBUGFLAGS) $(DEFS) $(INCLUDEPATHS)
+CXXFLAGS=-O2 -Wno-invalid-offsetof -Wformat $(DEBUGFLAGS) $(DEFS) $(WXINCLUDEPATHS)
 HEADERS=headers.h strlcpy.h serialize.h uint256.h util.h key.h bignum.h base58.h \
     script.h db.h net.h irc.h main.h rpc.h uibase.h ui.h noui.h init.h
 
@@ -53,23 +46,23 @@ all: bitcoin
 
 
 obj/%.o: %.cpp $(HEADERS)
-	g++ -c $(CFLAGS) -DGUI -o $@ $<
+	$(CXX) -c $(CXXFLAGS) -DGUI -o $@ $<
 
 cryptopp/obj/%.o: cryptopp/%.cpp
-	g++ -c $(CFLAGS) -O3 -o $@ $<
+	$(CXX) -c $(CXXFLAGS) -O3 -o $@ $<
 
 obj/sha256.o: sha256.cpp
-	g++ -c $(CFLAGS) -msse2 -O3 -march=amdfam10 -o $@ $<
+	$(CXX) -c $(CXXFLAGS) -msse2 -O3 -march=amdfam10 -o $@ $<
 
 bitcoin: $(OBJS) obj/ui.o obj/uibase.o obj/sha256.o
-	g++ $(CFLAGS) -o $@ $^ $(WXLIBS) $(LIBS)
+	$(CXX) $(CXXFLAGS) -o $@ $^ $(WXLIBS) $(LIBS)
 
 
 obj/nogui/%.o: %.cpp $(HEADERS)
-	g++ -c $(CFLAGS) -o $@ $<
+	$(CXX) -c $(CXXFLAGS) -o $@ $<
 
 bitcoind: $(OBJS:obj/%=obj/nogui/%) obj/sha256.o
-	g++ $(CFLAGS) -o $@ $^ $(LIBS)
+	$(CXX) $(CXXFLAGS) -o $@ $^ $(LIBS)
 
 
 clean:
@@ -77,3 +70,5 @@ clean:
 	-rm -f obj/nogui/*.o
 	-rm -f cryptopp/obj/*.o
 	-rm -f headers.h.gch
+	-rm -f bitcoin
+	-rm -f bitcoind

--- a/makefile.unix
+++ b/makefile.unix
@@ -4,9 +4,9 @@
 
 CXX=g++
 
-WXINCLUDEPATHS:=$(shell wx-config --cxxflags)
+WXINCLUDEPATHS=$(shell wx-config --cxxflags)
 
-WXLIBS:=$(shell wx-config --libs)
+WXLIBS=$(shell wx-config --libs)
 
 # for boost 1.37, add -mt to the boost libraries
 LIBS= \

--- a/makefile.unix
+++ b/makefile.unix
@@ -4,7 +4,7 @@
 
 CXX=g++
 
-WXINCLUDEPATHS:=$(shell wx-config --cppflags)
+WXINCLUDEPATHS:=$(shell wx-config --cxxflags)
 
 WXLIBS:=$(shell wx-config --libs)
 
@@ -23,7 +23,7 @@ LIBS= \
    -l z \
    -l dl
 
-DEFS:=$(shell wx-config --cxxflags) -DNOPCH -DFOURWAYSSE2 -DUSE_SSL
+DEFS=-DNOPCH -DFOURWAYSSE2 -DUSE_SSL
 DEBUGFLAGS=-g -D__WXDEBUG__
 CXXFLAGS=-O2 -Wno-invalid-offsetof -Wformat $(DEBUGFLAGS) $(DEFS) $(WXINCLUDEPATHS)
 HEADERS=headers.h strlcpy.h serialize.h uint256.h util.h key.h bignum.h base58.h \


### PR DESCRIPTION
Hi,

This is a response to the [other pull request](https://github.com/bitcoin/bitcoin/pull/52) by ojab. I didn't want to make a new pull request but I couldn't find another way to do it.

The last comment by tcatm was "This patch works ... outputs annoying errors (wx-config not found) when building bitcoind. Can you fix that?"

I have fixed it in this branch (it no longer tries to include wx at all for any non-GUI files), and updated the readme to say it's OK to use wx 2.9.1 now. It now builds bitcoind just fine even if your system has no trace of wxWidgets.
