### PR TITLE
File "bitcoin_ru.ts" update in terms of applicable existing rules English-Russian practical transcription.

### DIFF
--- a/src/qt/locale/bitcoin_ru.ts
+++ b/src/qt/locale/bitcoin_ru.ts
@@ -248,7 +248,7 @@ This product includes software developed by the OpenSSL Project for use in the O
     <message>
         <location line="+1"/>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
-        <translation>Внимание: если вы зашифруете бумажник и потеряете пароль, вы &lt;b&gt;ПОТЕРЯЕТЕ ВСЕ ВАШИ БИТКОИНЫ&lt;/b&gt;!</translation>
+        <translation>Внимание: если вы зашифруете бумажник и потеряете пароль, вы &lt;b&gt;ПОТЕРЯЕТЕ ВСЕ ВАШИ БИТКОЙНЫ&lt;/b&gt;!</translation>
     </message>
     <message>
         <location line="+0"/>
@@ -275,7 +275,7 @@ This product includes software developed by the OpenSSL Project for use in the O
     <message>
         <location line="-56"/>
         <source>Bitcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
-        <translation>Сейчас программа закроется для завершения процесса шифрования. Помните, что шифрование вашего бумажника не может полностью защитить ваши биткоины от кражи с помощью инфицирования вашего компьютера вредоносным ПО.</translation>
+        <translation>Сейчас программа закроется для завершения процесса шифрования. Помните, что шифрование вашего бумажника не может полностью защитить ваши биткойны от кражи с помощью инфицирования вашего компьютера вредоносным ПО.</translation>
     </message>
     <message>
         <location line="+13"/>
@@ -447,7 +447,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <location line="+6"/>
         <location line="+513"/>
         <source>Bitcoin</source>
-        <translation>Биткоин</translation>
+        <translation>Биткойн</translation>
     </message>
     <message>
         <location line="-519"/>
@@ -1232,7 +1232,7 @@ Address: %4
         <location line="+5"/>
         <location filename="../intro.cpp" line="-32"/>
         <source>Bitcoin</source>
-        <translation>Биткоин</translation>
+        <translation>Биткойн</translation>
     </message>
     <message>
         <location line="-4"/>


### PR DESCRIPTION
Corrections associated with the existing rules of the English-Russian practical transcription [1], and active discussion of this issue in Wikipedia [3,4].
[1]. http://ru.wikipedia.org/wiki/Англо-русская_практическая_транскрипция
[2]. http://ru.wikipedia.org/wiki/Википедия:К_переименованию/13_декабря_2013#Bitcoin_.E2.86.92_.D0.91.D0.B8.D1.82.D0.BA.D0.BE.D0.B9.D0.BD
[3]. http://ru.wikipedia.org/wiki/Википедия:Заявки_на_транскрипцию_и_транслитерацию/Английский_язык#Bitcoin
