### PR TITLE
Make building using LLVM/Clang easier.

### DIFF
--- a/bitcoin-qt.pro
+++ b/bitcoin-qt.pro
@@ -76,8 +76,30 @@ contains(BITCOIN_NEED_QT_PLUGINS, 1) {
 !windows {
     # for extra security against potential buffer overflows
     QMAKE_CXXFLAGS += -fstack-protector
-    QMAKE_LFLAGS += -fstack-protector
+    !contains(USE_CLANG, 1) {
+        # llvm-ld doesn't have a -fstack-protector
+        QMAKE_LFLAGS += -fstack-protector
+    }
     # do not enable this on windows, as it will result in a non-working executable!
+}
+
+contains(USE_CLANG, 1) {
+    QMAKE_CC = clang
+    QMAKE_CXX = clang++
+    QMAKE_LINK = llvm-ld
+    QMAKE_LFLAGS = -native
+    QMAKE_LFLAGS_RELEASE =
+}
+
+contains(USE_LTO, 1) {
+    contains(USE_CLANG, 1) {
+        QMAKE_CFLAGS += -emit-llvm
+        QMAKE_CXXFLAGS += -emit-llvm
+    } else {
+        QMAKE_CFLAGS += -flto
+        QMAKE_CXXFLAGS += -flto
+        QMAKE_LFLAGS += -flto
+    }
 }
 
 # regenerate src/build.h

--- a/src/makefile.unix
+++ b/src/makefile.unix
@@ -66,13 +66,14 @@ LIBS+= \
     # Make some important things such as the global offset table read only as soon as
     # the dynamic linker is finished building it. This will prevent overwriting of addresses
     # which would later be jumped to.
-    HARDENING+=-Wl,-z,relro -Wl,-z,now
+    LDHARDENING+=-Wl,-z,relro -Wl,-z,now
 
     # Build position independent code to take advantage of Address Space Layout Randomization
     # offered by some kernels.
     # see doc/build-unix.txt for more information.
     ifdef PIE
-        HARDENING+=-fPIE -pie
+        HARDENING+=-fPIE
+        LDHARDENING+=-pie
     endif
 
     # -D_FORTIFY_SOURCE=2 does some checking for potentially exploitable code patterns in
@@ -87,6 +88,10 @@ DEBUGFLAGS=-g
 # adds some defaults in front. Unfortunately, CXXFLAGS=... $(CXXFLAGS) does not work.
 xCXXFLAGS=-O2 -pthread -Wall -Wextra -Wformat -Wformat-security -Wno-unused-parameter \
     $(DEBUGFLAGS) $(DEFS) $(HARDENING) $(CXXFLAGS)
+
+# LDFLAGS can be specified on the make command line, so we use xLDFLAGS that only
+# adds some defaults in front. Unfortunately, LDFLAGS=... $(LDFLAGS) does not work.
+xLDFLAGS=$(LDHARDENING) $(LDFLAGS)
 
 OBJS= \
     obj/version.o \
@@ -132,7 +137,7 @@ obj/%.o: %.cpp
 	  rm -f $(@:%.o=%.d)
 
 bitcoind: $(OBJS:obj/%=obj/%)
-	$(CXX) $(xCXXFLAGS) -o $@ $^ $(LDFLAGS) $(LIBS)
+	$(CXX) $(xCXXFLAGS) -o $@ $^ $(xLDFLAGS) $(LIBS)
 
 TESTOBJS := $(patsubst test/%.cpp,obj-test/%.o,$(wildcard test/*.cpp))
 
@@ -144,7 +149,7 @@ obj-test/%.o: test/%.cpp
 	  rm -f $(@:%.o=%.d)
 
 test_bitcoin: $(TESTOBJS) $(filter-out obj/init.o,$(OBJS:obj/%=obj/%))
-	$(CXX) $(xCXXFLAGS) -o $@ $(LIBPATHS) $^ -Wl,-B$(LMODE) -lboost_unit_test_framework $(LDFLAGS) $(LIBS)
+	$(CXX) $(xCXXFLAGS) -o $@ $(LIBPATHS) $^ -Wl,-B$(LMODE) -lboost_unit_test_framework $(xLDFLAGS) $(LIBS)
 
 clean:
 	-rm -f bitcoind test_bitcoin


### PR DESCRIPTION
This is based on #1514 and adds fixes to bitcoin-qt.pro to build with clang+lto without editing makefiles.
After this, you can use:
qmake bitcoin-qt.pro USE_CLANG=1 USE_LTO=1 && make
or
make -f makefile.unix CXX=clang++ LDFLAGS="-use-gold-plugin" CXXFLAGS=-emit-llvm
Building bitcoind requires ld-gold, however bitcoin-qt does not.

Motivation here is a speedup:
clang-lto: " block index            6523ms"
gcc-lto: " block index            8497ms"

That said, 
<gmaxwell> Seriously, every time I've seen a major speedup with clang it was miscompiling the code.
Still its interesting that there is a speedup that large, and making it easier to compile using clang is not bad.
