### PR TITLE
Addition of Import Private Key Menu

### DIFF
--- a/bitcoin-qt.pro
+++ b/bitcoin-qt.pro
@@ -195,7 +195,8 @@ HEADERS += src/qt/bitcoingui.h \
     src/netbase.h \
     src/clientversion.h \
     src/txdb.h \
-    src/leveldb.h
+    src/leveldb.h \
+    src/qt/importprivatekeydialog.h
 
 SOURCES += src/qt/bitcoin.cpp src/qt/bitcoingui.cpp \
     src/qt/transactiontablemodel.cpp \
@@ -257,7 +258,8 @@ SOURCES += src/qt/bitcoin.cpp src/qt/bitcoingui.cpp \
     src/qt/rpcconsole.cpp \
     src/noui.cpp \
     src/leveldb.cpp \
-    src/txdb.cpp
+    src/txdb.cpp \
+    src/qt/importprivatekeydialog.cpp
 
 RESOURCES += \
     src/qt/bitcoin.qrc
@@ -273,7 +275,8 @@ FORMS += \
     src/qt/forms/sendcoinsentry.ui \
     src/qt/forms/askpassphrasedialog.ui \
     src/qt/forms/rpcconsole.ui \
-    src/qt/forms/optionsdialog.ui
+    src/qt/forms/optionsdialog.ui \
+    src/qt/forms/importprivatekeydialog.ui
 
 contains(USE_QRCODE, 1) {
 HEADERS += src/qt/qrcodedialog.h

--- a/bitcoin-qt.pro
+++ b/bitcoin-qt.pro
@@ -196,7 +196,8 @@ HEADERS += src/qt/bitcoingui.h \
     src/clientversion.h \
     src/txdb.h \
     src/leveldb.h \
-    src/qt/importprivatekeydialog.h
+    src/qt/importprivatekeydialog.h \
+    src/qt/progressdialog.h
 
 SOURCES += src/qt/bitcoin.cpp src/qt/bitcoingui.cpp \
     src/qt/transactiontablemodel.cpp \
@@ -259,7 +260,8 @@ SOURCES += src/qt/bitcoin.cpp src/qt/bitcoingui.cpp \
     src/noui.cpp \
     src/leveldb.cpp \
     src/txdb.cpp \
-    src/qt/importprivatekeydialog.cpp
+    src/qt/importprivatekeydialog.cpp \
+    src/qt/progressdialog.cpp
 
 RESOURCES += \
     src/qt/bitcoin.qrc
@@ -276,7 +278,8 @@ FORMS += \
     src/qt/forms/askpassphrasedialog.ui \
     src/qt/forms/rpcconsole.ui \
     src/qt/forms/optionsdialog.ui \
-    src/qt/forms/importprivatekeydialog.ui
+    src/qt/forms/importprivatekeydialog.ui \
+    src/qt/forms/progressdialog.ui
 
 contains(USE_QRCODE, 1) {
 HEADERS += src/qt/qrcodedialog.h

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -25,6 +25,7 @@
 #include "notificator.h"
 #include "guiutil.h"
 #include "rpcconsole.h"
+#include "importprivatekeydialog.h"
 
 #ifdef Q_OS_MAC
 #include "macdockiconhandler.h"
@@ -62,6 +63,7 @@ BitcoinGUI::BitcoinGUI(QWidget *parent):
     clientModel(0),
     walletModel(0),
     encryptWalletAction(0),
+    importPrivateKeyAction(0),
     changePassphraseAction(0),
     aboutQtAction(0),
     trayIcon(0),
@@ -259,6 +261,9 @@ void BitcoinGUI::createActions()
     encryptWalletAction = new QAction(QIcon(":/icons/lock_closed"), tr("&Encrypt Wallet..."), this);
     encryptWalletAction->setStatusTip(tr("Encrypt the private keys that belong to your wallet"));
     encryptWalletAction->setCheckable(true);
+    importPrivateKeyAction = new QAction(QIcon(":/icons/lock_closed"), tr("&Import Private Key..."), this);
+    importPrivateKeyAction->setStatusTip(tr("Import Private Key into your wallet"));
+    importPrivateKeyAction->setCheckable(true);
     backupWalletAction = new QAction(QIcon(":/icons/filesave"), tr("&Backup Wallet..."), this);
     backupWalletAction->setStatusTip(tr("Backup wallet to another location"));
     changePassphraseAction = new QAction(QIcon(":/icons/key"), tr("&Change Passphrase..."), this);
@@ -280,6 +285,7 @@ void BitcoinGUI::createActions()
     connect(optionsAction, SIGNAL(triggered()), this, SLOT(optionsClicked()));
     connect(toggleHideAction, SIGNAL(triggered()), this, SLOT(toggleHidden()));
     connect(encryptWalletAction, SIGNAL(triggered(bool)), this, SLOT(encryptWallet(bool)));
+    connect(importPrivateKeyAction, SIGNAL(triggered(bool)), this, SLOT(importPrivateKey()));
     connect(backupWalletAction, SIGNAL(triggered()), this, SLOT(backupWallet()));
     connect(changePassphraseAction, SIGNAL(triggered()), this, SLOT(changePassphrase()));
     connect(signMessageAction, SIGNAL(triggered()), this, SLOT(gotoSignMessageTab()));
@@ -309,6 +315,7 @@ void BitcoinGUI::createMenuBar()
     settings->addAction(encryptWalletAction);
     settings->addAction(changePassphraseAction);
     settings->addSeparator();
+    settings->addAction(importPrivateKeyAction);
     settings->addAction(optionsAction);
 
     QMenu *help = appMenuBar->addMenu(tr("&Help"));
@@ -811,6 +818,8 @@ void BitcoinGUI::setEncryptionStatus(int status)
         encryptWalletAction->setChecked(false);
         changePassphraseAction->setEnabled(false);
         encryptWalletAction->setEnabled(true);
+
+        importPrivateKeyAction->setEnabled(true);
         break;
     case WalletModel::Unlocked:
         labelEncryptionIcon->show();
@@ -819,6 +828,7 @@ void BitcoinGUI::setEncryptionStatus(int status)
         encryptWalletAction->setChecked(true);
         changePassphraseAction->setEnabled(true);
         encryptWalletAction->setEnabled(false); // TODO: decrypt currently not supported
+        importPrivateKeyAction->setEnabled(true);
         break;
     case WalletModel::Locked:
         labelEncryptionIcon->show();
@@ -827,6 +837,8 @@ void BitcoinGUI::setEncryptionStatus(int status)
         encryptWalletAction->setChecked(true);
         changePassphraseAction->setEnabled(true);
         encryptWalletAction->setEnabled(false); // TODO: decrypt currently not supported
+
+        importPrivateKeyAction->setEnabled(false);
         break;
     }
 }
