### PR TITLE
Improve debug.log output.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ qrc_*.cpp
 *.pro.user
 #mac specific
 .DS_Store
+build/

--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -303,7 +303,8 @@ void CAddrMan::Good_(const CService &addr, int64 nTime)
     // TODO: maybe re-add the node, but for now, just bail out
     if (nUBucket == -1) return;
 
-    printf("Moving %s to tried\n", addr.ToString().c_str());
+    if (fDebug)
+        printf("Moving %s to tried\n", addr.ToString().c_str());
 
     // move nId to the tried tables
     MakeTried(info, nId, nUBucket);

--- a/src/addrman.h
+++ b/src/addrman.h
@@ -418,7 +418,7 @@ public:
             fRet |= Add_(addr, source, nTimePenalty);
             Check();
         }
-        if (fRet)
+        if (fRet && CaughtUp())
             printf("Added %s from %s: %i tried, %i new\n", addr.ToStringIPPort().c_str(), source.ToString().c_str(), nTried, nNew);
         return fRet;
     }
@@ -434,7 +434,7 @@ public:
                 nAdd += Add_(*it, source, nTimePenalty) ? 1 : 0;
             Check();
         }
-        if (nAdd)
+        if (nAdd && CaughtUp())
             printf("Added %i addresses from %s: %i tried, %i new\n", nAdd, source.ToString().c_str(), nTried, nNew);
         return nAdd > 0;
     }

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -289,6 +289,7 @@ bool CDB::Rewrite(const string& strFile, const char* pszSkip)
 
 void DBFlush(bool fShutdown)
 {
+    int64 nStart = GetTimeMillis();
     // Flush log data to the actual data file
     //  on all files that are not in use
     printf("DBFlush(%s)%s\n", fShutdown ? "true" : "false", fDbEnvInit ? "" : " db not started");
@@ -318,6 +319,7 @@ void DBFlush(bool fShutdown)
             else
                 mi++;
         }
+        printf("DBFlush: After while loop (%s)%s %15"PRI64d"ms\n", fShutdown ? "true" : "false", fDbEnvInit ? "" : " db not started", GetTimeMillis() - nStart);
         if (fShutdown)
         {
             char** listp;
@@ -589,7 +591,9 @@ bool CTxDB::LoadBlockIndex()
     pindexBest = mapBlockIndex[hashBestChain];
     nBestHeight = pindexBest->nHeight;
     bnBestChainWork = pindexBest->bnChainWork;
-    printf("LoadBlockIndex(): hashBestChain=%s  height=%d\n", hashBestChain.ToString().substr(0,20).c_str(), nBestHeight);
+    printf("LoadBlockIndex(): hashBestChain=%s  height=%d  date=%s\n",
+      hashBestChain.ToString().substr(0,20).c_str(), nBestHeight,
+      DateTimeStrFormat("%x %H:%M:%S", pindexBest->GetBlockTime()).c_str());
 
     // Load bnBestInvalidWork, OK if it doesn't exist
     ReadBestInvalidWork(bnBestInvalidWork);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -38,6 +38,7 @@ void ExitTimeout(void* parg)
 
 void Shutdown(void* parg)
 {
+    printf("Shutdown() entered\n"); // REB
     static CCriticalSection cs_Shutdown;
     static bool fTaken;
     bool fFirstThread = false;
@@ -75,9 +76,10 @@ void Shutdown(void* parg)
     }
 }
 
-void HandleSIGTERM(int)
+void HandleSIGTERM(int signal)
 {
     fRequestShutdown = true;
+    printf("HandleSIGTERM(%d)\n", signal);
 }
 
 
@@ -154,6 +156,7 @@ bool AppInit(int argc, char* argv[])
     }
     if (!fRet)
         Shutdown(NULL);
+    printf("AppInit() exited\n");
     return fRet;
 }
 #endif
@@ -232,6 +235,7 @@ std::string HelpMessage()
         "  -testnet               " + _("Use the test network") + "\n" +
         "  -debug                 " + _("Output extra debugging information") + "\n" +
         "  -logtimestamps         " + _("Prepend debug output with timestamp") + "\n" +
+        "  -quietinitial          " + _("Reduce debug output on initial block download") + "\n" +
         "  -printtoconsole        " + _("Send trace/debug info to console instead of debug.log file") + "\n" +
 #ifdef WIN32
         "  -printtodebugger       " + _("Send trace/debug info to debugger") + "\n" +
@@ -315,6 +319,8 @@ bool AppInit2()
     fPrintToConsole = GetBoolArg("-printtoconsole");
     fPrintToDebugger = GetBoolArg("-printtodebugger");
     fLogTimestamps = GetBoolArg("-logtimestamps");
+    fQuietInitial = GetBoolArg("-quietinitial");
+    fLogPeers = GetBoolArg("-logpeers");
 
 #if !defined(WIN32) && !defined(QT_GUI)
     if (fDaemon)
@@ -343,6 +349,7 @@ bool AppInit2()
     printf("\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n");
     printf("Bitcoin version %s (%s)\n", FormatFullVersion().c_str(), CLIENT_DATE.c_str());
     printf("Default data directory %s\n", GetDefaultDataDir().string().c_str());
