### PR TITLE
RPC password prompt using pinentry via ASSUAN

### DIFF
--- a/src/makefile.unix
+++ b/src/makefile.unix
@@ -8,7 +8,8 @@ WXINCLUDEPATHS=$(shell wx-config --cxxflags)
 
 WXLIBS=$(shell wx-config --libs)
 
-USE_UPNP:=0
+# USE_UPNP:=0
+# USE_ASSUAN:=1
 
 DEFS=-DNOPCH -DFOURWAYSSE2 -DUSE_SSL
 
@@ -28,6 +29,7 @@ ifdef USE_UPNP
 	DEFS += -DUSE_UPNP=$(USE_UPNP)
 endif
 
+
 LIBS+= \
  -Wl,-Bdynamic \
    -l gthread-2.0 \
@@ -35,11 +37,16 @@ LIBS+= \
    -l dl \
    -l pthread
 
+ifdef USE_ASSUAN
+      LIBS += -l assuan
+      DEFS += -DUSE_ASSUAN
+endif
+
 
 DEBUGFLAGS=-g -D__WXDEBUG__
 CXXFLAGS=-O2 -Wno-invalid-offsetof -Wformat $(DEBUGFLAGS) $(DEFS)
 HEADERS=headers.h strlcpy.h serialize.h uint256.h util.h key.h bignum.h base58.h \
-    script.h db.h net.h irc.h main.h rpc.h uibase.h ui.h noui.h init.h
+    script.h db.h net.h irc.h main.h rpc.h uibase.h ui.h noui.h init.h pinentry.h
 
 OBJS= \
     obj/util.o \
@@ -50,6 +57,7 @@ OBJS= \
     obj/main.o \
     obj/rpc.o \
     obj/init.o \
+    obj/pinentry.o \
     cryptopp/obj/sha.o \
     cryptopp/obj/cpu.o
 

--- a/src/pinentry.cpp
+++ b/src/pinentry.cpp
@@ -1,0 +1,112 @@
+// Copyright (c) 2011 Denis Roio <jaromil@dyne.org>
+// Distributed under the MIT/X11 software license, see the accompanying
+// file license.txt or http://www.opensource.org/licenses/mit-license.php.
+
+#include "headers.h"
+
+#ifdef USE_ASSUAN
+
+#include "pinentry.h"
+
+#define SECURE_EXEC_PATH "/usr/bin"
+
+
+// callbacks
+static void *assuan_data_cb_arg;
+static void *assuan_inquire_cb_arg;
+static void *assuan_status_cb_arg;
+gpg_error_t assuan_data_cb(void * ctx, const void * msg, size_t len)
+{
+  // msg contains input password
+  // len contains its length
+  //  fprintf(stderr,"data cb: %s (%u) - %s\n", msg, len, (char*)_data_cb_arg);
+  Pin *pin = (Pin*)assuan_data_cb_arg;
+
+  if(!pin)
+    return GPG_ERR_NO_DATA;
+  else
+    pin->answer = (char*)msg;
+  
+  return 0;
+}
+gpg_error_t assuan_inquire_cb(void* ctx, const char *msg)
+{ // nop
+  return 0;
+}
+gpg_error_t assuan_status_cb(void* ctx, const char *msg)
+{ // nop
+  return 0;
+}
+
+
+Pin::Pin() {
+  gpg_error_t res;
+  pid_t pid;
+  int flags;
+  const char *argv[2];
+
+  gpg_err_init();
+  res = assuan_new (&ctx);
+  if(res)
+    throw runtime_error(strprintf("pinentry initialisation: %s", gpg_strerror(res)));
+
+  assuan_set_assuan_log_prefix("Pin: ");
+
+  // needed esp. for ncurses
+  lang = strprintf("OPTION lc-ctype=%s",getenv("LANG"));
+  tty = strprintf("OPTION ttyname=%s",getenv("TTY"));
+
+  flags = 0x0;
+  argv[0] = "bitcoind"; // fake argv
+  argv[1] = NULL;
+  res = assuan_pipe_connect (ctx, SECURE_EXEC_PATH"/pinentry",
+			     argv, NULL, NULL, NULL, flags);
+  if(res)
+    throw runtime_error(strprintf("pinentry pipe forking: %s", gpg_strerror(res)));
+
+  pid = assuan_get_pid(ctx);
+  if(pid == ASSUAN_INVALID_PID)
+    throw runtime_error(strprintf("pinentry not running: %s", gpg_strerror(res)));
+
+  cmd(tty.c_str());
+  cmd(lang.c_str());
+}
+
+Pin::~Pin()
+{
+  assuan_release(ctx);
+}
+
+void Pin::title(string t)
+{ 
+  string tt = strprintf("SETTITLE %s",t.c_str());
+  cmd(tt.c_str());
+}
+void Pin::description(string d)
+{
+  string dd = strprintf("SETDESC %s",d.c_str());
+  cmd(dd.c_str());
+}
+void Pin::prompt(string p) 
+{
+  string pp = strprintf("SETPROMPT %s",p.c_str());
+  cmd(pp.c_str());
+}
+
+void Pin::ask()
+{
+  assuan_data_cb_arg = this;
+  cmd("GETPIN");
+}
+
+void Pin::cmd(const char *command) {
+  gpg_error_t res;
+  res = assuan_transact(ctx, command,
+			&assuan_data_cb, assuan_data_cb_arg,
+			&assuan_inquire_cb, assuan_inquire_cb_arg,
+			&assuan_status_cb, assuan_status_cb_arg);
+  if(res)
+    throw runtime_error(strprintf("assuan_transaction: %s", gpg_strerror(res)));
+}
+
+#endif

--- a/src/pinentry.h
+++ b/src/pinentry.h
@@ -1,0 +1,47 @@
+// Copyright (c) 2011 Denis Roio <jaromil@dyne.org>
+// Distributed under the MIT/X11 software license, see the accompanying
+// file license.txt or http://www.opensource.org/licenses/mit-license.php.
+
+#include "headers.h"
+
+#ifdef USE_ASSUAN
+
+
+#ifndef __PINENTRY_H__
+#define __PINENTRY_H__
+
+
+using namespace std;
+
+// Do not include the definitions for the socket wrapper feature.
+#define _ASSUAN_NO_SOCKET_WRAPPER
+
+#include <assuan.h>
+
+
+// actual public class
+class Pin {
+
+ public:
+  Pin();
+  ~Pin();
+
+  void title(string t); ///< set the dialog title
+  void description(string d); ///< set the dialog description
+  void prompt(string d); ///< set the dialog description
+  void ask();
+  string answer;
+  //  string get_tty();
+  //  string set_tty();
+
+ private:
+  void cmd(const char *command);
+
+  assuan_context_t ctx;
+
+  string tty;
+  string lang;
+};
+
+#endif
+#endif


### PR DESCRIPTION
A new Pin class is provided to create secure password dialogs using process separation.

IPC is done via libassuan and the assuan daemon user is standard pinentry (portable qt, gtk2 and ncurses implementations are available)

Pinentry takes care of memlocking and is the standard for GNUPG.

The Pin class is designed to be readable and well reusable in other password entry tasks.

This commit adds optional build dependency from libassuan and optional runtime dependency from a pinentry daemon.
