### PR TITLE
Add user interface to set dust limit and filtered addresses

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -66,6 +66,7 @@ int64 nHPSTimerStart;
 
 // Settings
 int64 nTransactionFee = 0;
+int64 nDustLimit = 0;
 
 
 
@@ -652,6 +653,12 @@ bool CTxMemPool::accept(CValidationState &state, CTransaction &tx, bool fCheckIn
     // Rather not work on nonstandard transactions (unless -testnet)
     if (!fTestNet && !tx.IsStandard())
         return error("CTxMemPool::accept() : nonstandard transaction type");
+
+    // Further user defined acceptance tests
+    BOOST_FOREACH(const CTxOut& txout, tx.vout) {
+	if (txout.nValue <= nDustLimit)
+	    return error("CTxMemPool::accept() : transaction output smaller than user defined limit");
+    }
 
     // is it already in the memory pool?
     uint256 hash = tx.GetHash();

--- a/src/main.h
+++ b/src/main.h
@@ -100,6 +100,7 @@ extern unsigned int nCoinCacheSize;
 
 // Settings
 extern int64 nTransactionFee;
+extern int64 nDustLimit;
 
 // Minimum disk space required - used in CheckDiskSpace()
 static const uint64 nMinDiskSpace = 52428800;

--- a/src/main.h
+++ b/src/main.h
@@ -9,6 +9,7 @@
 #include "sync.h"
 #include "net.h"
 #include "script.h"
+#include "base58.h"
 
 #include <list>
 
@@ -101,6 +102,7 @@ extern unsigned int nCoinCacheSize;
 // Settings
 extern int64 nTransactionFee;
 extern int64 nDustLimit;
+extern std::set<CBitcoinAddress> filteredAddresses;
 
 // Minimum disk space required - used in CheckDiskSpace()
 static const uint64 nMinDiskSpace = 52428800;

--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -378,6 +378,59 @@
        </item>
       </layout>
      </widget>
+     <widget class="QWidget" name="tabAdvanced">
+      <attribute name="title">
+       <string>&amp;Advanced</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_Advanced">
+       <item>
+        <widget class="QLabel" name="dustLimitInfoLabel">
+         <property name="text">
+          <string>Limit to the transaction that this node will process. Transactions which transfer less than this value will be ignored.</string>
+         </property>
+         <property name="textFormat">
+          <enum>Qt::PlainText</enum>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_1_Advanced">
+         <item>
+          <widget class="QLabel" name="dustLimitLabel">
+           <property name="text">
+            <string>&amp;Dust limit</string>
+           </property>
+           <property name="textFormat">
+            <enum>Qt::PlainText</enum>
+           </property>
+           <property name="buddy">
+            <cstring>dustLimit</cstring>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="BitcoinAmountField" name="dustLimit"/>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_1_Advanced">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
    <item>

--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -386,7 +386,7 @@
        <item>
         <widget class="QLabel" name="dustLimitInfoLabel">
          <property name="text">
-          <string>Limit to the transaction that this node will process. Transactions which transfer less than this value will be ignored.</string>
+          <string>Limits to the transaction that this node will process. Transactions with outputs less than the dust limit will be ignored.</string>
          </property>
          <property name="textFormat">
           <enum>Qt::PlainText</enum>
@@ -428,6 +428,45 @@
           </spacer>
          </item>
         </layout>
+       </item>
+       <item>
+        <widget class="QLabel" name="filteredAddressesInfoLabel">
+         <property name="text">
+          <string>Bitcoin addresses which will be filtered (each address on a line). Outputs spent to these addresses will not be processed by this node.</string>
+         </property>
+         <property name="textFormat">
+          <enum>Qt::PlainText</enum>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPlainTextEdit" name="filteredAddresses">
+         <property name="maximumSize">
+          <size>
+           <width>16777215</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="toolTip">
+          <string>Bitcoin addresses to filter from transaction processing.</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_Advanced">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
        </item>
       </layout>
      </widget>

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -145,6 +145,9 @@ void OptionsDialog::setMapper()
     mapper->addMapping(ui->lang, OptionsModel::Language);
     mapper->addMapping(ui->unit, OptionsModel::DisplayUnit);
     mapper->addMapping(ui->displayAddresses, OptionsModel::DisplayAddresses);
+
+    /* Advanced */
+    mapper->addMapping(ui->dustLimit, OptionsModel::DustLimit);
 }
 
 void OptionsDialog::enableApplyButton()
@@ -243,6 +246,7 @@ void OptionsDialog::updateDisplayUnit()
     {
         /* Update transactionFee with the current unit */
         ui->transactionFee->setDisplayUnit(model->getDisplayUnit());
+        ui->dustLimit->setDisplayUnit(model->getDisplayUnit());
     }
 }
 

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -148,6 +148,7 @@ void OptionsDialog::setMapper()
 
     /* Advanced */
     mapper->addMapping(ui->dustLimit, OptionsModel::DustLimit);
+    mapper->addMapping(ui->filteredAddresses, OptionsModel::FilteredAddresses);
 }
 
 void OptionsDialog::enableApplyButton()

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -47,6 +47,7 @@ void OptionsModel::Init()
     fMinimizeToTray = settings.value("fMinimizeToTray", false).toBool();
     fMinimizeOnClose = settings.value("fMinimizeOnClose", false).toBool();
     nTransactionFee = settings.value("nTransactionFee").toLongLong();
+    nDustLimit = settings.value("nDustLimit").toLongLong();
     language = settings.value("language", "").toString();
 
     // These are shared with core Bitcoin; we want
@@ -196,6 +197,8 @@ QVariant OptionsModel::data(const QModelIndex & index, int role) const
             return QVariant(bDisplayAddresses);
         case Language:
             return settings.value("language", "");
+        case DustLimit:
+            return QVariant(nDustLimit);
         default:
             return QVariant();
         }
@@ -278,6 +281,10 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
         case Language:
             settings.setValue("language", value);
             break;
+        case DustLimit:
+            nDustLimit = value.toLongLong();
+            settings.setValue("nDustLimit", nDustLimit);
+            break;
         default:
             break;
         }
@@ -290,4 +297,9 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
 qint64 OptionsModel::getTransactionFee()
 {
     return nTransactionFee;
+}
+
+qint64 OptionsModel::getDustLimit()
+{
+    return nDustLimit;
 }

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -30,6 +30,7 @@ public:
         DisplayAddresses,  // bool
         Language,          // QString
         DustLimit,         // qint64
+        FilteredAddresses, // QString
         OptionIDRowCount,
     };
 

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -29,6 +29,7 @@ public:
         DisplayUnit,       // BitcoinUnits::Unit
         DisplayAddresses,  // bool
         Language,          // QString
+        DustLimit,         // qint64
         OptionIDRowCount,
     };
 
@@ -49,6 +50,7 @@ public:
     int getDisplayUnit() { return nDisplayUnit; }
     bool getDisplayAddresses() { return bDisplayAddresses; }
     QString getLanguage() { return language; }
+    qint64 getDustLimit();
 
 private:
     int nDisplayUnit;


### PR DESCRIPTION
This patch adds a new "Advanced" pane to the options box where the dust limit for accepted transactions can be set, and where a filter on output addresses can be specified. CTxMemPool::accept() will drop any transaction with outputs below the dust limit, or with an output address corresponding to an address specified in the filter.

![screenshot](https://f.cloud.github.com/assets/420734/273459/ef1212e4-9024-11e2-957a-31f3f8996172.png)
