### PR TITLE
core: remove includes in .cpp, if header is already in .h

### DIFF
--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -11,8 +11,6 @@
 #include "util.h"
 #include "wallet.h"
 
-#include <stdint.h>
-
 #include <boost/algorithm/string.hpp>
 #include <boost/asio.hpp>
 #include <boost/asio/ssl.hpp>

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -7,8 +7,6 @@
 
 #include "util.h"
 
-#include <stdint.h>
-
 std::string COutPoint::ToString() const
 {
     return strprintf("COutPoint(%s, %u)", hash.ToString().substr(0,10).c_str(), n);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,7 +19,6 @@
 
 #include <inttypes.h>
 #include <sstream>
-#include <stdint.h>
 
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/filesystem.hpp>

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -10,8 +10,6 @@
 #include "net.h"
 #include "wallet.h"
 
-#include <stdint.h>
-
 double dHashesPerSec = 0.0;
 int64_t nHPSTimerStart = 0;
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -15,9 +15,6 @@
 #include "db.h"
 #include "ui_interface.h"
 
-#include <inttypes.h>
-#include <stdint.h>
-
 #ifdef WIN32
 #include <string.h>
 #else

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -10,8 +10,6 @@
 #include "uint256.h"
 #include "util.h"
 
-#include <stdint.h>
-
 #ifndef WIN32
 #include <fcntl.h>
 #endif

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -7,8 +7,6 @@
 
 #include "util.h"
 
-#include <stdint.h>
-
 #ifndef WIN32
 # include <arpa/inet.h>
 #endif

--- a/src/script.cpp
+++ b/src/script.cpp
@@ -14,8 +14,6 @@
 #include "uint256.h"
 #include "util.h"
 
-#include <stdint.h>
-
 #include <boost/foreach.hpp>
 #include <boost/tuple/tuple.hpp>
 #include <boost/tuple/tuple_comparison.hpp>

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -12,9 +12,7 @@
 #include "uint256.h"
 #include "version.h"
 
-#include <inttypes.h>
 #include <stdarg.h>
-#include <stdint.h>
 
 #ifndef WIN32
 // for posix_fallocate

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -9,7 +9,6 @@
 #include "net.h"
 
 #include <inttypes.h>
-#include <stdint.h>
 
 #include <boost/algorithm/string/replace.hpp>
 #include <openssl/rand.h>

--- a/src/walletdb.cpp
+++ b/src/walletdb.cpp
@@ -12,7 +12,6 @@
 #include "wallet.h"
 
 #include <inttypes.h>
-#include <stdint.h>
 
 #include <boost/filesystem.hpp>
 #include <boost/foreach.hpp>


### PR DESCRIPTION
- example: if util.h includes stdint.h, remove it from util.cpp, as
  util.h is the first header included in util.cpp