@@ -841,6 +853,14 @@ void BitcoinGUI::encryptWallet(bool status)
     dlg.exec();
 
     setEncryptionStatus(walletModel->getEncryptionStatus());
+}
+
+void BitcoinGUI::importPrivateKey()
+{
+    //todo!
+    ImportPrivateKeyDialog dlg(this);
+    dlg.setModel(walletModel);
+    dlg.exec();
 }
 
 void BitcoinGUI::backupWallet()

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -262,7 +262,8 @@ void BitcoinGUI::createActions()
     encryptWalletAction->setStatusTip(tr("Encrypt the private keys that belong to your wallet"));
     encryptWalletAction->setCheckable(true);
     importPrivateKeyAction = new QAction(QIcon(":/icons/key"), tr("&Import Private Key..."), this);
-    importPrivateKeyAction->setStatusTip(tr("Import Private Key into your wallet"));
+    importPrivateKeyAction->setStatusTip(tr("Import private key into wallet."));
+    importPrivateKeyAction->setEnabled(true);
     backupWalletAction = new QAction(QIcon(":/icons/filesave"), tr("&Backup Wallet..."), this);
     backupWalletAction->setStatusTip(tr("Backup wallet to another location"));
     changePassphraseAction = new QAction(QIcon(":/icons/key"), tr("&Change Passphrase..."), this);
@@ -818,7 +819,7 @@ void BitcoinGUI::setEncryptionStatus(int status)
         changePassphraseAction->setEnabled(false);
         encryptWalletAction->setEnabled(true);
 
-        importPrivateKeyAction->setEnabled(true);
+
         break;
     case WalletModel::Unlocked:
         labelEncryptionIcon->show();
