### PR TITLE
[Qt] additional small fix for #3099 (new receive flow)

### DIFF
--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -68,8 +68,6 @@ WalletView::WalletView(QWidget *parent):
     // Double-clicking on a transaction on the transaction history page shows details
     connect(transactionView, SIGNAL(doubleClicked(QModelIndex)), transactionView, SLOT(showDetails()));
 
-    // Clicking on "Sign Message" in the receive coins page opens the sign message tab in the Sign/Verify Message dialog
-    connect(receiveCoinsPage, SIGNAL(signMessage(QString)), this, SLOT(gotoSignMessageTab(QString)));
     // Clicking on "Export" allows to export the transaction list
     connect(exportButton, SIGNAL(clicked()), transactionView, SLOT(exportClicked()));
 }


### PR DESCRIPTION
- remove an obsolete connection to a signMessage() signal
