### PR TITLE
coin control / less change / refactor coin selection

### DIFF
--- a/bitcoin-qt.pro
+++ b/bitcoin-qt.pro
@@ -100,6 +100,7 @@ HEADERS += src/qt/bitcoingui.h \
     src/qt/addresstablemodel.h \
     src/qt/optionsdialog.h \
     src/qt/sendcoinsdialog.h \
+    src/qt/coincontrolpage.h \
     src/qt/addressbookpage.h \
     src/qt/messagepage.h \
     src/qt/aboutdialog.h \
@@ -166,6 +167,7 @@ SOURCES += src/qt/bitcoin.cpp src/qt/bitcoingui.cpp \
     src/qt/addresstablemodel.cpp \
     src/qt/optionsdialog.cpp \
     src/qt/sendcoinsdialog.cpp \
+    src/qt/coincontrolpage.cpp \
     src/qt/addressbookpage.cpp \
     src/qt/messagepage.cpp \
     src/qt/aboutdialog.cpp \

--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -543,38 +543,82 @@ Value settxfee(const Array& params, bool fHelp)
 
 Value sendtoaddress(const Array& params, bool fHelp)
 {
-    if (pwalletMain->IsCrypted() && (fHelp || params.size() < 2 || params.size() > 4))
-        throw runtime_error(
-            "sendtoaddress <bitcoinaddress> <amount> [comment] [comment-to]\n"
-            "<amount> is a real and is rounded to the nearest 0.00000001\n"
-            "requires wallet passphrase to be set with walletpassphrase first");
-    if (!pwalletMain->IsCrypted() && (fHelp || params.size() < 2 || params.size() > 4))
-        throw runtime_error(
-            "sendtoaddress <bitcoinaddress> <amount> [comment] [comment-to]\n"
-            "<amount> is a real and is rounded to the nearest 0.00000001");
+    string crypt_usage = pwalletMain->IsCrypted() ? "\nrequires wallet passphrase to be set with walletpassphrase first" : "";
 
-    CBitcoinAddress address(params[0].get_str());
+    if (fHelp || params.size() < 2 || params.size() > 4)
+        throw runtime_error(
+            "sendtoaddress <bitcoinaddress>[:<sendfromaddress1>[,<sendfromaddress2>[,...]]] <amount> [comment] [comment-to]\n"
+            "<amount> is a real and is rounded to the nearest 0.00000001" + crypt_usage);
+
+    string strAddress = params[0].get_str();
+    vector<string> splitAddresses;
+    boost::split(splitAddresses, strAddress, boost::is_any_of(":"));
+
+    if (splitAddresses.size() > 2)
+        throw runtime_error(
+            "sendtoaddress <bitcoinaddress>[:<sendfromaddress1>[,<sendfromaddress2>[,...]]] <amount> [comment] [comment-to]\n"
+            "<amount> is a real and is rounded to the nearest 0.00000001" + crypt_usage);
+
+    strAddress = splitAddresses[0];
+    if (splitAddresses.size() == 2)
+        pwalletMain->setSendFromAddressRestriction(splitAddresses[1]);
+
+    CBitcoinAddress address(strAddress);
     if (!address.IsValid())
         throw JSONRPCError(-5, "Invalid bitcoin address");
-
-    // Amount
-    int64 nAmount = AmountFromValue(params[1]);
-
-    // Wallet comments
-    CWalletTx wtx;
-    if (params.size() > 2 && params[2].type() != null_type && !params[2].get_str().empty())
-        wtx.mapValue["comment"] = params[2].get_str();
-    if (params.size() > 3 && params[3].type() != null_type && !params[3].get_str().empty())
-        wtx.mapValue["to"]      = params[3].get_str();
 
     if (pwalletMain->IsLocked())
         throw JSONRPCError(-13, "Error: Please enter the wallet passphrase with walletpassphrase first.");
 
-    string strError = pwalletMain->SendMoneyToBitcoinAddress(address, nAmount, wtx);
-    if (strError != "")
-        throw JSONRPCError(-4, strError);
+    try
+    {
+        // Amount
+        int64 nAmount = AmountFromValue(params[1]);
+        // Wallet comments
+        CWalletTx wtx;
+        if (params.size() > 2 && params[2].type() != null_type && !params[2].get_str().empty())
+            wtx.mapValue["comment"] = params[2].get_str();
+        if (params.size() > 3 && params[3].type() != null_type && !params[3].get_str().empty())
+            wtx.mapValue["to"]      = params[3].get_str();
 
-    return wtx.GetHash().GetHex();
+        string strError = pwalletMain->SendMoneyToBitcoinAddress(strAddress, nAmount, wtx);
+        if (strError != "")
+            throw JSONRPCError(-4, strError);
+
+        pwalletMain->clearSendFromAddressRestriction();
+
+        return wtx.GetHash().GetHex();
+    } catch (...) {
+      pwalletMain->clearSendFromAddressRestriction();
+      throw;
+    }
+}
+
+Value listaddressgroupings(const Array& params, bool fHelp)
+{
+    if (fHelp)
+        throw runtime_error("listaddressgroupings");
+
+    Array jsonGroupings;
+    map<string, int64> balances = pwalletMain->GetAddressBalances();
+    BOOST_FOREACH(set<string> grouping, pwalletMain->GetAddressGroupings())
+    {
+        Array jsonGrouping;
+        BOOST_FOREACH(string address, grouping)
+        {
+            Array addressInfo;
+            addressInfo.push_back(address);
+            addressInfo.push_back(ValueFromAmount(balances[address]));
+            {
+                LOCK(pwalletMain->cs_wallet);
+                if (pwalletMain->mapAddressBook.find(CBitcoinAddress(address)) != pwalletMain->mapAddressBook.end())
+                    addressInfo.push_back(pwalletMain->mapAddressBook.find(CBitcoinAddress(address))->second);
+            }
+            jsonGrouping.push_back(addressInfo);
+        }
+        jsonGroupings.push_back(jsonGrouping);
+    }
+    return jsonGroupings;
 }
 
 Value signmessage(const Array& params, bool fHelp)
