### PR TITLE
getblocktemplate: longpolling support

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -28,6 +28,9 @@
 #include <utility>
 #include <vector>
 
+#include <boost/thread/condition_variable.hpp>
+#include <boost/thread/mutex.hpp>
+
 class CBlockIndex;
 class CBloomFilter;
 class CInv;
@@ -87,6 +90,8 @@ extern uint64_t nLastBlockTx;
 extern uint64_t nLastBlockSize;
 extern const std::string strMessageMagic;
 extern int64_t nTimeBestReceived;
+extern boost::mutex csBestBlock;
+extern boost::condition_variable cvBlockChange;
 extern bool fImporting;
 extern bool fReindex;
 extern bool fBenchmark;

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -3,6 +3,10 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <boost/date_time/posix_time/posix_time.hpp>
+#include <boost/thread/locks.hpp>
+#include <boost/thread/thread_time.hpp>
+
 #include "rpcserver.h"
 #include "chainparams.h"
 #include "init.h"
@@ -10,6 +14,7 @@
 #include "main.h"
 #include "miner.h"
 #include "pow.h"
+#include "util.h"
 #ifdef ENABLE_WALLET
 #include "db.h"
 #include "wallet.h"
@@ -324,6 +329,7 @@ Value getblocktemplate(const Array& params, bool fHelp)
          );
 
     std::string strMode = "template";
+    Value lpval = Value::null;
     if (params.size() > 0)
     {
         const Object& oparam = params[0].get_obj();
@@ -336,6 +342,7 @@ Value getblocktemplate(const Array& params, bool fHelp)
         }
         else
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid mode");
+        lpval = find_value(oparam, "longpollid");
     }
 
     if (strMode != "template")
@@ -347,8 +354,56 @@ Value getblocktemplate(const Array& params, bool fHelp)
     if (IsInitialBlockDownload())
         throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "Bitcoin is downloading blocks...");
 
-    // Update block
     static unsigned int nTransactionsUpdatedLast;
+
+    if (lpval.type() != null_type)
+    {
+        // Wait to respond until either the best block changes, OR a minute has passed and there are more transactions
+        uint256 hashWatchedChain;
+        boost::system_time checktxtime;
+        unsigned int nTransactionsUpdatedLastLP;
+
+        if (lpval.type() == str_type)
+        {
+            // Format: <hashBestChain><nTransactionsUpdatedLast>
+            std::string lpstr = lpval.get_str();
+
+            hashWatchedChain.SetHex(lpstr.substr(0, 64));
+            nTransactionsUpdatedLastLP = atoi64(lpstr.substr(64));
+        }
+        else
+        {
+            // NOTE: Spec does not specify behaviour for non-string longpollid, but this makes testing easier
+            hashWatchedChain = chainActive.Tip()->GetBlockHash();
+            nTransactionsUpdatedLastLP = nTransactionsUpdatedLast;
+        }
+
+        LEAVE_CRITICAL_SECTION(pwalletMain->cs_wallet);
+        LEAVE_CRITICAL_SECTION(cs_main);
+        {
+            checktxtime = boost::get_system_time() + boost::posix_time::minutes(1);
+
+            boost::unique_lock<boost::mutex> lock(csBestBlock);
+            while (chainActive.Tip()->GetBlockHash() == hashWatchedChain && fRPCRunning)
+            {
+                if (!cvBlockChange.timed_wait(lock, checktxtime))
+                {
+                    // Timeout: Check transactions for update
+                    if (nTransactionsUpdatedLast != nTransactionsUpdatedLastLP)
+                        break;
+                    checktxtime += boost::posix_time::seconds(10);
+                }
+            }
+        }
+        ENTER_CRITICAL_SECTION(cs_main);
+        ENTER_CRITICAL_SECTION(pwalletMain->cs_wallet);
+
+        if (!fRPCRunning)
+            throw JSONRPCError(RPC_CLIENT_NOT_CONNECTED, "Shutting down");
+        // TODO: Maybe recheck connections/IBD and (if something wrong) send an expires-immediately template to stop miners?
+    }
+
+    // Update block
     static CBlockIndex* pindexPrev;
     static int64_t nStart;
     static CBlockTemplate* pblocktemplate;
@@ -436,6 +491,7 @@ Value getblocktemplate(const Array& params, bool fHelp)
     result.push_back(Pair("transactions", transactions));
     result.push_back(Pair("coinbaseaux", aux));
     result.push_back(Pair("coinbasevalue", (int64_t)pblock->vtx[0].vout[0].nValue));
+    result.push_back(Pair("longpollid", chainActive.Tip()->GetBlockHash().GetHex() + i64tostr(nTransactionsUpdatedLast)));
     result.push_back(Pair("target", hashTarget.GetHex()));
     result.push_back(Pair("mintime", (int64_t)pindexPrev->GetMedianTimePast()+1));
     result.push_back(Pair("mutable", aMutable));

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -21,6 +21,8 @@
 class CBlockIndex;
 class CNetAddr;
 
+extern bool fRPCRunning;
+
 class AcceptedConnection
 {
 public:


### PR DESCRIPTION
Resubmission of #1355, since GitHub closed it on me.

I have rebased it and addressed both of @jeremysawicki's concerns:
- Shutdown now disconnects all longpoll sessions with an error.
- Longpolling now mimicks the behaviour of BitcoinMiner by returning a new template after a minute has passed and there are new transactions.

These changes were not exactly trivial, so re-review of the code is probably necessary.
