### PR TITLE
Translation look-up logic improvements for Qt UI

### DIFF
--- a/bitcoin-qt.pro
+++ b/bitcoin-qt.pro
@@ -175,10 +175,8 @@ FORMS += \
 CODECFORTR = UTF-8
 
 # for lrelease/lupdate
-TRANSLATIONS = src/qt/locale/bitcoin_de.ts \
-    src/qt/locale/bitcoin_es.ts \
-    src/qt/locale/bitcoin_nl.ts \
-    src/qt/locale/bitcoin_ru.ts
+# also add new translations to src/qt/bitcoin.qrc under translations/
+TRANSLATIONS = $$files(src/qt/locale/bitcoin_*.ts)
 
 isEmpty(QMAKE_LRELEASE) {
     win32:QMAKE_LRELEASE = $$[QT_INSTALL_BINS]\lrelease.exe

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -118,14 +118,27 @@ int main(int argc, char *argv[])
     Q_INIT_RESOURCE(bitcoin);
     QApplication app(argc, argv);
 
-    // Load language file for system locale
-    QString locale = QLocale::system().name();
-    QTranslator qtTranslator;
-    qtTranslator.load(QLibraryInfo::location(QLibraryInfo::TranslationsPath) + "/qt_" + locale);
+    // Load language files for system locale:
+    // - First load the translator for the base language, without territory
+    // - Then load the more specific locale translator
+    QString lang_territory = QLocale::system().name(); // "en_US"
+    QString lang = lang_territory;
+    lang.truncate(lang_territory.lastIndexOf('_')); // "en"
+    QTranslator qtTranslatorBase, qtTranslator, translatorBase, translator;
+
+    qtTranslatorBase.load(QLibraryInfo::location(QLibraryInfo::TranslationsPath) + "/qt_" + lang);
+    if (!qtTranslatorBase.isEmpty())
+        app.installTranslator(&qtTranslatorBase);
+
+    qtTranslator.load(QLibraryInfo::location(QLibraryInfo::TranslationsPath) + "/qt_" + lang_territory);
     if (!qtTranslator.isEmpty())
         app.installTranslator(&qtTranslator);
-    QTranslator translator;
-    translator.load(":/translations/"+locale);
+
+    translatorBase.load(":/translations/"+lang);
+    if (!translatorBase.isEmpty())
+        app.installTranslator(&translatorBase);
+
+    translator.load(":/translations/"+lang_territory);
     if (!translator.isEmpty())
         app.installTranslator(&translator);
 

--- a/src/qt/bitcoin.qrc
+++ b/src/qt/bitcoin.qrc
@@ -46,8 +46,11 @@
         <file alias="update_spinner">res/movies/update_spinner.mng</file>
     </qresource>
     <qresource prefix="/translations">
-        <file alias="de_DE">locale/bitcoin_de.qm</file>
-        <file alias="nl_NL">locale/bitcoin_nl.qm</file>
-        <file alias="ru_RU">locale/bitcoin_ru.qm</file>
+        <file alias="de">locale/bitcoin_de.qm</file>
+        <file alias="es">locale/bitcoin_es.qm</file>
+        <file alias="es_CL">locale/bitcoin_es_CL.qm</file>
+        <file alias="nb">locale/bitcoin_nb.qm</file>
+        <file alias="nl">locale/bitcoin_nl.qm</file>
+        <file alias="ru">locale/bitcoin_ru.qm</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
Improve translation look-up logic. This properly handles cases where a translation is available for the language but not for the specific territory (ie, "es_AR" now falls back on "es" not the default "en_US").
- use wildcard for TRANSLATIONS in bitcoin-qt.pro to automatically build all translations present in src/qt/locale (thanks @tcatm)
- first load translations/&lt;language>.qm, then translations/&lt;language>_&lt;TERRITORY>.qm, so that territory-specific translations take precedence, but the fallback is on the base language if no territory-specific translation exists
