### PR TITLE
Changed nprev->pprev

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -1174,7 +1174,7 @@ public:
 
     std::string ToString() const
     {
-        return strprintf("CBlockIndex(nprev=%08x, pnext=%08x, nFile=%d, nBlockPos=%-6d nHeight=%d, merkle=%s, hashBlock=%s)",
+        return strprintf("CBlockIndex(pprev=%08x, pnext=%08x, nFile=%d, nBlockPos=%-6d nHeight=%d, merkle=%s, hashBlock=%s)",
             pprev, pnext, nFile, nBlockPos, nHeight,
             hashMerkleRoot.ToString().substr(0,10).c_str(),
             GetBlockHash().ToString().substr(0,20).c_str());


### PR DESCRIPTION
It should be pprev, because the next one is pnext, and it's printing the memory address of the CBlockIndex (so pSomething).
