### PR TITLE
Coinbaser

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -199,6 +199,9 @@ bool AppInit2(int argc, char* argv[])
             "  -rpcport=<port>  \t\t  " + _("Listen for JSON-RPC connections on <port> (default: 8332)\n") +
             "  -rpcallowip=<ip> \t\t  " + _("Allow JSON-RPC connections from specified IP address\n") +
             "  -rpcconnect=<ip> \t  "   + _("Send commands to node running on <ip> (default: 127.0.0.1)\n") +
+#ifndef __WXMSW__
+            "  -coinbaser=<cmd> \t  "   + _("Execute <cmd> to calculate coinbase payees\n") +
+#endif
             "  -keypool=<n>     \t  "   + _("Set key pool size to <n> (default: 100)\n") +
             "  -rescan          \t  "   + _("Rescan the block chain for missing wallet transactions\n");
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3224,6 +3224,66 @@ public:
 };
 
 
+#ifndef __WXMSW__
+int DoCoinbaser_I(CBlock* pblock, uint64 nTotal, FILE* file)
+{
+    int nCount;
+    if (fscanf(file, "%d\n", &nCount) != 1)
+    {
+        printf("DoCoinbaser(): failed to fscanf count\n");
+        return -2;
+    }
+    pblock->vtx[0].vout.resize(nCount + 1);
+    uint64 nDistributed = 0;
+    for (int i = 1; i <= nCount; ++i)
+    {
+        uint64 nValue;
+        if (fscanf(file, "%" PRI64u "\n", &nValue) != 1)
+        {
+            printf("DoCoinbaser(): failed to fscanf amount for transaction #%d\n", i);
+            return -(0x1000 | i);
+        }
+        pblock->vtx[0].vout[i].nValue = nValue;
+        nDistributed += nValue;
+        char strAddr[35];
+        if (fscanf(file, "%34s\n", strAddr) != 1)
+        {
+            printf("DoCoinbaser(): failed to fscanf address for transaction #%d\n", i);
+            return -(0x2000 | i);
+        }
+        if (!pblock->vtx[0].vout[i].scriptPubKey.SetBitcoinAddress(string(strAddr)))
+        {
+            printf("DoCoinbaser(): invalid bitcoin address for transaction #%d\n", i);
+            return -(0x3000 | i);
+        }
+    }
+    if (nTotal < nDistributed)
+    {
+        printf("DoCoinbaser(): attempt to distribute %" PRI64u "/%" PRI64u "\n", nDistributed, nTotal);
+        return -3;
+    }
+    uint64 nMine = nTotal - nDistributed;
+    printf("DoCoinbaser(): total distributed: %" PRI64u "/%" PRI64u " = %" PRI64u " for me\n", nDistributed, nTotal, nMine);
+    pblock->vtx[0].vout[0].nValue = nMine;
+    return 0;
+}
+
+int DoCoinbaser(CBlock* pblock, uint64 nTotal)
+{
+    FILE* file = popen(mapArgs["-coinbaser"].c_str(), "r");
+    if (!file)
+    {
+        printf("DoCoinbaser(): failed to popen: %s", strerror(errno));
+        return -1;
+    }
+    int rv = DoCoinbaser_I(pblock, nTotal, file);
+    pclose(file);
+    if (rv)
+        pblock->vtx[0].vout.resize(1);
+    return rv;
+}
+#endif
+
 CBlock* CreateNewBlock(CReserveKey& reservekey)
 {
     CBlockIndex* pindexPrev = pindexBest;
@@ -3359,7 +3419,12 @@ CBlock* CreateNewBlock(CReserveKey& reservekey)
             }
         }
     }
-    pblock->vtx[0].vout[0].nValue = GetBlockValue(pindexPrev->nHeight+1, nFees);
+    int64 nBlkValue = GetBlockValue(pindexPrev->nHeight+1, nFees);
+    pblock->vtx[0].vout[0].nValue = nBlkValue;
+#ifndef __WXMSW__
+    if (mapArgs.count("-coinbaser"))
+        DoCoinbaser(&*pblock, nBlkValue);
+#endif
 
     // Fill in header
     pblock->hashPrevBlock  = pindexPrev->GetBlockHash();
@@ -3368,6 +3433,7 @@ CBlock* CreateNewBlock(CReserveKey& reservekey)
     pblock->nBits          = GetNextWorkRequired(pindexPrev);
     pblock->nNonce         = 0;
 
+    pblock->print();
     return pblock.release();
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3487,6 +3487,8 @@ CBlock* CreateNewBlock(CReserveKey& reservekey)
 }
 
 
