### PR TITLE
fix wrong memcmp() usage in CKey::operator==

### DIFF
--- a/src/key.h
+++ b/src/key.h
@@ -205,7 +205,8 @@ public:
     }
 
     friend bool operator==(const CKey &a, const CKey &b) {
-        return a.fCompressed == b.fCompressed && memcmp(&a.vch[0], &b.vch[0], 32);
+        return a.fCompressed == b.fCompressed && a.size() == b.size() &&
+               memcmp(&a.vch[0], &b.vch[0], a.size()) == 0;
     }
 
     // Initialize using begin and end iterators to byte data.
@@ -261,9 +262,9 @@ public:
 
     // Derive BIP32 child key.
     bool Derive(CKey& keyChild, unsigned char ccChild[32], unsigned int nChild, const unsigned char cc[32]) const;
-    
+
     // Load private key and check that public key matches.
-    bool Load(CPrivKey &privkey, CPubKey &vchPubKey, bool fSkipCheck);  
+    bool Load(CPrivKey &privkey, CPubKey &vchPubKey, bool fSkipCheck);
 };
 
 struct CExtPubKey {


### PR DESCRIPTION
- add a check for CKey::size() of a and b (size can be 0 or 32)
- change the fixed value in memcmp() to use a.size() instead
- fixes #3090
