### PR TITLE
Removed useless assignment

### DIFF
--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1317,7 +1317,6 @@ int CWallet::LoadWallet(bool& fFirstRunRet)
             // User will be prompted to unlock wallet the next operation
             // the requires a new key.
         }
-        nLoadWalletRet = DB_NEED_REWRITE;
     }
 
     if (nLoadWalletRet != DB_LOAD_OK)


### PR DESCRIPTION
nLoadWalletRet is already equal to DB_NEED_REWRITE (we are in an if)
