### PR TITLE
EvalScript: avoid relying on undefined behavior for overflow check

### DIFF
--- a/src/script.cpp
+++ b/src/script.cpp
@@ -683,9 +683,10 @@ bool EvalScript(vector<vector<unsigned char> >& stack, const CScript& script, co
                         return false;
                     valtype& vch = stacktop(-3);
                     int nBegin = CastToBigNum(stacktop(-2)).getint();
-                    int nEnd = nBegin + CastToBigNum(stacktop(-1)).getint();
-                    if (nBegin < 0 || nEnd < nBegin)
+                    int size = CastToBigNum(stacktop(-1)).getint();
+                    if (nBegin < 0 || size < 0 || size > INT_MAX - nBegin)
                         return false;
+                    int nEnd = nBegin + size;
                     if (nBegin > (int)vch.size())
                         nBegin = vch.size();
                     if (nEnd > (int)vch.size())


### PR DESCRIPTION
In C/C++, signed integer overflow is undefined behavior, and some
compilers (such as gcc) will optimize away checks like the one that
was present in EvalScript; specifically:

  int nBegin = ...;
  int nEnd = nBegin + size;
  if (nBegin < 0 || nEnd < nBegin)

will get compiled into:

  if (nBegin < 0 || size < 0)

This patch changes the overflow check to avoid relying on the behavior
of signed integer overflow, by checking for size > INT_MAX - nBegin
(and computing nEnd after the check).
