### PR TITLE
Transaction expiration

### DIFF
--- a/src/core.h
+++ b/src/core.h
@@ -229,6 +229,11 @@ public:
     // Compute priority, given priority of inputs and (optionally) tx size
     double ComputePriority(double dPriorityInputs, unsigned int nTxSize=0) const;
 
+    bool IsExpired(unsigned int nBlockTime) const
+    {
+        return (!vin.empty() && nBlockTime > 129600 && vin[0].nSequence < nBlockTime - 129600); // txs expire after 36h
+    }
+
     bool IsCoinBase() const
     {
         return (vin.size() == 1 && vin[0].prevout.IsNull());
@@ -345,7 +350,7 @@ class CBlockHeader
 {
 public:
     // header
-    static const int CURRENT_VERSION=2;
+    static const int CURRENT_VERSION=3;
     int nVersion;
     uint256 hashPrevBlock;
     uint256 hashMerkleRoot;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -265,6 +265,8 @@ std::string HelpMessage(HelpMessageMode hmm)
     strUsage += "  -loadblock=<file>      " + _("Imports blocks from external blk000??.dat file") + "\n";
     strUsage += "  -reindex               " + _("Rebuild block chain index from current blk000??.dat files") + "\n";
     strUsage += "  -par=<n>               " + _("Set the number of script verification threads (up to 16, 0 = auto, <0 = leave that many cores free, default: 0)") + "\n";
+    strUsage += "  -txtimestamp           " + _("Timestamp transactions on creation. This lets created unconfirmed transactions expire after 36 hours, if they have not been confirmed by the network (default: 1)") + "\n";
+    strUsage += "  -expirenotify=<cmd>    " + _("Execute command when a wallet transaction expires (%s in cmd is replaced by TxID)") + "\n";
 #ifdef ENABLE_WALLET
     strUsage += "\n" + _("Wallet options:") + "\n";
     strUsage += "  -disablewallet         " + _("Do not load the wallet and disable wallet RPC calls") + "\n";
@@ -531,6 +533,8 @@ bool AppInit2(boost::thread_group& threadGroup)
         if (nTransactionFee > 0.25 * COIN)
             InitWarning(_("Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction."));
     }
+
+    fTimestampTransactions = GetBoolArg("-txtimestamp", true);
 
     strWalletFile = GetArg("-wallet", "wallet.dat");
 #endif

--- a/src/main.h
+++ b/src/main.h
@@ -185,7 +185,7 @@ bool GetNodeStateStats(NodeId nodeid, CNodeStateStats &stats);
 
 /** (try to) add transaction to memory pool **/
 bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransaction &tx, bool fLimitFree,
-                        bool* pfMissingInputs, bool fRejectInsaneFee=false);
+                        bool* pfMissingInputs, bool fRejectInsaneFee=false, bool fCheckExpired=true);
 
 
 
@@ -1092,7 +1092,7 @@ class CWalletInterface {
 protected:
     virtual void SyncTransaction(const uint256 &hash, const CTransaction &tx, const CBlock *pblock) =0;
     virtual void EraseFromWallet(const uint256 &hash) =0;
-    virtual void SetBestChain(const CBlockLocator &locator) =0;
+    virtual void SetBestChain(CBlockIndex* pindexNew, bool fIsInitialDownload) =0;
     virtual void UpdatedTransaction(const uint256 &hash) =0;
     virtual void Inventory(const uint256 &hash) =0;
     virtual void ResendWalletTransactions() =0;

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -48,6 +48,7 @@ public:
         QString address = index.data(Qt::DisplayRole).toString();
         qint64 amount = index.data(TransactionTableModel::AmountRole).toLongLong();
         bool confirmed = index.data(TransactionTableModel::ConfirmedRole).toBool();
+        bool expired = index.data(TransactionTableModel::ExpiredRole).toBool();
         QVariant value = index.data(Qt::ForegroundRole);
         QColor foreground = option.palette.color(QPalette::Text);
         if(value.canConvert<QBrush>())
@@ -75,7 +76,10 @@ public:
         QString amountText = BitcoinUnits::formatWithUnit(unit, amount, true);
         if(!confirmed)
         {
-            amountText = QString("[") + amountText + QString("]");
+            if (expired)
+                amountText = QString("[") + tr("expired") + QString("]");
+            else
+                amountText = QString("[") + amountText + QString("]");
         }
         painter->drawText(amountRect, Qt::AlignRight|Qt::AlignVCenter, amountText);
 

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -183,7 +183,11 @@ void TransactionRecord::updateStatus(const CWalletTx &wtx)
     }
     else
     {
-        if (GetAdjustedTime() - wtx.nTimeReceived > 2 * 60 && wtx.GetRequestCount() == 0)
+        if (wtx.fExpired)
+        {
+            status.status = TransactionStatus::Expired;
+        }
+        else if (GetAdjustedTime() - wtx.nTimeReceived > 2 * 60 && wtx.GetRequestCount() == 0)
         {
             status.status = TransactionStatus::Offline;
         }

--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -36,7 +36,8 @@ public:
         OpenUntilBlock,
         Offline,
         Unconfirmed,
-        HaveConfirmations
+        HaveConfirmations,
+        Expired
     };
 
     bool confirmed;

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -320,6 +320,9 @@ QString TransactionTableModel::formatTxStatus(const TransactionRecord *wtx) cons
         case TransactionStatus::HaveConfirmations:
             status = tr("Confirmed (%1 confirmations)").arg(wtx->status.depth);
             break;
