### PR TITLE
minor cleanup in CheckBlock

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2042,7 +2042,7 @@ bool CheckBlock(const CBlock& block, CValidationState& state, bool fCheckPOW, bo
                              REJECT_INVALID, "time in future");
 
     // First transaction must be coinbase, the rest must not be
-    if (block.vtx.empty() || !block.vtx[0].IsCoinBase())
+    if (!block.vtx[0].IsCoinBase())
         return state.DoS(100, error("CheckBlock() : first tx is not coinbase"),
                          REJECT_INVALID, "no coinbase");
     for (unsigned int i = 1; i < block.vtx.size(); i++)


### PR DESCRIPTION
  block.vtx.empty() is checked in the "size limits failed" part already. just a couple of lines above in that same function.
