### PR TITLE
Bugfix: add autogenerated addresses to address book

### DIFF
--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -268,7 +268,10 @@ bool CWallet::AddToWallet(const CWalletTx& wtxIn)
         BOOST_FOREACH(const CTxOut& txout, wtx.vout)
         {
             if (txout.scriptPubKey == scriptDefaultKey)
+            {
                 SetDefaultKey(GetOrReuseKeyFromPool());
+                SetAddressBookName(PubKeyToAddress(vchDefaultKey), "");
+            }
         }
 
         // Notify UI


### PR DESCRIPTION
This was a bug, as it was changed unintentionally. I'm not sure it's such a bad idea though, as autogenerated addresses seem to clutter the address book for many. Maybe a "add current default address to wallet" button would be more useful than auto-adding?
