### PR TITLE
Normalize wallet RPC commands (refillkeypool, unlockwallet, lockwallet, setpassphrase)

### DIFF
--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -223,10 +223,14 @@ static const CRPCCommand vRPCCommands[] =
     { "listreceivedbyaddress",  &listreceivedbyaddress,  false,  false },
     { "listreceivedbyaccount",  &listreceivedbyaccount,  false,  false },
     { "backupwallet",           &backupwallet,           true,   false },
-    { "keypoolrefill",          &keypoolrefill,          true,   false },
-    { "walletpassphrase",       &walletpassphrase,       true,   false },
-    { "walletpassphrasechange", &walletpassphrasechange, false,  false },
-    { "walletlock",             &walletlock,             true,   false },
+    { "keypoolrefill",          &refillkeypool,          true,   false },  // deprecated
+    { "refillkeypool",          &refillkeypool,          true,   false },
+    { "walletpassphrase",       &unlockwallet,           true,   false },  // deprecated
+    { "unlockwallet",           &unlockwallet,           true,   false },
+    { "walletpassphrasechange", &setpassphrase,          false,  false },  // deprecated
+    { "setpassphrase",          &setpassphrase,          false,  false },
+    { "walletlock",             &lockwallet,             true,   false },  // deprecated
+    { "lockwallet",             &lockwallet,             true,   false },
     { "encryptwallet",          &encryptwallet,          false,  false },
     { "validateaddress",        &validateaddress,        true,   false },
     { "getbalance",             &getbalance,             false,  false },

--- a/src/bitcoinrpc.h
+++ b/src/bitcoinrpc.h
@@ -167,10 +167,10 @@ extern json_spirit::Value listaccounts(const json_spirit::Array& params, bool fH
 extern json_spirit::Value listsinceblock(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value gettransaction(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value backupwallet(const json_spirit::Array& params, bool fHelp);
-extern json_spirit::Value keypoolrefill(const json_spirit::Array& params, bool fHelp);
-extern json_spirit::Value walletpassphrase(const json_spirit::Array& params, bool fHelp);
-extern json_spirit::Value walletpassphrasechange(const json_spirit::Array& params, bool fHelp);
-extern json_spirit::Value walletlock(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value refillkeypool(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value unlockwallet(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value setpassphrase(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value lockwallet(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value encryptwallet(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value validateaddress(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value getinfo(const json_spirit::Array& params, bool fHelp);


### PR DESCRIPTION
Updates 4 odd RPC commands to match other RPC commands which tend to follow a <VERB><OBJECT> naming scheme.

The old names still work as aliases of the new names, but don't show up in the help lists.

See:  https://bitcointalk.org/index.php?topic=122345.0
