### PR TITLE
Fix build.h dependencies

### DIFF
--- a/bitcoin-qt.pro
+++ b/bitcoin-qt.pro
@@ -83,9 +83,9 @@ contains(BITCOIN_NEED_QT_PLUGINS, 1) {
 # regenerate src/build.h
 !windows || contains(USE_BUILD_INFO, 1) {
     genbuild.depends = FORCE
-    genbuild.commands = share/genbuild.sh src/build.h
-    genbuild.target = src/build.h
-    "src/version.cpp".depends += src/build.h
+    genbuild.commands = cd $$PWD; share/genbuild.sh $$OUT_PWD/build/build.h
+    genbuild.target = genbuildhook
+    PRE_TARGETDEPS += genbuildhook
     QMAKE_EXTRA_TARGETS += genbuild
     DEFINES += HAVE_BUILD_INFO
 }

--- a/src/makefile.linux-mingw
+++ b/src/makefile.linux-mingw
@@ -10,7 +10,8 @@ INCLUDEPATHS= \
  -I"$(DEPSDIR)/boost_1_47_0" \
  -I"$(DEPSDIR)/db-4.8.30.NC/build_unix" \
  -I"$(DEPSDIR)/openssl-1.0.0e/include" \
- -I"$(DEPSDIR)"
+ -I"$(DEPSDIR)" \
+ -I"$(CURDIR)"/obj \
 
 LIBPATHS= \
  -L"$(DEPSDIR)/boost_1_47_0/stage/lib" \
@@ -65,14 +66,15 @@ OBJS= \
 
 all: bitcoind.exe
 
-build.h: FORCE
-	@../share/genbuild.sh build.h
+obj/build.h: FORCE
+	../share/genbuild.sh obj/build.h
+version.cpp: obj/build.h
 DEFS += -DHAVE_BUILD_INFO
 
 obj/%.o: %.cpp $(HEADERS)
 	i586-mingw32msvc-g++ -c $(CFLAGS) -o $@ $<
 
-bitcoind.exe: build.h $(OBJS:obj/%=obj/%)
+bitcoind.exe: $(OBJS:obj/%=obj/%)
 	i586-mingw32msvc-g++ $(CFLAGS) -o $@ $(LIBPATHS) $^ $(LIBS)
 
 

--- a/src/makefile.osx
+++ b/src/makefile.osx
@@ -11,6 +11,7 @@ DEPSDIR=/opt/local
 
 INCLUDEPATHS= \
  -I"$(CURDIR)" \
+ -I"$(CURDIR)"/obj \
  -I"$(DEPSDIR)/include" \
  -I"$(DEPSDIR)/include/db48"
 
@@ -100,8 +101,9 @@ all: bitcoind
 -include obj/*.P
 -include obj-test/*.P
 
-build.h: FORCE
-	@../share/genbuild.sh build.h
+obj/build.h: FORCE
+	../share/genbuild.sh obj/build.h
+version.cpp: obj/build.h
 DEFS += -DHAVE_BUILD_INFO
 
 obj/%.o: %.cpp
@@ -111,7 +113,7 @@ obj/%.o: %.cpp
 	      -e '/^$$/ d' -e 's/$$/ :/' < $(@:%.o=%.d) >> $(@:%.o=%.P); \
 	  rm -f $(@:%.o=%.d)
 
-bitcoind: build.h $(OBJS:obj/%=obj/%)
+bitcoind: $(OBJS:obj/%=obj/%)
 	$(CXX) $(CFLAGS) -o $@ $(LIBPATHS) $^ $(LIBS)
 
 TESTOBJS := $(patsubst test/%.cpp,obj-test/%.o,$(wildcard test/*.cpp))

--- a/src/makefile.unix
+++ b/src/makefile.unix
@@ -6,7 +6,7 @@ USE_UPNP:=0
 
 DEFS=-DNOPCH
 
-DEFS += $(addprefix -I,$(CURDIR) $(BOOST_INCLUDE_PATH) $(BDB_INCLUDE_PATH) $(OPENSSL_INCLUDE_PATH))
+DEFS += $(addprefix -I,$(CURDIR) $(CURDIR)/obj $(BOOST_INCLUDE_PATH) $(BDB_INCLUDE_PATH) $(OPENSSL_INCLUDE_PATH))
 LIBS = $(addprefix -L,$(BOOST_LIB_PATH) $(BDB_LIB_PATH) $(OPENSSL_LIB_PATH))
 
 LMODE = dynamic
@@ -112,8 +112,9 @@ all: bitcoind
 -include obj/*.P
 -include obj-test/*.P
 
-build.h: FORCE
-	@../share/genbuild.sh build.h
+obj/build.h: FORCE
+	../share/genbuild.sh obj/build.h
+version.cpp: obj/build.h
 DEFS += -DHAVE_BUILD_INFO
 
 obj/%.o: %.cpp
@@ -123,7 +124,7 @@ obj/%.o: %.cpp
 	      -e '/^$$/ d' -e 's/$$/ :/' < $(@:%.o=%.d) >> $(@:%.o=%.P); \
 	  rm -f $(@:%.o=%.d)
 
-bitcoind: build.h $(OBJS:obj/%=obj/%)
+bitcoind: $(OBJS:obj/%=obj/%)
 	$(CXX) $(xCXXFLAGS) -o $@ $^ $(LDFLAGS) $(LIBS)
 
 TESTOBJS := $(patsubst test/%.cpp,obj-test/%.o,$(wildcard test/*.cpp))


### PR DESCRIPTION
Sorry for the mess w.r.t. this build.h issue. I did a full gitian build and normal builds to make sure it worked, but apparently other environments existed as well (see #1076).

This pull request contains a few extra changes to fix all issues I'm currently aware of.

For Qt builds, the build.h file is moved to build/build.h. For regular builds, it is moved to obj/build.h. This allows the Qt build to be done in a different directory than the source, and without interfering with other builds.
