### PR TITLE
Print detailed LevelDB error to log

### DIFF
--- a/src/leveldb.cpp
+++ b/src/leveldb.cpp
@@ -15,6 +15,7 @@
 void HandleError(const leveldb::Status &status) throw(leveldb_error) {
     if (status.ok())
         return;
+    printf("LevelDB error encountered: %s\n", status.ToString().c_str());
     if (status.IsCorruption())
         throw leveldb_error("Database corrupted");
     if (status.IsIOError())


### PR DESCRIPTION
As the actual error message currently gets lost.
