### PR TITLE
Set CLIENT_VERSION_IS_RELEASE, bump build to 0.8.2.1

### DIFF
--- a/share/setup.nsi
+++ b/share/setup.nsi
@@ -51,7 +51,7 @@ CRCCheck on
 XPStyle on
 BrandingText " "
 ShowInstDetails show
-VIProductVersion 0.8.2.0
+VIProductVersion 0.8.2.1
 VIAddVersionKey ProductName Bitcoin
 VIAddVersionKey ProductVersion "${VERSION}"
 VIAddVersionKey CompanyName "${COMPANY}"

--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -9,10 +9,10 @@
 #define CLIENT_VERSION_MAJOR       0
 #define CLIENT_VERSION_MINOR       8
 #define CLIENT_VERSION_REVISION    2
-#define CLIENT_VERSION_BUILD       0
+#define CLIENT_VERSION_BUILD       1
 
 // Set to true for release, false for prerelease or test build
-#define CLIENT_VERSION_IS_RELEASE  false
+#define CLIENT_VERSION_IS_RELEASE  true
 
 // Copyright year (2009-this)
 // Todo: update this when changing our copyright comments in the source


### PR DESCRIPTION
This needs to be pulled before tagging 0.8.2 final release.
