### PR TITLE
allow emit message() in sendcoinsdialog and walletview

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -752,9 +752,17 @@ bool BitcoinGUI::eventFilter(QObject *object, QEvent *event)
     return QMainWindow::eventFilter(object, event);
 }
 
-void BitcoinGUI::handlePaymentRequest(const SendCoinsRecipient& recipient)
+bool BitcoinGUI::handlePaymentRequest(const SendCoinsRecipient& recipient)
 {
-    walletFrame->handlePaymentRequest(recipient);
+    // URI has to be valid
+    if (walletFrame->handlePaymentRequest(recipient))
+    {
+        showNormalIfMinimized();
+        gotoSendCoinsPage();
+        return true;
+    }
+    else
+        return false;
 }
 
 void BitcoinGUI::setEncryptionStatus(int status)

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -146,7 +146,7 @@ public slots:
     */
     void askFee(qint64 nFeeRequired, bool *payFee);
 
-    void handlePaymentRequest(const SendCoinsRecipient& recipient);
+    bool handlePaymentRequest(const SendCoinsRecipient& recipient);
 
     /** Show incoming transaction notification for new transactions. */
     void incomingTransaction(const QString& date, int unit, qint64 amount, const QString& type, const QString& address);

--- a/src/qt/sendcoinsdialog.h
+++ b/src/qt/sendcoinsdialog.h
@@ -52,6 +52,10 @@ private slots:
     void on_sendButton_clicked();
     void removeEntry(SendCoinsEntry* entry);
     void updateDisplayUnit();
+
+signals:
+    // Fired when a message should be reported to the user
+    void message(const QString &title, const QString &message, unsigned int style);
 };
 
 #endif // SENDCOINSDIALOG_H

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -81,9 +81,15 @@ WalletView::~WalletView()
 void WalletView::setBitcoinGUI(BitcoinGUI *gui)
 {
     this->gui = gui;
-    if(gui)
+
+    if (gui)
     {
+        // Clicking on a transaction on the overview page sends you to the transactions tab
         connect(overviewPage, SIGNAL(transactionClicked(QModelIndex)), gui, SLOT(gotoHistoryPage()));
+
+        // Receive and report messages
+        connect(this, SIGNAL(message(QString,QString,unsigned int)), gui, SLOT(message(QString,QString,unsigned int)));
+        connect(sendCoinsPage, SIGNAL(message(QString,QString,unsigned int)), gui, SLOT(message(QString,QString,unsigned int)));
     }
 }
 
@@ -187,15 +193,7 @@ void WalletView::gotoVerifyMessageTab(QString addr)
 
 bool WalletView::handlePaymentRequest(const SendCoinsRecipient& recipient)
 {
-    // URI has to be valid
-    if (sendCoinsPage->handlePaymentRequest(recipient))
-    {
-        gotoSendCoinsPage();
-        emit showNormalIfMinimized();
-        return true;
-    }
-    else
-        return false;
+    return sendCoinsPage->handlePaymentRequest(recipient);
 }
 
 void WalletView::showOutOfSyncWarning(bool fShow)
@@ -229,12 +227,12 @@ void WalletView::backupWallet()
     QString filename = QFileDialog::getSaveFileName(this, tr("Backup Wallet"), saveDir, tr("Wallet Data (*.dat)"));
     if (!filename.isEmpty()) {
         if (!walletModel->backupWallet(filename)) {
-            gui->message(tr("Backup Failed"), tr("There was an error trying to save the wallet data to the new location."),
-                      CClientUIInterface::MSG_ERROR);
+            emit message(tr("Backup Failed"), tr("There was an error trying to save the wallet data to the new location."),
+                CClientUIInterface::MSG_ERROR);
         }
         else
-            gui->message(tr("Backup Successful"), tr("The wallet data was successfully saved to the new location."),
-                      CClientUIInterface::MSG_INFORMATION);
+            emit message(tr("Backup Successful"), tr("The wallet data was successfully saved to the new location."),
+                CClientUIInterface::MSG_INFORMATION);
     }
 }
 

--- a/src/qt/walletview.h
+++ b/src/qt/walletview.h
@@ -105,6 +105,9 @@ public slots:
 signals:
     /** Signal that we want to show the main window */
     void showNormalIfMinimized();
+
+    /**  Fired when a message should be reported to the user */
+    void message(const QString &title, const QString &message, unsigned int style);
 };
 
 #endif // WALLETVIEW_H


### PR DESCRIPTION
- this allows us to use emit message() over MessageBox:: or gui->message()
  calls in sendcoinsdialog and walletview
- move main handlePaymentRequest() functionality back to BitcoinGUI
- move a showNormalIfMinimized() before gotoSendCoinsPage()
