### PR TITLE
[Qt] allow deletion of payment-requests in sendcoins

### DIFF
--- a/src/qt/forms/sendcoinsentry.ui
+++ b/src/qt/forms/sendcoinsentry.ui
@@ -16,9 +16,6 @@
   <property name="autoFillBackground">
    <bool>false</bool>
   </property>
-  <property name="currentIndex">
-   <number>0</number>
-  </property>
   <widget class="QFrame" name="SendCoins">
    <property name="toolTip">
     <string>This is a normal payment.</string>
@@ -33,20 +30,7 @@
     <property name="spacing">
      <number>12</number>
     </property>
-    <item row="5" column="0">
-     <widget class="QLabel" name="amountLabel">
-      <property name="text">
-       <string>A&amp;mount:</string>
-      </property>
-      <property name="alignment">
-       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-      </property>
-      <property name="buddy">
-       <cstring>payAmount</cstring>
-      </property>
-     </widget>
-    </item>
-    <item row="3" column="0">
+    <item row="0" column="0">
      <widget class="QLabel" name="payToLabel">
       <property name="text">
        <string>Pay &amp;To:</string>
@@ -59,23 +43,7 @@
       </property>
      </widget>
     </item>
-    <item row="5" column="1">
-     <widget class="BitcoinAmountField" name="payAmount"/>
-    </item>
-    <item row="4" column="0">
-     <widget class="QLabel" name="labellLabel">
-      <property name="text">
-       <string>&amp;Label:</string>
-      </property>
-      <property name="alignment">
-       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-      </property>
-      <property name="buddy">
-       <cstring>addAsLabel</cstring>
-      </property>
-     </widget>
-    </item>
-    <item row="3" column="1">
+    <item row="0" column="1">
      <layout class="QHBoxLayout" name="payToLayout">
       <property name="spacing">
        <number>0</number>
