### PR TITLE
Make -DDEBUGLOCKORDER + -debug less noisy

### DIFF
--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -78,7 +78,7 @@ static void push_lock(void* c, const CLockLocation& locklocation, bool fTry)
     if (lockstack.get() == NULL)
         lockstack.reset(new LockStack);
 
-    if (fDebug) LogPrintf("Locking: %s\n", locklocation.ToString().c_str());
+    LogPrint("lock", "Locking: %s\n", locklocation.ToString().c_str());
     dd_mutex.lock();
 
     (*lockstack).push_back(std::make_pair(c, locklocation));
@@ -108,7 +108,7 @@ static void pop_lock()
     if (fDebug)
     {
         const CLockLocation& locklocation = (*lockstack).rbegin()->second;
-        LogPrintf("Unlocked: %s\n", locklocation.ToString().c_str());
+        LogPrint("lock", "Unlocked: %s\n", locklocation.ToString().c_str());
     }
     dd_mutex.lock();
     (*lockstack).pop_back();


### PR DESCRIPTION
Print out every mutex lock/unlock if compiled -DDEBUGLOCKORDER
only if -debug=lock is set.
