### PR TITLE
fix "socket select error 10022" spam

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -781,10 +781,9 @@ void ThreadSocketHandler2(void* parg)
             return;
         if (nSelect == SOCKET_ERROR)
         {
-            int nErr = WSAGetLastError();
-            if (hSocketMax != INVALID_SOCKET)
+            if ((hSocketMax != INVALID_SOCKET) && (hSocketMax != (SOCKET)0))
             {
-                printf("socket select error %d\n", nErr);
+                printf("socket select error %d\n", WSAGetLastError());
                 for (unsigned int i = 0; i <= hSocketMax; i++)
                     FD_SET(i, &fdsetRecv);
             }


### PR DESCRIPTION
- when there is no network connection or a failing / non-existent proxy
  passed to the client the debug.log was spamed with socket 10022 errors
- this is fixed by adding a check for hSocketMax != 0
- merged a WSAGetLastError() into the related printf()
