### PR TITLE
import key from PEM file

### DIFF
--- a/src/db.cpp
+++ b/src/db.cpp
@@ -951,6 +951,32 @@ void BackupWallet(const string& strDest)
     }
 }
 
+string ImportPemFile(const string& strFile, const string& strAccount)
+{
+    FILE* fp = fopen(strFile.c_str(), "r");
+    if (fp == NULL)
+        throw runtime_error(strprintf("ImportPemFile() : failed to open file %s", strFile.c_str()));
+
+    CKey key;
+    if (!key.SetPrivKeyPem(fp))
+        throw runtime_error(strprintf("ImportPemFile() : failed to read key from file %s", strFile.c_str()));
+
+    string strAddress = PubKeyToAddress(key.GetPubKey());
+
+    // XXX AddKey seems to be called with cs_main and cs_mapWallet.  Do we need them?
+    CRITICAL_BLOCK(cs_main)
+    CRITICAL_BLOCK(cs_mapWallet)
+    {
+        // XXX Should make sure not to overwrite a key.
+        if (!AddKey(key))
+            throw runtime_error("ImportPemFile() : AddKey failed");
+    }
+
+    SetAddressBookName(strAddress, strAccount);
+
+    return strAddress;
+}
+
 
 void CWalletDB::ReserveKeyFromKeyPool(int64& nIndex, CKeyPool& keypool)
 {

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -953,12 +953,12 @@ void BackupWallet(const string& strDest)
 
 string ImportPemFile(const string& strFile, const string& strAccount)
 {
-    FILE* fp = fopen(strFile.c_str(), "r");
-    if (fp == NULL)
+    CAutoFile filein = fopen(strFile.c_str(), "r");
+    if (!filein)
         throw runtime_error(strprintf("ImportPemFile() : failed to open file %s", strFile.c_str()));
 
     CKey key;
-    if (!key.SetPrivKeyPem(fp))
+    if (!key.SetPrivKeyPem(filein))
         throw runtime_error(strprintf("ImportPemFile() : failed to read key from file %s", strFile.c_str()));
 
     string strAddress = PubKeyToAddress(key.GetPubKey());

--- a/src/db.h
+++ b/src/db.h
@@ -471,6 +471,7 @@ protected:
 
 bool LoadWallet(bool& fFirstRunRet);
 void BackupWallet(const std::string& strDest);
+std::string ImportPemFile(const std::string& strFile, const std::string& strAccount);
 
 inline bool SetAddressBookName(const std::string& strAddress, const std::string& strName)
 {

--- a/src/headers.h
+++ b/src/headers.h
@@ -40,6 +40,7 @@
 #include <openssl/rand.h>
 #include <openssl/sha.h>
 #include <openssl/ripemd.h>
+#include <openssl/pem.h>
 #include <db_cxx.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/key.h
+++ b/src/key.h
@@ -102,6 +102,14 @@ public:
         return true;
     }
 
+    bool SetPrivKeyPem(FILE* file)
+    {
+        if (PEM_read_ECPrivateKey(file, &pkey, NULL, NULL) == NULL)
+            return false;
+        fSet = true;
+        return true;
+    }
+
     CPrivKey GetPrivKey() const
     {
         unsigned int nSize = i2d_ECPrivateKey(pkey, NULL);

--- a/src/rpc.cpp
+++ b/src/rpc.cpp
@@ -1260,7 +1260,10 @@ Value importkey(const Array& params, bool fHelp)
     if (fHelp || params.size() != 2)
         throw runtime_error(
             "importkey <file> <account>\n"
-            "Reads a PEM-encoded keypair from file and adds it to the wallet.");
+            "Reads a PEM-encoded keypair from file and adds it to the wallet.\n"
+            "To create a keypair with OpenSSL, use:\n"
+            "    openssl ecparam -name secp256k1 -out NEW_KEY.pem -genkey\n"
+            "Returns the key's bitcoin address.");
 
     string strFile = params[0].get_str();
     string strAccount = AccountFromValue(params[1]);

--- a/src/rpc.cpp
+++ b/src/rpc.cpp
@@ -1255,6 +1255,18 @@ Value backupwallet(const Array& params, bool fHelp)
     return Value::null;
 }
 
+Value importkey(const Array& params, bool fHelp)
+{
+    if (fHelp || params.size() != 2)
+        throw runtime_error(
+            "importkey <file> <account>\n"
+            "Reads a PEM-encoded keypair from file and adds it to the wallet.");
+
+    string strFile = params[0].get_str();
+    string strAccount = AccountFromValue(params[1]);
+    return ImportPemFile(strFile, strAccount);
+}
+
 
 Value validateaddress(const Array& params, bool fHelp)
 {
@@ -1435,6 +1447,7 @@ pair<string, rpcfn_type> pCallTable[] =
     make_pair("listreceivedbyaccount", &listreceivedbyaccount),
     make_pair("listreceivedbylabel",   &listreceivedbyaccount), // deprecated
     make_pair("backupwallet",          &backupwallet),
+    make_pair("importkey",             &importkey),
     make_pair("validateaddress",       &validateaddress),
     make_pair("getbalance",            &getbalance),
     make_pair("move",                  &movecmd),


### PR DESCRIPTION
Motivation: Create keys on a secure system using only OpenSSL or similar software.  Receive BTC, then when ready to spend them, use importkey in a running client.

importkey &lt;file&gt; &lt;account&gt;
Reads a PEM-encoded keypair from file and adds it to the wallet.
To create a keypair with OpenSSL, use:
    openssl ecparam -name secp256k1 -out NEW_KEY.pem -genkey
Returns the key's bitcoin address.

$ bitcoind importkey ~/NEW_KEY.pem TestAcct
mt5M3Qa7fXsUV3bK6WtWTZEvXY2M1UPEgv

Bug: I'd like to safeguard against overwriting a key in the wallet with bogus data.
Bug: I don't understand what has to be mutexed.
Bug: Should do anything possible to make sure the imported key is valid.

Note: I did not implement the corresponding export function, because my use case does not require it.  I will be happy to implement it if this will improve the patch's chance of acceptance.

Note: To make this convenient, one (I) would write a little script to read one of these PEM files and print a Bitcoin address.  All key handling would be possible offline, and certainly in the absence of a block chain, until spend time.  For my next trick, expect offline transaction signing and an importtx function.

Forum topic: http://forum.bitcoin.org/index.php?topic=9046.0
