### PR TITLE
Bugfix: don't overuse limited ExtractAddress

### DIFF
--- a/src/script.cpp
+++ b/src/script.cpp
@@ -1122,26 +1122,33 @@ bool IsMine(const CKeyStore &keystore, const CScript& scriptPubKey)
     return true;
 }
 
-
-bool ExtractAddress(const CScript& scriptPubKey, const CKeyStore* keystore, CBitcoinAddress& addressRet)
+// requires either keystore==0, or a lock on keystore->cs_KeyStore
+bool static ExtractAddressInner(const CScript& scriptPubKey, const CKeyStore* keystore, CBitcoinAddress& addressRet)
 {
     vector<pair<opcodetype, valtype> > vSolution;
     if (!Solver(scriptPubKey, vSolution))
         return false;
 
-    CRITICAL_BLOCK(keystore->cs_KeyStore)
+    BOOST_FOREACH(PAIRTYPE(opcodetype, valtype)& item, vSolution)
     {
-        BOOST_FOREACH(PAIRTYPE(opcodetype, valtype)& item, vSolution)
-        {
-            uint160 hash160;
-            if (item.first == OP_PUBKEY)
-                addressRet.SetPubKey(item.second);
-            else if (item.first == OP_PUBKEYHASH)
-                addressRet.SetHash160((uint160)item.second);
-            if (keystore == NULL || keystore->HaveKey(addressRet))
-                return true;
-        }
+        if (item.first == OP_PUBKEY)
+            addressRet.SetPubKey(item.second);
+        else if (item.first == OP_PUBKEYHASH)
+            addressRet.SetHash160((uint160)item.second);
+        if (keystore == NULL || keystore->HaveKey(addressRet))
+            return true;
     }
+    return false;
+}
+
+
+bool ExtractAddress(const CScript& scriptPubKey, const CKeyStore* keystore, CBitcoinAddress& addressRet)
+{
+    if (keystore)
+        CRITICAL_BLOCK(keystore->cs_KeyStore)
+            return ExtractAddressInner(scriptPubKey, keystore, addressRet);
+    else
+        return ExtractAddressInner(scriptPubKey, NULL, addressRet);
     return false;
 }
 

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -776,6 +776,7 @@ bool CMainFrame::InsertTransaction(const CWalletTx& wtx, bool fNew, int nIndex)
                 if (pwalletMain->IsMine(txout))
                     continue;
 
+                CBitcoinAddress address;
                 string strAddress;
                 if (!mapValue["to"].empty())
                 {
@@ -785,15 +786,14 @@ bool CMainFrame::InsertTransaction(const CWalletTx& wtx, bool fNew, int nIndex)
                 else
                 {
                     // Sent to Bitcoin Address
-                    CBitcoinAddress address;
-                    if (ExtractAddress(txout.scriptPubKey, pwalletMain, address))
+                    if (ExtractAddress(txout.scriptPubKey, NULL, address))
                         strAddress = address.ToString();
                 }
 
                 string strDescription = _("To: ");
                 CRITICAL_BLOCK(pwalletMain->cs_mapAddressBook)
-                    if (pwalletMain->mapAddressBook.count(strAddress) && !pwalletMain->mapAddressBook[strAddress].empty())
-                        strDescription += pwalletMain->mapAddressBook[strAddress] + " ";
+                    if (pwalletMain->mapAddressBook.count(address) && !pwalletMain->mapAddressBook[address].empty())
+                        strDescription += pwalletMain->mapAddressBook[address] + " ";
                 strDescription += strAddress;
                 if (!mapValue["message"].empty())
                 {

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -437,7 +437,7 @@ void CWalletTx::GetAmounts(int64& nGeneratedImmature, int64& nGeneratedMature, l
     {
         CBitcoinAddress address;
         vector<unsigned char> vchPubKey;
-        if (!ExtractAddress(txout.scriptPubKey, pwallet, address))
+        if (!ExtractAddress(txout.scriptPubKey, NULL, address))
         {
             printf("CWalletTx::GetAmounts: Unknown transaction type found, txid %s\n",
                    this->GetHash().ToString().c_str());


### PR DESCRIPTION
ExtractAddress was called with the keystore as argument in RPC and
UI, limiting results to own keys. This caused empty "address"
fields.
