### PR TITLE
Added ability to respond to signals during Block Loading stage.

### DIFF
--- a/src/db.cpp
+++ b/src/db.cpp
@@ -529,7 +529,7 @@ bool CTxDB::LoadBlockIndex()
         // Unserialize
         string strType;
         ssKey >> strType;
-        if (strType == "blockindex")
+        if (strType == "blockindex" && !fRequestShutdown)
         {
             CDiskBlockIndex diskindex;
             ssValue >> diskindex;
@@ -556,10 +556,13 @@ bool CTxDB::LoadBlockIndex()
         }
         else
         {
-            break;
+            break; // if shutdown requested or finished loading block index
         }
     }
     pcursor->close();
+
+    if (fRequestShutdown)
+        return true;
 
     // Calculate bnChainWork
     vector<pair<int, CBlockIndex*> > vSortedByHeight;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -353,6 +353,15 @@ bool AppInit2(int argc, char* argv[])
     nStart = GetTimeMillis();
     if (!LoadBlockIndex())
         strErrors << _("Error loading blkindex.dat") << "\n";
+
+    // as LoadBlockIndex can take several minutes, it's possible the user
+    // requested to kill bitcoin-qt during the last operation. If so, exit.
+    // As the program has not fully started yet, Shutdown() is possibly overkill.
+    if (fRequestShutdown)
+    {
+        printf("Shutdown requested. Exiting.\n");
+        return false;
+    }
     printf(" block index %15"PRI64d"ms\n", GetTimeMillis() - nStart);
 
     InitMessage(_("Loading wallet..."));


### PR DESCRIPTION
As the Loading of the Block Index can take several minutes, it's possible the user might want to exit the process during this, and so far the only way was with a kill -9. This small change allows the Block Index Loading to watch out for a requested exit, and abort during the process.

It's been tested on my computer so far.

Without this change: the bitcoin-qt process is unkillable (without a kill -9) during the initial Loading of the Block Index. This goes against standards for processes, which should try to exit cleanly as soon as a kill signal is sent.
