### PR TITLE
revert to default OS theme for progressbar (fix #1071)

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -143,15 +143,12 @@ BitcoinGUI::BitcoinGUI(QWidget *parent):
     progressBarLabel = new QLabel();
     progressBarLabel->setVisible(false);
     progressBar = new QProgressBar();
+    progressBar->setAlignment(Qt::AlignCenter);
     progressBar->setVisible(false);
 
     statusBar()->addWidget(progressBarLabel);
     statusBar()->addWidget(progressBar);
     statusBar()->addPermanentWidget(frameBlocks);
-
-    // define OS independent progress bar style (has to be placed after addWidget(), otherwise we crash)
-    // we did this, because with some OSes default style, text on the progress bar is unreadable
-    progressBar->setStyleSheet("QProgressBar { background-color: transparent; border: 1px solid grey; border-radius: 2px; padding: 1px; text-align: center; } QProgressBar::chunk { background: QLinearGradient(x1: 0, y1: 0, x2: 1, y2: 0, stop: 0 #FF8000, stop: 1 orange); margin: 0px; }");
 
     syncIconMovie = new QMovie(":/movies/update_spinner", "mng", this);
 
@@ -416,7 +413,7 @@ void BitcoinGUI::trayIconActivated(QSystemTrayIcon::ActivationReason reason)
 {
     if(reason == QSystemTrayIcon::Trigger)
     {
-        // Click on system tray icon triggers "open bitcoin"
+        // Click on system tray icon triggers "show/hide bitcoin"
         toggleHideAction->trigger();
     }
 }
@@ -425,17 +422,17 @@ void BitcoinGUI::trayIconActivated(QSystemTrayIcon::ActivationReason reason)
 void BitcoinGUI::toggleHidden()
 {
     // activateWindow() (sometimes) helps with keyboard focus on Windows
-    if(isHidden())
+    if (isHidden())
     {
         show();
         activateWindow();
     }
-    else if(isMinimized())
+    else if (isMinimized())
     {
         showNormal();
         activateWindow();
     }
-    else if(GUIUtil::isObscured(this))
+    else if (GUIUtil::isObscured(this))
     {
         raise();
         activateWindow();
@@ -555,7 +552,7 @@ void BitcoinGUI::setNumBlocks(int count)
     if(secs < 90*60)
     {
         tooltip = tr("Up to date") + QString(".\n") + tooltip;
-        labelBlocksIcon->setPixmap(QIcon(":/icons/synced").pixmap(STATUSBAR_ICONSIZE,STATUSBAR_ICONSIZE));
+        labelBlocksIcon->setPixmap(QIcon(":/icons/synced").pixmap(STATUSBAR_ICONSIZE, STATUSBAR_ICONSIZE));
     }
     else
     {


### PR DESCRIPTION
As there were a few readability issues with certain OS themes and our self-defined progressbar style, this reverts the bar to OS defaults.

Fixes #1071.
