### PR TITLE
re-work -debug switch handling

### DIFF
--- a/src/addrman.h
+++ b/src/addrman.h
@@ -419,7 +419,7 @@ public:
             Check();
         }
         if (fRet)
-            LogPrint("addr", "Added %s from %s: %i tried, %i new\n", addr.ToStringIPPort().c_str(), source.ToString().c_str(), nTried, nNew);
+            LogPrint("addrman", "Added %s from %s: %i tried, %i new\n", addr.ToStringIPPort().c_str(), source.ToString().c_str(), nTried, nNew);
         return fRet;
     }
 
@@ -435,7 +435,7 @@ public:
             Check();
         }
         if (nAdd)
-            LogPrint("addr", "Added %i addresses from %s: %i tried, %i new\n", nAdd, source.ToString().c_str(), nTried, nNew);
+            LogPrint("addrman", "Added %i addresses from %s: %i tried, %i new\n", nAdd, source.ToString().c_str(), nTried, nNew);
         return nAdd > 0;
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3544,10 +3544,10 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
             return error("message getdata size() = %"PRIszu"", vInv.size());
         }
 
-        if (fDebugNet || (vInv.size() != 1))
+        if (fDebug || (vInv.size() != 1))
             LogPrint("net", "received getdata (%"PRIszu" invsz)\n", vInv.size());
 
-        if ((fDebugNet && vInv.size() > 0) || (vInv.size() == 1))
+        if ((fDebug && vInv.size() > 0) || (vInv.size() == 1))
             LogPrint("net", "received getdata for: %s\n", vInv[0].ToString().c_str());
 
         pfrom->vRecvGetData.insert(pfrom->vRecvGetData.end(), vInv.begin(), vInv.end());
@@ -4213,7 +4213,7 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
             const CInv& inv = (*pto->mapAskFor.begin()).second;
             if (!AlreadyHave(inv))
             {
-                if (fDebugNet)
+                if (fDebug)
                     LogPrint("net", "sending getdata: %s\n", inv.ToString().c_str());
                 vGetData.push_back(inv);
                 if (vGetData.size() >= 1000)

--- a/src/qt/paymentrequestplus.cpp
+++ b/src/qt/paymentrequestplus.cpp
@@ -75,8 +75,7 @@ bool PaymentRequestPlus::getMerchant(X509_STORE* certStore, QString& merchant) c
         digestAlgorithm = EVP_sha1();
     }
     else if (paymentRequest.pki_type() == "none") {
-        if (fDebug)
-            qDebug() << "PaymentRequestPlus::getMerchant : Payment request: pki_type == none";
+        qDebug() << "PaymentRequestPlus::getMerchant : Payment request: pki_type == none";
         return false;
     }
     else {

--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -87,9 +87,7 @@ static QList<QString> savedPaymentRequests;
 
 static void ReportInvalidCertificate(const QSslCertificate& cert)
 {
-    if (fDebug) {
-        qDebug() << "ReportInvalidCertificate : Payment server found an invalid certificate: " << cert.subjectInfo(QSslCertificate::CommonName);
-    }
+    qDebug() << "ReportInvalidCertificate : Payment server found an invalid certificate: " << cert.subjectInfo(QSslCertificate::CommonName);
 }
 
 //
@@ -160,8 +158,7 @@ void PaymentServer::LoadRootCAs(X509_STORE* _store)
             continue;
         }
     }
-    if (fDebug)
-        qDebug() << "PaymentServer::LoadRootCAs : Loaded " << nRootCerts << " root certificates";
+    qDebug() << "PaymentServer::LoadRootCAs : Loaded " << nRootCerts << " root certificates";
 
     // Project for another day:
     // Fetch certificate revocation lists, and add them to certStore.
@@ -375,8 +372,7 @@ void PaymentServer::handleURIOrFile(const QString& s)
             QString decoded = QUrl::fromPercentEncoding(temp);
             QUrl fetchUrl(decoded, QUrl::StrictMode);
 
-            if (fDebug)
-                qDebug() << "PaymentServer::handleURIOrFile : fetchRequest(" << fetchUrl << ")";
+            qDebug() << "PaymentServer::handleURIOrFile : fetchRequest(" << fetchUrl << ")";
 
             if (fetchUrl.isValid())
                 fetchRequest(fetchUrl);
@@ -475,8 +471,7 @@ bool PaymentServer::processPaymentRequest(PaymentRequestPlus& request, QList<Sen
     if (request.getMerchant(PaymentServer::certStore, recipients[0].authenticatedMerchant)) {
         recipients[0].paymentRequest = request;
         recipients[0].amount = totalAmount;
-        if (fDebug)
-            qDebug() << "PaymentServer::processPaymentRequest : Payment request from " << recipients[0].authenticatedMerchant;
+        qDebug() << "PaymentServer::processPaymentRequest : Payment request from " << recipients[0].authenticatedMerchant;
     }
     else {
         recipients.clear();
@@ -493,8 +488,7 @@ bool PaymentServer::processPaymentRequest(PaymentRequestPlus& request, QList<Sen
                 if (i == 0) // Tie request to first pay-to, we don't want multiple ACKs
                     recipients[i].paymentRequest = request;
                 recipients[i].address = QString::fromStdString(CBitcoinAddress(dest).ToString());
-                if (fDebug)
-                    qDebug() << "PaymentServer::processPaymentRequest : Payment request, insecure " << recipients[i].address;
+                qDebug() << "PaymentServer::processPaymentRequest : Payment request, insecure " << recipients[i].address;
             }
             else {
                 // Insecure payments to custom bitcoin addresses are not supported

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -73,7 +73,6 @@ using namespace std;
 map<string, string> mapArgs;
 map<string, vector<string> > mapMultiArgs;
 bool fDebug = false;
-bool fDebugNet = false;
 bool fPrintToConsole = false;
 bool fPrintToDebugger = false;
 bool fDaemon = false;
@@ -226,10 +225,20 @@ int LogPrint(const char* category, const char* pszFormat, ...)
 {
     if (category != NULL)
     {
-        if (!fDebug) return 0;
-        const vector<string>& categories = mapMultiArgs["-debug"];
-        if (find(categories.begin(), categories.end(), string(category)) == categories.end())
+        if (!fDebug)
             return 0;
+
+        const vector<string>& categories = mapMultiArgs["-debug"];
+        bool allCategories = count(categories.begin(), categories.end(), string(""));
+
+        // Only look for categories, if not -debug/-debug=1 was passed,
+        // as that implies every category should be logged.
+        if (!allCategories)
+        {
+            // Category was not found (not supplied via -debug=<category>)
+            if (find(categories.begin(), categories.end(), string(category)) == categories.end())
+                return 0;
+        }
     }
 
     int ret = 0; // Returns total number of characters written

--- a/src/util.h
+++ b/src/util.h
@@ -140,7 +140,6 @@ inline void MilliSleep(int64 n)
 extern std::map<std::string, std::string> mapArgs;
 extern std::map<std::string, std::vector<std::string> > mapMultiArgs;
 extern bool fDebug;
-extern bool fDebugNet;
 extern bool fPrintToConsole;
 extern bool fPrintToDebugger;
 extern bool fDaemon;


### PR DESCRIPTION
- re-work -debug help message text
- make -debug log every debugging information again (even all categories)
- remove unneeded fDebug checks in front of LogPrint()/qDebug(), as that
  check is done in LogPrintf() when category is != NULL (true for all
  LogPrint() calls
- remove fDebug ONLY in code which is NOT performance-critical
- harmonize addrman category name
- deprecate -debugnet usage, should be used via -debug=net and remove the
  corresponding global
