### PR TITLE
add splashscreen message when importing blocks via -loadblock

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -715,6 +715,7 @@ bool AppInit2()
 
     if (mapArgs.count("-loadblock"))
     {
+        uiInterface.InitMessage(_("Importing blocks..."));
         BOOST_FOREACH(string strFile, mapMultiArgs["-loadblock"])
         {
             FILE *file = fopen(strFile.c_str(), "rb");


### PR DESCRIPTION
This was missing and formerly the displayed message during -loadblock was just "Loading wallet...", which was a little missleading IMHO.
