### PR TITLE
Fix gitian win32 build

### DIFF
--- a/contrib/gitian-descriptors/boost-win32.yml
+++ b/contrib/gitian-descriptors/boost-win32.yml
@@ -17,22 +17,6 @@ script: |
   mkdir -p $TMPDIR/bin/$GBUILD_BITS $TMPDIR/include
   tar xjf boost_1_49_0.tar.bz2
   cd boost_1_49_0
-  echo "--- tmp_dir_helpers.orig.hpp	2012-06-10 01:39:25.403268210 +0200
-+++ tmp_dir_helpers.hpp	2012-06-10 01:41:14.653823479 +0200
-@@ -19,9 +19,9 @@
- #include <string>
- 
- #if defined(BOOST_INTERPROCESS_WINDOWS)
--   //#define BOOST_INTERPROCESS_HAS_WINDOWS_KERNEL_BOOTTIME
--   //#define BOOST_INTERPROCESS_HAS_KERNEL_BOOTTIME
--   //#include <boost/interprocess/detail/win32_api.hpp>
-+   #define BOOST_INTERPROCESS_HAS_WINDOWS_KERNEL_BOOTTIME
-+   #define BOOST_INTERPROCESS_HAS_KERNEL_BOOTTIME
-+   #include <boost/interprocess/detail/win32_api.hpp>
- #elif defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__APPLE__)
-    //#include <sys/sysctl.h>
-    //#if defined(CTL_KERN) && defined (KERN_BOOTTIME)" > useboottime.patch
-  patch boost/interprocess/detail/tmp_dir_helpers.hpp useboottime.patch
   echo "using gcc : 4.4 : i586-mingw32msvc-g++
         :
         <rc>i586-mingw32msvc-windres

--- a/contrib/gitian-descriptors/gitian-win32.yml
+++ b/contrib/gitian-descriptors/gitian-win32.yml
@@ -51,7 +51,7 @@ script: |
   export LD_PRELOAD=/usr/lib/faketime/libfaketime.so.1
   export FAKETIME=$REFERENCE_DATETIME
   export TZ=UTC
-  $HOME/qt/src/bin/qmake -spec unsupported/win32-g++-cross MINIUPNPC_LIB_PATH=$HOME/build/miniupnpc MINIUPNPC_INCLUDE_PATH=$HOME/build/ BDB_LIB_PATH=$HOME/build/db-4.8.30.NC/build_unix BDB_INCLUDE_PATH=$HOME/build/db-4.8.30.NC/build_unix BOOST_LIB_PATH=$HOME/build/boost_1_47_0/stage/lib BOOST_INCLUDE_PATH=$HOME/build/boost_1_47_0 BOOST_LIB_SUFFIX=-mt-s BOOST_THREAD_LIB_SUFFIX=_win32-mt-s OPENSSL_LIB_PATH=$HOME/build/openssl-1.0.1b OPENSSL_INCLUDE_PATH=$HOME/build/openssl-1.0.1b/include QRENCODE_LIB_PATH=$HOME/build/qrencode-3.2.0/.libs QRENCODE_INCLUDE_PATH=$HOME/build/qrencode-3.2.0 USE_QRCODE=1 INCLUDEPATH=$HOME/build DEFINES=BOOST_THREAD_USE_LIB BITCOIN_NEED_QT_PLUGINS=1 QMAKE_LRELEASE=lrelease QMAKE_CXXFLAGS=-frandom-seed=bitcoin QMAKE_LFLAGS=-frandom-seed=bitcoin USE_BUILD_INFO=1
+  $HOME/qt/src/bin/qmake -spec unsupported/win32-g++-cross MINIUPNPC_LIB_PATH=$HOME/build/miniupnpc MINIUPNPC_INCLUDE_PATH=$HOME/build/ BDB_LIB_PATH=$HOME/build/db-4.8.30.NC/build_unix BDB_INCLUDE_PATH=$HOME/build/db-4.8.30.NC/build_unix BOOST_LIB_PATH=$HOME/build/boost_1_49_0/stage/lib BOOST_INCLUDE_PATH=$HOME/build/boost_1_49_0 BOOST_LIB_SUFFIX=-mt-s BOOST_THREAD_LIB_SUFFIX=_win32-mt-s OPENSSL_LIB_PATH=$HOME/build/openssl-1.0.1b OPENSSL_INCLUDE_PATH=$HOME/build/openssl-1.0.1b/include QRENCODE_LIB_PATH=$HOME/build/qrencode-3.2.0/.libs QRENCODE_INCLUDE_PATH=$HOME/build/qrencode-3.2.0 USE_QRCODE=1 INCLUDEPATH=$HOME/build DEFINES=BOOST_THREAD_USE_LIB BITCOIN_NEED_QT_PLUGINS=1 QMAKE_LRELEASE=lrelease QMAKE_CXXFLAGS=-frandom-seed=bitcoin QMAKE_LFLAGS=-frandom-seed=bitcoin USE_BUILD_INFO=1
   make $MAKEOPTS
   cp release/bitcoin-qt.exe $OUTDIR/
   #

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -20,9 +20,6 @@
 #include <QSplashScreen>
 #include <QLibraryInfo>
 
