### PR TITLE
Address Book related Fixes

### DIFF
--- a/src/rpc.cpp
+++ b/src/rpc.cpp
@@ -445,7 +445,7 @@ Value setaccount(const Array& params, bool fHelp)
     CRITICAL_BLOCK(pwalletMain->cs_mapWallet)
     CRITICAL_BLOCK(pwalletMain->cs_mapAddressBook)
     {
-        if (pwalletMain->mapAddressBook.count(address))
+        if (pwalletMain->HaveKey(address) && pwalletMain->mapAddressBook.count(address))
         {
             string strOldAccount = pwalletMain->mapAddressBook[address];
             if (address == GetAccountAddress(strOldAccount))

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -2736,13 +2736,20 @@ void CAddressBookDialog::OnButtonCopy(wxCommandEvent& event)
     }
 }
 
-bool CAddressBookDialog::CheckIfMine(const string& strAddress, const string& strTitle)
+bool CAddressBookDialog::CheckSendingAddress(const string& strAddress, const string& strTitle)
 {
     CBitcoinAddress address(strAddress);
-    bool fMine = address.IsValid() && pwalletMain->HaveKey(address);
-    if (fMine)
+    if (!address.IsValid())
+    {
+        wxMessageBox(_("Invalid bitcoin address"), strTitle);
+        return false;
+    }
+    if (pwalletMain->HaveKey(address))
+    {
         wxMessageBox(_("This is one of your own addresses for receiving payments and cannot be entered in the address book.  "), strTitle);
-    return fMine;
+        return false;
+    }
+    return true;
 }
 
 void CAddressBookDialog::OnButtonEdit(wxCommandEvent& event)
@@ -2765,7 +2772,7 @@ void CAddressBookDialog::OnButtonEdit(wxCommandEvent& event)
             strName = dialog.GetValue1();
             strAddress = dialog.GetValue2();
         }
-        while (CheckIfMine(strAddress, _("Edit Address")));
+        while (!CheckSendingAddress(strAddress, _("Edit Address")));
 
     }
     else if (nPage == RECEIVING)
@@ -2805,7 +2812,7 @@ void CAddressBookDialog::OnButtonNew(wxCommandEvent& event)
             strName = dialog.GetValue1();
             strAddress = dialog.GetValue2();
         }
-        while (CheckIfMine(strAddress, _("Add Address")));
+        while (!CheckSendingAddress(strAddress, _("Add Address")));
     }
     else if (nPage == RECEIVING)
     {

--- a/src/ui.h
+++ b/src/ui.h
@@ -264,7 +264,7 @@ public:
     wxString GetSelectedAddress();
     wxString GetSelectedSendingAddress();
     wxString GetSelectedReceivingAddress();
-    bool CheckIfMine(const std::string& strAddress, const std::string& strTitle);
+    bool CheckSendingAddress(const std::string& strAddress, const std::string& strTitle);
 };
 
 

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1154,6 +1154,8 @@ int CWallet::LoadWallet(bool& fFirstRunRet)
 
 bool CWallet::SetAddressBookName(const CBitcoinAddress& address, const string& strName)
 {
+    if (mapAddressBook.count(address) && mapAddressBook[address] == strName)
+        return false;
     mapAddressBook[address] = strName;
     if (!fFileBacked)
         return false;
@@ -1162,6 +1164,8 @@ bool CWallet::SetAddressBookName(const CBitcoinAddress& address, const string& s
 
 bool CWallet::DelAddressBookName(const CBitcoinAddress& address)
 {
+    if (!mapAddressBook.count(address))
+        return false;
     mapAddressBook.erase(address);
     if (!fFileBacked)
         return false;


### PR DESCRIPTION
This is a rebased series of patches from pull request #335

1) Fix the synchronization of sending addresses between a CWallet and its associated CWalletDB (this was reported independently in Issue #350).

2) Add a check for validity of sending addresses (Issue #328).

3) Avoid propagation of unnecessary updates to CWalletDB.

4) Fix the behavior of setaccount on sending addresses that are already listed in the Address Book. (Issue #329).

5) Add wallet methods GetDefaultAddress and SetDefaultAddress (contributed by laanwj in Issue #350).
