### PR TITLE
[Qt] fix possibilty to delete even last sendcoins entry

### DIFF
--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -306,11 +306,13 @@ void SendCoinsDialog::updateTabsAndLabels()
 
 void SendCoinsDialog::removeEntry(SendCoinsEntry* entry)
 {
-    entry->deleteLater();
+    entry->hide();
 
-    // If the last entry was removed add an empty one
-    if (!ui->entries->count())
+    // If the last entry is about to be removed add an empty one
+    if (ui->entries->count() == 1)
         addEntry();
+
+    entry->deleteLater();
 
     updateTabsAndLabels();
 }
@@ -543,7 +545,7 @@ void SendCoinsDialog::coinControlChangeChecked(int state)
 }
 
 // Coin Control: custom change address changed
-void SendCoinsDialog::coinControlChangeEdited(const QString & text)
+void SendCoinsDialog::coinControlChangeEdited(const QString& text)
 {
     if (model)
     {


### PR DESCRIPTION
- this bug was introduced when switching to deleteLater() call when
  deleting entries
