### PR TITLE
Relay first-double-spend transactions

### DIFF
--- a/src/bloom.cpp
+++ b/src/bloom.cpp
@@ -96,6 +96,13 @@ bool CBloomFilter::contains(const uint256& hash) const
     return contains(data);
 }
 
+void CBloomFilter::clear()
+{
+    vData.clear();
+    isFull = false;
+    isEmpty = true;
+}
+
 bool CBloomFilter::IsWithinSizeConstraints() const
 {
     return vData.size() <= MAX_BLOOM_FILTER_SIZE && nHashFuncs <= MAX_HASH_FUNCS;

--- a/src/bloom.h
+++ b/src/bloom.h
@@ -78,6 +78,8 @@ public:
     bool contains(const COutPoint& outpoint) const;
     bool contains(const uint256& hash) const;
 
+    void clear();
+
     // True if the size is <= MAX_BLOOM_FILTER_SIZE and the number of hash functions is <= MAX_HASH_FUNCS
     // (catch a filter which was just deserialized which was too big)
     bool IsWithinSizeConstraints() const;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1041,6 +1041,7 @@ bool AppInit2(boost::thread_group& threadGroup, bool fForceServer)
     LogPrintf("mapWallet.size() = %"PRIszu"\n",       pwalletMain ? pwalletMain->mapWallet.size() : 0);
     LogPrintf("mapAddressBook.size() = %"PRIszu"\n",  pwalletMain ? pwalletMain->mapAddressBook.size() : 0);
 
+    RegisterInternalSignals();
     StartNode(threadGroup);
 
     // InitRPCMining is needed here so getwork/getblocktemplate in the GUI debug console works properly.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,6 +7,7 @@
 
 #include "addrman.h"
 #include "alert.h"
+#include "bloom.h"
 #include "chainparams.h"
 #include "checkpoints.h"
 #include "checkqueue.h"
@@ -89,6 +90,10 @@ CBlockFileInfo infoLastBlockFile;
 int nLastBlockFile = 0;
 }
 
+// Forward reference functions defined here:
+static const unsigned int MAX_DOUBLESPEND_BLOOM = 1000;
+static void RelayDoubleSpend(const COutPoint& outPoint, const CTransaction& doubleSpend, bool fInBlock, CBloomFilter& filter);
+
 //////////////////////////////////////////////////////////////////////////////
 //
 // dispatching functions
@@ -118,6 +123,15 @@ struct CMainSignals {
     boost::signals2::signal<void (const COutPoint&, const CTransaction&, const CTransaction&, bool)> DetectedDoubleSpend;
 } g_signals;
 }
+
+void RegisterInternalSignals() {
+    static CBloomFilter doubleSpendFilter;
+    seed_insecure_rand();
+    doubleSpendFilter = CBloomFilter(MAX_DOUBLESPEND_BLOOM, 0.01, insecure_rand(), BLOOM_UPDATE_NONE);
+
+    g_signals.DetectedDoubleSpend.connect(boost::bind(RelayDoubleSpend, _1, _3, _4, doubleSpendFilter));
+}
+
 
 void RegisterWallet(CWalletInterface* pwalletIn) {
     g_signals.SyncTransaction.connect(boost::bind(&CWalletInterface::SyncTransaction, pwalletIn, _1, _2, _3));
@@ -767,6 +781,32 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
     g_signals.SyncTransaction(hash, tx, NULL);
 
     return true;
+}
+
+static void
+RelayDoubleSpend(const COutPoint& outPoint, const CTransaction& doubleSpend, bool fInBlock, CBloomFilter& filter)
+{
+    // Relaying double-spend attempts to our peers lets them detect when
+    // somebody might be trying to cheat them. However, blindly relaying
+    // every double-spend across the entire network gives attackers
+    // a denial-of-service attack: just generate a stream of double-spends
+    // re-spending the same (limited) set of outpoints owned by the attacker.
+    // So, we use a bloom filter and only relay (at most) the first double
+    // spend for each outpoint. False-positives ("we have already relayed")
+    // are OK, because if the peer doesn't hear about the double-spend
+    // from us they are very likely to hear about it from another peer, since
+    // each peer uses a different, randomized bloom filter.
+
+    if (fInBlock || filter.contains(outPoint)) return;
+
+    // Clear the filter on average every MAX_DOUBLE_SPEND_BLOOM
+    // insertions
+    if (insecure_rand()%MAX_DOUBLESPEND_BLOOM == 0)
+        filter.clear();
+
+    filter.insert(outPoint);
+
+    RelayTransaction(doubleSpend, doubleSpend.GetHash());
 }
 
 

