### PR TITLE
[Qt] addressbookpage: make addressbookpage use message() / remove optionsmodel

### DIFF
--- a/src/qt/addressbookpage.cpp
+++ b/src/qt/addressbookpage.cpp
@@ -6,7 +6,6 @@
 #include "ui_addressbookpage.h"
 
 #include "addresstablemodel.h"
-#include "optionsmodel.h"
 #include "bitcoingui.h"
 #include "editaddressdialog.h"
 #include "csvmodelwriter.h"
@@ -21,7 +20,6 @@ AddressBookPage::AddressBookPage(Mode mode, Tabs tab, QWidget *parent) :
     QDialog(parent),
     ui(new Ui::AddressBookPage),
     model(0),
-    optionsModel(0),
     mode(mode),
     tab(tab)
 {
@@ -136,17 +134,12 @@ void AddressBookPage::setModel(AddressTableModel *model)
 #endif
 
     connect(ui->tableView->selectionModel(), SIGNAL(selectionChanged(QItemSelection,QItemSelection)),
-            this, SLOT(selectionChanged()));
+        this, SLOT(selectionChanged()));
 
     // Select row for newly created address
     connect(model, SIGNAL(rowsInserted(QModelIndex,int,int)), this, SLOT(selectNewAddress(QModelIndex,int,int)));
 
     selectionChanged();
-}
-
-void AddressBookPage::setOptionsModel(OptionsModel *optionsModel)
-{
-    this->optionsModel = optionsModel;
 }
 
 void AddressBookPage::on_copyAddress_clicked()

--- a/src/qt/addressbookpage.cpp
+++ b/src/qt/addressbookpage.cpp
@@ -10,6 +10,7 @@
 #include "editaddressdialog.h"
 #include "csvmodelwriter.h"
 #include "guiutil.h"
+#include "walletmodel.h"
 
 #include <QSortFilterProxyModel>
 #include <QClipboard>
@@ -97,14 +98,15 @@ AddressBookPage::~AddressBookPage()
     delete ui;
 }
 
-void AddressBookPage::setModel(AddressTableModel *model)
+void AddressBookPage::setModel(WalletModel *model)
 {
-    this->model = model;
-    if(!model)
+    if(!model && !model->getAddressTableModel())
         return;
 
+    this->model = model->getAddressTableModel();
+
     proxyModel = new QSortFilterProxyModel(this);
-    proxyModel->setSourceModel(model);
+    proxyModel->setSourceModel(this->model);
     proxyModel->setDynamicSortFilter(true);
     proxyModel->setSortCaseSensitivity(Qt::CaseInsensitive);
     proxyModel->setFilterCaseSensitivity(Qt::CaseInsensitive);
@@ -138,6 +140,8 @@ void AddressBookPage::setModel(AddressTableModel *model)
 
     // Select row for newly created address
     connect(model, SIGNAL(rowsInserted(QModelIndex,int,int)), this, SLOT(selectNewAddress(QModelIndex,int,int)));
+    // Receive and report messages (WalletModel is only used for passing through message())
+    connect(this, SIGNAL(message(QString,QString,unsigned int)), model, SIGNAL(message(QString,QString,unsigned int)));	
 
     selectionChanged();
 }

--- a/src/qt/addressbookpage.h
+++ b/src/qt/addressbookpage.h
@@ -7,7 +7,6 @@ namespace Ui {
     class AddressBookPage;
 }
 class AddressTableModel;
-class OptionsModel;
 
 QT_BEGIN_NAMESPACE
 class QTableView;
@@ -38,7 +37,6 @@ public:
     ~AddressBookPage();
 
     void setModel(AddressTableModel *model);
-    void setOptionsModel(OptionsModel *optionsModel);
     const QString &getReturnValue() const { return returnValue; }
 
 public slots:
@@ -47,7 +45,6 @@ public slots:
 private:
     Ui::AddressBookPage *ui;
     AddressTableModel *model;
-    OptionsModel *optionsModel;
     Mode mode;
     Tabs tab;
     QString returnValue;

--- a/src/qt/addressbookpage.h
+++ b/src/qt/addressbookpage.h
@@ -7,6 +7,7 @@ namespace Ui {
     class AddressBookPage;
 }
 class AddressTableModel;
+class WalletModel;
 
 QT_BEGIN_NAMESPACE
 class QTableView;
@@ -36,7 +37,7 @@ public:
     explicit AddressBookPage(Mode mode, Tabs tab, QWidget *parent = 0);
     ~AddressBookPage();
 
