### PR TITLE
Handle locked pages more robustly (Fixes issue #1462)

### DIFF
--- a/src/crypter.cpp
+++ b/src/crypter.cpp
@@ -17,12 +17,6 @@ bool CCrypter::SetKeyFromPassphrase(const SecureString& strKeyData, const std::v
     if (nRounds < 1 || chSalt.size() != WALLET_CRYPTO_SALT_SIZE)
         return false;
 
-    // Try to keep the key data out of swap (and be a bit over-careful to keep the IV that we don't even use out of swap)
-    // Note that this does nothing about suspend-to-disk (which will put all our key data on disk)
-    // Note as well that at no point in this program is any attempt made to prevent stealing of keys by reading the memory of the running process.  
-    mlock(&chKey[0], sizeof chKey);
-    mlock(&chIV[0], sizeof chIV);
-
     int i = 0;
     if (nDerivationMethod == 0)
         i = EVP_BytesToKey(EVP_aes_256_cbc(), EVP_sha512(), &chSalt[0],
@@ -43,12 +37,6 @@ bool CCrypter::SetKey(const CKeyingMaterial& chNewKey, const std::vector<unsigne
 {
     if (chNewKey.size() != WALLET_CRYPTO_KEY_SIZE || chNewIV.size() != WALLET_CRYPTO_KEY_SIZE)
         return false;
-
-    // Try to keep the key data out of swap
-    // Note that this does nothing about suspend-to-disk (which will put all our key data on disk)
-    // Note as well that at no point in this program is any attempt made to prevent stealing of keys by reading the memory of the running process.  
-    mlock(&chKey[0], sizeof chKey);
-    mlock(&chIV[0], sizeof chIV);
 
     memcpy(&chKey[0], &chNewKey[0], sizeof chKey);
     memcpy(&chIV[0], &chNewIV[0], sizeof chIV);

--- a/src/crypter.h
+++ b/src/crypter.h
@@ -78,19 +78,26 @@ public:
     {
         memset(&chKey, 0, sizeof chKey);
         memset(&chIV, 0, sizeof chIV);
-        munlock(&chKey, sizeof chKey);
-        munlock(&chIV, sizeof chIV);
         fKeySet = false;
     }
 
     CCrypter()
     {
         fKeySet = false;
+
+        // Try to keep the key data out of swap (and be a bit over-careful to keep the IV that we don't even use out of swap)
+        // Note that this does nothing about suspend-to-disk (which will put all our key data on disk)
+        // Note as well that at no point in this program is any attempt made to prevent stealing of keys by reading the memory of the running process.
+        LockedPageManager::instance.LockRange(&chKey[0], sizeof chKey);
+        LockedPageManager::instance.LockRange(&chIV[0], sizeof chIV);
     }
 
     ~CCrypter()
     {
         CleanKey();
+
+        LockedPageManager::instance.UnlockRange(&chKey[0], sizeof chKey);
+        LockedPageManager::instance.UnlockRange(&chIV[0], sizeof chIV);
     }
 };
 

--- a/src/test/allocator_tests.cpp
+++ b/src/test/allocator_tests.cpp
@@ -1,0 +1,115 @@
+#include <boost/test/unit_test.hpp>
+
+#include "init.h"
+#include "main.h"
+#include "util.h"
+
+BOOST_AUTO_TEST_SUITE(allocator_tests)
+
+// Dummy memory page locker for platform independent tests
+static const void *last_lock_addr, *last_unlock_addr;
+static size_t last_lock_len, last_unlock_len;
+class TestLocker
+{
+public:
+    bool Lock(const void *addr, size_t len)
+    {
+        last_lock_addr = addr;
+        last_lock_len = len;
+        return true;
+    }
+    bool Unlock(const void *addr, size_t len)
+    {
+        last_unlock_addr = addr;
+        last_unlock_len = len;
+        return true;
+    }
+};
+
+BOOST_AUTO_TEST_CASE(test_LockedPageManagerBase)
+{
+    const size_t test_page_size = 4096;
+    LockedPageManagerBase<TestLocker> lpm(test_page_size);
+    size_t addr;
+    last_lock_addr = last_unlock_addr = 0;
+    last_lock_len = last_unlock_len = 0;
+
+    /* Try large number of small objects */
+    addr = 0;
+    for(int i=0; i<1000; ++i)
+    {
+        lpm.LockRange(reinterpret_cast<void*>(addr), 33);
+        addr += 33;
+    }
+    /* Try small number of page-sized objects, straddling two pages */
+    addr = test_page_size*100 + 53;
+    for(int i=0; i<100; ++i)
+    {
+        lpm.LockRange(reinterpret_cast<void*>(addr), test_page_size);
+        addr += test_page_size;
+    }
+    /* Try small number of page-sized objects aligned to exactly one page */
+    addr = test_page_size*300;
+    for(int i=0; i<100; ++i)
+    {
+        lpm.LockRange(reinterpret_cast<void*>(addr), test_page_size);
+        addr += test_page_size;
+    }
+    /* one very large object, straddling pages */
+    lpm.LockRange(reinterpret_cast<void*>(test_page_size*600+1), test_page_size*500);
+    BOOST_CHECK(last_lock_addr == reinterpret_cast<void*>(test_page_size*(600+500)));
+    /* one very large object, page aligned */
+    lpm.LockRange(reinterpret_cast<void*>(test_page_size*1200), test_page_size*500-1);
+    BOOST_CHECK(last_lock_addr == reinterpret_cast<void*>(test_page_size*(1200+500-1)));
+
+    BOOST_CHECK(lpm.GetLockedPageCount() == (
+        (1000*33+test_page_size-1)/test_page_size + // small objects
+        101 + 100 +  // page-sized objects
+        501 + 500)); // large objects
+    BOOST_CHECK((last_lock_len & (test_page_size-1)) == 0); // always lock entire pages
+    BOOST_CHECK(last_unlock_len == 0); // nothing unlocked yet
+
+    /* And unlock again */
+    addr = 0;
+    for(int i=0; i<1000; ++i)
+    {
+        lpm.UnlockRange(reinterpret_cast<void*>(addr), 33);
+        addr += 33;
+    }
+    addr = test_page_size*100 + 53;
+    for(int i=0; i<100; ++i)
+    {
+        lpm.UnlockRange(reinterpret_cast<void*>(addr), test_page_size);
+        addr += test_page_size;
+    }
+    addr = test_page_size*300;
+    for(int i=0; i<100; ++i)
+    {
+        lpm.UnlockRange(reinterpret_cast<void*>(addr), test_page_size);
+        addr += test_page_size;
+    }
+    lpm.UnlockRange(reinterpret_cast<void*>(test_page_size*600+1), test_page_size*500);
+    lpm.UnlockRange(reinterpret_cast<void*>(test_page_size*1200), test_page_size*500-1);
+
+    /* Check that everything is released */
+    BOOST_CHECK(lpm.GetLockedPageCount() == 0);
+
+    /* A few and unlocks of size zero (should have no effect) */
+    addr = 0;
+    for(int i=0; i<1000; ++i)
+    {
+        lpm.LockRange(reinterpret_cast<void*>(addr), 0);
+        addr += 1;
+    }
+    BOOST_CHECK(lpm.GetLockedPageCount() == 0);
+    addr = 0;
+    for(int i=0; i<1000; ++i)
+    {
+        lpm.UnlockRange(reinterpret_cast<void*>(addr), 0);
+        addr += 1;
+    }
+    BOOST_CHECK(lpm.GetLockedPageCount() == 0);
+    BOOST_CHECK((last_unlock_len & (test_page_size-1)) == 0); // always unlock entire pages
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -86,6 +86,8 @@ void locking_callback(int mode, int i, const char* file, int line)
     }
 }
 
+LockedPageManager LockedPageManager::instance;
+
 // Init
 class CInit
 {


### PR DESCRIPTION
I've investigated issue #1462 and in my experiments, the memory allocation pattern with a many transient objects almost guarantees that after the initialization of bitcoin **only one** of the pages is actually locked. This means that most of the keying material can end up in swap.

I considered two ways to address this:
1) A special memory pool (using boost::pool) of locked pages
2) Keep track of which pages are locked with a lock count

I first tried (1), but it ended up non-optimal. boost::pool is very wasteful with tiny objects (in this case, char), as the minimum chunk size seems to be the pointer size, resulting in a blow-up of 8× on 64 bit architectures. As locked pages are a limited resource, this should be avoided.

So I went with the second alternative. This solution is also easier to test than a full-blown custom memory pool. I've added an autotester.
