### PR TITLE
Bitcoin-Qt: massive options/settings handling rework

### DIFF
--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -232,6 +232,7 @@ static const CRPCCommand vRPCCommands[] =
     { "getconnectioncount",     &getconnectioncount,     true,      false,      false },
     { "getpeerinfo",            &getpeerinfo,            true,      false,      false },
     { "ping",                   &ping,                   true,      false,      false },
+    { "getproxyinfo",           &getproxyinfo,           true,      false,      false },
     { "addnode",                &addnode,                true,      true,       false },
     { "getaddednodeinfo",       &getaddednodeinfo,       true,      true,       false },
     { "getnettotals",           &getnettotals,           true,      true,       false },

--- a/src/bitcoinrpc.h
+++ b/src/bitcoinrpc.h
@@ -161,6 +161,7 @@ extern void EnsureWalletIsUnlocked();
 extern json_spirit::Value getconnectioncount(const json_spirit::Array& params, bool fHelp); // in rpcnet.cpp
 extern json_spirit::Value getpeerinfo(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value ping(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value getproxyinfo(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value addnode(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value getaddednodeinfo(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value getnettotals(const json_spirit::Array& params, bool fHelp);

--- a/src/net.h
+++ b/src/net.h
@@ -254,7 +254,7 @@ public:
     int64_t nPingUsecStart;
     int64_t nPingUsecTime;
     bool fPingQueued;
-    
+
     CNode(SOCKET hSocketIn, CAddress addrIn, std::string addrNameIn = "", bool fInboundIn=false) : ssSend(SER_NETWORK, INIT_PROTO_VERSION)
     {
         nServices = 0;

--- a/src/netbase.h
+++ b/src/netbase.h
@@ -137,14 +137,20 @@ class CService : public CNetAddr
             )
 };
 
-typedef std::pair<CService, int> proxyType;
+typedef struct proxyType {
+    CService addrProxy;
+    int nSocksVersion;
+    bool fIsDefault;
+} proxyType;
+
+typedef std::pair<CService, int> nameproxyType;
 
 enum Network ParseNetwork(std::string net);
 void SplitHostPort(std::string in, int &portOut, std::string &hostOut);
-bool SetProxy(enum Network net, CService addrProxy, int nSocksVersion = 5);
+bool SetProxy(enum Network net, CService addrProxy, int nSocksVersion, bool fIsDefault);
 bool GetProxy(enum Network net, proxyType &proxyInfoOut);
 bool IsProxy(const CNetAddr &addr);
-bool SetNameProxy(CService addrProxy, int nSocksVersion = 5);
+bool SetNameProxy(CService addrProxy, int nSocksVersion);
 bool HaveNameProxy();
 bool LookupHost(const char *pszName, std::vector<CNetAddr>& vIP, unsigned int nMaxSolutions = 0, bool fAllowLookup = true);
 bool LookupHostNumeric(const char *pszName, std::vector<CNetAddr>& vIP, unsigned int nMaxSolutions = 0);

--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>540</width>
-    <height>380</height>
+    <width>560</width>
+    <height>400</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -19,9 +19,6 @@
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <widget class="QTabWidget" name="tabWidget">
-     <property name="tabPosition">
-      <enum>QTabWidget::North</enum>
-     </property>
      <property name="currentIndex">
       <number>0</number>
      </property>
@@ -87,20 +84,33 @@
         </widget>
        </item>
        <item>
-        <spacer name="verticalSpacer_Main">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item>
         <layout class="QHBoxLayout" name="horizontalLayout_2_Main">
+         <item>
+          <widget class="QLabel" name="databaseCacheLabel">
+           <property name="text">
+            <string>Size of &amp;database cache</string>
+           </property>
+           <property name="textFormat">
+            <enum>Qt::PlainText</enum>
+           </property>
+           <property name="buddy">
+            <cstring>databaseCache</cstring>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QSpinBox" name="databaseCache">
+           <property name="toolTip">
+            <string>Set database cache size in megabytes (default: 25)</string>
+           </property>
+           <property name="maximum">
+            <number>1024</number>
+           </property>
+           <property name="value">
+            <number>25</number>
+           </property>
+          </widget>
+         </item>
          <item>
           <spacer name="horizontalSpacer_2_Main">
            <property name="orientation">
@@ -114,20 +124,63 @@
            </property>
           </spacer>
          </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_3_Main">
          <item>
-          <widget class="QPushButton" name="resetButton">
-           <property name="toolTip">
-            <string>Reset all client options to default.</string>
-           </property>
+          <widget class="QLabel" name="threadsScriptVerifLabel">
            <property name="text">
-            <string>&amp;Reset Options</string>
+            <string>Number of script &amp;verification threads</string>
            </property>
-           <property name="autoDefault">
-            <bool>false</bool>
+           <property name="textFormat">
+            <enum>Qt::PlainText</enum>
+           </property>
+           <property name="buddy">
+            <cstring>threadsScriptVerif</cstring>
            </property>
           </widget>
          </item>
+         <item>
+          <widget class="QSpinBox" name="threadsScriptVerif">
+           <property name="toolTip">
+            <string>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</string>
+           </property>
+           <property name="minimum">
+            <number>-16</number>
+           </property>
+           <property name="maximum">
+            <number>16</number>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_3_Main">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
         </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_Main">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
        </item>
       </layout>
      </widget>
@@ -149,15 +202,15 @@
        <item>
         <widget class="QCheckBox" name="connectSocks">
          <property name="toolTip">
-          <string>Connect to the Bitcoin network through a SOCKS proxy (e.g. when connecting through Tor).</string>
+          <string>Connect to the Bitcoin network through a SOCKS proxy.</string>
          </property>
          <property name="text">
-          <string>&amp;Connect through SOCKS proxy:</string>
+          <string>&amp;Connect through SOCKS proxy (base):</string>
          </property>
         </widget>
        </item>
        <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_Network">
+        <layout class="QHBoxLayout" name="horizontalLayout_1_Network">
          <item>
           <widget class="QLabel" name="proxyIpLabel">
            <property name="text">
@@ -173,6 +226,12 @@
          </item>
          <item>
           <widget class="QValidatedLineEdit" name="proxyIp">
+           <property name="minimumSize">
+            <size>
+             <width>140</width>
+             <height>0</height>
+            </size>
+           </property>
            <property name="maximumSize">
             <size>
              <width>140</width>
@@ -180,7 +239,7 @@
             </size>
            </property>
            <property name="toolTip">
-            <string>IP address of the proxy (e.g. 127.0.0.1)</string>
+            <string>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</string>
            </property>
           </widget>
          </item>
@@ -199,6 +258,12 @@
          </item>
          <item>
           <widget class="QLineEdit" name="proxyPort">
+           <property name="minimumSize">
+            <size>
+             <width>55</width>
+             <height>0</height>
+            </size>
+           </property>
            <property name="maximumSize">
             <size>
              <width>55</width>
@@ -231,7 +296,285 @@
           </widget>
          </item>
          <item>
-          <spacer name="horizontalSpacer_Network">
+          <spacer name="horizontalSpacer_1_Network">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_2_Network">
+         <item>
+          <widget class="QLabel" name="proxyActiveNets">
+           <property name="text">
+            <string>Used for reaching peers via:</string>
+           </property>
+           <property name="textFormat">
+            <enum>Qt::PlainText</enum>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="proxyReachIPv4">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="toolTip">
+            <string>Shows, if the supplied (base) SOCKS proxy is used to reach peers via this network type.</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="proxyReachIPv4Label">
+           <property name="text">
+            <string>IPv4</string>
+           </property>
+           <property name="textFormat">
+            <enum>Qt::PlainText</enum>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="proxyReachIPv6">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="toolTip">
+            <string>Shows, if the supplied (base) SOCKS proxy is used to reach peers via this network type.</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="proxyReachIPv6Label">
+           <property name="text">
+            <string>IPv6</string>
+           </property>
+           <property name="textFormat">
+            <enum>Qt::PlainText</enum>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="proxyReachTor">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="toolTip">
+            <string>Shows, if the supplied (base) SOCKS proxy is used to reach peers via this network type.</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="proxyReachTorLabel">
+           <property name="text">
+            <string>Tor</string>
+           </property>
+           <property name="textFormat">
+            <enum>Qt::PlainText</enum>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_2_Network">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="connectSocksIpv6">
+         <property name="toolTip">
+          <string>Connect to the Bitcoin network through a separate SOCKS5 proxy for IPv6 peers.</string>
+         </property>
+         <property name="text">
+          <string>Use separate SOCKS5 proxy to reach &amp;IPv6 peers:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_3_Network">
+         <item>
+          <widget class="QLabel" name="proxyIpv6Label">
+           <property name="text">
+            <string>Proxy &amp;IP:</string>
+           </property>
+           <property name="textFormat">
+            <enum>Qt::PlainText</enum>
+           </property>
+           <property name="buddy">
+            <cstring>proxyIpv6</cstring>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QValidatedLineEdit" name="proxyIpv6">
+           <property name="minimumSize">
+            <size>
+             <width>140</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>140</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="toolTip">
+            <string>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="proxyPortIpv6Label">
+           <property name="text">
+            <string>&amp;Port:</string>
+           </property>
+           <property name="textFormat">
+            <enum>Qt::PlainText</enum>
+           </property>
+           <property name="buddy">
+            <cstring>proxyPortIpv6</cstring>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLineEdit" name="proxyPortIpv6">
+           <property name="minimumSize">
+            <size>
+             <width>55</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>55</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="toolTip">
+            <string>Port of the proxy (e.g. 9050)</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_3_Network">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="connectSocksTor">
+         <property name="toolTip">
+          <string>Connect to the Bitcoin network through a separate SOCKS5 proxy for hidden services.</string>
+         </property>
+         <property name="text">
+          <string>Use separate SOCKS5 proxy to reach &amp;Tor hidden services:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_4_Network">
+         <item>
+          <widget class="QLabel" name="proxyIpTorLabel">
+           <property name="text">
+            <string>Proxy &amp;IP:</string>
+           </property>
+           <property name="textFormat">
+            <enum>Qt::PlainText</enum>
+           </property>
+           <property name="buddy">
+            <cstring>proxyIpTor</cstring>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QValidatedLineEdit" name="proxyIpTor">
+           <property name="minimumSize">
+            <size>
+             <width>140</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>140</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="toolTip">
+            <string>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="proxyPortTorLabel">
+           <property name="text">
+            <string>&amp;Port:</string>
+           </property>
+           <property name="textFormat">
+            <enum>Qt::PlainText</enum>
+           </property>
+           <property name="buddy">
+            <cstring>proxyPortTor</cstring>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLineEdit" name="proxyPortTor">
+           <property name="minimumSize">
+            <size>
+             <width>55</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>55</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="toolTip">
+            <string>Port of the proxy (e.g. 9050)</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_4_Network">
            <property name="orientation">
             <enum>Qt::Horizontal</enum>
            </property>
@@ -391,6 +734,65 @@
     </widget>
    </item>
    <item>
+    <widget class="QFrame" name="frame">
+     <layout class="QVBoxLayout" name="verticalLayout_Bottom">
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_Bottom">
+        <item>
+         <widget class="QLabel" name="overriddenByCommandLineInfoLabel">
+          <property name="text">
+           <string>Active command-line options that override above options: </string>
+          </property>
+          <property name="textFormat">
+           <enum>Qt::PlainText</enum>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_Bottom">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QPushButton" name="resetButton">
+          <property name="toolTip">
+           <string>Reset all client options to default.</string>
+          </property>
+          <property name="text">
+           <string>&amp;Reset Options</string>
+          </property>
+          <property name="autoDefault">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <widget class="QLabel" name="overriddenByCommandLineLabel">
+        <property name="text">
+         <string/>
+        </property>
+        <property name="textFormat">
+         <enum>Qt::PlainText</enum>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <layout class="QHBoxLayout" name="horizontalLayout_Buttons">
      <item>
       <spacer name="horizontalSpacer_1">
@@ -407,6 +809,12 @@
      </item>
      <item>
       <widget class="QLabel" name="statusLabel">
+       <property name="minimumSize">
+        <size>
+         <width>200</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="font">
         <font>
          <weight>75</weight>
@@ -454,16 +862,6 @@
        </property>
       </widget>
      </item>
-     <item>
-      <widget class="QPushButton" name="applyButton">
-       <property name="text">
-        <string>&amp;Apply</string>
-       </property>
-       <property name="autoDefault">
-        <bool>false</bool>
-       </property>
-      </widget>
-     </item>
     </layout>
    </item>
   </layout>
@@ -473,16 +871,17 @@
    <class>BitcoinAmountField</class>
    <extends>QLineEdit</extends>
    <header>bitcoinamountfield.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QValueComboBox</class>
-   <extends>QComboBox</extends>
-   <header>qvaluecombobox.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>QValidatedLineEdit</class>
    <extends>QLineEdit</extends>
    <header>qvalidatedlineedit.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QValueComboBox</class>
+   <extends>QComboBox</extends>
+   <header>qvaluecombobox.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -10,6 +10,7 @@
 #include "ui_optionsdialog.h"
 
 #include "bitcoinunits.h"
+#include "guiutil.h"
 #include "monitoreddatamapper.h"
 #include "optionsmodel.h"
 
@@ -19,17 +20,20 @@
 #include <QIntValidator>
 #include <QLocale>
 #include <QMessageBox>
+#include <QTimer>
 
 OptionsDialog::OptionsDialog(QWidget *parent) :
     QDialog(parent),
     ui(new Ui::OptionsDialog),
     model(0),
     mapper(0),
-    fRestartWarningDisplayed_Proxy(false),
-    fRestartWarningDisplayed_Lang(false),
-    fProxyIpValid(true)
+    fProxyIpsValid(true)
 {
     ui->setupUi(this);
+    GUIUtil::restoreWindowGeometry("nOptionsDialogWindow", this->size(), this);
+
+    /* Main elements init */
+    ui->databaseCache->setMaximum(sizeof(void*) > 4 ? 4096 : 1024);
 
     /* Network elements init */
 #ifndef USE_UPNP
@@ -40,17 +44,35 @@ OptionsDialog::OptionsDialog(QWidget *parent) :
     ui->proxyPort->setEnabled(false);
     ui->proxyPort->setValidator(new QIntValidator(1, 65535, this));
 
+    /** SOCKS version is only selectable for base proxy and is always 5 for IPv6 and Tor */
     ui->socksVersion->setEnabled(false);
     ui->socksVersion->addItem("5", 5);
     ui->socksVersion->addItem("4", 4);
     ui->socksVersion->setCurrentIndex(0);
 
+    ui->proxyIpv6->setEnabled(false);
+    ui->proxyPortIpv6->setEnabled(false);
+    ui->proxyPortIpv6->setValidator(new QIntValidator(1, 65535, this));
+
+    ui->proxyIpTor->setEnabled(false);
+    ui->proxyPortTor->setEnabled(false);
+    ui->proxyPortTor->setValidator(new QIntValidator(1, 65535, this));
+
     connect(ui->connectSocks, SIGNAL(toggled(bool)), ui->proxyIp, SLOT(setEnabled(bool)));
     connect(ui->connectSocks, SIGNAL(toggled(bool)), ui->proxyPort, SLOT(setEnabled(bool)));
     connect(ui->connectSocks, SIGNAL(toggled(bool)), ui->socksVersion, SLOT(setEnabled(bool)));
-    connect(ui->connectSocks, SIGNAL(clicked(bool)), this, SLOT(showRestartWarning_Proxy()));
+
+    connect(ui->connectSocksIpv6, SIGNAL(toggled(bool)), ui->proxyIpv6, SLOT(setEnabled(bool)));
+    connect(ui->connectSocksIpv6, SIGNAL(toggled(bool)), ui->proxyPortIpv6, SLOT(setEnabled(bool)));
+
+    connect(ui->connectSocksTor, SIGNAL(toggled(bool)), ui->proxyIpTor, SLOT(setEnabled(bool)));
+    connect(ui->connectSocksTor, SIGNAL(toggled(bool)), ui->proxyPortTor, SLOT(setEnabled(bool)));
 
     ui->proxyIp->installEventFilter(this);
+    ui->proxyIpv6->installEventFilter(this);
+    ui->proxyIpTor->installEventFilter(this);
+
+    updateDefaultProxyNets();
 
     /* Window elements init */
 #ifdef Q_OS_MAC
@@ -95,16 +117,13 @@ OptionsDialog::OptionsDialog(QWidget *parent) :
     mapper->setSubmitPolicy(QDataWidgetMapper::ManualSubmit);
     mapper->setOrientation(Qt::Vertical);
 
-    /* enable apply button when data modified */
-    connect(mapper, SIGNAL(viewModified()), this, SLOT(enableApplyButton()));
-    /* disable apply button when new data loaded */
-    connect(mapper, SIGNAL(currentIndexChanged(int)), this, SLOT(disableApplyButton()));
-    /* setup/change UI elements when proxy IP is invalid/valid */
-    connect(this, SIGNAL(proxyIpValid(QValidatedLineEdit *, bool)), this, SLOT(handleProxyIpValid(QValidatedLineEdit *, bool)));
+    /* setup/change UI elements when proxy IPs are invalid/valid */
+    connect(this, SIGNAL(proxyIpChecks(QValidatedLineEdit *, int)), this, SLOT(doProxyIpChecks(QValidatedLineEdit *, int)));
 }
 
 OptionsDialog::~OptionsDialog()
 {
+    GUIUtil::saveWindowGeometry("nOptionsDialogWindow", this);
     delete ui;
 }
 
@@ -114,6 +133,15 @@ void OptionsDialog::setModel(OptionsModel *model)
 
     if(model)
     {
+        /* check if client restart is needed and show persistent message */
+        if (model->isRestartRequired())
+            showRestartWarning(true);
+
+        QString strLabel = model->getOverriddenByCommandLine();
+        if (strLabel.isEmpty())
+            strLabel = tr("none");
+        ui->overriddenByCommandLineLabel->setText(strLabel);
+
         connect(model, SIGNAL(displayUnitChanged(int)), this, SLOT(updateDisplayUnit()));
 
         mapper->setModel(model);
@@ -124,11 +152,15 @@ void OptionsDialog::setModel(OptionsModel *model)
     /* update the display unit, to not use the default ("BTC") */
     updateDisplayUnit();
 
-    /* warn only when language selection changes by user action (placed here so init via mapper doesn't trigger this) */
-    connect(ui->lang, SIGNAL(valueChanged()), this, SLOT(showRestartWarning_Lang()));
+    /* warn when one of the following settings changes by user action (placed here so init via mapper doesn't trigger them) */
 
-    /* disable apply button after settings are loaded as there is nothing to save */
-    disableApplyButton();
+    /* Main */
+    connect(ui->databaseCache, SIGNAL(valueChanged(int)), this, SLOT(showRestartWarning()));
+    connect(ui->threadsScriptVerif, SIGNAL(valueChanged(int)), this, SLOT(showRestartWarning()));
+    /* Network */
+    connect(ui->connectSocks, SIGNAL(clicked(bool)), this, SLOT(showRestartWarning()));
+    /* Display */
+    connect(ui->lang, SIGNAL(valueChanged()), this, SLOT(showRestartWarning()));
 }
 
 void OptionsDialog::setMapper()
@@ -136,6 +168,8 @@ void OptionsDialog::setMapper()
     /* Main */
     mapper->addMapping(ui->transactionFee, OptionsModel::Fee);
     mapper->addMapping(ui->bitcoinAtStartup, OptionsModel::StartAtStartup);
+    mapper->addMapping(ui->threadsScriptVerif, OptionsModel::ThreadsScriptVerif);
+    mapper->addMapping(ui->databaseCache, OptionsModel::DatabaseCache);
 
     /* Network */
     mapper->addMapping(ui->mapPortUpnp, OptionsModel::MapPortUPnP);
@@ -144,6 +178,14 @@ void OptionsDialog::setMapper()
     mapper->addMapping(ui->proxyIp, OptionsModel::ProxyIP);
     mapper->addMapping(ui->proxyPort, OptionsModel::ProxyPort);
     mapper->addMapping(ui->socksVersion, OptionsModel::ProxySocksVersion);
+
+    mapper->addMapping(ui->connectSocksIpv6, OptionsModel::ProxyUseIPv6);
+    mapper->addMapping(ui->proxyIpv6, OptionsModel::ProxyIPv6);
+    mapper->addMapping(ui->proxyPortIpv6, OptionsModel::ProxyPortIPv6);
+
+    mapper->addMapping(ui->connectSocksTor, OptionsModel::ProxyUseTor);
+    mapper->addMapping(ui->proxyIpTor, OptionsModel::ProxyIPTor);
+    mapper->addMapping(ui->proxyPortTor, OptionsModel::ProxyPortTor);
 
     /* Window */
 #ifndef Q_OS_MAC
@@ -158,31 +200,20 @@ void OptionsDialog::setMapper()
     mapper->addMapping(ui->coinControlFeatures, OptionsModel::CoinControlFeatures);
 }
 
-void OptionsDialog::enableApplyButton()
+void OptionsDialog::enableOkButton()
 {
-    ui->applyButton->setEnabled(true);
+    /* prevent enabling of the OK button when data modified, if there is an invalid proxy address present */
+    if(fProxyIpsValid)
+        setOkButtonState(true);
 }
 
-void OptionsDialog::disableApplyButton()
+void OptionsDialog::disableOkButton()
 {
-    ui->applyButton->setEnabled(false);
+    setOkButtonState(false);
 }
 
-void OptionsDialog::enableSaveButtons()
+void OptionsDialog::setOkButtonState(bool fState)
 {
-    /* prevent enabling of the save buttons when data modified, if there is an invalid proxy address present */
-    if(fProxyIpValid)
-        setSaveButtonState(true);
-}
-
-void OptionsDialog::disableSaveButtons()
-{
-    setSaveButtonState(false);
-}
-
-void OptionsDialog::setSaveButtonState(bool fState)
-{
-    ui->applyButton->setEnabled(fState);
     ui->okButton->setEnabled(fState);
 }
 
@@ -192,24 +223,15 @@ void OptionsDialog::on_resetButton_clicked()
     {
         // confirmation dialog
         QMessageBox::StandardButton btnRetVal = QMessageBox::question(this, tr("Confirm options reset"),
-            tr("Some settings may require a client restart to take effect.") + "<br><br>" + tr("Do you want to proceed?"),
+            tr("Client restart required to activate changes.") + "<br><br>" + tr("Client will be shutdown, do you want to proceed?"),
             QMessageBox::Yes | QMessageBox::Cancel, QMessageBox::Cancel);
 
         if(btnRetVal == QMessageBox::Cancel)
             return;
 
-        disableApplyButton();
-
-        /* disable restart warning messages display */
-        fRestartWarningDisplayed_Lang = fRestartWarningDisplayed_Proxy = true;
-
-        /* reset all options and save the default values (QSettings) */
+        /* reset all options and close Bitcoin-Qt */
         model->Reset();
-        mapper->toFirst();
-        mapper->submit();
-
-        /* re-enable restart warning messages display */
-        fRestartWarningDisplayed_Lang = fRestartWarningDisplayed_Proxy = false;
+        QApplication::quit();
     }
 }
 
@@ -217,6 +239,7 @@ void OptionsDialog::on_okButton_clicked()
 {
     mapper->submit();
     accept();
+    updateDefaultProxyNets();
 }
 
 void OptionsDialog::on_cancelButton_clicked()
@@ -224,28 +247,26 @@ void OptionsDialog::on_cancelButton_clicked()
     reject();
 }
 
-void OptionsDialog::on_applyButton_clicked()
+void OptionsDialog::showRestartWarning(bool fPersistent)
 {
-    mapper->submit();
-    disableApplyButton();
-}
+    ui->statusLabel->setStyleSheet("QLabel { color: red; }");
 
-void OptionsDialog::showRestartWarning_Proxy()
-{
-    if(!fRestartWarningDisplayed_Proxy)
+    if(fPersistent)
     {
-        QMessageBox::warning(this, tr("Warning"), tr("This setting will take effect after restarting Bitcoin."), QMessageBox::Ok);
-        fRestartWarningDisplayed_Proxy = true;
+        ui->statusLabel->setText(tr("Client restart required to activate changes."));
+    }
+    else
+    {
+        ui->statusLabel->setText(tr("This change would require a client restart."));
+        // clear non-persistent status label after 10 seconds
+        // Todo: should perhaps be a class attribute, if we extend the use of statusLabel
+        QTimer::singleShot(10000, this, SLOT(clearStatusLabel()));
     }
 }
 
-void OptionsDialog::showRestartWarning_Lang()
+void OptionsDialog::clearStatusLabel()
 {
-    if(!fRestartWarningDisplayed_Lang)
-    {
-        QMessageBox::warning(this, tr("Warning"), tr("This setting will take effect after restarting Bitcoin."), QMessageBox::Ok);
-        fRestartWarningDisplayed_Lang = true;
-    }
+    ui->statusLabel->clear();
 }
 
 void OptionsDialog::updateDisplayUnit()
@@ -257,23 +278,39 @@ void OptionsDialog::updateDisplayUnit()
     }
 }
 
