### PR TITLE
Fix segmentation fault when editing address not in address book (issue #615)

### DIFF
--- a/src/qt/editaddressdialog.cpp
+++ b/src/qt/editaddressdialog.cpp
@@ -113,3 +113,9 @@ QString EditAddressDialog::getAddress() const
 {
     return address;
 }
+
+void EditAddressDialog::setAddress(const QString &address)
+{
+    this->address = address;
+    ui->addressEdit->setText(address);
+}

--- a/src/qt/editaddressdialog.h
+++ b/src/qt/editaddressdialog.h
@@ -33,6 +33,7 @@ public:
     void accept();
 
     QString getAddress() const;
+    void setAddress(const QString &address);
 private:
     bool saveCurrentRow();
 

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -322,6 +322,8 @@ void TransactionView::editLabel()
             // If this transaction has no associated address, exit
             return;
         }
+        // Is address in address book? Address book can miss address when a transaction is
+        // sent from outside the UI.
         int idx = addressBook->lookupAddress(address);
         if(idx != -1)
         {
@@ -343,6 +345,8 @@ void TransactionView::editLabel()
             // Add sending address
             EditAddressDialog dlg(EditAddressDialog::NewSendingAddress,
                                   this);
+            dlg.setModel(addressBook);
+            dlg.setAddress(address);
             dlg.exec();
         }
     }


### PR DESCRIPTION
See issue #615 for discussion. Fixes the segmentation fault and pre-fills the new address in the add address dialog.
