### PR TITLE
Multithreaded JSON-RPC with HTTP 1.1 Keep-Alive support

### DIFF
--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -2138,7 +2138,7 @@ string rfc1123Time()
     return string(buffer);
 }
 
-static string HTTPReply(int nStatus, const string& strMsg)
+static string HTTPReply(int nStatus, const string& strMsg, bool keepalive)
 {
     if (nStatus == 401)
         return strprintf("HTTP/1.0 401 Authorization Required\r\n"
@@ -2167,7 +2167,7 @@ static string HTTPReply(int nStatus, const string& strMsg)
     return strprintf(
             "HTTP/1.1 %d %s\r\n"
             "Date: %s\r\n"
-            "Connection: close\r\n"
+            "Connection: %s\r\n"
             "Content-Length: %d\r\n"
             "Content-Type: application/json\r\n"
             "Server: bitcoin-json-rpc/%s\r\n"
@@ -2176,12 +2176,13 @@ static string HTTPReply(int nStatus, const string& strMsg)
         nStatus,
         cStatus,
         rfc1123Time().c_str(),
+        keepalive ? "keep-alive" : "close",
         strMsg.size(),
         FormatFullVersion().c_str(),
         strMsg.c_str());
 }
 
-int ReadHTTPStatus(std::basic_istream<char>& stream)
+int ReadHTTPStatus(std::basic_istream<char>& stream, int &proto)
 {
     string str;
     getline(stream, str);
@@ -2189,6 +2190,10 @@ int ReadHTTPStatus(std::basic_istream<char>& stream)
     boost::split(vWords, str, boost::is_any_of(" "));
     if (vWords.size() < 2)
         return 500;
+    proto = 0;
+    const char *ver = strstr(str.c_str(), "HTTP/1.");
+    if (ver != NULL)
+        proto = atoi(ver+7);
     return atoi(vWords[1].c_str());
 }
 
@@ -2223,7 +2228,8 @@ int ReadHTTP(std::basic_istream<char>& stream, map<string, string>& mapHeadersRe
     strMessageRet = "";
 
     // Read status
-    int nStatus = ReadHTTPStatus(stream);
+    int nProto;
+    int nStatus = ReadHTTPStatus(stream, nProto);
 
     // Read header
     int nLen = ReadHTTPHeader(stream, mapHeadersRet);
@@ -2236,6 +2242,16 @@ int ReadHTTP(std::basic_istream<char>& stream, map<string, string>& mapHeadersRe
         vector<char> vch(nLen);
         stream.read(&vch[0], nLen);
         strMessageRet = string(vch.begin(), vch.end());
+    }
+
+    string sConHdr=mapHeadersRet["connection"];
+
+    if ( (sConHdr != "close") && (sConHdr != "keep-alive") )
+    {
+        if(nProto >= 1)
+            mapHeadersRet["connection"]="keep-alive";
+        else
+            mapHeadersRet["connection"]="close";
     }
 
     return nStatus;
@@ -2290,7 +2306,7 @@ void ErrorReply(std::ostream& stream, const Object& objError, const Value& id)
     if (code == -32600) nStatus = 400;
     else if (code == -32601) nStatus = 404;
     string strReply = JSONRPCReply(Value::null, objError, id);
-    stream << HTTPReply(nStatus, strReply) << std::flush;
+    stream << HTTPReply(nStatus, strReply, false) << std::flush;
 }
 
 bool ClientAllowed(const string& strAddress)
@@ -2468,7 +2484,7 @@ void ThreadRPCServer2(void* parg)
         {
             // Only send a 403 if we're not using SSL to prevent a DoS during the SSL handshake.
             if (!fUseSSL)
-                conn->stream << HTTPReply(403, "") << std::flush;
+                conn->stream << HTTPReply(403, "", false) << std::flush;
             delete conn;
         }
         else
@@ -2483,7 +2499,15 @@ void ThreadRPCServer3(void* parg)
     AcceptedConnection *conn=(AcceptedConnection *) parg;
     fUnsafe.reset(new bool(false));
 
-    do {
+    bool fRun = true;
+    loop {
+        if (fShutdown || !fRun)
+        {
+            conn->stream.close();
+            delete conn;
+            --vnThreadsRunning[THREAD_RPCHANDLER];
+            return;
+        }
         map<string, string> mapHeaders;
         string strRequest;
 
@@ -2504,7 +2528,7 @@ void ThreadRPCServer3(void* parg)
         // Check authorization
         if (mapHeaders.count("authorization") == 0)
         {
-            conn->stream << HTTPReply(401, "") << std::flush;
+            conn->stream << HTTPReply(401, "", false) << std::flush;
             break;
         }
         if (!HTTPAuthorized(mapHeaders))
@@ -2516,9 +2540,11 @@ void ThreadRPCServer3(void* parg)
             if (mapArgs["-rpcpassword"].size() < 20)
                 Sleep(250);
 
-            conn->stream << HTTPReply(401, "") << std::flush;
+            conn->stream << HTTPReply(401, "", false) << std::flush;
             break;
         }
+        if (mapHeaders["connection"] == "close")
+            fRun = false;
 
         ThreadUnsafeRPC();
 
@@ -2577,17 +2603,19 @@ void ThreadRPCServer3(void* parg)
 
                 // Send reply
                 string strReply = JSONRPCReply(result, Value::null, id);
-                conn->stream << HTTPReply(200, strReply) << std::flush;
+                conn->stream << HTTPReply(200, strReply, fRun) << std::flush;
             }
             catch (std::exception& e)
             {
                 ThreadSafeRPC();
                 ErrorReply(conn->stream, JSONRPCError(-1, e.what()), id);
+                fRun = false;
             }
             catch (Object& e)
             {
                 ThreadSafeRPC();
                 ErrorReply(conn->stream, e, id);
+                fRun = false;
             }
         }
         catch (Object& objError)

