### PR TITLE
database log size has increased so CheckDiskSpace needs to change

### DIFF
--- a/src/db.cpp
+++ b/src/db.cpp
@@ -87,7 +87,7 @@ CDB::CDB(const char* pszFile, const char* pszMode) : pdb(NULL)
             int nDbCache = GetArg("-dbcache", 25);
             dbenv.set_lg_dir(strLogDir.c_str());
             dbenv.set_cachesize(nDbCache / 1024, (nDbCache % 1024)*1048576, 1);
-            dbenv.set_lg_bsize(10485760);
+            dbenv.set_lg_bsize(DB_LOG_BUFFER_SIZE);
             dbenv.set_lg_max(DB_MAX_LOG_SIZE);
             dbenv.set_lk_max_locks(10000);
             dbenv.set_lk_max_objects(10000);

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -88,7 +88,7 @@ CDB::CDB(const char* pszFile, const char* pszMode) : pdb(NULL)
             dbenv.set_lg_dir(strLogDir.c_str());
             dbenv.set_cachesize(nDbCache / 1024, (nDbCache % 1024)*1048576, 1);
             dbenv.set_lg_bsize(10485760);
-            dbenv.set_lg_max(104857600);
+            dbenv.set_lg_max(DB_MAX_LOG_SIZE);
             dbenv.set_lk_max_locks(10000);
             dbenv.set_lk_max_objects(10000);
             dbenv.set_errfile(fopen(strErrorFile.c_str(), "a")); /// debug

--- a/src/db.h
+++ b/src/db.h
@@ -26,7 +26,11 @@ class CTxIndex;
 class CWallet;
 class CWalletTx;
 
-static const u_int32_t DB_MAX_LOG_SIZE = 100*1024*1024;
+// the size of the in-memory log buffer, in bytes
+static const u_int32_t DB_LOG_BUFFER_SIZE = 10 * 1024*1024;
+
+// the maximum size of a single file in the log, in bytes
+static const u_int32_t DB_MAX_LOG_SIZE = 10 * DB_LOG_BUFFER_SIZE;
 
 extern unsigned int nWalletDBUpdated;
 extern DbEnv dbenv;

--- a/src/db.h
+++ b/src/db.h
@@ -26,6 +26,8 @@ class CTxIndex;
 class CWallet;
 class CWalletTx;
 
+static const u_int32_t DB_MAX_LOG_SIZE = 100*1024*1024;
+
 extern unsigned int nWalletDBUpdated;
 extern DbEnv dbenv;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1804,8 +1804,8 @@ bool CheckDiskSpace(uint64 nAdditionalBytes)
 {
     uint64 nFreeBytesAvailable = filesystem::space(GetDataDir()).available;
 
-    // Check for 110MB because database could create another 100MB log file at any time
-    if (nFreeBytesAvailable < (uint64)115343360 + nAdditionalBytes)
+    // Make sure we have enough space for at least one more database log file, plus 10 MB
+    if (nFreeBytesAvailable < (uint64)(DB_MAX_LOG_SIZE + 10*1024*1024) + nAdditionalBytes)
     {
         fShutdown = true;
         string strMessage = _("Warning: Disk space is low  ");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1804,8 +1804,8 @@ bool CheckDiskSpace(uint64 nAdditionalBytes)
 {
     uint64 nFreeBytesAvailable = filesystem::space(GetDataDir()).available;
 
-    // Check for 15MB because database could create another 10MB log file at any time
-    if (nFreeBytesAvailable < (uint64)15000000 + nAdditionalBytes)
+    // Check for 110MB because database could create another 100MB log file at any time
+    if (nFreeBytesAvailable < (uint64)115343360 + nAdditionalBytes)
     {
         fShutdown = true;
         string strMessage = _("Warning: Disk space is low  ");


### PR DESCRIPTION
The database log size recently increased from 10MB to 100MB, but CheckDiskSpace() is still only checking for 15MB free before warning.  That needs to be increased "because database could create another 100MB log file at any time".
