### PR TITLE
Make send coins dialog honor the configured unit type even on the first attempt.

### DIFF
--- a/src/qt/sendcoinsentry.cpp
+++ b/src/qt/sendcoinsentry.cpp
@@ -66,6 +66,7 @@ void SendCoinsEntry::on_payTo_textChanged(const QString &address)
 void SendCoinsEntry::setModel(WalletModel *model)
 {
     this->model = model;
+    clear();
 }
 
 void SendCoinsEntry::setRemoveEnabled(bool enabled)


### PR DESCRIPTION
This fixes the issue of send coins dialog initially having BTC selected as the unit to be sent even when, for example, mBTC is chosen as the default unit.
