### PR TITLE
Use Hal's optimized secp256k1 verifier

### DIFF
--- a/bitcoin-qt.pro
+++ b/bitcoin-qt.pro
@@ -300,7 +300,7 @@ HEADERS += src/qt/test/uritests.h
 DEPENDPATH += src/qt/test
 QT += testlib
 TARGET = bitcoin-qt_test
-DEFINES += BITCOIN_QT_TEST
+DEFINES += BITCOIN_QT_TEST VERIFY_OPTIMIZED_SECP256K1=1
   macx: CONFIG -= app_bundle
 }
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -9,6 +9,7 @@
 #include "net.h"
 #include "init.h"
 #include "util.h"
+#include "key.h"
 #include "ui_interface.h"
 
 #include <boost/filesystem.hpp>
@@ -311,6 +312,7 @@ std::string HelpMessage()
         "  -loadblock=<file>      " + _("Imports blocks from external blk000??.dat file") + "\n" +
         "  -reindex               " + _("Rebuild blockchain index from current blk000??.dat files") + "\n" +
         "  -par=N                 " + _("Set the number of script verification threads (1-16, 0=auto, default: 0)") + "\n" +
+        "  -turbo                 " + _("Enable experimental optimized verification code (default: 0)") + "\n" +
 
         "\n" + _("Block creation options:") + "\n" +
         "  -blockminsize=<n>      "   + _("Set minimum block size in bytes (default: 0)") + "\n" +
@@ -493,6 +495,8 @@ bool AppInit2()
 
     fDebug = GetBoolArg("-debug");
     fBenchmark = GetBoolArg("-benchmark");
+
+    fOptimizedEC = GetBoolArg("-turbo", false);
 
     // -par=0 means autodetect, but nScriptCheckThreads==0 means no concurrency
     nScriptCheckThreads = GetArg("-par", 0);

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -120,57 +120,62 @@ err:
     return ret;
 }
 
+static const unsigned char secp256k1_a1b2[] = {       0x30, 0x86, 0xd2, 0x21, 0xa7, 0xd4, 0x6b, 0xcd, 0xe8, 0x6c, 0x90, 0xe4, 0x92, 0x84, 0xeb, 0x15 };
+static const unsigned char secp256k1_b1m[] =  {       0xe4, 0x43, 0x7e, 0xd6, 0x01, 0x0e, 0x88, 0x28, 0x6f, 0x54, 0x7f, 0xa9, 0x0a, 0xbf, 0xe4, 0xc3 };
+static const unsigned char secp256k1_a2[] =   { 0x01, 0x14, 0xca, 0x50, 0xf7, 0xa8, 0xe2, 0xf3, 0xf6, 0x57, 0xc1, 0x10, 0x8d, 0x9d, 0x44, 0xcf, 0xd8 };
+static const unsigned char secp256k1_beta[] = { 0x7a, 0xe9, 0x6a, 0x2b, 0x65, 0x7c, 0x07, 0x10, 0x6e, 0x64, 0x47, 0x9e, 0xac, 0x34, 0x34, 0xe9, 0x9c, 0xf0, 0x49, 0x75, 0x12, 0xf5, 0x89, 0x95, 0xc1, 0x39, 0x6c, 0x28, 0x71, 0x95, 0x01, 0xee };
+
+struct CSecp256k1Consts {
+    BIGNUM* bna1b2;
+    BIGNUM* bnb1m;
+    BIGNUM* bna2;
+    BIGNUM* bnbeta;
+
+    CSecp256k1Consts() {
+        bna1b2 = BN_bin2bn(secp256k1_a1b2, sizeof(secp256k1_a1b2), NULL);
+        bnb1m  = BN_bin2bn(secp256k1_b1m,  sizeof(secp256k1_b1m),  NULL);
+        bna2   = BN_bin2bn(secp256k1_a2,   sizeof(secp256k1_a2),   NULL);
+        bnbeta = BN_bin2bn(secp256k1_beta, sizeof(secp256k1_beta), NULL);
+    }
+
+    ~CSecp256k1Consts() {
+        BN_free(bna1b2);
+        BN_free(bnb1m);
+        BN_free(bna2);
+        BN_free(bnbeta);
+    }
+};
+
+static CSecp256k1Consts secp256k1Consts;
+
 // Split a secp256k1 exponent k into two smaller ones k1 and k2 such that for any point Y,
 // k*Y = k1*Y + k2*Y', where Y' = lambda*Y is very fast
