### PR TITLE
makefile.mingw: Use normal boost libraries instead of debug for Windows

### DIFF
--- a/src/makefile.mingw
+++ b/src/makefile.mingw
@@ -21,7 +21,7 @@ USE_UPNP:=-
 USE_IPV6:=1
 
 DEPSDIR?=/usr/local
-BOOST_SUFFIX?=-mgw46-mt-sd-1_52
+BOOST_SUFFIX?=-mgw46-mt-s-1_52
 
 INCLUDEPATHS= \
  -I"$(CURDIR)" \


### PR DESCRIPTION
See also: https://github.com/bitcoin/bitcoin/pull/2835#issuecomment-21231694
(There might still be room for a small improvement in building speed here using  --build-type=minimal )
