### PR TITLE
Don't force getblocktemplate to have a parameter.

### DIFF
--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -198,7 +198,7 @@ Value getwork(const Array& params, bool fHelp)
 
 Value getblocktemplate(const Array& params, bool fHelp)
 {
-    if (fHelp || params.size() != 1)
+    if (fHelp || params.size() > 1)
         throw runtime_error(
             "getblocktemplate [params]\n"
             "Returns data needed to construct a block to work on:\n"


### PR DESCRIPTION
This looks like it was just a munged merge when ultraprune
was committed.
