### PR TITLE
Parallel block download

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ qrc_*.cpp
 *.pro.user
 #mac specific
 .DS_Store
+build/

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -31,8 +31,8 @@ uint256 hashGenesisBlock("0x000000000019d6689c085ae165831e934ff763ae46a2a6c172b3
 static CBigNum bnProofOfWorkLimit(~uint256(0) >> 32);
 CBlockIndex* pindexGenesisBlock = NULL;
 int nBestHeight = -1;
-CNode* txnode = NULL;           // node calling AcceptToMemoryPool()
 int nAskedForBlocks = 0;
+int nWaitingForBlocks = 0;
 CBigNum bnBestChainWork = 0;
 CBigNum bnBestInvalidWork = 0;
 uint256 hashBestChain = 0;
@@ -925,6 +925,11 @@ bool CheckProofOfWork(uint256 hash, unsigned int nBits)
 int GetNumBlocksOfPeers()
 {
     return std::max(cPeerBlockCounts.median(), Checkpoints::GetTotalBlocksEstimate());
+}
+
+bool CaughtUp()
+{
+    return (nBestHeight >= GetNumBlocksOfPeers());
 }
 
 bool IsInitialBlockDownload()
@@ -2387,16 +2392,17 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
     }
 
 
-    // Ask the first connected node for block updates
+    // Ask a connected node for block updates
     if (!pfrom->fClient && !pfrom->fOneShot &&
-        (pfrom->nVersion < NOBLKS_VERSION_START ||
-         pfrom->nVersion >= NOBLKS_VERSION_END) &&
-         (nAskedForBlocks < 1 || vNodes.size() <= 1))
+        //(pfrom->nVersion < NOBLKS_VERSION_START ||
+        // pfrom->nVersion >= NOBLKS_VERSION_END) &&
+         nAskedForBlocks < 8 && !pfrom->fAskedForBlocks && !CaughtUp()) // TODO - tune
     {
         nAskedForBlocks++;
         pfrom->fAskedForBlocks = true;
         printf("initial getblocks to %s\n", pfrom->addr.ToString().c_str());
         pfrom->PushGetBlocks(pindexBest, uint256(0));
+        NodeSummary();
     }
 
 
@@ -2671,7 +2677,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
         {
             SyncWithWallets(tx, NULL, true);
             RelayMessage(inv, vMsg);
-            mapAlreadyAskedFor.erase(inv);
+            mapWaitingFor.erase(inv);
             vWorkQueue.push_back(inv.hash);
 
             // Recursively process any orphan transactions that depended on this one
@@ -2692,7 +2698,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
                         printf("   accepted orphan tx %s\n", inv.hash.ToString().substr(0,10).c_str());
                         SyncWithWallets(tx, NULL, true);
                         RelayMessage(inv, vMsg);
-                        mapAlreadyAskedFor.erase(inv);
+                        mapWaitingFor.erase(inv);
                         vWorkQueue.push_back(inv.hash);
                     }
                 }
@@ -2720,14 +2726,19 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
         CBlock block;
         vRecv >> block;
 
-        printf("received block %s\n", block.GetHash().ToString().substr(0,20).c_str());
+        printf("received block %s from %s\n", block.GetHash().ToString().substr(0,20).c_str(), pfrom->addr.ToString().c_str());
+        if (pfrom->fWaitingForBlock) {
+            pfrom->fWaitingForBlock = false;
+            nWaitingForBlocks--;
+        }
+        NodeSummary();
         // block.print();
 
         CInv inv(MSG_BLOCK, block.GetHash());
         pfrom->AddInventoryKnown(inv);
 
         if (ProcessBlock(pfrom, &block))
-            mapAlreadyAskedFor.erase(inv);
+            mapWaitingFor.erase(inv);
         if (block.nDoS) pfrom->Misbehaving(block.nDoS);
     }
 
@@ -3096,26 +3107,44 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
         vector<CInv> vGetData;
         int64 nNow = GetTime() * 1000000;
         CTxDB txdb("r");
