### PR TITLE
[wallet] Consider generated coins mature at COINBASE_MATURITY+1

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1096,7 +1096,7 @@ int CMerkleTx::GetBlocksToMaturity() const
 {
     if (!IsCoinBase())
         return 0;
-    return max(0, (COINBASE_MATURITY+20) - GetDepthInMainChain());
+    return max(0, (COINBASE_MATURITY+1) - GetDepthInMainChain());
 }
 
 


### PR DESCRIPTION
We're not seeing large reorgs that would justify waiting a large
 amount past the rule required maturity, and the extra three
 hours is just a nuisance. Take one more block to at least give
 the 100th block time to propagate.
