### PR TITLE
Check for correct genesis

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -862,6 +862,11 @@ bool AppInit2(boost::thread_group& threadGroup)
                     break;
                 }
 
+                // If the loaded chain has a wrong genesis, bail out immediately
+                // (we're likely using a testnet datadir, or the other way around).
+                if (!mapBlockIndex.empty() && pindexGenesisBlock == NULL)
+                    return InitError(_("Incorrect or no genesis block found. Wrong datadir for network?"));
+
                 // Initialize the block index (no-op if non-empty database was already loaded)
                 if (!InitBlockIndex()) {
                     strLoadError = _("Error initializing block database");


### PR DESCRIPTION
At startup, check that the expected genesis is loaded. This should prevent cases where accidentally a datadir from the wrong network is loaded (testnet vs mainnet, e.g.).

This should at least partially #2547, by giving a clearer and sooner error message.
