### PR TITLE
GUI: allow a clean Bitcoin-Qt shutdown

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -64,9 +64,14 @@ void Shutdown(void* parg)
         delete pwalletMain;
         CreateThread(ExitTimeout, NULL);
         Sleep(50);
-        printf("Bitcoin exited\n\n");
         fExit = true;
+// ensure a clean exit for Bitcoin-Qt
+#ifndef QT_GUI
+        printf("Bitcoin exited\n\n");
         exit(0);
+#else
+        uiInterface.QueueShutdown();
+#endif
     }
     else
     {

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -301,6 +301,7 @@ int main(int argc, char *argv[])
     } catch (...) {
         handleRunawayException(NULL);
     }
+    printf("Bitcoin-Qt exited\n\n");
     return 0;
 }
 #endif // BITCOIN_QT_TEST


### PR DESCRIPTION
When using Bitcoin-Qt don't call exit() in Shutdown(), to allow a clean exit for Bitcoin-Qt - this ensures the removal of the tray-icon (in BitcoinGUI destructor) after the core is shutdown.

On Windows the tray-icon was still visible after a shutdown, which could lead to many orphan icons in the tray that only disappeared after hovering them with the mouse. This is now fixed.
