### PR TITLE
VC2010 compile fixes

### DIFF
--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -2371,13 +2371,13 @@ void ThreadRPCServer2(void* parg)
             strWhatAmI = strprintf(_("To use the %s option"), "\"-server\"");
         else if (mapArgs.count("-daemon"))
             strWhatAmI = strprintf(_("To use the %s option"), "\"-daemon\"");
-        ::error(
-            _("%s, you must set a rpcpassword in the configuration file:\n %s\n"
-              "It is recommended you use the following random password:\n"
-              "rpcuser=bitcoinrpc\n"
-              "rpcpassword=%s\n"
-              "(you do not need to remember this password)\n"
-              "If the file does not exist, create it with owner-readable-only file permissions.\n"),
+        std::string strMessage = _("%s, you must set a rpcpassword in the configuration file:\n %s\n"
+                                          "It is recommended you use the following random password:\n"
+                                          "rpcuser=bitcoinrpc\n"
+                                          "rpcpassword=%s\n"
+                                          "(you do not need to remember this password)\n"
+                                          "If the file does not exist, create it with owner-readable-only file permissions.\n");
+        fprintf(stderr, strMessage.c_str(),
                 strWhatAmI.c_str(),
                 GetConfigFile().c_str(),
                 EncodeBase58(&rand_pwd[0],&rand_pwd[0]+32).c_str());

--- a/src/headers.h
+++ b/src/headers.h
@@ -18,7 +18,9 @@
 #endif
 #define _WIN32_IE 0x0400
 #define WIN32_LEAN_AND_MEAN 1
-
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
 // Include boost/foreach here as it defines __STDC_LIMIT_MACROS on some systems.
 #include <boost/foreach.hpp>
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -24,6 +24,10 @@ Q_IMPORT_PLUGIN(qkrcodecs)
 Q_IMPORT_PLUGIN(qtaccessiblewidgets)
 #endif
 
+#ifdef WIN32
+#define strncasecmp strnicmp
+#endif
+
 using namespace std;
 using namespace boost;
 

--- a/src/main.h
+++ b/src/main.h
@@ -11,6 +11,10 @@
 #include "script.h"
 #include "db.h"
 
+#ifdef WIN32
+#include <io.h> /* for _commit */
+#endif
+
 #include <list>
 
 class CBlock;
@@ -161,7 +165,7 @@ public:
     std::string ToString() const
     {
         if (IsNull())
-            return strprintf("null");
+            return "null";
         else
             return strprintf("(nFile=%d, nBlockPos=%d, nTxPos=%d)", nFile, nBlockPos, nTxPos);
     }
@@ -288,7 +292,7 @@ public:
     std::string ToString() const
     {
         std::string str;
-        str += strprintf("CTxIn(");
+        str += "CTxIn(";
         str += prevout.ToString();
         if (prevout.IsNull())
             str += strprintf(", coinbase %s", HexStr(scriptSig).c_str());

--- a/src/netbase.h
+++ b/src/netbase.h
@@ -9,6 +9,10 @@
 
 #ifdef WIN32
 #define _WIN32_WINNT 0x0501
+#define WIN32_LEAN_AND_MEAN 1
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
 #include <winsock2.h>
 #include <mswsock.h>
 #include <ws2tcpip.h>
@@ -29,6 +33,10 @@
 
 extern int nConnectTimeout;
 
+#ifdef WIN32
+// In MSVC, this is defined as a macro, undefine it to prevent a compile and link error
+#undef SetPort
+#endif
 
 /** IP address (IPv6, or IPv4 using mapped IPv6 range (::FFFF:0:0/96)) */
 class CNetAddr

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -123,6 +123,9 @@ std::string _(const char* psz)
     return QCoreApplication::translate("bitcoin-core", psz).toStdString();
 }
 
+#ifdef WIN32
+#define strncasecmp strnicmp
+#endif
 #ifndef BITCOIN_QT_TEST
 int main(int argc, char *argv[])
 {

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -1,4 +1,4 @@
-#include <transactiondesc.h>
+#include "transactiondesc.h"
 
 #include "guiutil.h"
 #include "bitcoinunits.h"

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -10,8 +10,9 @@ class AddressTableModel;
 class TransactionTableModel;
 class CWallet;
 
-struct SendCoinsRecipient
+class SendCoinsRecipient
 {
+public:
     QString address;
     QString label;
     qint64 amount;

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -24,12 +24,15 @@ typedef unsigned long long  uint64;
 
 #ifdef WIN32
 #define _WIN32_WINNT 0x0501
+#define WIN32_LEAN_AND_MEAN 1
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
 #include <windows.h>
 // This is used to attempt to keep keying material out of swap
 // Note that VirtualLock does not provide this as a guarantee on Windows,
 // but, in practice, memory that has been VirtualLock'd almost never gets written to
 // the pagefile except in rare circumstances where memory is extremely low.
-#include <windows.h>
 #define mlock(p, n) VirtualLock((p), (n));
 #define munlock(p, n) VirtualUnlock((p), (n));
 #else

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -265,7 +265,7 @@ int my_snprintf(char* buffer, size_t limit, const char* format, ...)
     return ret;
 }
 
-string strprintf(const std::string &format, ...)
+string real_strprintf(const std::string &format, int dummy, ...)
 {
     char buffer[50000];
     char* p = buffer;
@@ -274,7 +274,7 @@ string strprintf(const std::string &format, ...)
     loop
     {
         va_list arg_ptr;
-        va_start(arg_ptr, format);
+        va_start(arg_ptr, dummy);
         ret = _vsnprintf(p, limit, format.c_str(), arg_ptr);
         va_end(arg_ptr);
         if (ret >= 0 && ret < limit)
@@ -292,13 +292,13 @@ string strprintf(const std::string &format, ...)
     return str;
 }
 
-bool error(const std::string &format, ...)
+bool error(const char *format, ...)
 {
     char buffer[50000];
     int limit = sizeof(buffer);
     va_list arg_ptr;
     va_start(arg_ptr, format);
-    int ret = _vsnprintf(buffer, limit, format.c_str(), arg_ptr);
+    int ret = _vsnprintf(buffer, limit, format, arg_ptr);
     va_end(arg_ptr);
     if (ret < 0 || ret >= limit)
     {

--- a/src/util.h
+++ b/src/util.h
@@ -11,6 +11,8 @@
 #include <sys/types.h>
 #include <sys/time.h>
 #include <sys/resource.h>
+#else
+typedef int pid_t; /* define for windows compatiblity */
 #endif
 #include <map>
 #include <vector>
@@ -128,8 +130,15 @@ void RandAddSeed();
 void RandAddSeedPerfmon();
 int OutputDebugStringF(const char* pszFormat, ...);
 int my_snprintf(char* buffer, size_t limit, const char* format, ...);
-std::string strprintf(const std::string &format, ...);
-bool error(const std::string &format, ...);
+
+/* It is not allowed to use va_start with a pass-by-reference argument.
+   (C++ standard, 18.7, paragraph 3). Use a dummy argument to work around this, and use a
+   macro to keep similar semantics.
+*/
+std::string real_strprintf(const std::string &format, int dummy, ...);
+#define strprintf(format, ...) real_strprintf(format, 0, __VA_ARGS__)
+
+bool error(const char *format, ...);
 void LogException(std::exception* pex, const char* pszThread);
 void PrintException(std::exception* pex, const char* pszThread);
 void PrintExceptionContinue(std::exception* pex, const char* pszThread);


### PR DESCRIPTION
I spent some time today trying to get Bitcoin to compile with MSVC2010. Eventually got it to work nicely. I'll publish the solution and build files this week. 

However there were quite some surprises:
- Define `WIN32_LEAN_AND_MEAN` in serialize.h to prevent winsock compile errors.
- CService::SetPort, was mysterious unresolved external. Turned out to be a macro issue, windows defines SetPort
- strprintf problem: http://stackoverflow.com/questions/222195/are-there-gotchas-using-varargs-with-reference-parameters
  - works in g++, but in MSVC causes horrible crashes. 
- `NOMINMAX` needs to be defined before include of windows.h to prevent windows from defining min and max macros, and std::min and std::max from causing compile errors
- `pid_t` needs to be defined for compatibility

All these are fixed in this patch. The changes are trivial.

This still builds in Linux, however I still need to test whether this doesn't break the gitian cross-compile.
