### PR TITLE
Fix off-by-one error: change outputs were never last

### DIFF
--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1188,7 +1188,7 @@ bool CWallet::CreateTransaction(const vector<pair<CScript, int64> >& vecSend, CW
                     scriptChange.SetDestination(vchPubKey.GetID());
 
                     // Insert change txn at random position:
-                    vector<CTxOut>::iterator position = wtxNew.vout.begin()+GetRandInt(wtxNew.vout.size());
+                    vector<CTxOut>::iterator position = wtxNew.vout.begin()+GetRandInt(wtxNew.vout.size()+1);
                     wtxNew.vout.insert(position, CTxOut(nChange, scriptChange));
                 }
                 else


### PR DESCRIPTION
Found by Hal Finney (thanks Hal!): change outputs were never
inserted as the last output, so were not randomized at all
for single-output transactions (they were always the first output).
Fixes issue #2107
