### PR TITLE
Fix Minimize to the tray instead of the taskbar

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -85,6 +85,9 @@ BitcoinGUI::BitcoinGUI(QWidget *parent):
     // Create the tray icon (or setup the dock icon)
     createTrayIcon();
 
+    // Dummy widget used when restoring window state after minimization
+    dummyWidget = new QWidget();
+
     // Create tabs
     overviewPage = new OverviewPage();
 
@@ -403,6 +406,7 @@ void BitcoinGUI::trayIconActivated(QSystemTrayIcon::ActivationReason reason)
     if(reason == QSystemTrayIcon::Trigger)
     {
         // Click on system tray icon triggers "open bitcoin"
+        setParent(NULL, Qt::Window);
         openBitcoinAction->trigger();
     }
 
@@ -550,6 +554,8 @@ void BitcoinGUI::changeEvent(QEvent *e)
         {
             if(isMinimized())
             {
+                // Hiding the window from taskbar
+                setParent(dummyWidget, Qt::SubWindow);
                 hide();
                 e->ignore();
             }

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -58,6 +58,8 @@ private:
 
     QStackedWidget *centralWidget;
 
+    QWidget *dummyWidget;
+
     OverviewPage *overviewPage;
     QWidget *transactionsPage;
     AddressBookPage *addressBookPage;


### PR DESCRIPTION
The "Minimize to the tray instead of the taskbar" option in Options should now work correctly.
