### PR TITLE
Silence inttypes.h compiler warnings on Windows

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -46,6 +46,16 @@ static const int64_t CENT = 1000000;
 #define UEND(a)             ((unsigned char*)&((&(a))[1]))
 #define ARRAYLEN(array)     (sizeof(array)/sizeof((array)[0]))
 
+/* Silence compiler warnings on Windows related to MinGWs inttypes.h */
+#if defined(_MSC_VER) || defined(__MSVCRT__)
+#undef PRId64
+#define PRId64 "I64d"
+#undef PRIu64
+#define PRIu64 "I64u"
+#undef PRIx64
+#define PRIx64 "I64x"
+#endif
+
 /* Format characters for (s)size_t and ptrdiff_t */
 #if defined(_MSC_VER) || defined(__MSVCRT__)
   /* (s)size_t and ptrdiff_t have the same size specifier in MSVC:


### PR DESCRIPTION
- the warnings are related to MinGWs inttypes.h (observed with MinGW based
  on GCC version 4.8.1 (rev5, Built by MinGW-W64 project) and likely
  other version also suffer from this)
- fixes #3236
