### PR TITLE
Bitcoin-Qt: fix GUI after initial multi-wallet patch

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -56,7 +56,7 @@
 
 const QString BitcoinGUI::DEFAULT_WALLET = "~Default";
 
-BitcoinGUI::BitcoinGUI(QWidget *parent):
+BitcoinGUI::BitcoinGUI(QWidget *parent) :
     QMainWindow(parent),
     clientModel(0),
     encryptWalletAction(0),
@@ -94,7 +94,7 @@ BitcoinGUI::BitcoinGUI(QWidget *parent):
     // Create wallet frame and make it the central widget
     walletFrame = new WalletFrame(this);
     setCentralWidget(walletFrame);
-    
+
     // Create status bar
     statusBar();
 
@@ -221,6 +221,7 @@ void BitcoinGUI::createActions()
     optionsAction->setMenuRole(QAction::PreferencesRole);
     toggleHideAction = new QAction(QIcon(":/icons/bitcoin"), tr("&Show / Hide"), this);
     toggleHideAction->setStatusTip(tr("Show or hide the main Window"));
+
     encryptWalletAction = new QAction(QIcon(":/icons/lock_closed"), tr("&Encrypt Wallet..."), this);
     encryptWalletAction->setStatusTip(tr("Encrypt the private keys that belong to your wallet"));
     encryptWalletAction->setCheckable(true);

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -29,6 +29,7 @@ class QStackedWidget;
 class QUrl;
 class QListWidget;
 class QPushButton;
+class QAction;
 QT_END_NAMESPACE
 
 /**
@@ -41,7 +42,7 @@ class BitcoinGUI : public QMainWindow
 
 public:
     static const QString DEFAULT_WALLET;
-    
+
     explicit BitcoinGUI(QWidget *parent = 0);
     ~BitcoinGUI();
 
@@ -56,8 +57,16 @@ public:
 
     bool addWallet(const QString& name, WalletModel *walletModel);
     bool setCurrentWallet(const QString& name);
-    
+
     void removeAllWallets();
+
+    /** Used by WalletView to allow access to needed QActions */
+    QAction * getOverviewAction() { return overviewAction; }
+    QAction * getHistoryAction() { return historyAction; }
+    QAction * getAddressBookAction() { return addressBookAction; }
+    QAction * getReceiveCoinsAction() { return receiveCoinsAction; }
+    QAction * getSendCoinsAction() { return sendCoinsAction; }
+    QAction * getExportAction() { return exportAction; }
 
 protected:
     void changeEvent(QEvent *e);

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -10,26 +10,17 @@
 #include "addressbookpage.h"
 #include "sendcoinsdialog.h"
 #include "signverifymessagedialog.h"
-#include "optionsdialog.h"
-#include "aboutdialog.h"
 #include "clientmodel.h"
 #include "walletmodel.h"
-#include "editaddressdialog.h"
 #include "optionsmodel.h"
-#include "transactiondescdialog.h"
-#include "addresstablemodel.h"
 #include "transactionview.h"
 #include "overviewpage.h"
-#include "bitcoinunits.h"
-#include "guiconstants.h"
 #include "askpassphrasedialog.h"
-#include "guiutil.h"
 #include "ui_interface.h"
 
 #include <QVBoxLayout>
 #include <QActionGroup>
 #include <QAction>
-#include <QLabel>
 #include <QDesktopServices>
 #include <QFileDialog>
 
@@ -37,13 +28,8 @@ WalletView::WalletView(QWidget *parent, BitcoinGUI *_gui):
     QStackedWidget(parent),
     gui(_gui),
     clientModel(0),
