### PR TITLE
Improve unit test code not to compare explanatory messages directly.

### DIFF
--- a/src/test/serialize_tests.cpp
+++ b/src/test/serialize_tests.cpp
@@ -61,11 +61,13 @@ BOOST_AUTO_TEST_CASE(compactsize)
 
 static bool isCanonicalException(const std::ios_base::failure& ex)
 {
-    std::string strExplanatoryString("non-canonical ReadCompactSize()");
+    std::ios_base::failure expectedException("non-canonical ReadCompactSize()");
 
-    return strExplanatoryString == ex.what() ||
-           // OSX Apple LLVM version 5.0 (OSX 10.9) 
-           strExplanatoryString + ": unspecified iostream_category error" == ex.what();
+    // The string returned by what() can be different for different platforms.
+    // Instead of directly comparing the ex.what() with an expected string,
+    // create an instance of exception to see if ex.what() matches 
+    // the expected explanatory string returned by the exception instance. 
+    return strcmp(expectedException.what(), ex.what()) == 0;
 }
 
 


### PR DESCRIPTION
Instead, use an exception object to check if the string returned by what() on the raised exception matches the string returned by what() on the expected exception instance.
This way, we do not need to list all different possible explanatory strings for different platforms in the test code, and make it simple. (The idea is from Cory Fields.)
