### PR TITLE
Send 'mempool' P2P command at the start of each P2P session

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -25,6 +25,7 @@ using namespace boost;
 
 CWallet* pwalletMain;
 CClientUIInterface uiInterface;
+int64 nTimeNodeStart;
 
 //////////////////////////////////////////////////////////////////////////////
 //
@@ -469,8 +470,10 @@ bool AppInit2()
     printf("\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n");
     printf("Bitcoin version %s (%s)\n", FormatFullVersion().c_str(), CLIENT_DATE.c_str());
     printf("Using OpenSSL version %s\n", SSLeay_version(SSLEAY_VERSION));
+
+    nTimeNodeStart = GetTime();
     if (!fLogTimestamps)
-        printf("Startup time: %s\n", DateTimeStrFormat("%x %H:%M:%S", GetTime()).c_str());
+        printf("Startup time: %s\n", DateTimeStrFormat("%x %H:%M:%S", nTimeNodeStart).c_str());
     printf("Default data directory %s\n", GetDefaultDataDir().string().c_str());
     printf("Used data directory %s\n", GetDataDir().string().c_str());
     std::ostringstream strErrors;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2404,6 +2404,14 @@ bool static AlreadyHave(CTxDB& txdb, const CInv& inv)
 
 
 
+static bool NodeRecentlyStarted()
+{
+    extern int64 nTimeNodeStart;
+    int64 timediff = GetTime() - nTimeNodeStart;
+
+    return (timediff < (2 * 60 * 60));
+}
+
 
 // The message start string is designed to be unlikely to occur in normal data.
 // The characters are rarely used upper ASCII, not valid as UTF-8, and produce
@@ -2509,6 +2517,12 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
                 addrman.Good(addrFrom);
             }
         }
+
+        // Trigger download of remote node's memory pool
+        if (!IsInitialBlockDownload() && !pfrom->fInbound &&
+            !pfrom->fClient && NodeRecentlyStarted() &&
+            pfrom->nVersion >= MEMPOOL_GD_VERSION)
+            pfrom->PushMessage("mempool");
 
         // Ask the first connected node for block updates
         static int nAskedForBlocks = 0;


### PR DESCRIPTION
to query remote node mempool contents.

NOTE: It is expected behavior that this will pump up the orphan pool initially, before dependencies resolve themselves.
