### PR TITLE
Security. Adds config option -rpcipcmds to enable filtering which RPC commands can be called per client IP.

### DIFF
--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -570,7 +570,7 @@ bool ClientAllowedForMethod(const boost::asio::ip::address& address, string strM
         }
     }
     
-    // If there is no rpcallowmethodsforip entry matching our IP, then we allow
+    // If there is no rpcipcmds entry matching our IP, then we allow
     // the rpc call to proceed.  Otherwise, it would require listing all allowed
     // methods for all IPs in the config, even if we only want to restrict
     // method calls for one IP.
@@ -1068,7 +1068,7 @@ void ServiceConnection(AcceptedConnection *conn)
             } else if (valRequest.type() == array_type) {
 
                 // Verify that all methods are allowed for this IP before we execute any method.
-                // We only do these checks if -rpcallowmethodsforip is specified.
+                // We only do these checks if -rpcipcmds is specified.
                 const vector<string>& vAllow = mapMultiArgs["-rpcipcmds"];
                 
                 if( !vAllow.empty() ) {

--- a/src/bitcoinrpc.h
+++ b/src/bitcoinrpc.h
@@ -49,6 +49,7 @@ enum RPCErrorCode
     RPC_INVALID_PARAMETER           = -8,  // Invalid, missing or duplicate parameter
     RPC_DATABASE_ERROR              = -20, // Database error
     RPC_DESERIALIZATION_ERROR       = -22, // Error parsing or validating structure in raw format
+    RPC_FORBIDDEN_BY_IP             = -23, // Remote IP not allowed to access this RPC method.
 
     // P2P client errors
     RPC_CLIENT_NOT_CONNECTED        = -9,  // Bitcoin is not connected

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -222,6 +222,7 @@ std::string HelpMessage()
     strUsage += "  -rpcpassword=<pw>      " + _("Password for JSON-RPC connections") + "\n";
     strUsage += "  -rpcport=<port>        " + _("Listen for JSON-RPC connections on <port> (default: 8332 or testnet: 18332)") + "\n";
     strUsage += "  -rpcallowip=<ip>       " + _("Allow JSON-RPC connections from specified IP address") + "\n";
+    strUsage += "  -rpcipcmds=<ip>,<cmd>  " + _("Allow only specific commands from specified IP address. <ip>,<cmd1>,<cmd2>,<cmd3>...") + "\n";
     if (!fHaveGUI)
         strUsage += "  -rpcconnect=<ip>       " + _("Send commands to node running on <ip> (default: 127.0.0.1)") + "\n";
     strUsage += "  -rpcthreads=<n>        " + _("Set the number of threads to service RPC calls (default: 4)") + "\n";


### PR DESCRIPTION
This patch enables one to configure a whitelist of RPC commands that can be called for each allowed client IP.

Let's look at the motivating use case for this feature.   Consider a website that accepts bitcoin payments using the bitcoind API directly.  The webserver and bitcoind are on separate servers.  It is desirable that the webserver be able to call getnewaddress() and gettransaction (or listtransactions).  It is highly undesirable (security risk) that the webserver be able to call any of the send\* commands or stop command, or probably others, especially because the public-facing webserver is the most likely target to be attacked and possibly compromised.

At this point, let's not get distracted with a discussion about using hot wallets vs cold storage vs 3rd party API.  Instead suffice to say that the website has a need to do this, but desires to be as secure about it as possible.

It is also possible to envision more complex scenarios with various client IPs, each with differering requirements / permissions, or all the same, as in a pool of frontend webservers.

Okay, so -rpcipcmds to the rescue.  Now the site administrator can configure bitcoind to only allow desired RPC calls from the webserver IP.  Any other command results in "Method not allowed for client IP." json-rpc error.

./bitcoind --help | grep rpcip
  -rpcipcmds=<ip>,<cmd>  Allow only specific commands from specified IP address. <ip>,<cmd1>,<cmd2>,<cmd3>...

Example bitcoin.conf usage:

rpcallowip=192.168.2.200
rpcipcmds=192.168.2.200,getnewaddress
rpcipcmds=127.0.0.1,getnewaddress,sendtoaddress,getinfo,stop,help

Implementation Notes:

1) If an IP is allowed with rpcallowip but does not have an rpcipcmds entry then all commands can be used.

2) WildCards in IP are accepted.

3) Works with single command invocation and also batch invocation.  

4) For batch invocation, all commands are checked before any command is called.  So all or nothing.

5) Some might find the syntax a little funky.  I considered using &lt;ip&gt;:&lt;cmd&gt; format, one per line, but rejected it because it requires specifying the same IP over and over.  The CSV format enables &lt;ip&gt;,&lt;cmd&gt;,&lt;cmd&gt;,&lt;cmd&gt;... per line and is easy to read/grok and to parse.  So that was my thought process.

6) This is my first bitcoind modification effort, and my first ever github pull request.  Also, I am not a networking expert, and my C++ is very rusty.  It is likely something could have been done better, code or pull request does not meet standards, etc.  If so, my apologies in advance.  The patch meets my needs so far, and I felt I should contribute it in case it can benefit others.  Feel free to re-work, re-write etc as necessary.

7) -rpcipcmds is kind of hard to read.  I originally called it rpcallowipmethods.  But that didn't format nicely with the other commands in the help.  This does.  

Testing:
-  Has been briefly tested with both single and batch invocation from localhost as well as a remote IP.  Tested with IPv4 addresses only.
- I did not create a unit test for it.  Maybe could test with localhost.... remote IP seems hard.