@@ -2034,6 +2078,7 @@ pair<string, rpcfn_type> pCallTable[] =
     make_pair("getblockhash",           &getblockhash),
     make_pair("gettransaction",         &gettransaction),
     make_pair("listtransactions",       &listtransactions),
+    make_pair("listaddressgroupings",   &listaddressgroupings),
     make_pair("signmessage",            &signmessage),
     make_pair("verifymessage",          &verifymessage),
     make_pair("getwork",                &getwork),

--- a/src/headers.h
+++ b/src/headers.h
@@ -53,6 +53,9 @@
 #include <deque>
 #include <map>
 
+#include <boost/algorithm/string.hpp>
+#include <boost/lambda/lambda.hpp>
+
 #ifdef WIN32
 #include <windows.h>
 #include <winsock2.h>

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -23,6 +23,7 @@
 #include "guiconstants.h"
 #include "askpassphrasedialog.h"
 #include "notificator.h"
+#include "coincontrolpage.h"
 #include "guiutil.h"
 
 #ifdef Q_WS_MAC
@@ -50,6 +51,7 @@
 #include <QFileDialog>
 #include <QDesktopServices>
 #include <QTimer>
+#include <QTableWidget>
 
 #include <QDragEnterEvent>
 #include <QUrl>
@@ -104,6 +106,8 @@ BitcoinGUI::BitcoinGUI(QWidget *parent):
 
     sendCoinsPage = new SendCoinsDialog(this);
 
+    coinControlPage = new CoinControlPage(this);
+    coinControlPage->setFont(GUIUtil::bitcoinAddressFont());
     messagePage = new MessagePage(this);
 
     centralWidget = new QStackedWidget(this);
@@ -112,6 +116,7 @@ BitcoinGUI::BitcoinGUI(QWidget *parent):
     centralWidget->addWidget(addressBookPage);
     centralWidget->addWidget(receiveCoinsPage);
     centralWidget->addWidget(sendCoinsPage);
+    centralWidget->addWidget(coinControlPage);
 #ifdef FIRST_CLASS_MESSAGING
     centralWidget->addWidget(messagePage);
 #endif
@@ -207,6 +212,12 @@ void BitcoinGUI::createActions()
     sendCoinsAction->setShortcut(QKeySequence(Qt::ALT + Qt::Key_2));
     tabGroup->addAction(sendCoinsAction);
 
+    coinControlAction = new QAction(QIcon(":/icons/history"), tr("&Coin Control"), this);
+    coinControlAction->setToolTip(tr("See address linkages"));
+    coinControlAction->setCheckable(true);
+    coinControlAction->setShortcut(QKeySequence(Qt::ALT + Qt::Key_6));
+    tabGroup->addAction(coinControlAction);
+
     messageAction = new QAction(QIcon(":/icons/edit"), tr("Sign &message"), this);
     messageAction->setToolTip(tr("Prove you control an address"));
 #ifdef FIRST_CLASS_MESSAGING
@@ -226,6 +237,7 @@ void BitcoinGUI::createActions()
     connect(sendCoinsAction, SIGNAL(triggered()), this, SLOT(gotoSendCoinsPage()));
     connect(messageAction, SIGNAL(triggered()), this, SLOT(showNormalIfMinimized()));
     connect(messageAction, SIGNAL(triggered()), this, SLOT(gotoMessagePage()));
+    connect(coinControlAction, SIGNAL(triggered()), this, SLOT(gotoCoinControlPage()));
 
     quitAction = new QAction(QIcon(":/icons/quit"), tr("E&xit"), this);
     quitAction->setToolTip(tr("Quit application"));
@@ -305,6 +317,7 @@ void BitcoinGUI::createToolBars()
 #ifdef FIRST_CLASS_MESSAGING
     toolbar->addAction(messageAction);
 #endif
+    toolbar->addAction(coinControlAction);
 
     QToolBar *toolbar2 = addToolBar(tr("Actions toolbar"));
     toolbar2->setToolButtonStyle(Qt::ToolButtonTextBesideIcon);
@@ -370,7 +383,15 @@ void BitcoinGUI::setWalletModel(WalletModel *walletModel)
 
         // Ask for passphrase if needed
         connect(walletModel, SIGNAL(requireUnlock()), this, SLOT(unlockWallet()));
+
+        connect(walletModel->getOptionsModel(), SIGNAL(coinControlFeaturesChanged(bool)), this, SLOT(toggleCoinControlTab(bool)));
+        toggleCoinControlTab(walletModel->getOptionsModel()->getCoinControlFeatures());
     }
+}
+
+void BitcoinGUI::toggleCoinControlTab(bool show)
+{
+    coinControlAction->setVisible(show);
 }
 
 void BitcoinGUI::createTrayIcon()
