### PR TITLE
fix extract_strings_qt.py

### DIFF
--- a/share/qt/extract_strings_qt.py
+++ b/share/qt/extract_strings_qt.py
@@ -50,7 +50,7 @@ def parse_po(text):
 files = glob.glob('src/*.cpp') + glob.glob('src/*.h') 
 
 # xgettext -n --keyword=_ $FILES
-XGETTEXT=os.getenv('XGETTEXT', 'gettext')
+XGETTEXT=os.getenv('XGETTEXT', 'xgettext')
 child = Popen([XGETTEXT,'--output=-','-n','--keyword=_'] + files, stdout=PIPE)
 (out, err) = child.communicate()
 


### PR DESCRIPTION
- a recent pull changed xgettext to gettext, this is reverted here

I had problems using the script with just gettext (on Windows), so I reverted back to xgettext.
