### PR TITLE
Skip unspendable outputs in consistency check

### DIFF
--- a/src/core.h
+++ b/src/core.h
@@ -390,11 +390,7 @@ public:
 
     // construct a CCoins from a CTransaction, at a given height
     CCoins(const CTransaction &tx, int nHeightIn) : fCoinBase(tx.IsCoinBase()), vout(tx.vout), nHeight(nHeightIn), nVersion(tx.nVersion) {
-        BOOST_FOREACH(CTxOut &txout, vout) {
-            if (txout.scriptPubKey.IsUnspendable())
-                txout.SetNull();
-        }
-        Cleanup();
+        ClearUnspendable();
     }
 
     // empty constructor
@@ -406,6 +402,14 @@ public:
             vout.pop_back();
         if (vout.empty())
             std::vector<CTxOut>().swap(vout);
+    }
+
+    void ClearUnspendable() {
+        BOOST_FOREACH(CTxOut &txout, vout) {
+            if (txout.scriptPubKey.IsUnspendable())
+                txout.SetNull();
+        }
+        Cleanup();
     }
 
     void swap(CCoins &to) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1781,6 +1781,7 @@ bool DisconnectBlock(CBlock& block, CValidationState& state, CBlockIndex* pindex
             view.SetCoins(hash, CCoins());
         }
         CCoins &outs = view.GetCoins(hash);
+        outs.ClearUnspendable();
 
         CCoins outsBlock = CCoins(tx, pindex->nHeight);
         // The CCoins serialization does not serialize negative numbers.


### PR DESCRIPTION
As it's possible that the on-disk UTXO set now has unspendable outputs, the startup consistency check may fail (reported by runeks on IRC).
