### PR TITLE
add client startup time as an entry to debug.log

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -414,6 +414,7 @@ bool AppInit2()
         ShrinkDebugFile();
     printf("\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n");
     printf("Bitcoin version %s (%s)\n", FormatFullVersion().c_str(), CLIENT_DATE.c_str());
+    printf("Startup time: %s\n", DateTimeStrFormat("%x %H:%M:%S", GetTime()).c_str());
     printf("Default data directory %s\n", GetDefaultDataDir().string().c_str());
     std::ostringstream strErrors;
 

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -130,9 +130,9 @@ QString ClientModel::clientName() const
     return QString::fromStdString(CLIENT_NAME);
 }
 
-QDateTime ClientModel::formatClientStartupTime() const
+QString ClientModel::formatClientStartupTime() const
 {
-    return QDateTime::fromTime_t(nClientStartupTime);
+    return QDateTime::fromTime_t(nClientStartupTime).toString();
 }
 
 // Handlers for core signals

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -41,7 +41,7 @@ public:
     QString formatFullVersion() const;
     QString formatBuildDate() const;
     QString clientName() const;
-    QDateTime formatClientStartupTime() const;
+    QString formatClientStartupTime() const;
 
 private:
     OptionsModel *optionsModel;

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -163,7 +163,7 @@ void RPCConsole::setClientModel(ClientModel *model)
         ui->clientVersion->setText(model->formatFullVersion());
         ui->clientName->setText(model->clientName());
         ui->buildDate->setText(model->formatBuildDate());
-        ui->startupTime->setText(model->formatClientStartupTime().toString());
+        ui->startupTime->setText(model->formatClientStartupTime());
 
         setNumConnections(model->getNumConnections());
         ui->isTestNet->setChecked(model->isTestNet());


### PR DESCRIPTION
- make ClientModel::formatClientStartupTime() return a QString

Note: Logged time in debug.log differs by a few seconds from the one displayed in the Debug window because of different initialisation times.
