### PR TITLE
Full checking of all loaded keys

### DIFF
--- a/src/db.cpp
+++ b/src/db.cpp
@@ -862,7 +862,7 @@ int CWalletDB::LoadWallet(CWallet* pwallet)
                     ssValue >> pkey;
                     key.SetPubKey(vchPubKey);
                     key.SetPrivKey(pkey);
-                    if (key.GetPubKey() != vchPubKey)
+                    if (key.GetPubKey() != vchPubKey || !key.IsValid())
                         return DB_CORRUPT;
                 }
                 else
@@ -871,6 +871,8 @@ int CWalletDB::LoadWallet(CWallet* pwallet)
                     ssValue >> wkey;
                     key.SetPubKey(vchPubKey);
                     key.SetPrivKey(wkey.vchPrivKey);
+                    if (key.GetPubKey() != vchPubKey || !key.IsValid())
+                        return DB_CORRUPT;
                 }
                 if (!pwallet->LoadKey(key))
                     return DB_CORRUPT;

--- a/src/key.h
+++ b/src/key.h
@@ -307,6 +307,18 @@ public:
             return false;
         return true;
     }
+
+    bool IsValid()
+    {
+        if (!fSet)
+            return false;
+
+        bool fCompr;
+        CSecret secret = GetSecret(fCompr);
+        CKey key2;
+        key2.SetSecret(secret, fCompr);
+        return GetPubKey() == key2.GetPubKey();
+    }
 };
 
 #endif


### PR DESCRIPTION
See #782: @piratelinux is right in saying that not everything is checked, as GetPubKey() returns the public key embedded in the PrivKey structure, and does not force recalculation.

CKey::IsValid() performs this check now.
