### PR TITLE
Reorganize(): remove spurious TxnAbort()

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1438,7 +1438,6 @@ bool static Reorganize(CTxDB& txdb, CBlockIndex* pindexNew)
         if (!block.ConnectBlock(txdb, pindex))
         {
             // Invalid block
-            txdb.TxnAbort();
             return error("Reorganize() : ConnectBlock %s failed", pindex->GetBlockHash().ToString().substr(0,20).c_str());
         }
 


### PR DESCRIPTION
If Reorganize() fails, then its caller, CBlock::SetBestChain(),
will call TxnAbort().

Redundant TxnAbort() calls are harmless.  The second will return an
error return value, with no other side effects.  TxnAbort() return
values are generally never checked.  The impact is nil.
