### PR TITLE
Add Bitcoin-Qt.app to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ src/test_bitcoin
 *.qm
 Makefile
 bitcoin-qt
+Bitcoin-Qt.app
 
 # Unit-tests
 Makefile.test


### PR DESCRIPTION
Once you've compiled Bitcoin-Qt on osx, git shows the files inside the Bitcoin-Qt.app/Contents/ dir, info.plist, PkgInfo, etc. Adding Bitcoin-Qt.app to .gitignore will prevent this.
