### PR TITLE
Quieter initial block download

### DIFF
--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -303,7 +303,8 @@ void CAddrMan::Good_(const CService &addr, int64 nTime)
     // TODO: maybe re-add the node, but for now, just bail out
     if (nUBucket == -1) return;
 
-    printf("Moving %s to tried\n", addr.ToString().c_str());
+    if (!fQuietInitial || CaughtUp())
+        printf("Moving %s to tried\n", addr.ToString().c_str());
 
     // move nId to the tried tables
     MakeTried(info, nId, nUBucket);

--- a/src/addrman.h
+++ b/src/addrman.h
@@ -418,7 +418,7 @@ public:
             fRet |= Add_(addr, source, nTimePenalty);
             Check();
         }
-        if (fRet)
+        if (fRet && (!fQuietInitial || CaughtUp()))
             printf("Added %s from %s: %i tried, %i new\n", addr.ToStringIPPort().c_str(), source.ToString().c_str(), nTried, nNew);
         return fRet;
     }
@@ -434,7 +434,7 @@ public:
                 nAdd += Add_(*it, source, nTimePenalty) ? 1 : 0;
             Check();
         }
-        if (nAdd)
+        if (nAdd && (!fQuietInitial || CaughtUp()))
             printf("Added %i addresses from %s: %i tried, %i new\n", nAdd, source.ToString().c_str(), nTried, nNew);
         return nAdd > 0;
     }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -243,6 +243,7 @@ std::string HelpMessage()
         "  -testnet               " + _("Use the test network") + "\n" +
         "  -debug                 " + _("Output extra debugging information") + "\n" +
         "  -logtimestamps         " + _("Prepend debug output with timestamp") + "\n" +
+        "  -quietinitial          " + _("Reduce debug output on initial block download") + "\n" +
         "  -printtoconsole        " + _("Send trace/debug info to console instead of debug.log file") + "\n" +
 #ifdef WIN32
         "  -printtodebugger       " + _("Send trace/debug info to debugger") + "\n" +
@@ -364,6 +365,7 @@ bool AppInit2()
     fPrintToConsole = GetBoolArg("-printtoconsole");
     fPrintToDebugger = GetBoolArg("-printtodebugger");
     fLogTimestamps = GetBoolArg("-logtimestamps");
+    fQuietInitial = GetBoolArg("-quietinitial");
 
     if (mapArgs.count("-timeout"))
     {

--- a/src/irc.cpp
+++ b/src/irc.cpp
@@ -319,7 +319,8 @@ void ThreadIRCSeed2(void* parg)
                 // index 7 is limited to 16 characters
                 // could get full length name at index 10, but would be different from join messages
                 strlcpy(pszName, vWords[7].c_str(), sizeof(pszName));
-                printf("IRC got who\n");
+                if (!fQuietInitial || CaughtUp())
+                    printf("IRC got who\n");
             }
 
             if (vWords[1] == "JOIN" && vWords[0].size() > 1)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -189,8 +189,9 @@ bool AddOrphanTx(const CDataStream& vMsg)
     BOOST_FOREACH(const CTxIn& txin, tx.vin)
         mapOrphanTransactionsByPrev[txin.prevout.hash].insert(make_pair(hash, pvMsg));
 
-    printf("stored orphan tx %s (mapsz %u)\n", hash.ToString().substr(0,10).c_str(),
-        mapOrphanTransactions.size());
+    if (!fQuietInitial || CaughtUp())
+        printf("stored orphan tx %s (mapsz %u)\n", hash.ToString().substr(0,10).c_str(),
+            mapOrphanTransactions.size());
     return true;
 }
 
@@ -939,6 +940,11 @@ int GetNumBlocksOfPeers()
     return std::max(cPeerBlockCounts.median(), Checkpoints::GetTotalBlocksEstimate());
 }
 
