### PR TITLE
Fix compile error when USE_UPNP is not defined

### DIFF
--- a/db.cpp
+++ b/db.cpp
@@ -807,8 +807,10 @@ bool CWalletDB::LoadWallet()
     printf("fMinimizeOnClose = %d\n", fMinimizeOnClose);
     printf("fUseProxy = %d\n", fUseProxy);
     printf("addrProxy = %s\n", addrProxy.ToString().c_str());
+#ifdef USE_UPNP
     if (fHaveUPnP)
         printf("fUseUPnP = %d\n", fUseUPnP);
+#endif
 
 
     // Upgrade


### PR DESCRIPTION
Code in db.cpp was missing an #ifdef
