### PR TITLE
Remove the IRC triggered hard last-seen check from the peer selection.

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1396,11 +1396,6 @@ void ThreadOpenConnections2(void* parg)
                 if (nSinceLastTry < nDelay)
                     continue;
 
-                // If we have IRC, we'll be notified when they first come online,
-                // and again every 24 hours by the refresh broadcast.
-                if (nGotIRCAddresses > 0 && vNodes.size() >= 2 && nSinceLastSeen > 24 * 60 * 60)
-                    continue;
-
                 // Only try the old stuff if we don't have enough connections
                 if (vNodes.size() >= 8 && nSinceLastSeen > 24 * 60 * 60)
                     continue;


### PR DESCRIPTION
.Now that IRC is partitioned we won't actually see most nodes coming
and going, so excluding these nodes greatly increases the amount of
clique formation.

This was bad even before the channel split because the /who output
was limited, so we'd end to stop connecting to long running stable
nodes.
