### PR TITLE
qt: keep a list of requested payments

### DIFF
--- a/src/qt/Makefile.am
+++ b/src/qt/Makefile.am
@@ -96,6 +96,7 @@ QT_MOC_CPP = moc_aboutdialog.cpp moc_addressbookpage.cpp \
   moc_optionsmodel.cpp moc_overviewpage.cpp moc_paymentserver.cpp \
   moc_receiverequestdialog.cpp moc_qvalidatedlineedit.cpp moc_qvaluecombobox.cpp \
   moc_receivecoinsdialog.cpp \
+  moc_recentrequeststablemodel.cpp \
   moc_rpcconsole.cpp moc_sendcoinsdialog.cpp moc_sendcoinsentry.cpp \
   moc_signverifymessagedialog.cpp moc_splashscreen.cpp moc_trafficgraphwidget.cpp moc_transactiondesc.cpp \
   moc_transactiondescdialog.cpp moc_transactionfilterproxy.cpp \
@@ -122,6 +123,7 @@ BITCOIN_QT_H  = aboutdialog.h addressbookpage.h addresstablemodel.h \
   optionsdialog.h \
   optionsmodel.h overviewpage.h paymentrequestplus.h paymentserver.h \
   receivecoinsdialog.h \
+  recentrequeststablemodel.h \
   receiverequestdialog.h qvalidatedlineedit.h qvaluecombobox.h rpcconsole.h \
   sendcoinsdialog.h sendcoinsentry.h signverifymessagedialog.h splashscreen.h \
   trafficgraphwidget.h transactiondescdialog.h transactiondesc.h transactionfilterproxy.h \
@@ -157,6 +159,7 @@ BITCOIN_QT_CPP = aboutdialog.cpp addressbookpage.cpp \
   optionsdialog.cpp optionsmodel.cpp overviewpage.cpp paymentrequestplus.cpp \
   paymentserver.cpp qvalidatedlineedit.cpp qvaluecombobox.cpp \
   receivecoinsdialog.cpp receiverequestdialog.cpp \
+  recentrequeststablemodel.cpp \
   rpcconsole.cpp sendcoinsdialog.cpp sendcoinsentry.cpp \
   signverifymessagedialog.cpp splashscreen.cpp trafficgraphwidget.cpp transactiondesc.cpp \
   transactiondescdialog.cpp transactionfilterproxy.cpp transactionrecord.cpp \

