### PR TITLE
Improve CWalletTx::IsConfirmed performance.

### DIFF
--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -729,6 +729,49 @@ void CWalletTx::GetAccountAmounts(const string& strAccount, int64& nReceived,
     }
 }
 
+bool CWalletTx::IsConfirmed() const
+{
+    // Quick answer in most cases
+    if (!IsFinalTx(*this))
+        return false;
+    if (GetDepthInMainChain() >= 1)
+        return true;
+    if (!IsFromMe()) // using wtx's cached debit
+        return false;
+
+    // If no confirmations but it's from us, we can still
+    // consider it confirmed if all dependencies are confirmed
+    std::map<uint256, const CMerkleTx*> mapPrev;
+    std::vector<const CMerkleTx*> vWorkQueue;
+    vWorkQueue.reserve(vtxPrev.size()+1);
+    vWorkQueue.push_back(this);
+    for (unsigned int i = 0; i < vWorkQueue.size(); i++)
+    {
+        const CMerkleTx* ptx = vWorkQueue[i];
+
+        if (!IsFinalTx(*ptx))
+            return false;
+        if (ptx->GetDepthInMainChain() >= 1)
+            continue;
+        if (!pwallet->IsFromMe(*ptx))
+            return false;
+
+        if (mapPrev.empty())
+        {
+            BOOST_FOREACH(const CMerkleTx& tx, vtxPrev)
+                mapPrev[tx.GetHash()] = &tx;
+        }
+
+        BOOST_FOREACH(const CTxIn& txin, ptx->vin)
+        {
+            if (!mapPrev.count(txin.prevout.hash))
+                return false;
+            vWorkQueue.push_back(mapPrev[txin.prevout.hash]);
+        }
+    }
+    return true;
+}
+
 void CWalletTx::AddSupportingTransactions()
 {
     vtxPrev.clear();

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -666,48 +666,7 @@ public:
         return (GetDebit() > 0);
     }
 
-    bool IsConfirmed() const
-    {
-        // Quick answer in most cases
-        if (!IsFinalTx(*this))
-            return false;
-        if (GetDepthInMainChain() >= 1)
-            return true;
-        if (!IsFromMe()) // using wtx's cached debit
-            return false;
-
-        // If no confirmations but it's from us, we can still
-        // consider it confirmed if all dependencies are confirmed
-        std::map<uint256, const CMerkleTx*> mapPrev;
-        std::vector<const CMerkleTx*> vWorkQueue;
-        vWorkQueue.reserve(vtxPrev.size()+1);
-        vWorkQueue.push_back(this);
-        for (unsigned int i = 0; i < vWorkQueue.size(); i++)
-        {
-            const CMerkleTx* ptx = vWorkQueue[i];
-
-            if (!IsFinalTx(*ptx))
-                return false;
-            if (ptx->GetDepthInMainChain() >= 1)
-                continue;
-            if (!pwallet->IsFromMe(*ptx))
-                return false;
-
-            if (mapPrev.empty())
-            {
-                BOOST_FOREACH(const CMerkleTx& tx, vtxPrev)
-                    mapPrev[tx.GetHash()] = &tx;
-            }
-
-            BOOST_FOREACH(const CTxIn& txin, ptx->vin)
-            {
-                if (!mapPrev.count(txin.prevout.hash))
-                    return false;
-                vWorkQueue.push_back(mapPrev[txin.prevout.hash]);
-            }
-        }
-        return true;
-    }
+    bool IsConfirmed() const;
 
     bool WriteToDisk();
 


### PR DESCRIPTION
Build a cache of already processed transactions is sufficient to fix this.CWalletTx::IsConfirmed displays exceptionally poor performance when there are multiple unconfirmed transactions where IsFromMe() is true.

A cache of already processed transactions is sufficient to largely fix this.

This is still optimized for the common case where most dependent transactions are not IsFromMe()

As part of this change the logic has been simplified.

Simple benchmark results:

generate 200 blocks with regtest, create 300 transactions using standard sendtoaddress rpc and a new address for each transaction

95 seconds

for the IsConfirmed this is replacing... well it still hasn't finished running at transactions 216 1414 seconds and getting worse

![isconfirmed](https://f.cloud.github.com/assets/620611/1052946/a100588e-10e6-11e3-8e2c-4985e4b04dbb.png)

after transaction 175 the time per transaction grows exponentially 1.25 \* e ^ (0.107 \* x)
