### PR TITLE
Deploy properly with Nokia Qt installer's Frameworks on OSX

### DIFF
--- a/contrib/macdeploy/macdeployqtplus
+++ b/contrib/macdeploy/macdeployqtplus
@@ -172,7 +172,9 @@ class DeploymentInfo(object):
         elif os.path.exists(os.path.join(os.path.dirname(parentDir), "share", "qt4", "translations")):
             # Newer Macports layout
             self.qtPath = os.path.join(os.path.dirname(parentDir), "share", "qt4")
-        
+        else:
+            self.qtPath = os.getenv("QTDIR", None)
+
         if self.qtPath is not None:
             pluginPath = os.path.join(self.qtPath, "plugins")
             if os.path.exists(pluginPath):
@@ -242,7 +244,11 @@ def runStrip(binaryPath, verbose):
     subprocess.check_call(["strip", "-x", binaryPath])
 
 def copyFramework(framework, path, verbose):
-    fromPath = framework.sourceFilePath
+    if framework.sourceFilePath.startswith("Qt"):
+        #standard place for Nokia Qt installer's frameworks
+        fromPath = "/Library/Frameworks/" + framework.sourceFilePath
+    else:
+        fromPath = framework.sourceFilePath
     toDir = os.path.join(path, framework.destinationDirectory)
     toPath = os.path.join(toDir, framework.binaryName)
     
@@ -345,7 +351,7 @@ def deployPlugins(appBundleInfo, deploymentInfo, strip, verbose):
         if pluginDirectory == "designer":
             # Skip designer plugins
             continue
-        elif pluginDirectory == "phonon":
+        elif pluginDirectory == "phonon" or pluginDirectory == "phonon_backend":
             # Deploy the phonon plugins only if phonon is in use
             if not deploymentInfo.usesFramework("phonon"):
                 continue


### PR DESCRIPTION
Pursuant to a "discussion" here:
https://github.com/bitcoin/bitcoin/issues/2015

The patch does three things:
1. Copies Qt frameworks from a well-known location.
2, On my installation "phonon" plugin is called "phonon_backend". Make sure phonon_backend is ignored.
3. env. variable QTDIR is used to find the plugins directory. On my installation the dir is "/Developer/Application/Qt". I decided that instead of hard-coding this path, setting QTDIR before running the script is a more flexible solution.
