### PR TITLE
Bitcoin-Qt: move num TX label to debug window

### DIFF
--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -159,23 +159,6 @@
               </property>
              </widget>
             </item>
-            <item row="3" column="0">
-             <widget class="QLabel" name="label_2">
-              <property name="text">
-               <string>Number of transactions:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="3" column="1">
-             <widget class="QLabel" name="labelNumTransactions">
-              <property name="toolTip">
-               <string>Total number of transactions in wallet</string>
-              </property>
-              <property name="text">
-               <string notr="true">0</string>
-              </property>
-             </widget>
-            </item>
             <item row="2" column="0">
              <widget class="QLabel" name="labelImmatureText">
               <property name="text">

--- a/src/qt/forms/rpcconsole.ui
+++ b/src/qt/forms/rpcconsole.ui
@@ -23,7 +23,7 @@
       <attribute name="title">
        <string>&amp;Information</string>
       </attribute>
-      <layout class="QGridLayout" name="gridLayout" columnstretch="0,1">
+      <layout class="QFormLayout" name="formLayout">
        <property name="horizontalSpacing">
         <number>12</number>
        </property>
@@ -294,6 +294,19 @@
         </widget>
        </item>
        <item row="13" column="0">
+        <widget class="QLabel" name="labelWallet">
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Wallet</string>
+         </property>
+        </widget>
+       </item>
+       <item row="15" column="0">
         <spacer name="verticalSpacer_2">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
@@ -306,7 +319,7 @@
          </property>
         </spacer>
        </item>
-       <item row="14" column="0">
+       <item row="16" column="0">
         <widget class="QLabel" name="labelDebugLogfile">
          <property name="font">
           <font>
@@ -319,7 +332,7 @@
          </property>
         </widget>
        </item>
-       <item row="15" column="0">
+       <item row="17" column="0">
         <widget class="QPushButton" name="openDebugLogfileButton">
          <property name="toolTip">
           <string>Open the Bitcoin debug log file from the current data directory. This can take a few seconds for large log files.</string>
@@ -332,7 +345,7 @@
          </property>
         </widget>
        </item>
-       <item row="16" column="0">
+       <item row="18" column="0">
         <widget class="QLabel" name="labelCLOptions">
          <property name="font">
           <font>
@@ -345,7 +358,7 @@
          </property>
         </widget>
        </item>
-       <item row="17" column="0">
+       <item row="19" column="0">
         <widget class="QPushButton" name="showCLOptionsButton">
          <property name="toolTip">
           <string>Show the Bitcoin-Qt help message to get a list with possible Bitcoin command-line options.</string>
@@ -358,18 +371,28 @@
          </property>
         </widget>
        </item>
-       <item row="18" column="0">
-        <spacer name="verticalSpacer">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
+       <item row="14" column="0">
+        <widget class="QLabel" name="labelNumUniqueTxIds">
+         <property name="text">
+          <string>unique transaction IDs</string>
          </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
+        </widget>
+       </item>
+       <item row="14" column="1">
+        <widget class="QLabel" name="numUniqueTxIds">
+         <property name="cursor">
+          <cursorShape>IBeamCursor</cursorShape>
          </property>
-        </spacer>
+         <property name="text">
+          <string>N/A</string>
+         </property>
+         <property name="textFormat">
+          <enum>Qt::PlainText</enum>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
        </item>
       </layout>
      </widget>

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -147,11 +147,6 @@ void OverviewPage::setBalance(qint64 balance, qint64 unconfirmedBalance, qint64 
     ui->labelImmatureText->setVisible(showImmature);
 }
 
-void OverviewPage::setNumTransactions(int count)
-{
-    ui->labelNumTransactions->setText(QLocale::system().toString(count));
-}
-
 void OverviewPage::setClientModel(ClientModel *model)
 {
     this->clientModel = model;
@@ -182,9 +177,6 @@ void OverviewPage::setWalletModel(WalletModel *model)
         // Keep up to date with wallet
         setBalance(model->getBalance(), model->getUnconfirmedBalance(), model->getImmatureBalance());
         connect(model, SIGNAL(balanceChanged(qint64, qint64, qint64)), this, SLOT(setBalance(qint64, qint64, qint64)));
-
-        setNumTransactions(model->getNumTransactions());
-        connect(model, SIGNAL(numTransactionsChanged(int)), this, SLOT(setNumTransactions(int)));
 
         connect(model->getOptionsModel(), SIGNAL(displayUnitChanged(int)), this, SLOT(updateDisplayUnit()));
     }

