### PR TITLE
Added balance to tooltip and send coin option to tray menu

### DIFF
--- a/ui.cpp
+++ b/ui.cpp
@@ -2605,6 +2605,7 @@ void CAddressBookDialog::OnClose(wxCloseEvent& event)
 enum
 {
     ID_TASKBAR_RESTORE = 10001,
+    ID_TASKBAR_SEND,
     ID_TASKBAR_OPTIONS,
     ID_TASKBAR_GENERATE,
     ID_TASKBAR_EXIT,
@@ -2613,6 +2614,7 @@ enum
 BEGIN_EVENT_TABLE(CMyTaskBarIcon, wxTaskBarIcon)
     EVT_TASKBAR_LEFT_DCLICK(CMyTaskBarIcon::OnLeftButtonDClick)
     EVT_MENU(ID_TASKBAR_RESTORE, CMyTaskBarIcon::OnMenuRestore)
+    EVT_MENU(ID_TASKBAR_SEND, CMyTaskBarIcon::OnMenuSend)
     EVT_MENU(ID_TASKBAR_OPTIONS, CMyTaskBarIcon::OnMenuOptions)
     EVT_MENU(ID_TASKBAR_GENERATE, CMyTaskBarIcon::OnMenuGenerate)
     EVT_UPDATE_UI(ID_TASKBAR_GENERATE, CMyTaskBarIcon::OnUpdateUIGenerate)
@@ -2665,6 +2667,13 @@ void CMyTaskBarIcon::OnMenuRestore(wxCommandEvent& event)
     Restore();
 }
 
+void CMyTaskBarIcon::OnMenuSend(wxCommandEvent& event)
+{
+    // Taskbar: Send
+    CSendDialog dialog(pframeMain);
+    dialog.ShowModal();
+}
+
 void CMyTaskBarIcon::OnMenuOptions(wxCommandEvent& event)
 {
     // Since it's modal, get the main window to do it
@@ -2706,6 +2715,7 @@ wxMenu* CMyTaskBarIcon::CreatePopupMenu()
 {
     wxMenu* pmenu = new wxMenu;
     pmenu->Append(ID_TASKBAR_RESTORE, _("&Open Bitcoin"));
+    pmenu->Append(ID_TASKBAR_SEND, _("&Send Bitcoins"));
     pmenu->Append(ID_TASKBAR_OPTIONS, _("O&ptions..."));
     pmenu->AppendCheckItem(ID_TASKBAR_GENERATE, _("&Generate Coins"))->Check(fGenerateBitcoins);
 #ifndef __WXMAC_OSX__ // Mac has built-in quit menu

--- a/ui.cpp
+++ b/ui.cpp
@@ -2627,9 +2627,9 @@ void CMyTaskBarIcon::Show(bool fShow)
     static char pszPrevTip[200];
     if (fShow)
     {
-        string strTooltip = _("Balance: ") + FormatMoney(GetBalance());
+        string strTooltip = strprintf(_("Balance: %s"), FormatMoney(GetBalance()).c_str());
         if (fGenerateBitcoins)
-            strTooltip = _("Bitcoin - Generating (Balance: ") + FormatMoney(GetBalance()) + ")";
+            strTooltip = strprintf(_("Bitcoin - Generating (Balance: %s)"), FormatMoney(GetBalance()).c_str());
         if (fGenerateBitcoins && vNodes.empty())
             strTooltip = _("Bitcoin - (not connected)");
 

--- a/ui.cpp
+++ b/ui.cpp
@@ -1859,6 +1859,7 @@ CSendDialog::CSendDialog(wxWindow* parent, const wxString& strAddress) : CSendDi
     m_bitmapCheckMark->Show(false);
     fEnabledPrev = true;
     m_textCtrlAddress->SetFocus();
+    
     //// todo: should add a display of your balance for convenience
 #ifndef __WXMSW__
     wxFont fontTmp = m_staticTextInstructions->GetFont();
@@ -1867,7 +1868,7 @@ CSendDialog::CSendDialog(wxWindow* parent, const wxString& strAddress) : CSendDi
     m_staticTextInstructions->SetFont(fontTmp);
     SetSize(725, 180);
 #endif
-
+    
     // Set Icon
     wxIcon iconSend;
     iconSend.CopyFromBitmap(wxBitmap(send16noshadow_xpm));
@@ -2626,9 +2627,9 @@ void CMyTaskBarIcon::Show(bool fShow)
     static char pszPrevTip[200];
     if (fShow)
     {
-        string strTooltip = _("Bitcoin");
+        string strTooltip = _("Balance: ") + FormatMoney(GetBalance());
         if (fGenerateBitcoins)
-            strTooltip = _("Bitcoin - Generating");
+            strTooltip = _("Bitcoin - Generating (Balance: ") + FormatMoney(GetBalance()) + ")";
         if (fGenerateBitcoins && vNodes.empty())
             strTooltip = _("Bitcoin - (not connected)");
 

--- a/ui.h
+++ b/ui.h
@@ -323,6 +323,7 @@ protected:
     // Event handlers
     void OnLeftButtonDClick(wxTaskBarIconEvent& event);
     void OnMenuRestore(wxCommandEvent& event);
+    void OnMenuSend(wxCommandEvent& event);
     void OnMenuOptions(wxCommandEvent& event);
     void OnUpdateUIGenerate(wxUpdateUIEvent& event);
     void OnMenuGenerate(wxCommandEvent& event);


### PR DESCRIPTION
Too features which I thought would be very useful is an easy way to view your balance without opening up the whole application, so I added the balance to the tooltip.

I also felt that adding a send coins option was nice, as there is even less reason to open up the whole bitcoin client just to send some coins.

Please note that I may not have done the translations (that is, used _()) perfectly regarding the tooltips, so please check that first.
