### PR TITLE
GUI: move class HelpMessageBox to guiutil.cpp/.h

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -113,54 +113,6 @@ static void handleRunawayException(std::exception *e)
     exit(1);
 }
 
-/** Help message for Bitcoin-Qt, shown with --help. */
-class HelpMessageBox: public QMessageBox
-{
-    Q_OBJECT
-public:
-    HelpMessageBox(QWidget *parent = 0);
-
-    void exec();
-private:
-    QString header;
-    QString coreOptions;
-    QString uiOptions;
-};
-
-HelpMessageBox::HelpMessageBox(QWidget *parent):
-    QMessageBox(parent)
-{
-    header = tr("Bitcoin-Qt") + " " + tr("version") + " " +
-        QString::fromStdString(FormatFullVersion()) + "\n\n" +
-        tr("Usage:") + "\n" +
-        "  bitcoin-qt [" + tr("options") + "]                     " + "\n";
-    coreOptions = QString::fromStdString(HelpMessage());
-    uiOptions = tr("UI options") + ":\n" +
-        "  -lang=<lang>           " + tr("Set language, for example \"de_DE\" (default: system locale)") + "\n" +
-        "  -min                   " + tr("Start minimized") + "\n" +
-        "  -splash                " + tr("Show splash screen on startup (default: 1)") + "\n";
-
-    setWindowTitle(tr("Bitcoin-Qt"));
-    setTextFormat(Qt::PlainText);
-    // setMinimumWidth is ignored for QMessageBox so put in nonbreaking spaces to make it wider.
-    QChar em_space(0x2003);
-    setText(header + QString(em_space).repeated(40));
-    setDetailedText(coreOptions + "\n" + uiOptions);
-}
-#include "bitcoin.moc"
-
-void HelpMessageBox::exec()
-{
-#if defined(WIN32)
-    // On windows, show a message box, as there is no stderr in windowed applications
-    QMessageBox::exec();
-#else
-    // On other operating systems, the expected action is to print the message to the console.
-    QString strUsage = header + "\n" + coreOptions + "\n" + uiOptions;
-    fprintf(stderr, "%s", strUsage.toStdString().c_str());
-#endif
-}
-
 #ifndef BITCOIN_QT_TEST
 int main(int argc, char *argv[])
 {
@@ -259,7 +211,7 @@ int main(int argc, char *argv[])
     // but before showing splash screen.
     if (mapArgs.count("-?") || mapArgs.count("--help"))
     {
-        HelpMessageBox help;
+        GUIUtil::HelpMessageBox help;
         help.exec();
         return 1;
     }

--- a/src/qt/forms/rpcconsole.ui
+++ b/src/qt/forms/rpcconsole.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>706</width>
-    <height>446</height>
+    <width>740</width>
+    <height>450</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -304,6 +304,29 @@
         </widget>
        </item>
        <item row="15" column="0">
+        <widget class="QLabel" name="labelCLOptions">
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Command-line options</string>
+         </property>
+        </widget>
+       </item>
+       <item row="16" column="0">
+        <widget class="QPushButton" name="showCLOptionsButton">
+         <property name="toolTip">
+          <string>Show the Bitcoin-Qt help message to get a list with possible Bitcoin command-line options.</string>
+         </property>
+         <property name="text">
+          <string>&amp;Show</string>
+         </property>
+        </widget>
+       </item>
+       <item row="17" column="0">
         <spacer name="verticalSpacer">
          <property name="orientation">
           <enum>Qt::Vertical</enum>

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -3,6 +3,7 @@
 #include "walletmodel.h"
 #include "bitcoinunits.h"
 #include "util.h"
+#include "init.h"
 
 #include <QString>
 #include <QDateTime>
@@ -412,6 +413,40 @@ bool GetStartOnSystemStartup() { return false; }
 bool SetStartOnSystemStartup(bool fAutoStart) { return false; }
 
 #endif
+
+HelpMessageBox::HelpMessageBox(QWidget *parent) :
+    QMessageBox(parent)
+{
+    header = tr("Bitcoin-Qt") + " " + tr("version") + " " +
+        QString::fromStdString(FormatFullVersion()) + "\n\n" +
+        tr("Usage:") + "\n" +
+        "  bitcoin-qt [" + tr("command-line options") + "]                     " + "\n";
+
+    coreOptions = QString::fromStdString(HelpMessage());
+
+    uiOptions = tr("UI options") + ":\n" +
+        "  -lang=<lang>           " + tr("Set language, for example \"de_DE\" (default: system locale)") + "\n" +
+        "  -min                   " + tr("Start minimized") + "\n" +
+        "  -splash                " + tr("Show splash screen on startup (default: 1)") + "\n";
+
+    setWindowTitle(tr("Bitcoin-Qt"));
+    setTextFormat(Qt::PlainText);
+    // setMinimumWidth is ignored for QMessageBox so put in nonbreaking spaces to make it wider.
+    setText(header + QString(QChar(0x2003)).repeated(50));
+    setDetailedText(coreOptions + "\n" + uiOptions);
+}
+
+void HelpMessageBox::exec()
+{
+#if defined(WIN32)
+    // On windows, show a message box, as there is no stderr in windowed applications
+    QMessageBox::exec();
+#else
+    // On other operating systems, the expected action is to print the message to the console.
+    QString strUsage = header + "\n" + coreOptions + "\n" + uiOptions;
+    fprintf(stderr, "%s", strUsage.toStdString().c_str());
+#endif
+}
 
 } // namespace GUIUtil
 

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -3,6 +3,7 @@
 
 #include <QString>
 #include <QObject>