--- a/src/qt/addresstablemodel.cpp
+++ b/src/qt/addresstablemodel.cpp
@@ -297,7 +297,7 @@ QVariant AddressTableModel::headerData(int section, Qt::Orientation orientation,
 {
     if(orientation == Qt::Horizontal)
     {
-        if(role == Qt::DisplayRole)
+        if(role == Qt::DisplayRole && section < columns.size())
         {
             return columns[section];
         }

--- a/src/qt/forms/receivecoinsdialog.ui
+++ b/src/qt/forms/receivecoinsdialog.ui
@@ -7,35 +7,60 @@
     <x>0</x>
     <y>0</y>
     <width>776</width>
-    <height>343</height>
+    <height>364</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <layout class="QGridLayout" name="gridLayout">
-     <item row="3" column="0">
-      <widget class="QLabel" name="label">
+     <item row="7" column="2">
+      <widget class="QCheckBox" name="reuseAddress">
+       <property name="toolTip">
+        <string>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</string>
+       </property>
        <property name="text">
-        <string>&amp;Amount:</string>
+        <string>R&amp;euse an existing receiving address (not recommended)</string>
+       </property>
+      </widget>
+     </item>
+     <item row="7" column="0">
+      <widget class="QLabel" name="label_4">
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="0">
+      <widget class="QLabel" name="label_3">
+       <property name="text">
+        <string>&amp;Message:</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
        </property>
        <property name="buddy">
-        <cstring>reqAmount</cstring>
+        <cstring>reqMessage</cstring>
        </property>
       </widget>
      </item>
-     <item row="3" column="1">
-      <widget class="BitcoinAmountField" name="reqAmount">
-       <property name="minimumSize">
-        <size>
-         <width>80</width>
-         <height>0</height>
-        </size>
-       </property>
+     <item row="4" column="2">
+      <widget class="QLineEdit" name="reqLabel">
        <property name="toolTip">
-        <string>The amount to request</string>
+        <string>The label to associate with the new receiving address</string>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="2">
+      <widget class="QLineEdit" name="reqMessage">
+       <property name="toolTip">
+        <string>The message to attach to payment request</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="2">
+      <widget class="QLabel" name="label_5">
+       <property name="text">
+        <string>Use this form to request payments. All fields are optional.</string>
        </property>
       </widget>
      </item>
@@ -52,71 +77,33 @@
        </property>
       </widget>
      </item>
-     <item row="4" column="1">
-      <widget class="QLineEdit" name="reqLabel">
-       <property name="toolTip">
-        <string>The label to associate with the receiving address</string>
-       </property>
-      </widget>
-     </item>
      <item row="5" column="0">
-      <widget class="QLabel" name="label_3">
+      <widget class="QLabel" name="label">
        <property name="text">
-        <string>&amp;Message:</string>
+        <string>&amp;Amount:</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
        </property>
        <property name="buddy">
-        <cstring>reqMessage</cstring>
+        <cstring>reqAmount</cstring>
        </property>
       </widget>
      </item>
-     <item row="5" column="1">
-      <widget class="QLineEdit" name="reqMessage">
+     <item row="5" column="2">
+      <widget class="BitcoinAmountField" name="reqAmount">
+       <property name="minimumSize">
+        <size>
+         <width>80</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="toolTip">
-        <string>The message to attach to payment request</string>
-       </property>
-      </widget>
-     </item>
-     <item row="6" column="0">
-      <widget class="QLabel" name="label_4">
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
-     </item>
-     <item row="6" column="1">
-      <widget class="QCheckBox" name="reuseAddress">
-       <property name="toolTip">
-        <string>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</string>
-       </property>
-       <property name="text">
-        <string>R&amp;euse an existing receiving address (not recommended)</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="1">
-      <widget class="QLabel" name="label_5">
-       <property name="text">
-        <string>Use this form to request payments. All fields are optional.</string>
+        <string>The amount to request</string>
        </property>
       </widget>
      </item>
     </layout>
-   </item>
-   <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
    </item>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
@@ -178,6 +165,98 @@
      </item>
     </layout>
    </item>
+   <item>
+    <spacer name="verticalSpacer_2">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QFrame" name="frame">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <widget class="QLabel" name="label_6">
+        <property name="font">
+         <font>
+          <weight>75</weight>
+          <bold>true</bold>
+         </font>
+        </property>
+        <property name="text">
+         <string>Previously requested payments</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QTableView" name="recentRequestsView"/>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <item>
+         <widget class="QPushButton" name="showRequestButton">
+          <property name="toolTip">
+           <string>Show the selected request (does the same as double clicking an entry)</string>
+          </property>
+          <property name="text">
+           <string>Show</string>
+          </property>
+          <property name="icon">
+           <iconset resource="../bitcoin.qrc">
+            <normaloff>:/icons/edit</normaloff>:/icons/edit</iconset>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="removeRequestButton">
+          <property name="toolTip">
+           <string>Remove the selected entries from the list</string>
+          </property>
+          <property name="text">
+           <string>Remove</string>
+          </property>
+          <property name="icon">
+           <iconset resource="../bitcoin.qrc">
+            <normaloff>:/icons/remove</normaloff>:/icons/remove</iconset>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_2">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
   </layout>
  </widget>
  <customwidgets>
@@ -187,6 +266,17 @@
    <header>bitcoinamountfield.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>reqLabel</tabstop>
+  <tabstop>reqAmount</tabstop>
+  <tabstop>reqMessage</tabstop>
+  <tabstop>reuseAddress</tabstop>
+  <tabstop>clearButton</tabstop>
+  <tabstop>receiveButton</tabstop>
+  <tabstop>recentRequestsView</tabstop>
+  <tabstop>showRequestButton</tabstop>
+  <tabstop>removeRequestButton</tabstop>
+ </tabstops>
  <resources>
   <include location="../bitcoin.qrc"/>
  </resources>

--- a/src/qt/forms/receiverequestdialog.ui
+++ b/src/qt/forms/receiverequestdialog.ui
@@ -84,13 +84,6 @@
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="btnCopyImage">
-       <property name="text">
-        <string>&amp;Copy Image</string>
-       </property>
-      </widget>
-     </item>
-     <item>
       <widget class="QPushButton" name="btnSaveAs">
        <property name="text">
         <string>&amp;Save Image...</string>

--- a/src/qt/receivecoinsdialog.cpp
+++ b/src/qt/receivecoinsdialog.cpp
@@ -12,6 +12,7 @@
 #include "guiutil.h"
 #include "receiverequestdialog.h"
 #include "addresstablemodel.h"
+#include "recentrequeststablemodel.h"
 
 #include <QMessageBox>
 #include <QTextDocument>
@@ -27,6 +28,8 @@ ReceiveCoinsDialog::ReceiveCoinsDialog(QWidget *parent) :
 #ifdef Q_OS_MAC // Icons on push buttons are very uncommon on Mac
     ui->clearButton->setIcon(QIcon());
     ui->receiveButton->setIcon(QIcon());
+    ui->showRequestButton->setIcon(QIcon());
+    ui->removeRequestButton->setIcon(QIcon());
 #endif
     connect(ui->clearButton, SIGNAL(clicked()), this, SLOT(clear()));
 }
@@ -39,6 +42,19 @@ void ReceiveCoinsDialog::setModel(WalletModel *model)
     {
         connect(model->getOptionsModel(), SIGNAL(displayUnitChanged(int)), this, SLOT(updateDisplayUnit()));
         updateDisplayUnit();
+
+        ui->recentRequestsView->setModel(model->getRecentRequestsTableModel());
+        ui->recentRequestsView->setAlternatingRowColors(true);
+        ui->recentRequestsView->setSelectionBehavior(QAbstractItemView::SelectRows);
+        ui->recentRequestsView->setSelectionMode(QAbstractItemView::ContiguousSelection);
+        ui->recentRequestsView->horizontalHeader()->resizeSection(RecentRequestsTableModel::Date, 130);
+        ui->recentRequestsView->horizontalHeader()->resizeSection(RecentRequestsTableModel::Label, 120);
+#if QT_VERSION < 0x050000
+        ui->recentRequestsView->horizontalHeader()->setResizeMode(RecentRequestsTableModel::Message, QHeaderView::Stretch);
+#else
+        ui->recentRequestsView->horizontalHeader()->setSectionResizeMode(RecentRequestsTableModel::Message, QHeaderView::Stretch);
+#endif
+        ui->recentRequestsView->horizontalHeader()->resizeSection(RecentRequestsTableModel::Amount, 100);
     }
 }
 
@@ -76,7 +92,7 @@ void ReceiveCoinsDialog::updateDisplayUnit()
 
 void ReceiveCoinsDialog::on_receiveButton_clicked()
 {
-    if(!model || !model->getOptionsModel() || !model->getAddressTableModel())
+    if(!model || !model->getOptionsModel() || !model->getAddressTableModel() || !model->getRecentRequestsTableModel())
         return;
 
     QString address;
@@ -108,4 +124,41 @@ void ReceiveCoinsDialog::on_receiveButton_clicked()
     dialog->setAttribute(Qt::WA_DeleteOnClose);
     dialog->show();
     clear();
+
+    /* Store request for later reference */
+    model->getRecentRequestsTableModel()->addNewRequest(info);
+}
+
+void ReceiveCoinsDialog::on_recentRequestsView_doubleClicked(const QModelIndex &index)
+{
+    const RecentRequestsTableModel *submodel = model->getRecentRequestsTableModel();
+    ReceiveRequestDialog *dialog = new ReceiveRequestDialog(this);
+    dialog->setModel(model->getOptionsModel());
+    dialog->setInfo(submodel->entry(index.row()).recipient);
+    dialog->setAttribute(Qt::WA_DeleteOnClose);
+    dialog->show();
+}
+
+void ReceiveCoinsDialog::on_showRequestButton_clicked()
+{
+    if(!model || !model->getRecentRequestsTableModel() || !ui->recentRequestsView->selectionModel())
+        return;
+    QModelIndexList selection = ui->recentRequestsView->selectionModel()->selectedRows();
+
+    foreach (QModelIndex index, selection)
+    {
+        on_recentRequestsView_doubleClicked(index);
+    }
+}
+
+void ReceiveCoinsDialog::on_removeRequestButton_clicked()
+{
+    if(!model || !model->getRecentRequestsTableModel() || !ui->recentRequestsView->selectionModel())
+        return;
+    QModelIndexList selection = ui->recentRequestsView->selectionModel()->selectedRows();
+    if(selection.empty())
+        return;
+    // correct for selection mode ContiguousSelection
+    QModelIndex firstIndex = selection.at(0);
+    model->getRecentRequestsTableModel()->removeRows(firstIndex.row(), selection.length(), firstIndex.parent());
 }

--- a/src/qt/receivecoinsdialog.h
+++ b/src/qt/receivecoinsdialog.h
@@ -13,6 +13,9 @@ namespace Ui {
 }
 class WalletModel;
 class OptionsModel;
+QT_BEGIN_NAMESPACE
+class QModelIndex;
+QT_END_NAMESPACE
 
 /** Dialog for requesting payment of bitcoins */
 class ReceiveCoinsDialog : public QDialog
@@ -36,6 +39,9 @@ private:
 
 private slots:
     void on_receiveButton_clicked();
+    void on_showRequestButton_clicked();
+    void on_removeRequestButton_clicked();
+    void on_recentRequestsView_doubleClicked(const QModelIndex &index);
     void updateDisplayUnit();
 };
 

