### PR TITLE
Bugfix: do not mark all future coins spent

### DIFF
--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -780,8 +780,8 @@ void CWallet::ReacceptWalletTransactions()
 
             CCoins coins;
             bool fUpdated = false;
-            bool fNotFound = pcoinsTip->GetCoins(wtx.GetHash(), coins);
-            if (!fNotFound || wtx.GetDepthInMainChain() > 0)
+            bool fFound = pcoinsTip->GetCoins(wtx.GetHash(), coins);
+            if (fFound || wtx.GetDepthInMainChain() > 0)
             {
                 // Update fSpent if a tx got spent somewhere else by a copy of wallet.dat
                 for (unsigned int i = 0; i < wtx.vout.size(); i++)


### PR DESCRIPTION
This seems to be recently-introduced bug in ultraprune.

@jgarzik, @gmaxwell: can you check whether this fixes the zero-balance issue? You may need to restore from a backup.
