### PR TITLE
CBlockLocator improvements & move to core

### DIFF
--- a/src/core.h
+++ b/src/core.h
@@ -661,4 +661,38 @@ public:
     void print() const;
 };
 
+
+/** Describes a place in the block chain to another node such that if the
+ * other node doesn't have the same branch, it can find a recent common trunk.
+ * The further back it is, the further before the fork it may be.
+ */
+struct CBlockLocator
+{
+    std::vector<uint256> vHave;
+
+    CBlockLocator() {}
+
+    CBlockLocator(const std::vector<uint256>& vHaveIn)
+    {
+        vHave = vHaveIn;
+    }
+
+    IMPLEMENT_SERIALIZE
+    (
+        if (!(nType & SER_GETHASH))
+            READWRITE(nVersion);
+        READWRITE(vHave);
+    )
+
+    void SetNull()
+    {
+        vHave.clear();
+    }
+
+    bool IsNull()
+    {
+        return vHave.empty();
+    }
+};
+
 #endif

--- a/src/db.h
+++ b/src/db.h
@@ -16,7 +16,7 @@
 #include <db_cxx.h>
 
 class CAddrMan;
-class CBlockLocator;
+struct CBlockLocator;
 class CDiskBlockIndex;
 class CMasterKey;
 class COutPoint;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -116,7 +116,7 @@ void Shutdown()
     {
         LOCK(cs_main);
         if (pwalletMain)
-            pwalletMain->SetBestChain(CBlockLocator(chainActive.Tip()));
+            pwalletMain->SetBestChain(chainActive.GetLocator());
         if (pblocktree)
             pblocktree->Flush();
         if (pcoinsTip)
@@ -912,7 +912,7 @@ bool AppInit2(boost::thread_group& threadGroup)
                 strErrors << _("Cannot write default address") << "\n";
         }
 
-        pwalletMain->SetBestChain(CBlockLocator(chainActive.Tip()));
+        pwalletMain->SetBestChain(chainActive.GetLocator());
     }
 
     LogPrintf("%s", strErrors.str().c_str());
@@ -928,7 +928,7 @@ bool AppInit2(boost::thread_group& threadGroup)
         CWalletDB walletdb(strWalletFile);
         CBlockLocator locator;
         if (walletdb.ReadBestBlock(locator))
-            pindexRescan = locator.GetBlockIndex();
+            pindexRescan = chainActive.FindFork(locator);
         else
             pindexRescan = chainActive.Genesis();
     }
@@ -939,7 +939,7 @@ bool AppInit2(boost::thread_group& threadGroup)
         nStart = GetTimeMillis();
         pwalletMain->ScanForWalletTransactions(pindexRescan, true);
         LogPrintf(" rescan      %15"PRI64d"ms\n", GetTimeMillis() - nStart);
-        pwalletMain->SetBestChain(CBlockLocator(chainActive.Tip()));
+        pwalletMain->SetBestChain(chainActive.GetLocator());
         nWalletDBUpdated++;
     }
 

--- a/src/main.h
+++ b/src/main.h
@@ -22,7 +22,6 @@ class CBlock;
 class CBlockIndex;
 class CKeyItem;
 class CReserveKey;
-class CBlockLocator;
 
 class CAddress;
 class CInv;
@@ -1045,43 +1044,6 @@ public:
 /** The currently-connected chain of blocks. */
 extern CChain chainActive;
 
-
-
-/** Describes a place in the block chain to another node such that if the
- * other node doesn't have the same branch, it can find a recent common trunk.
- * The further back it is, the further before the fork it may be.
- */
-class CBlockLocator
-{
-protected:
-    std::vector<uint256> vHave;
-public:
-    CBlockLocator() {}
-
-    CBlockLocator(const std::vector<uint256>& vHaveIn)
-    {
-        vHave = vHaveIn;
-    }
-
-    IMPLEMENT_SERIALIZE
-    (
-        if (!(nType & SER_GETHASH))
-            READWRITE(nVersion);
-        READWRITE(vHave);
-    )
-
-    void SetNull()
-    {
-        vHave.clear();
-    }
-
-    bool IsNull()
-    {
-        return vHave.empty();
-    }
-
-    friend class CChain;
-};
 
 
 

--- a/src/main.h
+++ b/src/main.h
@@ -22,6 +22,7 @@ class CBlock;
 class CBlockIndex;
 class CKeyItem;
 class CReserveKey;
+class CBlockLocator;
 
 class CAddress;
 class CInv;
@@ -1033,6 +1034,12 @@ public:
 
     /** Set/initialize a chain with a given tip. Returns the forking point. */
     CBlockIndex *SetTip(CBlockIndex *pindex);
+
+    /** Return a CBlockLocator that refers to a block in this chain (by default the tip). */
+    CBlockLocator GetLocator(const CBlockIndex *pindex = NULL) const;
+
+    /** Find the last common block between this chain and a locator. */
+    CBlockIndex *FindFork(const CBlockLocator &locator) const;
 };
 
 /** The currently-connected chain of blocks. */
@@ -1050,13 +1057,6 @@ protected:
     std::vector<uint256> vHave;
 public:
     CBlockLocator() {}
-
-    explicit CBlockLocator(const CBlockIndex* pindex)
-    {
-        Set(pindex);
-    }
-
-    explicit CBlockLocator(uint256 hashBlock);
 
     CBlockLocator(const std::vector<uint256>& vHaveIn)
     {
@@ -1080,16 +1080,7 @@ public:
         return vHave.empty();
     }
 
-    /** Given a block initialises the locator to that point in the chain. */
-    void Set(const CBlockIndex* pindex);
-    /** Returns the distance in blocks this locator is from our chain head. */
-    int GetDistanceBack();
-    /** Returns the first best-chain block the locator contains. */
-    CBlockIndex* GetBlockIndex();
-    /** Returns the hash of the first best chain block the locator contains. */
-    uint256 GetBlockHash();
-    /** Returns the height of the first best chain block the locator has. */
-    int GetHeight();
+    friend class CChain;
 };
 
 

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -1169,7 +1169,9 @@ Value listsinceblock(const Array& params, bool fHelp)
         uint256 blockId = 0;
 
         blockId.SetHex(params[0].get_str());
-        pindex = CBlockLocator(blockId).GetBlockIndex();
+        std::map<uint256, CBlockIndex*>::iterator it = mapBlockIndex.find(blockId);
+        if (it != mapBlockIndex.end())
+            pindex = it->second;
     }
 
     if (params.size() > 1)


### PR DESCRIPTION
This moves the chain-related logic in CBlockLocator to CChain (CBlockLocator is a P2P data structure, its implementation shouldn't depend on validation engine globals), and then moves CBlockLocator itself from main.h to core.h.

This means construction of CBlockLocator objects now happens in O(log nHeight) instead of O(nHeight), as it can use CChain's height-based index.

Depends on #3077.
