### PR TITLE
Log aborted block database rebuilds

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -785,6 +785,7 @@ bool AppInit2(boost::thread_group& threadGroup)
                     fReindex = true;
                     fRequestShutdown = false;
                 } else {
+                    printf("Aborted block database rebuild. Exiting.\n");
                     return false;
                 }
             } else {


### PR DESCRIPTION
Log when a shutdown has occurred because of an aborted database rebuild.
