### PR TITLE
prevent compiler redefinition warnings

### DIFF
--- a/src/compat.h
+++ b/src/compat.h
@@ -6,10 +6,16 @@
 #define _BITCOIN_COMPAT_H
 
 #ifdef WIN32
+#ifdef _WIN32_WINNT
+#undef _WIN32_WINNT
+#endif
 #define _WIN32_WINNT 0x0501
 #define WIN32_LEAN_AND_MEAN 1
 #ifndef NOMINMAX
 #define NOMINMAX
+#endif
+#ifdef FD_SETSIZE
+#undef FD_SETSIZE // prevent redefinition compiler warning
 #endif
 #define FD_SETSIZE 1024 // max number of fds in fd_set
 #include <winsock2.h>


### PR DESCRIPTION
- I observed a massive amount of redefinition warnings after #3071, which
  are silenced by this patch
- uses the same style as we do in other places, where we define `_WIN32_WINNT`
