### PR TITLE
IRC connection command line arguments

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -193,6 +193,9 @@ bool AppInit2(int argc, char* argv[])
             "  -daemon          \t\t  " + _("Run in the background as a daemon and accept commands\n") +
 #endif
             "  -testnet         \t\t  " + _("Use the test network\n") +
+            "  -dnsseed         \t\t  " + _("Use DNS lookup for peer discovery\n") +
+            "  -irchost=<host>  \t\t  " + _("Connect to <host> for irc peer discovery\n") +
+            "  -ircport=<port>  \t\t  " + _("Connect to irc host using <port>\n") +
             "  -rpcuser=<user>  \t  "   + _("Username for JSON-RPC connections\n") +
             "  -rpcpassword=<pw>\t  "   + _("Password for JSON-RPC connections\n") +
             "  -rpcport=<port>  \t\t  " + _("Listen for JSON-RPC connections on <port> (default: 8332)\n") +

--- a/src/irc.cpp
+++ b/src/irc.cpp
@@ -265,14 +265,20 @@ void ThreadIRCSeed2(void* parg)
     bool fNameInUse = false;
     bool fTOR = (fUseProxy && addrProxy.port == htons(9050));
 
+    //  string hostname = GetArg("-irchost", "chat.freenode.net");
+    string hostname = GetArg("-irchost", "irc.lfnet.org");
+
+    //  string hostnameTOR = GetArg("-irchost", "216.155.130.130"); // chat.freenode.net
+    string hostnameTOR = GetArg("-irchost", "92.243.23.21"); // irc.lfnet.org
+
+    int port = GetArg("-ircport", 6667);
+
     while (!fShutdown)
     {
-        //CAddress addrConnect("216.155.130.130:6667"); // chat.freenode.net
-        CAddress addrConnect("92.243.23.21", 6667); // irc.lfnet.org
+        CAddress addrConnect(hostnameTOR, port);
         if (!fTOR)
         {
-            //struct hostent* phostent = gethostbyname("chat.freenode.net");
-            CAddress addrIRC("irc.lfnet.org", 6667, true);
+            CAddress addrIRC(hostname, port, true);
             if (addrIRC.IsValid())
                 addrConnect = addrIRC;
         }


### PR DESCRIPTION
This pull adds 2 new command line arguments, -ircport and -irchost.  This allows the internal hostname and port to be overridden.  This is for the benefit of users who can't connect to standard IRC ports due to ISP restrictions.
