### PR TITLE
Added automake to the macports depdency list

### DIFF
--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -45,7 +45,7 @@ Instructions: MacPorts
 
 Installing the dependencies using MacPorts is very straightforward.
 
-    sudo port install boost db48@+no_java openssl miniupnpc autoconf pkgconfig
+    sudo port install boost db48@+no_java openssl miniupnpc autoconf pkgconfig automake
 
 ### Building `bitcoind`
 


### PR DESCRIPTION
as it was required to complete the autogen.sh step. It required aclocal (which isn't included in recent versions of xcode).
