### PR TITLE
[Qt] fix RecentRequestsTableModel function ambuguity

### DIFF
--- a/src/qt/recentrequeststablemodel.cpp
+++ b/src/qt/recentrequeststablemodel.cpp
@@ -3,13 +3,16 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "recentrequeststablemodel.h"
-#include "guiutil.h"
+
 #include "bitcoinunits.h"
+#include "guiutil.h"
 #include "optionsmodel.h"
 
-RecentRequestsTableModel::RecentRequestsTableModel(CWallet *wallet, WalletModel *parent):
+RecentRequestsTableModel::RecentRequestsTableModel(CWallet *wallet, WalletModel *parent) :
     walletModel(parent)
 {
+    Q_UNUSED(wallet);
+
     /* These columns must match the indices in the ColumnIndex enumeration */
     columns << tr("Date") << tr("Label") << tr("Message") << tr("Amount");
 }
@@ -22,12 +25,14 @@ RecentRequestsTableModel::~RecentRequestsTableModel()
 int RecentRequestsTableModel::rowCount(const QModelIndex &parent) const
 {
     Q_UNUSED(parent);
+
     return list.length();
 }
 
 int RecentRequestsTableModel::columnCount(const QModelIndex &parent) const
 {
     Q_UNUSED(parent);
+
     return columns.length();
 }
 
@@ -88,12 +93,15 @@ QVariant RecentRequestsTableModel::headerData(int section, Qt::Orientation orien
 
 QModelIndex RecentRequestsTableModel::index(int row, int column, const QModelIndex &parent) const
 {
-    return createIndex(row, column, 0);
+    Q_UNUSED(parent);
+
+    return createIndex(row, column);
 }
 
 bool RecentRequestsTableModel::removeRows(int row, int count, const QModelIndex &parent)
 {
     Q_UNUSED(parent);
+
     if(count > 0 && row >= 0 && (row+count) <= list.size())
     {
         beginRemoveRows(parent, row, row + count - 1);

--- a/src/qt/recentrequeststablemodel.h
+++ b/src/qt/recentrequeststablemodel.h
@@ -5,11 +5,11 @@
 #ifndef RECENTREQUESTSTABLEMODEL_H
 #define RECENTREQUESTSTABLEMODEL_H
 
+#include "walletmodel.h"
+
 #include <QAbstractTableModel>
 #include <QStringList>
 #include <QDateTime>
-
-#include "walletmodel.h"
 
 class CWallet;
 
@@ -27,7 +27,7 @@ class RecentRequestsTableModel: public QAbstractTableModel
     Q_OBJECT
 
 public:
-    explicit RecentRequestsTableModel(CWallet *wallet, WalletModel *parent = 0);
+    explicit RecentRequestsTableModel(CWallet *wallet, WalletModel *parent);
     ~RecentRequestsTableModel();
 
     enum ColumnIndex {


### PR DESCRIPTION
- fixes a compiler error with ::createIndex() called in
  RecentRequestsTableModel::index()
- also add some Q_UNUSED() macros
