### PR TITLE
Wallet RPC calls integration test

### DIFF
--- a/qa/pull-tester/build-tests.sh.in
+++ b/qa/pull-tester/build-tests.sh.in
@@ -68,6 +68,9 @@ fi
 cd @abs_top_srcdir@/linux-build
 make check
 
+# Run RPC integration test on Linux:
+@abs_top_srcdir@/qa/rpc-tests/wallet.sh @abs_top_srcdir@/linux-build/src
+
 if [ $RUN_EXPENSIVE_TESTS = 1 ]; then
   # Run unit tests and blockchain-tester on Windows:
   cd @abs_top_srcdir@/win32-build

--- a/qa/rpc-tests/README.md
+++ b/qa/rpc-tests/README.md
@@ -1,0 +1,6 @@
+Regression tests of RPC interface
+=================================
+
+wallet.sh : Test wallet send/receive code (see comments for details)
+
+util.sh : useful re-usable functions 

--- a/qa/rpc-tests/util.sh
+++ b/qa/rpc-tests/util.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+
+# Functions used by more than one test
+
+function echoerr {
+  echo "$@" 1>&2;
+}
+
+# Usage: ExtractKey <key> "<json_object_string>"
+# Warning: this will only work for the very-well-behaved
+# JSON produced by bitcoind, do NOT use it to try to
+# parse arbitrary/nested/etc JSON.
+function ExtractKey {
+    echo $2 | tr -d ' "{}\n' | awk -v RS=',' -F: "\$1 ~ /$1/ { print \$2}"
+}
+
+function CreateDataDir {
+  DIR=$1
+  mkdir -p $DIR
+  CONF=$DIR/bitcoin.conf
+  echo "regtest=1" >> $CONF
+  echo "keypool=2" >> $CONF
+  echo "rpcuser=rt" >> $CONF
+  echo "rpcpassword=rt" >> $CONF
+  echo "rpcwait=1" >> $CONF
+  shift
+  while (( "$#" )); do
+      echo $1 >> $CONF
+      shift
+  done
+}
+
+function AssertEqual {
+  if (( $( echo "$1 == $2" | bc ) == 0 ))
+  then
+    echoerr "AssertEqual: $1 != $2"
+    exit 1
+  fi
+}
+
+# CheckBalance -datadir=... amount account minconf
+function CheckBalance {
+  B=$( $CLI $1 getbalance $3 $4 )
+  if (( $( echo "$B == $2" | bc ) == 0 ))
+  then
+    echoerr "bad balance: $B (expected $2)"
+    exit 1
+  fi
+}
+
+# Use: Address <datadir> [account]
+function Address {
+  $CLI $1 getnewaddress $2
+}
+
+# Send from to amount
+function Send {
+  from=$1
+  to=$2
+  amount=$3
+  address=$(Address $to)
+  txid=$( $CLI $from sendtoaddress $address $amount )
+}
+
+# Use: Unspent <datadir> <n'th-last-unspent> <var>
+function Unspent {
+  local r=$( $CLI $1 listunspent | awk -F'[ |:,"]+' "\$2 ~ /$3/ { print \$3 }" | tail -n $2 | head -n 1)
+  echo $r
+}
+
+# Use: CreateTxn1 <datadir> <n'th-last-unspent> <destaddress>
+# produces hex from signrawtransaction
+function CreateTxn1 {
+  TXID=$(Unspent $1 $2 txid)
+  AMOUNT=$(Unspent $1 $2 amount)
+  VOUT=$(Unspent $1 $2 vout)
+  RAWTXN=$( $CLI $1 createrawtransaction "[{\"txid\":\"$TXID\",\"vout\":$VOUT}]" "{\"$3\":$AMOUNT}")
+  ExtractKey hex "$( $CLI $1 signrawtransaction $RAWTXN )"
+}
+
+# Use: SendRawTxn <datadir> <hex_txn_data>
+function SendRawTxn {
+  $CLI $1 sendrawtransaction $2
+}

