### PR TITLE
GUI RPC Console: if there is no current block number available display N/A on totalBlocks label,...

### DIFF
--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -232,7 +232,8 @@ void RPCConsole::setNumBlocks(int count)
     ui->numberOfBlocks->setText(QString::number(count));
     if(clientModel)
     {
-        ui->totalBlocks->setText(QString::number(clientModel->getNumBlocksOfPeers()));
+        // If there is no current number available display N/A instead of 0, which can't ever be true
+        ui->totalBlocks->setText(clientModel->getNumBlocksOfPeers() == 0 ? tr("N/A") : QString::number(clientModel->getNumBlocksOfPeers()));
         ui->lastBlockTime->setText(clientModel->getLastBlockDate().toString());
     }
 }


### PR DESCRIPTION
...instead of 0, which can not ever be true