-        while (!pto->mapAskFor.empty() && (*pto->mapAskFor.begin()).first <= nNow)
+
+        while (!pto->fWaitingForBlock && !pto->mapAskFor.empty() &&
+          (*pto->mapAskFor.begin()).first <= nNow)
         {
             const CInv& inv = (*pto->mapAskFor.begin()).second;
-            if (!AlreadyHave(txdb, inv))
-            {
-                printf("sending getdata: %s\n", inv.ToString().c_str());
-                vGetData.push_back(inv);
-                if (vGetData.size() >= 1000)
-                {
-                    pto->PushMessage("getdata", vGetData);
-                    vGetData.clear();
+            if (!AlreadyHave(txdb, inv)) {
+                int64 nRequestTime = mapWaitingFor[inv];
+                if (nRequestTime == 0) {
+                    if (inv.type == MSG_BLOCK)
+                        printf("getdata %s to %s\n", inv.ToString().c_str(), pto->addr.ToString().c_str());
+                    else
+                        printf("getdata %s\n", inv.ToString().c_str(), pto->addr.ToString().c_str());
+
+                    if (inv.type == MSG_BLOCK) {
+                        pto->fWaitingForBlock = true;
+                        pto->WaitingForBlock = inv;
+                        nWaitingForBlocks++;
+                        NodeSummary();
+                    }
+                    vGetData.push_back(inv);
+                    if (vGetData.size() >= 1000)
+                    {
+                        pto->PushMessage("getdata", vGetData);
+                        vGetData.clear();
+                    }
+                    mapWaitingFor[inv] = nNow;
+                } else { // Another node is waiting for this inv, so ask for again later
+                    pto->mapAskFor.insert(std::make_pair(nNow + 120000000, inv));
+                    printf("waitingfor %s at %s\n", inv.ToString().c_str(), DateTimeStrFormat("%H:%M:%S", nRequestTime/1000000).c_str());
                 }
-            }
-            mapAlreadyAskedFor[inv] = nNow;
+            } // if !AlreadyHave
+            mapWaitingFor[inv] = nNow;
             pto->mapAskFor.erase(pto->mapAskFor.begin());
         }
         if (!vGetData.empty())
             pto->PushMessage("getdata", vGetData);
 
-    }
+    } // if LockMain
     return true;
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2492,12 +2492,13 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
 
         // find last block in inv vector
         unsigned int nLastBlock = (unsigned int)(-1);
