### PR TITLE
Denial-of-service prevention: low-difficulty blocks

### DIFF
--- a/bitcoin-qt.pro
+++ b/bitcoin-qt.pro
@@ -88,6 +88,7 @@ HEADERS += src/qt/bitcoingui.h \
     src/qt/bitcoinaddressvalidator.h \
     src/base58.h \
     src/bignum.h \
+    src/checkpoints.h \
     src/util.h \
     src/uint256.h \
     src/serialize.h \
@@ -152,6 +153,7 @@ SOURCES += src/qt/bitcoin.cpp src/qt/bitcoingui.cpp \
     src/init.cpp \
     src/net.cpp \
     src/irc.cpp \
+    src/checkpoints.cpp \
     src/db.cpp \
     src/json/json_spirit_writer.cpp \
     src/json/json_spirit_value.cpp \

--- a/src/checkpoints.cpp
+++ b/src/checkpoints.cpp
@@ -2,16 +2,23 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file license.txt or http://www.opensource.org/licenses/mit-license.php.
 
-#include "checkpoints.h"
-#include "uint256.h"
-#include "util.h"
-
 #include <boost/assign/list_of.hpp> // for 'map_list_of()'
+#include <boost/foreach.hpp>
+
+#include "headers.h"
+#include "checkpoints.h"
 
 namespace Checkpoints
 {
     typedef std::map<int, uint256> MapCheckpoints;
 
+    //
+    // What makes a good checkpoint block?
+    // + Is surrounded by blocks with reasonable timestamps
+    //   (no blocks before with a timestamp after, none after with
+    //    timestamp before)
+    // + Contains no strange transactions
+    //
     static MapCheckpoints mapCheckpoints =
         boost::assign::map_list_of
         ( 11111, uint256("0x0000000069e244f73d78e8fd29ba2fd2ed618bd6fa2ee92559f542fdb26e7c1d"))
@@ -36,8 +43,23 @@ namespace Checkpoints
 
     int GetTotalBlocksEstimate()
     {
-        if (fTestNet) return 0; // Testnet has no checkpoints
+        if (fTestNet) return 0;
 
         return mapCheckpoints.rbegin()->first;
+    }
+
+    CBlockIndex* GetLastCheckpoint(const std::map<uint256, CBlockIndex*>& mapBlockIndex)
+    {
+        if (fTestNet) return NULL;
+
+        int64 nResult;
+        BOOST_REVERSE_FOREACH(const MapCheckpoints::value_type& i, mapCheckpoints)
+        {
+            const uint256& hash = i.second;
+            std::map<uint256, CBlockIndex*>::const_iterator t = mapBlockIndex.find(hash);
+            if (t != mapBlockIndex.end())
+                return t->second;
+        }
+        return NULL;
     }
 }

--- a/src/checkpoints.cpp
+++ b/src/checkpoints.cpp
@@ -1,0 +1,43 @@
+// Copyright (c) 2011 The Bitcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file license.txt or http://www.opensource.org/licenses/mit-license.php.
+
+#include "checkpoints.h"
+#include "uint256.h"
+#include "util.h"
+
+#include <boost/assign/list_of.hpp> // for 'map_list_of()'
+
+namespace Checkpoints
+{
+    typedef std::map<int, uint256> MapCheckpoints;
+
+    static MapCheckpoints mapCheckpoints =
+        boost::assign::map_list_of
+        ( 11111, uint256("0x0000000069e244f73d78e8fd29ba2fd2ed618bd6fa2ee92559f542fdb26e7c1d"))
+        ( 33333, uint256("0x000000002dd5588a74784eaa7ab0507a18ad16a236e7b1ce69f00d7ddfb5d0a6"))
+        ( 68555, uint256("0x00000000001e1b4903550a0b96e9a9405c8a95f387162e4944e8d9fbe501cd6a"))
+        ( 70567, uint256("0x00000000006a49b14bcf27462068f1264c961f11fa2e0eddd2be0791e1d4124a"))
+        ( 74000, uint256("0x0000000000573993a3c9e41ce34471c079dcf5f52a0e824a81e7f953b8661a20"))
+        (105000, uint256("0x00000000000291ce28027faea320c8d2b054b2e0fe44a773f3eefb151d6bdc97"))
+        (118000, uint256("0x000000000000774a7f8a7a12dc906ddb9e17e75d684f15e00f8767f9e8f36553"))
+        (134444, uint256("0x00000000000005b12ffd4cd315cd34ffd4a594f430ac814c91184a0d42d2b0fe"))
+        (140700, uint256("0x000000000000033b512028abb90e1626d8b346fd0ed598ac0a3c371138dce2bd"))
+        ;
+
+    bool CheckBlock(int nHeight, const uint256& hash)
+    {
+        if (fTestNet) return true; // Testnet has no checkpoints
+
+        MapCheckpoints::const_iterator i = mapCheckpoints.find(nHeight);
+        if (i == mapCheckpoints.end()) return true;
+        return hash == i->second;
+    }
+
+    int GetTotalBlocksEstimate()
+    {
+        if (fTestNet) return 0; // Testnet has no checkpoints
+
+        return mapCheckpoints.rbegin()->first;
+    }
+}

