### PR TITLE
Bitcoin-Qt: ensure createTrayIconMenu() is always called on Mac

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -326,8 +326,7 @@ void BitcoinGUI::setClientModel(ClientModel *clientModel)
 
         // Create system tray menu (or setup the dock menu) that late to prevent users from calling actions,
         // while the client has not yet fully loaded
-        if(trayIcon)
-            createTrayIconMenu();
+        createTrayIconMenu();
 
         // Keep up to date with client
         setNumConnections(clientModel->getNumConnections());
@@ -375,6 +374,10 @@ void BitcoinGUI::createTrayIconMenu()
 {
     QMenu *trayIconMenu;
 #ifndef Q_OS_MAC
+    // return if trayIcon is unset (only on non-Mac OSes)
+    if (!trayIcon)
+        return;
+
     trayIconMenu = new QMenu(this);
     trayIcon->setContextMenu(trayIconMenu);
 


### PR DESCRIPTION
- this should prevent GUI issues on Mac that were observed before (disappearing
  GUI - see #1522)
- the patch ensures, that createTrayIconMenu() is always called on Mac to
  process and use our MacDockIconHandler
