### PR TITLE
Rework network config settings

### DIFF
--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -531,6 +531,9 @@ Value getinfo(const Array& params, bool fHelp)
             "getinfo\n"
             "Returns an object containing various state info.");
 
+    CService addrProxy;
+    GetProxy(NET_IPV4, addrProxy);
+
     Object obj;
     obj.push_back(Pair("version",       (int)CLIENT_VERSION));
     obj.push_back(Pair("protocolversion",(int)PROTOCOL_VERSION));
@@ -538,7 +541,7 @@ Value getinfo(const Array& params, bool fHelp)
     obj.push_back(Pair("balance",       ValueFromAmount(pwalletMain->GetBalance())));
     obj.push_back(Pair("blocks",        (int)nBestHeight));
     obj.push_back(Pair("connections",   (int)vNodes.size()));
-    obj.push_back(Pair("proxy",         (fUseProxy ? addrProxy.ToStringIPPort() : string())));
+    obj.push_back(Pair("proxy",         (addrProxy.IsValid() ? addrProxy.ToStringIPPort() : string())));
     obj.push_back(Pair("difficulty",    (double)GetDifficulty()));
     obj.push_back(Pair("testnet",       fTestNet));
     obj.push_back(Pair("keypoololdest", (boost::int64_t)pwalletMain->GetOldestKeyPoolTime()));

--- a/src/irc.cpp
+++ b/src/irc.cpp
@@ -176,8 +176,6 @@ bool GetIPFromIRC(SOCKET hSocket, string strMyName, CNetAddr& ipRet)
     // Hybrid IRC used by lfnet always returns IP when you userhost yourself,
     // but in case another IRC is ever used this should work.
     printf("GetIPFromIRC() got userhost %s\n", strHost.c_str());
-    if (fUseProxy)
-        return false;
     CNetAddr addr(strHost, true);
     if (!addr.IsValid())
         return false;
