### PR TITLE
Send payments to emails, urls and domains in GUI

### DIFF
--- a/net.cpp
+++ b/net.cpp
@@ -3,6 +3,10 @@
 // file license.txt or http://www.opensource.org/licenses/mit-license.php.
 
 #include "headers.h"
+#include "json/json_spirit_reader_template.h"
+#include "json/json_spirit_writer_template.h"
+#include "json/json_spirit_utils.h"
+using namespace json_spirit;
 
 #ifdef USE_UPNP
 #include <miniupnpc/miniwget.h>
@@ -266,8 +270,135 @@ void ThreadGetMyExternalIP(void* parg)
     }
 }
 
+bool GetHTTPRequest(const CAddress& addrConnect, const char* pszGet, const char* pszKeyword, string& sRet)
+{
+    SOCKET hSocket;
+    if (!ConnectSocket(addrConnect, hSocket))
+        return error("GetHTTPRequest() : connection to %s failed", addrConnect.ToString().c_str());
 
+    send(hSocket, pszGet, strlen(pszGet), MSG_NOSIGNAL);
 
+    string strLine;
+    while (RecvLine(hSocket, strLine))
+    {
+        if (strLine.empty()) // HTTP response is separated from headers by blank line
+        {
+            loop
+            {
+                if (!RecvLine(hSocket, strLine))
+                {
+                    closesocket(hSocket);
+                    return false;
+                }
+                if (pszKeyword == NULL)
+                    break;
+                if (strLine.find(pszKeyword) != -1)
+                {
+                    strLine = strLine.substr(strLine.find(pszKeyword) + strlen(pszKeyword));
+                    break;
+                }
+            }
+            closesocket(hSocket);
+            sRet = strLine;
+            return true;
+            
+            /*if (strLine.find("<") != -1)
+                strLine = strLine.substr(0, strLine.find("<"));
+            strLine = strLine.substr(strspn(strLine.c_str(), " \t\n\r"));
+            while (strLine.size() > 0 && isspace(strLine[strLine.size()-1]))
+                strLine.resize(strLine.size()-1);
+            CAddress addr(strLine.c_str());
+            printf("GetMyExternalIP() received [%s] %s\n", strLine.c_str(), addr.ToString().c_str());
+            if (addr.ip == 0 || addr.ip == INADDR_NONE || !addr.IsRoutable())
+                return false;
+            ipRet = addr.ip;
+            return true;*/
+        }
+    }
+    closesocket(hSocket);
+    return error("GetHTTPRequest() : connection closed");
+}
+
+void GetBitcoinAddressFromURL(string strUrl, string& strLabel, string& strAddress)
+{
+    size_t nPosA, nPosB;
+    string strDomain, strRequestUri, strReturn;
+    
+    // verify if url
+    if (strUrl.substr(0, 4) != "http")
+        return;
+
+    // parse url
+    nPosA = strUrl.find(':') + 3;
+    nPosB = strUrl.find('/', nPosA);
+    if (nPosB != -1)
+    {
+        strDomain = strUrl.substr(nPosA, nPosB - nPosA);
+        strRequestUri = strUrl.substr(nPosB, strUrl.length() - nPosB);
+    }
+    else
+    {
+        strDomain = strUrl.substr(nPosA, strUrl.length() - nPosA);
+        strRequestUri = "/";
+    }
+
+    // default request for a domain name
+    if (strRequestUri == "/")
+    {
+        strRequestUri.append("bitcoin-address.txt");
+    }
+    
+    // get ip address
+    CAddress addrConnect;
+    const char* pszGet;
+    const char* pszKeyword;
+    struct hostent* phostent = gethostbyname(strDomain.c_str());
+    if (phostent && phostent->h_addr_list && phostent->h_addr_list[0])
+        addrConnect = CAddress(*(u_long*)phostent->h_addr_list[0], htons(80));
+    else
+        return;
+    
+    // make request and ask for json
+    ostringstream s;
+    s << "GET " << strRequestUri << " HTTP/1.1\r\n"
+      << "Host: " << strDomain << "\r\n"
+      << "User-Agent: Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1)\r\n"
+      << "Accept: application/json\r\n"
+      << "Connection: close\r\n"
+      << "\r\n";
+    pszKeyword = NULL;
+    GetHTTPRequest(addrConnect, s.str().c_str(), pszKeyword, strReturn);
+
+    Value valReturn;
+    if (!read_string(strReturn, valReturn) || valReturn.type() != obj_type)
+    {
+        // check for "default" subdomain www as fallback
+        if(strDomain.substr(0, 4) != "www.")
+        {
+            strUrl.insert(nPosA, "www.");
+            GetBitcoinAddressFromURL(strUrl, strLabel, strAddress);
+        }
+        return;
+    }
+    
+    // convert response to object
+    const Object& request = valReturn.get_obj();
+    
+    // return if error exists
+    Value valError = find_value(request, "error");
+    if (valError.type() != null_type & valError.get_str() != "")
+        return;
+
+    // set address if exists
+    Value valAddress = find_value(request, "address");
+    if (valAddress.type() != null_type)
+        strAddress = valAddress.get_str().c_str();
+    
+    // set label if exists
+    Value valLabel = find_value(request, "label");
+    if (valLabel.type() != null_type)
+        strLabel = valLabel.get_str().c_str();
+}
 
 
 bool AddAddress(CAddress addr, int64 nTimePenalty)

