### PR TITLE
fix mac specific button modification on addressbookpage

### DIFF
--- a/src/qt/addressbookpage.cpp
+++ b/src/qt/addressbookpage.cpp
@@ -28,9 +28,11 @@ AddressBookPage::AddressBookPage(Mode mode, Tabs tab, QWidget *parent) :
     ui->setupUi(this);
 
 #ifdef Q_OS_MAC // Icons on push buttons are very uncommon on Mac
-    ui->newAddressButton->setIcon(QIcon());
-    ui->copyToClipboard->setIcon(QIcon());
-    ui->deleteButton->setIcon(QIcon());
+    ui->newAddress->setIcon(QIcon());
+    ui->copyAddress->setIcon(QIcon());
+    ui->deleteAddress->setIcon(QIcon());
+    ui->verifyMessage->setIcon(QIcon());
+    ui->signMessage->setIcon(QIcon());
 #endif
 
 #ifndef USE_QRCODE


### PR DESCRIPTION
- continue the mac behavior of clearing button icons (because it's unusual on mac apps)
- fix: new button variable names, new buttons (verifyMessage, signMessage)

Signed-off-by: Jonas Schnelli jonas.schnelli@include7.ch
