### PR TITLE
Identify as "Bitcoin + version number" when mapping UPnP port

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1092,13 +1092,14 @@ void ThreadMapPort2(void* parg)
     {
         char intClient[16];
         char intPort[6];
+        string strDesc = "Bitcoin " + FormatFullVersion();
 
 #ifndef __WXMSW__
         r = UPNP_AddPortMapping(urls.controlURL, data.first.servicetype,
-	                        port, port, lanaddr, 0, "TCP", 0);
+	                        port, port, lanaddr, strDesc.c_str(), "TCP", 0);
 #else
         r = UPNP_AddPortMapping(urls.controlURL, data.first.servicetype,
-	                        port, port, lanaddr, 0, "TCP", 0, "0");
+	                        port, port, lanaddr, strDesc.c_str(), "TCP", 0, "0");
 #endif
         if(r!=UPNPCOMMAND_SUCCESS)
             printf("AddPortMapping(%s, %s, %s) failed with code %d (%s)\n",


### PR DESCRIPTION
Makes Bitcoin identify itself as "Bitcoin + version number" instead of the nondescript "libminiupnpc" when forwarding a port via UPnP.

A lot of home routers show this information in their web interface, e.g. DD-WRT: http://dl.dropbox.com/u/6457172/upnp.png
