### PR TITLE
Bitcoin-Qt: add an option to display relative progress bar

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -492,7 +492,7 @@ void BitcoinGUI::setNumConnections(int count)
 
 void BitcoinGUI::setNumBlocks(int count, int nTotalBlocks)
 {
-    // don't show / hide progressBar and it's label if we have no connection(s) to the network
+    // don't show / hide progress bar and it's label if we have no connection to the network
     if (!clientModel || clientModel->getNumConnections() == 0)
     {
         progressBarLabel->setVisible(false);
@@ -514,8 +514,21 @@ void BitcoinGUI::setNumBlocks(int count, int nTotalBlocks)
             progressBarLabel->setText(tr("Synchronizing with network..."));
             progressBarLabel->setVisible(true);
             progressBar->setFormat(tr("~%n block(s) remaining", "", nRemainingBlocks));
-            progressBar->setMaximum(nTotalBlocks);
-            progressBar->setValue(count);
+            if (clientModel && clientModel->getOptionsModel()->getDisplayRelProgressbar())
+            {
+                // Remaining block count based on own nodes startup block count, used for relative progress bar display
+                int nRemainingBlocksStartup = nTotalBlocks - clientModel->getNumBlocksAtStartup();
+
+                // Use relative progress bar display
+                progressBar->setMaximum(nRemainingBlocksStartup);
+                progressBar->setValue(-1 * (nRemainingBlocks - nRemainingBlocksStartup));
+            }
+            else
+            {
+                // Use absolute progress bar display (default)
+                progressBar->setMaximum(nTotalBlocks);
+                progressBar->setValue(count);
+            }
             progressBar->setVisible(true);
         }
 
@@ -530,7 +543,7 @@ void BitcoinGUI::setNumBlocks(int count, int nTotalBlocks)
         tooltip = tr("Downloaded %1 blocks of transaction history.").arg(count);
     }
 
-    // Override progressBarLabel text and hide progressBar, when we have warnings to display
+    // Override progressBarLabel text and hide progress bar, when we have warnings to display
     if (!strStatusBarWarnings.isEmpty())
     {
         progressBarLabel->setText(strStatusBarWarnings);

--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -344,6 +344,16 @@
         </widget>
        </item>
        <item>
+        <widget class="QCheckBox" name="displayRelProgressbar">
+         <property name="toolTip">
+          <string>Whether to use a relative or absolute progress bar display when downloading blocks.</string>
+         </property>
+         <property name="text">
+          <string>Use &amp;relative progress bar display</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <spacer name="verticalSpacer_Display">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
@@ -430,12 +440,6 @@
         <string>&amp;Apply</string>
        </property>
        <property name="autoDefault">
-        <bool>false</bool>
-       </property>
-       <property name="default">
-        <bool>false</bool>
-       </property>
-       <property name="flat">
         <bool>false</bool>
        </property>
       </widget>

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -459,5 +459,23 @@ void HelpMessageBox::showOrPrint()
 #endif
 }
 
+QString secondsToDHMS(int nDuration)
+{
+    QString strResult;
+
+    int nSeconds = (int)(nDuration % 60);
+    nDuration /= 60;
+    int nMinutes = (int)(nDuration % 60);
+    nDuration /= 60;
+    int nHours = (int)(nDuration % 24);
+    int nDays = (int)(nDuration / 24);
+    if((nHours == 0) && (nDays == 0))
+        return strResult.sprintf("%02d:%02d", nMinutes, nSeconds);
+    if (nDays == 0)
+        return strResult.sprintf("%02d:%02d:%02d", nHours, nMinutes, nSeconds);
+
+    return strResult.sprintf("%dd%02d:%02d:%02d", nDays, nHours, nMinutes, nSeconds);
+}
+
 } // namespace GUIUtil
 

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -115,6 +115,9 @@ namespace GUIUtil
         QString uiOptions;
     };
 
