### PR TITLE
[net] Don't use third-party "what is my IP" services.

### DIFF
--- a/src/checkpoints.cpp
+++ b/src/checkpoints.cpp
@@ -157,4 +157,19 @@ namespace Checkpoints
         }
         return NULL;
     }
+
+    bool IsInitialBlockDownload()
+    {
+        if (pindexBest == NULL || fImporting || fReindex || nBestHeight < GetTotalBlocksEstimate())
+            return true;
+        static int64 nLastUpdate;
+        static CBlockIndex* pindexLastBest;
+        if (pindexBest != pindexLastBest)
+        {
+            pindexLastBest = pindexBest;
+            nLastUpdate = GetTime();
+        }
+        return (GetTime() - nLastUpdate < 10 &&
+                pindexBest->GetBlockTime() < GetTime() - 24 * 60 * 60);
+    }
 }

--- a/src/checkpoints.h
+++ b/src/checkpoints.h
@@ -26,6 +26,10 @@ namespace Checkpoints
     double GuessVerificationProgress(CBlockIndex *pindex);
 
     extern bool fEnabled;
+
+    /** Check whether we are doing an initial block download (synchronizing from disk or network) */
+    bool IsInitialBlockDownload();
 }
+
 
 #endif

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -329,6 +329,7 @@ void ThreadImport(std::vector<boost::filesystem::path> vImportFiles)
  */
 bool AppInit2(boost::thread_group& threadGroup)
 {
+    nNodeStartTime = GetTime();
     // ********************************************************* Step 1: setup
 #ifdef _MSC_VER
     // Turn off Microsoft heap dump noise
@@ -531,7 +532,7 @@ bool AppInit2(boost::thread_group& threadGroup)
     LogPrintf("Bitcoin version %s (%s)\n", FormatFullVersion().c_str(), CLIENT_DATE.c_str());
     LogPrintf("Using OpenSSL version %s\n", SSLeay_version(SSLEAY_VERSION));
     if (!fLogTimestamps)
-        LogPrintf("Startup time: %s\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()).c_str());
+        LogPrintf("Startup time: %s\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", nNodeStartTime).c_str());
     LogPrintf("Default data directory %s\n", GetDefaultDataDir().string().c_str());
     LogPrintf("Using data directory %s\n", strDataDir.c_str());
     LogPrintf("Using at most %i connections (%i file descriptors available)\n", nMaxConnections, nFD);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1231,7 +1231,7 @@ bool WriteBlockToDisk(CBlock& block, CDiskBlockPos& pos)
 
     // Flush stdio buffers and commit to disk before returning
     fflush(fileout);
-    if (!IsInitialBlockDownload())
+    if (!Checkpoints::IsInitialBlockDownload())
         FileCommit(fileout);
 
     return true;
@@ -1402,21 +1402,6 @@ int GetNumBlocksOfPeers()
     return std::max(cPeerBlockCounts.median(), Checkpoints::GetTotalBlocksEstimate());
 }
 
-bool IsInitialBlockDownload()
-{
-    if (pindexBest == NULL || fImporting || fReindex || nBestHeight < Checkpoints::GetTotalBlocksEstimate())
-        return true;
-    static int64 nLastUpdate;
-    static CBlockIndex* pindexLastBest;
-    if (pindexBest != pindexLastBest)
-    {
-        pindexLastBest = pindexBest;
-        nLastUpdate = GetTime();
-    }
-    return (GetTime() - nLastUpdate < 10 &&
-            pindexBest->GetBlockTime() < GetTime() - 24 * 60 * 60);
-}
-
 bool fLargeWorkForkFound = false;
 bool fLargeWorkInvalidChainFound = false;
 CBlockIndex *pindexBestForkTip = NULL, *pindexBestForkBase = NULL;
