### PR TITLE
rpc server: send '403 Forbidden' to rejected clients

### DIFF
--- a/src/rpc.cpp
+++ b/src/rpc.cpp
@@ -1889,7 +1889,9 @@ void ThreadRPCServer2(void* parg)
         // Restrict callers by IP
         if (!ClientAllowed(peer.address().to_string()))
         {
-            stream << HTTPReply(403, "") << std::flush;
+            // Only send a 403 if we're not using SSL to prevent a DoS during the SSL handshake.
+            if (!fUseSSL)
+                stream << HTTPReply(403, "") << std::flush;
             continue;
         }
 

--- a/src/rpc.cpp
+++ b/src/rpc.cpp
@@ -1532,7 +1532,7 @@ string rfc1123Time()
     return string(buffer);
 }
 
-string HTTPReply(int nStatus, const string& strMsg)
+static string HTTPReply(int nStatus, const string& strMsg)
 {
     if (nStatus == 401)
         return strprintf("HTTP/1.0 401 Authorization Required\r\n"
@@ -1554,6 +1554,7 @@ string HTTPReply(int nStatus, const string& strMsg)
     string strStatus;
          if (nStatus == 200) strStatus = "OK";
     else if (nStatus == 400) strStatus = "Bad Request";
+    else if (nStatus == 403) strStatus = "Forbidden";
     else if (nStatus == 404) strStatus = "Not Found";
     else if (nStatus == 500) strStatus = "Internal Server Error";
     return strprintf(
@@ -1887,7 +1888,10 @@ void ThreadRPCServer2(void* parg)
 
         // Restrict callers by IP
         if (!ClientAllowed(peer.address().to_string()))
+        {
+            stream << HTTPReply(403, "") << std::flush;
             continue;
+        }
 
         map<string, string> mapHeaders;
         string strRequest;


### PR DESCRIPTION
In order to be a proper HTTP implementation clients that aren't allowed
to connect to the RPC server (using -rpcallowip), should receive a
proper HTTP response.  So instead of closing the connection on them send
a '403 Forbidden' status.

Signed-off-by: Giel van Schijndel me@mortis.eu
