### PR TITLE
[Qt] additional small fixes for #3099 (new receive flow)

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -7,14 +7,12 @@
 
 #include "bitcoingui.h"
 
-#include "transactiontablemodel.h"
 #include "optionsdialog.h"
 #include "aboutdialog.h"
 #include "clientmodel.h"
 #include "walletmodel.h"
 #include "walletframe.h"
 #include "optionsmodel.h"
-#include "transactiondescdialog.h"
 #include "bitcoinunits.h"
 #include "guiconstants.h"
 #include "notificator.h"
@@ -258,9 +256,9 @@ void BitcoinGUI::createActions(bool fIsTestnet)
     openRPCConsoleAction->setStatusTip(tr("Open debugging and diagnostic console"));
 
     usedSendingAddressesAction = new QAction(QIcon(":/icons/address-book"), tr("&Used sending addresses..."), this);
-    usedSendingAddressesAction->setStatusTip(tr("Edit the list of used sending addresses and labels"));
+    usedSendingAddressesAction->setStatusTip(tr("Show the list of used sending addresses and labels"));
     usedReceivingAddressesAction = new QAction(QIcon(":/icons/address-book"), tr("Used &receiving addresses..."), this);
-    usedReceivingAddressesAction->setStatusTip(tr("Edit the list of used receiving addresses and labels"));
+    usedReceivingAddressesAction->setStatusTip(tr("Show the list of used receiving addresses and labels"));
 
     connect(quitAction, SIGNAL(triggered()), qApp, SLOT(quit()));
     connect(aboutAction, SIGNAL(triggered()), this, SLOT(aboutClicked()));

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -5,13 +5,11 @@
 #include <QSystemTrayIcon>
 #include <QMap>
 
-class TransactionTableModel;
 class WalletFrame;
 class WalletView;
 class ClientModel;
 class WalletModel;
 class WalletStack;
-class TransactionView;
 class OverviewPage;
 class SendCoinsDialog;
 class SendCoinsRecipient;
@@ -50,11 +48,11 @@ public:
         The client model represents the part of the core that communicates with the P2P network, and is wallet-agnostic.
     */
     void setClientModel(ClientModel *clientModel);
+
     /** Set the wallet model.
         The wallet model represents a bitcoin wallet, and offers access to the list of transactions, address book and sending
         functionality.
     */
-
     bool addWallet(const QString& name, WalletModel *walletModel);
     bool setCurrentWallet(const QString& name);
 
@@ -98,7 +96,6 @@ private:
 
     QSystemTrayIcon *trayIcon;
     Notificator *notificator;
-    TransactionView *transactionView;
     RPCConsole *rpcConsole;
 
     QMovie *syncIconMovie;

--- a/src/qt/forms/receivecoinsdialog.ui
+++ b/src/qt/forms/receivecoinsdialog.ui
@@ -10,9 +10,6 @@
     <height>343</height>
    </rect>
   </property>
-  <property name="windowTitle">
-   <string>Form</string>
-  </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <layout class="QFormLayout" name="formLayout">
@@ -113,7 +110,7 @@
         </sizepolicy>
        </property>
        <property name="toolTip">
-        <string>Remove all transaction fields</string>
+        <string>Clear all fields of the form.</string>
        </property>
        <property name="text">
         <string>Clear</string>

--- a/src/qt/forms/receiverequestdialog.ui
+++ b/src/qt/forms/receiverequestdialog.ui
@@ -10,9 +10,6 @@
     <height>597</height>
    </rect>
   </property>
-  <property name="windowTitle">
-   <string>Request coins</string>
-  </property>
   <layout class="QVBoxLayout" name="verticalLayout_3">
    <item>
     <widget class="QRImageWidget" name="lblQRCode">

--- a/src/qt/forms/sendcoinsdialog.ui
+++ b/src/qt/forms/sendcoinsdialog.ui
@@ -84,7 +84,7 @@
         </sizepolicy>
        </property>
        <property name="toolTip">
-        <string>Remove all transaction fields</string>
+        <string>Clear all fields of the form.</string>
        </property>
        <property name="text">
         <string>Clear &amp;All</string>

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -3,7 +3,6 @@
 
 #include "walletmodel.h"
 #include "bitcoinunits.h"
-#include "addressbookpage.h"
 #include "optionsmodel.h"
 #include "sendcoinsentry.h"
 #include "guiutil.h"


### PR DESCRIPTION
- remove 2 unneeded windowTitle attributes, which bloat our translations
- cleanup some unneeded .cpp/.h includes and class usages
- use a more generic string for clearing sendcoinsdialog and
  requestpaymentdialog
- edit 2 strings in BitcoinGUI and replace "edit" with "show" as this
  seems more clear in the context where it is used
