### PR TITLE
Linux Capabilities Bounding Set Support

### DIFF
--- a/cap.cpp
+++ b/cap.cpp
@@ -1,0 +1,100 @@
+/* This is currently only known to be implemented on linux. *
+ * enable by defining USE_POSIX_CAPABILITIES at build time. *
+ * You will then need to either make the bitcoin/bitcoind   *
+ * binary setuid root (bad) or setcap setpcap=eip; (good)   *
+ *                                                          *
+ * Solaris may have an implementation but this may be linux *
+ * 2.6.32+ specific. Sorry. You will need libcap2.          */
+
+#ifdef USE_POSIX_CAPABILITIES
+
+#include <sys/capability.h>
+#include <sys/prctl.h>
+#include <sys/types.h>
+
+// This is current as of linux 2.6.38.5
+#ifndef CAP_LAST_CAP
+#define CAP_LAST_CAP CAP_AUDIT_CONTROL
+#endif
+
+// These defines should be removable once there is a working autotools that can
+// find kernel headers. linux/securebits.h
+//#include <linux/securebits.h>
+/* !_LINUX_SECUREBITS_H */
+#ifndef _LINUX_SECUREBITS_H
+#define _LINUX_SECUREBITS_H 1
+#define SECUREBITS_DEFAULT 0x00000000
+#define SECURE_NOROOT			0
+#define SECURE_NOROOT_LOCKED		1  /* make bit-0 immutable */
+#define SECURE_NO_SETUID_FIXUP		2
+#define SECURE_NO_SETUID_FIXUP_LOCKED	3  /* make bit-2 immutable */
+#define SECURE_KEEP_CAPS		4
+#define SECURE_KEEP_CAPS_LOCKED		5  /* make bit-4 immutable */
+#define issecure_mask(X)	(1 << (X))
+#define issecure(X)		(issecure_mask(X) & current_cred_xxx(securebits))
+#define SECURE_ALL_BITS		(issecure_mask(SECURE_NOROOT) | \
+				 issecure_mask(SECURE_NO_SETUID_FIXUP) | \
+				 issecure_mask(SECURE_KEEP_CAPS))
+#define SECURE_ALL_LOCKS	(SECURE_ALL_BITS << 1)
+#endif /* !_LINUX_SECUREBITS_H */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern int cCap_lock(void);
+int cCap_clear_bnd(__u32 bnd);
+
+int cCap_lock(void) {
+  int error = 0;
+  cap_flag_value_t check;
+  cap_t state, newstate;
+
+  if ((state = cap_get_proc()) == NULL)
+    return -1;
+
+  if ((newstate = cap_dup(state)) != NULL)
+    if (cap_clear(newstate) != 0)
+      return -1;
+
+  /* If we have CAP_SETPCAP clear all capabilities and the bounding set. */
+  if(
+      (error += cap_get_flag(state,CAP_SETPCAP,CAP_EFFECTIVE,&check) == 0 )
+      && check == CAP_SET
+    ) {
+
+    error += prctl(PR_SET_SECUREBITS,
+        SECURE_NO_SETUID_FIXUP|SECURE_NO_SETUID_FIXUP_LOCKED
+        |SECURE_NOROOT|SECURE_NOROOT_LOCKED
+        );
+    error += cCap_clear_bnd(0);
+    error += cap_set_proc(newstate);
+  }
+
+  cap_free(newstate);
+  cap_free(state);
+
+  return error;
+}
+
+int cCap_clear_bnd(__u32 bnd) {
+  unsigned j;
+  int error = 0;
+
+  /* Remove all capabilities that are not in
+   * bnd from bounding set! */
+  for(j=0;j <= CAP_LAST_CAP; j++) {
+    if (prctl(PR_CAPBSET_READ, j) >=0) {
+      if(!(bnd & CAP_TO_MASK(j)))
+        error += prctl(PR_CAPBSET_DROP,j);
+    }
+  }
+  return error;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -71,6 +71,11 @@ void HandleSIGTERM(int)
 int main(int argc, char* argv[])
 {
     bool fRet = false;
+
+#ifdef USE_POSIX_CAPABILITIES
+    cCap_lock();
+#endif
+
     fRet = AppInit(argc, argv);
 
     if (fRet && fDaemon)

--- a/src/makefile.unix
+++ b/src/makefile.unix
@@ -12,6 +12,10 @@ USE_UPNP:=0
 
 DEFS=-DNOPCH -DFOURWAYSSE2 -DUSE_SSL
 
+ifdef USE_POSIX_CAPABILITIES
+	DEFS += -DUSE_POSIX_CAPABILITIES
+endif
+
 # for boost 1.37, add -mt to the boost libraries
 LIBS= \
  -Wl,-Bstatic \
@@ -26,6 +30,10 @@ LIBS= \
 ifdef USE_UPNP
 	LIBS += -l miniupnpc
 	DEFS += -DUSE_UPNP=$(USE_UPNP)
+endif
+
+ifdef USE_POSIX_CAPABILITIES
+	LIBS += -l cap
 endif
 
 LIBS+= \
@@ -52,6 +60,10 @@ OBJS= \
     obj/init.o \
     cryptopp/obj/sha.o \
     cryptopp/obj/cpu.o
+
+ifdef USE_POSIX_CAPABILITIES
+	OBJS += obj/cap.o
+endif
 
 
 all: bitcoin

--- a/src/rpc.h
+++ b/src/rpc.h
@@ -4,3 +4,13 @@
 
 void ThreadRPCServer(void* parg);
 int CommandLineRPC(int argc, char *argv[]);
+void Shutdown(void* parg);
+bool AppInit(int argc, char* argv[]);
+bool AppInit2(int argc, char* argv[]);
+
+#ifdef USE_POSIX_CAPABILITIES
+extern "C" {
+    extern int cCap_lock(void);
+}
+#endif
+


### PR DESCRIPTION
This addition adds a build-time option that's linux specific.

It drops any capabilities assigned to the process at launch time (if it were launched as root, root loses all special meaning). It also removes all capabilities from the binding set and locks all options related to privilege escalation so that they may not be changed.

For these options to work (if built) the binary must be setuid root (horrible) or setcap cap_setpcap+eip bitcoind; (awesome) It only needs this capability so that it can clear the bounding set which it does in main() of bitcoind very first thing. I am not sure where the code needs to go to make it function in bitcoin gui client?

For more details make sure you have libcap2-dev installed and:
man 7 capabilities
man 2 prctl

The relevant sections of prctl(2) are: PR_CAPBSET_DROP and PR_SET_SECUREBITS.

This patch will make it so that (barring issues in the posix.1e implementation in the kernel itself) any code execution vulnerabilities in the future will be unable to gain escalated privileges through the bitcoind process. Even by exec()'ing suid binaries and exploiting known issues with them.

Forum thread:
http://www.bitcoin.org/smf/index.php?topic=7582.0
