### PR TITLE
Link with boost_chrono library on OSX

### DIFF
--- a/bitcoin-qt.pro
+++ b/bitcoin-qt.pro
@@ -411,6 +411,7 @@ LIBS += -lssl -lcrypto -ldb_cxx$$BDB_LIB_SUFFIX
 win32:LIBS += -lws2_32 -lshlwapi -lmswsock -lole32 -loleaut32 -luuid -lgdi32
 LIBS += -lboost_system$$BOOST_LIB_SUFFIX -lboost_filesystem$$BOOST_LIB_SUFFIX -lboost_program_options$$BOOST_LIB_SUFFIX -lboost_thread$$BOOST_THREAD_LIB_SUFFIX
 win32:LIBS += -lboost_chrono$$BOOST_LIB_SUFFIX
+macx:LIBS += -lboost_chrono$$BOOST_LIB_SUFFIX
 
 contains(RELEASE, 1) {
     !win32:!macx {

--- a/src/makefile.osx
+++ b/src/makefile.osx
@@ -36,6 +36,7 @@ LIBS += \
  $(DEPSDIR)/lib/libboost_filesystem-mt.a \
  $(DEPSDIR)/lib/libboost_program_options-mt.a \
  $(DEPSDIR)/lib/libboost_thread-mt.a \
+ $(DEPSDIR)/lib/libboost_chrono-mt.a \
  $(DEPSDIR)/lib/libssl.a \
  $(DEPSDIR)/lib/libcrypto.a \
  -lz
@@ -48,6 +49,7 @@ LIBS += \
  -lboost_filesystem-mt \
  -lboost_program_options-mt \
  -lboost_thread-mt \
+ -lboost_chrono-mt \
  -lssl \
  -lcrypto \
  -lz


### PR DESCRIPTION
Compiling on my OSX 10.6 build machine, I get:

Undefined symbols:
  "boost::chrono::steady_clock::now()", referenced from:
      boost::cv_status boost::condition_variable::wait_for<long long, boost::ratio<1ll, 1000000000ll> >(boost::unique_lockboost::mutex&, boost::chrono::duration<long long, boost::ratio<1ll, 1000000000ll> > const&)in bitcoinrpc.o

Linking against the boost_chrono fixes the issue.

Windows builds already link against boost_chrono; Linux doesn't, but compiles (on pull-tester / gitian, at least).
