### PR TITLE
Toggle hide

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -23,6 +23,7 @@
 #include "guiconstants.h"
 #include "askpassphrasedialog.h"
 #include "notificator.h"
+#include "guiutil.h"
 
 #ifdef Q_WS_MAC
 #include "macdockiconhandler.h"
@@ -239,8 +240,8 @@ void BitcoinGUI::createActions()
     optionsAction = new QAction(QIcon(":/icons/options"), tr("&Options..."), this);
     optionsAction->setToolTip(tr("Modify configuration options for bitcoin"));
     optionsAction->setMenuRole(QAction::PreferencesRole);
-    openBitcoinAction = new QAction(QIcon(":/icons/bitcoin"), tr("Open &Bitcoin"), this);
-    openBitcoinAction->setToolTip(tr("Show the Bitcoin window"));
+    toggleHideAction = new QAction(QIcon(":/icons/bitcoin"), tr("Show/Hide &Bitcoin"), this);
+    toggleHideAction->setToolTip(tr("Show or Hide the Bitcoin window"));
     exportAction = new QAction(QIcon(":/icons/export"), tr("&Export..."), this);
     exportAction->setToolTip(tr("Export the data in the current tab to a file"));
     encryptWalletAction = new QAction(QIcon(":/icons/lock_closed"), tr("&Encrypt Wallet"), this);
@@ -255,7 +256,7 @@ void BitcoinGUI::createActions()
     connect(optionsAction, SIGNAL(triggered()), this, SLOT(optionsClicked()));
     connect(aboutAction, SIGNAL(triggered()), this, SLOT(aboutClicked()));
     connect(aboutQtAction, SIGNAL(triggered()), qApp, SLOT(aboutQt()));
-    connect(openBitcoinAction, SIGNAL(triggered()), this, SLOT(showNormalIfMinimized()));
+    connect(toggleHideAction, SIGNAL(triggered()), this, SLOT(toggleHidden()));
     connect(encryptWalletAction, SIGNAL(triggered(bool)), this, SLOT(encryptWallet(bool)));
     connect(backupWalletAction, SIGNAL(triggered()), this, SLOT(backupWallet()));
     connect(changePassphraseAction, SIGNAL(triggered()), this, SLOT(changePassphrase()));
@@ -392,7 +393,7 @@ void BitcoinGUI::createTrayIcon()
 #endif
 
     // Configuration of the tray icon (or dock icon) icon menu
-    trayIconMenu->addAction(openBitcoinAction);
+    trayIconMenu->addAction(toggleHideAction);
     trayIconMenu->addSeparator();
     trayIconMenu->addAction(messageAction);
 #ifndef FIRST_CLASS_MESSAGING
@@ -416,10 +417,32 @@ void BitcoinGUI::trayIconActivated(QSystemTrayIcon::ActivationReason reason)
     if(reason == QSystemTrayIcon::Trigger)
     {
         // Click on system tray icon triggers "open bitcoin"
-        openBitcoinAction->trigger();
+        toggleHideAction->trigger();
     }
 }
 #endif
+
+void BitcoinGUI::toggleHidden()
+{
+    // activateWindow() (sometimes) helps with keyboard focus on Windows
+    if(isHidden())
+    {
+        show();
+        activateWindow();
+    }
+    else if(isMinimized())
+    {
+        showNormal();
+        activateWindow();
+    }
+    else if(GUIUtil::isObscured(this))
+    {
+        raise();
+        activateWindow();
+    }
+    else
+        hide();
+}
 
 void BitcoinGUI::optionsClicked()
 {

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -81,7 +81,7 @@ private:
     QAction *aboutAction;
     QAction *receiveCoinsAction;
     QAction *optionsAction;
-    QAction *openBitcoinAction;
+    QAction *toggleHideAction;
     QAction *exportAction;
     QAction *encryptWalletAction;
     QAction *backupWalletAction;
@@ -166,6 +166,8 @@ private slots:
 
     /** Show window if hidden, unminimize when minimized */
     void showNormalIfMinimized();
+    /** Hide window if visible, show if hidden */
+    void toggleHidden();
 };
 
 #endif

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -19,31 +19,33 @@
 #include <QDesktopServices>
 #include <QThread>
 
