### PR TITLE
keys indexed by address + introduced CBitcoinaddress

### DIFF
--- a/src/base58.h
+++ b/src/base58.h
@@ -173,14 +173,16 @@ protected:
 
     ~CBase58Data()
     {
-        memset(&vchData[0], 0, vchData.size());
+        if (!vchData.empty())
+            memset(&vchData[0], 0, vchData.size());
     }
 
     void SetData(int nVersionIn, const void* pdata, size_t nSize)
     {
         nVersion = nVersionIn;
         vchData.resize(nSize);
-        memcpy(&vchData[0], pdata, nSize);
+        if (!vchData.empty())
+            memcpy(&vchData[0], pdata, nSize);
     }
 
     void SetData(int nVersionIn, const unsigned char *pbegin, const unsigned char *pend)
@@ -201,7 +203,8 @@ public:
         }
         nVersion = vchTemp[0];
         vchData.resize(vchTemp.size() - 1);
-        memcpy(&vchData[0], &vchTemp[1], vchData.size());
+        if (!vchData.empty())
+            memcpy(&vchData[0], &vchTemp[1], vchData.size());
         memset(&vchTemp[0], 0, vchTemp.size());
         return true;
     }
@@ -221,7 +224,7 @@ public:
     int CompareTo(const CBase58Data& b58) const
     {
         if (nVersion < b58.nVersion) return -1;
-        if (nVersion < b58.nVersion) return  1;
+        if (nVersion > b58.nVersion) return  1;
         if (vchData < b58.vchData)   return -1;
         if (vchData > b58.vchData)   return  1;
         return 0;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -425,7 +425,6 @@ bool AppInit2(int argc, char* argv[])
         printf("mapBlockIndex.size() = %d\n",   mapBlockIndex.size());
         printf("nBestHeight = %d\n",            nBestHeight);
         printf("setKeyPool.size() = %d\n",      pwalletMain->setKeyPool.size());
-        printf("mapPubKeys.size() = %d\n",      mapPubKeys.size());
         printf("mapWallet.size() = %d\n",       pwalletMain->mapWallet.size());
         printf("mapAddressBook.size() = %d\n",  pwalletMain->mapAddressBook.size());
 

--- a/src/key.h
+++ b/src/key.h
@@ -220,6 +220,11 @@ public:
             return false;
         return true;
     }
+
+    CBitcoinAddress GetAddress() const
+    {
+        return CBitcoinAddress(GetPubKey());
+    }
 };
 
 #endif

--- a/src/keystore.cpp
+++ b/src/keystore.cpp
@@ -16,14 +16,19 @@ std::vector<unsigned char> CKeyStore::GenerateNewKey()
     return key.GetPubKey();
 }
 
+bool CKeyStore::GetPubKey(const uint160 &hashAddress, std::vector<unsigned char> &vchPubKeyOut) const
+{
+    CKey key;
+    if (!GetKey(hashAddress, key))
+        return false;
+    vchPubKeyOut = key.GetPubKey();
+    return true;
+}
+
 bool CBasicKeyStore::AddKey(const CKey& key)
 {
-    CRITICAL_BLOCK(cs_mapPubKeys)
     CRITICAL_BLOCK(cs_KeyStore)
-    {
-        mapKeys[key.GetPubKey()] = key.GetPrivKey();
-        mapPubKeys[Hash160(key.GetPubKey())] = key.GetPubKey();
-    }
+        mapKeys[Hash160(key.GetPubKey())] = key.GetSecret();
     return true;
 }
 
@@ -44,11 +49,11 @@ bool CCryptoKeyStore::Unlock(const CKeyingMaterial& vMasterKeyIn)
         if (!SetCrypted())
             return false;
 
