### PR TITLE
Check consistency of private keys

### DIFF
--- a/src/db.cpp
+++ b/src/db.cpp
@@ -862,6 +862,8 @@ int CWalletDB::LoadWallet(CWallet* pwallet)
                     ssValue >> pkey;
                     key.SetPubKey(vchPubKey);
                     key.SetPrivKey(pkey);
+                    if (key.GetPubKey() != vchPubKey)
+                        return DB_CORRUPT;
                 }
                 else
                 {


### PR DESCRIPTION
Reported by onlineproof on IRC: Bitcoin does not verify whether private
keys and public keys correspond, when loading a wallet.
