### PR TITLE
Issue 1884: Add a backup warning to the encryptwallet RPC command

### DIFF
--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -1396,7 +1396,7 @@ Value encryptwallet(const Array& params, bool fHelp)
     // slack space in .dat files; that is bad if the old data is
     // unencrypted private keys. So:
     StartShutdown();
-    return "wallet encrypted; Bitcoin server stopping, restart to run with encrypted wallet";
+    return "wallet encrypted; Bitcoin server stopping, restart to run with encrypted wallet.  The keypool has been flushed, you need to make a new backup.";
 }
 
 class DescribeAddressVisitor : public boost::static_visitor<Object>


### PR DESCRIPTION
Simply change the RPC response to indicate that a new backup is needed after encrypting the wallet.  The RPC counterpart to pull #1890.
