### PR TITLE
RPC command "eraseprivkey" for removing a specified private key

### DIFF
--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -251,6 +251,7 @@ static const CRPCCommand vRPCCommands[] =
     { "listsinceblock",         &listsinceblock,         false,     false },
     { "dumpprivkey",            &dumpprivkey,            true,      false },
     { "importprivkey",          &importprivkey,          false,     false },
+    { "eraseprivkey",           &eraseprivkey,           false,     false },
     { "listunspent",            &listunspent,            false,     false },
     { "getrawtransaction",      &getrawtransaction,      false,     false },
     { "createrawtransaction",   &createrawtransaction,   false,     false },
@@ -1184,6 +1185,7 @@ Array RPCConvertValues(const std::string &strMethod, const std::vector<std::stri
     if (strMethod == "lockunspent"            && n > 0) ConvertTo<bool>(params[0]);
     if (strMethod == "lockunspent"            && n > 1) ConvertTo<Array>(params[1]);
     if (strMethod == "importprivkey"          && n > 2) ConvertTo<bool>(params[2]);
+    if (strMethod == "eraseprivkey"           && n > 1) ConvertTo<bool>(params[1]);
 
     return params;
 }

--- a/src/bitcoinrpc.h
+++ b/src/bitcoinrpc.h
@@ -139,6 +139,7 @@ extern json_spirit::Value addnode(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value getaddednodeinfo(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value dumpprivkey(const json_spirit::Array& params, bool fHelp); // in rpcdump.cpp
 extern json_spirit::Value importprivkey(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value eraseprivkey(const json_spirit::Array& params, bool fHelp);
 
 extern json_spirit::Value getgenerate(const json_spirit::Array& params, bool fHelp); // in rpcmining.cpp
 extern json_spirit::Value setgenerate(const json_spirit::Array& params, bool fHelp);

--- a/src/keystore.h
+++ b/src/keystore.h
@@ -56,6 +56,7 @@ protected:
 
 public:
     bool AddKey(const CKey& key);
+    bool EraseKey(const CKeyID &address);
     bool HaveKey(const CKeyID &address) const
     {
         bool result;
@@ -146,7 +147,9 @@ public:
     bool Lock();
 
     virtual bool AddCryptedKey(const CPubKey &vchPubKey, const std::vector<unsigned char> &vchCryptedSecret);
+    virtual bool EraseCryptedKey(const CKeyID &address);
     bool AddKey(const CKey& key);
+    bool EraseKey(const CKeyID &address);
     bool HaveKey(const CKeyID &address) const
     {
         {

--- a/src/rpcdump.cpp
+++ b/src/rpcdump.cpp
@@ -95,18 +95,19 @@ Value eraseprivkey(const Array& params, bool fHelp)
     bool fCompressed;
     CSecret secret = vchSecret.GetSecret(fCompressed);
     key.SetSecret(secret, fCompressed);
-    CKeyID vchAddress = key.GetPubKey().GetID();
+    CPubKey vchPubKey = key.GetPubKey();
+    //const CKeyID address = key.GetPubKey().GetID();
 
-    if (!pwalletMain->HaveKey(vchAddress))
+    if (!pwalletMain->HaveKey(vchPubKey.GetID()))
         throw JSONRPCError(RPC_WALLET_ERROR, "Private key is not known");
     {
         LOCK2(cs_main, pwalletMain->cs_wallet);
 
-        if (!pwalletMain->EraseKey(key))
+        if (!pwalletMain->EraseKey(vchPubKey))
             throw JSONRPCError(RPC_WALLET_ERROR, "Error erasing key from wallet");
 
         pwalletMain->MarkDirty();
-        pwalletMain->DelAddressBookName(vchAddress);
+        pwalletMain->DelAddressBookName(vchPubKey.GetID());
         }
 
     return Value::null;

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -55,6 +55,17 @@ bool CWallet::AddKey(const CKey& key)
     return true;
 }
 
+bool CWallet::EraseKey(const CKey& key)
+{
+    if (!CCryptoKeyStore::EraseKey(key.GetPubKey().GetID()))
+        return false;
+    if (!fFileBacked)
+        return true;
+    if (!IsCrypted())
+        return CWalletDB(strWalletFile).EraseKey(key.GetPubKey(), key.GetPrivKey());
+    return true;
+}
+
 bool CWallet::AddCryptedKey(const CPubKey &vchPubKey, const vector<unsigned char> &vchCryptedSecret)
 {
     if (!CCryptoKeyStore::AddCryptedKey(vchPubKey, vchCryptedSecret))

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -55,14 +55,16 @@ bool CWallet::AddKey(const CKey& key)
     return true;
 }
 
-bool CWallet::EraseKey(const CKey& key)
+bool CWallet::EraseKey(const CPubKey &vchPubKey)
 {
-    if (!CCryptoKeyStore::EraseKey(key.GetPubKey().GetID()))
+    if (!CCryptoKeyStore::EraseKey(vchPubKey.GetID()))
         return false;
     if (!fFileBacked)
         return true;
     if (!IsCrypted())
-        return CWalletDB(strWalletFile).EraseKey(key.GetPubKey(), key.GetPrivKey());
+        return CWalletDB(strWalletFile).EraseKey(vchPubKey);
+    else
+        return CWalletDB(strWalletFile).EraseCryptedKey(vchPubKey);
     return true;
 }
 

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -138,7 +138,7 @@ public:
     // Adds a key to the store, and saves it to disk.
     bool AddKey(const CKey& key);
     // Erases a key from the store, and erases it from disk.
-    bool EraseKey(const CKey& key);
+    bool EraseKey(const CPubKey &vchPubKey);
     // Adds a key to the store, without saving it to disk (used by LoadWallet)
     bool LoadKey(const CKey& key) { return CCryptoKeyStore::AddKey(key); }
 

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -137,6 +137,8 @@ public:
     CPubKey GenerateNewKey();
     // Adds a key to the store, and saves it to disk.
     bool AddKey(const CKey& key);
+    // Erases a key from the store, and erases it from disk.
+    bool EraseKey(const CKey& key);
     // Adds a key to the store, without saving it to disk (used by LoadWallet)
     bool LoadKey(const CKey& key) { return CCryptoKeyStore::AddKey(key); }
 

--- a/src/walletdb.h
+++ b/src/walletdb.h
@@ -56,11 +56,18 @@ public:
         return Write(std::make_pair(std::string("key"), vchPubKey.Raw()), vchPrivKey, false);
     }
 
-    bool EraseKey(const CPubKey& vchPubKey, const CPrivKey& vchPrivKey)
+    bool EraseKey(const CPubKey &vchPubKey)
     {
         nWalletDBUpdated++;
         Erase(std::make_pair(std::string("key"), vchPubKey.Raw()));
         Erase(std::make_pair(std::string("wkey"), vchPubKey.Raw()));
+        return true;
+    }
+
+    bool EraseCryptedKey(const CPubKey& vchPubKey)
+    {
+        nWalletDBUpdated++;
+        Erase(std::make_pair(std::string("ckey"), vchPubKey.Raw()));
         return true;
     }
 

--- a/src/walletdb.h
+++ b/src/walletdb.h
@@ -56,6 +56,14 @@ public:
         return Write(std::make_pair(std::string("key"), vchPubKey.Raw()), vchPrivKey, false);
     }
 
+    bool EraseKey(const CPubKey& vchPubKey, const CPrivKey& vchPrivKey)
+    {
+        nWalletDBUpdated++;
+        Erase(std::make_pair(std::string("key"), vchPubKey.Raw()));
+        Erase(std::make_pair(std::string("wkey"), vchPubKey.Raw()));
+        return true;
+    }
+
     bool WriteCryptedKey(const CPubKey& vchPubKey, const std::vector<unsigned char>& vchCryptedSecret, bool fEraseUnencryptedKey = true)
     {
         nWalletDBUpdated++;


### PR DESCRIPTION
- Now you can instantly remove a specified private key
- No need to rescan for wallet transaction in case you use "importprivkey", just enter:
  importprivkey <bitcoinprivkey> [label] false
  and you would have your wallet ready again in 1 second
- If wallet is encrypted, it would be necessary to use walletpassphrase in advance (as it's same rule for importprivkey)
- If watch-only pulls get merged, it would hopefully help to add 'sweep
  private key' functionality (like Armory Bitcoin client)
