### PR TITLE
More fixes for blockchain corruption on OSX.

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1156,6 +1156,8 @@ void FileCommit(FILE *fileout)
 #else
     #if defined(__linux__) || defined(__NetBSD__)
     fdatasync(fileno(fileout));
+    #elif defined(__APPLE__) && defined(F_FULLFSYNC)
+    fcntl(fileno(fileout), F_FULLFSYNC, 0);
     #else
     fsync(fileno(fileout));
     #endif


### PR DESCRIPTION
As we'd previously learned, OSX's fsync is a data eating lie.

Since 0.8.4 we're still getting some reports of disk corruption on
 OSX but now all of it looks like the block files have gotten out of
 sync with the database. It turns out that we were still using fsync()
 on the block files, so this isn't surprising.
