### PR TITLE
Make bitcoin-deps (gitian/win32) deterministic, and only include files we actually use

### DIFF
--- a/contrib/gitian-descriptors/deps-win32.yml
+++ b/contrib/gitian-descriptors/deps-win32.yml
@@ -58,6 +58,8 @@ script: |
   make $MAKEOPTS
   cd ..
   #
-  tar cjvpf "$OUTDIR/bitcoin-deps-0.0.1.tbz2" "$HOME/build"
-
-
+  tar --mtime "$REFERENCE_DATETIME" -cjvpf "$OUTDIR/bitcoin-deps-0.0.2.tbz2" \
+    qrencode-*/{qrencode.h,.libs/libqrencode.{,l}a} \
+    db-*/build_unix/{libdb_cxx.a,db.h,db_cxx.h,libdb.a,.libs/libdb_cxx-?.?.a} \
+    $(find openssl-* -name '*.a' -o -name '*.h') \
+    miniupnpc

--- a/contrib/gitian-descriptors/gitian-win32.yml
+++ b/contrib/gitian-descriptors/gitian-win32.yml
@@ -17,7 +17,7 @@ remotes:
 files:
 - "qt-win32-4.7.4-gitian.zip"
 - "boost-win32-1.47.0-gitian.zip"
-- "bitcoin-deps-0.0.1.tbz2"
+- "bitcoin-deps-0.0.2.tbz2"
 script: |
   #
   mkdir $HOME/qt
@@ -39,7 +39,7 @@ script: |
   mv include/boost .
   cd ..
   #
-  tar -C / -xjvpf bitcoin-deps-0.0.1.tbz2
+  tar -xjvpf bitcoin-deps-0.0.2.tbz2
   #
   find -type f | xargs touch --date="$REFERENCE_DATETIME"
   #


### PR DESCRIPTION
Can someone confirm the determinism?

ab069992eaf3bde0e6580e00b19935c91438f57b657160b93643152511421cd2  gitian-inputs/bitcoin-deps-0.0.2.tbz2