@@ -827,7 +828,6 @@ void BitcoinGUI::setEncryptionStatus(int status)
         encryptWalletAction->setChecked(true);
         changePassphraseAction->setEnabled(true);
         encryptWalletAction->setEnabled(false); // TODO: decrypt currently not supported
-        importPrivateKeyAction->setEnabled(true);
         break;
     case WalletModel::Locked:
         labelEncryptionIcon->show();
@@ -837,7 +837,7 @@ void BitcoinGUI::setEncryptionStatus(int status)
         changePassphraseAction->setEnabled(true);
         encryptWalletAction->setEnabled(false); // TODO: decrypt currently not supported
 
-        importPrivateKeyAction->setEnabled(false);
+
         break;
     }
 }

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -261,9 +261,8 @@ void BitcoinGUI::createActions()
     encryptWalletAction = new QAction(QIcon(":/icons/lock_closed"), tr("&Encrypt Wallet..."), this);
     encryptWalletAction->setStatusTip(tr("Encrypt the private keys that belong to your wallet"));
     encryptWalletAction->setCheckable(true);
-    importPrivateKeyAction = new QAction(QIcon(":/icons/lock_closed"), tr("&Import Private Key..."), this);
+    importPrivateKeyAction = new QAction(QIcon(":/icons/key"), tr("&Import Private Key..."), this);
     importPrivateKeyAction->setStatusTip(tr("Import Private Key into your wallet"));
-    importPrivateKeyAction->setCheckable(true);
     backupWalletAction = new QAction(QIcon(":/icons/filesave"), tr("&Backup Wallet..."), this);
     backupWalletAction->setStatusTip(tr("Backup wallet to another location"));
     changePassphraseAction = new QAction(QIcon(":/icons/key"), tr("&Change Passphrase..."), this);

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -87,6 +87,7 @@ private:
     QAction *toggleHideAction;
     QAction *exportAction;
     QAction *encryptWalletAction;
+    QAction *importPrivateKeyAction;
     QAction *backupWalletAction;
     QAction *changePassphraseAction;
     QAction *aboutQtAction;
@@ -164,6 +165,8 @@ private slots:
     void incomingTransaction(const QModelIndex & parent, int start, int end);
     /** Encrypt the wallet */
     void encryptWallet(bool status);
+    /** Encrypt the wallet */
+    void importPrivateKey();
     /** Backup the wallet */
     void backupWallet();
     /** Change encrypted wallet passphrase */

--- a/src/qt/forms/importprivatekeydialog.ui
+++ b/src/qt/forms/importprivatekeydialog.ui
@@ -70,7 +70,7 @@
    <item>
     <widget class="QLabel" name="warningLabel">
      <property name="text">
-      <string>Enter the private key and a label to import key into wallet. This process can take a minute or 2 to complete.</string>
+      <string>Enter the private key and a label to import key into wallet. This process can take a few minutes to complete.</string>
      </property>
      <property name="textFormat">
       <enum>Qt::RichText</enum>
@@ -148,7 +148,7 @@
       </widget>
      </item>
      <item row="0" column="5">
-      <widget class="QDialogButtonBox" name="buttonBox_2">
+      <widget class="QDialogButtonBox" name="cancelButton">
        <property name="standardButtons">
         <set>QDialogButtonBox::Cancel</set>
        </property>

--- a/src/qt/forms/importprivatekeydialog.ui
+++ b/src/qt/forms/importprivatekeydialog.ui
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ImportPrivateKeyDialog</class>
+ <widget class="QDialog" name="ImportPrivateKeyDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>598</width>
+    <height>103</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>550</width>
+    <height>0</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Import Private Key Dialog</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="warningLabel">
+     <property name="textFormat">
+      <enum>Qt::RichText</enum>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QFormLayout" name="formLayout">
+     <property name="fieldGrowthPolicy">
+      <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+     </property>
+     <item row="0" column="0">
+      <widget class="QLabel" name="passLabel1">
+       <property name="text">
+        <string>Enter Private Key</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QLineEdit" name="privateKeyEdit1">
+       <property name="echoMode">
+        <enum>QLineEdit::Password</enum>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>ImportPrivateKeyDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>ImportPrivateKeyDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/qt/forms/importprivatekeydialog.ui
+++ b/src/qt/forms/importprivatekeydialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>598</width>
-    <height>103</height>
+    <width>602</width>
+    <height>203</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -27,16 +27,6 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QLabel" name="warningLabel">
-     <property name="textFormat">
-      <enum>Qt::RichText</enum>
-     </property>
-     <property name="wordWrap">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item>
     <layout class="QFormLayout" name="formLayout">
      <property name="fieldGrowthPolicy">
       <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
