### PR TITLE
IPv6 support

### DIFF
--- a/src/db.cpp
+++ b/src/db.cpp
@@ -710,7 +710,7 @@ int CWalletDB::LoadWallet(CWallet* pwallet)
             {
                 string strAddress;
                 ssKey >> strAddress;
-                ssValue >> pwallet->mapAddressBook[strAddress];
+                ssValue >> pwallet->mapAddressBook[CBitcoinAddress(strAddress)];
             }
             else if (strType == "tx")
             {

--- a/src/headers.h
+++ b/src/headers.h
@@ -11,7 +11,7 @@
 #ifdef _WIN32_WINNT
 #undef _WIN32_WINNT
 #endif
-#define _WIN32_WINNT 0x0500
+#define _WIN32_WINNT 0x0501
 #ifdef _WIN32_IE
 #undef _WIN32_IE
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1835,9 +1835,10 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
         if (!pfrom->fInbound)
         {
             // Advertise our address
-            if (addrLocalHost.IsRoutable() && !fUseProxy)
+            const CAddress *paddrLocal = GetLocalAddress(pfrom->addr);
+            if (paddrLocal && !fUseProxy)
             {
-                CAddress addr(addrLocalHost);
+                CAddress addr(*paddrLocal);
                 addr.nTime = GetAdjustedTime();
                 pfrom->PushAddress(addr);
             }
@@ -2400,9 +2401,10 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
                     pnode->setAddrKnown.clear();
 
                     // Rebroadcast our address
-                    if (addrLocalHost.IsRoutable() && !fUseProxy)
+                    const CAddress *paddrLocal = GetLocalAddress(pnode->addr);
+                    if (paddrLocal && !fUseProxy)
                     {
-                        CAddress addr(addrLocalHost);
+                        CAddress addr(*paddrLocal);
                         addr.nTime = GetAdjustedTime();
                         pnode->PushAddress(addr);
                     }

--- a/src/makefile.unix
+++ b/src/makefile.unix
@@ -10,7 +10,7 @@ WXLIBS=$(shell wx-config --libs)
 
 USE_UPNP:=0
 
-DEFS=-DNOPCH -DFOURWAYSSE2 -DUSE_SSL
+DEFS=-DNOPCH -DFOURWAYSSE2 -DUSE_SSL -DUSE_IPV6
 
 # for boost 1.37, add -mt to the boost libraries
 LIBS= \

--- a/src/script.cpp
+++ b/src/script.cpp
@@ -1141,7 +1141,6 @@ bool static ExtractAddressInner(const CScript& scriptPubKey, const CKeyStore* ke
     return false;
 }
 
-
 bool ExtractAddress(const CScript& scriptPubKey, const CKeyStore* keystore, CBitcoinAddress& addressRet)
 {
     if (keystore)

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -1935,12 +1935,12 @@ CAddress COptionsDialog::GetProxyAddr()
 {
     // Be careful about byte order, addr.ip and addr.port are big endian
     CAddress addr(m_textCtrlProxyIP->GetValue() + ":" + m_textCtrlProxyPort->GetValue());
-    if (addr.ip == INADDR_NONE)
-        addr.ip = addrProxy.ip;
+    if (!addr.IsValid())
+        addr = addrProxy;
     int nPort = atoi(m_textCtrlProxyPort->GetValue());
-    addr.port = htons(nPort);
+    addr.SetPort(nPort);
     if (nPort <= 0 || nPort > USHRT_MAX)
-        addr.port = addrProxy.port;
+        addr.SetPort(addrProxy.GetPort());
     return addr;
 }
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -826,13 +826,13 @@ int64 GetAdjustedTime()
     return GetTime() + nTimeOffset;
 }
 
-void AddTimeData(unsigned int ip, int64 nTime)
+void AddTimeData(const vector<unsigned char>& vchIp, int64 nTime)
 {
     int64 nOffsetSample = nTime - GetTime();
 
     // Ignore duplicates
-    static set<unsigned int> setKnown;
-    if (!setKnown.insert(ip).second)
+    static set<vector<unsigned char> > setKnown;
+    if (!setKnown.insert(vchIp).second)
         return;
 
     // Add data

--- a/src/util.h
+++ b/src/util.h
@@ -207,7 +207,7 @@ int GetRandInt(int nMax);
 uint64 GetRand(uint64 nMax);
 int64 GetTime();
 int64 GetAdjustedTime();
-void AddTimeData(unsigned int ip, int64 nTime);
+void AddTimeData(const std::vector<unsigned char> &vchIp, int64 nTime);
 std::string FormatFullVersion();
 
 


### PR DESCRIPTION
This commit introduces IPv6 support (selectable at compile time),

General changes (even when IPv6 support is not compiled in):
- Valid, routable IPv6 addresses are stored and forwarded
- Name lookups are done using the general getaddrinfo() call
- The detection system for the local address is improved. (addresses are classified according to their 'reachability', and the most reachable local address encountered is used).
- The rule that no two connections to addresses within the same /16 should be attempted, was generalized by defining address groups:
  - IPv4 addresses are grouped in /16 blocks
  - IPv6 addresses are grouped in /32 blocks
  - Tunneled IPv6 addresses use the encapsulated IPv4 address (teredo, 6to4, SIIT, well-known prefix)
- Hostnames can be given using the "[host]:port" format.
- Support for the "checkorder" message was removed (obsolete, and not worth porting)

Behaviour changes when IPv6 support is enabled:
- DNS lookups also return IPv6 matches
- The listening socket is bound to the IPv6 ANY address (::/128) instead of the IPv4 ANY address (0.0.0.0)
- Connections to non-IPv4 addresses are attempted, using IPv6 sockets (connections to IPv4 addresses still use IPv4 sockets)
- A local IPv6 address is used instead of an IPv4 one if no routable IPv4 address is available. In this case, it is not advertized through IRC (obsolete).

For internal changes, see the commit message.

Possible future improvements:
- Some pruning/ageing of addr.dat 
- Cmdline/config options to modify IPv6 behaviour (eg. IPv6-only connection slots, preference for IPv6 connections, ...)
- Intelligent choice of nodes to download initial chain from (avoid Teredo tunnels eg.)