+bool CaughtUp()
+{
+    return (nBestHeight >= GetNumBlocksOfPeers());
+}
+
 bool IsInitialBlockDownload()
 {
     if (pindexBest == NULL || nBestHeight < Checkpoints::GetTotalBlocksEstimate())
@@ -1064,8 +1070,11 @@ bool CTransaction::FetchInputs(CTxDB& txdb, const map<uint256, CTxIndex>& mapTes
             // Get prev tx from single transactions in memory
             {
                 LOCK(mempool.cs);
-                if (!mempool.exists(prevout.hash))
-                    return error("FetchInputs() : %s mempool Tx prev not found %s", GetHash().ToString().substr(0,10).c_str(),  prevout.hash.ToString().substr(0,10).c_str());
+                if (!mempool.exists(prevout.hash)) {
+                    if (!fQuietInitial || CaughtUp())
+                        printf("mempool.exists() : %s prev (%s) not found\n", GetHash().ToString().substr(0,10).c_str(),  prevout.hash.ToString().substr(0,10).c_str());
+                    return false;
+                }
                 txPrev = mempool.lookup(prevout.hash);
             }
             if (!fFound)
@@ -2250,7 +2259,8 @@ bool CAlert::ProcessAlert()
             uiInterface.NotifyAlertChanged(GetHash(), CT_NEW);
     }
 
-    printf("accepted alert %d, AppliesToMe()=%d\n", nID, AppliesToMe());
+    if (!fQuietInitial || CaughtUp())
+        printf("accepted alert %d, AppliesToMe()=%d\n", nID, AppliesToMe());
     return true;
 }
 
@@ -2515,6 +2525,10 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
             pfrom->Misbehaving(20);
             return error("message inv size() = %d", vInv.size());
         }
+        int invblocks = 0;
+        int askblocks = 0;
+        int orphanget = 0;
+        int lastblockget = 0;
 
         // find last block in inv vector
         unsigned int nLastBlock = (unsigned int)(-1);
@@ -2531,30 +2545,60 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
 
             if (fShutdown)
                 return true;
+
+            if (inv.type == MSG_BLOCK) invblocks++;
+
             pfrom->AddInventoryKnown(inv);
 
             bool fAlreadyHave = AlreadyHave(txdb, inv);
             if (fDebug)
                 printf("  got inventory: %s  %s\n", inv.ToString().c_str(), fAlreadyHave ? "have" : "new");
 
-            if (!fAlreadyHave)
-                pfrom->AskFor(inv);
-            else if (inv.type == MSG_BLOCK && mapOrphanBlocks.count(inv.hash)) {
-                pfrom->PushGetBlocks(pindexBest, GetOrphanRoot(mapOrphanBlocks[inv.hash]));
-            } else if (nInv == nLastBlock) {
-                // In case we are on a very long side-chain, it is possible that we already have
-                // the last block in an inv bundle sent in response to getblocks. Try to detect
-                // this situation and push another getblocks to continue.
-                std::vector<CInv> vGetData(1,inv);
-                pfrom->PushGetBlocks(mapBlockIndex[inv.hash], uint256(0));
-                if (fDebug)
-                    printf("force request: %s\n", inv.ToString().c_str());
+            if (!fAlreadyHave) {
+                if (inv.type == MSG_BLOCK) {
+                    int64 nRequestTime = pfrom->AskForBlock(inv);
+                    if (!fQuietInitial || vInv.size() == 1 || CaughtUp())
+                        printf("askfor %s   %s (%"PRI64d")   %s\n", inv.ToString().c_str(),
+                          DateTimeStrFormat("%H:%M:%S", nRequestTime/1000000).c_str(), nRequestTime,
+                          pfrom->addr.ToString().c_str());
+                    askblocks++;
+                } else
+                    pfrom->AskFor(inv);
+            } else {
+                if (inv.type == MSG_BLOCK && vInv.size() == 1)
+                    printf("inv %s at %s\n", inv.ToString().c_str(), pfrom->addr.ToString().c_str());
+                if (inv.type == MSG_BLOCK && mapOrphanBlocks.count(inv.hash)) {
+                    pfrom->PushGetBlocks(pindexBest, GetOrphanRoot(mapOrphanBlocks[inv.hash]));
+                    orphanget++;
+                    if (!fQuietInitial || vInv.size() == 1 || CaughtUp())
+                        printf("orphan getblocks %s to %s\n", inv.ToString().c_str(),
+                          pfrom->addr.ToString().c_str());
+                } else if (nInv == nLastBlock) {
+                    // In case we are on a very long side-chain, it is possible that we already have
+                    // the last block in an inv bundle sent in response to getblocks. Try to detect
+                    // this situation and push another getblocks to continue.
+                    std::vector<CInv> vGetData(1,inv);
+                    pfrom->PushGetBlocks(mapBlockIndex[inv.hash], uint256(0));
+                    lastblockget++;
+                    if (fDebug)
+                        printf("force request: %s\n", inv.ToString().c_str());
+                }
             }
 
             // Track requests for our stuff
             Inventory(inv.hash);
+        } // for each item in inv bundle
+
+        if (fQuietInitial && !CaughtUp()) {
+            if (invblocks && vInv.size() > 1)
+                printf("inv containing %d (askfor %d) blocks at %s\n", invblocks, askblocks,
+                  pfrom->addr.ToString().c_str());
+            if (orphanget)
+                printf("orphan getblocks (%d) to %s\n", orphanget, pfrom->addr.ToString().c_str());
+            if (lastblockget)
+                printf("lastblock getblocks to %s\n", pfrom->addr.ToString().c_str());
         }
