### PR TITLE
Network stack refactor

### DIFF
--- a/bitcoin-qt.pro
+++ b/bitcoin-qt.pro
@@ -97,6 +97,7 @@ HEADERS += src/qt/bitcoingui.h \
     src/base58.h \
     src/bignum.h \
     src/checkpoints.h \
+    src/compat.h \
     src/util.h \
     src/uint256.h \
     src/serialize.h \
@@ -156,6 +157,7 @@ SOURCES += src/qt/bitcoin.cpp src/qt/bitcoingui.cpp \
     src/qt/editaddressdialog.cpp \
     src/qt/bitcoinaddressvalidator.cpp \
     src/util.cpp \
+    src/netbase.cpp \
     src/key.cpp \
     src/script.cpp \
     src/main.cpp \

--- a/src/compat.h
+++ b/src/compat.h
@@ -1,0 +1,42 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2011 The Bitcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file license.txt or http://www.opensource.org/licenses/mit-license.php.
+#ifndef _BITCOIN_COMPAT_H
+#define _BITCOIN_COMPAT_H 1
+
+typedef u_int SOCKET;
+#ifdef WIN32
+#define MSG_NOSIGNAL        0
+#define MSG_DONTWAIT        0
+typedef int socklen_t;
+#else
+#include "errno.h"
+#define WSAGetLastError()   errno
+#define WSAEINVAL           EINVAL
+#define WSAEALREADY         EALREADY
+#define WSAEWOULDBLOCK      EWOULDBLOCK
+#define WSAEMSGSIZE         EMSGSIZE
+#define WSAEINTR            EINTR
+#define WSAEINPROGRESS      EINPROGRESS
+#define WSAEADDRINUSE       EADDRINUSE
+#define WSAENOTSOCK         EBADF
+#define INVALID_SOCKET      (SOCKET)(~0)
+#define SOCKET_ERROR        -1
+#endif
+
+inline int myclosesocket(SOCKET& hSocket)
+{
+    if (hSocket == INVALID_SOCKET)
+        return WSAENOTSOCK;
+#ifdef WIN32
+    int ret = closesocket(hSocket);
+#else
+    int ret = close(hSocket);
+#endif
+    hSocket = INVALID_SOCKET;
+    return ret;
+}
+#define closesocket(s)      myclosesocket(s)
+
+#endif

--- a/src/headers.h
+++ b/src/headers.h
@@ -12,7 +12,7 @@
 #ifdef _WIN32_WINNT
 #undef _WIN32_WINNT
 #endif
-#define _WIN32_WINNT 0x0500
+#define _WIN32_WINNT 0x0501
 #ifdef _WIN32_IE
 #undef _WIN32_IE
 #endif

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -470,7 +470,7 @@ bool AppInit2(int argc, char* argv[])
         }
     }
 
