### PR TITLE
qt: add vout index to transaction id in transactions details dialog

### DIFF
--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -8,6 +8,7 @@
 #include "ui_interface.h"
 #include "base58.h"
 #include "paymentserver.h"
+#include "transactionrecord.h"
 
 #include <string>
 
@@ -32,7 +33,7 @@ QString TransactionDesc::FormatTxStatus(const CWalletTx& wtx)
     }
 }
 
-QString TransactionDesc::toHTML(CWallet *wallet, CWalletTx &wtx, int unit)
+QString TransactionDesc::toHTML(CWallet *wallet, CWalletTx &wtx, int vout, int unit)
 {
     QString strHTML;
 
@@ -215,7 +216,7 @@ QString TransactionDesc::toHTML(CWallet *wallet, CWalletTx &wtx, int unit)
         if (wtx.mapValue.count("comment") && !wtx.mapValue["comment"].empty())
             strHTML += "<br><b>" + tr("Comment") + ":</b><br>" + GUIUtil::HtmlEscape(wtx.mapValue["comment"], true) + "<br>";
 
-        strHTML += "<b>" + tr("Transaction ID") + ":</b> " + wtx.GetHash().ToString().c_str() + "<br>";
+        strHTML += "<b>" + tr("Transaction ID") + ":</b> " + TransactionRecord::formatSubTxId(wtx.GetHash(), vout) + "<br>";
 
         //
         // PaymentRequest info:
@@ -225,7 +226,7 @@ QString TransactionDesc::toHTML(CWallet *wallet, CWalletTx &wtx, int unit)
             if (r.first == "PaymentRequest")
             {
                 PaymentRequestPlus req;
-                req.parse(QByteArray::fromRawData(r.second.c_str(), r.second.size()));
+                req.parse(QByteArray::fromRawData(r.second.data(), r.second.size()));
                 QString merchant;
                 if (req.getMerchant(PaymentServer::getCertStore(), merchant))
                     strHTML += "<b>" + tr("Merchant") + ":</b> " + GUIUtil::HtmlEscape(merchant) + "<br>";

--- a/src/qt/transactiondesc.h
+++ b/src/qt/transactiondesc.h
@@ -14,7 +14,7 @@ class TransactionDesc: public QObject
     Q_OBJECT
 
 public:
-    static QString toHTML(CWallet *wallet, CWalletTx &wtx, int unit);
+    static QString toHTML(CWallet *wallet, CWalletTx &wtx, int vout, int unit);
 
 private:
     TransactionDesc() {}

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -224,8 +224,13 @@ bool TransactionRecord::statusUpdateNeeded()
     return status.cur_num_blocks != nBestHeight;
 }
 
-std::string TransactionRecord::getTxID()
+QString TransactionRecord::getTxID() const
 {
-    return hash.ToString() + strprintf("-%03d", idx);
+    return formatSubTxId(hash, idx);
+}
+
+QString TransactionRecord::formatSubTxId(const uint256 &hash, int vout)
+{
+    return QString::fromStdString(hash.ToString() + strprintf("-%03d", vout));
 }
 

--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -4,6 +4,7 @@
 #include "uint256.h"
 
 #include <QList>
+#include <QString>
 
 class CWallet;
 class CWalletTx;
@@ -117,7 +118,10 @@ public:
     TransactionStatus status;
 
     /** Return the unique identifier for this transaction (part) */
-    std::string getTxID();
+    QString getTxID() const;
+
+    /** Format subtransaction id */
+    static QString formatSubTxId(const uint256 &hash, int vout);
 
     /** Update status from core wallet tx.
      */

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -208,7 +208,7 @@ public:
             std::map<uint256, CWalletTx>::iterator mi = wallet->mapWallet.find(rec->hash);
             if(mi != wallet->mapWallet.end())
             {
-                return TransactionDesc::toHTML(wallet, mi->second, unit);
+                return TransactionDesc::toHTML(wallet, mi->second, rec->idx, unit);
             }
         }
         return QString("");
@@ -569,7 +569,7 @@ QVariant TransactionTableModel::data(const QModelIndex &index, int role) const
     case AmountRole:
         return rec->credit + rec->debit;
     case TxIDRole:
-        return QString::fromStdString(rec->getTxID());
+        return rec->getTxID();
     case ConfirmedRole:
         // Return True if transaction counts for balance
         return rec->status.confirmed && !(rec->type == TransactionRecord::Generated &&


### PR DESCRIPTION
Show the transaction vout index in transactions details dialog (in the same format as when copying it). Alternative to #2970.
- Adds an vout parameter to TransactionDesc::toHTML, this will also make it possible to show specific subtransaction details in the details window.
