### PR TITLE
Sanitize assert usage and refuse to compile with NDEBUG.

### DIFF
--- a/src/key.cpp
+++ b/src/key.cpp
@@ -148,10 +148,13 @@ public:
     }
 
     void SetSecretBytes(const unsigned char vch[32]) {
+        bool ret;
         BIGNUM bn;
         BN_init(&bn);
-        assert(BN_bin2bn(vch, 32, &bn));
-        assert(EC_KEY_regenerate_key(pkey, &bn));
+        ret = BN_bin2bn(vch, 32, &bn);
+        assert(ret);
+        ret = EC_KEY_regenerate_key(pkey, &bn);
+        assert(ret);
         BN_clear_free(&bn);
     }
 

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1298,7 +1298,9 @@ bool CWallet::CreateTransaction(const vector<pair<CScript, int64_t> >& vecSend,
 
                         // Reserve a new key pair from key pool
                         CPubKey vchPubKey;
-                        assert(reservekey.GetReservedKey(vchPubKey)); // should never fail, as we just unlocked
+                        bool ret;
+                        ret = reservekey.GetReservedKey(vchPubKey);
+                        assert(ret); // should never fail, as we just unlocked
 
                         scriptChange.SetDestination(vchPubKey.GetID());
                     }


### PR DESCRIPTION
There were quite a few places where assert() was used with side effects,
 making operation with NDEBUG non-functional.  This commit fixes all the
 cases I know about, but also adds an  #error on NDEBUG because the code
 is untested without assertions and may still have vulnerabilities if
 used without assert.
