### PR TITLE
Check integrity of gitian input source tarballs

### DIFF
--- a/contrib/gitian-descriptors/deps-win32.yml
+++ b/contrib/gitian-descriptors/deps-win32.yml
@@ -27,7 +27,14 @@ script: |
   export TZ=UTC
   export INSTALLPREFIX=$OUTDIR/staging/deps
   export HOST=i686-w64-mingw32
-  #
+  # Input Integrity Check
+  echo "2a9eb3cd4e8b114eb9179c0d3884d61658e7d8e8bf4984798a5f5bd48e325ebe  openssl-1.0.1c.tar.gz"  | sha256sum -c
+  echo "b75dae26151f9b031062c8d2f577a094b08da0ae44fe8c11175d0b9ff434cc02  libpng-1.5.9.tar.gz"    | sha256sum -c
+  echo "12edc0df75bf9abd7f82f821795bcee50f42cb2e5f76a6a281b85732798364ef  db-4.8.30.NC.tar.gz"    | sha256sum -c
+  echo "21235e08552e6feba09ea5e8d750805b3391c62fb81c71a235c0044dc7a8a61b  zlib-1.2.6.tar.gz"      | sha256sum -c
+  echo "b75dae26151f9b031062c8d2f577a094b08da0ae44fe8c11175d0b9ff434cc02  libpng-1.5.9.tar.gz"    | sha256sum -c
+  echo "03c4bc7cd9a75747c3815d509bbe061907d615764f2357923f0db948c567068f  qrencode-3.2.0.tar.bz2" | sha256sum -c
+
   mkdir -p $INSTALLPREFIX
 
   tar xzf openssl-1.0.1c.tar.gz

--- a/contrib/gitian-descriptors/gitian.yml
+++ b/contrib/gitian-descriptors/gitian.yml
@@ -35,7 +35,11 @@ files:
 script: |
   STAGING="$HOME/install"
   export LIBRARY_PATH="$STAGING/lib"
-  #
+  # Integrity Check
+  echo "bbd6b756e6af44b5a5b0f9b93eada3fb8922ed1d6451b7d6f184d0ae0c813994  miniupnpc-1.6.tar.gz"   | sha256sum -c
+  echo "03c4bc7cd9a75747c3815d509bbe061907d615764f2357923f0db948c567068f  qrencode-3.2.0.tar.bz2" | sha256sum -c
+  echo "13bfc5ae543cf3aa180ac2485c0bc89495e3ae711fc6fab4f8ffe90dfb4bb677  protobuf-2.5.0.tar.bz2" | sha256sum -c
+
   tar xzfm miniupnpc-1.6.tar.gz
   cd miniupnpc-1.6
   INSTALLPREFIX=$STAGING make $MAKEOPTS install

--- a/contrib/gitian-descriptors/protobuf-win32.yml
+++ b/contrib/gitian-descriptors/protobuf-win32.yml
@@ -18,7 +18,9 @@ script: |
   export TZ=UTC
   export INSTALLPREFIX=$OUTDIR/staging/deps
   export HOST=i686-w64-mingw32
-  #
+  # Integrity Check
+  echo "13bfc5ae543cf3aa180ac2485c0bc89495e3ae711fc6fab4f8ffe90dfb4bb677  protobuf-2.5.0.tar.bz2" | sha256sum -c
+
   #
   mkdir -p $INSTALLPREFIX
 

--- a/contrib/gitian-descriptors/qt-win32.yml
+++ b/contrib/gitian-descriptors/qt-win32.yml
@@ -20,7 +20,9 @@ script: |
   #
   HOST=i686-w64-mingw32
   INSTDIR="$HOME/qt/"
-  #
+  # Integrity Check
+  echo "f1f72974f924861be04019f49f07cd43ab3c95056db2ba8f34b283487cccc728  qt-everywhere-opensource-src-4.8.3.tar.gz" | sha256sum -c
+
   mkdir $INSTDIR
   mkdir -p $INSTDIR/host/bin
   #


### PR DESCRIPTION
sha256sum verification of source tarballs during gitian build.  This follows the earlier example in boost-win32.yml.  This does not change anything about the gitian outputs.

**Test Plan**
- Search for multiple copies of the tarball and download them from multiple distros.  Confirm that they match the sha256sum's in this commit.
