### PR TITLE
Remove stack randomization

### DIFF
--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -617,8 +617,6 @@ private:
 
 void ThreadRPCServer(void* parg)
 {
-    IMPLEMENT_RANDOMIZE_STACK(ThreadRPCServer(parg));
-
     // Make this thread recognisable as the RPC listener
     RenameThread("bitcoin-rpclist");
 
@@ -919,8 +917,6 @@ static CCriticalSection cs_THREAD_RPCHANDLER;
 
 void ThreadRPCServer3(void* parg)
 {
-    IMPLEMENT_RANDOMIZE_STACK(ThreadRPCServer3(parg));
-
     // Make this thread recognisable as the RPC handler
     RenameThread("bitcoin-rpchand");
 

--- a/src/irc.cpp
+++ b/src/irc.cpp
@@ -188,8 +188,6 @@ bool GetIPFromIRC(SOCKET hSocket, string strMyName, CNetAddr& ipRet)
 
 void ThreadIRCSeed(void* parg)
 {
-    IMPLEMENT_RANDOMIZE_STACK(ThreadIRCSeed(parg));
-
     // Make this thread recognisable as the IRC seeding thread
     RenameThread("bitcoin-ircseed");
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -639,8 +639,6 @@ void CNode::copyStats(CNodeStats &stats)
 
 void ThreadSocketHandler(void* parg)
 {
-    IMPLEMENT_RANDOMIZE_STACK(ThreadSocketHandler(parg));
-
     // Make this thread recognisable as the networking thread
     RenameThread("bitcoin-net");
 
@@ -1000,8 +998,6 @@ void ThreadSocketHandler2(void* parg)
 #ifdef USE_UPNP
 void ThreadMapPort(void* parg)
 {
-    IMPLEMENT_RANDOMIZE_STACK(ThreadMapPort(parg));
-
     // Make this thread recognisable as the UPnP thread
     RenameThread("bitcoin-UPnP");
 
@@ -1160,8 +1156,6 @@ static const char *strDNSSeed[][2] = {
 
 void ThreadDNSAddressSeed(void* parg)
 {
-    IMPLEMENT_RANDOMIZE_STACK(ThreadDNSAddressSeed(parg));
-
     // Make this thread recognisable as the DNS seeding thread
     RenameThread("bitcoin-dnsseed");
 
@@ -1333,8 +1327,6 @@ void ThreadDumpAddress2(void* parg)
 
 void ThreadDumpAddress(void* parg)
 {
-    IMPLEMENT_RANDOMIZE_STACK(ThreadDumpAddress(parg));
-
     // Make this thread recognisable as the address dumping thread
     RenameThread("bitcoin-adrdump");
 
@@ -1350,8 +1342,6 @@ void ThreadDumpAddress(void* parg)
 
 void ThreadOpenConnections(void* parg)
 {
-    IMPLEMENT_RANDOMIZE_STACK(ThreadOpenConnections(parg));
-
     // Make this thread recognisable as the connection opening thread
     RenameThread("bitcoin-opencon");
 
@@ -1513,8 +1503,6 @@ void ThreadOpenConnections2(void* parg)
 
 void ThreadOpenAddedConnections(void* parg)
 {
-    IMPLEMENT_RANDOMIZE_STACK(ThreadOpenAddedConnections(parg));
-
     // Make this thread recognisable as the connection opening thread
     RenameThread("bitcoin-opencon");
 
@@ -1646,8 +1634,6 @@ bool OpenNetworkConnection(const CAddress& addrConnect, CSemaphoreGrant *grantOu
 
 void ThreadMessageHandler(void* parg)
 {
-    IMPLEMENT_RANDOMIZE_STACK(ThreadMessageHandler(parg));
-
     // Make this thread recognisable as the message handling thread
     RenameThread("bitcoin-msghand");
 

--- a/src/qt/qtipcserver.cpp
+++ b/src/qt/qtipcserver.cpp
@@ -74,8 +74,6 @@ void ipcScanRelay(int argc, char *argv[])
 
 static void ipcThread(void* pArg)
 {
-    IMPLEMENT_RANDOMIZE_STACK(ipcThread(pArg));
-	
     // Make this thread recognisable as the GUI-IPC thread
     RenameThread("bitcoin-gui-ipc");
 	

--- a/src/util.h
+++ b/src/util.h
@@ -396,20 +396,6 @@ bool SoftSetBoolArg(const std::string& strArg, bool fValue);
 
 
 
-// Randomize the stack to help protect against buffer overrun exploits
-#define IMPLEMENT_RANDOMIZE_STACK(ThreadFn)     \
-    {                                           \
-        static char nLoops;                     \
-        if (nLoops <= 0)                        \
-            nLoops = GetRand(20) + 1;           \
-        if (nLoops-- > 1)                       \
-        {                                       \
-            ThreadFn;                           \
-            return;                             \
-        }                                       \
-    }
-
-
 template<typename T1>
 inline uint256 Hash(const T1 pbegin, const T1 pend)
 {


### PR DESCRIPTION
We currently have better measures to deal with stack overflow problems (-fstack-protector, ASLR, non-executable stack, ...) than this hack.

Furthermore, GCC optimizes the loop away through tail call optimization...
