### PR TITLE
Move QMAKE_LIBS_QT_ENTRY adjustment to bitcoin side of build

### DIFF
--- a/bitcoin-qt.pro
+++ b/bitcoin-qt.pro
@@ -291,9 +291,20 @@ isEmpty(BOOST_INCLUDE_PATH) {
     macx:BOOST_INCLUDE_PATH = /opt/local/include
 }
 
-windows:LIBS += -lmingwthrd -lws2_32 -lshlwapi
-windows:DEFINES += _MT WIN32
+windows:LIBS += -lws2_32 -lshlwapi
+windows:DEFINES += WIN32
 windows:RC_FILE = src/qt/res/bitcoin-qt.rc
+
+windows:!contains(MINGW_THREAD_BUGFIX, 0) {
+    # At least qmake's win32-g++-cross profile is missing the -lmingwthrd
+    # thread-safety flag. GCC has -mthreads to enable this, but it doesn't
+    # work with static linking. -lmingwthrd must come BEFORE -lmingw, so
+    # it is prepended to QMAKE_LIBS_QT_ENTRY.
+    # It can be turned off with MINGW_THREAD_BUGFIX=0, just in case it causes
+    # any problems on some untested qmake profile now or in the future.
+    DEFINES += _MT
+    QMAKE_LIBS_QT_ENTRY = -lmingwthrd $$QMAKE_LIBS_QT_ENTRY
+}
 
 !windows:!mac {
     DEFINES += LINUX

--- a/contrib/gitian-descriptors/qt-win32.yml
+++ b/contrib/gitian-descriptors/qt-win32.yml
@@ -47,7 +47,6 @@ script: |
   cp -a bin $SRCDIR/
   cd $INSTDIR
   find . -name *.prl | xargs -l sed 's|/$||' -i
-  sed 's/QMAKE_LIBS_QT_ENTRY     = -lmingw32 -lqtmain/QMAKE_LIBS_QT_ENTRY     = -lqtmain/' -i mkspecs/unsupported/win32-g++-cross/qmake.conf
   #sed 's|QMAKE_PRL_LIBS.*|QMAKE_PRL_LIBS = -lQtDeclarative -lQtScript -lQtSvg -lQtSql -lQtXmlPatterns -lQtGui -lgdi32 -lcomdlg32 -loleaut32 -limm32 -lwinmm -lwinspool -lmsimg32 -lQtNetwork -lQtCore -lole32 -luuid -lws2_32 -ladvapi32 -lshell32 -luser32 -lkernel32|' -i imports/Qt/labs/particles/qmlparticlesplugin.prl
 
   # as zip stores file timestamps, use faketime to intercept stat calls to set dates for all files to reference date


### PR DESCRIPTION
It could just as well be on either part of the gitian build, but to safely put it on the Qt side would require bumping the filename, and every gitian user rebuilding it.
v0.5.3.1 put it on the Bitcoin side, and this is easier to work with and keep safe, so I'm moving it.
