### PR TITLE
Fix OBO in socks5 auth proposal.

### DIFF
--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -224,7 +224,7 @@ bool static Socks5(string strDest, int port, SOCKET& hSocket)
     }
     char pszSocks5Init[] = "\5\1\0";
     char *pszSocks5 = pszSocks5Init;
-    ssize_t nSize = sizeof(pszSocks5Init);
+    ssize_t nSize = sizeof(pszSocks5Init) - 1;
 
     ssize_t ret = send(hSocket, pszSocks5, nSize, MSG_NOSIGNAL);
     if (ret != nSize)


### PR DESCRIPTION
This fixes compatibility with openssh's socks5 proxy and tor's .2.3.x branch.
