### PR TITLE
Make time facet non-constant

### DIFF
--- a/src/rpcdump.cpp
+++ b/src/rpcdump.cpp
@@ -26,7 +26,7 @@ std::string static EncodeDumpTime(int64 nTime) {
 }
 
 int64 static DecodeDumpTime(const std::string &str) {
-    static const boost::posix_time::time_input_facet facet("%Y-%m-%dT%H:%M:%SZ");
+    static boost::posix_time::time_input_facet facet("%Y-%m-%dT%H:%M:%SZ");
     static const boost::posix_time::ptime epoch = boost::posix_time::from_time_t(0);
     const std::locale loc(std::locale::classic(), &facet);
     std::istringstream iss(str);


### PR DESCRIPTION
This is supposed to fix #2806 (compilation problems on OSX 10.9:

``````
...
  CXX      rpcdump.o
In file included from rpcdump.cpp:5:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/c++/v1/iostream:38:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/c++/v1/ios:216:
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/c++/v1/__locale:144:29: error: 
      cannot initialize a parameter of type 'std::__1::locale::facet *' with an lvalue of type
      'const boost::date_time::time_input_facet<boost::posix_time::ptime, char,
      std::__1::istreambuf_iterator<char, std::__1::char_traits<char> > > *'
    __install_ctor(__other, __f, __f ? __f->id.__get() : 0);
                            ^~~
rpcdump.cpp:31:23: note: in instantiation of function template specialization
      'std::__1::locale::locale<const
      boost::date_time::time_input_facet<boost::posix_time::ptime, char,
      std::__1::istreambuf_iterator<char, std::__1::char_traits<char> > > >' requested here
    const std::locale loc(std::locale::classic(), &facet);
                      ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/c++/v1/__locale:96:46: note: 
      passing argument to parameter here
    void __install_ctor(const locale&, facet*, long);
                                             ^
1 error generated.
make[3]: *** [rpcdump.o] Error 1
make[2]: *** [all-recursive] Error 1
make[1]: *** [all] Error 2
make: *** [all-recursive] Error 1
```)
``````
