### PR TITLE
Add -reindex, to perform in-place reindexing of blockchain data files

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -283,6 +283,7 @@ std::string HelpMessage()
         "  -checkblocks=<n>       " + _("How many blocks to check at startup (default: 2500, 0 = all)") + "\n" +
         "  -checklevel=<n>        " + _("How thorough the block verification is (0-6, default: 1)") + "\n" +
         "  -loadblock=<file>      " + _("Imports blocks from external blk000?.dat file") + "\n" +
+        "  -reindex               " + _("Rebuild blockchain index from current blk000?.dat files") + "\n" +
 
         "\n" + _("Block creation options:") + "\n" +
         "  -blockminsize=<n>      "   + _("Set minimum block size in bytes (default: 0)") + "\n" +
@@ -638,6 +639,9 @@ bool AppInit2()
         return InitError(msg);
     }
 
+    if (GetBoolArg("-reindex"))
+        ReindexBlockchainPrep();
+
     if (GetBoolArg("-loadblockindextest"))
     {
         CTxDB txdb("r");
@@ -775,6 +779,9 @@ bool AppInit2()
     }
 
     // ********************************************************* Step 9: import blocks
+
+    if (GetBoolArg("-reindex"))
+        ReindexBlockchain();
 
     if (mapArgs.count("-loadblock"))
     {


### PR DESCRIPTION
Hopefully this is done in a database-independent manner, with minimal interference to the upcoming ultraprune.
