### PR TITLE
Use unpadded encryption for wallet keys (fixes #933)

### DIFF
--- a/src/crypter.h
+++ b/src/crypter.h
@@ -67,8 +67,8 @@ private:
 
 public:
     bool SetKeyFromPassphrase(const SecureString &strKeyData, const std::vector<unsigned char>& chSalt, const unsigned int nRounds, const unsigned int nDerivationMethod);
-    bool Encrypt(const CKeyingMaterial& vchPlaintext, std::vector<unsigned char> &vchCiphertext);
-    bool Decrypt(const std::vector<unsigned char>& vchCiphertext, CKeyingMaterial& vchPlaintext);
+    bool Encrypt(const CKeyingMaterial& vchPlaintext, std::vector<unsigned char> &vchCiphertext, bool fPad = true);
+    bool Decrypt(const std::vector<unsigned char>& vchCiphertext, CKeyingMaterial& vchPlaintext, bool fPad = true);
     bool SetKey(const CKeyingMaterial& chNewKey, const std::vector<unsigned char>& chNewIV);
 
     void CleanKey()


### PR DESCRIPTION
Wallet keys are 32 bytes, exactly two AES blocks. Using padded encryption makes attacking somewhat easier, as the attacker can check whether the padding is correct after decrypting using an attempted passphrase, rather than needing to do an EC multiplication to check whether the private and public keys match.
