### PR TITLE
Move options from wallet.dat to QT settings files

### DIFF
--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -301,7 +301,7 @@ Value getgenerate(const Array& params, bool fHelp)
             "getgenerate\n"
             "Returns true or false.");
 
-    return (bool)fGenerateBitcoins;
+    return GetBoolArg("-gen");
 }
 
 
@@ -320,13 +320,11 @@ Value setgenerate(const Array& params, bool fHelp)
     if (params.size() > 1)
     {
         int nGenProcLimit = params[1].get_int();
-        fLimitProcessors = (nGenProcLimit != -1);
-        WriteSetting("fLimitProcessors", fLimitProcessors);
-        if (nGenProcLimit != -1)
-            WriteSetting("nLimitProcessors", nLimitProcessors = nGenProcLimit);
+        mapArgs["-genproclimit"] = itostr(nGenProcLimit);
         if (nGenProcLimit == 0)
             fGenerate = false;
     }
+    mapArgs["-gen"] = (fGenerate ? "1" : "0");
 
     GenerateBitcoins(fGenerate, pwalletMain);
     return Value::null;
@@ -385,8 +383,8 @@ Value getmininginfo(const Array& params, bool fHelp)
     obj.push_back(Pair("currentblocktx",(uint64_t)nLastBlockTx));
     obj.push_back(Pair("difficulty",    (double)GetDifficulty()));
     obj.push_back(Pair("errors",        GetWarnings("statusbar")));
-    obj.push_back(Pair("generate",      (bool)fGenerateBitcoins));
-    obj.push_back(Pair("genproclimit",  (int)(fLimitProcessors ? nLimitProcessors : -1)));
+    obj.push_back(Pair("generate",      GetBoolArg("-gen")));
+    obj.push_back(Pair("genproclimit",  (int)GetArg("-genproclimit", -1)));
     obj.push_back(Pair("hashespersec",  gethashespersec(params, false)));
     obj.push_back(Pair("pooledtx",      (uint64_t)nPooledTx));
     obj.push_back(Pair("testnet",       fTestNet));

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -768,13 +768,6 @@ int CWalletDB::LoadWallet(CWallet* pwallet)
     vector<uint256> vWalletUpgrade;
     bool fIsEncrypted = false;
 
-    // Modify defaults
-#ifndef WIN32
-    // Tray icon sometimes disappears on 9.10 karmic koala 64-bit, leaving no way to access the program
-    fMinimizeToTray = false;
-    fMinimizeOnClose = false;
-#endif
-
     //// todo: shouldn't we catch exceptions and try to recover and continue?
     CRITICAL_BLOCK(pwallet->cs_wallet)
     {
@@ -916,24 +909,6 @@ int CWalletDB::LoadWallet(CWallet* pwallet)
                 if (nFileVersion == 10300)
                     nFileVersion = 300;
             }
-            else if (strType == "setting")
-            {
-                string strKey;
-                ssKey >> strKey;
-
-                // Options
-#ifndef QT_GUI
-                if (strKey == "fGenerateBitcoins")  ssValue >> fGenerateBitcoins;
-#endif
-                if (strKey == "nTransactionFee")    ssValue >> nTransactionFee;
-                if (strKey == "fLimitProcessors")   ssValue >> fLimitProcessors;
-                if (strKey == "nLimitProcessors")   ssValue >> nLimitProcessors;
-                if (strKey == "fMinimizeToTray")    ssValue >> fMinimizeToTray;
-                if (strKey == "fMinimizeOnClose")   ssValue >> fMinimizeOnClose;
-                if (strKey == "fUseProxy")          ssValue >> fUseProxy;
-                if (strKey == "addrProxy")          ssValue >> addrProxy;
-                if (fHaveUPnP && strKey == "fUseUPnP")           ssValue >> fUseUPnP;
-            }
             else if (strType == "minversion")
             {
                 int nMinVersion = 0;
@@ -959,14 +934,6 @@ int CWalletDB::LoadWallet(CWallet* pwallet)
         WriteTx(hash, pwallet->mapWallet[hash]);
 
     printf("nFileVersion = %d\n", nFileVersion);
-    printf("fGenerateBitcoins = %d\n", fGenerateBitcoins);
-    printf("nTransactionFee = %"PRI64d"\n", nTransactionFee);
-    printf("fMinimizeToTray = %d\n", fMinimizeToTray);
-    printf("fMinimizeOnClose = %d\n", fMinimizeOnClose);
-    printf("fUseProxy = %d\n", fUseProxy);
-    printf("addrProxy = %s\n", addrProxy.ToString().c_str());
-    if (fHaveUPnP)
-        printf("fUseUPnP = %d\n", fUseUPnP);
 
 
     // Rewrite encrypted wallets of versions 0.4.0 and 0.5.0rc:

--- a/src/db.h
+++ b/src/db.h
@@ -473,17 +473,23 @@ public:
         return Erase(std::make_pair(std::string("pool"), nPool));
     }
 
