### PR TITLE
RPC: Add per-message statistics to 'getpeerinfo'

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2978,6 +2978,8 @@ bool ProcessMessages(CNode* pfrom)
         {
             {
                 LOCK(cs_main);
+                pfrom->mapRecvMsgs[strCommand]++;
+                pfrom->mapRecvMsgBytes[strCommand] += nHeaderSize+nMessageSize;
                 fRet = ProcessMessage(pfrom, strCommand, vMsg);
             }
             if (fShutdown)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2955,6 +2955,8 @@ bool ProcessMessages(CNode* pfrom)
             break;
         }
 
+        pfrom->nRecvBytes += nHeaderSize + nMessageSize;
+
         // Checksum
         uint256 hash = Hash(vRecv.begin(), vRecv.begin() + nMessageSize);
         unsigned int nChecksum = 0;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -614,6 +614,8 @@ void CNode::copyStats(CNodeStats &stats)
     X(nLastSend);
     X(nLastRecv);
     X(nTimeConnected);
+    X(nRecvBytes);
+    X(nSendBytes);
     X(addrName);
     X(nVersion);
     X(strSubVer);

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -621,6 +621,10 @@ void CNode::copyStats(CNodeStats &stats)
     X(strSubVer);
     X(fInbound);
     X(nReleaseTime);
+    X(mapRecvMsgs);
+    X(mapRecvMsgBytes);
+    X(mapSendMsgs);
+    X(mapSendMsgBytes);
     X(nStartingHeight);
     X(nMisbehavior);
 }

--- a/src/net.h
+++ b/src/net.h
@@ -135,6 +135,8 @@ public:
     int64 nLastSend;
     int64 nLastRecv;
     int64 nTimeConnected;
+    uint64 nRecvBytes;
+    uint64 nSendBytes;
     std::string addrName;
     int nVersion;
     std::string strSubVer;
@@ -163,6 +165,8 @@ public:
     int64 nLastRecv;
     int64 nLastSendEmpty;
     int64 nTimeConnected;
+    uint64 nRecvBytes;
+    uint64 nSendBytes;
     int nHeaderStart;
     unsigned int nMessageStart;
     CAddress addr;
@@ -215,6 +219,8 @@ public:
         nLastRecv = 0;
         nLastSendEmpty = GetTime();
         nTimeConnected = GetTime();
+        nRecvBytes = 0;
+        nSendBytes = 0;
         nHeaderStart = -1;
         nMessageStart = -1;
         addr = addrIn;
@@ -379,6 +385,8 @@ public:
         memcpy(&nChecksum, &hash, sizeof(nChecksum));
         assert(nMessageStart - nHeaderStart >= offsetof(CMessageHeader, nChecksum) + sizeof(nChecksum));
         memcpy((char*)&vSend[nHeaderStart] + offsetof(CMessageHeader, nChecksum), &nChecksum, sizeof(nChecksum));
+
+        nSendBytes += nSize;
 
         if (fDebug) {
             printf("(%d bytes)\n", nSize);

--- a/src/net.h
+++ b/src/net.h
@@ -144,6 +144,10 @@ public:
     int64 nReleaseTime;
     int nStartingHeight;
     int nMisbehavior;
+    std::map<std::string, uint64> mapRecvMsgs;
+    std::map<std::string, uint64> mapRecvMsgBytes;
+    std::map<std::string, uint64> mapSendMsgs;
+    std::map<std::string, uint64> mapSendMsgBytes;
 };
 
 
@@ -169,6 +173,7 @@ public:
     uint64 nSendBytes;
     int nHeaderStart;
     unsigned int nMessageStart;
+    std::string strSendCmd;
     CAddress addr;
     std::string addrName;
     CService addrLocal;
@@ -181,6 +186,11 @@ public:
     bool fSuccessfullyConnected;
     bool fDisconnect;
     CSemaphoreGrant grantOutbound;
+    std::map<std::string, uint64> mapRecvMsgs;
+    std::map<std::string, uint64> mapRecvMsgBytes;
+    std::map<std::string, uint64> mapSendMsgs;
+    std::map<std::string, uint64> mapSendMsgBytes;
+
 protected:
     int nRefCount;
 
