### PR TITLE
gitian deps-win32.yml needs psmisc package for killall to end the build

### DIFF
--- a/contrib/gitian-descriptors/deps-win32.yml
+++ b/contrib/gitian-descriptors/deps-win32.yml
@@ -10,6 +10,7 @@ packages:
 - "zip"
 - "faketime"
 - "wine"
+- "psmisc"
 reference_datetime: "2011-01-30 00:00:00"
 remotes: []
 files:


### PR DESCRIPTION
gitian build of contrib/gitian-descriptors/deps-win32.yml fails with the following and gets stuck.  This patch adds psmisc which contains killall.  The build is allowed to complete when these processes are dead.

  adding: miniupnpc/upnpcommands.h (deflated 76%)
  adding: miniupnpc/upnperrors.h (deflated 38%)
  adding: miniupnpc/upnpreplyparse.h (deflated 58%)
- killall wineserver services.exe explorer.exe winedevice.exe
  bash: line 59: killall: command not found
