### PR TITLE
Use host to generate miniupnpcstring.h, instead of wine

### DIFF
--- a/contrib/gitian-descriptors/deps-win32.yml
+++ b/contrib/gitian-descriptors/deps-win32.yml
@@ -10,7 +10,6 @@ packages:
 - "git-core"
 - "zip"
 - "faketime"
-- "wine"
 - "psmisc"
 reference_datetime: "2011-01-30 00:00:00"
 remotes: []
@@ -47,10 +46,10 @@ script: |
   #
   tar xzf miniupnpc-1.6.tar.gz
   cd miniupnpc-1.6
-  sed 's/dllwrap -k --driver-name gcc/$(DLLWRAP) -k --driver-name $(CC)/' -i Makefile.mingw
-  sed 's|wingenminiupnpcstrings $< $@|./wingenminiupnpcstrings $< $@|' -i Makefile.mingw
   mkdir -p dll
-  make -f Makefile.mingw DLLWRAP=$HOST-dllwrap CC=$HOST-gcc AR=$HOST-ar libminiupnpc.a
+  sed 's|miniupnpcstrings.h: |_erased_miniupnpcstrings.h: |' -i Makefile.mingw
+  make -f Makefile miniupnpcstrings.h
+  make -f Makefile.mingw CC=$HOST-gcc AR=$HOST-ar libminiupnpc.a
   install -d $INSTALLPREFIX/include/miniupnpc
   install *.h $INSTALLPREFIX/include/miniupnpc
   install libminiupnpc.a  $INSTALLPREFIX/lib
@@ -78,6 +77,4 @@ script: |
   cd ..
   #
   cd $INSTALLPREFIX
-  zip -r $OUTDIR/bitcoin-deps-win32-gitian-r8.zip include lib
-  # Kill wine processes as gitian won't figure out we are done otherwise
-  killall wineserver services.exe explorer.exe winedevice.exe
+  zip -r $OUTDIR/bitcoin-deps-win32-gitian-r9.zip include lib

--- a/contrib/gitian-descriptors/gitian-win32.yml
+++ b/contrib/gitian-descriptors/gitian-win32.yml
@@ -24,7 +24,7 @@ remotes:
 files:
 - "qt-win32-4.8.3-gitian-r4.zip"
 - "boost-win32-1.54.0-gitian-r6.zip"
-- "bitcoin-deps-win32-gitian-r8.zip"
+- "bitcoin-deps-win32-gitian-r9.zip"
 - "protobuf-win32-2.5.0-gitian-r3.zip"
 script: |
   #
@@ -35,7 +35,7 @@ script: |
   cd $STAGING
   unzip ../build/qt-win32-4.8.3-gitian-r4.zip
   unzip ../build/boost-win32-1.54.0-gitian-r6.zip
-  unzip ../build/bitcoin-deps-win32-gitian-r8.zip
+  unzip ../build/bitcoin-deps-win32-gitian-r9.zip
   unzip ../build/protobuf-win32-2.5.0-gitian-r3.zip
   cd $HOME/build/
   #


### PR DESCRIPTION
Simplifies gitian win32 build by removing the wine build-time dependency.  Patch by @sipa, with cleanup and testing by wtogami.  Resulting binaries seem to operate just fine.

Getting rid of wine makes it much easier to use gitan LXC.  After gitian LXC is fixed, it will be possible to do deterministic gitian builds wthin Linux VM's, making the process more accessible to a greater number of people.
