### PR TITLE
Fix unit test error.

### DIFF
--- a/src/test/serialize_tests.cpp
+++ b/src/test/serialize_tests.cpp
@@ -61,7 +61,7 @@ BOOST_AUTO_TEST_CASE(compactsize)
 
 static bool isCanonicalException(const std::ios_base::failure& ex)
 {
-    return std::string("non-canonical ReadCompactSize()") == ex.what();
+    return std::string("non-canonical ReadCompactSize(): unspecified iostream_category error") == ex.what();
 }
 
 BOOST_AUTO_TEST_CASE(noncanonical)


### PR DESCRIPTION
Before the fix, there were 6 errors such as :
serialize_tests.cpp:77: error in "noncanonical": incorrect exception std::ios_base::failure is caught

It turns out that ex.what() returns following string instead of "non-canonical ReadCompactSize()"
"non-canonical ReadCompactSize(): unspecified iostream_category error"

After the fix, unit test passed.

The test ran using Apple LLVM v5.0 on OSX 10.9.

In case the unit test error happened because of different error messages by different compilers, you may want to merge the code as shown below.

```
static bool isCanonicalException(const std::ios_base::failure& ex)
{
    return std::string("non-canonical ReadCompactSize()") == ex.what() ||
             std::string("non-canonical ReadCompactSize(): unspecified iostream_category error") == ex.what();
}
```

g++ --version on my development environment.

```
Configured with: --prefix=/Applications/Xcode.app/Contents/Developer/usr --with-gxx-include-dir=/usr/include/c++/4.2.1
Apple LLVM version 5.0 (clang-500.2.79) (based on LLVM 3.3svn)
Target: x86_64-apple-darwin13.0.0
Thread model: posix
```
