### PR TITLE
Updated configure.ac and build-unix.md to instruct about Ubuntu 13.10 and libboost1.54-all-dev error.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -395,7 +395,7 @@ LIBS="$TEMP_LIBS"
 fi
 
 if test x$boost_sleep != xyes; then
-  AC_MSG_ERROR(No working boost sleep implementation found)
+  AC_MSG_ERROR(No working boost sleep implementation found. If on ubuntu 13.10 with libboost1.54-all-dev remove libboost.1.54-all-dev and use libboost1.53-all-dev)
 fi
 
 BITCOIN_QT_INIT

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -68,6 +68,9 @@ for Ubuntu 12.04 and later:
 
  Ubuntu 12.04 and later have packages for libdb5.1-dev and libdb5.1++-dev,
  but using these will break binary wallet compatibility, and is not recommended.
+ 
+for Ubuntu 13.10: 
+        libboost1.54-all-dev will not work. Remove libboost1.54-all-dev and install libboost1.53-all-dev
 
 for other Ubuntu & Debian:
 


### PR DESCRIPTION
Updated configure.ac and build-unix.md to instruct about Ubuntu 13.10 and libboost1.54-all-dev error. If using Ubuntu 13.10 with libboost1.54-all-dev you must remove libboost1.54-all-dev and install libboost1.53-all-dev instead.
