### PR TITLE
Add build directory to .gitignore, so that it's not tracked.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ qrc_*.cpp
 *.pro.user
 #mac specific
 .DS_Store
+build


### PR DESCRIPTION
I'm not sure how come I'm the only person who seems to need this line, but I'm currently unable to submit pulls without this entry, so rather than have it in every pull request, here's a separate one to hit the nail on the head.

If there's a way to untrack the build directory without adding it to .gitignore, please NACK this and let me know! Thanks!
