### PR TITLE
Add source tarballs to release process

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 src/version.cpp export-subst
+share/genbuild.sh export-subst

--- a/contrib/gitian-descriptors/gitian-win32.yml
+++ b/contrib/gitian-descriptors/gitian-win32.yml
@@ -10,6 +10,7 @@ packages:
 - "unzip"
 - "nsis"
 - "faketime"
+- "xz-utils"
 reference_datetime: "2011-01-30 00:00:00"
 remotes:
 - "url": "https://github.com/bitcoin/bitcoin.git"
@@ -45,7 +46,11 @@ script: |
   #
   cd bitcoin
   mkdir -p $OUTDIR/src
+  VERSION=$(git describe)
+  if [ "d${VERSION:0:1}" == "dv" ]; then VERSION="${VERSION:1}"; fi
   git archive HEAD | tar -x -C $OUTDIR/src
+  git archive HEAD --prefix=bitcoin-${VERSION}/ | gzip -cn >$OUTDIR/bitcoin-${VERSION}-src.tar.gz
+  gunzip <$OUTDIR/bitcoin-${VERSION}-src.tar.gz | xz -7e >$OUTDIR/bitcoin-${VERSION}-src.tar.xz
   cp $OUTDIR/src/doc/README_windows.txt $OUTDIR/readme.txt
   cp $OUTDIR/src/COPYING $OUTDIR/COPYING.txt
   export LD_PRELOAD=/usr/lib/faketime/libfaketime.so.1

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -63,6 +63,7 @@ Release Process
 	./bin/gbuild --commit bitcoin=v${VERSION} ../bitcoin/contrib/gitian-descriptors/gitian-win32.yml
 	./bin/gsign --signer $SIGNER --release ${VERSION}-win32 --destination ../gitian.sigs/ ../bitcoin/contrib/gitian-descriptors/gitian-win32.yml
 	pushd build/out
+	mv bitcoin-*-src.tar.* ../..
 	zip -r bitcoin-${VERSION}-win32-gitian.zip *
 	mv bitcoin-${VERSION}-win32-gitian.zip ../../
 	popd
@@ -71,7 +72,8 @@ Release Process
 
   1. linux 32-bit and 64-bit binaries + source (bitcoin-${VERSION}-linux-gitian.zip)
   2. windows 32-bit binary, installer + source (bitcoin-${VERSION}-win32-gitian.zip)
-  3. Gitian signatures (in gitian.sigs/${VERSION}[-win32]/(your gitian key)/
+  3. source tarballs (bitcoin-${VERSION}-src.tar.{gz,xz})
+  4. Gitian signatures (in gitian.sigs/${VERSION}[-win32]/(your gitian key)/
 
 repackage gitian builds for release as stand-alone zip/tar/installer exe
 

--- a/share/genbuild.sh
+++ b/share/genbuild.sh
@@ -11,15 +11,20 @@ else
     exit 1
 fi
 
-if [ -e "$(which git)" ]; then
-    # clean 'dirty' status of touched files that haven't been modified
-    git diff >/dev/null 2>/dev/null 
+TIME=""
+TRY_GIT=1
+# This will add a line 'TRY_GIT=0' to exported archives. $Format:%nTRY_GIT=0$
+if [ $TRY_GIT -eq 1 ]; then
+    if [ -e "$(which git)" ]; then
+        # clean 'dirty' status of touched files that haven't been modified
+        git diff >/dev/null 2>/dev/null 
 
-    # get a string like "v0.6.0-66-g59887e8-dirty"
-    DESC="$(git describe --dirty 2>/dev/null)"
+        # get a string like "v0.6.0-66-g59887e8-dirty"
+        DESC="$(git describe --dirty 2>/dev/null)"
 
-    # get a string like "2012-04-10 16:27:19 +0200"
-    TIME="$(git log -n 1 --format="%ci")"
+        # get a string like "2012-04-10 16:27:19 +0200"
+        TIME="$(git log -n 1 --format="%ci")"
+    fi
 fi
 
 if [ -n "$DESC" ]; then
@@ -31,5 +36,7 @@ fi
 # only update build.h if necessary
 if [ "$INFO" != "$NEWINFO" ]; then
     echo "$NEWINFO" >"$FILE"
-    echo "#define BUILD_DATE \"$TIME\"" >>"$FILE"
+    if [ -n "$TIME" ]; then
+        echo "#define BUILD_DATE \"$TIME\"" >>"$FILE"
+    fi
 fi


### PR DESCRIPTION
As git provides a way to export a tarball given a commit, it's very easy to add the creation of source releases, IMHO. We very much like people to build from git tags, but apparently this is hard or at least inconvenient for some infrastructure out there. I hope the overhead is minimal enough for those doing the release...

This also disables the use of git-describe in exported source archives, as it results in a spurious error otherwise.

I hope this closes #2476.
