### PR TITLE
ListTransactionsOfBlock RPC method

### DIFF
--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -245,6 +245,7 @@ static const CRPCCommand vRPCCommands[] =
     { "getblocktemplate",       &getblocktemplate,       true,      false },
     { "submitblock",            &submitblock,            false,     false },
     { "listsinceblock",         &listsinceblock,         false,     false },
+    { "listtransactionsofblock",&listtransactionsofblock,false,     false },
     { "dumpprivkey",            &dumpprivkey,            true,      false },
     { "importprivkey",          &importprivkey,          false,     false },
     { "listunspent",            &listunspent,            false,     false },
@@ -1150,6 +1151,7 @@ Array RPCConvertValues(const std::string &strMethod, const std::vector<std::stri
     if (strMethod == "listaccounts"           && n > 0) ConvertTo<boost::int64_t>(params[0]);
     if (strMethod == "walletpassphrase"       && n > 1) ConvertTo<boost::int64_t>(params[1]);
     if (strMethod == "getblocktemplate"       && n > 0) ConvertTo<Object>(params[0]);
+    if (strMethod == "listtransactionsofblock" && n > 1) ConvertTo<boost::int64_t>(params[1]);
     if (strMethod == "listsinceblock"         && n > 1) ConvertTo<boost::int64_t>(params[1]);
     if (strMethod == "sendmany"               && n > 1) ConvertTo<Object>(params[1]);
     if (strMethod == "sendmany"               && n > 2) ConvertTo<boost::int64_t>(params[2]);

--- a/src/bitcoinrpc.h
+++ b/src/bitcoinrpc.h
@@ -168,6 +168,7 @@ extern json_spirit::Value listtransactions(const json_spirit::Array& params, boo
 extern json_spirit::Value listaddressgroupings(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value listaccounts(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value listsinceblock(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value listtransactionsofblock(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value gettransaction(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value backupwallet(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value keypoolrefill(const json_spirit::Array& params, bool fHelp);

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -1191,6 +1191,34 @@ Value listsinceblock(const Array& params, bool fHelp)
     return ret;
 }
 
+Value listtransactionsofblock(const Array& params, bool fHelp)
+{
+    if (fHelp || params.size() != 1)
+        throw runtime_error(
+            "listtransactionsofblock [blockhash]\n"
+            "Get all transactions in block with bockhash [blockhash]");
+
+    CBlockIndex *pindex = NULL;
+
+    uint256 hash;
+    hash.SetHex(params[0].get_str());
+
+    Array transactions;
+
+    for (map<uint256, CWalletTx>::iterator it = pwalletMain->mapWallet.begin(); it != pwalletMain->mapWallet.end(); it++)
+    {
+        CWalletTx tx = (*it).second;
+
+        if (tx.hashBlock == hash)
+            ListTransactions(tx, "*", 0, true, transactions);
+    }
+
+    Object ret;
+    ret.push_back(Pair("transactions", transactions));
+
+    return ret;
+}
+
 Value gettransaction(const Array& params, bool fHelp)
 {
     if (fHelp || params.size() != 1)


### PR DESCRIPTION
The method 'listtransactionsofblock' lists all transactions (from the wallet) which are in block with blockhash <hash>

It can be used this way: (pseudo-code)

```
ScanTransactions() {
  Database.TransactionBegin()

  long lastBlock = BitcoinRPC.getLastBlockNr()
  long lastScannedBlock = Database.getLastScannedBlock()

  while (lastBlock - lastScannedBlock > targetConfirms)  {
    lastScannedBlock++;
    string hash = BitcoinRPC.getHashOfBlock(lastScannedBlock)
    list<Transaction> list = BitcoinRPC.getTransactionsOfBlock(hash)
    for (Transaction t : list)
    {
      // do something
      // at this point, you can absolutely be sure to see only transactions 
      // with <targetconfirms> confirms.
      // and you only have to scan each block exactly once
    }
  }
  Database.saveLastScannedBlock()
  Database.TransactionCommit()
}
```

This is an easy example how payments can reliably be received.

Explained here: https://github.com/bitcoin/bitcoin/issues/2565