@@ -50,22 +40,134 @@
      </item>
      <item row="0" column="1">
       <widget class="QLineEdit" name="privateKeyEdit1">
+       <property name="maxLength">
+        <number>64</number>
+       </property>
        <property name="echoMode">
-        <enum>QLineEdit::Password</enum>
+        <enum>QLineEdit::Normal</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Address Label</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QLineEdit" name="addressLabelEdit">
+       <property name="text">
+        <string>Imported Private Key </string>
+       </property>
+       <property name="maxLength">
+        <number>64</number>
        </property>
       </widget>
      </item>
     </layout>
    </item>
    <item>
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+    <widget class="QLabel" name="warningLabel">
+     <property name="text">
+      <string>Enter the private key and a label to import key into wallet. This process can take a minute or 2 to complete.</string>
      </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     <property name="textFormat">
+      <enum>Qt::RichText</enum>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
      </property>
     </widget>
+   </item>
+   <item>
+    <layout class="QGridLayout" name="gridLayout">
+     <item row="0" column="0">
+      <spacer name="horizontalSpacer_4">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item row="0" column="3">
+      <spacer name="horizontalSpacer_3">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item row="0" column="2">
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item row="0" column="4">
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item row="0" column="6">
+      <widget class="QDialogButtonBox" name="buttonBox">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="standardButtons">
+        <set>QDialogButtonBox::Ok</set>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="5">
+      <widget class="QDialogButtonBox" name="buttonBox_2">
+       <property name="standardButtons">
+        <set>QDialogButtonBox::Cancel</set>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <spacer name="horizontalSpacer_5">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>

--- a/src/qt/forms/progressdialog.ui
+++ b/src/qt/forms/progressdialog.ui
@@ -2,6 +2,9 @@
 <ui version="4.0">
  <class>ProgressDialog</class>
  <widget class="QDialog" name="ProgressDialog">
+  <property name="windowModality">
+   <enum>Qt::WindowModal</enum>
+  </property>
   <property name="geometry">
    <rect>
     <x>0</x>
@@ -11,7 +14,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Dialog</string>
+   <string>Block Scan Progress</string>
   </property>
   <widget class="QProgressBar" name="progressBar">
    <property name="geometry">
@@ -24,6 +27,9 @@
    </property>
    <property name="value">
     <number>0</number>
+   </property>
+   <property name="format">
+    <string>%v out of %m</string>
    </property>
   </widget>
   <widget class="QLabel" name="label">

--- a/src/qt/forms/progressdialog.ui
+++ b/src/qt/forms/progressdialog.ui
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ProgressDialog</class>
+ <widget class="QDialog" name="ProgressDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>102</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <widget class="QProgressBar" name="progressBar">
+   <property name="geometry">
+    <rect>
+     <x>30</x>
+     <y>60</y>
+     <width>341</width>
+     <height>23</height>
+    </rect>
+   </property>
+   <property name="value">
+    <number>0</number>
+   </property>
+  </widget>
+  <widget class="QLabel" name="label">
+   <property name="geometry">
+    <rect>
+     <x>60</x>
+     <y>20</y>
+     <width>281</width>
+     <height>17</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Scanning blocks for new transactions...</string>
+   </property>
+  </widget>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/qt/importprivatekeydialog.cpp
+++ b/src/qt/importprivatekeydialog.cpp
@@ -1,6 +1,7 @@
 #include "importprivatekeydialog.h"
 #include "ui_importprivatekeydialog.h"
 #include "walletmodel.h"
+#include "progressdialog.h"
 #include "base58.h"
  #include <QValidator>
 #include "version.h"
@@ -63,8 +64,15 @@ void ImportPrivateKeyDialog::on_buttonBox_accepted()
     string strLabel = ui->addressLabelEdit->text().toStdString();
 
     //TODO handle errors returned.
