### PR TITLE
qt: Remove unused method OptionsModel::getTransactionFee

### DIFF
--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -307,11 +307,6 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
     return successful;
 }
 
-qint64 OptionsModel::getTransactionFee()
-{
-    return (qint64) nTransactionFee;
-}
-
 bool OptionsModel::getProxySettings(QString& proxyIP, quint16 &proxyPort) const
 {
     std::string proxy = GetArg("-proxy", "");

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -48,7 +48,6 @@ public:
     bool setData(const QModelIndex & index, const QVariant & value, int role = Qt::EditRole);
 
     /* Explicit getters */
-    qint64 getTransactionFee();
     bool getMinimizeToTray() { return fMinimizeToTray; }
     bool getMinimizeOnClose() { return fMinimizeOnClose; }
     int getDisplayUnit() { return nDisplayUnit; }


### PR DESCRIPTION
As it says on the tin.
