### PR TITLE
[Fee logic] Don't count txins for priority to encourage sweeping.

### DIFF
--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1300,7 +1300,15 @@ bool CWallet::CreateTransaction(const vector<pair<CScript, int64> >& vecSend,
                     strFailReason = _("Transaction too large");
                     return false;
                 }
-                dPriority /= nBytes;
+                unsigned int nTxSizeMod = nBytes;
+                // See miner.c's dPriority logic for the matching network-node side code.
+                BOOST_FOREACH(const CTxIn& txin, (*(CTransaction*)&wtxNew).vin)
+                {
+                    unsigned int offset = 41U + min(110U, (unsigned int)txin.scriptSig.size());
+                    if (nTxSizeMod > offset)
+                        nTxSizeMod -= offset;
+                }
+                dPriority /= nTxSizeMod;
 
                 // Check that enough fee is included
                 int64 nPayFee = nTransactionFee * (1 + (int64)nBytes / 1000);


### PR DESCRIPTION
This changes the priority calculation to not include the size of per-txin
 data including up to 109 bytes of scriptsig so that transactions which
 sweep up extra UTXO don't lose priority relative to ones that don't.

I'd toyed with some other variations, but it seems like any formulation
 which results in an incentive stronger than making them not count will
 sometimes create incentives to add extra outputs so that you have
 extra inputs to consume later.  The maximum credit is limited so that
 users don't lose the disincentive to stuff random data in their
 transactions, the limit of 109 is based on the size of a P2SH
 redemption with a compressed public key.

This shouldn't need a staged deployment because the priority is not
 used as a relay criteria, only a mining criteria.
