### PR TITLE
Give DNS seeds a random age between 3 and 7 days old

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1093,8 +1093,9 @@ void ThreadDNSAddressSeed2(void* parg)
             {
                 BOOST_FOREACH(CNetAddr& ip, vaddr)
                 {
+                    int nOneDay = 24*3600;
                     CAddress addr = CAddress(CService(ip, GetDefaultPort()));
-                    addr.nTime = 0;
+                    addr.nTime = GetTime() - 3*nOneDay - GetRand(4*nOneDay); // use a random age between 3 and 7 days old
                     vAdd.push_back(addr);
                     found++;
                 }


### PR DESCRIPTION
This speeds up initial connections with an old/large addr.dat a lot.
