### PR TITLE
Introduce -tracenet option, thereby quieting some redundant debug messages

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -344,6 +344,13 @@ bool AppInit2()
     // ********************************************************* Step 3: parameter-to-internal-flags
 
     fDebug = GetBoolArg("-debug");
+
+    // -debug implies fDebug*
+    if (fDebug)
+        fDebugNet = true;
+    else
+        fDebugNet = GetBoolArg("-debugnet");
+
     bitdb.SetDetach(GetBoolArg("-detachdb", false));
 
 #if !defined(WIN32) && !defined(QT_GUI)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3142,7 +3142,8 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
             const CInv& inv = (*pto->mapAskFor.begin()).second;
             if (!AlreadyHave(txdb, inv))
             {
-                printf("sending getdata: %s\n", inv.ToString().c_str());
+                if (fDebugNet)
+                    printf("sending getdata: %s\n", inv.ToString().c_str());
                 vGetData.push_back(inv);
                 if (vGetData.size() >= 1000)
                 {

--- a/src/net.h
+++ b/src/net.h
@@ -296,7 +296,8 @@ public:
         // We're using mapAskFor as a priority queue,
         // the key is the earliest time the request can be sent
         int64& nRequestTime = mapAlreadyAskedFor[inv];
-        printf("askfor %s   %"PRI64d"\n", inv.ToString().c_str(), nRequestTime);
+        if (fDebugNet)
+            printf("askfor %s   %"PRI64d"\n", inv.ToString().c_str(), nRequestTime);
 
         // Make sure not to reuse time indexes to keep things in the same order
         int64 nNow = (GetTime() - 1) * 1000000;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -58,6 +58,7 @@ using namespace std;
 map<string, string> mapArgs;
 map<string, vector<string> > mapMultiArgs;
 bool fDebug = false;
+bool fDebugNet = false;
 bool fPrintToConsole = false;
 bool fPrintToDebugger = false;
 bool fRequestShutdown = false;

--- a/src/util.h
+++ b/src/util.h
@@ -105,6 +105,7 @@ inline void Sleep(int64 n)
 extern std::map<std::string, std::string> mapArgs;
 extern std::map<std::string, std::vector<std::string> > mapMultiArgs;
 extern bool fDebug;
+extern bool fDebugNet;
 extern bool fPrintToConsole;
 extern bool fPrintToDebugger;
 extern bool fRequestShutdown;


### PR DESCRIPTION
Prior to this change, each TX typically generated 3+ debug messages,

```
askfor tx 8644cc97480ba1537214   0
sending getdata: tx 8644cc97480ba1537214
askfor tx 8644cc97480ba1537214   1339640761000000
askfor tx 8644cc97480ba1537214   1339640881000000
CTxMemPool::accept() : accepted 8644cc9748 (poolsz 6857)
```

After this change, there is only one message for each valid TX received

```
CTxMemPool::accept() : accepted 22a73c5d8c (poolsz 42)
```

and two messages for each orphan tx received

```
ERROR: FetchInputs() : 673dc195aa mempool Tx prev not found 1e439346fc
stored orphan tx 673dc195aa (mapsz 19)
```

The -tracenet option, or its superset -debug, will restore the full debug
output.
