### PR TITLE
Remove include of windows.h from allocators.h

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -31,7 +31,7 @@ obj/build.h: FORCE
 	  $(abs_top_srcdir)
 version.o: obj/build.h
 
-libbitcoin_a_SOURCES = addrman.cpp alert.cpp bitcoinrpc.cpp bloom.cpp \
+libbitcoin_a_SOURCES = addrman.cpp alert.cpp allocators.cpp bitcoinrpc.cpp bloom.cpp \
   chainparams.cpp checkpoints.cpp core.cpp crypter.cpp db.cpp hash.cpp \
   init.cpp key.cpp keystore.cpp leveldb.cpp main.cpp miner.cpp \
   netbase.cpp net.cpp noui.cpp protocol.cpp rpcblockchain.cpp rpcdump.cpp \

--- a/src/allocators.cpp
+++ b/src/allocators.cpp
@@ -1,0 +1,64 @@
+// Copyright (c) 2009-2013 The Bitcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "allocators.h"
+
+#ifdef WIN32
+#ifdef _WIN32_WINNT
+#undef _WIN32_WINNT
+#endif
+#define _WIN32_WINNT 0x0501
+#define WIN32_LEAN_AND_MEAN 1
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+// This is used to attempt to keep keying material out of swap
+// Note that VirtualLock does not provide this as a guarantee on Windows,
+// but, in practice, memory that has been VirtualLock'd almost never gets written to
+// the pagefile except in rare circumstances where memory is extremely low.
+#else
+#include <sys/mman.h>
+#include <limits.h> // for PAGESIZE
+#include <unistd.h> // for sysconf
+#endif
+
+/** Determine system page size in bytes */
+static inline size_t GetSystemPageSize()
+{
+    size_t page_size;
+#if defined(WIN32)
+    SYSTEM_INFO sSysInfo;
+    GetSystemInfo(&sSysInfo);
+    page_size = sSysInfo.dwPageSize;
+#elif defined(PAGESIZE) // defined in limits.h
+    page_size = PAGESIZE;
+#else // assume some POSIX OS
+    page_size = sysconf(_SC_PAGESIZE);
+#endif
+    return page_size;
+}
+
+bool MemoryPageLocker::Lock(const void *addr, size_t len)
+{
+#ifdef WIN32
+    return VirtualLock(const_cast<void*>(addr), len);
+#else
+    return mlock(addr, len) == 0;
+#endif
+}
+
+bool MemoryPageLocker::Unlock(const void *addr, size_t len)
+{
+#ifdef WIN32
+    return VirtualUnlock(const_cast<void*>(addr), len);
+#else
+    return munlock(addr, len) == 0;
+#endif
+}
+
+LockedPageManager::LockedPageManager() : LockedPageManagerBase<MemoryPageLocker>(GetSystemPageSize())
+{
+}
+

--- a/src/allocators.h
+++ b/src/allocators.h
@@ -11,25 +11,6 @@
 #include <map>
 #include <openssl/crypto.h> // for OPENSSL_cleanse()
 
-#ifdef WIN32
-#ifdef _WIN32_WINNT
-#undef _WIN32_WINNT
-#endif
-#define _WIN32_WINNT 0x0501
-#define WIN32_LEAN_AND_MEAN 1
-#ifndef NOMINMAX
-#define NOMINMAX
-#endif
-#include <windows.h>
-// This is used to attempt to keep keying material out of swap
-// Note that VirtualLock does not provide this as a guarantee on Windows,
-// but, in practice, memory that has been VirtualLock'd almost never gets written to
-// the pagefile except in rare circumstances where memory is extremely low.
-#else
-#include <sys/mman.h>
-#include <limits.h> // for PAGESIZE
-#include <unistd.h> // for sysconf
-#endif
 
 /**
  * Thread-safe class to keep track of locked (ie, non-swappable) memory pages.
@@ -115,21 +96,6 @@ private:
     Histogram histogram;
 };
 
-/** Determine system page size in bytes */
-static inline size_t GetSystemPageSize()
-{
-    size_t page_size;
-#if defined(WIN32)
-    SYSTEM_INFO sSysInfo;
-    GetSystemInfo(&sSysInfo);
-    page_size = sSysInfo.dwPageSize;
-#elif defined(PAGESIZE) // defined in limits.h
-    page_size = PAGESIZE;
-#else // assume some POSIX OS
-    page_size = sysconf(_SC_PAGESIZE);
-#endif
-    return page_size;
-}
 
 /**
  * OS-dependent memory page locking/unlocking.
@@ -141,25 +107,11 @@ public:
     /** Lock memory pages.
      * addr and len must be a multiple of the system page size
      */
-    bool Lock(const void *addr, size_t len)
-    {
-#ifdef WIN32
-        return VirtualLock(const_cast<void*>(addr), len);
-#else
-        return mlock(addr, len) == 0;
-#endif
-    }
+    bool Lock(const void *addr, size_t len);
     /** Unlock memory pages.
      * addr and len must be a multiple of the system page size
      */
-    bool Unlock(const void *addr, size_t len)
-    {
-#ifdef WIN32
-        return VirtualUnlock(const_cast<void*>(addr), len);
-#else
-        return munlock(addr, len) == 0;
-#endif
-    }
+    bool Unlock(const void *addr, size_t len);
 };
 
 /**
@@ -171,9 +123,7 @@ class LockedPageManager: public LockedPageManagerBase<MemoryPageLocker>
 public:
     static LockedPageManager instance; // instantiated in util.cpp
 private:
-    LockedPageManager():
-        LockedPageManagerBase<MemoryPageLocker>(GetSystemPageSize())
-    {}
+    LockedPageManager();
 };
 
 //


### PR DESCRIPTION
Create an allocators.cpp, and move all of the #ifdef WIN32
code and the #include of windows.h into it.

Two motives for this cleanup:
1. I'm getting a weird error in windows.h in my smartfee branch.
2. allocators.h is included (indirectly) just about everywhere, so
this should speed up Windows compiles quite a lot.
