### PR TITLE
Support for multiple local addresses

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -182,6 +182,7 @@ bool AppInit2(int argc, char* argv[])
             "  -maxconnections=<n>\t  " + _("Maintain at most <n> connections to peers (default: 125)") + "\n" +
             "  -addnode=<ip>    \t  "   + _("Add a node to connect to and attempt to keep the connection open") + "\n" +
             "  -connect=<ip>    \t\t  " + _("Connect only to the specified node") + "\n" +
+            "  -externalip=<ip> \t  "   + _("Specify your own public address") + "\n" +
             "  -irc             \t  "   + _("Find peers using internet relay chat (default: 0)") + "\n" +
             "  -listen          \t  "   + _("Accept connections from outside (default: 1)") + "\n" +
 #ifdef QT_GUI
@@ -532,6 +533,12 @@ bool AppInit2(int argc, char* argv[])
             ThreadSafeMessageBox(strError, _("Bitcoin"), wxOK | wxMODAL);
             return false;
         }
+    }
+
+    if (mapArgs.count("-externalip"))
+    {
+        BOOST_FOREACH(string strAddr, mapMultiArgs["-externalip"])
+            AddLocal(CNetAddr(strAddr, fAllowDNS), LOCAL_MANUAL);
     }
 
     if (mapArgs.count("-addnode"))

--- a/src/irc.cpp
+++ b/src/irc.cpp
@@ -12,7 +12,6 @@ using namespace std;
 using namespace boost;
 
 int nGotIRCAddresses = 0;
-bool fGotExternalIP = false;
 
 void ThreadIRCSeed2(void* parg);
 
@@ -248,9 +247,10 @@ void ThreadIRCSeed2(void* parg)
                 return;
         }
 
+        CNetAddr addrLocal;
         string strMyName;
-        if (addrLocalHost.IsRoutable() && !fUseProxy && !fNameInUse)
-            strMyName = EncodeAddress(addrLocalHost);
+        if (GetLocal(addrLocal, &addrConnect))
+            strMyName = EncodeAddress(GetLocalAddress(&addrConnect));
         else
             strMyName = strprintf("x%u", GetRand(1000000000));
 
@@ -285,9 +285,8 @@ void ThreadIRCSeed2(void* parg)
             if (!fUseProxy && addrFromIRC.IsRoutable())
             {
                 // IRC lets you to re-nick
-                fGotExternalIP = true;
-                addrLocalHost.SetIP(addrFromIRC);
-                strMyName = EncodeAddress(addrLocalHost);
+                AddLocal(addrFromIRC, LOCAL_IRC);
+                strMyName = EncodeAddress(GetLocalAddress(&addrConnect));
                 Send(hSocket, strprintf("NICK %s\r", strMyName.c_str()).c_str());
             }
         }

--- a/src/irc.h
+++ b/src/irc.h
@@ -8,6 +8,5 @@
 void ThreadIRCSeed(void* parg);
 
 extern int nGotIRCAddresses;
-extern bool fGotExternalIP;
 
 #endif

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -46,7 +46,8 @@ bool fClient = false;
 bool fAllowDNS = false;
 static bool fUseUPnP = false;
 uint64 nLocalServices = (fClient ? 0 : NODE_NETWORK);
-CAddress addrLocalHost(CService("0.0.0.0", 0), nLocalServices);
+CCriticalSection cs_mapLocalHost;
+map<CNetAddr, int> mapLocalHost;
 static CNode* pnodeLocalHost = NULL;
 uint64 nLocalHostNonce = 0;
 array<int, THREAD_MAX> vnThreadsRunning;
@@ -85,7 +86,45 @@ void CNode::PushGetBlocks(CBlockIndex* pindexBegin, uint256 hashEnd)
     PushMessage("getblocks", CBlockLocator(pindexBegin), hashEnd);
 }
 
+// find 'best' local address for a particular peer
+bool GetLocal(CNetAddr& addr, const CNetAddr *paddrPeer)
+{
+    if (fUseProxy || mapArgs.count("-connect") || fNoListen)
+        return false;
 
+    int nBestCount = -1;
+    int nBestReachability = -1;
+    {
+        LOCK(cs_mapLocalHost);
+        for (map<CNetAddr, int>::iterator it = mapLocalHost.begin(); it != mapLocalHost.end(); it++)
+        {
+            int nCount = (*it).second;
+            int nReachability = (*it).first.GetReachabilityFrom(paddrPeer);
+            if (nReachability > nBestReachability || (nReachability == nBestReachability && nCount > nBestCount))
+            {
+                addr = (*it).first;
+                nBestReachability = nReachability;
+                nBestCount = nCount;
+            }
+        }
+    }
+    return nBestCount >= 0;
+}
+
+// get best local address for a particular peer as a CAddress
+CAddress GetLocalAddress(const CNetAddr *paddrPeer)
+{
+    CAddress ret(CService("0.0.0.0",0),0);
+    CNetAddr addr;
+    if (GetLocal(addr, paddrPeer))
+    {
+        ret.SetIP(addr);
+        ret.SetPort(GetListenPort());
+        ret.nServices = nLocalServices;
+        ret.nTime = GetAdjustedTime();
+    }
+    return ret;
+}
 
 bool RecvLine(SOCKET hSocket, string& strLine)
 {
@@ -138,6 +177,64 @@ bool RecvLine(SOCKET hSocket, string& strLine)
     }
 }
 
