### PR TITLE
detection of conflicts between wallet tx's and the blockchain

### DIFF
--- a/src/db.h
+++ b/src/db.h
@@ -392,16 +392,12 @@ public:
         return Read(std::make_pair(std::string("tx"), hash), wtx);
     }
 
-    bool WriteTx(uint256 hash, const CWalletTx& wtx)
-    {
-        nWalletDBUpdated++;
-        return Write(std::make_pair(std::string("tx"), hash), wtx);
-    }
+    bool WriteTx(uint256 hash, const CWalletTx& wtx);
 
     bool EraseTx(uint256 hash)
     {
         nWalletDBUpdated++;
-        return Erase(std::make_pair(std::string("tx"), hash));
+        return Erase(std::make_pair(std::string("tx"), hash)) || Erase(std::make_pair(std::string("rejtx"), hash));
     }
 
     bool ReadKey(const std::vector<unsigned char>& vchPubKey, CPrivKey& vchPrivKey)

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -383,7 +383,7 @@ bool AppInit2(int argc, char* argv[])
     {
         printf("Rescanning last %i blocks (from block %i)...\n", pindexBest->nHeight - pindexRescan->nHeight, pindexRescan->nHeight);
         nStart = GetTimeMillis();
-        ScanForWalletTransactions(pindexRescan);
+        ScanForWalletTransactions(pindexRescan, true);
         printf(" rescan      %15"PRI64d"ms\n", GetTimeMillis() - nStart);
     }
 
@@ -395,6 +395,7 @@ bool AppInit2(int argc, char* argv[])
         printf("mapKeys.size() = %d\n",         mapKeys.size());
         printf("mapPubKeys.size() = %d\n",      mapPubKeys.size());
         printf("mapWallet.size() = %d\n",       mapWallet.size());
+        printf("mapWalletInputs.size() = %d\n", mapWalletInputs.size());
         printf("mapAddressBook.size() = %d\n",  mapAddressBook.size());
 
     if (!strErrors.empty())

--- a/src/script.cpp
+++ b/src/script.cpp
@@ -1199,10 +1199,5 @@ bool VerifySignature(const CTransaction& txFrom, const CTransaction& txTo, unsig
     if (!VerifyScript(txin.scriptSig, txout.scriptPubKey, txTo, nIn, nHashType))
         return false;
 
-    // Anytime a signature is successfully verified, it's proof the outpoint is spent,
-    // so lets update the wallet spent flag if it doesn't know due to wallet.dat being
-    // restored from backup or the user making copies of wallet.dat.
-    WalletUpdateSpent(txin.prevout);
-
     return true;
 }

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -516,6 +516,8 @@ string FormatTxStatus(const CWalletTx& wtx)
     }
     else
     {
+        if (wtx.IsRejected())
+            return "rejected";
         int nDepth = wtx.GetDepthInMainChain();
         if (GetAdjustedTime() - wtx.nTimeReceived > 2 * 60 && wtx.GetRequestCount() == 0)
             return strprintf(_("%d/offline?"), nDepth);


### PR DESCRIPTION
Changes:
- added mapWalletInputs to track wallet tx's that use a certain outpoint
- added AddWalletTx to update mapWallet and keep mapWalletInputs up-to-date
- CWalletTx's can be in a rejected state and optionally "conflicting", in
  which case they are ignored for balances and coin selection.
- rejected tx's are stored separately in wallet.dat (as 'rejtx' key, and
  with an additional 'rejected' field)
- new function MarkConflicting() marks a tx conflicting, and all dependent
  wallet transactions rejected.
- a new function SyncWithWallet will do both adding to the block chain and
  check for conflicts, and is called when connecting blocks, for incoming
  transactions, and when rescanning
- WalletUpdateSpend works now per-transaction, and is not called anymore
  from script, but from AddToWallet and SyncWithWallet
- GUI is updated to show rejected transactions as "rejected" instead of
  "0/unconfirmed", with credit and debet 0 (like unmatured generations)

Re-enabling of transactions after they would stop being conflicting after
a block chain reorganisation is not supported yet. The is no RPC call to
retrieve information about rejected transactions.
