### PR TITLE
Full URL Support in bitcoin-qt

### DIFF
--- a/bitcoin-qt.pro
+++ b/bitcoin-qt.pro
@@ -144,7 +144,8 @@ HEADERS += src/qt/bitcoingui.h \
     src/qt/qvaluecombobox.h \
     src/qt/askpassphrasedialog.h \
     src/protocol.h \
-    src/qt/notificator.h
+    src/qt/notificator.h \
+    src/qt/qtipcserver.h
 
 SOURCES += src/qt/bitcoin.cpp src/qt/bitcoingui.cpp \
     src/qt/transactiontablemodel.cpp \
@@ -192,7 +193,8 @@ SOURCES += src/qt/bitcoin.cpp src/qt/bitcoingui.cpp \
     src/qt/qvaluecombobox.cpp \
     src/qt/askpassphrasedialog.cpp \
     src/protocol.cpp \
-    src/qt/notificator.cpp
+    src/qt/notificator.cpp \
+    src/qt/qtipcserver.cpp
 
 RESOURCES += \
     src/qt/bitcoin.qrc

--- a/contrib/debian/bitcoin-qt.desktop
+++ b/contrib/debian/bitcoin-qt.desktop
@@ -6,6 +6,5 @@ Exec=/usr/bin/bitcoin-qt
 Terminal=false
 Type=Application
 Icon=/usr/share/pixmaps/bitcoin80.xpm
-#For when bitcoin (finally) properly handles bitcoin: URLs
-#MimeType=x-scheme-handler/bitcoin;
+MimeType=x-scheme-handler/bitcoin;
 Categories=Office;

--- a/contrib/debian/bitcoin-qt.install
+++ b/contrib/debian/bitcoin-qt.install
@@ -3,3 +3,4 @@ bitcoin-qt usr/lib/bitcoin
 share/pixmaps/bitcoin32.xpm usr/share/pixmaps
 share/pixmaps/bitcoin80.xpm usr/share/pixmaps
 debian/bitcoin-qt.desktop usr/share/applications
+debian/bitcoin-qt.protocol usr/share/kde4/services/

--- a/contrib/debian/bitcoin-qt.protocol
+++ b/contrib/debian/bitcoin-qt.protocol
@@ -1,0 +1,11 @@
+[Protocol]
+exec=bitcoin-qt '%u'
+protocol=bitcoin
+input=none
+output=none
+helper=true
+listing=
+reading=false
+writing=false
+makedir=false
+deleting=false

--- a/contrib/debian/changelog
+++ b/contrib/debian/changelog
@@ -1,3 +1,10 @@
+bitcoin (0.5.1-natty1) natty; urgency=low
+
+  * Add GNOME/KDE support for bitcoin-qt's bitcoin: URI support.
+    Thanks to luke-jr for the KDE .protocol file.
+
+ -- Matt Corallo <matt@bluematt.me>  Fri, 23 Dec 2011 20:25:00 -0500
+
 bitcoin (0.5.1-natty0) natty; urgency=low
 
   * New upstream release.

--- a/share/setup.nsi
+++ b/share/setup.nsi
@@ -94,6 +94,10 @@ Section -post SEC0001
     WriteRegStr HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$(^Name)" UninstallString $INSTDIR\uninstall.exe
     WriteRegDWORD HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$(^Name)" NoModify 1
     WriteRegDWORD HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$(^Name)" NoRepair 1
+    WriteRegStr HKCR "bitcoin" "URL Protocol" ""
+    WriteRegStr HKCR "bitcoin" "" "URL:Bitcoin"
+    WriteRegStr HKCR "bitcoin\DefaultIcon" "" $INSTDIR\bitcoin.exe
+    WriteRegStr HKCR "bitcoin\shell\open\command" "" '"$INSTDIR\bitcoin.exe" "$$1"'
 SectionEnd
 
 # Macro for selecting uninstaller sections
@@ -131,6 +135,7 @@ Section -un.post UNSEC0001
     DeleteRegValue HKCU "${REGKEY}" Path
     DeleteRegKey /IfEmpty HKCU "${REGKEY}\Components"
     DeleteRegKey /IfEmpty HKCU "${REGKEY}"
+    DeleteRegKey HKCR "bitcoin"
     RmDir /REBOOTOK $SMPROGRAMS\$StartMenuGroup
     RmDir /REBOOTOK $INSTDIR
     Push $R0

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -272,7 +272,7 @@ bool AppInit2(int argc, char* argv[])
 
 #ifndef QT_GUI
     for (int i = 1; i < argc; i++)
