### PR TITLE
Add robustness against null models in Qt UI

### DIFF
--- a/src/qt/aboutdialog.cpp
+++ b/src/qt/aboutdialog.cpp
@@ -12,7 +12,10 @@ AboutDialog::AboutDialog(QWidget *parent) :
 
 void AboutDialog::setModel(ClientModel *model)
 {
-    ui->versionLabel->setText(model->formatFullVersion());
+    if(model)
+    {
+        ui->versionLabel->setText(model->formatFullVersion());
+    }
 }
 
 AboutDialog::~AboutDialog()

--- a/src/qt/addressbookpage.cpp
+++ b/src/qt/addressbookpage.cpp
@@ -57,6 +57,8 @@ AddressBookPage::~AddressBookPage()
 void AddressBookPage::setModel(AddressTableModel *model)
 {
     this->model = model;
+    if(!model)
+        return;
     // Refresh list from core
     model->updateList();
 
@@ -96,16 +98,13 @@ void AddressBookPage::setModel(AddressTableModel *model)
     selectionChanged();
 }
 
-QTableView *AddressBookPage::getCurrentTable()
-{
-    return ui->tableView;
-}
-
 void AddressBookPage::on_copyToClipboard_clicked()
 {
     // Copy currently selected address to clipboard
     //   (or nothing, if nothing selected)
-    QTableView *table = getCurrentTable();
+    QTableView *table = ui->tableView;
+    if(!table->selectionModel())
+        return;
     QModelIndexList indexes = table->selectionModel()->selectedRows(AddressTableModel::Address);
 
     foreach (QModelIndex index, indexes)
@@ -117,6 +116,8 @@ void AddressBookPage::on_copyToClipboard_clicked()
 
 void AddressBookPage::on_newAddressButton_clicked()
 {
+    if(!model)
+        return;
     EditAddressDialog dlg(
             tab == SendingTab ?
             EditAddressDialog::NewSendingAddress :
@@ -139,7 +140,9 @@ void AddressBookPage::on_newAddressButton_clicked()
 
 void AddressBookPage::on_deleteButton_clicked()
 {
-    QTableView *table = getCurrentTable();
+    QTableView *table = ui->tableView;
+    if(!table->selectionModel())
+        return;
     QModelIndexList indexes = table->selectionModel()->selectedRows();
     if(!indexes.isEmpty())
     {
@@ -150,7 +153,9 @@ void AddressBookPage::on_deleteButton_clicked()
 void AddressBookPage::selectionChanged()
 {
     // Set button states based on selected tab and selection
-    QTableView *table = getCurrentTable();
+    QTableView *table = ui->tableView;
+    if(!table->selectionModel())
+        return;
 
     if(table->selectionModel()->hasSelection())
     {
@@ -174,12 +179,14 @@ void AddressBookPage::selectionChanged()
 
 void AddressBookPage::done(int retval)
 {
+    QTableView *table = ui->tableView;
+    if(!table->selectionModel() || !table->model())
+        return;
     // When this is a tab/widget and not a model dialog, ignore "done"
     if(mode == ForEditing)
         return;
 
     // Figure out which address was selected, and return it
-    QTableView *table = getCurrentTable();
     QModelIndexList indexes = table->selectionModel()->selectedRows(AddressTableModel::Address);
 
     foreach (QModelIndex index, indexes)

--- a/src/qt/addressbookpage.h
+++ b/src/qt/addressbookpage.h
@@ -47,8 +47,6 @@ private:
     QString returnValue;
     QSortFilterProxyModel *proxyModel;
 
-    QTableView *getCurrentTable();
-
 private slots:
     void on_deleteButton_clicked();
     void on_newAddressButton_clicked();

--- a/src/qt/askpassphrasedialog.cpp
+++ b/src/qt/askpassphrasedialog.cpp
@@ -72,6 +72,8 @@ void AskPassphraseDialog::setModel(WalletModel *model)
 void AskPassphraseDialog::accept()
 {
     std::string oldpass, newpass1, newpass2;
+    if(!model)
+        return;
     // TODO: mlock memory / munlock on return so they will not be swapped out, really need "mlockedstring" wrapper class to do this safely
     oldpass.reserve(MAX_PASSPHRASE_SIZE);
     newpass1.reserve(MAX_PASSPHRASE_SIZE);

--- a/src/qt/csvmodelwriter.cpp
+++ b/src/qt/csvmodelwriter.cpp
@@ -48,7 +48,11 @@ bool CSVModelWriter::write()
         return false;
     QTextStream out(&file);
 
-    int numRows = model->rowCount();
+    int numRows = 0;
+    if(model)
+    {
+        numRows = model->rowCount();
+    }
 
     // Header row
     for(int i=0; i<columns.size(); ++i)

--- a/src/qt/editaddressdialog.cpp
+++ b/src/qt/editaddressdialog.cpp
@@ -56,6 +56,8 @@ void EditAddressDialog::loadRow(int row)
 
 bool EditAddressDialog::saveCurrentRow()
 {
+    if(!model)
+        return false;
     switch(mode)
     {
     case NewReceivingAddress:
@@ -78,6 +80,8 @@ bool EditAddressDialog::saveCurrentRow()
 
 void EditAddressDialog::accept()
 {
+    if(!model)
+        return;
     if(!saveCurrentRow())
     {
         switch(model->getEditStatus())

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -43,9 +43,11 @@ void SendCoinsDialog::setModel(WalletModel *model)
             entry->setModel(model);
         }
     }
-
-    setBalance(model->getBalance(), model->getUnconfirmedBalance());
-    connect(model, SIGNAL(balanceChanged(qint64, qint64)), this, SLOT(setBalance(qint64, qint64)));
+    if(model)
+    {
+        setBalance(model->getBalance(), model->getUnconfirmedBalance());
+        connect(model, SIGNAL(balanceChanged(qint64, qint64)), this, SLOT(setBalance(qint64, qint64)));
+    }
 }
 
 SendCoinsDialog::~SendCoinsDialog()
@@ -57,6 +59,10 @@ void SendCoinsDialog::on_sendButton_clicked()
 {
     QList<SendCoinsRecipient> recipients;
     bool valid = true;
+
+    if(!model)
+        return;
+
     for(int i = 0; i < ui->entries->count(); ++i)
     {
         SendCoinsEntry *entry = qobject_cast<SendCoinsEntry*>(ui->entries->itemAt(i)->widget());
@@ -255,6 +261,9 @@ void SendCoinsDialog::handleURL(const QUrl *url)
 void SendCoinsDialog::setBalance(qint64 balance, qint64 unconfirmedBalance)
 {
     Q_UNUSED(unconfirmedBalance);
+    if(!model || !model->getOptionsModel())
+        return;
+
     int unit = model->getOptionsModel()->getDisplayUnit();
     ui->labelBalance->setText(BitcoinUnits::formatWithUnit(unit, balance));
 }

--- a/src/qt/sendcoinsentry.cpp
+++ b/src/qt/sendcoinsentry.cpp
@@ -44,6 +44,8 @@ void SendCoinsEntry::on_pasteButton_clicked()
 
 void SendCoinsEntry::on_addressBookButton_clicked()
 {
+    if(!model)
+        return;
     AddressBookPage dlg(AddressBookPage::ForSending, AddressBookPage::SendingTab, this);
     dlg.setModel(model->getAddressTableModel());
     if(dlg.exec())
@@ -55,6 +57,8 @@ void SendCoinsEntry::on_addressBookButton_clicked()
 
 void SendCoinsEntry::on_payTo_textChanged(const QString &address)
 {
+    if(!model)
+        return;
     ui->addAsLabel->setText(model->getAddressTableModel()->labelForAddress(address));
 }
 
@@ -74,7 +78,7 @@ void SendCoinsEntry::clear()
     ui->addAsLabel->clear();
     ui->payAmount->clear();
     ui->payTo->setFocus();
-    if(model)
+    if(model && model->getOptionsModel())
     {
         ui->payAmount->setDisplayUnit(model->getOptionsModel()->getDisplayUnit());
     }


### PR DESCRIPTION
Handle null models gracefully in the views; this prevents segmentation faults such as issue #595 and #615 from happening.
