### PR TITLE
qt: use deleteLater to remove send entries

### DIFF
--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -260,7 +260,7 @@ void SendCoinsDialog::clear()
     // Remove entries until only one left
     while(ui->entries->count())
     {
-        delete ui->entries->takeAt(0)->widget();
+        ui->entries->takeAt(0)->widget()->deleteLater();
     }
     addEntry();
 
@@ -306,7 +306,7 @@ void SendCoinsDialog::updateTabsAndLabels()
 
 void SendCoinsDialog::removeEntry(SendCoinsEntry* entry)
 {
-    delete entry;
+    entry->deleteLater();
 
     // If the last entry was removed add an empty one
     if (!ui->entries->count())


### PR DESCRIPTION
Use deleteLater() instead of delete, as it is not allowed to delete widgets directly in an event handler.
Should solve the MacOSX random crashes on send with coincontrol.
