### PR TITLE
Fix #955: Verify status of encrypt/decrypt calls to detect failed padding

### DIFF
--- a/src/crypter.cpp
+++ b/src/crypter.cpp
@@ -73,13 +73,15 @@ bool CCrypter::Encrypt(const CKeyingMaterial& vchPlaintext, std::vector<unsigned
 
     EVP_CIPHER_CTX ctx;
 
+    bool fOk = true;
+
     EVP_CIPHER_CTX_init(&ctx);
-    EVP_EncryptInit_ex(&ctx, EVP_aes_256_cbc(), NULL, chKey, chIV);
-
-    EVP_EncryptUpdate(&ctx, &vchCiphertext[0], &nCLen, &vchPlaintext[0], nLen);
-    EVP_EncryptFinal_ex(&ctx, (&vchCiphertext[0])+nCLen, &nFLen);
-
+    if (fOk) fOk = EVP_EncryptInit_ex(&ctx, EVP_aes_256_cbc(), NULL, chKey, chIV);
+    if (fOk) fOk = EVP_EncryptUpdate(&ctx, &vchCiphertext[0], &nCLen, &vchPlaintext[0], nLen);
+    if (fOk) fOk = EVP_EncryptFinal_ex(&ctx, (&vchCiphertext[0])+nCLen, &nFLen);
     EVP_CIPHER_CTX_cleanup(&ctx);
+
+    if (!fOk) return false;
 
     vchCiphertext.resize(nCLen + nFLen);
     return true;
@@ -98,13 +100,15 @@ bool CCrypter::Decrypt(const std::vector<unsigned char>& vchCiphertext, CKeyingM
 
     EVP_CIPHER_CTX ctx;
 
+    bool fOk = true;
+
     EVP_CIPHER_CTX_init(&ctx);
-    EVP_DecryptInit_ex(&ctx, EVP_aes_256_cbc(), NULL, chKey, chIV);
-
-    EVP_DecryptUpdate(&ctx, &vchPlaintext[0], &nPLen, &vchCiphertext[0], nLen);
-    EVP_DecryptFinal_ex(&ctx, (&vchPlaintext[0])+nPLen, &nFLen);
-
+    if (fOk) fOk = EVP_DecryptInit_ex(&ctx, EVP_aes_256_cbc(), NULL, chKey, chIV);
+    if (fOk) fOk = EVP_DecryptUpdate(&ctx, &vchPlaintext[0], &nPLen, &vchCiphertext[0], nLen);
+    if (fOk) fOk = EVP_DecryptFinal_ex(&ctx, (&vchPlaintext[0])+nPLen, &nFLen);
     EVP_CIPHER_CTX_cleanup(&ctx);
+
+    if (!fOk) return false;
 
     vchPlaintext.resize(nPLen + nFLen);
     return true;

--- a/src/keystore.cpp
+++ b/src/keystore.cpp
@@ -84,6 +84,8 @@ bool CCryptoKeyStore::Unlock(const CKeyingMaterial& vMasterKeyIn)
             CSecret vchSecret;
             if(!DecryptSecret(vMasterKeyIn, vchCryptedSecret, Hash(vchPubKey.begin(), vchPubKey.end()), vchSecret))
                 return false;
+            if (vchSecret.size() != 32)
+                return false;
             CKey key;
             key.SetPubKey(vchPubKey);
             key.SetSecret(vchSecret);
@@ -145,6 +147,8 @@ bool CCryptoKeyStore::GetKey(const CBitcoinAddress &address, CKey& keyOut) const
             const std::vector<unsigned char> &vchCryptedSecret = (*mi).second.second;
             CSecret vchSecret;
             if (!DecryptSecret(vMasterKey, vchCryptedSecret, Hash(vchPubKey.begin(), vchPubKey.end()), vchSecret))
+                return false;
+            if (vchSecret.size() != 32)
                 return false;
             keyOut.SetPubKey(vchPubKey);
             keyOut.SetSecret(vchSecret);


### PR DESCRIPTION
Issue #955 was discovered to be caused by users entering an _incorrect_ password that accidentally (with a chance of 1/255) resulted in valid AES-CBC padding, which causes a decrypted secret of 45-47 bytes, causing a failed CKey::SetSecret call. In the normal case, a bad password causes an incorrect padding which is detected by the decrypt function. As the return code is not checked, the previously (incorrectly) decrypted 32 bytes are used anyway, leading to a succesful CKey::SetSecret call.

So in summary: we didn't know we were padding by default, and hence forgot to check for the case of a failed padding, which apparently resulted in something of the expected size.
