### PR TITLE
JSON-RPC: Add 'sendrawtx' op, for sending pre-built TX's to network

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -109,7 +109,7 @@ void static EraseFromWallets(uint256 hash)
 }
 
 // make sure all wallets know about the given transaction, in the given block
-void static SyncWithWallets(const CTransaction& tx, const CBlock* pblock = NULL, bool fUpdate = false)
+void SyncWithWallets(const CTransaction& tx, const CBlock* pblock, bool fUpdate)
 {
     BOOST_FOREACH(CWallet* pwallet, setpwalletRegistered)
         pwallet->AddToWalletIfInvolvingMe(tx, pblock, fUpdate);

--- a/src/main.h
+++ b/src/main.h
@@ -81,6 +81,7 @@ class CTxIndex;
 
 void RegisterWallet(CWallet* pwalletIn);
 void UnregisterWallet(CWallet* pwalletIn);
+void SyncWithWallets(const CTransaction& tx, const CBlock* pblock = NULL, bool fUpdate = false);
 bool ProcessBlock(CNode* pfrom, CBlock* pblock);
 bool CheckDiskSpace(uint64 nAdditionalBytes=0);
 FILE* OpenBlockFile(unsigned int nFile, unsigned int nBlockPos, const char* pszMode="rb");


### PR DESCRIPTION
This RPC assumes that you Know What You Are Doing.  It will
- reject any TX that fails validation, rather than adding to mapOrphanTransactions
- not detect or process dependent orphans

This should not present a problem to anybody who is creating well formed transactions with connect-able inputs.