@@ -84,9 +52,6 @@
        <widget class="QValidatedLineEdit" name="payTo">
         <property name="toolTip">
          <string>The address to send the payment to (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</string>
-        </property>
-        <property name="maxLength">
-         <number>34</number>
         </property>
        </widget>
       </item>
@@ -127,7 +92,7 @@
       <item>
        <widget class="QToolButton" name="deleteButton">
         <property name="toolTip">
-         <string>Remove this recipient</string>
+         <string>Remove this entry</string>
         </property>
         <property name="text">
          <string/>
@@ -140,12 +105,41 @@
       </item>
      </layout>
     </item>
-    <item row="4" column="1">
+    <item row="1" column="0">
+     <widget class="QLabel" name="labellLabel">
+      <property name="text">
+       <string>&amp;Label:</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      </property>
+      <property name="buddy">
+       <cstring>addAsLabel</cstring>
+      </property>
+     </widget>
+    </item>
+    <item row="1" column="1">
      <widget class="QLineEdit" name="addAsLabel">
       <property name="toolTip">
        <string>Enter a label for this address to add it to the list of used addresses</string>
       </property>
      </widget>
+    </item>
+    <item row="2" column="0">
+     <widget class="QLabel" name="amountLabel">
+      <property name="text">
+       <string>A&amp;mount:</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      </property>
+      <property name="buddy">
+       <cstring>payAmount</cstring>
+      </property>
+     </widget>
+    </item>
+    <item row="2" column="1">
+     <widget class="BitcoinAmountField" name="payAmount"/>
     </item>
    </layout>
   </widget>
@@ -581,27 +575,7 @@
     <property name="spacing">
      <number>12</number>
     </property>
-    <item row="4" column="0">
-     <widget class="QLabel" name="memoLabel_is">
-      <property name="text">
-       <string>Memo:</string>
-      </property>
-      <property name="alignment">
-       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-      </property>
-     </widget>
-    </item>
-    <item row="5" column="0">
-     <widget class="QLabel" name="amountLabel_is">
-      <property name="text">
-       <string>Amount:</string>
-      </property>
-      <property name="alignment">
-       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-      </property>
-     </widget>
-    </item>
-    <item row="3" column="0">
+    <item row="0" column="0">
      <widget class="QLabel" name="payToLabel_is">
       <property name="text">
        <string>Pay To:</string>
@@ -611,14 +585,7 @@
       </property>
      </widget>
     </item>
-    <item row="5" column="2">
-     <widget class="BitcoinAmountField" name="payAmount_is">
-      <property name="acceptDrops">
-       <bool>false</bool>
-      </property>
-     </widget>
-    </item>
-    <item row="3" column="2">
+    <item row="0" column="1">
      <layout class="QHBoxLayout" name="payToLayout_is">
       <property name="spacing">
        <number>0</number>
@@ -626,12 +593,56 @@
       <item>
        <widget class="QLabel" name="payTo_is"/>
       </item>
+      <item>
+       <widget class="QToolButton" name="deleteButton_is">
+        <property name="toolTip">
+         <string>Remove this entry</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="icon">
+         <iconset resource="../bitcoin.qrc">
+          <normaloff>:/icons/remove</normaloff>:/icons/remove</iconset>
+        </property>
+       </widget>
+      </item>
      </layout>
     </item>
-    <item row="4" column="2">
+    <item row="1" column="0">
+     <widget class="QLabel" name="memoLabel_is">
+      <property name="text">
+       <string>Memo:</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      </property>
+     </widget>
+    </item>
+    <item row="1" column="1">
      <widget class="QLabel" name="memoTextLabel_is">
       <property name="textFormat">
        <enum>Qt::PlainText</enum>
+      </property>
+     </widget>
+    </item>
+    <item row="2" column="0">
+     <widget class="QLabel" name="amountLabel_is">
+      <property name="text">
+       <string>A&amp;mount:</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      </property>
+      <property name="buddy">
+       <cstring>payAmount_is</cstring>
+      </property>
+     </widget>
+    </item>
+    <item row="2" column="1">
+     <widget class="BitcoinAmountField" name="payAmount_is">
+      <property name="acceptDrops">
+       <bool>false</bool>
       </property>
      </widget>
     </item>
@@ -1096,27 +1107,7 @@
     <property name="spacing">
      <number>12</number>
     </property>
-    <item row="4" column="0">
-     <widget class="QLabel" name="memoLabel_s">
-      <property name="text">
-       <string>Memo:</string>
-      </property>
-      <property name="alignment">
-       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-      </property>
-     </widget>
-    </item>
-    <item row="5" column="0">
-     <widget class="QLabel" name="amountLabel_s">
-      <property name="text">
-       <string>Amount:</string>
-      </property>
-      <property name="alignment">
-       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-      </property>
-     </widget>
-    </item>
-    <item row="3" column="0">
+    <item row="0" column="0">
      <widget class="QLabel" name="payToLabel_s">
       <property name="text">
        <string>Pay To:</string>
@@ -1126,14 +1117,7 @@
       </property>
      </widget>
     </item>
-    <item row="5" column="2">
-     <widget class="BitcoinAmountField" name="payAmount_s">
-      <property name="acceptDrops">
-       <bool>false</bool>
-      </property>
-     </widget>
-    </item>
-    <item row="3" column="2">
+    <item row="0" column="1">
      <layout class="QHBoxLayout" name="payToLayout_s">
       <property name="spacing">
        <number>0</number>
@@ -1145,12 +1129,56 @@
         </property>
        </widget>
       </item>
+      <item>
+       <widget class="QToolButton" name="deleteButton_s">
+        <property name="toolTip">
+         <string>Remove this entry</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="icon">
+         <iconset resource="../bitcoin.qrc">
+          <normaloff>:/icons/remove</normaloff>:/icons/remove</iconset>
+        </property>
+       </widget>
+      </item>
      </layout>
     </item>
-    <item row="4" column="2">
+    <item row="1" column="0">
+     <widget class="QLabel" name="memoLabel_s">
+      <property name="text">
+       <string>Memo:</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      </property>
+     </widget>
+    </item>
+    <item row="1" column="1">
      <widget class="QLabel" name="memoTextLabel_s">
       <property name="textFormat">
        <enum>Qt::PlainText</enum>
+      </property>
+     </widget>
+    </item>
+    <item row="2" column="0">
+     <widget class="QLabel" name="amountLabel_s">
+      <property name="text">
+       <string>A&amp;mount:</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      </property>
+      <property name="buddy">
+       <cstring>payAmount_s</cstring>
+      </property>
+     </widget>
+    </item>
+    <item row="2" column="1">
+     <widget class="BitcoinAmountField" name="payAmount_s">
+      <property name="acceptDrops">
+       <bool>false</bool>
       </property>
      </widget>
     </item>
@@ -1159,16 +1187,28 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>BitcoinAmountField</class>
-   <extends>QLineEdit</extends>
-   <header>bitcoinamountfield.h</header>
-  </customwidget>
-  <customwidget>
    <class>QValidatedLineEdit</class>
    <extends>QLineEdit</extends>
    <header>qvalidatedlineedit.h</header>
   </customwidget>
+  <customwidget>
+   <class>BitcoinAmountField</class>
+   <extends>QLineEdit</extends>
+   <header>bitcoinamountfield.h</header>
+  </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>payTo</tabstop>
+  <tabstop>addressBookButton</tabstop>
+  <tabstop>pasteButton</tabstop>
+  <tabstop>deleteButton</tabstop>
+  <tabstop>addAsLabel</tabstop>
+  <tabstop>payAmount</tabstop>
+  <tabstop>payAmount_is</tabstop>
+  <tabstop>deleteButton_is</tabstop>
+  <tabstop>payAmount_s</tabstop>
+  <tabstop>deleteButton_s</tabstop>
+ </tabstops>
  <resources>
   <include location="../bitcoin.qrc"/>
  </resources>

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -227,8 +227,8 @@ void SendCoinsDialog::on_sendButton_clicked()
             alternativeUnits.append(BitcoinUnits::formatWithUnit(u, totalAmount));
     }
     questionString.append(tr("Total Amount %1 (= %2)")
-            .arg(BitcoinUnits::formatWithUnit(model->getOptionsModel()->getDisplayUnit(), totalAmount))
-            .arg(alternativeUnits.join(" "+tr("or")+" ")));
+        .arg(BitcoinUnits::formatWithUnit(model->getOptionsModel()->getDisplayUnit(), totalAmount))
+        .arg(alternativeUnits.join(" " + tr("or") + " ")));
 
     QMessageBox::StandardButton retval = QMessageBox::question(this, tr("Confirm send coins"),
         questionString.arg(formatted.join("<br />")),
@@ -264,9 +264,7 @@ void SendCoinsDialog::clear()
     }
     addEntry();
 
