### PR TITLE
-blocknotify : run a command when best-block changes

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -227,6 +227,7 @@ bool AppInit2(int argc, char* argv[])
             "  -rpcport=<port>  \t\t  " + _("Listen for JSON-RPC connections on <port> (default: 8332)") + "\n" +
             "  -rpcallowip=<ip> \t\t  " + _("Allow JSON-RPC connections from specified IP address") + "\n" +
             "  -rpcconnect=<ip> \t  "   + _("Send commands to node running on <ip> (default: 127.0.0.1)") + "\n" +
+            "  -blocknotify=<cmd> "     + _("Execute command when the best block changes (%s in cmd is replaced by block hash)") + "\n" +
             "  -keypool=<n>     \t  "   + _("Set key pool size to <n> (default: 100)") + "\n" +
             "  -rescan          \t  "   + _("Rescan the block chain for missing wallet transactions") + "\n";
 


### PR DESCRIPTION
This re-implements pull#714, using system() (which does work on Windows) and boost::thread().

Help text is:
  -blocknotify=&lt;cmd&gt; Execute command when the best block changes (%s in cmd is replaced by block hash)

Example usage (this is how I tested):

  ./bitcoind -blocknotify="./bitcoind getblock %s >> /tmp/blocks.txt"
