### PR TITLE
Added ability to set config parameters through environment variables

### DIFF
--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -20,6 +20,8 @@ static bool AppInitRPC(int argc, char* argv[])
     //
     // Parameters
     //
+    ClearArgs();
+    ParseEnvironment();
     ParseParameters(argc, argv);
     if (!boost::filesystem::is_directory(GetDataDir(false)))
     {

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -20,7 +20,6 @@ static bool AppInitRPC(int argc, char* argv[])
     //
     // Parameters
     //
-    ClearArgs();
     ParseEnvironment();
     ParseParameters(argc, argv);
     if (!boost::filesystem::is_directory(GetDataDir(false)))

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -62,7 +62,6 @@ bool AppInit(int argc, char* argv[])
         // Parameters
         //
         // If Qt is used, parameters/bitcoin.conf are parsed in qt/bitcoin.cpp's main()
-        ClearArgs();
 	ParseEnvironment();
 	ParseParameters(argc, argv);
         if (!boost::filesystem::is_directory(GetDataDir(false)))

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -62,7 +62,9 @@ bool AppInit(int argc, char* argv[])
         // Parameters
         //
         // If Qt is used, parameters/bitcoin.conf are parsed in qt/bitcoin.cpp's main()
-        ParseParameters(argc, argv);
+        ClearArgs();
+	ParseEnvironment();
+	ParseParameters(argc, argv);
         if (!boost::filesystem::is_directory(GetDataDir(false)))
         {
             fprintf(stderr, "Error: Specified data directory \"%s\" does not exist.\n", mapArgs["-datadir"].c_str());

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -165,6 +165,8 @@ int main(int argc, char *argv[])
     bool fSelParFromCLFailed = false;
 
     // Command-line options take precedence:
+    ClearArgs();
+    ParseEnvironment();
     ParseParameters(argc, argv);
     // ... then bitcoin.conf:
     if (!boost::filesystem::is_directory(GetDataDir(false))) {

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -165,7 +165,6 @@ int main(int argc, char *argv[])
     bool fSelParFromCLFailed = false;
 
     // Command-line options take precedence:
-    ClearArgs();
     ParseEnvironment();
     ParseParameters(argc, argv);
     // ... then bitcoin.conf:

--- a/src/test/getarg_tests.cpp
+++ b/src/test/getarg_tests.cpp
@@ -24,6 +24,7 @@ static void ResetArgs(const std::string& strArg)
     BOOST_FOREACH(std::string& s, vecArg)
         vecChar.push_back(s.c_str());
 
+    ClearArgs();
     ParseParameters(vecChar.size(), &vecChar[0]);
 }
 

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -117,12 +117,15 @@ BOOST_AUTO_TEST_CASE(util_ParseParameters)
 {
     const char *argv_test[] = {"-ignored", "-a", "-b", "-ccc=argument", "-ccc=multiple", "f", "-d=e"};
 
+    ClearArgs();
     ParseParameters(0, (char**)argv_test);
     BOOST_CHECK(mapArgs.empty() && mapMultiArgs.empty());
 
+    ClearArgs();
     ParseParameters(1, (char**)argv_test);
     BOOST_CHECK(mapArgs.empty() && mapMultiArgs.empty());
 
+    ClearArgs();
     ParseParameters(5, (char**)argv_test);
     // expectation: -ignored is ignored (program name argument),
     // -a, -b and -ccc end up in map, -d ignored because it is after

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -552,23 +552,23 @@ void ParseEnvironment()
     while (environ[i] != NULL && strlen(environ[i]) > 0) {
 
         string str(environ[i]);
-	string strName;
+        string strName;
         string strValue;
 
         if (boost::algorithm::starts_with(str, "BITCOIN_")) {
 
-	    size_t und_index = str.find('_');
-	    size_t is_index = str.find('=');
+            size_t und_index = str.find('_');
+            size_t is_index = str.find('=');
 
-	    strName = "-" + str.substr(und_index+1, is_index-und_index-1);
-	    boost::to_lower(strName);
-	    strValue = str.substr(is_index+1);
+            strName = "-" + str.substr(und_index+1, is_index-und_index-1);
+            boost::to_lower(strName);
+            strValue = str.substr(is_index+1);
 
-	    if (envWhitelist.find(strName) != envWhitelist.end()) {
+            if (envWhitelist.find(strName) != envWhitelist.end()) {
                 mapArgs[strName] = strValue;
                 mapMultiArgs[strName].push_back(strValue);
-		//cout << "Setting '" << strName << "' to '" << strValue << "'" << endl;
-	    }
+                //cout << "Setting '" << strName << "' to '" << strValue << "'" << endl;
+            }
         }
 
         i++;

--- a/src/util.h
+++ b/src/util.h
@@ -22,6 +22,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <unistd.h>
 
 #ifndef WIN32
 #include <sys/resource.h>
@@ -172,6 +173,8 @@ std::vector<unsigned char> DecodeBase32(const char* p, bool* pfInvalid = NULL);
 std::string DecodeBase32(const std::string& str);
 std::string EncodeBase32(const unsigned char* pch, size_t len);
 std::string EncodeBase32(const std::string& str);
+void ClearArgs();
+void ParseEnvironment();
 void ParseParameters(int argc, const char*const argv[]);
 bool WildcardMatch(const char* psz, const char* mask);
 bool WildcardMatch(const std::string& str, const std::string& mask);


### PR DESCRIPTION
The environment is parsed for variables starting with BITCOIN_, and
the remaining portion of the name becomes the argument name, with
the value set to the portion after the = sign, e.g.,

BITCOIN_DATADIR=FOO is equivalent to -datadir=FOO

The environment is parsed before the command line, allowing the
command line to take precedence over the environment.

There is a whitelist in util.cpp that only allows specified environment
variables to be used this way; currently, this is set to just -datadir
and -conf.

Signed-off-by: Johnathan Corgan johnathan@corganlabs.com
