### PR TITLE
Also copy the address to the X11 clipboard (the one you middle-click to paste)

### DIFF
--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -159,7 +159,7 @@ void copyEntryData(QAbstractItemView *view, int column, int role)
     if(!selection.isEmpty())
     {
         // Copy first item
-        QApplication::clipboard()->setText(selection.at(0).data(role).toString());
+        QApplication::clipboard()->setText(selection.at(0).data(role).toString(),QClipboard::Selection);
     }
 }
 


### PR DESCRIPTION
Bitcoin-qt has annoyed me and others for some time because the "Copy Address" button only copies to the clipboard that you have to use the cut and paste keystrokes.  It does not, until now, copies to the old-fashioned X11 clipboard that you can just select something and paste using the middle button.  That complicates doing things like pasting a command line into arbitrary windows (particularly xterm).  This very simple change fixes that oversight.  
