### PR TITLE
Bugfix: do not keep relaying spent wallet transactions

### DIFF
--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -820,21 +820,17 @@ void CWallet::ReacceptWalletTransactions()
 
 void CWalletTx::RelayWalletTransaction()
 {
-    CCoinsViewCache& coins = *pcoinsTip;
     BOOST_FOREACH(const CMerkleTx& tx, vtxPrev)
     {
-        if (!tx.IsCoinBase())
-        {
-            uint256 hash = tx.GetHash();
-            if (!coins.HaveCoins(hash))
-                RelayMessage(CInv(MSG_TX, hash), (CTransaction)tx);
+        if (!tx.IsCoinBase()) {
+            if (tx.GetDepthInMainChain() == 0)
+                RelayMessage(CInv(MSG_TX, tx.GetHash()), (CTransaction)tx);
         }
     }
     if (!IsCoinBase())
     {
-        uint256 hash = GetHash();
-        if (!coins.HaveCoins(hash))
-        {
+        if (GetDepthInMainChain() == 0) {
+            uint256 hash = GetHash();
             printf("Relaying wtx %s\n", hash.ToString().substr(0,10).c_str());
             RelayMessage(CInv(MSG_TX, hash), (CTransaction)*this);
         }


### PR DESCRIPTION
The original test (checking whether the transaction occurs in the txindex) is not usable anymore, as it will miss anything already fully spent. However, as merkle transactions (and by extension, wallet transactions) track which block they were last seen being included in, we can use that to determine the need for rebroadcasting.
