### PR TITLE
Use shared lock for wallet registration functions.

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -85,7 +85,7 @@ extern const std::string strMessageMagic;
 extern double dHashesPerSec;
 extern int64 nHPSTimerStart;
 extern int64 nTimeBestReceived;
-extern CCriticalSection cs_setpwalletRegistered;
+extern boost::shared_mutex cs_setpwalletRegistered;
 extern std::set<CWallet*> setpwalletRegistered;
 extern bool fImporting;
 extern bool fReindex;


### PR DESCRIPTION
Using a shared lock for wallet registration functions since only functions that modify the setpwalletRegistered container structure itself (and not the contents) need exclusive access.
