### PR TITLE
LogPrint(category...) fixes

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -299,27 +299,24 @@ int LogPrint(const char* category, const char* pszFormat, ...)
 #ifdef WIN32
     if (fPrintToDebugger)
     {
-        static CCriticalSection cs_OutputDebugStringF;
-
         // accumulate and output a line at a time
+        static std::string buffer;
+
+        boost::mutex::scoped_lock scoped_lock(*mutexDebugLog);
+
+        va_list arg_ptr;
+        va_start(arg_ptr, pszFormat);
+        buffer += vstrprintf(pszFormat, arg_ptr);
+        va_end(arg_ptr);
+
+        int line_start = 0, line_end;
+        while((line_end = buffer.find('\n', line_start)) != -1)
         {
-            LOCK(cs_OutputDebugStringF);
-            static std::string buffer;
-
-            va_list arg_ptr;
-            va_start(arg_ptr, pszFormat);
-            buffer += vstrprintf(pszFormat, arg_ptr);
-            va_end(arg_ptr);
-
-            int line_start = 0, line_end;
-            while((line_end = buffer.find('\n', line_start)) != -1)
-            {
-                OutputDebugStringA(buffer.substr(line_start, line_end - line_start).c_str());
-                line_start = line_end + 1;
-                ret += line_end-line_start;
-            }
-            buffer.erase(0, line_start);
+            OutputDebugStringA(buffer.substr(line_start, line_end - line_start).c_str());
+            line_start = line_end + 1;
+            ret += line_end-line_start;
         }
+        buffer.erase(0, line_start);
     }
 #endif
     return ret;


### PR DESCRIPTION
Two commits, two fixes.

First is an obscure infinite loop on Windows (and possible crash-at-shutdown). Most of the difference in that commit are just an indentation change from switching from LOCK(cs_...) to using mutexDebugLock.

Second is a fix for an obscure crash-at-shutdown on all platforms.

Tested by running without -debug, with -debug and with    -debug=net -debug=mempool.