+    ProgressDialog prgdlg(this);
+    prgdlg.setModal (true );
+    prgdlg.show();
+    prgdlg.raise();
+    prgdlg.activateWindow();
+    connect(model, SIGNAL(ScanWalletTransactionsProgress(int)), &prgdlg, SLOT(UpdateProgress(int)));
     model->ImportPrivateKey(strSecret,strLabel);
-
+    disconnect(model, SIGNAL(ScanWalletTransactionsProgress(int)), &prgdlg, SLOT(UpdateProgress(int)));
+    prgdlg.hide();
     close();
 }
 

--- a/src/qt/importprivatekeydialog.cpp
+++ b/src/qt/importprivatekeydialog.cpp
@@ -1,0 +1,30 @@
+#include "importprivatekeydialog.h"
+#include "ui_importprivatekeydialog.h"
+#include "walletmodel.h"
+
+#include "version.h"
+
+ImportPrivateKeyDialog::ImportPrivateKeyDialog(QWidget *parent) :
+    QDialog(parent),
+    ui(new Ui::ImportPrivateKeyDialog)
+{
+    ui->setupUi(this);
+}
+
+void ImportPrivateKeyDialog::setModel(WalletModel *model)
+{
+    if(model)
+    {
+        //ui->versionLabel->setText(model->formatFullVersion());
+    }
+}
+
+ImportPrivateKeyDialog::~ImportPrivateKeyDialog()
+{
+    delete ui;
+}
+
+void ImportPrivateKeyDialog::on_buttonBox_accepted()
+{
+    close();
+}

--- a/src/qt/importprivatekeydialog.cpp
+++ b/src/qt/importprivatekeydialog.cpp
@@ -3,7 +3,8 @@
 #include "walletmodel.h"
 #include "progressdialog.h"
 #include "base58.h"
- #include <QValidator>
+#include <QValidator>
+#include <QMessageBox>
 #include "version.h"
 using namespace std;
 
@@ -59,12 +60,22 @@ ImportPrivateKeyDialog::~ImportPrivateKeyDialog()
 
 void ImportPrivateKeyDialog::on_buttonBox_accepted()
 {
+    WalletModel::UnlockContext ctx(model->requestUnlock());
+    if(!ctx.isValid())
+    {
+        QMessageBox::critical(this, windowTitle(),
+            tr("Could not unlock wallet. Key not imported."),
+            QMessageBox::Ok, QMessageBox::Ok);
+        return;
+    }
+
     //Import the key...
     string strSecret = ui->privateKeyEdit1->text().toStdString();
     string strLabel = ui->addressLabelEdit->text().toStdString();
 
     //TODO handle errors returned.
     ProgressDialog prgdlg(this);
+    prgdlg.setMax(model->getNumBlocks());
     prgdlg.setModal (true );
     prgdlg.show();
     prgdlg.raise();
@@ -81,4 +92,9 @@ void ImportPrivateKeyDialog::on_privateKeyEdit1_textChanged(const QString &arg1)
     //TODO - check if wallet encrypted and locked
     ui->buttonBox->setEnabled(
         ui->privateKeyEdit1->hasAcceptableInput ());
+}
+
+void ImportPrivateKeyDialog::on_cancelButton_accepted()
+{
+    close();
 }

--- a/src/qt/importprivatekeydialog.h
+++ b/src/qt/importprivatekeydialog.h
@@ -1,0 +1,29 @@
+#ifndef IMPORTPRIVATEKEYDIALOG_H
+#define IMPORTPRIVATEKEYDIALOG_H
+
+#include <QDialog>
+
+namespace Ui {
+    class ImportPrivateKeyDialog;
+}
+class WalletModel;
+
+/** "Import Private Key" dialog box */
+class ImportPrivateKeyDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit ImportPrivateKeyDialog(QWidget *parent = 0);
+    ~ImportPrivateKeyDialog();
+
+    void setModel(WalletModel *model);
+private:
+    Ui::ImportPrivateKeyDialog *ui;
+
+private slots:
+    void on_buttonBox_accepted();
+};
+
+#endif // IMPORTPRIVATEKEYDIALOG_H
+

--- a/src/qt/importprivatekeydialog.h
+++ b/src/qt/importprivatekeydialog.h
@@ -2,11 +2,25 @@
 #define IMPORTPRIVATEKEYDIALOG_H
 
 #include <QDialog>