+#include <QMessageBox>
 
 QT_BEGIN_NAMESPACE
 class QFont;
@@ -80,6 +81,7 @@ namespace GUIUtil
     class ToolTipToRichTextFilter : public QObject
     {
         Q_OBJECT
+
     public:
         explicit ToolTipToRichTextFilter(int size_threshold, QObject *parent = 0);
 
@@ -92,6 +94,22 @@ namespace GUIUtil
 
     bool GetStartOnSystemStartup();
     bool SetStartOnSystemStartup(bool fAutoStart);
+
+    /** Help message for Bitcoin-Qt, shown with --help. */
+    class HelpMessageBox : public QMessageBox
+    {
+        Q_OBJECT
+
+    public:
+        HelpMessageBox(QWidget *parent = 0);
+
+        void exec();
+
+    private:
+        QString header;
+        QString coreOptions;
+        QString uiOptions;
+    };
 
 } // namespace GUIUtil
 

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -109,10 +109,13 @@ RPCConsole::RPCConsole(QWidget *parent) :
 {
     ui->setupUi(this);
 
-#ifdef WIN32
+#ifndef Q_WS_MAC
     ui->openDebugLogfileButton->setIcon(QIcon(":/icons/export"));
-#else
-    // Show Debug logfile label and Open button only for Windows
+    ui->showCLOptionsButton->setIcon(QIcon(":/icons/options"));
+#endif
+
+#ifndef WIN32
+    // Hide Debug logfile label and Open button for non Windows-OSes
     ui->labelDebugLogfile->setVisible(false);
     ui->openDebugLogfileButton->setVisible(false);
 #endif
@@ -325,4 +328,10 @@ void RPCConsole::scrollToEnd()
 {
     QScrollBar *scrollbar = ui->messagesWidget->verticalScrollBar();
     scrollbar->setValue(scrollbar->maximum());
+}
+
+void RPCConsole::on_showCLOptionsButton_clicked()
+{
+    GUIUtil::HelpMessageBox help;
+    help.exec();
 }

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -35,6 +35,8 @@ private slots:
     void on_tabWidget_currentChanged(int index);
     /** open the debug.log from the current datadir */
     void on_openDebugLogfileButton_clicked();
+    /** display messagebox with program parameters (same as bitcoin-qt --help) */
+    void on_showCLOptionsButton_clicked();
 
 public slots:
     void clear();


### PR DESCRIPTION
- move class HelpMessageBox to guiutil.cpp/.h
- add button to show Bitcoin options (in RPC Console -> Information)
- resize Debug window a little to allow for a non-breaking display of the welcome message with non-english translation
- use 50 nonbreaking spaces (up from 40) on Windows to widen the HelpMessage Box for better readability
