### PR TITLE
[doc] Add testnet hidden service port to the example tor config.

### DIFF
--- a/doc/tor.md
+++ b/doc/tor.md
@@ -48,6 +48,7 @@ config file):
 
 	HiddenServiceDir /var/lib/tor/bitcoin-service/
 	HiddenServicePort 8333 127.0.0.1:8333
+	HiddenServicePort 18333 127.0.0.1:18333
 
 The directory can be different of course, but (both) port numbers should be equal to
 your bitcoind's P2P listen port (8333 by default).


### PR DESCRIPTION
Seems like there are a lot of advertised testnet HS nodes that
don't actually work. Lack of the testnet port on the example
HS config might be one reason.
