### PR TITLE
add #if guard around fUseUPnP to fix build warning

### DIFF
--- a/db.cpp
+++ b/db.cpp
@@ -790,7 +790,9 @@ bool CWalletDB::LoadWallet()
                 if (strKey == "fMinimizeOnClose")   ssValue >> fMinimizeOnClose;
                 if (strKey == "fUseProxy")          ssValue >> fUseProxy;
                 if (strKey == "addrProxy")          ssValue >> addrProxy;
+#if USE_UPNP
                 if (fHaveUPnP && strKey == "fUseUPnP")           ssValue >> fUseUPnP;
+#endif
             }
         }
         pcursor->close();

--- a/db.cpp
+++ b/db.cpp
@@ -790,9 +790,7 @@ bool CWalletDB::LoadWallet()
                 if (strKey == "fMinimizeOnClose")   ssValue >> fMinimizeOnClose;
                 if (strKey == "fUseProxy")          ssValue >> fUseProxy;
                 if (strKey == "addrProxy")          ssValue >> addrProxy;
-#if USE_UPNP
                 if (fHaveUPnP && strKey == "fUseUPnP")           ssValue >> fUseUPnP;
-#endif
             }
         }
         pcursor->close();

--- a/main.cpp
+++ b/main.cpp
@@ -65,12 +65,10 @@ int fLimitProcessors = false;
 int nLimitProcessors = 1;
 int fMinimizeToTray = true;
 int fMinimizeOnClose = true;
-#ifdef USE_UPNP
-#if USE_UPNP
+#if defined(USE_UPNP) && USE_UPNP
 int fUseUPnP = true;
 #else
 int fUseUPnP = false;
-#endif
 #endif
 
 


### PR DESCRIPTION
This fixes the build problem that I described in https://github.com/bitcoin/bitcoin/issues/212

(NOTE: There's actually one other un-#if-guarded usage of the variable "fUseUPnP" in this file, but that one doesn't seem to cause build problems, for whatever reason. So I just added #if guards around this usage, to make the change as minimal as possible.)
