### PR TITLE
Fix invalid berkeley db library path on OSX with homebrew.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -243,7 +243,7 @@ case $host in
          bdb_prefix=`$BREW --prefix berkeley-db4`
          export PKG_CONFIG_PATH="$openssl_prefix/lib/pkgconfig:$PKG_CONFIG_PATH"
          CPPFLAGS="$CPPFLAGS -I$bdb_prefix/include"
-         LIBS="$LIBS -L/$bdb_prefix/lib"
+         LIBS="$LIBS -L$bdb_prefix/lib"
        fi
      fi
 


### PR DESCRIPTION
brew --prefix retruns a fully qualified path, so using -L/$prefix results in a path with two leading '/'.
