### PR TITLE
Bitcoin-Qt: use $$TRANSLATIONS in bitcoin-qt.pro

### DIFF
--- a/bitcoin-qt.pro
+++ b/bitcoin-qt.pro
@@ -410,4 +410,4 @@ contains(RELEASE, 1) {
     }
 }
 
-system($$QMAKE_LRELEASE -silent $$_PRO_FILE_)
+system($$QMAKE_LRELEASE -silent $$TRANSLATIONS)


### PR DESCRIPTION
- instead of parsing the project file by using $$_PRO_FILE_ just use
  $$TRANSLATIONS, which contains a list of all needed files, to build
  our *.qm translation files

With the local build I had some weird problems with $$_PRO_FILE_, which I solved by using $$TRANSLATIONS directly. If everything is working with our official build it would be nice to update to this :).
