### PR TITLE
makefile.mingw: Use normal boost libraries instead of debug for Windows MinGW

### DIFF
--- a/src/makefile.mingw
+++ b/src/makefile.mingw
@@ -21,7 +21,7 @@ USE_UPNP:=-
 USE_IPV6:=1
 
 DEPSDIR?=/usr/local
-BOOST_SUFFIX?=-mgw46-mt-sd-1_52
+BOOST_SUFFIX?=-mgw46-mt-1_52
 
 INCLUDEPATHS= \
  -I"$(CURDIR)" \


### PR DESCRIPTION
https://bitcointalk.org/index.php?topic=258618

Using -mt-1_52 instead of -mt-s-1_52 as it can be compiled with the --build-type=minimal boost option saving space and time.
