### PR TITLE
Qt: small header changes / fixes

### DIFF
--- a/src/qt/addressbookpage.h
+++ b/src/qt/addressbookpage.h
@@ -82,4 +82,4 @@ signals:
     void verifyMessage(QString addr);
 };
 
-#endif // ADDRESSBOOKDIALOG_H
+#endif // ADDRESSBOOKPAGE_H

--- a/src/qt/bitcoinamountfield.h
+++ b/src/qt/bitcoinamountfield.h
@@ -1,5 +1,5 @@
-#ifndef BITCOINFIELD_H
-#define BITCOINFIELD_H
+#ifndef BITCOINAMOUNTFIELD_H
+#define BITCOINAMOUNTFIELD_H
 
 #include <QWidget>
 
@@ -57,4 +57,4 @@ private slots:
 };
 
 
-#endif // BITCOINFIELD_H
+#endif // BITCOINAMOUNTFIELD_H

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -177,4 +177,4 @@ private slots:
     void toggleHidden();
 };
 
-#endif
+#endif // BITCOINGUI_H

--- a/src/qt/macdockiconhandler.h
+++ b/src/qt/macdockiconhandler.h
@@ -1,7 +1,7 @@
 #ifndef MACDOCKICONHANDLER_H
 #define MACDOCKICONHANDLER_H
 
-#include <QtCore/QObject>
+#include <QObject>
 
 class QMenu;
 class QIcon;

--- a/src/qt/transactiontablemodel.h
+++ b/src/qt/transactiontablemodel.h
@@ -81,5 +81,4 @@ public slots:
     friend class TransactionTablePriv;
 };
 
-#endif
-
+#endif // TRANSACTIONTABLEMODEL_H


### PR DESCRIPTION
- ensure header inclusion guard is named after the header file
- add missing comments at the end of some inclusion guards
- add a small Qt5 compatibility fix in macdockiconhandler.h
