### PR TITLE
Use boost::thread locking instead of interprocess

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -27,6 +27,7 @@ namespace boost {
 #include <boost/foreach.hpp>
 #include <openssl/crypto.h>
 #include <openssl/rand.h>
+#include <stdarg.h>
 
 #ifdef WIN32
 #ifdef _MSC_VER


### PR DESCRIPTION
Luke noticed there was a boost/thread/\* set of synchronisation primitives, separate from those in boost/interprocess/sync/*. Given that they do not need to cope with locks being in shared memory, they are different and simpler on some systems.

This commit replaces all sync.{h,cpp} infrastructure by systems provided by boost/thread/*.

So far, it seems to work well on Linux, OSX and BSD (the latter two required a workaround before, as the interprocess semaphores and condition variables used spinlocks - it seems the thread ones don't).
