### PR TITLE
-fuzzmessagestest=N : randomly corrupt 1-of-N sent messages

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -218,6 +218,9 @@ protected:
     static CCriticalSection cs_setBanned;
     int nMisbehavior;
 
+    // Basic fuzz-testing
+    void Fuzz(int nChance); // modifies ssSend
+
 public:
     uint256 hashContinue;
     CBlockIndex* pindexLastGetBlocksBegin;
@@ -434,12 +437,17 @@ public:
     // TODO: Document the precondition of this function.  Is cs_vSend locked?
     void EndMessage() UNLOCK_FUNCTION(cs_vSend)
     {
-        if (mapArgs.count("-dropmessagestest") && GetRand(atoi(mapArgs["-dropmessagestest"])) == 0)
+        // The -*messagestest options are intentionally not documented in the help message,
+        // since they are only used during development to debug the networking code and are
+        // not intended for end-users.
+        if (mapArgs.count("-dropmessagestest") && GetRand(GetArg("-dropmessagestest", 2)) == 0)
         {
             LogPrint("net", "dropmessages DROPPING SEND MESSAGE\n");
             AbortMessage();
             return;
         }
+        if (mapArgs.count("-fuzzmessagestest"))
+            Fuzz(GetArg("-fuzzmessagestest", 10));
 
         if (ssSend.size() == 0)
             return;

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -1104,8 +1104,8 @@ public:
     }
 
     void GetAndClear(CSerializeData &data) {
-        vch.swap(data);
-        CSerializeData().swap(vch);
+        data.insert(data.end(), begin(), end());
+        clear();
     }
 };
 

--- a/src/test/serialize_tests.cpp
+++ b/src/test/serialize_tests.cpp
@@ -102,4 +102,52 @@ BOOST_AUTO_TEST_CASE(noncanonical)
     BOOST_CHECK_EXCEPTION(ReadCompactSize(ss), std::ios_base::failure, isCanonicalException);
 }
 
+BOOST_AUTO_TEST_CASE(insert_delete)
+{
+    // Test inserting/deleting bytes.
+    CDataStream ss(SER_DISK, 0);
+    BOOST_CHECK_EQUAL(ss.size(), 0);
+
+    ss.write("\x00\x01\x02\xff", 4);
+    BOOST_CHECK_EQUAL(ss.size(), 4);
+
+    char c = (char)11;
+
+    // Inserting at beginning/end/middle:
+    ss.insert(ss.begin(), c);
+    BOOST_CHECK_EQUAL(ss.size(), 5);
+    BOOST_CHECK_EQUAL(ss[0], c);
+    BOOST_CHECK_EQUAL(ss[1], 0);
+
+    ss.insert(ss.end(), c);
+    BOOST_CHECK_EQUAL(ss.size(), 6);
+    BOOST_CHECK_EQUAL(ss[4], (char)0xff);
+    BOOST_CHECK_EQUAL(ss[5], c);
+
+    ss.insert(ss.begin()+2, c);
+    BOOST_CHECK_EQUAL(ss.size(), 7);
+    BOOST_CHECK_EQUAL(ss[2], c);
+
+    // Delete at beginning/end/middle
+    ss.erase(ss.begin());
+    BOOST_CHECK_EQUAL(ss.size(), 6);
+    BOOST_CHECK_EQUAL(ss[0], 0);
+
+    ss.erase(ss.begin()+ss.size()-1);
+    BOOST_CHECK_EQUAL(ss.size(), 5);
+    BOOST_CHECK_EQUAL(ss[4], (char)0xff);
+
+    ss.erase(ss.begin()+1);
+    BOOST_CHECK_EQUAL(ss.size(), 4);
+    BOOST_CHECK_EQUAL(ss[0], 0);
+    BOOST_CHECK_EQUAL(ss[1], 1);
+    BOOST_CHECK_EQUAL(ss[2], 2);
+    BOOST_CHECK_EQUAL(ss[3], (char)0xff);
+
+    // Make sure GetAndClear does the right thing:
+    CSerializeData d;
+    ss.GetAndClear(d);
+    BOOST_CHECK_EQUAL(ss.size(), 0);
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
I needed this to test the new "reject" p2p message, but it should be generally
useful for fuzz-testing network message handling code.

Note: you'll quickly trigger the DoS-and-ban code if you connect to random peers, this is most useful in a two-nodes-on-your-development-machine testnet-in-a-box or -regtest setup.
