### PR TITLE
Command "listunspent" returns outputs sorted by amount (instead of unsorted)

### DIFF
--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -17,6 +17,14 @@ using namespace boost;
 using namespace boost::assign;
 using namespace json_spirit;
 
+struct CompareCOutputByAmount
+{
+    bool operator()(const COutput& t1, const COutput& t2) const
+    {
+        return (t1.tx->vout[t1.i].nValue < t2.tx->vout[t2.i].nValue);
+    }
+};
+
 void ScriptPubKeyToJSON(const CScript& scriptPubKey, Object& out, bool fIncludeHex)
 {
     txnouttype type;
@@ -172,6 +180,8 @@ Value listunspent(const Array& params, bool fHelp)
     Array results;
     vector<COutput> vecOutputs;
     pwalletMain->AvailableCoins(vecOutputs, false);
+    sort(vecOutputs.begin(), vecOutputs.end(), CompareCOutputByAmount());
+
     BOOST_FOREACH(const COutput& out, vecOutputs)
     {
         if (out.nDepth < nMinDepth || out.nDepth > nMaxDepth)


### PR DESCRIPTION
I often see how many and which outputs are unspent (and try to guess which inputs will be used in next payment, and so on). This can be done by command "listunspent" but now it's a little bit unpractical. Outputs are not sorted by any key and when outputs count is more than 10, it's badly readable. This patch sorts outputs by amount, ascending.

**Pros:**
- better readability of outputs

**Cons:**
- complexity of printing is n*log(n) instead of n (where n is number of outputs)
- maybe question why to sort by amount and no by any other key (but I think that better any sort than no sort)

For me, this is very useful. If you find it useful too, I'll be glad when it will be pulled to master.
