### PR TITLE
Fail to load wallet if it contains unknown keys.

### DIFF
--- a/src/db.cpp
+++ b/src/db.cpp
@@ -670,7 +670,7 @@ void CWalletDB::ListAccountCreditDebit(const string& strAccount, list<CAccountin
 }
 
 
-bool CWalletDB::LoadWallet(CWallet* pwallet)
+int CWalletDB::LoadWallet(CWallet* pwallet)
 {
     pwallet->vchDefaultKey.clear();
     int nFileVersion = 0;
@@ -690,7 +690,7 @@ bool CWalletDB::LoadWallet(CWallet* pwallet)
         // Get cursor
         Dbc* pcursor = GetCursor();
         if (!pcursor)
-            return false;
+            return DB_CORRUPT;
 
         loop
         {
@@ -701,7 +701,7 @@ bool CWalletDB::LoadWallet(CWallet* pwallet)
             if (ret == DB_NOTFOUND)
                 break;
             else if (ret != 0)
-                return false;
+                return DB_CORRUPT;
 
             // Unserialize
             // Taking advantage of the fact that pair serialization
@@ -809,6 +809,10 @@ bool CWalletDB::LoadWallet(CWallet* pwallet)
                 if (strKey == "addrProxy")          ssValue >> addrProxy;
                 if (fHaveUPnP && strKey == "fUseUPnP")           ssValue >> fUseUPnP;
             }
+            else
+            {
+                return DB_UNSUPPORTED;
+            }
         }
         pcursor->close();
     }
@@ -839,7 +843,7 @@ bool CWalletDB::LoadWallet(CWallet* pwallet)
     }
 
 
-    return true;
+    return DB_LOAD_OK;
 }
 
 void ThreadFlushWalletDB(void* parg)

--- a/src/db.h
+++ b/src/db.h
@@ -342,6 +342,13 @@ public:
 
 
 
+enum DBErrors
+{
+    DB_LOAD_OK,
+    DB_CORRUPT,
+    DB_UNSUPPORTED
+};
+
 class CWalletDB : public CDB
 {
 public:
@@ -450,7 +457,7 @@ public:
     int64 GetAccountCreditDebit(const std::string& strAccount);
     void ListAccountCreditDebit(const std::string& strAccount, std::list<CAccountingEntry>& acentries);
 
-    bool LoadWallet(CWallet* pwallet);
+    int LoadWallet(CWallet* pwallet);
 };
 
 #endif

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -387,8 +387,16 @@ bool AppInit2(int argc, char* argv[])
     nStart = GetTimeMillis();
     bool fFirstRun;
     pwalletMain = new CWallet("wallet.dat");
-    if (!pwalletMain->LoadWallet(fFirstRun))
-        strErrors += _("Error loading wallet.dat      \n");
+    int nLoadWalletRet = pwalletMain->LoadWallet(fFirstRun);
+    if (nLoadWalletRet != DB_LOAD_OK)
+    {
+        if (nLoadWalletRet == DB_CORRUPT)
+            strErrors += _("Error loading wallet.dat: Wallet corrupted      \n");
+        else if (nLoadWalletRet == DB_UNSUPPORTED)
+            strErrors += _("Error loading wallet.dat: Wallet requires newer version of Bitcoin      \n");
+        else
+            strErrors += _("Error loading wallet.dat      \n");
+    }
     printf(" wallet      %15"PRI64d"ms\n", GetTimeMillis() - nStart);
 
     RegisterWallet(pwalletMain);

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -958,8 +958,9 @@ bool CWallet::LoadWallet(bool& fFirstRunRet)
     if (!fFileBacked)
         return false;
     fFirstRunRet = false;
-    if (!CWalletDB(strWalletFile,"cr+").LoadWallet(this))
-        return false;
+    int nLoadWalletRet = CWalletDB(strWalletFile,"cr+").LoadWallet(this);
+    if (nLoadWalletRet != DB_LOAD_OK)
+        return nLoadWalletRet;
     fFirstRunRet = vchDefaultKey.empty();
 
     if (!mapKeys.count(vchDefaultKey))


### PR DESCRIPTION
The motivation here is that if a wallet is encrypted, old versions
should simply fail to load the wallet.  Additionally, if a wallet
gets corrupted, the client should always fail to load the wallet
to give the user a chance for manual recovery.

This needs to go into 0.3.24, so that users who downgrade don't mess up their wallet by adding unencrypted keys to an encrypted wallet, making all versions unable to use the wallet.
