### PR TITLE
Override progress bar on platforms with segmented progress bars

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -53,6 +53,7 @@
 #include <QTimer>
 #include <QDragEnterEvent>
 #include <QUrl>
+#include <QStyle>
 
 #include <iostream>
 
@@ -147,6 +148,15 @@ BitcoinGUI::BitcoinGUI(QWidget *parent):
     progressBar = new QProgressBar();
     progressBar->setAlignment(Qt::AlignCenter);
     progressBar->setVisible(false);
+
+    // Override style sheet for progress bar for styles that have a segmented progress bar,
+    // as they make the text unreadable (workaround for issue #1071)
+    // See https://qt-project.org/doc/qt-4.8/gallery.html
+    QString curStyle = qApp->style()->metaObject()->className();
+    if(curStyle == "QWindowsStyle" || curStyle == "QWindowsXPStyle")
+    {
+        progressBar->setStyleSheet("QProgressBar { background-color: #e8e8e8; border: 1px solid grey; border-radius: 7px; padding: 1px; text-align: center; } QProgressBar::chunk { background: QLinearGradient(x1: 0, y1: 0, x2: 1, y2: 0, stop: 0 #FF8000, stop: 1 orange); border-radius: 7px; margin: 0px; }");
+    }
 
     statusBar()->addWidget(progressBarLabel);
     statusBar()->addWidget(progressBar);


### PR DESCRIPTION
Some qt styles have a problem with displaying the block progress, as text on a segmented progress bar is terrible to read. This mostly affects older Windows, and some Linux distributions (which also use the windows/windowsxp theme).

Add a custom stylesheet as workaround, but only when one of those renderers is active, otherwise leave the theme alone (issue #1071).

Before:
![](http://i47.tinypic.com/156e0p4.png)

After:
![](http://i48.tinypic.com/2cwubf9.png)

@diapolo: can you test this on Windows 7 and see whether it stays as it is?
