### PR TITLE
DNS seeding of P2P node addresses

### DIFF
--- a/init.cpp
+++ b/init.cpp
@@ -416,6 +416,9 @@ bool AppInit2(int argc, char* argv[])
         }
     }
 
+    if (mapArgs.count("-dnsseed"))
+        DNSAddressSeed();
+
     if (mapArgs.count("-paytxfee"))
     {
         if (!ParseMoney(mapArgs["-paytxfee"], nTransactionFee))

--- a/net.cpp
+++ b/net.cpp
@@ -883,7 +883,7 @@ void DNSAddressSeed()
         }
     }
 
-    printf("%d addresses found from DNS seeds\n");
+    printf("%d addresses found from DNS seeds\n", found);
 }
 
 

--- a/net.cpp
+++ b/net.cpp
@@ -857,7 +857,34 @@ void ThreadSocketHandler2(void* parg)
 
 
 
+static const char *strDNSSeed[] = {
+    "bitseed.xf2.org",
+};
 
+void DNSAddressSeed()
+{
+    int found = 0;
+
+    printf("Loading addresses from DNS seeds (could take a while)\n");
+
+    for (int seed_idx = 0; seed_idx < ARRAYLEN(strDNSSeed); seed_idx++) {
+        struct hostent* phostent = gethostbyname(strDNSSeed[seed_idx]);
+        if (!phostent)
+            continue;
+
+        for (int host = 0; phostent->h_addr_list[host] != NULL; host++) {
+            CAddress addr(*(unsigned int*)phostent->h_addr_list[host],
+                          GetDefaultPort(), NODE_NETWORK);
+            addr.nTime = 0;
+            if (addr.IsValid() && addr.GetByte(3) != 127) {
+                AddAddress(addr);
+                found++;
+            }
+        }
+    }
+
+    printf("%d addresses found from DNS seeds\n");
+}
 
 
 

--- a/net.h
+++ b/net.h
@@ -30,6 +30,7 @@ CNode* FindNode(unsigned int ip);
 CNode* ConnectNode(CAddress addrConnect, int64 nTimeout=0);
 void AbandonRequests(void (*fn)(void*, CDataStream&), void* param1);
 bool AnySubscribed(unsigned int nChannel);
+void DNSAddressSeed();
 bool BindListenPort(string& strError=REF(string()));
 void StartNode(void* parg);
 bool StopNode();


### PR DESCRIPTION
This change adds DNS (via "-dnsseed") as an alternative method for seeding P2P node addresses.
