### PR TITLE
Automatically rescan after restoring wallet.dat

### DIFF
--- a/db.h
+++ b/db.h
@@ -13,6 +13,7 @@ class CAddress;
 class CWalletTx;
 class CAccount;
 class CAccountingEntry;
+class CBlockLocator;
 
 extern map<string, string> mapAddressBook;
 extern CCriticalSection cs_mapAddressBook;
@@ -403,6 +404,17 @@ public:
     {
         nWalletDBUpdated++;
         return Write(make_pair(string("key"), vchPubKey), vchPrivKey, false);
+    }
+
+    bool WriteBestBlock(const CBlockLocator& locator)
+    {
+        nWalletDBUpdated++;
+        return Write(string("bestblock"), locator);
+    }
+
+    bool ReadBestBlock(CBlockLocator& locator)
+    {
+        return Read(string("bestblock"), locator);
     }
 
     bool ReadDefaultKey(vector<unsigned char>& vchPubKey)

--- a/init.cpp
+++ b/init.cpp
@@ -372,10 +372,21 @@ bool AppInit2(int argc, char* argv[])
         strErrors += _("Error loading wallet.dat      \n");
     printf(" wallet      %15"PRI64d"ms\n", GetTimeMillis() - nStart);
 
+    CBlockIndex *pindexRescan = pindexBest;
     if (GetBoolArg("-rescan"))
+        pindexRescan = pindexGenesisBlock;
+    else
     {
+        CWalletDB walletdb;
+        CBlockLocator locator;
+        if (walletdb.ReadBestBlock(locator))
+            pindexRescan = locator.GetBlockIndex();
+    }
+    if (pindexBest != pindexRescan)
+    {
+        printf("Rescanning last %i blocks (from block %i)...\n", pindexBest->nHeight - pindexRescan->nHeight, pindexRescan->nHeight);
         nStart = GetTimeMillis();
-        ScanForWalletTransactions(pindexGenesisBlock);
+        ScanForWalletTransactions(pindexRescan);
         printf(" rescan      %15"PRI64d"ms\n", GetTimeMillis() - nStart);
     }
 

--- a/main.cpp
+++ b/main.cpp
@@ -1611,6 +1611,15 @@ bool CBlock::SetBestChain(CTxDB& txdb, CBlockIndex* pindexNew)
         }
     }
 
+    // Update best block in wallet (so we can detect restored wallets)
+    if (!IsInitialBlockDownload())
+    {
+        CWalletDB walletdb;
+        const CBlockLocator locator(pindexNew);
+        if (!walletdb.WriteBestBlock(locator))
+            return error("SetBestChain() : WriteWalletBest failed");
+    }
+
     // New best block
     hashBestChain = hash;
     pindexBest = pindexNew;


### PR DESCRIPTION
Information about the best known chain is added to wallet.dat. If this
information does not match the data in blkindex.dat, a rescan is automatically
performed at startup, starting from the the last known block. When upgrading from a wallet
which does not have this information, no rescan is done automatically.
