### PR TITLE
Changed a comment about a QVariant type

### DIFF
--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -23,7 +23,7 @@ public:
         ProxyUse, // bool
         ProxySocksVersion, // int
         ProxyIP, // QString
-        ProxyPort, // QString
+        ProxyPort, // int
         Fee, // qint64
         DisplayUnit, // BitcoinUnits::Unit
         DisplayAddresses, // bool


### PR DESCRIPTION
The OptionsModel::data that set it has changed. Now it's

``` C++
        case ProxyPort: {
            CService addrProxy;
            if (GetProxy(NET_IPV4, addrProxy))
                return QVariant(addrProxy.GetPort());
            else
                return 9050;
        }
```

GetPort() returns an unsigned short, that is upcasted by the QVariant (that doesn't directly support shorts)