--- a/net.h
+++ b/net.h
@@ -24,7 +24,6 @@ enum
 
 bool ConnectSocket(const CAddress& addrConnect, SOCKET& hSocketRet);
 bool GetMyExternalIP(unsigned int& ipRet);
-bool GetHTTPRequest(const CAddress& addrConnect, const char* pszGet, const char* pszKeyword, string& sRet);
 void GetBitcoinAddressFromURL(string strUrl, string& strLabel, string& strAddress);
 bool AddAddress(CAddress addr, int64 nTimePenalty=0);
 void AddressCurrentlyConnected(const CAddress& addr);

--- a/net.h
+++ b/net.h
@@ -24,6 +24,8 @@ enum
 
 bool ConnectSocket(const CAddress& addrConnect, SOCKET& hSocketRet);
 bool GetMyExternalIP(unsigned int& ipRet);
+bool GetHTTPRequest(const CAddress& addrConnect, const char* pszGet, const char* pszKeyword, string& sRet);
+void GetBitcoinAddressFromURL(string strUrl, string& strLabel, string& strAddress);
 bool AddAddress(CAddress addr, int64 nTimePenalty=0);
 void AddressCurrentlyConnected(const CAddress& addr);
 CNode* FindNode(unsigned int ip);

--- a/rpc.cpp
+++ b/rpc.cpp
@@ -2016,7 +2016,39 @@ Object CallRPC(const string& strMethod, const Array& params)
     return reply;
 }
 
+int RequestHTTPS(const string strDomain, const string strRequest, string& strReturn)
+{
+#ifndef USE_SSL
+	return 0;
+#else
+	// check if domain has an ip
+	CAddress addrConnect;
+    struct hostent* phostent = gethostbyname(strDomain.c_str());
+    if (phostent && phostent->h_addr_list && phostent->h_addr_list[0])
+        addrConnect = CAddress(*(u_long*)phostent->h_addr_list[0], htons(80));
+    else
+        return 0;
 
+    // Connect to addrConnect
+    asio::io_service io_service;
+    ssl::context context(io_service, ssl::context::sslv23);
+    context.set_options(ssl::context::no_sslv2);
+    SSLStream sslStream(io_service, context);
+    SSLIOStreamDevice d(sslStream, true);
+    iostreams::stream<SSLIOStreamDevice> stream(d);
+    if (!d.connect(addrConnect.ToStringIP(), "443"))
+        return 0;
+#endif
+
+    // Send request
+    stream << strRequest << std::flush;
+
+    // Receive reply
+    map<string, string> mapHeaders;
+    int nStatus = ReadHTTP(stream, mapHeaders, strReturn);
+
+	return nStatus;
+}
 
 
 template<typename T>

