### PR TITLE
remove I2P support mention from release notes

### DIFF
--- a/doc/release-notes.txt
+++ b/doc/release-notes.txt
@@ -51,7 +51,7 @@ JSON-RPC API
 P2P networking
 --------------
 * IPv6 support
-* Tor/I2P hidden service support
+* Tor hidden service support
 * Attempts to fix "stuck blockchain download" problems
 * Replace BDB database "addr.dat" with internally-managed "peers.dat"
   file containing peer address data.


### PR DESCRIPTION
As requested by @sipa in #1736
