### PR TITLE
GUI: optionsdialog cleanup

### DIFF
--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -1,26 +1,17 @@
 #include "optionsdialog.h"
 #include "ui_optionsdialog.h"
 
-#include "bitcoinamountfield.h"
 #include "bitcoinunits.h"
 #include "monitoreddatamapper.h"
 #include "netbase.h"
 #include "optionsmodel.h"
-#include "qvalidatedlineedit.h"
-#include "qvaluecombobox.h"
 
-#include <QCheckBox>
 #include <QDir>
 #include <QIntValidator>
-#include <QLabel>
-#include <QLineEdit>
 #include <QLocale>
 #include <QMessageBox>
-#include <QPushButton>
 #include <QRegExp>
 #include <QRegExpValidator>
-#include <QTabWidget>
-#include <QWidget>
 
 OptionsDialog::OptionsDialog(QWidget *parent) :
     QDialog(parent),
@@ -38,18 +29,19 @@ OptionsDialog::OptionsDialog(QWidget *parent) :
     ui->mapPortUpnp->setEnabled(false);
 #endif
 
+    ui->proxyIp->setEnabled(false);
+    ui->proxyPort->setEnabled(false);
+    ui->proxyPort->setValidator(new QIntValidator(1, 65535, this));
+
     ui->socksVersion->setEnabled(false);
     ui->socksVersion->addItem("5", 5);
     ui->socksVersion->addItem("4", 4);
     ui->socksVersion->setCurrentIndex(0);
 
-    ui->proxyIp->setEnabled(false);
-    ui->proxyPort->setEnabled(false);
-    ui->proxyPort->setValidator(new QIntValidator(0, 65535, this));
-
-    connect(ui->connectSocks, SIGNAL(toggled(bool)), ui->socksVersion, SLOT(setEnabled(bool)));
     connect(ui->connectSocks, SIGNAL(toggled(bool)), ui->proxyIp, SLOT(setEnabled(bool)));
     connect(ui->connectSocks, SIGNAL(toggled(bool)), ui->proxyPort, SLOT(setEnabled(bool)));
+    connect(ui->connectSocks, SIGNAL(toggled(bool)), ui->socksVersion, SLOT(setEnabled(bool)));
+    connect(ui->connectSocks, SIGNAL(clicked(bool)), this, SLOT(showRestartWarning_Proxy()));
 
     ui->proxyIp->installEventFilter(this);
 
@@ -90,9 +82,6 @@ OptionsDialog::OptionsDialog(QWidget *parent) :
 
     ui->unit->setModel(new BitcoinUnits(this));
 
-    connect(ui->connectSocks, SIGNAL(clicked(bool)), this, SLOT(showRestartWarning_Proxy()));
-    connect(ui->lang, SIGNAL(activated(int)), this, SLOT(showRestartWarning_Lang()));
-
     /* Widget-to-option mapper */
     mapper = new MonitoredDataMapper(this);
     mapper->setSubmitPolicy(QDataWidgetMapper::ManualSubmit);
@@ -102,8 +91,8 @@ OptionsDialog::OptionsDialog(QWidget *parent) :
     connect(mapper, SIGNAL(viewModified()), this, SLOT(enableSaveButtons()));
     /* disable save buttons when new data loaded */
     connect(mapper, SIGNAL(currentIndexChanged(int)), this, SLOT(disableSaveButtons()));
-    /* disable/enable save buttons when proxy IP is invalid/valid */
-    connect(this, SIGNAL(proxyIpValid(bool)), this, SLOT(setSaveButtonState(bool)));
+    /* setup/change UI elements when proxy IP is invalid/valid */
+    connect(this, SIGNAL(proxyIpValid(QValidatedLineEdit *, bool)), this, SLOT(handleProxyIpValid(QValidatedLineEdit *, bool)));
 }
 
 OptionsDialog::~OptionsDialog()
@@ -124,8 +113,11 @@ void OptionsDialog::setModel(OptionsModel *model)
         mapper->toFirst();
     }
 
-    // update the display unit, to not use the default ("BTC")
+    /* update the display unit, to not use the default ("BTC") */
     updateDisplayUnit();
+
+    /* warn only when language selection changes (placed here so init of ui->lang via mapper doesn't trigger this) */
+    connect(ui->lang, SIGNAL(valueChanged()), this, SLOT(showRestartWarning_Lang()));
 }
 
 void OptionsDialog::setMapper()
@@ -137,10 +129,11 @@ void OptionsDialog::setMapper()
 
     /* Network */
     mapper->addMapping(ui->mapPortUpnp, OptionsModel::MapPortUPnP);
