### PR TITLE
gitian: remove zlib and libpng deps

### DIFF
--- a/contrib/gitian-descriptors/README.md
+++ b/contrib/gitian-descriptors/README.md
@@ -33,8 +33,6 @@ Once you've got the right hardware and software:
     wget 'https://downloads.sourceforge.net/project/boost/boost/1.50.0/boost_1_50_0.tar.bz2'
     wget 'http://www.openssl.org/source/openssl-1.0.1c.tar.gz'
     wget 'http://download.oracle.com/berkeley-db/db-4.8.30.NC.tar.gz'
-    wget 'https://downloads.sourceforge.net/project/libpng/zlib/1.2.6/zlib-1.2.6.tar.gz'
-    wget 'https://downloads.sourceforge.net/project/libpng/libpng15/older-releases/1.5.9/libpng-1.5.9.tar.gz'
     wget 'https://download.qt-project.org/archive/qt/4.8/4.8.3/qt-everywhere-opensource-src-4.8.3.tar.gz'
     wget 'http://protobuf.googlecode.com/files/protobuf-2.5.0.tar.bz2'
     cd ../..

--- a/contrib/gitian-descriptors/deps-win32.yml
+++ b/contrib/gitian-descriptors/deps-win32.yml
@@ -17,8 +17,6 @@ files:
 - "openssl-1.0.1c.tar.gz"
 - "db-4.8.30.NC.tar.gz"
 - "miniupnpc-1.6.tar.gz"
-- "zlib-1.2.6.tar.gz"
-- "libpng-1.5.9.tar.gz"
 - "qrencode-3.2.0.tar.bz2"
 script: |
   #
@@ -29,10 +27,7 @@ script: |
   export HOST=i686-w64-mingw32
   # Input Integrity Check
   echo "2a9eb3cd4e8b114eb9179c0d3884d61658e7d8e8bf4984798a5f5bd48e325ebe  openssl-1.0.1c.tar.gz"  | sha256sum -c
-  echo "b75dae26151f9b031062c8d2f577a094b08da0ae44fe8c11175d0b9ff434cc02  libpng-1.5.9.tar.gz"    | sha256sum -c
   echo "12edc0df75bf9abd7f82f821795bcee50f42cb2e5f76a6a281b85732798364ef  db-4.8.30.NC.tar.gz"    | sha256sum -c
-  echo "21235e08552e6feba09ea5e8d750805b3391c62fb81c71a235c0044dc7a8a61b  zlib-1.2.6.tar.gz"      | sha256sum -c
-  echo "b75dae26151f9b031062c8d2f577a094b08da0ae44fe8c11175d0b9ff434cc02  libpng-1.5.9.tar.gz"    | sha256sum -c
   echo "03c4bc7cd9a75747c3815d509bbe061907d615764f2357923f0db948c567068f  qrencode-3.2.0.tar.bz2" | sha256sum -c
 
   mkdir -p $INSTALLPREFIX
@@ -75,26 +70,12 @@ script: |
   install libminiupnpc.a  $INSTALLPREFIX/lib
   cd ..
   #
-  tar xzf zlib-1.2.6.tar.gz
-  cd zlib-1.2.6
-  CROSS_PREFIX=$HOST- ./configure --prefix=$INSTALLPREFIX --static
-  make
-  make install
-  cd ..
-  #
-  tar xzf libpng-1.5.9.tar.gz
-  cd libpng-1.5.9
-  CFLAGS="-I$INSTALLPREFIX/include" LDFLAGS="-L$INSTALLPREFIX/lib" ./configure --disable-shared --prefix=$INSTALLPREFIX --host=$HOST
-  make $MAKEOPTS
-  make install
-  cd ..
-  #
   tar xjf qrencode-3.2.0.tar.bz2
   cd qrencode-3.2.0
