### PR TITLE
Remove possibility of 63 bit overflow in ParseMoney

### DIFF
--- a/src/test/base58_tests.cpp
+++ b/src/test/base58_tests.cpp
@@ -1,0 +1,87 @@
+#include <boost/test/unit_test.hpp>
+
+#include "../util.h"
+
+BOOST_AUTO_TEST_SUITE(base58_tests)
+
+// TODO:
+// EncodeBase58Check
+// DecodeBase58Check
+// CBase58Data
+//    bool SetString(const char* psz)
+    // bool SetString(const std::string& str)
+    // std::string ToString() const
+    // int CompareTo(const CBase58Data& b58) const
+    // bool operator==(const CBase58Data& b58) const
+    // bool operator<=(const CBase58Data& b58) const
+    // bool operator>=(const CBase58Data& b58) const
+    // bool operator< (const CBase58Data& b58) const
+    // bool operator> (const CBase58Data& b58) const
+
+// CBitcoinAddress
+    // bool SetHash160(const uint160& hash160)
+    // bool SetPubKey(const std::vector<unsigned char>& vchPubKey)
+    // bool IsValid() const
+    // CBitcoinAddress()
+    // CBitcoinAddress(uint160 hash160In)
+    // CBitcoinAddress(const std::vector<unsigned char>& vchPubKey)
+    // CBitcoinAddress(const std::string& strAddress)
+    // CBitcoinAddress(const char* pszAddress)
+    // uint160 GetHash160() const
+
+#define U(x) (reinterpret_cast<const unsigned char*>(x))
+static struct {
+    const unsigned char *data;
+    int size;
+} vstrIn[] = {
+{U(""), 0},
+{U("\x61"), 1},
+{U("\x62\x62\x62"), 3},
+{U("\x63\x63\x63"), 3},
+{U("\x73\x69\x6d\x70\x6c\x79\x20\x61\x20\x6c\x6f\x6e\x67\x20\x73\x74\x72\x69\x6e\x67"), 20},
+{U("\x00\xeb\x15\x23\x1d\xfc\xeb\x60\x92\x58\x86\xb6\x7d\x06\x52\x99\x92\x59\x15\xae\xb1\x72\xc0\x66\x47"), 25},
+{U("\x51\x6b\x6f\xcd\x0f"), 5},
+{U("\xbf\x4f\x89\x00\x1e\x67\x02\x74\xdd"), 9},
+{U("\x57\x2e\x47\x94"), 4},
+{U("\xec\xac\x89\xca\xd9\x39\x23\xc0\x23\x21"), 10},
+{U("\x10\xc8\x51\x1e"), 4},
+{U("\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"), 10},
+};
+
+const char *vstrOut[] = {
+"",
+"2g",
+"a3gV",
+"aPEr",
+"2cFupjhnEsSn59qHXstmK2ffpLv2",
+"1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L",
+"ABnLTmg",
+"3SEo3LWLoPntC",
+"3EFU7m",
+"EJDM8drfXA6uyA",
+"Rt5zm",
+"1111111111"
+};
+
+BOOST_AUTO_TEST_CASE(base58_EncodeBase58)
+{
+    for (int i=0; i<sizeof(vstrIn)/sizeof(vstrIn[0]); i++)
+    {
+        BOOST_CHECK_EQUAL(EncodeBase58(vstrIn[i].data, vstrIn[i].data + vstrIn[i].size), vstrOut[i]);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(base58_DecodeBase58)
+{
+    std::vector<unsigned char> result;
+    for (int i=0; i<sizeof(vstrIn)/sizeof(vstrIn[0]); i++)
+    {
+        std::vector<unsigned char> expected(vstrIn[i].data, vstrIn[i].data + vstrIn[i].size);
+        BOOST_CHECK(DecodeBase58(vstrOut[i], result));
+        BOOST_CHECK_EQUAL_COLLECTIONS(result.begin(), result.end(), expected.begin(), expected.end());
+    }
+    BOOST_CHECK(!DecodeBase58("invalid", result));
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -10,6 +10,8 @@
 #include "transaction_tests.cpp"
 #include "DoS_tests.cpp"
 #include "base64_tests.cpp"
+#include "util_tests.cpp"
+#include "base58_tests.cpp"
 
 CWallet* pwalletMain;
 

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -12,25 +12,203 @@ BOOST_AUTO_TEST_CASE(util_MedianFilter)
 {    
     CMedianFilter<int> filter(5, 15);
 
-    BOOST_CHECK(filter.median() == 15);
+    BOOST_CHECK_EQUAL(filter.median(), 15);
 
     filter.input(20); // [15 20]
-    BOOST_CHECK(filter.median() == 17);
+    BOOST_CHECK_EQUAL(filter.median(), 17);
 
     filter.input(30); // [15 20 30]
-    BOOST_CHECK(filter.median() == 20);
+    BOOST_CHECK_EQUAL(filter.median(), 20);
 
     filter.input(3); // [3 15 20 30]
-    BOOST_CHECK(filter.median() == 17);
+    BOOST_CHECK_EQUAL(filter.median(), 17);
 
     filter.input(7); // [3 7 15 20 30]
-    BOOST_CHECK(filter.median() == 15);
+    BOOST_CHECK_EQUAL(filter.median(), 15);
 
     filter.input(18); // [3 7 18 20 30]
-    BOOST_CHECK(filter.median() == 18);
+    BOOST_CHECK_EQUAL(filter.median(), 18);
 
     filter.input(0); // [0 3 7 18 30]
-    BOOST_CHECK(filter.median() == 7);
+    BOOST_CHECK_EQUAL(filter.median(), 7);
+}
+
+static const unsigned char ParseHex_expected[65] = {
+    0x04, 0x67, 0x8a, 0xfd, 0xb0, 0xfe, 0x55, 0x48, 0x27, 0x19, 0x67, 0xf1, 0xa6, 0x71, 0x30, 0xb7, 
+    0x10, 0x5c, 0xd6, 0xa8, 0x28, 0xe0, 0x39, 0x09, 0xa6, 0x79, 0x62, 0xe0, 0xea, 0x1f, 0x61, 0xde, 
+    0xb6, 0x49, 0xf6, 0xbc, 0x3f, 0x4c, 0xef, 0x38, 0xc4, 0xf3, 0x55, 0x04, 0xe5, 0x1e, 0xc1, 0x12, 
+    0xde, 0x5c, 0x38, 0x4d, 0xf7, 0xba, 0x0b, 0x8d, 0x57, 0x8a, 0x4c, 0x70, 0x2b, 0x6b, 0xf1, 0x1d, 
+    0x5f
+};
+BOOST_AUTO_TEST_CASE(util_ParseHex)
+{
+    std::vector<unsigned char> result;
+    std::vector<unsigned char> expected(ParseHex_expected, ParseHex_expected + sizeof(ParseHex_expected));
+    // Basic test vector
+    result = ParseHex("04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5f");
+    BOOST_CHECK_EQUAL_COLLECTIONS(result.begin(), result.end(), expected.begin(), expected.end());
+
+    // Spaces between bytes must be supported
+    result = ParseHex("12 34 56 78");
+    BOOST_CHECK(result.size() == 4 && result[0] == 0x12 && result[1] == 0x34 && result[2] == 0x56 && result[3] == 0x78);
+
+    // Stop parsing at invalid value
+    result = ParseHex("1234 invalid 1234");
+    BOOST_CHECK(result.size() == 2 && result[0] == 0x12 && result[1] == 0x34);
+}
+
+BOOST_AUTO_TEST_CASE(util_HexStr)
+{
+    BOOST_CHECK_EQUAL(
+        HexStr(ParseHex_expected, ParseHex_expected + sizeof(ParseHex_expected)),
+        "04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5f");
+
+    BOOST_CHECK_EQUAL(
+        HexStr(ParseHex_expected, ParseHex_expected + 5, true),
+        "04 67 8a fd b0");
+}
+
+BOOST_AUTO_TEST_CASE(util_DateTimeStrFormat)
+{
+    BOOST_CHECK_EQUAL(DateTimeStrFormat("%x %H:%M:%S", 0), "01/01/70 00:00:00");
+    BOOST_CHECK_EQUAL(DateTimeStrFormat("%x %H:%M:%S", 0x7FFFFFFF), "01/19/38 03:14:07");
+    // Formats used within bitcoin
+    BOOST_CHECK_EQUAL(DateTimeStrFormat("%x %H:%M:%S", 1317425777), "09/30/11 23:36:17");
+    BOOST_CHECK_EQUAL(DateTimeStrFormat("%x %H:%M", 1317425777), "09/30/11 23:36");
+}
+
+BOOST_AUTO_TEST_CASE(util_ParseParameters)
+{
+    const char *argv_test[] = {"-ignored", "-a", "-b", "-ccc=argument", "-ccc=multiple", "f", "-d=e"};
+
+    ParseParameters(0, (char**)argv_test);
+    BOOST_CHECK(mapArgs.empty() && mapMultiArgs.empty());
+
+    ParseParameters(1, (char**)argv_test);
+    BOOST_CHECK(mapArgs.empty() && mapMultiArgs.empty());
+
+    ParseParameters(5, (char**)argv_test);
+    // expectation: -ignored is ignored (program name argument), 
+    // -a, -b and -ccc end up in map, -d ignored because it is after
+    // a non-option argument (non-GNU option parsing)
+    BOOST_CHECK(mapArgs.size() == 3 && mapMultiArgs.size() == 3);
+    BOOST_CHECK(mapArgs.count("-a") && mapArgs.count("-b") && mapArgs.count("-ccc") 
+                && !mapArgs.count("f") && !mapArgs.count("-d"));
+    BOOST_CHECK(mapMultiArgs.count("-a") && mapMultiArgs.count("-b") && mapMultiArgs.count("-ccc") 
+                && !mapMultiArgs.count("f") && !mapMultiArgs.count("-d"));
+
+    BOOST_CHECK(mapArgs["-a"] == "" && mapArgs["-ccc"] == "multiple");
+    BOOST_CHECK(mapMultiArgs["-ccc"].size() == 2);
+}
+
+BOOST_AUTO_TEST_CASE(util_GetArg)
+{
+    mapArgs.clear();
+    mapArgs["strtest1"] = "string...";
+    // strtest2 undefined on purpose
+    mapArgs["inttest1"] = "12345";
+    mapArgs["inttest2"] = "81985529216486895";
+    // inttest3 undefined on purpose
+    mapArgs["booltest1"] = "";
+    // booltest2 undefined on purpose
+    mapArgs["booltest3"] = "0";
+    mapArgs["booltest4"] = "1";
+
+    BOOST_CHECK_EQUAL(GetArg("strtest1", "default"), "string...");
+    BOOST_CHECK_EQUAL(GetArg("strtest2", "default"), "default");
+    BOOST_CHECK_EQUAL(GetArg("inttest1", -1), 12345);
+    BOOST_CHECK_EQUAL(GetArg("inttest2", -1), 81985529216486895);
+    BOOST_CHECK_EQUAL(GetArg("inttest3", -1), -1);
+    BOOST_CHECK_EQUAL(GetBoolArg("booltest1"), true);
+    BOOST_CHECK_EQUAL(GetBoolArg("booltest2"), false);
+    BOOST_CHECK_EQUAL(GetBoolArg("booltest3"), false);
+    BOOST_CHECK_EQUAL(GetBoolArg("booltest4"), true);
+}
+
+BOOST_AUTO_TEST_CASE(util_WildcardMatch)
+{
+    BOOST_CHECK(WildcardMatch("127.0.0.1", "*"));
+    BOOST_CHECK(WildcardMatch("127.0.0.1", "127.*"));
+    BOOST_CHECK(WildcardMatch("abcdef", "a?cde?"));
+    BOOST_CHECK(!WildcardMatch("abcdef", "a?cde??"));
+    BOOST_CHECK(WildcardMatch("abcdef", "a*f"));
+    BOOST_CHECK(!WildcardMatch("abcdef", "a*x"));
+    BOOST_CHECK(WildcardMatch("", "*"));
+}
+
+BOOST_AUTO_TEST_CASE(util_FormatMoney)
+{
+    BOOST_CHECK_EQUAL(FormatMoney(0, false), "0.00");
+    BOOST_CHECK_EQUAL(FormatMoney((COIN/10000)*123456789, false), "12345.6789");
+    BOOST_CHECK_EQUAL(FormatMoney(COIN, true), "+1.00");
+    BOOST_CHECK_EQUAL(FormatMoney(-COIN, false), "-1.00");
+    BOOST_CHECK_EQUAL(FormatMoney(-COIN, true), "-1.00");
+
+    BOOST_CHECK_EQUAL(FormatMoney(COIN*100000000, false), "100000000.00");
+    BOOST_CHECK_EQUAL(FormatMoney(COIN*10000000, false), "10000000.00");
+    BOOST_CHECK_EQUAL(FormatMoney(COIN*1000000, false), "1000000.00");
+    BOOST_CHECK_EQUAL(FormatMoney(COIN*100000, false), "100000.00");
+    BOOST_CHECK_EQUAL(FormatMoney(COIN*10000, false), "10000.00");
+    BOOST_CHECK_EQUAL(FormatMoney(COIN*1000, false), "1000.00");
+    BOOST_CHECK_EQUAL(FormatMoney(COIN*100, false), "100.00");
+    BOOST_CHECK_EQUAL(FormatMoney(COIN*10, false), "10.00");
+    BOOST_CHECK_EQUAL(FormatMoney(COIN, false), "1.00");
+    BOOST_CHECK_EQUAL(FormatMoney(COIN/10, false), "0.10");
+    BOOST_CHECK_EQUAL(FormatMoney(COIN/100, false), "0.01");
+    BOOST_CHECK_EQUAL(FormatMoney(COIN/1000, false), "0.001");
+    BOOST_CHECK_EQUAL(FormatMoney(COIN/10000, false), "0.0001");
+    BOOST_CHECK_EQUAL(FormatMoney(COIN/100000, false), "0.00001");
+    BOOST_CHECK_EQUAL(FormatMoney(COIN/1000000, false), "0.000001");
+    BOOST_CHECK_EQUAL(FormatMoney(COIN/10000000, false), "0.0000001");
+    BOOST_CHECK_EQUAL(FormatMoney(COIN/100000000, false), "0.00000001");
+}
+
+BOOST_AUTO_TEST_CASE(util_ParseMoney)
+{
+    int64 ret = 0;
+    BOOST_CHECK(ParseMoney("0.0", ret));
+    BOOST_CHECK_EQUAL(ret, 0);
+
+    BOOST_CHECK(ParseMoney("12345.6789", ret));
+    BOOST_CHECK_EQUAL(ret, (COIN/10000)*123456789);
+
+    BOOST_CHECK(ParseMoney("100000000.00", ret));
+    BOOST_CHECK_EQUAL(ret, COIN*100000000);
+    BOOST_CHECK(ParseMoney("10000000.00", ret));
+    BOOST_CHECK_EQUAL(ret, COIN*10000000);
+    BOOST_CHECK(ParseMoney("1000000.00", ret));
+    BOOST_CHECK_EQUAL(ret, COIN*1000000);
+    BOOST_CHECK(ParseMoney("100000.00", ret));
+    BOOST_CHECK_EQUAL(ret, COIN*100000);
+    BOOST_CHECK(ParseMoney("10000.00", ret));
+    BOOST_CHECK_EQUAL(ret, COIN*10000);
+    BOOST_CHECK(ParseMoney("1000.00", ret));
+    BOOST_CHECK_EQUAL(ret, COIN*1000);
+    BOOST_CHECK(ParseMoney("100.00", ret));
+    BOOST_CHECK_EQUAL(ret, COIN*100);
+    BOOST_CHECK(ParseMoney("10.00", ret));
+    BOOST_CHECK_EQUAL(ret, COIN*10);
+    BOOST_CHECK(ParseMoney("1.00", ret));
+    BOOST_CHECK_EQUAL(ret, COIN);
+    BOOST_CHECK(ParseMoney("0.1", ret));
+    BOOST_CHECK_EQUAL(ret, COIN/10);
+    BOOST_CHECK(ParseMoney("0.01", ret));
+    BOOST_CHECK_EQUAL(ret, COIN/100);
+    BOOST_CHECK(ParseMoney("0.001", ret));
+    BOOST_CHECK_EQUAL(ret, COIN/1000);
+    BOOST_CHECK(ParseMoney("0.0001", ret));
+    BOOST_CHECK_EQUAL(ret, COIN/10000);
+    BOOST_CHECK(ParseMoney("0.00001", ret));
+    BOOST_CHECK_EQUAL(ret, COIN/100000);
+    BOOST_CHECK(ParseMoney("0.000001", ret));
+    BOOST_CHECK_EQUAL(ret, COIN/1000000);
+    BOOST_CHECK(ParseMoney("0.0000001", ret));
+    BOOST_CHECK_EQUAL(ret, COIN/10000000);
+    BOOST_CHECK(ParseMoney("0.00000001", ret));
+    BOOST_CHECK_EQUAL(ret, COIN/100000000);
+
+    // Attempted 63 bit overflow should fail
+    BOOST_CHECK(!ParseMoney("92233720368.54775808", ret));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -387,7 +387,7 @@ bool ParseMoney(const char* pszIn, int64& nRet)
     for (; *p; p++)
         if (!isspace(*p))
             return false;
-    if (strWhole.size() > 14)
+    if (strWhole.size() > 10) // guard against 63 bit overflow
         return false;
     if (nUnits < 0 || nUnits > COIN)
         return false;


### PR DESCRIPTION
ParseMoney checks for a maximum number of digits before the dot, returning invalid if that is exceeded, supposedly guarding against overflow. However, this amount is set far too lenient (14) making it possible to overflow from positive into negative integer values:

```
10   9999999999.99999999   -> 9999999999999999999
11   99999999999.99999999 -> -8446744073709551617
... 
```

This commit sets the maximum number of digits before the dot to 10, the maximum safe value. It also adds unit tests for various functions in util.cpp/util.h and base58.
