### PR TITLE
Fix importprivkey / rescan

### DIFF
--- a/src/rpcdump.cpp
+++ b/src/rpcdump.cpp
@@ -116,8 +116,13 @@ Value importprivkey(const Array& params, bool fHelp)
         if (pwalletMain->HaveKey(vchAddress))
             return Value::null;
 
+        pwalletMain->mapKeyMetadata[vchAddress].nCreateTime = 1;
+
         if (!pwalletMain->AddKeyPubKey(key, pubkey))
             throw JSONRPCError(RPC_WALLET_ERROR, "Error adding key to wallet");
+
+        // whenever a key is imported, we need to scan the whole chain
+        pwalletMain->nTimeFirstKey = 1; // 0 would be considered 'no value'
 
         if (fRescan) {
             pwalletMain->ScanForWalletTransactions(chainActive.Genesis(), true);


### PR DESCRIPTION
importprivkey / rescan does not always work currently.

Use case:
- dumpprivkey with a balance
- close bitcoin
- delete wallet.dat
- start bitcoin
- importprivkey

Result:
rescan fails because wallet uses nTimeFirstKey of the other keys.
Setting
    pwalletMain->nTimeFirstKey = 1;
solves the problem in this case, scanning the chain from genesis.
But I if import with rescan=false, then close bitcoin and do
    bitcoin-qt -rescan
this fails again. Because nCreateTime of the metadata is zero,
and now nTimeFirstKey is set to zero, but overwritten later again,
because if(0) is false. So setting this to 1 solves the problem.

Further ideas, not part of this pull:
dumprivkey could export nCreationTime as well.
importprivkey would then have distinguish between old and new format.
rescan from the genesis block could reassign all nCreationTime.
