### PR TITLE
Increase time ago of last block for "up to date" status from 30 to 90 minutes

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -515,7 +515,7 @@ void BitcoinGUI::setNumBlocks(int count)
     }
 
     // Set icon state: spinning if catching up, tick otherwise
-    if(secs < 30*60)
+    if(secs < 90*60)
     {
         tooltip = tr("Up to date") + QString(".\n") + tooltip;
         labelBlocksIcon->setPixmap(QIcon(":/icons/synced").pixmap(STATUSBAR_ICONSIZE,STATUSBAR_ICONSIZE));


### PR DESCRIPTION
It was too hyperactive.

@gmaxwell: I mean that right now when the block gap goes over an hour it starts showing synchronizing. Increasing that to 90 minutes or so would make it only happen about 6.4 times per year
