### PR TITLE
OptionsModel now has MapPortUPnP=false if UPNP is not supported

### DIFF
--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -137,7 +137,11 @@ QVariant OptionsModel::data(const QModelIndex & index, int role) const
         case MinimizeToTray:
             return QVariant(fMinimizeToTray);
         case MapPortUPnP:
+#ifdef USE_UPNP
             return settings.value("fUseUPnP", GetBoolArg("-upnp", true));
+#else
+            return QVariant(false);
+#endif
         case MinimizeOnClose:
             return QVariant(fMinimizeOnClose);
         case ProxyUse: {


### PR DESCRIPTION
When compiled with `USE_UPNP=-`, in "Options/Network" tab the "Map port using UPNP" checkbox is set up and disabled, which creates the impression that UPnP is always on.

This patch makes `OptionModel` to always return `false` if UPnP is disabled, which solves this checkbox problem and, IMHO, is much more intuitive behaviour overall. Please review. 
