### PR TITLE
Do not use C++11 std::vector.data()

### DIFF
--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -307,7 +307,7 @@ Value getblocktemplate(const Array& params, bool fHelp)
         }
         entry.push_back(Pair("depends", deps));
 
-        int index_in_template = &tx - pblock->vtx.data();
+        int index_in_template = i - 1;
         entry.push_back(Pair("fee", pblocktemplate->vTxFees[index_in_template]));
         entry.push_back(Pair("sigops", pblocktemplate->vTxSigOps[index_in_template]));
 


### PR DESCRIPTION
std::vector.data() is a C++11 feature that makes my OSX build machine unhappy.

Somebody who mines with getblocktemplate, please help test.

Fixes #2285
