### PR TITLE
Added extractpubkey rpc call, allows extraction of public key from a message and signature.

### DIFF
--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -255,6 +255,7 @@ static const CRPCCommand vRPCCommands[] =
     { "validateaddress",        &validateaddress,        true,      false,      false },
     { "createmultisig",         &createmultisig,         true,      true ,      false },
     { "verifymessage",          &verifymessage,          false,     false,      false },
+    { "extractpubkey",          &extractpubkey,          false,     false,      false },
 
 #ifdef ENABLE_WALLET
     /* Wallet */

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -132,6 +132,7 @@ extern json_spirit::Value getaddressesbyaccount(const json_spirit::Array& params
 extern json_spirit::Value sendtoaddress(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value signmessage(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value verifymessage(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value extractpubkey(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value getreceivedbyaddress(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value getreceivedbyaccount(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value getbalance(const json_spirit::Array& params, bool fHelp);


### PR DESCRIPTION
Can be useful for logging into websites, without requiring the user to enter a username when they log in. User signs a message and the site recovers the public key from the known message and signature and checks the public key belongs to a user in the database.
