### PR TITLE
Do not select first address automatically in the address book

### DIFF
--- a/src/qt/addressbookpage.cpp
+++ b/src/qt/addressbookpage.cpp
@@ -136,11 +136,6 @@ void AddressBookPage::setModel(AddressTableModel *model)
     connect(model, SIGNAL(rowsInserted(QModelIndex,int,int)),
             this, SLOT(selectNewAddress(QModelIndex,int,int)));
 
-    if(mode == ForSending)
-    {
-        // Auto-select first row when in sending mode
-        ui->tableView->selectRow(0);
-    }
     selectionChanged();
 }
 


### PR DESCRIPTION
This contributed to an accidental send (#1384), and has no clear advantage, better to disable it.
