### PR TITLE
Set hyperlink to blockexplorer.com on transaction details window

### DIFF
--- a/src/qt/forms/transactiondescdialog.ui
+++ b/src/qt/forms/transactiondescdialog.ui
@@ -15,9 +15,12 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QTextEdit" name="detailText">
+    <widget class="QTextBrowser" name="detailText">
      <property name="toolTip">
       <string>This pane shows a detailed description of the transaction</string>
+     </property>
+     <property name="openExternalLinks">
+      <bool>true</bool>
      </property>
      <property name="readOnly">
       <bool>true</bool>

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -214,7 +214,7 @@ QString TransactionDesc::toHTML(CWallet *wallet, CWalletTx &wtx)
         if (!wtx.mapValue["comment"].empty())
             strHTML += "<br><b>" + tr("Comment") + ":</b><br>" + GUIUtil::HtmlEscape(wtx.mapValue["comment"], true) + "<br>";
 
-        strHTML += "<b>" + tr("Transaction ID") + ":</b> " + wtx.GetHash().ToString().c_str() + "<br>";
+        strHTML += "<b>" + tr("Transaction ID") + ":</b> <a href=\"https://blockexplorer.com/tx/" + wtx.GetHash().ToString().c_str() + "\">" + wtx.GetHash().ToString().c_str() + "</a><br>";
 
         if (wtx.IsCoinBase())
             strHTML += "<br>" + tr("Generated coins must mature 120 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to \"not accepted\" and it won't be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.") + "<br>";


### PR DESCRIPTION
- This sets a clickable hyperlink for the transaction ID text on the transaction detail window.
- The links points to https://blockexplorer.com/tx/${transactionid}
- This is very handy because avoid copying the transaction id, opening the browser, going to blockexplorer and pasting the transaction id.
- When sending money to someone sometimes is useful to give them the link to the corresponding blockexplorer transaction id. Is also useful to easily check advanced details of the transaction.
