### PR TITLE
[Qt] paymentserver: start netManager in uiReady()

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -308,7 +308,6 @@ int main(int argc, char *argv[])
 
                 PaymentServer::LoadRootCAs();
                 paymentServer->setOptionsModel(&optionsModel);
-                paymentServer->initNetManager();
 
                 if (splashref)
                     splash.finish(&window);

--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -341,7 +341,7 @@ void PaymentServer::initNetManager()
 
 void PaymentServer::uiReady()
 {
-    assert(netManager != NULL); // Must call initNetManager before uiReady()
+    initNetManager();
 
     saveURIs = false;
     foreach (const QString& s, savedPaymentRequests)

--- a/src/qt/paymentserver.h
+++ b/src/qt/paymentserver.h
@@ -77,9 +77,6 @@ public:
     // Return certificate store
     static X509_STORE* getCertStore() { return certStore; }
 
-    // Setup networking
-    void initNetManager();
-
     // Constructor registers this on the parent QApplication to
     // receive QEvent::FileOpen events
     bool eventFilter(QObject *object, QEvent *event);
@@ -116,6 +113,9 @@ private:
     bool processPaymentRequest(PaymentRequestPlus& request, SendCoinsRecipient& recipient);
     void handleURIOrFile(const QString& s);
     void fetchRequest(const QUrl& url);
+
+    // Setup networking
+    void initNetManager();
 
     bool saveURIs;                      // true during startup
     QLocalServer* uriServer;

--- a/src/qt/test/paymentservertests.cpp
+++ b/src/qt/test/paymentservertests.cpp
@@ -60,7 +60,6 @@ void PaymentServerTests::paymentServerTests()
     X509_STORE_add_cert(caStore, parse_b64der_cert(caCert_BASE64));
     PaymentServer::LoadRootCAs(caStore);
     server->setOptionsModel(&optionsModel);
-    server->initNetManager();
     server->uiReady();
 
     // Now feed PaymentRequests to server, and observe signals it produces:


### PR DESCRIPTION
- remove explicit init of netManager as this is done in the constructor
  anyway
- move initNetManager() call to uiReady(), which removes an assert() and
  allows us to use message() in initNetManager() (currently unused but
  could be necessary because of proxy related messages)
- make initNetManager() private
- update paymentservertests.cpp