+#include <QValidator>
+
+#include "bitcoinrpc.h"
 
 namespace Ui {
     class ImportPrivateKeyDialog;
 }
 class WalletModel;
+
+class PrivateKeyValidator : public QValidator
+{
+    Q_OBJECT
+    public:
+        PrivateKeyValidator(QObject * parent);
+        QValidator::State validate(QString &valueToValidate, int &pos) const;
+    private:
+        std::string sBase58;
+        QObject *parentObject;
+};
 
 /** "Import Private Key" dialog box */
 class ImportPrivateKeyDialog : public QDialog
@@ -17,12 +31,16 @@ public:
     explicit ImportPrivateKeyDialog(QWidget *parent = 0);
     ~ImportPrivateKeyDialog();
 
-    void setModel(WalletModel *model);
+    void setModel(WalletModel *walletmodel);
 private:
     Ui::ImportPrivateKeyDialog *ui;
+    WalletModel *model;
 
 private slots:
     void on_buttonBox_accepted();
+
+
+    void on_privateKeyEdit1_textChanged(const QString &arg1);
 };
 
 #endif // IMPORTPRIVATEKEYDIALOG_H

--- a/src/qt/importprivatekeydialog.h
+++ b/src/qt/importprivatekeydialog.h
@@ -41,6 +41,8 @@ private slots:
 
 
     void on_privateKeyEdit1_textChanged(const QString &arg1);
+
+    void on_cancelButton_accepted();
 };
 
 #endif // IMPORTPRIVATEKEYDIALOG_H

--- a/src/qt/progressdialog.cpp
+++ b/src/qt/progressdialog.cpp
@@ -13,7 +13,13 @@ ProgressDialog::~ProgressDialog()
     delete ui;
 }
 
-void ProgressDialog::UpdateProgress(int percent)
+void ProgressDialog::UpdateProgress(int v)
 {
-    ui->progressBar->setValue(percent);
+    ui->progressBar->setValue(v);
 }
+
+void ProgressDialog::setMax(int m)
+{
+    ui->progressBar->setMaximum(m);
+}
+

--- a/src/qt/progressdialog.cpp
+++ b/src/qt/progressdialog.cpp
@@ -1,0 +1,19 @@
+#include "progressdialog.h"
+#include "ui_progressdialog.h"
+
+ProgressDialog::ProgressDialog(QWidget *parent) :
+    QDialog(parent),
+    ui(new Ui::ProgressDialog)
+{
+    ui->setupUi(this);
+}
+
+ProgressDialog::~ProgressDialog()
+{
+    delete ui;
+}
+
+void ProgressDialog::UpdateProgress(int percent)
+{
+    ui->progressBar->setValue(percent);
+}

--- a/src/qt/progressdialog.h
+++ b/src/qt/progressdialog.h
@@ -10,16 +10,18 @@ class ProgressDialog;
 class ProgressDialog : public QDialog
 {
     Q_OBJECT
+
     
 public:
     explicit ProgressDialog(QWidget *parent = 0);
     ~ProgressDialog();
+    void setMax(int m);
     
 private:
     Ui::ProgressDialog *ui;
 
 public slots:
-    void UpdateProgress(int percent);
+    void UpdateProgress(int v);
 
 };
 

