### PR TITLE
Upgrade gitian win32 to Precise 12.04.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -177,6 +177,10 @@ case $host in
      AC_CHECK_LIB([mswsock],      [main],, AC_MSG_ERROR(lib missing))
      AC_CHECK_LIB([shlwapi],      [main],, AC_MSG_ERROR(lib missing))
      AC_CHECK_LIB([iphlpapi],      [main],, AC_MSG_ERROR(lib missing))
+     AC_CHECK_LIB([crypt32],      [main],, AC_MSG_ERROR(lib missing))
+
+     AX_CHECK_LINK_FLAG([[-static-libgcc]],[LDFLAGS="$LDFLAGS -static-libgcc"])
+     AX_CHECK_LINK_FLAG([[-static-libstdc++]],[LDFLAGS="$LDFLAGS -static-libstdc++"])
 
      AC_PATH_PROG([MAKENSIS], [makensis], none)
      if test x$MAKENSIS = xnone; then

--- a/contrib/gitian-descriptors/boost-win32.yml
+++ b/contrib/gitian-descriptors/boost-win32.yml
@@ -1,11 +1,12 @@
 ---
 name: "boost"
 suites:
-- "lucid"
+- "precise"
 architectures:
-- "i386"
+- "amd64"
 packages:
-- "mingw32"
+- "mingw-w64"
+- "g++-mingw-w64"
 - "faketime"
 - "zip"
 reference_datetime: "2011-01-30 00:00:00"
@@ -13,21 +14,69 @@ remotes: []
 files:
 - "boost_1_50_0.tar.bz2"
 script: |
+  #
   INSTALLPREFIX="$OUTDIR/staging/boost"
+  HOST=i686-w64-mingw32
+  #
+
   mkdir -p "$INSTALLPREFIX"
   tar xjf boost_1_50_0.tar.bz2
   cd boost_1_50_0
