### PR TITLE
Properly work with USE_UPNP from makefiles

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -181,12 +181,10 @@ bool AppInit2(int argc, char* argv[])
             "  -nolisten        \t  "   + _("Don't accept connections from outside\n") +
             "  -banscore=<n>    \t  "   + _("Threshold for disconnecting misbehaving peers (default: 100)\n") +
             "  -bantime=<n>     \t  "   + _("Number of seconds to keep misbehaving peers from reconnecting (default: 86400)\n") +
-#ifdef USE_UPNP
 #if USE_UPNP
             "  -noupnp          \t  "   + _("Don't attempt to use UPnP to map the listening port\n") +
 #else
             "  -upnp            \t  "   + _("Attempt to use UPnP to map the listening port\n") +
-#endif
 #endif
             "  -paytxfee=<amt>  \t  "   + _("Fee per KB to add to transactions you send\n") +
 #ifdef GUI

--- a/src/main.h
+++ b/src/main.h
@@ -39,7 +39,7 @@ inline bool MoneyRange(int64 nValue) { return (nValue >= 0 && nValue <= MAX_MONE
 static const int COINBASE_MATURITY = 100;
 // Threshold for nLockTime: below this value it is interpreted as block number, otherwise as UNIX timestamp.
 static const int LOCKTIME_THRESHOLD = 500000000; // Tue Nov  5 00:53:20 1985 UTC
-#ifdef USE_UPNP
+#if USE_UPNP
 static const int fHaveUPnP = true;
 #else
 static const int fHaveUPnP = false;

--- a/src/makefile.linux-mingw
+++ b/src/makefile.linux-mingw
@@ -51,7 +51,7 @@ HEADERS = \
     util.h \
     wallet.h
 
-ifdef USE_UPNP
+ifneq (USE_UPNP,0)
 	LIBPATHS += -L"$(DEPSDIR)/miniupnpc"
 	LIBS += -l miniupnpc -l iphlpapi
 	DEFS += -DSTATICLIB -DUSE_UPNP=$(USE_UPNP)

--- a/src/makefile.mingw
+++ b/src/makefile.mingw
@@ -48,7 +48,7 @@ HEADERS = \
     util.h \
     wallet.h
 
-ifdef USE_UPNP
+ifneq (USE_UPNP,0)
  INCLUDEPATHS += -I"C:\miniupnpc-1.6-mgw"
  LIBPATHS += -L"C:\miniupnpc-1.6-mgw"
  LIBS += -l miniupnpc -l iphlpapi

--- a/src/makefile.osx
+++ b/src/makefile.osx
@@ -68,7 +68,7 @@ OBJS= \
     cryptopp/obj/sha.o \
     cryptopp/obj/cpu.o
 
-ifdef USE_UPNP
+ifneq (USE_UPNP,0)
 	LIBS += $(DEPSDIR)/lib/libminiupnpc.a
 	DEFS += -DUSE_UPNP=$(USE_UPNP)
 endif

--- a/src/makefile.unix
+++ b/src/makefile.unix
@@ -19,7 +19,7 @@ LIBS= \
    -l ssl \
    -l crypto
 
-ifdef USE_UPNP
+ifneq (USE_UPNP,0)
 	LIBS += -l miniupnpc
 	DEFS += -DUSE_UPNP=$(USE_UPNP)
 endif

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -14,7 +14,7 @@
 #include <string.h>
 #endif
 
-#ifdef USE_UPNP
+#if USE_UPNP
 #include <miniupnpc/miniwget.h>
 #include <miniupnpc/miniupnpc.h>
 #include <miniupnpc/upnpcommands.h>
@@ -29,7 +29,7 @@ static const int MAX_OUTBOUND_CONNECTIONS = 8;
 void ThreadMessageHandler2(void* parg);
 void ThreadSocketHandler2(void* parg);
 void ThreadOpenConnections2(void* parg);
-#ifdef USE_UPNP
+#if USE_UPNP
 void ThreadMapPort2(void* parg);
 #endif
 bool OpenNetworkConnection(const CAddress& addrConnect);
@@ -1101,7 +1101,7 @@ void ThreadSocketHandler2(void* parg)
 
 
 
-#ifdef USE_UPNP
+#if USE_UPNP
 void ThreadMapPort(void* parg)
 {
     IMPLEMENT_RANDOMIZE_STACK(ThreadMapPort(parg));
@@ -1786,7 +1786,7 @@ bool StopNode()
     nTransactionsUpdated++;
     int64 nStart = GetTime();
     while (vnThreadsRunning[0] > 0 || vnThreadsRunning[2] > 0 || vnThreadsRunning[3] > 0 || vnThreadsRunning[4] > 0
-#ifdef USE_UPNP
+#if USE_UPNP
         || vnThreadsRunning[5] > 0
 #endif
     )


### PR DESCRIPTION
Use "#if USE_UPNP" instead of "#ifdef USE_UPNP" to work properly with the makefiles

Additionally, don't try to link with libminiupnc when USE_UPNP=0.

Signed-off-by: Giel van Schijndel me@mortis.eu
