### PR TITLE
Windows compilation updates / fixes (bitcoin-qt.pro)

### DIFF
--- a/bitcoin-qt.pro
+++ b/bitcoin-qt.pro
@@ -87,7 +87,7 @@ contains(BITCOIN_NEED_QT_PLUGINS, 1) {
 }
 
 # disable quite some warnings because bitcoin core "sins" a lot
-QMAKE_CXXFLAGS_WARN_ON = -fdiagnostics-show-option -Wall -Wno-strict-aliasing -Wno-invalid-offsetof -Wno-unused-variable -Wno-unused-parameter -Wno-sign-compare -Wno-char-subscripts  -Wno-unused-value -Wno-sequence-point -Wno-parentheses -Wno-unknown-pragmas -Wno-switch
+QMAKE_CXXFLAGS_WARN_ON = -fdiagnostics-show-option -Wall -Wno-strict-aliasing -Wno-invalid-offsetof -Wno-unused-variable -Wno-unused-parameter -Wno-sign-compare -Wno-char-subscripts -Wno-unused-value -Wno-sequence-point -Wno-parentheses -Wno-unknown-pragmas -Wno-switch
 
 # Input
 DEPENDPATH += src/qt src src json/include
@@ -325,7 +325,7 @@ INCLUDEPATH += $$BOOST_INCLUDE_PATH $$BDB_INCLUDE_PATH $$OPENSSL_INCLUDE_PATH $$
 LIBS += $$join(BOOST_LIB_PATH,,-L,) $$join(BDB_LIB_PATH,,-L,) $$join(OPENSSL_LIB_PATH,,-L,) $$join(QRENCODE_LIB_PATH,,-L,)
 LIBS += -lssl -lcrypto -ldb_cxx$$BDB_LIB_SUFFIX
 # -lgdi32 has to happen after -lcrypto (see  #681)
-windows:LIBS += -lole32 -luuid -lgdi32
+windows:LIBS += -lole32 -loleaut32 -luuid -lgdi32
 LIBS += -lboost_system$$BOOST_LIB_SUFFIX -lboost_filesystem$$BOOST_LIB_SUFFIX -lboost_program_options$$BOOST_LIB_SUFFIX -lboost_thread$$BOOST_THREAD_LIB_SUFFIX
 
 contains(RELEASE, 1) {

--- a/bitcoin-qt.pro
+++ b/bitcoin-qt.pro
@@ -266,7 +266,7 @@ OTHER_FILES += \
 # platform specific defaults, if not overridden on command line
 isEmpty(BOOST_LIB_SUFFIX) {
     macx:BOOST_LIB_SUFFIX = -mt
-    windows:BOOST_LIB_SUFFIX = -mgw44-mt-1_47
+    windows:BOOST_LIB_SUFFIX = -mgw44-mt-s-1_49
 }
 
 isEmpty(BOOST_THREAD_LIB_SUFFIX) {

--- a/bitcoin-qt.pro
+++ b/bitcoin-qt.pro
@@ -266,7 +266,7 @@ OTHER_FILES += \
 # platform specific defaults, if not overridden on command line
 isEmpty(BOOST_LIB_SUFFIX) {
     macx:BOOST_LIB_SUFFIX = -mt
-    windows:BOOST_LIB_SUFFIX = -mgw44-mt-1_43
+    windows:BOOST_LIB_SUFFIX = -mgw44-mt-1_47
 }
 
 isEmpty(BOOST_THREAD_LIB_SUFFIX) {


### PR DESCRIPTION
The commit assumes we update the used Boost libs for Windows to version 1.49 to switch to the latest release.

If we switch over to 1.49 on Windows, we need to add oleaut32 lib in bitcoin-qt.pro, to avoid the compilation error "undefined reference to _imp__VariantClear@4", because VariantClear() is used in the boost::interprocess code.

In the end we would also need to update the qtgui_deps_1.zip with the 1.49 boost libs for Windows and the 1.49 pre-compiled header files.
