### PR TITLE
Fix signed/unsigned warnings in {script,serialize}.h (fixes #1541)

### DIFF
--- a/src/script.h
+++ b/src/script.h
@@ -452,7 +452,7 @@ public:
                 memcpy(&nSize, &pc[0], 4);
                 pc += 4;
             }
-            if (end() - pc < nSize)
+            if (end() - pc < 0 || (unsigned int)(end() - pc) < nSize)
                 return false;
             if (pvchRet)
                 pvchRet->assign(pc, pc + nSize);

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -809,7 +809,8 @@ public:
 
     void insert(iterator it, const_iterator first, const_iterator last)
     {
-        if (it == vch.begin() + nReadPos && last - first <= nReadPos)
+        assert(last - first >= 0);
+        if (it == vch.begin() + nReadPos && (unsigned int)(last - first) <= nReadPos)
         {
             // special case for inserting at the front when there's room
             nReadPos -= (last - first);
@@ -821,7 +822,8 @@ public:
 
     void insert(iterator it, std::vector<char>::const_iterator first, std::vector<char>::const_iterator last)
     {
-        if (it == vch.begin() + nReadPos && last - first <= nReadPos)
+        assert(last - first >= 0);
+        if (it == vch.begin() + nReadPos && (unsigned int)(last - first) <= nReadPos)
         {
             // special case for inserting at the front when there's room
             nReadPos -= (last - first);
@@ -834,7 +836,8 @@ public:
 #if !defined(_MSC_VER) || _MSC_VER >= 1300
     void insert(iterator it, const char* first, const char* last)
     {
-        if (it == vch.begin() + nReadPos && last - first <= nReadPos)
+        assert(last - first >= 0);
+        if (it == vch.begin() + nReadPos && (unsigned int)(last - first) <= nReadPos)
         {
             // special case for inserting at the front when there's room
             nReadPos -= (last - first);


### PR DESCRIPTION
In the most obvious way possible.
