### PR TITLE
fix some thread related log messages

### DIFF
--- a/src/irc.cpp
+++ b/src/irc.cpp
@@ -192,6 +192,8 @@ void ThreadIRCSeed(void* parg)
     // Make this thread recognisable as the IRC seeding thread
     RenameThread("bitcoin-ircseed");
 
+    printf("ThreadIRCSeed started\n");
+
     try
     {
         ThreadIRCSeed2(parg);
@@ -218,7 +220,8 @@ void ThreadIRCSeed2(void* parg)
     if (!GetBoolArg("-irc", false))
         return;
 
-    printf("ThreadIRCSeed started\n");
+    printf("ThreadIRCSeed trying to connect...\n");
+
     int nErrorWait = 10;
     int nRetryWait = 10;
     int nNameRetry = 0;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1313,6 +1313,8 @@ void DumpAddresses()
 
 void ThreadDumpAddress2(void* parg)
 {
+    printf("ThreadDumpAddress started\n");
+
     vnThreadsRunning[THREAD_DUMPADDRESS]++;
     while (!fShutdown)
     {


### PR DESCRIPTION
- "ThreadIRCSeed started" was not displayed, even if the thread ran
  (although only for a short time as the "do we want this thread?"-checks
  happen IN ThreadIRCSeed2())
- the patch ensures we always get that message
- add a "ThreadIRCSeed trying to connect..." message
- add missing "ThreadDumpAddress started" message