@@ -1425,7 +1410,7 @@ void CheckForkWarningConditions()
 {
     // Before we get past initial download, we cannot reliably alert about forks
     // (we assume we don't get stuck on a fork before the last checkpoint)
-    if (IsInitialBlockDownload())
+    if (Checkpoints::IsInitialBlockDownload())
         return;
 
     // If our best fork is no longer within 72 blocks (+/- 12 hours if no one mines it)
@@ -2110,7 +2095,7 @@ bool SetBestChain(CValidationState &state, CBlockIndex* pindexNew)
         LogPrintf("- Flush %i transactions: %.2fms (%.4fms/tx)\n", nModified, 0.001 * nTime, 0.001 * nTime / nModified);
 
     // Make sure it's successfully written to disk before changing memory structure
-    bool fIsInitialDownload = IsInitialBlockDownload();
+    bool fIsInitialDownload = Checkpoints::IsInitialBlockDownload();
     if (!fIsInitialDownload || pcoinsTip->GetCacheSize() > nCoinCacheSize) {
         // Typical CCoins structures on disk are around 100 bytes in size.
         // Pushing a new one to the database can cause it to be written
@@ -3431,6 +3416,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
         else
             pfrom->fRelayTxes = true;
 
+        pfrom->addrMe = addrMe;
         if (pfrom->fInbound && addrMe.IsRoutable())
         {
             pfrom->addrLocal = addrMe;
@@ -3460,12 +3446,8 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
         if (!pfrom->fInbound)
         {
             // Advertise our address
-            if (!fNoListen && !IsInitialBlockDownload())
-            {
-                CAddress addr = GetLocalAddress(&pfrom->addr);
-                if (addr.IsRoutable())
-                    pfrom->PushAddress(addr);
-            }
+            if (!fNoListen && !Checkpoints::IsInitialBlockDownload())
+                AdvertizeLocalNode(pfrom, true);
 
             // Get recent addresses
             if (pfrom->fOneShot || pfrom->nVersion >= CADDR_TIME_VERSION || addrman.size() < 1000)
@@ -4103,14 +4085,14 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
         // Resend wallet transactions that haven't gotten in a block yet
         // Except during reindex, importing and IBD, when old wallet
         // transactions become unconfirmed and spams other nodes.
-        if (!fReindex && !fImporting && !IsInitialBlockDownload())
+        if (!fReindex && !fImporting && !Checkpoints::IsInitialBlockDownload())
         {
             ResendWalletTransactions();
         }
 
         // Address refresh broadcast
         static int64 nLastRebroadcast;
-        if (!IsInitialBlockDownload() && (GetTime() - nLastRebroadcast > 24 * 60 * 60))
+        if (!Checkpoints::IsInitialBlockDownload() && (GetTime() - nLastRebroadcast > 24 * 60 * 60) && (GetTime() - nNodeStartTime > 60 * 60))
         {
             {
                 LOCK(cs_vNodes);
@@ -4122,11 +4104,7 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
 
                     // Rebroadcast our address
                     if (!fNoListen)
-                    {
-                        CAddress addr = GetLocalAddress(&pnode->addr);
-                        if (addr.IsRoutable())
-                            pnode->PushAddress(addr);
-                    }
+                        AdvertizeLocalNode(pnode,true);
                 }
             }
             nLastRebroadcast = GetTime();

--- a/src/main.h
+++ b/src/main.h
@@ -14,6 +14,7 @@
 #include "sync.h"
 #include "net.h"
 #include "script.h"
+#include "checkpoints.h"
 
 #include <list>
 
@@ -167,8 +168,6 @@ bool CheckProofOfWork(uint256 hash, unsigned int nBits);
 unsigned int ComputeMinWork(unsigned int nBase, int64 nTime);
 /** Get the number of active peers */
 int GetNumBlocksOfPeers();
-/** Check whether we are doing an initial block download (synchronizing from disk or network) */
-bool IsInitialBlockDownload();
 /** Format a string that describes several potential problems detected by the core */
 std::string GetWarnings(std::string strFor);
 /** Retrieve a transaction (from memory pool, or from disk, if possible) */
@@ -365,7 +364,7 @@ public:
 
         // Flush stdio buffers and commit to disk before returning
         fflush(fileout);
-        if (!IsInitialBlockDownload())
+        if (!Checkpoints::IsInitialBlockDownload())
             FileCommit(fileout);
 
         return true;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -14,6 +14,7 @@
 #include "addrman.h"
 #include "ui_interface.h"
 #include "script.h"
+#include "checkpoints.h"
 
 #ifdef WIN32
 #include <string.h>
@@ -64,6 +65,7 @@ uint64 nLocalHostNonce = 0;
 static std::vector<SOCKET> vhListenSocket;
 CAddrMan addrman;
 int nMaxConnections = 125;
+int64 nNodeStartTime;
 
 vector<CNode*> vNodes;
 CCriticalSection cs_vNodes;
@@ -187,22 +189,49 @@ bool RecvLine(SOCKET hSocket, string& strLine)
     }
 }
 
+bool static HasSeenLocal(const CService& addr)
+{
+    LOCK(cs_mapLocalHost);
+    if (mapLocalHost.count(addr) == 0)
+      return false;
+    return mapLocalHost[addr].nScore > 1;
+}
+
+void AdvertizeLocalNode(CNode* pnode, bool fForce)
+{
+    // If our routably addressed peer claims a routable address for
+    // us on a network we support and we are open to discovery and
+    // are listening on the default port, and we either don't know
+    // our address or seems to not be working we'll tell just that
+    // peer the address it sees for us.
+    CAddress addrLocal = GetLocalAddress(&pnode->addr);
+    if (fDiscover && pnode->addr.IsRoutable() && pnode->addrMe.IsRoutable() && pnode->addrMe != addrLocal &&
+        GetListenPort() == Params().GetDefaultPort() && !IsLimited(pnode->addrMe.GetNetwork()) &&
+        (!addrLocal.IsRoutable() || ((GetTime() - nNodeStartTime > 60 * 60) && GetRand(4) == 0 && !HasSeenLocal(addrLocal))))
+    {
+        addrLocal = CAddress(pnode->addrMe);
+        addrLocal.SetPort(GetListenPort());
+    }
+    if (addrLocal.IsRoutable() && (fForce || (CService)addrLocal != (CService)pnode->addrLocal))
+    {
+        pnode->PushAddress(addrLocal);
+        pnode->addrLocal = addrLocal;
+    }
+}
+
 // used when scores of local addresses may have changed
 // pushes better local address to peers
 void static AdvertizeLocal()
 {
+    if (fNoListen)
+        return;
+    if (Checkpoints::IsInitialBlockDownload())
+        return;
     LOCK(cs_vNodes);
     BOOST_FOREACH(CNode* pnode, vNodes)
     {
         if (pnode->fSuccessfullyConnected)
-        {
-            CAddress addrLocal = GetLocalAddress(&pnode->addr);
-            if (addrLocal.IsRoutable() && (CService)addrLocal != (CService)pnode->addrLocal)
-            {
-                pnode->PushAddress(addrLocal);
-                pnode->addrLocal = addrLocal;
-            }
-        }
+            AdvertizeLocalNode(pnode);
     }
 }
 
@@ -299,135 +328,11 @@ bool IsReachable(const CNetAddr& addr)
     return vfReachable[net] && !vfLimited[net];
 }
 
-bool GetMyExternalIP2(const CService& addrConnect, const char* pszGet, const char* pszKeyword, CNetAddr& ipRet)
-{
-    SOCKET hSocket;
-    if (!ConnectSocket(addrConnect, hSocket))
-        return error("GetMyExternalIP() : connection to %s failed", addrConnect.ToString().c_str());
-
-    send(hSocket, pszGet, strlen(pszGet), MSG_NOSIGNAL);
-
-    string strLine;
-    while (RecvLine(hSocket, strLine))
-    {
-        if (strLine.empty()) // HTTP response is separated from headers by blank line
-        {
-            while (true)
-            {
-                if (!RecvLine(hSocket, strLine))
-                {
-                    closesocket(hSocket);
-                    return false;
-                }
-                if (pszKeyword == NULL)
-                    break;
-                if (strLine.find(pszKeyword) != string::npos)
-                {
-                    strLine = strLine.substr(strLine.find(pszKeyword) + strlen(pszKeyword));
-                    break;
-                }
-            }
-            closesocket(hSocket);
-            if (strLine.find("<") != string::npos)
-                strLine = strLine.substr(0, strLine.find("<"));
-            strLine = strLine.substr(strspn(strLine.c_str(), " \t\n\r"));
-            while (strLine.size() > 0 && isspace(strLine[strLine.size()-1]))
-                strLine.resize(strLine.size()-1);
-            CService addr(strLine,0,true);
-            LogPrintf("GetMyExternalIP() received [%s] %s\n", strLine.c_str(), addr.ToString().c_str());
-            if (!addr.IsValid() || !addr.IsRoutable())
-                return false;
-            ipRet.SetIP(addr);
-            return true;
-        }
-    }
-    closesocket(hSocket);
-    return error("GetMyExternalIP() : connection closed");
-}
-
-bool GetMyExternalIP(CNetAddr& ipRet)
-{
-    CService addrConnect;
-    const char* pszGet;
-    const char* pszKeyword;
-
-    for (int nLookup = 0; nLookup <= 1; nLookup++)
-    for (int nHost = 1; nHost <= 2; nHost++)
-    {
-        // We should be phasing out our use of sites like these. If we need
-        // replacements, we should ask for volunteers to put this simple
-        // php file on their web server that prints the client IP:
-        //  <?php echo $_SERVER["REMOTE_ADDR"]; ?>
-        if (nHost == 1)
-        {
-            addrConnect = CService("91.198.22.70", 80); // checkip.dyndns.org
-
-            if (nLookup == 1)
-            {
-                CService addrIP("checkip.dyndns.org", 80, true);
-                if (addrIP.IsValid())
-                    addrConnect = addrIP;
-            }
-
-            pszGet = "GET / HTTP/1.1\r\n"
-                     "Host: checkip.dyndns.org\r\n"
-                     "User-Agent: Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1)\r\n"
-                     "Connection: close\r\n"
-                     "\r\n";
-
-            pszKeyword = "Address:";
-        }
-        else if (nHost == 2)
-        {
-            addrConnect = CService("74.208.43.192", 80); // www.showmyip.com
-
-            if (nLookup == 1)
-            {
-                CService addrIP("www.showmyip.com", 80, true);
-                if (addrIP.IsValid())
-                    addrConnect = addrIP;
-            }
-
-            pszGet = "GET /simple/ HTTP/1.1\r\n"
-                     "Host: www.showmyip.com\r\n"
-                     "User-Agent: Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1)\r\n"
-                     "Connection: close\r\n"
-                     "\r\n";
-
-            pszKeyword = NULL; // Returns just IP address
-        }
-
-        if (GetMyExternalIP2(addrConnect, pszGet, pszKeyword, ipRet))
-            return true;
-    }
-
-    return false;
-}
-
-void ThreadGetMyExternalIP()
-{
-    CNetAddr addrLocalHost;
-    if (GetMyExternalIP(addrLocalHost))
-    {
-        LogPrintf("GetMyExternalIP() returned %s\n", addrLocalHost.ToStringIP().c_str());
-        AddLocal(addrLocalHost, LOCAL_HTTP);
-    }
-}
-
-
-
-
 
 void AddressCurrentlyConnected(const CService& addr)
 {
     addrman.Connected(addr);
 }
-
-
-
-
-
-
 
 CNode* FindNode(const CNetAddr& ip)
 {
@@ -1702,9 +1607,6 @@ void static Discover()
     }
 #endif
 
-    // Don't use external IPv4 discovery, when -onlynet="IPv6"
-    if (!IsLimited(NET_IPV4))
-        boost::thread(boost::bind(&TraceThread<void (*)()>, "ext-ip", &ThreadGetMyExternalIP));
 }
 
 void StartNode(boost::thread_group& threadGroup)
