### PR TITLE
small UX update for optionsdialog

### DIFF
--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -432,12 +432,6 @@
        <property name="autoDefault">
         <bool>false</bool>
        </property>
-       <property name="default">
-        <bool>false</bool>
-       </property>
-       <property name="flat">
-        <bool>false</bool>
-       </property>
       </widget>
      </item>
     </layout>

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -87,10 +87,10 @@ OptionsDialog::OptionsDialog(QWidget *parent) :
     mapper->setSubmitPolicy(QDataWidgetMapper::ManualSubmit);
     mapper->setOrientation(Qt::Vertical);
 
-    /* enable save buttons when data modified */
-    connect(mapper, SIGNAL(viewModified()), this, SLOT(enableSaveButtons()));
-    /* disable save buttons when new data loaded */
-    connect(mapper, SIGNAL(currentIndexChanged(int)), this, SLOT(disableSaveButtons()));
+    /* enable apply button when data modified */
+    connect(mapper, SIGNAL(viewModified()), this, SLOT(enableApplyButton()));
+    /* disable apply button when new data loaded */
+    connect(mapper, SIGNAL(currentIndexChanged(int)), this, SLOT(disableApplyButton()));
     /* setup/change UI elements when proxy IP is invalid/valid */
     connect(this, SIGNAL(proxyIpValid(QValidatedLineEdit *, bool)), this, SLOT(handleProxyIpValid(QValidatedLineEdit *, bool)));
 }
@@ -116,8 +116,11 @@ void OptionsDialog::setModel(OptionsModel *model)
     /* update the display unit, to not use the default ("BTC") */
     updateDisplayUnit();
 
-    /* warn only when language selection changes (placed here so init of ui->lang via mapper doesn't trigger this) */
+    /* warn only when language selection changes by user action (placed here so init via mapper doesn't trigger this) */
     connect(ui->lang, SIGNAL(valueChanged()), this, SLOT(showRestartWarning_Lang()));
+
+    /* disable apply button after settings are loaded as there is nothing to save */
+    disableApplyButton();
 }
 
 void OptionsDialog::setMapper()
@@ -145,6 +148,16 @@ void OptionsDialog::setMapper()
     mapper->addMapping(ui->lang, OptionsModel::Language);
     mapper->addMapping(ui->unit, OptionsModel::DisplayUnit);
     mapper->addMapping(ui->displayAddresses, OptionsModel::DisplayAddresses);
+}
+
+void OptionsDialog::enableApplyButton()
+{
+    ui->applyButton->setEnabled(true);
+}
+
+void OptionsDialog::disableApplyButton()
+{
+    ui->applyButton->setEnabled(false);
 }
 
 void OptionsDialog::enableSaveButtons()
@@ -179,7 +192,7 @@ void OptionsDialog::on_cancelButton_clicked()
 void OptionsDialog::on_applyButton_clicked()
 {
     mapper->submit();
-    ui->applyButton->setEnabled(false);
+    disableApplyButton();
 }
 
 void OptionsDialog::showRestartWarning_Proxy()

--- a/src/qt/optionsdialog.h
+++ b/src/qt/optionsdialog.h
@@ -26,6 +26,10 @@ protected:
     bool eventFilter(QObject *object, QEvent *event);
 
 private slots:
+    /* enable only apply button */
+    void enableApplyButton();
+    /* disable only apply button */
+    void disableApplyButton();
     /* enable apply button and OK button */
     void enableSaveButtons();
     /* disable apply button and OK button */


### PR DESCRIPTION
- add enableApplyButton() and disableApplyButton() to optionsdialog.{h/cpp}
- they are used to ensure the Ok button does not get disabled, when Apply needs to be disabled (standard UX should allow Ok always to dismiss the dialog and only disable it, when we have a faulty proxy IP)
- disable Apply after initially loading the settings, as nothing new needs to be saved
- remove orphan settings from optionsdialog.ui that are default anyway
