### PR TITLE
SocketHandler thread can be detached

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1713,7 +1713,7 @@ void StartNode(void* parg)
         printf("Error: CreateThread(ThreadIRCSeed) failed\n");
 
     // Send and receive from sockets, accept connections
-    CreateThread(ThreadSocketHandler, NULL, true);
+    CreateThread(ThreadSocketHandler, NULL);
 
     // Initiate outbound connections
     if (!CreateThread(ThreadOpenConnections, NULL))


### PR DESCRIPTION
One small fix from #385 that wasn't merged yet.
