### PR TITLE
getblocktemplate: longpolling support

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -14,6 +14,9 @@
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/filesystem/fstream.hpp>
+#include <boost/thread/condition_variable.hpp>
+#include <boost/thread/locks.hpp>
+#include <boost/thread/mutex.hpp>
 
 using namespace std;
 using namespace boost;
@@ -41,6 +44,8 @@ uint256 hashBestChain = 0;
 CBlockIndex* pindexBest = NULL;
 set<CBlockIndex*, CBlockIndexWorkComparator> setBlockIndexValid; // may contain all CBlockIndex*'s that have validness >=BLOCK_VALID_TRANSACTIONS, and must contain those who aren't failed
 int64 nTimeBestReceived = 0;
+boost::mutex csBestBlock;
+boost::condition_variable cvBlockChange;
 int nScriptCheckThreads = 0;
 bool fImporting = false;
 bool fReindex = false;
@@ -1853,6 +1858,9 @@ bool SetBestChain(CValidationState &state, CBlockIndex* pindexNew)
         ::SetBestChain(locator);
     }
 
+    {
+        boost::lock_guard<boost::mutex> lock(csBestBlock);
+
     // New best block
     hashBestChain = pindexNew->GetBlockHash();
     pindexBest = pindexNew;
@@ -1861,10 +1869,15 @@ bool SetBestChain(CValidationState &state, CBlockIndex* pindexNew)
     bnBestChainWork = pindexNew->bnChainWork;
     nTimeBestReceived = GetTime();
     nTransactionsUpdated++;
+
+    }
+
     printf("SetBestChain: new best=%s  height=%d  work=%s  tx=%lu  date=%s  progress=%f\n",
       hashBestChain.ToString().c_str(), nBestHeight, bnBestChainWork.ToString().c_str(), (unsigned long)pindexNew->nChainTx,
       DateTimeStrFormat("%Y-%m-%d %H:%M:%S", pindexBest->GetBlockTime()).c_str(),
       Checkpoints::GuessVerificationProgress(pindexBest));
+
+    cvBlockChange.notify_all();
 
     // Check the version of the last 100 blocks to see if we need to upgrade:
     if (!fIsInitialDownload)

--- a/src/main.h
+++ b/src/main.h
@@ -5,6 +5,9 @@
 #ifndef BITCOIN_MAIN_H
 #define BITCOIN_MAIN_H
 
+#include <boost/thread/condition_variable.hpp>
+#include <boost/thread/mutex.hpp>
+
 #include "bignum.h"
 #include "sync.h"
 #include "net.h"
@@ -88,6 +91,8 @@ extern const std::string strMessageMagic;
 extern double dHashesPerSec;
 extern int64 nHPSTimerStart;
 extern int64 nTimeBestReceived;
+extern boost::mutex csBestBlock;
+extern boost::condition_variable cvBlockChange;
 extern CCriticalSection cs_setpwalletRegistered;
 extern std::set<CWallet*> setpwalletRegistered;
 extern unsigned char pchMessageStart[4];

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -3,6 +3,8 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <boost/thread/locks.hpp>
+
 #include "main.h"
 #include "db.h"
 #include "init.h"
@@ -220,6 +222,7 @@ Value getblocktemplate(const Array& params, bool fHelp)
             "See https://en.bitcoin.it/wiki/BIP_0022 for full specification.");
 
     std::string strMode = "template";
+    Value lpval = Value::null;
     if (params.size() > 0)
     {
         const Object& oparam = params[0].get_obj();
@@ -232,6 +235,7 @@ Value getblocktemplate(const Array& params, bool fHelp)
         }
         else
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid mode");
+        lpval = find_value(oparam, "longpollid");
     }
 
     if (strMode != "template")
@@ -242,6 +246,30 @@ Value getblocktemplate(const Array& params, bool fHelp)
 
     if (IsInitialBlockDownload())
         throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "Bitcoin is downloading blocks...");
+
+    if (lpval.type() == str_type)
+    {
+        // If longpollid is provided but doesn't match our current best block, we want to respond immediately, not wait
+        uint256 lpid;
+        lpid.SetHex(lpval.get_str());
+        if (lpid != hashBestChain)
+            lpval = Value::null;
+    }
+    if (lpval.type() != null_type)
+    {
+        // Wait until the best block changes to respond
+        uint256 hashWatchedChain = hashBestChain;
+
+        LEAVE_CRITICAL_SECTION(pwalletMain->cs_wallet);
+        LEAVE_CRITICAL_SECTION(cs_main);
+        {
+            boost::unique_lock<boost::mutex> lock(csBestBlock);
+            while (hashBestChain == hashWatchedChain)
+                cvBlockChange.wait(lock);
+        }
+        ENTER_CRITICAL_SECTION(cs_main);
+        ENTER_CRITICAL_SECTION(pwalletMain->cs_wallet);
+    }
 
     static CReserveKey reservekey(pwalletMain);
 
@@ -333,6 +361,7 @@ Value getblocktemplate(const Array& params, bool fHelp)
     result.push_back(Pair("transactions", transactions));
     result.push_back(Pair("coinbaseaux", aux));
     result.push_back(Pair("coinbasevalue", (int64_t)pblock->vtx[0].vout[0].nValue));
+    result.push_back(Pair("longpollid", hashBestChain.GetHex()));
     result.push_back(Pair("target", hashTarget.GetHex()));
     result.push_back(Pair("mintime", (int64_t)pindexPrev->GetMedianTimePast()+1));
     result.push_back(Pair("mutable", aMutable));


### PR DESCRIPTION
Built on top of #936, this adds support for getblocktemplate longpolling to bitcoind.
