### PR TITLE
Upgrading to 0.8: re-use blkNNNN.dat files.

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -729,6 +729,33 @@ bool AppInit2()
         return InitError(msg);
     }
 
+    // Upgrading to 0.8; hard-link the old blknnnn.dat files into /blocks/
+    filesystem::path blocksDir = GetDataDir() / "blocks";
+    if (!filesystem::exists(blocksDir))
+    {
+        filesystem::create_directories(blocksDir);
+        bool linked = false;
+        for (unsigned int i = 1; i < 10000; i++) {
+            filesystem::path source = GetDataDir() / strprintf("blk%04u.dat", i);
+            if (!filesystem::exists(source)) break;
+            filesystem::path dest = blocksDir / strprintf("blk%05u.dat", i-1);
+            try {
+                filesystem::create_hard_link(source, dest);
+                printf("Hardlinked %s -> %s\n", source.string().c_str(), dest.string().c_str());
+                linked = true;
+            } catch (filesystem::filesystem_error & e) {
+                // Note: hardlink creation failing is not a disaster, it just means
+                // blocks will get re-downloaded from peers.
+                printf("Error hardlinking blk%04u.dat : %s\n", i, e.what());
+                break;
+            }
+        }
+        if (linked)
+        {
+            fReindex = true;
+        }
+    }
+
     // cache size calculations
     size_t nTotalCache = GetArg("-dbcache", 25) << 20;
     if (nTotalCache < (1 << 22))


### PR DESCRIPTION
This uses boost::filesystem::create_hard_link to hard-link the pre-0.8 blkNNNN.dat files to blocks/blkNNNNN-1.dat

A hard link is the semantics we want:  a copy would use twice the disk space, and a move would mean you have to re-download blocks if you switch back to 0.7.

The hard link failing is a soft error-- in that case, you just re-download the blocks.

According to my research, this should work on Windows, unless you're running a FAT32 filesystem.
