### PR TITLE
Fix segfault when creating new wallet

### DIFF
--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -962,21 +962,15 @@ bool CWallet::LoadWallet(bool& fFirstRunRet)
         return false;
     fFirstRunRet = vchDefaultKey.empty();
 
-    if (mapKeys.count(vchDefaultKey))
+    if (!mapKeys.count(vchDefaultKey))
     {
-        // Set keyUser
-        keyUser.SetPubKey(vchDefaultKey);
-        keyUser.SetPrivKey(mapKeys[vchDefaultKey]);
-    }
-    else
-    {
-        // Create new keyUser and set as default key
+        // Create new default key
         RandAddSeedPerfmon();
 
         vchDefaultKey = GetKeyFromKeyPool();
         if (!SetAddressBookName(PubKeyToAddress(vchDefaultKey), ""))
             return false;
-        CWalletDB(strWalletFile).WriteDefaultKey(keyUser.GetPubKey());
+        CWalletDB(strWalletFile).WriteDefaultKey(vchDefaultKey);
     }
 
     CreateThread(ThreadFlushWalletDB, &strWalletFile);

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -47,7 +47,6 @@ public:
     mutable CCriticalSection cs_mapAddressBook;
 
     std::vector<unsigned char> vchDefaultKey;
-    CKey keyUser;
 
     bool AddKey(const CKey& key);
     bool AddToWallet(const CWalletTx& wtxIn);


### PR DESCRIPTION
The initialization of the default key used keyUser instead
of vchDefaultKey. keyUser is now complete removed.
