### PR TITLE
show Window, when user is clicking bitcoin: link

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -733,6 +733,11 @@ void BitcoinGUI::handleURL(QString strURL)
 {
     gotoSendCoinsPage();
     sendCoinsPage->handleURL(strURL);
+
+    if(!isActiveWindow())
+        activateWindow();
+
+    showNormalIfMinimized();
 }
 
 void BitcoinGUI::setEncryptionStatus(int status)


### PR DESCRIPTION
Simple fix, currently the Window is not shown, if a user opens a bitcoin: link in the browser. This one brings the window to front, if it's minimized or not active.
