### PR TITLE
Make qt-win32 gitian build deterministic

### DIFF
--- a/contrib/gitian-descriptors/qt-win32.yml
+++ b/contrib/gitian-descriptors/qt-win32.yml
@@ -20,22 +20,35 @@ script: |
   #
   tar xzf qt-everywhere-opensource-src-4.7.4.tar.gz
   cd qt-everywhere-opensource-src-4.7.4
+  sed 's/$TODAY/2011-01-30/' -i configure
   sed 's/i686-pc-mingw32-/i586-mingw32msvc-/' -i mkspecs/unsupported/win32-g++-cross/qmake.conf
-  sed --posix 's|QMAKE_CFLAGS\t\t= -pipe|QMAKE_CFLAGS\t\t= -pipe -isystem /usr/i586-mingw32msvc/include/|' -i mkspecs/unsupported/win32-g++-cross/qmake.conf
+  sed --posix 's|QMAKE_CFLAGS\t\t= -pipe|QMAKE_CFLAGS\t\t= -pipe -isystem /usr/i586-mingw32msvc/include/ -frandom-seed=qtbuild|' -i mkspecs/unsupported/win32-g++-cross/qmake.conf
   sed 's/QMAKE_CXXFLAGS_EXCEPTIONS_ON = -fexceptions -mthreads/QMAKE_CXXFLAGS_EXCEPTIONS_ON = -fexceptions/' -i mkspecs/unsupported/win32-g++-cross/qmake.conf
   sed 's/QMAKE_LFLAGS_EXCEPTIONS_ON = -mthreads/QMAKE_LFLAGS_EXCEPTIONS_ON = -lmingwthrd/' -i mkspecs/unsupported/win32-g++-cross/qmake.conf
   sed --posix 's/QMAKE_MOC\t\t= i586-mingw32msvc-moc/QMAKE_MOC\t\t= moc/' -i mkspecs/unsupported/win32-g++-cross/qmake.conf
   sed --posix 's/QMAKE_RCC\t\t= i586-mingw32msvc-rcc/QMAKE_RCC\t\t= rcc/' -i mkspecs/unsupported/win32-g++-cross/qmake.conf
   sed --posix 's/QMAKE_UIC\t\t= i586-mingw32msvc-uic/QMAKE_UIC\t\t= uic/' -i mkspecs/unsupported/win32-g++-cross/qmake.conf
-  export LD_PRELOAD=/usr/lib/faketime/libfaketime.so.1
+  # ar adds timestamps to every object file included in the static library
+  # providing -D as ar argument is supposed to solve it, but doesn't work as qmake strips off the arguments and adds -M to pass a script...
+  # which somehow cannot be combined with other flags.
+  # use faketime only for ar, as it confuses make/qmake into hanging sometimes
+  sed --posix "s|QMAKE_LIB\t\t= i586-mingw32msvc-ar -ru|QMAKE_LIB\t\t= $HOME/ar -Dr|" -i mkspecs/unsupported/win32-g++-cross/qmake.conf
+  echo '#!/bin/bash' > $HOME/ar
+  echo 'export LD_PRELOAD=/usr/lib/faketime/libfaketime.so.1' >> $HOME/ar
+  echo 'i586-mingw32msvc-ar "$@"' >> $HOME/ar
+  chmod +x $HOME/ar
+  #export LD_PRELOAD=/usr/lib/faketime/libfaketime.so.1
   export FAKETIME=$REFERENCE_DATETIME
   export TZ=UTC
-  ./configure -prefix $INSTDIR -confirm-license -release -opensource -static -no-qt3support -xplatform unsupported/win32-g++-cross -no-multimedia -no-audio-backend -no-phonon -no-phonon-backend -nomake examples -nomake demos -nomake docs
+  ./configure -prefix $INSTDIR -confirm-license -release -opensource -static -no-qt3support -xplatform unsupported/win32-g++-cross -no-multimedia -no-audio-backend -no-phonon -no-phonon-backend -no-declarative -no-script -no-scripttools -no-javascript-jit  -no-webkit -no-svg -no-xmlpatterns -no-sql-sqlite -no-nis -no-cups -no-iconv -no-dbus -no-gif -no-libtiff -opengl no -nomake examples -nomake demos -nomake docs
   find . -name *.prl | xargs -l sed 's|/\.||' -i
   find . -name *.prl | xargs -l sed 's|/$||' -i
   make $MAKEOPTS install
   cp -a bin $SRCDIR/
   cd $INSTDIR
   find . -name *.prl | xargs -l sed 's|/$||' -i
-  sed 's|QMAKE_PRL_LIBS.*|QMAKE_PRL_LIBS = -lQtDeclarative -lQtScript -lQtSvg -lQtSql -lQtXmlPatterns -lQtGui -lgdi32 -lcomdlg32 -loleaut32 -limm32 -lwinmm -lwinspool -lmsimg32 -lQtNetwork -lQtCore -lole32 -luuid -lws2_32 -ladvapi32 -lshell32 -luser32 -lkernel32|' -i imports/Qt/labs/particles/qmlparticlesplugin.prl
+  #sed 's|QMAKE_PRL_LIBS.*|QMAKE_PRL_LIBS = -lQtDeclarative -lQtScript -lQtSvg -lQtSql -lQtXmlPatterns -lQtGui -lgdi32 -lcomdlg32 -loleaut32 -limm32 -lwinmm -lwinspool -lmsimg32 -lQtNetwork -lQtCore -lole32 -luuid -lws2_32 -ladvapi32 -lshell32 -luser32 -lkernel32|' -i imports/Qt/labs/particles/qmlparticlesplugin.prl
+
+  # as zip stores file timestamps, use faketime to intercept stat calls to set dates for all files to reference date
+  export LD_PRELOAD=/usr/lib/faketime/libfaketime.so.1
   zip -r $OUTDIR/qt-win32-4.7.4-gitian.zip *


### PR DESCRIPTION
It took a lot of testing and experimentation, but these changes make the qt-win32 gitian build deterministic, and stop the build from randomly hanging on qmake in a loop due to time conflicts.

They also shorten the build time and reduce library size by disabling more qt features such as OpenGL that we don't use.

Hopefully, this is reproducible on other computers as well. The output hashes are:

```
7996f302a7ea07a7c3728c857ca0ed783dd96fc49898cf149432787b93016ce6  qt-win32-4.7.4-gitian.zip
dbdda19724304cb7006c6bcfe851a4b91f9939f9f282eec24d6768f8070126e7  qt-res.yml
```
