### PR TITLE
add -cleardebugfile switch to clear debug.log on startup

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -265,7 +265,8 @@ std::string HelpMessage()
         "  -debug                 " + _("Output extra debugging information. Implies all other -debug* options") + "\n" +
         "  -debugnet              " + _("Output extra network debugging information") + "\n" +
         "  -logtimestamps         " + _("Prepend debug output with timestamp") + "\n" +
-        "  -shrinkdebugfile       " + _("Shrink debug.log file on client startup (default: 1 when no -debug)") + "\n" +
+        "  -cleardebugfile        " + _("Clear debug.log file on client startup (default: 0)") + "\n" +
+        "  -shrinkdebugfile       " + _("Shrink debug.log file on client startup (default: 1 when no -debug or -cleardebugfile)") + "\n" +
         "  -printtoconsole        " + _("Send trace/debug info to console instead of debug.log file") + "\n" +
 #ifdef WIN32
         "  -printtodebugger       " + _("Send trace/debug info to debugger") + "\n" +
@@ -464,8 +465,11 @@ bool AppInit2()
     }
 #endif
 
-    if (GetBoolArg("-shrinkdebugfile", !fDebug))
+    if (GetBoolArg("-cleardebugfile", false))
+        RemoveDebugFile();
+    else if (GetBoolArg("-shrinkdebugfile", !fDebug))
         ShrinkDebugFile();
+
     printf("\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n");
     printf("Bitcoin version %s (%s)\n", FormatFullVersion().c_str(), CLIENT_DATE.c_str());
     printf("Using OpenSSL version %s\n", SSLeay_version(SSLEAY_VERSION));

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1118,10 +1118,11 @@ void ShrinkDebugFile()
     // Scroll debug.log if it's getting too big
     boost::filesystem::path pathLog = GetDataDir() / "debug.log";
     FILE* file = fopen(pathLog.string().c_str(), "r");
-    if (file && GetFilesize(file) > 10 * 1000000)
+    // 10 MiB limit
+    if (file && GetFilesize(file) > 10 * 1048576)
     {
-        // Restart the file with some of the end
-        char pch[200000];
+        // Restart the file with 200 KiB of the end
+        char pch[204800];
         fseek(file, -sizeof(pch), SEEK_END);
         int nBytes = fread(pch, 1, sizeof(pch), file);
         fclose(file);
@@ -1135,12 +1136,14 @@ void ShrinkDebugFile()
     }
 }
 
+void RemoveDebugFile()
+{
+    namespace fs = boost::filesystem;
+    fs::path pathLog = GetDataDir() / "debug.log";
 
-
-
-
-
-
+    if (fs::exists(pathLog))
+        fs::remove(pathLog);
+}
 
 //
 // "Never go to sea with two chronometers; take one or three."

--- a/src/util.h
+++ b/src/util.h
@@ -167,6 +167,7 @@ void ReadConfigFile(std::map<std::string, std::string>& mapSettingsRet, std::map
 boost::filesystem::path GetSpecialFolderPath(int nFolder, bool fCreate = true);
 #endif
 void ShrinkDebugFile();
+void RemoveDebugFile();
 int GetRandInt(int nMax);
 uint64 GetRand(uint64 nMax);
 uint256 GetRandHash();


### PR DESCRIPTION
I found it really helpful when debugging stuff to not need to delete the
debug.log everytime I re-start the client.
- changes ShrinkDebugFile() function to use nice MiB and KiB boundaries
