### PR TITLE
Fix rfc1918 and rfc3927 compliance for ignoring non-internet-routable hos

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -88,8 +88,7 @@ bool ConnectSocket(const CAddress& addrConnect, SOCKET& hSocketRet)
     setsockopt(hSocket, SOL_SOCKET, SO_NOSIGPIPE, (void*)&set, sizeof(int));
 #endif
 
-    bool fRoutable = !(addrConnect.GetByte(3) == 10 || (addrConnect.GetByte(3) == 192 && addrConnect.GetByte(2) == 168));
-    bool fProxy = (fUseProxy && fRoutable);
+    bool fProxy = (fUseProxy && addrConnect.IsRoutable());
     struct sockaddr_in sockaddr = (fProxy ? addrProxy.GetSockAddr() : addrConnect.GetSockAddr());
 
     if (connect(hSocket, (struct sockaddr*)&sockaddr, sizeof(sockaddr)) == SOCKET_ERROR)

--- a/src/net.h
+++ b/src/net.h
@@ -283,13 +283,29 @@ public:
         return (memcmp(pchReserved, pchIPv4, sizeof(pchIPv4)) == 0);
     }
 
+    bool IsRFC1918() const
+    {
+      return IsIPv4() && (GetByte(3) == 10 ||
+        (GetByte(3) == 192 && GetByte(2) == 168) ||
+        (GetByte(3) == 172 &&
+          (GetByte(2) >= 16 && GetByte(2) <= 31)));
+    }
+
+    bool IsRFC3927() const
+    {
+      return IsIPv4() && (GetByte(3) == 169 && GetByte(2) == 254);
+    }
+
+    bool IsLocal() const
+    {
+      return IsIPv4() && (GetByte(3) == 127 ||
+          GetByte(3) == 0);
+    }
+
     bool IsRoutable() const
     {
         return IsValid() &&
-            !(GetByte(3) == 10 ||
-              (GetByte(3) == 192 && GetByte(2) == 168) ||
-              GetByte(3) == 127 ||
-              GetByte(3) == 0);
+            !(IsRFC1918() || IsRFC3927() || IsLocal());
     }
 
     bool IsValid() const


### PR DESCRIPTION
Fix rfc1918 and rfc3927 compliance for ignoring non-internet-routable hosts.

Pretty self explanatory I think. Fixes filtering of 172.16/12 and 169.254/16 which were missing and expands IsRoutable() to be more easily updated later as well as actually be used in ConnectSocket() instead of re-implementing logic that exists in the CAddress class.