-  png_CFLAGS="-I$INSTALLPREFIX/include" png_LIBS="-L$INSTALLPREFIX/lib -lpng" ./configure --prefix=$INSTALLPREFIX --host=$HOST
+  ./configure --prefix=$INSTALLPREFIX --host=$HOST --without-tools
   make
   make install
   cd ..
   #
   cd $INSTALLPREFIX
-  zip -r $OUTDIR/bitcoin-deps-win32-gitian-r9.zip include lib
+  zip -r $OUTDIR/bitcoin-deps-win32-gitian-r10.zip include lib

--- a/contrib/gitian-descriptors/gitian-win32.yml
+++ b/contrib/gitian-descriptors/gitian-win32.yml
@@ -24,7 +24,7 @@ remotes:
 files:
 - "qt-win32-4.8.3-gitian-r4.zip"
 - "boost-win32-1.54.0-gitian-r6.zip"
-- "bitcoin-deps-win32-gitian-r9.zip"
+- "bitcoin-deps-win32-gitian-r10.zip"
 - "protobuf-win32-2.5.0-gitian-r3.zip"
 script: |
   #
@@ -35,7 +35,7 @@ script: |
   cd $STAGING
   unzip ../build/qt-win32-4.8.3-gitian-r4.zip
   unzip ../build/boost-win32-1.54.0-gitian-r6.zip
-  unzip ../build/bitcoin-deps-win32-gitian-r9.zip
+  unzip ../build/bitcoin-deps-win32-gitian-r10.zip
   unzip ../build/protobuf-win32-2.5.0-gitian-r3.zip
   cd $HOME/build/
   #

--- a/contrib/gitian-descriptors/qt-win32.yml
+++ b/contrib/gitian-descriptors/qt-win32.yml
@@ -15,7 +15,7 @@ reference_datetime: "2011-01-30 00:00:00"
 remotes: []
 files:
 - "qt-everywhere-opensource-src-4.8.3.tar.gz"
-- "bitcoin-deps-win32-gitian-r9.zip"
+- "bitcoin-deps-win32-gitian-r10.zip"
 script: |
   #
   HOST=i686-w64-mingw32
@@ -27,7 +27,7 @@ script: |
   mkdir -p $INSTDIR/host/bin
   #
   # Need mingw-compiled openssl from bitcoin-deps:
-  unzip bitcoin-deps-win32-gitian-r9.zip
+  unzip bitcoin-deps-win32-gitian-r10.zip
   DEPSDIR=`pwd`
   #
   tar xzf qt-everywhere-opensource-src-4.8.3.tar.gz

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -42,8 +42,6 @@ Release Process
 	wget 'http://miniupnp.free.fr/files/download.php?file=miniupnpc-1.6.tar.gz' -O miniupnpc-1.6.tar.gz
 	wget 'https://www.openssl.org/source/openssl-1.0.1c.tar.gz'
 	wget 'http://download.oracle.com/berkeley-db/db-4.8.30.NC.tar.gz'
-	wget 'ftp://ftp.simplesystems.org/pub/libpng/png/src/history/zlib/zlib-1.2.6.tar.gz'
-	wget 'ftp://ftp.simplesystems.org/pub/libpng/png/src/history/libpng15/libpng-1.5.9.tar.gz'
 	wget 'https://fukuchi.org/works/qrencode/qrencode-3.2.0.tar.bz2'
 	wget 'https://downloads.sourceforge.net/project/boost/boost/1.54.0/boost_1_54_0.tar.bz2'
 	wget 'https://svn.boost.org/trac/boost/raw-attachment/ticket/7262/boost-mingw.patch' -O \ 


### PR DESCRIPTION
Triggered by #3341.

The bitcoin win32 build was relying on an old insecure version of libpng for no good reason. The libqrcode tools make use of libpng but we don't use the tools, just the library.

In turn, this libpng dependency pulled in zlib.

Remove both dependencies both from the documentation and descriptor.

Bump deps version to r10 (for good measure; the used parts of the dependencies don't actually change, so it may not be strictly needed).
