### PR TITLE
Use full block hash as unique identifier in debug.log

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -176,7 +176,7 @@ CBlockIndex * InsertBlockIndex(uint256 hash);
 
 static inline std::string BlockHashStr(const uint256& hash)
 {
-    return hash.ToString().substr(0, 20);
+    return hash.ToString();
 }
 
 bool GetWalletFile(CWallet* pwallet, std::string &strWalletFileOut);

--- a/src/main.h
+++ b/src/main.h
@@ -174,6 +174,11 @@ CBlockIndex * InsertBlockIndex(uint256 hash);
 
 
 
+static inline std::string BlockHashStr(const uint256& hash)
+{
+    return hash.ToString().substr(0, 20);
+}
+
 bool GetWalletFile(CWallet* pwallet, std::string &strWalletFileOut);
 
 class CDiskBlockPos
@@ -1257,9 +1262,9 @@ public:
     void print() const
     {
         printf("CBlock(hash=%s, ver=%d, hashPrevBlock=%s, hashMerkleRoot=%s, nTime=%u, nBits=%08x, nNonce=%u, vtx=%"PRIszu")\n",
-            GetHash().ToString().substr(0,20).c_str(),
+            BlockHashStr(GetHash()).c_str(),
             nVersion,
-            hashPrevBlock.ToString().substr(0,20).c_str(),
+            BlockHashStr(hashPrevBlock).c_str(),
             hashMerkleRoot.ToString().substr(0,10).c_str(),
             nTime, nBits, nNonce,
             vtx.size());
@@ -1570,7 +1575,7 @@ public:
         return strprintf("CBlockIndex(pprev=%p, pnext=%p, nHeight=%d, merkle=%s, hashBlock=%s)",
             pprev, pnext, nHeight,
             hashMerkleRoot.ToString().substr(0,10).c_str(),
-            GetBlockHash().ToString().substr(0,20).c_str());
+            BlockHashStr(GetBlockHash()).c_str());
     }
 
     void print() const
@@ -1651,7 +1656,7 @@ public:
         str += CBlockIndex::ToString();
         str += strprintf("\n                hashBlock=%s, hashPrev=%s)",
             GetBlockHash().ToString().c_str(),
-            hashPrev.ToString().substr(0,20).c_str());
+            BlockHashStr(hashPrev).c_str());
         return str;
     }
 

--- a/src/net.h
+++ b/src/net.h
@@ -67,12 +67,6 @@ void SetReachable(enum Network net, bool fFlag = true);
 CAddress GetLocalAddress(const CNetAddr *paddrPeer = NULL);
 
 
-enum
-{
-    MSG_TX = 1,
-    MSG_BLOCK,
-};
-
 /** Thread types */
 enum threadId
 {

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -6,6 +6,7 @@
 #include "protocol.h"
 #include "util.h"
 #include "netbase.h"
+#include "main.h"
 
 #ifndef WIN32
 # include <arpa/inet.h>
@@ -140,6 +141,11 @@ const char* CInv::GetCommand() const
 
 std::string CInv::ToString() const
 {
+    if (type == MSG_BLOCK)
+        return strprintf("%s %s", GetCommand(), BlockHashStr(hash).c_str());
+    if (type == MSG_TX)
+        return strprintf("%s %s", GetCommand(), hash.ToString().substr(0,10).c_str());
+
     return strprintf("%s %s", GetCommand(), hash.ToString().substr(0,20).c_str());
 }
 

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -134,4 +134,10 @@ class CInv
         uint256 hash;
 };
 
+enum
+{
+    MSG_TX = 1,
+    MSG_BLOCK,
+};
+
 #endif // __INCLUDED_PROTOCOL_H__


### PR DESCRIPTION
This is a rebase and cleanup of #1426

Note that while these bits are less significant numerically, they are more useful because they are likely to be unique (whereas the most significant bits will generally be zero)
