### PR TITLE
"USE_UPNP=-" is needed to remove UPnP support.

### DIFF
--- a/doc/build-unix.txt
+++ b/doc/build-unix.txt
@@ -33,7 +33,7 @@ Dependencies
 miniupnpc may be used for UPnP port mapping.  It can be downloaded from
 http://miniupnp.tuxfamily.org/files/.  UPnP support is compiled in and
 turned off by default.  Set USE_UPNP to a different value to control this:
- USE_UPNP=     No UPnP support - miniupnp not required
+ USE_UPNP=-    No UPnP support - miniupnp not required
  USE_UPNP=0    (the default) UPnP support turned off by default at runtime
  USE_UPNP=1    UPnP support turned on by default at runtime
 


### PR DESCRIPTION
The text file is wrong on how to build without UPNP support, as shown below:

```
$qmake USE_UPNP=
Project MESSAGE: Building with UPNP support

$ qmake USE_UPNP=-
Project MESSAGE: Building without UPNP support
```
