### PR TITLE
fix check for USE_UPNP in makefile.unix

### DIFF
--- a/src/makefile.unix
+++ b/src/makefile.unix
@@ -23,7 +23,7 @@ LIBS= \
    -l ssl \
    -l crypto
 
-ifdef USE_UPNP
+ifneq ($(USE_UPNP),0)
 	LIBS += -l miniupnpc
 	DEFS += -DUSE_UPNP=$(USE_UPNP)
 endif


### PR DESCRIPTION
When miniupnpc isn't installed, building fails due to wrong check in makefile.unix.
