### PR TITLE
fix "send coins" via context menu in address book

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -205,7 +205,7 @@ void BitcoinGUI::createActions()
     connect(historyAction, SIGNAL(triggered()), this, SLOT(gotoHistoryPage()));
     connect(addressBookAction, SIGNAL(triggered()), this, SLOT(showNormalIfMinimized()));
     connect(addressBookAction, SIGNAL(triggered()), this, SLOT(gotoAddressBookPage()));
-    
+
     quitAction = new QAction(QIcon(":/icons/quit"), tr("E&xit"), this);
     quitAction->setStatusTip(tr("Quit application"));
     quitAction->setShortcut(QKeySequence(Qt::CTRL + Qt::Key_Q));
@@ -475,9 +475,9 @@ void BitcoinGUI::gotoReceiveCoinsPage()
     if (walletFrame) walletFrame->gotoReceiveCoinsPage();
 }
 
-void BitcoinGUI::gotoSendCoinsPage()
+void BitcoinGUI::gotoSendCoinsPage(QString addr)
 {
-    if (walletFrame) walletFrame->gotoSendCoinsPage();
+    if (walletFrame) walletFrame->gotoSendCoinsPage(addr);
 }
 
 void BitcoinGUI::gotoSignMessageTab(QString addr)
@@ -700,7 +700,7 @@ void BitcoinGUI::askFee(qint64 nFeeRequired, bool *payFee)
 
 void BitcoinGUI::incomingTransaction(const QString& date, int unit, qint64 amount, const QString& type, const QString& address)
 {
-   // On new transaction, make an info balloon
+    // On new transaction, make an info balloon
     message((amount)<0 ? tr("Sent transaction") : tr("Incoming transaction"),
              tr("Date: %1\n"
                 "Amount: %2\n"

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -94,7 +94,7 @@ private:
     QAction *changePassphraseAction;
     QAction *aboutQtAction;
     QAction *openRPCConsoleAction;
-    
+
     QSystemTrayIcon *trayIcon;
     Notificator *notificator;
     TransactionView *transactionView;
@@ -162,7 +162,7 @@ private slots:
     /** Switch to receive coins page */
     void gotoReceiveCoinsPage();
     /** Switch to send coins page */
-    void gotoSendCoinsPage();
+    void gotoSendCoinsPage(QString addr = "");
 
     /** Show Sign/Verify Message dialog and switch to sign message tab */
     void gotoSignMessageTab(QString addr = "");

--- a/src/qt/walletframe.cpp
+++ b/src/qt/walletframe.cpp
@@ -88,9 +88,9 @@ void WalletFrame::gotoReceiveCoinsPage()
     walletStack->gotoReceiveCoinsPage();
 }
 
-void WalletFrame::gotoSendCoinsPage()
+void WalletFrame::gotoSendCoinsPage(QString addr)
 {
-    walletStack->gotoSendCoinsPage();
+    walletStack->gotoSendCoinsPage(addr);
 }
 
 void WalletFrame::gotoSignMessageTab(QString addr)

--- a/src/qt/walletframe.h
+++ b/src/qt/walletframe.h
@@ -25,7 +25,7 @@ public:
 
     bool addWallet(const QString& name, WalletModel *walletModel);
     bool setCurrentWallet(const QString& name);
-    
+
     void removeAllWallets();
 
     bool handleURI(const QString &uri);
@@ -47,7 +47,7 @@ public slots:
     /** Switch to receive coins page */
     void gotoReceiveCoinsPage();
     /** Switch to send coins page */
-    void gotoSendCoinsPage();
+    void gotoSendCoinsPage(QString addr = "");
 
     /** Show Sign/Verify Message dialog and switch to sign message tab */
     void gotoSignMessageTab(QString addr = "");

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -56,6 +56,8 @@ int WalletModel::getNumTransactions() const
     int numTransactions = 0;
     {
         LOCK(wallet->cs_wallet);
+        // the size of mapWallet contains the number of unique transaction IDs
+        // (e.g. payments to yourself generate 2 transactions, but both share the same transaction ID)
         numTransactions = wallet->mapWallet.size();
     }
     return numTransactions;

--- a/src/qt/walletstack.cpp
+++ b/src/qt/walletstack.cpp
@@ -97,11 +97,11 @@ void WalletStack::gotoReceiveCoinsPage()
         i.value()->gotoReceiveCoinsPage();
 }
 
-void WalletStack::gotoSendCoinsPage()
+void WalletStack::gotoSendCoinsPage(QString addr)
 {
     QMap<QString, WalletView*>::const_iterator i;
     for (i = mapWalletViews.constBegin(); i != mapWalletViews.constEnd(); ++i)
-        i.value()->gotoSendCoinsPage();
+        i.value()->gotoSendCoinsPage(addr);
 }
 
 void WalletStack::gotoSignMessageTab(QString addr)

--- a/src/qt/walletstack.h
+++ b/src/qt/walletstack.h
@@ -45,16 +45,16 @@ public:
     ~WalletStack();
 
     void setBitcoinGUI(BitcoinGUI *gui) { this->gui = gui; }
-    
+
     void setClientModel(ClientModel *clientModel) { this->clientModel = clientModel; }
-    
+
     bool addWallet(const QString& name, WalletModel *walletModel);
     bool removeWallet(const QString& name);
-    
+
     void removeAllWallets();
 
     bool handleURI(const QString &uri);
-    
+
     void showOutOfSyncWarning(bool fShow);
 
 private:
@@ -76,7 +76,7 @@ public slots:
     /** Switch to receive coins page */
     void gotoReceiveCoinsPage();
     /** Switch to send coins page */
-    void gotoSendCoinsPage();
+    void gotoSendCoinsPage(QString addr = "");
 
     /** Show Sign/Verify Message dialog and switch to sign message tab */
     void gotoSignMessageTab(QString addr = "");

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -74,9 +74,11 @@ WalletView::WalletView(QWidget *parent, BitcoinGUI *_gui):
     // Double-clicking on a transaction on the transaction history page shows details
     connect(transactionView, SIGNAL(doubleClicked(QModelIndex)), transactionView, SLOT(showDetails()));
 
-    // Clicking on "Verify Message" in the address book sends you to the verify message tab
+    // Clicking on "Send Coins" in the address book sends you to the send coins tab
+    connect(addressBookPage, SIGNAL(sendCoins(QString)), this, SLOT(gotoSendCoinsPage(QString)));
+    // Clicking on "Verify Message" in the address book opens the verify message tab in the Sign/Verify Message dialog
     connect(addressBookPage, SIGNAL(verifyMessage(QString)), this, SLOT(gotoVerifyMessageTab(QString)));
-    // Clicking on "Sign Message" in the receive coins page sends you to the sign message tab
+    // Clicking on "Sign Message" in the receive coins page opens the sign message tab in the Sign/Verify Message dialog
     connect(receiveCoinsPage, SIGNAL(signMessage(QString)), this, SLOT(gotoSignMessageTab(QString)));
 
     gotoOverviewPage();
@@ -257,13 +259,16 @@ void WalletView::gotoReceiveCoinsPage()
     connect(exportAction, SIGNAL(triggered()), receiveCoinsPage, SLOT(exportClicked()));
 }
 
