### PR TITLE
Move hash->CBlockIndex BDB into its own database, blkhash.dat

### DIFF
--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -1037,7 +1037,8 @@ Value movecmd(const Array& params, bool fHelp)
         strComment = params[4].get_str();
 
     CWalletDB walletdb(pwalletMain->strWalletFile);
-    walletdb.TxnBegin();
+    if (!walletdb.TxnBegin())
+        throw JSONRPCError(-20, "database error");
 
     int64 nNow = GetAdjustedTime();
 
@@ -1059,7 +1060,8 @@ Value movecmd(const Array& params, bool fHelp)
     credit.strComment = strComment;
     walletdb.WriteAccountingEntry(credit);
 
-    walletdb.TxnCommit();
+    if (!walletdb.TxnCommit())
+        throw JSONRPCError(-20, "database error");
 
     return true;
 }

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -169,9 +169,9 @@ void CDB::Close()
 {
     if (!pdb)
         return;
-    if (!vTxn.empty())
-        vTxn.front()->abort();
-    vTxn.clear();
+    if (activeTxn)
+        activeTxn->abort();
+    activeTxn = NULL;
     pdb = NULL;
 
     // Flush database activity from memory pool to disk log

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -26,14 +26,11 @@ unsigned int nWalletDBUpdated;
 // CDB
 //
 
-CCriticalSection cs_db;
-static bool fDbEnvInit = false;
-bool fDetachDB = false;
-DbEnv dbenv(0);
+CDBEnv bitdb;
 map<string, int> mapFileUseCount;
 static map<string, Db*> mapDb;
 
-static void EnvShutdown()
+void CDBEnv::EnvShutdown()
 {
     if (!fDbEnvInit)
         return;
@@ -50,18 +47,66 @@ static void EnvShutdown()
     DbEnv(0).remove(GetDataDir().string().c_str(), 0);
 }
 
-class CDBInit
+CDBEnv::CDBEnv() : dbenv(0)
 {
-public:
-    CDBInit()
-    {
-    }
-    ~CDBInit()
-    {
-        EnvShutdown();
-    }
 }
-instance_of_cdbinit;
+
+CDBEnv::~CDBEnv()
+{
+    EnvShutdown();
+}
+
+void CDBEnv::Close()
+{
+    EnvShutdown();
+}
+
+bool CDBEnv::Open(boost::filesystem::path pathEnv_)
+{
+    if (fDbEnvInit)
+        return true;
+
+    if (fShutdown)
+        return false;
+
+    pathEnv = pathEnv_;
+    filesystem::path pathDataDir = pathEnv;
+    filesystem::path pathLogDir = pathDataDir / "database";
+    filesystem::create_directory(pathLogDir);
+    filesystem::path pathErrorFile = pathDataDir / "db.log";
+    printf("dbenv.open LogDir=%s ErrorFile=%s\n", pathLogDir.string().c_str(), pathErrorFile.string().c_str());
+
+    int nDbCache = GetArg("-dbcache", 25);
+    dbenv.set_lg_dir(pathLogDir.string().c_str());
+    dbenv.set_cachesize(nDbCache / 1024, (nDbCache % 1024)*1048576, 1);
+    dbenv.set_lg_bsize(1048576);
+    dbenv.set_lg_max(10485760);
+    dbenv.set_lk_max_locks(10000);
+    dbenv.set_lk_max_objects(10000);
+    dbenv.set_errfile(fopen(pathErrorFile.string().c_str(), "a")); /// debug
+    dbenv.set_flags(DB_AUTO_COMMIT, 1);
+    dbenv.log_set_config(DB_LOG_AUTO_REMOVE, 1);
+    int ret = dbenv.open(pathDataDir.string().c_str(),
+                     DB_CREATE     |
+                     DB_INIT_LOCK  |
+                     DB_INIT_LOG   |
+                     DB_INIT_MPOOL |
+                     DB_INIT_TXN   |
+                     DB_THREAD     |
+                     DB_RECOVER,
+                     S_IRUSR | S_IWUSR);
+    if (ret > 0)
+        return error("CDB() : error %d opening database environment", ret);
+
+    fDbEnvInit = true;
+    return true;
+}
+
+void CDBEnv::CheckpointLSN(std::string strFile)
+{
+    dbenv.txn_checkpoint(0, 0, 0);
+    dbenv.lsn_reset(strFile.c_str(), 0);
+}
 
 
 CDB::CDB(const char *pszFile, const char* pszMode) : pdb(NULL)
@@ -77,47 +122,16 @@ CDB::CDB(const char *pszFile, const char* pszMode) : pdb(NULL)
         nFlags |= DB_CREATE;
 
     {
-        LOCK(cs_db);
-        if (!fDbEnvInit)
-        {
-            if (fShutdown)
-                return;
-            filesystem::path pathDataDir = GetDataDir();
-            filesystem::path pathLogDir = pathDataDir / "database";
-            filesystem::create_directory(pathLogDir);
-            filesystem::path pathErrorFile = pathDataDir / "db.log";
-            printf("dbenv.open LogDir=%s ErrorFile=%s\n", pathLogDir.string().c_str(), pathErrorFile.string().c_str());
-
-            int nDbCache = GetArg("-dbcache", 25);
-            dbenv.set_lg_dir(pathLogDir.string().c_str());
-            dbenv.set_cachesize(nDbCache / 1024, (nDbCache % 1024)*1048576, 1);
-            dbenv.set_lg_bsize(1048576);
-            dbenv.set_lg_max(10485760);
-            dbenv.set_lk_max_locks(10000);
-            dbenv.set_lk_max_objects(10000);
-            dbenv.set_errfile(fopen(pathErrorFile.string().c_str(), "a")); /// debug
-            dbenv.set_flags(DB_AUTO_COMMIT, 1);
-            dbenv.log_set_config(DB_LOG_AUTO_REMOVE, 1);
-            ret = dbenv.open(pathDataDir.string().c_str(),
-                             DB_CREATE     |
-                             DB_INIT_LOCK  |
-                             DB_INIT_LOG   |
-                             DB_INIT_MPOOL |
-                             DB_INIT_TXN   |
-                             DB_THREAD     |
-                             DB_RECOVER,
-                             S_IRUSR | S_IWUSR);
-            if (ret > 0)
-                throw runtime_error(strprintf("CDB() : error %d opening database environment", ret));
-            fDbEnvInit = true;
-        }
+        LOCK(bitdb.cs_db);
+        if (!bitdb.Open(GetDataDir()))
+            throw runtime_error("env open failed");
 
         strFile = pszFile;
         ++mapFileUseCount[strFile];
         pdb = mapDb[strFile];
         if (pdb == NULL)
         {
-            pdb = new Db(&dbenv, 0);
+            pdb = new Db(&bitdb.dbenv, 0);
 
             ret = pdb->open(NULL,      // Txn pointer
                             pszFile,   // Filename
@@ -131,7 +145,7 @@ CDB::CDB(const char *pszFile, const char* pszMode) : pdb(NULL)
                 delete pdb;
                 pdb = NULL;
                 {
-                     LOCK(cs_db);
+                     LOCK(bitdb.cs_db);
                     --mapFileUseCount[strFile];
                 }
                 strFile = "";
@@ -171,10 +185,10 @@ void CDB::Close()
     if (strFile == "blkindex.dat" && IsInitialBlockDownload())
         nMinutes = 5;
 
-    dbenv.txn_checkpoint(nMinutes ? GetArg("-dblogsize", 100)*1024 : 0, nMinutes, 0);
+    bitdb.dbenv.txn_checkpoint(nMinutes ? GetArg("-dblogsize", 100)*1024 : 0, nMinutes, 0);
 
     {
-        LOCK(cs_db);
+        LOCK(bitdb.cs_db);
         --mapFileUseCount[strFile];
     }
 }
@@ -182,7 +196,7 @@ void CDB::Close()
 void CloseDb(const string& strFile)
 {
     {
-        LOCK(cs_db);
+        LOCK(bitdb.cs_db);
         if (mapDb[strFile] != NULL)
         {
             // Close the database handle
@@ -199,13 +213,12 @@ bool CDB::Rewrite(const string& strFile, const char* pszSkip)
     while (!fShutdown)
     {
         {
-            LOCK(cs_db);
+            LOCK(bitdb.cs_db);
             if (!mapFileUseCount.count(strFile) || mapFileUseCount[strFile] == 0)
             {
                 // Flush log data to the dat file
                 CloseDb(strFile);
-                dbenv.txn_checkpoint(0, 0, 0);
-                dbenv.lsn_reset(strFile.c_str(), 0);
+                bitdb.CheckpointLSN(strFile);
                 mapFileUseCount.erase(strFile);
 
                 bool fSuccess = true;
@@ -213,7 +226,7 @@ bool CDB::Rewrite(const string& strFile, const char* pszSkip)
                 string strFileRes = strFile + ".rewrite";
                 { // surround usage of db with extra {}
                     CDB db(strFile.c_str(), "r");
-                    Db* pdbCopy = new Db(&dbenv, 0);
+                    Db* pdbCopy = new Db(&bitdb.dbenv, 0);
     
                     int ret = pdbCopy->open(NULL,                 // Txn pointer
                                             strFileRes.c_str(),   // Filename
@@ -271,10 +284,10 @@ bool CDB::Rewrite(const string& strFile, const char* pszSkip)
                 }
                 if (fSuccess)
                 {
-                    Db dbA(&dbenv, 0);
+                    Db dbA(&bitdb.dbenv, 0);
                     if (dbA.remove(strFile.c_str(), NULL, 0))
                         fSuccess = false;
-                    Db dbB(&dbenv, 0);
+                    Db dbB(&bitdb.dbenv, 0);
                     if (dbB.rename(strFileRes.c_str(), NULL, strFile.c_str(), 0))
                         fSuccess = false;
                 }
@@ -289,11 +302,11 @@ bool CDB::Rewrite(const string& strFile, const char* pszSkip)
 }
 
 
-void DBFlush(bool fShutdown)
+void CDBEnv::Flush(bool fShutdown)
 {
     // Flush log data to the actual data file
     //  on all files that are not in use
-    printf("DBFlush(%s)%s\n", fShutdown ? "true" : "false", fDbEnvInit ? "" : " db not started");
+    printf("Flush(%s)%s\n", fShutdown ? "true" : "false", fDbEnvInit ? "" : " db not started");
     if (!fDbEnvInit)
         return;
     {
@@ -326,7 +339,7 @@ void DBFlush(bool fShutdown)
             if (mapFileUseCount.empty())
             {
                 dbenv.log_archive(&listp, DB_ARCH_REMOVE);
-                EnvShutdown();
+                Close();
             }
         }
     }

--- a/src/db.h
+++ b/src/db.h
@@ -51,10 +51,10 @@ public:
     void CheckpointLSN(std::string strFile);
     void SetDetach(bool fDetachDB_) { fDetachDB = fDetachDB_; }
 
-    DbTxn *TxnBegin(DbTxn *baseTxn, int flags=DB_TXN_NOSYNC)
+    DbTxn *TxnBegin(int flags=DB_TXN_NOSYNC)
     {
         DbTxn* ptxn = NULL;
-        int ret = dbenv.txn_begin(baseTxn, &ptxn, flags);
+        int ret = dbenv.txn_begin(NULL, &ptxn, flags);
         if (!ptxn || ret != 0)
             return NULL;
         return ptxn;
@@ -70,7 +70,7 @@ class CDB
 protected:
     Db* pdb;
     std::string strFile;
-    std::vector<DbTxn*> vTxn;
+    DbTxn *activeTxn;
     bool fReadOnly;
 
     explicit CDB(const char* pszFile, const char* pszMode="r+");
@@ -97,7 +97,7 @@ protected:
         // Read
         Dbt datValue;
         datValue.set_flags(DB_DBT_MALLOC);
-        int ret = pdb->get(GetTxn(), &datKey, &datValue, 0);
+        int ret = pdb->get(activeTxn, &datKey, &datValue, 0);
         memset(datKey.get_data(), 0, datKey.get_size());
         if (datValue.get_data() == NULL)
             return false;
@@ -133,7 +133,7 @@ protected:
         Dbt datValue(&ssValue[0], ssValue.size());
 
         // Write
-        int ret = pdb->put(GetTxn(), &datKey, &datValue, (fOverwrite ? 0 : DB_NOOVERWRITE));
+        int ret = pdb->put(activeTxn, &datKey, &datValue, (fOverwrite ? 0 : DB_NOOVERWRITE));
 
         // Clear memory in case it was a private key
         memset(datKey.get_data(), 0, datKey.get_size());
@@ -156,7 +156,7 @@ protected:
         Dbt datKey(&ssKey[0], ssKey.size());
 
         // Erase
-        int ret = pdb->del(GetTxn(), &datKey, 0);
+        int ret = pdb->del(activeTxn, &datKey, 0);
 
         // Clear memory
         memset(datKey.get_data(), 0, datKey.get_size());
@@ -176,7 +176,7 @@ protected:
         Dbt datKey(&ssKey[0], ssKey.size());
 
         // Exists
-        int ret = pdb->exists(GetTxn(), &datKey, 0);
+        int ret = pdb->exists(activeTxn, &datKey, 0);
 
         // Clear memory
         memset(datKey.get_data(), 0, datKey.get_size());
@@ -233,45 +233,33 @@ protected:
         return 0;
     }
 
-    DbTxn* GetTxn()
-    {
-        if (!vTxn.empty())
-            return vTxn.back();
-        else
-            return NULL;
-    }
-
 public:
     bool TxnBegin()
     {
-        if (!pdb)
+        if (!pdb || activeTxn)
             return false;
-        DbTxn* ptxn = bitdb.TxnBegin(GetTxn());
+        DbTxn* ptxn = bitdb.TxnBegin();
         if (!ptxn)
             return false;
-        vTxn.push_back(ptxn);
+        activeTxn = ptxn;
         return true;
     }
 
     bool TxnCommit()
     {
-        if (!pdb)
+        if (!pdb || !activeTxn)
             return false;
-        if (vTxn.empty())
-            return false;
-        int ret = vTxn.back()->commit(0);
-        vTxn.pop_back();
+        int ret = activeTxn->commit(0);
+        activeTxn = NULL;
         return (ret == 0);
     }
 
     bool TxnAbort()
     {
-        if (!pdb)
+        if (!pdb || !activeTxn)
             return false;
-        if (vTxn.empty())
-            return false;
-        int ret = vTxn.back()->abort();
-        vTxn.pop_back();
+        int ret = activeTxn->abort();
+        activeTxn = NULL;
         return (ret == 0);
     }
 

--- a/src/db.h
+++ b/src/db.h
@@ -50,6 +50,15 @@ public:
     void Flush(bool fShutdown);
     void CheckpointLSN(std::string strFile);
     void SetDetach(bool fDetachDB_) { fDetachDB = fDetachDB_; }
+
+    DbTxn *TxnBegin(DbTxn *baseTxn, int flags=DB_TXN_NOSYNC)
+    {
+        DbTxn* ptxn = NULL;
+        int ret = dbenv.txn_begin(baseTxn, &ptxn, flags);
+        if (!ptxn || ret != 0)
+            return NULL;
+        return ptxn;
+    }
 };
 
 extern CDBEnv bitdb;
@@ -237,9 +246,8 @@ public:
     {
         if (!pdb)
             return false;
-        DbTxn* ptxn = NULL;
-        int ret = bitdb.dbenv.txn_begin(GetTxn(), &ptxn, DB_TXN_NOSYNC);
-        if (!ptxn || ret != 0)
+        DbTxn* ptxn = bitdb.TxnBegin(GetTxn());
+        if (!ptxn)
             return false;
         vTxn.push_back(ptxn);
         return true;

--- a/src/db.h
+++ b/src/db.h
@@ -73,7 +73,7 @@ protected:
     DbTxn *activeTxn;
     bool fReadOnly;
 
-    explicit CDB(const char* pszFile, const char* pszMode="r+");
+    explicit CDB(const char* pszFile, const char* pszMode="r+", bool fHash=false);
     ~CDB() { Close(); }
 public:
     void Close();
@@ -302,13 +302,26 @@ public:
     bool ReadDiskTx(uint256 hash, CTransaction& tx);
     bool ReadDiskTx(COutPoint outpoint, CTransaction& tx, CTxIndex& txindex);
     bool ReadDiskTx(COutPoint outpoint, CTransaction& tx);
-    bool WriteBlockIndex(const CDiskBlockIndex& blockindex);
-    bool EraseBlockIndex(uint256 hash);
     bool ReadHashBestChain(uint256& hashBestChain);
     bool WriteHashBestChain(uint256 hashBestChain);
     bool ReadBestInvalidWork(CBigNum& bnBestInvalidWork);
     bool WriteBestInvalidWork(CBigNum bnBestInvalidWork);
     bool LoadBlockIndex();
+};
+
+
+/** Access to the block chain index (blkhash.dat) */
+class CBlockIdxDB : public CDB
+{
+public:
+    CBlockIdxDB(const char* pszMode="r+") : CDB("blkhash.dat", pszMode, true) {}
+private:
+    CBlockIdxDB(const CBlockIdxDB&);
+    void operator=(const CBlockIdxDB&);
+public:
+    bool LoadBlockIndex();
+    bool WriteBlockIndex(const CDiskBlockIndex& blockindex);
+    bool EraseBlockIndex(uint256 hash);
 };
 
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -54,9 +54,9 @@ void Shutdown(void* parg)
     {
         fShutdown = true;
         nTransactionsUpdated++;
-        DBFlush(false);
+        bitdb.Flush(false);
         StopNode();
-        DBFlush(true);
+        bitdb.Flush(true);
         boost::filesystem::remove(GetPidFile());
         UnregisterWallet(pwalletMain);
         delete pwalletMain;
@@ -295,7 +295,7 @@ bool AppInit2()
     }
 
     fDebug = GetBoolArg("-debug");
-    fDetachDB = GetBoolArg("-detachdb", false);
+    bitdb.SetDetach(GetBoolArg("-detachdb", false));
 
 #if !defined(WIN32) && !defined(QT_GUI)
     fDaemon = GetBoolArg("-daemon");

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -346,8 +346,12 @@ bool AppInit2()
 
     if (GetBoolArg("-loadblockindextest"))
     {
+        CBlockIdxDB blkidxdb("r");
+        blkidxdb.LoadBlockIndex();
+
         CTxDB txdb("r");
         txdb.LoadBlockIndex();
+
         PrintBlockTree();
         return false;
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1438,7 +1438,6 @@ bool static Reorganize(CTxDB& txdb, CBlockIndex* pindexNew)
         if (!block.ConnectBlock(txdb, pindex))
         {
             // Invalid block
-            txdb.TxnAbort();
             return error("Reorganize() : ConnectBlock %s failed", pindex->GetBlockHash().ToString().substr(0,20).c_str());
         }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1257,7 +1257,8 @@ bool CTransaction::ClientConnectInputs()
 
 
 
-bool CBlock::DisconnectBlock(CTxDB& txdb, CBlockIndex* pindex)
+bool CBlock::DisconnectBlock(CBlockIdxDB& blkidxdb, CTxDB& txdb,
+                             CBlockIndex* pindex)
 {
     // Disconnect in reverse order
     for (int i = vtx.size()-1; i >= 0; i--)
@@ -1270,14 +1271,15 @@ bool CBlock::DisconnectBlock(CTxDB& txdb, CBlockIndex* pindex)
     {
         CDiskBlockIndex blockindexPrev(pindex->pprev);
         blockindexPrev.hashNext = 0;
-        if (!txdb.WriteBlockIndex(blockindexPrev))
+        if (!blkidxdb.WriteBlockIndex(blockindexPrev))
             return error("DisconnectBlock() : WriteBlockIndex failed");
     }
 
     return true;
 }
 
-bool CBlock::ConnectBlock(CTxDB& txdb, CBlockIndex* pindex)
+bool CBlock::ConnectBlock(CBlockIdxDB& blkidxdb, CTxDB& txdb,
+                          CBlockIndex* pindex)
 {
     // Check it again in case a previous version let a bad block in
     if (!CheckBlock())
@@ -1368,7 +1370,7 @@ bool CBlock::ConnectBlock(CTxDB& txdb, CBlockIndex* pindex)
     {
         CDiskBlockIndex blockindexPrev(pindex->pprev);
         blockindexPrev.hashNext = pindex->GetBlockHash();
-        if (!txdb.WriteBlockIndex(blockindexPrev))
+        if (!blkidxdb.WriteBlockIndex(blockindexPrev))
             return error("ConnectBlock() : WriteBlockIndex failed");
     }
 
@@ -1379,7 +1381,8 @@ bool CBlock::ConnectBlock(CTxDB& txdb, CBlockIndex* pindex)
     return true;
 }
 
-bool static Reorganize(CTxDB& txdb, CBlockIndex* pindexNew)
+bool static Reorganize(CBlockIdxDB& blkidxdb, CTxDB& txdb, DbTxn *txn,
+                       CBlockIndex* pindexNew)
 {
     printf("REORGANIZE\n");
 
@@ -1418,7 +1421,7 @@ bool static Reorganize(CTxDB& txdb, CBlockIndex* pindexNew)
         CBlock block;
         if (!block.ReadFromDisk(pindex))
             return error("Reorganize() : ReadFromDisk for disconnect failed");
-        if (!block.DisconnectBlock(txdb, pindex))
+        if (!block.DisconnectBlock(blkidxdb, txdb, pindex))
             return error("Reorganize() : DisconnectBlock %s failed", pindex->GetBlockHash().ToString().substr(0,20).c_str());
 
         // Queue memory transactions to resurrect
@@ -1435,7 +1438,7 @@ bool static Reorganize(CTxDB& txdb, CBlockIndex* pindexNew)
         CBlock block;
         if (!block.ReadFromDisk(pindex))
             return error("Reorganize() : ReadFromDisk for connect failed");
-        if (!block.ConnectBlock(txdb, pindex))
+        if (!block.ConnectBlock(blkidxdb, txdb, pindex))
         {
             // Invalid block
             return error("Reorganize() : ConnectBlock %s failed", pindex->GetBlockHash().ToString().substr(0,20).c_str());
@@ -1449,7 +1452,7 @@ bool static Reorganize(CTxDB& txdb, CBlockIndex* pindexNew)
         return error("Reorganize() : WriteHashBestChain failed");
 
     // Make sure it's successfully written to disk before changing memory structure
-    if (!txdb.TxnCommit())
+    if (txn->commit(0) != 0)
         return error("Reorganize() : TxnCommit failed");
 
     // Disconnect shorter branch
@@ -1485,18 +1488,19 @@ runCommand(std::string strCommand)
 }
 
 // Called from inside SetBestChain: attaches a block to the new best chain being built
-bool CBlock::SetBestChainInner(CTxDB& txdb, CBlockIndex *pindexNew)
+bool CBlock::SetBestChainInner(CBlockIdxDB& blkidxdb, CTxDB& txdb, DbTxn *txn,
+                               CBlockIndex *pindexNew)
 {
     uint256 hash = GetHash();
 
     // Adding to current best branch
-    if (!ConnectBlock(txdb, pindexNew) || !txdb.WriteHashBestChain(hash))
+    if (!ConnectBlock(blkidxdb, txdb, pindexNew) || !txdb.WriteHashBestChain(hash))
     {
-        txdb.TxnAbort();
+        txn->abort();
         InvalidChainFound(pindexNew);
         return false;
     }
-    if (!txdb.TxnCommit())
+    if (txn->commit(0) != 0)
         return error("SetBestChain() : TxnCommit failed");
 
     // Add to current best branch
@@ -1509,23 +1513,24 @@ bool CBlock::SetBestChainInner(CTxDB& txdb, CBlockIndex *pindexNew)
     return true;
 }
 
-bool CBlock::SetBestChain(CTxDB& txdb, CBlockIndex* pindexNew)
+bool CBlock::SetBestChain(CBlockIdxDB& blkidxdb, CTxDB& txdb, CBlockIndex* pindexNew)
 {
     uint256 hash = GetHash();
 
-    if (!txdb.TxnBegin())
+    DbTxn *txn = bitdb.TxnBegin();
+    if (!txn)
         return error("SetBestChain() : TxnBegin failed");
 
     if (pindexGenesisBlock == NULL && hash == hashGenesisBlock)
     {
         txdb.WriteHashBestChain(hash);
-        if (!txdb.TxnCommit())
+        if (txn->commit(0) != 0)
             return error("SetBestChain() : TxnCommit failed");
         pindexGenesisBlock = pindexNew;
     }
     else if (hashPrevBlock == hashBestChain)
     {
-        if (!SetBestChainInner(txdb, pindexNew))
+        if (!SetBestChainInner(blkidxdb, txdb, txn, pindexNew))
             return error("SetBestChain() : SetBestChainInner failed");
     }
     else
@@ -1548,9 +1553,9 @@ bool CBlock::SetBestChain(CTxDB& txdb, CBlockIndex* pindexNew)
             printf("Postponing %i reconnects\n", vpindexSecondary.size());
 
         // Switch to new best branch
-        if (!Reorganize(txdb, pindexIntermediate))
+        if (!Reorganize(blkidxdb, txdb, txn, pindexIntermediate))
         {
-            txdb.TxnAbort();
+            txn->abort();
             InvalidChainFound(pindexNew);
             return error("SetBestChain() : Reorganize failed");
         }
@@ -1564,12 +1569,14 @@ bool CBlock::SetBestChain(CTxDB& txdb, CBlockIndex* pindexNew)
                 printf("SetBestChain() : ReadFromDisk failed\n");
                 break;
             }
-            if (!txdb.TxnBegin()) {
+
+            txn = bitdb.TxnBegin();
+            if (!txn) {
                 printf("SetBestChain() : TxnBegin 2 failed\n");
                 break;
             }
             // errors now are not fatal, we still did a reorganisation to a new chain in a valid way
-            if (!block.SetBestChainInner(txdb, pindex))
+            if (!block.SetBestChainInner(blkidxdb, txdb, txn, pindex))
                 break;
         }
     }
@@ -1624,19 +1631,22 @@ bool CBlock::AddToBlockIndex(unsigned int nFile, unsigned int nBlockPos)
     }
     pindexNew->bnChainWork = (pindexNew->pprev ? pindexNew->pprev->bnChainWork : 0) + pindexNew->GetBlockWork();
 
+    CBlockIdxDB blkidxdb;
+    if (!blkidxdb.TxnBegin())
+        return false;
+    blkidxdb.WriteBlockIndex(CDiskBlockIndex(pindexNew));
+    if (!blkidxdb.TxnCommit())
+        return false;
+
     CTxDB txdb;
-    if (!txdb.TxnBegin())
-        return false;
-    txdb.WriteBlockIndex(CDiskBlockIndex(pindexNew));
-    if (!txdb.TxnCommit())
-        return false;
 
     // New best
     if (pindexNew->bnChainWork > bnBestChainWork)
-        if (!SetBestChain(txdb, pindexNew))
+        if (!SetBestChain(blkidxdb, txdb, pindexNew))
             return false;
 
     txdb.Close();
+    blkidxdb.Close();
 
     if (pindexNew == pindexBest)
     {
@@ -1918,7 +1928,15 @@ bool LoadBlockIndex(bool fAllowNew)
     }
 
     //
-    // Load block index
+    // Load block hashes index
+    //
+    CBlockIdxDB blkidxdb("cr");
+    if (!blkidxdb.LoadBlockIndex())
+        return false;
+    blkidxdb.Close();
+
+    //
+    // Load TX index
     //
     CTxDB txdb("cr");
     if (!txdb.LoadBlockIndex())

--- a/src/main.h
+++ b/src/main.h
@@ -16,6 +16,8 @@
 
 #include <list>
 
+class DbTxn;
+
 class CWallet;
 class CBlock;
 class CBlockIndex;
@@ -80,6 +82,7 @@ extern int64 nTransactionFee;
 
 
 class CReserveKey;
+class CBlockIdxDB;
 class CTxDB;
 class CTxIndex;
 
@@ -1011,16 +1014,16 @@ public:
     }
 
 
-    bool DisconnectBlock(CTxDB& txdb, CBlockIndex* pindex);
-    bool ConnectBlock(CTxDB& txdb, CBlockIndex* pindex);
+    bool DisconnectBlock(CBlockIdxDB& blkidxdb, CTxDB& txdb, CBlockIndex* pindex);
+    bool ConnectBlock(CBlockIdxDB& blkidxdb, CTxDB& txdb, CBlockIndex* pindex);
     bool ReadFromDisk(const CBlockIndex* pindex, bool fReadTransactions=true);
-    bool SetBestChain(CTxDB& txdb, CBlockIndex* pindexNew);
+    bool SetBestChain(CBlockIdxDB& blkidxdb, CTxDB& txdb, CBlockIndex* pindexNew);
     bool AddToBlockIndex(unsigned int nFile, unsigned int nBlockPos);
     bool CheckBlock() const;
     bool AcceptBlock();
 
 private:
-    bool SetBestChainInner(CTxDB& txdb, CBlockIndex *pindexNew);
+    bool SetBestChainInner(CBlockIdxDB& blkidxdb, CTxDB& txdb, DbTxn *txn, CBlockIndex *pindexNew);
 };
 
 

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -242,7 +242,8 @@ bool CWallet::EncryptWallet(const SecureString& strWalletPassphrase)
         if (fFileBacked)
         {
             pwalletdbEncryption = new CWalletDB(strWalletFile);
-            pwalletdbEncryption->TxnBegin();
+            if (!pwalletdbEncryption->TxnBegin())
+                return false;
             pwalletdbEncryption->WriteMasterKey(nMasterKeyMaxID, kMasterKey);
         }
 

--- a/src/walletdb.cpp
+++ b/src/walletdb.cpp
@@ -13,7 +13,6 @@ using namespace boost;
 
 static uint64 nAccountingEntryNumber = 0;
 
-extern CCriticalSection cs_db;
 extern map<string, int> mapFileUseCount;
 extern void CloseDb(const string& strFile);
 
@@ -350,7 +349,7 @@ void ThreadFlushWalletDB(void* parg)
 
         if (nLastFlushed != nWalletDBUpdated && GetTime() - nLastWalletUpdate >= 2)
         {
-            TRY_LOCK(cs_db,lockDb);
+            TRY_LOCK(bitdb.cs_db,lockDb);
             if (lockDb)
             {
                 // Don't do this if any databases are in use
@@ -374,8 +373,7 @@ void ThreadFlushWalletDB(void* parg)
 
                         // Flush wallet.dat so it's self contained
                         CloseDb(strFile);
-                        dbenv.txn_checkpoint(0, 0, 0);
-                        dbenv.lsn_reset(strFile.c_str(), 0);
+                        bitdb.CheckpointLSN(strFile);
 
                         mapFileUseCount.erase(mi++);
                         printf("Flushed wallet.dat %"PRI64d"ms\n", GetTimeMillis() - nStart);
@@ -393,13 +391,12 @@ bool BackupWallet(const CWallet& wallet, const string& strDest)
     while (!fShutdown)
     {
         {
-            LOCK(cs_db);
+            LOCK(bitdb.cs_db);
             if (!mapFileUseCount.count(wallet.strWalletFile) || mapFileUseCount[wallet.strWalletFile] == 0)
             {
                 // Flush log data to the dat file
                 CloseDb(wallet.strWalletFile);
-                dbenv.txn_checkpoint(0, 0, 0);
-                dbenv.lsn_reset(wallet.strWalletFile.c_str(), 0);
+                bitdb.CheckpointLSN(wallet.strWalletFile);
                 mapFileUseCount.erase(wallet.strWalletFile);
 
                 // Copy wallet.dat


### PR DESCRIPTION
blkindex.dat stores all kinds of data, and as such, each key is overloaded to
form a namespace.  All keys beginning with "blockindex" form the
hash->CBlockIndex data that is loaded into mapBlockIndex.

This change moves mapBlockIndex data to its own database, custom tailored for
the sort of data we wish to store:
- BDB type changed from btree to hash
- key is uint256 hash, with no prefixes

Usage is cleaner, and uses slightly less CPU and disk space than the previous
solution.

COMPATIBILITY STATUS: A new block chain must be downloaded, or at least reindexed.  As such, may want to delay this change, if other major database changes are planned.

MERGE STATUS: Ready for review and comment, but not ready for immediate upstreaming.
