### PR TITLE
Bump version numbers for 0.8

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,4 +1,4 @@
-Copyright (c) 2009-2012 Bitcoin Developers
+Copyright (c) 2009-2013 Bitcoin Developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/bitcoin-qt.pro
+++ b/bitcoin-qt.pro
@@ -1,6 +1,6 @@
 TEMPLATE = app
 TARGET = bitcoin-qt
-VERSION = 0.7.99
+VERSION = 0.8.0
 INCLUDEPATH += src src/json src/qt
 DEFINES += QT_GUI BOOST_THREAD_USE_LIB BOOST_SPIRIT_THREADSAFE
 CONFIG += no_include_pwd

--- a/contrib/verifysfbinaries/verify.sh
+++ b/contrib/verifysfbinaries/verify.sh
@@ -18,7 +18,7 @@ WORKINGDIR="/tmp/bitcoin"
 TMPFILE="hashes.tmp"
 
 #this URL is used if a version number is not specified as an argument to the script
-SIGNATUREFILE="http://downloads.sourceforge.net/project/bitcoin/Bitcoin/bitcoin-0.7.1/test/SHA256SUMS.asc"
+SIGNATUREFILE="http://downloads.sourceforge.net/project/bitcoin/Bitcoin/bitcoin-0.8.0/test/SHA256SUMS.asc"
 
 SIGNATUREFILENAME="SHA256SUMS.asc"
 RCSUBDIR="test/"

--- a/doc/README
+++ b/doc/README
@@ -1,6 +1,6 @@
-Bitcoin 0.7.99 BETA
+Bitcoin 0.8.0 BETA
 
-Copyright (c) 2009-2012 Bitcoin Developers
+Copyright (c) 2009-2013 Bitcoin Developers
 Distributed under the MIT/X11 software license, see the accompanying
 file COPYING or http://www.opensource.org/licenses/mit-license.php.
 This product includes software developed by the OpenSSL Project for use in

--- a/doc/README_windows.txt
+++ b/doc/README_windows.txt
@@ -1,6 +1,6 @@
-Bitcoin 0.7.99 BETA
+Bitcoin 0.8.0 BETA
 
-Copyright (c) 2009-2012 Bitcoin Developers
+Copyright (c) 2009-2013 Bitcoin Developers
 Distributed under the MIT/X11 software license, see the accompanying
 file COPYING or http://www.opensource.org/licenses/mit-license.php.
 This product includes software developed by the OpenSSL Project for use in

--- a/doc/release-notes.txt
+++ b/doc/release-notes.txt
@@ -3,71 +3,91 @@ release time)
 
 Building this from
 
-	$ git shortlog --no-merges v0.7.0..
+	$ git shortlog --no-merges v0.7.1..
 
-How to Upgrade
---------------
+Incompatible Changes
+--------------------
 
-If you are running an older version, shut it down. Wait
-until it has completely shut down (which might take a few minutes for older
-versions), then run the installer (on Windows) or just copy over
-/Applications/Bitcoin-Qt (on Mac) or bitcoind/bitcoin-qt (on Linux).
+This release no longer maintains a full index of historical transaction ids
+by default, so looking up an arbitrary transaction using the getrawtransaction
+RPC call will not work. If you need that functionality, you must run once
+with -txindex=1 -reindex=1 to rebuild block-chain indices (see below for more
+details).
 
-If you were running on Linux with a version that might have been compiled
-with a different version of Berkeley DB (for example, if you were using an
-Ubuntu PPA version), then run the old version again with the -detachdb
-argument and shut it down; if you do not, then the new version will not
-be able to read the database files and will exit with an error.
-
-Explanation of -detachdb (and the new "stop true" RPC command):
-The Berkeley DB database library stores data in both ".dat" and
-"log" files, so the database is always in a consistent state,
-even in case of power failure or other sudden shutdown. The
-format of the ".dat" files is portable between different
-versions of Berkeley DB, but the "log" files are not-- even minor
-version differences may have incompatible "log" files. The
--detachdb option moves any pending changes from the "log" files
-to the "blkindex.dat" file for maximum compatibility, but makes
-shutdown much slower. Note that the "wallet.dat" file is always
-detached, and versions prior to 0.6.0 detached all databases
-at shutdown.
-
-New features
+Improvements
 ------------
 
-* Added a boolean argument to the RPC 'stop' command, if true sets
-  -detachdb to create standalone database .dat files before shutting down.
+Mac and Windows binaries are signed with certificates owned by the Bitcoin
+Foundation, to be compatible with the new security features in OSX 10.8 and
+Windows 8.
 
-* -salvagewallet command-line option, which moves any existing wallet.dat
-  to wallet.{timestamp}.dat and then attempts to salvage public/private
-  keys and master encryption keys (if the wallet is encrypted) into
-  a new wallet.dat. This should only be used if your wallet becomes
-  corrupted, and is not intended to replace regular wallet backups.
+LevelDB, a fast, open-source, non-relational database from Google, is
+now used to store transaction and block indices.  LevelDB works much better
+on machines with slow I/O and is faster in general. Berkeley DB is now only
+used for the wallet.dat file (public and private wallet keys and transactions
+relevant to you).
 
-* Import $DataDir/bootstrap.dat automatically, if it exists.
+Pieter Wuille implemented many optimizations to the way transactions are
+verified, so a running, synchronized node uses much less memory and does
+much less I/O. He also implemented parallel signature checking, so if you
+have a multi-CPU machine all CPUs will be used to verify transactions.
 
