### PR TITLE
Boost unit-testing framework.

### DIFF
--- a/src/makefile.mingw
+++ b/src/makefile.mingw
@@ -81,9 +81,17 @@ obj/nogui/%.o: %.cpp $(HEADERS)
 bitcoind.exe: $(OBJS:obj/%=obj/nogui/%) obj/ui_res.o
 	g++ $(CFLAGS) -o $@ $(LIBPATHS) $^ $(LIBS)
 
+obj/test/%.o: obj/test/%.cpp $(HEADERS)
+	g++ -c $(CFLAGS) -o $@ $<
+
+test_bitcoin: obj/test/test_bitcoin.o
+	g++ $(CFLAGS) -o $@ $(LIBPATHS) $^ $(LIBS)
 
 clean:
+	-del /Q bitcoin bitcoind test_bitcoin
 	-del /Q obj\*
 	-del /Q obj\nogui\*
+	-del /Q obj\test\*
 	-del /Q cryptopp\obj\*
+	-del /Q test\*.o
 	-del /Q headers.h.gch

--- a/src/makefile.osx
+++ b/src/makefile.osx
@@ -74,9 +74,15 @@ obj/nogui/%.o: %.cpp $(HEADERS)
 bitcoind: $(OBJS:obj/%=obj/nogui/%)
 	$(CXX) $(CFLAGS) -o $@ $(LIBPATHS) $^ $(LIBS)
 
+obj/test/%.o: test/%.cpp $(HEADERS)
+	$(CXX) -c $(CFLAGS) -o $@ $<
+
+test_bitcoin: obj/test/test_bitcoin.o
+	$(CXX) $(CFLAGS) -o $@ $(LIBPATHS) $^ $(LIBS) -lboost_unit_test_framework
 
 clean:
-	-rm -f bitcoin bitcoind
+	-rm -f bitcoin bitcoind test_bitcoin
 	-rm -f obj/*.o
 	-rm -f obj/nogui/*.o
+	-rm -f obj/test/*.o
 	-rm -f cryptopp/obj/*.o

--- a/src/makefile.unix
+++ b/src/makefile.unix
@@ -75,11 +75,16 @@ obj/nogui/%.o: %.cpp $(HEADERS)
 bitcoind: $(OBJS:obj/%=obj/nogui/%)
 	$(CXX) $(CXXFLAGS) -o $@ $^ $(LIBS)
 
+obj/test/%.o: test/%.cpp $(HEADERS)
+	$(CXX) -c $(CFLAGS) -o $@ $<
+
+test_bitcoin: obj/test/test_bitcoin.o
+	$(CXX) $(CFLAGS) -o $@ $(LIBPATHS) $^ $(LIBS) -lboost_unit_test_framework
 
 clean:
+	-rm -f bitcoin bitcoind test_bitcoin
 	-rm -f obj/*.o
 	-rm -f obj/nogui/*.o
+	-rm -f obj/test/*.o
 	-rm -f cryptopp/obj/*.o
 	-rm -f headers.h.gch
-	-rm -f bitcoin
-	-rm -f bitcoind

--- a/src/obj/test/.gitignore
+++ b/src/obj/test/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/src/test/README
+++ b/src/test/README
@@ -1,0 +1,21 @@
+The sources in this directory are unit test cases.  Boost includes a
+unit testing framework, and since bitcoin already uses boost, it makes
+sense to simply use this framework rather than require developers to
+configure some other framework (we want as few impediments to creating
+unit tests as possible).
+
+The build system is setup to compile an executable called "test_bitcoin"
+that runs all of the unit tests.  The main source file is called
+test_bitcoin.cpp, which simply includes other files that contain the
+actual unit tests (outside of a couple required preprocessor
+directives).  The pattern is to create one test file for each class or
+source file for which you want to create unit tests.  The file naming
+convention is "<source_filename>_tests.cpp" and such files should wrap
+their tests in a test suite called "<source_filename>_tests".  For an
+examples of this pattern, examine uint160_tests.cpp and
+uint256_tests.cpp.
+
+For further reading, I found the following website to be helpful in
+explaining how the boost unit test framework works:
+
+http://www.alittlemadness.com/2009/03/31/c-unit-testing-with-boosttest/

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -1,0 +1,6 @@
+#define BOOST_TEST_MODULE uint160
+#include <boost/test/unit_test.hpp>
+
+#include "uint160_tests.cpp"
+#include "uint256_tests.cpp"
+

--- a/src/test/uint160_tests.cpp
+++ b/src/test/uint160_tests.cpp
@@ -1,0 +1,16 @@
+#include "../uint256.h"
+
+BOOST_AUTO_TEST_SUITE(uint160_tests)
+
+BOOST_AUTO_TEST_CASE(equality)
+{
+    uint160 num1 = 10;
+    uint160 num2 = 11;
+    BOOST_CHECK(num1+1 == num2);
+
+    uint64 num3 = 10;
+    BOOST_CHECK(num1 == num3);
+    BOOST_CHECK(num1+num2 == num3+num2);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/uint256_tests.cpp
+++ b/src/test/uint256_tests.cpp
@@ -1,0 +1,16 @@
+#include "../uint256.h"
+
+BOOST_AUTO_TEST_SUITE(uint256_tests)
+
+BOOST_AUTO_TEST_CASE(equality)
+{
+    uint256 num1 = 10;
+    uint256 num2 = 11;
+    BOOST_CHECK(num1+1 == num2);
+
+    uint64 num3 = 10;
+    BOOST_CHECK(num1 == num3);
+    BOOST_CHECK(num1+num2 == num3+num2);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
make -f makefile.{unix,osx,mingw} test_bitcoin
to compile dumb, do-almost-nothing placeholder unit tests.
