### PR TITLE
RPC: strictly require HTTP URI "/"

### DIFF
--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -940,6 +940,11 @@ void ServiceConnection(AcceptedConnection *conn)
         // Read HTTP message headers and body
         ReadHTTPMessage(conn->stream(), mapHeaders, strRequest, nProto);
 
+        if (strURI != "/") {
+            conn->stream() << HTTPReply(HTTP_NOT_FOUND, "", false) << std::flush;
+            break;
+        }
+
         // Check authorization
         if (mapHeaders.count("authorization") == 0)
         {


### PR DESCRIPTION
Previously, JSON-RPC clients accessed URI "/", and the JSON-RPC server
did not care about the URI at all, and would accept any URI as valid.

Change the JSON-RPC server to require URI "/" for all current accesses.

This changes enables the addition of future interfaces at different
URIs, such as pull request #1982 which demonstrates HTTP REST wallet
download.

Or, a future, breaking change in JSON-RPC interface could be introduced
by serving JSON-RPC calls from new URI "/v2/".
