### PR TITLE
Allow `-noserver` with bitcoind

### DIFF
--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -30,6 +30,8 @@
  * Use the buttons <code>Namespaces</code>, <code>Classes</code> or <code>Files</code> at the top of the page to start navigating the code.
  */
 
+static bool fDaemon;
+
 void DetectShutdownThread(boost::thread_group* threadGroup)
 {
     bool fShutdown = ShutdownRequested();
@@ -108,6 +110,8 @@ bool AppInit(int argc, char* argv[])
         fDaemon = GetBoolArg("-daemon", false);
         if (fDaemon)
         {
+            fprintf(stdout, "Bitcoin server starting\n");
+
             // Daemonize
             pid_t pid = fork();
             if (pid < 0)
@@ -127,9 +131,10 @@ bool AppInit(int argc, char* argv[])
                 fprintf(stderr, "Error: setsid() returned %d errno %d\n", sid, errno);
         }
 #endif
+        SoftSetBoolArg("-server", true);
 
         detectShutdownThread = new boost::thread(boost::bind(&DetectShutdownThread, &threadGroup));
-        fRet = AppInit2(threadGroup, true);
+        fRet = AppInit2(threadGroup);
     }
     catch (std::exception& e) {
         PrintExceptionContinue(&e, "AppInit()");

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -242,10 +242,7 @@ std::string HelpMessage(HelpMessageMode hmm)
     strUsage += "  -printtoconsole        " + _("Send trace/debug info to console instead of debug.log file") + "\n";
     strUsage += "  -regtest               " + _("Enter regression test mode, which uses a special chain in which blocks can be solved instantly.") + "\n";
     strUsage += "                         " + _("This is intended for regression testing tools and app development.") + "\n";
-    if (hmm == HMM_BITCOIN_QT)
-    {
-        strUsage += "  -server                " + _("Accept command line and JSON-RPC commands") + "\n";
-    }
+    strUsage += "  -server                " + _("Accept command line and JSON-RPC commands") + "\n";
 
     if (hmm == HMM_BITCOIND)
     {
@@ -356,7 +353,7 @@ void ThreadImport(std::vector<boost::filesystem::path> vImportFiles)
 /** Initialize bitcoin.
  *  @pre Parameters should be parsed and config file should be read.
  */
-bool AppInit2(boost::thread_group& threadGroup, bool fForceServer)
+bool AppInit2(boost::thread_group& threadGroup)
 {
     // ********************************************************* Step 1: setup
 #ifdef _MSC_VER
@@ -483,11 +480,7 @@ bool AppInit2(boost::thread_group& threadGroup, bool fForceServer)
     else if (nScriptCheckThreads > MAX_SCRIPTCHECK_THREADS)
         nScriptCheckThreads = MAX_SCRIPTCHECK_THREADS;
 
-    if (fDaemon || fForceServer)
-        fServer = true;
-    else
-        fServer = GetBoolArg("-server", false);
-
+    fServer = GetBoolArg("-server", false);
     fPrintToConsole = GetBoolArg("-printtoconsole", false);
     fLogTimestamps = GetBoolArg("-logtimestamps", true);
 #ifdef ENABLE_WALLET
@@ -568,9 +561,6 @@ bool AppInit2(boost::thread_group& threadGroup, bool fForceServer)
     LogPrintf("Using data directory %s\n", strDataDir.c_str());
     LogPrintf("Using at most %i connections (%i file descriptors available)\n", nMaxConnections, nFD);
     std::ostringstream strErrors;
-
-    if (fDaemon)
-        fprintf(stdout, "Bitcoin server starting\n");
 
     if (nScriptCheckThreads) {
         LogPrintf("Using %u threads for script verification\n", nScriptCheckThreads);

--- a/src/init.h
+++ b/src/init.h
@@ -20,7 +20,7 @@ extern CWallet* pwalletMain;
 void StartShutdown();
 bool ShutdownRequested();
 void Shutdown();
-bool AppInit2(boost::thread_group& threadGroup, bool fForceServer);
+bool AppInit2(boost::thread_group& threadGroup);
 
 /* The help message mode determines what help message to show */
 enum HelpMessageMode

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -289,7 +289,7 @@ int main(int argc, char *argv[])
         QObject::connect(pollShutdownTimer, SIGNAL(timeout()), guiref, SLOT(detectShutdown()));
         pollShutdownTimer->start(200);
 
-        if(AppInit2(threadGroup, false))
+        if(AppInit2(threadGroup))
         {
             {
                 // Put this in a block, so that the Model objects are cleaned up before

--- a/src/util.h
+++ b/src/util.h
@@ -121,7 +121,6 @@ extern std::map<std::string, std::vector<std::string> > mapMultiArgs;
 extern bool fDebug;
 extern bool fPrintToConsole;
 extern bool fPrintToDebugLog;
-extern bool fDaemon;
 extern bool fServer;
 extern std::string strMiscWarning;
 extern bool fNoListen;


### PR DESCRIPTION
Allow running bitcoind without RPC server. Removes a pointless limitation as daemon can still be stopped cleanly by sending it SIGINT/SIGTERM.
- Default to -server mode (of course) for bitcoind with SoftSetBoolArg
- Remove fForceServer argument from AppInit2
- Move fDaemon to a static variable in bitcoind
