### PR TITLE
Trim trailing whitespace in src/*.{cpp,h}

### DIFF
--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -174,7 +174,7 @@ int CAddrMan::ShrinkNew(int nUBucket)
         nI++;
     }
     CAddrInfo &info = mapInfo[nOldest];
-    if (--info.nRefCount == 0) 
+    if (--info.nRefCount == 0)
     {
         SwapRandom(info.nRandomPos, vRandom.size()-1);
         vRandom.pop_back();
@@ -223,7 +223,7 @@ void CAddrMan::MakeTried(CAddrInfo& info, int nId, int nOrigin)
     infoOld.nRefCount = 1;
     // do not update nTried, as we are going to move something else there immediately
 
-    // check whether there is place in that one, 
+    // check whether there is place in that one,
     if (vNew.size() < ADDRMAN_NEW_BUCKET_SIZE)
     {
         // if so, move it back there

--- a/src/addrman.h
+++ b/src/addrman.h
@@ -213,7 +213,7 @@ protected:
     // This is the only place where actual deletes occur.
     // They are never deleted while in the "tried" table, only possibly evicted back to the "new" table.
     int ShrinkNew(int nUBucket);
- 
+
     // Move an entry from the "new" table(s) to the "tried" table
     // @pre vvUnkown[nOrigin].count(nId) != 0
     void MakeTried(CAddrInfo& info, int nId, int nOrigin);

--- a/src/base58.h
+++ b/src/base58.h
@@ -362,7 +362,7 @@ class CBitcoinSecret : public CBase58Data
 {
 public:
     void SetSecret(const CSecret& vchSecret, bool fCompressed)
-    { 
+    {
         assert(vchSecret.size() == 32);
         SetData(fTestNet ? 239 : 128, &vchSecret[0], vchSecret.size());
         if (fCompressed)

--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -19,7 +19,7 @@
 #include <boost/iostreams/stream.hpp>
 #include <boost/algorithm/string.hpp>
 #include <boost/lexical_cast.hpp>
-#include <boost/asio/ssl.hpp> 
+#include <boost/asio/ssl.hpp>
 #include <boost/filesystem/fstream.hpp>
 typedef boost::asio::ssl::stream<boost::asio::ip::tcp::socket> SSLStream;
 
@@ -951,7 +951,7 @@ Value sendmany(const Array& params, bool fHelp)
 
         CScript scriptPubKey;
         scriptPubKey.SetBitcoinAddress(address);
-        int64 nAmount = AmountFromValue(s.value_); 
+        int64 nAmount = AmountFromValue(s.value_);
         totalAmount += nAmount;
 
         vecSend.push_back(make_pair(scriptPubKey, nAmount));
@@ -1330,7 +1330,7 @@ Value listtransactions(const Array& params, bool fHelp)
         if (ret.size() >= (nCount+nFrom)) break;
     }
     // ret is newest to oldest
-    
+
     if (nFrom > (int)ret.size())
         nFrom = ret.size();
     if ((nFrom + nCount) > (int)ret.size())

--- a/src/crypter.cpp
+++ b/src/crypter.cpp
@@ -19,7 +19,7 @@ bool CCrypter::SetKeyFromPassphrase(const SecureString& strKeyData, const std::v
 
     // Try to keep the keydata out of swap (and be a bit over-careful to keep the IV that we don't even use out of swap)
     // Note that this does nothing about suspend-to-disk (which will put all our key data on disk)
-    // Note as well that at no point in this program is any attempt made to prevent stealing of keys by reading the memory of the running process.  
+    // Note as well that at no point in this program is any attempt made to prevent stealing of keys by reading the memory of the running process.
     mlock(&chKey[0], sizeof chKey);
     mlock(&chIV[0], sizeof chIV);
 
@@ -46,7 +46,7 @@ bool CCrypter::SetKey(const CKeyingMaterial& chNewKey, const std::vector<unsigne
 
     // Try to keep the keydata out of swap
     // Note that this does nothing about suspend-to-disk (which will put all our key data on disk)
-    // Note as well that at no point in this program is any attempt made to prevent stealing of keys by reading the memory of the running process.  
+    // Note as well that at no point in this program is any attempt made to prevent stealing of keys by reading the memory of the running process.
     mlock(&chKey[0], sizeof chKey);
     mlock(&chIV[0], sizeof chIV);
 

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -214,7 +214,7 @@ bool CDB::Rewrite(const string& strFile, const char* pszSkip)
                 { // surround usage of db with extra {}
                     CDB db(strFile.c_str(), "r");
                     Db* pdbCopy = new Db(&dbenv, 0);
-    
+
                     int ret = pdbCopy->open(NULL,                 // Txn pointer
                                             strFileRes.c_str(),   // Filename
                                             "main",    // Logical db name
@@ -226,7 +226,7 @@ bool CDB::Rewrite(const string& strFile, const char* pszSkip)
                         printf("Cannot create database file %s\n", strFileRes.c_str());
                         fSuccess = false;
                     }
-    
+
                     Dbc* pcursor = db.GetCursor();
                     if (pcursor)
                         while (fSuccess)
@@ -749,7 +749,7 @@ bool CAddrDB::LoadAddresses()
         printf("Loaded %i addresses\n", addrman.size());
         return true;
     }
-    
+
     // Read pre-0.6 addr records
 
     vector<CAddress> vAddr;

--- a/src/irc.cpp
+++ b/src/irc.cpp
@@ -291,7 +291,7 @@ void ThreadIRCSeed2(void* parg)
                 Send(hSocket, strprintf("NICK %s\r", strMyName.c_str()).c_str());
             }
         }
-        
+
         if (fTestNet) {
             Send(hSocket, "JOIN #bitcoinTEST\r");
             Send(hSocket, "WHO #bitcoinTEST\r");

--- a/src/key.h
+++ b/src/key.h
@@ -165,7 +165,7 @@ public:
         if (bn == NULL)
             throw key_error("CKey::GetSecret() : EC_KEY_get0_private_key failed");
         int n=BN_bn2bin(bn,&vchRet[32 - nBytes]);
-        if (n != nBytes) 
+        if (n != nBytes)
             throw key_error("CKey::GetSecret(): BN_bn2bin failed");
         fCompressed = fCompressedPubKey;
         return vchRet;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -718,7 +718,7 @@ bool CWalletTx::AcceptWalletTransaction(CTxDB& txdb, bool fCheckInputs)
     return false;
 }
 
-bool CWalletTx::AcceptWalletTransaction() 
+bool CWalletTx::AcceptWalletTransaction()
 {
     CTxDB txdb("r");
     return AcceptWalletTransaction(txdb);
@@ -2862,7 +2862,7 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
         if (pto->nVersion == 0)
             return true;
 
-        // Keep-alive ping. We send a nonce of zero because we don't use it anywhere 
+        // Keep-alive ping. We send a nonce of zero because we don't use it anywhere
         // right now.
         if (pto->nLastSend && GetTime() - pto->nLastSend > 30 * 60 && pto->vSend.empty()) {
             if (pto->nVersion > BIP0031_VERSION)
@@ -3062,7 +3062,7 @@ void SHA256Transform(void* pstate, void* pinput, const void* pinit)
         ctx.h[i] = ((uint32_t*)pinit)[i];
 
     SHA256_Update(&ctx, data, sizeof(data));
-    for (int i = 0; i < 8; i++) 
+    for (int i = 0; i < 8; i++)
         ((uint32_t*)pstate)[i] = ctx.h[i];
 }
 

--- a/src/main.h
+++ b/src/main.h
@@ -790,7 +790,7 @@ public:
         return !(a == b);
     }
     int GetDepthInMainChain() const;
- 
+
 };
 
 

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -352,8 +352,8 @@ bool CNetAddr::IsIPv4() const
 bool CNetAddr::IsRFC1918() const
 {
     return IsIPv4() && (
-        GetByte(3) == 10 || 
-        (GetByte(3) == 192 && GetByte(2) == 168) || 
+        GetByte(3) == 10 ||
+        (GetByte(3) == 192 && GetByte(2) == 168) ||
         (GetByte(3) == 172 && (GetByte(2) >= 16 && GetByte(2) <= 31)));
 }
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1329,7 +1329,7 @@ static void push_lock(void* c, const CLockLocation& locklocation, bool fTry)
 
 static void pop_lock()
 {
-    if (fDebug) 
+    if (fDebug)
     {
         const CLockLocation& locklocation = (*lockstack).rbegin()->second;
         printf("Unlocked: %s\n", locklocation.ToString().c_str());

--- a/src/util.h
+++ b/src/util.h
@@ -571,7 +571,7 @@ inline uint160 Hash160(const std::vector<unsigned char>& vch)
 }
 
 
-/** Median filter over a stream of values. 
+/** Median filter over a stream of values.
  * Returns the median of the last N numbers
  */
 template <typename T> class CMedianFilter
