### PR TITLE
Store fewer time samples

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -30,7 +30,7 @@ string strMiscWarning;
 bool fTestNet = false;
 bool fNoListen = false;
 bool fLogTimestamps = false;
-
+CMedianFilter<int64> vTimeOffsets(200,0);
 
 
 
@@ -940,15 +940,12 @@ void AddTimeData(unsigned int ip, int64 nTime)
         return;
 
     // Add data
-    static vector<int64> vTimeOffsets;
-    if (vTimeOffsets.empty())
-        vTimeOffsets.push_back(0);
-    vTimeOffsets.push_back(nOffsetSample);
-    printf("Added time data, samples %d, offset %+"PRI64d" (%+"PRI64d" minutes)\n", vTimeOffsets.size(), vTimeOffsets.back(), vTimeOffsets.back()/60);
+    vTimeOffsets.input(nOffsetSample);
+    printf("Added time data, samples %d, offset %+"PRI64d" (%+"PRI64d" minutes)\n", vTimeOffsets.size(), nOffsetSample, nOffsetSample/60);
     if (vTimeOffsets.size() >= 5 && vTimeOffsets.size() % 2 == 1)
     {
-        sort(vTimeOffsets.begin(), vTimeOffsets.end());
-        int64 nMedian = vTimeOffsets[vTimeOffsets.size()/2];
+        int64 nMedian = vTimeOffsets.median();
+        std::vector<int64> vSorted = vTimeOffsets.sorted();
         // Only let other nodes change our time by so much
         if (abs64(nMedian) < 70 * 60)
         {
@@ -963,7 +960,7 @@ void AddTimeData(unsigned int ip, int64 nTime)
             {
                 // If nobody has a time different than ours but within 5 minutes of ours, give a warning
                 bool fMatch = false;
-                BOOST_FOREACH(int64 nOffset, vTimeOffsets)
+                BOOST_FOREACH(int64 nOffset, vSorted)
                     if (nOffset != 0 && abs64(nOffset) < 5 * 60)
                         fMatch = true;
 
@@ -978,7 +975,7 @@ void AddTimeData(unsigned int ip, int64 nTime)
             }
         }
         if (fDebug) {
-            BOOST_FOREACH(int64 n, vTimeOffsets)
+            BOOST_FOREACH(int64 n, vSorted)
                 printf("%+"PRI64d"  ", n);
             printf("|  ");
         }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -977,9 +977,12 @@ void AddTimeData(unsigned int ip, int64 nTime)
                 }
             }
         }
-        BOOST_FOREACH(int64 n, vTimeOffsets)
-            printf("%+"PRI64d"  ", n);
-        printf("|  nTimeOffset = %+"PRI64d"  (%+"PRI64d" minutes)\n", nTimeOffset, nTimeOffset/60);
+        if (fDebug) {
+            BOOST_FOREACH(int64 n, vTimeOffsets)
+                printf("%+"PRI64d"  ", n);
+            printf("|  ");
+        }
+        printf("nTimeOffset = %+"PRI64d"  (%+"PRI64d" minutes)\n", nTimeOffset, nTimeOffset/60);
     }
 }
 

--- a/src/util.h
+++ b/src/util.h
@@ -623,6 +623,16 @@ public:
             return (vSorted[size/2-1] + vSorted[size/2]) / 2;
         }
     }
+
+    int size() const
+    {
+        return vValues.size();
+    }
+
+    std::vector<T> sorted () const
+    {
+        return vSorted;
+    }
 };
 
 


### PR DESCRIPTION
Storing fewer time samples makes a node's time offset more accurate following system clock adjustments, uses less memory and avoids a possible memory exhaustion attack.

The only part of this patch I'm not entirely pleased with is the choice of 200 as the limit.  In my tests, that's roughly two hours of network activity.  I chose two hours because it seemed about right, but have no rational basis for the decision.