@@ -1731,7 +1633,7 @@ void StartNode(boost::thread_group& threadGroup)
 
 #ifdef USE_UPNP
     // Map ports with UPnP
-    MapPort(GetBoolArg("-upnp", USE_UPNP));
+    if (!fNoListen && !IsLimited(NET_IPV4)) MapPort(GetBoolArg("-upnp", USE_UPNP));
 #endif
 
     // Send and receive from sockets, accept connections

--- a/src/net.h
+++ b/src/net.h
@@ -30,14 +30,14 @@ class CNode;
 class CBlockIndex;
 extern int nBestHeight;
 
-
+extern int64 nNodeStartTime;
 
 inline unsigned int ReceiveFloodSize() { return 1000*GetArg("-maxreceivebuffer", 5*1000); }
 inline unsigned int SendBufferSize() { return 1000*GetArg("-maxsendbuffer", 1*1000); }
 
 void AddOneShot(std::string strDest);
 bool RecvLine(SOCKET hSocket, std::string& strLine);
-bool GetMyExternalIP(CNetAddr& ipRet);
+void AdvertizeLocalNode(CNode* pnode, bool fForce=false);
 void AddressCurrentlyConnected(const CService& addr);
 CNode* FindNode(const CNetAddr& ip);
 CNode* FindNode(const CService& ip);
