### PR TITLE
Fix compilation on Mac OS X.

### DIFF
--- a/src/sync.h
+++ b/src/sync.h
@@ -10,8 +10,9 @@
 #include <boost/interprocess/sync/interprocess_semaphore.hpp>
 #include <boost/interprocess/sync/lock_options.hpp>
 
-
-
+#ifdef MAC_OSX
+#include "util.h" // for Sleep().
+#endif
 
 /** Wrapped boost mutex: supports recursive locking, but no waiting  */
 typedef boost::interprocess::interprocess_recursive_mutex CCriticalSection;


### PR DESCRIPTION
This patch fixes compilation on Mac OS X since the CSemaphore on Mac OS X uses the Sleep() function in the sync.h file.
