### PR TITLE
fix default Proxy address in Qt options (no hostname allowed currently)

### DIFF
--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -148,7 +148,7 @@ QVariant OptionsModel::data(const QModelIndex & index, int role) const
             if (GetProxy(NET_IPV4, addrProxy))
                 return QVariant(QString::fromStdString(addrProxy.ToStringIP()));
             else
-                return QVariant(QString::fromStdString("localhost"));
+                return QVariant(QString::fromStdString("127.0.0.1"));
         }
         case ProxyPort: {
             CService addrProxy;


### PR DESCRIPTION
This small glitch was introduced with #1389 and get's fixed with this pull.

The options page needs a rework and it would be nice, if @sipa could open a small issue on Github, which explains what needs to be added there.
