### PR TITLE
Generalize the remove-outputs check for fully-prunable transactions.

### DIFF
--- a/src/core.h
+++ b/src/core.h
@@ -421,6 +421,9 @@ public:
 
     // equality test
     friend bool operator==(const CCoins &a, const CCoins &b) {
+         // Empty CCoins objects are always equal.
+         if (a.IsPruned() && b.IsPruned())
+             return true;
          return a.fCoinBase == b.fCoinBase &&
                 a.nHeight == b.nHeight &&
                 a.nVersion == b.nVersion &&

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1750,12 +1750,12 @@ bool DisconnectBlock(CBlock& block, CValidationState& state, CBlockIndex* pindex
         const CTransaction &tx = block.vtx[i];
         uint256 hash = tx.GetHash();
 
-        // check that all outputs are available
-        if (!view.HaveCoins(hash)) {
-            fClean = fClean && error("DisconnectBlock() : outputs still spent? database corrupted");
-            view.SetCoins(hash, CCoins());
-        }
-        CCoins &outs = view.GetCoins(hash);
+        // Check that all outputs are available and match the outputs in the block itself
+        // exactly. Note that transactions with only provably unspendable outputs won't
+        // have outputs available even in the block itself, so we handle that case
+        // specially with outsEmpty.
+        CCoins outsEmpty;
+        CCoins &outs = view.HaveCoins(hash) ? view.GetCoins(hash) : outsEmpty;
         outs.ClearUnspendable();
 
         CCoins outsBlock = CCoins(tx, pindex->nHeight);


### PR DESCRIPTION
Instead of explicitly testing for the presence of any output, and dealing with this case specially, just interpret it as an empty CCoins.

The case previously caught using the HaveCoins check, is now handled by the generic outs != outsBlock test.

This fixes #3156 and replaces #3143.
