### PR TITLE
RPC getmemorypool improvements: coinbase flags, min timestamp

### DIFF
--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -1871,6 +1871,7 @@ Value getmemorypool(const Array& params, bool fHelp)
             "  \"previousblockhash\" : hash of current highest block\n"
             "  \"transactions\" : contents of non-coinbase transactions that should be included in the next block\n"
             "  \"coinbasevalue\" : maximum allowable input to coinbase transaction, including the generation award and transaction fees\n"
+            "  \"coinbaseflags\" : data that should be included in coinbase so support for new features can be judged\n"
             "  \"time\" : timestamp appropriate for next block\n"
             "  \"bits\" : compressed target of next block\n"
             "If [data] is specified, tries to solve the block and returns true if it was successful.");
@@ -1925,6 +1926,7 @@ Value getmemorypool(const Array& params, bool fHelp)
         result.push_back(Pair("previousblockhash", pblock->hashPrevBlock.GetHex()));
         result.push_back(Pair("transactions", transactions));
         result.push_back(Pair("coinbasevalue", (int64_t)pblock->vtx[0].vout[0].nValue));
+        result.push_back(Pair("coinbaseflags", HexStr(COINBASE_FLAGS.begin(), COINBASE_FLAGS.end())));
         result.push_back(Pair("time", (int64_t)pblock->nTime));
 
         union {

--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -1873,6 +1873,8 @@ Value getmemorypool(const Array& params, bool fHelp)
             "  \"coinbasevalue\" : maximum allowable input to coinbase transaction, including the generation award and transaction fees\n"
             "  \"coinbaseflags\" : data that should be included in coinbase so support for new features can be judged\n"
             "  \"time\" : timestamp appropriate for next block\n"
+            "  \"mintime\" : minimum timestamp appropriate for next block\n"
+            "  \"curtime\" : current timestamp\n"
             "  \"bits\" : compressed target of next block\n"
             "If [data] is specified, tries to solve the block and returns true if it was successful.");
 
@@ -1928,6 +1930,8 @@ Value getmemorypool(const Array& params, bool fHelp)
         result.push_back(Pair("coinbasevalue", (int64_t)pblock->vtx[0].vout[0].nValue));
         result.push_back(Pair("coinbaseflags", HexStr(COINBASE_FLAGS.begin(), COINBASE_FLAGS.end())));
         result.push_back(Pair("time", (int64_t)pblock->nTime));
+        result.push_back(Pair("mintime", (int64_t)pindexPrev->GetMedianTimePast()+1));
+        result.push_back(Pair("curtime", (int64_t)GetAdjustedTime()));
 
         union {
             int32_t nBits;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3130,12 +3130,7 @@ void IncrementExtraNonce(CBlock* pblock, CBlockIndex* pindexPrev, unsigned int& 
         hashPrevBlock = pblock->hashPrevBlock;
     }
     ++nExtraNonce;
-    pblock->vtx[0].vin[0].scriptSig = CScript() << pblock->nTime << CBigNum(nExtraNonce);
-
-    // Put "/P2SH/" in the coinbase so everybody can tell when
-    // a majority of miners support it
-    const char* pszP2SH = "/P2SH/";
-    pblock->vtx[0].vin[0].scriptSig += CScript() << std::vector<unsigned char>(pszP2SH, pszP2SH+strlen(pszP2SH));
+    pblock->vtx[0].vin[0].scriptSig = (CScript() << pblock->nTime << CBigNum(nExtraNonce)) + COINBASE_FLAGS;
     assert(pblock->vtx[0].vin[0].scriptSig.size() <= 100);
 
     pblock->hashMerkleRoot = pblock->BuildMerkleTree();

--- a/src/main.h
+++ b/src/main.h
@@ -49,6 +49,12 @@ static const int fHaveUPnP = false;
 #endif
 
 
+// Put "/P2SH/" in the coinbase so everybody can tell when
+// a majority of miners support it
+static const char* pszP2SH = "/P2SH/";
+static const CScript COINBASE_FLAGS = CScript() << std::vector<unsigned char>(pszP2SH, pszP2SH+strlen(pszP2SH));
+
+
 
 
 


### PR DESCRIPTION
Adds coinbaseflags, mintime, and curtime to output of getmemorypool.

Since users of getmemorypool generate coinbase transactions themselves, they need bitcoind to indicate what should be included in the coinbase data.

Mintime and curtime are useful for generating work by changing the timestamp. Without them, P2Pool can only increment the timestamp. With the knowledge of the minimum allowable timestamp, work can be generated symmetrically around the current timestamp, reducing future bias.

Generation (without using getmemorypool) tested on testnet: http://blockexplorer.com/testnet/block/00000000014be554b29d072c2c079f8e120715d2799899cc9774a8dd02c78345
