### PR TITLE
Prevent tooltip filter from ever causing infinite loops

### DIFF
--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -256,7 +256,7 @@ bool ToolTipToRichTextFilter::eventFilter(QObject *obj, QEvent *evt)
     {
         QWidget *widget = static_cast<QWidget*>(obj);
         QString tooltip = widget->toolTip();
-        if(!Qt::mightBeRichText(tooltip) && tooltip.size() > size_threshold)
+        if(tooltip.size() > size_threshold && !tooltip.startsWith("<qt/>") && !Qt::mightBeRichText(tooltip))
         {
             // Prefix <qt/> to make sure Qt detects this as rich text
             // Escape the current message as HTML and replace \n by <br>


### PR DESCRIPTION
As it says on the tin. Seems there is a mysterious issue on Qt 4.6.2.
