### PR TITLE
Small logical error in mruset

### DIFF
--- a/src/mruset.h
+++ b/src/mruset.h
@@ -51,7 +51,7 @@ public:
     size_type max_size(size_type s)
     {
         if (s)
-            while (queue.size() >= s)
+            while (queue.size() > s)
             {
                 set.erase(queue.front());
                 queue.pop_front();


### PR DESCRIPTION
As written if you make a new_size(10) the mruset will be reduced to up to 9 elements (the while will exit when !(queue.size() >= 10)  so (queue.size() < 10).

This "feature" of reducing the mruset length isn't used, so the impact on the program should be zero.
