### PR TITLE
Payment request URI syntax changed, from request=... to r=...

### DIFF
--- a/src/qt/openuridialog.cpp
+++ b/src/qt/openuridialog.cpp
@@ -48,5 +48,5 @@ void OpenURIDialog::on_selectFileButton_clicked()
     if(filename.isEmpty())
         return;
     QUrl fileUri = QUrl::fromLocalFile(filename);
-    ui->uriEdit->setText("bitcoin:?request=" + QUrl::toPercentEncoding(fileUri.toString()));
+    ui->uriEdit->setText("bitcoin:?r=" + QUrl::toPercentEncoding(fileUri.toString()));
 }

--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -366,10 +366,10 @@ void PaymentServer::handleURIOrFile(const QString& s)
 #else
         QUrlQuery uri((QUrl(s)));
 #endif
-        if (uri.hasQueryItem("request"))
+        if (uri.hasQueryItem("r"))
         {
             QByteArray temp;
-            temp.append(uri.queryItemValue("request"));
+            temp.append(uri.queryItemValue("r"));
             QString decoded = QUrl::fromPercentEncoding(temp);
             QUrl fetchUrl(decoded, QUrl::StrictMode);
 


### PR DESCRIPTION
BIP 72 was changed to save six bytes in bitcoin: URIs.

I updated the Handy Dandy Payment Request Generator page at https://bitcoincore.org/~gavin/createpaymentrequest.php and run a couple of -testnet tests.