--- a/src/main.h
+++ b/src/main.h
@@ -113,6 +113,9 @@ class CWalletInterface;
 
 struct CBlockTemplate;
 
+/** Set up internal signal handlers **/
+void RegisterInternalSignals();
+
 /** Register a wallet to receive updates from core */
 void RegisterWallet(CWalletInterface* pwalletIn);
 /** Unregister a wallet from core */

--- a/src/test/bloom_tests.cpp
+++ b/src/test/bloom_tests.cpp
@@ -41,6 +41,10 @@ BOOST_AUTO_TEST_CASE(bloom_create_insert_serialize)
         expected[i] = (char)vch[i];
 
     BOOST_CHECK_EQUAL_COLLECTIONS(stream.begin(), stream.end(), expected.begin(), expected.end());
+
+    BOOST_CHECK_MESSAGE( filter.contains(ParseHex("99108ad8ed9bb6274d3980bab5a85c048f0950c8")), "BloomFilter doesn't contain just-inserted object!");
+    filter.clear();
+    BOOST_CHECK_MESSAGE( !filter.contains(ParseHex("99108ad8ed9bb6274d3980bab5a85c048f0950c8")), "BloomFilter should be empty!");
 }
 
 BOOST_AUTO_TEST_CASE(bloom_create_insert_serialize_with_tweak)

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -73,7 +73,7 @@ public:
 
     bool addUnchecked(const uint256& hash, const CTxMemPoolEntry &entry);
     bool remove(const CTransaction &tx, bool fRecursive = false);
-    bool removeConflicts(const CTransaction &tx);
+    std::map<COutPoint, CTransaction> removeConflicts(const CTransaction &tx);
     void clear();
     void queryHashes(std::vector<uint256>& vtxid);
     void pruneSpent(const uint256& hash, CCoins &coins);


### PR DESCRIPTION
Submitting this in the hopes somebody might pick it up and run with it (see the TODO list at end):

Instead of dropping double-spent transactions, relay them to peers. Why? To make it easier for merchants to quickly detect attempted fraud for low-value, in-person purchases.

A bloom filter is used so that only the first double-spend is relayed, to prevent an attacker from mounting a network denial-of-service attack by flooding it with double-spends of a transaction output they control.

Peter Todd pointed out a possible try-to-DoS-network-bandwidth attack that this enables that works like this:

1) Attacker starts with an unspent transaction input.
2) Attacker sends a small-in-size first spend with a small fee.
3) Attacker double-spends the transaction input with a very large (e.g. 100K) transaction with a large fee.

Since miners will mine the first, small transaction (it might even pay a higher fee-per-kilobyte, but pay lower overall fee), an attacker can waste network bandwidth for a low cost.  Whether or not attackers will actually do this isn't clear, they don't directly gain anything by wasting network bandwidth.

The right solution to that possible DoS attack is for nodes to have a bandwidth budget for 'tx' messages, and start dropping messages (perhaps starting with the largest double-spends) if that budget is exceeded.

Other things on the TODO:

1) Bitcoin-Qt should warn the user if a zero-confirmation transaction is double-spent, and should have a notion of "dead" transactions (another spend made it into a block). NOTE: I found it is easy to create double spends running three local nodes in -regtest mode, and the raw transactions API (create/sign a pair of double-spending transactions, then sendrawtransaction them from two nodes at the same time).

2) The RPC calls that give transaction information should report (somehow) double-spend attempts and "dead" transactions.

3) Write up a test plan for all of the above.
