### PR TITLE
Bugfix in recursive check in IsConfirmed()

### DIFF
--- a/main.h
+++ b/main.h
@@ -1028,7 +1028,7 @@ public:
             if (!ptx->IsFinal())
                 return false;
             if (ptx->GetDepthInMainChain() >= 1)
-                return true;
+                continue;
             if (!ptx->IsFromMe())
                 return false;
 


### PR DESCRIPTION
When one single dependency of an unconfirmed transaction is already verified, this does not mean the parent is confirmed. We can skip checking its own dependencies though.
