### PR TITLE
Mitigate Timing Attacks On Basic RPC Authorization

### DIFF
--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -479,20 +479,15 @@ bool HTTPAuthorized(map<string, string>& mapHeaders)
     string strUserPass = DecodeBase64(strUserPass64);
 
     //Begin constant-time comparison
-    if (strUserPass.length() != strRPCUserColonPass.length()) 
-    {
-        for (size_t i = 0; i < strUserPass.length(); i++) //Stops timing-leaks for the length of the password
-        { 
-            nResult |= strUserPass.at(i) ^ strUserPass.at(i); 
-        }
-        return ++nResult == 0;
-    }
-
-    //XOR's chars in each password together, and then adds either 0 or 1 (0 if the chars match) to nResult
-    for (size_t i = 0; i < strUserPass.length(); i++)
+    //XOR chars in each password together, and then adds either 0 or 1 (0 if they match) to nResult
+    for(size_t i = 0; i < min(strUserPass.length(), strRPCUserColonPass.length()); i++)
     { 
         nResult |= strUserPass.at(i) ^ strRPCUserColonPass.at(i); 
     }
+
+    if(strUserPass.length() != strRPCUserColonPass.length())
+        nResult++;
+
     return nResult == 0;
 }
 

--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -471,12 +471,23 @@ int ReadHTTPMessage(std::basic_istream<char>& stream, map<string,
 
 bool HTTPAuthorized(map<string, string>& mapHeaders)
 {
+    int nResult = 0;
     string strAuth = mapHeaders["authorization"];
     if (strAuth.substr(0,6) != "Basic ")
         return false;
     string strUserPass64 = strAuth.substr(6); boost::trim(strUserPass64);
     string strUserPass = DecodeBase64(strUserPass64);
-    return strUserPass == strRPCUserColonPass;
+
+    //Begin constant-time comparison
+    if (strUserPass.length() != strRPCUserColonPass.length())
+        return false;
+
+    //XOR's chars in each password together, and then adds either 0 or 1 (0 if the chars match) to nResult
+    for (size_t i = 0; i < strUserPass.length(); i++)
+    { 
+        nResult |= strUserPass.at(i) ^ strRPCUserColonPass.at(i); 
+    }
+    return nResult == 0;
 }
 
 //

--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -479,8 +479,14 @@ bool HTTPAuthorized(map<string, string>& mapHeaders)
     string strUserPass = DecodeBase64(strUserPass64);
 
     //Begin constant-time comparison
-    if (strUserPass.length() != strRPCUserColonPass.length())
-        return false;
+    if (strUserPass.length() != strRPCUserColonPass.length()) 
+    {
+        for (size_t i = 0; i < strUserPass.length(); i++) //Stops timing-leaks for the length of the password
+        { 
+            nResult |= strUserPass.at(i) ^ strUserPass.at(i); 
+        }
+        return ++nResult == 0;
+    }
 
     //XOR's chars in each password together, and then adds either 0 or 1 (0 if the chars match) to nResult
     for (size_t i = 0; i < strUserPass.length(); i++)


### PR DESCRIPTION
As per #2838 . Eliminates the possibility of timing attacks by changing the way the two passwords are compared. 
It iterates through each char in the strings, and if the two chars it is comparing aren't the same, then it adds 1 to nReturn and the function, once it's done comparing all the chars, will return false. Previously, the function would return false on the first char that didn't match, allowing a possible attacker to run a timing attack.

See http://rdist.root.org/2010/01/07/timing-independent-array-comparison/ for reference.