+std::map<std::string, CScript> mapAuxCoinbases;
+
 void IncrementExtraNonce(CBlock* pblock, CBlockIndex* pindexPrev, unsigned int& nExtraNonce, int64& nPrevTime)
 {
     // Update nExtraNonce
@@ -3496,7 +3498,16 @@ void IncrementExtraNonce(CBlock* pblock, CBlockIndex* pindexPrev, unsigned int& 
         nExtraNonce = 1;
         nPrevTime = nNow;
     }
-    pblock->vtx[0].vin[0].scriptSig = CScript() << pblock->nBits << CBigNum(nExtraNonce);
+
+    CScript &scriptSig = pblock->vtx[0].vin[0].scriptSig;
+    scriptSig = CScript();
+
+    map<std::string, CScript>::iterator it;
+    for (it = mapAuxCoinbases.begin() ; it != mapAuxCoinbases.end(); ++it)
+        scriptSig += (*it).second;
+
+    scriptSig << CBigNum(nExtraNonce);
+
     pblock->hashMerkleRoot = pblock->BuildMerkleTree();
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3500,13 +3500,14 @@ void IncrementExtraNonce(CBlock* pblock, CBlockIndex* pindexPrev, unsigned int& 
     }
 
     CScript &scriptSig = pblock->vtx[0].vin[0].scriptSig;
-    scriptSig = CScript();
+    scriptSig = CScript() << CBigNum(nExtraNonce);
 
     map<std::string, CScript>::iterator it;
     for (it = mapAuxCoinbases.begin() ; it != mapAuxCoinbases.end(); ++it)
         scriptSig += (*it).second;
 
-    scriptSig << CBigNum(nExtraNonce);
+    if (scriptSig.size() > 100)
+        scriptSig.resize(100);
 
     pblock->hashMerkleRoot = pblock->BuildMerkleTree();
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3271,6 +3271,23 @@ int DoCoinbaser_I(CBlock* pblock, uint64 nTotal, FILE* file)
 int DoCoinbaser(CBlock* pblock, uint64 nTotal)
 {
     string strCmd = mapArgs["-coinbaser"];
+    FILE* file = NULL;
+    if (!strCmd.compare(0, 4, "tcp:"))
+    {
+        CAddress addrCoinbaser(strCmd.substr(4), true, 0);
+        SOCKET hSocket;
+        if (!ConnectSocket(addrCoinbaser, hSocket))
+        {
+            perror("DoCoinbaser(): failed to connect");
+            return -3;
+        }
+        file = fdopen(hSocket, "r+");
+        if (file)
+            fprintf(file, "total: %" PRI64u "\n\n", nTotal);
+    }
+    else
+    {
+
     try
     {
         char strTotal[11];
@@ -3290,12 +3307,16 @@ int DoCoinbaser(CBlock* pblock, uint64 nTotal)
     {
         return 1;
     }
-    FILE* file = popen(strCmd.c_str(), "r");
+    file = popen(strCmd.c_str(), "r");
+
+    }
+
     if (!file)
     {
         printf("DoCoinbaser(): failed to popen: %s", strerror(errno));
         return -1;
     }
+
     int rv;
     try
     {

--- a/src/main.h
+++ b/src/main.h
@@ -103,6 +103,7 @@ std::string SendMoneyToBitcoinAddress(std::string strAddress, int64 nValue, CWal
 void GenerateBitcoins(bool fGenerate);
 void ThreadBitcoinMiner(void* parg);
 CBlock* CreateNewBlock(CReserveKey& reservekey);
+extern std::map<std::string, CScript> mapAuxCoinbases;
 void IncrementExtraNonce(CBlock* pblock, CBlockIndex* pindexPrev, unsigned int& nExtraNonce, int64& nPrevTime);
 void FormatHashBuffers(CBlock* pblock, char* pmidstate, char* pdata, char* phash1);
 bool CheckWork(CBlock* pblock, CReserveKey& reservekey);

--- a/src/main.h
+++ b/src/main.h
@@ -104,6 +104,7 @@ void GenerateBitcoins(bool fGenerate);
 void ThreadBitcoinMiner(void* parg);
 CBlock* CreateNewBlock(CReserveKey& reservekey);
 extern std::map<std::string, CScript> mapAuxCoinbases;
+CScript BuildCoinbaseScriptSig(unsigned int nExtraNonce, bool *pfOverflow = NULL);
 void IncrementExtraNonce(CBlock* pblock, CBlockIndex* pindexPrev, unsigned int& nExtraNonce, int64& nPrevTime);
 void FormatHashBuffers(CBlock* pblock, char* pmidstate, char* pdata, char* phash1);
 bool CheckWork(CBlock* pblock, CReserveKey& reservekey);

--- a/src/rpc.cpp
+++ b/src/rpc.cpp
@@ -1318,7 +1318,8 @@ Value getwork(const Array& params, bool fHelp)
     if (IsInitialBlockDownload())
         throw JSONRPCError(-10, "Bitcoin is downloading blocks...");
 
-    static map<uint256, pair<CBlock*, unsigned int> > mapNewBlock;
+    typedef map<uint256, pair<CBlock*, CScript> > mapNewBlock_t;
+    static mapNewBlock_t mapNewBlock;
     static vector<CBlock*> vNewBlock;
     static CReserveKey reservekey;
 
@@ -1361,7 +1362,7 @@ Value getwork(const Array& params, bool fHelp)
         IncrementExtraNonce(pblock, pindexPrev, nExtraNonce, nPrevTime);
 
         // Save
-        mapNewBlock[pblock->hashMerkleRoot] = make_pair(pblock, nExtraNonce);
+        mapNewBlock[pblock->hashMerkleRoot] = make_pair(pblock, pblock->vtx[0].vin[0].scriptSig);
 
         // Prebuild hash buffers
         char pmidstate[32];
@@ -1394,11 +1395,10 @@ Value getwork(const Array& params, bool fHelp)
         if (!mapNewBlock.count(pdata->hashMerkleRoot))
             return false;
         CBlock* pblock = mapNewBlock[pdata->hashMerkleRoot].first;
-        unsigned int nExtraNonce = mapNewBlock[pdata->hashMerkleRoot].second;
 
         pblock->nTime = pdata->nTime;
         pblock->nNonce = pdata->nNonce;
-        pblock->vtx[0].vin[0].scriptSig = CScript() << pblock->nBits << CBigNum(nExtraNonce);
+        pblock->vtx[0].vin[0].scriptSig = mapNewBlock[pdata->hashMerkleRoot].second;
         pblock->hashMerkleRoot = pblock->BuildMerkleTree();
 
         return CheckWork(pblock, reservekey);

--- a/src/rpc.cpp
+++ b/src/rpc.cpp
@@ -1300,6 +1300,27 @@ Value validateaddress(const Array& params, bool fHelp)
 }
 
 
+Value setworkaux(const Array& params, bool fHelp)
+{
+    if (fHelp || params.size() < 1 || params.size() > 2)
+        throw runtime_error(
+            "setworkaux <id> [data]\n"
+            "If [data] is not specified, deletes aux.\n"
+        );
+
+    std::string strId = params[0].get_str();
+    if (params.size() > 1)
+    {
+        std::vector<unsigned char> vchData = ParseHex(params[1].get_str());
+        mapAuxCoinbases[strId] = CScript(vchData);
+    }
+    else
+        mapAuxCoinbases.erase(strId);
+
+    return true;
+}
+
+
 Value getwork(const Array& params, bool fHelp)
 {
     if (fHelp || params.size() > 1)
@@ -1456,6 +1477,7 @@ pair<string, rpcfn_type> pCallTable[] =
     make_pair("sendmany",              &sendmany),
     make_pair("gettransaction",        &gettransaction),
     make_pair("listtransactions",      &listtransactions),
+    make_pair("setworkaux",            &setworkaux),
     make_pair("getwork",               &getwork),
     make_pair("listaccounts",          &listaccounts),
     make_pair("settxfee",              &settxfee),

--- a/src/rpc.cpp
+++ b/src/rpc.cpp
@@ -1311,8 +1311,16 @@ Value setworkaux(const Array& params, bool fHelp)
     std::string strId = params[0].get_str();
     if (params.size() > 1)
     {
-        std::vector<unsigned char> vchData = ParseHex(params[1].get_str());
+        std::string strData = params[1].get_str();
+        std::vector<unsigned char> vchData = ParseHex(strData);
+        if (vchData.size() * 2 != strData.size())
+            throw JSONRPCError(-8, "Failed to parse data as hexadecimal");
+        CScript scriptBackup = mapAuxCoinbases[strId];
         mapAuxCoinbases[strId] = CScript(vchData);
+        bool fOverflow;
+        BuildCoinbaseScriptSig(UINT_MAX, &fOverflow);
+        if (fOverflow)
+            throw JSONRPCError(-7, "Change would overflow coinbase script");
     }
     else
         mapAuxCoinbases.erase(strId);


### PR DESCRIPTION
Allow customizing what addresses are paid by generation, with failover to the standard "50 BTC to me" behaviour; also adds the "setworkaux" JSON-RPC call to add arbitrary data to the coinbase, which can be used to implement merged-mining (has safeguards against creating invalid coinbases)

The internal code changes for "setworkaux" can also be used to put "feature flags" in coinbases, to enable upgrades (like OP_EVAL) when X% of the last Y blocks advertise support (after which, they should stop advertising the flag to make room for future content).

Eligius has tested this changeset quite a bit under the 0.3.23 codebase.