-void OptionsDialog::handleProxyIpValid(QValidatedLineEdit *object, bool fState)
+void OptionsDialog::doProxyIpChecks(QValidatedLineEdit *pUiProxyIp, int nProxyPort)
 {
-    // this is used in a check before re-enabling the save buttons
-    fProxyIpValid = fState;
+    Q_UNUSED(nProxyPort);
 
-    if(fProxyIpValid)
+    const std::string strAddrProxy = pUiProxyIp->text().toStdString();
+    CService addrProxy;
+
+    /* Check for a valid IPv4 / IPv6 address */
+    if (!(fProxyIpsValid = LookupNumeric(strAddrProxy.c_str(), addrProxy)))
     {
-        enableSaveButtons();
-        ui->statusLabel->clear();
-    }
-    else
-    {
-        disableSaveButtons();
-        object->setValid(fProxyIpValid);
+        disableOkButton();
+        pUiProxyIp->setValid(false);
         ui->statusLabel->setStyleSheet("QLabel { color: red; }");
         ui->statusLabel->setText(tr("The supplied proxy address is invalid."));
     }
+    else
+    {
+        enableOkButton();
+        ui->statusLabel->clear();
+    }
+}
+
+void OptionsDialog::updateDefaultProxyNets()
+{
+    proxyType proxy;
+
+    (GetProxy(NET_IPV4, proxy) && proxy.fIsDefault) ? ui->proxyReachIPv4->setChecked(true) : ui->proxyReachIPv4->setChecked(false);
+#ifdef USE_IPV6
+    (GetProxy(NET_IPV6, proxy) && proxy.fIsDefault) ? ui->proxyReachIPv6->setChecked(true) : ui->proxyReachIPv6->setChecked(false);
+#else
+    ui->proxyReachIPv6->setChecked(false);
+#endif
+    (GetProxy(NET_TOR, proxy) && proxy.fIsDefault) ? ui->proxyReachTor->setChecked(true) : ui->proxyReachTor->setChecked(false);
 }
 
 bool OptionsDialog::eventFilter(QObject *object, QEvent *event)
