### PR TITLE
CWallet: fix mapAddress book update

### DIFF
--- a/src/wallet.h
+++ b/src/wallet.h
@@ -149,13 +149,10 @@ public:
 
     bool LoadWallet(bool& fFirstRunRet);
 //    bool BackupWallet(const std::string& strDest);
-
-    bool SetAddressBookName(const std::string& strAddress, const std::string& strName)
-    {
-        if (!fFileBacked)
-            return false;
-        return CWalletDB(strWalletFile).WriteName(strAddress, strName);
-    }
+    bool SetAddressBookName(const std::string& strAddress, const std::string& strName);
+    bool EraseAddressBookName(const std::string& strAddress);
+    std::string GetDefaultAddress();
+    bool SetDefaultAddress(const std::string& strAddress);
 
     void UpdatedTransaction(const uint256 &hashTx)
     {


### PR DESCRIPTION
Fix update of internal data structure (mapAddressBook) after changes to the address book, and add convenience methods EraseAddressBookName, GetDefaultAddress, SetDefaultAddress to be used from UI.

The problem was introduced in the new CWallet class; mapAddress book used to be updated in db.cpp. It now makes more sense to do the update directly in CWallet.
