### PR TITLE
move Checkpoints:fEnabled from step 2 to step 3 in init

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -377,8 +377,6 @@ bool AppInit2(boost::thread_group& threadGroup)
 
     // ********************************************************* Step 2: parameter interactions
 
-    Checkpoints::fEnabled = GetBoolArg("-checkpoints", true);
-
     if (mapArgs.count("-bind")) {
         // when specifying an explicit binding address, you want to listen on it
         // even when -connect or -proxy is specified
@@ -427,6 +425,7 @@ bool AppInit2(boost::thread_group& threadGroup)
     fDebug = GetBoolArg("-debug", false);
     fBenchmark = GetBoolArg("-benchmark", false);
     mempool.fChecks = GetBoolArg("-checkmempool", RegTest());
+    Checkpoints::fEnabled = GetBoolArg("-checkpoints", true);
 
     // -par=0 means autodetect, but nScriptCheckThreads==0 means no concurrency
     nScriptCheckThreads = GetArg("-par", 0);


### PR DESCRIPTION
- it belongs to parameter-to-internal flags step, not parameter
  interactions phase
