### PR TITLE
Support for "exact send" with manual coin selection

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -338,6 +338,22 @@ public:
         scriptPubKey = scriptPubKeyIn;
     }
 
+    std::string GetAddress() const
+    {
+        uint160 hash160;
+        std::vector<unsigned char> vchPubKey;
+        if (ExtractHash160(scriptPubKey, hash160))
+            return Hash160ToAddress(hash160);
+        else if (ExtractPubKey(scriptPubKey, NULL, vchPubKey))
+            return PubKeyToAddress(vchPubKey);
+        else
+        {
+            printf("CTxOut::GetAddress: Unknown transaction type found: %s\n",
+                   scriptPubKey.ToString().c_str());
+            return " unknown ";
+        }
+    }
+
     IMPLEMENT_SERIALIZE
     (
         READWRITE(nValue);

--- a/src/rpc.cpp
+++ b/src/rpc.cpp
@@ -874,6 +874,56 @@ Value sendmany(const Array& params, bool fHelp)
     return wtx.GetHash().GetHex();
 }
 
+Value sendexact(const Array& params, bool fHelp)
+{
+    if (fHelp || params.size() < 4 || params.size() > 5)
+        throw runtime_error(
+            "sendexact <fromaccount> [transaction,...] {dstaddress:amount,...} <txfeeamount> [comment]\n"
+            "Claim all bitcoins received for <fromaccount> within the given list\n"
+            "of transactions and distribute them into given list of addresses while\n"
+            "paying the specified tx fee. You can use listtransactions and\n"
+            "gettransaction to pick transactions to source bitcoins from. You must\n"
+            "spend all coins from these transactions.\n"
+            "Amounts are double-precision floating point numbers.");
+
+    string strAccount = AccountFromValue(params[0]);
+    Array listTx = params[1].get_array();
+    Object sendTo = params[2].get_obj();
+    int64 nTxFee = 0.0;
+    if (params[3].get_real() != 0.0)
+        nTxFee = AmountFromValue(params[3]);        // rejects 0.0 amounts
+
+    CWalletTx wtx;
+    wtx.strFromAccount = strAccount;
+    if (params.size() > 4 && params[4].type() != null_type && !params[4].get_str().empty())
+        wtx.mapValue["comment"] = params[4].get_str();
+
+    set<string> setTx;
+    vector<uint256> vecTx;
+    BOOST_FOREACH(const Value& s, listTx)
+    {
+        uint256 hash;
+        hash.SetHex(s.get_str());
+        vecTx.push_back(hash);
+    }
+
+    vector<pair<CScript, int64> > vecSend;
+    int64 totalAmount = AddressAmountList(sendTo, vecSend);
+
+    CRITICAL_BLOCK(cs_main)
+    CRITICAL_BLOCK(pwalletMain->cs_mapWallet)
+    {
+        CReserveKey keyChange(pwalletMain);
+        bool fCreated = pwalletMain->CreateExactTransaction(vecTx, vecSend, wtx, keyChange, nTxFee);
+        if (!fCreated)
+            throw JSONRPCError(-4, "Transaction creation failed");
+        if (!pwalletMain->CommitTransaction(wtx, keyChange))
+            throw JSONRPCError(-4, "Transaction commit failed");
+    }
+
+    return wtx.GetHash().GetHex();
+}
+
 
 struct tallyitem
 {
@@ -1465,6 +1515,7 @@ pair<string, rpcfn_type> pCallTable[] =
     make_pair("move",                  &movecmd),
     make_pair("sendfrom",              &sendfrom),
     make_pair("sendmany",              &sendmany),
+    make_pair("sendexact",             &sendexact),
     make_pair("gettransaction",        &gettransaction),
     make_pair("listtransactions",      &listtransactions),
     make_pair("getwork",               &getwork),
@@ -2132,7 +2183,21 @@ int CommandLineRPC(int argc, char *argv[])
                 throw runtime_error("type mismatch");
             params[1] = v.get_obj();
         }
-        if (strMethod == "sendmany"                && n > 2) ConvertTo<boost::int64_t>(params[2]);
+        if (strMethod == "sendmany"               && n > 2) ConvertTo<boost::int64_t>(params[2]);
+        if (strMethod == "sendexact"              && n > 2)
+        {
+            string s = params[1].get_str();
+            Value v;
+            if (!read_string(s, v) || v.type() != array_type)
+                throw runtime_error("type mismatch");
+            params[1] = v.get_array();
+
+            s = params[2].get_str();
+            if (!read_string(s, v) || v.type() != obj_type)
+                throw runtime_error("type mismatch");
+            params[2] = v.get_obj();
+        }
+        if (strMethod == "sendexact"              && n > 3) ConvertTo<double>(params[3]);
 
         // Execute
         Object reply = CallRPC(strMethod, params);

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -265,27 +265,14 @@ void CWalletTx::GetAmounts(int64& nGeneratedImmature, int64& nGeneratedMature, l
         nFee = nDebit - nValueOut;
     }
 
