### PR TITLE
Do not call ResendWalletTransactions during reindex

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3793,7 +3793,10 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
         }
 
         // Resend wallet transactions that haven't gotten in a block yet
-        ResendWalletTransactions();
+        if (!fReindex)
+        {
+            ResendWalletTransactions();
+        }
 
         // Address refresh broadcast
         static int64 nLastRebroadcast;


### PR DESCRIPTION
Calling ResendWalletTransactions during a reindex spams other
nodes with our old transactions, because they become unconfirmed.
