### PR TITLE
fix a double inclusion of txdb.h in bitcoin-qt.pro

### DIFF
--- a/bitcoin-qt.pro
+++ b/bitcoin-qt.pro
@@ -146,7 +146,6 @@ HEADERS += src/qt/bitcoingui.h \
     src/net.h \
     src/key.h \
     src/db.h \
-    src/txdb.h \
     src/walletdb.h \
     src/script.h \
     src/init.h \


### PR DESCRIPTION
Was included twice, and is only needed once :).
