### PR TITLE
Suppress output when running unit tests.

### DIFF
--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -13,7 +13,7 @@ extern void noui_connect();
 
 struct TestingSetup {
     TestingSetup() {
-        fPrintToConsole = true; // don't want to write to debug.log file
+        fPrintToDebugger = true; // don't want to write to debug.log file
         noui_connect();
         bitdb.MakeMock();
         LoadBlockIndex(true);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -204,7 +204,7 @@ inline int OutputDebugStringF(const char* pszFormat, ...)
         ret = vprintf(pszFormat, arg_ptr);
         va_end(arg_ptr);
     }
-    else
+    else if (!fPrintToDebugger)
     {
         // print to debug.log
         static FILE* fileout = NULL;


### PR DESCRIPTION
This does two things:
1) Now does not output to debug.log if -printtodebugger flag is passed
2) Unit tests set -printtodebugger so only test results are output to stdout

Note that -printtodebugger only actually prints to the debugger on Windows.
