### PR TITLE
Use -Wall with relevant -Wno and fix one operator undefined error.

### DIFF
--- a/src/makefile.unix
+++ b/src/makefile.unix
@@ -35,9 +35,20 @@ LIBS+= \
    -l dl \
    -l pthread
 
+WARNS = \
+  -Wall \
+  -Wno-char-subscripts \
+  -Wno-switch \
+  -Wno-unknown-pragmas \
+  -Wno-sign-compare \
+  -Wno-unused \
+  -Wno-uninitialized \
+  -Wno-undef \
+  -Wno-strict-aliasing \
+  -Wno-parentheses
 
 DEBUGFLAGS=-g -D__WXDEBUG__
-CXXFLAGS=-O2 -Wno-invalid-offsetof -Wformat $(DEBUGFLAGS) $(DEFS)
+CXXFLAGS=-O2 $(WARNS) $(DEBUGFLAGS) $(DEFS)
 HEADERS=headers.h strlcpy.h serialize.h uint256.h util.h key.h bignum.h base58.h \
     script.h db.h net.h irc.h main.h rpc.h uibase.h ui.h noui.h init.h
 

--- a/src/net.h
+++ b/src/net.h
@@ -644,7 +644,8 @@ public:
         // Make sure not to reuse time indexes to keep things in the same order
         int64 nNow = (GetTime() - 1) * 1000000;
         static int64 nLastTime;
-        nLastTime = nNow = std::max(nNow, ++nLastTime);
+        nLastTime++;
+        nLastTime = nNow = std::max(nNow, nLastTime);
 
         // Each retry is 2 minutes after the last
         nRequestTime = std::max(nRequestTime + 2 * 60 * 1000000, nNow);


### PR DESCRIPTION
The goal here is to show people how many warnings we have and
get someone to look into them.  Additionally, this might prevent
keep more warnings from popping up with new patches (though
thats a bit unlikely).
