### PR TITLE
Fix potential deadlock

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2807,8 +2807,8 @@ bool ProcessMessages(CNode* pfrom)
 
 bool SendMessages(CNode* pto, bool fSendTrickle)
 {
-    {
-        LOCK(cs_main);
+    TRY_LOCK(cs_main, lockMain);
+    if (lockMain) {
         // Don't send anything until we get their version message
         if (pto->nVersion == 0)
             return true;


### PR DESCRIPTION
Conflict:
- cs_main in ProcessMessages() (before calling ProcessMessages)
- cs_vSend in CNode::BeginMessage
  versus:
- cs_vSend in ThreadMessageHandler2 (before calling SendMessages)
- cs_main in SendMessages

Even though cs_vSend is a try_lock, if it succeeds simultaneously with
the locking of cs_main in ProcessMessages(), it could cause a deadlock.
