### PR TITLE
make qmake accept pre-defined --param options

### DIFF
--- a/bitcoin-qt.pro
+++ b/bitcoin-qt.pro
@@ -35,8 +35,8 @@ contains(RELEASE, 1) {
 
 !win32 {
 # for extra security against potential buffer overflows: enable GCCs Stack Smashing Protection
-QMAKE_CXXFLAGS *= -fstack-protector-all
-QMAKE_LFLAGS *= -fstack-protector-all
+QMAKE_CXXFLAGS *= -fstack-protector-all "--param ssp-buffer-size=1"
+QMAKE_LFLAGS *= -fstack-protector-all "--param ssp-buffer-size=1"
 # We need to exclude this for Windows cross compile with MinGW 4.2.x, as it will result in a non-working executable!
 # This can be enabled for Windows, when we switch to MinGW >= 4.4.x.
 }


### PR DESCRIPTION
This fixes qmake-breakage in case the build-system has other --param options pre-defined in its CFLAGS.
