### PR TITLE
Use a 64-bit nonce in ping

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3013,8 +3013,9 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
         // Keep-alive ping. We send a nonce of zero because we don't use it anywhere
         // right now.
         if (pto->nLastSend && GetTime() - pto->nLastSend > 30 * 60 && pto->vSend.empty()) {
+            uint64 nonce = 0;
             if (pto->nVersion > BIP0031_VERSION)
-                pto->PushMessage("ping", 0);
+                pto->PushMessage("ping", nonce);
             else
                 pto->PushMessage("ping");
         }


### PR DESCRIPTION
Former code sent '0' as nonce, which was serialized as 32-bit.

Fixes #1455.
