### PR TITLE
Link with libpthread on Linux, required by libboost_thread.

### DIFF
--- a/makefile.unix
+++ b/makefile.unix
@@ -32,7 +32,8 @@ LIBS+= \
  -Wl,-Bdynamic \
    -l gthread-2.0 \
    -l z \
-   -l dl
+   -l dl \
+   -l pthread
 
 
 DEBUGFLAGS=-g -D__WXDEBUG__


### PR DESCRIPTION
Fixes link failure when using the 'gold' linker.
Also tested with regular 'ld' and it seems to work fine.
