### PR TITLE
Reduce number of open LevelDB files to 64

### DIFF
--- a/src/leveldb.cpp
+++ b/src/leveldb.cpp
@@ -30,6 +30,7 @@ static leveldb::Options GetOptions(size_t nCacheSize) {
     options.write_buffer_size = nCacheSize / 4; // up to two write buffers may be held in memory simultaneously
     options.filter_policy = leveldb::NewBloomFilterPolicy(10);
     options.compression = leveldb::kNoCompression;
+    options.max_open_files = 64;
     return options;
 }
 


### PR DESCRIPTION
I don't notice any significant IBD performance degradation using this.
