### PR TITLE
special case DoS value == 0

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3785,8 +3785,8 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
             if (nEvicted > 0)
                 LogPrint("mempool", "mapOrphan overflow, removed %u tx\n", nEvicted);
         }
-        int nDoS;
-        if (state.IsInvalid(nDoS))
+        int nDoS = 0;
+        if (state.IsInvalid(nDoS) && nDoS > 0)
             pfrom->Misbehaving(nDoS);
     }
 
@@ -3805,8 +3805,8 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
         CValidationState state;
         if (ProcessBlock(state, pfrom, &block))
             mapAlreadyAskedFor.erase(inv);
-        int nDoS;
-        if (state.IsInvalid(nDoS))
+        int nDoS = 0;
+        if (state.IsInvalid(nDoS) && nDoS > 0)
             pfrom->Misbehaving(nDoS);
     }
 


### PR DESCRIPTION
- prevents unneeded log messages, which could make users think something
  bad was happening