-    updateRemoveEnabled();
-
-    ui->sendButton->setDefault(true);
+    updateTabsAndLabels();
 }
 
 void SendCoinsDialog::reject()
@@ -287,7 +285,7 @@ SendCoinsEntry *SendCoinsDialog::addEntry()
     connect(entry, SIGNAL(removeEntry(SendCoinsEntry*)), this, SLOT(removeEntry(SendCoinsEntry*)));
     connect(entry, SIGNAL(payAmountChanged()), this, SLOT(coinControlUpdateLabels()));
 
-    updateRemoveEnabled();
+    updateTabsAndLabels();
 
     // Focus the field, so that entry can start immediately
     entry->clear();
@@ -300,27 +298,21 @@ SendCoinsEntry *SendCoinsDialog::addEntry()
     return entry;
 }
 
-void SendCoinsDialog::updateRemoveEnabled()
+void SendCoinsDialog::updateTabsAndLabels()
 {
-    // Remove buttons are enabled as soon as there is more than one send-entry
-    bool enabled = (ui->entries->count() > 1);
-    for(int i = 0; i < ui->entries->count(); ++i)
-    {
-        SendCoinsEntry *entry = qobject_cast<SendCoinsEntry*>(ui->entries->itemAt(i)->widget());
-        if(entry)
-        {
-            entry->setRemoveEnabled(enabled);
-        }
-    }
     setupTabChain(0);
-
     coinControlUpdateLabels();
 }
 
 void SendCoinsDialog::removeEntry(SendCoinsEntry* entry)
 {
     delete entry;
-    updateRemoveEnabled();
+
+    // If the last entry was removed add an empty one
+    if (!ui->entries->count())
+        addEntry();
+
+    updateTabsAndLabels();
 }
 
 QWidget *SendCoinsDialog::setupTabChain(QWidget *prev)
