### PR TITLE
Bitcoin-Qt (Windows only): enable DEP for bitcoin-qt.exe

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -312,10 +312,22 @@ bool AppInit2()
     // Disable confusing "helpful" text message on abort, Ctrl-C
     _set_abort_behavior(0, _WRITE_ABORT_MSG | _CALL_REPORTFAULT);
 #endif
-#ifndef WIN32
-    umask(077);
+#ifdef WIN32
+    // Enable Data Execution Prevention (DEP)
+    // Minimum supported OS versions: WinXP SP3, WinVista >= SP1, Win Server 2008
+    // A failure is non-critical and needs no further attention!
+#ifndef PROCESS_DEP_ENABLE
+// We define this here, because GCCs winbase.h limits this to _WIN32_WINNT >= 0x0601 (Windows 7),
+// which is not correct. Can be removed, when GCCs winbase.h is fixed!
+#define PROCESS_DEP_ENABLE 0x00000001
+#endif
+    typedef BOOL (WINAPI *PSETPROCDEPPOL)(DWORD);
+    PSETPROCDEPPOL setProcDEPPol = (PSETPROCDEPPOL)GetProcAddress(GetModuleHandleA("Kernel32.dll"), "SetProcessDEPPolicy");
+    if (setProcDEPPol != NULL) setProcDEPPol(PROCESS_DEP_ENABLE);
 #endif
 #ifndef WIN32
+    umask(077);
+
     // Clean shutdown on SIGTERM
     struct sigaction sa;
     sa.sa_handler = HandleSIGTERM;


### PR DESCRIPTION
- this enables DEP on all Windows version which support the
  SetProcessDEPPolicy() call in Kernel32.dll
- use a dynamic approach via GetProcAddress() to not rely on headers or
  compiler libs
- this is the same way the Tor-project does it

See https://en.wikipedia.org/wiki/Data_Execution_Prevention for a detailed explanation of DEP! It is possible to enable this directly when linking, but this needs much more testing than this small patch :). I consider it a valuable 0.7 security feature on Windows.

To verify if DEP is enabled for bitcoin-qt.exe you can use Sysinternals ProcessExplorer:

![verify DEP state](http://i48.tinypic.com/r8tesl.png)
