### PR TITLE
Add HTTP REST, wget(1)-friendly crypted key dump via GET /wallet-ckeys.json

### DIFF
--- a/src/bitcoinrpc.h
+++ b/src/bitcoinrpc.h
@@ -134,6 +134,7 @@ extern json_spirit::Value getconnectioncount(const json_spirit::Array& params, b
 extern json_spirit::Value getpeerinfo(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value dumpprivkey(const json_spirit::Array& params, bool fHelp); // in rpcdump.cpp
 extern json_spirit::Value importprivkey(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value GetWalletCKeyDump(void);
 
 extern json_spirit::Value getgenerate(const json_spirit::Array& params, bool fHelp); // in rpcmining.cpp
 extern json_spirit::Value setgenerate(const json_spirit::Array& params, bool fHelp);

--- a/src/keystore.cpp
+++ b/src/keystore.cpp
@@ -177,6 +177,21 @@ bool CCryptoKeyStore::GetKey(const CKeyID &address, CKey& keyOut) const
     return false;
 }
 
+void CCryptoKeyStore::GetCryptedKeys(
+        std::map<CKeyID, std::vector<unsigned char> > &mapKeysOut) const
+{
+    LOCK(cs_KeyStore);
+
+    mapKeysOut.clear();
+
+    CryptedKeyMap::const_iterator mi = mapCryptedKeys.begin();
+    while (mi != mapCryptedKeys.end()) {
+        mapKeysOut[(*mi).first] = (*mi).second.second;
+
+        mi++;
+    }
+}
+
 bool CCryptoKeyStore::GetPubKey(const CKeyID &address, CPubKey& vchPubKeyOut) const
 {
     {

--- a/src/keystore.h
+++ b/src/keystore.h
@@ -174,6 +174,8 @@ public:
             mi++;
         }
     }
+    void GetCryptedKeys(std::map<CKeyID, std::vector<unsigned char> > &mapKeysOut) const;
+
 
     /* Wallet status (encrypted, locked) changed.
      * Note: Called without locks held.

--- a/src/rpcdump.cpp
+++ b/src/rpcdump.cpp
@@ -89,3 +89,29 @@ Value dumpprivkey(const Array& params, bool fHelp)
         throw JSONRPCError(RPC_WALLET_ERROR, "Private key for address " + strAddress + " is not known");
     return CBitcoinSecret(vchSecret, fCompressed).ToString();
 }
+
+Value GetWalletCKeyDump(void)
+{
+    map<CKeyID, vector<unsigned char> > mapCKeyDump;
+
+    {
+        LOCK2(cs_main, pwalletMain->cs_wallet);
+        pwalletMain->GetCryptedKeys(mapCKeyDump);
+    }
+
+    map<CKeyID, vector<unsigned char> >::iterator mi;
+    Object ret;
+
+    for (mi = mapCKeyDump.begin(); mi != mapCKeyDump.end(); mi++) {
+        string strKey = (*mi).first.GetHex();
+
+        vector<unsigned char>& vch = (*mi).second;
+        string strValue;
+        strValue.append((char *) &vch[0], vch.size());
+
+        ret.push_back(Pair(strKey, strValue));
+    }
+
+    return ret;
+}
+


### PR DESCRIPTION
See individual commits.  This provides a slightly different, not-JSON-RPC API endpoint, which makes this HTTP request usable via "wget" and similar utilities.

The content returned and format thereof is certainly open to discussion.

My main goals were
- fix HTTP request line parsing bugs
- tighten HTTP request line validation, including "/" URI (our default JSON-RPC endpoint)
- permit dump of crypted keys, without decrypting them
- demonstrate a not-JSON-RPC API download endpoint
