### PR TITLE
Several shutdown-related fixes

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1274,9 +1274,13 @@ void ThreadOpenConnections2(void* parg)
     int64 nStart = GetTime();
     loop
     {
-        // Limit outbound connections
         vnThreadsRunning[1]--;
         Sleep(500);
+        vnThreadsRunning[1]++;
+        if (fShutdown)
+            return;
+
+        // Limit outbound connections
         loop
         {
             int nOutbound = 0;
@@ -1288,13 +1292,12 @@ void ThreadOpenConnections2(void* parg)
             nMaxOutboundConnections = min(nMaxOutboundConnections, (int)GetArg("-maxconnections", 125));
             if (nOutbound < nMaxOutboundConnections)
                 break;
+            vnThreadsRunning[1]--;
             Sleep(2000);
+            vnThreadsRunning[1]++;
             if (fShutdown)
                 return;
         }
-        vnThreadsRunning[1]++;
-        if (fShutdown)
-            return;
 
         bool fAddSeeds = false;
 
@@ -1766,7 +1769,7 @@ bool StopNode()
     fShutdown = true;
     nTransactionsUpdated++;
     int64 nStart = GetTime();
-    while (vnThreadsRunning[0] > 0 || vnThreadsRunning[2] > 0 || vnThreadsRunning[3] > 0 || vnThreadsRunning[4] > 0
+    while (vnThreadsRunning[0] > 0 || vnThreadsRunning[1] > 0 || vnThreadsRunning[2] > 0 || vnThreadsRunning[3] > 0 || vnThreadsRunning[4] > 0
         || (fHaveUPnP && vnThreadsRunning[5] > 0) || vnThreadsRunning[6] > 0 || vnThreadsRunning[7] > 0
     )
     {


### PR DESCRIPTION
- do not let vnThreadsRunning[1] go negative
- do not perform locking operations while vnThreadsRunning[1] is decreased
- check vnThreadsRunning[1] at exit
