### PR TITLE
Don't warn about forks while fIsInitialDownload

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1421,6 +1421,11 @@ CBlockIndex *pindexBestForkTip = NULL, *pindexBestForkBase = NULL;
 
 void CheckForkWarningConditions()
 {
+    // Before we get past initial download, we cannot reliably alert about forks
+    // (we assume we don't get stuck on a fork before the last checkpoint)
+    if (IsInitialBlockDownload())
+        return;
+
     // If our best fork is no longer within 72 blocks (+/- 12 hours if no one mines it)
     // of our head, drop it
     if (pindexBestForkTip && nBestHeight - pindexBestForkTip->nHeight >= 72)


### PR DESCRIPTION
This is a cheap hack to address the warnings people get during initial download, feel free to discard in favor of something more reasonable.
