### PR TITLE
qt: move export button to tabs

### DIFF
--- a/src/qt/addressbookpage.cpp
+++ b/src/qt/addressbookpage.cpp
@@ -33,6 +33,7 @@ AddressBookPage::AddressBookPage(Mode mode, Tabs tab, QWidget *parent) :
     ui->deleteAddress->setIcon(QIcon());
     ui->verifyMessage->setIcon(QIcon());
     ui->signMessage->setIcon(QIcon());
+    ui->exportButton->setIcon(QIcon());
 #endif
 
 #ifndef USE_QRCODE
@@ -45,6 +46,7 @@ AddressBookPage::AddressBookPage(Mode mode, Tabs tab, QWidget *parent) :
         connect(ui->tableView, SIGNAL(doubleClicked(QModelIndex)), this, SLOT(accept()));
         ui->tableView->setEditTriggers(QAbstractItemView::NoEditTriggers);
         ui->tableView->setFocus();
+        ui->exportButton->hide();
         break;
     case ForEditing:
         ui->buttonBox->setVisible(false);
@@ -323,7 +325,7 @@ void AddressBookPage::done(int retval)
     QDialog::done(retval);
 }
 
-void AddressBookPage::exportClicked()
+void AddressBookPage::on_exportButton_clicked()
 {
     // CSV is currently the only supported format
     QString filename = GUIUtil::getSaveFileName(

--- a/src/qt/addressbookpage.h
+++ b/src/qt/addressbookpage.h
@@ -43,7 +43,6 @@ public:
 
 public slots:
     void done(int retval);
-    void exportClicked();
 
 private:
     Ui::AddressBookPage *ui;
@@ -76,6 +75,8 @@ private slots:
     void onCopyLabelAction();
     /** Edit currently selected address entry (no button) */
     void onEditAction();
+    /** Export button clicked */
+    void on_exportButton_clicked();
 
     /** Set button states based on selected tab and selection */
     void selectionChanged();

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -236,9 +236,6 @@ void BitcoinGUI::createActions()
     verifyMessageAction = new QAction(QIcon(":/icons/transaction_0"), tr("&Verify message..."), this);
     verifyMessageAction->setStatusTip(tr("Verify messages to ensure they were signed with specified Bitcoin addresses"));
 
-    exportAction = new QAction(QIcon(":/icons/export"), tr("&Export..."), this);
-    exportAction->setStatusTip(tr("Export the data in the current tab to a file"));
-    exportAction->setToolTip(exportAction->statusTip());
     openRPCConsoleAction = new QAction(QIcon(":/icons/debugwindow"), tr("&Debug window"), this);
     openRPCConsoleAction->setStatusTip(tr("Open debugging and diagnostic console"));
 
@@ -267,7 +264,6 @@ void BitcoinGUI::createMenuBar()
     // Configure the menus
     QMenu *file = appMenuBar->addMenu(tr("&File"));
     file->addAction(backupWalletAction);
-    file->addAction(exportAction);
     file->addAction(signMessageAction);
     file->addAction(verifyMessageAction);
     file->addSeparator();
@@ -295,10 +291,6 @@ void BitcoinGUI::createToolBars()
     toolbar->addAction(receiveCoinsAction);
     toolbar->addAction(historyAction);
     toolbar->addAction(addressBookAction);
-
-    QToolBar *toolbar2 = addToolBar(tr("Actions toolbar"));
-    toolbar2->setToolButtonStyle(Qt::ToolButtonTextBesideIcon);
-    toolbar2->addAction(exportAction);
 }
 
 void BitcoinGUI::setClientModel(ClientModel *clientModel)

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -67,7 +67,6 @@ public:
     QAction * getAddressBookAction() { return addressBookAction; }
     QAction * getReceiveCoinsAction() { return receiveCoinsAction; }
     QAction * getSendCoinsAction() { return sendCoinsAction; }
-    QAction * getExportAction() { return exportAction; }
 
 protected:
     void changeEvent(QEvent *e);
@@ -98,7 +97,6 @@ private:
     QAction *receiveCoinsAction;
     QAction *optionsAction;
     QAction *toggleHideAction;
-    QAction *exportAction;
     QAction *encryptWalletAction;
     QAction *backupWalletAction;
     QAction *changePassphraseAction;

--- a/src/qt/forms/addressbookpage.ui
+++ b/src/qt/forms/addressbookpage.ui
@@ -149,6 +149,20 @@
       </spacer>
      </item>
      <item>
+      <widget class="QPushButton" name="exportButton">
+       <property name="toolTip">
+        <string>Export the data in the current tab to a file</string>
+       </property>
+       <property name="text">
+        <string>&amp;Export</string>
+       </property>
+       <property name="icon">
+        <iconset resource="../bitcoin.qrc">
+         <normaloff>:/icons/export</normaloff>:/icons/export</iconset>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QDialogButtonBox" name="buttonBox">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Maximum" vsizetype="Fixed">

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -23,6 +23,7 @@
 #include <QAction>
 #include <QDesktopServices>
 #include <QFileDialog>
+#include <QPushButton>
 
 WalletView::WalletView(QWidget *parent, BitcoinGUI *_gui):
     QStackedWidget(parent),
@@ -35,8 +36,17 @@ WalletView::WalletView(QWidget *parent, BitcoinGUI *_gui):
 
     transactionsPage = new QWidget(this);
     QVBoxLayout *vbox = new QVBoxLayout();
+    QHBoxLayout *hbox_buttons = new QHBoxLayout();
     transactionView = new TransactionView(this);
     vbox->addWidget(transactionView);
+    QPushButton *exportButton = new QPushButton("&Export", this);
+    exportButton->setToolTip(tr("Export the data in the current tab to a file"));
+#ifndef Q_OS_MAC // Icons on push buttons are very uncommon on Mac
+    exportButton->setIcon(QIcon(":/icons/export"));
+#endif
+    hbox_buttons->addStretch();
+    hbox_buttons->addWidget(exportButton);
+    vbox->addLayout(hbox_buttons);
     transactionsPage->setLayout(vbox);
 
     addressBookPage = new AddressBookPage(AddressBookPage::ForEditing, AddressBookPage::SendingTab);
@@ -66,6 +76,8 @@ WalletView::WalletView(QWidget *parent, BitcoinGUI *_gui):
     connect(addressBookPage, SIGNAL(verifyMessage(QString)), this, SLOT(gotoVerifyMessageTab(QString)));
     // Clicking on "Sign Message" in the receive coins page opens the sign message tab in the Sign/Verify Message dialog
     connect(receiveCoinsPage, SIGNAL(signMessage(QString)), this, SLOT(gotoSignMessageTab(QString)));
+    // Clicking on "Export" allows to export the transaction list
+    connect(exportButton, SIGNAL(clicked()), transactionView, SLOT(exportClicked()));
 
     gotoOverviewPage();
 }
