### PR TITLE
Fix default suffixes in save dialog in GNOME

### DIFF
--- a/src/qt/addressbookpage.cpp
+++ b/src/qt/addressbookpage.cpp
@@ -9,7 +9,6 @@
 
 #include <QSortFilterProxyModel>
 #include <QClipboard>
-#include <QFileDialog>
 #include <QMessageBox>
 #include <QMenu>
 
@@ -277,10 +276,9 @@ void AddressBookPage::done(int retval)
 void AddressBookPage::exportClicked()
 {
     // CSV is currently the only supported format
-    QString filename = QFileDialog::getSaveFileName(
+    QString filename = GUIUtil::getSaveFileName(
             this,
-            tr("Export Address Book Data"),
-            QDir::currentPath(),
+            tr("Export Address Book Data"), QString(),
             tr("Comma separated file (*.csv)"));
 
     if (filename.isNull()) return;

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -15,6 +15,8 @@
 #include <QAbstractItemView>
 #include <QApplication>
 #include <QClipboard>
+#include <QFileDialog>
+#include <QDesktopServices>
 
 QString GUIUtil::dateTimeStr(qint64 nTime)
 {
@@ -121,3 +123,50 @@ void GUIUtil::copyEntryData(QAbstractItemView *view, int column, int role)
         QApplication::clipboard()->setText(selection.at(0).data(role).toString());
     }
 }
+
+QString GUIUtil::getSaveFileName(QWidget *parent, const QString &caption,
+                                 const QString &dir,
+                                 const QString &filter,
+                                 QString *selectedSuffixOut)
+{
+    QString selectedFilter;
+    QString myDir;
+    if(dir.isEmpty()) // Default to user documents location
+    {
+        myDir = QDesktopServices::storageLocation(QDesktopServices::DocumentsLocation);
+    }
+    else
+    {
+        myDir = dir;
+    }
+    QString result = QFileDialog::getSaveFileName(parent, caption, myDir, filter, &selectedFilter);
+
+    /* Extract first suffix from filter pattern "Description (*.foo)" or "Description (*.foo *.bar ...) */
+    QRegExp filter_re(".* \\(\\*\\.(.*)[ \\)]");
+    QString selectedSuffix;
+    if(filter_re.exactMatch(selectedFilter))
+    {
+        selectedSuffix = filter_re.cap(1);
+    }
+
+    /* Add suffix if needed */
+    QFileInfo info(result);
+    if(!result.isEmpty())
+    {
+        if(info.suffix().isEmpty() && !selectedSuffix.isEmpty())
+        {
+            /* No suffix specified, add selected suffix */
+            if(!result.endsWith("."))
+                result.append(".");
+            result.append(selectedSuffix);
+        }
+    }
+
+    /* Return selected suffix if asked to */
+    if(selectedSuffixOut)
+    {
+        *selectedSuffixOut = selectedSuffix;
+    }
+    return result;
+}
+

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -45,6 +45,20 @@ public:
      */
     static void copyEntryData(QAbstractItemView *view, int column, int role=Qt::EditRole);
 
+    /** Get save file name, mimics QFileDialog::getSaveFileName, except that it appends a default suffix
+        when no suffix is provided by the user.
+
+      @param[in] parent  Parent window (or 0)
+      @param[in] caption Window caption (or empty, for default)
+      @param[in] dir     Starting directory (or empty, to default to documents directory)
+      @param[in] filter  Filter specification such as "Comma Separated Files (*.csv)"
+      @param[out] selectedSuffixOut  Pointer to return the suffix (file type) that was selected (or 0).
+                  Can be useful when choosing the save file format based on suffix.
+     */
+    static QString getSaveFileName(QWidget *parent=0, const QString &caption=QString(),
+                                   const QString &dir=QString(), const QString &filter=QString(),
+                                   QString *selectedSuffixOut=0);
+
 };
 
 #endif // GUIUTIL_H

--- a/src/qt/qrcodedialog.cpp
+++ b/src/qt/qrcodedialog.cpp
@@ -1,9 +1,9 @@
 #include "qrcodedialog.h"
 #include "ui_qrcodedialog.h"
+#include "guiutil.h"
+
 #include <QPixmap>
 #include <QUrl>
-#include <QFileDialog>
-#include <QDesktopServices>
 #include <QDebug>
 
 #include <qrencode.h>
@@ -98,7 +98,7 @@ void QRCodeDialog::on_lnMessage_textChanged(const QString &)
 
 void QRCodeDialog::on_btnSaveAs_clicked()
 {
-    QString fn = QFileDialog::getSaveFileName(this, "Save Image...", QDesktopServices::storageLocation(QDesktopServices::DocumentsLocation), "Images (*.png)");
+    QString fn = GUIUtil::getSaveFileName(this, tr("Save Image..."), QString(), tr("PNG Images (*.png)"));
     if(!fn.isEmpty()) {
         myImage.scaled(EXPORT_IMAGE_SIZE, EXPORT_IMAGE_SIZE).save(fn);
     }

--- a/src/qt/qrcodedialog.cpp
+++ b/src/qt/qrcodedialog.cpp
@@ -34,8 +34,8 @@ QRCodeDialog::~QRCodeDialog()
     delete ui;
 }
 
-void QRCodeDialog::genCode() {
-
+void QRCodeDialog::genCode()
+{
     QString uri = getURI();
     //qDebug() << "Encoding:" << uri.toUtf8().constData();
     QRcode *code = QRcode_encodeString(uri.toUtf8().constData(), 0, QR_ECLEVEL_L, QR_MODE_8, 1);
@@ -52,7 +52,8 @@ void QRCodeDialog::genCode() {
     ui->lblQRCode->setPixmap(QPixmap::fromImage(myImage).scaled(300, 300));
 }
 
-QString QRCodeDialog::getURI() {
+QString QRCodeDialog::getURI()
+{
     QString ret = QString("bitcoin:%1").arg(address);
 
     int paramCount = 0;
@@ -80,15 +81,18 @@ QString QRCodeDialog::getURI() {
     return ret;
 }
 
-void QRCodeDialog::on_lnReqAmount_textChanged(const QString &) {
+void QRCodeDialog::on_lnReqAmount_textChanged(const QString &)
+{
     genCode();
 }
 
-void QRCodeDialog::on_lnLabel_textChanged(const QString &) {
+void QRCodeDialog::on_lnLabel_textChanged(const QString &)
+{
     genCode();
 }
 
-void QRCodeDialog::on_lnMessage_textChanged(const QString &) {
+void QRCodeDialog::on_lnMessage_textChanged(const QString &)
+{
     genCode();
 }
 

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -21,7 +21,6 @@
 #include <QTableView>
 #include <QHeaderView>
 #include <QPushButton>
-#include <QFileDialog>
 #include <QMessageBox>
 #include <QPoint>
 #include <QMenu>
@@ -264,10 +263,9 @@ void TransactionView::changedAmount(const QString &amount)
 void TransactionView::exportClicked()
 {
     // CSV is currently the only supported format
-    QString filename = QFileDialog::getSaveFileName(
+    QString filename = GUIUtil::getSaveFileName(
             this,
-            tr("Export Transaction Data"),
-            QDir::currentPath(),
+            tr("Export Transaction Data"), QString(),
             tr("Comma separated file (*.csv)"));
 
     if (filename.isNull()) return;


### PR DESCRIPTION
Fix default suffixes in save dialog in GNOME and make it more clear that PNG is used (solves #833)
