### PR TITLE
RPC: lock push-down, preparing for parallelization opportunities

### DIFF
--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -416,6 +416,8 @@ string CRPCTable::help(string strCommand) const
 
 Value help(const Array& params, bool fHelp)
 {
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
     if (fHelp || params.size() > 1)
         throw runtime_error(
             "help [command]\n"
@@ -431,6 +433,8 @@ Value help(const Array& params, bool fHelp)
 
 Value stop(const Array& params, bool fHelp)
 {
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
     if (fHelp || params.size() != 0)
         throw runtime_error(
             "stop\n"
@@ -443,6 +447,8 @@ Value stop(const Array& params, bool fHelp)
 
 Value getblockcount(const Array& params, bool fHelp)
 {
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
     if (fHelp || params.size() != 0)
         throw runtime_error(
             "getblockcount\n"
@@ -454,6 +460,8 @@ Value getblockcount(const Array& params, bool fHelp)
 
 Value getconnectioncount(const Array& params, bool fHelp)
 {
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
     if (fHelp || params.size() != 0)
         throw runtime_error(
             "getconnectioncount\n"
@@ -465,6 +473,8 @@ Value getconnectioncount(const Array& params, bool fHelp)
 
 Value getdifficulty(const Array& params, bool fHelp)
 {
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
     if (fHelp || params.size() != 0)
         throw runtime_error(
             "getdifficulty\n"
@@ -476,6 +486,8 @@ Value getdifficulty(const Array& params, bool fHelp)
 
 Value getgenerate(const Array& params, bool fHelp)
 {
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
     if (fHelp || params.size() != 0)
         throw runtime_error(
             "getgenerate\n"
@@ -487,6 +499,8 @@ Value getgenerate(const Array& params, bool fHelp)
 
 Value setgenerate(const Array& params, bool fHelp)
 {
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
     if (fHelp || params.size() < 1 || params.size() > 2)
         throw runtime_error(
             "setgenerate <generate> [genproclimit]\n"
@@ -513,6 +527,8 @@ Value setgenerate(const Array& params, bool fHelp)
 
 Value gethashespersec(const Array& params, bool fHelp)
 {
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
     if (fHelp || params.size() != 0)
         throw runtime_error(
             "gethashespersec\n"
@@ -526,6 +542,8 @@ Value gethashespersec(const Array& params, bool fHelp)
 
 Value getinfo(const Array& params, bool fHelp)
 {
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
     if (fHelp || params.size() != 0)
         throw runtime_error(
             "getinfo\n"
@@ -556,6 +574,8 @@ Value getinfo(const Array& params, bool fHelp)
 
 Value getmininginfo(const Array& params, bool fHelp)
 {
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
     if (fHelp || params.size() != 0)
         throw runtime_error(
             "getmininginfo\n"
@@ -578,6 +598,8 @@ Value getmininginfo(const Array& params, bool fHelp)
 
 Value getnewaddress(const Array& params, bool fHelp)
 {
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
     if (fHelp || params.size() > 1)
         throw runtime_error(
             "getnewaddress [account]\n"
@@ -645,6 +667,8 @@ CBitcoinAddress GetAccountAddress(string strAccount, bool bForceNew=false)
 
 Value getaccountaddress(const Array& params, bool fHelp)
 {
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
     if (fHelp || params.size() != 1)
         throw runtime_error(
             "getaccountaddress <account>\n"
@@ -664,6 +688,8 @@ Value getaccountaddress(const Array& params, bool fHelp)
 
 Value setaccount(const Array& params, bool fHelp)
 {
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
     if (fHelp || params.size() < 1 || params.size() > 2)
         throw runtime_error(
             "setaccount <bitcoinaddress> <account>\n"
@@ -694,6 +720,8 @@ Value setaccount(const Array& params, bool fHelp)
 
 Value getaccount(const Array& params, bool fHelp)
 {
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
     if (fHelp || params.size() != 1)
         throw runtime_error(
             "getaccount <bitcoinaddress>\n"
@@ -713,6 +741,8 @@ Value getaccount(const Array& params, bool fHelp)
 
 Value getaddressesbyaccount(const Array& params, bool fHelp)
 {
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
     if (fHelp || params.size() != 1)
         throw runtime_error(
             "getaddressesbyaccount <account>\n"
@@ -734,6 +764,8 @@ Value getaddressesbyaccount(const Array& params, bool fHelp)
 
 Value settxfee(const Array& params, bool fHelp)
 {
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
     if (fHelp || params.size() < 1 || params.size() > 1)
         throw runtime_error(
             "settxfee <amount>\n"
@@ -750,6 +782,8 @@ Value settxfee(const Array& params, bool fHelp)
 
 Value sendtoaddress(const Array& params, bool fHelp)
 {
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
     if (fHelp || params.size() < 2 || params.size() > 4)
         throw runtime_error(
             "sendtoaddress <bitcoinaddress> <amount> [comment] [comment-to]\n"
@@ -782,6 +816,8 @@ Value sendtoaddress(const Array& params, bool fHelp)
 
 Value signmessage(const Array& params, bool fHelp)
 {
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
     if (fHelp || params.size() != 2)
         throw runtime_error(
             "signmessage <bitcoinaddress> <message>\n"
@@ -817,6 +853,8 @@ Value signmessage(const Array& params, bool fHelp)
 
 Value verifymessage(const Array& params, bool fHelp)
 {
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
     if (fHelp || params.size() != 3)
         throw runtime_error(
             "verifymessage <bitcoinaddress> <signature> <message>\n"
@@ -854,6 +892,8 @@ Value verifymessage(const Array& params, bool fHelp)
 
 Value getreceivedbyaddress(const Array& params, bool fHelp)
 {
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
     if (fHelp || params.size() < 1 || params.size() > 2)
         throw runtime_error(
             "getreceivedbyaddress <bitcoinaddress> [minconf=1]\n"
@@ -904,6 +944,8 @@ void GetAccountAddresses(string strAccount, set<CTxDestination>& setAddress)
 
 Value getreceivedbyaccount(const Array& params, bool fHelp)
 {
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
     if (fHelp || params.size() < 1 || params.size() > 2)
         throw runtime_error(
             "getreceivedbyaccount <account> [minconf=1]\n"
@@ -974,6 +1016,8 @@ int64 GetAccountBalance(const string& strAccount, int nMinDepth)
 
 Value getbalance(const Array& params, bool fHelp)
 {
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
     if (fHelp || params.size() > 2)
         throw runtime_error(
             "getbalance [account] [minconf=1]\n"
@@ -1027,6 +1071,8 @@ Value getbalance(const Array& params, bool fHelp)
 
 Value movecmd(const Array& params, bool fHelp)
 {
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
     if (fHelp || params.size() < 3 || params.size() > 5)
         throw runtime_error(
             "move <fromaccount> <toaccount> <amount> [minconf=1] [comment]\n"
@@ -1075,6 +1121,8 @@ Value movecmd(const Array& params, bool fHelp)
 
 Value sendfrom(const Array& params, bool fHelp)
 {
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
     if (fHelp || params.size() < 3 || params.size() > 6)
         throw runtime_error(
             "sendfrom <fromaccount> <tobitcoinaddress> <amount> [minconf=1] [comment] [comment-to]\n"
@@ -1115,6 +1163,8 @@ Value sendfrom(const Array& params, bool fHelp)
 
 Value sendmany(const Array& params, bool fHelp)
 {
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
     if (fHelp || params.size() < 2 || params.size() > 4)
         throw runtime_error(
             "sendmany <fromaccount> {address:amount,...} [minconf=1] [comment]\n"
@@ -1179,6 +1229,8 @@ Value sendmany(const Array& params, bool fHelp)
 
 Value addmultisigaddress(const Array& params, bool fHelp)
 {
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
     if (fHelp || params.size() < 2 || params.size() > 3)
     {
         string msg = "addmultisigaddress <nrequired> <'[\"key\",\"key\"]'> [account]\n"
@@ -1350,6 +1402,8 @@ Value ListReceived(const Array& params, bool fByAccounts)
 
 Value listreceivedbyaddress(const Array& params, bool fHelp)
 {
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
     if (fHelp || params.size() > 2)
         throw runtime_error(
             "listreceivedbyaddress [minconf=1] [includeempty=false]\n"
@@ -1366,6 +1420,8 @@ Value listreceivedbyaddress(const Array& params, bool fHelp)
 
 Value listreceivedbyaccount(const Array& params, bool fHelp)
 {
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
     if (fHelp || params.size() > 2)
         throw runtime_error(
             "listreceivedbyaccount [minconf=1] [includeempty=false]\n"
@@ -1469,6 +1525,8 @@ void AcentryToJSON(const CAccountingEntry& acentry, const string& strAccount, Ar
 
 Value listtransactions(const Array& params, bool fHelp)
 {
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
     if (fHelp || params.size() > 3)
         throw runtime_error(
             "listtransactions [account] [count=10] [from=0]\n"
@@ -1544,6 +1602,8 @@ Value listtransactions(const Array& params, bool fHelp)
 
 Value listaccounts(const Array& params, bool fHelp)
 {
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
     if (fHelp || params.size() > 1)
         throw runtime_error(
             "listaccounts [minconf=1]\n"
@@ -1595,6 +1655,8 @@ Value listaccounts(const Array& params, bool fHelp)
 
 Value listsinceblock(const Array& params, bool fHelp)
 {
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
     if (fHelp)
         throw runtime_error(
             "listsinceblock [blockhash] [target-confirmations]\n"
@@ -1716,6 +1778,8 @@ AnyTxToJSON(const uint256 hash, const CTransaction* ptx, Object& entry, const Ob
 
 Value gettransaction(const Array& params, bool fHelp)
 {
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
     if (fHelp || params.size() < 1 || params.size() > 2)
         throw runtime_error(
             "gettransaction <txid> [decompositions]\n"
@@ -1735,6 +1799,8 @@ Value gettransaction(const Array& params, bool fHelp)
 
 Value backupwallet(const Array& params, bool fHelp)
 {
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
     if (fHelp || params.size() != 1)
         throw runtime_error(
             "backupwallet <destination>\n"
@@ -1749,6 +1815,8 @@ Value backupwallet(const Array& params, bool fHelp)
 
 Value keypoolrefill(const Array& params, bool fHelp)
 {
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
     if (fHelp || params.size() > 0)
         throw runtime_error(
             "keypoolrefill\n"
@@ -1814,6 +1882,8 @@ void ThreadCleanWalletPassphrase(void* parg)
 
 Value walletpassphrase(const Array& params, bool fHelp)
 {
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
     if (pwalletMain->IsCrypted() && (fHelp || params.size() != 2))
         throw runtime_error(
             "walletpassphrase <passphrase> <timeout>\n"
@@ -1853,6 +1923,8 @@ Value walletpassphrase(const Array& params, bool fHelp)
 
 Value walletpassphrasechange(const Array& params, bool fHelp)
 {
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
     if (pwalletMain->IsCrypted() && (fHelp || params.size() != 2))
         throw runtime_error(
             "walletpassphrasechange <oldpassphrase> <newpassphrase>\n"
@@ -1886,6 +1958,8 @@ Value walletpassphrasechange(const Array& params, bool fHelp)
 
 Value walletlock(const Array& params, bool fHelp)
 {
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
     if (pwalletMain->IsCrypted() && (fHelp || params.size() != 0))
         throw runtime_error(
             "walletlock\n"
@@ -1909,6 +1983,8 @@ Value walletlock(const Array& params, bool fHelp)
 
 Value encryptwallet(const Array& params, bool fHelp)
 {
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
     if (!pwalletMain->IsCrypted() && (fHelp || params.size() != 1))
         throw runtime_error(
             "encryptwallet <passphrase>\n"
@@ -1976,6 +2052,8 @@ public:
 
 Value validateaddress(const Array& params, bool fHelp)
 {
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
     if (fHelp || params.size() != 1)
         throw runtime_error(
             "validateaddress <bitcoinaddress>\n"
@@ -2005,6 +2083,8 @@ Value validateaddress(const Array& params, bool fHelp)
 
 Value getwork(const Array& params, bool fHelp)
 {
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
     if (fHelp || params.size() > 1)
         throw runtime_error(
             "getwork [data]\n"
@@ -2110,6 +2190,8 @@ Value getwork(const Array& params, bool fHelp)
 
 Value getmemorypool(const Array& params, bool fHelp)
 {
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
     if (fHelp || params.size() > 1)
         throw runtime_error(
             "getmemorypool [data]\n"
@@ -2196,6 +2278,8 @@ Value getmemorypool(const Array& params, bool fHelp)
 
 Value getblockhash(const Array& params, bool fHelp)
 {
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
     if (fHelp || params.size() != 1)
         throw runtime_error(
             "getblockhash <index>\n"
@@ -2214,6 +2298,8 @@ Value getblockhash(const Array& params, bool fHelp)
 
 Value getblock(const Array& params, bool fHelp)
 {
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
     if (fHelp || params.size() < 1 || params.size() > 2)
         throw runtime_error(
             "getblock <hash> [decompositions]\n"
@@ -2235,6 +2321,8 @@ Value getblock(const Array& params, bool fHelp)
 
 Value sendrawtx(const Array& params, bool fHelp)
 {
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
     if (fHelp || params.size() < 1 || params.size() > 1)
         throw runtime_error(
             "sendrawtx <hex string>\n"
@@ -2872,12 +2960,7 @@ json_spirit::Value CRPCTable::execute(const std::string &strMethod, const json_s
     try
     {
         // Execute
-        Value result;
-        {
-            LOCK2(cs_main, pwalletMain->cs_wallet);
-            result = pcmd->actor(params, false);
-        }
-        return result;
+        return pcmd->actor(params, false);
     }
     catch (std::exception& e)
     {

--- a/src/rpcdump.cpp
+++ b/src/rpcdump.cpp
@@ -34,8 +34,6 @@ public:
 
 Value importprivkey(const Array& params, bool fHelp)
 {
-    LOCK2(cs_main, pwalletMain->cs_wallet);
-
     if (fHelp || params.size() < 1 || params.size() > 2)
         throw runtime_error(
             "importprivkey <bitcoinprivkey> [label]\n"
@@ -49,6 +47,8 @@ Value importprivkey(const Array& params, bool fHelp)
     bool fGood = vchSecret.SetString(strSecret);
 
     if (!fGood) throw JSONRPCError(-5,"Invalid private key");
+
+    LOCK2(cs_main, pwalletMain->cs_wallet);
 
     CKey key;
     bool fCompressed;
@@ -73,12 +73,12 @@ Value importprivkey(const Array& params, bool fHelp)
 
 Value dumpprivkey(const Array& params, bool fHelp)
 {
-    LOCK2(cs_main, pwalletMain->cs_wallet);
-
     if (fHelp || params.size() != 1)
         throw runtime_error(
             "dumpprivkey <bitcoinaddress>\n"
             "Reveals the private key corresponding to <bitcoinaddress>.");
+
+    LOCK2(cs_main, pwalletMain->cs_wallet);
 
     string strAddress = params[0].get_str();
     CBitcoinAddress address;

--- a/src/rpcdump.cpp
+++ b/src/rpcdump.cpp
@@ -34,6 +34,8 @@ public:
 
 Value importprivkey(const Array& params, bool fHelp)
 {
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
     if (fHelp || params.size() < 1 || params.size() > 2)
         throw runtime_error(
             "importprivkey <bitcoinprivkey> [label]\n"
@@ -71,6 +73,8 @@ Value importprivkey(const Array& params, bool fHelp)
 
 Value dumpprivkey(const Array& params, bool fHelp)
 {
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
     if (fHelp || params.size() != 1)
         throw runtime_error(
             "dumpprivkey <bitcoinaddress>\n"


### PR DESCRIPTION
As an alternative to req #1493, this set of commits pushes the lock down into each RPC function itself.

From there, locking may be improved on a case-by-case basis.