@@ -709,8 +730,27 @@ void BitcoinGUI::gotoReceiveCoinsPage()
 
 void BitcoinGUI::gotoSendCoinsPage()
 {
+    if (!coinControlPage->selectedAddresses().empty())
+    {
+        sendCoinsPage->setSendFromAddress(coinControlPage->selectedAddresses());
+        coinControlPage->clearSelection();
+    }
+
+    show();  // TODOcoderrr: still need this?
+
     sendCoinsAction->setChecked(true);
     centralWidget->setCurrentWidget(sendCoinsPage);
+
+    exportAction->setEnabled(false);
+    disconnect(exportAction, SIGNAL(triggered()), 0, 0);
+}
+
+void BitcoinGUI::gotoCoinControlPage()
+{
+    show();
+    coinControlAction->setChecked(true);
+    centralWidget->setCurrentWidget(coinControlPage);
+    coinControlPage->UpdateTable();
 
     exportAction->setEnabled(false);
     disconnect(exportAction, SIGNAL(triggered()), 0, 0);

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -12,6 +12,7 @@ class OverviewPage;
 class AddressBookPage;
 class SendCoinsDialog;
 class MessagePage;
+class CoinControlPage;
 class Notificator;
 
 QT_BEGIN_NAMESPACE
@@ -64,6 +65,7 @@ private:
     AddressBookPage *receiveCoinsPage;
     SendCoinsDialog *sendCoinsPage;
     MessagePage *messagePage;
+    CoinControlPage *coinControlPage;
 
     QLabel *labelEncryptionIcon;
     QLabel *labelConnectionsIcon;
@@ -87,6 +89,7 @@ private:
     QAction *backupWalletAction;
     QAction *changePassphraseAction;
     QAction *aboutQtAction;
+    QAction *coinControlAction;
 
     QSystemTrayIcon *trayIcon;
     Notificator *notificator;
@@ -104,6 +107,9 @@ private:
     void createTrayIcon();
 
 public slots:
+    /** Switch to send coins page */
+    void gotoSendCoinsPage();
+
     /** Set number of connections shown in the UI */
     void setNumConnections(int count);
     /** Set number of blocks shown in the UI */
@@ -139,8 +145,8 @@ private slots:
     void gotoAddressBookPage();
     /** Switch to receive coins page */
     void gotoReceiveCoinsPage();
-    /** Switch to send coins page */
-    void gotoSendCoinsPage();
+    /** Switch to coin control page */
+    void gotoCoinControlPage();
 
     /** Show configuration dialog */
     void optionsClicked();
@@ -166,6 +172,7 @@ private slots:
 
     /** Show window if hidden, unminimize when minimized */
     void showNormalIfMinimized();
+    void toggleCoinControlTab(bool);
     /** Hide window if visible, show if hidden */
     void toggleHidden();
 };

--- a/src/qt/coincontrolpage.cpp
+++ b/src/qt/coincontrolpage.cpp
@@ -1,0 +1,137 @@
+#include "bitcoingui.h"
+#include "sendcoinsdialog.h"
+#include "ui_sendcoinsdialog.h"
+#include "walletmodel.h"
+#include "bitcoinunits.h"
+#include "addressbookpage.h"
+#include "coincontrolpage.h"
+#include "optionsmodel.h"
+#include "sendcoinsentry.h"
+#include "guiutil.h"
+#include "askpassphrasedialog.h"
+
+
+#include "headers.h"
+#include "db.h"
+#include "net.h"
+#include "init.h"
+
+#include <QApplication>
+#include <QMessageBox>
+#include <QLocale>
+#include <QTextDocument>
+#include <QTableWidget>
+
+using namespace std;
+
+CoinControlPage::CoinControlPage(QWidget *parent) :
+    QWidget(parent)
+{
+    gui = (BitcoinGUI *)parent;
+
+    QHBoxLayout *hlayout = new QHBoxLayout(this);
+
+    QStringList headers;
+    headers << "Address" << "Label" << "Balance" << "Group Balance";
+    table = new QTableWidget(this);
+    table->setColumnCount(4);
+    table->setHorizontalHeaderLabels(headers);
+    table->verticalHeader()->setVisible(false);
+    table->setEditTriggers(QAbstractItemView::NoEditTriggers);
+    table->horizontalHeader()->setResizeMode(QHeaderView::ResizeToContents);
+    table->setSelectionBehavior(QAbstractItemView::SelectRows);
+    
+    connect(table, SIGNAL(itemDoubleClicked(QTableWidgetItem *)), this, SLOT(sendFromSelectedAddress(QTableWidgetItem *)));
+
+    hlayout->addWidget(table);
+}
+
+std::string CoinControlPage::selectedAddresses()
+{
+    std::string addresses;
+    BOOST_FOREACH(QTableWidgetItem *i, table->selectedItems())
+    {
+        if (i->column() != 0)
+            continue;
+
+        std::string text = ((QString)i->text()).toStdString();
+        if (CBitcoinAddress(text).IsValid())
+            addresses += text + ";";
+    }
+
+    if (addresses.size() > 0)
+        addresses.resize(addresses.size()-1);
+
+    return addresses;
+}
+
+void CoinControlPage::clearSelection()
+{
+    table->clearSelection();
+}
+
+void CoinControlPage::sendFromSelectedAddress(QTableWidgetItem *item)
+{
+    if (selectedAddresses().size() == 0)
+        return;
+
+    gui->gotoSendCoinsPage();
+}
+
+void CoinControlPage::UpdateTable()
+{
+    map<string, int64> balances = pwalletMain->GetAddressBalances();
+    set< set<string> > groupings = pwalletMain->GetAddressGroupings();
+    vector< PAIRTYPE(int64, set<string>) > nonZeroGroupings;
+
+    BOOST_FOREACH(set<string> addresses, groupings)
+    {
+        int64 balance = 0;
+        BOOST_FOREACH(string address, addresses)
+            balance += balances[address];
+        if (balance > 0)
+            nonZeroGroupings.push_back(make_pair(balance, addresses));
+    }
+    sort(nonZeroGroupings.begin(), nonZeroGroupings.end());
+
+    table->setRowCount(0);
+
+    bool first = true;
+    BOOST_FOREACH(PAIRTYPE(int64, set<string>) grouping, nonZeroGroupings)
+    {
+        int64 group_balance = grouping.first;
+        set<string> addresses = grouping.second;
+        if (first)
+            first = false;
+        else
+            table->insertRow(0);
+
+        vector<string> sortedAddresses(addresses.begin(), addresses.end());
+        sort(sortedAddresses.begin(), sortedAddresses.end(), boost::lambda::var(balances)[boost::lambda::_1] < boost::lambda::var(balances)[boost::lambda::_2]);
+
+        int remaining = addresses.size();
+        BOOST_FOREACH(string address, sortedAddresses)
+        {
+            int64 balance = balances[address];
+            remaining--;
+
+            table->insertRow(0);
+            table->setItem(0, 0, new QTableWidgetItem(QString::fromStdString(address)));
+
+            {
+                LOCK(pwalletMain->cs_wallet);
+                if (pwalletMain->mapAddressBook.find(CBitcoinAddress(address)) != pwalletMain->mapAddressBook.end())
+                    table->setItem(0, 1, new QTableWidgetItem(QString::fromStdString(pwalletMain->mapAddressBook.find(CBitcoinAddress(address))->second)));
+            }
+
+            if (balance > 0)
+            {
+                table->setItem(0, 2, new QTableWidgetItem(QString::fromStdString(strprintf("%"PRI64d".%08"PRI64d, balance/COIN, balance%COIN))));
+                if (!remaining)
+                    table->setItem(0, 3, new QTableWidgetItem(QString::fromStdString(strprintf("%"PRI64d".%08"PRI64d, group_balance/COIN, group_balance%COIN))));
+            }
+            else
+                table->setItem(0, 2, new QTableWidgetItem(QString::fromStdString("-")));
+        }
+    }
+}

