### PR TITLE
Add support for a cjdns network type

### DIFF
--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -26,10 +26,12 @@ static const unsigned char pchIPv4[12] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0
 
 enum Network ParseNetwork(std::string net) {
     boost::to_lower(net);
-    if (net == "ipv4") return NET_IPV4;
-    if (net == "ipv6") return NET_IPV6;
-    if (net == "tor")  return NET_TOR;
-    if (net == "i2p")  return NET_I2P;
+    if (net == "ipv4")  return NET_IPV4;
+    if (net == "ipv6")  return NET_IPV6;
+    if (net == "tor")   return NET_TOR;
+    if (net == "i2p")   return NET_I2P;
+    if (net == "cjdns") return NET_CJDNS;
+
     return NET_UNROUTABLE;
 }
 
@@ -647,6 +649,12 @@ bool CNetAddr::IsGarliCat() const
     return (memcmp(ip, pchGarliCat, sizeof(pchGarliCat)) == 0);
 }
 
+bool CNetAddr::IsCJDNS() const
+{
+    static const unsigned char pchCJDNS[] = {0xFC};
+    return (memcmp(ip, pchCJDNS, sizeof(pchCJDNS)) == 0);
+}
+
 bool CNetAddr::IsLocal() const
 {
     // IPv4 loopback
@@ -705,7 +713,7 @@ bool CNetAddr::IsValid() const
 
 bool CNetAddr::IsRoutable() const
 {
-    return IsValid() && !(IsRFC1918() || IsRFC3927() || IsRFC4862() || (IsRFC4193() && !IsOnionCat() && !IsGarliCat()) || IsRFC4843() || IsLocal());
+    return IsValid() && !(IsRFC1918() || IsRFC3927() || IsRFC4862() || (IsRFC4193() && !IsOnionCat() && !IsGarliCat() && !IsCJDNS()) || IsRFC4843() || IsLocal());
 }
 
 enum Network CNetAddr::GetNetwork() const
@@ -721,6 +729,9 @@ enum Network CNetAddr::GetNetwork() const
 
     if (IsGarliCat())
         return NET_I2P;
+
+    if (IsCJDNS())
+        return NET_CJDNS;
 
     return NET_IPV6;
 }

--- a/src/netbase.h
+++ b/src/netbase.h
@@ -24,6 +24,7 @@ enum Network
     NET_IPV6,
     NET_TOR,
     NET_I2P,
+    NET_CJDNS,
 
     NET_MAX
 };
@@ -58,6 +59,7 @@ class CNetAddr
         bool IsRFC6145() const; // IPv6 IPv4-translated address (::FFFF:0:0:0/96)
         bool IsOnionCat() const;
         bool IsGarliCat() const;
+        bool IsCJDNS() const;
         bool IsLocal() const;
         bool IsRoutable() const;
         bool IsValid() const;


### PR DESCRIPTION
This pull request adds support for a [CJDNS](http://cjdns.info/) network type modeled after the existing support for tor and i2p networks.

Using "-onlynet=cjdns" and relevant -externalip, -bind and -addnode, allows running a bitcoind that communicates over cjdns only. 

A cjdns/ip4 bridging node is running on fca5:372b:57be:78aa:e490:6b0f:da2a:c882 and can be used for testing. An example command for running a node that communicates over cjdns:

```
./bitcoind -onlynet=cjdns -addnode=fca5:372b:57be:78aa:e490:6b0f:da2a:c882 -bind=fc46:96cb:122a:4eff:fa50:24c4:2436:e564 -externalip=fc46:96cb:122a:4eff:fa50:24c4:2436:e564
```

The 'bind' and 'externalip' switches should be changed to your own cjdns address of course.
