### PR TITLE
Document strlcpy.h in assets-attribution.txt since it isn't MIT-licensed

### DIFF
--- a/doc/assets-attribution.txt
+++ b/doc/assets-attribution.txt
@@ -1,3 +1,7 @@
+Code: src/strlcpy.h
+Author: Todd C. Miller <Todd.Miller@courtesan.com>
+License: ISC
+
 Icon: src/qt/res/icons/clock*.png, src/qt/res/icons/tx*.png,
       src/qt/res/src/*.svg
 Designer: Wladimir van der Laan


### PR DESCRIPTION
This is mainly so I don't forget where the ISC license comes from.
