### PR TITLE
Leave IRC enabled by default on testnet

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -259,6 +259,11 @@ bool AppInit2(int argc, char* argv[])
     }
 
     fTestNet = GetBoolArg("-testnet");
+    if (fTestNet)
+    {
+        SoftSetBoolArg("-irc", true);
+    }
+
     fDebug = GetBoolArg("-debug");
 
 #if !defined(WIN32) && !defined(QT_GUI)


### PR DESCRIPTION
As testnet has neither DNS seeds or built-in seed addresses to
bootstrap from.
