### PR TITLE
rename "QR-Code Dialog" to "QR Code Dialog" in qrcodedialog.ui as this spelling is used all over the code

### DIFF
--- a/src/qt/forms/qrcodedialog.ui
+++ b/src/qt/forms/qrcodedialog.ui
@@ -7,11 +7,11 @@
     <x>0</x>
     <y>0</y>
     <width>334</width>
-    <height>423</height>
+    <height>425</height>
    </rect>
   </property>
   <property name="windowTitle">
-   <string>QR-Code Dialog</string>
+   <string>QR Code Dialog</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_3">
    <item>


### PR DESCRIPTION
- set minimum size for height allowed by Qt Creator
