### PR TITLE
Specified base_uint component size

### DIFF
--- a/src/uint256.h
+++ b/src/uint256.h
@@ -8,6 +8,7 @@
 #include <limits.h>
 #include <stdio.h>
 #include <string.h>
+#include <inttypes.h>
 #include <string>
 #include <vector>
 
@@ -20,14 +21,14 @@ inline int Testuint256AdHoc(std::vector<std::string> vArg);
 
 
 /** Base class without constructors for uint256 and uint160.
- * This makes the compiler let u use it in a union.
+ * This makes the compiler let you use it in a union.
  */
 template<unsigned int BITS>
 class base_uint
 {
 protected:
     enum { WIDTH=BITS/32 };
-    unsigned int pn[WIDTH];
+    uint32_t pn[WIDTH];
 public:
 
     bool operator!() const


### PR DESCRIPTION
A `base_uint` used to be made of an array of `unsigned int`s. This works
fine on most platforms, but might not work on certain present or future
platforms. The code breaks if an `unsigned int` is 16 or 64 bits, so it might pay to be specific. Also changed "u" to "you" in the comment text.
