### PR TITLE
Optimize header dependencies; improve Makefile dependency graph

### DIFF
--- a/src/db.cpp
+++ b/src/db.cpp
@@ -4,6 +4,7 @@
 
 #include "headers.h"
 #include "db.h"
+#include "net.h"
 
 using namespace std;
 using namespace boost;

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -3,6 +3,7 @@
 // file license.txt or http://www.opensource.org/licenses/mit-license.php.
 
 #include "headers.h"
+#include "db.h"
 
 using namespace std;
 using namespace boost;

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -5,6 +5,7 @@
 #include "headers.h"
 #include "db.h"
 #include "net.h"
+#include <boost/filesystem/fstream.hpp>
 
 using namespace std;
 using namespace boost;

--- a/src/headers.h
+++ b/src/headers.h
@@ -120,7 +120,6 @@
 #include "script.h"
 #include "net.h"
 #include "main.h"
-#include "rpc.h"
 #ifdef GUI
 #include "uibase.h"
 #include "ui.h"

--- a/src/headers.h
+++ b/src/headers.h
@@ -118,7 +118,6 @@
 #include "bignum.h"
 #include "base58.h"
 #include "script.h"
-#include "db.h"
 #include "net.h"
 #include "main.h"
 #include "rpc.h"

--- a/src/headers.h
+++ b/src/headers.h
@@ -48,7 +48,6 @@
 #include <limits.h>
 #include <float.h>
 #include <assert.h>
-#include <memory>
 #include <iostream>
 #include <sstream>
 #include <string>
@@ -56,14 +55,8 @@
 #include <list>
 #include <deque>
 #include <map>
-#include <set>
-#include <algorithm>
-#include <numeric>
+
 #include <boost/foreach.hpp>
-#include <boost/lexical_cast.hpp>
-#include <boost/tuple/tuple.hpp>
-#include <boost/tuple/tuple_comparison.hpp>
-#include <boost/tuple/tuple_io.hpp>
 #include <boost/array.hpp>
 #include <boost/bind.hpp>
 #include <boost/function.hpp>
@@ -74,9 +67,6 @@
 #include <boost/interprocess/sync/file_lock.hpp>
 #include <boost/interprocess/sync/interprocess_mutex.hpp>
 #include <boost/interprocess/sync/interprocess_recursive_mutex.hpp>
-#include <boost/date_time/gregorian/gregorian_types.hpp>
-#include <boost/date_time/posix_time/posix_time_types.hpp>
-#include <boost/config.hpp>
 #include <boost/program_options/detail/config_file.hpp>
 #include <boost/program_options/parsers.hpp>
 

--- a/src/headers.h
+++ b/src/headers.h
@@ -57,18 +57,6 @@
 #include <map>
 
 #include <boost/foreach.hpp>
-#include <boost/array.hpp>
-#include <boost/bind.hpp>
-#include <boost/function.hpp>
-#include <boost/filesystem.hpp>
-#include <boost/filesystem/fstream.hpp>
-#include <boost/algorithm/string.hpp>
-#include <boost/thread.hpp>
-#include <boost/interprocess/sync/file_lock.hpp>
-#include <boost/interprocess/sync/interprocess_mutex.hpp>
-#include <boost/interprocess/sync/interprocess_recursive_mutex.hpp>
-#include <boost/program_options/detail/config_file.hpp>
-#include <boost/program_options/parsers.hpp>
 
 #ifdef __WXMSW__
 #include <windows.h>

--- a/src/headers.h
+++ b/src/headers.h
@@ -110,7 +110,6 @@
 
 #pragma hdrstop
 
-#include "strlcpy.h"
 #include "serialize.h"
 #include "uint256.h"
 #include "util.h"

--- a/src/headers.h
+++ b/src/headers.h
@@ -120,7 +120,6 @@
 #include "script.h"
 #include "db.h"
 #include "net.h"
-#include "irc.h"
 #include "main.h"
 #include "rpc.h"
 #ifdef GUI

--- a/src/headers.h
+++ b/src/headers.h
@@ -118,7 +118,6 @@
 #include "bignum.h"
 #include "base58.h"
 #include "script.h"
-#include "net.h"
 #include "main.h"
 #ifdef GUI
 #include "uibase.h"

