### PR TITLE
RPC: do not launch Shutdown in a new thread in case we are running the UI

### DIFF
--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -160,10 +160,13 @@ Value stop(const Array& params, bool fHelp)
         throw runtime_error(
             "stop\n"
             "Stop bitcoin server.");
-
+#ifndef QT_GUI
     // Shutdown will take long enough that the response should get back
     CreateThread(Shutdown, NULL);
     return "bitcoin server stopping";
+#else
+    throw runtime_error("NYI: cannot shut down GUI with RPC command");
+#endif
 }
 
 
@@ -2175,11 +2178,13 @@ void ThreadRPCServer2(void* parg)
         else if (mapArgs.count("-daemon"))
             strWhatAmI = strprintf(_("To use the %s option"), "\"-daemon\"");
         PrintConsole(
-            _("Warning: %s, you must set rpcpassword=<password>\nin the configuration file: %s\n"
+            _("Error: %s, you must set rpcpassword=<password>\nin the configuration file: %s\n"
               "If the file does not exist, create it with owner-readable-only file permissions.\n"),
                 strWhatAmI.c_str(),
                 GetConfigFile().c_str());
+#ifndef QT_GUI
         CreateThread(Shutdown, NULL);
+#endif
         return;
     }
 


### PR DESCRIPTION
This leads to the bitcoin core being shut down while the UI is accessing it, and generally results in a segmentation fault or crash. In case it is desirable to make it possible to shutdown the GUI from its RPC server, we'll need to implement a signal for it. For the mean time, this is a safe stopgap.

Reproducing the bug:

```
bitcoin-qt -testnet -server -datadir=&lt;new directory>
```

Output:

```
Warning: To use the "-server" option, you must set rpcpassword=<password>
in the configuration file: /tmp/test/testnet/bitcoin.conf
If the file does not exist, create it with owner-readable-only file permissions.
Segmentation fault
```

Also changes the Warning to an Error (as it is kind of fatal, terminating the rpc thread).