@@ -346,6 +356,7 @@ public:
         nHeaderStart = vSend.size();
         vSend << CMessageHeader(pszCommand, 0);
         nMessageStart = vSend.size();
+        strSendCmd = pszCommand;
         if (fDebug)
             printf("sending: %s ", pszCommand);
     }
@@ -357,6 +368,7 @@ public:
         vSend.resize(nHeaderStart);
         nHeaderStart = -1;
         nMessageStart = -1;
+        strSendCmd = "";
         LEAVE_CRITICAL_SECTION(cs_vSend);
 
         if (fDebug)
@@ -387,6 +399,8 @@ public:
         memcpy((char*)&vSend[nHeaderStart] + offsetof(CMessageHeader, nChecksum), &nChecksum, sizeof(nChecksum));
 
         nSendBytes += nSize;
+        mapSendMsgs[strSendCmd]++;
+        mapSendMsgBytes[strSendCmd] += (nMessageStart - nHeaderStart) + nSize;
 
         if (fDebug) {
             printf("(%d bytes)\n", nSize);

--- a/src/rpcnet.cpp
+++ b/src/rpcnet.cpp
@@ -52,6 +52,8 @@ Value getpeerinfo(const Array& params, bool fHelp)
         obj.push_back(Pair("lastsend", (boost::int64_t)stats.nLastSend));
         obj.push_back(Pair("lastrecv", (boost::int64_t)stats.nLastRecv));
         obj.push_back(Pair("conntime", (boost::int64_t)stats.nTimeConnected));
+        obj.push_back(Pair("recvbytes", (boost::uint64_t)stats.nRecvBytes));
+        obj.push_back(Pair("sendbytes", (boost::uint64_t)stats.nSendBytes));
         obj.push_back(Pair("version", stats.nVersion));
         obj.push_back(Pair("subver", stats.strSubVer));
         obj.push_back(Pair("inbound", stats.fInbound));

--- a/src/rpcnet.cpp
+++ b/src/rpcnet.cpp
@@ -32,6 +32,28 @@ static void CopyNodeStats(std::vector<CNodeStats>& vstats)
     }
 }
 
+static Object CmdStatToJSON(const map<string, uint64>& mapMsgs,
+                            const map<string, uint64>& mapMsgBytes_)
+{
+    Object ret;
+
+    map<string, uint64> mapMsgBytes(mapMsgBytes_);
+
+    for (map<string, uint64>::const_iterator mi = mapMsgs.begin(); mi != mapMsgs.end(); ++mi) {
+        Array a;
+
+        string strCommand = mi->first;
+        boost::uint64_t msgCount = mi->second;
+        boost::uint64_t msgBytes = mapMsgBytes[strCommand];
+
+        a.push_back(msgCount);
+        a.push_back(msgBytes);
+        ret.push_back(Pair(strCommand, a));
+    }
+
+    return ret;
+}
+
 Value getpeerinfo(const Array& params, bool fHelp)
 {
     if (fHelp || params.size() != 0)
@@ -58,6 +80,10 @@ Value getpeerinfo(const Array& params, bool fHelp)
         obj.push_back(Pair("subver", stats.strSubVer));
         obj.push_back(Pair("inbound", stats.fInbound));
         obj.push_back(Pair("releasetime", (boost::int64_t)stats.nReleaseTime));
+        obj.push_back(Pair("recvmsgs",
+            CmdStatToJSON(stats.mapRecvMsgs, stats.mapRecvMsgBytes)));
+        obj.push_back(Pair("sendmsgs",
+            CmdStatToJSON(stats.mapSendMsgs, stats.mapSendMsgBytes)));
         obj.push_back(Pair("height", stats.nStartingHeight));
         obj.push_back(Pair("banscore", stats.nMisbehavior));
 


### PR DESCRIPTION
The first commit maintains a per-node byte count, returned as "recvbytes" and "sendbytes".

The second commit maintains per-node, per-msg counters, returned as "recvmsgs" and "sendmsgs" objects.

Example output: https://gist.github.com/3021791
