### PR TITLE
update dependency-libs for Gitian builds

### DIFF
--- a/bitcoin-qt.pro
+++ b/bitcoin-qt.pro
@@ -330,7 +330,7 @@ OTHER_FILES += \
 # platform specific defaults, if not overridden on command line
 isEmpty(BOOST_LIB_SUFFIX) {
     macx:BOOST_LIB_SUFFIX = -mt
-    win32:BOOST_LIB_SUFFIX = -mgw44-mt-s-1_50
+    win32:BOOST_LIB_SUFFIX = -mgw44-mt-s-1_53
 }
 
 isEmpty(BOOST_THREAD_LIB_SUFFIX) {
@@ -395,7 +395,6 @@ LIBS += -lssl -lcrypto -ldb_cxx$$BDB_LIB_SUFFIX
 # -lgdi32 has to happen after -lcrypto (see  #681)
 win32:LIBS += -lws2_32 -lshlwapi -lmswsock -lole32 -loleaut32 -luuid -lgdi32
 LIBS += -lboost_system$$BOOST_LIB_SUFFIX -lboost_filesystem$$BOOST_LIB_SUFFIX -lboost_program_options$$BOOST_LIB_SUFFIX -lboost_thread$$BOOST_THREAD_LIB_SUFFIX
-win32:LIBS += -lboost_chrono$$BOOST_LIB_SUFFIX
 
 contains(RELEASE, 1) {
     !win32:!macx {

--- a/contrib/gitian-descriptors/README
+++ b/contrib/gitian-descriptors/README
@@ -23,15 +23,15 @@ Once you've got the right hardware and software:
     mkdir gitian-builder/inputs
     cd gitian-builder/inputs
     # Inputs for Linux and Win32:
-    wget -O miniupnpc-1.6.tar.gz 'http://miniupnp.tuxfamily.org/files/download.php?file=miniupnpc-1.6.tar.gz'
-    wget 'http://fukuchi.org/works/qrencode/qrencode-3.2.0.tar.bz2'
+    wget 'http://miniupnp.tuxfamily.org/files/download.php?file=miniupnpc-1.6.tar.gz' -O miniupnpc-1.6.tar.gz
+    wget 'http://fukuchi.org/works/qrencode/qrencode-3.4.2.tar.bz2'
     # Inputs for Win32: (Linux has packages for these)
-    wget 'https://downloads.sourceforge.net/project/boost/boost/1.50.0/boost_1_50_0.tar.bz2'
-    wget 'http://www.openssl.org/source/openssl-1.0.1c.tar.gz'
+    wget 'https://sourceforge.net/projects/boost/files/boost/1.53.0/boost_1_53_0.tar.bz2/download'
+    wget 'https://www.openssl.org/source/openssl-1.0.1e.tar.gz'
     wget 'http://download.oracle.com/berkeley-db/db-4.8.30.NC.tar.gz'
-    wget 'https://downloads.sourceforge.net/project/libpng/zlib/1.2.6/zlib-1.2.6.tar.gz'
-    wget 'https://downloads.sourceforge.net/project/libpng/libpng15/older-releases/1.5.9/libpng-1.5.9.tar.gz'
-    wget 'http://releases.qt-project.org/qt4/source/qt-everywhere-opensource-src-4.8.3.tar.gz'
+    wget 'https://sourceforge.net/projects/libpng/files/zlib/1.2.6/zlib-1.2.6.tar.gz/download'
+    wget 'https://sourceforge.net/projects/libpng/files/libpng15/older-releases/1.5.9/libpng-1.5.9.tar.gz/download'
+    wget 'https://releases.qt-project.org/qt4/source/qt-everywhere-opensource-src-4.8.4.tar.gz'
     cd ../..
 
     cd gitian-builder

--- a/contrib/gitian-descriptors/boost-win32.yml
+++ b/contrib/gitian-descriptors/boost-win32.yml
@@ -4,19 +4,19 @@ suites:
 - "lucid"
 architectures:
 - "i386"
-packages: 
+packages:
 - "mingw32"
 - "faketime"
 - "zip"
 reference_datetime: "2011-01-30 00:00:00"
 remotes: []
 files:
-- "boost_1_50_0.tar.bz2"
+- "boost_1_53_0.tar.bz2"
 script: |
   TMPDIR="$HOME/tmpdir"
   mkdir -p $TMPDIR/bin/$GBUILD_BITS $TMPDIR/include
-  tar xjf boost_1_50_0.tar.bz2
-  cd boost_1_50_0
+  tar xjf boost_1_53_0.tar.bz2
+  cd boost_1_53_0
   echo "using gcc : 4.4 : i586-mingw32msvc-g++
         :
         <rc>i586-mingw32msvc-windres
@@ -34,5 +34,5 @@ script: |
   cd $TMPDIR
   export LD_PRELOAD=/usr/lib/faketime/libfaketime.so.1
   export FAKETIME=$REFERENCE_DATETIME
-  zip -r boost-win32-1.50.0-gitian2.zip *
-  cp boost-win32-1.50.0-gitian2.zip $OUTDIR
+  zip -r boost-win32-1.53.0-gitian.zip *
+  cp boost-win32-1.53.0-gitian.zip $OUTDIR

--- a/contrib/gitian-descriptors/deps-win32.yml
+++ b/contrib/gitian-descriptors/deps-win32.yml
@@ -13,20 +13,20 @@ packages:
 reference_datetime: "2011-01-30 00:00:00"
 remotes: []
 files:
-- "openssl-1.0.1c.tar.gz"
+- "openssl-1.0.1e.tar.gz"
 - "db-4.8.30.NC.tar.gz"
 - "miniupnpc-1.6.tar.gz"
 - "zlib-1.2.6.tar.gz"
 - "libpng-1.5.9.tar.gz"
-- "qrencode-3.2.0.tar.bz2"
+- "qrencode-3.4.2.tar.bz2"
 script: |
   #
   export LD_PRELOAD=/usr/lib/faketime/libfaketime.so.1
   export FAKETIME=$REFERENCE_DATETIME
   export TZ=UTC
   #
-  tar xzf openssl-1.0.1c.tar.gz
-  cd openssl-1.0.1c
+  tar xzf openssl-1.0.1e.tar.gz
+  cd openssl-1.0.1e
   ./Configure --cross-compile-prefix=i586-mingw32msvc- mingw
   make
   cd ..
@@ -56,13 +56,13 @@ script: |
   make $MAKEOPTS
   cd ..
   #
-  tar xjf qrencode-3.2.0.tar.bz2
-  cd qrencode-3.2.0
+  tar xjf qrencode-3.4.2.tar.bz2
+  cd qrencode-3.4.2
   ./configure CC=i586-mingw32msvc-cc AR=i586-mingw32msvc-ar STRIP=i586-mingw32msvc-strip RANLIB=i586-mingw32msvc-ranlib OBJDUMP=i586-mingw32msvc-objdump LD=i586-mingw32msvc-ld png_LIBS="../libpng-1.5.9/.libs/libpng15.a ../zlib-1.2.6/libz.a" png_CFLAGS="-I../libpng-1.5.9"
   make $MAKEOPTS
   cd ..
   #
-  zip -r $OUTDIR/bitcoin-deps-0.0.5.zip \
+  zip -r $OUTDIR/bitcoin-deps-0.0.6.zip \
     $(ls qrencode-*/{qrencode.h,.libs/libqrencode.{,l}a} | sort) \
     $(ls db-*/build_unix/{libdb_cxx.a,db.h,db_cxx.h,libdb.a,.libs/libdb_cxx-?.?.a} | sort) \
     $(find openssl-* -name '*.a' -o -name '*.h' | sort) \

--- a/contrib/gitian-descriptors/gitian-win32.yml
+++ b/contrib/gitian-descriptors/gitian-win32.yml
@@ -15,21 +15,21 @@ remotes:
 - "url": "https://github.com/bitcoin/bitcoin.git"
   "dir": "bitcoin"
 files:
-- "qt-win32-4.8.3-gitian-r1.zip"
-- "boost-win32-1.50.0-gitian2.zip"
-- "bitcoin-deps-0.0.5.zip"
+- "qt-win32-4.8.4-gitian.zip"
+- "boost-win32-1.53.0-gitian.zip"
+- "bitcoin-deps-0.0.6.zip"
 script: |
   #
   mkdir $HOME/qt
   cd $HOME/qt
-  unzip ../build/qt-win32-4.8.3-gitian-r1.zip
+  unzip ../build/qt-win32-4.8.4-gitian.zip
   cd $HOME/build/
   export PATH=$HOME/qt/bin/:$PATH
   #
-  mkdir boost_1_50_0
-  cd boost_1_50_0
+  mkdir boost_1_53_0
+  cd boost_1_53_0
   mkdir -p stage/lib
-  unzip ../boost-win32-1.50.0-gitian2.zip
+  unzip ../boost-win32-1.53.0-gitian.zip
   cd bin/$GBUILD_BITS
   for lib in *; do
     i586-mingw32msvc-ar rc ../../stage/lib/libboost_${lib}-mt-s.a $lib/*.o
@@ -39,7 +39,7 @@ script: |
   mv include/boost .
   cd ..
   #
-  unzip bitcoin-deps-0.0.5.zip
+  unzip bitcoin-deps-0.0.6.zip
   #
   find -type f | xargs touch --date="$REFERENCE_DATETIME"
   #
@@ -51,7 +51,7 @@ script: |
   export LD_PRELOAD=/usr/lib/faketime/libfaketime.so.1
   export FAKETIME=$REFERENCE_DATETIME
   export TZ=UTC
-  $HOME/qt/src/bin/qmake -spec unsupported/win32-g++-cross MINIUPNPC_LIB_PATH=$HOME/build/miniupnpc MINIUPNPC_INCLUDE_PATH=$HOME/build/ BDB_LIB_PATH=$HOME/build/db-4.8.30.NC/build_unix BDB_INCLUDE_PATH=$HOME/build/db-4.8.30.NC/build_unix BOOST_LIB_PATH=$HOME/build/boost_1_50_0/stage/lib BOOST_INCLUDE_PATH=$HOME/build/boost_1_50_0 BOOST_LIB_SUFFIX=-mt-s BOOST_THREAD_LIB_SUFFIX=_win32-mt-s OPENSSL_LIB_PATH=$HOME/build/openssl-1.0.1c OPENSSL_INCLUDE_PATH=$HOME/build/openssl-1.0.1c/include QRENCODE_LIB_PATH=$HOME/build/qrencode-3.2.0/.libs QRENCODE_INCLUDE_PATH=$HOME/build/qrencode-3.2.0 USE_QRCODE=1 INCLUDEPATH=$HOME/build DEFINES=BOOST_THREAD_USE_LIB BITCOIN_NEED_QT_PLUGINS=1 QMAKE_LRELEASE=lrelease QMAKE_CXXFLAGS=-frandom-seed=bitcoin USE_BUILD_INFO=1
+  $HOME/qt/src/bin/qmake -spec unsupported/win32-g++-cross MINIUPNPC_LIB_PATH=$HOME/build/miniupnpc MINIUPNPC_INCLUDE_PATH=$HOME/build/ BDB_LIB_PATH=$HOME/build/db-4.8.30.NC/build_unix BDB_INCLUDE_PATH=$HOME/build/db-4.8.30.NC/build_unix BOOST_LIB_PATH=$HOME/build/boost_1_53_0/stage/lib BOOST_INCLUDE_PATH=$HOME/build/boost_1_53_0 BOOST_LIB_SUFFIX=-mt-s BOOST_THREAD_LIB_SUFFIX=_win32-mt-s OPENSSL_LIB_PATH=$HOME/build/openssl-1.0.1e OPENSSL_INCLUDE_PATH=$HOME/build/openssl-1.0.1e/include QRENCODE_LIB_PATH=$HOME/build/qrencode-3.4.2/.libs QRENCODE_INCLUDE_PATH=$HOME/build/qrencode-3.4.2 USE_QRCODE=1 INCLUDEPATH=$HOME/build DEFINES=BOOST_THREAD_USE_LIB BITCOIN_NEED_QT_PLUGINS=1 QMAKE_LRELEASE=lrelease QMAKE_CXXFLAGS=-frandom-seed=bitcoin USE_BUILD_INFO=1
   make $MAKEOPTS
   cp release/bitcoin-qt.exe $OUTDIR/
   #

--- a/contrib/gitian-descriptors/gitian.yml
+++ b/contrib/gitian-descriptors/gitian.yml
@@ -24,7 +24,7 @@ remotes:
   "dir": "bitcoin"
 files:
 - "miniupnpc-1.6.tar.gz"
-- "qrencode-3.2.0.tar.bz2"
+- "qrencode-3.4.2.tar.bz2"
 script: |
   INSTDIR="$HOME/install"
   export LIBRARY_PATH="$INSTDIR/lib"
@@ -34,8 +34,8 @@ script: |
   INSTALLPREFIX=$INSTDIR make $MAKEOPTS install
   cd ..
   #
-  tar xjf qrencode-3.2.0.tar.bz2
-  cd qrencode-3.2.0
+  tar xjf qrencode-3.4.2.tar.bz2
+  cd qrencode-3.4.2
   ./configure --prefix=$INSTDIR --enable-static --disable-shared
   make $MAKEOPTS install
   cd ..

--- a/contrib/gitian-descriptors/qt-win32.yml
+++ b/contrib/gitian-descriptors/qt-win32.yml
@@ -11,15 +11,15 @@ packages:
 reference_datetime: "2011-01-30 00:00:00"
 remotes: []
 files:
-- "qt-everywhere-opensource-src-4.8.3.tar.gz"
+- "qt-everywhere-opensource-src-4.8.4.tar.gz"
 script: |
   INSTDIR="$HOME/qt/"
   mkdir $INSTDIR
   SRCDIR="$INSTDIR/src/"
   mkdir $SRCDIR
   #
-  tar xzf qt-everywhere-opensource-src-4.8.3.tar.gz
-  cd qt-everywhere-opensource-src-4.8.3
+  tar xzf qt-everywhere-opensource-src-4.8.4.tar.gz
+  cd qt-everywhere-opensource-src-4.8.4
   sed 's/$TODAY/2011-01-30/' -i configure
   sed 's/i686-pc-mingw32-/i586-mingw32msvc-/' -i mkspecs/unsupported/win32-g++-cross/qmake.conf
   sed --posix 's|QMAKE_CFLAGS\t\t= -pipe|QMAKE_CFLAGS\t\t= -pipe -isystem /usr/i586-mingw32msvc/include/ -frandom-seed=qtbuild|' -i mkspecs/unsupported/win32-g++-cross/qmake.conf
@@ -51,4 +51,4 @@ script: |
 
   # as zip stores file timestamps, use faketime to intercept stat calls to set dates for all files to reference date
   export LD_PRELOAD=/usr/lib/faketime/libfaketime.so.1
-  zip -r $OUTDIR/qt-win32-4.8.3-gitian-r1.zip *
+  zip -r $OUTDIR/qt-win32-4.8.4-gitian.zip *

--- a/doc/build-msw.txt
+++ b/doc/build-msw.txt
@@ -24,9 +24,9 @@ Dependencies
 Libraries you need to download separately and build:
 
                 default path               download
-OpenSSL         \openssl-1.0.1c-mgw        http://www.openssl.org/source/
+OpenSSL         \openssl-1.0.1e-mgw        https://www.openssl.org/source/
 Berkeley DB     \db-4.8.30.NC-mgw          http://www.oracle.com/technology/software/products/berkeley-db/index.html
-Boost           \boost-1.50.0-mgw          http://www.boost.org/users/download/
+Boost           \boost-1.53.0-mgw          http://www.boost.org/users/download/
 miniupnpc       \miniupnpc-1.6-mgw         http://miniupnp.tuxfamily.org/files/
 
 Their licenses:
@@ -36,9 +36,9 @@ Boost          MIT-like license
 miniupnpc      New (3-clause) BSD license
 
 Versions used in this release:
-OpenSSL      1.0.1c
+OpenSSL      1.0.1e
 Berkeley DB  4.8.30.NC
-Boost        1.50.0
+Boost        1.53.0
 miniupnpc    1.6
 
 
@@ -48,7 +48,7 @@ MSYS shell:
 un-tar sources with MSYS 'tar xfz' to avoid issue with symlinks (OpenSSL ticket 2377)
 change 'MAKE' env. variable from 'C:\MinGW32\bin\mingw32-make.exe' to '/c/MinGW32/bin/mingw32-make.exe'
 
-cd /c/openssl-1.0.1c-mgw
+cd /c/openssl-1.0.1e-mgw
 ./config
 make
 
@@ -63,7 +63,7 @@ Boost
 -----
 DOS prompt:
 downloaded boost jam 3.1.18
-cd \boost-1.50.0-mgw
+cd \boost-1.53.0-mgw
 bjam toolset=gcc --build-type=complete stage
 
 MiniUPnPc

--- a/doc/build-unix.txt
+++ b/doc/build-unix.txt
@@ -25,7 +25,7 @@ Dependencies
  Library     Purpose           Description
  -------     -------           -----------
  libssl      SSL Support       Secure communications
- libdb4.8    Berkeley DB       Blockchain & wallet storage
+ libdb4.8    Berkeley DB       Wallet storage
  libboost    Boost             C++ Library
  miniupnpc   UPnP Support      Optional firewall-jumping support
 
@@ -47,7 +47,7 @@ Licenses of statically linked libraries:
 
 Versions used in this release:
  GCC           4.3.3
- OpenSSL       1.0.1c
+ OpenSSL       1.0.1e
  Berkeley DB   4.8.30.NC
  Boost         1.37
  miniupnpc     1.6

--- a/doc/release-process.txt
+++ b/doc/release-process.txt
@@ -25,20 +25,20 @@
   * Fetch and build inputs: (first time, or when dependency versions change)
    mkdir -p inputs; cd inputs/
    wget 'http://miniupnp.free.fr/files/download.php?file=miniupnpc-1.6.tar.gz' -O miniupnpc-1.6.tar.gz
-   wget 'http://www.openssl.org/source/openssl-1.0.1c.tar.gz'
+   wget 'https://www.openssl.org/source/openssl-1.0.1e.tar.gz'
    wget 'http://download.oracle.com/berkeley-db/db-4.8.30.NC.tar.gz'
-   wget 'http://zlib.net/zlib-1.2.6.tar.gz'
-   wget 'ftp://ftp.simplesystems.org/pub/libpng/png/src/libpng-1.5.9.tar.gz'
-   wget 'http://fukuchi.org/works/qrencode/qrencode-3.2.0.tar.bz2'
-   wget 'http://downloads.sourceforge.net/project/boost/boost/1.50.0/boost_1_50_0.tar.bz2'
-   wget 'http://releases.qt-project.org/qt4/source/qt-everywhere-opensource-src-4.8.3.tar.gz'
+   wget 'https://sourceforge.net/projects/libpng/files/zlib/1.2.6/zlib-1.2.6.tar.gz/download'
+   wget 'https://sourceforge.net/projects/libpng/files/libpng15/older-releases/1.5.9/libpng-1.5.9.tar.gz/download'
+   wget 'http://fukuchi.org/works/qrencode/qrencode-3.4.2.tar.bz2'
+   wget 'https://sourceforge.net/projects/boost/files/boost/1.53.0/boost_1_53_0.tar.bz2/download'
+   wget 'https://releases.qt-project.org/qt4/source/qt-everywhere-opensource-src-4.8.4.tar.gz'
    cd ..
    ./bin/gbuild ../bitcoin/contrib/gitian-descriptors/boost-win32.yml
-   mv build/out/boost-win32-1.50.0-gitian2.zip inputs/
+   mv build/out/boost-win32-1.53.0-gitian.zip inputs/
    ./bin/gbuild ../bitcoin/contrib/gitian-descriptors/qt-win32.yml
-   mv build/out/qt-win32-4.8.3-gitian-r1.zip inputs/
+   mv build/out/qt-win32-4.8.4-gitian.zip inputs/
    ./bin/gbuild ../bitcoin/contrib/gitian-descriptors/deps-win32.yml
-   mv build/out/bitcoin-deps-0.0.5.zip inputs/
+   mv build/out/bitcoin-deps-0.0.6.zip inputs/
 
   * Build bitcoind and bitcoin-qt on Linux32, Linux64, and Win32:
    ./bin/gbuild --commit bitcoin=v${VERSION} ../bitcoin/contrib/gitian-descriptors/gitian.yml

--- a/src/makefile.linux-mingw
+++ b/src/makefile.linux-mingw
@@ -13,15 +13,15 @@ USE_IPV6:=1
 INCLUDEPATHS= \
  -I"$(CURDIR)" \
  -I"$(CURDIR)"/obj \
- -I"$(DEPSDIR)/boost_1_50_0" \
+ -I"$(DEPSDIR)/boost_1_53_0" \
  -I"$(DEPSDIR)/db-4.8.30.NC/build_unix" \
- -I"$(DEPSDIR)/openssl-1.0.1c/include" \
+ -I"$(DEPSDIR)/openssl-1.0.1e/include" \
  -I"$(DEPSDIR)"
 
 LIBPATHS= \
- -L"$(DEPSDIR)/boost_1_50_0/stage/lib" \
+ -L"$(DEPSDIR)/boost_1_53_0/stage/lib" \
  -L"$(DEPSDIR)/db-4.8.30.NC/build_unix" \
- -L"$(DEPSDIR)/openssl-1.0.1c"
+ -L"$(DEPSDIR)/openssl-1.0.1e"
 
 LIBS= \
   $(CURDIR)/leveldb/libleveldb.a $(CURDIR)/leveldb/libmemenv.a \
@@ -29,7 +29,6 @@ LIBS= \
  -l boost_filesystem-mt-s \
  -l boost_program_options-mt-s \
  -l boost_thread_win32-mt-s \
- -l boost_chrono-mt-s \
  -l db_cxx \
  -l ssl \
  -l crypto

--- a/src/makefile.mingw
+++ b/src/makefile.mingw
@@ -21,7 +21,7 @@ USE_UPNP:=-
 USE_IPV6:=1
 
 DEPSDIR?=/usr/local
-BOOST_SUFFIX?=-mgw46-mt-sd-1_52
+BOOST_SUFFIX?=-mgw44-mt-s-1_53
 
 INCLUDEPATHS= \
  -I"$(CURDIR)" \
@@ -38,7 +38,6 @@ LIBS= \
  -l boost_filesystem$(BOOST_SUFFIX) \
  -l boost_program_options$(BOOST_SUFFIX) \
  -l boost_thread$(BOOST_SUFFIX) \
- -l boost_chrono$(BOOST_SUFFIX) \
  -l db_cxx \
  -l ssl \
  -l crypto


### PR DESCRIPTION
- Update Boost from 1.50 to 1.53
  -- removes the need to build the Chrono lib
- Update OpenSSL from 1.0.1c to 1.0.1e
  -- fixes for CVE-2013-0169, CVE-2012-2686 and CVE-2013-0166
- Update Qt from 4.8.3 to 4.8.4
- Update libqrencode from 3.2.0 to 3.4.2
  -- Memory leak bug has been fixed and others

Don't merge this yet, this is just to see what pull tester is doing with it :).

Replaces #2108