+// used when scores of local addresses may have changed
+// pushes better local address to peers
+void static AdvertizeLocal()
+{
+    LOCK(cs_vNodes);
+    BOOST_FOREACH(CNode* pnode, vNodes)
+    {
+        if (pnode->fSuccessfullyConnected)
+        {
+            CAddress addrLocal = GetLocalAddress(&pnode->addr);
+            if (addrLocal.IsRoutable() && (CNetAddr)addrLocal != (CNetAddr)pnode->addrLocal)
+            {
+                pnode->PushAddress(addrLocal);
+                pnode->addrLocal = addrLocal;
+            }
+        }
+    }
+}
+
+// learn a new local address
+bool AddLocal(const CNetAddr& addr, int nScore)
+{
+    if (!addr.IsRoutable())
+        return false;
+
+    printf("AddLocal(%s,%i)\n", addr.ToString().c_str(), nScore);
+
+    {
+        LOCK(cs_mapLocalHost);
+        mapLocalHost[addr] = std::max(nScore, mapLocalHost[addr]) + (mapLocalHost.count(addr) ? 1 : 0);
+    }
+
+    AdvertizeLocal();
+
+    return true;
+}
+
+// vote for a local address
+bool SeenLocal(const CNetAddr& addr)
+{
+    {
+        LOCK(cs_mapLocalHost);
+        if (mapLocalHost.count(addr) == 0)
+            return false;
+        mapLocalHost[addr]++;
+    }
+
+    AdvertizeLocal();
+
+    return true;
+}
+
+// check whether a given address is potentially local
+bool IsLocal(const CNetAddr& addr)
+{
+    LOCK(cs_mapLocalHost);
+    return mapLocalHost.count(addr) > 0;
+}
 
 
 bool GetMyExternalIP2(const CService& addrConnect, const char* pszGet, const char* pszKeyword, CNetAddr& ipRet)
@@ -251,33 +348,11 @@ bool GetMyExternalIP(CNetAddr& ipRet)
 
 void ThreadGetMyExternalIP(void* parg)
 {
-    // Wait for IRC to get it first
-    if (GetBoolArg("-irc", false))
-    {
-        for (int i = 0; i < 2 * 60; i++)
-        {
-            Sleep(1000);
-            if (fGotExternalIP || fShutdown)
-                return;
-        }
-    }
-
-    // Fallback in case IRC fails to get it
+    CNetAddr addrLocalHost;
     if (GetMyExternalIP(addrLocalHost))
     {
         printf("GetMyExternalIP() returned %s\n", addrLocalHost.ToStringIP().c_str());
-        if (addrLocalHost.IsRoutable())
-        {
-            // If we already connected to a few before we had our IP, go back and addr them.
-            // setAddrKnown automatically filters any duplicate sends.
-            CAddress addr(addrLocalHost);
-            addr.nTime = GetAdjustedTime();
-            {
-                LOCK(cs_vNodes);
-                BOOST_FOREACH(CNode* pnode, vNodes)
-                    pnode->PushAddress(addr);
-            }
-        }
+        AddLocal(addrLocalHost, LOCAL_HTTP);
     }
 }
 
