### PR TITLE
GUI: change verifymessagepage behaviour to match RPC-call "verifymessage"

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -849,7 +849,7 @@ void BitcoinGUI::changePassphrase()
 
 void BitcoinGUI::verifyMessage()
 {
-    VerifyMessageDialog *dlg = new VerifyMessageDialog(walletModel->getAddressTableModel(), this);
+    VerifyMessageDialog *dlg = new VerifyMessageDialog(this);
     dlg->setAttribute(Qt::WA_DeleteOnClose);
     dlg->show();
 }

--- a/src/qt/forms/verifymessagedialog.ui
+++ b/src/qt/forms/verifymessagedialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>494</width>
-    <height>342</height>
+    <width>650</width>
+    <height>380</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -17,7 +17,7 @@
    <item>
     <widget class="QLabel" name="label">
      <property name="text">
-      <string>Enter the message and signature below (be careful to correctly copy newlines, spaces, tabs and other invisible characters) to obtain the Bitcoin address used to sign the message.</string>
+      <string>Enter the signing address, signature and message below (be careful to correctly copy newlines, spaces, tabs and other invisible characters) to verify the message.</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
@@ -28,38 +28,28 @@
     </widget>
    </item>
    <item>
+    <widget class="QValidatedLineEdit" name="lnAddress">
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QValidatedLineEdit" name="lnSig">
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QPlainTextEdit" name="edMessage"/>
-   </item>
-   <item>
-    <widget class="QLineEdit" name="lnSig">
-     <property name="text">
-      <string/>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QLineEdit" name="lnAddress">
-     <property name="text">
-      <string/>
-     </property>
-     <property name="readOnly">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QLabel" name="lblStatus">
-     <property name="text">
-      <string/>
-     </property>
-    </widget>
    </item>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
       <widget class="QPushButton" name="verifyMessage">
        <property name="toolTip">
-        <string>Verify a message and obtain the Bitcoin address used to sign the message</string>
+        <string>Verify a message to ensure it was signed with the specified Bitcoin address</string>
        </property>
        <property name="text">
         <string>&amp;Verify Message</string>
@@ -67,23 +57,6 @@
        <property name="icon">
         <iconset resource="../bitcoin.qrc">
          <normaloff>:/icons/transaction_0</normaloff>:/icons/transaction_0</iconset>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="copyToClipboard">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="toolTip">
-        <string>Copy the currently selected address to the system clipboard</string>
-       </property>
-       <property name="text">
-        <string>&amp;Copy Address</string>
-       </property>
-       <property name="icon">
-        <iconset resource="../bitcoin.qrc">
-         <normaloff>:/icons/editcopy</normaloff>:/icons/editcopy</iconset>
        </property>
       </widget>
      </item>
@@ -98,6 +71,41 @@
        <property name="icon">
         <iconset resource="../bitcoin.qrc">
          <normaloff>:/icons/remove</normaloff>:/icons/remove</iconset>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QLabel" name="lblStatus">
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>48</height>
+        </size>
+       </property>
+       <property name="font">
+        <font>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
        </property>
       </widget>
      </item>
@@ -118,6 +126,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QValidatedLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>qvalidatedlineedit.h</header>
+  </customwidget>
+ </customwidgets>
  <resources>
   <include location="../bitcoin.qrc"/>
  </resources>

--- a/src/qt/verifymessagedialog.h
+++ b/src/qt/verifymessagedialog.h
@@ -16,21 +16,17 @@ class VerifyMessageDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit VerifyMessageDialog(AddressTableModel *addressModel, QWidget *parent = 0);
+    explicit VerifyMessageDialog(QWidget *parent);
     ~VerifyMessageDialog();
 
 protected:
     bool eventFilter(QObject *object, QEvent *event);
 
 private:
-    bool checkAddress();
-
     Ui::VerifyMessageDialog *ui;
-    AddressTableModel *model;
 
 private slots:
     void on_verifyMessage_clicked();
-    void on_copyToClipboard_clicked();
     void on_clearButton_clicked();
 };
 


### PR DESCRIPTION
- change verifymessagepage behaviour to match RPC-call "verifymessage" (input address, signature and message)
- remove "copy to clipboard" button as that is unneeded now
- re-positioned the status label
- display (error / info) messages in status label (remove message boxes)
- resize window to make signature fully readable
- change signature font to BC-address font (like in messagepage)
- remove checkAddress() and place code directly in on_verifyMessage_clicked()
- add visual feedback to LineEdits
- remove AddressTableModel references
- add addr.GetKeyID(keyID) check

This addresses #1356.
