### PR TITLE
Add test for GetTime()

### DIFF
--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -330,4 +330,12 @@ BOOST_AUTO_TEST_CASE(strprintf_numbers)
 #undef B
 #undef E
 
+/* Check for mingw/wine issue #3494
+ * Remove this test before time.ctime(0xffffffff) == 'Sun Feb  7 07:28:15 2106'
+ */
+BOOST_AUTO_TEST_CASE(gettime)
+{
+    BOOST_CHECK((GetTime() & ~0xFFFFFFFFLL) == 0);
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Test for mingw/wine issue #3494, where the upper word of time(NULL) return value gets clobbered.
