### PR TITLE
Qt: move paymentACK handling to paymentserver

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -331,8 +331,6 @@ int main(int argc, char *argv[])
                                  &window, SLOT(handlePaymentRequest(SendCoinsRecipient)));
                 QObject::connect(&walletModel, SIGNAL(coinsSent(CWallet*,SendCoinsRecipient,QByteArray)),
                                  paymentServer, SLOT(fetchPaymentACK(CWallet*,const SendCoinsRecipient&,QByteArray)));
-                QObject::connect(paymentServer, SIGNAL(receivedPaymentACK(QString)),
-                                 &window, SLOT(showPaymentACK(QString)));
                 QObject::connect(paymentServer, SIGNAL(message(QString,QString,unsigned int)),
                                  guiref, SLOT(message(QString,QString,unsigned int)));
                 QTimer::singleShot(100, paymentServer, SLOT(uiReady()));

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -763,11 +763,6 @@ void BitcoinGUI::handlePaymentRequest(const SendCoinsRecipient& recipient)
     walletFrame->handlePaymentRequest(recipient);
 }
 
-void BitcoinGUI::showPaymentACK(const QString& msg)
-{
-    message(tr("Payment acknowledged"), GUIUtil::HtmlEscape(msg), CClientUIInterface::MODAL);
-}
-
 void BitcoinGUI::setEncryptionStatus(int status)
 {
     switch(status)

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -135,6 +135,7 @@ public slots:
        @param[in] ret       pointer to a bool that will be modified to whether Ok was clicked (modal only)
     */
     void message(const QString &title, const QString &message, unsigned int style, bool *ret = NULL);
+
     /** Asks the user whether to pay the transaction fee or to cancel the transaction.
        It is currently not possible to pass a return value to another thread through
        BlockingQueuedConnection, so an indirected pointer is used.
@@ -146,7 +147,6 @@ public slots:
     void askFee(qint64 nFeeRequired, bool *payFee);
 
     void handlePaymentRequest(const SendCoinsRecipient& recipient);
-    void showPaymentACK(const QString& msg);
 
     /** Show incoming transaction notification for new transactions. */
     void incomingTransaction(const QString& date, int unit, qint64 amount, const QString& type, const QString& address);

--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -258,7 +258,7 @@ PaymentServer::PaymentServer(QObject* parent, bool startLocalServer) : QObject(p
 
     // Install global event filter to catch QFileOpenEvents
     // on Mac: sent when you click bitcoin: links
-    // other OSes: helpful when dealing with payment-request files (in the future)
+    // other OSes: helpful when dealing with payment request files (in the future)
     if (parent)
         parent->installEventFilter(this);
 
@@ -273,8 +273,10 @@ PaymentServer::PaymentServer(QObject* parent, bool startLocalServer) : QObject(p
 
         if (!uriServer->listen(name))
             qDebug() << "PaymentServer::PaymentServer : Cannot start bitcoin: click-to-pay handler";
-        else
+        else {
             connect(uriServer, SIGNAL(newConnection()), this, SLOT(handleURIConnection()));
+            connect(this, SIGNAL(receivedPaymentACK(QString)), this, SLOT(handlePaymentACK(QString)));
+        }
     }
 
     // netManager is null until uiReady() is called
@@ -316,7 +318,7 @@ void PaymentServer::initNetManager()
     // netManager is used to fetch paymentrequests given in bitcoin: URIs
     netManager = new QNetworkAccessManager(this);
 
-    // Use proxy settings from optionsModel:
+    // Use proxy settings from optionsModel
     QString proxyIP;
     quint16 proxyPort;
     if (optionsModel->getProxySettings(proxyIP, proxyPort))
@@ -452,7 +454,7 @@ bool PaymentServer::processPaymentRequest(PaymentRequestPlus& request, QList<Sen
     foreach(const PAIRTYPE(CScript, qint64)& sendingTo, sendingTos) {
         CTxOut txOut(sendingTo.second, sendingTo.first);
         if (txOut.IsDust(CTransaction::nMinRelayTxFee)) {
-            QString msg = QObject::tr("Requested payment amount (%1) too small")
+            QString msg = tr("Requested payment amount of %1 is too small (considered dust).")
                 .arg(BitcoinUnits::formatWithUnit(optionsModel->getDisplayUnit(), sendingTo.second));
 
             qDebug() << "PaymentServer::processPaymentRequest : " << msg;
@@ -532,7 +534,7 @@ void PaymentServer::fetchPaymentACK(CWallet* wallet, SendCoinsRecipient recipien
     payment.add_transactions(transaction.data(), transaction.size());
 
     // Create a new refund address, or re-use:
-    QString account = tr("Refund from") + QString(" ") + recipient.authenticatedMerchant;
+    QString account = tr("Refund from %1").arg(recipient.authenticatedMerchant);
     std::string strAccount = account.toStdString();
     set<CTxDestination> refundAddresses = wallet->GetAccountAddresses(strAccount);
     if (!refundAddresses.empty()) {
@@ -574,9 +576,10 @@ void PaymentServer::netRequestFinished(QNetworkReply* reply)
     reply->deleteLater();
     if (reply->error() != QNetworkReply::NoError)
     {
-        QString msg = QObject::tr("Error communicating with %1: %2")
+        QString msg = tr("Error communicating with %1: %2")
             .arg(reply->request().url().toString())
             .arg(reply->errorString());
+
         qDebug() << "PaymentServer::netRequestFinished : " << msg;
         emit message(tr("Network request error"), msg, CClientUIInterface::MSG_ERROR);
         return;
@@ -590,12 +593,13 @@ void PaymentServer::netRequestFinished(QNetworkReply* reply)
         PaymentRequestPlus request;
         QList<SendCoinsRecipient> recipients;
         if (request.parse(data) && processPaymentRequest(request, recipients)) {
-            foreach (const SendCoinsRecipient& recipient, recipients){
+            foreach (const SendCoinsRecipient& recipient, recipients) {
                 emit receivedPaymentRequest(recipient);
             }
         }
         else
             qDebug() << "PaymentServer::netRequestFinished : Error processing payment request";
+
         return;
     }
     else if (requestType == "PaymentACK")
@@ -603,13 +607,14 @@ void PaymentServer::netRequestFinished(QNetworkReply* reply)
         payments::PaymentACK paymentACK;
         if (!paymentACK.ParseFromArray(data.data(), data.size()))
         {
-            QString msg = QObject::tr("Bad response from server %1")
+            QString msg = tr("Bad response from server %1")
                 .arg(reply->request().url().toString());
+
             qDebug() << "PaymentServer::netRequestFinished : " << msg;
             emit message(tr("Network request error"), msg, CClientUIInterface::MSG_ERROR);
         }
         else {
-            emit receivedPaymentACK(QString::fromStdString(paymentACK.memo()));
+            emit receivedPaymentACK(GUIUtil::HtmlEscape(paymentACK.memo()));
         }
     }
 }
@@ -629,4 +634,10 @@ void PaymentServer::reportSslErrors(QNetworkReply* reply, const QList<QSslError>
 void PaymentServer::setOptionsModel(OptionsModel *optionsModel)
 {
     this->optionsModel = optionsModel;
+}
+
+void PaymentServer::handlePaymentACK(const QString& paymentACKMsg)
+{
+    // currently we don't futher process or store the paymentACK message
+    emit message(tr("Payment acknowledged"), paymentACKMsg, CClientUIInterface::ICON_INFORMATION | CClientUIInterface::MODAL);
 }

--- a/src/qt/paymentserver.h
+++ b/src/qt/paymentserver.h
@@ -88,7 +88,7 @@ signals:
     void receivedPaymentRequest(SendCoinsRecipient);
 
     // Fired when a valid PaymentACK is received
-    void receivedPaymentACK(QString);
+    void receivedPaymentACK(const QString &paymentACKMsg);
 
     // Fired when a message should be reported to the user
     void message(const QString &title, const QString &message, unsigned int style);
@@ -105,6 +105,7 @@ private slots:
     void handleURIConnection();
     void netRequestFinished(QNetworkReply*);
     void reportSslErrors(QNetworkReply*, const QList<QSslError> &);
+    void handlePaymentACK(const QString& paymentACKMsg);
 
 private:
     static bool readPaymentRequest(const QString& filename, PaymentRequestPlus& request);


### PR DESCRIPTION
- add new slot handlePaymentACK() to paymentserver, which handles
  paymentACK messages (currently we just display them)
- make paymentACK message a modal information dialog
- change some QObject::tr() to just tr()
- clarify the processPaymentRequest() error, when IsDust()
- small string change to prevent a tripple + usage with QString
