### PR TITLE
rpcwallet: use EnsureWalletIsUnlocked() where possible

### DIFF
--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -109,8 +109,8 @@ Value getnewaddress(const Array& params, bool fHelp)
     if (params.size() > 0)
         strAccount = AccountFromValue(params[0]);
 
-    if (!pwalletMain->IsLocked())
-        pwalletMain->TopUpKeyPool();
+    EnsureWalletIsUnlocked();
+    pwalletMain->TopUpKeyPool();
 
     // Generate a new key that is added to wallet
     CPubKey newKey;
@@ -188,8 +188,8 @@ Value getrawchangeaddress(const Array& params, bool fHelp)
             "Returns a new Bitcoin address, for receiving change.  "
             "This is for use with raw transactions, NOT normal use.");
 
-    if (!pwalletMain->IsLocked())
-        pwalletMain->TopUpKeyPool();
+    EnsureWalletIsUnlocked();
+    pwalletMain->TopUpKeyPool();
 
     CReserveKey reservekey(pwalletMain);
     CPubKey vchPubKey;
@@ -296,8 +296,7 @@ Value sendtoaddress(const Array& params, bool fHelp)
     if (params.size() > 3 && params[3].type() != null_type && !params[3].get_str().empty())
         wtx.mapValue["to"]      = params[3].get_str();
 
-    if (pwalletMain->IsLocked())
-        throw JSONRPCError(RPC_WALLET_UNLOCK_NEEDED, "Error: Please enter the wallet passphrase with walletpassphrase first.");
+    EnsureWalletIsUnlocked();
 
     string strError = pwalletMain->SendMoneyToDestination(address.Get(), nAmount, wtx);
     if (strError != "")
@@ -1268,15 +1267,14 @@ Value keypoolrefill(const Array& params, bool fHelp)
             "Fills the keypool."
             + HelpRequiringPassphrase());
 
-    unsigned int kpSize = max(GetArg("-keypool", 100), 0LL);
+    unsigned int kpSize = 0;
     if (params.size() > 0) {
         if (params[0].get_int() < 0)
-            throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, expected valid size");
-        kpSize = (unsigned int) params[0].get_int();
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, expected valid size.");
+        kpSize = (unsigned int)params[0].get_int();
     }
 
     EnsureWalletIsUnlocked();
-
     pwalletMain->TopUpKeyPool(kpSize);
 
     if (pwalletMain->GetKeyPoolSize() < kpSize)


### PR DESCRIPTION
- replaces pwalletMain->IsLocked() checks, which mostly did not even throw
  an error
- in keypoolrefill init kpSize to 0 as we have the logic to determine max
  kpSize in pwalletMain->TopUpKeyPool() anyway
