### PR TITLE
Remove -bip16 and -paytoscripthashtime command-line arguments

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -489,24 +489,11 @@ bool AppInit2(int argc, char* argv[])
     fAllowDNS = GetBoolArg("-dns");
     fNoListen = !GetBoolArg("-listen", true);
 
-    // This code can be removed once a super-majority of the network has upgraded.
-    if (GetBoolArg("-bip16", true))
-    {
-        if (fTestNet)
-            SoftSetArg("-paytoscripthashtime", "1329264000"); // Feb 15
-        else
-            SoftSetArg("-paytoscripthashtime", "1333238400"); // April 1 2012
-
-        // Put "/P2SH/" in the coinbase so everybody can tell when
-        // a majority of miners support it
-        const char* pszP2SH = "/P2SH/";
-        COINBASE_FLAGS << std::vector<unsigned char>(pszP2SH, pszP2SH+strlen(pszP2SH));
-    }
-    else
-    {
-        const char* pszP2SH = "NOP2SH";
-        COINBASE_FLAGS << std::vector<unsigned char>(pszP2SH, pszP2SH+strlen(pszP2SH));
-    }
+    // Continue to put "/P2SH/" in the coinbase to monitor
+    // BIP16 support.
+    // This can be removed eventually...
+    const char* pszP2SH = "/P2SH/";
+    COINBASE_FLAGS << std::vector<unsigned char>(pszP2SH, pszP2SH+strlen(pszP2SH));
 
     if (!fNoListen)
     {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1278,12 +1278,9 @@ bool CBlock::ConnectBlock(CTxDB& txdb, CBlockIndex* pindex)
                         return false;
         }
 
-    // To avoid being on the short end of a block-chain split,
-    // don't do secondary validation of pay-to-script-hash transactions
-    // until blocks with timestamps after paytoscripthashtime (see init.cpp for default).
-    // This code can be removed once a super-majority of the network has upgraded.
-    int64 nEvalSwitchTime = GetArg("-paytoscripthashtime", std::numeric_limits<int64_t>::max());
-    bool fStrictPayToScriptHash = (pindex->nTime >= nEvalSwitchTime);
+    // BIP16 didn't become active until Apr 1 2012 (Feb 15 on testnet)
+    int64 nBIP16SwitchTime = fTestNet ? 1329264000 : 1333238400;
+    bool fStrictPayToScriptHash = (pindex->nTime >= nBIP16SwitchTime);
 
     //// issue here: it doesn't know the version
     unsigned int nTxPos = pindex->nBlockPos + ::GetSerializeSize(CBlock(), SER_DISK) - 1 + GetSizeOfCompactSize(vtx.size());


### PR DESCRIPTION
Now that the BIP16 switchover is locked-in, I think it is best to remove the command-line arguments that were only needed during the transition period.
