### PR TITLE
Bash completion for bitcoind(1)

### DIFF
--- a/contrib/bitcoind.bash-completion
+++ b/contrib/bitcoind.bash-completion
@@ -1,0 +1,115 @@
+# bash programmable completion for bitcoind(1)
+# Copyright (c) 2012 Christian von Roques <roques@mti.ag>
+# Distributed under the MIT/X11 software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+have bitcoind && {
+
+# call $bitcoind for RPC
+_bitcoin_rpc() {
+    # determine already specified args necessary for RPC
+    local rpcargs=()
+    for i in ${COMP_LINE}; do
+        case "$i" in
+            -conf=*|-proxy*|-rpc*)
+                rpcargs=( "${rpcargs[@]}" "$i" )
+                ;;
+        esac
+    done
+    $bitcoind "${rpcargs[@]}" "$@"
+}
+
+# Add bitcoin accounts to COMPREPLY
+_bitcoin_accounts() {
+    local accounts
+    accounts=$(_bitcoin_rpc listaccounts | awk '/".*"/ { a=$1; gsub(/"/, "", a); print a}')
+    COMPREPLY=( "${COMPREPLY[@]}" $( compgen -W "$accounts" -- "$cur" ) )
+}
+
+_bitcoind() {
+    local cur prev words=() cword
+    local bitcoind
+
+    # save and use original argument to invoke bitcoind
+    # bitcoind might not be in $PATH
+    bitcoind="$1"
+
+    COMPREPLY=()
+    _get_comp_words_by_ref -n = cur prev words cword
+
+    if ((cword > 2)); then
+        case ${words[cword-2]} in
+            listreceivedbyaccount|listreceivedbyaddress)
+                COMPREPLY=( $( compgen -W "true false" -- "$cur" ) )
+                return 0
+                ;;
+            move|setaccount)
+                _bitcoin_accounts
+                return 0
+                ;;
+        esac
+    fi
+
+    case "$prev" in
+        backupwallet)
+            _filedir
+            return 0
+            ;;
+        setgenerate)
+            COMPREPLY=( $( compgen -W "true false" -- "$cur" ) )
+            return 0
+            ;;
+        getaccountaddress|getaddressesbyaccount|getbalance|getnewaddress|getreceivedbyaccount|listtransactions|move|sendfrom|sendmany)
+            _bitcoin_accounts
+            return 0
+            ;;
+    esac
+
+    case "$cur" in
+        -conf=*|-pid=*|-rpcsslcertificatechainfile=*|-rpcsslprivatekeyfile=*)
+            cur="${cur#*=}"
+            _filedir
+            return 0
+            ;;
+        -datadir=*)
+            cur="${cur#*=}"
+            _filedir -d
+            return 0
+            ;;
+        -*=*)	# prevent nonsense completions
+            return 0
+            ;;
+        *)
+            local helpopts commands
+
+            # only parse --help if senseful
+            if [[ -z "$cur" || "$cur" =~ ^- ]]; then
+                helpopts=$($bitcoind --help 2>&1 | awk '$1 ~ /^-/ { sub(/=.*/, "="); print $1 }' )
+            fi
+
+            # only parse help if senseful
+            if [[ -z "$cur" || "$cur" =~ ^[a-z] ]]; then
+                commands=$(_bitcoin_rpc help 2>/dev/null | awk '{ print $1; }')
+            fi
+
+            COMPREPLY=( $( compgen -W "$helpopts $commands" -- "$cur" ) )
+
+            # Prevent space if an argument is desired
+            if [[ $COMPREPLY == *= ]]; then
+                compopt -o nospace
+            fi
+            return 0
+            ;;
+    esac
+}
+
+complete -F _bitcoind bitcoind
+}
+
+# Local variables:
+# mode: shell-script
+# sh-basic-offset: 4
+# sh-indent-comment: t
+# indent-tabs-mode: nil
+# End:
+# ex: ts=4 sw=4 et filetype=sh

--- a/contrib/debian/bitcoind.bash-completion
+++ b/contrib/debian/bitcoind.bash-completion
@@ -1,0 +1,1 @@
+contrib/bitcoind.bash-completion	bitcoind

--- a/contrib/debian/control
+++ b/contrib/debian/control
@@ -5,6 +5,7 @@ Maintainer: Jonas Smedegaard <dr@jones.dk>
 Uploaders: Micah Anderson <micah@debian.org>
 Build-Depends: debhelper,
  devscripts,
+ bash-completion,
  libboost-system-dev (>> 1.35) | libboost-system1.35-dev,
  libdb4.8++-dev,
  libssl-dev,

--- a/contrib/debian/rules
+++ b/contrib/debian/rules
@@ -9,7 +9,7 @@ DEB_INSTALL_EXAMPLES_bitcoind += debian/examples/*
 DEB_INSTALL_MANPAGES_bitcoind += debian/manpages/*
 
 %:
-	dh $@
+	dh --with bash-completion $@
 
 override_dh_auto_build:
 	cd src; $(MAKE) -f makefile.unix bitcoind


### PR DESCRIPTION
Uses `bitcoind --help` to determine available options and `bitcoind help` to determine available commands.
Currently placed in contrib/debian/bitcoind.bash-completion, so it can be picked up automatically by the Debian package building process.
