### PR TITLE
= instead of == in multisig_tests.cpp

### DIFF
--- a/src/test/multisig_tests.cpp
+++ b/src/test/multisig_tests.cpp
@@ -235,7 +235,7 @@ BOOST_AUTO_TEST_CASE(multisig_Solver1)
         BOOST_CHECK(ExtractDestinations(s, whichType, addrs, nRequired));
         BOOST_CHECK(addrs[0] == keyaddr[0]);
         BOOST_CHECK(addrs[1] == keyaddr[1]);
-        BOOST_CHECK(nRequired = 1);
+        BOOST_CHECK(nRequired == 1);
         BOOST_CHECK(IsMine(keystore, s));
         BOOST_CHECK(!IsMine(emptykeystore, s));
         BOOST_CHECK(!IsMine(partialkeystore, s));


### PR DESCRIPTION
I don't have a C++ environment to test it, but I'm quite sure it should be ==.
