### PR TITLE
Removing some implicit conversions

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3277,7 +3277,7 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
                         hashSalt = GetRandHash();
                     uint256 hashRand = inv.hash ^ hashSalt;
                     hashRand = Hash(BEGIN(hashRand), END(hashRand));
-                    bool fTrickleWait = ((hashRand & 3) != 0);
+                    bool fTrickleWait = ((hashRand.Get64() & 3) != 0);
 
                     // always trickle our own transactions
                     if (!fTrickleWait)


### PR DESCRIPTION
I think that implicitly converting 3 (the number) to uint256, doing an & between two uint256 and finally comparing the result to an uint64 (the 0) is a little overkill if all you want is to check 2 bits of an uint256. 
I have to say the truth, I'm not sure if now we would be comparing the "same" 2 bits or the 2 bits from the other side of the uint256 (looking at operator= and Get64 I would say the same), but considering what this code wants to obtain, it shouldn't be a problem.

(I'm not even sure if this code will be faster, but I do think that all those implicit conversions are b.a.d.). We could even do a (*hashrand.begin() & 3) but that would be quite unreadable.
