### PR TITLE
add GetTotalBlocksEstimate() function, move magic number to constant

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,6 +25,8 @@ map<COutPoint, CInPoint> mapNextTx;
 map<uint256, CBlockIndex*> mapBlockIndex;
 uint256 hashGenesisBlock("0x000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f");
 CBigNum bnProofOfWorkLimit(~uint256(0) >> 32);
+const int nTotalBlocksEstimate = 131000; // Conservative estimate of total nr of blocks on main chain
+const int nInitialBlockThreshold = 114; // Regard blocks up until N-threshold as "initial download"
 CBlockIndex* pindexGenesisBlock = NULL;
 int nBestHeight = -1;
 CBigNum bnBestChainWork = 0;
@@ -1156,9 +1158,22 @@ bool CheckProofOfWork(uint256 hash, unsigned int nBits)
     return true;
 }
 
+// Return conservative estimate of total number of blocks, 0 if unknown
+int GetTotalBlocksEstimate()
+{
+    if(fTestNet)
+    {
+        return 0;
+    }
+    else
+    {
+        return nTotalBlocksEstimate;
+    }
+}
+
 bool IsInitialBlockDownload()
 {
-    if (pindexBest == NULL || (!fTestNet && nBestHeight < 118000))
+    if (pindexBest == NULL || nBestHeight < (GetTotalBlocksEstimate()-nInitialBlockThreshold))
         return true;
     static int64 nLastUpdate;
     static CBlockIndex* pindexLastBest;

--- a/src/main.h
+++ b/src/main.h
@@ -118,6 +118,7 @@ void FormatHashBuffers(CBlock* pblock, char* pmidstate, char* pdata, char* phash
 bool CheckWork(CBlock* pblock, CReserveKey& reservekey);
 void BitcoinMiner();
 bool CheckProofOfWork(uint256 hash, unsigned int nBits);
+int GetTotalBlocksEstimate();
 bool IsInitialBlockDownload();
 std::string GetWarnings(std::string strFor);
 


### PR DESCRIPTION
For my Qt GUI, I display a progress bar on first start to keep track of how far the initial block chain download is.

This needs a conservative estimate of the total blocks in the chain. Currently, one such estimate is hardcoded into IsInitialBlockDownload as a magic number. 

This patch moves the magic number to a constant, and adds a function GetTotalBlocksEstimate() to retrieve the value (always 0 for testnet).

According to the forum topic https://forum.bitcoin.org/index.php?topic=17485.0 it would be possible to compute a real estimate based on version messages; this same interface could later be extended to return this.
