### PR TITLE
do not call BuildMerkleTree() unnecessarily twice

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2264,7 +2264,7 @@ bool CheckBlock(const CBlock& block, CValidationState& state, bool fCheckPOW, bo
         return state.DoS(100, error("CheckBlock() : out-of-bounds SigOpCount"));
 
     // Check merkle root
-    if (fCheckMerkleRoot && block.hashMerkleRoot != block.BuildMerkleTree())
+    if (fCheckMerkleRoot && block.hashMerkleRoot != block.vMerkleTree.back())
         return state.DoS(100, error("CheckBlock() : hashMerkleRoot mismatch"));
 
     return true;


### PR DESCRIPTION
block.BuildMerkleTree(); is called twice for no reason. Just a few lines above its called the first time.
We dont need to check for empty container here before the block.vMerkleTree.back() call, because block.vMerkleTree can not be empty at this point, because block.vtx.empty() has been checked before.
