### PR TITLE
Revert "OSX build tweaks (laszlo)"

### DIFF
--- a/src/makefile.osx
+++ b/src/makefile.osx
@@ -47,7 +47,7 @@ OBJS= \
     cryptopp/obj/sha.o \
     cryptopp/obj/cpu.o
 
-ifeq (USE_UPNP, 1)
+ifdef USE_UPNP
 	LIBS += $(DEPSDIR)/lib/libminiupnpc.a
 	DEFS += -DUSE_UPNP=$(USE_UPNP)
 endif


### PR DESCRIPTION
This reverts commit 69ae372b51cd589a3ac0b1ad09b0ebb90c1b6861 which
removes support for building the Mac version of Bitcoin with UPnP
support and UPnP disabled by default (which should be the default,
according to the community vote and as its the default on all
other platforms).
