### PR TITLE
Temporarily disable "minimize to tray" in the startup phase if the "-min" option is specified

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -148,7 +148,10 @@ bool AppInit2(int argc, char* argv[])
     //
     // Parameters
     //
+    // If Qt is used, parameters are parsed in qt/bitcoin.cpp's main()
+#if !defined(QT_GUI)
     ParseParameters(argc, argv);
+#endif
 
     if (mapArgs.count("-datadir"))
     {

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -118,6 +118,8 @@ int main(int argc, char *argv[])
     Q_INIT_RESOURCE(bitcoin);
     QApplication app(argc, argv);
 
+    ParseParameters(argc, argv);
+
     // Load language files for system locale:
     // - First load the translator for the base language, without territory
     // - Then load the more specific locale translator

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -173,7 +173,10 @@ int main(int argc, char *argv[])
                 // If -min option passed, start window minimized.
                 if(GetBoolArg("-min"))
                 {
+                    // If we minimize to tray in the start-up phase, the GUI cannot be unminimized again
+                    fMinimizeToTray = false;
                     window.showMinimized();
+                    fMinimizeToTray = true;
                 }
                 else
                 {

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -176,9 +176,10 @@ int main(int argc, char *argv[])
                 if(GetBoolArg("-min"))
                 {
                     // If we minimize to tray in the start-up phase, the GUI cannot be unminimized again
+                    int fMinimizeToTrayTemp = fMinimizeToTray;
                     fMinimizeToTray = false;
                     window.showMinimized();
-                    fMinimizeToTray = true;
+                    fMinimizeToTray = fMinimizeToTrayTemp;
                 }
                 else
                 {


### PR DESCRIPTION
If the "minimize to tray"-option is in effect, and the Qt GUI is started with the "-min" option, the main window will not be recoverable from the tray icon by double clicking it. This is only the case if the main window is minimized to the tray in the start-up phase (by running window.showMinimized() in qt/bitcoin.cpp:main()). After the main window has been shown for the first time (in a minimized state), minimizing to the tray works again.
This relates to pull request #679.
