### PR TITLE
remove duplicate definition of SecureString in util.h

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -302,14 +302,6 @@ typedef boost::interprocess::interprocess_condition CConditionVariable;
     }
 
 
-// This is exactly like std::string, but with a custom allocator.
-// (secure_allocator<> is defined in serialize.h)
-typedef std::basic_string<char, std::char_traits<char>, secure_allocator<char> > SecureString;
-
-
-
-
-
 inline std::string i64tostr(int64 n)
 {
     return strprintf("%"PRI64d, n);


### PR DESCRIPTION
SecureString was moved to allocators.h in commit 6cb6d623479c5dd42d91de7a4d391078d0800e54
