### PR TITLE
New -minfee and -minfeeper options (with JSON-RPC setminfee to change at runtime) to control minimum fee requirements for transaction inclusion in blocks mined

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -199,6 +199,8 @@ std::string HelpMessage()
         "  -pid=<file>            " + _("Specify pid file (default: bitcoind.pid)") + "\n" +
         "  -gen                   " + _("Generate coins") + "\n" +
         "  -gen=0                 " + _("Don't generate coins") + "\n" +
+        "  -minfee=<amt>          " + _("Fee to require of transactions you mine") + "\n" +
+        "  -minfeeper=<bytes>     " + _("Amount of transaction bytes before minfee is doubled") + "\n" +
         "  -datadir=<dir>         " + _("Specify data directory") + "\n" +
         "  -dbcache=<n>           " + _("Set database cache size in megabytes (default: 25)") + "\n" +
         "  -dblogsize=<n>         " + _("Set database disk log size in megabytes (default: 100)") + "\n" +
@@ -377,6 +379,20 @@ bool AppInit2()
         if (nTransactionFee > 0.25 * COIN)
             InitWarning(_("Warning: -paytxfee is set very high. This is the transaction fee you will pay if you send a transaction."));
     }
+
+    if (mapArgs.count("-minfee"))
+    {
+        if (!ParseMoney(mapArgs["-minfee"], nMinFeeBase))
+            return InitError(strprintf(_("Invalid amount for -minfee=<amount>: '%s'"), mapArgs["-minfee"].c_str()));
+    }
+    if (mapArgs.count("-minfeeper"))
+    {
+        nMinFeePer = GetArg("-minfeeper", nMinFeePer);
+        if (nMinFeePer < 1)
+            return InitError(strprintf(_("Invalid amount for -minfeeper=<bytes>: '%s'"), mapArgs["-minfeeper"].c_str()));
+    }
+    if (nMinFeeBase / nMinFeePer > 0.00025 * COIN)
+        InitWarning(_("Warning: -minfee is set very high.  This is the transaction fee people must pay to get transactions accepted into your blocks."));
 
     // ********************************************************* Step 4: application initialization: dir lock, daemonize, pidfile, debug log
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -56,6 +56,8 @@ int64 nHPSTimerStart;
 
 // Settings
 int64 nTransactionFee = 0;
+int64 nMinFeeBase = 0;
+int64 nMinFeePer = 1000;
 
 
 

--- a/src/main.h
+++ b/src/main.h
@@ -70,6 +70,8 @@ extern unsigned char pchMessageStart[4];
 
 // Settings
 extern int64 nTransactionFee;
+extern int64 nMinFeeBase;
+extern int64 nMinFeePer;
 
 // Minimum disk space required - used in CheckDiskSpace()
 static const uint64 nMinDiskSpace = 52428800;
@@ -581,6 +583,14 @@ public:
 
         if (!MoneyRange(nMinFee))
             nMinFee = MAX_MONEY;
+
+        if (mode == GMF_BLOCK)
+        {
+            int64 nAltMinFee = (1 + ((int64)nBytes / nMinFeePer)) * nMinFeeBase;
+            if (nAltMinFee > nMinFee)
+                nMinFee = nAltMinFee;
+        }
+
         return nMinFee;
     }
 


### PR DESCRIPTION
This feature was requested and paid for by p2pool miner "DeathAndTaxes": https://bitcointalk.org/?topic=73941.0

I've asked non-developers to express support on that thread.
