### PR TITLE
fix makefiles and init.cpp after chainparams merge

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -14,7 +14,6 @@
 #include "util.h"
 #include "ui_interface.h"
 #include "checkpoints.h"
-#include "chainparams.h"
 
 #include <boost/filesystem.hpp>
 #include <boost/filesystem/fstream.hpp>

--- a/src/makefile.linux-mingw
+++ b/src/makefile.linux-mingw
@@ -93,7 +93,8 @@ OBJS= \
     obj/hash.o \
     obj/bloom.o \
     obj/leveldb.o \
-    obj/txdb.o
+    obj/txdb.o \
+    obj/chainparams.o
 
 all: bitcoind.exe
 

--- a/src/makefile.mingw
+++ b/src/makefile.mingw
@@ -101,7 +101,8 @@ OBJS= \
     obj/bloom.o \
     obj/noui.o \
     obj/leveldb.o \
-    obj/txdb.o
+    obj/txdb.o \
+    obj/chainparams.o
 
 
 all: bitcoind.exe

--- a/src/makefile.osx
+++ b/src/makefile.osx
@@ -104,7 +104,8 @@ OBJS= \
     obj/bloom.o \
     obj/noui.o \
     obj/leveldb.o \
-    obj/txdb.o
+    obj/txdb.o \
+    obj/chainparams.o
 
 ifndef USE_UPNP
 	override USE_UPNP = -


### PR DESCRIPTION
- add missing chainparams.o to some makefiles
- remove a double-include of chainparams.h in init.cpp
