### PR TITLE
CreateNewBlock performance improvements

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -659,7 +659,7 @@ public:
                      std::vector<CScriptCheck> *pvChecks = NULL) const;
 
     // Apply the effects of this transaction on the UTXO set represented by view
-    bool UpdateCoins(CValidationState &state, CCoinsViewCache &view, CTxUndo &txundo, int nHeight, const uint256 &txhash) const;
+    void UpdateCoins(CValidationState &state, CCoinsViewCache &view, CTxUndo &txundo, int nHeight, const uint256 &txhash) const;
 
     // Context-independent validity checks
     bool CheckTransaction(CValidationState &state) const;


### PR DESCRIPTION
Remove some unnecessary copying and coins view cache layers in CreateNewBlock.

This results in a >10x speedup for GBT for me, with a large mempool (poolsz >5000).
