### PR TITLE
Fix a rare crash on Mac OS X, by removing a setFocus on the payTo field ...

### DIFF
--- a/src/qt/sendcoinsentry.cpp
+++ b/src/qt/sendcoinsentry.cpp
@@ -97,8 +97,6 @@ void SendCoinsEntry::clear()
     ui->memoTextLabel_s->clear();
     ui->payAmount_s->clear();
 
-    ui->payTo->setFocus();
-
     // update the display unit, to not use the default ("BTC")
     updateDisplayUnit();
 }


### PR DESCRIPTION
...that was not necessary, as the field still receives focus without it.
