### PR TITLE
BIP 0031: pong message

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2185,7 +2185,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
         CAddress addrFrom;
         uint64 nNonce = 1;
         vRecv >> pfrom->nVersion >> pfrom->nServices >> nTime >> addrMe;
-        if (pfrom->nVersion < 209)
+        if (pfrom->nVersion < MIN_PROTO_VERSION)
         {
             // Since February 20, 2012, the protocol is initiated at version 209,
             // and earlier versions are no longer supported
@@ -2235,7 +2235,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
             }
 
             // Get recent addresses
-            if (pfrom->nVersion >= 31402 || addrman.size() < 1000)
+            if (pfrom->nVersion >= CADDR_TIME_VERSION || addrman.size() < 1000)
             {
                 pfrom->PushMessage("getaddr");
                 pfrom->fGetAddr = true;
@@ -2252,7 +2252,8 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
         // Ask the first connected node for block updates
         static int nAskedForBlocks = 0;
         if (!pfrom->fClient &&
-            (pfrom->nVersion < 32000 || pfrom->nVersion >= 32400) &&
+            (pfrom->nVersion < NOBLKS_VERSION_START ||
+	     pfrom->nVersion >= NOBLKS_VERSION_END) &&
              (nAskedForBlocks < 1 || vNodes.size() <= 1))
         {
             nAskedForBlocks++;
@@ -2294,7 +2295,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
         vRecv >> vAddr;
 
         // Don't want addr from older versions unless seeding
-        if (pfrom->nVersion < 31402 && addrman.size() > 1000)
+        if (pfrom->nVersion < CADDR_TIME_VERSION && addrman.size() > 1000)
             return true;
         if (vAddr.size() > 1000)
         {
@@ -2331,7 +2332,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
                     multimap<uint256, CNode*> mapMix;
                     BOOST_FOREACH(CNode* pnode, vNodes)
                     {
-                        if (pnode->nVersion < 31402)
+                        if (pnode->nVersion < CADDR_TIME_VERSION)
                             continue;
                         unsigned int nPointer;
                         memcpy(&nPointer, &pnode, sizeof(nPointer));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2652,6 +2652,23 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
 
     else if (strCommand == "ping")
     {
+        if (pfrom->nVersion > BIP0031_VERSION)
+        {
+            uint64 nonce = 0;
+            vRecv >> nonce;
+            // Echo the message back with the nonce. This allows for two useful features:
+            //
+            // 1) A remote node can quickly check if the connection is operational
+            // 2) Remote nodes can measure the latency of the network thread. If this node
+            //    is overloaded it won't respond to pings quickly and the remote node can
+            //    avoid sending us more work, like chain download requests.
+            //
+            // The nonce stops the remote getting confused between different pings: without
+            // it, if the remote node sends a ping once per second and this node takes 5
+            // seconds to respond to each, the 5th ping the remote sends would appear to
+            // return very quickly.
+            pfrom->PushMessage("pong", nonce);
+        }
     }
 
 
@@ -2814,9 +2831,14 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
         if (pto->nVersion == 0)
             return true;
 
-        // Keep-alive ping
-        if (pto->nLastSend && GetTime() - pto->nLastSend > 30 * 60 && pto->vSend.empty())
-            pto->PushMessage("ping");
+        // Keep-alive ping. We send a nonce of zero because we don't use it anywhere 
+        // right now.
+        if (pto->nLastSend && GetTime() - pto->nLastSend > 30 * 60 && pto->vSend.empty()) {
+            if (pto->nVersion > BIP0031_VERSION)
+                pto->PushMessage("ping", 0);
+            else
+                pto->PushMessage("ping");
+        }
 
         // Resend wallet transactions that haven't gotten in a block yet
         ResendWalletTransactions();

--- a/src/net.h
+++ b/src/net.h
@@ -163,8 +163,8 @@ public:
         hSocket = hSocketIn;
         vSend.SetType(SER_NETWORK);
         vRecv.SetType(SER_NETWORK);
-        vSend.SetVersion(209);
-        vRecv.SetVersion(209);
+        vSend.SetVersion(MIN_PROTO_VERSION);
+        vRecv.SetVersion(MIN_PROTO_VERSION);
         nLastSend = 0;
         nLastRecv = 0;
         nLastSendEmpty = GetTime();

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -79,9 +79,10 @@ class CAddress : public CService
              if (fRead)
                  pthis->Init();
              if (nType & SER_DISK)
-             READWRITE(nVersion);
-             if ((nType & SER_DISK) || (nVersion >= 31402 && !(nType & SER_GETHASH)))
-             READWRITE(nTime);
+                 READWRITE(nVersion);
+             if ((nType & SER_DISK) ||
+                 (nVersion >= CADDR_TIME_VERSION && !(nType & SER_GETHASH)))
+                 READWRITE(nTime);
              READWRITE(nServices);
              READWRITE(*pip);
             )

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -20,6 +20,7 @@
 #include <boost/tuple/tuple_io.hpp>
 
 #include "allocators.h"
+#include "version.h"
 
 typedef long long  int64;
 typedef unsigned long long  uint64;
@@ -28,8 +29,6 @@ class CScript;
 class CDataStream;
 class CAutoFile;
 static const unsigned int MAX_SIZE = 0x02000000;
-
-static const int PROTOCOL_VERSION = 60000;
 
 // Used to bypass the rule against non-const reference to temporary
 // where it makes sense with wrappers such as CFlatData or CTxDB

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -11,17 +11,7 @@
 const std::string CLIENT_NAME("Satoshi");
 
 // Client version number
-#define CLIENT_VERSION_MAJOR          0
-#define CLIENT_VERSION_MINOR          6
-#define CLIENT_VERSION_REVISION       0
-#define CLIENT_VERSION_BUILD         99
 #define CLIENT_VERSION_SUFFIX   "-beta"
-
-const int CLIENT_VERSION = 1000000 * CLIENT_VERSION_MAJOR
-                         +   10000 * CLIENT_VERSION_MINOR 
-                         +     100 * CLIENT_VERSION_REVISION
-                         +       1 * CLIENT_VERSION_BUILD;
-
 
 
 // The following part of the code determines the CLIENT_BUILD variable.

--- a/src/version.h
+++ b/src/version.h
@@ -6,12 +6,32 @@
 
 #include <string>
 
+//
+// client versioning
+//
+
+static const int CLIENT_VERSION_MAJOR       =  0;
+static const int CLIENT_VERSION_MINOR       =  6;
+static const int CLIENT_VERSION_REVISION    =  0;
+static const int CLIENT_VERSION_BUILD       = 99;
+
+static const int CLIENT_VERSION =
+                           1000000 * CLIENT_VERSION_MAJOR
+                         +   10000 * CLIENT_VERSION_MINOR 
+                         +     100 * CLIENT_VERSION_REVISION
+                         +       1 * CLIENT_VERSION_BUILD;
+
 extern const std::string CLIENT_NAME;
 extern const std::string CLIENT_BUILD;
 extern const std::string CLIENT_DATE;
-extern const int         CLIENT_VERSION;
+
+//
+// network protocol versioning
+//
+
+static const int PROTOCOL_VERSION = 60000;
 
 // BIP 0031, pong message, is enabled for all versions AFTER this one
-const int BIP0031_VERSION = 60000;
+static const int BIP0031_VERSION = 60000;
 
 #endif

--- a/src/version.h
+++ b/src/version.h
@@ -11,4 +11,7 @@ extern const std::string CLIENT_BUILD;
 extern const std::string CLIENT_DATE;
 extern const int         CLIENT_VERSION;
 
+// BIP 0031, pong message, is enabled for all versions AFTER this one
+const int BIP0031_VERSION = 60000;
+
 #endif

--- a/src/version.h
+++ b/src/version.h
@@ -31,6 +31,17 @@ extern const std::string CLIENT_DATE;
 
 static const int PROTOCOL_VERSION = 60000;
 
+// earlier versions not supported as of Feb 2012, and are disconnected
+static const int MIN_PROTO_VERSION = 209;
+
+// nTime field added to CAddress, starting with this version;
+// if possible, avoid requesting addresses nodes older than this
+static const int CADDR_TIME_VERSION = 31402;
+
+// only request blocks from nodes outside this range of versions
+static const int NOBLKS_VERSION_START = 32000;
+static const int NOBLKS_VERSION_END = 32400;
+
 // BIP 0031, pong message, is enabled for all versions AFTER this one
 static const int BIP0031_VERSION = 60000;
 


### PR DESCRIPTION
Add a pong message that is sent in reply to a ping. It echoes back a nonce
field that is now added to the ping message. Send a nonce of zero in ping
messages.

Original author: Mike Hearn @ Google

Modified Mike's change to introduce a mild form of protocol documentation in
version.h.
