### PR TITLE
Avoid advertising the node's address when it is not listening or IsInitialBlockDownload().

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -141,7 +141,7 @@ bool GetMyExternalIP(CNetAddr& ipRet)
     const char* pszGet;
     const char* pszKeyword;
 
-    if (fUseProxy)
+    if (fNoListen||fUseProxy)
         return false;
 
     for (int nLookup = 0; nLookup <= 1; nLookup++)


### PR DESCRIPTION
This also avoids flushing setAddrKnown until 24 hours has passed,
and avoids contacting the external IP services when not listening.

Advertising non-listening nodes is just addr message spam.
It doesn't help the network, in fact it hurts the network,
and it also hurts user's privacy.

Advertising far out of sync nodes doesn't help the network—
they can't even forward (most) transactions and wastes nodes
outbound slots.
