### PR TITLE
Fix remaining compile warnings.

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -371,14 +371,14 @@ public:
 
         // Set the size
         unsigned int nSize = vSend.size() - nMessageStart;
-        memcpy((char*)&vSend[nHeaderStart] + offsetof(CMessageHeader, nMessageSize), &nSize, sizeof(nSize));
+        memcpy((char*)&vSend[nHeaderStart] + CMessageHeader::MESSAGE_SIZE_OFFSET, &nSize, sizeof(nSize));
 
         // Set the checksum
         uint256 hash = Hash(vSend.begin() + nMessageStart, vSend.end());
         unsigned int nChecksum = 0;
         memcpy(&nChecksum, &hash, sizeof(nChecksum));
-        assert(nMessageStart - nHeaderStart >= offsetof(CMessageHeader, nChecksum) + sizeof(nChecksum));
-        memcpy((char*)&vSend[nHeaderStart] + offsetof(CMessageHeader, nChecksum), &nChecksum, sizeof(nChecksum));
+        assert(nMessageStart - nHeaderStart >= CMessageHeader::CHECKSUM_OFFSET + sizeof(nChecksum));
+        memcpy((char*)&vSend[nHeaderStart] + CMessageHeader::CHECKSUM_OFFSET, &nChecksum, sizeof(nChecksum));
 
         if (fDebug) {
             printf("(%d bytes)\n", nSize);

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -49,8 +49,16 @@ class CMessageHeader
 
     // TODO: make private (improves encapsulation)
     public:
-        enum { COMMAND_SIZE=12 };
-        char pchMessageStart[sizeof(::pchMessageStart)];
+        enum {
+            MESSAGE_START_SIZE=sizeof(::pchMessageStart),
+            COMMAND_SIZE=12,
+            MESSAGE_SIZE_SIZE=sizeof(int),
+            CHECKSUM_SIZE=sizeof(int),
+
+            MESSAGE_SIZE_OFFSET=MESSAGE_START_SIZE+COMMAND_SIZE,
+            CHECKSUM_OFFSET=MESSAGE_SIZE_OFFSET+MESSAGE_SIZE_SIZE
+        };
+        char pchMessageStart[MESSAGE_START_SIZE];
         char pchCommand[COMMAND_SIZE];
         unsigned int nMessageSize;
         unsigned int nChecksum;


### PR DESCRIPTION
(aside from some boost::thread ones on win32)
Fixes:
src/net.h: In member function ‘void CNode::EndMessage()’:
src/net.h:374: warning: invalid access to non-static data member ‘CMessageHeader::nMessageSize’ of NULL object
src/net.h:374: warning: (perhaps the ‘offsetof’ macro was used incorrectly)
src/net.h:380: warning: invalid access to non-static data member ‘CMessageHeader::nChecksum’ of NULL object
src/net.h:380: warning: (perhaps the ‘offsetof’ macro was used incorrectly)
src/net.h:381: warning: invalid access to non-static data member ‘CMessageHeader::nChecksum’ of NULL object
src/net.h:381: warning: (perhaps the ‘offsetof’ macro was used incorrectly)

Or, put better by clang++:
src/net.h:377:46: warning: offset of on non-POD type 'CMessageHeader' [-Winvalid-offsetof]
