### PR TITLE
Cache RPC user and password in globals

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -239,6 +239,9 @@ bool AppInit2(int argc, char* argv[])
     else
         fServer = GetBoolArg("-server");
 
+    strRPCUser = mapArgs["-rpcuser"];
+    strRPCPass = mapArgs["-rpcpassword"];
+
     /* force fServer when running without GUI */
 #ifndef GUI
     fServer = true;

--- a/src/rpc.cpp
+++ b/src/rpc.cpp
@@ -1864,7 +1864,7 @@ bool HTTPAuthorized(map<string, string>& mapHeaders)
         return false;
     string strUser = strUserPass.substr(0, nColon);
     string strPassword = strUserPass.substr(nColon+1);
-    return (strUser == mapArgs["-rpcuser"] && strPassword == mapArgs["-rpcpassword"]);
+    return (strUser == strRPCUser && strPassword == strRPCPass);
 }
 
 //
@@ -1997,7 +1997,7 @@ void ThreadRPCServer2(void* parg)
 {
     printf("ThreadRPCServer started\n");
 
-    if (mapArgs["-rpcuser"] == "" && mapArgs["-rpcpassword"] == "")
+    if (strRPCUser == "" && strRPCPass == "")
     {
         string strWhatAmI = "To use bitcoind";
         if (mapArgs.count("-server"))
@@ -2179,7 +2179,7 @@ void ThreadRPCServer2(void* parg)
 
 Object CallRPC(const string& strMethod, const Array& params)
 {
-    if (mapArgs["-rpcuser"] == "" && mapArgs["-rpcpassword"] == "")
+    if (strRPCUser == "" && strRPCPass == "")
         throw runtime_error(strprintf(
             _("You must set rpcpassword=<password> in the configuration file:\n%s\n"
               "If the file does not exist, create it with owner-readable-only file permissions."),
@@ -2207,7 +2207,7 @@ Object CallRPC(const string& strMethod, const Array& params)
 
 
     // HTTP basic authentication
-    string strUserPass64 = EncodeBase64(mapArgs["-rpcuser"] + ":" + mapArgs["-rpcpassword"]);
+    string strUserPass64 = EncodeBase64(strRPCUser + ":" + strRPCPass);
     map<string, string> mapRequestHeaders;
     mapRequestHeaders["Authorization"] = string("Basic ") + strUserPass64;
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -26,7 +26,7 @@ bool fShutdown = false;
 bool fDaemon = false;
 bool fServer = false;
 bool fCommandLine = false;
-string strMiscWarning;
+string strMiscWarning, strRPCUser, strRPCPass;
 bool fTestNet = false;
 bool fNoListen = false;
 bool fLogTimestamps = false;

--- a/src/util.h
+++ b/src/util.h
@@ -160,7 +160,7 @@ extern bool fShutdown;
 extern bool fDaemon;
 extern bool fServer;
 extern bool fCommandLine;
-extern std::string strMiscWarning;
+extern std::string strMiscWarning, strRPCUser, strRPCPass;
 extern bool fTestNet;
 extern bool fNoListen;
 extern bool fLogTimestamps;


### PR DESCRIPTION
Stash the RPC user and password in a global string so we don't have to fetch them from the map on every RPC request.
