### PR TITLE
[Qt] walletview: make backupWallet() use GUIUtil::getSaveFileName()

### DIFF
--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -18,16 +18,11 @@
 #include "overviewpage.h"
 #include "askpassphrasedialog.h"
 #include "ui_interface.h"
+#include "guiutil.h"
 
 #include <QHBoxLayout>
 #include <QVBoxLayout>
 #include <QAction>
-#if QT_VERSION < 0x050000
-#include <QDesktopServices>
-#else
-#include <QStandardPaths>
-#endif
-#include <QFileDialog>
 #include <QPushButton>
 
 WalletView::WalletView(QWidget *parent):
@@ -222,20 +217,20 @@ void WalletView::encryptWallet(bool status)
 
 void WalletView::backupWallet()
 {
-#if QT_VERSION < 0x050000
-    QString saveDir = QDesktopServices::storageLocation(QDesktopServices::DocumentsLocation);
-#else
-    QString saveDir = QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
-#endif
-    QString filename = QFileDialog::getSaveFileName(this, tr("Backup Wallet"), saveDir, tr("Wallet Data (*.dat)"));
-    if (!filename.isEmpty()) {
-        if (!walletModel->backupWallet(filename)) {
-            emit message(tr("Backup Failed"), tr("There was an error trying to save the wallet data to the new location."),
-                CClientUIInterface::MSG_ERROR);
+    QString filename = GUIUtil::getSaveFileName(this,
+        tr("Backup Wallet"), QString(),
+        tr("Wallet Data (*.dat)"));
+
+    if (filename.isEmpty())
+        return;
+
+    if (!walletModel->backupWallet(filename)) {
+        emit message(tr("Backup Failed"), tr("There was an error trying to save the wallet data to %1.").arg(filename),
+            CClientUIInterface::MSG_ERROR);
         }
-        else
-            emit message(tr("Backup Successful"), tr("The wallet data was successfully saved to the new location."),
-                CClientUIInterface::MSG_INFORMATION);
+    else {
+        emit message(tr("Backup Successful"), tr("The wallet data was successfully saved to %1.").arg(filename),
+            CClientUIInterface::MSG_INFORMATION);
     }
 }
 

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -56,7 +56,7 @@ WalletView::WalletView(QWidget *parent):
     addWidget(receiveCoinsPage);
     addWidget(sendCoinsPage);
 
-    // Clicking on a transaction on the overview page simply sends you to transaction history page
+    // Clicking on a transaction on the overview pre-selects the transaction on the transaction history page
     connect(overviewPage, SIGNAL(transactionClicked(QModelIndex)), transactionView, SLOT(focusTransaction(QModelIndex)));
 
     // Double-clicking on a transaction on the transaction history page shows details
@@ -77,7 +77,7 @@ void WalletView::setBitcoinGUI(BitcoinGUI *gui)
 {
     if (gui)
     {
-        // Clicking on a transaction on the overview page sends you to the transactions tab
+        // Clicking on a transaction on the overview page simply sends you to transaction history page
         connect(overviewPage, SIGNAL(transactionClicked(QModelIndex)), gui, SLOT(gotoHistoryPage()));
 
         // Receive and report messages


### PR DESCRIPTION
Related to #3157 and #3159 (same changes for addressbookpage and transactionview).

Goal: Harmonize user experience for export of addresses, transactions and backup of the wallet!

![wallet](https://f.cloud.github.com/assets/1419649/1414039/4b926b92-3e65-11e3-8c5f-65c727020c5b.png)
