### PR TITLE
Auto-remove logs, and decrease logfile size to 10M

### DIFF
--- a/src/db.cpp
+++ b/src/db.cpp
@@ -87,12 +87,13 @@ CDB::CDB(const char* pszFile, const char* pszMode) : pdb(NULL)
             int nDbCache = GetArg("-dbcache", 25);
             dbenv.set_lg_dir(strLogDir.c_str());
             dbenv.set_cachesize(nDbCache / 1024, (nDbCache % 1024)*1048576, 1);
-            dbenv.set_lg_bsize(10485760);
-            dbenv.set_lg_max(104857600);
+            dbenv.set_lg_bsize(1048576);
+            dbenv.set_lg_max(10485760);
             dbenv.set_lk_max_locks(10000);
             dbenv.set_lk_max_objects(10000);
             dbenv.set_errfile(fopen(strErrorFile.c_str(), "a")); /// debug
             dbenv.set_flags(DB_AUTO_COMMIT, 1);
+            dbenv.log_set_config(DB_LOG_AUTO_REMOVE, 1);
             ret = dbenv.open(strDataDir.c_str(),
                              DB_CREATE     |
                              DB_INIT_LOCK  |


### PR DESCRIPTION
This is an alternative to pull #1004 , to fix part of bug #999

Tested by doing a complete blockchain download and observing the number of log files every 2 minutes (see https://gist.github.com/2236954 -- maximum of 5 were created).

Removing log files before shutdown does make 'catastrophic database recovery' impossible, however catastrophic recovery is only possible if you have ALL of the log files available (all since the creation of the database), so the only situation in which that is an issue would be a brand-new user running Bitcoin for the first time and then suffering a disk-corrupting failure before they shutdown.
