### PR TITLE
implement CAutoFile via std::fstream

### DIFF
--- a/src/db.h
+++ b/src/db.h
@@ -315,10 +315,7 @@ public:
 /** Access to the (IP) address database (peers.dat) */
 class CAddrDB
 {
-private:
-    boost::filesystem::path pathAddr;
 public:
-    CAddrDB();
     bool Write(const CAddrMan& addr);
     bool Read(CAddrMan& addr);
 };

--- a/src/test/checkblock_tests.cpp
+++ b/src/test/checkblock_tests.cpp
@@ -15,8 +15,7 @@
 
 BOOST_AUTO_TEST_SUITE(CheckBlock_tests)
 
-bool
-read_block(const std::string& filename, CBlock& block)
+bool read_block(const std::string& filename, CBlock& block)
 {
     namespace fs = boost::filesystem;
     fs::path testFile = fs::current_path() / "data" / filename;
@@ -26,15 +25,16 @@ read_block(const std::string& filename, CBlock& block)
         testFile = fs::path(BOOST_PP_STRINGIZE(TEST_DATA_DIR)) / filename;
     }
 #endif
-    FILE* fp = fopen(testFile.string().c_str(), "rb");
-    if (!fp) return false;
 
-    fseek(fp, 8, SEEK_SET); // skip msgheader/size
+    CAutoFile fileIn(SER_DISK, CLIENT_VERSION);
+    // open input file
+    if (!fileIn.open(testFile.string().c_str(), std::ios::binary | std::ios::in))
+        return false;
 
-    CAutoFile filein = CAutoFile(fp, SER_DISK, CLIENT_VERSION);
-    if (!filein) return false;
+    // skip msgheader/size
+    fileIn.seekg(8);
 
-    filein >> block;
+    fileIn >> block;
 
     return true;
 }

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -148,7 +148,7 @@ bool CCoinsViewDB::GetStats(CCoinsStats &stats) {
             }
             pcursor->Next();
         } catch (std::exception &e) {
-            return error("%s() : deserialize error", __PRETTY_FUNCTION__);
+            return error("%s : Deserialize or I/O error - %s", __PRETTY_FUNCTION__, e.what());
         }
     }
     delete pcursor;
@@ -226,7 +226,7 @@ bool CBlockTreeDB::LoadBlockIndexGuts()
                 break; // if shutdown requested or finished loading block index
             }
         } catch (std::exception &e) {
-            return error("%s() : deserialize error", __PRETTY_FUNCTION__);
+            return error("%s : Deserialize or I/O error - %s", __PRETTY_FUNCTION__, e.what());
         }
     }
     delete pcursor;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1178,9 +1178,10 @@ bool RenameOver(boost::filesystem::path src, boost::filesystem::path dest)
 
 void FileCommit(FILE *fileout)
 {
-    fflush(fileout);                // harmless if redundantly called
+    fflush(fileout); // harmless if redundantly called
 #ifdef WIN32
-    _commit(_fileno(fileout));
+    HANDLE hFile = (HANDLE)_get_osfhandle(_fileno(fileout));
+    FlushFileBuffers(hFile);
 #else
     #if defined(__linux__) || defined(__NetBSD__)
     fdatasync(fileno(fileout));


### PR DESCRIPTION
- implement CAutoFile via std::fstream and use it in the code
- unify log/error messages for serializing/deserializing exceptions
- add debug and benchmark messages for writing/reading block/undo files
- remove boost::path member from CAddrDB class
- add new helper functions GetBlockFile() and GetUndoFile()

If considered usefull, I'm open to feedback and comments. I've been using this for ages with my local build and never had any problems with it. I know that currently there is no "flush to disk" when downloading blocks, but perhaps this pull can help investigating the Mac corruption problems.
