### PR TITLE
setgenerate creates multiple blocks in -regtest mode

### DIFF
--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -238,7 +238,7 @@ static const CRPCCommand vRPCCommands[] =
     { "getdifficulty",          &getdifficulty,          true,      false,      false },
     { "getnetworkhashps",       &getnetworkhashps,       true,      false,      false },
     { "getgenerate",            &getgenerate,            true,      false,      false },
-    { "setgenerate",            &setgenerate,            true,      false,      true },
+    { "setgenerate",            &setgenerate,            true,      true,       false },
     { "gethashespersec",        &gethashespersec,        true,      false,      false },
     { "getinfo",                &getinfo,                true,      false,      false },
     { "getmininginfo",          &getmininginfo,          true,      false,      false },

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -112,7 +112,7 @@ void Shutdown()
     ShutdownRPCMining();
     if (pwalletMain)
         bitdb.Flush(false);
-    GenerateBitcoins(false, NULL);
+    GenerateBitcoins(false, NULL, 0);
     StopNode();
     {
         LOCK(cs_main);
@@ -1050,7 +1050,7 @@ bool AppInit2(boost::thread_group& threadGroup, bool fForceServer)
 
     // Generate coins in the background
     if (pwalletMain)
-        GenerateBitcoins(GetBoolArg("-gen", false), pwalletMain);
+        GenerateBitcoins(GetBoolArg("-gen", false), pwalletMain, GetArg("-genproclimit", -1));
 
     // ********************************************************* Step 12: finished
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -650,11 +650,10 @@ void static BitcoinMiner(CWallet *pwallet)
     }
 }
 
-void GenerateBitcoins(bool fGenerate, CWallet* pwallet)
+void GenerateBitcoins(bool fGenerate, CWallet* pwallet, int nThreads)
 {
     static boost::thread_group* minerThreads = NULL;
 
-    int nThreads = GetArg("-genproclimit", -1);
     if (nThreads < 0) {
         if (Params().NetworkID() == CChainParams::REGTEST)
             nThreads = 1;

--- a/src/miner.h
+++ b/src/miner.h
@@ -16,7 +16,7 @@ class CScript;
 class CWallet;
 
 /** Run the miner threads */
-void GenerateBitcoins(bool fGenerate, CWallet* pwallet);
+void GenerateBitcoins(bool fGenerate, CWallet* pwallet, int nThreads);
 /** Generate a new block, without valid proof-of-work */
 CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn);
 CBlockTemplate* CreateNewBlockWithKey(CReserveKey& reservekey);


### PR DESCRIPTION
I'm writing some wallet regression tests using -regtest mode, and
need to generate an initial multi-hundred-block chain. Repeatedly
calling setgenerate to generate one block is slow and doesn't
work properly, because block creation happens asynchronously.

This adds two features to setgenerate in -regtest mode:

1) Instead of being interpreted as number of threads to start, the
third argument is the number of blocks to generate.

2) setgenerate will not return until the block creation threads
have created the requested number of blocks.