@@ -282,9 +319,15 @@ bool OptionsDialog::eventFilter(QObject *object, QEvent *event)
     {
         if(object == ui->proxyIp)
         {
-            CService addr;
-            /* Check proxyIp for a valid IPv4/IPv6 address and emit the proxyIpValid signal */
-            emit proxyIpValid(ui->proxyIp, LookupNumeric(ui->proxyIp->text().toStdString().c_str(), addr));
+            emit proxyIpChecks(ui->proxyIp, ui->proxyPort->text().toInt());
+        }
+        else if(object == ui->proxyIpv6)
+        {
+            emit proxyIpChecks(ui->proxyIpv6, ui->proxyPortIpv6->text().toInt());
+        }
+        else if(object == ui->proxyIpTor)
+        {
+            emit proxyIpChecks(ui->proxyIpTor, ui->proxyPortTor->text().toInt());
         }
     }
     return QDialog::eventFilter(object, event);

--- a/src/qt/optionsdialog.h
+++ b/src/qt/optionsdialog.h
@@ -31,36 +31,31 @@ protected:
     bool eventFilter(QObject *object, QEvent *event);
 
 private slots:
-    /* enable only apply button */
-    void enableApplyButton();
-    /* disable only apply button */
-    void disableApplyButton();
-    /* enable apply button and OK button */
-    void enableSaveButtons();
-    /* disable apply button and OK button */
-    void disableSaveButtons();
-    /* set apply button and OK button state (enabled / disabled) */
-    void setSaveButtonState(bool fState);
+    /* enable OK button */
+    void enableOkButton();
+    /* disable OK button */
+    void disableOkButton();
+    /* set OK button state (enabled / disabled) */
+    void setOkButtonState(bool fState);
     void on_resetButton_clicked();
     void on_okButton_clicked();
     void on_cancelButton_clicked();
