### PR TITLE
ensure we use our format macros to avoid compilation warnings

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1610,7 +1610,7 @@ bool CBlock::ConnectBlock(CBlockIndex* pindex, CCoinsViewCache &view, bool fJust
     }
 
     if (vtx[0].GetValueOut() > GetBlockValue(pindex->nHeight, nFees))
-        return error("ConnectBlock() : coinbase pays too much (actual=%lld vs limit=%lld)", (long long)vtx[0].GetValueOut(), (long long)GetBlockValue(pindex->nHeight, nFees));
+        return error("ConnectBlock() : coinbase pays too much (actual=%"PRI64u" vs limit=%"PRI64u")", vtx[0].GetValueOut(), GetBlockValue(pindex->nHeight, nFees));
 
     if (fJustCheck)
         return true;


### PR DESCRIPTION
- fixes 2 warnings I observed while compiling on Windows with MinGW
