### PR TITLE
Remove "minimize to tray"

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -557,32 +557,12 @@ void BitcoinGUI::error(const QString &title, const QString &message)
     notificator->notify(Notificator::Critical, title, message);
 }
 
-void BitcoinGUI::changeEvent(QEvent *e)
-{
-    QMainWindow::changeEvent(e);
-#ifndef Q_WS_MAC // Ignored on Mac
-    if(e->type() == QEvent::WindowStateChange)
-    {
-        if(clientModel && clientModel->getOptionsModel()->getMinimizeToTray())
-        {
-            QWindowStateChangeEvent *wsevt = static_cast<QWindowStateChangeEvent*>(e);
-            if(!(wsevt->oldState() & Qt::WindowMinimized) && isMinimized())
-            {
-                QTimer::singleShot(0, this, SLOT(hide()));
-                e->ignore();
-            }
-        }
-    }
-#endif
-}
-
 void BitcoinGUI::closeEvent(QCloseEvent *event)
 {
     if(clientModel)
     {
 #ifndef Q_WS_MAC // Ignored on Mac
-        if(!clientModel->getOptionsModel()->getMinimizeToTray() &&
-           !clientModel->getOptionsModel()->getMinimizeOnClose())
+        if(!clientModel->getOptionsModel()->getMinimizeOnClose())
         {
             qApp->quit();
         }

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -47,7 +47,6 @@ public:
     void setWalletModel(WalletModel *walletModel);
     
 protected:
-    void changeEvent(QEvent *e);
     void closeEvent(QCloseEvent *event);
     void dragEnterEvent(QDragEnterEvent *event);
     void dropEvent(QDropEvent *event);

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -30,9 +30,6 @@ public:
     void setMapper(MonitoredDataMapper *mapper);
 private:
     QCheckBox *bitcoin_at_startup;
-#ifndef Q_WS_MAC
-    QCheckBox *minimize_to_tray;
-#endif
     QCheckBox *map_port_upnp;
 #ifndef Q_WS_MAC
     QCheckBox *minimize_on_close;
@@ -171,12 +168,6 @@ MainOptionsPage::MainOptionsPage(QWidget *parent):
     bitcoin_at_startup->setToolTip(tr("Automatically start Bitcoin after the computer is turned on"));
     layout->addWidget(bitcoin_at_startup);
 
-#ifndef Q_WS_MAC
-    minimize_to_tray = new QCheckBox(tr("&Minimize to the tray instead of the taskbar"));
-    minimize_to_tray->setToolTip(tr("Show only a tray icon after minimizing the window"));
-    layout->addWidget(minimize_to_tray);
-#endif
-
     map_port_upnp = new QCheckBox(tr("Map port using &UPnP"));
     map_port_upnp->setToolTip(tr("Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled."));
     layout->addWidget(map_port_upnp);
@@ -247,9 +238,6 @@ void MainOptionsPage::setMapper(MonitoredDataMapper *mapper)
 {
     // Map model to widgets
     mapper->addMapping(bitcoin_at_startup, OptionsModel::StartAtStartup);
-#ifndef Q_WS_MAC
-    mapper->addMapping(minimize_to_tray, OptionsModel::MinimizeToTray);
-#endif
     mapper->addMapping(map_port_upnp, OptionsModel::MapPortUPnP);
 #ifndef Q_WS_MAC
     mapper->addMapping(minimize_on_close, OptionsModel::MinimizeOnClose);

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -18,7 +18,6 @@ void OptionsModel::Init()
     // These are QT-only settings:
     nDisplayUnit = settings.value("nDisplayUnit", BitcoinUnits::BTC).toInt();
     bDisplayAddresses = settings.value("bDisplayAddresses", false).toBool();
-    fMinimizeToTray = settings.value("fMinimizeToTray", false).toBool();
     fMinimizeOnClose = settings.value("fMinimizeOnClose", false).toBool();
     nTransactionFee = settings.value("nTransactionFee").toLongLong();
 
@@ -103,8 +102,6 @@ QVariant OptionsModel::data(const QModelIndex & index, int role) const
         {
         case StartAtStartup:
             return QVariant(GetStartOnSystemStartup());
-        case MinimizeToTray:
-            return QVariant(fMinimizeToTray);
         case MapPortUPnP:
             return settings.value("fUseUPnP", GetBoolArg("-upnp", true));
         case MinimizeOnClose:
@@ -138,10 +135,6 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
         {
         case StartAtStartup:
             successful = SetStartOnSystemStartup(value.toBool());
-            break;
-        case MinimizeToTray:
-            fMinimizeToTray = value.toBool();
-            settings.setValue("fMinimizeToTray", fMinimizeToTray);
             break;
         case MapPortUPnP:
             {
@@ -214,11 +207,6 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
 qint64 OptionsModel::getTransactionFee()
 {
     return nTransactionFee;
-}
-
-bool OptionsModel::getMinimizeToTray()
-{
-    return fMinimizeToTray;
 }
 
 bool OptionsModel::getMinimizeOnClose()

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -17,7 +17,6 @@ public:
 
     enum OptionID {
         StartAtStartup, // bool
-        MinimizeToTray, // bool
         MapPortUPnP, // bool
         MinimizeOnClose, // bool
         ConnectSOCKS4, // bool
@@ -47,7 +46,6 @@ public:
 private:
     int nDisplayUnit;
     bool bDisplayAddresses;
-    bool fMinimizeToTray;
     bool fMinimizeOnClose;
 signals:
     void displayUnitChanged(int unit);


### PR DESCRIPTION
I've had it with this "feature". I've had a lot of patience with it but... see pull requests #941, #826, #853, #795, #855 and issues #620, #692, #788... 

It appears impossible to implement this functionality in Qt without breaking in some OS, or some combination, or breaking something else. And I wasted too much time on it. I've tried four different implementations at least.

If someone has a perfect implementation that works on all OSes _and feels like testing it extensively_ then be my guest and submit a new implementation as pull request. 

Please use "Close to tray" instead.
