### PR TITLE
[Qt] massive options/settings rework (no core changes)

### DIFF
--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>540</width>
-    <height>380</height>
+    <width>560</width>
+    <height>400</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -19,9 +19,6 @@
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <widget class="QTabWidget" name="tabWidget">
-     <property name="tabPosition">
-      <enum>QTabWidget::North</enum>
-     </property>
      <property name="currentIndex">
       <number>0</number>
      </property>
@@ -87,20 +84,43 @@
         </widget>
        </item>
        <item>
-        <spacer name="verticalSpacer_Main">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item>
         <layout class="QHBoxLayout" name="horizontalLayout_2_Main">
+         <item>
+          <widget class="QLabel" name="databaseCacheLabel">
+           <property name="text">
+            <string>Size of &amp;database cache</string>
+           </property>
+           <property name="textFormat">
+            <enum>Qt::PlainText</enum>
+           </property>
+           <property name="buddy">
+            <cstring>databaseCache</cstring>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QSpinBox" name="databaseCache">
+           <property name="toolTip">
+            <string>Set database cache size in megabytes (default: 25)</string>
+           </property>
+           <property name="maximum">
+            <number>1024</number>
+           </property>
+           <property name="value">
+            <number>25</number>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="databaseCacheUnitLabel">
+           <property name="text">
+            <string>MB</string>
+           </property>
+           <property name="textFormat">
+            <enum>Qt::PlainText</enum>
+           </property>
+          </widget>
+         </item>
          <item>
           <spacer name="horizontalSpacer_2_Main">
            <property name="orientation">
@@ -114,20 +134,63 @@
            </property>
           </spacer>
          </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_3_Main">
          <item>
-          <widget class="QPushButton" name="resetButton">
-           <property name="toolTip">
-            <string>Reset all client options to default.</string>
-           </property>
+          <widget class="QLabel" name="threadsScriptVerifLabel">
            <property name="text">
-            <string>&amp;Reset Options</string>
+            <string>Number of script &amp;verification threads</string>
            </property>
-           <property name="autoDefault">
-            <bool>false</bool>
+           <property name="textFormat">
+            <enum>Qt::PlainText</enum>
+           </property>
+           <property name="buddy">
+            <cstring>threadsScriptVerif</cstring>
            </property>
           </widget>
          </item>
+         <item>
+          <widget class="QSpinBox" name="threadsScriptVerif">
+           <property name="toolTip">
+            <string>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</string>
+           </property>
+           <property name="minimum">
+            <number>-16</number>
+           </property>
+           <property name="maximum">
+            <number>16</number>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_3_Main">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
         </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_Main">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
        </item>
       </layout>
      </widget>
@@ -149,15 +212,15 @@
        <item>
         <widget class="QCheckBox" name="connectSocks">
          <property name="toolTip">
-          <string>Connect to the Bitcoin network through a SOCKS proxy (e.g. when connecting through Tor).</string>
+          <string>Connect to the Bitcoin network through a SOCKS proxy.</string>
          </property>
          <property name="text">
-          <string>&amp;Connect through SOCKS proxy:</string>
+          <string>&amp;Connect through SOCKS proxy (default proxy):</string>
          </property>
         </widget>
        </item>
        <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_Network">
+        <layout class="QHBoxLayout" name="horizontalLayout_1_Network">
          <item>
           <widget class="QLabel" name="proxyIpLabel">
            <property name="text">
@@ -173,6 +236,12 @@
          </item>
          <item>
           <widget class="QValidatedLineEdit" name="proxyIp">
+           <property name="minimumSize">
+            <size>
+             <width>140</width>
+             <height>0</height>
+            </size>
+           </property>
            <property name="maximumSize">
             <size>
              <width>140</width>
@@ -180,7 +249,7 @@
             </size>
            </property>
            <property name="toolTip">
-            <string>IP address of the proxy (e.g. 127.0.0.1)</string>
+            <string>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</string>
            </property>
           </widget>
          </item>
