### PR TITLE
make appbundle target for OSX development

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -81,10 +81,10 @@ OSX_APP_BUILT=$(OSX_APP)/Contents/PkgInfo $(OSX_APP)/Contents/Resources/empty.lp
 
 $(OSX_DMG): $(OSX_APP_BUILT) $(OSX_PACKAGING)
 	$(OSX_DEPLOY_SCRIPT) $(OSX_APP) -add-qt-tr da,de,es,hu,ru,uk,zh_CN,zh_TW -dmg -fancy $(OSX_FANCY_PLIST) -verbose 2
-	rm -rf $(OSX_APP)
 
 
 if TARGET_DARWIN
+appbundle: $(OSX_APP_BUILT)
 deploy: $(OSX_DMG)
 endif
 if TARGET_WINDOWS
@@ -151,9 +151,9 @@ endif
 
 EXTRA_DIST = $(top_srcdir)/share/genbuild.sh qa/pull-tester/pull-tester.sh $(WINDOWS_PACKAGING) $(OSX_PACKAGING)
 
-CLEANFILES = $(OSX_DMG) $(BITCOIN_WIN_INSTALLER)
+CLEANFILES = $(OSX_DMG) $(OSX_APP) $(BITCOIN_WIN_INSTALLER)
 
-.INTERMEDIATE: $(OSX_APP_BUILT) $(COVERAGE_INFO)
+.INTERMEDIATE: $(COVERAGE_INFO)
 
 clean-local:
 	rm -rf test_bitcoin.coverage/ total.coverage/


### PR DESCRIPTION
Adds an 'appbundle' target that creates a top-level Bitcoin-Qt.app/
Modifies the 'deploy' target so that it leaves behind Bitcoin-Qt.app;
make clean will remove it.

This is very useful in combination with http://www.rubicode.com/Software/RCDefaultApp/ for testing payment request handling (I compile a source-tree Bitcoin-Qt.app/ and then use RCDefaultApp so that it is used to handle bitcoin: URIs).
