### PR TITLE
move SelectParamsFromCommandLine() to bitcoin.cpp

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -371,9 +371,6 @@ bool AppInit2(boost::thread_group& threadGroup)
     // ********************************************************* Step 2: parameter interactions
 
     Checkpoints::fEnabled = GetBoolArg("-checkpoints", true);
-    if (!SelectParamsFromCommandLine()) {
-        return InitError("Invalid combination of -testnet and -regtest.");
-    }
 
     if (mapArgs.count("-bind")) {
         // when specifying an explicit binding address, you want to listen on it

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -117,6 +117,11 @@ int main(int argc, char *argv[])
 
     // Command-line options take precedence:
     ParseParameters(argc, argv);
+    // Check for -testnet or -regtest parameter
+    if (!SelectParamsFromCommandLine()) {
+        QMessageBox::critical(0, QObject::tr("Bitcoin"), QObject::tr("Invalid combination of -testnet and -regtest."));
+        return 1;
+    }
 
 #if QT_VERSION < 0x050000
     // Internal string conversion is all UTF-8


### PR DESCRIPTION
- move SelectParamsFromCommandLine() from init.cpp to bitcoin.cpp to allow
  to use TestNet() for Bitcoin-Qt instead of GetBoolArg("-testnet", false)

Does this still work for bitcoind, whose check resides in bitcoind.cpp AFAIK?
