### PR TITLE
Address Book related Fixes

### DIFF
--- a/src/rpc.cpp
+++ b/src/rpc.cpp
@@ -429,7 +429,7 @@ Value setaccount(const Array& params, bool fHelp)
     CRITICAL_BLOCK(pwalletMain->cs_mapWallet)
     CRITICAL_BLOCK(pwalletMain->cs_mapAddressBook)
     {
-        if (pwalletMain->mapAddressBook.count(strAddress))
+        if (mapPubKeys.count(hash160))
         {
             string strOldAccount = pwalletMain->mapAddressBook[strAddress];
             if (strAddress == GetAccountAddress(strOldAccount))

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -1186,7 +1186,8 @@ void CMainFrame::OnButtonNew(wxCommandEvent& event)
     string strAddress = PubKeyToAddress(pwalletMain->GetKeyFromKeyPool());
 
     // Save
-    pwalletMain->SetAddressBookName(strAddress, strName);
+    CRITICAL_BLOCK(pwalletMain->cs_mapAddressBook)
+        pwalletMain->SetAddressBookName(strAddress, strName);
     SetDefaultReceivingAddress(strAddress);
 }
 
@@ -2444,7 +2445,8 @@ void CAddressBookDialog::OnListEndLabelEdit(wxListEvent& event)
     if (event.IsEditCancelled())
         return;
     string strAddress = (string)GetItemText(m_listCtrl, event.GetIndex(), 1);
-    pwalletMain->SetAddressBookName(strAddress, string(event.GetText()));
+    CRITICAL_BLOCK(pwalletMain->cs_mapAddressBook)
+        pwalletMain->SetAddressBookName(strAddress, string(event.GetText()));
     pframeMain->RefreshListCtrl();
 }
 
@@ -2479,7 +2481,8 @@ void CAddressBookDialog::OnButtonDelete(wxCommandEvent& event)
         if (m_listCtrl->GetItemState(nIndex, wxLIST_STATE_SELECTED))
         {
             string strAddress = (string)GetItemText(m_listCtrl, nIndex, 1);
-            pwalletMain->DelAddressBookName(strAddress);
+            CRITICAL_BLOCK(pwalletMain->cs_mapAddressBook)
+                pwalletMain->DelAddressBookName(strAddress);
             m_listCtrl->DeleteItem(nIndex);
         }
     }
@@ -2543,9 +2546,12 @@ void CAddressBookDialog::OnButtonEdit(wxCommandEvent& event)
     }
 
     // Write back
-    if (strAddress != strAddressOrg)
-        pwalletMain->DelAddressBookName(strAddressOrg);
-    pwalletMain->SetAddressBookName(strAddress, strName);
+    CRITICAL_BLOCK(pwalletMain->cs_mapAddressBook)
+    {
+        if (strAddress != strAddressOrg)
+            pwalletMain->DelAddressBookName(strAddressOrg);
+        pwalletMain->SetAddressBookName(strAddress, strName);
+    }
     m_listCtrl->SetItem(nIndex, 1, strAddress);
     m_listCtrl->SetItemText(nIndex, strName);
     pframeMain->RefreshListCtrl();
@@ -2585,7 +2591,8 @@ void CAddressBookDialog::OnButtonNew(wxCommandEvent& event)
     }
 
     // Add to list and select it
-    pwalletMain->SetAddressBookName(strAddress, strName);
+    CRITICAL_BLOCK(pwalletMain->cs_mapAddressBook)
+        pwalletMain->SetAddressBookName(strAddress, strName);
     int nIndex = InsertLine(m_listCtrl, strName, strAddress);
     SetSelection(m_listCtrl, nIndex);
     m_listCtrl->SetFocus();

--- a/src/ui.h
+++ b/src/ui.h
@@ -262,7 +262,7 @@ public:
     wxString GetSelectedAddress();
     wxString GetSelectedSendingAddress();
     wxString GetSelectedReceivingAddress();
-    bool CheckIfMine(const std::string& strAddress, const std::string& strTitle);
+    bool CheckSendingAddress(const std::string& strAddress, const std::string& strTitle);
 };
 
 

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1004,6 +1004,28 @@ bool CWallet::DelAddressBookName(const string& strAddress)
     return CWalletDB(strWalletFile).EraseName(strAddress);
 }
 
+string CWallet::GetDefaultAddress()
+{
+    if (!fFileBacked)
+        return false;
+    std::vector<unsigned char> vchPubKey;
+    if (CWalletDB(strWalletFile, "r").ReadDefaultKey(vchPubKey))
+    {
+        return PubKeyToAddress(vchPubKey);
+    }
+    else
+        return "";
+}
+
+bool CWallet::SetDefaultAddress(const string& strAddress)
+{
+    uint160 hash160;
+    if (!AddressToHash160(strAddress, hash160))
+        return false;
+    if (!mapPubKeys.count(hash160))
+        return false;
+    return CWalletDB(strWalletFile).WriteDefaultKey(mapPubKeys[hash160]);
+}
 
 void CWallet::PrintWallet(const CBlock& block)
 {

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -983,6 +983,28 @@ bool CWallet::LoadWallet(bool& fFirstRunRet)
     return true;
 }
 
