### PR TITLE
Send --help message to stdout i.s.o stderr

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -144,7 +144,7 @@ bool AppInit(int argc, char* argv[])
 
             strUsage += "\n" + HelpMessage();
 
-            fprintf(stderr, "%s", strUsage.c_str());
+            fprintf(stdout, "%s", strUsage.c_str());
             return false;
         }
 

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -439,7 +439,7 @@ void HelpMessageBox::printToConsole()
 {
     // On other operating systems, the expected action is to print the message to the console.
     QString strUsage = header + "\n" + coreOptions + "\n" + uiOptions;
-    fprintf(stderr, "%s", strUsage.toStdString().c_str());
+    fprintf(stdout, "%s", strUsage.toStdString().c_str());
 }
 
 void HelpMessageBox::showOrPrint()


### PR DESCRIPTION
As the list of options is getting very long, there's a large chance it doesn't fit on the terminal at once.

Sending the output to stdout allows fun stuff such as `bitcoin --help | less`, and more easy piping to files (yes, technically it's also possible with stderr, but less convenient). 

Looking at other tools such as bash, gcc, they all send their help text to stdout.