-    void on_applyButton_clicked();
 
-    void showRestartWarning_Proxy();
-    void showRestartWarning_Lang();
+    void showRestartWarning(bool fPersistent = false);
+    void clearStatusLabel();
     void updateDisplayUnit();
-    void handleProxyIpValid(QValidatedLineEdit *object, bool fState);
+    void doProxyIpChecks(QValidatedLineEdit *pUiProxyIp, int nProxyPort);
+    /* query the networks, for which the base proxy is used */
+    void updateDefaultProxyNets();
 
 signals:
-    void proxyIpValid(QValidatedLineEdit *object, bool fValid);
+    void proxyIpChecks(QValidatedLineEdit *pUiProxyIp, int nProxyPort);
 
 private:
     Ui::OptionsDialog *ui;
     OptionsModel *model;
     MonitoredDataMapper *mapper;
-    bool fRestartWarningDisplayed_Proxy;
-    bool fRestartWarningDisplayed_Lang;
-    bool fProxyIpValid;
+    bool fProxyIpsValid;
 };
 
 #endif // OPTIONSDIALOG_H

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -29,11 +29,19 @@ public:
         ProxyIP,                // QString
         ProxyPort,              // int
         ProxySocksVersion,      // int
+        ProxyUseIPv6,           // bool
+        ProxyIPv6,              // QString
+        ProxyPortIPv6,          // int
+        ProxyUseTor,            // bool
+        ProxyIPTor,             // QString
+        ProxyPortTor,           // int
         Fee,                    // qint64
         DisplayUnit,            // BitcoinUnits::Unit
         DisplayAddresses,       // bool
         Language,               // QString
         CoinControlFeatures,    // bool
