### PR TITLE
Integrate @JoelKatz's optimized ToHex (#562) into current HexStr function

### DIFF
--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -88,7 +88,18 @@ BOOST_AUTO_TEST_CASE(util_HexStr)
     BOOST_CHECK_EQUAL(
         HexStr(ParseHex_expected, ParseHex_expected + 5, true),
         "04 67 8a fd b0");
+
+    BOOST_CHECK_EQUAL(
+        HexStr(ParseHex_expected, ParseHex_expected, true),
+        "");
+
+    std::vector<unsigned char> ParseHex_vec(ParseHex_expected, ParseHex_expected + 5);
+
+    BOOST_CHECK_EQUAL(
+        HexStr(ParseHex_vec, true),
+        "04 67 8a fd b0");
 }
+
 
 BOOST_AUTO_TEST_CASE(util_DateTimeStrFormat)
 {

--- a/src/util.h
+++ b/src/util.h
@@ -361,15 +361,20 @@ inline int64 abs64(int64 n)
 template<typename T>
 std::string HexStr(const T itbegin, const T itend, bool fSpaces=false)
 {
-    if (itbegin == itend)
-        return "";
-    const unsigned char* pbegin = (const unsigned char*)&itbegin[0];
-    const unsigned char* pend = pbegin + (itend - itbegin) * sizeof(itbegin[0]);
-    std::string str;
-    str.reserve((pend-pbegin) * (fSpaces ? 3 : 2));
-    for (const unsigned char* p = pbegin; p != pend; p++)
-        str += strprintf((fSpaces && p != pend-1 ? "%02x " : "%02x"), *p);
-    return str;
+    std::vector<char> rv;
+    static char hexmap[16] = { '0', '1', '2', '3', '4', '5', '6', '7',
+                               '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' };
+    rv.reserve((itend-itbegin)*3);
+    for(T it = itbegin; it < itend; ++it)
+    {
+        unsigned char val = (unsigned char)(*it);
+        if(fSpaces && it != itbegin)
+            rv.push_back(' ');
+        rv.push_back(hexmap[val>>4]);
+        rv.push_back(hexmap[val&15]);
+    }
+
+    return std::string(rv.begin(), rv.end());
 }
 
 inline std::string HexStr(const std::vector<unsigned char>& vch, bool fSpaces=false)


### PR DESCRIPTION
Pull request #562 was rejected because it introduced a new ToHex function with a different, potentially less safe interface.

This pull request gives most of the speed-up (~30x on my CPU) of @JoelKatz his patch but rolls it into the current HexStr function. See the following benchmark results (made using https://gist.github.com/2439041).

```
Testing HexStrOld (1000000 iterations)
-> 14120.0 ms
Testing HexStrNew (1000000 iterations)
-> 470.0 ms
Testing ToHex (1000000 iterations)
-> 100.0 ms
```

It also adds two tests for HexStr: testing HexStr for the empty string and the function that takes a std::vector.
