### PR TITLE
Avoid using CBigNum for simple multiplications

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1148,7 +1148,7 @@ void CheckForkWarningConditions()
     if (pindexBestForkTip && chainActive.Height() - pindexBestForkTip->nHeight >= 72)
         pindexBestForkTip = NULL;
 
-    if (pindexBestForkTip || (pindexBestInvalid && pindexBestInvalid->nChainWork > chainActive.Tip()->nChainWork + (chainActive.Tip()->GetBlockWork() * 6).getuint256()))
+    if (pindexBestForkTip || (pindexBestInvalid && pindexBestInvalid->nChainWork > chainActive.Tip()->nChainWork + chainActive.Tip()->GetBlockWork() * 6))
     {
         if (!fLargeWorkForkFound)
         {
@@ -1203,7 +1203,7 @@ void CheckForkWarningConditionsOnNewFork(CBlockIndex* pindexNewForkTip)
     // We define it this way because it allows us to only store the highest fork tip (+ base) which meets
     // the 7-block condition and from this always have the most-likely-to-cause-warning fork
     if (pfork && (!pindexBestForkTip || (pindexBestForkTip && pindexNewForkTip->nHeight > pindexBestForkTip->nHeight)) &&
-            pindexNewForkTip->nChainWork - pfork->nChainWork > (pfork->GetBlockWork() * 7).getuint256() &&
+            pindexNewForkTip->nChainWork - pfork->nChainWork > pfork->GetBlockWork() * 7 &&
             chainActive.Height() - pindexNewForkTip->nHeight < 72)
     {
         pindexBestForkTip = pindexNewForkTip;
@@ -1909,7 +1909,7 @@ bool AddToBlockIndex(CBlock& block, CValidationState& state, const CDiskBlockPos
         pindexNew->nHeight = pindexNew->pprev->nHeight + 1;
     }
     pindexNew->nTx = block.vtx.size();
-    pindexNew->nChainWork = (pindexNew->pprev ? pindexNew->pprev->nChainWork : 0) + pindexNew->GetBlockWork().getuint256();
+    pindexNew->nChainWork = (pindexNew->pprev ? pindexNew->pprev->nChainWork : 0) + pindexNew->GetBlockWork();
     pindexNew->nChainTx = (pindexNew->pprev ? pindexNew->pprev->nChainTx : 0) + pindexNew->nTx;
     pindexNew->nFile = pos.nFile;
     pindexNew->nDataPos = pos.nPos;
@@ -2565,7 +2565,7 @@ bool static LoadBlockIndexDB()
     BOOST_FOREACH(const PAIRTYPE(int, CBlockIndex*)& item, vSortedByHeight)
     {
         CBlockIndex* pindex = item.second;
-        pindex->nChainWork = (pindex->pprev ? pindex->pprev->nChainWork : 0) + pindex->GetBlockWork().getuint256();
+        pindex->nChainWork = (pindex->pprev ? pindex->pprev->nChainWork : 0) + pindex->GetBlockWork();
         pindex->nChainTx = (pindex->pprev ? pindex->pprev->nChainTx : 0) + pindex->nTx;
         if ((pindex->nStatus & BLOCK_VALID_MASK) >= BLOCK_VALID_TRANSACTIONS && !(pindex->nStatus & BLOCK_FAILED_MASK))
             setBlockIndexValid.insert(pindex);

--- a/src/main.h
+++ b/src/main.h
@@ -798,13 +798,13 @@ public:
         return (int64_t)nTime;
     }
 
-    CBigNum GetBlockWork() const
+    uint256 GetBlockWork() const
     {
         CBigNum bnTarget;
         bnTarget.SetCompact(nBits);
         if (bnTarget <= 0)
             return 0;
-        return (CBigNum(1)<<256) / (bnTarget+1);
+        return ((CBigNum(1)<<256) / (bnTarget+1)).getuint256();
     }
 
     bool CheckIndex() const

--- a/src/test/uint256_tests.cpp
+++ b/src/test/uint256_tests.cpp
@@ -1,3 +1,4 @@
+#include <boost/foreach.hpp>
 #include <boost/test/unit_test.hpp>
 #include <stdint.h>
 #include <sstream>
@@ -6,6 +7,7 @@
 #include <cmath>
 #include "uint256.h"
 #include <string>
+#include "bignum.h"
 #include "version.h"
 
 BOOST_AUTO_TEST_SUITE(uint256_tests)
@@ -627,6 +629,18 @@ BOOST_AUTO_TEST_CASE( getmaxcoverage ) // some more tests just to get 100% cover
     CHECKBITWISEOPERATOR(R1,~R2,|)
     CHECKBITWISEOPERATOR(R1,~R2,^)
     CHECKBITWISEOPERATOR(R1,~R2,&)
+}
+
+BOOST_AUTO_TEST_CASE(multiply) {
+    uint32_t factors[] = {0, 1, 16, 256, 257, 1000, 1000000, 16777216, 0xFFFFFFFFUL};
+    BOOST_FOREACH(uint32_t f, factors) {
+        BOOST_CHECK(R1L * f == (CBigNum(R1L) * f).getuint256());
+        BOOST_CHECK(R2L * f == (CBigNum(R2L) * f).getuint256());
+        BOOST_CHECK(ZeroL * f == (CBigNum(ZeroL) * f).getuint256());
+        BOOST_CHECK(MaxL * f == (CBigNum(MaxL) * f).getuint256());
+        BOOST_CHECK(OneL * f == (CBigNum(OneL) * f).getuint256());
+        BOOST_CHECK(HalfL * f == (CBigNum(HalfL) * f).getuint256());
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -178,6 +178,16 @@ public:
         return *this;
     }
 
+    base_uint& operator*=(uint32_t b32)
+    {
+        uint32_t carry = 0;
+        for (unsigned int i = 0; i < WIDTH; i++) {
+            uint64_t sum = carry + (uint64_t)pn[i]*b32;
+            pn[i] = sum & 0xFFFFFFFF;
+            carry = sum >> 32;
+        }
+        return *this;
+    }
 
     base_uint& operator++()
     {
@@ -477,6 +487,8 @@ inline const uint160 operator<<(const base_uint160& a, unsigned int shift)   { r
 inline const uint160 operator>>(const base_uint160& a, unsigned int shift)   { return uint160(a) >>= shift; }
 inline const uint160 operator<<(const uint160& a, unsigned int shift)        { return uint160(a) <<= shift; }
 inline const uint160 operator>>(const uint160& a, unsigned int shift)        { return uint160(a) >>= shift; }
+inline const uint160 operator*(const base_uint160& a, uint32_t b)            { return uint160(a) *= b; }
+inline const uint160 operator*(const uint160& a, uint32_t b)                 { return uint160(a) *= b; }
 
 inline const uint160 operator^(const base_uint160& a, const base_uint160& b) { return uint160(a) ^= b; }
 inline const uint160 operator&(const base_uint160& a, const base_uint160& b) { return uint160(a) &= b; }
@@ -589,6 +601,8 @@ inline const uint256 operator<<(const base_uint256& a, unsigned int shift)   { r
 inline const uint256 operator>>(const base_uint256& a, unsigned int shift)   { return uint256(a) >>= shift; }
 inline const uint256 operator<<(const uint256& a, unsigned int shift)        { return uint256(a) <<= shift; }
 inline const uint256 operator>>(const uint256& a, unsigned int shift)        { return uint256(a) >>= shift; }
+inline const uint256 operator*(const base_uint256& a, uint32_t b)            { return uint256(a) *= b; }
+inline const uint256 operator*(const uint256& a, uint32_t b)                 { return uint256(a) *= b; }
 
 inline const uint256 operator^(const base_uint256& a, const base_uint256& b) { return uint256(a) ^= b; }
 inline const uint256 operator&(const base_uint256& a, const base_uint256& b) { return uint256(a) &= b; }


### PR DESCRIPTION
Implement a simple multiplication operator in uint256, and use it for the few cases where we used to convert to CBigNum for this.

Tests are included that verify the behavior is identical to converting to CBigNum, doing the multiplication, and converting back.

Overall goal: reduce dependency on OpenSSL where possible in core code.
