### PR TITLE
Two cleanups before 0.8

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -814,21 +814,11 @@ public:
         uint256 hashChecksum;
         try {
             filein >> *this;
+            filein >> hashChecksum;
         }
         catch (std::exception &e) {
             return error("%s() : deserialize or I/O error", __PRETTY_FUNCTION__);
         }
-
-        // for compatibility with pre-release code that didn't write checksums to undo data
-        // TODO: replace by a simply 'filein >> hashChecksum' in the above try block
-        try {
-            filein >> hashChecksum;
-        } catch (std::exception &e) {
-            hashChecksum = 0;
-        }
-        uint32_t hashInit = hashChecksum.Get64(0) & 0xFFFFFFFFUL;
-        if (hashChecksum == 0 || memcmp(&hashInit, pchMessageStart, 4) == 0)
-            return true;
 
         // Verify checksum
         CHashWriter hasher(SER_GETHASH, PROTOCOL_VERSION);

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -19,7 +19,7 @@ void static BatchWriteHashBestChain(CLevelDBBatch &batch, const uint256 &hash) {
     batch.Write('B', hash);
 }
 
-CCoinsViewDB::CCoinsViewDB(size_t nCacheSize, bool fMemory, bool fWipe) : db(GetDataDir() / "coins", nCacheSize, fMemory, fWipe) {
+CCoinsViewDB::CCoinsViewDB(size_t nCacheSize, bool fMemory, bool fWipe) : db(GetDataDir() / "chainstate", nCacheSize, fMemory, fWipe) {
 }
 
 bool CCoinsViewDB::GetCoins(uint256 txid, CCoins &coins) { 
@@ -64,7 +64,7 @@ bool CCoinsViewDB::BatchWrite(const std::map<uint256, CCoins> &mapCoins, CBlockI
     return db.WriteBatch(batch);
 }
 
-CBlockTreeDB::CBlockTreeDB(size_t nCacheSize, bool fMemory, bool fWipe) : CLevelDB(GetDataDir() / "blktree", nCacheSize, fMemory, fWipe) {
+CBlockTreeDB::CBlockTreeDB(size_t nCacheSize, bool fMemory, bool fWipe) : CLevelDB(GetDataDir() / "blocks" / "index", nCacheSize, fMemory, fWipe) {
 }
 
 bool CBlockTreeDB::WriteBlockIndex(const CDiskBlockIndex& blockindex)

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -8,7 +8,7 @@
 #include "main.h"
 #include "leveldb.h"
 
-/** CCoinsView backed by the LevelDB coin database (coins/) */
+/** CCoinsView backed by the LevelDB coin database (chainstate/) */
 class CCoinsViewDB : public CCoinsView
 {
 protected:
@@ -25,7 +25,7 @@ public:
     bool GetStats(CCoinsStats &stats);
 };
 
-/** Access to the block database (blktree/) */
+/** Access to the block database (blocks/index/) */
 class CBlockTreeDB : public CLevelDB
 {
 public:


### PR DESCRIPTION
- Rename database directories (blocks/index/ and chainstate/)
- Remove support for pre-checksum undo files
