### PR TITLE
Reopen log file on SIGHUP

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -80,6 +80,10 @@ void HandleSIGTERM(int)
     fRequestShutdown = true;
 }
 
+void HandleSIGHUP(int)
+{
+    fReopenDebugLog = true;
+}
 
 
 
@@ -285,7 +289,13 @@ bool AppInit2()
     sa.sa_flags = 0;
     sigaction(SIGTERM, &sa, NULL);
     sigaction(SIGINT, &sa, NULL);
-    sigaction(SIGHUP, &sa, NULL);
+
+    // Reopen debug.log on SIGHUP
+    struct sigaction sa_hup;
+    sa_hup.sa_handler = HandleSIGHUP;
+    sigemptyset(&sa_hup.sa_mask);
+    sa_hup.sa_flags = 0;
+    sigaction(SIGHUP, &sa_hup, NULL);
 #endif
 
     fTestNet = GetBoolArg("-testnet");

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -25,6 +25,7 @@ namespace boost {
 #include <boost/filesystem.hpp>
 #include <boost/filesystem/fstream.hpp>
 #include <boost/foreach.hpp>
+#include <boost/thread.hpp>
 #include <openssl/crypto.h>
 #include <openssl/rand.h>
 #include <stdarg.h>
@@ -209,6 +210,8 @@ inline int OutputDebugStringF(const char* pszFormat, ...)
         if (fileout)
         {
             static bool fStartedNewLine = true;
+            static boost::mutex mutexDebugLog;
+            boost::mutex::scoped_lock scoped_lock(mutexDebugLog);
 
             // Debug print useful for profiling
             if (fLogTimestamps && fStartedNewLine)

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -70,6 +70,7 @@ bool fTestNet = false;
 bool fNoListen = false;
 bool fLogTimestamps = false;
 CMedianFilter<int64> vTimeOffsets(200,0);
+bool fReopenDebugLog = false;
 
 // Init openssl library multithreading support
 static CCriticalSection** ppmutexOpenSSL;
@@ -212,6 +213,14 @@ inline int OutputDebugStringF(const char* pszFormat, ...)
             static bool fStartedNewLine = true;
             static boost::mutex mutexDebugLog;
             boost::mutex::scoped_lock scoped_lock(mutexDebugLog);
+
+            // reopen the log file, if requested
+            if (fReopenDebugLog) {
+                fReopenDebugLog = false;
+                boost::filesystem::path pathDebug = GetDataDir() / "debug.log";
+                if (freopen(pathDebug.string().c_str(),"a",fileout) != NULL)
+                    setbuf(fileout, NULL); // unbuffered
+            }
 
             // Debug print useful for profiling
             if (fLogTimestamps && fStartedNewLine)

--- a/src/util.h
+++ b/src/util.h
@@ -121,6 +121,7 @@ extern std::string strMiscWarning;
 extern bool fTestNet;
 extern bool fNoListen;
 extern bool fLogTimestamps;
+extern bool fReopenDebugLog;
 
 void RandAddSeed();
 void RandAddSeedPerfmon();


### PR DESCRIPTION
This pull request is intended to facilitate bitcoind log rotation.  When the daemon receives a HUP signal, it reopens the debug.log file so the previous one can be rotated.  I've tried to describe the technical motivation in each of the three commit messages.  It uses flockfile and funlockfile to avoid thread contention issues.  As best I can tell, those functions are available on most platforms, but I have only compiled on OS X.

I have a test script which sends SIGHUP to the bitcoind process every 100 ms.  I've been running with that test script and this patch for the last few days and haven't had any problems.  In my tests, it behaves well during startup and shutdown too.  Each rotated log contains the content I expect.

Suggestions for improvement welcome.
