### PR TITLE
Compressed pubkeys

### DIFF
--- a/src/base58.h
+++ b/src/base58.h
@@ -359,22 +359,25 @@ public:
 class CBitcoinSecret : public CBase58Data
 {
 public:
-    void SetSecret(const CSecret& vchSecret)
-    {
+    void SetSecret(const CSecret& vchSecret, bool fCompressed)
+    { 
+        assert(vchSecret.size() == 32);
         SetData(fTestNet ? 239 : 128, &vchSecret[0], vchSecret.size());
+        if (fCompressed)
+            vchData.push_back(1);
     }
 
-    CSecret GetSecret()
+    CSecret GetSecret(bool &fCompressedOut)
     {
         CSecret vchSecret;
-        vchSecret.resize(vchData.size());
-        memcpy(&vchSecret[0], &vchData[0], vchData.size());
+        vchSecret.resize(32);
+        memcpy(&vchSecret[0], &vchData[0], 32);
+        fCompressedOut = vchData.size() == 33;
         return vchSecret;
     }
 
     bool IsValid() const
     {
-        int nExpectedSize = 32;
         bool fExpectTestNet = false;
         switch(nVersion)
         {
@@ -388,12 +391,12 @@ public:
             default:
                 return false;
         }
-        return fExpectTestNet == fTestNet && vchData.size() == nExpectedSize;
+        return fExpectTestNet == fTestNet && (vchData.size() == 32 || (vchData.size() == 33 && vchData[32] == 1));
     }
 
-    CBitcoinSecret(const CSecret& vchSecret)
+    CBitcoinSecret(const CSecret& vchSecret, bool fCompressed)
     {
-        SetSecret(vchSecret);
+        SetSecret(vchSecret, fCompressed);
     }
 
     CBitcoinSecret()

--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -1701,6 +1701,9 @@ Value validateaddress(const Array& params, bool fHelp)
             ret.push_back(Pair("pubkey", HexStr(vchPubKey)));
             std::string strPubKey(vchPubKey.begin(), vchPubKey.end());
             ret.push_back(Pair("pubkey58", EncodeBase58(vchPubKey)));
+            CKey key;
+            key.SetPubKey(vchPubKey);
+            ret.push_back(Pair("iscompressed", key.IsCompressed()));
         }
         else if (pwalletMain->HaveCScript(address.GetHash160()))
         {

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -860,12 +860,14 @@ int CWalletDB::LoadWallet(CWallet* pwallet)
                 {
                     CPrivKey pkey;
                     ssValue >> pkey;
+                    key.SetPubKey(vchPubKey);
                     key.SetPrivKey(pkey);
                 }
                 else
                 {
                     CWalletKey wkey;
                     ssValue >> wkey;
+                    key.SetPubKey(vchPubKey);
                     key.SetPrivKey(wkey.vchPrivKey);
                 }
                 if (!pwallet->LoadKey(key))

--- a/src/rpcdump.cpp
+++ b/src/rpcdump.cpp
@@ -62,7 +62,9 @@ Value importprivkey(const Array& params, bool fHelp)
     if (!fGood) throw JSONRPCError(-5,"Invalid private key");
 
     CKey key;
-    key.SetSecret(vchSecret.GetSecret());
+    bool fCompressed;
+    CSecret secret = vchSecret.GetSecret(fCompressed);
+    key.SetSecret(secret, fCompressed);
     CBitcoinAddress vchAddress = CBitcoinAddress(key.GetPubKey());
 
     CRITICAL_BLOCK(cs_main)
@@ -95,7 +97,8 @@ Value dumpprivkey(const Array& params, bool fHelp)
     if (!address.SetString(strAddress))
         throw JSONRPCError(-5, "Invalid bitcoin address");
     CSecret vchSecret;
-    if (!pwalletMain->GetSecret(address, vchSecret))
+    bool fCompressed;
+    if (!pwalletMain->GetSecret(address, vchSecret, fCompressed))
         throw JSONRPCError(-4,"Private key for address " + strAddress + " is not known");
-    return CBitcoinSecret(vchSecret).ToString();
+    return CBitcoinSecret(vchSecret, fCompressed).ToString();
 }

--- a/src/test/key_tests.cpp
+++ b/src/test/key_tests.cpp
@@ -1,0 +1,138 @@
+#include <boost/test/unit_test.hpp>
+
+#include <string>
+#include <vector>
+
+#include "key.h"
+#include "base58.h"
+#include "uint256.h"
+#include "util.h"
+
+using namespace std;
+
+static const string strSecret1 ("5HxWvvfubhXpYYpS3tJkw6fq9jE9j18THftkZjHHfmFiWtmAbrj");
+static const string strSecret2 ("5KC4ejrDjv152FGwP386VD1i2NYc5KkfSMyv1nGy1VGDxGHqVY3");
+static const string strSecret1C("Kwr371tjA9u2rFSMZjTNun2PXXP3WPZu2afRHTcta6KxEUdm1vEw");
+static const string strSecret2C("L3Hq7a8FEQwJkW1M2GNKDW28546Vp5miewcCzSqUD9kCAXrJdS3g");
+
+#ifdef KEY_TESTS_DUMPINFO
+void dumpKeyInfo(uint256 privkey)
+{
+    CSecret secret;
+    secret.resize(32);
+    memcpy(&secret[0], &privkey, 32);
+    vector<unsigned char> sec;
+    sec.resize(32);
+    memcpy(&sec[0], &secret[0], 32);
+    printf("  * secret (hex): %s\n", HexStr(sec).c_str());
+
+    for (int nCompressed=0; nCompressed<2; nCompressed++)
+    {
+        bool fCompressed = nCompressed == 1;
+        printf("  * %s:\n", fCompressed ? "compressed" : "uncompressed");
+        CBitcoinSecret bsecret;
+        bsecret.SetSecret(secret, fCompressed);
+        printf("    * secret (base58): %s\n", bsecret.ToString().c_str());
+        CKey key;
+        key.SetSecret(secret, fCompressed);
+        vector<unsigned char> vchPubKey = key.GetPubKey();
+        printf("    * pubkey (hex): %s\n", HexStr(vchPubKey).c_str());
+        printf("    * address (base58): %s\n", CBitcoinAddress(vchPubKey).ToString().c_str());
+    }
+}
+#endif
+
+
+BOOST_AUTO_TEST_SUITE(key_tests)
+
+BOOST_AUTO_TEST_CASE(key_test1)
+{
+    CBitcoinSecret bsecret1, bsecret2, bsecret1C, bsecret2C;
+    bsecret1.SetString (strSecret1);
+    bsecret2.SetString (strSecret2);
+    bsecret1C.SetString(strSecret1C);
+    bsecret2C.SetString(strSecret2C);
+
+    bool fCompressed;
+    CSecret secret1  = bsecret1.GetSecret (fCompressed);
+    BOOST_CHECK(fCompressed == false);
+    CSecret secret2  = bsecret2.GetSecret (fCompressed);
+    BOOST_CHECK(fCompressed == false);
+    CSecret secret1C = bsecret1C.GetSecret(fCompressed);
+    BOOST_CHECK(fCompressed == true);
+    CSecret secret2C = bsecret2C.GetSecret(fCompressed);
+    BOOST_CHECK(fCompressed == true);
+
+    BOOST_CHECK(secret1 == secret1C);
+    BOOST_CHECK(secret2 == secret2C);
+
+    CKey key1, key2, key1C, key2C;
+    key1.SetSecret(secret1, false);
+    key2.SetSecret(secret2, false);
+    key1C.SetSecret(secret1, true);
+    key2C.SetSecret(secret2, true);
+
+    BOOST_CHECK(CBitcoinAddress(key1.GetPubKey ()).ToString() == "1QFqqMUD55ZV3PJEJZtaKCsQmjLT6JkjvJ");
+    BOOST_CHECK(CBitcoinAddress(key2.GetPubKey ()).ToString() == "1F5y5E5FMc5YzdJtB9hLaUe43GDxEKXENJ");
+    BOOST_CHECK(CBitcoinAddress(key1C.GetPubKey()).ToString() == "1NoJrossxPBKfCHuJXT4HadJrXRE9Fxiqs");
+    BOOST_CHECK(CBitcoinAddress(key2C.GetPubKey()).ToString() == "1CRj2HyM1CXWzHAXLQtiGLyggNT9WQqsDs");
+
+    for (int n=0; n<16; n++)
+    {
+        string strMsg = strprintf("Very secret message %i: 11", n);
+        uint256 hashMsg = Hash(strMsg.begin(), strMsg.end());
+
+        // normal signatures
+
+        vector<unsigned char> sign1, sign2, sign1C, sign2C;
+
+        BOOST_CHECK(key1.Sign (hashMsg, sign1));
+        BOOST_CHECK(key2.Sign (hashMsg, sign2));
+        BOOST_CHECK(key1C.Sign(hashMsg, sign1C));
+        BOOST_CHECK(key2C.Sign(hashMsg, sign2C));
+
+        BOOST_CHECK( key1.Verify(hashMsg, sign1));
+        BOOST_CHECK(!key1.Verify(hashMsg, sign2));
+        BOOST_CHECK( key1.Verify(hashMsg, sign1C));
+        BOOST_CHECK(!key1.Verify(hashMsg, sign2C));
+
+        BOOST_CHECK(!key2.Verify(hashMsg, sign1));
+        BOOST_CHECK( key2.Verify(hashMsg, sign2));
+        BOOST_CHECK(!key2.Verify(hashMsg, sign1C));
+        BOOST_CHECK( key2.Verify(hashMsg, sign2C));
+
+        BOOST_CHECK( key1C.Verify(hashMsg, sign1));
+        BOOST_CHECK(!key1C.Verify(hashMsg, sign2));
+        BOOST_CHECK( key1C.Verify(hashMsg, sign1C));
+        BOOST_CHECK(!key1C.Verify(hashMsg, sign2C));
+
+        BOOST_CHECK(!key2C.Verify(hashMsg, sign1));
+        BOOST_CHECK( key2C.Verify(hashMsg, sign2));
+        BOOST_CHECK(!key2C.Verify(hashMsg, sign1C));
+        BOOST_CHECK( key2C.Verify(hashMsg, sign2C));
+
+        // compact signatures (with key recovery)
+
+        vector<unsigned char> csign1, csign2, csign1C, csign2C;
+
+        BOOST_CHECK(key1.SignCompact (hashMsg, csign1));
+        BOOST_CHECK(key2.SignCompact (hashMsg, csign2));
+        BOOST_CHECK(key1C.SignCompact(hashMsg, csign1C));
+        BOOST_CHECK(key2C.SignCompact(hashMsg, csign2C));
+
+        CKey rkey1, rkey2, rkey1C, rkey2C;
+
+        BOOST_CHECK(rkey1.SetCompactSignature (hashMsg, csign1));
+        BOOST_CHECK(rkey2.SetCompactSignature (hashMsg, csign2));
+        BOOST_CHECK(rkey1C.SetCompactSignature(hashMsg, csign1C));
+        BOOST_CHECK(rkey2C.SetCompactSignature(hashMsg, csign2C));
+
+
+        BOOST_CHECK(rkey1.GetPubKey()  == key1.GetPubKey());
+        BOOST_CHECK(rkey2.GetPubKey()  == key2.GetPubKey());
+        BOOST_CHECK(rkey1C.GetPubKey() == key1C.GetPubKey());
+        BOOST_CHECK(rkey2C.GetPubKey() == key2C.GetPubKey());
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This patch enables compressed pubkeys when -compressedpubkeys is passed.
These are 33 bytes instead of 65, and require only marginally more CPU
power when verifying. Compressed pubkeys have a different corresponding
address, so it is determined at generation. When -compressedpubkeys is
given, all newly generated addresses will use a compressed key, while
older/other addresses keep using normal keys. Unpatched clients will
relay and verify these transactions.

Tested on testnet with both normal and encrypted wallets, using compressed and non-compressed keys.

Initial idea and tests for this patch were done by roconnor.
