### PR TITLE
Show command line options as dialog when opened from debug window

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -212,7 +212,7 @@ int main(int argc, char *argv[])
     if (mapArgs.count("-?") || mapArgs.count("--help"))
     {
         GUIUtil::HelpMessageBox help;
-        help.exec();
+        help.showOrPrint();
         return 1;
     }
 

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -441,15 +441,21 @@ HelpMessageBox::HelpMessageBox(QWidget *parent) :
     setDetailedText(coreOptions + "\n" + uiOptions);
 }
 
-void HelpMessageBox::exec()
+void HelpMessageBox::printToConsole()
 {
-#if defined(WIN32)
-    // On windows, show a message box, as there is no stderr in windowed applications
-    QMessageBox::exec();
-#else
     // On other operating systems, the expected action is to print the message to the console.
     QString strUsage = header + "\n" + coreOptions + "\n" + uiOptions;
     fprintf(stderr, "%s", strUsage.toStdString().c_str());
+}
+
+void HelpMessageBox::showOrPrint()
+{
+#if defined(WIN32)
+        // On windows, show a message box, as there is no stderr/stdout in windowed applications
+        exec();
+#else
+        // On other operating systems, print help text to console
+        printToConsole();
 #endif
 }
 

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -103,7 +103,11 @@ namespace GUIUtil
     public:
         HelpMessageBox(QWidget *parent = 0);
 
-        void exec();
+        /** Show message box or print help message to standard output, based on operating system. */
+        void showOrPrint();
+
+        /** Print help message to console */
+        void printToConsole();
 
     private:
         QString header;


### PR DESCRIPTION
On Linux/Mac the command-line options were printed to stderr when the button was pressed in the debug window, resulting in confusion. This is fixed in this commit by adding a separate method.