--- a/src/headers.h
+++ b/src/headers.h
@@ -125,7 +125,6 @@
 #else
 #include "noui.h"
 #endif
-#include "init.h"
 
 #ifdef GUI
 #include "xpm/addressbook16.xpm"

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file license.txt or http://www.opensource.org/licenses/mit-license.php.
 #include "headers.h"
+#include "db.h"
 
 using namespace std;
 using namespace boost;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -6,6 +6,7 @@
 #include "rpc.h"
 #include "net.h"
 #include "init.h"
+#include "strlcpy.h"
 
 using namespace std;
 using namespace boost;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -4,6 +4,7 @@
 #include "headers.h"
 #include "db.h"
 #include "rpc.h"
+#include "net.h"
 
 using namespace std;
 using namespace boost;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -7,6 +7,8 @@
 #include "net.h"
 #include "init.h"
 #include "strlcpy.h"
+#include <boost/filesystem/fstream.hpp>
+#include <boost/interprocess/sync/file_lock.hpp>
 
 using namespace std;
 using namespace boost;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -5,6 +5,7 @@
 #include "db.h"
 #include "rpc.h"
 #include "net.h"
+#include "init.h"
 
 using namespace std;
 using namespace boost;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -3,6 +3,7 @@
 // file license.txt or http://www.opensource.org/licenses/mit-license.php.
 #include "headers.h"
 #include "db.h"
+#include "rpc.h"
 
 using namespace std;
 using namespace boost;

--- a/src/irc.cpp
+++ b/src/irc.cpp
@@ -3,6 +3,7 @@
 // file license.txt or http://www.opensource.org/licenses/mit-license.php.
 
 #include "headers.h"
+#include "irc.h"
 
 using namespace std;
 using namespace boost;

--- a/src/irc.cpp
+++ b/src/irc.cpp
@@ -5,6 +5,7 @@
 #include "headers.h"
 #include "irc.h"
 #include "net.h"
+#include "strlcpy.h"
 
 using namespace std;
 using namespace boost;

--- a/src/irc.cpp
+++ b/src/irc.cpp
@@ -4,6 +4,7 @@
 
 #include "headers.h"
 #include "irc.h"
+#include "net.h"
 
 using namespace std;
 using namespace boost;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,6 +3,7 @@
 // file license.txt or http://www.opensource.org/licenses/mit-license.php.
 #include "headers.h"
 #include "db.h"
+#include "net.h"
 #include "cryptopp/sha.h"
 
 using namespace std;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,6 +4,7 @@
 #include "headers.h"
 #include "db.h"
 #include "net.h"
+#include "init.h"
 #include "cryptopp/sha.h"
 
 using namespace std;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,6 +6,7 @@
 #include "net.h"
 #include "init.h"
 #include "cryptopp/sha.h"
+#include <boost/filesystem/fstream.hpp>
 
 using namespace std;
 using namespace boost;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file license.txt or http://www.opensource.org/licenses/mit-license.php.
 #include "headers.h"
+#include "db.h"
 #include "cryptopp/sha.h"
 
 using namespace std;

--- a/src/main.h
+++ b/src/main.h
@@ -77,6 +77,9 @@ extern int fUseUPnP;
 
 
 
+class CReserveKey;
+class CTxDB;
+class CTxIndex;
 
 
 bool CheckDiskSpace(uint64 nAdditionalBytes=0);

--- a/src/main.h
+++ b/src/main.h
@@ -24,6 +24,13 @@ class CBlockIndex;
 class CWalletTx;
 class CKeyItem;
 
+class CMessageHeader;
+class CAddress;
+class CInv;
+class CRequestTracker;
+class CNode;
+class CBlockIndex;
+
 static const unsigned int MAX_BLOCK_SIZE = 1000000;
 static const unsigned int MAX_BLOCK_SIZE_GEN = MAX_BLOCK_SIZE/2;
 static const int MAX_BLOCK_SIGOPS = MAX_BLOCK_SIZE/50;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -6,6 +6,7 @@
 #include "irc.h"
 #include "db.h"
 #include "net.h"
+#include "init.h"
 
 #ifdef USE_UPNP
 #include <miniupnpc/miniwget.h>

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -7,6 +7,7 @@
 #include "db.h"
 #include "net.h"
 #include "init.h"
