### PR TITLE
[Qt] make a UI element in sendcoins non-validated

### DIFF
--- a/src/qt/forms/sendcoinsentry.ui
+++ b/src/qt/forms/sendcoinsentry.ui
@@ -141,7 +141,7 @@
      </layout>
     </item>
     <item row="4" column="1">
-     <widget class="QValidatedLineEdit" name="addAsLabel">
+     <widget class="QLineEdit" name="addAsLabel">
       <property name="toolTip">
        <string>Enter a label for this address to add it to the list of used addresses</string>
       </property>


### PR DESCRIPTION
- this was unused for the label and also makes no sense, so remove it
