### PR TITLE
Cross-platform “Open debug logfile”

### DIFF
--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -241,11 +241,9 @@ void openDebugLogfile()
 {
     boost::filesystem::path pathDebug = GetDataDir() / "debug.log";
 
-#ifdef WIN32
+    /* Open debug.log with the associated application */
     if (boost::filesystem::exists(pathDebug))
-        /* Open debug.log with the associated application */
-        ShellExecuteA((HWND)0, (LPCSTR)"open", (LPCSTR)pathDebug.string().c_str(), NULL, NULL, SW_SHOWNORMAL);
-#endif
+        QDesktopServices::openUrl(QUrl::fromLocalFile(QString::fromStdString(pathDebug.string())));
 }
 
 ToolTipToRichTextFilter::ToolTipToRichTextFilter(int size_threshold, QObject *parent) :

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -114,12 +114,6 @@ RPCConsole::RPCConsole(QWidget *parent) :
     ui->showCLOptionsButton->setIcon(QIcon(":/icons/options"));
 #endif
 
-#ifndef WIN32
-    // Hide Debug logfile label and Open button for non Windows-OSes
-    ui->labelDebugLogfile->setVisible(false);
-    ui->openDebugLogfileButton->setVisible(false);
-#endif
-
     // Install event filter for up and down arrow
     ui->lineEdit->installEventFilter(this);
 


### PR DESCRIPTION
The option to open the debug logfile from the debug window was implemented only for
windows. By using `QDesktopServices::openUrl` it now works on any platform.