-    void setModel(AddressTableModel *model);
+    void setModel(WalletModel *model);
     const QString &getReturnValue() const { return returnValue; }
 
 public slots:
@@ -76,6 +77,9 @@ private slots:
 
 signals:
     void sendCoins(QString addr);
+
+    /**  Fired when a message should be reported to the user */
+    void message(const QString &title, const QString &message, unsigned int style);
 };
 
 #endif // ADDRESSBOOKPAGE_H

--- a/src/qt/receivecoinsdialog.cpp
+++ b/src/qt/receivecoinsdialog.cpp
@@ -81,7 +81,7 @@ void ReceiveCoinsDialog::on_receiveButton_clicked()
     {
         /* Choose existing receiving address */
         AddressBookPage dlg(AddressBookPage::ForSelection, AddressBookPage::ReceivingTab, this);
-        dlg.setModel(model->getAddressTableModel());
+        dlg.setModel(model);
         if(dlg.exec())
         {
             address = dlg.getReturnValue();
@@ -97,7 +97,7 @@ void ReceiveCoinsDialog::on_receiveButton_clicked()
         address = model->getAddressTableModel()->addRow(AddressTableModel::Receive, label, "");
     }
     SendCoinsRecipient info(address, label,
-            ui->reqAmount->value(), ui->reqMessage->text());
+        ui->reqAmount->value(), ui->reqMessage->text());
     ReceiveRequestDialog *dialog = new ReceiveRequestDialog(this);
     dialog->setModel(model->getOptionsModel());
     dialog->setInfo(info);

--- a/src/qt/sendcoinsentry.cpp
+++ b/src/qt/sendcoinsentry.cpp
@@ -50,7 +50,7 @@ void SendCoinsEntry::on_addressBookButton_clicked()
     if(!model)
         return;
     AddressBookPage dlg(AddressBookPage::ForSelection, AddressBookPage::SendingTab, this);
-    dlg.setModel(model->getAddressTableModel());
+    dlg.setModel(model);
     if(dlg.exec())
     {
         ui->payTo->setText(dlg.getReturnValue());

--- a/src/qt/signverifymessagedialog.cpp
+++ b/src/qt/signverifymessagedialog.cpp
@@ -87,7 +87,7 @@ void SignVerifyMessageDialog::on_addressBookButton_SM_clicked()
     if (model && model->getAddressTableModel())
     {
         AddressBookPage dlg(AddressBookPage::ForSelection, AddressBookPage::ReceivingTab, this);
-        dlg.setModel(model->getAddressTableModel());
+        dlg.setModel(model);
         if (dlg.exec())
         {
             setAddress_SM(dlg.getReturnValue());
@@ -179,7 +179,7 @@ void SignVerifyMessageDialog::on_addressBookButton_VM_clicked()
     if (model && model->getAddressTableModel())
     {
         AddressBookPage dlg(AddressBookPage::ForSelection, AddressBookPage::SendingTab, this);
-        dlg.setModel(model->getAddressTableModel());
+        dlg.setModel(model);
         if (dlg.exec())
         {
             setAddress_VM(dlg.getReturnValue());

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -259,7 +259,7 @@ void WalletView::usedSendingAddresses()
     if(!walletModel)
         return;
     AddressBookPage *dlg = new AddressBookPage(AddressBookPage::ForEditing, AddressBookPage::SendingTab, this);
-    dlg->setModel(walletModel->getAddressTableModel());
+    dlg->setModel(walletModel);
     dlg->setAttribute(Qt::WA_DeleteOnClose);
     dlg->show();
 }
@@ -269,7 +269,7 @@ void WalletView::usedReceivingAddresses()
     if(!walletModel)
         return;
     AddressBookPage *dlg = new AddressBookPage(AddressBookPage::ForEditing, AddressBookPage::ReceivingTab, this);
-    dlg->setModel(walletModel->getAddressTableModel());
+    dlg->setModel(walletModel);
     dlg->setAttribute(Qt::WA_DeleteOnClose);
     dlg->show();
 }


### PR DESCRIPTION
Related to #3159 and #3160 (same changes for transactionview and walletview).

Goal: Harmonize user experience for export of addresses, transactions and backup of the wallet!

![export_addr](https://f.cloud.github.com/assets/1419649/1414006/c2433602-3e62-11e3-8743-bbb0f3ad0599.png)
