### PR TITLE
implement proxy server connection-test on client startup

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2,6 +2,7 @@
 // Copyright (c) 2009-2012 The Bitcoin developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include "db.h"
 #include "walletdb.h"
 #include "bitcoinrpc.h"
@@ -9,6 +10,8 @@
 #include "init.h"
 #include "util.h"
 #include "ui_interface.h"
+#include "netbase.h"
+
 #include <boost/filesystem.hpp>
 #include <boost/filesystem/fstream.hpp>
 #include <boost/filesystem/convenience.hpp>
@@ -513,6 +516,14 @@ bool AppInit2()
         addrProxy = CService(mapArgs["-proxy"], 9050);
         if (!addrProxy.IsValid())
             return InitError(strprintf(_("Invalid -proxy address: '%s'"), mapArgs["-proxy"].c_str()));
+
+        uiInterface.InitMessage(_("Proxy Connection-test..."));
+        // check proxy server connection (1sec timeout)
+        if (!ConnectionTest(addrProxy, 1000))
+        {
+            // allow the client to start, to fix a possibly non working proxy, if it was entered in the Qt network settings
+            InitWarning(strprintf(_("Warning: Connection-test to -proxy address '%s' failed, check network settings!"), mapArgs["-proxy"].c_str()));
+        }
 
         if (!IsLimited(NET_IPV4))
             SetProxy(NET_IPV4, addrProxy, nSocksVersion);

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -246,7 +246,7 @@ bool static Socks5(string strDest, int port, SOCKET& hSocket)
     string strSocks5("\5\1");
     strSocks5 += '\000'; strSocks5 += '\003';
     strSocks5 += static_cast<char>(std::min((int)strDest.size(), 255));
-    strSocks5 += strDest; 
+    strSocks5 += strDest;
     strSocks5 += static_cast<char>((port >> 8) & 0xFF);
     strSocks5 += static_cast<char>((port >> 0) & 0xFF);
     ret = send(hSocket, strSocks5.c_str(), strSocks5.size(), MSG_NOSIGNAL);
@@ -478,7 +478,7 @@ bool ConnectSocket(const CService &addrDest, SOCKET& hSocketRet, int nTimeout)
     // first connect to proxy server
     if (!ConnectSocketDirectly(proxy.first, hSocket, nTimeout))
         return false;
- 
+
     // do socks negotiation
     switch (proxy.second) {
     case 4:
@@ -527,6 +527,18 @@ bool ConnectSocketByName(CService &addr, SOCKET& hSocketRet, const char *pszDest
 
     hSocketRet = hSocket;
     return true;
+}
+
+bool ConnectionTest(const CService &addrConnect, int nTimeout)
+{
+    SOCKET hSocket = INVALID_SOCKET;
+    // Try to establish a connection to addrConnect as connection-test
+    if (ConnectSocketDirectly(addrConnect, hSocket, nTimeout))
+    {
+        closesocket(hSocket);
+        return true;
+    }
+    return false;
 }
 
 void CNetAddr::Init()
@@ -617,8 +629,8 @@ bool CNetAddr::IsIPv6() const
 bool CNetAddr::IsRFC1918() const
 {
     return IsIPv4() && (
-        GetByte(3) == 10 || 
-        (GetByte(3) == 192 && GetByte(2) == 168) || 
+        GetByte(3) == 10 ||
+        (GetByte(3) == 192 && GetByte(2) == 168) ||
         (GetByte(3) == 172 && (GetByte(2) >= 16 && GetByte(2) <= 31)));
 }
 

--- a/src/netbase.h
+++ b/src/netbase.h
@@ -147,5 +147,6 @@ bool Lookup(const char *pszName, std::vector<CService>& vAddr, int portDefault =
 bool LookupNumeric(const char *pszName, CService& addr, int portDefault = 0);
 bool ConnectSocket(const CService &addr, SOCKET& hSocketRet, int nTimeout = nConnectTimeout);
 bool ConnectSocketByName(CService &addr, SOCKET& hSocketRet, const char *pszDest, int portDefault = 0, int nTimeout = nConnectTimeout);
+bool ConnectionTest(const CService &addrConnect, int nTimeout = nConnectTimeout);
 
 #endif


### PR DESCRIPTION
- add ConnectionTest() to netbase.h to do a connection-test for a present
  -proxy address on client init and warn on failure

This is informing users about a failure to connect to a supplied proxy, current timeout is 1sec, which we can discuss.

Fixes: #763