-    bool fTor = (fUseProxy && addrProxy.port == htons(9050));
+    bool fTor = (fUseProxy && addrProxy.GetPort() == 9050);
     if (fTor)
     {
         // Use SoftSetArg here so user can override any of these if they wish.

--- a/src/makefile.linux-mingw
+++ b/src/makefile.linux-mingw
@@ -33,6 +33,7 @@ HEADERS = \
     base58.h \
     bignum.h \
     checkpoints.h \
+    compat.h \
     crypter.h \
     db.h \
     headers.h \
@@ -63,6 +64,7 @@ LIBS += -l mingwthrd -l kernel32 -l user32 -l gdi32 -l comdlg32 -l winspool -l w
 
 OBJS= \
     obj/checkpoints.o \
+    obj/netbase.o \
     obj/crypter.o \
     obj/key.o \
     obj/db.o \

--- a/src/makefile.mingw
+++ b/src/makefile.mingw
@@ -30,6 +30,7 @@ HEADERS = \
     base58.h \
     bignum.h \
     checkpoints.h \
+    compat.h \
     crypter.h \
     db.h \
     headers.h \
@@ -60,6 +61,7 @@ LIBS += -l kernel32 -l user32 -l gdi32 -l comdlg32 -l winspool -l winmm -l shell
 
 OBJS= \
     obj/checkpoints.o \
+    obj/netbase.o \
     obj/crypter.o \
     obj/key.o \
     obj/db.o \

--- a/src/makefile.osx
+++ b/src/makefile.osx
@@ -51,6 +51,7 @@ HEADERS = \
     base58.h \
     bignum.h \
     checkpoints.h \
+    compat.h \
     crypter.h \
     db.h \
     headers.h \
@@ -72,6 +73,7 @@ HEADERS = \
 
 OBJS= \
     obj/checkpoints.o \
+    obj/netbase.o \
     obj/crypter.o \
     obj/key.o \
     obj/db.o \

--- a/src/makefile.unix
+++ b/src/makefile.unix
@@ -88,6 +88,7 @@ HEADERS = \
     base58.h \
     bignum.h \
     checkpoints.h \
+    compat.h \
     crypter.h \
     db.h \
     headers.h \
@@ -109,6 +110,7 @@ HEADERS = \
 
 OBJS= \
     obj/checkpoints.o \
+    obj/netbase.o \
     obj/crypter.o \
     obj/key.o \
     obj/db.o \

--- a/src/net.h
+++ b/src/net.h
@@ -14,6 +14,7 @@
 #include <arpa/inet.h>
 #endif
 
+#include "netbase.h"
 #include "protocol.h"
 
 class CAddrDB;
@@ -21,7 +22,6 @@ class CRequestTracker;
 class CNode;
 class CBlockIndex;
 extern int nBestHeight;
-extern int nConnectTimeout;
 
 
 
@@ -29,13 +29,11 @@ inline unsigned int ReceiveBufferSize() { return 1000*GetArg("-maxreceivebuffer"
 inline unsigned int SendBufferSize() { return 1000*GetArg("-maxsendbuffer", 10*1000); }
 static const unsigned int PUBLISH_HOPS = 5;
 
-bool ConnectSocket(const CAddress& addrConnect, SOCKET& hSocketRet, int nTimeout=nConnectTimeout);
-bool Lookup(const char *pszName, std::vector<CAddress>& vaddr, int nServices, int nMaxSolutions, bool fAllowLookup = false, int portDefault = 0, bool fAllowPort = false);
-bool Lookup(const char *pszName, CAddress& addr, int nServices, bool fAllowLookup = false, int portDefault = 0, bool fAllowPort = false);
-bool GetMyExternalIP(unsigned int& ipRet);
+bool GetMyExternalIP(CNetAddr& ipRet);
 bool AddAddress(CAddress addr, int64 nTimePenalty=0, CAddrDB *pAddrDB=NULL);
-void AddressCurrentlyConnected(const CAddress& addr);
-CNode* FindNode(unsigned int ip);
+void AddressCurrentlyConnected(const CService& addr);
+CNode* FindNode(const CNetAddr& ip);
+CNode* FindNode(const CService& ip);
 CNode* ConnectNode(CAddress addrConnect, int64 nTimeout=0);
 void AbandonRequests(void (*fn)(void*, CDataStream&), void* param1);
 bool AnySubscribed(unsigned int nChannel);
@@ -88,9 +86,6 @@ extern std::deque<std::pair<int64, CInv> > vRelayExpiration;
 extern CCriticalSection cs_mapRelay;
 extern std::map<CInv, int64> mapAlreadyAskedFor;
 
-// Settings
-extern int fUseProxy;
-extern CAddress addrProxy;
 
 
 
@@ -126,7 +121,7 @@ protected:
 
     // Denial-of-service detection/prevention
     // Key is ip address, value is banned-until-time
-    static std::map<unsigned int, int64> setBanned;
+    static std::map<CNetAddr, int64> setBanned;
     static CCriticalSection cs_setBanned;
     int nMisbehavior;
 
@@ -355,7 +350,6 @@ public:
 
 
 
-
     void PushVersion();
 
 
@@ -581,7 +575,7 @@ public:
     // between nodes running old code and nodes running
     // new code.
     static void ClearBanned(); // needed for unit testing
-    static bool IsBanned(unsigned int ip);
+    static bool IsBanned(CNetAddr ip);
     bool Misbehaving(int howmuch); // 1 == a little, 100 == a lot
 };
 

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -1,0 +1,715 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2011 The Bitcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file license.txt or http://www.opensource.org/licenses/mit-license.php.
+
+#include "netbase.h"
+#include "util.h"
+
+#ifndef WIN32
+#include <sys/fcntl.h>
+#endif
+
+#include "strlcpy.h"
+
+using namespace std;
+
+// Settings
+int fUseProxy = false;
+CService addrProxy("127.0.0.1",9050);
+int nConnectTimeout = 5000;
+
+
+static const unsigned char pchIPv4[12] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff };
+
+bool static LookupIntern(const char *pszName, std::vector<CNetAddr>& vIP, int nMaxSolutions, bool fAllowLookup)
+{
+    vIP.clear();
+    struct addrinfo aiHint = {};
+    aiHint.ai_socktype = SOCK_STREAM;
+    aiHint.ai_protocol = IPPROTO_TCP;
+#ifdef WIN32
+#  ifdef USE_IPV6
+    aiHint.ai_family = AF_UNSPEC;
+    aiHint.ai_flags = fAllowLookup ? 0 : AI_NUMERICHOST;
+#  else
+    aiHint.ai_family = AF_INET;
+    aiHint.ai_flags = fAllowLookup ? 0 : AI_NUMERICHOST;
+#  endif
+#else
+#  ifdef USE_IPV6
+    aiHint.ai_family = AF_UNSPEC;
+    aiHint.ai_flags = AI_ADDRCONFIG | (fAllowLookup ? 0 : AI_NUMERICHOST);
+#  else
+    aiHint.ai_family = AF_INET;
+    aiHint.ai_flags = AI_ADDRCONFIG | (fAllowLookup ? 0 : AI_NUMERICHOST);
+#  endif
+#endif
+    struct addrinfo *aiRes = NULL;
+    int nErr = getaddrinfo(pszName, NULL, &aiHint, &aiRes);
+    if (nErr)
+        return false;
+
+    struct addrinfo *aiTrav = aiRes;
+    while (aiTrav != NULL && (nMaxSolutions == 0 || vIP.size() < nMaxSolutions))
+    {
+        if (aiTrav->ai_family == AF_INET)
+        {
+            assert(aiTrav->ai_addrlen >= sizeof(sockaddr_in));
+            vIP.push_back(CNetAddr(((struct sockaddr_in*)(aiTrav->ai_addr))->sin_addr));
+        }
+
+#ifdef USE_IPV6
+        if (aiTrav->ai_family == AF_INET6)
+        {
+            assert(aiTrav->ai_addrlen >= sizeof(sockaddr_in6));
+            vIP.push_back(CNetAddr(((struct sockaddr_in6*)(aiTrav->ai_addr))->sin6_addr));
+        }
+#endif
+
+        aiTrav = aiTrav->ai_next;
+    }
+
+    freeaddrinfo(aiRes);
+
+    return (vIP.size() > 0);
+}
+
+bool LookupHost(const char *pszName, std::vector<CNetAddr>& vIP, int nMaxSolutions, bool fAllowLookup)
+{
+    if (pszName[0] == 0)
+        return false;
+    char psz[256];
+    char *pszHost = psz;
+    strlcpy(psz, pszName, sizeof(psz));
+    if (psz[0] == '[' && psz[strlen(psz)-1] == ']')
+    {
+        pszHost = psz+1;
+        psz[strlen(psz)-1] = 0;
+    }
+
+    return LookupIntern(pszHost, vIP, nMaxSolutions, fAllowLookup);
+}
+
+bool LookupHostNumeric(const char *pszName, std::vector<CNetAddr>& vIP, int nMaxSolutions)
+{
+    return LookupHost(pszName, vIP, nMaxSolutions, false);
+}
+
+bool Lookup(const char *pszName, CService& addr, int portDefault, bool fAllowLookup)
+{
+    if (pszName[0] == 0)
+        return false;
+    int port = portDefault;
+    char psz[256];
+    char *pszHost = psz;
+    strlcpy(psz, pszName, sizeof(psz));
+    char* pszColon = strrchr(psz+1,':');
+    char *pszPortEnd = NULL;
+    int portParsed = pszColon ? strtoul(pszColon+1, &pszPortEnd, 10) : 0;
+    if (pszColon && pszPortEnd && pszPortEnd[0] == 0)
+    {
+        if (psz[0] == '[' && pszColon[-1] == ']')
+        {
+            pszHost = psz+1;
+            pszColon[-1] = 0;
+        }
+        else
+            pszColon[0] = 0;
+        if (port >= 0 && port <= USHRT_MAX)
+            port = portParsed;
+    }
+    else
+    {
+        if (psz[0] == '[' && psz[strlen(psz)-1] == ']')
+        {
+            pszHost = psz+1;
+            psz[strlen(psz)-1] = 0;
+        }
+
+    }
+
+    std::vector<CNetAddr> vIP;
+    bool fRet = LookupIntern(pszHost, vIP, 1, fAllowLookup);
+    if (!fRet)
+        return false;
+    addr = CService(vIP[0], port);
+    return true;
+}
+
+bool LookupNumeric(const char *pszName, CService& addr, int portDefault)
+{
+    return Lookup(pszName, addr, portDefault, false);
+}
+
+bool ConnectSocket(const CService &addrDest, SOCKET& hSocketRet, int nTimeout)
+{
+    hSocketRet = INVALID_SOCKET;
+
+    SOCKET hSocket = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+    if (hSocket == INVALID_SOCKET)
+        return false;
+#ifdef SO_NOSIGPIPE
+    int set = 1;
+    setsockopt(hSocket, SOL_SOCKET, SO_NOSIGPIPE, (void*)&set, sizeof(int));
+#endif
+
+    bool fProxy = (fUseProxy && addrDest.IsRoutable());
+    struct sockaddr_in sockaddr;
+    if (fProxy)
+        addrProxy.GetSockAddr(&sockaddr);
+    else
+        addrDest.GetSockAddr(&sockaddr);
+
+#ifdef WIN32
+    u_long fNonblock = 1;
+    if (ioctlsocket(hSocket, FIONBIO, &fNonblock) == SOCKET_ERROR)
+#else
+    int fFlags = fcntl(hSocket, F_GETFL, 0);
+    if (fcntl(hSocket, F_SETFL, fFlags | O_NONBLOCK) == -1)
+#endif
+    {
+        closesocket(hSocket);
+        return false;
+    }
+
+
+    if (connect(hSocket, (struct sockaddr*)&sockaddr, sizeof(sockaddr)) == SOCKET_ERROR)
+    {
+        // WSAEINVAL is here because some legacy version of winsock uses it
+        if (WSAGetLastError() == WSAEINPROGRESS || WSAGetLastError() == WSAEWOULDBLOCK || WSAGetLastError() == WSAEINVAL)
+        {
+            struct timeval timeout;
+            timeout.tv_sec  = nTimeout / 1000;
+            timeout.tv_usec = (nTimeout % 1000) * 1000;
+
+            fd_set fdset;
+            FD_ZERO(&fdset);
+            FD_SET(hSocket, &fdset);
+            int nRet = select(hSocket + 1, NULL, &fdset, NULL, &timeout);
+            if (nRet == 0)
+            {
+                printf("connection timeout\n");
+                closesocket(hSocket);
+                return false;
+            }
+            if (nRet == SOCKET_ERROR)
+            {
+                printf("select() for connection failed: %i\n",WSAGetLastError());
+                closesocket(hSocket);
+                return false;
+            }
+            socklen_t nRetSize = sizeof(nRet);
+#ifdef WIN32
+            if (getsockopt(hSocket, SOL_SOCKET, SO_ERROR, (char*)(&nRet), &nRetSize) == SOCKET_ERROR)
+#else
+            if (getsockopt(hSocket, SOL_SOCKET, SO_ERROR, &nRet, &nRetSize) == SOCKET_ERROR)
+#endif
+            {
+                printf("getsockopt() for connection failed: %i\n",WSAGetLastError());
+                closesocket(hSocket);
+                return false;
+            }
+            if (nRet != 0)
+            {
+                printf("connect() failed after select(): %s\n",strerror(nRet));
+                closesocket(hSocket);
+                return false;
+            }
+        }
+#ifdef WIN32
+        else if (WSAGetLastError() != WSAEISCONN)
+#else
+        else
+#endif
+        {
+            printf("connect() failed: %i\n",WSAGetLastError());
+            closesocket(hSocket);
+            return false;
+        }
+    }
+
+    // this isn't even strictly necessary
+    // CNode::ConnectNode immediately turns the socket back to non-blocking
+    // but we'll turn it back to blocking just in case
+#ifdef WIN32
+    fNonblock = 0;
+    if (ioctlsocket(hSocket, FIONBIO, &fNonblock) == SOCKET_ERROR)
+#else
+    fFlags = fcntl(hSocket, F_GETFL, 0);
+    if (fcntl(hSocket, F_SETFL, fFlags & !O_NONBLOCK) == SOCKET_ERROR)
+#endif
+    {
+        closesocket(hSocket);
+        return false;
+    }
+
+    if (fProxy)
+    {
+        printf("proxy connecting %s\n", addrDest.ToString().c_str());
+        char pszSocks4IP[] = "\4\1\0\0\0\0\0\0user";
+        struct sockaddr_in addr;
+        addrDest.GetSockAddr(&addr);
+        memcpy(pszSocks4IP + 2, &addr.sin_port, 2);
+        memcpy(pszSocks4IP + 4, &addr.sin_addr, 4);
+        char* pszSocks4 = pszSocks4IP;
+        int nSize = sizeof(pszSocks4IP);
+
+        int ret = send(hSocket, pszSocks4, nSize, MSG_NOSIGNAL);
+        if (ret != nSize)
+        {
+            closesocket(hSocket);
+            return error("Error sending to proxy");
+        }
+        char pchRet[8];
+        if (recv(hSocket, pchRet, 8, 0) != 8)
+        {
+            closesocket(hSocket);
+            return error("Error reading proxy response");
+        }
+        if (pchRet[1] != 0x5a)
+        {
+            closesocket(hSocket);
+            if (pchRet[1] != 0x5b)
+                printf("ERROR: Proxy returned error %d\n", pchRet[1]);
+            return false;
+        }
+        printf("proxy connected %s\n", addrDest.ToString().c_str());
+    }
+
+    hSocketRet = hSocket;
+    return true;
+}
+
+void CNetAddr::Init()
+{
+    memset(ip, 0, 16);
+}
+
+void CNetAddr::SetIP(const CNetAddr& ipIn)
+{
+    memcpy(ip, ipIn.ip, sizeof(ip));
+}
+
+CNetAddr::CNetAddr()
+{
+    Init();
+}
+
+CNetAddr::CNetAddr(const struct in_addr& ipv4Addr)
+{
+    memcpy(ip,    pchIPv4, 12);
+    memcpy(ip+12, &ipv4Addr, 4);
+}
+
+#ifdef USE_IPV6
+CNetAddr::CNetAddr(const struct in6_addr& ipv6Addr)
+{
+    memcpy(ip, &ipv6Addr, 16);
+}
+#endif
+
+CNetAddr::CNetAddr(const char *pszIp, bool fAllowLookup)
+{
+    Init();
+    std::vector<CNetAddr> vIP;
+    if (LookupHost(pszIp, vIP, 1, fAllowLookup))
+        *this = vIP[0];
+}
+
+CNetAddr::CNetAddr(const std::string &strIp, bool fAllowLookup)
+{
+    Init();
+    std::vector<CNetAddr> vIP;
+    if (LookupHost(strIp.c_str(), vIP, 1, fAllowLookup))
+        *this = vIP[0];
+}
+
+int CNetAddr::GetByte(int n) const
+{
+    return ip[15-n];
+}
+
+bool CNetAddr::IsIPv4() const
+{
+    return (memcmp(ip, pchIPv4, sizeof(pchIPv4)) == 0);
+}
+
+bool CNetAddr::IsRFC1918() const
+{
+    return IsIPv4() && (
+        GetByte(3) == 10 || 
+        (GetByte(3) == 192 && GetByte(2) == 168) || 
+        (GetByte(3) == 172 && (GetByte(2) >= 16 && GetByte(2) <= 31)));
+}
+
+bool CNetAddr::IsRFC3927() const
+{
+    return IsIPv4() && (GetByte(3) == 169 && GetByte(2) == 254);
+}
+
+bool CNetAddr::IsRFC3849() const
+{
+    return GetByte(15) == 0x20 && GetByte(14) == 0x01 && GetByte(13) == 0x0D && GetByte(12) == 0xB8;
+}
+
+bool CNetAddr::IsRFC3964() const
+{
+    return (GetByte(15) == 0x20 && GetByte(14) == 0x02);
+}
+
+bool CNetAddr::IsRFC6052() const
+{
+    static const unsigned char pchRFC6052[] = {0,0x64,0xFF,0x9B,0,0,0,0,0,0,0,0};
+    return (memcmp(ip, pchRFC6052, sizeof(pchRFC6052)) == 0);
+}
+
+bool CNetAddr::IsRFC4380() const
+{
+    return (GetByte(15) == 0x20 && GetByte(14) == 0x01 && GetByte(13) == 0 && GetByte(12) == 0);
+}
+
+bool CNetAddr::IsRFC4862() const
+{
+    static const unsigned char pchRFC4862[] = {0xFE,0x80,0,0,0,0,0,0};
+    return (memcmp(ip, pchRFC4862, sizeof(pchRFC4862)) == 0);
+}
+
+bool CNetAddr::IsRFC4193() const
+{
+    return ((GetByte(15) & 0xFE) == 0xFC);
+}
+
+bool CNetAddr::IsRFC6145() const
+{
+    static const unsigned char pchRFC6145[] = {0,0,0,0,0,0,0,0,0xFF,0xFF,0,0};
+    return (memcmp(ip, pchRFC6145, sizeof(pchRFC6145)) == 0);
+}
+
+bool CNetAddr::IsRFC4843() const
+{
+    return (GetByte(15) == 0x20 && GetByte(14) == 0x01 && GetByte(13) == 0x00 && GetByte(12) & 0xF0 == 0x10);
+}
+
+bool CNetAddr::IsLocal() const
+{
+    // IPv4 loopback
+   if (IsIPv4() && (GetByte(3) == 127 || GetByte(3) == 0))
+       return true;
+
+   // IPv6 loopback (::1/128)
+   static const unsigned char pchLocal[16] = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1};
+   if (memcmp(ip, pchLocal, 16) == 0)
+       return true;
+
+   return false;
+}
+
+bool CNetAddr::IsMulticast() const
+{
+    return    (IsIPv4() && (GetByte(3) & 0xF0) == 0xE0)
+           || (GetByte(15) == 0xFF);
+}
+
+bool CNetAddr::IsValid() const
+{
+    // Clean up 3-byte shifted addresses caused by garbage in size field
+    // of addr messages from versions before 0.2.9 checksum.
+    // Two consecutive addr messages look like this:
+    // header20 vectorlen3 addr26 addr26 addr26 header20 vectorlen3 addr26 addr26 addr26...
+    // so if the first length field is garbled, it reads the second batch
+    // of addr misaligned by 3 bytes.
+    if (memcmp(ip, pchIPv4+3, sizeof(pchIPv4)-3) == 0)
+        return false;
+
+    // unspecified IPv6 address (::/128)
+    unsigned char ipNone[16] = {};
+    if (memcmp(ip, ipNone, 16) == 0)
+        return false;
+
+    // documentation IPv6 address
+    if (IsRFC3849())
+        return false;
+
+    if (IsIPv4())
+    {
+        // INADDR_NONE
+        uint32_t ipNone = INADDR_NONE;
+        if (memcmp(ip+12, &ipNone, 4) == 0)
+            return false;
+
+        // 0
+        ipNone = 0;
+        if (memcmp(ip+12, &ipNone, 4) == 0)
+            return false;
+    }
+
+    return true;
+}
+
+bool CNetAddr::IsRoutable() const
+{
+    return IsValid() && !(IsRFC1918() || IsRFC3927() || IsRFC4862() || IsRFC4193() || IsRFC4843() || IsLocal());
+}
+
+std::string CNetAddr::ToStringIP() const
+{
+    if (IsIPv4())
+        return strprintf("%u.%u.%u.%u", GetByte(3), GetByte(2), GetByte(1), GetByte(0));
+    else
+        return strprintf("%x:%x:%x:%x:%x:%x:%x:%x",
+                         GetByte(15) << 8 | GetByte(14), GetByte(13) << 8 | GetByte(12),
+                         GetByte(11) << 8 | GetByte(10), GetByte(9) << 8 | GetByte(8),
+                         GetByte(7) << 8 | GetByte(6), GetByte(5) << 8 | GetByte(4),
+                         GetByte(3) << 8 | GetByte(2), GetByte(1) << 8 | GetByte(0));
+}
+
+std::string CNetAddr::ToString() const
+{
+    return ToStringIP();
+}
+
+bool operator==(const CNetAddr& a, const CNetAddr& b)
+{
+    return (memcmp(a.ip, b.ip, 16) == 0);
+}
+
+bool operator!=(const CNetAddr& a, const CNetAddr& b)
+{
+    return (memcmp(a.ip, b.ip, 16) != 0);
+}
+
+bool operator<(const CNetAddr& a, const CNetAddr& b)
+{
+    return (memcmp(a.ip, b.ip, 16) < 0);
+}
+
+bool CNetAddr::GetInAddr(struct in_addr* pipv4Addr) const
+{
+    if (!IsIPv4())
+        return false;
+    memcpy(pipv4Addr, ip+12, 4);
+    return true;
+}
+
+#ifdef USE_IPV6
+bool CNetAddr::GetIn6Addr(struct in6_addr* pipv6Addr) const
+{
+    memcpy(pipv6Addr, ip, 16);
+    return true;
+}
+#endif
+
+// get canonical identifier of an address' group
+// no two connections will be attempted to addresses with the same group
+std::vector<unsigned char> CNetAddr::GetGroup() const
+{
+    std::vector<unsigned char> vchRet;
+    int nClass = 0; // 0=IPv6, 1=IPv4, 255=unroutable
+    int nStartByte = 0;
+    int nBits = 16;
+
+    // for unroutable addresses, each address is considered different
+    if (!IsRoutable())
+    {
+        nClass = 255;
+        nBits = 128;
+    }
+    // for IPv4 addresses, '1' + the 16 higher-order bits of the IP
+    // includes mapped IPv4, SIIT translated IPv4, and the well-known prefix
+    else if (IsIPv4() || IsRFC6145() || IsRFC6052())
+    {
+        nClass = 1;
+        nStartByte = 12;
+    }
+    // for 6to4 tunneled addresses, use the encapsulated IPv4 address
+    else if (IsRFC3964())
+    {
+        nClass = 1;
+        nStartByte = 2;
+    }
+    // for Teredo-tunneled IPv6 addresses, use the encapsulated IPv4 address
+    else if (IsRFC4380())
+    {
+        vchRet.push_back(1);
+        vchRet.push_back(GetByte(3) ^ 0xFF);
+        vchRet.push_back(GetByte(2) ^ 0xFF);
+        return vchRet;
+    }
+    // for he.net, use /36 groups
+    else if (GetByte(15) == 0x20 && GetByte(14) == 0x11 && GetByte(13) == 0x04 && GetByte(12) == 0x70)
+        nBits = 36;
+    // for the rest of the IPv6 network, use /32 groups
+    else
+        nBits = 32;
+
+    vchRet.push_back(nClass);
+    while (nBits >= 8)
+    {
+        vchRet.push_back(GetByte(15 - nStartByte));
+        nStartByte++;
+        nBits -= 8;
+    }
+    if (nBits > 0)
+        vchRet.push_back(GetByte(15 - nStartByte) | ((1 << nBits) - 1));
+
+    return vchRet;
+}
+
+int64 CNetAddr::GetHash() const
+{
+    uint256 hash = Hash(&ip[0], &ip[16]);
+    int64 nRet;
+    memcpy(&nRet, &hash, sizeof(nRet));
+    return nRet;
+}
+
+void CNetAddr::print() const
+{
+    printf("CNetAddr(%s)\n", ToString().c_str());
+}
+
+void CService::Init()
+{
+    port = 0;
+}
+
+CService::CService()
+{
+    Init();
+}
+
+CService::CService(const CNetAddr& cip, unsigned short portIn) : CNetAddr(cip), port(portIn)
+{
+}
+
+CService::CService(const struct in_addr& ipv4Addr, unsigned short portIn) : CNetAddr(ipv4Addr), port(portIn)
+{
+}
+
+#ifdef USE_IPV6
+CService::CService(const struct in6_addr& ipv6Addr, unsigned short portIn) : CNetAddr(ipv6Addr), port(portIn)
+{
+}
+#endif
+
+CService::CService(const struct sockaddr_in& addr) : CNetAddr(addr.sin_addr), port(ntohs(addr.sin_port))
+{
+    assert(addr.sin_family == AF_INET);
+}
+
+#ifdef USE_IPV6
+CService::CService(const struct sockaddr_in6 &addr) : CNetAddr(addr.sin6_addr), port(ntohs(addr.sin6_port))
+{
+   assert(addr.sin6_family == AF_INET6);
+}
+#endif
+
+CService::CService(const char *pszIpPort, bool fAllowLookup)
+{
+    Init();
+    CService ip;
+    if (Lookup(pszIpPort, ip, 0, fAllowLookup))
+        *this = ip;
+}
+
+CService::CService(const char *pszIp, int portIn, bool fAllowLookup)
+{
+    std::vector<CNetAddr> ip;
+    if (LookupHost(pszIp, ip, 1, fAllowLookup))
+        *this = CService(ip[0], portIn);
+}
+
+CService::CService(const std::string &strIpPort, bool fAllowLookup)
+{
+    Init();
+    CService ip;
+    if (Lookup(strIpPort.c_str(), ip, 0, fAllowLookup))
+        *this = ip;
+}
+
+CService::CService(const std::string &strIp, int portIn, bool fAllowLookup)
+{
+    std::vector<CNetAddr> ip;
+    if (LookupHost(strIp.c_str(), ip, 1, fAllowLookup))
+        *this = CService(ip[0], portIn);
+}
+
+unsigned short CService::GetPort() const
+{
+    return port;
+}
+
+bool operator==(const CService& a, const CService& b)
+{
+    return (CNetAddr)a == (CNetAddr)b && a.port == b.port;
+}
+
+bool operator!=(const CService& a, const CService& b)
+{
+    return (CNetAddr)a != (CNetAddr)b || a.port != b.port;
+}
+
+bool operator<(const CService& a, const CService& b)
+{
+    return (CNetAddr)a < (CNetAddr)b || ((CNetAddr)a == (CNetAddr)b && a.port < b.port);
+}
+
+bool CService::GetSockAddr(struct sockaddr_in* paddr) const
+{
+    if (!IsIPv4())
+        return false;
+    memset(paddr, 0, sizeof(struct sockaddr_in));
+    if (!GetInAddr(&paddr->sin_addr))
+        return false;
+    paddr->sin_family = AF_INET;
+    paddr->sin_port = htons(port);
+    return true;
+}
+
+#ifdef USE_IPV6
+bool CService::GetSockAddr6(struct sockaddr_in6* paddr) const
+{
+    memset(paddr, 0, sizeof(struct sockaddr_in6));
+    if (!GetIn6Addr(&paddr->sin6_addr))
+        return false;
+    paddr->sin6_family = AF_INET6;
+    paddr->sin6_port = htons(port);
+    return true;
+}
+#endif
+
+std::vector<unsigned char> CService::GetKey() const
+{
+     std::vector<unsigned char> vKey;
+     vKey.resize(18);
+     memcpy(&vKey[0], ip, 16);
+     vKey[16] = port / 0x100;
+     vKey[17] = port & 0x0FF;
+     return vKey;
+}
+
+std::string CService::ToStringPort() const
+{
+    return strprintf(":%i", port);
+}
+
+std::string CService::ToStringIPPort() const
+{
+    return ToStringIP() + ToStringPort();
+}
+
+std::string CService::ToString() const
+{
+    return ToStringIPPort();
+}
+
+void CService::print() const
+{
+    printf("CService(%s)\n", ToString().c_str());
+}
+
+void CService::SetPort(unsigned short portIn)
+{
+    port = portIn;
+}

