### PR TITLE
Update Qt 4.8.3 download link in Gitian Descriptors README

### DIFF
--- a/contrib/gitian-descriptors/README
+++ b/contrib/gitian-descriptors/README
@@ -31,7 +31,7 @@ Once you've got the right hardware and software:
     wget 'http://download.oracle.com/berkeley-db/db-4.8.30.NC.tar.gz'
     wget 'https://downloads.sourceforge.net/project/libpng/zlib/1.2.6/zlib-1.2.6.tar.gz'
     wget 'https://downloads.sourceforge.net/project/libpng/libpng15/older-releases/1.5.9/libpng-1.5.9.tar.gz'
-    wget 'http://releases.qt-project.org/qt4/source/qt-everywhere-opensource-src-4.8.3.tar.gz'
+    wget 'https://download.qt-project.org/archive/qt/4.8/4.8.3/qt-everywhere-opensource-src-4.8.3.tar.gz'
     wget 'http://protobuf.googlecode.com/files/protobuf-2.5.0.tar.bz2'
     cd ../..
 


### PR DESCRIPTION
The current link is redirecting to http://download.qt-project.org/
