### PR TITLE
Fix minor backward incompatibility

### DIFF
--- a/src/key.cpp
+++ b/src/key.cpp
@@ -155,7 +155,8 @@ public:
         BN_clear_free(&bn);
     }
 
-    void GetPrivKey(CPrivKey &privkey) {
+    void GetPrivKey(CPrivKey &privkey, bool fCompressed) {
+        EC_KEY_set_conv_form(pkey, fCompressed ? POINT_CONVERSION_COMPRESSED : POINT_CONVERSION_UNCOMPRESSED);
         int nSize = i2d_ECPrivateKey(pkey, NULL);
         assert(nSize);
         privkey.resize(nSize);
@@ -304,7 +305,7 @@ CPrivKey CKey::GetPrivKey() const {
     CECKey key;
     key.SetSecretBytes(vch);
     CPrivKey privkey;
-    key.GetPrivKey(privkey);
+    key.GetPrivKey(privkey, fCompressed);
     return privkey;
 }
 


### PR DESCRIPTION
The key refactor changed the way unencrypted private keys with compressed public key are stored in the wallet. Apparently older versions relied on this to verify the correctness of stored keys.

Note that earlier pre-release versions do risk creating wallets that can not be opened by 0.8.3 and earlier.
