### PR TITLE
[Qt] let OptionsModel::getProxySettings() directly query proxy

### DIFF
--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -53,7 +53,6 @@ OptionsDialog::OptionsDialog(QWidget *parent) :
     connect(ui->connectSocks, SIGNAL(toggled(bool)), ui->proxyIp, SLOT(setEnabled(bool)));
     connect(ui->connectSocks, SIGNAL(toggled(bool)), ui->proxyPort, SLOT(setEnabled(bool)));
     connect(ui->connectSocks, SIGNAL(toggled(bool)), ui->socksVersion, SLOT(setEnabled(bool)));
-    connect(ui->connectSocks, SIGNAL(clicked(bool)), this, SLOT(showRestartWarning_Proxy()));
 
     ui->proxyIp->installEventFilter(this);
 
@@ -204,7 +203,7 @@ void OptionsDialog::on_resetButton_clicked()
         if(btnRetVal == QMessageBox::Cancel)
             return;
 
-        /* reset all options and close Bitcoin-Qt */
+        /* reset all options and close GUI */
         model->Reset();
         QApplication::quit();
     }

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -7,6 +7,10 @@
 
 #include <QAbstractListModel>
 
+QT_BEGIN_NAMESPACE
+class QNetworkProxy;
+QT_END_NAMESPACE
+
 /** Interface from Qt to configuration data structure for Bitcoin client.
    To Qt, the options are presented as a list with the different options
    laid out vertically.
@@ -54,7 +58,7 @@ public:
     bool getMinimizeOnClose() { return fMinimizeOnClose; }
     int getDisplayUnit() { return nDisplayUnit; }
     bool getDisplayAddresses() { return bDisplayAddresses; }
-    bool getProxySettings(QString& proxyIP, quint16 &proxyPort) const;
+    bool getProxySettings(QNetworkProxy& proxy) const;
     bool getCoinControlFeatures() { return fCoinControlFeatures; }
     const QString& getOverriddenByCommandLine() { return strOverriddenByCommandLine; }
 


### PR DESCRIPTION
- as a proxy set via GUI can be overridden via -proxy, directly query the
  core to get active proxy
- give a warning, if active proxy is not SOCKS5 (needs to be SOCKS5 for
  the Qt networking code to work)
- also remove an obsolete connect() call from optionsdialog.cpp and a
  reference to Bitcoin-Qt (now just GUI)
