### PR TITLE
Fixes for 0.8.1 release

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4152,6 +4152,10 @@ CBlockTemplate* CreateNewBlock(CReserveKey& reservekey)
     // Limit to betweeen 1K and MAX_BLOCK_SIZE-1K for sanity:
     nBlockMaxSize = std::max((unsigned int)1000, std::min((unsigned int)(MAX_BLOCK_SIZE-1000), nBlockMaxSize));
 
+    // Special compatibility rule before 15 May: limit size to 500,000 bytes:
+    if (GetAdjustedTime() < 1368576000)
+        nBlockMaxSize = std::min(nBlockMaxSize, (unsigned int)(MAX_BLOCK_SIZE_GEN));
+
     // How much of the block should be dedicated to high-priority transactions,
     // included regardless of the fees they pay
     unsigned int nBlockPrioritySize = GetArg("-blockprioritysize", 27000);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2053,6 +2053,25 @@ bool CBlock::CheckBlock(CValidationState &state, bool fCheckPOW, bool fCheckMerk
     if (vtx.empty() || vtx.size() > MAX_BLOCK_SIZE || ::GetSerializeSize(*this, SER_NETWORK, PROTOCOL_VERSION) > MAX_BLOCK_SIZE)
         return state.DoS(100, error("CheckBlock() : size limits failed"));
 
+    // Special short-term limits to avoid 10,000 BDB lock limit:
+    if (GetBlockTime() > 1363039171 && // 11 March 2013, timestamp of block before the big fork
+        GetBlockTime() < 1368576000)  // 15 May 2013 00:00:00
+    {
+        // Rule is: #unique txids referenced <= 4,500
+        // ... to prevent 10,000 BDB lock exhaustion on old clients
+        set<uint256> setTxIn;
+        for (size_t i = 0; i < vtx.size(); i++)
+        {
+            setTxIn.insert(vtx[i].GetHash());
+            if (i == 0) continue; // skip coinbase txin
+            BOOST_FOREACH(const CTxIn& txin, vtx[i].vin)
+                setTxIn.insert(txin.prevout.hash);
+        }
+        size_t nTxids = setTxIn.size();
+        if (nTxids > 4500)
+            return error("CheckBlock() : 15 May maxlocks violation");
+    }
+
     // Check proof of work matches claimed amount
     if (fCheckPOW && !CheckProofOfWork(GetHash(), nBits))
         return state.DoS(50, error("CheckBlock() : proof of work failed"));

--- a/src/test/checkblock_tests.cpp
+++ b/src/test/checkblock_tests.cpp
@@ -1,0 +1,66 @@
+//
+// Unit tests for block.CheckBlock()
+//
+#include <algorithm>
+
+#include <boost/assign/list_of.hpp> // for 'map_list_of()'
+#include <boost/date_time/posix_time/posix_time_types.hpp>
+#include <boost/test/unit_test.hpp>
+#include <boost/foreach.hpp>
+
+#include "main.h"
+#include "wallet.h"
+#include "net.h"
+#include "util.h"
+
+BOOST_AUTO_TEST_SUITE(CheckBlock_tests)
+
+bool
+read_block(const std::string& filename, CBlock& block)
+{
+    namespace fs = boost::filesystem;
+    fs::path testFile = fs::current_path() / "test" / "data" / filename;
+#ifdef TEST_DATA_DIR
+    if (!fs::exists(testFile))
+    {
+        testFile = fs::path(BOOST_PP_STRINGIZE(TEST_DATA_DIR)) / filename;
+    }
+#endif
+    FILE* fp = fopen(testFile.string().c_str(), "rb");
+    if (!fp) return false;
+
+    fseek(fp, 8, SEEK_SET); // skip msgheader/size
+
+    CAutoFile filein = CAutoFile(fp, SER_DISK, CLIENT_VERSION);
+    if (!filein) return false;
+
+    filein >> block;
+
+    return true;
+}
+
+BOOST_AUTO_TEST_CASE(May15)
+{
+    // Putting a 1MB binary file in the git repository is not a great
+    // idea, so this test is only run if you manually download
+    // test/data/Mar12Fork.dat from
+    // http://sourceforge.net/projects/bitcoin/files/Bitcoin/blockchain/Mar12Fork.dat/download
+    unsigned int tMay15 = 1368576000;
+    SetMockTime(tMay15); // Test as if it was right at May 15
+
+    CBlock forkingBlock;
+    if (read_block("Mar12Fork.dat", forkingBlock))
+    {
+        CValidationState state;
+        BOOST_CHECK(!forkingBlock.CheckBlock(state, true, true));
+        BOOST_CHECK(!forkingBlock.CheckBlock(state, false, false));
+
+        // After May 15'th, big blocks are OK:
+        forkingBlock.nTime = tMay15; // Invalidates PoW
+        BOOST_CHECK(forkingBlock.CheckBlock(state, false, false));
+    }
+
+    SetMockTime(0);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
I intend these three commits, applied on top of the v0.8.0 tag, to be the 0.8.1 release.

The plan is:
- A new checkblock rule, in effect until 15 May, that ensure only blocks compatible with old releases are accepted into the main chain (only blocks that touch 4,500 or fewer distinct txids are allowed).
- A limit of 500k to blocks created, also in effect until 15 May.

Alerts will be sent to pre-0.8 releases over the next two months, telling people to either upgrade or create a DB_CONFIG file so they can handle large blocks. After May 15'th, blocks up to 1MB large will be allowed again.

Tested by syncing the entire main chain and the testnet chains. A unit test is included, but it only runs if you download the 900K forking block (see the comment in src/test/checkblock_tests.cpp ).
