### PR TITLE
Check minversion before loading the rest of the wallet

### DIFF
--- a/src/db.cpp
+++ b/src/db.cpp
@@ -771,6 +771,14 @@ int CWalletDB::LoadWallet(CWallet* pwallet)
     //// todo: shouldn't we catch exceptions and try to recover and continue?
     CRITICAL_BLOCK(pwallet->cs_wallet)
     {
+        int nMinVersion = 0;
+        if (Read((string)"minversion", nMinVersion))
+        {
+            if (nMinVersion > CLIENT_VERSION)
+                return DB_TOO_NEW;
+            pwallet->LoadMinVersion(nMinVersion);
+        }
+
         // Get cursor
         Dbc* pcursor = GetCursor();
         if (!pcursor)
@@ -939,14 +947,6 @@ int CWalletDB::LoadWallet(CWallet* pwallet)
                 ssValue >> nFileVersion;
                 if (nFileVersion == 10300)
                     nFileVersion = 300;
-            }
-            else if (strType == "minversion")
-            {
-                int nMinVersion = 0;
-                ssValue >> nMinVersion;
-                if (nMinVersion > CLIENT_VERSION)
-                    return DB_TOO_NEW;
-                pwallet->LoadMinVersion(nMinVersion);
             }
             else if (strType == "cscript")
             {


### PR DESCRIPTION
When a 0.6 wallet with compressed pubkeys is created, it writes a minversion record to prevent older clients from reading it. If the 0.5 loading it sees a key record before seeing the minversion record however, it will fail with DB_CORRUPT instead of DB_TOO_NEW.

This is more needed in backports than in mainline for now, but it's code improvement in any case.