@@ -588,7 +588,7 @@ public:
         vValues.push_back(initial_value);
         vSorted = vValues;
     }
-    
+
     void input(T value)
     {
         if(vValues.size() == nSize)

--- a/src/version.h
+++ b/src/version.h
@@ -17,7 +17,7 @@ static const int CLIENT_VERSION_BUILD       = 1;
 
 static const int CLIENT_VERSION =
                            1000000 * CLIENT_VERSION_MAJOR
-                         +   10000 * CLIENT_VERSION_MINOR 
+                         +   10000 * CLIENT_VERSION_MINOR
                          +     100 * CLIENT_VERSION_REVISION
                          +       1 * CLIENT_VERSION_BUILD;
 

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -567,7 +567,7 @@ void CWalletTx::GetAmounts(int64& nGeneratedImmature, int64& nGeneratedMature, l
 
 }
 
-void CWalletTx::GetAccountAmounts(const string& strAccount, int64& nGenerated, int64& nReceived, 
+void CWalletTx::GetAccountAmounts(const string& strAccount, int64& nGenerated, int64& nReceived,
                                   int64& nSent, int64& nFee) const
 {
     nGenerated = nReceived = nSent = nFee = 0;

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -298,7 +298,7 @@ public:
 };
 
 
-/** A transaction with a bunch of additional info that only the owner cares about. 
+/** A transaction with a bunch of additional info that only the owner cares about.
  * It includes any unrecorded transactions needed to link it back to the block chain.
  */
 class CWalletTx : public CMerkleTx
@@ -533,7 +533,7 @@ public:
     void GetAmounts(int64& nGeneratedImmature, int64& nGeneratedMature, std::list<std::pair<CBitcoinAddress, int64> >& listReceived,
                     std::list<std::pair<CBitcoinAddress, int64> >& listSent, int64& nFee, std::string& strSentAccount) const;
 
-    void GetAccountAmounts(const std::string& strAccount, int64& nGenerated, int64& nReceived, 
+    void GetAccountAmounts(const std::string& strAccount, int64& nGenerated, int64& nReceived,
                            int64& nSent, int64& nFee) const;
 
     bool IsFromMe() const


### PR DESCRIPTION
This commit changes no code, and makes no other cleanups than removing the trailing whitespace from source code and comment lines.

Script used: https://gist.github.com/2561322
