### PR TITLE
new COPYRIGHT_YEAR macro in clientversion.h

### DIFF
--- a/bitcoin-qt.pro
+++ b/bitcoin-qt.pro
@@ -330,8 +330,15 @@ TSQM.CONFIG = no_link
 QMAKE_EXTRA_COMPILERS += TSQM
 
 # "Other files" to show in Qt Creator
-OTHER_FILES += \
-    doc/*.rst doc/*.txt doc/README README.md res/bitcoin-qt.rc src/test/*.cpp src/test/*.h src/qt/test/*.cpp src/qt/test/*.h
+OTHER_FILES += README.md \
+    doc/*.rst \
+    doc/*.txt \
+    doc/README \
+    src/qt/res/bitcoin-qt.rc \
+    src/test/*.cpp \
+    src/test/*.h \
+    src/qt/test/*.cpp \
+    src/qt/test/*.h
 
 # platform specific defaults, if not overridden on command line
 isEmpty(BOOST_LIB_SUFFIX) {

--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -2,7 +2,7 @@
 #define CLIENTVERSION_H
 
 //
-// client versioning
+// client versioning and copyright year
 //
 
 // These need to be macros, as version.cpp's and bitcoin-qt.rc's voodoo requires it
@@ -13,6 +13,10 @@
 
 // Set to true for release, false for prerelease or test build
 #define CLIENT_VERSION_IS_RELEASE  false
+
+// Copyright year (2009-this)
+// Todo: update this when changing our copyright comments in the source
+#define COPYRIGHT_YEAR 2013
 
 // Converts the parameter X to a string after macro replacement on X has been performed.
 // Don't merge these into one macro!

--- a/src/qt/aboutdialog.cpp
+++ b/src/qt/aboutdialog.cpp
@@ -2,10 +2,7 @@
 #include "ui_aboutdialog.h"
 
 #include "clientmodel.h"
-
-// Copyright year (2009-this)
-// Todo: update this when changing our copyright comments in the source
-const int ABOUTDIALOG_COPYRIGHT_YEAR = 2013;
+#include "clientversion.h"
 
 AboutDialog::AboutDialog(QWidget *parent) :
     QDialog(parent),
@@ -14,7 +11,7 @@ AboutDialog::AboutDialog(QWidget *parent) :
     ui->setupUi(this);
 
     // Set current copyright year
-    ui->copyrightLabel->setText(tr("Copyright") + QString(" &copy; ") + tr("2009-%1 The Bitcoin developers").arg(ABOUTDIALOG_COPYRIGHT_YEAR));
+    ui->copyrightLabel->setText(tr("Copyright") + QString(" &copy; ") + tr("2009-%1 The Bitcoin developers").arg(COPYRIGHT_YEAR));
 }
 
 void AboutDialog::setModel(ClientModel *model)

--- a/src/qt/res/bitcoin-qt.rc
+++ b/src/qt/res/bitcoin-qt.rc
@@ -7,6 +7,7 @@ IDI_ICON1 ICON DISCARDABLE "icons/bitcoin.ico"
 #define VER_PRODUCTVERSION_STR STRINGIZE(CLIENT_VERSION_MAJOR) "." STRINGIZE(CLIENT_VERSION_MINOR) "." STRINGIZE(CLIENT_VERSION_REVISION) "." STRINGIZE(CLIENT_VERSION_BUILD)
 #define VER_FILEVERSION        VER_PRODUCTVERSION
 #define VER_FILEVERSION_STR    VER_PRODUCTVERSION_STR
+#define COPYRIGHT_STR          "2009-" STRINGIZE(COPYRIGHT_YEAR) " The Bitcoin developers"
 
 VS_VERSION_INFO VERSIONINFO
 FILEVERSION     VER_FILEVERSION
@@ -22,7 +23,7 @@ BEGIN
             VALUE "FileDescription",    "Bitcoin-Qt (OSS GUI client for Bitcoin)"
             VALUE "FileVersion",        VER_FILEVERSION_STR
             VALUE "InternalName",       "bitcoin-qt"
-            VALUE "LegalCopyright",     "2009-2013 The Bitcoin developers"
+            VALUE "LegalCopyright",     COPYRIGHT_STR
             VALUE "LegalTrademarks1",   "Distributed under the MIT/X11 software license, see the accompanying file COPYING or http://www.opensource.org/licenses/mit-license.php."
             VALUE "OriginalFilename",   "bitcoin-qt.exe"
             VALUE "ProductName",        "Bitcoin-Qt"


### PR DESCRIPTION
- move COPYRIGHT_YEAR to clientversion.h
  -- this allows usage of that information also in other places (e.g. splash
  screen)
- use the new COPYRIGHT_YEAR macro in bitcoin-qt.rc
  -- this reduces the places, where we need to change the year further
- fix bitcoin-qt.rc not showing up in Qt Creator 

Intended for #2495 mainly, but allows further usage cases.
