### PR TITLE
Bitcoin-Qt: remove obsolete modal flag from GUI APIs

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -45,7 +45,6 @@ static void ThreadSafeMessageBox(const std::string& message, const std::string& 
                                    modal ? GUIUtil::blockingGUIThreadConnection() : Qt::QueuedConnection,
                                    Q_ARG(QString, QString::fromStdString(caption)),
                                    Q_ARG(QString, QString::fromStdString(message)),
-                                   Q_ARG(bool, modal),
                                    Q_ARG(unsigned int, style));
     }
     else

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -373,7 +373,7 @@ void BitcoinGUI::setClientModel(ClientModel *clientModel)
         connect(clientModel, SIGNAL(numBlocksChanged(int,int)), this, SLOT(setNumBlocks(int,int)));
 
         // Receive and report messages from network/worker thread
-        connect(clientModel, SIGNAL(message(QString,QString,bool,unsigned int)), this, SLOT(message(QString,QString,bool,unsigned int)));
+        connect(clientModel, SIGNAL(message(QString,QString,unsigned int)), this, SLOT(message(QString,QString,unsigned int)));
 
         overviewPage->setClientModel(clientModel);
         rpcConsole->setClientModel(clientModel);
@@ -388,7 +388,7 @@ void BitcoinGUI::setWalletModel(WalletModel *walletModel)
     if(walletModel)
     {
         // Receive and report messages from wallet thread
-        connect(walletModel, SIGNAL(message(QString,QString,bool,unsigned int)), this, SLOT(message(QString,QString,bool,unsigned int)));
+        connect(walletModel, SIGNAL(message(QString,QString,unsigned int)), this, SLOT(message(QString,QString,unsigned int)));
 
         // Put transaction list in tabs
         transactionView->setModel(walletModel);
@@ -606,7 +606,7 @@ void BitcoinGUI::setNumBlocks(int count, int nTotalBlocks)
     progressBar->setToolTip(tooltip);
 }
 
-void BitcoinGUI::message(const QString &title, const QString &message, bool modal, unsigned int style)
+void BitcoinGUI::message(const QString &title, const QString &message, unsigned int style)
 {
     QString strTitle = tr("Bitcoin") + " - ";
     // Default to information icon
@@ -639,7 +639,7 @@ void BitcoinGUI::message(const QString &title, const QString &message, bool moda
     }
 
     // Display message
-    if (modal) {
+    if (style & CClientUIInterface::MODAL) {
         // Check for buttons, use OK as default, if none was supplied
         QMessageBox::StandardButton buttons;
         if (!(buttons = (QMessageBox::StandardButton)(style & CClientUIInterface::BTN_MASK)))

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -124,11 +124,10 @@ public slots:
     /** Notify the user of an event from the core network or transaction handling code.
        @param[in] title     the message box / notification title
        @param[in] message   the displayed text
-       @param[in] modal     true to use a message box, false to use a notification
-       @param[in] style     style definitions (icon and used buttons - buttons only for message boxes)
+       @param[in] style     modality and style definitions (icon and used buttons - buttons only for message boxes)
                             @see CClientUIInterface::MessageBoxFlags
     */
-    void message(const QString &title, const QString &message, bool modal, unsigned int style);
+    void message(const QString &title, const QString &message, unsigned int style);
     /** Asks the user whether to pay the transaction fee or to cancel the transaction.
        It is currently not possible to pass a return value to another thread through
        BlockingQueuedConnection, so an indirected pointer is used.

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -84,7 +84,7 @@ void ClientModel::updateAlert(const QString &hash, int status)
         CAlert alert = CAlert::getAlertByHash(hash_256);
         if(!alert.IsNull())
         {
-            emit message(tr("Network Alert"), QString::fromStdString(alert.strStatusBar), false, CClientUIInterface::ICON_ERROR);
+            emit message(tr("Network Alert"), QString::fromStdString(alert.strStatusBar), CClientUIInterface::ICON_ERROR);
         }
     }
 

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -71,7 +71,7 @@ signals:
     void alertsChanged(const QString &warnings);
 
     //! Asynchronous message notification
-    void message(const QString &title, const QString &message, bool modal, unsigned int style);
+    void message(const QString &title, const QString &message, unsigned int style);
 
 public slots:
     void updateTimer();

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -148,7 +148,7 @@ signals:
     void requireUnlock();
 
     // Asynchronous message notification
-    void message(const QString &title, const QString &message, bool modal, unsigned int style);
+    void message(const QString &title, const QString &message, unsigned int style);
 
 public slots:
     /* Wallet status might have changed */


### PR DESCRIPTION
- as we (can) supply the CClientUIInterface::MODAL flag via the style
  parameter, we don't need a separate bool for checking the modality

@laanwj As requested :), should be much better now.

This needs to get in before #2045, because I need to rebase that pull after this one gets in!