--- a/src/qt/progressdialog.h
+++ b/src/qt/progressdialog.h
@@ -1,0 +1,26 @@
+#ifndef PROGRESSDIALOG_H
+#define PROGRESSDIALOG_H
+
+#include <QDialog>
+
+namespace Ui {
+class ProgressDialog;
+}
+
+class ProgressDialog : public QDialog
+{
+    Q_OBJECT
+    
+public:
+    explicit ProgressDialog(QWidget *parent = 0);
+    ~ProgressDialog();
+    
+private:
+    Ui::ProgressDialog *ui;
+
+public slots:
+    void UpdateProgress(int percent);
+
+};
+
+#endif // PROGRESSDIALOG_H

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -385,11 +385,14 @@ static void NotifyChainBlocksScanned(WalletModel *walletmodel, CWallet *wallet, 
 
 void WalletModel::EmitBlocksScanned(int blockNumber)
 {
-    if (blockNumber==0)
-        blockNumber=1;
+//    if (blockNumber==0)
+//      blockNumber=1;
+    emit ScanWalletTransactionsProgress(blockNumber);
+}
 
-    int percent=blockNumber*100/nBestHeight;
-    emit ScanWalletTransactionsProgress(percent);
+int WalletModel::getNumBlocks()
+{
+    return nBestHeight;
 }
 
 bool WalletModel::ImportPrivateKey(string keyString, string label)

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -111,6 +111,7 @@ public:
     UnlockContext requestUnlock();
 
     bool ImportPrivateKey(string keyString, string label);
+    void EmitBlocksScanned(const int blockNumber);
 
 private:
     CWallet *wallet;
@@ -136,6 +137,7 @@ private:
     void unsubscribeFromCoreSignals();
     void checkBalanceChanged();
 
+
 signals:
     // Signal that balance in wallet changed
     void balanceChanged(qint64 balance, qint64 unconfirmedBalance, qint64 immatureBalance);
@@ -153,6 +155,8 @@ signals:
 
     // Asynchronous error notification
     void error(const QString &title, const QString &message, bool modal);
+
+    void ScanWalletTransactionsProgress(int blockcount);
 
 public slots:
     /* Wallet status might have changed */

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -112,6 +112,7 @@ public:
 
     bool ImportPrivateKey(string keyString, string label);
     void EmitBlocksScanned(const int blockNumber);
+    int getNumBlocks();
 
 private:
     CWallet *wallet;

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -5,6 +5,8 @@
 
 #include "allocators.h" /* for SecureString */
 
+using namespace std;
+
 class OptionsModel;
 class AddressTableModel;
 class TransactionTableModel;
@@ -107,6 +109,8 @@ public:
     };
 
     UnlockContext requestUnlock();
+
+    bool ImportPrivateKey(string keyString, string label);
 
 private:
     CWallet *wallet;

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -749,7 +749,7 @@ bool CWalletTx::WriteToDisk()
 int CWallet::ScanForWalletTransactions(CBlockIndex* pindexStart, bool fUpdate)
 {
     int ret = 0;
-
+    int blockNumber=0;
     CBlockIndex* pindex = pindexStart;
     {
         LOCK(cs_wallet);
@@ -763,6 +763,9 @@ int CWallet::ScanForWalletTransactions(CBlockIndex* pindexStart, bool fUpdate)
                     ret++;
             }
             pindex = pindex->pnext;
+            if(blockNumber%1000==0)
+                NotifyChainBlocksScanned(this, blockNumber);
+            blockNumber++;
         }
     }
     return ret;

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -763,7 +763,8 @@ int CWallet::ScanForWalletTransactions(CBlockIndex* pindexStart, bool fUpdate)
                     ret++;
             }
             pindex = pindex->pnext;
-            if(blockNumber%1000==0)
+            if(blockNumber%100==0 ||
+               (blockNumber%10==0 && blockNumber>150000))
                 NotifyChainBlocksScanned(this, blockNumber);
             blockNumber++;
         }

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -302,6 +302,11 @@ public:
      * @note called with lock cs_wallet held.
      */
     boost::signals2::signal<void (CWallet *wallet, const uint256 &hashTx, ChangeType status)> NotifyTransactionChanged;
+
+    /** 1 sec has passed during scanning for scanforwallettransactions.
+     * @note called with lock cs_wallet held.
+     */
+    boost::signals2::signal<void (CWallet *wallet, const int blockNumber)> NotifyChainBlocksScanned;
 };
 
 /** A key allocated from the key pool. */

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -303,7 +303,7 @@ public:
      */
     boost::signals2::signal<void (CWallet *wallet, const uint256 &hashTx, ChangeType status)> NotifyTransactionChanged;
 
-    /** 1 sec has passed during scanning for scanforwallettransactions.
+    /** 100 blocks scanned during scanforwallettransactions.
      * @note called with lock cs_wallet held.
      */
     boost::signals2::signal<void (CWallet *wallet, const int blockNumber)> NotifyChainBlocksScanned;


### PR DESCRIPTION
Does what it says on the tin.
Has full validation of private key before trying to import.
Includes logic to request passphrase if wallet is locked.
Include progress bar when scanning transactions as can take a few mins.

Motivation was to make it easier for people to import vanity addresses.
I wrote bitcoinvanity.appspot.com and so want to make importing key easier for users.

1st attempt at QT programming so could be improved I expect.
