### PR TITLE
Bugfix: Compare deserialized block height in coinbase with expected height

### DIFF
--- a/src/script.h
+++ b/src/script.h
@@ -222,6 +222,7 @@ inline std::string StackString(const std::vector<std::vector<unsigned char> >& v
     return str;
 }
 
+extern CBigNum CastToBigNum(const std::vector<unsigned char>& vch);
 
 
 


### PR DESCRIPTION
Using a byte-for-byte comparison excludes valid nHeight encodings. Replace with standard script method for decoding integer values on the script stack.
