### PR TITLE
Reduce sync frequency for blkindex.dat

### DIFF
--- a/src/db.cpp
+++ b/src/db.cpp
@@ -162,6 +162,8 @@ void CDB::Close()
         nMinutes = 1;
     if (strFile == "addr.dat")
         nMinutes = 2;
+    if (strFile == "blkindex.dat")
+        nMinutes = 2;
     if (strFile == "blkindex.dat" && IsInitialBlockDownload())
         nMinutes = 5;
 


### PR DESCRIPTION
Since auto-remove-db-logs was enabled, each time a CTxDB was closed
outside of the initial download window, it causes a checkpoint + log
cleanup. This is overkill, so reduce the sync frequency to once per
minute at most.