@@ -199,6 +268,12 @@
          </item>
          <item>
           <widget class="QLineEdit" name="proxyPort">
+           <property name="minimumSize">
+            <size>
+             <width>55</width>
+             <height>0</height>
+            </size>
+           </property>
            <property name="maximumSize">
             <size>
              <width>55</width>
@@ -231,7 +306,7 @@
           </widget>
          </item>
          <item>
-          <spacer name="horizontalSpacer_Network">
+          <spacer name="horizontalSpacer_1_Network">
            <property name="orientation">
             <enum>Qt::Horizontal</enum>
            </property>
@@ -391,7 +466,66 @@
     </widget>
    </item>
    <item>
+    <widget class="QFrame" name="frame">
+     <layout class="QVBoxLayout" name="verticalLayout_Bottom">
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_Bottom">
+        <item>
+         <widget class="QLabel" name="overriddenByCommandLineInfoLabel">
+          <property name="text">
+           <string>Active command-line options that override above options: </string>
+          </property>
+          <property name="textFormat">
+           <enum>Qt::PlainText</enum>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_Bottom">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <widget class="QLabel" name="overriddenByCommandLineLabel">
+        <property name="text">
+         <string/>
+        </property>
+        <property name="textFormat">
+         <enum>Qt::PlainText</enum>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <layout class="QHBoxLayout" name="horizontalLayout_Buttons">
+     <item>
+      <widget class="QPushButton" name="resetButton">
+       <property name="toolTip">
+        <string>Reset all client options to default.</string>
+       </property>
+       <property name="text">
+        <string>&amp;Reset Options</string>
+       </property>
+       <property name="autoDefault">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
      <item>
       <spacer name="horizontalSpacer_1">
        <property name="orientation">
@@ -407,6 +541,12 @@
      </item>
      <item>
       <widget class="QLabel" name="statusLabel">
+       <property name="minimumSize">
+        <size>
+         <width>200</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="font">
         <font>
          <weight>75</weight>
@@ -454,16 +594,6 @@
        </property>
       </widget>
      </item>
-     <item>
-      <widget class="QPushButton" name="applyButton">
-       <property name="text">
-        <string>&amp;Apply</string>
-       </property>
-       <property name="autoDefault">
-        <bool>false</bool>
-       </property>
-      </widget>
-     </item>
     </layout>
    </item>
   </layout>
@@ -473,16 +603,17 @@
    <class>BitcoinAmountField</class>
    <extends>QLineEdit</extends>
    <header>bitcoinamountfield.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QValueComboBox</class>
-   <extends>QComboBox</extends>
-   <header>qvaluecombobox.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>QValidatedLineEdit</class>
    <extends>QLineEdit</extends>
    <header>qvalidatedlineedit.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QValueComboBox</class>
+   <extends>QComboBox</extends>
+   <header>qvaluecombobox.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/src/qt/optionsdialog.h
+++ b/src/qt/optionsdialog.h
@@ -31,35 +31,28 @@ protected:
     bool eventFilter(QObject *object, QEvent *event);
 
 private slots:
-    /* enable only apply button */
-    void enableApplyButton();
-    /* disable only apply button */
-    void disableApplyButton();
-    /* enable apply button and OK button */
-    void enableSaveButtons();
-    /* disable apply button and OK button */
-    void disableSaveButtons();
-    /* set apply button and OK button state (enabled / disabled) */
-    void setSaveButtonState(bool fState);
+    /* enable OK button */
+    void enableOkButton();
+    /* disable OK button */
+    void disableOkButton();
+    /* set OK button state (enabled / disabled) */
+    void setOkButtonState(bool fState);
     void on_resetButton_clicked();
     void on_okButton_clicked();
     void on_cancelButton_clicked();
-    void on_applyButton_clicked();
 
-    void showRestartWarning_Proxy();
-    void showRestartWarning_Lang();
+    void showRestartWarning(bool fPersistent = false);
+    void clearStatusLabel();
     void updateDisplayUnit();
