### PR TITLE
Give threads a recognisable name to aid in debugging

### DIFF
--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -1577,8 +1577,8 @@ void ThreadTopUpKeyPool(void* parg)
 
 void ThreadCleanWalletPassphrase(void* parg)
 {
-    // Make this thread recognisable as the wallet unlocking thread
-    RenameThread("bitcoin-unlo-wa");
+    // Make this thread recognisable as the wallet relocking thread
+    RenameThread("bitcoin-lock-wa");
 
     int64 nMyWakeTime = GetTimeMillis() + *((int64*)parg) * 1000;
 

--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -1569,11 +1569,17 @@ Value keypoolrefill(const Array& params, bool fHelp)
 
 void ThreadTopUpKeyPool(void* parg)
 {
+    // Make this thread recognisable as the key-topping-up thread
+    RenameThread("bitcoin-key-top");
+
     pwalletMain->TopUpKeyPool();
 }
 
 void ThreadCleanWalletPassphrase(void* parg)
 {
+    // Make this thread recognisable as the wallet unlocking thread
+    RenameThread("bitcoin-unlo-wa");
+
     int64 nMyWakeTime = GetTimeMillis() + *((int64*)parg) * 1000;
 
     ENTER_CRITICAL_SECTION(cs_nWalletUnlockTime);
@@ -2479,6 +2485,10 @@ private:
 void ThreadRPCServer(void* parg)
 {
     IMPLEMENT_RANDOMIZE_STACK(ThreadRPCServer(parg));
+
+    // Make this thread recognisable as the RPC listener
+    RenameThread("bitcoin-rpclist");
+
     try
     {
         vnThreadsRunning[THREAD_RPCLISTENER]++;
@@ -2762,6 +2772,10 @@ static CCriticalSection cs_THREAD_RPCHANDLER;
 void ThreadRPCServer3(void* parg)
 {
     IMPLEMENT_RANDOMIZE_STACK(ThreadRPCServer3(parg));
+
+    // Make this thread recognisable as the RPC handler
+    RenameThread("bitcoin-rpchand");
+
     {
         LOCK(cs_THREAD_RPCHANDLER);
         vnThreadsRunning[THREAD_RPCHANDLER]++;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -53,6 +53,10 @@ void Shutdown(void* parg)
 {
     static CCriticalSection cs_Shutdown;
     static bool fTaken;
+
+    // Make this thread recognisable as the shutdown thread
+    RenameThread("bitcoin-shutoff");
+
     bool fFirstThread = false;
     {
         TRY_LOCK(cs_Shutdown, lockShutdown);

--- a/src/irc.cpp
+++ b/src/irc.cpp
@@ -189,6 +189,10 @@ bool GetIPFromIRC(SOCKET hSocket, string strMyName, CNetAddr& ipRet)
 void ThreadIRCSeed(void* parg)
 {
     IMPLEMENT_RANDOMIZE_STACK(ThreadIRCSeed(parg));
+
+    // Make this thread recognisable as the IRC seeding thread
+    RenameThread("bitcoin-ircseed");
+
     try
     {
         ThreadIRCSeed2(parg);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3595,7 +3595,7 @@ void static BitcoinMiner(CWallet *pwallet)
     SetThreadPriority(THREAD_PRIORITY_LOWEST);
 
     // Make this thread recognisable as the mining thread
-    RenameThread("bitcoin [miner]");
+    RenameThread("bitcoin-miner");
 
     // Each thread has its own key and counter
     CReserveKey reservekey(pwallet);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3594,6 +3594,9 @@ void static BitcoinMiner(CWallet *pwallet)
     printf("BitcoinMiner started\n");
     SetThreadPriority(THREAD_PRIORITY_LOWEST);
 
+    // Make this thread recognisable as the mining thread
+    RenameThread("bitcoin [miner]");
+
     // Each thread has its own key and counter
     CReserveKey reservekey(pwallet);
     unsigned int nExtraNonce = 0;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -407,6 +407,9 @@ bool GetMyExternalIP(CNetAddr& ipRet)
 
 void ThreadGetMyExternalIP(void* parg)
 {
+    // Make this thread recognisable as the message handling thread
+    RenameThread("bitcoin-ext-ip");
+
     CNetAddr addrLocalHost;
     if (GetMyExternalIP(addrLocalHost))
     {
@@ -636,6 +639,10 @@ void CNode::copyStats(CNodeStats &stats)
 void ThreadSocketHandler(void* parg)
 {
     IMPLEMENT_RANDOMIZE_STACK(ThreadSocketHandler(parg));
+
+    // Make this thread recognisable as the networking thread
+    RenameThread("bitcoind [net]");
+
     try
     {
         vnThreadsRunning[THREAD_SOCKETHANDLER]++;
@@ -988,6 +995,10 @@ void ThreadSocketHandler2(void* parg)
 void ThreadMapPort(void* parg)
 {
     IMPLEMENT_RANDOMIZE_STACK(ThreadMapPort(parg));
+
+    // Make this thread recognisable as the UPnP thread
+    RenameThread("bitcoind [UPnP]");
+
     try
     {
         vnThreadsRunning[THREAD_UPNP]++;
@@ -1146,6 +1157,10 @@ static const char *strDNSSeed[][2] = {
 void ThreadDNSAddressSeed(void* parg)
 {
     IMPLEMENT_RANDOMIZE_STACK(ThreadDNSAddressSeed(parg));
+
+    // Make this thread recognisable as the DNS seeding thread
+    RenameThread("bitcoin-dnsseed");
+
     try
     {
         vnThreadsRunning[THREAD_DNSSEED]++;
@@ -1315,6 +1330,10 @@ void ThreadDumpAddress2(void* parg)
 void ThreadDumpAddress(void* parg)
 {
     IMPLEMENT_RANDOMIZE_STACK(ThreadDumpAddress(parg));
+
+    // Make this thread recognisable as the address dumping thread
+    RenameThread("bitcoin-adrdump");
+
     try
     {
         ThreadDumpAddress2(parg);
@@ -1328,6 +1347,10 @@ void ThreadDumpAddress(void* parg)
 void ThreadOpenConnections(void* parg)
 {
     IMPLEMENT_RANDOMIZE_STACK(ThreadOpenConnections(parg));
+
+    // Make this thread recognisable as the connection opening thread
+    RenameThread("bitcoin-opencon");
+
     try
     {
         vnThreadsRunning[THREAD_OPENCONNECTIONS]++;
@@ -1481,6 +1504,10 @@ void ThreadOpenConnections2(void* parg)
 void ThreadOpenAddedConnections(void* parg)
 {
     IMPLEMENT_RANDOMIZE_STACK(ThreadOpenAddedConnections(parg));
+
+    // Make this thread recognisable as the connection opening thread
+    RenameThread("bitcoin-opencon");
+
     try
     {
         vnThreadsRunning[THREAD_ADDEDCONNECTIONS]++;
@@ -1610,6 +1637,10 @@ bool OpenNetworkConnection(const CAddress& addrConnect, CSemaphoreGrant *grantOu
 void ThreadMessageHandler(void* parg)
 {
     IMPLEMENT_RANDOMIZE_STACK(ThreadMessageHandler(parg));
+
+    // Make this thread recognisable as the message handling thread
+    RenameThread("bitcoin-msghand");
+
     try
     {
         vnThreadsRunning[THREAD_MESSAGEHANDLER]++;
@@ -1852,6 +1883,9 @@ void static Discover()
 
 void StartNode(void* parg)
 {
+    // Make this thread recognisable as the startup thread
+    RenameThread("bitcoin [start]");
+
     if (semOutbound == NULL) {
         // initialize semaphore
         int nMaxOutbound = min(MAX_OUTBOUND_CONNECTIONS, (int)GetArg("-maxconnections", 125));

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -641,7 +641,7 @@ void ThreadSocketHandler(void* parg)
     IMPLEMENT_RANDOMIZE_STACK(ThreadSocketHandler(parg));
 
     // Make this thread recognisable as the networking thread
-    RenameThread("bitcoind [net]");
+    RenameThread("bitcoin-net");
 
     try
     {
@@ -997,7 +997,7 @@ void ThreadMapPort(void* parg)
     IMPLEMENT_RANDOMIZE_STACK(ThreadMapPort(parg));
 
     // Make this thread recognisable as the UPnP thread
-    RenameThread("bitcoind [UPnP]");
+    RenameThread("bitcoin-UPnP");
 
     try
     {
@@ -1884,7 +1884,7 @@ void static Discover()
 void StartNode(void* parg)
 {
     // Make this thread recognisable as the startup thread
-    RenameThread("bitcoin [start]");
+    RenameThread("bitcoin-start");
 
     if (semOutbound == NULL) {
         // initialize semaphore

--- a/src/qt/qtipcserver.cpp
+++ b/src/qt/qtipcserver.cpp
@@ -14,6 +14,7 @@
 
 #include "ui_interface.h"
 #include "qtipcserver.h"
+#include "util.h"
 
 using namespace boost::interprocess;
 using namespace boost::posix_time;
@@ -35,6 +36,9 @@ void ipcShutdown()
 
 void ipcThread(void* parg)
 {
+    // Make this thread recognisable as the GUI-IPC thread
+    RenameThread("bitcoin-gui-ipc");
+
     message_queue* mq = (message_queue*)parg;
     char strBuf[257];
     size_t nSize;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -51,6 +51,8 @@ namespace boost {
 #endif
 #include <io.h> /* for _commit */
 #include "shlobj.h"
+#elif defined(__linux__)
+# include <sys/prctl.h>
 #endif
 
 using namespace std;
@@ -1275,3 +1277,13 @@ void runCommand(std::string strCommand)
         printf("runCommand error: system(%s) returned %d\n", strCommand.c_str(), nErr);
 }
 
+void RenameThread(const char* name)
+{
+#if defined(__linux__) && defined(PR_SET_NAME)
+    // Only the first 15 characters are used (16 - NUL terminator)
+    ::prctl(PR_SET_NAME, name, 0, 0, 0);
+#else
+    // Prevent warnings for unused parameters...
+    (void)name;
+#endif
+}

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1282,6 +1282,11 @@ void RenameThread(const char* name)
 #if defined(__linux__) && defined(PR_SET_NAME)
     // Only the first 15 characters are used (16 - NUL terminator)
     ::prctl(PR_SET_NAME, name, 0, 0, 0);
+#elif 0 && (defined(__FreeBSD__) || defined(__OpenBSD__))
+    // TODO: This is currently disabled because it needs to be verified to work
+    //       on FreeBSD or OpenBSD first. When verified the '0 &&' part can be
+    //       removed.
+    pthread_set_name_np(pthread_self(), name);
 #else
     // Prevent warnings for unused parameters...
     (void)name;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1279,7 +1279,7 @@ void runCommand(std::string strCommand)
 
 void RenameThread(const char* name)
 {
-#if defined(__linux__) && defined(PR_SET_NAME)
+#if defined(PR_SET_NAME)
     // Only the first 15 characters are used (16 - NUL terminator)
     ::prctl(PR_SET_NAME, name, 0, 0, 0);
 #elif 0 && (defined(__FreeBSD__) || defined(__OpenBSD__))

--- a/src/util.h
+++ b/src/util.h
@@ -621,9 +621,7 @@ inline void ExitThread(size_t nExitCode)
 }
 #endif
 
-
-
-
+void RenameThread(const char* name);
 
 inline uint32_t ByteReverse(uint32_t value)
 {

--- a/src/walletdb.cpp
+++ b/src/walletdb.cpp
@@ -323,6 +323,9 @@ int CWalletDB::LoadWallet(CWallet* pwallet)
 
 void ThreadFlushWalletDB(void* parg)
 {
+    // Make this thread recognisable as the wallet flushing thread
+    RenameThread("bitcoin-wallet");
+
     const string& strFile = ((const string*)parg)[0];
     static bool fOneThread;
     if (fOneThread)


### PR DESCRIPTION
These thread names are visible in gdb when using 'info threads'. Additionally both 'top' and 'ps' show these names _unless_ told to display the command-line instead of task name.
