### PR TITLE
Add assert and comment for subtle pay-to-script-hash logic

### DIFF
--- a/src/script.cpp
+++ b/src/script.cpp
@@ -1658,6 +1658,11 @@ bool VerifyScript(const CScript& scriptSig, const CScript& scriptPubKey, const C
         if (!scriptSig.IsPushOnly()) // scriptSig must be literals-only
             return false;            // or validation fails
 
+        // stackCopy cannot be empty here, because if it was the
+        // P2SH  HASH <> EQUAL  scriptPubKey would be evaluated with
+        // an empty stack and the EvalScript above would return false.
+        assert(!stackCopy.empty());
+
         const valtype& pubKeySerialized = stackCopy.back();
         CScript pubKey2(pubKeySerialized.begin(), pubKeySerialized.end());
         popstack(stackCopy);


### PR DESCRIPTION
From a question raised by @jgarzik as he re-reviewed the p2sh code.