-int static secp256k1Splitk (BIGNUM *bnk1, BIGNUM *bnk2, const BIGNUM *bnk, const BIGNUM *bnn, BN_CTX *ctx)
+void static secp256k1Splitk (BIGNUM *bnk1, BIGNUM *bnk2, const BIGNUM *bnk, const BIGNUM *bnn, BN_CTX *ctx)
 {
-    BIGNUM *bnc1 = BN_new();
-    BIGNUM *bnc2 = BN_new();
-    BIGNUM *bnt1 = BN_new();
-    BIGNUM *bnt2 = BN_new();
-    BIGNUM *bnn2 = BN_new();
-    static unsigned char a1b2[] = {
-        0x30, 0x86, 0xd2, 0x21, 0xa7, 0xd4, 0x6b, 0xcd,
-        0xe8, 0x6c, 0x90, 0xe4, 0x92, 0x84, 0xeb, 0x15,
-    };
-    static unsigned char b1m[] = {
-        0xe4, 0x43, 0x7e, 0xd6, 0x01, 0x0e, 0x88, 0x28,
-        0x6f, 0x54, 0x7f, 0xa9, 0x0a, 0xbf, 0xe4, 0xc3,
-    };
-    static unsigned char a2[] = {
-        0x01, 0x14, 0xca, 0x50, 0xf7, 0xa8, 0xe2, 0xf3,
-        0xf6, 0x57, 0xc1, 0x10, 0x8d, 0x9d, 0x44, 0xcf,
-        0xd8,
-    };
-    BIGNUM *bna1b2 = BN_bin2bn(a1b2, sizeof(a1b2), NULL);
-    BIGNUM *bnb1m = BN_bin2bn(b1m, sizeof(b1m), NULL);
-    BIGNUM *bna2 = BN_bin2bn(a2, sizeof(a2), NULL);
+    BN_CTX_start(ctx);
+    BIGNUM *bnc1 = BN_CTX_get(ctx);
+    BIGNUM *bnc2 = BN_CTX_get(ctx);
+    BIGNUM *bnt1 = BN_CTX_get(ctx);
+    BIGNUM *bnt2 = BN_CTX_get(ctx);
+    BIGNUM *bnn2 = BN_CTX_get(ctx);
 
     BN_rshift1(bnn2, bnn);
-    BN_mul(bnc1, bnk, bna1b2, ctx);
+    BN_mul(bnc1, bnk,  secp256k1Consts.bna1b2, ctx);
     BN_add(bnc1, bnc1, bnn2);
     BN_div(bnc1, NULL, bnc1, bnn, ctx);
-    BN_mul(bnc2, bnk, bnb1m, ctx);
+    BN_mul(bnc2, bnk,  secp256k1Consts.bnb1m, ctx);
     BN_add(bnc2, bnc2, bnn2);
     BN_div(bnc2, NULL, bnc2, bnn, ctx);
 
-    BN_mul(bnt1, bnc1, bna1b2, ctx);
-    BN_mul(bnt2, bnc2, bna2, ctx);
+    BN_mul(bnt1, bnc1, secp256k1Consts.bna1b2, ctx);
+    BN_mul(bnt2, bnc2, secp256k1Consts.bna2, ctx);
     BN_add(bnt1, bnt1, bnt2);
-    BN_sub(bnk1, bnk, bnt1);
-    BN_mul(bnt1, bnc1, bnb1m, ctx);
-    BN_mul(bnt2, bnc2, bna1b2, ctx);
+    BN_sub(bnk1, bnk,  bnt1);
+    BN_mul(bnt1, bnc1, secp256k1Consts.bnb1m, ctx);
+    BN_mul(bnt2, bnc2, secp256k1Consts.bna1b2, ctx);
     BN_sub(bnk2, bnt1, bnt2);
 
-    BN_free(bnc1);
-    BN_free(bnc2);
-    BN_free(bnt1);
-    BN_free(bnt2);
-    BN_free(bnn2);
-    BN_free(bna1b2);
-    BN_free(bnb1m);
-    BN_free(bna2);
-    return 0;
+    BN_CTX_end(ctx);
 }
 
 bool static secp256k1Verify(const unsigned char hash[32], const unsigned char *dersig, size_t sigsize, const EC_KEY *pkey)
