### PR TITLE
Base58 en-/de-coding

### DIFF
--- a/src/base58.h
+++ b/src/base58.h
@@ -32,14 +32,9 @@ inline std::string EncodeBase58(const unsigned char* pbegin, const unsigned char
     CBigNum bn58 = 58;
     CBigNum bn0 = 0;
 
-    // Convert big endian data to little endian
-    // Extra zero at the end make sure bignum will interpret as a positive number
-    std::vector<unsigned char> vchTmp(pend-pbegin+1, 0);
-    reverse_copy(pbegin, pend, vchTmp.begin());
-
-    // Convert little endian data to bignum
+    // Convert big endian data to bignum
     CBigNum bn;
-    bn.setvch(vchTmp);
+    BN_bin2bn(pbegin, pend - pbegin, &bn);
 
     // Convert bignum to std::string
     std::string str;

--- a/src/bignum.h
+++ b/src/bignum.h
@@ -380,9 +380,23 @@ public:
         return *this;
     }
 
+    CBigNum& operator+=(const BN_ULONG b)
+    {
+        if (!BN_add_word(this, b))
+            throw bignum_error("CBigNum::operator+= : BN_add_word failed");
+        return *this;
+    }
+
     CBigNum& operator-=(const CBigNum& b)
     {
         *this = *this - b;
+        return *this;
+    }
+
+    CBigNum& operator-=(const BN_ULONG b)
+    {
+        if (!BN_sub_word(this, b))
+            throw bignum_error("CBigNum::operator-= : BN_sub_word failed");
         return *this;
     }
 
@@ -394,15 +408,39 @@ public:
         return *this;
     }
 
+    CBigNum& operator*=(const BN_ULONG b)
+    {
+        if (!BN_mul_word(this, b))
+            throw bignum_error("CBigNum::operator*= : BN_mul_word failed");
+        return *this;
+    }
+
     CBigNum& operator/=(const CBigNum& b)
     {
         *this = *this / b;
         return *this;
     }
 
+    CBigNum& operator/=(const BN_ULONG b)
+    {
+        BN_ULONG r = BN_div_word(this, b);
+        if (r == (BN_ULONG)-1)
+            throw bignum_error("CBigNum::operator/= : BN_div_word failed");
+        return *this;
+    }
+
     CBigNum& operator%=(const CBigNum& b)
     {
         *this = *this % b;
+        return *this;
+    }
+
+    CBigNum& operator%=(const BN_ULONG b)
+    {
+        BN_ULONG r = BN_mod_word(this, b);
+        if (r == (BN_ULONG)-1)
+            throw bignum_error("CBigNum::operator%= : BN_mod_word failed");
+        BN_set_word(this, r);
         return *this;
     }
 
@@ -417,11 +455,9 @@ public:
     {
         // Note: BN_rshift segfaults on 64-bit if 2^shift is greater than the number
         //   if built on ubuntu 9.04 or 9.10, probably depends on version of OpenSSL
-        CBigNum a = 1;
-        a <<= shift;
-        if (BN_cmp(&a, this) > 0)
+        if ((int)shift >= BN_num_bits(this))
         {
-            *this = 0;
+            BN_zero(this);
             return *this;
         }
 
@@ -434,8 +470,8 @@ public:
     CBigNum& operator++()
     {
         // prefix operator
-        if (!BN_add(this, this, BN_value_one()))
-            throw bignum_error("CBigNum::operator++ : BN_add failed");
+        if (!BN_add_word(this, 1))
+            throw bignum_error("CBigNum::operator++ : BN_add_word failed");
         return *this;
     }
 
@@ -450,10 +486,8 @@ public:
     CBigNum& operator--()
     {
         // prefix operator
-        CBigNum r;
-        if (!BN_sub(&r, this, BN_value_one()))
-            throw bignum_error("CBigNum::operator-- : BN_sub failed");
-        *this = r;
+        if (!BN_sub_word(this, 1))
+            throw bignum_error("CBigNum::operator-- : BN_sub_word failed");
         return *this;
     }
 

--- a/src/test/base58_tests.cpp
+++ b/src/test/base58_tests.cpp
@@ -55,6 +55,12 @@ BOOST_AUTO_TEST_CASE(base58_DecodeBase58)
     }
 
     BOOST_CHECK(!DecodeBase58("invalid", result));
+
+    // check that DecodeBase58 skips whitespace, but still fails with unexpected non-whitespace at the end.
+    BOOST_CHECK(!DecodeBase58(" \t\n\v\f\r skip \r\f\v\n\t a", result));
+    BOOST_CHECK( DecodeBase58(" \t\n\v\f\r skip \r\f\v\n\t ", result));
+    std::vector<unsigned char> expected = ParseHex("971a55");
+    BOOST_CHECK_EQUAL_COLLECTIONS(result.begin(), result.end(), expected.begin(), expected.end());
 }
 
 // Visitor to check address type


### PR DESCRIPTION
The base58 codec uses full length bignum operations for each digit and `strchr(pszBase58, *p)` to find the value of each base58 digit.  I've cleaned up the implementation by:
- using bignum operations with word-sized operands
- using a pre-computed decoding table
- adding comments
- getting rid of useless copy operations

As with my other recent pull-requests I think I've made the source easier to understand and the speedup is just a side benefit.

However, I could not restrain myself and added a last commit which is a much faster version, converting 5 or 10 digits at a time (depending on `sizeof(BN_ULONG)`).  Esulting in an overall speedup of over 10 times.

If your prime interest is in simple code, please pull all but the last commit.
If you don't mind a bit longer, but much faster code, pull the whole branch.