--- a/src/netbase.h
+++ b/src/netbase.h
@@ -1,0 +1,138 @@
+// Copyright (c) 2011 The Bitcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file license.txt or http://www.opensource.org/licenses/mit-license.php.
+#ifndef BITCOIN_NETBASE_H
+#define BITCOIN_NETBASE_H
+
+#include <string>
+#include <vector>
+
+#ifdef WIN32
+#define _WIN32_WINNT 0x0501
+#include <winsock2.h>
+#include <mswsock.h>
+#include <ws2tcpip.h>
+#else
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <net/if.h>
+#include <ifaddrs.h>
+#endif
+#ifdef BSD
+#include <netinet/in.h>
+#endif
+
+#include "serialize.h"
+#include "compat.h"
+
+extern int nConnectTimeout;
+
+
+// IP address (IPv6, or IPv4 using mapped IPv6 range (::FFFF:0:0/96))
+class CNetAddr
+{
+    protected:
+        unsigned char ip[16]; // in network byte order
+
+    public:
+        CNetAddr();
+        CNetAddr(const struct in_addr& ipv4Addr);
+        CNetAddr(const char *pszIp, bool fAllowLookup = false);
+        CNetAddr(const std::string &strIp, bool fAllowLookup = false);
+        void Init();
+        void SetIP(const CNetAddr& ip);
+        bool IsIPv4() const;    // IPv4 mapped address (::FFFF:0:0/96, 0.0.0.0/0)
+        bool IsRFC1918() const; // IPv4 private networks (10.0.0.0/8, 192.168.0.0/16, 172.16.0.0/12)
+        bool IsRFC3849() const; // IPv6 documentation address (2001:0DB8::/32)
+        bool IsRFC3927() const; // IPv4 autoconfig (169.254.0.0/16)
+        bool IsRFC3964() const; // IPv6 6to4 tunneling (2002::/16)
+        bool IsRFC4193() const; // IPv6 unique local (FC00::/15)
+        bool IsRFC4380() const; // IPv6 Teredo tunneling (2001::/32)
+        bool IsRFC4843() const; // IPv6 ORCHID (2001:10::/28)
+        bool IsRFC4862() const; // IPv6 autoconfig (FE80::/64)
+        bool IsRFC6052() const; // IPv6 well-known prefix (64:FF9B::/96)
+        bool IsRFC6145() const; // IPv6 IPv4-translated address (::FFFF:0:0:0/96)
+        bool IsLocal() const;
+        bool IsRoutable() const;
+        bool IsValid() const;
+        bool IsMulticast() const;
+        std::string ToString() const;
+        std::string ToStringIP() const;
+        int GetByte(int n) const;
+        int64 GetHash() const;
+        bool GetInAddr(struct in_addr* pipv4Addr) const;
+        std::vector<unsigned char> GetGroup() const;
+        void print() const;
+
+#ifdef USE_IPV6
+        CNetAddr(const struct in6_addr& pipv6Addr);
+        bool GetIn6Addr(struct in6_addr* pipv6Addr) const;
+#endif
+
+        friend bool operator==(const CNetAddr& a, const CNetAddr& b);
+        friend bool operator!=(const CNetAddr& a, const CNetAddr& b);
+        friend bool operator<(const CNetAddr& a, const CNetAddr& b);
+
+        IMPLEMENT_SERIALIZE
+            (
+             READWRITE(FLATDATA(ip));
+            )
+};
+
+class CService : public CNetAddr
+{
+    protected:
+        unsigned short port; // host order
+
+    public:
+        CService();
+        CService(const CNetAddr& ip, unsigned short port);
+        CService(const struct in_addr& ipv4Addr, unsigned short port);
+        CService(const struct sockaddr_in& addr);
+        CService(const char *pszIp, int port, bool fAllowLookup = false);
+        CService(const char *pszIpPort, bool fAllowLookup = false);
+        CService(const std::string& strIp, int port, bool fAllowLookup = false);
+        CService(const std::string& strIpPort, bool fAllowLookup = false);
+        void Init();
+        void SetPort(unsigned short portIn);
+        unsigned short GetPort() const;
+        bool GetSockAddr(struct sockaddr_in* paddr) const;
+        friend bool operator==(const CService& a, const CService& b);
+        friend bool operator!=(const CService& a, const CService& b);
+        friend bool operator<(const CService& a, const CService& b);
+        std::vector<unsigned char> GetKey() const;
+        std::string ToString() const;
+        std::string ToStringPort() const;
+        std::string ToStringIPPort() const;
+        void print() const;
+
+#ifdef USE_IPV6
+        CService(const struct in6_addr& ipv6Addr, unsigned short port);
+        bool GetSockAddr6(struct sockaddr_in6* paddr) const;
+        CService(const struct sockaddr_in6& addr);
+#endif
+
+        IMPLEMENT_SERIALIZE
+            (
+             CService* pthis = const_cast<CService*>(this);
+             READWRITE(FLATDATA(ip));
+             unsigned short portN = htons(port);
+             READWRITE(portN);
+             if (fRead)
+                 pthis->port = ntohs(portN);
+            )
+};
+
+bool LookupHost(const char *pszName, std::vector<CNetAddr>& vIP, int nMaxSolutions = 0, bool fAllowLookup = true);
+bool LookupHostNumeric(const char *pszName, std::vector<CNetAddr>& vIP, int nMaxSolutions = 0);
+bool Lookup(const char *pszName, CService& addr, int portDefault = 0, bool fAllowLookup = true);
+bool LookupNumeric(const char *pszName, CService& addr, int portDefault = 0);
+bool ConnectSocket(const CService &addr, SOCKET& hSocketRet, int nTimeout = nConnectTimeout);
+
+// Settings
+extern int fUseProxy;
+extern CService addrProxy;
+
+#endif

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -5,16 +5,12 @@
 
 #include "protocol.h"
 #include "util.h"