--- a/src/qt/overviewpage.h
+++ b/src/qt/overviewpage.h
@@ -30,7 +30,6 @@ public:
 
 public slots:
     void setBalance(qint64 balance, qint64 unconfirmedBalance, qint64 immatureBalance);
-    void setNumTransactions(int count);
 
 signals:
     void transactionClicked(const QModelIndex &index);

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -2,6 +2,7 @@
 #include "ui_rpcconsole.h"
 
 #include "clientmodel.h"
+#include "walletmodel.h"
 #include "bitcoinrpc.h"
 #include "guiutil.h"
 
@@ -187,6 +188,8 @@ void RPCExecutor::request(const QString &command)
 RPCConsole::RPCConsole(QWidget *parent) :
     QDialog(parent),
     ui(new Ui::RPCConsole),
+    clientModel(0),
+    walletModel(0),
     historyPtr(0)
 {
     ui->setupUi(this);
@@ -269,6 +272,17 @@ void RPCConsole::setClientModel(ClientModel *model)
 
         setNumConnections(model->getNumConnections());
         ui->isTestNet->setChecked(model->isTestNet());
+    }
+}
+
+void RPCConsole::setWalletModel(WalletModel *model)
+{
+    this->walletModel = model;
+    if(model)
+    {
+        // Subscribe to numTransactionsChanged() signal from wallet and provide initial value
+        connect(model, SIGNAL(numTransactionsChanged(int)), this, SLOT(setNumUniqueTxIds(int)));
+        setNumUniqueTxIds(model->getNumTransactions());
     }
 }
 
@@ -430,4 +444,9 @@ void RPCConsole::on_showCLOptionsButton_clicked()
 {
     GUIUtil::HelpMessageBox help;
     help.exec();
+}
+
+void RPCConsole::setNumUniqueTxIds(int count)
+{
+    ui->numUniqueTxIds->setText(QString::number(count));
 }

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -7,6 +7,7 @@ namespace Ui {
     class RPCConsole;
 }
 class ClientModel;
+class WalletModel;
 
 /** Local Bitcoin RPC console. */
 class RPCConsole: public QDialog
@@ -18,6 +19,7 @@ public:
     ~RPCConsole();
 
     void setClientModel(ClientModel *model);
+    void setWalletModel(WalletModel *model);
 
     enum MessageClass {
         MC_ERROR,
@@ -49,6 +51,9 @@ public slots:
     void browseHistory(int offset);
     /** Scroll console view to end */
     void scrollToEnd();
+    /** Set number of unique transaction IDs in wallet */
+    void setNumUniqueTxIds(int count);
+
 signals:
     // For RPC command executor
     void stopExecutor();
@@ -57,6 +62,7 @@ signals:
 private:
     Ui::RPCConsole *ui;
     ClientModel *clientModel;
+    WalletModel *walletModel;
     QStringList history;
     int historyPtr;
 

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -56,6 +56,8 @@ int WalletModel::getNumTransactions() const
     int numTransactions = 0;
     {
         LOCK(wallet->cs_wallet);
+        // the size of mapWallet contains the number of unique transaction IDs
+        // (e.g. payments to yourself generate 2 transactions, but both share the same transaction ID)
         numTransactions = wallet->mapWallet.size();
     }
     return numTransactions;


### PR DESCRIPTION
- Bitcoin-Qt: remove num transactions from overviewpage 
- Bitcoin-Qt: add wallet category and num unique tx IDs in dbg window

-- this adds a new Wallet category to the debug window and implements a
  label which contains the current unique transaction ID count from the
  wallet (wallet model access is added to RPCConsole class)
-- layout was converted from table to form and a spacer removed
-- I also added an initialisation of the model variables in RPCConsole
  class, these were missing before

I had the idea because of issue #2175 and it also seems nice to be able to access walletmodel from RPCConsole for further additions to the debug window.