-    void handleProxyIpValid(QValidatedLineEdit *object, bool fState);
+    void doProxyIpChecks(QValidatedLineEdit *pUiProxyIp, int nProxyPort);
 
 signals:
-    void proxyIpValid(QValidatedLineEdit *object, bool fValid);
+    void proxyIpChecks(QValidatedLineEdit *pUiProxyIp, int nProxyPort);
 
 private:
     Ui::OptionsDialog *ui;
     OptionsModel *model;
     MonitoredDataMapper *mapper;
-    bool fRestartWarningDisplayed_Proxy;
-    bool fRestartWarningDisplayed_Lang;
     bool fProxyIpValid;
 };
 

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -18,6 +18,7 @@
 #include "walletdb.h"
 
 #include <QSettings>
+#include <QStringList>
 
 OptionsModel::OptionsModel(QObject *parent) :
     QAbstractListModel(parent)
@@ -25,79 +26,114 @@ OptionsModel::OptionsModel(QObject *parent) :
     Init();
 }
 
-bool static ApplyProxySettings()
-{
-    QSettings settings;
-    CService addrProxy(settings.value("addrProxy", "127.0.0.1:9050").toString().toStdString());
-    int nSocksVersion(settings.value("nSocksVersion", 5).toInt());
-    if (!settings.value("fUseProxy", false).toBool()) {
-        addrProxy = CService();
-        nSocksVersion = 0;
-        return false;
-    }
-    if (nSocksVersion && !addrProxy.IsValid())
-        return false;
-    if (!IsLimited(NET_IPV4))
-        SetProxy(NET_IPV4, addrProxy, nSocksVersion);
-    if (nSocksVersion > 4) {
-#ifdef USE_IPV6
-        if (!IsLimited(NET_IPV6))
-            SetProxy(NET_IPV6, addrProxy, nSocksVersion);
-#endif
-        SetNameProxy(addrProxy, nSocksVersion);
-    }
-    return true;
-}
-
+// Writes all missing QSettings with their default values
 void OptionsModel::Init()
 {
     QSettings settings;
 
+    // Ensure restart flag is unset on client startup
+    setRestartRequired(false);
+
     // These are Qt-only settings:
-    nDisplayUnit = settings.value("nDisplayUnit", BitcoinUnits::BTC).toInt();
+
+    // Window
+    if (!settings.contains("fMinimizeToTray"))
+        settings.setValue("fMinimizeToTray", false);
+    fMinimizeToTray = settings.value("fMinimizeToTray").toBool();
+
+    if (!settings.contains("fMinimizeOnClose"))
+        settings.setValue("fMinimizeOnClose", false);
+    fMinimizeOnClose = settings.value("fMinimizeOnClose").toBool();
+
+    // Display
+    if (!settings.contains("nDisplayUnit"))
+        settings.setValue("nDisplayUnit", BitcoinUnits::BTC);
+    nDisplayUnit = settings.value("nDisplayUnit").toInt();
+
+    if (!settings.contains("bDisplayAddresses"))
+        settings.setValue("bDisplayAddresses", false);
     bDisplayAddresses = settings.value("bDisplayAddresses", false).toBool();
-    fMinimizeToTray = settings.value("fMinimizeToTray", false).toBool();
-    fMinimizeOnClose = settings.value("fMinimizeOnClose", false).toBool();
-    nTransactionFee = settings.value("nTransactionFee").toLongLong();
-    language = settings.value("language", "").toString();
+
+    if (!settings.contains("fCoinControlFeatures"))
+        settings.setValue("fCoinControlFeatures", false);
     fCoinControlFeatures = settings.value("fCoinControlFeatures", false).toBool();
 
-    // These are shared with core Bitcoin; we want
-    // command-line options to override the GUI settings:
-    if (settings.contains("fUseUPnP"))
-        SoftSetBoolArg("-upnp", settings.value("fUseUPnP").toBool());
-    if (settings.contains("addrProxy") && settings.value("fUseProxy").toBool())
-        SoftSetArg("-proxy", settings.value("addrProxy").toString().toStdString());
-    if (settings.contains("nSocksVersion") && settings.value("fUseProxy").toBool())
-        SoftSetArg("-socks", settings.value("nSocksVersion").toString().toStdString());
-    if (!language.isEmpty())
-        SoftSetArg("-lang", language.toStdString());
+    // These are shared with the core or have a command-line parameter
+    // and we want command-line parameters to overwrite the GUI settings.
+    //
+    // If setting doesn't exist create it with defaults.
+    //
+    // If SoftSetArg() or SoftSetBoolArg() return false we were overridden
+    // by command-line and show this in the UI.
+
+    // Main
+    if (!settings.contains("nTransactionFee"))
+        settings.setValue("nTransactionFee", 0);
+
+    if (!settings.contains("nDatabaseCache"))
+        settings.setValue("nDatabaseCache", 25);
+    if (!SoftSetArg("-dbcache", settings.value("nDatabaseCache").toString().toStdString()))
+        strOverriddenByCommandLine += "-dbcache ";
+
+    if (!settings.contains("nThreadsScriptVerif"))
+        settings.setValue("nThreadsScriptVerif", 0);
+    if (!SoftSetArg("-par", settings.value("nThreadsScriptVerif").toString().toStdString()))
+        strOverriddenByCommandLine += "-par ";
+
+    // Network
+    if (!settings.contains("fUseUPnP"))
+#ifdef USE_UPNP
+        settings.setValue("fUseUPnP", true);
+#else
+        settings.setValue("fUseUPnP", false);
+#endif	
+    if (!SoftSetBoolArg("-upnp", settings.value("fUseUPnP").toBool()))
+        strOverriddenByCommandLine += "-upnp ";
+
+    if (!settings.contains("fUseProxy"))
+        settings.setValue("fUseProxy", false);
+    if (!settings.contains("addrProxy"))
+        settings.setValue("addrProxy", "127.0.0.1:9050");
+    // Only try to set -proxy, if user has enabled fUseProxy
+    if (settings.value("fUseProxy").toBool() && !SoftSetArg("-proxy", settings.value("addrProxy").toString().toStdString()))
+        strOverriddenByCommandLine += "-proxy ";
+    if (!settings.contains("nSocksVersion"))
+        settings.setValue("nSocksVersion", 5);
+    // Only try to set -socks, if user has enabled fUseProxy
+    if (settings.value("fUseProxy").toBool() && !SoftSetArg("-socks", settings.value("nSocksVersion").toString().toStdString()))
+        strOverriddenByCommandLine += "-socks ";
+
+    // Display
+    if (!settings.contains("language"))
+        settings.setValue("language", "");
+    if (!SoftSetArg("-lang", settings.value("language").toString().toStdString()))
+        strOverriddenByCommandLine += "-lang";
+
+    language = settings.value("language").toString();
 }
 
 void OptionsModel::Reset()
 {
     QSettings settings;
 
-    // Remove all entries in this QSettings object
+    // Remove all entries from our QSettings object
     settings.clear();
 
     // default setting for OptionsModel::StartAtStartup - disabled
     if (GUIUtil::GetStartOnSystemStartup())
         GUIUtil::SetStartOnSystemStartup(false);
 
-    // Re-Init to get default values
-    Init();
-
     // Ensure Upgrade() is not running again by setting the bImportFinished flag
     settings.setValue("bImportFinished", true);
 }
 
