### PR TITLE
We should include netinet/in.h to use sockaddr_in (POSIX.1-2001)

### DIFF
--- a/src/compat.h
+++ b/src/compat.h
@@ -21,10 +21,8 @@
 #include <arpa/inet.h>
 #include <netdb.h>
 #include <net/if.h>
-#include <ifaddrs.h>
-#endif
-#ifdef BSD
 #include <netinet/in.h>
+#include <ifaddrs.h>
 #endif
 
 typedef u_int SOCKET;


### PR DESCRIPTION
It's also needed to compile bitcoin under BSD systems without editing makefile and add -DBSD to CXXFLAGS.
Under linux it still compiles without any changes
