### PR TITLE
Prefer direct access to cached pathDataDir, rather than calling a function

### DIFF
--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -2680,12 +2680,12 @@ void ThreadRPCServer2(void* parg)
         context.set_options(ssl::context::no_sslv2);
 
         filesystem::path pathCertFile(GetArg("-rpcsslcertificatechainfile", "server.cert"));
-        if (!pathCertFile.is_complete()) pathCertFile = filesystem::path(GetDataDir()) / pathCertFile;
+        if (!pathCertFile.is_complete()) pathCertFile = pathDataDir / pathCertFile;
         if (filesystem::exists(pathCertFile)) context.use_certificate_chain_file(pathCertFile.string());
         else printf("ThreadRPCServer ERROR: missing server certificate file %s\n", pathCertFile.string().c_str());
 
         filesystem::path pathPKFile(GetArg("-rpcsslprivatekeyfile", "server.pem"));
-        if (!pathPKFile.is_complete()) pathPKFile = filesystem::path(GetDataDir()) / pathPKFile;
+        if (!pathPKFile.is_complete()) pathPKFile = pathDataDir / pathPKFile;
         if (filesystem::exists(pathPKFile)) context.use_private_key_file(pathPKFile.string(), ssl::context::pem);
         else printf("ThreadRPCServer ERROR: missing server private key file %s\n", pathPKFile.string().c_str());
 

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -47,7 +47,7 @@ static void EnvShutdown()
     {
         printf("EnvShutdown exception: %s (%d)\n", e.what(), e.get_errno());
     }
-    DbEnv(0).remove(GetDataDir().string().c_str(), 0);
+    DbEnv(0).remove(pathDataDir.string().c_str(), 0);
 }
 
 class CDBInit
@@ -82,7 +82,6 @@ CDB::CDB(const char *pszFile, const char* pszMode) : pdb(NULL)
         {
             if (fShutdown)
                 return;
-            filesystem::path pathDataDir = GetDataDir();
             filesystem::path pathLogDir = pathDataDir / "database";
             filesystem::create_directory(pathLogDir);
             filesystem::path pathErrorFile = pathDataDir / "db.log";

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -162,12 +162,13 @@ bool AppInit2(int argc, char* argv[])
     // If Qt is used, parameters/bitcoin.conf are parsed in qt/bitcoin.cpp's main()
 #if !defined(QT_GUI)
     ParseParameters(argc, argv);
-    if (!boost::filesystem::is_directory(GetDataDir(false)))
+    if (!boost::filesystem::is_directory(GetPrepDataDir(false)))
     {
         fprintf(stderr, "Error: Specified directory does not exist\n");
         Shutdown(NULL);
     }
     ReadConfigFile(mapArgs, mapMultiArgs);
+    pathDataDir = GetPrepDataDir(true);
 #endif
 
     if (mapArgs.count("-?") || mapArgs.count("--help"))
@@ -347,13 +348,13 @@ bool AppInit2(int argc, char* argv[])
     }
 
     // Make sure only a single bitcoin process is using the data directory.
