### PR TITLE
Reconstruct coins/ database when missing

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -865,7 +865,7 @@ bool AppInit2()
         if (walletdb.ReadBestBlock(locator))
             pindexRescan = locator.GetBlockIndex();
     }
-    if (pindexBest != pindexRescan)
+    if (pindexBest && pindexBest != pindexRescan)
     {
         uiInterface.InitMessage(_("Rescanning..."));
         printf("Rescanning last %i blocks (from block %i)...\n", pindexBest->nHeight - pindexRescan->nHeight, pindexRescan->nHeight);


### PR DESCRIPTION
When the blocks/ and blktree/ databases exist, but the coins/ database doesn't, reconstruct it automatically at startup.

More generally, if the block database has more recent blocks than the coins database, they are automatically constructed at startup. This already worked, but not when the coins database was missing entirely. This pullreq should fix that.

This provides a very nice way for benchmarking the block validation logic, as this reconstruction happens before the actual node is started, and doesn't require writing to block files.
