### PR TITLE
Fixed "Copy transaction ID" so that subtransaction index is not included

### DIFF
--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -226,6 +226,6 @@ bool TransactionRecord::statusUpdateNeeded()
 
 std::string TransactionRecord::getTxID()
 {
-    return hash.ToString() + strprintf("-%03d", idx);
+    return hash.ToString();
 }
 


### PR DESCRIPTION
When using the context menu to copy a transaction ID, the subtransaction index is added for no apparent reason.

We don't show the subtransaction index in the details window, so I see no reason why a user would want it appended to their transaction ID from the context menu.
