### PR TITLE
Introduce explicit -walletupgrade option

### DIFF
--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -336,6 +336,7 @@ Value getinfo(const Array& params, bool fHelp)
     Object obj;
     obj.push_back(Pair("version",       (int)CLIENT_VERSION));
     obj.push_back(Pair("protocolversion",(int)PROTOCOL_VERSION));
+    obj.push_back(Pair("walletversion", pwalletMain->GetVersion()));
     obj.push_back(Pair("balance",       ValueFromAmount(pwalletMain->GetBalance())));
     obj.push_back(Pair("blocks",        (int)nBestHeight));
     obj.push_back(Pair("connections",   (int)vNodes.size()));


### PR DESCRIPTION
Do not automatically change the wallet format unless the user takes an explicit action that implies an upgrade (encrypting, for now), or uses -walletupgrade.

-walletupgrade optionally takes an integer argument: the client version up to which upgrading is allowed. Without an argument, it is upgraded to latest supported version. If an argument to -walletupgrade is provided at the time the wallet is created, the new wallet will initially not use features beyond that version.

Third, the current wallet version number is reported in getinfo.
