### PR TITLE
Command-line parsing changes, and no irc by default

### DIFF
--- a/src/db.cpp
+++ b/src/db.cpp
@@ -990,7 +990,7 @@ void ThreadFlushWalletDB(void* parg)
     if (fOneThread)
         return;
     fOneThread = true;
-    if (mapArgs.count("-noflushwallet"))
+    if (!GetBoolArg("-flushwallet", true))
         return;
 
     unsigned int nLastSeen = nWalletDBUpdated;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -194,18 +194,18 @@ bool AppInit2(int argc, char* argv[])
             "  -maxconnections=<n>\t  " + _("Maintain at most <n> connections to peers (default: 125)") + "\n" +
             "  -addnode=<ip>    \t  "   + _("Add a node to connect to and attempt to keep the connection open") + "\n" +
             "  -connect=<ip>    \t\t  " + _("Connect only to the specified node") + "\n" +
-            "  -noirc           \t  "   + _("Don't find peers using internet relay chat") + "\n" +
-            "  -nolisten        \t  "   + _("Don't accept connections from outside") + "\n" +
-            "  -nodnsseed       \t  "   + _("Don't bootstrap list of peers using DNS") + "\n" +
+            "  -irc             \t  "   + _("Find peers using internet relay chat (default: 0)") + "\n" +
+            "  -listen          \t  "   + _("Accept connections from outside (default: 1)") + "\n" +
+            "  -dnsseed         \t  "   + _("Find peers using DNS lookup (default: 1)") + "\n" +
             "  -banscore=<n>    \t  "   + _("Threshold for disconnecting misbehaving peers (default: 100)") + "\n" +
             "  -bantime=<n>     \t  "   + _("Number of seconds to keep misbehaving peers from reconnecting (default: 86400)") + "\n" +
             "  -maxreceivebuffer=<n>\t  " + _("Maximum per-connection receive buffer, <n>*1000 bytes (default: 10000)") + "\n" +
             "  -maxsendbuffer=<n>\t  "   + _("Maximum per-connection send buffer, <n>*1000 bytes (default: 10000)") + "\n" +
 #ifdef USE_UPNP
 #if USE_UPNP
-            "  -noupnp          \t  "   + _("Don't attempt to use UPnP to map the listening port") + "\n" +
+            "  -upnp            \t  "   + _("Use Universal Plug and Play to map the listening port (default: 1)") + "\n" +
 #else
-            "  -upnp            \t  "   + _("Attempt to use UPnP to map the listening port") + "\n" +
+            "  -upnp            \t  "   + _("Use Universal Plug and Play to map the listening port (default: 0)") + "\n" +
 #endif
 #endif
             "  -paytxfee=<amt>  \t  "   + _("Fee per KB to add to transactions you send") + "\n" +
@@ -476,16 +476,15 @@ bool AppInit2(int argc, char* argv[])
     {
         // Use SoftSetBoolArg here so user can override any of these if they wish.
         // Note: the GetBoolArg() calls for all of these must happen later.
-        SoftSetBoolArg("-nolisten", true);
-        SoftSetBoolArg("-noirc", true);
-        SoftSetBoolArg("-nodnsseed", true);
-        SoftSetBoolArg("-noupnp", true);
+        SoftSetBoolArg("-listen", false);
+        SoftSetBoolArg("-irc", false);
+        SoftSetBoolArg("-dnsseed", false);
         SoftSetBoolArg("-upnp", false);
         SoftSetBoolArg("-dns", false);
     }
 
     fAllowDNS = GetBoolArg("-dns");
-    fNoListen = GetBoolArg("-nolisten");
+    fNoListen = !GetBoolArg("-listen", true);
 
     // This code can be removed once a super-majority of the network has upgraded.
     if (GetBoolArg("-bip16", true))
@@ -507,10 +506,11 @@ bool AppInit2(int argc, char* argv[])
     }
 
     // Command-line args override in-wallet settings:
-    if (mapArgs.count("-upnp"))
-        fUseUPnP = GetBoolArg("-upnp");
-    else if (mapArgs.count("-noupnp"))
-        fUseUPnP = !GetBoolArg("-noupnp");
+#if USE_UPNP
+    fUseUPnP = GetBoolArg("-upnp", true);
+#else
+    fUseUPnP = GetBoolArg("-upnp", false);
+#endif
 
     if (!fNoListen)
     {

--- a/src/irc.cpp
+++ b/src/irc.cpp
@@ -261,8 +261,9 @@ void ThreadIRCSeed2(void* parg)
     if (mapArgs.count("-connect") || fNoListen)
         return;
 
-    if (GetBoolArg("-noirc"))
+    if (!GetBoolArg("-irc", false))
         return;
+
     printf("ThreadIRCSeed started\n");
     int nErrorWait = 10;
     int nRetryWait = 10;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -200,7 +200,7 @@ bool GetMyExternalIP(CNetAddr& ipRet)
 void ThreadGetMyExternalIP(void* parg)
 {
     // Wait for IRC to get it first
-    if (!GetBoolArg("-noirc"))
+    if (GetBoolArg("-irc", false))
     {
         for (int i = 0; i < 2 * 60; i++)
         {
@@ -1706,7 +1706,7 @@ void StartNode(void* parg)
     // Start threads
     //
 
-    if (GetBoolArg("-nodnsseed"))
+    if (!GetBoolArg("-dnsseed", true))
         printf("DNS seeding disabled\n");
     else
         if (!CreateThread(ThreadDNSAddressSeed, NULL))

--- a/src/test/getarg_tests.cpp
+++ b/src/test/getarg_tests.cpp
@@ -1,0 +1,95 @@
+#include <boost/algorithm/string.hpp>
+#include <boost/foreach.hpp>
+#include <boost/test/unit_test.hpp>
+
+#include "util.h"
+
+BOOST_AUTO_TEST_SUITE(getarg_tests)
+
+static void
+ResetArgs(const std::string& strArg)
+{
+    std::vector<std::string> vecArg;
+    boost::split(vecArg, strArg, boost::is_space(), boost::token_compress_on);
+
+    // Insert dummy executable name:
+    vecArg.insert(vecArg.begin(), "testbitcoin");
+
+    // Convert to char*:
+    std::vector<const char*> vecChar;
+    BOOST_FOREACH(std::string& s, vecArg)
+        vecChar.push_back(s.c_str());
+
+    ParseParameters(vecChar.size(), &vecChar[0]);
+}
+
+BOOST_AUTO_TEST_CASE(boolarg)
+{
+    ResetArgs("-foo");
+    BOOST_CHECK(GetBoolArg("-foo"));
+    BOOST_CHECK(GetBoolArg("-foo", false));
+    BOOST_CHECK(GetBoolArg("-foo", true));
+
+    BOOST_CHECK(!GetBoolArg("-fo"));
+    BOOST_CHECK(!GetBoolArg("-fo", false));
+    BOOST_CHECK(GetBoolArg("-fo", true));
+
+    BOOST_CHECK(!GetBoolArg("-fooo"));
+    BOOST_CHECK(!GetBoolArg("-fooo", false));
+    BOOST_CHECK(GetBoolArg("-fooo", true));
+
+    ResetArgs("-foo=0");
+    BOOST_CHECK(!GetBoolArg("-foo"));
+    BOOST_CHECK(!GetBoolArg("-foo", false));
+    BOOST_CHECK(!GetBoolArg("-foo", true));
+
+    ResetArgs("-foo=1");
+    BOOST_CHECK(GetBoolArg("-foo"));
+    BOOST_CHECK(GetBoolArg("-foo", false));
+    BOOST_CHECK(GetBoolArg("-foo", true));
+}
+
+BOOST_AUTO_TEST_CASE(stringarg)
+{
+    ResetArgs("");
+    BOOST_CHECK_EQUAL(GetArg("-foo", ""), "");
+    BOOST_CHECK_EQUAL(GetArg("-foo", "eleven"), "eleven");
+
+    ResetArgs("-foo -bar");
+    BOOST_CHECK_EQUAL(GetArg("-foo", ""), "");
+    BOOST_CHECK_EQUAL(GetArg("-foo", "eleven"), "");
+
+    ResetArgs("-foo=");
+    BOOST_CHECK_EQUAL(GetArg("-foo", ""), "");
+    BOOST_CHECK_EQUAL(GetArg("-foo", "eleven"), "");
+
+    ResetArgs("-foo=11");
+    BOOST_CHECK_EQUAL(GetArg("-foo", ""), "11");
+    BOOST_CHECK_EQUAL(GetArg("-foo", "eleven"), "11");
+
+    ResetArgs("-foo=eleven");
+    BOOST_CHECK_EQUAL(GetArg("-foo", ""), "eleven");
+    BOOST_CHECK_EQUAL(GetArg("-foo", "eleven"), "eleven");
+
+}
+
+BOOST_AUTO_TEST_CASE(intarg)
+{
+    ResetArgs("");
+    BOOST_CHECK_EQUAL(GetArg("-foo", 11), 11);
+    BOOST_CHECK_EQUAL(GetArg("-foo", 0), 0);
+
+    ResetArgs("-foo -bar");
+    BOOST_CHECK_EQUAL(GetArg("-foo", 11), 0);
+    BOOST_CHECK_EQUAL(GetArg("-bar", 11), 0);
+
+    ResetArgs("-foo=11 -bar=12");
+    BOOST_CHECK_EQUAL(GetArg("-foo", 0), 11);
+    BOOST_CHECK_EQUAL(GetArg("-bar", 11), 12);
+
+    ResetArgs("-foo=NaN -bar=NotANumber");
+    BOOST_CHECK_EQUAL(GetArg("-foo", 1), 0);
+    BOOST_CHECK_EQUAL(GetArg("-bar", 11), 0);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/getarg_tests.cpp
+++ b/src/test/getarg_tests.cpp
@@ -47,6 +47,44 @@ BOOST_AUTO_TEST_CASE(boolarg)
     BOOST_CHECK(GetBoolArg("-foo"));
     BOOST_CHECK(GetBoolArg("-foo", false));
     BOOST_CHECK(GetBoolArg("-foo", true));
+
+    // New 0.6 feature: auto-map -nosomething to !-something:
+    ResetArgs("-nofoo");
+    BOOST_CHECK(!GetBoolArg("-foo"));
+    BOOST_CHECK(!GetBoolArg("-foo", false));
+    BOOST_CHECK(!GetBoolArg("-foo", true));
+
+    ResetArgs("-nofoo=1");
+    BOOST_CHECK(!GetBoolArg("-foo"));
+    BOOST_CHECK(!GetBoolArg("-foo", false));
+    BOOST_CHECK(!GetBoolArg("-foo", true));
+
+    ResetArgs("-foo -nofoo");  // -foo should win
+    BOOST_CHECK(GetBoolArg("-foo"));
+    BOOST_CHECK(GetBoolArg("-foo", false));
+    BOOST_CHECK(GetBoolArg("-foo", true));
+
+    ResetArgs("-foo=1 -nofoo=1");  // -foo should win
+    BOOST_CHECK(GetBoolArg("-foo"));
+    BOOST_CHECK(GetBoolArg("-foo", false));
+    BOOST_CHECK(GetBoolArg("-foo", true));
+
+    ResetArgs("-foo=0 -nofoo=0");  // -foo should win
+    BOOST_CHECK(!GetBoolArg("-foo"));
+    BOOST_CHECK(!GetBoolArg("-foo", false));
+    BOOST_CHECK(!GetBoolArg("-foo", true));
+
+    // New 0.6 feature: treat -- same as -:
+    ResetArgs("--foo=1");
+    BOOST_CHECK(GetBoolArg("-foo"));
+    BOOST_CHECK(GetBoolArg("-foo", false));
+    BOOST_CHECK(GetBoolArg("-foo", true));
+
+    ResetArgs("--nofoo=1");
+    BOOST_CHECK(!GetBoolArg("-foo"));
+    BOOST_CHECK(!GetBoolArg("-foo", false));
+    BOOST_CHECK(!GetBoolArg("-foo", true));
+
 }
 
 BOOST_AUTO_TEST_CASE(stringarg)
@@ -90,6 +128,40 @@ BOOST_AUTO_TEST_CASE(intarg)
     ResetArgs("-foo=NaN -bar=NotANumber");
     BOOST_CHECK_EQUAL(GetArg("-foo", 1), 0);
     BOOST_CHECK_EQUAL(GetArg("-bar", 11), 0);
+}
+
+BOOST_AUTO_TEST_CASE(doubledash)
+{
+    ResetArgs("--foo");
+    BOOST_CHECK_EQUAL(GetBoolArg("-foo"), true);
+
+    ResetArgs("--foo=verbose --bar=1");
+    BOOST_CHECK_EQUAL(GetArg("-foo", ""), "verbose");
+    BOOST_CHECK_EQUAL(GetArg("-bar", 0), 1);
+}
+
+BOOST_AUTO_TEST_CASE(boolargno)
+{
+    ResetArgs("-nofoo");
+    BOOST_CHECK(!GetBoolArg("-foo"));
+    BOOST_CHECK(!GetBoolArg("-foo", true));
+    BOOST_CHECK(!GetBoolArg("-foo", false));
+
+    ResetArgs("-nofoo=1");
+    BOOST_CHECK(!GetBoolArg("-foo"));
+    BOOST_CHECK(!GetBoolArg("-foo", true));
+    BOOST_CHECK(!GetBoolArg("-foo", false));
+
+    ResetArgs("-nofoo=0");
+    BOOST_CHECK(GetBoolArg("-foo"));
+    BOOST_CHECK(GetBoolArg("-foo", true));
+    BOOST_CHECK(GetBoolArg("-foo", false));
+
+    ResetArgs("-foo --nofoo");
+    BOOST_CHECK(GetBoolArg("-foo"));
+
+    ResetArgs("-nofoo -foo"); // foo always wins:
+    BOOST_CHECK(GetBoolArg("-foo"));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -454,7 +454,7 @@ vector<unsigned char> ParseHex(const string& str)
     return ParseHex(str.c_str());
 }
 
-void ParseParameters(int argc, char* argv[])
+void ParseParameters(int argc, const char*const argv[])
 {
     mapArgs.clear();
     mapMultiArgs.clear();
@@ -478,6 +478,31 @@ void ParseParameters(int argc, char* argv[])
         mapArgs[psz] = pszValue;
         mapMultiArgs[psz].push_back(pszValue);
     }
+}
+
+std::string GetArg(const std::string& strArg, const std::string& strDefault)
+{
+    if (mapArgs.count(strArg))
+        return mapArgs[strArg];
+    return strDefault;
+}
+
+int64 GetArg(const std::string& strArg, int64 nDefault)
+{
+    if (mapArgs.count(strArg))
+        return atoi64(mapArgs[strArg]);
+    return nDefault;
+}
+
+bool GetBoolArg(const std::string& strArg, bool fDefault)
+{
+    if (mapArgs.count(strArg))
+    {
+        if (mapArgs[strArg].empty())
+            return true;
+        return (atoi(mapArgs[strArg]) != 0);
+    }
+    return fDefault;
 }
 
 bool SoftSetArg(const std::string& strArg, const std::string& strValue)

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -475,8 +475,36 @@ void ParseParameters(int argc, const char*const argv[])
         #endif
         if (psz[0] != '-')
             break;
+
         mapArgs[psz] = pszValue;
         mapMultiArgs[psz].push_back(pszValue);
+    }
+
+    // New 0.6 features:
+    BOOST_FOREACH(const PAIRTYPE(string,string)& entry, mapArgs)
+    {
+        string name = entry.first;
+
+        //  interpret --foo as -foo (as long as both are not set)
+        if (name.find("--") == 0)
+        {
+            std::string singleDash(name.begin()+1, name.end());
+            if (mapArgs.count(singleDash) == 0)
+                mapArgs[singleDash] = entry.second;
+            name = singleDash;
+        }
+
+        //  interpret -nofoo as -foo=0 (and -nofoo=0 as -foo=1, as long as -foo not set)
+        if (name.find("-no") == 0)
+        {
+            std::string positive("-");
+            positive.append(name.begin()+3, name.end());
+            if (mapArgs.count(positive) == 0)
+            {
+                bool value = !GetBoolArg(name);
+                mapArgs[positive] = (value ? "1" : "0");
+            }
+        }
     }
 }
 