-        std::map<std::vector<unsigned char>, std::vector<unsigned char> >::const_iterator mi = mapCryptedKeys.begin();
+        CryptedKeyMap::const_iterator mi = mapCryptedKeys.begin();
         for (; mi != mapCryptedKeys.end(); ++mi)
         {
-            const std::vector<unsigned char> &vchPubKey = (*mi).first;
-            const std::vector<unsigned char> &vchCryptedSecret = (*mi).second;
+            const std::vector<unsigned char> &vchPubKey = (*mi).second.first;
+            const std::vector<unsigned char> &vchCryptedSecret = (*mi).second.second;
             CSecret vchSecret;
             if(!DecryptSecret(vMasterKeyIn, vchCryptedSecret, Hash(vchPubKey.begin(), vchPubKey.end()), vchSecret))
                 return false;
@@ -88,33 +93,49 @@ bool CCryptoKeyStore::AddKey(const CKey& key)
 
 bool CCryptoKeyStore::AddCryptedKey(const std::vector<unsigned char> &vchPubKey, const std::vector<unsigned char> &vchCryptedSecret)
 {
-    CRITICAL_BLOCK(cs_mapPubKeys)
     CRITICAL_BLOCK(cs_KeyStore)
     {
         if (!SetCrypted())
             return false;
 
-        mapCryptedKeys[vchPubKey] = vchCryptedSecret;
-        mapPubKeys[Hash160(vchPubKey)] = vchPubKey;
+        mapCryptedKeys[Hash160(vchPubKey)] = make_pair(vchPubKey, vchCryptedSecret);
     }
     return true;
 }
 
-bool CCryptoKeyStore::GetPrivKey(const std::vector<unsigned char> &vchPubKey, CKey& keyOut) const
+bool CCryptoKeyStore::GetKey(const uint160 &hashAddress, CKey& keyOut) const
 {
     CRITICAL_BLOCK(cs_vMasterKey)
     {
         if (!IsCrypted())
-            return CBasicKeyStore::GetPrivKey(vchPubKey, keyOut);
+            return CBasicKeyStore::GetKey(hashAddress, keyOut);
 
-        std::map<std::vector<unsigned char>, std::vector<unsigned char> >::const_iterator mi = mapCryptedKeys.find(vchPubKey);
+        CryptedKeyMap::const_iterator mi = mapCryptedKeys.find(hashAddress);
         if (mi != mapCryptedKeys.end())
         {
-            const std::vector<unsigned char> &vchCryptedSecret = (*mi).second;
+            const std::vector<unsigned char> &vchPubKey = (*mi).second.first;
+            const std::vector<unsigned char> &vchCryptedSecret = (*mi).second.second;
             CSecret vchSecret;
-            if (!DecryptSecret(vMasterKey, (*mi).second, Hash((*mi).first.begin(), (*mi).first.end()), vchSecret))
+            if (!DecryptSecret(vMasterKey, vchCryptedSecret, Hash(vchPubKey.begin(), vchPubKey.end()), vchSecret))
                 return false;
             keyOut.SetSecret(vchSecret);
+            return true;
+        }
+    }
+    return false;
+}
+
+bool CCryptoKeyStore::GetPubKey(const uint160 &hashAddress, std::vector<unsigned char>& vchPubKeyOut) const
+{
+    CRITICAL_BLOCK(cs_vMasterKey)
+    {
+        if (!IsCrypted())
+            return CKeyStore::GetPubKey(hashAddress, vchPubKeyOut);
+
+        CryptedKeyMap::const_iterator mi = mapCryptedKeys.find(hashAddress);
+        if (mi != mapCryptedKeys.end())
+        {
+            vchPubKeyOut = (*mi).second.first;
             return true;
         }
     }
@@ -135,10 +156,11 @@ bool CCryptoKeyStore::EncryptKeys(CKeyingMaterial& vMasterKeyIn)
         {
             if (!key.SetPrivKey(mKey.second))
                 return false;
+            const std::vector<unsigned char> vchPubKey = key.GetPubKey();
             std::vector<unsigned char> vchCryptedSecret;
-            if (!EncryptSecret(vMasterKeyIn, key.GetSecret(), Hash(mKey.first.begin(), mKey.first.end()), vchCryptedSecret))
+            if (!EncryptSecret(vMasterKeyIn, key.GetSecret(), Hash(vchPubKey.begin(), vchPubKey.end()), vchCryptedSecret))
                 return false;
-            if (!AddCryptedKey(mKey.first, vchCryptedSecret))
+            if (!AddCryptedKey(vchPubKey, vchCryptedSecret))
                 return false;
         }
         mapKeys.clear();

--- a/src/keystore.h
+++ b/src/keystore.h
@@ -12,12 +12,13 @@ public:
     mutable CCriticalSection cs_KeyStore;
 
     virtual bool AddKey(const CKey& key) =0;
-    virtual bool HaveKey(const std::vector<unsigned char> &vchPubKey) const =0;
-    virtual bool GetPrivKey(const std::vector<unsigned char> &vchPubKey, CKey& keyOut) const =0;
+    virtual bool HaveKey(const uint160 &hashAddress) const =0;
+    virtual bool GetKey(const uint160 &hashAddress, CKey& keyOut) const =0;
+    virtual bool GetPubKey(const uint160 &hashAddress, std::vector<unsigned char>& vchPubKeyOut) const;
     virtual std::vector<unsigned char> GenerateNewKey();
 };
 
-typedef std::map<std::vector<unsigned char>, CPrivKey> KeyMap;
+typedef std::map<uint160, CSecret> KeyMap;
 
 class CBasicKeyStore : public CKeyStore
 {
@@ -26,26 +27,28 @@ protected:
 
 public:
     bool AddKey(const CKey& key);
-    bool HaveKey(const std::vector<unsigned char> &vchPubKey) const
+    bool HaveKey(const uint160 &hashAddress) const
     {
-        return (mapKeys.count(vchPubKey) > 0);
+        return (mapKeys.count(hashAddress) > 0);
     }
-    bool GetPrivKey(const std::vector<unsigned char> &vchPubKey, CKey& keyOut) const
+    bool GetKey(const uint160 &hashAddress, CKey& keyOut) const
     {
-        std::map<std::vector<unsigned char>, CPrivKey>::const_iterator mi = mapKeys.find(vchPubKey);
+        KeyMap::const_iterator mi = mapKeys.find(hashAddress);
         if (mi != mapKeys.end())
         {
-            keyOut.SetPrivKey((*mi).second);
+            keyOut.SetSecret((*mi).second);
             return true;
         }
         return false;
     }
 };
 
+typedef std::map<uint160, std::pair<std::vector<unsigned char>, std::vector<unsigned char> > > CryptedKeyMap;
+
 class CCryptoKeyStore : public CBasicKeyStore
 {
 private:
-    std::map<std::vector<unsigned char>, std::vector<unsigned char> > mapCryptedKeys;
+    CryptedKeyMap mapCryptedKeys;
 
     CKeyingMaterial vMasterKey;
 
@@ -103,13 +106,14 @@ public:
     virtual bool AddCryptedKey(const std::vector<unsigned char> &vchPubKey, const std::vector<unsigned char> &vchCryptedSecret);
     std::vector<unsigned char> GenerateNewKey();
     bool AddKey(const CKey& key);
-    bool HaveKey(const std::vector<unsigned char> &vchPubKey) const
+    bool HaveKey(const uint160 &hashAddress) const
     {
         if (!IsCrypted())
-            return CBasicKeyStore::HaveKey(vchPubKey);
-        return mapCryptedKeys.count(vchPubKey) > 0;
+            return CBasicKeyStore::HaveKey(hashAddress);
+        return mapCryptedKeys.count(hashAddress) > 0;
     }
-    bool GetPrivKey(const std::vector<unsigned char> &vchPubKey, CKey& keyOut) const;
+    bool GetKey(const uint160 &hashAddress, CKey& keyOut) const;
+    bool GetPubKey(const uint160 &hashAddress, std::vector<unsigned char>& vchPubKeyOut) const;
 };
 
 #endif

--- a/src/keystore.h
+++ b/src/keystore.h
@@ -12,13 +12,13 @@ public:
     mutable CCriticalSection cs_KeyStore;
 
     virtual bool AddKey(const CKey& key) =0;
-    virtual bool HaveKey(const uint160 &hashAddress) const =0;
-    virtual bool GetKey(const uint160 &hashAddress, CKey& keyOut) const =0;
-    virtual bool GetPubKey(const uint160 &hashAddress, std::vector<unsigned char>& vchPubKeyOut) const;
+    virtual bool HaveKey(const CBitcoinAddress &address) const =0;
+    virtual bool GetKey(const CBitcoinAddress &address, CKey& keyOut) const =0;
+    virtual bool GetPubKey(const CBitcoinAddress &address, std::vector<unsigned char>& vchPubKeyOut) const;
     virtual std::vector<unsigned char> GenerateNewKey();
 };
 
