### PR TITLE
Ignore checksum on 'version' messages.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2652,7 +2652,7 @@ bool ProcessMessages(CNode* pfrom)
             uint256 hash = Hash(vRecv.begin(), vRecv.begin() + nMessageSize);
             unsigned int nChecksum = 0;
             memcpy(&nChecksum, &hash, sizeof(nChecksum));
-            if (nChecksum != hdr.nChecksum)
+            if (strCommand != "version" && nChecksum != hdr.nChecksum)
             {
                 printf("ProcessMessage(%s, %u bytes) : CHECKSUM ERROR nChecksum=%08x hdr.nChecksum=%08x\n",
                        strCommand.c_str(), nMessageSize, nChecksum, hdr.nChecksum);


### PR DESCRIPTION
Februari 15th, the protocol changes and 'version' and 'verack' messages
get a checksum. However, some NAT routers change the IP address inside
packet's payloads, causing the version message's checksum to become invalid.

This commit disables the checksum check, so clients behind such routers can
continue to connect after februari 15th.
