### PR TITLE
.gitignore: Simplify references to the same file in different directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,6 @@
 *.tar.gz
 
 *.exe
-src/*.exe
-src/*/*.exe
 src/bitcoin
 src/bitcoind
 src/bitcoin-cli
@@ -15,33 +13,21 @@ autom4te.cache/
 config.log
 config.status
 configure
-src/.deps/
-src/Makefile.in
 src/bitcoin-config.h
 src/bitcoin-config.h.in
 src/build-aux/
-src/qt/Makefile.in
 src/stamp-h1
 share/setup.nsi
 share/qt/Info.plist
 
-src/leveldb/.deps/
-
-src/test/.deps
-src/test/.dirstamp
-
-src/qt/.deps/
-src/qt/.dirstamp
 src/qt/*.moc
 src/qt/moc_*.cpp
 src/qt/forms/ui_*.h
 
-src/qt/test/.deps/
-src/qt/test/.dirstamp
 src/qt/test/moc*.cpp
-src/qt/res/.deps/
-src/qt/res/.dirstamp
 
+.deps
+.dirstamp
 .*.swp
 *.*~*
 *.bak


### PR DESCRIPTION
Unless a .gitignore pattern is anchored, it'll match in any directory, not juts at the top level.  Simplify .gitignore accordingly.