-#include <boost/interprocess/ipc/message_queue.hpp>
-#include <boost/algorithm/string/predicate.hpp>
-
 #if defined(BITCOIN_NEED_QT_PLUGINS) && !defined(_BITCOIN_QT_PLUGINS_INCLUDED)
 #define _BITCOIN_QT_PLUGINS_INCLUDED
 #define __INSURE__
@@ -116,35 +113,8 @@ static void handleRunawayException(std::exception *e)
 #ifndef BITCOIN_QT_TEST
 int main(int argc, char *argv[])
 {
-// TODO: implement URI support on the Mac.
-#if !defined(MAC_OSX)
     // Do this early as we don't want to bother initializing if we are just calling IPC
-    for (int i = 1; i < argc; i++)
-    {
-        if (boost::algorithm::istarts_with(argv[i], "bitcoin:"))
-        {
-            const char *strURI = argv[i];
-            try {
-                boost::interprocess::message_queue mq(boost::interprocess::open_only, BITCOINURI_QUEUE_NAME);
-                if (mq.try_send(strURI, strlen(strURI), 0))
-                    // if URI could be sent to the message queue exit here
-                    exit(0);
-                else
-                    // if URI could not be sent to the message queue do a normal Bitcoin-Qt startup
-                    break;
-            }
-            catch (boost::interprocess::interprocess_exception &ex) {
-                // don't log the "file not found" exception, because that's normal for
-                // the first start of the first instance
-                if (ex.get_error_code() != boost::interprocess::not_found_error)
-                {
-                    printf("main() - boost interprocess exception #%d: %s\n", ex.get_error_code(), ex.what());
-                    break;
-                }
-            }
-        }
-    }
-#endif
+    ipcScanRelay(argc, argv);
 
     // Internal string conversion is all UTF-8
     QTextCodec::setCodecForTr(QTextCodec::codecForName("UTF-8"));
@@ -269,29 +239,10 @@ int main(int argc, char *argv[])
                 {
                     window.show();
                 }
-// TODO: implement URI support on the Mac.
-#if !defined(MAC_OSX)
 
                 // Place this here as guiref has to be defined if we don't want to lose URIs
-                ipcInit();
+                ipcInit(argc, argv);
 
-                // Check for URI in argv
-                for (int i = 1; i < argc; i++)
-                {
-                    if (boost::algorithm::istarts_with(argv[i], "bitcoin:"))
-                    {
-                        const char *strURI = argv[i];
-                        try {
-                            boost::interprocess::message_queue mq(boost::interprocess::open_only, BITCOINURI_QUEUE_NAME);
-                            mq.try_send(strURI, strlen(strURI), 0);
-                        }
-                        catch (boost::interprocess::interprocess_exception &ex) {
-                            printf("main() - boost interprocess exception #%d: %s\n", ex.get_error_code(), ex.what());
-                            break;
-                        }
-                    }
-                }
-#endif
                 app.exec();
 
                 window.hide();

--- a/src/qt/qtipcserver.cpp
+++ b/src/qt/qtipcserver.cpp
@@ -2,6 +2,12 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <boost/version.hpp>
+#if defined(WIN32) && BOOST_VERSION == 104900
+#define BOOST_INTERPROCESS_HAS_WINDOWS_KERNEL_BOOTTIME
+#define BOOST_INTERPROCESS_HAS_KERNEL_BOOTTIME
+#endif
+
 #include "qtipcserver.h"
 #include "guiconstants.h"
 #include "ui_interface.h"

--- a/src/qt/qtipcserver.cpp
+++ b/src/qt/qtipcserver.cpp
@@ -7,6 +7,7 @@
 #include "ui_interface.h"
 #include "util.h"
 
+#include <boost/algorithm/string/predicate.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/interprocess/ipc/message_queue.hpp>
 #include <boost/version.hpp>
@@ -24,9 +25,46 @@ static void ipcThread2(void* pArg);
 #ifdef MAC_OSX
 // URI handling not implemented on OSX yet
 
-void ipcInit() { }
+void ipcScanRelay(int argc, char *argv[]) { }
+void ipcInit(int argc, char *argv[]) { }
 
 #else
+
+static bool ipcScanCmd(int argc, char *argv[], bool fRelay)
+{
+    // Check for URI in argv
+    bool fSent = false;
+    for (int i = 1; i < argc; i++)
+    {
+        if (boost::algorithm::istarts_with(argv[i], "bitcoin:"))
+        {
+            const char *strURI = argv[i];
+            try {
+                boost::interprocess::message_queue mq(boost::interprocess::open_only, BITCOINURI_QUEUE_NAME);
+                if (mq.try_send(strURI, strlen(strURI), 0))
+                    fSent = true;
+                else if (fRelay)
+                    break;
+            }
+            catch (boost::interprocess::interprocess_exception &ex) {
+                // don't log the "file not found" exception, because that's normal for
+                // the first start of the first instance
+                if (ex.get_error_code() != boost::interprocess::not_found_error || !fRelay)
+                {
+                    printf("main() - boost interprocess exception #%d: %s\n", ex.get_error_code(), ex.what());
+                    break;
+                }
+            }
+        }
+    }
+    return fSent;
+}
+
+void ipcScanRelay(int argc, char *argv[])
+{
+    if (ipcScanCmd(argc, argv, true))
+        exit(0);
+}
 
 static void ipcThread(void* pArg)
 {
@@ -75,7 +113,7 @@ static void ipcThread2(void* pArg)
     delete mq;
 }
 
-void ipcInit()
+void ipcInit(int argc, char *argv[])
 {
     message_queue* mq = NULL;
     char buffer[MAX_URI_LENGTH + 1] = "";
@@ -113,6 +151,8 @@ void ipcInit()
         delete mq;
         return;
     }
+
+    ipcScanCmd(argc, argv, false);
 }
 
 #endif

--- a/src/qt/qtipcserver.h
+++ b/src/qt/qtipcserver.h
@@ -4,6 +4,7 @@
 // Define Bitcoin-Qt message queue name
 #define BITCOINURI_QUEUE_NAME "BitcoinURI"
 
-void ipcInit();
+void ipcScanRelay(int argc, char *argv[]);
+void ipcInit(int argc, char *argv[]);
 
 #endif // QTIPCSERVER_H


### PR DESCRIPTION
- The patch created in boost-win32.yml was not indented as gitian requires it to be - no longer applicable with this next change:
- Move the boost::interprocess workaround to Bitcoin-Qt sources, so it works even with native builds (note that Boost 1.50+ do not have the bug).
- Adjust the paths gitian-win32.yml looks for Boost to reflect new 1.49 version dependency.