@@ -142,48 +154,30 @@ void WalletView::gotoOverviewPage()
 {
     gui->getOverviewAction()->setChecked(true);
     setCurrentWidget(overviewPage);
-
-    gui->getExportAction()->setEnabled(false);
-    disconnect(gui->getExportAction(), SIGNAL(triggered()), 0, 0);
 }
 
 void WalletView::gotoHistoryPage()
 {
     gui->getHistoryAction()->setChecked(true);
     setCurrentWidget(transactionsPage);
-
-    gui->getExportAction()->setEnabled(true);
-    disconnect(gui->getExportAction(), SIGNAL(triggered()), 0, 0);
-    connect(gui->getExportAction(), SIGNAL(triggered()), transactionView, SLOT(exportClicked()));
 }
 
 void WalletView::gotoAddressBookPage()
 {
     gui->getAddressBookAction()->setChecked(true);
     setCurrentWidget(addressBookPage);
-
-    gui->getExportAction()->setEnabled(true);
-    disconnect(gui->getExportAction(), SIGNAL(triggered()), 0, 0);
-    connect(gui->getExportAction(), SIGNAL(triggered()), addressBookPage, SLOT(exportClicked()));
 }
 
 void WalletView::gotoReceiveCoinsPage()
 {
     gui->getReceiveCoinsAction()->setChecked(true);
     setCurrentWidget(receiveCoinsPage);
-
-    gui->getExportAction()->setEnabled(true);
-    disconnect(gui->getExportAction(), SIGNAL(triggered()), 0, 0);
-    connect(gui->getExportAction(), SIGNAL(triggered()), receiveCoinsPage, SLOT(exportClicked()));
 }
 
 void WalletView::gotoSendCoinsPage(QString addr)
 {
     gui->getSendCoinsAction()->setChecked(true);
     setCurrentWidget(sendCoinsPage);
-
-    gui->getExportAction()->setEnabled(false);
-    disconnect(gui->getExportAction(), SIGNAL(triggered()), 0, 0);
 
     if (!addr.isEmpty())
         sendCoinsPage->setAddress(addr);


### PR DESCRIPTION
Having the export button at the top was confusing people into thinking the entire wallet was exported.

This commit moves the export button to the address book, receiving addresses and transaction tabs separately.