-QString GUIUtil::dateTimeStr(qint64 nTime)
-{
-    return dateTimeStr(QDateTime::fromTime_t((qint32)nTime));
-}
+namespace GUIUtil {
 
-QString GUIUtil::dateTimeStr(const QDateTime &date)
+QString dateTimeStr(const QDateTime &date)
 {
     return date.date().toString(Qt::SystemLocaleShortDate) + QString(" ") + date.toString("hh:mm");
 }
 
-QFont GUIUtil::bitcoinAddressFont()
+QString dateTimeStr(qint64 nTime)
+{
+    return dateTimeStr(QDateTime::fromTime_t((qint32)nTime));
+}
+
+QFont bitcoinAddressFont()
 {
     QFont font("Monospace");
     font.setStyleHint(QFont::TypeWriter);
     return font;
 }
 
-void GUIUtil::setupAddressWidget(QLineEdit *widget, QWidget *parent)
+void setupAddressWidget(QLineEdit *widget, QWidget *parent)
 {
     widget->setMaxLength(BitcoinAddressValidator::MaxAddressLength);
     widget->setValidator(new BitcoinAddressValidator(parent));
     widget->setFont(bitcoinAddressFont());
 }
 
-void GUIUtil::setupAmountWidget(QLineEdit *widget, QWidget *parent)
+void setupAmountWidget(QLineEdit *widget, QWidget *parent)
 {
     QDoubleValidator *amountValidator = new QDoubleValidator(parent);
     amountValidator->setDecimals(8);
@@ -52,7 +54,7 @@ void GUIUtil::setupAmountWidget(QLineEdit *widget, QWidget *parent)
     widget->setAlignment(Qt::AlignRight|Qt::AlignVCenter);
 }
 
-bool GUIUtil::parseBitcoinURI(const QUrl &uri, SendCoinsRecipient *out)
+bool parseBitcoinURI(const QUrl &uri, SendCoinsRecipient *out)
 {
     if(uri.scheme() != QString("bitcoin"))
         return false;
@@ -97,7 +99,7 @@ bool GUIUtil::parseBitcoinURI(const QUrl &uri, SendCoinsRecipient *out)
     return true;
 }
 
-bool GUIUtil::parseBitcoinURI(QString uri, SendCoinsRecipient *out)
+bool parseBitcoinURI(QString uri, SendCoinsRecipient *out)
 {
     // Convert bitcoin:// to bitcoin:
     //
@@ -111,7 +113,7 @@ bool GUIUtil::parseBitcoinURI(QString uri, SendCoinsRecipient *out)
     return parseBitcoinURI(uriInstance, out);
 }
 
-QString GUIUtil::HtmlEscape(const QString& str, bool fMultiLine)
+QString HtmlEscape(const QString& str, bool fMultiLine)
 {
     QString escaped = Qt::escape(str);
     if(fMultiLine)
@@ -121,12 +123,12 @@ QString GUIUtil::HtmlEscape(const QString& str, bool fMultiLine)
     return escaped;
 }
 
-QString GUIUtil::HtmlEscape(const std::string& str, bool fMultiLine)
+QString HtmlEscape(const std::string& str, bool fMultiLine)
 {
     return HtmlEscape(QString::fromStdString(str), fMultiLine);
 }
 
-void GUIUtil::copyEntryData(QAbstractItemView *view, int column, int role)
+void copyEntryData(QAbstractItemView *view, int column, int role)
 {
     if(!view || !view->selectionModel())
         return;
@@ -139,7 +141,7 @@ void GUIUtil::copyEntryData(QAbstractItemView *view, int column, int role)
     }
 }
 
-QString GUIUtil::getSaveFileName(QWidget *parent, const QString &caption,
+QString getSaveFileName(QWidget *parent, const QString &caption,
                                  const QString &dir,
                                  const QString &filter,
                                  QString *selectedSuffixOut)
@@ -185,7 +187,7 @@ QString GUIUtil::getSaveFileName(QWidget *parent, const QString &caption,
     return result;
 }
 
-Qt::ConnectionType GUIUtil::blockingGUIThreadConnection()
+Qt::ConnectionType blockingGUIThreadConnection()
 {
     if(QThread::currentThread() != QCoreApplication::instance()->thread())
     {
@@ -196,3 +198,23 @@ Qt::ConnectionType GUIUtil::blockingGUIThreadConnection()
         return Qt::DirectConnection;
     }
 }
+
+bool checkPoint(const QPoint &p, const QWidget *w)
+{
+  QWidget *atW = qApp->widgetAt(w->mapToGlobal(p));
+  if(!atW) return false;
+  return atW->topLevelWidget() == w;
+}
+
+bool isObscured(QWidget *w)
+{
+
+  return !(checkPoint(QPoint(0, 0), w)
+           && checkPoint(QPoint(w->width() - 1, 0), w)
+           && checkPoint(QPoint(0, w->height() - 1), w)
+           && checkPoint(QPoint(w->width() - 1, w->height() - 1), w)
+           && checkPoint(QPoint(w->width()/2, w->height()/2), w));
+}
+
+} // namespace GUIUtil
+

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -13,30 +13,29 @@ class QAbstractItemView;
 QT_END_NAMESPACE
 class SendCoinsRecipient;
 
-/** Static utility functions used by the Bitcoin Qt UI.
+/** Utility functions used by the Bitcoin Qt UI.
  */
