### PR TITLE
Resolve path to allow for Bitcoin directory to be a symlink

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1070,6 +1070,9 @@ const boost::filesystem::path &GetDataDir(bool fNetSpecific)
     if (fNetSpecific && GetBoolArg("-testnet", false))
         path /= "testnet3";
 
+#if BOOST_FILESYSTEM_VERSION == 3
+    path = fs::canonical(path);
+#endif
     fs::create_directory(path);
 
     cachedPath[fNetSpecific] = true;


### PR DESCRIPTION
At current if your .bitcoin directory is a symlink (which is becoming more likely as the size of the blockchain increases) then bitcoind will fail to start.  This is because fs::create_directory() fails if it is called on a symlink.

This patch resolves the symlink and stores it in the path cache prior to creating the directory, ensuring that operations are always carried out against the correct location and work as expected.

SIDE-EFFECT:
Because the fully resolved path is stored in the path cache any error messages that are returned which include the path now show the canonical (i.e. resolved) path.  I think that this makes more sense for users and developers, however if this is not desired it would be possible (albeit somewhat more expensive) to only use the canonical path for the create_directory() call and leave the path unresolved elsewhere.