+        ThreadsScriptVerif,     // int
+        DatabaseCache,          // int
         OptionIDRowCount,
     };
 
@@ -41,29 +49,35 @@ public:
     void Reset();
 
     /* Migrate settings from wallet.dat after app initialization */
-    bool Upgrade(); /* returns true if settings upgraded */
+    void Upgrade();
 
     int rowCount(const QModelIndex & parent = QModelIndex()) const;
     QVariant data(const QModelIndex & index, int role = Qt::DisplayRole) const;
     bool setData(const QModelIndex & index, const QVariant & value, int role = Qt::EditRole);
 
     /* Explicit getters */
-    qint64 getTransactionFee();
     bool getMinimizeToTray() { return fMinimizeToTray; }
     bool getMinimizeOnClose() { return fMinimizeOnClose; }
     int getDisplayUnit() { return nDisplayUnit; }
     bool getDisplayAddresses() { return bDisplayAddresses; }
-    QString getLanguage() { return language; }
     bool getProxySettings(QString& proxyIP, quint16 &proxyPort) const;
     bool getCoinControlFeatures() { return fCoinControlFeatures; }
+    const QString& getOverriddenByCommandLine() { return strOverriddenByCommandLine; }
+
+    /* Restart flag helper */
+    void setRestartRequired(bool fRequired);
+    bool isRestartRequired();
 
 private:
