### PR TITLE
Bitcoin-Qt: fix crash on Windows caused by CDBEnv::EnvShutdown()

### DIFF
--- a/src/db.cpp
+++ b/src/db.cpp
@@ -38,11 +38,13 @@ void CDBEnv::EnvShutdown()
     if (ret != 0)
         printf("EnvShutdown exception: %s (%d)\n", DbEnv::strerror(ret), ret);
     if (!fMockDb)
-        DbEnv(0).remove(GetDataDir().string().c_str(), 0);
+        DbEnv(0).remove(strPath.c_str(), 0);
 }
 
 CDBEnv::CDBEnv() : dbenv(DB_CXX_NO_EXCEPTIONS)
 {
+    fDbEnvInit = false;
+    fMockDb = false;
 }
 
 CDBEnv::~CDBEnv()
@@ -63,6 +65,7 @@ bool CDBEnv::Open(const boost::filesystem::path& path)
     if (fShutdown)
         return false;
 
+    strPath = path.string();
     filesystem::path pathLogDir = path / "database";
     filesystem::create_directory(pathLogDir);
     filesystem::path pathErrorFile = path / "db.log";
@@ -83,7 +86,7 @@ bool CDBEnv::Open(const boost::filesystem::path& path)
     dbenv.set_flags(DB_AUTO_COMMIT, 1);
     dbenv.set_flags(DB_TXN_WRITE_NOSYNC, 1);
     dbenv.log_set_config(DB_LOG_AUTO_REMOVE, 1);
-    int ret = dbenv.open(path.string().c_str(),
+    int ret = dbenv.open(strPath.c_str(),
                      DB_CREATE     |
                      DB_INIT_LOCK  |
                      DB_INIT_LOG   |

--- a/src/db.h
+++ b/src/db.h
@@ -33,6 +33,7 @@ class CDBEnv
 private:
     bool fDbEnvInit;
     bool fMockDb;
+    std::string strPath;
 
     void EnvShutdown();
 


### PR DESCRIPTION
- can be triggerd by just adding -proxy=crashme with 0.7.1
- crash occured, when AppInit2() was left with return false; after the
  first call to bitdb.open() (Step 6 in init)
- this is caused by GetDataDir() or .string() in CDBEnv::EnvShutdown()
  called via the bitdb global destructor

More details in #2025, as I'm not sure this fixes the underlying issue or just that single appearance of the bug.
