### PR TITLE
Upgrade and Shared Lock support and locking test cases.

### DIFF
--- a/src/sync.h
+++ b/src/sync.h
@@ -36,6 +36,9 @@ public:
     void lock_shared();
     bool try_lock_shared();
     void unlock_shared();
+
+    // Temporary function to allow useful warnings when upgrading shared->exclusive
+    bool has_shared();
 };
 
 /** RAII wrapper around CCriticalSection */
@@ -90,9 +93,12 @@ void static inline EnterCritical(const char* pszName, const char* pszFile, int n
 void static inline LeaveCritical() {}
 #endif
 
+void CheckLockUpgrade(const char* pszfile, int nLine, CCriticalSection& cs);
+
 #define ENTER_CRITICAL_SECTION(cs) \
     { \
         EnterCritical(#cs, __FILE__, __LINE__, (void*)(&cs)); \
+        CheckLockUpgrade(__FILE__, __LINE__, cs); \
         (cs).lock(); \
     }
 

--- a/src/test/sync_tests.cpp
+++ b/src/test/sync_tests.cpp
@@ -1,0 +1,128 @@
+#include <boost/test/unit_test.hpp>
+
+#include "sync.h"
+#include "util.h"
+
+BOOST_AUTO_TEST_SUITE(sync_tests)
+
+CCriticalSection cs;
+int nIsInCS = 0;
+bool fIsInSharedCS = false;
+bool fIsInUpgradeCS = false;
+bool fThreadOneDone = false;
+bool fThreadTwoDone = false;
+
+void ThreadOne(void* parg)
+{
+    {
+        LOCK(cs);
+        nIsInCS++;
+        Sleep(100);
+        nIsInCS--;
+    }
+    Sleep(50);
+    BOOST_CHECK_MESSAGE(nIsInCS != 0, "LOCK doesnt unlock.");
+    BOOST_CHECK_MESSAGE(nIsInCS != 1, "Multiple LOCKs in a thread deadlocks.");
+    BOOST_CHECK_MESSAGE(nIsInCS == 2, "See previous error, or int++/-- is broken.");
+    {
+        LOCK(cs);
+    }
+    BOOST_CHECK_MESSAGE(nIsInCS == 0, "Recursive lock unlocks fully after first unlock.");
+    // Finished first test set (200ms in Sleeps)
+    Sleep(50);
+    {
+        SHARED_LOCK(cs);
+        BOOST_CHECK_MESSAGE(fIsInSharedCS, "Cant get a shared lock.");
+        {
+            LOCK(cs);
+            BOOST_CHECK_MESSAGE(!fIsInSharedCS, "Lock upgrade from shared doesn't wait.");
+            nIsInCS++;
+            Sleep(100);
+            nIsInCS--;
+        }
+    }
+    Sleep(25);
+    {
+        SHARED_LOCK(cs);
+        BOOST_CHECK_MESSAGE(nIsInCS == 0, "SHARED_LOCK doesn't wait for LOCK.");
+    }
+    // Finished second test set (300ms in Sleeps)
+    Sleep(25);
+    {
+        UPGRADE_LOCK(cs);
+        fIsInUpgradeCS = true;
+        Sleep(75);
+        {
+            LOCK(cs);
+            BOOST_CHECK_MESSAGE(!fIsInSharedCS, "Lock upgrade from upgrade doesn't wait.");
+            nIsInCS++;
+            Sleep(50);
+            nIsInCS--;
+        }
+        Sleep(50);
+        fIsInUpgradeCS = false;
+    }
+    // Finished third test set (225ms in Sleeps)
+    fThreadOneDone = true;
+}
+
+void ThreadTwo(void* parg)
+{
+    Sleep(50);
+    {
+        LOCK(cs);
+        BOOST_CHECK_MESSAGE(nIsInCS == 0, "LOCK doesn't lock.");
+        nIsInCS++;
+        {
+            LOCK(cs);
+            nIsInCS++;
+            Sleep(50);
+            nIsInCS--;
+        }
+        Sleep(50);
+        nIsInCS--;
+    }
+    // Finished first test set (200ms in Sleeps)
+    Sleep(25);
+    {
+        SHARED_LOCK(cs);
+        fIsInSharedCS = true;
+        Sleep(75);
+        fIsInSharedCS = false;
+    }
+    Sleep(25);
+    {
+        LOCK(cs);
+        BOOST_CHECK_MESSAGE(nIsInCS == 0, "LOCK doesn't lock after SHARED_LOCK.");
+        nIsInCS++;
+        Sleep(100);
+        nIsInCS--;
+    }
+    // Finished second test set (300ms in Sleeps)
+    Sleep(50);
+    {
+        SHARED_LOCK(cs);
+        BOOST_CHECK_MESSAGE(fIsInUpgradeCS, "SHARED_LOCK waits for UPGRADE_LOCK.");
+        fIsInSharedCS = true;
+        Sleep(75);
+        fIsInSharedCS = false;
+    }
+    {
+        UPGRADE_LOCK(cs);
+        BOOST_CHECK_MESSAGE(nIsInCS == 0, "UPGRADE_LOCK doesn't wait for LOCK.");
+        BOOST_CHECK_MESSAGE(!fIsInUpgradeCS, "UPGRADE_LOCK is non-exclusive.");
+    }
+    // Finished third test set (225ms in Sleeps)
+    fThreadTwoDone = true;
+}
+
+BOOST_AUTO_TEST_CASE(lock_tests)
+{
+    BOOST_CHECK_MESSAGE(CreateThread(ThreadOne, NULL), "CreateThread Failed!");
+    BOOST_CHECK_MESSAGE(CreateThread(ThreadTwo, NULL), "CreateThread Failed!");
+    Sleep(750);
+    BOOST_CHECK_MESSAGE(fThreadOneDone, "CreateThread doesn't create thread or LOCK/SHARED_LOCK deadlocks.");
+    BOOST_CHECK_MESSAGE(fThreadTwoDone, "CreateThread doesn't create thread or LOCK/SHARED_LOCK deadlocks.");
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -7,12 +7,12 @@
 CWallet* pwalletMain;
 CClientUIInterface uiInterface;
 
-extern bool fPrintToConsole;
+extern bool fDontPrint;
 extern void noui_connect();
 
 struct TestingSetup {
     TestingSetup() {
-        fPrintToConsole = true; // don't want to write to debug.log file
+        fDontPrint = true; // don't want to write to debug.log file
         noui_connect();
         pwalletMain = new CWallet();
         RegisterWallet(pwalletMain);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -60,6 +60,7 @@ map<string, vector<string> > mapMultiArgs;
 bool fDebug = false;
 bool fDebugNet = false;
 bool fPrintToConsole = false;
+bool fDontPrint = false;
 bool fPrintToDebugger = false;
 bool fRequestShutdown = false;
 bool fShutdown = false;
@@ -202,7 +203,7 @@ inline int OutputDebugStringF(const char* pszFormat, ...)
         ret = vprintf(pszFormat, arg_ptr);
         va_end(arg_ptr);
     }
-    else
+    else if (!fDontPrint)
     {
         // print to debug.log
         static FILE* fileout = NULL;


### PR DESCRIPTION
This adds SHARED_LOCK, TRY_SHARED_LOCK, and UPGRADE_LOCK to complement LOCK and TRY_LOCK.

It implements the many-readers, single-writer model where any thread holding a LOCK excludes other threads from a SHARED_LOCK, but many threads can hold a SHARED_LOCK.  Only one thread can hold a UPGRADE_LOCK, it can be held while others hold a SHARED_LOCK, but it cannot be held while another thread holds a LOCK.

This should create tons of low-hanging fruit for optimization, even though it doesn't do any itself.
