### PR TITLE
Explicitly ensure that wallet is unlocked in `importprivkey`

### DIFF
--- a/src/rpcdump.cpp
+++ b/src/rpcdump.cpp
@@ -86,6 +86,8 @@ Value importprivkey(const Array& params, bool fHelp)
             + HelpExampleRpc("importprivkey", "\"mykey\", \"testing\", false")
         );
 
+    EnsureWalletIsUnlocked();
+
     string strSecret = params[0].get_str();
     string strLabel = "";
     if (params.size() > 1)


### PR DESCRIPTION
This makes for a more useful error reply (fixes #957).
