### PR TITLE
GUI: set cursor for balance field to IBeamCursor (to show the user it IS selectable)

### DIFF
--- a/src/qt/forms/sendcoinsdialog.ui
+++ b/src/qt/forms/sendcoinsdialog.ui
@@ -70,6 +70,9 @@
         <iconset resource="../bitcoin.qrc">
          <normaloff>:/icons/add</normaloff>:/icons/add</iconset>
        </property>
+       <property name="autoDefault">
+        <bool>false</bool>
+       </property>
       </widget>
      </item>
      <item>
@@ -93,6 +96,9 @@
        <property name="autoRepeatDelay">
         <number>300</number>
        </property>
+       <property name="autoDefault">
+        <bool>false</bool>
+       </property>
       </widget>
      </item>
      <item>
@@ -109,6 +115,9 @@
        </item>
        <item>
         <widget class="QLabel" name="labelBalance">
+         <property name="cursor">
+          <cursorShape>IBeamCursor</cursorShape>
+         </property>
          <property name="text">
           <string>123.456 BTC</string>
          </property>


### PR DESCRIPTION
- set autoDefault to false for the buttons that do not need this
