### PR TITLE
Fix minor unit test memory leaks

### DIFF
--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -83,6 +83,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
 
     // Just to make sure we can still make simple blocks
     BOOST_CHECK(pblocktemplate = CreateNewBlockWithKey(reservekey));
+    delete pblocktemplate;
 
     // block sigops > limit: 1000 CHECKMULTISIG + 1
     tx.vin.resize(1);
@@ -200,6 +201,9 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     BOOST_CHECK(pblocktemplate = CreateNewBlockWithKey(reservekey));
     delete pblocktemplate;
     pindexBest->nHeight = nHeight;
+
+    BOOST_FOREACH(CTransaction *tx, txFirst)
+        delete tx;
 }
 
 BOOST_AUTO_TEST_CASE(sha256transform_equality)

--- a/src/test/wallet_tests.cpp
+++ b/src/test/wallet_tests.cpp
@@ -289,6 +289,7 @@ BOOST_AUTO_TEST_CASE(coin_selection_tests)
             BOOST_CHECK_NE(fails, RANDOM_REPEATS);
         }
     }
+    empty_wallet();
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Result:

```
==1519== LEAK SUMMARY:
==1519==    definitely lost: 0 bytes in 0 blocks
==1519==    indirectly lost: 0 bytes in 0 blocks
==1519==      possibly lost: 0 bytes in 0 blocks
==1519==    still reachable: 2,360 bytes in 14 blocks
==1519==         suppressed: 0 bytes in 0 blocks
```
