### PR TITLE
Fix OpenDiskFile's fReadOnly flag to work, as well as other problems importing read-only block files

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2182,9 +2182,7 @@ FILE* OpenDiskFile(const CDiskBlockPos &pos, const char *prefix, bool fReadOnly)
         return NULL;
     boost::filesystem::path path = GetDataDir() / "blocks" / strprintf("%s%05u.dat", prefix, pos.nFile);
     boost::filesystem::create_directories(path.parent_path());
-    FILE* file = fopen(path.string().c_str(), "rb+");
-    if (!file && !fReadOnly)
-        file = fopen(path.string().c_str(), "wb+");
+    FILE* file = fopen(path.string().c_str(), fReadOnly ? "rb" : "wb+");
     if (!file) {
         printf("Unable to open file %s\n", path.string().c_str());
         return NULL;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1510,10 +1510,14 @@ void static FlushBlockFile()
     posOld.nPos = 0;
 
     FILE *fileOld = OpenBlockFile(posOld);
-    FileCommit(fileOld);
-    fclose(fileOld);
+    if (fileOld)
+    {
+        FileCommit(fileOld);
+        fclose(fileOld);
+    }
 
     fileOld = OpenUndoFile(posOld);
+    assert(fileOld);
     FileCommit(fileOld);
     fclose(fileOld);
 }
@@ -1721,7 +1725,9 @@ bool SetBestChain(CBlockIndex* pindexNew)
     // Make sure it's successfully written to disk before changing memory structure
     bool fIsInitialDownload = IsInitialBlockDownload();
     if (!fIsInitialDownload || view.GetCacheSize()>5000) {
-        FlushBlockFile();
+        if (!fImporting)
+            // Importing is read-only, so don't flush block file
+            FlushBlockFile();
         pblocktree->Sync();
         if (!view.Flush())
             return false;


### PR DESCRIPTION
OpenDiskFile was always opening files in "rb+" mode (read-write binary), and if that failed and fReadOnly was false, trying to truncate the file. Truncate would always fail (AFAIK) unless a race condition set the file read-write between the two attempts.

This changes it to actually honour fReadOnly. The truncate race ''is not'' fixed, and cannot easily be fixed (fopen lacks a "open read-write, random access, but don't truncate" mode).
If we want to actually try truncating in !fReadOnly mode, I'm pretty sure we need to unlink first.

This bug was introduced as part of ultraprune, so does not affect any released versions.
