### PR TITLE
Added a workaround for an Ubuntu bug which causes -fstack-protector-all t

### DIFF
--- a/src/makefile.unix
+++ b/src/makefile.unix
@@ -51,12 +51,17 @@ LIBS+= \
 # Hardening
 # Make some classes of vulnerabilities unexploitable in case one is discovered.
 #
+    # This is a workaround for Ubuntu bug #691722, the default -fstack-protector causes
+    # -fstack-protector-all to be ignored unless -fno-stack-protector is used first.
+    # see: https://bugs.launchpad.net/ubuntu/+source/gcc-4.5/+bug/691722
+    HARDENING=-fno-stack-protector
+
     # Stack Canaries
     # Put numbers at the beginning of each stack frame and check that they are the same.
     # If a stack buffer if overflowed, it writes over the canary number and then on return
     # when that number is checked, it won't be the same and the program will exit with
     # a "Stack smashing detected" error instead of being exploited.
-    HARDENING=-fstack-protector-all -Wstack-protector
+    HARDENING+=-fstack-protector-all -Wstack-protector
 
     # Make some important things such as the global offset table read only as soon as
     # the dynamic linker is finished building it. This will prevent overwriting of addresses


### PR DESCRIPTION
Added a workaround for an Ubuntu bug which causes -fstack-protector-all to be disregarded.
this causes some functions not to be protected and leads to a warning:
"warning: not protecting function: no buffer at least 8 bytes long"
The bug which this is working around: https://bugs.launchpad.net/ubuntu/+source/gcc-4.5/+bug/691722
