### PR TITLE
create keypool in LoadWallet()

### DIFF
--- a/src/db.cpp
+++ b/src/db.cpp
@@ -845,12 +845,11 @@ bool LoadWallet(bool& fFirstRunRet)
     {
         // Create new keyUser and set as default key
         RandAddSeedPerfmon();
-        keyUser.MakeNewKey();
-        if (!AddKey(keyUser))
-            return false;
-        if (!SetAddressBookName(PubKeyToAddress(keyUser.GetPubKey()), ""))
-            return false;
-        CWalletDB().WriteDefaultKey(keyUser.GetPubKey());
+
+        CWalletDB walletdb;
+        vchDefaultKey = GetKeyFromKeyPool();
+        walletdb.WriteDefaultKey(vchDefaultKey);
+        walletdb.WriteName(PubKeyToAddress(vchDefaultKey), "");
     }
 
     CreateThread(ThreadFlushWalletDB, NULL);


### PR DESCRIPTION
Make LoadWallet() create the KeyPool for empty wallets. Perceived startup time on first start might increase (<5s on my system, could be up to a minute on very slow hosts) as LoadWallet() is called before the UI is displayed.

This makes it safe to backup a new wallet.dat used for savings.
