### PR TITLE
discussion on number of outbound connections (limited to 8)

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -24,7 +24,8 @@
 using namespace std;
 using namespace boost;
 
-static const int MAX_OUTBOUND_CONNECTIONS = 8;
+static const int MAX_OUTBOUND_CONNECTIONS = 125;
+static const int MIN_OUTBOUND_CONNECTIONS = 1;
 
 void ThreadMessageHandler2(void* parg);
 void ThreadSocketHandler2(void* parg);
@@ -805,7 +806,7 @@ void ThreadSocketHandler2(void* parg)
                 if (WSAGetLastError() != WSAEWOULDBLOCK)
                     printf("socket error accept failed: %d\n", WSAGetLastError());
             }
-            else if (nInbound >= GetArg("-maxconnections", 125) - MAX_OUTBOUND_CONNECTIONS)
+            else if (nInbound >= max(min((int)GetArg("-maxconnections", 125), MAX_OUTBOUND_CONNECTIONS), MIN_OUTBOUND_CONNECTIONS))
             {
                 CRITICAL_BLOCK(cs_setservAddNodeAddresses)
                     if (!setservAddNodeAddresses.count(addr))
@@ -1340,8 +1341,7 @@ void ThreadOpenConnections2(void* parg)
                 BOOST_FOREACH(CNode* pnode, vNodes)
                     if (!pnode->fInbound)
                         nOutbound++;
-            int nMaxOutboundConnections = MAX_OUTBOUND_CONNECTIONS;
-            nMaxOutboundConnections = min(nMaxOutboundConnections, (int)GetArg("-maxconnections", 125));
+            int nMaxOutboundConnections = max(min((int)GetArg("-maxconnections", 125), MAX_OUTBOUND_CONNECTIONS), MIN_OUTBOUND_CONNECTIONS);
             if (nOutbound < nMaxOutboundConnections)
                 break;
             vnThreadsRunning[THREAD_OPENCONNECTIONS]--;


### PR DESCRIPTION
old behaviour:
- if -maxconnections is 0 or negative, no connection to the network was established at all
- the maximum number of connections was in range 0 to 8 (125 was unused)

new behavior:
- if -maxconnections is 0 or negative, MIN_OUTBOUND_CONNECTIONS will be used to ensure connectivity
- if -maxconnections is unset Gavins intended default of 125 is used
- if -maxconnections is > MAX_OUTBOUND_CONNECTIONS, MAX_OUTBOUND_CONNECTIONS is used

Perhaps the value of MAX_OUTBOUND_CONNECTIONS and MIN_OUTBOUND_CONNECTIONS should be refined further.

I tested the changes on Windows and can confirm they work. Oh and I think this "bug" or let's say strange behaviour was introduced by Gavins commit to set defaults to 125. I was so sure, that I saw more than 8 connections before 0.6, but no one seems to have noticed?
