### PR TITLE
Show the receiving address for generation transactions

### DIFF
--- a/src/rpc.cpp
+++ b/src/rpc.cpp
@@ -704,11 +704,15 @@ Value getbalance(const Array& params, bool fHelp)
             list<pair<string, int64> > listReceived;
             list<pair<string, int64> > listSent;
             wtx.GetAmounts(allGeneratedImmature, allGeneratedMature, listReceived, listSent, allFee, strSentAccount);
-            if (wtx.GetDepthInMainChain() >= nMinDepth)
-                BOOST_FOREACH(const PAIRTYPE(string,int64)& r, listReceived)
-                    nBalance += r.second;
-            BOOST_FOREACH(const PAIRTYPE(string,int64)& r, listSent)
-                nBalance -= r.second;
+            if (!wtx.IsCoinBase())
+            {
+                if (wtx.GetDepthInMainChain() >= nMinDepth)
+                    BOOST_FOREACH(const PAIRTYPE(string,int64)& r, listReceived)
+                        nBalance += r.second;
+                BOOST_FOREACH(const PAIRTYPE(string,int64)& r, listSent)
+                    nBalance -= r.second;
+            }
+
             nBalance -= allFee;
             nBalance += allGeneratedMature;
         }
@@ -1033,6 +1037,7 @@ void ListTransactions(const CWalletTx& wtx, const string& strAccount, int nMinDe
     {
         Object entry;
         entry.push_back(Pair("account", string("")));
+        entry.push_back(Pair("address", listReceived.front().first));
         if (nGeneratedImmature)
         {
             entry.push_back(Pair("category", wtx.GetDepthInMainChain() ? "immature" : "orphan"));
@@ -1046,6 +1051,8 @@ void ListTransactions(const CWalletTx& wtx, const string& strAccount, int nMinDe
         if (fLong)
             WalletTxToJSON(wtx, entry);
         ret.push_back(entry);
+
+        return;
     }
 
     // Sent
@@ -1209,11 +1216,15 @@ Value listaccounts(const Array& params, bool fHelp)
             if (wtx.GetDepthInMainChain() >= nMinDepth)
             {
                 mapAccountBalances[""] += nGeneratedMature;
-                BOOST_FOREACH(const PAIRTYPE(string, int64)& r, listReceived)
-                    if (pwalletMain->mapAddressBook.count(r.first))
-                        mapAccountBalances[pwalletMain->mapAddressBook[r.first]] += r.second;
-                    else
-                        mapAccountBalances[""] += r.second;
+
+                if (!wtx.IsCoinBase())
+                {
+                    BOOST_FOREACH(const PAIRTYPE(string, int64)& r, listReceived)
+                        if (pwalletMain->mapAddressBook.count(r.first))
+                            mapAccountBalances[pwalletMain->mapAddressBook[r.first]] += r.second;
+                        else
+                            mapAccountBalances[""] += r.second;
+                }
             }
         }
     }

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -247,7 +247,6 @@ void CWalletTx::GetAmounts(int64& nGeneratedImmature, int64& nGeneratedMature, l
             nGeneratedImmature = pwallet->GetCredit(*this);
         else
             nGeneratedMature = GetCredit();
-        return;
     }
 
     // Compute fee:
@@ -309,6 +308,8 @@ void CWalletTx::GetAccountAmounts(const string& strAccount, int64& nGenerated, i
             nSent += s.second;
         nFee = allFee;
     }
+
+    if (!IsCoinBase())
     CRITICAL_BLOCK(pwallet->cs_mapAddressBook)
     {
         BOOST_FOREACH(const PAIRTYPE(string,int64)& r, listReceived)


### PR DESCRIPTION
As has been requested by a few people, here is a patch that shows the address coins were generated to in transaction dumps (listtransaction, etc).
