### PR TITLE
Update Bitcoin to use OpenSSL 1.0.1c

### DIFF
--- a/contrib/gitian-descriptors/README
+++ b/contrib/gitian-descriptors/README
@@ -27,7 +27,7 @@ Once you've got the right hardware and software:
     wget 'http://fukuchi.org/works/qrencode/qrencode-3.2.0.tar.bz2'
     # Inputs for Win32: (Linux has packages for these)
     wget 'https://downloads.sourceforge.net/project/boost/boost/1.50.0/boost_1_50_0.tar.bz2'
-    wget 'http://www.openssl.org/source/openssl-1.0.1b.tar.gz'
+    wget 'http://www.openssl.org/source/openssl-1.0.1c.tar.gz'
     wget 'http://download.oracle.com/berkeley-db/db-4.8.30.NC.tar.gz'
     wget 'https://downloads.sourceforge.net/project/libpng/zlib/1.2.6/zlib-1.2.6.tar.gz'
     wget 'https://downloads.sourceforge.net/project/libpng/libpng15/older-releases/1.5.9/libpng-1.5.9.tar.gz'

--- a/contrib/gitian-descriptors/deps-win32.yml
+++ b/contrib/gitian-descriptors/deps-win32.yml
@@ -62,7 +62,7 @@ script: |
   make $MAKEOPTS
   cd ..
   #
-  zip -r $OUTDIR/bitcoin-deps-0.0.4.zip \
+  zip -r $OUTDIR/bitcoin-deps-0.0.5.zip \
     $(ls qrencode-*/{qrencode.h,.libs/libqrencode.{,l}a} | sort) \
     $(ls db-*/build_unix/{libdb_cxx.a,db.h,db_cxx.h,libdb.a,.libs/libdb_cxx-?.?.a} | sort) \
     $(find openssl-* -name '*.a' -o -name '*.h' | sort) \

--- a/contrib/gitian-descriptors/deps-win32.yml
+++ b/contrib/gitian-descriptors/deps-win32.yml
@@ -4,7 +4,7 @@ suites:
 - "lucid"
 architectures:
 - "i386"
-packages: 
+packages:
 - "mingw32"
 - "git-core"
 - "zip"
@@ -13,7 +13,7 @@ packages:
 reference_datetime: "2011-01-30 00:00:00"
 remotes: []
 files:
-- "openssl-1.0.1b.tar.gz"
+- "openssl-1.0.1c.tar.gz"
 - "db-4.8.30.NC.tar.gz"
 - "miniupnpc-1.6.tar.gz"
 - "zlib-1.2.6.tar.gz"
@@ -25,8 +25,8 @@ script: |
   export FAKETIME=$REFERENCE_DATETIME
   export TZ=UTC
   #
-  tar xzf openssl-1.0.1b.tar.gz
-  cd openssl-1.0.1b
+  tar xzf openssl-1.0.1c.tar.gz
+  cd openssl-1.0.1c
   ./Configure --cross-compile-prefix=i586-mingw32msvc- mingw
   make
   cd ..

--- a/contrib/gitian-descriptors/gitian-win32.yml
+++ b/contrib/gitian-descriptors/gitian-win32.yml
@@ -17,7 +17,7 @@ remotes:
 files:
 - "qt-win32-4.7.4-gitian-r1.zip"
 - "boost-win32-1.50.0-gitian2.zip"
-- "bitcoin-deps-0.0.4.zip"
+- "bitcoin-deps-0.0.5.zip"
 script: |
   #
   mkdir $HOME/qt
@@ -39,7 +39,7 @@ script: |
   mv include/boost .
   cd ..
   #
-  unzip bitcoin-deps-0.0.4.zip
+  unzip bitcoin-deps-0.0.5.zip
   #
   find -type f | xargs touch --date="$REFERENCE_DATETIME"
   #

