### PR TITLE
Bitcoin-Qt: update for BitcoinGUI::eventFilter()

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -751,7 +751,7 @@ bool BitcoinGUI::eventFilter(QObject *object, QEvent *event)
     if (event->type() == QEvent::StatusTip)
     {
         // Prevent adding text from setStatusTip(), if we currently use the status bar for displaying other stuff
-        if (progressBarLabel->isVisible() && progressBar->isVisible())
+        if (progressBarLabel->isVisible() || progressBar->isVisible())
             return true;
     }
     return QMainWindow::eventFilter(object, event);


### PR DESCRIPTION
- this allows us to use the progressbar and the label independently (if
  needed) and still prevents setStatusTip() to use them, if one of the 2
  is active
