### PR TITLE
OutputDebugStringF code cleanup

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -138,7 +138,7 @@ extern std::string strMiscWarning;
 extern bool fTestNet;
 extern bool fNoListen;
 extern bool fLogTimestamps;
-extern bool fReopenDebugLog;
+extern volatile bool fReopenDebugLog;
 
 void RandAddSeed();
 void RandAddSeedPerfmon();


### PR DESCRIPTION
There was a bunch of shed-painting about this before the 0.7.1 release, and I promised to tidy up the code, so:

Initialize the OutputDebugStringF mutex and file pointer using boost::call_once, to be thread-safe.

Make the return value of OutputDebugStringF really be the number of characters written (*printf() semantics).

Declare the fReopenDebugLog flag volatile, since it is changed from a signal handler.

And don't declare OutputDebugStringF() as inline.