--- a/qa/rpc-tests/wallet.sh
+++ b/qa/rpc-tests/wallet.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+
+# Test block generation and basic wallet sending
+
+if [ $# -lt 1 ]; then
+        echo "Usage: $0 path_to_binaries"
+        echo "e.g. $0 ../../src"
+        exit 1
+fi
+
+BITCOIND=${1}/bitcoind
+CLI=${1}/bitcoin-cli
+
+DIR="${BASH_SOURCE%/*}"
+if [[ ! -d "$DIR" ]]; then DIR="$PWD"; fi
+. "$DIR/util.sh"
+
+D=$(mktemp -d test.XXXXX)
+
+D1=${D}/node1
+CreateDataDir $D1 port=11000 rpcport=11001
+B1ARGS="-datadir=$D1"
+$BITCOIND $B1ARGS &
+B1PID=$!
+
+D2=${D}/node2
+CreateDataDir $D2 port=11010 rpcport=11011 connect=127.0.0.1:11000
+B2ARGS="-datadir=$D2"
+$BITCOIND $B2ARGS &
+B2PID=$!
+
+D3=${D}/node3
+CreateDataDir $D3 port=11020 rpcport=11021 connect=127.0.0.1:11000
+B3ARGS="-datadir=$D3"
+$BITCOIND $BITCOINDARGS $B3ARGS &
+B3PID=$!
+
+trap "kill -9 $B1PID $B2PID $B3PID; rm -rf $D" EXIT
+
+# 1 block, 50 XBT each == 50 XBT
+$CLI $B1ARGS setgenerate true 1
+sleep 1  # sleep is necessary to let block broadcast
+# 101 blocks, 1 mature == 50 XBT
+$CLI $B2ARGS setgenerate true 101
+sleep 1
+
+CheckBalance $B1ARGS 50
+CheckBalance $B2ARGS 50
+
+# Send 21 XBT from 1 to 3. Second
+# transaction will be child of first, and
+# will require a fee
+Send $B1ARGS $B3ARGS 11
+Send $B1ARGS $B3ARGS 10
+
+# Have B1 mine a new block, and mature it
+# to recover transaction fees
+$CLI $B1ARGS setgenerate true 1
+sleep 1
+
+# Have B2 mine 100 blocks so B1's block is mature:
+$CLI $B2ARGS setgenerate true 100
+sleep 1
+
+# B1 should end up with 100 XBT in block rewards plus fees,
+# minus the 21 XBT sent to B3:
+CheckBalance $B1ARGS "100-21"
+CheckBalance $B3ARGS "21"
+
+# B1 should have two unspent outputs; create a couple
+# of raw transactions to send them to B3, submit them through
+# B2, and make sure both B1 and B3 pick them up properly:
+RAW1=$(CreateTxn1 $B1ARGS 1 $(Address $B3ARGS "from1" ) )
+RAW2=$(CreateTxn1 $B1ARGS 2 $(Address $B3ARGS "from1" ) )
+RAWTXID1=$(SendRawTxn $B2ARGS $RAW1)
+RAWTXID2=$(SendRawTxn $B2ARGS $RAW2)
+
+# Have B2 mine a block to confirm transactions:
+$CLI $B2ARGS setgenerate true 1
+sleep 1 # allow time for block to be relayed
+
+# Check balances after confirmation
+CheckBalance $B1ARGS 0
+CheckBalance $B3ARGS 100
+CheckBalance $B3ARGS "100-21" "from1"
+
+$CLI $B3ARGS stop > /dev/null 2>&1
+wait $B3PID
+$CLI $B2ARGS stop > /dev/null 2>&1
+wait $B2PID
+$CLI $B1ARGS stop > /dev/null 2>&1
+wait $B1PID
+
+echo "Tests successful, cleaning up"
+trap "" EXIT
+rm -rf $D
+exit 0


### PR DESCRIPTION
qa/rpc-tests/wallet.sh runs a three-node -regtest network, generates a fresh blockchain, and then exercises basic wallet sending/receiving functionality using command-line RPC.

Depends on #3294
