### PR TITLE
Bitcoin-Qt: show address labels when using bitcoin: URIs

### DIFF
--- a/src/qt/sendcoinsentry.cpp
+++ b/src/qt/sendcoinsentry.cpp
@@ -60,12 +60,7 @@ void SendCoinsEntry::on_addressBookButton_clicked()
 
 void SendCoinsEntry::on_payTo_textChanged(const QString &address)
 {
-    if(!model)
-        return;
-    // Fill in label from address book, if address has an associated label
-    QString associatedLabel = model->getAddressTableModel()->labelForAddress(address);
-    if(!associatedLabel.isEmpty())
-        ui->addAsLabel->setText(associatedLabel);
+    updateLabel(address);
 }
 
 void SendCoinsEntry::setModel(WalletModel *model)
@@ -164,7 +159,11 @@ void SendCoinsEntry::setValue(const SendCoinsRecipient &value)
     if (recipient.authenticatedMerchant.isEmpty())
     {
         ui->payTo->setText(recipient.address);
-        ui->addAsLabel->setText(recipient.label);
+        // if no label is set, query users address book for current user-defined label
+        if (recipient.label.isEmpty())
+            updateLabel(recipient.address);
+        else
+            ui->addAsLabel->setText(recipient.label);
         ui->payAmount->setValue(recipient.amount);
     }
     else
@@ -202,4 +201,20 @@ void SendCoinsEntry::updateDisplayUnit()
         ui->payAmount->setDisplayUnit(model->getOptionsModel()->getDisplayUnit());
         ui->payAmount_s->setDisplayUnit(model->getOptionsModel()->getDisplayUnit());
     }
+}
+
+bool SendCoinsEntry::updateLabel(const QString &address)
+{
+    if(!model)
+        return false;
+
+    // Fill in label from address book, if address has an associated label
+    QString associatedLabel = model->getAddressTableModel()->labelForAddress(address);
+    if(!associatedLabel.isEmpty())
+    {
+        ui->addAsLabel->setText(associatedLabel);
+        return true;
+    }
+
+    return false;
 }

--- a/src/qt/sendcoinsentry.h
+++ b/src/qt/sendcoinsentry.h
@@ -58,6 +58,8 @@ private:
     SendCoinsRecipient recipient;
     Ui::SendCoinsEntry *ui;
     WalletModel *model;
+
+    bool updateLabel(const QString &address);
 };
 
 #endif // SENDCOINSENTRY_H


### PR DESCRIPTION
- ensure that user-defined address labels are shown in the sendcoins
  dialog, when using bitcoin: URIs or insecure payments (no changes to the
  secure payments UI)
- favors supplied labels over user-defined ones from addressbook
