### PR TITLE
mutex debugging routines: LocksHeld() and AssertLockHeld()

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2215,6 +2215,8 @@ void PushGetBlocks(CNode* pnode, CBlockIndex* pindexBegin, uint256 hashEnd)
 
 bool ProcessBlock(CValidationState &state, CNode* pfrom, CBlock* pblock, CDiskBlockPos *dbp)
 {
+    AssertLockHeld("cs_main");
+
     // Check for duplicate
     uint256 hash = pblock->GetHash();
     if (mapBlockIndex.count(hash))

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -42,6 +42,8 @@ struct CLockLocation
         return mutexName+"  "+sourceFile+":"+itostr(sourceLine);
     }
 
+    std::string MutexName() const { return mutexName; }
+
 private:
     std::string mutexName;
     std::string sourceFile;
@@ -124,6 +126,22 @@ void EnterCritical(const char* pszName, const char* pszFile, int nLine, void* cs
 void LeaveCritical()
 {
     pop_lock();
+}
+
+std::string LocksHeld()
+{
+    std::string result;
+    BOOST_FOREACH(const PAIRTYPE(void*, CLockLocation)&i, *lockstack)
+        result += i.second.ToString() + std::string("\n");
+    return result;
+}
+
+void AssertLockHeld(std::string strName)
+{
+    BOOST_FOREACH(const PAIRTYPE(void*, CLockLocation)&i, *lockstack)
+        if (i.second.MutexName() == strName) return;
+    LogPrintf("Lock %s not held; locks held:\n%s", strName.c_str(), LocksHeld().c_str());
+    assert(0);
 }
 
 #endif /* DEBUG_LOCKORDER */

--- a/src/sync.h
+++ b/src/sync.h
@@ -87,9 +87,12 @@ typedef AnnotatedMixin<boost::mutex> CWaitableCriticalSection;
 #ifdef DEBUG_LOCKORDER
 void EnterCritical(const char* pszName, const char* pszFile, int nLine, void* cs, bool fTry = false);
 void LeaveCritical();
+std::string LocksHeld();
+void AssertLockHeld(std::string strName);
 #else
 void static inline EnterCritical(const char* pszName, const char* pszFile, int nLine, void* cs, bool fTry = false) {}
 void static inline LeaveCritical() {}
+void static inline AssertLockHeld(std::string) {}
 #endif
 
 #ifdef DEBUG_LOCKCONTENTION


### PR DESCRIPTION
Inspired by a Mike Hearn comment on #3276 -- adds a couple of mutex-related routines:

AssertLockHeld("cs_foo")  :  if compiled -DDEBUG_LOCKORDER, walks the lock stack and makes sure the specified lock is held. If not, a message and the list of locks that ARE held are LogPrintf'ed and then assert(0) is called. Does nothing in normal builds.

LocksHeld() : -DDEBUG_LOCKORDER-only routine:  returns a human-readable string with all of the locks held. This can be very handy to call from within an interactive debugging session (and it is used by AssertLockHeld).

I added AssertLockHeld("cs_main") to ProcessBlock as proof-of-concept; if we like this, adding AssertLockHeld calls to more routines can be done in subsequent pulls.

PS: compiling with -DDEBUG_LOCKORDER in the new autotools-world means a 'make clean' and then something like:
  CXXFLAGS='-DDEBUG_LOCKORDER' ./configure ...
