### PR TITLE
Make MIN_TX_FEE match MIN_RELAY_TX_FEE.

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -45,7 +45,7 @@ static const unsigned int UNDOFILE_CHUNK_SIZE = 0x100000; // 1 MiB
 /** Fake height value used in CCoins to signify they are only in the memory pool (since 0.8) */
 static const unsigned int MEMPOOL_HEIGHT = 0x7FFFFFFF;
 /** Fees smaller than this (in satoshi) are considered zero fee (for transaction creation) */
-static const int64 MIN_TX_FEE = 50000;
+static const int64 MIN_TX_FEE = 10000;
 /** Fees smaller than this (in satoshi) are considered zero fee (for relaying) */
 static const int64 MIN_RELAY_TX_FEE = 10000;
 /** No amount larger than this (in satoshi) is valid */


### PR DESCRIPTION
Current relay behavior is widely deployed. Supplying a higher minfee than
mining and relaying just irritates users without anti-spam gain.