-        for (unsigned int nInv = 0; nInv < vInv.size(); nInv++) {
-            if (vInv[vInv.size() - 1 - nInv].type == MSG_BLOCK) {
-                nLastBlock = vInv.size() - 1 - nInv;
-                break;
+        if (!CaughtUp()) // No need to do this once caught up...
+            for (unsigned int nInv = 0; nInv < vInv.size(); nInv++) {
+                if (vInv[vInv.size() - 1 - nInv].type == MSG_BLOCK) {
+                    nLastBlock = vInv.size() - 1 - nInv;
+                    break;
+                }
             }
-        }
         CTxDB txdb("r");
         for (unsigned int nInv = 0; nInv < vInv.size(); nInv++)
         {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -31,6 +31,8 @@ uint256 hashGenesisBlock("0x000000000019d6689c085ae165831e934ff763ae46a2a6c172b3
 static CBigNum bnProofOfWorkLimit(~uint256(0) >> 32);
 CBlockIndex* pindexGenesisBlock = NULL;
 int nBestHeight = -1;
+CNode* txnode = NULL;           // node calling AcceptToMemoryPool()
+int nAskedForBlocks = 0;
 CBigNum bnBestChainWork = 0;
 CBigNum bnBestInvalidWork = 0;
 uint256 hashBestChain = 0;
@@ -2362,17 +2364,6 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
             }
         }
 
-        // Ask the first connected node for block updates
-        static int nAskedForBlocks = 0;
-        if (!pfrom->fClient && !pfrom->fOneShot &&
-            (pfrom->nVersion < NOBLKS_VERSION_START ||
-             pfrom->nVersion >= NOBLKS_VERSION_END) &&
-             (nAskedForBlocks < 1 || vNodes.size() <= 1))
-        {
-            nAskedForBlocks++;
-            pfrom->PushGetBlocks(pindexBest, uint256(0));
-        }
-
         // Relay alerts
         {
             LOCK(cs_mapAlerts);
@@ -2396,6 +2387,20 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
     }
 
 
+    // Ask the first connected node for block updates
+    if (!pfrom->fClient && !pfrom->fOneShot &&
+        (pfrom->nVersion < NOBLKS_VERSION_START ||
+         pfrom->nVersion >= NOBLKS_VERSION_END) &&
+         (nAskedForBlocks < 1 || vNodes.size() <= 1))
+    {
+        nAskedForBlocks++;
+        pfrom->fAskedForBlocks = true;
+        printf("initial getblocks to %s\n", pfrom->addr.ToString().c_str());
+        pfrom->PushGetBlocks(pindexBest, uint256(0));
+    }
+
+
+    if (strCommand == "version") ;
     else if (strCommand == "verack")
     {
         pfrom->vRecv.SetVersion(min(pfrom->nVersion, PROTOCOL_VERSION));

--- a/src/main.h
+++ b/src/main.h
@@ -71,6 +71,7 @@ extern int64 nTimeBestReceived;
 extern CCriticalSection cs_setpwalletRegistered;
 extern std::set<CWallet*> setpwalletRegistered;
 extern unsigned char pchMessageStart[4];
+extern int nAskedForBlocks;
 
 // Settings
 extern int64 nTransactionFee;

--- a/src/main.h
+++ b/src/main.h
@@ -72,6 +72,7 @@ extern CCriticalSection cs_setpwalletRegistered;
 extern std::set<CWallet*> setpwalletRegistered;
 extern unsigned char pchMessageStart[4];
 extern int nAskedForBlocks;
+extern int nWaitingForBlocks;
 
 // Settings
 extern int64 nTransactionFee;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -526,7 +526,14 @@ void CNode::CloseSocketDisconnect()
     fDisconnect = true;
     if (hSocket != INVALID_SOCKET)
     {
-        printf("disconnecting node %s\n", addrName.c_str());
+        if (fDebug)
+            printf("%s ", DateTimeStrFormat("%x %H:%M:%S", GetTime()).c_str());
+        printf("disconnecting node %s [", addrName.c_str());
+        if (fAskedForBlocks) {
+            nAskedForBlocks--;
+            printf("ASKFOR.");
+        }
+        printf("]\n");
         closesocket(hSocket);
         hSocket = INVALID_SOCKET;
         vRecv.clear();

--- a/src/net.h
+++ b/src/net.h
@@ -143,6 +143,8 @@ public:
     int64 nLastRecv;
     int64 nLastSendEmpty;
     int64 nTimeConnected;
+    int nDupBlocks;
+    bool fAskedForBlocks;
     int nHeaderStart;
     unsigned int nMessageStart;
     CAddress addr;
@@ -195,6 +197,8 @@ public:
         nLastRecv = 0;
         nLastSendEmpty = GetTime();
         nTimeConnected = GetTime();
+        nDupBlocks = 0;
+        fAskedForBlocks = false;
         nHeaderStart = -1;
         nMessageStart = -1;
         addr = addrIn;


### PR DESCRIPTION
Builds upon pull #1271, which fixes Issue #1234.

This allows multiple peers to provide blocks, not just one. Up to 8 peers can provide blocks in parallel, thereby increasing block download speed by up to 8.

Submitted for comments. I think ideally I'll add some more code to cater for stuck downloads, so it can give up and move onto another peer. Currently, it'll only move onto another peer if the selected peer disconnects. It a peer took a long time to disconnect, then all blocks downloaded would be orphans until the missing block was eventually downloaded.

Also, the "8" concurrent downloads is hard-coded, would people prefer this to be a configurable command-line option?
