### PR TITLE
Display when SIGTERM received (or any signal, for that matter) in debug.log

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -75,9 +75,10 @@ void Shutdown(void* parg)
     }
 }
 
-void HandleSIGTERM(int)
+void HandleSIGTERM(int signal)
 {
     fRequestShutdown = true;
+    printf("HandleSIGTERM(%d)\n", signal);
 }
 
 


### PR DESCRIPTION
Useful for debugging bitcoin dealing with signals and exiting. Adds a line to debug.log when signal received.
