### PR TITLE
Fix uninitialized variable added in b33b9a6fe

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -937,7 +937,7 @@ private:
     unsigned char chRejectCode;
     bool corruptionPossible;
 public:
-    CValidationState() : mode(MODE_VALID), nDoS(0) {}
+    CValidationState() : mode(MODE_VALID), nDoS(0), corruptionPossible(false) {}
     bool DoS(int level, bool ret = false,
              unsigned char chRejectCodeIn=0, std::string strRejectReasonIn="",
              bool corruptionIn=false) {


### PR DESCRIPTION
After discussing with BlueMatt, this appears to be harmless in its
current state since it's always set before it's used. Initialize it
anyway for readability and future safety.
