### PR TITLE
ensure AskPassphraseDialog::eventFilter forwards events

### DIFF
--- a/src/qt/askpassphrasedialog.cpp
+++ b/src/qt/askpassphrasedialog.cpp
@@ -19,7 +19,7 @@ AskPassphraseDialog::AskPassphraseDialog(Mode mode, QWidget *parent) :
     ui->passEdit1->setMaxLength(MAX_PASSPHRASE_SIZE);
     ui->passEdit2->setMaxLength(MAX_PASSPHRASE_SIZE);
     ui->passEdit3->setMaxLength(MAX_PASSPHRASE_SIZE);
-    
+
     // Setup Caps Lock detection.
     ui->passEdit1->installEventFilter(this);
     ui->passEdit2->installEventFilter(this);
@@ -108,15 +108,15 @@ void AskPassphraseDialog::accept()
                 if(model->setWalletEncrypted(true, newpass1))
                 {
                     QMessageBox::warning(this, tr("Wallet encrypted"),
-                                         "<qt>" + 
+                                         "<qt>" +
                                          tr("Bitcoin will close now to finish the encryption process. "
                                          "Remember that encrypting your wallet cannot fully protect "
-                                         "your bitcoins from being stolen by malware infecting your computer.") + 
-                                         "<br><br><b>" + 
+                                         "your bitcoins from being stolen by malware infecting your computer.") +
+                                         "<br><br><b>" +
                                          tr("IMPORTANT: Any previous backups you have made of your wallet file "
                                          "should be replaced with the newly generated, encrypted wallet file. "
                                          "For security reasons, previous backups of the unencrypted wallet file "
-                                         "will become useless as soon as you start using the new, encrypted wallet.") + 
+                                         "will become useless as soon as you start using the new, encrypted wallet.") +
                                          "</b></qt>");
                     QApplication::quit();
                 }
@@ -221,7 +221,7 @@ bool AskPassphraseDialog::event(QEvent *event)
     return QWidget::event(event);
 }
 
-bool AskPassphraseDialog::eventFilter(QObject *, QEvent *event)
+bool AskPassphraseDialog::eventFilter(QObject *object, QEvent *event)
 {
     /* Detect Caps Lock.
      * There is no good OS-independent way to check a key state in Qt, but we
@@ -244,5 +244,5 @@ bool AskPassphraseDialog::eventFilter(QObject *, QEvent *event)
             }
         }
     }
-    return false;
+    return QDialog::eventFilter(object, event);
 }

--- a/src/qt/askpassphrasedialog.h
+++ b/src/qt/askpassphrasedialog.h
@@ -39,7 +39,7 @@ private:
 private slots:
     void textChanged();
     bool event(QEvent *event);
-    bool eventFilter(QObject *, QEvent *event);
+    bool eventFilter(QObject *object, QEvent *event);
 };
 
 #endif // ASKPASSPHRASEDIALOG_H


### PR DESCRIPTION
- instead of "return false;" use "return QDialog::eventFilter(object,
  event);" to harmonize this event filter with our default behaviour
- remove orphan spaces found while editting the files
