### PR TITLE
Bugfix for spentpertxout: slow startup

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -950,6 +950,8 @@ void ReacceptWalletTransactions()
                 }
                 for (int i = 0; i < txindex.vSpent.size(); i++)
                 {
+                    if (wtx.IsSpent(i))
+                        continue;
                     if (!txindex.vSpent[i].IsNull() && wtx.vout[i].IsMine())
                     {
                         wtx.MarkSpent(i);


### PR DESCRIPTION
When starting the client, ReacceptWalletTransaction didn't skip spent transactions in its loop, and processed all old spent transactions again.
