### PR TITLE
Added new DNS seed from bitcoinstats.com.

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -143,6 +143,7 @@ public:
         vSeeds.push_back(CDNSSeedData("bitcoin.sipa.be", "seed.bitcoin.sipa.be"));
         vSeeds.push_back(CDNSSeedData("bluematt.me", "dnsseed.bluematt.me"));
         vSeeds.push_back(CDNSSeedData("dashjr.org", "dnsseed.bitcoin.dashjr.org"));
+        vSeeds.push_back(CDNSSeedData("bitcoinstats.com", "seed.bitcoinstats.com"));
         vSeeds.push_back(CDNSSeedData("xf2.org", "bitseed.xf2.org"));
 
         base58Prefixes[PUBKEY_ADDRESS] = list_of(0);


### PR DESCRIPTION
This adds a new bootstrapping DNS seed to the list.

I assume they are in alphabetical order, hence the positioning.

I had a short discussion with sipa during the last Zurich Meetup and he said I should go ahead and get this pulled into the mainline client.
