### PR TITLE
remove windows.h from crypter.cpp includes

### DIFF
--- a/src/crypter.cpp
+++ b/src/crypter.cpp
@@ -6,9 +6,6 @@
 #include <openssl/evp.h>
 #include <vector>
 #include <string>
-#ifdef WIN32
-#include <windows.h>
-#endif
 
 #include "crypter.h"
 


### PR DESCRIPTION
- remove an unneeded windows.h include (comes from allocators.h, which is
  included in crypter.h)
