### PR TITLE
[Qt] display native dir separators in select dadatir dialog

### DIFF
--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -233,7 +233,7 @@ void Intro::on_dataDirectory_textChanged(const QString &dataDirStr)
 
 void Intro::on_ellipsisButton_clicked()
 {
-    QString dir = QFileDialog::getExistingDirectory(0, "Choose data directory", ui->dataDirectory->text());
+    QString dir = QDir::toNativeSeparators(QFileDialog::getExistingDirectory(0, "Choose data directory", ui->dataDirectory->text()));
     if(!dir.isEmpty())
         ui->dataDirectory->setText(dir);
 }


### PR DESCRIPTION
- fixes display on Windows now \ instead of / before
