### PR TITLE
JSON-RPC: add filter{clearall,clear,add}, a block and tx notification system

### DIFF
--- a/bitcoin-qt.pro
+++ b/bitcoin-qt.pro
@@ -147,6 +147,7 @@ HEADERS += src/qt/bitcoingui.h \
     src/qt/transactionview.h \
     src/qt/walletmodel.h \
     src/bitcoinrpc.h \
+    src/filter.h \
     src/qt/overviewpage.h \
     src/qt/csvmodelwriter.h \
     src/crypter.h \
@@ -206,6 +207,7 @@ SOURCES += src/qt/bitcoin.cpp src/qt/bitcoingui.cpp \
     src/qt/walletmodel.cpp \
     src/bitcoinrpc.cpp \
     src/rpcdump.cpp \
+    src/filter.cpp \
     src/qt/overviewpage.cpp \
     src/qt/csvmodelwriter.cpp \
     src/crypter.cpp \

--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -44,6 +44,9 @@ static CCriticalSection cs_nWalletUnlockTime;
 
 extern Value dumpprivkey(const Array& params, bool fHelp);
 extern Value importprivkey(const Array& params, bool fHelp);
+extern Value filterclearall(const Array& params, bool fHelp);
+extern Value filterclear(const Array& params, bool fHelp);
+extern Value filteradd(const Array& params, bool fHelp);
 
 const Object emptyobj;
 
@@ -2331,6 +2334,9 @@ static const CRPCCommand vRPCCommands[] =
     { "dumpprivkey",            &dumpprivkey,            false },
     { "importprivkey",          &importprivkey,          false },
     { "sendrawtx",              &sendrawtx,              false },
+    { "filterclearall",         &filterclearall,         false },
+    { "filterclear",            &filterclear,            false },
+    { "filteradd",              &filteradd,              false },
 };
 
 CRPCTable::CRPCTable()

--- a/src/filter.cpp
+++ b/src/filter.cpp
@@ -1,0 +1,148 @@
+// Copyright (c) 2010 Satoshi Nakamoto
+// Copyright (c) 2009-2012 The Bitcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "bitcoinrpc.h"
+#include "filter.h"
+#include "util.h"
+#include "sync.h"
+#include "main.h"
+
+using namespace std;
+using namespace json_spirit;
+
+static CBloomers bloomers;
+static CCriticalSection cs_lock;
+static string strNotifyTx;
+static string strNotifyBlock;
+
+Value filterclearall(const Array& params, bool fHelp)
+{
+    if (fHelp || params.size() > 0)
+        throw runtime_error(
+            "filterclearall\n"
+            "Clear all filters.");
+
+    LOCK(cs_lock);
+    bloomers.clearall();
+
+    return true;
+}
+
+Value filterclear(const Array& params, bool fHelp)
+{
+    if (fHelp || params.size() != 1)
+        throw runtime_error(
+            "filterclear <name>\n"
+            "Clear filter named <name>.");
+
+    LOCK(cs_lock);
+    bloomers.clear(params[0].get_str());
+
+    return true;
+}
+
+Value filteradd(const Array& params, bool fHelp)
+{
+    if (fHelp || params.size() != 2)
+        throw runtime_error(
+            "filteradd <name> <hash hexstring>\n"
+            "Add <hash> to filter <name>.");
+
+    LOCK(cs_lock);
+    bloomers.add(params[0].get_str(), ParseHex(params[1].get_str()));
+
+    return true;
+}
+
+static bool FilterMatchTxOut(const CTxOut& txout)
+{
+    txnouttype type;
+    int nRequired;
+    vector<CBitcoinAddress> addresses;
+
+    if (!ExtractAddresses(txout.scriptPubKey, type, addresses, nRequired))
+        return false;
+
+    for (unsigned int i = 0; i < addresses.size(); i++) {
+        uint160 hash = addresses[i].GetHash160();
+        vector<string> rv = bloomers.contains(string(hash.begin(), hash.end()));
+        if (rv.size() > 0)
+            return true;
+    }
+
+    return false;
+}
+
+static bool __FilterMatchTx(const CTransaction& tx)
+{
+    BOOST_FOREACH(const CTxOut& txout, tx.vout) {
+        if (FilterMatchTxOut(txout))
+            return true;
+    }
+
+    return false;
+}
+
+static bool FilterMatchTx(const CTransaction& tx)
+{
+    LOCK(cs_lock);
+    return __FilterMatchTx(tx);
+}
+
+static bool FilterMatchBlock(const CBlock& block)
+{
+    LOCK(cs_lock);
+
+    BOOST_FOREACH(const CTransaction& tx, block.vtx) {
+        if (__FilterMatchTx(tx))
+            return true;
+    }
+
+    return false;
+}
+
+void FilterNotifyTx(const CTransaction& tx)
+{
+    if (strNotifyTx.empty())
+        return;
+
+    if (!FilterMatchTx(tx))
+        return;
+
+    string strCmd(strNotifyTx);
+    boost::replace_all(strCmd, "%t", "tx");
+    boost::replace_all(strCmd, "%h", tx.GetHash().GetHex());
+
+    printf("FILTER(tx) exec: %s\n", strCmd.c_str());
+    boost::thread t(runCommand, strCmd); // thread runs free
+}
+
+void FilterNotifyBlock(const CBlock& block)
+{
+    if (strNotifyBlock.empty())
+        return;
+
+    if (!FilterMatchBlock(block))
+        return;
+
+    string strCmd(strNotifyBlock);
+    boost::replace_all(strCmd, "%t", "block");
+    boost::replace_all(strCmd, "%h", block.GetHash().GetHex());
+
+    printf("FILTER(block) exec: %s\n", strCmd.c_str());
+    boost::thread t(runCommand, strCmd); // thread runs free
+}
+
+void FilterSetup()
+{
+    string strNotifyTx = GetArg("-filtertx", "");
+    if (strNotifyTx.empty())
+        strNotifyTx = GetArg("-filter", "");
+
+    string strNotifyBlock = GetArg("-filterblock", "");
+    if (strNotifyBlock.empty())
+        strNotifyBlock = GetArg("-filter", "");
+}
+