-bool OptionsModel::Upgrade()
+void OptionsModel::Upgrade()
 {
     QSettings settings;
 
+    // Already upgraded
     if (settings.contains("bImportFinished"))
-        return false; // Already upgraded
+        return;
 
     settings.setValue("bImportFinished", true);
 
@@ -145,18 +181,16 @@ bool OptionsModel::Upgrade()
             walletdb.EraseSetting("addrProxy");
         }
     }
-    ApplyProxySettings();
+
     Init();
-
-    return true;
 }
-
 
 int OptionsModel::rowCount(const QModelIndex & parent) const
 {
     return OptionIDRowCount;
 }
 
+// read QSettings values and return them
 QVariant OptionsModel::data(const QModelIndex & index, int role) const
 {
     if(role == Qt::EditRole)
@@ -165,52 +199,55 @@ QVariant OptionsModel::data(const QModelIndex & index, int role) const
         switch(index.row())
         {
         case StartAtStartup:
-            return QVariant(GUIUtil::GetStartOnSystemStartup());
+            return GUIUtil::GetStartOnSystemStartup();
         case MinimizeToTray:
-            return QVariant(fMinimizeToTray);
+            return fMinimizeToTray;
         case MapPortUPnP:
 #ifdef USE_UPNP
-            return settings.value("fUseUPnP", GetBoolArg("-upnp", true));
+            return settings.value("fUseUPnP");
 #else
-            return QVariant(false);
+            return false;
 #endif
         case MinimizeOnClose:
-            return QVariant(fMinimizeOnClose);
-        case ProxyUse: {
-            proxyType proxy;
-            return QVariant(GetProxy(NET_IPV4, proxy));
-        }
+            return fMinimizeOnClose;
+
+        // default proxy
+        case ProxyUse:
+            return settings.value("fUseProxy", false);
         case ProxyIP: {
-            proxyType proxy;
-            if (GetProxy(NET_IPV4, proxy))
-                return QVariant(QString::fromStdString(proxy.first.ToStringIP()));
-            else
-                return QVariant(QString::fromStdString("127.0.0.1"));
+            // contains IP at index 0 and port at index 1
+            QStringList strlIpPort = settings.value("addrProxy").toString().split(":", QString::SkipEmptyParts);
+            return strlIpPort.at(0);
         }
         case ProxyPort: {
-            proxyType proxy;
-            if (GetProxy(NET_IPV4, proxy))
-                return QVariant(proxy.first.GetPort());
-            else
-                return QVariant(9050);
+            // contains IP at index 0 and port at index 1
+            QStringList strlIpPort = settings.value("addrProxy").toString().split(":", QString::SkipEmptyParts);
+            return strlIpPort.at(1);
         }
-        case ProxySocksVersion: {
-            proxyType proxy;
-            if (GetProxy(NET_IPV4, proxy))
-                return QVariant(proxy.second);
-            else
-                return QVariant(5);
-        }
+        case ProxySocksVersion:
+            return settings.value("nSocksVersion", 5);
+
         case Fee:
-            return QVariant((qint64) nTransactionFee);
+            // Attention: Init() is called before nTransactionFee is set in AppInit2()!
+            // To ensure we can change the fee on-the-fly update our QSetting when
+            // opening OptionsDialog, which queries Fee via the mapper.
+            if (nTransactionFee != settings.value("nTransactionFee").toLongLong())
+                settings.setValue("nTransactionFee", (qint64)nTransactionFee);
+            // Todo: Consider to revert back to use just nTransactionFee here, if we don't want
+            // -paytxfee to update our QSettings!
+            return settings.value("nTransactionFee");
         case DisplayUnit:
-            return QVariant(nDisplayUnit);
+            return nDisplayUnit;
         case DisplayAddresses:
-            return QVariant(bDisplayAddresses);
+            return bDisplayAddresses;
         case Language:
-            return settings.value("language", "");
+            return settings.value("language");
         case CoinControlFeatures:
-            return QVariant(fCoinControlFeatures);
+            return fCoinControlFeatures;
+        case DatabaseCache:
+            return settings.value("nDatabaseCache");
+        case ThreadsScriptVerif:
+            return settings.value("nThreadsScriptVerif");
         default:
             return QVariant();
         }
@@ -218,6 +255,7 @@ QVariant OptionsModel::data(const QModelIndex & index, int role) const
     return QVariant();
 }
 
