### PR TITLE
Alert fix

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2322,6 +2322,28 @@ bool CAlert::ProcessAlert()
     if (!IsInEffect())
         return false;
 
+    // alert.nID=max is reserved for if the alert key is
+    // compromised. It must have a pre-defined message,
+    // must never expire, must apply to all versions,
+    // and must cancel all previous
+    // alerts or it will be ignored (so an attacker can't
+    // send an "everything is OK, don't panic" version that
+    // cannot be overridden):
+    int maxInt = std::numeric_limits<int>::max();
+    if (nID == maxInt)
+    {
+        if (!(
+                nExpiration == maxInt &&
+                nCancel == (maxInt-1) &&
+                nMinVer == 0 &&
+                nMaxVer == maxInt &&
+                setSubVer.empty() &&
+                nPriority == maxInt &&
+                strStatusBar == "URGENT: Alert key compromised, upgrade required"
+                ))
+            return false;
+    }
+
     {
         LOCK(cs_mapAlerts);
         // Cancel previous alerts

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2997,14 +2997,27 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
         CAlert alert;
         vRecv >> alert;
 
-        if (alert.ProcessAlert())
+        uint256 alertHash = alert.GetHash();
+        if (pfrom->setKnown.count(alertHash) == 0)
         {
-            // Relay
-            pfrom->setKnown.insert(alert.GetHash());
+            if (alert.ProcessAlert())
             {
-                LOCK(cs_vNodes);
-                BOOST_FOREACH(CNode* pnode, vNodes)
-                    alert.RelayTo(pnode);
+                // Relay
+                pfrom->setKnown.insert(alertHash);
+                {
+                    LOCK(cs_vNodes);
+                    BOOST_FOREACH(CNode* pnode, vNodes)
+                        alert.RelayTo(pnode);
+                }
+            }
+            else {
+                // Small DoS penalty so peers that send us lots of
+                // duplicate/expired/invalid-signature/whatever alerts
+                // eventually get banned.
+                // This isn't a Misbehaving(100) (immediate ban) because the
+                // peer might be an older or different implementation with
+                // a different signature key, etc.
+                pfrom->Misbehaving(10);
             }
         }
     }

--- a/src/main.h
+++ b/src/main.h
@@ -1535,7 +1535,7 @@ public:
 
     uint256 GetHash() const
     {
-        return SerializeHash(*this);
+        return Hash(this->vchMsg.begin(), this->vchMsg.end());
     }
 
     bool IsInEffect() const


### PR DESCRIPTION
These commits:

1) prevents a possible DoS (make nodes waste CPU time checking alert signatures) attack (thanks to Sergio Lerner for finding/reporting)
2) implement's theymos' suggestion of a non-overrideable alert message, to be used only in case the alert key is compromised.

Both thoroughly tested by me in a testnet-in-a-box environment:

Verified that nodes are disconnected/banned if they send too many invalid alerts.
Verified that the alert system still works properly when sent valid alerts.
Verified that nId=max alerts are ignored unless they match hard-coded values.
Verified that nId=max alerts work properly if they do match.
