### PR TITLE
Rework the clients thread priority handling

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -596,7 +596,7 @@ bool AppInit2()
     if (nScriptCheckThreads) {
         printf("Using %u threads for script verification\n", nScriptCheckThreads);
         for (int i=0; i<nScriptCheckThreads-1; i++)
-            NewThread(ThreadScriptCheck, NULL);
+            NewThread(ThreadScriptCheck, NULL, THREAD_PRIORITY_BELOW_NORMAL);
     }
 
     int64 nStart;
@@ -941,7 +941,7 @@ bool AppInit2()
         BOOST_FOREACH(string strFile, mapMultiArgs["-loadblock"])
             pimport->vFiles.push_back(strFile);
     }
-    NewThread(ThreadImport, pimport);
+    NewThread(ThreadImport, pimport, THREAD_PRIORITY_ABOVE_NORMAL);
 
     // ********************************************************* Step 10: load peers
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4402,7 +4402,6 @@ static int nLimitProcessors = -1;
 void static BitcoinMiner(CWallet *pwallet)
 {
     printf("BitcoinMiner started\n");
-    SetThreadPriority(THREAD_PRIORITY_LOWEST);
 
     // Make this thread recognisable as the mining thread
     RenameThread("bitcoin-miner");
@@ -4483,9 +4482,7 @@ void static BitcoinMiner(CWallet *pwallet)
                     pblock->nNonce = ByteReverse(nNonceFound);
                     assert(hash == pblock->GetHash());
 
-                    SetThreadPriority(THREAD_PRIORITY_NORMAL);
                     CheckWork(pblock, *pwalletMain, reservekey);
-                    SetThreadPriority(THREAD_PRIORITY_LOWEST);
                     break;
                 }
             }
@@ -4591,7 +4588,7 @@ void GenerateBitcoins(bool fGenerate, CWallet* pwallet)
         printf("Starting %d BitcoinMiner threads\n", nAddThreads);
         for (int i = 0; i < nAddThreads; i++)
         {
-            if (!NewThread(ThreadBitcoinMiner, pwallet))
+            if (!NewThread(ThreadBitcoinMiner, pwallet, THREAD_PRIORITY_BELOW_NORMAL))
                 printf("Error: NewThread(ThreadBitcoinMiner) failed\n");
             Sleep(10);
         }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1653,7 +1653,7 @@ void ThreadMessageHandler(void* parg)
 void ThreadMessageHandler2(void* parg)
 {
     printf("ThreadMessageHandler started\n");
-    SetThreadPriority(THREAD_PRIORITY_BELOW_NORMAL);
+
     while (!fShutdown)
     {
         vector<CNode*> vNodesCopy;
@@ -1923,7 +1923,7 @@ void StartNode(void* parg)
         printf("Error: NewThread(ThreadOpenConnections) failed\n");
 
     // Process messages
-    if (!NewThread(ThreadMessageHandler, NULL))
+    if (!NewThread(ThreadMessageHandler, NULL, THREAD_PRIORITY_BELOW_NORMAL))
         printf("Error: NewThread(ThreadMessageHandler) failed\n");
 
     // Dump network addresses

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -35,7 +35,7 @@ struct TestingSetup {
         RegisterWallet(pwalletMain);
         nScriptCheckThreads = 3;
         for (int i=0; i < nScriptCheckThreads-1; i++)
-            NewThread(ThreadScriptCheck, NULL);
+            NewThread(ThreadScriptCheck, NULL, THREAD_PRIORITY_BELOW_NORMAL);
     }
     ~TestingSetup()
     {

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1375,13 +1375,18 @@ void RenameThread(const char* name)
 #endif
 }
 
-bool NewThread(void(*pfn)(void*), void* parg)
+bool NewThread(void(*pfn)(void*), void* parg, int nPriority)
 {
     try
     {
-        boost::thread(pfn, parg); // thread detaches when out of scope
+        boost::thread newThread(pfn, parg); // thread detaches when out of scope
+#ifdef WIN32
+        bool bResult = SetThreadPriority(newThread.native_handle(), nPriority);
+        if (!bResult)
+            printf("NewThread() : Error setting thread priority to %i\n", nPriority);
+#endif
     } catch(boost::thread_resource_error &e) {
-        printf("Error creating thread: %s\n", e.what());
+        printf("NewThread() : Error creating thread: %s\n", e.what());
         return false;
     }
     return true;

--- a/src/util.h
+++ b/src/util.h
@@ -467,36 +467,21 @@ public:
     }
 };
 
-bool NewThread(void(*pfn)(void*), void* parg);
-
-#ifdef WIN32
-inline void SetThreadPriority(int nPriority)
-{
-    SetThreadPriority(GetCurrentThread(), nPriority);
-}
-#else
-
+#ifndef WIN32
+// These are here to prevent compilation failures because of missing defines for
+// non-Windows OSes and result in a no-op.
 #define THREAD_PRIORITY_LOWEST          PRIO_MAX
 #define THREAD_PRIORITY_BELOW_NORMAL    2
 #define THREAD_PRIORITY_NORMAL          0
-#define THREAD_PRIORITY_ABOVE_NORMAL    0
-
-inline void SetThreadPriority(int nPriority)
-{
-    // It's unclear if it's even possible to change thread priorities on Linux,
-    // but we really and truly need it for the generation threads.
-#ifdef PRIO_THREAD
-    setpriority(PRIO_THREAD, 0, nPriority);
-#else
-    setpriority(PRIO_PROCESS, 0, nPriority);
-#endif
-}
+#define THREAD_PRIORITY_ABOVE_NORMAL    (-2)
 
 inline void ExitThread(size_t nExitCode)
 {
     pthread_exit((void*)nExitCode);
 }
 #endif
+
+bool NewThread(void(*pfn)(void*), void* parg, int nPriority = THREAD_PRIORITY_NORMAL);
 
 void RenameThread(const char* name);
 
@@ -506,5 +491,4 @@ inline uint32_t ByteReverse(uint32_t value)
     return (value<<16) | (value>>16);
 }
 
-#endif
-
+#endif // BITCOIN_UTIL_H


### PR DESCRIPTION
This is just a suggestion to assist in re-thinking our current thread priorities and assists (IMHO) in easily setting priorities for threads during the creation time of the thread.

I chose to change some default thread priorities, which should also be considered to be part of a discussion. I'm currently using that code and can verify the internal miner did quite happily find new blocks ;).

That pull could be extended to give users the ability to set the default thread prio via command-line or GUI option.
- removes SetThreadPriority() and integrates that into NewThread() with a
  default of THREAD_PRIORITY_NORMAL
- removes special-casing (priority switching) for internal Bitcoin miner
- uses a new default for the following threads: ThreadScriptCheck (below
  normal - because normal prio threads on every CPU core could slowdown UX),
  ThreadImport (above normal - to speed it up a little) and
  ThreadBitcoinMiner (below normal - to compensate the removed special
  casing)
- removes thread priority code for non-Windows OSes, so these will just
  get a no-op
