### PR TITLE
Bitcoin-Qt: add a Signature label on sign message page

### DIFF
--- a/src/qt/forms/signverifymessagedialog.ui
+++ b/src/qt/forms/signverifymessagedialog.ui
@@ -105,6 +105,16 @@
         </widget>
        </item>
        <item>
+        <widget class="QLabel" name="signatureLabel_SM">
+         <property name="text">
+          <string>Signature</string>
+         </property>
+         <property name="textFormat">
+          <enum>Qt::PlainText</enum>
+         </property>
+        </widget>
+       </item>
+       <item>
         <layout class="QHBoxLayout" name="horizontalLayout_2_SM">
          <property name="spacing">
           <number>0</number>


### PR DESCRIPTION
This adds a suggestion from issue #2144, so that the signature is prepended by a label.