-    walletModel(0),
-    encryptWalletAction(0),
-    changePassphraseAction(0)
+    walletModel(0)
 {
-    // Create actions for the toolbar, menu bar and tray/dock icon
-    createActions();
-
     // Create tabs
     overviewPage = new OverviewPage();
 
@@ -88,74 +74,6 @@ WalletView::~WalletView()
 {
 }
 
-void WalletView::createActions()
-{
-    QActionGroup *tabGroup = new QActionGroup(this);
-
-    overviewAction = new QAction(QIcon(":/icons/overview"), tr("&Overview"), this);
-    overviewAction->setStatusTip(tr("Show general overview of wallet"));
-    overviewAction->setToolTip(overviewAction->statusTip());
-    overviewAction->setCheckable(true);
-    overviewAction->setShortcut(QKeySequence(Qt::ALT + Qt::Key_1));
-    tabGroup->addAction(overviewAction);
-
-    sendCoinsAction = new QAction(QIcon(":/icons/send"), tr("&Send coins"), this);
-    sendCoinsAction->setStatusTip(tr("Send coins to a Bitcoin address"));
-    sendCoinsAction->setToolTip(sendCoinsAction->statusTip());
-    sendCoinsAction->setCheckable(true);
-    sendCoinsAction->setShortcut(QKeySequence(Qt::ALT + Qt::Key_2));
-    tabGroup->addAction(sendCoinsAction);
-
-    receiveCoinsAction = new QAction(QIcon(":/icons/receiving_addresses"), tr("&Receive coins"), this);
-    receiveCoinsAction->setStatusTip(tr("Show the list of addresses for receiving payments"));
-    receiveCoinsAction->setToolTip(receiveCoinsAction->statusTip());
-    receiveCoinsAction->setCheckable(true);
-    receiveCoinsAction->setShortcut(QKeySequence(Qt::ALT + Qt::Key_3));
-    tabGroup->addAction(receiveCoinsAction);
-
-    historyAction = new QAction(QIcon(":/icons/history"), tr("&Transactions"), this);
-    historyAction->setStatusTip(tr("Browse transaction history"));
-    historyAction->setToolTip(historyAction->statusTip());
-    historyAction->setCheckable(true);
-    historyAction->setShortcut(QKeySequence(Qt::ALT + Qt::Key_4));
-    tabGroup->addAction(historyAction);
-
-    addressBookAction = new QAction(QIcon(":/icons/address-book"), tr("&Address Book"), this);
-    addressBookAction->setStatusTip(tr("Edit the list of stored addresses and labels"));
-    addressBookAction->setToolTip(addressBookAction->statusTip());
-    addressBookAction->setCheckable(true);
-    addressBookAction->setShortcut(QKeySequence(Qt::ALT + Qt::Key_5));
-    tabGroup->addAction(addressBookAction);
-
-    connect(overviewAction, SIGNAL(triggered()), this, SLOT(gotoOverviewPage()));
-    connect(sendCoinsAction, SIGNAL(triggered()), this, SLOT(gotoSendCoinsPage()));
-    connect(receiveCoinsAction, SIGNAL(triggered()), this, SLOT(gotoReceiveCoinsPage()));
-    connect(historyAction, SIGNAL(triggered()), this, SLOT(gotoHistoryPage()));
-    connect(addressBookAction, SIGNAL(triggered()), this, SLOT(gotoAddressBookPage()));
-
-    encryptWalletAction = new QAction(QIcon(":/icons/lock_closed"), tr("&Encrypt Wallet..."), this);
-    encryptWalletAction->setStatusTip(tr("Encrypt the private keys that belong to your wallet"));
-    encryptWalletAction->setCheckable(true);
-    backupWalletAction = new QAction(QIcon(":/icons/filesave"), tr("&Backup Wallet..."), this);
-    backupWalletAction->setStatusTip(tr("Backup wallet to another location"));
-    changePassphraseAction = new QAction(QIcon(":/icons/key"), tr("&Change Passphrase..."), this);
-    changePassphraseAction->setStatusTip(tr("Change the passphrase used for wallet encryption"));
-    signMessageAction = new QAction(QIcon(":/icons/edit"), tr("Sign &message..."), this);
-    signMessageAction->setStatusTip(tr("Sign messages with your Bitcoin addresses to prove you own them"));
-    verifyMessageAction = new QAction(QIcon(":/icons/transaction_0"), tr("&Verify message..."), this);
-    verifyMessageAction->setStatusTip(tr("Verify messages to ensure they were signed with specified Bitcoin addresses"));
-
-    exportAction = new QAction(QIcon(":/icons/export"), tr("&Export..."), this);
-    exportAction->setStatusTip(tr("Export the data in the current tab to a file"));
-    exportAction->setToolTip(exportAction->statusTip());
-
-    connect(encryptWalletAction, SIGNAL(triggered(bool)), this, SLOT(encryptWallet(bool)));
-    connect(backupWalletAction, SIGNAL(triggered()), this, SLOT(backupWallet()));
-    connect(changePassphraseAction, SIGNAL(triggered()), this, SLOT(changePassphrase()));
-    connect(signMessageAction, SIGNAL(triggered()), this, SLOT(gotoSignMessageTab()));
-    connect(verifyMessageAction, SIGNAL(triggered()), this, SLOT(gotoVerifyMessageTab()));
-}
-
 void WalletView::setBitcoinGUI(BitcoinGUI *gui)
 {
     this->gui = gui;
@@ -164,7 +82,7 @@ void WalletView::setBitcoinGUI(BitcoinGUI *gui)
 void WalletView::setClientModel(ClientModel *clientModel)
 {
     this->clientModel = clientModel;
-    if(clientModel)
+    if (clientModel)
     {
         overviewPage->setClientModel(clientModel);
         addressBookPage->setOptionsModel(clientModel->getOptionsModel());
@@ -175,7 +93,7 @@ void WalletView::setClientModel(ClientModel *clientModel)
 void WalletView::setWalletModel(WalletModel *walletModel)
 {
     this->walletModel = walletModel;
-    if(walletModel)
+    if (walletModel)
     {
         // Receive and report messages from wallet thread
         connect(walletModel, SIGNAL(message(QString,QString,unsigned int)), gui, SLOT(message(QString,QString,unsigned int)));
@@ -222,52 +140,52 @@ void WalletView::incomingTransaction(const QModelIndex& parent, int start, int /
 
 void WalletView::gotoOverviewPage()
 {
-    overviewAction->setChecked(true);
+    gui->getOverviewAction()->setChecked(true);
     setCurrentWidget(overviewPage);
 
-    exportAction->setEnabled(false);
-    disconnect(exportAction, SIGNAL(triggered()), 0, 0);
+    gui->getExportAction()->setEnabled(false);
+    disconnect(gui->getExportAction(), SIGNAL(triggered()), 0, 0);
 }
 
 void WalletView::gotoHistoryPage()
 {
-    historyAction->setChecked(true);
+    gui->getHistoryAction()->setChecked(true);
     setCurrentWidget(transactionsPage);
 
-    exportAction->setEnabled(true);
-    disconnect(exportAction, SIGNAL(triggered()), 0, 0);
-    connect(exportAction, SIGNAL(triggered()), transactionView, SLOT(exportClicked()));
+    gui->getExportAction()->setEnabled(true);
+    disconnect(gui->getExportAction(), SIGNAL(triggered()), 0, 0);
+    connect(gui->getExportAction(), SIGNAL(triggered()), transactionView, SLOT(exportClicked()));
 }
 
 void WalletView::gotoAddressBookPage()
 {
-    addressBookAction->setChecked(true);
+    gui->getAddressBookAction()->setChecked(true);
     setCurrentWidget(addressBookPage);
 
-    exportAction->setEnabled(true);
-    disconnect(exportAction, SIGNAL(triggered()), 0, 0);
-    connect(exportAction, SIGNAL(triggered()), addressBookPage, SLOT(exportClicked()));
+    gui->getExportAction()->setEnabled(true);
+    disconnect(gui->getExportAction(), SIGNAL(triggered()), 0, 0);
+    connect(gui->getExportAction(), SIGNAL(triggered()), addressBookPage, SLOT(exportClicked()));
 }
 
 void WalletView::gotoReceiveCoinsPage()
 {
-    receiveCoinsAction->setChecked(true);
+    gui->getReceiveCoinsAction()->setChecked(true);
     setCurrentWidget(receiveCoinsPage);
 
-    exportAction->setEnabled(true);
-    disconnect(exportAction, SIGNAL(triggered()), 0, 0);
-    connect(exportAction, SIGNAL(triggered()), receiveCoinsPage, SLOT(exportClicked()));
+    gui->getExportAction()->setEnabled(true);
+    disconnect(gui->getExportAction(), SIGNAL(triggered()), 0, 0);
+    connect(gui->getExportAction(), SIGNAL(triggered()), receiveCoinsPage, SLOT(exportClicked()));
 }
 
 void WalletView::gotoSendCoinsPage(QString addr)
 {
-    sendCoinsAction->setChecked(true);
+    gui->getSendCoinsAction()->setChecked(true);
     setCurrentWidget(sendCoinsPage);
 
-    exportAction->setEnabled(false);
-    disconnect(exportAction, SIGNAL(triggered()), 0, 0);
+    gui->getExportAction()->setEnabled(false);
+    disconnect(gui->getExportAction(), SIGNAL(triggered()), 0, 0);
 
-    if(!addr.isEmpty())
+    if (!addr.isEmpty())
         sendCoinsPage->setAddress(addr);
 }
 
@@ -276,7 +194,7 @@ void WalletView::gotoSignMessageTab(QString addr)
     // call show() in showTab_SM()
     signVerifyMessageDialog->showTab_SM(true);
 
-    if(!addr.isEmpty())
+    if (!addr.isEmpty())
         signVerifyMessageDialog->setAddress_SM(addr);
 }
 
@@ -285,7 +203,7 @@ void WalletView::gotoVerifyMessageTab(QString addr)
     // call show() in showTab_VM()
     signVerifyMessageDialog->showTab_VM(true);
 
-    if(!addr.isEmpty())
+    if (!addr.isEmpty())
         signVerifyMessageDialog->setAddress_VM(addr);
 }
 
@@ -327,8 +245,8 @@ void WalletView::backupWallet()
 {
     QString saveDir = QDesktopServices::storageLocation(QDesktopServices::DocumentsLocation);
     QString filename = QFileDialog::getSaveFileName(this, tr("Backup Wallet"), saveDir, tr("Wallet Data (*.dat)"));
-    if(!filename.isEmpty()) {
-        if(!walletModel->backupWallet(filename)) {
+    if (!filename.isEmpty()) {
+        if (!walletModel->backupWallet(filename)) {
             gui->message(tr("Backup Failed"), tr("There was an error trying to save the wallet data to the new location."),
                       CClientUIInterface::MSG_ERROR);
         }
@@ -350,7 +268,7 @@ void WalletView::unlockWallet()
     if(!walletModel)
         return;
     // Unlock wallet when requested by wallet model
-    if(walletModel->getEncryptionStatus() == WalletModel::Locked)
+    if (walletModel->getEncryptionStatus() == WalletModel::Locked)
     {
         AskPassphraseDialog dlg(AskPassphraseDialog::Unlock, this);
         dlg.setModel(walletModel);

--- a/src/qt/walletview.h
+++ b/src/qt/walletview.h
@@ -10,7 +10,6 @@
 #include <QStackedWidget>
 
 class BitcoinGUI;
-class TransactionTableModel;
 class ClientModel;
 class WalletModel;
 class TransactionView;
@@ -18,7 +17,6 @@ class OverviewPage;
 class AddressBookPage;
 class SendCoinsDialog;
 class SignVerifyMessageDialog;
-class Notificator;
 class RPCConsole;
 
 QT_BEGIN_NAMESPACE
@@ -35,6 +33,7 @@ QT_END_NAMESPACE
 class WalletView : public QStackedWidget
 {
     Q_OBJECT
+
 public:
     explicit WalletView(QWidget *parent, BitcoinGUI *_gui);
     ~WalletView();
@@ -66,34 +65,7 @@ private:
     SendCoinsDialog *sendCoinsPage;
     SignVerifyMessageDialog *signVerifyMessageDialog;
 
-    QLabel *labelEncryptionIcon;
-    QLabel *labelConnectionsIcon;
-    QLabel *labelBlocksIcon;
-    QLabel *progressBarLabel;
-
-    QAction *overviewAction;
-    QAction *historyAction;
-    QAction *quitAction;
-    QAction *sendCoinsAction;
-    QAction *addressBookAction;
-    QAction *signMessageAction;
-    QAction *verifyMessageAction;
-    QAction *aboutAction;
-    QAction *receiveCoinsAction;
-    QAction *optionsAction;
-    QAction *toggleHideAction;
-    QAction *exportAction;
-    QAction *encryptWalletAction;
-    QAction *backupWalletAction;
-    QAction *changePassphraseAction;
-    QAction *aboutQtAction;
-    QAction *openRPCConsoleAction;
-
     TransactionView *transactionView;
-
-    /** Create the main UI actions. */
-    void createActions();
-    /** Create the menu bar and sub-menus. */
 
 public slots:
     /** Switch to overview (home) page */


### PR DESCRIPTION
- adds 6 methods in BitcoinGUI to access some actions needed by the new
  WalletView class
- updates WalletView class to use these instead of trying to duplicate
  these
- cleanup walletview.h and remove all unneeded stuff
- this fixes problems with tabs toolbar (#2451) and export broken (#2436)
- more details in #2447