--- a/src/checkpoints.h
+++ b/src/checkpoints.h
@@ -1,0 +1,22 @@
+// Copyright (c) 2011 The Bitcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file license.txt or http://www.opensource.org/licenses/mit-license.php.
+#ifndef BITCOIN_CHECKPOINT_H
+#define  BITCOIN_CHECKPOINT_H
+
+class uint256;
+
+//
+// Block-chain checkpoints are compiled-in sanity checks.
+// They are updated every release or three.
+//
+namespace Checkpoints
+{
+    // Returns true if block passes checkpoint checks
+    bool CheckBlock(int nHeight, const uint256& hash);
+
+    // Return conservative estimate of total number of blocks, 0 if unknown
+    int GetTotalBlocksEstimate();
+}
+
+#endif

--- a/src/checkpoints.h
+++ b/src/checkpoints.h
@@ -4,7 +4,11 @@
 #ifndef BITCOIN_CHECKPOINT_H
 #define  BITCOIN_CHECKPOINT_H
 
+#include <map>
+#include "util.h"
+
 class uint256;
+class CBlockIndex;
 
 //
 // Block-chain checkpoints are compiled-in sanity checks.
@@ -17,6 +21,9 @@ namespace Checkpoints
 
     // Return conservative estimate of total number of blocks, 0 if unknown
     int GetTotalBlocksEstimate();
+
+    // Returns last CBlockIndex* in mapBlockIndex that is a checkpoint
+    CBlockIndex* GetLastCheckpoint(const std::map<uint256, CBlockIndex*>& mapBlockIndex);
 }
 
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,6 +3,7 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file license.txt or http://www.opensource.org/licenses/mit-license.php.
 #include "headers.h"
+#include "checkpoints.h"
 #include "db.h"
 #include "net.h"
 #include "init.h"
@@ -29,7 +30,6 @@ map<COutPoint, CInPoint> mapNextTx;
 map<uint256, CBlockIndex*> mapBlockIndex;
 uint256 hashGenesisBlock("0x000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f");
 static CBigNum bnProofOfWorkLimit(~uint256(0) >> 32);
-const int nTotalBlocksEstimate = 140700; // Conservative estimate of total nr of blocks on main chain
 const int nInitialBlockThreshold = 120; // Regard blocks up until N-threshold as "initial download"
 CBlockIndex* pindexGenesisBlock = NULL;
 int nBestHeight = -1;
@@ -721,28 +721,15 @@ bool CheckProofOfWork(uint256 hash, unsigned int nBits)
     return true;
 }
 
