### PR TITLE
signmessage: auto-select signature when field is focused/clicked

### DIFF
--- a/src/qt/messagepage.cpp
+++ b/src/qt/messagepage.cpp
@@ -26,6 +26,7 @@ MessagePage::MessagePage(QWidget *parent) :
     ui->setupUi(this);
 
     GUIUtil::setupAddressWidget(ui->signFrom, this);
+    ui->signature->installEventFilter(this);
 }
 
 MessagePage::~MessagePage()
@@ -111,4 +112,15 @@ void MessagePage::on_clearButton_clicked()
     ui->signFrom->clear();
     ui->message->clear();
     ui->signature->clear();
+}
+
+bool MessagePage::eventFilter(QObject *object, QEvent *event)
+{
+    if(object == ui->signature && (event->type() == QEvent::MouseButtonPress ||
+                                   event->type() == QEvent::FocusIn))
+    {
+        ui->signature->selectAll();
+        return true;
+    }
+    return QDialog::eventFilter(object, event);
 }

--- a/src/qt/messagepage.h
+++ b/src/qt/messagepage.h
@@ -23,6 +23,9 @@ public:
 
     void setAddress(QString);
 
+protected:
+    bool eventFilter(QObject *object, QEvent *event);
+
 private:
     Ui::MessagePage *ui;
     WalletModel *model;


### PR DESCRIPTION
This is the behavior I expect (but miss) every time I use this functionality.
