### PR TITLE
Fix Minimize to the tray instead of the taskbar (rework)

### DIFF
--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -58,6 +58,8 @@ private:
 
     QStackedWidget *centralWidget;
 
+    QWidget *dummyWidget;
+
     OverviewPage *overviewPage;
     QWidget *transactionsPage;
     AddressBookPage *addressBookPage;
@@ -130,6 +132,8 @@ public slots:
 
     void gotoMessagePage();
     void gotoMessagePage(QString);
+
+    void showNormal();
 
 private slots:
     /** Switch to overview (home) page */


### PR DESCRIPTION
I've reworked #795:
- Now works in unity (on Ubuntu Ocelot)
- The other tray menu options also re-show the window in the correct way
- Delete dummy widget in destructor
- Commit message fixed
