### PR TITLE
Split dependencies into deps-gitian.yml

### DIFF
--- a/contrib/gitian-descriptors/deps-win32.yml
+++ b/contrib/gitian-descriptors/deps-win32.yml
@@ -1,0 +1,63 @@
+---
+name: "bitcoin-deps"
+suites:
+- "lucid"
+architectures:
+- "i386"
+packages: 
+- "mingw32"
+- "git-core"
+- "unzip"
+- "faketime"
+- "wine"
+reference_datetime: "2011-01-30 00:00:00"
+remotes: []
+files:
+- "openssl-1.0.0e.tar.gz"
+- "db-4.8.30.NC.tar.gz"
+- "miniupnpc-1.6.tar.gz"
+- "zlib-1.2.6.tar.gz"
+- "libpng-1.5.8.tar.gz"
+- "qrencode-3.2.0.tar.bz2"
+script: |
+  #
+  tar xzf openssl-1.0.0e.tar.gz
+  cd openssl-1.0.0e
+  ./Configure --cross-compile-prefix=i586-mingw32msvc- mingw
+  make
+  cd ..
+  #
+  tar xzf db-4.8.30.NC.tar.gz
+  cd db-4.8.30.NC/build_unix
+  ../dist/configure --enable-mingw --enable-cxx --host=i586-mingw32msvc CFLAGS="-I/usr/i586-mingw32msvc/include"
+  make $MAKEOPTS
+  cd ../..
+  #
+  tar xzf miniupnpc-1.6.tar.gz
+  cd miniupnpc-1.6
+  sed 's/dllwrap -k --driver-name gcc/$(DLLWRAP) -k --driver-name $(CC)/' -i Makefile.mingw
+  sed 's|wingenminiupnpcstrings $< $@|./wingenminiupnpcstrings $< $@|' -i Makefile.mingw
+  make -f Makefile.mingw DLLWRAP=i586-mingw32msvc-dllwrap CC=i586-mingw32msvc-gcc AR=i586-mingw32msvc-ar
+  cd ..
+  mv miniupnpc-1.6 miniupnpc
+  #
+  tar xzf zlib-1.2.6.tar.gz
+  cd zlib-1.2.6
+  make -f win32/Makefile.gcc PREFIX=i586-mingw32msvc- $MAKEOPTS
+  cd ..
+  #
+  tar xzf libpng-1.5.8.tar.gz
+  cd libpng-1.5.8
+  ./configure CC=i586-mingw32msvc-cc AR=i586-mingw32msvc-ar STRIP=i586-mingw32msvc-strip RANLIB=i586-mingw32msvc-ranlib OBJDUMP=i586-mingw32msvc-objdump LD=i586-mingw32msvc-ld LDFLAGS="-L../zlib-1.2.6/" CFLAGS="-I../zlib-1.2.6/"
+  make $MAKEOPTS
+  cd ..
+  #
+  tar xjf qrencode-3.2.0.tar.bz2
+  cd qrencode-3.2.0
+  ./configure CC=i586-mingw32msvc-cc AR=i586-mingw32msvc-ar STRIP=i586-mingw32msvc-strip RANLIB=i586-mingw32msvc-ranlib OBJDUMP=i586-mingw32msvc-objdump LD=i586-mingw32msvc-ld png_LIBS="../libpng-1.5.8/.libs/libpng15.a ../zlib-1.2.6/libz.a" png_CFLAGS="-I../libpng-1.5.8"
+  make $MAKEOPTS
+  cd ..
+  #
+  tar cjvpf "$OUTDIR/bitcoin-deps-0.0.1.tbz2" "$HOME/build"
+
+

--- a/contrib/gitian-descriptors/gitian-win32.yml
+++ b/contrib/gitian-descriptors/gitian-win32.yml
@@ -10,7 +10,6 @@ packages:
 - "unzip"
 - "nsis"
 - "faketime"
-- "wine"
 reference_datetime: "2011-01-30 00:00:00"
 remotes:
 - "url": "https://github.com/bitcoin/bitcoin.git"
@@ -18,12 +17,7 @@ remotes:
 files:
 - "qt-win32-4.7.4-gitian.zip"
 - "boost-win32-1.47.0-gitian.zip"
