### PR TITLE
Remove redundant insert method in serialize

### DIFF
--- a/src/serialize.h
+++ b/src/serialize.h
@@ -901,19 +901,6 @@ public:
     iterator insert(iterator it, const char& x=char()) { return vch.insert(it, x); }
     void insert(iterator it, size_type n, const char& x) { vch.insert(it, n, x); }
 
-    void insert(iterator it, const_iterator first, const_iterator last)
-    {
-        assert(last - first >= 0);
-        if (it == vch.begin() + nReadPos && (unsigned int)(last - first) <= nReadPos)
-        {
-            // special case for inserting at the front when there's room
-            nReadPos -= (last - first);
-            memcpy(&vch[nReadPos], &first[0], last - first);
-        }
-        else
-            vch.insert(it, first, last);
-    }
-
     void insert(iterator it, std::vector<char>::const_iterator first, std::vector<char>::const_iterator last)
     {
         assert(last - first >= 0);


### PR DESCRIPTION
This seems to cause problems on recent clang, and looks totally redundant and unused.

The const_iterator version is identical to the vector::const_iterator one (which is a typedef thereof). Marking it private (instead of removing) compiles fine, so this version is effectively unused even.
