### PR TITLE
Use 'unsigned char' rather than 'char' for pchMessageStart.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1766,7 +1766,7 @@ bool static AlreadyHave(CTxDB& txdb, const CInv& inv)
 // The message start string is designed to be unlikely to occur in normal data.
 // The characters are rarely used upper ascii, not valid as UTF-8, and produce
 // a large 4-byte int at any alignment.
-char pchMessageStart[4] = { 0xf9, 0xbe, 0xb4, 0xd9 };
+unsigned char pchMessageStart[4] = { 0xf9, 0xbe, 0xb4, 0xd9 };
 
 
 bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)

--- a/src/net.h
+++ b/src/net.h
@@ -66,7 +66,7 @@ bool StopNode();
 //  (4) size
 //  (4) checksum
 
-extern char pchMessageStart[4];
+extern unsigned char pchMessageStart[4];
 
 class CMessageHeader
 {


### PR DESCRIPTION
Regarding https://bitcointalk.org/index.php?topic=28022.0

main.cpp has: "char pchMessageStart[4] = { 0xf9, 0xbe, 0xb4, 0xd9 };"
Per discussion on the thread linked, leaving the signedness of
pchMessageStart is unsafe for values > 0x80. This patch specifies
'unsigned char' in main.cpp and net.h.
