### PR TITLE
Include missing Boost header

### DIFF
--- a/src/db.cpp
+++ b/src/db.cpp
@@ -5,6 +5,7 @@
 #include "headers.h"
 #include "db.h"
 #include "net.h"
+#include <boost/filesystem.hpp>
 #include <boost/filesystem/fstream.hpp>
 
 using namespace std;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -7,6 +7,7 @@
 #include "net.h"
 #include "init.h"
 #include "strlcpy.h"
+#include <boost/filesystem.hpp>
 #include <boost/filesystem/fstream.hpp>
 #include <boost/interprocess/sync/file_lock.hpp>
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,6 +6,7 @@
 #include "net.h"
 #include "init.h"
 #include "cryptopp/sha.h"
+#include <boost/filesystem.hpp>
 #include <boost/filesystem/fstream.hpp>
 
 using namespace std;

--- a/src/rpc.cpp
+++ b/src/rpc.cpp
@@ -14,6 +14,7 @@
 #include <boost/algorithm/string.hpp>
 #ifdef USE_SSL
 #include <boost/asio/ssl.hpp> 
+#include <boost/filesystem.hpp>
 #include <boost/filesystem/fstream.hpp>
 typedef boost::asio::ssl::stream<boost::asio::ip::tcp::socket> SSLStream;
 #endif

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -5,6 +5,7 @@
 #include "strlcpy.h"
 #include <boost/program_options/detail/config_file.hpp>
 #include <boost/program_options/parsers.hpp>
+#include <boost/filesystem.hpp>
 #include <boost/filesystem/fstream.hpp>
 #include <boost/interprocess/sync/interprocess_mutex.hpp>
 #include <boost/interprocess/sync/interprocess_recursive_mutex.hpp>


### PR DESCRIPTION
This fixes a fail to compile with Boost 1.46.1, need to include boost/filesystem.hpp
