### PR TITLE
Change 'make' to $(MAKE) in leveldb make command line

### DIFF
--- a/src/makefile.linux-mingw
+++ b/src/makefile.linux-mingw
@@ -92,7 +92,7 @@ LIBS += $(CURDIR)/leveldb/libleveldb.a $(CURDIR)/leveldb/libmemenv.a
 DEFS += -I"$(CURDIR)/leveldb/include"
 DEFS += -I"$(CURDIR)/leveldb/helpers"
 leveldb/libleveldb.a:
-	@echo "Building LevelDB ..." && cd leveldb && CC=i586-mingw32msvc-gcc CXX=i586-mingw32msvc-g++ TARGET_OS=OS_WINDOWS_CROSSCOMPILE CXXFLAGS="-I$(INCLUDEPATHS)" LDFLAGS="-L$(LIBPATHS)" make libleveldb.a libmemenv.a && i586-mingw32msvc-ranlib libleveldb.a && i586-mingw32msvc-ranlib libmemenv.a && cd ..
+	@echo "Building LevelDB ..." && cd leveldb && CC=i586-mingw32msvc-gcc CXX=i586-mingw32msvc-g++ TARGET_OS=OS_WINDOWS_CROSSCOMPILE CXXFLAGS="-I$(INCLUDEPATHS)" LDFLAGS="-L$(LIBPATHS)" $(MAKE) libleveldb.a libmemenv.a && i586-mingw32msvc-ranlib libleveldb.a && i586-mingw32msvc-ranlib libmemenv.a && cd ..
 obj/leveldb.o: leveldb/libleveldb.a
 
 obj/build.h: FORCE

--- a/src/makefile.mingw
+++ b/src/makefile.mingw
@@ -96,7 +96,7 @@ DEFS += $(addprefix -I,$(CURDIR)/leveldb/include)
 DEFS += $(addprefix -I,$(CURDIR)/leveldb/helpers)
 # TODO: If this fails, try adding a ranlib libleveldb.a && ranlib libmemenv.a
 leveldb/libleveldb.a:
-	cd leveldb && make libleveldb.a libmemenv.a && cd ..
+	cd leveldb && $(MAKE) libleveldb.a libmemenv.a && cd ..
 obj/leveldb.o: leveldb/libleveldb.lib
 
 obj/%.o: %.cpp $(HEADERS)

--- a/src/makefile.osx
+++ b/src/makefile.osx
@@ -128,7 +128,7 @@ LIBS += $(CURDIR)/leveldb/libleveldb.a $(CURDIR)/leveldb/libmemenv.a
 DEFS += $(addprefix -I,$(CURDIR)/leveldb/include)
 DEFS += $(addprefix -I,$(CURDIR)/leveldb/helpers)
 leveldb/libleveldb.a:
-	@echo "Building LevelDB ..." && cd leveldb && make libleveldb.a libmemenv.a && cd ..
+	@echo "Building LevelDB ..." && cd leveldb && $(MAKE) libleveldb.a libmemenv.a && cd ..
 obj/leveldb.o: leveldb/libleveldb.a
 
 # auto-generated dependencies:

--- a/src/makefile.unix
+++ b/src/makefile.unix
@@ -144,7 +144,7 @@ LIBS += $(CURDIR)/leveldb/libleveldb.a $(CURDIR)/leveldb/libmemenv.a
 DEFS += $(addprefix -I,$(CURDIR)/leveldb/include)
 DEFS += $(addprefix -I,$(CURDIR)/leveldb/helpers)
 leveldb/libleveldb.a:
-	@echo "Building LevelDB ..." && cd leveldb && make libleveldb.a libmemenv.a && cd ..
+	@echo "Building LevelDB ..." && cd leveldb && $(MAKE) libleveldb.a libmemenv.a && cd ..
 obj/leveldb.o: leveldb/libleveldb.a
 
 # auto-generated dependencies:


### PR DESCRIPTION
Other operating systems, like FreeBSD, have their own make programs, with different syntax. These install GNU make as gmake, and relay on the $(MAKE) macro to specify the right program.
The src/makefile.\* files hard code make command line for leveldb, causing FreeBSD to use the wrong make command.

This pull edits this command to use the $(MAKE) macro, so the right make command is used.
