### PR TITLE
bitcoin-qt.pro Brew patch

### DIFF
--- a/contrib/homebrew/bitcoin.qt.pro.patch
+++ b/contrib/homebrew/bitcoin.qt.pro.patch
@@ -1,0 +1,32 @@
+diff --git a/bitcoin-qt.pro b/bitcoin-qt.pro
+index d938c07..e1dd4ec 100644
+--- a/bitcoin-qt.pro
++++ b/bitcoin-qt.pro
+@@ -353,7 +353,7 @@
+ }
+ 
+ isEmpty(BDB_LIB_PATH) {
+-    macx:BDB_LIB_PATH = /opt/local/lib/db48
++    macx:BDB_LIB_PATH = /usr/local/opt/berkeley-db4/lib
+ }
+ 
+ isEmpty(BDB_LIB_SUFFIX) {
+@@ -361,15 +361,15 @@
+ }
+ 
+ isEmpty(BDB_INCLUDE_PATH) {
+-    macx:BDB_INCLUDE_PATH = /opt/local/include/db48
++    macx:BDB_INCLUDE_PATH = /usr/local/opt/berkeley-db4/include
+ }
+ 
+ isEmpty(BOOST_LIB_PATH) {
+-    macx:BOOST_LIB_PATH = /opt/local/lib
++    macx:BOOST_LIB_PATH = /usr/local/opt/boost/lib
+ }
+ 
+ isEmpty(BOOST_INCLUDE_PATH) {
+-    macx:BOOST_INCLUDE_PATH = /opt/local/include
++    macx:BOOST_INCLUDE_PATH = /usr/local/opt/boost/include
+ }
+ 
+ win32:DEFINES += WIN32

--- a/doc/readme-qt.rst
+++ b/doc/readme-qt.rst
@@ -46,19 +46,31 @@ Mac OS X
 
 - Download and install the `Qt Mac OS X SDK`_. It is recommended to also install Apple's Xcode with UNIX tools.
 
-- Download and install `MacPorts`_.
+- Download and install either `MacPorts`_ or `HomeBrew`_.
 
-- Execute the following commands in a terminal to get the dependencies:
+- Execute the following commands in a terminal to get the dependencies using MacPorts:
 
 ::
 
 	sudo port selfupdate
 	sudo port install boost db48 miniupnpc
 
+- Execute the following commands in a terminal to get the dependencies using HomeBrew:
+
+::
+
+	brew update
+	brew install boost miniupnpc openssl berkeley-db4
+
+- If using HomeBrew,  edit `bitcoin-qt.pro` to account for library location differences. There's a diff in `contrib/homebrew/bitcoin-qt-pro.patch` that shows what you need to change, or you can just patch by doing
+
+        patch -p1 < contrib/homebrew/bitcoin.qt.pro.patch
+
 - Open the bitcoin-qt.pro file in Qt Creator and build as normal (cmd-B)
 
 .. _`Qt Mac OS X SDK`: http://qt-project.org/downloads/
 .. _`MacPorts`: http://www.macports.org/install.php
+.. _`HomeBrew`: http://mxcl.github.io/homebrew/
 
 
 Build configuration options


### PR DESCRIPTION
Similar to the osx-makefile patch, when applied this patch file will update the include paths for users who have installed dependencies using HomeBrew.
