### PR TITLE
Bitcoin-Qt: give testnet a unique IPC message queue name

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -113,6 +113,14 @@ static void handleRunawayException(std::exception *e)
 #ifndef BITCOIN_QT_TEST
 int main(int argc, char *argv[])
 {
+    // Command-line options take precedence:
+    ParseParameters(argc, argv);
+
+    if(GetBoolArg("-testnet")) // Separate message queue name for testnet
+        strBitcoinURIQueueName = BITCOINURI_QUEUE_NAME_TESTNET;
+    else
+        strBitcoinURIQueueName = BITCOINURI_QUEUE_NAME_MAINNET;
+
     // Do this early as we don't want to bother initializing if we are just calling IPC
     ipcScanRelay(argc, argv);
 
@@ -125,9 +133,6 @@ int main(int argc, char *argv[])
 
     // Install global event filter that makes sure that long tooltips can be word-wrapped
     app.installEventFilter(new GUIUtil::ToolTipToRichTextFilter(TOOLTIP_WRAP_THRESHOLD, &app));
-
-    // Command-line options take precedence:
-    ParseParameters(argc, argv);
 
     // ... then bitcoin.conf:
     if (!boost::filesystem::is_directory(GetDataDir(false)))

--- a/src/qt/qtipcserver.h
+++ b/src/qt/qtipcserver.h
@@ -1,8 +1,14 @@
 #ifndef QTIPCSERVER_H
 #define QTIPCSERVER_H
 
-// Define Bitcoin-Qt message queue name
-#define BITCOINURI_QUEUE_NAME "BitcoinURI"
+#include <string>
+
+// Define Bitcoin-Qt message queue name for mainnet
+#define BITCOINURI_QUEUE_NAME_MAINNET "BitcoinURI"
+// Define Bitcoin-Qt message queue name for testnet
+#define BITCOINURI_QUEUE_NAME_TESTNET "BitcoinURI-testnet"
+
+extern std::string strBitcoinURIQueueName;
 
 void ipcScanRelay(int argc, char *argv[]);
 void ipcInit(int argc, char *argv[]);


### PR DESCRIPTION
- this prevents an interference with the IPC message queue (which is used
  for URI processing) when running a testnet and mainnet instance in
  parallel
- to check for testnet, I had to raise the ParseParameters() call in
  main() to the topmost position
