### PR TITLE
qt: add "Show all" option in "receiving addresses"

### DIFF
--- a/src/qt/Makefile.am
+++ b/src/qt/Makefile.am
@@ -105,7 +105,7 @@ QT_MOC_CPP = moc_aboutdialog.cpp moc_addressbookpage.cpp \
 
 BITCOIN_MM = macdockiconhandler.mm macnotificationhandler.mm
 
-QT_MOC = intro.moc overviewpage.moc rpcconsole.moc
+QT_MOC = intro.moc overviewpage.moc rpcconsole.moc addressbookpage.moc
 
 QT_QRC_CPP = qrc_bitcoin.cpp
 QT_QRC = bitcoin.qrc

--- a/src/qt/addressbookpage.h
+++ b/src/qt/addressbookpage.h
@@ -9,6 +9,7 @@
 
 class AddressTableModel;
 class OptionsModel;
+class AddressFilterProxyModel;
 
 namespace Ui {
     class AddressBookPage;
@@ -18,7 +19,6 @@ QT_BEGIN_NAMESPACE
 class QItemSelection;
 class QMenu;
 class QModelIndex;
-class QSortFilterProxyModel;
 class QTableView;
 QT_END_NAMESPACE
 
@@ -54,10 +54,11 @@ private:
     Mode mode;
     Tabs tab;
     QString returnValue;
-    QSortFilterProxyModel *proxyModel;
+    AddressFilterProxyModel *proxyModel;
     QMenu *contextMenu;
     QAction *deleteAction; // to be able to explicitly disable it
     QString newAddressToSelect;
+    QAction *editAction;
 
 private slots:
     /** Delete currently selected address entry */
@@ -79,6 +80,8 @@ private slots:
     void contextualMenu(const QPoint &point);
     /** New entry/entries were added to address table */
     void selectNewAddress(const QModelIndex &parent, int begin, int /*end*/);
+    /** Set whether to show all addresses */
+    void setShowAll(bool enabled);
 
 signals:
     void sendCoins(QString addr);

--- a/src/qt/addresstablemodel.h
+++ b/src/qt/addresstablemodel.h
@@ -30,7 +30,8 @@ public:
     };
 
     enum RoleIndex {
-        TypeRole = Qt::UserRole /**< Type of address (#Send or #Receive) */
+        TypeRole = Qt::UserRole, /**< Type of address (#Send or #Receive) */
+        PurposeRole = Qt::UserRole+1 /**< Purpose of address ("change", "receive", "refund", ...) */
     };
 
     /** Return status of edit/insert operation */

--- a/src/qt/forms/addressbookpage.ui
+++ b/src/qt/forms/addressbookpage.ui
@@ -50,6 +50,13 @@
     </widget>
    </item>
    <item>
+    <widget class="QCheckBox" name="showAll">
+     <property name="text">
+      <string>Show all</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
       <widget class="QPushButton" name="newAddress">


### PR DESCRIPTION
Extra information for nosy people.
Add "Show all" option in "receiving addresses" to show change, keypool, refund etc addresses. These can only be viewed, not edited.

![showall_disabled](https://f.cloud.github.com/assets/126646/1723290/95f6fe5a-6255-11e3-9ed9-2365bc091f31.png)
![showall_enabled](https://f.cloud.github.com/assets/126646/1723291/960b9c2a-6255-11e3-8836-029b0a2a11ac.png)

If you think this should be in the client, please help testing.

Known issues, need to be solved before merging:
- New keypool addresses are not added to the dialog without a client restart
- Addresses don't change from (keypool) to (change) when sending a transaction without a client restart
