### PR TITLE
Fix for #956 (GUI freeze on Windows)

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -143,7 +143,7 @@ int main(int argc, char *argv[])
                     break;
             }
             catch (boost::interprocess::interprocess_exception &ex) {
-                printf("boost::interprocess exception #%d: %s\n", ex.get_error_code(), ex.what());
+                printf("boost interprocess exception #%d: %s\n", ex.get_error_code(), ex.what());
                 break;
             }
         }
@@ -265,7 +265,7 @@ int main(int argc, char *argv[])
                             mq.try_send(strURL, strlen(strURL), 0);
                         }
                         catch (boost::interprocess::interprocess_exception &ex) {
-                            printf("boost::interprocess exception #%d: %s\n", ex.get_error_code(), ex.what());
+                            printf("boost interprocess exception #%d: %s\n", ex.get_error_code(), ex.what());
 							break;
                         }
                     }

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -143,7 +143,7 @@ int main(int argc, char *argv[])
                     break;
             }
             catch (boost::interprocess::interprocess_exception &ex) {
-                printf("boost::interprocess exeption: %s\n", ex.what());
+                printf("boost::interprocess exception: %s\n", ex.what());
                 break;
             }
         }
@@ -265,7 +265,7 @@ int main(int argc, char *argv[])
                             mq.try_send(strURL, strlen(strURL), 0);
                         }
                         catch (boost::interprocess::interprocess_exception &ex) {
-                            printf("boost::interprocess exeption: %s\n", ex.what());
+                            printf("boost::interprocess exception: %s\n", ex.what());
 							break;
                         }
                     }

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -143,7 +143,7 @@ int main(int argc, char *argv[])
                     break;
             }
             catch (boost::interprocess::interprocess_exception &ex) {
-                printf("boost::interprocess exception: %s\n", ex.what());
+                printf("boost::interprocess exception #%d: %s\n", ex.get_error_code(), ex.what());
                 break;
             }
         }
@@ -265,7 +265,7 @@ int main(int argc, char *argv[])
                             mq.try_send(strURL, strlen(strURL), 0);
                         }
                         catch (boost::interprocess::interprocess_exception &ex) {
-                            printf("boost::interprocess exception: %s\n", ex.what());
+                            printf("boost::interprocess exception #%d: %s\n", ex.get_error_code(), ex.what());
 							break;
                         }
                     }

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -128,8 +128,8 @@ std::string _(const char* psz)
 #ifndef BITCOIN_QT_TEST
 int main(int argc, char *argv[])
 {
-#if !defined(MAC_OSX) && !defined(WIN32)
-// TODO: implement qtipcserver.cpp for Mac and Windows
+#if !defined(MAC_OSX)
+// TODO: implement qtipcserver.cpp for Mac
 
     // Do this early as we don't want to bother initializing if we are just calling IPC
     for (int i = 1; i < argc; i++)
@@ -253,8 +253,8 @@ int main(int argc, char *argv[])
                 // Place this here as guiref has to be defined if we dont want to lose URLs
                 ipcInit();
 
-#if !defined(MAC_OSX) && !defined(WIN32)
-// TODO: implement qtipcserver.cpp for Mac and Windows
+#if !defined(MAC_OSX)
+// TODO: implement qtipcserver.cpp for Mac
 
                 // Check for URL in argv
                 for (int i = 1; i < argc; i++)

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -143,6 +143,7 @@ int main(int argc, char *argv[])
                     break;
             }
             catch (boost::interprocess::interprocess_exception &ex) {
+                printf("boost::interprocess exeption: %s\n", ex.what());
                 break;
             }
         }
@@ -264,6 +265,8 @@ int main(int argc, char *argv[])
                             mq.try_send(strURL, strlen(strURL), 0);
                         }
                         catch (boost::interprocess::interprocess_exception &ex) {
+                            printf("boost::interprocess exeption: %s\n", ex.what());
+							break;
                         }
                     }
                 }

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -21,6 +21,8 @@
 
 #include <boost/interprocess/ipc/message_queue.hpp>
 
+using namespace boost;
+
 // Need a global reference for the notifications to find the GUI
 BitcoinGUI *guiref;
 QSplashScreen *splashref;
