### PR TITLE
Fix for small change outputs

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3854,9 +3854,18 @@ bool CreateTransaction(const vector<pair<CScript, int64> >& vecSend, CWalletTx& 
                     dPriority += (double)nCredit * pcoin.first->GetDepthInMainChain();
                 }
 
-                // Fill a vout back to self with any change
-                int64 nChange = nValueIn - nTotalValue;
-                if (nChange >= CENT)
+                int64 nChange = nValueIn - nValue - nFeeRet;
+
+                // if sub-cent change is required, the fee must be raised to at least MIN_TX_FEE
+                // or until nChange becomes zero
+                if (nFeeRet < MIN_TX_FEE && nChange > 0 && nChange < CENT)
+                {
+                    int64 nMoveToFee = min(nChange, MIN_TX_FEE - nFeeRet);
+                    nChange -= nMoveToFee;
+                    nFeeRet += nMoveToFee;
+                }
+
+                if (nChange > 0)
                 {
                     // Note: We use a new key here to keep it from being obvious which side is the change.
                     //  The drawback is that by not reusing a previous key, the change may be lost if a


### PR DESCRIPTION
With the separation of CENT and MIN_TX_FEE, it is now reasonable
to create change outputs between 0.01 and 0.0005, as these are
spendable according to the policy, even though they require a fee
to be paid.

Also, when enough fee was already present, everything can go into
a change output, without further increasing the fee.
