### PR TITLE
Exit cleanly if AppInit2 returns false

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1033,6 +1033,9 @@ bool AppInit2(boost::thread_group& threadGroup)
     if (!CheckDiskSpace())
         return false;
 
+    if (!strErrors.str().empty())
+        return InitError(strErrors.str());
+
     RandAddSeedPerfmon();
 
     //// debug print
@@ -1053,9 +1056,6 @@ bool AppInit2(boost::thread_group& threadGroup)
     // ********************************************************* Step 12: finished
 
     uiInterface.InitMessage(_("Done loading"));
-
-    if (!strErrors.str().empty())
-        return InitError(strErrors.str());
 
      // Add wallet transactions that aren't already in a block to mapTransactions
     pwalletMain->ReacceptWalletTransactions();

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -271,6 +271,9 @@ int main(int argc, char *argv[])
         }
         else
         {
+            threadGroup.interrupt_all();
+            threadGroup.join_all();
+            Shutdown();
             return 1;
         }
     } catch (std::exception& e) {


### PR DESCRIPTION
Bitcoin-Qt could core dump if application initialization failed in certain ways.

I double-fixed this:
1) qt/bitcoin.cpp now shuts down core threads cleanly if AppInit2 returns false
2) init.cpp now exits before StartNode() if strErrors is set (no reason to StartNode if we're just going to exit immediately anyway).

Tested by triggering all of the various ways AppInit2 can fail, either by passing bogus command-line arguments or just recompiling tweaked code to simulate failure.

This is a partial fix for #2480
