### PR TITLE
When using Qt GUI, move parameter-parsing to start of qt/bitcoin.cpp:main()

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -148,7 +148,10 @@ bool AppInit2(int argc, char* argv[])
     //
     // Parameters
     //
+    // If Qt is used, parameters are parsed in qt/bitcoin.cpp's main()
+#if !defined(QT_GUI)
     ParseParameters(argc, argv);
+#endif
 
     if (mapArgs.count("-datadir"))
     {

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -118,6 +118,8 @@ int main(int argc, char *argv[])
     Q_INIT_RESOURCE(bitcoin);
     QApplication app(argc, argv);
 
+    ParseParameters(argc, argv);
+
     // Load language files for system locale:
     // - First load the translator for the base language, without territory
     // - Then load the more specific locale translator


### PR DESCRIPTION
To be able to not show the splash screen when the "-min" option is specified on the command line, we need to parse the command line options in Qt's main() function, before AppInit2().
This is also useful if we want to be able to override system language settings using a command line option (#678).
