### PR TITLE
Remove some rule differences which aren't needed with testnet3.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1317,8 +1317,7 @@ bool CBlock::ConnectBlock(CTxDB& txdb, CBlockIndex* pindex)
     // This logic is not necessary for memory pool transactions, as AcceptToMemoryPool
     // already refuses previously-known transaction id's entirely.
     // This rule applies to all blocks whose timestamp is after March 15, 2012, 0:00 UTC.
-    // On testnet it is enabled as of februari 20, 2012, 0:00 UTC.
-    if (pindex->nTime > 1331769600 || (fTestNet && pindex->nTime > 1329696000))
+    if (pindex->nTime > 1331769600)
     {
         BOOST_FOREACH(CTransaction& tx, vtx)
         {
@@ -1332,8 +1331,8 @@ bool CBlock::ConnectBlock(CTxDB& txdb, CBlockIndex* pindex)
         }
     }
 
-    // BIP16 didn't become active until Apr 1 2012 (Feb 15 on testnet)
-    int64 nBIP16SwitchTime = fTestNet ? 1329264000 : 1333238400;
+    // BIP16 didn't become active until Apr 1 2012
+    int64 nBIP16SwitchTime = 1333238400;
     bool fStrictPayToScriptHash = (pindex->nTime >= nBIP16SwitchTime);
 
     //// issue here: it doesn't know the version


### PR DESCRIPTION
Bip16 and Bip30 had early activation dates for testnet, but
with the reset they might as well use the same dates as
the main network.
