### PR TITLE
Update transaction statistics

### DIFF
--- a/src/checkpoints.cpp
+++ b/src/checkpoints.cpp
@@ -15,11 +15,11 @@ namespace Checkpoints
     typedef std::map<int, uint256> MapCheckpoints;
 
     // How many times we expect transactions after the last checkpoint to
-    // be slower. This number is conservative. On multi-core CPUs with
-    // parallel signature checking enabled, this number is way too high.
-    // We prefer a progressbar that's faster at the end than the other
-    // way around, though.
-    static const double fSigcheckVerificationFactor = 15.0;
+    // be slower. This number is a compromise, as it can't be accurate for
+    // every system. When reindexing from a fast disk with a slow CPU, it
+    // can be up to 20, while when downloading from a slow network with a
+    // fast multicore CPU, it won't be much higher than 1.
+    static const double fSigcheckVerificationFactor = 5.0;
 
     struct CCheckpointData {
         const MapCheckpoints *mapCheckpoints;
@@ -48,10 +48,10 @@ namespace Checkpoints
         ;
     static const CCheckpointData data = {
         &mapCheckpoints,
-        1357902690, // * UNIX timestamp of last checkpoint block
-        11011160,   // * total number of transactions between genesis and last checkpoint
+        1363044259, // * UNIX timestamp of last checkpoint block
+        14264869,   // * total number of transactions between genesis and last checkpoint
                     //   (the tx=... number in the SetBestChain debug.log lines)
-        50000.0     // * estimated number of transactions per day after checkpoint
+        60000.0     // * estimated number of transactions per day after checkpoint
     };
 
     static MapCheckpoints mapCheckpointsTestnet = 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1868,9 +1868,10 @@ bool SetBestChain(CValidationState &state, CBlockIndex* pindexNew)
     bnBestChainWork = pindexNew->bnChainWork;
     nTimeBestReceived = GetTime();
     nTransactionsUpdated++;
-    printf("SetBestChain: new best=%s  height=%d  work=%s  tx=%lu  date=%s\n",
+    printf("SetBestChain: new best=%s  height=%d  work=%s  tx=%lu  date=%s  progress=%f\n",
       BlockHashStr(hashBestChain).c_str(), nBestHeight, bnBestChainWork.ToString().c_str(), (unsigned long)pindexNew->nChainTx,
-      DateTimeStrFormat("%Y-%m-%d %H:%M:%S", pindexBest->GetBlockTime()).c_str());
+      DateTimeStrFormat("%Y-%m-%d %H:%M:%S", pindexBest->GetBlockTime()).c_str(),
+      Checkpoints::GuessVerificationProgress(pindexBest));
 
     // Check the version of the last 100 blocks to see if we need to upgrade:
     if (!fIsInitialDownload)


### PR DESCRIPTION
As these were not updated when 'backporting' the 225430 checkpoint into head.

Additionally, also report verification progress in debug.log, and tweak the sigcheck-verification-speed-factor a bit.