@@ -65,7 +65,6 @@ enum
     LOCAL_IF,     // address a local interface listens on
     LOCAL_BIND,   // address explicit bound to
     LOCAL_UPNP,   // address reported by UPnP
-    LOCAL_HTTP,   // address reported by whatismyip.com and similar
     LOCAL_MANUAL, // address explicitly specified (-externalip=)
 
     LOCAL_MAX
@@ -189,6 +188,7 @@ public:
     int64 nTimeConnected;
     CAddress addr;
     std::string addrName;
+    CService addrMe;
     CService addrLocal;
     int nVersion;
     std::string strSubVer;

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -116,7 +116,7 @@ bool ClientModel::isTestNet() const
 
 bool ClientModel::inInitialBlockDownload() const
 {
-    return IsInitialBlockDownload();
+    return Checkpoints::IsInitialBlockDownload();
 }
 
 enum BlockSource ClientModel::getBlockSource() const

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -8,6 +8,7 @@
 #include "init.h"
 #include "miner.h"
 #include "bitcoinrpc.h"
+#include "checkpoints.h"
 
 using namespace json_spirit;
 using namespace std;
@@ -178,7 +179,7 @@ Value getwork(const Array& params, bool fHelp)
     if (vNodes.empty())
         throw JSONRPCError(RPC_CLIENT_NOT_CONNECTED, "Bitcoin is not connected!");
 
