### PR TITLE
Hide UI immediately after leaving the main loop

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -282,6 +282,7 @@ int main(int argc, char *argv[])
 #endif
                 app.exec();
 
+                window.hide();
                 window.setClientModel(0);
                 window.setWalletModel(0);
                 guiref = 0;


### PR DESCRIPTION
Prevents it from seeming to hang during shutdown if shutdown is triggered while the window is open.
