### PR TITLE
Don't use -dbcache for BDB anymore

### DIFF
--- a/src/db.cpp
+++ b/src/db.cpp
@@ -75,11 +75,10 @@ bool CDBEnv::Open(const boost::filesystem::path& path)
     if (GetBoolArg("-privdb", true))
         nEnvFlags |= DB_PRIVATE;
 
-    unsigned int nDbCache = GetArg("-dbcache", 25);
     dbenv.set_lg_dir(pathLogDir.string().c_str());
-    dbenv.set_cachesize(nDbCache / 1024, (nDbCache % 1024)*1048576, 1);
-    dbenv.set_lg_bsize(1048576);
-    dbenv.set_lg_max(10485760);
+    dbenv.set_cachesize(0, 0x100000, 1); // 1 MiB should be enough for just the wallet
+    dbenv.set_lg_bsize(0x10000);
+    dbenv.set_lg_max(1048576);
     dbenv.set_lk_max_locks(40000);
     dbenv.set_lk_max_objects(40000);
     dbenv.set_errfile(fopen(pathErrorFile.string().c_str(), "a")); /// debug


### PR DESCRIPTION
-dbcache was originally used to set the maximum buffer size in the BDB environment, and was later changed to set the chainstate cache and leveldb caches. No need to use it for BDB now that only the wallet remains there.

This should reduce memory allocation (but not necessarily memory usage) a bit, especially when -dbcache is set high.
