### PR TITLE
honor blocked networks (-onlynet="XXX") with inbound connections

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -832,6 +832,11 @@ void ThreadSocketHandler2(void* parg)
                         closesocket(hSocket);
                 }
             }
+            else if (IsLimited(addr))
+            {
+                printf("connection from %s dropped (blocked network)\n", addr.ToString().c_str());
+                closesocket(hSocket);
+            }
             else if (CNode::IsBanned(addr))
             {
                 printf("connection from %s dropped (banned)\n", addr.ToString().c_str());


### PR DESCRIPTION
- current code, when set e.g. -onlynet="IPv6", only prevents outgoing
  connections to peers via the blocked networks (in this example IPv4/ Tor)
- this patch extends the behaviour to inbound connections, so when e.g.
  -onlynet="IPv6", don't allow incoming IPv4/Tor connections from peers