+    printf("Config file %s\n", GetConfigFile().c_str());
 
     if (GetBoolArg("-loadblockindextest"))
     {
@@ -487,7 +494,6 @@ bool AppInit2()
 
     //// debug print
     printf("mapBlockIndex.size() = %d\n",   mapBlockIndex.size());
-    printf("nBestHeight = %d\n",            nBestHeight);
     printf("setKeyPool.size() = %d\n",      pwalletMain->setKeyPool.size());
     printf("mapWallet.size() = %d\n",       pwalletMain->mapWallet.size());
     printf("mapAddressBook.size() = %d\n",  pwalletMain->mapAddressBook.size());
@@ -662,6 +668,7 @@ bool AppInit2()
 
     RandAddSeedPerfmon();
 
+    printf("CreateThread(StartNode)\n");
     if (!CreateThread(StartNode, NULL))
         InitError(_("Error: could not start node"));
 
@@ -675,6 +682,7 @@ bool AppInit2()
         Sleep(5000);
 #endif
 
+    printf("AppInit2() exited\n");
     return true;
 }
 

--- a/src/irc.cpp
+++ b/src/irc.cpp
@@ -200,7 +200,7 @@ void ThreadIRCSeed(void* parg)
     } catch (...) {
         PrintExceptionContinue(NULL, "ThreadIRCSeed()");
     }
-    printf("ThreadIRCSeed exiting\n");
+    printf("ThreadIRCSeed exited\n");
 }
 
 void ThreadIRCSeed2(void* parg)
@@ -321,7 +321,7 @@ void ThreadIRCSeed2(void* parg)
                 // index 7 is limited to 16 characters
                 // could get full length name at index 10, but would be different from join messages
                 strlcpy(pszName, vWords[7].c_str(), sizeof(pszName));
-                printf("IRC got who\n");
+                if (fDebug) printf("IRC got who\n");
             }
 
             if (vWords[1] == "JOIN" && vWords[0].size() > 1)

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -372,7 +372,7 @@ bool static ConnectSocketDirectly(const CService &addrConnect, SOCKET& hSocketRe
             int nRet = select(hSocket + 1, NULL, &fdset, NULL, &timeout);
             if (nRet == 0)
             {
-                printf("connection timeout\n");
+                if (fDebug) printf("connection timeout\n");
                 closesocket(hSocket);
                 return false;
             }
@@ -395,7 +395,7 @@ bool static ConnectSocketDirectly(const CService &addrConnect, SOCKET& hSocketRe
             }
             if (nRet != 0)
             {
-                printf("connect() failed after select(): %s\n",strerror(nRet));
+                if (fDebug) printf("connect() failed after select(): %s\n",strerror(nRet));
                 closesocket(hSocket);
                 return false;
             }
@@ -406,7 +406,7 @@ bool static ConnectSocketDirectly(const CService &addrConnect, SOCKET& hSocketRe
         else
 #endif
         {
-            printf("connect() failed: %i\n",WSAGetLastError());
+            if (fDebug) printf("connect() failed: %i\n", WSAGetLastError());
             closesocket(hSocket);
             return false;
         }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -67,6 +67,8 @@ string strMiscWarning;
 bool fTestNet = false;
 bool fNoListen = false;
 bool fLogTimestamps = false;
+bool fQuietInitial = false;
+bool fLogPeers = false;
 CMedianFilter<int64> vTimeOffsets(200,0);
 
 // Init openssl library multithreading support

--- a/src/util.h
+++ b/src/util.h
@@ -121,6 +121,8 @@ extern std::string strMiscWarning;
 extern bool fTestNet;
 extern bool fNoListen;
 extern bool fLogTimestamps;
+extern bool fQuietInitial;
+extern bool fLogPeers;
 
 void RandAddSeed();
 void RandAddSeedPerfmon();
@@ -173,6 +175,7 @@ int64 GetAdjustedTime();
 std::string FormatFullVersion();
 std::string FormatSubVersion(const std::string& name, int nClientVersion, const std::vector<std::string>& comments);
 void AddTimeData(const CNetAddr& ip, int64 nTime);
+bool CaughtUp();
 
 
 

--- a/src/walletdb.cpp
+++ b/src/walletdb.cpp
@@ -367,7 +367,11 @@ void ThreadFlushWalletDB(void* parg)
                     map<string, int>::iterator mi = mapFileUseCount.find(strFile);
                     if (mi != mapFileUseCount.end())
                     {
-                        printf("Flushing wallet.dat\n");
+                        if (CaughtUp() || !fQuietInitial) {
+                            if (!fLogTimestamps) // we don't want the date twice.
+                                printf("%s ", DateTimeStrFormat("%x %H:%M:%S", GetTime()).c_str());
+                            printf("Flushing wallet.dat\n");
+                        }
                         nLastFlushed = nWalletDBUpdated;
                         int64 nStart = GetTimeMillis();
 


### PR DESCRIPTION
This change improves debug.log output in the following ways:-

It reduces some duplicate output, and no longer needed output (which was originally added for testing).

It reduces the verbosity of output during initial block download, so rather than showing every block requested, it summarises. Once caught up, the previously level of verbosity is restored.

Information about the nodes connected are shown, and additional information about errors (particularly rejected transactions) are shown, with the offending peer alongside.

Recent changes which add many lines, such as address handling have been kept in as this code is still relatively new - I was tempted to comment out various lines such as the "tried...", etc.

Timestamps is now enabled by default. -nologtimestamps or logtimestamps=0 will disable this.

Also, renamed AlreadyAskedFor to AlreadyWaitingFor (makes more sense, as can cease waiting, but cannot stop having done a past thing.)
