### PR TITLE
Sign and verify message with bitcoin address and public key

### DIFF
--- a/rpc.cpp
+++ b/rpc.cpp
@@ -494,6 +494,70 @@ Value sendtoaddress(const Array& params, bool fHelp)
     return wtx.GetHash().GetHex();
 }
 
+Value signmessage(const Array& params, bool fHelp)
+{
+    if (fHelp || params.size() != 2)
+        throw runtime_error(
+            "signmessage <bitcoinaddress> <message>\n"
+            "Sign a message with the private key of an address");
+
+    string strAddress = params[0].get_str();
+    string strMessage = params[1].get_str();
+    strMessage.insert(0, "Padding text - ");
+    
+    uint160 hash160;
+    if(!AddressToHash160(strAddress, hash160))
+        throw JSONRPCError(-3, "Invalid address");
+    
+    vector<unsigned char>& vchPubKey = mapPubKeys[hash160];
+    CKey key;
+    if(!key.SetPubKey(vchPubKey))
+        throw JSONRPCError(-3, "Public key not found");
+    strMessage.insert(0, HexStr(vchPubKey.begin(), vchPubKey.end()).c_str());
+
+    vector<unsigned char> vchMsg(strMessage.begin(), strMessage.end());
+    vector<unsigned char> vchSig;
+    if (!CKey::Sign(mapKeys[vchPubKey], Hash(vchMsg.begin(), vchMsg.end()), vchSig))
+        throw JSONRPCError(-3, "Sign failed");
+
+    Object obj;
+    obj.push_back(Pair("address",       strAddress));
+    obj.push_back(Pair("pubkey",        HexStr(vchPubKey.begin(), vchPubKey.end()).c_str()));
+    obj.push_back(Pair("sign",          HexStr(vchSig.begin(), vchSig.end()).c_str()));
+
+    return obj;
+}
+
+Value verifymessage(const Array& params, bool fHelp)
+{
+    if (fHelp || params.size() != 3)
+        throw runtime_error(
+            "verifymessage <pubkey> <sign> <message>\n"
+            "Verify a signed message with the public key");
+
+    string strPubKey  = params[0].get_str();
+    string strSign    = params[1].get_str();
+    string strMessage = params[2].get_str();
+    strMessage.insert(0, "Padding text - ");
+    strMessage.insert(0, strPubKey.c_str());
+
+    vector<unsigned char> vchPubKey = ParseHex(strPubKey);
+    vector<unsigned char> vchSig = ParseHex(strSign);
+    vector<unsigned char> vchMsg(strMessage.begin(), strMessage.end());
+
+    CKey key;
+    if(!key.SetPubKey(vchPubKey))
+        throw JSONRPCError(-3, "Invalid pubkey");
+    
+    if (!key.Verify(Hash(vchMsg.begin(), vchMsg.end()), vchSig))
+        throw JSONRPCError(-3, "Verify failed");
+    
+    Object obj;
+    obj.push_back(Pair("address",       PubKeyToAddress(vchPubKey)));
+    obj.push_back(Pair("pubkey",        strPubKey.c_str()));
+    return obj;
+}
+
 
 Value getreceivedbyaddress(const Array& params, bool fHelp)
 {
@@ -1438,6 +1502,8 @@ pair<string, rpcfn_type> pCallTable[] =
     make_pair("listtransactions",      &listtransactions),
     make_pair("getwork",               &getwork),
     make_pair("listaccounts",          &listaccounts),
+    make_pair("signmessage",           &signmessage),
+    make_pair("verifymessage",         &verifymessage),
 };
 map<string, rpcfn_type> mapCallTable(pCallTable, pCallTable + sizeof(pCallTable)/sizeof(pCallTable[0]));
 


### PR DESCRIPTION
Adds two rpc commands :
- signmessage <bitcoinaddress> <message>
- verifymessage <pubkey> <sign> <message>

It allows to sign a message with the public key of a bitcoin address you own, to be sure of the identity of the sender.
Command : ./bitcoind signmessage 1L5zqFahc8Ahu9wtgJqCeJMendvD174xsG "Hi github users :p"
Output :
{
    "address" : "1L5zqFahc8Ahu9wtgJqCeJMendvD174xsG",
    "pubkey" : "04ef6e366cd6b0b8fbf02c0c25ad39fe892b90c597875899fdc9db16941cf43fb8c429e0534cb8b972f5cc9f1a50f36dc3352ffad427f073e1c64a145828a3be6e",
    "sign" : "3046022100a80b6e0c7c54c54ba943f4e3cde12f5a7dc5313e3f0a15ce868f01683ced64fa0221008b4ad7d3800a11c241dcef7aaf44c8224a7d9f1e54d3e669bf4887036b6d10af"
}

Command : ./bitcoind verifymessage <above pubkey> <above sign> "Hi github users :p"
Output :
{
    "address" : "1L5zqFahc8Ahu9wtgJqCeJMendvD174xsG",
    "pubkey" : "04ef6e366cd6b0b8fbf02c0c25ad39fe892b90c597875899fdc9db16941cf43fb8c429e0534cb8b972f5cc9f1a50f36dc3352ffad427f073e1c64a145828a3be6e"
}

Reviews and comments are welcomed, I don't know if all is used as it should.

Forum thread : http://www.bitcoin.org/smf/index.php?topic=6428.0

EDIT(alex): Sipa's revision references pull 183 - https://github.com/bitcoin/bitcoin/pull/524 
