### PR TITLE
Two small free transaction policy changes

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -760,8 +760,10 @@ int64 GetMinFee(const CTransaction& tx, bool fAllowFree, enum GetMinFee_mode mod
             nMinFee = 0;
     }
 
-    // To limit dust spam, require base fee if any output is less than 0.01
-    if (nMinFee < nBaseFee)
+    // This code can be removed after enough miners have upgraded to version 0.9.
+    // Until then, be safe when sending and require a fee if any output
+    // is less than CENT:
+    if (nMinFee < nBaseFee && mode == GMF_SEND)
     {
         BOOST_FOREACH(const CTxOut& txout, tx.vout)
             if (txout.nValue < CENT)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -753,10 +753,11 @@ int64 GetMinFee(const CTransaction& tx, bool fAllowFree, enum GetMinFee_mode mod
     {
         // There is a free transaction area in blocks created by most miners,
         // * If we are relaying we allow transactions up to DEFAULT_BLOCK_PRIORITY_SIZE - 1000
-        //   to be considered to fall into this category
-        // * If we are creating a transaction we allow transactions up to DEFAULT_BLOCK_PRIORITY_SIZE - 17000
-        //   (= 10000) to be considered safe and assume they can likely make it into this section
-        if (nBytes < (mode == GMF_SEND ? (DEFAULT_BLOCK_PRIORITY_SIZE - 17000) : (DEFAULT_BLOCK_PRIORITY_SIZE - 1000)))
+        //   to be considered to fall into this category. We don't want to encourage sending
+        //   multiple transactions instead of one big transaction to avoid fees.
+        // * If we are creating a transaction we allow transactions up to 1,000 bytes
+        //   to be considered safe and assume they can likely make it into this section.
+        if (nBytes < (mode == GMF_SEND ? 1000 : (DEFAULT_BLOCK_PRIORITY_SIZE - 1000)))
             nMinFee = 0;
     }
 

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1232,9 +1232,10 @@ bool CWallet::CreateTransaction(const vector<pair<CScript, int64> >& vecSend,
                 }
 
                 int64 nChange = nValueIn - nValue - nFeeRet;
-                // if sub-cent change is required, the fee must be raised to at least nMinTxFee
-                // or until nChange becomes zero
-                // NOTE: this depends on the exact behaviour of GetMinFee
+                // The following if statement should be removed once enough miners
+                // have upgraded to the 0.9 GetMinFee() rules. Until then, this avoids
+                // creating free transactions that have change outputs less than
+                // CENT bitcoins.
                 if (nFeeRet < CTransaction::nMinTxFee && nChange > 0 && nChange < CENT)
                 {
                     int64 nMoveToFee = min(nChange, CTransaction::nMinTxFee - nFeeRet);


### PR DESCRIPTION
This is part of my quest to eliminate hard-coded fees from the reference implementation.

The first: Remove the rule that all outputs of free transactions must be  greater than 0.01 XBT. Dust spam is now taken care of by making dusty outputs non-standard.

I did not change the coin selection algorithm, it will still try to avoid creating outputs less than 0.01 XBT. That could be changed/simplified a release after this rolls out to miners/relay nodes (before then, there is too much risk your free transactions would never confirm).

The second: Changes the maximum size of a free transaction that will be created from 10,000 bytes to 1,000 bytes. The idea behind this change is to make the free transaction area available to a greater number of people; with the default 27K-per-block, just three very-large very-high-priority transactions could fill the space.

I did not change the relay policy for free transactions (yet); you can still send a 26,000 byte zero-fee transaction and it will be relayed and might be mined. This just stops somebody moving a lot of old coins from accidentally monopolizing the free transaction area when they would almost certainly be perfectly happy to pay the fee.
