### PR TITLE
Bitcoin-Qt (Windows only): add version info to Resource File

### DIFF
--- a/bitcoin-qt.pro
+++ b/bitcoin-qt.pro
@@ -178,7 +178,8 @@ HEADERS += src/qt/bitcoingui.h \
     src/ui_interface.h \
     src/qt/rpcconsole.h \
     src/version.h \
-    src/netbase.h
+    src/netbase.h \
+    src/clientversion.h
 
 SOURCES += src/qt/bitcoin.cpp src/qt/bitcoingui.cpp \
     src/qt/transactiontablemodel.cpp \

--- a/doc/release-process.txt
+++ b/doc/release-process.txt
@@ -2,7 +2,7 @@
 
 * update (commit) version in sources
   bitcoin-qt.pro
-  src/version.h
+  src/clientversion.h
   share/setup.nsi
   doc/README*
 

--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -1,0 +1,19 @@
+#ifndef CLIENTVERSION_H
+#define CLIENTVERSION_H
+
+//
+// client versioning
+//
+
+// These need to be macros, as version.cpp's and bitcoin-qt.rc's voodoo requires it
+#define CLIENT_VERSION_MAJOR       0
+#define CLIENT_VERSION_MINOR       7
+#define CLIENT_VERSION_REVISION    0
+#define CLIENT_VERSION_BUILD       2
+
+// Converts the parameter X to a string after macro replacement on X has been performed.
+// Don't merge these into one macro!
+#define STRINGIZE(X) DO_STRINGIZE(X)
+#define DO_STRINGIZE(X) #X
+
+#endif // CLIENTVERSION_H

--- a/src/qt/res/bitcoin-qt.rc
+++ b/src/qt/res/bitcoin-qt.rc
@@ -1,10 +1,18 @@
 IDI_ICON1 ICON DISCARDABLE "icons/bitcoin.ico"
 
-#include <windows.h> // needed for VERSIONINFO
+#include <windows.h>             // needed for VERSIONINFO
+#include "../../clientversion.h" // holds the needed client version information
+
+#define VER_PRODUCTVERSION     CLIENT_VERSION_MAJOR,CLIENT_VERSION_MINOR,CLIENT_VERSION_REVISION,CLIENT_VERSION_BUILD
+#define VER_PRODUCTVERSION_STR STRINGIZE(CLIENT_VERSION_MAJOR) "." STRINGIZE(CLIENT_VERSION_MINOR) "." STRINGIZE(CLIENT_VERSION_REVISION) "." STRINGIZE(CLIENT_VERSION_BUILD)
+#define VER_FILEVERSION        VER_PRODUCTVERSION
+#define VER_FILEVERSION_STR    VER_PRODUCTVERSION_STR
 
 VS_VERSION_INFO VERSIONINFO
-FILEOS         	VOS_NT_WINDOWS32
-FILETYPE       	VFT_APP
+FILEVERSION     VER_FILEVERSION
+PRODUCTVERSION  VER_PRODUCTVERSION
+FILEOS          VOS_NT_WINDOWS32
+FILETYPE        VFT_APP
 BEGIN
     BLOCK "StringFileInfo"
     BEGIN
@@ -12,11 +20,13 @@ BEGIN
         BEGIN
             VALUE "CompanyName",        "Bitcoin"
             VALUE "FileDescription",    "Bitcoin-Qt (OSS GUI client for Bitcoin)"
+            VALUE "FileVersion",        VER_FILEVERSION_STR
             VALUE "InternalName",       "bitcoin-qt"
             VALUE "LegalCopyright",     "2009-2012 The Bitcoin developers"
             VALUE "LegalTrademarks1",   "Distributed under the MIT/X11 software license, see the accompanying file COPYING or http://www.opensource.org/licenses/mit-license.php."
             VALUE "OriginalFilename",   "bitcoin-qt.exe"
             VALUE "ProductName",        "Bitcoin-Qt"
+            VALUE "ProductVersion",     VER_PRODUCTVERSION_STR
         END
     END
 

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -39,13 +39,11 @@ const std::string CLIENT_NAME("Satoshi");
 #    define GIT_COMMIT_DATE "$Format:%cD"
 #endif
 
-#define STRINGIFY(s) #s
-
 #define BUILD_DESC_FROM_COMMIT(maj,min,rev,build,commit) \
-    "v" STRINGIFY(maj) "." STRINGIFY(min) "." STRINGIFY(rev) "." STRINGIFY(build) "-g" commit
+    "v" DO_STRINGIZE(maj) "." DO_STRINGIZE(min) "." DO_STRINGIZE(rev) "." DO_STRINGIZE(build) "-g" commit
 
 #define BUILD_DESC_FROM_UNKNOWN(maj,min,rev,build) \
-    "v" STRINGIFY(maj) "." STRINGIFY(min) "." STRINGIFY(rev) "." STRINGIFY(build) "-unk"
+    "v" DO_STRINGIZE(maj) "." DO_STRINGIZE(min) "." DO_STRINGIZE(rev) "." DO_STRINGIZE(build) "-unk"
 
 #ifndef BUILD_DESC
 #    ifdef GIT_COMMIT_ID

--- a/src/version.h
+++ b/src/version.h
@@ -4,21 +4,16 @@
 #ifndef BITCOIN_VERSION_H
 #define BITCOIN_VERSION_H
 
+#include "clientversion.h"
 #include <string>
 
 //
 // client versioning
 //
 
-// These need to be macros, as version.cpp's voodoo requires it
-#define CLIENT_VERSION_MAJOR       0
-#define CLIENT_VERSION_MINOR       7
-#define CLIENT_VERSION_REVISION    0
-#define CLIENT_VERSION_BUILD       2
-
 static const int CLIENT_VERSION =
                            1000000 * CLIENT_VERSION_MAJOR
-                         +   10000 * CLIENT_VERSION_MINOR 
+                         +   10000 * CLIENT_VERSION_MINOR
                          +     100 * CLIENT_VERSION_REVISION
                          +       1 * CLIENT_VERSION_BUILD;
 


### PR DESCRIPTION
This extends #1607, which got recently merged, with version information for bitcoin-qt.exe (no additional files need to be modified by hand).
- add version information to bitcoin-qt.rc, which is displayed on Windows, when looking in the executable properties and selecting "Details"
- introduce a new clientversion.h (used in bitcoin-qt.rc to generate
  version information), which takes only the version defines from
  version.h and is included in it (to allow usage with the windres rc-file
  compiler)
- move #define STRINGIFY(s) #s into clientversion.h as that is used in
  bitcoin-qt.rc and rename to DO_STRINGIZE(X)
- add #define STRINGIZE(X) DO_STRINGIZE(X), which is needed to convert the
  version defines into a version string in the rc-file
- this ensures we only need to update 1 file and have bitcoin-qt.exe
  version information
- for RC-file documentation see:
  http://msdn.microsoft.com/en-us/library/windows/desktop/aa381058%28v=vs.85%29.aspx

![bitcoin-qt.exe details](http://i45.tinypic.com/2qn63hw.png)
