### PR TITLE
Create -keypoolmin, and only top up keypool if size falls below that

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -27,6 +27,8 @@ class CKeyItem;
 static const unsigned int MAX_BLOCK_SIZE = 1000000;
 static const unsigned int MAX_BLOCK_SIZE_GEN = MAX_BLOCK_SIZE/2;
 static const int MAX_BLOCK_SIGOPS = MAX_BLOCK_SIZE/50;
+static const int DEF_KEYPOOL_SZ = 125;
+static const int DEF_KEYPOOL_MIN = 100;
 static const int64 COIN = 100000000;
 static const int64 CENT = 1000000;
 static const int64 MIN_TX_FEE = 50000;


### PR DESCRIPTION
Avoid creating a new key -every- time you use a reserve key.  Instead, create them in bursts.

Currently, default is to generate 25 keys (filling keypool up to 100), if keypool size falls below 75.
