### PR TITLE
Document cs_wallet lock and add AssertLockHeld

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2238,7 +2238,7 @@ void PushGetBlocks(CNode* pnode, CBlockIndex* pindexBegin, uint256 hashEnd)
 
 bool ProcessBlock(CValidationState &state, CNode* pfrom, CBlock* pblock, CDiskBlockPos *dbp)
 {
-    AssertLockHeld("cs_main");
+    AssertLockHeld(cs_main);
 
     // Check for duplicate
     uint256 hash = pblock->GetHash();

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -136,11 +136,11 @@ std::string LocksHeld()
     return result;
 }
 
-void AssertLockHeld(std::string strName)
+void AssertLockHeldInternal(const char *pszName, const char* pszFile, int nLine, void *cs)
 {
     BOOST_FOREACH(const PAIRTYPE(void*, CLockLocation)&i, *lockstack)
-        if (i.second.MutexName() == strName) return;
-    LogPrintf("Lock %s not held; locks held:\n%s", strName.c_str(), LocksHeld().c_str());
+        if (i.first == cs) return;
+    LogPrintf("Lock %s not held in %s:%i; locks held:\n%s", pszName, pszFile, nLine, LocksHeld().c_str());
     assert(0);
 }
 

--- a/src/sync.h
+++ b/src/sync.h
@@ -88,12 +88,13 @@ typedef AnnotatedMixin<boost::mutex> CWaitableCriticalSection;
 void EnterCritical(const char* pszName, const char* pszFile, int nLine, void* cs, bool fTry = false);
 void LeaveCritical();
 std::string LocksHeld();
-void AssertLockHeld(std::string strName);
+void AssertLockHeldInternal(const char* pszName, const char* pszFile, int nLine, void *cs);
 #else
 void static inline EnterCritical(const char* pszName, const char* pszFile, int nLine, void* cs, bool fTry = false) {}
 void static inline LeaveCritical() {}
-void static inline AssertLockHeld(std::string) {}
+void static inline AssertLockHeldInternal(const char* pszName, const char* pszFile, int nLine, void *cs) {}
 #endif
+#define AssertLockHeld(cs) AssertLockHeldInternal(#cs, __FILE__, __LINE__, &cs)
 
 #ifdef DEBUG_LOCKCONTENTION
 void PrintLockContention(const char* pszName, const char* pszFile, int nLine);

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1489,7 +1489,6 @@ string CWallet::SendMoneyToDestination(const CTxDestination& address, int64_t nV
 
 DBErrors CWallet::LoadWallet(bool& fFirstRunRet)
 {
-    AssertLockHeld(cs_wallet); // setKeyPool
     if (!fFileBacked)
         return DB_LOAD_OK;
     fFirstRunRet = false;
@@ -1498,6 +1497,7 @@ DBErrors CWallet::LoadWallet(bool& fFirstRunRet)
     {
         if (CDB::Rewrite(strWalletFile, "\x04pool"))
         {
+            LOCK(cs_wallet);
             setKeyPool.clear();
             // Note: can't top-up keypool here, because wallet is locked.
             // User will be prompted to unlock wallet the next operation

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -102,6 +102,11 @@ private:
     int64_t nLastResend;
 
 public:
+    /// Main wallet lock.
+    /// This lock protects all the fields added by CWallet
+    ///   except for:
+    ///      fFileBacked (immutable after instantiation)
+    ///      strWalletFile (immutable after instantiation)
     mutable CCriticalSection cs_wallet;
 
     bool fFileBacked;
@@ -151,10 +156,11 @@ public:
     int64_t nTimeFirstKey;
 
     // check whether we are allowed to upgrade (or already support) to the named feature
-    bool CanSupportFeature(enum WalletFeature wf) { return nWalletMaxVersion >= wf; }
+    bool CanSupportFeature(enum WalletFeature wf) { AssertLockHeld(cs_wallet); return nWalletMaxVersion >= wf; }
 
     void AvailableCoins(std::vector<COutput>& vCoins, bool fOnlyConfirmed=true, const CCoinControl *coinControl = NULL) const;
     bool SelectCoinsMinConf(int64_t nTargetValue, int nConfMine, int nConfTheirs, std::vector<COutput> vCoins, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoinsRet, int64_t& nValueRet) const;
+
     bool IsLockedCoin(uint256 hash, unsigned int n) const;
     void LockCoin(COutPoint& output);
     void UnlockCoin(COutPoint& output);
@@ -171,7 +177,7 @@ public:
     // Load metadata (used by LoadWallet)
     bool LoadKeyMetadata(const CPubKey &pubkey, const CKeyMetadata &metadata);
 
-    bool LoadMinVersion(int nVersion) { nWalletVersion = nVersion; nWalletMaxVersion = std::max(nWalletMaxVersion, nVersion); return true; }
+    bool LoadMinVersion(int nVersion) { AssertLockHeld(cs_wallet); nWalletVersion = nVersion; nWalletMaxVersion = std::max(nWalletMaxVersion, nVersion); return true; }
 
     // Adds an encrypted key to the store, and saves it to disk.
     bool AddCryptedKey(const CPubKey &vchPubKey, const std::vector<unsigned char> &vchCryptedSecret);
@@ -320,6 +326,7 @@ public:
 
     unsigned int GetKeyPoolSize()
     {
+        AssertLockHeld(cs_wallet); // setKeyPool
         return setKeyPool.size();
     }
 
@@ -332,7 +339,7 @@ public:
     bool SetMaxVersion(int nVersion);
 
     // get the current wallet format (the oldest client version guaranteed to understand this wallet)
-    int GetVersion() { return nWalletVersion; }
+    int GetVersion() { AssertLockHeld(cs_wallet); return nWalletVersion; }
 
     /** Address book entry changed.
      * @note called with lock cs_wallet held.


### PR DESCRIPTION
- Document what the wallet lock is protecting (did I get this right?)
  
   /// Main wallet lock.
   /// This lock protects all the fields added by CWallet
   ///   except for:
   ///      fFileBacked (immutable after instantiation)
   ///      strWalletFile (immutable after instantiation)
- Add locking assertions to wallet to all methods that access internal fields and do not aquire the cs_wallet mutex (and add comment why the lock is needed)
