### PR TITLE
Remove vtxPrev from CWalletTx

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1125,7 +1125,7 @@ bool CWalletTx::AcceptWalletTransaction()
             vWorkQueue.push_back(txin.prevout.hash);
         }
         
-        // build unconfirmed supporting transactions list top to bottom
+        // build unconfirmed supporting transactions list
         for (unsigned int i = 0; i < vWorkQueue.size(); i++)
         {
             uint256 hash = vWorkQueue[i];
@@ -1151,8 +1151,10 @@ bool CWalletTx::AcceptWalletTransaction()
             }
         }
         
+        // reverse for depth first iteration
         reverse(vWorkQueue.begin(), vWorkQueue.end());
         
+        // attempt to add supporting transaction to the mempool
         for (unsigned int i = 0; i < vWorkQueue.size(); i++)
         {
             uint256 hash = vWorkQueue[i];

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1124,7 +1124,8 @@ bool CWalletTx::AcceptWalletTransaction()
             uint256 hash = vWorkQueue[i];
             map<uint256, CWalletTx>::const_iterator mi = pwallet->mapWallet.find(hash);
             CWalletTx tx = (*mi).second;
-            tx.AcceptToMemoryPool(false);
+            if (!tx.IsCoinBase())
+                tx.AcceptToMemoryPool(false);
         }
         
         return AcceptToMemoryPool(false);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1113,43 +1113,7 @@ bool CWalletTx::AcceptWalletTransaction()
     {
         LOCK(mempool.cs);
         // Add previous supporting transactions first
-        std::vector<uint256> vWorkQueue;
-        set<uint256> setAlreadyQueued;
-        
-        BOOST_FOREACH(const CTxIn& txin, vin)
-        {
-            if (setAlreadyQueued.count(txin.prevout.hash))
-                continue;
-            setAlreadyQueued.insert(txin.prevout.hash);
-            
-            vWorkQueue.push_back(txin.prevout.hash);
-        }
-        
-        // build unconfirmed supporting transactions list
-        for (unsigned int i = 0; i < vWorkQueue.size(); i++)
-        {
-            uint256 hash = vWorkQueue[i];
-            
-            map<uint256, CWalletTx>::const_iterator mi = pwallet->mapWallet.find(hash);
-            
-            // dependent transaction cannot be found
-            if (mi == pwallet->mapWallet.end())
-                continue;
-            
-            CWalletTx tx = (*mi).second;
-            
-            if (tx.IsInMainChain())
-                continue;
-            
-            BOOST_FOREACH(const CTxIn& txin, tx.vin)
-            {
-                if (setAlreadyQueued.count(txin.prevout.hash))
-                    continue;
-                setAlreadyQueued.insert(txin.prevout.hash);
-                
-                vWorkQueue.push_back(txin.prevout.hash);
-            }
-        }
+        std::vector<uint256> vWorkQueue = ListUnconfirmedSupportingTransactions();
         
         // reverse for depth first iteration
         reverse(vWorkQueue.begin(), vWorkQueue.end());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1107,33 +1107,6 @@ bool CMerkleTx::AcceptToMemoryPool(bool fLimitFree)
 }
 
 
-
-bool CWalletTx::AcceptWalletTransaction()
-{
-    {
-        LOCK(mempool.cs);
-        // Add previous supporting transactions first
-        std::vector<uint256> vWorkQueue = ListUnconfirmedSupportingTransactions();
-        
-        // reverse for depth first iteration
-        reverse(vWorkQueue.begin(), vWorkQueue.end());
-        
-        // attempt to add supporting transaction to the mempool
-        for (unsigned int i = 0; i < vWorkQueue.size(); i++)
-        {
-            uint256 hash = vWorkQueue[i];
-            map<uint256, CWalletTx>::const_iterator mi = pwallet->mapWallet.find(hash);
-            CWalletTx tx = (*mi).second;
-            if (!tx.IsCoinBase())
-                tx.AcceptToMemoryPool(false);
-        }
-        
-        return AcceptToMemoryPool(false);
-    }
-    return false;
-}
-
-
 // Return transaction in tx, and if it was found inside a block, its hash is placed in hashBlock
 bool GetTransaction(const uint256 &hash, CTransaction &txOut, uint256 &hashBlock, bool fAllowSlow)
 {


### PR DESCRIPTION
vtxPrev was intended to make it possible to broadcast supporting transactions.

For various reasons it doesn't actually accomplish this goal while still consuming a sizable amount of space in the wallet.

I've removed most references to vtxPrev and replaced them with procedures that pull transactions from mapWallet.

As a side effect this code includes similar performance improvements to CWalletTx::IsConfirmed as https://github.com/bitcoin/bitcoin/pull/2952
