### PR TITLE
Make lsn_reset ("detach databases") optional and off by default.

### DIFF
--- a/src/db.cpp
+++ b/src/db.cpp
@@ -28,6 +28,7 @@ unsigned int nWalletDBUpdated;
 
 CCriticalSection cs_db;
 static bool fDbEnvInit = false;
+bool fDetachDB = false;
 DbEnv dbenv(0);
 map<string, int> mapFileUseCount;
 static map<string, Db*> mapDb;
@@ -307,9 +308,13 @@ void DBFlush(bool fShutdown)
             {
                 // Move log data to the dat file
                 CloseDb(strFile);
+                printf("%s checkpoint\n", strFile.c_str());
                 dbenv.txn_checkpoint(0, 0, 0);
-                printf("%s flush\n", strFile.c_str());
-                dbenv.lsn_reset(strFile.c_str(), 0);
+                if ((strFile != "blkindex.dat" && strFile != "addr.dat") || fDetachDB) {
+                    printf("%s detach\n", strFile.c_str());
+                    dbenv.lsn_reset(strFile.c_str(), 0);
+                }
+                printf("%s closed\n", strFile.c_str());
                 mapFileUseCount.erase(mi++);
             }
             else

--- a/src/db.h
+++ b/src/db.h
@@ -25,6 +25,7 @@ class CWallet;
 class CWalletTx;
 
 extern unsigned int nWalletDBUpdated;
+extern bool fDetachDB;
 extern DbEnv dbenv;
 
 extern void DBFlush(bool fShutdown);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -200,6 +200,7 @@ bool AppInit2(int argc, char* argv[])
 #else
             "  -upnp            \t  "   + _("Use Universal Plug and Play to map the listening port (default: 0)") + "\n" +
 #endif
+            "  -detachdb        \t  "   + _("Detach block and address databases. Increases shutdown time (default: 0)") + "\n" +
 #endif
             "  -paytxfee=<amt>  \t  "   + _("Fee per KB to add to transactions you send") + "\n" +
 #ifdef QT_GUI
@@ -255,6 +256,7 @@ bool AppInit2(int argc, char* argv[])
     }
 
     fDebug = GetBoolArg("-debug");
+    fDetachDB = GetBoolArg("-detachdb", false);
 
 #if !defined(WIN32) && !defined(QT_GUI)
     fDaemon = GetBoolArg("-daemon");

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -38,6 +38,7 @@ private:
     QCheckBox *minimize_on_close;
 #endif
     QCheckBox *connect_socks4;
+    QCheckBox *detach_database;
     QLineEdit *proxy_ip;
     QLineEdit *proxy_port;
     BitcoinAmountField *fee_edit;
@@ -229,6 +230,10 @@ MainOptionsPage::MainOptionsPage(QWidget *parent):
 
     layout->addLayout(fee_hbox);
 
+    detach_database = new QCheckBox(tr("Detach databases at shutdown"));
+    detach_database->setToolTip(tr("Detach block and address databases at shutdown. This means they can be moved to another data directory, but it slows down shutdown. The wallet is always detached."));
+    layout->addWidget(detach_database);
+
     layout->addStretch(1); // Extra space at bottom
 
     setLayout(layout);
@@ -256,6 +261,7 @@ void MainOptionsPage::setMapper(MonitoredDataMapper *mapper)
     mapper->addMapping(proxy_ip, OptionsModel::ProxyIP);
     mapper->addMapping(proxy_port, OptionsModel::ProxyPort);
     mapper->addMapping(fee_edit, OptionsModel::Fee);
+    mapper->addMapping(detach_database, OptionsModel::DetachDatabases);
 }
 
 DisplayOptionsPage::DisplayOptionsPage(QWidget *parent):

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -28,6 +28,8 @@ void OptionsModel::Init()
         SoftSetBoolArg("-upnp", settings.value("fUseUPnP").toBool());
     if (settings.contains("addrProxy") && settings.value("fUseProxy").toBool())
         SoftSetArg("-proxy", settings.value("addrProxy").toString().toStdString());
+    if (settings.contains("detachDB"))
+        SoftSetBoolArg("-detachdb", settings.value("detachDB").toBool());
 }
 
 bool OptionsModel::Upgrade()
@@ -121,6 +123,8 @@ QVariant OptionsModel::data(const QModelIndex & index, int role) const
             return QVariant(nDisplayUnit);
         case DisplayAddresses:
             return QVariant(bDisplayAddresses);
+        case DetachDatabases:
+            return QVariant(fDetachDB);
         default:
             return QVariant();
         }
@@ -202,6 +206,11 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
         case DisplayAddresses: {
             bDisplayAddresses = value.toBool();
             settings.setValue("bDisplayAddresses", bDisplayAddresses);
+            }
+            break;
+        case DetachDatabases: {
+            fDetachDB = value.toBool();
+            settings.setValue("detachDB", fDetachDB);
             }
             break;
         default:

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -26,7 +26,8 @@ public:
         Fee, // qint64
         DisplayUnit, // BitcoinUnits::Unit
         DisplayAddresses, // bool
-        OptionIDRowCount
+        DetachDatabases, // bool
+        OptionIDRowCount,
     };
 
     void Init();


### PR DESCRIPTION
Add an option -detachdb (and entry in OptionDialog), without which no lsn_reset is called on addr.dat and  blkindex.dat. That means these files cannot be moved to a new environment, but shutdown can be significantly faster. The wallet file is always lsn_reset'ed.

-detachdb corresponds to the old behaviour, though it is off by default now to speed up shutdowns.
