### PR TITLE
Smart (floating) fees for the client

### DIFF
--- a/qa/rpc-tests/README.md
+++ b/qa/rpc-tests/README.md
@@ -3,4 +3,6 @@ Regression tests of RPC interface
 
 wallet.sh : Test wallet send/receive code (see comments for details)
 
+estimatefee.sh : Test estimatefee/estimatepriority RPC calls
+
 util.sh : useful re-usable functions 

--- a/qa/rpc-tests/estimatefee.sh
+++ b/qa/rpc-tests/estimatefee.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+
+# Test estimatefee
+
+#set -o xtrace  # Uncomment to debug
+
+if [ $# -lt 1 ]; then
+        echo "Usage: $0 path_to_binaries"
+        echo "e.g. $0 ../../src"
+        exit 1
+fi
+
+echo "Tests can take more than 10 minutes to run; be patient."
+
+BITCOIND=${1}/bitcoind
+CLI=${1}/bitcoin-cli
+
+DIR="${BASH_SOURCE%/*}"
+if [[ ! -d "$DIR" ]]; then DIR="$PWD"; fi
+. "$DIR/util.sh"
+
+D=$(mktemp -d test.XXXXX)
+
+# Three nodes:
+#  B1 relays between the other two, runs with defaults,
+D1=${D}/node1
+CreateDataDir $D1 port=11000 rpcport=11001 debug=estimatefee
+B1ARGS="-datadir=$D1"
+$BITCOIND $B1ARGS &
+B1PID=$!
+
+#  B2 runs with -paytxfee=0.001, is also used to send
+#  higher/lower priority transactions
+D2=${D}/node2
+CreateDataDir $D2 port=11010 rpcport=11011 connect=127.0.0.1:11000 paytxfee=0.001 debug=estimatefee
+B2ARGS="-datadir=$D2"
+$BITCOIND $B2ARGS &
+B2PID=$!
+
+#  B3 runs with -paytxfee=0.02
+D3=${D}/node3
+CreateDataDir $D3 port=11020 rpcport=11021 connect=127.0.0.1:11000 paytxfee=0.02 debug=estimatefee
+B3ARGS="-datadir=$D3"
+$BITCOIND $BITCOINDARGS $B3ARGS &
+B3PID=$!
+
+# trap "kill -9 $B1PID $B2PID $B3PID; rm -rf $D" EXIT
+
+echo "Generating initial blockchain"
+
+# B2 starts with 220 blocks (so 120 old, mature):
+$CLI $B2ARGS setgenerate true 220
+WaitForBlock $B1ARGS 220
+
+PRI=$($CLI $B1ARGS estimatepriority)
+AssertEqual $PRI -1.0
+
+B1ADDRESS=$(Address $B1ARGS)
+B2ADDRESS=$(Address $B2ARGS)
+B3ADDRESS=$(Address $B3ARGS)
+
+echo "Testing priority estimation"
+
+# Generate 110 very-high-priority (50 BTC with at least 100 confirmations) transactions
+# (in two batches, with a block generated in between)
+# 100 confirmed transactions is the minimum the estimation code needs.
+for i in {1..55} ; do
+    RAW=$(CreateTxn1 $B2ARGS 1 $B1ADDRESS)
+    RAWTXID=$(SendRawTxn $B2ARGS $RAW)
+done
+$CLI $B3ARGS setgenerate true 1
+WaitForBlock $B1ARGS 221
+for i in {1..55} ; do
+    RAW=$(CreateTxn1 $B2ARGS 1 $B1ADDRESS)
+    RAWTXID=$(SendRawTxn $B2ARGS $RAW)
+done
+sleep 1
+$CLI $B3ARGS setgenerate true 3
+WaitForBlock $B1ARGS 224
+
+PRI_HIGH=$($CLI $B3ARGS estimatepriority)
+AssertGreater "$PRI_HIGH" 56000000
+
+# Generate 100 very-low-priority free transactions;
+# priority estimate should go down
+
+for i in {1..50} ; do
+    RAW=$(CreateTxn1 $B1ARGS 1 $B2ADDRESS)
+    RAWTXID=$(SendRawTxn $B1ARGS $RAW)
+    RAW=$(CreateTxn1 $B1ARGS 1 $B3ADDRESS)
+    RAWTXID=$(SendRawTxn $B1ARGS $RAW)
+done
+$CLI $B3ARGS setgenerate true 3
+WaitForBlock $B1ARGS 227
+
+PRI_LOW=$($CLI $B3ARGS estimatepriority)
+AssertGreater "$PRI_HIGH" "$PRI_LOW"
+
+echo "Success. Testing fee estimation."
+
+# At this point:
+#  B1 has 60 unspent outputs with 6 or 7 confirmations
+#  B2 has 17 coinbases with over 100 confirmations
+#   and 50 utxos with 3 confirmations
+#  B3 has no mature coins/transactions.
+#
+# So: create 200 1 XBT transactions from B2 to B3,
+# using sendtoaddress.  The first 67 will be free, the
+# rest will pay a 0.001 XBT fee, and estimatefee
+# should give an estimate of over 0.00099 XBT/kilobyte
+#  (transactions are less than 1KB big)
+for i in {1..200} ; do
+    Send $B2ARGS $B3ARGS 1
+done
+$CLI $B2ARGS setgenerate true 1
+WaitForBlock $B3ARGS 228
+
+FEE_LOW=$($CLI $B3ARGS estimatefee)
+AssertGreater "$FEE_LOW" "0.00099"
+echo "Fee low: $FEE_LOW"
+
+# Now create 500 0.1 XBT transactions
+# from B3 to B1, each paying a 0.02 XBT fee.
+# At most 200 will have non-zero priority,
+# so at least 300 will be zero-priority.
+# Median fee estimate should go up.
+for i in {1..500} ; do
+    Send $B3ARGS $B1ARGS 0.1
+done
+$CLI $B2ARGS setgenerate true 2
+WaitForBlock $B1ARGS 230
+
+FEE_HIGH=$($CLI $B2ARGS estimatefee)
+echo "Fee high: $FEE_HIGH"
+AssertGreater "$FEE_HIGH" "$FEE_LOW"
+
+# Shut down, clean up
+
+$CLI $B3ARGS stop > /dev/null 2>&1
+wait $B3PID
+$CLI $B2ARGS stop > /dev/null 2>&1
+wait $B2PID
+$CLI $B1ARGS stop > /dev/null 2>&1
+wait $B1PID
+
+echo "Tests successful, cleaning up"
+trap "" EXIT
+rm -rf $D
+exit 0

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1799,11 +1799,7 @@ bool SetBestChain(CValidationState &state, CBlockIndex* pindexNew)
             LogPrintf("- Connect: %.2fms\n", (GetTimeMicros() - nStart) * 0.001);
 
         // Accepted into block, means remove from memory pool
-        BOOST_FOREACH(const CTransaction& tx, block.vtx)
-        {
-            mempool.remove(tx, false, pindex->nHeight-1);
-            mempool.removeConflicts(tx);
-        }
+        mempool.removeForBlock(block.vtx, pindex->nHeight-1);
     }
 
     // Flush changes to global coin state