--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -1818,15 +1818,20 @@ Value getwork(const Array& params, bool fHelp)
                     delete pblock;
                 vNewBlock.clear();
             }
+
+            // Create new block
+            CBlock* pNewBlock;
+            ThreadSafeRPC();
+            pNewBlock = CreateNewBlock(reservekey);
+            ThreadUnsafeRPC();
+            if (!pNewBlock)
+                throw JSONRPCError(-7, "Out of memory");
+            vNewBlock.push_back(pNewBlock);
+            pblock = pNewBlock;
+
             nTransactionsUpdatedLast = nTransactionsUpdated;
             pindexPrev = pindexBest;
             nStart = GetTime();
-
-            // Create new block
-            pblock = CreateNewBlock(reservekey);
-            if (!pblock)
-                throw JSONRPCError(-7, "Out of memory");
-            vNewBlock.push_back(pblock);
         }
 
         // Update nTime

--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -56,7 +56,25 @@ extern Value dumpprivkey(const Array& params, bool fHelp);
 extern Value importprivkey(const Array& params, bool fHelp);
 
 void ThreadRPCServer3(void* parg);
-boost::mutex mRPCHandler; // for some reason, 'getwork' is not reentrant
+
+static boost::mutex mUnsafeRPC;
+boost::thread_specific_ptr<bool> fUnsafe;
+
+inline void ThreadSafeRPC()
+{
+    if (!*fUnsafe)
+        return;
+    mUnsafeRPC.unlock();
+    *fUnsafe = false;
+}
+
+inline void ThreadUnsafeRPC()
+{
+    if (*fUnsafe)
+        return;
+    mUnsafeRPC.lock();
+    *fUnsafe = true;
+}
 
 Object JSONRPCError(int code, const string& message)
 {
@@ -2463,6 +2481,7 @@ void ThreadRPCServer3(void* parg)
     IMPLEMENT_RANDOMIZE_STACK(ThreadRPCServer3(parg));
     ++vnThreadsRunning[THREAD_RPCHANDLER];
     AcceptedConnection *conn=(AcceptedConnection *) parg;
+    fUnsafe.reset(new bool(false));
 
     do {
         map<string, string> mapHeaders;
@@ -2500,6 +2519,8 @@ void ThreadRPCServer3(void* parg)
             conn->stream << HTTPReply(401, "") << std::flush;
             break;
         }
+
+        ThreadUnsafeRPC();
 
         Value id = Value::null;
         try
@@ -2545,7 +2566,6 @@ void ThreadRPCServer3(void* parg)
 
             try
             {
-                boost::unique_lock<boost::mutex> lock(mRPCHandler);
                 // Execute
                 Value result;
                 {
@@ -2553,32 +2573,41 @@ void ThreadRPCServer3(void* parg)
                     result = (*(*mi).second)(params, false);
                 }
 
+                ThreadSafeRPC();
+
                 // Send reply
                 string strReply = JSONRPCReply(result, Value::null, id);
                 conn->stream << HTTPReply(200, strReply) << std::flush;
             }
             catch (std::exception& e)
             {
+                ThreadSafeRPC();
                 ErrorReply(conn->stream, JSONRPCError(-1, e.what()), id);
             }
             catch (Object& e)
             {
+                ThreadSafeRPC();
                 ErrorReply(conn->stream, e, id);
             }
         }
         catch (Object& objError)
         {
+            ThreadSafeRPC();
             ErrorReply(conn->stream, objError, id);
             break;
         }
         catch (std::exception& e)
         {
+            ThreadSafeRPC();
             ErrorReply(conn->stream, JSONRPCError(-32700, e.what()), id);
             break;
         }
