### PR TITLE
remove 2 ugly spaces from a string used in translations

### DIFF
--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -213,7 +213,7 @@ MainOptionsPage::MainOptionsPage(QWidget *parent):
     proxy_hbox->addStretch(1);
 
     layout->addLayout(proxy_hbox);
-    QLabel *fee_help = new QLabel(tr("Optional transaction fee per kB that helps make sure your transactions are processed quickly.  Most transactions are 1 kB.  Fee 0.01 recommended."));
+    QLabel *fee_help = new QLabel(tr("Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB. Fee 0.01 recommended."));
     fee_help->setWordWrap(true);
     layout->addWidget(fee_help);
 


### PR DESCRIPTION
See: https://github.com/bitcoin/bitcoin/commit/1f7e0e51aa2ae6e1aafed52731a4a0fe714a3657#commitcomment-1303905

This wont break any translations, as we had a correct and an ugly translations in for quite some time. This is a cosmetic fix that breaks nothing!
