### PR TITLE
Provide fee data for all txs in RPC getblocktemplate response

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -108,6 +108,8 @@ class CTxUndo;
 class CCoinsView;
 class CCoinsViewCache;
 
+struct CBlockTemplate;
+
 /** Register a wallet to receive updates from core */
 void RegisterWallet(CWallet* pwalletIn);
 /** Unregister a wallet from core */
@@ -139,7 +141,7 @@ void ThreadImport(void *parg);
 /** Run the miner threads */
 void GenerateBitcoins(bool fGenerate, CWallet* pwallet);
 /** Generate a new block, without valid proof-of-work */
-CBlock* CreateNewBlock(CReserveKey& reservekey);
+CBlockTemplate* CreateNewBlock(CReserveKey& reservekey);
 /** Modify the extranonce in a block */
 void IncrementExtraNonce(CBlock* pblock, CBlockIndex* pindexPrev, unsigned int& nExtraNonce);
 /** Do mining precalculation */
@@ -1974,5 +1976,12 @@ extern CCoinsViewCache *pcoinsTip;
 
 /** Global variable that points to the active block tree (protected by cs_main) */
 extern CBlockTreeDB *pblocktree;
+
+struct CBlockTemplate
+{
+    CBlock block;
+    std::vector<int64_t> vTxFees;
+    std::vector<int64_t> vTxSigOps;
+};
 
 #endif

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -283,7 +283,6 @@ Value getblocktemplate(const Array& params, bool fHelp)
     Array transactions;
     map<uint256, int64_t> setTxIndex;
     int i = 0;
-    CCoinsViewCache &view = *pcoinsTip;
     BOOST_FOREACH (CTransaction& tx, pblock->vtx)
     {
         uint256 txHash = tx.GetHash();
@@ -308,13 +307,8 @@ Value getblocktemplate(const Array& params, bool fHelp)
         }
         entry.push_back(Pair("depends", deps));
 
-        int64_t nSigOps = tx.GetLegacySigOpCount();
-        if (tx.HaveInputs(view))
-        {
-            entry.push_back(Pair("fee", (int64_t)(tx.GetValueIn(view) - tx.GetValueOut())));
-            nSigOps += tx.GetP2SHSigOpCount(view);
-        }
-        entry.push_back(Pair("sigops", nSigOps));
+        entry.push_back(Pair("fee", pblocktemplate->vTxFees[&tx - pblock->vtx.data()]));
+        entry.push_back(Pair("sigops", pblocktemplate->vTxSigOps[&tx - pblock->vtx.data()]));
 
         transactions.push_back(entry);
     }

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -307,8 +307,9 @@ Value getblocktemplate(const Array& params, bool fHelp)
         }
         entry.push_back(Pair("depends", deps));
 
-        entry.push_back(Pair("fee", pblocktemplate->vTxFees[&tx - pblock->vtx.data()]));
-        entry.push_back(Pair("sigops", pblocktemplate->vTxSigOps[&tx - pblock->vtx.data()]));
+        int index_in_template = &tx - pblock->vtx.data();
+        entry.push_back(Pair("fee", pblocktemplate->vTxFees[index_in_template]));
+        entry.push_back(Pair("sigops", pblocktemplate->vTxSigOps[index_in_template]));
 
         transactions.push_back(entry);
     }


### PR DESCRIPTION
Having the fee data for every transaction returned by "getblocktemplate" was broken by the ultraprune commit (450cbb09). It made it so transactions that depend on other transactions in the block-to-be don't have fee data.
