### PR TITLE
Add "mempool" P2P command

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -652,8 +652,23 @@ bool CTxMemPool::remove(CTransaction &tx)
     return true;
 }
 
+void CTxMemPool::fillInv(std::vector<CInv> &vInv, unsigned int max_inv)
+{
+    LOCK(cs);
 
+    for (map<uint256, CTransaction>::iterator mi = mempool.mapTx.begin(); mi != mempool.mapTx.end(); ++mi)
+    {
+        CTransaction& tx = (*mi).second;
 
+        {
+            CInv inv(MSG_TX, tx.GetHash());
+            vInv.push_back(inv);
+        }
+
+        if (vInv.size() >= max_inv)
+            return;
+    }
+}
 
 
 
@@ -2866,6 +2881,14 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
                     alert.RelayTo(pnode);
             }
         }
+    }
+
+
+    else if (strCommand == "mempool")
+    {
+        vector<CInv> vInv;
+        mempool.fillInv(vInv, 49999);
+        pfrom->PushMessage("inv", vInv);
     }
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -656,7 +656,7 @@ void CTxMemPool::fillInv(std::vector<CInv> &vInv, unsigned int max_inv)
 {
     LOCK(cs);
 
-    for (map<uint256, CTransaction>::iterator mi = mempool.mapTx.begin(); mi != mempool.mapTx.end(); ++mi)
+    for (map<uint256, CTransaction>::iterator mi = mapTx.begin(); mi != mapTx.end(); ++mi)
     {
         CTransaction& tx = (*mi).second;
 

--- a/src/main.h
+++ b/src/main.h
@@ -1604,6 +1604,7 @@ public:
                 bool fCheckInputs, bool* pfMissingInputs);
     bool addUnchecked(CTransaction &tx);
     bool remove(CTransaction &tx);
+    void fillInv(std::vector<CInv> &vInv, unsigned int max_inv);
 
     unsigned long size()
     {


### PR DESCRIPTION
This adds the "mempool" P2P command, which returns the first 50,000 entries in the TX memory pool (CInv vectors are capped at 50,000 already).  SPV clients and other nodes may use this command following a block sync-up, to ensure they have the latest snapshot of the collective network.
