### PR TITLE
Fix OP_CHECKSIG bug with OP_PUSHDATA

### DIFF
--- a/src/script.cpp
+++ b/src/script.cpp
@@ -751,7 +751,7 @@ bool EvalScript(vector<vector<unsigned char> >& stack, const CScript& script, co
                     CScript scriptCode(pbegincodehash, pend);
 
                     // Drop the signature, since there's no way for a signature to sign itself
-                    scriptCode.FindAndDelete(CScript(vchSig));
+                    scriptCode.FindAndDelete(vchSig);
 
                     bool fSuccess = CheckSig(vchSig, vchPubKey, scriptCode, txTo, nIn, nHashType);
 
@@ -803,7 +803,7 @@ bool EvalScript(vector<vector<unsigned char> >& stack, const CScript& script, co
                     for (int k = 0; k < nSigsCount; k++)
                     {
                         valtype& vchSig = stacktop(-isig-k);
-                        scriptCode.FindAndDelete(CScript(vchSig));
+                        scriptCode.FindAndDelete(vchSig);
                     }
 
                     bool fSuccess = true;

--- a/src/script.h
+++ b/src/script.h
@@ -586,6 +586,22 @@ public:
         while (GetOp(pc, opcode));
     }
 
+    void FindAndDelete(const std::vector<unsigned char> &vch)
+    {
+        if (vch.empty())
+            return;
+        iterator pc = begin();
+        iterator prev_pc = pc;
+        opcodetype opcode;
+        std::vector<unsigned char> vchPushValue;
+        while (GetOp(pc, opcode, vchPushValue)) {
+            if (vchPushValue == vch)
+                erase(prev_pc, pc);
+
+            prev_pc = pc;
+        }
+    }
+
 
     int GetSigOpCount() const
     {


### PR DESCRIPTION
To delete the signature from scriptSig, OP_CHECKSIG constructs a new
CScript object from the signature found on the stack and then looks for
an exact copy of this object in scriptSig.

However, if the original signature was pushed using OP_PUSHDATA and the
signature is short enough to be pushed using one of the 1-75 opcodes,
the two objects will not match and the signature verification will fail
even though the values are the same.

This patch fixes this by comparing the data-pushing opcode's payload
only (excluding the opcode itself).

I've tested this with valid testnet transactions, which are verified
correctly.

As this is my first bitcoin patch and it touches a rather sensitive part of the code, please review/test it for yourselves as well!
