### PR TITLE
doc: add note about building on Ubuntu 13.10

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -11,6 +11,11 @@ To Build
 
 This will build bitcoin-qt as well if the dependencies are met.
 
+**Note:** on Ubuntu 13.10 (Saucy Salamander) the boost configuration script doesn't look in the
+correct directory and an error about boost-system will appear. For now you need to do
+
+        ./configure --with-boost-libdir=/usr/lib/x86_64-linux-gnu
+
 Dependencies
 ---------------------
 
@@ -57,7 +62,7 @@ Dependency Build Instructions: Ubuntu & Debian
 Build requirements:
 
 	sudo apt-get install build-essential
-	sudo apt-get install libtool autotools-dev
+	sudo apt-get install libtool autotools-dev autoconf
 	sudo apt-get install libssl-dev
 
 for Ubuntu 12.04 and later:


### PR DESCRIPTION
Add note about building on Ubuntu 13.10 (issue #3219).

Also mention `autoconf` as required package.
