### PR TITLE
Adding blockhash parameter to getrawtransaction - Issue #2077

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -957,7 +957,7 @@ bool GetTransaction(const uint256 &hash, CTransaction &txOut, uint256 &hashBlock
             }
         }
 
-        if (lookupHashBlock != 0 && mapBlockIndex.count(lookupHashBlock) > 0) {
+        if (lookupHashBlock != 0) {
             CBlock block;
             CBlockIndex* pblockindex = mapBlockIndex[lookupHashBlock];
             block.ReadFromDisk(pblockindex);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -943,7 +943,7 @@ bool CWalletTx::AcceptWalletTransaction(bool fCheckInputs)
 
 
 // Return transaction in tx, and if it was found inside a block, its hash is placed in hashBlock
-bool GetTransaction(const uint256 &hash, CTransaction &txOut, uint256 &hashBlock, bool fAllowSlow)
+bool GetTransaction(const uint256 &hash, CTransaction &txOut, uint256 &hashBlock, bool fAllowSlow, const uint256 lookupHashBlock)
 {
     CBlockIndex *pindexSlow = NULL;
     {
@@ -954,6 +954,18 @@ bool GetTransaction(const uint256 &hash, CTransaction &txOut, uint256 &hashBlock
             {
                 txOut = mempool.lookup(hash);
                 return true;
+            }
+        }
+
+        if (lookupHashBlock != 0 && mapBlockIndex.count(lookupHashBlock) > 0) {
+            CBlock block;
+            CBlockIndex* pblockindex = mapBlockIndex[lookupHashBlock];
+            block.ReadFromDisk(pblockindex);
+            BOOST_FOREACH(const CTransaction&tx, block.vtx){
+                if( tx.GetHash() == hash ){
+                    txOut = tx;
+                    return true;
+                }
             }
         }
 

--- a/src/main.h
+++ b/src/main.h
@@ -177,7 +177,7 @@ bool IsInitialBlockDownload();
 /** Format a string that describes several potential problems detected by the core */
 std::string GetWarnings(std::string strFor);
 /** Retrieve a transaction (from memory pool, or from disk, if possible) */
-bool GetTransaction(const uint256 &hash, CTransaction &tx, uint256 &hashBlock, bool fAllowSlow = false);
+bool GetTransaction(const uint256 &hash, CTransaction &tx, uint256 &hashBlock, bool fAllowSlow = false, const uint256 lookupHashBlock = 0);
 /** Connect/disconnect blocks until pindexNew is the new tip of the active block chain */
 bool SetBestChain(CValidationState &state, CBlockIndex* pindexNew);
 /** Find the best known block, and make it the tip of the block chain */

--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -155,6 +155,8 @@ Value getrawtransaction(const Array& params, bool fHelp)
     if (params.size() > 2){
         std::string strHash = params[2].get_str();
         uint256 hash(strHash);
+        if (mapBlockIndex.count(hash) == 0)
+            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Blockhash not found");
         lookupHashBlock = hash;
     }
 

--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -134,12 +134,13 @@ void TxToJSON(const CTransaction& tx, const uint256 hashBlock, Object& entry)
 
 Value getrawtransaction(const Array& params, bool fHelp)
 {
-    if (fHelp || params.size() < 1 || params.size() > 2)
+    if (fHelp || params.size() < 1 || params.size() > 3)
         throw runtime_error(
-            "getrawtransaction <txid> [verbose=0]\n"
+            "getrawtransaction <txid> [verbose=0] [blockhash]\n"
             "If verbose=0, returns a string that is\n"
             "serialized, hex-encoded data for <txid>.\n"
             "If verbose is non-zero, returns an Object\n"
+            "If blockhash is provided, search into block \n"
             "with information about <txid>.");
 
     uint256 hash = ParseHashV(params[0], "parameter 1");
@@ -150,7 +151,14 @@ Value getrawtransaction(const Array& params, bool fHelp)
 
     CTransaction tx;
     uint256 hashBlock = 0;
-    if (!GetTransaction(hash, tx, hashBlock, true))
+    uint256 lookupHashBlock = 0;
+    if (params.size() > 2){
+        std::string strHash = params[2].get_str();
+        uint256 hash(strHash);
+        lookupHashBlock = hash;
+    }
+
+    if (!GetTransaction(hash, tx, hashBlock, true,lookupHashBlock))
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "No information available about transaction");
 
     CDataStream ssTx(SER_NETWORK, PROTOCOL_VERSION);

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -87,6 +87,7 @@ BOOST_AUTO_TEST_CASE(rpc_rawparams)
     BOOST_CHECK_THROW(CallRPC("getrawtransaction"), runtime_error);
     BOOST_CHECK_THROW(CallRPC("getrawtransaction not_hex"), runtime_error);
     BOOST_CHECK_THROW(CallRPC("getrawtransaction a3b807410df0b60fcb9736768df5823938b2f838694939ba45f3c0a1bff150ed not_int"), runtime_error);
+    BOOST_CHECK_THROW(CallRPC("getrawtransaction a3b807410df0b60fcb9736768df5823938b2f838694939ba45f3c0a1bff150ed 0 not_hex"), runtime_error);
 
     BOOST_CHECK_NO_THROW(CallRPC("listunspent"));
     BOOST_CHECK_THROW(CallRPC("listunspent string"), runtime_error);


### PR DESCRIPTION
This optional parameter is used to specify the block which is used to look up the raw transaction.

(https://github.com/bitcoin/bitcoin/issues/2077)
![Pantallazo](https://f.cloud.github.com/assets/155036/316346/a28a2b3c-9812-11e2-81a5-c9f788280e7b.png)
