### PR TITLE
Fix version numbers of archive builds

### DIFF
--- a/src/version.h
+++ b/src/version.h
@@ -10,10 +10,11 @@
 // client versioning
 //
 
-static const int CLIENT_VERSION_MAJOR       =  0;
-static const int CLIENT_VERSION_MINOR       =  6;
-static const int CLIENT_VERSION_REVISION    = 99;
-static const int CLIENT_VERSION_BUILD       =  0;
+// These need to be macro's, as version.cpp's voodoo requires it
+#define CLIENT_VERSION_MAJOR       0
+#define CLIENT_VERSION_MINOR       6
+#define CLIENT_VERSION_REVISION   99
+#define CLIENT_VERSION_BUILD       0
 
 static const int CLIENT_VERSION =
                            1000000 * CLIENT_VERSION_MAJOR


### PR DESCRIPTION
The preprocessor magic in version.cpp require CLIENT_VERSION_\* to be macro's, as they are stringified into CLIENT_DESC when no git-describe output is available.