+#include "netbase.h"
 
 #ifndef WIN32
 # include <arpa/inet.h>
 #endif
 
-// Prototypes from net.h, but that header (currently) stinks, can't #include it without breaking things
-bool Lookup(const char *pszName, std::vector<CAddress>& vaddr, int nServices, int nMaxSolutions, bool fAllowLookup = false, int portDefault = 0, bool fAllowPort = false);
-bool Lookup(const char *pszName, CAddress& addr, int nServices, bool fAllowLookup = false, int portDefault = 0, bool fAllowPort = false);
-
-static const unsigned char pchIPv4[12] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff };
 static const char* ppszTypeName[] =
 {
     "ERROR",
@@ -77,183 +73,24 @@ bool CMessageHeader::IsValid() const
     return true;
 }
 
-CAddress::CAddress()
+
+
+CAddress::CAddress() : CService()
 {
     Init();
 }
 
-CAddress::CAddress(unsigned int ipIn, unsigned short portIn, uint64 nServicesIn)
+CAddress::CAddress(CService ipIn, uint64 nServicesIn) : CService(ipIn)
 {
     Init();
-    ip = ipIn;
-    port = htons(portIn == 0 ? GetDefaultPort() : portIn);
     nServices = nServicesIn;
-}
-
-CAddress::CAddress(const struct sockaddr_in& sockaddr, uint64 nServicesIn)
-{
-    Init();
-    ip = sockaddr.sin_addr.s_addr;
-    port = sockaddr.sin_port;
-    nServices = nServicesIn;
-}
-
-CAddress::CAddress(const char* pszIn, int portIn, bool fNameLookup, uint64 nServicesIn)
-{
-    Init();
-    Lookup(pszIn, *this, nServicesIn, fNameLookup, portIn);
-}
-
-CAddress::CAddress(const char* pszIn, bool fNameLookup, uint64 nServicesIn)
-{
-    Init();
-    Lookup(pszIn, *this, nServicesIn, fNameLookup, 0, true);
-}
-
-CAddress::CAddress(std::string strIn, int portIn, bool fNameLookup, uint64 nServicesIn)
-{
-    Init();
-    Lookup(strIn.c_str(), *this, nServicesIn, fNameLookup, portIn);
-}
-
-CAddress::CAddress(std::string strIn, bool fNameLookup, uint64 nServicesIn)
-{
-    Init();
-    Lookup(strIn.c_str(), *this, nServicesIn, fNameLookup, 0, true);
 }
 
 void CAddress::Init()
 {
     nServices = NODE_NETWORK;
-    memcpy(pchReserved, pchIPv4, sizeof(pchReserved));
-    ip = INADDR_NONE;
-    port = htons(GetDefaultPort());
     nTime = 100000000;
     nLastTry = 0;
-}
-
-bool operator==(const CAddress& a, const CAddress& b)
-{
-    return (memcmp(a.pchReserved, b.pchReserved, sizeof(a.pchReserved)) == 0 &&
-            a.ip   == b.ip &&
-            a.port == b.port);
-}
-
-bool operator!=(const CAddress& a, const CAddress& b)
-{
-    return (!(a == b));
-}
-
-bool operator<(const CAddress& a, const CAddress& b)
-{
-    int ret = memcmp(a.pchReserved, b.pchReserved, sizeof(a.pchReserved));
-    if (ret < 0)
-        return true;
-    else if (ret == 0)
-    {
-        if (ntohl(a.ip) < ntohl(b.ip))
-            return true;
-        else if (a.ip == b.ip)
-            return ntohs(a.port) < ntohs(b.port);
-    }
-    return false;
-}
-
-std::vector<unsigned char> CAddress::GetKey() const
-{
-    CDataStream ss;
-    ss.reserve(18);
-    ss << FLATDATA(pchReserved) << ip << port;
-
-    #if defined(_MSC_VER) && _MSC_VER < 1300
-    return std::vector<unsigned char>((unsigned char*)&ss.begin()[0], (unsigned char*)&ss.end()[0]);
-    #else
-    return std::vector<unsigned char>(ss.begin(), ss.end());
-    #endif
-}
-
-struct sockaddr_in CAddress::GetSockAddr() const
-{
-    struct sockaddr_in sockaddr;
-    memset(&sockaddr, 0, sizeof(sockaddr));
-    sockaddr.sin_family = AF_INET;
-    sockaddr.sin_addr.s_addr = ip;
-    sockaddr.sin_port = port;
-    return sockaddr;
-}
-
-bool CAddress::IsIPv4() const
-{
-    return (memcmp(pchReserved, pchIPv4, sizeof(pchIPv4)) == 0);
-}
-
-bool CAddress::IsRFC1918() const
-{
-  return IsIPv4() && (GetByte(3) == 10 ||
-    (GetByte(3) == 192 && GetByte(2) == 168) ||
-    (GetByte(3) == 172 &&
-      (GetByte(2) >= 16 && GetByte(2) <= 31)));
-}
-
-bool CAddress::IsRFC3927() const
-{
-  return IsIPv4() && (GetByte(3) == 169 && GetByte(2) == 254);
-}
-
-bool CAddress::IsLocal() const
-{
-  return IsIPv4() && (GetByte(3) == 127 ||
-      GetByte(3) == 0);
-}
-
-bool CAddress::IsRoutable() const
-{
-    return IsValid() &&
-        !(IsRFC1918() || IsRFC3927() || IsLocal());
-}
-
-bool CAddress::IsValid() const
-{
-    // Clean up 3-byte shifted addresses caused by garbage in size field
-    // of addr messages from versions before 0.2.9 checksum.
-    // Two consecutive addr messages look like this:
-    // header20 vectorlen3 addr26 addr26 addr26 header20 vectorlen3 addr26 addr26 addr26...
-    // so if the first length field is garbled, it reads the second batch
-    // of addr misaligned by 3 bytes.
-    if (memcmp(pchReserved, pchIPv4+3, sizeof(pchIPv4)-3) == 0)
-        return false;
-
-    return (ip != 0 && ip != INADDR_NONE && port != htons(std::numeric_limits<unsigned short>::max()));
-}
-
-unsigned char CAddress::GetByte(int n) const
-{
-    return ((unsigned char*)&ip)[3-n];
-}
-
-std::string CAddress::ToStringIPPort() const
-{
-    return strprintf("%u.%u.%u.%u:%u", GetByte(3), GetByte(2), GetByte(1), GetByte(0), ntohs(port));
-}
-
-std::string CAddress::ToStringIP() const
-{
-    return strprintf("%u.%u.%u.%u", GetByte(3), GetByte(2), GetByte(1), GetByte(0));
-}
-
-std::string CAddress::ToStringPort() const
-{
-    return strprintf("%u", ntohs(port));
-}
-
-std::string CAddress::ToString() const
-{
-    return strprintf("%u.%u.%u.%u:%u", GetByte(3), GetByte(2), GetByte(1), GetByte(0), ntohs(port));
-}
-
-void CAddress::print() const
-{
-    printf("CAddress(%s)\n", ToString().c_str());
 }
 
 CInv::CInv()
