### PR TITLE
Do not call ResendWalletTransactions when reindexing or importing

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3812,7 +3812,12 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
         }
 
         // Resend wallet transactions that haven't gotten in a block yet
-        ResendWalletTransactions();
+        // Except during reindex, importing and IBD, when old wallet
+        // transactions become unconfirmed and spams other nodes.
+        if (!fReindex && !fImporting && !IsInitialBlockDownload())
+        {
+            ResendWalletTransactions();
+        }
 
         // Address refresh broadcast
         static int64 nLastRebroadcast;


### PR DESCRIPTION
Calling ResendWalletTransactions when reindexing or importing spams
other nodes with our old transactions, because they become unconfirmed.
