### PR TITLE
GUI: init with correct display unit and update it, when user changes it via options dialog

### DIFF
--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -152,7 +152,7 @@ void OverviewPage::setNumTransactions(int count)
 void OverviewPage::setModel(WalletModel *model)
 {
     this->model = model;
-    if(model)
+    if(model && model->getOptionsModel())
     {
         // Set up transaction list
         filter = new TransactionFilterProxy();
@@ -172,19 +172,25 @@ void OverviewPage::setModel(WalletModel *model)
         setNumTransactions(model->getNumTransactions());
         connect(model, SIGNAL(numTransactionsChanged(int)), this, SLOT(setNumTransactions(int)));
 
-        connect(model->getOptionsModel(), SIGNAL(displayUnitChanged(int)), this, SLOT(displayUnitChanged()));
+        connect(model->getOptionsModel(), SIGNAL(displayUnitChanged(int)), this, SLOT(updateDisplayUnit()));
     }
+
+    // update the display unit, to not use the default ("BTC")
+    updateDisplayUnit();
 }
 
-void OverviewPage::displayUnitChanged()
+void OverviewPage::updateDisplayUnit()
 {
-    if(!model || !model->getOptionsModel())
-        return;
-    if(currentBalance != -1)
-        setBalance(currentBalance, currentUnconfirmedBalance, currentImmatureBalance);
+    if(model && model->getOptionsModel())
+    {
+        if(currentBalance != -1)
+            setBalance(currentBalance, currentUnconfirmedBalance, currentImmatureBalance);
 
-    txdelegate->unit = model->getOptionsModel()->getDisplayUnit();
-    ui->listTransactions->update();
+        // Update txdelegate->unit with the current unit
+        txdelegate->unit = model->getOptionsModel()->getDisplayUnit();
+
+        ui->listTransactions->update();
+    }
 }
 
 void OverviewPage::showOutOfSyncWarning(bool fShow)

--- a/src/qt/overviewpage.h
+++ b/src/qt/overviewpage.h
@@ -44,7 +44,7 @@ private:
     TransactionFilterProxy *filter;
 
 private slots:
-    void displayUnitChanged();
+    void updateDisplayUnit();
     void handleTransactionClicked(const QModelIndex &index);
 };
 

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -46,10 +46,11 @@ void SendCoinsDialog::setModel(WalletModel *model)
             entry->setModel(model);
         }
     }
-    if(model)
+    if(model && model->getOptionsModel())
     {
         setBalance(model->getBalance(), model->getUnconfirmedBalance(), model->getImmatureBalance());
         connect(model, SIGNAL(balanceChanged(qint64, qint64, qint64)), this, SLOT(setBalance(qint64, qint64, qint64)));
+        connect(model->getOptionsModel(), SIGNAL(displayUnitChanged(int)), this, SLOT(updateDisplayUnit()));
     }
 }
 
@@ -202,7 +203,7 @@ SendCoinsEntry *SendCoinsDialog::addEntry()
     ui->scrollAreaWidgetContents->resize(ui->scrollAreaWidgetContents->sizeHint());
     QCoreApplication::instance()->processEvents();
     QScrollBar* bar = ui->scrollArea->verticalScrollBar();
-    if (bar)
+    if(bar)
         bar->setSliderPosition(bar->maximum());
     return entry;
 }
@@ -245,7 +246,7 @@ QWidget *SendCoinsDialog::setupTabChain(QWidget *prev)
 
 void SendCoinsDialog::pasteEntry(const SendCoinsRecipient &rv)
 {
-    if (!fNewRecipientAllowed)
+    if(!fNewRecipientAllowed)
         return;
 
     SendCoinsEntry *entry = 0;
@@ -288,4 +289,13 @@ void SendCoinsDialog::setBalance(qint64 balance, qint64 unconfirmedBalance, qint
 
     int unit = model->getOptionsModel()->getDisplayUnit();
     ui->labelBalance->setText(BitcoinUnits::formatWithUnit(unit, balance));
+}
+
+void SendCoinsDialog::updateDisplayUnit()
+{
+    if(model && model->getOptionsModel())
+    {
+        // Update labelBalance with the current balance and the current unit
+        ui->labelBalance->setText(BitcoinUnits::formatWithUnit(model->getOptionsModel()->getDisplayUnit(), model->getBalance()));
+    }
 }

--- a/src/qt/sendcoinsdialog.h
+++ b/src/qt/sendcoinsdialog.h
@@ -47,8 +47,8 @@ private:
 
 private slots:
     void on_sendButton_clicked();
-
     void removeEntry(SendCoinsEntry* entry);
+    void updateDisplayUnit();
 };
 
 #endif // SENDCOINSDIALOG_H

--- a/src/qt/sendcoinsentry.cpp
+++ b/src/qt/sendcoinsentry.cpp
@@ -68,6 +68,10 @@ void SendCoinsEntry::on_payTo_textChanged(const QString &address)
 void SendCoinsEntry::setModel(WalletModel *model)
 {
     this->model = model;
+
+    if(model && model->getOptionsModel())
+        connect(model->getOptionsModel(), SIGNAL(displayUnitChanged(int)), this, SLOT(updateDisplayUnit()));
+
     clear();
 }
 
@@ -82,10 +86,8 @@ void SendCoinsEntry::clear()
     ui->addAsLabel->clear();
     ui->payAmount->clear();
     ui->payTo->setFocus();
-    if(model && model->getOptionsModel())
-    {
-        ui->payAmount->setDisplayUnit(model->getOptionsModel()->getDisplayUnit());
-    }
+    // update the display unit, to not use the default ("BTC")
+    updateDisplayUnit();
 }
 
 void SendCoinsEntry::on_deleteButton_clicked()
@@ -160,3 +162,11 @@ void SendCoinsEntry::setFocus()
     ui->payTo->setFocus();
 }
 
+void SendCoinsEntry::updateDisplayUnit()
+{
+    if(model && model->getOptionsModel())
+    {
+        // Update payAmount with the current unit
+        ui->payAmount->setDisplayUnit(model->getOptionsModel()->getDisplayUnit());
+    }
+}

--- a/src/qt/sendcoinsentry.h
+++ b/src/qt/sendcoinsentry.h
@@ -45,6 +45,7 @@ private slots:
     void on_payTo_textChanged(const QString &address);
     void on_addressBookButton_clicked();
     void on_pasteButton_clicked();
+    void updateDisplayUnit();
 
 private:
     Ui::SendCoinsEntry *ui;


### PR DESCRIPTION
- add the slot updateDisplayUnit() to overviewpage, sendcoinsdialog, sendcoinsentry and connect it to displayUnitChanged() - this ensures all fields in the GUI, who use a display unit are imediately updated, when the user changes this setting in the optionsdialog
- ensure used fields init with the current set display unit

This addresses / fixes #781 and #927.
