### PR TITLE
Fix inverted logic for !Discover/!UPNP when !Listen.

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -344,7 +344,7 @@ bool AppInit2()
         SoftSetBoolArg("-listen", false);
     }
 
-    if (GetBoolArg("-listen", true)) {
+    if (!GetBoolArg("-listen", true)) {
         // do not map ports or try to retrieve public IP when not listening (pointless)
         SoftSetBoolArg("-upnp", false);
         SoftSetBoolArg("-discover", false);


### PR DESCRIPTION
The code which soft disabled address discovery/upnp when not listening was instead disabling it when listening.