-    boost::filesystem::path pathLockFile = GetDataDir() / ".lock";
+    boost::filesystem::path pathLockFile = pathDataDir / ".lock";
     FILE* file = fopen(pathLockFile.string().c_str(), "a"); // empty lock file; created if it doesn't exist.
     if (file) fclose(file);
     static boost::interprocess::file_lock lock(pathLockFile.string().c_str());
     if (!lock.try_lock())
     {
-        ThreadSafeMessageBox(strprintf(_("Cannot obtain a lock on data directory %s.  Bitcoin is probably already running."), GetDataDir().string().c_str()), _("Bitcoin"), wxOK|wxMODAL);
+        ThreadSafeMessageBox(strprintf(_("Cannot obtain a lock on data directory %s.  Bitcoin is probably already running."), pathDataDir.string().c_str()), _("Bitcoin"), wxOK|wxMODAL);
         return false;
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1843,7 +1843,7 @@ bool ProcessBlock(CNode* pfrom, CBlock* pblock)
 
 bool CheckDiskSpace(uint64 nAdditionalBytes)
 {
-    uint64 nFreeBytesAvailable = filesystem::space(GetDataDir()).available;
+    uint64 nFreeBytesAvailable = filesystem::space(pathDataDir).available;
 
     // Check for 15MB because database could create another 10MB log file at any time
     if (nFreeBytesAvailable < (uint64)15000000 + nAdditionalBytes)
@@ -1863,7 +1863,7 @@ FILE* OpenBlockFile(unsigned int nFile, unsigned int nBlockPos, const char* pszM
 {
     if ((nFile < 1) || (nFile == (unsigned int) -1))
         return NULL;
-    FILE* file = fopen((GetDataDir() / strprintf("blk%04d.dat", nFile)).string().c_str(), pszMode);
+    FILE* file = fopen((pathDataDir / strprintf("blk%04d.dat", nFile)).string().c_str(), pszMode);
     if (!file)
         return NULL;
     if (nBlockPos != 0 && !strchr(pszMode, 'a') && !strchr(pszMode, 'w'))

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -172,12 +172,13 @@ int main(int argc, char *argv[])
     ParseParameters(argc, argv);
 
     // ... then bitcoin.conf:
-    if (!boost::filesystem::is_directory(GetDataDir(false)))
+    if (!boost::filesystem::is_directory(GetPrepDataDir(false)))
     {
         fprintf(stderr, "Error: Specified directory does not exist\n");
         return 1;
     }
     ReadConfigFile(mapArgs, mapMultiArgs);
+    pathDataDir = GetPrepDataDir(true);
 
     // Application identification (must be set before OptionsModel is initialized,
     // as it is used to locate QSettings)

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -235,7 +235,7 @@ bool isObscured(QWidget *w)
 
 void openDebugLogfile()
 {
-    boost::filesystem::path pathDebug = GetDataDir() / "debug.log";
+    boost::filesystem::path pathDebug = pathDataDir / "debug.log";
 
 #ifdef WIN32
     if (boost::filesystem::exists(pathDebug))

--- a/src/util.h
+++ b/src/util.h
@@ -121,6 +121,7 @@ extern std::string strMiscWarning;
 extern bool fTestNet;
 extern bool fNoListen;
 extern bool fLogTimestamps;
+extern boost::filesystem::path pathDataDir;
 
 void RandAddSeed();
 void RandAddSeedPerfmon();
@@ -154,7 +155,7 @@ bool WildcardMatch(const char* psz, const char* mask);
 bool WildcardMatch(const std::string& str, const std::string& mask);
 int GetFilesize(FILE* file);
 boost::filesystem::path GetDefaultDataDir();
-const boost::filesystem::path &GetDataDir(bool fNetSpecific = true);
+const boost::filesystem::path &GetPrepDataDir(bool fNetSpecific);
 boost::filesystem::path GetConfigFile();
 boost::filesystem::path GetPidFile();
 void CreatePidFile(const boost::filesystem::path &path, pid_t pid);

--- a/src/walletdb.cpp
+++ b/src/walletdb.cpp
@@ -403,7 +403,7 @@ bool BackupWallet(const CWallet& wallet, const string& strDest)
                 mapFileUseCount.erase(wallet.strWalletFile);
 
                 // Copy wallet.dat
-                filesystem::path pathSrc = GetDataDir() / wallet.strWalletFile;
+                filesystem::path pathSrc = pathDataDir / wallet.strWalletFile;
                 filesystem::path pathDest(strDest);
                 if (filesystem::is_directory(pathDest))
                     pathDest /= wallet.strWalletFile;


### PR DESCRIPTION
Even with the GetDataDir() cached system, a function call is overkill for the vast majority of uses in the code.  The values are static once the program is initialized, so initialize pathDataDir once.

GetDataDir() is renamed to GetPrepDataDir() to better indicate that it has side effects.

Curious to see whether people think this is worth merging or not.  I think it cleans up the code, and is ever so slightly more CPU efficient for most use cases.
