### PR TITLE
Require strictly-standard encodings in mempool

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -768,7 +768,7 @@ bool CTxMemPool::accept(CValidationState &state, CTransaction &tx, bool fCheckIn
 
         // Check against previous transactions
         // This is done last to help prevent CPU exhaustion denial-of-service attacks.
-        if (!tx.CheckInputs(state, view, true, SCRIPT_VERIFY_P2SH))
+        if (!tx.CheckInputs(state, view, true, SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_STRICTENC))
         {
             return error("CTxMemPool::accept() : ConnectInputs failed %s", hash.ToString().c_str());
         }


### PR DESCRIPTION
This will make the mempool require strictly DER-encoded signatures, and restrict public keys to being either compressed or uncompressed (so no "hybrid" ones).

See the discussion here: http://comments.gmane.org/gmane.comp.bitcoin.devel/1973
