### PR TITLE
GUI messagepage: add placeholder text to address field (like in sendcoins dialog)...

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -724,8 +724,11 @@ void BitcoinGUI::gotoSendCoinsPage()
     disconnect(exportAction, SIGNAL(triggered()), 0, 0);
 }
 
-void BitcoinGUI::gotoMessagePage()
+void BitcoinGUI::gotoMessagePage(QString addr)
 {
+    if(!addr.isEmpty())
+        messagePage->setAddress(addr);
+
 #ifdef FIRST_CLASS_MESSAGING
     messageAction->setChecked(true);
     centralWidget->setCurrentWidget(messagePage);
@@ -734,14 +737,7 @@ void BitcoinGUI::gotoMessagePage()
     disconnect(exportAction, SIGNAL(triggered()), 0, 0);
 #else
     messagePage->show();
-    messagePage->setFocus();
 #endif
-}
-
-void BitcoinGUI::gotoMessagePage(QString addr)
-{
-    gotoMessagePage();
-    messagePage->setAddress(addr);
 }
 
 void BitcoinGUI::dragEnterEvent(QDragEnterEvent *event)

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -46,7 +46,7 @@ public:
         functionality.
     */
     void setWalletModel(WalletModel *walletModel);
-    
+
 protected:
     void changeEvent(QEvent *e);
     void closeEvent(QCloseEvent *event);
@@ -130,8 +130,7 @@ public slots:
     void askFee(qint64 nFeeRequired, bool *payFee);
     void handleURI(QString strURI);
 
-    void gotoMessagePage();
-    void gotoMessagePage(QString);
+    void gotoMessagePage(QString addr = "");
 
 private slots:
     /** Switch to overview (home) page */

--- a/src/qt/forms/messagepage.ui
+++ b/src/qt/forms/messagepage.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Message</string>
+   <string>Sign Message Dialog</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>

--- a/src/qt/messagepage.cpp
+++ b/src/qt/messagepage.cpp
@@ -24,14 +24,17 @@ MessagePage::MessagePage(QWidget *parent) :
     ui(new Ui::MessagePage)
 {
     ui->setupUi(this);
-    
+
 #if (QT_VERSION >= 0x040700)
     /* Do not move this to the XML file, Qt before 4.7 will choke on it */
+    ui->signFrom->setPlaceholderText(tr("Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)"));
     ui->signature->setPlaceholderText(tr("Click \"Sign Message\" to get signature"));
 #endif
 
     GUIUtil::setupAddressWidget(ui->signFrom, this);
     ui->signature->installEventFilter(this);
+
+    ui->signFrom->setFocus();
 }
 
 MessagePage::~MessagePage()
@@ -117,6 +120,8 @@ void MessagePage::on_clearButton_clicked()
     ui->signFrom->clear();
     ui->message->clear();
     ui->signature->clear();
+
+    ui->signFrom->setFocus();
 }
 
 bool MessagePage::eventFilter(QObject *object, QEvent *event)


### PR DESCRIPTION
- set focus to address field on opening messagepage or "Clear All"
- consolidate BitcoinGUI::gotoMessagePage() functions into a single one
- rename window title to "Sign Message Dialog"

If you directly open the message page via clicking Sign Message and passing an address, the focus is in the message input field, as intended. If you simply open the message page via menu, focus is set to the address field.
