### PR TITLE
Provide build time when building from tarball:

### DIFF
--- a/share/genbuild.sh
+++ b/share/genbuild.sh
@@ -13,6 +13,8 @@ else
     exit 1
 fi
 
+TIME=$(date '+%F %T %z')
+
 if [ -e "$(which git)" -a -d ".git" ]; then
     # clean 'dirty' status of touched files that haven't been modified
     git diff >/dev/null 2>/dev/null 


### PR DESCRIPTION
 When building from tarball (i.g. not from git source tree or when git
 is not available) `genbuild.sh` write undefined $TIME to "build/build.h".

 Even worse, when TIME is set in the environment then its value
 is written instead of a date.

 For me this change fixed FTBFS which I got because I had
 TIME enviroment variable set with format for time(1) utility.
