### PR TITLE
Add immature blocks to listtransactions output

### DIFF
--- a/init.cpp
+++ b/init.cpp
@@ -78,7 +78,9 @@ int main(int argc, char* argv[])
     fRet = AppInit(argc, argv);
 
     if (fRet && fDaemon)
-        pthread_exit((void*)0);
+        return 0;
+
+    return 1;
 }
 #endif
 
@@ -158,6 +160,8 @@ bool AppInit2(int argc, char* argv[])
             "  -paytxfee=<amt>  \t  "   + _("Fee per KB to add to transactions you send\n") +
 #ifdef GUI
             "  -server          \t\t  " + _("Accept command line and JSON-RPC commands\n") +
+#endif
+#ifndef WIN32 
             "  -daemon          \t\t  " + _("Run in the background as a daemon and accept commands\n") +
 #endif
             "  -testnet         \t\t  " + _("Use the test network\n") +
@@ -194,17 +198,20 @@ bool AppInit2(int argc, char* argv[])
 
     fDebug = GetBoolArg("-debug");
 
+#ifndef WIN32
     fDaemon = GetBoolArg("-daemon");
+#else
+    fDaemon = false;
+#endif
 
     if (fDaemon)
         fServer = true;
     else
         fServer = GetBoolArg("-server");
 
-    /* force fServer and fDaemon when running without GUI */
+    /* force fServer when running without GUI */
 #ifndef GUI
     fServer = true;
-    fDaemon = true;
 #endif
 
     fPrintToConsole = GetBoolArg("-printtoconsole");
@@ -224,7 +231,7 @@ bool AppInit2(int argc, char* argv[])
         exit(ret);
     }
 
-#ifndef GUI
+#ifndef WIN32
     if (fDaemon)
     {
         // Daemonize
@@ -470,10 +477,11 @@ bool AppInit2(int argc, char* argv[])
     if (fFirstRun)
         SetStartOnSystemStartup(true);
 #endif
-    
-    if (fDaemon)
-        while (!fShutdown)
-            Sleep(5000);
+
+#ifndef GUI
+    while (1)
+        Sleep(5000);
+#endif
 
     return true;
 }

--- a/main.cpp
+++ b/main.cpp
@@ -407,18 +407,20 @@ int CWalletTx::GetRequestCount() const
     return nRequests;
 }
 
