### PR TITLE
Encapsulate memory pool inside a new class, CTxMemPool

### DIFF
--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -363,7 +363,7 @@ Value getmininginfo(const Array& params, bool fHelp)
     obj.push_back(Pair("generate",      GetBoolArg("-gen")));
     obj.push_back(Pair("genproclimit",  (int)GetArg("-genproclimit", -1)));
     obj.push_back(Pair("hashespersec",  gethashespersec(params, false)));
-    obj.push_back(Pair("pooledtx",      (uint64_t)nPooledTx));
+    obj.push_back(Pair("pooledtx",      (uint64_t)mempool.size()));
     obj.push_back(Pair("testnet",       fTestNet));
     return obj;
 }

--- a/src/main.h
+++ b/src/main.h
@@ -1608,4 +1608,12 @@ public:
     bool ProcessAlert();
 };
 
+class CTxMemPool
+{
+public:
+    mutable CCriticalSection cs;
+    std::map<uint256, CTransaction> mapTx;
+    std::map<COutPoint, CInPoint> mapNextTx;
+};
+
 #endif

--- a/src/main.h
+++ b/src/main.h
@@ -1611,6 +1611,8 @@ public:
     std::map<uint256, CTransaction> mapTx;
     std::map<COutPoint, CInPoint> mapNextTx;
 
+    bool accept(CTxDB& txdb, CTransaction &tx,
+                bool fCheckInputs, bool* pfMissingInputs);
     bool addUnchecked(CTransaction &tx);
     bool remove(CTransaction &tx);
 

--- a/src/main.h
+++ b/src/main.h
@@ -1621,6 +1621,16 @@ public:
         LOCK(cs);
         return mapTx.size();
     }
+
+    bool exists(uint256 hash)
+    {
+        return (mapTx.count(hash) != 0);
+    }
+
+    CTransaction& lookup(uint256 hash)
+    {
+        return mapTx[hash];
+    }
 };
 
 extern CTxMemPool mempool;

--- a/src/main.h
+++ b/src/main.h
@@ -67,7 +67,6 @@ extern CBigNum bnBestChainWork;
 extern CBigNum bnBestInvalidWork;
 extern uint256 hashBestChain;
 extern CBlockIndex* pindexBest;
-extern uint64 nPooledTx;
 extern unsigned int nTransactionsUpdated;
 extern uint64 nLastBlockTx;
 extern uint64 nLastBlockSize;
@@ -689,9 +688,6 @@ public:
 
 protected:
     const CTxOut& GetOutputFor(const CTxIn& input, const MapPrevTx& inputs) const;
-    bool AddToMemoryPoolUnchecked();
-public:
-    bool RemoveFromMemoryPool();
 };
 
 
@@ -1614,6 +1610,17 @@ public:
     mutable CCriticalSection cs;
     std::map<uint256, CTransaction> mapTx;
     std::map<COutPoint, CInPoint> mapNextTx;
+
+    bool addUnchecked(CTransaction &tx);
+    bool remove(CTransaction &tx);
+
+    unsigned long size()
+    {
+        LOCK(cs);
+        return mapTx.size();
+    }
 };
+
+extern CTxMemPool mempool;
 
 #endif


### PR DESCRIPTION
As mentioned on IRC, the mempool code always seemed inside-out to me.  This set of commits updates main.{h,cpp} code to create a new CTxMemPool class.

This is essentially just code movement and renaming.  No behavior changes should occur [that have not already been submitted separately as independent pull requests].
