### PR TITLE
remove init messages from ThreadImport()

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2549,7 +2549,6 @@ void ThreadImport(void *data) {
     vnThreadsRunning[THREAD_IMPORT]++;
 
     // -loadblock=
-    uiInterface.InitMessage(_("Starting block import..."));
     BOOST_FOREACH(boost::filesystem::path &path, *vFiles) {
         FILE *file = fopen(path.string().c_str(), "rb");
         if (file)
@@ -2559,8 +2558,6 @@ void ThreadImport(void *data) {
     // hardcoded $DATADIR/bootstrap.dat
     filesystem::path pathBootstrap = GetDataDir() / "bootstrap.dat";
     if (filesystem::exists(pathBootstrap)) {
-        uiInterface.InitMessage(_("Importing bootstrap blockchain data file."));
-
         FILE *file = fopen(pathBootstrap.string().c_str(), "rb");
         if (file) {
             filesystem::path pathBootstrapOld = GetDataDir() / "bootstrap.dat.old";


### PR DESCRIPTION
- remove uiInterface.InitMessage() calls from ThreadImport(), as Qt
  doesn't like them getting called out of it's main thread and because the
  thread will continue to run after the GUI was loaded

This fixes a crash I discovered, while compiling Bitcoin-Qt the first time after Ultraprune was merged to master.
