### PR TITLE
Support for building against system LevelDB

### DIFF
--- a/bitcoin-qt.pro
+++ b/bitcoin-qt.pro
@@ -99,6 +99,9 @@ contains(BITCOIN_NEED_QT_PLUGINS, 1) {
     QTPLUGIN += qcncodecs qjpcodecs qtwcodecs qkrcodecs qtaccessiblewidgets
 }
 
+contains(USE_SYSTEM_LEVELDB, 1) {
+    LIBS += -lleveldb
+} else {
 INCLUDEPATH += src/leveldb/include src/leveldb/helpers
 LIBS += $$PWD/src/leveldb/libleveldb.a
 !win32 {
@@ -116,8 +119,9 @@ genleveldb.target = $$PWD/src/leveldb/libleveldb.a
 genleveldb.depends = FORCE
 PRE_TARGETDEPS += $$PWD/src/leveldb/libleveldb.a
 QMAKE_EXTRA_TARGETS += genleveldb
+}
 # Gross ugly hack that depends on qmake internals, unfortunately there is no other way to do it.
-QMAKE_CLEAN += $$PWD/src/leveldb/libleveldb.a; cd $$PWD/src/leveldb ; $(MAKE) clean
+QMAKE_CLEAN += $$PWD/src/leveldb/libleveldb.a; cd $$PWD/src/leveldb && $(MAKE) clean || true
 
 # regenerate src/build.h
 !win32|contains(USE_BUILD_INFO, 1) {

--- a/bitcoin-qt.pro
+++ b/bitcoin-qt.pro
@@ -5,7 +5,7 @@ VERSION = 0.8.2
 INCLUDEPATH += src src/json src/qt
 QT += core gui network
 greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
-DEFINES += BOOST_THREAD_USE_LIB BOOST_SPIRIT_THREADSAFE
+DEFINES += BOOST_THREAD_USE_LIB BOOST_SPIRIT_THREADSAFE LEVELDB_WITHOUT_MEMENV
 CONFIG += no_include_pwd
 CONFIG += thread
 
@@ -100,17 +100,17 @@ contains(BITCOIN_NEED_QT_PLUGINS, 1) {
 }
 
 INCLUDEPATH += src/leveldb/include src/leveldb/helpers
-LIBS += $$PWD/src/leveldb/libleveldb.a $$PWD/src/leveldb/libmemenv.a
+LIBS += $$PWD/src/leveldb/libleveldb.a
 !win32 {
     # we use QMAKE_CXXFLAGS_RELEASE even without RELEASE=1 because we use RELEASE to indicate linking preferences not -O preferences
-    genleveldb.commands = cd $$PWD/src/leveldb && CC=$$QMAKE_CC CXX=$$QMAKE_CXX $(MAKE) OPT=\"$$QMAKE_CXXFLAGS $$QMAKE_CXXFLAGS_RELEASE\" libleveldb.a libmemenv.a
+    genleveldb.commands = cd $$PWD/src/leveldb && CC=$$QMAKE_CC CXX=$$QMAKE_CXX $(MAKE) OPT=\"$$QMAKE_CXXFLAGS $$QMAKE_CXXFLAGS_RELEASE\" libleveldb.a
 } else {
     # make an educated guess about what the ranlib command is called
     isEmpty(QMAKE_RANLIB) {
         QMAKE_RANLIB = $$replace(QMAKE_STRIP, strip, ranlib)
     }
     LIBS += -lshlwapi
-    genleveldb.commands = cd $$PWD/src/leveldb && CC=$$QMAKE_CC CXX=$$QMAKE_CXX TARGET_OS=OS_WINDOWS_CROSSCOMPILE $(MAKE) OPT=\"$$QMAKE_CXXFLAGS $$QMAKE_CXXFLAGS_RELEASE\" libleveldb.a libmemenv.a && $$QMAKE_RANLIB $$PWD/src/leveldb/libleveldb.a && $$QMAKE_RANLIB $$PWD/src/leveldb/libmemenv.a
+    genleveldb.commands = cd $$PWD/src/leveldb && CC=$$QMAKE_CC CXX=$$QMAKE_CXX TARGET_OS=OS_WINDOWS_CROSSCOMPILE $(MAKE) OPT=\"$$QMAKE_CXXFLAGS $$QMAKE_CXXFLAGS_RELEASE\" libleveldb.a && $$QMAKE_RANLIB $$PWD/src/leveldb/libleveldb.a
 }
 genleveldb.target = $$PWD/src/leveldb/libleveldb.a
 genleveldb.depends = FORCE

--- a/src/leveldb.cpp
+++ b/src/leveldb.cpp
@@ -9,7 +9,7 @@
 #include <leveldb/cache.h>
 #include <leveldb/filter_policy.h>
 #ifndef LEVELDB_WITHOUT_MEMENV
-#include <memenv/memenv.h>
+#include <memenv.h>
 #endif
 
 #include <boost/filesystem.hpp>

--- a/src/leveldb.cpp
+++ b/src/leveldb.cpp
@@ -8,7 +8,9 @@
 #include <leveldb/env.h>
 #include <leveldb/cache.h>
 #include <leveldb/filter_policy.h>
+#ifndef LEVELDB_WITHOUT_MEMENV
 #include <memenv/memenv.h>
+#endif
 
 #include <boost/filesystem.hpp>
 
@@ -43,8 +45,12 @@ CLevelDB::CLevelDB(const boost::filesystem::path &path, size_t nCacheSize, bool 
     options = GetOptions(nCacheSize);
     options.create_if_missing = true;
     if (fMemory) {
+#ifndef LEVELDB_WITHOUT_MEMENV
         penv = leveldb::NewMemEnv(leveldb::Env::Default());
         options.env = penv;
+#else
+        throw std::runtime_error("CLevelDB(): compiled without memenv support");
+#endif
     } else {
         if (fWipe) {
             printf("Wiping LevelDB in %s\n", path.string().c_str());

--- a/src/makefile.unix
+++ b/src/makefile.unix
@@ -159,6 +159,10 @@ all: bitcoind
 test check: test_bitcoin FORCE
 	./test_bitcoin
 
+ifdef USE_SYSTEM_LEVELDB
+    LIBS += -lleveldb
+    TESTLIBS += -lmemenv
+else
 #
 # LevelDB support
 #
@@ -166,13 +170,14 @@ MAKEOVERRIDES =
 LIBS += $(CURDIR)/leveldb/libleveldb.a
 TESTLIBS += $(CURDIR)/leveldb/libmemenv.a
 DEFS += $(addprefix -I,$(CURDIR)/leveldb/include)
-DEFS += $(addprefix -I,$(CURDIR)/leveldb/helpers)
+DEFS += $(addprefix -I,$(CURDIR)/leveldb/helpers/memenv)
 leveldb/libleveldb.a:
 	@echo "Building LevelDB ..." && cd leveldb && $(MAKE) CC=$(CC) CXX=$(CXX) OPT="$(xCXXFLAGS)" libleveldb.a && cd ..
 leveldb/libmemenv.a:
 	@echo "Building LevelDB memenv ..." && cd leveldb && $(MAKE) CC=$(CC) CXX=$(CXX) OPT="$(xCXXFLAGS)" libmemenv.a && cd ..
 OBJS += leveldb/libleveldb.a
 TESTOBJS += leveldb/libmemenv.a
+endif
 
 # auto-generated dependencies:
 -include obj/*.P

--- a/src/makefile.unix
+++ b/src/makefile.unix
@@ -110,8 +110,7 @@ xCXXFLAGS=-O2 -pthread -Wall -Wextra -Wformat -Wformat-security -Wno-unused-para
 # adds some defaults in front. Unfortunately, LDFLAGS=... $(LDFLAGS) does not work.
 xLDFLAGS=$(LDHARDENING) $(LDFLAGS)
 
-OBJS= \
-    leveldb/libleveldb.a \
+BASEOBJS := \
     obj/alert.o \
     obj/version.o \
     obj/checkpoints.o \
@@ -120,8 +119,6 @@ OBJS= \
     obj/crypter.o \
     obj/key.o \
     obj/db.o \
-    obj/init.o \
-    obj/bitcoind.o \
     obj/keystore.o \
     obj/core.o \
     obj/main.o \
@@ -142,9 +139,19 @@ OBJS= \
     obj/hash.o \
     obj/bloom.o \
     obj/noui.o \
-    obj/leveldb.o \
     obj/txdb.o \
     obj/chainparams.o
+
+OBJS := \
+    obj/leveldb.o \
+    obj/init.o \
+    obj/bitcoind.o \
+    $(BASEOBJS)
+
+TESTOBJS := \
+    obj-test/leveldb.o \
+    $(patsubst test/%.cpp,obj-test/%.o,$(wildcard test/*.cpp)) \
+    $(BASEOBJS)
 
 
 all: bitcoind
@@ -156,11 +163,16 @@ test check: test_bitcoin FORCE
 # LevelDB support
 #
 MAKEOVERRIDES =
-LIBS += $(CURDIR)/leveldb/libleveldb.a $(CURDIR)/leveldb/libmemenv.a
+LIBS += $(CURDIR)/leveldb/libleveldb.a
+TESTLIBS += $(CURDIR)/leveldb/libmemenv.a
 DEFS += $(addprefix -I,$(CURDIR)/leveldb/include)
 DEFS += $(addprefix -I,$(CURDIR)/leveldb/helpers)
 leveldb/libleveldb.a:
-	@echo "Building LevelDB ..." && cd leveldb && $(MAKE) CC=$(CC) CXX=$(CXX) OPT="$(xCXXFLAGS)" libleveldb.a libmemenv.a && cd ..
+	@echo "Building LevelDB ..." && cd leveldb && $(MAKE) CC=$(CC) CXX=$(CXX) OPT="$(xCXXFLAGS)" libleveldb.a && cd ..
+leveldb/libmemenv.a:
+	@echo "Building LevelDB memenv ..." && cd leveldb && $(MAKE) CC=$(CC) CXX=$(CXX) OPT="$(xCXXFLAGS)" libmemenv.a && cd ..
+OBJS += leveldb/libleveldb.a
+TESTOBJS += leveldb/libmemenv.a
 
 # auto-generated dependencies:
 -include obj/*.P
@@ -171,26 +183,28 @@ obj/build.h: FORCE
 version.cpp: obj/build.h
 DEFS += -DHAVE_BUILD_INFO
 
-obj/%.o: %.cpp
-	$(CXX) -c $(xCXXFLAGS) -MMD -MF $(@:%.o=%.d) -o $@ $<
+P_TO_D = \
 	@cp $(@:%.o=%.d) $(@:%.o=%.P); \
-	  sed -e 's/#.*//' -e 's/^[^:]*: *//' -e 's/ *\\$$//' \
+	  sed -e 's/\#.*//' -e 's/^[^:]*: *//' -e 's/ *\\$$//' \
 	      -e '/^$$/ d' -e 's/$$/ :/' < $(@:%.o=%.d) >> $(@:%.o=%.P); \
 	  rm -f $(@:%.o=%.d)
 
-bitcoind: $(OBJS:obj/%=obj/%)
-	$(LINK) $(xCXXFLAGS) -o $@ $^ $(xLDFLAGS) $(LIBS)
+obj/%.o: %.cpp
+	$(CXX) -c $(xCXXFLAGS) -DLEVELDB_WITHOUT_MEMENV -MMD -MF $(@:%.o=%.d) -o $@ $<
+	$(P_TO_D)
 
-TESTOBJS := $(patsubst test/%.cpp,obj-test/%.o,$(wildcard test/*.cpp))
+bitcoind: $(OBJS)
+	$(LINK) $(xCXXFLAGS) -o $@ $^ $(xLDFLAGS) $(LIBS)
 
 obj-test/%.o: test/%.cpp
 	$(CXX) -c $(TESTDEFS) $(xCXXFLAGS) -MMD -MF $(@:%.o=%.d) -o $@ $<
-	@cp $(@:%.o=%.d) $(@:%.o=%.P); \
-	  sed -e 's/#.*//' -e 's/^[^:]*: *//' -e 's/ *\\$$//' \
-	      -e '/^$$/ d' -e 's/$$/ :/' < $(@:%.o=%.d) >> $(@:%.o=%.P); \
-	  rm -f $(@:%.o=%.d)
+	$(P_TO_D)
 
-test_bitcoin: $(TESTOBJS) $(filter-out obj/init.o obj/bitcoind.o,$(OBJS:obj/%=obj/%))
+obj-test/leveldb.o: leveldb.cpp
+	$(CXX) -c $(TESTDEFS) $(xCXXFLAGS) -MMD -MF $(@:%.o=%.d) -o $@ $<
+	$(P_TO_D)
+
+test_bitcoin: $(TESTOBJS)
 	$(LINK) $(xCXXFLAGS) -o $@ $(LIBPATHS) $^ $(TESTLIBS) $(xLDFLAGS) $(LIBS)
 
 clean:


### PR DESCRIPTION
**Status**: Tests succeed, looks complete.

This is based on top of #2243 (LevelDB build bugfixes).

This is necessary for proper downstream distro packaging, and useful for people who have LevelDB installed for other reasons anyway. Undocumented to infer an unsupported status, but I could add a brief blurb if that's desirable. Only implemented for Linux (ie, not makefile.<not-unix>) for now - I assume OSX and Windows won't be packaging LevelDB/Bitcoin themselves anytime soon. Note that this does NOT remove the copied leveldb from the code, and will still build with that by default.

**To test with system LevelDB:**
1) Optional: Delete or move src/leveldb so any attempt to use it errors explicitly
2) Install LevelDB on your system as a shared library
3) qmake bitcoin-qt.pro USE_SYSTEM_LEVELDB=1 && make
4) cd src
5) make -f makefile.unix USE_SYSTEM_LEVELDB=1 bitcoind
6) make -f makefile.unix USE_SYSTEM_LEVELDB=1 test_bitcoin

Step 6 (test_bitcoin) will fail if your system LevelDB does not support memenv. This is expected behaviour.

**To test included LevelDB still works:**
1) Restore src/leveldb
2) Remove system LevelDB library/package
3) qmake bitcoin-qt.pro && make
4) cd src
5) make -f makefile.unix bitcoind
6) make -f makefile.unix test_bitcoin

**SIDE EFFECT:**
Bitcoin-Qt and bitcoind no longer include the LevelDB memenv module (only test_bitcoin uses it) - saves 423 KB
