### PR TITLE
Support for customized wallet location

### DIFF
--- a/src/db.h
+++ b/src/db.h
@@ -356,12 +356,16 @@ public:
 class CWalletDB : public CDB
 {
 public:
-    CWalletDB(const char* pszMode="r+") : CDB("wallet.dat", pszMode)
+    CWalletDB(const char* pszMode="r+", const char* pszWalletFilePath=pszSavedWalletFilePath) : CDB(pszWalletFilePath, pszMode)
     {
+        // For ease-of-use, the wallet file path only needs to be passed in to CWalletDB the first time it's initialized. After that, it'll remember it automatically
+        if (pszWalletFilePath != NULL)
+            pszSavedWalletFilePath = const_cast<char*>(pszWalletFilePath);
     }
 private:
     CWalletDB(const CWalletDB&);
     void operator=(const CWalletDB&);
+    static char* pszSavedWalletFilePath;
 public:
     bool ReadName(const std::string& strAddress, std::string& strName)
     {
@@ -469,7 +473,7 @@ protected:
     friend int64 GetOldestKeyPoolTime();
 };
 
-bool LoadWallet(bool& fFirstRunRet);
+bool LoadWallet(bool& fFirstRunRet, const char* pszWalletFilePath);
 void BackupWallet(const std::string& strDest);
 
 inline bool SetAddressBookName(const std::string& strAddress, const std::string& strName)

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -725,6 +725,17 @@ string GetConfigFile()
     return pathConfig.string();
 }
 
+string GetWalletFile()
+{
+    namespace fs = boost::filesystem;
+    fs::path pathWallet(GetArg("-wallet", "wallet.dat"));
+    if (is_directory(pathWallet))
+        pathWallet = pathWallet / fs::path("wallet.dat");
+    if (!pathWallet.is_complete())
+        pathWallet = fs::path(GetDataDir()) / pathWallet;
+    return pathWallet.string();
+}
+
 void ReadConfigFile(map<string, string>& mapSettingsRet,
                     map<string, vector<string> >& mapMultiSettingsRet)
 {
@@ -898,6 +909,21 @@ string FormatFullVersion()
     if (VERSION_IS_BETA)
         s += _("-beta");
     return s;
+}
+
+
+
+
+bool LockDirectory(string dir)
+{
+    string strLockFile = dir + "/.lock";
+    FILE* file = fopen(strLockFile.c_str(), "a"); // empty lock file; created if it doesn't exist.
+    if (file) fclose(file);
+    static boost::interprocess::file_lock lock(strLockFile.c_str());
+    if (lock.try_lock())
+        return true;
+    else
+        return false;
 }
 
 

--- a/src/util.h
+++ b/src/util.h
@@ -193,6 +193,7 @@ bool WildcardMatch(const std::string& str, const std::string& mask);
 int GetFilesize(FILE* file);
 void GetDataDir(char* pszDirRet);
 std::string GetConfigFile();
+std::string GetWalletFile();
 std::string GetPidFile();
 void CreatePidFile(std::string pidFile, pid_t pid);
 void ReadConfigFile(std::map<std::string, std::string>& mapSettingsRet, std::map<std::string, std::vector<std::string> >& mapMultiSettingsRet);
@@ -208,6 +209,7 @@ int64 GetTime();
 int64 GetAdjustedTime();
 void AddTimeData(unsigned int ip, int64 nTime);
 std::string FormatFullVersion();
+bool LockDirectory(std::string dir);
 
 
 


### PR DESCRIPTION
Adds a -wallet argument that can be passed to the client to determine the name of the wallet file and where it should be located.

It works like this:
$ ./bitcoind
-It will use [datadir]/wallet.dat as the wallet

$./bitcoind -wallet=mywallet
-It will use [datadir]/mywallet

$./bitcoind -wallet=/tmp
-It will use /tmp/wallet.dat

$./bitcoind -wallet=/tmp/mywallet
-It will use /tmp/mywallet

If your wallet is in a directory other than the datadir, bitcoin will create another .lock file in that directory (originally, I tried using the wallet file itself as the lock file, but bdb didn't like opening a locked file).

Let me know if you have questions or if I've missed anything.
