### PR TITLE
Comment "deprecated"

### DIFF
--- a/src/rpc.cpp
+++ b/src/rpc.cpp
@@ -1742,7 +1742,7 @@ string pAllowInSafeMode[] =
     "getinfo",
     "getnewaddress",
     "getaccountaddress",
-    "setlabel",
+    "setlabel", // deprecated
     "getaccount",
     "getlabel", // deprecated
     "getaddressesbyaccount",
@@ -2373,7 +2373,7 @@ int CommandLineRPC(int argc, char *argv[])
         if (strMethod == "getreceivedbyaccount"   && n > 1) ConvertTo<boost::int64_t>(params[1]);
         if (strMethod == "getreceivedbylabel"     && n > 1) ConvertTo<boost::int64_t>(params[1]); // deprecated
         if (strMethod == "getallreceived"         && n > 0) ConvertTo<boost::int64_t>(params[0]); // deprecated
-        if (strMethod == "getallreceived"         && n > 1) ConvertTo<bool>(params[1]);
+        if (strMethod == "getallreceived"         && n > 1) ConvertTo<bool>(params[1]); // deprecated
         if (strMethod == "listreceivedbyaddress"  && n > 0) ConvertTo<boost::int64_t>(params[0]);
         if (strMethod == "listreceivedbyaddress"  && n > 1) ConvertTo<bool>(params[1]);
         if (strMethod == "listreceivedbyaccount"  && n > 0) ConvertTo<boost::int64_t>(params[0]);


### PR DESCRIPTION
I assume these should be commented deprecated because this is commented deprecated https://github.com/bitcoin/bitcoin/blob/e1f13129e89f46df631f9523eea4c0e0448c9b7b/src/rpc.cpp#L1698
