### PR TITLE
URI-handling code update: added safety checks and notifications

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -744,12 +744,19 @@ void BitcoinGUI::dropEvent(QDropEvent *event)
 {
     if(event->mimeData()->hasUrls())
     {
-        gotoSendCoinsPage();
+        int nValidUrisFound = 0;
         QList<QUrl> uris = event->mimeData()->urls();
         foreach(const QUrl &uri, uris)
         {
-            sendCoinsPage->handleURI(uri.toString());
+            if (sendCoinsPage->handleURI(uri.toString()))
+                nValidUrisFound++;
         }
+
+        // if valid URIs were found
+        if (nValidUrisFound)
+            gotoSendCoinsPage();
+        else
+            notificator->notify(Notificator::Warning, tr("URI handling"), tr("URI can not be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters."));
     }
 
     event->acceptProposedAction();
@@ -757,10 +764,14 @@ void BitcoinGUI::dropEvent(QDropEvent *event)
 
 void BitcoinGUI::handleURI(QString strURI)
 {
-    gotoSendCoinsPage();
-    sendCoinsPage->handleURI(strURI);
-
-    showNormalIfMinimized();
+    // URI has to be valid
+    if (sendCoinsPage->handleURI(strURI))
+    {
+        showNormalIfMinimized();
+        gotoSendCoinsPage();
+    }
+    else
+        notificator->notify(Notificator::Warning, tr("URI handling"), tr("URI can not be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters."));
 }
 
 void BitcoinGUI::setEncryptionStatus(int status)

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -4,6 +4,7 @@
 #include "bitcoinunits.h"
 #include "util.h"
 #include "init.h"
+#include "base58.h"
 
 #include <QString>
 #include <QDateTime>
@@ -78,6 +79,11 @@ void setupAmountWidget(QLineEdit *widget, QWidget *parent)
 bool parseBitcoinURI(const QUrl &uri, SendCoinsRecipient *out)
 {
     if(uri.scheme() != QString("bitcoin"))
+        return false;
+
+    // check if the address is valid
+    CBitcoinAddress addressFromUri(uri.path().toStdString());
+    if (!addressFromUri.IsValid())
         return false;
 
     SendCoinsRecipient rv;
@@ -222,19 +228,18 @@ Qt::ConnectionType blockingGUIThreadConnection()
 
 bool checkPoint(const QPoint &p, const QWidget *w)
 {
-  QWidget *atW = qApp->widgetAt(w->mapToGlobal(p));
-  if(!atW) return false;
-  return atW->topLevelWidget() == w;
+    QWidget *atW = qApp->widgetAt(w->mapToGlobal(p));
+    if (!atW) return false;
+    return atW->topLevelWidget() == w;
 }
 
 bool isObscured(QWidget *w)
 {
-
-  return !(checkPoint(QPoint(0, 0), w)
-           && checkPoint(QPoint(w->width() - 1, 0), w)
-           && checkPoint(QPoint(0, w->height() - 1), w)
-           && checkPoint(QPoint(w->width() - 1, w->height() - 1), w)
-           && checkPoint(QPoint(w->width()/2, w->height()/2), w));
+    return !(checkPoint(QPoint(0, 0), w)
+        && checkPoint(QPoint(w->width() - 1, 0), w)
+        && checkPoint(QPoint(0, w->height() - 1), w)
+        && checkPoint(QPoint(w->width() - 1, w->height() - 1), w)
+        && checkPoint(QPoint(w->width() / 2, w->height() / 2), w));
 }
 
 void openDebugLogfile()

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -266,15 +266,17 @@ void SendCoinsDialog::pasteEntry(const SendCoinsRecipient &rv)
     entry->setValue(rv);
 }
 
-
-void SendCoinsDialog::handleURI(const QString &uri)
+bool SendCoinsDialog::handleURI(const QString &uri)
 {
     SendCoinsRecipient rv;
-    if(!GUIUtil::parseBitcoinURI(uri, &rv))
+    // URI has to be valid
+    if (GUIUtil::parseBitcoinURI(uri, &rv))
     {
-        return;
+        pasteEntry(rv);
+        return true;
     }
-    pasteEntry(rv);
+
+    return false;
 }
 
 void SendCoinsDialog::setBalance(qint64 balance, qint64 unconfirmedBalance, qint64 immatureBalance)

--- a/src/qt/sendcoinsdialog.h
+++ b/src/qt/sendcoinsdialog.h
@@ -30,7 +30,7 @@ public:
     QWidget *setupTabChain(QWidget *prev);
 
     void pasteEntry(const SendCoinsRecipient &rv);
-    void handleURI(const QString &uri);
+    bool handleURI(const QString &uri);
 
 public slots:
     void clear();


### PR DESCRIPTION
- validate bitcoin address in the URI before switching to sendCoinsPage and pasting into the form, when a bitcoin: link is clicked
- validate bitcoin address in the URI before switching to sendCoinsPage and pasting into the form, when a bitcoin: link is dropped on the Bitcoin-Qt window (Drag&Drop feature)
- show a tray-notification if an URI could not be parsed to alert the user
