### PR TITLE
RPC: add 'getnetstats' op, to return data on messages and peers

### DIFF
--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -2284,7 +2284,37 @@ Value sendrawtx(const Array& params, bool fHelp)
     return tx.GetHash().GetHex();
 }
 
+Value getnetstats(const Array& params, bool fHelp)
+{
+    if (fHelp || params.size() != 0)
+        throw runtime_error(
+            "getnetstats\n"
+            "Obtain various network node statistics.");
 
+    LOCK(netstats.cs);
+    Object ret, ret_cmd, ret_peers;
+
+    for (map<string, uint64>::const_iterator mi = netstats.mapCmdCount.begin(); mi != netstats.mapCmdCount.end(); ++mi) {
+        Array a;
+        string strCommand = (*mi).first;
+
+        a.resize(2);
+        a[0] = strprintf("%"PRI64u, netstats.mapCmdCount[strCommand]);
+        a[1] = strprintf("%"PRI64u, netstats.mapCmdBytes[strCommand]);
+
+        ret_cmd.push_back(Pair(strCommand, a));
+    }
+
+    netstats.countPeers();
+    ret_peers.push_back(Pair("connected", (int)netstats.nConn));
+    ret_peers.push_back(Pair("inbound", (int)netstats.nInbound));
+    ret_peers.push_back(Pair("outbound", (int)netstats.nOutbound));
+
+    ret.push_back(Pair("messages", ret_cmd));
+    ret.push_back(Pair("peers", ret_peers));
+
+    return ret;
+}
 
 
 
@@ -2349,6 +2379,7 @@ static const CRPCCommand vRPCCommands[] =
     { "dumpprivkey",            &dumpprivkey,            false },
     { "importprivkey",          &importprivkey,          false },
     { "sendrawtx",              &sendrawtx,              false },
+    { "getnetstats",            &getnetstats,            true },
 };
 
 CRPCTable::CRPCTable()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2967,6 +2967,9 @@ bool ProcessMessages(CNode* pfrom)
         CDataStream vMsg(vRecv.begin(), vRecv.begin() + nMessageSize, vRecv.nType, vRecv.nVersion);
         vRecv.ignore(nMessageSize);
 
+        // Collect statistics
+        netstats.msg(strCommand, nHeaderSize + nMessageSize);
+
         // Process message
         bool fRet = false;
         try

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -59,6 +59,7 @@ uint64 nLocalHostNonce = 0;
 array<int, THREAD_MAX> vnThreadsRunning;
 static std::vector<SOCKET> vhListenSocket;
 CAddrMan addrman;
+CNetStats netstats;
 
 vector<CNode*> vNodes;
 CCriticalSection cs_vNodes;
@@ -1949,3 +1950,18 @@ public:
     }
 }
 instance_of_cnetcleanup;
+
+
+void CNetStats::countPeers()
+{
+    nInbound = nOutbound = 0;
+
+    LOCK(cs_vNodes);
+    nConn = vNodes.size();
+    BOOST_FOREACH(CNode* pnode, vNodes) {
+        if (pnode->fInbound)
+            nInbound++;
+        else
+            nOutbound++;
+    }
+}

--- a/src/net.h
+++ b/src/net.h
@@ -667,4 +667,27 @@ inline void RelayMessage<>(const CInv& inv, const CDataStream& ss)
 }
 
 
+
+
+
+class CNetStats
+{
+public:
+    std::map<std::string, uint64> mapCmdCount;
+    std::map<std::string, uint64> mapCmdBytes;
+    mutable CCriticalSection cs;
+
+    unsigned int nConn, nInbound, nOutbound;
+
+    void msg(std::string strCommand, unsigned long msgSize)
+    {
+       LOCK(cs);
+       mapCmdCount[strCommand]++;
+       mapCmdBytes[strCommand] += msgSize;
+    }
+    void countPeers();
+};
+
+extern CNetStats netstats;
+
 #endif


### PR DESCRIPTION
The returned data is
1. Per-message arrays.
   
   Index 0 is total number of $ThisType messages
   received since program start (or uint64 counter wrap).
   
   Index 1 is total byte count since program start (or uint64
   counter wrap).
   
   They are returned as strings due to unfortunate JSON implementations
   in the field that do not handle unquoted uint64 numbers correctly.
2. Peer information.  Returns number of inbound, outbound and total peers.
   Total peer count is equivalent to RPC 'getconnectioncount'.
