### PR TITLE
change initial Balance on overviewpage from "123.456 BTC" to "0 BTC" to ...

### DIFF
--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -105,7 +105,7 @@
              <string>Your current balance</string>
             </property>
             <property name="text">
-             <string notr="true">123.456 BTC</string>
+             <string notr="true">0 BTC</string>
             </property>
             <property name="textInteractionFlags">
              <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>


### PR DESCRIPTION
...not confuse users, which could see it before we init with the real wallet balance

This was mentioned in IRC today, so let's just change it :).
