### PR TITLE
qt: add Open URI dialog

### DIFF
--- a/contrib/bitcoin-qt.pro
+++ b/contrib/bitcoin-qt.pro
@@ -12,7 +12,8 @@ FORMS += \
     ../src/qt/forms/addressbookpage.ui \
     ../src/qt/forms/aboutdialog.ui \
     ../src/qt/forms/receivecoinsdialog.ui \
-    ../src/qt/forms/receiverequestdialog.ui
+    ../src/qt/forms/receiverequestdialog.ui \
+    ../src/qt/forms/openuridialog.ui
 
 RESOURCES += \
     ../src/qt/bitcoin.qrc

--- a/src/qt/Makefile.am
+++ b/src/qt/Makefile.am
@@ -33,6 +33,7 @@ QT_TS = locale/bitcoin_ach.ts locale/bitcoin_af_ZA.ts locale/bitcoin_ar.ts \
 
 QT_FORMS_UI = forms/aboutdialog.ui forms/addressbookpage.ui \
   forms/askpassphrasedialog.ui forms/editaddressdialog.ui forms/intro.ui \
+  forms/openuridialog.ui \
   forms/optionsdialog.ui forms/overviewpage.ui forms/receiverequestdialog.ui \
   forms/receivecoinsdialog.ui \
   forms/rpcconsole.ui forms/sendcoinsdialog.ui forms/sendcoinsentry.ui \
@@ -44,7 +45,9 @@ QT_MOC_CPP = moc_aboutdialog.cpp moc_addressbookpage.cpp \
   moc_bitcoingui.cpp moc_bitcoinunits.cpp moc_clientmodel.cpp \
   moc_csvmodelwriter.cpp moc_editaddressdialog.cpp moc_guiutil.cpp \
   moc_intro.cpp moc_macdockiconhandler.cpp moc_macnotificationhandler.cpp \
-  moc_monitoreddatamapper.cpp moc_notificator.cpp moc_optionsdialog.cpp \
+  moc_monitoreddatamapper.cpp moc_notificator.cpp \
+  moc_openuridialog.cpp \
+  moc_optionsdialog.cpp \
   moc_optionsmodel.cpp moc_overviewpage.cpp moc_paymentserver.cpp \
   moc_receiverequestdialog.cpp moc_qvalidatedlineedit.cpp moc_qvaluecombobox.cpp \
   moc_receivecoinsdialog.cpp \
@@ -69,7 +72,9 @@ BITCOIN_QT_H  = aboutdialog.h addressbookpage.h addresstablemodel.h \
   askpassphrasedialog.h bitcoinaddressvalidator.h bitcoinamountfield.h \
   bitcoingui.h bitcoinunits.h clientmodel.h csvmodelwriter.h \
   editaddressdialog.h guiconstants.h guiutil.h intro.h macdockiconhandler.h \
-  macnotificationhandler.h monitoreddatamapper.h notificator.h optionsdialog.h \
+  macnotificationhandler.h monitoreddatamapper.h notificator.h \
+  openuridialog.h \
+  optionsdialog.h \
   optionsmodel.h overviewpage.h paymentrequestplus.h paymentserver.h \
   receivecoinsdialog.h \
   receiverequestdialog.h qvalidatedlineedit.h qvaluecombobox.h rpcconsole.h \
@@ -100,6 +105,7 @@ BITCOIN_QT_CPP = aboutdialog.cpp addressbookpage.cpp \
   bitcoinamountfield.cpp bitcoin.cpp bitcoingui.cpp \
   bitcoinunits.cpp clientmodel.cpp csvmodelwriter.cpp editaddressdialog.cpp \
   guiutil.cpp intro.cpp monitoreddatamapper.cpp notificator.cpp \
+  openuridialog.cpp \
   optionsdialog.cpp optionsmodel.cpp overviewpage.cpp paymentrequestplus.cpp \
   paymentserver.cpp qvalidatedlineedit.cpp qvaluecombobox.cpp \
   receivecoinsdialog.cpp receiverequestdialog.cpp \

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -334,6 +334,8 @@ int main(int argc, char *argv[])
                 // bitcoin: URIs or payment requests:
                 QObject::connect(paymentServer, SIGNAL(receivedPaymentRequest(SendCoinsRecipient)),
                                  &window, SLOT(handlePaymentRequest(SendCoinsRecipient)));
