### PR TITLE
cleanup db.cpp/.h after Ultraprune patch

### DIFF
--- a/src/db.h
+++ b/src/db.h
@@ -2,6 +2,7 @@
 // Copyright (c) 2009-2012 The Bitcoin developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #ifndef BITCOIN_DB_H
 #define BITCOIN_DB_H
 
@@ -13,12 +14,7 @@
 
 #include <db_cxx.h>
 
-class CAddress;
 class CAddrMan;
-class CBlockLocator;
-class CDiskBlockIndex;
-class CMasterKey;
-class COutPoint;
 class CWallet;
 class CWalletTx;
 
@@ -27,12 +23,10 @@ extern unsigned int nWalletDBUpdated;
 void ThreadFlushWalletDB(void* parg);
 bool BackupWallet(const CWallet& wallet, const std::string& strDest);
 
-
 class CDBEnv
 {
 private:
     bool fDbEnvInit;
-    bool fMockDb;
 
     void EnvShutdown();
 
@@ -44,8 +38,6 @@ public:
 
     CDBEnv();
     ~CDBEnv();
-    void MakeMock();
-    bool IsMock() { return fMockDb; }
 
     /*
      * Verify that database file strFile is OK. If it is not,
@@ -71,7 +63,6 @@ public:
     void CheckpointLSN(std::string strFile);
 
     void CloseDb(const std::string& strFile);
-    bool RemoveDb(const std::string& strFile);
 
     DbTxn *TxnBegin(int flags=DB_TXN_WRITE_NOSYNC)
     {
@@ -304,12 +295,6 @@ public:
 
     bool static Rewrite(const std::string& strFile, const char* pszSkip = NULL);
 };
-
-
-
-
-
-
 
 
 /** Access to the (IP) address database (peers.dat) */


### PR DESCRIPTION
- remove obsolete functions, variables, definitions and such
- cleanup layout (no need to keep that many ugly empty lines IMHO)

I searched trough the source to see where functions are used and removed all that were not used anywhere anymore. Tried a compilation afterwards and the client still works fine :). Needs a careful review from a core dev.
