### PR TITLE
AlreadyAskedFor -> WaitingFor rename, for reasons of least surprise.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2672,7 +2672,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
         {
             SyncWithWallets(tx, NULL, true);
             RelayMessage(inv, vMsg);
-            mapAlreadyAskedFor.erase(inv);
+            mapWaitingFor.erase(inv);
             vWorkQueue.push_back(inv.hash);
 
             // Recursively process any orphan transactions that depended on this one
@@ -2693,7 +2693,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
                         printf("   accepted orphan tx %s\n", inv.hash.ToString().substr(0,10).c_str());
                         SyncWithWallets(tx, NULL, true);
                         RelayMessage(inv, vMsg);
-                        mapAlreadyAskedFor.erase(inv);
+                        mapWaitingFor.erase(inv);
                         vWorkQueue.push_back(inv.hash);
                     }
                 }
@@ -2728,7 +2728,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
         pfrom->AddInventoryKnown(inv);
 
         if (ProcessBlock(pfrom, &block))
-            mapAlreadyAskedFor.erase(inv);
+            mapWaitingFor.erase(inv);
         if (block.nDoS) pfrom->Misbehaving(block.nDoS);
     }
 
@@ -3110,7 +3110,7 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
                     vGetData.clear();
                 }
             }
-            mapAlreadyAskedFor[inv] = nNow;
+            mapWaitingFor[inv] = nNow;
             pto->mapAskFor.erase(pto->mapAskFor.begin());
         }
         if (!vGetData.empty())

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -64,7 +64,7 @@ CCriticalSection cs_vNodes;
 map<CInv, CDataStream> mapRelay;
 deque<pair<int64, CInv> > vRelayExpiration;
 CCriticalSection cs_mapRelay;
-map<CInv, int64> mapAlreadyAskedFor;
+map<CInv, int64> mapWaitingFor;
 
 static deque<string> vOneShots;
 CCriticalSection cs_vOneShots;

--- a/src/net.h
+++ b/src/net.h
@@ -120,7 +120,7 @@ extern CCriticalSection cs_vNodes;
 extern std::map<CInv, CDataStream> mapRelay;
 extern std::deque<std::pair<int64, CInv> > vRelayExpiration;
 extern CCriticalSection cs_mapRelay;
-extern std::map<CInv, int64> mapAlreadyAskedFor;
+extern std::map<CInv, int64> mapWaitingFor;
 
 
 
@@ -293,7 +293,7 @@ public:
     {
         // We're using mapAskFor as a priority queue,
         // the key is the earliest time the request can be sent
-        int64& nRequestTime = mapAlreadyAskedFor[inv];
+        int64& nRequestTime = mapWaitingFor[inv];
         printf("askfor %s   %"PRI64d"\n", inv.ToString().c_str(), nRequestTime);
 
         // Make sure not to reuse time indexes to keep things in the same order


### PR DESCRIPTION
Also, reduces confusion when combined with future pull requests.

This is a small change, and possibly seems petty, but it's useful for two reasons:

1) Principle of least surprise. Waiting can end (and does in the code), but Already Asked for requires a past event that's happened to unhappen. This is confusing.

2) Later code (which I am hoping gets pulled when finished, such as #1326) uses variables that make sense, and makes the code simpler to understand when used with this renamed mapping.

3) probably other reasons....
