### PR TITLE
"move" command now uses [minconf] and check the balance

### DIFF
--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -563,9 +563,9 @@ Value movecmd(const Array& params, bool fHelp)
     string strFrom = AccountFromValue(params[0]);
     string strTo = AccountFromValue(params[1]);
     int64 nAmount = AmountFromValue(params[2]);
+    int nMinDepth = 1;
     if (params.size() > 3)
-        // unused parameter, used to be nMinDepth, keep type-checking it though
-        (void)params[3].get_int();
+        nMinDepth = params[3].get_int();
     string strComment;
     if (params.size() > 4)
         strComment = params[4].get_str();
@@ -573,6 +573,10 @@ Value movecmd(const Array& params, bool fHelp)
     CWalletDB walletdb(pwalletMain->strWalletFile);
     if (!walletdb.TxnBegin())
         throw JSONRPCError(RPC_DATABASE_ERROR, "database error");
+
+    int64 nBalance = GetAccountBalance(strFrom, nMinDepth);
+    if (nAmount > nBalance)
+        throw JSONRPCError(RPC_WALLET_INSUFFICIENT_FUNDS, "Account has insufficient funds");
 
     int64 nNow = GetAdjustedTime();
 

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -563,7 +563,7 @@ Value movecmd(const Array& params, bool fHelp)
     string strFrom = AccountFromValue(params[0]);
     string strTo = AccountFromValue(params[1]);
     int64 nAmount = AmountFromValue(params[2]);
-    int nMinDepth = 1;
+    int nMinDepth = -1;
     if (params.size() > 3)
         nMinDepth = params[3].get_int();
     string strComment;
@@ -574,10 +574,12 @@ Value movecmd(const Array& params, bool fHelp)
     if (!walletdb.TxnBegin())
         throw JSONRPCError(RPC_DATABASE_ERROR, "database error");
 
-    int64 nBalance = GetAccountBalance(strFrom, nMinDepth);
-    if (nAmount > nBalance)
-        throw JSONRPCError(RPC_WALLET_INSUFFICIENT_FUNDS, "Account has insufficient funds");
-
+    if (nMinDepth >= 0)
+    {
+        int64 nBalance = GetAccountBalance(strFrom, nMinDepth);
+        if (nAmount > nBalance)
+            throw JSONRPCError(RPC_WALLET_INSUFFICIENT_FUNDS, "Account has insufficient funds");
+    }
     int64 nNow = GetAdjustedTime();
 
     // Debit


### PR DESCRIPTION
You could end up with a negative balance by moving funds you don't have from one account to another using "move".
This now check [minconf] and the balance.
