### PR TITLE
internal miner: move 2 globals from main to miner

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -67,9 +67,6 @@ CScript COINBASE_FLAGS;
 
 const string strMessageMagic = "Bitcoin Signed Message:\n";
 
-double dHashesPerSec = 0.0;
-int64 nHPSTimerStart = 0;
-
 // Settings
 int64 nTransactionFee = 0;
 

--- a/src/main.h
+++ b/src/main.h
@@ -86,8 +86,6 @@ extern unsigned int nTransactionsUpdated;
 extern uint64 nLastBlockTx;
 extern uint64 nLastBlockSize;
 extern const std::string strMessageMagic;
-extern double dHashesPerSec;
-extern int64 nHPSTimerStart;
 extern int64 nTimeBestReceived;
 extern CCriticalSection cs_setpwalletRegistered;
 extern std::set<CWallet*> setpwalletRegistered;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -3,15 +3,11 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include "core.h"
-#include "wallet.h"
 #include "miner.h"
 #include "main.h"
 
-
-
-
-
+double dHashesPerSec = 0.0;
+int64 nHPSTimerStart = 0;
 
 //////////////////////////////////////////////////////////////////////////////
 //

--- a/src/miner.h
+++ b/src/miner.h
@@ -22,4 +22,7 @@ bool CheckWork(CBlock* pblock, CWallet& wallet, CReserveKey& reservekey);
 /** Base sha256 mining transform */
 void SHA256Transform(void* pstate, void* pinput, const void* pinit);
 
+extern double dHashesPerSec;
+extern int64 nHPSTimerStart;
+
 #endif // BITCOIN_MINER_H


### PR DESCRIPTION
- moves 2 global variables from main.cpp/h to miner.cpp/h
- also removes 2 unneded includes in miner.cpp, that come from miner.h
  already
