### PR TITLE
Add dumppubkey RPC command

### DIFF
--- a/src/rpcdump.cpp
+++ b/src/rpcdump.cpp
@@ -248,6 +248,34 @@ Value dumpprivkey(const Array& params, bool fHelp)
     return CBitcoinSecret(vchSecret).ToString();
 }
 
+Value dumppubkey(const Array& params, bool fHelp)
+{
+    if (fHelp || params.size() != 1)
+        throw runtime_error(
+            "dumppubkey \"bitcoinaddress\"\n"
+            "\nReveals the public key corresponding to 'bitcoinaddress'.\n"
+            "\nArguments:\n"
+            "1. \"bitcoinaddress\"   (string, required) The bitcoin address for the public key\n"
+            "\nResult:\n"
+            "\"key\"                (string) The public key\n"
+            "\nExamples:\n"
+            + HelpExampleCli("dumppubkey", "\"myaddress\"")
+            + HelpExampleRpc("dumppubkey", "\"myaddress\"")
+        );
+
+    string strAddress = params[0].get_str();
+    CBitcoinAddress address;
+    if (!address.SetString(strAddress))
+        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid Bitcoin address");
+    CKeyID keyID;
+    if (!address.GetKeyID(keyID))
+        throw JSONRPCError(RPC_TYPE_ERROR, "Address does not refer to a key");
+    CPubKey vchPubKey;
+    if (!pwalletMain->GetPubKey(keyID, vchPubKey))
+        throw JSONRPCError(RPC_WALLET_ERROR, "Public key for address " + strAddress + " is not known");
+    return HexStr(vchPubKey);
+}
+
 
 Value dumpwallet(const Array& params, bool fHelp)
 {

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -287,6 +287,7 @@ static const CRPCCommand vRPCCommands[] =
     { "verifymessage",          &verifymessage,          false,     false,      false },
     { "listaccounts",           &listaccounts,           false,     false,      true },
     { "listsinceblock",         &listsinceblock,         false,     false,      true },
+    { "dumppubkey",             &dumppubkey,             true,      false,      true },
     { "dumpprivkey",            &dumpprivkey,            true,      false,      true },
     { "dumpwallet",             &dumpwallet,             true,      false,      true },
     { "importprivkey",          &importprivkey,          false,     false,      true },

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -109,6 +109,7 @@ extern json_spirit::Value addnode(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value getaddednodeinfo(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value getnettotals(const json_spirit::Array& params, bool fHelp);
 
+extern json_spirit::Value dumppubkey(const json_spirit::Array& params, bool fHelp); // in rpcdump.cpp
 extern json_spirit::Value dumpprivkey(const json_spirit::Array& params, bool fHelp); // in rpcdump.cpp
 extern json_spirit::Value importprivkey(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value dumpwallet(const json_spirit::Array& params, bool fHelp);


### PR DESCRIPTION
This adds a dumppubkey RPC command. It closely resembles the dumpprivkey command, but it outputs the public key of an address encoded in hexadecimal rather than the private key in base58. (bitaddress.org, sx, and bitcoin's createmultisig and addmultisigaddress RPC commands are all compatible with this public key encoding.)

This is intended to help facilitate multisig transactions. Multisig addresses require a public key from each participant. There's no simple way using the existing Bitcoin client for participants to figure out the public keys of their addresses without this feature.
