### PR TITLE
Limit getheaders to a hard 2000.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2496,8 +2496,8 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
         }
 
         vector<CBlock> vHeaders;
-        int nLimit = 2000 + locator.GetDistanceBack();
-        printf("getheaders %d to %s limit %d\n", (pindex ? pindex->nHeight : -1), hashStop.ToString().substr(0,20).c_str(), nLimit);
+        int nLimit = 2000;
+        printf("getheaders %d to %s\n", (pindex ? pindex->nHeight : -1), hashStop.ToString().substr(0,20).c_str());
         for (; pindex; pindex = pindex->pnext)
         {
             vHeaders.push_back(pindex->GetBlockHeader());


### PR DESCRIPTION
Previously getheaders would return any number of headers up to
2000 + the distance the locator parameter was back (which is up to
~ the number of items in the locator ^ 2).

The only client I was able to find which actually handles the headers
message is BitcoinJ, and it clearly expects no more than 2000 headers
See:
http://code.google.com/p/bitcoinj/source/browse/core/src/main/java/com/google/bitcoin/core/HeadersMessage.java#35

Additionally, the wiki clearly states that getheaders will only ever
return 2000 headers: https://en.bitcoin.it/wiki/Network#Messages
