### PR TITLE
fixes #2506: mac binary with proper version and copyright meta-informati...

### DIFF
--- a/doc/release-process.txt
+++ b/doc/release-process.txt
@@ -80,6 +80,7 @@
   make
   export QTDIR=/opt/local/share/qt4  # needed to find translations/qt_*.qm files
   T=$(contrib/qt_translations.py $QTDIR/translations src/qt/locale)
+  python2.7 share/qt/clean_mac_info_plist.py
   python2.7 contrib/macdeploy/macdeployqtplus Bitcoin-Qt.app -add-qt-tr $T -dmg -fancy contrib/macdeploy/fancy.plist
 
  Build output expected:

--- a/share/qt/Info.plist
+++ b/share/qt/Info.plist
@@ -7,7 +7,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleGetInfoString</key>
-	<string>Bitcoin-Qt</string>
+	<string>$VERSION, Copyright © 2009-$YEAR The Bitcoin developers</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$VERSION</string>
+	<key>CFBundleVersion</key>
+	<string>$VERSION</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleExecutable</key>

--- a/share/qt/clean_mac_info_plist.py
+++ b/share/qt/clean_mac_info_plist.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+# Jonas Schnelli, 2013
+# make sure the Bitcoin-Qt.app contains the right plist (including the right version)
+# fix made because of serval bugs in Qt mac deployment (https://bugreports.qt-project.org/browse/QTBUG-21267)
+
+from string import Template
+from datetime import date
+
+bitcoinDir = "./";
+
+inFile     = bitcoinDir+"/share/qt/Info.plist"
+outFile    = "Bitcoin-Qt.app/Contents/Info.plist"
+version    = "unknown";
+
+fileForGrabbingVersion = bitcoinDir+"bitcoin-qt.pro"
+for line in open(fileForGrabbingVersion):
+	lineArr = line.replace(" ", "").split("=");
+	if lineArr[0].startswith("VERSION"):
+		version = lineArr[1].replace("\n", "");
+
+fIn = open(inFile, "r")
+fileContent = fIn.read()
+s = Template(fileContent)
+newFileContent = s.substitute(VERSION=version,YEAR=date.today().year)
+
+fOut = open(outFile, "w");
+fOut.write(newFileContent);
+
+print "Info.plist fresh created"


### PR DESCRIPTION
...ons (Info.plist)

Due a bug in QT (https://bugreports.qt-project.org/browse/QTBUG-21267), the mac binary of the last release contains bulk meta informations.

The url-handler (bitcoin://) is also not working in current release

Should be fixed with this commit.

see #2506 
