### PR TITLE
Deleting everything except the wallet will not help recover from BDB errors.

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -612,9 +612,7 @@ bool AppInit2()
 
     if (!bitdb.Open(GetDataDir()))
     {
-        string msg = strprintf(_("Error initializing database environment %s!"
-                                 " To recover, BACKUP THAT DIRECTORY, then remove"
-                                 " everything from it except for wallet.dat."), strDataDir.c_str());
+        string msg = strprintf(_("Error initializing wallet database environment %s!"), strDataDir.c_str());
         return InitError(msg);
     }
 


### PR DESCRIPTION
Now that the wallet is the only thing in BDB any DB open errors must be
from the wallet itself-- so deleting everything else will not likely help.
