### PR TITLE
Win32: use _strnicmp (ISO C++) instead of deprecated strnicmp (POSIX)

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -16,6 +16,7 @@
 
 #ifndef WIN32
 #include <signal.h>
+#define strncasecmp _strnicmp
 #endif
 
 using namespace std;
@@ -162,7 +163,6 @@ bool static InitError(const std::string &str)
 {
     ThreadSafeMessageBox(str, _("Bitcoin"), wxOK | wxMODAL);
     return false;
-
 }
 
 bool static InitWarning(const std::string &str)

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -33,6 +33,10 @@ Q_IMPORT_PLUGIN(qkrcodecs)
 Q_IMPORT_PLUGIN(qtaccessiblewidgets)
 #endif
 
+#ifdef WIN32
+#define strncasecmp _strnicmp
+#endif
+
 // Need a global reference for the notifications to find the GUI
 static BitcoinGUI *guiref;
 static QSplashScreen *splashref;
@@ -177,9 +181,6 @@ void HelpMessageBox::exec()
 #endif
 }
 
-#ifdef WIN32
-#define strncasecmp strnicmp
-#endif
 #ifndef BITCOIN_QT_TEST
 int main(int argc, char *argv[])
 {


### PR DESCRIPTION
- the #ifdef WIN32 parts were moved to the top of the files as this is a place everyone looks from time to time
- add missing "#define strncasecmp _strnicmp" in init.cpp
- removes an unintentional add line break added by sipa ^^ (https://github.com/bitcoin/bitcoin/commit/ac7c7ab99aeee4aeea333d720c5a211a443a366d#L0R126)

See http://msdn.microsoft.com/en-us/library/ms235324%28v=vs.80%29.aspx for reference on _strnicmp.
