### PR TITLE
Do not use comma as thousands separator

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -346,11 +346,6 @@ string FormatMoney(int64 n, bool fPlus)
     if (nTrim)
         str.erase(str.size()-nTrim, nTrim);
 
-    // Insert thousands-separators:
-    size_t point = str.find(".");
-    for (int i = (str.size()-point)+3; i < str.size(); i += 4)
-        if (isdigit(str[str.size() - i - 1]))
-            str.insert(str.size() - i, 1, ',');
     if (n < 0)
         str.insert((unsigned int)0, 1, '-');
     else if (fPlus && n > 0)
@@ -373,8 +368,6 @@ bool ParseMoney(const char* pszIn, int64& nRet)
         p++;
     for (; *p; p++)
     {
-        if (*p == ',' && p > pszIn && isdigit(p[-1]) && isdigit(p[1]) && isdigit(p[2]) && isdigit(p[3]) && !isdigit(p[4]))
-            continue;
         if (*p == '.')
         {
             p++;


### PR DESCRIPTION
Using the comma as thousands separator causes problems for parts of the world
where comma == decimal point.  Germans sending 0,001 bitcoins are unpleasantly
surprised when that results in 1 BTC getting sent.
