### PR TITLE
cleanup compat.h Windows stuff

### DIFF
--- a/src/compat.h
+++ b/src/compat.h
@@ -3,7 +3,7 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #ifndef _BITCOIN_COMPAT_H
-#define _BITCOIN_COMPAT_H 1
+#define _BITCOIN_COMPAT_H
 
 #ifdef WIN32
 #define _WIN32_WINNT 0x0501
@@ -13,7 +13,6 @@
 #endif
 #define FD_SETSIZE 1024 // max number of fds in fd_set
 #include <winsock2.h>
-#include <mswsock.h>
 #include <ws2tcpip.h>
 #else
 #include <sys/types.h>
@@ -26,12 +25,11 @@
 #include <ifaddrs.h>
 #endif
 
-typedef u_int SOCKET;
 #ifdef WIN32
 #define MSG_NOSIGNAL        0
 #define MSG_DONTWAIT        0
-typedef int socklen_t;
 #else
+typedef u_int SOCKET;
 #include "errno.h"
 #define WSAGetLastError()   errno
 #define WSAEINVAL           EINVAL


### PR DESCRIPTION
- remove an unneded include for mswsock.h as we use winsock2.h anyway
- move typedef u_int SOCKET; into the #ifndef WIN32 part
- remove typedef int socklen_t;  as this is defined in ws2tcpip.h

I hope pulltester is happy with this :).
