### PR TITLE
When disconnecting a node, the receive buffer should be cleared

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -559,6 +559,7 @@ void CNode::CloseSocketDisconnect()
         printf("disconnecting node %s\n", addr.ToString().c_str());
         closesocket(hSocket);
         hSocket = INVALID_SOCKET;
+        vRecv.clear();
     }
 }
 


### PR DESCRIPTION
Currently, if a node is banned for misbehaviour the receive buffer, vRecv, is not cleared
and ProcessMessages continues to process any further messages already received from the node.

Thus, if a node spams hundreds of messages and does not wait for a response, all the messages
get processed, even if the node is banned after just a couple.

This patch clears the receive buffer when the socket is closed. Perhaps it should be done in Misbehaving() instead? But it seems logical that we never want to process messages from a disconnected node since we can't reply to them anyway.

EDIT: Two things I forgot to mention:

Firstly, I found this problem in litecoin, which is being actively attacked by spammers. I don't know for sure if bitcoin has this problem.

Secondly, this won't do much alone, because there is very little code to actually ban bad nodes. I am experimenting with detecting bad behaviour - ie adding banning code, and that's how I noticed this.
