### PR TITLE
[Qt] make event() and eventFilter() in askpassphrasedialog protected

### DIFF
--- a/src/qt/askpassphrasedialog.h
+++ b/src/qt/askpassphrasedialog.h
@@ -41,6 +41,8 @@ private:
 
 private slots:
     void textChanged();
+
+protected:
     bool event(QEvent *event);
     bool eventFilter(QObject *object, QEvent *event);
 };


### PR DESCRIPTION
@laanwj Could you check the `AskPassphraseDialog::event()` code, it looks like we nearly duplicated `AskPassphraseDialog::eventFilter()`. Perhaps it's save to remove it, I'm not sure.
