### PR TITLE
RPC: Avoid cleartext passwords by default

### DIFF
--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -499,6 +499,17 @@ static uint256 BitcoinAuthHash(string &strKey, string& strUser,
     return BitcoinHMAC(strKey, strText);
 }
 
+static bool ValidAuthTimestamp(const string& strDate)
+{
+    int64 timestamp = (int64) atoll(strDate.c_str());
+    int64 now = GetTime();
+
+    if ((timestamp < (now - 60)) ||
+        (timestamp > (now + 60)))
+        return false;
+    return true;
+}
+
 static bool HTTPAuthBitcoin(string& strAuth, string& strRequest)
 {
     // Format: Bitcoin SP $Username SP $Timestamp SP $Nonce SP $HMAC_hash (hex)
@@ -515,6 +526,8 @@ static bool HTTPAuthBitcoin(string& strAuth, string& strRequest)
     if (strUser != mapArgs["-rpcuser"])
         return false;
     string strDate = vWords[2];
+    if (!ValidAuthTimestamp(strDate))
+        return false;
     string strNonce = vWords[3];
     string strHash = vWords[4];
     if (strHash.size() < (sizeof(uint256) * 2))


### PR DESCRIPTION
Although in theory RPC API access should be locked down, there are
occasions where cleartext passwords have been used anyway.

HTTP Basic authentication remains, but a new default "Bitcoin" HTTP
Authorization header is used.  HTTP Digest authentication was considered
initially, but that may require additional HTTP round-trips.  The standard
HMAC-SHA256 algorithm pair was chosen instead, with some additional stirring
factors (random nonce, time).

The HTTP server will accept Basic or Bitcoin authentication now.

The HTTP client will attempt Bitcoin authentication, and fall back to
Basic if that fails.
