### PR TITLE
ECDSA signature optimization and more DoS prevention 

### DIFF
--- a/src/key.cpp
+++ b/src/key.cpp
@@ -2,8 +2,10 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file license.txt or http://www.opensource.org/licenses/mit-license.php.
 
-#include <openssl/ec.h>
 #include <openssl/ecdsa.h>
+#include <openssl/obj_mac.h>
+
+#include "key.h"
 
 // Generate a private key from just the secret parameter
 int EC_KEY_regenerate_key(EC_KEY *eckey, BIGNUM *priv_key)
@@ -114,4 +116,263 @@ err:
     if (O != NULL) EC_POINT_free(O);
     if (Q != NULL) EC_POINT_free(Q);
     return ret;
+}
+
+void CKey::SetCompressedPubKey()
+{
+    EC_KEY_set_conv_form(pkey, POINT_CONVERSION_COMPRESSED);
+    fCompressedPubKey = true;
+}
+
+void CKey::Reset()
+{
+    fCompressedPubKey = false;
+    pkey = EC_KEY_new_by_curve_name(NID_secp256k1);
+    if (pkey == NULL)
+        throw key_error("CKey::CKey() : EC_KEY_new_by_curve_name failed");
+    fSet = false;
+}
+
+CKey::CKey()
+{
+    Reset();
+}
+
+CKey::CKey(const CKey& b)
+{
+    pkey = EC_KEY_dup(b.pkey);
+    if (pkey == NULL)
+        throw key_error("CKey::CKey(const CKey&) : EC_KEY_dup failed");
+    fSet = b.fSet;
+}
+
+CKey& CKey::operator=(const CKey& b)
+{
+    if (!EC_KEY_copy(pkey, b.pkey))
+        throw key_error("CKey::operator=(const CKey&) : EC_KEY_copy failed");
+    fSet = b.fSet;
+    return (*this);
+}
+
+CKey::~CKey()
+{
+    EC_KEY_free(pkey);
+}
+
+bool CKey::IsNull() const
+{
+    return !fSet;
+}
+
+bool CKey::IsCompressed() const
+{
+    return fCompressedPubKey;
+}
+
+void CKey::MakeNewKey(bool fCompressed)
+{
+    if (!EC_KEY_generate_key(pkey))
+        throw key_error("CKey::MakeNewKey() : EC_KEY_generate_key failed");
+    if (fCompressed)
+        SetCompressedPubKey();
+    fSet = true;
+}
+
+bool CKey::SetPrivKey(const CPrivKey& vchPrivKey)
+{
+    const unsigned char* pbegin = &vchPrivKey[0];
+    if (!d2i_ECPrivateKey(&pkey, &pbegin, vchPrivKey.size()))
+        return false;
+    fSet = true;
+    return true;
+}
+
+bool CKey::SetSecret(const CSecret& vchSecret, bool fCompressed)
+{
+    EC_KEY_free(pkey);
+    pkey = EC_KEY_new_by_curve_name(NID_secp256k1);
+    if (pkey == NULL)
+        throw key_error("CKey::SetSecret() : EC_KEY_new_by_curve_name failed");
+    if (vchSecret.size() != 32)
+        throw key_error("CKey::SetSecret() : secret must be 32 bytes");
+    BIGNUM *bn = BN_bin2bn(&vchSecret[0],32,BN_new());
+    if (bn == NULL)
+        throw key_error("CKey::SetSecret() : BN_bin2bn failed");
+    if (!EC_KEY_regenerate_key(pkey,bn))
+    {
+        BN_clear_free(bn);
+        throw key_error("CKey::SetSecret() : EC_KEY_regenerate_key failed");
+    }
+    BN_clear_free(bn);
+    fSet = true;
+    if (fCompressed || fCompressedPubKey)
+        SetCompressedPubKey();
+    return true;
+}
+
+CSecret CKey::GetSecret(bool &fCompressed) const
+{
+    CSecret vchRet;
+    vchRet.resize(32);
+    const BIGNUM *bn = EC_KEY_get0_private_key(pkey);
+    int nBytes = BN_num_bytes(bn);
+    if (bn == NULL)
+        throw key_error("CKey::GetSecret() : EC_KEY_get0_private_key failed");
+    int n=BN_bn2bin(bn,&vchRet[32 - nBytes]);
+    if (n != nBytes)
+        throw key_error("CKey::GetSecret(): BN_bn2bin failed");
+    fCompressed = fCompressedPubKey;
+    return vchRet;
+}
+
+CPrivKey CKey::GetPrivKey() const
+{
+    int nSize = i2d_ECPrivateKey(pkey, NULL);
+    if (!nSize)
+        throw key_error("CKey::GetPrivKey() : i2d_ECPrivateKey failed");
+    CPrivKey vchPrivKey(nSize, 0);
+    unsigned char* pbegin = &vchPrivKey[0];
+    if (i2d_ECPrivateKey(pkey, &pbegin) != nSize)
+        throw key_error("CKey::GetPrivKey() : i2d_ECPrivateKey returned unexpected size");
+    return vchPrivKey;
+}
+
+bool CKey::SetPubKey(const std::vector<unsigned char>& vchPubKey)
+{
+    const unsigned char* pbegin = &vchPubKey[0];
+    if (!o2i_ECPublicKey(&pkey, &pbegin, vchPubKey.size()))
+        return false;
+    fSet = true;
+    if (vchPubKey.size() == 33)
+        SetCompressedPubKey();
+    return true;
+}
+
+std::vector<unsigned char> CKey::GetPubKey() const
+{
+    int nSize = i2o_ECPublicKey(pkey, NULL);
+    if (!nSize)
+        throw key_error("CKey::GetPubKey() : i2o_ECPublicKey failed");
+    std::vector<unsigned char> vchPubKey(nSize, 0);
+    unsigned char* pbegin = &vchPubKey[0];
+    if (i2o_ECPublicKey(pkey, &pbegin) != nSize)
+        throw key_error("CKey::GetPubKey() : i2o_ECPublicKey returned unexpected size");
+    return vchPubKey;
+}
+
+bool CKey::Sign(uint256 hash, std::vector<unsigned char>& vchSig)
+{
+    unsigned int nSize = ECDSA_size(pkey);
+    vchSig.resize(nSize); // Make sure it is big enough
+    if (!ECDSA_sign(0, (unsigned char*)&hash, sizeof(hash), &vchSig[0], &nSize, pkey))
+    {
+        vchSig.clear();
+        return false;
+    }
+    vchSig.resize(nSize); // Shrink to fit actual size
+    return true;
+}
+
+// create a compact signature (65 bytes), which allows reconstructing the used public key
+// The format is one header byte, followed by two times 32 bytes for the serialized r and s values.
+// The header byte: 0x1B = first key with even y, 0x1C = first key with odd y,
+//                  0x1D = second key with even y, 0x1E = second key with odd y
+bool CKey::SignCompact(uint256 hash, std::vector<unsigned char>& vchSig)
+{
+    bool fOk = false;
+    ECDSA_SIG *sig = ECDSA_do_sign((unsigned char*)&hash, sizeof(hash), pkey);
+    if (sig==NULL)
+        return false;
+    vchSig.clear();
+    vchSig.resize(65,0);
+    int nBitsR = BN_num_bits(sig->r);
+    int nBitsS = BN_num_bits(sig->s);
+    if (nBitsR <= 256 && nBitsS <= 256)
+    {
+        int nRecId = -1;
+        for (int i=0; i<4; i++)
+        {
+            CKey keyRec;
+            keyRec.fSet = true;
+            if (fCompressedPubKey)
+                keyRec.SetCompressedPubKey();
+            if (ECDSA_SIG_recover_key_GFp(keyRec.pkey, sig, (unsigned char*)&hash, sizeof(hash), i, 1) == 1)
+                if (keyRec.GetPubKey() == this->GetPubKey())
+                {
+                    nRecId = i;
+                    break;
+                }
+        }
+
+        if (nRecId == -1)
+            throw key_error("CKey::SignCompact() : unable to construct recoverable key");
+
+        vchSig[0] = nRecId+27+(fCompressedPubKey ? 4 : 0);
+        BN_bn2bin(sig->r,&vchSig[33-(nBitsR+7)/8]);
+        BN_bn2bin(sig->s,&vchSig[65-(nBitsS+7)/8]);
+        fOk = true;
+    }
+    ECDSA_SIG_free(sig);
+    return fOk;
+}
+
+// reconstruct public key from a compact signature
+// This is only slightly more CPU intensive than just verifying it.
+// If this function succeeds, the recovered public key is guaranteed to be valid
+// (the signature is a valid signature of the given data for that key)
+bool CKey::SetCompactSignature(uint256 hash, const std::vector<unsigned char>& vchSig)
+{
+    if (vchSig.size() != 65)
+        return false;
+    int nV = vchSig[0];
+    if (nV<27 || nV>=35)
+        return false;
+    ECDSA_SIG *sig = ECDSA_SIG_new();
+    BN_bin2bn(&vchSig[1],32,sig->r);
+    BN_bin2bn(&vchSig[33],32,sig->s);
+
+    EC_KEY_free(pkey);
+    pkey = EC_KEY_new_by_curve_name(NID_secp256k1);
+    if (nV >= 31)
+    {
+        SetCompressedPubKey();
+        nV -= 4;
+    }
+    if (ECDSA_SIG_recover_key_GFp(pkey, sig, (unsigned char*)&hash, sizeof(hash), nV - 27, 0) == 1)
+    {
+        fSet = true;
+        ECDSA_SIG_free(sig);
+        return true;
+    }
+    return false;
+}
+
+bool CKey::Verify(uint256 hash, const std::vector<unsigned char>& vchSig)
+{
+    // -1 = error, 0 = bad sig, 1 = good
+    if (ECDSA_verify(0, (unsigned char*)&hash, sizeof(hash), &vchSig[0], vchSig.size(), pkey) != 1)
+        return false;
+    return true;
+}
+
+bool CKey::VerifyCompact(uint256 hash, const std::vector<unsigned char>& vchSig)
+{
+    CKey key;
+    if (!key.SetCompactSignature(hash, vchSig))
+        return false;
+    if (GetPubKey() != key.GetPubKey())
+        return false;
+    return true;
+}
+
+bool CKey::IsValid()
+{
+    if (!fSet)
+        return false;
+
+    bool fCompr;
+    CSecret secret = GetSecret(fCompr);
+    CKey key2;
+    key2.SetSecret(secret, fCompr);
+    return GetPubKey() == key2.GetPubKey();
 }

