### PR TITLE
Add missing MacPorts dependencies to osx build docs

### DIFF
--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -45,7 +45,7 @@ Instructions: MacPorts
 
 Installing the dependencies using MacPorts is very straightforward.
 
-    sudo port install boost db48@+no_java openssl miniupnpc
+    sudo port install boost db48@+no_java openssl miniupnpc autoconf pkgconfig
 
 ### Building `bitcoind`
 


### PR DESCRIPTION
Fixes #3398