-void CWalletTx::GetAmounts(int64& nGenerated, list<pair<string, int64> >& listReceived,
+void CWalletTx::GetAmounts(int64& nGeneratedImmature, int64& nGeneratedMature, list<pair<string, int64> >& listReceived,
                            list<pair<string, int64> >& listSent, int64& nFee, string& strSentAccount) const
 {
-    nGenerated = nFee = 0;
+    nGeneratedImmature = nGeneratedMature = nFee = 0;
     listReceived.clear();
     listSent.clear();
     strSentAccount = strFromAccount;
 
     if (IsCoinBase())
     {
-        if (GetDepthInMainChain() >= COINBASE_MATURITY)
-            nGenerated = GetCredit();
+        if (GetBlocksToMaturity() > 0)
+            nGeneratedImmature = CTransaction::GetCredit();
+        else
+            nGeneratedMature = GetCredit();
         return;
     }
 
@@ -466,15 +468,15 @@ void CWalletTx::GetAccountAmounts(const string& strAccount, int64& nGenerated, i
 {
     nGenerated = nReceived = nSent = nFee = 0;
 
-    int64 allGenerated, allFee;
-    allGenerated = allFee = 0;
+    int64 allGeneratedImmature, allGeneratedMature, allFee;
+    allGeneratedImmature = allGeneratedMature = allFee = 0;
     string strSentAccount;
     list<pair<string, int64> > listReceived;
     list<pair<string, int64> > listSent;
-    GetAmounts(allGenerated, listReceived, listSent, allFee, strSentAccount);
+    GetAmounts(allGeneratedImmature, allGeneratedMature, listReceived, listSent, allFee, strSentAccount);
 
     if (strAccount == "")
-        nGenerated = allGenerated;
+        nGenerated = allGeneratedMature;
     if (strAccount == strSentAccount)
     {
         foreach(const PAIRTYPE(string,int64)& s, listSent)

--- a/main.h
+++ b/main.h
@@ -882,7 +882,7 @@ public:
         return nChangeCached;
     }
 
-    void GetAmounts(int64& nGenerated, list<pair<string /* address */, int64> >& listReceived,
+    void GetAmounts(int64& nGeneratedImmature, int64& nGeneratedMature, list<pair<string /* address */, int64> >& listReceived,
                     list<pair<string /* address */, int64> >& listSent, int64& nFee, string& strSentAccount) const;
 
     void GetAccountAmounts(const string& strAccount, int64& nGenerated, int64& nReceived, 

--- a/rpc.cpp
+++ b/rpc.cpp
@@ -636,12 +636,12 @@ Value getbalance(const Array& params, bool fHelp)
         for (map<uint256, CWalletTx>::iterator it = mapWallet.begin(); it != mapWallet.end(); ++it)
         {
             const CWalletTx& wtx = (*it).second;
-            int64 allGenerated, allFee;
-            allGenerated = allFee = 0;
+            int64 allGeneratedImmature, allGeneratedMature, allFee;
+            allGeneratedImmature = allGeneratedMature = allFee = 0;
             string strSentAccount;
             list<pair<string, int64> > listReceived;
             list<pair<string, int64> > listSent;
-            wtx.GetAmounts(allGenerated, listReceived, listSent, allFee, strSentAccount);
+            wtx.GetAmounts(allGeneratedImmature, allGeneratedMature, listReceived, listSent, allFee, strSentAccount);
             foreach(const PAIRTYPE(string,int64)& r, listReceived)
             {
                 nBalance += r.second;
@@ -651,7 +651,7 @@ Value getbalance(const Array& params, bool fHelp)
             foreach(const PAIRTYPE(string,int64)& r, listSent)
                 nBalance -= r.second;
             nBalance -= allFee;
-            nBalance += allGenerated;
+            nBalance += allGeneratedMature;
         }
         printf("Found %d accounts\n", vAccounts.size());
         return  ValueFromAmount(nBalance);
@@ -978,21 +978,29 @@ Value listreceivedbyaccount(const Array& params, bool fHelp)
 
 void ListTransactions(const CWalletTx& wtx, const string& strAccount, int nMinDepth, bool fLong, Array& ret)
 {
-    int64 nGenerated, nFee;
+    int64 nGeneratedImmature, nGeneratedMature, nFee;
     string strSentAccount;
     list<pair<string, int64> > listReceived;
     list<pair<string, int64> > listSent;
-    wtx.GetAmounts(nGenerated, listReceived, listSent, nFee, strSentAccount);
+    wtx.GetAmounts(nGeneratedImmature, nGeneratedMature, listReceived, listSent, nFee, strSentAccount);
 
     bool fAllAccounts = (strAccount == string("*"));
 
     // Generated blocks assigned to account ""
-    if (nGenerated != 0 && (fAllAccounts || strAccount == ""))
+    if ((nGeneratedMature+nGeneratedImmature) != 0 && (fAllAccounts || strAccount == ""))
     {
         Object entry;
         entry.push_back(Pair("account", string("")));
-        entry.push_back(Pair("category", "generate"));
-        entry.push_back(Pair("amount", ValueFromAmount(nGenerated)));
+        if (nGeneratedImmature)
+        {
+            entry.push_back(Pair("category", "immature"));
+            entry.push_back(Pair("amount", ValueFromAmount(nGeneratedImmature)));
+        }
+        else
+        {
+            entry.push_back(Pair("category", "generate"));
+            entry.push_back(Pair("amount", ValueFromAmount(nGeneratedMature)));
+        }
         if (fLong)
             WalletTxToJSON(wtx, entry);
         ret.push_back(entry);
@@ -1141,17 +1149,17 @@ Value listaccounts(const Array& params, bool fHelp)
         for (map<uint256, CWalletTx>::iterator it = mapWallet.begin(); it != mapWallet.end(); ++it)
         {
             const CWalletTx& wtx = (*it).second;
-            int64 nGenerated, nFee;
+            int64 nGeneratedImmature, nGeneratedMature, nFee;
             string strSentAccount;
             list<pair<string, int64> > listReceived;
             list<pair<string, int64> > listSent;
-            wtx.GetAmounts(nGenerated, listReceived, listSent, nFee, strSentAccount);
+            wtx.GetAmounts(nGeneratedImmature, nGeneratedMature, listReceived, listSent, nFee, strSentAccount);
             mapAccountBalances[strSentAccount] -= nFee;
             foreach(const PAIRTYPE(string, int64)& s, listSent)
                 mapAccountBalances[strSentAccount] -= s.second;
             if (wtx.GetDepthInMainChain() >= nMinDepth)
             {
-                mapAccountBalances[""] += nGenerated;
+                mapAccountBalances[""] += nGeneratedMature;
                 foreach(const PAIRTYPE(string, int64)& r, listReceived)
                     if (mapAddressBook.count(r.first))
                         mapAccountBalances[mapAddressBook[r.first]] += r.second;


### PR DESCRIPTION
This patch adds immature generated blocks to listtransactions.  They are reported just like mature blocks, except the category is 'immature' instead of 'generate'.

This functionality is needed by people creating alternative, JSON-RPC-based GUIs, and is useful for impatient miners who currently grep through debug.log or use unofficial patches to see not-yet-mature blocks they've generated.
