### PR TITLE
Bugfix: Require OrderedTxItems to provide properly scoped accounting entry list

### DIFF
--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -987,7 +987,8 @@ Value listtransactions(const Array& params, bool fHelp)
 
     Array ret;
 
-    CWallet::TxItems txOrdered = pwalletMain->OrderedTxItems(strAccount);
+    std::list<CAccountingEntry> acentries;
+    CWallet::TxItems txOrdered = pwalletMain->OrderedTxItems(acentries, strAccount);
 
     // iterate backwards until we have nCount items to return:
     for (CWallet::TxItems::reverse_iterator it = txOrdered.rbegin(); it != txOrdered.rend(); ++it)

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -291,8 +291,7 @@ bool CWallet::EncryptWallet(const SecureString& strWalletPassphrase)
     return true;
 }
 
-CWallet::TxItems
-CWallet::OrderedTxItems(std::string strAccount)
+CWallet::TxItems CWallet::OrderedTxItems(std::list<CAccountingEntry>& acentries, std::string strAccount)
 {
     CWalletDB walletdb(strWalletFile);
 
@@ -306,7 +305,7 @@ CWallet::OrderedTxItems(std::string strAccount)
         CWalletTx* wtx = &((*it).second);
         txOrdered.insert(make_pair(wtx->nOrderPos, TxPair(wtx, (CAccountingEntry*)0)));
     }
-    list<CAccountingEntry> acentries;
+    acentries.clear();
     walletdb.ListAccountCreditDebit(strAccount, acentries);
     BOOST_FOREACH(CAccountingEntry& entry, acentries)
     {
@@ -375,7 +374,8 @@ bool CWallet::AddToWallet(const CWalletTx& wtxIn)
                     {
                         // Tolerate times up to the last timestamp in the wallet not more than 5 minutes into the future
                         int64 latestTolerated = latestNow + 300;
-                        TxItems txOrdered = OrderedTxItems();
+                        std::list<CAccountingEntry> acentries;
+                        TxItems txOrdered = OrderedTxItems(acentries);
                         for (TxItems::reverse_iterator it = txOrdered.rbegin(); it != txOrdered.rend(); ++it)
                         {
                             CWalletTx *const pwtx = (*it).second.first;

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -146,7 +146,12 @@ public:
 
     typedef std::pair<CWalletTx*, CAccountingEntry*> TxPair;
     typedef std::multimap<int64, TxPair > TxItems;
-    TxItems OrderedTxItems(std::string strAccount = "");
+
+    /** Get the wallet's activity log
+        @return multimap of ordered transactions and accounting entries
+        @warning Returned pointers are *only* valid within the scope of passed acentries
+     */
+    TxItems OrderedTxItems(std::list<CAccountingEntry>& acentries, std::string strAccount = "");
 
     void MarkDirty();
     bool AddToWallet(const CWalletTx& wtxIn);


### PR DESCRIPTION
OrderedTxItems returns a multimap of pointers, but needs a place to store the actual CAccountingEntries it points to. It had been using a stack item, which was clobbered as soon as it returned, resulting in undefined behaviour.

This fixes at least bug #1768.