--- a/contrib/gitian-descriptors/gitian-win32.yml
+++ b/contrib/gitian-descriptors/gitian-win32.yml
@@ -4,7 +4,7 @@ suites:
 - "lucid"
 architectures:
 - "i386"
-packages: 
+packages:
 - "mingw32"
 - "git-core"
 - "unzip"
@@ -51,7 +51,7 @@ script: |
   export LD_PRELOAD=/usr/lib/faketime/libfaketime.so.1
   export FAKETIME=$REFERENCE_DATETIME
   export TZ=UTC
-  $HOME/qt/src/bin/qmake -spec unsupported/win32-g++-cross MINIUPNPC_LIB_PATH=$HOME/build/miniupnpc MINIUPNPC_INCLUDE_PATH=$HOME/build/ BDB_LIB_PATH=$HOME/build/db-4.8.30.NC/build_unix BDB_INCLUDE_PATH=$HOME/build/db-4.8.30.NC/build_unix BOOST_LIB_PATH=$HOME/build/boost_1_50_0/stage/lib BOOST_INCLUDE_PATH=$HOME/build/boost_1_50_0 BOOST_LIB_SUFFIX=-mt-s BOOST_THREAD_LIB_SUFFIX=_win32-mt-s OPENSSL_LIB_PATH=$HOME/build/openssl-1.0.1b OPENSSL_INCLUDE_PATH=$HOME/build/openssl-1.0.1b/include QRENCODE_LIB_PATH=$HOME/build/qrencode-3.2.0/.libs QRENCODE_INCLUDE_PATH=$HOME/build/qrencode-3.2.0 USE_QRCODE=1 INCLUDEPATH=$HOME/build DEFINES=BOOST_THREAD_USE_LIB BITCOIN_NEED_QT_PLUGINS=1 QMAKE_LRELEASE=lrelease QMAKE_CXXFLAGS=-frandom-seed=bitcoin QMAKE_LFLAGS=-frandom-seed=bitcoin USE_BUILD_INFO=1
+  $HOME/qt/src/bin/qmake -spec unsupported/win32-g++-cross MINIUPNPC_LIB_PATH=$HOME/build/miniupnpc MINIUPNPC_INCLUDE_PATH=$HOME/build/ BDB_LIB_PATH=$HOME/build/db-4.8.30.NC/build_unix BDB_INCLUDE_PATH=$HOME/build/db-4.8.30.NC/build_unix BOOST_LIB_PATH=$HOME/build/boost_1_50_0/stage/lib BOOST_INCLUDE_PATH=$HOME/build/boost_1_50_0 BOOST_LIB_SUFFIX=-mt-s BOOST_THREAD_LIB_SUFFIX=_win32-mt-s OPENSSL_LIB_PATH=$HOME/build/openssl-1.0.1c OPENSSL_INCLUDE_PATH=$HOME/build/openssl-1.0.1c/include QRENCODE_LIB_PATH=$HOME/build/qrencode-3.2.0/.libs QRENCODE_INCLUDE_PATH=$HOME/build/qrencode-3.2.0 USE_QRCODE=1 INCLUDEPATH=$HOME/build DEFINES=BOOST_THREAD_USE_LIB BITCOIN_NEED_QT_PLUGINS=1 QMAKE_LRELEASE=lrelease QMAKE_CXXFLAGS=-frandom-seed=bitcoin QMAKE_LFLAGS=-frandom-seed=bitcoin USE_BUILD_INFO=1
   make $MAKEOPTS
   cp release/bitcoin-qt.exe $OUTDIR/
   #

--- a/doc/build-msw.txt
+++ b/doc/build-msw.txt
@@ -26,7 +26,7 @@ Libraries you need to download separately and build:
                 default path               download
 OpenSSL         \openssl-1.0.1c-mgw        http://www.openssl.org/source/
 Berkeley DB     \db-4.8.30.NC-mgw          http://www.oracle.com/technology/software/products/berkeley-db/index.html
