### PR TITLE
Update transactions already in the wallet when rescanning.

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -383,7 +383,7 @@ bool AppInit2(int argc, char* argv[])
     {
         printf("Rescanning last %i blocks (from block %i)...\n", pindexBest->nHeight - pindexRescan->nHeight, pindexRescan->nHeight);
         nStart = GetTimeMillis();
-        ScanForWalletTransactions(pindexRescan);
+        ScanForWalletTransactions(pindexRescan, true);
         printf(" rescan      %15"PRI64d"ms\n", GetTimeMillis() - nStart);
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -884,7 +884,7 @@ bool CWalletTx::AcceptWalletTransaction(CTxDB& txdb, bool fCheckInputs)
     return false;
 }
 
-int ScanForWalletTransactions(CBlockIndex* pindexStart)
+int ScanForWalletTransactions(CBlockIndex* pindexStart, bool fUpdate)
 {
     int ret = 0;
 
@@ -897,7 +897,7 @@ int ScanForWalletTransactions(CBlockIndex* pindexStart)
             block.ReadFromDisk(pindex, true);
             BOOST_FOREACH(CTransaction& tx, block.vtx)
             {
-                if (AddToWalletIfInvolvingMe(tx, &block))
+                if (AddToWalletIfInvolvingMe(tx, &block, fUpdate))
                     ret++;
             }
             pindex = pindex->pnext;

--- a/src/main.h
+++ b/src/main.h
@@ -86,7 +86,7 @@ bool AddKey(const CKey& key);
 std::vector<unsigned char> GenerateNewKey();
 bool AddToWallet(const CWalletTx& wtxIn);
 void WalletUpdateSpent(const COutPoint& prevout);
-int ScanForWalletTransactions(CBlockIndex* pindexStart);
+int ScanForWalletTransactions(CBlockIndex* pindexStart, bool fUpdate = false);
 void ReacceptWalletTransactions();
 bool LoadBlockIndex(bool fAllowNew=true);
 void PrintBlockTree();


### PR DESCRIPTION
When rescanning, if the scanned transaction is already in the wallet, it
is skipped. However, if someone sends a transaction, does not wait for
confirmation, switches wallets, waits for a block that contains his original
transaction, and switches wallets again, a rescan will leave his wallet
transaction (which has no merkle branch, so no confirmations) untouched.
