### PR TITLE
improve dust spamming prevention algorithm

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -563,13 +563,10 @@ public:
             }
         }
 
-        // To limit dust spam, require MIN_TX_FEE/MIN_RELAY_TX_FEE if any output is less than 0.01
-        if (nMinFee < nBaseFee)
-        {
-            BOOST_FOREACH(const CTxOut& txout, vout)
-                if (txout.nValue < CENT)
-                    nMinFee = nBaseFee;
-        }
+        // To limit dust spam, add MIN_TX_FEE/MIN_RELAY_TX_FEE for any output that is less than 0.01
+        BOOST_FOREACH(const CTxOut& txout, vout)
+            if (txout.nValue < CENT)
+                nMinFee += nBaseFee;
 
         // Raise the price as the block approaches full
         if (nBlockSize != 1 && nNewBlockSize >= MAX_BLOCK_SIZE_GEN/2)


### PR DESCRIPTION
This code helps with reducing dust spam. The original code will make the transaction fee become the minimum fee if any output is less than a cent. This makes it costly to send dust spam, but there's an edge case. The attacker can send a transaction with 1000 outputs of one satoshi each. The transaction size is huge but the fee is only the base fee. This fix will increase the fee by the base fee amount for each output that's less than a cent.
