### PR TITLE
Explictly cast calculation to int, to allow std::min to work.

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -530,7 +530,7 @@ bool AppInit2(boost::thread_group& threadGroup)
     // Make sure enough file descriptors are available
     int nBind = std::max((int)mapArgs.count("-bind"), 1);
     nMaxConnections = GetArg("-maxconnections", 125);
-    nMaxConnections = std::max(std::min(nMaxConnections, FD_SETSIZE - nBind - MIN_CORE_FILEDESCRIPTORS), 0);
+    nMaxConnections = std::max(std::min(nMaxConnections, (int)(FD_SETSIZE - nBind - MIN_CORE_FILEDESCRIPTORS)), 0);
     int nFD = RaiseFileDescriptorLimit(nMaxConnections + MIN_CORE_FILEDESCRIPTORS);
     if (nFD < MIN_CORE_FILEDESCRIPTORS)
         return InitError(_("Not enough file descriptors available."));


### PR DESCRIPTION
When compiling on FreeBSD, the calculation here returns an unsigned int. This causes a compile-time error with std::min, which cannot compare signed with unsigned integers.

This pull inserts an explicit cast, treating the calculated value as signed, keeping the compiler happy.
