### PR TITLE
Hardcode string in miniupnpcstring.h and remove wine from deps-win32.yml

### DIFF
--- a/contrib/gitian-descriptors/deps-win32.yml
+++ b/contrib/gitian-descriptors/deps-win32.yml
@@ -10,7 +10,6 @@ packages:
 - "git-core"
 - "zip"
 - "faketime"
-- "wine"
 - "psmisc"
 reference_datetime: "2011-01-30 00:00:00"
 remotes: []
@@ -47,10 +46,23 @@ script: |
   #
   tar xzf miniupnpc-1.6.tar.gz
   cd miniupnpc-1.6
-  sed 's/dllwrap -k --driver-name gcc/$(DLLWRAP) -k --driver-name $(CC)/' -i Makefile.mingw
-  sed 's|wingenminiupnpcstrings $< $@|./wingenminiupnpcstrings $< $@|' -i Makefile.mingw
+  echo "
+  --- miniupnpc-1.6/Makefile.mingw.orig   2013-09-29 18:52:51.014087958 -1000
+  +++ miniupnpc-1.6/Makefile.mingw        2013-09-29 19:09:29.663318691 -1000
+  @@ -67,8 +67,8 @@
+   
+   wingenminiupnpcstrings.o:	wingenminiupnpcstrings.c
+   
+  -miniupnpcstrings.h: miniupnpcstrings.h.in wingenminiupnpcstrings
+  -	wingenminiupnpcstrings \$< \$@
+  +miniupnpcstrings.h: miniupnpcstrings.h.in 
+  +	sed -e 's|OS/version|MSWindows/5.1.2600|' -e 's|MINIUPNPC_VERSION_STRING \"version\"|MINIUPNPC_VERSION_STRING \"VERSIONHERE\"|' \$< > \$@
+   
+   minixml.o:	minixml.c minixml.h miniupnpcstrings.h
+   
+  " | sed "s/VERSIONHERE/$(cat VERSION)/" | patch -p1
   mkdir -p dll
-  make -f Makefile.mingw DLLWRAP=$HOST-dllwrap CC=$HOST-gcc AR=$HOST-ar libminiupnpc.a
+  make -f Makefile.mingw CC=$HOST-gcc AR=$HOST-ar libminiupnpc.a
   install -d $INSTALLPREFIX/include/miniupnpc
   install *.h $INSTALLPREFIX/include/miniupnpc
   install libminiupnpc.a  $INSTALLPREFIX/lib
@@ -78,6 +90,4 @@ script: |
   cd ..
   #
   cd $INSTALLPREFIX
-  zip -r $OUTDIR/bitcoin-deps-win32-gitian-r8.zip include lib
-  # Kill wine processes as gitian won't figure out we are done otherwise
-  killall wineserver services.exe explorer.exe winedevice.exe
+  zip -r $OUTDIR/bitcoin-deps-win32-gitian-r9.zip include lib

--- a/contrib/gitian-descriptors/gitian-win32.yml
+++ b/contrib/gitian-descriptors/gitian-win32.yml
@@ -24,7 +24,7 @@ remotes:
 files:
 - "qt-win32-4.8.3-gitian-r4.zip"
 - "boost-win32-1.54.0-gitian-r6.zip"
-- "bitcoin-deps-win32-gitian-r8.zip"
+- "bitcoin-deps-win32-gitian-r9.zip"
 - "protobuf-win32-2.5.0-gitian-r3.zip"
 script: |
   #
@@ -35,7 +35,7 @@ script: |
   cd $STAGING
   unzip ../build/qt-win32-4.8.3-gitian-r4.zip
   unzip ../build/boost-win32-1.54.0-gitian-r6.zip
-  unzip ../build/bitcoin-deps-win32-gitian-r8.zip
+  unzip ../build/bitcoin-deps-win32-gitian-r9.zip
   unzip ../build/protobuf-win32-2.5.0-gitian-r3.zip
   cd $HOME/build/
   #

--- a/contrib/gitian-descriptors/qt-win32.yml
+++ b/contrib/gitian-descriptors/qt-win32.yml
@@ -15,7 +15,7 @@ reference_datetime: "2011-01-30 00:00:00"
 remotes: []
 files:
 - "qt-everywhere-opensource-src-4.8.3.tar.gz"
-- "bitcoin-deps-win32-gitian-r8.zip"
+- "bitcoin-deps-win32-gitian-r9.zip"
 script: |
   #
   HOST=i686-w64-mingw32
@@ -25,7 +25,7 @@ script: |
   mkdir -p $INSTDIR/host/bin
   #
   # Need mingw-compiled openssl from bitcoin-deps:
-  unzip bitcoin-deps-win32-gitian-r8.zip
+  unzip bitcoin-deps-win32-gitian-r9.zip
   DEPSDIR=`pwd`
   #
   tar xzf qt-everywhere-opensource-src-4.8.3.tar.gz


### PR DESCRIPTION
Credit: sipa, cfields, Luke-Jr and michagogo contributed to this fix.

Removing wine as a win32 build dep is beneficial to fixing Gitian LXC,
which would enable many more people to join in the gitian.sigs process
by being able to build with a linux VM instead of a virt capable host.
