### PR TITLE
Don't announce to non-peer CNodes

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -256,7 +256,7 @@ public:
         pfilter = NULL;
 
         // Be shy and don't send version until we hear
-        if (!fInbound)
+        if (hSocket != INVALID_SOCKET && !fInbound)
             PushVersion();
     }
 


### PR DESCRIPTION
This is a very minor bug: we tried to send out a "version" message in CNode's constructor, which meant also for pnodeLocalHost, causing a "socket send error 9" under Linux or "socket send error 10038" in Windows.

Fixes #2587