-Boost           \boost-1.47.0-mgw          http://www.boost.org/users/download/
+Boost           \boost-1.5.0-mgw          http://www.boost.org/users/download/
 miniupnpc       \miniupnpc-1.6-mgw         http://miniupnp.tuxfamily.org/files/
 
 Their licenses:
@@ -38,7 +38,7 @@ miniupnpc      New (3-clause) BSD license
 Versions used in this release:
 OpenSSL      1.0.1c
 Berkeley DB  4.8.30.NC
-Boost        1.47.0
+Boost        1.5.0
 miniupnpc    1.6
 
 
@@ -63,7 +63,7 @@ Boost
 -----
 DOS prompt:
 downloaded boost jam 3.1.18
-cd \boost-1.47.0-mgw
+cd \boost-1.5.0-mgw
 bjam toolset=gcc --build-type=complete stage
 
 MiniUPnPc

--- a/doc/build-msw.txt
+++ b/doc/build-msw.txt
@@ -26,7 +26,7 @@ Libraries you need to download separately and build:
                 default path               download
 OpenSSL         \openssl-1.0.1c-mgw        http://www.openssl.org/source/
 Berkeley DB     \db-4.8.30.NC-mgw          http://www.oracle.com/technology/software/products/berkeley-db/index.html
-Boost           \boost-1.5.0-mgw          http://www.boost.org/users/download/
+Boost           \boost-1.50.0-mgw          http://www.boost.org/users/download/
 miniupnpc       \miniupnpc-1.6-mgw         http://miniupnp.tuxfamily.org/files/
 
 Their licenses:
@@ -38,7 +38,7 @@ miniupnpc      New (3-clause) BSD license
 Versions used in this release:
 OpenSSL      1.0.1c
 Berkeley DB  4.8.30.NC
-Boost        1.5.0
+Boost        1.50.0
 miniupnpc    1.6
 
 
@@ -63,7 +63,7 @@ Boost
 -----
 DOS prompt:
 downloaded boost jam 3.1.18
-cd \boost-1.5.0-mgw
+cd \boost-1.50.0-mgw
 bjam toolset=gcc --build-type=complete stage
 
 MiniUPnPc

--- a/doc/build-msw.txt
+++ b/doc/build-msw.txt
@@ -24,7 +24,7 @@ Dependencies
 Libraries you need to download separately and build:
 
                 default path               download
-OpenSSL         \openssl-1.0.1b-mgw        http://www.openssl.org/source/
+OpenSSL         \openssl-1.0.1c-mgw        http://www.openssl.org/source/
 Berkeley DB     \db-4.8.30.NC-mgw          http://www.oracle.com/technology/software/products/berkeley-db/index.html
 Boost           \boost-1.47.0-mgw          http://www.boost.org/users/download/
 miniupnpc       \miniupnpc-1.6-mgw         http://miniupnp.tuxfamily.org/files/
@@ -36,7 +36,7 @@ Boost          MIT-like license
 miniupnpc      New (3-clause) BSD license
 
 Versions used in this release:
-OpenSSL      1.0.1b
+OpenSSL      1.0.1c
 Berkeley DB  4.8.30.NC
 Boost        1.47.0
 miniupnpc    1.6
@@ -48,7 +48,7 @@ MSYS shell:
 un-tar sources with MSYS 'tar xfz' to avoid issue with symlinks (OpenSSL ticket 2377)
 change 'MAKE' env. variable from 'C:\MinGW32\bin\mingw32-make.exe' to '/c/MinGW32/bin/mingw32-make.exe'
 
-cd /c/openssl-1.0.1b-mgw
+cd /c/openssl-1.0.1c-mgw
 ./config
 make
 

--- a/doc/build-unix.txt
+++ b/doc/build-unix.txt
@@ -47,7 +47,7 @@ Licenses of statically linked libraries:
 
 Versions used in this release:
  GCC           4.3.3
