### PR TITLE
Upgrade gitian win32 to boost-1.55.

### DIFF
--- a/contrib/gitian-descriptors/boost-win32.yml
+++ b/contrib/gitian-descriptors/boost-win32.yml
@@ -12,19 +12,19 @@ packages:
 reference_datetime: "2011-01-30 00:00:00"
 remotes: []
 files:
-- "boost_1_54_0.tar.bz2"
+- "boost_1_55_0.tar.bz2"
 - "boost-mingw-gas-cross-compile-2013-03-03.patch"
 script: |
   # Defines
   INSTALLPREFIX="$OUTDIR/staging/boost"
   HOST=i686-w64-mingw32
   # Input Integrity Check
-  echo "047e927de336af106a24bceba30069980c191529fd76b8dff8eb9a328b48ae1d  boost_1_54_0.tar.bz2" | shasum -c
+  echo "fff00023dd79486d444c8e29922f4072e1d451fc5a4d2b6075852ead7f2b7b52  boost_1_55_0.tar.bz2" | shasum -c
   echo "d2b7f6a1d7051faef3c9cf41a92fa3671d905ef1e1da920d07651a43299f6268  boost-mingw-gas-cross-compile-2013-03-03.patch" | shasum -c
 
   mkdir -p "$INSTALLPREFIX"
-  tar xjf boost_1_54_0.tar.bz2
-  cd boost_1_54_0
+  tar xjf boost_1_55_0.tar.bz2
+  cd boost_1_55_0
   GCCVERSION=$($HOST-g++ -E -dM $(mktemp --suffix=.h) | grep __VERSION__ | cut -d ' ' -f 3 | cut -d '"' -f 2)
   echo "using gcc : $GCCVERSION : $HOST-g++
         :
@@ -48,7 +48,7 @@ script: |
   # Patch Mirror:   http://rose.makesad.us/~paulproteus/mirrors/boost-mingw-gas-cross-compile-2013-03-03.patch
   patch -p0 < ../boost-mingw-gas-cross-compile-2013-03-03.patch
 
-  # Bug Workaround: boost-1.54.0 broke the ability to disable zlib
+  # Bug Workaround: boost-1.54.0 broke the ability to disable zlib, still broken in 1.55
   # https://svn.boost.org/trac/boost/ticket/9156
   sed -i 's^\[ ac.check-library /zlib//zlib : <library>/zlib//zlib^^' libs/iostreams/build/Jamfile.v2
   sed -i 's^<source>zlib.cpp <source>gzip.cpp \]^^' libs/iostreams/build/Jamfile.v2
@@ -62,5 +62,5 @@ script: |
   cd "$INSTALLPREFIX"
   export LD_PRELOAD=/usr/lib/faketime/libfaketime.so.1
   export FAKETIME=$REFERENCE_DATETIME
-  zip -r boost-win32-1.54.0-gitian-r6.zip *
-  cp boost-win32-1.54.0-gitian-r6.zip $OUTDIR
+  zip -r boost-win32-1.55.0-gitian-r6.zip *
+  cp boost-win32-1.55.0-gitian-r6.zip $OUTDIR

--- a/contrib/gitian-descriptors/gitian-win32.yml
+++ b/contrib/gitian-descriptors/gitian-win32.yml
@@ -23,7 +23,7 @@ remotes:
   "dir": "bitcoin"
 files:
 - "qt-win32-4.8.3-gitian-r4.zip"
-- "boost-win32-1.54.0-gitian-r6.zip"
+- "boost-win32-1.55.0-gitian-r6.zip"
 - "bitcoin-deps-win32-gitian-r9.zip"
 - "protobuf-win32-2.5.0-gitian-r3.zip"
 script: |
@@ -34,7 +34,7 @@ script: |
   mkdir -p $STAGING
   cd $STAGING
   unzip ../build/qt-win32-4.8.3-gitian-r4.zip
-  unzip ../build/boost-win32-1.54.0-gitian-r6.zip
+  unzip ../build/boost-win32-1.55.0-gitian-r6.zip
   unzip ../build/bitcoin-deps-win32-gitian-r9.zip
   unzip ../build/protobuf-win32-2.5.0-gitian-r3.zip
   cd $HOME/build/


### PR DESCRIPTION
Fixes issue where all network activity just stops.

Litecoin 0.8.6.1 upgraded the gitian win32 environment to precise and boost-1.54 in exactly the same manner as Bitcoin master.  After Litecoin 0.8.6.1 was released we began to hear complaints from Windows users about block sync getting stuck forever.  When networking stops the GUI remains responsive and the debug.log has a few lines like this before stopping entirely.

`2013-12-28 12:40:46 socket send error 10054
2013-12-28 12:40:46 disconnecting node 125.86.21.116:1985`

Several hours after the point where it fails, `netstat -a` on Windows reports a great many connections stuck in the CLOSED_WAIT state.

https://litecointalk.org/index.php?topic=12526.0
Testing by several members of the Litecoin community found that downgrading to boost-1.50 seemed to fix the issue.  We also tried boost-1.55 which also seems to fix the issue.

https://svn.boost.org/trac/boost/ticket/8933
This upstream ticket against boost-1.54 might be related.  This is confusing though as Bitcoin does not use boost ASIO except for RPC which is disabled by default on the -qt builds.  Whatever the issue, at this point it seems that boost-1.55 solves the issue, or at least none of the Litecoin testers of the boost-1.55 builds have reported the permanent network failure condition that occurs with boost-1.54.

http://download1.rpmfusion.org/~warren/bitcoin-win32-network-test/
This is a gitian win32 build of bitcoin-qt.exe at 13e99e463d4aa0bd2b2892010ca8c7007c40c242.  I personally reproduced a similar failure only a few thousand blocks into a fresh sync on Windows 7 x64.  Unlike the 0.8.x + boost-1.54 client it did not have the 10054 errors in debug.log.  Instead the log just stopped.  GUI remained responsive.  Subsequent `addnode ADDRESS onetry` appeared to add an entry to `getpeerinfo` but it was clearly defective.

![defective-addnode](https://f.cloud.github.com/assets/93665/1878101/520a531c-7935-11e3-8ff8-4300fe3e59ab.jpg)

Note that it failed to read the subver and it received zero bytes from this peer.
