### PR TITLE
Replace text on how to enable IPv6 with disable

### DIFF
--- a/doc/build-osx.txt
+++ b/doc/build-osx.txt
@@ -44,7 +44,7 @@ sudo port install qrencode
 4.  Now you should be able to build bitcoind:
 
 cd bitcoin/src
-make -f makefile.osx USE_IPV6=1
+make -f makefile.osx
 
 Run:
   ./bitcoind --help  # for a list of command-line options.

--- a/doc/build-unix.txt
+++ b/doc/build-unix.txt
@@ -36,8 +36,8 @@ turned off by default.  Set USE_UPNP to a different value to control this:
  USE_UPNP=0    (the default) UPnP support turned off by default at runtime
  USE_UPNP=1    UPnP support turned on by default at runtime
 
-IPv6 support may be enabled by setting:
- USE_IPV6=1    Enable IPv6 support
+IPv6 support may be disabled by setting:
+ USE_IPV6=0    Disable IPv6 support
 
 Licenses of statically linked libraries:
  Berkeley DB   New BSD license with additional requirement that linked


### PR DESCRIPTION
IPv6 support is now enabled by default, thus documentation should tell
you how to disable it.

Similarly the build-osx use of the flag can be removed.
