### PR TITLE
Bitcoin-Qt: translation fixes in sendcoins

### DIFF
--- a/src/qt/forms/sendcoinsentry.ui
+++ b/src/qt/forms/sendcoinsentry.ui
@@ -10,19 +10,13 @@
     <height>150</height>
    </rect>
   </property>
-  <property name="windowTitle">
-   <string>StackedWidget</string>
-  </property>
   <property name="autoFillBackground">
    <bool>false</bool>
   </property>
   <property name="currentIndex">
-   <number>1</number>
+   <number>0</number>
   </property>
   <widget class="QFrame" name="SendCoinsInsecure">
-   <property name="windowTitle">
-    <string>Form</string>
-   </property>
    <property name="frameShape">
     <enum>QFrame::StyledPanel</enum>
    </property>
@@ -34,7 +28,7 @@
      <number>12</number>
     </property>
     <item row="5" column="0">
-     <widget class="QLabel" name="label">
+     <widget class="QLabel" name="amountLabel">
       <property name="text">
        <string>A&amp;mount:</string>
       </property>
@@ -47,7 +41,7 @@
      </widget>
     </item>
     <item row="3" column="0">
-     <widget class="QLabel" name="label_2">
+     <widget class="QLabel" name="payToLabel">
       <property name="text">
        <string>Pay &amp;To:</string>
       </property>
@@ -63,7 +57,7 @@
      <widget class="BitcoinAmountField" name="payAmount"/>
     </item>
     <item row="4" column="0">
-     <widget class="QLabel" name="label_4">
+     <widget class="QLabel" name="labellLabel">
       <property name="text">
        <string>&amp;Label:</string>
       </property>
@@ -592,9 +586,6 @@
      </disabled>
     </palette>
    </property>
-   <property name="windowTitle">
-    <string>SecureSend</string>
-   </property>
    <property name="autoFillBackground">
     <bool>true</bool>
    </property>
@@ -609,7 +600,7 @@
      <number>12</number>
     </property>
     <item row="4" column="0">
-     <widget class="QLabel" name="label_s4">
+     <widget class="QLabel" name="memoLabel_s">
       <property name="text">
        <string>Memo:</string>
       </property>
@@ -622,7 +613,7 @@
      </widget>
     </item>
     <item row="5" column="0">
-     <widget class="QLabel" name="label_s1">
+     <widget class="QLabel" name="amountLabel_s">
       <property name="text">
        <string>A&amp;mount:</string>
       </property>
@@ -635,7 +626,7 @@
      </widget>
     </item>
     <item row="3" column="0">
-     <widget class="QLabel" name="label_s2">
+     <widget class="QLabel" name="payToLabel_s">
       <property name="text">
        <string>Pay &amp;To:</string>
       </property>
@@ -667,14 +658,17 @@
       </property>
       <item>
        <widget class="QLabel" name="payTo_s">
+        <property name="textFormat">
+         <enum>Qt::PlainText</enum>
+        </property>
        </widget>
       </item>
      </layout>
     </item>
     <item row="4" column="2">
-     <widget class="QLabel" name="memo_s">
-      <property name="text">
-       <string>message from merchant</string>
+     <widget class="QLabel" name="memoTextLabel_s">
+      <property name="textFormat">
+       <enum>Qt::PlainText</enum>
       </property>
      </widget>
     </item>

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -94,27 +94,33 @@ void SendCoinsDialog::on_sendButton_clicked()
     QStringList formatted;
     foreach(const SendCoinsRecipient &rcp, recipients)
     {
-        QString amount = BitcoinUnits::formatWithUnit(model->getOptionsModel()->getDisplayUnit(), rcp.amount);
+        // generate bold amount string
+        QString amount = "<b>" + BitcoinUnits::formatWithUnit(model->getOptionsModel()->getDisplayUnit(), rcp.amount);
+        amount.append("</b>");
+        // generate monospace address string
+        QString address = "<span style='font-family: monospace;'>" + rcp.address;
+        address.append("</span>");
+
+        QString recipientElement;
+
         if (rcp.authenticatedMerchant.isEmpty())
         {
-            QString recipientElement = QString("<b>%1</b> ").arg(BitcoinUnits::formatWithUnit(model->getOptionsModel()->getDisplayUnit(), rcp.amount));
-            recipientElement.append(tr("to"));
-
-            if(rcp.label.length() > 0)
+            if(rcp.label.length() > 0) // label with address
             {
-                recipientElement.append(QString(" %1 <span style='font-size:8px;'>%2</span><br />").arg(GUIUtil::HtmlEscape(rcp.label), rcp.address)); // add address with label
+                recipientElement = tr("%1 to %2").arg(amount, GUIUtil::HtmlEscape(rcp.label));
+                recipientElement.append(QString(" (%1)").arg(address));
             }
-            else
+            else // just address
             {
-                recipientElement.append(QString(" %1<br />").arg(rcp.address)); // add address WITHOUT label
+                recipientElement = tr("%1 to %2").arg(amount, address);
             }
-            formatted.append(recipientElement);
         }
-        else
+        else // just merchant
         {
-            QString merchant = GUIUtil::HtmlEscape(rcp.authenticatedMerchant);
-            formatted.append(tr("<b>%1</b> to %2").arg(amount, merchant));
+            recipientElement = tr("%1 to %2").arg(amount, GUIUtil::HtmlEscape(rcp.authenticatedMerchant));
         }
+
+        formatted.append(recipientElement);
     }
 
     fNewRecipientAllowed = false;
