### PR TITLE
Enable accessible widgets Qt module on win32

### DIFF
--- a/bitcoin-qt.pro
+++ b/bitcoin-qt.pro
@@ -76,7 +76,7 @@ contains(FIRST_CLASS_MESSAGING, 1) {
 
 contains(BITCOIN_NEED_QT_PLUGINS, 1) {
     DEFINES += BITCOIN_NEED_QT_PLUGINS
-    QTPLUGIN += qcncodecs qjpcodecs qtwcodecs qkrcodecs
+    QTPLUGIN += qcncodecs qjpcodecs qtwcodecs qkrcodecs qtaccessiblewidgets
 }
 
 !windows {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -21,6 +21,7 @@ Q_IMPORT_PLUGIN(qcncodecs)
 Q_IMPORT_PLUGIN(qjpcodecs)
 Q_IMPORT_PLUGIN(qtwcodecs)
 Q_IMPORT_PLUGIN(qkrcodecs)
+Q_IMPORT_PLUGIN(qtaccessiblewidgets)
 #endif
 
 using namespace std;


### PR DESCRIPTION
Enable accessible widgets Qt module on win32 (when static linking), so that people with screen readers such as NVDA can make sense of it.
