### PR TITLE
Show "N blocks remaining" rather than a percentage.

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -465,6 +465,7 @@ void BitcoinGUI::setNumBlocks(int count)
             progressBar->setVisible(true);
             progressBar->setMaximum(total);
             progressBar->setValue(count);
+            progressBar->setFormat(tr("%1 block(s) remaining").arg(total-count));
         }
         else
         {


### PR DESCRIPTION
As suggested by sipa in #753, show how many blocks still need syncing, rather than always just showing "99%" if the blockchain was recently synced.
