### PR TITLE
Don't stay connected to old-version peers

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2390,6 +2390,12 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
             pfrom->fDisconnect = true;
             return false;
         }
+        if (fTestNet && pfrom->nVersion < TESTNET3_VERSION)
+        {
+            printf("partner %s using obsolete version %i; banning\n", pfrom->addr.ToString().c_str(), pfrom->nVersion);
+            pfrom->Misbehaving(100);
+            return false;
+        }
 
         if (pfrom->nVersion == 10300)
             pfrom->nVersion = 300;

--- a/src/version.h
+++ b/src/version.h
@@ -46,4 +46,7 @@ static const int NOBLKS_VERSION_END = 32400;
 // BIP 0031, pong message, is enabled for all versions AFTER this one
 static const int BIP0031_VERSION = 60000;
 
+// testnet3 minimum version
+static const int TESTNET3_VERSION = 60001;
+
 #endif


### PR DESCRIPTION
If running on the testnet, this disconnects and bans any peers that are running PROTOCOL_VERSION 60000 or earlier.  This cuts way down on the number of peers that try to send you a testnet1 or 2 block chain.

If PROCOTOL_VERSION is bumped before the 0.7 release, TESTNET3_VERSION should be increased to match.
