### PR TITLE
Removed duplicated lock

### DIFF
--- a/src/db.cpp
+++ b/src/db.cpp
@@ -195,10 +195,7 @@ CDB::CDB(const char *pszFile, const char* pszMode) :
             {
                 delete pdb;
                 pdb = NULL;
-                {
-                     LOCK(bitdb.cs_db);
-                    --bitdb.mapFileUseCount[strFile];
-                }
+                --bitdb.mapFileUseCount[strFile];
                 strFile = "";
                 throw runtime_error(strprintf("CDB() : can't open database file %s, error %d", pszFile, ret));
             }


### PR DESCRIPTION
Around line 167 there is already a LOCK(bitdb.cs_db) that covers everything. Re-locking is useless.
