### PR TITLE
Use a uint256 for bnChainWork

### DIFF
--- a/contrib/test-patches/bitcoind-comparison.patch
+++ b/contrib/test-patches/bitcoind-comparison.patch
@@ -1,5 +1,5 @@
-diff --git a/src/main.cpp b/src/main.cpp
-index 8c115c2..1e70ff2 100644
+diff --git a/contrib/test-patches/bitcoind-comparison.patch b/contrib/test-patches/bitcoind-comparison.patch
+index 04a8618..519429a 100644
 --- a/src/main.cpp
 +++ b/src/main.cpp
 @@ -31,8 +31,8 @@ CTxMemPool mempool;
@@ -12,7 +12,7 @@ index 8c115c2..1e70ff2 100644
 +static CBigNum bnProofOfWorkLimit(~uint256(0) >> 1);
  CBlockIndex* pindexGenesisBlock = NULL;
  int nBestHeight = -1;
- CBigNum bnBestChainWork = 0;
+ uint256 nBestChainWork = 0;
 @@ -1055,7 +1055,7 @@ int64 static GetBlockValue(int nHeight, int64 nFees)
      int64 nSubsidy = 50 * COIN;
  
@@ -22,7 +22,7 @@ index 8c115c2..1e70ff2 100644
  
      return nSubsidy + nFees;
  }
-@@ -2706,9 +2706,9 @@ bool InitBlockIndex() {
+@@ -2736,9 +2736,9 @@ bool InitBlockIndex() {
          block.hashPrevBlock = 0;
          block.hashMerkleRoot = block.BuildMerkleTree();
          block.nVersion = 1;
@@ -35,7 +35,7 @@ index 8c115c2..1e70ff2 100644
  
          if (fTestNet)
          {
-@@ -3007,7 +3007,7 @@ bool static AlreadyHave(const CInv& inv)
+@@ -3024,7 +3024,7 @@ bool static AlreadyHave(const CInv& inv)
  // The message start string is designed to be unlikely to occur in normal data.
  // The characters are rarely used upper ASCII, not valid as UTF-8, and produce
  // a large 4-byte int at any alignment.

--- a/src/bignum.h
+++ b/src/bignum.h
@@ -222,7 +222,7 @@ public:
         BN_mpi2bn(pch, p - pch, this);
     }
 
-    uint256 getuint256()
+    uint256 getuint256() const
     {
         unsigned int nSize = BN_bn2mpi(this, NULL);
         if (nSize < 4)

--- a/src/main.h
+++ b/src/main.h
@@ -77,8 +77,8 @@ extern std::set<CBlockIndex*, CBlockIndexWorkComparator> setBlockIndexValid;
 extern uint256 hashGenesisBlock;
 extern CBlockIndex* pindexGenesisBlock;
 extern int nBestHeight;
-extern CBigNum bnBestChainWork;
-extern CBigNum bnBestInvalidWork;
+extern uint256 nBestChainWork;
+extern uint256 nBestInvalidWork;
 extern uint256 hashBestChain;
 extern CBlockIndex* pindexBest;
 extern unsigned int nTransactionsUpdated;
@@ -1619,7 +1619,7 @@ public:
     unsigned int nUndoPos;
 
     // (memory only) Total amount of work (expected number of hashes) in the chain up to and including this block
-    CBigNum bnChainWork;
+    uint256 nChainWork;
 
     // Number of transactions in this block.
     // Note: in a potential headers-first mode, this number cannot be relied upon
@@ -1648,7 +1648,7 @@ public:
         nFile = 0;
         nDataPos = 0;
         nUndoPos = 0;
-        bnChainWork = 0;
+        nChainWork = 0;
         nTx = 0;
         nChainTx = 0;
         nStatus = 0;
@@ -1669,7 +1669,7 @@ public:
         nFile = 0;
         nDataPos = 0;
         nUndoPos = 0;
-        bnChainWork = 0;
+        nChainWork = 0;
         nTx = 0;
         nChainTx = 0;
         nStatus = 0;
@@ -1793,8 +1793,8 @@ public:
 struct CBlockIndexWorkComparator
 {
     bool operator()(CBlockIndex *pa, CBlockIndex *pb) {
-        if (pa->bnChainWork > pb->bnChainWork) return false;
-        if (pa->bnChainWork < pb->bnChainWork) return true;
+        if (pa->nChainWork > pb->nChainWork) return false;
+        if (pa->nChainWork < pb->nChainWork) return true;
 
         if (pa->GetBlockHash() < pb->GetBlockHash()) return false;
         if (pa->GetBlockHash() > pb->GetBlockHash()) return true;

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -55,6 +55,16 @@ public:
         return ret;
     }
 
+    double getdouble() const
+    {
+        double ret = 0.0;
+        double fact = 1.0;
+        for (int i = 0; i < WIDTH; i++) {
+            ret += fact * pn[i];
+            fact *= 4294967296.0;
+        }
+        return ret;
+    }
 
     base_uint& operator=(uint64 b)
     {


### PR DESCRIPTION
Every block index entry currently requires a separately-allocated CBigNum. By replacing them with uint256, it's just 32 bytes extra in CBlockIndex itself.

This should save us a few megabytes in RAM (around 32 bytes per block), and less allocation overhead.
