### PR TITLE
Add "getbestchain" P2P request, and "bestchain" reply

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3021,6 +3021,13 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
     }
 
 
+    else if (strCommand == "getbestchain")
+    {
+        CBestChain bc(hashBestChain, nBestHeight);
+        pfrom->PushMessage("bestchain", bc);
+    }
+
+
     else
     {
         // Ignore unknown commands for extensibility

--- a/src/main.h
+++ b/src/main.h
@@ -168,6 +168,47 @@ public:
 };
 
 
+/** CBestChain - a network data structure describing the best chain */
+class CBestChain
+{
+public:
+    uint256 hash;
+    unsigned int nHeight;
+
+    CBestChain() { SetNull(); }
+    CBestChain(uint256 hashIn, unsigned int nIn) { hash = hashIn; nHeight = nIn; }
+    IMPLEMENT_SERIALIZE( READWRITE(FLATDATA(*this)); )
+    void SetNull() { hash = 0; nHeight = (unsigned int) -1; }
+    bool IsNull() const { return (hash == 0 && nHeight == (unsigned int) -1); }
+
+    friend bool operator<(const CBestChain& a, const CBestChain& b)
+    {
+        return (a.hash < b.hash || (a.hash == b.hash && a.nHeight < b.nHeight));
+    }
+
+    friend bool operator==(const CBestChain& a, const CBestChain& b)
+    {
+        return (a.hash == b.hash && a.nHeight == b.nHeight);
+    }
+
+    friend bool operator!=(const CBestChain& a, const CBestChain& b)
+    {
+        return !(a == b);
+    }
+
+    std::string ToString() const
+    {
+        return strprintf("CBestChain(%s, %u)", hash.ToString().substr(0,10).c_str(), nHeight);
+    }
+
+    void print() const
+    {
+        printf("%s\n", ToString().c_str());
+    }
+};
+
+
+
 
 /** An inpoint - a combination of a transaction and an index n into its vin */
 class CInPoint

--- a/src/version.h
+++ b/src/version.h
@@ -25,7 +25,7 @@ extern const std::string CLIENT_DATE;
 // network protocol versioning
 //
 
-static const int PROTOCOL_VERSION = 60002;
+static const int PROTOCOL_VERSION = 60003;
 
 // earlier versions not supported as of Feb 2012, and are disconnected
 static const int MIN_PROTO_VERSION = 209;
@@ -43,5 +43,8 @@ static const int BIP0031_VERSION = 60000;
 
 // "mempool" command, enhanced "getdata" behavior starts with this version:
 static const int MEMPOOL_GD_VERSION = 60002;
+
+// "getbestchain" command starts with this version
+static const int GETBESTCHAIN_VERSION = 60003;
 
 #endif


### PR DESCRIPTION
Makes diagnostics possible, reverse-header-sync a lot easier, and other uses.

Will BIP-ify if people like this.

NOTE: The CBestChain class was copied from COutPoint, if anyone was curious about the origin of that code.
