### PR TITLE
FastGetWork optimization

### DIFF
--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -1763,6 +1763,64 @@ Value validateaddress(const Array& params, bool fHelp)
     return ret;
 }
 
+
+static boost::mutex mGetWork;
+static CReserveKey *reservekey = NULL;
+typedef map<uint256, pair<CBlock*, CScript> > mapNewBlock_t;
+static mapNewBlock_t mapNewBlock;
+
+void GetWorkBlock(char *pmidstate, char *pdata, char *phash1, uint256 &hashTarget)
+{ // Fill the buffers with a correct work unit
+    boost::unique_lock<boost::mutex> lock(mGetWork);
+
+        static unsigned int nTransactionsUpdatedLast;
+        static CBlockIndex* pindexPrev;
+        static int64 nStart;
+        static CBlock* pblock;
+    static vector<CBlock*> vNewBlock;
+
+    // Update block if needed
+    while (pindexPrev != pindexBest ||
+            (nTransactionsUpdated != nTransactionsUpdatedLast && GetTime() - nStart > 60))
+        {
+            if (pindexPrev != pindexBest)
+            {
+                // Deallocate old blocks since they're obsolete now
+                mapNewBlock.clear();
+                BOOST_FOREACH(CBlock* pblock, vNewBlock)
+                    delete pblock;
+                vNewBlock.clear();
+            }
+            nTransactionsUpdatedLast = nTransactionsUpdated;
+            pindexPrev = pindexBest;
+            nStart = GetTime();
+
+            // Create new block
+        if (reservekey == NULL)
+            reservekey = new CReserveKey(pwalletMain);
+        pblock = CreateNewBlock(*reservekey);
+        if (pblock == NULL)
+                throw JSONRPCError(-7, "Out of memory");
+
+            vNewBlock.push_back(pblock);
+        }
+
+        // Update nTime
+        pblock->UpdateTime(pindexPrev);
+        pblock->nNonce = 0;
+
+        // Update nExtraNonce
+        static unsigned int nExtraNonce = 0;
+        IncrementExtraNonce(pblock, pindexPrev, nExtraNonce);
+
+        // Save
+        mapNewBlock[pblock->hashMerkleRoot] = make_pair(pblock, pblock->vtx[0].vin[0].scriptSig);
+
+        // Prebuild hash buffers
+    FormatHashBuffers(pblock, pmidstate, pdata, phash1);
+    hashTarget = CBigNum().SetCompact(pblock->nBits).getuint256();
+}
+
 Value getwork(const Array& params, bool fHelp)
 {
     if (fHelp || params.size() > 1)
@@ -1781,58 +1839,14 @@ Value getwork(const Array& params, bool fHelp)
     if (IsInitialBlockDownload())
         throw JSONRPCError(-10, "Bitcoin is downloading blocks...");
 
-    typedef map<uint256, pair<CBlock*, CScript> > mapNewBlock_t;
-    static mapNewBlock_t mapNewBlock;
-    static vector<CBlock*> vNewBlock;
-    static CReserveKey reservekey(pwalletMain);
-
     if (params.size() == 0)
     {
-        // Update block
-        static unsigned int nTransactionsUpdatedLast;
-        static CBlockIndex* pindexPrev;
-        static int64 nStart;
-        static CBlock* pblock;
-        if (pindexPrev != pindexBest ||
-            (nTransactionsUpdated != nTransactionsUpdatedLast && GetTime() - nStart > 60))
-        {
-            if (pindexPrev != pindexBest)
-            {
-                // Deallocate old blocks since they're obsolete now
-                mapNewBlock.clear();
-                BOOST_FOREACH(CBlock* pblock, vNewBlock)
-                    delete pblock;
-                vNewBlock.clear();
-            }
-            nTransactionsUpdatedLast = nTransactionsUpdated;
-            pindexPrev = pindexBest;
-            nStart = GetTime();
-
-            // Create new block
-            pblock = CreateNewBlock(reservekey);
-            if (!pblock)
-                throw JSONRPCError(-7, "Out of memory");
-            vNewBlock.push_back(pblock);
-        }
-
-        // Update nTime
-        pblock->UpdateTime(pindexPrev);
-        pblock->nNonce = 0;
-
-        // Update nExtraNonce
-        static unsigned int nExtraNonce = 0;
-        IncrementExtraNonce(pblock, pindexPrev, nExtraNonce);
-
-        // Save
-        mapNewBlock[pblock->hashMerkleRoot] = make_pair(pblock, pblock->vtx[0].vin[0].scriptSig);
-
-        // Prebuild hash buffers
         char pmidstate[32];
         char pdata[128];
         char phash1[64];
-        FormatHashBuffers(pblock, pmidstate, pdata, phash1);
+        uint256 hashTarget;
 
-        uint256 hashTarget = CBigNum().SetCompact(pblock->nBits).getuint256();
+        GetWorkBlock(pmidstate, pdata, phash1, hashTarget);
 
         Object result;
         result.push_back(Pair("midstate", HexStr(BEGIN(pmidstate), END(pmidstate)))); // deprecated
@@ -1853,6 +1867,9 @@ Value getwork(const Array& params, bool fHelp)
         for (int i = 0; i < 128/4; i++)
             ((unsigned int*)pdata)[i] = ByteReverse(((unsigned int*)pdata)[i]);
 
+        // Get exclusive access to getwork structures
+        boost::unique_lock<boost::mutex> lock(mGetWork);
+
         // Get saved block
         if (!mapNewBlock.count(pdata->hashMerkleRoot))
             return false;
@@ -1863,10 +1880,38 @@ Value getwork(const Array& params, bool fHelp)
         pblock->vtx[0].vin[0].scriptSig = mapNewBlock[pdata->hashMerkleRoot].second;
         pblock->hashMerkleRoot = pblock->BuildMerkleTree();
 
-        return CheckWork(pblock, *pwalletMain, reservekey);
+        return CheckWork(pblock, *pwalletMain, *reservekey);
     }
 }
 
