### PR TITLE
Bitcoin-Qt: fix debug window

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -338,6 +338,7 @@ void BitcoinGUI::setClientModel(ClientModel *clientModel)
         // Receive and report messages from network/worker thread
         connect(clientModel, SIGNAL(message(QString,QString,unsigned int)), this, SLOT(message(QString,QString,unsigned int)));
 
+        rpcConsole->setClientModel(clientModel);
         walletFrame->setClientModel(clientModel);
     }
 }


### PR DESCRIPTION
- fix debug window, by re-adding rpcConsole->setClientModel(clientModel);
  in BitcoinGUI::setClientModel(), which was removed by #2220
