### PR TITLE
Bitcoin-Qt: misc changes for sendcoins and paymentsever

### DIFF
--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -48,6 +48,7 @@ const int BITCOIN_IPC_CONNECT_TIMEOUT = 1000; // milliseconds
 const QString BITCOIN_IPC_PREFIX("bitcoin:");
 const char* BITCOIN_REQUEST_MIMETYPE = "application/bitcoin-paymentrequest";
 const char* BITCOIN_PAYMENTACK_MIMETYPE = "application/bitcoin-paymentack";
+const char* BITCOIN_PAYMENTACK_CONTENTTYPE = "application/bitcoin-payment";
 
 X509_STORE* PaymentServer::certStore = NULL;
 void PaymentServer::freeCertStore()
@@ -471,11 +472,7 @@ bool PaymentServer::processPaymentRequest(PaymentRequestPlus& request, QList<Sen
             recipients.append(SendCoinsRecipient());
             recipients[i].amount = sendingTo.second;
             QString memo = QString::fromStdString(request.getDetails().memo());
-#if QT_VERSION < 0x050000
-            recipients[i].label = Qt::escape(memo);
-#else
-            recipients[i].label = memo.toHtmlEscaped();
-#endif
+            recipients[i].label = GUIUtil::HtmlEscape(memo);
             CTxDestination dest;
             if (ExtractDestination(sendingTo.first, dest)) {
                 if (i == 0) // Tie request to first pay-to, we don't want multiple ACKs
@@ -518,7 +515,7 @@ void PaymentServer::fetchPaymentACK(CWallet* wallet, SendCoinsRecipient recipien
     QNetworkRequest netRequest;
     netRequest.setAttribute(QNetworkRequest::User, "PaymentACK");
     netRequest.setUrl(QString::fromStdString(details.payment_url()));
-    netRequest.setHeader(QNetworkRequest::ContentTypeHeader, "application/bitcoin-payment");
+    netRequest.setHeader(QNetworkRequest::ContentTypeHeader, BITCOIN_PAYMENTACK_CONTENTTYPE);
     netRequest.setRawHeader("User-Agent", CLIENT_NAME.c_str());
     netRequest.setRawHeader("Accept", BITCOIN_PAYMENTACK_MIMETYPE);
 

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -365,9 +365,8 @@ bool SendCoinsDialog::handlePaymentRequest(const SendCoinsRecipient &rv)
     else {
         CBitcoinAddress address(rv.address.toStdString());
         if (!address.IsValid()) {
-            QString strAddress(address.ToString().c_str());
             QMessageBox::warning(this, strSendCoins,
-                tr("Invalid payment address %1").arg(strAddress));
+                tr("Invalid payment address %1").arg(rv.address));
             return false;
         }
     }

--- a/src/qt/sendcoinsentry.cpp
+++ b/src/qt/sendcoinsentry.cpp
@@ -85,10 +85,17 @@ void SendCoinsEntry::setRemoveEnabled(bool enabled)
 
 void SendCoinsEntry::clear()
 {
+    // clear UI elements for insecure payments
     ui->payTo->clear();
     ui->addAsLabel->clear();
     ui->payAmount->clear();
+    // and the ones for secure payments just to be sure
+    ui->payTo_s->clear();
+    ui->memoTextLabel_s->clear();
+    ui->payAmount_s->clear();
+
     ui->payTo->setFocus();
+
     // update the display unit, to not use the default ("BTC")
     updateDisplayUnit();
 }
@@ -154,17 +161,19 @@ void SendCoinsEntry::setValue(const SendCoinsRecipient &value)
 {
     recipient = value;
 
-    ui->payTo->setText(value.address);
-    ui->addAsLabel->setText(value.label);
-    ui->payAmount->setValue(value.amount);
-
-    if (!recipient.authenticatedMerchant.isEmpty())
+    if (recipient.authenticatedMerchant.isEmpty())
     {
-        const payments::PaymentDetails& details = value.paymentRequest.getDetails();
+        ui->payTo->setText(recipient.address);
+        ui->addAsLabel->setText(recipient.label);
+        ui->payAmount->setValue(recipient.amount);
+    }
+    else
+    {
+        const payments::PaymentDetails& details = recipient.paymentRequest.getDetails();
 
-        ui->payTo_s->setText(value.authenticatedMerchant);
+        ui->payTo_s->setText(recipient.authenticatedMerchant);
         ui->memoTextLabel_s->setText(QString::fromStdString(details.memo()));
-        ui->payAmount_s->setValue(value.amount);
+        ui->payAmount_s->setValue(recipient.amount);
         setCurrentWidget(ui->SendCoinsSecure);
     }
 }


### PR DESCRIPTION
sendcoinsentry: small clear() and setValue() changes
- clear(): clear all UI elements (for secure and insecure payments)
- setValue(): only modify UI elements, which need to be set (for secure
  or insecure payments)

sendcoinsdialog: display real failed address string
- display the real string (faulty address), which causes the valid address
  check to fail, instead of a stringified "nonsense" CBitcoinAddress

paymentserver: use own HTML-esc / add new header const
- make processPaymentRequest() use our own HTML-escaping function from
  GUIUtil
- make string "application/bitcoin-payment" a constant (below similar
  constant strings in the .cpp file)
