### PR TITLE
-acceptnonstdtxn option to skip "non-standard transaction" checks

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -199,6 +199,7 @@ bool AppInit2(int argc, char* argv[])
             "  -rpcport=<port>  \t\t  " + _("Listen for JSON-RPC connections on <port> (default: 8332)\n") +
             "  -rpcallowip=<ip> \t\t  " + _("Allow JSON-RPC connections from specified IP address\n") +
             "  -rpcconnect=<ip> \t  "   + _("Send commands to node running on <ip> (default: 127.0.0.1)\n") +
+            "  -acceptnonstdtxn \t  "   + _("Accept \"non-standard\" transactions for relay and blocks\n") +
             "  -keypool=<n>     \t  "   + _("Set key pool size to <n> (default: 100)\n") +
             "  -rescan          \t  "   + _("Rescan the block chain for missing wallet transactions\n");
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -352,12 +352,16 @@ bool CTransaction::AcceptToMemoryPool(CTxDB& txdb, bool fCheckInputs, bool* pfMi
     if (IsCoinBase())
         return error("AcceptToMemoryPool() : coinbase as individual tx");
 
+    unsigned int nSize = ::GetSerializeSize(*this, SER_NETWORK);
+
+    if (!GetBoolArg("-acceptnonstdtxn"))
+    {
+
     // To help v0.1.5 clients who would see it as a negative number
     if ((int64)nLockTime > INT_MAX)
         return error("AcceptToMemoryPool() : not accepting nLockTime beyond 2038 yet");
 
     // Safety limits
-    unsigned int nSize = ::GetSerializeSize(*this, SER_NETWORK);
     // Checking ECDSA signatures is a CPU bottleneck, so to avoid denial-of-service
     // attacks disallow transactions with more than one SigOp per 34 bytes.
     // 34 bytes because a TxOut is:
@@ -368,6 +372,8 @@ bool CTransaction::AcceptToMemoryPool(CTxDB& txdb, bool fCheckInputs, bool* pfMi
     // Rather not work on nonstandard transactions (unless -testnet)
     if (!fTestNet && !IsStandard())
         return error("AcceptToMemoryPool() : nonstandard transaction type");
+
+    }
 
     // Do we already have it?
     uint256 hash = GetHash();


### PR DESCRIPTION
Adds a -acceptnonstdtxn option to allow miners to easily accept "non-standard" transactions

We probably want to amend this with a block for OP_NOP*?
