### PR TITLE
Fix crash-on-wallet-upgrade bug on OSX

### DIFF
--- a/bitcoin-qt.pro
+++ b/bitcoin-qt.pro
@@ -256,7 +256,7 @@ windows:RC_FILE = src/qt/res/bitcoin-qt.rc
 macx:HEADERS += src/qt/macdockiconhandler.h
 macx:OBJECTIVE_SOURCES += src/qt/macdockiconhandler.mm
 macx:LIBS += -framework Foundation -framework ApplicationServices -framework AppKit
-macx:DEFINES += MAC_OSX MSG_NOSIGNAL=0 BOOST_FILESYSTEM_VERSION=3
+macx:DEFINES += MAC_OSX MSG_NOSIGNAL=0
 macx:ICON = src/qt/res/icons/bitcoin.icns
 macx:TARGET = "Bitcoin-Qt"
 

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -51,7 +51,7 @@ static void EnvShutdown(bool fRemoveLogFiles)
         while (it != filesystem::directory_iterator())
         {
             const filesystem::path& p = it->path();
-#if BOOST_FILESYSTEM_VERSION == 3
+#if BOOST_FILESYSTEM_VERSION >= 3
             std::string f = p.filename().generic_string();
 #else
             std::string f = p.filename();

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -34,7 +34,14 @@ static void EnvShutdown(bool fRemoveLogFiles)
         return;
 
     fDbEnvInit = false;
-    dbenv.close(0);
+    try
+    {
+        dbenv.close(0);
+    }
+    catch (const DbException& e)
+    {
+        printf("EnvShutdown exception: %s (%d)\n", e.what(), e.get_errno());
+    }
     DbEnv(0).remove(GetDataDir().c_str(), 0);
 
     if (fRemoveLogFiles)
@@ -229,7 +236,10 @@ bool CDB::Rewrite(const string& strFile, const char* pszSkip)
                         CDataStream ssValue;
                         int ret = db.ReadAtCursor(pcursor, ssKey, ssValue, DB_NEXT);
                         if (ret == DB_NOTFOUND)
+                        {
+                            pcursor->close();
                             break;
+                        }
                         else if (ret != 0)
                         {
                             pcursor->close();
@@ -253,14 +263,11 @@ bool CDB::Rewrite(const string& strFile, const char* pszSkip)
                     }
                 if (fSuccess)
                 {
-                    Db* pdb = mapDb[strFile];
-                    if (pdb->close(0))
-                        fSuccess = false;
+                    db.Close();
+                    CloseDb(strFile);
                     if (pdbCopy->close(0))
                         fSuccess = false;
-                    delete pdb;
                     delete pdbCopy;
-                    mapDb[strFile] = NULL;
                 }
                 if (fSuccess)
                 {


### PR DESCRIPTION
Testing Bitcoin-Qt on my mac, I got a crash when running 0.5rc4 on a previously-encrypted wallet, after clicking the "you must restart" dialog box OK button.

This catches the exception that is causing the problem (DbEnv::close(0) is upset about an invalid parameter), but I'm still concerned that I haven't found the root cause-- I still don't know WHY the exception is thrown.