+// write QSettings values
 bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, int role)
 {
     bool successful = true; /* set to false on parse error */
@@ -233,7 +271,7 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
             fMinimizeToTray = value.toBool();
             settings.setValue("fMinimizeToTray", fMinimizeToTray);
             break;
-        case MapPortUPnP:
+        case MapPortUPnP: // core option - can be changed on-the-fly
             settings.setValue("fUseUPnP", value.toBool());
             MapPort(value.toBool());
             break;
@@ -241,44 +279,50 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
             fMinimizeOnClose = value.toBool();
             settings.setValue("fMinimizeOnClose", fMinimizeOnClose);
             break;
+
+        // default proxy
         case ProxyUse:
-            settings.setValue("fUseProxy", value.toBool());
-            successful = ApplyProxySettings();
+            if (settings.value("fUseProxy") != value) {
+                settings.setValue("fUseProxy", value.toBool());
+                setRestartRequired(true);
+            }
             break;
         case ProxyIP: {
-            proxyType proxy;
-            proxy.first = CService("127.0.0.1", 9050);
-            GetProxy(NET_IPV4, proxy);
-
-            CNetAddr addr(value.toString().toStdString());
-            proxy.first.SetIP(addr);
-            settings.setValue("addrProxy", proxy.first.ToStringIPPort().c_str());
-            successful = ApplyProxySettings();
+            // contains current IP at index 0 and current port at index 1
+            QStringList strlIpPort = settings.value("addrProxy").toString().split(":", QString::SkipEmptyParts);
+            // if that key doesn't exist or has a changed IP
+            if (!settings.contains("addrProxy") || strlIpPort.at(0) != value.toString()) {
+                // construct new value from new IP and current port
+                QString strNewValue = value.toString() + ":" + strlIpPort.at(1);
+                settings.setValue("addrProxy", strNewValue);
+                setRestartRequired(true);
+            }
         }
         break;
         case ProxyPort: {
-            proxyType proxy;
-            proxy.first = CService("127.0.0.1", 9050);
-            GetProxy(NET_IPV4, proxy);
-
-            proxy.first.SetPort(value.toInt());
-            settings.setValue("addrProxy", proxy.first.ToStringIPPort().c_str());
-            successful = ApplyProxySettings();
+            // contains current IP at index 0 and current port at index 1
+            QStringList strlIpPort = settings.value("addrProxy").toString().split(":", QString::SkipEmptyParts);
+            // if that key doesn't exist or has a changed port
+            if (!settings.contains("addrProxy") || strlIpPort.at(1) != value.toString()) {
+                // construct new value from current IP and new port
+                QString strNewValue = strlIpPort.at(0) + ":" + value.toString();
+                settings.setValue("addrProxy", strNewValue);
+                setRestartRequired(true);
+            }
         }
         break;
         case ProxySocksVersion: {
-            proxyType proxy;
-            proxy.second = 5;
-            GetProxy(NET_IPV4, proxy);
-
-            proxy.second = value.toInt();
-            settings.setValue("nSocksVersion", proxy.second);
-            successful = ApplyProxySettings();
+            if (settings.value("nSocksVersion") != value) {
+                settings.setValue("nSocksVersion", value.toInt());
+                setRestartRequired(true);
+            }
         }
         break;
-        case Fee:
+
+        case Fee: // core option - can be changed on-the-fly
+            // Todo: Add is valid check  and warn via message, if not
             nTransactionFee = value.toLongLong();
-            settings.setValue("nTransactionFee", (qint64) nTransactionFee);
+            settings.setValue("nTransactionFee", (qint64)nTransactionFee);
             emit transactionFeeChanged(nTransactionFee);
             break;
         case DisplayUnit:
@@ -291,12 +335,27 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
             settings.setValue("bDisplayAddresses", bDisplayAddresses);
             break;
         case Language:
-            settings.setValue("language", value);
+            if (settings.value("language") != value) {
+                settings.setValue("language", value);
+                setRestartRequired(true);
+            }
             break;
         case CoinControlFeatures:
             fCoinControlFeatures = value.toBool();
             settings.setValue("fCoinControlFeatures", fCoinControlFeatures);
             emit coinControlFeaturesChanged(fCoinControlFeatures);
+            break;
+        case DatabaseCache:
+            if (settings.value("nDatabaseCache") != value) {
+                settings.setValue("nDatabaseCache", value);
+                setRestartRequired(true);
+            }
+            break;
+        case ThreadsScriptVerif:
+            if (settings.value("nThreadsScriptVerif") != value) {
+                settings.setValue("nThreadsScriptVerif", value);
+                setRestartRequired(true);
+            }
             break;
         default:
             break;
@@ -316,4 +375,16 @@ bool OptionsModel::getProxySettings(QString& proxyIP, quint16 &proxyPort) const
     proxyIP = QString(addrProxy.ToStringIP().c_str());
     proxyPort = addrProxy.GetPort();
     return true;
+}
+
+void OptionsModel::setRestartRequired(bool fRequired)
+{
+    QSettings settings;
+    return settings.setValue("fRestartRequired", fRequired);
+}
+
+bool OptionsModel::isRestartRequired()
+{
+    QSettings settings;
+    return settings.value("fRestartRequired", false).toBool();
 }

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -34,6 +34,8 @@ public:
         DisplayAddresses,       // bool
         Language,               // QString
         CoinControlFeatures,    // bool
