### PR TITLE
Add wallet privkey encryption.

### DIFF
--- a/share/uiproject.fbp
+++ b/share/uiproject.fbp
@@ -167,6 +167,21 @@
                         <property name="checked">0</property>
                         <property name="enabled">1</property>
                         <property name="help"></property>
+                        <property name="id">wxID_ANY</property>
+                        <property name="kind">wxITEM_NORMAL</property>
+                        <property name="label">Change Wallet &amp;Password...</property>
+                        <property name="name">m_menuOptionsChangeWalletPassword</property>
+                        <property name="permission">none</property>
+                        <property name="shortcut"></property>
+                        <property name="unchecked_bitmap"></property>
+                        <event name="OnMenuSelection">OnMenuOptionsChangeWalletPassword</event>
+                        <event name="OnUpdateUI"></event>
+                    </object>
+                    <object class="wxMenuItem" expanded="1">
+                        <property name="bitmap"></property>
+                        <property name="checked">0</property>
+                        <property name="enabled">1</property>
+                        <property name="help"></property>
                         <property name="id">wxID_PREFERENCES</property>
                         <property name="kind">wxITEM_NORMAL</property>
                         <property name="label">&amp;Options...</property>

--- a/src/crypter.cpp
+++ b/src/crypter.cpp
@@ -1,0 +1,176 @@
+#include <openssl/aes.h>
+#include <openssl/evp.h>
+#include <vector>
+#include <string>
+#ifdef __WXMSW__
+#include <windows.h>
+#else
+#include <sys/mman.h>
+#endif
+
+#include "crypter.h"
+#include "main.h"
+#include "util.h"
+
+bool CCrypter::SetKey(const std::string &strKeyData)
+{
+    std::vector<unsigned char> vchKeyData(strKeyData.size());
+    unsigned char chNotIV[32];
+
+    // Try to keep the keydata out of swap (and be a bit over-careful to keep the IV that we don't even use out of swap)
+    // Note that this does nothing about suspend-to-disk (which will put all our key data on disk)
+    // Note as well that at no point in this program is any attempt made to prevent stealing of keys by reading the memory of the running process.  
+    MLOCK(vchKeyData[0], vchKeyData.size());
+    MLOCK(chNotIV[0], sizeof chNotIV);
+    MLOCK(chKey[0], sizeof chKey);
+
+    memcpy(&vchKeyData[0], &strKeyData[0], strKeyData.size());
+
+    int i = EVP_BytesToKey(EVP_aes_256_cbc(), EVP_sha256(), (unsigned char *)"bitcoin is fun! and I prefer much longer salts, though I don't think they offer any real advantage",
+                           (unsigned char *)&vchKeyData[0], vchKeyData.size(), 1000, chKey, chNotIV);
+
+    std::fill(vchKeyData.begin(), vchKeyData.end(), '\0');
+    memset(&chNotIV, 0, sizeof chNotIV);
+
+    if (i != 32)
+    {
+        memset(&chKey, 0, sizeof chKey);
+        return false;
+    }
+
+    fCorrectKey = false;
+    fKeySet = true;
+    return true;
+}
+
+bool CCrypter::Encrypt(const std::vector<unsigned char> &vchPlaintext, const unsigned char chIV[32], std::vector<unsigned char> &vchCiphertext)
+{
+    if (!fKeySet)
+        return false;
+
+    // max ciphertext len for a n bytes of plaintext is
+    // n + AES_BLOCK_SIZE - 1 bytes
+    int nLen = vchPlaintext.size();
+    int nCLen = nLen + AES_BLOCK_SIZE, nFLen = 0;
+    vchCiphertext = std::vector<unsigned char> (nCLen);
+
+    EVP_CIPHER_CTX ctx;
+
+    EVP_CIPHER_CTX_init(&ctx);
+    EVP_EncryptInit_ex(&ctx, EVP_aes_256_cbc(), NULL, chKey, chIV);
+
+    EVP_EncryptUpdate(&ctx, &vchCiphertext[0], &nCLen, &vchPlaintext[0], nLen);
+    EVP_EncryptFinal_ex(&ctx, (&vchCiphertext[0])+nCLen, &nFLen);
+
+    EVP_CIPHER_CTX_cleanup(&ctx);
+
+    vchCiphertext.resize(nCLen + nFLen);
+    return true;
+}
+
+bool CCrypter::Decrypt(const std::vector<unsigned char> &vchCiphertext, const unsigned char chIV[32], std::vector<unsigned char> &vchPlaintext)
+{
+    if (!fKeySet)
+        return false;
+
+    // plaintext will always be equal to or lesser than length of ciphertext
+    int nLen = vchCiphertext.size();
+    int nPLen = nLen, nFLen = 0;
+
+    vchPlaintext = std::vector<unsigned char> (nPLen);
+    MLOCK(vchPlaintext[0], vchPlaintext.size());
+
+    EVP_CIPHER_CTX ctx;
+
+    EVP_CIPHER_CTX_init(&ctx);
+    EVP_DecryptInit_ex(&ctx, EVP_aes_256_cbc(), NULL, chKey, chIV);
+
+    EVP_DecryptUpdate(&ctx, &vchPlaintext[0], &nPLen, &vchCiphertext[0], nLen);
+    EVP_DecryptFinal_ex(&ctx, (&vchPlaintext[0])+nPLen, &nFLen);
+
+    EVP_CIPHER_CTX_cleanup(&ctx);
+
+    vchPlaintext.resize(nPLen + nFLen);
+    return true;
+}
+
+bool CheckKeyOnPrivKey(PubToPrivKeyMap::iterator &pairFirstKey)
+{
+    uint256 hashPubKey = Hash((*pairFirstKey).first.begin(), (*pairFirstKey).first.end());
+    unsigned char chIV[32];
+    memcpy(&chIV, &hashPubKey, 32);
+
+    std::vector<unsigned char> vchPlaintext;
+    std::vector<unsigned char> vchCiphertext;
+    vchCiphertext.resize((*pairFirstKey).second.size());
+    memcpy(&vchCiphertext[0], &(*pairFirstKey).second[0], vchCiphertext.size());
+
+    if (!cWalletCrypter.Decrypt(vchCiphertext, chIV, vchPlaintext)) //mlock()s vchPlaintext for us
+        return false;
+
+    CPrivKey vchPrivKey;
+    vchPrivKey.resize(vchPlaintext.size());
+    MLOCK(vchPrivKey[0], vchPrivKey.size());
+
+    memcpy(&vchPrivKey[0], &vchPlaintext[0], vchPlaintext.size());
+    std::fill(vchPlaintext.begin(), vchPlaintext.end(), '\0');
+
+    CKey key;
+    if (!key.SetPrivKey(vchPrivKey))
+    {
+        std::fill(vchPrivKey.begin(), vchPrivKey.end(), '\0');
+        return false;
+    }
+    std::vector<unsigned char> vchDerivedPubKey = key.GetPubKey();
+    if (vchDerivedPubKey.size() < 1 || vchDerivedPubKey != (*pairFirstKey).first)
+    {
+        std::fill(vchPrivKey.begin(), vchPrivKey.end(), '\0');
+        return false;
+    }
+
+    std::fill(vchPrivKey.begin(), vchPrivKey.end(), '\0');
+    return true;
+}
+
+bool CCrypter::CheckKey(const bool fVerifyAllAddresses)
+{
+    if (fCorrectKeyForAllKeys)
+        return true;
+    if (fCorrectKey && !fVerifyAllAddresses)
+        return true;
+
+    if (mapKeys.size() == 0)
+    {
+        fCorrectKey = true;
+        return true;
+    }
+
+    PubToPrivKeyMap::iterator pairFirstKey = mapKeys.begin();
+
+    if (!fVerifyAllAddresses)
+    {
+        fCorrectKey = CheckKeyOnPrivKey(pairFirstKey);
+        return fCorrectKey;
+    }
+    else
+    {
+        fCorrectKeyForAllKeys = true;
+        fCorrectKey = true;
+        for (; pairFirstKey != mapKeys.end(); pairFirstKey++)
+        {
+            fCorrectKeyForAllKeys = CheckKeyOnPrivKey(pairFirstKey);
+            fCorrectKey = fCorrectKeyForAllKeys;
+            if (!fCorrectKey)
+                return false;
+        }
+    }
+
+    return true;
+}
+
+void CCrypter::CleanKey()
+{
+    memset(&chKey, 0, sizeof chKey);
+    fCorrectKey = false;
+    fKeySet = false;
+}