+
+        ThreadSafeRPC();
     }
     while (0);
     delete conn;
+    delete fUnsafe.release();
     --vnThreadsRunning[THREAD_RPCHANDLER];
 }
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1708,12 +1708,13 @@ bool StopNode()
     if (vnThreadsRunning[THREAD_OPENCONNECTIONS] > 0) printf("ThreadOpenConnections still running\n");
     if (vnThreadsRunning[THREAD_MESSAGEHANDLER] > 0) printf("ThreadMessageHandler still running\n");
     if (vnThreadsRunning[THREAD_MINER] > 0) printf("ThreadBitcoinMiner still running\n");
-    if (vnThreadsRunning[THREAD_RPCSERVER] > 0) printf("ThreadRPCServer still running\n");
+    if (vnThreadsRunning[THREAD_RPCLISTENER] > 0) printf("ThreadRPCListener still running\n");
+    if (vnThreadsRunning[THREAD_RPCHANDLER] > 0) printf("ThreadsRPCServer still running\n");
     if (fHaveUPnP && vnThreadsRunning[THREAD_UPNP] > 0) printf("ThreadMapPort still running\n");
     if (vnThreadsRunning[THREAD_DNSSEED] > 0) printf("ThreadDNSAddressSeed still running\n");
     if (vnThreadsRunning[THREAD_ADDEDCONNECTIONS] > 0) printf("ThreadOpenAddedConnections still running\n");
     if (vnThreadsRunning[THREAD_DUMPADDRESS] > 0) printf("ThreadDumpAddresses still running\n");
-    while (vnThreadsRunning[THREAD_MESSAGEHANDLER] > 0 || vnThreadsRunning[THREAD_RPCSERVER] > 0)
+    while (vnThreadsRunning[THREAD_MESSAGEHANDLER] > 0 || vnThreadsRunning[THREAD_RPCHANDLER] > 0)
         Sleep(20);
     Sleep(50);
     DumpAddresses();

--- a/src/net.h
+++ b/src/net.h
@@ -7,6 +7,7 @@
 
 #include <deque>
 #include <boost/array.hpp>
+#include <boost/detail/atomic_count.hpp>
 #include <boost/foreach.hpp>
 #include <openssl/rand.h>
 
@@ -73,11 +74,12 @@ enum threadId
     THREAD_OPENCONNECTIONS,
     THREAD_MESSAGEHANDLER,
     THREAD_MINER,
-    THREAD_RPCSERVER,
+    THREAD_RPCLISTENER,
     THREAD_UPNP,
     THREAD_DNSSEED,
     THREAD_ADDEDCONNECTIONS,
     THREAD_DUMPADDRESS,
+    THREAD_RPCHANDLER,
 
     THREAD_MAX
 };


### PR DESCRIPTION
This is a combination of my older multithreaded patch and parts of JoelKatz's 4diff patch. My original patch was required to get Eligius started and had testing from early 2011 until a few months ago when I merged it with JoelKatz's code (which fixed SSL JSON-RPC and added keepalive support). Since then, the combination has had plenty of testing on Eligius with the 0.3.24 codebase.
