### PR TITLE
Added RPC method for dumping wallet addresses without the private keys.

### DIFF
--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -245,6 +245,7 @@ static const CRPCCommand vRPCCommands[] =
     { "listsinceblock",         &listsinceblock,         false,     false },
     { "dumpprivkey",            &dumpprivkey,            true,      false },
     { "dumpwallet",             &dumpwallet,             true,      false },
+    { "dumpaddresses",          &dumpaddresses,          true,      false },          
     { "importprivkey",          &importprivkey,          false,     false },
     { "importwallet",           &importwallet,           false,     false },
     { "listunspent",            &listunspent,            false,     false },

--- a/src/bitcoinrpc.h
+++ b/src/bitcoinrpc.h
@@ -150,6 +150,7 @@ extern json_spirit::Value dumpprivkey(const json_spirit::Array& params, bool fHe
 extern json_spirit::Value importprivkey(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value dumpwallet(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value importwallet(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value dumpaddresses(const json_spirit::Array& params, bool fHelp);
 
 extern json_spirit::Value getgenerate(const json_spirit::Array& params, bool fHelp); // in rpcmining.cpp
 extern json_spirit::Value setgenerate(const json_spirit::Array& params, bool fHelp);

--- a/src/rpcdump.cpp
+++ b/src/rpcdump.cpp
@@ -268,3 +268,53 @@ Value dumpwallet(const Array& params, bool fHelp)
     file.close();
     return Value::null;
 }
+
+Value dumpaddresses(const Array& params, bool fHelp)
+{
+    if (fHelp || params.size() != 1)
+        throw runtime_error(
+            "dumpaddresses <filename>\n"
+            "Dumps all wallet addresses to a text file.");
+
+    ofstream file;
+    file.open(params[0].get_str().c_str());
+    if (!file.is_open())
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Cannot open address dump file");
+
+    std::map<CKeyID, int64> mapKeyBirth;
+    std::set<CKeyID> setKeyPool;
+    pwalletMain->GetKeyBirthTimes(mapKeyBirth);
+    pwalletMain->GetAllReserveKeys(setKeyPool);
+
+    // sort time/key pairs
+    std::vector<std::pair<int64, CKeyID> > vKeyBirth;
+    for (std::map<CKeyID, int64>::const_iterator it = mapKeyBirth.begin(); it != mapKeyBirth.end(); it++) {
+        vKeyBirth.push_back(std::make_pair(it->second, it->first));
+    }
+    mapKeyBirth.clear();
+    std::sort(vKeyBirth.begin(), vKeyBirth.end());
+
+    // produce output
+    file << strprintf("# Wallet address dump created by Bitcoin %s (%s)\n", CLIENT_BUILD.c_str(), CLIENT_DATE.c_str());
+    file << strprintf("# * Created on %s\n", EncodeDumpTime(GetTime()).c_str());
+    file << strprintf("# * Best block at time of dump was %i (%s),\n", nBestHeight, hashBestChain.ToString().c_str());
+    file << strprintf("#   mined on %s\n", EncodeDumpTime(pindexBest->nTime).c_str());
+    file << "\n";
+    for (std::vector<std::pair<int64, CKeyID> >::const_iterator it = vKeyBirth.begin(); it != vKeyBirth.end(); it++) {
+        const CKeyID &keyid = it->second;
+        std::string strTime = EncodeDumpTime(it->first);
+        std::string strAddr = CBitcoinAddress(keyid).ToString();
+        if (pwalletMain->mapAddressBook.count(keyid)) {
+            file << strprintf("%s label=%s # addr=%s\n", strTime.c_str(), EncodeDumpString(pwalletMain->mapAddressBook[keyid]).c_str(), strAddr.c_str());
+        } else if (setKeyPool.count(keyid)) {
+            file << strprintf("%s reserve=1 # addr=%s\n", strTime.c_str(), strAddr.c_str());
+        } else {
+            file << strprintf("%s change=1 # addr=%s\n", strTime.c_str(), strAddr.c_str());
+        }
+    }
+    file << "\n";
+    file << "# End of dump\n";
+    file.close();
+    return Value::null;
+}
+


### PR DESCRIPTION
I figured we needed a convenient address export mechanism that doesn't require decrypting the wallet or knowing any private keys.
