### PR TITLE
Log reason for non-standard transaction rejection

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -324,7 +324,7 @@ bool CheckTransaction(const CTransaction& tx, CValidationState& state);
 /** Check for standard transaction types
     @return True if all outputs (scriptPubKeys) use only standard transaction forms
 */
-bool IsStandardTx(const CTransaction& tx);
+bool IsStandardTx(const CTransaction& tx, std::string& reason);
 
 bool IsFinalTx(const CTransaction &tx, int nBlockHeight = 0, int64 nBlockTime = 0);
 

--- a/src/test/script_P2SH_tests.cpp
+++ b/src/test/script_P2SH_tests.cpp
@@ -74,6 +74,7 @@ BOOST_AUTO_TEST_CASE(sign)
     }
 
     CTransaction txFrom;  // Funding transaction:
+    string reason;
     txFrom.vout.resize(8);
     for (int i = 0; i < 4; i++)
     {
@@ -82,7 +83,7 @@ BOOST_AUTO_TEST_CASE(sign)
         txFrom.vout[i+4].scriptPubKey = standardScripts[i];
         txFrom.vout[i+4].nValue = COIN;
     }
-    BOOST_CHECK(IsStandardTx(txFrom));
+    BOOST_CHECK(IsStandardTx(txFrom, reason));
 
     CTransaction txTo[8]; // Spending transactions
     for (int i = 0; i < 8; i++)
@@ -167,13 +168,14 @@ BOOST_AUTO_TEST_CASE(set)
     }
 
     CTransaction txFrom;  // Funding transaction:
+    string reason;
     txFrom.vout.resize(4);
     for (int i = 0; i < 4; i++)
     {
         txFrom.vout[i].scriptPubKey = outer[i];
         txFrom.vout[i].nValue = CENT;
     }
-    BOOST_CHECK(IsStandardTx(txFrom));
+    BOOST_CHECK(IsStandardTx(txFrom, reason));
 
     CTransaction txTo[4]; // Spending transactions
     for (int i = 0; i < 4; i++)
@@ -189,7 +191,7 @@ BOOST_AUTO_TEST_CASE(set)
     for (int i = 0; i < 4; i++)
     {
         BOOST_CHECK_MESSAGE(SignSignature(keystore, txFrom, txTo[i], 0), strprintf("SignSignature %d", i));
-        BOOST_CHECK_MESSAGE(IsStandardTx(txTo[i]), strprintf("txTo[%d].IsStandard", i));
+        BOOST_CHECK_MESSAGE(IsStandardTx(txTo[i], reason), strprintf("txTo[%d].IsStandard", i));
     }
 }
 

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -260,16 +260,17 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
     key.MakeNewKey(true);
     t.vout[0].scriptPubKey.SetDestination(key.GetPubKey().GetID());
 
-    BOOST_CHECK(IsStandardTx(t));
+    string reason;
+    BOOST_CHECK(IsStandardTx(t, reason));
 
     t.vout[0].nValue = 5011; // dust
-    BOOST_CHECK(!IsStandardTx(t));
+    BOOST_CHECK(!IsStandardTx(t, reason));
 
     t.vout[0].nValue = 6011; // not dust
-    BOOST_CHECK(IsStandardTx(t));
+    BOOST_CHECK(IsStandardTx(t, reason));
 
     t.vout[0].scriptPubKey = CScript() << OP_1;
-    BOOST_CHECK(!IsStandardTx(t));
+    BOOST_CHECK(!IsStandardTx(t, reason));
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Update CTransaction::IsStandard() to return a string describing the reason a transaction is considered non-standard.  Add that string to the TX-is-nonstd error message.