@@ -132,42 +138,38 @@ void SendCoinsDialog::on_sendButton_clicked()
     WalletModelTransaction currentTransaction(recipients);
     WalletModel::SendCoinsReturn prepareStatus = model->prepareTransaction(currentTransaction);
 
+    QString strSendCoins = tr("Send Coins");
     switch(prepareStatus.status)
     {
     case WalletModel::InvalidAddress:
-        QMessageBox::warning(this, tr("Send Coins"),
-            tr("The recipient address is not valid, please recheck."),
-            QMessageBox::Ok, QMessageBox::Ok);
+        QMessageBox::warning(this, strSendCoins,
+            tr("The recipient address is not valid, please recheck."));
         break;
     case WalletModel::InvalidAmount:
-        QMessageBox::warning(this, tr("Send Coins"),
-            tr("The amount to pay must be larger than 0."),
-            QMessageBox::Ok, QMessageBox::Ok);
+        QMessageBox::warning(this, strSendCoins,
+            tr("The amount to pay must be larger than 0."));
         break;
     case WalletModel::AmountExceedsBalance:
-        QMessageBox::warning(this, tr("Send Coins"),
-            tr("The amount exceeds your balance."),
-            QMessageBox::Ok, QMessageBox::Ok);
+        QMessageBox::warning(this, strSendCoins,
+            tr("The amount exceeds your balance."));
         break;
     case WalletModel::AmountWithFeeExceedsBalance:
-        QMessageBox::warning(this, tr("Send Coins"),
+        QMessageBox::warning(this, strSendCoins,
             tr("The total exceeds your balance when the %1 transaction fee is included.").
-            arg(BitcoinUnits::formatWithUnit(model->getOptionsModel()->getDisplayUnit(), currentTransaction.getTransactionFee())),
-            QMessageBox::Ok, QMessageBox::Ok);
+            arg(BitcoinUnits::formatWithUnit(model->getOptionsModel()->getDisplayUnit(), currentTransaction.getTransactionFee())));
         break;
     case WalletModel::DuplicateAddress:
-        QMessageBox::warning(this, tr("Send Coins"),
-            tr("Duplicate address found, can only send to each address once per send operation."),
-            QMessageBox::Ok, QMessageBox::Ok);
+        QMessageBox::warning(this, strSendCoins,
+            tr("Duplicate address found, can only send to each address once per send operation."));
         break;
     case WalletModel::TransactionCreationFailed:
-        QMessageBox::warning(this, tr("Send Coins"),
-            tr("Error: Transaction creation failed!"),
-            QMessageBox::Ok, QMessageBox::Ok);
+        QMessageBox::warning(this, strSendCoins,
+            tr("Error: Transaction creation failed!"));
         break;
-    case WalletModel::Aborted: // User aborted, nothing to do
-    case WalletModel::OK:
     case WalletModel::TransactionCommitFailed:
+    case WalletModel::OK:
+    case WalletModel::Aborted: // User aborted, nothing to do
+    default:
         break;
     }
 
@@ -197,7 +199,7 @@ void SendCoinsDialog::on_sendButton_clicked()
 
     QMessageBox::StandardButton retval = QMessageBox::question(this, tr("Confirm send coins"),
         questionString.arg(formatted.join("<br />")),
-        QMessageBox::Yes|QMessageBox::Cancel,
+        QMessageBox::Yes | QMessageBox::Cancel,
         QMessageBox::Cancel);
 
     if(retval != QMessageBox::Yes)
