### PR TITLE
Fix unit test error on OSX 10.9 using Apple LLVM v5.0.

### DIFF
--- a/src/test/serialize_tests.cpp
+++ b/src/test/serialize_tests.cpp
@@ -61,8 +61,13 @@ BOOST_AUTO_TEST_CASE(compactsize)
 
 static bool isCanonicalException(const std::ios_base::failure& ex)
 {
-    return std::string("non-canonical ReadCompactSize()") == ex.what();
+    std::string strExplanatoryString("non-canonical ReadCompactSize()");
+
+    return strExplanatoryString == ex.what() ||
+           // OSX Apple LLVM version 5.0 (OSX 10.9) 
+           strExplanatoryString + ": unspecified iostream_category error" == ex.what();
 }
+
 
 BOOST_AUTO_TEST_CASE(noncanonical)
 {


### PR DESCRIPTION
( Next time, I will re-push to the same branch instead of closing and opening pull requests. )

Before the fix, there were 6 errors such as :
serialize_tests.cpp:77: error in "noncanonical": incorrect exception std::ios_base::failure is caught

It turns out that ex.what() returns following string instead of "non-canonical ReadCompactSize()"
"non-canonical ReadCompactSize(): unspecified iostream_category error"

After the fix, unit test passed.

The test ran using Apple LLVM v5.0 on OSX 10.9 and the unit test error happened because of different error messages by different compilers.

g++ --version on my development environment.

```
Configured with: --prefix=/Applications/Xcode.app/Contents/Developer/usr --with-gxx-include-dir=/usr/include/c++/4.2.1
Apple LLVM version 5.0 (clang-500.2.79) (based on LLVM 3.3svn)
Target: x86_64-apple-darwin13.0.0
Thread model: posix
```