- OpenSSL       0.9.8g
+ OpenSSL       1.0.1c
  Berkeley DB   4.8.30.NC
  Boost         1.37
  miniupnpc     1.6
@@ -55,7 +55,7 @@ Versions used in this release:
 Dependency Build Instructions: Ubuntu & Debian
 ----------------------------------------------
 Build requirements:
- sudo apt-get install build-essential 
+ sudo apt-get install build-essential
  sudo apt-get install libssl-dev
 
 for Ubuntu 12.04:
@@ -68,7 +68,7 @@ for Ubuntu 12.04:
  but using these will break binary wallet compatibility, and is not recommended.
 
 for other Ubuntu & Debian:
- sudo apt-get install libdb4.8-dev 
+ sudo apt-get install libdb4.8-dev
  sudo apt-get install libdb4.8++-dev
  sudo apt-get install libboost1.37-dev
  (If using Boost 1.37, append -mt to the boost libraries in the makefile)

--- a/doc/release-process.txt
+++ b/doc/release-process.txt
@@ -24,7 +24,7 @@
   * Fetch and build inputs: (first time, or when dependency versions change)
    mkdir -p inputs; cd inputs/
    wget 'http://miniupnp.free.fr/files/download.php?file=miniupnpc-1.6.tar.gz' -O miniupnpc-1.6.tar.gz
-   wget 'http://www.openssl.org/source/openssl-1.0.1b.tar.gz'
+   wget 'http://www.openssl.org/source/openssl-1.0.1c.tar.gz'
    wget 'http://download.oracle.com/berkeley-db/db-4.8.30.NC.tar.gz'
    wget 'http://zlib.net/zlib-1.2.6.tar.gz'
    wget 'ftp://ftp.simplesystems.org/pub/libpng/png/src/libpng-1.5.9.tar.gz'

--- a/src/makefile.linux-mingw
+++ b/src/makefile.linux-mingw
@@ -12,13 +12,13 @@ INCLUDEPATHS= \
  -I"$(CURDIR)"/obj \
  -I"$(DEPSDIR)/boost_1_50_0" \
  -I"$(DEPSDIR)/db-4.8.30.NC/build_unix" \
- -I"$(DEPSDIR)/openssl-1.0.1b/include" \
+ -I"$(DEPSDIR)/openssl-1.0.1c/include" \
  -I"$(DEPSDIR)"
 
 LIBPATHS= \
  -L"$(DEPSDIR)/boost_1_50_0/stage/lib" \
  -L"$(DEPSDIR)/db-4.8.30.NC/build_unix" \
- -L"$(DEPSDIR)/openssl-1.0.1b"
+ -L"$(DEPSDIR)/openssl-1.0.1c"
 
 LIBS= \
  -l boost_system-mt-s \

--- a/src/makefile.mingw
+++ b/src/makefile.mingw
@@ -8,12 +8,12 @@ USE_IPV6:=1
 INCLUDEPATHS= \
  -I"C:\boost-1.50.0-mgw" \
  -I"C:\db-4.8.30.NC-mgw\build_unix" \
- -I"C:\openssl-1.0.1b-mgw\include"
+ -I"C:\openssl-1.0.1c-mgw\include"
 
 LIBPATHS= \
  -L"C:\boost-1.50.0-mgw\stage\lib" \
  -L"C:\db-4.8.30.NC-mgw\build_unix" \
- -L"C:\openssl-1.0.1b-mgw"
+ -L"C:\openssl-1.0.1c-mgw"
 
 LIBS= \
  -l boost_system-mgw45-mt-s-1_50 \


### PR DESCRIPTION
I noticed that 0.7.0 for OSX is compiled with 1.0.1c, so I thought it might be an idea to update the makefiles, readme etc. I'm assuming that theres no reason that unix and windows builds cannot use 1.0.1b.
