### PR TITLE
fix a memory leak in key.cpp

### DIFF
--- a/src/key.cpp
+++ b/src/key.cpp
@@ -129,6 +129,8 @@ void CKey::SetCompressedPubKey()
 void CKey::Reset()
 {
     fCompressedPubKey = false;
+    if (pkey != NULL)
+        EC_KEY_free(pkey);
     pkey = EC_KEY_new_by_curve_name(NID_secp256k1);
     if (pkey == NULL)
         throw key_error("CKey::CKey() : EC_KEY_new_by_curve_name failed");
@@ -137,6 +139,7 @@ void CKey::Reset()
 
 CKey::CKey()
 {
+    pkey = NULL;
     Reset();
 }
 


### PR DESCRIPTION
- add EC_KEY_free() in CKey::Reset() when pkey != NULL
- init pkey with NULL in CKey constructor

Fix for #1474
