### PR TITLE
Bugfix: Store last/next wallet resend times unique per CWallet object

### DIFF
--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -892,19 +892,17 @@ void CWallet::ResendWalletTransactions()
 {
     // Do this infrequently and randomly to avoid giving away
     // that these are our transactions.
-    static int64 nNextTime;
-    if (GetTime() < nNextTime)
+    if (GetTime() < nNextResend)
         return;
-    bool fFirst = (nNextTime == 0);
-    nNextTime = GetTime() + GetRand(30 * 60);
+    bool fFirst = (nNextResend == 0);
+    nNextResend = GetTime() + GetRand(30 * 60);
     if (fFirst)
         return;
 
     // Only do it if there's been a new block since last time
-    static int64 nLastTime;
-    if (nTimeBestReceived < nLastTime)
+    if (nTimeBestReceived < nLastResend)
         return;
-    nLastTime = GetTime();
+    nLastResend = GetTime();
 
     // Rebroadcast any of our txes that aren't in a block yet
     printf("ResendWalletTransactions()\n");

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -80,6 +80,9 @@ private:
     // the maximum wallet format version: memory-only variable that specifies to what version this wallet may be upgraded
     int nWalletMaxVersion;
 
+    int64 nNextResend;
+    int64 nLastResend;
+
 public:
     mutable CCriticalSection cs_wallet;
 


### PR DESCRIPTION
As soon as we have multiple CWallet objects, this bug would cause them to interfere with each other rebroadcasting.
