### PR TITLE
List Accounts Fix (Issue 76)

### DIFF
--- a/rpc.cpp
+++ b/rpc.cpp
@@ -1135,10 +1135,11 @@ Value listaccounts(const Array& params, bool fHelp)
     CRITICAL_BLOCK(cs_mapWallet)
     CRITICAL_BLOCK(cs_mapAddressBook)
     {
-        foreach(const PAIRTYPE(string, string)& entry, mapAddressBook)
+        foreach(const PAIRTYPE(string, string)& entry, mapAddressBook) {
             uint160 hash160;
-            if(AddressToHash160(entry.first, hash160) && mapPubKeys.count(hash1
+            if(AddressToHash160(entry.first, hash160) && mapPubKeys.count(hash160)) // This address belongs to me
                 mapAccountBalances[entry.second] = 0;
+        }
 
         for (map<uint256, CWalletTx>::iterator it = mapWallet.begin(); it != mapWallet.end(); ++it)
         {

--- a/rpc.cpp
+++ b/rpc.cpp
@@ -1136,7 +1136,9 @@ Value listaccounts(const Array& params, bool fHelp)
     CRITICAL_BLOCK(cs_mapAddressBook)
     {
         foreach(const PAIRTYPE(string, string)& entry, mapAddressBook)
-            mapAccountBalances[entry.second] = 0;
+            uint160 hash160;
+            if(AddressToHash160(entry.first, hash160) && mapPubKeys.count(hash1
+                mapAccountBalances[entry.second] = 0;
 
         for (map<uint256, CWalletTx>::iterator it = mapWallet.begin(); it != mapWallet.end(); ++it)
         {


### PR DESCRIPTION
Addresses from the sending tab in wxGUI's addressbook appear in listaccounts. The RPC will happily return that address even though it isn't yours.

This is a problem when switching from wxGUI to a RPC UI.

Fixed by adding

```
foreach(const PAIRTYPE(string, string)& entry, mapAddressBook)  
   uint160 hash160;
   if(AddressToHash160(entry.first, hash160) && mapPubKeys.count(hash160)) // This address belongs to me
       mapAccountBalances[entry.second] = 0;
```

to make sure that mapAccountBalances doesn't contain any addresses that we don't have in our key list.

My previous request didn't build. _whoops_ Fixed for sure this time.
