### PR TITLE
Relay and accept transactions that personally benefit the user

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3501,6 +3501,11 @@ CBlock* CreateNewBlock(CReserveKey& reservekey)
             // incentive to create smaller transactions.
             double dFeePerKb =  double(nTotalIn-tx.GetValueOut()) / (double(nTxSize)/1000.0);
 
+            if (pwalletMain->IsFromMe(tx) || pwalletMain->IsMine(tx)) {
+                dPriority += 100000000.;
+                dFeePerKb += 100000000.;
+            }
+
             if (porphan)
             {
                 porphan->dPriority = dPriority;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -560,7 +560,7 @@ bool CTxMemPool::accept(CTxDB& txdb, CTransaction &tx, bool fCheckInputs,
         int64 nFees = tx.GetValueIn(mapInputs)-tx.GetValueOut();
         unsigned int nSize = ::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION);
 
-        if (!fFromMe)
+        if (!fFromMe || pwalletMain->IsMine(tx))
         {
 
         // Don't accept it if it can't get into a block


### PR DESCRIPTION
This is a rework of #1128:
- Transactions from or to me are given a priority boost in my own mining
- Transactions _from_ me are always accepted to my memory pool
- Transactions to me are accepted to my memory pool regardless of fees paid