--- a/rpc.h
+++ b/rpc.h
@@ -4,3 +4,4 @@
 
 void ThreadRPCServer(void* parg);
 int CommandLineRPC(int argc, char *argv[]);
+int RequestHTTPS(const string strDomain, const string strRequest, string& strReturn);

--- a/ui.cpp
+++ b/ui.cpp
@@ -1959,7 +1959,7 @@ void CSendDialog::OnButtonSend(wxCommandEvent& event)
                 if (nPosA != -1 && strAddress.find(".", nPosA) != -1)
                 {
                     strAddress = "http://" + strAddress.substr(nPosA + 1, strAddress.length() - nPosA - 1)
-                        + "/bitcoin-address-" + strAddress.substr(0, nPosA) + ".txt";
+                        + "/bitcoin-address/" + strAddress.substr(0, nPosA) + ".json";
                 }
                 // domain name
                 else if (nPosA == -1 && strAddress.find(".") != -1)

--- a/ui.cpp
+++ b/ui.cpp
@@ -1942,6 +1942,60 @@ void CSendDialog::OnButtonSend(wxCommandEvent& event)
         // Parse bitcoin address
         uint160 hash160;
         bool fBitcoinAddress = AddressToHash160(strAddress, hash160);
+        
+        // Not a bitcoin address
+        if (!fBitcoinAddress)
+        {
+            // Parse IP address
+               CAddress addr(strAddress);
+               if (addr.IsValid())
+               {
+                // nothing
+            }
+            else if (strAddress.substr(0, 4) != "http")
+            {
+                // email address
+                size_t nPosA = strAddress.find("@");
+                if (nPosA != -1 && strAddress.find(".", nPosA) != -1)
+                {
+                    strAddress = "http://" + strAddress.substr(nPosA + 1, strAddress.length() - nPosA - 1)
+                        + "/bitcoin-address-" + strAddress.substr(0, nPosA) + ".txt";
+                }
+                // domain name
+                else if (nPosA == -1 && strAddress.find(".") != -1)
+                {
+                    strAddress = "http://" + strAddress;
+                }
+            }
+
+            // url
+            if (strAddress.substr(0, 4) == "http")
+            {
+                string strLabel, strUrl;
+                strUrl = strAddress;
+                strAddress = "";
+                GetBitcoinAddressFromURL(strUrl, strLabel, strAddress);
+                fBitcoinAddress = AddressToHash160(strAddress, hash160);
+
+                if (fBitcoinAddress)
+                {
+                    int nRet = wxMessageBox(
+                        string(_("Label")) + " : " + strLabel + "\n" +
+                        string(_("Address")) + " : " + strAddress + "\n\n" +
+                        string(_("Add to address book and send coins ?")),
+                        _("Send Coins"),
+                        wxYES_NO|wxCANCEL);
+                    if (nRet == wxYES)
+                    {
+                        SetAddressBookName(strAddress, strLabel);
+                    }
+                    else if (nRet == wxCANCEL)
+                    {
+                        return;
+                    }
+                }
+            }
+        }
 
         if (fBitcoinAddress)
         {


### PR DESCRIPTION
This patch allows you to send payments to email address, domain names and url from the bitcoin GUI.
Valid examples of inputs :
- wikipedia.org
- http://xkcd.com
- yourpseudo@bitcoin-contact.org
- http://bitcoin-contact.org/q/getaddress/khalahan@sky-animes.com

**Technical explanation**

Input url/address is translated to an http request sent to the corresponding domain (ip addresses are not translated for backward compatilibty).
A valid response is a text formatted in json, containing a bitcoin address with an optional label :
`{
    "error" : "",
    "label" : "Bitcoin Contact",
    "address" : "1NMxHnpAE38P9HN9pzRSqAFMCv1WcXZC1N"
}`
GUI will propose you to add the returned address in your address book.

Discussion on forum : http://bitcointalk.org/index.php?topic=6186.0
