### PR TITLE
makefile.unix accidentally enables UPNP by default because =0 is defined

### DIFF
--- a/src/makefile.unix
+++ b/src/makefile.unix
@@ -8,7 +8,7 @@ WXINCLUDEPATHS=$(shell wx-config --cxxflags)
 
 WXLIBS=$(shell wx-config --libs)
 
-USE_UPNP:=0
+# USE_UPNP:=0
 
 DEFS=-DNOPCH -DFOURWAYSSE2 -DUSE_SSL
 


### PR DESCRIPTION
The ifdef for USE_PNP below evals to "true" because it's defined to zero, thereby erroneously enabling UPNP even when it's initialized to zero, which is probably not what's desired.  Commenting out the variable makes it not try to build UPNP support by default.

make USE_PNP=1 reenables it nicely.

(I assume the =0 was meant to default it to off?)
