### PR TITLE
CTXOut::nValue encapsulation

### DIFF
--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -285,7 +285,7 @@ void TxToJSON(const CTransaction &tx, Object& entry, const Object& decomposition
     BOOST_FOREACH(const CTxOut& txout, tx.vout)
     {
         Object out;
-        out.push_back(Pair("value", ValueFromAmount(txout.nValue)));
+        out.push_back(Pair("value", ValueFromAmount(txout.GetPresentValue())));
         switch (decomposeScript) {
         case DM_NONE:
             break;
@@ -888,7 +888,7 @@ Value getreceivedbyaddress(const Array& params, bool fHelp)
         BOOST_FOREACH(const CTxOut& txout, wtx.vout)
             if (txout.scriptPubKey == scriptPubKey)
                 if (wtx.GetDepthInMainChain() >= nMinDepth)
-                    nAmount += txout.nValue;
+                    nAmount += txout.GetPresentValue();
     }
 
     return  ValueFromAmount(nAmount);
@@ -936,7 +936,7 @@ Value getreceivedbyaccount(const Array& params, bool fHelp)
             CTxDestination address;
             if (ExtractDestination(txout.scriptPubKey, address) && IsMine(*pwalletMain, address) && setAddress.count(address))
                 if (wtx.GetDepthInMainChain() >= nMinDepth)
-                    nAmount += txout.nValue;
+                    nAmount += txout.GetPresentValue();
         }
     }
 
@@ -1294,7 +1294,7 @@ Value ListReceived(const Array& params, bool fByAccounts)
                 continue;
 
             tallyitem& item = mapTally[address];
-            item.nAmount += txout.nValue;
+            item.nAmount += txout.GetPresentValue();
             item.nConf = min(item.nConf, nDepth);
         }
     }
@@ -2178,7 +2178,7 @@ Value getmemorypool(const Array& params, bool fHelp)
         result.push_back(Pair("version", pblock->nVersion));
         result.push_back(Pair("previousblockhash", pblock->hashPrevBlock.GetHex()));
         result.push_back(Pair("transactions", transactions));
-        result.push_back(Pair("coinbasevalue", (int64_t)pblock->vtx[0].vout[0].nValue));
+        result.push_back(Pair("coinbasevalue", (int64_t)pblock->vtx[0].vout[0].GetPresentValue()));
         result.push_back(Pair("coinbaseflags", HexStr(COINBASE_FLAGS.begin(), COINBASE_FLAGS.end())));
         result.push_back(Pair("time", (int64_t)pblock->nTime));
         result.push_back(Pair("mintime", (int64_t)pindexPrev->GetMedianTimePast()+1));

--- a/src/main.h
+++ b/src/main.h
@@ -307,8 +307,11 @@ public:
  */
 class CTxOut
 {
+
+private:
+	int64 nValue;
+
 public:
-    int64 nValue;
     CScript scriptPubKey;
 
     CTxOut()
@@ -365,6 +368,16 @@ public:
     void print() const
     {
         printf("%s\n", ToString().c_str());
+    }
+
+    int64 GetPresentValue() const
+    {
+    	return nValue;
+    }
+
+    void SetPresentValue(int64 presentValue)
+    {
+    	nValue = presentValue;
     }
 };
 
@@ -513,8 +526,8 @@ public:
         int64 nValueOut = 0;
         BOOST_FOREACH(const CTxOut& txout, vout)
         {
-            nValueOut += txout.nValue;
-            if (!MoneyRange(txout.nValue) || !MoneyRange(nValueOut))
+            nValueOut += txout.GetPresentValue();
+            if (!MoneyRange(txout.GetPresentValue()) || !MoneyRange(nValueOut))
                 throw std::runtime_error("CTransaction::GetValueOut() : value out of range");
         }
         return nValueOut;
@@ -567,7 +580,7 @@ public:
         if (nMinFee < nBaseFee)
         {
             BOOST_FOREACH(const CTxOut& txout, vout)
-                if (txout.nValue < CENT)
+                if (txout.GetPresentValue() < CENT)
                     nMinFee = nBaseFee;
         }
 

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -183,7 +183,7 @@ QString TransactionDesc::toHTML(CWallet *wallet, CWalletTx &wtx)
                         }
                     }
 
-                    strHTML += tr("<b>Debit:</b> ") + BitcoinUnits::formatWithUnit(BitcoinUnits::BTC, -txout.nValue) + "<br>";
+                    strHTML += tr("<b>Debit:</b> ") + BitcoinUnits::formatWithUnit(BitcoinUnits::BTC, -txout.GetPresentValue()) + "<br>";
                 }
 
                 if (fAllToMe)
@@ -269,7 +269,7 @@ QString TransactionDesc::toHTML(CWallet *wallet, CWalletTx &wtx)
                                     strHTML += GUIUtil::HtmlEscape(wallet->mapAddressBook[address]) + " ";
                                 strHTML += QString::fromStdString(CBitcoinAddress(address).ToString());
                             }
