### PR TITLE
Bugfix: Instead of reporting "bitcoin-qt" for both bitcoind and Bitcoin-Qt, report "Satoshi" which is at least correct

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,7 +21,7 @@ using namespace boost;
 // Name of client reported in the 'version' message. Report the same name
 // for both bitcoind and bitcoin-qt, to make it harder for attackers to
 // target servers or GUI users specifically.
-const std::string CLIENT_NAME("bitcoin-qt");
+const std::string CLIENT_NAME("Satoshi");
 
 CCriticalSection cs_setpwalletRegistered;
 set<CWallet*> setpwalletRegistered;


### PR DESCRIPTION
Simplified form of #715
