### PR TITLE
Bitcoin-Qt: fix build of splashscreen.cpp

### DIFF
--- a/src/qt/splashscreen.cpp
+++ b/src/qt/splashscreen.cpp
@@ -1,9 +1,10 @@
+#include <QApplication>
+
 #include "splashscreen.h"
 #include "clientversion.h"
 #include "util.h"
 
 #include <QPainter>
-#include <QApplication>
 
 SplashScreen::SplashScreen(const QPixmap &pixmap, Qt::WindowFlags f) :
     QSplashScreen(pixmap, f)


### PR DESCRIPTION
- include QApplictaion at the top-most position to make it compile again
  via Qt Creator on Windows with Qt5
