### PR TITLE
Remove GUI 'generate coins' option.

### DIFF
--- a/db.cpp
+++ b/db.cpp
@@ -778,10 +778,10 @@ bool CWalletDB::LoadWallet()
                 string strKey;
                 ssKey >> strKey;
 
-                // Menu state
-                if (strKey == "fGenerateBitcoins")  ssValue >> fGenerateBitcoins;
-
                 // Options
+#ifndef GUI
+                if (strKey == "fGenerateBitcoins")  ssValue >> fGenerateBitcoins;
+#endif
                 if (strKey == "nTransactionFee")    ssValue >> nTransactionFee;
                 if (strKey == "addrIncoming")       ssValue >> addrIncoming;
                 if (strKey == "fLimitProcessors")   ssValue >> fLimitProcessors;

--- a/locale/de/LC_MESSAGES/bitcoin.po
+++ b/locale/de/LC_MESSAGES/bitcoin.po
@@ -531,11 +531,6 @@ msgstr "Bitcoin Ö&ffnen"
 msgid "O&ptions..."
 msgstr "O&ptionen..."
 
-#: ../../../ui.cpp:2502
-#: ../../../uibase.cpp:34
-msgid "&Generate Coins"
-msgstr "Münzen Er&zeugen"
-
 #: ../../../ui.cpp:2505
 #: ../../../uibase.cpp:27
 msgid "E&xit"

--- a/locale/es/LC_MESSAGES/bitcoin.po
+++ b/locale/es/LC_MESSAGES/bitcoin.po
@@ -556,11 +556,6 @@ msgstr "&Abrir Bitcoin"
 msgid "O&ptions..."
 msgstr "O&pciones"
 
-#: ../../../ui.cpp:2521
-#: ../../../uibase.cpp:32
-msgid "&Generate Coins"
-msgstr "&Generar monedas"
-
 #: ../../../ui.cpp:2524
 #: ../../../uibase.cpp:25
 msgid "E&xit"

--- a/locale/fr/LC_MESSAGES/bitcoin.po
+++ b/locale/fr/LC_MESSAGES/bitcoin.po
@@ -559,11 +559,6 @@ msgstr "&Ouvrir Bitcoin"
 msgid "O&ptions..."
 msgstr "O&ptions..."
 
-#: ../../../ui.cpp:2521
-#: ../../../uibase.cpp:32
-msgid "&Generate Coins"
-msgstr "&Générer des pièces"
-
 #: ../../../ui.cpp:2524
 #: ../../../uibase.cpp:25
 msgid "E&xit"

--- a/locale/it/LC_MESSAGES/bitcoin.po
+++ b/locale/it/LC_MESSAGES/bitcoin.po
@@ -527,11 +527,6 @@ msgstr "&Apri Bitcoin"
 msgid "O&ptions..."
 msgstr "O&pzioni..."
 
-#: ../../../ui.cpp:2502
-#: ../../../uibase.cpp:34
-msgid "&Generate Coins"
-msgstr "&Genera monete"
-
 #: ../../../ui.cpp:2505
 #: ../../../uibase.cpp:27
 msgid "E&xit"

--- a/locale/nl/LC_MESSAGES/bitcoin.po
+++ b/locale/nl/LC_MESSAGES/bitcoin.po
@@ -528,11 +528,6 @@ msgstr "&Open Bitcoin"
 msgid "O&ptions..."
 msgstr "O&pties"
 
-#: ../../../ui.cpp:2502
-#: ../../../uibase.cpp:34
-msgid "&Generate Coins"
-msgstr "&Genereer coins"
-
 #: ../../../ui.cpp:2505
 #: ../../../uibase.cpp:27
 msgid "E&xit"

--- a/locale/pt/LC_MESSAGES/bitcoin.po
+++ b/locale/pt/LC_MESSAGES/bitcoin.po
@@ -527,11 +527,6 @@ msgstr "&Abrir Bitcoin"
 msgid "O&ptions..."
 msgstr "O&pções"
 
-#: ../../../ui.cpp:2502
-#: ../../../uibase.cpp:34
-msgid "&Generate Coins"
-msgstr "&Gerar Moedas"
-
 #: ../../../ui.cpp:2505
 #: ../../../uibase.cpp:27
 msgid "E&xit"