-    }
+    } // strCommand == "inv"
 
 
     else if (strCommand == "getdata")
@@ -2566,16 +2610,20 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
             pfrom->Misbehaving(20);
             return error("message getdata size() = %d", vInv.size());
         }
+        int nBlocks = 0;
+        int nTxs = 0;
 
         BOOST_FOREACH(const CInv& inv, vInv)
         {
             if (fShutdown)
                 return true;
-            printf("received getdata for: %s\n", inv.ToString().c_str());
+            if (!fQuietInitial || vInv.size() < 5 || CaughtUp())
+                printf("received getdata for: %s\n", inv.ToString().c_str());
 
             if (inv.type == MSG_BLOCK)
             {
                 // Send block from disk
+                nBlocks++;
                 map<uint256, CBlockIndex*>::iterator mi = mapBlockIndex.find(inv.hash);
                 if (mi != mapBlockIndex.end())
                 {
@@ -2595,10 +2643,11 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
                         pfrom->hashContinue = 0;
                     }
                 }
-            }
+            } // if a block
             else if (inv.IsKnownType())
             {
                 // Send stream from relay memory
+                nTxs++;
                 {
                     LOCK(cs_mapRelay);
                     map<CInv, CDataStream>::iterator mi = mapRelay.find(inv);
@@ -2609,8 +2658,19 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
 
             // Track requests for our stuff
             Inventory(inv.hash);
+        } // for each getdata request
+
+        if (vInv.size() > 4 && fQuietInitial && !CaughtUp()) {
+            printf("got getdata for ");
+            if (nBlocks) {
+                printf("%d blocks ", nBlocks);
+                if (nTxs) printf("and ");
+            }
+            if (nTxs) printf("%d txs ", nTxs);
+            printf("from %s. Sending.\n", pfrom->addr.ToString().c_str());
         }
-    }
+
+    } // strCommand = "getdata"
 
 
     else if (strCommand == "getblocks")
@@ -2627,12 +2687,14 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
             pindex = pindex->pnext;
         int nLimit = 500 + locator.GetDistanceBack();
         unsigned int nBytes = 0;
-        printf("getblocks %d to %s limit %d\n", (pindex ? pindex->nHeight : -1), hashStop.ToString().substr(0,20).c_str(), nLimit);
+        if (!fQuietInitial || CaughtUp())
+            printf("getblocks %d to %s limit %d\n", (pindex ? pindex->nHeight : -1), hashStop.ToString().substr(0,20).c_str(), nLimit);
         for (; pindex; pindex = pindex->pnext)
         {
             if (pindex->GetBlockHash() == hashStop)
             {
-                printf("  getblocks stopping at %d %s (%u bytes)\n", pindex->nHeight, pindex->GetBlockHash().ToString().substr(0,20).c_str(), nBytes);
+                if (!fQuietInitial || CaughtUp())
+                    printf("  getblocks stopping at %d %s (%u bytes)\n", pindex->nHeight, pindex->GetBlockHash().ToString().substr(0,20).c_str(), nBytes);
                 break;
             }
             pfrom->PushInventory(CInv(MSG_BLOCK, pindex->GetBlockHash()));
@@ -3137,26 +3199,47 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
         vector<CInv> vGetData;
         int64 nNow = GetTime() * 1000000;
         CTxDB txdb("r");
+        int gettxs = 0;
+        int getblocks = 0;
+        CInv blockinv;
+
         while (!pto->mapAskFor.empty() && (*pto->mapAskFor.begin()).first <= nNow)
         {
             const CInv& inv = (*pto->mapAskFor.begin()).second;
             if (!AlreadyHave(txdb, inv))
             {
-                printf("sending getdata: %s\n", inv.ToString().c_str());
+                if (!fQuietInitial || CaughtUp())
+                    printf("sending getdata: %s\n", inv.ToString().c_str());
+
+                if (inv.type == MSG_BLOCK) {
+                    getblocks++;
+                    blockinv = inv;
+                }
+                if (inv.type == MSG_TX) gettxs++;
                 vGetData.push_back(inv);
                 if (vGetData.size() >= 1000)
                 {
                     pto->PushMessage("getdata", vGetData);
                     vGetData.clear();
                 }
+                mapAlreadyAskedFor[inv] = nNow;
             }
-            mapAlreadyAskedFor[inv] = nNow;
             pto->mapAskFor.erase(pto->mapAskFor.begin());
         }
         if (!vGetData.empty())
             pto->PushMessage("getdata", vGetData);
 
-    }
+        if (getblocks && fQuietInitial && !CaughtUp()) {
+            if (getblocks == 1)
+                printf("sending getdata %s\n", blockinv.ToString().c_str());
+            else {
+                printf("getdata %d blocks", getblocks);
+                if (gettxs) printf(" and %d txs\n", gettxs);
+                else printf("\n");
+            }
+        }
+
+    } // if LockMain
     return true;
 }
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -173,7 +173,7 @@ bool RecvLine(SOCKET hSocket, string& strLine)
             if (nBytes == 0)
             {
                 // socket closed
-                printf("socket closed\n");
+                if (fDebug) printf("socket closed\n");
                 return false;
             }
             else
