### PR TITLE
Bugfix: Initialize CWallet::nOrderPosNext on an empty wallet, and save it in db

### DIFF
--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -544,7 +544,7 @@ Value movecmd(const Array& params, bool fHelp)
 
     // Debit
     CAccountingEntry debit;
-    debit.nOrderPos = pwalletMain->nOrderPosNext++;
+    debit.nOrderPos = pwalletMain->IncOrderPosNext();
     debit.strAccount = strFrom;
     debit.nCreditDebit = -nAmount;
     debit.nTime = nNow;
@@ -554,7 +554,7 @@ Value movecmd(const Array& params, bool fHelp)
 
     // Credit
     CAccountingEntry credit;
-    credit.nOrderPos = pwalletMain->nOrderPosNext++;
+    credit.nOrderPos = pwalletMain->IncOrderPosNext();
     credit.strAccount = strTo;
     credit.nCreditDebit = nAmount;
     credit.nTime = nNow;

--- a/src/test/accounting_tests.cpp
+++ b/src/test/accounting_tests.cpp
@@ -60,7 +60,7 @@ BOOST_AUTO_TEST_CASE(acc_orderupgrade)
 
     ae.nTime = 1333333330;
     ae.strOtherAccount = "d";
-    ae.nOrderPos = pwalletMain->nOrderPosNext++;
+    ae.nOrderPos = pwalletMain->IncOrderPosNext();
     walletdb.WriteAccountingEntry(ae);
 
     GetResults(walletdb, results);

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -291,6 +291,13 @@ bool CWallet::EncryptWallet(const SecureString& strWalletPassphrase)
     return true;
 }
 
+int64 CWallet::IncOrderPosNext()
+{
+    int64 nRet = nOrderPosNext;
+    CWalletDB(strWalletFile).WriteOrderPosNext(++nOrderPosNext);
+    return nRet;
+}
+
 CWallet::TxItems CWallet::OrderedTxItems(std::list<CAccountingEntry>& acentries, std::string strAccount)
 {
     CWalletDB walletdb(strWalletFile);
@@ -362,7 +369,7 @@ bool CWallet::AddToWallet(const CWalletTx& wtxIn)
         if (fInsertedNew)
         {
             wtx.nTimeReceived = GetAdjustedTime();
-            wtx.nOrderPos = nOrderPosNext++;
+            wtx.nOrderPos = IncOrderPosNext();
 
             wtx.nTimeSmart = wtx.nTimeReceived;
             if (wtxIn.hashBlock != 0)

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -98,6 +98,7 @@ public:
         fFileBacked = false;
         nMasterKeyMaxID = 0;
         pwalletdbEncryption = NULL;
+        nOrderPosNext = 0;
     }
     CWallet(std::string strWalletFileIn)
     {
@@ -107,6 +108,7 @@ public:
         fFileBacked = true;
         nMasterKeyMaxID = 0;
         pwalletdbEncryption = NULL;
+        nOrderPosNext = 0;
     }
 
     std::map<uint256, CWalletTx> mapWallet;
@@ -143,6 +145,11 @@ public:
     bool Unlock(const SecureString& strWalletPassphrase);
     bool ChangeWalletPassphrase(const SecureString& strOldWalletPassphrase, const SecureString& strNewWalletPassphrase);
     bool EncryptWallet(const SecureString& strWalletPassphrase);
+
+    /** Increment the next transaction order id
+        @return next transaction order id
+     */
+    int64 IncOrderPosNext();
 
     typedef std::pair<CWalletTx*, CAccountingEntry*> TxPair;
     typedef std::multimap<int64, TxPair > TxItems;

--- a/src/walletdb.cpp
+++ b/src/walletdb.cpp
@@ -392,6 +392,10 @@ int CWalletDB::LoadWallet(CWallet* pwallet)
                     return DB_CORRUPT;
                 }
             }
+            else if (strType == "orderposnext")
+            {
+                ssValue >> pwallet->nOrderPosNext;
+            }
         }
         pcursor->close();
     }

--- a/src/walletdb.h
+++ b/src/walletdb.h
@@ -115,6 +115,12 @@ public:
         return Read(std::string("bestblock"), locator);
     }
 
+    bool WriteOrderPosNext(int64 nOrderPosNext)
+    {
+        nWalletDBUpdated++;
+        return Write(std::string("orderposnext"), nOrderPosNext);
+    }
+
     bool ReadDefaultKey(std::vector<unsigned char>& vchPubKey)
     {
         vchPubKey.clear();


### PR DESCRIPTION
Thanks @gmaxwell for finding these bugs!
