### PR TITLE
qt: Create splash screen only when requested, delete after use

### DIFF
--- a/src/qt/splashscreen.cpp
+++ b/src/qt/splashscreen.cpp
@@ -13,6 +13,8 @@
 SplashScreen::SplashScreen(const QPixmap &pixmap, Qt::WindowFlags f, bool isTestNet) :
     QSplashScreen(pixmap, f)
 {
+    setAutoFillBackground(true);
+
     // set reference point, paddings
     int paddingRight            = 50;
     int paddingTop              = 50;


### PR DESCRIPTION
Splash screen was always created (but hidden), even when -nosplash or -min was provided on the command line. Fix this.

Also make the splash screen delete itself after use. No need to keep it in memory after initialization.

Reduces memory usage a bit and may improve Ubuntu window detection issues.
