### PR TITLE
Make IsCanonicalScript() check the hash type more thoroughly

### DIFF
--- a/src/script.cpp
+++ b/src/script.cpp
@@ -278,7 +278,8 @@ bool IsCanonicalSignature(const valtype &vchSig) {
         return error("Non-canonical signature: too short");
     if (vchSig.size() > 73)
         return error("Non-canonical signature: too long");
-    if (vchSig[vchSig.size() - 1] & 0x7C)
+    unsigned char nHashType = vchSig[vchSig.size() - 1] & (~(SIGHASH_ANYONECANPAY));
+    if (nHashType < SIGHASH_ALL || nHashType > SIGHASH_SINGLE)
         return error("Non-canonical signature: unknown hashtype byte");
     if (vchSig[0] != 0x30)
         return error("Non-canonical signature: wrong type");


### PR DESCRIPTION
0 and 128 were previously accepted as standard hash type.

Note that this function is not active in the current verification code.