@@ -136,13 +138,13 @@ int main(int argc, char *argv[])
         {
             const char *strURL = argv[i];
             try {
-                boost::interprocess::message_queue mq(boost::interprocess::open_only, "BitcoinURL");
+                interprocess::message_queue mq(interprocess::open_only, "BitcoinURL");
                 if(mq.try_send(strURL, strlen(strURL), 0))
                     exit(0);
                 else
                     break;
             }
-            catch (boost::interprocess::interprocess_exception &ex) {
+            catch (interprocess::interprocess_exception &ex) {
                 printf("boost interprocess exception #%d: %s\n", ex.get_error_code(), ex.what());
                 break;
             }
@@ -261,12 +263,12 @@ int main(int argc, char *argv[])
                     {
                         const char *strURL = argv[i];
                         try {
-                            boost::interprocess::message_queue mq(boost::interprocess::open_only, "BitcoinURL");
+                            interprocess::message_queue mq(interprocess::open_only, "BitcoinURL");
                             mq.try_send(strURL, strlen(strURL), 0);
                         }
-                        catch (boost::interprocess::interprocess_exception &ex) {
+                        catch (interprocess::interprocess_exception &ex) {
                             printf("boost interprocess exception #%d: %s\n", ex.get_error_code(), ex.what());
-							break;
+                            break;
                         }
                     }
                 }

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -138,7 +138,7 @@ int main(int argc, char *argv[])
         {
             const char *strURL = argv[i];
             try {
-                interprocess::message_queue mq(interprocess::open_only, "BitcoinURL");
+                interprocess::message_queue mq(interprocess::open_only, BCQT_MESSAGE_QUEUE_NAME);
                 if(mq.try_send(strURL, strlen(strURL), 0))
                     exit(0);
                 else
@@ -263,7 +263,7 @@ int main(int argc, char *argv[])
                     {
                         const char *strURL = argv[i];
                         try {
-                            interprocess::message_queue mq(interprocess::open_only, "BitcoinURL");
+                            interprocess::message_queue mq(interprocess::open_only, BCQT_MESSAGE_QUEUE_NAME);
                             mq.try_send(strURL, strlen(strURL), 0);
                         }
                         catch (interprocess::interprocess_exception &ex) {

--- a/src/qt/qtipcserver.cpp
+++ b/src/qt/qtipcserver.cpp
@@ -22,8 +22,8 @@ void ipcShutdown()
 bool ipcRecover(const char* pszFilename)
 {
     std::string strIpcDir;
-    // get path to stale ipc message queue file
-    interprocess::ipcdetail::tmp_filename(pszFilename, strIpcDir);
+    // get path to stale ipc message queue file (hint: ::detail changes to ::ipcdetail when switching to boost 1.49)
+    interprocess::detail::tmp_filename(pszFilename, strIpcDir);
 
     filesystem::path pathMessageQueue(strIpcDir);
     pathMessageQueue.make_preferred();

--- a/src/qt/qtipcserver.cpp
+++ b/src/qt/qtipcserver.cpp
@@ -19,11 +19,11 @@ void ipcShutdown()
     interprocess::message_queue::remove("BitcoinURL");
 }
 
-bool ipcRecover(const char* Filename)
+bool ipcRecover(const char* pszFilename)
 {
     std::string strIpcDir;
     // get path to stale ipc message queue file
-    interprocess::ipcdetail::tmp_filename(Filename, strIpcDir);
+    interprocess::ipcdetail::tmp_filename(pszFilename, strIpcDir);
 
     filesystem::path pathMessageQueue(strIpcDir);
     pathMessageQueue.make_preferred();
@@ -32,17 +32,17 @@ bool ipcRecover(const char* Filename)
     if (exists(pathMessageQueue))
     {
         string strLogMessage = ("ipcRecover - old message queue found, trying to remove " + pathMessageQueue.string());
-        system::error_code ec;
+        system::error_code ecErrorCode;
 
         // try removal, but take care of further errors
-        if (remove(pathMessageQueue, ec))
+        if (remove(pathMessageQueue, ecErrorCode))
         {
             printf("%s ...success\n", strLogMessage.c_str());
             return true;
         }
         else
         {
-            printf("%s ...failed\nipcRecover - removal of old message queue failed with error #%d: %s\n", strLogMessage.c_str(), ec.value(), ec.message().c_str());
+            printf("%s ...failed\nipcRecover - removal of old message queue failed with error #%d: %s\n", strLogMessage.c_str(), ecErrorCode.value(), ecErrorCode.message().c_str());
             return false;
         }
     }
@@ -50,16 +50,16 @@ bool ipcRecover(const char* Filename)
         return false;
 }
 
-void ipcThread(void* parg)
+void ipcThread(void* pArg)
 {
-    interprocess::message_queue* mq = (interprocess::message_queue*)parg;
+    interprocess::message_queue* mqMessageQueue = (interprocess::message_queue*)pArg;
     char strBuf[257];
     size_t nSize;
     unsigned int nPriority;
     loop
     {
         posix_time::ptime d = posix_time::microsec_clock::universal_time() + posix_time::millisec(100);
-        if (mq->timed_receive(&strBuf, sizeof(strBuf), nSize, nPriority, d))
+        if (mqMessageQueue->timed_receive(&strBuf, sizeof(strBuf), nSize, nPriority, d))
         {
             ThreadSafeHandleURL(std::string(strBuf, nSize));
             Sleep(1000);
@@ -86,18 +86,18 @@ void ipcInit()
     return;
 #endif
 
-    interprocess::message_queue* mq;
+    interprocess::message_queue* mqMessageQueue;
     char strBuf[257];
     size_t nSize;
     unsigned int nPriority;
     try {
-        mq = new interprocess::message_queue(interprocess::create_only, "BitcoinURL", 2, 256);
+        mqMessageQueue = new interprocess::message_queue(interprocess::create_only, "BitcoinURL", 2, 256);
 
         // Make sure we don't lose any bitcoin: URIs
         for (int i = 0; i < 2; i++)
         {
             posix_time::ptime d = posix_time::microsec_clock::universal_time() + posix_time::millisec(1);
-            if (mq->timed_receive(&strBuf, sizeof(strBuf), nSize, nPriority, d))
+            if (mqMessageQueue->timed_receive(&strBuf, sizeof(strBuf), nSize, nPriority, d))
             {
                 ThreadSafeHandleURL(std::string(strBuf, nSize));
             }
@@ -107,13 +107,13 @@ void ipcInit()
 
         // Make sure only one bitcoin instance is listening
         interprocess::message_queue::remove("BitcoinURL");
-        mq = new interprocess::message_queue(interprocess::create_only, "BitcoinURL", 2, 256);
+        mqMessageQueue = new interprocess::message_queue(interprocess::create_only, "BitcoinURL", 2, 256);
     }
-    catch (interprocess::interprocess_exception &ex) {
-        printf("ipcInit - boost interprocess exception #%d: %s\n", ex.get_error_code(), ex.what());
+    catch (interprocess::interprocess_exception &exIPCException) {
+        printf("ipcInit - boost interprocess exception #%d: %s\n", exIPCException.get_error_code(), exIPCException.what());
 
         // check if the exception is a "file already exists" error
-        if (ex.get_error_code() == interprocess::already_exists_error)
+        if (exIPCException.get_error_code() == interprocess::already_exists_error)
         {
             // try a recovery to fix #956 and pass our message queue name
             if (ipcRecover("BitcoinURL"))
@@ -122,8 +122,8 @@ void ipcInit()
         }
         return;
     }
-    if (!CreateThread(ipcThread, mq))
+    if (!CreateThread(ipcThread, mqMessageQueue))
     {
-        delete mq;
+        delete mqMessageQueue;
     }
 }

--- a/src/qt/qtipcserver.cpp
+++ b/src/qt/qtipcserver.cpp
@@ -9,25 +9,23 @@
 
 #include "headers.h"
 
-using namespace boost::interprocess;
-using namespace boost::posix_time;
 using namespace boost;
 using namespace std;
 
 void ipcShutdown()
 {
-    message_queue::remove("BitcoinURL");
+    boost::interprocess::message_queue::remove("BitcoinURL");
 }
 
 void ipcThread(void* parg)
 {
-    message_queue* mq = (message_queue*)parg;
+    boost::interprocess::message_queue* mq = (boost::interprocess::message_queue*)parg;
     char strBuf[257];
     size_t nSize;
     unsigned int nPriority;
     loop
     {
-        ptime d = boost::posix_time::microsec_clock::universal_time() + millisec(100);
+        boost::posix_time::ptime d = boost::posix_time::microsec_clock::universal_time() + boost::posix_time::millisec(100);
         if(mq->timed_receive(&strBuf, sizeof(strBuf), nSize, nPriority, d))
         {
             ThreadSafeHandleURL(std::string(strBuf, nSize));
@@ -55,17 +53,17 @@ void ipcInit()
     return;
 #endif
 
-    message_queue* mq;
+    boost::interprocess::message_queue* mq;
     char strBuf[257];
     size_t nSize;
     unsigned int nPriority;
     try {
-        mq = new message_queue(open_or_create, "BitcoinURL", 2, 256);
+        mq = new boost::interprocess::message_queue(boost::interprocess::open_or_create, "BitcoinURL", 2, 256);
 
         // Make sure we don't lose any bitcoin: URIs
         for (int i = 0; i < 2; i++)
         {
-            ptime d = boost::posix_time::microsec_clock::universal_time() + millisec(1);
+            boost::posix_time::ptime d = boost::posix_time::microsec_clock::universal_time() + boost::posix_time::millisec(1);
             if(mq->timed_receive(&strBuf, sizeof(strBuf), nSize, nPriority, d))
             {
                 ThreadSafeHandleURL(std::string(strBuf, nSize));
@@ -75,8 +73,8 @@ void ipcInit()
         }
 
         // Make sure only one bitcoin instance is listening
-        message_queue::remove("BitcoinURL");
-        mq = new message_queue(open_or_create, "BitcoinURL", 2, 256);
+        boost::interprocess::message_queue::remove("BitcoinURL");
+        mq = new boost::interprocess::message_queue(boost::interprocess::open_or_create, "BitcoinURL", 2, 256);
     }
     catch (interprocess_exception &ex) {
         printf("ipcInit - boost::interprocess exeption: %s\n", ex.what());

--- a/src/qt/qtipcserver.cpp
+++ b/src/qt/qtipcserver.cpp
@@ -14,6 +14,9 @@
 using namespace boost;
 using namespace std;
 
+// Global state
+bool fInitCalledAfterRecovery = false;
+
 void ipcShutdown()
 {
     interprocess::message_queue::remove("BitcoinURL");
@@ -116,8 +119,10 @@ void ipcInit()
         if (exIPCException.get_error_code() == interprocess::already_exists_error)
         {
             // try a recovery to fix #956 and pass our message queue name
-            if (ipcRecover("BitcoinURL"))
-                // if that worked try init once more
+            if (ipcRecover("BitcoinURL") && !fInitCalledAfterRecovery)
+                // set fInitCalledAfterRecovery to true, to avoid an infinite recursion
+                fInitCalledAfterRecovery = true;
+                // try init once more
                 ipcInit();
         }
         return;

--- a/src/qt/qtipcserver.cpp
+++ b/src/qt/qtipcserver.cpp
@@ -31,21 +31,18 @@ bool ipcRecover(const char *Filename)
     // verify that the message queue file really exists and remove it
     if(exists(pathMessageQueue))
     {
-        string strLogMessage = ("ipcRecover - old message queue found, trying to remove: " + pathMessageQueue.string());
+        string strLogMessage = ("ipcRecover - old message queue found, trying to remove " + pathMessageQueue.string());
         system::error_code ec;
 
         // try removal, but take care of further errors
         if(remove(pathMessageQueue, ec))
         {
-            strLogMessage += " ...success\n";
-            printf(strLogMessage.c_str());
+            printf("%s ...success\n", strLogMessage.c_str());
             return true;
         }
         else
         {
-            strLogMessage += " ...failed\n";
-            printf(strLogMessage.c_str());
-            printf("ipcRecover - removal of old message queue failed with error #%d: %s\n", ec.value(), ec.message().c_str());
+            printf("%s ...failed\nipcRecover - removal of old message queue failed with error #%d: %s\n", strLogMessage.c_str(), ec.value(), ec.message().c_str());
             return false;
         }
     }

--- a/src/qt/qtipcserver.cpp
+++ b/src/qt/qtipcserver.cpp
@@ -19,7 +19,7 @@ void ipcShutdown()
     boost::interprocess::message_queue::remove("BitcoinURL");
 }
 
-void ipcRecover(const char *Filename)
+bool ipcRecover(const char *Filename)
 {
     std::string strIpcDir;
     // get path to stale ipc message queue file
@@ -32,10 +32,25 @@ void ipcRecover(const char *Filename)
     if(exists(pathMessageQueue))
     {
         string strLogMessage = ("ipcRecover - old message queue found, trying to remove: " + pathMessageQueue.string());
-        (remove(pathMessageQueue)) ? strLogMessage += " ...success\n" : strLogMessage += " ...failed\n";
+        system::error_code ec;
 
-        printf(strLogMessage.c_str());
+        // try removal, but take care of further errors
+        if(remove(pathMessageQueue, ec))
+        {
+            strLogMessage += " ...success\n";
+            printf(strLogMessage.c_str());
+            return true;
+        }
+        else
+        {
+            strLogMessage += " ...failed\n";
+            printf(strLogMessage.c_str());
+            printf("ipcRecover - removal of old message queue failed with error #%d: %s\n", ec.value(), ec.message().c_str());
+            return false;
+        }
     }
+    else
+        return false;
 }
 
 void ipcThread(void* parg)

--- a/src/qt/qtipcserver.cpp
+++ b/src/qt/qtipcserver.cpp
@@ -110,7 +110,7 @@ void ipcInit()
         mq = new interprocess::message_queue(interprocess::create_only, "BitcoinURL", 2, 256);
     }
     catch (interprocess::interprocess_exception &ex) {
-        printf("ipcInit - interprocess exception #%d: %s\n", ex.get_error_code(), ex.what());
+        printf("ipcInit - boost interprocess exception #%d: %s\n", ex.get_error_code(), ex.what());
 
         // check if the exception is a "file already exists" error
         if(ex.get_error_code() == interprocess::already_exists_error)

--- a/src/qt/qtipcserver.cpp
+++ b/src/qt/qtipcserver.cpp
@@ -98,7 +98,7 @@ void ipcInit()
         mq = new boost::interprocess::message_queue(boost::interprocess::create_only, "BitcoinURL", 2, 256);
     }
     catch (boost::interprocess::interprocess_exception &ex) {
-        printf("ipcInit - boost::interprocess exeption: %s\n", ex.what());
+        printf("ipcInit - boost::interprocess exception: %s\n", ex.what());
         // try a recovery to fix #956 and pass our message queue name
         ipcRecover("BitcoinURL");
         return;

--- a/src/qt/qtipcserver.cpp
+++ b/src/qt/qtipcserver.cpp
@@ -17,7 +17,7 @@ using namespace std;
 
 void ipcShutdown()
 {
-    interprocess::message_queue::remove("BitcoinURL");
+    interprocess::message_queue::remove(BCQT_MESSAGE_QUEUE_NAME);
 }
 
 bool ipcRecover(const char* pszFilename)
@@ -25,7 +25,7 @@ bool ipcRecover(const char* pszFilename)
     string strLogMessage = ("ipcRecover - possible stale message queue detected, trying to remove");
 
     // try to remove the possible stale message queue
-    if (interprocess::message_queue::remove("BitcoinURL"))
+    if (interprocess::message_queue::remove(BCQT_MESSAGE_QUEUE_NAME))
     {
         printf("%s %s ...success\n", strLogMessage.c_str(), pszFilename);
         return true;
@@ -79,9 +79,9 @@ void ipcInit(bool fUseMQModeCreateOnly, bool fInitCalledAfterRecovery)
     unsigned int nPriority;
     try {
         if (fUseMQModeCreateOnly)
-            mq = new interprocess::message_queue(interprocess::create_only, "BitcoinURL", 2, 256);
+            mq = new interprocess::message_queue(interprocess::create_only, BCQT_MESSAGE_QUEUE_NAME, 2, 256);
         else
-            mq = new interprocess::message_queue(interprocess::open_or_create, "BitcoinURL", 2, 256);
+            mq = new interprocess::message_queue(interprocess::open_or_create, BCQT_MESSAGE_QUEUE_NAME, 2, 256);
 
         // Make sure we don't lose any bitcoin: URIs
         for (int i = 0; i < 2; i++)
@@ -96,11 +96,11 @@ void ipcInit(bool fUseMQModeCreateOnly, bool fInitCalledAfterRecovery)
         }
 
         // Make sure only one bitcoin instance is listening
-        interprocess::message_queue::remove("BitcoinURL");
+        interprocess::message_queue::remove(BCQT_MESSAGE_QUEUE_NAME);
         if (fUseMQModeCreateOnly)
-            mq = new interprocess::message_queue(interprocess::create_only, "BitcoinURL", 2, 256);
+            mq = new interprocess::message_queue(interprocess::create_only, BCQT_MESSAGE_QUEUE_NAME, 2, 256);
         else
-            mq = new interprocess::message_queue(interprocess::open_or_create, "BitcoinURL", 2, 256);
+            mq = new interprocess::message_queue(interprocess::open_or_create, BCQT_MESSAGE_QUEUE_NAME, 2, 256);
     }
     catch (interprocess::interprocess_exception &ex) {
 // we currently only handle stale message queue files on Windows
@@ -111,7 +111,7 @@ void ipcInit(bool fUseMQModeCreateOnly, bool fInitCalledAfterRecovery)
         if (ex.get_error_code() == interprocess::already_exists_error)
         {
             // try a recovery and pass our message queue name
-            if (ipcRecover("BitcoinURL") && !fInitCalledAfterRecovery)
+            if (ipcRecover(BCQT_MESSAGE_QUEUE_NAME) && !fInitCalledAfterRecovery)
                 // try init once more (true - create_only mode / true - avoid an infinite recursion)
                 // create_only: stale message queue removed, create a new message queue
                 ipcInit(true, true);

--- a/src/qt/qtipcserver.cpp
+++ b/src/qt/qtipcserver.cpp
@@ -78,7 +78,7 @@ void ipcInit()
         boost::interprocess::message_queue::remove("BitcoinURL");
         mq = new boost::interprocess::message_queue(boost::interprocess::create_only, "BitcoinURL", 2, 256);
     }
-    catch (interprocess_exception &ex) {
+    catch (boost::interprocess::interprocess_exception &ex) {
         printf("ipcInit - boost::interprocess exeption: %s\n", ex.what());
         return;
     }

--- a/src/qt/qtipcserver.cpp
+++ b/src/qt/qtipcserver.cpp
@@ -116,7 +116,9 @@ void ipcInit()
         if (ex.get_error_code() == interprocess::already_exists_error)
         {
             // try a recovery to fix #956 and pass our message queue name
-            ipcRecover("BitcoinURL");
+            if (ipcRecover("BitcoinURL"))
+                // if that worked try init once more
+                ipcInit();
         }
         return;
     }

--- a/src/qt/qtipcserver.cpp
+++ b/src/qt/qtipcserver.cpp
@@ -79,6 +79,7 @@ void ipcInit()
         mq = new message_queue(open_or_create, "BitcoinURL", 2, 256);
     }
     catch (interprocess_exception &ex) {
+        printf("ipcInit - boost::interprocess exeption: %s\n", ex.what());
         return;
     }
     if (!CreateThread(ipcThread, mq))

--- a/src/qt/qtipcserver.cpp
+++ b/src/qt/qtipcserver.cpp
@@ -3,9 +3,11 @@
 // file license.txt or http://www.opensource.org/licenses/mit-license.php.
 
 #include <boost/algorithm/string.hpp>
+#include <boost/date_time/posix_time/posix_time.hpp>
+#include <boost/filesystem.hpp>
+#include <boost/filesystem/fstream.hpp>
 #include <boost/interprocess/ipc/message_queue.hpp>
 #include <boost/tokenizer.hpp>
-#include <boost/date_time/posix_time/posix_time.hpp>
 
 #include "headers.h"
 
@@ -58,7 +60,7 @@ void ipcInit()
     size_t nSize;
     unsigned int nPriority;
     try {
-        mq = new boost::interprocess::message_queue(boost::interprocess::open_or_create, "BitcoinURL", 2, 256);
+        mq = new boost::interprocess::message_queue(boost::interprocess::create_only, "BitcoinURL", 2, 256);
 
         // Make sure we don't lose any bitcoin: URIs
         for (int i = 0; i < 2; i++)
@@ -74,7 +76,7 @@ void ipcInit()
 
         // Make sure only one bitcoin instance is listening
         boost::interprocess::message_queue::remove("BitcoinURL");
-        mq = new boost::interprocess::message_queue(boost::interprocess::open_or_create, "BitcoinURL", 2, 256);
+        mq = new boost::interprocess::message_queue(boost::interprocess::create_only, "BitcoinURL", 2, 256);
     }
     catch (interprocess_exception &ex) {
         printf("ipcInit - boost::interprocess exeption: %s\n", ex.what());

--- a/src/qt/qtipcserver.cpp
+++ b/src/qt/qtipcserver.cpp
@@ -19,7 +19,7 @@ void ipcShutdown()
     interprocess::message_queue::remove("BitcoinURL");
 }
 
-bool ipcRecover(const char *Filename)
+bool ipcRecover(const char* Filename)
 {
     std::string strIpcDir;
     // get path to stale ipc message queue file
@@ -29,13 +29,13 @@ bool ipcRecover(const char *Filename)
     pathMessageQueue.make_preferred();
 
     // verify that the message queue file really exists and remove it
-    if(exists(pathMessageQueue))
+    if (exists(pathMessageQueue))
     {
         string strLogMessage = ("ipcRecover - old message queue found, trying to remove " + pathMessageQueue.string());
         system::error_code ec;
 
         // try removal, but take care of further errors
-        if(remove(pathMessageQueue, ec))
+        if (remove(pathMessageQueue, ec))
         {
             printf("%s ...success\n", strLogMessage.c_str());
             return true;
@@ -59,7 +59,7 @@ void ipcThread(void* parg)
     loop
     {
         posix_time::ptime d = posix_time::microsec_clock::universal_time() + posix_time::millisec(100);
-        if(mq->timed_receive(&strBuf, sizeof(strBuf), nSize, nPriority, d))
+        if (mq->timed_receive(&strBuf, sizeof(strBuf), nSize, nPriority, d))
         {
             ThreadSafeHandleURL(std::string(strBuf, nSize));
             Sleep(1000);
@@ -97,7 +97,7 @@ void ipcInit()
         for (int i = 0; i < 2; i++)
         {
             posix_time::ptime d = posix_time::microsec_clock::universal_time() + posix_time::millisec(1);
-            if(mq->timed_receive(&strBuf, sizeof(strBuf), nSize, nPriority, d))
+            if (mq->timed_receive(&strBuf, sizeof(strBuf), nSize, nPriority, d))
             {
                 ThreadSafeHandleURL(std::string(strBuf, nSize));
             }
@@ -113,7 +113,7 @@ void ipcInit()
         printf("ipcInit - boost interprocess exception #%d: %s\n", ex.get_error_code(), ex.what());
 
         // check if the exception is a "file already exists" error
-        if(ex.get_error_code() == interprocess::already_exists_error)
+        if (ex.get_error_code() == interprocess::already_exists_error)
         {
             // try a recovery to fix #956 and pass our message queue name
             ipcRecover("BitcoinURL");

--- a/src/qt/qtipcserver.cpp
+++ b/src/qt/qtipcserver.cpp
@@ -14,9 +14,6 @@
 using namespace boost;
 using namespace std;
 
-// Global state
-bool fInitCalledAfterRecovery = false;
-
 void ipcShutdown()
 {
     interprocess::message_queue::remove("BitcoinURL");
@@ -76,7 +73,7 @@ void ipcThread(void* pArg)
     ipcShutdown();
 }
 
-void ipcInit()
+void ipcInit(bool fInitCalledAfterRecovery)
 {
 #ifdef MAC_OSX
     // TODO: implement bitcoin: URI handling the Mac Way
@@ -120,10 +117,8 @@ void ipcInit()
         {
             // try a recovery to fix #956 and pass our message queue name
             if (ipcRecover("BitcoinURL") && !fInitCalledAfterRecovery)
-                // set fInitCalledAfterRecovery to true, to avoid an infinite recursion
-                fInitCalledAfterRecovery = true;
-                // try init once more
-                ipcInit();
+                // try init once more and pass true, to avoid an infinite recursion
+                ipcInit(true);
         }
         return;
     }

--- a/src/qt/qtipcserver.h
+++ b/src/qt/qtipcserver.h
@@ -1,4 +1,4 @@
-// define Bitcoin-Qt message queue name
+/** define Bitcoin-Qt message queue name */
 #define BCQT_MESSAGE_QUEUE_NAME "BitcoinURL"
 
 void ipcShutdown();

--- a/src/qt/qtipcserver.h
+++ b/src/qt/qtipcserver.h
@@ -1,4 +1,4 @@
 void ipcShutdown();
-void ipcRecover(const char *);
+bool ipcRecover(const char *);
 void ipcThread(void*);
 void ipcInit();

--- a/src/qt/qtipcserver.h
+++ b/src/qt/qtipcserver.h
@@ -1,4 +1,4 @@
 void ipcShutdown();
-bool ipcRecover(const char*);
-void ipcThread(void*);
+bool ipcRecover(const char* pszFilename);
+void ipcThread(void* pArg);
 void ipcInit();

--- a/src/qt/qtipcserver.h
+++ b/src/qt/qtipcserver.h
@@ -1,4 +1,5 @@
 void ipcShutdown();
 bool ipcRecover(const char* pszFilename);
+bool ipcRecover2(const char* pszFilename);
 void ipcThread(void* pArg);
-void ipcInit(bool fInitCalledAfterRecovery = false);
+void ipcInit(bool fUseMQModeCreateOnly = true, bool fInitCalledAfterRecovery = false);

--- a/src/qt/qtipcserver.h
+++ b/src/qt/qtipcserver.h
@@ -1,3 +1,6 @@
+// define Bitcoin-Qt message queue name
+#define BCQT_MESSAGE_QUEUE_NAME "BitcoinURL"
+
 void ipcShutdown();
 bool ipcRecover(const char* pszFilename);
 void ipcThread(void* pArg);

--- a/src/qt/qtipcserver.h
+++ b/src/qt/qtipcserver.h
@@ -1,4 +1,4 @@
 void ipcShutdown();
 bool ipcRecover(const char* pszFilename);
 void ipcThread(void* pArg);
-void ipcInit();
+void ipcInit(bool fInitCalledAfterRecovery = false);

--- a/src/qt/qtipcserver.h
+++ b/src/qt/qtipcserver.h
@@ -1,5 +1,4 @@
 void ipcShutdown();
 bool ipcRecover(const char* pszFilename);
-bool ipcRecover2(const char* pszFilename);
 void ipcThread(void* pArg);
 void ipcInit(bool fUseMQModeCreateOnly = true, bool fInitCalledAfterRecovery = false);

--- a/src/qt/qtipcserver.h
+++ b/src/qt/qtipcserver.h
@@ -1,4 +1,4 @@
 void ipcShutdown();
-bool ipcRecover(const char *);
+bool ipcRecover(const char*);
 void ipcThread(void*);
 void ipcInit();

--- a/src/qt/qtipcserver.h
+++ b/src/qt/qtipcserver.h
@@ -1,2 +1,4 @@
-void ipcInit();
 void ipcShutdown();
+void ipcRecover(const char *);
+void ipcThread(void*);
+void ipcInit();


### PR DESCRIPTION
Okay, so my former assumption boost 1.47 would fix #956 was wrong and boost 1.49 did not fix it either. It turns out, that I could recreate the error condition by running Bitcoin-Qt and simply switch of my PC. So there were the 2 orphan files from boost interprocess that cause the problem.

I found out, that no interprocess_exception was thrown, not in qtipcserver.cpp and not in bitcoin.cpp. Next step was to look through the code and the "create_or_open" option in the message_queue constructor got my attention. I changed this to create_only and voila there was an exception I could work with. It sais "file already exists", which makes sens as there are those orphan files left.

In the end I introduced a new ipcRecover() function, which is called after catching interprocess::already_exists_error. This function works with the path were the stale message queue file "BitcoinURL" resides and checks if the file is there and tries to remove it. If that succeeds the function returns true and ipcInit() is called again. If this fails an error is written to the debug.log.

Test case with 1.47 boost libs:
- kill running Bitcoin-Qt instance by switching PC of
- check for stale files, which are there
- starting the client again with the fix disabled in the code
- no exception, no log entries and a frozen GUI
- starting the client again with fix enabled results in a not frozen GUI and normal client operation

Log:
ipcInit - boost interprocess exception #9: File exists.
ipcRecover - old message queue found, trying to remove C:\ProgramData\boost_interprocess\BitcoinURL ...success

I know there are many commits in here, so I would suggest to first only look at the diff and if you are interested in the history of the fix take a look at the commits itself.

As I only run Windows the Linux / Mac devs should test this code, during our discussion.
