### PR TITLE
autotools: fix a parallel build race condition spotted by the pull-tester

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -50,13 +50,12 @@ bitcoind_SOURCES = bitcoind.cpp
 AM_CPPFLAGS += $(BDB_CPPFLAGS)
 bitcoind_LDADD += $(BDB_LIBS)
 
-leveldb/libleveldb.a:
-	@echo "Building LevelDB ..." && cd leveldb && CXX="$(CXX)" CC="$(CC)" \
-	  PLATFORM=$(TARGET_OS) AR="$(AR)" $(MAKE) $(LEVELDB_TARGET_FLAGS) OPT="$(CXXFLAGS) $(CPPFLAGS)" libleveldb.a
+leveldb/libleveldb.a: leveldb/libmemenv.a
 
-leveldb/libmemenv.a:
-	@echo "Building LevelDB ..." && cd leveldb && CXX="$(CXX)" CC="$(CC)" \
-	  PLATFORM=$(TARGET_OS) AR="$(AR)" $(MAKE) $(LEVELDB_TARGET_FLAGS) OPT="$(CXXFLAGS) $(CPPFLAGS)" libmemenv.a
+leveldb/%.a:
+	@echo "Building LevelDB ..." && $(MAKE) -C $(@D) $(@F) CXX="$(CXX)" \
+	  CC="$(CC)" PLATFORM=$(TARGET_OS) AR="$(AR)" $(LEVELDB_TARGET_FLAGS) \
+	  OPT="$(CXXFLAGS) $(CPPFLAGS)"
 
 qt/bitcoinstrings.cpp: $(libbitcoin_a_SOURCES)
 	@test -n $(XGETTEXT) || echo "xgettext is required for updating translations"


### PR DESCRIPTION
libleveldb.a and libmemenv.a should be able to build in parallel, but in
practice calling the leveldb makefile ends up rewriting build_config.mk. If
one target tries to build while the other is halfway through writing the
.mk, the make ends up in an undefined state.

Fix that by making one depend on the other. This also reorders the variables
to be passed by param rather than via the environment, and combines the targets
into a single rule to avoid needless duplication.
