### PR TITLE
Added RPC method for dumping the raw hex for a public key in the wallet.

### DIFF
--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -243,6 +243,7 @@ static const CRPCCommand vRPCCommands[] =
     { "submitblock",            &submitblock,            false,     false },
     { "listsinceblock",         &listsinceblock,         false,     false },
     { "dumpprivkey",            &dumpprivkey,            true,      false },
+    { "dumppubkey",             &dumppubkey,             true,      false },
     { "dumpwallet",             &dumpwallet,             true,      false },
     { "importprivkey",          &importprivkey,          false,     false },
     { "importwallet",           &importwallet,           false,     false },

--- a/src/bitcoinrpc.h
+++ b/src/bitcoinrpc.h
@@ -148,6 +148,7 @@ extern json_spirit::Value getaddednodeinfo(const json_spirit::Array& params, boo
 
 extern json_spirit::Value dumpprivkey(const json_spirit::Array& params, bool fHelp); // in rpcdump.cpp
 extern json_spirit::Value importprivkey(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value dumppubkey(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value dumpwallet(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value importwallet(const json_spirit::Array& params, bool fHelp);
 

--- a/src/rpcdump.cpp
+++ b/src/rpcdump.cpp
@@ -214,6 +214,25 @@ Value dumpprivkey(const Array& params, bool fHelp)
     return CBitcoinSecret(vchSecret).ToString();
 }
 
+Value dumppubkey(const Array& params, bool fHelp)
+{
+    if (fHelp || params.size() != 1)
+        throw runtime_error(
+            "dumppubkey <bitcoinaddress>\n"
+            "Reveals the full hex public key corresponding to <bitcoinaddress>.");
+
+    string strAddress = params[0].get_str();
+    CBitcoinAddress address;
+    if (!address.SetString(strAddress))
+        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid Bitcoin address");
+    CKeyID keyID;
+    if (!address.GetKeyID(keyID))
+        throw JSONRPCError(RPC_TYPE_ERROR, "Address does not refer to a key");
+    CPubKey pubKey;
+    if (!pwalletMain->GetPubKey(keyID, pubKey))
+        throw JSONRPCError(RPC_WALLET_ERROR, "Public key for address " + strAddress + " is not known");
+    return HexStr(pubKey.begin(), pubKey.end());
+}
 
 Value dumpwallet(const Array& params, bool fHelp)
 {


### PR DESCRIPTION
Motivation:

There already exists a method for dumping private keys in wallet by address. In order to construct multisig addresses the full public keys are needed but the private keys are not. So it is useful to have a way of exporting full public keys from a wallet.
