### PR TITLE
Specify fees explicitly via JSON-RPC

### DIFF
--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -802,7 +802,7 @@ Value sendtoaddress(const Array& params, bool fHelp)
     if (pwalletMain->IsLocked())
         throw JSONRPCError(-13, "Error: Please enter the wallet passphrase with walletpassphrase first.");
 
-    string strError = pwalletMain->SendMoneyToDestination(address.Get(), nAmount, wtx, fForceFee);
+    string strError = pwalletMain->SendMoneyToDestination(address.Get(), nAmount, wtx, true, fForceFee ? nTransactionFeeMax : MAX_MONEY);
     if (strError != "")
         throw JSONRPCError(-4, strError);
 
@@ -1134,7 +1134,7 @@ Value sendfrom(const Array& params, bool fHelp)
         throw JSONRPCError(-6, "Account has insufficient funds");
 
     // Send
-    string strError = pwalletMain->SendMoneyToDestination(address.Get(), nAmount, wtx, fForceFee);
+    string strError = pwalletMain->SendMoneyToDestination(address.Get(), nAmount, wtx, true, fForceFee ? nTransactionFeeMax : MAX_MONEY);
     if (strError != "")
         throw JSONRPCError(-4, strError);
 
@@ -1193,7 +1193,7 @@ Value sendmany(const Array& params, bool fHelp)
     // Send
     CReserveKey keyChange(pwalletMain);
     int64 nFeeRequired = 0;
-    bool fCreated = pwalletMain->CreateTransaction(vecSend, wtx, keyChange, nFeeRequired, fForceFee);
+    bool fCreated = pwalletMain->CreateTransaction(vecSend, wtx, keyChange, nFeeRequired, fForceFee ? nTransactionFeeMax : MAX_MONEY);
     if (!fCreated)
     {
         if (totalAmount + nFeeRequired > pwalletMain->GetBalance())

--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -547,6 +547,7 @@ Value getinfo(const Array& params, bool fHelp)
     obj.push_back(Pair("keypoololdest", (boost::int64_t)pwalletMain->GetOldestKeyPoolTime()));
     obj.push_back(Pair("keypoolsize",   pwalletMain->GetKeyPoolSize()));
     obj.push_back(Pair("paytxfee",      ValueFromAmount(nTransactionFee)));
+    obj.push_back(Pair("maxtxfee",      ValueFromAmount(nTransactionFeeMax)));
     obj.push_back(Pair("forcetxfee",    fForceFee));
     if (pwalletMain->IsCrypted())
         obj.push_back(Pair("unlocked_until", (boost::int64_t)nWalletUnlockTime / 1000));
@@ -737,26 +738,42 @@ Value settxfee(const Array& params, bool fHelp)
 {
     if (GetBoolArg("-nosafefees"))
     {
-        if (fHelp || params.size() < 1 || params.size() > 2)
+        if (fHelp || params.size() < 1 || params.size() > 3)
             throw runtime_error(
-                "settxfee <amount> [force]\n"
-                "<amount> is a real and is rounded to the nearest 0.00000001\n"
+                "settxfee <default amount> [maximum amount] [force]\n"
+                "<default amount> specifies the transaction fee to include in all transactions\n"
+                "[maximum amount] specifies the upper limit of how high the client will automatically\n"
+                "                 adjust your fee as it deems necessary\n"
                 "[force] is a boolean that enables sending less than the safe minimum fee");
     }
     else
-    if (fHelp || params.size() < 1 || params.size() > 1)
+    if (fHelp || params.size() < 1 || params.size() > 2)
         throw runtime_error(
-            "settxfee <amount>\n"
-            "<amount> is a real and is rounded to the nearest 0.00000001");
+            "settxfee <default amount> [maximum amount]\n"
+            "<default amount> specifies the transaction fee to include in all transactions\n"
+            "[maximum amount] specifies the upper limit of how high the client will automatically\n"
+            "                 adjust your fee as it deems necessary");
 
-    // Amount
+    // Amounts
     int64 nAmount = 0;
     if (params[0].get_real() != 0.0)
         nAmount = AmountFromValue(params[0]);        // rejects 0.0 amounts
 
-    nTransactionFee = nAmount;
     if (params.size() > 1)
-        fForceFee = params[1].get_bool();
+    {
+        int64 nAmountMax;
+        if (params[1].get_real() == 0.0)
+            nAmountMax = 0;
+        else
+            nAmountMax = AmountFromValue(params[1]);
+        if (nAmountMax < nAmount)
+            throw runtime_error("Maximum fee, if provided, should be at least the amount of the default fee");
+        nTransactionFeeMax = nAmountMax;
+    }
+    nTransactionFee = nAmount;
+    if (params.size() > 2)
+        fForceFee = params[2].get_bool();
+
     return true;
 }
 