@@ -486,7 +486,8 @@ CNode* ConnectNode(CAddress addrConnect, const char *pszDest, int64 nTimeout)
         addrman.Attempt(addrConnect);
 
         /// debug print
-        printf("connected %s\n", pszDest ? pszDest : addrConnect.ToString().c_str());
+        if (CaughtUp() || !fQuietInitial)
+            printf("connected %s\n", pszDest ? pszDest : addrConnect.ToString().c_str());
 
         // Set to nonblocking
 #ifdef WIN32

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -364,7 +364,7 @@ bool static ConnectSocketDirectly(const CService &addrConnect, SOCKET& hSocketRe
             int nRet = select(hSocket + 1, NULL, &fdset, NULL, &timeout);
             if (nRet == 0)
             {
-                printf("connection timeout\n");
+                if (fDebug) printf("connection timeout\n");
                 closesocket(hSocket);
                 return false;
             }
@@ -387,7 +387,7 @@ bool static ConnectSocketDirectly(const CService &addrConnect, SOCKET& hSocketRe
             }
             if (nRet != 0)
             {
-                printf("connect() failed after select(): %s\n",strerror(nRet));
+                if (fDebug) printf("connect() failed after select(): %s\n",strerror(nRet));
                 closesocket(hSocket);
                 return false;
             }
@@ -398,7 +398,7 @@ bool static ConnectSocketDirectly(const CService &addrConnect, SOCKET& hSocketRe
         else
 #endif
         {
-            printf("connect() failed: %i\n",WSAGetLastError());
+            if (fDebug) printf("connect() failed: %i\n", WSAGetLastError());
             closesocket(hSocket);
             return false;
         }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -69,6 +69,7 @@ string strMiscWarning;
 bool fTestNet = false;
 bool fNoListen = false;
 bool fLogTimestamps = false;
+bool fQuietInitial = false;
 CMedianFilter<int64> vTimeOffsets(200,0);
 bool fReopenDebugLog = false;
 

--- a/src/util.h
+++ b/src/util.h
@@ -117,6 +117,7 @@ extern bool fTestNet;
 extern bool fNoListen;
 extern bool fLogTimestamps;
 extern bool fReopenDebugLog;
+extern bool fQuietInitial;
 
 void RandAddSeed();
 void RandAddSeedPerfmon();
@@ -172,6 +173,7 @@ std::string FormatFullVersion();
 std::string FormatSubVersion(const std::string& name, int nClientVersion, const std::vector<std::string>& comments);
 void AddTimeData(const CNetAddr& ip, int64 nTime);
 void runCommand(std::string strCommand);
+bool CaughtUp();
 
 
 


### PR DESCRIPTION
This pull is a subset of pull #1311, which many said was too big, and did too many things. It wasn't easy to break it up into smaller pieces as so many are interdependent. Anyway, here goes. Comments welcome.

This pull adds a command line argument "-quietinitial", which is intended to make the "traffic" in debug.log less so that the block download progress can be more easily seen. It's off by default, and without using it, things look the same as usual.

I realise that some of what this does can be achieved with 3rd party log file filterers, but some of it can't, and it's mostly developers that use such 3rd party tools, and I'd like to help enable bitcoin to be useful to less technical people too.

This sub-pull, IMHO, isn't as useful unless combined with some of the other pull requests I've raised (and am still raising, due to hacking #1311 into smaller pieces).

I suspect the others will need rebasing depending on what order the pulls are effected. ho hum..!

Heh... #1337 is a cool pull number :) Not sure this one deserves such a number though!

Anyway, comments welcomed - I need to get a better idea of what makes a good pull or not.
