### PR TITLE
RPC: error code changes and prevent crash with walletpassphrase

### DIFF
--- a/src/bitcoinrpc.h
+++ b/src/bitcoinrpc.h
@@ -49,10 +49,13 @@ enum RPCErrorCode
     RPC_INVALID_PARAMETER           = -8,  // Invalid, missing or duplicate parameter
     RPC_DATABASE_ERROR              = -20, // Database error
     RPC_DESERIALIZATION_ERROR       = -22, // Error parsing or validating structure in raw format
+    RPC_SERVER_NOT_STARTED          = -18, // RPC server was not started (StartRPCThreads() not called)
 
     // P2P client errors
     RPC_CLIENT_NOT_CONNECTED        = -9,  // Bitcoin is not connected
     RPC_CLIENT_IN_INITIAL_DOWNLOAD  = -10, // Still downloading initial blocks
+    RPC_CLIENT_NODE_ALREADY_ADDED   = -23, // Node is already added
+    RPC_CLIENT_NODE_NOT_ADDED       = -24, // Node has not been added before
 
     // Wallet errors
     RPC_WALLET_ERROR                = -4,  // Unspecified problem with wallet (key not found etc.)

--- a/src/rpcnet.cpp
+++ b/src/rpcnet.cpp
@@ -27,7 +27,7 @@ Value ping(const Array& params, bool fHelp)
             "Requests that a ping be sent to all other nodes, to measure ping time.\n"
             "Results provided in getpeerinfo, pingtime and pingwait fields are decimal seconds.\n"
             "Ping command is handled in queue with all other commands, so it measures processing backlog, not just network ping.");
-    
+
     // Request that each node send a ping during next message processing pass
     LOCK(cs_vNodes);
     BOOST_FOREACH(CNode* pNode, vNodes) {
@@ -120,13 +120,13 @@ Value addnode(const Array& params, bool fHelp)
     if (strCommand == "add")
     {
         if (it != vAddedNodes.end())
-            throw JSONRPCError(-23, "Error: Node already added");
+            throw JSONRPCError(RPC_CLIENT_NODE_ALREADY_ADDED, "Error: Node already added");
         vAddedNodes.push_back(strNode);
     }
     else if(strCommand == "remove")
     {
         if (it == vAddedNodes.end())
-            throw JSONRPCError(-24, "Error: Node has not been added.");
+            throw JSONRPCError(RPC_CLIENT_NODE_NOT_ADDED, "Error: Node has not been added.");
         vAddedNodes.erase(it);
     }
 
@@ -163,7 +163,7 @@ Value getaddednodeinfo(const Array& params, bool fHelp)
                 break;
             }
         if (laddedNodes.size() == 0)
-            throw JSONRPCError(-24, "Error: Node has not been added.");
+            throw JSONRPCError(RPC_CLIENT_NODE_NOT_ADDED, "Error: Node has not been added.");
     }
 
     if (!fDns)

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -1271,7 +1271,7 @@ Value keypoolrefill(const Array& params, bool fHelp)
     unsigned int kpSize = max(GetArg("-keypool", 100), 0LL);
     if (params.size() > 0) {
         if (params[0].get_int() < 0)
-            throw JSONRPCError(-8, "Invalid parameter, expected valid size");
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, expected valid size");
         kpSize = (unsigned int) params[0].get_int();
     }
 
@@ -1301,6 +1301,8 @@ Value walletpassphrase(const Array& params, bool fHelp)
             "Stores the wallet decryption key in memory for <timeout> seconds.");
     if (fHelp)
         return true;
+    if (!fServer)
+        throw JSONRPCError(RPC_SERVER_NOT_STARTED, "Error: RPC server was not started, use server=1 to change this.");
     if (!pwalletMain->IsCrypted())
         throw JSONRPCError(RPC_WALLET_WRONG_ENC_STATE, "Error: running with an unencrypted wallet, but walletpassphrase was called.");
 


### PR DESCRIPTION
- fix crash with walletpassphrase by checking if RPC server is running and
  give a friendly error message how to fix this (fixes #3100)
- add 3 new RPCErrorCodes RPC_SERVER_NOT_STARTED, RPC_NODE_ALREADY_ADDED
  and RCP_NODE_NOT_ADDED (I checked the source to not use a number already
  in use for RPC_SERVER_NOT_STARTED)
- use the new codes where needed / missing
- add missing use of RPC_INVALID_PARAMETER