--- a/src/qt/receiverequestdialog.cpp
+++ b/src/qt/receiverequestdialog.cpp
@@ -85,12 +85,10 @@ ReceiveRequestDialog::ReceiveRequestDialog(QWidget *parent) :
 
 #ifndef USE_QRCODE
     ui->btnSaveAs->setVisible(false);
-    ui->btnCopyImage->setVisible(false);
     ui->lblQRCode->setVisible(false);
 #endif
 
     connect(ui->btnSaveAs, SIGNAL(clicked()), ui->lblQRCode, SLOT(saveImage()));
-    connect(ui->btnCopyImage, SIGNAL(clicked()), ui->lblQRCode, SLOT(copyImage()));
 }
 
 ReceiveRequestDialog::~ReceiveRequestDialog()

--- a/src/qt/recentrequeststablemodel.cpp
+++ b/src/qt/recentrequeststablemodel.cpp
@@ -1,0 +1,121 @@
+// Copyright (c) 2011-2013 The Bitcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "recentrequeststablemodel.h"
+#include "guiutil.h"
+#include "bitcoinunits.h"
+#include "optionsmodel.h"
+
+RecentRequestsTableModel::RecentRequestsTableModel(CWallet *wallet, WalletModel *parent):
+    walletModel(parent)
+{
+    /* These columns must match the indices in the ColumnIndex enumeration */
+    columns << tr("Date") << tr("Label") << tr("Message") << tr("Amount");
+}
+
+RecentRequestsTableModel::~RecentRequestsTableModel()
+{
+    /* Intentionally left empty */
+}
+
+int RecentRequestsTableModel::rowCount(const QModelIndex &parent) const
+{
+    Q_UNUSED(parent);
+    return list.length();
+}
+
+int RecentRequestsTableModel::columnCount(const QModelIndex &parent) const
+{
+    Q_UNUSED(parent);
+    return columns.length();
+}
+
+QVariant RecentRequestsTableModel::data(const QModelIndex &index, int role) const
+{
+    if(!index.isValid() || index.row() >= list.length())
+        return QVariant();
+
+    const RecentRequestEntry *rec = &list[index.row()];
+
+    if(role == Qt::DisplayRole || role == Qt::EditRole)
+    {
+        switch(index.column())
+        {
+        case Date:
+            return GUIUtil::dateTimeStr(rec->date);
+        case Label:
+            if(rec->recipient.label.isEmpty() && role == Qt::DisplayRole)
+            {
+                return tr("(no label)");
+            }
+            else
+            {
+                return rec->recipient.label;
+            }
+        case Message:
+            if(rec->recipient.message.isEmpty() && role == Qt::DisplayRole)
+            {
+                return tr("(no message)");
+            }
+            else
+            {
+                return rec->recipient.message;
+            }
+        case Amount:
+            return BitcoinUnits::format(walletModel->getOptionsModel()->getDisplayUnit(), rec->recipient.amount);
+        }
+    }
+    return QVariant();
+}
+
+bool RecentRequestsTableModel::setData(const QModelIndex &index, const QVariant &value, int role)
+{
+    return true;
+}
+
+QVariant RecentRequestsTableModel::headerData(int section, Qt::Orientation orientation, int role) const
+{
+    if(orientation == Qt::Horizontal)
+    {
+        if(role == Qt::DisplayRole && section < columns.size())
+        {
+            return columns[section];
+        }
+    }
+    return QVariant();
+}
+
+QModelIndex RecentRequestsTableModel::index(int row, int column, const QModelIndex &parent) const
+{
+    return createIndex(row, column, 0);
+}
+
+bool RecentRequestsTableModel::removeRows(int row, int count, const QModelIndex &parent)
+{
+    Q_UNUSED(parent);
+    if(count > 0 && row >= 0 && (row+count) <= list.size())
+    {
+        beginRemoveRows(parent, row, row + count - 1);
+        list.erase(list.begin() + row, list.begin() + row + count);
+        endRemoveRows();
+        return true;
+    } else {
+        return false;
+    }
+}
+
+Qt::ItemFlags RecentRequestsTableModel::flags(const QModelIndex &index) const
+{
+    return Qt::ItemIsSelectable | Qt::ItemIsEnabled;
+}
+
+void RecentRequestsTableModel::addNewRequest(const SendCoinsRecipient &recipient)
+{
+    RecentRequestEntry newEntry;
+    newEntry.date = QDateTime::currentDateTime();
+    newEntry.recipient = recipient;
+    beginInsertRows(QModelIndex(), 0, 0);
+    list.prepend(newEntry);
+    endInsertRows();
+}