@@ -320,7 +395,7 @@ CNode* FindNode(const CService& addr)
 
 CNode* ConnectNode(CAddress addrConnect, int64 nTimeout)
 {
-    if ((CNetAddr)addrConnect == (CNetAddr)addrLocalHost)
+    if (IsLocal(addrConnect))
         return NULL;
 
     // Look for an existing connection
@@ -406,7 +481,7 @@ void CNode::PushVersion()
     /// when NTP implemented, change to just nTime = GetAdjustedTime()
     int64 nTime = (fInbound ? GetAdjustedTime() : GetTime());
     CAddress addrYou = (fUseProxy ? CAddress(CService("0.0.0.0",0)) : addr);
-    CAddress addrMe = (fUseProxy || !addrLocalHost.IsRoutable() ? CAddress(CService("0.0.0.0",0)) : addrLocalHost);
+    CAddress addrMe = GetLocalAddress(&addr);
     RAND_bytes((unsigned char*)&nLocalHostNonce, sizeof(nLocalHostNonce));
     PushMessage("version", PROTOCOL_VERSION, nLocalServices, nTime, addrYou, addrMe,
                 nLocalHostNonce, FormatSubVersion(CLIENT_NAME, CLIENT_VERSION, std::vector<string>()), nBestHeight);
@@ -878,24 +953,19 @@ void ThreadMapPort2(void* parg)
     r = UPNP_GetValidIGD(devlist, &urls, &data, lanaddr, sizeof(lanaddr));
     if (r == 1)
     {
-        if (!addrLocalHost.IsRoutable())
+        char externalIPAddress[40];
+        r = UPNP_GetExternalIPAddress(urls.controlURL, data.first.servicetype, externalIPAddress);
+        if(r != UPNPCOMMAND_SUCCESS)
+            printf("UPnP: GetExternalIPAddress() returned %d\n", r);
+        else
         {
-            char externalIPAddress[40];
-            r = UPNP_GetExternalIPAddress(urls.controlURL, data.first.servicetype, externalIPAddress);
-            if(r != UPNPCOMMAND_SUCCESS)
-                printf("UPnP: GetExternalIPAddress() returned %d\n", r);
-            else
+            if(externalIPAddress[0])
             {
-                if(externalIPAddress[0])
-                {
-                    printf("UPnP: ExternalIPAddress = %s\n", externalIPAddress);
-                    CAddress addrExternalFromUPnP(CService(externalIPAddress, 0), nLocalServices);
-                    if (addrExternalFromUPnP.IsRoutable())
-                        addrLocalHost = addrExternalFromUPnP;
-                }
-                else
-                    printf("UPnP: GetExternalIPAddress failed.\n");
+                printf("UPnP: ExternalIPAddress = %s\n", externalIPAddress);
+                AddLocal(CNetAddr(externalIPAddress), LOCAL_UPNP);
             }
+            else
+                printf("UPnP: GetExternalIPAddress failed.\n");
         }
 
         string strDesc = "Bitcoin " + FormatFullVersion();
@@ -1280,7 +1350,7 @@ void ThreadOpenConnections2(void* parg)
             CAddress addr = addrman.Select(10 + min(nOutbound,8)*10);
 
             // if we selected an invalid address, restart
-            if (!addr.IsIPv4() || !addr.IsValid() || setConnected.count(addr.GetGroup()) || addr == addrLocalHost)
+            if (!addr.IsIPv4() || !addr.IsValid() || setConnected.count(addr.GetGroup()) || IsLocal(addr))
                 break;
 
             nTries++;
@@ -1383,7 +1453,7 @@ bool OpenNetworkConnection(const CAddress& addrConnect)
     //
     if (fShutdown)
         return false;
-    if ((CNetAddr)addrConnect == (CNetAddr)addrLocalHost || !addrConnect.IsIPv4() ||
+    if (IsLocal(addrConnect) || !addrConnect.IsIPv4() ||
         FindNode((CNetAddr)addrConnect) || CNode::IsBanned(addrConnect))
         return false;
 
@@ -1492,7 +1562,6 @@ bool BindListenPort(string& strError)
 {
     strError = "";
     int nOne = 1;
-    addrLocalHost.SetPort(GetListenPort());
 
 #ifdef WIN32
     // Initialize Windows Sockets
@@ -1589,11 +1658,7 @@ void StartNode(void* parg)
         vector<CNetAddr> vaddr;
         if (LookupHost(pszHostName, vaddr))
             BOOST_FOREACH (const CNetAddr &addr, vaddr)
-                if (!addr.IsLocal())
-                {
-                    addrLocalHost.SetIP(addr);
-                    break;
-                }
+               AddLocal(addr, LOCAL_IF);
     }
 #else
     // Get local host ip
@@ -1614,32 +1679,26 @@ void StartNode(void* parg)
                     printf("ipv4 %s: %s\n", ifa->ifa_name, pszIP);
 
                 // Take the first IP that isn't loopback 127.x.x.x
-                CAddress addr(CService(s4->sin_addr, GetListenPort()), nLocalServices);
-                if (addr.IsValid() && !addr.IsLocal())
-                {
-                    addrLocalHost = addr;
-                    break;
-                }
+                CNetAddr addr(s4->sin_addr);
+                AddLocal(addr, LOCAL_IF);
             }
             else if (ifa->ifa_addr->sa_family == AF_INET6)
             {
                 struct sockaddr_in6* s6 = (struct sockaddr_in6*)(ifa->ifa_addr);
                 if (inet_ntop(ifa->ifa_addr->sa_family, (void*)&(s6->sin6_addr), pszIP, sizeof(pszIP)) != NULL)
                     printf("ipv6 %s: %s\n", ifa->ifa_name, pszIP);
+
+#ifdef USE_IPV6
+                CNetAddr addr(s6->sin6_addr);
+                AddLocal(addr, LOCAL_IF);
+#endif
             }
         }
         freeifaddrs(myaddrs);
     }
 #endif
