### PR TITLE
add extract_strings_qt_win.py and edit translation_process.md

### DIFF
--- a/doc/translation_process.md
+++ b/doc/translation_process.md
@@ -39,8 +39,11 @@ so make sure that utility is installed (ie, `apt-get install gettext` on
 Ubuntu/Debian):
 
     python share/qt/extract_strings_qt.py
+    or (for Windows in a MinGW Shell)
+    share/qt/extract_strings_qt_winpy
+
     lupdate bitcoin-qt.pro -no-obsolete -locations relative -ts src/qt/locale/bitcoin_en.ts
-    
+
 ##### Handling of plurals in the source file
 
 When new plurals are added to the source file, it's important to do the following steps:

--- a/share/qt/extract_strings_qt_win.py
+++ b/share/qt/extract_strings_qt_win.py
@@ -1,7 +1,7 @@
-#!/usr/bin/python
+#!/d/Python27/python
 '''
 Extract _("...") strings for translation and convert to Qt4 stringdefs so that
-they can be picked up by Qt linguist. Assumes Python is installed in /usr/bin/.
+they can be picked up by Qt linguist. Assumes Python is installed in D:\Python27\.
 '''
 from subprocess import Popen, PIPE
 import glob


### PR DESCRIPTION
- extends the translation process a little in terms of usability on Windows
- I'm now able to create bitcoinstrings.cpp straight from master without
  the need to edit or copy that Python script ;)
