### PR TITLE
Fix addrProxy setting

### DIFF
--- a/src/db.cpp
+++ b/src/db.cpp
@@ -931,7 +931,21 @@ int CWalletDB::LoadWallet(CWallet* pwallet)
                 if (strKey == "fMinimizeToTray")    ssValue >> fMinimizeToTray;
                 if (strKey == "fMinimizeOnClose")   ssValue >> fMinimizeOnClose;
                 if (strKey == "fUseProxy")          ssValue >> fUseProxy;
-                if (strKey == "addrProxy")          ssValue >> addrProxy;
+                if (strKey == "addrProxy")
+                {
+                    CAddress addr; 
+                    CDataStream ssValue2 = ssValue;
+                    // 0.6.0rc1 saved this as a CService, which causes failure when parsing as a CAddress
+                    try
+                    {
+                        ssValue >> addr;
+                        addrProxy = addr;
+                    }
+                    catch (std::ios_base::failure &e)
+                    {
+                        ssValue2 >> addrProxy;
+                    }
+                }
                 if (fHaveUPnP && strKey == "fUseUPnP")           ssValue >> fUseUPnP;
             }
             else if (strType == "minversion")

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -91,7 +91,7 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
                 if (addr.IsValid())
                 {
                     addrProxy.SetIP(addr);
-                    walletdb.WriteSetting("addrProxy", addrProxy);
+                    walletdb.WriteSetting("addrProxy", CAddress(addrProxy));
                 }
                 else
                 {
@@ -105,7 +105,7 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
                 if (nPort > 0 && nPort < std::numeric_limits<unsigned short>::max())
                 {
                     addrProxy.SetPort(nPort);
-                    walletdb.WriteSetting("addrProxy", addrProxy);
+                    walletdb.WriteSetting("addrProxy", CAddress(addrProxy));
                 }
                 else
                 {


### PR DESCRIPTION
Before 0.6 addrProxy was a CAddress, but netbase changed it to CService.
Retain compatibility by wrapping/unwrapping with a CAddress when saving
or loading.

This commit retains compatibility with 0.6.0rc1 (which wrote the setting
as a CService) by trying to parse twice.

Fixes #814
