### PR TITLE
Add signfile/verifyfile RPC calls.

### DIFF
--- a/src/bitcoinrpc.h
+++ b/src/bitcoinrpc.h
@@ -151,6 +151,8 @@ extern json_spirit::Value getaddressesbyaccount(const json_spirit::Array& params
 extern json_spirit::Value sendtoaddress(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value signmessage(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value verifymessage(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value signfile(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value verifyfile(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value getreceivedbyaddress(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value getreceivedbyaccount(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value getbalance(const json_spirit::Array& params, bool fHelp);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -78,9 +78,12 @@ void Shutdown(void* parg)
         StopNode();
         {
             LOCK(cs_main);
-            pcoinsTip->Flush();
+            if (pcoinsTip)
+            {
+                pcoinsTip->Flush();
+                delete pcoinsTip;
+            }
             pblocktree->Flush();
-            delete pcoinsTip;
             delete pcoinsdbview;
             delete pblocktree;
         }


### PR DESCRIPTION
These calls can be used to generate and check signatures for arbitrary
(potentially binary) files, much like signmessage / verifymessage.

The client should hash the file locally then send a uint256 in hex form
as the 2rd parameter to signfile and the 3rd parameter to verifyfile.

The other option would have been for the client to hash the file locally and send it to the server using the signmessage / verifymessage calls, but then the server would be signing a hash of a hash.

I'm new to the bitcoin code, so if there's a better way of doing this, let me know.

The functionality has been verified by one other person on IRC but it still could be wrong.
