### PR TITLE
log low-level network messages only when fDebug is set

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1744,9 +1744,10 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
 {
     static map<unsigned int, vector<unsigned char> > mapReuseKey;
     RandAddSeedPerfmon();
-    if (fDebug)
+    if (fDebug) {
         printf("%s ", DateTimeStrFormat("%x %H:%M:%S", GetTime()).c_str());
-    printf("received: %s (%d bytes)\n", strCommand.c_str(), vRecv.size());
+        printf("received: %s (%d bytes)\n", strCommand.c_str(), vRecv.size());
+    }
     if (mapArgs.count("-dropmessagestest") && GetRand(atoi(mapArgs["-dropmessagestest"])) == 0)
     {
         printf("dropmessagestest DROPPING RECV MESSAGE\n");
@@ -1934,7 +1935,8 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
             pfrom->AddInventoryKnown(inv);
 
             bool fAlreadyHave = AlreadyHave(txdb, inv);
-            printf("  got inventory: %s  %s\n", inv.ToString().c_str(), fAlreadyHave ? "have" : "new");
+            if (fDebug)
+                printf("  got inventory: %s  %s\n", inv.ToString().c_str(), fAlreadyHave ? "have" : "new");
 
             if (!fAlreadyHave)
                 pfrom->AskFor(inv);

--- a/src/net.h
+++ b/src/net.h
@@ -296,7 +296,9 @@ public:
         nHeaderStart = -1;
         nMessageStart = -1;
         cs_vSend.Leave();
-        printf("(aborted)\n");
+
+        if (fDebug)
+            printf("(aborted)\n");
     }
 
     void EndMessage()
@@ -326,8 +328,7 @@ public:
         }
 
         if (fDebug) {
-            printf("(%d bytes) ", nSize);
-            printf("\n");
+            printf("(%d bytes)\n", nSize);
         }
 
         nHeaderStart = -1;

--- a/src/net.h
+++ b/src/net.h
@@ -282,9 +282,10 @@ public:
         nHeaderStart = vSend.size();
         vSend << CMessageHeader(pszCommand, 0);
         nMessageStart = vSend.size();
-        if (fDebug)
+        if (fDebug) {
             printf("%s ", DateTimeStrFormat("%x %H:%M:%S", GetTime()).c_str());
-        printf("sending: %s ", pszCommand);
+            printf("sending: %s ", pszCommand);
+        }
     }
 
     void AbortMessage()
@@ -324,8 +325,10 @@ public:
             memcpy((char*)&vSend[nHeaderStart] + offsetof(CMessageHeader, nChecksum), &nChecksum, sizeof(nChecksum));
         }
 
-        printf("(%d bytes) ", nSize);
-        printf("\n");
+        if (fDebug) {
+            printf("(%d bytes) ", nSize);
+            printf("\n");
+        }
 
         nHeaderStart = -1;
         nMessageStart = -1;


### PR DESCRIPTION
This patch wraps three debug messages (`sending`, `received` and `got inventory`) in `if (fDebug) {...}`.

I analyzed `debug.log` on a few long-running bitcoin nodes and noticed > 80% of debug.log is composed of those three messages. Thus this patch should greatly reduce debug.log size and disk I/O.
- `sending` is triggered whenever a low-level message is sent (i.e. `sending: inv (37 bytes)`).
- `received` is triggered whenever a message is received (i.e. `received: inv (37 bytes)`).
- `got inventory` is triggered when an `inv``-message is received.
