### PR TITLE
Update the comment in GetBlockValue() to better reflect the uncertainty about the time interval between subsidy reductions

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -828,7 +828,7 @@ int64 static GetBlockValue(int nHeight, int64 nFees)
 {
     int64 nSubsidy = 50 * COIN;
 
-    // Subsidy is cut in half every 4 years
+    // Subsidy is cut in half every 210000 blocks, which will occur approximately every 4 years
     nSubsidy >>= (nHeight / 210000);
 
     return nSubsidy + nFees;


### PR DESCRIPTION
Update the comment in GetBlockValue() to better reflect the uncertainty about the time interval between subsidy reductions
