### PR TITLE
Update to require IE 5.1 as it is required to build on mingw64.

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -43,7 +43,7 @@ namespace boost {
 #ifdef _WIN32_IE
 #undef _WIN32_IE
 #endif
-#define _WIN32_IE 0x0400
+#define _WIN32_IE 0x0501
 #define WIN32_LEAN_AND_MEAN 1
 #ifndef NOMINMAX
 #define NOMINMAX


### PR DESCRIPTION
We already require XP, this just fixes Mingw64 build.
