### PR TITLE
[Qt] misc PaymentServer changes (e.g. changes to eventFilter())

### DIFF
--- a/src/qt/paymentserver.h
+++ b/src/qt/paymentserver.h
@@ -77,10 +77,6 @@ public:
     // Return certificate store
     static X509_STORE* getCertStore() { return certStore; }
 
-    // Constructor registers this on the parent QApplication to
-    // receive QEvent::FileOpen events
-    bool eventFilter(QObject *object, QEvent *event);
-
     // OptionsModel is used for getting proxy settings and display unit
     void setOptionsModel(OptionsModel *optionsModel);
 
@@ -110,6 +106,11 @@ private slots:
     void netRequestFinished(QNetworkReply*);
     void reportSslErrors(QNetworkReply*, const QList<QSslError> &);
     void handlePaymentACK(const QString& paymentACKMsg);
+
+protected:
+    // Constructor registers this on the parent QApplication to
+    // receive QEvent::FileOpen and QEvent:Drop events
+    bool eventFilter(QObject *object, QEvent *event);
 
 private:
     static bool readPaymentRequest(const QString& filename, PaymentRequestPlus& request);

--- a/src/qt/test/paymentservertests.cpp
+++ b/src/qt/test/paymentservertests.cpp
@@ -7,12 +7,9 @@
 
 #include <openssl/x509.h>
 #include <openssl/x509_vfy.h>
-#include <QCoreApplication>
-#include <QDebug>
+
 #include <QFileOpenEvent>
 #include <QTemporaryFile>
-#include <QVariant>
-
 
 X509 *parse_b64der_cert(const char* cert_data)
 {
@@ -41,9 +38,14 @@ static SendCoinsRecipient handleRequest(PaymentServer* server, std::vector<unsig
     f.write((const char*)&data[0], data.size());
     f.close();
 
-    // Create a FileOpenEvent and send it directly to the server's event filter:
+    // Create a QObject, install event filter from PaymentServer
+    // and send a file open event to the object
+    QObject object;
+    object.installEventFilter(server);
     QFileOpenEvent event(f.fileName());
-    server->eventFilter(NULL, &event);
+    // If sending the event fails, this will cause sigCatcher to be empty,
+    // which will lead to a test failure anyway.
+    QCoreApplication::sendEvent(&object, &event);
 
     QObject::disconnect(server, SIGNAL(receivedPaymentRequest(SendCoinsRecipient)),
                         &sigCatcher, SLOT(getRecipient(SendCoinsRecipient)));

--- a/src/qt/test/paymentservertests.h
+++ b/src/qt/test/paymentservertests.h
@@ -20,8 +20,10 @@ private slots:
 class RecipientCatcher : public QObject
 {
     Q_OBJECT
+
 public slots:
     void getRecipient(SendCoinsRecipient r);
+
 public:
     SendCoinsRecipient recipient;
 };

--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -1,8 +1,7 @@
-
-
 #include "paymentservertests.h"
 #include "uritests.h"
 
+#include <QCoreApplication>
 #include <QObject>
 #include <QTest>
 
@@ -10,6 +9,11 @@
 int main(int argc, char *argv[])
 {
     bool fInvalid = false;
+
+    // Don't remove this, it's needed to access
+    // QCoreApplication:: in the tests
+    QCoreApplication app(argc, argv);
+    app.setApplicationName("Bitcoin-Qt-test");
 
     URITests test1;
     if (QTest::qExec(&test1) != 0)


### PR DESCRIPTION
- make eventFilter() private and pass events on to QObject::eventFilter()
  instead of just returning false
- re-work paymentservertest.cpp to correctly handle the event test
  after the above change (rewrite test_main to allow usage of
  QCoreApplication:: in the tests)
- delete socket when we were unable to connect in ipcSendCommandLine()
- show a message to the user if we fail to start-up (instead of just a
  debug.log entry)
- misc small comment changes
