### PR TITLE
Allow move RPC to take account balances negative

### DIFF
--- a/src/rpc.cpp
+++ b/src/rpc.cpp
@@ -702,21 +702,6 @@ Value movecmd(const Array& params, bool fHelp)
         CWalletDB walletdb;
         walletdb.TxnBegin();
 
-        // Check funds
-        if (!strFrom.empty())
-        {
-            int64 nBalance = GetAccountBalance(walletdb, strFrom, nMinDepth);
-            if (nAmount > nBalance)
-                throw JSONRPCError(-6, "Account has insufficient funds");
-        }
-        else
-        {
-            // move from "" account special case
-            int64 nBalance = GetAccountBalance(walletdb, strTo, nMinDepth);
-            if (nAmount > GetBalance() - nBalance)
-                throw JSONRPCError(-6, "Account has insufficient funds");
-        }
-
         int64 nNow = GetAdjustedTime();
 
         // Debit


### PR DESCRIPTION
Use case:  Customer owes you bitcoins, so you create a payment address
associated with an account with a negative balance (the amount they owe), using
move ...account... ...other_account... +amount
When customer pays, that account balance will go to zero.

This doesn't change sends-- you still can't send from an account with a zero or negative balance.