-        if (!IsSwitchChar(argv[i][0]))
+        if (!IsSwitchChar(argv[i][0]) && !(strlen(argv[i]) > 7 && strncasecmp(argv[i], "bitcoin:", 8) == 0))
             fCommandLine = true;
 
     if (fCommandLine)

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -671,6 +671,13 @@ void BitcoinGUI::dropEvent(QDropEvent *event)
     event->acceptProposedAction();
 }
 
+void BitcoinGUI::handleURL(QString strURL)
+{
+    gotoSendCoinsPage();
+    QUrl url = QUrl(strURL);
+    sendCoinsPage->handleURL(&url);
+}
+
 void BitcoinGUI::setEncryptionStatus(int status)
 {
     switch(status)

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -123,6 +123,7 @@ public slots:
       @param[out] payFee            true to pay the fee, false to not pay the fee
     */
     void askFee(qint64 nFeeRequired, bool *payFee);
+    void handleURL(QString strURL);
 
 private slots:
     /** Switch to overview (home) page */

--- a/src/qt/qtipcserver.cpp
+++ b/src/qt/qtipcserver.cpp
@@ -1,0 +1,95 @@
+// Copyright (c) 2011 The Bitcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file license.txt or http://www.opensource.org/licenses/mit-license.php.
+
+#include <boost/algorithm/string.hpp>
+#include <boost/interprocess/ipc/message_queue.hpp>
+#include <boost/tokenizer.hpp>
+#include <boost/date_time/posix_time/posix_time.hpp>
+
+#include "headers.h"
+
+using namespace boost::interprocess;
+using namespace boost::posix_time;
+using namespace boost;
+using namespace std;
+
+void ipcShutdown()
+{
+    message_queue::remove("BitcoinURL");
+}
+
+void ipcThread(void* parg)
+{
+    message_queue* mq = (message_queue*)parg;
+    char strBuf[257];
+    size_t nSize;
+    unsigned int nPriority;
+    loop
+    {
+        ptime d = boost::posix_time::microsec_clock::universal_time() + millisec(100);
+        if(mq->timed_receive(&strBuf, sizeof(strBuf), nSize, nPriority, d))
+        {
+            strBuf[nSize] = '\0';
+            // Convert bitcoin:// URLs to bitcoin: URIs
+            if (strBuf[8] == '/' && strBuf[9] == '/')
+            {
+                for (int i = 8; i < 256; i++)
+                {
+                    strBuf[i] = strBuf[i+2];
+                }
+            }
+            ThreadSafeHandleURL(strBuf);
+            Sleep(1000);
+        }
+        if (fShutdown)
+        {
+            ipcShutdown();
+            break;
+        }
+    }
+    ipcShutdown();
+}
+
+void ipcInit()
+{
+    message_queue* mq;
+    char strBuf[257];
+    size_t nSize;
+    unsigned int nPriority;
+    try {
+        mq = new message_queue(open_or_create, "BitcoinURL", 2, 256);
+
+        // Make sure we don't lose any bitcoin: URIs
+        for (int i = 0; i < 2; i++)
+        {
+            ptime d = boost::posix_time::microsec_clock::universal_time() + millisec(1);
+            if(mq->timed_receive(&strBuf, sizeof(strBuf), nSize, nPriority, d))
+            {
+                strBuf[nSize] = '\0';
+                // Convert bitcoin:// URLs to bitcoin: URIs
+                if (strBuf[8] == '/' && strBuf[9] == '/')
+                {
+                    for (int i = 8; i < 256; i++)
+                    {
+                        strBuf[i] = strBuf[i+2];
+                    }
+                }
+                ThreadSafeHandleURL(strBuf);
+            }
+            else
+                break;
+        }
+
+        // Make sure only one bitcoin instance is listening
+        message_queue::remove("BitcoinURL");
+        mq = new message_queue(open_or_create, "BitcoinURL", 2, 256);
+    }
+    catch (interprocess_exception &ex) {
+        return;
+    }
+    if (!CreateThread(ipcThread, mq))
+    {
+        delete mq;
+    }
+}

--- a/src/qt/qtipcserver.h
+++ b/src/qt/qtipcserver.h
@@ -1,0 +1,2 @@
+void ipcInit();
+void ipcShutdown();

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -11,6 +11,7 @@
 #include <QMessageBox>
 #include <QLocale>
 #include <QTextDocument>
+#include <QScrollBar>
 
 SendCoinsDialog::SendCoinsDialog(QWidget *parent) :
     QDialog(parent),
@@ -188,6 +189,12 @@ SendCoinsEntry *SendCoinsDialog::addEntry()
 
     // Focus the field, so that entry can start immediately
     entry->clear();
+    entry->setFocus();
+    ui->scrollAreaWidgetContents->resize(ui->scrollAreaWidgetContents->sizeHint());
+    QCoreApplication::instance()->processEvents();
+    QScrollBar* bar = ui->scrollArea->verticalScrollBar();
+    if (bar)
+        bar->setSliderPosition(bar->maximum());
     return entry;
 }
 

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -30,6 +30,8 @@ SendCoinsDialog::SendCoinsDialog(QWidget *parent) :
 
     connect(ui->addButton, SIGNAL(clicked()), this, SLOT(addEntry()));
     connect(ui->clearButton, SIGNAL(clicked()), this, SLOT(clear()));
