### PR TITLE
Prevent unencrypted private keys from being written to wallet.dat

### DIFF
--- a/src/db.cpp
+++ b/src/db.cpp
@@ -28,6 +28,34 @@ DbEnv dbenv(0);
 static map<string, int> mapFileUseCount;
 static map<string, Db*> mapDb;
 
+static void EnvShutdown(bool fRemoveLogFiles)
+{
+    if (!fDbEnvInit)
+        return;
+
+    fDbEnvInit = false;
+    dbenv.close(0);
+    DbEnv(0).remove(GetDataDir().c_str(), 0);
+
+    if (fRemoveLogFiles)
+    {
+        filesystem::path datadir(GetDataDir());
+        filesystem::directory_iterator it(datadir / "database");
+        while (it != filesystem::directory_iterator())
+        {
+            const filesystem::path& p = it->path();
+#if BOOST_FILESYSTEM_VERSION == 2
+            std::string f = p.filename();
+#else
+            std::string f = p.filename().generic_string();
+#endif
+            if (f.find("log.") == 0)
+                filesystem::remove(p);
+            ++it;
+        }
+    }
+}
+
 class CDBInit
 {
 public:
@@ -36,11 +64,7 @@ public:
     }
     ~CDBInit()
     {
-        if (fDbEnvInit)
-        {
-            dbenv.close(0);
-            fDbEnvInit = false;
-        }
+        EnvShutdown(false);
     }
 }
 instance_of_cdbinit;
@@ -165,7 +189,7 @@ void static CloseDb(const string& strFile)
     }
 }
 
-bool Resilver(const string& strFile)
+bool CDB::Rewrite(const string& strFile, const char* pszSkip)
 {
     while (!fShutdown)
     {
@@ -180,8 +204,8 @@ bool Resilver(const string& strFile)
                 mapFileUseCount.erase(strFile);
 
                 bool fSuccess = true;
-                printf("Resilvering %s...\n", strFile.c_str());
-                string strFileRes = strFile + ".resilver";
+                printf("Rewriting %s...\n", strFile.c_str());
+                string strFileRes = strFile + ".rewrite";
                 CDB db(strFile.c_str(), "r");
                 Db* pdbCopy = new Db(&dbenv, 0);
 
@@ -212,6 +236,15 @@ bool Resilver(const string& strFile)
                             fSuccess = false;
                             break;
                         }
+                        if (pszSkip &&
+                            strncmp(&ssKey[0], pszSkip, std::min(ssKey.size(), strlen(pszSkip))) == 0)
+                            continue;
+                        if (strncmp(&ssKey[0], "\x07version", 8) == 0)
+                        {
+                            // Update version:
+                            ssValue.clear();
+                            ssValue << VERSION;
+                        }
                         Dbt datKey(&ssKey[0], ssKey.size());
                         Dbt datValue(&ssValue[0], ssValue.size());
                         int ret2 = pdbCopy->put(NULL, &datKey, &datValue, DB_NOOVERWRITE);
@@ -239,7 +272,7 @@ bool Resilver(const string& strFile)
                         fSuccess = false;
                 }
                 if (!fSuccess)
-                    printf("Resilvering of %s FAILED!\n", strFileRes.c_str());
+                    printf("Rewriting of %s FAILED!\n", strFileRes.c_str());
                 return fSuccess;
             }
         }
@@ -249,7 +282,7 @@ bool Resilver(const string& strFile)
 }
 
 
-void DBFlush(bool fShutdown)
+void DBFlush(bool fShutdown, bool fRemoveLogFiles)
 {
     // Flush log data to the actual data file
     //  on all files that are not in use
@@ -280,9 +313,10 @@ void DBFlush(bool fShutdown)
         {
             char** listp;
             if (mapFileUseCount.empty())
+            {
                 dbenv.log_archive(&listp, DB_ARCH_REMOVE);
-            dbenv.close(0);
-            fDbEnvInit = false;
+                EnvShutdown(fRemoveLogFiles);
+            }
         }
     }
 }
@@ -740,7 +774,6 @@ int CWalletDB::LoadWallet(CWallet* pwallet)
     pwallet->vchDefaultKey.clear();
     int nFileVersion = 0;
     vector<uint256> vWalletUpgrade;
-    bool fIsResilvered = false;
     bool fIsEncrypted = false;
 
     // Modify defaults
@@ -901,7 +934,6 @@ int CWalletDB::LoadWallet(CWallet* pwallet)
                 if (strKey == "fMinimizeOnClose")   ssValue >> fMinimizeOnClose;
                 if (strKey == "fUseProxy")          ssValue >> fUseProxy;
                 if (strKey == "addrProxy")          ssValue >> addrProxy;
-                if (strKey == "fIsResilvered")      ssValue >> fIsResilvered;
                 if (fHaveUPnP && strKey == "fUseUPnP")           ssValue >> fUseUPnP;
             }
             else if (strType == "minversion")
@@ -929,8 +961,11 @@ int CWalletDB::LoadWallet(CWallet* pwallet)
         printf("fUseUPnP = %d\n", fUseUPnP);
 
 
