### PR TITLE
Hide tray icon in destructor, as deleting will let it linger until quit (on ubuntu)

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -165,6 +165,8 @@ BitcoinGUI::BitcoinGUI(QWidget *parent):
 
 BitcoinGUI::~BitcoinGUI()
 {
+    if(trayIcon) // Hide tray icon, as deleting will let it linger until quit (on Ubuntu)
+        trayIcon->hide();
 #ifdef Q_WS_MAC
     delete appMenuBar;
 #endif


### PR DESCRIPTION
Hide tray icon in destructor, as the deletion (which automatically happens as it is a child object of BitcoinGUI) will let it linger until quit, at least on Ubuntu.

This is annoying as the icon and menu will still be there for a few seconds (ignoring command), so that it seems the quit did not work properly.
