### PR TITLE
Support for name lookups in -connect and -addnode

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -158,6 +158,7 @@ bool AppInit2(int argc, char* argv[])
             "  -min             \t\t  " + _("Start minimized\n") +
             "  -datadir=<dir>   \t\t  " + _("Specify data directory\n") +
             "  -proxy=<ip:port> \t  "   + _("Connect through socks4 proxy\n") +
+            "  -dns             \t  "   + _("Allow DNS lookups for addnode and connect\n") +
             "  -addnode=<ip>    \t  "   + _("Add a node to connect to\n") +
             "  -connect=<ip>    \t\t  " + _("Connect only to the specified node\n") +
             "  -nolisten        \t  "   + _("Don't accept connections from outside\n") +
@@ -208,6 +209,7 @@ bool AppInit2(int argc, char* argv[])
     }
 
     fDebug = GetBoolArg("-debug");
+    fAllowDNS = GetBoolArg("-dns");
 
 #ifndef __WXMSW__
     fDaemon = GetBoolArg("-daemon");
@@ -458,7 +460,7 @@ bool AppInit2(int argc, char* argv[])
     {
         foreach(string strAddr, mapMultiArgs["-addnode"])
         {
-            CAddress addr(strAddr, NODE_NETWORK);
+            CAddress addr(strAddr, fAllowDNS);
             addr.nTime = 0; // so it won't relay unless successfully connected
             if (addr.IsValid())
                 AddAddress(addr);


### PR DESCRIPTION
- A new option -dns is introduced that enables name lookups in
  -connect and -addnode, which is not enabled by default, as
  it may be considered a security issue.
- A NameLookup function is added that supports retrieving
  one or more addresses based on a host name
- CAddress constructors (optionally) support name lookups.
- The different places in the source code that did name lookups
  are refactored to use NameLookup or CAddress instead (dns seeding,
  irc server lookup, getexternalip, ...).
