### PR TITLE
Broken Link in /Doc README

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -43,7 +43,6 @@ Building
 ---------------------
 The following are developer notes on how to build Bitcoin on your native platform. They are not complete guide, but include notes on the necessary libraries, compile flags, etc.
 
-- [Bitcoin-Qt Readme](readme-qt.md)
 - [OSX Build Notes](build-osx.md)
 - [Unix Build Notes](build-unix.md)
 - [Windows Build Notes](build-msw.md)


### PR DESCRIPTION
#3092 removed readme-qt.md, but it was still listed in the index for the /doc README.
