### PR TITLE
FreeBSD and OpenBSD build fixes

### DIFF
--- a/src/compat.h
+++ b/src/compat.h
@@ -59,5 +59,10 @@ inline int myclosesocket(SOCKET& hSocket)
 }
 #define closesocket(s)      myclosesocket(s)
 
+/* Special case for some *BSD that do not have this constant. */
+#ifndef AI_ADDRCONFIG
+#define AI_ADDRCONFIG 0
+#endif
+
 
 #endif

--- a/src/makefile.unix
+++ b/src/makefile.unix
@@ -8,9 +8,11 @@ USE_IPV6:=1
 LINK:=$(CXX)
 
 DEFS=-DBOOST_SPIRIT_THREADSAFE
+# This is needed for broken bdb48 includes that assume autotools on some platforms
+DEFS+=-DHAVE_CXX_STDHEADERS
 
 DEFS += $(addprefix -I,$(CURDIR) $(CURDIR)/obj $(BOOST_INCLUDE_PATH) $(BDB_INCLUDE_PATH) $(OPENSSL_INCLUDE_PATH))
-LIBS = $(addprefix -L,$(BOOST_LIB_PATH) $(BDB_LIB_PATH) $(OPENSSL_LIB_PATH))
+LIBS = $(addprefix -L,$(BDB_LIB_PATH) $(BOOST_LIB_PATH) $(OPENSSL_LIB_PATH))
 
 TESTDEFS = -DTEST_DATA_DIR=$(abspath test/data)
 
@@ -51,7 +53,6 @@ endif
 LIBS+= \
  -Wl,-B$(LMODE2) \
    -l z \
-   -l dl \
    -l pthread
 
 
@@ -169,6 +170,8 @@ clean:
 	-rm -f obj-test/*.o
 	-rm -f obj/*.P
 	-rm -f obj-test/*.P
-	-rm -f src/build.h
+	-rm -f obj/build.h
+	-rm -f obj/*.d
+	-rm -f obj-test/*.d
 
 FORCE:

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -8,6 +8,10 @@
 #include "strlcpy.h"
 #include "version.h"
 #include "ui_interface.h"
+#if defined(__FreeBSD__) || defined(__OpenBSD__)
+#  include "pthread.h"
+#  include "pthread_np.h"
+#endif
 #include <boost/algorithm/string/join.hpp>
 
 // Work around clang compilation problem in Boost 1.46:
@@ -1284,10 +1288,7 @@ void RenameThread(const char* name)
 #if defined(PR_SET_NAME)
     // Only the first 15 characters are used (16 - NUL terminator)
     ::prctl(PR_SET_NAME, name, 0, 0, 0);
-#elif 0 && (defined(__FreeBSD__) || defined(__OpenBSD__))
-    // TODO: This is currently disabled because it needs to be verified to work
-    //       on FreeBSD or OpenBSD first. When verified the '0 &&' part can be
-    //       removed.
+#elif (defined(__FreeBSD__) || defined(__OpenBSD__))
     pthread_set_name_np(pthread_self(), name);
 
 // This is XCode 10.6-and-later; bring back if we drop 10.5 support:


### PR DESCRIPTION
OpenBSD is failing some tests related to wallet coin selection AND SHOULD NOT UNDER ANY CIRCUMSTANCES BE USED AS THE OS ON ANY INSTANCES HANDLING A WALLET YET.

The *.d cleanup in the clean target is needed for instances when you try and link against a bad db version (<4.8) but they shouldn't exist under "normal" circumstances. Should still clean them up.

The swap of the bdb and boost include search paths is intentional. The openbsd port/package for db4 is stuck at 4.6 for right now and exists in /usr/local. Boost also exists in /usr/local so if it's specified first you can't get the linker to find the correct bdb.

Getting the unit tests working on OpenBSD requires patching the boost 1.42 port before building as the provided one will not work with any unit tests whatsoever.

I'll write up build instructions for both platforms for a different pull request.

I've tested that this builds on both OpenBSD 5.1 and FreeBSD 9.0-RELEASE-p4. (AKA, current stable versions as of this writing.)

I've also tested that it does not break builds on debian wheezy.

Edit:

FreeBSD build example:

BOOST_INCLUDE_PATH=/usr/local/include \
BOOST_LIB_PATH=/usr/local/lib \
BDB_INCLUDE_PATH=/usr/local/include/db48 \
BDB_LIB_PATH=/usr/local/lib/db48 \
gmake -f makefile.unix -j8 USE_UPNP= bitcoind test_bitcoin

OpenBSD build example:

BOOST_INCLUDE_PATH=/usr/local/include \
BOOST_LIB_PATH=/usr/local/lib \
BDB_INCLUDE_PATH=/opt/OpenBSD/5.1/amd64/db4-4.8.30/include \
BDB_LIB_PATH=/opt/OpenBSD/5.1/amd64/db4-4.8.30/lib \
BOOST_LIB_SUFFIX=-mt \
gmake -f makefile.unix -j8 USE_UPNP= bitcoind test_bitcoin

See this pastebin for details on the failing unit tests on OpenBSD: http://pastebin.com/kFjiXui2 
