### PR TITLE
Tighten permissions of ~/.bitcoin/ to prevent unauthorized access

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1073,6 +1073,14 @@ const boost::filesystem::path &GetDataDir(bool fNetSpecific)
         path /= "testnet3";
 
     fs::create_directory(path);
+    
+    // fs::create_directory sets access permission to 0777 (full access
+    // by all users). Secure DataDir by setting his to 0700 (full
+    // access by owner only).
+#ifndef WIN32
+    // Mac and Linux
+    chmod(path.string().c_str(), S_IRUSR|S_IWUSR|S_IXUSR);
+#endif
 
     cachedPath[fNetSpecific]=true;
     return path;


### PR DESCRIPTION
boost::filesystem::create_directory() defaults to allow all users full access to the Bitcoin DataDir. This directory should only be accessible to the owner to limit unauthorized access.

A future version can use boost::filesystem::permissions() (v1.49+) instead of dealing with the lower level chmod directly.
