### PR TITLE
Sendmany RPC call

### DIFF
--- a/main.h
+++ b/main.h
@@ -77,6 +77,7 @@ bool ProcessMessages(CNode* pfrom);
 bool ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv);
 bool SendMessages(CNode* pto, bool fSendTrickle);
 int64 GetBalance();
+bool CreateTransaction(const vector<pair<CScript, int64> >& vecSend, CWalletTx& wtxNew, CReserveKey& reservekey, int64& nFeeRet);
 bool CreateTransaction(CScript scriptPubKey, int64 nValue, CWalletTx& wtxNew, CReserveKey& reservekey, int64& nFeeRet);
 bool CommitTransaction(CWalletTx& wtxNew, CReserveKey& reservekey);
 bool BroadcastTransaction(CWalletTx& wtxNew);


### PR DESCRIPTION
Need for this is being driven by mining pool operators; it is much more efficient to pay lots of people with one transaction rather than lots of little transactions.

Old clients will refuse to relay sendmany transactions, so to ensure timely inclusion in a block mining pool operators should either upgrade together and connect their clients together or wait until a good percentage of the network has had a change to upgrade to the next version of bitcoin.