--- a/src/filter.cpp
+++ b/src/filter.cpp
@@ -137,11 +137,11 @@ void FilterNotifyBlock(const CBlock& block)
 
 void FilterSetup()
 {
-    string strNotifyTx = GetArg("-filtertx", "");
+    strNotifyTx = GetArg("-filtertx", "");
     if (strNotifyTx.empty())
         strNotifyTx = GetArg("-filter", "");
 
-    string strNotifyBlock = GetArg("-filterblock", "");
+    strNotifyBlock = GetArg("-filterblock", "");
     if (strNotifyBlock.empty())
         strNotifyBlock = GetArg("-filter", "");
 }

--- a/src/filter.h
+++ b/src/filter.h
@@ -1,0 +1,70 @@
+// Copyright (c) 2010 Satoshi Nakamoto
+// Copyright (c) 2009-2012 The Bitcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef __BITCOIN_FILTER_H__
+#define __BITCOIN_FILTER_H__ 1
+
+#include <string>
+#include <map>
+
+class CTransaction;
+class CBlock;
+
+class CFilter
+{
+private:
+    std::map<std::string, bool> filter;
+
+public:
+    void insert(const std::string& data) { filter[data] = true; }
+
+    bool contains(const std::string& data) const
+    {
+        return (filter.count(data) > 0);
+    }
+};
+
+class CBloomers
+{
+private:
+    std::map<std::string, CFilter> mapFilters;
+public:
+    void clearall()
+    {
+        mapFilters.clear();
+    }
+
+    void clear(const std::string& name)
+    {
+        mapFilters.erase(name);
+    }
+
+    void add(const std::string& name, const std::string& data)
+    {
+        mapFilters[name].insert(data);
+    }
+
+    void add(const std::string& name, std::vector<unsigned char> data_)
+    {
+        std::string data((char *)&data_[0], data_.size());
+        add(name, data);
+    }
+
+    std::vector<std::string> contains(const std::string& data)
+    {
+        std::vector<std::string> retNames;
+        for (std::map<std::string, CFilter>::const_iterator mi =
+                    mapFilters.begin(); mi != mapFilters.end(); mi++) {
+            if (mi->second.contains(data))
+                retNames.push_back(mi->first);
+        }
+        return retNames;
+    }
+};
+
+void FilterNotifyTx(const CTransaction& tx);
+void FilterNotifyBlock(const CBlock& block);
+
+#endif // __BITCOIN_FILTER_H__

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -387,6 +387,9 @@ bool AppInit2()
             InitWarning(_("Warning: -paytxfee is set very high. This is the transaction fee you will pay if you send a transaction."));
     }
 