-                            strHTML = strHTML + " Amount=" + BitcoinUnits::formatWithUnit(BitcoinUnits::BTC,vout.nValue);
+                            strHTML = strHTML + " Amount=" + BitcoinUnits::formatWithUnit(BitcoinUnits::BTC,vout.GetPresentValue());
                             strHTML = strHTML + " IsMine=" + (wallet->IsMine(vout) ? "true" : "false") + "</li>";
                         }
                     }

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -53,7 +53,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
                 TransactionRecord sub(hash, nTime);
                 CTxDestination address;
                 sub.idx = parts.size(); // sequence number
-                sub.credit = txout.nValue;
+                sub.credit = txout.GetPresentValue();
                 if (wtx.IsCoinBase())
                 {
                     // Generated
@@ -128,7 +128,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
                     sub.address = mapValue["to"];
                 }
 
-                int64 nValue = txout.nValue;
+                int64 nValue = txout.GetPresentValue();
                 /* Add fee to first output */
                 if (nTxFee > 0)
                 {

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -457,7 +457,7 @@ int64 CWallet::GetDebit(const CTxIn &txin) const
             const CWalletTx& prev = (*mi).second;
             if (txin.prevout.n < prev.vout.size())
                 if (IsMine(prev.vout[txin.prevout.n]))
-                    return prev.vout[txin.prevout.n].nValue;
+                    return prev.vout[txin.prevout.n].GetPresentValue();
         }
     }
     return 0;
@@ -568,10 +568,10 @@ void CWalletTx::GetAmounts(int64& nGeneratedImmature, int64& nGeneratedMature, l
             continue;
 
         if (nDebit > 0)
-            listSent.push_back(make_pair(address, txout.nValue));
+            listSent.push_back(make_pair(address, txout.GetPresentValue()));
 
         if (pwallet->IsMine(txout))
-            listReceived.push_back(make_pair(address, txout.nValue));
+            listReceived.push_back(make_pair(address, txout.GetPresentValue()));
     }
 
 }
@@ -916,7 +916,7 @@ void CWallet::AvailableCoins(vector<COutput>& vCoins) const
                 continue;
 
             for (unsigned int i = 0; i < pcoin->vout.size(); i++)
-                if (!(pcoin->IsSpent(i)) && IsMine(pcoin->vout[i]) && pcoin->vout[i].nValue > 0)
+                if (!(pcoin->IsSpent(i)) && IsMine(pcoin->vout[i]) && pcoin->vout[i].GetPresentValue() > 0)
                     vCoins.push_back(COutput(pcoin, i, pcoin->GetDepthInMainChain()));
         }
     }
@@ -983,7 +983,7 @@ bool CWallet::SelectCoinsMinConf(int64 nTargetValue, int nConfMine, int nConfThe
             continue;
 
         int i = output.i;
-        int64 n = pcoin->vout[i].nValue;
+        int64 n = pcoin->vout[i].GetPresentValue();
 
         pair<int64,pair<const CWalletTx*,unsigned int> > coin = make_pair(n,make_pair(pcoin, i));
 
@@ -1111,7 +1111,7 @@ bool CWallet::CreateTransaction(const vector<pair<CScript, int64> >& vecSend, CW
                     return false;
                 BOOST_FOREACH(PAIRTYPE(const CWalletTx*, unsigned int) pcoin, setCoins)
                 {
-                    int64 nCredit = pcoin.first->vout[pcoin.second].nValue;
+                    int64 nCredit = pcoin.first->vout[pcoin.second].GetPresentValue();
                     dPriority += (double)nCredit * pcoin.first->GetDepthInMainChain();
                 }
 

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -172,16 +172,16 @@ public:
     }
     int64 GetCredit(const CTxOut& txout) const
     {
-        if (!MoneyRange(txout.nValue))
+        if (!MoneyRange(txout.GetPresentValue()))
             throw std::runtime_error("CWallet::GetCredit() : value out of range");
-        return (IsMine(txout) ? txout.nValue : 0);
+        return (IsMine(txout) ? txout.GetPresentValue() : 0);
     }
     bool IsChange(const CTxOut& txout) const;
     int64 GetChange(const CTxOut& txout) const
     {
-        if (!MoneyRange(txout.nValue))
+        if (!MoneyRange(txout.GetPresentValue()))
             throw std::runtime_error("CWallet::GetChange() : value out of range");
-        return (IsChange(txout) ? txout.nValue : 0);
+        return (IsChange(txout) ? txout.GetPresentValue() : 0);
     }
     bool IsMine(const CTransaction& tx) const
     {
@@ -621,7 +621,7 @@ public:
 
     std::string ToString() const
     {
-        return strprintf("COutput(%s, %d, %d) [%s]", tx->GetHash().ToString().substr(0,10).c_str(), i, nDepth, FormatMoney(tx->vout[i].nValue).c_str());
+        return strprintf("COutput(%s, %d, %d) [%s]", tx->GetHash().ToString().substr(0,10).c_str(), i, nDepth, FormatMoney(tx->vout[i].GetPresentValue()).c_str());
     }
 
     void print() const


### PR DESCRIPTION
This is a change that will make it much easier to maintain alternative chains for which nValue is not a constant. Initially this will be used to implement some of the models found in Appendix B of the document below.

http://fire.nist.gov/bfrlpubs/build02/PDF/b02155.pdf

Allowing this will enable tracking of more complexly defined financial assets.
