### PR TITLE
Check for null pointers in Shutdown (issue #1950)

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -78,8 +78,10 @@ void Shutdown(void* parg)
         StopNode();
         {
             LOCK(cs_main);
-            pcoinsTip->Flush();
-            pblocktree->Flush();
+            if (pcoinsTip)
+                pcoinsTip->Flush();
+            if (pblocktree)
+                pblocktree->Flush();
             delete pcoinsTip;
             delete pcoinsdbview;
             delete pblocktree;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -79,13 +79,9 @@ void Shutdown(void* parg)
         {
             LOCK(cs_main);
             if (pcoinsTip)
-            {
                 pcoinsTip->Flush();
-            }
             if (pblocktree)
-            {
                 pblocktree->Flush();
-            }
             delete pcoinsTip;
             delete pcoinsdbview;
             delete pblocktree;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -78,8 +78,14 @@ void Shutdown(void* parg)
         StopNode();
         {
             LOCK(cs_main);
-            pcoinsTip->Flush();
-            pblocktree->Flush();
+            if (pcoinsTip)
+            {
+                pcoinsTip->Flush();
+            }
+            if (pblocktree)
+            {
+                pblocktree->Flush();
+            }
             delete pcoinsTip;
             delete pcoinsdbview;
             delete pblocktree;


### PR DESCRIPTION
Both `pcointTip` and `pblocktree` can be null, but since `CBlockTree::Flush` is empty the call is optimized away and so the second check is not strictly necessary...