--- a/src/crypter.h
+++ b/src/crypter.h
@@ -1,0 +1,33 @@
+#ifndef __CRYPTER_H__
+#define __CRYPTER_H__
+
+class CCrypter
+{
+private:
+    unsigned char chKey[32];
+    bool fCorrectKey;
+    bool fCorrectKeyForAllKeys;
+
+public:
+    bool fKeySet;
+    bool SetKey(const std::string &strKeyData);
+    bool Encrypt(const std::vector<unsigned char> &vchPlaintext, const unsigned char chIV[32], std::vector<unsigned char> &vchCiphertext);
+    bool Decrypt(const std::vector<unsigned char> &vchCiphertext, const unsigned char chIV[32], std::vector<unsigned char> &vchPlaintext);
+
+    // Only call after wallet has been loaded
+    bool CheckKey(const bool fVerifyAllAddresses = false);
+
+    void CleanKey();
+    CCrypter()
+    {
+        fCorrectKey = false;
+        fKeySet = false;
+    }
+
+    ~CCrypter()
+    {
+        CleanKey();
+    }
+};
+
+#endif /* __CRYPTER_H__ */

--- a/src/headers.h
+++ b/src/headers.h
@@ -115,6 +115,7 @@
 #include "uint256.h"
 #include "util.h"
 #include "key.h"
