### PR TITLE
Update osx build instructions to ensure users are building with the correct version of OpenSSL when using HomeBrew

### DIFF
--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -95,6 +95,18 @@ Instructions: HomeBrew
 
         brew install boost miniupnpc openssl berkeley-db4
 
+Note: After you have installed the dependencies, you should check that the Brew installed version of OpenSSL is the one available for compilation. You can check this by typing
+
+        openssl version
+
+into Terminal. You should see OpenSSL 1.0.1e 11 Feb 2013.
+
+If not, you can ensure that the Brew OpenSSL is correctly linked by running
+
+        brew link openssl --force
+
+Rerunning "openssl version" should now return the correct version.
+
 ### Building `bitcoind`
 
 1. Clone the github tree to get the source code and go into the directory.


### PR DESCRIPTION
It's possible that once Brew has installed OpenSSL it won't be used when compiling.

This means that the version bundled with OSX will be used, which is currently 0.9.8.r

This adds a note to the build instructions to help users check that the are using the correct version, and if not, how to fix the problem.