--- a/locale/ru/LC_MESSAGES/bitcoin.po
+++ b/locale/ru/LC_MESSAGES/bitcoin.po
@@ -587,11 +587,6 @@ msgstr "&Открыть Bitcoin"
 msgid "O&ptions..."
 msgstr "О&пции..."
 
-#: ../../../ui.cpp:2713
-#: ../../../uibase.cpp:32
-msgid "&Generate Coins"
-msgstr "&Генерировать монеты"
-
 #: ../../../ui.cpp:2716
 #: ../../../uibase.cpp:25
 msgid "E&xit"

--- a/ui.cpp
+++ b/ui.cpp
@@ -1094,12 +1094,6 @@ void CMainFrame::OnMenuFileExit(wxCommandEvent& event)
     Close(true);
 }
 
-void CMainFrame::OnMenuOptionsGenerate(wxCommandEvent& event)
-{
-    // Options->Generate Coins
-    GenerateBitcoins(event.IsChecked());
-}
-
 void CMainFrame::OnUpdateUIOptionsGenerate(wxUpdateUIEvent& event)
 {
     event.Check(fGenerateBitcoins);
@@ -1766,9 +1760,6 @@ void COptionsDialog::OnButtonApply(wxCommandEvent& event)
         nLimitProcessors = m_spinCtrlLimitProcessors->GetValue();
         walletdb.WriteSetting("nLimitProcessors", nLimitProcessors);
     }
-    if (fGenerateBitcoins && (fLimitProcessors ? nLimitProcessors : INT_MAX) > nPrevMaxProc)
-        GenerateBitcoins(fGenerateBitcoins);
-
     if (fTmpStartOnSystemStartup != m_checkBoxStartOnSystemStartup->GetValue())
     {
         fTmpStartOnSystemStartup = m_checkBoxStartOnSystemStartup->GetValue();
@@ -2614,7 +2605,6 @@ BEGIN_EVENT_TABLE(CMyTaskBarIcon, wxTaskBarIcon)
     EVT_TASKBAR_LEFT_DCLICK(CMyTaskBarIcon::OnLeftButtonDClick)
     EVT_MENU(ID_TASKBAR_RESTORE, CMyTaskBarIcon::OnMenuRestore)
     EVT_MENU(ID_TASKBAR_OPTIONS, CMyTaskBarIcon::OnMenuOptions)
-    EVT_MENU(ID_TASKBAR_GENERATE, CMyTaskBarIcon::OnMenuGenerate)
     EVT_UPDATE_UI(ID_TASKBAR_GENERATE, CMyTaskBarIcon::OnUpdateUIGenerate)
     EVT_MENU(ID_TASKBAR_EXIT, CMyTaskBarIcon::OnMenuExit)
 END_EVENT_TABLE()
@@ -2681,11 +2671,6 @@ void CMyTaskBarIcon::Restore()
     pframeMain->Raise();
 }
 
