### PR TITLE
switch to Qt 4.8.2 for Windows builds

### DIFF
--- a/contrib/gitian-descriptors/README
+++ b/contrib/gitian-descriptors/README
@@ -31,7 +31,7 @@ Once you've got the right hardware and software:
     wget 'http://download.oracle.com/berkeley-db/db-4.8.30.NC.tar.gz'
     wget 'https://downloads.sourceforge.net/project/libpng/zlib/1.2.6/zlib-1.2.6.tar.gz'
     wget 'https://downloads.sourceforge.net/project/libpng/libpng15/older-releases/1.5.9/libpng-1.5.9.tar.gz'
-    wget 'ftp://ftp.trolltech.com/qt/source/qt-everywhere-opensource-src-4.7.4.tar.gz'
+    wget 'http://releases.qt-project.org/qt4/source/qt-everywhere-opensource-src-4.8.2.tar.gz'
     cd ../..
 
     cd gitian-builder

--- a/contrib/gitian-descriptors/gitian-win32.yml
+++ b/contrib/gitian-descriptors/gitian-win32.yml
@@ -15,14 +15,14 @@ remotes:
 - "url": "https://github.com/bitcoin/bitcoin.git"
   "dir": "bitcoin"
 files:
-- "qt-win32-4.7.4-gitian-r1.zip"
+- "qt-win32-4.8.2-gitian-r1.zip"
 - "boost-win32-1.50.0-gitian2.zip"
 - "bitcoin-deps-0.0.4.zip"
 script: |
   #
   mkdir $HOME/qt
   cd $HOME/qt
-  unzip ../build/qt-win32-4.7.4-gitian-r1.zip
+  unzip ../build/qt-win32-4.8.2-gitian-r1.zip
   cd $HOME/build/
   export PATH=$PATH:$HOME/qt/bin/
   #

--- a/contrib/gitian-descriptors/qt-win32.yml
+++ b/contrib/gitian-descriptors/qt-win32.yml
@@ -11,15 +11,15 @@ packages:
 reference_datetime: "2011-01-30 00:00:00"
 remotes: []
 files:
-- "qt-everywhere-opensource-src-4.7.4.tar.gz"
+- "qt-everywhere-opensource-src-4.8.2.tar.gz"
 script: |
   INSTDIR="$HOME/qt/"
   mkdir $INSTDIR
   SRCDIR="$INSTDIR/src/"
   mkdir $SRCDIR
   #
-  tar xzf qt-everywhere-opensource-src-4.7.4.tar.gz
-  cd qt-everywhere-opensource-src-4.7.4
+  tar xzf qt-everywhere-opensource-src-4.8.2.tar.gz
+  cd qt-everywhere-opensource-src-4.8.2
   sed 's/$TODAY/2011-01-30/' -i configure
   sed 's/i686-pc-mingw32-/i586-mingw32msvc-/' -i mkspecs/unsupported/win32-g++-cross/qmake.conf
   sed --posix 's|QMAKE_CFLAGS\t\t= -pipe|QMAKE_CFLAGS\t\t= -pipe -isystem /usr/i586-mingw32msvc/include/ -frandom-seed=qtbuild|' -i mkspecs/unsupported/win32-g++-cross/qmake.conf
@@ -51,4 +51,4 @@ script: |
 
   # as zip stores file timestamps, use faketime to intercept stat calls to set dates for all files to reference date
   export LD_PRELOAD=/usr/lib/faketime/libfaketime.so.1
-  zip -r $OUTDIR/qt-win32-4.7.4-gitian-r1.zip *
+  zip -r $OUTDIR/qt-win32-4.8.2-gitian-r1.zip *

--- a/doc/release-process.txt
+++ b/doc/release-process.txt
@@ -30,12 +30,12 @@
    wget 'ftp://ftp.simplesystems.org/pub/libpng/png/src/libpng-1.5.9.tar.gz'
    wget 'http://fukuchi.org/works/qrencode/qrencode-3.2.0.tar.bz2'
    wget 'http://downloads.sourceforge.net/project/boost/boost/1.50.0/boost_1_50_0.tar.bz2'
-   wget 'http://download.qt.nokia.com/qt/source/qt-everywhere-opensource-src-4.7.4.tar.gz'
+   wget 'http://releases.qt-project.org/qt4/source/qt-everywhere-opensource-src-4.8.2.tar.gz'
    cd ..
    ./bin/gbuild ../bitcoin/contrib/gitian-descriptors/boost-win32.yml
    mv build/out/boost-win32-1.50.0-gitian2.zip inputs/
    ./bin/gbuild ../bitcoin/contrib/gitian-descriptors/qt-win32.yml
-   mv build/out/qt-win32-4.7.4-gitian.zip inputs/
+   mv build/out/qt-win32-4.8.2-gitian-r1.zip inputs/
    ./bin/gbuild ../bitcoin/contrib/gitian-descriptors/deps-win32.yml
    mv build/out/bitcoin-deps-0.0.3.zip inputs/
 


### PR DESCRIPTION
AFAIK the BitcoinPullTester was using Qt 4.8.2 for weeks now without any problems. As there were many fixes since Qt 4.7.4 this should be a valuable change and perhaps fix some of the GUI problems we see on Windows.

I'm not sure how or where I can change the used Qt version for our Linux / Mac builds though and any input is welcome :)!
