### PR TITLE
-bip16=1/0 option to support / not support BIP 16.

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -474,18 +474,37 @@ bool AppInit2(int argc, char* argv[])
     bool fTor = (fUseProxy && addrProxy.GetPort() == 9050);
     if (fTor)
     {
-        // Use SoftSetArg here so user can override any of these if they wish.
+        // Use SoftSetBoolArg here so user can override any of these if they wish.
         // Note: the GetBoolArg() calls for all of these must happen later.
-        SoftSetArg("-nolisten", true);
-        SoftSetArg("-noirc", true);
-        SoftSetArg("-nodnsseed", true);
-        SoftSetArg("-noupnp", true);
-        SoftSetArg("-upnp", false);
-        SoftSetArg("-dns", false);
+        SoftSetBoolArg("-nolisten", true);
+        SoftSetBoolArg("-noirc", true);
+        SoftSetBoolArg("-nodnsseed", true);
+        SoftSetBoolArg("-noupnp", true);
+        SoftSetBoolArg("-upnp", false);
+        SoftSetBoolArg("-dns", false);
     }
 
     fAllowDNS = GetBoolArg("-dns");
     fNoListen = GetBoolArg("-nolisten");
+
+    // This code can be removed once a super-majority of the network has upgraded.
+    if (GetBoolArg("-bip16", true))
+    {
+        if (fTestNet)
+            SoftSetArg("-paytoscripthashtime", "1329264000"); // Feb 15
+        else
+            SoftSetArg("-paytoscripthashtime", "1330578000"); // Mar 1
+
+        // Put "/P2SH/" in the coinbase so everybody can tell when
+        // a majority of miners support it
+        const char* pszP2SH = "/P2SH/";
+        COINBASE_FLAGS << std::vector<unsigned char>(pszP2SH, pszP2SH+strlen(pszP2SH));
+    }
+    else
+    {
+        const char* pszP2SH = "NOP2SH";
+        COINBASE_FLAGS << std::vector<unsigned char>(pszP2SH, pszP2SH+strlen(pszP2SH));
+    }
 
     // Command-line args override in-wallet settings:
     if (mapArgs.count("-upnp"))

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -52,6 +52,8 @@ multimap<uint256, CBlock*> mapOrphanBlocksByPrev;
 map<uint256, CDataStream*> mapOrphanTransactions;
 multimap<uint256, CDataStream*> mapOrphanTransactionsByPrev;
 
+// Constant stuff for coinbase transactions we create:
+CScript COINBASE_FLAGS;
 
 const string strMessageMagic = "Bitcoin Signed Message:\n";
 
@@ -1213,8 +1215,9 @@ bool CBlock::ConnectBlock(CTxDB& txdb, CBlockIndex* pindex)
 
     // To avoid being on the short end of a block-chain split,
     // don't do secondary validation of pay-to-script-hash transactions
-    // until blocks with timestamps after paytoscripthashtime:
-    int64 nEvalSwitchTime = GetArg("-paytoscripthashtime", 1329264000); // Feb 15, 2012
+    // until blocks with timestamps after paytoscripthashtime (see init.cpp for default).
+    // This code can be removed once a super-majority of the network has upgraded.
+    int64 nEvalSwitchTime = GetArg("-paytoscripthashtime", std::numeric_limits<int64_t>::max());
     bool fStrictPayToScriptHash = (pindex->nTime >= nEvalSwitchTime);
 
     //// issue here: it doesn't know the version

--- a/src/main.h
+++ b/src/main.h
@@ -49,10 +49,7 @@ static const int fHaveUPnP = false;
 #endif
 
 
-// Put "/P2SH/" in the coinbase so everybody can tell when
-// a majority of miners support it
-static const char* pszP2SH = "/P2SH/";
-static const CScript COINBASE_FLAGS = CScript() << std::vector<unsigned char>(pszP2SH, pszP2SH+strlen(pszP2SH));
+extern CScript COINBASE_FLAGS;
 
 
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -488,7 +488,7 @@ bool SoftSetArg(const std::string& strArg, const std::string& strValue)
     return true;
 }
 
-bool SoftSetArg(const std::string& strArg, bool fValue)
+bool SoftSetBoolArg(const std::string& strArg, bool fValue)
 {
     if (fValue)
         return SoftSetArg(strArg, std::string("1"));

--- a/src/util.h
+++ b/src/util.h
@@ -442,7 +442,7 @@ bool SoftSetArg(const std::string& strArg, const std::string& strValue);
  * @param fValue Value (e.g. false)
  * @return true if argument gets set, false if it already had a value
  */
-bool SoftSetArg(const std::string& strArg, bool fValue);
+bool SoftSetBoolArg(const std::string& strArg, bool fValue);
 
 
 


### PR DESCRIPTION
This is a variation on pull #755

I made the option -bip16, defaults to 1 (true).

I also moved the logic for setting the switchover time into init.cpp, and set the current-anticpated-switchover-time to March 1 for main network (left it at Feb 15 for test network).

I also changed the SoftSetArg(...bool) method's name; during testing I was getting bitten by C++'s annoying habit of converting char\* to bool instead of string.
