### PR TITLE
GUI: make buttons in debug window non autoDefault

### DIFF
--- a/src/qt/forms/rpcconsole.ui
+++ b/src/qt/forms/rpcconsole.ui
@@ -301,6 +301,9 @@
          <property name="text">
           <string>&amp;Open</string>
          </property>
+         <property name="autoDefault">
+          <bool>false</bool>
+         </property>
         </widget>
        </item>
        <item row="15" column="0">
@@ -323,6 +326,9 @@
          </property>
          <property name="text">
           <string>&amp;Show</string>
+         </property>
+         <property name="autoDefault">
+          <bool>false</bool>
          </property>
         </widget>
        </item>


### PR DESCRIPTION
On Windows they are somehow shimmering, if they are autoDefault, which is not needed here.
