### PR TITLE
Some database/-related recovery improvements

### DIFF
--- a/src/db.cpp
+++ b/src/db.cpp
@@ -38,7 +38,7 @@ void CDBEnv::EnvShutdown()
     if (ret != 0)
         printf("EnvShutdown exception: %s (%d)\n", DbEnv::strerror(ret), ret);
     if (!fMockDb)
-        DbEnv(0).remove(strPath.c_str(), 0);
+        DbEnv(0).remove(path.string().c_str(), 0);
 }
 
 CDBEnv::CDBEnv() : dbenv(DB_CXX_NO_EXCEPTIONS)
@@ -57,14 +57,14 @@ void CDBEnv::Close()
     EnvShutdown();
 }
 
-bool CDBEnv::Open(const boost::filesystem::path& path)
+bool CDBEnv::Open(const boost::filesystem::path& pathIn)
 {
     if (fDbEnvInit)
         return true;
 
     boost::this_thread::interruption_point();
 
-    strPath = path.string();
+    path = pathIn;
     filesystem::path pathLogDir = path / "database";
     filesystem::create_directory(pathLogDir);
     filesystem::path pathErrorFile = path / "db.log";
@@ -84,7 +84,7 @@ bool CDBEnv::Open(const boost::filesystem::path& path)
     dbenv.set_flags(DB_AUTO_COMMIT, 1);
     dbenv.set_flags(DB_TXN_WRITE_NOSYNC, 1);
     dbenv.log_set_config(DB_LOG_AUTO_REMOVE, 1);
-    int ret = dbenv.open(strPath.c_str(),
+    int ret = dbenv.open(path.string().c_str(),
                      DB_CREATE     |
                      DB_INIT_LOCK  |
                      DB_INIT_LOG   |
@@ -456,6 +456,8 @@ void CDBEnv::Flush(bool fShutdown)
             {
                 dbenv.log_archive(&listp, DB_ARCH_REMOVE);
                 Close();
+                if (!fMockDb)
+                    boost::filesystem::remove_all(path / "database");
             }
         }
     }

--- a/src/db.h
+++ b/src/db.h
@@ -33,7 +33,7 @@ class CDBEnv
 private:
     bool fDbEnvInit;
     bool fMockDb;
-    std::string strPath;
+    boost::filesystem::path path;
 
     void EnvShutdown();
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -733,15 +733,6 @@ bool AppInit2(boost::thread_group& threadGroup)
 
     fReindex = GetBoolArg("-reindex");
 
-    // Todo: Check if needed, because in step 5 we do the same
-    if (!bitdb.Open(GetDataDir()))
-    {
-        string msg = strprintf(_("Error initializing database environment %s!"
-                                 " To recover, BACKUP THAT DIRECTORY, then remove"
-                                 " everything from it except for wallet.dat."), strDataDir.c_str());
-        return InitError(msg);
-    }
-
     // Upgrading to 0.8; hard-link the old blknnnn.dat files into /blocks/
     filesystem::path blocksDir = GetDataDir() / "blocks";
     if (!filesystem::exists(blocksDir))


### PR DESCRIPTION
- After clean shutdown, delete the database/ subdir. This means upgrading/changing the BDB dir won't kill you anymore because of incompatible logs.
- In case opening the database environment fails, move database/ to database.$TIMESTAMP.bak, and try again.
- Do not advise the user to nuke his datadir anymore - there's no point in doing so (closes #2488).
- Drop double opening of the environment (includes #2333).
