### PR TITLE
Win32: use a more modern API call in FileCommit()

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1159,9 +1159,10 @@ bool RenameOver(boost::filesystem::path src, boost::filesystem::path dest)
 
 void FileCommit(FILE *fileout)
 {
-    fflush(fileout);                // harmless if redundantly called
+    fflush(fileout); // harmless if redundantly called
 #ifdef WIN32
-    _commit(_fileno(fileout));
+    HANDLE hFile = (HANDLE)_get_osfhandle(_fileno(fileout));
+    FlushFileBuffers(hFile);
 #else
     #if defined(__linux__) || defined(__NetBSD__)
     fdatasync(fileno(fileout));


### PR DESCRIPTION
- this seems to be a more recent API call and also supports e.g. SMB3,
  ReFS, which is not guaranteed for commit_()
