### PR TITLE
Handle incompatible BDB environments

### DIFF
--- a/src/db.cpp
+++ b/src/db.cpp
@@ -34,19 +34,14 @@ void CDBEnv::EnvShutdown()
         return;
 
     fDbEnvInit = false;
-    try
-    {
-        dbenv.close(0);
-    }
-    catch (const DbException& e)
-    {
-        printf("EnvShutdown exception: %s (%d)\n", e.what(), e.get_errno());
-    }
+    int ret = dbenv.close(0);
+    if (ret != 0)
+        printf("EnvShutdown exception: %s (%d)\n", DbEnv::strerror(ret), ret);
     if (!fMockDb)
         DbEnv(0).remove(GetDataDir().string().c_str(), 0);
 }
 
-CDBEnv::CDBEnv() : dbenv(0)
+CDBEnv::CDBEnv() : dbenv(DB_CXX_NO_EXCEPTIONS)
 {
 }
 
@@ -100,8 +95,8 @@ bool CDBEnv::Open(boost::filesystem::path pathEnv_)
                      DB_RECOVER    |
                      nEnvFlags,
                      S_IRUSR | S_IWUSR);
-    if (ret > 0)
-        return error("CDB() : error %d opening database environment", ret);
+    if (ret != 0)
+        return error("CDB() : error %s (%d) opening database environment", DbEnv::strerror(ret), ret);
 
     fDbEnvInit = true;
     fMockDb = false;
@@ -191,7 +186,7 @@ CDB::CDB(const char *pszFile, const char* pszMode) :
                             nFlags,    // Flags
                             0);
 
-            if (ret > 0)
+            if (ret != 0)
             {
                 delete pdb;
                 pdb = NULL;


### PR DESCRIPTION
Before, opening a -datadir that was created with a new
version of Berkeley DB would result in an un-caught DB_RUNRECOVERY
exception.

After these changes, the error is caught and the user is told
that there is a problem and is told how to try to recover from
it.
