### PR TITLE
modified block DL progressbar to be more informative and precise

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -148,7 +148,7 @@ BitcoinGUI::BitcoinGUI(QWidget *parent):
     statusBar()->addWidget(progressBar);
     statusBar()->addPermanentWidget(frameBlocks);
 
-    // define OS independent progress bar style (has to be after addWidget(), otherwise we crash)
+    // define OS independent progress bar style (has to be placed after addWidget(), otherwise we crash)
     progressBar->setStyleSheet("QProgressBar { background-color: transparent; border: 1px solid grey; border-radius: 2px; padding: 1px; text-align: center; } QProgressBar::chunk { background: QLinearGradient(x1: 0, y1: 0, x2: 1, y2: 0, stop: 0 #FF8000, stop: 1 orange); margin: 0px; }");
 
     syncIconMovie = new QMovie(":/movies/update_spinner", "mng", this);
@@ -468,13 +468,13 @@ void BitcoinGUI::setNumBlocks(int count)
     if(count < nTotalBlocks)
     {
         int nRemainingBlocks = nTotalBlocks - count;
-        int nPercentageDone = (count / ((nTotalBlocks / 100) + 0.5f));
+        float nPercentageDone = count / (nTotalBlocks * 0.01f);
 
         if (clientModel->getStatusBarWarnings() == "")
         {
             progressBarLabel->setText(tr("Synchronizing with network..."));
             progressBarLabel->setVisible(true);
-            progressBar->setFormat("~" + QString::number(nRemainingBlocks)+ tr(" blocks remaining"));
+            progressBar->setFormat("~" + tr("%n block(s) remaining", "", nRemainingBlocks));
             progressBar->setMaximum(nTotalBlocks);
             progressBar->setValue(count);
             progressBar->setVisible(true);
@@ -485,7 +485,7 @@ void BitcoinGUI::setNumBlocks(int count)
             progressBarLabel->setVisible(true);
             progressBar->setVisible(false);
         }
-        tooltip = tr("Downloaded %1 of %2 blocks of transaction history (%3% done).").arg(count).arg(nTotalBlocks).arg(nPercentageDone);
+        tooltip = tr("Downloaded %1 of %2 blocks of transaction history (%3% done).").arg(count).arg(nTotalBlocks).arg(nPercentageDone, 0, 'f', 2);
     }
     else
     {

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -138,16 +138,20 @@ BitcoinGUI::BitcoinGUI(QWidget *parent):
     frameBlocksLayout->addWidget(labelBlocksIcon);
     frameBlocksLayout->addStretch();
 
-    // Progress bar for blocks download
-    progressBarLabel = new QLabel(tr("Synchronizing with network..."));
+    // Progress bar and label for blocks download
+    progressBarLabel = new QLabel();
     progressBarLabel->setVisible(false);
     progressBar = new QProgressBar();
-    progressBar->setToolTip(tr("Block chain synchronization in progress"));
     progressBar->setVisible(false);
 
     statusBar()->addWidget(progressBarLabel);
     statusBar()->addWidget(progressBar);
     statusBar()->addPermanentWidget(frameBlocks);
+
+    // define progress bar format
+    progressBar->setFormat(tr("~%m blocks remaining"));
+    // define OS independent progress bar style (has to be after addWidget(), otherwise we crash)
+    progressBar->setStyleSheet("QProgressBar { background-color: transparent; border: 1px solid grey; border-radius: 5px; text-align: center; } QProgressBar::chunk { background: QLinearGradient(x1: 0, y1: 0, x2: 1, y2: 0, stop: 0 transparent, stop: 1 orange); margin: 0px; }");
 
     syncIconMovie = new QMovie(":/movies/update_spinner", "mng", this);
 
@@ -471,13 +475,11 @@ void BitcoinGUI::setNumBlocks(int count)
 
         if (clientModel->getStatusBarWarnings() == "")
         {
-            progressBarLabel->setVisible(true);
             progressBarLabel->setText(tr("Synchronizing with network..."));
-            progressBar->setVisible(true);
-            progressBar->setFormat(tr("~%m blocks remaining"));
-            progressBar->setAlignment(Qt::AlignCenter);
+            progressBarLabel->setVisible(true);
             progressBar->setMaximum(nCurMax);
             progressBar->setValue(nOnePercentCurMax * nPercentageDone);
+            progressBar->setVisible(true);
         }
         else
         {

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -461,20 +461,23 @@ void BitcoinGUI::setNumBlocks(int count)
     }
 
     int nTotal = clientModel->getNumBlocksOfPeers();
-    int nPercentageLeft = 100 - (count / (nTotal / 100));
     QString tooltip;
 
     if(count < nTotal)
     {
+        int nCurMax = nTotal - count;
+        int nOnePercentCurMax = nCurMax / 100;
+        int nPercentageDone = (count / (nTotal / 100));
+
         if (clientModel->getStatusBarWarnings() == "")
         {
             progressBarLabel->setVisible(true);
             progressBarLabel->setText(tr("Synchronizing with network..."));
             progressBar->setVisible(true);
-            progressBar->setFormat(tr("%v of %m blocks (%p%)"));
+            progressBar->setFormat(tr("~%m blocks remaining"));
             progressBar->setAlignment(Qt::AlignCenter);
-            progressBar->setMaximum(nTotal);
-            progressBar->setValue(count);
+            progressBar->setMaximum(nCurMax);
+            progressBar->setValue(nOnePercentCurMax * nPercentageDone);
         }
         else
         {
@@ -482,7 +485,7 @@ void BitcoinGUI::setNumBlocks(int count)
             progressBarLabel->setVisible(true);
             progressBar->setVisible(false);
         }
-        tooltip = tr("Downloaded %1 of %2 blocks of transaction history (%3% left).").arg(count).arg(nTotal).arg(nPercentageLeft);
+        tooltip = tr("Downloaded %1 of %2 blocks of transaction history (%3% done).").arg(count).arg(nTotal).arg(nPercentageDone);
     }
     else
     {

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -149,6 +149,7 @@ BitcoinGUI::BitcoinGUI(QWidget *parent):
     statusBar()->addPermanentWidget(frameBlocks);
 
     // define OS independent progress bar style (has to be placed after addWidget(), otherwise we crash)
+    // we did this, because with some OSes default style, text on the progress bar is unreadable
     progressBar->setStyleSheet("QProgressBar { background-color: transparent; border: 1px solid grey; border-radius: 2px; padding: 1px; text-align: center; } QProgressBar::chunk { background: QLinearGradient(x1: 0, y1: 0, x2: 1, y2: 0, stop: 0 #FF8000, stop: 1 orange); margin: 0px; }");
 
     syncIconMovie = new QMovie(":/movies/update_spinner", "mng", this);
@@ -474,7 +475,7 @@ void BitcoinGUI::setNumBlocks(int count)
         {
             progressBarLabel->setText(tr("Synchronizing with network..."));
             progressBarLabel->setVisible(true);
-            progressBar->setFormat("~" + tr("%n block(s) remaining", "", nRemainingBlocks));
+            progressBar->setFormat(tr("~%n block(s) remaining", "", nRemainingBlocks));
             progressBar->setMaximum(nTotalBlocks);
             progressBar->setValue(count);
             progressBar->setVisible(true);

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -148,10 +148,8 @@ BitcoinGUI::BitcoinGUI(QWidget *parent):
     statusBar()->addWidget(progressBar);
     statusBar()->addPermanentWidget(frameBlocks);
 
-    // define progress bar format
-    progressBar->setFormat(tr("~%m blocks remaining"));
     // define OS independent progress bar style (has to be after addWidget(), otherwise we crash)
-    progressBar->setStyleSheet("QProgressBar { background-color: transparent; border: 1px solid grey; border-radius: 5px; text-align: center; } QProgressBar::chunk { background: QLinearGradient(x1: 0, y1: 0, x2: 1, y2: 0, stop: 0 #FF8000, stop: 1 orange); margin: 0px; }");
+    progressBar->setStyleSheet("QProgressBar { background-color: transparent; border: 1px solid grey; border-radius: 2px; padding: 1px; text-align: center; } QProgressBar::chunk { background: QLinearGradient(x1: 0, y1: 0, x2: 1, y2: 0, stop: 0 #FF8000, stop: 1 orange); margin: 0px; }");
 
     syncIconMovie = new QMovie(":/movies/update_spinner", "mng", this);
 
@@ -464,21 +462,21 @@ void BitcoinGUI::setNumBlocks(int count)
         return;
     }
 
-    int nTotal = clientModel->getNumBlocksOfPeers();
+    int nTotalBlocks = clientModel->getNumBlocksOfPeers();
     QString tooltip;
 
-    if(count < nTotal)
+    if(count < nTotalBlocks)
     {
-        int nCurMax = nTotal - count;
-        int nOnePercentCurMax = nCurMax / 100;
-        int nPercentageDone = (count / (nTotal / 100));
+        int nRemainingBlocks = nTotalBlocks - count;
+        int nPercentageDone = (count / ((nTotalBlocks / 100) + 0.5f));
 
         if (clientModel->getStatusBarWarnings() == "")
         {
             progressBarLabel->setText(tr("Synchronizing with network..."));
             progressBarLabel->setVisible(true);
-            progressBar->setMaximum(nCurMax);
-            progressBar->setValue(nOnePercentCurMax * nPercentageDone);
+            progressBar->setFormat("~" + QString::number(nRemainingBlocks)+ tr(" blocks remaining"));
+            progressBar->setMaximum(nTotalBlocks);
+            progressBar->setValue(count);
             progressBar->setVisible(true);
         }
         else
@@ -487,7 +485,7 @@ void BitcoinGUI::setNumBlocks(int count)
             progressBarLabel->setVisible(true);
             progressBar->setVisible(false);
         }
-        tooltip = tr("Downloaded %1 of %2 blocks of transaction history (%3% done).").arg(count).arg(nTotal).arg(nPercentageDone);
+        tooltip = tr("Downloaded %1 of %2 blocks of transaction history (%3% done).").arg(count).arg(nTotalBlocks).arg(nPercentageDone);
     }
     else
     {

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -151,7 +151,7 @@ BitcoinGUI::BitcoinGUI(QWidget *parent):
     // define progress bar format
     progressBar->setFormat(tr("~%m blocks remaining"));
     // define OS independent progress bar style (has to be after addWidget(), otherwise we crash)
-    progressBar->setStyleSheet("QProgressBar { background-color: transparent; border: 1px solid grey; border-radius: 5px; text-align: center; } QProgressBar::chunk { background: QLinearGradient(x1: 0, y1: 0, x2: 1, y2: 0, stop: 0 transparent, stop: 1 orange); margin: 0px; }");
+    progressBar->setStyleSheet("QProgressBar { background-color: transparent; border: 1px solid grey; border-radius: 5px; text-align: center; } QProgressBar::chunk { background: QLinearGradient(x1: 0, y1: 0, x2: 1, y2: 0, stop: 0 #FF8000, stop: 1 orange); margin: 0px; }");
 
     syncIconMovie = new QMovie(":/movies/update_spinner", "mng", this);
 


### PR DESCRIPTION
I added a % left value to the tooltip, the progressbar text is now displayed in it's middle centered and uses real block values instead of only a % value ("x of y blocks (z %)"). The progressbar is hidden, if there is no network connection and get's hidden, if the connection is lost.

Edit: Removed the dynamic component of the idea ;).
