### PR TITLE
Fix script that creates mac builds.

### DIFF
--- a/contrib/create_osx_dmg.sh
+++ b/contrib/create_osx_dmg.sh
@@ -34,8 +34,8 @@ macdeployqt Bitcoin-Qt.app
 cp /opt/local/lib/db48/libdb_cxx-4.8.dylib Bitcoin-Qt.app/Contents/Frameworks/
 install_name_tool -id @executable_path/../Frameworks/libdb_cxx-4.8.dylib \
     Bitcoin-Qt.app/Contents/Frameworks/libdb_cxx-4.8.dylib
-install_name_tool -change libqt.3.dylib \
-        @executable_path/../Frameworks/libqt.3.dylib \
+install_name_tool -change /opt/local/lib/db48/libdb_cxx-4.8.dylib \
+        @executable_path/../Frameworks/libdb_cxx-4.8.dylib \
         Bitcoin-Qt.app/Contents/MacOS/Bitcoin-Qt
 
 # Create a .dmg


### PR DESCRIPTION
I noticed that mac builds created with this script still has /opt/local/lib/db48/libdb_cxx-4.8.dylib hardcoded. This fix should fix the problem. And it doesn't look like we are using libqt.3.dylib. I assume this was copy pasted from somewhere and it was just never fixed.
