### PR TITLE
Make test_bitcoin run in a temp datadir

### DIFF
--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -1,10 +1,12 @@
 #define BOOST_TEST_MODULE Bitcoin Test Suite
 #include <boost/test/unit_test.hpp>
+#include <boost/filesystem.hpp>
 
 #include "db.h"
 #include "txdb.h"
 #include "main.h"
 #include "wallet.h"
+#include "util.h"
 
 CWallet* pwalletMain;
 CClientUIInterface uiInterface;
@@ -14,11 +16,15 @@ extern void noui_connect();
 
 struct TestingSetup {
     CCoinsViewDB *pcoinsdbview;
+    boost::filesystem::path pathTemp;
 
     TestingSetup() {
         fPrintToDebugger = true; // don't want to write to debug.log file
         noui_connect();
         bitdb.MakeMock();
+        pathTemp = GetTempPath() / strprintf("test_bitcoin_%lu_%i", (unsigned long)GetTime(), (int)(GetRand(100000)));
+        boost::filesystem::create_directories(pathTemp);
+        mapArgs["-datadir"] = pathTemp.string();
         pblocktree = new CBlockTreeDB(1 << 20, true);
         pcoinsdbview = new CCoinsViewDB(1 << 23, true);
         pcoinsTip = new CCoinsViewCache(*pcoinsdbview);
@@ -36,6 +42,7 @@ struct TestingSetup {
         delete pcoinsdbview;
         delete pblocktree;
         bitdb.Flush(true);
+        boost::filesystem::remove_all(pathTemp);
     }
 };
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1310,6 +1310,28 @@ boost::filesystem::path GetSpecialFolderPath(int nFolder, bool fCreate)
 }
 #endif
 
+boost::filesystem::path GetTempPath() {
+#if BOOST_FILESYSTEM_VERSION == 3
+    return boost::filesystem::temp_directory_path();
+#else
+    // TODO: remove when we don't support filesystem v2 anymore
+    boost::filesystem::path path;
+#ifdef WIN32
+    char pszPath[MAX_PATH] = "";
+
+    if (GetTempPathA(MAX_PATH, pszPath))
+        path = boost::filesystem::path(pszPath);
+#else
+    path = boost::filesystem::path("/tmp");
+#endif
+    if (path.empty() || !boost::filesystem::is_directory(path)) {
+        printf("GetTempPath(): failed to find temp path\n");
+        return boost::filesystem::path("");
+    }
+    return path;
+#endif
+}
+
 void runCommand(std::string strCommand)
 {
     int nErr = ::system(strCommand.c_str());

--- a/src/util.h
+++ b/src/util.h
@@ -207,6 +207,7 @@ void ReadConfigFile(std::map<std::string, std::string>& mapSettingsRet, std::map
 #ifdef WIN32
 boost::filesystem::path GetSpecialFolderPath(int nFolder, bool fCreate = true);
 #endif
+boost::filesystem::path GetTempPath();
 void ShrinkDebugFile();
 int GetRandInt(int nMax);
 uint64 GetRand(uint64 nMax);


### PR DESCRIPTION
Apparently, test_bitcoin has been silently corrupting $DATADIR/blocks/blk00000.dat and rev00000.dat since ultraprune was merged...