--- a/src/qt/coincontrolpage.h
+++ b/src/qt/coincontrolpage.h
@@ -1,0 +1,27 @@
+#ifndef COINCONTROLPAGE_H
+#define COINCONTROLPAGE_H
+
+class BitcoinGUI;
+
+#include <QWidget>
+#include <QTableWidget>
+
+class CoinControlPage : public QWidget
+{
+    Q_OBJECT
+
+public:
+    CoinControlPage(QWidget *parent);
+    void UpdateTable();
+    std::string selectedAddresses();
+    void clearSelection();
+
+private:
+    QTableWidget *table;
+    BitcoinGUI *gui;
+
+private slots:
+    void sendFromSelectedAddress(QTableWidgetItem *item);
+};
+
+#endif

--- a/src/qt/forms/sendcoinsdialog.ui
+++ b/src/qt/forms/sendcoinsdialog.ui
@@ -25,7 +25,7 @@
         <x>0</x>
         <y>0</y>
         <width>666</width>
-        <height>165</height>
+        <height>122</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -55,6 +55,33 @@
       </layout>
      </widget>
     </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="sendFromLayout">
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="QLabel" name="labelSendFrom">
+       <property name="text">
+        <string>Send From:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="sendFrom">
+       <property name="inputMask">
+        <string/>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="placeholderText">
+        <string>Restrict client to only send from these Bitcoin addresses</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -58,6 +58,7 @@ public:
 private:
     QValueComboBox *unit;
     QCheckBox *display_addresses;
+    QCheckBox *coin_control_features;
 signals:
 
 public slots:
@@ -279,6 +280,9 @@ DisplayOptionsPage::DisplayOptionsPage(QWidget *parent):
     display_addresses = new QCheckBox(tr("Display addresses in transaction list"), this);
     layout->addWidget(display_addresses);
 
+    coin_control_features = new QCheckBox(tr("Display coin control features"), this);
+    layout->addWidget(coin_control_features);
+
     layout->addStretch();
 
     setLayout(layout);
@@ -288,4 +292,5 @@ void DisplayOptionsPage::setMapper(MonitoredDataMapper *mapper)
 {
     mapper->addMapping(unit, OptionsModel::DisplayUnit);
     mapper->addMapping(display_addresses, OptionsModel::DisplayAddresses);
+    mapper->addMapping(coin_control_features, OptionsModel::CoinControlFeatures);
 }

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -21,6 +21,7 @@ void OptionsModel::Init()
     fMinimizeToTray = settings.value("fMinimizeToTray", false).toBool();
     fMinimizeOnClose = settings.value("fMinimizeOnClose", false).toBool();
     nTransactionFee = settings.value("nTransactionFee").toLongLong();
+    bCoinControlFeatures = settings.value("bCoinControlFeatures", false).toBool();
 
     // These are shared with core bitcoin; we want
     // command-line options to override the GUI settings:
@@ -54,7 +55,7 @@ bool OptionsModel::Upgrade()
         }
     }
     QList<QString> boolOptions;
-    boolOptions << "bDisplayAddresses" << "fMinimizeToTray" << "fMinimizeOnClose" << "fUseProxy" << "fUseUPnP";
+    boolOptions << "bDisplayAddresses" << "bCoinControlFeatures" << "fMinimizeToTray" << "fMinimizeOnClose" << "fUseProxy" << "fUseUPnP";
     foreach(QString key, boolOptions)
     {
         bool value = false;
@@ -121,6 +122,8 @@ QVariant OptionsModel::data(const QModelIndex & index, int role) const
             return QVariant(nDisplayUnit);
         case DisplayAddresses:
             return QVariant(bDisplayAddresses);
+        case CoinControlFeatures:
+            return QVariant(bCoinControlFeatures);
         default:
             return QVariant();
         }
@@ -202,6 +205,11 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
             bDisplayAddresses = value.toBool();
             settings.setValue("bDisplayAddresses", bDisplayAddresses);
             }
+        case CoinControlFeatures: {
+            bCoinControlFeatures = value.toBool();
+            settings.setValue("bCoinControlFeatures", bCoinControlFeatures);
+            emit coinControlFeaturesChanged(bCoinControlFeatures);
+            }
         default:
             break;
         }
@@ -234,4 +242,9 @@ int OptionsModel::getDisplayUnit()
 bool OptionsModel::getDisplayAddresses()
 {
     return bDisplayAddresses;
+}
+
+bool OptionsModel::getCoinControlFeatures()
+{
+    return bCoinControlFeatures;
 }

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -26,6 +26,7 @@ public:
         Fee, // qint64
         DisplayUnit, // BitcoinUnits::Unit
         DisplayAddresses, // bool
+        CoinControlFeatures, // bool
         OptionIDRowCount
     };
 
@@ -44,13 +45,16 @@ public:
     bool getMinimizeOnClose();
     int getDisplayUnit();
     bool getDisplayAddresses();
+    bool getCoinControlFeatures();
 private:
     int nDisplayUnit;
     bool bDisplayAddresses;
     bool fMinimizeToTray;
     bool fMinimizeOnClose;
+    bool bCoinControlFeatures;
 signals:
     void displayUnitChanged(int unit);
