### PR TITLE
init.cpp: fix chainparams.h double include.

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -14,7 +14,6 @@
 #include "util.h"
 #include "ui_interface.h"
 #include "checkpoints.h"
-#include "chainparams.h"
 
 #include <boost/filesystem.hpp>
 #include <boost/filesystem/fstream.hpp>


### PR DESCRIPTION
Noticed by Diapolo.
