### PR TITLE
fix for build.h regeneration failure when compiling on Windows

### DIFF
--- a/bitcoin-qt.pro
+++ b/bitcoin-qt.pro
@@ -81,7 +81,7 @@ contains(BITCOIN_NEED_QT_PLUGINS, 1) {
 }
 
 # regenerate src/build.h
-!windows || contains(USE_BUILD_INFO, 1) {
+!windows|contains(USE_BUILD_INFO, 1) {
     genbuild.depends = FORCE
     genbuild.commands = cd $$PWD; /bin/sh share/genbuild.sh $$OUT_PWD/build/build.h
     genbuild.target = $$OUT_PWD/build/build.h


### PR DESCRIPTION
- as the "||" operator is not known to qmake use "|" instead,
  which ensures the code in brackets does never get executed on Windows
