### PR TITLE
Make the rand tests determinstic.

### DIFF
--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -263,28 +263,10 @@ BOOST_AUTO_TEST_CASE(util_IsHex)
 
 BOOST_AUTO_TEST_CASE(util_seed_insecure_rand)
 {
-    // Expected results for the determinstic seed.
-    const uint32_t exp_vals[11] = {  91632771U,1889679809U,3842137544U,3256031132U,
-                                   1761911779U, 489223532U,2692793790U,2737472863U,
-                                   2796262275U,1309899767U,840571781U};
-    // Expected 0s in rand()%(idx+2) for the determinstic seed.
-    const int exp_count[9] = {5013,3346,2415,1972,1644,1386,1176,1096,1009};
     int i;
     int count=0;
 
-    seed_insecure_rand();
-
-    //Does the non-determistic rand give us results that look too like the determinstic one?
-    for (i=0;i<10;i++)
-    {
-        int match = 0;
-        uint32_t rval = insecure_rand();
-        for (int j=0;j<11;j++)match |= rval==exp_vals[j];
-        count += match;
-    }
-    // sum(binomial(10,i)*(11/(2^32))^i*(1-(11/(2^32)))^(10-i),i,0,4) ~= 1-1/2^134.73
-    // So _very_ unlikely to throw a false failure here.
-    BOOST_CHECK(count<=4);
+    seed_insecure_rand(true);
 
     for (int mod=2;mod<11;mod++)
     {
@@ -306,20 +288,6 @@ BOOST_AUTO_TEST_CASE(util_seed_insecure_rand)
         }
         BOOST_CHECK(count<=10000/mod+err);
         BOOST_CHECK(count>=10000/mod-err);
-    }
-
-    seed_insecure_rand(true);
-
-    for (i=0;i<11;i++)
-    {
-        BOOST_CHECK_EQUAL(insecure_rand(),exp_vals[i]);
-    }
-
-    for (int mod=2;mod<11;mod++)
-    {
-        count = 0;
-        for (i=0;i<10000;i++) count += insecure_rand()%mod==0;
-        BOOST_CHECK_EQUAL(count,exp_count[mod-2]);
     }
 }
 


### PR DESCRIPTION
This avoids spurious errors with the old tests but still tests
 enough that if the rng is replaced with a totally broken one
 it should still fail.
