### PR TITLE
Change progress bar from block-based to time-based

### DIFF
--- a/src/checkpoints.cpp
+++ b/src/checkpoints.cpp
@@ -14,14 +14,21 @@ namespace Checkpoints
 {
     typedef std::map<int, uint256> MapCheckpoints;
 
-    //
+    static const double fSigcheckVerificationFactor = 15.0;
+
+    struct CCheckpointData {
+        MapCheckpoints mapCheckpoints;
+        int64 nTimeLastCheckpoint;
+        int64 nTransactionsLastCheckpoint;
+        double fTransactionsPerDay;
+    };
+
     // What makes a good checkpoint block?
     // + Is surrounded by blocks with reasonable timestamps
     //   (no blocks before with a timestamp after, none after with
     //    timestamp before)
     // + Contains no strange transactions
-    //
-    static MapCheckpoints mapCheckpoints =
+    static const CCheckpointData checkpoints = {
         boost::assign::map_list_of
         ( 11111, uint256("0x0000000069e244f73d78e8fd29ba2fd2ed618bd6fa2ee92559f542fdb26e7c1d"))
         ( 33333, uint256("0x000000002dd5588a74784eaa7ab0507a18ad16a236e7b1ce69f00d7ddfb5d0a6"))
@@ -31,25 +38,33 @@ namespace Checkpoints
         (168000, uint256("0x000000000000099e61ea72015e79632f216fe6cb33d7899acb35b75c8303b763"))
         (193000, uint256("0x000000000000059f452a5f7340de6682a977387c17010ff6e6c3bd83ca8b1317"))
         (210000, uint256("0x000000000000048b95347e83192f69cf0366076336c639f9b7228e9ba171342e"))
-        (216116, uint256("0x00000000000001b4f4b433e81ee46494af945cf96014816a4e2370f11b23df4e"))
-        ;
+        (216116, uint256("0x00000000000001b4f4b433e81ee46494af945cf96014816a4e2370f11b23df4e")),
+        1357902690, // UNIX timestamp of last checkpoint
+        11011160, // total number of transactions between genesis and last checkpoint
+        50500.0 // estimated number of transactions per day after checkpoint
+    };
 
-    static const int64 nTimeLastCheckpoint = 1357902690;
-    static const int64 nTransactionsLastCheckpoint = 11011160;
-    static const double fTransactionsPerDay = 50500;
-    static const double fSigcheckVerificationFactor = 15.0;
-
-    static MapCheckpoints mapCheckpointsTestnet =
+    static const CCheckpointData checkpointsTestnet = {
         boost::assign::map_list_of
-        ( 546, uint256("000000002a936ca763904c3c35fce2f3556c559c0214345d31b1bcebf76acb70"))
-        ;
+        ( 546, uint256("000000002a936ca763904c3c35fce2f3556c559c0214345d31b1bcebf76acb70")),
+        1338180505,
+        16341,
+        300
+    };
+
+    const CCheckpointData &Checkpoints() {
+        if (fTestNet)
+            return checkpointsTestnet;
+        else
+            return checkpoints;
+    }
 
     bool CheckBlock(int nHeight, const uint256& hash)
     {
         if (!GetBoolArg("-checkpoints", true))
             return true;
 
-        MapCheckpoints& checkpoints = (fTestNet ? mapCheckpointsTestnet : mapCheckpoints);
+        const MapCheckpoints& checkpoints = Checkpoints().mapCheckpoints;
 
         MapCheckpoints::const_iterator i = checkpoints.find(nHeight);
         if (i == checkpoints.end()) return true;
@@ -62,17 +77,19 @@ namespace Checkpoints
         double fWorkBefore = 0.0;
         double fWorkAfter = 0.0;
 
-        if (pindex->nTime <= nTimeLastCheckpoint) {
+        const CCheckpointData &data = Checkpoints();
+
+        if (pindex->nTime <= data.nTimeLastCheckpoint) {
             double nCheapBefore = pindex->nChainTx;
-            double nCheapAfter = nTransactionsLastCheckpoint - pindex->nChainTx;
-            double nExpensiveAfter = (nNow - nTimeLastCheckpoint)/86400.0*fTransactionsPerDay;
+            double nCheapAfter = data.nTransactionsLastCheckpoint - pindex->nChainTx;
+            double nExpensiveAfter = (nNow - data.nTimeLastCheckpoint)/86400.0*data.fTransactionsPerDay;
             fWorkBefore = nCheapBefore;
             fWorkAfter = nCheapAfter + nExpensiveAfter*fSigcheckVerificationFactor;
             // printf("before checkpoint: nCheapBefore=%f nCheapAfter=%f nExpensiveAfter=%f\n", nCheapBefore, nCheapAfter, nExpensiveAfter);
         } else {
-            double nCheapBefore = nTransactionsLastCheckpoint;
-            double nExpensiveBefore = pindex->nChainTx - nTransactionsLastCheckpoint;
-            double nExpensiveAfter = (nNow - pindex->nTime)/86400.0*fTransactionsPerDay;
+            double nCheapBefore = data.nTransactionsLastCheckpoint;
+            double nExpensiveBefore = pindex->nChainTx - data.nTransactionsLastCheckpoint;
+            double nExpensiveAfter = (nNow - pindex->nTime)/86400.0*data.fTransactionsPerDay;
             fWorkBefore = nCheapBefore + nExpensiveBefore*fSigcheckVerificationFactor;
             fWorkAfter = nExpensiveAfter*fSigcheckVerificationFactor;
             // printf("after checkpoint: nCheapBefore=%f nExpensiveBefore=%f nExpensiveAfter=%f\n", nCheapBefore, nExpensiveBefore, nExpensiveAfter);
@@ -87,7 +104,7 @@ namespace Checkpoints
         if (!GetBoolArg("-checkpoints", true))
             return 0;
 
-        MapCheckpoints& checkpoints = (fTestNet ? mapCheckpointsTestnet : mapCheckpoints);
+        const MapCheckpoints& checkpoints = Checkpoints().mapCheckpoints;
 
         return checkpoints.rbegin()->first;
     }
@@ -97,7 +114,7 @@ namespace Checkpoints
         if (!GetBoolArg("-checkpoints", true))
             return NULL;
 
-        MapCheckpoints& checkpoints = (fTestNet ? mapCheckpointsTestnet : mapCheckpoints);
+        const MapCheckpoints& checkpoints = Checkpoints().mapCheckpoints;
 
         BOOST_REVERSE_FOREACH(const MapCheckpoints::value_type& i, checkpoints)
         {

--- a/src/checkpoints.h
+++ b/src/checkpoints.h
@@ -22,6 +22,8 @@ namespace Checkpoints
 
     // Returns last CBlockIndex* in mapBlockIndex that is a checkpoint
     CBlockIndex* GetLastCheckpoint(const std::map<uint256, CBlockIndex*>& mapBlockIndex);
+
+    double GuessVerificationProgress(CBlockIndex *pindex);
 }
 
 #endif

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -572,8 +572,8 @@ void BitcoinGUI::setNumBlocks(int count, int nTotalBlocks)
         progressBarLabel->setText(importText);
         progressBarLabel->setVisible(true);
         progressBar->setFormat(tr("%1 behind").arg(timeBehindText));
-        progressBar->setMaximum(totalSecs);
-        progressBar->setValue(totalSecs - secs);
+        progressBar->setMaximum(1000000000);
+        progressBar->setValue(clientModel->getVerificationProgress() * 1000000000.0 + 0.5);
         progressBar->setVisible(true);
 
         tooltip = tr("Catching up...") + QString("<br>") + tooltip;

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -67,7 +67,8 @@ BitcoinGUI::BitcoinGUI(QWidget *parent):
     aboutQtAction(0),
     trayIcon(0),
     notificator(0),
-    rpcConsole(0)
+    rpcConsole(0),
+    prevBlocks(0)
 {
     resize(850, 550);
     setWindowTitle(tr("Bitcoin") + " - " + tr("Wallet"));
@@ -527,52 +528,17 @@ void BitcoinGUI::setNumBlocks(int count, int nTotalBlocks)
         importText = tr("Reindexing blocks on disk...");
     }
 
+    QDateTime lastBlockDate = clientModel->getLastBlockDate();
+    QDateTime currentDate = QDateTime::currentDateTime();
+    int secs = lastBlockDate.secsTo(currentDate);
+
     if(count < nTotalBlocks)
     {
-        int nRemainingBlocks = nTotalBlocks - count;
-        float nPercentageDone = count / (nTotalBlocks * 0.01f);
-
-        progressBarLabel->setText(importText);
-        progressBarLabel->setVisible(true);
-        progressBar->setFormat(tr("~%n block(s) remaining", "", nRemainingBlocks));
-        progressBar->setMaximum(nTotalBlocks);
-        progressBar->setValue(count);
-        progressBar->setVisible(true);
-
-        tooltip = tr("Processed %1 of %2 blocks of transaction history (%3% done).").arg(count).arg(nTotalBlocks).arg(nPercentageDone, 0, 'f', 2);
+        tooltip = tr("Processed %1 of %2 (estimated) blocks of transaction history.").arg(count).arg(nTotalBlocks);
     }
     else
     {
-        progressBarLabel->setVisible(false);
-
-        progressBar->setVisible(false);
         tooltip = tr("Processed %1 blocks of transaction history.").arg(count);
-    }
-
-    QDateTime lastBlockDate = clientModel->getLastBlockDate();
-    int secs = lastBlockDate.secsTo(QDateTime::currentDateTime());
-    QString text;
-
-    // Represent time from last generated block in human readable text
-    if(secs <= 0)
-    {
-        // Fully up to date. Leave text empty.
-    }
-    else if(secs < 60)
-    {
-        text = tr("%n second(s) ago","",secs);
-    }
-    else if(secs < 60*60)
-    {
-        text = tr("%n minute(s) ago","",secs/60);
-    }
-    else if(secs < 24*60*60)
-    {
-        text = tr("%n hour(s) ago","",secs/(60*60));
-    }
-    else
-    {
-        text = tr("%n day(s) ago","",secs/(60*60*24));
     }
 
     // Set icon state: spinning if catching up, tick otherwise
@@ -582,20 +548,46 @@ void BitcoinGUI::setNumBlocks(int count, int nTotalBlocks)
         labelBlocksIcon->setPixmap(QIcon(":/icons/synced").pixmap(STATUSBAR_ICONSIZE, STATUSBAR_ICONSIZE));
 
         overviewPage->showOutOfSyncWarning(false);
+
+        progressBarLabel->setVisible(false);
+        progressBar->setVisible(false);
     }
     else
     {
+        // Represent time from last generated block in human readable text
+        QString timeBehindText;
+        if(secs < 48*60*60)
+        {
+            timeBehindText = tr("%n hour(s)","",secs/(60*60));
+        }
+        else if(secs < 14*24*60*60)
+        {
+            timeBehindText = tr("%n day(s)","",secs/(24*60*60));
+        }
+        else
+        {
+            timeBehindText = tr("%n week(s)","",secs/(7*24*60*60));
+        }
+
+        progressBarLabel->setText(importText);
+        progressBarLabel->setVisible(true);
+        progressBar->setFormat(tr("%1 behind").arg(timeBehindText));
+        progressBar->setMaximum(totalSecs);
+        progressBar->setValue(totalSecs - secs);
+        progressBar->setVisible(true);
+
         tooltip = tr("Catching up...") + QString("<br>") + tooltip;
         labelBlocksIcon->setMovie(syncIconMovie);
-        syncIconMovie->start();
+        if(count != prevBlocks)
+            syncIconMovie->jumpToNextFrame();
+        prevBlocks = count;
 
         overviewPage->showOutOfSyncWarning(true);
-    }
 
-    if(!text.isEmpty())
-    {
         tooltip += QString("<br>");
-        tooltip += tr("Last received block was generated %1.").arg(text);
+        tooltip += tr("Last received block was generated %1 ago.").arg(timeBehindText);
+        tooltip += QString("<br>");
+        tooltip += tr("Transactions after this will not yet be visible.");
     }
 
     // Don't word-wrap this (fixed-width) tooltip

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -98,6 +98,8 @@ private:
     RPCConsole *rpcConsole;
 
     QMovie *syncIconMovie;
+    /** Keep track of previous number of blocks, to detect progress */
+    int prevBlocks;
 
     /** Create the main UI actions. */
     void createActions();

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -6,6 +6,7 @@
 
 #include "alert.h"
 #include "main.h"
+#include "checkpoints.h"
 #include "ui_interface.h"
 
 #include <QDateTime>
@@ -54,6 +55,10 @@ QDateTime ClientModel::getLastBlockDate() const
         return QDateTime::fromTime_t(1231006505); // Genesis block's time
 }
 
+double ClientModel::getVerificationProgress() const
+{
+    return Checkpoints::GuessVerificationProgress(pindexBest);
+}
 
 void ClientModel::updateTimer()
 {

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -54,6 +54,7 @@ QDateTime ClientModel::getLastBlockDate() const
         return QDateTime::fromTime_t(1231006505); // Genesis block's time
 }
 
+
 void ClientModel::updateTimer()
 {
     // Some quantities (such as number of blocks) change so fast that we don't want to be notified for each change.

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -34,6 +34,7 @@ public:
     int getNumBlocks() const;
     int getNumBlocksAtStartup();
 
+    double getVerificationProgress() const;
     QDateTime getLastBlockDate() const;
 
     //! Return true if client connected to testnet

--- a/src/qt/guiconstants.h
+++ b/src/qt/guiconstants.h
@@ -2,7 +2,7 @@
 #define GUICONSTANTS_H
 
 /* Milliseconds between model updates */
-static const int MODEL_UPDATE_DELAY = 500;
+static const int MODEL_UPDATE_DELAY = 250;
 
 /* AskPassphraseDialog -- Maximum passphrase length */
 static const int MAX_PASSPHRASE_SIZE = 1024;


### PR DESCRIPTION
This is less confusing to most people, and doesn't rely on estimates
of the total number of blocks received from other nodes.

Like in the Android app, in the progress bar label now shows the time that the node is behind instead of the number of blocks left.
