### PR TITLE
Fix for win64 build

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -710,8 +710,8 @@ inline bool AffinityBugWorkaround(void(*pfn)(void*))
 {
 #ifdef __WXMSW__
     // Sometimes after a few hours affinity gets stuck on one processor
-    DWORD dwProcessAffinityMask = -1;
-    DWORD dwSystemAffinityMask = -1;
+    DWORD_PTR dwProcessAffinityMask = -1;
+    DWORD_PTR dwSystemAffinityMask = -1;
     GetProcessAffinityMask(GetCurrentProcess(), &dwProcessAffinityMask, &dwSystemAffinityMask);
     DWORD dwPrev1 = SetThreadAffinityMask(GetCurrentThread(), dwProcessAffinityMask);
     DWORD dwPrev2 = SetThreadAffinityMask(GetCurrentThread(), dwProcessAffinityMask);


### PR DESCRIPTION
Hi, I was writing a script for automated cross-build (Linux -> win64) for bitcoin (https://github.com/delirium---/bqt-autobuild) and met some issues with building the client. One is solved in attached commit https://github.com/delirium---/bitcoin/commit/b95e6376d083dc904722c4b5ddd7954a3a44826d

DWORD and DWORD_PTR have same size of 32bit systems but different on 64bit. 
