### PR TITLE
Removed alert system from main.cpp

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2219,22 +2219,6 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
     }
 
 
-    else if (strCommand == "alert")
-    {
-        CAlert alert;
-        vRecv >> alert;
-
-        if (alert.ProcessAlert())
-        {
-            // Relay
-            pfrom->setKnown.insert(alert.GetHash());
-            CRITICAL_BLOCK(cs_vNodes)
-                BOOST_FOREACH(CNode* pnode, vNodes)
-                    alert.RelayTo(pnode);
-        }
-    }
-
-
     else
     {
         // Ignore unknown commands for extensibility


### PR DESCRIPTION
Even though it no longer triggers RPC safe mode there is some concern that it could still be misused.
Signed-off-by: David Perry enmaku@gmail.com
