### PR TITLE
GUI: fix immature display in GUI / add balance updates on block change

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -357,6 +357,8 @@ void BitcoinGUI::setClientModel(ClientModel *clientModel)
         connect(clientModel, SIGNAL(error(QString,QString,bool)), this, SLOT(error(QString,QString,bool)));
 
         rpcConsole->setClientModel(clientModel);
+        overviewPage->setClientModel(clientModel);
+        sendCoinsPage->setClientModel(clientModel);
     }
 }
 
@@ -371,10 +373,10 @@ void BitcoinGUI::setWalletModel(WalletModel *walletModel)
         // Put transaction list in tabs
         transactionView->setModel(walletModel);
 
-        overviewPage->setModel(walletModel);
+        overviewPage->setWalletModel(walletModel);
         addressBookPage->setModel(walletModel->getAddressTableModel());
         receiveCoinsPage->setModel(walletModel->getAddressTableModel());
-        sendCoinsPage->setModel(walletModel);
+        sendCoinsPage->setWalletModel(walletModel);
         messagePage->setModel(walletModel);
 
         setEncryptionStatus(walletModel->getEncryptionStatus());

--- a/src/qt/overviewpage.h
+++ b/src/qt/overviewpage.h
@@ -11,6 +11,7 @@ namespace Ui {
     class OverviewPage;
 }
 class WalletModel;
+class ClientModel;
 class TxViewDelegate;
 class TransactionFilterProxy;
 
@@ -23,7 +24,8 @@ public:
     explicit OverviewPage(QWidget *parent = 0);
     ~OverviewPage();
 
-    void setModel(WalletModel *model);
+    void setWalletModel(WalletModel *model);
+    void setClientModel(ClientModel *model);
     void showOutOfSyncWarning(bool fShow);
 
 public slots:
@@ -35,7 +37,8 @@ signals:
 
 private:
     Ui::OverviewPage *ui;
-    WalletModel *model;
+    WalletModel *walletModel;
+    ClientModel *clientModel;
     qint64 currentBalance;
     qint64 currentUnconfirmedBalance;
     qint64 currentImmatureBalance;
@@ -46,6 +49,7 @@ private:
 private slots:
     void displayUnitChanged();
     void handleTransactionClicked(const QModelIndex &index);
+    void updateBalance();
 };
 
 #endif // OVERVIEWPAGE_H

--- a/src/qt/sendcoinsdialog.h
+++ b/src/qt/sendcoinsdialog.h
@@ -7,6 +7,7 @@ namespace Ui {
     class SendCoinsDialog;
 }
 class WalletModel;
+class ClientModel;
 class SendCoinsEntry;
 class SendCoinsRecipient;
 
@@ -23,7 +24,8 @@ public:
     explicit SendCoinsDialog(QWidget *parent = 0);
     ~SendCoinsDialog();
 
-    void setModel(WalletModel *model);
+    void setWalletModel(WalletModel *model);
+    void setClientModel(ClientModel *model);
 
     /** Set up the tab chain manually, as Qt messes up the tab chain by default in some cases (issue http://bugreports.qt.nokia.com/browse/QTBUG-10907).
      */
@@ -42,13 +44,15 @@ public slots:
 
 private:
     Ui::SendCoinsDialog *ui;
-    WalletModel *model;
+    WalletModel *walletModel;
+    ClientModel *clientModel;
     bool fNewRecipientAllowed;
 
 private slots:
     void on_sendButton_clicked();
 
     void removeEntry(SendCoinsEntry* entry);
+    void updateBalance();
 };
 
 #endif // SENDCOINSDIALOG_H

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -74,15 +74,20 @@ void WalletModel::updateTransaction(const QString &hash, int status)
     int newNumTransactions = getNumTransactions();
 
     if(cachedBalance != newBalance || cachedUnconfirmedBalance != newUnconfirmedBalance || cachedImmatureBalance != newImmatureBalance)
+    {
+        cachedBalance = newBalance;
+        cachedUnconfirmedBalance = newUnconfirmedBalance;
+        cachedImmatureBalance = newImmatureBalance;
+
         emit balanceChanged(newBalance, newUnconfirmedBalance, newImmatureBalance);
+    }
 
     if(cachedNumTransactions != newNumTransactions)
-        emit numTransactionsChanged(newNumTransactions);
+    {
+        cachedNumTransactions = newNumTransactions;
 
-    cachedBalance = newBalance;
-    cachedUnconfirmedBalance = newUnconfirmedBalance;
-    cachedImmatureBalance = newImmatureBalance;
-    cachedNumTransactions = newNumTransactions;
+        emit numTransactionsChanged(newNumTransactions);
+    }
 }
 
 void WalletModel::updateAddressBook(const QString &address, const QString &label, bool isMine, int status)

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -890,9 +890,8 @@ int64 CWallet::GetImmatureBalance() const
         LOCK(cs_wallet);
         for (map<uint256, CWalletTx>::const_iterator it = mapWallet.begin(); it != mapWallet.end(); ++it)
         {
-            const CWalletTx& pcoin = (*it).second;
-            if (pcoin.IsCoinBase() && pcoin.GetBlocksToMaturity() > 0 && pcoin.GetDepthInMainChain() >= 2)
-                nTotal += GetCredit(pcoin);
+            const CWalletTx* pcoin = &(*it).second;
+            nTotal += pcoin->GetImmatureCredit();
         }
     }
     return nTotal;

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -325,10 +325,12 @@ public:
     // memory only
     mutable bool fDebitCached;
     mutable bool fCreditCached;
+    mutable bool fImmatureCreditCached;
     mutable bool fAvailableCreditCached;
     mutable bool fChangeCached;
     mutable int64 nDebitCached;
     mutable int64 nCreditCached;
+    mutable int64 nImmatureCreditCached;
     mutable int64 nAvailableCreditCached;
     mutable int64 nChangeCached;
 
@@ -365,10 +367,12 @@ public:
         vfSpent.clear();
         fDebitCached = false;
         fCreditCached = false;
+        fImmatureCreditCached = false;
         fAvailableCreditCached = false;
         fChangeCached = false;
         nDebitCached = 0;
         nCreditCached = 0;
+        nImmatureCreditCached = 0;
         nAvailableCreditCached = 0;
         nChangeCached = 0;
     }
@@ -498,6 +502,20 @@ public:
         nCreditCached = pwallet->GetCredit(*this);
         fCreditCached = true;
         return nCreditCached;
+    }
+
+    int64 GetImmatureCredit(bool fUseCache=true) const
+    {
+        if (IsCoinBase() && GetBlocksToMaturity() > 0 && IsInMainChain())
+        {
+            if (fUseCache && fImmatureCreditCached)
+                return nImmatureCreditCached;
+            nImmatureCreditCached = pwallet->GetCredit(*this);
+            fImmatureCreditCached = true;
+            return nImmatureCreditCached;
+        }
+
+        return 0;
     }
 
     int64 GetAvailableCredit(bool fUseCache=true) const


### PR DESCRIPTION
As no one responds in #1432, I decided to create a pull for further discussion!
- add GetImmatureCredit() function in CWalletTx
- include clientModel in overviewpage and sendcoinsdialog
- rename model to walletModel in overviewpage and sendcoinsdialog
- update displayed balances when numBlocksChanged() SIGNAL occurs (as
  an immature balance matures via new blocks and not new Tx) on
  overviewpage and sendcoinsdialog
- optimize handling of cached balances in walletmodell
