### PR TITLE
[Qt] don't regenerate autostart link on every client startup

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -567,12 +567,6 @@ int main(int argc, char *argv[])
 
     try
     {
-#ifndef Q_OS_MAC
-        // Regenerate startup link, to fix links to old versions
-        // OSX: makes no sense on mac and might also scan/mount external (and sleeping) volumes (can take up some secs)
-        if (GUIUtil::GetStartOnSystemStartup())
-            GUIUtil::SetStartOnSystemStartup(true);
-#endif
         app.createWindow(isaTestNet);
         app.requestInitialize();
         app.exec();


### PR DESCRIPTION
- allows users to add additional paramaters via the autostart link
- related to #2197
