### PR TITLE
Refactor keytime/metadata and wallet encryption bugfix

### DIFF
--- a/src/wallet.h
+++ b/src/wallet.h
@@ -87,7 +87,7 @@ public:
     std::string strWalletFile;
 
     std::set<int64> setKeyPool;
-
+    std::map<CKeyID, CKeyMetadata> mapKeyMetadata;
 
     typedef std::map<unsigned int, CMasterKey> MasterKeyMap;
     MasterKeyMap mapMasterKeys;
@@ -140,14 +140,16 @@ public:
     // Generate a new key
     CPubKey GenerateNewKey();
     // Adds a key to the store, and saves it to disk.
-    bool AddKeyPubKey(const CKey& key, const CPubKey &pubkey, int64 nCreateTime = 0);
+    bool AddKeyPubKey(const CKey& key, const CPubKey &pubkey);
     // Adds a key to the store, without saving it to disk (used by LoadWallet)
     bool LoadKey(const CKey& key, const CPubKey &pubkey) { return CCryptoKeyStore::AddKeyPubKey(key, pubkey); }
+    // Load metadata (used by LoadWallet)
+    bool LoadKeyMetadata(const CPubKey &pubkey, const CKeyMetadata &metadata);
 
     bool LoadMinVersion(int nVersion) { nWalletVersion = nVersion; nWalletMaxVersion = std::max(nWalletMaxVersion, nVersion); return true; }
 
     // Adds an encrypted key to the store, and saves it to disk.
-    bool AddCryptedKey(const CPubKey &vchPubKey, const std::vector<unsigned char> &vchCryptedSecret, int64 nCreateTime = 0);
+    bool AddCryptedKey(const CPubKey &vchPubKey, const std::vector<unsigned char> &vchCryptedSecret);
     // Adds an encrypted key to the store, without saving it to disk (used by LoadWallet)
     bool LoadCryptedKey(const CPubKey &vchPubKey, const std::vector<unsigned char> &vchCryptedSecret);
     bool AddCScript(const CScript& redeemScript);

--- a/src/walletdb.cpp
+++ b/src/walletdb.cpp
@@ -344,11 +344,13 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
         }
         else if (strType == "keymeta")
         {
-            vector<unsigned char> vchPubKey;
+            CPubKey vchPubKey;
             ssKey >> vchPubKey;
             CKeyMetadata keyMeta;
             ssValue >> keyMeta;
             wss.nKeyMeta++;
+
+            pwallet->LoadKeyMetadata(vchPubKey, keyMeta);
 
             // find earliest key creation time, as wallet birthday
             if (!pwallet->nTimeFirstKey ||
@@ -483,7 +485,7 @@ DBErrors CWalletDB::LoadWallet(CWallet* pwallet)
 
     // nTimeFirstKey is only reliable if all keys have metadata
     if ((wss.nKeys + wss.nCKeys) != wss.nKeyMeta)
-        pwallet->nTimeFirstKey = 0;
+        pwallet->nTimeFirstKey = 1; // 0 would be considered 'no value'
 
     BOOST_FOREACH(uint256 hash, wss.vWalletUpgrade)
         WriteTx(hash, pwallet->mapWallet[hash]);

--- a/src/walletdb.h
+++ b/src/walletdb.h
@@ -30,7 +30,7 @@ class CKeyMetadata
 public:
     static const int CURRENT_VERSION=1;
     int nVersion;
-    int64 nCreateTime;
+    int64 nCreateTime; // 0 means unknown
 
     CKeyMetadata()
     {
@@ -52,7 +52,7 @@ public:
     void SetNull()
     {
         nVersion = CKeyMetadata::CURRENT_VERSION;
-        nCreateTime = GetTime();
+        nCreateTime = 0;
     }
 };
 
@@ -84,13 +84,12 @@ public:
     }
 
     bool WriteKey(const CPubKey& vchPubKey, const CPrivKey& vchPrivKey,
-                  int64 nCreateTime)
+                  const CKeyMetadata &keyMeta)
     {
         nWalletDBUpdated++;
 
-        CKeyMetadata keyMeta(nCreateTime);
         if (!Write(std::make_pair(std::string("keymeta"), vchPubKey),
-                   keyMeta, false))
+                   keyMeta))
             return false;
 
         return Write(std::make_pair(std::string("key"), vchPubKey), vchPrivKey, false);
@@ -98,14 +97,13 @@ public:
 
     bool WriteCryptedKey(const CPubKey& vchPubKey,
                          const std::vector<unsigned char>& vchCryptedSecret,
-                         int64 nCreateTime)
+                         const CKeyMetadata &keyMeta)
     {
         const bool fEraseUnencryptedKey = true;
         nWalletDBUpdated++;
 
-        CKeyMetadata keyMeta(nCreateTime);
         if (!Write(std::make_pair(std::string("keymeta"), vchPubKey),
-                   keyMeta, false))
+                   keyMeta))
             return false;
 
         if (!Write(std::make_pair(std::string("ckey"), vchPubKey), vchCryptedSecret, false))


### PR DESCRIPTION
Refactor keytime:
- Key metadata is kept in a CWallet::mapKeyMetadata (std::map< CKeyID, CKeyMetadata>).
- When generating a new key, time is put in that map, and new key is written.
- AddKeyPubKey and AddCryptedKey do not take a creation time argument, but instead
  pull it from that map, if it exists there.

Bugfix:
- AddKeyPubKey and AddCryptedKey in CWallet didn't override the CKeyStore
  definition anymore. This is fixed, as they no longed need the nCreationTime
  argument now.

Also a few related other changes:
- Metadata can be overwritten.
- Only GenerateNewKey calls GetTime(), as it's the only place where we know for
  sure a key was not constructed earlier.
- When the nTimeFirstKey is known to be inaccurate, it is set to the value 1
  (instead of 0, which would mean unknown).
- Use CPubKey instead of std::vector< unsigned char> where possible.

Fixes #2779 and #2780 
