### PR TITLE
Short-circuit bloom checking if we will always return true.

### DIFF
--- a/src/bloom.cpp
+++ b/src/bloom.cpp
@@ -37,6 +37,8 @@ inline unsigned int CBloomFilter::Hash(unsigned int nHashNum, const std::vector<
 
 void CBloomFilter::insert(const vector<unsigned char>& vKey)
 {
+    if (vData.size() == 1 && vData[0] == 0xff)
+        return;
     for (unsigned int i = 0; i < nHashFuncs; i++)
     {
         unsigned int nIndex = Hash(i, vKey);
@@ -61,6 +63,8 @@ void CBloomFilter::insert(const uint256& hash)
 
 bool CBloomFilter::contains(const vector<unsigned char>& vKey) const
 {
+    if (vData.size() == 1 && vData[0] == 0xff)
+        return true;
     for (unsigned int i = 0; i < nHashFuncs; i++)
     {
         unsigned int nIndex = Hash(i, vKey);


### PR DESCRIPTION
This allows full nodes to use bloom filters as an optimization when downloading blocks (dont double-relay txn) as long as we have a sufficiently large mempool.
