### PR TITLE
add option "-memtxnotify" which will execute command when mempool accept a transaction

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -226,6 +226,7 @@ std::string HelpMessage()
     strUsage += "  -blocknotify=<cmd>     " + _("Execute command when the best block changes (%s in cmd is replaced by block hash)") + "\n";
     strUsage += "  -walletnotify=<cmd>    " + _("Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)") + "\n";
     strUsage += "  -alertnotify=<cmd>     " + _("Execute command when a relevant alert is received (%s in cmd is replaced by message)") + "\n";
+    strUsage += "  -memtxnotify=<cmd>     " + _("Execute command when mempool accept a transaction (%s in cmd is replaced by TxID)") + "\n";
     strUsage += "  -upgradewallet         " + _("Upgrade wallet to latest format") + "\n";
     strUsage += "  -keypool=<n>           " + _("Set key pool size to <n> (default: 100)") + "\n";
     strUsage += "  -rescan                " + _("Rescan the block chain for missing wallet transactions") + "\n";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -936,6 +936,14 @@ bool CTxMemPool::accept(CValidationState &state, CTransaction &tx, bool fLimitFr
         EraseFromWallets(ptxOld->GetHash());
     SyncWithWallets(hash, tx, NULL, true);
 
+    // notify an external script when mempool accept a transaction
+    std::string strCmd = GetArg("-memtxnotify", "");
+    if (!strCmd.empty())
+    {
+        boost::replace_all(strCmd, "%s", hash.ToString().c_str());
+        boost::thread t(runCommand, strCmd); // thread runs free
+    }
+
     printf("CTxMemPool::accept() : accepted %s (poolsz %"PRIszu")\n",
            hash.ToString().c_str(),
            mapTx.size());


### PR DESCRIPTION
Usage:

```
$bitcoind -memtxnotify="/tmp/memtxnotify.sh %s"
```

`cat /tmp/memtxnotify.sh`:

```
#!/bin/bash

F=/tmp/mempool_transaction_log
D=`date +"%Y-%m-%d %H:%M:%S"`

echo ${D} - ${1} >> ${F}
```

`tailf /tmp/mempool_transaction_log`:

```
2013-06-27 01:38:44 - c5c4a2bf7a44c9c4b39ae22042da6b86cbcada35f7b2fff864d9a114c65d9b94
2013-06-27 01:38:45 - 6cc77917dfc90c518ad5aa188967ba6d04becca4f5d6f633b4afe754d8b3e21d
2013-06-27 01:38:46 - 1fbea7b1773a9efc9f3b06e90773d159083218e256d1d9edf11669048e1f8088
2013-06-27 01:38:49 - 99321b4748cac1f7612b9546eba01bf5fe28e8617aa3fa23487eb122759076a8
2013-06-27 01:38:50 - 1bb1b3881d18cd674e5023a67b6c0757a587d45eb6973454852f7e295efacf92
2013-06-27 01:39:01 - 64e3fee386ca632e97a0ce55ea58711bb73054cc0c4e6cd41fe9f6fbfbcf262b
2013-06-27 01:39:02 - 84152de18356948583917ed2a36644cfff08c0df65b8f7add4e60efe8c1a1580
2013-06-27 01:39:02 - 45fd501203fc4bd6f5df99ab054a8080fcd2b9acaafb05d9007a8db1b715cdea
2013-06-27 01:39:03 - 659058f7f41e6315a780c48dc8d0d31c697c4b3b14d64de947c6a49ee33954a1
2013-06-27 01:39:04 - 7ac0c0ea12171ee782d98a7d545573e1659d72864ac8dc7a85ce02e35544d896
2013-06-27 01:39:11 - 5817219e8cc418c366e402a89d70dd8878455258c28b3782be8544fe78f1ff72
2013-06-27 01:39:12 - ad03c04b56438655339a65c2f9e20106f9e7c1a991c66d8fbc933a275a84fdd1
```
