### PR TITLE
Shy clients

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -2366,6 +2366,10 @@ bool ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
             return true;
         }
 
+        // Be shy and don't send version until we hear
+        if (pfrom->fInbound)
+            pfrom->PushVersion();
+
         pfrom->fClient = !(pfrom->nServices & NODE_NETWORK);
 
         AddTimeData(pfrom->addr.ip, nTime);

--- a/net.h
+++ b/net.h
@@ -571,14 +571,9 @@ public:
         fGetAddr = false;
         vfSubscribe.assign(256, false);
 
-        // Push a version message
-        /// when NTP implemented, change to just nTime = GetAdjustedTime()
-        int64 nTime = (fInbound ? GetAdjustedTime() : GetTime());
-        CAddress addrYou = (fUseProxy ? CAddress("0.0.0.0") : addr);
-        CAddress addrMe = (fUseProxy ? CAddress("0.0.0.0") : addrLocalHost);
-        RAND_bytes((unsigned char*)&nLocalHostNonce, sizeof(nLocalHostNonce));
-        PushMessage("version", VERSION, nLocalServices, nTime, addrYou, addrMe,
-                    nLocalHostNonce, string(pszSubVer), nBestHeight);
+        // Be shy and don't send version until we hear
+        if (!fInbound)
+            PushVersion();
     }
 
     ~CNode()
@@ -731,6 +726,19 @@ public:
             EndMessage();
         else
             AbortMessage();
+    }
+
+
+
+    void PushVersion()
+    {
+        /// when NTP implemented, change to just nTime = GetAdjustedTime()
+        int64 nTime = (fInbound ? GetAdjustedTime() : GetTime());
+        CAddress addrYou = (fUseProxy ? CAddress("0.0.0.0") : addr);
+        CAddress addrMe = (fUseProxy ? CAddress("0.0.0.0") : addrLocalHost);
+        RAND_bytes((unsigned char*)&nLocalHostNonce, sizeof(nLocalHostNonce));
+        PushMessage("version", VERSION, nLocalServices, nTime, addrYou, addrMe,
+                nLocalHostNonce, string(pszSubVer), nBestHeight);
     }
 
 


### PR DESCRIPTION
Shy client patch from Hal Finney:
"On incoming connections, it won't send a version message until it receives one. This can help make port scanning identification harder."