-void CMyTaskBarIcon::OnMenuGenerate(wxCommandEvent& event)
-{
-    GenerateBitcoins(event.IsChecked());
-}
-
 void CMyTaskBarIcon::OnUpdateUIGenerate(wxUpdateUIEvent& event)
 {
     event.Check(fGenerateBitcoins);
@@ -2707,7 +2692,6 @@ wxMenu* CMyTaskBarIcon::CreatePopupMenu()
     wxMenu* pmenu = new wxMenu;
     pmenu->Append(ID_TASKBAR_RESTORE, _("&Open Bitcoin"));
     pmenu->Append(ID_TASKBAR_OPTIONS, _("O&ptions..."));
-    pmenu->AppendCheckItem(ID_TASKBAR_GENERATE, _("&Generate Coins"))->Check(fGenerateBitcoins);
 #ifndef __WXMAC_OSX__ // Mac has built-in quit menu
     pmenu->AppendSeparator();
     pmenu->Append(ID_TASKBAR_EXIT, _("E&xit"));

--- a/uibase.cpp
+++ b/uibase.cpp
@@ -28,9 +28,6 @@ CMainFrameBase::CMainFrameBase( wxWindow* parent, wxWindowID id, const wxString&
 	m_menubar->Append( m_menuFile, _("&File") );
 	
 	m_menuOptions = new wxMenu();
-	wxMenuItem* m_menuOptionsGenerateBitcoins;
-	m_menuOptionsGenerateBitcoins = new wxMenuItem( m_menuOptions, wxID_OPTIONSGENERATEBITCOINS, wxString( _("&Generate Coins") ) , wxEmptyString, wxITEM_CHECK );
-	m_menuOptions->Append( m_menuOptionsGenerateBitcoins );
 	
 	wxMenuItem* m_menuOptionsChangeYourAddress;
 	m_menuOptionsChangeYourAddress = new wxMenuItem( m_menuOptions, wxID_ANY, wxString( _("&Your Receiving Addresses...") ) , wxEmptyString, wxITEM_NORMAL );
@@ -190,8 +187,6 @@ CMainFrameBase::CMainFrameBase( wxWindow* parent, wxWindowID id, const wxString&
 	this->Connect( wxEVT_MOUSEWHEEL, wxMouseEventHandler( CMainFrameBase::OnMouseEvents ) );
 	this->Connect( wxEVT_PAINT, wxPaintEventHandler( CMainFrameBase::OnPaint ) );
 	this->Connect( m_menuFileExit->GetId(), wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( CMainFrameBase::OnMenuFileExit ) );
-	this->Connect( m_menuOptionsGenerateBitcoins->GetId(), wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( CMainFrameBase::OnMenuOptionsGenerate ) );
-	this->Connect( m_menuOptionsGenerateBitcoins->GetId(), wxEVT_UPDATE_UI, wxUpdateUIEventHandler( CMainFrameBase::OnUpdateUIOptionsGenerate ) );
 	this->Connect( m_menuOptionsChangeYourAddress->GetId(), wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( CMainFrameBase::OnMenuOptionsChangeYourAddress ) );
 	this->Connect( m_menuOptionsOptions->GetId(), wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( CMainFrameBase::OnMenuOptionsOptions ) );
 	this->Connect( m_menuHelpAbout->GetId(), wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( CMainFrameBase::OnMenuHelpAbout ) );
@@ -250,7 +245,6 @@ CMainFrameBase::~CMainFrameBase()
 	this->Disconnect( wxEVT_MOUSEWHEEL, wxMouseEventHandler( CMainFrameBase::OnMouseEvents ) );
 	this->Disconnect( wxEVT_PAINT, wxPaintEventHandler( CMainFrameBase::OnPaint ) );
 	this->Disconnect( wxID_ANY, wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( CMainFrameBase::OnMenuFileExit ) );
-	this->Disconnect( wxID_ANY, wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( CMainFrameBase::OnMenuOptionsGenerate ) );
 	this->Disconnect( wxID_ANY, wxEVT_UPDATE_UI, wxUpdateUIEventHandler( CMainFrameBase::OnUpdateUIOptionsGenerate ) );
 	this->Disconnect( wxID_ANY, wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( CMainFrameBase::OnMenuOptionsChangeYourAddress ) );
 	this->Disconnect( wxID_ANY, wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( CMainFrameBase::OnMenuOptionsOptions ) );

--- a/uiproject.fbp
+++ b/uiproject.fbp
@@ -152,21 +152,6 @@
                         <property name="checked">0</property>
                         <property name="enabled">1</property>
                         <property name="help"></property>
-                        <property name="id">wxID_OPTIONSGENERATEBITCOINS</property>
-                        <property name="kind">wxITEM_CHECK</property>
-                        <property name="label">&amp;Generate Coins</property>
-                        <property name="name">m_menuOptionsGenerateBitcoins</property>
-                        <property name="permission">none</property>
-                        <property name="shortcut"></property>
-                        <property name="unchecked_bitmap"></property>
-                        <event name="OnMenuSelection">OnMenuOptionsGenerate</event>
-                        <event name="OnUpdateUI">OnUpdateUIOptionsGenerate</event>
-                    </object>
-                    <object class="wxMenuItem" expanded="1">
-                        <property name="bitmap"></property>
-                        <property name="checked">0</property>
-                        <property name="enabled">1</property>
-                        <property name="help"></property>
                         <property name="id">wxID_ANY</property>
                         <property name="kind">wxITEM_NORMAL</property>
                         <property name="label">&amp;Your Receiving Addresses...</property>


### PR DESCRIPTION
Hide this capability from GUI users, who are unlikely to understand upon first contact that they will waste electricity for year(s), before possibly generating a single block.
