### PR TITLE
RPC: add client startuptime to RPC getinfo

### DIFF
--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -11,6 +11,7 @@
 #include "init.h"
 #include "ui_interface.h"
 #include "bitcoinrpc.h"
+#include "util.h"
 
 #undef printf
 #include <boost/asio.hpp>
@@ -19,7 +20,7 @@
 #include <boost/iostreams/stream.hpp>
 #include <boost/algorithm/string.hpp>
 #include <boost/lexical_cast.hpp>
-#include <boost/asio/ssl.hpp> 
+#include <boost/asio/ssl.hpp>
 #include <boost/filesystem/fstream.hpp>
 typedef boost::asio::ssl::stream<boost::asio::ip::tcp::socket> SSLStream;
 
@@ -516,21 +517,22 @@ Value getinfo(const Array& params, bool fHelp)
             "Returns an object containing various state info.");
 
     Object obj;
-    obj.push_back(Pair("version",       (int)CLIENT_VERSION));
-    obj.push_back(Pair("protocolversion",(int)PROTOCOL_VERSION));
-    obj.push_back(Pair("walletversion", pwalletMain->GetVersion()));
-    obj.push_back(Pair("balance",       ValueFromAmount(pwalletMain->GetBalance())));
-    obj.push_back(Pair("blocks",        (int)nBestHeight));
-    obj.push_back(Pair("connections",   (int)vNodes.size()));
-    obj.push_back(Pair("proxy",         (fUseProxy ? addrProxy.ToStringIPPort() : string())));
-    obj.push_back(Pair("difficulty",    (double)GetDifficulty()));
-    obj.push_back(Pair("testnet",       fTestNet));
-    obj.push_back(Pair("keypoololdest", (boost::int64_t)pwalletMain->GetOldestKeyPoolTime()));
-    obj.push_back(Pair("keypoolsize",   pwalletMain->GetKeyPoolSize()));
-    obj.push_back(Pair("paytxfee",      ValueFromAmount(nTransactionFee)));
+    obj.push_back(Pair("version",         (int)CLIENT_VERSION));
+    obj.push_back(Pair("protocolversion", (int)PROTOCOL_VERSION));
+    obj.push_back(Pair("walletversion",   pwalletMain->GetVersion()));
+    obj.push_back(Pair("balance",         ValueFromAmount(pwalletMain->GetBalance())));
+    obj.push_back(Pair("blocks",          (int)nBestHeight));
+    obj.push_back(Pair("connections",     (int)vNodes.size()));
+    obj.push_back(Pair("proxy",           (fUseProxy ? addrProxy.ToStringIPPort() : string())));
+    obj.push_back(Pair("difficulty",      (double)GetDifficulty()));
+    obj.push_back(Pair("testnet",         fTestNet));
+    obj.push_back(Pair("keypoololdest",   (boost::int64_t)pwalletMain->GetOldestKeyPoolTime()));
+    obj.push_back(Pair("keypoolsize",     pwalletMain->GetKeyPoolSize()));
+    obj.push_back(Pair("paytxfee",        ValueFromAmount(nTransactionFee)));
     if (pwalletMain->IsCrypted())
         obj.push_back(Pair("unlocked_until", (boost::int64_t)nWalletUnlockTime / 1000));
-    obj.push_back(Pair("errors",        GetWarnings("statusbar")));
+    obj.push_back(Pair("errors",          GetWarnings("statusbar")));
+    obj.push_back(Pair("startuptime",     (boost::int64_t)GetClientStartupTime()));
     return obj;
 }
 
@@ -1136,7 +1138,7 @@ Value sendmany(const Array& params, bool fHelp)
 
         CScript scriptPubKey;
         scriptPubKey.SetBitcoinAddress(address);
-        int64 nAmount = AmountFromValue(s.value_); 
+        int64 nAmount = AmountFromValue(s.value_);
         totalAmount += nAmount;
 
         vecSend.push_back(make_pair(scriptPubKey, nAmount));

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -5,7 +5,7 @@
 #include "transactiontablemodel.h"
 
 #include "main.h"
-static const int64 nClientStartupTime = GetTime();
+#include "util.h"
 
 #include <QDateTime>
 
@@ -102,5 +102,5 @@ QString ClientModel::clientName() const
 
 QDateTime ClientModel::formatClientStartupTime() const
 {
-    return QDateTime::fromTime_t(nClientStartupTime);
+    return QDateTime::fromTime_t(GetClientStartupTime());
 }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -69,6 +69,8 @@ bool fTestNet = false;
 bool fNoListen = false;
 bool fLogTimestamps = false;
 CMedianFilter<int64> vTimeOffsets(200,0);
+// Client startup time
+static const int64 nClientStartupTime = GetTime();
 
 // Init openssl library multithreading support
 static CCriticalSection** ppmutexOpenSSL;
@@ -1101,3 +1103,8 @@ boost::filesystem::path GetSpecialFolderPath(int nFolder, bool fCreate)
     return fs::path("");
 }
 #endif
+
+int64 GetClientStartupTime()
+{
+    return nClientStartupTime;
+}

--- a/src/util.h
+++ b/src/util.h
@@ -173,7 +173,7 @@ int64 GetAdjustedTime();
 std::string FormatFullVersion();
 std::string FormatSubVersion(const std::string& name, int nClientVersion, const std::vector<std::string>& comments);
 void AddTimeData(const CNetAddr& ip, int64 nTime);
-
+int64 GetClientStartupTime();
 
 
 
@@ -443,7 +443,7 @@ inline uint160 Hash160(const std::vector<unsigned char>& vch)
 }
 
 
-/** Median filter over a stream of values. 
+/** Median filter over a stream of values.
  * Returns the median of the last N numbers
  */
 template <typename T> class CMedianFilter


### PR DESCRIPTION
- add GetClientStartupTime() to util.cpp/.h, which returns a static const int64 from util.cpp
- change indentation in getininfo() function, to match all lines (better readability)
- remove some spaces in comments

Perhaps it makes sense to place it somewhere else in the getinfo, but I didn't want to break things that perhaps rely on the current ordering.
