### PR TITLE
Clang cleanup

### DIFF
--- a/src/irc.cpp
+++ b/src/irc.cpp
@@ -248,7 +248,6 @@ void ThreadIRCSeed2(void* parg)
         if (!RecvUntil(hSocket, "Found your hostname", "using your IP address instead", "Couldn't look up your hostname", "ignoring hostname"))
         {
             closesocket(hSocket);
-            hSocket = INVALID_SOCKET;
             nErrorWait = nErrorWait * 11 / 10;
             if (Wait(nErrorWait += 60))
                 continue;
@@ -273,7 +272,6 @@ void ThreadIRCSeed2(void* parg)
         if (nRet != 1)
         {
             closesocket(hSocket);
-            hSocket = INVALID_SOCKET;
             if (nRet == 2)
             {
                 printf("IRC name already in use\n");
@@ -362,7 +360,6 @@ void ThreadIRCSeed2(void* parg)
             }
         }
         closesocket(hSocket);
-        hSocket = INVALID_SOCKET;
 
         if (GetTime() - nStart > 20 * 60)
         {

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -1045,10 +1045,7 @@ public:
         if (nReadPosNext >= vch.size())
         {
             if (nReadPosNext > vch.size())
-            {
                 setstate(std::ios::failbit, "CDataStream::ignore() : end of data");
-                nSize = vch.size() - nReadPos;
-            }
             nReadPos = 0;
             vch.clear();
             return (*this);


### PR DESCRIPTION
Yesterday LLVM 3.2 was released, as well as a corresponding version of the clang compiler and static analyzer.

I ran the static analyzer over the bitcoin code and picked up a couple of assignments to variables that are never read. These two patches remove those assigments.
