### PR TITLE
make bitcoinrpc.cpp UTF-8 conformant again

### DIFF
--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -176,7 +176,7 @@ Value help(const Array& params, bool fHelp)
 
 Value stop(const Array& params, bool fHelp)
 {
-    // Accept the deprecated and ignored 'detach´ boolean argument
+    // Accept the deprecated and ignored 'detach' boolean argument
     if (fHelp || params.size() > 1)
         throw runtime_error(
             "stop\n"


### PR DESCRIPTION
- just replaces a character in a comment, which I had problems with when
  opening the file in Qt Creator IDE
