### PR TITLE
Logic running with -keypool=0 was wrong (empty keys were being returned).

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2183,7 +2183,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
 
         // Keep giving the same key to the same ip until they use it
         if (!mapReuseKey.count(pfrom->addr.ip))
-            mapReuseKey[pfrom->addr.ip] = pwalletMain->GetOrReuseKeyFromPool();
+            pwalletMain->GetKeyFromPool(mapReuseKey[pfrom->addr.ip], true);
 
         // Send back approval of order and pubkey to use
         CScript scriptPubKey;

--- a/src/rpc.cpp
+++ b/src/rpc.cpp
@@ -382,7 +382,7 @@ CBitcoinAddress GetAccountAddress(string strAccount, bool bForceNew=false)
         if (pwalletMain->GetKeyPoolSize() < 1)
         {
             if (!pwalletMain->GetKeyFromPool(account.vchPubKey, false))
-                throw JSONRPCError(-12, "Error: Keypool ran out, please call topupkeypool first");
+                throw JSONRPCError(-12, "Error: Keypool ran out, please call keypoolrefill first");
 
             pwalletMain->SetAddressBookName(CBitcoinAddress(account.vchPubKey), strAccount);
             walletdb.WriteAccount(strAccount, account);

--- a/src/rpc.cpp
+++ b/src/rpc.cpp
@@ -331,21 +331,20 @@ Value getnewaddress(const Array& params, bool fHelp)
             "If [account] is specified (recommended), it is added to the address book "
             "so payments received with the address will be credited to [account].");
 
-    if (!pwalletMain->IsLocked())
-        pwalletMain->TopUpKeyPool();
-
-    if (pwalletMain->GetKeyPoolSize() < 1)
-        throw JSONRPCError(-12, "Error: Keypool ran out, please call keypoolrefill first");
-
     // Parse the account first so we don't generate a key if there's an error
     string strAccount;
     if (params.size() > 0)
         strAccount = AccountFromValue(params[0]);
 
-    // Generate a new key that is added to wallet
-    CBitcoinAddress address(pwalletMain->GetOrReuseKeyFromPool());
+    if (!pwalletMain->IsLocked())
+        pwalletMain->TopUpKeyPool();
 
-    // This could be done in the same main CS as GetKeyFromKeyPool.
+    // Generate a new key that is added to wallet
+    std::vector<unsigned char> newKey;
+    if (!pwalletMain->GetKeyFromPool(newKey, false))
+        throw JSONRPCError(-12, "Error: Keypool ran out, please call keypoolrefill first");
+    CBitcoinAddress address(newKey);
+
     pwalletMain->SetAddressBookName(address, strAccount);
 
     return address.ToString();
@@ -382,12 +381,9 @@ CBitcoinAddress GetAccountAddress(string strAccount, bool bForceNew=false)
     {
         if (pwalletMain->GetKeyPoolSize() < 1)
         {
-            if (bKeyUsed || bForceNew)
+            if (!pwalletMain->GetKeyFromPool(account.vchPubKey, false))
                 throw JSONRPCError(-12, "Error: Keypool ran out, please call topupkeypool first");
-        }
-        else
-        {
-            account.vchPubKey = pwalletMain->GetOrReuseKeyFromPool();
+
             pwalletMain->SetAddressBookName(CBitcoinAddress(account.vchPubKey), strAccount);
             walletdb.WriteAccount(strAccount, account);
         }

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -1391,7 +1391,9 @@ void CMainFrame::OnButtonNew(wxCommandEvent& event)
         return;
 
     // Generate new key
-    strAddress = CBitcoinAddress(pwalletMain->GetOrReuseKeyFromPool()).ToString();
+    std::vector<unsigned char> newKey;
+    pwalletMain->GetKeyFromPool(newKey, true);
+    strAddress = CBitcoinAddress(newKey).ToString();
 
     if (fWasLocked)
         pwalletMain->Lock();
@@ -2826,7 +2828,9 @@ void CAddressBookDialog::OnButtonNew(wxCommandEvent& event)
             return;
 
         // Generate new key
-        strAddress = CBitcoinAddress(pwalletMain->GetOrReuseKeyFromPool()).ToString();
+        std::vector<unsigned char> newKey;
+        pwalletMain->GetKeyFromPool(newKey, true);
+        strAddress = CBitcoinAddress(newKey).ToString();
 
         if (fWasLocked)
             pwalletMain->Lock();

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -85,7 +85,7 @@ public:
     void ReserveKeyFromKeyPool(int64& nIndex, CKeyPool& keypool);
     void KeepKey(int64 nIndex);
     void ReturnKey(int64 nIndex);
-    std::vector<unsigned char> GetOrReuseKeyFromPool();
+    bool GetKeyFromPool(std::vector<unsigned char> &key, bool fAllowReuse=true);
     int64 GetOldestKeyPoolTime();
 
     bool IsMine(const CTxIn& txin) const;


### PR DESCRIPTION
Logic running with -keypool=0 was wrong (empty keys were being returned). Fixes #445

sipa, Matt: can you sanity check this?  I did some quick testing with/without wallet encryption, running with -keypool=0.

Logic is:  GetOrReuseKey method should never return empty key.

And GetAccountAddress should always complain if GetOrReuseKey has to reuse (== return the default key).
