### PR TITLE
Add /bin/sh to bitcoin-qt.pro - as some filesystems don't have the execute flag.

### DIFF
--- a/bitcoin-qt.pro
+++ b/bitcoin-qt.pro
@@ -83,7 +83,7 @@ contains(BITCOIN_NEED_QT_PLUGINS, 1) {
 # regenerate src/build.h
 !windows || contains(USE_BUILD_INFO, 1) {
     genbuild.depends = FORCE
-    genbuild.commands = cd $$PWD; share/genbuild.sh $$OUT_PWD/build/build.h
+    genbuild.commands = cd $$PWD; /bin/sh share/genbuild.sh $$OUT_PWD/build/build.h
     genbuild.target = $$OUT_PWD/build/build.h
     PRE_TARGETDEPS += $$OUT_PWD/build/build.h
     QMAKE_EXTRA_TARGETS += genbuild

--- a/src/makefile.linux-mingw
+++ b/src/makefile.linux-mingw
@@ -70,7 +70,7 @@ OBJS= \
 all: bitcoind.exe
 
 obj/build.h: FORCE
-	../share/genbuild.sh obj/build.h
+	/bin/sh ../share/genbuild.sh obj/build.h
 version.cpp: obj/build.h
 DEFS += -DHAVE_BUILD_INFO
 

--- a/src/makefile.osx
+++ b/src/makefile.osx
@@ -107,7 +107,7 @@ all: bitcoind
 -include obj-test/*.P
 
 obj/build.h: FORCE
-	../share/genbuild.sh obj/build.h
+	/bin/sh ../share/genbuild.sh obj/build.h
 version.cpp: obj/build.h
 DEFS += -DHAVE_BUILD_INFO
 

--- a/src/makefile.unix
+++ b/src/makefile.unix
@@ -119,7 +119,7 @@ all: bitcoind
 -include obj-test/*.P
 
 obj/build.h: FORCE
-	../share/genbuild.sh obj/build.h
+	/bin/sh ../share/genbuild.sh obj/build.h
 version.cpp: obj/build.h
 DEFS += -DHAVE_BUILD_INFO
 


### PR DESCRIPTION
genbuild.sh will not run when used on filesystems without the execute flag for files. This is the only thing so far which causes make to fail in this situation, so an easy fix to restore functionality.
