### PR TITLE
Fix for #156: UPnP segfault when no valid UPnP IGDs are found.

### DIFF
--- a/net.cpp
+++ b/net.cpp
@@ -906,7 +906,8 @@ void ThreadMapPort2(void* parg)
     struct IGDdatas data;
     int r;
 
-    if (UPNP_GetValidIGD(devlist, &urls, &data, lanaddr, sizeof(lanaddr)) == 1)
+    r = UPNP_GetValidIGD(devlist, &urls, &data, lanaddr, sizeof(lanaddr));
+    if (r == 1)
     {
         char intClient[16];
         char intPort[6];
@@ -937,7 +938,8 @@ void ThreadMapPort2(void* parg)
     } else {
         printf("No valid UPnP IGDs found\n");
         freeUPNPDevlist(devlist); devlist = 0;
-        FreeUPNPUrls(&urls);
+        if (r != 0)
+            FreeUPNPUrls(&urls);
         loop {
             if (fShutdown)
                 return;


### PR DESCRIPTION
This should fix #156 by only calling FreeUPNPUrls(urls) when the UPNP_GetValidIGD() value is non-zero.
