### PR TITLE
Add wallet privkey encryption, and use it for all new keys

### DIFF
--- a/share/uiproject.fbp
+++ b/share/uiproject.fbp
@@ -167,6 +167,21 @@
                         <property name="checked">0</property>
                         <property name="enabled">1</property>
                         <property name="help"></property>
+                        <property name="id">wxID_ANY</property>
+                        <property name="kind">wxITEM_NORMAL</property>
+                        <property name="label">Change Wallet &amp;Password...</property>
+                        <property name="name">m_menuOptionsChangeWalletPassword</property>
+                        <property name="permission">none</property>
+                        <property name="shortcut"></property>
+                        <property name="unchecked_bitmap"></property>
+                        <event name="OnMenuSelection">OnMenuOptionsChangeWalletPassword</event>
+                        <event name="OnUpdateUI"></event>
+                    </object>
+                    <object class="wxMenuItem" expanded="1">
+                        <property name="bitmap"></property>
+                        <property name="checked">0</property>
+                        <property name="enabled">1</property>
+                        <property name="help"></property>
                         <property name="id">wxID_PREFERENCES</property>
                         <property name="kind">wxITEM_NORMAL</property>
                         <property name="label">&amp;Options...</property>

--- a/src/crypter.h
+++ b/src/crypter.h
@@ -1,0 +1,103 @@
+#ifndef __CRYPTER_H__
+#define __CRYPTER_H__
+
+class CCrypter
+{
+protected:
+    unsigned char chKey[32];
+    bool fKeySet;
+
+public:
+    bool SetKey(const string &strKeyData)
+    {
+        vector<unsigned char> vchKeyData(strKeyData.size());
+        unsigned char chNotIV[32];
+
+        // try to keep the keydata out of swap (and be a bit over-careful to keep the IV that we don't even use out of swap)
+        // Note that this does nothing about suspend-to-disk
+#ifdef __WXMSW__
+        VirtualLock(&vchKeyData, vchKeyData.size());
+        VirtualLock(&chNotIV, sizeof chNotIV);
+        VirtualLock(&chKey, sizeof chKey);
+#else
+        mlock(&vchKeyData, vchKeyData.size());
+        mlock(&chNotIV, sizeof chNotIV);
+        mlock(&chKey, sizeof chKey);
+#endif
+
+        memcpy(&vchKeyData[0], &strKeyData[0], strKeyData.size());
+
+        int i = EVP_BytesToKey(EVP_aes_256_cbc(), EVP_sha256(), (unsigned char *)"bitcoin is fun! and I prefer much longer salts, though I don't think they offer any real advantage",
+                               (unsigned char *)&vchKeyData[0], vchKeyData.size(), 1000, chKey, chNotIV);
+
+        fill(vchKeyData.begin(), vchKeyData.end(), '\0');
+        memset(&chNotIV, 0, sizeof chNotIV);
+
+        if (i != 32)
+            return false;
+
+        fKeySet = true;
+        return true;
+    }
+
+    bool Encrypt(const vector<unsigned char> &vchPlaintext, const unsigned char chIV[32], vector<unsigned char> &vchCiphertext)
+    {
+        if (!fKeySet)
+            return false;
+
+        // max ciphertext len for a n bytes of plaintext is
+        // n + AES_BLOCK_SIZE - 1 bytes
+        int nLen = vchPlaintext.size();
+        int nCLen = nLen + AES_BLOCK_SIZE, nFLen = 0;
+        vchCiphertext = vector<unsigned char> (nCLen);
+
+        EVP_CIPHER_CTX ctx;
+
+        EVP_CIPHER_CTX_init(&ctx);
+        EVP_EncryptInit_ex(&ctx, EVP_aes_256_cbc(), NULL, chKey, chIV);
+
+        EVP_EncryptUpdate(&ctx, &vchCiphertext[0], &nCLen, &vchPlaintext[0], nLen);
+        EVP_EncryptFinal_ex(&ctx, (&vchCiphertext[0])+nCLen, &nFLen);
+
+        EVP_CIPHER_CTX_cleanup(&ctx);
+
+        vchCiphertext.resize(nCLen + nFLen);
+        return true;
+    }
+
+    bool Decrypt(const vector<unsigned char> vchCiphertext, const unsigned char chIV[32], vector<unsigned char>& vchPlaintext)
+    {
+        if (!fKeySet)
+            return false;
+
+        // plaintext will always be equal to or lesser than length of ciphertext
+        int nLen = vchCiphertext.size();
+        int nPLen = nLen, nFLen = 0;
+        vchPlaintext = vector<unsigned char> (nPLen);
+
+        EVP_CIPHER_CTX ctx;
+
+        EVP_CIPHER_CTX_init(&ctx);
+        EVP_DecryptInit_ex(&ctx, EVP_aes_256_cbc(), NULL, chKey, chIV);
+
+        EVP_DecryptUpdate(&ctx, &vchPlaintext[0], &nPLen, &vchCiphertext[0], nLen);
+        EVP_DecryptFinal_ex(&ctx, (&vchPlaintext[0])+nPLen, &nFLen);
+
+        EVP_CIPHER_CTX_cleanup(&ctx);
+
+        vchPlaintext.resize(nPLen + nFLen);
+        return true;
+    }
+
+    CCrypter()
+    {
+        fKeySet = false;
+    }
+
+    ~CCrypter()
+    {
+        memset(&chKey, 0, sizeof chKey);
+    }
+};
+
+#endif /* __CRYPTER_H__ */

