### PR TITLE
Added new peerlocal field to RPC getpeerinfo per-node output

### DIFF
--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -198,6 +198,7 @@ static const CRPCCommand vRPCCommands[] =
     { "getbestblockhash",       &getbestblockhash,       true,      false },
     { "getconnectioncount",     &getconnectioncount,     true,      false },
     { "getpeerinfo",            &getpeerinfo,            true,      false },
+    { "ping",                   &ping,                   true,      false },
     { "addnode",                &addnode,                true,      true },
     { "getaddednodeinfo",       &getaddednodeinfo,       true,      true },
     { "getdifficulty",          &getdifficulty,          true,      false },

--- a/src/bitcoinrpc.h
+++ b/src/bitcoinrpc.h
@@ -143,6 +143,7 @@ extern void EnsureWalletIsUnlocked();
 
 extern json_spirit::Value getconnectioncount(const json_spirit::Array& params, bool fHelp); // in rpcnet.cpp
 extern json_spirit::Value getpeerinfo(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value ping(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value addnode(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value getaddednodeinfo(const json_spirit::Array& params, bool fHelp);
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -597,6 +597,18 @@ bool CNode::Misbehaving(int howmuch)
 #define X(name) stats.name = name
 void CNode::copyStats(CNodeStats &stats)
 {
+    // Raw is microsecs, but show it to user as whole seconds (Bitcoin users should be well used to small numbers with many decimal places by now :)
+    stats.dPingTime = ((double)((nPingTime > 0) ? nPingTime : 0)) / 1000000.0;
+    stats.nPingStat = 0;
+    
+    // Since ping does not update instantly, give user feedback, avoid ambiguity
+    if (fPingRequested) {
+        stats.nPingStat |= 0x1;  // Ping request by user
+    }
+    if (nPingStart > 0) {
+        stats.nPingStat |= 0x2;  // Ping in flight
+    }
+    
     X(nServices);
     X(nLastSend);
     X(nLastRecv);

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -610,6 +610,7 @@ void CNode::copyStats(CNodeStats &stats)
     X(nSendBytes);
     X(nRecvBytes);
     stats.fSyncNode = (this == pnodeSync);
+    stats.addrLocal = CAddress(addrLocal).ToString().c_str();
 }
 #undef X
 

--- a/src/net.h
+++ b/src/net.h
@@ -119,6 +119,7 @@ public:
     uint64 nSendBytes;
     uint64 nRecvBytes;
     bool fSyncNode;
+    std::string addrLocal;
 };
 
 

--- a/src/net.h
+++ b/src/net.h
@@ -110,6 +110,8 @@ public:
     int64 nLastSend;
     int64 nLastRecv;
     int64 nTimeConnected;
+    double dPingTime;
+    int nPingStat;
     std::string addrName;
     int nVersion;
     std::string strSubVer;
@@ -235,6 +237,12 @@ public:
     CCriticalSection cs_inventory;
     std::multimap<int64, CInv> mapAskFor;
 
+    // Ping time measurement
+    bool fPingRequested;
+    uint64 nPingNonce;
+    int64 nPingStart;
+    int64 nPingTime;
+    
     CNode(SOCKET hSocketIn, CAddress addrIn, std::string addrNameIn = "", bool fInboundIn=false) : ssSend(SER_NETWORK, MIN_PROTO_VERSION)
     {
         nServices = 0;
@@ -269,6 +277,9 @@ public:
         fRelayTxes = false;
         setInventoryKnown.max_size(SendBufferSize() / 1000);
         pfilter = new CBloomFilter();
+        fPingRequested = false;
+        nPingStart = -1; // no ping request outstanding on network right now
+        nPingTime = -1; // no previous ping request successfully completed yet
 
         // Be shy and don't send version until we hear
         if (hSocket != INVALID_SOCKET && !fInbound)

--- a/src/rpcnet.cpp
+++ b/src/rpcnet.cpp
@@ -19,6 +19,24 @@ Value getconnectioncount(const Array& params, bool fHelp)
     return (int)vNodes.size();
 }
 
+Value ping(const Array& params, bool fHelp)
+{
+    if (fHelp || params.size() != 0)
+        throw runtime_error(
+            "ping\n"
+            "Requests that a ping be sent to all other nodes, to measure ping time.\n"
+            "Results in getpeerinfo: pingtime is decimal seconds, pingstat is bitmask.\n"
+            "Bitmask: 0x1 = ping requested, 0x2 = ping is in flight.\n"
+            "Ping command is handled in queue with all other commands, so it measures processing backlog, not just network ping.");
+
+    LOCK(cs_vNodes);
+    BOOST_FOREACH(CNode* pNode, vNodes) {
+        pNode->fPingRequested = true;
+    }
+    
+    return Value::null;
+}
+
 static void CopyNodeStats(std::vector<CNodeStats>& vstats)
 {
     vstats.clear();
@@ -54,6 +72,8 @@ Value getpeerinfo(const Array& params, bool fHelp)
         obj.push_back(Pair("bytessent", (boost::int64_t)stats.nSendBytes));
         obj.push_back(Pair("bytesrecv", (boost::int64_t)stats.nRecvBytes));
         obj.push_back(Pair("conntime", (boost::int64_t)stats.nTimeConnected));
+        obj.push_back(Pair("pingtime", stats.dPingTime));
+        obj.push_back(Pair("pingstat", stats.nPingStat));
         obj.push_back(Pair("version", stats.nVersion));
         obj.push_back(Pair("subver", stats.strSubVer));
         obj.push_back(Pair("inbound", stats.fInbound));

--- a/src/rpcnet.cpp
+++ b/src/rpcnet.cpp
@@ -61,6 +61,9 @@ Value getpeerinfo(const Array& params, bool fHelp)
         obj.push_back(Pair("banscore", stats.nMisbehavior));
         if (stats.fSyncNode)
             obj.push_back(Pair("syncnode", true));
+        
+        // Name "peerlocal" instead of "addrlocal" to avoid breaking scripts that grep for "addr"
+        obj.push_back(Pair("peerlocal", stats.addrLocal));
 
         ret.push_back(obj);
     }


### PR DESCRIPTION
This exposes CNode::addrLocal to the user, formatted as a string, just like the existing "addr" field.
I named it "peerlocal" instead of "addrlocal" to avoid breaking scripts that grep on the word "addr".
Interestingly, the addrLocal structure isn't filled in properly in all cases (I have seen IPv6 nodes connect to my bitcoind but addrLocal contains only my IPv4 address), but at least this gives it exposure to aid in fixing this deeper bug that lies elsewhere in bitcoind.