--- a/src/main.h
+++ b/src/main.h
@@ -255,7 +255,8 @@ enum GetMinFee_mode
     GMF_SEND,
 };
 
-int64_t GetMinFee(const CTransaction& tx, unsigned int nBytes, bool fAllowFree, enum GetMinFee_mode mode);
+bool AllowFree(const CTransaction& tx, double dPriority, unsigned int nBytes, enum GetMinFee_mode mode);
+int64_t GetMinFee(unsigned int nBytes, enum GetMinFee_mode mode);
 
 //
 // Check transaction inputs, and make sure any
@@ -289,13 +290,6 @@ unsigned int GetLegacySigOpCount(const CTransaction& tx);
  */
 unsigned int GetP2SHSigOpCount(const CTransaction& tx, CCoinsViewCache& mapInputs);
 
-
-inline bool AllowFree(double dPriority)
-{
-    // Large (in bytes) low-priority (new, small-coin) transactions
-    // need a fee.
-    return dPriority > COIN * 144 / 250;
-}
 
 // Check whether all inputs of this transaction are valid (no double spends, scripts & sigs, amounts)
 // This does not modify the UTXO set. If pvChecks is not NULL, script checks are pushed onto it

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -247,9 +247,6 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn)
             unsigned int nTxSize = ::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION);
             dPriority = tx.ComputePriority(dPriority, nTxSize);
 
