### PR TITLE
Fix reorganization crash

### DIFF
--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -99,4 +99,8 @@ inline bool TestNet() {
     return Params().NetworkID() == CChainParams::TESTNET;
 }
 
+inline bool RegTest() {
+    return Params().NetworkID() == CChainParams::REGTEST;
+}
+
 #endif

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -424,6 +424,7 @@ bool AppInit2(boost::thread_group& threadGroup)
 
     fDebug = GetBoolArg("-debug", false);
     fBenchmark = GetBoolArg("-benchmark", false);
+    mempool.fChecks = GetBoolArg("-checkmempool", RegTest());
 
     // -par=0 means autodetect, but nScriptCheckThreads==0 means no concurrency
     nScriptCheckThreads = GetArg("-par", 0);

--- a/src/main.h
+++ b/src/main.h
@@ -1077,6 +1077,7 @@ public:
 class CTxMemPool
 {
 public:
+    static bool fChecks;
     mutable CCriticalSection cs;
     std::map<uint256, CTransaction> mapTx;
     std::map<COutPoint, CInPoint> mapNextTx;
@@ -1088,6 +1089,7 @@ public:
     void clear();
     void queryHashes(std::vector<uint256>& vtxid);
     void pruneSpent(const uint256& hash, CCoins &coins);
+    void check(CCoinsViewCache *pcoins) const;
 
     unsigned long size()
     {


### PR DESCRIPTION
This is a potential fix for the bug that causes several miner nodes to crash a few days ago.

The problem: when a block is disconnected, the transactions in it are attempted to be moved to the mempool; if some of these are non-standard, this will fail. If there were transactions in the mempool already that depended one or more of those, they become orphan transactions - which breaks the mempool's consistency assumption.

In addition, this pull request adds a CTxMempool::check() method which runs an extensive consistency check on the mempool, and is called from several places when -checkmempool is passed (a non-documented flag).