--- a/src/key.h
+++ b/src/key.h
@@ -8,12 +8,10 @@
 #include <stdexcept>
 #include <vector>
 
-#include <openssl/ec.h>
-#include <openssl/ecdsa.h>
-#include <openssl/obj_mac.h>
-
 #include "allocators.h"
 #include "uint256.h"
+
+#include <openssl/ec.h> // for EC_KEY definition
 
 // secp160k1
 // const unsigned int PRIVATE_KEY_SIZE = 192;
@@ -38,9 +36,6 @@
 // see www.keylength.com
 // script supports up to 75 for single byte push
 
-int extern EC_KEY_regenerate_key(EC_KEY *eckey, BIGNUM *priv_key);
-int extern ECDSA_SIG_recover_key_GFp(EC_KEY *eckey, ECDSA_SIG *ecsig, const unsigned char *msg, int msglen, int recid, int check);
-
 class key_error : public std::runtime_error
 {
 public:
@@ -62,267 +57,50 @@ protected:
     bool fSet;
     bool fCompressedPubKey;
 
-    void SetCompressedPubKey()
-    {
-        EC_KEY_set_conv_form(pkey, POINT_CONVERSION_COMPRESSED);
-        fCompressedPubKey = true;
-    }
+    void SetCompressedPubKey();
 
 public:
 
-    void Reset()
-    {
-        fCompressedPubKey = false;
-        pkey = EC_KEY_new_by_curve_name(NID_secp256k1);
-        if (pkey == NULL)
-            throw key_error("CKey::CKey() : EC_KEY_new_by_curve_name failed");
-        fSet = false;
-    }
+    void Reset();
 
-    CKey()
-    {
-        Reset();
-    }
+    CKey();
+    CKey(const CKey& b);
 
-    CKey(const CKey& b)
-    {
-        pkey = EC_KEY_dup(b.pkey);
-        if (pkey == NULL)
-            throw key_error("CKey::CKey(const CKey&) : EC_KEY_dup failed");
-        fSet = b.fSet;
-    }
+    CKey& operator=(const CKey& b);
 
-    CKey& operator=(const CKey& b)
-    {
-        if (!EC_KEY_copy(pkey, b.pkey))
-            throw key_error("CKey::operator=(const CKey&) : EC_KEY_copy failed");
-        fSet = b.fSet;
-        return (*this);
-    }
+    ~CKey();
 
-    ~CKey()
-    {
-        EC_KEY_free(pkey);
-    }
+    bool IsNull() const;
+    bool IsCompressed() const;
 
-    bool IsNull() const
-    {
-        return !fSet;
-    }
+    void MakeNewKey(bool fCompressed);
+    bool SetPrivKey(const CPrivKey& vchPrivKey);
+    bool SetSecret(const CSecret& vchSecret, bool fCompressed = false);
+    CSecret GetSecret(bool &fCompressed) const;
+    CPrivKey GetPrivKey() const;
+    bool SetPubKey(const std::vector<unsigned char>& vchPubKey);
+    std::vector<unsigned char> GetPubKey() const;
 
-    bool IsCompressed() const
-    {
-        return fCompressedPubKey;
-    }
-
-    void MakeNewKey(bool fCompressed)
-    {
-        if (!EC_KEY_generate_key(pkey))
-            throw key_error("CKey::MakeNewKey() : EC_KEY_generate_key failed");
-        if (fCompressed)
-            SetCompressedPubKey();
-        fSet = true;
-    }
-
-    bool SetPrivKey(const CPrivKey& vchPrivKey)
-    {
-        const unsigned char* pbegin = &vchPrivKey[0];
-        if (!d2i_ECPrivateKey(&pkey, &pbegin, vchPrivKey.size()))
-            return false;
-        fSet = true;
-        return true;
-    }
-
-    bool SetSecret(const CSecret& vchSecret, bool fCompressed = false)
-    {
-        EC_KEY_free(pkey);
-        pkey = EC_KEY_new_by_curve_name(NID_secp256k1);
-        if (pkey == NULL)
-            throw key_error("CKey::SetSecret() : EC_KEY_new_by_curve_name failed");
-        if (vchSecret.size() != 32)
-            throw key_error("CKey::SetSecret() : secret must be 32 bytes");
-        BIGNUM *bn = BN_bin2bn(&vchSecret[0],32,BN_new());
-        if (bn == NULL)
-            throw key_error("CKey::SetSecret() : BN_bin2bn failed");
-        if (!EC_KEY_regenerate_key(pkey,bn))
-        {
-            BN_clear_free(bn);
-            throw key_error("CKey::SetSecret() : EC_KEY_regenerate_key failed");
-        }
-        BN_clear_free(bn);
-        fSet = true;
-        if (fCompressed || fCompressedPubKey)
-            SetCompressedPubKey();
-        return true;
-    }
-
-    CSecret GetSecret(bool &fCompressed) const
-    {
-        CSecret vchRet;
-        vchRet.resize(32);
-        const BIGNUM *bn = EC_KEY_get0_private_key(pkey);
-        int nBytes = BN_num_bytes(bn);
-        if (bn == NULL)
-            throw key_error("CKey::GetSecret() : EC_KEY_get0_private_key failed");
-        int n=BN_bn2bin(bn,&vchRet[32 - nBytes]);
-        if (n != nBytes) 
-            throw key_error("CKey::GetSecret(): BN_bn2bin failed");
-        fCompressed = fCompressedPubKey;
-        return vchRet;
-    }
-
-    CPrivKey GetPrivKey() const
-    {
-        int nSize = i2d_ECPrivateKey(pkey, NULL);
-        if (!nSize)
-            throw key_error("CKey::GetPrivKey() : i2d_ECPrivateKey failed");
-        CPrivKey vchPrivKey(nSize, 0);
-        unsigned char* pbegin = &vchPrivKey[0];
-        if (i2d_ECPrivateKey(pkey, &pbegin) != nSize)
-            throw key_error("CKey::GetPrivKey() : i2d_ECPrivateKey returned unexpected size");
-        return vchPrivKey;
-    }
-
-    bool SetPubKey(const std::vector<unsigned char>& vchPubKey)
-    {
-        const unsigned char* pbegin = &vchPubKey[0];
-        if (!o2i_ECPublicKey(&pkey, &pbegin, vchPubKey.size()))
-            return false;
-        fSet = true;
-        if (vchPubKey.size() == 33)
-            SetCompressedPubKey();
-        return true;
-    }
-
-    std::vector<unsigned char> GetPubKey() const
-    {
-        int nSize = i2o_ECPublicKey(pkey, NULL);
-        if (!nSize)
-            throw key_error("CKey::GetPubKey() : i2o_ECPublicKey failed");
-        std::vector<unsigned char> vchPubKey(nSize, 0);
-        unsigned char* pbegin = &vchPubKey[0];
-        if (i2o_ECPublicKey(pkey, &pbegin) != nSize)
-            throw key_error("CKey::GetPubKey() : i2o_ECPublicKey returned unexpected size");
-        return vchPubKey;
-    }
-
-    bool Sign(uint256 hash, std::vector<unsigned char>& vchSig)
-    {
-        unsigned int nSize = ECDSA_size(pkey);
-        vchSig.resize(nSize); // Make sure it is big enough
-        if (!ECDSA_sign(0, (unsigned char*)&hash, sizeof(hash), &vchSig[0], &nSize, pkey))
-        {
-            vchSig.clear();
-            return false;
-        }
-        vchSig.resize(nSize); // Shrink to fit actual size
-        return true;
-    }
+    bool Sign(uint256 hash, std::vector<unsigned char>& vchSig);
 
     // create a compact signature (65 bytes), which allows reconstructing the used public key
     // The format is one header byte, followed by two times 32 bytes for the serialized r and s values.
     // The header byte: 0x1B = first key with even y, 0x1C = first key with odd y,
     //                  0x1D = second key with even y, 0x1E = second key with odd y
-    bool SignCompact(uint256 hash, std::vector<unsigned char>& vchSig)
-    {
-        bool fOk = false;
-        ECDSA_SIG *sig = ECDSA_do_sign((unsigned char*)&hash, sizeof(hash), pkey);
-        if (sig==NULL)
-            return false;
-        vchSig.clear();
-        vchSig.resize(65,0);
-        int nBitsR = BN_num_bits(sig->r);
-        int nBitsS = BN_num_bits(sig->s);
-        if (nBitsR <= 256 && nBitsS <= 256)
-        {
-            int nRecId = -1;
-            for (int i=0; i<4; i++)
-            {
-                CKey keyRec;
-                keyRec.fSet = true;
-                if (fCompressedPubKey)
-                    keyRec.SetCompressedPubKey();
-                if (ECDSA_SIG_recover_key_GFp(keyRec.pkey, sig, (unsigned char*)&hash, sizeof(hash), i, 1) == 1)
-                    if (keyRec.GetPubKey() == this->GetPubKey())
-                    {
-                        nRecId = i;
-                        break;
-                    }
-            }
-
-            if (nRecId == -1)
-                throw key_error("CKey::SignCompact() : unable to construct recoverable key");
-
-            vchSig[0] = nRecId+27+(fCompressedPubKey ? 4 : 0);
-            BN_bn2bin(sig->r,&vchSig[33-(nBitsR+7)/8]);
-            BN_bn2bin(sig->s,&vchSig[65-(nBitsS+7)/8]);
-            fOk = true;
-        }
-        ECDSA_SIG_free(sig);
-        return fOk;
-    }
+    bool SignCompact(uint256 hash, std::vector<unsigned char>& vchSig);
 
     // reconstruct public key from a compact signature
     // This is only slightly more CPU intensive than just verifying it.
     // If this function succeeds, the recovered public key is guaranteed to be valid
     // (the signature is a valid signature of the given data for that key)
-    bool SetCompactSignature(uint256 hash, const std::vector<unsigned char>& vchSig)
-    {
-        if (vchSig.size() != 65)
-            return false;
-        int nV = vchSig[0];
-        if (nV<27 || nV>=35)
-            return false;
-        ECDSA_SIG *sig = ECDSA_SIG_new();
-        BN_bin2bn(&vchSig[1],32,sig->r);
-        BN_bin2bn(&vchSig[33],32,sig->s);
+    bool SetCompactSignature(uint256 hash, const std::vector<unsigned char>& vchSig);
 
-        EC_KEY_free(pkey);
-        pkey = EC_KEY_new_by_curve_name(NID_secp256k1);
-        if (nV >= 31)
-        {
-            SetCompressedPubKey();
-            nV -= 4;
-        }
-        if (ECDSA_SIG_recover_key_GFp(pkey, sig, (unsigned char*)&hash, sizeof(hash), nV - 27, 0) == 1)
-        {
-            fSet = true;
-            ECDSA_SIG_free(sig);
-            return true;
-        }
-        return false;
-    }
-
-    bool Verify(uint256 hash, const std::vector<unsigned char>& vchSig)
-    {
-        // -1 = error, 0 = bad sig, 1 = good
-        if (ECDSA_verify(0, (unsigned char*)&hash, sizeof(hash), &vchSig[0], vchSig.size(), pkey) != 1)
-            return false;
-        return true;
-    }
+    bool Verify(uint256 hash, const std::vector<unsigned char>& vchSig);
 
     // Verify a compact signature
-    bool VerifyCompact(uint256 hash, const std::vector<unsigned char>& vchSig)
-    {
-        CKey key;
-        if (!key.SetCompactSignature(hash, vchSig))
-            return false;
-        if (GetPubKey() != key.GetPubKey())
-            return false;
-        return true;
-    }
+    bool VerifyCompact(uint256 hash, const std::vector<unsigned char>& vchSig);
 
-    bool IsValid()
-    {
-        if (!fSet)
-            return false;
-
-        bool fCompr;
-        CSecret secret = GetSecret(fCompr);
-        CKey key2;
-        key2.SetSecret(secret, fCompr);
-        return GetPubKey() == key2.GetPubKey();
-    }
+    bool IsValid();
 };
 
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -201,9 +201,7 @@ unsigned int LimitOrphanTxSize(unsigned int nMaxOrphans)
     while (mapOrphanTransactions.size() > nMaxOrphans)
     {
         // Evict a random orphan:
-        std::vector<unsigned char> randbytes(32);
-        RAND_bytes(&randbytes[0], 32);
-        uint256 randomhash(randbytes);
+        uint256 randomhash = GetRandHash();
         map<uint256, CDataStream*>::iterator it = mapOrphanTransactions.lower_bound(randomhash);
         if (it == mapOrphanTransactions.end())
             it = mapOrphanTransactions.begin();
@@ -2354,7 +2352,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
                     // at a time so the setAddrKnowns of the chosen nodes prevent repeats
                     static uint256 hashSalt;
                     if (hashSalt == 0)
-                        RAND_bytes((unsigned char*)&hashSalt, sizeof(hashSalt));
+                        hashSalt = GetRandHash();
                     int64 hashAddr = addr.GetHash();
                     uint256 hashRand = hashSalt ^ (hashAddr<<32) ^ ((GetTime()+hashAddr)/(24*60*60));
                     hashRand = Hash(BEGIN(hashRand), END(hashRand));
@@ -2945,7 +2943,7 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
                     // 1/4 of tx invs blast to all immediately
                     static uint256 hashSalt;
                     if (hashSalt == 0)
-                        RAND_bytes((unsigned char*)&hashSalt, sizeof(hashSalt));
+                        hashSalt = GetRandHash();
                     uint256 hashRand = inv.hash ^ hashSalt;
                     hashRand = Hash(BEGIN(hashRand), END(hashRand));
                     bool fTrickleWait = ((hashRand & 3) != 0);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2564,6 +2564,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
     else if (strCommand == "tx")
     {
         vector<uint256> vWorkQueue;
+        vector<uint256> vEraseQueue;
         CDataStream vMsg(vRecv);
         CTxDB txdb("r");
         CTransaction tx;
@@ -2579,6 +2580,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
             RelayMessage(inv, vMsg);
             mapAlreadyAskedFor.erase(inv);
             vWorkQueue.push_back(inv.hash);
+            vEraseQueue.push_back(inv.hash);
 
             // Recursively process any orphan transactions that depended on this one
             for (unsigned int i = 0; i < vWorkQueue.size(); i++)
@@ -2592,19 +2594,27 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
                     CTransaction tx;
                     CDataStream(vMsg) >> tx;
                     CInv inv(MSG_TX, tx.GetHash());
+                    bool fMissingInputs2 = false;
 
-                    if (tx.AcceptToMemoryPool(txdb, true))
+                    if (tx.AcceptToMemoryPool(txdb, true, &fMissingInputs2))
                     {
                         printf("   accepted orphan tx %s\n", inv.hash.ToString().substr(0,10).c_str());
                         SyncWithWallets(tx, NULL, true);
                         RelayMessage(inv, vMsg);
                         mapAlreadyAskedFor.erase(inv);
                         vWorkQueue.push_back(inv.hash);
+                        vEraseQueue.push_back(inv.hash);
+                    }
+                    else if (!fMissingInputs2)
+                    {
+                        // invalid orphan
+                        vEraseQueue.push_back(inv.hash);
+                        printf("   removed invalid orphan tx %s\n", inv.hash.ToString().substr(0,10).c_str());
                     }
                 }
             }
 
