### PR TITLE
Additional field to RPC getpeerinfo output: addrlocal

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -639,6 +639,9 @@ void CNode::copyStats(CNodeStats &stats)
     // Raw ping time is in microseconds, but show it to user as whole seconds (Bitcoin users should be well used to small numbers with many decimal places by now :)
     stats.dPingTime = (((double)nPingUsecTime) / 1e6);
     stats.dPingWait = (((double)nPingUsecWait) / 1e6);
+    
+    // Leave string empty if addrLocal invalid (not filled in yet)
+    stats.addrLocal = addrLocal.IsValid() ? addrLocal.ToString() : "";
 }
 #undef X
 

--- a/src/net.h
+++ b/src/net.h
@@ -121,6 +121,7 @@ public:
     bool fSyncNode;
     double dPingTime;
     double dPingWait;
+    std::string addrLocal;
 };
 
 

--- a/src/rpcnet.cpp
+++ b/src/rpcnet.cpp
@@ -66,6 +66,8 @@ Value getpeerinfo(const Array& params, bool fHelp)
         Object obj;
 
         obj.push_back(Pair("addr", stats.addrName));
+        if (!(stats.addrLocal.empty()))
+            obj.push_back(Pair("addrlocal", stats.addrLocal));
         obj.push_back(Pair("services", strprintf("%08"PRI64x, stats.nServices)));
         obj.push_back(Pair("lastsend", (boost::int64_t)stats.nLastSend));
         obj.push_back(Pair("lastrecv", (boost::int64_t)stats.nLastRecv));


### PR DESCRIPTION
This simple patch gives user visibility to see the contents of the existing CNode::addrLocal member.
No existing behavior is changed, this is read-only.
If addrLocal is invalid (not filled in yet), the field will not be included in the output.