@@ -211,15 +213,13 @@ void SendCoinsDialog::on_sendButton_clicked()
     switch(sendstatus.status)
     {
     case WalletModel::TransactionCommitFailed:
-        QMessageBox::warning(this, tr("Send Coins"),
-            tr("Error: The transaction was rejected. This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here."),
-            QMessageBox::Ok, QMessageBox::Ok);
-        break;
-    case WalletModel::Aborted: // User aborted, nothing to do
+        QMessageBox::warning(this, strSendCoins,
+            tr("Error: The transaction was rejected. This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here."));
         break;
     case WalletModel::OK:
         accept();
         break;
+    case WalletModel::Aborted: // User aborted, nothing to do
     default:
         break;
     }
@@ -351,13 +351,14 @@ void SendCoinsDialog::pasteEntry(const SendCoinsRecipient &rv)
 
 bool SendCoinsDialog::handlePaymentRequest(const SendCoinsRecipient &rv)
 {
+    QString strSendCoins = tr("Send Coins");
     if (!rv.authenticatedMerchant.isEmpty()) {
         // Expired payment request?
         const payments::PaymentDetails& details = rv.paymentRequest.getDetails();
         if (details.has_expires() && (int64)details.expires() < GetTime())
         {
-            QMessageBox::warning(this, tr("Send Coins"),
-                                 tr("Payment request expired"));
+            QMessageBox::warning(this, strSendCoins,
+                tr("Payment request expired"));
             return false;
         }
     }
@@ -365,8 +366,8 @@ bool SendCoinsDialog::handlePaymentRequest(const SendCoinsRecipient &rv)
         CBitcoinAddress address(rv.address.toStdString());
         if (!address.IsValid()) {
             QString strAddress(address.ToString().c_str());
-            QMessageBox::warning(this, tr("Send Coins"),
-                                 tr("Invalid payment address %1").arg(strAddress));
+            QMessageBox::warning(this, strSendCoins,
+                tr("Invalid payment address %1").arg(strAddress));
             return false;
         }
     }

--- a/src/qt/sendcoinsentry.cpp
+++ b/src/qt/sendcoinsentry.cpp
@@ -106,8 +106,8 @@ bool SendCoinsEntry::validate()
     if (!recipient.authenticatedMerchant.isEmpty())
         return retval;
 
-    if(!ui->payTo->hasAcceptableInput() ||
-       (model && !model->validateAddress(ui->payTo->text())))
+    if (!ui->payTo->hasAcceptableInput() ||
+        (model && !model->validateAddress(ui->payTo->text())))
     {
         ui->payTo->setValid(false);
         retval = false;
@@ -163,8 +163,7 @@ void SendCoinsEntry::setValue(const SendCoinsRecipient &value)
         const payments::PaymentDetails& details = value.paymentRequest.getDetails();
 
         ui->payTo_s->setText(value.authenticatedMerchant);
-        ui->memo_s->setTextFormat(Qt::PlainText);
-        ui->memo_s->setText(QString::fromStdString(details.memo()));
+        ui->memoTextLabel_s->setText(QString::fromStdString(details.memo()));
         ui->payAmount_s->setValue(value.amount);
         setCurrentWidget(ui->SendCoinsSecure);
     }

--- a/src/qt/sendcoinsentry.h
+++ b/src/qt/sendcoinsentry.h
@@ -33,7 +33,8 @@ public:
     void setValue(const SendCoinsRecipient &value);
     void setAddress(const QString &address);
 
-    /** Set up the tab chain manually, as Qt messes up the tab chain by default in some cases (issue https://bugreports.qt-project.org/browse/QTBUG-10907).
+    /** Set up the tab chain manually, as Qt messes up the tab chain by default in some cases
+     *  (issue https://bugreports.qt-project.org/browse/QTBUG-10907).
      */
     QWidget *setupTabChain(QWidget *prev);
 


### PR DESCRIPTION
- remove some unneeded translatable strings from sendcoinsentry.ui file and
  rename some elements for better readability
- optimize string prorcessing in SendCoinsDialog::on_sendButton_clicked()
- make all UI labels for secure payments plain text and move the settings
  to sendcoinsentry.ui file
- remove unneeded button and default button definiton from warning message
  boxes
- remove fixed font-size when sending coins to an address with label and
  use monospace font for addresses