-Dependency changes
+New Features
+------------
+
+"Bloom filter" support in the network protocol for sending only relevant transactions to
+lightweight clients.
+
+contrib/verifysfbinaries is a shell-script to verify that the binary downloads
+at sourceforge have not been tampered with. If you are able, you can help make
+everybody's downloads more secure by running this occasionally to check PGP
+signatures against download file checksums.
+
+contrib/spendfrom is a python-language command-line utility that demonstrates
+how to use the "raw transactions" JSON-RPC api to send coins received from particular
+addresses (also known as "coin control").
+
+New/changed settings (command-line or bitcoin.conf file)
+--------------------------------------------------------
+
+dbcache : now controls LevelDB memory usage. Running with (for example) -dbcache=1000
+will use a gigabyte of memory and might make the initial blockchain download faster.
+
+par : controls how many threads to use to validate transactions. Defaults to the number
+of CPUs on your machine, use -par=1 to limit to a single CPU.
+
+txindex : maintains an extra index of old, spent transaction ids so they will be found
+by the getrawtransaction JSON-RPC method.
+
+reindex : rebuild block and transaction indices from the downloaded block data.
+
+New JSON-RPC API Features
+-------------------------
+
+lockunspent / listlockunspent allow locking transaction outputs for a period of time so
+they will not be spent by other processes that might be accessing the same wallet.
+
+addnode / getaddednodeinfo methods, to connect to specific peers without restarting.
+
+importprivkey now takes an optional boolean parameter (default true) to control whether
+or not to rescan the blockchain for transactions after importing a new private key.
+
+Important Bug Fixes
+-------------------
+
+Privacy leak: the position of the "change" output in most transactions was not being
+properly randomized, making network analysis of the transaction graph to identify
+users' wallets easier. 
+
+Zero-confirmation transaction vulnerability: accepting zero-confirmation transactions
+(transactions that have not yet been included in a block) from somebody you do not
+trust is still not recommended, because there will always be ways for attackers to
+double-spend zero-confirmation transactions. However, this release includes a bug
+fix that makes it a little bit more difficult for attackers to double-spend a
+certain type ("lockTime in the future") of zero-confirmation transaction.
+
+Dependency Changes
 ------------------
 
-* Qt 4.8.2 for Windows builds
-
-* openssl 1.0.1c
-
-Bug fixes
----------
-
-* When running -testnet, use RPC port 18332 by default.
-
-* Better detection and handling of corrupt wallet.dat and blkindex.dat files.
-  Previous versions would crash with a DB_RUNRECOVERY exception, this
-  version detects most problems and tells you how to recover if it
-  cannot recover itself.
-
-* Fixed an uninitialized variable bug that could cause transactions to
-  be reported out of order.
-
-* Fixed a bug that could cause occasional crashes on exit.
-
-* Warn the user that they need to create fresh wallet backups after they
-  encrypt their wallet.
+Qt 4.8.3 (compiling against older versions of Qt 4 should continue to work)
 

--- a/doc/release-process.txt
+++ b/doc/release-process.txt
@@ -5,6 +5,7 @@
   src/clientversion.h (change CLIENT_VERSION_IS_RELEASE to true)
   share/setup.nsi
   doc/README*
+  contrib/verifysfbinaries/verify.sh
 
 * tag version in git
 

--- a/share/setup.nsi
+++ b/share/setup.nsi
@@ -5,7 +5,7 @@ SetCompressor /SOLID lzma
 
 # General Symbol Definitions
 !define REGKEY "SOFTWARE\$(^Name)"
-!define VERSION 0.7.99
+!define VERSION 0.8.0
 !define COMPANY "Bitcoin project"
 !define URL http://www.bitcoin.org/
 
@@ -45,13 +45,13 @@ Var StartMenuGroup
 !insertmacro MUI_LANGUAGE English
 
 # Installer attributes
-OutFile bitcoin-0.7.99-win32-setup.exe
+OutFile bitcoin-0.8.0-win32-setup.exe
 InstallDir $PROGRAMFILES\Bitcoin
 CRCCheck on
 XPStyle on
 BrandingText " "
 ShowInstDetails show
-VIProductVersion 0.7.99.0
+VIProductVersion 0.8.0.0
 VIAddVersionKey ProductName Bitcoin
 VIAddVersionKey ProductVersion "${VERSION}"
 VIAddVersionKey CompanyName "${COMPANY}"

--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -7,12 +7,12 @@
 
 // These need to be macros, as version.cpp's and bitcoin-qt.rc's voodoo requires it
 #define CLIENT_VERSION_MAJOR       0
-#define CLIENT_VERSION_MINOR       7
-#define CLIENT_VERSION_REVISION    99
+#define CLIENT_VERSION_MINOR       8
+#define CLIENT_VERSION_REVISION    0
 #define CLIENT_VERSION_BUILD       0
 
 // Set to true for release, false for prerelease or test build
-#define CLIENT_VERSION_IS_RELEASE  false
+#define CLIENT_VERSION_IS_RELEASE  true
 
 // Converts the parameter X to a string after macro replacement on X has been performed.
 // Don't merge these into one macro!


### PR DESCRIPTION
Version numbers changed from 0.7.99 to 0.8.0
Set CLIENT_VERSION_IS_RELEASE to remove pre-release warning
Updated copyright in COPYING and doc/READMEs to 2013
Updated doc/release-notes.txt
