### PR TITLE
Block uneconomic UTXO creation

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -602,7 +602,7 @@ int64 CTransaction::GetMinFee(unsigned int nBlockSize, bool fAllowFree,
     if (nMinFee < nBaseFee)
     {
         BOOST_FOREACH(const CTxOut& txout, vout)
-            if (txout.nValue < CENT)
+            if (txout.nValue < COIN_DUST)
                 nMinFee = nBaseFee;
     }
 

--- a/src/main.h
+++ b/src/main.h
@@ -48,6 +48,9 @@ static const unsigned int MEMPOOL_HEIGHT = 0x7FFFFFFF;
 static const int64 MIN_TX_FEE = 50000;
 /** Fees smaller than this (in satoshi) are considered zero fee (for relaying) */
 static const int64 MIN_RELAY_TX_FEE = 10000;
+/** Coin dust is defined as any output with less than this multiple of the minimum tx fee */
+static const int64 COIN_DUST_RATIO = 20;
+static const int64 COIN_DUST = MIN_TX_FEE * COIN_DUST_RATIO; // 0.01 BTC
 /** No amount larger than this (in satoshi) is valid */
 static const int64 MAX_MONEY = 21000000 * COIN;
 inline bool MoneyRange(int64 nValue) { return (nValue >= 0 && nValue <= MAX_MONEY); }

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1182,7 +1182,7 @@ bool CWallet::CreateTransaction(const vector<pair<CScript, int64> >& vecSend, CW
                 // if sub-cent change is required, the fee must be raised to at least MIN_TX_FEE
                 // or until nChange becomes zero
                 // NOTE: this depends on the exact behaviour of GetMinFee
-                if (nFeeRet < MIN_TX_FEE && nChange > 0 && nChange < CENT)
+                if (nFeeRet < MIN_TX_FEE && nChange > 0 && nChange < COIN_DUST)
                 {
                     int64 nMoveToFee = min(nChange, MIN_TX_FEE - nFeeRet);
                     nChange -= nMoveToFee;

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1189,7 +1189,10 @@ bool CWallet::CreateTransaction(const vector<pair<CScript, int64> >& vecSend, CW
                     nFeeRet += nMoveToFee;
                 }
 
-                if (nChange > 0)
+                // Create change if required, but do not create change that
+                // results in a output value that isn't economical to spend.
+                // (see CTxMemPool::accept() logic)
+                if (nChange > max(MIN_TX_FEE, nTransactionFee))
                 {
                     // Note: We use a new key here to keep it from being obvious which side is the change.
                     //  The drawback is that by not reusing a previous key, the change may be lost if a
@@ -1315,6 +1318,14 @@ string CWallet::SendMoney(CScript scriptPubKey, int64 nValue, CWalletTx& wtxNew,
 {
     CReserveKey reservekey(this);
     int64 nFeeRequired;
+
+    int64 nTxFee = max(MIN_TX_FEE, nTransactionFee);
+    if (nValue <= nTxFee){
+        string strError;
+        strError = strprintf(_("Error: Output value is too small; amount must be greater than the transaction fee, %s"), FormatMoney(nTxFee).c_str());
+        printf("SendMoney() : %s", strError.c_str());
+        return strError;
+    }
 
     if (IsLocked())
     {


### PR DESCRIPTION
Keeps the UTXO set from being bloated by the creation of outputs that will never be spent because doing so would cost more in fees than they are worth.

Includes changes to the UI to ensure the user can't create such outputs, as well as the transaction creation code to round off change if the change txout would itself be unspendable.
