### PR TITLE
Correct include path for MOC_DEFS

### DIFF
--- a/src/Makefile.include
+++ b/src/Makefile.include
@@ -12,7 +12,7 @@ LIBBITCOIN_CLI=$(top_builddir)/src/libbitcoin_cli.a
 LIBLEVELDB=$(top_builddir)/src/leveldb/libleveldb.a
 LIBMEMENV=$(top_builddir)/src/leveldb/libmemenv.a
 LIBBITCOINQT=$(top_builddir)/src/qt/libbitcoinqt.a
-MOC_DEFS=$(DEFS) -I$(top_srcdir)/src
+MOC_DEFS+=$(DEFS) -I$(top_srcdir)/src
 
 $(LIBBITCOIN):
 	$(MAKE) -C $(top_builddir)/src $(@F)


### PR DESCRIPTION
This was causing building on OS X to fail.