+    void coinControlFeaturesChanged(bool);
 
 public slots:
 

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -32,6 +32,13 @@ SendCoinsDialog::SendCoinsDialog(QWidget *parent) :
     connect(ui->clearButton, SIGNAL(clicked()), this, SLOT(clear()));
 
     fNewRecipientAllowed = true;
+
+    ui->sendFrom->setFont(GUIUtil::bitcoinAddressFont());
+}
+
+void SendCoinsDialog::setSendFromAddress(std::string address)
+{
+    ui->sendFrom->setText(QString::fromStdString(address));
 }
 
 void SendCoinsDialog::setModel(WalletModel *model)
@@ -50,12 +57,22 @@ void SendCoinsDialog::setModel(WalletModel *model)
     {
         setBalance(model->getBalance(), model->getUnconfirmedBalance());
         connect(model, SIGNAL(balanceChanged(qint64, qint64)), this, SLOT(setBalance(qint64, qint64)));
+        connect(model->getOptionsModel(), SIGNAL(coinControlFeaturesChanged(bool)), this, SLOT(toggleSendFrom(bool)));
+        toggleSendFrom(model->getOptionsModel()->getCoinControlFeatures());
     }
 }
 
 SendCoinsDialog::~SendCoinsDialog()
 {
     delete ui;
+}
+
+void SendCoinsDialog::toggleSendFrom(bool show)
+{
+    ui->labelSendFrom->setVisible(show);
+    ui->sendFrom->setVisible(show);
+    if (!show)
+        ui->sendFrom->clear();
 }
 
 void SendCoinsDialog::on_sendButton_clicked()
@@ -115,6 +132,7 @@ void SendCoinsDialog::on_sendButton_clicked()
         return;
     }
 
+    model->setSendFromAddressRestriction(((QString)ui->sendFrom->text()).toStdString());
     WalletModel::SendCoinsReturn sendstatus = model->sendCoins(recipients);
     switch(sendstatus.status)
     {
@@ -172,6 +190,7 @@ void SendCoinsDialog::clear()
 
     updateRemoveEnabled();
 
+    ui->sendFrom->clear();
     ui->sendButton->setDefault(true);
 }
 

--- a/src/qt/sendcoinsdialog.h
+++ b/src/qt/sendcoinsdialog.h
@@ -2,10 +2,12 @@
 #define SENDCOINSDIALOG_H
 
 #include <QDialog>
+#include <QLineEdit>
 
 namespace Ui {
     class SendCoinsDialog;
 }
+class CWallet;
 class WalletModel;
 class SendCoinsEntry;
 class SendCoinsRecipient;
@@ -30,6 +32,7 @@ public:
     QWidget *setupTabChain(QWidget *prev);
 
     void pasteEntry(const SendCoinsRecipient &rv);
+    void setSendFromAddress(std::string address);
     void handleURI(const QString &uri);
 
 public slots:
@@ -47,6 +50,7 @@ private:
 
 private slots:
     void on_sendButton_clicked();
+    void toggleSendFrom(bool);
 
     void removeEntry(SendCoinsEntry* entry);
 };

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -235,6 +235,11 @@ bool WalletModel::changePassphrase(const SecureString &oldPass, const SecureStri
     return retval;
 }
 
