### PR TITLE
Use scoped locks instead of CRITICAL_BLOCK

### DIFF
--- a/src/addrman.h
+++ b/src/addrman.h
@@ -266,8 +266,8 @@ public:
         //
         // This format is more complex, but significantly smaller (at most 1.5 MiB), and supports
         // changes to the ADDRMAN_ parameters without breaking the on-disk structure.
-        CRITICAL_BLOCK(cs)
         {
+            LOCK(cs);
             unsigned char nVersion = 0;
             READWRITE(nVersion);
             READWRITE(nKey);
@@ -398,8 +398,8 @@ public:
     void Check()
     {
 #ifdef DEBUG_ADDRMAN
-        CRITICAL_BLOCK(cs)
         {
+            LOCK(cs);
             int err;
             if ((err=Check_()))
                 printf("ADDRMAN CONSISTENCY CHECK FAILED!!! err=%i\n", err);
@@ -411,8 +411,8 @@ public:
     bool Add(const CAddress &addr, const CNetAddr& source, int64 nTimePenalty = 0)
     {
         bool fRet = false;
-        CRITICAL_BLOCK(cs)
         {
+            LOCK(cs);
             Check();
             fRet |= Add_(addr, source, nTimePenalty);
             Check();
@@ -426,8 +426,8 @@ public:
     bool Add(const std::vector<CAddress> &vAddr, const CNetAddr& source, int64 nTimePenalty = 0)
     {
         int nAdd = 0;
-        CRITICAL_BLOCK(cs)
         {
+            LOCK(cs);
             Check();
             for (std::vector<CAddress>::const_iterator it = vAddr.begin(); it != vAddr.end(); it++)
                 nAdd += Add_(*it, source, nTimePenalty) ? 1 : 0;
@@ -441,8 +441,8 @@ public:
     // Mark an entry as accessible.
     void Good(const CService &addr, int64 nTime = GetAdjustedTime())
     {
-        CRITICAL_BLOCK(cs)
         {
+            LOCK(cs);
             Check();
             Good_(addr, nTime);
             Check();
@@ -452,8 +452,8 @@ public:
     // Mark an entry as connection attempted to.
     void Attempt(const CService &addr, int64 nTime = GetAdjustedTime())
     {
-        CRITICAL_BLOCK(cs)
         {
+            LOCK(cs);
             Check();
             Attempt_(addr, nTime);
             Check();
@@ -465,8 +465,8 @@ public:
     CAddress Select(int nUnkBias = 50)
     {
         CAddress addrRet;
-        CRITICAL_BLOCK(cs)
         {
+            LOCK(cs);
             Check();
             addrRet = Select_(nUnkBias);
             Check();
@@ -479,8 +479,10 @@ public:
     {
         Check();
         std::vector<CAddress> vAddr;
-        CRITICAL_BLOCK(cs)
+        {
+            LOCK(cs);
             GetAddr_(vAddr);
+        }
         Check();
         return vAddr;
     }
@@ -488,8 +490,8 @@ public:
     // Mark an entry as currently-connected-to.
     void Connected(const CService &addr, int64 nTime = GetAdjustedTime())
     {
-        CRITICAL_BLOCK(cs)
         {
+            LOCK(cs);
             Check();
             Connected_(addr, nTime);
             Check();

--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -1648,8 +1648,8 @@ Value walletlock(const Array& params, bool fHelp)
     if (!pwalletMain->IsCrypted())
         throw JSONRPCError(-15, "Error: running with an unencrypted wallet, but walletlock was called.");
 
-    CRITICAL_BLOCK(cs_nWalletUnlockTime)
     {
+        LOCK(cs_nWalletUnlockTime);
         pwalletMain->Lock();
         nWalletUnlockTime = 0;
     }
@@ -2498,9 +2498,10 @@ void ThreadRPCServer2(void* parg)
             {
                 // Execute
                 Value result;
-                CRITICAL_BLOCK(cs_main)
-                CRITICAL_BLOCK(pwalletMain->cs_wallet)
+                {
+                    LOCK2(cs_main, pwalletMain->cs_wallet);
                     result = (*(*mi).second)(params, false);
+                }
 
                 // Send reply
                 string strReply = JSONRPCReply(result, Value::null, id);

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -72,8 +72,8 @@ CDB::CDB(const char* pszFile, const char* pszMode) : pdb(NULL)
     if (fCreate)
         nFlags |= DB_CREATE;
 
-    CRITICAL_BLOCK(cs_db)
     {
+        LOCK(cs_db);
         if (!fDbEnvInit)
         {
             if (fShutdown)
@@ -126,8 +126,10 @@ CDB::CDB(const char* pszFile, const char* pszMode) : pdb(NULL)
             {
                 delete pdb;
                 pdb = NULL;
-                CRITICAL_BLOCK(cs_db)
+                {
+                     LOCK(cs_db);
                     --mapFileUseCount[strFile];
+                }
                 strFile = "";
                 throw runtime_error(strprintf("CDB() : can't open database file %s, error %d", pszFile, ret));
             }
@@ -165,14 +167,16 @@ void CDB::Close()
 
     dbenv.txn_checkpoint(nMinutes ? GetArg("-dblogsize", 100)*1024 : 0, nMinutes, 0);
 
-    CRITICAL_BLOCK(cs_db)
+    {
+        LOCK(cs_db);
         --mapFileUseCount[strFile];
+    }
 }
 
 void static CloseDb(const string& strFile)
 {
-    CRITICAL_BLOCK(cs_db)
     {
+        LOCK(cs_db);
         if (mapDb[strFile] != NULL)
         {
             // Close the database handle
@@ -188,8 +192,8 @@ bool CDB::Rewrite(const string& strFile, const char* pszSkip)
 {
     while (!fShutdown)
     {
-        CRITICAL_BLOCK(cs_db)
         {
+            LOCK(cs_db);
             if (!mapFileUseCount.count(strFile) || mapFileUseCount[strFile] == 0)
             {
                 // Flush log data to the dat file
@@ -286,8 +290,8 @@ void DBFlush(bool fShutdown)
     printf("DBFlush(%s)%s\n", fShutdown ? "true" : "false", fDbEnvInit ? "" : " db not started");
     if (!fDbEnvInit)
         return;
-    CRITICAL_BLOCK(cs_db)
     {
+        LOCK(cs_db);
         map<string, int>::iterator mi = mapFileUseCount.begin();
         while (mi != mapFileUseCount.end())
         {
@@ -877,8 +881,8 @@ int CWalletDB::LoadWallet(CWallet* pwallet)
     bool fIsEncrypted = false;
 
     //// todo: shouldn't we catch exceptions and try to recover and continue?
-    CRITICAL_BLOCK(pwallet->cs_wallet)
     {
+        LOCK(pwallet->cs_wallet);
         int nMinVersion = 0;
         if (Read((string)"minversion", nMinVersion))
         {
@@ -1119,7 +1123,8 @@ void ThreadFlushWalletDB(void* parg)
 
         if (nLastFlushed != nWalletDBUpdated && GetTime() - nLastWalletUpdate >= 2)
         {
-            TRY_CRITICAL_BLOCK(cs_db)
+            TRY_LOCK(cs_db,lockDb);
+            if (lockDb)
             {
                 // Don't do this if any databases are in use
                 int nRefCount = 0;
@@ -1160,8 +1165,8 @@ bool BackupWallet(const CWallet& wallet, const string& strDest)
         return false;
     while (!fShutdown)
     {
-        CRITICAL_BLOCK(cs_db)
         {
+            LOCK(cs_db);
             if (!mapFileUseCount.count(wallet.strWalletFile) || mapFileUseCount[wallet.strWalletFile] == 0)
             {
                 // Flush log data to the dat file

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -40,10 +40,13 @@ void Shutdown(void* parg)
     static CCriticalSection cs_Shutdown;
     static bool fTaken;
     bool fFirstThread = false;
-    TRY_CRITICAL_BLOCK(cs_Shutdown)
     {
-        fFirstThread = !fTaken;
-        fTaken = true;
+        TRY_LOCK(cs_Shutdown, lockShutdown);
+        if (lockShutdown)
+        {
+            fFirstThread = !fTaken;
+            fTaken = true;
+        }
     }
     static bool fExit;
     if (fFirstThread)

--- a/src/keystore.cpp
+++ b/src/keystore.cpp
@@ -21,31 +21,37 @@ bool CBasicKeyStore::AddKey(const CKey& key)
 {
     bool fCompressed = false;
     CSecret secret = key.GetSecret(fCompressed);
-    CRITICAL_BLOCK(cs_KeyStore)
+    {
+        LOCK(cs_KeyStore);
         mapKeys[CBitcoinAddress(key.GetPubKey())] = make_pair(secret, fCompressed);
+    }
     return true;
 }
 
 bool CBasicKeyStore::AddCScript(const CScript& redeemScript)
 {
-    CRITICAL_BLOCK(cs_KeyStore)
+    {
+        LOCK(cs_KeyStore);
         mapScripts[Hash160(redeemScript)] = redeemScript;
+    }
     return true;
 }
 
 bool CBasicKeyStore::HaveCScript(const uint160& hash) const
 {
     bool result;
-    CRITICAL_BLOCK(cs_KeyStore)
+    {
+        LOCK(cs_KeyStore);
         result = (mapScripts.count(hash) > 0);
+    }
     return result;
 }
 
 
 bool CBasicKeyStore::GetCScript(const uint160 &hash, CScript& redeemScriptOut) const
 {
-    CRITICAL_BLOCK(cs_KeyStore)
     {
+        LOCK(cs_KeyStore);
         ScriptMap::const_iterator mi = mapScripts.find(hash);
         if (mi != mapScripts.end())
         {
@@ -58,8 +64,8 @@ bool CBasicKeyStore::GetCScript(const uint160 &hash, CScript& redeemScriptOut) c
 
 bool CCryptoKeyStore::SetCrypted()
 {
-    CRITICAL_BLOCK(cs_KeyStore)
     {
+        LOCK(cs_KeyStore);
         if (fUseCrypto)
             return true;
         if (!mapKeys.empty())
@@ -71,8 +77,8 @@ bool CCryptoKeyStore::SetCrypted()
 
 bool CCryptoKeyStore::Unlock(const CKeyingMaterial& vMasterKeyIn)
 {
-    CRITICAL_BLOCK(cs_KeyStore)
     {
+        LOCK(cs_KeyStore);
         if (!SetCrypted())
             return false;
 
@@ -100,8 +106,8 @@ bool CCryptoKeyStore::Unlock(const CKeyingMaterial& vMasterKeyIn)
 
 bool CCryptoKeyStore::AddKey(const CKey& key)
 {
-    CRITICAL_BLOCK(cs_KeyStore)
     {
+        LOCK(cs_KeyStore);
         if (!IsCrypted())
             return CBasicKeyStore::AddKey(key);
 
@@ -123,8 +129,8 @@ bool CCryptoKeyStore::AddKey(const CKey& key)
 
 bool CCryptoKeyStore::AddCryptedKey(const std::vector<unsigned char> &vchPubKey, const std::vector<unsigned char> &vchCryptedSecret)
 {
-    CRITICAL_BLOCK(cs_KeyStore)
     {
+        LOCK(cs_KeyStore);
         if (!SetCrypted())
             return false;
 
@@ -135,8 +141,8 @@ bool CCryptoKeyStore::AddCryptedKey(const std::vector<unsigned char> &vchPubKey,
 
 bool CCryptoKeyStore::GetKey(const CBitcoinAddress &address, CKey& keyOut) const
 {
-    CRITICAL_BLOCK(cs_KeyStore)
     {
+        LOCK(cs_KeyStore);
         if (!IsCrypted())
             return CBasicKeyStore::GetKey(address, keyOut);
 
@@ -160,8 +166,8 @@ bool CCryptoKeyStore::GetKey(const CBitcoinAddress &address, CKey& keyOut) const
 
 bool CCryptoKeyStore::GetPubKey(const CBitcoinAddress &address, std::vector<unsigned char>& vchPubKeyOut) const
 {
-    CRITICAL_BLOCK(cs_KeyStore)
     {
+        LOCK(cs_KeyStore);
         if (!IsCrypted())
             return CKeyStore::GetPubKey(address, vchPubKeyOut);
 
@@ -177,8 +183,8 @@ bool CCryptoKeyStore::GetPubKey(const CBitcoinAddress &address, std::vector<unsi
 
 bool CCryptoKeyStore::EncryptKeys(CKeyingMaterial& vMasterKeyIn)
 {
-    CRITICAL_BLOCK(cs_KeyStore)
     {
+        LOCK(cs_KeyStore);
         if (!mapCryptedKeys.empty() || IsCrypted())
             return false;
 

--- a/src/keystore.h
+++ b/src/keystore.h
@@ -54,15 +54,17 @@ public:
     bool HaveKey(const CBitcoinAddress &address) const
     {
         bool result;
-        CRITICAL_BLOCK(cs_KeyStore)
+        {
+            LOCK(cs_KeyStore);
             result = (mapKeys.count(address) > 0);
+        }
         return result;
     }
     void GetKeys(std::set<CBitcoinAddress> &setAddress) const
     {
         setAddress.clear();
-        CRITICAL_BLOCK(cs_KeyStore)
         {
+            LOCK(cs_KeyStore);
             KeyMap::const_iterator mi = mapKeys.begin();
             while (mi != mapKeys.end())
             {
@@ -73,8 +75,8 @@ public:
     }
     bool GetKey(const CBitcoinAddress &address, CKey &keyOut) const
     {
-        CRITICAL_BLOCK(cs_KeyStore)
         {
+            LOCK(cs_KeyStore);
             KeyMap::const_iterator mi = mapKeys.find(address);
             if (mi != mapKeys.end())
             {
@@ -129,8 +131,10 @@ public:
         if (!IsCrypted())
             return false;
         bool result;
-        CRITICAL_BLOCK(cs_KeyStore)
+        {
+            LOCK(cs_KeyStore);
             result = vMasterKey.empty();
+        }
         return result;
     }
 
@@ -139,8 +143,10 @@ public:
         if (!SetCrypted())
             return false;
 
-        CRITICAL_BLOCK(cs_KeyStore)
+        {
+            LOCK(cs_KeyStore);
             vMasterKey.clear();
+        }
 
         return true;
     }
@@ -149,8 +155,8 @@ public:
     bool AddKey(const CKey& key);
     bool HaveKey(const CBitcoinAddress &address) const
     {
-        CRITICAL_BLOCK(cs_KeyStore)
         {
+            LOCK(cs_KeyStore);
             if (!IsCrypted())
                 return CBasicKeyStore::HaveKey(address);
             return mapCryptedKeys.count(address) > 0;

--- a/src/qt/addresstablemodel.cpp
+++ b/src/qt/addresstablemodel.cpp
@@ -39,8 +39,8 @@ struct AddressTablePriv
     {
         cachedAddressTable.clear();
 
-        CRITICAL_BLOCK(wallet->cs_wallet)
         {
+            LOCK(wallet->cs_wallet);
             BOOST_FOREACH(const PAIRTYPE(CBitcoinAddress, std::string)& item, wallet->mapAddressBook)
             {
                 const CBitcoinAddress& address = item.first;
@@ -169,8 +169,8 @@ bool AddressTableModel::setData(const QModelIndex & index, const QVariant & valu
             // Double-check that we're not overwriting a receiving address
             if(rec->type == AddressTableEntry::Sending)
             {
-                CRITICAL_BLOCK(wallet->cs_wallet)
                 {
+                    LOCK(wallet->cs_wallet);
                     // Remove old entry
                     wallet->DelAddressBookName(rec->address.toStdString());
                     // Add new entry with new address
@@ -254,8 +254,8 @@ QString AddressTableModel::addRow(const QString &type, const QString &label, con
             return QString();
         }
         // Check for duplicate addresses
-        CRITICAL_BLOCK(wallet->cs_wallet)
         {
+            LOCK(wallet->cs_wallet);
             if(wallet->mapAddressBook.count(strAddress))
             {
                 editStatus = DUPLICATE_ADDRESS;
@@ -286,8 +286,10 @@ QString AddressTableModel::addRow(const QString &type, const QString &label, con
         return QString();
     }
     // Add entry
-    CRITICAL_BLOCK(wallet->cs_wallet)
+    {
+        LOCK(wallet->cs_wallet);
         wallet->SetAddressBookName(strAddress, strLabel);
+    }
     return QString::fromStdString(strAddress);
 }
 
@@ -301,8 +303,8 @@ bool AddressTableModel::removeRows(int row, int count, const QModelIndex & paren
         // Also refuse to remove receiving addresses.
         return false;
     }
-    CRITICAL_BLOCK(wallet->cs_wallet)
     {
+        LOCK(wallet->cs_wallet);
         wallet->DelAddressBookName(rec->address.toStdString());
     }
     return true;
@@ -312,8 +314,8 @@ bool AddressTableModel::removeRows(int row, int count, const QModelIndex & paren
  */
 QString AddressTableModel::labelForAddress(const QString &address) const
 {
-    CRITICAL_BLOCK(wallet->cs_wallet)
     {
+        LOCK(wallet->cs_wallet);
         CBitcoinAddress address_parsed(address.toStdString());
         std::map<CBitcoinAddress, std::string>::iterator mi = wallet->mapAddressBook.find(address_parsed);
         if (mi != wallet->mapAddressBook.end())

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -34,8 +34,9 @@ QString TransactionDesc::FormatTxStatus(const CWalletTx& wtx)
 QString TransactionDesc::toHTML(CWallet *wallet, CWalletTx &wtx)
 {
     QString strHTML;
-    CRITICAL_BLOCK(wallet->cs_wallet)
+
     {
+        LOCK(wallet->cs_wallet);
         strHTML.reserve(4000);
         strHTML += "<html><font face='verdana, arial, helvetica, sans-serif'>";
 
@@ -243,8 +244,9 @@ QString TransactionDesc::toHTML(CWallet *wallet, CWalletTx &wtx)
 
             strHTML += "<br><b>Inputs:</b>";
             strHTML += "<ul>";
-            CRITICAL_BLOCK(wallet->cs_wallet)
+
             {
+                LOCK(wallet->cs_wallet);
                 BOOST_FOREACH(const CTxIn& txin, wtx.vin)
                 {
                     COutPoint prevout = txin.prevout;

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -32,8 +32,8 @@ qint64 WalletModel::getUnconfirmedBalance() const
 int WalletModel::getNumTransactions() const
 {
     int numTransactions = 0;
-    CRITICAL_BLOCK(wallet->cs_wallet)
     {
+        LOCK(wallet->cs_wallet);
         numTransactions = wallet->mapWallet.size();
     }
     return numTransactions;
@@ -115,9 +115,9 @@ WalletModel::SendCoinsReturn WalletModel::sendCoins(const QList<SendCoinsRecipie
         return SendCoinsReturn(AmountWithFeeExceedsBalance, nTransactionFee);
     }
 
-    CRITICAL_BLOCK(cs_main)
-    CRITICAL_BLOCK(wallet->cs_wallet)
     {
+        LOCK2(cs_main, wallet->cs_wallet);
+
         // Sendmany
         std::vector<std::pair<CScript, int64> > vecSend;
         foreach(const SendCoinsRecipient &rcp, recipients)
@@ -155,8 +155,8 @@ WalletModel::SendCoinsReturn WalletModel::sendCoins(const QList<SendCoinsRecipie
     foreach(const SendCoinsRecipient &rcp, recipients)
     {
         std::string strAddress = rcp.address.toStdString();
-        CRITICAL_BLOCK(wallet->cs_wallet)
         {
+            LOCK(wallet->cs_wallet);
             if (!wallet->mapAddressBook.count(strAddress))
                 wallet->SetAddressBookName(strAddress, rcp.label.toStdString());
         }
@@ -227,8 +227,8 @@ bool WalletModel::setWalletLocked(bool locked, const SecureString &passPhrase)
 bool WalletModel::changePassphrase(const SecureString &oldPass, const SecureString &newPass)
 {
     bool retval;
-    CRITICAL_BLOCK(wallet->cs_wallet)
     {
+        LOCK(wallet->cs_wallet);
         wallet->Lock(); // Make sure wallet is locked before attempting pass change
         retval = wallet->ChangeWalletPassphrase(oldPass, newPass);
     }

--- a/src/rpcdump.cpp
+++ b/src/rpcdump.cpp
@@ -60,9 +60,9 @@ Value importprivkey(const Array& params, bool fHelp)
     key.SetSecret(secret, fCompressed);
     CBitcoinAddress vchAddress = CBitcoinAddress(key.GetPubKey());
 
-    CRITICAL_BLOCK(cs_main)
-    CRITICAL_BLOCK(pwalletMain->cs_wallet)
     {
+        LOCK2(cs_main, pwalletMain->cs_wallet);
+
         pwalletMain->MarkDirty();
         pwalletMain->SetAddressBookName(vchAddress, strLabel);
 

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -15,14 +15,15 @@ BOOST_AUTO_TEST_CASE(util_criticalsection)
     CCriticalSection cs;
 
     do {
-        CRITICAL_BLOCK(cs)
-            break;
+        LOCK(cs);
+        break;
 
         BOOST_ERROR("break was swallowed!");
     } while(0);
 
     do {
-        TRY_CRITICAL_BLOCK(cs)
+        TRY_LOCK(cs, lockTest);
+        if (lockTest)
             break;
 
         BOOST_ERROR("break was swallowed!");

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -195,8 +195,8 @@ inline int OutputDebugStringF(const char* pszFormat, ...)
         static CCriticalSection cs_OutputDebugStringF;
 
         // accumulate a line at a time
-        CRITICAL_BLOCK(cs_OutputDebugStringF)
         {
+            LOCK(cs_OutputDebugStringF);
             static char pszBuffer[50000];
             static char* pend;
             if (pend == NULL)

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1141,7 +1141,7 @@ static void potential_deadlock_detected(const std::pair<void*, void*>& mismatch,
     }
 }
 
-static void push_lock(void* c, const CLockLocation& locklocation)
+static void push_lock(void* c, const CLockLocation& locklocation, bool fTry)
 {
     bool fOrderOK = true;
     if (lockstack.get() == NULL)
@@ -1152,7 +1152,7 @@ static void push_lock(void* c, const CLockLocation& locklocation)
 
     (*lockstack).push_back(std::make_pair(c, locklocation));
 
-    BOOST_FOREACH(const PAIRTYPE(void*, CLockLocation)& i, (*lockstack))
+    if (!fTry) BOOST_FOREACH(const PAIRTYPE(void*, CLockLocation)& i, (*lockstack))
     {
         if (i.first == c) break;
 
@@ -1183,9 +1183,9 @@ static void pop_lock()
     dd_mutex.unlock();
 }
 
-void EnterCritical(const char* pszName, const char* pszFile, int nLine, void* cs)
+void EnterCritical(const char* pszName, const char* pszFile, int nLine, void* cs, bool fTry)
 {
-    push_lock(cs, CLockLocation(pszName, pszFile, nLine));
+    push_lock(cs, CLockLocation(pszName, pszFile, nLine), fTry);
 }
 
 void LeaveCritical()

--- a/src/util.h
+++ b/src/util.h
@@ -190,10 +190,10 @@ typedef boost::interprocess::interprocess_recursive_mutex CCriticalSection;
 typedef boost::interprocess::interprocess_mutex CWaitableCriticalSection;
 
 #ifdef DEBUG_LOCKORDER
-void EnterCritical(const char* pszName, const char* pszFile, int nLine, void* cs);
+void EnterCritical(const char* pszName, const char* pszFile, int nLine, void* cs, bool fTry = false);
 void LeaveCritical();
 #else
-void static inline EnterCritical(const char* pszName, const char* pszFile, int nLine, void* cs) {}
+void static inline EnterCritical(const char* pszName, const char* pszFile, int nLine, void* cs, bool fTry = false) {}
 void static inline LeaveCritical() {}
 #endif
 
@@ -234,7 +234,7 @@ public:
     {
         if (!lock.owns())
         {
-            EnterCritical(pszName, pszFile, nLine, (void*)(lock.mutex()));
+            EnterCritical(pszName, pszFile, nLine, (void*)(lock.mutex()), true);
             lock.try_lock();
             if (!lock.owns())
                 LeaveCritical();

--- a/src/util.h
+++ b/src/util.h
@@ -282,13 +282,10 @@ typedef boost::interprocess::interprocess_condition CConditionVariable;
 #define NOTIFY_ALL(name) \
    do { (name).notify_all(); } while(0)
 
-#define CRITICAL_BLOCK(cs)     \
-    for (bool fcriticalblockonce=true; fcriticalblockonce; assert(("break caught by CRITICAL_BLOCK!" && !fcriticalblockonce)), fcriticalblockonce=false) \
-        for (CCriticalBlock criticalblock(cs, #cs, __FILE__, __LINE__); fcriticalblockonce; fcriticalblockonce=false)
-
-#define WAITABLE_CRITICAL_BLOCK(cs)     \
-    for (bool fcriticalblockonce=true; fcriticalblockonce; assert(("break caught by WAITABLE_CRITICAL_BLOCK!" && !fcriticalblockonce)), fcriticalblockonce=false) \
-        for (CWaitableCriticalBlock waitablecriticalblock(cs, #cs, __FILE__, __LINE__); fcriticalblockonce; fcriticalblockonce=false)
+#define LOCK(cs) CCriticalBlock criticalblock(cs, #cs, __FILE__, __LINE__)
+#define LOCK2(cs1,cs2) CCriticalBlock criticalblock1(cs1, #cs1, __FILE__, __LINE__),criticalblock2(cs2, #cs2, __FILE__, __LINE__)
+#define TRY_LOCK(cs,name) CCriticalBlock name(cs, #cs, __FILE__, __LINE__, true)
+#define WAITABLE_LOCK(cs) CWaitableCriticalBlock waitablecriticalblock(cs, #cs, __FILE__, __LINE__)
 
 #define ENTER_CRITICAL_SECTION(cs) \
     { \
@@ -301,10 +298,6 @@ typedef boost::interprocess::interprocess_condition CConditionVariable;
         (cs).unlock(); \
         LeaveCritical(); \
     }
-
-#define TRY_CRITICAL_BLOCK(cs)     \
-    for (bool fcriticalblockonce=true; fcriticalblockonce; assert(("break caught by TRY_CRITICAL_BLOCK!" && !fcriticalblockonce)), fcriticalblockonce=false) \
-        for (CCriticalBlock criticalblock(cs, #cs, __FILE__, __LINE__, true); fcriticalblockonce && (fcriticalblockonce = criticalblock); fcriticalblockonce=false)
 
 
 // This is exactly like std::string, but with a custom allocator.

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -211,16 +211,18 @@ public:
 
     void UpdatedTransaction(const uint256 &hashTx)
     {
-        CRITICAL_BLOCK(cs_wallet)
+        {
+            LOCK(cs_wallet);
             vWalletUpdated.push_back(hashTx);
+        }
     }
 
     void PrintWallet(const CBlock& block);
 
     void Inventory(const uint256 &hash)
     {
-        CRITICAL_BLOCK(cs_wallet)
         {
+            LOCK(cs_wallet);
             std::map<uint256, int>::iterator mi = mapRequestCount.find(hash);
             if (mi != mapRequestCount.end())
                 (*mi).second++;


### PR DESCRIPTION
Remove CRITICAL_BLOCK and TRY_CRITICAL_BLOCK, and replace them with LOCK, TRY_LOCK and IS_LOCKED. These are macros that define a local CCriticalBlock variable (a boost::interprocess::scoped_lock wrapper), which is much more C++ than the if and/or for constructions in macros.

I've intentionally not touched formattng/indentation where possible, in order not to break other patches. There are several cases where simplications are possible now, though.
