### PR TITLE
Have bitcoind recommend a secure RPC password. Increase invalid password delay.

### DIFF
--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -2368,18 +2368,25 @@ void ThreadRPCServer2(void* parg)
     printf("ThreadRPCServer started\n");
 
     strRPCUserColonPass = mapArgs["-rpcuser"] + ":" + mapArgs["-rpcpassword"];
-    if (strRPCUserColonPass == ":")
+    if (mapArgs["-rpcpassword"] == "")
     {
+        unsigned char rand_pwd[32];
+        RAND_bytes(rand_pwd, 32);
         string strWhatAmI = "To use bitcoind";
         if (mapArgs.count("-server"))
             strWhatAmI = strprintf(_("To use the %s option"), "\"-server\"");
         else if (mapArgs.count("-daemon"))
             strWhatAmI = strprintf(_("To use the %s option"), "\"-daemon\"");
         PrintConsole(
-            _("Error: %s, you must set rpcpassword=<password>\nin the configuration file: %s\n"
+            _("Error: %s, you must set a rpcpassword in the configuration file:\n %s\n"
+              "It is recommended you use the following random password:\n"
+              "rpcuser=bitcoinrpc\n"
+              "rpcpassword=%s\n"
+              "(you do not need to remember this password)\n"
               "If the file does not exist, create it with owner-readable-only file permissions.\n"),
                 strWhatAmI.c_str(),
-                GetConfigFile().c_str());
+                GetConfigFile().c_str(),
+                EncodeBase58(&rand_pwd[0],&rand_pwd[0]+32).c_str());
 #ifndef QT_GUI
         CreateThread(Shutdown, NULL);
 #endif
@@ -2468,12 +2475,14 @@ void ThreadRPCServer2(void* parg)
         }
         if (!HTTPAuthorized(mapHeaders))
         {
-            // Deter brute-forcing short passwords
-            if (mapArgs["-rpcpassword"].size() < 15)
-                Sleep(50);
+            printf("ThreadRPCServer incorrect password attempt from %s\n",peer.address().to_string().c_str());
+            /* Deter brute-forcing short passwords.
+               If this results in a DOS the user really
+               shouldn't have their RPC port exposed.*/
+            if (mapArgs["-rpcpassword"].size() < 20)
+                Sleep(250);
 
             stream << HTTPReply(401, "") << std::flush;
-            printf("ThreadRPCServer incorrect password attempt\n");
             continue;
         }
 


### PR DESCRIPTION
Help users avoid insecure configurations a bit by recommending a
secure RPC password and increasing the incorrect password delay.

This may open up a RPC DOS for users with exposed RPC ports and
short passwords. Since users shouldn't have exposed RPC ports OR
short passwords, the DOS risk is preferable to the compromise
risk.

Also logs the client IP address for incorrect attempts.

With this patch running bitcoind when there is no configuration file now results in:
[gmaxwell@helmholtz src]$ ./bitcoind
Error: To use bitcoind, you must set a rpcpassword in the configuration file:
/home/gmaxwell/.bitcoin/bitcoin.conf
It is recommended you use the following random password:
rpcuser=bitcoinrpc
rpcpassword=HXt6c9zmw6jqW4jvh3pcHTGb7owrmNLUtaSVGvoT2Sho
(you do not need to remember this password)
If the file does not exist, create it with owner-readable-only file permissions.

Previously it just advised rpcpassword= which probably gets filled in with insecure normal password like values.

I think ideally bitcoin would just autocreate the file with a random authentication string like this— but I thought this change was more minimal. Thoughts?
