### PR TITLE
Make release-process.md followable verbatim

### DIFF
--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -31,7 +31,7 @@ Release Process
   
 	export SIGNER=(your gitian key, ie bluematt, sipa, etc)
 	export VERSION=(new version, e.g. 0.8.0)
-	cd ./gitian-builder
+	pushd ./gitian-builder
 
  Fetch and build inputs: (first time, or when dependency versions change)
 
@@ -58,13 +58,14 @@ Release Process
 	./bin/gsign --signer $SIGNER --release ${VERSION} --destination ../gitian.sigs/ ../bitcoin/contrib/gitian-descriptors/gitian.yml
 	pushd build/out
 	zip -r bitcoin-${VERSION}-linux-gitian.zip *
-	mv bitcoin-${VERSION}-linux-gitian.zip ../../
+	mv bitcoin-${VERSION}-linux-gitian.zip ../../../
 	popd
 	./bin/gbuild --commit bitcoin=v${VERSION} ../bitcoin/contrib/gitian-descriptors/gitian-win32.yml
 	./bin/gsign --signer $SIGNER --release ${VERSION}-win32 --destination ../gitian.sigs/ ../bitcoin/contrib/gitian-descriptors/gitian-win32.yml
 	pushd build/out
 	zip -r bitcoin-${VERSION}-win32-gitian.zip *
-	mv bitcoin-${VERSION}-win32-gitian.zip ../../
+	mv bitcoin-${VERSION}-win32-gitian.zip ../../../
+	popd
 	popd
 
   Build output expected:


### PR DESCRIPTION
The process outlined in the current release-process.md uses pushd and popd, to dip into and return from directories. It starts in the directory that contains the gitian-builder, gitian.sigs, and bitcoin directories. It then changes directory to the gitian-builder directory, builds, puts the signature into gitian.sigs, and the build outputs zipped up in the gitian-builder directory. Then, it repackages the builds into stand-alone files, still within gitian-builder. Once that's done, the time comes to commit the signatures and then, once enough people have signed, to repackage the gitian zips. At this point, the document appears to assume you're already back in the initial directory, the one with the gitian zips (which are actually in gitian-builder), gitian.sigs and bitcoin directories. This edit addresses these issues, by putting the gitian zips in that top directory, and using that directory as the base camp, so to speak, from which the various directories are dipped into and returned from throughout the process.
