### PR TITLE
Listunspent txout address filtering and listaddressgroupings

### DIFF
--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -231,6 +231,7 @@ static const CRPCCommand vRPCCommands[] =
     { "getblockhash",           &getblockhash,           false,  false },
     { "gettransaction",         &gettransaction,         false,  false },
     { "listtransactions",       &listtransactions,       false,  false },
+    { "listaddressgroupings",   &listaddressgroupings,   false,  false },
     { "signmessage",            &signmessage,            false,  false },
     { "verifymessage",          &verifymessage,          false,  false },
     { "getwork",                &getwork,                true,   false },

--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -1140,6 +1140,7 @@ Array RPCConvertValues(const std::string &strMethod, const std::vector<std::stri
     if (strMethod == "addmultisigaddress"     && n > 1) ConvertTo<Array>(params[1]);
     if (strMethod == "listunspent"            && n > 0) ConvertTo<boost::int64_t>(params[0]);
     if (strMethod == "listunspent"            && n > 1) ConvertTo<boost::int64_t>(params[1]);
+    if (strMethod == "listunspent"            && n > 2) ConvertTo<Array>(params[2]);
     if (strMethod == "getrawtransaction"      && n > 1) ConvertTo<boost::int64_t>(params[1]);
     if (strMethod == "createrawtransaction"   && n > 0) ConvertTo<Array>(params[0]);
     if (strMethod == "createrawtransaction"   && n > 1) ConvertTo<Object>(params[1]);

--- a/src/bitcoinrpc.h
+++ b/src/bitcoinrpc.h
@@ -114,6 +114,7 @@ extern json_spirit::Value addmultisigaddress(const json_spirit::Array& params, b
 extern json_spirit::Value listreceivedbyaddress(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value listreceivedbyaccount(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value listtransactions(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value listaddressgroupings(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value listaccounts(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value listsinceblock(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value gettransaction(const json_spirit::Array& params, bool fHelp);

--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -138,23 +138,39 @@ Value getrawtransaction(const Array& params, bool fHelp)
 
 Value listunspent(const Array& params, bool fHelp)
 {
-    if (fHelp || params.size() > 2)
+    if (fHelp || params.size() > 3)
         throw runtime_error(
-            "listunspent [minconf=1] [maxconf=999999]\n"
+            "listunspent [minconf=1] [maxconf=9999999] ['addr1','addr2',...]\n"
             "Returns array of unspent transaction outputs\n"
             "with between minconf and maxconf (inclusive) confirmations.\n"
+            "Optionally filtered to only include txouts paid to specified addresses.\n"
             "Results are an array of Objects, each of which has:\n"
             "{txid, vout, scriptPubKey, amount, confirmations}");
 
-    RPCTypeCheck(params, list_of(int_type)(int_type));
+    RPCTypeCheck(params, list_of(int_type)(int_type)(array_type));
 
     int nMinDepth = 1;
     if (params.size() > 0)
         nMinDepth = params[0].get_int();
 
-    int nMaxDepth = 999999;
+    int nMaxDepth = 9999999;
     if (params.size() > 1)
         nMaxDepth = params[1].get_int();
+
+    set<CBitcoinAddress> setAddress;
+    if (params.size() > 2)
+    {
+        Array inputs = params[2].get_array();
+        BOOST_FOREACH(Value& input, inputs)
+        {
+            CBitcoinAddress address(input.get_str());
+            if (!address.IsValid())
+                throw JSONRPCError(-5, string("Invalid Bitcoin address:")+input.get_str());
+            if (setAddress.count(address))
+                throw JSONRPCError(-8, string("Invalid parameter, duplicated address: ")+input.get_str());
+           setAddress.insert(address);
+        }
+    }
 
     Array results;
     vector<COutput> vecOutputs;
@@ -162,6 +178,9 @@ Value listunspent(const Array& params, bool fHelp)
     BOOST_FOREACH(const COutput& out, vecOutputs)
     {
         if (out.nDepth < nMinDepth || out.nDepth > nMaxDepth)
+            continue;
+
+        if (setAddress.size() && !setAddress.count(out.tx->GetAddressOfTxOut(out.i)))
             continue;
 
         int64 nValue = out.tx->vout[out.i].nValue;

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -274,6 +274,33 @@ Value sendtoaddress(const Array& params, bool fHelp)
     return wtx.GetHash().GetHex();
 }
 
+Value listaddressgroupings(const Array& params, bool fHelp)
+{
+    if (fHelp)
+        throw runtime_error("listaddressgroupings");
+
+    Array jsonGroupings;
+    map<string, int64> balances = pwalletMain->GetAddressBalances();
+    BOOST_FOREACH(set<string> grouping, pwalletMain->GetAddressGroupings())
+    {
+        Array jsonGrouping;
+        BOOST_FOREACH(string address, grouping)
+        {
+            Array addressInfo;
+            addressInfo.push_back(address);
+            addressInfo.push_back(ValueFromAmount(balances[address]));
+            {
+                LOCK(pwalletMain->cs_wallet);
+                if (pwalletMain->mapAddressBook.find(CBitcoinAddress(address).Get()) != pwalletMain->mapAddressBook.end())
+                    addressInfo.push_back(pwalletMain->mapAddressBook.find(CBitcoinAddress(address).Get())->second);
+            }
+            jsonGrouping.push_back(addressInfo);
+        }
+        jsonGroupings.push_back(jsonGrouping);
+    }
+    return jsonGroupings;
+}
+
 Value signmessage(const Array& params, bool fHelp)
 {
     if (fHelp || params.size() != 2)

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -277,17 +277,21 @@ Value sendtoaddress(const Array& params, bool fHelp)
 Value listaddressgroupings(const Array& params, bool fHelp)
 {
     if (fHelp)
-        throw runtime_error("listaddressgroupings");
+        throw runtime_error(
+            "listaddressgroupings\n"
+            "Lists groups of addresses which have had their common ownership\n"
+            "made public by common use as inputs or as the resulting change\n"
+            "in past transactions");
 
     Array jsonGroupings;
-    map<string, int64> balances = pwalletMain->GetAddressBalances();
-    BOOST_FOREACH(set<string> grouping, pwalletMain->GetAddressGroupings())
+    map<CTxDestination, int64> balances = pwalletMain->GetAddressBalances();
+    BOOST_FOREACH(set<CTxDestination> grouping, pwalletMain->GetAddressGroupings())
     {
         Array jsonGrouping;
-        BOOST_FOREACH(string address, grouping)
+        BOOST_FOREACH(CTxDestination address, grouping)
         {
             Array addressInfo;
-            addressInfo.push_back(address);
+            addressInfo.push_back(CBitcoinAddress(address).ToString());
             addressInfo.push_back(ValueFromAmount(balances[address]));
             {
                 LOCK(pwalletMain->cs_wallet);

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1620,6 +1620,129 @@ int64 CWallet::GetOldestKeyPoolTime()
     return keypool.nTime;
 }
 
+std::map<std::string, int64> CWallet::GetAddressBalances()
+{
+    map<string, int64> balances;
+
+    {
+        LOCK(cs_wallet);
+        BOOST_FOREACH(PAIRTYPE(uint256, CWalletTx) walletEntry, mapWallet)
+        {
+            CWalletTx *pcoin = &walletEntry.second;
+
+            if (!pcoin->IsFinal() || !pcoin->IsConfirmed())
+                continue;
+
+            if (pcoin->IsCoinBase() && pcoin->GetBlocksToMaturity() > 0)
+                continue;
+
+            int nDepth = pcoin->GetDepthInMainChain();
+            if (nDepth < (pcoin->IsFromMe() ? 0 : 1))
+                continue;
+
+            for (int i = 0; i < pcoin->vout.size(); i++)
+            {
+                if (!IsMine(pcoin->vout[i]))
+                    continue;
+
+                int64 n = pcoin->IsSpent(i) ? 0 : pcoin->vout[i].nValue;
+
+                string addr = pcoin->GetAddressOfTxOut(i);
+                if (!balances.count(addr))
+                    balances[addr] = 0;
+                balances[addr] += n;
+            }
+        }
+    }
+
+    return balances;
+}
+
+set< set<string> > CWallet::GetAddressGroupings()
+{
+    set< set<string> > groupings;
+    set<string> grouping;
+
+    BOOST_FOREACH(PAIRTYPE(uint256, CWalletTx) walletEntry, mapWallet)
+    {
+        CWalletTx *pcoin = &walletEntry.second;
+
+        if (!pcoin->IsFinal() || !pcoin->IsConfirmed())
+            continue;
+
+        if (pcoin->IsCoinBase() && pcoin->GetBlocksToMaturity() > 0)
+            continue;
+
+        int nDepth = pcoin->GetDepthInMainChain();
+        if (nDepth < (pcoin->IsFromMe() ? 0 : 1))
+            continue;
+
+        if (pcoin->vin.size() > 0 && IsMine(pcoin->vin[0]))
+        {
+            // group all input addresses with each other
+            BOOST_FOREACH(CTxIn txin, pcoin->vin)
+                grouping.insert(mapWallet[txin.prevout.hash].GetAddressOfTxOut(txin.prevout.n));
+
+            // group change with input addresses
+            BOOST_FOREACH(CTxOut txout, pcoin->vout)
+                if (IsChange(txout))
+                {
+                    CWalletTx tx = mapWallet[pcoin->vin[0].prevout.hash];
+                    string addr = tx.GetAddressOfTxOut(pcoin->vin[0].prevout.n);
+                    CTxDestination txoutAddr;
+                    ExtractDestination(txout.scriptPubKey, txoutAddr);
+                    grouping.insert(CBitcoinAddress(txoutAddr).ToString());
+                }
+            groupings.insert(grouping);
+            grouping.clear();
+        }
+
+        // group lone addrs by themselves
+        for (int i = 0; i < pcoin->vout.size(); i++)
+            if (IsMine(pcoin->vout[i]))
+            {
+                grouping.insert(pcoin->GetAddressOfTxOut(i));
+                groupings.insert(grouping);
+                grouping.clear();
+            }
+    }
+
+    set< set<string>* > uniqueGroupings; // a set of pointers to groups of addresses
+    map< string, set<string>* > setmap;  // map addresses to the unique group containing it
+    BOOST_FOREACH(set<string> grouping, groupings)
+    {
+        // make a set of all the groups hit by this new group
+        set< set<string>* > hits;
+        map< string, set<string>* >::iterator it;
+        BOOST_FOREACH(string address, grouping)
+            if ((it = setmap.find(address)) != setmap.end())
+                hits.insert((*it).second);
+
+        // merge all hit groups into a new single group and delete old groups
+        set<string>* merged = new set<string>(grouping);
+        BOOST_FOREACH(set<string>* hit, hits)
+        {
+            merged->insert(hit->begin(), hit->end());
+            uniqueGroupings.erase(hit);
+            delete hit;
+        }
+        uniqueGroupings.insert(merged);
+
+        // update setmap
+        BOOST_FOREACH(string element, *merged)
+            setmap[element] = merged;
+    }
+
+    set< set<string> > ret;
+    BOOST_FOREACH(set<string>* uniqueGrouping, uniqueGroupings)
+    {
+        ret.insert(*uniqueGrouping);
+        delete uniqueGrouping;
+    }
+
+    return ret;
+}
+
 CPubKey CReserveKey::GetReservedKey()
 {
     if (nIndex == -1)

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -10,7 +10,6 @@
 
 #include <stdlib.h>
 
-#include "base58.h"
 #include "main.h"
 #include "key.h"
 #include "keystore.h"
@@ -177,8 +176,8 @@ public:
     int64 GetOldestKeyPoolTime();
     void GetAllReserveKeys(std::set<CKeyID>& setAddress);
 
-    std::set< std::set<std::string> > GetAddressGroupings();
-    std::map<std::string, int64> GetAddressBalances();
+    std::set< std::set<CTxDestination> > GetAddressGroupings();
+    std::map<CTxDestination, int64> GetAddressBalances();
 
     bool IsMine(const CTxIn& txin) const;
     int64 GetDebit(const CTxIn& txin) const;
@@ -645,13 +644,6 @@ public:
             }
         }
         return true;
-    }
-
-    std::string GetAddressOfTxOut(int n) const
-    {
-        CTxDestination addr;
-        ExtractDestination(vout[n].scriptPubKey, addr);
-        return CBitcoinAddress(addr).ToString();
     }
 
     bool WriteToDisk();

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -10,6 +10,7 @@
 
 #include <stdlib.h>
 
+#include "base58.h"
 #include "main.h"
 #include "key.h"
 #include "keystore.h"
@@ -175,6 +176,9 @@ public:
     bool GetKeyFromPool(CPubKey &key, bool fAllowReuse=true);
     int64 GetOldestKeyPoolTime();
     void GetAllReserveKeys(std::set<CKeyID>& setAddress);
+
+    std::set< std::set<std::string> > GetAddressGroupings();
+    std::map<std::string, int64> GetAddressBalances();
 
     bool IsMine(const CTxIn& txin) const;
     int64 GetDebit(const CTxIn& txin) const;
@@ -641,6 +645,13 @@ public:
             }
         }
         return true;
+    }
+
+    std::string GetAddressOfTxOut(int n)
+    {
+        CTxDestination addr;
+        ExtractDestination(vout[n].scriptPubKey, addr);
+        return CBitcoinAddress(addr).ToString();
     }
 
     bool WriteToDisk();

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -647,7 +647,7 @@ public:
         return true;
     }
 
-    std::string GetAddressOfTxOut(int n)
+    std::string GetAddressOfTxOut(int n) const
     {
         CTxDestination addr;
         ExtractDestination(vout[n].scriptPubKey, addr);


### PR DESCRIPTION
This applies on top of the coincontrol listaddressgroupings patch
and makes finding eligible outputs from the groups returned
by listaddressgroupings possible.