+                QObject::connect(&window, SIGNAL(receivedURI(QString)),
+                                 paymentServer, SLOT(handleURIOrFile(QString)));
                 QObject::connect(&walletModel, SIGNAL(coinsSent(CWallet*,SendCoinsRecipient,QByteArray)),
                                  paymentServer, SLOT(fetchPaymentACK(CWallet*,const SendCoinsRecipient&,QByteArray)));
                 QObject::connect(paymentServer, SIGNAL(message(QString,QString,unsigned int)),

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -87,6 +87,7 @@ private:
     QAction *changePassphraseAction;
     QAction *aboutQtAction;
     QAction *openRPCConsoleAction;
+    QAction *openAction;
 
     QSystemTrayIcon *trayIcon;
     Notificator *notificator;
@@ -106,6 +107,10 @@ private:
     void createTrayIcon(bool fIsTestnet);
     /** Create system tray menu (or setup the dock menu) */
     void createTrayIconMenu();
+
+signals:
+    /** Signal raised when a URI was entered or dragged to the GUI */
+    void receivedURI(const QString &uri);
 
 public slots:
     /** Set number of connections shown in the UI */
@@ -165,6 +170,8 @@ private slots:
     /** Handle tray icon clicked */
     void trayIconActivated(QSystemTrayIcon::ActivationReason reason);
 #endif
+    /** Show open dialog */
+    void openClicked();
 
     /** Show window if hidden, unminimize when minimized, rise when obscured or show if hidden and fToggleHidden is true */
     void showNormalIfMinimized(bool fToggleHidden = false);

--- a/src/qt/forms/openuridialog.ui
+++ b/src/qt/forms/openuridialog.ui
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>OpenURIDialog</class>
+ <widget class="QDialog" name="OpenURIDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>564</width>
+    <height>109</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Open URI</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>Open payment request from URI or file</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>URI:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QValidatedLineEdit" name="uriEdit">
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="selectFileButton">
+       <property name="toolTip">
+        <string>Select payment request file</string>
+       </property>
+       <property name="text">
+        <string notr="true">…</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QValidatedLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>qvalidatedlineedit.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>OpenURIDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>OpenURIDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -278,6 +278,41 @@ QString getSaveFileName(QWidget *parent, const QString &caption, const QString &
     return result;
 }
 
+QString getOpenFileName(QWidget *parent, const QString &caption, const QString &dir,
+    const QString &filter,
+    QString *selectedSuffixOut)
+{
+    QString selectedFilter;
+    QString myDir;
+    if(dir.isEmpty()) // Default to user documents location
+    {
+#if QT_VERSION < 0x050000
+        myDir = QDesktopServices::storageLocation(QDesktopServices::DocumentsLocation);
+#else
+        myDir = QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
+#endif
+    }
+    else
+    {
+        myDir = dir;
+    }
+    /* Directly convert path to native OS path separators */
+    QString result = QDir::toNativeSeparators(QFileDialog::getOpenFileName(parent, caption, myDir, filter, &selectedFilter));
+
+    if(selectedSuffixOut)
+    {
+        /* Extract first suffix from filter pattern "Description (*.foo)" or "Description (*.foo *.bar ...) */
+        QRegExp filter_re(".* \\(\\*\\.(.*)[ \\)]");
+        QString selectedSuffix;
+        if(filter_re.exactMatch(selectedFilter))
+        {
+            selectedSuffix = filter_re.cap(1);
+        }
+        *selectedSuffixOut = selectedSuffix;
+    }
+    return result;
+}
+
 Qt::ConnectionType blockingGUIThreadConnection()
 {
     if(QThread::currentThread() != qApp->thread())

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -36,7 +36,6 @@ namespace GUIUtil
     void setupAmountWidget(QLineEdit *widget, QWidget *parent);
 
     // Parse "bitcoin:" URI into recipient object, return true on successful parsing
-    // See Bitcoin URI definition discussion here: https://bitcointalk.org/index.php?topic=33490.0
     bool parseBitcoinURI(const QUrl &uri, SendCoinsRecipient *out);
     bool parseBitcoinURI(QString uri, SendCoinsRecipient *out);
     QString formatBitcoinURI(const SendCoinsRecipient &info);
@@ -69,6 +68,19 @@ namespace GUIUtil
     QString getSaveFileName(QWidget *parent=0, const QString &caption=QString(),
                                    const QString &dir=QString(), const QString &filter=QString(),
                                    QString *selectedSuffixOut=0);
+
+    /** Get open filename, convenience wrapper for QFileDialog::getOpenFileName.
+
+      @param[in] parent  Parent window (or 0)
+      @param[in] caption Window caption (or empty, for default)
+      @param[in] dir     Starting directory (or empty, to default to documents directory)
+      @param[in] filter  Filter specification such as "Comma Separated Files (*.csv)"
+      @param[out] selectedSuffixOut  Pointer to return the suffix (file type) that was selected (or 0).
+                  Can be useful when choosing the save file format based on suffix.
+     */
+    QString getOpenFileName(QWidget *parent, const QString &caption, const QString &dir,
+        const QString &filter,
+        QString *selectedSuffixOut);
 
     /** Get connection type to call object slot in GUI thread with invokeMethod. The call will be blocking.
 

--- a/src/qt/openuridialog.cpp
+++ b/src/qt/openuridialog.cpp
@@ -1,0 +1,52 @@
+// Copyright (c) 2011-2013 The Bitcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "openuridialog.h"
+#include "ui_openuridialog.h"
+
+#include "guiutil.h"
+#include "walletmodel.h"
+
+#include <QUrl>
+
+OpenURIDialog::OpenURIDialog(QWidget *parent) :
+    QDialog(parent),
+    ui(new Ui::OpenURIDialog)
+{
+    ui->setupUi(this);
+#if QT_VERSION >= 0x040700
+    ui->uriEdit->setPlaceholderText("bitcoin:");
+#endif
+}
+
+OpenURIDialog::~OpenURIDialog()
+{
+    delete ui;
+}
+
+QString OpenURIDialog::getURI()
+{
+    return ui->uriEdit->text();
+}
+
+void OpenURIDialog::accept()
+{
+    SendCoinsRecipient rcp;
+    if(GUIUtil::parseBitcoinURI(getURI(), &rcp))
+    {
+        /* Only accept value URIs */
+        QDialog::accept();
+    } else {
+        ui->uriEdit->setValid(false);
+    }
+}
+
+void OpenURIDialog::on_selectFileButton_clicked()
+{
+    QString filename = GUIUtil::getOpenFileName(this, tr("Select payment request file to open"), "", "", NULL);
+    if(filename.isEmpty())
+        return;
+    QUrl fileUri = QUrl::fromLocalFile(filename);
+    ui->uriEdit->setText("bitcoin:?request=" + QUrl::toPercentEncoding(fileUri.toString()));
+}

