### PR TITLE
Make bitcoin include files modular / Qt4 compat

### DIFF
--- a/src/bignum.h
+++ b/src/bignum.h
@@ -1,14 +1,14 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Distributed under the MIT/X11 software license, see the accompanying
 // file license.txt or http://www.opensource.org/licenses/mit-license.php.
+#ifndef BITCOIN_BIGNUM_H
+#define BITCOIN_BIGNUM_H
 
 #include <stdexcept>
 #include <vector>
 #include <openssl/bn.h>
 
-
-
-
+#include "util.h"
 
 class bignum_error : public std::runtime_error
 {
@@ -308,7 +308,7 @@ public:
         CAutoBN_CTX pctx;
         CBigNum bnBase = nBase;
         CBigNum bn0 = 0;
-        string str;
+        std::string str;
         CBigNum bn = *this;
         BN_set_negative(&bn, false);
         CBigNum dv;
@@ -348,7 +348,7 @@ public:
     template<typename Stream>
     void Unserialize(Stream& s, int nType=0, int nVersion=VERSION)
     {
-        vector<unsigned char> vch;
+        std::vector<unsigned char> vch;
         ::Unserialize(s, vch, nType, nVersion);
         setvch(vch);
     }
@@ -530,3 +530,5 @@ inline bool operator<=(const CBigNum& a, const CBigNum& b) { return (BN_cmp(&a, 
 inline bool operator>=(const CBigNum& a, const CBigNum& b) { return (BN_cmp(&a, &b) >= 0); }
 inline bool operator<(const CBigNum& a, const CBigNum& b)  { return (BN_cmp(&a, &b) < 0); }
 inline bool operator>(const CBigNum& a, const CBigNum& b)  { return (BN_cmp(&a, &b) > 0); }
+
+#endif

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -4,6 +4,9 @@
 
 #include "headers.h"
 
+using namespace std;
+using namespace boost;
+
 void ThreadFlushWalletDB(void* parg);
 
 
@@ -434,13 +437,13 @@ bool CTxDB::LoadBlockIndex()
     // Calculate bnChainWork
     vector<pair<int, CBlockIndex*> > vSortedByHeight;
     vSortedByHeight.reserve(mapBlockIndex.size());
-    foreach(const PAIRTYPE(uint256, CBlockIndex*)& item, mapBlockIndex)
+    BOOST_FOREACH(const PAIRTYPE(uint256, CBlockIndex*)& item, mapBlockIndex)
     {
         CBlockIndex* pindex = item.second;
         vSortedByHeight.push_back(make_pair(pindex->nHeight, pindex));
     }
     sort(vSortedByHeight.begin(), vSortedByHeight.end());
-    foreach(const PAIRTYPE(int, CBlockIndex*)& item, vSortedByHeight)
+    BOOST_FOREACH(const PAIRTYPE(int, CBlockIndex*)& item, vSortedByHeight)
     {
         CBlockIndex* pindex = item.second;
         pindex->bnChainWork = (pindex->pprev ? pindex->pprev->bnChainWork : 0) + pindex->GetBlockWork();
@@ -603,7 +606,7 @@ int64 CWalletDB::GetAccountCreditDebit(const string& strAccount)
     ListAccountCreditDebit(strAccount, entries);
 
     int64 nCreditDebit = 0;
-    foreach (const CAccountingEntry& entry, entries)
+    BOOST_FOREACH (const CAccountingEntry& entry, entries)
         nCreditDebit += entry.nCreditDebit;
 
     return nCreditDebit;
@@ -796,7 +799,7 @@ bool CWalletDB::LoadWallet()
         pcursor->close();
     }
 
-    foreach(uint256 hash, vWalletUpgrade)
+    BOOST_FOREACH(uint256 hash, vWalletUpgrade)
         WriteTx(hash, mapWallet[hash]);
 
     printf("nFileVersion = %d\n", nFileVersion);

--- a/src/headers.h
+++ b/src/headers.h
@@ -109,8 +109,6 @@
 
 
 #pragma hdrstop
-using namespace std;
-using namespace boost;
 
 #include "strlcpy.h"
 #include "serialize.h"
@@ -133,6 +131,7 @@ using namespace boost;
 #endif
 #include "init.h"
 
+#ifdef GUI
 #include "xpm/addressbook16.xpm"
 #include "xpm/addressbook20.xpm"
 #include "xpm/bitcoin16.xpm"
@@ -145,3 +144,4 @@ using namespace boost;
 #include "xpm/send16noshadow.xpm"
 #include "xpm/send20.xpm"
 #include "xpm/about.xpm"
+#endif

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1,14 +1,10 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Distributed under the MIT/X11 software license, see the accompanying
 // file license.txt or http://www.opensource.org/licenses/mit-license.php.
-
 #include "headers.h"
 
-
-
-
-
-
+using namespace std;
+using namespace boost;
 
 //////////////////////////////////////////////////////////////////////////////
 //
@@ -71,7 +67,6 @@ void HandleSIGTERM(int)
 //
 // Start
 //
-
 #ifndef GUI
 int main(int argc, char* argv[])
 {
@@ -458,7 +453,7 @@ bool AppInit2(int argc, char* argv[])
 
     if (mapArgs.count("-addnode"))
     {
-        foreach(string strAddr, mapMultiArgs["-addnode"])
+        BOOST_FOREACH(string strAddr, mapMultiArgs["-addnode"])
         {
             CAddress addr(strAddr, fAllowDNS);
             addr.nTime = 0; // so it won't relay unless successfully connected

--- a/src/init.h
+++ b/src/init.h
@@ -1,7 +1,11 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Distributed under the MIT/X11 software license, see the accompanying
 // file license.txt or http://www.opensource.org/licenses/mit-license.php.
+#ifndef BITCOIN_INIT_H
+#define BITCOIN_INIT_H
 
 void Shutdown(void* parg);
 bool AppInit(int argc, char* argv[]);
 bool AppInit2(int argc, char* argv[]);
+
+#endif

--- a/src/irc.cpp
+++ b/src/irc.cpp
@@ -4,6 +4,9 @@
 
 #include "headers.h"
 
+using namespace std;
+using namespace boost;
+
 int nGotIRCAddresses = 0;
 bool fGotExternalIP = false;
 

--- a/src/irc.h
+++ b/src/irc.h
@@ -1,9 +1,13 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Distributed under the MIT/X11 software license, see the accompanying
 // file license.txt or http://www.opensource.org/licenses/mit-license.php.
+#ifndef BITCOIN_IRC_H
+#define BITCOIN_IRC_H
 
-bool RecvLine(SOCKET hSocket, string& strLine);
+bool RecvLine(SOCKET hSocket, std::string& strLine);
 void ThreadIRCSeed(void* parg);
 
 extern int nGotIRCAddresses;
 extern bool fGotExternalIP;
+
+#endif

--- a/src/key.h
+++ b/src/key.h
@@ -1,7 +1,12 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Distributed under the MIT/X11 software license, see the accompanying
 // file license.txt or http://www.opensource.org/licenses/mit-license.php.
+#ifndef BITCOIN_KEY_H
+#define BITCOIN_KEY_H
 
+#include <openssl/ec.h>
+#include <openssl/ecdsa.h>
+#include <openssl/obj_mac.h>
 
 // secp160k1
 // const unsigned int PRIVATE_KEY_SIZE = 192;
@@ -36,7 +41,7 @@ public:
 
 
 // secure_allocator is defined in serialize.h
-typedef vector<unsigned char, secure_allocator<unsigned char> > CPrivKey;
+typedef std::vector<unsigned char, secure_allocator<unsigned char> > CPrivKey;
 
 
 
@@ -109,7 +114,7 @@ public:
         return vchPrivKey;
     }
 
-    bool SetPubKey(const vector<unsigned char>& vchPubKey)
+    bool SetPubKey(const std::vector<unsigned char>& vchPubKey)
     {
         const unsigned char* pbegin = &vchPubKey[0];
         if (!o2i_ECPublicKey(&pkey, &pbegin, vchPubKey.size()))
@@ -118,19 +123,19 @@ public:
         return true;
     }
 
-    vector<unsigned char> GetPubKey() const
+    std::vector<unsigned char> GetPubKey() const
     {
         unsigned int nSize = i2o_ECPublicKey(pkey, NULL);
         if (!nSize)
             throw key_error("CKey::GetPubKey() : i2o_ECPublicKey failed");
-        vector<unsigned char> vchPubKey(nSize, 0);
+        std::vector<unsigned char> vchPubKey(nSize, 0);
         unsigned char* pbegin = &vchPubKey[0];
         if (i2o_ECPublicKey(pkey, &pbegin) != nSize)
             throw key_error("CKey::GetPubKey() : i2o_ECPublicKey returned unexpected size");
         return vchPubKey;
     }
 
-    bool Sign(uint256 hash, vector<unsigned char>& vchSig)
+    bool Sign(uint256 hash, std::vector<unsigned char>& vchSig)
     {
         vchSig.clear();
         unsigned char pchSig[10000];
@@ -142,7 +147,7 @@ public:
         return true;
     }
 
-    bool Verify(uint256 hash, const vector<unsigned char>& vchSig)
+    bool Verify(uint256 hash, const std::vector<unsigned char>& vchSig)
     {
         // -1 = error, 0 = bad sig, 1 = good
         if (ECDSA_verify(0, (unsigned char*)&hash, sizeof(hash), &vchSig[0], vchSig.size(), pkey) != 1)
@@ -150,7 +155,7 @@ public:
         return true;
     }
 
-    static bool Sign(const CPrivKey& vchPrivKey, uint256 hash, vector<unsigned char>& vchSig)
+    static bool Sign(const CPrivKey& vchPrivKey, uint256 hash, std::vector<unsigned char>& vchSig)
     {
         CKey key;
         if (!key.SetPrivKey(vchPrivKey))
@@ -158,7 +163,7 @@ public:
         return key.Sign(hash, vchSig);
     }
 
-    static bool Verify(const vector<unsigned char>& vchPubKey, uint256 hash, const vector<unsigned char>& vchSig)
+    static bool Verify(const std::vector<unsigned char>& vchPubKey, uint256 hash, const std::vector<unsigned char>& vchSig)
     {
         CKey key;
         if (!key.SetPubKey(vchPubKey))
@@ -166,3 +171,5 @@ public:
         return key.Verify(hash, vchSig);
     }
 };
+
+#endif

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -11,6 +11,9 @@
 #include <miniupnpc/upnperrors.h>
 #endif
 
+using namespace std;
+using namespace boost;
+
 static const int MAX_OUTBOUND_CONNECTIONS = 8;
 
 void ThreadMessageHandler2(void* parg);
@@ -330,7 +333,7 @@ void ThreadGetMyExternalIP(void* parg)
             CAddress addr(addrLocalHost);
             addr.nTime = GetAdjustedTime();
             CRITICAL_BLOCK(cs_vNodes)
-                foreach(CNode* pnode, vNodes)
+                BOOST_FOREACH(CNode* pnode, vNodes)
                     pnode->PushAddress(addr);
         }
     }
@@ -414,7 +417,7 @@ void AbandonRequests(void (*fn)(void*, CDataStream&), void* param1)
     // call this in the destructor so it doesn't get called after it's deleted.
     CRITICAL_BLOCK(cs_vNodes)
     {
-        foreach(CNode* pnode, vNodes)
+        BOOST_FOREACH(CNode* pnode, vNodes)
         {
             CRITICAL_BLOCK(pnode->cs_mapRequests)
             {
@@ -451,7 +454,7 @@ bool AnySubscribed(unsigned int nChannel)
     if (pnodeLocalHost->IsSubscribed(nChannel))
         return true;
     CRITICAL_BLOCK(cs_vNodes)
-        foreach(CNode* pnode, vNodes)
+        BOOST_FOREACH(CNode* pnode, vNodes)
             if (pnode->IsSubscribed(nChannel))
                 return true;
     return false;
@@ -473,7 +476,7 @@ void CNode::Subscribe(unsigned int nChannel, unsigned int nHops)
     {
         // Relay subscribe
         CRITICAL_BLOCK(cs_vNodes)
-            foreach(CNode* pnode, vNodes)
+            BOOST_FOREACH(CNode* pnode, vNodes)
                 if (pnode != this)
                     pnode->PushMessage("subscribe", nChannel, nHops);
     }
@@ -495,7 +498,7 @@ void CNode::CancelSubscribe(unsigned int nChannel)
     {
         // Relay subscription cancel
         CRITICAL_BLOCK(cs_vNodes)
-            foreach(CNode* pnode, vNodes)
+            BOOST_FOREACH(CNode* pnode, vNodes)
                 if (pnode != this)
                     pnode->PushMessage("sub-cancel", nChannel);
     }
@@ -513,7 +516,7 @@ CNode* FindNode(unsigned int ip)
 {
     CRITICAL_BLOCK(cs_vNodes)
     {
-        foreach(CNode* pnode, vNodes)
+        BOOST_FOREACH(CNode* pnode, vNodes)
             if (pnode->addr.ip == ip)
                 return (pnode);
     }
@@ -524,7 +527,7 @@ CNode* FindNode(CAddress addr)
 {
     CRITICAL_BLOCK(cs_vNodes)
     {
-        foreach(CNode* pnode, vNodes)
+        BOOST_FOREACH(CNode* pnode, vNodes)
             if (pnode->addr == addr)
                 return (pnode);
     }
@@ -661,7 +664,7 @@ void ThreadSocketHandler2(void* parg)
         {
             // Disconnect unused nodes
             vector<CNode*> vNodesCopy = vNodes;
-            foreach(CNode* pnode, vNodesCopy)
+            BOOST_FOREACH(CNode* pnode, vNodesCopy)
             {
                 if (pnode->fDisconnect ||
                     (pnode->GetRefCount() <= 0 && pnode->vRecv.empty() && pnode->vSend.empty()))
@@ -683,7 +686,7 @@ void ThreadSocketHandler2(void* parg)
 
             // Delete disconnected nodes
             list<CNode*> vNodesDisconnectedCopy = vNodesDisconnected;
-            foreach(CNode* pnode, vNodesDisconnectedCopy)
+            BOOST_FOREACH(CNode* pnode, vNodesDisconnectedCopy)
             {
                 // wait until threads are done using it
                 if (pnode->GetRefCount() <= 0)
@@ -729,7 +732,7 @@ void ThreadSocketHandler2(void* parg)
         hSocketMax = max(hSocketMax, hListenSocket);
         CRITICAL_BLOCK(cs_vNodes)
         {
-            foreach(CNode* pnode, vNodes)
+            BOOST_FOREACH(CNode* pnode, vNodes)
             {
                 if (pnode->hSocket == INVALID_SOCKET || pnode->hSocket < 0)
                     continue;
@@ -771,7 +774,7 @@ void ThreadSocketHandler2(void* parg)
             int nInbound = 0;
 
             CRITICAL_BLOCK(cs_vNodes)
-                foreach(CNode* pnode, vNodes)
+                BOOST_FOREACH(CNode* pnode, vNodes)
                 if (pnode->fInbound)
                     nInbound++;
             if (hSocket == INVALID_SOCKET)
@@ -801,10 +804,10 @@ void ThreadSocketHandler2(void* parg)
         CRITICAL_BLOCK(cs_vNodes)
         {
             vNodesCopy = vNodes;
-            foreach(CNode* pnode, vNodesCopy)
+            BOOST_FOREACH(CNode* pnode, vNodesCopy)
                 pnode->AddRef();
         }
-        foreach(CNode* pnode, vNodesCopy)
+        BOOST_FOREACH(CNode* pnode, vNodesCopy)
         {
             if (fShutdown)
                 return;
@@ -921,7 +924,7 @@ void ThreadSocketHandler2(void* parg)
         }
         CRITICAL_BLOCK(cs_vNodes)
         {
-            foreach(CNode* pnode, vNodesCopy)
+            BOOST_FOREACH(CNode* pnode, vNodesCopy)
                 pnode->Release();
         }
 
@@ -1057,7 +1060,7 @@ void DNSAddressSeed()
         vector<CAddress> vaddr;
         if (Lookup(strDNSSeed[seed_idx], vaddr, NODE_NETWORK, true))
         {
-            foreach (CAddress& addr, vaddr)
+            BOOST_FOREACH (CAddress& addr, vaddr)
             {
                 if (addr.GetByte(3) != 127)
                 {
@@ -1148,7 +1151,7 @@ void ThreadOpenConnections2(void* parg)
     {
         for (int64 nLoop = 0;; nLoop++)
         {
-            foreach(string strAddr, mapMultiArgs["-connect"])
+            BOOST_FOREACH(string strAddr, mapMultiArgs["-connect"])
             {
                 CAddress addr(strAddr, fAllowDNS);
                 if (addr.IsValid())
@@ -1166,7 +1169,7 @@ void ThreadOpenConnections2(void* parg)
     // Connect to manually added nodes first
     if (mapArgs.count("-addnode"))
     {
-        foreach(string strAddr, mapMultiArgs["-addnode"])
+        BOOST_FOREACH(string strAddr, mapMultiArgs["-addnode"])
         {
             CAddress addr(strAddr, fAllowDNS);
             if (addr.IsValid())
@@ -1190,7 +1193,7 @@ void ThreadOpenConnections2(void* parg)
         {
             int nOutbound = 0;
             CRITICAL_BLOCK(cs_vNodes)
-                foreach(CNode* pnode, vNodes)
+                BOOST_FOREACH(CNode* pnode, vNodes)
                     if (!pnode->fInbound)
                         nOutbound++;
             int nMaxOutboundConnections = MAX_OUTBOUND_CONNECTIONS;
@@ -1233,7 +1236,7 @@ void ThreadOpenConnections2(void* parg)
                 {
                     nSeedDisconnected = GetTime();
                     CRITICAL_BLOCK(cs_vNodes)
-                        foreach(CNode* pnode, vNodes)
+                        BOOST_FOREACH(CNode* pnode, vNodes)
                             if (setSeed.count(pnode->addr.ip))
                                 pnode->fDisconnect = true;
                 }
@@ -1241,7 +1244,7 @@ void ThreadOpenConnections2(void* parg)
                 // Keep setting timestamps to 0 so they won't reconnect
                 if (GetTime() - nSeedDisconnected < 60 * 60)
                 {
-                    foreach(PAIRTYPE(const vector<unsigned char>, CAddress)& item, mapAddresses)
+                    BOOST_FOREACH(PAIRTYPE(const vector<unsigned char>, CAddress)& item, mapAddresses)
                     {
                         if (setSeed.count(item.second.ip) && item.second.nTime != 0)
                         {
@@ -1264,12 +1267,12 @@ void ThreadOpenConnections2(void* parg)
         // Do this here so we don't have to critsect vNodes inside mapAddresses critsect.
         set<unsigned int> setConnected;
         CRITICAL_BLOCK(cs_vNodes)
-            foreach(CNode* pnode, vNodes)
+            BOOST_FOREACH(CNode* pnode, vNodes)
                 setConnected.insert(pnode->addr.ip & 0x0000ffff);
 
         CRITICAL_BLOCK(cs_mapAddresses)
         {
-            foreach(const PAIRTYPE(vector<unsigned char>, CAddress)& item, mapAddresses)
+            BOOST_FOREACH(const PAIRTYPE(vector<unsigned char>, CAddress)& item, mapAddresses)
             {
                 const CAddress& addr = item.second;
                 if (!addr.IsIPv4() || !addr.IsValid() || setConnected.count(addr.ip & 0x0000ffff))
@@ -1385,7 +1388,7 @@ void ThreadMessageHandler2(void* parg)
         CRITICAL_BLOCK(cs_vNodes)
         {
             vNodesCopy = vNodes;
-            foreach(CNode* pnode, vNodesCopy)
+            BOOST_FOREACH(CNode* pnode, vNodesCopy)
                 pnode->AddRef();
         }
 
@@ -1393,7 +1396,7 @@ void ThreadMessageHandler2(void* parg)
         CNode* pnodeTrickle = NULL;
         if (!vNodesCopy.empty())
             pnodeTrickle = vNodesCopy[GetRand(vNodesCopy.size())];
-        foreach(CNode* pnode, vNodesCopy)
+        BOOST_FOREACH(CNode* pnode, vNodesCopy)
         {
             // Receive messages
             TRY_CRITICAL_BLOCK(pnode->cs_vRecv)
@@ -1410,7 +1413,7 @@ void ThreadMessageHandler2(void* parg)
 
         CRITICAL_BLOCK(cs_vNodes)
         {
-            foreach(CNode* pnode, vNodesCopy)
+            BOOST_FOREACH(CNode* pnode, vNodesCopy)
                 pnode->Release();
         }
 
@@ -1527,7 +1530,7 @@ void StartNode(void* parg)
     {
         vector<CAddress> vaddr;
         if (Lookup(pszHostName, vaddr, nLocalServices, -1, true))
-            foreach (const CAddress &addr, vaddr)
+            BOOST_FOREACH (const CAddress &addr, vaddr)
                 if (addr.GetByte(3) != 127)
                 {
                     addrLocalHost = addr;
@@ -1648,7 +1651,7 @@ public:
     ~CNetCleanup()
     {
         // Close sockets
-        foreach(CNode* pnode, vNodes)
+        BOOST_FOREACH(CNode* pnode, vNodes)
             if (pnode->hSocket != INVALID_SOCKET)
                 closesocket(pnode->hSocket);
         if (hListenSocket != INVALID_SOCKET)

--- a/src/net.h
+++ b/src/net.h
@@ -1,6 +1,16 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Distributed under the MIT/X11 software license, see the accompanying
 // file license.txt or http://www.opensource.org/licenses/mit-license.php.
+#ifndef BITCOIN_NET_H
+#define BITCOIN_NET_H
+
+#include <deque>
+#include <boost/array.hpp>
+#include <openssl/rand.h>
+
+#ifndef __WXMSW__
+#include <arpa/inet.h>
+#endif
 
 class CMessageHeader;
 class CAddress;
@@ -23,7 +33,7 @@ enum
 
 
 bool ConnectSocket(const CAddress& addrConnect, SOCKET& hSocketRet);
-bool Lookup(const char *pszName, vector<CAddress>& vaddr, int nServices, int nMaxSolutions, bool fAllowLookup = false, int portDefault = 0, bool fAllowPort = false);
+bool Lookup(const char *pszName, std::vector<CAddress>& vaddr, int nServices, int nMaxSolutions, bool fAllowLookup = false, int portDefault = 0, bool fAllowPort = false);
 bool Lookup(const char *pszName, CAddress& addr, int nServices, bool fAllowLookup = false, int portDefault = 0, bool fAllowPort = false);
 bool GetMyExternalIP(unsigned int& ipRet);
 bool AddAddress(CAddress addr, int64 nTimePenalty=0);
@@ -34,7 +44,7 @@ void AbandonRequests(void (*fn)(void*, CDataStream&), void* param1);
 bool AnySubscribed(unsigned int nChannel);
 void MapPort(bool fMapPort);
 void DNSAddressSeed();
-bool BindListenPort(string& strError=REF(string()));
+bool BindListenPort(std::string& strError=REF(std::string()));
 void StartNode(void* parg);
 bool StopNode();
 
@@ -89,12 +99,12 @@ public:
             READWRITE(nChecksum);
     )
 
-    string GetCommand()
+    std::string GetCommand()
     {
         if (pchCommand[COMMAND_SIZE-1] == 0)
-            return string(pchCommand, pchCommand + strlen(pchCommand));
+            return std::string(pchCommand, pchCommand + strlen(pchCommand));
         else
-            return string(pchCommand, pchCommand + COMMAND_SIZE);
+            return std::string(pchCommand, pchCommand + COMMAND_SIZE);
     }
 
     bool IsValid()
@@ -182,13 +192,13 @@ public:
         Lookup(pszIn, *this, nServicesIn, fNameLookup, 0, true);
     }
 
-    explicit CAddress(string strIn, int portIn, bool fNameLookup = false, uint64 nServicesIn=NODE_NETWORK)
+    explicit CAddress(std::string strIn, int portIn, bool fNameLookup = false, uint64 nServicesIn=NODE_NETWORK)
     {
         Init();
         Lookup(strIn.c_str(), *this, nServicesIn, fNameLookup, portIn);
     }
 
-    explicit CAddress(string strIn, bool fNameLookup = false, uint64 nServicesIn=NODE_NETWORK)
+    explicit CAddress(std::string strIn, bool fNameLookup = false, uint64 nServicesIn=NODE_NETWORK)
     {
         Init();
         Lookup(strIn.c_str(), *this, nServicesIn, fNameLookup, 0, true);
@@ -245,16 +255,16 @@ public:
         return false;
     }
 
-    vector<unsigned char> GetKey() const
+    std::vector<unsigned char> GetKey() const
     {
         CDataStream ss;
         ss.reserve(18);
         ss << FLATDATA(pchReserved) << ip << port;
 
         #if defined(_MSC_VER) && _MSC_VER < 1300
-        return vector<unsigned char>((unsigned char*)&ss.begin()[0], (unsigned char*)&ss.end()[0]);
+        return std::vector<unsigned char>((unsigned char*)&ss.begin()[0], (unsigned char*)&ss.end()[0]);
         #else
-        return vector<unsigned char>(ss.begin(), ss.end());
+        return std::vector<unsigned char>(ss.begin(), ss.end());
         #endif
     }
 
@@ -301,22 +311,22 @@ public:
         return ((unsigned char*)&ip)[3-n];
     }
 
-    string ToStringIPPort() const
+    std::string ToStringIPPort() const
     {
         return strprintf("%u.%u.%u.%u:%u", GetByte(3), GetByte(2), GetByte(1), GetByte(0), ntohs(port));
     }
 
-    string ToStringIP() const
+    std::string ToStringIP() const
     {
         return strprintf("%u.%u.%u.%u", GetByte(3), GetByte(2), GetByte(1), GetByte(0));
     }
 
-    string ToStringPort() const
+    std::string ToStringPort() const
     {
         return strprintf("%u", ntohs(port));
     }
 
-    string ToString() const
+    std::string ToString() const
     {
         return strprintf("%u.%u.%u.%u:%u", GetByte(3), GetByte(2), GetByte(1), GetByte(0), ntohs(port));
     }
@@ -364,7 +374,7 @@ public:
         hash = hashIn;
     }
 
-    CInv(const string& strType, const uint256& hashIn)
+    CInv(const std::string& strType, const uint256& hashIn)
     {
         int i;
         for (i = 1; i < ARRAYLEN(ppszTypeName); i++)
@@ -403,7 +413,7 @@ public:
         return ppszTypeName[type];
     }
 
-    string ToString() const
+    std::string ToString() const
     {
         return strprintf("%s %s", GetCommand(), hash.ToString().substr(0,20).c_str());
     }
@@ -446,17 +456,17 @@ extern uint64 nLocalServices;
 extern CAddress addrLocalHost;
 extern CNode* pnodeLocalHost;
 extern uint64 nLocalHostNonce;
-extern array<int, 10> vnThreadsRunning;
+extern boost::array<int, 10> vnThreadsRunning;
 extern SOCKET hListenSocket;
 
-extern vector<CNode*> vNodes;
+extern std::vector<CNode*> vNodes;
 extern CCriticalSection cs_vNodes;
-extern map<vector<unsigned char>, CAddress> mapAddresses;
+extern std::map<std::vector<unsigned char>, CAddress> mapAddresses;
 extern CCriticalSection cs_mapAddresses;
-extern map<CInv, CDataStream> mapRelay;
-extern deque<pair<int64, CInv> > vRelayExpiration;
+extern std::map<CInv, CDataStream> mapRelay;
+extern std::deque<std::pair<int64, CInv> > vRelayExpiration;
 extern CCriticalSection cs_mapRelay;
-extern map<CInv, int64> mapAlreadyAskedFor;
+extern std::map<CInv, int64> mapAlreadyAskedFor;
 
 // Settings
 extern int fUseProxy;
@@ -485,7 +495,7 @@ public:
     unsigned int nMessageStart;
     CAddress addr;
     int nVersion;
-    string strSubVer;
+    std::string strSubVer;
     bool fClient;
     bool fInbound;
     bool fNetworkNode;
@@ -495,7 +505,7 @@ protected:
     int nRefCount;
 public:
     int64 nReleaseTime;
-    map<uint256, CRequestTracker> mapRequests;
+    std::map<uint256, CRequestTracker> mapRequests;
     CCriticalSection cs_mapRequests;
     uint256 hashContinue;
     CBlockIndex* pindexLastGetBlocksBegin;
@@ -503,19 +513,19 @@ public:
     int nStartingHeight;
 
     // flood relay
-    vector<CAddress> vAddrToSend;
-    set<CAddress> setAddrKnown;
+    std::vector<CAddress> vAddrToSend;
+    std::set<CAddress> setAddrKnown;
     bool fGetAddr;
-    set<uint256> setKnown;
+    std::set<uint256> setKnown;
 
     // inventory based relay
-    set<CInv> setInventoryKnown;
-    vector<CInv> vInventoryToSend;
+    std::set<CInv> setInventoryKnown;
+    std::vector<CInv> vInventoryToSend;
     CCriticalSection cs_inventory;
-    multimap<int64, CInv> mapAskFor;
+    std::multimap<int64, CInv> mapAskFor;
 
     // publish and subscription
-    vector<char> vfSubscribe;
+    std::vector<char> vfSubscribe;
 
 
     CNode(SOCKET hSocketIn, CAddress addrIn, bool fInboundIn=false)
@@ -577,13 +587,13 @@ public:
 
     int GetRefCount()
     {
-        return max(nRefCount, 0) + (GetTime() < nReleaseTime ? 1 : 0);
+        return std::max(nRefCount, 0) + (GetTime() < nReleaseTime ? 1 : 0);
     }
 
     CNode* AddRef(int64 nTimeout=0)
     {
         if (nTimeout != 0)
-            nReleaseTime = max(nReleaseTime, GetTime() + nTimeout);
+            nReleaseTime = std::max(nReleaseTime, GetTime() + nTimeout);
         else
             nRefCount++;
         return this;
@@ -634,11 +644,11 @@ public:
         // Make sure not to reuse time indexes to keep things in the same order
         int64 nNow = (GetTime() - 1) * 1000000;
         static int64 nLastTime;
-        nLastTime = nNow = max(nNow, ++nLastTime);
+        nLastTime = nNow = std::max(nNow, ++nLastTime);
 
         // Each retry is 2 minutes after the last
-        nRequestTime = max(nRequestTime + 2 * 60 * 1000000, nNow);
-        mapAskFor.insert(make_pair(nRequestTime, inv));
+        nRequestTime = std::max(nRequestTime + 2 * 60 * 1000000, nNow);
+        mapAskFor.insert(std::make_pair(nRequestTime, inv));
     }
 
 
@@ -722,7 +732,7 @@ public:
         CAddress addrMe = (fUseProxy ? CAddress("0.0.0.0") : addrLocalHost);
         RAND_bytes((unsigned char*)&nLocalHostNonce, sizeof(nLocalHostNonce));
         PushMessage("version", VERSION, nLocalServices, nTime, addrYou, addrMe,
-                nLocalHostNonce, string(pszSubVer), nBestHeight);
+                    nLocalHostNonce, std::string(pszSubVer), nBestHeight);
     }
 
 
@@ -948,7 +958,7 @@ inline void RelayInventory(const CInv& inv)
 {
     // Put on lists to offer to the other nodes
     CRITICAL_BLOCK(cs_vNodes)
-        foreach(CNode* pnode, vNodes)
+        BOOST_FOREACH(CNode* pnode, vNodes)
             pnode->PushInventory(inv);
 }
 
@@ -975,7 +985,7 @@ inline void RelayMessage<>(const CInv& inv, const CDataStream& ss)
 
         // Save original serialized message so newer versions are preserved
         mapRelay[inv] = ss;
-        vRelayExpiration.push_back(make_pair(GetTime() + 15 * 60, inv));
+        vRelayExpiration.push_back(std::make_pair(GetTime() + 15 * 60, inv));
     }
 
     RelayInventory(inv);
@@ -1007,7 +1017,7 @@ void AdvertStartPublish(CNode* pfrom, unsigned int nChannel, unsigned int nHops,
 
     // Relay
     CRITICAL_BLOCK(cs_vNodes)
-        foreach(CNode* pnode, vNodes)
+        BOOST_FOREACH(CNode* pnode, vNodes)
             if (pnode != pfrom && (nHops < PUBLISH_HOPS || pnode->IsSubscribed(nChannel)))
                 pnode->PushMessage("publish", nChannel, nHops, obj);
 }
@@ -1018,7 +1028,7 @@ void AdvertStopPublish(CNode* pfrom, unsigned int nChannel, unsigned int nHops, 
     uint256 hash = obj.GetHash();
 
     CRITICAL_BLOCK(cs_vNodes)
-        foreach(CNode* pnode, vNodes)
+        BOOST_FOREACH(CNode* pnode, vNodes)
             if (pnode != pfrom && (nHops < PUBLISH_HOPS || pnode->IsSubscribed(nChannel)))
                 pnode->PushMessage("pub-cancel", nChannel, nHops, hash);
 
@@ -1035,3 +1045,5 @@ void AdvertRemoveSource(CNode* pfrom, unsigned int nChannel, unsigned int nHops,
     if (obj.setSources.empty())
         AdvertStopPublish(pfrom, nChannel, nHops, obj);
 }
+
+#endif

--- a/src/noui.h
+++ b/src/noui.h
@@ -1,7 +1,10 @@
 // Copyright (c) 2010 Satoshi Nakamoto
 // Distributed under the MIT/X11 software license, see the accompanying
 // file license.txt or http://www.opensource.org/licenses/mit-license.php.
+#ifndef BITCOIN_NOUI_H
+#define BITCOIN_NOUI_H
 
+#include <string>
 
 typedef void wxWindow;
 #define wxYES                   0x00000002
@@ -31,7 +34,7 @@ typedef void wxWindow;
 #define wxMORE                  0x00010000
 #define wxSETUP                 0x00020000
 
-inline int MyMessageBox(const string& message, const string& caption="Message", int style=wxOK, wxWindow* parent=NULL, int x=-1, int y=-1)
+inline int MyMessageBox(const std::string& message, const std::string& caption="Message", int style=wxOK, wxWindow* parent=NULL, int x=-1, int y=-1)
 {
     printf("%s: %s\n", caption.c_str(), message.c_str());
     fprintf(stderr, "%s: %s\n", caption.c_str(), message.c_str());
@@ -39,17 +42,17 @@ inline int MyMessageBox(const string& message, const string& caption="Message", 
 }
 #define wxMessageBox  MyMessageBox
 
-inline int ThreadSafeMessageBox(const string& message, const string& caption, int style=wxOK, wxWindow* parent=NULL, int x=-1, int y=-1)
+inline int ThreadSafeMessageBox(const std::string& message, const std::string& caption, int style=wxOK, wxWindow* parent=NULL, int x=-1, int y=-1)
 {
     return MyMessageBox(message, caption, style, parent, x, y);
 }
 
-inline bool ThreadSafeAskFee(int64 nFeeRequired, const string& strCaption, wxWindow* parent)
+inline bool ThreadSafeAskFee(int64 nFeeRequired, const std::string& strCaption, wxWindow* parent)
 {
     return true;
 }
 
-inline void CalledSetStatusBar(const string& strText, int nField)
+inline void CalledSetStatusBar(const std::string& strText, int nField)
 {
 }
 
@@ -60,3 +63,5 @@ inline void UIThreadCall(boost::function0<void> fn)
 inline void MainFrameRepaint()
 {
 }
+
+#endif

--- a/src/rpc.cpp
+++ b/src/rpc.cpp
@@ -21,6 +21,8 @@ typedef boost::asio::ssl::stream<boost::asio::ip::tcp::socket> SSLStream;
 // a certain size around 145MB.  If we need access to json_spirit outside this
 // file, we could use the compiled json_spirit option.
 
+using namespace std;
+using namespace boost;
 using namespace boost::asio;
 using namespace json_spirit;
 
@@ -81,7 +83,7 @@ void WalletTxToJSON(const CWalletTx& wtx, Object& entry)
     entry.push_back(Pair("confirmations", wtx.GetDepthInMainChain()));
     entry.push_back(Pair("txid", wtx.GetHash().GetHex()));
     entry.push_back(Pair("time", (boost::int64_t)wtx.GetTxTime()));
-    foreach(const PAIRTYPE(string,string)& item, wtx.mapValue)
+    BOOST_FOREACH(const PAIRTYPE(string,string)& item, wtx.mapValue)
         entry.push_back(Pair(item.first, item.second));
 }
 
@@ -336,7 +338,7 @@ string GetAccountAddress(string strAccount, bool bForceNew=false)
              ++it)
         {
             const CWalletTx& wtx = (*it).second;
-            foreach(const CTxOut& txout, wtx.vout)
+            BOOST_FOREACH(const CTxOut& txout, wtx.vout)
                 if (txout.scriptPubKey == scriptPubKey)
                     account.vchPubKey.clear();
         }
@@ -449,7 +451,7 @@ Value getaddressesbyaccount(const Array& params, bool fHelp)
     Array ret;
     CRITICAL_BLOCK(cs_mapAddressBook)
     {
-        foreach(const PAIRTYPE(string, string)& item, mapAddressBook)
+        BOOST_FOREACH(const PAIRTYPE(string, string)& item, mapAddressBook)
         {
             const string& strAddress = item.first;
             const string& strName = item.second;
@@ -541,7 +543,7 @@ Value getreceivedbyaddress(const Array& params, bool fHelp)
             if (wtx.IsCoinBase() || !wtx.IsFinal())
                 continue;
 
-            foreach(const CTxOut& txout, wtx.vout)
+            BOOST_FOREACH(const CTxOut& txout, wtx.vout)
                 if (txout.scriptPubKey == scriptPubKey)
                     if (wtx.GetDepthInMainChain() >= nMinDepth)
                         nAmount += txout.nValue;
@@ -556,7 +558,7 @@ void GetAccountPubKeys(string strAccount, set<CScript>& setPubKey)
 {
     CRITICAL_BLOCK(cs_mapAddressBook)
     {
-        foreach(const PAIRTYPE(string, string)& item, mapAddressBook)
+        BOOST_FOREACH(const PAIRTYPE(string, string)& item, mapAddressBook)
         {
             const string& strAddress = item.first;
             const string& strName = item.second;
@@ -600,7 +602,7 @@ Value getreceivedbyaccount(const Array& params, bool fHelp)
             if (wtx.IsCoinBase() || !wtx.IsFinal())
                 continue;
 
-            foreach(const CTxOut& txout, wtx.vout)
+            BOOST_FOREACH(const CTxOut& txout, wtx.vout)
                 if (setPubKey.count(txout.scriptPubKey))
                     if (wtx.GetDepthInMainChain() >= nMinDepth)
                         nAmount += txout.nValue;
@@ -678,9 +680,9 @@ Value getbalance(const Array& params, bool fHelp)
             list<pair<string, int64> > listSent;
             wtx.GetAmounts(allGeneratedImmature, allGeneratedMature, listReceived, listSent, allFee, strSentAccount);
             if (wtx.GetDepthInMainChain() >= nMinDepth)
-                foreach(const PAIRTYPE(string,int64)& r, listReceived)
+                BOOST_FOREACH(const PAIRTYPE(string,int64)& r, listReceived)
                     nBalance += r.second;
-            foreach(const PAIRTYPE(string,int64)& r, listSent)
+            BOOST_FOREACH(const PAIRTYPE(string,int64)& r, listSent)
                 nBalance -= r.second;
             nBalance -= allFee;
             nBalance += allGeneratedMature;
@@ -804,7 +806,7 @@ Value sendmany(const Array& params, bool fHelp)
     vector<pair<CScript, int64> > vecSend;
 
     int64 totalAmount = 0;
-    foreach(const Pair& s, sendTo)
+    BOOST_FOREACH(const Pair& s, sendTo)
     {
         uint160 hash160;
         string strAddress = s.name_;
@@ -885,7 +887,7 @@ Value ListReceived(const Array& params, bool fByAccounts)
             if (nDepth < nMinDepth)
                 continue;
 
-            foreach(const CTxOut& txout, wtx.vout)
+            BOOST_FOREACH(const CTxOut& txout, wtx.vout)
             {
                 // Only counting our own bitcoin addresses and not ip addresses
                 uint160 hash160 = txout.scriptPubKey.GetBitcoinAddressHash160();
@@ -904,7 +906,7 @@ Value ListReceived(const Array& params, bool fByAccounts)
     map<string, tallyitem> mapAccountTally;
     CRITICAL_BLOCK(cs_mapAddressBook)
     {
-        foreach(const PAIRTYPE(string, string)& item, mapAddressBook)
+        BOOST_FOREACH(const PAIRTYPE(string, string)& item, mapAddressBook)
         {
             const string& strAddress = item.first;
             const string& strAccount = item.second;
@@ -1024,7 +1026,7 @@ void ListTransactions(const CWalletTx& wtx, const string& strAccount, int nMinDe
     // Sent
     if ((!listSent.empty() || nFee != 0) && (fAllAccounts || strAccount == strSentAccount))
     {
-        foreach(const PAIRTYPE(string, int64)& s, listSent)
+        BOOST_FOREACH(const PAIRTYPE(string, int64)& s, listSent)
         {
             Object entry;
             entry.push_back(Pair("account", strSentAccount));
@@ -1042,7 +1044,7 @@ void ListTransactions(const CWalletTx& wtx, const string& strAccount, int nMinDe
     if (listReceived.size() > 0 && wtx.GetDepthInMainChain() >= nMinDepth)
         CRITICAL_BLOCK(cs_mapAddressBook)
         {
-            foreach(const PAIRTYPE(string, int64)& r, listReceived)
+            BOOST_FOREACH(const PAIRTYPE(string, int64)& r, listReceived)
             {
                 string account;
                 if (mapAddressBook.count(r.first))
@@ -1114,7 +1116,7 @@ Value listtransactions(const Array& params, bool fHelp)
         }
         list<CAccountingEntry> acentries;
         walletdb.ListAccountCreditDebit(strAccount, acentries);
-        foreach(CAccountingEntry& entry, acentries)
+        BOOST_FOREACH(CAccountingEntry& entry, acentries)
         {
             txByTime.insert(make_pair(entry.nTime, TxPair((CWalletTx*)0, &entry)));
         }
@@ -1162,7 +1164,7 @@ Value listaccounts(const Array& params, bool fHelp)
     CRITICAL_BLOCK(cs_mapWallet)
     CRITICAL_BLOCK(cs_mapAddressBook)
     {
-        foreach(const PAIRTYPE(string, string)& entry, mapAddressBook) {
+        BOOST_FOREACH(const PAIRTYPE(string, string)& entry, mapAddressBook) {
             uint160 hash160;
             if(AddressToHash160(entry.first, hash160) && mapPubKeys.count(hash160)) // This address belongs to me
                 mapAccountBalances[entry.second] = 0;
@@ -1177,12 +1179,12 @@ Value listaccounts(const Array& params, bool fHelp)
             list<pair<string, int64> > listSent;
             wtx.GetAmounts(nGeneratedImmature, nGeneratedMature, listReceived, listSent, nFee, strSentAccount);
             mapAccountBalances[strSentAccount] -= nFee;
-            foreach(const PAIRTYPE(string, int64)& s, listSent)
+            BOOST_FOREACH(const PAIRTYPE(string, int64)& s, listSent)
                 mapAccountBalances[strSentAccount] -= s.second;
             if (wtx.GetDepthInMainChain() >= nMinDepth)
             {
                 mapAccountBalances[""] += nGeneratedMature;
-                foreach(const PAIRTYPE(string, int64)& r, listReceived)
+                BOOST_FOREACH(const PAIRTYPE(string, int64)& r, listReceived)
                     if (mapAddressBook.count(r.first))
                         mapAccountBalances[mapAddressBook[r.first]] += r.second;
                     else
@@ -1193,11 +1195,11 @@ Value listaccounts(const Array& params, bool fHelp)
 
     list<CAccountingEntry> acentries;
     CWalletDB().ListAccountCreditDebit("*", acentries);
-    foreach(const CAccountingEntry& entry, acentries)
+    BOOST_FOREACH(const CAccountingEntry& entry, acentries)
         mapAccountBalances[entry.strAccount] += entry.nCreditDebit;
 
     Object ret;
-    foreach(const PAIRTYPE(string, int64)& accountBalance, mapAccountBalances) {
+    BOOST_FOREACH(const PAIRTYPE(string, int64)& accountBalance, mapAccountBalances) {
         ret.push_back(Pair(accountBalance.first, ValueFromAmount(accountBalance.second)));
     }
     return ret;
@@ -1320,7 +1322,7 @@ Value getwork(const Array& params, bool fHelp)
             {
                 // Deallocate old blocks since they're obsolete now
                 mapNewBlock.clear();
-                foreach(CBlock* pblock, vNewBlock)
+                BOOST_FOREACH(CBlock* pblock, vNewBlock)
                     delete pblock;
                 vNewBlock.clear();
             }
@@ -1490,7 +1492,7 @@ string HTTPPost(const string& strMsg, const map<string,string>& mapRequestHeader
       << "Content-Type: application/json\r\n"
       << "Content-Length: " << strMsg.size() << "\r\n"
       << "Accept: application/json\r\n";
-    foreach(const PAIRTYPE(string, string)& item, mapRequestHeaders)
+    BOOST_FOREACH(const PAIRTYPE(string, string)& item, mapRequestHeaders)
         s << item.first << ": " << item.second << "\r\n";
     s << "\r\n" << strMsg;
 
@@ -1710,7 +1712,7 @@ bool ClientAllowed(const string& strAddress)
     if (strAddress == asio::ip::address_v4::loopback().to_string())
         return true;
     const vector<string>& vAllow = mapMultiArgs["-rpcallowip"];
-    foreach(string strAllow, vAllow)
+    BOOST_FOREACH(string strAllow, vAllow)
         if (WildcardMatch(strAddress, strAllow))
             return true;
     return false;

--- a/src/script.cpp
+++ b/src/script.cpp
@@ -1,8 +1,10 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Distributed under the MIT/X11 software license, see the accompanying
 // file license.txt or http://www.opensource.org/licenses/mit-license.php.
-
 #include "headers.h"
+
+using namespace std;
+using namespace boost;
 
 bool CheckSig(vector<unsigned char> vchSig, vector<unsigned char> vchPubKey, CScript scriptCode, const CTransaction& txTo, unsigned int nIn, int nHashType);
 
@@ -974,7 +976,7 @@ bool Solver(const CScript& scriptPubKey, vector<pair<opcodetype, valtype> >& vSo
 
     // Scan templates
     const CScript& script1 = scriptPubKey;
-    foreach(const CScript& script2, vTemplates)
+    BOOST_FOREACH(const CScript& script2, vTemplates)
     {
         vSolutionRet.clear();
         opcodetype opcode1, opcode2;
@@ -1030,7 +1032,7 @@ bool Solver(const CScript& scriptPubKey, uint256 hash, int nHashType, CScript& s
     // Compile solution
     CRITICAL_BLOCK(cs_mapKeys)
     {
-        foreach(PAIRTYPE(opcodetype, valtype)& item, vSolution)
+        BOOST_FOREACH(PAIRTYPE(opcodetype, valtype)& item, vSolution)
         {
             if (item.first == OP_PUBKEY)
             {
@@ -1100,7 +1102,7 @@ bool ExtractPubKey(const CScript& scriptPubKey, bool fMineOnly, vector<unsigned 
 
     CRITICAL_BLOCK(cs_mapKeys)
     {
-        foreach(PAIRTYPE(opcodetype, valtype)& item, vSolution)
+        BOOST_FOREACH(PAIRTYPE(opcodetype, valtype)& item, vSolution)
         {
             valtype vchPubKey;
             if (item.first == OP_PUBKEY)
@@ -1133,7 +1135,7 @@ bool ExtractHash160(const CScript& scriptPubKey, uint160& hash160Ret)
     if (!Solver(scriptPubKey, vSolution))
         return false;
 
-    foreach(PAIRTYPE(opcodetype, valtype)& item, vSolution)
+    BOOST_FOREACH(PAIRTYPE(opcodetype, valtype)& item, vSolution)
     {
         if (item.first == OP_PUBKEYHASH)
         {

--- a/src/script.h
+++ b/src/script.h
@@ -1,6 +1,13 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Distributed under the MIT/X11 software license, see the accompanying
 // file license.txt or http://www.opensource.org/licenses/mit-license.php.
+#ifndef H_BITCOIN_SCRIPT
+#define H_BITCOIN_SCRIPT
+
+#include "base58.h"
+
+#include <string>
+#include <vector>
 
 class CTransaction;
 
@@ -310,7 +317,7 @@ inline const char* GetOpName(opcodetype opcode)
 
 
 
-inline string ValueString(const vector<unsigned char>& vch)
+inline std::string ValueString(const std::vector<unsigned char>& vch)
 {
     if (vch.size() <= 4)
         return strprintf("%d", CBigNum(vch).getint());
@@ -318,10 +325,10 @@ inline string ValueString(const vector<unsigned char>& vch)
         return HexStr(vch);
 }
 
-inline string StackString(const vector<vector<unsigned char> >& vStack)
+inline std::string StackString(const std::vector<std::vector<unsigned char> >& vStack)
 {
-    string str;
-    foreach(const vector<unsigned char>& vch, vStack)
+    std::string str;
+    BOOST_FOREACH(const std::vector<unsigned char>& vch, vStack)
     {
         if (!str.empty())
             str += " ";
@@ -338,7 +345,7 @@ inline string StackString(const vector<vector<unsigned char> >& vStack)
 
 
 
-class CScript : public vector<unsigned char>
+class CScript : public std::vector<unsigned char>
 {
 protected:
     CScript& push_int64(int64 n)
@@ -371,10 +378,10 @@ protected:
 
 public:
     CScript() { }
-    CScript(const CScript& b) : vector<unsigned char>(b.begin(), b.end()) { }
-    CScript(const_iterator pbegin, const_iterator pend) : vector<unsigned char>(pbegin, pend) { }
+    CScript(const CScript& b) : std::vector<unsigned char>(b.begin(), b.end()) { }
+    CScript(const_iterator pbegin, const_iterator pend) : std::vector<unsigned char>(pbegin, pend) { }
 #ifndef _MSC_VER
-    CScript(const unsigned char* pbegin, const unsigned char* pend) : vector<unsigned char>(pbegin, pend) { }
+    CScript(const unsigned char* pbegin, const unsigned char* pend) : std::vector<unsigned char>(pbegin, pend) { }
 #endif
 
     CScript& operator+=(const CScript& b)
@@ -405,7 +412,7 @@ public:
     explicit CScript(opcodetype b)     { operator<<(b); }
     explicit CScript(const uint256& b) { operator<<(b); }
     explicit CScript(const CBigNum& b) { operator<<(b); }
-    explicit CScript(const vector<unsigned char>& b) { operator<<(b); }
+    explicit CScript(const std::vector<unsigned char>& b) { operator<<(b); }
 
 
     CScript& operator<<(char b)           { return push_int64(b); }
@@ -422,7 +429,7 @@ public:
     CScript& operator<<(opcodetype opcode)
     {
         if (opcode < 0 || opcode > 0xff)
-            throw runtime_error("CScript::operator<<() : invalid opcode");
+            throw std::runtime_error("CScript::operator<<() : invalid opcode");
         insert(end(), (unsigned char)opcode);
         return *this;
     }
@@ -447,7 +454,7 @@ public:
         return *this;
     }
 
-    CScript& operator<<(const vector<unsigned char>& b)
+    CScript& operator<<(const std::vector<unsigned char>& b)
     {
         if (b.size() < OP_PUSHDATA1)
         {
@@ -483,7 +490,7 @@ public:
     }
 
 
-    bool GetOp(iterator& pc, opcodetype& opcodeRet, vector<unsigned char>& vchRet)
+    bool GetOp(iterator& pc, opcodetype& opcodeRet, std::vector<unsigned char>& vchRet)
     {
          // Wrapper so it can be called with either iterator or const_iterator
          const_iterator pc2 = pc;
@@ -500,7 +507,7 @@ public:
          return fRet;
     }
 
-    bool GetOp(const_iterator& pc, opcodetype& opcodeRet, vector<unsigned char>& vchRet) const
+    bool GetOp(const_iterator& pc, opcodetype& opcodeRet, std::vector<unsigned char>& vchRet) const
     {
         return GetOp2(pc, opcodeRet, &vchRet);
     }
@@ -510,7 +517,7 @@ public:
         return GetOp2(pc, opcodeRet, NULL);
     }
 
-    bool GetOp2(const_iterator& pc, opcodetype& opcodeRet, vector<unsigned char>* pvchRet) const
+    bool GetOp2(const_iterator& pc, opcodetype& opcodeRet, std::vector<unsigned char>* pvchRet) const
     {
         opcodeRet = OP_INVALIDOPCODE;
         if (pvchRet)
@@ -617,7 +624,7 @@ public:
     uint160 GetBitcoinAddressHash160() const
     {
         opcodetype opcode;
-        vector<unsigned char> vch;
+        std::vector<unsigned char> vch;
         CScript::const_iterator pc = begin();
         if (!GetOp(pc, opcode, vch) || opcode != OP_DUP) return 0;
         if (!GetOp(pc, opcode, vch) || opcode != OP_HASH160) return 0;
@@ -629,7 +636,7 @@ public:
         return hash160;
     }
 
-    string GetBitcoinAddress() const
+    std::string GetBitcoinAddress() const
     {
         uint160 hash160 = GetBitcoinAddressHash160();
         if (hash160 == 0)
@@ -643,12 +650,12 @@ public:
         *this << OP_DUP << OP_HASH160 << hash160 << OP_EQUALVERIFY << OP_CHECKSIG;
     }
 
-    void SetBitcoinAddress(const vector<unsigned char>& vchPubKey)
+    void SetBitcoinAddress(const std::vector<unsigned char>& vchPubKey)
     {
         SetBitcoinAddress(Hash160(vchPubKey));
     }
 
-    bool SetBitcoinAddress(const string& strAddress)
+    bool SetBitcoinAddress(const std::string& strAddress)
     {
         this->clear();
         uint160 hash160;
@@ -664,11 +671,11 @@ public:
         printf("CScript(%s)\n", HexStr(begin(), end(), true).c_str());
     }
 
-    string ToString() const
+    std::string ToString() const
     {
-        string str;
+        std::string str;
         opcodetype opcode;
-        vector<unsigned char> vch;
+        std::vector<unsigned char> vch;
         const_iterator pc = begin();
         while (pc < end())
         {
@@ -703,7 +710,9 @@ public:
 uint256 SignatureHash(CScript scriptCode, const CTransaction& txTo, unsigned int nIn, int nHashType);
 bool IsStandard(const CScript& scriptPubKey);
 bool IsMine(const CScript& scriptPubKey);
-bool ExtractPubKey(const CScript& scriptPubKey, bool fMineOnly, vector<unsigned char>& vchPubKeyRet);
+bool ExtractPubKey(const CScript& scriptPubKey, bool fMineOnly, std::vector<unsigned char>& vchPubKeyRet);
 bool ExtractHash160(const CScript& scriptPubKey, uint160& hash160Ret);
 bool SignSignature(const CTransaction& txFrom, CTransaction& txTo, unsigned int nIn, int nHashType=SIGHASH_ALL, CScript scriptPrereq=CScript());
 bool VerifySignature(const CTransaction& txFrom, const CTransaction& txTo, unsigned int nIn, int nHashType=0);
+
+#endif

--- a/src/strlcpy.h
+++ b/src/strlcpy.h
@@ -13,7 +13,8 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
-
+#ifndef BITCOIN_STRLCPY_H
+#define BITCOIN_STRLCPY_H
 /*
  * Copy src to string dst of size siz.  At most siz-1 characters
  * will be copied.  Always NUL terminates (unless siz == 0).
@@ -82,3 +83,4 @@ inline size_t strlcat(char *dst, const char *src, size_t siz)
 
     return(dlen + (s - src)); /* count does not include NUL */
 }
+#endif

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -7,6 +7,8 @@
 #include <crtdbg.h>
 #endif
 
+using namespace std;
+using namespace boost;
 
 
 DEFINE_EVENT_TYPE(wxEVT_UITHREADCALL)
@@ -294,7 +296,7 @@ CMainFrame::CMainFrame(wxWindow* parent) : CMainFrameBase(parent)
     dResize -= 0.01;
 #endif
     wxListCtrl* pplistCtrl[] = {m_listCtrlAll, m_listCtrlSentReceived, m_listCtrlSent, m_listCtrlReceived};
-    foreach(wxListCtrl* p, pplistCtrl)
+    BOOST_FOREACH(wxListCtrl* p, pplistCtrl)
     {
         p->InsertColumn(0, "",               wxLIST_FORMAT_LEFT,  dResize * 0);
         p->InsertColumn(1, "",               wxLIST_FORMAT_LEFT,  dResize * 0);
@@ -528,7 +530,7 @@ string SingleLine(const string& strIn)
 {
     string strOut;
     bool fOneSpace = false;
-    foreach(unsigned char c, strIn)
+    BOOST_FOREACH(unsigned char c, strIn)
     {
         if (isspace(c))
         {
@@ -609,7 +611,7 @@ bool CMainFrame::InsertTransaction(const CWalletTx& wtx, bool fNew, int nIndex)
             if (nCredit == 0)
             {
                 int64 nUnmatured = 0;
-                foreach(const CTxOut& txout, wtx.vout)
+                BOOST_FOREACH(const CTxOut& txout, wtx.vout)
                     nUnmatured += txout.GetCredit();
                 if (wtx.IsInMainChain())
                 {
@@ -644,7 +646,7 @@ bool CMainFrame::InsertTransaction(const CWalletTx& wtx, bool fNew, int nIndex)
             // Received by Bitcoin Address
             if (!fShowReceived)
                 return false;
-            foreach(const CTxOut& txout, wtx.vout)
+            BOOST_FOREACH(const CTxOut& txout, wtx.vout)
             {
                 if (txout.IsMine())
                 {
@@ -687,11 +689,11 @@ bool CMainFrame::InsertTransaction(const CWalletTx& wtx, bool fNew, int nIndex)
     else
     {
         bool fAllFromMe = true;
-        foreach(const CTxIn& txin, wtx.vin)
+        BOOST_FOREACH(const CTxIn& txin, wtx.vin)
             fAllFromMe = fAllFromMe && txin.IsMine();
 
         bool fAllToMe = true;
-        foreach(const CTxOut& txout, wtx.vout)
+        BOOST_FOREACH(const CTxOut& txout, wtx.vout)
             fAllToMe = fAllToMe && txout.IsMine();
 
         if (fAllFromMe && fAllToMe)
@@ -776,9 +778,9 @@ bool CMainFrame::InsertTransaction(const CWalletTx& wtx, bool fNew, int nIndex)
             // Mixed debit transaction, can't break down payees
             //
             bool fAllMine = true;
-            foreach(const CTxOut& txout, wtx.vout)
+            BOOST_FOREACH(const CTxOut& txout, wtx.vout)
                 fAllMine = fAllMine && txout.IsMine();
-            foreach(const CTxIn& txin, wtx.vin)
+            BOOST_FOREACH(const CTxIn& txin, wtx.vin)
                 fAllMine = fAllMine && txin.IsMine();
 
             InsertLine(fNew, nIndex, hash, strSort, colour,
@@ -1006,7 +1008,7 @@ void CMainFrame::OnPaintListCtrl(wxPaintEvent& event)
                 string strTop;
                 if (m_listCtrl->GetItemCount())
                     strTop = (string)m_listCtrl->GetItemText(0);
-                foreach(uint256 hash, vWalletUpdated)
+                BOOST_FOREACH(uint256 hash, vWalletUpdated)
                 {
                     map<uint256, CWalletTx>::iterator mi = mapWallet.find(hash);
                     if (mi != mapWallet.end())
@@ -1265,7 +1267,7 @@ CTxDetailsDialog::CTxDetailsDialog(wxWindow* parent, CWalletTx wtx) : CTxDetails
             if (nNet > 0)
             {
                 // Credit
-                foreach(const CTxOut& txout, wtx.vout)
+                BOOST_FOREACH(const CTxOut& txout, wtx.vout)
                 {
                     if (txout.IsMine())
                     {
@@ -1316,7 +1318,7 @@ CTxDetailsDialog::CTxDetailsDialog(wxWindow* parent, CWalletTx wtx) : CTxDetails
             // Coinbase
             //
             int64 nUnmatured = 0;
-            foreach(const CTxOut& txout, wtx.vout)
+            BOOST_FOREACH(const CTxOut& txout, wtx.vout)
                 nUnmatured += txout.GetCredit();
             strHTML += _("<b>Credit:</b> ");
             if (wtx.IsInMainChain())
@@ -1335,11 +1337,11 @@ CTxDetailsDialog::CTxDetailsDialog(wxWindow* parent, CWalletTx wtx) : CTxDetails
         else
         {
             bool fAllFromMe = true;
-            foreach(const CTxIn& txin, wtx.vin)
+            BOOST_FOREACH(const CTxIn& txin, wtx.vin)
                 fAllFromMe = fAllFromMe && txin.IsMine();
 
             bool fAllToMe = true;
-            foreach(const CTxOut& txout, wtx.vout)
+            BOOST_FOREACH(const CTxOut& txout, wtx.vout)
                 fAllToMe = fAllToMe && txout.IsMine();
 
             if (fAllFromMe)
@@ -1347,7 +1349,7 @@ CTxDetailsDialog::CTxDetailsDialog(wxWindow* parent, CWalletTx wtx) : CTxDetails
                 //
                 // Debit
                 //
-                foreach(const CTxOut& txout, wtx.vout)
+                BOOST_FOREACH(const CTxOut& txout, wtx.vout)
                 {
                     if (txout.IsMine())
                         continue;
@@ -1388,10 +1390,10 @@ CTxDetailsDialog::CTxDetailsDialog(wxWindow* parent, CWalletTx wtx) : CTxDetails
                 //
                 // Mixed debit transaction
                 //
-                foreach(const CTxIn& txin, wtx.vin)
+                BOOST_FOREACH(const CTxIn& txin, wtx.vin)
                     if (txin.IsMine())
                         strHTML += _("<b>Debit:</b> ") + FormatMoney(-txin.GetDebit()) + "<br>";
-                foreach(const CTxOut& txout, wtx.vout)
+                BOOST_FOREACH(const CTxOut& txout, wtx.vout)
                     if (txout.IsMine())
                         strHTML += _("<b>Credit:</b> ") + FormatMoney(txout.GetCredit()) + "<br>";
             }
@@ -1418,10 +1420,10 @@ CTxDetailsDialog::CTxDetailsDialog(wxWindow* parent, CWalletTx wtx) : CTxDetails
         if (fDebug)
         {
             strHTML += "<hr><br>debug print<br><br>";
-            foreach(const CTxIn& txin, wtx.vin)
+            BOOST_FOREACH(const CTxIn& txin, wtx.vin)
                 if (txin.IsMine())
                     strHTML += "<b>Debit:</b> " + FormatMoney(-txin.GetDebit()) + "<br>";
-            foreach(const CTxOut& txout, wtx.vout)
+            BOOST_FOREACH(const CTxOut& txout, wtx.vout)
                 if (txout.IsMine())
                     strHTML += "<b>Credit:</b> " + FormatMoney(txout.GetCredit()) + "<br>";
 
@@ -1431,7 +1433,7 @@ CTxDetailsDialog::CTxDetailsDialog(wxWindow* parent, CWalletTx wtx) : CTxDetails
             strHTML += "<br><b>Inputs:</b><br>";
             CRITICAL_BLOCK(cs_mapWallet)
             {
-                foreach(const CTxIn& txin, wtx.vin)
+                BOOST_FOREACH(const CTxIn& txin, wtx.vin)
                 {
                     COutPoint prevout = txin.prevout;
                     map<uint256, CWalletTx>::iterator mi = mapWallet.find(prevout.hash);
@@ -2341,7 +2343,7 @@ CAddressBookDialog::CAddressBookDialog(wxWindow* parent, const wxString& strInit
     CRITICAL_BLOCK(cs_mapAddressBook)
     {
         string strDefaultReceiving = (string)pframeMain->m_textCtrlAddress->GetValue();
-        foreach(const PAIRTYPE(string, string)& item, mapAddressBook)
+        BOOST_FOREACH(const PAIRTYPE(string, string)& item, mapAddressBook)
         {
             string strAddress = item.first;
             string strName = item.second;

--- a/src/ui.h
+++ b/src/ui.h
@@ -1,6 +1,8 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Distributed under the MIT/X11 software license, see the accompanying
 // file license.txt or http://www.opensource.org/licenses/mit-license.php.
+#ifndef BITCOIN_UI_H
+#define BITCOIN_UI_H
 
 DECLARE_EVENT_TYPE(wxEVT_UITHREADCALL, -1)
 
@@ -12,9 +14,9 @@ extern wxLocale g_locale;
 
 void HandleCtrlA(wxKeyEvent& event);
 void UIThreadCall(boost::function0<void>);
-int ThreadSafeMessageBox(const string& message, const string& caption="Message", int style=wxOK, wxWindow* parent=NULL, int x=-1, int y=-1);
-bool ThreadSafeAskFee(int64 nFeeRequired, const string& strCaption, wxWindow* parent);
-void CalledSetStatusBar(const string& strText, int nField);
+int ThreadSafeMessageBox(const std::string& message, const std::string& caption="Message", int style=wxOK, wxWindow* parent=NULL, int x=-1, int y=-1);
+bool ThreadSafeAskFee(int64 nFeeRequired, const std::string& strCaption, wxWindow* parent);
+void CalledSetStatusBar(const std::string& strText, int nField);
 void MainFrameRepaint();
 void CreateMainWindow();
 void SetStartOnSystemStartup(bool fAutoStart);
@@ -28,8 +30,8 @@ inline int MyMessageBox(const wxString& message, const wxString& caption="Messag
     if (!fDaemon)
         return wxMessageBox(message, caption, style, parent, x, y);
 #endif
-    printf("wxMessageBox %s: %s\n", string(caption).c_str(), string(message).c_str());
-    fprintf(stderr, "%s: %s\n", string(caption).c_str(), string(message).c_str());
+    printf("wxMessageBox %s: %s\n", std::string(caption).c_str(), std::string(message).c_str());
+    fprintf(stderr, "%s: %s\n", std::string(caption).c_str(), std::string(message).c_str());
     return wxOK;
 }
 #define wxMessageBox  MyMessageBox
@@ -93,8 +95,8 @@ public:
     bool fRefresh;
 
     void OnUIThreadCall(wxCommandEvent& event);
-    int GetSortIndex(const string& strSort);
-    void InsertLine(bool fNew, int nIndex, uint256 hashKey, string strSort, const wxColour& colour, const wxString& str1, const wxString& str2, const wxString& str3, const wxString& str4, const wxString& str5);
+    int GetSortIndex(const std::string& strSort);
+    void InsertLine(bool fNew, int nIndex, uint256 hashKey, std::string strSort, const wxColour& colour, const wxString& str1, const wxString& str2, const wxString& str3, const wxString& str4, const wxString& str5);
     bool DeleteLine(uint256 hashKey);
     bool InsertTransaction(const CWalletTx& wtx, bool fNew, int nIndex=-1);
     void RefreshListCtrl();
@@ -176,8 +178,8 @@ public:
 
     // Custom
     bool fEnabledPrev;
-    string strFromSave;
-    string strMessageSave;
+    std::string strFromSave;
+    std::string strMessageSave;
 };
 
 
@@ -211,8 +213,8 @@ public:
     void Close();
     void Repaint();
     bool Status();
-    bool Status(const string& str);
-    bool Error(const string& str);
+    bool Status(const std::string& str);
+    bool Error(const std::string& str);
     void StartTransfer();
     void OnReply2(CDataStream& vRecv);
     void OnReply3(CDataStream& vRecv);
@@ -257,7 +259,7 @@ public:
     wxString GetSelectedAddress();
     wxString GetSelectedSendingAddress();
     wxString GetSelectedReceivingAddress();
-    bool CheckIfMine(const string& strAddress, const string& strTitle);
+    bool CheckIfMine(const std::string& strAddress, const std::string& strTitle);
 };
 
 
@@ -281,11 +283,11 @@ protected:
 public:
     /** Constructor */
     CGetTextFromUserDialog(wxWindow* parent,
-                           const string& strCaption,
-                           const string& strMessage1,
-                           const string& strValue1="",
-                           const string& strMessage2="",
-                           const string& strValue2="") : CGetTextFromUserDialogBase(parent, wxID_ANY, strCaption)
+                           const std::string& strCaption,
+                           const std::string& strMessage1,
+                           const std::string& strValue1="",
+                           const std::string& strMessage2="",
+                           const std::string& strValue2="") : CGetTextFromUserDialogBase(parent, wxID_ANY, strCaption)
     {
         int x = GetSize().GetWidth();
         int y = GetSize().GetHeight();
@@ -308,9 +310,9 @@ public:
     }
 
     // Custom
-    string GetValue()  { return (string)m_textCtrl1->GetValue(); }
-    string GetValue1() { return (string)m_textCtrl1->GetValue(); }
-    string GetValue2() { return (string)m_textCtrl2->GetValue(); }
+    std::string GetValue()  { return (std::string)m_textCtrl1->GetValue(); }
+    std::string GetValue1() { return (std::string)m_textCtrl1->GetValue(); }
+    std::string GetValue2() { return (std::string)m_textCtrl2->GetValue(); }
 };
 
 
@@ -341,3 +343,5 @@ public:
 
 DECLARE_EVENT_TABLE()
 };
+
+#endif

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -1,9 +1,15 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Distributed under the MIT/X11 software license, see the accompanying
 // file license.txt or http://www.opensource.org/licenses/mit-license.php.
+#ifndef BITCOIN_UINT256_H
+#define BITCOIN_UINT256_H
+
+#include "serialize.h"
 
 #include <limits.h>
 #include <string>
+#include <vector>
+
 #if defined(_MSC_VER) || defined(__BORLANDC__)
 typedef __int64  int64;
 typedef unsigned __int64  uint64;
@@ -16,7 +22,7 @@ typedef unsigned long long  uint64;
 #endif
 
 
-inline int Testuint256AdHoc(vector<string> vArg);
+inline int Testuint256AdHoc(std::vector<std::string> vArg);
 
 
 
@@ -296,7 +302,7 @@ public:
         char psz[sizeof(pn)*2 + 1];
         for (int i = 0; i < sizeof(pn); i++)
             sprintf(psz + i*2, "%02x", ((unsigned char*)pn)[sizeof(pn) - i - 1]);
-        return string(psz, psz + sizeof(pn)*2);
+        return std::string(psz, psz + sizeof(pn)*2);
     }
 
     void SetHex(const char* psz)
@@ -377,7 +383,7 @@ public:
 
     friend class uint160;
     friend class uint256;
-    friend inline int Testuint256AdHoc(vector<string> vArg);
+    friend inline int Testuint256AdHoc(std::vector<std::string> vArg);
 };
 
 typedef base_uint<160> base_uint160;
@@ -626,7 +632,7 @@ inline const uint256 operator-(const uint256& a, const uint256& b)      { return
 
 
 
-inline int Testuint256AdHoc(vector<string> vArg)
+inline int Testuint256AdHoc(std::vector<std::string> vArg)
 {
     uint256 g(0);
 
@@ -755,3 +761,5 @@ inline int Testuint256AdHoc(vector<string> vArg)
 
     return (0);
 }
+
+#endif

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1,9 +1,10 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Distributed under the MIT/X11 software license, see the accompanying
 // file license.txt or http://www.opensource.org/licenses/mit-license.php.
-
 #include "headers.h"
 
+using namespace std;
+using namespace boost;
 
 map<string, string> mapArgs;
 map<string, vector<string> > mapMultiArgs;
@@ -704,7 +705,7 @@ void GetDataDir(char* pszDir)
     if (!pfMkdir[nVariation])
     {
         pfMkdir[nVariation] = true;
-        filesystem::create_directory(pszDir);
+        boost::filesystem::create_directory(pszDir);
     }
 }
 
@@ -855,7 +856,7 @@ void AddTimeData(unsigned int ip, int64 nTime)
             {
                 // If nobody has a time different than ours but within 5 minutes of ours, give a warning
                 bool fMatch = false;
-                foreach(int64 nOffset, vTimeOffsets)
+                BOOST_FOREACH(int64 nOffset, vTimeOffsets)
                     if (nOffset != 0 && abs64(nOffset) < 5 * 60)
                         fMatch = true;
 
@@ -869,7 +870,7 @@ void AddTimeData(unsigned int ip, int64 nTime)
                 }
             }
         }
-        foreach(int64 n, vTimeOffsets)
+        BOOST_FOREACH(int64 n, vTimeOffsets)
             printf("%+"PRI64d"  ", n);
         printf("|  nTimeOffset = %+"PRI64d"  (%+"PRI64d" minutes)\n", nTimeOffset, nTimeOffset/60);
     }


### PR DESCRIPTION
To be able to make an external GUI, I am working on modularizing bitcoin into a library. This push request is basic code plumbing, 100% no functional or build system changes.
- Put guard statements around header files.
- Removed macro foreach: conflicts with Qt4 keyword `foreach`, replaced with BOOST_FOREACH.
- Prefix C++ stdlib structures and functions with std:: in headers; "using namespace" in header files is generally frowned upon because it 'infects' other files included after it. These are moved to the implementation files.
- Modularity: `base48.h` and most other header files can now be included without the other shebang (useful for linking external GUI to bitcoin core, part of GUI separation). The include files that need each other, now include each other.
