### PR TITLE
Add NSHighResolutionCapable flag to Info.plist for better font rendering on Retina displays

### DIFF
--- a/share/qt/Info.plist
+++ b/share/qt/Info.plist
@@ -31,5 +31,7 @@
             </array>
           </dict>
         </array>
+	<key>NSHighResolutionCapable</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
Adding this flag to the file Info.plist fixes the font appearance on Retina displays. Icons appear still blurry but that's not so disruptive as blurry text.

Having sharp text adds so much to the user experience on MacOS, please consider this fix.
