### PR TITLE
fix boost::filesystem::path for WIN32 ('\' instead of '/')

### DIFF
--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -15,7 +15,6 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/asio/ssl.hpp> 
-#include <boost/filesystem.hpp>
 #include <boost/filesystem/fstream.hpp>
 typedef boost::asio::ssl::stream<boost::asio::ip::tcp::socket> SSLStream;
 
@@ -2385,18 +2384,21 @@ void ThreadRPCServer2(void* parg)
     if (fUseSSL)
     {
         context.set_options(ssl::context::no_sslv2);
-        filesystem::path certfile = GetArg("-rpcsslcertificatechainfile", "server.cert");
-        if (!certfile.is_complete()) certfile = filesystem::path(GetDataDir()) / certfile;
-        if (filesystem::exists(certfile)) context.use_certificate_chain_file(certfile.string().c_str());
-        else printf("ThreadRPCServer ERROR: missing server certificate file %s\n", certfile.string().c_str());
-        filesystem::path pkfile = GetArg("-rpcsslprivatekeyfile", "server.pem");
-        if (!pkfile.is_complete()) pkfile = filesystem::path(GetDataDir()) / pkfile;
-        if (filesystem::exists(pkfile)) context.use_private_key_file(pkfile.string().c_str(), ssl::context::pem);
-        else printf("ThreadRPCServer ERROR: missing server private key file %s\n", pkfile.string().c_str());
 
-        string ciphers = GetArg("-rpcsslciphers",
-                                         "TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!AH:!3DES:@STRENGTH");
-        SSL_CTX_set_cipher_list(context.impl(), ciphers.c_str());
+        filesystem::path pathCertFile(GetArg("-rpcsslcertificatechainfile", "server.cert"));
+        if (!pathCertFile.is_complete()) pathCertFile = filesystem::path(GetDataDir()) / pathCertFile;
+        pathCertFile.make_preferred();
+        if (filesystem::exists(pathCertFile)) context.use_certificate_chain_file(certfile.string().c_str());
+        else printf("ThreadRPCServer ERROR: missing server certificate file %s\n", pathCertFile.string().c_str());
+
+        filesystem::path pathPKFile(GetArg("-rpcsslprivatekeyfile", "server.pem"));
+        if (!pathPKFile.is_complete()) pathPKFile = filesystem::path(GetDataDir()) / pathPKFile;
+        pathPKFile.make_preferred();
+        if (filesystem::exists(pathPKFile)) context.use_private_key_file(pkfile.string().c_str(), ssl::context::pem);
+        else printf("ThreadRPCServer ERROR: missing server private key file %s\n", pathPKFile.string().c_str());
+
+        string strCiphers = GetArg("-rpcsslciphers", "TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!AH:!3DES:@STRENGTH");
+        SSL_CTX_set_cipher_list(context.impl(), strCiphers.c_str());
     }
 
     loop

--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -2388,13 +2388,13 @@ void ThreadRPCServer2(void* parg)
         filesystem::path pathCertFile(GetArg("-rpcsslcertificatechainfile", "server.cert"));
         if (!pathCertFile.is_complete()) pathCertFile = filesystem::path(GetDataDir()) / pathCertFile;
         pathCertFile.make_preferred();
-        if (filesystem::exists(pathCertFile)) context.use_certificate_chain_file(certfile.string().c_str());
+        if (filesystem::exists(pathCertFile)) context.use_certificate_chain_file(pathCertFile.string().c_str());
         else printf("ThreadRPCServer ERROR: missing server certificate file %s\n", pathCertFile.string().c_str());
 
         filesystem::path pathPKFile(GetArg("-rpcsslprivatekeyfile", "server.pem"));
         if (!pathPKFile.is_complete()) pathPKFile = filesystem::path(GetDataDir()) / pathPKFile;
         pathPKFile.make_preferred();
-        if (filesystem::exists(pathPKFile)) context.use_private_key_file(pkfile.string().c_str(), ssl::context::pem);
+        if (filesystem::exists(pathPKFile)) context.use_private_key_file(pathPKFile.string().c_str(), ssl::context::pem);
         else printf("ThreadRPCServer ERROR: missing server private key file %s\n", pathPKFile.string().c_str());
 
         string strCiphers = GetArg("-rpcsslciphers", "TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!AH:!3DES:@STRENGTH");

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -79,19 +79,21 @@ CDB::CDB(const char* pszFile, const char* pszMode) : pdb(NULL)
             if (fShutdown)
                 return;
             string strDataDir = GetDataDir();
-            string strLogDir = strDataDir + "/database";
-            filesystem::create_directory(strLogDir.c_str());
-            string strErrorFile = strDataDir + "/db.log";
-            printf("dbenv.open strLogDir=%s strErrorFile=%s\n", strLogDir.c_str(), strErrorFile.c_str());
+            filesystem::path pathLogDir(strDataDir + "/database");
+            pathLogDir.make_preferred();
+            filesystem::create_directory(pathLogDir);
+            filesystem::path pathErrorFile(strDataDir + "/db.log");
+            pathErrorFile.make_preferred();
+            printf("dbenv.open LogDir=%s ErrorFile=%s\n", pathLogDir.string().c_str(), pathErrorFile.string().c_str());
 
             int nDbCache = GetArg("-dbcache", 25);
-            dbenv.set_lg_dir(strLogDir.c_str());
+            dbenv.set_lg_dir(pathLogDir.string().c_str());
             dbenv.set_cachesize(nDbCache / 1024, (nDbCache % 1024)*1048576, 1);
             dbenv.set_lg_bsize(1048576);
             dbenv.set_lg_max(10485760);
             dbenv.set_lk_max_locks(10000);
             dbenv.set_lk_max_objects(10000);
-            dbenv.set_errfile(fopen(strErrorFile.c_str(), "a")); /// debug
+            dbenv.set_errfile(fopen(pathErrorFile.string().c_str(), "a")); /// debug
             dbenv.set_flags(DB_AUTO_COMMIT, 1);
             dbenv.log_set_config(DB_LOG_AUTO_REMOVE, 1);
             ret = dbenv.open(strDataDir.c_str(),
@@ -1172,7 +1174,9 @@ bool BackupWallet(const CWallet& wallet, const string& strDest)
 
                 // Copy wallet.dat
                 filesystem::path pathSrc(GetDataDir() + "/" + wallet.strWalletFile);
+                pathSrc.make_preferred();
                 filesystem::path pathDest(strDest);
+                pathDest.make_preferred();
                 if (filesystem::is_directory(pathDest))
                     pathDest = pathDest / wallet.strWalletFile;
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -2,6 +2,7 @@
 // Copyright (c) 2009-2012 The Bitcoin developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file license.txt or http://www.opensource.org/licenses/mit-license.php.
+
 #include "headers.h"
 #include "strlcpy.h"
 #include <boost/algorithm/string/join.hpp>
@@ -858,10 +859,11 @@ string GetDataDir()
 string GetConfigFile()
 {
     namespace fs = boost::filesystem;
-    fs::path pathConfig(GetArg("-conf", "bitcoin.conf"));
-    if (!pathConfig.is_complete())
-        pathConfig = fs::path(GetDataDir()) / pathConfig;
-    return pathConfig.string();
+
+    fs::path pathConfigFile(GetArg("-conf", "bitcoin.conf"));
+    if (!pathConfigFile.is_complete()) pathConfigFile = fs::path(GetDataDir()) / pathConfigFile;
+    pathConfigFile.make_preferred();
+    return pathConfigFile.string();
 }
 
 bool ReadConfigFile(map<string, string>& mapSettingsRet,
@@ -874,7 +876,9 @@ bool ReadConfigFile(map<string, string>& mapSettingsRet,
     {
         if (fs::is_directory(fs::system_complete(mapSettingsRet["-datadir"])))
         {
-            fs::path pathDataDir = fs::system_complete(mapSettingsRet["-datadir"]);
+            fs::path pathDataDir(fs::system_complete(mapSettingsRet["-datadir"]));
+            pathDataDir.make_preferred();
+
             strlcpy(pszSetDataDir, pathDataDir.string().c_str(), sizeof(pszSetDataDir));
         }
         else
@@ -908,10 +912,11 @@ bool ReadConfigFile(map<string, string>& mapSettingsRet,
 string GetPidFile()
 {
     namespace fs = boost::filesystem;
-    fs::path pathConfig(GetArg("-pid", "bitcoind.pid"));
-    if (!pathConfig.is_complete())
-        pathConfig = fs::path(GetDataDir()) / pathConfig;
-    return pathConfig.string();
+
+    fs::path pathPidFile(GetArg("-pid", "bitcoind.pid"));
+    if (!pathPidFile.is_complete()) pathPidFile = fs::path(GetDataDir()) / pathPidFile;
+    pathPidFile.make_preferred();
+    return pathPidFile.string();
 }
 
 void CreatePidFile(string pidFile, pid_t pid)


### PR DESCRIPTION
This commit fixes the filesystem paths to be Windows-style on Windows.

Currently this was added for the database directory, the database log, the dst and src path in the backup wallet operation, server.cert, server.pem, bitcoin.conf and bitcoind.pid.

Example from the debug.log:
old: dbenv.open strLogDir=D:\Bitcoin\Wallet/database strErrorFile=D:\Bitcoin\Wallet/db.log
new: dbenv.open LogDir=D:\Bitcoin\Wallet\database ErrorFile=D:\Bitcoin\Wallet\db.log

Tested on my Win7 machine and works.
