### PR TITLE
Yet another attempt of a "minimize to tray" that works on all OSes

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -48,6 +48,7 @@
 #include <QMovie>
 #include <QFileDialog>
 #include <QDesktopServices>
+#include <QTimer>
 
 #include <QDragEnterEvent>
 #include <QUrl>
@@ -558,29 +559,21 @@ void BitcoinGUI::error(const QString &title, const QString &message)
 
 void BitcoinGUI::changeEvent(QEvent *e)
 {
+    QMainWindow::changeEvent(e);
 #ifndef Q_WS_MAC // Ignored on Mac
     if(e->type() == QEvent::WindowStateChange)
     {
         if(clientModel && clientModel->getOptionsModel()->getMinimizeToTray())
         {
             QWindowStateChangeEvent *wsevt = static_cast<QWindowStateChangeEvent*>(e);
-            bool wasMinimized = wsevt->oldState() & Qt::WindowMinimized;
-            bool isMinimized = windowState() & Qt::WindowMinimized;
-            if(!wasMinimized && isMinimized)
+            if(!(wsevt->oldState() & Qt::WindowMinimized) && isMinimized())
             {
-                // Minimized, hide the window from taskbar
-                setWindowFlags(windowFlags() | Qt::Tool);
-                return;
-            }
-            else if(wasMinimized && !isMinimized)
-            {
-                // Unminimized, show the window in taskbar
-                setWindowFlags(windowFlags() &~ Qt::Tool);
+                QTimer::singleShot(0, this, SLOT(hide()));
+                e->ignore();
             }
         }
     }
 #endif
-    QMainWindow::changeEvent(e);
 }
 
 void BitcoinGUI::closeEvent(QCloseEvent *event)


### PR DESCRIPTION
The current "minimize to tray" implementation has problems on Windows. It converts the window to a tool window, but when it is brought back it is not converted back to a normal window, causing strange behavior (such as an ugly title bar), as tool windows don't get a ChangeEvent on unminimization.

This implements the eventual suggestion from the Qt forums http://qt-project.org/forums/viewthread/4423/P15 .

I've tested it on Ubuntu and Windows (XP) and it works there. Can someone test it on KDE please? @sje397?

If we don't manage to get it right this time I'm going to remove the "minimize to tray" functionality completely (but not "Minimize on close" of course, because that works fine...). Or maybe keep it only on Windows.
