### PR TITLE
update ThreadSafeMessageBox function to use strCaption

### DIFF
--- a/src/noui.cpp
+++ b/src/noui.cpp
@@ -24,10 +24,10 @@ static int noui_ThreadSafeMessageBox(const std::string& message, const std::stri
         strCaption += _("Information");
         break;
     default:
-        strCaption += caption; // Use supplied caption
+        strCaption += caption; // Use supplied caption (can be empty)
     }
 
-    printf("%s: %s\n", caption.c_str(), message.c_str());
+    printf("%s: %s\n", strCaption.c_str(), message.c_str());
     fprintf(stderr, "%s: %s\n", strCaption.c_str(), message.c_str());
     return 4;
 }


### PR DESCRIPTION
- ensure we use strCaption for printf and fprintf, as before it could
  happen to have an error message in the debug.log, which had no "Error"
  (or whatever) in front
- ensure ThreadSafeMessageBox() uses the same code (when guiref == NULL)
  as noui_ThreadSafeMessageBox()