+#include "crypter.h"
 #include "bignum.h"
 #include "base58.h"
 #include "script.h"

--- a/src/key.h
+++ b/src/key.h
@@ -102,16 +102,17 @@ public:
         return true;
     }
 
-    CPrivKey GetPrivKey() const
+    bool GetPrivKey(CPrivKey& vchPrivKeyRet) const
     {
         unsigned int nSize = i2d_ECPrivateKey(pkey, NULL);
         if (!nSize)
             throw key_error("CKey::GetPrivKey() : i2d_ECPrivateKey failed");
-        CPrivKey vchPrivKey(nSize, 0);
-        unsigned char* pbegin = &vchPrivKey[0];
+        vchPrivKeyRet = CPrivKey (nSize, 0);
+        MLOCK(vchPrivKeyRet[0], vchPrivKeyRet.size());
+        unsigned char* pbegin = &vchPrivKeyRet[0];
         if (i2d_ECPrivateKey(pkey, &pbegin) != nSize)
             throw key_error("CKey::GetPrivKey() : i2d_ECPrivateKey returned unexpected size");
-        return vchPrivKey;
+        return true;
     }
 
     bool SetPubKey(const std::vector<unsigned char>& vchPubKey)

--- a/src/main.h
+++ b/src/main.h
@@ -63,6 +63,7 @@ extern CCriticalSection cs_mapAddressBook;
 extern std::vector<unsigned char> vchDefaultKey;
 extern double dHashesPerSec;
 extern int64 nHPSTimerStart;
+extern CCrypter cWalletCrypter;
 
 // Settings
 extern int fGenerateBitcoins;
@@ -2058,9 +2059,10 @@ extern std::map<uint256, CTransaction> mapTransactions;
 extern std::map<uint256, CWalletTx> mapWallet;
 extern std::vector<uint256> vWalletUpdated;
 extern CCriticalSection cs_mapWallet;
-extern std::map<std::vector<unsigned char>, CPrivKey> mapKeys;
+extern CCriticalSection cs_walletCrypter;
+typedef std::map<std::vector<unsigned char>, CPrivKey> PubToPrivKeyMap;
+extern PubToPrivKeyMap mapKeys;
 extern std::map<uint160, std::vector<unsigned char> > mapPubKeys;
 extern CCriticalSection cs_mapKeys;
-extern CKey keyUser;
 
 #endif

--- a/src/makefile.mingw
+++ b/src/makefile.mingw
@@ -33,7 +33,7 @@ DEFS=-DWIN32 -D__WXMSW__ -D_WINDOWS -DNOPCH -DUSE_SSL
 DEBUGFLAGS=-g -D__WXDEBUG__
 CFLAGS=-mthreads -O2 -w -Wno-invalid-offsetof -Wformat $(DEBUGFLAGS) $(DEFS) $(INCLUDEPATHS)
 HEADERS=headers.h strlcpy.h serialize.h uint256.h util.h key.h bignum.h base58.h \
-    script.h db.h net.h irc.h main.h rpc.h uibase.h ui.h noui.h init.h
+    script.h db.h net.h irc.h main.h rpc.h uibase.h ui.h noui.h init.h crypter.h
 
 ifdef USE_UPNP
  INCLUDEPATHS += -I"C:\upnpc-exe-win32-20110215"
@@ -53,6 +53,7 @@ OBJS= \
     obj/main.o \
     obj/rpc.o \
     obj/init.o \
+    obj/crypter.o \
     cryptopp/obj/sha.o \
     cryptopp/obj/cpu.o
 

--- a/src/makefile.osx
+++ b/src/makefile.osx
@@ -33,7 +33,7 @@ DEBUGFLAGS=-g -DwxDEBUG_LEVEL=0
 # ppc doesn't work because we don't support big-endian
 CFLAGS=-mmacosx-version-min=10.5 -arch i386 -arch x86_64 -O3 -Wno-invalid-offsetof -Wformat $(DEBUGFLAGS) $(DEFS) $(INCLUDEPATHS)
 HEADERS=headers.h strlcpy.h serialize.h uint256.h util.h key.h bignum.h base58.h \