@@ -281,7 +279,7 @@ void ThreadIRCSeed2(void* parg)
         if (GetIPFromIRC(hSocket, strMyName, addrFromIRC))
         {
             printf("GetIPFromIRC() returned %s\n", addrFromIRC.ToString().c_str());
-            if (!fUseProxy && addrFromIRC.IsRoutable())
+            if (addrFromIRC.IsRoutable())
             {
                 // IRC lets you to re-nick
                 AddLocal(addrFromIRC, LOCAL_IRC);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2377,7 +2377,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
         if (!pfrom->fInbound)
         {
             // Advertise our address
-            if (!fNoListen && !fUseProxy && !IsInitialBlockDownload())
+            if (!fNoListen && !IsInitialBlockDownload())
             {
                 CAddress addr = GetLocalAddress(&pfrom->addr);
                 if (addr.IsRoutable())
@@ -3035,7 +3035,7 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
                         pnode->setAddrKnown.clear();
 
                     // Rebroadcast our address
-                    if (!fNoListen && !fUseProxy)
+                    if (!fNoListen)
                     {
                         CAddress addr = GetLocalAddress(&pnode->addr);
                         if (addr.IsRoutable())

--- a/src/net.h
+++ b/src/net.h
@@ -36,7 +36,7 @@ void AddressCurrentlyConnected(const CService& addr);
 CNode* FindNode(const CNetAddr& ip);
 CNode* FindNode(const CService& ip);
 CNode* ConnectNode(CAddress addrConnect, const char *strDest = NULL, int64 nTimeout=0);
-void MapPort(bool fMapPort);
+void MapPort();
 unsigned short GetListenPort();
 bool BindListenPort(const CService &bindAddr, std::string& strError=REF(std::string()));
 void StartNode(void* parg);
@@ -110,6 +110,8 @@ enum threadId
 };
 
 extern bool fClient;
+extern bool fDiscover;
+extern bool fUseUPnP;
 extern uint64 nLocalServices;
 extern uint64 nLocalHostNonce;
 extern boost::array<int, THREAD_MAX> vnThreadsRunning;

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -16,14 +16,11 @@
 using namespace std;
 
 // Settings
-int nSocksVersion = 5;
-int fUseProxy = false;
-bool fProxyNameLookup = false;
-bool fNameLookup = false;
-CService addrProxy("127.0.0.1",9050);
+typedef std::pair<CService, int> proxyType;
+static proxyType proxyInfo[NET_MAX];
+static proxyType nameproxyInfo;
 int nConnectTimeout = 5000;
-static bool vfNoProxy[NET_MAX] = {};
-
+bool fNameLookup = false;
 
 static const unsigned char pchIPv4[12] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff };
 
@@ -34,11 +31,6 @@ enum Network ParseNetwork(std::string net) {
     if (net == "tor")  return NET_TOR;
     if (net == "i2p")  return NET_I2P;
     return NET_UNROUTABLE;
-}
-
-void SetNoProxy(enum Network net, bool fNoProxy) {
-    assert(net >= 0 && net < NET_MAX);
-    vfNoProxy[net] = fNoProxy;
 }
 
 bool static LookupIntern(const char *pszName, std::vector<CNetAddr>& vIP, unsigned int nMaxSolutions, bool fAllowLookup)
@@ -431,29 +423,71 @@ bool static ConnectSocketDirectly(const CService &addrConnect, SOCKET& hSocketRe
     return true;
 }
 
+bool SetProxy(enum Network net, CService addrProxy, int nSocksVersion) {
+    assert(net >= 0 && net < NET_MAX);
+    if (nSocksVersion != 0 && nSocksVersion != 4 && nSocksVersion != 5)
+        return false;
+    if (nSocksVersion != 0 && !addrProxy.IsValid())
+        return false;
+    proxyInfo[net] = std::make_pair(addrProxy, nSocksVersion);
+    return true;
+}
+
+bool GetProxy(enum Network net, CService &addrProxy) {
+    assert(net >= 0 && net < NET_MAX);
+    if (!proxyInfo[net].second)
+        return false;
+    addrProxy = proxyInfo[net].first;
+    return true;
+}
+
+bool SetNameProxy(CService addrProxy, int nSocksVersion) {
+    if (nSocksVersion != 0 && nSocksVersion != 5)
+        return false;
+    if (nSocksVersion != 0 && !addrProxy.IsValid())
+        return false;
+    nameproxyInfo = std::make_pair(addrProxy, nSocksVersion);
+    return true;
+}
+
+bool GetNameProxy() {
+    return nameproxyInfo.second != 0;
+}
+
+bool IsProxy(const CNetAddr &addr) {
+    for (int i=0; i<NET_MAX; i++) {
+        if (proxyInfo[i].second && (addr == (CNetAddr)proxyInfo[i].first))
+            return true;
+    }
+    return false;
+}
+
 bool ConnectSocket(const CService &addrDest, SOCKET& hSocketRet, int nTimeout)
 {
+    const proxyType &proxy = proxyInfo[addrDest.GetNetwork()];
+
+    // no proxy needed
+    if (!proxy.second)
+        return ConnectSocketDirectly(addrDest, hSocketRet, nTimeout);
+
     SOCKET hSocket = INVALID_SOCKET;
-    bool fProxy = (fUseProxy && addrDest.IsRoutable() && !vfNoProxy[addrDest.GetNetwork()]);
 
-    if (!ConnectSocketDirectly(fProxy ? addrProxy : addrDest, hSocket, nTimeout))
+    // first connect to proxy server
+    if (!ConnectSocketDirectly(proxy.first, hSocket, nTimeout))
         return false;
-
-    if (fProxy)
-    {
-        switch(nSocksVersion)
-        {
-            case 4:
-                if (!Socks4(addrDest, hSocket))
-                    return false;
-                break;
-
-            case 5:
-            default:
-                if (!Socks5(addrDest.ToStringIP(), addrDest.GetPort(), hSocket))
-                    return false;
-                break;
-        } 
+ 
+    // do socks negotiation
+    switch (proxy.second) {
+    case 4:
+        if (!Socks4(addrDest, hSocket))
+            return false;
+        break;
+    case 5:
+        if (!Socks5(addrDest.ToStringIP(), addrDest.GetPort(), hSocket))
+            return false;
+        break;
+    default:
+        return false;
     }
 
     hSocketRet = hSocket;
@@ -465,6 +499,7 @@ bool ConnectSocketByName(CService &addr, SOCKET& hSocketRet, const char *pszDest
     string strDest(pszDest);
     int port = portDefault;
 
+    // split hostname and port
     size_t colon = strDest.find_last_of(':');
     if (colon != strDest.npos) {
         char *endp = NULL;
@@ -479,26 +514,26 @@ bool ConnectSocketByName(CService &addr, SOCKET& hSocketRet, const char *pszDest
         strDest = strDest.substr(1, strDest.size()-2);
 
     SOCKET hSocket = INVALID_SOCKET;
-    CService addrResolved(CNetAddr(strDest, fNameLookup && !fProxyNameLookup), port);
+    CService addrResolved(CNetAddr(strDest, fNameLookup && !nameproxyInfo.second), port);
     if (addrResolved.IsValid()) {
         addr = addrResolved;
         return ConnectSocket(addr, hSocketRet, nTimeout);
     }
     addr = CService("0.0.0.0:0");
-    if (!fNameLookup)
+    if (!nameproxyInfo.second)
         return false;
-    if (!ConnectSocketDirectly(addrProxy, hSocket, nTimeout))
+    if (!ConnectSocketDirectly(nameproxyInfo.first, hSocket, nTimeout))
         return false;
 
-    switch(nSocksVersion)
-        {
-            case 4: return false;
-            case 5:
-            default:
-                if (!Socks5(strDest, port, hSocket))
-                    return false;
-                break;
-        }
+    switch(nameproxyInfo.second)
+    {
+        default:
+        case 4: return false;
+        case 5:
+            if (!Socks5(strDest, port, hSocket))
+                return false;
+            break;
+    }
 
     hSocketRet = hSocket;
     return true;

--- a/src/netbase.h
+++ b/src/netbase.h
@@ -28,8 +28,8 @@ enum Network
     NET_MAX
 };
 
-enum Network ParseNetwork(std::string net);
-void SetNoProxy(enum Network net, bool fNoProxy = true);
+extern int nConnectTimeout;
+extern bool fNameLookup;
 
 /** IP address (IPv6, or IPv4 using mapped IPv6 range (::FFFF:0:0/96)) */
 class CNetAddr
@@ -132,6 +132,12 @@ class CService : public CNetAddr
             )
 };
 
+enum Network ParseNetwork(std::string net);
+bool SetProxy(enum Network net, CService addrProxy, int nSocksVersion = 5);
+bool GetProxy(enum Network net, CService &addrProxy);
+bool IsProxy(const CNetAddr &addr);
+bool SetNameProxy(CService addrProxy, int nSocksVersion = 5);
+bool GetNameProxy();
 bool LookupHost(const char *pszName, std::vector<CNetAddr>& vIP, unsigned int nMaxSolutions = 0, bool fAllowLookup = true);
 bool LookupHostNumeric(const char *pszName, std::vector<CNetAddr>& vIP, unsigned int nMaxSolutions = 0);
 bool Lookup(const char *pszName, CService& addr, int portDefault = 0, bool fAllowLookup = true);
@@ -139,12 +145,5 @@ bool Lookup(const char *pszName, std::vector<CService>& vAddr, int portDefault =
 bool LookupNumeric(const char *pszName, CService& addr, int portDefault = 0);
 bool ConnectSocket(const CService &addr, SOCKET& hSocketRet, int nTimeout = nConnectTimeout);
 bool ConnectSocketByName(CService &addr, SOCKET& hSocketRet, const char *pszDest, int portDefault = 0, int nTimeout = nConnectTimeout);
-
-// Settings
-extern int nSocksVersion;
-extern int fUseProxy;
-extern bool fProxyNameLookup;
-extern bool fNameLookup;
-extern CService addrProxy;
 
 #endif

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -390,7 +390,7 @@ void NetworkOptionsPage::setMapper(MonitoredDataMapper *mapper)
 {
     // Map model to widgets
     mapper->addMapping(map_port_upnp, OptionsModel::MapPortUPnP);
-    mapper->addMapping(connect_socks4, OptionsModel::ConnectSOCKS4);
+    mapper->addMapping(connect_socks4, OptionsModel::ProxyUse);
     mapper->addMapping(proxy_ip, OptionsModel::ProxyIP);
     mapper->addMapping(proxy_port, OptionsModel::ProxyPort);
 }

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -20,7 +20,8 @@ public:
         MinimizeToTray, // bool
         MapPortUPnP, // bool
         MinimizeOnClose, // bool
-        ConnectSOCKS4, // bool
+        ProxyUse, // bool
+        ProxySocksVersion, // int
         ProxyIP, // QString
         ProxyPort, // QString
         Fee, // qint64


### PR DESCRIPTION
Rework network config settings according to the specification in https://gist.github.com/2763381.

The network base does no longer call GetArg directly. Instead, everything happens through a few globals and the SetProxy/SetNameProxy methods. These are called in init.cpp:AppInit2, and in Bitcoin-Qt's optionsmodel.cpp.
