### PR TITLE
Cleanups and robustness for autotooling

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,3 +1,5 @@
 #!/bin/sh
 set -e
+srcdir="$(dirname $0)"
+cd "$srcdir"
 autoreconf -vif

--- a/autogen.sh
+++ b/autogen.sh
@@ -2,4 +2,4 @@
 set -e
 srcdir="$(dirname $0)"
 cd "$srcdir"
-autoreconf -vif
+autoreconf --verbose --install --force

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,2 +1,3 @@
 #!/bin/sh
+set -e
 autoreconf -vif

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,1 +1,2 @@
+#!/bin/sh
 autoreconf -vif

--- a/autogen.sh
+++ b/autogen.sh
@@ -2,4 +2,4 @@
 set -e
 srcdir="$(dirname $0)"
 cd "$srcdir"
-autoreconf --verbose --install --force
+autoreconf --install --force

--- a/configure.ac
+++ b/configure.ac
@@ -342,7 +342,11 @@ BITCOIN_FIND_BDB48
 
 dnl Check for libminiupnpc (optional)
 if test x$use_upnp != xno; then
-  AC_CHECK_LIB([miniupnpc], [main],, [have_miniupnpc=no])
+  AC_CHECK_HEADERS(
+    [miniupnpc/miniwget.h miniupnpc/miniupnpc.h miniupnpc/upnpcommands.h miniupnpc/upnperrors.h],
+    [AC_CHECK_LIB([miniupnpc], [main],, [have_miniupnpc=no])],
+    [have_miniupnpc=no]
+  )
 fi
 
 dnl Check for boost libs

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -85,5 +85,4 @@ EXTRA_DIST = leveldb Makefile.include
 
 clean-local:
 	-$(MAKE) -C leveldb clean
-	rm -f leveldb/port/*.gcno leveldb/db/*.gcno leveldb/table/*.gcno leveldb/helpers/*.gcno
-	rm -f leveldb/util/*.gcno leveldb/helpers/memenv/*.gcno
+	rm -f leveldb/*/*.gcno leveldb/helpers/memenv/*.gcno


### PR DESCRIPTION
This series cleans up autogen.sh and adds support for running autogen.sh from out of tree.  Out-of-tree configure works as well, but unfortunately out-of-tree builds don't because leveldb doesn't support them yet.

This also makes configure's test for miniupnpc more robust (working around a bug observed on my system when trying to build), and simplifies leveldb's clean target a bit.
