### PR TITLE
several small Qt-related fixes

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -155,11 +155,14 @@ static void initTranslations(QTranslator &qtTranslatorBase, QTranslator &qtTrans
 #if QT_VERSION < 0x050000
 void DebugMessageHandler(QtMsgType type, const char * msg)
 {
+    Q_UNUSED(type);
     LogPrint("qt", "Bitcoin-Qt: %s\n", msg);
 }
 #else
 void DebugMessageHandler(QtMsgType type, const QMessageLogContext& context, const QString &msg)
 {
+    Q_UNUSED(type);
+    Q_UNUSED(context);
     LogPrint("qt", "Bitcoin-Qt: %s\n", qPrintable(msg));
 }
 #endif

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -751,13 +751,9 @@ void BitcoinGUI::handlePaymentRequest(const SendCoinsRecipient& recipient)
     walletFrame->handlePaymentRequest(recipient);
 }
 
-void BitcoinGUI::showPaymentACK(QString msg)
+void BitcoinGUI::showPaymentACK(const QString& msg)
 {
-#if QT_VERSION < 0x050000
-    message(tr("Payment acknowledged"), Qt::escape(msg), CClientUIInterface::MODAL);
-#else
-    message(tr("Payment acknowledged"), msg.toHtmlEscaped(), CClientUIInterface::MODAL);
-#endif
+    message(tr("Payment acknowledged"), GUIUtil::HtmlEscape(msg), CClientUIInterface::MODAL);
 }
 
 void BitcoinGUI::setEncryptionStatus(int status)

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -154,7 +154,7 @@ public slots:
     void askFee(qint64 nFeeRequired, bool *payFee);
 
     void handlePaymentRequest(const SendCoinsRecipient& recipient);
-    void showPaymentACK(QString msg);
+    void showPaymentACK(const QString& msg);
 
     /** Show incoming transaction notification for new transactions. */
     void incomingTransaction(const QString& date, int unit, qint64 amount, const QString& type, const QString& address);

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -24,9 +24,8 @@ ClientModel::ClientModel(OptionsModel *optionsModel, QObject *parent) :
     numBlocksAtStartup(-1), pollTimer(0)
 {
     pollTimer = new QTimer(this);
-    pollTimer->setInterval(MODEL_UPDATE_DELAY);
-    pollTimer->start();
     connect(pollTimer, SIGNAL(timeout()), this, SLOT(updateTimer()));
+    pollTimer->start(MODEL_UPDATE_DELAY);
 
     subscribeToCoreSignals();
 }

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -143,7 +143,7 @@ WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransact
     foreach(const SendCoinsRecipient &rcp, recipients)
     {
         if (rcp.paymentRequest.IsInitialized())
-        {    // PaymentRequest...
+        {   // PaymentRequest...
             int64 subtotal = 0;
             const payments::PaymentDetails& details = rcp.paymentRequest.getDetails();
             for (int i = 0; i < details.outputs_size(); i++)

--- a/src/qt/walletmodeltransaction.cpp
+++ b/src/qt/walletmodeltransaction.cpp
@@ -32,7 +32,7 @@ qint64 WalletModelTransaction::getTransactionFee()
 
 void WalletModelTransaction::setTransactionFee(qint64 newFee)
 {
-    fee=newFee;
+    fee = newFee;
 }
 
 qint64 WalletModelTransaction::getTotalTransactionAmount()
@@ -40,7 +40,7 @@ qint64 WalletModelTransaction::getTotalTransactionAmount()
     qint64 totalTransactionAmount = 0;
     foreach(const SendCoinsRecipient &rcp, recipients)
     {
-        totalTransactionAmount+=rcp.amount;
+        totalTransactionAmount += rcp.amount;
     }
     return totalTransactionAmount;
 }


### PR DESCRIPTION
- make BitcoinGUI::showPaymentACK() use a reference for msg and use our
  own GUIUtil::HtmlEscape() function
- ensure QTimer usage in clientmodel is the same as in walletmodel
- remove an unneeded debug message in walletframe
- flag some parameters as unused in DebugMessageHandler()
- small code formatting changes
