### PR TITLE
Win32: use _strnicmp (ISO C++) instead of deprecated strnicmp (POSIX) - V2

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -16,6 +16,8 @@
 
 #ifndef WIN32
 #include <signal.h>
+#else
+#define strncasecmp _strnicmp
 #endif
 
 using namespace std;
@@ -162,7 +164,6 @@ bool static InitError(const std::string &str)
 {
     ThreadSafeMessageBox(str, _("Bitcoin"), wxOK | wxMODAL);
     return false;
-
 }
 
 bool static InitWarning(const std::string &str)

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -33,6 +33,10 @@ Q_IMPORT_PLUGIN(qkrcodecs)
 Q_IMPORT_PLUGIN(qtaccessiblewidgets)
 #endif
 
+#ifdef WIN32
+#define strncasecmp _strnicmp
+#endif
+
 // Need a global reference for the notifications to find the GUI
 static BitcoinGUI *guiref;
 static QSplashScreen *splashref;
@@ -177,9 +181,6 @@ void HelpMessageBox::exec()
 #endif
 }
 
-#ifdef WIN32
-#define strncasecmp strnicmp
-#endif
 #ifndef BITCOIN_QT_TEST
 int main(int argc, char *argv[])
 {


### PR DESCRIPTION
This does things better than the first commit, which had a bug and placed `define strncasecmp _strnicmp` in an `#ifndef WIN32` in init.cpp. Sorry for this.