-    int nDisplayUnit;
-    bool bDisplayAddresses;
+    /* Qt-only settings */
     bool fMinimizeToTray;
     bool fMinimizeOnClose;
     QString language;
+    int nDisplayUnit;
+    bool bDisplayAddresses;
     bool fCoinControlFeatures;
+    /* settings that were overriden by command-line */
+    QString strOverriddenByCommandLine;
 
 signals:
     void displayUnitChanged(int unit);

--- a/src/rpcnet.cpp
+++ b/src/rpcnet.cpp
@@ -328,3 +328,51 @@ Value getnettotals(const Array& params, bool fHelp)
     obj.push_back(Pair("timemillis", static_cast<boost::int64_t>(GetTimeMillis())));
     return obj;
 }
+
+Value getproxyinfo(const Array& params, bool fHelp)
+{
+    if (fHelp || params.size() != 0)
+        throw runtime_error(
+            "getproxyinfo\n"
+            "Returns information about used proxy servers.\n"
+            "\nResult:\n"
+            "{\n"
+            "  \"proxy-default-ip\": xxxxx,                 (string)  ip of default proxy server\n"
+            "  \"proxy-default-socks\": n,                  (numeric) socks version of above proxy server\n"
+#ifdef USE_IPV6
+            "  \"proxy-ipv6-ip\": xxxxx,                    (string)  ip of proxy server for reaching peers via ipv6\n"
+            "  \"proxy-ipv6-socks\": n,                     (numeric) socks version of above proxy server\n"
+            "  \"proxy-ipv6-from-default\": true|false,     (boolean) is ip derived from default proxy server\n"
+#endif
+            "  \"proxy-onion-ip\": xxxxxx,                  (string)  ip of proxy server for reaching peers via tor hidden services\n"
+            "  \"proxy-onion-socks\": n,                    (numeric) socks version of above proxy server\n"
+            "  \"proxy-onion-from-default\": true|false,    (boolean) is ip derived from default proxy server\n"
+            "}\n"
+            "\nExamples:\n"
+            + HelpExampleCli("getproxyinfo", "")
+            + HelpExampleRpc("getproxyinfo", "")
+        );
+
+    // collect current proxy settings
+    proxyType proxyIpv4;
+    GetProxy(NET_IPV4, proxyIpv4);
+#ifdef USE_IPV6
+    proxyType proxyIpv6;
+    GetProxy(NET_IPV6, proxyIpv6);
+#endif
+    proxyType proxyTor;
+    GetProxy(NET_TOR, proxyTor);
+
+    Object obj;
+    obj.push_back(Pair("proxy-default-ip",            proxyIpv4.addrProxy.IsValid() ? proxyIpv4.addrProxy.ToStringIPPort() : "none"));
+    obj.push_back(Pair("proxy-default-socks",         proxyIpv4.addrProxy.IsValid() ? proxyIpv4.nSocksVersion : 0));
+#ifdef USE_IPV6
+    obj.push_back(Pair("proxy-ipv6-ip",               proxyIpv6.addrProxy.IsValid() ? proxyIpv6.addrProxy.ToStringIPPort() : "none"));
+    obj.push_back(Pair("proxy-ipv6-socks",            proxyIpv6.addrProxy.IsValid() ? proxyIpv6.nSocksVersion : 0));
+    obj.push_back(Pair("proxy-ipv6-from-default",     proxyIpv6.fIsDefault));
+#endif
+    obj.push_back(Pair("proxy-onion-ip",              proxyTor.addrProxy.IsValid() ? proxyTor.addrProxy.ToStringIPPort() : "none"));
+    obj.push_back(Pair("proxy-onion-socks",           proxyTor.addrProxy.IsValid() ? proxyTor.nSocksVersion : 0));
+    obj.push_back(Pair("proxy-onion-from-default",    proxyTor.fIsDefault));
+    return obj;
+}

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -92,7 +92,6 @@ Value getinfo(const Array& params, bool fHelp)
             "  \"blocks\": xxxxxx,           (numeric) the current number of blocks processed in the server\n"
             "  \"timeoffset\": xxxxx,        (numeric) the time offset\n"
             "  \"connections\": xxxxx,       (numeric) the number of connections\n"
