### PR TITLE
Remove fClient

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -467,28 +467,21 @@ CTransaction::GetLegacySigOpCount() const
 
 int CMerkleTx::SetMerkleBranch(const CBlock* pblock)
 {
-    if (fClient)
-    {
-        if (hashBlock == 0)
-            return 0;
-    }
-    else
-    {
-        CBlock blockTmp;
+    CBlock blockTmp;
 
-        if (pblock == NULL) {
-            CCoins coins;
-            if (pcoinsTip->GetCoins(GetHash(), coins)) {
-                CBlockIndex *pindex = FindBlockByHeight(coins.nHeight);
-                if (pindex) {
-                    if (!blockTmp.ReadFromDisk(pindex))
-                        return 0;
-                    pblock = &blockTmp;
-                }
+    if (pblock == NULL) {
+        CCoins coins;
+        if (pcoinsTip->GetCoins(GetHash(), coins)) {
+            CBlockIndex *pindex = FindBlockByHeight(coins.nHeight);
+            if (pindex) {
+                if (!blockTmp.ReadFromDisk(pindex))
+                    return 0;
+                pblock = &blockTmp;
             }
         }
+    }
 
-        if (pblock) {
+    if (pblock) {
         // Update the tx's hashBlock
         hashBlock = pblock->GetHash();
 
@@ -506,7 +499,6 @@ int CMerkleTx::SetMerkleBranch(const CBlock* pblock)
 
         // Fill in merkle branch
         vMerkleBranch = pblock->GetMerkleBranch(nIndex);
-        }
     }
 
     // Is the tx in a block that's in the main chain
@@ -915,16 +907,7 @@ int CMerkleTx::GetBlocksToMaturity() const
 
 bool CMerkleTx::AcceptToMemoryPool(bool fCheckInputs)
 {
-    if (fClient)
-    {
-        if (!IsInMainChain() && !ClientCheckInputs())
-            return false;
-        return CTransaction::AcceptToMemoryPool(false);
-    }
-    else
-    {
-        return CTransaction::AcceptToMemoryPool(fCheckInputs);
-    }
+    return CTransaction::AcceptToMemoryPool(fCheckInputs);
 }
 
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -45,10 +45,9 @@ struct LocalServiceInfo {
 //
 // Global state variables
 //
-bool fClient = false;
 bool fDiscover = true;
 bool fUseUPnP = false;
-uint64 nLocalServices = (fClient ? 0 : NODE_NETWORK);
+uint64 nLocalServices = NODE_NETWORK;
 static CCriticalSection cs_mapLocalHost;
 static map<CNetAddr, LocalServiceInfo> mapLocalHost;
 static bool vfReachable[NET_MAX] = {};

--- a/src/net.h
+++ b/src/net.h
@@ -86,7 +86,6 @@ enum threadId
     THREAD_MAX
 };
 
-extern bool fClient;
 extern bool fDiscover;
 extern bool fUseUPnP;
 extern uint64 nLocalServices;


### PR DESCRIPTION
Client (SPV) mode never got implemented entirely, and whatever part was already working, is likely not been tested (or even executed at all) for the past two years. This removes it entirely.

If we want an SPV implementation, I think we should first get the block chain data structures to be encapsulated in a class implementing a standard interface, and then writing an alternate implementation with SPV semantics.