-    script.h db.h net.h irc.h main.h rpc.h uibase.h ui.h noui.h init.h
+    script.h db.h net.h irc.h main.h rpc.h uibase.h ui.h noui.h init.h crypter.h
 
 OBJS= \
     obj/util.o \
@@ -44,6 +44,7 @@ OBJS= \
     obj/main.o \
     obj/rpc.o \
     obj/init.o \
+    obj/crypter.o \
     cryptopp/obj/sha.o \
     cryptopp/obj/cpu.o
 

--- a/src/makefile.unix
+++ b/src/makefile.unix
@@ -39,7 +39,7 @@ LIBS+= \
 DEBUGFLAGS=-g -D__WXDEBUG__
 CXXFLAGS=-O2 -Wno-invalid-offsetof -Wformat $(DEBUGFLAGS) $(DEFS)
 HEADERS=headers.h strlcpy.h serialize.h uint256.h util.h key.h bignum.h base58.h \
-    script.h db.h net.h irc.h main.h rpc.h uibase.h ui.h noui.h init.h
+    script.h db.h net.h irc.h main.h rpc.h uibase.h ui.h noui.h init.h crypter.h
 
 OBJS= \
     obj/util.o \
@@ -50,6 +50,7 @@ OBJS= \
     obj/main.o \
     obj/rpc.o \
     obj/init.o \
+    obj/crypter.o \
     cryptopp/obj/sha.o \
     cryptopp/obj/cpu.o
 

