### PR TITLE
Fixes for obscure mempool-checkpoint interaction

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1704,9 +1704,11 @@ bool SetBestChain(CBlockIndex* pindexNew)
         if (!viewTemp.Flush())
             return error("SetBestBlock() : Cache flush failed after disconnect");
 
-        // Queue memory transactions to resurrect
+        // Queue memory transactions to resurrect.
+        // We only do this for blocks after the last checkpoint (reorganisation before that
+        // point should only happen with -reindex/-loadblock, or a misbehaving peer.
         BOOST_FOREACH(const CTransaction& tx, block.vtx)
-            if (!tx.IsCoinBase())
+            if (!tx.IsCoinBase() && pindex->nHeight > Checkpoints::GetTotalBlocksEstimate())
                 vResurrect.push_back(tx);
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1754,7 +1754,7 @@ bool SetBestChain(CBlockIndex* pindexNew)
 
     // Resurrect memory transactions that were in the disconnected branch
     BOOST_FOREACH(CTransaction& tx, vResurrect)
-        tx.AcceptToMemoryPool(false);
+        tx.AcceptToMemoryPool();
 
     // Delete redundant memory transactions that are in the connected branch
     BOOST_FOREACH(CTransaction& tx, vDelete)


### PR DESCRIPTION
Implements the suggestions listed in #2052:
- Only move disconnected transactions to the mempool after the last checkpoint
- Always very scripts of transactions that do
