### PR TITLE
RPC: add 'getpeerinfo', returning easy-to-retrieve per-CNode data

### DIFF
--- a/bitcoin-qt.pro
+++ b/bitcoin-qt.pro
@@ -206,6 +206,7 @@ SOURCES += src/qt/bitcoin.cpp src/qt/bitcoingui.cpp \
     src/qt/walletmodel.cpp \
     src/bitcoinrpc.cpp \
     src/rpcdump.cpp \
+    src/rpcnet.cpp \
     src/qt/overviewpage.cpp \
     src/qt/csvmodelwriter.cpp \
     src/crypter.cpp \

--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -46,6 +46,7 @@ static std::string strRPCUserColonPass;
 static int64 nWalletUnlockTime;
 static CCriticalSection cs_nWalletUnlockTime;
 
+extern Value getconnectioncount(const Array& params, bool fHelp);
 extern Value dumpprivkey(const Array& params, bool fHelp);
 extern Value importprivkey(const Array& params, bool fHelp);
 
@@ -453,17 +454,6 @@ Value getblockcount(const Array& params, bool fHelp)
             "Returns the number of blocks in the longest block chain.");
 
     return nBestHeight;
-}
-
-
-Value getconnectioncount(const Array& params, bool fHelp)
-{
-    if (fHelp || params.size() != 0)
-        throw runtime_error(
-            "getconnectioncount\n"
-            "Returns the number of connections to other nodes.");
-
-    return (int)vNodes.size();
 }
 
 

--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -47,6 +47,7 @@ static int64 nWalletUnlockTime;
 static CCriticalSection cs_nWalletUnlockTime;
 
 extern Value getconnectioncount(const Array& params, bool fHelp);
+extern Value getpeerinfo(const Array& params, bool fHelp);
 extern Value dumpprivkey(const Array& params, bool fHelp);
 extern Value importprivkey(const Array& params, bool fHelp);
 
@@ -2300,6 +2301,7 @@ static const CRPCCommand vRPCCommands[] =
     { "stop",                   &stop,                   true },
     { "getblockcount",          &getblockcount,          true },
     { "getconnectioncount",     &getconnectioncount,     true },
+    { "getpeerinfo",            &getpeerinfo,            true },
     { "getdifficulty",          &getdifficulty,          true },
     { "getgenerate",            &getgenerate,            true },
     { "setgenerate",            &setgenerate,            true },

--- a/src/makefile.linux-mingw
+++ b/src/makefile.linux-mingw
@@ -60,6 +60,7 @@ OBJS= \
     obj/protocol.o \
     obj/bitcoinrpc.o \
     obj/rpcdump.o \
+    obj/rpcnet.o \
     obj/script.o \
     obj/sync.o \
     obj/util.o \

--- a/src/makefile.mingw
+++ b/src/makefile.mingw
@@ -57,6 +57,7 @@ OBJS= \
     obj/protocol.o \
     obj/bitcoinrpc.o \
     obj/rpcdump.o \
+    obj/rpcnet.o \
     obj/script.o \
     obj/sync.o \
     obj/util.o \

--- a/src/makefile.osx
+++ b/src/makefile.osx
@@ -84,6 +84,7 @@ OBJS= \
     obj/protocol.o \
     obj/bitcoinrpc.o \
     obj/rpcdump.o \
+    obj/rpcnet.o \
     obj/script.o \
     obj/sync.o \
     obj/util.o \

--- a/src/makefile.unix
+++ b/src/makefile.unix
@@ -104,6 +104,7 @@ OBJS= \
     obj/protocol.o \
     obj/bitcoinrpc.o \
     obj/rpcdump.o \
+    obj/rpcnet.o \
     obj/script.o \
     obj/sync.o \
     obj/util.o \

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -606,7 +606,23 @@ bool CNode::Misbehaving(int howmuch)
     return false;
 }
 
-
+#undef X
+#define X(name) stats.name = name
+void CNode::copyStats(CNodeStats &stats)
+{
+    X(nServices);
+    X(nLastSend);
+    X(nLastRecv);
+    X(nTimeConnected);
+    X(addrName);
+    X(nVersion);
+    X(strSubVer);
+    X(fInbound);
+    X(nReleaseTime);
+    X(nStartingHeight);
+    X(nMisbehavior);
+}
+#undef X
 
 
 

--- a/src/net.h
+++ b/src/net.h
@@ -128,6 +128,24 @@ extern std::map<CInv, int64> mapAlreadyAskedFor;
 
 
 