@@ -310,3 +147,4 @@ void CInv::print() const
 {
     printf("CInv(%s)\n", ToString().c_str());
 }
+

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -11,6 +11,8 @@
 #define __INCLUDED_PROTOCOL_H__
 
 #include "serialize.h"
+#include "netbase.h"
+#include "util.h"
 #include <string>
 #include "uint256.h"
 
@@ -61,58 +63,33 @@ enum
     NODE_NETWORK = (1 << 0),
 };
 
-class CAddress
+class CAddress : public CService
 {
     public:
         CAddress();
-        CAddress(unsigned int ipIn, unsigned short portIn=0, uint64 nServicesIn=NODE_NETWORK);
-        explicit CAddress(const struct sockaddr_in& sockaddr, uint64 nServicesIn=NODE_NETWORK);
-        explicit CAddress(const char* pszIn, int portIn, bool fNameLookup = false, uint64 nServicesIn=NODE_NETWORK);
-        explicit CAddress(const char* pszIn, bool fNameLookup = false, uint64 nServicesIn=NODE_NETWORK);
-        explicit CAddress(std::string strIn, int portIn, bool fNameLookup = false, uint64 nServicesIn=NODE_NETWORK);
-        explicit CAddress(std::string strIn, bool fNameLookup = false, uint64 nServicesIn=NODE_NETWORK);
+        CAddress(CService ipIn, uint64 nServicesIn=NODE_NETWORK);
 
         void Init();
 
         IMPLEMENT_SERIALIZE
             (
+             CAddress* pthis = const_cast<CAddress*>(this);
+             CService* pip = (CService*)pthis;
              if (fRead)
-             const_cast<CAddress*>(this)->Init();
+                 pthis->Init();
              if (nType & SER_DISK)
              READWRITE(nVersion);
              if ((nType & SER_DISK) || (nVersion >= 31402 && !(nType & SER_GETHASH)))
              READWRITE(nTime);
              READWRITE(nServices);
-             READWRITE(FLATDATA(pchReserved)); // for IPv6
-             READWRITE(ip);
-             READWRITE(port);
+             READWRITE(*pip);
             )
 
-        friend bool operator==(const CAddress& a, const CAddress& b);
-        friend bool operator!=(const CAddress& a, const CAddress& b);
-        friend bool operator<(const CAddress& a, const CAddress& b);
-
-        std::vector<unsigned char> GetKey() const;
-        struct sockaddr_in GetSockAddr() const;
-        bool IsIPv4() const;
-        bool IsRFC1918() const;
-        bool IsRFC3927() const;
-        bool IsLocal() const;
-        bool IsRoutable() const;
-        bool IsValid() const;
-        unsigned char GetByte(int n) const;
-        std::string ToStringIPPort() const;
-        std::string ToStringIP() const;
-        std::string ToStringPort() const;
-        std::string ToString() const;
         void print() const;
 
     // TODO: make private (improves encapsulation)
     public:
         uint64 nServices;
-        unsigned char pchReserved[12];
-        unsigned int ip;
-        unsigned short port;
 
         // disk and network only
         unsigned int nTime;

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -88,9 +88,9 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
             {
                 // Use CAddress to parse and check IP
                 CAddress addr(value.toString().toStdString() + ":1");
-                if (addr.ip != INADDR_NONE)
+                if (addr.IsValid())
                 {
-                    addrProxy.ip = addr.ip;
+                    addrProxy.SetIP(addr);
                     walletdb.WriteSetting("addrProxy", addrProxy);
                 }
                 else
@@ -104,7 +104,7 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
                 int nPort = atoi(value.toString().toAscii().data());
                 if (nPort > 0 && nPort < std::numeric_limits<unsigned short>::max())
                 {
-                    addrProxy.port = htons(nPort);
+                    addrProxy.SetPort(nPort);
                     walletdb.WriteSetting("addrProxy", addrProxy);
                 }
                 else

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -623,7 +623,7 @@ inline const uint256 operator-(const uint256& a, const uint256& b)      { return
 
 
 
-
+#ifdef TEST_UINT256
 
 inline int Testuint256AdHoc(std::vector<std::string> vArg)
 {
@@ -754,5 +754,7 @@ inline int Testuint256AdHoc(std::vector<std::string> vArg)
 
     return (0);
 }
+
+#endif
 
 #endif

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -948,12 +948,12 @@ int64 GetAdjustedTime()
     return GetTime() + nTimeOffset;
 }
 
-void AddTimeData(unsigned int ip, int64 nTime)
+void AddTimeData(const CNetAddr& ip, int64 nTime)
 {
     int64 nOffsetSample = nTime - GetTime();
 
     // Ignore duplicates
-    static set<unsigned int> setKnown;
+    static set<CNetAddr> setKnown;
     if (!setKnown.insert(ip).second)
         return;
 
@@ -1000,7 +1000,6 @@ void AddTimeData(unsigned int ip, int64 nTime)
         printf("nTimeOffset = %+"PRI64d"  (%+"PRI64d" minutes)\n", nTimeOffset, nTimeOffset/60);
     }
 }
-
 
 
 
@@ -1178,3 +1177,4 @@ bool CCriticalSection::TryEnter(const char*, const char*, int)
 }
 
 #endif /* DEBUG_LOCKORDER */
