### PR TITLE
Update the bloom state on the real object, not the temporary one.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3893,7 +3893,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
             LOCK(pfrom->cs_filter);
             delete pfrom->pfilter;
             pfrom->pfilter = new CBloomFilter(filter);
-            filter.UpdateEmptyFull();
+            pfrom->pfilter->UpdateEmptyFull();
         }
         pfrom->fRelayTxes = true;
     }


### PR DESCRIPTION
This resulted in just passing all transactions to filtered wallets
which worked surprisingly well, except where it didn't.