-            BOOST_FOREACH(uint256 hash, vWorkQueue)
+            BOOST_FOREACH(uint256 hash, vEraseQueue)
                 EraseOrphanTx(hash);
         }
         else if (fMissingInputs)

--- a/src/test/DoS_tests.cpp
+++ b/src/test/DoS_tests.cpp
@@ -129,18 +129,10 @@ BOOST_AUTO_TEST_CASE(DoS_checknbits)
     
 }
 
-static uint256 RandomHash()
-{
-    std::vector<unsigned char> randbytes(32);
-    RAND_bytes(&randbytes[0], 32);
-    uint256 randomhash(randbytes);
-    return randomhash;
-}
-
 CTransaction RandomOrphan()
 {
     std::map<uint256, CDataStream*>::iterator it;
-    it = mapOrphanTransactions.lower_bound(RandomHash());
+    it = mapOrphanTransactions.lower_bound(GetRandHash());
     if (it == mapOrphanTransactions.end())
         it = mapOrphanTransactions.begin();
     const CDataStream* pvMsg = it->second;
@@ -162,7 +154,7 @@ BOOST_AUTO_TEST_CASE(DoS_mapOrphans)
         CTransaction tx;
         tx.vin.resize(1);
         tx.vin[0].prevout.n = 0;
-        tx.vin[0].prevout.hash = RandomHash();
+        tx.vin[0].prevout.hash = GetRandHash();
         tx.vin[0].scriptSig << OP_1;
         tx.vout.resize(1);
         tx.vout[0].nValue = 1*CENT;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -174,6 +174,12 @@ int GetRandInt(int nMax)
     return GetRand(nMax);
 }
 
+uint256 GetRandHash()
+{
+    uint256 hash;
+    RAND_bytes((unsigned char*)&hash, sizeof(hash));
+    return hash;
+}
 
 
 

--- a/src/util.h
+++ b/src/util.h
@@ -168,6 +168,7 @@ bool SetStartOnSystemStartup(bool fAutoStart);
 void ShrinkDebugFile();
 int GetRandInt(int nMax);
 uint64 GetRand(uint64 nMax);
+uint256 GetRandHash();
 int64 GetTime();
 void SetMockTime(int64 nMockTimeIn);
 int64 GetAdjustedTime();


### PR DESCRIPTION
These 6 commits:
1. Implement an ECDSA signature cache, which should cut the amount of CPU time spent verifying signatures in half (because transaction signatures are verified before going into the memory pool and then again when the block is accepted).  Please review that commit very carefully, since it is the very heart of transaction security.
2. Implement several "belt and suspenders" changes to prevent possible denial-of-service attacks involving sending orphan transactions (suggested by Sergio Demian Lerner) or transactions with lots of inputs.

Tested by:
- writing new unit tests, and stepping through the code in the debugger while running the new tests
- running the new code under valgrind for more than 24 hours on the main network
