### PR TITLE
Prevent Qt crash at startup with an empty data directory

### DIFF
--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -48,7 +48,10 @@ int ClientModel::getNumBlocksAtStartup()
 
 QDateTime ClientModel::getLastBlockDate() const
 {
-    return QDateTime::fromTime_t(pindexBest->GetBlockTime());
+    if (pindexBest)
+        return QDateTime::fromTime_t(pindexBest->GetBlockTime());
+    else
+        return QDateTime::fromTime_t(1231006505); // Genesis block's time
 }
 
 void ClientModel::updateTimer()


### PR DESCRIPTION
Fixes issue #2239 -- return the main network genesis block time if pindexBest has not yet been set.
