### PR TITLE
Unnecessary (possibly incorrect) check on transaction count.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2258,7 +2258,7 @@ bool CheckBlock(const CBlock& block, CValidationState& state, bool fCheckPOW, bo
     // that can be verified before saving an orphan block.
 
     // Size limits
-    if (block.vtx.empty() || block.vtx.size() > MAX_BLOCK_SIZE || ::GetSerializeSize(block, SER_NETWORK, PROTOCOL_VERSION) > MAX_BLOCK_SIZE)
+    if (block.vtx.empty() || ::GetSerializeSize(block, SER_NETWORK, PROTOCOL_VERSION) > MAX_BLOCK_SIZE)
         return state.DoS(100, error("CheckBlock() : size limits failed"));
 
     // Check proof of work matches claimed amount


### PR DESCRIPTION
This check is unnecessary since the size of a transaction is no less than 60.
It also seems a little inconsistent since MAX_BLOCK_SIZE is used for both
length of the serialized block and for the number of transactions in a block.
If there are MAX_BLOCK_SIZE transactions, the serialized size check will fail.
