### PR TITLE
ui: Fix GUI initialization order

### DIFF
--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -148,7 +148,7 @@ QString Intro::getDefaultDataDirectory()
 
 void Intro::pickDataDirectory(bool fIsTestnet)
 {
-    namespace fs = boost::filesystem;;
+    namespace fs = boost::filesystem;
     QSettings settings;
     /* If data directory provided on command line, no need to look at settings
        or show a picking dialog */

--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -180,10 +180,8 @@ void PaymentServer::LoadRootCAs(X509_STORE* _store)
 // and the items in savedPaymentRequest will be handled
 // when uiReady() is called.
 //
-bool PaymentServer::ipcSendCommandLine(int argc, char* argv[])
+bool PaymentServer::ipcParseCommandLine(int argc, char* argv[])
 {
-    bool fResult = false;
-
     for (int i = 1; i < argc; i++)
     {
         QString arg(argv[i]);
@@ -226,7 +224,18 @@ bool PaymentServer::ipcSendCommandLine(int argc, char* argv[])
             qDebug() << "PaymentServer::ipcSendCommandLine : Payment request file does not exist: " << arg;
         }
     }
+    return true;
+}
 
+//
+// Sending to the server is done synchronously, at startup.
+// If the server isn't already running, startup continues,
+// and the items in savedPaymentRequest will be handled
+// when uiReady() is called.
+//
+bool PaymentServer::ipcSendCommandLine()
+{
+    bool fResult = false;
     foreach (const QString& r, savedPaymentRequests)
     {
         QLocalSocket* socket = new QLocalSocket();

--- a/src/qt/paymentserver.h
+++ b/src/qt/paymentserver.h
@@ -56,12 +56,16 @@ class PaymentServer : public QObject
     Q_OBJECT
 
 public:
+    // Parse URIs on command line
+    // Returns false on error
+    static bool ipcParseCommandLine(int argc, char *argv[]);
+
     // Returns true if there were URIs on the command line
     // which were successfully sent to an already-running
     // process.
     // Note: if a payment request is given, SelectParams(MAIN/TESTNET)
     // will be called so we startup in the right mode.
-    static bool ipcSendCommandLine(int argc, char *argv[]);
+    static bool ipcSendCommandLine();
 
     // parent should be QApplication object
     PaymentServer(QObject* parent, bool startLocalServer = true);


### PR DESCRIPTION
I thought through the initialization order a bit. Fixes at least #3478. @diapolo can you please help testing?

Splits and documents the phases:
1. Parse command-line options. These take precedence over anything else.
2. Basic Qt initialization (not dependent on parameters or configuration)
3. Application identification
4. Initialization of translations
5. Now that settings and translations are available, ask user for data directory
6. Determine availability of data directory and parse bitcoin.conf
7. URI IPC sending
8. Main GUI initialization

Splits command line parsing logic from ipcSendCommandLine into ipcParseCommandLine, as isTestNet() can only be overridden in the early stages before choosing a data directory. Sending however needs to happen after choosing a data directory.

Tested:
- URI handling to running testnet and mainnet instances
- URI handling with custom data directories
- URI handling for testnet URIs launches testnet GUI
- `-choosedatadir` can be used to provide custom data directories
