### PR TITLE
 P2P: improve RX/TX flow control

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -40,6 +40,7 @@ unsigned short GetListenPort();
 bool BindListenPort(const CService &bindAddr, std::string& strError=REF(std::string()));
 void StartNode(void* parg);
 bool StopNode();
+void SocketSendData(CNode *pnode);
 
 enum
 {
@@ -362,6 +363,10 @@ public:
         if (fDebug) {
             printf("(%d bytes)\n", nSize);
         }
+
+        // If write queue empty, attempt "optimistic write"
+        if (nHeaderStart == 0)
+            SocketSendData(this);
 
         nHeaderStart = -1;
         nMessageStart = -1;


### PR DESCRIPTION
- "optimistic write": Push each message to kernel socket buffer immediately
- If there is write data at select time, that implies send() blocked during optimistic write.  Drain write queue, before receiving any more messages.

This avoids needlessly queueing received data, if the remote peer is not themselves receiving data.

Result: write buffer (and thus memory usage) is kept small, DoS potential is slightly lower, and TCP flow control signalling is properly utilized.

The kernel will queue data into the socket buffer, then signal the remote peer to stop sending data, until we resume reading again.
