### PR TITLE
fix "commas at the end of enumerator lists..." compiler warning

### DIFF
--- a/src/base58.h
+++ b/src/base58.h
@@ -266,7 +266,7 @@ public:
         PUBKEY_ADDRESS = 0,
         SCRIPT_ADDRESS = 5,
         PUBKEY_ADDRESS_TEST = 111,
-        SCRIPT_ADDRESS_TEST = 196,
+        SCRIPT_ADDRESS_TEST = 196
     };
 
     bool SetHash160(const uint160& hash160)

--- a/src/main.h
+++ b/src/main.h
@@ -382,7 +382,7 @@ enum GetMinFee_mode
 {
     GMF_BLOCK,
     GMF_RELAY,
-    GMF_SEND,
+    GMF_SEND
 };
 
 typedef std::map<uint256, std::pair<CTxIndex, CTransaction> > MapPrevTx;

--- a/src/net.h
+++ b/src/net.h
@@ -47,7 +47,7 @@ bool StopNode();
 enum
 {
     MSG_TX = 1,
-    MSG_BLOCK,
+    MSG_BLOCK
 };
 
 class CRequestTracker

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -60,7 +60,7 @@ class CMessageHeader
 /** nServices flags */
 enum
 {
-    NODE_NETWORK = (1 << 0),
+    NODE_NETWORK = (1 << 0)
 };
 
 /** A CService with information about it as peer */

--- a/src/script.h
+++ b/src/script.h
@@ -21,7 +21,7 @@ enum
     SIGHASH_ALL = 1,
     SIGHASH_NONE = 2,
     SIGHASH_SINGLE = 3,
-    SIGHASH_ANYONECANPAY = 0x80,
+    SIGHASH_ANYONECANPAY = 0x80
 };
 
 
@@ -32,7 +32,7 @@ enum txnouttype
     TX_PUBKEY,
     TX_PUBKEYHASH,
     TX_SCRIPTHASH,
-    TX_MULTISIG,
+    TX_MULTISIG
 };
 
 const char* GetTxnOutputType(txnouttype t);

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -78,7 +78,7 @@ enum
 
     // modifiers
     SER_SKIPSIG         = (1 << 16),
-    SER_BLOCKHEADERONLY = (1 << 17),
+    SER_BLOCKHEADERONLY = (1 << 17)
 };
 
 #define IMPLEMENT_SERIALIZE(statements)    \


### PR DESCRIPTION
Fixed compiler warning / hint "commas at the end of enumerator lists are a C++0x-specific feature". Guess the commas were there by mistake, so I removed them and it still compiles fine :).
