### PR TITLE
Minor: Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ submit new unit tests for old code.
 
 Unit tests for the core code are in `src/test/`. To compile and run them:
 
-    cd src; make -f makefile.linux test
+    cd src; make -f makefile.unix test
 
 Unit tests for the GUI code are in `src/qt/test/`. To compile and run them:
 


### PR DESCRIPTION
s/linux/unix/
