### PR TITLE
Make gitian builds consistent across platforms

### DIFF
--- a/contrib/gitian-descriptors/README.md
+++ b/contrib/gitian-descriptors/README.md
@@ -39,7 +39,7 @@ Once you've got the right hardware and software:
     git pull
     cd ../gitian-builder
     git pull
-    ./bin/gbuild --commit bitcoin=HEAD ../bitcoin/contrib/gitian-descriptors/gitian.yml
+    ./bin/gbuild --commit bitcoin=HEAD ../bitcoin/contrib/gitian-descriptors/gitian-linux.yml
 
     # Build Win32 dependencies: (only needs to be done once, or when dependency versions change)
     ./bin/gbuild --commit bitcoin=HEAD ../bitcoin/contrib/gitian-descriptors/boost-win32.yml

--- a/contrib/gitian-descriptors/deps-linux.yml
+++ b/contrib/gitian-descriptors/deps-linux.yml
@@ -7,6 +7,7 @@ architectures:
 - "amd64"
 packages:
 - "unzip"
+- "zip"
 - "pkg-config"
 - "libtool"
 - "faketime"
@@ -59,4 +60,4 @@ script: |
   cd ../..
   #
   cd $STAGING
-  tar -czf $OUTDIR/bitcoin-deps-linux${GBUILD_BITS}-gitian-r1.tar.gz include lib bin host
+  zip -r $OUTDIR/bitcoin-deps-linux${GBUILD_BITS}-gitian-r1.zip include lib bin host

--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -27,8 +27,8 @@ remotes:
 - "url": "https://github.com/bitcoin/bitcoin.git"
   "dir": "bitcoin"
 files:
-- "bitcoin-deps-linux32-gitian-r1.tar.gz"
-- "bitcoin-deps-linux64-gitian-r1.tar.gz"
+- "bitcoin-deps-linux32-gitian-r1.zip"
+- "bitcoin-deps-linux64-gitian-r1.zip"
 script: |
   STAGING="$HOME/install"
   OPTFLAGS='-O2'
@@ -38,7 +38,7 @@ script: |
   #
   mkdir -p $STAGING
   cd $STAGING
-  tar xzfm ../build/bitcoin-deps-linux${GBUILD_BITS}-gitian-r1.tar.gz
+  unzip ../build/bitcoin-deps-linux${GBUILD_BITS}-gitian-r1.zip
   cd ../build
   #
   cd bitcoin

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -52,7 +52,7 @@ Release Process
 	wget 'https://protobuf.googlecode.com/files/protobuf-2.5.0.tar.bz2'
 	cd ..
 	./bin/gbuild ../bitcoin/contrib/gitian-descriptors/deps-linux.yml
-	mv build/out/*.tar.gz inputs/
+	mv build/out/bitcoin-deps-*.zip inputs/
 	./bin/gbuild ../bitcoin/contrib/gitian-descriptors/boost-win32.yml
 	mv build/out/boost-win32-*.zip inputs/
 	./bin/gbuild ../bitcoin/contrib/gitian-descriptors/deps-win32.yml
@@ -64,8 +64,8 @@ Release Process
 
  Build bitcoind and bitcoin-qt on Linux32, Linux64, and Win32:
   
-	./bin/gbuild --commit bitcoin=v${VERSION} ../bitcoin/contrib/gitian-descriptors/gitian.yml
-	./bin/gsign --signer $SIGNER --release ${VERSION} --destination ../gitian.sigs/ ../bitcoin/contrib/gitian-descriptors/gitian.yml
+	./bin/gbuild --commit bitcoin=v${VERSION} ../bitcoin/contrib/gitian-descriptors/gitian-linux.yml
+	./bin/gsign --signer $SIGNER --release ${VERSION} --destination ../gitian.sigs/ ../bitcoin/contrib/gitian-descriptors/gitian-linux.yml
 	pushd build/out
 	zip -r bitcoin-${VERSION}-linux-gitian.zip *
 	mv bitcoin-${VERSION}-linux-gitian.zip ../../../


### PR DESCRIPTION
Change Linux deps to use a zip archive rather than a gzipped tarball to
match win32
Rename Linux descriptor to gitian-linux.yml to match win32
