### PR TITLE
Bitcoin-Qt: add missing setIcon() for MacDoc when on Mac

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -74,6 +74,7 @@ BitcoinGUI::BitcoinGUI(QWidget *parent) :
     QApplication::setWindowIcon(QIcon(":icons/bitcoin"));
     setWindowIcon(QIcon(":icons/bitcoin"));
 #else
+    MacDockIconHandler::instance()->setIcon(QIcon(":icons/bitcoin"));
     setUnifiedTitleAndToolBarOnMac(true);
     QApplication::setAttribute(Qt::AA_DontShowIconsInMenus);
 #endif


### PR DESCRIPTION
@jonasschnelli Can you verify if this is needed, at least it seems to be missing as we have THIS in the current code: https://github.com/bitcoin/bitcoin/blob/master/src/qt/bitcoingui.cpp#L317
