### PR TITLE
Allow signrawtransaction '...' null null 'hashtype'

### DIFF
--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -66,7 +66,8 @@ Object JSONRPCError(int code, const string& message)
 }
 
 void RPCTypeCheck(const Array& params,
-                  const list<Value_type>& typesExpected)
+                  const list<Value_type>& typesExpected,
+                  bool fAllowNull)
 {
     unsigned int i = 0;
     BOOST_FOREACH(Value_type t, typesExpected)
@@ -74,8 +75,8 @@ void RPCTypeCheck(const Array& params,
         if (params.size() <= i)
             break;
 
-       const Value& v = params[i];
-        if (v.type() != t)
+        const Value& v = params[i];
+        if (!((v.type() == t) || (fAllowNull && (v.type() == null_type))))
         {
             string err = strprintf("Expected type %s, got %s",
                                    Value_type_name[t], Value_type_name[v.type()]);
@@ -86,14 +87,16 @@ void RPCTypeCheck(const Array& params,
 }
 
 void RPCTypeCheck(const Object& o,
-                  const map<string, Value_type>& typesExpected)
+                  const map<string, Value_type>& typesExpected,
+                  bool fAllowNull)
 {
     BOOST_FOREACH(const PAIRTYPE(string, Value_type)& t, typesExpected)
     {
         const Value& v = find_value(o, t.first);
-        if (v.type() == null_type)
+        if (!fAllowNull && v.type() == null_type)
             throw JSONRPCError(-3, strprintf("Missing %s", t.first.c_str()));
-        if (v.type() != t.second)
+
+        if (!((v.type() == t.second) || (fAllowNull && (v.type() == null_type))))
         {
             string err = strprintf("Expected type %s for %s, got %s",
                                    Value_type_name[t.second], t.first.c_str(), Value_type_name[v.type()]);
@@ -3040,8 +3043,10 @@ Object CallRPC(const string& strMethod, const Array& params)
 
 
 template<typename T>
-void ConvertTo(Value& value)
+void ConvertTo(Value& value, bool fAllowNull=false)
 {
+    if (fAllowNull && value.type() == null_type)
+        return;
     if (value.type() == str_type)
     {
         // reinterpret string as unquoted json value
@@ -3049,7 +3054,8 @@ void ConvertTo(Value& value)
         string strJSON = value.get_str();
         if (!read_string(strJSON, value2))
             throw runtime_error(string("Error parsing JSON:")+strJSON);
-        value = value2.get_value<T>();
+        ConvertTo<T>(value2, fAllowNull);
+        value = value2;
     }
     else
     {
@@ -3100,8 +3106,8 @@ Array RPCConvertValues(const std::string &strMethod, const std::vector<std::stri
     if (strMethod == "getrawtransaction"      && n > 1) ConvertTo<boost::int64_t>(params[1]);
     if (strMethod == "createrawtransaction"   && n > 0) ConvertTo<Array>(params[0]);
     if (strMethod == "createrawtransaction"   && n > 1) ConvertTo<Object>(params[1]);
-    if (strMethod == "signrawtransaction"     && n > 1) ConvertTo<Array>(params[1]);
-    if (strMethod == "signrawtransaction"     && n > 2) ConvertTo<Array>(params[2]);
+    if (strMethod == "signrawtransaction"     && n > 1) ConvertTo<Array>(params[1], true);
+    if (strMethod == "signrawtransaction"     && n > 2) ConvertTo<Array>(params[2], true);
 
     return params;
 }

--- a/src/bitcoinrpc.h
+++ b/src/bitcoinrpc.h
@@ -28,13 +28,13 @@ json_spirit::Array RPCConvertValues(const std::string &strMethod, const std::vec
   Use like:  RPCTypeCheck(params, boost::assign::list_of(str_type)(int_type)(obj_type));
 */
 void RPCTypeCheck(const json_spirit::Array& params,
-                  const std::list<json_spirit::Value_type>& typesExpected);
+                  const std::list<json_spirit::Value_type>& typesExpected, bool fAllowNull=false);
 /*
   Check for expected keys/value types in an Object.
   Use like: RPCTypeCheck(object, boost::assign::map_list_of("name", str_type)("value", int_type));
 */
 void RPCTypeCheck(const json_spirit::Object& o,
-                  const std::map<std::string, json_spirit::Value_type>& typesExpected);
+                  const std::map<std::string, json_spirit::Value_type>& typesExpected, bool fAllowNull=false);
 
 typedef json_spirit::Value(*rpcfn_type)(const json_spirit::Array& params, bool fHelp);
 


### PR DESCRIPTION
Allows the user to pass null as the second or third parameter to signrawtransaction, in case you need to (for example) fetch private keys from the wallet but want to specify the hash type.

(As discussed with @gmaxwell in IRC while testing the signrawtransaction ... SINGLE fix)
