### PR TITLE
add 2 constructors in CDiskBlockPos to simplify class usage

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -346,9 +346,7 @@ void ThreadImport(void *data) {
         CImportingNow imp;
         int nFile = 0;
         while (!fShutdown) {
-            CDiskBlockPos pos;
-            pos.nFile = nFile;
-            pos.nPos = 0;
+            CDiskBlockPos pos(nFile, 0);
             FILE *file = OpenBlockFile(pos, true);
             if (!file)
                 break;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1535,9 +1535,7 @@ void static FlushBlockFile()
 {
     LOCK(cs_LastBlockFile);
 
-    CDiskBlockPos posOld;
-    posOld.nFile = nLastBlockFile;
-    posOld.nPos = 0;
+    CDiskBlockPos posOld(nLastBlockFile, 0);
 
     FILE *fileOld = OpenBlockFile(posOld);
     FileCommit(fileOld);

--- a/src/main.h
+++ b/src/main.h
@@ -192,6 +192,15 @@ public:
         READWRITE(VARINT(nPos));
     )
 
+    CDiskBlockPos() {
+        SetNull();
+    }
+
+    CDiskBlockPos(int nFileIn, unsigned int nPosIn) {
+        nFile = nFileIn;
+        nPos = nPosIn;
+    }
+
     friend bool operator==(const CDiskBlockPos &a, const CDiskBlockPos &b) {
         return (a.nFile == b.nFile && a.nPos == b.nPos);
     }
@@ -1493,8 +1502,7 @@ public:
         if (nStatus & BLOCK_HAVE_DATA) {
             ret.nFile = nFile;
             ret.nPos  = nDataPos;
-        } else
-            ret.SetNull();
+        }
         return ret;
     }
 
@@ -1503,8 +1511,7 @@ public:
         if (nStatus & BLOCK_HAVE_UNDO) {
             ret.nFile = nFile;
             ret.nPos  = nUndoPos;
-        } else
-            ret.SetNull();
+        }
         return ret;
     }
 


### PR DESCRIPTION
- add a default-constructor, which simply calls SetNull() and a
  constructor to directly pass nFile and nPos
- change code to use that new constructors
