### PR TITLE
Windows URI Support

### DIFF
--- a/contrib/gitian-descriptors/boost-win32.yml
+++ b/contrib/gitian-descriptors/boost-win32.yml
@@ -11,12 +11,12 @@ packages:
 reference_datetime: "2011-01-30 00:00:00"
 remotes: []
 files:
-- "boost_1_47_0.tar.bz2"
+- "boost_1_49_0.tar.bz2"
 script: |
   TMPDIR="$HOME/tmpdir"
   mkdir -p $TMPDIR/bin/$GBUILD_BITS $TMPDIR/include
-  tar xjf boost_1_47_0.tar.bz2
-  cd boost_1_47_0
+  tar xjf boost_1_49_0.tar.bz2
+  cd boost_1_49_0
   echo "using gcc : 4.4 : i586-mingw32msvc-g++
         :
         <rc>i586-mingw32msvc-windres
@@ -34,5 +34,5 @@ script: |
   cd $TMPDIR
   export LD_PRELOAD=/usr/lib/faketime/libfaketime.so.1
   export FAKETIME=$REFERENCE_DATETIME
-  zip -r boost-win32-1.47.0-gitian.zip *
-  cp boost-win32-1.47.0-gitian.zip $OUTDIR
+  zip -r boost-win32-1.49.0-gitian.zip *
+  cp boost-win32-1.49.0-gitian.zip $OUTDIR

--- a/contrib/gitian-descriptors/boost-win32.yml
+++ b/contrib/gitian-descriptors/boost-win32.yml
@@ -17,6 +17,22 @@ script: |
   mkdir -p $TMPDIR/bin/$GBUILD_BITS $TMPDIR/include
   tar xjf boost_1_49_0.tar.bz2
   cd boost_1_49_0
+  echo "--- tmp_dir_helpers.orig.hpp	2012-06-10 01:39:25.403268210 +0200
++++ tmp_dir_helpers.hpp	2012-06-10 01:41:14.653823479 +0200
+@@ -19,9 +19,9 @@
+ #include <string>
+ 
+ #if defined(BOOST_INTERPROCESS_WINDOWS)
+-   //#define BOOST_INTERPROCESS_HAS_WINDOWS_KERNEL_BOOTTIME
+-   //#define BOOST_INTERPROCESS_HAS_KERNEL_BOOTTIME
+-   //#include <boost/interprocess/detail/win32_api.hpp>
++   #define BOOST_INTERPROCESS_HAS_WINDOWS_KERNEL_BOOTTIME
++   #define BOOST_INTERPROCESS_HAS_KERNEL_BOOTTIME
++   #include <boost/interprocess/detail/win32_api.hpp>
+ #elif defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__APPLE__)
+    //#include <sys/sysctl.h>
+    //#if defined(CTL_KERN) && defined (KERN_BOOTTIME)" > useboottime.patch
+  patch boost/interprocess/detail/tmp_dir_helpers.hpp useboottime.patch
   echo "using gcc : 4.4 : i586-mingw32msvc-g++
         :
         <rc>i586-mingw32msvc-windres
@@ -34,5 +50,5 @@ script: |
   cd $TMPDIR
   export LD_PRELOAD=/usr/lib/faketime/libfaketime.so.1
   export FAKETIME=$REFERENCE_DATETIME
-  zip -r boost-win32-1.49.0-gitian.zip *
-  cp boost-win32-1.49.0-gitian.zip $OUTDIR
+  zip -r boost-win32-1.49.0-gitian2.zip *
+  cp boost-win32-1.49.0-gitian2.zip $OUTDIR

--- a/contrib/gitian-descriptors/gitian-win32.yml
+++ b/contrib/gitian-descriptors/gitian-win32.yml
@@ -16,7 +16,7 @@ remotes:
   "dir": "bitcoin"
 files:
 - "qt-win32-4.7.4-gitian.zip"
-- "boost-win32-1.47.0-gitian.zip"
+- "boost-win32-1.49.0-gitian.zip"
 - "bitcoin-deps-0.0.4.zip"
 script: |
   #