-typedef std::map<uint160, CSecret> KeyMap;
+typedef std::map<CBitcoinAddress, CSecret> KeyMap;
 
 class CBasicKeyStore : public CKeyStore
 {
@@ -27,13 +27,13 @@ protected:
 
 public:
     bool AddKey(const CKey& key);
-    bool HaveKey(const uint160 &hashAddress) const
+    bool HaveKey(const CBitcoinAddress &address) const
     {
-        return (mapKeys.count(hashAddress) > 0);
+        return (mapKeys.count(address) > 0);
     }
-    bool GetKey(const uint160 &hashAddress, CKey& keyOut) const
+    bool GetKey(const CBitcoinAddress &address, CKey& keyOut) const
     {
-        KeyMap::const_iterator mi = mapKeys.find(hashAddress);
+        KeyMap::const_iterator mi = mapKeys.find(address);
         if (mi != mapKeys.end())
         {
             keyOut.SetSecret((*mi).second);
@@ -43,7 +43,7 @@ public:
     }
 };
 
-typedef std::map<uint160, std::pair<std::vector<unsigned char>, std::vector<unsigned char> > > CryptedKeyMap;
+typedef std::map<CBitcoinAddress, std::pair<std::vector<unsigned char>, std::vector<unsigned char> > > CryptedKeyMap;
 
 class CCryptoKeyStore : public CBasicKeyStore
 {
@@ -106,14 +106,14 @@ public:
     virtual bool AddCryptedKey(const std::vector<unsigned char> &vchPubKey, const std::vector<unsigned char> &vchCryptedSecret);
     std::vector<unsigned char> GenerateNewKey();
     bool AddKey(const CKey& key);
-    bool HaveKey(const uint160 &hashAddress) const
+    bool HaveKey(const CBitcoinAddress &address) const
     {
         if (!IsCrypted())
-            return CBasicKeyStore::HaveKey(hashAddress);
-        return mapCryptedKeys.count(hashAddress) > 0;
+            return CBasicKeyStore::HaveKey(address);
+        return mapCryptedKeys.count(address) > 0;
     }
-    bool GetKey(const uint160 &hashAddress, CKey& keyOut) const;
-    bool GetPubKey(const uint160 &hashAddress, std::vector<unsigned char>& vchPubKeyOut) const;
+    bool GetKey(const CBitcoinAddress &address, CKey& keyOut) const;
+    bool GetPubKey(const CBitcoinAddress &address, std::vector<unsigned char>& vchPubKeyOut) const;
 };
 
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,9 +21,6 @@ set<CWallet*> setpwalletRegistered;
 
 CCriticalSection cs_main;
 
-CCriticalSection cs_mapPubKeys;
-map<uint160, vector<unsigned char> > mapPubKeys;
-
 map<uint256, CTransaction> mapTransactions;
 CCriticalSection cs_mapTransactions;
 unsigned int nTransactionsUpdated = 0;

--- a/src/main.h
+++ b/src/main.h
@@ -1568,7 +1568,5 @@ public:
 
 
 extern std::map<uint256, CTransaction> mapTransactions;
-extern std::map<uint160, std::vector<unsigned char> > mapPubKeys;
-extern CCriticalSection cs_mapPubKeys;
 
 #endif

--- a/src/rpc.cpp
+++ b/src/rpc.cpp
@@ -342,7 +342,7 @@ Value getnewaddress(const Array& params, bool fHelp)
         strAccount = AccountFromValue(params[0]);
 
     // Generate a new key that is added to wallet
-    string strAddress = PubKeyToAddress(pwalletMain->GetOrReuseKeyFromPool());
+    string strAddress = CBitcoinAddress(pwalletMain->GetOrReuseKeyFromPool()).ToString();
 
     // This could be done in the same main CS as GetKeyFromKeyPool.
     CRITICAL_BLOCK(pwalletMain->cs_mapAddressBook)
@@ -353,7 +353,7 @@ Value getnewaddress(const Array& params, bool fHelp)
 
 
 // requires cs_main, cs_mapWallet, cs_mapAddressBook locks
-string GetAccountAddress(string strAccount, bool bForceNew=false)
+CBitcoinAddress GetAccountAddress(string strAccount, bool bForceNew=false)
 {
     string strAddress;
 
@@ -393,16 +393,14 @@ string GetAccountAddress(string strAccount, bool bForceNew=false)
             else
             {
                 account.vchPubKey = pwalletMain->GetOrReuseKeyFromPool();
-                string strAddress = PubKeyToAddress(account.vchPubKey);
+                string strAddress = CBitcoinAddress(account.vchPubKey).ToString();
                 pwalletMain->SetAddressBookName(strAddress, strAccount);
                 walletdb.WriteAccount(strAccount, account);
             }
         }
     }
 
-    strAddress = PubKeyToAddress(account.vchPubKey);
-
-    return strAddress;
+    return CBitcoinAddress(account.vchPubKey);
 }
 
 Value getaccountaddress(const Array& params, bool fHelp)
@@ -421,7 +419,7 @@ Value getaccountaddress(const Array& params, bool fHelp)
     CRITICAL_BLOCK(pwalletMain->cs_mapWallet)
     CRITICAL_BLOCK(pwalletMain->cs_mapAddressBook)
     {
-        ret = GetAccountAddress(strAccount);
+        ret = GetAccountAddress(strAccount).ToString();
     }
 
     return ret;
@@ -437,9 +435,8 @@ Value setaccount(const Array& params, bool fHelp)
             "Sets the account associated with the given address.");
 
     string strAddress = params[0].get_str();
-    uint160 hash160;
-    bool isValid = AddressToHash160(strAddress, hash160);
-    if (!isValid)
+    CBitcoinAddress address(strAddress);
+    if (!address.IsValid())
         throw JSONRPCError(-5, "Invalid bitcoin address");
 
 
@@ -452,10 +449,10 @@ Value setaccount(const Array& params, bool fHelp)
     CRITICAL_BLOCK(pwalletMain->cs_mapWallet)
     CRITICAL_BLOCK(pwalletMain->cs_mapAddressBook)
     {
-        if (pwalletMain->mapAddressBook.count(strAddress))
+        if (pwalletMain->mapAddressBook.count(address))
         {
-            string strOldAccount = pwalletMain->mapAddressBook[strAddress];
-            if (strAddress == GetAccountAddress(strOldAccount))
+            string strOldAccount = pwalletMain->mapAddressBook[address];
+            if (address == GetAccountAddress(strOldAccount))
                 GetAccountAddress(strOldAccount, true);
         }
 
@@ -474,11 +471,12 @@ Value getaccount(const Array& params, bool fHelp)
             "Returns the account associated with the given address.");
 
     string strAddress = params[0].get_str();
+    CBitcoinAddress address(strAddress);
 
     string strAccount;
     CRITICAL_BLOCK(pwalletMain->cs_mapAddressBook)
     {
-        map<string, string>::iterator mi = pwalletMain->mapAddressBook.find(strAddress);
+        map<CBitcoinAddress, string>::iterator mi = pwalletMain->mapAddressBook.find(address);
         if (mi != pwalletMain->mapAddressBook.end() && !(*mi).second.empty())
             strAccount = (*mi).second;
     }
@@ -499,17 +497,12 @@ Value getaddressesbyaccount(const Array& params, bool fHelp)
     Array ret;
     CRITICAL_BLOCK(pwalletMain->cs_mapAddressBook)
     {
-        BOOST_FOREACH(const PAIRTYPE(string, string)& item, pwalletMain->mapAddressBook)
+        BOOST_FOREACH(const PAIRTYPE(CBitcoinAddress, string)& item, pwalletMain->mapAddressBook)
         {
-            const string& strAddress = item.first;
+            const CBitcoinAddress& address = item.first;
             const string& strName = item.second;
             if (strName == strAccount)
-            {
-                // We're only adding valid bitcoin addresses and not ip addresses
-                CScript scriptPubKey;
-                if (scriptPubKey.SetBitcoinAddress(strAddress))
-                    ret.push_back(strAddress);
-            }
+                ret.push_back(address.ToString());
         }
     }
     return ret;
@@ -578,10 +571,11 @@ Value getreceivedbyaddress(const Array& params, bool fHelp)
             "Returns the total amount received by <bitcoinaddress> in transactions with at least [minconf] confirmations.");
 
     // Bitcoin address
-    string strAddress = params[0].get_str();
+    CBitcoinAddress address = CBitcoinAddress(params[0].get_str());
     CScript scriptPubKey;
-    if (!scriptPubKey.SetBitcoinAddress(strAddress))
+    if (!address.IsValid())
         throw JSONRPCError(-5, "Invalid bitcoin address");
+    scriptPubKey.SetBitcoinAddress(address);
     if (!IsMine(*pwalletMain,scriptPubKey))
         return (double)0.0;
 
@@ -611,22 +605,16 @@ Value getreceivedbyaddress(const Array& params, bool fHelp)
 }
 
 