+    // Settings are no longer stored in wallet.dat; these are
+    // used only for backwards compatibility:
     template<typename T>
     bool ReadSetting(const std::string& strKey, T& value)
     {
         return Read(std::make_pair(std::string("setting"), strKey), value);
     }
-
     template<typename T>
     bool WriteSetting(const std::string& strKey, const T& value)
     {
         nWalletDBUpdated++;
         return Write(std::make_pair(std::string("setting"), strKey), value);
+    }
+    bool EraseSetting(const std::string& strKey)
+    {
+        nWalletDBUpdated++;
+        return Erase(std::make_pair(std::string("setting"), strKey));
     }
 
     bool WriteMinVersion(int nVersion)

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -150,27 +150,15 @@ bool AppInit2(int argc, char* argv[])
     //
     // Parameters
     //
-    // If Qt is used, parameters are parsed in qt/bitcoin.cpp's main()
+    // If Qt is used, parameters/bitcoin.conf are parsed in qt/bitcoin.cpp's main()
 #if !defined(QT_GUI)
     ParseParameters(argc, argv);
-#endif
-
-    if (mapArgs.count("-datadir"))
+    if (!ReadConfigFile(mapArgs, mapMultiArgs))
     {
-        if (filesystem::is_directory(filesystem::system_complete(mapArgs["-datadir"])))
-        {
-            filesystem::path pathDataDir = filesystem::system_complete(mapArgs["-datadir"]);
-            strlcpy(pszSetDataDir, pathDataDir.string().c_str(), sizeof(pszSetDataDir));
-        }
-        else
-        {
-            fprintf(stderr, "Error: Specified directory does not exist\n");
-            Shutdown(NULL);
-        }
+        fprintf(stderr, "Error: Specified directory does not exist\n");
+        Shutdown(NULL);
     }
-
-
-    ReadConfigFile(mapArgs, mapMultiArgs); // Must be done after processing datadir
+#endif
 
     if (mapArgs.count("-?") || mapArgs.count("--help"))
     {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -472,8 +472,6 @@ bool AppInit2(int argc, char* argv[])
         return false;
     }
 
-    fGenerateBitcoins = GetBoolArg("-gen");
-
     if (mapArgs.count("-proxy"))
     {
         fUseProxy = true;
@@ -518,13 +516,6 @@ bool AppInit2(int argc, char* argv[])
         const char* pszP2SH = "NOP2SH";
         COINBASE_FLAGS << std::vector<unsigned char>(pszP2SH, pszP2SH+strlen(pszP2SH));
     }
