### PR TITLE
Fix: CAddrMan: verify pchMessageStart file marker, before reading address data

### DIFF
--- a/src/db.cpp
+++ b/src/db.cpp
@@ -842,19 +842,21 @@ bool CAddrDB::Read(CAddrMan& addr)
     if (hashIn != hashTmp)
         return error("CAddrman::Read() : checksum mismatch; data corrupted");
 
-    // de-serialize address data
     unsigned char pchMsgTmp[4];
     try {
+        // de-serialize file header (pchMessageStart magic number) and
         ssPeers >> FLATDATA(pchMsgTmp);
+
+        // verify the network matches ours
+        if (memcmp(pchMsgTmp, pchMessageStart, sizeof(pchMsgTmp)))
+            return error("CAddrman::Read() : invalid network magic number");
+
+        // de-serialize address data into one CAddrMan object
         ssPeers >> addr;
     }
     catch (std::exception &e) {
         return error("CAddrman::Read() : I/O error or stream data corrupted");
     }
-
-    // finally, verify the network matches ours
-    if (memcmp(pchMsgTmp, pchMessageStart, sizeof(pchMsgTmp)))
-        return error("CAddrman::Read() : invalid network magic number");
 
     return true;
 }


### PR DESCRIPTION
This avoids the case where you read the address data, before noticing it is
the wrong network.
