### PR TITLE
Spent per txout

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -217,10 +217,10 @@ void WalletUpdateSpent(const COutPoint& prevout)
         if (mi != mapWallet.end())
         {
             CWalletTx& wtx = (*mi).second;
-            if (!wtx.vfSpent[prevout.n] && wtx.vout[prevout.n].IsMine())
+            if (!wtx.IsSpent(prevout.n) && wtx.vout[prevout.n].IsMine())
             {
                 printf("WalletUpdateSpent found spent coin %sbc %s\n", FormatMoney(wtx.GetCredit()).c_str(), wtx.GetHash().ToString().c_str());
-                wtx.vfSpent[prevout.n] = true;
+                wtx.MarkSpent(prevout.n);
                 wtx.WriteToDisk();
                 vWalletUpdated.push_back(prevout.hash);
             }
@@ -938,7 +938,7 @@ void ReacceptWalletTransactions()
                 {
                     if (!txindex.vSpent[i].IsNull() && wtx.vout[i].IsMine())
                     {
-                        wtx.vfSpent[i] = true;
+                        wtx.MarkSpent(i);
                         fUpdated = true;
                         vMissingTx.push_back(txindex.vSpent[i]);
                     }
@@ -3746,7 +3746,7 @@ bool SelectCoinsMinConf(int64 nTargetValue, int nConfMine, int nConfTheirs, set<
 
             for (int i = 0; i < pcoin->vout.size(); i++)
             {
-                if (pcoin->vfSpent[i] || !pcoin->vout[i].IsMine())
+                if (pcoin->IsSpent(i) || !pcoin->vout[i].IsMine())
                     continue;
 
                 int64 n = pcoin->vout[i].nValue;
@@ -3974,7 +3974,7 @@ bool CommitTransaction(CWalletTx& wtxNew, CReserveKey& reservekey)
             foreach(const CTxIn& txin, wtxNew.vin)
             {
                 CWalletTx &pcoin = mapWallet[txin.prevout.hash];
-                pcoin.vfSpent[txin.prevout.n] = true;
+                pcoin.MarkSpent(txin.prevout.n);
                 pcoin.WriteToDisk();
                 vWalletUpdated.push_back(pcoin.GetHash());
             }

--- a/main.cpp
+++ b/main.cpp
@@ -892,6 +892,7 @@ int ScanForWalletTransactions(CBlockIndex* pindexStart)
                 AddToWalletIfMine(tx, &block);
                 if (mapWallet.count(hash))
                 {
+                    tx.MarkDirty();
                     ++ret;
                     printf("Added missing RECEIVE %s\n", hash.ToString().c_str());
                     continue;
@@ -899,6 +900,7 @@ int ScanForWalletTransactions(CBlockIndex* pindexStart)
                 AddToWalletIfFromMe(tx, &block);
                 if (mapWallet.count(hash))
                 {
+                    tx.MarkDirty();
                     ++ret;
                     printf("Added missing SEND %s\n", hash.ToString().c_str());
                     continue;

--- a/main.cpp
+++ b/main.cpp
@@ -3888,11 +3888,10 @@ bool CreateTransaction(CScript scriptPubKey, int64 nValue, CWalletTx& wtxNew, CR
                 int64 nValueIn = 0;
                 if (!SelectCoins(nTotalValue, setCoins, nValueIn))
                     return false;
-                foreach(CWalletTx* pcoin, setCoins)
+                foreach(PAIRTYPE(CWalletTx*, unsigned int) pcoin, setCoins)
                 {
-                    int64 nCredit = pcoin->GetCredit();
-                    nValueIn += nCredit;
-                    dPriority += (double)nCredit * pcoin->GetDepthInMainChain();
+                    int64 nCredit = pcoin.first->vout[pcoin.second].nValue;
+                    dPriority += (double)nCredit * pcoin.first->GetDepthInMainChain();
                 }
 
                 // Fill a vout to the payee

--- a/main.cpp
+++ b/main.cpp
@@ -892,7 +892,6 @@ int ScanForWalletTransactions(CBlockIndex* pindexStart)
                 AddToWalletIfMine(tx, &block);
                 if (mapWallet.count(hash))
                 {
-                    tx.MarkDirty();
                     ++ret;
                     printf("Added missing RECEIVE %s\n", hash.ToString().c_str());
                     continue;
@@ -900,7 +899,6 @@ int ScanForWalletTransactions(CBlockIndex* pindexStart)
                 AddToWalletIfFromMe(tx, &block);
                 if (mapWallet.count(hash))
                 {
-                    tx.MarkDirty();
                     ++ret;
                     printf("Added missing SEND %s\n", hash.ToString().c_str());
                     continue;
@@ -948,6 +946,7 @@ void ReacceptWalletTransactions()
                 if (fUpdated)
                 {
                     printf("ReacceptWalletTransactions found spent coin %sbc %s\n", FormatMoney(wtx.GetCredit()).c_str(), wtx.GetHash().ToString().c_str());
+                    wtx.MarkDirty();
                     wtx.WriteToDisk();
                 }
             }

--- a/main.cpp
+++ b/main.cpp
@@ -3764,6 +3764,9 @@ bool SelectCoinsMinConf(int64 nTargetValue, int nConfMine, int nConfTheirs, set<
             if (!pcoin->IsFinal() || !pcoin->IsConfirmed())
                 continue;
 
+            if (pcoin->IsCoinBase() && pcoin->GetBlocksToMaturity() > 0)
+                continue;
+
             int nDepth = pcoin->GetDepthInMainChain();
             if (nDepth < (pcoin->IsFromMe() ? nConfMine : nConfTheirs))
                 continue;
@@ -3771,9 +3774,6 @@ bool SelectCoinsMinConf(int64 nTargetValue, int nConfMine, int nConfTheirs, set<
             for (int i = 0; i < pcoin->vout.size(); i++)
             {
                 if (pcoin->IsSpent(i) || !pcoin->vout[i].IsMine())
-                    continue;
-
-                if (pcoin->IsCoinBase() && pcoin->GetBlocksToMaturity() > 0)
                     continue;
 
                 int64 n = pcoin->vout[i].nValue;

--- a/main.cpp
+++ b/main.cpp
@@ -921,8 +921,8 @@ void ReacceptWalletTransactions()
         foreach(PAIRTYPE(const uint256, CWalletTx)& item, mapWallet)
         {
             CWalletTx& wtx = item.second;
-//            if (wtx.fSpent && wtx.IsCoinBase())
-//                continue;
+            if (wtx.IsCoinBase() && wtx.IsSpent(0))
+                continue;
 
             CTxIndex txindex;
             bool fUpdated;

--- a/main.cpp
+++ b/main.cpp
@@ -3750,6 +3750,9 @@ bool SelectCoinsMinConf(int64 nTargetValue, int nConfMine, int nConfTheirs, set<
                 if (pcoin->IsSpent(i) || !pcoin->vout[i].IsMine())
                     continue;
 
+                if (pcoin->IsCoinBase() && pcoin->GetBlocksToMaturity() > 0)
+                    continue;
+
                 int64 n = pcoin->vout[i].nValue;
 
                 if (n <= 0)

--- a/main.h
+++ b/main.h
@@ -894,7 +894,7 @@ public:
         vfSpent[nOut] = true;
     }
 
-    bool IsSpent(unsigned int nOut)
+    bool IsSpent(unsigned int nOut) const
     {
         if (nOut >= vout.size())
             throw runtime_error("CWalletTx::IsSpent() : nOut out of range");

--- a/main.h
+++ b/main.h
@@ -882,6 +882,7 @@ public:
             {
                 vfSpent[i] = true;
                 fReturn = true;
+                fAvailableCreditCached = false;
             }
         }
         return fReturn;
@@ -900,7 +901,11 @@ public:
         if (nOut >= vout.size())
             throw runtime_error("CWalletTx::MarkSpent() : nOut out of range");
         vfSpent.resize(vout.size());
-        vfSpent[nOut] = true;
+        if (!vfSpent[nOut])
+        {
+            vfSpent[nOut] = true;
+            fAvailableCreditCached = false;
+        }
     }
 
     bool IsSpent(unsigned int nOut) const

--- a/main.h
+++ b/main.h
@@ -928,10 +928,10 @@ public:
         return nCreditCached;
     }
 
-    int64 GetAvailableCredit() const
+    int64 GetAvailableCredit(bool fProspected=false) const
     {
         // Must wait until coinbase is safely deep enough in the chain before valuing it
-        if (IsCoinBase() && GetBlocksToMaturity() > 0)
+        if (!fProspected && IsCoinBase() && GetBlocksToMaturity() > 0)
             return 0;
 
         int64 nCredit = 0;

--- a/main.h
+++ b/main.h
@@ -930,6 +930,10 @@ public:
 
     int64 GetAvailableCredit() const
     {
+        // Must wait until coinbase is safely deep enough in the chain before valuing it
+        if (IsCoinBase() && GetBlocksToMaturity() > 0)
+            return 0;
+
         int64 nCredit = 0;
         for (int i = 0; i < vout.size(); i++)
         {

--- a/makefile.unix
+++ b/makefile.unix
@@ -25,7 +25,7 @@ LIBS= \
 
 DEFS=-DNOPCH -DFOURWAYSSE2 -DUSE_SSL
 DEBUGFLAGS=-g -D__WXDEBUG__
-CXXFLAGS=-O2 -Wno-invalid-offsetof -Wformat $(DEBUGFLAGS) $(DEFS)
+CXXFLAGS=-O2 -Wno-invalid-offsetof -Wformat -pthread $(DEBUGFLAGS) $(DEFS)
 HEADERS=headers.h strlcpy.h serialize.h uint256.h util.h key.h bignum.h base58.h \
     script.h db.h net.h irc.h main.h rpc.h uibase.h ui.h noui.h init.h
 

--- a/ui.cpp
+++ b/ui.cpp
@@ -784,7 +784,7 @@ bool CMainFrame::InsertTransaction(const CWalletTx& wtx, bool fNew, int nIndex)
             InsertLine(fNew, nIndex, hash, strSort, colour,
                        strStatus,
                        nTime ? DateTimeStr(nTime) : "",
-                       "",
+                       "Mixed transaction",
                        FormatMoney(nNet, true),
                        "");
         }


### PR DESCRIPTION
This patch changes some internal structures to keep track of spentness of each wallet transaction output separately, to support partially-spent transactions. It contains:
- an update to the data structures (vfSpent in CWalletTx instead of fSpent)
- a backward-compatible update to the wallet disk format (written by Satoshi, Gavin knows). Old clients reading back an updated wallet will ignore partially spent transactions when creating new ones, and may report a wrong balance, though.
- some helper functions (CWalletTx: IsSpent, MarkSpent, MarkDirty to reset cached values, GetAvailableCredit which only counts unredeemed outputs)
- update to SelectCoins and CreateTransaction to select source transaction outputs separately instead of per whole transaction. This fixes the issue mentioned in http://www.bitcoin.org/smf/index.php?topic=3759.0

The reason for writing this patch: i'm also working on an import/export wallet patch, where situations with partially spent transactions become hard to avoid.

Everything except loading a new wallet into an old client is tested on the testnet, including crafted situations with partially-spent transactions.
