### PR TITLE
Remove wxWidgets .exe during setup

### DIFF
--- a/share/setup.nsi
+++ b/share/setup.nsi
@@ -75,6 +75,10 @@ Section -Main SEC0000
     File /r /x *.exe /x *.o ../src\*.*
     SetOutPath $INSTDIR
     WriteRegStr HKCU "${REGKEY}\Components" Main 1
+
+    # Remove old wxwidgets-based-bitcoin executable and locales:
+    Delete /REBOOTOK $INSTDIR\bitcoin.exe
+    RMDir /r /REBOOTOK $INSTDIR\locale
 SectionEnd
 
 Section -post SEC0001


### PR DESCRIPTION
Tested using a WinXPsp3 virtual machine:
- Installed bitcoin-0.4.5rc1-win32
- Installed bitcoin-0.6.0rc4 on top, ran bitcoin-qt
- Uninstalled bitcoin-0.6.0rc4

RESULT: bitcoin.exe left in C:\Program Files\Bitcoin

This pull will clean that up.  HOWEVER:

RESULT: locale\ folder left in C:\Program Files\Bitcoin

Is Qt writing that folder at first startup? I don't see it mentioned in the setup.nsi; should the uninstaller explicitly remove it?
