### PR TITLE
Move GenerateBitcoins() call out of net.cpp's StartNode()

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1027,6 +1027,9 @@ bool AppInit2()
     if (fServer)
         NewThread(ThreadRPCServer, NULL);
 
+    // Generate coins in the background
+    GenerateBitcoins(GetBoolArg("-gen", false), pwalletMain);
+
     // ********************************************************* Step 12: finished
 
     uiInterface.InitMessage(_("Done loading"));

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2047,9 +2047,6 @@ void StartNode(void* parg)
     // Dump network addresses
     if (!NewThread(ThreadDumpAddress, NULL))
         printf("Error; NewThread(ThreadDumpAddress) failed\n");
-
-    // Generate coins in the background
-    GenerateBitcoins(GetBoolArg("-gen", false), pwalletMain);
 }
 
 bool StopNode()


### PR DESCRIPTION
The internal miner is closely bound to the wallet engine,
not the blockchain engine.

This small cleanup was cherry-picked from #2154 because it is useful beyond the obvious merits:  it gets closer to my goal of fork()'ing away the blockchain engine.

Note that this commit places GenerateBitcoins() after RPC server start, unlike #2154 which employs a stub thread.
