### PR TITLE
Initialize database before checking changed txindex

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -744,15 +744,15 @@ bool AppInit2(boost::thread_group& threadGroup)
                 if (!mapBlockIndex.empty() && pindexGenesisBlock == NULL)
                     return InitError(_("Incorrect or no genesis block found. Wrong datadir for network?"));
 
-                // Check for changed -txindex state (only necessary if we are not reindexing anyway)
-                if (!fReindex && fTxIndex != GetBoolArg("-txindex", false)) {
-                    strLoadError = _("You need to rebuild the database using -reindex to change -txindex");
-                    break;
-                }
-
                 // Initialize the block index (no-op if non-empty database was already loaded)
                 if (!InitBlockIndex()) {
                     strLoadError = _("Error initializing block database");
+                    break;
+                }
+
+                // Check for changed -txindex state
+                if (fTxIndex != GetBoolArg("-txindex", false)) {
+                    strLoadError = _("You need to rebuild the database using -reindex to change -txindex");
                     break;
                 }
 


### PR DESCRIPTION
In case no database exists yet, and -txindex(=1) is passed, we currently first check whether fTxIndex differs from -txindex (and ask the user to reindex in that case), and only afterwards initialize the database. By swapping these
around (the initialization is a no-op in case the database already exists), we allow it to be born in txindex mode, without warning.

That also means we don't need to check -reindex anymore, as the wiping/reinit
of the databases happens before checking.

Closes #2782.

Tested all 8 combinations of the database already existing or not, -reindex passed or not, -txindex set or not.