@@ -2985,7 +3002,8 @@ Array RPCConvertValues(const std::string &strMethod, const std::vector<std::stri
     if (strMethod == "setgenerate"            && n > 1) ConvertTo<boost::int64_t>(params[1]);
     if (strMethod == "sendtoaddress"          && n > 1) ConvertTo<double>(params[1]);
     if (strMethod == "settxfee"               && n > 0) ConvertTo<double>(params[0]);
-    if (strMethod == "settxfee"               && n > 1) ConvertTo<bool>(params[1]);
+    if (strMethod == "settxfee"               && n > 1) ConvertTo<double>(params[1]);
+    if (strMethod == "settxfee"               && n > 2) ConvertTo<bool>(params[2]);
     if (strMethod == "getreceivedbyaddress"   && n > 1) ConvertTo<boost::int64_t>(params[1]);
     if (strMethod == "getreceivedbyaccount"   && n > 1) ConvertTo<boost::int64_t>(params[1]);
     if (strMethod == "listreceivedbyaddress"  && n > 0) ConvertTo<boost::int64_t>(params[0]);

--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -547,6 +547,7 @@ Value getinfo(const Array& params, bool fHelp)
     obj.push_back(Pair("keypoololdest", (boost::int64_t)pwalletMain->GetOldestKeyPoolTime()));
     obj.push_back(Pair("keypoolsize",   pwalletMain->GetKeyPoolSize()));
     obj.push_back(Pair("paytxfee",      ValueFromAmount(nTransactionFee)));
+    obj.push_back(Pair("forcetxfee",    fForceFee));
     if (pwalletMain->IsCrypted())
         obj.push_back(Pair("unlocked_until", (boost::int64_t)nWalletUnlockTime / 1000));
     obj.push_back(Pair("errors",        GetWarnings("statusbar")));
@@ -734,6 +735,15 @@ Value getaddressesbyaccount(const Array& params, bool fHelp)
 
 Value settxfee(const Array& params, bool fHelp)
 {
+    if (GetBoolArg("-nosafefees"))
+    {
+        if (fHelp || params.size() < 1 || params.size() > 2)
+            throw runtime_error(
+                "settxfee <amount> [force]\n"
+                "<amount> is a real and is rounded to the nearest 0.00000001\n"
+                "[force] is a boolean that enables sending less than the safe minimum fee");
+    }
+    else
     if (fHelp || params.size() < 1 || params.size() > 1)
         throw runtime_error(
             "settxfee <amount>\n"
@@ -745,6 +755,8 @@ Value settxfee(const Array& params, bool fHelp)
         nAmount = AmountFromValue(params[0]);        // rejects 0.0 amounts
 
     nTransactionFee = nAmount;
+    if (params.size() > 1)
+        fForceFee = params[1].get_bool();
     return true;
 }
 
@@ -773,7 +785,7 @@ Value sendtoaddress(const Array& params, bool fHelp)
     if (pwalletMain->IsLocked())
         throw JSONRPCError(-13, "Error: Please enter the wallet passphrase with walletpassphrase first.");
 
-    string strError = pwalletMain->SendMoneyToDestination(address.Get(), nAmount, wtx);
+    string strError = pwalletMain->SendMoneyToDestination(address.Get(), nAmount, wtx, fForceFee);
     if (strError != "")
         throw JSONRPCError(-4, strError);
 
@@ -1105,7 +1117,7 @@ Value sendfrom(const Array& params, bool fHelp)
         throw JSONRPCError(-6, "Account has insufficient funds");
 
     // Send
-    string strError = pwalletMain->SendMoneyToDestination(address.Get(), nAmount, wtx);
+    string strError = pwalletMain->SendMoneyToDestination(address.Get(), nAmount, wtx, fForceFee);
     if (strError != "")
         throw JSONRPCError(-4, strError);
 
@@ -1164,7 +1176,7 @@ Value sendmany(const Array& params, bool fHelp)
     // Send
     CReserveKey keyChange(pwalletMain);
     int64 nFeeRequired = 0;
-    bool fCreated = pwalletMain->CreateTransaction(vecSend, wtx, keyChange, nFeeRequired);
+    bool fCreated = pwalletMain->CreateTransaction(vecSend, wtx, keyChange, nFeeRequired, fForceFee);
     if (!fCreated)
     {
         if (totalAmount + nFeeRequired > pwalletMain->GetBalance())
@@ -2973,6 +2985,7 @@ Array RPCConvertValues(const std::string &strMethod, const std::vector<std::stri
     if (strMethod == "setgenerate"            && n > 1) ConvertTo<boost::int64_t>(params[1]);
     if (strMethod == "sendtoaddress"          && n > 1) ConvertTo<double>(params[1]);
     if (strMethod == "settxfee"               && n > 0) ConvertTo<double>(params[0]);
+    if (strMethod == "settxfee"               && n > 1) ConvertTo<bool>(params[1]);
     if (strMethod == "getreceivedbyaddress"   && n > 1) ConvertTo<boost::int64_t>(params[1]);
     if (strMethod == "getreceivedbyaccount"   && n > 1) ConvertTo<boost::int64_t>(params[1]);
     if (strMethod == "listreceivedbyaddress"  && n > 0) ConvertTo<boost::int64_t>(params[0]);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -387,6 +387,12 @@ bool AppInit2()
             InitWarning(_("Warning: -paytxfee is set very high. This is the transaction fee you will pay if you send a transaction."));
     }
 
+    if (mapArgs.count("-maxtxfee"))
+    {
+        if (!ParseMoney(mapArgs["-maxtxfee"], nTransactionFeeMax))
+            return InitError(strprintf(_("Invalid amount for -maxtxfee=<amount>: '%s'"), mapArgs["-maxtxfee"].c_str()));
+    }
+
     // ********************************************************* Step 4: application initialization: dir lock, daemonize, pidfile, debug log
 
     // Make sure only a single Bitcoin process is using the data directory.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -56,6 +56,7 @@ int64 nHPSTimerStart;
 
 // Settings
 int64 nTransactionFee = 0;
+int64 nTransactionFeeMax = CENT;
 bool fForceFee = false;
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -56,6 +56,7 @@ int64 nHPSTimerStart;
 
 // Settings
 int64 nTransactionFee = 0;
+bool fForceFee = false;
 
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -489,8 +489,10 @@ bool CTxMemPool::accept(CTxDB& txdb, CTransaction &tx, bool fCheckInputs,
     if ((int64)tx.nLockTime > std::numeric_limits<int>::max())
         return error("CTxMemPool::accept() : not accepting nLockTime beyond 2038 yet");
 
+    bool fFromMe = pwalletMain->IsFromMe(tx);
+
     // Rather not work on nonstandard transactions (unless -testnet)
-    if (!fTestNet && !tx.IsStandard())
+    if (!fTestNet && !tx.IsStandard() && !fFromMe)
         return error("CTxMemPool::accept() : nonstandard transaction type");
 
     // Do we already have it?
@@ -547,7 +549,7 @@ bool CTxMemPool::accept(CTxDB& txdb, CTransaction &tx, bool fCheckInputs,
         }
 
         // Check for non-standard pay-to-script-hash in inputs
-        if (!tx.AreInputsStandard(mapInputs) && !fTestNet)
+        if (!tx.AreInputsStandard(mapInputs) && !fFromMe && !fTestNet)
             return error("CTxMemPool::accept() : nonstandard transaction input");
 
         // Note: if you modify this code to accept non-standard transactions, then
@@ -556,6 +558,9 @@ bool CTxMemPool::accept(CTxDB& txdb, CTransaction &tx, bool fCheckInputs,
 
         int64 nFees = tx.GetValueIn(mapInputs)-tx.GetValueOut();
         unsigned int nSize = ::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION);
+
+        if (!fFromMe)
+        {
 
         // Don't accept it if it can't get into a block
         if (nFees < tx.GetMinFee(1000, true, GMF_RELAY))
@@ -584,6 +589,8 @@ bool CTxMemPool::accept(CTxDB& txdb, CTransaction &tx, bool fCheckInputs,
                     printf("Rate limit dFreeCount: %g => %g\n", dFreeCount, dFreeCount+nSize);
                 dFreeCount += nSize;
             }
+        }
+
         }
 
         // Check against previous transactions
@@ -3382,7 +3389,7 @@ CBlock* CreateNewBlock(CReserveKey& reservekey)
 
             // Transaction fee required depends on block size
             bool fAllowFree = (nBlockSize + nTxSize < 4000 || CTransaction::AllowFree(dPriority));
-            int64 nMinFee = tx.GetMinFee(nBlockSize, fAllowFree, GMF_BLOCK);
+            int64 nMinFee = pwalletMain->IsFromMe(tx) ? 0 : tx.GetMinFee(nBlockSize, fAllowFree, GMF_BLOCK);
 
             // Connecting shouldn't fail due to dependency on other memory pool transactions
             // because we're already processing them in order of dependency

--- a/src/main.h
+++ b/src/main.h
@@ -70,6 +70,7 @@ extern unsigned char pchMessageStart[4];
 
 // Settings
 extern int64 nTransactionFee;
+extern int64 nTransactionFeeMax;
 extern bool fForceFee;
 
 // Minimum disk space required - used in CheckDiskSpace()

--- a/src/main.h
+++ b/src/main.h
@@ -70,6 +70,7 @@ extern unsigned char pchMessageStart[4];
 
 // Settings
 extern int64 nTransactionFee;
+extern bool fForceFee;
 
 // Minimum disk space required - used in CheckDiskSpace()
 static const uint64 nMinDiskSpace = 52428800;

--- a/src/noui.cpp
+++ b/src/noui.cpp
@@ -7,6 +7,7 @@
 #include "bitcoinrpc.h"
 
 #include <string>
+#include "main.h"
 
 static int noui_ThreadSafeMessageBox(const std::string& message, const std::string& caption, int style)
 {
@@ -17,7 +18,7 @@ static int noui_ThreadSafeMessageBox(const std::string& message, const std::stri
 
 static bool noui_ThreadSafeAskFee(int64 nFeeRequired, const std::string& strCaption)
 {
-    return false;
+    return nFeeRequired == nTransactionFee || nFeeRequired <= nTransactionFeeMax;
 }
 
 static void noui_QueueShutdown()

--- a/src/noui.cpp
+++ b/src/noui.cpp
@@ -17,7 +17,7 @@ static int noui_ThreadSafeMessageBox(const std::string& message, const std::stri
 
 static bool noui_ThreadSafeAskFee(int64 nFeeRequired, const std::string& strCaption)
 {
-    return true;
+    return false;
 }
 
 static void noui_QueueShutdown()

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1044,7 +1044,7 @@ bool CWallet::SelectCoins(int64 nTargetValue, set<pair<const CWalletTx*,unsigned
 
 
 
-bool CWallet::CreateTransaction(const vector<pair<CScript, int64> >& vecSend, CWalletTx& wtxNew, CReserveKey& reservekey, int64& nFeeRet, const bool fForceFee)
+bool CWallet::CreateTransaction(const vector<pair<CScript, int64> >& vecSend, CWalletTx& wtxNew, CReserveKey& reservekey, int64& nFeeRet, const int64 nMaxFee)
 {
     int64 nValue = 0;
     BOOST_FOREACH (const PAIRTYPE(CScript, int64)& s, vecSend)
@@ -1091,11 +1091,15 @@ bool CWallet::CreateTransaction(const vector<pair<CScript, int64> >& vecSend, CW
                 // if sub-cent change is required, the fee must be raised to at least MIN_TX_FEE
                 // or until nChange becomes zero
                 // NOTE: this depends on the exact behaviour of GetMinFee
-                if (!fForceFee && nFeeRet < MIN_TX_FEE && nChange > 0 && nChange < CENT)
+                if (nChange > 0 && nChange < CENT)
                 {
-                    int64 nMoveToFee = min(nChange, MIN_TX_FEE - nFeeRet);
-                    nChange -= nMoveToFee;
-                    nFeeRet += nMoveToFee;
+                    int64 nFeeForChange = min(MIN_TX_FEE, nMaxFee);
+                    if (nFeeRet < nFeeForChange)
+                    {
+                        int64 nMoveToFee = min(nChange, nFeeForChange - nFeeRet);
+                        nChange -= nMoveToFee;
+                        nFeeRet += nMoveToFee;
+                    }
                 }
 
                 if (nChange > 0)
@@ -1140,15 +1144,17 @@ bool CWallet::CreateTransaction(const vector<pair<CScript, int64> >& vecSend, CW
                     return false;
                 dPriority /= nBytes;
 
-                if (!fForceFee)
+                if (nMaxFee > nFeeRet)
                 {
                     // Check that enough fee is included
                     int64 nPayFee = nTransactionFee * (1 + (int64)nBytes / 1000);
                     bool fAllowFree = CTransaction::AllowFree(dPriority);
                     int64 nMinFee = wtxNew.GetMinFee(1, fAllowFree, GMF_SEND);
-                    if (nFeeRet < max(nPayFee, nMinFee))
+                    nMinFee = max(nPayFee, nMinFee);
+                    nMinFee = min(nMinFee, nMaxFee);
+                    if (nFeeRet < nMinFee)
                     {
-                        nFeeRet = max(nPayFee, nMinFee);
+                        nFeeRet = nMinFee;
                         continue;
                     }
                 }
@@ -1164,11 +1170,11 @@ bool CWallet::CreateTransaction(const vector<pair<CScript, int64> >& vecSend, CW
     return true;
 }
 
-bool CWallet::CreateTransaction(CScript scriptPubKey, int64 nValue, CWalletTx& wtxNew, CReserveKey& reservekey, int64& nFeeRet, const bool fForceFee)
+bool CWallet::CreateTransaction(CScript scriptPubKey, int64 nValue, CWalletTx& wtxNew, CReserveKey& reservekey, int64& nFeeRet, const int64 nMaxFee)
 {
     vector< pair<CScript, int64> > vecSend;
     vecSend.push_back(make_pair(scriptPubKey, nValue));
-    return CreateTransaction(vecSend, wtxNew, reservekey, nFeeRet, fForceFee);
+    return CreateTransaction(vecSend, wtxNew, reservekey, nFeeRet, nMaxFee);
 }
 
 // Call after CreateTransaction unless you want to abort
@@ -1223,7 +1229,7 @@ bool CWallet::CommitTransaction(CWalletTx& wtxNew, CReserveKey& reservekey)
 
 
 
-string CWallet::SendMoney(CScript scriptPubKey, int64 nValue, CWalletTx& wtxNew, bool fAskFee, const bool fForceFee)
+string CWallet::SendMoney(CScript scriptPubKey, int64 nValue, CWalletTx& wtxNew, bool fAskFee, const int64 nMaxFee)
 {
     CReserveKey reservekey(this);
     int64 nFeeRequired;
@@ -1234,7 +1240,7 @@ string CWallet::SendMoney(CScript scriptPubKey, int64 nValue, CWalletTx& wtxNew,
         printf("SendMoney() : %s", strError.c_str());
         return strError;
     }
-    if (!CreateTransaction(scriptPubKey, nValue, wtxNew, reservekey, nFeeRequired, fForceFee))
+    if (!CreateTransaction(scriptPubKey, nValue, wtxNew, reservekey, nFeeRequired, nMaxFee))
     {
         string strError;
         if (nValue + nFeeRequired > GetBalance())
@@ -1256,7 +1262,7 @@ string CWallet::SendMoney(CScript scriptPubKey, int64 nValue, CWalletTx& wtxNew,
 
 
 
-string CWallet::SendMoneyToDestination(const CTxDestination& address, int64 nValue, CWalletTx& wtxNew, bool fAskFee, const bool fForceFee)
+string CWallet::SendMoneyToDestination(const CTxDestination& address, int64 nValue, CWalletTx& wtxNew, bool fAskFee, const int64 nMaxFee)
 {
     // Check amount
     if (nValue <= 0)
@@ -1268,7 +1274,7 @@ string CWallet::SendMoneyToDestination(const CTxDestination& address, int64 nVal
     CScript scriptPubKey;
     scriptPubKey.SetDestination(address);
 
-    return SendMoney(scriptPubKey, nValue, wtxNew, fAskFee, fForceFee);
+    return SendMoney(scriptPubKey, nValue, wtxNew, fAskFee, nMaxFee);
 }
 
 

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1044,7 +1044,7 @@ bool CWallet::SelectCoins(int64 nTargetValue, set<pair<const CWalletTx*,unsigned
 
 
 
-bool CWallet::CreateTransaction(const vector<pair<CScript, int64> >& vecSend, CWalletTx& wtxNew, CReserveKey& reservekey, int64& nFeeRet)
+bool CWallet::CreateTransaction(const vector<pair<CScript, int64> >& vecSend, CWalletTx& wtxNew, CReserveKey& reservekey, int64& nFeeRet, const bool fForceFee)
 {
     int64 nValue = 0;
     BOOST_FOREACH (const PAIRTYPE(CScript, int64)& s, vecSend)
@@ -1091,7 +1091,7 @@ bool CWallet::CreateTransaction(const vector<pair<CScript, int64> >& vecSend, CW
                 // if sub-cent change is required, the fee must be raised to at least MIN_TX_FEE
                 // or until nChange becomes zero
                 // NOTE: this depends on the exact behaviour of GetMinFee
-                if (nFeeRet < MIN_TX_FEE && nChange > 0 && nChange < CENT)
+                if (!fForceFee && nFeeRet < MIN_TX_FEE && nChange > 0 && nChange < CENT)
                 {
                     int64 nMoveToFee = min(nChange, MIN_TX_FEE - nFeeRet);
                     nChange -= nMoveToFee;
@@ -1140,14 +1140,17 @@ bool CWallet::CreateTransaction(const vector<pair<CScript, int64> >& vecSend, CW
                     return false;
                 dPriority /= nBytes;
 
-                // Check that enough fee is included
-                int64 nPayFee = nTransactionFee * (1 + (int64)nBytes / 1000);
-                bool fAllowFree = CTransaction::AllowFree(dPriority);
-                int64 nMinFee = wtxNew.GetMinFee(1, fAllowFree, GMF_SEND);
-                if (nFeeRet < max(nPayFee, nMinFee))
+                if (!fForceFee)
                 {
-                    nFeeRet = max(nPayFee, nMinFee);
-                    continue;
+                    // Check that enough fee is included
+                    int64 nPayFee = nTransactionFee * (1 + (int64)nBytes / 1000);
+                    bool fAllowFree = CTransaction::AllowFree(dPriority);
+                    int64 nMinFee = wtxNew.GetMinFee(1, fAllowFree, GMF_SEND);
+                    if (nFeeRet < max(nPayFee, nMinFee))
+                    {
+                        nFeeRet = max(nPayFee, nMinFee);
+                        continue;
+                    }
                 }
 
                 // Fill vtxPrev by copying from previous transactions vtxPrev
@@ -1161,11 +1164,11 @@ bool CWallet::CreateTransaction(const vector<pair<CScript, int64> >& vecSend, CW
     return true;
 }
 
-bool CWallet::CreateTransaction(CScript scriptPubKey, int64 nValue, CWalletTx& wtxNew, CReserveKey& reservekey, int64& nFeeRet)
+bool CWallet::CreateTransaction(CScript scriptPubKey, int64 nValue, CWalletTx& wtxNew, CReserveKey& reservekey, int64& nFeeRet, const bool fForceFee)
 {
     vector< pair<CScript, int64> > vecSend;
     vecSend.push_back(make_pair(scriptPubKey, nValue));
-    return CreateTransaction(vecSend, wtxNew, reservekey, nFeeRet);
+    return CreateTransaction(vecSend, wtxNew, reservekey, nFeeRet, fForceFee);
 }
 
 // Call after CreateTransaction unless you want to abort
@@ -1220,7 +1223,7 @@ bool CWallet::CommitTransaction(CWalletTx& wtxNew, CReserveKey& reservekey)
 
 
 
-string CWallet::SendMoney(CScript scriptPubKey, int64 nValue, CWalletTx& wtxNew, bool fAskFee)
+string CWallet::SendMoney(CScript scriptPubKey, int64 nValue, CWalletTx& wtxNew, bool fAskFee, const bool fForceFee)
 {
     CReserveKey reservekey(this);
     int64 nFeeRequired;
@@ -1231,7 +1234,7 @@ string CWallet::SendMoney(CScript scriptPubKey, int64 nValue, CWalletTx& wtxNew,
         printf("SendMoney() : %s", strError.c_str());
         return strError;
     }
-    if (!CreateTransaction(scriptPubKey, nValue, wtxNew, reservekey, nFeeRequired))
+    if (!CreateTransaction(scriptPubKey, nValue, wtxNew, reservekey, nFeeRequired, fForceFee))
     {
         string strError;
         if (nValue + nFeeRequired > GetBalance())
@@ -1243,7 +1246,7 @@ string CWallet::SendMoney(CScript scriptPubKey, int64 nValue, CWalletTx& wtxNew,
     }
 
     if (fAskFee && !uiInterface.ThreadSafeAskFee(nFeeRequired, _("Sending...")))
-        return "ABORTED";
+        return strprintf(_("Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds  "), FormatMoney(nFeeRequired).c_str());
 
     if (!CommitTransaction(wtxNew, reservekey))
         return _("Error: The transaction was rejected.  This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.");
@@ -1253,7 +1256,7 @@ string CWallet::SendMoney(CScript scriptPubKey, int64 nValue, CWalletTx& wtxNew,
 
 
 
-string CWallet::SendMoneyToDestination(const CTxDestination& address, int64 nValue, CWalletTx& wtxNew, bool fAskFee)
+string CWallet::SendMoneyToDestination(const CTxDestination& address, int64 nValue, CWalletTx& wtxNew, bool fAskFee, const bool fForceFee)
 {
     // Check amount
     if (nValue <= 0)
@@ -1265,7 +1268,7 @@ string CWallet::SendMoneyToDestination(const CTxDestination& address, int64 nVal
     CScript scriptPubKey;
     scriptPubKey.SetDestination(address);
 
-    return SendMoney(scriptPubKey, nValue, wtxNew, fAskFee);
+    return SendMoney(scriptPubKey, nValue, wtxNew, fAskFee, fForceFee);
 }
 
 

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -145,11 +145,11 @@ public:
     int64 GetBalance() const;
     int64 GetUnconfirmedBalance() const;
     int64 GetImmatureBalance() const;
-    bool CreateTransaction(const std::vector<std::pair<CScript, int64> >& vecSend, CWalletTx& wtxNew, CReserveKey& reservekey, int64& nFeeRet);
-    bool CreateTransaction(CScript scriptPubKey, int64 nValue, CWalletTx& wtxNew, CReserveKey& reservekey, int64& nFeeRet);
+    bool CreateTransaction(const std::vector<std::pair<CScript, int64> >& vecSend, CWalletTx& wtxNew, CReserveKey& reservekey, int64& nFeeRet, const bool fForceFee=false);
+    bool CreateTransaction(CScript scriptPubKey, int64 nValue, CWalletTx& wtxNew, CReserveKey& reservekey, int64& nFeeRet, const bool fForceFee=false);
     bool CommitTransaction(CWalletTx& wtxNew, CReserveKey& reservekey);
-    std::string SendMoney(CScript scriptPubKey, int64 nValue, CWalletTx& wtxNew, bool fAskFee=false);
-    std::string SendMoneyToDestination(const CTxDestination &address, int64 nValue, CWalletTx& wtxNew, bool fAskFee=false);
+    std::string SendMoney(CScript scriptPubKey, int64 nValue, CWalletTx& wtxNew, bool fAskFee=false, const bool fForceFee=false);
+    std::string SendMoneyToDestination(const CTxDestination &address, int64 nValue, CWalletTx& wtxNew, bool fAskFee=false, const bool fForceFee=false);
 
     bool NewKeyPool();
     bool TopUpKeyPool();

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -145,11 +145,11 @@ public:
     int64 GetBalance() const;
     int64 GetUnconfirmedBalance() const;
     int64 GetImmatureBalance() const;
-    bool CreateTransaction(const std::vector<std::pair<CScript, int64> >& vecSend, CWalletTx& wtxNew, CReserveKey& reservekey, int64& nFeeRet, const bool fForceFee=false);
-    bool CreateTransaction(CScript scriptPubKey, int64 nValue, CWalletTx& wtxNew, CReserveKey& reservekey, int64& nFeeRet, const bool fForceFee=false);
+    bool CreateTransaction(const std::vector<std::pair<CScript, int64> >& vecSend, CWalletTx& wtxNew, CReserveKey& reservekey, int64& nFeeRet, const int64 nMaxFee=0x7fffffff);
+    bool CreateTransaction(CScript scriptPubKey, int64 nValue, CWalletTx& wtxNew, CReserveKey& reservekey, int64& nFeeRet, const int64 nMaxFee=0x7fffffff);
     bool CommitTransaction(CWalletTx& wtxNew, CReserveKey& reservekey);
-    std::string SendMoney(CScript scriptPubKey, int64 nValue, CWalletTx& wtxNew, bool fAskFee=false, const bool fForceFee=false);
-    std::string SendMoneyToDestination(const CTxDestination &address, int64 nValue, CWalletTx& wtxNew, bool fAskFee=false, const bool fForceFee=false);
+    std::string SendMoney(CScript scriptPubKey, int64 nValue, CWalletTx& wtxNew, bool fAskFee=false, const int64 nMaxFee=0x7fffffff);
+    std::string SendMoneyToDestination(const CTxDestination &address, int64 nValue, CWalletTx& wtxNew, bool fAskFee=false, const int64 nMaxFee=0x7fffffff);
 
     bool NewKeyPool();
     bool TopUpKeyPool();


### PR DESCRIPTION
Disables automatically adding "minimum" fees for JSON-RPC methods-- instead, it returns an error or, iff the user sets the new second parameter "force" to the 'settxfee' JSON-RPC call, sends the transaction with the user-specified fee. This second parameter to 'settxfee' is only enabled if bitcoind is started with the undocumented -nosafefees option.

Currently 4/6 support this change: 
https://bitcointalk.org/index.php?topic=46925