-    // Sent/received.  Standard client will never generate a send-to-multiple-recipients,
-    // but non-standard clients might (so return a list of address/amount pairs)
+    // Sent/received.
     BOOST_FOREACH(const CTxOut& txout, vout)
     {
-        string address;
-        uint160 hash160;
-        vector<unsigned char> vchPubKey;
-        if (ExtractHash160(txout.scriptPubKey, hash160))
-            address = Hash160ToAddress(hash160);
-        else if (ExtractPubKey(txout.scriptPubKey, NULL, vchPubKey))
-            address = PubKeyToAddress(vchPubKey);
-        else
-        {
-            printf("CWalletTx::GetAmounts: Unknown transaction type found, txid %s\n",
-                   this->GetHash().ToString().c_str());
-            address = " unknown ";
-        }
-
         // Don't report 'change' txouts
         if (nDebit > 0 && pwallet->IsChange(txout))
             continue;
+
+        string address = txout.GetAddress();
 
         if (nDebit > 0)
             listSent.push_back(make_pair(address, txout.nValue));

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -59,6 +59,7 @@ public:
     int64 GetBalance() const;
     bool CreateTransaction(const std::vector<std::pair<CScript, int64> >& vecSend, CWalletTx& wtxNew, CReserveKey& reservekey, int64& nFeeRet);
     bool CreateTransaction(CScript scriptPubKey, int64 nValue, CWalletTx& wtxNew, CReserveKey& reservekey, int64& nFeeRet);
+    bool CreateExactTransaction(const std::vector<uint256>& vecTxIn, const std::vector<std::pair<CScript, int64> >& vecSend, CWalletTx& wtxNew, CReserveKey& reservekey, int64 nFee);
     bool CommitTransaction(CWalletTx& wtxNew, CReserveKey& reservekey);
     bool BroadcastTransaction(CWalletTx& wtxNew);
     std::string SendMoney(CScript scriptPubKey, int64 nValue, CWalletTx& wtxNew, bool fAskFee=false);


### PR DESCRIPTION
These commits introduce CWallet::CreateExactTransaction() function that
works like CWallet::CreateTransaction(), but takes explicit list of
prev_out transactions for sourcing the new transaction and fixed value
of transaction fee.

Furthermore, new RPC call 'sendexact' is introduced; it works like
'sendmany', but takes explicit list of transactions to use as coin
sources, and explicit value of transaction fee.

All outputs of the listed transactions that the account can claim are
used to source coins; the output of the new transaction must be exactly
the same amount, the user is responsible for dealing with any change.
The user is also responsible for setting the transaction fee to such
a value that other nodes will relay the transaction.

The point is to provide a low-level interface for making transactions
without all the auto-guessing implicitly done by the client. My primary
motivation is that I am a control freak and I want to have precise
control over the addresses used as "sources" of my transactions.

There are other applications too - even if more specific interfaces
might be more suited to them, this interface makes them possible at all
as the lowest common denominator. E.g. people who wish to be sure no
transaction fees will be paid for their transaction can use this
interface. Or people wishing to try out different coin selection
algorithms (or when coin selection makes sense at the moment of
transaction setup, e.g. in case of anonymizers).

Q: Why use explicit transactions instead of addresses?
A: In reality, you do not quite transfer money "from" an address.
Address is just a token that proves you are authorized to claim
a particular amount of bitcoins listed as one of outputs of some
transaction. Specific use-cases might be simplified, but you would
still be in hands of a fixed coin selection algorithm.  You can use
(somewhat laborously) listtransactions or external service to discover
transactions that send money to a given address.

Q: Why use account instead of explicit addresses?
A: First, it is more consistent with the other "send" interfaces
and the wallet organization. Second, I believe account is the right
abstraction - as mentioned, address is just a token for claiming some
bitcoins, but different kind of claim proofs might be used (e.g. the
now-deprecated "send to IP address", or it could be possible to also
specify password-protected coins). In the future, you could associate
further methods of authentication with accounts, but addresses are
limited. If you require a specific set of addresses to be used, you can
set up an ad-hoc account.

Q: What does that bit about "change" mean?
A: If transaction input claims some output of a previous transaction,
it must claim all the coins in the output. If you need to transfer
smaller amount than that, you must specify what to do with the
remaining amount (change). The built-in coin selection algorithm
either sends them to a new address (for better anonymity) or returns
them to the source address. Here, you are responsible for manually
specifying the destiny of your remaining amount.

Q: Can I be finally sure I pay only the TX fee I specify?
A: Yes, the TX fee you specify is final. However, please note that
if the new transaction is large (i.e. has many inputs and outputs)
or transfers too small amount and you do not offer any TX fee, it
may not be accepted by any other nodes. Note that this is more
serious than not being included in a block - you could just wait
longer for a benevolent miner. In these circumstances, your
transaction is not likely to even _reach_ a mining node because
the P2P network will not relay it.

(If you like the feature, you can send donations to
19VF444umGxX76DZwPuWVMHpv7i84DHM1D.)
