### PR TITLE
BDB: restore DB_PRIVATE flag to environment

### DIFF
--- a/src/db.cpp
+++ b/src/db.cpp
@@ -76,6 +76,10 @@ CDB::CDB(const char *pszFile, const char* pszMode) : pdb(NULL)
     if (fCreate)
         nFlags |= DB_CREATE;
 
+    unsigned int nEnvFlags = 0;
+    if (GetBoolArg("-privdb", true))
+        nEnvFlags |= DB_PRIVATE;
+
     {
         LOCK(cs_db);
         if (!fDbEnvInit)
@@ -106,7 +110,8 @@ CDB::CDB(const char *pszFile, const char* pszMode) : pdb(NULL)
                              DB_INIT_MPOOL |
                              DB_INIT_TXN   |
                              DB_THREAD     |
-                             DB_RECOVER,
+                             DB_RECOVER    |
+                             nEnvFlags,
                              S_IRUSR | S_IWUSR);
             if (ret > 0)
                 throw runtime_error(strprintf("CDB() : error %d opening database environment", ret));


### PR DESCRIPTION
Satoshi's commits fdbf76d4f49c220e2ed4412a3d8d8cd6efd74826 and
c8ad9b8375f5308bb46a124f096a80926ea42fba (SVN import) removed the
DB_PRIVATE flag from the environment.  In part, this enables processes
other than bitcoind to examine the active database environment.

However, this incurs a slight performance penalty versus working entirely
within application memory (DB_PRIVATE).  Because bitcointools and other
direct-BDB-accessing tools are not used by the vast majority of users, prefer
to default with DB_PRIVATE with the option of disabling it if needed
via -privdb=0.
