### PR TITLE
RPC client option: -rpcwait, to wait for server start

### DIFF
--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -1124,8 +1124,16 @@ Object CallRPC(const string& strMethod, const Array& params)
     asio::ssl::stream<asio::ip::tcp::socket> sslStream(io_service, context);
     SSLIOStreamDevice<asio::ip::tcp> d(sslStream, fUseSSL);
     iostreams::stream< SSLIOStreamDevice<asio::ip::tcp> > stream(d);
-    if (!d.connect(GetArg("-rpcconnect", "127.0.0.1"), GetArg("-rpcport", itostr(Params().RPCPort()))))
-        throw runtime_error("couldn't connect to server");
+
+    bool fWait = GetBoolArg("-rpcwait", false); // -rpcwait means try until server has started
+    do {
+        bool fConnected = d.connect(GetArg("-rpcconnect", "127.0.0.1"), GetArg("-rpcport", itostr(Params().RPCPort())));
+        if (fConnected) break;
+        if (fWait)
+            MilliSleep(1000);
+        else
+            throw runtime_error("couldn't connect to server");
+    } while (fWait);
 
     // HTTP basic authentication
     string strUserPass64 = EncodeBase64(mapArgs["-rpcuser"] + ":" + mapArgs["-rpcpassword"]);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -253,6 +253,7 @@ std::string HelpMessage(HelpMessageMode hmm)
     if (hmm == HMM_BITCOIND || hmm == HMM_BITCOIN_CLI)
     {
         strUsage += "  -rpcconnect=<ip>       " + _("Send commands to node running on <ip> (default: 127.0.0.1)") + "\n";
+        strUsage += "  -rpcwait               " + _("Wait for RPC server to start") + "\n";
     }
 
     strUsage += "  -rpcuser=<user>        " + _("Username for JSON-RPC connections") + "\n";


### PR DESCRIPTION
I often want to run RPC command(s) as soon as I've started bitcoind.

This lets me do that without annoying sleeps or grepping debug.log; e.g.

```
bitcoin-cli -rpcwait getinfo
```
