### PR TITLE
Remove automatic update of default key

### DIFF
--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -483,25 +483,6 @@ bool CWallet::AddToWallet(const CWalletTx& wtxIn)
             if (!wtx.WriteToDisk())
                 return false;
 
-        if (!fHaveGUI) {
-            // If default receiving address gets used, replace it with a new one
-            if (vchDefaultKey.IsValid()) {
-                CScript scriptDefaultKey;
-                scriptDefaultKey.SetDestination(vchDefaultKey.GetID());
-                BOOST_FOREACH(const CTxOut& txout, wtx.vout)
-                {
-                    if (txout.scriptPubKey == scriptDefaultKey)
-                    {
-                        CPubKey newDefaultKey;
-                        if (GetKeyFromPool(newDefaultKey))
-                        {
-                            SetDefaultKey(newDefaultKey);
-                            SetAddressBook(vchDefaultKey.GetID(), "", "receive");
-                        }
-                    }
-                }
-            }
-        }
         // since AddToWallet is called directly for self-originating transactions, check for consumption of own coins
         WalletUpdateSpent(wtx);
 


### PR DESCRIPTION
This equalizes the behavior between the GUI and bitcoind and removes the last usage of fHaveGui (the other is removed in #3072).

The commit doesn't completely remove default key functionality but removes the code that sets a new default key after a transaction when it received coins.
Completely removing default key functionality is not that easy because it is used as stopgap in a few places
- https://github.com/bitcoin/bitcoin/blob/master/src/wallet.cpp#L1453 (in `CWallet::LoadWallet`) to determine whether this is the first run with this wallet.
- https://github.com/bitcoin/bitcoin/blob/master/src/wallet.cpp#L1837 (in `CReserveKey::GetReservedKey`) to return something when the keys are exhausted and keypool should be topped up

However these stopgaps are not affected by this change. There will still be an initial default key, it will just never change.
