### PR TITLE
Bitcoin-Qt (Windows only): add ASLR and DEP linker flags

### DIFF
--- a/bitcoin-qt.pro
+++ b/bitcoin-qt.pro
@@ -30,6 +30,9 @@ contains(RELEASE, 1) {
     }
 }
 
+# for extra security on Windows: enable ASLR and DEP via GCC linker flags
+win32:QMAKE_LFLAGS *= -Wl,--dynamicbase -Wl,--nxcompat
+
 # use: qmake "USE_QRCODE=1"
 # libqrencode (http://fukuchi.org/works/qrencode/index.en.html) must be installed for support
 contains(USE_QRCODE, 1) {


### PR DESCRIPTION
- for extra security on Windows: enable ASLR and DEP via GCC linker flags

GCC linker flag description:
--dynamicbase  The image base address may be relocated using address space layout randomization (ASLR). This feature was introduced with MS Windows Vista for i386 PE targets.
--nxcompat The image is compatible with the Data Execution Prevention.
This feature was introduced with MS Windows XP SP2 for i386 PE targets.

Tor project is also using this. Even if we don't want this for 0.7 it should be tested and talked about for a near release IMHO.