+
     mapper->addMapping(ui->connectSocks, OptionsModel::ProxyUse);
-    mapper->addMapping(ui->socksVersion, OptionsModel::ProxySocksVersion);
     mapper->addMapping(ui->proxyIp, OptionsModel::ProxyIP);
     mapper->addMapping(ui->proxyPort, OptionsModel::ProxyPort);
+    mapper->addMapping(ui->socksVersion, OptionsModel::ProxySocksVersion);
 
     /* Window */
 #ifndef Q_WS_MAC
@@ -156,7 +149,7 @@ void OptionsDialog::setMapper()
 
 void OptionsDialog::enableSaveButtons()
 {
-    // prevent enabling of the save buttons when data modified, if there is an invalid proxy address present
+    /* prevent enabling of the save buttons when data modified, if there is an invalid proxy address present */
     if(fProxyIpValid)
         setSaveButtonState(true);
 }
@@ -211,30 +204,39 @@ void OptionsDialog::updateDisplayUnit()
 {
     if(model)
     {
-        // Update transactionFee with the current unit
+        /* Update transactionFee with the current unit */
         ui->transactionFee->setDisplayUnit(model->getDisplayUnit());
+    }
+}
+
+void OptionsDialog::handleProxyIpValid(QValidatedLineEdit *object, bool fState)
+{
+    // this is used in a check before re-enabling the save buttons
+    fProxyIpValid = fState;
+
+    if(fProxyIpValid)
+    {
+        enableSaveButtons();
+        ui->statusLabel->clear();
+    }
+    else
+    {
+        disableSaveButtons();
+        object->setValid(fProxyIpValid);
+        ui->statusLabel->setStyleSheet("QLabel { color: red; }");
+        ui->statusLabel->setText(tr("The supplied proxy address is invalid."));
     }
 }
 
 bool OptionsDialog::eventFilter(QObject *object, QEvent *event)
 {
-    if(object == ui->proxyIp && event->type() == QEvent::FocusOut)
+    if(event->type() == QEvent::FocusOut)
     {
-        // Check proxyIP for a valid IPv4/IPv6 address
-        CService addr;
-        if(!LookupNumeric(ui->proxyIp->text().toStdString().c_str(), addr))
+        if(object == ui->proxyIp)
         {
-            ui->proxyIp->setValid(false);
-            fProxyIpValid = false;
-            ui->statusLabel->setStyleSheet("QLabel { color: red; }");
-            ui->statusLabel->setText(tr("The supplied proxy address is invalid."));
-            emit proxyIpValid(false);
-        }
-        else
-        {
-            fProxyIpValid = true;
-            ui->statusLabel->clear();
-            emit proxyIpValid(true);
+            CService addr;
+            /* Check proxyIp for a valid IPv4/IPv6 address and emit the proxyIpValid signal */
+            emit proxyIpValid(ui->proxyIp, LookupNumeric(ui->proxyIp->text().toStdString().c_str(), addr));
         }
     }
     return QDialog::eventFilter(object, event);

--- a/src/qt/optionsdialog.h
+++ b/src/qt/optionsdialog.h
@@ -8,6 +8,7 @@ class OptionsDialog;
 }
 class OptionsModel;
 class MonitoredDataMapper;
+class QValidatedLineEdit;
 
 /** Preferences dialog. */
 class OptionsDialog : public QDialog
@@ -38,9 +39,10 @@ private slots:
     void showRestartWarning_Proxy();
     void showRestartWarning_Lang();
     void updateDisplayUnit();
+    void handleProxyIpValid(QValidatedLineEdit *object, bool fState);
 
 signals:
-    void proxyIpValid(bool fValid);
+    void proxyIpValid(QValidatedLineEdit *object, bool fValid);
 
 private:
     Ui::OptionsDialog *ui;


### PR DESCRIPTION
This pull is intended to prepare the optionsdialog for further changes to the proxy options and includes a few changes that would bloat a proxy options pull.
- remove duplicate includes, that are already present in ui_optionsdialog.h
- change QIntValidator to not allow 0 as port-number
- re-order some function calls to match the Ui element order, for better readbility and to prepare for the addition of further IPv6 and Tor proxy options
- restat warning for the language selection is only shown, when the
  language was changed (not on simply activating the Ui element)
- modify proxy warning message "This setting..." into "Proxy settings..."
- split check for object == ui->proxyIp into seperate if-clause
- unify used format for comments in the code
-  introduce handleProxyIpValid() function, which handles UI elements and the save button states for valid/invalid
  proxy IPs

This is what I intend to do with the proxy options (not included here):
![planned proxy options](http://i45.tinypic.com/5a5ef9.png)
