### PR TITLE
Report 'neverseen' TXs: the number of TXs in block, but not memory pool

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -648,9 +648,10 @@ bool CTxMemPool::remove(CTransaction &tx)
                 mapNextTx.erase(txin.prevout);
             mapTx.erase(hash);
             nTransactionsUpdated++;
+            return true;                     // success, TX was removed
         }
     }
-    return true;
+    return false;                            // failure, TX not found
 }
 
 void
@@ -1552,7 +1553,8 @@ bool static Reorganize(CTxDB& txdb, CBlockIndex* pindexNew)
 
 
 // Called from inside SetBestChain: attaches a block to the new best chain being built
-bool CBlock::SetBestChainInner(CTxDB& txdb, CBlockIndex *pindexNew)
+bool CBlock::SetBestChainInner(CTxDB& txdb, CBlockIndex *pindexNew,
+                               unsigned int& neverseen)
 {
     uint256 hash = GetHash();
 
@@ -1571,7 +1573,8 @@ bool CBlock::SetBestChainInner(CTxDB& txdb, CBlockIndex *pindexNew)
 
     // Delete redundant memory transactions
     BOOST_FOREACH(CTransaction& tx, vtx)
-        mempool.remove(tx);
+        if (!mempool.remove(tx))
+            neverseen++;
 
     return true;
 }
@@ -1579,6 +1582,8 @@ bool CBlock::SetBestChainInner(CTxDB& txdb, CBlockIndex *pindexNew)
 bool CBlock::SetBestChain(CTxDB& txdb, CBlockIndex* pindexNew)
 {
     uint256 hash = GetHash();
+    unsigned int neverseen = 0;
+    string strNeverSeen;
 
     if (!txdb.TxnBegin())
         return error("SetBestChain() : TxnBegin failed");
@@ -1592,8 +1597,9 @@ bool CBlock::SetBestChain(CTxDB& txdb, CBlockIndex* pindexNew)
     }
     else if (hashPrevBlock == hashBestChain)
     {
-        if (!SetBestChainInner(txdb, pindexNew))
+        if (!SetBestChainInner(txdb, pindexNew, neverseen))
             return error("SetBestChain() : SetBestChainInner failed");
+        strNeverSeen = strprintf("  neverseen=%u", neverseen);
     }
     else
     {
@@ -1636,7 +1642,7 @@ bool CBlock::SetBestChain(CTxDB& txdb, CBlockIndex* pindexNew)
                 break;
             }
             // errors now are not fatal, we still did a reorganisation to a new chain in a valid way
-            if (!block.SetBestChainInner(txdb, pindex))
+            if (!block.SetBestChainInner(txdb, pindex, neverseen))
                 break;
         }
     }
@@ -1657,9 +1663,10 @@ bool CBlock::SetBestChain(CTxDB& txdb, CBlockIndex* pindexNew)
     bnBestChainWork = pindexNew->bnChainWork;
     nTimeBestReceived = GetTime();
     nTransactionsUpdated++;
-    printf("SetBestChain: new best=%s  height=%d  work=%s  date=%s\n",
+    printf("SetBestChain: new best=%s  height=%d  work=%s  date=%s%s\n",
       hashBestChain.ToString().substr(0,20).c_str(), nBestHeight, bnBestChainWork.ToString().c_str(),
-      DateTimeStrFormat("%x %H:%M:%S", pindexBest->GetBlockTime()).c_str());
+      DateTimeStrFormat("%x %H:%M:%S", pindexBest->GetBlockTime()).c_str(),
+      strNeverSeen.c_str());
 
     // Check the version of the last 100 blocks to see if we need to upgrade:
     if (!fIsInitialDownload)

--- a/src/main.h
+++ b/src/main.h
@@ -1025,7 +1025,7 @@ public:
     bool AcceptBlock();
 
 private:
-    bool SetBestChainInner(CTxDB& txdb, CBlockIndex *pindexNew);
+    bool SetBestChainInner(CTxDB& txdb, CBlockIndex *pindexNew, unsigned int& neverseen);
 };
 
 


### PR DESCRIPTION
This statistic is only reported when a new block appends onto the
strongest chain.

Tested by comparing bitcoind new-block results with pynode, which performs a similar calculation.