+
+bool CWallet::SetAddressBookName(const string& strAddress, const string& strName)
+{
+    if (mapAddressBook[strAddress] == strName)
+        return false;
+    mapAddressBook[strAddress] = strName;
+    if (!fFileBacked)
+        return false;
+    return CWalletDB(strWalletFile).WriteName(strAddress, strName);
+}
+
+bool CWallet::DelAddressBookName(const string& strAddress)
+{
+    if (!mapAddressBook.count(strAddress))
+        return false;
+    mapAddressBook.erase(strAddress);
+    if (!fFileBacked)
+        return false;
+    return CWalletDB(strWalletFile).EraseName(strAddress);
+}
+
+
 void CWallet::PrintWallet(const CBlock& block)
 {
     CRITICAL_BLOCK(cs_mapWallet)

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -151,6 +151,7 @@ public:
     bool LoadWallet(bool& fFirstRunRet);
 //    bool BackupWallet(const std::string& strDest);
 
+    // requires cs_mapAddressBook lock
     bool SetAddressBookName(const std::string& strAddress, const std::string& strName)
     {
         mapAddressBook[strAddress] = strName;
@@ -159,6 +160,7 @@ public:
         return CWalletDB(strWalletFile).WriteName(strAddress, strName);
     }
 
+    // requires cs_mapAddressBook lock
     bool DelAddressBookName(const std::string& strAddress)
     {
         mapAddressBook.erase(strAddress);

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -157,6 +157,9 @@ public:
     // requires cs_mapAddressBook lock
     bool DelAddressBookName(const std::string& strAddress);
 
+    std::string GetDefaultAddress();
+    bool SetDefaultAddress(const std::string& strAddress);
+
     void UpdatedTransaction(const uint256 &hashTx)
     {
         CRITICAL_BLOCK(cs_mapWallet)

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -152,26 +152,10 @@ public:
 //    bool BackupWallet(const std::string& strDest);
 
     // requires cs_mapAddressBook lock
-    bool SetAddressBookName(const std::string& strAddress, const std::string& strName)
-    {
-        if (mapAddressBook[strAddress] == strName)
-            return false;
-        mapAddressBook[strAddress] = strName;
-        if (!fFileBacked)
-            return false;
-        return CWalletDB(strWalletFile).WriteName(strAddress, strName);
-    }
+    bool SetAddressBookName(const std::string& strAddress, const std::string& strName);
 
     // requires cs_mapAddressBook lock
-    bool DelAddressBookName(const std::string& strAddress)
-    {
-        if (!mapAddressBook.count(strAddress))
-            return false;
-        mapAddressBook.erase(strAddress);
-        if (!fFileBacked)
-            return false;
-        return CWalletDB(strWalletFile).EraseName(strAddress);
-    }
+    bool DelAddressBookName(const std::string& strAddress);
 
     void UpdatedTransaction(const uint256 &hashTx)
     {

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -155,7 +155,16 @@ public:
     {
         if (!fFileBacked)
             return false;
+        mapAddressBook[strAddress] = strName;
         return CWalletDB(strWalletFile).WriteName(strAddress, strName);
+    }
+
+    bool DelAddressBookName(const std::string& strAddress)
+    {
+        if (!fFileBacked)
+            return false;
+        mapAddressBook.erase(strAddress);
+        return CWalletDB(strWalletFile).EraseName(strAddress);
     }
 
     void UpdatedTransaction(const uint256 &hashTx)

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -153,17 +153,17 @@ public:
 
     bool SetAddressBookName(const std::string& strAddress, const std::string& strName)
     {
+        mapAddressBook[strAddress] = strName;
         if (!fFileBacked)
             return false;
-        mapAddressBook[strAddress] = strName;
         return CWalletDB(strWalletFile).WriteName(strAddress, strName);
     }
 
     bool DelAddressBookName(const std::string& strAddress)
     {
+        mapAddressBook.erase(strAddress);
         if (!fFileBacked)
             return false;
-        mapAddressBook.erase(strAddress);
         return CWalletDB(strWalletFile).EraseName(strAddress);
     }
 

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -154,6 +154,8 @@ public:
     // requires cs_mapAddressBook lock
     bool SetAddressBookName(const std::string& strAddress, const std::string& strName)
     {
+        if (mapAddressBook[strAddress] == strName)
+            return false;
         mapAddressBook[strAddress] = strName;
         if (!fFileBacked)
             return false;
@@ -163,6 +165,8 @@ public:
     // requires cs_mapAddressBook lock
     bool DelAddressBookName(const std::string& strAddress)
     {
+        if (!mapAddressBook.count(strAddress))
+            return false;
         mapAddressBook.erase(strAddress);
         if (!fFileBacked)
             return false;


### PR DESCRIPTION
Add a check for validity of sending addresses (Issue #328). 
Fix the behaviour of setaccount on sending addresses that are already listed in the Address Book. (Issue #329). 
This also fixes the syncrhonization of sending addresses between a
CWallet and its associated CWalletDB, and avoids unnecessary CWalletDB updates.

This is my first commit. It is quite small, but please review it in details before the pull.
Thanks.
