### PR TITLE
makefile.unix: Default to linking against BDB 4.8 specifically

### DIFF
--- a/bitcoin-qt.pro
+++ b/bitcoin-qt.pro
@@ -290,7 +290,7 @@ isEmpty(BDB_LIB_PATH) {
 }
 
 isEmpty(BDB_LIB_SUFFIX) {
-    macx:BDB_LIB_SUFFIX = -4.8
+    BDB_LIB_SUFFIX = -4.8
 }
 
 isEmpty(BDB_INCLUDE_PATH) {

--- a/src/makefile.unix
+++ b/src/makefile.unix
@@ -22,6 +22,8 @@ else
 	TESTDEFS += -DBOOST_TEST_DYN_LINK
 endif
 
+BDB_LIB_SUFFIX = -4.8
+
 # for boost 1.37, add -mt to the boost libraries
 LIBS += \
  -Wl,-B$(LMODE) \


### PR DESCRIPTION
If someone wants to shoot themselves in the foot by linking to 5.0 or whatever, make them clear BDB_LIB_SUFFIX manually.
