### PR TITLE
Fix LevelDB removing /dev/null at build time

### DIFF
--- a/src/leveldb/build_detect_platform
+++ b/src/leveldb/build_detect_platform
@@ -25,6 +25,8 @@
 #       -DSNAPPY                     if the Snappy library is present
 #
 
+TMPDIR="/tmp"
+
 OUTPUT=$1
 PREFIX=$2
 if test -z "$OUTPUT" || test -z "$PREFIX"; then
@@ -164,7 +166,9 @@ if [ "$CROSS_COMPILE" = "true" ]; then
     true
 else
     # If -std=c++0x works, use <cstdatomic>.  Otherwise use port_posix.h.
-    $CXX $CXXFLAGS -std=c++0x -x c++ - -o /dev/null 2>/dev/null  <<EOF
+    CPP0X_TEST_TEMPFILE="${TMPDIR}/leveldb-build_detect_platform_cpp0x.$$"
+
+    $CXX $CXXFLAGS -std=c++0x -x c++ - -o ${CPP0X_TEST_TEMPFILE} 2>/dev/null  <<EOF
       #include <cstdatomic>
       int main() {}
 EOF
@@ -175,13 +179,19 @@ EOF
         COMMON_FLAGS="$COMMON_FLAGS -DLEVELDB_PLATFORM_POSIX"
     fi
 
+    rm -f ${CPP0X_TEST_TEMPFILE} > /dev/null 2>&1
+
     # Test whether tcmalloc is available
-    $CXX $CXXFLAGS -x c++ - -o /dev/null -ltcmalloc 2>/dev/null  <<EOF
+    TCMALLOC_TEST_TEMPFILE="${TMPDIR}/leveldb-build_detect_platform_tcmalloc.$$"
+
+    $CXX $CXXFLAGS -x c++ - -o ${TCMALLOC_TEST_TEMPFILE} -ltcmalloc 2>/dev/null  <<EOF
       int main() {}
 EOF
     if [ "$?" = 0 ]; then
         PLATFORM_LIBS="$PLATFORM_LIBS -ltcmalloc"
     fi
+
+    rm -f ${TCMALLOC_TEST_TEMPFILE} > /dev/null 2>&1
 fi
 
 PLATFORM_CCFLAGS="$PLATFORM_CCFLAGS $COMMON_FLAGS"


### PR DESCRIPTION
Building bitcoin as root can cause /dev/null to be removed on some systems (e.g. FreeBSD 8.3-RELEASE-p3 and gcc version 4.2.2). This pull request fixes the issue.

A patch has also been sent upstream, see http://code.google.com/p/leveldb/issues/detail?id=153.