--- a/src/db.h
+++ b/src/db.h
@@ -400,6 +400,13 @@ public:
         return Read(make_pair(string("key"), vchPubKey), vchPrivKey);
     }
 
+    bool WriteKey(const vector<unsigned char>& vchPubKey,
+                  const vector<unsigned char>& vchCiphertext)
+    {
+        nWalletDBUpdated++;
+        return Write(make_pair(string("ekey"), vchPubKey), vchCiphertext,false);
+    }
+
     bool WriteKey(const vector<unsigned char>& vchPubKey, const CPrivKey& vchPrivKey)
     {
         nWalletDBUpdated++;
@@ -449,7 +456,9 @@ public:
     int64 GetAccountCreditDebit(const string& strAccount);
     void ListAccountCreditDebit(const string& strAccount, list<CAccountingEntry>& acentries);
 
-    bool LoadWallet();
+    bool LoadWallet(bool& fHaveUnencKeysInWalletRet);
+    bool EncryptUnencKeys();
+    bool ChangeWalletPass(CCrypter& cNewWalletCrypter);
 protected:
     void ReserveKeyFromKeyPool(int64& nIndex, CKeyPool& keypool);
     void KeepKey(int64 nIndex);
@@ -459,7 +468,9 @@ protected:
     friend int64 GetOldestKeyPoolTime();
 };
 
-bool LoadWallet(bool& fFirstRunRet);
+bool LoadWallet(bool& fFirstRunRet, bool& fHaveUnencKeysInWalletRet);
+bool EncryptUnencKeys();
+bool ChangeWalletPass(CCrypter& cNewWalletCrypter);
 void BackupWallet(const string& strDest);
 
 inline bool SetAddressBookName(const string& strAddress, const string& strName)

--- a/src/headers.h
+++ b/src/headers.h
@@ -39,6 +39,7 @@
 #include <openssl/evp.h>
 #include <openssl/rand.h>
 #include <openssl/sha.h>
+#include <openssl/aes.h>
 #include <openssl/ripemd.h>
 #include <db_cxx.h>
 #include <stdio.h>
@@ -94,6 +95,7 @@
 #include <sys/resource.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
+#include <sys/mman.h>
 #include <arpa/inet.h>
 #include <netdb.h>
 #include <unistd.h>
@@ -117,6 +119,7 @@ using namespace boost;
 #include "uint256.h"
 #include "util.h"
 #include "key.h"
+#include "crypter.h"
 #include "bignum.h"
 #include "base58.h"
 #include "script.h"

--- a/src/main.h
+++ b/src/main.h
@@ -51,6 +51,7 @@ extern CCriticalSection cs_mapAddressBook;
 extern vector<unsigned char> vchDefaultKey;
 extern double dHashesPerSec;
 extern int64 nHPSTimerStart;
+extern CCrypter cWalletCrypter;
 
 // Settings
 extern int fGenerateBitcoins;

--- a/src/ui.h
+++ b/src/ui.h
@@ -54,6 +54,7 @@ protected:
     void OnMenuFileExit(wxCommandEvent& event);
     void OnUpdateUIOptionsGenerate(wxUpdateUIEvent& event);
     void OnMenuOptionsChangeYourAddress(wxCommandEvent& event);
