### PR TITLE
use $(MAKE) in the makefile, so FreeBSD will use the right make tool (gmake)

### DIFF
--- a/src/makefile.unix
+++ b/src/makefile.unix
@@ -144,7 +144,7 @@ LIBS += $(CURDIR)/leveldb/libleveldb.a $(CURDIR)/leveldb/libmemenv.a
 DEFS += $(addprefix -I,$(CURDIR)/leveldb/include)
 DEFS += $(addprefix -I,$(CURDIR)/leveldb/helpers)
 leveldb/libleveldb.a:
-	@echo "Building LevelDB ..." && cd leveldb && make libleveldb.a libmemenv.a && cd ..
+	@echo "Building LevelDB ..." && cd leveldb && $(MAKE) libleveldb.a libmemenv.a && cd ..
 obj/leveldb.o: leveldb/libleveldb.a
 
 # auto-generated dependencies:


### PR DESCRIPTION
After the leveldb import, src/makefile.unix has the 'make' command for leveldb hard coded. When a build is run on FreeBSD, it uses the system make, which uses different syntaxes.
Using the macro $(MAKE) will cause it to run gmake, and the build will work.
