### PR TITLE
Decrease COIN_DUST to 0.001 BTC, Update TX miner and relay fee defaults

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -605,7 +605,7 @@ int64 CTransaction::GetMinFee(unsigned int nBlockSize, bool fAllowFree,
     if (nMinFee < nBaseFee)
     {
         BOOST_FOREACH(const CTxOut& txout, vout)
-            if (txout.nValue < CENT)
+            if (txout.nValue < COIN_DUST)
                 nMinFee = nBaseFee;
     }
 

--- a/src/main.h
+++ b/src/main.h
@@ -42,10 +42,12 @@ static const unsigned int BLOCKFILE_CHUNK_SIZE = 0x1000000; // 16 MiB
 static const unsigned int UNDOFILE_CHUNK_SIZE = 0x100000; // 1 MiB
 /** Fake height value used in CCoins to signify they are only in the memory pool (since 0.8) */
 static const unsigned int MEMPOOL_HEIGHT = 0x7FFFFFFF;
+
 /** Fees smaller than this (in satoshi) are considered zero fee (for transaction creation) */
-static const int64 MIN_TX_FEE = 50000;
+static const int64 MIN_TX_FEE = 100000;                // 0.001 BTC
 /** Fees smaller than this (in satoshi) are considered zero fee (for relaying) */
-static const int64 MIN_RELAY_TX_FEE = 10000;
+static const int64 MIN_RELAY_TX_FEE = 50000;           // 0.0005 BTC
+
 /** No amount larger than this (in satoshi) is valid */
 static const int64 MAX_MONEY = 21000000 * COIN;
 inline bool MoneyRange(int64 nValue) { return (nValue >= 0 && nValue <= MAX_MONEY); }

--- a/src/util.h
+++ b/src/util.h
@@ -34,6 +34,7 @@ typedef unsigned long long  uint64;
 
 static const int64 COIN = 100000000;
 static const int64 CENT = 1000000;
+static const int64 COIN_DUST = CENT;                // 1000000, or 0.01 BTC
 
 #define loop                for (;;)
 #define BEGIN(a)            ((char*)&(a))

--- a/src/util.h
+++ b/src/util.h
@@ -34,7 +34,7 @@ typedef unsigned long long  uint64;
 
 static const int64 COIN = 100000000;
 static const int64 CENT = 1000000;
-static const int64 COIN_DUST = CENT;                // 1000000, or 0.01 BTC
+static const int64 COIN_DUST = (CENT / 10);         // 100000, or 0.001 BTC
 
 #define loop                for (;;)
 #define BEGIN(a)            ((char*)&(a))

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1161,7 +1161,7 @@ bool CWallet::CreateTransaction(const vector<pair<CScript, int64> >& vecSend, CW
                 // if sub-cent change is required, the fee must be raised to at least MIN_TX_FEE
                 // or until nChange becomes zero
                 // NOTE: this depends on the exact behaviour of GetMinFee
-                if (nFeeRet < MIN_TX_FEE && nChange > 0 && nChange < CENT)
+                if (nFeeRet < MIN_TX_FEE && nChange > 0 && nChange < COIN_DUST)
                 {
                     int64 nMoveToFee = min(nChange, MIN_TX_FEE - nFeeRet);
                     nChange -= nMoveToFee;


### PR DESCRIPTION
1) Create COIN_DUST constant, to represent the dust spam limit used.

2)  Decrease COIN_DUST to 0.001 BTC

Rationale: With the increase in bitcoin value (US$13.67 as of this writing), it seems reasonable to reduce the value level of which we consider "dust spam."

3) Update TX miner and relay fee defaults to 0.001 / 0.0005 BTC respectively

Rationale: Reflects growth of dust spam in unspent transaction output dataset.
