### PR TITLE
re-enable -D_FORTIFY_SOURCE=2 for all platforms

### DIFF
--- a/bitcoin-qt.pro
+++ b/bitcoin-qt.pro
@@ -30,10 +30,8 @@ contains(RELEASE, 1) {
     macx:QMAKE_OBJECTIVE_CFLAGS += -mmacosx-version-min=10.5 -arch i386 -isysroot /Developer/SDKs/MacOSX10.5.sdk
 
     !win32:!macx {
-        # Linux: static link
+        # Linux: static link and extra security (see: https://wiki.debian.org/Hardening)
         LIBS += -Wl,-Bstatic -Wl,-z,relro -Wl,-z,now
-        # for extra security (see: https://wiki.debian.org/Hardening)
-        QMAKE_CXXFLAGS *= -D_FORTIFY_SOURCE=2
     }
 }
 
@@ -44,6 +42,8 @@ contains(RELEASE, 1) {
     # Exclude on Windows cross compile with MinGW 4.2.x, as it will result in a non-working executable!
     # This can be enabled for Windows, when we switch to MinGW >= 4.4.x.
 }
+# for extra security (see: https://wiki.debian.org/Hardening): this flag is GCC compiler-specific
+QMAKE_CXXFLAGS *= -D_FORTIFY_SOURCE=2
 # for extra security on Windows: enable ASLR and DEP via GCC linker flags
 win32:QMAKE_LFLAGS *= -Wl,--dynamicbase -Wl,--nxcompat
 # on Windows: enable GCC large address aware linker flag


### PR DESCRIPTION
IMHO, this is no Linux specific switch.