+

--- a/src/util.h
+++ b/src/util.h
@@ -24,6 +24,7 @@
 #include <openssl/sha.h>
 #include <openssl/ripemd.h>
 
+#include "netbase.h"
 
 typedef long long  int64;
 typedef unsigned long long  uint64;
@@ -79,20 +80,7 @@ T* alignup(T* p)
 #define S_IWUSR             0200
 #endif
 #define unlink              _unlink
-typedef int socklen_t;
 #else
-#define WSAGetLastError()   errno
-#define WSAEINVAL           EINVAL
-#define WSAEALREADY         EALREADY
-#define WSAEWOULDBLOCK      EWOULDBLOCK
-#define WSAEMSGSIZE         EMSGSIZE
-#define WSAEINTR            EINTR
-#define WSAEINPROGRESS      EINPROGRESS
-#define WSAEADDRINUSE       EADDRINUSE
-#define WSAENOTSOCK         EBADF
-#define INVALID_SOCKET      (SOCKET)(~0)
-#define SOCKET_ERROR        -1
-typedef u_int SOCKET;
 #define _vsnprintf(a,b,c,d) vsnprintf(a,b,c,d)
 #define strlwr(psz)         to_lower(psz)
 #define _strlwr(psz)        to_lower(psz)
@@ -104,19 +92,6 @@ inline void Sleep(int64 n)
 }
 #endif
 
