### PR TITLE
Bitcoin-Qt: fix QApplication includes to match our include defaults

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -2,8 +2,6 @@
  * W.J. van der Laan 2011-2012
  */
 
-#include <QApplication>
-
 #include "bitcoingui.h"
 #include "clientmodel.h"
 #include "walletmodel.h"
@@ -17,6 +15,8 @@
 #include "splashscreen.h"
 #include "intro.h"
 
+#undef loop /* Todo: ugh, remove this when the #define loop is gone from util.h */
+#include <QApplication>
 #include <QMessageBox>
 #if QT_VERSION < 0x050000
 #include <QTextCodec>

--- a/src/qt/bitcoinamountfield.cpp
+++ b/src/qt/bitcoinamountfield.cpp
@@ -4,10 +4,11 @@
 #include "bitcoinunits.h"
 #include "guiconstants.h"
 
+#include <QApplication>
 #include <QHBoxLayout>
 #include <QKeyEvent>
 #include <QDoubleSpinBox>
-#include <QApplication>
+
 #include <qmath.h> // for qPow()
 
 BitcoinAmountField::BitcoinAmountField(QWidget *parent):

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -5,8 +5,6 @@
  * The Bitcoin Developers 2011-2012
  */
 
-#include <QApplication>
-
 #include "bitcoingui.h"
 
 #include "transactiontablemodel.h"
@@ -30,6 +28,8 @@
 #include "macdockiconhandler.h"
 #endif
 
+#undef loop /* Todo: ugh, remove this when the #define loop is gone from util.h */
+#include <QApplication>
 #include <QMenuBar>
 #include <QMenu>
 #include <QIcon>

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -1,5 +1,3 @@
-#include <QApplication>
-
 #include "guiutil.h"
 
 #include "bitcoinaddressvalidator.h"
@@ -9,6 +7,8 @@
 #include "util.h"
 #include "init.h"
 
+#undef loop /* Todo: ugh, remove this when the #define loop is gone from util.h */
+#include <QApplication>
 #include <QDateTime>
 #include <QDoubleValidator>
 #include <QFont>

--- a/src/qt/notificator.cpp
+++ b/src/qt/notificator.cpp
@@ -1,9 +1,9 @@
 #include "notificator.h"
 
+#include <QApplication>
 #include <QMetaType>
 #include <QVariant>
 #include <QIcon>
-#include <QApplication>
 #include <QStyle>
 #include <QByteArray>
 #include <QSystemTrayIcon>

--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -2,14 +2,14 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <QApplication>
-
 #include "paymentserver.h"
 
 #include "guiconstants.h"
 #include "ui_interface.h"
 #include "util.h"
 
+#undef loop /* Todo: ugh, remove this when the #define loop is gone from util.h */
+#include <QApplication>
 #include <QByteArray>
 #include <QDataStream>
 #include <QDebug>

--- a/src/qt/splashscreen.cpp
+++ b/src/qt/splashscreen.cpp
@@ -2,9 +2,9 @@
 #include "clientversion.h"
 #include "util.h"
 
-#include <QPainter>
-#undef loop /* ugh, remove this when the #define loop is gone from util.h */
+#undef loop /* Todo: ugh, remove this when the #define loop is gone from util.h */
 #include <QApplication>
+#include <QPainter>
 
 SplashScreen::SplashScreen(const QPixmap &pixmap, Qt::WindowFlags f) :
     QSplashScreen(pixmap, f)


### PR DESCRIPTION
- move all QApplication includes to top of included Qt headers
- undef our loop macro where it would cause compilation errors otherwise