-  echo "using gcc : 4.4 : i586-mingw32msvc-g++
+
+  # Boost #4258: multiple definition of `_tls_used' https://svn.boost.org/trac/boost/ticket/4258
+  cd libs/thread/
+  patch -p1 << 'EOF'
+  From 8b83ad1f0ac4c56f019072de4a7a93f8fcccb96b Mon Sep 17 00:00:00 2001
+  From: "Vicente J. Botet Escriba" <vicente.botet@wanadoo.fr>
+  Date: Sat, 7 Jul 2012 14:37:07 +0000
+  Subject: [PATCH] Thread: Added __MINGW64_VERSION_MAJOR when __MINGW64__ is not
+   defined
+  
+  ---
+   src/win32/tss_pe.cpp | 4 ++--
+   1 file changed, 2 insertions(+), 2 deletions(-)
+  
+  diff --git a/src/win32/tss_pe.cpp b/src/win32/tss_pe.cpp
+  index 4d75680..0cdb7a6 100644
+  --- a/src/win32/tss_pe.cpp
+  +++ b/src/win32/tss_pe.cpp
+  @@ -11,7 +11,7 @@
+   
+   #if defined(BOOST_HAS_WINTHREADS) && defined(BOOST_THREAD_BUILD_LIB) 
+   
+  -#if (defined(__MINGW32__) && !defined(_WIN64)) || defined(__MINGW64__)
+  +#if (defined(__MINGW32__) && !defined(_WIN64)) || defined(__MINGW64__) || (__MINGW64_VERSION_MAJOR)
+   
+   #include <boost/thread/detail/tss_hooks.hpp>
+   
+  @@ -38,7 +38,7 @@
+       }
+   }
+   
+  -#if defined(__MINGW64__) || (__MINGW32_MAJOR_VERSION >3) ||             \
+  +#if defined(__MINGW64__) || (__MINGW64_VERSION_MAJOR) || (__MINGW32_MAJOR_VERSION >3) ||             \
+       ((__MINGW32_MAJOR_VERSION==3) && (__MINGW32_MINOR_VERSION>=18))
+   extern "C"
+   {
+  -- 
+  1.8.4
+  EOF
+  cd -
+
+  GCCVERSION=$($HOST-g++ -E -dM $(mktemp --suffix=.h) | grep __VERSION__ | cut -d ' ' -f 3 | cut -d '"' -f 2)
+  echo "using gcc : $GCCVERSION : $HOST-g++
         :
-        <rc>i586-mingw32msvc-windres
-        <archiver>i586-mingw32msvc-ar
+        <rc>$HOST-windres
+        <archiver>$HOST-ar
         <cxxflags>-frandom-seed=boost1
+        <ranlib>$HOST-ranlib
   ;" > user-config.jam
   ./bootstrap.sh --without-icu
+
   ./bjam toolset=gcc target-os=windows threadapi=win32 threading=multi variant=release link=static --user-config=user-config.jam --without-mpi --without-python -sNO_BZIP2=1 -sNO_ZLIB=1 --layout=tagged --build-type=complete --prefix="$INSTALLPREFIX" $MAKEOPTS install
 
   cd "$INSTALLPREFIX"
   export LD_PRELOAD=/usr/lib/faketime/libfaketime.so.1
   export FAKETIME=$REFERENCE_DATETIME
-  zip -r boost-win32-1.50.0-gitian3.zip *
-  cp boost-win32-1.50.0-gitian3.zip $OUTDIR
+  zip -r boost-win32-1.50.0-gitian-r5.zip *
+  cp boost-win32-1.50.0-gitian-r5.zip $OUTDIR

--- a/contrib/gitian-descriptors/boost-win32.yml
+++ b/contrib/gitian-descriptors/boost-win32.yml
@@ -12,57 +12,19 @@ packages:
 reference_datetime: "2011-01-30 00:00:00"
 remotes: []
 files:
-- "boost_1_50_0.tar.bz2"
+- "boost_1_54_0.tar.bz2"
+- "boost-mingw-gas-cross-compile-2013-03-03.patch"
 script: |
-  #
+  # Defines
   INSTALLPREFIX="$OUTDIR/staging/boost"
   HOST=i686-w64-mingw32
-  #
+  # Input Integrity Check
+  echo "047e927de336af106a24bceba30069980c191529fd76b8dff8eb9a328b48ae1d  boost_1_54_0.tar.bz2" | shasum -c
+  echo "d2b7f6a1d7051faef3c9cf41a92fa3671d905ef1e1da920d07651a43299f6268  boost-mingw-gas-cross-compile-2013-03-03.patch" | shasum -c
 
   mkdir -p "$INSTALLPREFIX"
-  tar xjf boost_1_50_0.tar.bz2
-  cd boost_1_50_0
-
-  # Boost #4258: multiple definition of `_tls_used' https://svn.boost.org/trac/boost/ticket/4258
-  cd libs/thread/
-  patch -p1 << 'EOF'
-  From 8b83ad1f0ac4c56f019072de4a7a93f8fcccb96b Mon Sep 17 00:00:00 2001
-  From: "Vicente J. Botet Escriba" <vicente.botet@wanadoo.fr>
-  Date: Sat, 7 Jul 2012 14:37:07 +0000
-  Subject: [PATCH] Thread: Added __MINGW64_VERSION_MAJOR when __MINGW64__ is not
-   defined
-  
-  ---
-   src/win32/tss_pe.cpp | 4 ++--
-   1 file changed, 2 insertions(+), 2 deletions(-)
-  
-  diff --git a/src/win32/tss_pe.cpp b/src/win32/tss_pe.cpp
-  index 4d75680..0cdb7a6 100644
-  --- a/src/win32/tss_pe.cpp
-  +++ b/src/win32/tss_pe.cpp
-  @@ -11,7 +11,7 @@
-   
-   #if defined(BOOST_HAS_WINTHREADS) && defined(BOOST_THREAD_BUILD_LIB) 
-   
-  -#if (defined(__MINGW32__) && !defined(_WIN64)) || defined(__MINGW64__)
-  +#if (defined(__MINGW32__) && !defined(_WIN64)) || defined(__MINGW64__) || (__MINGW64_VERSION_MAJOR)
-   
-   #include <boost/thread/detail/tss_hooks.hpp>
-   
-  @@ -38,7 +38,7 @@
-       }
-   }
-   
-  -#if defined(__MINGW64__) || (__MINGW32_MAJOR_VERSION >3) ||             \
-  +#if defined(__MINGW64__) || (__MINGW64_VERSION_MAJOR) || (__MINGW32_MAJOR_VERSION >3) ||             \
-       ((__MINGW32_MAJOR_VERSION==3) && (__MINGW32_MINOR_VERSION>=18))
-   extern "C"
-   {
-  -- 
-  1.8.4
-  EOF
-  cd -
-
+  tar xjf boost_1_54_0.tar.bz2
+  cd boost_1_54_0
   GCCVERSION=$($HOST-g++ -E -dM $(mktemp --suffix=.h) | grep __VERSION__ | cut -d ' ' -f 3 | cut -d '"' -f 2)
   echo "using gcc : $GCCVERSION : $HOST-g++
         :
@@ -73,10 +35,32 @@ script: |
   ;" > user-config.jam
   ./bootstrap.sh --without-icu
 
-  ./bjam toolset=gcc target-os=windows threadapi=win32 threading=multi variant=release link=static --user-config=user-config.jam --without-mpi --without-python -sNO_BZIP2=1 -sNO_ZLIB=1 --layout=tagged --build-type=complete --prefix="$INSTALLPREFIX" $MAKEOPTS install
+  # Workaround: Upstream boost dev refuses to include patch that would allow Free Software cross-compile toolchain to work
+  #             This patch was authored by the Fedora package developer and ships in Fedora's mingw32-boost.
+  #             Please obtain the exact patch that matches the above sha256sum from one of the following mirrors.
+  #
+  # Read History:   https://svn.boost.org/trac/boost/ticket/7262
+  # History Mirror: http://rose.makesad.us/~paulproteus/mirrors/7262%20Boost.Context%20fails%20to%20build%20using%20MinGW.html
+  #
+  # Patch:          https://svn.boost.org/trac/boost/raw-attachment/ticket/7262/boost-mingw.patch
+  # Patch Mirror:   http://wtogami.fedorapeople.org/boost-mingw-gas-cross-compile-2013-03-03.patch
+  # Patch Mirror:   http://mindstalk.net/host/boost-mingw-gas-cross-compile-2013-03-03.patch
+  # Patch Mirror:   http://rose.makesad.us/~paulproteus/mirrors/boost-mingw-gas-cross-compile-2013-03-03.patch
+  patch -p0 < ../boost-mingw-gas-cross-compile-2013-03-03.patch
+
+  # Bug Workaround: boost-1.54.0 broke the ability to disable zlib
+  # https://svn.boost.org/trac/boost/ticket/9156
+  sed -i 's^\[ ac.check-library /zlib//zlib : <library>/zlib//zlib^^' libs/iostreams/build/Jamfile.v2
+  sed -i 's^<source>zlib.cpp <source>gzip.cpp \]^^' libs/iostreams/build/Jamfile.v2
+
+  # http://statmt.org/~s0565741/software/boost_1_52_0/libs/context/doc/html/context/requirements.html
+  # Note: Might need these options in the future for 64bit builds.
+  # "Please note that address-model=64 must be given to bjam command line on 64bit Windows for 64bit build; otherwise 32bit code will be generated."
+  # "For cross-compiling the lib you must specify certain additional properties at bjam command line: target-os, abi, binary-format, architecture and address-model."
+  ./bjam toolset=gcc binary-format=pe target-os=windows threadapi=win32 threading=multi variant=release link=static --user-config=user-config.jam --without-mpi --without-python -sNO_BZIP2=1 -sNO_ZLIB=1 --layout=tagged --build-type=complete --prefix="$INSTALLPREFIX" $MAKEOPTS install
 
   cd "$INSTALLPREFIX"
   export LD_PRELOAD=/usr/lib/faketime/libfaketime.so.1
   export FAKETIME=$REFERENCE_DATETIME
-  zip -r boost-win32-1.50.0-gitian-r5.zip *
-  cp boost-win32-1.50.0-gitian-r5.zip $OUTDIR
+  zip -r boost-win32-1.54.0-gitian-r6.zip *
+  cp boost-win32-1.54.0-gitian-r6.zip $OUTDIR

--- a/contrib/gitian-descriptors/deps-win32.yml
+++ b/contrib/gitian-descriptors/deps-win32.yml
@@ -1,11 +1,12 @@
 ---
 name: "bitcoin-deps"
 suites:
-- "lucid"
+- "precise"
 architectures:
-- "i386"
+- "amd64"
 packages:
-- "mingw32"
+- "mingw-w64"
+- "g++-mingw-w64"
 - "git-core"
 - "zip"
 - "faketime"
@@ -26,7 +27,7 @@ script: |
   export FAKETIME=$REFERENCE_DATETIME
   export TZ=UTC
   export INSTALLPREFIX=$OUTDIR/staging/deps
-  export HOST=i586-mingw32msvc
+  export HOST=i686-w64-mingw32
   #
   mkdir -p $INSTALLPREFIX
 
@@ -71,12 +72,12 @@ script: |
   #
   tar xjf qrencode-3.2.0.tar.bz2
   cd qrencode-3.2.0
-  png_CFLAGS="-I$INSTALLPREFIX/include" png_LIBS="-L$INSTALLPREFIX/lib -lpng" ./configure --prefix=$INSTALLPREFIX --host=i586-mingw32msvc
+  png_CFLAGS="-I$INSTALLPREFIX/include" png_LIBS="-L$INSTALLPREFIX/lib -lpng" ./configure --prefix=$INSTALLPREFIX --host=$HOST
   make
   make install
   cd ..
   #
   cd $INSTALLPREFIX
-  zip -r $OUTDIR/bitcoin-deps-0.0.7.zip include lib
+  zip -r $OUTDIR/bitcoin-deps-win32-gitian-r8.zip include lib
   # Kill wine processes as gitian won't figure out we are done otherwise
   killall wineserver services.exe explorer.exe winedevice.exe

--- a/contrib/gitian-descriptors/gitian-win32.yml
+++ b/contrib/gitian-descriptors/gitian-win32.yml
@@ -1,11 +1,12 @@
 ---
 name: "bitcoin"
 suites:
-- "lucid"
+- "precise"
 architectures:
-- "i386"
+- "amd64"
 packages:
-- "mingw32"
+- "mingw-w64"
+- "g++-mingw-w64"
 - "git-core"
 - "unzip"
 - "nsis"
@@ -21,31 +22,33 @@ remotes:
 - "url": "https://github.com/bitcoin/bitcoin.git"
   "dir": "bitcoin"
 files:
-- "qt-win32-4.8.3-gitian-r3.zip"
-- "boost-win32-1.50.0-gitian3.zip"
-- "bitcoin-deps-0.0.7.zip"
-- "protobuf-win32-2.5.0-gitian-r2.zip"
+- "qt-win32-4.8.3-gitian-r4.zip"
+- "boost-win32-1.50.0-gitian-r5.zip"
+- "bitcoin-deps-win32-gitian-r8.zip"
+- "protobuf-win32-2.5.0-gitian-r3.zip"
 script: |
   #
   STAGING=$HOME/staging
+  HOST=i686-w64-mingw32
+  #
   mkdir -p $STAGING
   cd $STAGING
-  unzip ../build/qt-win32-4.8.3-gitian-r3.zip
-  unzip ../build/boost-win32-1.50.0-gitian3.zip
-  unzip ../build/bitcoin-deps-0.0.7.zip
-  unzip ../build/protobuf-win32-2.5.0-gitian-r2.zip
+  unzip ../build/qt-win32-4.8.3-gitian-r4.zip
+  unzip ../build/boost-win32-1.50.0-gitian-r5.zip
+  unzip ../build/bitcoin-deps-win32-gitian-r8.zip
+  unzip ../build/protobuf-win32-2.5.0-gitian-r3.zip
   cd $HOME/build/
   #
   cd bitcoin
   export PATH=$STAGING/host/bin:$PATH
   export TAR_OPTIONS=--mtime=`echo $REFERENCE_DATETIME | awk '{ print $1 }'`
   ./autogen.sh
-  ./configure --bindir=$OUTDIR --prefix=$STAGING --host=i586-mingw32msvc --with-qt-plugindir=$STAGING/plugins  --with-qt-incdir=$STAGING/include --with-qt-bindir=$STAGING/host/bin --with-boost=$STAGING --disable-maintainer-mode --with-protoc-bindir=$STAGING/host/bin --disable-dependency-tracking CPPFLAGS="-I$STAGING/include" LDFLAGS="-L$STAGING/lib" CXXFLAGS="-frandom-seed=bitcoin"
+  ./configure --bindir=$OUTDIR --prefix=$STAGING --host=$HOST --with-qt-plugindir=$STAGING/plugins  --with-qt-incdir=$STAGING/include --with-qt-bindir=$STAGING/host/bin --with-boost=$STAGING --disable-maintainer-mode --with-protoc-bindir=$STAGING/host/bin --disable-dependency-tracking CPPFLAGS="-I$STAGING/include" LDFLAGS="-L$STAGING/lib" CXXFLAGS="-frandom-seed=bitcoin"
   make dist
   mkdir -p distsrc
   cd distsrc
   tar --strip-components=1 -xf ../bitcoin-*.tar.*
-  ./configure --bindir=$OUTDIR --prefix=$STAGING --host=i586-mingw32msvc --with-qt-plugindir=$STAGING/plugins  --with-qt-incdir=$STAGING/include --with-qt-bindir=$STAGING/host/bin --with-boost=$STAGING --disable-maintainer-mode --with-protoc-bindir=$STAGING/host/bin --disable-dependency-tracking CPPFLAGS="-I$STAGING/include" LDFLAGS="-L$STAGING/lib" CXXFLAGS="-frandom-seed=bitcoin"
+  ./configure --bindir=$OUTDIR --prefix=$STAGING --host=i686-w64-mingw32 --with-qt-plugindir=$STAGING/plugins  --with-qt-incdir=$STAGING/include --with-qt-bindir=$STAGING/host/bin --with-boost=$STAGING --disable-maintainer-mode --with-protoc-bindir=$STAGING/host/bin --disable-dependency-tracking CPPFLAGS="-I$STAGING/include" LDFLAGS="-L$STAGING/lib" CXXFLAGS="-frandom-seed=bitcoin"
   export LD_PRELOAD=/usr/lib/faketime/libfaketime.so.1
   export FAKETIME=$REFERENCE_DATETIME
   export TZ=UTC

--- a/contrib/gitian-descriptors/gitian-win32.yml
+++ b/contrib/gitian-descriptors/gitian-win32.yml
@@ -23,7 +23,7 @@ remotes:
   "dir": "bitcoin"
 files:
 - "qt-win32-4.8.3-gitian-r4.zip"
-- "boost-win32-1.50.0-gitian-r5.zip"
+- "boost-win32-1.54.0-gitian-r6.zip"
 - "bitcoin-deps-win32-gitian-r8.zip"
 - "protobuf-win32-2.5.0-gitian-r3.zip"
 script: |
@@ -34,7 +34,7 @@ script: |
   mkdir -p $STAGING
   cd $STAGING
   unzip ../build/qt-win32-4.8.3-gitian-r4.zip
-  unzip ../build/boost-win32-1.50.0-gitian-r5.zip
+  unzip ../build/boost-win32-1.54.0-gitian-r6.zip
   unzip ../build/bitcoin-deps-win32-gitian-r8.zip
   unzip ../build/protobuf-win32-2.5.0-gitian-r3.zip
   cd $HOME/build/

--- a/contrib/gitian-descriptors/protobuf-win32.yml
+++ b/contrib/gitian-descriptors/protobuf-win32.yml
@@ -1,11 +1,12 @@
 ---
 name: "protobuf-win32"
 suites:
-- "lucid"
+- "precise"
 architectures:
-- "i386"
+- "amd64"
 packages:
-- "mingw32"
+- "mingw-w64"
+- "g++-mingw-w64"
 - "zip"
 - "faketime"
 reference_datetime: "2013-04-15 00:00:00"
@@ -16,7 +17,7 @@ script: |
   #
   export TZ=UTC
   export INSTALLPREFIX=$OUTDIR/staging/deps
-  export HOST=i586-mingw32msvc
+  export HOST=i686-w64-mingw32
   #
   #
   mkdir -p $INSTALLPREFIX
@@ -36,6 +37,6 @@ script: |
   cd $INSTALLPREFIX
   export LD_PRELOAD=/usr/lib/faketime/libfaketime.so.1
   export FAKETIME=$REFERENCE_DATETIME
-  zip -r $OUTDIR/protobuf-win32-2.5.0-gitian-r2.zip include lib host
+  zip -r $OUTDIR/protobuf-win32-2.5.0-gitian-r3.zip include lib host
   unset LD_PRELOAD
   unset FAKETIME

--- a/contrib/gitian-descriptors/qt-win32.yml
+++ b/contrib/gitian-descriptors/qt-win32.yml
@@ -1,11 +1,12 @@
 ---
 name: "qt"
 suites:
-- "lucid"
+- "precise"
 architectures:
-- "i386"
+- "amd64"
 packages: 
-- "mingw32"
+- "mingw-w64"
+- "g++-mingw-w64"
 - "zip"
 - "unzip"
 - "faketime"
@@ -14,34 +15,37 @@ reference_datetime: "2011-01-30 00:00:00"
 remotes: []
 files:
 - "qt-everywhere-opensource-src-4.8.3.tar.gz"
-- "bitcoin-deps-0.0.7.zip"
+- "bitcoin-deps-win32-gitian-r8.zip"
 script: |
+  #
+  HOST=i686-w64-mingw32
   INSTDIR="$HOME/qt/"
+  #
   mkdir $INSTDIR
   mkdir -p $INSTDIR/host/bin
   #
   # Need mingw-compiled openssl from bitcoin-deps:
-  unzip bitcoin-deps-0.0.7.zip
+  unzip bitcoin-deps-win32-gitian-r8.zip
   DEPSDIR=`pwd`
   #
   tar xzf qt-everywhere-opensource-src-4.8.3.tar.gz
   cd qt-everywhere-opensource-src-4.8.3
   sed 's/$TODAY/2011-01-30/' -i configure
-  sed 's/i686-pc-mingw32-/i586-mingw32msvc-/' -i mkspecs/unsupported/win32-g++-cross/qmake.conf
-  sed --posix 's|QMAKE_CFLAGS\t\t= -pipe|QMAKE_CFLAGS\t\t= -pipe -isystem /usr/i586-mingw32msvc/include/ -frandom-seed=qtbuild|' -i mkspecs/unsupported/win32-g++-cross/qmake.conf
+  sed 's/i686-pc-mingw32-/$HOST-/' -i mkspecs/unsupported/win32-g++-cross/qmake.conf
+  sed --posix 's|QMAKE_CFLAGS\t\t= -pipe|QMAKE_CFLAGS\t\t= -pipe -isystem /usr/$HOST/include/ -frandom-seed=qtbuild|' -i mkspecs/unsupported/win32-g++-cross/qmake.conf
   sed 's/QMAKE_CXXFLAGS_EXCEPTIONS_ON = -fexceptions -mthreads/QMAKE_CXXFLAGS_EXCEPTIONS_ON = -fexceptions/' -i mkspecs/unsupported/win32-g++-cross/qmake.conf
   sed 's/QMAKE_LFLAGS_EXCEPTIONS_ON = -mthreads/QMAKE_LFLAGS_EXCEPTIONS_ON = -lmingwthrd/' -i mkspecs/unsupported/win32-g++-cross/qmake.conf
-  sed --posix 's/QMAKE_MOC\t\t= i586-mingw32msvc-moc/QMAKE_MOC\t\t= moc/' -i mkspecs/unsupported/win32-g++-cross/qmake.conf
-  sed --posix 's/QMAKE_RCC\t\t= i586-mingw32msvc-rcc/QMAKE_RCC\t\t= rcc/' -i mkspecs/unsupported/win32-g++-cross/qmake.conf
-  sed --posix 's/QMAKE_UIC\t\t= i586-mingw32msvc-uic/QMAKE_UIC\t\t= uic/' -i mkspecs/unsupported/win32-g++-cross/qmake.conf
+  sed --posix 's/QMAKE_MOC\t\t= $HOST-moc/QMAKE_MOC\t\t= moc/' -i mkspecs/unsupported/win32-g++-cross/qmake.conf
+  sed --posix 's/QMAKE_RCC\t\t= $HOST-rcc/QMAKE_RCC\t\t= rcc/' -i mkspecs/unsupported/win32-g++-cross/qmake.conf
+  sed --posix 's/QMAKE_UIC\t\t= $HOST-uic/QMAKE_UIC\t\t= uic/' -i mkspecs/unsupported/win32-g++-cross/qmake.conf
   # ar adds timestamps to every object file included in the static library
   # providing -D as ar argument is supposed to solve it, but doesn't work as qmake strips off the arguments and adds -M to pass a script...
   # which somehow cannot be combined with other flags.
   # use faketime only for ar, as it confuses make/qmake into hanging sometimes
-  sed --posix "s|QMAKE_LIB\t\t= i586-mingw32msvc-ar -ru|QMAKE_LIB\t\t= $HOME/ar -Dr|" -i mkspecs/unsupported/win32-g++-cross/qmake.conf
+  sed --posix "s|QMAKE_LIB\t\t= $HOST-ar -ru|QMAKE_LIB\t\t= $HOME/ar -Dr|" -i mkspecs/unsupported/win32-g++-cross/qmake.conf
   echo '#!/bin/bash' > $HOME/ar
   echo 'export LD_PRELOAD=/usr/lib/faketime/libfaketime.so.1' >> $HOME/ar
-  echo 'i586-mingw32msvc-ar "$@"' >> $HOME/ar
+  echo '$HOST-ar "$@"' >> $HOME/ar
   chmod +x $HOME/ar
   #export LD_PRELOAD=/usr/lib/faketime/libfaketime.so.1
   export FAKETIME=$REFERENCE_DATETIME
@@ -56,4 +60,4 @@ script: |
 
   # as zip stores file timestamps, use faketime to intercept stat calls to set dates for all files to reference date
   export LD_PRELOAD=/usr/lib/faketime/libfaketime.so.1
-  zip -r $OUTDIR/qt-win32-4.8.3-gitian-r3.zip *
+  zip -r $OUTDIR/qt-win32-4.8.3-gitian-r4.zip *

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -42,18 +42,20 @@ Release Process
 	wget 'http://zlib.net/zlib-1.2.6.tar.gz'
 	wget 'ftp://ftp.simplesystems.org/pub/libpng/png/src/libpng-1.5.9.tar.gz'
 	wget 'http://fukuchi.org/works/qrencode/qrencode-3.2.0.tar.bz2'
-	wget 'http://downloads.sourceforge.net/project/boost/boost/1.50.0/boost_1_50_0.tar.bz2'
+	wget 'http://downloads.sourceforge.net/project/boost/boost/1.54.0/boost_1_54_0.tar.bz2'
+	wget 'https://svn.boost.org/trac/boost/raw-attachment/ticket/7262/boost-mingw.patch' -O \ 
+	     boost-mingw-gas-cross-compile-2013-03-03.patch
 	wget 'http://releases.qt-project.org/qt4/source/qt-everywhere-opensource-src-4.8.3.tar.gz'
 	wget 'http://protobuf.googlecode.com/files/protobuf-2.5.0.tar.bz2'
 	cd ..
 	./bin/gbuild ../bitcoin/contrib/gitian-descriptors/boost-win32.yml
-	mv build/out/boost-win32-1.50.0-gitian2.zip inputs/
+	mv build/out/boost-win32-*.zip inputs/
 	./bin/gbuild ../bitcoin/contrib/gitian-descriptors/qt-win32.yml
-	mv build/out/qt-win32-4.8.3-gitian-r2.zip inputs/
+	mv build/out/qt-win32-*.zip inputs/
 	./bin/gbuild ../bitcoin/contrib/gitian-descriptors/deps-win32.yml
-	mv build/out/bitcoin-deps-0.0.5.zip inputs/
+	mv build/out/bitcoin-deps-*.zip inputs/
 	./bin/gbuild ../bitcoin/contrib/gitian-descriptors/protobuf-win32.yml
-	mv build/out/protobuf-win32-2.5.0-gitian-r1.zip inputs/
+	mv build/out/protobuf-win32-*.zip inputs/
 
  Build bitcoind and bitcoin-qt on Linux32, Linux64, and Win32:
   


### PR DESCRIPTION
mingw upgrade allows more hardening, compiler bug fixes and possibily win64 later.

Rename deps .zip files to be more consistent in revision format.
Remove "msvc" compat triplet name.
LDFLAGS -static-libgcc -static-libstdc++
Upgrade win32 gitian to boost-1.54.0.
Workaround 1.54.0  build bug, upstream #9156
Workaround 1.51.0+ human bug, upstream #7262

Upstream 1.51.0 fixed a multiple reference bug that is problematic in 1.50.0.  The cross-compile patch is by the Fedora package developer and shipped in Fedora.

Please also note the sha256sum -c thing in boost-win32.yml.  devrandom agreed it is a good approach to better ensure the integrity of inputs, at least prior to gitian itself gaining the ability to track and enforce particular input hashes.  If folks have no objections to this sha256sum -c approach, I would like to do a different pull request that does it for all inputs.

All unit tests pass.
