### PR TITLE
small passphrasedialog update

### DIFF
--- a/src/qt/askpassphrasedialog.cpp
+++ b/src/qt/askpassphrasedialog.cpp
@@ -24,7 +24,6 @@ AskPassphraseDialog::AskPassphraseDialog(Mode mode, QWidget *parent) :
     ui->passEdit1->installEventFilter(this);
     ui->passEdit2->installEventFilter(this);
     ui->passEdit3->installEventFilter(this);
-    ui->capsLabel->clear();
 
     switch(mode)
     {
@@ -215,7 +214,7 @@ bool AskPassphraseDialog::event(QEvent *event)
 
 bool AskPassphraseDialog::eventFilter(QObject *, QEvent *event)
 {
-    /* Detect Caps Lock. 
+    /* Detect Caps Lock.
      * There is no good OS-independent way to check a key state in Qt, but we
      * can detect Caps Lock by checking for the following condition:
      * Shift key is down and the result is a lower case character, or

--- a/src/qt/forms/askpassphrasedialog.ui
+++ b/src/qt/forms/askpassphrasedialog.ui
@@ -23,7 +23,7 @@
    </size>
   </property>
   <property name="windowTitle">
-   <string>Dialog</string>
+   <string>Passphrase Dialog</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
@@ -88,13 +88,14 @@
      </item>
      <item row="4" column="1">
       <widget class="QLabel" name="capsLabel">
-       <property name="styleSheet">
-        <string notr="true">#capsLabel {
-	font: bold;
-}</string>
+       <property name="font">
+        <font>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
        </property>
        <property name="text">
-        <string>TextLabel</string>
+        <string/>
        </property>
        <property name="alignment">
         <set>Qt::AlignCenter</set>


### PR DESCRIPTION
- change dialog title to "Passphrase Dialog as that's better for distinction on Transifex
- remove style-sheet for bold font and use default Qt Designer option for bold
- remove capsLabel default text -> results in removal of a clear() in the source

I tried to move the string, which is displayed when Caps Lock is active into the .ui file and use setVisible(true / false), but that resulted in layout jumping / small layout movements, which were rather ugly!
