### PR TITLE
Don't create empty transactions when reading corrupted wallet

### DIFF
--- a/src/walletdb.cpp
+++ b/src/walletdb.cpp
@@ -357,16 +357,13 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
         {
             uint256 hash;
             ssKey >> hash;
-            CWalletTx& wtx = pwallet->mapWallet[hash];
+            CWalletTx wtx;
             ssValue >> wtx;
             CValidationState state;
             if (CheckTransaction(wtx, state) && (wtx.GetHash() == hash) && state.IsValid())
                 wtx.BindWallet(pwallet);
             else
-            {
-                pwallet->mapWallet.erase(hash);
                 return false;
-            }
 
             // Undo serialize changes in 31600
             if (31404 <= wtx.fTimeReceivedIsTxTime && wtx.fTimeReceivedIsTxTime <= 31703)
@@ -391,6 +388,7 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
             if (wtx.nOrderPos == -1)
                 wss.fAnyUnordered = true;
 
+            pwallet->mapWallet[hash] = wtx;
             //// debug print
             //LogPrintf("LoadWallet  %s\n", wtx.GetHash().ToString().c_str());
             //LogPrintf(" %12"PRId64"  %s  %s  %s\n",


### PR DESCRIPTION
The current transaction loading code is not exception safe. An exception during deserialization causes an empty transaction to be left behind in the wallet.

Fix this by building the transaction separately and adding it only to the wallet at the end.

Fixes #3333.
Should also be backported to 0.8.7 if we roll one.
