### PR TITLE
Bitcoin-Qt: cleanup / optimise addressbookpage

### DIFF
--- a/src/qt/addressbookpage.cpp
+++ b/src/qt/addressbookpage.cpp
@@ -62,8 +62,8 @@ AddressBookPage::AddressBookPage(Mode mode, Tabs tab, QWidget *parent) :
     }
 
     // Context menu actions
-    QAction *copyLabelAction = new QAction(tr("Copy &Label"), this);
     QAction *copyAddressAction = new QAction(ui->copyToClipboard->text(), this);
+    QAction *copyLabelAction = new QAction(tr("Copy &Label"), this);
     QAction *editAction = new QAction(tr("&Edit"), this);
     QAction *showQRCodeAction = new QAction(ui->showQRCode->text(), this);
     QAction *signMessageAction = new QAction(ui->signMessage->text(), this);
@@ -78,7 +78,9 @@ AddressBookPage::AddressBookPage(Mode mode, Tabs tab, QWidget *parent) :
     if(tab == SendingTab)
         contextMenu->addAction(deleteAction);
     contextMenu->addSeparator();
+#ifdef USE_QRCODE
     contextMenu->addAction(showQRCodeAction);
+#endif
     if(tab == ReceivingTab)
         contextMenu->addAction(signMessageAction);
     else if(tab == SendingTab)
@@ -184,36 +186,31 @@ void AddressBookPage::on_signMessage_clicked()
 {
     QTableView *table = ui->tableView;
     QModelIndexList indexes = table->selectionModel()->selectedRows(AddressTableModel::Address);
-    QString addr;
 
     foreach (QModelIndex index, indexes)
     {
-        QVariant address = index.data();
-        addr = address.toString();
+        QString address = index.data().toString();
+        emit signMessage(address);
     }
-
-    emit signMessage(addr);
 }
 
 void AddressBookPage::on_verifyMessage_clicked()
 {
     QTableView *table = ui->tableView;
     QModelIndexList indexes = table->selectionModel()->selectedRows(AddressTableModel::Address);
-    QString addr;
 
     foreach (QModelIndex index, indexes)
     {
-        QVariant address = index.data();
-        addr = address.toString();
+        QString address = index.data().toString();
+        emit verifyMessage(address);
     }
-
-    emit verifyMessage(addr);
 }
 
 void AddressBookPage::on_newAddressButton_clicked()
 {
     if(!model)
         return;
+
     EditAddressDialog dlg(
             tab == SendingTab ?
             EditAddressDialog::NewSendingAddress :
@@ -230,6 +227,7 @@ void AddressBookPage::on_deleteButton_clicked()
     QTableView *table = ui->tableView;
     if(!table->selectionModel())
         return;
+
     QModelIndexList indexes = table->selectionModel()->selectedRows();
     if(!indexes.isEmpty())
     {
@@ -341,11 +339,11 @@ void AddressBookPage::on_showQRCode_clicked()
 
     foreach (QModelIndex index, indexes)
     {
-        QString address = index.data().toString(), label = index.sibling(index.row(), 0).data(Qt::EditRole).toString();
+        QString address = index.data().toString();
+        QString label = index.sibling(index.row(), 0).data(Qt::EditRole).toString();
 
         QRCodeDialog *dialog = new QRCodeDialog(address, label, tab == ReceivingTab, this);
-        if(optionsModel)
-            dialog->setModel(optionsModel);
+        dialog->setModel(optionsModel);
         dialog->setAttribute(Qt::WA_DeleteOnClose);
         dialog->show();
     }

--- a/src/qt/addressbookpage.h
+++ b/src/qt/addressbookpage.h
@@ -54,26 +54,31 @@ private:
     QString returnValue;
     QSortFilterProxyModel *proxyModel;
     QMenu *contextMenu;
-    QAction *deleteAction;
+    QAction *deleteAction; // to be able to explicitly disable it
     QString newAddressToSelect;
 
 private slots:
+    /** Delete currently selected address entry */
     void on_deleteButton_clicked();
+    /** Create a new address for receiving coins and / or add a new address book entry */
     void on_newAddressButton_clicked();
     /** Copy address of currently selected address entry to clipboard */
     void on_copyToClipboard_clicked();
+    /** Open the sign message tab in the Sign/Verify Message dialog with currently selected address */
     void on_signMessage_clicked();
+    /** Open the verify message tab in the Sign/Verify Message dialog with currently selected address */
     void on_verifyMessage_clicked();
-    void selectionChanged();
+    /** Generate a QR Code from the currently selected address */
     void on_showQRCode_clicked();
-    /** Spawn contextual menu (right mouse menu) for address book entry */
-    void contextualMenu(const QPoint &point);
-
-    /** Copy label of currently selected address entry to clipboard */
+    /** Copy label of currently selected address entry to clipboard (no button) */
     void onCopyLabelAction();
-    /** Edit currently selected address entry */
+    /** Edit currently selected address entry (no button) */
     void onEditAction();
 
+    /** Set button states based on selected tab and selection */
+    void selectionChanged();
+    /** Spawn contextual menu (right mouse menu) for address book entry */
+    void contextualMenu(const QPoint &point);
     /** New entry/entries were added to address table */
     void selectNewAddress(const QModelIndex &parent, int begin, int /*end*/);
 


### PR DESCRIPTION
- don't show QR Code context menu, when USE_QRCODE=1 was not specified
  when compiling the client
- re-work on_showQRCode_clicked() for better readability and remove an
  unneeded duplicate check
- re-work on_signMessage_clicked() and on_verifyMessage_clicked() to match
  foreach in on_showQRCode_clicked(), which seems more robust / cleaner
- re-order context menu stuff to match real context menu layout
- add comments for all private slots in the class
