### PR TITLE
Bugfix: if no bestblock record is present, do a -rescan

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -988,6 +988,8 @@ bool AppInit2(boost::thread_group& threadGroup)
         CBlockLocator locator;
         if (walletdb.ReadBestBlock(locator))
             pindexRescan = locator.GetBlockIndex();
+        else
+            pindexRescan = pindexGenesisBlock;
     }
     if (pindexBest && pindexBest != pindexRescan)
     {
@@ -996,6 +998,8 @@ bool AppInit2(boost::thread_group& threadGroup)
         nStart = GetTimeMillis();
         pwalletMain->ScanForWalletTransactions(pindexRescan, true);
         printf(" rescan      %15"PRI64d"ms\n", GetTimeMillis() - nStart);
+        pwalletMain->SetBestChain(CBlockLocator(pindexBest));
+        nWalletDBUpdated++;
     }
 
     // ********************************************************* Step 9: import blocks


### PR DESCRIPTION
It is possible to have a wallet.dat file without any bestblock record at all (if created offline, for example), which - when loaded into a client with a up-to-date chain - does no rescan and shows no transactions.

Also make sure to write the current best block after a rescan, so it isn't necessary twice.
