### PR TITLE
remove 2 unneeded includes from util.cpp that are in the .h

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -23,10 +23,8 @@ namespace boost {
 
 #include <boost/program_options/detail/config_file.hpp>
 #include <boost/program_options/parsers.hpp>
-#include <boost/filesystem.hpp>
 #include <boost/filesystem/fstream.hpp>
 #include <boost/foreach.hpp>
-#include <boost/thread.hpp>
 #include <openssl/crypto.h>
 #include <openssl/rand.h>
 #include <stdarg.h>


### PR DESCRIPTION
filesystem.hpp and thread.hpp are included in util.h, which is included in util.cpp
