### PR TITLE
display txfee in first sendCoinsDialog message box (issue #1715)

### DIFF
--- a/bitcoin-qt.pro
+++ b/bitcoin-qt.pro
@@ -216,7 +216,8 @@ HEADERS += src/qt/bitcoingui.h \
     src/threadsafety.h \
     src/limitedmap.h \
     src/qt/splashscreen.h \
-    src/qt/intro.h
+    src/qt/intro.h \
+    src/qt/walletmodeltransaction.h
 
 SOURCES += src/qt/bitcoin.cpp \
     src/qt/bitcoingui.cpp \
@@ -288,7 +289,8 @@ SOURCES += src/qt/bitcoin.cpp \
     src/leveldb.cpp \
     src/txdb.cpp \
     src/qt/splashscreen.cpp \
-    src/qt/intro.cpp
+    src/qt/intro.cpp \
+    src/qt/walletmodeltransaction.cpp
 
 RESOURCES += src/qt/bitcoin.qrc
 

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -93,25 +93,26 @@ void SendCoinsDialog::on_sendButton_clicked()
     QStringList formatted;
     foreach(const SendCoinsRecipient &rcp, recipients)
     {
+        QString recipientElement = QString("<b>%1</b> ").arg(BitcoinUnits::formatWithUnit(BitcoinUnits::BTC, rcp.amount));
+        recipientElement.append(tr("to"));
+
+        if(rcp.label.length() > 0)
+        {
 #if QT_VERSION < 0x050000
-        formatted.append(tr("<b>%1</b> to %2 (%3)").arg(BitcoinUnits::formatWithUnit(BitcoinUnits::BTC, rcp.amount), Qt::escape(rcp.label), rcp.address));
+            recipientElement.append(QString(" %1 <span style='font-size:8px;'>%2</span><br />").arg(Qt::escape(rcp.label), rcp.address)); // add address with label
 #else
-        formatted.append(tr("<b>%1</b> to %2 (%3)").arg(BitcoinUnits::formatWithUnit(BitcoinUnits::BTC, rcp.amount), rcp.label.toHtmlEscaped(), rcp.address));
+            recipientElement.append(QString(" %1 <span style='font-size:8px;'>%2</span><br />").arg(rcp.label.toHtmlEscaped(), rcp.address)); // add address with label
 #endif
+        }
+        else
+        {
+            recipientElement.append(QString(" %1<br />").arg(rcp.address)); // add address WITHOUT label
+        }
+        formatted.append(recipientElement);
     }
 
     fNewRecipientAllowed = false;
 
-    QMessageBox::StandardButton retval = QMessageBox::question(this, tr("Confirm send coins"),
-                          tr("Are you sure you want to send %1?").arg(formatted.join(tr(" and "))),
-          QMessageBox::Yes|QMessageBox::Cancel,
-          QMessageBox::Cancel);
-
-    if(retval != QMessageBox::Yes)
-    {
-        fNewRecipientAllowed = true;
-        return;
-    }
 
     WalletModel::UnlockContext ctx(model->requestUnlock());
     if(!ctx.isValid())
@@ -121,8 +122,11 @@ void SendCoinsDialog::on_sendButton_clicked()
         return;
     }
 
