### PR TITLE
mapAlreadyAskedFor gets additions when AlreadyHave()

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3109,8 +3109,8 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
                     pto->PushMessage("getdata", vGetData);
                     vGetData.clear();
                 }
+                mapAlreadyAskedFor[inv] = nNow;
             }
-            mapAlreadyAskedFor[inv] = nNow;
             pto->mapAskFor.erase(pto->mapAskFor.begin());
         }
         if (!vGetData.empty())


### PR DESCRIPTION
Without this change, mappings will be created even after AlreadyHave equals true, and will never be erased.

A small fix, probably would never have caused a problem, other than filling unbounded and potentially using up more memory than needed. Might be quite significant is bitcoind is left running for a long period of time.
