### PR TITLE
Child-pays-for-parent mempool

### DIFF
--- a/src/core.h
+++ b/src/core.h
@@ -45,19 +45,6 @@ public:
     void print() const;
 };
 
-/** An inpoint - a combination of a transaction and an index n into its vin */
-class CInPoint
-{
-public:
-    CTransaction* ptx;
-    unsigned int n;
-
-    CInPoint() { SetNull(); }
-    CInPoint(CTransaction* ptxIn, unsigned int nIn) { ptx = ptxIn; n = nIn; }
-    void SetNull() { ptx = NULL; n = (unsigned int) -1; }
-    bool IsNull() const { return (ptx == NULL && n == (unsigned int) -1); }
-};
-
 /** An input of a transaction.  It contains the location of the previous
  * transaction's output that it claims and a signature that matches the
  * output's public key.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -950,6 +950,19 @@ void CMemPoolTx::calcPrioritySums(const CTxMemPool &mempool)
     nSumTxFees = nFees;
     nDepth = 1;
 
+    // FIXME: shouldn't change sums unless we're at a higher priority than our
+    // parent, otherwise we're essentially free-riding on their priority
+    //
+    // So logic should be if we have a higher priority than any parent, then we
+    // can sum parent fees.
+    //
+    // Idea: have a -debugcreateblock flag that can dump the mempool to a log
+    // file so that the createnewblock decisions can be analyzed after the
+    // fact.
+    //
+    // Idea2: have a -changemempooltxfee, like luke did, to bump up fees for
+    // transactions artificially.
+
     LOCK(mempool.cs);
     int64 max_parent_fees = 0;
     BOOST_FOREACH(const CTxIn txin, this->vin){

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -807,6 +807,8 @@ bool CTxMemPool::accept(CValidationState &state, CTransaction &tx, bool fLimitFr
             return false;
     }
 
+    int64 nFees;
+
     // Check for conflicts with in-memory transactions
     CTransaction* ptxOld = NULL;
     for (unsigned int i = 0; i < tx.vin.size(); i++)
@@ -878,7 +880,7 @@ bool CTxMemPool::accept(CValidationState &state, CTransaction &tx, bool fLimitFr
         // you should add code here to check that the transaction does a
         // reasonable number of ECDSA signature verifications.
 
-        int64 nFees = view.GetValueIn(tx)-GetValueOut(tx);
+        nFees = view.GetValueIn(tx)-GetValueOut(tx);
         unsigned int nSize = ::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION);
 
         // Don't accept it if it can't get into a block
@@ -925,9 +927,9 @@ bool CTxMemPool::accept(CValidationState &state, CTransaction &tx, bool fLimitFr
         if (ptxOld)
         {
             printf("CTxMemPool::accept() : replacing tx %s with new version\n", ptxOld->GetHash().ToString().c_str());
-            remove(*ptxOld);
+            remove(ptxOld->GetHash());
         }
-        addUnchecked(hash, tx);
+        addUnchecked(tx, nFees);
     }
 
     ///// are we sure this is ok when loading transactions or restoring block txes
@@ -942,38 +944,116 @@ bool CTxMemPool::accept(CValidationState &state, CTransaction &tx, bool fLimitFr
     return true;
 }
 
+void CMemPoolTx::calcPrioritySums(const CTxMemPool &mempool)
+{
+    nSumTxSize = ::GetSerializeSize(*this, SER_NETWORK, PROTOCOL_VERSION);
+    nSumTxFees = nFees;
+    nDepth = 1;
 
-bool CTxMemPool::addUnchecked(const uint256& hash, CTransaction &tx)
+    LOCK(mempool.cs);
+    int64 max_parent_fees = 0;
+    BOOST_FOREACH(const CTxIn txin, this->vin){
+        std::map<uint256, CMemPoolTx *>::const_iterator it = mempool.mapTx.find(txin.prevout.hash);
+        if (it != mempool.mapTx.end()){
+            CMemPoolTx &parent = *(it->second);
+
+            // Calculating sums for the purpose of priority is a bit tricky
+            // because transactions can have multiple outputs - we need to make
+            // sure an attacker can't spend multiple outputs of a single high
+            // fee transaction, directly or indirectly, as a way to make their
+            // transaction look like it is paying a higher fee than it really
+            // is.
+            //
+            // Thus we take a pessimistic view when we sum the fees and size of
+            // unconfirmed transactions we depend on by assuming that only the
+            // largest fee seen is the "real one" so we'll never count a fee
+            // twice. Since the main reason child-pays-for-parent is useful is
+            // to essentially add a fee to a transaction this dodge doesn't
+            // badly affect many legit transaction patterns and lets us use
+            // a pure memoization implementation safely.
+            max_parent_fees = max(parent.nSumTxFees, max_parent_fees);
+
+            // Unconfirmed size is a bad thing, so double-counting is safe. We
+            // could create a set of all our direct parents, but spending
+            // multiple outputs of an unconfirmed transaction by a second
+            // transaction is something rarely done for legit reasons.
+            nSumTxSize += parent.nSumTxSize;
+
+            nDepth = max(nDepth, parent.nDepth + 1);
+        }
+    }
+    nSumTxFees += max_parent_fees;
+}
+
+bool CTxMemPool::addUnchecked(const CTransaction &new_tx, int64 nFees)
 {
     // Add to memory pool without checking anything.  Don't call this directly,
     // call CTxMemPool::accept to properly check the transaction first.
     {
-        mapTx[hash] = tx;
-        for (unsigned int i = 0; i < tx.vin.size(); i++)
-            mapNextTx[tx.vin[i].prevout] = CInPoint(&mapTx[hash], i);
+        // We assume there exists a mapNextTx entry for every transaction in
+        // the mempool; sloppily written unittest code sometimes violates this
+        // assumption.
+        assert(new_tx.vin.size() > 0);
+
+        LOCK(cs);
+
+        // We do need to check for duplicates or you would end up with a heapTx
+        // with more elements in it than mapTx*
+        uint256 hash = new_tx.GetHash();
+        if (mapTx.count(hash))
+            return false;
+
+        // FIXME: should use emplace() - what versions of Boost support it?
+        CMemPoolTx tx(new_tx, nFees);
+        tx.calcPrioritySums(*this);
+        boost::heap::fibonacci_heap<CMemPoolTx>::handle_type handle = heapTx.push(tx);
+
+        (*handle).handle = handle; // store heap handle for later
+        CMemPoolTx *ptx= &(*handle); // get pointer to actual copy in the heap
+
+        mapTx[hash] = ptx;
+        for (unsigned int i = 0; i < ptx->vin.size(); i++){
+            assert(mapNextTx.count(ptx->vin[i].prevout) == 0); // double-spends
+            mapNextTx[ptx->vin[i].prevout] = CInPoint(ptx, i);
+        }
+
         nTransactionsUpdated++;
+
+        assert(heapTx.size() == mapTx.size());
+        assert(mapTx.size() <= mapNextTx.size()); // all tx's have one or more inputs
     }
     return true;
 }
 
 
-bool CTxMemPool::remove(const CTransaction &tx, bool fRecursive)
+bool CTxMemPool::remove(const uint256 hash, bool fRecursive)
 {
     // Remove transaction from memory pool
     {
         LOCK(cs);
-        uint256 hash = tx.GetHash();
-        if (mapTx.count(hash))
+        std::map<uint256, CMemPoolTx*>::iterator txit = mapTx.find(hash);
+        if (txit != mapTx.end())
         {
-            if (fRecursive) {
+            CMemPoolTx &tx = *txit->second;
+
+            if (fRecursive){
                 for (unsigned int i = 0; i < tx.vout.size(); i++) {
                     std::map<COutPoint, CInPoint>::iterator it = mapNextTx.find(COutPoint(hash, i));
                     if (it != mapNextTx.end())
-                        remove(*it->second.ptx, true);
+                        remove(it->second.ptx->GetHash());
                 }
             }
+
             BOOST_FOREACH(const CTxIn& txin, tx.vin)
                 mapNextTx.erase(txin.prevout);
+
+            // Boost has a bug with removing the last element of a fibonacci
+            // heap, so check for that case separately.
+            if (heapTx.size() > 1)
+                heapTx.erase(tx.handle);
+            else
+                heapTx.pop();
+
             mapTx.erase(hash);
             nTransactionsUpdated++;
         }
@@ -990,10 +1070,70 @@ bool CTxMemPool::removeConflicts(const CTransaction &tx)
         if (it != mapNextTx.end()) {
             const CTransaction &txConflict = *it->second.ptx;
             if (txConflict != tx)
-                remove(txConflict, true);
+                remove(txConflict.GetHash());
         }
     }
     return true;
+}
+
+void CTxMemPool::updatePriorities(std::set<uint256> &setChangedHashes)
+{
+    // Update priorities of transactions depending on any in setChangedHashes.
+    // This may be because those transactions were removed from the mempool, or
+    // even added in the case of a re-org. The transactions in setChangedHashed
+    // are not touched unless they themselves depend on a transaction in
+    // setChangedHashed.
+
+    LOCK(cs);
+
+    std::set<uint256> d1,d2;
+    std::set<uint256> *dirty = &d1;
+    std::set<uint256> *next_dirty = &d2;
+
+    // Populate the initial dirty set with all changed hashes that are either
+    // not in this mempool, or don't depend on any inputs in the changed hash
+    // set. This ensures that we'll never do more than O(n) work, important in
+    // the case of a large re-org.
+    BOOST_FOREACH(uint256 hash, setChangedHashes){
+        std::map<uint256, CMemPoolTx *>::iterator it = mapTx.find(hash);
+        if (it == mapTx.end()){
+            // The transaction is not in this mempool, safe.
+            dirty->insert(hash);
+        } else {
+            // The transaction is is in this mempool, check if it has any
+            // inputs already in the dirty set.
+            bool fOK = true;
+            BOOST_FOREACH(const CTxIn txin, it->second->vin){
+                if (setChangedHashes.count(txin.prevout.hash)){
+                    // tx has a parent already in the set, ignore it.
+                    fOK = false;
+                    break;
+                }
+            }
+            if (fOK) dirty->insert(hash);
+        }
+    }
+
+    int n = 0;
+    while (!dirty->empty()){
+        next_dirty->clear();
+
+        BOOST_FOREACH(uint256 parent_hash, *dirty){
+
+            // Iterate over all the transactions in the mempool that spent an
+            // output of this changed transaction.
+            std::map<COutPoint, CInPoint>::iterator it = mapNextTx.lower_bound(COutPoint(parent_hash, 0));
+            while (it != mapNextTx.end() && it->first.hash == parent_hash){
+                it->second.ptx->calcPrioritySums(*this);
+                next_dirty->insert(it->second.ptx->GetHash());
+                ++it;
+                n++;
+            }
+        }
+        std::swap(dirty, next_dirty);
+    }
+
+    printf("CTxMemPool::updatePriorities() : updated priorities for %d transactions", n);
 }
 
 void CTxMemPool::clear()
@@ -1001,6 +1141,7 @@ void CTxMemPool::clear()
     LOCK(cs);
     mapTx.clear();
     mapNextTx.clear();
+    heapTx.clear();
     ++nTransactionsUpdated;
 }
 
@@ -1009,9 +1150,10 @@ void CTxMemPool::queryHashes(std::vector<uint256>& vtxid)
     vtxid.clear();
 
     LOCK(cs);
-    vtxid.reserve(mapTx.size());
-    for (map<uint256, CTransaction>::iterator mi = mapTx.begin(); mi != mapTx.end(); ++mi)
-        vtxid.push_back((*mi).first);
+    vtxid.reserve(heapTx.size());
+    boost::heap::fibonacci_heap<CMemPoolTx>::ordered_iterator it;
+    for (it = heapTx.ordered_begin(); it != heapTx.ordered_end(); ++it)
+        vtxid.push_back((*it).GetHash());
 }
 
 
@@ -2002,10 +2144,14 @@ bool SetBestChain(CValidationState &state, CBlockIndex* pindexNew)
     }
 
     // Delete redundant memory transactions that are in the connected branch
+    std::set<uint256> removed_txs;
     BOOST_FOREACH(CTransaction& tx, vDelete) {
-        mempool.remove(tx);
+        uint256 hash = tx.GetHash();
+        removed_txs.insert(hash);
+        mempool.remove(hash, false);
         mempool.removeConflicts(tx);
     }
+    mempool.updatePriorities(removed_txs);
 
     // Update best block in wallet (so we can detect restored wallets)
     if ((pindexNew->nHeight % 20160) == 0 || (!fIsInitialDownload && (pindexNew->nHeight % 144) == 0))
@@ -4195,12 +4341,12 @@ unsigned int static ScanHash_CryptoPP(char* pmidstate, char* pdata, char* phash1
 class COrphan
 {
 public:
-    CTransaction* ptx;
+    CMemPoolTx* ptx;
     set<uint256> setDependsOn;
     double dPriority;
     double dFeePerKb;
 
-    COrphan(CTransaction* ptxIn)
+    COrphan(CMemPoolTx* ptxIn)
     {
         ptx = ptxIn;
         dPriority = dFeePerKb = 0;
@@ -4220,7 +4366,7 @@ uint64 nLastBlockTx = 0;
 uint64 nLastBlockSize = 0;
 
 // We want to sort transactions by priority and fee, so:
-typedef boost::tuple<double, double, CTransaction*> TxPriority;
+typedef boost::tuple<double, double, CMemPoolTx*> TxPriority;
 class TxPriorityCompare
 {
     bool byFee;
@@ -4296,9 +4442,9 @@ CBlockTemplate* CreateNewBlock(CReserveKey& reservekey)
         // This vector will be sorted into a priority queue:
         vector<TxPriority> vecPriority;
         vecPriority.reserve(mempool.mapTx.size());
-        for (map<uint256, CTransaction>::iterator mi = mempool.mapTx.begin(); mi != mempool.mapTx.end(); ++mi)
+        for (map<uint256, CMemPoolTx *>::iterator mi = mempool.mapTx.begin(); mi != mempool.mapTx.end(); ++mi)
         {
-            CTransaction& tx = (*mi).second;
+            CMemPoolTx& tx = *mi->second;
             if (tx.IsCoinBase() || !IsFinalTx(tx))
                 continue;
 
@@ -4333,7 +4479,7 @@ CBlockTemplate* CreateNewBlock(CReserveKey& reservekey)
                     }
                     mapDependers[txin.prevout.hash].push_back(porphan);
                     porphan->setDependsOn.insert(txin.prevout.hash);
-                    nTotalIn += mempool.mapTx[txin.prevout.hash].vout[txin.prevout.n].nValue;
+                    nTotalIn += mempool.mapTx[txin.prevout.hash]->vout[txin.prevout.n].nValue;
                     continue;
                 }
                 const CCoins &coins = view.GetCoins(txin.prevout.hash);
@@ -4362,7 +4508,7 @@ CBlockTemplate* CreateNewBlock(CReserveKey& reservekey)
                 porphan->dFeePerKb = dFeePerKb;
             }
             else
-                vecPriority.push_back(TxPriority(dPriority, dFeePerKb, &(*mi).second));
+                vecPriority.push_back(TxPriority(dPriority, dFeePerKb, mi->second));
         }
 
         // Collect transactions into block

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1133,7 +1133,7 @@ void CTxMemPool::updatePriorities(std::set<uint256> &setChangedHashes)
         std::swap(dirty, next_dirty);
     }
 
-    printf("CTxMemPool::updatePriorities() : updated priorities for %d transactions", n);
+    printf("CTxMemPool::updatePriorities() : updated priorities for %d transactions\n", n);
 }
 
 void CTxMemPool::clear()

--- a/src/main.h
+++ b/src/main.h
@@ -1096,7 +1096,8 @@ public:
         assert(nSumTxSize >= 0);
 
         if (nSumTxSize > 0)
-            return (double)nSumTxFees / ((double)nSumTxSize/1000);
+            // The +1 makes the order meaningful even for zero-fee txs
+            return (double)(nSumTxFees+1) / ((double)nSumTxSize/1000);
         else
             return 0;
     }

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -130,6 +130,7 @@ Value getrawmempool(const Array& params, bool fHelp)
 
         CMemPoolTx &tx = *(mempool.mapTx[hash]);
 
+        rtx.push_back(Pair("priority",tx.priority()));
         rtx.push_back(Pair("nFees",(boost::int64_t)tx.nFees));
         rtx.push_back(Pair("nDepth",(boost::int64_t)tx.nDepth));
         rtx.push_back(Pair("nSumTxFees",(boost::int64_t)tx.nSumTxFees));

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -117,12 +117,27 @@ Value getrawmempool(const Array& params, bool fHelp)
             "getrawmempool\n"
             "Returns all transaction ids in memory pool.");
 
+    LOCK(mempool.cs);
+
     vector<uint256> vtxid;
     mempool.queryHashes(vtxid);
 
     Array a;
-    BOOST_FOREACH(const uint256& hash, vtxid)
-        a.push_back(hash.ToString());
+    BOOST_FOREACH(const uint256& hash, vtxid){
+        Object rtx;
+
+        rtx.push_back(Pair("txid",hash.ToString()));
+
+        CMemPoolTx &tx = *(mempool.mapTx[hash]);
+
+        rtx.push_back(Pair("nFees",(boost::int64_t)tx.nFees));
+        rtx.push_back(Pair("nDepth",(boost::int64_t)tx.nDepth));
+        rtx.push_back(Pair("nSumTxFees",(boost::int64_t)tx.nSumTxFees));
+        rtx.push_back(Pair("nSumTxSize",(boost::int64_t)tx.nSumTxSize));
+        rtx.push_back(Pair("nRecvTime",(boost::int64_t)tx.nRecvTime));
+
+        a.push_back(rtx);
+    }
 
     return a;
 }

--- a/src/test/mempool_tests.cpp
+++ b/src/test/mempool_tests.cpp
@@ -1,0 +1,270 @@
+#include <boost/test/unit_test.hpp>
+
+#include "init.h"
+#include "main.h"
+#include "uint256.h"
+#include "util.h"
+
+BOOST_AUTO_TEST_SUITE(mempool_tests)
+
+BOOST_AUTO_TEST_CASE(CTxMemPool_add_remove)
+{
+    BOOST_CHECK_EQUAL(mempool.size(), 0);
+
+    CTransaction tx1,tx2;
+
+    tx1.vin.resize(1);
+    tx1.vout.resize(1);
+    tx1.vout[0].nValue = 2LL * COIN;
+
+    // Adding and removing a single transaction
+    BOOST_CHECK(!mempool.exists(tx1.GetHash()));
+
+    mempool.addUnchecked(tx1, 1);
+
+    BOOST_CHECK(mempool.exists(tx1.GetHash()));
+    BOOST_CHECK_EQUAL(mempool.size(), 1);
+    BOOST_CHECK(mempool.lookup(tx1.GetHash()) == tx1);
+
+    mempool.remove(tx1.GetHash());
+    BOOST_CHECK(!mempool.exists(tx1.GetHash()));
+    BOOST_CHECK_EQUAL(mempool.size(), 0);
+
+
+    // Adding and removing a transaction with dependencies, tx2 depends on tx1
+    tx2.vin.resize(1);
+    tx2.vin[0].scriptSig = CScript() << OP_1;
+    tx2.vin[0].prevout.hash = tx1.GetHash();
+    tx2.vin[0].prevout.n = 0;
+    tx2.vout.resize(1);
+    tx2.vout[0].nValue = 1LL * COIN;
+
+    mempool.addUnchecked(tx1, 0);
+    mempool.addUnchecked(tx2, 1LL * COIN);
+
+    BOOST_CHECK(mempool.exists(tx1.GetHash()));
+    BOOST_CHECK(mempool.exists(tx2.GetHash()));
+    BOOST_CHECK_EQUAL(mempool.size(), 2);
+
+
+    // tx2 depends on tx1, so both should be removed with recursive flag set
+    mempool.remove(tx1.GetHash());
+    BOOST_CHECK(!mempool.exists(tx1.GetHash()));
+    BOOST_CHECK(!mempool.exists(tx2.GetHash()));
+
+    BOOST_CHECK_EQUAL(mempool.size(), 0);
+    BOOST_CHECK_EQUAL(mempool.heapTx.size(), 0);
+    BOOST_CHECK_EQUAL(mempool.mapTx.size(), 0);
+    BOOST_CHECK_EQUAL(mempool.mapNextTx.size(), 0);
+
+    mempool.clear();
+}
+
+BOOST_AUTO_TEST_CASE(CTxMemPool_priority_tracking)
+{
+    BOOST_CHECK(mempool.size() == 0);
+
+    CTransaction tx1,tx2,tx3,tx4,tx5,tx6;
+
+    // First transaction, 1BTC fee
+    tx1.vin.resize(1);
+    tx1.vout.resize(4);
+    tx1.vout[0].nValue = 10LL * COIN;
+    tx1.vout[1].nValue = 10LL * COIN;
+    tx1.vout[2].nValue = 10LL * COIN;
+    tx1.vout[3].nValue = 10LL * COIN;
+    BOOST_CHECK(mempool.addUnchecked(tx1, 1LL * COIN));
+
+    // Exactly one tx in the heap
+    BOOST_CHECK(mempool.heapTx.top() == tx1);
+    BOOST_CHECK_EQUAL(mempool.heapTx.top().nSumTxFees, 1LL * COIN);
+    BOOST_CHECK_EQUAL(mempool.heapTx.top().nSumTxSize, 87);
+    BOOST_CHECK_EQUAL(mempool.heapTx.top().nDepth, 1);
+
+
+    // Second tx, 2BTC fee, replaces tx1 as top of the heap
+    tx2.vin.resize(1);
+    tx2.vin[0].prevout.n = 1; // need to make tx1 != tx2
+    tx2.vout.resize(2);
+    tx2.vout[0].nValue = 10LL * COIN;
+    tx2.vout[1].nValue = 10LL * COIN;
+    BOOST_CHECK(mempool.addUnchecked(tx2, 2LL * COIN));
+
+    BOOST_CHECK(mempool.heapTx.top() == tx2);
+    BOOST_CHECK_EQUAL(mempool.heapTx.top().nSumTxFees, 2LL * COIN);
+    BOOST_CHECK_EQUAL(mempool.heapTx.top().nSumTxSize, 69);
+    BOOST_CHECK_EQUAL(mempool.heapTx.top().nDepth, 1);
+
+
+    // Third tx, 1BTC fee, top of heap remains unchanged
+    tx3.vin.resize(1);
+    tx3.vin[0].prevout.n = 2;
+    tx3.vout.resize(1);
+    tx3.vout[0].nValue = 10LL * COIN;
+    BOOST_CHECK(mempool.addUnchecked(tx3, 1LL * COIN));
+
+    BOOST_CHECK(mempool.heapTx.top() == tx2);
+    BOOST_CHECK_EQUAL(mempool.lookup(tx3.GetHash()).nSumTxFees, 1LL * COIN);
+    BOOST_CHECK_EQUAL(mempool.lookup(tx3.GetHash()).nSumTxSize, 60);
+    BOOST_CHECK_EQUAL(mempool.lookup(tx3.GetHash()).nDepth, 1);
+
+
+    // Spend tx1 output 0 with 4BTC fee
+    tx4.vin.resize(1);
+    tx4.vin[0].scriptSig = CScript() << OP_1;
+    tx4.vin[0].prevout.hash = tx1.GetHash();
+    tx4.vin[0].prevout.n = 0;
+    tx4.vout.resize(1);
+    tx4.vout[0].nValue = 6LL * COIN;
+    BOOST_CHECK(mempool.addUnchecked(tx4, 4LL * COIN));
+
+    // tx4 becomes new heap top
+    BOOST_CHECK(mempool.heapTx.top() == tx4);
+    BOOST_CHECK_EQUAL(mempool.lookup(tx4.GetHash()).nSumTxFees, 5LL * COIN);
+    BOOST_CHECK_EQUAL(mempool.lookup(tx4.GetHash()).nSumTxSize, 87+61);
+    BOOST_CHECK_EQUAL(mempool.lookup(tx4.GetHash()).nDepth, 2);
+
+
+    // Spend tx1 output 1, 2, and tx2 output 1 with 1BTC fee
+    tx5.vin.resize(3);
+    tx5.vin[0].scriptSig = CScript() << OP_1;
+    tx5.vin[0].prevout.hash = tx1.GetHash();
+    tx5.vin[0].prevout.n = 1;
+    tx5.vin[1].scriptSig = CScript() << OP_1;
+    tx5.vin[1].prevout.hash = tx1.GetHash();
+    tx5.vin[1].prevout.n = 2;
+    tx5.vin[2].scriptSig = CScript() << OP_1;
+    tx5.vin[2].prevout.hash = tx2.GetHash();
+    tx5.vin[2].prevout.n = 1;
+    tx5.vout.resize(1);
+    tx5.vout[0].nValue = 29LL * COIN;
+    BOOST_CHECK(mempool.addUnchecked(tx5, 1LL * COIN));
+
+    // Fees counted pessimisticly, only one fee counted out of all three
+    BOOST_CHECK_EQUAL(mempool.lookup(tx5.GetHash()).nSumTxFees, (2LL + 1LL) * COIN);
+
+    // Size also counted pessimisticly, every txin sumed together, which even
+    // double-counted tx1
+    BOOST_CHECK_EQUAL(::GetSerializeSize(tx5, SER_NETWORK, PROTOCOL_VERSION), 145);
+    BOOST_CHECK_EQUAL(mempool.lookup(tx5.GetHash()).nSumTxSize, 87+87+69+145);
+    BOOST_CHECK_EQUAL(mempool.lookup(tx5.GetHash()).nDepth, 2);
+
+
+    // Spend tx1.3 and tx5 with 1BTC fee
+    tx6.vin.resize(2);
+    tx6.vin[0].scriptSig = CScript() << OP_1;
+    tx6.vin[0].prevout.hash = tx1.GetHash();
+    tx6.vin[0].prevout.n = 3;
+    tx6.vin[1].scriptSig = CScript() << OP_1;
+    tx6.vin[1].prevout.hash = tx5.GetHash();
+    tx6.vin[1].prevout.n = 0;
+    tx6.vout.resize(1);
+    tx6.vout[0].nValue = 39LL * COIN;
+    BOOST_CHECK(mempool.addUnchecked(tx6, 1LL * COIN));
+
+    // tx6 is not the heap top
+    BOOST_CHECK_EQUAL(mempool.lookup(tx6.GetHash()).nSumTxFees, 4LL * COIN);
+    BOOST_CHECK_EQUAL(mempool.lookup(tx6.GetHash()).nSumTxSize, 87+(87+87+69+145)+103);
+    BOOST_CHECK_EQUAL(mempool.lookup(tx6.GetHash()).nDepth, 3);
+
+
+    // Remove tx2 and update priorities
+    std::set<uint256> changed;
+    changed.insert(tx2.GetHash());
+    mempool.remove(tx2.GetHash(), false);
+    mempool.updatePriorities(changed);
+
+    // Fees no longer include tx2, but they do include tx1
+    BOOST_CHECK_EQUAL(mempool.lookup(tx5.GetHash()).nSumTxFees, (1LL + 1LL) * COIN);
+    BOOST_CHECK_EQUAL(mempool.lookup(tx5.GetHash()).nSumTxSize, 87+87+145);
+    BOOST_CHECK_EQUAL(mempool.lookup(tx5.GetHash()).nDepth, 2);
+
+    // tx6 updated correctly
+    BOOST_CHECK_EQUAL(mempool.lookup(tx6.GetHash()).nSumTxFees, (1LL + 1LL + 1LL) * COIN);
+    BOOST_CHECK_EQUAL(mempool.lookup(tx6.GetHash()).nSumTxSize, 87+(87+87+145)+103);
+    BOOST_CHECK_EQUAL(mempool.lookup(tx6.GetHash()).nDepth, 3);
+
+
+    // Remove tx1
+    changed.clear();
+    changed.insert(tx1.GetHash());
+    mempool.remove(tx1.GetHash(), false);
+    mempool.updatePriorities(changed);
+
+    BOOST_CHECK(mempool.heapTx.top() == tx4);
+    BOOST_CHECK_EQUAL(mempool.lookup(tx4.GetHash()).nSumTxFees, 4LL * COIN);
+    BOOST_CHECK_EQUAL(mempool.lookup(tx4.GetHash()).nSumTxSize, 61);
+    BOOST_CHECK_EQUAL(mempool.lookup(tx4.GetHash()).nDepth, 1);
+
+    BOOST_CHECK_EQUAL(mempool.lookup(tx5.GetHash()).nSumTxFees, 1LL * COIN);
+    BOOST_CHECK_EQUAL(mempool.lookup(tx5.GetHash()).nSumTxSize, 145);
+    BOOST_CHECK_EQUAL(mempool.lookup(tx5.GetHash()).nDepth, 1);
+
+    BOOST_CHECK_EQUAL(mempool.lookup(tx6.GetHash()).nSumTxFees, (1LL + 1LL) * COIN);
+    BOOST_CHECK_EQUAL(mempool.lookup(tx6.GetHash()).nSumTxSize, 145+103);
+    BOOST_CHECK_EQUAL(mempool.lookup(tx6.GetHash()).nDepth, 2);
+
+    // Remove tx5
+    changed.clear();
+    changed.insert(tx5.GetHash());
+    mempool.remove(tx5.GetHash(), false);
+    mempool.updatePriorities(changed);
+
+    BOOST_CHECK(mempool.heapTx.top() == tx4);
+    BOOST_CHECK_EQUAL(mempool.lookup(tx4.GetHash()).nSumTxFees, 4LL * COIN);
+    BOOST_CHECK_EQUAL(mempool.lookup(tx4.GetHash()).nSumTxSize, 61);
+    BOOST_CHECK_EQUAL(mempool.lookup(tx4.GetHash()).nDepth, 1);
+
+    BOOST_CHECK_EQUAL(mempool.lookup(tx6.GetHash()).nSumTxFees, 1LL * COIN);
+    BOOST_CHECK_EQUAL(mempool.lookup(tx6.GetHash()).nSumTxSize, 103);
+    BOOST_CHECK_EQUAL(mempool.lookup(tx6.GetHash()).nDepth, 1);
+
+
+    // Reinstate tx1, tx2 and tx5 as though a re-org happened and they got put
+    // back in the mempool. Note how the order ensures the sums won't be
+    // correct.
+    BOOST_CHECK(mempool.addUnchecked(tx5, 1LL * COIN));
+    BOOST_CHECK(mempool.addUnchecked(tx2, 2LL * COIN));
+    BOOST_CHECK(mempool.addUnchecked(tx1, 1LL * COIN));
+
+    changed.clear();
+    changed.insert(tx1.GetHash());
+    changed.insert(tx2.GetHash());
+    changed.insert(tx5.GetHash());
+    mempool.updatePriorities(changed);
+
+    BOOST_CHECK_EQUAL(mempool.lookup(tx1.GetHash()).nSumTxFees, 1LL * COIN);
+    BOOST_CHECK_EQUAL(mempool.lookup(tx1.GetHash()).nSumTxSize, 87);
+    BOOST_CHECK_EQUAL(mempool.lookup(tx1.GetHash()).nDepth, 1);
+
+    BOOST_CHECK_EQUAL(mempool.lookup(tx2.GetHash()).nSumTxFees, 2LL * COIN);
+    BOOST_CHECK_EQUAL(mempool.lookup(tx2.GetHash()).nSumTxSize, 69);
+    BOOST_CHECK_EQUAL(mempool.lookup(tx2.GetHash()).nDepth, 1);
+
+    BOOST_CHECK_EQUAL(mempool.lookup(tx4.GetHash()).nSumTxFees, 5LL * COIN);
+    BOOST_CHECK_EQUAL(mempool.lookup(tx4.GetHash()).nSumTxSize, 87+61);
+    BOOST_CHECK_EQUAL(mempool.lookup(tx4.GetHash()).nDepth, 2);
+
+    BOOST_CHECK_EQUAL(mempool.lookup(tx5.GetHash()).nSumTxFees, (2LL + 1LL) * COIN);
+    BOOST_CHECK_EQUAL(mempool.lookup(tx5.GetHash()).nSumTxSize, 87+87+69+145);
+    BOOST_CHECK_EQUAL(mempool.lookup(tx5.GetHash()).nDepth, 2);
+
+    BOOST_CHECK_EQUAL(mempool.lookup(tx6.GetHash()).nSumTxFees, (2LL + 1LL + 1LL) * COIN);
+    BOOST_CHECK_EQUAL(mempool.lookup(tx6.GetHash()).nSumTxSize, (87+87+69+145)+87+103);
+    BOOST_CHECK_EQUAL(mempool.lookup(tx6.GetHash()).nDepth, 3);
+
+
+    // Remove everything
+    mempool.remove(tx1.GetHash());
+    mempool.remove(tx2.GetHash());
+    mempool.remove(tx3.GetHash());
+
+    BOOST_CHECK_EQUAL(mempool.size(), 0);
+    BOOST_CHECK_EQUAL(mempool.heapTx.size(), 0);
+    BOOST_CHECK_EQUAL(mempool.mapTx.size(), 0);
+    BOOST_CHECK_EQUAL(mempool.mapNextTx.size(), 0);
+
+    mempool.clear();
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -94,9 +94,8 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     for (unsigned int i = 0; i < 1001; ++i)
     {
         tx.vout[0].nValue -= 1000000;
-        hash = tx.GetHash();
-        mempool.addUnchecked(hash, tx);
-        tx.vin[0].prevout.hash = hash;
+        mempool.addUnchecked(tx, 0);
+        tx.vin[0].prevout.hash = tx.GetHash();
     }
     BOOST_CHECK(pblocktemplate = CreateNewBlock(reservekey));
     delete pblocktemplate;
@@ -114,17 +113,15 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     for (unsigned int i = 0; i < 128; ++i)
     {
         tx.vout[0].nValue -= 10000000;
-        hash = tx.GetHash();
-        mempool.addUnchecked(hash, tx);
-        tx.vin[0].prevout.hash = hash;
+        mempool.addUnchecked(tx, 0);
+        tx.vin[0].prevout.hash = tx.GetHash();
     }
     BOOST_CHECK(pblocktemplate = CreateNewBlock(reservekey));
     delete pblocktemplate;
     mempool.clear();
 
     // orphan in mempool
-    hash = tx.GetHash();
-    mempool.addUnchecked(hash, tx);
+    mempool.addUnchecked(tx, 0);
     BOOST_CHECK(pblocktemplate = CreateNewBlock(reservekey));
     delete pblocktemplate;
     mempool.clear();
@@ -133,16 +130,14 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     tx.vin[0].scriptSig = CScript() << OP_1;
     tx.vin[0].prevout.hash = txFirst[1]->GetHash();
     tx.vout[0].nValue = 4900000000LL;
-    hash = tx.GetHash();
-    mempool.addUnchecked(hash, tx);
-    tx.vin[0].prevout.hash = hash;
+    mempool.addUnchecked(tx, 0);
+    tx.vin[0].prevout.hash = tx.GetHash();
     tx.vin.resize(2);
     tx.vin[1].scriptSig = CScript() << OP_1;
     tx.vin[1].prevout.hash = txFirst[0]->GetHash();
     tx.vin[1].prevout.n = 0;
     tx.vout[0].nValue = 5900000000LL;
-    hash = tx.GetHash();
-    mempool.addUnchecked(hash, tx);
+    mempool.addUnchecked(tx, 0);
     BOOST_CHECK(pblocktemplate = CreateNewBlock(reservekey));
     delete pblocktemplate;
     mempool.clear();
@@ -152,8 +147,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     tx.vin[0].prevout.SetNull();
     tx.vin[0].scriptSig = CScript() << OP_0 << OP_1;
     tx.vout[0].nValue = 0;
-    hash = tx.GetHash();
-    mempool.addUnchecked(hash, tx);
+    mempool.addUnchecked(tx, 0);
     BOOST_CHECK(pblocktemplate = CreateNewBlock(reservekey));
     delete pblocktemplate;
     mempool.clear();
@@ -165,30 +159,29 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     tx.vout[0].nValue = 4900000000LL;
     script = CScript() << OP_0;
     tx.vout[0].scriptPubKey.SetDestination(script.GetID());
-    hash = tx.GetHash();
-    mempool.addUnchecked(hash, tx);
-    tx.vin[0].prevout.hash = hash;
+    mempool.addUnchecked(tx, 0);
+    tx.vin[0].prevout.hash = tx.GetHash();
     tx.vin[0].scriptSig = CScript() << (std::vector<unsigned char>)script;
     tx.vout[0].nValue -= 1000000;
-    hash = tx.GetHash();
-    mempool.addUnchecked(hash,tx);
+    mempool.addUnchecked(tx, 0);
     BOOST_CHECK(pblocktemplate = CreateNewBlock(reservekey));
     delete pblocktemplate;
     mempool.clear();
 
     // double spend txn pair in mempool
+    // disabled: not supported by current mempool
+#if 0
     tx.vin[0].prevout.hash = txFirst[0]->GetHash();
     tx.vin[0].scriptSig = CScript() << OP_1;
     tx.vout[0].nValue = 4900000000LL;
     tx.vout[0].scriptPubKey = CScript() << OP_1;
-    hash = tx.GetHash();
-    mempool.addUnchecked(hash, tx);
+    mempool.addUnchecked(tx, 0);
     tx.vout[0].scriptPubKey = CScript() << OP_2;
-    hash = tx.GetHash();
-    mempool.addUnchecked(hash, tx);
+    mempool.addUnchecked(tx, 0);
     BOOST_CHECK(pblocktemplate = CreateNewBlock(reservekey));
     delete pblocktemplate;
     mempool.clear();
+#endif
 
     // subsidy changing
     int nHeight = pindexBest->nHeight;


### PR DESCRIPTION
Calculates total uncommitted fees and transaction size required to include the transaction in a block for all transactions in the mempool. Cost is O(1) for mempool.accept() and limited to O(n) when a new block changes what transactions are in the mempool, either due to them being mined, conflicts, or reinstated by a re-org.

I haven't changed the mining code, and don't keep track of sigops yet. This isn't useful without mining code and mempool expiration so it's not ready to be actually pulled yet. (mainly I want to see what the pulltester thinks)

Note that this is a safe implementation, not a 100% accurate one, for reasons mentioned in CMemPoolTx::calcPrioritySums() In addition the memoized approach can't directly handle the case where a transaction with a lot of outputs is made worthwhile to mine because of multiple children.
