### PR TITLE
Add a timer to check for changes in immature or unconfirmed balances,

### DIFF
--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -18,7 +18,7 @@ ClientModel::ClientModel(OptionsModel *optionsModel, QObject *parent) :
 {
     numBlocksAtStartup = -1;
 
-    pollTimer = new QTimer();
+    pollTimer = new QTimer(this);
     pollTimer->setInterval(MODEL_UPDATE_DELAY);
     pollTimer->start();
     connect(pollTimer, SIGNAL(timeout()), this, SLOT(updateTimer()));

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -10,6 +10,10 @@ class AddressTableModel;
 class TransactionTableModel;
 class CWallet;
 
+QT_BEGIN_NAMESPACE
+class QTimer;
+QT_END_NAMESPACE
+
 class SendCoinsRecipient
 {
 public:
@@ -120,9 +124,14 @@ private:
     qint64 cachedImmatureBalance;
     qint64 cachedNumTransactions;
     EncryptionStatus cachedEncryptionStatus;
+    int cachedNumBlocks;
+
+    QTimer *pollTimer;
 
     void subscribeToCoreSignals();
     void unsubscribeFromCoreSignals();
+    void checkBalanceChanged();
+
 signals:
     // Signal that balance in wallet changed
     void balanceChanged(qint64 balance, qint64 unconfirmedBalance, qint64 immatureBalance);
@@ -148,6 +157,8 @@ public slots:
     void updateTransaction(const QString &hash, int status);
     /* New, updated or removed address book entry */
     void updateAddressBook(const QString &address, const QString &label, bool isMine, int status);
+    /* Current, immature or unconfirmed balance might have changed - emit 'balanceChanged' if so */
+    void pollBalanceChanged();
 };
 
 


### PR DESCRIPTION
when these are non-zero. Fixed a minor mem leak.

Relates to #837 and #1475.
