### PR TITLE
Add 'hdderive' RPC, a generic BIP32 calculator

### DIFF
--- a/src/base58.h
+++ b/src/base58.h
@@ -403,14 +403,30 @@ public:
         SetData(Params().Base58Prefix(Type), vch, vch+Size);
     }
 
+    void SetString(const std::string &str) {
+        CBase58Data::SetString(str.c_str(), 4);
+    }
+
+    bool IsValid() const {
+        if (vchVersion != Params().Base58Prefix(Type))
+            return false;
+        if (vchData.size() != Size)
+            return false;
+        return true;
+    }
+
     K GetKey() {
         K ret;
-        ret.Decode(&vchData[0], &vchData[Size]);
+        ret.Decode(&vchData[0]);
         return ret;
     }
 
     CBitcoinExtKeyBase(const K &key) {
         SetKey(key);
+    }
+
+    CBitcoinExtKeyBase(const std::string &str) {
+        SetString(str);
     }
 
     CBitcoinExtKeyBase() {}

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -295,6 +295,7 @@ static const CRPCCommand vRPCCommands[] =
     { "lockunspent",            &lockunspent,            false,     false,      true },
     { "listlockunspent",        &listlockunspent,        false,     false,      true },
     { "settxfee",               &settxfee,               false,     false,      true },
+    { "hdderive",               &hdderive,               true,      true,       false },
 
     /* Wallet-enabled mining */
     { "getgenerate",            &getgenerate,            true,      false,      false },

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -156,6 +156,7 @@ extern json_spirit::Value walletlock(const json_spirit::Array& params, bool fHel
 extern json_spirit::Value encryptwallet(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value validateaddress(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value getinfo(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value hdderive(const json_spirit::Array& params, bool fHelp);
 
 extern json_spirit::Value getrawtransaction(const json_spirit::Array& params, bool fHelp); // in rcprawtransaction.cpp
 extern json_spirit::Value listunspent(const json_spirit::Array& params, bool fHelp);

--- a/src/test/Makefile.am
+++ b/src/test/Makefile.am
@@ -65,6 +65,7 @@ test_bitcoin_SOURCES = \
 if ENABLE_WALLET
 test_bitcoin_SOURCES += \
    accounting_tests.cpp \
+   bip32_tests.cpp \
    wallet_tests.cpp \
    rpc_wallet_tests.cpp
 endif


### PR DESCRIPTION
This adds a 'hdderive' RPC command, which allows arbitrary BIP32 chains/addresses to be computed.

It supports starting from a seed, or from an xpub/xprv specification, and computes for the provided root or any derivation thereof the depth, index, chaincode, public key, address, fingerprint, parent fingerprint, private key, extended public key, and extended private key.

Note that this does not add HD functionality to the wallet itself.
