### PR TITLE
Make explicitly requested salvage operations keep going when there is an error.

### DIFF
--- a/src/db.cpp
+++ b/src/db.cpp
@@ -167,9 +167,18 @@ bool CDBEnv::Salvage(std::string strFile, bool fAggressive,
 
     Db db(&dbenv, 0);
     int result = db.verify(strFile.c_str(), NULL, &strDump, flags);
-    if (result != 0)
+    if (result == DB_VERIFY_BAD)
     {
-        printf("ERROR: db salvage failed\n");
+        printf("Error: Salvage found errors, all data may not be recoverable.\n");
+        if (!fAggressive)
+        {
+            printf("Error: Rerun with aggressive mode to ignore errors and continue.\n");
+            return false;
+        }
+    }
+    if (result != 0 && result != DB_VERIFY_BAD)
+    {
+        printf("ERROR: db salvage failed: %d\n",result);
         return false;
     }
 


### PR DESCRIPTION
In my tests corrupted wallets would often result in BDB dropping an error
just due to duplicate records being found, which appears harmless.