-    // Upgrade
-    if (nFileVersion < VERSION)
+    // Rewrite encrypted wallets of versions 0.4.0 and 0.5.0rc:
+    if (fIsEncrypted && (nFileVersion == 40000 || nFileVersion == 50000))
+        return DB_NEED_REWRITE;
+
+    if (nFileVersion < VERSION) // Update
     {
         // Get rid of old debug.log file in current directory
         if (nFileVersion <= 105 && !pszSetDataDir[0])
@@ -938,9 +973,6 @@ int CWalletDB::LoadWallet(CWallet* pwallet)
 
         WriteVersion(VERSION);
     }
-
-    if (fIsEncrypted && !fIsResilvered)
-        return DB_NEED_RESILVER;
 
     return DB_LOAD_OK;
 }

--- a/src/db.h
+++ b/src/db.h
@@ -29,10 +29,9 @@ extern unsigned int nWalletDBUpdated;
 extern DbEnv dbenv;
 
 
-extern void DBFlush(bool fShutdown);
+extern void DBFlush(bool fShutdown, bool fRemoveLogFiles);
 void ThreadFlushWalletDB(void* parg);
 bool BackupWallet(const CWallet& wallet, const std::string& strDest);
-extern bool Resilver(const std::string& strFile);
 
 
 
@@ -258,7 +257,7 @@ public:
         return Write(std::string("version"), nVersion);
     }
 
-    friend bool Resilver(const std::string&);
+    bool static Rewrite(const std::string& strFile, const char* pszSkip = NULL);
 };
 
 
@@ -351,7 +350,7 @@ enum DBErrors
     DB_CORRUPT,
     DB_TOO_NEW,
     DB_LOAD_FAIL,
-    DB_NEED_RESILVER
+    DB_NEED_REWRITE
 };
 
 class CWalletDB : public CDB

--- a/src/db.h
+++ b/src/db.h
@@ -32,7 +32,7 @@ extern DbEnv dbenv;
 extern void DBFlush(bool fShutdown);
 void ThreadFlushWalletDB(void* parg);
 bool BackupWallet(const CWallet& wallet, const std::string& strDest);
-
+extern bool Resilver(const std::string& strFile);
 
 
 
@@ -257,6 +257,8 @@ public:
     {
         return Write(std::string("version"), nVersion);
     }
+
+    friend bool Resilver(const std::string&);
 };
 
 
@@ -349,6 +351,7 @@ enum DBErrors
     DB_CORRUPT,
     DB_TOO_NEW,
     DB_LOAD_FAIL,
+    DB_NEED_RESILVER
 };
 
 class CWalletDB : public CDB

--- a/src/qt/askpassphrasedialog.cpp
+++ b/src/qt/askpassphrasedialog.cpp
@@ -101,7 +101,8 @@ void AskPassphraseDialog::accept()
                 if(model->setWalletEncrypted(true, newpass1))
                 {
                     QMessageBox::warning(this, tr("Wallet encrypted"),
-                                         tr("Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer."));
+                                         tr("Bitcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer."));
+                    QApplication::quit();
                 }
                 else
                 {

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -60,7 +60,7 @@ class CDataStream;
 class CAutoFile;
 static const unsigned int MAX_SIZE = 0x02000000;
 
-static const int VERSION = 50000;
+static const int VERSION = 50001;
 static const char* pszSubVer = "";
 static const bool VERSION_IS_BETA = true;
 

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -189,6 +189,9 @@ bool CWallet::EncryptWallet(const string& strWalletPassphrase)
         Lock();
     }
 
+    if (Resilver(strWalletFile))
+        CWalletDB(strWalletFile, "r+").WriteSetting("fIsResilvered", true);
+
     return true;
 }
 
@@ -1142,6 +1145,13 @@ int CWallet::LoadWallet(bool& fFirstRunRet)
         return false;
     fFirstRunRet = false;
     int nLoadWalletRet = CWalletDB(strWalletFile,"cr+").LoadWallet(this);
+    if (nLoadWalletRet == DB_NEED_RESILVER)
+    {
+        if (Resilver(strWalletFile))
+            CWalletDB(strWalletFile, "r+").WriteSetting("fIsResilvered", true);
+        nLoadWalletRet = DB_LOAD_OK;
+    }
+
     if (nLoadWalletRet != DB_LOAD_OK)
         return nLoadWalletRet;
     fFirstRunRet = vchDefaultKey.empty();


### PR DESCRIPTION
Unencrypted private keys could remain in the wallet.dat file (and other berkely db database files) after wallet encryption.

This pull request does several things to fix the problem:

1) Completely rewrites the wallet.dat file upon encryption.

2) Removes all keys from the keypool so they will not be used for new transactions (they are encrypted and stored in the new wallet, in case any bitcoins are sent to them).

3) Modifies the database code so temporary database files are cleaned up when bitcoin shuts down

4) Successful encryption of the wallet is now followed by a shutdown, so old unencrypted private keys that might have been in the database's caches will not be written to the new, encrypted wallet file.