+        case TransactionStatus::Expired:
+            status = tr("Expired");
+            break;
         }
     }
 
@@ -486,6 +489,8 @@ QVariant TransactionTableModel::txStatusDecoration(const TransactionRecord *wtx)
             };
         case TransactionStatus::HaveConfirmations:
             return QIcon(":/icons/transaction_confirmed");
+        case TransactionStatus::Expired:
+            return QIcon(":/icons/quit");
         }
     }
     return QColor(0,0,0);
@@ -585,6 +590,8 @@ QVariant TransactionTableModel::data(const QModelIndex &index, int role) const
         // Return True if transaction counts for balance
         return rec->status.confirmed && !(rec->type == TransactionRecord::Generated &&
                                           rec->status.maturity != TransactionStatus::Mature);
+    case ExpiredRole:
+        return (rec->status.status == TransactionStatus::Expired);
     case FormattedAmountRole:
         return formatTxAmount(rec, false);
     }

--- a/src/qt/transactiontablemodel.h
+++ b/src/qt/transactiontablemodel.h
@@ -52,6 +52,8 @@ public:
         TxIDRole,
         /** Is transaction confirmed? */
         ConfirmedRole,
+        /** Is transaction expired? */
+        ExpiredRole,
         /** Formatted amount, without brackets when unconfirmed */
         FormattedAmountRole
     };

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -314,7 +314,7 @@ Value getwork(const Array& params, bool fHelp)
         static CBlockIndex* pindexPrev;
         static int64_t nStart;
         static CBlockTemplate* pblocktemplate;
