### PR TITLE
Fix boost lib detection in Ubuntu 13.10. Fixes #3219.

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -11,11 +11,6 @@ To Build
 
 This will build bitcoin-qt as well if the dependencies are met.
 
-**Note:** on Ubuntu 13.10 (Saucy Salamander) the boost configuration script doesn't look in the
-correct directory and an error about boost-system will appear. For now you need to do
-
-        ./configure --with-boost-libdir=/usr/lib/x86_64-linux-gnu
-
 Dependencies
 ---------------------
 

--- a/src/m4/ax_boost_base.m4
+++ b/src/m4/ax_boost_base.m4
@@ -33,7 +33,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 21
+#serial 22
 
 AC_DEFUN([AX_BOOST_BASE],
 [
@@ -96,6 +96,12 @@ if test "x$want_boost" = "xyes"; then
         libsubdirs="lib64 lib lib64"
         ;;
     esac
+
+    dnl allow for real multi-arch paths e.g. /usr/lib/x86_64-linux-gnu. Give
+    dnl them priority over the other paths since, if libs are found there, they
+    dnl are almost assuredly the ones desired.
+    AC_REQUIRE([AC_CANONICAL_HOST])
+    libsubdirs="lib/${host_cpu}-${host_os} $libsubdirs"
 
     dnl first we check the system location for boost libraries
     dnl this location ist chosen if boost libraries are installed with the --layout=system option


### PR DESCRIPTION
See title. fake-verified by moving my libs on 13.04 to /usr/lib/x86_64-linux-gnu.

Patch submitted upstream: https://savannah.gnu.org/patch/index.php?8254
