### PR TITLE
Allow select()ing up to 1024 file descriptors on Windows

### DIFF
--- a/src/compat.h
+++ b/src/compat.h
@@ -11,6 +11,7 @@
 #ifndef NOMINMAX
 #define NOMINMAX
 #endif
+#define FD_SETSIZE 1024 // max number of fds in fd_set
 #include <winsock2.h>
 #include <mswsock.h>
 #include <ws2tcpip.h>


### PR DESCRIPTION
Closes #2408.
