### PR TITLE
update Boost version to 1.49 for Windows in the Qt project file

### DIFF
--- a/bitcoin-qt.pro
+++ b/bitcoin-qt.pro
@@ -282,7 +282,7 @@ OTHER_FILES += \
 # platform specific defaults, if not overridden on command line
 isEmpty(BOOST_LIB_SUFFIX) {
     macx:BOOST_LIB_SUFFIX = -mt
-    windows:BOOST_LIB_SUFFIX = -mgw44-mt-1_43
+    windows:BOOST_LIB_SUFFIX = -mgw44-mt-s-1_49
 }
 
 isEmpty(BOOST_THREAD_LIB_SUFFIX) {


### PR DESCRIPTION
- add -s flag as we also use a static build in makefile.mingw

As we now use Boost 1.49 on Windows I think this should be updated as well.
