### PR TITLE
add GetBlockFile() to main.cpp

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1991,11 +1991,16 @@ bool CheckDiskSpace(uint64 nAdditionalBytes)
     return true;
 }
 
+const std::string GetBlockFile(unsigned int nFile)
+{
+    return boost::filesystem::path(GetDataDir() / strprintf("blk%04u.dat", nFile)).string();
+}
+
 FILE* OpenBlockFile(unsigned int nFile, unsigned int nBlockPos, const char* pszMode)
 {
     if ((nFile < 1) || (nFile == (unsigned int) -1))
         return NULL;
-    FILE* file = fopen((GetDataDir() / strprintf("blk%04d.dat", nFile)).string().c_str(), pszMode);
+    FILE* file = fopen(GetBlockFile(nFile).c_str(), pszMode);
     if (!file)
         return NULL;
     if (nBlockPos != 0 && !strchr(pszMode, 'a') && !strchr(pszMode, 'w'))

--- a/src/main.h
+++ b/src/main.h
@@ -85,6 +85,7 @@ void UnregisterWallet(CWallet* pwalletIn);
 void SyncWithWallets(const CTransaction& tx, const CBlock* pblock = NULL, bool fUpdate = false);
 bool ProcessBlock(CNode* pfrom, CBlock* pblock);
 bool CheckDiskSpace(uint64 nAdditionalBytes=0);
+const std::string GetBlockFile(unsigned int nFile);
 FILE* OpenBlockFile(unsigned int nFile, unsigned int nBlockPos, const char* pszMode="rb");
 FILE* AppendBlockFile(unsigned int& nFileRet);
 bool LoadBlockIndex(bool fAllowNew=true);


### PR DESCRIPTION
- this function converts an unsigned block-file number into a std::string
  containing the full path to the file
- make OpenBlockFile() use GetBlockFile()

Can be usefull for @sipa Ultraprune work, when we have many more block-files.
