### PR TITLE
Verify that newly mined nVersion=2 block coinbase height is correct

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -83,7 +83,7 @@ class CTxIndex;
 void RegisterWallet(CWallet* pwalletIn);
 void UnregisterWallet(CWallet* pwalletIn);
 void SyncWithWallets(const CTransaction& tx, const CBlock* pblock = NULL, bool fUpdate = false);
-bool ProcessBlock(CNode* pfrom, CBlock* pblock);
+bool ProcessBlock(CNode* pfrom, CBlock* pblock, bool fStrictMiner=false);
 bool CheckDiskSpace(uint64 nAdditionalBytes=0);
 FILE* OpenBlockFile(unsigned int nFile, unsigned int nBlockPos, const char* pszMode="rb");
 FILE* AppendBlockFile(unsigned int& nFileRet);
@@ -1023,7 +1023,7 @@ public:
     bool SetBestChain(CTxDB& txdb, CBlockIndex* pindexNew);
     bool AddToBlockIndex(unsigned int nFile, unsigned int nBlockPos);
     bool CheckBlock(bool fCheckPOW=true, bool fCheckMerkleRoot=true) const;
-    bool AcceptBlock();
+    bool AcceptBlock(bool fStrictMiner=false);
 
 private:
     bool SetBestChainInner(CTxDB& txdb, CBlockIndex *pindexNew);

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -372,7 +372,7 @@ Value submitblock(const Array& params, bool fHelp)
         throw JSONRPCError(-22, "Block decode failed");
     }
 
-    bool fAccepted = ProcessBlock(NULL, &block);
+    bool fAccepted = ProcessBlock(NULL, &block, true);
     if (!fAccepted)
         return "rejected";
 


### PR DESCRIPTION
Checks are applied to:  getwork RPC submission, internal miner submission, and submitblock RPC submission.

Arguably pointless for the first two, as 'getwork' miners cannot change that field, but it is a sanity check even in those cases.
