### PR TITLE
qt: restore icon dock menu

### DIFF
--- a/src/qt/macdockiconhandler.mm
+++ b/src/qt/macdockiconhandler.mm
@@ -8,6 +8,10 @@
 #undef slots
 #include <Cocoa/Cocoa.h>
 
+#if QT_VERSION < 0x050000
+extern void qt_mac_set_dock_menu(QMenu *);
+#endif
+
 @interface DockIconClickEventHandler : NSObject
 {
     MacDockIconHandler* dockIconHandler;
@@ -52,7 +56,9 @@ MacDockIconHandler::MacDockIconHandler() : QObject()
     this->m_dummyWidget = new QWidget();
     this->m_dockMenu = new QMenu(this->m_dummyWidget);
     this->setMainWindow(NULL);
-
+#if QT_VERSION < 0x050000
+    qt_mac_set_dock_menu(this->m_dockMenu);
+#endif
     [pool release];
 }
 


### PR DESCRIPTION
This was removed by 25c0cce7f. It was apparently removed in qt5, but
may return for 5.1.
