### PR TITLE
Remove VC6 comment and pointless #ifdef'd benchmark code

### DIFF
--- a/src/serialize.h
+++ b/src/serialize.h
@@ -243,7 +243,6 @@ uint64 ReadCompactSize(Stream& is)
 #define FLATDATA(obj)   REF(CFlatData((char*)&(obj), (char*)&(obj) + sizeof(obj)))
 
 /** Wrapper for serializing arrays and POD.
- * There's a clever template way to make arrays serialize normally, but MSVC6 doesn't support it.
  */
 class CFlatData
 {
@@ -1009,57 +1008,6 @@ public:
         return (*this);
     }
 };
-
-#ifdef TESTCDATASTREAM
-// VC6sp6
-// CDataStream:
-// n=1000       0 seconds
-// n=2000       0 seconds
-// n=4000       0 seconds
-// n=8000       0 seconds
-// n=16000      0 seconds
-// n=32000      0 seconds
-// n=64000      1 seconds
-// n=128000     1 seconds
-// n=256000     2 seconds
-// n=512000     4 seconds
-// n=1024000    8 seconds
-// n=2048000    16 seconds
-// n=4096000    32 seconds
-// stringstream:
-// n=1000       1 seconds
-// n=2000       1 seconds
-// n=4000       13 seconds
-// n=8000       87 seconds
-// n=16000      400 seconds
-// n=32000      1660 seconds
-// n=64000      6749 seconds
-// n=128000     27241 seconds
-// n=256000     109804 seconds
-#include <iostream>
-int main(int argc, char *argv[])
-{
-    vector<unsigned char> vch(0xcc, 250);
-    printf("CDataStream:\n");
-    for (int n = 1000; n <= 4500000; n *= 2)
-    {
-        CDataStream ss;
-        time_t nStart = time(NULL);
-        for (int i = 0; i < n; i++)
-            ss.write((char*)&vch[0], vch.size());
-        printf("n=%-10d %d seconds\n", n, time(NULL) - nStart);
-    }
-    printf("stringstream:\n");
-    for (int n = 1000; n <= 4500000; n *= 2)
-    {
-        stringstream ss;
-        time_t nStart = time(NULL);
-        for (int i = 0; i < n; i++)
-            ss.write((char*)&vch[0], vch.size());
-        printf("n=%-10d %d seconds\n", n, time(NULL) - nStart);
-    }
-}
-#endif
 
 
 


### PR DESCRIPTION
We're in a wholly different world now, C++-compiler-wise.

Current std::stringstream implementations don't have the stated problem anymore, and are just as fast as CDataStream.

The #ifdef'd block does not even compile anymore; CDataStream constructor changed, and missing some std::. Also timing in whole seconds is also way too granular to say anything sensible in such microbenchmarks. Just remove it, it can always be found again in git history.
