### PR TITLE
massive URI-handling / IPC server re-work

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -116,23 +116,34 @@ static void handleRunawayException(std::exception *e)
 #ifndef BITCOIN_QT_TEST
 int main(int argc, char *argv[])
 {
-#if !defined(MAC_OSX) && !defined(WIN32)
-// TODO: implement qtipcserver.cpp for Mac and Windows
+#if !defined(MAC_OSX)
+// TODO: implement qtipcserver.cpp for Mac
 
     // Do this early as we don't want to bother initializing if we are just calling IPC
     for (int i = 1; i < argc; i++)
     {
-        if (boost::algorithm::istarts_with(argv[i], "bitcoin:"))
+        // limit length of parsed URIs to max. size of message queue messages
+        if (strlen(argv[i]) <= IPC_MQ_MAX_MESSAGE_SIZE && boost::algorithm::istarts_with(argv[i], "bitcoin:"))
         {
-            const char *strURI = argv[i];
+            std::string strURI = argv[i];
             try {
-                boost::interprocess::message_queue mq(boost::interprocess::open_only, BITCOINURI_QUEUE_NAME);
-                if(mq.try_send(strURI, strlen(strURI), 0))
+                boost::interprocess::message_queue mq(boost::interprocess::open_only, IPC_MQ_NAME);
+                if (mq.try_send(strURI.c_str(), strURI.length(), 0))
                     exit(0);
                 else
                     break;
             }
             catch (boost::interprocess::interprocess_exception &ex) {
+                // don't log the "file not found" exception, because that's normal for
+                // the first start of the first instance
+                if (ex.get_error_code() != boost::interprocess::not_found_error)
+                {
+                    printf("boost interprocess exception #%d: %s\n", ex.get_error_code(), ex.what());
+
+                    // without this every clicked bitcoin: URI would show the datadir locked error in the case of an exception,
+                    // while the client is already running (perhaps this should be shown as message box?)
+                    exit(0);
+                }
                 break;
             }
         }
@@ -262,8 +273,8 @@ int main(int argc, char *argv[])
                 {
                     window.show();
                 }
-#if !defined(MAC_OSX) && !defined(WIN32)
-// TODO: implement qtipcserver.cpp for Mac and Windows
+#if !defined(MAC_OSX)
+// TODO: implement qtipcserver.cpp for Mac
 
                 // Place this here as guiref has to be defined if we dont want to lose URIs
                 ipcInit();
@@ -271,14 +282,17 @@ int main(int argc, char *argv[])
                 // Check for URI in argv
                 for (int i = 1; i < argc; i++)
                 {
-                    if (boost::algorithm::istarts_with(argv[i], "bitcoin:"))
+                    // only bother with this if IPC is initialized
+                    if (globalIpcState == IPC_INITIALIZED && strlen(argv[i]) <= IPC_MQ_MAX_MESSAGE_SIZE && boost::algorithm::istarts_with(argv[i], "bitcoin:"))
                     {
-                        const char *strURI = argv[i];
+                        std::string strURI = argv[i];
                         try {
-                            boost::interprocess::message_queue mq(boost::interprocess::open_only, BITCOINURI_QUEUE_NAME);
-                            mq.try_send(strURI, strlen(strURI), 0);
+                            boost::interprocess::message_queue mq(boost::interprocess::open_only, IPC_MQ_NAME);
+                            mq.try_send(strURI.c_str(), strURI.length(), 0);
                         }
                         catch (boost::interprocess::interprocess_exception &ex) {
+                            printf("boost interprocess exception #%d: %s\n", ex.get_error_code(), ex.what());
+                            break;
                         }
                     }
                 }

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -122,13 +122,12 @@ int main(int argc, char *argv[])
     // Do this early as we don't want to bother initializing if we are just calling IPC
     for (int i = 1; i < argc; i++)
     {
-        // limit length of parsed URIs to max. size of message queue messages
-        if (strlen(argv[i]) <= IPC_MQ_MAX_MESSAGE_SIZE && boost::algorithm::istarts_with(argv[i], "bitcoin:"))
+        if (boost::algorithm::istarts_with(argv[i], "bitcoin:"))
         {
             std::string strURI = argv[i];
             try {
                 boost::interprocess::message_queue mq(boost::interprocess::open_only, IPC_MQ_NAME);
-                if (mq.try_send(strURI.c_str(), strURI.length(), 0))
+                if (mq.try_send(strURI.data(), strURI.length(), 0))
                     exit(0);
                 else
                     break;
@@ -283,12 +282,12 @@ int main(int argc, char *argv[])
                 for (int i = 1; i < argc; i++)
                 {
                     // only bother with this if IPC is initialized
-                    if (globalIpcState == IPC_INITIALIZED && strlen(argv[i]) <= IPC_MQ_MAX_MESSAGE_SIZE && boost::algorithm::istarts_with(argv[i], "bitcoin:"))
+                    if (globalIpcState == IPC_INITIALIZED && boost::algorithm::istarts_with(argv[i], "bitcoin:"))
                     {
                         std::string strURI = argv[i];
                         try {
                             boost::interprocess::message_queue mq(boost::interprocess::open_only, IPC_MQ_NAME);
-                            mq.try_send(strURI.c_str(), strURI.length(), 0);
+                            mq.try_send(strURI.data(), strURI.length(), 0);
                         }
                         catch (boost::interprocess::interprocess_exception &ex) {
                             printf("boost interprocess exception #%d: %s\n", ex.get_error_code(), ex.what());

--- a/src/qt/qtipcserver.cpp
+++ b/src/qt/qtipcserver.cpp
@@ -2,88 +2,115 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file license.txt or http://www.opensource.org/licenses/mit-license.php.
 
-#include <boost/algorithm/string.hpp>
+#include <boost/filesystem.hpp>
 #include <boost/interprocess/ipc/message_queue.hpp>
-#include <boost/tokenizer.hpp>
-#include <boost/date_time/posix_time/posix_time.hpp>
 
 #include "ui_interface.h"
+#include "util.h"
 #include "qtipcserver.h"
 
-using namespace boost::interprocess;
-using namespace boost::posix_time;
 using namespace boost;
-using namespace std;
 
-void ipcShutdown()
+/** global state definition */
+ipcState globalIpcState = IPC_NOT_INITIALIZED;
+
+void ipcThread(void* pArg)
 {
-    message_queue::remove(BITCOINURI_QUEUE_NAME);
+    IMPLEMENT_RANDOMIZE_STACK(ipcThread(pArg));
+    try
+    {
+        ipcThread2(pArg);
+    }
+    catch (std::exception& e) {
+        PrintExceptionContinue(&e, "ipcThread()");
+    } catch (...) {
+        PrintExceptionContinue(NULL, "ipcThread()");
+    }
+    printf("ipcThread exited\n");
 }
 
-void ipcThread(void* parg)
+void ipcThread2(void* pArg)
 {
-    message_queue* mq = (message_queue*)parg;
-    char strBuf[257];
-    size_t nSize;
-    unsigned int nPriority;
+    printf("ipcThread started\n");
+
+    interprocess::message_queue* mq = (interprocess::message_queue*)pArg;
+    char buffer[IPC_MQ_MAX_MESSAGE_SIZE + 1] = "";
+    size_t nSize = 0;
+    unsigned int nPriority = 0;
+
     loop
     {
-        ptime d = boost::posix_time::microsec_clock::universal_time() + millisec(100);
-        if(mq->timed_receive(&strBuf, sizeof(strBuf), nSize, nPriority, d))
+        if (mq->try_receive(&buffer, sizeof(buffer), nSize, nPriority))
         {
-            uiInterface.ThreadSafeHandleURI(std::string(strBuf, nSize));
+            uiInterface.ThreadSafeHandleURI(std::string(buffer, nSize));
             Sleep(1000);
         }
+        else
+            /** needs to be here to stop this thread from utilizing 100% of a CPU core */
+            Sleep(100);
+
         if (fShutdown)
-        {
-            ipcShutdown();
             break;
-        }
     }
-    ipcShutdown();
+
+    /** cleanup allocated memory and set global IPC state to not initialized */
+    delete mq;
+    globalIpcState = IPC_NOT_INITIALIZED;
 }
 
-void ipcInit()
+void ipcInit(bool fUseMQModeOpenOnly, bool fInitCalledAfterRecovery)
 {
-#ifdef MAC_OSX
-    // TODO: implement bitcoin: URI handling the Mac Way
-    return;
-#endif
-#ifdef WIN32
-    // TODO: THOROUGHLY test boost::interprocess fix,
-    // and make sure there are no Windows argument-handling exploitable
-    // problems.
-    return;
-#endif
+    /** set global IPC state variable to not initialized */
+    globalIpcState = IPC_NOT_INITIALIZED;
 
-    message_queue* mq;
-    char strBuf[257];
-    size_t nSize;
-    unsigned int nPriority;
+    interprocess::message_queue* mq = NULL;
+
     try {
-        mq = new message_queue(open_or_create, BITCOINURI_QUEUE_NAME, 2, 256);
-
-        // Make sure we don't lose any bitcoin: URIs
-        for (int i = 0; i < 2; i++)
-        {
-            ptime d = boost::posix_time::microsec_clock::universal_time() + millisec(1);
-            if(mq->timed_receive(&strBuf, sizeof(strBuf), nSize, nPriority, d))
-            {
-                uiInterface.ThreadSafeHandleURI(std::string(strBuf, nSize));
-            }
-            else
-                break;
-        }
-
-        // Make sure only one bitcoin instance is listening
-        message_queue::remove(BITCOINURI_QUEUE_NAME);
-        mq = new message_queue(open_or_create, BITCOINURI_QUEUE_NAME, 2, 256);
+        if (fUseMQModeOpenOnly)
+            mq = new interprocess::message_queue(interprocess::open_only, IPC_MQ_NAME);
+        else
+            mq = new interprocess::message_queue(interprocess::create_only, IPC_MQ_NAME, IPC_MQ_MAX_MESSAGES, IPC_MQ_MAX_MESSAGE_SIZE);
     }
-    catch (interprocess_exception &ex) {
+    catch (interprocess::interprocess_exception &ex) {
+#ifdef WIN32
+        /** check if the exception is a "file not found" error */
+        if(ex.get_error_code() == interprocess::not_found_error)
+        {
+            if (!fInitCalledAfterRecovery)
+            {
+                printf("ipcInit - trying to create new message queue...\n");
+
+                /** try init once more (false - create_only mode / true - avoid an infinite recursion)
+                 * create_only: create new message queue
+                 */
+                ipcInit(false, true);
+            }
+        }
+        /** check if the exception is a "file already exists" error */
+        else if (ex.get_error_code() == interprocess::already_exists_error)
+        {
+            if (!fInitCalledAfterRecovery)
+            {
+                printf("ipcInit - trying to open current message queue...\n");
+
+                /** try init once more (true - open_only mode / true - avoid an infinite recursion)
+                 * open_only: try to open the existing queue
+                 */
+                ipcInit(true, true);
+            }
+        }
+        else
+            printf("ipcInit - boost interprocess exception #%d: %s\n", ex.get_error_code(), ex.what());
+#endif
         return;
     }
+
     if (!CreateThread(ipcThread, mq))
     {
         delete mq;
+        return;
     }
+
+    /** if we reach this, set global IPC state to initialized */
+    globalIpcState = IPC_INITIALIZED;
 }

--- a/src/qt/qtipcserver.cpp
+++ b/src/qt/qtipcserver.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file license.txt or http://www.opensource.org/licenses/mit-license.php.
 
+#include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/interprocess/ipc/message_queue.hpp>
 
@@ -40,14 +41,12 @@ void ipcThread2(void* pArg)
 
     loop
     {
-        if (mq->try_receive(&buffer, sizeof(buffer), nSize, nPriority))
+        boost::posix_time::ptime d = boost::posix_time::microsec_clock::universal_time() + boost::posix_time::millisec(100);
+        if (mq->timed_receive(&buffer, sizeof(buffer), nSize, nPriority, d))
         {
             uiInterface.ThreadSafeHandleURI(std::string(buffer, nSize));
             Sleep(1000);
         }
-        else
-            /** needs to be here to stop this thread from utilizing 100% of a CPU core */
-            Sleep(100);
 
         if (fShutdown)
             break;
@@ -60,7 +59,7 @@ void ipcThread2(void* pArg)
 
 void ipcInit(bool fUseMQModeOpenOnly, bool fInitCalledAfterRecovery)
 {
-    /** set global IPC state variable to not initialized */
+    /** set global IPC state to not initialized */
     globalIpcState = IPC_NOT_INITIALIZED;
 
     interprocess::message_queue* mq = NULL;

--- a/src/qt/qtipcserver.h
+++ b/src/qt/qtipcserver.h
@@ -1,4 +1,27 @@
-#define BITCOINURI_QUEUE_NAME "BitcoinURI"
+#ifndef QTIPCSERVER_H
+#define QTIPCSERVER_H
 
-void ipcInit();
-void ipcShutdown();
+using namespace boost;
+
+/** define Bitcoin-Qt message queue name */
+#define IPC_MQ_NAME "BitcoinURI"
+
+/** define Bitcoin-Qt message queue maximum message number */
+#define IPC_MQ_MAX_MESSAGES 2
+
+/** define Bitcoin-Qt message queue maximum message size */
+#define IPC_MQ_MAX_MESSAGE_SIZE 255
+
+enum ipcState {
+    IPC_NOT_INITIALIZED = 0,
+    IPC_INITIALIZED = 1
+};
+
+/** global state declaration */
+extern ipcState globalIpcState;
+
+void ipcThread(void* pArg);
+void ipcThread2(void* pArg);
+void ipcInit(bool fUseMQModeOpenOnly = true, bool fInitCalledAfterRecovery = false);
+
+#endif // QTIPCSERVER_H


### PR DESCRIPTION
What I try to achieve here:
- harden the URI handling / IPC server (i.e. buffer length checks use of  IMPLEMENT_RANDOMIZE_STACK for the ipcThread)
- log and handle boost interprocess exceptions where possible
- make URI handling more usable / robust on Windows (and not worse on other platforms - needs tests on Linux OSes)

What I achieved (running and verified on Windows):
- it's possible to start the client via URI click, if no message_queue file exists
- if one exists the clicked URI is sent to the queue file, but doesn't start the client (call to try_send() in bitcoin.cpp succeeds and we exit there - currently no check if the client is running - ideas are welcome), the URI is processed after manually starting the client and is not lost
- on Windows it's now possible to use 2 client instances in parallel and the first started one receives clicked URIs, if I close one of the instances the one left will process URIs
- URI length is limited to 255 chars as message queue message size is 256 chars max.

What I could not achieve:
- handle some special cases i.e. a BitcoinURI file get's created by a user and is placed in the boost_interprocess folder -> results in the GUI freeze bug, as the file permissions differ from what boost would set, when creating the mq file -> that causes a boost deadlock (https://svn.boost.org/trac/boost/ticket/6745)

Some details:
The message queue is not removed anymore when closing the client, as this causes massive handling problems on Windows with 2 instances and my former approach of stale mq detection. First try is always to open the mq file for a re-use. If this fails a new mq is created.

This needs boost 1.49 with a small edit in boost/interprocess/detail/tmp_dir_helpers.hpp see: https://svn.boost.org/trac/boost/ticket/5392#comment:24

There is currently no need for any hard monkey-patches like #986.
