### PR TITLE
Removes a spurious file which is created by leveldb

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -100,6 +100,7 @@ baseline_filtered.info: baseline.info
 	$(LCOV) -r $< "/usr/include/*" -o $@
 
 leveldb_baseline.info: baseline_filtered.info
+	-rm -f $(abs_builddir)/src/leveldb/-.gcno	
 	$(LCOV) -c -i -d $(abs_builddir)/src/leveldb -b $(abs_builddir)/src/leveldb -o $@
 
 leveldb_baseline_filtered.info: leveldb_baseline.info


### PR DESCRIPTION
The file "-.gcno" is created by leveldb in case configure was ran with "--enable-lcov" as follows:
  (1) the leveldb Makefile calls build_detect_platform
  (2) build_detect_platform compiles an input from <stdin> to figure out if  <cstdatomic> is present
  (3) gcc --coverage is used, which in turn creates the file "-.gcno"
The file disrupts the creation of coverage info and should be removed.
