### PR TITLE
RPC console: scroll to the end when user enters a command

### DIFF
--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -11,6 +11,7 @@
 #include <QTextEdit>
 #include <QKeyEvent>
 #include <QUrl>
+#include <QScrollBar>
 
 #include <boost/tokenizer.hpp>
 
@@ -262,6 +263,8 @@ void RPCConsole::on_lineEdit_returnPressed()
             history.removeFirst();
         // Set pointer to end of history
         historyPtr = history.size();
+        // Scroll console view to end
+        scrollToEnd();
     }
 }
 
@@ -314,4 +317,10 @@ void RPCConsole::on_tabWidget_currentChanged(int index)
 void RPCConsole::on_openDebugLogfileButton_clicked()
 {
     GUIUtil::openDebugLogfile();
+}
+
+void RPCConsole::scrollToEnd()
+{
+    QScrollBar *scrollbar = ui->messagesWidget->verticalScrollBar();
+    scrollbar->setValue(scrollbar->maximum());
 }

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -44,7 +44,8 @@ public slots:
     void setNumBlocks(int count);
     /** Go forward or back in history */
     void browseHistory(int offset);
-
+    /** Scroll console view to end */
+    void scrollToEnd();
 signals:
     // For RPC command executor
     void stopExecutor();


### PR DESCRIPTION
Ensures that the command and reply is visible.

My take on #1297, but scrolls to the end after the user executed a command instead of when something is appended, which is more natural to me and prevents annoyances without having to special-case message types.

(By setting the scrollbar to the end, this re-enables auto-scrolling in the widget itself)
