### PR TITLE
build: fix MacOSX build after ec41342

### DIFF
--- a/src/Makefile.include
+++ b/src/Makefile.include
@@ -12,7 +12,6 @@ LIBBITCOIN_CLI=$(top_builddir)/src/libbitcoin_cli.a
 LIBLEVELDB=$(top_builddir)/src/leveldb/libleveldb.a
 LIBMEMENV=$(top_builddir)/src/leveldb/libmemenv.a
 LIBBITCOINQT=$(top_builddir)/src/qt/libbitcoinqt.a
-MOC_DEFS=$(DEFS) -I$(top_srcdir)/src
 
 $(LIBBITCOIN):
 	$(MAKE) -C $(top_builddir)/src $(@F)

--- a/src/m4/bitcoin_qt.m4
+++ b/src/m4/bitcoin_qt.m4
@@ -100,13 +100,13 @@ AC_DEFUN([BITCOIN_QT_CONFIGURE],[
   BITCOIN_QT_PATH_PROGS([LRELEASE], [lrelease-qt${bitcoin_qt_got_major_vers} lrelease${bitcoin_qt_got_major_vers} lrelease], $qt_bin_path)
   BITCOIN_QT_PATH_PROGS([LUPDATE], [lupdate-qt${bitcoin_qt_got_major_vers} lupdate${bitcoin_qt_got_major_vers} lupdate],$qt_bin_path, yes)
 
+  MOC_DEFS='-DHAVE_CONFIG_H -I$(top_srcdir)/src'
   case $host in
     *darwin*)
      BITCOIN_QT_CHECK([
-       MOC_DEFS="-DQ_OS_MAC"
+       MOC_DEFS="${MOC_DEFS} -DQ_OS_MAC"
        base_frameworks="-framework Foundation -framework ApplicationServices -framework AppKit"
        AX_CHECK_LINK_FLAG([[$base_frameworks]],[QT_LIBS="$QT_LIBS $base_frameworks"],[AC_MSG_ERROR(could not find base frameworks)])
-       AC_SUBST(MOC_DEFS)
      ])
     ;;
   esac
@@ -142,6 +142,7 @@ AC_DEFUN([BITCOIN_QT_CONFIGURE],[
   AC_SUBST(QT_TEST_INCLUDES)
   AC_SUBST(QT_TEST_LIBS)
   AC_SUBST(QT_SELECT, qt${bitcoin_qt_got_major_vers})
+  AC_SUBST(MOC_DEFS)
 ])
 
 dnl All macros below are internal and should _not_ be used from the main


### PR DESCRIPTION
Fix regression introduced in ec41342.

Also use a less ugly solution, by defining the value of `MOC_DEFS` in the configure script instead of `Makefile.include`.