+std::string FastGetWork(const std::string id)
+{ // bypass JSON in the most common case
+    if (vNodes.empty())
+        throw JSONRPCError(-9, "Bitcoin is not connected!");
+
+    if (IsInitialBlockDownload())
+        throw JSONRPCError(-10, "Bitcoin is downloading blocks...");
+
+    char pmidstate[32];
+    char pdata[128];
+    char phash1[64];
+    uint256 hashTarget;
+
+    GetWorkBlock(pmidstate, pdata, phash1, hashTarget);
+
+    std::string result = "{\"result\":{\"midstate\" : \"";
+    result += HexStr(BEGIN(pmidstate), END(pmidstate));
+    result += "\",\"data\":\"";
+    result += HexStr(BEGIN(pdata), END(pdata));
+    result += "\",\"hash1\":\"";
+    result += HexStr(BEGIN(phash1), END(phash1));
+    result += "\",\"target\":\"";
+    result += HexStr(BEGIN(hashTarget), END(hashTarget));
+    result += "\"},\"error\":null,\"id\":\"";
+    result += id;
+    result += "\"}\n";
+    return result;
+}
 
 Value getmemorypool(const Array& params, bool fHelp)
 {
@@ -2492,6 +2537,30 @@ void ThreadRPCServer2(void* parg)
             continue;
         }
 
+        if ((strRequest.find("\"getwork\"") != std::string::npos) && strRequest.find("[]") != std::string::npos)
+        { // This is imperfect code
+            std::string id;
+            size_t p = strRequest.find("\"id\":\"");
+            if (p != std::string::npos)
+            {
+                size_t ep = strRequest.find("\"", p+6);
+                id = strRequest.substr(p+6, p+ep);
+            }
+            try
+            {
+                stream << HTTPReply(200, FastGetWork(id)) << std::flush;
+            }
+            catch (std::exception& e)
+            {
+                ErrorReply(stream, JSONRPCError(-1, e.what()), id);
+            }
+            catch (Object& e)
+            {
+                ErrorReply(stream, e, id);
+            }
+            continue;
+        }
+
         Value id = Value::null;
         try
         {
@@ -2505,17 +2574,39 @@ void ThreadRPCServer2(void* parg)
             id = find_value(request, "id");
 
             // Parse method
+            Value valParams = find_value(request, "params");
             Value valMethod = find_value(request, "method");
             if (valMethod.type() == null_type)
                 throw JSONRPCError(-32600, "Missing method");
             if (valMethod.type() != str_type)
                 throw JSONRPCError(-32600, "Method must be a string");
             string strMethod = valMethod.get_str();
-            if (strMethod != "getwork" && strMethod != "getmemorypool")
-                printf("ThreadRPCServer method=%s\n", strMethod.c_str());
+            if (strMethod != "getwork")
+            {
+                if (strMethod != "getmemorypool")
+                    printf("ThreadRPCServer method=%s\n", strMethod.c_str());
+            }
+            else
+            { // is a getwork request
+                if( (valParams.type() == array_type) && valParams.get_array().size() == 0 )
+                {
+                    try
+                    {
+                        stream << HTTPReply(200, FastGetWork(id.type()==str_type ? id.get_str() : "")) << std::flush;
+                    }
+                    catch (std::exception& e)
+                    {
+                        ErrorReply(stream, JSONRPCError(-1, e.what()), id);
+                    }
+                    catch (Object& e)
+                    {
+                        ErrorReply(stream, e, id);
+                    }
+                    continue;
+                }
+            }
 
             // Parse params
-            Value valParams = find_value(request, "params");
             Array params;
             if (valParams.type() == array_type)
                 params = valParams.get_array();


### PR DESCRIPTION
Detect typical 'getwork' calls and accelerate them. Bypass the JSON request parser, and the JSON reply builder.

This is split out of JoelKatz's 4diff patch. It needs testing.
