### PR TITLE
CTxMemPool: encapsulate map[Next]Tx, by adding method copyFinal()

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -1595,15 +1595,18 @@ public:
 
 class CTxMemPool
 {
-public:
-    mutable CCriticalSection cs;
+private:
     std::map<uint256, CTransaction> mapTx;
     std::map<COutPoint, CInPoint> mapNextTx;
+
+public:
+    mutable CCriticalSection cs;
 
     bool accept(CTxDB& txdb, CTransaction &tx,
                 bool fCheckInputs, bool* pfMissingInputs);
     bool addUnchecked(CTransaction &tx);
     bool remove(CTransaction &tx);
+    void copyFinal(std::vector<CTransaction> &vtx);
 
     unsigned long size()
     {


### PR DESCRIPTION
This [re]moves a lock and a direct mempool.mapTx access, by copying
the TX memory pool contents into a temporary vector, for use when
building a new block inside CreateNewBlock().

In addition to holding CTxMemPool::cs for a shorter amount of time,
this makes it easier to parallelize CreateNewBlock() -- something
already done in widely circulating miner-pool patches.

The cost: memcopying the TX memory pool at each CreateNewBlock()
invocation (each getwork / getmemorypool new-work request).
