### PR TITLE
Use transactions-updated as flush condition

### DIFF
--- a/src/db.cpp
+++ b/src/db.cpp
@@ -28,6 +28,7 @@ static bool fDbEnvInit = false;
 DbEnv dbenv(0);
 static map<string, int> mapFileUseCount;
 static map<string, Db*> mapDb;
+static int64 nTxn = 0;
 
 static void EnvShutdown()
 {
@@ -160,8 +161,15 @@ void CDB::Close()
         nMinutes = 1;
     if (strFile == "addr.dat")
         nMinutes = 2;
-    if (strFile == "blkindex.dat" && IsInitialBlockDownload() && nBestHeight % 5000 != 0)
-        nMinutes = 1;
+    if (strFile == "blkindex.dat" && IsInitialBlockDownload())
+        nMinutes = 5;
+
+    if (nMinutes == 0 || nTxn > 200000)
+    {
+        nTxn = 0;
+        nMinutes = 0;
+    }
+
     dbenv.txn_checkpoint(0, nMinutes, 0);
 
     CRITICAL_BLOCK(cs_db)
@@ -336,6 +344,7 @@ bool CTxDB::ReadTxIndex(uint256 hash, CTxIndex& txindex)
 bool CTxDB::UpdateTxIndex(uint256 hash, const CTxIndex& txindex)
 {
     assert(!fClient);
+    nTxn++;
     return Write(make_pair(string("tx"), hash), txindex);
 }
 
@@ -346,6 +355,7 @@ bool CTxDB::AddTxIndex(const CTransaction& tx, const CDiskTxPos& pos, int nHeigh
     // Add to tx index
     uint256 hash = tx.GetHash();
     CTxIndex txindex(pos, tx.vout.size());
+    nTxn++;
     return Write(make_pair(string("tx"), hash), txindex);
 }
 


### PR DESCRIPTION
The normal checkpointing during the block chain download is reduced
to every five minutes only, but forced every 200000 updated transactions.
