### PR TITLE
Update build docs that refer to old makefile.* files.

### DIFF
--- a/doc/build-msw.md
+++ b/doc/build-msw.md
@@ -76,6 +76,8 @@ Bitcoin
 -------
 DOS prompt:
 
-	cd \bitcoin\src
-	mingw32-make -f makefile.mingw
+	cd \bitcoin
+	sh autogen.sh
+	sh configure
+	mingw32-make
 	strip bitcoind.exe

--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -56,12 +56,13 @@ Installing the dependencies using MacPorts is very straightforward.
 
 2.  Build bitcoind:
 
-        cd src
-        make -f makefile.osx
+        ./autogen.sh
+        ./configure
+        make
 
 3.  It is a good idea to build and run the unit tests, too:
 
-        make -f makefile.osx test
+        make test
 
 Instructions: HomeBrew
 ----------------------
@@ -89,22 +90,15 @@ Rerunning "openssl version" should now return the correct version.
         git clone git@github.com:bitcoin/bitcoin.git bitcoin
         cd bitcoin
 
-2.  Modify source in order to pick up the `openssl` library.
+2.  Build bitcoind:
 
-    Edit `makefile.osx` to account for library location differences. There's a
-    diff in `contrib/homebrew/makefile.osx.patch` that shows what you need to
-    change, or you can just patch by doing
+        ./autogen.sh
+        ./configure
+        make
 
-        patch -p1 < contrib/homebrew/makefile.osx.patch
+3.  It is a good idea to build and run the unit tests, too:
 
-3.  Build bitcoind:
-
-        cd src
-        make -f makefile.osx
-
-4.  It is a good idea to build and run the unit tests, too:
-
-        make -f makefile.osx test
+        make test
 
 Creating a release build
 ------------------------

--- a/qa/pull-tester/pull-tester.py
+++ b/qa/pull-tester/pull-tester.py
@@ -81,7 +81,7 @@ This pull does not merge cleanly onto current master""" + common_message}
         post_data = { "body" : "Automatic sanity-testing: FAILED BUILD/TEST, see " + linkUrl + " for binaries and test log." + """
 
 This could happen for one of several reasons:
-1. It chanages paths in makefile.linux-mingw or otherwise changes build scripts in a way that made them incompatible with the automated testing scripts (please tweak those patches in qa/pull-tester)
+1. It chanages changes build scripts in a way that made them incompatible with the automated testing scripts (please tweak those patches in qa/pull-tester)
 2. It adds/modifies tests which test network rules (thanks for doing that), which conflicts with a patch applied at test time
 3. It does not build on either Linux i386 or Win32 (via MinGW cross compile)
 4. The test suite fails on either Linux i386 or Win32


### PR DESCRIPTION
Updates some documentation, sparked from issue #3230.

I cannot test the build instructions myself, but assume they will work (what is there now doesn't work regardless).

The command

```
find . -path '*/.git*' -prune -o -type f -exec grep makefile\\. {} \; -print
```

shows only 2 more files that reference the old makefile.\* files:

```
        cd src; $(MAKE) -f makefile.unix bitcoind
        cd src; $(MAKE) -f makefile.unix clean
        cd src; $(MAKE) -f makefile.unix test_bitcoin
./contrib/debian/rules
      src/makefile.osx (Expat).
./contrib/debian/changelog
```