+class CNodeStats
+{
+public:
+    uint64 nServices;
+    int64 nLastSend;
+    int64 nLastRecv;
+    int64 nTimeConnected;
+    std::string addrName;
+    int nVersion;
+    std::string strSubVer;
+    bool fInbound;
+    int64 nReleaseTime;
+    int nStartingHeight;
+    int nMisbehavior;
+};
+
+
+
 
 
 /** Information about a peer */
@@ -617,6 +635,7 @@ public:
     static void ClearBanned(); // needed for unit testing
     static bool IsBanned(CNetAddr ip);
     bool Misbehaving(int howmuch); // 1 == a little, 100 == a lot
+    void copyStats(CNodeStats &stats);
 };
 
 

--- a/src/rpcnet.cpp
+++ b/src/rpcnet.cpp
@@ -1,0 +1,21 @@
+// Copyright (c) 2009-2012 Bitcoin Developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "net.h"
+#include "bitcoinrpc.h"
+
+using namespace json_spirit;
+using namespace std;
+
+Value getconnectioncount(const Array& params, bool fHelp)
+{
+    if (fHelp || params.size() != 0)
+        throw runtime_error(
+            "getconnectioncount\n"
+            "Returns the number of connections to other nodes.");
+
+    return (int)vNodes.size();
+}
+
+

--- a/src/rpcnet.cpp
+++ b/src/rpcnet.cpp
@@ -15,7 +15,53 @@ Value getconnectioncount(const Array& params, bool fHelp)
             "getconnectioncount\n"
             "Returns the number of connections to other nodes.");
 
+    LOCK(cs_vNodes);
     return (int)vNodes.size();
 }
 
+static void CopyNodeStats(std::vector<CNodeStats>& vstats)
+{
+    vstats.clear();
+
+    LOCK(cs_vNodes);
+    vstats.reserve(vNodes.size());
+    BOOST_FOREACH(CNode* pnode, vNodes) {
+        CNodeStats stats;
+        pnode->copyStats(stats);
+        vstats.push_back(stats);
+    }
+}
+
+Value getpeerinfo(const Array& params, bool fHelp)
+{
+    if (fHelp || params.size() != 0)
+        throw runtime_error(
+            "getpeerinfo\n"
+            "Returns data about each connected network node.");
+
+    vector<CNodeStats> vstats;
+    CopyNodeStats(vstats);
+
+    Array ret;
+
+    BOOST_FOREACH(const CNodeStats& stats, vstats) {
+        Object obj;
+
+        obj.push_back(Pair("addr", stats.addrName));
+        obj.push_back(Pair("services", strprintf("%08"PRI64x, stats.nServices)));
+        obj.push_back(Pair("lastsend", (boost::int64_t)stats.nLastSend));
+        obj.push_back(Pair("lastrecv", (boost::int64_t)stats.nLastRecv));
+        obj.push_back(Pair("conntime", (boost::int64_t)stats.nTimeConnected));
+        obj.push_back(Pair("version", stats.nVersion));
+        obj.push_back(Pair("subver", stats.strSubVer));
+        obj.push_back(Pair("inbound", stats.fInbound));
+        obj.push_back(Pair("releasetime", (boost::int64_t)stats.nReleaseTime));
+        obj.push_back(Pair("height", stats.nStartingHeight));
+        obj.push_back(Pair("banscore", stats.nMisbehavior));
+
+        ret.push_back(obj);
+    }
+    
+    return ret;
+}
 


### PR DESCRIPTION
This pull request adds 'getpeerinfo', initially returning low-hanging fruit available inside each CNode.

Once this initial form is OK'd, additional commits will add per-message statistics similar to those seen in now-closed req #1510.

Example output:

```
     [
     {
        "addr" : "64.27.57.122:8333",
        "services" : "1",
        "last_send" : "1340943593",
        "last_send_empty" : "1340943593",
        "last_recv" : "1340943593",
        "time_conn" : "1340943569",
        "version" : 60001,
        "subver" : "/Satoshi:0.6.3/",
        "inbound" : false,
        "time_release" : "0",
        "start_height" : 186712,
        "banscore" : 0
     },
     {
        "addr" : "178.152.104.61:8333",
        "services" : "1",
        "last_send" : "1340943593",
        "last_send_empty" : "1340943593",
        "last_recv" : "1340943592",
        "time_conn" : "1340943591",
        "version" : 40000,
        "subver" : "",
        "inbound" : false,
        "time_release" : "0",
        "start_height" : 186712,
        "banscore" : 0
     }
     ]
```