-        if (pindexPrev != chainActive.Tip() ||
+        if (pindexPrev != chainActive.Tip() || GetTime() - nStart > 1800 ||
             (mempool.GetTransactionsUpdated() != nTransactionsUpdatedLast && GetTime() - nStart > 60))
         {
             if (pindexPrev != chainActive.Tip())
@@ -490,7 +490,7 @@ Value getblocktemplate(const Array& params, bool fHelp)
     static CBlockIndex* pindexPrev;
     static int64_t nStart;
     static CBlockTemplate* pblocktemplate;
-    if (pindexPrev != chainActive.Tip() ||
+    if (pindexPrev != chainActive.Tip() || GetTime() - nStart > 1800 ||
         (mempool.GetTransactionsUpdated() != nTransactionsUpdatedLast && GetTime() - nStart > 5))
     {
         // Clear pindexPrev so future calls make a new block, despite any failures from here on

--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -365,6 +365,17 @@ Value createrawtransaction(const Array& params, bool fHelp)
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, vout must be positive");
 
         CTxIn in(COutPoint(txid, nOutput));
+
+        // timestamp for transaction expiration
+        if (fTimestampTransactions && rawTx.vin.empty())
+        {
+            // check if system clock is more than 12 hours in the past
+            if ((unsigned int)GetAdjustedTime() + 43200 < ((chainActive.Tip()) ? chainActive.Tip()->nTime : 0))
+                throw JSONRPCError(RPC_INVALID_PARAMETER, "Your computers date and time seem to be wrong. Please fix your system clock!");
+
+            in.nSequence = (unsigned int)GetAdjustedTime();
+        }
+
         rawTx.vin.push_back(in);
     }
 

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -125,6 +125,23 @@ bool CTxMemPool::removeConflicts(const CTransaction &tx)
     return true;
 }
 
+void CTxMemPool::removeExpired(unsigned int nBlockTime)
+{
+    vector<CTransaction> vDelete;
+    {
+        LOCK(cs);
+        for (std::map<uint256, CTxMemPoolEntry>::const_iterator it = mapTx.begin(); it != mapTx.end(); ++it) {
+            const CTransaction& tx = it->second.GetTx();
+            if (tx.IsExpired(nBlockTime))
+                vDelete.push_back(tx);
+        }
+    }
+    BOOST_FOREACH(CTransaction& tx, vDelete) {
+        remove(tx);
+        removeConflicts(tx);
+    }
+}
+
 void CTxMemPool::clear()
 {
     LOCK(cs);

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -74,6 +74,7 @@ public:
     bool addUnchecked(const uint256& hash, const CTxMemPoolEntry &entry);
     bool remove(const CTransaction &tx, bool fRecursive = false);
     bool removeConflicts(const CTransaction &tx);
+    void removeExpired(unsigned int nBlockTime);
     void clear();
     void queryHashes(std::vector<uint256>& vtxid);
     void pruneSpent(const uint256& hash, CCoins &coins);


### PR DESCRIPTION
Motivation
Transaction expiration is a fallback solution for never or too slow confirming transactions. Unconfirmed transactions expire after about 36 hours, if not included in a block by miners.
The coins are credited back to the wallet and free to use again, just like sending the transaction had never happened. The transaction stays in the wallet, marked as expired. If someone would sync his wallet from scratch, the expired transaction would not appear anymore, because obviously it is not part of the blockchain.

Implementation
Abusing vin[0].nSequence for timestamping the transactions. Do not remove any of the original features of the field, even this pull #2340 would still be possible.
People actually using the nLockTime features can decide, if they want to go with the timestamp, sending maximum of 1 tx per second, or start their sequences at, lets say, 2 billion. This would equal sending transactions "never expiring", just like it is now.

Block version 3
Blocks version 3 do not allow expired transactions. Introduced same as block version 2 by a 95% majority softfork. Expired transactions are checked against blocktime, not local time, to avoid chain splits.

Deployment
Needs staging, but no hardfork. Older versions would not remove expired transactions from their mempool and consider follow-up transactions as double spend. So Step 1 would be introducing block version 3, the relay rule and the mempool removal. Then if block v3 and, lets say, 50% of all nodes have upgraded, transaction expiration can be introduced.

Relay
The relay rule is: do not relay transactions expiring in 24 hours or less

Mining
CreateNewBlock does not include transactions which would expire in 1 hour or less. This is a safety threshold because mining software may change the timestamp afterwards, resulting in mining an invalid block, containing expired transactions.

Timeline
0 - CreateTransation
12hs later: stop relaying the transaction, other nodes would reject it, because it expires in 24 hours or less
35hs: 1 hour before expiring. CreateNewBlock does not include the tx anymore (reason see above).
36hs: transaction expires. nodes remove it from their mempool.
38hs: the wallet checks against block median time, not local time and adds another hour, to ensure the transaction is really expired and cannot appear in blocks anymore. So about ~2hs late, the wallet marks the tx as expired and frees the coins.
Resulting in a total time of about 38 hours, from creating until expiring in the wallet.

Faking
It is allowed to fake your timestamp into the future, for whatever reasons. This can increase expiration time up to "never expiring".
The relay rule is 24 hours, so you can fake your timestamp up to 12 hours into the past. This can reduce expiration time from 36 down to max 24 hours.
If you fake more than 12 hours in the past, your transaction would not get relayed by other nodes anymore. If you fake more than 36 hours in the past, you would create an already expired transactions. This doesnt make sense anyway.
This is not only about faking, but also misconfigured clocks up to 12 hours are no problem.

System clock
If transaction timestamping is on (default), the wallet refuses to create a transaction if your system clock is more than 12 hours behind the best block time. This is to ensure nobody creates an already expired transaction on accident.

Off switch
There is an option "bitcoin-qt -txtimestamp=0".
If someone does this, transactions are not timestamped anymore. This equals sending "never expiring" transactions, just like it is now.

Expiration times
"Long" expiration times are good, because:
- Merchants accepting 0-confirmations have at least 24 hours for every transaction to get confirmed, until it would expire.
  Allowing short expiration times could cause them troubles.
  Also such merchants should not only ask "Has the transaction been double spended", but also "Will it probably be confirmed". Transaction expiration makes this even more clear.
- Transaction expiration is a fallback solution only. Not something that should be part of peoples usual workflow.
  Otherwise people would always start with a free transaction, and if it expires after an hour, try again, spamming the network.
  So allowing short expiration times would be an unnecessary waste of network resources.
  People sending a not confirming transaction have to wait about 38 hours, for the transaction to expire. Then they can decide, if they want to send the transaction again, maybe with a higher fee this time...

Chainfork
It is very unlikely, a transaction the wallet marked as expired suddenly appears in block. Basically only in chainfork scenarios possible.
If this happens for whatever reasons, the transaction will be unmarked expired, and gets confirmed as normal.
If then another longer chain would win again, the transaction could expire again. But even more unlikely scenario here.
But still the wallet would handle these scenarios correctly.

Screenshots 
Expired transaction:
http://imageshack.com/a/img541/8103/h8j6.png

Overviewpage shows [expired]:
http://imageshack.com/a/img542/5076/be8y.png

Description of unconfirmed transaction shows expires in x hours:
http://imageshack.com/a/img856/8558/66ls.png

RPC
- listtransactions has a new filter attribut, showing expired transactions only:
  listtransactions "*" 10 0 "expired"
- WalletTxToJSON shows a boolean expired true/false

Notify
-expirenotify=<cmd> can notify an external script when a wallet transaction expires

Testing
I have tested this locally, modifying the other necessary code parts, to test and debug the code part being tested. Tested all added code parts.
I also tested the scenarios with expiring, then unexpiring again and what happens to the balances, unspent outputs etc. in these scenarios. Or what happens if transaction B depends on A, then A expires etc...
Not tested payment request, but there shouldnt be any difference, I guess.
No testplan or automated tests currently.