+        ThreadsScriptVerif,     // int
+        DatabaseCache,          // int
         OptionIDRowCount,
     };
 
@@ -41,7 +43,7 @@ public:
     void Reset();
 
     /* Migrate settings from wallet.dat after app initialization */
-    bool Upgrade(); /* returns true if settings upgraded */
+    void Upgrade();
 
     int rowCount(const QModelIndex & parent = QModelIndex()) const;
     QVariant data(const QModelIndex & index, int role = Qt::DisplayRole) const;
@@ -52,17 +54,24 @@ public:
     bool getMinimizeOnClose() { return fMinimizeOnClose; }
     int getDisplayUnit() { return nDisplayUnit; }
     bool getDisplayAddresses() { return bDisplayAddresses; }
-    QString getLanguage() { return language; }
     bool getProxySettings(QString& proxyIP, quint16 &proxyPort) const;
     bool getCoinControlFeatures() { return fCoinControlFeatures; }
+    const QString& getOverriddenByCommandLine() { return strOverriddenByCommandLine; }
+
+    /* Restart flag helper */
+    void setRestartRequired(bool fRequired);
+    bool isRestartRequired();
 
 private:
-    int nDisplayUnit;
-    bool bDisplayAddresses;
+    /* Qt-only settings */
     bool fMinimizeToTray;
     bool fMinimizeOnClose;
     QString language;
