### PR TITLE
Reject dust amounts during validation

### DIFF
--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -148,6 +148,14 @@ bool parseBitcoinURI(QString uri, SendCoinsRecipient *out)
     return parseBitcoinURI(uriInstance, out);
 }
 
+bool isDust(const QString& address, qint64 amount)
+{
+    CTxDestination dest = CBitcoinAddress(address.toStdString()).Get();
+    CScript script; script.SetDestination(dest);
+    CTxOut txOut(amount, script);
+    return txOut.IsDust(CTransaction::nMinRelayTxFee);
+}
+
 QString HtmlEscape(const QString& str, bool fMultiLine)
 {
 #if QT_VERSION < 0x050000

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -36,6 +36,9 @@ namespace GUIUtil
     bool parseBitcoinURI(const QUrl &uri, SendCoinsRecipient *out);
     bool parseBitcoinURI(QString uri, SendCoinsRecipient *out);
 
+    // Returns true if given address+amount meets "dust" definition
+    bool isDust(const QString& address, qint64 amount);
+
     // HTML escaping for rich text controls
     QString HtmlEscape(const QString& str, bool fMultiLine=false);
     QString HtmlEscape(const std::string& str, bool fMultiLine=false);

--- a/src/qt/sendcoinsentry.cpp
+++ b/src/qt/sendcoinsentry.cpp
@@ -101,24 +101,21 @@ bool SendCoinsEntry::validate()
     // Check input validity
     bool retval = true;
 
-    if(!ui->payAmount->validate())
-    {
-        retval = false;
-    }
-    else
-    {
-        if(ui->payAmount->value() <= 0)
-        {
-            // Cannot send 0 coins or less
-            ui->payAmount->setValid(false);
-            retval = false;
-        }
-    }
-
     if(!ui->payTo->hasAcceptableInput() ||
        (model && !model->validateAddress(ui->payTo->text())))
     {
         ui->payTo->setValid(false);
+        retval = false;
+    }
+
+    if(!ui->payAmount->validate())
+    {
+        retval = false;
+    }
+
+    // Reject dust outputs:
+    if (retval && GUIUtil::isDust(ui->payTo->text(), ui->payAmount->value())) {
+        ui->payAmount->setValid(false);
         retval = false;
     }
 


### PR DESCRIPTION
Replaces the validation check for "amount == 0" with an isDust check,
so very small output amounts are caught before the wallet
is unlocked, a transaction is created, etc.
