### PR TITLE
[Qt] remove GUIUtil::getSaveFileName() default arguments

### DIFF
--- a/src/qt/addressbookpage.cpp
+++ b/src/qt/addressbookpage.cpp
@@ -263,10 +263,9 @@ void AddressBookPage::done(int retval)
 void AddressBookPage::on_exportButton_clicked()
 {
     // CSV is currently the only supported format
-    QString filename = GUIUtil::getSaveFileName(
-            this,
-            tr("Export Address List"), QString(),
-            tr("Comma separated file (*.csv)"));
+    QString filename = GUIUtil::getSaveFileName(this,
+        tr("Export Address List"), QString(),
+        tr("Comma separated file (*.csv)"), NULL);
 
     if (filename.isNull()) return;
 

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -65,9 +65,9 @@ namespace GUIUtil
       @param[out] selectedSuffixOut  Pointer to return the suffix (file type) that was selected (or 0).
                   Can be useful when choosing the save file format based on suffix.
      */
-    QString getSaveFileName(QWidget *parent=0, const QString &caption=QString(),
-                                   const QString &dir=QString(), const QString &filter=QString(),
-                                   QString *selectedSuffixOut=0);
+    QString getSaveFileName(QWidget *parent, const QString &caption, const QString &dir,
+        const QString &filter,
+        QString *selectedSuffixOut);
 
     /** Get open filename, convenience wrapper for QFileDialog::getOpenFileName.
 

--- a/src/qt/receiverequestdialog.cpp
+++ b/src/qt/receiverequestdialog.cpp
@@ -64,7 +64,7 @@ void QRImageWidget::mousePressEvent(QMouseEvent *event)
 
 void QRImageWidget::saveImage()
 {
-    QString fn = GUIUtil::getSaveFileName(this, tr("Save QR Code"), QString(), tr("PNG Images (*.png)"));
+    QString fn = GUIUtil::getSaveFileName(this, tr("Save QR Code"), QString(), tr("PNG Image (*.png)"), NULL);
     if (!fn.isEmpty())
     {
         exportImage().save(fn);

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -273,7 +273,7 @@ void TransactionView::exportClicked()
     // CSV is currently the only supported format
     QString filename = GUIUtil::getSaveFileName(this,
         tr("Export Transaction History"), QString(),
-        tr("Comma separated file (*.csv)"));
+        tr("Comma separated file (*.csv)"), NULL);
 
     if (filename.isNull())
         return;

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -223,7 +223,7 @@ void WalletView::backupWallet()
 {
     QString filename = GUIUtil::getSaveFileName(this,
         tr("Backup Wallet"), QString(),
-        tr("Wallet Data (*.dat)"));
+        tr("Wallet Data (*.dat)"), NULL);
 
     if (filename.isEmpty())
         return;


### PR DESCRIPTION
- harmonize function with GUIUtil::getOpenFileName()
- also make PNG Image singular (grammar)
