### PR TITLE
ui: Better tab order in send coins entry

### DIFF
--- a/src/qt/sendcoinsentry.cpp
+++ b/src/qt/sendcoinsentry.cpp
@@ -155,11 +155,12 @@ SendCoinsRecipient SendCoinsEntry::getValue()
 QWidget *SendCoinsEntry::setupTabChain(QWidget *prev)
 {
     QWidget::setTabOrder(prev, ui->payTo);
-    QWidget::setTabOrder(ui->payTo, ui->addressBookButton);
+    QWidget::setTabOrder(ui->payTo, ui->addAsLabel);
+    QWidget *w = ui->payAmount->setupTabChain(ui->addAsLabel);
+    QWidget::setTabOrder(w, ui->addressBookButton);
     QWidget::setTabOrder(ui->addressBookButton, ui->pasteButton);
     QWidget::setTabOrder(ui->pasteButton, ui->deleteButton);
-    QWidget::setTabOrder(ui->deleteButton, ui->addAsLabel);
-    return ui->payAmount->setupTabChain(ui->addAsLabel);
+    return ui->deleteButton;
 }
 
 void SendCoinsEntry::setValue(const SendCoinsRecipient &value)


### PR DESCRIPTION
Pressing <tab> after entering a label now brings the focus to the address entry, instead of the row of buttons. In my experience this is more useful, as I usually want to paste an address after entering the label.

The buttons are mostly useless in this case:
- Choosing a previously used address should be discouraged
- When I'm already using the keyboard the 'paste address' button is useless - just press Ctrl-V or Shift-Insert. Maybe it would be an idea to remove it completely
- I usually don't want to remove the entry I'm typing now! So makes sense to have it at the end of the tab chain
