### PR TITLE
make optionsmodel query real proxy state for ::data()

### DIFF
--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -142,8 +142,10 @@ QVariant OptionsModel::data(const QModelIndex & index, int role) const
             return settings.value("fUseUPnP", GetBoolArg("-upnp", true));
         case MinimizeOnClose:
             return QVariant(fMinimizeOnClose);
-        case ProxyUse:
-            return settings.value("fUseProxy", false);
+        case ProxyUse: {
+            proxyType proxy;
+            return QVariant(GetProxy(NET_IPV4, proxy));
+        }
         case ProxyIP: {
             proxyType proxy;
             if (GetProxy(NET_IPV4, proxy))
@@ -158,8 +160,13 @@ QVariant OptionsModel::data(const QModelIndex & index, int role) const
             else
                 return QVariant(9050);
         }
-        case ProxySocksVersion:
-            return settings.value("nSocksVersion", 5);
+        case ProxySocksVersion: {
+            proxyType proxy;
+            if (GetProxy(NET_IPV4, proxy))
+                return QVariant(proxy.second);
+            else
+                return QVariant(5);
+        }
         case Fee:
             return QVariant(nTransactionFee);
         case DisplayUnit:
@@ -203,7 +210,7 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
             break;
         case ProxyUse:
             settings.setValue("fUseProxy", value.toBool());
-            ApplyProxySettings();
+            successful = ApplyProxySettings();
             break;
         case ProxyIP: {
             proxyType proxy;


### PR DESCRIPTION
- don't rely on the QSettings for cases ProxyUse and ProxySocksVersion and
  query the real values via the GetProxy() call
- add a missing "succesful =" for case ProxyUse in ::setData()

This is based on #1859!
