### PR TITLE
"getnetworkhashps" with defaults was yielding "0", the hashrate is not 0

### DIFF
--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -55,7 +55,10 @@ void ShutdownRPCMining()
 // or from the last difficulty change if 'lookup' is nonpositive.
 // If 'height' is nonnegative, compute the estimate at the time when a given block was found.
 Value GetNetworkHashPS(int lookup, int height) {
-    CBlockIndex *pb = chainActive[height];
+    CBlockIndex *pb = chainActive.Tip();
+
+    if (height >= 0 && height < chainActive.Height())
+        pb = chainActive[height];
 
     if (pb == NULL || !pb->nHeight)
         return 0;


### PR DESCRIPTION
This was broken in 4c6d41b8b653ef90639b1a32f6aab0bb1cef90c5.
