### PR TITLE
Global cleanups

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4750,3 +4750,29 @@ uint64 CTxOutCompressor::DecompressAmount(uint64 x)
     }
     return n;
 }
+
+
+class CMainCleanup
+{
+public:
+    CMainCleanup() {}
+    ~CMainCleanup() {
+        // block headers
+        std::map<uint256, CBlockIndex*>::iterator it1 = mapBlockIndex.begin();
+        for (; it1 != mapBlockIndex.end(); it1++)
+            delete (*it1).second;
+        mapBlockIndex.clear();
+
+        // orphan blocks
+        std::map<uint256, CBlock*>::iterator it2 = mapOrphanBlocks.begin();
+        for (; it2 != mapOrphanBlocks.end(); it2++)
+            delete (*it2).second;
+        mapOrphanBlocks.clear();
+
+        // orphan transactions
+        std::map<uint256, CDataStream*>::iterator it3 = mapOrphanTransactions.begin();
+        for (; it3 != mapOrphanTransactions.end(); it3++)
+            delete (*it3).second;
+        mapOrphanTransactions.clear();
+    }
+} instance_of_cmaincleanup;


### PR DESCRIPTION
Clean up all known global datastructures at shutdown.

This should make leak detection much easier.

Typical valgrind output after this:
==5897==    definitely lost: 0 bytes in 0 blocks
==5897==    indirectly lost: 0 bytes in 0 blocks
==5897==      possibly lost: 1,903 bytes in 9 blocks
==5897==    still reachable: 194,073 bytes in 2,929 blocks

(almost all of the reachable stuff is RPC/asio/boostthreads)
