### PR TITLE
GUI fix: DebugLog file opens twice after clicking "Open" in RPC Console Information tab

### DIFF
--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -119,7 +119,6 @@ RPCConsole::RPCConsole(QWidget *parent) :
     ui->lineEdit->installEventFilter(this);
 
     connect(ui->clearButton, SIGNAL(clicked()), this, SLOT(clear()));
-    connect(ui->openDebugLogfileButton, SIGNAL(clicked()), this, SLOT(on_openDebugLogfileButton_clicked()));
 
     startExecutor();
 


### PR DESCRIPTION
I observed this today and thought why does the debug.log open twice. It seems that my naming with on_openDebugLogfileButton_clicked() is somehow internally used by Qt. So we had a connect() which uses on_openDebugLogfileButton_clicked() on clicked() and the internal stuff, which resulted in that strange behaviour. After renaming the function to on_openDebugLogfileBtn_clicked() the debug.log opens only once, as intended.

I stumpled upon this as on_lineEdit_returnPressed() is used in no connect and only the function declaration and definition exists.
