### PR TITLE
Implement -min option to start minimized

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -159,7 +159,7 @@ int main(int argc, char *argv[])
         {
             {
                 // Put this in a block, so that BitcoinGUI is cleaned up properly before
-                // calling Shutdown().
+                // calling Shutdown() in case of exceptions.
                 BitcoinGUI window;
                 splash.finish(&window);
                 OptionsModel optionsModel(pwalletMain);
@@ -170,7 +170,15 @@ int main(int argc, char *argv[])
                 window.setClientModel(&clientModel);
                 window.setWalletModel(&walletModel);
 
-                window.show();
+                // If -min option passed, start window minimized.
+                if(GetBoolArg("-min"))
+                {
+                    window.showMinimized();
+                }
+                else
+                {
+                    window.show();
+                }
 
                 app.exec();
 


### PR DESCRIPTION
The -min command line option, according to the help text, is supposed to start bitcoin minimized. This pull request implements this functionality again. See issue #671.
