### PR TITLE
Make bitcoin compile without wallet if "db_cxx.h" is not present

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -10,7 +10,6 @@
 #include "init.h"
 
 #include "addrman.h"
-#include "db.h"
 #include "checkpoints.h"
 #include "main.h"
 #include "miner.h"
@@ -20,6 +19,7 @@
 #include "ui_interface.h"
 #include "util.h"
 #ifdef ENABLE_WALLET
+#include "db.h"
 #include "wallet.h"
 #include "walletdb.h"
 #endif

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -8,8 +8,9 @@
 #include "core.h"
 #include "main.h"
 #include "net.h"
+#ifdef ENABLE_WALLET
 #include "wallet.h"
-
+#endif 
 //////////////////////////////////////////////////////////////////////////////
 //
 // BitcoinMiner

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -12,9 +12,6 @@
 #include "addrman.h"
 #include "chainparams.h"
 #include "core.h"
-#ifdef ENABLE_WALLET
-#include "db.h"
-#endif
 #include "ui_interface.h"
 
 #ifdef WIN32

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -12,7 +12,9 @@
 #include "addrman.h"
 #include "chainparams.h"
 #include "core.h"
+#ifdef ENABLE_WALLET
 #include "db.h"
+#endif
 #include "ui_interface.h"
 
 #ifdef WIN32

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -5,13 +5,14 @@
 
 #include "rpcserver.h"
 #include "chainparams.h"
-#include "db.h"
 #include "init.h"
 #include "net.h"
 #include "main.h"
 #include "miner.h"
+#ifdef ENABLE_WALLET
+#include "db.h"
 #include "wallet.h"
-
+#endif
 #include <stdint.h>
 
 #include "json/json_spirit_utils.h"

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -4,9 +4,6 @@
 #include "miner.h"
 #include "uint256.h"
 #include "util.h"
-#ifdef ENABLE_WALLET
-#include "wallet.h"
-#endif
 
 #include <boost/test/unit_test.hpp>
 

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -4,7 +4,9 @@
 #include "miner.h"
 #include "uint256.h"
 #include "util.h"
+#ifdef ENABLE_WALLET
 #include "wallet.h"
+#endif
 
 #include <boost/test/unit_test.hpp>
 

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -2,12 +2,12 @@
 
 
 
-#include "db.h"
 #include "main.h"
 #include "txdb.h"
 #include "ui_interface.h"
 #include "util.h"
 #ifdef ENABLE_WALLET
+#include "db.h"
 #include "wallet.h"
 #endif
 


### PR DESCRIPTION
The compile didn't work with --disable-wallet before when berkeleydb (in particular, "db_cxx.h") wasn't present. I brainlessly moved all the
  #include "db.h"
into 
  #ifdef ENABLE_WALLET
blocks. Now it works.