-// Return conservative estimate of total number of blocks, 0 if unknown
-int GetTotalBlocksEstimate()
-{
-    if(fTestNet)
-    {
-        return 0;
-    }
-    else
-    {
-        return nTotalBlocksEstimate;
-    }
-}
-
 // Return maximum amount of blocks that other nodes claim to have
 int GetNumBlocksOfPeers()
 {
-    return std::max(cPeerBlockCounts.median(), GetTotalBlocksEstimate());
+    return std::max(cPeerBlockCounts.median(), Checkpoints::GetTotalBlocksEstimate());
 }
 
 bool IsInitialBlockDownload()
 {
-    if (pindexBest == NULL || nBestHeight < (GetTotalBlocksEstimate()-nInitialBlockThreshold))
+    if (pindexBest == NULL || nBestHeight < (Checkpoints::GetTotalBlocksEstimate()-nInitialBlockThreshold))
         return true;
     static int64 nLastUpdate;
     static CBlockIndex* pindexLastBest;
@@ -1317,17 +1304,8 @@ bool CBlock::AcceptBlock()
             return DoS(10, error("AcceptBlock() : contains a non-final transaction"));
 
     // Check that the block chain matches the known block chain up to a checkpoint
-    if (!fTestNet)
-        if ((nHeight ==  11111 && hash != uint256("0x0000000069e244f73d78e8fd29ba2fd2ed618bd6fa2ee92559f542fdb26e7c1d")) ||
-            (nHeight ==  33333 && hash != uint256("0x000000002dd5588a74784eaa7ab0507a18ad16a236e7b1ce69f00d7ddfb5d0a6")) ||
-            (nHeight ==  68555 && hash != uint256("0x00000000001e1b4903550a0b96e9a9405c8a95f387162e4944e8d9fbe501cd6a")) ||
-            (nHeight ==  70567 && hash != uint256("0x00000000006a49b14bcf27462068f1264c961f11fa2e0eddd2be0791e1d4124a")) ||
-            (nHeight ==  74000 && hash != uint256("0x0000000000573993a3c9e41ce34471c079dcf5f52a0e824a81e7f953b8661a20")) ||
-            (nHeight == 105000 && hash != uint256("0x00000000000291ce28027faea320c8d2b054b2e0fe44a773f3eefb151d6bdc97")) ||
-            (nHeight == 118000 && hash != uint256("0x000000000000774a7f8a7a12dc906ddb9e17e75d684f15e00f8767f9e8f36553")) ||
-            (nHeight == 134444 && hash != uint256("0x00000000000005b12ffd4cd315cd34ffd4a594f430ac814c91184a0d42d2b0fe")) ||
-            (nHeight == 140700 && hash != uint256("0x000000000000033b512028abb90e1626d8b346fd0ed598ac0a3c371138dce2bd")))
-            return DoS(100, error("AcceptBlock() : rejected by checkpoint lockin at %d", nHeight));
+    if (!Checkpoints::CheckBlock(nHeight, hash))
+        return DoS(100, error("AcceptBlock() : rejected by checkpoint lockin at %d", nHeight));
 
     // Write block to history file
     if (!CheckDiskSpace(::GetSerializeSize(*this, SER_DISK)))

--- a/src/main.h
+++ b/src/main.h
@@ -99,6 +99,7 @@ void IncrementExtraNonce(CBlock* pblock, CBlockIndex* pindexPrev, unsigned int& 
 void FormatHashBuffers(CBlock* pblock, char* pmidstate, char* pdata, char* phash1);
 bool CheckWork(CBlock* pblock, CWallet& wallet, CReserveKey& reservekey);
 bool CheckProofOfWork(uint256 hash, unsigned int nBits);
+unsigned int ComputeMinWork(unsigned int nBase, int64 nTime);
 int GetNumBlocksOfPeers();
 bool IsInitialBlockDownload();
 std::string GetWarnings(std::string strFor);

--- a/src/main.h
+++ b/src/main.h
@@ -99,7 +99,6 @@ void IncrementExtraNonce(CBlock* pblock, CBlockIndex* pindexPrev, unsigned int& 
 void FormatHashBuffers(CBlock* pblock, char* pmidstate, char* pdata, char* phash1);
 bool CheckWork(CBlock* pblock, CWallet& wallet, CReserveKey& reservekey);
 bool CheckProofOfWork(uint256 hash, unsigned int nBits);
-int GetTotalBlocksEstimate();
 int GetNumBlocksOfPeers();
 bool IsInitialBlockDownload();
 std::string GetWarnings(std::string strFor);

--- a/src/makefile.linux-mingw
+++ b/src/makefile.linux-mingw
@@ -32,6 +32,7 @@ CFLAGS=-O2 -w -Wno-invalid-offsetof -Wformat $(DEBUGFLAGS) $(DEFS) $(INCLUDEPATH
 HEADERS = \
     base58.h \
     bignum.h \
+    checkpoints.h \
     crypter.h \
     db.h \
     headers.h \
@@ -61,6 +62,7 @@ endif
 LIBS += -l mingwthrd -l kernel32 -l user32 -l gdi32 -l comdlg32 -l winspool -l winmm -l shell32 -l comctl32 -l ole32 -l oleaut32 -l uuid -l rpcrt4 -l advapi32 -l ws2_32 -l shlwapi
 
 OBJS= \
+    obj/checkpoints.o \
     obj/crypter.o \
     obj/db.o \
     obj/init.o \

--- a/src/makefile.mingw
+++ b/src/makefile.mingw
@@ -29,6 +29,7 @@ CFLAGS=-mthreads -O2 -w -Wno-invalid-offsetof -Wformat $(DEBUGFLAGS) $(DEFS) $(I
 HEADERS = \
     base58.h \
     bignum.h \
+    checkpoints.h \
     crypter.h \
     db.h \
     headers.h \
@@ -58,6 +59,7 @@ endif
 LIBS += -l kernel32 -l user32 -l gdi32 -l comdlg32 -l winspool -l winmm -l shell32 -l comctl32 -l ole32 -l oleaut32 -l uuid -l rpcrt4 -l advapi32 -l ws2_32 -l shlwapi
 
 OBJS= \
+    obj/checkpoints.o \
     obj/crypter.o \
     obj/db.o \
     obj/init.o \

--- a/src/makefile.osx
+++ b/src/makefile.osx
@@ -49,6 +49,7 @@ CFLAGS=-mmacosx-version-min=10.5 -arch i386 -O3 -Wno-invalid-offsetof -Wformat $
 HEADERS = \
     base58.h \
     bignum.h \
+    checkpoints.h \
     crypter.h \
     db.h \
     headers.h \
@@ -69,6 +70,7 @@ HEADERS = \
     wallet.h
 
 OBJS= \
+    obj/checkpoints.o \
     obj/crypter.o \
     obj/db.o \
     obj/init.o \

--- a/src/makefile.unix
+++ b/src/makefile.unix
@@ -87,6 +87,7 @@ xCXXFLAGS=-pthread -Wno-invalid-offsetof -Wformat $(DEBUGFLAGS) $(DEFS) $(HARDEN
 HEADERS = \
     base58.h \
     bignum.h \
+    checkpoints.h \
     crypter.h \
     db.h \
     headers.h \
@@ -107,6 +108,7 @@ HEADERS = \
     wallet.h
 
 OBJS= \
+    obj/checkpoints.o \
     obj/crypter.o \
     obj/db.o \
     obj/init.o \

--- a/src/makefile.vc
+++ b/src/makefile.vc
@@ -43,6 +43,7 @@ CFLAGS=/MD /c /nologo /EHsc /GR /Zm300 $(DEBUGFLAGS) $(DEFS) $(INCLUDEPATHS)
 HEADERS = \
     base58.h \
     bignum.h \
+    checkpoints.h \
     crypter.h \
     db.h \
     headers.h \
@@ -65,6 +66,7 @@ HEADERS = \
     wallet.h
 
 OBJS= \
+    obj\checkpoints.o \
     obj\crypter.o \
     obj\db.o \
     obj\init.o \
@@ -86,6 +88,8 @@ all: bitcoind.exe
 
 .cpp{obj}.obj:
     cl $(CFLAGS) /DGUI /Fo$@ %s
+
+obj\checkpoints.obj: $(HEADERS)
 
 obj\util.obj: $(HEADERS)
 
@@ -115,6 +119,8 @@ obj\uibase.obj: $(HEADERS)
 
 .cpp{obj\nogui}.obj:
     cl $(CFLAGS) /Fo$@ %s
+
+obj\nogui\checkpoints.obj: $(HEADERS)
 
 obj\nogui\util.obj: $(HEADERS)
 

--- a/src/test/Checkpoints_tests.cpp
+++ b/src/test/Checkpoints_tests.cpp
@@ -1,0 +1,34 @@
+//
+// Unit tests for block-chain checkpoints
+//
+#include <boost/assign/list_of.hpp> // for 'map_list_of()'
+#include <boost/test/unit_test.hpp>
+#include <boost/foreach.hpp>
+
+#include "../checkpoints.h"
+#include "../util.h"
+
+using namespace std;
+
+BOOST_AUTO_TEST_SUITE(Checkpoints_tests)
+
+BOOST_AUTO_TEST_CASE(sanity)
+{
+    uint256 p11111 = uint256("0x0000000069e244f73d78e8fd29ba2fd2ed618bd6fa2ee92559f542fdb26e7c1d");
+    uint256 p140700 = uint256("0x000000000000033b512028abb90e1626d8b346fd0ed598ac0a3c371138dce2bd");
+    BOOST_CHECK(Checkpoints::CheckBlock(11111, p11111));
+    BOOST_CHECK(Checkpoints::CheckBlock(140700, p140700));
+
+    
+    // Wrong hashes at checkpoints should fail:
+    BOOST_CHECK(!Checkpoints::CheckBlock(11111, p140700));
+    BOOST_CHECK(!Checkpoints::CheckBlock(140700, p11111));
+
+    // ... but any hash not at a checkpoint should succeed:
+    BOOST_CHECK(Checkpoints::CheckBlock(11111+1, p140700));
+    BOOST_CHECK(Checkpoints::CheckBlock(140700+1, p11111));
+
+    BOOST_CHECK(Checkpoints::GetTotalBlocksEstimate() >= 140700);
+}    
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/DoS_tests.cpp
+++ b/src/test/DoS_tests.cpp
@@ -1,6 +1,7 @@
 //
 // Unit tests for denial-of-service detection/prevention code
 //
+#include <boost/assign/list_of.hpp> // for 'map_list_of()'
 #include <boost/test/unit_test.hpp>
 #include <boost/foreach.hpp>
 
@@ -63,5 +64,55 @@ BOOST_AUTO_TEST_CASE(DoS_bantime)
     SetMockTime(nStartTime+60*60*24+1);
     BOOST_CHECK(!CNode::IsBanned(addr.ip));
 }    
+
+static bool CheckNBits(unsigned int nbits1, int64 time1, unsigned int nbits2, int64 time2)
+{
+    if (time1 > time2)
+        return CheckNBits(nbits2, time2, nbits1, time1);
+    int64 deltaTime = time2-time1;
+
+    CBigNum required;
+    required.SetCompact(ComputeMinWork(nbits1, deltaTime));
+    CBigNum have;
+    have.SetCompact(nbits2);
+    return (have <= required);
+}
+
+BOOST_AUTO_TEST_CASE(DoS_checknbits)
+{
+    using namespace boost::assign; // for 'map_list_of()'
+
+    // Timestamps,nBits from the bitcoin blockchain.
+    // These are the block-chain checkpoint blocks
+    typedef std::map<int64, unsigned int> BlockData;
+    BlockData chainData =
+        map_list_of(1239852051,486604799)(1262749024,486594666)
+        (1279305360,469854461)(1280200847,469830746)(1281678674,469809688)
+        (1296207707,453179945)(1302624061,453036989)(1309640330,437004818)
+        (1313172719,436789733);
+
+    // Make sure CheckNBits considers every combination of block-chain-lock-in-points
+    // "sane":
+    BOOST_FOREACH(const BlockData::value_type& i, chainData)
+    {
+        BOOST_FOREACH(const BlockData::value_type& j, chainData)
+        {
+            BOOST_CHECK(CheckNBits(i.second, i.first, j.second, j.first));
+        }
+    }
+
+    // Test a couple of insane combinations:
+    BlockData::value_type firstcheck = *(chainData.begin());
+    BlockData::value_type lastcheck = *(chainData.rbegin());
+
+    // First checkpoint difficulty at or a while after the last checkpoint time should fail when
+    // compared to last checkpoint
+    BOOST_CHECK(!CheckNBits(firstcheck.second, lastcheck.first+60*10, lastcheck.second, lastcheck.first));
+    BOOST_CHECK(!CheckNBits(firstcheck.second, lastcheck.first+60*60*24*14, lastcheck.second, lastcheck.first));
+
+    // ... but OK if enough time passed for difficulty to adjust downward:
+    BOOST_CHECK(CheckNBits(firstcheck.second, lastcheck.first+60*60*24*365*4, lastcheck.second, lastcheck.first));
+    
+}
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/DoS_tests.cpp
+++ b/src/test/DoS_tests.cpp
@@ -64,5 +64,4 @@ BOOST_AUTO_TEST_CASE(DoS_bantime)
     BOOST_CHECK(!CNode::IsBanned(addr.ip));
 }    
 
-
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -13,6 +13,7 @@
 #include "util_tests.cpp"
 #include "base58_tests.cpp"
 #include "miner_tests.cpp"
+#include "Checkpoints_tests.cpp"
 
 CWallet* pwalletMain;
 


### PR DESCRIPTION
The attack this prevents:  Generate valid low-difficulty blocks (maybe built on top of an early part of the block chain) and send them to a bitcoin node. Before this patch the bitcoin client could store an arbitrary number of them in memory or on disk, in case they later became part of the main chain.

Two checks are added:

1) Blocks before the last blockchain lock-in are rejected, and the peer sending these obviously-not-part-of-the-main-chain blocks it will be disconnected and banned.

2) Blocks must have a plausible proof-of-work. It is impossible for a difficulty 1.0 block to follow a difficulty 1-million block (it would take at least 19 months for difficulty to drop from 1-million to 1). Blocks with too-low proof-of-work are ignored, and peers relaying them are disconnected/banned.

Requiring plausible proof-of-work for orphan blocks or alternate chains foils this attack (you would have to be able to generate valid blocks near current difficulty).
