### PR TITLE
deprecate midstate and hash1 in getwork

### DIFF
--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -1482,9 +1482,9 @@ Value getwork(const Array& params, bool fHelp)
         throw runtime_error(
             "getwork [data]\n"
             "If [data] is not specified, returns formatted hash data to work on:\n"
-            "  \"midstate\" : precomputed hash state after hashing the first half of the data\n"
+            "  \"midstate\" : precomputed hash state after hashing the first half of the data (DEPRECATED)\n" // deprecated
             "  \"data\" : block data\n"
-            "  \"hash1\" : formatted hash buffer for second hash\n"
+            "  \"hash1\" : formatted hash buffer for second hash (DEPRECATED)\n" // deprecated
             "  \"target\" : little endian hash target\n"
             "If [data] is specified, tries to solve the block and returns true if it was successful.");
 
@@ -1548,9 +1548,9 @@ Value getwork(const Array& params, bool fHelp)
         uint256 hashTarget = CBigNum().SetCompact(pblock->nBits).getuint256();
 
         Object result;
-        result.push_back(Pair("midstate", HexStr(BEGIN(pmidstate), END(pmidstate))));
+        result.push_back(Pair("midstate", HexStr(BEGIN(pmidstate), END(pmidstate)))); // deprecated
         result.push_back(Pair("data",     HexStr(BEGIN(pdata), END(pdata))));
-        result.push_back(Pair("hash1",    HexStr(BEGIN(phash1), END(phash1))));
+        result.push_back(Pair("hash1",    HexStr(BEGIN(phash1), END(phash1)))); // deprecated
         result.push_back(Pair("target",   HexStr(BEGIN(hashTarget), END(hashTarget))));
         return result;
     }


### PR DESCRIPTION
This adds `(DEPRECATED)` to both `midstate` and `hash1` in `help getwork`-RPC. The idea is to remove both fields "soon".

`hash1` is a buffer the miner should use to insert the hash between both `SHA256()` calls. It contains some bytes for padding. These are standardized in the SHA256 spec and all the popular miners have them hardcoded for performance reasons so there is no need to provide it with every getwork.

`midstate` contains the internal SHA256 state after hashing the first half of the blockheader. This can be easily done in miners as they are already doing lots of SHA256 iterations and have probably faster algorithms than bitcoind.

Deprecating these fields will allow for cleaner code in `main.cpp /BitcoinMiner` (i.e. only build blockheader without any hashing or formatting of buffers) and will make it easier to remove cryptopp from the source tree.
