### PR TITLE
Prevent empty transactions from being added to vtxPrev

### DIFF
--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -765,6 +765,10 @@ void CWalletTx::AddSupportingTransactions()
                 {
                     tx = *mapWalletPrev[hash];
                 }
+                else
+                {
+                    continue;
+                }
 
                 int nDepth = tx.SetMerkleBranch();
                 vtxPrev.push_back(tx);


### PR DESCRIPTION
CWalletTx::AddSupportingTransactions() was adding empty transaction to vtxPrev in some cases. Skip over these.

Part one of the solution to #3190. This prevents invalid vtxPrev from entering the wallet, but not current ones being transmitted.

This will need to go into 0.8.6 as well.
