### PR TITLE
If an error is returned, the client won't crash.

### DIFF
--- a/ui.cpp
+++ b/ui.cpp
@@ -1952,6 +1952,7 @@ void CSendDialog::OnButtonSend(wxCommandEvent& event)
                 {
                     wxMessageBox(strError + "  ", _("Sending..."));
                     EndModal(false);
+                    return;
                 }
 	    }
         }


### PR DESCRIPTION
Minor bug where the client crashes after displaying the error I dug up while testing (should never effect users, but worth patching anyway).