-void WalletView::gotoSendCoinsPage()
+void WalletView::gotoSendCoinsPage(QString addr)
 {
     sendCoinsAction->setChecked(true);
     setCurrentWidget(sendCoinsPage);
 
     exportAction->setEnabled(false);
     disconnect(exportAction, SIGNAL(triggered()), 0, 0);
+
+    if(!addr.isEmpty())
+        sendCoinsPage->setAddress(addr);
 }
 
 void WalletView::gotoSignMessageTab(QString addr)

--- a/src/qt/walletview.h
+++ b/src/qt/walletview.h
@@ -49,9 +49,9 @@ public:
         functionality.
     */
     void setWalletModel(WalletModel *walletModel);
-    
+
     bool handleURI(const QString &uri);
-    
+
     void showOutOfSyncWarning(bool fShow);
 
 private:
@@ -105,7 +105,7 @@ public slots:
     /** Switch to receive coins page */
     void gotoReceiveCoinsPage();
     /** Switch to send coins page */
-    void gotoSendCoinsPage();
+    void gotoSendCoinsPage(QString addr = "");
 
     /** Show Sign/Verify Message dialog and switch to sign message tab */
     void gotoSignMessageTab(QString addr = "");
@@ -125,7 +125,7 @@ public slots:
     void changePassphrase();
     /** Ask for passphrase to unlock wallet temporarily */
     void unlockWallet();
-    
+
     void setEncryptionStatus();
 };
 


### PR DESCRIPTION
- the send coins context menu entry was not working anymore, because
  a non current version of #2220 was merged onto current master
- also removes some unneeded spaces and adds a comment to
  WalletModel::getNumTransactions()
