### PR TITLE
Semaphores

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -147,6 +147,7 @@ public:
     bool fNetworkNode;
     bool fSuccessfullyConnected;
     bool fDisconnect;
+    CSemaphoreGrant grantOutbound;
 protected:
     int nRefCount;
 

--- a/src/util.h
+++ b/src/util.h
@@ -292,7 +292,47 @@ typedef CMutexLock<CCriticalSection> CCriticalBlock;
         LeaveCritical(); \
     }
 
+#ifdef MAC_OSX
+// boost::interprocess::interprocess_semaphore seems to spinlock on OSX; prefer polling instead
+class CSemaphore
+{
+private:
+    CCriticalSection cs;
+    int val;
+
+public:
+    CSemaphore(int init) : val(init) {}
+
+    void wait() {
+        do {
+            {
+                LOCK(cs);
+                if (val>0) {
+                    val--;
+                    return;
+                }
+            }
+            Sleep(100);
+        } while(1);
+    }
+
+    bool try_wait() {
+        LOCK(cs);
+        if (val>0) {
+            val--;
+            return true;
+        }
+        return false;
+    }
+
+    void post() {
+        LOCK(cs);
+        val++;
+    }
+};
+#else
 typedef boost::interprocess::interprocess_semaphore CSemaphore;
+#endif
 
 /** RAII-style semaphore lock */
 class CSemaphoreGrant


### PR DESCRIPTION
- Use semaphores instead of condition variables for limiting outgoing connections
- Cleanup handling of outgoing connections
- Use polling implementation of semaphores on OSX, as boost's semaphores seem to spinlock.
