### PR TITLE
Change to RPC command "validateaddress" to return the hex-encoded public key of an address

### DIFF
--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -1592,6 +1592,9 @@ Value validateaddress(const Array& params, bool fHelp)
         string currentAddress = address.ToString();
         ret.push_back(Pair("address", currentAddress));
         ret.push_back(Pair("ismine", (pwalletMain->HaveKey(address) > 0)));
+        std::vector<unsigned char> pubkey;
+        if (pwalletMain->GetPubKey(address, pubkey))
+            ret.push_back(Pair("pubkey", HexStr(pubkey)));
         if (pwalletMain->mapAddressBook.count(address))
             ret.push_back(Pair("account", pwalletMain->mapAddressBook[address]));
     }


### PR DESCRIPTION
This change is useful for programs that might send payments to pubkeys, such as P2Pool. Currently, the only way to do this is to require the user to enable IP transactions and then use the "checkorder" bitcoin P2P command. However, checkorder may be removed and using it is very clumsy.

Background: Using public keys wherever they can be used is good for the bitcoin network. The total size of a txout and claim txin is smaller when using them, as the pubkey hash is never included and there are several less opcodes.
