### PR TITLE
Explicitly #include stdarg.h, for access to va_list

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -7,6 +7,8 @@
 
 #include "uint256.h"
 
+#include <stdarg.h>
+
 #ifndef WIN32
 #include <sys/types.h>
 #include <sys/time.h>


### PR DESCRIPTION
When compiling on util.h FreeBSD, the build fails with "va_list not declared." Including stdarg.h corrects this error and allows the build to succeed.
