### PR TITLE
fix Windows redefinition warning in compat.h

### DIFF
--- a/src/compat.h
+++ b/src/compat.h
@@ -11,7 +11,9 @@
 #undef _WIN32_WINNT
 #endif
 #define _WIN32_WINNT 0x0501
+#ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN 1
+#endif
 #ifndef NOMINMAX
 #define NOMINMAX
 #endif


### PR DESCRIPTION
- also remove compat.h include from net.h as it comes from netbase.h
  (which is needed as base for net.h anyway)
