### PR TITLE
Reduce latency in network processing

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3155,6 +3155,9 @@ void static ProcessGetData(CNode* pfrom)
 
             // Track requests for our stuff.
             g_signals.Inventory(inv.hash);
+            
+            if (inv.type == MSG_BLOCK || inv.type == MSG_FILTERED_BLOCK)
+                break;
         }
     }
 
@@ -3841,7 +3844,10 @@ bool ProcessMessages(CNode* pfrom)
 
     if (!pfrom->vRecvGetData.empty())
         ProcessGetData(pfrom);
-
+    
+    // this maintains the order of responses
+    if (!pfrom->vRecvGetData.empty()) return fOk;
+    
     std::deque<CNetMessage>::iterator it = pfrom->vRecvMsg.begin();
     while (!pfrom->fDisconnect && it != pfrom->vRecvMsg.end()) {
         // Don't bother if send buffer is too full to respond anyway
@@ -3929,6 +3935,8 @@ bool ProcessMessages(CNode* pfrom)
 
         if (!fRet)
             LogPrintf("ProcessMessage(%s, %u bytes) FAILED\n", strCommand.c_str(), nMessageSize);
+        
+        break;
     }
 
     // In case the connection got shut down, its receive buffer was wiped

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1540,6 +1540,9 @@ void ThreadMessageHandler()
         CNode* pnodeTrickle = NULL;
         if (!vNodesCopy.empty())
             pnodeTrickle = vNodesCopy[GetRand(vNodesCopy.size())];
+        
+        bool fSleep = true;
+        
         BOOST_FOREACH(CNode* pnode, vNodesCopy)
         {
             if (pnode->fDisconnect)
@@ -1549,8 +1552,18 @@ void ThreadMessageHandler()
             {
                 TRY_LOCK(pnode->cs_vRecvMsg, lockRecv);
                 if (lockRecv)
+                {
                     if (!g_signals.ProcessMessages(pnode))
                         pnode->CloseSocketDisconnect();
+                    
+                    if (pnode->nSendSize < SendBufferSize())
+                    {
+                        if (!pnode->vRecvGetData.empty() || (!pnode->vRecvMsg.empty() && pnode->vRecvMsg[0].complete()))
+                        {
+                            fSleep = false;
+                        }
+                    }
+                }
             }
             boost::this_thread::interruption_point();
 
@@ -1568,8 +1581,9 @@ void ThreadMessageHandler()
             BOOST_FOREACH(CNode* pnode, vNodesCopy)
                 pnode->Release();
         }
-
-        MilliSleep(100);
+        
+        if (fSleep)
+            MilliSleep(100);
     }
 }
 


### PR DESCRIPTION
Currently there is a 100ms sleep in the message processing thread that adds delay to processing messages.

This patch skips the sleep when there is additional work to do.

Additionally ProcessMessages & ProcessGetData are modified such that their maximum run time is reduced; this improves the average latency peers see when there is high load. (This has a significant impact on high latency networks during initial block synchronization).
