### PR TITLE
GUI: optionsmodel cleanup

### DIFF
--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -144,8 +144,6 @@ QVariant OptionsModel::data(const QModelIndex & index, int role) const
             return QVariant(fMinimizeOnClose);
         case ProxyUse:
             return settings.value("fUseProxy", false);
-        case ProxySocksVersion:
-            return settings.value("nSocksVersion", 5);
         case ProxyIP: {
             CService addrProxy;
             if (GetProxy(NET_IPV4, addrProxy))
@@ -160,6 +158,8 @@ QVariant OptionsModel::data(const QModelIndex & index, int role) const
             else
                 return 9050;
         }
+        case ProxySocksVersion:
+            return settings.value("nSocksVersion", 5);
         case Fee:
             return QVariant(nTransactionFee);
         case DisplayUnit:
@@ -192,11 +192,9 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
             settings.setValue("fMinimizeToTray", fMinimizeToTray);
             break;
         case MapPortUPnP:
-            {
-                fUseUPnP = value.toBool();
-                settings.setValue("fUseUPnP", fUseUPnP);
-                MapPort();
-            }
+            fUseUPnP = value.toBool();
+            settings.setValue("fUseUPnP", fUseUPnP);
+            MapPort();
             break;
         case MinimizeOnClose:
             fMinimizeOnClose = value.toBool();
@@ -206,60 +204,41 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
             settings.setValue("fUseProxy", value.toBool());
             ApplyProxySettings();
             break;
-        case ProxySocksVersion:
-            settings.setValue("nSocksVersion", value.toInt());
-            ApplyProxySettings();
-            break;
         case ProxyIP:
             {
                 CService addrProxy("127.0.0.1", 9050);
                 GetProxy(NET_IPV4, addrProxy);
                 CNetAddr addr(value.toString().toStdString());
-                if (addr.IsValid())
-                {
-                    addrProxy.SetIP(addr);
-                    settings.setValue("addrProxy", addrProxy.ToStringIPPort().c_str());
-                    successful = ApplyProxySettings();
-                }
-                else
-                {
-                    successful = false;
-                }
+                addrProxy.SetIP(addr);
+                settings.setValue("addrProxy", addrProxy.ToStringIPPort().c_str());
+                successful = ApplyProxySettings();
             }
             break;
         case ProxyPort:
             {
                 CService addrProxy("127.0.0.1", 9050);
                 GetProxy(NET_IPV4, addrProxy);
-                int nPort = atoi(value.toString().toAscii().data());
-                if (nPort > 0 && nPort < std::numeric_limits<unsigned short>::max())
-                {
-                    addrProxy.SetPort(nPort);
-                    settings.setValue("addrProxy", addrProxy.ToStringIPPort().c_str());
-                    successful = ApplyProxySettings();
-                }
-                else
-                {
-                    successful = false;
-                }
+                addrProxy.SetPort(value.toInt());
+                settings.setValue("addrProxy", addrProxy.ToStringIPPort().c_str());
+                successful = ApplyProxySettings();
             }
             break;
-        case Fee: {
+        case ProxySocksVersion:
+            settings.setValue("nSocksVersion", value.toInt());
+            ApplyProxySettings();
+            break;
+        case Fee:
             nTransactionFee = value.toLongLong();
             settings.setValue("nTransactionFee", nTransactionFee);
-            }
             break;
-        case DisplayUnit: {
-            int unit = value.toInt();
-            nDisplayUnit = unit;
+        case DisplayUnit:
+            nDisplayUnit = value.toInt();
             settings.setValue("nDisplayUnit", nDisplayUnit);
-            emit displayUnitChanged(unit);
-            }
+            emit displayUnitChanged(nDisplayUnit);
             break;
-        case DisplayAddresses: {
+        case DisplayAddresses:
             bDisplayAddresses = value.toBool();
             settings.setValue("bDisplayAddresses", bDisplayAddresses);
-            }
             break;
         case DetachDatabases: {
             bool fDetachDB = value.toBool();
@@ -267,9 +246,8 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
             settings.setValue("detachDB", fDetachDB);
             }
             break;
-        case Language: {
+        case Language:
             settings.setValue("language", value);
-            }
             break;
         default:
             break;

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -12,23 +12,24 @@
 class OptionsModel : public QAbstractListModel
 {
     Q_OBJECT
+
 public:
     explicit OptionsModel(QObject *parent = 0);
 
     enum OptionID {
-        StartAtStartup, // bool
-        MinimizeToTray, // bool
-        MapPortUPnP, // bool
-        MinimizeOnClose, // bool
-        ProxyUse, // bool
+        StartAtStartup,    // bool
+        MinimizeToTray,    // bool
+        MapPortUPnP,       // bool
+        MinimizeOnClose,   // bool
+        ProxyUse,          // bool
+        ProxyIP,           // QString
+        ProxyPort,         // int
         ProxySocksVersion, // int
-        ProxyIP, // QString
-        ProxyPort, // int
-        Fee, // qint64
-        DisplayUnit, // BitcoinUnits::Unit
-        DisplayAddresses, // bool
-        DetachDatabases, // bool
-        Language, // QString
+        Fee,               // qint64
+        DisplayUnit,       // BitcoinUnits::Unit
+        DisplayAddresses,  // bool
+        DetachDatabases,   // bool
+        Language,          // QString
         OptionIDRowCount,
     };
 
@@ -48,17 +49,16 @@ public:
     int getDisplayUnit();
     bool getDisplayAddresses();
     QString getLanguage() { return language; }
+
 private:
     int nDisplayUnit;
     bool bDisplayAddresses;
     bool fMinimizeToTray;
     bool fMinimizeOnClose;
     QString language;
+
 signals:
     void displayUnitChanged(int unit);
-
-public slots:
-
 };
 
 #endif // OPTIONSMODEL_H


### PR DESCRIPTION
- cleanup optionsmodel before adding new proxy options
- place SOCKS version stuff below proxy port (IP, Port, SOCKS version)
- simplyfy some parts of the code (e.g. don't check IP and port, as this
  is done in optionsdialog anyway, remove unneeded {} in switch/case)
- small comsetic changed in the header for better readability

This is what I intend to do with the proxy options (not included here):
![planned proxy options](http://i45.tinypic.com/5a5ef9.png)
