### PR TITLE
Support for boost filesystem version 3

### DIFF
--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -1805,7 +1805,11 @@ void SetStartOnSystemStartup(bool fAutoStart)
 {
     if (!fAutoStart)
     {
+#if defined(BOOST_FILESYSTEM_VERSION) && BOOST_FILESYSTEM_VERSION >= 3
+        unlink(GetAutostartFilePath().string().c_str());
+#else
         unlink(GetAutostartFilePath().native_file_string().c_str());
+#endif
     }
     else
     {


### PR DESCRIPTION
I have tested this with Ubuntu 11.04 and it repairs the wx build bug: https://github.com/bitcoin/bitcoin/issues/489

Thanks luke-jr!
