### PR TITLE
More bestblock records in wallets

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -100,6 +100,7 @@ void Shutdown()
     StopNode();
     {
         LOCK(cs_main);
+        pwalletMain->SetBestChain(CBlockLocator(pindexBest));
         if (pblocktree)
             pblocktree->Flush();
         if (pcoinsTip)
@@ -998,6 +999,8 @@ bool AppInit2(boost::thread_group& threadGroup)
             if (!pwalletMain->SetAddressBookName(pwalletMain->vchDefaultKey.GetID(), ""))
                 strErrors << _("Cannot write default address") << "\n";
         }
+
+        pwalletMain->SetBestChain(CBlockLocator(pindexBest));
     }
 
     printf("%s", strErrors.str().c_str());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1870,7 +1870,7 @@ bool SetBestChain(CValidationState &state, CBlockIndex* pindexNew)
     }
 
     // Update best block in wallet (so we can detect restored wallets)
-    if (!fIsInitialDownload)
+    if ((pindexNew->nHeight % 20160) == 0 || (!fIsInitialDownload && (pindexNew->nHeight % 144) == 0))
     {
         const CBlockLocator locator(pindexNew);
         ::SetBestChain(locator);


### PR DESCRIPTION
Write bestblock records in wallets:
- Every 20160 blocks synced, no matter what (before: none during IBD)
- Every 144 blocks after IBD (before: for every block, slow)
- When creating a new wallet (new)
- At shutdown (new)

This should result in far fewer spurious rescans.

To correct all previously missed rescans, we should probably also once change the bestblock record name (suggested by gmaxwell), to force a single rescan once for every wallet. As this is likely to be annoying for almost all, and most that have missed funds in the past have already done a full rescan already, this is perhaps controversial and not included in this pullreq.

Should close #2676 (but I haven't tested that).
