### PR TITLE
gui: fix non-sticking proxy setting

### DIFF
--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -169,7 +169,7 @@ QVariant OptionsModel::data(const QModelIndex & index, int role) const
             return QVariant(fMinimizeOnClose);
         case ProxyUse: {
             proxyType proxy;
-            return QVariant(GetProxy(NET_IPV4, proxy));
+            return QVariant(settings.value("fUseProxy", false).toBool());
         }
         case ProxyIP: {
             proxyType proxy;


### PR DESCRIPTION
Addresses the last (I believe) work-item in https://github.com/bitcoin/bitcoin/issues/2371.

I'm unsure of the correct fix here, but I hope this can at least get some discussion going. This change at least fixes the problem on the surface. Here's the summary as I see it:

There's a mix of current-proxy-setting and saved-proxy-setting logic. Assuming the proxy is currently enabled: User unchecks the proxy checkbox, hits apply, the dialog checks to see what the new proxy setting should be, GetProxy() returns true because it's currently enabled, check remains in the checkbox, user is confused.

Logically (to me) it makes sense to be checking the setting rather than the current runtime values, as the setting should reflect what user sees on next restart. But there are plenty of other GetProxy()/SetProxy() calls, so I'm inclined not to trust that line of reasoning.
