### PR TITLE
Fix shutdown deadlock, ticket #2690

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -20,6 +20,7 @@
 #include <vector>
 #include <string>
 
+#include <boost/version.hpp>
 #include <boost/thread.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/filesystem/path.hpp>

--- a/src/util.h
+++ b/src/util.h
@@ -105,7 +105,11 @@ T* alignup(T* p)
 
 inline void MilliSleep(int64 n)
 {
-#if BOOST_VERSION >= 105000
+// Boost's sleep_for was uninterruptable when backed by nanosleep from 1.50
+// until fixed in 1.52. Use the deprecated sleep method for the broken case.
+// See: https://svn.boost.org/trac/boost/ticket/7238
+
+#if BOOST_VERSION >= 105000 && (!defined(BOOST_HAS_NANOSLEEP) || BOOST_VERSION >= 105200)
     boost::this_thread::sleep_for(boost::chrono::milliseconds(n));
 #else
     boost::this_thread::sleep(boost::posix_time::milliseconds(n));


### PR DESCRIPTION
See commits for explanation. Busted boost release, this works around it.

This affected fedora 18, and probably Ubuntu Quantal as well.
