### PR TITLE
Fix synchronization of default key

### DIFF
--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -240,7 +240,7 @@ void SetDefaultReceivingAddress(const string& strAddress)
             return;
         if (!mapPubKeys.count(hash160))
             return;
-        CWalletDB(pwalletMain->strWalletFile).WriteDefaultKey(mapPubKeys[hash160]);
+        pwalletMain->SetDefaultKey(mapPubKeys[hash160]);
         pframeMain->m_textCtrlAddress->SetValue(strAddress);
     }
 }

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -176,6 +176,7 @@ public:
 
     bool GetTransaction(const uint256 &hashTx, CWalletTx& wtx);
 
+    bool SetDefaultKey(const std::vector<unsigned char> &vchPubKey);
 };
 
 


### PR DESCRIPTION
Changing the default address from the GUI did not update vchDefaultKey.