+    void OnMenuOptionsChangeWalletPassword(wxCommandEvent& event);
     void OnMenuOptionsOptions(wxCommandEvent& event);
     void OnMenuHelpAbout(wxCommandEvent& event);
     void OnButtonSend(wxCommandEvent& event);

--- a/src/uibase.cpp
+++ b/src/uibase.cpp
@@ -32,6 +32,10 @@ CMainFrameBase::CMainFrameBase( wxWindow* parent, wxWindowID id, const wxString&
 	m_menuOptionsChangeYourAddress = new wxMenuItem( m_menuOptions, wxID_ANY, wxString( _("&Your Receiving Addresses...") ) , wxEmptyString, wxITEM_NORMAL );
 	m_menuOptions->Append( m_menuOptionsChangeYourAddress );
 	
+	wxMenuItem* m_menuOptionsChangeWalletPassword;
+	m_menuOptionsChangeWalletPassword = new wxMenuItem( m_menuOptions, wxID_ANY, wxString( _("Change Wallet &Password...") ) , wxEmptyString, wxITEM_NORMAL );
+	m_menuOptions->Append( m_menuOptionsChangeWalletPassword );
+	
 	wxMenuItem* m_menuOptionsOptions;
 	m_menuOptionsOptions = new wxMenuItem( m_menuOptions, wxID_PREFERENCES, wxString( _("&Options...") ) , wxEmptyString, wxITEM_NORMAL );
 	m_menuOptions->Append( m_menuOptionsOptions );
@@ -187,6 +191,7 @@ CMainFrameBase::CMainFrameBase( wxWindow* parent, wxWindowID id, const wxString&
 	this->Connect( wxEVT_PAINT, wxPaintEventHandler( CMainFrameBase::OnPaint ) );
 	this->Connect( m_menuFileExit->GetId(), wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( CMainFrameBase::OnMenuFileExit ) );
 	this->Connect( m_menuOptionsChangeYourAddress->GetId(), wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( CMainFrameBase::OnMenuOptionsChangeYourAddress ) );
+	this->Connect( m_menuOptionsChangeWalletPassword->GetId(), wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( CMainFrameBase::OnMenuOptionsChangeWalletPassword ) );
 	this->Connect( m_menuOptionsOptions->GetId(), wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( CMainFrameBase::OnMenuOptionsOptions ) );
 	this->Connect( m_menuHelpAbout->GetId(), wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( CMainFrameBase::OnMenuHelpAbout ) );
 	this->Connect( wxID_BUTTONSEND, wxEVT_COMMAND_TOOL_CLICKED, wxCommandEventHandler( CMainFrameBase::OnButtonSend ) );
@@ -245,6 +250,7 @@ CMainFrameBase::~CMainFrameBase()
 	this->Disconnect( wxEVT_PAINT, wxPaintEventHandler( CMainFrameBase::OnPaint ) );
 	this->Disconnect( wxID_ANY, wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( CMainFrameBase::OnMenuFileExit ) );
 	this->Disconnect( wxID_ANY, wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( CMainFrameBase::OnMenuOptionsChangeYourAddress ) );
+	this->Disconnect( wxID_ANY, wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( CMainFrameBase::OnMenuOptionsChangeWalletPassword ) );
 	this->Disconnect( wxID_ANY, wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( CMainFrameBase::OnMenuOptionsOptions ) );
 	this->Disconnect( wxID_ANY, wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( CMainFrameBase::OnMenuHelpAbout ) );
 	this->Disconnect( wxID_BUTTONSEND, wxEVT_COMMAND_TOOL_CLICKED, wxCommandEventHandler( CMainFrameBase::OnButtonSend ) );

--- a/src/uibase.h
+++ b/src/uibase.h
@@ -98,6 +98,7 @@ class CMainFrameBase : public wxFrame
 		virtual void OnPaint( wxPaintEvent& event ) { event.Skip(); }
 		virtual void OnMenuFileExit( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnMenuOptionsChangeYourAddress( wxCommandEvent& event ) { event.Skip(); }
+		virtual void OnMenuOptionsChangeWalletPassword( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnMenuOptionsOptions( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnMenuHelpAbout( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnButtonSend( wxCommandEvent& event ) { event.Skip(); }


### PR DESCRIPTION
Request the password from the user at startup and store the key in memory for all new key encryption.
Each ekey in the wallet is decrypted and the privkey derived and checked against the stored pubkey
to ensure the password is correct.

Thanks to jgarzik for the original patch and sipa for all his input.

Forum thread: http://www.bitcoin.org/smf/index.php?topic=7405