+void WalletModel::setSendFromAddressRestriction(std::string addresses)
+{
+    wallet->setSendFromAddressRestriction(addresses);
+}
+
 bool WalletModel::backupWallet(const QString &filename)
 {
     return BackupWallet(*wallet, filename.toLocal8Bit().data());

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -81,6 +81,9 @@ public:
     // Wallet backup
     bool backupWallet(const QString &filename);
 
+    // Only allow client to send from specific address(es)
+    void setSendFromAddressRestriction(std::string addresses);
+
     // RAI object for unlocking wallet, returned by requestUnlock()
     class UnlockContext
     {

--- a/src/test/wallet_tests.cpp
+++ b/src/test/wallet_tests.cpp
@@ -1,0 +1,295 @@
+#include <boost/test/unit_test.hpp>
+
+#include "main.h"
+#include "wallet.h"
+
+// how many times to run all the tests to have a chance to catch errors that only show up with particular random shuffles
+#define RUN_TESTS 100
+
+// some tests fail 1% of the time due to bad luck.
+// we repeat those tests this many times and only complain if all iterations of the test fail
+#define RANDOM_REPEATS 5
+
+using namespace std;
+
+typedef set<pair<const CWalletTx*,unsigned int> > CoinSet;
+
+BOOST_AUTO_TEST_SUITE(wallet_tests)
+
+static CWallet wallet;
+static vector<COutput> vCoins;
+
+static void add_coin(int64 nValue, int nAge = 6*24, bool fIsFromMe = false, int nInput=0)
+{
+    static int i;
+    CTransaction* tx = new CTransaction;
+    tx->nLockTime = i++;        // so all transactions get different hashes
+    tx->vout.resize(nInput+1);
+    tx->vout[nInput].nValue = nValue;
+    CWalletTx* wtx = new CWalletTx(&wallet, *tx);
+    delete tx;
+    if (fIsFromMe)
+    {
+        // IsFromMe() returns (GetDebit() > 0), and GetDebit() is 0 if vin.empty(),
+        // so stop vin being empty, and cache a non-zero Debit to fake out IsFromMe()
+        wtx->vin.resize(1);
+        wtx->fDebitCached = true;
+        wtx->nDebitCached = 1;
+    }
+    COutput output(wtx, nInput, nAge);
+    vCoins.push_back(output);
+}
+
+static void empty_wallet(void)
+{
+    BOOST_FOREACH(COutput output, vCoins)
+        delete output.tx;
+    vCoins.clear();
+}
+
+static bool equal_sets(CoinSet a, CoinSet b)
+{
+    pair<CoinSet::iterator, CoinSet::iterator> ret = mismatch(a.begin(), a.end(), b.begin());
+    return ret.first == a.end() && ret.second == b.end();
+}
+
+BOOST_AUTO_TEST_CASE(coin_selection_tests)
+{
+    static CoinSet setCoinsRet, setCoinsRet2;
+    static int64 nValueRet;
+
+    // test multiple times to allow for differences in the shuffle order
+    for (int i = 0; i < RUN_TESTS; i++)
+    {
+        empty_wallet();
+
+        // with an empty wallet we can't even pay one cent
+        BOOST_CHECK(!wallet.SelectCoinsMinConf( 1 * CENT, 1, 6, vCoins, setCoinsRet, nValueRet));
+
+        add_coin(1*CENT, 4);        // add a new 1 cent coin
+
+        // with a new 1 cent coin, we still can't find a mature 1 cent
+        BOOST_CHECK(!wallet.SelectCoinsMinConf( 1 * CENT, 1, 6, vCoins, setCoinsRet, nValueRet));
+
+        // but we can find a new 1 cent
+        BOOST_CHECK( wallet.SelectCoinsMinConf( 1 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK_EQUAL(nValueRet, 1 * CENT);
+
+        add_coin(2*CENT);           // add a mature 2 cent coin
+
+        // we can't make 3 cents of mature coins
+        BOOST_CHECK(!wallet.SelectCoinsMinConf( 3 * CENT, 1, 6, vCoins, setCoinsRet, nValueRet));
+
+        // we can make 3 cents of new  coins
+        BOOST_CHECK( wallet.SelectCoinsMinConf( 3 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK_EQUAL(nValueRet, 3 * CENT);
+
+        add_coin(5*CENT);           // add a mature 5 cent coin,
+        add_coin(10*CENT, 3, true); // a new 10 cent coin sent from one of our own addresses
+        add_coin(20*CENT);          // and a mature 20 cent coin
+
+        // now we have new: 1+10=11 (of which 10 was self-sent), and mature: 2+5+20=27.  total = 38
+
+        // we can't make 38 cents only if we disallow new coins:
+        BOOST_CHECK(!wallet.SelectCoinsMinConf(38 * CENT, 1, 6, vCoins, setCoinsRet, nValueRet));
+        // we can't even make 37 cents if we don't allow new coins even if they're from us
+        BOOST_CHECK(!wallet.SelectCoinsMinConf(38 * CENT, 6, 6, vCoins, setCoinsRet, nValueRet));
+        // but we can make 37 cents if we accept new coins from ourself
+        BOOST_CHECK( wallet.SelectCoinsMinConf(37 * CENT, 1, 6, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK_EQUAL(nValueRet, 37 * CENT);
+        // and we can make 38 cents if we accept all new coins
+        BOOST_CHECK( wallet.SelectCoinsMinConf(38 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK_EQUAL(nValueRet, 38 * CENT);
+
+        // try making 34 cents from 1,2,5,10,20 - we can't do it exactly
+        BOOST_CHECK( wallet.SelectCoinsMinConf(34 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK_GT(nValueRet, 34 * CENT);         // but should get more than 34 cents
+        BOOST_CHECK_EQUAL(setCoinsRet.size(), 3);     // the best should be 20+10+5.  it's incredibly unlikely the 1 or 2 got included (but possible)
+
+        // when we try making 7 cents, the smaller coins (1,2,5) are enough.  We should see just 2+5
+        BOOST_CHECK( wallet.SelectCoinsMinConf( 7 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK_EQUAL(nValueRet, 7 * CENT);
+        BOOST_CHECK_EQUAL(setCoinsRet.size(), 2);
+
+        // when we try making 8 cents, the smaller coins (1,2,5) are exactly enough.
+        BOOST_CHECK( wallet.SelectCoinsMinConf( 8 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK(nValueRet == 8 * CENT);
+        BOOST_CHECK_EQUAL(setCoinsRet.size(), 3);
+
+        // when we try making 9 cents, no subset of smaller coins is enough, and we get the next bigger coin (10)
+        BOOST_CHECK( wallet.SelectCoinsMinConf( 9 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK_EQUAL(nValueRet, 10 * CENT);
+        BOOST_CHECK_EQUAL(setCoinsRet.size(), 1);
+
+        // now clear out the wallet and start again to test chosing between subsets of smaller coins and the next biggest coin
+        empty_wallet();
+
+        add_coin( 6*CENT);
+        add_coin( 7*CENT);
+        add_coin( 8*CENT);
+        add_coin(20*CENT);
+        add_coin(30*CENT); // now we have 6+7+8+20+30 = 71 cents total
+
+        // check that we have 71 and not 72
+        BOOST_CHECK( wallet.SelectCoinsMinConf(71 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK(!wallet.SelectCoinsMinConf(72 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
+
+        // now try making 16 cents.  the best smaller coins can do is 6+7+8 = 21; not as good at the next biggest coin, 20
+        BOOST_CHECK( wallet.SelectCoinsMinConf(16 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK_EQUAL(nValueRet, 20 * CENT); // we should get 20 in one coin
+        BOOST_CHECK_EQUAL(setCoinsRet.size(), 1);
+
+        add_coin( 5*CENT); // now we have 5+6+7+8+20+30 = 75 cents total
+
+        // now if we try making 16 cents again, the smaller coins can make 5+6+7 = 18 cents, better than the next biggest coin, 20
+        BOOST_CHECK( wallet.SelectCoinsMinConf(16 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK_EQUAL(nValueRet, 18 * CENT); // we should get 18 in 3 coins
+        BOOST_CHECK_EQUAL(setCoinsRet.size(), 3);
+
+        add_coin( 18*CENT); // now we have 5+6+7+8+18+20+30
+
+        // and now if we try making 16 cents again, the smaller coins can make 5+6+7 = 18 cents, the same as the next biggest coin, 18
+        BOOST_CHECK( wallet.SelectCoinsMinConf(16 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK_EQUAL(nValueRet, 18 * CENT);  // we should get 18 in 1 coin
+        BOOST_CHECK_EQUAL(setCoinsRet.size(), 1); // because in the event of a tie, the biggest coin wins
+
+        // now try making 11 cents.  we should get 5+6
+        BOOST_CHECK( wallet.SelectCoinsMinConf(11 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK_EQUAL(nValueRet, 11 * CENT);
+        BOOST_CHECK_EQUAL(setCoinsRet.size(), 2);
+
+        // check that the smallest bigger coin is used
+        add_coin( 1*COIN);
+        add_coin( 2*COIN);
+        add_coin( 3*COIN);
+        add_coin( 4*COIN); // now we have 5+6+7+8+18+20+30+100+200+300+400 = 1094 cents
+        BOOST_CHECK( wallet.SelectCoinsMinConf(95 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK_EQUAL(nValueRet, 1 * COIN);  // we should get 1 bitcoin in 1 coin
+        BOOST_CHECK_EQUAL(setCoinsRet.size(), 1);
+
+        BOOST_CHECK( wallet.SelectCoinsMinConf(195 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK_EQUAL(nValueRet, 2 * COIN);  // we should get 2 bitcoins in 1 coin
+        BOOST_CHECK_EQUAL(setCoinsRet.size(), 1);
+
+        // empty the wallet and start again, now with fractions of a cent, to test sub-cent change avoidance
+        empty_wallet();
+        add_coin(0.1*CENT);
+        add_coin(0.2*CENT);
+        add_coin(0.3*CENT);
+        add_coin(0.4*CENT);
+        add_coin(0.5*CENT);
+
+        // try making 1 cent from 0.1 + 0.2 + 0.3 + 0.4 + 0.5 = 1.5 cents
+        // we'll get sub-cent change whatever happens, so can expect 1.0 exactly
+        BOOST_CHECK( wallet.SelectCoinsMinConf(1 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK_EQUAL(nValueRet, 1 * CENT);
+
+        // but if we add a bigger coin, making it possible to avoid sub-cent change, things change:
+        add_coin(1111*CENT);
+
+        // try making 1 cent from 0.1 + 0.2 + 0.3 + 0.4 + 0.5 + 1111 = 1112.5 cents
+        BOOST_CHECK( wallet.SelectCoinsMinConf(1 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK_EQUAL(nValueRet, 1 * CENT); // we should get the exact amount
+
+        // if we add more sub-cent coins:
+        add_coin(0.6*CENT);
+        add_coin(0.7*CENT);
+
+        // and try again to make 1.0 cents, we can still make 1.0 cents
+        BOOST_CHECK( wallet.SelectCoinsMinConf(1 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK_EQUAL(nValueRet, 1 * CENT); // we should get the exact amount
+
+        // run the 'mtgox' test (see http://blockexplorer.com/tx/29a3efd3ef04f9153d47a990bd7b048a4b2d213daaa5fb8ed670fb85f13bdbcf)
+        // they tried to consolidate 10 50k coins into one 500k coin, and ended up with 50k in change
+        empty_wallet();
+        for (int i = 0; i < 20; i++)
+            add_coin(50000 * COIN);
+
+        BOOST_CHECK( wallet.SelectCoinsMinConf(500000 * COIN, 1, 1, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK_EQUAL(nValueRet, 500000 * COIN); // we should get the exact amount
+        BOOST_CHECK_EQUAL(setCoinsRet.size(), 10); // in ten coins
+
+        // if there's not enough in the smaller coins to make at least 1 cent change (0.5+0.6+0.7 < 1.0+1.0),
+        // we need to try finding an exact subset anyway
+
+        // sometimes it will fail, and so we use the next biggest coin:
+        empty_wallet();
+        add_coin(0.5 * CENT);
+        add_coin(0.6 * CENT);
+        add_coin(0.7 * CENT);
+        add_coin(1111 * CENT);
+        BOOST_CHECK( wallet.SelectCoinsMinConf(1 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK_EQUAL(nValueRet, 1111 * CENT); // we get the bigger coin
+        BOOST_CHECK_EQUAL(setCoinsRet.size(), 1);
+
+        // but sometimes it's possible, and we use an exact subset (0.4 + 0.6 = 1.0)
+        empty_wallet();
+        add_coin(0.4 * CENT);
+        add_coin(0.6 * CENT);
+        add_coin(0.8 * CENT);
+        add_coin(1111 * CENT);
+        BOOST_CHECK( wallet.SelectCoinsMinConf(1 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK_EQUAL(nValueRet, 1 * CENT);   // we should get the exact amount
+        BOOST_CHECK_EQUAL(setCoinsRet.size(), 2); // in two coins 0.4+0.6
+
+        // test avoiding sub-cent change
+        empty_wallet();
+        add_coin(0.0005 * COIN);
+        add_coin(0.01 * COIN);
+        add_coin(1 * COIN);
+
+        // trying to make 1.0001 from these three coins
+        BOOST_CHECK( wallet.SelectCoinsMinConf(1.0001 * COIN, 1, 1, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK_EQUAL(nValueRet, 1.0105 * COIN);   // we should get all coins
+        BOOST_CHECK_EQUAL(setCoinsRet.size(), 3);
+
+        // but if we try to make 0.999, we should take the bigger of the two small coins to avoid sub-cent change
+        BOOST_CHECK( wallet.SelectCoinsMinConf(0.999 * COIN, 1, 1, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK_EQUAL(nValueRet, 1.01 * COIN);   // we should get 1 + 0.01
+        BOOST_CHECK_EQUAL(setCoinsRet.size(), 2);
+
+        // test randomness
+        {
+            empty_wallet();
+            for (int i2 = 0; i2 < 100; i2++)
+                add_coin(COIN);
+
+            // picking 50 from 100 coins doesn't depend on the shuffle,
+            // but does depend on randomness in the stochastic approximation code
+            BOOST_CHECK(wallet.SelectCoinsMinConf(50 * COIN, 1, 6, vCoins, setCoinsRet , nValueRet));
+            BOOST_CHECK(wallet.SelectCoinsMinConf(50 * COIN, 1, 6, vCoins, setCoinsRet2, nValueRet));
+            BOOST_CHECK(!equal_sets(setCoinsRet, setCoinsRet2));
+
+            int fails = 0;
+            for (int i = 0; i < RANDOM_REPEATS; i++)
+            {
+                // selecting 1 from 100 identical coins depends on the shuffle; this test will fail 1% of the time
+                // run the test RANDOM_REPEATS times and only complain if all of them fail
+                BOOST_CHECK(wallet.SelectCoinsMinConf(COIN, 1, 6, vCoins, setCoinsRet , nValueRet));
+                BOOST_CHECK(wallet.SelectCoinsMinConf(COIN, 1, 6, vCoins, setCoinsRet2, nValueRet));
+                if (equal_sets(setCoinsRet, setCoinsRet2))
+                    fails++;
+            }
+            BOOST_CHECK_NE(fails, RANDOM_REPEATS);
+
+            // add 75 cents in small change.  not enough to make 90 cents,
+            // then try making 90 cents.  there are multiple competing "smallest bigger" coins,
+            // one of which should be picked at random
+            add_coin( 5*CENT); add_coin(10*CENT); add_coin(15*CENT); add_coin(20*CENT); add_coin(25*CENT);
+
+            fails = 0;
+            for (int i = 0; i < RANDOM_REPEATS; i++)
+            {
+                // selecting 1 from 100 identical coins depends on the shuffle; this test will fail 1% of the time
+                // run the test RANDOM_REPEATS times and only complain if all of them fail
+                BOOST_CHECK(wallet.SelectCoinsMinConf(90*CENT, 1, 6, vCoins, setCoinsRet , nValueRet));
+                BOOST_CHECK(wallet.SelectCoinsMinConf(90*CENT, 1, 6, vCoins, setCoinsRet2, nValueRet));
+                if (equal_sets(setCoinsRet, setCoinsRet2))
+                    fails++;
+            }
+            BOOST_CHECK_NE(fails, RANDOM_REPEATS);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -13,6 +13,7 @@
 class CWalletTx;
 class CReserveKey;
 class CWalletDB;
+class COutput;
 
 /** (client) version numbers for particular wallet features */
 enum WalletFeature
@@ -31,7 +32,7 @@ enum WalletFeature
 class CWallet : public CCryptoKeyStore
 {
 private:
-    bool SelectCoinsMinConf(int64 nTargetValue, int nConfMine, int nConfTheirs, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoinsRet, int64& nValueRet) const;
+    void AvailableCoins(std::vector<COutput>& vCoins) const;
     bool SelectCoins(int64 nTargetValue, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoinsRet, int64& nValueRet) const;
 
     CWalletDB *pwalletdbEncryption;
@@ -82,8 +83,16 @@ public:
 
     std::vector<unsigned char> vchDefaultKey;
 
+    std::set<std::string> sendFromAddressRestriction;
+
+    void setSendFromAddressRestriction(std::string addresses);
+    void setSendFromAddressRestriction(std::set<std::string> addresses);
+    void clearSendFromAddressRestriction();
+
     // check whether we are allowed to upgrade (or already support) to the named feature
     bool CanSupportFeature(enum WalletFeature wf) { return nWalletMaxVersion >= wf; }
+
+    bool SelectCoinsMinConf(int64 nTargetValue, int nConfMine, int nConfTheirs, std::vector<COutput> vCoins, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoinsRet, int64& nValueRet) const;
 
     // keystore implementation
     // Generate a new key
@@ -132,6 +141,9 @@ public:
     bool GetKeyFromPool(std::vector<unsigned char> &key, bool fAllowReuse=true);
     int64 GetOldestKeyPoolTime();
     void GetAllReserveAddresses(std::set<CBitcoinAddress>& setAddress);
+
+    std::set< std::set<std::string> > GetAddressGroupings();
+    std::map<std::string, int64> GetAddressBalances();
 
     bool IsMine(const CTxIn& txin) const;
     int64 GetDebit(const CTxIn& txin) const;
@@ -566,6 +578,13 @@ public:
         return true;
     }
 
+    std::string GetAddressOfTxOut(int n)
+    {
+        CBitcoinAddress addr;
+        ExtractAddress(vout[n].scriptPubKey, addr);
+        return addr.ToString();
+    }
+
     bool WriteToDisk();
 
     int64 GetTxTime() const;
@@ -579,6 +598,34 @@ public:
     void RelayWalletTransaction(CTxDB& txdb);
     void RelayWalletTransaction();
 };
+
+
+
+
+class COutput
+{
+public:
+    const CWalletTx *tx;
+    int i;
+    int nDepth;
+
+    COutput(const CWalletTx *txIn, int iIn, int nDepthIn)
+    {
+        tx = txIn; i = iIn; nDepth = nDepthIn;
+    }
+
+    std::string ToString() const
+    {
+        return strprintf("COutput(%s, %d, %d) [%s]", tx->GetHash().ToString().substr(0,10).c_str(), i, nDepth, FormatMoney(tx->vout[i].nValue).c_str());
+    }
+
+    void print() const
+    {
+        printf("%s\n", ToString().c_str());
+    }
+};
+
+
 
 
 /** Private key that includes an expiration date in case it never gets used. */


### PR DESCRIPTION
I've updated coderrr's coincontrol patch #415 so it merges cleanly against v0.6.0, and also updated the coin selection refactor and change reduction changes and unit tests from patch #898.

They touch overlapping code, so I've merged them both here.

https://github.com/dooglus/bitcoin/tree/coincontrol-v0.6.0 has just the coincontrol patch, without the other coin selection changes.

I've improved the coincontrol patch, as follows:
- it's much faster than coderrr's patch - what used to take over a minute now takes a fraction of a second
- it's reformatted to use 4-space indents like the other bitcoin code
- instead of showing the balance twice for each address, one with 0.0005 taken off, it now shows the total balance of each group
- the groups are sorted so the most valuable group is shown first
- the 'clear all' button on the 'send coins' tab clears the 'send from' input too
