### PR TITLE
Sometimes nodes send many duplicate blocks. This patch disconnects the p...

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -148,6 +148,7 @@ public:
     std::string addrName;
     CService addrLocal;
     int nVersion;
+    int nDupBlocks;
     std::string strSubVer;
     bool fOneShot;
     bool fClient;
@@ -199,6 +200,7 @@ public:
         addr = addrIn;
         addrName = addrNameIn == "" ? addr.ToStringIPPort() : addrNameIn;
         nVersion = 0;
+        nDupBlocks = 0;
         strSubVer = "";
         fOneShot = false;
         fClient = false; // set by version message


### PR DESCRIPTION
...eer that's lagging behind. This ideally shouldn't happen, but it can and does sometimes, so this code caters for that.

This code also becomes more important if the block download algorithm is changed in future (e.g. pull #1326, which is still in development), e.g. if and retries are sent to other peers when peers seem unresponsive, only to become responsive again later, by which time they are sending duplicate blocks. Obviously the unresponsive peers could be disconnected when deemed unresponsive, but my tests have shown it's more efficient to give them a chance to become responsive again, (even though it does increase the chances of them sending duplicate blocks), and disconnecting them at that point.

Future patches could identify the duplicate blocks before they are downloaded, by the block size (looking up against blocks recently downloaded and against blocks requested from the peer sending the block). Ideally they'd be identified by something more specific than the block size, but currently block headers communicate only the size.
