### PR TITLE
[Qt] allow drag and drop of payment request URLs on main window

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -711,30 +711,6 @@ void BitcoinGUI::dragEnterEvent(QDragEnterEvent *event)
         event->acceptProposedAction();
 }
 
-void BitcoinGUI::dropEvent(QDropEvent *event)
-{
-    if(event->mimeData()->hasUrls())
-    {
-        int nValidUrisFound = 0;
-        QList<QUrl> uris = event->mimeData()->urls();
-        foreach(const QUrl &uri, uris)
-        {
-            SendCoinsRecipient r;
-            if (GUIUtil::parseBitcoinURI(uri, &r) && walletFrame->handlePaymentRequest(r))
-                nValidUrisFound++;
-        }
-
-        // if valid URIs were found
-        if (nValidUrisFound)
-            walletFrame->gotoSendCoinsPage();
-        else
-            message(tr("URI handling"), tr("URI can not be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters."),
-                CClientUIInterface::ICON_WARNING);
-    }
-
-    event->acceptProposedAction();
-}
-
 bool BitcoinGUI::eventFilter(QObject *object, QEvent *event)
 {
     // Catch status tip events

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -66,7 +66,6 @@ protected:
     void changeEvent(QEvent *e);
     void closeEvent(QCloseEvent *event);
     void dragEnterEvent(QDragEnterEvent *event);
-    void dropEvent(QDropEvent *event);
     bool eventFilter(QObject *object, QEvent *event);
 
 private:

--- a/src/qt/paymentserver.h
+++ b/src/qt/paymentserver.h
@@ -80,10 +80,6 @@ public:
     // Setup networking
     void initNetManager();
 
-    // Constructor registers this on the parent QApplication to
-    // receive QEvent::FileOpen events
-    bool eventFilter(QObject *object, QEvent *event);
-
     // OptionsModel is used for getting proxy settings and display unit
     void setOptionsModel(OptionsModel *optionsModel);
 
@@ -110,6 +106,11 @@ private slots:
     void netRequestFinished(QNetworkReply*);
     void reportSslErrors(QNetworkReply*, const QList<QSslError> &);
     void handlePaymentACK(const QString& paymentACKMsg);
+
+protected:
+    // Constructor registers this on the parent QApplication to
+    // receive QEvent::FileOpen and QEvent:Drop events
+    bool eventFilter(QObject *object, QEvent *event);
 
 private:
     static bool readPaymentRequest(const QString& filename, PaymentRequestPlus& request);


### PR DESCRIPTION
- this change extends our working drag and drop feature for bitcoin: URIs
  by adding support for payment request URIs (payment request files should
  be easy to do in another pull also)
- removes code from BitcoinGUI and lets PaymentServer handle it
- makes eventFilter() in PaymentServer protected

Intended as a first step for #3202.
