### PR TITLE
Add protobuf 2.5.0 download to gitian release process

### DIFF
--- a/contrib/gitian-descriptors/qt-win32.yml
+++ b/contrib/gitian-descriptors/qt-win32.yml
@@ -7,6 +7,7 @@ architectures:
 packages: 
 - "mingw32"
 - "zip"
+- "unzip"
 - "faketime"
 reference_datetime: "2011-01-30 00:00:00"
 remotes: []

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -49,7 +49,7 @@ Release Process
 	./bin/gbuild ../bitcoin/contrib/gitian-descriptors/boost-win32.yml
 	mv build/out/boost-win32-1.50.0-gitian2.zip inputs/
 	./bin/gbuild ../bitcoin/contrib/gitian-descriptors/qt-win32.yml
-	mv build/out/qt-win32-4.8.3-gitian-r1.zip inputs/
+	mv build/out/qt-win32-4.8.3-gitian-r2.zip inputs/
 	./bin/gbuild ../bitcoin/contrib/gitian-descriptors/deps-win32.yml
 	mv build/out/bitcoin-deps-0.0.5.zip inputs/
 	./bin/gbuild ../bitcoin/contrib/gitian-descriptors/protobuf-win32.yml

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -44,6 +44,7 @@ Release Process
 	wget 'http://fukuchi.org/works/qrencode/qrencode-3.2.0.tar.bz2'
 	wget 'http://downloads.sourceforge.net/project/boost/boost/1.50.0/boost_1_50_0.tar.bz2'
 	wget 'http://releases.qt-project.org/qt4/source/qt-everywhere-opensource-src-4.8.3.tar.gz'
+	wget 'http://protobuf.googlecode.com/files/protobuf-2.5.0.tar.bz2'
 	cd ..
 	./bin/gbuild ../bitcoin/contrib/gitian-descriptors/boost-win32.yml
 	mv build/out/boost-win32-1.50.0-gitian2.zip inputs/
@@ -51,6 +52,8 @@ Release Process
 	mv build/out/qt-win32-4.8.3-gitian-r1.zip inputs/
 	./bin/gbuild ../bitcoin/contrib/gitian-descriptors/deps-win32.yml
 	mv build/out/bitcoin-deps-0.0.5.zip inputs/
+	./bin/gbuild ../bitcoin/contrib/gitian-descriptors/protobuf-win32.yml
+	mv build/out/protobuf-win32-2.5.0-gitian-r1.zip inputs/
 
  Build bitcoind and bitcoin-qt on Linux32, Linux64, and Win32:
   


### PR DESCRIPTION
Add protobuf 2.5.0 download for inputs. Seems to be missing.

Edit: also fixed Qt gitian build and updated process for that
