### PR TITLE
[Qt] transactionview: make transactionview use message()

### DIFF
--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -11,6 +11,7 @@
 #include "editaddressdialog.h"
 #include "optionsmodel.h"
 #include "guiutil.h"
+#include "ui_interface.h"
 
 #include <QScrollBar>
 #include <QComboBox>
@@ -20,7 +21,6 @@
 #include <QLineEdit>
 #include <QTableView>
 #include <QHeaderView>
-#include <QMessageBox>
 #include <QPoint>
 #include <QMenu>
 #include <QLabel>
@@ -266,12 +266,12 @@ void TransactionView::changedAmount(const QString &amount)
 void TransactionView::exportClicked()
 {
     // CSV is currently the only supported format
-    QString filename = GUIUtil::getSaveFileName(
-            this,
-            tr("Export Transaction Data"), QString(),
-            tr("Comma separated file (*.csv)"));
+    QString filename = GUIUtil::getSaveFileName(this,
+        tr("Export Transaction History"), QString(),
+        tr("Comma separated file (*.csv)"));
 
-    if (filename.isNull()) return;
+    if (filename.isNull())
+        return;
 
     CSVModelWriter writer(filename);
 
@@ -285,10 +285,13 @@ void TransactionView::exportClicked()
     writer.addColumn(tr("Amount"), 0, TransactionTableModel::FormattedAmountRole);
     writer.addColumn(tr("ID"), 0, TransactionTableModel::TxIDRole);
 
-    if(!writer.write())
-    {
-        QMessageBox::critical(this, tr("Error exporting"), tr("Could not write to file %1.").arg(filename),
-                              QMessageBox::Abort, QMessageBox::Abort);
+    if(!writer.write()) {
+        emit message(tr("Exporting Failed"), tr("There was an error trying to save the transaction history to %1.").arg(filename),
+            CClientUIInterface::MSG_ERROR);
+    }
+    else {
+        emit message(tr("Exporting Successful"), tr("The transaction history was successfully saved to %1.").arg(filename),
+            CClientUIInterface::MSG_INFORMATION);
     }
 }
 

--- a/src/qt/transactionview.h
+++ b/src/qt/transactionview.h
@@ -71,6 +71,9 @@ private slots:
 signals:
     void doubleClicked(const QModelIndex&);
 
+    /**  Fired when a message should be reported to the user */
+    void message(const QString &title, const QString &message, unsigned int style);
+
 public slots:
     void chooseDate(int idx);
     void chooseType(int idx);

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -67,6 +67,8 @@ WalletView::WalletView(QWidget *parent):
 
     // Pass through messages from sendCoinsPage
     connect(sendCoinsPage, SIGNAL(message(QString,QString,unsigned int)), this, SIGNAL(message(QString,QString,unsigned int)));
+    // Pass through messages from transactionView
+    connect(transactionView, SIGNAL(message(QString,QString,unsigned int)), this, SIGNAL(message(QString,QString,unsigned int)));
 }
 
 WalletView::~WalletView()
@@ -110,7 +112,7 @@ void WalletView::setWalletModel(WalletModel *walletModel)
 
     if (walletModel)
     {
-        // Receive and report messages from wallet thread
+        // Receive and pass through messages from wallet model
         connect(walletModel, SIGNAL(message(QString,QString,unsigned int)), this, SIGNAL(message(QString,QString,unsigned int)));
 
         // Handle changes in encryption status


### PR DESCRIPTION
Related to #3157 and #3160 (same changes for addressbookpage and walletview).

Goal: Harmonize user experience for export of addresses, transactions and backup of the wallet!

![export_tx](https://f.cloud.github.com/assets/1419649/1414017/64e2b766-3e63-11e3-938d-028db94dbc2c.png)
