### PR TITLE
Fix issue #848 : broken mining on testnet

### DIFF
--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -1816,7 +1816,7 @@ Value getwork(const Array& params, bool fHelp)
         }
 
         // Update nTime
-        pblock->nTime = max(pindexPrev->GetMedianTimePast()+1, GetAdjustedTime());
+        pblock->UpdateTime(pindexPrev);
         pblock->nNonce = 0;
 
         // Update nExtraNonce
@@ -1916,7 +1916,7 @@ Value getmemorypool(const Array& params, bool fHelp)
         }
 
         // Update nTime
-        pblock->nTime = max(pindexPrev->GetMedianTimePast()+1, GetAdjustedTime());
+        pblock->UpdateTime(pindexPrev);
         pblock->nNonce = 0;
 
         Array transactions;

--- a/src/main.h
+++ b/src/main.h
@@ -913,6 +913,7 @@ public:
         return (int64)nTime;
     }
 
+    void UpdateTime(const CBlockIndex* pindexPrev);
 
 
     uint256 BuildMerkleTree() const


### PR DESCRIPTION
This is just a refactor on main-net (new UpdateTime() method to avoid duplication of GetMedianTimePast() math).

On testnet it fixes miners getting invalid blocks if they mine across the 20-minute "switch to minimum difficulty" rule that is new with 0.6.
