### PR TITLE
The generic UNIX Makefile builds with lots of warnings

### DIFF
--- a/src/makefile.unix
+++ b/src/makefile.unix
@@ -85,7 +85,7 @@ LIBS+= \
 
 DEBUGFLAGS=-g
 CXXFLAGS=-O2
-xCXXFLAGS=-pthread -Wextra -Wno-sign-compare -Wno-char-subscripts -Wno-invalid-offsetof -Wformat-security \
+xCXXFLAGS=-pthread -Wextra -Wno-sign-compare -Wno-char-subscripts -Wno-invalid-offsetof -Wformat -Wformat-security \
     $(DEBUGFLAGS) $(DEFS) $(HARDENING) $(CXXFLAGS)
 
 OBJS= \


### PR DESCRIPTION
Hi bitcoin team,

I have just made this trivial change on my system (NetBSD/amd64 6.0_BETA) so that compilation warnings are more relevant. Without it, each file compiled triggers this message:
`cc1plus: warning: -Wformat-security ignored without -Wformat`

FWIW, "gcc --version" returns:
`gcc (NetBSD nb2 20110806) 4.5.3`

Cheers,
-- khorben
