### PR TITLE
Correct LoadWallet() return value (false -> DB_LOAD_OK)

### DIFF
--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1305,7 +1305,7 @@ string CWallet::SendMoneyToDestination(const CTxDestination& address, int64 nVal
 int CWallet::LoadWallet(bool& fFirstRunRet)
 {
     if (!fFileBacked)
-        return false;
+        return DB_LOAD_OK;
     fFirstRunRet = false;
     int nLoadWalletRet = CWalletDB(strWalletFile,"cr+").LoadWallet(this);
     if (nLoadWalletRet == DB_NEED_REWRITE)


### PR DESCRIPTION
Equivalent code. (false == 0 == DB_LOAD_OK)
