### PR TITLE
Watch-Only Addresses: Separating Transaction Signing From Transaction Processing

### DIFF
--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -247,6 +247,7 @@ static const CRPCCommand vRPCCommands[] =
     { "listsinceblock",         &listsinceblock,         false,     false },
     { "dumpprivkey",            &dumpprivkey,            true,      false },
     { "importprivkey",          &importprivkey,          false,     false },
+    { "importaddress",          &importaddress,          false,     false },
     { "listunspent",            &listunspent,            false,     false },
     { "getrawtransaction",      &getrawtransaction,      false,     false },
     { "createrawtransaction",   &createrawtransaction,   false,     false },
@@ -1170,6 +1171,7 @@ Array RPCConvertValues(const std::string &strMethod, const std::vector<std::stri
     if (strMethod == "lockunspent"            && n > 0) ConvertTo<bool>(params[0]);
     if (strMethod == "lockunspent"            && n > 1) ConvertTo<Array>(params[1]);
     if (strMethod == "importprivkey"          && n > 2) ConvertTo<bool>(params[2]);
+    if (strMethod == "importaddress"          && n > 2) ConvertTo<bool>(params[2]);
 
     return params;
 }

--- a/src/bitcoinrpc.h
+++ b/src/bitcoinrpc.h
@@ -137,6 +137,7 @@ extern json_spirit::Value addnode(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value getaddednodeinfo(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value dumpprivkey(const json_spirit::Array& params, bool fHelp); // in rpcdump.cpp
 extern json_spirit::Value importprivkey(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value importaddress(const json_spirit::Array& params, bool fHelp);
 
 extern json_spirit::Value getgenerate(const json_spirit::Array& params, bool fHelp); // in rpcmining.cpp
 extern json_spirit::Value setgenerate(const json_spirit::Array& params, bool fHelp);

--- a/src/keystore.h
+++ b/src/keystore.h
@@ -56,6 +56,7 @@ protected:
 
 public:
     bool AddKey(const CKey& key);
+    bool AddKey(const CKeyID& address);
     bool HaveKey(const CKeyID &address) const
     {
         bool result;
@@ -147,6 +148,7 @@ public:
 
     virtual bool AddCryptedKey(const CPubKey &vchPubKey, const std::vector<unsigned char> &vchCryptedSecret);
     bool AddKey(const CKey& key);
+    bool AddKey(const CKeyID& address);
     bool HaveKey(const CKeyID &address) const
     {
         {

--- a/src/rpcdump.cpp
+++ b/src/rpcdump.cpp
@@ -77,6 +77,46 @@ Value importprivkey(const Array& params, bool fHelp)
     return Value::null;
 }
 
+Value importaddress(const Array& params, bool fHelp)
+{
+    if (fHelp || params.size() < 1 || params.size() > 3)
+        throw runtime_error(
+            "importaddress <bitcoinaddress> [label] [rescan=true]\n"
+            "Adds an address that can be watched as if it were in your wallet but cannot be used to spend.");
+
+    CKeyID vchAddress;
+    CBitcoinAddress address(params[0].get_str());
+    if (!address.GetKeyID(vchAddress)) throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid Bitcoin address");
+	
+    string strLabel = "";
+    if (params.size() > 1)
+        strLabel = params[1].get_str();
+	
+    // Whether to perform rescan after import
+    bool fRescan = true;
+    if (params.size() > 2)
+        fRescan = params[2].get_bool();
+	
+    {
+        LOCK2(cs_main, pwalletMain->cs_wallet);
+			
+        pwalletMain->MarkDirty();
+        pwalletMain->SetAddressBookName(vchAddress, strLabel);
+			
+        if (!pwalletMain->AddAddress(vchAddress))
+            throw JSONRPCError(RPC_WALLET_ERROR, "Error adding address to wallet");
+			
+        if (fRescan)
+        {
+            pwalletMain->ScanForWalletTransactions(pindexGenesisBlock, true);
+            pwalletMain->ReacceptWalletTransactions();
+        }
+    }
+	
+    return Value::null;
+}
+
+
 Value dumpprivkey(const Array& params, bool fHelp)
 {
     if (fHelp || params.size() != 1)

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -55,6 +55,17 @@ bool CWallet::AddKey(const CKey& key)
     return true;
 }
 
+bool CWallet::AddAddress(const CKeyID& address)
+{
+    if (!CCryptoKeyStore::AddKey(address))
+        return false;
+    if (!fFileBacked)
+        return true;
+    if (!IsCrypted())
+        return CWalletDB(strWalletFile).WriteAddress(address);
+    return true;
+}
+
 bool CWallet::AddCryptedKey(const CPubKey &vchPubKey, const vector<unsigned char> &vchCryptedSecret)
 {
     if (!CCryptoKeyStore::AddCryptedKey(vchPubKey, vchCryptedSecret))

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -137,8 +137,12 @@ public:
     CPubKey GenerateNewKey();
     // Adds a key to the store, and saves it to disk.
     bool AddKey(const CKey& key);
+    // Adds a watching address to the store, saves it to disk.
+    bool AddAddress(const CKeyID& address);
     // Adds a key to the store, without saving it to disk (used by LoadWallet)
     bool LoadKey(const CKey& key) { return CCryptoKeyStore::AddKey(key); }
+    // Adds a watching address to the store, without saving it to disk (used by LoadWallet)
+    bool LoadAddress(const CKeyID& address) { return CCryptoKeyStore::AddKey(address); }
 
     bool LoadMinVersion(int nVersion) { nWalletVersion = nVersion; nWalletMaxVersion = std::max(nWalletMaxVersion, nVersion); return true; }
 

--- a/src/walletdb.cpp
+++ b/src/walletdb.cpp
@@ -369,6 +369,16 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
                 return false;
             }
         }
+        else if (strType == "address")
+        {
+            CKeyID address;
+            ssKey >> address;
+            if (!pwallet->LoadAddress(address))
+            {
+                strErr = "Error reading wallet database: LoadKey failed on address";
+                return false;
+            }
+        }
         else if (strType == "orderposnext")
         {
             ssValue >> pwallet->nOrderPosNext;

--- a/src/walletdb.h
+++ b/src/walletdb.h
@@ -56,6 +56,12 @@ public:
         return Write(std::make_pair(std::string("key"), vchPubKey.Raw()), vchPrivKey, false);
     }
 
+    bool WriteAddress(const CKeyID& address)
+    {
+        nWalletDBUpdated++;
+        return Write(std::make_pair(std::string("address"), address), address, false);
+    }
+	
     bool WriteCryptedKey(const CPubKey& vchPubKey, const std::vector<unsigned char>& vchCryptedSecret, bool fEraseUnencryptedKey = true)
     {
         nWalletDBUpdated++;


### PR DESCRIPTION
# 

A major issue many have faced in using bitcoind to build applications is the lack of RPC support for tracking transactions and balances without having to know and keep associated private keys in the wallet. Oftentimes one might want to watch other people's transactions or to keep signing nodes behind tighter security while using separate relay nodes to service all nonsigning, non-key-generating application functionality such as sending payment and confirmation alerts.

In order to achieve these objectives, I have had to build a bunch of custom software - much of which duplicates functionality that is already present in the Satoshi Client. This pull request is an attempt at addressing some of these concerns without having to fundamentally restructure the client architecture. (Thanks, sipa!)

The proposal is to add another kind of object to the wallet database - a bitcoin address sans private key - which the client treats as if it were any other wallet adddress except for when it comes to signing and privkey export operations. This means RPC calls such as getreceivedbyaddress and listtransactions can be used on arbitrary bitcoin addresses.

I've added an RPC call:

```
importaddress <bitcoinaddress> [label] [rescan=true]
```

The address is added as a new type of serialized object in wallet.dat and loads into the key maps of the CKeyStore instances with the key set to the CKeyID and the secret set to an empty vector.

Please test it out and let me know what you think.

Cheers,

-Eric Lombrozo
