### PR TITLE
add Windows specific optimization to pre-alloc block/undo files

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -117,11 +117,15 @@ void SyncWithWallets(const uint256 &hash, const CTransaction& tx, const CBlock* 
 /** Process an incoming block */
 bool ProcessBlock(CNode* pfrom, CBlock* pblock, CDiskBlockPos *dbp = NULL);
 /** Check whether enough disk space is available for an incoming block */
-bool CheckDiskSpace(uint64 nAdditionalBytes=0);
+bool CheckDiskSpace(uint64 nAdditionalBytes = 0);
 /** Open a block file (blk?????.dat) */
 FILE* OpenBlockFile(const CDiskBlockPos &pos, bool fReadOnly = false);
 /** Open an undo file (rev?????.dat) */
 FILE* OpenUndoFile(const CDiskBlockPos &pos, bool fReadOnly = false);
+/** Get full path for the block file referenced by pos */
+const std::string& GetBlockFile(const CDiskBlockPos &pos);
+/** Get full path for the undo file referenced by pos */
+const std::string& GetUndoFile(const CDiskBlockPos &pos);
 /** Import blocks from an external file */
 bool LoadExternalBlockFile(FILE* fileIn, CDiskBlockPos *dbp = NULL);
 /** Load the block tree and coins database from disk */

--- a/src/util.h
+++ b/src/util.h
@@ -197,6 +197,9 @@ bool WildcardMatch(const std::string& str, const std::string& mask);
 void FileCommit(FILE *fileout);
 int GetFilesize(FILE* file);
 void AllocateFileRange(FILE *file, unsigned int offset, unsigned int length);
+#ifdef WIN32
+bool AllocateFileRangeWin(const std::string& strFile, unsigned int nLength);
+#endif
 bool RenameOver(boost::filesystem::path src, boost::filesystem::path dest);
 boost::filesystem::path GetDefaultDataDir();
 const boost::filesystem::path &GetDataDir(bool fNetSpecific = true);


### PR DESCRIPTION
- add AllocateFileRangeWin(), which is used to pre-allocate block/undo files
  as a single contignous chunk on disk, so these files are not fragmented
  (current master has 95 - 409 fragments for such files, this patch
  reduces all those to 1 fragment)
- add GetBlockFile() and GetUndoFile() helper functions, which are a
  wrapper for GetDiskFile(), which caches the last used file (separate
  cache for the last block and undo file)

I guess the helper functions could be used in other places of the code as well. I have another pull in the pipe, which makes CAutoFile based on an std::fstream and I use these helper functions there, too.

Todo:
- perhaps there is no need for another function name even, so AllocateFileRangeWin() could be changed to AllocateFileRange()
- as I didn't know how big undo files can grow (no MAX_UNDOFILE_SIZE from @sipa ^^), I used the same size for them, as for the block files (MAX_BLOCKFILE_SIZE)
