### PR TITLE
Introduce and use new nServices P2P flag, NODE_VALIDATION

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -49,7 +49,7 @@ struct LocalServiceInfo {
 bool fClient = false;
 bool fDiscover = true;
 bool fUseUPnP = false;
-uint64 nLocalServices = (fClient ? 0 : NODE_NETWORK);
+uint64 nLocalServices = (fClient ? 0 : NODE_NETWORK | NODE_VALIDATION);
 static CCriticalSection cs_mapLocalHost;
 static map<CNetAddr, LocalServiceInfo> mapLocalHost;
 static bool vfReachable[NET_MAX] = {};

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -88,7 +88,7 @@ CAddress::CAddress(CService ipIn, uint64 nServicesIn) : CService(ipIn)
 
 void CAddress::Init()
 {
-    nServices = NODE_NETWORK;
+    nServices = NODE_NETWORK | NODE_VALIDATION;
     nTime = 100000000;
     nLastTry = 0;
 }

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -67,7 +67,8 @@ class CMessageHeader
 /** nServices flags */
 enum
 {
-    NODE_NETWORK = (1 << 0),
+    NODE_NETWORK = (1 << 0),           // has full blockchain
+    NODE_VALIDATION = (1 << 1),        // has full block headers + UTXO set
 };
 
 /** A CService with information about it as peer */
@@ -75,7 +76,7 @@ class CAddress : public CService
 {
     public:
         CAddress();
-        explicit CAddress(CService ipIn, uint64 nServicesIn=NODE_NETWORK);
+        explicit CAddress(CService ipIn, uint64 nServicesIn=NODE_NETWORK | NODE_VALIDATION);
 
         void Init();
 


### PR DESCRIPTION
Not sure whether we want CAddress() to continue defaulting to non-zero, so the behavior of the current code was retained.

Warrants a BIP, presumably.
