### PR TITLE
MacOSX leveldb corruption fix

### DIFF
--- a/src/leveldb/util/env_posix.cc
+++ b/src/leveldb/util/env_posix.cc
@@ -209,6 +209,11 @@ class PosixMmapFile : public WritableFile {
   bool UnmapCurrentRegion() {
     bool result = true;
     if (base_ != NULL) {
+#if defined(OS_MACOSX)
+      if (msync(base_, limit_ - base_, MS_SYNC) != 0) {
+        result = false;
+      }
+#endif
       if (last_sync_ < limit_) {
         // Defer syncing this data until next Sync() call, if any
         pending_sync_ = true;


### PR DESCRIPTION
Here's the gist of what's going wrong:
1.  PosixMmapFile is used for performing sequential writes.  Internally, it maps
   regions of the file one after the other.  Each region is unmapped before the
   next region is mapped.
2.  In some circumstances on OS X, the unmapped data is not written to disk.

The fix is to perform a msync before the munmap on OS X, which seems to be where
this issue manifests itself most.

Note:  Simply performing a write with the `sync' option is not a sufficient fix
    because the sync will happen after the munmap.

See also:  http://hackingdistributed.com/2013/11/27/bitcoin-leveldb/
