### PR TITLE
Remove transaction count from overview page

### DIFF
--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -158,23 +158,6 @@
               </property>
              </widget>
             </item>
-            <item row="3" column="0">
-             <widget class="QLabel" name="label_2">
-              <property name="text">
-               <string>Number of transactions:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="3" column="1">
-             <widget class="QLabel" name="labelNumTransactions">
-              <property name="toolTip">
-               <string>Total number of transactions in wallet</string>
-              </property>
-              <property name="text">
-               <string notr="true">0</string>
-              </property>
-             </widget>
-            </item>
             <item row="2" column="0">
              <widget class="QLabel" name="labelImmatureText">
               <property name="text">

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -147,11 +147,6 @@ void OverviewPage::setBalance(qint64 balance, qint64 unconfirmedBalance, qint64 
     ui->labelImmatureText->setVisible(showImmature);
 }
 
-void OverviewPage::setNumTransactions(int count)
-{
-    ui->labelNumTransactions->setText(QLocale::system().toString(count));
-}
-
 void OverviewPage::setClientModel(ClientModel *model)
 {
     this->clientModel = model;
@@ -182,9 +177,6 @@ void OverviewPage::setWalletModel(WalletModel *model)
         // Keep up to date with wallet
         setBalance(model->getBalance(), model->getUnconfirmedBalance(), model->getImmatureBalance());
         connect(model, SIGNAL(balanceChanged(qint64, qint64, qint64)), this, SLOT(setBalance(qint64, qint64, qint64)));
-
-        setNumTransactions(model->getNumTransactions());
-        connect(model, SIGNAL(numTransactionsChanged(int)), this, SLOT(setNumTransactions(int)));
 
         connect(model->getOptionsModel(), SIGNAL(displayUnitChanged(int)), this, SLOT(updateDisplayUnit()));
     }

--- a/src/qt/overviewpage.h
+++ b/src/qt/overviewpage.h
@@ -30,7 +30,6 @@ public:
 
 public slots:
     void setBalance(qint64 balance, qint64 unconfirmedBalance, qint64 immatureBalance);
-    void setNumTransactions(int count);
 
 signals:
     void transactionClicked(const QModelIndex &index);


### PR DESCRIPTION
It was needlessly confusing people, as it doesn't necessarily match the
number of transactions in the transaction list.
There is discussion and code in #2177 to add this to the debug window. I'm not sure about that, but I am sure that it needs to go from the overview page.