-void GetAccountPubKeys(string strAccount, set<CScript>& setPubKey)
+void GetAccountAddresses(string strAccount, set<CBitcoinAddress>& setAddress)
 {
     CRITICAL_BLOCK(pwalletMain->cs_mapAddressBook)
     {
-        BOOST_FOREACH(const PAIRTYPE(string, string)& item, pwalletMain->mapAddressBook)
+        BOOST_FOREACH(const PAIRTYPE(CBitcoinAddress, string)& item, pwalletMain->mapAddressBook)
         {
-            const string& strAddress = item.first;
+            const CBitcoinAddress& address = item.first;
             const string& strName = item.second;
             if (strName == strAccount)
-            {
-                // We're only counting our own valid bitcoin addresses and not ip addresses
-                CScript scriptPubKey;
-                if (scriptPubKey.SetBitcoinAddress(strAddress))
-                    if (IsMine(*pwalletMain,scriptPubKey))
-                        setPubKey.insert(scriptPubKey);
-            }
+                setAddress.insert(address);
         }
     }
 }
@@ -646,8 +634,8 @@ Value getreceivedbyaccount(const Array& params, bool fHelp)
 
     // Get the set of pub keys that have the label
     string strAccount = AccountFromValue(params[0]);
-    set<CScript> setPubKey;
-    GetAccountPubKeys(strAccount, setPubKey);
+    set<CBitcoinAddress> setAddress;
+    GetAccountAddresses(strAccount, setAddress);
 
     // Tally
     int64 nAmount = 0;
@@ -660,9 +648,12 @@ Value getreceivedbyaccount(const Array& params, bool fHelp)
                 continue;
 
             BOOST_FOREACH(const CTxOut& txout, wtx.vout)
-                if (setPubKey.count(txout.scriptPubKey))
+            {
+                CBitcoinAddress address;
+                if (ExtractAddress(txout.scriptPubKey, pwalletMain, address) && setAddress.count(address))
                     if (wtx.GetDepthInMainChain() >= nMinDepth)
                         nAmount += txout.nValue;
+            }
         }
     }
 
@@ -733,13 +724,13 @@ Value getbalance(const Array& params, bool fHelp)
             int64 allGeneratedImmature, allGeneratedMature, allFee;
             allGeneratedImmature = allGeneratedMature = allFee = 0;
             string strSentAccount;
-            list<pair<string, int64> > listReceived;
-            list<pair<string, int64> > listSent;
+            list<pair<CBitcoinAddress, int64> > listReceived;
+            list<pair<CBitcoinAddress, int64> > listSent;
             wtx.GetAmounts(allGeneratedImmature, allGeneratedMature, listReceived, listSent, allFee, strSentAccount);
             if (wtx.GetDepthInMainChain() >= nMinDepth)
-                BOOST_FOREACH(const PAIRTYPE(string,int64)& r, listReceived)
+                BOOST_FOREACH(const PAIRTYPE(CBitcoinAddress,int64)& r, listReceived)
                     nBalance += r.second;
-            BOOST_FOREACH(const PAIRTYPE(string,int64)& r, listSent)
+            BOOST_FOREACH(const PAIRTYPE(CBitcoinAddress,int64)& r, listSent)
                 nBalance -= r.second;
             nBalance -= allFee;
             nBalance += allGeneratedMature;
@@ -874,22 +865,22 @@ Value sendmany(const Array& params, bool fHelp)
     if (params.size() > 3 && params[3].type() != null_type && !params[3].get_str().empty())
         wtx.mapValue["comment"] = params[3].get_str();
 
