### PR TITLE
Specify SIGHASH_ to use with signrawtransaction 

### DIFF
--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -2957,8 +2957,9 @@ void ConvertTo(Value& value)
     {
         // reinterpret string as unquoted json value
         Value value2;
-        if (!read_string(value.get_str(), value2))
-            throw runtime_error("type mismatch");
+        string strJSON = value.get_str();
+        if (!read_string(strJSON, value2))
+            throw runtime_error(string("Error parsing JSON:")+strJSON);
         value = value2.get_value<T>();
     }
     else


### PR DESCRIPTION
I wanted this to create a transaction on testnet that exercised all of the SIGHASH_ modes (see txid 8ccc87b72d766ab3128f03176bb1c98293f2d1f85ebfaf07b82cc81ea6891fa9 on testnet3)

It adds a fourth optional string argument to signrawtransaction, which can be ALL / NONE / SINGLE / ALL|ANYONECANPAY / etc.  It just converts the string to one of the enum SIGHASH_ constants and then uses that signing mode when signing.

I created that testnet transaction by:
- I manually created a raw transaction with six inputs and 7 outputs
- I extracted the private keys (using dumpprivkey) corresponding to the six inputs
- I called signrawtransaction six times to sign each of the six inputs separately, passing in just one of the private keys and using a different SIGHASH_ mode each time.
- I called sendrawtransaction to broadcast the completed transaction.
