### PR TITLE
qt: make wallet test consistent

### DIFF
--- a/qa/rpc-tests/util.sh
+++ b/qa/rpc-tests/util.sh
@@ -82,3 +82,9 @@ function CreateTxn1 {
 function SendRawTxn {
   $CLI $1 sendrawtransaction $2
 }
+
+# Use: GetBlocks <datadir>
+# returns number of blocks from getinfo
+function GetBlocks {
+    ExtractKey blocks "$( $CLI $1 getinfo )"
+}


### PR DESCRIPTION
Add a function `WaitBlocks` to wait for blocks to propagate to all three nodes, and use this instead of waiting a fixed time of one second.

Fixes #3445.

Let's see what the pulltester does.
