### PR TITLE
Edit: configure.am and doc/build-unix.md for Ubuntu 13.10 with libboost1.54-all-dev incompatibility

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -420,6 +420,7 @@ AC_TRY_LINK([
   #if BOOST_VERSION >= 105000 && (!defined(BOOST_HAS_NANOSLEEP) || BOOST_VERSION >= 105200)
       boost::this_thread::sleep_for(boost::chrono::milliseconds(0));
   #else
+   AC_MSG_ERROR("Could not link against boost::chrono! Ubuntu 13.10 cannot use libboost1.54-all-dev! If libboost1.54-all-dev on Ubuntu 13.10, remove libboost1.54-all-dev and then: sudo apt-get install libboost1.53-all-dev")
    choke me
   #endif
   ],
@@ -440,6 +441,7 @@ AC_TRY_LINK([
   #if BOOST_VERSION <= 105600
       boost::this_thread::sleep(boost::posix_time::milliseconds(0));
   #else
+   AC_MSG_ERROR("Could not link against boost::chrono! Ubuntu 13.10 cannot use libboost1.54-all-dev! If libboost1.54-all-dev on Ubuntu 13.10, remove libboost1.54-all-dev and then: sudo apt-get install libboost1.53-all-dev")
    choke me
   #endif
   ],

--- a/configure.ac
+++ b/configure.ac
@@ -71,10 +71,10 @@ AC_ARG_WITH([qt],
   [use_qt=auto])
 AC_DEFUN([BITCOIN_QT_FAIL],[
   if test "x$use_qt" = "xauto"; then
-    AC_MSG_WARN([bitcoin-qt frontend will not be built])
+    AC_MSG_WARN([$1; bitcoin-qt frontend will not be built])
     use_qt=no
   else
-    AC_MSG_ERROR([bitcoin-qt frontend will not be built with no other target to build, [ exit-status = ‘ $?/1 ’])
+    AC_MSG_ERROR([$1])
   fi
 ])
 AC_DEFUN([BITCOIN_QT_CHECK],[
@@ -425,7 +425,7 @@ AC_TRY_LINK([
   ],
   [boost_sleep=yes; BOOST_LIBS="$BOOST_LIBS $BOOST_CHRONO_LIB";
      AC_DEFINE(HAVE_WORKING_BOOST_SLEEP_FOR, 1, [Define this symbol if boost sleep_for works])],
-  [boost_sleep=no; boost_chrono=no])
+  [boost_sleep=no])
 LIBS="$TEMP_LIBS"
 fi
 
@@ -449,12 +449,14 @@ LIBS="$TEMP_LIBS"
 fi
 
 if test x$boost_sleep != xyes; then
-<<<<<<< HEAD
-  AC_MSG_ERROR([No working boost sleep implementation found ("Ubuntu 13.10 cannot use libboost1.54-all-dev! If libboost1.54-all-dev is installed on Ubuntu 13.10 remove libboost1.54-all-dev and install libboost1.53-all-dev")])
-=======
-  AC_MSG_ERROR ( no working boost sleep implementation found Ubuntu 13.10 cannot use libboost1.54-all-dev If libboost1.54-all-dev is installed on Ubuntu 13.10 remove libboost1.54-all-dev and install libboost1.53-all-dev, [ exit-status = ‘ $?/1 ’])
-  AC_MSG_FAILURE ( no working boost sleep implementation found Ubuntu 13.10 cannot use libboost1.54-all-dev If libboost1.54-all-dev is installed on Ubuntu 13.10 remove libboost1.54-all-dev and install libboost1.53-all-dev , [ exit-status ])
->>>>>>> fc48f9857eee71bc07b765c0c7efe806aa3051b6
+  AC_MSG_ERROR(no working boost sleep implementation found, [exit-status = ‘$?/1’])
+AC_TRY_LINK([
+  #if BOOST_VERSION >= 105300 && BOOST_VERSION <= 105400
+  AC_MSG_FAILURE(incompatiblity issue with ubuntu 13.10 cannot use libboost1.54-all-dev if libboost1.54-all-dev is installed remove libboost1.54-all-dev and install libboost1.53-all-dev, [exit-status]);
+  #else
+   choke me
+  #endif
+  ]
 fi
 
 if test x$use_pkgconfig = xyes; then

--- a/configure.ac
+++ b/configure.ac
@@ -420,13 +420,12 @@ AC_TRY_LINK([
   #if BOOST_VERSION >= 105000 && (!defined(BOOST_HAS_NANOSLEEP) || BOOST_VERSION >= 105200)
       boost::this_thread::sleep_for(boost::chrono::milliseconds(0));
   #else
-   AC_MSG_ERROR(Could not link against boost chrono! Ubuntu 13.10 cannot use libboost1.54-all-dev! If libboost1.54-all-dev is installed on Ubuntu 13.10 remove libboost1.54-all-dev and install libboost1.53-all-dev);
    choke me
   #endif
   ],
   [boost_sleep=yes; BOOST_LIBS="$BOOST_LIBS $BOOST_CHRONO_LIB";
      AC_DEFINE(HAVE_WORKING_BOOST_SLEEP_FOR, 1, [Define this symbol if boost sleep_for works])],
-  [boost_sleep=no])
+  [boost_sleep=no; boost_chrono=no])
 LIBS="$TEMP_LIBS"
 fi
 
@@ -441,7 +440,6 @@ AC_TRY_LINK([
   #if BOOST_VERSION <= 105600
       boost::this_thread::sleep(boost::posix_time::milliseconds(0));
   #else
-   AC_MSG_ERROR(Could not link against boost chrono! Ubuntu 13.10 cannot use libboost1.54-all-dev! If libboost1.54-all-dev is installed on Ubuntu 13.10 remove libboost1.54-all-dev and install libboost1.53-all-dev);
    choke me
   #endif
   ],
@@ -451,7 +449,7 @@ LIBS="$TEMP_LIBS"
 fi
 
 if test x$boost_sleep != xyes; then
-  AC_MSG_ERROR(No working boost sleep implementation found)
+  AC_MSG_ERROR([No working boost sleep implementation found ("Ubuntu 13.10 cannot use libboost1.54-all-dev! If libboost1.54-all-dev is installed on Ubuntu 13.10 remove libboost1.54-all-dev and install libboost1.53-all-dev")])
 fi
 
 if test x$use_pkgconfig = xyes; then

--- a/configure.ac
+++ b/configure.ac
@@ -420,6 +420,7 @@ AC_TRY_LINK([
   #if BOOST_VERSION >= 105000 && (!defined(BOOST_HAS_NANOSLEEP) || BOOST_VERSION >= 105200)
       boost::this_thread::sleep_for(boost::chrono::milliseconds(0));
   #else
+   AC_MSG_ERROR(Could not link against boost chrono! Ubuntu 13.10 cannot use libboost1.54-all-dev! If libboost1.54-all-dev is installed on Ubuntu 13.10 remove libboost1.54-all-dev and install libboost1.53-all-dev);
    choke me
   #endif
   ],
@@ -440,6 +441,7 @@ AC_TRY_LINK([
   #if BOOST_VERSION <= 105600
       boost::this_thread::sleep(boost::posix_time::milliseconds(0));
   #else
+   AC_MSG_ERROR(Could not link against boost chrono! Ubuntu 13.10 cannot use libboost1.54-all-dev! If libboost1.54-all-dev is installed on Ubuntu 13.10 remove libboost1.54-all-dev and install libboost1.53-all-dev);
    choke me
   #endif
   ],

--- a/configure.ac
+++ b/configure.ac
@@ -420,7 +420,7 @@ AC_TRY_LINK([
   #if BOOST_VERSION >= 105000 && (!defined(BOOST_HAS_NANOSLEEP) || BOOST_VERSION >= 105200)
       boost::this_thread::sleep_for(boost::chrono::milliseconds(0));
   #else
-   AC_MSG_ERROR("Could not link against boost::chrono! Ubuntu 13.10 cannot use libboost1.54-all-dev! If libboost1.54-all-dev on Ubuntu 13.10, remove libboost1.54-all-dev and then: sudo apt-get install libboost1.53-all-dev")
+   AC_MSG_ERROR(Could not link against boost chrono! Ubuntu 13.10 cannot use libboost1.54-all-dev! If libboost1.54-all-dev is installed on Ubuntu 13.10 remove libboost1.54-all-dev and install libboost1.53-all-dev);
    choke me
   #endif
   ],
@@ -441,7 +441,7 @@ AC_TRY_LINK([
   #if BOOST_VERSION <= 105600
       boost::this_thread::sleep(boost::posix_time::milliseconds(0));
   #else
-   AC_MSG_ERROR("Could not link against boost::chrono! Ubuntu 13.10 cannot use libboost1.54-all-dev! If libboost1.54-all-dev on Ubuntu 13.10, remove libboost1.54-all-dev and then: sudo apt-get install libboost1.53-all-dev")
+   AC_MSG_ERROR(Could not link against boost chrono! Ubuntu 13.10 cannot use libboost1.54-all-dev! If libboost1.54-all-dev is installed on Ubuntu 13.10 remove libboost1.54-all-dev and install libboost1.53-all-dev);
    choke me
   #endif
   ],

--- a/configure.ac
+++ b/configure.ac
@@ -71,10 +71,10 @@ AC_ARG_WITH([qt],
   [use_qt=auto])
 AC_DEFUN([BITCOIN_QT_FAIL],[
   if test "x$use_qt" = "xauto"; then
-    AC_MSG_WARN([$1; bitcoin-qt frontend will not be built])
+    AC_MSG_WARN([bitcoin-qt frontend will not be built])
     use_qt=no
   else
-    AC_MSG_ERROR([$1])
+    AC_MSG_ERROR([bitcoin-qt frontend will not be built with no other target to build, [ exit-status = ‘ $?/1 ’])
   fi
 ])
 AC_DEFUN([BITCOIN_QT_CHECK],[
@@ -420,7 +420,6 @@ AC_TRY_LINK([
   #if BOOST_VERSION >= 105000 && (!defined(BOOST_HAS_NANOSLEEP) || BOOST_VERSION >= 105200)
       boost::this_thread::sleep_for(boost::chrono::milliseconds(0));
   #else
-   AC_MSG_ERROR(Could not link against boost chrono! Ubuntu 13.10 cannot use libboost1.54-all-dev! If libboost1.54-all-dev is installed on Ubuntu 13.10 remove libboost1.54-all-dev and install libboost1.53-all-dev);
    choke me
   #endif
   ],
@@ -441,7 +440,6 @@ AC_TRY_LINK([
   #if BOOST_VERSION <= 105600
       boost::this_thread::sleep(boost::posix_time::milliseconds(0));
   #else
-   AC_MSG_ERROR(Could not link against boost chrono! Ubuntu 13.10 cannot use libboost1.54-all-dev! If libboost1.54-all-dev is installed on Ubuntu 13.10 remove libboost1.54-all-dev and install libboost1.53-all-dev);
    choke me
   #endif
   ],
@@ -451,7 +449,8 @@ LIBS="$TEMP_LIBS"
 fi
 
 if test x$boost_sleep != xyes; then
-  AC_MSG_ERROR(No working boost sleep implementation found)
+  AC_MSG_ERROR ( no working boost sleep implementation found Ubuntu 13.10 cannot use libboost1.54-all-dev If libboost1.54-all-dev is installed on Ubuntu 13.10 remove libboost1.54-all-dev and install libboost1.53-all-dev, [ exit-status = ‘ $?/1 ’])
+  AC_MSG_FAILURE ( no working boost sleep implementation found Ubuntu 13.10 cannot use libboost1.54-all-dev If libboost1.54-all-dev is installed on Ubuntu 13.10 remove libboost1.54-all-dev and install libboost1.53-all-dev , [ exit-status ])
 fi
 
 if test x$use_pkgconfig = xyes; then

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -68,8 +68,18 @@ for Ubuntu 12.04 and later:
 
  Ubuntu 12.04 and later have packages for libdb5.1-dev and libdb5.1++-dev,
  but using these will break binary wallet compatibility, and is not recommended.
-
-for other Ubuntu & Debian:
+ 
+ Ubuntu 13.10 cannot use libboost1.54-all-dev! If you have libboost1.54-all-dev 
+ installed on Ubuntu 13.10: 
+ 	
+ 	sudo apt-get remove libboost1.54-all-dev 
+ 	sudo apt-get install libboost1.53-all-dev
+ 
+ With new Ubuntu 13.10 install only need to do:
+ 
+ 	sudo apt-get install libboost1.53-all-dev
+ 	
+ for other Ubuntu & Debian:
 
 	sudo apt-get install libdb4.8-dev
 	sudo apt-get install libdb4.8++-dev

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -68,6 +68,16 @@ for Ubuntu 12.04 and later:
 
  Ubuntu 12.04 and later have packages for libdb5.1-dev and libdb5.1++-dev,
  but using these will break binary wallet compatibility, and is not recommended.
+ 
+ Ubuntu 13.10 cannot use libboost1.54-all-dev! If you have libboost1.54-all-dev 
+ installed on Ubuntu 13.10: 
+ 	
+ 	sudo apt-get remove libboost1.54-all-dev 
+ 	sudo apt-get install libboost1.53-all-dev
+ 
+ With new Ubuntu 13.10 install only need to do:
+ 
+ 	sudo apt-get install libboost1.53-all-dev
 
 for other Ubuntu & Debian:
 

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -78,8 +78,8 @@ for Ubuntu 12.04 and later:
  With new Ubuntu 13.10 install only need to do:
  
  	sudo apt-get install libboost1.53-all-dev
-
-for other Ubuntu & Debian:
+ 	
+ for other Ubuntu & Debian:
 
 	sudo apt-get install libdb4.8-dev
 	sudo apt-get install libdb4.8++-dev

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -68,6 +68,9 @@ for Ubuntu 12.04 and later:
 
  Ubuntu 12.04 and later have packages for libdb5.1-dev and libdb5.1++-dev,
  but using these will break binary wallet compatibility, and is not recommended.
+ To continue build with libdb5.1-dev and libdb5.1++-dev or above use:
+ 
+	 --with-incompatible-dbd
  
  Ubuntu 13.10 cannot use libboost1.54-all-dev! If you have libboost1.54-all-dev 
  installed on Ubuntu 13.10: 

--- a/src/m4/ax_boost_chrono.m4
+++ b/src/m4/ax_boost_chrono.m4
@@ -108,7 +108,7 @@ AC_DEFUN([AX_BOOST_CHRONO],
                 AC_MSG_ERROR(Could not find a version of the library!)
             fi
 			if test "x$link_chrono" = "xno"; then
-				AC_MSG_ERROR(Could not link against $ax_lib !)
+				AC_MSG_ERROR(Could not link against $ax_lib ! Ubuntu 13.10 cannot use libboost1.54-all-dev! If libboost1.54-all-dev on Ubuntu 13.10 remove libboost1.54-all-dev then: sudo apt-get install libboost1.53-all-dev)
 			fi
 		fi
 

--- a/src/m4/ax_boost_chrono.m4
+++ b/src/m4/ax_boost_chrono.m4
@@ -108,7 +108,7 @@ AC_DEFUN([AX_BOOST_CHRONO],
                 AC_MSG_ERROR(Could not find a version of the library!)
             fi
 			if test "x$link_chrono" = "xno"; then
-				AC_MSG_ERROR(Could not link against $ax_lib ! Ubuntu 13.10 cannot use libboost1.54-all-dev! If libboost1.54-all-dev on Ubuntu 13.10 remove libboost1.54-all-dev then: sudo apt-get install libboost1.53-all-dev)
+				AC_MSG_ERROR(Could not link against $ax_lib !)
 			fi
 		fi
 


### PR DESCRIPTION
Edit: configure.am and doc/build-unix.md for Ubuntu 13.10 users to deal with very messy issue with Ubuntu Saucy 13.10 and libboost1.54-all-dev because Ubuntu is now using multi architecture libs for 64 bit systems but libboost1.54-all-dev was looked over this time, so libboost1.53-all-dev works on Saucy 13.10 and libboost1.54-all-dev will work in Trusty but libboost1.54-all-dev does not work to build Bitcoin with Ubuntu Saucy 13.10 and configure will return error: 'Could not link against libboost::chrono !' because the boost libs are placed in different locations for 1.53 and 1.54.