@@ -26,10 +26,10 @@ script: |
   cd $HOME/build/
   export PATH=$PATH:$HOME/qt/bin/
   #
-  mkdir boost_1_47_0
-  cd boost_1_47_0
+  mkdir boost_1_49_0
+  cd boost_1_49_0
   mkdir -p stage/lib
-  unzip ../boost-win32-1.47.0-gitian.zip
+  unzip ../boost-win32-1.49.0-gitian.zip
   cd bin/$GBUILD_BITS
   for lib in *; do
     i586-mingw32msvc-ar rc ../../stage/lib/libboost_${lib}-mt-s.a $lib/*.o

--- a/contrib/gitian-descriptors/gitian-win32.yml
+++ b/contrib/gitian-descriptors/gitian-win32.yml
@@ -16,7 +16,7 @@ remotes:
   "dir": "bitcoin"
 files:
 - "qt-win32-4.7.4-gitian.zip"
-- "boost-win32-1.49.0-gitian.zip"
+- "boost-win32-1.49.0-gitian2.zip"
 - "bitcoin-deps-0.0.4.zip"
 script: |
   #
@@ -29,7 +29,7 @@ script: |
   mkdir boost_1_49_0
   cd boost_1_49_0
   mkdir -p stage/lib
-  unzip ../boost-win32-1.49.0-gitian.zip
+  unzip ../boost-win32-1.49.0-gitian2.zip
   cd bin/$GBUILD_BITS
   for lib in *; do
     i586-mingw32msvc-ar rc ../../stage/lib/libboost_${lib}-mt-s.a $lib/*.o

--- a/share/setup.nsi
+++ b/share/setup.nsi
@@ -98,12 +98,10 @@ Section -post SEC0001
     WriteRegStr HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$(^Name)" UninstallString $INSTDIR\uninstall.exe
     WriteRegDWORD HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$(^Name)" NoModify 1
     WriteRegDWORD HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$(^Name)" NoRepair 1
-
-    # bitcoin: URI handling disabled for 0.6.0
-    #    WriteRegStr HKCR "bitcoin" "URL Protocol" ""
-    #    WriteRegStr HKCR "bitcoin" "" "URL:Bitcoin"
-    #    WriteRegStr HKCR "bitcoin\DefaultIcon" "" $INSTDIR\bitcoin-qt.exe
-    #    WriteRegStr HKCR "bitcoin\shell\open\command" "" '"$INSTDIR\bitcoin-qt.exe" "$$1"'
+    WriteRegStr HKCR "bitcoin" "URL Protocol" ""
+    WriteRegStr HKCR "bitcoin" "" "URL:Bitcoin"
+    WriteRegStr HKCR "bitcoin\DefaultIcon" "" $INSTDIR\bitcoin-qt.exe
+    WriteRegStr HKCR "bitcoin\shell\open\command" "" '"$INSTDIR\bitcoin-qt.exe" "$$1"'
 SectionEnd
 
 # Macro for selecting uninstaller sections

--- a/src/makefile.linux-mingw
+++ b/src/makefile.linux-mingw
@@ -7,14 +7,14 @@ DEPSDIR:=/usr/i586-mingw32msvc
 USE_UPNP:=0
 
 INCLUDEPATHS= \
- -I"$(DEPSDIR)/boost_1_47_0" \
+ -I"$(DEPSDIR)/boost_1_49_0" \
  -I"$(DEPSDIR)/db-4.8.30.NC/build_unix" \
  -I"$(DEPSDIR)/openssl-1.0.1b/include" \
  -I"$(DEPSDIR)" \
  -I"$(CURDIR)"/obj \
 
 LIBPATHS= \
- -L"$(DEPSDIR)/boost_1_47_0/stage/lib" \
+ -L"$(DEPSDIR)/boost_1_49_0/stage/lib" \
  -L"$(DEPSDIR)/db-4.8.30.NC/build_unix" \
  -L"$(DEPSDIR)/openssl-1.0.1b"
 

--- a/src/makefile.mingw
+++ b/src/makefile.mingw
@@ -5,20 +5,20 @@
 USE_UPNP:=0
 
 INCLUDEPATHS= \
- -I"C:\boost-1.47.0-mgw" \
+ -I"C:\boost-1.49.0-mgw" \
  -I"C:\db-4.8.30.NC-mgw\build_unix" \
  -I"C:\openssl-1.0.0d-mgw\include"
 
 LIBPATHS= \
- -L"C:\boost-1.47.0-mgw\stage\lib" \
+ -L"C:\boost-1.49.0-mgw\stage\lib" \
  -L"C:\db-4.8.30.NC-mgw\build_unix" \
  -L"C:\openssl-1.0.0d-mgw"
 
 LIBS= \
- -l boost_system-mgw45-mt-s-1_47 \
- -l boost_filesystem-mgw45-mt-s-1_47 \
- -l boost_program_options-mgw45-mt-s-1_47 \
- -l boost_thread-mgw45-mt-s-1_47 \
+ -l boost_system-mgw45-mt-s-1_49 \
+ -l boost_filesystem-mgw45-mt-s-1_49 \
+ -l boost_program_options-mgw45-mt-s-1_49 \
+ -l boost_thread-mgw45-mt-s-1_49 \
  -l db_cxx \
  -l ssl \
  -l crypto

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -116,9 +116,6 @@ static void handleRunawayException(std::exception *e)
 #ifndef BITCOIN_QT_TEST
 int main(int argc, char *argv[])
 {
-#if !defined(MAC_OSX) && !defined(WIN32)
-// TODO: implement qtipcserver.cpp for Mac and Windows
-
     // Do this early as we don't want to bother initializing if we are just calling IPC
     for (int i = 1; i < argc; i++)
     {
@@ -137,7 +134,6 @@ int main(int argc, char *argv[])
             }
         }
     }
-#endif
 
     // Internal string conversion is all UTF-8
     QTextCodec::setCodecForTr(QTextCodec::codecForName("UTF-8"));
@@ -262,8 +258,6 @@ int main(int argc, char *argv[])
                 {
                     window.show();
                 }
-#if !defined(MAC_OSX) && !defined(WIN32)
-// TODO: implement qtipcserver.cpp for Mac and Windows
 
                 // Place this here as guiref has to be defined if we dont want to lose URIs
                 ipcInit();
@@ -282,7 +276,7 @@ int main(int argc, char *argv[])
                         }
                     }
                 }
-#endif
+
                 app.exec();
 
                 window.hide();

--- a/src/qt/qtipcserver.cpp
+++ b/src/qt/qtipcserver.cpp
@@ -6,6 +6,11 @@
 #include <boost/interprocess/ipc/message_queue.hpp>
 #include <boost/tokenizer.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
+#include <boost/version.hpp>
+
+#if defined(WIN32) && (!defined(BOOST_INTERPROCESS_HAS_WINDOWS_KERNEL_BOOTTIME) || !defined(BOOST_INTERPROCESS_HAS_KERNEL_BOOTTIME) || BOOST_VERSION < 104900)
+#warning Compiling without BOOST_INTERPROCESS_HAS_WINDOWS_KERNEL_BOOTTIME and BOOST_INTERPROCESS_HAS_KERNEL_BOOTTIME uncommented in boost/interprocess/detail/tmp_dir_helpers.hpp or using a boost version before 1.49 may have unintended results see svn.boost.org/trac/boost/ticket/5392
+#endif
 
 #include "ui_interface.h"
 #include "qtipcserver.h"

--- a/src/qt/qtipcserver.cpp
+++ b/src/qt/qtipcserver.cpp
@@ -54,12 +54,6 @@ void ipcInit()
     // TODO: implement bitcoin: URI handling the Mac Way
     return;
 #endif
-#ifdef WIN32
-    // TODO: THOROUGHLY test boost::interprocess fix,
-    // and make sure there are no Windows argument-handling exploitable
-    // problems.
-    return;
-#endif
 
     message_queue* mq;
     char strBuf[257];


### PR DESCRIPTION
This is a redo of #986, but is based on Boost 1.49 which fixed the underlying issue (mostly).
It also reverts 7b90edb5a6 to re-enable URI handling itself.
