### PR TITLE
More details for getblock and gettransaction

### DIFF
--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -172,6 +172,9 @@ Object blockToJSON(const CBlock& block, const CBlockIndex* blockindex)
 {
     Object result;
     result.push_back(Pair("hash", block.GetHash().GetHex()));
+    CMerkleTx txGen(block.vtx[0]);
+    txGen.SetMerkleBranch(&block);
+    result.push_back(Pair("confirmations", (int)txGen.GetDepthInMainChain()));
     result.push_back(Pair("size", (int)::GetSerializeSize(block, SER_NETWORK, PROTOCOL_VERSION)));
     result.push_back(Pair("height", blockindex->nHeight));
     result.push_back(Pair("version", block.nVersion));


### PR DESCRIPTION
Add block "confirmations" to getblock, mainly for identifying orphans

---

Second parameter to JSON-RPC getblock/gettransaction: decompositions

This is an Object specifying how to decompose specific elements.
Currently supported:
- "tx": "no", "hash", "hex", "obj"
- "script": "no", "hex", "asm", "obj"

---

Note that this depends on pulls #841 (sipa/getalltransactions) and #885 (luke-jr/getblock_cleanup), so the diff includes those until they are merged.