-    WalletModel::SendCoinsReturn sendstatus = model->sendCoins(recipients);
-    switch(sendstatus.status)
+    // prepare transaction for getting txFee earlier
+    WalletModelTransaction currentTransaction(recipients);
+    WalletModel::SendCoinsReturn prepareStatus = model->prepareTransaction(currentTransaction);
+
+    switch(prepareStatus.status)
     {
     case WalletModel::InvalidAddress:
         QMessageBox::warning(this, tr("Send Coins"),
@@ -142,7 +146,7 @@ void SendCoinsDialog::on_sendButton_clicked()
     case WalletModel::AmountWithFeeExceedsBalance:
         QMessageBox::warning(this, tr("Send Coins"),
             tr("The total exceeds your balance when the %1 transaction fee is included.").
-            arg(BitcoinUnits::formatWithUnit(BitcoinUnits::BTC, sendstatus.fee)),
+            arg(BitcoinUnits::formatWithUnit(BitcoinUnits::BTC, currentTransaction.getTransactionFee())),
             QMessageBox::Ok, QMessageBox::Ok);
         break;
     case WalletModel::DuplicateAddress:
@@ -155,6 +159,51 @@ void SendCoinsDialog::on_sendButton_clicked()
             tr("Error: Transaction creation failed!"),
             QMessageBox::Ok, QMessageBox::Ok);
         break;
+    case WalletModel::Aborted: // User aborted, nothing to do
+        break;
+    default:
+        break;
+    }
+
+    if(prepareStatus.status != WalletModel::OK) {
+        fNewRecipientAllowed = true;
+        return;
+    }
+
+    qint64 txFee = currentTransaction.getTransactionFee();
+    QString questionString = tr("Are you sure you want to send?");
+    questionString.append("<br /><br />%1");
+
+    if(txFee > 0)
+    {
+        // append fee string if a fee is required
+        questionString.append("<hr /><span style='color:#aa0000;'>");
+        questionString.append(BitcoinUnits::formatWithUnit(BitcoinUnits::BTC, txFee));
+        questionString.append("</span> ");
+        questionString.append(tr("added as transaction fee"));
+    }
+    if(txFee > 0 || recipients.count() > 1)
+    {
+        // add total amount string if there are more then one recipients or a fee is required
+        questionString.append("<hr />");
+        questionString.append(tr("Total Amount %1").arg(BitcoinUnits::formatWithUnit(BitcoinUnits::BTC, currentTransaction.getTotalTransactionAmount()+txFee)));
+    }
+
+    QMessageBox::StandardButton retval = QMessageBox::question(this, tr("Confirm send coins"),
+        questionString.arg(formatted.join("<br />")),
+        QMessageBox::Yes|QMessageBox::Cancel,
+        QMessageBox::Cancel);
+
+    if(retval != QMessageBox::Yes)
+    {
+        fNewRecipientAllowed = true;
+        return;
+    }
+
+    // now send the prepared transaction
+    WalletModel::SendCoinsReturn sendstatus = model->sendCoins(currentTransaction);
+    switch(sendstatus.status)
+    {
     case WalletModel::TransactionCommitFailed:
         QMessageBox::warning(this, tr("Send Coins"),
             tr("Error: The transaction was rejected. This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here."),
@@ -164,6 +213,8 @@ void SendCoinsDialog::on_sendButton_clicked()
         break;
     case WalletModel::OK:
         accept();
+        break;
+    default:
         break;
     }
     fNewRecipientAllowed = true;

--- a/src/qt/sendcoinsdialog.h
+++ b/src/qt/sendcoinsdialog.h
@@ -9,6 +9,7 @@ namespace Ui {
 class WalletModel;
 class SendCoinsEntry;
 class SendCoinsRecipient;
+class OptionsModel;
 
 QT_BEGIN_NAMESPACE
 class QUrl;

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -4,11 +4,14 @@
 #include <QObject>
 
 #include "allocators.h" /* for SecureString */
+#include "wallet.h"
+#include "walletmodeltransaction.h"
 
 class OptionsModel;
 class AddressTableModel;
 class TransactionTableModel;
 class CWallet;
+class WalletModelTransaction;
 
 QT_BEGIN_NAMESPACE
 class QTimer;
@@ -67,17 +70,17 @@ public:
     // Return status record for SendCoins, contains error id + information
     struct SendCoinsReturn
     {
-        SendCoinsReturn(StatusCode status,
-                         qint64 fee=0,
-                         QString hex=QString()):
-            status(status), fee(fee), hex(hex) {}
+        SendCoinsReturn(StatusCode status, QString hex=QString()):
+            status(status), hex(hex) {}
         StatusCode status;
-        qint64 fee; // is used in case status is "AmountWithFeeExceedsBalance"
         QString hex; // is filled with the transaction hash if status is "OK"
     };
 
+    // prepare transaction for getting txfee before sending coins
+    SendCoinsReturn prepareTransaction(WalletModelTransaction &transaction);
+
     // Send coins to a list of recipients
-    SendCoinsReturn sendCoins(const QList<SendCoinsRecipient> &recipients);
+    SendCoinsReturn sendCoins(WalletModelTransaction &transaction);
 
     // Wallet encryption
     bool setWalletEncrypted(bool encrypted, const SecureString &passphrase);

--- a/src/qt/walletmodeltransaction.cpp
+++ b/src/qt/walletmodeltransaction.cpp
@@ -1,0 +1,57 @@
+#include "walletmodeltransaction.h"
+
+WalletModelTransaction::WalletModelTransaction(const QList<SendCoinsRecipient> &recipients) :
+    recipients(recipients),
+    walletTransaction(0),
+    keyChange(0),
+    fee(0)
+{
+    walletTransaction = new CWalletTx();
+}
+
+WalletModelTransaction::~WalletModelTransaction()
+{
+    delete keyChange;
+    delete walletTransaction;
+}
+
+QList<SendCoinsRecipient> WalletModelTransaction::getRecipients()
+{
+    return recipients;
+}
+
+CWalletTx *WalletModelTransaction::getTransaction()
+{
+    return walletTransaction;
+}
+
+qint64 WalletModelTransaction::getTransactionFee()
+{
+    return fee;
+}
+
+void WalletModelTransaction::setTransactionFee(qint64 newFee)
+{
+    fee=newFee;
+}
+
+qint64 WalletModelTransaction::getTotalTransactionAmount()
+{
+    qint64 totalTransactionAmount = 0;
+    foreach(const SendCoinsRecipient &rcp, recipients)
+    {
+        totalTransactionAmount+=rcp.amount;
+    }
+    return totalTransactionAmount;
+}
+
+void WalletModelTransaction::newPossibleKeyChange(CWallet *wallet)
+{
+    keyChange = new CReserveKey(wallet);
+}
+
+CReserveKey *WalletModelTransaction::getPossibleKeyChange()
+{
+    return keyChange;
+}
+

--- a/src/qt/walletmodeltransaction.h
+++ b/src/qt/walletmodeltransaction.h
@@ -1,0 +1,37 @@
+#ifndef WALLETMODELTRANSACTION_H
+#define WALLETMODELTRANSACTION_H
+
+#include "walletmodel.h"
+
+class SendCoinsRecipient;
+
+/** Data model for a walletmodel transaction. */
+class WalletModelTransaction
+{
+public:
+    explicit WalletModelTransaction(const QList<SendCoinsRecipient> &recipients);
+    ~WalletModelTransaction();
+
+    QList<SendCoinsRecipient> getRecipients();
+
+    CWalletTx *getTransaction();
+
+    void setTransactionFee(qint64 newFee);
+    qint64 getTransactionFee();
+
+    qint64 getTotalTransactionAmount();
+
+    void newPossibleKeyChange(CWallet *wallet);
+    CReserveKey *getPossibleKeyChange();
+
+private:
+    const QList<SendCoinsRecipient> recipients;
+    CWalletTx *walletTransaction;
+    CReserveKey *keyChange;
+    qint64 fee;
+    
+public slots:
+    
+};
+
+#endif // WALLETMODELTRANSACTION_H


### PR DESCRIPTION
People companying about txfees are not shown in the first question (#1715, #1714) if funds should be sent.
This pull will calculate and include the txfee in the sendcoins question messagebox.
