### PR TITLE
Add additional data update to release-process.md

### DIFF
--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -121,6 +121,8 @@ repackage gitian builds for release as stand-alone zip/tar/installer exe
 
 * update bitcoin.org version
   make sure all OS download links go to the right versions
+  
+* update download sizes on bitcoin.org/_templates/download.html
 
 * update forum version
 


### PR DESCRIPTION
This adds https://github.com/bitcoin/bitcoin.org/pull/270 to the to-do
list for each release, avoiding future situations like
https://bitcointalk.org/index.php?topic=336042.0.
