### PR TITLE
BIP31 cleanups + fix

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2652,7 +2652,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
 
     else if (strCommand == "ping")
     {
-        if (pfrom->nVersion > BIP0031_VERSION)
+        if (pfrom->nVersion >= BIP0031_VERSION)
         {
             uint64 nonce = 0;
             vRecv >> nonce;
@@ -2834,7 +2834,7 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
         // Keep-alive ping. We send a nonce of zero because we don't use it anywhere 
         // right now.
         if (pto->nLastSend && GetTime() - pto->nLastSend > 30 * 60 && pto->vSend.empty()) {
-            if (pto->nVersion > BIP0031_VERSION)
+            if (pto->nVersion >= BIP0031_VERSION)
                 pto->PushMessage("ping", 0);
             else
                 pto->PushMessage("ping");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2831,14 +2831,10 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
         if (pto->nVersion == 0)
             return true;
 
-        // Keep-alive ping. We send a nonce of zero because we don't use it anywhere 
+        // Keep-alive ping. We don't send a nonce because we don't use pongs anywhere
         // right now.
-        if (pto->nLastSend && GetTime() - pto->nLastSend > 30 * 60 && pto->vSend.empty()) {
-            if (pto->nVersion >= BIP0031_VERSION)
-                pto->PushMessage("ping", 0);
-            else
-                pto->PushMessage("ping");
-        }
+        if (pto->nLastSend && GetTime() - pto->nLastSend > 30 * 60 && pto->vSend.empty())
+            pto->PushMessage("ping");
 
         // Resend wallet transactions that haven't gotten in a block yet
         ResendWalletTransactions();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2652,7 +2652,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
 
     else if (strCommand == "ping")
     {
-        if (pfrom->nVersion >= BIP0031_VERSION)
+        if (pfrom->nVersion >= BIP0031_VERSION && !vRecv.empty())
         {
             uint64 nonce = 0;
             vRecv >> nonce;

--- a/src/version.h
+++ b/src/version.h
@@ -42,7 +42,7 @@ static const int CADDR_TIME_VERSION = 31402;
 static const int NOBLKS_VERSION_START = 32000;
 static const int NOBLKS_VERSION_END = 32400;
 
-// BIP 0031, pong message, is enabled for all versions AFTER this one
-static const int BIP0031_VERSION = 60000;
+// BIP 0031, pong message, is enabled for all versions starting with this one
+static const int BIP0031_VERSION = 60001;
 
 #endif


### PR DESCRIPTION
- Use >= for BIP0031 version
- Bugfix: nonce is optional in ping messages
- Don't request a pong that we ignore
