### PR TITLE
make SetHash160 return a value (as specified in the function signature)

### DIFF
--- a/src/base58.h
+++ b/src/base58.h
@@ -244,6 +244,7 @@ public:
     bool SetHash160(const uint160& hash160)
     {
         SetData(fTestNet ? 111 : 0, &hash160, 20);
+        return true;
     }
 
     bool SetPubKey(const std::vector<unsigned char>& vchPubKey)


### PR DESCRIPTION
trivial fix for function that must return a success value but doesn't