-            // This is a more accurate fee-per-kilobyte than is used by the client code, because the
-            // client code rounds up the size to the nearest 1K. That's good, because it gives an
-            // incentive to create smaller transactions.
             double dFeePerKb =  double(nTotalIn-tx.GetValueOut()) / (double(nTxSize)/1000.0);
 
             if (porphan)
@@ -297,7 +294,7 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn)
             // Prioritize by fee once past the priority size or we run out of high-priority
             // transactions:
             if (!fSortedByFee &&
-                ((nBlockSize + nTxSize >= nBlockPrioritySize) || !AllowFree(dPriority)))
+                ((nBlockSize + nTxSize >= nBlockPrioritySize) || !AllowFree(tx, dPriority, nTxSize, GMF_SEND)))
             {
                 fSortedByFee = true;
                 comparer = TxPriorityCompare(fSortedByFee);

--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -177,6 +177,8 @@ Array RPCConvertValues(const std::string &strMethod, const std::vector<std::stri
     if (strMethod == "verifychain"            && n > 1) ConvertTo<boost::int64_t>(params[1]);
     if (strMethod == "keypoolrefill"          && n > 0) ConvertTo<boost::int64_t>(params[0]);
     if (strMethod == "getrawmempool"          && n > 0) ConvertTo<bool>(params[0]);
+    if (strMethod == "estimatefee"            && n > 0) ConvertTo<double>(params[0]);
+    if (strMethod == "estimatepriority"       && n > 0) ConvertTo<double>(params[0]);
 
     return params;
 }

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -247,6 +247,8 @@ static const CRPCCommand vRPCCommands[] =
     { "gettxoutsetinfo",        &gettxoutsetinfo,        true,      false,      false },
     { "gettxout",               &gettxout,               true,      false,      false },
     { "verifychain",            &verifychain,            true,      false,      false },
+    { "estimatefee",            &estimatefee,            true,      true,       false },
+    { "estimatepriority",       &estimatepriority,       true,      true,       false },
 
 #ifdef ENABLE_WALLET
     { "getnetworkhashps",       &getnetworkhashps,       true,      false,      false },

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -176,5 +176,7 @@ extern json_spirit::Value getblock(const json_spirit::Array& params, bool fHelp)
 extern json_spirit::Value gettxoutsetinfo(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value gettxout(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value verifychain(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value estimatefee(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value estimatepriority(const json_spirit::Array& params, bool fHelp);
 
 #endif

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -3,10 +3,156 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include "compat.h"
 #include "core.h"
 #include "txmempool.h"
 
+// These must come after compat.h to avoid windows
+// cross-compiler build errors.
+#include <boost/multi_index_container.hpp>
+#include <boost/multi_index/ordered_index.hpp>
+#include <boost/multi_index/member.hpp>
+
 using namespace std;
+using namespace boost;
+using namespace boost::multi_index;
+
+static const char* MEMPOOL_FILENAME="mempool.dat";
+
+// CMinerPolicyEstimator is told when transactions exit the
+// memory pool because they are included in blocks, and uses
+// that information to estimate the priority needed for
+// free transactions to be included in blocks and the
+// fee needed for fee-paying transactions.
+
+struct TimeValue
+{
+    int64_t t;
+    double v;
+    TimeValue(int64_t _t, double _v) : t(_t), v(_v) { }
+};
+typedef multi_index_container<
+    TimeValue,
+    indexed_by<
+        // Sort by time inserted
+        ordered_non_unique<member<TimeValue,int64_t,&TimeValue::t > >,
+
+        // Sort by value
+        ordered_non_unique<member<TimeValue,double,&TimeValue::v > >
+        >
+    > SortedValues ;
+
+class CMinerPolicyEstimator
+{
+private:
+    size_t nMin, nMax;
+    SortedValues byPriority;
+    SortedValues byFee;
+
+    // Results of estimate() are cached between new blocks, because
+    // the estimate doesn't change until a new block pulls transactions
+    // from the memory pool and because the transaction relaying code
+    // calls estimate on every transaction to decide whether or not it
+    // should be relayed.
+    map<double, double> byPriorityCache;
+    map<double, double> byFeeCache;
+
+    // Estimate what value is required to be chosen above
+    // fraction of other transactions (fraction is 0.0 to 1.0)
+    // Returns -1.0 if not enough data has been collected to
+    // give a good estimate.
+    double estimate(const SortedValues& values, double fraction, map<double,double>& cache)
+    {
+        assert(fraction >= 0.0 && fraction <= 1.0);
+        if (values.size() < nMin) return -1.0;
+
+        map<double,double>::iterator cached = cache.find(fraction);
+        if (cached != cache.end())
+            return cached->second;
+
+        size_t n = size_t(values.size()*fraction);
+        if (n > 0) --n;
+        SortedValues::nth_index<1>::type::iterator it=values.get<1>().begin();
+        std::advance(it, n);
+        cache[fraction] = it->v;
+        return it->v;
+    }
+
+    bool Write(CAutoFile& fileout, const SortedValues& values)
+    {
+        fileout << values.size();
+        SortedValues::nth_index<1>::type::iterator it=values.get<1>().begin();
+        while (it != values.get<1>().end())
+        {
+            fileout << it->t << it->v;
+            it++;
+        }
+        return true;
+    }
+    bool Read(CAutoFile& filein, SortedValues& values)
+    {
+        size_t n;
+        filein >> n;
+        for (size_t i = 0; i < n; i++)
+        {
+            int64_t t;
+            double v;
+            filein >> t >> v;
+            values.insert(TimeValue(t, v));
+        }
+        return true;
+    }
+
+public:
+    CMinerPolicyEstimator(size_t _nMin, size_t _nMax) : nMin(_nMin), nMax(_nMax)
+    {
+    }
+
+    void resize(SortedValues& what, size_t n)
+    {
+        while (what.size() > n)
+            what.erase(what.begin());
+    }
+
+    void add(const CTxMemPoolEntry& entry, unsigned int nBlockHeight)
+    {
+        if (nBlockHeight == 0 || entry.GetTxSize() == 0) return;
+        double dFeePerByte = entry.GetFee() / (double)entry.GetTxSize();
+        double dPriority = entry.GetPriority(nBlockHeight);
+        if (dPriority == 0 && dFeePerByte > 0)
+        {
+            byFee.insert(TimeValue(GetTimeMillis(), dFeePerByte));
+            resize(byFee, nMax);
+            byFeeCache.clear();
+        }
+        else if (dFeePerByte == 0 && dPriority > 0)
+        {
+            byPriority.insert(TimeValue(GetTimeMillis(), dPriority));
+            resize(byPriority, nMax);
+            byPriorityCache.clear();
+        }
+        // Ignore transactions with both fee and priority > 0,
+        // because we can't tell why miners included them (might
+        // have been priority, might have been fee)
+    }
+
+    double estimatePriority(double fraction)
+    {
+        return estimate(byPriority, fraction, byPriorityCache);
+    }
+    double estimateFee(double fraction)
+    {
+        return estimate(byFee, fraction, byFeeCache);
+    }
+    bool Write(CAutoFile& fileout)
+    {
+        return Write(fileout, byPriority) && Write(fileout, byFee);
+    }
+    bool Read(CAutoFile& filein)
+    {
+        return Read(filein, byPriority) && Read(filein, byFee);
+    }
+};
 
 CTxMemPoolEntry::CTxMemPoolEntry()
 {
@@ -41,6 +187,15 @@ CTxMemPool::CTxMemPool()
     // accepting transactions becomes O(N^2) where N is the number
     // of transactions in the pool
     fSanityCheck = false;
+    // 100 and 10,000 values here are arbitrary, but work
+    // well in practice, giving reasonable estimates within a few
+    // blocks and stable estimates over time.
+    minerPolicyEstimator = new CMinerPolicyEstimator(100, 10000);
+}
+
+CTxMemPool::~CTxMemPool()
+{
+    delete minerPolicyEstimator;
 }
 
 void CTxMemPool::pruneSpent(const uint256 &hashTx, CCoins &coins)
@@ -86,7 +241,7 @@ bool CTxMemPool::addUnchecked(const uint256& hash, const CTxMemPoolEntry &entry)
 }
 
 
-bool CTxMemPool::remove(const CTransaction &tx, bool fRecursive)
+bool CTxMemPool::remove(const CTransaction &tx, bool fRecursive, unsigned int nBlockHeight)
 {
     // Remove transaction from memory pool
     {
@@ -101,6 +256,7 @@ bool CTxMemPool::remove(const CTransaction &tx, bool fRecursive)
         }
         if (mapTx.count(hash))
         {
+            minerPolicyEstimator->add(mapTx[hash], nBlockHeight);
             BOOST_FOREACH(const CTxIn& txin, tx.vin)
                 mapNextTx.erase(txin.prevout);
             mapTx.erase(hash);
@@ -189,6 +345,141 @@ bool CTxMemPool::lookup(uint256 hash, CTransaction& result) const
     map<uint256, CTxMemPoolEntry>::const_iterator i = mapTx.find(hash);
     if (i == mapTx.end()) return false;
     result = i->second.GetTx();
+    return true;
+}
+
+void CTxMemPool::estimateFees(double dPriorityMedian, double& dPriority,
+                              double dFeeMedian, double& dFee, bool fUseHardCoded)
+{
+    LOCK(cs);
+    dPriority = minerPolicyEstimator->estimatePriority(dPriorityMedian);
+    // Hard-coded priority is 1-BTC, 144-confirmation old, 250-byte txn:
+    if (dPriority < 0 && fUseHardCoded) dPriority = COIN*144 / 250;
+    dFee = minerPolicyEstimator->estimateFee(dFeeMedian);
+    // Hard-coded fee is 10,000 satoshis per kilobyte (10 satoshis per byte):
+    if (dFee < 0 && fUseHardCoded) dFee = 10.0;
+}
+
+bool CTxMemPool::isDust(const CTxOut& txout)
+{
+    // "Dust" is defined as outputs so small
+    // (in value) that they would require that
+    // more than 1/3 of their value in fees to
+    // have a reasonable chance of being accepted into
+    // a block right now.
+    // Fees are per-byte, so:
+    int nSize = (int)::GetSerializeSize(txout, SER_DISK,0);
+    // ... and assume it will need a 148-byte CTxIn to spend:
+    nSize += 148;
+
+    // Use 0.01 (lowest 1%) as threshold to estimate fee-per-byte:
+    double dMinFee, dUnused;
+    estimateFees(0.01, dUnused, 0.01, dMinFee, true);
+
+    // Need to pay more than 1/3 of value?
+    bool fIsDust = dMinFee*nSize > txout.nValue/3;
+    return fIsDust;
+}
+
+void CTxMemPool::writeEntry(CAutoFile& file, const uint256& txid, std::set<uint256>& alreadyWritten) const
+{
+    if (alreadyWritten.count(txid)) return;
+    alreadyWritten.insert(txid);
+    const CTxMemPoolEntry& entry = mapTx.at(txid);
+    // Write txns we depend on first:
+    BOOST_FOREACH(const CTxIn txin, entry.GetTx().vin)
+    {
+        const uint256& prevout = txin.prevout.hash;
+        if (mapTx.count(prevout))
+            writeEntry(file, prevout, alreadyWritten);
+    }
+    unsigned int nHeight = entry.GetHeight();
+    file << entry.GetTx() << entry.GetFee() << entry.GetTime() << entry.GetPriority(nHeight) << nHeight;
+}
+
+//
+// Format of the mempool.dat file:
+//  32-bit versionRequiredToRead
+//  32-bit versionThatWrote
+//  32-bit-number of transactions
+//  [ serialized: transaction / fee / time / priority / height ]
+//    ... then the miner policy estimation data:
+//  32-bit-number of priority data points
+//  [ (time,priority) ]
+//  32-bit-number of fee data points
+//  [ (time,fee) ]
+//
+bool CTxMemPool::Write() const
+{
+    boost::filesystem::path path = GetDataDir() / MEMPOOL_FILENAME;
+    FILE *file = fopen(path.string().c_str(), "wb"); // Overwrites any older mempool (which is fine)
+    CAutoFile fileout = CAutoFile(file, SER_DISK, CLIENT_VERSION);
+    if (!fileout)
+        return error("CTxMemPool::Write() : open failed");
+
+    fileout << CLIENT_VERSION; // version required to read
+    fileout << CLIENT_VERSION; // version that wrote the file
+
+    std::set<uint256> alreadyWritten; // Used to write parents before dependents
+    try {
+        LOCK(cs);
+        fileout << mapTx.size();
+        for (map<uint256, CTxMemPoolEntry>::const_iterator it = mapTx.begin();
+             it != mapTx.end(); it++)
+        {
+            writeEntry(fileout, it->first, alreadyWritten);
+        }
+        minerPolicyEstimator->Write(fileout);
+    }
+    catch (std::exception &e) {
+        // We don't care much about errors; saving
+        // and restoring the memory pool is mostly an
+        // optimization for cases where a mining node shuts down
+        // briefly (maybe to change an option), and it is better
+        // to restart with a full memory pool of transactions to mine.
+        return error("CTxMemPool::Write() : unable to write (non-fatal)");
+    }
+
+    return true;
+}
+
+bool CTxMemPool::Read(std::list<CTxMemPoolEntry>& vecEntries) const
+{
+    boost::filesystem::path path = GetDataDir() / MEMPOOL_FILENAME;
+    FILE *file = fopen(path.string().c_str(), "rb");
+    if (!file) return true; // No mempool.dat: OK
+    CAutoFile filein = CAutoFile(file, SER_DISK, CLIENT_VERSION);
+    if (!filein)
+        return error("CTxMemPool::Read() : open failed");
+
+    try {
+        int nVersionRequired, nVersionThatWrote;
+        filein >> nVersionRequired >> nVersionThatWrote;
+
+        if (nVersionRequired > CLIENT_VERSION)
+            return error("CTxMemPool::Read() : up-version (%d) mempool.dat", nVersionRequired);
+
+        size_t nTx;
+        filein >> nTx;
+
+        for (size_t i = 0; i < nTx; i++)
+        {
+            CTransaction tx;
+            int64_t nFee;
+            int64_t nTime;
+            double dPriority;
+            unsigned int nHeight;
+            filein >> tx >> nFee >> nTime >> dPriority >> nHeight;
+            CTxMemPoolEntry e(tx, 0, nTime, dPriority, nHeight);
+            vecEntries.push_back(e);
+        }
+        minerPolicyEstimator->Read(filein);
+    }
+    catch (std::exception &e) {
+        // Not a big deal if mempool.dat gets corrupted:
+        return error("CTxMemPool::Read() : unable to read (non-fatal)");
+    }
+
     return true;
 }
 

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -12,7 +12,7 @@
 /** Fake height value used in CCoins to signify they are only in the memory pool (since 0.8) */
 static const unsigned int MEMPOOL_HEIGHT = 0x7FFFFFFF;
 
-class CMinerPolicyEstimator; // Internal class used for estimatefees functionality
+class CMinerPolicyEstimator; // Internal class used for estimatefee functionality
 
 /*
  * CTxMemPool stores these:
@@ -83,8 +83,8 @@ public:
     void clear();
     void queryHashes(std::vector<uint256>& vtxid);
     void pruneSpent(const uint256& hash, CCoins &coins);
-    void estimateFees(double dPriorityMedian, double& dPriority, double dFeeMedian, double& dFee, bool fUseHardCoded=false);
-    bool isDust(const CTxOut& txout);
+    double estimateFreePriority(double dPriorityMedian, bool fUseHardCoded=false);
+    double estimateFee(double dFeeMedian, bool fUseHardCoded=false); // Returns satoshi-per-byte estimate
     unsigned int GetTransactionsUpdated() const;
     void AddTransactionsUpdated(unsigned int n);
 

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -13,6 +13,7 @@
 static const unsigned int MEMPOOL_HEIGHT = 0x7FFFFFFF;
 
 class CMinerPolicyEstimator; // Internal class used for estimatefee functionality
+class CMinerPolicyEstimator2;
 
 /*
  * CTxMemPool stores these:
@@ -57,6 +58,7 @@ private:
     bool fSanityCheck; // Normally false, true if -checkmempool or -regtest
     unsigned int nTransactionsUpdated;
     CMinerPolicyEstimator* minerPolicyEstimator; // For estimating transaction fees
+    CMinerPolicyEstimator2* minerPolicyEstimator2;
 
     void writeEntry(CAutoFile& file, const uint256& txid, std::set<uint256>& alreadyWritten) const;
 
@@ -80,11 +82,14 @@ public:
     bool addUnchecked(const uint256& hash, const CTxMemPoolEntry &entry);
     bool remove(const CTransaction &tx, bool fRecursive = false, unsigned int nBlockHeight = 0);
     bool removeConflicts(const CTransaction &tx);
+    void removeForBlock(const std::vector<CTransaction>& vtx, unsigned int nBlockHeight);
     void clear();
     void queryHashes(std::vector<uint256>& vtxid);
     void pruneSpent(const uint256& hash, CCoins &coins);
     double estimateFreePriority(double dPriorityMedian, bool fUseHardCoded=false);
     double estimateFee(double dFeeMedian, bool fUseHardCoded=false); // Returns satoshi-per-byte estimate
+    double estimatePriorityToConfirmWithin(int nBlocks);
+    double estimateFeeToConfirmWithin(int nBlocks);
     unsigned int GetTransactionsUpdated() const;
     void AddTransactionsUpdated(unsigned int n);
 


### PR DESCRIPTION
This is a much more conservative pull request than my previous smart-fees request.

It only tries to solve the problem:  what fee (or priority) is needed to get into a block right now?

It adds two new RPC calls: estimatefee and estimatepriority.

Test plan:

Run qa/rpc-tests/estimatefee.sh   : EXPECT:  runs successfully (it is a -regtest integration test).

Restart bitcoind with this patch. Then run:

bitcoin-cli -rpcwait estimatefee       : EXPECT: -1  (not enough data to estimate)
bitcoin-cli -rpcwait estimatepriority   : EXPECT: -1  (not enough data)

Leave it running an hour or two, and repeat. EXPECT: reasonable fee/priority estimate.

Test different medians; EXPECT: estimatefee 0.1 is less than or equal to estimatefee 0.5.  Same for priority.

Test saving/restoring mempool/estimation state:  shutdown bitcoind, and restart.  EXPECT: same estimates as before.

Test Bitcoin-Qt fee/priority estimation:

Run with a wallet that has a combination of big/old and small/new unspent transaction inputs.
Turn on coin control.
Test send:  EXPECT: coin control values Do the Right Thing (fee turns red if not enough fee is included, preiority turns red if not enough priority to qualify, etc).