-    set<string> setAddress;
+    set<CBitcoinAddress> setAddress;
     vector<pair<CScript, int64> > vecSend;
 
     int64 totalAmount = 0;
     BOOST_FOREACH(const Pair& s, sendTo)
     {
-        uint160 hash160;
-        string strAddress = s.name_;
+        CBitcoinAddress address(s.name_);
+        if (!address.IsValid())
+            throw JSONRPCError(-5, string("Invalid bitcoin address:")+s.name_);
 
-        if (setAddress.count(strAddress))
-            throw JSONRPCError(-8, string("Invalid parameter, duplicated address: ")+strAddress);
-        setAddress.insert(strAddress);
+        if (setAddress.count(address))
+            throw JSONRPCError(-8, string("Invalid parameter, duplicated address: ")+s.name_);
+        setAddress.insert(address);
 
         CScript scriptPubKey;
-        if (!scriptPubKey.SetBitcoinAddress(strAddress))
-            throw JSONRPCError(-5, string("Invalid bitcoin address:")+strAddress);
+        scriptPubKey.SetBitcoinAddress(address);
         int64 nAmount = AmountFromValue(s.value_); 
         totalAmount += nAmount;
 
@@ -950,7 +941,7 @@ Value ListReceived(const Array& params, bool fByAccounts)
         fIncludeEmpty = params[1].get_bool();
 
     // Tally
-    map<uint160, tallyitem> mapTally;
+    map<CBitcoinAddress, tallyitem> mapTally;
     CRITICAL_BLOCK(pwalletMain->cs_mapWallet)
     {
         for (map<uint256, CWalletTx>::iterator it = pwalletMain->mapWallet.begin(); it != pwalletMain->mapWallet.end(); ++it)
@@ -965,12 +956,11 @@ Value ListReceived(const Array& params, bool fByAccounts)
 
             BOOST_FOREACH(const CTxOut& txout, wtx.vout)
             {
-                // Only counting our own bitcoin addresses and not ip addresses
-                uint160 hash160 = txout.scriptPubKey.GetBitcoinAddressHash160();
-                if (hash160 == 0 || !pwalletMain->HaveKey(hash160)) // IsMine
+                CBitcoinAddress address;
+                if (!ExtractAddress(txout.scriptPubKey, pwalletMain, address) || !address.IsValid())
                     continue;
 
-                tallyitem& item = mapTally[hash160];
+                tallyitem& item = mapTally[address];
                 item.nAmount += txout.nValue;
                 item.nConf = min(item.nConf, nDepth);
             }
@@ -982,14 +972,11 @@ Value ListReceived(const Array& params, bool fByAccounts)
     map<string, tallyitem> mapAccountTally;
     CRITICAL_BLOCK(pwalletMain->cs_mapAddressBook)
     {
-        BOOST_FOREACH(const PAIRTYPE(string, string)& item, pwalletMain->mapAddressBook)
+        BOOST_FOREACH(const PAIRTYPE(CBitcoinAddress, string)& item, pwalletMain->mapAddressBook)
         {
-            const string& strAddress = item.first;
+            const CBitcoinAddress& address = item.first;
             const string& strAccount = item.second;
-            uint160 hash160;
-            if (!AddressToHash160(strAddress, hash160))
-                continue;
-            map<uint160, tallyitem>::iterator it = mapTally.find(hash160);
+            map<CBitcoinAddress, tallyitem>::iterator it = mapTally.find(address);
             if (it == mapTally.end() && !fIncludeEmpty)
                 continue;
 
@@ -1010,7 +997,7 @@ Value ListReceived(const Array& params, bool fByAccounts)
             else
             {
                 Object obj;
-                obj.push_back(Pair("address",       strAddress));
+                obj.push_back(Pair("address",       address.ToString()));
                 obj.push_back(Pair("account",       strAccount));
                 obj.push_back(Pair("label",         strAccount)); // deprecated
                 obj.push_back(Pair("amount",        ValueFromAmount(nAmount)));
@@ -1073,8 +1060,8 @@ void ListTransactions(const CWalletTx& wtx, const string& strAccount, int nMinDe
 {
     int64 nGeneratedImmature, nGeneratedMature, nFee;
     string strSentAccount;
-    list<pair<string, int64> > listReceived;
-    list<pair<string, int64> > listSent;
+    list<pair<CBitcoinAddress, int64> > listReceived;
+    list<pair<CBitcoinAddress, int64> > listSent;
     wtx.GetAmounts(nGeneratedImmature, nGeneratedMature, listReceived, listSent, nFee, strSentAccount);
 
     bool fAllAccounts = (strAccount == string("*"));
@@ -1102,11 +1089,11 @@ void ListTransactions(const CWalletTx& wtx, const string& strAccount, int nMinDe
     // Sent
     if ((!listSent.empty() || nFee != 0) && (fAllAccounts || strAccount == strSentAccount))
     {
-        BOOST_FOREACH(const PAIRTYPE(string, int64)& s, listSent)
+        BOOST_FOREACH(const PAIRTYPE(CBitcoinAddress, int64)& s, listSent)
         {
             Object entry;
             entry.push_back(Pair("account", strSentAccount));
-            entry.push_back(Pair("address", s.first));
+            entry.push_back(Pair("address", s.first.ToString()));
             entry.push_back(Pair("category", "send"));
             entry.push_back(Pair("amount", ValueFromAmount(-s.second)));
             entry.push_back(Pair("fee", ValueFromAmount(-nFee)));
@@ -1120,7 +1107,7 @@ void ListTransactions(const CWalletTx& wtx, const string& strAccount, int nMinDe
     if (listReceived.size() > 0 && wtx.GetDepthInMainChain() >= nMinDepth)
         CRITICAL_BLOCK(pwalletMain->cs_mapAddressBook)
         {
-            BOOST_FOREACH(const PAIRTYPE(string, int64)& r, listReceived)
+            BOOST_FOREACH(const PAIRTYPE(CBitcoinAddress, int64)& r, listReceived)
             {
                 string account;
                 if (pwalletMain->mapAddressBook.count(r.first))
@@ -1129,7 +1116,7 @@ void ListTransactions(const CWalletTx& wtx, const string& strAccount, int nMinDe
                 {
                     Object entry;
                     entry.push_back(Pair("account", account));
-                    entry.push_back(Pair("address", r.first));
+                    entry.push_back(Pair("address", r.first.ToString()));
                     entry.push_back(Pair("category", "receive"));
                     entry.push_back(Pair("amount", ValueFromAmount(r.second)));
                     if (fLong)
@@ -1240,9 +1227,8 @@ Value listaccounts(const Array& params, bool fHelp)
     CRITICAL_BLOCK(pwalletMain->cs_mapWallet)
     CRITICAL_BLOCK(pwalletMain->cs_mapAddressBook)
     {
-        BOOST_FOREACH(const PAIRTYPE(string, string)& entry, pwalletMain->mapAddressBook) {
-            uint160 hash160;
-            if(AddressToHash160(entry.first, hash160) && pwalletMain->HaveKey(hash160)) // This address belongs to me
+        BOOST_FOREACH(const PAIRTYPE(CBitcoinAddress, string)& entry, pwalletMain->mapAddressBook) {
+            if (pwalletMain->HaveKey(entry.first)) // This address belongs to me
                 mapAccountBalances[entry.second] = 0;
         }
 
@@ -1251,16 +1237,16 @@ Value listaccounts(const Array& params, bool fHelp)
             const CWalletTx& wtx = (*it).second;
             int64 nGeneratedImmature, nGeneratedMature, nFee;
             string strSentAccount;
-            list<pair<string, int64> > listReceived;
-            list<pair<string, int64> > listSent;
+            list<pair<CBitcoinAddress, int64> > listReceived;
+            list<pair<CBitcoinAddress, int64> > listSent;
             wtx.GetAmounts(nGeneratedImmature, nGeneratedMature, listReceived, listSent, nFee, strSentAccount);
             mapAccountBalances[strSentAccount] -= nFee;
-            BOOST_FOREACH(const PAIRTYPE(string, int64)& s, listSent)
+            BOOST_FOREACH(const PAIRTYPE(CBitcoinAddress, int64)& s, listSent)
                 mapAccountBalances[strSentAccount] -= s.second;
             if (wtx.GetDepthInMainChain() >= nMinDepth)
             {
                 mapAccountBalances[""] += nGeneratedMature;
-                BOOST_FOREACH(const PAIRTYPE(string, int64)& r, listReceived)
+                BOOST_FOREACH(const PAIRTYPE(CBitcoinAddress, int64)& r, listReceived)
                     if (pwalletMain->mapAddressBook.count(r.first))
                         mapAccountBalances[pwalletMain->mapAddressBook[r.first]] += r.second;
                     else
@@ -1553,8 +1539,8 @@ Value validateaddress(const Array& params, bool fHelp)
             "Return information about <bitcoinaddress>.");
 
     string strAddress = params[0].get_str();
-    uint160 hash160;
-    bool isValid = AddressToHash160(strAddress, hash160);
+    CBitcoinAddress address(strAddress);
+    bool isValid = address.IsValid();
 
     Object ret;
     ret.push_back(Pair("isvalid", isValid));
@@ -1562,13 +1548,13 @@ Value validateaddress(const Array& params, bool fHelp)
     {
         // Call Hash160ToAddress() so we always return current ADDRESSVERSION
         // version of the address:
-        string currentAddress = Hash160ToAddress(hash160);
+        string currentAddress = address.ToString();
         ret.push_back(Pair("address", currentAddress));
-        ret.push_back(Pair("ismine", (pwalletMain->HaveKey(hash160) > 0)));
+        ret.push_back(Pair("ismine", (pwalletMain->HaveKey(address) > 0)));
         CRITICAL_BLOCK(pwalletMain->cs_mapAddressBook)
         {
-            if (pwalletMain->mapAddressBook.count(currentAddress))
-                ret.push_back(Pair("account", pwalletMain->mapAddressBook[currentAddress]));
+            if (pwalletMain->mapAddressBook.count(address))
+                ret.push_back(Pair("account", pwalletMain->mapAddressBook[address]));
         }
     }
     return ret;

--- a/src/rpc.cpp
+++ b/src/rpc.cpp
@@ -967,7 +967,7 @@ Value ListReceived(const Array& params, bool fByAccounts)
             {
                 // Only counting our own bitcoin addresses and not ip addresses
                 uint160 hash160 = txout.scriptPubKey.GetBitcoinAddressHash160();
-                if (hash160 == 0 || !mapPubKeys.count(hash160)) // IsMine
+                if (hash160 == 0 || !pwalletMain->HaveKey(hash160)) // IsMine
                     continue;
 
                 tallyitem& item = mapTally[hash160];
@@ -1242,7 +1242,7 @@ Value listaccounts(const Array& params, bool fHelp)
     {
         BOOST_FOREACH(const PAIRTYPE(string, string)& entry, pwalletMain->mapAddressBook) {
             uint160 hash160;
-            if(AddressToHash160(entry.first, hash160) && mapPubKeys.count(hash160)) // This address belongs to me
+            if(AddressToHash160(entry.first, hash160) && pwalletMain->HaveKey(hash160)) // This address belongs to me
                 mapAccountBalances[entry.second] = 0;
         }
 
@@ -1564,7 +1564,7 @@ Value validateaddress(const Array& params, bool fHelp)
         // version of the address:
         string currentAddress = Hash160ToAddress(hash160);
         ret.push_back(Pair("address", currentAddress));
-        ret.push_back(Pair("ismine", (mapPubKeys.count(hash160) > 0)));
+        ret.push_back(Pair("ismine", (pwalletMain->HaveKey(hash160) > 0)));
         CRITICAL_BLOCK(pwalletMain->cs_mapAddressBook)
         {
             if (pwalletMain->mapAddressBook.count(currentAddress))

--- a/src/script.cpp
+++ b/src/script.cpp
@@ -1135,9 +1135,9 @@ bool ExtractAddress(const CScript& scriptPubKey, const CKeyStore* keystore, CBit
         {
             uint160 hash160;
             if (item.first == OP_PUBKEY)
-                addressRet.SetAddress(item.second);
+                addressRet.SetPubKey(item.second);
             else if (item.first == OP_PUBKEYHASH)
-                addressRet.SetAddress(uint160(item.second));
+                addressRet.SetHash160((uint160)item.second);
             if (keystore == NULL || keystore->HaveKey(addressRet))
                 return true;
         }

--- a/src/script.cpp
+++ b/src/script.cpp
@@ -1123,7 +1123,7 @@ bool IsMine(const CKeyStore &keystore, const CScript& scriptPubKey)
 }
 
 
-bool ExtractHash160(const CScript& scriptPubKey, const CKeyStore* keystore, uint160& hash160Ret)
+bool ExtractAddress(const CScript& scriptPubKey, const CKeyStore* keystore, CBitcoinAddress& addressRet)
 {
     vector<pair<opcodetype, valtype> > vSolution;
     if (!Solver(scriptPubKey, vSolution))
@@ -1135,18 +1135,11 @@ bool ExtractHash160(const CScript& scriptPubKey, const CKeyStore* keystore, uint
         {
             uint160 hash160;
             if (item.first == OP_PUBKEY)
-            {
-                hash160 = Hash160(item.second);
-            }
+                addressRet.SetAddress(item.second);
             else if (item.first == OP_PUBKEYHASH)
-            {
-                hash160 = uint160(item.second);
-            }
-            if (keystore == NULL || keystore->HaveKey(hash160))
-            {
-                hash160Ret = hash160;
+                addressRet.SetAddress(uint160(item.second));
+            if (keystore == NULL || keystore->HaveKey(addressRet))
                 return true;
-            }
         }
     }
     return false;

--- a/src/script.cpp
+++ b/src/script.cpp
@@ -1041,7 +1041,9 @@ bool Solver(const CKeyStore& keystore, const CScript& scriptPubKey, uint256 hash
                 // Sign
                 const valtype& vchPubKey = item.second;
                 CKey key;
-                if (!keystore.GetPrivKey(vchPubKey, key))
+                if (!keystore.GetKey(Hash160(vchPubKey), key))
+                    return false;
+                if (key.GetPubKey() != vchPubKey)
                     return false;
                 if (hash != 0)
                 {
@@ -1055,12 +1057,8 @@ bool Solver(const CKeyStore& keystore, const CScript& scriptPubKey, uint256 hash
             else if (item.first == OP_PUBKEYHASH)
             {
                 // Sign and give pubkey
-                map<uint160, valtype>::iterator mi = mapPubKeys.find(uint160(item.second));
-                if (mi == mapPubKeys.end())
-                    return false;
-                const vector<unsigned char>& vchPubKey = (*mi).second;
                 CKey key;
-                if (!keystore.GetPrivKey(vchPubKey, key))
+                if (!keystore.GetKey(uint160(item.second), key))
                     return false;
                 if (hash != 0)
                 {
@@ -1068,7 +1066,7 @@ bool Solver(const CKeyStore& keystore, const CScript& scriptPubKey, uint256 hash
                     if (!key.Sign(hash, vchSig))
                         return false;
                     vchSig.push_back((unsigned char)nHashType);
-                    scriptSigRet << vchSig << vchPubKey;
+                    scriptSigRet << vchSig << key.GetPubKey();
                 }
             }
             else
@@ -1102,19 +1100,16 @@ bool IsMine(const CKeyStore &keystore, const CScript& scriptPubKey)
         {
             if (item.first == OP_PUBKEY)
             {
-                // Sign
                 const valtype& vchPubKey = item.second;
-                if (!keystore.HaveKey(vchPubKey))
+                vector<unsigned char> vchPubKeyFound;
+                if (!keystore.GetPubKey(Hash160(vchPubKey), vchPubKeyFound))
+                    return false;
+                if (vchPubKeyFound != vchPubKey)
                     return false;
             }
             else if (item.first == OP_PUBKEYHASH)
             {
-                // Sign and give pubkey
-                map<uint160, valtype>::iterator mi = mapPubKeys.find(uint160(item.second));
-                if (mi == mapPubKeys.end())
-                    return false;
-                const vector<unsigned char>& vchPubKey = (*mi).second;
-                if (!keystore.HaveKey(vchPubKey))
+                if (!keystore.HaveKey(uint160(item.second)))
                     return false;
             }
             else
@@ -1128,55 +1123,30 @@ bool IsMine(const CKeyStore &keystore, const CScript& scriptPubKey)
 }
 
 
-bool ExtractPubKey(const CScript& scriptPubKey, const CKeyStore* keystore, vector<unsigned char>& vchPubKeyRet)
+bool ExtractHash160(const CScript& scriptPubKey, const CKeyStore* keystore, uint160& hash160Ret)
 {
-    vchPubKeyRet.clear();
-
     vector<pair<opcodetype, valtype> > vSolution;
     if (!Solver(scriptPubKey, vSolution))
         return false;
 
-    CRITICAL_BLOCK(cs_mapPubKeys)
+    CRITICAL_BLOCK(keystore->cs_KeyStore)
     {
         BOOST_FOREACH(PAIRTYPE(opcodetype, valtype)& item, vSolution)
         {
-            valtype vchPubKey;
+            uint160 hash160;
             if (item.first == OP_PUBKEY)
             {
-                vchPubKey = item.second;
+                hash160 = Hash160(item.second);
             }
             else if (item.first == OP_PUBKEYHASH)
             {
-                map<uint160, valtype>::iterator mi = mapPubKeys.find(uint160(item.second));
-                if (mi == mapPubKeys.end())
-                    continue;
-                vchPubKey = (*mi).second;
+                hash160 = uint160(item.second);
             }
-            if (keystore == NULL || keystore->HaveKey(vchPubKey))
+            if (keystore == NULL || keystore->HaveKey(hash160))
             {
-                vchPubKeyRet = vchPubKey;
+                hash160Ret = hash160;
                 return true;
             }
-        }
-    }
-    return false;
-}
-
-
-bool ExtractHash160(const CScript& scriptPubKey, uint160& hash160Ret)
-{
-    hash160Ret = 0;
-
-    vector<pair<opcodetype, valtype> > vSolution;
-    if (!Solver(scriptPubKey, vSolution))
-        return false;
-
-    BOOST_FOREACH(PAIRTYPE(opcodetype, valtype)& item, vSolution)
-    {
-        if (item.first == OP_PUBKEYHASH)
-        {
-            hash160Ret = uint160(item.second);
-            return true;
         }
     }
     return false;

--- a/src/script.h
+++ b/src/script.h
@@ -622,7 +622,7 @@ public:
     }
 
 
-    uint160 GetBitcoinAddressHash160() const
+    CBitcoinAddress GetBitcoinAddress() const
     {
         opcodetype opcode;
         std::vector<unsigned char> vch;
@@ -634,36 +634,18 @@ public:
         if (!GetOp(pc, opcode, vch) || opcode != OP_EQUALVERIFY) return 0;
         if (!GetOp(pc, opcode, vch) || opcode != OP_CHECKSIG) return 0;
         if (pc != end()) return 0;
-        return hash160;
+        return CBitcoinAddress(hash160);
     }
 
-    std::string GetBitcoinAddress() const
-    {
-        uint160 hash160 = GetBitcoinAddressHash160();
-        if (hash160 == 0)
-            return "";
-        return Hash160ToAddress(hash160);
-    }
-
-    void SetBitcoinAddress(const uint160& hash160)
+    void SetBitcoinAddress(const CBitcoinAddress& address)
     {
         this->clear();
-        *this << OP_DUP << OP_HASH160 << hash160 << OP_EQUALVERIFY << OP_CHECKSIG;
+        *this << OP_DUP << OP_HASH160 << address.GetHash160() << OP_EQUALVERIFY << OP_CHECKSIG;
     }
 
     void SetBitcoinAddress(const std::vector<unsigned char>& vchPubKey)
     {
-        SetBitcoinAddress(Hash160(vchPubKey));
-    }
-
-    bool SetBitcoinAddress(const std::string& strAddress)
-    {
-        this->clear();
-        uint160 hash160;
-        if (!AddressToHash160(strAddress, hash160))
-            return false;
-        SetBitcoinAddress(hash160);
-        return true;
+        SetBitcoinAddress(CBitcoinAddress(vchPubKey));
     }
 
 
@@ -710,7 +692,7 @@ public:
 
 bool IsStandard(const CScript& scriptPubKey);
 bool IsMine(const CKeyStore& keystore, const CScript& scriptPubKey);
-bool ExtractHash160(const CScript& scriptPubKey, const CKeyStore* pkeystore, uint160& hash160Ret);
+bool ExtractAddress(const CScript& scriptPubKey, const CKeyStore* pkeystore, CBitcoinAddress& addressRet);
 bool SignSignature(const CKeyStore& keystore, const CTransaction& txFrom, CTransaction& txTo, unsigned int nIn, int nHashType=SIGHASH_ALL, CScript scriptPrereq=CScript());
 bool VerifySignature(const CTransaction& txFrom, const CTransaction& txTo, unsigned int nIn, int nHashType=0);
 

--- a/src/script.h
+++ b/src/script.h
@@ -710,8 +710,7 @@ public:
 
 bool IsStandard(const CScript& scriptPubKey);
 bool IsMine(const CKeyStore& keystore, const CScript& scriptPubKey);
-bool ExtractPubKey(const CScript& scriptPubKey, const CKeyStore* pkeystore, std::vector<unsigned char>& vchPubKeyRet);
-bool ExtractHash160(const CScript& scriptPubKey, uint160& hash160Ret);
+bool ExtractHash160(const CScript& scriptPubKey, const CKeyStore* pkeystore, uint160& hash160Ret);
 bool SignSignature(const CKeyStore& keystore, const CTransaction& txFrom, CTransaction& txTo, unsigned int nIn, int nHashType=SIGHASH_ALL, CScript scriptPrereq=CScript());
 bool VerifySignature(const CTransaction& txFrom, const CTransaction& txTo, unsigned int nIn, int nHashType=0);
 

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -270,7 +270,7 @@ bool CWallet::AddToWallet(const CWalletTx& wtxIn)
             if (txout.scriptPubKey == scriptDefaultKey)
             {
                 SetDefaultKey(GetOrReuseKeyFromPool());
-                SetAddressBookName(PubKeyToAddress(vchDefaultKey), "");
+                SetAddressBookName(CBitcoinAddress(vchDefaultKey), "");
             }
         }
 
@@ -406,8 +406,8 @@ int CWalletTx::GetRequestCount() const
     return nRequests;
 }
 
-void CWalletTx::GetAmounts(int64& nGeneratedImmature, int64& nGeneratedMature, list<pair<string, int64> >& listReceived,
-                           list<pair<string, int64> >& listSent, int64& nFee, string& strSentAccount) const
+void CWalletTx::GetAmounts(int64& nGeneratedImmature, int64& nGeneratedMature, list<pair<CBitcoinAddress, int64> >& listReceived,
+                           list<pair<CBitcoinAddress, int64> >& listSent, int64& nFee, string& strSentAccount) const
 {
     nGeneratedImmature = nGeneratedMature = nFee = 0;
     listReceived.clear();
@@ -435,12 +435,9 @@ void CWalletTx::GetAmounts(int64& nGeneratedImmature, int64& nGeneratedMature, l
     // but non-standard clients might (so return a list of address/amount pairs)
     BOOST_FOREACH(const CTxOut& txout, vout)
     {
-        string address;
-        uint160 hash160;
+        CBitcoinAddress address;
         vector<unsigned char> vchPubKey;
-        if (ExtractHash160(txout.scriptPubKey, pwallet, hash160))
-            address = Hash160ToAddress(hash160);
-        else
+        if (!ExtractAddress(txout.scriptPubKey, pwallet, address))
         {
             printf("CWalletTx::GetAmounts: Unknown transaction type found, txid %s\n",
                    this->GetHash().ToString().c_str());
@@ -468,25 +465,25 @@ void CWalletTx::GetAccountAmounts(const string& strAccount, int64& nGenerated, i
     int64 allGeneratedImmature, allGeneratedMature, allFee;
     allGeneratedImmature = allGeneratedMature = allFee = 0;
     string strSentAccount;
-    list<pair<string, int64> > listReceived;
-    list<pair<string, int64> > listSent;
+    list<pair<CBitcoinAddress, int64> > listReceived;
+    list<pair<CBitcoinAddress, int64> > listSent;
     GetAmounts(allGeneratedImmature, allGeneratedMature, listReceived, listSent, allFee, strSentAccount);
 
     if (strAccount == "")
         nGenerated = allGeneratedMature;
     if (strAccount == strSentAccount)
     {
-        BOOST_FOREACH(const PAIRTYPE(string,int64)& s, listSent)
+        BOOST_FOREACH(const PAIRTYPE(CBitcoinAddress,int64)& s, listSent)
             nSent += s.second;
         nFee = allFee;
     }
     CRITICAL_BLOCK(pwallet->cs_mapAddressBook)
     {
-        BOOST_FOREACH(const PAIRTYPE(string,int64)& r, listReceived)
+        BOOST_FOREACH(const PAIRTYPE(CBitcoinAddress,int64)& r, listReceived)
         {
             if (pwallet->mapAddressBook.count(r.first))
             {
-                map<string, string>::const_iterator mi = pwallet->mapAddressBook.find(r.first);
+                map<CBitcoinAddress, string>::const_iterator mi = pwallet->mapAddressBook.find(r.first);
                 if (mi != pwallet->mapAddressBook.end() && (*mi).second == strAccount)
                     nReceived += r.second;
             }
@@ -955,7 +952,7 @@ bool CWallet::CreateTransaction(const vector<pair<CScript, int64> >& vecSend, CW
 
                     // Fill a vout to ourself, using same address type as the payment
                     CScript scriptChange;
-                    if (vecSend[0].first.GetBitcoinAddressHash160() != 0)
+                    if (vecSend[0].first.GetBitcoinAddress().IsValid())
                         scriptChange.SetBitcoinAddress(vchPubKey);
                     else
                         scriptChange << vchPubKey << OP_CHECKSIG;
@@ -1104,7 +1101,7 @@ string CWallet::SendMoney(CScript scriptPubKey, int64 nValue, CWalletTx& wtxNew,
 
 
 // requires cs_main lock
-string CWallet::SendMoneyToBitcoinAddress(string strAddress, int64 nValue, CWalletTx& wtxNew, bool fAskFee)
+string CWallet::SendMoneyToBitcoinAddress(const CBitcoinAddress& address, int64 nValue, CWalletTx& wtxNew, bool fAskFee)
 {
     // Check amount
     if (nValue <= 0)
@@ -1114,8 +1111,7 @@ string CWallet::SendMoneyToBitcoinAddress(string strAddress, int64 nValue, CWall
 
     // Parse bitcoin address
     CScript scriptPubKey;
-    if (!scriptPubKey.SetBitcoinAddress(strAddress))
-        return _("Invalid bitcoin address");
+    scriptPubKey.SetBitcoinAddress(address);
 
     return SendMoney(scriptPubKey, nValue, wtxNew, fAskFee);
 }
@@ -1139,7 +1135,7 @@ int CWallet::LoadWallet(bool& fFirstRunRet)
         RandAddSeedPerfmon();
 
         SetDefaultKey(GetOrReuseKeyFromPool());
-        if (!SetAddressBookName(PubKeyToAddress(vchDefaultKey), ""))
+        if (!SetAddressBookName(CBitcoinAddress(vchDefaultKey), ""))
             return DB_LOAD_FAIL;
     }
 
@@ -1148,20 +1144,20 @@ int CWallet::LoadWallet(bool& fFirstRunRet)
 }
 
 
-bool CWallet::SetAddressBookName(const string& strAddress, const string& strName)
+bool CWallet::SetAddressBookName(const CBitcoinAddress& address, const string& strName)
 {
-    mapAddressBook[strAddress] = strName;
+    mapAddressBook[address] = strName;
     if (!fFileBacked)
         return false;
-    return CWalletDB(strWalletFile).WriteName(strAddress, strName);
+    return CWalletDB(strWalletFile).WriteName(address.ToString(), strName);
 }
 
-bool CWallet::DelAddressBookName(const string& strAddress)
+bool CWallet::DelAddressBookName(const CBitcoinAddress& address)
 {
-    mapAddressBook.erase(strAddress);
+    mapAddressBook.erase(address);
     if (!fFileBacked)
         return false;
-    return CWalletDB(strWalletFile).EraseName(strAddress);
+    return CWalletDB(strWalletFile).EraseName(address.ToString());
 }
 
 

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -104,10 +104,10 @@ public:
     }
     bool IsChange(const CTxOut& txout) const
     {
-        std::vector<unsigned char> vchPubKey;
-        if (ExtractPubKey(txout.scriptPubKey, this, vchPubKey))
+        uint160 hash160;
+        if (ExtractHash160(txout.scriptPubKey, this, hash160))
             CRITICAL_BLOCK(cs_mapAddressBook)
-                if (!mapAddressBook.count(PubKeyToAddress(vchPubKey)))
+                if (!mapAddressBook.count(Hash160ToAddress(hash160)))
                     return true;
         return false;
     }

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -53,7 +53,7 @@ public:
     std::map<uint256, int> mapRequestCount;
     mutable CCriticalSection cs_mapRequestCount;
 
-    std::map<std::string, std::string> mapAddressBook;
+    std::map<CBitcoinAddress, std::string> mapAddressBook;
     mutable CCriticalSection cs_mapAddressBook;
 
     std::vector<unsigned char> vchDefaultKey;
@@ -81,7 +81,7 @@ public:
     bool CommitTransaction(CWalletTx& wtxNew, CReserveKey& reservekey);
     bool BroadcastTransaction(CWalletTx& wtxNew);
     std::string SendMoney(CScript scriptPubKey, int64 nValue, CWalletTx& wtxNew, bool fAskFee=false);
-    std::string SendMoneyToBitcoinAddress(std::string strAddress, int64 nValue, CWalletTx& wtxNew, bool fAskFee=false);
+    std::string SendMoneyToBitcoinAddress(const CBitcoinAddress& address, int64 nValue, CWalletTx& wtxNew, bool fAskFee=false);
 
     bool TopUpKeyPool();
     void ReserveKeyFromKeyPool(int64& nIndex, CKeyPool& keypool);
@@ -104,10 +104,10 @@ public:
     }
     bool IsChange(const CTxOut& txout) const
     {
-        uint160 hash160;
-        if (ExtractHash160(txout.scriptPubKey, this, hash160))
+        CBitcoinAddress address;
+        if (ExtractAddress(txout.scriptPubKey, this, address))
             CRITICAL_BLOCK(cs_mapAddressBook)
-                if (!mapAddressBook.count(Hash160ToAddress(hash160)))
+                if (!mapAddressBook.count(address))
                     return true;
         return false;
     }
@@ -171,10 +171,10 @@ public:
 //    bool BackupWallet(const std::string& strDest);
 
     // requires cs_mapAddressBook lock
-    bool SetAddressBookName(const std::string& strAddress, const std::string& strName);
+    bool SetAddressBookName(const CBitcoinAddress& address, const std::string& strName);
 
     // requires cs_mapAddressBook lock
-    bool DelAddressBookName(const std::string& strAddress);
+    bool DelAddressBookName(const CBitcoinAddress& address);
 
     void UpdatedTransaction(const uint256 &hashTx)
     {
@@ -464,8 +464,8 @@ public:
         return nChangeCached;
     }
 
-    void GetAmounts(int64& nGeneratedImmature, int64& nGeneratedMature, std::list<std::pair<std::string /* address */, int64> >& listReceived,
-                    std::list<std::pair<std::string /* address */, int64> >& listSent, int64& nFee, std::string& strSentAccount) const;
+    void GetAmounts(int64& nGeneratedImmature, int64& nGeneratedMature, std::list<std::pair<CBitcoinAddress, int64> >& listReceived,
+                    std::list<std::pair<CBitcoinAddress, int64> >& listSent, int64& nFee, std::string& strSentAccount) const;
 
     void GetAccountAmounts(const std::string& strAccount, int64& nGenerated, int64& nReceived, 
                            int64& nSent, int64& nFee) const;


### PR DESCRIPTION
Three commits:
- The first one gets rid of the global 'mapPubKeys', by indexing keys by address instead of by pubkey. This brings a consistent interface to CKeyStore, and testing for ownership of a key becomes a call to CKeyStore::HaveKey(), instead of doing a lookup in mapPubKeys.
- The second one introduces the class CBitcoinAddress - represented by its raw data bytes (20 bytes containing the Hash160 of the pubkey), but convertible to string representation. In most places in the code, the use of a strAddress or hash160 as address identifier is replaced with CBitcoinAddress. (CAddress already existed, so I needed another name)
- The third one splits code not specifically related to addresses into a common CBase58Data
