### PR TITLE
Fix infinite loops in connection logic

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -357,7 +357,7 @@ bool AppInit2()
         SoftSetBoolArg("-listen", true);
     }
 
-    if (mapArgs.count("-connect")) {
+    if (mapArgs.count("-connect") && mapMultiArgs["-connect"].size() > 0) {
         // when only connecting to trusted nodes, do not seed via DNS, or listen by default
         SoftSetBoolArg("-dnsseed", false);
         SoftSetBoolArg("-listen", false);

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1391,7 +1391,7 @@ void ThreadOpenConnections2(void* parg)
     printf("ThreadOpenConnections started\n");
 
     // Connect to specific addresses
-    if (mapArgs.count("-connect"))
+    if (mapArgs.count("-connect") && mapMultiArgs["-connect"].size() > 0)
     {
         for (int64 nLoop = 0;; nLoop++)
         {
@@ -1407,6 +1407,7 @@ void ThreadOpenConnections2(void* parg)
                         return;
                 }
             }
+            Sleep(500);
         }
     }
 
@@ -1480,7 +1481,12 @@ void ThreadOpenConnections2(void* parg)
             if (!addr.IsValid() || setConnected.count(addr.GetGroup()) || IsLocal(addr))
                 break;
 
+            // If we didn't find an appropriate destination after trying 100 addresses fetched from addrman,
+            // stop this loop, and let the outer loop run again (which sleeps, adds seed nodes, recalculates
+            // already-connected network ranges, ...) before trying new addrman addresses.
             nTries++;
+            if (nTries > 100)
+                break;
 
             if (IsLimited(addr))
                 continue;


### PR DESCRIPTION
Fix two potential infinite loops in the connection logic:
- With -noconnect, the -connect code was trigger, but looped infinitely through the empty list of nodes
- Given restrictions on which networks to connect to, if no such nodes exist in addrman, the code would loop infinitely through the addresses being fetched. Break this loop after 100 iterations.

Closes #1664.
