### PR TITLE
Add Linux script to contrib/ that limits outgoing bandwidth to Bitcoin nodes

### DIFF
--- a/contrib/qos/README
+++ b/contrib/qos/README
@@ -1,0 +1,3 @@
+This is a Linux bash script that will set up tc to limit the outgoing bandwidth for connections to the Bitcoin network. It limits outbound TCP traffic with a source or destination port of 8333, but not if the destination IP is within a LAN (defined as 192.168.x.x).
+
+This means one can have an always-on bitcoind instance running, and another local bitcoind/bitcoin-qt instance which connects to this node and receives blocks from it.

--- a/contrib/qos/tc.sh
+++ b/contrib/qos/tc.sh
@@ -1,0 +1,41 @@
+#network interface on which to limit traffic
+IF="eth0"
+#limit of the network interface in question
+LINKCEIL="1gbit"
+#limit outbound Bitcoin protocol traffic to this rate
+LIMIT="160kbit"
+#defines the address space for which you wish to disable rate limiting
+LOCALNET="192.168.0.0/16"
+
+#delete existing rules
+tc qdisc del dev ${IF} root
+
+#add root class
+tc qdisc add dev ${IF} root handle 1: htb default 10
+
+#add parent class
+tc class add dev ${IF} parent 1: classid 1:1 htb rate ${LINKCEIL} ceil ${LINKCEIL}
+
+#add our two classes. one unlimited, another limited
+tc class add dev ${IF} parent 1:1 classid 1:10 htb rate ${LINKCEIL} ceil ${LINKCEIL} prio 0
+tc class add dev ${IF} parent 1:1 classid 1:11 htb rate ${LIMIT} ceil ${LIMIT} prio 1
+
+#add handles to our classes so packets marked with <x> go into the class with "... handle <x> fw ..."
+tc filter add dev ${IF} parent 1: protocol ip prio 1 handle 1 fw classid 1:10
+tc filter add dev ${IF} parent 1: protocol ip prio 2 handle 2 fw classid 1:11
+
+#delete any existing rules
+#disable for now
+#ret=0
+#while [ $ret -eq 0 ]; do
+#	iptables -t mangle -D OUTPUT 1
+#	ret=$?
+#done
+
+#limit outgoing traffic to and from port 8333. but not when dealing with a host on the local network
+#	(defined by $LOCALNET)
+#	--set-mark marks packages matching these criteria with the number "2"
+#	these packages are filtered by the tc filter with "handle 2"
+#	this filter sends the packages into the 1:11 class, and this class is limited to ${LIMIT}
+iptables -t mangle -A OUTPUT -p tcp -m tcp --dport 8333 ! -d ${LOCALNET} -j MARK --set-mark 0x2
+iptables -t mangle -A OUTPUT -p tcp -m tcp --sport 8333 ! -d ${LOCALNET} -j MARK --set-mark 0x2


### PR DESCRIPTION
This commit adds a Linux script that uses tc and iptables to
limit outgoing bandwidth to Bitcoin nodes. All tcp connections with
a source or destination port of 8333 are limited to the chosen rate.
It does not alter the incoming bandwidth. Additionally, outgoing
bandwidth to a host on a local LAN (192.168.x.x) is not limited.