-
-    // Command-line args override in-wallet settings:
-#if USE_UPNP
-    fUseUPnP = GetBoolArg("-upnp", true);
-#else
-    fUseUPnP = GetBoolArg("-upnp", false);
-#endif
 
     if (!fNoListen)
     {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -57,22 +57,12 @@ CScript COINBASE_FLAGS;
 
 const string strMessageMagic = "Bitcoin Signed Message:\n";
 
-
 double dHashesPerSec;
 int64 nHPSTimerStart;
 
 // Settings
-int fGenerateBitcoins = false;
 int64 nTransactionFee = 0;
-int fLimitProcessors = false;
-int nLimitProcessors = 1;
-int fMinimizeToTray = true;
-int fMinimizeOnClose = true;
-#if USE_UPNP
-int fUseUPnP = true;
-#else
-int fUseUPnP = false;
-#endif
+
 
 
 //////////////////////////////////////////////////////////////////////////////
@@ -3289,6 +3279,10 @@ bool CheckWork(CBlock* pblock, CWallet& wallet, CReserveKey& reservekey)
 
 void static ThreadBitcoinMiner(void* parg);
 
+static bool fGenerateBitcoins = false;
+static bool fLimitProcessors = false;
+static int nLimitProcessors = -1;
+
 void static BitcoinMiner(CWallet *pwallet)
 {
     printf("BitcoinMiner started\n");
@@ -3464,13 +3458,13 @@ void static ThreadBitcoinMiner(void* parg)
 
 void GenerateBitcoins(bool fGenerate, CWallet* pwallet)
 {
-    if (fGenerateBitcoins != fGenerate)
-    {
-        fGenerateBitcoins = fGenerate;
-        WriteSetting("fGenerateBitcoins", fGenerateBitcoins);
-        MainFrameRepaint();
-    }
-    if (fGenerateBitcoins)
+    fGenerateBitcoins = fGenerate;
+    nLimitProcessors = GetArg("-genproclimit", -1);
+    if (nLimitProcessors == 0)
+        fGenerateBitcoins = false;
+    fLimitProcessors = (nLimitProcessors != -1);
+
+    if (fGenerate)
     {
         int nProcessors = boost::thread::hardware_concurrency();
         printf("%d processors\n", nProcessors);

--- a/src/main.h
+++ b/src/main.h
@@ -77,13 +77,7 @@ extern CCriticalSection cs_setpwalletRegistered;
 extern std::set<CWallet*> setpwalletRegistered;
 
 // Settings
-extern int fGenerateBitcoins;
 extern int64 nTransactionFee;
-extern int fLimitProcessors;
-extern int nLimitProcessors;
-extern int fMinimizeToTray;
-extern int fMinimizeOnClose;
-extern int fUseUPnP;
 
 
 
@@ -126,20 +120,6 @@ std::string GetWarnings(std::string strFor);
 
 
 bool GetWalletFile(CWallet* pwallet, std::string &strWalletFileOut);
-
-template<typename T>
-bool WriteSetting(const std::string& strKey, const T& value)
-{
-    bool fOk = false;
-    BOOST_FOREACH(CWallet* pwallet, setpwalletRegistered)
-    {
-        std::string strWalletFile;
-        if (!GetWalletFile(pwallet, strWalletFile))
-            continue;
-        fOk |= CWalletDB(strWalletFile).WriteSetting(strKey, value);
-    }
-    return fOk;
-}
 
 
 class CDiskTxPos

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -43,6 +43,7 @@ bool OpenNetworkConnection(const CAddress& addrConnect);
 //
 bool fClient = false;
 bool fAllowDNS = false;
+static bool fUseUPnP = false;
 uint64 nLocalServices = (fClient ? 0 : NODE_NETWORK);
 CAddress addrLocalHost(CService("0.0.0.0", 0), nLocalServices);
 static CNode* pnodeLocalHost = NULL;
@@ -1102,7 +1103,6 @@ void MapPort(bool fMapPort)
     if (fUseUPnP != fMapPort)
     {
         fUseUPnP = fMapPort;
-        WriteSetting("fUseUPnP", fUseUPnP);
     }
     if (fUseUPnP && vnThreadsRunning[THREAD_UPNP] < 1)
     {
@@ -1711,6 +1711,14 @@ bool BindListenPort(string& strError)
 
 void StartNode(void* parg)
 {
+#ifdef USE_UPNP
+#if USE_UPNP
+    fUseUPnP = GetBoolArg("-upnp", true);
+#else
+    fUseUPnP = GetBoolArg("-upnp", false);
+#endif
+#endif
+
     if (pnodeLocalHost == NULL)
         pnodeLocalHost = new CNode(INVALID_SOCKET, CAddress(CService("127.0.0.1", 0), nLocalServices));
 
@@ -1812,7 +1820,7 @@ void StartNode(void* parg)
         printf("Error: CreateThread(ThreadMessageHandler) failed\n");
 
     // Generate coins in the background
-    GenerateBitcoins(fGenerateBitcoins, pwalletMain);
+    GenerateBitcoins(GetBoolArg("-gen", false), pwalletMain);
 }
 
 bool StopNode()

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -152,7 +152,27 @@ int main(int argc, char *argv[])
     Q_INIT_RESOURCE(bitcoin);
     QApplication app(argc, argv);
 
+    // Command-line options take precedence:
     ParseParameters(argc, argv);
+
+    // ... then bitcoin.conf:
+    if (!ReadConfigFile(mapArgs, mapMultiArgs))
+    {
+        fprintf(stderr, "Error: Specified directory does not exist\n");
+        return 1;
+    }
+
+    // Application identification (must be set before OptionsModel is initialized,
+    // as it is used to locate QSettings)
+    app.setOrganizationName("Bitcoin");
+    app.setOrganizationDomain("bitcoin.org");
+    if(GetBoolArg("-testnet")) // Separate UI settings for testnet
+        app.setApplicationName("Bitcoin-Qt-testnet");
+    else
+        app.setApplicationName("Bitcoin-Qt");
+
+    // ... then GUI settings:
+    OptionsModel optionsModel;
 
     // Get desired locale ("en_US") from command line or system locale
     QString lang_territory = QString::fromStdString(GetArg("-lang", QLocale::system().name().toStdString()));
@@ -180,8 +200,6 @@ int main(int argc, char *argv[])
     if (!translator.isEmpty())
         app.installTranslator(&translator);
 
-    app.setApplicationName(QApplication::translate("main", "Bitcoin-Qt"));
-
     QSplashScreen splash(QPixmap(":/images/splash"), 0);
     splash.show();
     splash.setAutoFillBackground(true);
@@ -198,9 +216,11 @@ int main(int argc, char *argv[])
             {
                 // Put this in a block, so that BitcoinGUI is cleaned up properly before
                 // calling Shutdown() in case of exceptions.
+
+                optionsModel.Upgrade(); // Must be done after AppInit2
+
                 BitcoinGUI window;
                 splash.finish(&window);
-                OptionsModel optionsModel(pwalletMain);
                 ClientModel clientModel(&optionsModel);
                 WalletModel walletModel(pwalletMain, &optionsModel);
 

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -1,20 +1,79 @@
 #include "optionsmodel.h"
 #include "bitcoinunits.h"
+#include <QSettings>
 
 #include "headers.h"
 #include "init.h"
 
-OptionsModel::OptionsModel(CWallet *wallet, QObject *parent) :
-    QAbstractListModel(parent),
-    wallet(wallet),
-    nDisplayUnit(BitcoinUnits::BTC),
-    bDisplayAddresses(false)
+OptionsModel::OptionsModel(QObject *parent) :
+    QAbstractListModel(parent)
 {
-    // Read our specific settings from the wallet db
-    CWalletDB walletdb(wallet->strWalletFile);
-    walletdb.ReadSetting("nDisplayUnit", nDisplayUnit);
-    walletdb.ReadSetting("bDisplayAddresses", bDisplayAddresses);
+    Init();
 }
+
+void OptionsModel::Init()
+{
+    QSettings settings;
+
+    // These are QT-only settings:
+    nDisplayUnit = settings.value("nDisplayUnit", BitcoinUnits::BTC).toInt();
+    bDisplayAddresses = settings.value("bDisplayAddresses", false).toBool();
+    fMinimizeToTray = settings.value("fMinimizeToTray", false).toBool();
+    fMinimizeOnClose = settings.value("fMinimizeOnClose", false).toBool();
+    nTransactionFee = settings.value("nTransactionFee").toLongLong();
+
+    // These are shared with core bitcoin; we want
+    // command-line options to override the GUI settings:
+    if (settings.contains("fUseUPnP"))
+        SoftSetBoolArg("-upnp", settings.value("fUseUPnP").toBool());
+    if (settings.contains("addrProxy") && settings.value("fUseProxy").toBool())
+        SoftSetArg("-proxy", settings.value("addrProxy").toString().toStdString());
+}
+
+bool OptionsModel::Upgrade()
+{
+    QSettings settings;
+
+    if (settings.contains("bImportFinished"))
+        return false; // Already upgraded
+
+    settings.setValue("bImportFinished", true);
+
+    // Move settings from old wallet.dat (if any):
+    CWalletDB walletdb("wallet.dat");
+
+    QList<QString> intOptions;
+    intOptions << "nDisplayUnit" << "nTransactionFee";
+    foreach(QString key, intOptions)
+    {
+        int value = 0;
+        if (walletdb.ReadSetting(key.toStdString(), value))
+        {
+            settings.setValue(key, value);
+            walletdb.EraseSetting(key.toStdString());
+        }
+    }
+    QList<QString> boolOptions;
+    boolOptions << "bDisplayAddresses" << "fMinimizeToTray" << "fMinimizeOnClose" << "fUseProxy" << "fUseUPnP";
+    foreach(QString key, boolOptions)
+    {
+        bool value = false;
+        if (walletdb.ReadSetting(key.toStdString(), value))
+        {
+            settings.setValue(key, value);
+            walletdb.EraseSetting(key.toStdString());
+        }
+    }
+    if (walletdb.ReadSetting("addrProxy", addrProxy))
+    {
+        settings.setValue("addrProxy", addrProxy.ToStringIP().c_str());
+        walletdb.EraseSetting("addrProxy");
+    }
+    Init();
+
+    return true;
+}
+
 
 int OptionsModel::rowCount(const QModelIndex & parent) const
 {
@@ -25,6 +84,7 @@ QVariant OptionsModel::data(const QModelIndex & index, int role) const
 {
     if(role == Qt::EditRole)
     {
+        QSettings settings;
         switch(index.row())
         {
         case StartAtStartup:
@@ -32,11 +92,11 @@ QVariant OptionsModel::data(const QModelIndex & index, int role) const
         case MinimizeToTray:
             return QVariant(fMinimizeToTray);
         case MapPortUPnP:
-            return QVariant(fUseUPnP);
+            return settings.value("fUseUPnP", GetBoolArg("-upnp", true));
         case MinimizeOnClose:
             return QVariant(fMinimizeOnClose);
         case ConnectSOCKS4:
-            return QVariant(fUseProxy);
+            return settings.value("fUseProxy", false);
         case ProxyIP:
             return QVariant(QString::fromStdString(addrProxy.ToStringIP()));
         case ProxyPort:
@@ -59,7 +119,7 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
     bool successful = true; /* set to false on parse error */
     if(role == Qt::EditRole)
     {
-        CWalletDB walletdb(wallet->strWalletFile);
+        QSettings settings;
         switch(index.row())
         {
         case StartAtStartup:
@@ -67,22 +127,22 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
             break;
         case MinimizeToTray:
             fMinimizeToTray = value.toBool();
-            walletdb.WriteSetting("fMinimizeToTray", fMinimizeToTray);
+            settings.setValue("fMinimizeToTray", fMinimizeToTray);
             break;
         case MapPortUPnP:
-            fUseUPnP = value.toBool();
-            walletdb.WriteSetting("fUseUPnP", fUseUPnP);
-#ifdef USE_UPNP
-            MapPort(fUseUPnP);
-#endif
+            {
+                bool bUseUPnP = value.toBool();
+                settings.setValue("fUseUPnP", bUseUPnP);
+                MapPort(bUseUPnP);
+            }
             break;
         case MinimizeOnClose:
             fMinimizeOnClose = value.toBool();
-            walletdb.WriteSetting("fMinimizeOnClose", fMinimizeOnClose);
+            settings.setValue("fMinimizeOnClose", fMinimizeOnClose);
             break;
         case ConnectSOCKS4:
             fUseProxy = value.toBool();
-            walletdb.WriteSetting("fUseProxy", fUseProxy);
+            settings.setValue("fUseProxy", fUseProxy);
             break;
         case ProxyIP:
             {
@@ -91,7 +151,7 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
                 if (addr.IsValid())
                 {
                     addrProxy.SetIP(addr);
-                    walletdb.WriteSetting("addrProxy", addrProxy);
+                    settings.setValue("addrProxy", addrProxy.ToStringIP().c_str());
                 }
                 else
                 {
@@ -105,7 +165,7 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
                 if (nPort > 0 && nPort < std::numeric_limits<unsigned short>::max())
                 {
                     addrProxy.SetPort(nPort);
-                    walletdb.WriteSetting("addrProxy", addrProxy);
+                    settings.setValue("addrProxy", addrProxy.ToStringIP().c_str());
                 }
                 else
                 {
@@ -115,18 +175,18 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
             break;
         case Fee: {
             nTransactionFee = value.toLongLong();
-            walletdb.WriteSetting("nTransactionFee", nTransactionFee);
+            settings.setValue("nTransactionFee", nTransactionFee);
             }
             break;
         case DisplayUnit: {
             int unit = value.toInt();
             nDisplayUnit = unit;
-            walletdb.WriteSetting("nDisplayUnit", nDisplayUnit);
+            settings.setValue("nDisplayUnit", nDisplayUnit);
             emit displayUnitChanged(unit);
             }
         case DisplayAddresses: {
             bDisplayAddresses = value.toBool();
-            walletdb.WriteSetting("bDisplayAddresses", bDisplayAddresses);
+            settings.setValue("bDisplayAddresses", bDisplayAddresses);
             }
         default:
             break;

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -3,8 +3,6 @@
 
 #include <QAbstractListModel>
 
-class CWallet;
-
 /** Interface from QT to configuration data structure for bitcoin client.
    To QT, the options are presented as a list with the different options
    laid out vertically.
@@ -15,7 +13,7 @@ class OptionsModel : public QAbstractListModel
 {
     Q_OBJECT
 public:
-    explicit OptionsModel(CWallet *wallet, QObject *parent = 0);
+    explicit OptionsModel(QObject *parent = 0);
 
     enum OptionID {
         StartAtStartup, // bool
@@ -31,6 +29,11 @@ public:
         OptionIDRowCount
     };
 
+    void Init();
+
+    /* Migrate settings from wallet.dat after app initialization */
+    bool Upgrade(); /* returns true if settings upgraded */
+
     int rowCount(const QModelIndex & parent = QModelIndex()) const;
     QVariant data(const QModelIndex & index, int role = Qt::DisplayRole) const;
     bool setData(const QModelIndex & index, const QVariant & value, int role = Qt::EditRole);
@@ -42,10 +45,10 @@ public:
     int getDisplayUnit();
     bool getDisplayAddresses();
 private:
-    // Wallet stores persistent options
-    CWallet *wallet;
     int nDisplayUnit;
     bool bDisplayAddresses;
+    bool fMinimizeToTray;
+    bool fMinimizeOnClose;
 signals:
     void displayUnitChanged(int unit);
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -908,15 +908,28 @@ string GetConfigFile()
     return pathConfig.string();
 }
 
-void ReadConfigFile(map<string, string>& mapSettingsRet,
+bool ReadConfigFile(map<string, string>& mapSettingsRet,
                     map<string, vector<string> >& mapMultiSettingsRet)
 {
     namespace fs = boost::filesystem;
     namespace pod = boost::program_options::detail;
 
+    if (mapSettingsRet.count("-datadir"))
+    {
+        if (fs::is_directory(fs::system_complete(mapSettingsRet["-datadir"])))
+        {
+            fs::path pathDataDir = fs::system_complete(mapSettingsRet["-datadir"]);
+            strlcpy(pszSetDataDir, pathDataDir.string().c_str(), sizeof(pszSetDataDir));
+        }
+        else
+        {
+            return false;
+        }
+    }
+
     fs::ifstream streamConfig(GetConfigFile());
     if (!streamConfig.good())
-        return;
+        return true; // No bitcoin.conf file is OK
 
     set<string> setOptions;
     setOptions.insert("*");
@@ -933,6 +946,7 @@ void ReadConfigFile(map<string, string>& mapSettingsRet,
         }
         mapMultiSettingsRet[strKey].push_back(it->value[0]);
     }
+    return true;
 }
 
 string GetPidFile()

--- a/src/util.h
+++ b/src/util.h
@@ -151,7 +151,7 @@ void GetDataDir(char* pszDirRet);
 std::string GetConfigFile();
 std::string GetPidFile();
 void CreatePidFile(std::string pidFile, pid_t pid);
-void ReadConfigFile(std::map<std::string, std::string>& mapSettingsRet, std::map<std::string, std::vector<std::string> >& mapMultiSettingsRet);
+bool ReadConfigFile(std::map<std::string, std::string>& mapSettingsRet, std::map<std::string, std::vector<std::string> >& mapMultiSettingsRet);
 #ifdef WIN32
 std::string MyGetSpecialFolderPath(int nFolder, bool fCreate);
 #endif


### PR DESCRIPTION
The main motivation for this was a lot of frustration because command-line, bitcoin.conf, and wallet.dat settings were interacting in ill-defined ways.

Now GUI settings are stored in QT settings files; see
  http://developer.qt.nokia.com/doc/qt-4.8/qsettings.html#platform-specific-notes

... for details on where.  Testnet and main network have their own separate files (thanks @laanwj).

The first time you run with this patch settings from your wallet.dat will be read and moved over to the new settings file (and the settings erased from wallet.dat).  From then on, settings in the wallet.dat are ignored-- so if you're using --datadir and multiple wallets, don't expect the setting to be read/erased from the other wallets.

The 'proxy' setting is behaving badly (e.g. 127.0.0.1 is turned into an IP6-looking address), but I'm 90% sure that is a pre-existing bug based on other reports of weird strings in the proxy setting with the 0.6 release.  I'll file an issue about that.
