### PR TITLE
GUI: Fix design in overview page

### DIFF
--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -90,6 +90,8 @@
            </layout>
           </item>
           <item>
+          <layout class="QHBoxLayout" name="horizontalLayout_3">
+           <item>
            <layout class="QFormLayout" name="formLayout_2">
             <property name="fieldGrowthPolicy">
              <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
@@ -231,6 +233,21 @@
                <enum>Qt::Horizontal</enum>
               </property>
              </widget>
+            </item>
+           </layout>
+          </item>
+            <item>
+             <spacer name="horizontalSpacer_3">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
             </item>
            </layout>
           </item>


### PR DESCRIPTION
The design in overview page looks a little weird currently, at least to my eyes.

There is too much space between label and amount.

Before:
http://imageshack.com/a/img856/9383/amju.png

After:
http://imageshack.com/a/img14/2466/pr7m.png
