### PR TITLE
Don't attempt to resize vector to negative size.

### DIFF
--- a/src/db.cpp
+++ b/src/db.cpp
@@ -541,6 +541,8 @@ bool CAddrDB::Read(CAddrMan& addr)
     // use file size to size memory buffer
     int fileSize = GetFilesize(filein);
     int dataSize = fileSize - sizeof(uint256);
+    //Don't try to resize to a negative number if file is small
+    if ( dataSize < 0 ) dataSize = 0;
     vector<unsigned char> vchData;
     vchData.resize(dataSize);
     uint256 hashIn;


### PR DESCRIPTION
When my system crashes, the peers.dat file often ends up zero-sized. When this happens, vector vchData.resize(dataSize) is handed a negative dataSize. It takes it as an unsigned int and attempts to resize it to 18 hexillion bytes, crashing with a std::bad_alloc, which is presented as "bitcoin in Runaway exception"

This pull simply adds a 'if ( dataSize < 0 ) dataSize = 0;' check before running resize(). Another option would be to make the resize() call itself conditional on dataSize being positive.
