### PR TITLE
setaccount should not create new accounts if provided with an invalid address

### DIFF
--- a/rpc.cpp
+++ b/rpc.cpp
@@ -381,6 +381,12 @@ Value setaccount(const Array& params, bool fHelp)
             "Sets the account associated with the given address.");
 
     string strAddress = params[0].get_str();
+    uint160 hash160;
+    bool isValid = AddressToHash160(strAddress, hash160);
+    if (!isValid)
+        throw runtime_error("provided address is not valid");
+
+
     string strAccount;
     if (params.size() > 1)
         strAccount = AccountFromValue(params[1]);

--- a/rpc.cpp
+++ b/rpc.cpp
@@ -384,7 +384,7 @@ Value setaccount(const Array& params, bool fHelp)
     uint160 hash160;
     bool isValid = AddressToHash160(strAddress, hash160);
     if (!isValid)
-        throw runtime_error("provided address is not valid");
+        throw JSONRPCError(-5, "Invalid bitcoin address");
 
 
     string strAccount;


### PR DESCRIPTION
Simple solution to just return an error if the address provided is invalid.