-inline int myclosesocket(SOCKET& hSocket)
-{
-    if (hSocket == INVALID_SOCKET)
-        return WSAENOTSOCK;
-#ifdef WIN32
-    int ret = closesocket(hSocket);
-#else
-    int ret = close(hSocket);
-#endif
-    hSocket = INVALID_SOCKET;
-    return ret;
-}
-#define closesocket(s)      myclosesocket(s)
 #if !defined(QT_GUI)
 inline const char* _(const char* psz)
 {
@@ -187,9 +162,9 @@ uint64 GetRand(uint64 nMax);
 int64 GetTime();
 void SetMockTime(int64 nMockTimeIn);
 int64 GetAdjustedTime();
-void AddTimeData(unsigned int ip, int64 nTime);
 std::string FormatFullVersion();
 std::string FormatSubVersion(const std::string& name, int nClientVersion, const std::vector<std::string>& comments);
+void AddTimeData(const CNetAddr& ip, int64 nTime);
 
 
 
@@ -745,3 +720,4 @@ inline uint32_t ByteReverse(uint32_t value)
 }
 
 #endif
+


### PR DESCRIPTION
This introduces CNetAddr and CService, respectively wrapping an
(IPv6) address and an IP+port combination. This functionality used
to be part of CAddress, which also contains network flags and
connection attempt information. These extra fields are however
not always necessary.

These classes, along with logic for creating connections and
doing name lookups, are moved to netbase.{h,cpp}, which does not
depend on headers.h.

Furthermore, CNetAddr is completely IPv6-ready, though IPv6
functionality is not yet enabled for the application itself.
