### PR TITLE
Default to DB_TXN_WRITE_NOSYNC for all transactional operations

### DIFF
--- a/src/db.cpp
+++ b/src/db.cpp
@@ -96,6 +96,7 @@ CDB::CDB(const char *pszFile, const char* pszMode) : pdb(NULL)
             dbenv.set_lk_max_locks(10000);
             dbenv.set_lk_max_objects(10000);
             dbenv.set_errfile(fopen(pathErrorFile.string().c_str(), "a")); /// debug
+            dbenv.set_flags(DB_TXN_WRITE_NOSYNC, 1);
             dbenv.set_flags(DB_AUTO_COMMIT, 1);
             dbenv.log_set_config(DB_LOG_AUTO_REMOVE, 1);
             ret = dbenv.open(pathDataDir.string().c_str(),

--- a/src/db.h
+++ b/src/db.h
@@ -216,7 +216,7 @@ public:
         if (!pdb)
             return false;
         DbTxn* ptxn = NULL;
-        int ret = dbenv.txn_begin(GetTxn(), &ptxn, DB_TXN_NOSYNC);
+        int ret = dbenv.txn_begin(GetTxn(), &ptxn, DB_TXN_WRITE_NOSYNC);
         if (!ptxn || ret != 0)
             return false;
         vTxn.push_back(ptxn);


### PR DESCRIPTION
- This is safer than DB_TXN_NOSYNC, and does not appear to impact
  performance.
- Applying this to the dbenv is necessary to avoid many fdatasync(2)
  calls on db 5.x
- We carefully and thoroughly flush databases upon shutdown and
  other important events already.
