### PR TITLE
Bitcoin-Qt: massive header and cpp cleanup

### DIFF
--- a/src/qt/addressbookpage.cpp
+++ b/src/qt/addressbookpage.cpp
@@ -8,14 +8,14 @@
 #include "csvmodelwriter.h"
 #include "guiutil.h"
 
+#ifdef USE_QRCODE
+#include "qrcodedialog.h"
+#endif
+
 #include <QSortFilterProxyModel>
 #include <QClipboard>
 #include <QMessageBox>
 #include <QMenu>
-
-#ifdef USE_QRCODE
-#include "qrcodedialog.h"
-#endif
 
 AddressBookPage::AddressBookPage(Mode mode, Tabs tab, QWidget *parent) :
     QDialog(parent),

--- a/src/qt/addresstablemodel.cpp
+++ b/src/qt/addresstablemodel.cpp
@@ -1,4 +1,5 @@
 #include "addresstablemodel.h"
+
 #include "guiutil.h"
 #include "walletmodel.h"
 
@@ -6,7 +7,6 @@
 #include "base58.h"
 
 #include <QFont>
-#include <QColor>
 
 const QString AddressTableModel::Send = "S";
 const QString AddressTableModel::Receive = "R";

--- a/src/qt/addresstablemodel.h
+++ b/src/qt/addresstablemodel.h
@@ -14,6 +14,7 @@ class WalletModel;
 class AddressTableModel : public QAbstractTableModel
 {
     Q_OBJECT
+
 public:
     explicit AddressTableModel(CWallet *wallet, WalletModel *parent = 0);
     ~AddressTableModel();

--- a/src/qt/askpassphrasedialog.h
+++ b/src/qt/askpassphrasedialog.h
@@ -6,7 +6,6 @@
 namespace Ui {
     class AskPassphraseDialog;
 }
-
 class WalletModel;
 
 /** Multifunctional dialog to ask for passphrases. Used for encryption, unlocking, and changing the passphrase.

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -1,6 +1,9 @@
 /*
  * W.J. van der Laan 2011-2012
  */
+
+#include <QApplication>
+
 #include "bitcoingui.h"
 #include "clientmodel.h"
 #include "walletmodel.h"
@@ -11,7 +14,6 @@
 #include "ui_interface.h"
 #include "paymentserver.h"
 
-#include <QApplication>
 #include <QMessageBox>
 #include <QTextCodec>
 #include <QLocale>

--- a/src/qt/bitcoin.qrc
+++ b/src/qt/bitcoin.qrc
@@ -1,4 +1,4 @@
-<RCC>
+<!DOCTYPE RCC><RCC version="1.0">
     <qresource prefix="/icons">
         <file alias="bitcoin">res/icons/bitcoin.png</file>
         <file alias="address-book">res/icons/address-book.png</file>

--- a/src/qt/bitcoinaddressvalidator.h
+++ b/src/qt/bitcoinaddressvalidator.h
@@ -1,7 +1,7 @@
 #ifndef BITCOINADDRESSVALIDATOR_H
 #define BITCOINADDRESSVALIDATOR_H
 
-#include <QRegExpValidator>
+#include <QValidator>
 
 /** Base48 entry widget validator.
    Corrects near-miss characters and refuses characters that are no part of base48.
@@ -9,16 +9,13 @@
 class BitcoinAddressValidator : public QValidator
 {
     Q_OBJECT
+
 public:
     explicit BitcoinAddressValidator(QObject *parent = 0);
 
     State validate(QString &input, int &pos) const;
 
     static const int MaxAddressLength = 35;
-signals:
-
-public slots:
-
 };
 
 #endif // BITCOINADDRESSVALIDATOR_H

--- a/src/qt/bitcoinamountfield.cpp
+++ b/src/qt/bitcoinamountfield.cpp
@@ -1,18 +1,14 @@
 #include "bitcoinamountfield.h"
+
 #include "qvaluecombobox.h"
 #include "bitcoinunits.h"
-
 #include "guiconstants.h"
 
-#include <QLabel>
-#include <QLineEdit>
-#include <QRegExpValidator>
 #include <QHBoxLayout>
 #include <QKeyEvent>
 #include <QDoubleSpinBox>
-#include <QComboBox>
 #include <QApplication>
-#include <qmath.h>
+#include <qmath.h> // for qPow()
 
 BitcoinAmountField::BitcoinAmountField(QWidget *parent):
         QWidget(parent), amount(0), currentUnit(-1)

--- a/src/qt/bitcoinamountfield.h
+++ b/src/qt/bitcoinamountfield.h
@@ -13,7 +13,9 @@ QT_END_NAMESPACE
 class BitcoinAmountField: public QWidget
 {
     Q_OBJECT
+
     Q_PROPERTY(qint64 value READ value WRITE setValue NOTIFY textChanged USER true)
+
 public:
     explicit BitcoinAmountField(QWidget *parent = 0);
 
@@ -55,6 +57,5 @@ private slots:
     void unitChanged(int idx);
 
 };
-
 
 #endif // BITCOINAMOUNTFIELD_H

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -4,7 +4,11 @@
  * W.J. van der Laan 2011-2012
  * The Bitcoin Developers 2011-2012
  */
+
+#include <QApplication>
+
 #include "bitcoingui.h"
+
 #include "transactiontablemodel.h"
 #include "addressbookpage.h"
 #include "sendcoinsdialog.h"
@@ -31,19 +35,13 @@
 #include "macdockiconhandler.h"
 #endif
 
-#include <QApplication>
-#include <QMainWindow>
 #include <QMenuBar>
 #include <QMenu>
 #include <QIcon>
-#include <QTabWidget>
 #include <QVBoxLayout>
 #include <QToolBar>
 #include <QStatusBar>
 #include <QLabel>
-#include <QLineEdit>
-#include <QPushButton>
-#include <QLocale>
 #include <QMessageBox>
 #include <QProgressBar>
 #include <QStackedWidget>
@@ -54,6 +52,7 @@
 #include <QTimer>
 #include <QDragEnterEvent>
 #include <QUrl>
+#include <QMimeData>
 #include <QStyle>
 
 #include <iostream>

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -17,13 +17,9 @@ class RPCConsole;
 
 QT_BEGIN_NAMESPACE
 class QLabel;
-class QLineEdit;
-class QTableView;
-class QAbstractItemModel;
 class QModelIndex;
 class QProgressBar;
 class QStackedWidget;
-class QUrl;
 QT_END_NAMESPACE
 
 /**
@@ -33,6 +29,7 @@ QT_END_NAMESPACE
 class BitcoinGUI : public QMainWindow
 {
     Q_OBJECT
+
 public:
     explicit BitcoinGUI(QWidget *parent = 0);
     ~BitcoinGUI();

--- a/src/qt/bitcoinunits.h
+++ b/src/qt/bitcoinunits.h
@@ -9,6 +9,8 @@
 */
 class BitcoinUnits: public QAbstractListModel
 {
+    Q_OBJECT
+
 public:
     explicit BitcoinUnits(QObject *parent);
 
@@ -58,6 +60,7 @@ public:
     int rowCount(const QModelIndex &parent) const;
     QVariant data(const QModelIndex &index, int role) const;
     ///@}
+
 private:
     QList<BitcoinUnits::Unit> unitlist;
 };

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -1,4 +1,5 @@
 #include "clientmodel.h"
+
 #include "guiconstants.h"
 #include "optionsmodel.h"
 #include "addresstablemodel.h"

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -24,6 +24,7 @@ enum BlockSource {
 class ClientModel : public QObject
 {
     Q_OBJECT
+
 public:
     explicit ClientModel(OptionsModel *optionsModel, QObject *parent = 0);
     ~ClientModel();
@@ -66,6 +67,7 @@ private:
 
     void subscribeToCoreSignals();
     void unsubscribeFromCoreSignals();
+
 signals:
     void numConnectionsChanged(int count);
     void numBlocksChanged(int count, int countOfPeers);

--- a/src/qt/csvmodelwriter.h
+++ b/src/qt/csvmodelwriter.h
@@ -14,6 +14,7 @@ QT_END_NAMESPACE
 class CSVModelWriter : public QObject
 {
     Q_OBJECT
+
 public:
     explicit CSVModelWriter(const QString &filename, QObject *parent = 0);
 
@@ -36,11 +37,6 @@ private:
         int role;
     };
     QList<Column> columns;
-
-signals:
-
-public slots:
-
 };
 
 #endif // CSVMODELWRITER_H

--- a/src/qt/editaddressdialog.cpp
+++ b/src/qt/editaddressdialog.cpp
@@ -1,5 +1,6 @@
 #include "editaddressdialog.h"
 #include "ui_editaddressdialog.h"
+
 #include "addresstablemodel.h"
 #include "guiutil.h"
 

--- a/src/qt/editaddressdialog.h
+++ b/src/qt/editaddressdialog.h
@@ -3,14 +3,14 @@
 
 #include <QDialog>
 
-QT_BEGIN_NAMESPACE
-class QDataWidgetMapper;
-QT_END_NAMESPACE
-
 namespace Ui {
     class EditAddressDialog;
 }
 class AddressTableModel;
+
+QT_BEGIN_NAMESPACE
+class QDataWidgetMapper;
+QT_END_NAMESPACE
 
 /** Dialog for editing an address and associated information.
  */

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -1,11 +1,14 @@
+#include <QApplication>
+
 #include "guiutil.h"
+
 #include "bitcoinaddressvalidator.h"
 #include "walletmodel.h"
 #include "bitcoinunits.h"
+
 #include "util.h"
 #include "init.h"
 
-#include <QString>
 #include <QDateTime>
 #include <QDoubleValidator>
 #include <QFont>
@@ -13,7 +16,6 @@
 #include <QUrl>
 #include <QTextDocument> // For Qt::escape
 #include <QAbstractItemView>
-#include <QApplication>
 #include <QClipboard>
 #include <QFileDialog>
 #include <QDesktopServices>

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -5,6 +5,8 @@
 #include <QObject>
 #include <QMessageBox>
 
+class SendCoinsRecipient;
+
 QT_BEGIN_NAMESPACE
 class QFont;
 class QLineEdit;
@@ -13,7 +15,6 @@ class QDateTime;
 class QUrl;
 class QAbstractItemView;
 QT_END_NAMESPACE
-class SendCoinsRecipient;
 
 /** Utility functions used by the Bitcoin Qt UI.
  */

--- a/src/qt/macdockiconhandler.h
+++ b/src/qt/macdockiconhandler.h
@@ -3,9 +3,11 @@
 
 #include <QObject>
 
+QT_BEGIN_NAMESPACE
 class QMenu;
 class QIcon;
 class QWidget;
+QT_END_NAMESPACE
 
 #ifdef __OBJC__
 @class DockIconClickEventHandler;
@@ -18,6 +20,7 @@ class DockIconClickEventHandler;
 class MacDockIconHandler : public QObject
 {
     Q_OBJECT
+
 public:
     ~MacDockIconHandler();
 
@@ -30,8 +33,6 @@ public:
 
 signals:
     void dockIconClicked();
-
-public slots:
 
 private:
     MacDockIconHandler();

--- a/src/qt/macdockiconhandler.mm
+++ b/src/qt/macdockiconhandler.mm
@@ -1,4 +1,3 @@
-
 #include "macdockiconhandler.h"
 
 #include <QMenu>

--- a/src/qt/monitoreddatamapper.cpp
+++ b/src/qt/monitoreddatamapper.cpp
@@ -9,7 +9,6 @@ MonitoredDataMapper::MonitoredDataMapper(QObject *parent) :
 {
 }
 
-
 void MonitoredDataMapper::addMapping(QWidget *widget, int section)
 {
     QDataWidgetMapper::addMapping(widget, section);

--- a/src/qt/monitoreddatamapper.h
+++ b/src/qt/monitoreddatamapper.h
@@ -13,19 +13,18 @@ QT_END_NAMESPACE
 class MonitoredDataMapper : public QDataWidgetMapper
 {
     Q_OBJECT
+
 public:
     explicit MonitoredDataMapper(QObject *parent=0);
 
     void addMapping(QWidget *widget, int section);
     void addMapping(QWidget *widget, int section, const QByteArray &propertyName);
+
 private:
     void addChangeMonitor(QWidget *widget);
 
 signals:
     void viewModified();
-
 };
-
-
 
 #endif // MONITOREDDATAMAPPER_H

--- a/src/qt/notificator.cpp
+++ b/src/qt/notificator.cpp
@@ -12,7 +12,7 @@
 #include <QImageWriter>
 
 #ifdef USE_DBUS
-#include <QtDBus/QtDBus>
+#include <QtDBus>
 #include <stdint.h>
 #endif
 

--- a/src/qt/notificator.h
+++ b/src/qt/notificator.h
@@ -15,6 +15,7 @@ QT_END_NAMESPACE
 class Notificator: public QObject
 {
     Q_OBJECT
+
 public:
     /** Create a new notificator.
        @note Ownership of trayIcon is not transferred to this object.
@@ -25,13 +26,12 @@ public:
     // Message class
     enum Class
     {
-        Information,         /**< Informational message */
-        Warning,             /**< Notify user of potential problem */
-        Critical             /**< An error occurred */
+        Information,    /**< Informational message */
+        Warning,        /**< Notify user of potential problem */
+        Critical        /**< An error occurred */
     };
 
 public slots:
-
     /** Show notification message.
        @param[in] cls    general message class
        @param[in] title  title shown with message

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -10,8 +10,6 @@
 #include <QIntValidator>
 #include <QLocale>
 #include <QMessageBox>
-#include <QRegExp>
-#include <QRegExpValidator>
 
 OptionsDialog::OptionsDialog(QWidget *parent) :
     QDialog(parent),

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -1,10 +1,11 @@
 #include "optionsmodel.h"
-#include "bitcoinunits.h"
-#include <QSettings>
 
+#include "bitcoinunits.h"
 #include "init.h"
 #include "walletdb.h"
 #include "guiutil.h"
+
+#include <QSettings>
 
 OptionsModel::OptionsModel(QObject *parent) :
     QAbstractListModel(parent)

--- a/src/qt/overviewpage.h
+++ b/src/qt/overviewpage.h
@@ -3,10 +3,6 @@
 
 #include <QWidget>
 
-QT_BEGIN_NAMESPACE
-class QModelIndex;
-QT_END_NAMESPACE
-
 namespace Ui {
     class OverviewPage;
 }
@@ -14,6 +10,10 @@ class ClientModel;
 class WalletModel;
 class TxViewDelegate;
 class TransactionFilterProxy;
+
+QT_BEGIN_NAMESPACE
+class QModelIndex;
+QT_END_NAMESPACE
 
 /** Overview ("home") page widget */
 class OverviewPage : public QWidget

--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -2,14 +2,15 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <QApplication>
+
 #include "paymentserver.h"
+
 #include "guiconstants.h"
 #include "ui_interface.h"
 #include "util.h"
 
-#include <QApplication>
 #include <QByteArray>
-#include <QCoreApplication>
 #include <QDataStream>
 #include <QDebug>
 #include <QFileOpenEvent>
@@ -59,7 +60,7 @@ bool PaymentServer::ipcSendCommandLine()
 {
     bool fResult = false;
 
-    const QStringList& args = QCoreApplication::arguments();
+    const QStringList& args = qApp->arguments();
     for (int i = 1; i < args.size(); i++)
     {
         if (!args[i].startsWith(BITCOIN_IPC_PREFIX, Qt::CaseInsensitive))

--- a/src/qt/qvalidatedlineedit.h
+++ b/src/qt/qvalidatedlineedit.h
@@ -9,6 +9,7 @@
 class QValidatedLineEdit : public QLineEdit
 {
     Q_OBJECT
+
 public:
     explicit QValidatedLineEdit(QWidget *parent = 0);
     void clear();

--- a/src/qt/qvaluecombobox.h
+++ b/src/qt/qvaluecombobox.h
@@ -8,7 +8,9 @@
 class QValueComboBox : public QComboBox
 {
     Q_OBJECT
+
     Q_PROPERTY(QVariant value READ value WRITE setValue NOTIFY valueChanged USER true)
+
 public:
     explicit QValueComboBox(QWidget *parent = 0);
 
@@ -20,8 +22,6 @@ public:
 
 signals:
     void valueChanged();
-
-public slots:
 
 private:
     int role;

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -6,9 +6,7 @@
 #include "guiutil.h"
 
 #include <QTime>
-#include <QTimer>
 #include <QThread>
-#include <QTextEdit>
 #include <QKeyEvent>
 #include <QUrl>
 #include <QScrollBar>
@@ -35,12 +33,14 @@ const struct {
 
 /* Object for executing console RPC commands in a separate thread.
 */
-class RPCExecutor: public QObject
+class RPCExecutor : public QObject
 {
     Q_OBJECT
+
 public slots:
     void start();
     void request(const QString &command);
+
 signals:
     void reply(int category, const QString &command);
 };

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -1,5 +1,6 @@
 #include "sendcoinsdialog.h"
 #include "ui_sendcoinsdialog.h"
+
 #include "walletmodel.h"
 #include "bitcoinunits.h"
 #include "addressbookpage.h"
@@ -10,7 +11,6 @@
 #include "base58.h"
 
 #include <QMessageBox>
-#include <QLocale>
 #include <QTextDocument>
 #include <QScrollBar>
 

--- a/src/qt/sendcoinsentry.cpp
+++ b/src/qt/sendcoinsentry.cpp
@@ -1,5 +1,6 @@
 #include "sendcoinsentry.h"
 #include "ui_sendcoinsentry.h"
+
 #include "guiutil.h"
 #include "bitcoinunits.h"
 #include "addressbookpage.h"

--- a/src/qt/signverifymessagedialog.cpp
+++ b/src/qt/signverifymessagedialog.cpp
@@ -10,10 +10,10 @@
 #include "walletmodel.h"
 #include "wallet.h"
 
+#include <QClipboard>
+
 #include <string>
 #include <vector>
-
-#include <QClipboard>
 
 SignVerifyMessageDialog::SignVerifyMessageDialog(QWidget *parent) :
     QDialog(parent),

--- a/src/qt/signverifymessagedialog.h
+++ b/src/qt/signverifymessagedialog.h
@@ -8,9 +8,6 @@ namespace Ui {
 }
 class WalletModel;
 
-QT_BEGIN_NAMESPACE
-QT_END_NAMESPACE
-
 class SignVerifyMessageDialog : public QDialog
 {
     Q_OBJECT

--- a/src/qt/test/uritests.cpp
+++ b/src/qt/test/uritests.cpp
@@ -4,15 +4,6 @@
 
 #include <QUrl>
 
-/*
-struct SendCoinsRecipient
-{
-    QString address;
-    QString label;
-    qint64 amount;
-};
-*/
-
 void URITests::uriTests()
 {
     SendCoinsRecipient rv;

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -2,12 +2,13 @@
 
 #include "guiutil.h"
 #include "bitcoinunits.h"
-
 #include "main.h"
 #include "wallet.h"
 #include "db.h"
 #include "ui_interface.h"
 #include "base58.h"
+
+#include <string>
 
 QString TransactionDesc::FormatTxStatus(const CWalletTx& wtx)
 {

--- a/src/qt/transactiondesc.h
+++ b/src/qt/transactiondesc.h
@@ -3,7 +3,6 @@
 
 #include <QString>
 #include <QObject>
-#include <string>
 
 class CWallet;
 class CWalletTx;
@@ -13,8 +12,10 @@ class CWalletTx;
 class TransactionDesc: public QObject
 {
     Q_OBJECT
+
 public:
     static QString toHTML(CWallet *wallet, CWalletTx &wtx);
+
 private:
     TransactionDesc() {}
 

--- a/src/qt/transactiondescdialog.h
+++ b/src/qt/transactiondescdialog.h
@@ -6,6 +6,7 @@
 namespace Ui {
     class TransactionDescDialog;
 }
+
 QT_BEGIN_NAMESPACE
 class QModelIndex;
 QT_END_NAMESPACE

--- a/src/qt/transactionfilterproxy.cpp
+++ b/src/qt/transactionfilterproxy.cpp
@@ -1,4 +1,5 @@
 #include "transactionfilterproxy.h"
+
 #include "transactiontablemodel.h"
 
 #include <QDateTime>

--- a/src/qt/transactionfilterproxy.h
+++ b/src/qt/transactionfilterproxy.h
@@ -8,6 +8,7 @@
 class TransactionFilterProxy : public QSortFilterProxyModel
 {
     Q_OBJECT
+
 public:
     explicit TransactionFilterProxy(QObject *parent = 0);
 
@@ -32,6 +33,7 @@ public:
     void setLimit(int limit);
 
     int rowCount(const QModelIndex &parent = QModelIndex()) const;
+
 protected:
     bool filterAcceptsRow(int source_row, const QModelIndex & source_parent) const;
 
@@ -42,11 +44,6 @@ private:
     quint32 typeFilter;
     qint64 minAmount;
     int limitRows;
-
-signals:
-
-public slots:
-
 };
 
 #endif // TRANSACTIONFILTERPROXY_H

--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -14,8 +14,8 @@ class TransactionStatus
 {
 public:
     TransactionStatus():
-            confirmed(false), sortKey(""), maturity(Mature),
-            matures_in(0), status(Offline), depth(0), open_for(0), cur_num_blocks(-1)
+        confirmed(false), sortKey(""), maturity(Mature),
+        matures_in(0), status(Offline), depth(0), open_for(0), cur_num_blocks(-1)
     { }
 
     enum Maturity

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -1,4 +1,5 @@
 #include "transactiontablemodel.h"
+
 #include "guiutil.h"
 #include "transactionrecord.h"
 #include "guiconstants.h"
@@ -11,13 +12,11 @@
 #include "wallet.h"
 #include "ui_interface.h"
 
-#include <QLocale>
 #include <QList>
 #include <QColor>
 #include <QTimer>
 #include <QIcon>
 #include <QDateTime>
-#include <QtAlgorithms>
 
 // Amount column is right-aligned it contains numbers
 static int column_alignments[] = {

--- a/src/qt/transactiontablemodel.h
+++ b/src/qt/transactiontablemodel.h
@@ -14,6 +14,7 @@ class WalletModel;
 class TransactionTableModel : public QAbstractTableModel
 {
     Q_OBJECT
+
 public:
     explicit TransactionTableModel(CWallet* wallet, WalletModel *parent = 0);
     ~TransactionTableModel();
@@ -55,6 +56,7 @@ public:
     QVariant data(const QModelIndex &index, int role) const;
     QVariant headerData(int section, Qt::Orientation orientation, int role) const;
     QModelIndex index(int row, int column, const QModelIndex & parent = QModelIndex()) const;
+
 private:
     CWallet* wallet;
     WalletModel *walletModel;

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -20,12 +20,9 @@
 #include <QLineEdit>
 #include <QTableView>
 #include <QHeaderView>
-#include <QPushButton>
 #include <QMessageBox>
 #include <QPoint>
 #include <QMenu>
-#include <QApplication>
-#include <QClipboard>
 #include <QLabel>
 #include <QDateTimeEdit>
 
@@ -173,16 +170,11 @@ void TransactionView::setModel(WalletModel *model)
         transactionView->sortByColumn(TransactionTableModel::Status, Qt::DescendingOrder);
         transactionView->verticalHeader()->hide();
 
-        transactionView->horizontalHeader()->resizeSection(
-                TransactionTableModel::Status, 23);
-        transactionView->horizontalHeader()->resizeSection(
-                TransactionTableModel::Date, 120);
-        transactionView->horizontalHeader()->resizeSection(
-                TransactionTableModel::Type, 120);
-        transactionView->horizontalHeader()->setResizeMode(
-                TransactionTableModel::ToAddress, QHeaderView::Stretch);
-        transactionView->horizontalHeader()->resizeSection(
-                TransactionTableModel::Amount, 100);
+        transactionView->horizontalHeader()->resizeSection(TransactionTableModel::Status, 23);
+        transactionView->horizontalHeader()->resizeSection(TransactionTableModel::Date, 120);
+        transactionView->horizontalHeader()->resizeSection(TransactionTableModel::Type, 120);
+        transactionView->horizontalHeader()->setResizeMode(TransactionTableModel::ToAddress, QHeaderView::Stretch);
+        transactionView->horizontalHeader()->resizeSection(TransactionTableModel::Amount, 100);
     }
 }
 

--- a/src/qt/transactionview.h
+++ b/src/qt/transactionview.h
@@ -22,6 +22,7 @@ QT_END_NAMESPACE
 class TransactionView : public QWidget
 {
     Q_OBJECT
+
 public:
     explicit TransactionView(QWidget *parent = 0);
 

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -26,6 +26,7 @@ public:
 class WalletModel : public QObject
 {
     Q_OBJECT
+
 public:
     explicit WalletModel(CWallet *wallet, OptionsModel *optionsModel, QObject *parent = 0);
     ~WalletModel();
@@ -160,6 +161,5 @@ public slots:
     /* Current, immature or unconfirmed balance might have changed - emit 'balanceChanged' if so */
     void pollBalanceChanged();
 };
-
 
 #endif // WALLETMODEL_H


### PR DESCRIPTION
This pull is currently here to see how pull-tester is handling it. To really be sure I didn't break something, this pull should be sent through a Gitian build.

I tried to harmonize the layout / style in all changed files. The QApplication moved to top in bitcoin.cpp and bitcoingui.cpp is related to Qt5 compatibility, I need to see if this is working correctly before I start doing my Qt5 compatibility pull.

@laanwj I know this has the potential to make you angry (:-P)or at least may steal some of your time, but in the end it should be well worth it. I even think removed includes could speed up compilation time a little :).
- try to enforce the same style to all Qt related files
- remove unneeded includes from the files
- add missing Q_OBJECT, QT_BEGIN_NAMESPACE / QT_END_NAMESPACE
- prepares for a pull-req to include Qt5 compatibility