@@ -379,7 +371,7 @@ void SendCoinsDialog::pasteEntry(const SendCoinsRecipient &rv)
     }
 
     entry->setValue(rv);
-    coinControlUpdateLabels();
+    updateTabsAndLabels();
 }
 
 bool SendCoinsDialog::handlePaymentRequest(const SendCoinsRecipient &rv)
@@ -619,4 +611,3 @@ void SendCoinsDialog::coinControlUpdateLabels()
         ui->labelCoinControlInsuffFunds->hide();
     }
 }
-

--- a/src/qt/sendcoinsdialog.h
+++ b/src/qt/sendcoinsdialog.h
@@ -46,7 +46,7 @@ public slots:
     void reject();
     void accept();
     SendCoinsEntry *addEntry();
-    void updateRemoveEnabled();
+    void updateTabsAndLabels();
     void setBalance(qint64 balance, qint64 unconfirmedBalance, qint64 immatureBalance);
 
 private:

--- a/src/qt/sendcoinsentry.cpp
+++ b/src/qt/sendcoinsentry.cpp
@@ -75,13 +75,11 @@ void SendCoinsEntry::setModel(WalletModel *model)
         connect(model->getOptionsModel(), SIGNAL(displayUnitChanged(int)), this, SLOT(updateDisplayUnit()));
 
     connect(ui->payAmount, SIGNAL(textChanged()), this, SIGNAL(payAmountChanged()));
+    connect(ui->deleteButton, SIGNAL(clicked()), this, SLOT(deleteClicked()));
+    connect(ui->deleteButton_is, SIGNAL(clicked()), this, SLOT(deleteClicked()));
+    connect(ui->deleteButton_s, SIGNAL(clicked()), this, SLOT(deleteClicked()));
 
     clear();
-}
-
-void SendCoinsEntry::setRemoveEnabled(bool enabled)
-{
-    ui->deleteButton->setEnabled(enabled);
 }
 
 void SendCoinsEntry::clear()
@@ -105,7 +103,7 @@ void SendCoinsEntry::clear()
     updateDisplayUnit();
 }
 
-void SendCoinsEntry::on_deleteButton_clicked()
+void SendCoinsEntry::deleteClicked()
 {
     emit removeEntry(this);
 }

--- a/src/qt/sendcoinsentry.h
+++ b/src/qt/sendcoinsentry.h
@@ -46,7 +46,6 @@ public:
     void setFocus();
 
 public slots:
-    void setRemoveEnabled(bool enabled);
     void clear();
 
 signals:
@@ -54,7 +53,7 @@ signals:
     void payAmountChanged();
 
 private slots:
-    void on_deleteButton_clicked();
+    void deleteClicked();
     void on_payTo_textChanged(const QString &address);
     void on_addressBookButton_clicked();
     void on_pasteButton_clicked();


### PR DESCRIPTION
- this adds a delete button for insecure and secure payment requests in
  the sendcoins dialog
- it also enables the delete button even for single and empty entries, as
  this is much easier to handle and doesn't need to special case single
  entries
- big parts of the ui file were changed, because I copied the delete
  button and had to delete the layout too and created it from scratch
  (which seems to cleanup the rows and colums in the layout also, which is
  nice IMHO)

@laanwj Would be nice, if you could take some time to review my open Qt pulls and merge, if you ACK them.

![sendcoins](https://f.cloud.github.com/assets/1419649/1631285/f2744d4a-5760-11e3-8793-3a7eacae33f3.png)
