### PR TITLE
FlushBlockFile(): check for valid FILE pointer

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1540,12 +1540,16 @@ void static FlushBlockFile()
     posOld.nPos = 0;
 
     FILE *fileOld = OpenBlockFile(posOld);
-    FileCommit(fileOld);
-    fclose(fileOld);
+    if (fileOld) {
+        FileCommit(fileOld);
+        fclose(fileOld);
+    }
 
     fileOld = OpenUndoFile(posOld);
-    FileCommit(fileOld);
-    fclose(fileOld);
+    if (fileOld) {
+        FileCommit(fileOld);
+        fclose(fileOld);
+    }
 }
 
 bool FindUndoPos(int nFile, CDiskBlockPos &pos, unsigned int nAddSize);


### PR DESCRIPTION
- don't call FileCommit() and fclose() if no valid FILE pointer was
  returned by OpenBlockFile()
