### PR TITLE
Fix wallet encryption with compressed pubkeys

### DIFF
--- a/src/keystore.cpp
+++ b/src/keystore.cpp
@@ -192,7 +192,7 @@ bool CCryptoKeyStore::EncryptKeys(CKeyingMaterial& vMasterKeyIn)
         BOOST_FOREACH(KeyMap::value_type& mKey, mapKeys)
         {
             CKey key;
-            if (!key.SetSecret(mKey.second.first, false))
+            if (!key.SetSecret(mKey.second.first, mKey.second.second))
                 return false;
             const std::vector<unsigned char> vchPubKey = key.GetPubKey();
             std::vector<unsigned char> vchCryptedSecret;


### PR DESCRIPTION
This is broken in 0.6.0rc1: encrypting a wallet with compressed pubkeys in it will fail after reloading.
