### PR TITLE
Remove json/*.cpp from Qt build system

### DIFF
--- a/bitcoin-qt.pro
+++ b/bitcoin-qt.pro
@@ -92,7 +92,7 @@ contains(BITCOIN_NEED_QT_PLUGINS, 1) {
     # for extra security against potential buffer overflows
     QMAKE_CXXFLAGS += -fstack-protector
     QMAKE_LFLAGS += -fstack-protector
-    # do not enable this on windows, as it will result in a non-working executable!
+    # do not enable this on windows cross compile with mingw 4.2.x, as it will result in a non-working executable!
 }
 
 # regenerate src/build.h
@@ -202,9 +202,6 @@ SOURCES += src/qt/bitcoin.cpp src/qt/bitcoingui.cpp \
     src/addrman.cpp \
     src/db.cpp \
     src/walletdb.cpp \
-    src/json/json_spirit_writer.cpp \
-    src/json/json_spirit_value.cpp \
-    src/json/json_spirit_reader.cpp \
     src/qt/clientmodel.cpp \
     src/qt/guiutil.cpp \
     src/qt/transactionrecord.cpp \


### PR DESCRIPTION
They are unneeded as jsonspirit is always used as template library, the other makefiles don't include them either.
