### PR TITLE
extend setgenerate RPC-call with 2 pre-checks

### DIFF
--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -30,6 +30,12 @@ Value setgenerate(const Array& params, bool fHelp)
             "<generate> is true or false to turn generation on or off.\n"
             "Generation is limited to [genproclimit] processors, -1 is unlimited.");
 
+    if (vNodes.empty())
+        throw JSONRPCError(RPC_CLIENT_NOT_CONNECTED, "Bitcoin is not connected!");
+
+    if (IsInitialBlockDownload())
+        throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "Bitcoin is downloading blocks...");
+
     bool fGenerate = true;
     if (params.size() > 0)
         fGenerate = params[0].get_bool();


### PR DESCRIPTION
- if we are not connected and if we are downloading the block-chain don't
  start the mining threads
- this pull makes the setgenerate-call explicit, which I found out to be a
  good thing as we don't have 4 idle threads when not needed and it
  prevents mining under erroneous conditions (which I was able to trigger
  sometimes before this patch and which lead to orphan blocks)
- the internal miner is only used for testnet anyway these days, but I
  love it for that scenario
