### PR TITLE
Make user actions more straightforward in address book

### DIFF
--- a/src/qt/addressbookpage.cpp
+++ b/src/qt/addressbookpage.cpp
@@ -58,25 +58,34 @@ AddressBookPage::AddressBookPage(Mode mode, Tabs tab, QWidget *parent) :
         ui->signMessage->setVisible(true);
         break;
     }
-    ui->tableView->setTabKeyNavigation(false);
-    ui->tableView->setContextMenuPolicy(Qt::CustomContextMenu);
 
     // Context menu actions
-    QAction *copyAddressAction = new QAction(tr("Copy address"), this);
-    QAction *copyLabelAction = new QAction(tr("Copy label"), this);
-    QAction *editAction = new QAction(tr("Edit"), this);
-    deleteAction = new QAction(tr("Delete"), this);
+    QAction *copyLabelAction = new QAction(tr("Copy &Label"), this);
+    QAction *copyAddressAction = new QAction(ui->copyToClipboard->text(), this);
+    QAction *editAction = new QAction(tr("&Edit"), this);
+    QAction *showQRCodeAction = new QAction(ui->showQRCode->text(), this);
+    QAction *signMessageAction = new QAction(ui->signMessage->text(), this);
+    deleteAction = new QAction(ui->deleteButton->text(), this);
 
+    // Build context menu
     contextMenu = new QMenu();
     contextMenu->addAction(copyAddressAction);
     contextMenu->addAction(copyLabelAction);
     contextMenu->addAction(editAction);
-    contextMenu->addAction(deleteAction);
+    if(tab == SendingTab)
+        contextMenu->addAction(deleteAction);
+    contextMenu->addSeparator();
+    contextMenu->addAction(showQRCodeAction);
+    if(tab == ReceivingTab)
+        contextMenu->addAction(signMessageAction);
 
+    // Connect signals for context menu actions
     connect(copyAddressAction, SIGNAL(triggered()), this, SLOT(on_copyToClipboard_clicked()));
     connect(copyLabelAction, SIGNAL(triggered()), this, SLOT(onCopyLabelAction()));
     connect(editAction, SIGNAL(triggered()), this, SLOT(onEditAction()));
     connect(deleteAction, SIGNAL(triggered()), this, SLOT(on_deleteButton_clicked()));
+    connect(showQRCodeAction, SIGNAL(triggered()), this, SLOT(on_showQRCode_clicked()));
+    connect(signMessageAction, SIGNAL(triggered()), this, SLOT(on_signMessage_clicked()));
 
     connect(ui->tableView, SIGNAL(customContextMenuRequested(QPoint)), this, SLOT(contextualMenu(QPoint)));
 

--- a/src/qt/forms/addressbookpage.ui
+++ b/src/qt/forms/addressbookpage.ui
@@ -29,8 +29,14 @@
    </item>
    <item>
     <widget class="QTableView" name="tableView">
+     <property name="contextMenuPolicy">
+      <enum>Qt::CustomContextMenu</enum>
+     </property>
      <property name="toolTip">
       <string>Double-click to edit address or label</string>
+     </property>
+     <property name="tabKeyNavigation">
+      <bool>false</bool>
      </property>
      <property name="alternatingRowColors">
       <bool>true</bool>
@@ -71,7 +77,7 @@
         <string>Copy the currently selected address to the system clipboard</string>
        </property>
        <property name="text">
-        <string>&amp;Copy to Clipboard</string>
+        <string>&amp;Copy Address</string>
        </property>
        <property name="icon">
         <iconset resource="../bitcoin.qrc">


### PR DESCRIPTION
- Add all actions that can be triggered with buttons to the context menu
- Hide delete action from context menu for receiving tab
- "Copy Address" instead of the vague, longwinded "Copy to Clipboard"
