### PR TITLE
Add flag -dbtrimlogs to occasionally remove database logs

### DIFF
--- a/src/db.cpp
+++ b/src/db.cpp
@@ -159,8 +159,11 @@ void CDB::Close()
         nMinutes = 1;
     if (strFile == "addr.dat")
         nMinutes = 2;
-    if (strFile == "blkindex.dat" && IsInitialBlockDownload() && nBestHeight % 5000 != 0)
-        nMinutes = 1;
+    if (strFile == "blkindex.dat")
+        if (nBestHeight % 5000 == 0)
+            dbenv.log_archive(NULL, DB_ARCH_REMOVE); // remove log files that are no longer needed
+        else if (IsInitialBlockDownload())
+            nMinutes = 1;
     dbenv.txn_checkpoint(0, nMinutes, 0);
 
     CRITICAL_BLOCK(cs_db)


### PR DESCRIPTION
When set, -dbtrimlogs will delete old unused database log files every 5000 blocks.  Otherwise several GB of logs build up while downloading the (1GB) blockchain, and are only deleted when the client exits.

Fixes part of the bug #999.  The QT client still sometimes crashes when it runs out of disk space.
