### PR TITLE
Remove another magic number: change threshold for nLockTime to constant

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -37,6 +37,8 @@ static const int64 MIN_RELAY_TX_FEE = 10000;
 static const int64 MAX_MONEY = 21000000 * COIN;
 inline bool MoneyRange(int64 nValue) { return (nValue >= 0 && nValue <= MAX_MONEY); }
 static const int COINBASE_MATURITY = 100;
+// Threshold for nLockTime: below this value it is interpreted as block number, otherwise as UNIX timestamp.
+static const int LOCKTIME_THRESHOLD = 500000000; // Tue Nov  5 00:53:20 1985 UTC
 #ifdef USE_UPNP
 static const int fHaveUPnP = true;
 #else
@@ -441,7 +443,7 @@ public:
             nBlockHeight = nBestHeight;
         if (nBlockTime == 0)
             nBlockTime = GetAdjustedTime();
-        if ((int64)nLockTime < (nLockTime < 500000000 ? (int64)nBlockHeight : nBlockTime))
+        if ((int64)nLockTime < (nLockTime < LOCKTIME_THRESHOLD ? (int64)nBlockHeight : nBlockTime))
             return true;
         BOOST_FOREACH(const CTxIn& txin, vin)
             if (!txin.IsFinal())

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -522,7 +522,7 @@ string FormatTxStatus(const CWalletTx& wtx)
     // Status
     if (!wtx.IsFinal())
     {
-        if (wtx.nLockTime < 500000000)
+        if (wtx.nLockTime < LOCKTIME_THRESHOLD)
             return strprintf(_("Open for %d blocks"), nBestHeight - wtx.nLockTime);
         else
             return strprintf(_("Open until %s"), DateTimeStr(wtx.nLockTime).c_str());


### PR DESCRIPTION
Minor patch to factor out another magic number
