### PR TITLE
Allow 10 additional local P2P connections

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -939,7 +939,7 @@ void ThreadSocketHandler2(void* parg)
                 if (WSAGetLastError() != WSAEWOULDBLOCK)
                     printf("socket error accept failed: %d\n", WSAGetLastError());
             }
-            else if (nInbound >= GetArg("-maxconnections", 125) - MAX_OUTBOUND_CONNECTIONS)
+            else if (nInbound >= GetArg("-maxconnections", 125) + (addr.IsLocal() ? 10 : 0) - MAX_OUTBOUND_CONNECTIONS)
             {
                 closesocket(hSocket);
             }


### PR DESCRIPTION
Raise the connection limit by 10 for local P2P connections, preventing P2Pool and testing efforts from being affected by the global connection limit.
