### PR TITLE
Bitcoin-Qt: add Genesis blocks time for testnet

### DIFF
--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -52,8 +52,10 @@ QDateTime ClientModel::getLastBlockDate() const
 {
     if (pindexBest)
         return QDateTime::fromTime_t(pindexBest->GetBlockTime());
-    else
+    else if(!isTestNet())
         return QDateTime::fromTime_t(1231006505); // Genesis block's time
+    else
+        return QDateTime::fromTime_t(1296688602); // Genesis block's time (testnet)
 }
 
 double ClientModel::getVerificationProgress() const


### PR DESCRIPTION
- add the Genesis blocks time for the testnet in
  ClientModel::getLastBlockDate()

See https://github.com/bitcoin/bitcoin/blob/master/src/main.cpp#L2743
