### PR TITLE
Bugfix: getwork/getmemorypool: NULL pindexPrev across CreateNewBlock, in case it fails

### DIFF
--- a/rpc.cpp
+++ b/rpc.cpp
@@ -967,8 +967,13 @@ Value getwork(const Array& params, bool fHelp)
                     delete pblock;
                 vNewBlock.clear();
             }
+
+            // Clear pindexPrev so future getworks make a new block, despite any failures from here on
+            pindexPrev = NULL;
+
+            // Store the pindexBest used before CreateNewBlock, to avoid races
             nTransactionsUpdatedLast = nTransactionsUpdated;
-            pindexPrev = pindexBest;
+            CBlockIndex* pindexPrevNew = pindexBest;
             nStart = GetTime();
 
             // Create new block
@@ -976,6 +981,9 @@ Value getwork(const Array& params, bool fHelp)
             if (!pblock)
                 throw JSONRPCError(-7, "Out of memory");
             vNewBlock.push_back(pblock);
+
+            // Need to update only after we know CreateNewBlock succeeded
+            pindexPrev = pindexPrevNew;
         }
 
         // Update nTime


### PR DESCRIPTION
Without this, the following bugs are possible:

1) NULL pointer dereference
- CreateNewBlock returns NULL (out of memory); pblock is left NULL and JSON error thrown
- Next call sees pindexPrev/nTransactionsUpdatedLast/nStart up to date, so skips over making a new one
- This next call then tries to update the time on the "current" pblock (NULL)

2) Deleted object dereference
- CreateNewBlock throws an exception (not sure if this is possible right now); pblock is left with a pointer to a deleted CBlock
- Next call sees pindexPrev/nTransactionsUpdatedLast/nStart up to date, so skips over making a new one
- This next call then tried to update the time on the 'current' pblock (which is deleted)
- Consequences of this memory corruption are undefined!
