### PR TITLE
Disable bitcoin: URI handling on Windows for the 0.6 release

### DIFF
--- a/share/setup.nsi
+++ b/share/setup.nsi
@@ -94,10 +94,12 @@ Section -post SEC0001
     WriteRegStr HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$(^Name)" UninstallString $INSTDIR\uninstall.exe
     WriteRegDWORD HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$(^Name)" NoModify 1
     WriteRegDWORD HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$(^Name)" NoRepair 1
-    WriteRegStr HKCR "bitcoin" "URL Protocol" ""
-    WriteRegStr HKCR "bitcoin" "" "URL:Bitcoin"
-    WriteRegStr HKCR "bitcoin\DefaultIcon" "" $INSTDIR\bitcoin-qt.exe
-    WriteRegStr HKCR "bitcoin\shell\open\command" "" '"$INSTDIR\bitcoin-qt.exe" "$$1"'
+
+    # bitcoin: URI handling disabled for 0.6.0
+    #    WriteRegStr HKCR "bitcoin" "URL Protocol" ""
+    #    WriteRegStr HKCR "bitcoin" "" "URL:Bitcoin"
+    #    WriteRegStr HKCR "bitcoin\DefaultIcon" "" $INSTDIR\bitcoin-qt.exe
+    #    WriteRegStr HKCR "bitcoin\shell\open\command" "" '"$INSTDIR\bitcoin-qt.exe" "$$1"'
 SectionEnd
 
 # Macro for selecting uninstaller sections

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -126,6 +126,9 @@ std::string _(const char* psz)
 #ifndef BITCOIN_QT_TEST
 int main(int argc, char *argv[])
 {
+#if !defined(MAC_OSX) && !defined(WIN32)
+// TODO: implement qtipcserver.cpp for Mac and Windows
+
     // Do this early as we don't want to bother initializing if we are just calling IPC
     for (int i = 1; i < argc; i++)
     {
@@ -144,6 +147,7 @@ int main(int argc, char *argv[])
             }
         }
     }
+#endif
 
     // Internal string conversion is all UTF-8
     QTextCodec::setCodecForTr(QTextCodec::codecForName("UTF-8"));
@@ -245,6 +249,10 @@ int main(int argc, char *argv[])
 
                 // Place this here as guiref has to be defined if we dont want to lose URLs
                 ipcInit();
+
+#if !defined(MAC_OSX) && !defined(WIN32)
+// TODO: implement qtipcserver.cpp for Mac and Windows
+
                 // Check for URL in argv
                 for (int i = 1; i < argc; i++)
                 {
@@ -259,7 +267,7 @@ int main(int argc, char *argv[])
                         }
                     }
                 }
-
+#endif
                 app.exec();
 
                 guiref = 0;

--- a/src/qt/qtipcserver.cpp
+++ b/src/qt/qtipcserver.cpp
@@ -48,6 +48,12 @@ void ipcInit()
     // TODO: implement bitcoin: URI handling the Mac Way
     return;
 #endif
+#ifdef WIN32
+    // TODO: THOROUGHLY test boost::interprocess fix,
+    // and make sure there are no Windows argument-handling exploitable
+    // problems.
+    return;
+#endif
 
     message_queue* mq;
     char strBuf[257];


### PR DESCRIPTION
I don't think bitcoin: URI handling on Windows has had nearly enough testing, so this disables it for the 0.6 release.

I'm all for re-enabling it for a 0.6.1 and/or 0.7, but only we take a step back and do two things:
1. Can we get an IPC solution that doesn't require monkey-patching boost::interprocess ?
2. I'm nervous that attackers might be able to craft bitcoin: URIs that Do Bad Things. I would suggest that we disable Linux bitcoin: URI handling until that is fixed, but I consider bitcoin: URI handling on Linux experimental anyway because users have to know how to manually enable it.
