### PR TITLE
Support pruning from txindex.dat.

### DIFF
--- a/src/checkpoints.cpp
+++ b/src/checkpoints.cpp
@@ -56,6 +56,13 @@ namespace Checkpoints
         return checkpoints.rbegin()->first;
     }
 
+    uint256 GetLastCheckpointHash()
+    {
+        MapCheckpoints& checkpoints = (fTestNet ? mapCheckpointsTestnet : mapCheckpoints);
+
+        return checkpoints.rbegin()->second;
+    }
+
     CBlockIndex* GetLastCheckpoint(const std::map<uint256, CBlockIndex*>& mapBlockIndex)
     {
         MapCheckpoints& checkpoints = (fTestNet ? mapCheckpointsTestnet : mapCheckpoints);

--- a/src/checkpoints.h
+++ b/src/checkpoints.h
@@ -20,6 +20,9 @@ namespace Checkpoints
     // Return conservative estimate of total number of blocks, 0 if unknown
     int GetTotalBlocksEstimate();
 
+    // Return the hash of the most recent checkpoint (with height GetTotalBlocksEstimate())
+    uint256 GetLastCheckpointHash();
+
     // Returns last CBlockIndex* in mapBlockIndex that is a checkpoint
     CBlockIndex* GetLastCheckpoint(const std::map<uint256, CBlockIndex*>& mapBlockIndex);
 }

--- a/src/db.h
+++ b/src/db.h
@@ -306,6 +306,7 @@ public:
     bool UpdateTxIndex(uint256 hash, const CTxIndex& txindex);
     bool AddTxIndex(const CTransaction& tx, const CDiskTxPos& pos, int nHeight);
     bool EraseTxIndex(const CTransaction& tx);
+    bool EraseTxIndex(uint256 hash);
     bool ContainsTx(uint256 hash);
     bool ReadOwnerTxes(uint160 hash160, int nHeight, std::vector<CTransaction>& vtx);
     bool ReadDiskTx(uint256 hash, CTransaction& tx, CTxIndex& txindex);
@@ -315,9 +316,12 @@ public:
     bool WriteBlockIndex(const CDiskBlockIndex& blockindex);
     bool ReadHashBestChain(uint256& hashBestChain);
     bool WriteHashBestChain(uint256 hashBestChain);
+    bool ReadHashBestCheckpoint(uint256& hashBestCheckpoint);
+    bool WriteHashBestCheckpoint(uint256 hashBestCheckpoint);
     bool ReadBestInvalidWork(CBigNum& bnBestInvalidWork);
     bool WriteBestInvalidWork(CBigNum bnBestInvalidWork);
     bool LoadBlockIndex();
+    bool PruneBlockIndex(uint256 hashPruneFrom, uint256 hashPruneTo);
 private:
     bool LoadBlockIndexGuts();
 };

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -676,6 +676,7 @@ bool AppInit2()
 
     if (mapArgs.count("-loadblock"))
     {
+        uiInterface.InitMessage(_("Importing additional blocks..."));
         BOOST_FOREACH(string strFile, mapMultiArgs["-loadblock"])
         {
             FILE *file = fopen(strFile.c_str(), "rb");


### PR DESCRIPTION
I did this to see how much it would actually prune, but, as it pruned just over half of the CTxIndexs in blkindex.dat, I thought I'd pull request it.
It only prunes up to the latest checkpoint as there is no undoing pruning, so chain reorgs cant undo transactions that have CTxIns that were pruned.

Note that the pruning process with -prune takes a _lot_ of time with -prune (an order of magnitude greater than loading chain on my tmpfs-backed system) and eats around 400MB of memory to load the needed information into memory.  -autoprune is much less resource-intensive, but the checkpoint has to exist before the given block is downloaded, so users upgrading will not be effected unless they use -prune once.

You can also run IBD with -autoprune to prune at each checkpoint.
