### PR TITLE
CBigNum: Convert negative int64 values in a more well-defined way

### DIFF
--- a/src/bignum.h
+++ b/src/bignum.h
@@ -131,15 +131,9 @@ public:
 
         if (sn < (int64)0)
         {
-            // We negate in 2 steps to avoid signed subtraction overflow,
-            // i.e. -(-2^63), which is an undefined operation and causes SIGILL
-            // when compiled with -ftrapv.
-            //
-            // Note that uint64_t n = sn, when sn is an int64_t, is a
-            // well-defined operation and n will be equal to sn + 2^64 when sn
-            // is negative.
-            n = sn;
-            n = -n;
+            // Since the minimum signed integer cannot be represented as positive so long as its type is signed, and it's not well-defined what happens if you make it unsigned before negating it, we instead increment the negative integer by 1, convert it, then increment the (now positive) unsigned integer by 1 to compensate
+            n = -(sn + 1);
+            ++n;
             fNegative = true;
         } else {
             n = sn;


### PR DESCRIPTION
Since the minimum signed integer cannot be represented as positive so long as its type is signed, and it's not well-defined what happens if you make it unsigned before negating it, we instead increment the negative integer by 1, convert it, then increment the (now positive) unsigned integer by 1 to compensate

@wizeman recently introduced this potential-bug in #1298, so I'd appreciate if he could comment (did not get a response on IRC)