-- "openssl-1.0.0e.tar.gz"
-- "db-4.8.30.NC.tar.gz"
-- "miniupnpc-1.6.tar.gz"
-- "zlib-1.2.6.tar.gz"
-- "libpng-1.5.8.tar.gz"
-- "qrencode-3.2.0.tar.bz2"
+- "bitcoin-deps-0.0.1.tbz2"
 script: |
   #
   mkdir $HOME/qt
@@ -45,42 +39,9 @@ script: |
   mv include/boost .
   cd ..
   #
-  tar xzf openssl-1.0.0e.tar.gz
-  cd openssl-1.0.0e
-  ./Configure --cross-compile-prefix=i586-mingw32msvc- mingw
-  make
-  cd ..
+  tar -C / -xjvpf bitcoin-deps-0.0.1.tbz2
   #
-  tar xzf db-4.8.30.NC.tar.gz
-  cd db-4.8.30.NC/build_unix
-  ../dist/configure --enable-mingw --enable-cxx --host=i586-mingw32msvc CFLAGS="-I/usr/i586-mingw32msvc/include"
-  make $MAKEOPTS
-  cd ../..
-  #
-  tar xzf miniupnpc-1.6.tar.gz
-  cd miniupnpc-1.6
-  sed 's/dllwrap -k --driver-name gcc/$(DLLWRAP) -k --driver-name $(CC)/' -i Makefile.mingw
-  sed 's|wingenminiupnpcstrings $< $@|./wingenminiupnpcstrings $< $@|' -i Makefile.mingw
-  make -f Makefile.mingw DLLWRAP=i586-mingw32msvc-dllwrap CC=i586-mingw32msvc-gcc AR=i586-mingw32msvc-ar
-  cd ..
-  mv miniupnpc-1.6 miniupnpc
-  #
-  tar xzf zlib-1.2.6.tar.gz
-  cd zlib-1.2.6
-  make -f win32/Makefile.gcc PREFIX=i586-mingw32msvc- $MAKEOPTS
-  cd ..
-  #
-  tar xzf libpng-1.5.8.tar.gz
-  cd libpng-1.5.8
-  ./configure CC=i586-mingw32msvc-cc AR=i586-mingw32msvc-ar STRIP=i586-mingw32msvc-strip RANLIB=i586-mingw32msvc-ranlib OBJDUMP=i586-mingw32msvc-objdump LD=i586-mingw32msvc-ld LDFLAGS="-L../zlib-1.2.6/" CFLAGS="-I../zlib-1.2.6/"
-  make $MAKEOPTS
-  cd ..
-  #
-  tar xjf qrencode-3.2.0.tar.bz2
-  cd qrencode-3.2.0
-  ./configure CC=i586-mingw32msvc-cc AR=i586-mingw32msvc-ar STRIP=i586-mingw32msvc-strip RANLIB=i586-mingw32msvc-ranlib OBJDUMP=i586-mingw32msvc-objdump LD=i586-mingw32msvc-ld png_LIBS="../libpng-1.5.8/.libs/libpng15.a ../zlib-1.2.6/libz.a" png_CFLAGS="-I../libpng-1.5.8"
-  make $MAKEOPTS
-  cd ..
+  find -type f | xargs touch --date="$REFERENCE_DATETIME"
   #
   cd bitcoin
   mkdir -p $OUTDIR/src

--- a/contrib/gitian-descriptors/gitian-win32.yml
+++ b/contrib/gitian-descriptors/gitian-win32.yml
@@ -21,8 +21,8 @@ files:
 - "openssl-1.0.0e.tar.gz"
 - "db-4.8.30.NC.tar.gz"
 - "miniupnpc-1.6.tar.gz"
-- "zlib-1.2.5.tar.gz"
-- "libpng-1.5.7.tar.gz"
+- "zlib-1.2.6.tar.gz"
+- "libpng-1.5.8.tar.gz"
 - "qrencode-3.2.0.tar.bz2"
 script: |
   #
@@ -65,20 +65,20 @@ script: |
   cd ..
   mv miniupnpc-1.6 miniupnpc
   #
