### PR TITLE
importprivkey doesn't check that it is given a private key

### DIFF
--- a/src/base58.h
+++ b/src/base58.h
@@ -396,6 +396,16 @@ public:
         return fExpectTestNet == fTestNet && (vchData.size() == 32 || (vchData.size() == 33 && vchData[32] == 1));
     }
 
+    bool SetString(const char* pszSecret)
+    {
+        return CBase58Data::SetString(pszSecret) && IsValid();
+    }
+
+    bool SetString(const std::string& strSecret)
+    {
+        return SetString(strSecret.c_str());
+    }
+
     CBitcoinSecret(const CSecret& vchSecret, bool fCompressed)
     {
         SetSecret(vchSecret, fCompressed);

--- a/src/test/key_tests.cpp
+++ b/src/test/key_tests.cpp
@@ -14,6 +14,7 @@ static const string strSecret1 ("5HxWvvfubhXpYYpS3tJkw6fq9jE9j18THftkZjHHfmFiWtm
 static const string strSecret2 ("5KC4ejrDjv152FGwP386VD1i2NYc5KkfSMyv1nGy1VGDxGHqVY3");
 static const string strSecret1C("Kwr371tjA9u2rFSMZjTNun2PXXP3WPZu2afRHTcta6KxEUdm1vEw");
 static const string strSecret2C("L3Hq7a8FEQwJkW1M2GNKDW28546Vp5miewcCzSqUD9kCAXrJdS3g");
+static const string strAddress1("1HV9Lc3sNHZxwj4Zk6fB38tEmBryq2cBiF");
 
 #ifdef KEY_TESTS_DUMPINFO
 void dumpKeyInfo(uint256 privkey)
@@ -47,11 +48,12 @@ BOOST_AUTO_TEST_SUITE(key_tests)
 
 BOOST_AUTO_TEST_CASE(key_test1)
 {
-    CBitcoinSecret bsecret1, bsecret2, bsecret1C, bsecret2C;
-    bsecret1.SetString (strSecret1);
-    bsecret2.SetString (strSecret2);
-    bsecret1C.SetString(strSecret1C);
-    bsecret2C.SetString(strSecret2C);
+    CBitcoinSecret bsecret1, bsecret2, bsecret1C, bsecret2C, baddress1;
+    BOOST_CHECK( bsecret1.SetString (strSecret1));
+    BOOST_CHECK( bsecret2.SetString (strSecret2));
+    BOOST_CHECK( bsecret1C.SetString(strSecret1C));
+    BOOST_CHECK( bsecret2C.SetString(strSecret2C));
+    BOOST_CHECK(!baddress1.SetString(strAddress1));
 
     bool fCompressed;
     CSecret secret1  = bsecret1.GetSecret (fCompressed);


### PR DESCRIPTION
I just accidentally ran:

```
bitcoind importprivkey 1HV9Lc3sNHZxwj4Zk6fB38tEmBryq2cBiF
```

passing an address instead of a private key, and it didn't complain.

I ended up with a new key in my wallet with a potentially publicly known private key.

This pull request adds a call of IsValid() to CBitcoinSecret's SetString() function to ensure that the private key at least has the correct version.

I also added unit tests that make sure CBitcoinSecret::SetString() fails when passed a Bitcoin address, and succeeds when passed compressed or regular private keys.
