### PR TITLE
Restore hex to getrawtransaction vout scriptPubkey.

### DIFF
--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -78,7 +78,7 @@ void TxToJSON(const CTransaction& tx, const uint256 hashBlock, Object& entry)
         out.push_back(Pair("value", ValueFromAmount(txout.nValue)));
         out.push_back(Pair("n", (boost::int64_t)i));
         Object o;
-        ScriptPubKeyToJSON(txout.scriptPubKey, o, false);
+        ScriptPubKeyToJSON(txout.scriptPubKey, o, true);
         out.push_back(Pair("scriptPubKey", o));
         vout.push_back(out);
     }


### PR DESCRIPTION
Commit be066fad accidentally removed the hex field.
This gets in the way of doing offline signing.

(credit belongs to sipa for actually looking for the
 cause instead of being lazy like me and just shrugging
 and writing the scriptpubkey from the asm.)