-  tar xzf zlib-1.2.5.tar.gz
-  cd zlib-1.2.5
+  tar xzf zlib-1.2.6.tar.gz
+  cd zlib-1.2.6
   make -f win32/Makefile.gcc PREFIX=i586-mingw32msvc- $MAKEOPTS
   cd ..
   #
-  tar xzf libpng-1.5.7.tar.gz
-  cd libpng-1.5.7
-  ./configure CC=i586-mingw32msvc-cc AR=i586-mingw32msvc-ar STRIP=i586-mingw32msvc-strip RANLIB=i586-mingw32msvc-ranlib OBJDUMP=i586-mingw32msvc-objdump LD=i586-mingw32msvc-ld LDFLAGS="-L../zlib-1.2.5/" CFLAGS="-I../zlib-1.2.5/"
+  tar xzf libpng-1.5.8.tar.gz
+  cd libpng-1.5.8
+  ./configure CC=i586-mingw32msvc-cc AR=i586-mingw32msvc-ar STRIP=i586-mingw32msvc-strip RANLIB=i586-mingw32msvc-ranlib OBJDUMP=i586-mingw32msvc-objdump LD=i586-mingw32msvc-ld LDFLAGS="-L../zlib-1.2.6/" CFLAGS="-I../zlib-1.2.6/"
   make $MAKEOPTS
   cd ..
   #
   tar xjf qrencode-3.2.0.tar.bz2
   cd qrencode-3.2.0
-  ./configure CC=i586-mingw32msvc-cc AR=i586-mingw32msvc-ar STRIP=i586-mingw32msvc-strip RANLIB=i586-mingw32msvc-ranlib OBJDUMP=i586-mingw32msvc-objdump LD=i586-mingw32msvc-ld png_LIBS="../libpng-1.5.7/.libs/libpng15.a ../zlib-1.2.5/libz.a" png_CFLAGS="-I../libpng-1.5.7"
+  ./configure CC=i586-mingw32msvc-cc AR=i586-mingw32msvc-ar STRIP=i586-mingw32msvc-strip RANLIB=i586-mingw32msvc-ranlib OBJDUMP=i586-mingw32msvc-objdump LD=i586-mingw32msvc-ld png_LIBS="../libpng-1.5.8/.libs/libpng15.a ../zlib-1.2.6/libz.a" png_CFLAGS="-I../libpng-1.5.8"
   make $MAKEOPTS
   cd ..
   #

--- a/doc/release-process.txt
+++ b/doc/release-process.txt
@@ -26,6 +26,9 @@
    wget 'http://miniupnp.free.fr/files/download.php?file=miniupnpc-1.6.tar.gz' -O miniupnpc-1.6.tar.gz
    wget 'http://www.openssl.org/source/openssl-1.0.0e.tar.gz'
    wget 'http://download.oracle.com/berkeley-db/db-4.8.30.NC.tar.gz'
+   wget 'http://zlib.net/zlib-1.2.6.tar.gz'
+   wget 'ftp://ftp.simplesystems.org/pub/libpng/png/src/libpng-1.5.8.tar.gz'
+   wget 'http://fukuchi.org/works/qrencode/qrencode-3.2.0.tar.bz2'
    wget 'http://downloads.sourceforge.net/project/boost/boost/1.47.0/boost_1_47_0.tar.bz2'
    wget 'http://download.qt.nokia.com/qt/source/qt-everywhere-opensource-src-4.7.4.tar.gz'
    cd ..
@@ -33,6 +36,8 @@
    cp build/out/boost-win32-1.47.0-gitian.zip inputs/
    ./bin/gbuild ../bitcoin/contrib/gitian-descriptors/qt-win32.yml
    cp build/out/qt-win32-4.7.4-gitian.zip inputs/
+   ./bin/gbuild ../bitcoin/contrib/gitian-descriptors/deps-win32.yml
+   cp build/out/bitcoin-deps-0.0.1.tbz2 inputs/
 
   * Build bitcoind and bitcoin-qt on Linux32, Linux64, and Win32:
    ./bin/gbuild --commit bitcoin=v${VERSION} ../bitcoin/contrib/gitian-descriptors/gitian.yml


### PR DESCRIPTION
This allows for rebuilding Bitcoin without compiling the deps every time. Also includes fix for #802 (libpng security vuln)