-    if (IsInitialBlockDownload())
+    if (Checkpoints::IsInitialBlockDownload())
         throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "Bitcoin is downloading blocks...");
 
     typedef map<uint256, pair<CBlock*, CScript> > mapNewBlock_t;
@@ -320,7 +321,7 @@ Value getblocktemplate(const Array& params, bool fHelp)
     if (vNodes.empty())
         throw JSONRPCError(RPC_CLIENT_NOT_CONNECTED, "Bitcoin is not connected!");
 
-    if (IsInitialBlockDownload())
+    if (Checkpoints::IsInitialBlockDownload())
         throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "Bitcoin is downloading blocks...");
 
     // Update block


### PR DESCRIPTION
This patch eliminates the privacy and reliability problematic use
of centralized web services for discovering the node's addresses
for advertisement.

The Bitcoin protocol already allows your peers to tell you what
IP they think you have, but this data isn't trustworthy since
they could lie. So the challenge is using it without creating a
DOS vector.

To accomplish this we adopt an approach similar to the one used
by P2Pool:  If we're announcing and don't have a better address
discovered (e.g. via UPNP) or configured we just announce to
each peer the address that peer told us.  Since peers could
already replace, forge, or drop our address messages this cannot
create a new vulnerability... but if even one of our peers is
giving us a good address we'll eventually make a useful
advertisement.