--- a/src/qt/openuridialog.h
+++ b/src/qt/openuridialog.h
@@ -1,0 +1,34 @@
+// Copyright (c) 2011-2013 The Bitcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef OPENURIDIALOG_H
+#define OPENURIDIALOG_H
+
+#include <QDialog>
+
+namespace Ui {
+class OpenURIDialog;
+}
+
+class OpenURIDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit OpenURIDialog(QWidget *parent = 0);
+    ~OpenURIDialog();
+
+    QString getURI();
+
+protected slots:
+    void accept();
+
+private slots:
+    void on_selectFileButton_clicked();
+
+private:
+    Ui::OpenURIDialog *ui;
+};
+
+#endif // OPENURIDIALOG_H

--- a/src/qt/paymentserver.h
+++ b/src/qt/paymentserver.h
@@ -105,6 +105,9 @@ public slots:
     // Submit Payment message to a merchant, get back PaymentACK:
     void fetchPaymentACK(CWallet* wallet, SendCoinsRecipient recipient, QByteArray transaction);
 
+    // Handle an incoming URI or file
+    void handleURIOrFile(const QString& s);
+
 private slots:
     void handleURIConnection();
     void netRequestFinished(QNetworkReply*);
@@ -114,7 +117,6 @@ private slots:
 private:
     static bool readPaymentRequest(const QString& filename, PaymentRequestPlus& request);
     bool processPaymentRequest(PaymentRequestPlus& request, SendCoinsRecipient& recipient);
-    void handleURIOrFile(const QString& s);
     void fetchRequest(const QUrl& url);
 
     bool saveURIs;                      // true during startup


### PR DESCRIPTION
This adds a simple "Open URI..." option to the menu which allows manually opening URIs and payment requests from files on disk.

![openurl1](https://f.cloud.github.com/assets/126646/1482933/a436f73c-46ed-11e3-9a17-c05f9d03c62c.png)
![openurl2](https://f.cloud.github.com/assets/126646/1482934/a448fe5a-46ed-11e3-8086-eda85889fec3.png)

Some behind-the-scenes code changes:
- Always route received URIs (even those drag/dropped) through PaymentServer; this means that bitcoin: URIs that refer to payment requests can be used
- Add getOpenFileName function to GUIUtil analogous to getSaveFileName

Addresses #3202.
