### PR TITLE
Fix boost::interprocess::detail::winapi::get_last_bootup_time

### DIFF
--- a/contrib/gitian-descriptors/boost-win32.yml
+++ b/contrib/gitian-descriptors/boost-win32.yml
@@ -17,6 +17,32 @@ script: |
   mkdir -p $TMPDIR/bin/$GBUILD_BITS $TMPDIR/include
   tar xjf boost_1_47_0.tar.bz2
   cd boost_1_47_0
+  echo "--- win32_api.orig.hpp	2012-03-25 16:08:28.932377422 -0400
++++ win32_api.hpp	2012-03-25 16:08:30.312377422 -0400
+@@ -1572,14 +1572,21 @@
+    return ret;
+ }
+ 
++static std::string strLastBootupTimeCache;
+ inline bool get_last_bootup_time( std::string& str )
+ {
++   if (strLastBootupTimeCache.size() > 0) {
++      str = strLastBootupTimeCache;
++      return true;
++   }
+    std::wstring wstr;
+    bool ret = get_last_bootup_time(wstr);
+    str.resize(wstr.size());
+    for(std::size_t i = 0, max = str.size(); i != max; ++i){
+       str[i] = '0' + (wstr[i]-L'0');
+    }
++   if (ret)
++      strLastBootupTimeCache = str;
+    return ret;
+ }
+ 
+" > fixbootuptime.patch
+  patch boost/interprocess/detail/win32_api.hpp fixbootuptime.patch
   echo "using gcc : 4.4 : i586-mingw32msvc-g++
         :
         <rc>i586-mingw32msvc-windres
@@ -34,5 +60,5 @@ script: |
   cd $TMPDIR
   export LD_PRELOAD=/usr/lib/faketime/libfaketime.so.1
   export FAKETIME=$REFERENCE_DATETIME
-  zip -r boost-win32-1.47.0-gitian.zip *
-  cp boost-win32-1.47.0-gitian.zip $OUTDIR
+  zip -r boost-win32-1.47.0-gitian2.zip *
+  cp boost-win32-1.47.0-gitian2.zip $OUTDIR

--- a/contrib/gitian-descriptors/gitian-win32.yml
+++ b/contrib/gitian-descriptors/gitian-win32.yml
@@ -16,7 +16,7 @@ remotes:
   "dir": "bitcoin"
 files:
 - "qt-win32-4.7.4-gitian.zip"
-- "boost-win32-1.47.0-gitian.zip"
+- "boost-win32-1.47.0-gitian2.zip"
 - "bitcoin-deps-0.0.3.zip"
 script: |
   #
@@ -29,7 +29,7 @@ script: |
   mkdir boost_1_47_0
   cd boost_1_47_0
   mkdir -p stage/lib
-  unzip ../boost-win32-1.47.0-gitian.zip
+  unzip ../boost-win32-1.47.0-gitian2.zip
   cd bin/$GBUILD_BITS
   for lib in *; do
     i586-mingw32msvc-ar rc ../../stage/lib/libboost_${lib}-mt-s.a $lib/*.o


### PR DESCRIPTION
This fixes #981 and should fix #956

I havent tested 956 after this patch, but it does fix #981 and afaict, they are actually the same underlying issue.
It would be nice to have someone do more digging and find out what is actually going on in the win32 api calls boost is making and find the real issue, but this fixes the problem.  Also, someone should file a boost bugreport.
