### PR TITLE
P2P: request blocks from new peer, if "block" not seen in 1 hour

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2513,6 +2513,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
         // Ask the first connected node for block updates
         static int nAskedForBlocks = 0;
         if (!pfrom->fClient && !pfrom->fOneShot &&
+            (pfrom->nStartingHeight > nBestHeight) &&
             (pfrom->nVersion < NOBLKS_VERSION_START ||
              pfrom->nVersion >= NOBLKS_VERSION_END) &&
              (nAskedForBlocks < 1 || vNodes.size() <= 1))


### PR DESCRIPTION
If we appear stuck and a new peer has blocks for us, ask for them.

NOTE: This triggers during the "version" message, and so, does not help cases where there is no connection turn-over.

However, this seems a very simple way to address stuck network sync under reverse-header-sync or something more fancy appears.

Builds on top of bug fix submitted in #1834.
