### PR TITLE
translation updates / string updates

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -645,7 +645,7 @@ bool AppInit2()
         if (!ParseMoney(mapArgs["-paytxfee"], nTransactionFee))
             return InitError(strprintf(_("Invalid amount for -paytxfee=<amount>: '%s'"), mapArgs["-paytxfee"].c_str()));
         if (nTransactionFee > 0.25 * COIN)
-            InitWarning(_("Warning: -paytxfee is set very high.  This is the transaction fee you will pay if you send a transaction."));
+            InitWarning(_("Warning: -paytxfee is set very high. This is the transaction fee you will pay if you send a transaction."));
     }
 
     //

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1755,7 +1755,7 @@ bool BindListenPort(const CService &addrBind, string& strError)
     {
         int nErr = WSAGetLastError();
         if (nErr == WSAEADDRINUSE)
-            strError = strprintf(_("Unable to bind to %s on this computer.  Bitcoin is probably already running."), addrBind.ToString().c_str());
+            strError = strprintf(_("Unable to bind to %s on this computer. Bitcoin is probably already running."), addrBind.ToString().c_str());
         else
             strError = strprintf(_("Unable to bind to %s on this computer (bind returned error %d, %s)"), addrBind.ToString().c_str(), nErr, strerror(nErr));
         printf("%s\n", strError.c_str());

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -147,14 +147,14 @@ HelpMessageBox::HelpMessageBox(QWidget *parent):
     QMessageBox(parent)
 {
     header = tr("Bitcoin-Qt") + " " + tr("version") + " " +
-            QString::fromStdString(FormatFullVersion()) + "\n\n" +
+        QString::fromStdString(FormatFullVersion()) + "\n\n" +
         tr("Usage:") + "\n" +
-          "  bitcoin-qt [options]                     " + "\n";
+        "  bitcoin-qt [" + tr("options") + "]                     " + "\n";
     coreOptions = QString::fromStdString(HelpMessage());
     uiOptions = tr("UI options") + ":\n" +
-            "  -lang=<lang>           " + tr("Set language, for example \"de_DE\" (default: system locale)") + "\n" +
-            "  -min                   " + tr("Start minimized") + "\n" +
-            "  -splash                " + tr("Show splash screen on startup (default: 1)") + "\n";
+        "  -lang=<lang>           " + tr("Set language, for example \"de_DE\" (default: system locale)") + "\n" +
+        "  -min                   " + tr("Start minimized") + "\n" +
+        "  -splash                " + tr("Show splash screen on startup (default: 1)") + "\n";
 
     setWindowTitle(tr("Bitcoin-Qt"));
     setTextFormat(Qt::PlainText);

--- a/src/qt/forms/messagepage.ui
+++ b/src/qt/forms/messagepage.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Sign Message Dialog</string>
+   <string>Sign Message</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -249,7 +249,7 @@ DisplayOptionsPage::DisplayOptionsPage(QWidget *parent):
 
     QHBoxLayout *lang_hbox = new QHBoxLayout();
     lang_hbox->addSpacing(18);
-    QLabel *lang_label = new QLabel(tr("User Interface &Language: "));
+    QLabel *lang_label = new QLabel(tr("User Interface &Language:"));
     lang_hbox->addWidget(lang_label);
     lang = new QValueComboBox(this);
     // Make list of languages
@@ -270,7 +270,7 @@ DisplayOptionsPage::DisplayOptionsPage(QWidget *parent):
 
     QHBoxLayout *unit_hbox = new QHBoxLayout();
     unit_hbox->addSpacing(18);
-    QLabel *unit_label = new QLabel(tr("&Unit to show amounts in: "));
+    QLabel *unit_label = new QLabel(tr("&Unit to show amounts in:"));
     unit_hbox->addWidget(unit_label);
     unit = new QValueComboBox(this);
     unit->setModel(new BitcoinUnits(this));
@@ -354,7 +354,7 @@ NetworkOptionsPage::NetworkOptionsPage(QWidget *parent):
 
     QHBoxLayout *proxy_hbox = new QHBoxLayout();
     proxy_hbox->addSpacing(18);
-    QLabel *proxy_ip_label = new QLabel(tr("Proxy &IP: "));
+    QLabel *proxy_ip_label = new QLabel(tr("Proxy &IP:"));
     proxy_hbox->addWidget(proxy_ip_label);
     proxy_ip = new QLineEdit();
     proxy_ip->setMaximumWidth(140);
@@ -363,7 +363,7 @@ NetworkOptionsPage::NetworkOptionsPage(QWidget *parent):
     proxy_ip->setToolTip(tr("IP address of the proxy (e.g. 127.0.0.1)"));
     proxy_ip_label->setBuddy(proxy_ip);
     proxy_hbox->addWidget(proxy_ip);
-    QLabel *proxy_port_label = new QLabel(tr("&Port: "));
+    QLabel *proxy_port_label = new QLabel(tr("&Port:"));
     proxy_hbox->addWidget(proxy_port_label);
     proxy_port = new QLineEdit();
     proxy_port->setMaximumWidth(55);

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -207,9 +207,9 @@ void RPCConsole::clear()
                 "b { color: #006060; } "
                 );
 
-    message(CMD_REPLY, tr("Welcome to the Bitcoin RPC console.<br>"
-                          "Use up and down arrows to navigate history, and <b>Ctrl-L</b> to clear screen.<br>"
-                          "Type <b>help</b> for an overview of available commands."), true);
+    message(CMD_REPLY, (tr("Welcome to the Bitcoin RPC console.") + "<br>" +
+                        tr("Use up and down arrows to navigate history, and <b>Ctrl-L</b> to clear screen.") + "<br>" +
+                        tr("Type <b>help</b> for an overview of available commands.")), true);
 }
 
 void RPCConsole::message(int category, const QString &message, bool html)

--- a/src/qt/verifymessagedialog.cpp
+++ b/src/qt/verifymessagedialog.cpp
@@ -25,7 +25,7 @@ VerifyMessageDialog::VerifyMessageDialog(AddressTableModel *addressModel, QWidge
 #if (QT_VERSION >= 0x040700)
     /* Do not move this to the XML file, Qt before 4.7 will choke on it */
     ui->lnSig->setPlaceholderText(tr("Enter Bitcoin signature"));
-    ui->lnAddress->setPlaceholderText(tr("Click \"Apply\" to obtain address"));
+    ui->lnAddress->setPlaceholderText(tr("Click \"Verify Message\" to obtain address"));
 #endif
 
     GUIUtil::setupAddressWidget(ui->lnAddress, this);


### PR DESCRIPTION
- allow translation of "options" used in the --help message
- split translation of RPC console welcome message and remove the need to take care of HTML-br
- remove some spaces in strings
- misc other small stuff related to translations

I know no one loves these pulls, but e.g. unneeded spaces are really ugly on Transifex and can irritate translators as can HTML-code. Guess most of my work on translations is done very soon!
