### PR TITLE
small util.cpp/h changes

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -163,6 +163,9 @@ boost::filesystem::path GetConfigFile();
 boost::filesystem::path GetPidFile();
 void CreatePidFile(const boost::filesystem::path &path, pid_t pid);
 void ReadConfigFile(std::map<std::string, std::string>& mapSettingsRet, std::map<std::string, std::vector<std::string> >& mapMultiSettingsRet);
+#ifdef WIN32
+boost::filesystem::path GetSpecialFolderPath(int nFolder, bool fCreate = true);
+#endif
 bool GetStartOnSystemStartup();
 bool SetStartOnSystemStartup(bool fAutoStart);
 void ShrinkDebugFile();


### PR DESCRIPTION
- add some comments / expand some comments
- move MyGetSpecialFolderPath() to another #ifdef WIN32 place, rename to GetSpecialFolderPath(), make fCreate default to true (could perhaps be removed and set to always true in the function) and remove fallbacks for  SHGetSpecialFolderPathA() (I added an error message instead - this had been suggested in a former pull-request)
- remove namespace fs = boost::filesystem; where fs was only used once to shorten the code