+    extern void FilterSetup();
+    FilterSetup();
+
     // ********************************************************* Step 4: application initialization: dir lock, daemonize, pidfile, debug log
 
     // Make sure only a single Bitcoin process is using the data directory.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,6 +7,7 @@
 #include "db.h"
 #include "net.h"
 #include "init.h"
+#include "filter.h"
 #include "ui_interface.h"
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/filesystem.hpp>
@@ -611,6 +612,10 @@ bool CTxMemPool::accept(CTxDB& txdb, CTransaction &tx, bool fCheckInputs,
     printf("CTxMemPool::accept() : accepted %s (poolsz %u)\n",
            hash.ToString().substr(0,10).c_str(),
            mapTx.size());
+
+    // exec -filtertx/-filter hook
+    FilterNotifyTx(tx);
+
     return true;
 }
 
@@ -1615,6 +1620,9 @@ bool CBlock::SetBestChain(CTxDB& txdb, CBlockIndex* pindexNew)
         boost::replace_all(strCmd, "%s", hashBestChain.GetHex());
         boost::thread t(runCommand, strCmd); // thread runs free
     }
+
+    // exec -filterblock/-filter hook
+    FilterNotifyBlock(*this);
 
     return true;
 }

--- a/src/makefile.linux-mingw
+++ b/src/makefile.linux-mingw
@@ -60,6 +60,7 @@ OBJS= \
     obj/protocol.o \
     obj/bitcoinrpc.o \
     obj/rpcdump.o \
+    obj/filter.o \
     obj/script.o \
     obj/sync.o \
     obj/util.o \

--- a/src/makefile.mingw
+++ b/src/makefile.mingw
@@ -57,6 +57,7 @@ OBJS= \
     obj/protocol.o \
     obj/bitcoinrpc.o \
     obj/rpcdump.o \
+    obj/filter.o \
     obj/script.o \
     obj/sync.o \
     obj/util.o \

--- a/src/makefile.osx
+++ b/src/makefile.osx
@@ -84,6 +84,7 @@ OBJS= \
     obj/protocol.o \
     obj/bitcoinrpc.o \
     obj/rpcdump.o \
+    obj/filter.o \
     obj/script.o \
     obj/sync.o \
     obj/util.o \

--- a/src/makefile.unix
+++ b/src/makefile.unix
@@ -104,6 +104,7 @@ OBJS= \
     obj/protocol.o \
     obj/bitcoinrpc.o \
     obj/rpcdump.o \
+    obj/filter.o \
     obj/script.o \
     obj/sync.o \
     obj/util.o \

--- a/src/test/filter_tests.cpp
+++ b/src/test/filter_tests.cpp
@@ -1,0 +1,41 @@
+
+#include <boost/test/unit_test.hpp>
+
+#include "uint256.h"
+#include "filter.h"
+
+using namespace std;
+
+BOOST_AUTO_TEST_SUITE(filter_tests)
+
+BOOST_AUTO_TEST_CASE(filter_test1)
+{
+    CBloomers bloomers;
+
+    vector<uint160> hash;
+    hash.push_back(0xaabbccdd11223344ULL);
+    hash.push_back(0x9988776655443322ULL);
+
+    vector<string> hashstr;
+    int i;
+
+    for (i = 0; i < 2; i++) {
+        string s;
+        s.assign(hash[i].begin(), hash[i].end());
+        hashstr.push_back(s);
+    }
+
+    for (i = 0; i < 2; i++)
+        bloomers.add("main", hashstr[i]);
+
+    for (i = 0; i < 2; i++) {
+        vector<string> rv;
+        rv = bloomers.contains(hashstr[i]);
+
+        BOOST_CHECK(rv.size() == 1);
+        BOOST_CHECK(rv[0] == "main");
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+


### PR DESCRIPTION
These RPCs manipulate a set of named lists, each of which matches zero or more bitcoin addresses.

If a match is found in the TX memory pool, the command specified by arg -filtertx (or -filter, if missing) is executed.

If a match is found in a newly [re-]accepted block (SetBestChain), the command specified by arg -filterblock (or -filter, if missing) is executed.

The following command string substituations are performed, before the notification command is executed:

```
    %t      "tx" or "block"
    %h      hex string of 256-bit block hash or tx hash
```
