### PR TITLE
Remove unused styles on Windows from gitian qt build

### DIFF
--- a/contrib/gitian-descriptors/gitian-win32.yml
+++ b/contrib/gitian-descriptors/gitian-win32.yml
@@ -15,14 +15,14 @@ remotes:
 - "url": "https://github.com/bitcoin/bitcoin.git"
   "dir": "bitcoin"
 files:
-- "qt-win32-4.7.4-gitian.zip"
+- "qt-win32-4.7.4-gitian-r1.zip"
 - "boost-win32-1.50.0-gitian2.zip"
 - "bitcoin-deps-0.0.4.zip"
 script: |
   #
   mkdir $HOME/qt
   cd $HOME/qt
-  unzip ../build/qt-win32-4.7.4-gitian.zip
+  unzip ../build/qt-win32-4.7.4-gitian-r1.zip
   cd $HOME/build/
   export PATH=$PATH:$HOME/qt/bin/
   #

--- a/contrib/gitian-descriptors/qt-win32.yml
+++ b/contrib/gitian-descriptors/qt-win32.yml
@@ -40,7 +40,7 @@ script: |
   #export LD_PRELOAD=/usr/lib/faketime/libfaketime.so.1
   export FAKETIME=$REFERENCE_DATETIME
   export TZ=UTC
-  ./configure -prefix $INSTDIR -confirm-license -release -opensource -static -no-qt3support -xplatform unsupported/win32-g++-cross -no-multimedia -no-audio-backend -no-phonon -no-phonon-backend -no-declarative -no-script -no-scripttools -no-javascript-jit  -no-webkit -no-svg -no-xmlpatterns -no-sql-sqlite -no-nis -no-cups -no-iconv -no-dbus -no-gif -no-libtiff -opengl no -nomake examples -nomake demos -nomake docs
+  ./configure -prefix $INSTDIR -confirm-license -release -opensource -static -no-qt3support -xplatform unsupported/win32-g++-cross -no-multimedia -no-audio-backend -no-phonon -no-phonon-backend -no-declarative -no-script -no-scripttools -no-javascript-jit -no-webkit -no-svg -no-xmlpatterns -no-sql-sqlite -no-nis -no-cups -no-iconv -no-dbus -no-gif -no-libtiff -no-opengl -nomake examples -nomake demos -nomake docs -no-feature-style-plastique -no-feature-style-cleanlooks -no-feature-style-motif -no-feature-style-cde -no-feature-style-windowsce -no-feature-style-windowsmobile -no-feature-style-s60
   find . -name *.prl | xargs -l sed 's|/\.||' -i
   find . -name *.prl | xargs -l sed 's|/$||' -i
   make $MAKEOPTS install
@@ -51,4 +51,4 @@ script: |
 
   # as zip stores file timestamps, use faketime to intercept stat calls to set dates for all files to reference date
   export LD_PRELOAD=/usr/lib/faketime/libfaketime.so.1
-  zip -r $OUTDIR/qt-win32-4.7.4-gitian.zip *
+  zip -r $OUTDIR/qt-win32-4.7.4-gitian-r1.zip *


### PR DESCRIPTION
Keeps the "windows", "windowsxp", "windowsvista" styles.

Reduces the size of a static bitcoin-qt.exe by ~400 kB.
