### PR TITLE
Refuse to retransmit transactions without vins

### DIFF
--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -895,7 +895,10 @@ void CWalletTx::RelayWalletTransaction()
 {
     BOOST_FOREACH(const CMerkleTx& tx, vtxPrev)
     {
-        if (!tx.IsCoinBase())
+        // Important: versions of bitcoin before 0.8.6 had a bug that inserted
+        // empty transactions into the vtxPrev, which will cause the node to be
+        // banned when retransmitted, hence the check for !tx.vin.empty()
+        if (!tx.IsCoinBase() && !tx.vin.empty())
             if (tx.GetDepthInMainChain() == 0)
                 RelayTransaction((CTransaction)tx, tx.GetHash());
     }


### PR DESCRIPTION
There is a bug that inserted empty transactions into the vtxPrev in the wallet (see #3356 for the fix), which will cause the node to be banned when retransmitted.

As wallets with these invalid vtxprevs will be around for a while to come, add a check for !tx.vin.empty() before RelayTransaction.

Part two of the solution for #3190.
This will need to go into 0.8.6 as well.
