### PR TITLE
Wrong address added to collection in test (address1 instead of address2)

### DIFF
--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -17,7 +17,7 @@ createArgs(int nRequired, const char* address1=NULL, const char* address2=NULL)
     result.push_back(nRequired);
     Array addresses;
     if (address1) addresses.push_back(address1);
-    if (address2) addresses.push_back(address1);
+    if (address2) addresses.push_back(address2);
     result.push_back(addresses);
     return result;
 }


### PR DESCRIPTION
The wrong address is added to the collection. As was written a second copy of address1 was added (and so address2 was useless).
