### PR TITLE
Clean up font size in main window for observed inconsistency in Mac OS

### DIFF
--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -49,7 +49,6 @@
              <widget class="QLabel" name="label_5">
               <property name="font">
                <font>
-                <pointsize>11</pointsize>
                 <weight>75</weight>
                 <bold>true</bold>
                </font>


### PR DESCRIPTION
This just changes the font size of the word "Wallet" from 11 to 13 points.
