### PR TITLE
GUI: fix sendcoinsdialog/sendcoinsentry

### DIFF
--- a/src/qt/forms/sendcoinsdialog.ui
+++ b/src/qt/forms/sendcoinsdialog.ui
@@ -28,7 +28,7 @@
         <height>165</height>
        </rect>
       </property>
-      <layout class="QVBoxLayout" name="verticalLayout_2">
+      <layout class="QVBoxLayout" name="verticalLayout_2" stretch="0,1">
        <property name="margin">
         <number>0</number>
        </property>


### PR DESCRIPTION
Rewrite of sendcoinsentry.ui for payment protocol introduced a little design error on KDE 4, Qt 4 here.
Adding a stretch in sendcoinsdialog fixes the problem for me.

I also tried layoutRowStretch in sendcoinsentry directly, but this does not work. Did not look at payment protocol.