--- a/src/util.h
+++ b/src/util.h
@@ -143,7 +143,7 @@ std::vector<unsigned char> DecodeBase64(const char* p, bool* pfInvalid = NULL);
 std::string DecodeBase64(const std::string& str);
 std::string EncodeBase64(const unsigned char* pch, size_t len);
 std::string EncodeBase64(const std::string& str);
-void ParseParameters(int argc, char* argv[]);
+void ParseParameters(int argc, const char*const argv[]);
 bool WildcardMatch(const char* psz, const char* mask);
 bool WildcardMatch(const std::string& str, const std::string& mask);
 int GetFilesize(FILE* file);
@@ -401,30 +401,32 @@ inline bool IsSwitchChar(char c)
 #endif
 }
 
-inline std::string GetArg(const std::string& strArg, const std::string& strDefault)
-{
-    if (mapArgs.count(strArg))
-        return mapArgs[strArg];
-    return strDefault;
-}
+/**
+ * Return string argument or default value
+ *
+ * @param strArg Argument to get (e.g. "-foo")
+ * @param default (e.g. "1")
+ * @return command-line argument or default value
+ */
+std::string GetArg(const std::string& strArg, const std::string& strDefault);
 
-inline int64 GetArg(const std::string& strArg, int64 nDefault)
-{
-    if (mapArgs.count(strArg))
-        return atoi64(mapArgs[strArg]);
-    return nDefault;
-}
+/**
+ * Return integer argument or default value
+ *
+ * @param strArg Argument to get (e.g. "-foo")
+ * @param default (e.g. 1)
+ * @return command-line argument (0 if invalid number) or default value
+ */
+int64 GetArg(const std::string& strArg, int64 nDefault);
 
-inline bool GetBoolArg(const std::string& strArg, bool fDefault=false)
-{
-    if (mapArgs.count(strArg))
-    {
-        if (mapArgs[strArg].empty())
-            return true;
-        return (atoi(mapArgs[strArg]) != 0);
-    }
-    return fDefault;
-}
+/**
+ * Return boolean argument or default value
+ *
+ * @param strArg Argument to get (e.g. "-foo")
+ * @param default (true or false)
+ * @return command-line argument or default value
+ */
+bool GetBoolArg(const std::string& strArg, bool fDefault=false);
 
 /**
  * Set an argument if it doesn't already have a value


### PR DESCRIPTION
I decided I'd typed "./bitcoind --nolisten" enough times to make command-line parsing work the way I think it should.

Changes are:
- Unit tests for the GetArg() methods
- --foo=... is automatically interpreted as -foo=... (so you can use double-dashes if you like for all args)
- Boolean arguments can be specified as either -foo (true) or -nofoo (false).
- Internally, all boolean args are looked up using the positive form and default value (e.g. GetBoolArg("-dnsseed", true))
- Tweaked the --help text
- Default for -irc to bootstrap via IRC channel was changed from true to false