--- a/src/qt/recentrequeststablemodel.h
+++ b/src/qt/recentrequeststablemodel.h
@@ -1,0 +1,61 @@
+// Copyright (c) 2011-2013 The Bitcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef RECENTREQUESTSTABLEMODEL_H
+#define RECENTREQUESTSTABLEMODEL_H
+
+#include <QAbstractTableModel>
+#include <QStringList>
+#include <QDateTime>
+
+#include "walletmodel.h"
+
+class CWallet;
+
+struct RecentRequestEntry
+{
+    QDateTime date;
+    SendCoinsRecipient recipient;
+};
+
+/** Model for list of recently generated payment requests / bitcoin URIs.
+ * Part of wallet model.
+ */
+class RecentRequestsTableModel: public QAbstractTableModel
+{
+    Q_OBJECT
+
+public:
+    explicit RecentRequestsTableModel(CWallet *wallet, WalletModel *parent = 0);
+    ~RecentRequestsTableModel();
+
+    enum ColumnIndex {
+        Date = 0,
+        Label = 1,
+        Message = 2,
+        Amount = 3
+    };
+
+    /** @name Methods overridden from QAbstractTableModel
+        @{*/
+    int rowCount(const QModelIndex &parent) const;
+    int columnCount(const QModelIndex &parent) const;
+    QVariant data(const QModelIndex &index, int role) const;
+    bool setData(const QModelIndex &index, const QVariant &value, int role);
+    QVariant headerData(int section, Qt::Orientation orientation, int role) const;
+    QModelIndex index(int row, int column, const QModelIndex &parent) const;
+    bool removeRows(int row, int count, const QModelIndex &parent = QModelIndex());
+    Qt::ItemFlags flags(const QModelIndex &index) const;
+    /*@}*/
+
+    const RecentRequestEntry &entry(int row) const { return list[row]; }
+    void addNewRequest(const SendCoinsRecipient &recipient);
+
+private:
+    WalletModel *walletModel;
+    QStringList columns;
+    QList<RecentRequestEntry> list;
+};
+
+#endif

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -7,6 +7,7 @@
 #include "addresstablemodel.h"
 #include "guiconstants.h"
 #include "transactiontablemodel.h"
