### PR TITLE
Prevent prevent file descriptor leak in ShrinkDebugFile()

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1231,6 +1231,8 @@ void ShrinkDebugFile()
             fclose(file);
         }
     }
+    else if(file != NULL)
+	     fclose(file);
 }
 
 


### PR DESCRIPTION
Squashed version of #2528
