### PR TITLE
Add block blacklisting RPC

### DIFF
--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -232,6 +232,9 @@ static const CRPCCommand vRPCCommands[] =
     { "getrawmempool",          &getrawmempool,          true,      false },
     { "getblock",               &getblock,               false,     false },
     { "getblockhash",           &getblockhash,           false,     false },
+#ifdef ENABLE_BLOCK_BLACKLISTING
+    { "blacklistblock",         &blacklistblock,         true,      false },
+#endif
     { "gettransaction",         &gettransaction,         false,     false },
     { "listtransactions",       &listtransactions,       false,     false },
     { "listaddressgroupings",   &listaddressgroupings,   false,     false },

--- a/src/bitcoinrpc.h
+++ b/src/bitcoinrpc.h
@@ -207,6 +207,7 @@ extern json_spirit::Value settxfee(const json_spirit::Array& params, bool fHelp)
 extern json_spirit::Value getrawmempool(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value getblockhash(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value getblock(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value blacklistblock(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value gettxoutsetinfo(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value gettxout(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value verifychain(const json_spirit::Array& params, bool fHelp);

--- a/src/main.h
+++ b/src/main.h
@@ -194,6 +194,8 @@ CBlockIndex * InsertBlockIndex(uint256 hash);
 bool VerifySignature(const CCoins& txFrom, const CTransaction& txTo, unsigned int nIn, unsigned int flags, int nHashType);
 /** Abort with a message */
 bool AbortNode(const std::string &msg);
+/** Mark a block as invalid, and reorganize away from it if necessary */
+void InvalidBlockFound(CBlockIndex *pindex);
 
 
 

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -207,6 +207,27 @@ Value gettxoutsetinfo(const Array& params, bool fHelp)
     return ret;
 }
 
+Value blacklistblock(const Array &params, bool fHelp)
+{
+    if (fHelp || params.size() < 1)
+        throw runtime_error(
+            "blacklistblock <blkid>\n"
+            "Blacklist a block, and reorganize away from it.\n"
+            "WARNING: USE ONLY IN EMERGENCY SITUATIONS.\n");
+
+    std::string strHash = params[0].get_str();
+    uint256 hash(strHash);
+    
+    if (mapBlockIndex.count(hash) == 0)
+        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found");
+
+    CBlockIndex* pblockindex = mapBlockIndex[hash];
+
+    InvalidBlockFound(pblockindex);
+
+    return Value::null;
+}
+
 Value gettxout(const Array& params, bool fHelp)
 {
     if (fHelp || params.size() < 2 || params.size() > 3)


### PR DESCRIPTION
This is a rebased version of a patch that mining.bitcoin.cz used during the march 11 2013 hardfork, to be able to continue using 0.8 while still mining the 0.7 chain.

The reason for submitting it to mainline is:
- When implementing this, I found that there were a few edge-cases in the reorganization handling, which are fixed here. They probably won't ever occur in normal operation, but I prefer the code to be robust.
- For emergencies, having a blacklistblock RPC is certainly useful to have in the code, though I prefer not having it in normal releases. It's only enabled when compiling with ENABLE_BLOCK_BLACKLISTING. The RPC code is always compiled, so we can catch refactorings that would break it, though - just the index entry is not present normally.
