### PR TITLE
Add NODE_BLOOM service bit and bump protocol version

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -545,6 +545,9 @@ bool AppInit2(boost::thread_group& threadGroup)
             nConnectTimeout = nNewTimeout;
     }
 
+    if (GetBoolArg("-bloomfilters", true))
+        nLocalServices |= NODE_BLOOM;
+
     // Continue to put "/P2SH/" in the coinbase to monitor
     // BIP16 support.
     // This can be removed eventually...

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4067,6 +4067,15 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
         }
     }
 
+    else if (!(nLocalServices & NODE_BLOOM) &&
+             (strCommand == "filterload" ||
+              strCommand == "filteradd" ||
+              strCommand == "filterclear"))
+    {
+        pfrom->CloseSocketDisconnect();
+        return error("peer %s %s attempted to set a bloom filter even though we do not advertise NODE_BLOOM",
+                     pfrom->addr.ToString(), pfrom->cleanSubVer);
+    }
 
     else if (strCommand == "filterload")
     {

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -63,6 +63,7 @@ class CMessageHeader
 enum
 {
     NODE_NETWORK = (1 << 0),
+    NODE_BLOOM   = (1 << 1),
 };
 
 /** A CService with information about it as peer */

--- a/src/rpcmisc.cpp
+++ b/src/rpcmisc.cpp
@@ -36,6 +36,7 @@ Value getinfo(const Array& params, bool fHelp)
             "{\n"
             "  \"version\": xxxxx,           (numeric) the server version\n"
             "  \"protocolversion\": xxxxx,   (numeric) the protocol version\n"
+            "  \"services\": \"xxxxxxxx\",   (string) the local services\n"
             "  \"walletversion\": xxxxx,     (numeric) the wallet version\n"
             "  \"balance\": xxxxxxx,         (numeric) the total bitcoin balance of the wallet\n"
             "  \"blocks\": xxxxxx,           (numeric) the current number of blocks processed in the server\n"
@@ -62,6 +63,7 @@ Value getinfo(const Array& params, bool fHelp)
     Object obj;
     obj.push_back(Pair("version",       (int)CLIENT_VERSION));
     obj.push_back(Pair("protocolversion",(int)PROTOCOL_VERSION));
+    obj.push_back(Pair("services",       strprintf("%08x", nLocalServices)));
 #ifdef ENABLE_WALLET
     if (pwalletMain) {
         obj.push_back(Pair("walletversion", pwalletMain->GetVersion()));

--- a/src/rpcnet.cpp
+++ b/src/rpcnet.cpp
@@ -80,7 +80,7 @@ Value getpeerinfo(const Array& params, bool fHelp)
             "  {\n"
             "    \"addr\":\"host:port\",      (string) The ip address and port of the peer\n"
             "    \"addrlocal\":\"ip:port\",   (string) local address\n"
-            "    \"services\":\"00000001\",   (string) The services\n"
+            "    \"services\":\"xxxxxxxx\",   (string) The services\n"
             "    \"lastsend\": ttt,           (numeric) The time in seconds since epoch (Jan 1 1970 GMT) of the last send\n"
             "    \"lastrecv\": ttt,           (numeric) The time in seconds since epoch (Jan 1 1970 GMT) of the last receive\n"
             "    \"bytessent\": n,            (numeric) The total bytes sent\n"

--- a/src/version.h
+++ b/src/version.h
@@ -26,7 +26,7 @@ extern const std::string CLIENT_DATE;
 // network protocol versioning
 //
 
-static const int PROTOCOL_VERSION = 70002;
+static const int PROTOCOL_VERSION = 70003;
 
 // intial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 209;


### PR DESCRIPTION
Lets nodes advertise that they offer bloom filter support explicitly.
The protocol version bump allows SPV nodes to assume that NODE_BLOOM is
set if NODE_NETWORK is set for pre-70002 nodes.

Also adds an undocumented option to turn bloom filter support off and
immediately kick peers that attempt to use bloom filters for testing
purposes. In addition a number of DoS attacks are made significantly
easier by bloom support, so having an option makes it easy to take
immediate steps in the event of an attack.
