### PR TITLE
Add 'chainwork' to getblock

### DIFF
--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -62,6 +62,7 @@ Object blockToJSON(const CBlock& block, const CBlockIndex* blockindex)
     result.push_back(Pair("nonce", (boost::uint64_t)block.nNonce));
     result.push_back(Pair("bits", HexBits(block.nBits)));
     result.push_back(Pair("difficulty", GetDifficulty(blockindex)));
+    result.push_back(Pair("chainwork", blockindex->nChainWork.GetHex()));
 
     if (blockindex->pprev)
         result.push_back(Pair("previousblockhash", blockindex->pprev->GetBlockHash().GetHex()));


### PR DESCRIPTION
Returns nChainWork from the block index, the total work done by all blocks since the genesis block.

Worth exposing for pedagogical reasons at the very least.

Anyone who tries to bikeshed either the name or the format the value is returned in will regret it - I'm warning you.
