### PR TITLE
osx: fix bitcoin-qt startup crash when clicking dock icon

### DIFF
--- a/src/qt/macdockiconhandler.mm
+++ b/src/qt/macdockiconhandler.mm
@@ -51,6 +51,7 @@ MacDockIconHandler::MacDockIconHandler() : QObject()
     this->m_dockIconClickEventHandler = [[DockIconClickEventHandler alloc] initWithDockIconHandler:this];
     this->m_dummyWidget = new QWidget();
     this->m_dockMenu = new QMenu(this->m_dummyWidget);
+    this->setMainWindow(NULL);
 
     [pool release];
 }
@@ -114,8 +115,11 @@ MacDockIconHandler *MacDockIconHandler::instance()
 
 void MacDockIconHandler::handleDockIconClickEvent()
 {
-    this->mainWindow->activateWindow();
-    this->mainWindow->show();
+    if (this->mainWindow)
+    {
+        this->mainWindow->activateWindow();
+        this->mainWindow->show();
+    }
 
     emit this->dockIconClicked();
 }


### PR DESCRIPTION
Fixes a regression from Crash probably introduced by 4d17a1b0.
Initialize the window to NULL and verify it before use.

Triggered in this case by running ./bitcoin-qt from a shell, and clicking on the icon before the window comes up.
