### PR TITLE
CKeyStore::AddKey must return a boolean

### DIFF
--- a/src/keystore.cpp
+++ b/src/keystore.cpp
@@ -29,5 +29,6 @@ bool CKeyStore::AddKey(const CKey& key)
         mapKeys[key.GetPubKey()] = key.GetPrivKey();
         mapPubKeys[Hash160(key.GetPubKey())] = key.GetPubKey();
     }
+    return true;
 }
 


### PR DESCRIPTION
Function should return true in case of success, currently returns nothing. This trivial patch fixes that.
