### PR TITLE
When fAllowFree is True, nMinFee is incorrectly calculated

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -772,7 +772,7 @@ int64 GetMinFee(const CTransaction& tx, bool fAllowFree, enum GetMinFee_mode mod
     {
         BOOST_FOREACH(const CTxOut& txout, tx.vout)
             if (txout.nValue < CENT)
-                nMinFee = nBaseFee;
+                nMinFee = (1 + (int64)nBytes / 1000) * nBaseFee;
     }
 
     if (!MoneyRange(nMinFee))


### PR DESCRIPTION
Should help to stop "correct horse" type tx.

as @gmaxwell say, it may be not a bug. I'll cancel the request if more core devs reject me...
