### PR TITLE
Fixwalletdates

### DIFF
--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -223,6 +223,7 @@ static const CRPCCommand vRPCCommands[] =
     { "listreceivedbyaddress",  &listreceivedbyaddress,  false,  false },
     { "listreceivedbyaccount",  &listreceivedbyaccount,  false,  false },
     { "backupwallet",           &backupwallet,           true,   false },
+    { "fixwalletdates",         &fixwalletdates,         false,  false },
     { "keypoolrefill",          &keypoolrefill,          true,   false },
     { "walletpassphrase",       &walletpassphrase,       true,   false },
     { "walletpassphrasechange", &walletpassphrasechange, false,  false },

--- a/src/bitcoinrpc.h
+++ b/src/bitcoinrpc.h
@@ -167,6 +167,7 @@ extern json_spirit::Value listaccounts(const json_spirit::Array& params, bool fH
 extern json_spirit::Value listsinceblock(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value gettransaction(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value backupwallet(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value fixwalletdates(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value keypoolrefill(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value walletpassphrase(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value walletpassphrasechange(const json_spirit::Array& params, bool fHelp);

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -68,15 +68,17 @@ public:
     void refreshWallet()
     {
         OutputDebugStringF("refreshWallet\n");
-        cachedWallet.clear();
-        {
-            LOCK(wallet->cs_wallet);
-            for(std::map<uint256, CWalletTx>::iterator it = wallet->mapWallet.begin(); it != wallet->mapWallet.end(); ++it)
+        parent->beginResetModel();
+            cachedWallet.clear();
             {
-                if(TransactionRecord::showTransaction(it->second))
-                    cachedWallet.append(TransactionRecord::decomposeTransaction(wallet, it->second));
+                LOCK(wallet->cs_wallet);
+                for(std::map<uint256, CWalletTx>::iterator it = wallet->mapWallet.begin(); it != wallet->mapWallet.end(); ++it)
+                {
+                    if(TransactionRecord::showTransaction(it->second))
+                        cachedWallet.append(TransactionRecord::decomposeTransaction(wallet, it->second));
+                }
             }
-        }
+        parent->endResetModel();
     }
 
     /* Update our model of the wallet incrementally, to synchronize our model of the wallet
@@ -86,6 +88,12 @@ public:
      */
     void updateWallet(const uint256 &hash, int status)
     {
+        if(CT_REBUILD_ALL == status)
+        {
+            refreshWallet();
+            return;
+        }
+
         OutputDebugStringF("updateWallet %s %i\n", hash.ToString().c_str(), status);
         {
             LOCK(wallet->cs_wallet);

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -1242,8 +1242,16 @@ Value fixwalletdates(const Array& params, bool fHelp)
             "Reset wallet transactions date to that of the block they appear in.");
 
     std::string result;
-    bool ok = pwalletMain->ResetTransactionTime(result);
-    return result + (ok ? "ok\n" : "failed\n");
+    int changedCount = pwalletMain->ResetTransactionTime(result);
+    if (changedCount < 0) {
+        result += "failed.\n";
+    }
+    else {
+        char buf[128];
+        sprintf(buf, "%d transactions were updated.\n", changedCount);
+        result += buf;
+    }
+    return result;
 }
 
 

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -1234,6 +1234,19 @@ Value backupwallet(const Array& params, bool fHelp)
 }
 
 
+Value fixwalletdates(const Array& params, bool fHelp)
+{
+    if (fHelp || params.size() != 0)
+        throw runtime_error(
+            "fixwalletdates\n"
+            "Reset wallet transactions date to that of the block they appear in.");
+
+    std::string result;
+    bool ok = pwalletMain->ResetTransactionTime(result);
+    return result + (ok ? "ok\n" : "failed\n");
+}
+
+
 Value keypoolrefill(const Array& params, bool fHelp)
 {
     if (fHelp || params.size() > 0)

--- a/src/ui_interface.h
+++ b/src/ui_interface.h
@@ -19,7 +19,8 @@ enum ChangeType
 {
     CT_NEW,
     CT_UPDATED,
-    CT_DELETED
+    CT_DELETED,
+    CT_REBUILD_ALL
 };
 
 /** Signals for UI communication. */

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -767,13 +767,14 @@ int CWallet::ScanForWalletTransactions(CBlockIndex* pindexStart, bool fUpdate)
 // Change the date of each transaction in the wallet to the
 // timestamp of the block the transactions appears in. The
 // time of TXs not yet appearing in a block remain unchanged.
-bool CWallet::ResetTransactionTime(std::string &result)
+int CWallet::ResetTransactionTime(std::string &result)
 {
+    uint256 hash;
+    int changedCount = 0;
     printf("ResetTransactionTime()\n");
     {
         LOCK(cs_wallet);
         BOOST_FOREACH(PAIRTYPE(const uint256, CWalletTx)& item, mapWallet) {
-            const uint256 &hash = item.first;
             CWalletTx &tx = item.second;
             if (tx.IsInMainChain()) {
                 CBlockIndex *index;
@@ -781,14 +782,14 @@ bool CWallet::ResetTransactionTime(std::string &result)
                 if (0<depth) {
                     int64 txTime = tx.GetTxTime();
                     unsigned int blockTime = index->nTime;
-                    if (blockTime != txTime) {
-                        tx.nTimeReceived = blockTime;
+                    if (blockTime != (unsigned int)txTime) {
+                        tx.nTimeReceived = tx.nTimeSmart = blockTime;
                         tx.MarkDirty();
                         tx.WriteToDisk();
-
-                        NotifyTransactionChanged(this, hash, CT_UPDATED);
+                        ++changedCount;
 
                         char buf[1024];
+                        hash = item.first;
                         sprintf(
                             buf,
                             "TX=%s OLDTIME=%d NEWTIME=%d\n",
@@ -802,7 +803,8 @@ bool CWallet::ResetTransactionTime(std::string &result)
             }
         }
     }
-    return true;
+    if (0<changedCount) NotifyTransactionChanged(this, hash, CT_REBUILD_ALL);
+    return changedCount;
 }
 
 void CWallet::ReacceptWalletTransactions()

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -166,6 +166,7 @@ public:
     bool EraseFromWallet(uint256 hash);
     void WalletUpdateSpent(const CTransaction& prevout);
     int ScanForWalletTransactions(CBlockIndex* pindexStart, bool fUpdate = false);
+    bool ResetTransactionTime(std::string &result);
     void ReacceptWalletTransactions();
     void ResendWalletTransactions();
     int64 GetBalance() const;

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -166,7 +166,7 @@ public:
     bool EraseFromWallet(uint256 hash);
     void WalletUpdateSpent(const CTransaction& prevout);
     int ScanForWalletTransactions(CBlockIndex* pindexStart, bool fUpdate = false);
-    bool ResetTransactionTime(std::string &result);
+    int ResetTransactionTime(std::string &result);
     void ReacceptWalletTransactions();
     void ResendWalletTransactions();
     int64 GetBalance() const;


### PR DESCRIPTION
```
Add the fixwalletdates RPC

    When the client has been off for a while and gets restarted,
    new transactions are received via blockchain updates and get
    tagged with the current time, which bear little to no correlation
    with the time at which the TX was broadcast by the sender.

    As a substitute, the "fixwalletdates" RPC re-tags all wallet
    transactions with the timestamp of the block they are included
    in (if any).

    One minor downside of calling this RPC is that TX that were
    actually received via broadcast will see their "broadcast date"
    be replaced by the time they got included in a block.

    In practice, I've found this not to be a problem. In fact,
    seeing all TXs tagged with the time at which they get included
    in the blockchain makes more sense : in a way, it's the time the
    TX became valid, and if we have to pick one canonically representative
    time for a TX, first block inclusion time is better than first
    broadcast time.
```