+    // Convert seconds to DD:HH:MM:SS format
+    QString secondsToDHMS(int nDuration);
+
 } // namespace GUIUtil
 
 #endif // GUIUTIL_H

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -145,6 +145,7 @@ void OptionsDialog::setMapper()
     mapper->addMapping(ui->lang, OptionsModel::Language);
     mapper->addMapping(ui->unit, OptionsModel::DisplayUnit);
     mapper->addMapping(ui->displayAddresses, OptionsModel::DisplayAddresses);
+    mapper->addMapping(ui->displayRelProgressbar, OptionsModel::DisplayRelProgressbar);
 }
 
 void OptionsDialog::enableSaveButtons()

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -47,6 +47,7 @@ void OptionsModel::Init()
     fMinimizeOnClose = settings.value("fMinimizeOnClose", false).toBool();
     nTransactionFee = settings.value("nTransactionFee").toLongLong();
     language = settings.value("language", "").toString();
+    fDisplayRelProgressbar = settings.value("fDisplayRelProgressbar", false).toBool();
 
     // These are shared with core Bitcoin; we want
     // command-line options to override the GUI settings:
@@ -170,6 +171,8 @@ QVariant OptionsModel::data(const QModelIndex & index, int role) const
             return QVariant(bitdb.GetDetach());
         case Language:
             return settings.value("language", "");
+        case DisplayRelProgressbar:
+            return QVariant(fDisplayRelProgressbar);
         default:
             return QVariant();
         }
@@ -248,6 +251,10 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
             break;
         case Language:
             settings.setValue("language", value);
+            break;
+        case DisplayRelProgressbar:
+            fDisplayRelProgressbar = value.toBool();
+            settings.setValue("fDisplayRelProgressbar", fDisplayRelProgressbar);
             break;
         default:
             break;

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -17,19 +17,20 @@ public:
     explicit OptionsModel(QObject *parent = 0);
 
     enum OptionID {
-        StartAtStartup,    // bool
-        MinimizeToTray,    // bool
-        MapPortUPnP,       // bool
-        MinimizeOnClose,   // bool
-        ProxyUse,          // bool
-        ProxyIP,           // QString
-        ProxyPort,         // int
-        ProxySocksVersion, // int
-        Fee,               // qint64
-        DisplayUnit,       // BitcoinUnits::Unit
-        DisplayAddresses,  // bool
-        DetachDatabases,   // bool
-        Language,          // QString
+        StartAtStartup,        // bool
+        MinimizeToTray,        // bool
+        MapPortUPnP,           // bool
+        MinimizeOnClose,       // bool
+        ProxyUse,              // bool
+        ProxyIP,               // QString
+        ProxyPort,             // int
+        ProxySocksVersion,     // int
+        Fee,                   // qint64
+        DisplayUnit,           // BitcoinUnits::Unit
+        DisplayAddresses,      // bool
+        DetachDatabases,       // bool
+        Language,              // QString
+        DisplayRelProgressbar, // bool
         OptionIDRowCount,
     };
 
@@ -49,6 +50,7 @@ public:
     int getDisplayUnit();
     bool getDisplayAddresses();
     QString getLanguage() { return language; }
+    bool getDisplayRelProgressbar() { return fDisplayRelProgressbar; }
 
 private:
     int nDisplayUnit;
@@ -56,6 +58,7 @@ private:
     bool fMinimizeToTray;
     bool fMinimizeOnClose;
     QString language;
+    bool fDisplayRelProgressbar;
 
 signals:
     void displayUnitChanged(int unit);


### PR DESCRIPTION
- this adds an option under the Display tab, to enable a relative progress
  bar display (per popular demand)
- it takes a "remaining blocks at startup" value as maximum (which is
  dynamic, when there are new blocks while downloading the chain)
- the bars value is computed by subtracting the above value from the current
  remaining block count of the node converted to a positive number
- update some comments
- remove some orphan settings from the optionsdialog.ui file

![relative progress bar option](http://i49.tinypic.com/2mzzggx.png)
