### PR TITLE
qt: Treat regtest as testnet

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -197,9 +197,10 @@ int main(int argc, char *argv[])
 
     // Application identification (must be set before OptionsModel is initialized,
     // as it is used to locate QSettings)
+    bool isaTestNet = TestNet() || RegTest();
     QApplication::setOrganizationName("Bitcoin");
     QApplication::setOrganizationDomain("bitcoin.org");
-    if (TestNet()) // Separate UI settings for testnet
+    if (isaTestNet) // Separate UI settings for testnets
         QApplication::setApplicationName("Bitcoin-Qt-testnet");
     else
         QApplication::setApplicationName("Bitcoin-Qt");
@@ -230,7 +231,7 @@ int main(int argc, char *argv[])
     PaymentServer* paymentServer = new PaymentServer(&app);
 
     // User language is set up: pick a data directory
-    Intro::pickDataDirectory(TestNet());
+    Intro::pickDataDirectory(isaTestNet);
 
     // Install global event filter that makes sure that long tooltips can be word-wrapped
     app.installEventFilter(new GUIUtil::ToolTipToRichTextFilter(TOOLTIP_WRAP_THRESHOLD, &app));
@@ -258,7 +259,7 @@ int main(int argc, char *argv[])
         return 1;
     }
 
-    SplashScreen splash(QPixmap(), 0);
+    SplashScreen splash(QPixmap(), 0, isaTestNet);
     if (GetBoolArg("-splash", true) && !GetBoolArg("-min", false))
     {
         splash.show();
@@ -280,7 +281,7 @@ int main(int argc, char *argv[])
 
         boost::thread_group threadGroup;
 
-        BitcoinGUI window(TestNet(), 0);
+        BitcoinGUI window(isaTestNet, 0);
         guiref = &window;
 
         QTimer* pollShutdownTimer = new QTimer(guiref);

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -123,9 +123,12 @@ void ClientModel::updateAlert(const QString &hash, int status)
     emit alertsChanged(getStatusBarWarnings());
 }
 
-bool ClientModel::isTestNet() const
+QString ClientModel::getNetworkName() const
 {
-    return TestNet();
+    QString netname(QString::fromStdString(Params().DataDir()));
+    if(netname.isEmpty())
+        netname = "main";
+    return netname;
 }
 
 bool ClientModel::inInitialBlockDownload() const

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -46,8 +46,8 @@ public:
     double getVerificationProgress() const;
     QDateTime getLastBlockDate() const;
 
-    //! Return true if client connected to testnet
-    bool isTestNet() const;
+    //! Return network (main, testnet3, regtest)
+    QString getNetworkName() const;
     //! Return true if core is doing initial block download
     bool inInitialBlockDownload() const;
     //! Return true if core is importing blocks

--- a/src/qt/forms/rpcconsole.ui
+++ b/src/qt/forms/rpcconsole.ui
@@ -172,14 +172,14 @@
         </widget>
        </item>
        <item row="7" column="0">
-        <widget class="QLabel" name="label_7">
+        <widget class="QLabel" name="label_8">
          <property name="text">
-          <string>Number of connections</string>
+          <string>Name</string>
          </property>
         </widget>
        </item>
        <item row="7" column="1">
-        <widget class="QLabel" name="numberOfConnections">
+        <widget class="QLabel" name="networkName">
          <property name="cursor">
           <cursorShape>IBeamCursor</cursorShape>
          </property>
@@ -195,19 +195,25 @@
         </widget>
        </item>
        <item row="8" column="0">
-        <widget class="QLabel" name="label_8">
+        <widget class="QLabel" name="label_7">
          <property name="text">
-          <string>On testnet</string>
+          <string>Number of connections</string>
          </property>
         </widget>
        </item>
        <item row="8" column="1">
-        <widget class="QCheckBox" name="isTestNet">
-         <property name="enabled">
-          <bool>false</bool>
+        <widget class="QLabel" name="numberOfConnections">
+         <property name="cursor">
+          <cursorShape>IBeamCursor</cursorShape>
          </property>
          <property name="text">
-          <string/>
+          <string>N/A</string>
+         </property>
+         <property name="textFormat">
+          <enum>Qt::PlainText</enum>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
          </property>
         </widget>
        </item>

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -284,7 +284,7 @@ void RPCConsole::setClientModel(ClientModel *model)
         ui->buildDate->setText(model->formatBuildDate());
         ui->startupTime->setText(model->formatClientStartupTime());
 
-        ui->isTestNet->setChecked(model->isTestNet());
+        ui->networkName->setText(model->getNetworkName());
     }
 }
 

--- a/src/qt/splashscreen.cpp
+++ b/src/qt/splashscreen.cpp
@@ -4,14 +4,13 @@
 
 #include "splashscreen.h"
 
-#include "chainparams.h"
 #include "clientversion.h"
 #include "util.h"
 
 #include <QApplication>
 #include <QPainter>
 
-SplashScreen::SplashScreen(const QPixmap &pixmap, Qt::WindowFlags f) :
+SplashScreen::SplashScreen(const QPixmap &pixmap, Qt::WindowFlags f, bool isTestNet) :
     QSplashScreen(pixmap, f)
 {
     // set reference point, paddings
@@ -32,7 +31,7 @@ SplashScreen::SplashScreen(const QPixmap &pixmap, Qt::WindowFlags f) :
 
     // load the bitmap for writing some text over it
     QPixmap newPixmap;
-    if(TestNet()) {
+    if(isTestNet) {
         newPixmap     = QPixmap(":/images/splash_testnet");
     }
     else {
@@ -72,7 +71,7 @@ SplashScreen::SplashScreen(const QPixmap &pixmap, Qt::WindowFlags f) :
     pixPaint.drawText(newPixmap.width()-titleTextWidth-paddingRight,paddingTop+titleCopyrightVSpace,copyrightText);
 
     // draw testnet string if testnet is on
-    if(TestNet()) {
+    if(isTestNet) {
         QFont boldFont = QFont(font, 10*fontFactor);
         boldFont.setWeight(QFont::Bold);
         pixPaint.setFont(boldFont);

--- a/src/qt/splashscreen.h
+++ b/src/qt/splashscreen.h
@@ -14,7 +14,7 @@ class SplashScreen : public QSplashScreen
     Q_OBJECT
 
 public:
-    explicit SplashScreen(const QPixmap &pixmap = QPixmap(), Qt::WindowFlags f = 0);
+    explicit SplashScreen(const QPixmap &pixmap, Qt::WindowFlags f, bool isTestNet);
 };
 
 #endif // SPLASHSCREEN_H


### PR DESCRIPTION
No need to do anything special in the GUI for regtest mode,
but do treat it as testnet not mainnet to prevent confusion.