-            "  \"proxy\": \"host:port\",     (string, optional) the proxy used by the server\n"
             "  \"difficulty\": xxxxxx,       (numeric) the current difficulty\n"
             "  \"testnet\": true|false,      (boolean) if the server is using testnet or not\n"
             "  \"keypoololdest\": xxxxxx,    (numeric) the timestamp (seconds since GMT epoch) of the oldest pre-generated key in the key pool\n"
@@ -106,30 +105,26 @@ Value getinfo(const Array& params, bool fHelp)
             + HelpExampleRpc("getinfo", "")
         );
 
-    proxyType proxy;
-    GetProxy(NET_IPV4, proxy);
-
     Object obj;
-    obj.push_back(Pair("version",       (int)CLIENT_VERSION));
-    obj.push_back(Pair("protocolversion",(int)PROTOCOL_VERSION));
+    obj.push_back(Pair("version",           (int)CLIENT_VERSION));
+    obj.push_back(Pair("protocolversion",   (int)PROTOCOL_VERSION));
     if (pwalletMain) {
         obj.push_back(Pair("walletversion", pwalletMain->GetVersion()));
         obj.push_back(Pair("balance",       ValueFromAmount(pwalletMain->GetBalance())));
     }
-    obj.push_back(Pair("blocks",        (int)chainActive.Height()));
-    obj.push_back(Pair("timeoffset",    (boost::int64_t)GetTimeOffset()));
-    obj.push_back(Pair("connections",   (int)vNodes.size()));
-    obj.push_back(Pair("proxy",         (proxy.first.IsValid() ? proxy.first.ToStringIPPort() : string())));
-    obj.push_back(Pair("difficulty",    (double)GetDifficulty()));
-    obj.push_back(Pair("testnet",       TestNet()));
+    obj.push_back(Pair("blocks",            (int)chainActive.Height()));
+    obj.push_back(Pair("timeoffset",        (boost::int64_t)GetTimeOffset()));
+    obj.push_back(Pair("connections",       (int)vNodes.size()));
+    obj.push_back(Pair("difficulty",        (double)GetDifficulty()));
+    obj.push_back(Pair("testnet",           TestNet()));
     if (pwalletMain) {
         obj.push_back(Pair("keypoololdest", (boost::int64_t)pwalletMain->GetOldestKeyPoolTime()));
         obj.push_back(Pair("keypoolsize",   (int)pwalletMain->GetKeyPoolSize()));
     }
