### PR TITLE
Bitcoin-Qt: better copyright year handling in AboutDialog

### DIFF
--- a/src/qt/aboutdialog.cpp
+++ b/src/qt/aboutdialog.cpp
@@ -1,14 +1,20 @@
 #include "aboutdialog.h"
 #include "ui_aboutdialog.h"
+
 #include "clientmodel.h"
 
-#include "version.h"
+// Copyright year (2009-this)
+// Todo: update this when changing our copyright comments in the source
+const int ABOUTDIALOG_COPYRIGHT_YEAR = 2013;
 
 AboutDialog::AboutDialog(QWidget *parent) :
     QDialog(parent),
     ui(new Ui::AboutDialog)
 {
     ui->setupUi(this);
+
+    // Set current copyright year
+    ui->copyrightLabel->setText(tr("Copyright") + QString(" &copy; ") + tr("2009-%1 The Bitcoin developers").arg(ABOUTDIALOG_COPYRIGHT_YEAR));
 }
 
 void AboutDialog::setModel(ClientModel *model)

--- a/src/qt/aboutdialog.h
+++ b/src/qt/aboutdialog.h
@@ -18,6 +18,7 @@ public:
     ~AboutDialog();
 
     void setModel(ClientModel *model);
+
 private:
     Ui::AboutDialog *ui;
 

--- a/src/qt/forms/aboutdialog.ui
+++ b/src/qt/forms/aboutdialog.ui
@@ -91,7 +91,10 @@
         <cursorShape>IBeamCursor</cursorShape>
        </property>
        <property name="text">
-        <string>Copyright © 2009-2012 The Bitcoin developers</string>
+        <string notr="true">Copyright &amp;copy; 2009-YYYY The Bitcoin developers</string>
+       </property>
+       <property name="textFormat">
+        <enum>Qt::RichText</enum>
        </property>
        <property name="textInteractionFlags">
         <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>


### PR DESCRIPTION
- this change allows us to keep the translation without the need to
  re-translate any string, when we update the copyright year
- copyright symbol is changed to HTML to ensure we get no encoding
  issues and it's removed from the translation string so translators don't
  break it by mistake

This is related to #2251.