+#include "recentrequeststablemodel.h"
 
 #include "base58.h"
 #include "db.h"
@@ -26,6 +27,7 @@
 WalletModel::WalletModel(CWallet *wallet, OptionsModel *optionsModel, QObject *parent) :
     QObject(parent), wallet(wallet), optionsModel(optionsModel), addressTableModel(0),
     transactionTableModel(0),
+    recentRequestsTableModel(0),
     cachedBalance(0), cachedUnconfirmedBalance(0), cachedImmatureBalance(0),
     cachedNumTransactions(0),
     cachedEncryptionStatus(Unencrypted),
@@ -33,6 +35,7 @@ WalletModel::WalletModel(CWallet *wallet, OptionsModel *optionsModel, QObject *p
 {
     addressTableModel = new AddressTableModel(wallet, this);
     transactionTableModel = new TransactionTableModel(wallet, this);
+    recentRequestsTableModel = new RecentRequestsTableModel(wallet, this);
 
     // This timer will be fired repeatedly to update the balance
     pollTimer = new QTimer(this);
@@ -323,6 +326,11 @@ AddressTableModel *WalletModel::getAddressTableModel()
 TransactionTableModel *WalletModel::getTransactionTableModel()
 {
     return transactionTableModel;
+}
+
+RecentRequestsTableModel *WalletModel::getRecentRequestsTableModel()
+{
+    return recentRequestsTableModel;
 }
 
 WalletModel::EncryptionStatus WalletModel::getEncryptionStatus() const

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -18,6 +18,7 @@
 class AddressTableModel;
 class OptionsModel;
 class TransactionTableModel;
+class RecentRequestsTableModel;
 class WalletModelTransaction;
 
 class CCoinControl;
@@ -88,6 +89,7 @@ public:
     OptionsModel *getOptionsModel();
     AddressTableModel *getAddressTableModel();
     TransactionTableModel *getTransactionTableModel();
+    RecentRequestsTableModel *getRecentRequestsTableModel();
 
     qint64 getBalance(const CCoinControl *coinControl = NULL) const;
     qint64 getUnconfirmedBalance() const;
@@ -160,6 +162,7 @@ private:
 
     AddressTableModel *addressTableModel;
     TransactionTableModel *transactionTableModel;
+    RecentRequestsTableModel *recentRequestsTableModel;
 
     // Cache some values to be able to detect changes
     qint64 cachedBalance;


### PR DESCRIPTION
Continuation of work in #3099.

Keep a list of requested payments in the Receive tab so that a user can recall previously created receive requests after closing their windows.

Currently this list is not stored between bitcoin-qt sessions. This can be implemented later, but it is not clear here it should be stored as I don't think it belongs in the wallet (maybe in QSettings?) at least until it is really associated with a transaction.

![recently_requested](https://f.cloud.github.com/assets/126646/1475793/dc78e68a-4640-11e3-812b-3f39978099c4.png)
