### PR TITLE
Add small-data OP_DROP transactions as standard transactions.

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -579,6 +579,7 @@ public:
         return dPriority > COIN * 144 / 250;
     }
 
+    bool IsDataCarrier() const;
     int64 GetMinFee(unsigned int nBlockSize=1, bool fAllowFree=true, enum GetMinFee_mode mode=GMF_BLOCK) const;
 
     friend bool operator==(const CTransaction& a, const CTransaction& b)

--- a/src/script.cpp
+++ b/src/script.cpp
@@ -105,6 +105,7 @@ const char* GetTxnOutputType(txnouttype t)
     case TX_PUBKEYHASH: return "pubkeyhash";
     case TX_SCRIPTHASH: return "scripthash";
     case TX_MULTISIG: return "multisig";
+    case TX_MULTISIG_DATA: return "multisig_data";
     }
     return NULL;
 }
@@ -244,6 +245,7 @@ const char* GetOpName(opcodetype opcode)
 
 
     // template matching params
+    case OP_SMALLDATA              : return "OP_SMALLDATA";
     case OP_PUBKEYHASH             : return "OP_PUBKEYHASH";
     case OP_PUBKEY                 : return "OP_PUBKEY";
 
@@ -1300,6 +1302,7 @@ bool Solver(const CScript& scriptPubKey, txnouttype& typeRet, vector<vector<unsi
 
         // Sender provides N pubkeys, receivers provides M signatures
         mTemplates.insert(make_pair(TX_MULTISIG, CScript() << OP_SMALLINTEGER << OP_PUBKEYS << OP_SMALLINTEGER << OP_CHECKMULTISIG));
+        mTemplates.insert(make_pair(TX_MULTISIG_DATA, CScript() << OP_SMALLDATA << OP_DROP << OP_SMALLINTEGER << OP_PUBKEYS << OP_SMALLINTEGER << OP_CHECKMULTISIG));
     }
 
     // Shortcut for pay-to-script-hash, which are more constrained than the other types:
@@ -1372,6 +1375,11 @@ bool Solver(const CScript& scriptPubKey, txnouttype& typeRet, vector<vector<unsi
                 if (vch1.size() != sizeof(uint160))
                     break;
                 vSolutionsRet.push_back(vch1);
+            }
+            else if (opcode2 == OP_SMALLDATA)
+            {
+                if (vch1.size() > 80)
+                    break;
             }
             else if (opcode2 == OP_SMALLINTEGER)
             {   // Single-byte small integer pushed onto vSolutions
@@ -1465,6 +1473,7 @@ bool Solver(const CKeyStore& keystore, const CScript& scriptPubKey, uint256 hash
         return keystore.GetCScript(uint160(vSolutions[0]), scriptSigRet);
 
     case TX_MULTISIG:
+    case TX_MULTISIG_DATA:
         scriptSigRet << OP_0; // workaround CHECKMULTISIG bug
         return (SignN(vSolutions, keystore, hash, nHashType, scriptSigRet));
     }
@@ -1482,6 +1491,7 @@ int ScriptSigArgsExpected(txnouttype t, const std::vector<std::vector<unsigned c
     case TX_PUBKEYHASH:
         return 2;
     case TX_MULTISIG:
+    case TX_MULTISIG_DATA:
         if (vSolutions.size() < 1 || vSolutions[0].size() < 1)
             return -1;
         return vSolutions[0][0] + 1;
@@ -1568,6 +1578,7 @@ bool IsMine(const CKeyStore &keystore, const CScript& scriptPubKey)
         return IsMine(keystore, subscript);
     }
     case TX_MULTISIG:
+    case TX_MULTISIG_DATA:
     {
         // Only consider transactions "mine" if we own ALL the
         // keys involved. multi-signature transactions that are
@@ -1830,6 +1841,7 @@ static CScript CombineSignatures(CScript scriptPubKey, const CTransaction& txTo,
             return result;
         }
     case TX_MULTISIG:
+    case TX_MULTISIG_DATA:
         return CombineMultisig(scriptPubKey, txTo, nIn, vSolutions, sigs1, sigs2);
     }
 

--- a/src/script.h
+++ b/src/script.h
@@ -35,6 +35,7 @@ enum txnouttype
     TX_PUBKEYHASH,
     TX_SCRIPTHASH,
     TX_MULTISIG,
+    TX_MULTISIG_DATA,
 };
 
 class CNoDestination {
@@ -191,6 +192,7 @@ enum opcodetype
 
 
     // template matching params
+    OP_SMALLDATA = 0xf9,
     OP_SMALLINTEGER = 0xfa,
     OP_PUBKEYS = 0xfb,
     OP_PUBKEYHASH = 0xfd,


### PR DESCRIPTION
This change is longer than preferred, because mTemplates is a map, and as
such, the notion of "variant of TX_PUBKEYHASH" is poorly supported.

TX_PUBKEYHASH_*DATA was added, but is largely to quiet compiler warnings,
because it is mapped to TX_PUBKEYHASH everywhere, including Solver()'s
transaction-type return value.

Intended to enable use cases such as Mike Hearn's distributed bond markets: https://bitcointalk.org/index.php?topic=92421.0
