### PR TITLE
Bitcoin-Qt: allow to differentiate Qt log entries from core

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -155,12 +155,12 @@ static void initTranslations(QTranslator &qtTranslatorBase, QTranslator &qtTrans
 #if QT_VERSION < 0x050000
 void DebugMessageHandler(QtMsgType type, const char * msg)
 {
-    OutputDebugStringF("%s\n", msg);
+    OutputDebugStringF("Bitcoin-Qt: %s\n", msg);
 }
 #else
 void DebugMessageHandler(QtMsgType type, const QMessageLogContext& context, const QString &msg)
 {
-    OutputDebugStringF("%s\n", qPrintable(msg));
+    OutputDebugStringF("Bitcoin-Qt: %s\n", qPrintable(msg));
 }
 #endif
 
@@ -236,6 +236,12 @@ int main(int argc, char *argv[])
 
     // Install global event filter that makes sure that long tooltips can be word-wrapped
     app.installEventFilter(new GUIUtil::ToolTipToRichTextFilter(TOOLTIP_WRAP_THRESHOLD, &app));
+    // Install qDebug() message handler to route to debug.log
+#if QT_VERSION < 0x050000
+    qInstallMsgHandler(DebugMessageHandler);
+#else
+    qInstallMessageHandler(DebugMessageHandler);
+#endif
 
     // ... now GUI settings:
     OptionsModel optionsModel;
@@ -254,13 +260,6 @@ int main(int argc, char *argv[])
         help.showOrPrint();
         return 1;
     }
-
-    // Install qDebug() message handler to route to debug.log:
-#if QT_VERSION < 0x050000
-    qInstallMsgHandler(DebugMessageHandler);
-#else
-    qInstallMessageHandler(DebugMessageHandler);
-#endif
 
     SplashScreen splash(QPixmap(), 0);
     if (GetBoolArg("-splash", true) && !GetBoolArg("-min", false))


### PR DESCRIPTION
- prepend "Bitcoin-Qt" in front of debug.log entries, which come from Qt
- move DebugMessageHandler installation upwards to the event handler
  installation, which fits much better
