### PR TITLE
renamed qrcodedialog.ui window title to "QR-Code Dialog"... 

### DIFF
--- a/src/qt/forms/qrcodedialog.ui
+++ b/src/qt/forms/qrcodedialog.ui
@@ -6,12 +6,12 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>320</width>
-    <height>404</height>
+    <width>334</width>
+    <height>423</height>
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Dialog</string>
+   <string>QR-Code Dialog</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_3">
    <item>


### PR DESCRIPTION
As this makes things easier on transifex, as currently we have 2x only "Dialog" to translate there.
- changed window size to the minimum values Qt Creator allows me to set
