### PR TITLE
Qt: add an exit notification on client shutdown

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -176,6 +176,9 @@ BitcoinGUI::BitcoinGUI(QWidget *parent):
     // Clicking on "Sign Message" in the receive coins page sends you to the sign message tab
     connect(receiveCoinsPage, SIGNAL(signMessage(QString)), this, SLOT(gotoSignMessageTab(QString)));
 
+    // When the client is about to quit show an exit notification
+    connect(qApp, SIGNAL(aboutToQuit()), this, SLOT(showExitNotification()));
+
     gotoOverviewPage();
 }
 
@@ -872,4 +875,9 @@ void BitcoinGUI::showNormalIfMinimized(bool fToggleHidden)
 void BitcoinGUI::toggleHidden()
 {
     showNormalIfMinimized(true);
+}
+
+void BitcoinGUI::showExitNotification()
+{
+    notificator->notify(Notificator::Information, tr("Bitcoin"), tr("Exiting..."));
 }

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -172,8 +172,10 @@ private slots:
 
     /** Show window if hidden, unminimize when minimized, rise when obscured or show if hidden and fToggleHidden is true */
     void showNormalIfMinimized(bool fToggleHidden = false);
-    /** simply calls showNormalIfMinimized(true) for use in SLOT() macro */
+    /** Simply calls showNormalIfMinimized(true) for use in SLOT() macro */
     void toggleHidden();
+    /** Show an exit notification as additional shutdown signal for users */
+    void showExitNotification();
 };
 
 #endif


### PR DESCRIPTION
- this extends the persistent tray icon until shutdown is complete, to
  ensure users wait before trying to restart the client
