### PR TITLE
Bitcoin-Qt: disable addressbook button when an addr is valid

### DIFF
--- a/src/qt/sendcoinsentry.cpp
+++ b/src/qt/sendcoinsentry.cpp
@@ -8,6 +8,8 @@
 #include "optionsmodel.h"
 #include "addresstablemodel.h"
 
+#include "base58.h" // for CBitcoinAddress
+
 #include <QApplication>
 #include <QClipboard>
 
@@ -60,6 +62,14 @@ void SendCoinsEntry::on_payTo_textChanged(const QString &address)
 {
     if(!model)
         return;
+
+    // enable addressBookButton on invalid address and disable otherwise
+    CBitcoinAddress addr(ui->payTo->text().toStdString());
+    if (!addr.IsValid())
+        ui->addressBookButton->setEnabled(true);
+    else
+        ui->addressBookButton->setEnabled(false);
+
     // Fill in label from address book, if address has an associated label
     QString associatedLabel = model->getAddressTableModel()->labelForAddress(address);
     if(!associatedLabel.isEmpty())

--- a/src/qt/signverifymessagedialog.cpp
+++ b/src/qt/signverifymessagedialog.cpp
@@ -171,6 +171,16 @@ void SignVerifyMessageDialog::on_clearButton_SM_clicked()
     ui->addressIn_SM->setFocus();
 }
 
+void SignVerifyMessageDialog::on_addressIn_SM_textChanged()
+{
+    CBitcoinAddress addr(ui->addressIn_SM->text().toStdString());
+    // enable addressBookButton on invalid address and disable otherwise
+    if (!addr.IsValid())
+        ui->addressBookButton_SM->setEnabled(true);
+    else
+        ui->addressBookButton_SM->setEnabled(false);
+}
+
 void SignVerifyMessageDialog::on_addressBookButton_VM_clicked()
 {
     if (model && model->getAddressTableModel())
@@ -246,6 +256,16 @@ void SignVerifyMessageDialog::on_clearButton_VM_clicked()
     ui->statusLabel_VM->clear();
 
     ui->addressIn_VM->setFocus();
+}
+
+void SignVerifyMessageDialog::on_addressIn_VM_textChanged()
+{
+    CBitcoinAddress addr(ui->addressIn_VM->text().toStdString());
+    // enable addressBookButton on invalid address and disable otherwise
+    if (!addr.IsValid())
+        ui->addressBookButton_VM->setEnabled(true);
+    else
+        ui->addressBookButton_VM->setEnabled(true);
 }
 
 bool SignVerifyMessageDialog::eventFilter(QObject *object, QEvent *event)

--- a/src/qt/signverifymessagedialog.h
+++ b/src/qt/signverifymessagedialog.h
@@ -37,10 +37,12 @@ private slots:
     void on_signMessageButton_SM_clicked();
     void on_copySignatureButton_SM_clicked();
     void on_clearButton_SM_clicked();
+    void on_addressIn_SM_textChanged();
     /* verify message */
     void on_addressBookButton_VM_clicked();
     void on_verifyMessageButton_VM_clicked();
     void on_clearButton_VM_clicked();
+    void on_addressIn_VM_textChanged();
 };
 
 #endif // SIGNVERIFYMESSAGEDIALOG_H


### PR DESCRIPTION
- this change is active for sendcoinsentry and signverifymessagedialog
- it disables the addressbook button, when an entered address is a valid
  Bitcoin address (it gets re-enabled when that case changes)

Partly related to #2218.
