### PR TITLE
Remove unnecessary line which creates a dependency on wx's png library.

### DIFF
--- a/build-unix.txt
+++ b/build-unix.txt
@@ -73,7 +73,7 @@ tar -xzvf wxWidgets-2.9.0.tar.gz
 cd wxWidgets-2.9.0
 mkdir buildgtk
 cd buildgtk
-../configure --with-gtk --enable-debug --disable-shared --enable-monolithic
+../configure --with-gtk --enable-debug --disable-shared --enable-monolithic --without-libpng --disable-svg
 make
 sudo su
 make install

--- a/ui.cpp
+++ b/ui.cpp
@@ -2839,9 +2839,6 @@ bool CMyApp::OnInit()
     extern int g_isPainting;
     g_isPainting = 10000;
 #endif
-#ifdef GUI
-    wxImage::AddHandler(new wxPNGHandler);
-#endif
 #if defined(__WXMSW__ ) || defined(__WXMAC_OSX__)
     SetAppName("Bitcoin");
 #else


### PR DESCRIPTION
This should allow the bitcoin binaries to run on ever so slightly more installs,
specifically those who use a different libpng library (many distros use 1.4 which is imcompatible with 1.2)

This is unused as bitcoin literally never uses PNGs, anywhere.