@@ -183,26 +188,21 @@ bool static secp256k1Verify(const unsigned char hash[32], const unsigned char *d
     EC_POINT *Ylam = EC_POINT_new(group);
     EC_POINT *R = EC_POINT_new(group);
     const EC_POINT *Points[3];
-    const BIGNUM *bnexps[3];
-    BIGNUM *bnp = BN_new();
-    BIGNUM *bnn = BN_new();
-    BIGNUM *bnx = BN_new();
-    BIGNUM *bny = BN_new();
-    BIGNUM *bnk = BN_new();
-    BIGNUM *bnk1 = BN_new();
-    BIGNUM *bnk2 = BN_new();
-    BIGNUM *bnk1a = BN_new();
-    BIGNUM *bnk2a = BN_new();
-    BIGNUM *bnsinv = BN_new();
-    BIGNUM *bnh = BN_bin2bn(hash, 32, NULL);
-    static unsigned char beta[] = {
-        0x7a, 0xe9, 0x6a, 0x2b, 0x65, 0x7c, 0x07, 0x10,
-        0x6e, 0x64, 0x47, 0x9e, 0xac, 0x34, 0x34, 0xe9,
-        0x9c, 0xf0, 0x49, 0x75, 0x12, 0xf5, 0x89, 0x95,
-        0xc1, 0x39, 0x6c, 0x28, 0x71, 0x95, 0x01, 0xee,
-    };
-    BIGNUM *bnbeta = BN_bin2bn(beta, 32, NULL);
     BN_CTX *ctx = BN_CTX_new();
+    const BIGNUM *bnexps[3];
+    BN_CTX_start(ctx);
+    BIGNUM *bnp = BN_CTX_get(ctx);
+    BIGNUM *bnn = BN_CTX_get(ctx);
+    BIGNUM *bnx = BN_CTX_get(ctx);
+    BIGNUM *bny = BN_CTX_get(ctx);
+    BIGNUM *bnk = BN_CTX_get(ctx);
+    BIGNUM *bnk1 = BN_CTX_get(ctx);
+    BIGNUM *bnk2 = BN_CTX_get(ctx);
+    BIGNUM *bnk1a = BN_CTX_get(ctx);
+    BIGNUM *bnk2a = BN_CTX_get(ctx);
+    BIGNUM *bnsinv = BN_CTX_get(ctx);
+    BIGNUM *bnh = BN_CTX_get(ctx);
+    bnh = BN_bin2bn(hash, 32, bnh);
     ECDSA_SIG *sig = d2i_ECDSA_SIG(NULL, &dersig, sigsize);
 
     if (sig == NULL)
@@ -216,10 +216,10 @@ bool static secp256k1Verify(const unsigned char hash[32], const unsigned char *d
         goto done;
 
     EC_POINT_get_affine_coordinates_GFp(group, G, bnx, bny, ctx);
-    BN_mod_mul(bnx, bnx, bnbeta, bnp, ctx);
+    BN_mod_mul(bnx, bnx, secp256k1Consts.bnbeta, bnp, ctx);
     EC_POINT_set_affine_coordinates_GFp(group, Glam, bnx, bny, ctx);
     EC_POINT_get_affine_coordinates_GFp(group, Y, bnx, bny, ctx);
-    BN_mod_mul(bnx, bnx, bnbeta, bnp, ctx);
+    BN_mod_mul(bnx, bnx, secp256k1Consts.bnbeta, bnp, ctx);
     EC_POINT_set_affine_coordinates_GFp(group, Ylam, bnx, bny, ctx);
 
     Points[0] = Glam;
@@ -240,23 +240,13 @@ bool static secp256k1Verify(const unsigned char hash[32], const unsigned char *d
     BN_mod(bnx, bnx, bnn, ctx);
     rslt = (BN_cmp(bnx, sig->r) == 0);
 
-    ECDSA_SIG_free(sig);
 done:
+    if (sig)
+        ECDSA_SIG_free(sig);
     EC_POINT_free(Glam);
     EC_POINT_free(Ylam);
     EC_POINT_free(R);
-    BN_free(bnp);
-    BN_free(bnn);
-    BN_free(bnx);
-    BN_free(bny);
-    BN_free(bnk);
-    BN_free(bnk1);
-    BN_free(bnk2);
-    BN_free(bnk1a);
-    BN_free(bnk2a);
-    BN_free(bnsinv);
-    BN_free(bnh);
-    BN_free(bnbeta);
+    BN_CTX_end(ctx);
     BN_CTX_free(ctx);
 
     return rslt;

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -120,21 +120,71 @@ err:
     return ret;
 }
 
-static const unsigned char secp256k1_a1b2[] = {       0x30, 0x86, 0xd2, 0x21, 0xa7, 0xd4, 0x6b, 0xcd, 0xe8, 0x6c, 0x90, 0xe4, 0x92, 0x84, 0xeb, 0x15 };
-static const unsigned char secp256k1_b1m[] =  {       0xe4, 0x43, 0x7e, 0xd6, 0x01, 0x0e, 0x88, 0x28, 0x6f, 0x54, 0x7f, 0xa9, 0x0a, 0xbf, 0xe4, 0xc3 };
-static const unsigned char secp256k1_a2[] =   { 0x01, 0x14, 0xca, 0x50, 0xf7, 0xa8, 0xe2, 0xf3, 0xf6, 0x57, 0xc1, 0x10, 0x8d, 0x9d, 0x44, 0xcf, 0xd8 };
-static const unsigned char secp256k1_beta[] = { 0x7a, 0xe9, 0x6a, 0x2b, 0x65, 0x7c, 0x07, 0x10, 0x6e, 0x64, 0x47, 0x9e, 0xac, 0x34, 0x34, 0xe9, 0x9c, 0xf0, 0x49, 0x75, 0x12, 0xf5, 0x89, 0x95, 0xc1, 0x39, 0x6c, 0x28, 0x71, 0x95, 0x01, 0xee };
 
-struct CSecp256k1Consts {
-    BIGNUM* bnn;
+class CSecp256k1Math {
+private:
+    BIGNUM* order;
     BIGNUM* bnp;
     BIGNUM* bna1b2;
     BIGNUM* bnb1m;
     BIGNUM* bna2;
     BIGNUM* bnbeta;
+    BIGNUM* bnlambda;
     EC_POINT* Glam;
 
-    CSecp256k1Consts() {
+    // Split a secp256k1 exponent k into two smaller ones k1 and k2 such that for any point Y,
+    // k*Y = k1*Y + k2*Y', where Y' = lambda*Y is very fast
+    void splitk(BIGNUM *bnk1, BIGNUM *bnk2, const BIGNUM *bnk, BN_CTX *ctx) {
+        BN_CTX_start(ctx);
+        BIGNUM *bnc1 = BN_CTX_get(ctx);
+        BIGNUM *bnc2 = BN_CTX_get(ctx);
+        BIGNUM *bnt1 = BN_CTX_get(ctx);
+        BIGNUM *bnt2 = BN_CTX_get(ctx);
+        BIGNUM *bnn2 = BN_CTX_get(ctx);
+
+        BN_rshift1(bnn2, order);
+        BN_mul(bnc1, bnk,  bna1b2, ctx);
+        BN_add(bnc1, bnc1, bnn2);
+        BN_div(bnc1, NULL, bnc1, order, ctx);
+        BN_mul(bnc2, bnk,  bnb1m, ctx);
+        BN_add(bnc2, bnc2, bnn2);
+        BN_div(bnc2, NULL, bnc2, order, ctx);
+
+        BN_mul(bnt1, bnc1, bna1b2, ctx);
+        BN_mul(bnt2, bnc2, bna2, ctx);
+        BN_add(bnt1, bnt1, bnt2);
+        BN_sub(bnk1, bnk,  bnt1);
+        BN_mul(bnt1, bnc1, bnb1m, ctx);
+        BN_mul(bnt2, bnc2, bna1b2, ctx);
+        BN_sub(bnk2, bnt1, bnt2);
+
+        BN_CTX_end(ctx);
+    }
+
+    // p2 = lambda*p, where lambda is chosen such that this operation is very fast
+    void mullambda(const EC_GROUP *group, EC_POINT *p2, const EC_POINT *p, BN_CTX *ctx) {
+        BN_CTX_start(ctx);
+        BIGNUM *x = BN_CTX_get(ctx);
+        BIGNUM *y = BN_CTX_get(ctx);
+
+        // deconstruct p as (x,y)
+        EC_POINT_get_affine_coordinates_GFp(group, p, x, y, ctx);
+        // x' = x*beta
+        BN_mod_mul(x, x, bnbeta, bnp, ctx);
+        // construct p2 as (x',y)
+        EC_POINT_set_affine_coordinates_GFp(group, p2, x, y, ctx);
+
+        BN_CTX_end(ctx);
+    }
+
+public:
+    CSecp256k1Math() {
+        static const unsigned char a1b2[] =   {       0x30, 0x86, 0xd2, 0x21, 0xa7, 0xd4, 0x6b, 0xcd, 0xe8, 0x6c, 0x90, 0xe4, 0x92, 0x84, 0xeb, 0x15 };
+        static const unsigned char b1m[] =    {       0xe4, 0x43, 0x7e, 0xd6, 0x01, 0x0e, 0x88, 0x28, 0x6f, 0x54, 0x7f, 0xa9, 0x0a, 0xbf, 0xe4, 0xc3 };
+        static const unsigned char a2[] =     { 0x01, 0x14, 0xca, 0x50, 0xf7, 0xa8, 0xe2, 0xf3, 0xf6, 0x57, 0xc1, 0x10, 0x8d, 0x9d, 0x44, 0xcf, 0xd8 };
+        static const unsigned char beta[] =   { 0x7a, 0xe9, 0x6a, 0x2b, 0x65, 0x7c, 0x07, 0x10, 0x6e, 0x64, 0x47, 0x9e, 0xac, 0x34, 0x34, 0xe9, 0x9c, 0xf0, 0x49, 0x75, 0x12, 0xf5, 0x89, 0x95, 0xc1, 0x39, 0x6c, 0x28, 0x71, 0x95, 0x01, 0xee };
+        static const unsigned char lambda[] = { 0x53, 0x63, 0xad, 0x4c, 0xc0, 0x5c, 0x30, 0xe0, 0xa5, 0x26, 0x1c, 0x02, 0x88, 0x12, 0x64, 0x5a, 0x12, 0x2e, 0x22, 0xea, 0x20, 0x81, 0x66, 0x78, 0xdf, 0x02, 0x96, 0x7c, 0x1b, 0x23, 0xbd, 0x72 };
+
         EC_KEY *pkey = EC_KEY_new_by_curve_name(NID_secp256k1);
         const EC_GROUP *group = EC_KEY_get0_group(pkey);
         const EC_POINT *G = EC_GROUP_get0_generator(group);
@@ -144,13 +194,14 @@ struct CSecp256k1Consts {
         BIGNUM *bny = BN_CTX_get(ctx);
 
         bnp = BN_new();
-        bnn = BN_new();
+        order = BN_new();
         EC_GROUP_get_curve_GFp(group, bnp, NULL, NULL, ctx);
-        EC_GROUP_get_order(group, bnn, ctx);
-        bna1b2 = BN_bin2bn(secp256k1_a1b2, sizeof(secp256k1_a1b2), NULL);
-        bnb1m  = BN_bin2bn(secp256k1_b1m,  sizeof(secp256k1_b1m),  NULL);
-        bna2   = BN_bin2bn(secp256k1_a2,   sizeof(secp256k1_a2),   NULL);
-        bnbeta = BN_bin2bn(secp256k1_beta, sizeof(secp256k1_beta), NULL);
+        EC_GROUP_get_order(group, order, ctx);
+        bna1b2   = BN_bin2bn(a1b2,   sizeof(a1b2),   NULL);
+        bnb1m    = BN_bin2bn(b1m,    sizeof(b1m),    NULL);
+        bna2     = BN_bin2bn(a2,     sizeof(a2),     NULL);
+        bnbeta   = BN_bin2bn(beta,   sizeof(beta),   NULL);
+        bnlambda = BN_bin2bn(lambda, sizeof(lambda), NULL);
         EC_POINT_get_affine_coordinates_GFp(group, G, bnx, bny, ctx);
         BN_mod_mul(bnx, bnx, bnbeta, bnp, ctx);
         Glam = EC_POINT_new(group);
@@ -161,110 +212,134 @@ struct CSecp256k1Consts {
         EC_KEY_free(pkey);
     }
 
-    ~CSecp256k1Consts() {
+    ~CSecp256k1Math() {
         EC_POINT_free(Glam);
-        BN_free(bnn);
+        BN_free(order);
         BN_free(bnp);
         BN_free(bna1b2);
         BN_free(bnb1m);
         BN_free(bna2);
         BN_free(bnbeta);
+        BN_free(bnlambda);
+    }
+
+    // calculate r = n*G + m*q
+    int EC_POINT_mul(const EC_GROUP *group, EC_POINT *r, const BIGNUM *n, const EC_POINT *q, const BIGNUM *m, BN_CTX *ctx) {
+        BN_CTX_start(ctx);
+        BIGNUM *na = BN_CTX_get(ctx);
+        BIGNUM *nb = BN_CTX_get(ctx);
+        BIGNUM *ma = BN_CTX_get(ctx);
+        BIGNUM *mb = BN_CTX_get(ctx);
+        EC_POINT *qlam = EC_POINT_new(group);
+
+        // rewrite n*G as na*G + nb*Glam, where na and nb are small, and Glam = lambda*G is precomputed
+        splitk(na, nb, n, ctx); // split n
+
+        // rewrite m*q as ma*q + mb*qlam, where ma and mb are small, and qlam = lambda*q is efficiently computable
+        splitk(ma, mb, m, ctx); // split m
+        mullambda(group, qlam, q, ctx); // calculate qlam = lamda*Q
+
+        // the actual calculation now becomes: r = nb*Glam + ma*q + mb*qlam + na*G, where [na,nb,ma,mb] are small
+        const EC_POINT *points[3] = {Glam, q,  qlam};
+        const BIGNUM   *exps[3]   = {nb,   ma, mb};
+        int ret = EC_POINTs_mul(group, r, na, 3, points, exps, ctx); // the exponent na to G is passed separately
+
+        EC_POINT_free(qlam);
+        BN_CTX_end(ctx);
+        return ret;
+    }
+
+    const BIGNUM *get_order() {
+        return order;
     }
 };
 
-static CSecp256k1Consts secp256k1Consts;
+static CSecp256k1Math secp256k1math;
 
-// Split a secp256k1 exponent k into two smaller ones k1 and k2 such that for any point Y,
-// k*Y = k1*Y + k2*Y', where Y' = lambda*Y is very fast
-void static secp256k1Splitk (BIGNUM *bnk1, BIGNUM *bnk2, const BIGNUM *bnk, const BIGNUM *bnn, BN_CTX *ctx)
+/** this is an almost exact copy of OpenSSL's ecdsa_do_verify, except:
+ *  - it takes fixed size input
+ *  - it uses a static order (which is a constant, assuming secp256k1)
+ *  - it uses the optimized EC_POINT_mul operation from CSecp256k1Math
+ */
+int static secp256k1_ecdsa_do_verify(const unsigned char hash[32], const ECDSA_SIG *sig, const EC_KEY *eckey)
 {
+    int ret = -1;
+
+    const EC_GROUP *group;
+    const EC_POINT *pub_key;
+    EC_POINT *point = NULL;
+    BIGNUM *m, *u2, *u1, *X;
+    const BIGNUM *order;
+    BN_CTX *ctx = NULL;
+
+    // check input values
+    if (eckey == NULL || (group = EC_KEY_get0_group(eckey)) == NULL ||
+        (pub_key = EC_KEY_get0_public_key(eckey)) == NULL || sig == NULL)
+        goto err;
+
+    ctx = BN_CTX_new();
     BN_CTX_start(ctx);
-    BIGNUM *bnc1 = BN_CTX_get(ctx);
-    BIGNUM *bnc2 = BN_CTX_get(ctx);
-    BIGNUM *bnt1 = BN_CTX_get(ctx);
-    BIGNUM *bnt2 = BN_CTX_get(ctx);
-    BIGNUM *bnn2 = BN_CTX_get(ctx);
 
-    BN_rshift1(bnn2, bnn);
-    BN_mul(bnc1, bnk,  secp256k1Consts.bna1b2, ctx);
-    BN_add(bnc1, bnc1, bnn2);
-    BN_div(bnc1, NULL, bnc1, bnn, ctx);
-    BN_mul(bnc2, bnk,  secp256k1Consts.bnb1m, ctx);
-    BN_add(bnc2, bnc2, bnn2);
-    BN_div(bnc2, NULL, bnc2, bnn, ctx);
+    m = BN_CTX_get(ctx);
+    u2 = BN_CTX_get(ctx);
+    u1 = BN_CTX_get(ctx);
+    X = BN_CTX_get(ctx);
+    if (!X)
+        goto err;
 
-    BN_mul(bnt1, bnc1, secp256k1Consts.bna1b2, ctx);
-    BN_mul(bnt2, bnc2, secp256k1Consts.bna2, ctx);
-    BN_add(bnt1, bnt1, bnt2);
-    BN_sub(bnk1, bnk,  bnt1);
-    BN_mul(bnt1, bnc1, secp256k1Consts.bnb1m, ctx);
-    BN_mul(bnt2, bnc2, secp256k1Consts.bna1b2, ctx);
-    BN_sub(bnk2, bnt1, bnt2);
+    // identical to: BIGNUM *order = BN_CTX_get(ctx); EC_GROUP_get_order(group, order, ctx);
+    order = secp256k1math.get_order();
 
-    BN_CTX_end(ctx);
-}
+    // sanity checks
+    if (BN_is_zero(sig->r) || BN_is_negative(sig->r) || BN_ucmp(sig->r, order) >= 0
+        || BN_is_zero(sig->s) || BN_is_negative(sig->s) || BN_ucmp(sig->s, order) >= 0)
+        goto err;
 
-bool static secp256k1Verify(const unsigned char hash[32], const unsigned char *dersig, size_t sigsize, const EC_KEY *pkey)
-{
-    bool rslt = false;;
-    const EC_GROUP *group = EC_KEY_get0_group(pkey);
-    const EC_POINT *Y = EC_KEY_get0_public_key(pkey);
-    EC_POINT *Ylam = EC_POINT_new(group);
-    EC_POINT *R = EC_POINT_new(group);
-    const EC_POINT *Points[3];
-    BN_CTX *ctx = BN_CTX_new();
-    const BIGNUM *bnexps[3];
-    BN_CTX_start(ctx);
-    BIGNUM *bnx = BN_CTX_get(ctx);
-    BIGNUM *bny = BN_CTX_get(ctx);
-    BIGNUM *bnk = BN_CTX_get(ctx);
-    BIGNUM *bnk1 = BN_CTX_get(ctx);
-    BIGNUM *bnk2 = BN_CTX_get(ctx);
-    BIGNUM *bnk1a = BN_CTX_get(ctx);
-    BIGNUM *bnk2a = BN_CTX_get(ctx);
-    BIGNUM *bnsinv = BN_CTX_get(ctx);
-    BIGNUM *bnh = BN_CTX_get(ctx);
-    bnh = BN_bin2bn(hash, 32, bnh);
-    ECDSA_SIG *sig = d2i_ECDSA_SIG(NULL, &dersig, sigsize);
+    // calculate tmp = inv(S) mod order
+    if (!BN_mod_inverse(u2, sig->s, order, ctx))
+        goto err;
 
-    if (sig == NULL)
-        goto done;
+    // turn message into number
+    if (!BN_bin2bn(hash, 32, m))
+        goto err;
 
-    if (BN_is_zero(sig->r) || BN_is_negative(sig->r) || BN_ucmp(sig->r, secp256k1Consts.bnn) >= 0
-        || BN_is_zero(sig->s) || BN_is_negative(sig->s) || BN_ucmp(sig->s, secp256k1Consts.bnn) >= 0)
-        goto done;
+    // u1 = m * tmp mod order
+    if (!BN_mod_mul(u1, m, u2, order, ctx))
+        goto err;
 
-    EC_POINT_get_affine_coordinates_GFp(group, Y, bnx, bny, ctx);
-    BN_mod_mul(bnx, bnx, secp256k1Consts.bnbeta, secp256k1Consts.bnp, ctx);
-    EC_POINT_set_affine_coordinates_GFp(group, Ylam, bnx, bny, ctx);
+    // u2 = r * tmp mod order
+    if (!BN_mod_mul(u2, sig->r, u2, order, ctx))
+        goto err;
 
-    Points[0] = secp256k1Consts.Glam;
-    Points[1] = Y;
-    Points[2] = Ylam;
+    // allocate result point
+    if ((point = EC_POINT_new(group)) == NULL)
+        goto err;
 
-    BN_mod_inverse(bnsinv, sig->s, secp256k1Consts.bnn, ctx);
-    BN_mod_mul(bnk, bnh, bnsinv, secp256k1Consts.bnn, ctx);
-    secp256k1Splitk(bnk1, bnk2, bnk, secp256k1Consts.bnn, ctx);
-    bnexps[0] = bnk2;
-    BN_mod_mul(bnk, sig->r, bnsinv, secp256k1Consts.bnn, ctx);
-    secp256k1Splitk(bnk1a, bnk2a, bnk, secp256k1Consts.bnn, ctx);
-    bnexps[1] = bnk1a;
-    bnexps[2] = bnk2a;
+    // calculate point = u1*G + u2*pub_key
+    // identical to: EC_POINT_mul(group, point, u1, pub_key, u2, ctx)
+    if (!secp256k1math.EC_POINT_mul(group, point, u1, pub_key, u2, ctx))
+        goto err;
 
-    EC_POINTs_mul(group, R, bnk1, 3, Points, bnexps, ctx);
-    EC_POINT_get_affine_coordinates_GFp(group, R, bnx, NULL, ctx);
-    BN_mod(bnx, bnx, secp256k1Consts.bnn, ctx);
-    rslt = (BN_cmp(bnx, sig->r) == 0);
+    // extract X coordinate from result point
+    if (!EC_POINT_get_affine_coordinates_GFp(group, point, X, NULL, ctx))
+        goto err;
 
-done:
-    if (sig)
-        ECDSA_SIG_free(sig);
-    EC_POINT_free(Ylam);
-    EC_POINT_free(R);
-    BN_CTX_end(ctx);
-    BN_CTX_free(ctx);
+    // u1 = X mod order
+    if (!BN_nnmod(u1, X, order, ctx))
+        goto err;
 
-    return rslt;
+    // compare u1 to r
+    ret = (BN_ucmp(u1, sig->r) == 0);
+
+err:
+    if (point)
+        EC_POINT_free(point);
+    if (ctx) {
+        BN_CTX_end(ctx);
+        BN_CTX_free(ctx);
+    }
+
+    return ret;
 }
 
 void CKey::SetCompressedPubKey(bool fCompressed)
@@ -519,7 +594,11 @@ bool CKey::SetCompactSignature(uint256 hash, const std::vector<unsigned char>& v
 
 bool CKey::Verify(uint256 hash, const std::vector<unsigned char>& vchSig)
 {
-    return secp256k1Verify((unsigned char*)&hash, &vchSig[0], vchSig.size(), pkey);
+    const unsigned char *ptr = &vchSig[0];
+    ECDSA_SIG *sig = d2i_ECDSA_SIG(NULL, &ptr, vchSig.size());
+    bool ret = (secp256k1_ecdsa_do_verify((unsigned char*)&hash, sig, pkey) == 1);
+    ECDSA_SIG_free(sig);
+    return ret;
 }
 
 bool CKey::VerifyCompact(uint256 hash, const std::vector<unsigned char>& vchSig)

--- a/src/key.h
+++ b/src/key.h
@@ -15,6 +15,8 @@
 
 #include <openssl/ec.h> // for EC_KEY definition
 
+extern bool fOptimizedEC;
+
 // secp160k1
 // const unsigned int PRIVATE_KEY_SIZE = 192;
 // const unsigned int PUBLIC_KEY_SIZE  = 41;

--- a/src/makefile.linux-mingw
+++ b/src/makefile.linux-mingw
@@ -40,7 +40,7 @@ CFLAGS=-O2 -w -Wall -Wextra -Wformat -Wformat-security -Wno-unused-parameter $(D
 # enable: ASLR, DEP and large address aware
 LDFLAGS=-Wl,--dynamicbase -Wl,--nxcompat -Wl,--large-address-aware
 
-TESTDEFS = -DTEST_DATA_DIR=$(abspath test/data)
+TESTDEFS = -DTEST_DATA_DIR=$(abspath test/data) -DVERIFY_OPTIMIZED_SECP256K1
 
 ifndef USE_UPNP
 	override USE_UPNP = -
@@ -117,7 +117,10 @@ TESTOBJS := $(patsubst test/%.cpp,obj-test/%.o,$(wildcard test/*.cpp))
 obj-test/%.o: test/%.cpp $(HEADERS)
 	$(CXX) -c $(TESTDEFS) $(CFLAGS) -o $@ $<
 
-test_bitcoin.exe: $(TESTOBJS) $(filter-out obj/init.o,$(OBJS:obj/%=obj/%))
+obj-test/%.o: %.cpp $(HEADERS)
+	$(CXX) -c $(TESTDEFS) $(CFLAGS) -o $@ $<
+
+test_bitcoin.exe: $(TESTOBJS) $(filter-out obj-test/init.o,$(OBJS:obj/%=obj-test/%))
 	$(CXX) $(CFLAGS) $(LDFLAGS) -o $@ $(LIBPATHS) $^ -lboost_unit_test_framework-mt-s $(LIBS)
 
 

--- a/src/makefile.mingw
+++ b/src/makefile.mingw
@@ -49,7 +49,7 @@ CFLAGS=-mthreads -O2 -w -Wall -Wextra -Wformat -Wformat-security -Wno-unused-par
 # enable: ASLR, DEP and large address aware
 LDFLAGS=-Wl,--dynamicbase -Wl,--nxcompat -Wl,--large-address-aware
 
-TESTDEFS = -DTEST_DATA_DIR=$(abspath test/data)
+TESTDEFS = -DTEST_DATA_DIR=$(abspath test/data) -DVERIFY_OPTIMIZED_SECP256K1
 
 ifndef USE_UPNP
 	override USE_UPNP = -
@@ -128,7 +128,10 @@ TESTOBJS := $(patsubst test/%.cpp,obj-test/%.o,$(wildcard test/*.cpp))
 obj-test/%.o: test/%.cpp $(HEADERS)
 	$(CXX) -c $(TESTDEFS) $(CFLAGS) -o $@ $<
 
-test_bitcoin.exe: $(TESTOBJS) $(filter-out obj/init.o,$(OBJS:obj/%=obj/%))
+obj-test/%.o: %.cpp $(HEADERS)
+	$(CXX) -c $(TESTDEFS) $(CFLAGS) -o $@ $<
+
+test_bitcoin.exe: $(TESTOBJS) $(filter-out obj-test/init.o,$(OBJS:obj/%=obj-test/%))
 	$(CXX) $(CFLAGS) $(LDFLAGS) -o $@ $(LIBPATHS) $^ -lboost_unit_test_framework$(BOOST_SUFFIX) $(LIBS)
 
 clean:

--- a/src/makefile.osx
+++ b/src/makefile.osx
@@ -24,7 +24,7 @@ USE_IPV6:=1
 
 LIBS= -dead_strip
 
-TESTDEFS = -DTEST_DATA_DIR=$(abspath test/data)
+TESTDEFS = -DTEST_DATA_DIR=$(abspath test/data) -DVERIFY_OPTIMIZED_SECP256K1
 
 ifdef STATIC
 # Build STATIC if you are redistributing the bitcoind binary
@@ -161,7 +161,14 @@ obj-test/%.o: test/%.cpp
 	      -e '/^$$/ d' -e 's/$$/ :/' < $(@:%.o=%.d) >> $(@:%.o=%.P); \
 	  rm -f $(@:%.o=%.d)
 
-test_bitcoin: $(TESTOBJS) $(filter-out obj/init.o,$(OBJS:obj/%=obj/%))
+obj-test/%.o: %.cpp
+	$(CXX) -c $(TESTDEFS) $(CFLAGS) -MMD -MF $(@:%.o=%.d) -o $@ $<
+	@cp $(@:%.o=%.d) $(@:%.o=%.P); \
+	  sed -e 's/#.*//' -e 's/^[^:]*: *//' -e 's/ *\\$$//' \
+	      -e '/^$$/ d' -e 's/$$/ :/' < $(@:%.o=%.d) >> $(@:%.o=%.P); \
+	  rm -f $(@:%.o=%.d)
+
+test_bitcoin: $(TESTOBJS) $(filter-out obj-test/init.o,$(OBJS:obj/%=obj-test/%))
 	$(CXX) $(CFLAGS) -o $@ $(LIBPATHS) $^ $(LIBS) $(TESTLIBS)
 
 clean:

--- a/src/makefile.unix
+++ b/src/makefile.unix
@@ -12,7 +12,7 @@ DEFS=-DBOOST_SPIRIT_THREADSAFE -D_FILE_OFFSET_BITS=64
 DEFS += $(addprefix -I,$(CURDIR) $(CURDIR)/obj $(BOOST_INCLUDE_PATH) $(BDB_INCLUDE_PATH) $(OPENSSL_INCLUDE_PATH))
 LIBS = $(addprefix -L,$(BOOST_LIB_PATH) $(BDB_LIB_PATH) $(OPENSSL_LIB_PATH))
 
-TESTDEFS = -DTEST_DATA_DIR=$(abspath test/data)
+TESTDEFS = -DTEST_DATA_DIR=$(abspath test/data) -DVERIFY_OPTIMIZED_SECP256K1
 
 LMODE = dynamic
 LMODE2 = dynamic
@@ -178,7 +178,15 @@ obj-test/%.o: test/%.cpp
 	      -e '/^$$/ d' -e 's/$$/ :/' < $(@:%.o=%.d) >> $(@:%.o=%.P); \
 	  rm -f $(@:%.o=%.d)
 
-test_bitcoin: $(TESTOBJS) $(filter-out obj/init.o,$(OBJS:obj/%=obj/%))
+obj-test/%.o: %.cpp
+	$(CXX) -c $(TESTDEFS) $(xCXXFLAGS) -MMD -MF $(@:%.o=%.d) -o $@ $<
+	@cp $(@:%.o=%.d) $(@:%.o=%.P); \
+	  sed -e 's/#.*//' -e 's/^[^:]*: *//' -e 's/ *\\$$//' \
+	      -e '/^$$/ d' -e 's/$$/ :/' < $(@:%.o=%.d) >> $(@:%.o=%.P); \
+	  rm -f $(@:%.o=%.d)
+
+
+test_bitcoin: $(TESTOBJS) $(filter-out obj-test/init.o,$(OBJS:obj/%=obj-test/%))
 	$(LINK) $(xCXXFLAGS) -o $@ $(LIBPATHS) $^ -Wl,-B$(LMODE) -lboost_unit_test_framework $(xLDFLAGS) $(LIBS)
 
 clean:

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -6,6 +6,7 @@
 #include "txdb.h"
 #include "main.h"
 #include "wallet.h"
+#include "key.h"
 #include "util.h"
 
 CWallet* pwalletMain;
@@ -20,6 +21,7 @@ struct TestingSetup {
 
     TestingSetup() {
         fPrintToDebugger = true; // don't want to write to debug.log file
+        fOptimizedEC = true;
         noui_connect();
         bitdb.MakeMock();
         pathTemp = GetTempPath() / strprintf("test_bitcoin_%lu_%i", (unsigned long)GetTime(), (int)(GetRand(100000)));


### PR DESCRIPTION
The first commit is a rebased version of Hal's feb 2011 patch. The second commit improves the code a bit (precalculate constants, and use BN_CTX_get for temporary values).

This reduces reindexing time for the first 210k blocks (script checks enabled everywhere, 4 verification threads, -dbcache=900) from 1h14m to 1h1m on my system.