+
+    fNewRecipientAllowed = true;
 }
 
 void SendCoinsDialog::setModel(WalletModel *model)
@@ -92,6 +94,8 @@ void SendCoinsDialog::on_sendButton_clicked()
         formatted.append(tr("<b>%1</b> to %2 (%3)").arg(BitcoinUnits::formatWithUnit(BitcoinUnits::BTC, rcp.amount), Qt::escape(rcp.label), rcp.address));
     }
 
+    fNewRecipientAllowed = false;
+
     QMessageBox::StandardButton retval = QMessageBox::question(this, tr("Confirm send coins"),
                           tr("Are you sure you want to send %1?").arg(formatted.join(tr(" and "))),
           QMessageBox::Yes|QMessageBox::Cancel,
@@ -99,6 +103,7 @@ void SendCoinsDialog::on_sendButton_clicked()
 
     if(retval != QMessageBox::Yes)
     {
+        fNewRecipientAllowed = true;
         return;
     }
 
@@ -106,6 +111,7 @@ void SendCoinsDialog::on_sendButton_clicked()
     if(!ctx.isValid())
     {
         // Unlock wallet was cancelled
+        fNewRecipientAllowed = true;
         return;
     }
 
@@ -152,6 +158,7 @@ void SendCoinsDialog::on_sendButton_clicked()
         accept();
         break;
     }
+    fNewRecipientAllowed = true;
 }
 
 void SendCoinsDialog::clear()
@@ -236,6 +243,9 @@ QWidget *SendCoinsDialog::setupTabChain(QWidget *prev)
 
 void SendCoinsDialog::pasteEntry(const SendCoinsRecipient &rv)
 {
+    if (!fNewRecipientAllowed)
+        return;
+
     SendCoinsEntry *entry = 0;
     // Replace the first entry if it is still unused
     if(ui->entries->count() == 1)

--- a/src/qt/sendcoinsdialog.h
+++ b/src/qt/sendcoinsdialog.h
@@ -43,6 +43,7 @@ public slots:
 private:
     Ui::SendCoinsDialog *ui;
     WalletModel *model;
+    bool fNewRecipientAllowed;
 
 private slots:
     void on_sendButton_clicked();

--- a/src/qt/sendcoinsentry.cpp
+++ b/src/qt/sendcoinsentry.cpp
@@ -151,3 +151,8 @@ bool SendCoinsEntry::isClear()
     return ui->payTo->text().isEmpty();
 }
 
+void SendCoinsEntry::setFocus()
+{
+    ui->payTo->setFocus();
+}
+

--- a/src/qt/sendcoinsentry.h
+++ b/src/qt/sendcoinsentry.h
@@ -31,6 +31,8 @@ public:
      */
     QWidget *setupTabChain(QWidget *prev);
 
+    void setFocus();
+
 public slots:
     void setRemoveEnabled(bool enabled);
     void clear();

--- a/src/qtui.h
+++ b/src/qtui.h
@@ -40,6 +40,7 @@ extern int MyMessageBox(const std::string& message, const std::string& caption="
 #define wxMessageBox  MyMessageBox
 extern int ThreadSafeMessageBox(const std::string& message, const std::string& caption, int style=wxOK, wxWindow* parent=NULL, int x=-1, int y=-1);
 extern bool ThreadSafeAskFee(int64 nFeeRequired, const std::string& strCaption, wxWindow* parent);
+extern void ThreadSafeHandleURL(const std::string& strURL);
 extern void CalledSetStatusBar(const std::string& strText, int nField);
 extern void UIThreadCall(boost::function0<void> fn);
 extern void MainFrameRepaint();


### PR DESCRIPTION
This adds support for opening bitcoin-qt to handle a URL instead of just drag-and-drop URL support (which has been available in bitcoin-qt since before merge).
Again it does not support OSX as you have to add OSX-specific URL handling and I don't have access to any OSX boxes to code that.
This does add hooks to add Bitcoin as the default bitcoin: opener for Win32 in the nsis installer, also the bitcoin-qt packages in the bitcoin/bitcoin ppa on launchpad install gnome hooks for the same.

Details:
If bitcoin is already running, the launch of the second process will use boost/interprocess/ipc/message_queue to send the URL to the running process which will handle it.  Otherwise the new process will launch to the send coins window.
Because of this, if bitcoin crashes, links will have to be clicked 3 times before bitcoin will open.
