### PR TITLE
GUI: adapt user-experience from messagepage for verifymessagedialog

### DIFF
--- a/src/qt/forms/verifymessagedialog.ui
+++ b/src/qt/forms/verifymessagedialog.ui
@@ -17,7 +17,7 @@
    <item>
     <widget class="QLabel" name="label">
      <property name="text">
-      <string>Enter the message and signature below (be careful to correctly copy newlines, spaces, tabs, and other invisible characters), and press apply to obtain the bitcoin address used to sign the message.</string>
+      <string>Enter the message and signature below (be careful to correctly copy newlines, spaces, tabs and other invisible characters) to obtain the Bitcoin address used to sign the message.</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
@@ -35,9 +35,6 @@
      <property name="text">
       <string/>
      </property>
-     <property name="placeholderText">
-      <string>Signature</string>
-     </property>
     </widget>
    </item>
    <item>
@@ -47,9 +44,6 @@
      </property>
      <property name="readOnly">
       <bool>true</bool>
-     </property>
-     <property name="placeholderText">
-      <string>Address</string>
      </property>
     </widget>
    </item>
@@ -62,6 +56,20 @@
    </item>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QPushButton" name="verifyMessage">
+       <property name="toolTip">
+        <string>Verify a message and obtain the Bitcoin address used to sign the message</string>
+       </property>
+       <property name="text">
+        <string>&amp;Verify Message</string>
+       </property>
+       <property name="icon">
+        <iconset resource="../bitcoin.qrc">
+         <normaloff>:/icons/transaction_0</normaloff>:/icons/transaction_0</iconset>
+       </property>
+      </widget>
+     </item>
      <item>
       <widget class="QPushButton" name="copyToClipboard">
        <property name="enabled">
@@ -80,6 +88,20 @@
       </widget>
      </item>
      <item>
+      <widget class="QPushButton" name="clearButton">
+       <property name="toolTip">
+        <string>Reset all verify message fields</string>
+       </property>
+       <property name="text">
+        <string>Clear &amp;All</string>
+       </property>
+       <property name="icon">
+        <iconset resource="../bitcoin.qrc">
+         <normaloff>:/icons/remove</normaloff>:/icons/remove</iconset>
+       </property>
+      </widget>
+     </item>
+     <item>
       <spacer name="horizontalSpacer">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
@@ -92,19 +114,6 @@
        </property>
       </spacer>
      </item>
-     <item>
-      <widget class="QDialogButtonBox" name="buttonBox">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="standardButtons">
-        <set>QDialogButtonBox::Apply|QDialogButtonBox::Close</set>
-       </property>
-       <property name="centerButtons">
-        <bool>false</bool>
-       </property>
-      </widget>
-     </item>
     </layout>
    </item>
   </layout>
@@ -112,38 +121,5 @@
  <resources>
   <include location="../bitcoin.qrc"/>
  </resources>
- <connections>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>accepted()</signal>
-   <receiver>VerifyMessageDialog</receiver>
-   <slot>accept()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>248</x>
-     <y>254</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>157</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>rejected()</signal>
-   <receiver>VerifyMessageDialog</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>316</x>
-     <y>260</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>286</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>

--- a/src/qt/verifymessagedialog.cpp
+++ b/src/qt/verifymessagedialog.cpp
@@ -22,7 +22,16 @@ VerifyMessageDialog::VerifyMessageDialog(AddressTableModel *addressModel, QWidge
 {
     ui->setupUi(this);
 
+#if (QT_VERSION >= 0x040700)
+    /* Do not move this to the XML file, Qt before 4.7 will choke on it */
+    ui->lnSig->setPlaceholderText(tr("Enter Bitcoin signature"));
+    ui->lnAddress->setPlaceholderText(tr("Click \"Apply\" to obtain address"));
+#endif
+
     GUIUtil::setupAddressWidget(ui->lnAddress, this);
+    ui->lnAddress->installEventFilter(this);
+
+    ui->edMessage->setFocus();
 }
 
 VerifyMessageDialog::~VerifyMessageDialog()
@@ -63,13 +72,33 @@ bool VerifyMessageDialog::checkAddress()
     return true;
 }
 
-void VerifyMessageDialog::on_buttonBox_clicked(QAbstractButton *button)
+void VerifyMessageDialog::on_verifyMessage_clicked()
 {
-    if(ui->buttonBox->buttonRole(button) == QDialogButtonBox::ApplyRole)
-        checkAddress();
+    checkAddress();
 }
 
 void VerifyMessageDialog::on_copyToClipboard_clicked()
 {
     QApplication::clipboard()->setText(ui->lnAddress->text());
+}
+
+void VerifyMessageDialog::on_clearButton_clicked()
+{
+    ui->edMessage->clear();
+    ui->lnSig->clear();
+    ui->lnAddress->clear();
+    ui->lblStatus->clear();
+
+    ui->edMessage->setFocus();
+}
+
+bool VerifyMessageDialog::eventFilter(QObject *object, QEvent *event)
+{
+    if(object == ui->lnAddress && (event->type() == QEvent::MouseButtonPress ||
+                                   event->type() == QEvent::FocusIn))
+    {
+        ui->lnAddress->selectAll();
+        return true;
+    }
+    return QDialog::eventFilter(object, event);
 }

--- a/src/qt/verifymessagedialog.h
+++ b/src/qt/verifymessagedialog.h
@@ -3,15 +3,13 @@
 
 #include <QDialog>
 
-class AddressTableModel;
-
-QT_BEGIN_NAMESPACE
-class QAbstractButton;
-QT_END_NAMESPACE
-
 namespace Ui {
     class VerifyMessageDialog;
 }
+class AddressTableModel;
+
+QT_BEGIN_NAMESPACE
+QT_END_NAMESPACE
 
 class VerifyMessageDialog : public QDialog
 {
@@ -21,16 +19,19 @@ public:
     explicit VerifyMessageDialog(AddressTableModel *addressModel, QWidget *parent = 0);
     ~VerifyMessageDialog();
 
-private slots:
-    void on_buttonBox_clicked(QAbstractButton *button);
-
-    void on_copyToClipboard_clicked();
+protected:
+    bool eventFilter(QObject *object, QEvent *event);
 
 private:
     bool checkAddress();
 
     Ui::VerifyMessageDialog *ui;
     AddressTableModel *model;
+
+private slots:
+    void on_verifyMessage_clicked();
+    void on_copyToClipboard_clicked();
+    void on_clearButton_clicked();
 };
 
 #endif // VERIFYMESSAGEDIALOG_H


### PR DESCRIPTION
- move placeholderTexts from XML to source to avoid a problem with Qt < 4.7
- add eventFilter for address field to select text when clicking in
- add Clear All button
- rework strings
- use QPushButtons instead of QDialogButtonBox
- use same layout as in messagepage.h for verifymessagedialog.h

It would be nice to discuss the strings once more, before we update the translation master file to not again get strings translated, that are not "final".

I really love that GUI feature and want to thank sje397 for his great work, which I only try to improve a little :).
