### PR TITLE
Locking fix for AlreadyHave()

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2137,8 +2137,17 @@ bool static AlreadyHave(CTxDB& txdb, const CInv& inv)
 {
     switch (inv.type)
     {
-    case MSG_TX:    return mapTransactions.count(inv.hash) || mapOrphanTransactions.count(inv.hash) || txdb.ContainsTx(inv.hash);
-    case MSG_BLOCK: return mapBlockIndex.count(inv.hash) || mapOrphanBlocks.count(inv.hash);
+    case MSG_TX:
+        {
+        LOCK(cs_mapTransactions);
+        return mapTransactions.count(inv.hash) ||
+               mapOrphanTransactions.count(inv.hash) ||
+               txdb.ContainsTx(inv.hash);
+        }
+
+    case MSG_BLOCK:
+        return mapBlockIndex.count(inv.hash) ||
+               mapOrphanBlocks.count(inv.hash);
     }
     // Don't know what it is, just say we already got one
     return true;


### PR DESCRIPTION
Access to mapTransactions[] must be guarded by cs_mapTransactions lock.

Also, reformat long lines to make the switch statement more readable.
