### PR TITLE
Prevent double connections

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2111,6 +2111,22 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
             return true;
         }
 
+        // Disconnect if we connected again to an already-connected peer
+        bool fAlreadyConnected = false;
+        CRITICAL_BLOCK(cs_vNodes)
+            BOOST_FOREACH(CNode* pnode, vNodes)
+                if (pfrom != pnode && nNonce > 1 && pnode->nNonce > 1 && pnode->nNonce == nNonce)
+                    fAlreadyConnected = true;
+        if (fAlreadyConnected)
+        {
+            printf("already connected to %s, disconnecting\n", pfrom->addr.ToString().c_str());
+            pfrom->fDisconnect = true;
+            return true;
+        }
+
+        pfrom->nNonce = nNonce;
+
+
         // Be shy and don't send version until we hear
         if (pfrom->fInbound)
             pfrom->PushVersion();

--- a/src/net.h
+++ b/src/net.h
@@ -132,6 +132,7 @@ public:
     uint256 hashContinue;
     CBlockIndex* pindexLastGetBlocksBegin;
     uint256 hashLastGetBlocksEnd;
+    uint64 nNonce;
     int nStartingHeight;
 
     // flood relay
@@ -186,6 +187,7 @@ public:
         fGetAddr = false;
         vfSubscribe.assign(256, false);
         nMisbehavior = 0;
+        nNonce = 0;
 
         // Be shy and don't send version until we hear
         if (!fInbound)


### PR DESCRIPTION
In preparation of IPv6 support: prevent double connections to the same node.

Not urgent.
