### PR TITLE
New RPC command - getrawtransaction

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -1568,5 +1568,7 @@ public:
 
 
 extern std::map<uint256, CTransaction> mapTransactions;
+extern CCriticalSection cs_mapTransactions;
+extern std::map<COutPoint, CInPoint> mapNextTx;
 
 #endif


### PR DESCRIPTION
Given a transaction hash, getrawtransaction returns that transaction and some metadata.

Example: (this is on the testnet)

$ ./bitcoind getrawtransaction ba73f8c8701550e50f667c6c02d671afd3f95069ce02938453048e79b0812bba
{
    "tx" : {
        "version" : 1,
        "txins" : [
            {
                "previous_output" : {
                    "hash" : "daea922234887459ba985977112454895466a36c167921651111596cc439add4",
                    "index" : 0
                },
                "script" : "47304402206fdeaabac261ef0e0183892555a7cdc94d23e4a01c1c55509d352215ee1628c302204dae58fa97ecf77cede4d340573f62abe13f1b7d9bc487a8e9230d4e9557fdd50141043338498afdbe933339072d3fe6ed36196b2e868f888df55e1b32ad27e418f3621628941482a816acde7b53d651fc13b3208885c07e6f1c54b4c04a5c5d009d86",
                "sequence" : 4294967295
            }
        ],
        "txouts" : [
            {
                "value" : 29462000000,
                "script2" : "76a9142a5ce61dff67eb864979905d2ca05d000a0586fd88ac"
            },
            {
                "value" : 500000000,
                "script2" : "76a9142400224224860152f4211a2b9daa6c45c79d04f388ac"
            }
        ],
        "lock_time" : 0
    },
    "parent_blocks" : [
        "00000000004610ac94e40725653c5ff54588a41e24d284244fcd4efd36f12ee9"
    ],
    "txout_claims" : [
        [
            "9f8aa7191c75c96d1cdf8a9fe78a5b4fa1d772cbe7345c1cabdb3f7c91c71cf7"
        ],
        [
        ]
    ]
}
