### PR TITLE
Enable tx replacement on testnet.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -669,7 +669,7 @@ bool CTxMemPool::accept(CValidationState &state, CTransaction &tx, bool fCheckIn
         if (mapNextTx.count(outpoint))
         {
             // Disable replacement feature for now
-            return false;
+            if (!fTestNet) return false;
 
             // Allow replacing with a newer version of the same transaction
             if (i != 0)


### PR DESCRIPTION
Tested: wrote a program that replaces a non-final tx and checked it against a bitcoind with this patch, replacement was successful.
