### PR TITLE
Split MIN_PROTO_VERSION into INIT_PROTO_VERSION and MIN_PEER_PROTO_VERSION

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3377,10 +3377,9 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
         CAddress addrFrom;
         uint64 nNonce = 1;
         vRecv >> pfrom->nVersion >> pfrom->nServices >> nTime >> addrMe;
-        if (pfrom->nVersion < MIN_PROTO_VERSION)
+        if (pfrom->nVersion < MIN_PEER_PROTO_VERSION)
         {
-            // Since February 20, 2012, the protocol is initiated at version 209,
-            // and earlier versions are no longer supported
+            // disconnect from peers older than this proto version
             LogPrintf("partner %s using obsolete version %i; disconnecting\n", pfrom->addr.ToString().c_str(), pfrom->nVersion);
             pfrom->fDisconnect = true;
             return false;

--- a/src/net.h
+++ b/src/net.h
@@ -243,11 +243,11 @@ public:
     int64 nPingUsecTime;
     bool fPingQueued;
     
-    CNode(SOCKET hSocketIn, CAddress addrIn, std::string addrNameIn = "", bool fInboundIn=false) : ssSend(SER_NETWORK, MIN_PROTO_VERSION)
+    CNode(SOCKET hSocketIn, CAddress addrIn, std::string addrNameIn = "", bool fInboundIn=false) : ssSend(SER_NETWORK, INIT_PROTO_VERSION)
     {
         nServices = 0;
         hSocket = hSocketIn;
-        nRecvVersion = MIN_PROTO_VERSION;
+        nRecvVersion = INIT_PROTO_VERSION;
         nLastSend = 0;
         nLastRecv = 0;
         nSendBytes = 0;

--- a/src/version.h
+++ b/src/version.h
@@ -27,8 +27,11 @@ extern const std::string CLIENT_DATE;
 
 static const int PROTOCOL_VERSION = 70001;
 
-// earlier versions not supported as of Feb 2012, and are disconnected
-static const int MIN_PROTO_VERSION = 209;
+// intial proto version, to be increased after version/verack negotiation
+static const int INIT_PROTO_VERSION = 209;
+
+// disconnect from peers older than this proto version
+static const int MIN_PEER_PROTO_VERSION = 209;
 
 // nTime field added to CAddress, starting with this version;
 // if possible, avoid requesting addresses nodes older than this


### PR DESCRIPTION
INIT_PROTO_VERSION is the initial version, after a succesful version/verack it is increased to a negotiated version.
MIN_PEER_PROTO_VERSION could be a different value to disconnect from peers older than a specified version.

This commit alone does not change any behavior.  It stresses the difference between the initial and minimum version, the latter of which can be set to enforce a minimum version in a later policy discussion.
