### PR TITLE
Fix final sign comparison warnings (major source of main.h warning spew)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1701,7 +1701,7 @@ bool CBlock::AcceptBlock()
     // Write block to history file
     if (!CheckDiskSpace(::GetSerializeSize(*this, SER_DISK, CLIENT_VERSION)))
         return error("AcceptBlock() : out of disk space");
-    unsigned int nFile = -1;
+    unsigned int nFile = 0;
     unsigned int nBlockPos = 0;
     if (!WriteToDisk(nFile, nBlockPos))
         return error("AcceptBlock() : WriteToDisk failed");
@@ -1826,7 +1826,7 @@ bool CheckDiskSpace(uint64 nAdditionalBytes)
 
 FILE* OpenBlockFile(unsigned int nFile, unsigned int nBlockPos, const char* pszMode)
 {
-    if (nFile == -1)
+    if (nFile < 1)
         return NULL;
     FILE* file = fopen((GetDataDir() / strprintf("blk%04d.dat", nFile)).string().c_str(), pszMode);
     if (!file)

--- a/src/main.h
+++ b/src/main.h
@@ -136,8 +136,8 @@ public:
     }
 
     IMPLEMENT_SERIALIZE( READWRITE(FLATDATA(*this)); )
-    void SetNull() { nFile = -1; nBlockPos = 0; nTxPos = 0; }
-    bool IsNull() const { return (nFile == -1); }
+    void SetNull() { nFile = 0; nBlockPos = 0; nTxPos = 0; }
+    bool IsNull() const { return (nFile == 0); }
 
     friend bool operator==(const CDiskTxPos& a, const CDiskTxPos& b)
     {
@@ -156,7 +156,7 @@ public:
         if (IsNull())
             return "null";
         else
-            return strprintf("(nFile=%d, nBlockPos=%d, nTxPos=%d)", nFile, nBlockPos, nTxPos);
+            return strprintf("(nFile=%u, nBlockPos=%d, nTxPos=%d)", nFile, nBlockPos, nTxPos);
     }
 
     void print() const
@@ -176,8 +176,8 @@ public:
 
     CInPoint() { SetNull(); }
     CInPoint(CTransaction* ptxIn, unsigned int nIn) { ptx = ptxIn; n = nIn; }
-    void SetNull() { ptx = NULL; n = -1; }
-    bool IsNull() const { return (ptx == NULL && n == -1); }
+    void SetNull() { ptx = NULL; n = 0; }
+    bool IsNull() const { return (ptx == NULL && n == 0); }
 };
 
 
@@ -192,8 +192,8 @@ public:
     COutPoint() { SetNull(); }
     COutPoint(uint256 hashIn, unsigned int nIn) { hash = hashIn; n = nIn; }
     IMPLEMENT_SERIALIZE( READWRITE(FLATDATA(*this)); )
-    void SetNull() { hash = 0; n = -1; }
-    bool IsNull() const { return (hash == 0 && n == -1); }
+    void SetNull() { hash = 0; n = 0; }
+    bool IsNull() const { return (hash == 0 && n == 0); }
 
     friend bool operator<(const COutPoint& a, const COutPoint& b)
     {
@@ -212,7 +212,7 @@ public:
 
     std::string ToString() const
     {
-        return strprintf("COutPoint(%s, %d)", hash.ToString().substr(0,10).c_str(), n);
+        return strprintf("COutPoint(%s, %u)", hash.ToString().substr(0,10).c_str(), n);
     }
 
     void print() const


### PR DESCRIPTION
After this commit, "-Wall" only produces two warnings on my platform.

This was sent under a separate cover because it deserves additional review.  It changes (slightly) the usage of some serialized objects in a hopefully-superficial way.
