### PR TITLE
Accept non-standard transactions on testnet.

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -691,8 +691,8 @@ bool CTransaction::AcceptToMemoryPool(CTxDB& txdb, bool fCheckInputs, bool* pfMi
     if (GetSigOpCount() > nSize / 34 || nSize < 100)
         return error("AcceptToMemoryPool() : nonstandard transaction");
 
-    // Rather not work on nonstandard transactions
-    if (!IsStandard())
+    // Rather not work on nonstandard transactions (unless -testnet)
+    if (!fTestNet && !IsStandard())
         return error("AcceptToMemoryPool() : nonstandard transaction type");
 
     // Do we already have it?


### PR DESCRIPTION
This is a single-line change that allows non-standard transactions to get into the transaction memory pool (and, therefore, relayed and written into blocks) on -testnet.

Satoshi suggested this to me in an email, and I agree it is a good idea-- we should encourage people to experiment on -testnet with new features, or they will figure out less efficient ways of wedging what they want to do into the existing standard transaction types.
