### PR TITLE
break after ProcessMessage() to give other peers a chance.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3427,7 +3427,9 @@ bool ProcessMessages(CNode* pfrom)
 
         if (!fRet)
             printf("ProcessMessage(%s, %u bytes) FAILED\n", strCommand.c_str(), nMessageSize);
-    }
+        else
+            break; // give other peers a chance
+    } // loop
 
     vRecv.Compact();
     return true;


### PR DESCRIPTION
This is to help with nodes becoming unresponsive in the eyes of other nodes. Also, in combination with my other pulls, this helps to reduce the number of duplicate blocks received.
