### PR TITLE
Should not be T minus, as this indicate duration to future event.

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -479,7 +479,7 @@ CNode* ConnectNode(CAddress addrConnect, const char *pszDest, int64 nTimeout)
     /// debug print
     printf("trying connection %s lastseen=%.1fhrs\n",
         pszDest ? pszDest : addrConnect.ToString().c_str(),
-        pszDest ? 0 : (double)(addrConnect.nTime - GetAdjustedTime())/3600.0);
+        pszDest ? 0 : (double)(GetAdjustedTime() - addrConnect.nTime)/3600.0);
 
     // Connect
     SOCKET hSocket;


### PR DESCRIPTION
Change to a positive number, to indicate a past event, and save a few bytes in debug.log!