-    printf("addrLocalHost = %s\n", addrLocalHost.ToString().c_str());
 
-    if (fUseProxy || mapArgs.count("-connect") || fNoListen)
-    {
-        // Proxies can't take incoming connections
-        addrLocalHost.SetIP(CNetAddr("0.0.0.0"));
-        printf("addrLocalHost = %s\n", addrLocalHost.ToString().c_str());
-    }
-    else
+    if (!fUseProxy && !mapArgs.count("-connect") && !fNoListen)
     {
         CreateThread(ThreadGetMyExternalIP, NULL);
     }

--- a/src/net.h
+++ b/src/net.h
@@ -48,6 +48,9 @@ enum
     LOCAL_UPNP,
     LOCAL_IRC,
     LOCAL_HTTP,
+    LOCAL_MANUAL,
+
+    LOCAL_MAX
 };
 
 bool AddLocal(const CNetAddr& addr, int nScore = LOCAL_NONE);

--- a/src/net.h
+++ b/src/net.h
@@ -43,6 +43,21 @@ bool StopNode();
 
 enum
 {
+    LOCAL_NONE,
+    LOCAL_IF,
+    LOCAL_UPNP,
+    LOCAL_IRC,
+    LOCAL_HTTP,
+};
+
+bool AddLocal(const CNetAddr& addr, int nScore = LOCAL_NONE);
+bool SeenLocal(const CNetAddr& addr);
+bool IsLocal(const CNetAddr& addr);
+bool GetLocal(CNetAddr &addr, const CNetAddr *paddrPeer = NULL);
+CAddress GetLocalAddress(const CNetAddr *paddrPeer = NULL);
+
+enum
+{
     MSG_TX = 1,
     MSG_BLOCK,
 };
@@ -85,7 +100,6 @@ enum threadId
 extern bool fClient;
 extern bool fAllowDNS;
 extern uint64 nLocalServices;
-extern CAddress addrLocalHost;
 extern uint64 nLocalHostNonce;
 extern boost::array<int, THREAD_MAX> vnThreadsRunning;
 extern CAddrMan addrman;
@@ -120,6 +134,7 @@ public:
     unsigned int nHeaderStart;
     unsigned int nMessageStart;
     CAddress addr;
+    CNetAddr addrLocal;
     int nVersion;
     std::string strSubVer;
     bool fClient;

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -590,6 +590,29 @@ void CNetAddr::print() const
     printf("CNetAddr(%s)\n", ToString().c_str());
 }
 
+// for IPv6 partners:        for unknown/Teredo partners:      for IPv4 partners:
+// 0 - unroutable            // 0 - unroutable                 // 0 - unroutable
+// 1 - teredo                // 1 - teredo                     // 1 - ipv4
+// 2 - tunneled ipv6         // 2 - tunneled ipv6
+// 3 - ipv4                  // 3 - ipv6
+// 4 - ipv6                  // 4 - ipv4
+int CNetAddr::GetReachabilityFrom(const CNetAddr *paddrPartner) const
+{
+    if (!IsValid() || !IsRoutable())
+        return 0;
+    if (paddrPartner && paddrPartner->IsIPv4())
+        return IsIPv4() ? 1 : 0;
+    if (IsRFC4380())
+        return 1;
+    if (IsRFC3964() || IsRFC6052())
+        return 2;
+    bool fRealIPv6 = paddrPartner && !paddrPartner->IsRFC4380() && paddrPartner->IsValid() && paddrPartner->IsRoutable();
+    if (fRealIPv6)
+        return IsIPv4() ? 3 : 4;
+    else
+        return IsIPv4() ? 4 : 3;
+}
+
 void CService::Init()
 {
     port = 0;

--- a/src/netbase.h
+++ b/src/netbase.h
@@ -72,6 +72,7 @@ class CNetAddr
         int64 GetHash() const;
         bool GetInAddr(struct in_addr* pipv4Addr) const;
         std::vector<unsigned char> GetGroup() const;
+        int GetReachabilityFrom(const CNetAddr *paddrPartner = NULL) const;
         void print() const;
 
 #ifdef USE_IPV6


### PR DESCRIPTION
In preparation of IPv6 support: keep a map of potential local addresses instead of a single addrLocalHost, and use addrMe in incoming "version" messages to vote for them.
