### PR TITLE
Made the build/release process completable verbatim as listed in release-process.md

### DIFF
--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -31,7 +31,7 @@ Release Process
   
 	export SIGNER=(your gitian key, ie bluematt, sipa, etc)
 	export VERSION=(new version, e.g. 0.8.0)
-	cd ./gitian-builder
+	pushd ./gitian-builder
 
  Fetch and build inputs: (first time, or when dependency versions change)
 
@@ -58,13 +58,14 @@ Release Process
 	./bin/gsign --signer $SIGNER --release ${VERSION} --destination ../gitian.sigs/ ../bitcoin/contrib/gitian-descriptors/gitian.yml
 	pushd build/out
 	zip -r bitcoin-${VERSION}-linux-gitian.zip *
-	mv bitcoin-${VERSION}-linux-gitian.zip ../../
+	mv bitcoin-${VERSION}-linux-gitian.zip ../../../
 	popd
 	./bin/gbuild --commit bitcoin=v${VERSION} ../bitcoin/contrib/gitian-descriptors/gitian-win32.yml
 	./bin/gsign --signer $SIGNER --release ${VERSION}-win32 --destination ../gitian.sigs/ ../bitcoin/contrib/gitian-descriptors/gitian-win32.yml
 	pushd build/out
 	zip -r bitcoin-${VERSION}-win32-gitian.zip *
-	mv bitcoin-${VERSION}-win32-gitian.zip ../../
+	mv bitcoin-${VERSION}-win32-gitian.zip ../../../
+	popd
 	popd
 
   Build output expected:


### PR DESCRIPTION
This is a recreation of https://github.com/bitcoin/bitcoin/pull/2798, on a separate branch rather than master.