+    int nDisplayUnit;
+    bool bDisplayAddresses;
     bool fCoinControlFeatures;
+    /* settings that were overriden by command-line */
+    QString strOverriddenByCommandLine;
 
 signals:
     void displayUnitChanged(int unit);


### PR DESCRIPTION
- add new options for database cache and script verification threads
- add label which displays options that are overridden by command-line
  parameters
- proxy settings are not applied on-the-fly anymore and require a client
  restart (ApplyProxySettings() was removed and was not working very well
  anyway)
- re-work options reset and require a client shutdown (as it is much
  easier to do it this way without having to mess with what can be changed
  on-the-fly and what needs a restart anyway)
- options reset now writes default values for every single option
- when changing an option which requires a client restart display a 10
  second warning message in statusLabel (via a QTimer)
- when applying the changes via ok change that to a persistent message,
  which is displayed even after closing optionsdialog and re-open it, when
  no client restart was made
- remove dialog boxes used when changing language or proxy settings
- add setRestartRequired() and isRestartRequired() to OptionsModel and
  use the set function when updating options to signal OptionsDialog
  when a restart is needed
- resize optionsdialog a little and add some min sizes for certain GUI
  elements
- remove apply button from optionsdialog
- save and restore optionsdialog window position
- update nTransactionFee in QSettings with a set -paytxfee value when
  opening optionsdialog (I'm not sure about this yet, perhaps revert to
  not updating QSettings and just display current -paytxfee value in
  optionsdialog.)

See #2612 for a version, which included several proxy related additions and core changes. This version is Qt-only and should be much easier to test and merge.
