### PR TITLE
Update default URL in verify.sh

### DIFF
--- a/contrib/macdeploy/notes.txt
+++ b/contrib/macdeploy/notes.txt
@@ -5,7 +5,7 @@ Python 2.7 and make it your default Python installation.
 You will need the appscript package for the fancy disk image creation to work.
 Install it by invoking "sudo easy_install appscript".
 
-Ths script should be invoked in the target directory like this:
+This script should be invoked in the target directory like this:
 $source_dir/contrib/macdeploy/macdeployqtplus Bitcoin-Qt.app -add-qt-tr da,de,es,hu,ru,uk,zh_CN,zh_TW -dmg -fancy $source_dir/contrib/macdeploy/fancy.plist -verbose 2
 
 During the process, the disk image window will pop up briefly where the fancy

--- a/contrib/verifysfbinaries/verify.sh
+++ b/contrib/verifysfbinaries/verify.sh
@@ -18,7 +18,7 @@ WORKINGDIR="/tmp/bitcoin"
 TMPFILE="hashes.tmp"
 
 #this URL is used if a version number is not specified as an argument to the script
-SIGNATUREFILE="http://downloads.sourceforge.net/project/bitcoin/Bitcoin/bitcoin-0.7.1/test/SHA256SUMS.asc"
+SIGNATUREFILE="http://downloads.sourceforge.net/project/bitcoin/Bitcoin/bitcoin-0.7.2/SHA256SUMS.asc"
 
 SIGNATUREFILENAME="SHA256SUMS.asc"
 RCSUBDIR="test/"
@@ -81,7 +81,7 @@ if [ $RET -ne 0 ]; then
       #and notify the user if it's bad
       echo "Bad signature."
    elif [ $RET -eq 2 ]; then
-      #or if a gpg error has occured
+      #or if a gpg error has occurred
       echo "gpg error. Do you have Gavin's code signing key installed?"
    fi
 


### PR DESCRIPTION
The current default URL doesn't seem to exist.

Unsure wether this should be updated to point to 0.7.2 now or wether
just to wait untill 0.8.0 is out and point there?

Commit also fixes a minor typo in the macdeploy notes.txt
