### PR TITLE
Enable addmultisigaddress RPC call for main network

### DIFF
--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -986,8 +986,6 @@ Value addmultisigaddress(const Array& params, bool fHelp)
             "If [account] is specified, assign address to [account].";
         throw runtime_error(msg);
     }
-    if (!fTestNet)
-        throw runtime_error("addmultisigaddress available only when running -testnet\n");
 
     int nRequired = params[0].get_int();
     const Array& keys = params[1].get_array();


### PR DESCRIPTION
Mining support is done, and network relay support for multisig transactions seems well on its way, so I'd like to enable the addmultisigaddress JSON-RPC call on the main network so people can start experimenting/prototyping.
