### PR TITLE
Signrawtransaction shouldn't require redeemScript for non-p2sh inputs

### DIFF
--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -421,7 +421,9 @@ Value signrawtransaction(const Array& params, bool fHelp)
 
             Object prevOut = p.get_obj();
 
-            RPCTypeCheck(prevOut, map_list_of("txid", str_type)("vout", int_type)("scriptPubKey", str_type)("redeemScript",str_type));
+            RPCTypeCheck(prevOut, map_list_of("txid", str_type)("vout", int_type)("scriptPubKey", str_type));
+            // redeemScript is optional:
+            RPCTypeCheck(prevOut, map_list_of("redeemScript",str_type), true);
 
             uint256 txid = ParseHashO(prevOut, "txid");
 


### PR DESCRIPTION
The redeemScript functionality broke plain offline signing, this
change makes it only look for that parameter when signing a p2sh
input.

Shorter version of https://github.com/bitcoin/bitcoin/pull/2264

Tested by creating two chained, not-broadcast raw transactions, verifying that not providing redeemScript for the second fails without this change, succeeds with this change.