+#include "strlcpy.h"
 
 #ifdef USE_UPNP
 #include <miniupnpc/miniwget.h>

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -5,6 +5,7 @@
 #include "headers.h"
 #include "irc.h"
 #include "db.h"
+#include "net.h"
 
 #ifdef USE_UPNP
 #include <miniupnpc/miniwget.h>

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -3,6 +3,7 @@
 // file license.txt or http://www.opensource.org/licenses/mit-license.php.
 
 #include "headers.h"
+#include "irc.h"
 
 #ifdef USE_UPNP
 #include <miniupnpc/miniwget.h>

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -4,6 +4,7 @@
 
 #include "headers.h"
 #include "irc.h"
+#include "db.h"
 
 #ifdef USE_UPNP
 #include <miniupnpc/miniwget.h>

--- a/src/rpc.cpp
+++ b/src/rpc.cpp
@@ -11,8 +11,10 @@
 #include <boost/asio.hpp>
 #include <boost/iostreams/concepts.hpp>
 #include <boost/iostreams/stream.hpp>
+#include <boost/algorithm/string.hpp>
 #ifdef USE_SSL
 #include <boost/asio/ssl.hpp> 
+#include <boost/filesystem/fstream.hpp>
 typedef boost::asio::ssl::stream<boost::asio::ip::tcp::socket> SSLStream;
 #endif
 #include "json/json_spirit_reader_template.h"

--- a/src/rpc.cpp
+++ b/src/rpc.cpp
@@ -6,6 +6,7 @@
 #include "cryptopp/sha.h"
 #include "db.h"
 #include "net.h"
+#include "init.h"
 #undef printf
 #include <boost/asio.hpp>
 #include <boost/iostreams/concepts.hpp>

--- a/src/rpc.cpp
+++ b/src/rpc.cpp
@@ -4,6 +4,7 @@
 
 #include "headers.h"
 #include "cryptopp/sha.h"
+#include "db.h"
 #undef printf
 #include <boost/asio.hpp>
 #include <boost/iostreams/concepts.hpp>

--- a/src/rpc.cpp
+++ b/src/rpc.cpp
@@ -5,6 +5,7 @@
 #include "headers.h"
 #include "cryptopp/sha.h"
 #include "db.h"
+#include "net.h"
 #undef printf
 #include <boost/asio.hpp>
 #include <boost/iostreams/concepts.hpp>

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -3,6 +3,10 @@
 // file license.txt or http://www.opensource.org/licenses/mit-license.php.
 
 #include "headers.h"
+#include "init.h"
+#include "strlcpy.h"
+#include <boost/filesystem/fstream.hpp>
+#include <boost/filesystem/convenience.hpp>
 #ifdef _MSC_VER
 #include <crtdbg.h>
 #endif

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -3,6 +3,12 @@
 // file license.txt or http://www.opensource.org/licenses/mit-license.php.
 #include "headers.h"
 #include "strlcpy.h"
+#include <boost/program_options/detail/config_file.hpp>
+#include <boost/program_options/parsers.hpp>
+#include <boost/filesystem/fstream.hpp>
+#include <boost/interprocess/sync/interprocess_mutex.hpp>
+#include <boost/interprocess/sync/interprocess_recursive_mutex.hpp>
+#include <boost/foreach.hpp>
 
 using namespace std;
 using namespace boost;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file license.txt or http://www.opensource.org/licenses/mit-license.php.
 #include "headers.h"
+#include "strlcpy.h"
 
 using namespace std;
 using namespace boost;

--- a/src/util.h
+++ b/src/util.h
@@ -15,7 +15,6 @@
 #include <vector>
 #include <string>
 
-#include <boost/foreach.hpp>
 #include <boost/thread.hpp>
 #include <boost/interprocess/sync/interprocess_recursive_mutex.hpp>
 #include <boost/date_time/gregorian/gregorian_types.hpp>


### PR DESCRIPTION
This patch set includes the following changes:
- Remove unused #includes
- Factor out #includes that are only needed in some source files from headers.h
- Add dependency tracking to unix, mac, and mingw makefiles via gcc's -MMD flag

These changes improve bitcoin's development environment. Previously changing any header file caused a global recompile. With these changes, only those files that directly depend on a changed header file will require recompilation.
