### PR TITLE
Move DNS Seed lookup to a new thread.

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -476,11 +476,6 @@ bool AppInit2(int argc, char* argv[])
         }
     }
 
-    if (GetBoolArg("-nodnsseed"))
-        printf("DNS seeding disabled\n");
-    else
-        DNSAddressSeed();
-
     if (mapArgs.count("-paytxfee"))
     {
         if (!ParseMoney(mapArgs["-paytxfee"], nTransactionFee))

--- a/src/net.h
+++ b/src/net.h
@@ -40,7 +40,6 @@ CNode* ConnectNode(CAddress addrConnect, int64 nTimeout=0);
 void AbandonRequests(void (*fn)(void*, CDataStream&), void* param1);
 bool AnySubscribed(unsigned int nChannel);
 void MapPort(bool fMapPort);
-void DNSAddressSeed();
 bool BindListenPort(std::string& strError=REF(std::string()));
 void StartNode(void* parg);
 bool StopNode();


### PR DESCRIPTION
Prevents bitcoin from blocking startup due to a slow dns resolver, or a broken dnsseed.
