### PR TITLE
Remove -logtodebugger option

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -245,10 +245,6 @@ std::string HelpMessage(HelpMessageMode hmm)
     strUsage += "  -printtoconsole        " + _("Send trace/debug info to console instead of debug.log file") + "\n";
     strUsage += "  -regtest               " + _("Enter regression test mode, which uses a special chain in which blocks can be "
                                                 "solved instantly. This is intended for regression testing tools and app development.") + "\n";
-#ifdef WIN32
-    strUsage += "  -printtodebugger       " + _("Send trace/debug info to debugger") + "\n";
-#endif
-
     if (hmm == HMM_BITCOIN_QT)
     {
         strUsage += "  -server                " + _("Accept command line and JSON-RPC commands") + "\n";
@@ -492,7 +488,6 @@ bool AppInit2(boost::thread_group& threadGroup, bool fForceServer)
         fServer = GetBoolArg("-server", false);
 
     fPrintToConsole = GetBoolArg("-printtoconsole", false);
-    fPrintToDebugger = GetBoolArg("-printtodebugger", false);
     fLogTimestamps = GetBoolArg("-logtimestamps", true);
 #ifdef ENABLE_WALLET
     bool fDisableWallet = GetBoolArg("-disablewallet", false);

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -26,7 +26,7 @@ struct TestingSetup {
     boost::thread_group threadGroup;
 
     TestingSetup() {
-        fPrintToDebugger = true; // don't want to write to debug.log file
+        fPrintToDebugLog = false; // don't want to write to debug.log file
         noui_connect();
 #ifdef ENABLE_WALLET
         bitdb.MakeMock();

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -88,7 +88,7 @@ map<string, string> mapArgs;
 map<string, vector<string> > mapMultiArgs;
 bool fDebug = false;
 bool fPrintToConsole = false;
-bool fPrintToDebugger = false;
+bool fPrintToDebugLog = true;
 bool fDaemon = false;
 bool fServer = false;
 string strMiscWarning;
@@ -270,7 +270,7 @@ int LogPrint(const char* category, const char* pszFormat, ...)
         ret += vprintf(pszFormat, arg_ptr);
         va_end(arg_ptr);
     }
-    else if (!fPrintToDebugger)
+    else if (fPrintToDebugLog)
     {
         static bool fStartedNewLine = true;
         boost::call_once(&DebugPrintInit, debugPrintInitFlag);
@@ -302,29 +302,6 @@ int LogPrint(const char* category, const char* pszFormat, ...)
         va_end(arg_ptr);
     }
 
-#ifdef WIN32
-    if (fPrintToDebugger)
-    {
-        // accumulate and output a line at a time
-        static std::string buffer;
-
-        boost::mutex::scoped_lock scoped_lock(*mutexDebugLog);
-
-        va_list arg_ptr;
-        va_start(arg_ptr, pszFormat);
-        buffer += vstrprintf(pszFormat, arg_ptr);
-        va_end(arg_ptr);
-
-        int line_start = 0, line_end;
-        while((line_end = buffer.find('\n', line_start)) != -1)
-        {
-            OutputDebugStringA(buffer.substr(line_start, line_end - line_start).c_str());
-            line_start = line_end + 1;
-            ret += line_end-line_start;
-        }
-        buffer.erase(0, line_start);
-    }
-#endif
     return ret;
 }
 

--- a/src/util.h
+++ b/src/util.h
@@ -120,7 +120,7 @@ extern std::map<std::string, std::string> mapArgs;
 extern std::map<std::string, std::vector<std::string> > mapMultiArgs;
 extern bool fDebug;
 extern bool fPrintToConsole;
-extern bool fPrintToDebugger;
+extern bool fPrintToDebugLog;
 extern bool fDaemon;
 extern bool fServer;
 extern std::string strMiscWarning;


### PR DESCRIPTION
(as discussed in #3377)
`-logtodebugger` is a strange, obscure, WIN32-only (mostly MSVC) thing. It went untested for a long time, so I'm pretty sure that noone is using it. Let's clean up the options a bit get rid of it.

test_bitcoin was using fLogToDebugger as a way to prevent logging to debug.log. For this, add a boolean (not exposed as option) fLogToDebugLog that defaults to true and is disabled in the tests.
