### PR TITLE
fix possible infinite loop in intro.cpp thread

### DIFF
--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -25,6 +25,7 @@ static const uint64 BLOCK_CHAIN_SIZE = 10LL * GB_BYTES;
 class FreespaceChecker : public QObject
 {
     Q_OBJECT
+
 public:
     FreespaceChecker(Intro *intro);
 
@@ -61,9 +62,16 @@ void FreespaceChecker::check()
 
     /* Find first parent that exists, so that fs::space does not fail */
     fs::path parentDir = dataDir;
+    fs::path parentDirOld = fs::path();
     while(parentDir.has_parent_path() && !fs::exists(parentDir))
     {
         parentDir = parentDir.parent_path();
+
+        /* Check if we make any progress, break if not to prevent an infinite loop here */
+        if (parentDirOld == parentDir)
+            break;
+
+        parentDirOld = parentDir;
     }
 
     try {
@@ -201,7 +209,7 @@ void Intro::setStatus(int status, const QString &message, quint64 bytesAvailable
         } else {
             ui->freeSpace->setStyleSheet("");
         }
-        ui->freeSpace->setText(freeString+".");
+        ui->freeSpace->setText(freeString + ".");
     }
     /* Don't allow confirm in ERROR state */
     ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(status != FreespaceChecker::ST_ERROR);

--- a/src/qt/intro.h
+++ b/src/qt/intro.h
@@ -37,6 +37,7 @@ public:
      * Determine default data directory for operating system.
      */
     static QString getDefaultDataDirectory();
+
 signals:
     void requestCheck();
     void stopThread();


### PR DESCRIPTION
- it was possible to trigger an infinite loop in FreespaceChecker::check() by
  simply removing the drive letter on Windows (which leads to an infinite
  loop in the FreespaceChecker thread)
- this was caused by not checking if we make progress with
  parentDir.parent_path()
