### PR TITLE
[Qt] ensure payment request network matches client network

### DIFF
--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -12,6 +12,7 @@
 #include "walletmodel.h"
 
 #include "base58.h"
+#include "chainparams.h"
 #include "ui_interface.h"
 
 #include <QMessageBox>
@@ -323,8 +324,17 @@ bool SendCoinsDialog::handlePaymentRequest(const SendCoinsRecipient &rv)
 {
     QString strSendCoins = tr("Send Coins");
     if (rv.paymentRequest.IsInitialized()) {
-        // Expired payment request?
         const payments::PaymentDetails& details = rv.paymentRequest.getDetails();
+
+        // Payment request network matches client network?
+        if ((details.network() == "main" && TestNet()) ||
+            (details.network() == "test" && !TestNet()))
+        {
+            emit message(strSendCoins, tr("Payment request network doesn't match clients network."),
+                CClientUIInterface::MSG_WARNING);
+            return false;
+        }
+        // Expired payment request?
         if (details.has_expires() && (int64_t)details.expires() < GetTime())
         {
             emit message(strSendCoins, tr("Payment request expired"),


### PR DESCRIPTION
- prevents the client to handle payment requests that do not match the
  clients network and shows a warning instead (was mainly a problem with
  drag&drop payment requests onto the client window)
