### PR TITLE
Increase default block size

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -36,9 +36,9 @@ class CInv;
 /** The maximum allowed size for a serialized block, in bytes (network rule) */
 static const unsigned int MAX_BLOCK_SIZE = 1000000;
 /** The maximum size for mined blocks */
-static const unsigned int MAX_BLOCK_SIZE_GEN = MAX_BLOCK_SIZE/2;
+static const unsigned int MAX_BLOCK_SIZE_GEN = 600000;
 /** The maximum size for transactions we're willing to relay/mine */
-static const unsigned int MAX_STANDARD_TX_SIZE = MAX_BLOCK_SIZE_GEN/5;
+static const unsigned int MAX_STANDARD_TX_SIZE = 100000;
 /** The maximum allowed number of signature check operations in a block (network rule) */
 static const unsigned int MAX_BLOCK_SIGOPS = MAX_BLOCK_SIZE/50;
 /** The maximum number of orphan transactions kept in memory */
@@ -59,7 +59,7 @@ static const unsigned int LOCKTIME_THRESHOLD = 500000000; // Tue Nov  5 00:53:20
 /** Maximum number of script-checking threads allowed */
 static const int MAX_SCRIPTCHECK_THREADS = 16;
 /** Default amount of block size reserved for high-priority transactions (in bytes) */
-static const int DEFAULT_BLOCK_PRIORITY_SIZE = 27000;
+static const int DEFAULT_BLOCK_PRIORITY_SIZE = 30000;
 #ifdef USE_UPNP
 static const int fHaveUPnP = true;
 #else


### PR DESCRIPTION
This is to go into 0.8.6 so I'm posting this pull request for completeness.
- increase default size by 50K to 300K
- increase high-priority area from 27K to 30K
#3229 may be a better alternative for master/0.9, as it gets rid of the defaults completely and forces the miners to decide.

Edit: MAX_BLOCK_SIZE_GEN is two times the default size, updated description accordingly
