### PR TITLE
Add command-line option to show version only and exit

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -183,6 +183,16 @@ bool AppInit(int argc, char* argv[])
             return false;
         }
 
+        if (mapArgs.count("-v") || mapArgs.count("--version"))
+        {
+            // Identify version of bitcoind
+            std::string strVersion = _("Bitcoin version") + " " + FormatFullVersion() + "\n";
+
+            fprintf(stdout, "%s", strVersion.c_str());
+            return false;
+        }
+
+
         // Command-line RPC
         for (int i = 1; i < argc; i++)
             if (!IsSwitchChar(argv[i][0]) && !boost::algorithm::istarts_with(argv[i], "bitcoin:"))
@@ -288,6 +298,7 @@ std::string HelpMessage()
 {
     string strUsage = _("Options:") + "\n" +
         "  -?                     " + _("This help message") + "\n" +
+        "  -v                     " + _("Show version and exit") + "\n" +
         "  -conf=<file>           " + _("Specify configuration file (default: bitcoin.conf)") + "\n" +
         "  -pid=<file>            " + _("Specify pid file (default: bitcoind.pid)") + "\n" +
         "  -gen                   " + _("Generate coins (default: 0)") + "\n" +


### PR DESCRIPTION
Adds -v and --version options to bitcoind (or Bitcoin-Qt) executable in order to print the version number and exit.

Currently the version can be discovered via -?, but that option gives a long usage message which isn't relevant if all you want to know is the version. (I can see sysadmins using this in scripts for leveling/upgrading bitcoind across multiple servers).
