### PR TITLE
listreceivedbyaddress now provides tx ids (issue #1149)

### DIFF
--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -813,6 +813,7 @@ struct tallyitem
 {
     int64 nAmount;
     int nConf;
+    vector<uint256> txids;
     tallyitem()
     {
         nAmount = 0;
@@ -854,6 +855,7 @@ Value ListReceived(const Array& params, bool fByAccounts)
             tallyitem& item = mapTally[address];
             item.nAmount += txout.nValue;
             item.nConf = min(item.nConf, nDepth);
+            item.txids.push_back(wtx.GetHash());
         }
     }
 
@@ -889,6 +891,12 @@ Value ListReceived(const Array& params, bool fByAccounts)
             obj.push_back(Pair("account",       strAccount));
             obj.push_back(Pair("amount",        ValueFromAmount(nAmount)));
             obj.push_back(Pair("confirmations", (nConf == std::numeric_limits<int>::max() ? 0 : nConf)));
+            Array transactions;
+            BOOST_FOREACH(const uint256& item, (*it).second.txids)
+            {
+                transactions.push_back(item.GetHex());
+            }
+            obj.push_back(Pair("txids", transactions));
             ret.push_back(obj);
         }
     }

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -892,9 +892,12 @@ Value ListReceived(const Array& params, bool fByAccounts)
             obj.push_back(Pair("amount",        ValueFromAmount(nAmount)));
             obj.push_back(Pair("confirmations", (nConf == std::numeric_limits<int>::max() ? 0 : nConf)));
             Array transactions;
-            BOOST_FOREACH(const uint256& item, (*it).second.txids)
+            if (it != mapTally.end())
             {
-                transactions.push_back(item.GetHex());
+                BOOST_FOREACH(const uint256& item, (*it).second.txids)
+                {
+                    transactions.push_back(item.GetHex());
+                }
             }
             obj.push_back(Pair("txids", transactions));
             ret.push_back(obj);
@@ -929,7 +932,8 @@ Value listreceivedbyaddress(const Array& params, bool fHelp)
             "  \"address\" : receiving address\n"
             "  \"account\" : the account of the receiving address\n"
             "  \"amount\" : total amount received by the address\n"
-            "  \"confirmations\" : number of confirmations of the most recent transaction included");
+            "  \"confirmations\" : number of confirmations of the most recent transaction included\n"
+            "  \"txids\" : list of transactions with outputs to the address\n");
 
     return ListReceived(params, false);
 }

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -79,6 +79,35 @@ static Value CallRPC(string args)
     }
 }
 
+BOOST_AUTO_TEST_CASE(rpc_wallet)
+{
+    // Test RPC calls for various wallet statistics
+    Value r;
+
+    BOOST_CHECK_NO_THROW(CallRPC("listunspent"));
+    BOOST_CHECK_THROW(CallRPC("listunspent string"), runtime_error);
+    BOOST_CHECK_THROW(CallRPC("listunspent 0 string"), runtime_error);
+    BOOST_CHECK_THROW(CallRPC("listunspent 0 1 not_array"), runtime_error);
+    BOOST_CHECK_THROW(CallRPC("listunspent 0 1 [] extra"), runtime_error);
+    BOOST_CHECK_NO_THROW(r=CallRPC("listunspent 0 1 []"));
+    BOOST_CHECK(r.get_array().empty());
+
+    BOOST_CHECK_NO_THROW(CallRPC("listreceivedbyaddress"));
+    BOOST_CHECK_NO_THROW(CallRPC("listreceivedbyaddress 0"));
+    BOOST_CHECK_THROW(CallRPC("listreceivedbyaddress not_int"), runtime_error);
+    BOOST_CHECK_THROW(CallRPC("listreceivedbyaddress 0 not_bool"), runtime_error);
+    BOOST_CHECK_NO_THROW(CallRPC("listreceivedbyaddress 0 true"));
+    BOOST_CHECK_THROW(CallRPC("listreceivedbyaddress 0 true extra"), runtime_error);
+
+    BOOST_CHECK_NO_THROW(CallRPC("listreceivedbyaccount"));
+    BOOST_CHECK_NO_THROW(CallRPC("listreceivedbyaccount 0"));
+    BOOST_CHECK_THROW(CallRPC("listreceivedbyaccount not_int"), runtime_error);
+    BOOST_CHECK_THROW(CallRPC("listreceivedbyaccount 0 not_bool"), runtime_error);
+    BOOST_CHECK_NO_THROW(CallRPC("listreceivedbyaccount 0 true"));
+    BOOST_CHECK_THROW(CallRPC("listreceivedbyaccount 0 true extra"), runtime_error);
+}
+
+
 BOOST_AUTO_TEST_CASE(rpc_rawparams)
 {
     // Test raw transaction API argument handling
@@ -87,14 +116,6 @@ BOOST_AUTO_TEST_CASE(rpc_rawparams)
     BOOST_CHECK_THROW(CallRPC("getrawtransaction"), runtime_error);
     BOOST_CHECK_THROW(CallRPC("getrawtransaction not_hex"), runtime_error);
     BOOST_CHECK_THROW(CallRPC("getrawtransaction a3b807410df0b60fcb9736768df5823938b2f838694939ba45f3c0a1bff150ed not_int"), runtime_error);
-
-    BOOST_CHECK_NO_THROW(CallRPC("listunspent"));
-    BOOST_CHECK_THROW(CallRPC("listunspent string"), runtime_error);
-    BOOST_CHECK_THROW(CallRPC("listunspent 0 string"), runtime_error);
-    BOOST_CHECK_THROW(CallRPC("listunspent 0 1 not_array"), runtime_error);
-    BOOST_CHECK_NO_THROW(r=CallRPC("listunspent 0 1 []"));
-    BOOST_CHECK_THROW(r=CallRPC("listunspent 0 1 [] extra"), runtime_error);
-    BOOST_CHECK(r.get_array().empty());
 
     BOOST_CHECK_THROW(CallRPC("createrawtransaction"), runtime_error);
     BOOST_CHECK_THROW(CallRPC("createrawtransaction null null"), runtime_error);


### PR DESCRIPTION
See [Issue #1149](https://github.com/bitcoin/bitcoin/issues/1149)

Example ouput:

```
[
{
"address" : "1...",
"account" : "",
"amount" : 0.1,
"confirmations" : 9000,
"txids" : [
"5b68f4799e90e5d04f0c67fa9a2971e0964ced225a31f548e3ede8f4a0fc5836",
"e132bb64a1a61c2d34163261d9c5bc2b166dc3a476e922dc1bd2d02a325b086b"
]
}
]
```
