### PR TITLE
Added new RPC method for explicitly banning nodes or removing a ban.

### DIFF
--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -200,6 +200,8 @@ static const CRPCCommand vRPCCommands[] =
     { "getpeerinfo",            &getpeerinfo,            true,      false },
     { "addnode",                &addnode,                true,      true },
     { "getaddednodeinfo",       &getaddednodeinfo,       true,      true },
+    { "bannode",                &bannode,                true,      true },
+    { "listbannednodes",        &listbannednodes,        true,      true },
     { "getdifficulty",          &getdifficulty,          true,      false },
     { "getgenerate",            &getgenerate,            true,      false },
     { "setgenerate",            &setgenerate,            true,      false },
@@ -1201,6 +1203,7 @@ Array RPCConvertValues(const std::string &strMethod, const std::vector<std::stri
     if (strMethod == "verifychain"            && n > 0) ConvertTo<boost::int64_t>(params[0]);
     if (strMethod == "verifychain"            && n > 1) ConvertTo<boost::int64_t>(params[1]);
     if (strMethod == "keypoolrefill"          && n > 0) ConvertTo<boost::int64_t>(params[0]);
+    if (strMethod == "bannode"                && n > 1) ConvertTo<boost::int64_t>(params[1]);
 
     return params;
 }

--- a/src/bitcoinrpc.h
+++ b/src/bitcoinrpc.h
@@ -145,6 +145,8 @@ extern json_spirit::Value getconnectioncount(const json_spirit::Array& params, b
 extern json_spirit::Value getpeerinfo(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value addnode(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value getaddednodeinfo(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value bannode(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value listbannednodes(const json_spirit::Array& params, bool fHelp);
 
 extern json_spirit::Value dumpprivkey(const json_spirit::Array& params, bool fHelp); // in rpcdump.cpp
 extern json_spirit::Value importprivkey(const json_spirit::Array& params, bool fHelp);

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -544,7 +544,7 @@ void CNode::PushVersion()
 
 
 
-std::map<CNetAddr, int64> CNode::setBanned;
+banned_map_t CNode::setBanned;
 CCriticalSection CNode::cs_setBanned;
 
 void CNode::ClearBanned()
@@ -566,6 +566,23 @@ bool CNode::IsBanned(CNetAddr ip)
         }
     }
     return fResult;
+}
+
+void CNode::Ban(CNetAddr ip, int64_t expiration)
+{
+    LOCK(cs_setBanned);
+    if (expiration < 0) {
+        setBanned.erase(ip);
+    }
+    else {
+        setBanned[ip] = expiration;
+    }
+}
+
+banned_map_t CNode::GetBannedMap()
+{
+    LOCK(cs_setBanned);
+    return setBanned;
 }
 
 bool CNode::Misbehaving(int howmuch)

--- a/src/net.h
+++ b/src/net.h
@@ -162,6 +162,7 @@ public:
 
 
 
+typedef std::map<CNetAddr, int64> banned_map_t;
 
 /** Information about a peer */
 class CNode
@@ -211,7 +212,7 @@ protected:
 
     // Denial-of-service detection/prevention
     // Key is IP address, value is banned-until-time
-    static std::map<CNetAddr, int64> setBanned;
+    static banned_map_t setBanned;
     static CCriticalSection cs_setBanned;
     int nMisbehavior;
 
@@ -637,6 +638,8 @@ public:
     // new code.
     static void ClearBanned(); // needed for unit testing
     static bool IsBanned(CNetAddr ip);
+    static void Ban(CNetAddr ip, int64_t expiration); // negative expiration unbans the node.
+    static banned_map_t GetBannedMap();
     bool Misbehaving(int howmuch); // 1 == a little, 100 == a lot
     void copyStats(CNodeStats &stats);
 };

--- a/src/rpcnet.cpp
+++ b/src/rpcnet.cpp
@@ -202,3 +202,39 @@ Value getaddednodeinfo(const Array& params, bool fHelp)
     return ret;
 }
 
+
+Value bannode(const Array& params, bool fHelp)
+{
+    if (fHelp || params.size() != 2)
+        throw runtime_error(
+            "bannode <node> <expiration>\n"
+            "Bans <node> until unix timestamp <expiration>. Set <expiration> to -1 to unban a node. Ban list is cleared on restart.");
+
+    std::vector<CNetAddr> addrs;
+    if (!LookupHost(params[0].get_str().c_str(), addrs, 50, true)) 
+        throw JSONRPCError(-25, "Error: Node lookup failed.");
+
+    BOOST_FOREACH(const CNetAddr& addr, addrs) {
+        CNode::Ban(addr, params[1].get_int64());
+    }
+
+    return Value::null;
+}
+
+Value listbannednodes(const Array& params, bool fHelp)
+{
+    if (fHelp || params.size() != 0)
+        throw runtime_error(
+            "listbannednodes\n"
+            "Returns a list of currently banned nodes along with the ban expiration timestamps.");
+
+    Array ret;
+    BOOST_FOREACH(const banned_map_t::value_type& pair, CNode::GetBannedMap()) {
+        Object node;
+        node.push_back(Pair("addr", pair.first.ToStringIP()));
+        node.push_back(Pair("until", (boost::int64_t)pair.second));
+        ret.push_back(node);
+    }
+
+    return ret;
+}


### PR DESCRIPTION
Makes it possible to test nodes against bitcoind and to test bitcoind's misbehavior detection without having to constantly restart bitcoind.