-class GUIUtil
+namespace GUIUtil
 {
-public:
     // Create human-readable string from date
-    static QString dateTimeStr(qint64 nTime);
-    static QString dateTimeStr(const QDateTime &datetime);
+    QString dateTimeStr(const QDateTime &datetime);
+    QString dateTimeStr(qint64 nTime);
 
     // Render bitcoin addresses in monospace font
-    static QFont bitcoinAddressFont();
+    QFont bitcoinAddressFont();
 
     // Set up widgets for address and amounts
-    static void setupAddressWidget(QLineEdit *widget, QWidget *parent);
-    static void setupAmountWidget(QLineEdit *widget, QWidget *parent);
+    void setupAddressWidget(QLineEdit *widget, QWidget *parent);
+    void setupAmountWidget(QLineEdit *widget, QWidget *parent);
 
     // Parse "bitcoin:" URI into recipient object, return true on succesful parsing
     // See Bitcoin URI definition discussion here: https://bitcointalk.org/index.php?topic=33490.0
-    static bool parseBitcoinURI(const QUrl &, SendCoinsRecipient *out);
-    static bool parseBitcoinURI(QString uri, SendCoinsRecipient *out);
+    bool parseBitcoinURI(const QUrl &uri, SendCoinsRecipient *out);
+    bool parseBitcoinURI(QString uri, SendCoinsRecipient *out);
 
     // HTML escaping for rich text controls
-    static QString HtmlEscape(const QString& str, bool fMultiLine=false);
-    static QString HtmlEscape(const std::string& str, bool fMultiLine=false);
+    QString HtmlEscape(const QString& str, bool fMultiLine=false);
+    QString HtmlEscape(const std::string& str, bool fMultiLine=false);
 
     /** Copy a field of the currently selected entry of a view to the clipboard. Does nothing if nothing
         is selected.
@@ -44,7 +43,7 @@ public:
        @param[in] role    Data role to extract from the model
        @see  TransactionView::copyLabel, TransactionView::copyAmount, TransactionView::copyAddress
      */
-    static void copyEntryData(QAbstractItemView *view, int column, int role=Qt::EditRole);
+    void copyEntryData(QAbstractItemView *view, int column, int role=Qt::EditRole);
 
     /** Get save file name, mimics QFileDialog::getSaveFileName, except that it appends a default suffix
         when no suffix is provided by the user.
@@ -56,18 +55,20 @@ public:
       @param[out] selectedSuffixOut  Pointer to return the suffix (file type) that was selected (or 0).
                   Can be useful when choosing the save file format based on suffix.
      */
-    static QString getSaveFileName(QWidget *parent=0, const QString &caption=QString(),
+    QString getSaveFileName(QWidget *parent=0, const QString &caption=QString(),
                                    const QString &dir=QString(), const QString &filter=QString(),
                                    QString *selectedSuffixOut=0);
-
 
     /** Get connection type to call object slot in GUI thread with invokeMethod. The call will be blocking.
 
        @returns If called from the GUI thread, return a Qt::DirectConnection.
                 If called from another thread, return a Qt::BlockingQueuedConnection.
     */
-    static Qt::ConnectionType blockingGUIThreadConnection();
+    Qt::ConnectionType blockingGUIThreadConnection();
 
-};
+    // Determine whether a widget is hidden behind other windows
+    bool isObscured(QWidget *w);
+
+} // namespace GUIUtil
 
 #endif // GUIUTIL_H

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -175,17 +175,15 @@ MainOptionsPage::MainOptionsPage(QWidget *parent):
     minimize_to_tray = new QCheckBox(tr("&Minimize to the tray instead of the taskbar"));
     minimize_to_tray->setToolTip(tr("Show only a tray icon after minimizing the window"));
     layout->addWidget(minimize_to_tray);
+
+    minimize_on_close = new QCheckBox(tr("M&inimize on close"));
+    minimize_on_close->setToolTip(tr("Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu."));
+    layout->addWidget(minimize_on_close);
 #endif
 
     map_port_upnp = new QCheckBox(tr("Map port using &UPnP"));
     map_port_upnp->setToolTip(tr("Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled."));
     layout->addWidget(map_port_upnp);
-
-#ifndef Q_WS_MAC
-    minimize_on_close = new QCheckBox(tr("M&inimize on close"));
-    minimize_on_close->setToolTip(tr("Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu."));
-    layout->addWidget(minimize_on_close);
-#endif
 
     connect_socks4 = new QCheckBox(tr("&Connect through SOCKS4 proxy:"));
     connect_socks4->setToolTip(tr("Connect to the Bitcon network through a SOCKS4 proxy (e.g. when connecting through Tor)"));


### PR DESCRIPTION
```
Toggle main window hide on tray icon click

- converted openBictoinAction to toggleHideAction
- put GUIUtil functions into a namespace instead of a class
- put window-related functions together in optionsdialog

Reasoning:
- toggle is more typical behaviour
- it's more functional
- better UX

The typical issue with toggling visibility is that when a window
is obscured by other windows but in the 'shown' state, hiding it
isn't what you want. I've added an 'isObscured' function to GUIUtil
that checks several pixels in the window to see if they are visible
on the desktop so that an obscured but shown window can be raised.
```