--- a/src/rpc.cpp
+++ b/src/rpc.cpp
@@ -366,8 +366,10 @@ string GetAccountAddress(string strAccount, bool bForceNew=false)
     if (account.vchPubKey.empty() || bForceNew)
     {
         if (!GetBoolArg("-nocrypt") && GetKeyPoolSize() == 0)
+        {
             if (!walletdb.ReadAccount(strAccount, account))
                 throw JSONRPCError(-13, "Error: Please enter the wallet password with walletpassword first.");
+        }
         else
         {
             account.vchPubKey = GetOrReuseKeyFromPool();

--- a/src/ui.h
+++ b/src/ui.h
@@ -56,6 +56,7 @@ protected:
     void OnMenuFileExit(wxCommandEvent& event);
     void OnUpdateUIOptionsGenerate(wxUpdateUIEvent& event);
     void OnMenuOptionsChangeYourAddress(wxCommandEvent& event);
+    void OnMenuOptionsChangeWalletPassword(wxCommandEvent& event);
     void OnMenuOptionsOptions(wxCommandEvent& event);
     void OnMenuHelpAbout(wxCommandEvent& event);
     void OnButtonSend(wxCommandEvent& event);

--- a/src/uibase.cpp
+++ b/src/uibase.cpp
@@ -32,6 +32,10 @@ CMainFrameBase::CMainFrameBase( wxWindow* parent, wxWindowID id, const wxString&
 	m_menuOptionsChangeYourAddress = new wxMenuItem( m_menuOptions, wxID_ANY, wxString( _("&Your Receiving Addresses...") ) , wxEmptyString, wxITEM_NORMAL );
 	m_menuOptions->Append( m_menuOptionsChangeYourAddress );
 	
+	wxMenuItem* m_menuOptionsChangeWalletPassword;
+	m_menuOptionsChangeWalletPassword = new wxMenuItem( m_menuOptions, wxID_ANY, wxString( _("Change Wallet &Password...") ) , wxEmptyString, wxITEM_NORMAL );
+	m_menuOptions->Append( m_menuOptionsChangeWalletPassword );
+	
 	wxMenuItem* m_menuOptionsOptions;
 	m_menuOptionsOptions = new wxMenuItem( m_menuOptions, wxID_PREFERENCES, wxString( _("&Options...") ) , wxEmptyString, wxITEM_NORMAL );
 	m_menuOptions->Append( m_menuOptionsOptions );
@@ -187,6 +191,7 @@ CMainFrameBase::CMainFrameBase( wxWindow* parent, wxWindowID id, const wxString&
 	this->Connect( wxEVT_PAINT, wxPaintEventHandler( CMainFrameBase::OnPaint ) );
 	this->Connect( m_menuFileExit->GetId(), wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( CMainFrameBase::OnMenuFileExit ) );
 	this->Connect( m_menuOptionsChangeYourAddress->GetId(), wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( CMainFrameBase::OnMenuOptionsChangeYourAddress ) );
+	this->Connect( m_menuOptionsChangeWalletPassword->GetId(), wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( CMainFrameBase::OnMenuOptionsChangeWalletPassword ) );
 	this->Connect( m_menuOptionsOptions->GetId(), wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( CMainFrameBase::OnMenuOptionsOptions ) );
 	this->Connect( m_menuHelpAbout->GetId(), wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( CMainFrameBase::OnMenuHelpAbout ) );
 	this->Connect( wxID_BUTTONSEND, wxEVT_COMMAND_TOOL_CLICKED, wxCommandEventHandler( CMainFrameBase::OnButtonSend ) );
@@ -245,6 +250,7 @@ CMainFrameBase::~CMainFrameBase()
 	this->Disconnect( wxEVT_PAINT, wxPaintEventHandler( CMainFrameBase::OnPaint ) );
 	this->Disconnect( wxID_ANY, wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( CMainFrameBase::OnMenuFileExit ) );
 	this->Disconnect( wxID_ANY, wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( CMainFrameBase::OnMenuOptionsChangeYourAddress ) );
+	this->Disconnect( wxID_ANY, wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( CMainFrameBase::OnMenuOptionsChangeWalletPassword ) );
 	this->Disconnect( wxID_ANY, wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( CMainFrameBase::OnMenuOptionsOptions ) );
 	this->Disconnect( wxID_ANY, wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( CMainFrameBase::OnMenuHelpAbout ) );
 	this->Disconnect( wxID_BUTTONSEND, wxEVT_COMMAND_TOOL_CLICKED, wxCommandEventHandler( CMainFrameBase::OnButtonSend ) );

--- a/src/uibase.h
+++ b/src/uibase.h
@@ -98,6 +98,7 @@ class CMainFrameBase : public wxFrame
 		virtual void OnPaint( wxPaintEvent& event ) { event.Skip(); }
 		virtual void OnMenuFileExit( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnMenuOptionsChangeYourAddress( wxCommandEvent& event ) { event.Skip(); }
+		virtual void OnMenuOptionsChangeWalletPassword( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnMenuOptionsOptions( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnMenuHelpAbout( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnButtonSend( wxCommandEvent& event ) { event.Skip(); }

--- a/src/util.h
+++ b/src/util.h
@@ -10,6 +10,7 @@
 #include <sys/types.h>
 #include <sys/time.h>
 #include <sys/resource.h>
+#include <sys/mman.h>
 #endif
 #include <map>
 #include <vector>
@@ -46,6 +47,16 @@ typedef unsigned long long  uint64;
 #define UEND(a)             ((unsigned char*)&((&(a))[1]))
 #define ARRAYLEN(array)     (sizeof(array)/sizeof((array)[0]))
 #define printf              OutputDebugStringF
+
+// This is used to attempt to keep keying material out of swap
+// Note that VirtualLock does not provide this as a guarantee on Windows,
+//   but, in practice, memory that has been VirtualLock'd almost never gets written to
+//   the pagefile except in rare circumstances where memory is extremely low.
+#ifdef __WXMSW__
+    #define MLOCK(pMemToLock, size) VirtualLock(&pMemToLock, size);
+#else
+    #define MLOCK(pMemToLock, size) mlock(&pMemToLock, size);
+#endif
 
 #ifdef snprintf
 #undef snprintf


### PR DESCRIPTION
This commit adds support for ekeys, or encrypted private keys, to the wallet.
All keys are stored in memory in their encrypted form and thus the passphrase
is required from the user to spend coins, or to create new addresses.

Keys are encrypted with AES-256-CBC through OpenSSL's EVP library. The key is
calculated via EVP_BytesToKey using AES256 with 1000 rounds.

Each RPC command which requires the password in practice has an additional
parameter, namely that password.  Due to the need to convert the types of
other parameters before sending them, users who do not use encryption (via
the -nocrypt option) will have to specify a blank string (or any string) as
the first parameter, followed by the command they currently use.

Whenever keying material (unencrypted private keys, the user's password, the
wallet's AES key) is stored unencrypted in memory, any reasonable attempt is
made to mlock/VirtualLock that memory before storing the keying material.
This is not true in several (commented) cases where mlock/VirtualLocking the
memory is not possible.

Although encryption of private keys in memory can be very useful on desktop
systems (as some small amount of protection against stupid viruses), on an
RPC server, the password is entered fairly insecurely. Thus, the only main
advantage encryption has for RPC servers is for RPC servers that do not spend
coins, except in rare cases, eg. a webserver of a merchant which only receives
payment except for cases of manual intervention.

Thanks to jgarzik for the original patch and sipa for all his input.