-    obj.push_back(Pair("paytxfee",      ValueFromAmount(nTransactionFee)));
+    obj.push_back(Pair("paytxfee",          ValueFromAmount(nTransactionFee)));
     if (pwalletMain && pwalletMain->IsCrypted())
         obj.push_back(Pair("unlocked_until", (boost::int64_t)nWalletUnlockTime));
-    obj.push_back(Pair("errors",        GetWarnings("statusbar")));
+    obj.push_back(Pair("errors",            GetWarnings("statusbar")));
     return obj;
 }
 


### PR DESCRIPTION
- add new options for database cache and script verification threads
- add new options for setting separate IPv6 and Tor proxy and show for
  which networks the base proxy is used currently
- add label which displays options that are overridden by command-line
  parameters
- proxy settings are not applied on-the-fly anymore and require a
  client restart (ApplyProxySettings() was removed and was not working
  very well anyway)
- re-work options reset and require a client shutdown (as it is much
  easier to do it this way without having to mess with what can be
  changed on-the-fly and what needs a restart anyway)
- options reset now writes default values for every single option
- when changing an option which requires a client restart display a 10
  second warning message in statusLabel (via a QTimer)
- when applying the changes via ok change that to a persistent message,
  which is displayed even after closing optionsdialog and re-open it,
  when no client restart was made
- remove dialog boxes used when changing language or proxy settings
- add setRestartRequired() and isRestartRequired() to OptionsModel and
  use the set function when updating options to signal OptionsDialog when
  a restart is needed
- resize optionsdialog a little and add some min sizes for certain GUI
  elements
- remove apply button from optionsdialog
- save and restore optionsdialog window position
- update nTransactionFee in QSettings with a set -paytxfee value when
  opening optionsdialog (I'm not sure about this yet, perhaps revert
  to not updating QSettings and just display current -paytxfee value in
  optionsdialog.)
