### PR TITLE
make BitcoinAmountField::setReadOnly() usable

### DIFF
--- a/src/qt/bitcoinamountfield.cpp
+++ b/src/qt/bitcoinamountfield.cpp
@@ -130,9 +130,10 @@ void BitcoinAmountField::setValue(qint64 value)
     setText(BitcoinUnits::format(currentUnit, value));
 }
 
-void BitcoinAmountField::setReadOnly(bool fReadeOnly)
+void BitcoinAmountField::setReadOnly(bool fReadOnly)
 {
-    // TODO ...
+    amount->setReadOnly(fReadOnly);
+    unit->setEnabled(!fReadOnly);
 }
 
 void BitcoinAmountField::unitChanged(int idx)

--- a/src/qt/forms/sendcoinsentry.ui
+++ b/src/qt/forms/sendcoinsentry.ui
@@ -621,7 +621,7 @@
        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
       </property>
       <property name="buddy">
-       <cstring>payAmount</cstring>
+       <cstring>payAmount_s</cstring>
       </property>
      </widget>
     </item>
@@ -640,14 +640,8 @@
     </item>
     <item row="5" column="2">
      <widget class="BitcoinAmountField" name="payAmount_s">
-      <property name="enabled">
-       <bool>false</bool>
-      </property>
       <property name="acceptDrops">
        <bool>false</bool>
-      </property>
-      <property name="readOnly">
-       <bool>true</bool>
       </property>
      </widget>
     </item>

--- a/src/qt/sendcoinsentry.cpp
+++ b/src/qt/sendcoinsentry.cpp
@@ -174,6 +174,7 @@ void SendCoinsEntry::setValue(const SendCoinsRecipient &value)
         ui->payTo_s->setText(recipient.authenticatedMerchant);
         ui->memoTextLabel_s->setText(QString::fromStdString(details.memo()));
         ui->payAmount_s->setValue(recipient.amount);
+        ui->payAmount_s->setReadOnly(true);
         setCurrentWidget(ui->SendCoinsSecure);
     }
 }


### PR DESCRIPTION
- use it for secure payment-requests (this change allows a copy&paste of
  the amount and looks a little nicer than just a disabled GUI element)
