### PR TITLE
qt: allow `walletpassphrase` in debug console without -server

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -21,6 +21,7 @@
 
 #include "init.h"
 #include "main.h"
+#include "rpcserver.h"
 #include "ui_interface.h"
 #include "util.h"
 #include "wallet.h"
@@ -227,6 +228,13 @@ void BitcoinCore::initialize()
     {
         LogPrintf("Running AppInit2 in thread\n");
         int rv = AppInit2(threadGroup);
+        if(rv)
+        {
+            /* Start a dummy RPC thread if no RPC thread is active yet
+             * to handle timeouts.
+             */
+            StartDummyRPCThread();
+        }
         emit initializeResult(rv);
     } catch (std::exception& e) {
         handleRunawayException(&e);

--- a/src/rpcprotocol.h
+++ b/src/rpcprotocol.h
@@ -49,7 +49,6 @@ enum RPCErrorCode
     RPC_INVALID_PARAMETER           = -8,  // Invalid, missing or duplicate parameter
     RPC_DATABASE_ERROR              = -20, // Database error
     RPC_DESERIALIZATION_ERROR       = -22, // Error parsing or validating structure in raw format
-    RPC_SERVER_NOT_STARTED          = -18, // RPC server was not started (StartRPCThreads() not called)
 
     // P2P client errors
     RPC_CLIENT_NOT_CONNECTED        = -9,  // Bitcoin is not connected

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -20,7 +20,14 @@
 
 class CBlockIndex;
 
+/* Start RPC threads */
 void StartRPCThreads();
+/* Alternative to StartRPCThreads for the GUI, when no server is
+ * used. The RPC thread in this case is only used to handle timeouts.
+ * If real RPC threads have already been started this is a no-op.
+ */
+void StartDummyRPCThread();
+/* Stop RPC threads */
 void StopRPCThreads();
 
 /*

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -1562,8 +1562,6 @@ Value walletpassphrase(const Array& params, bool fHelp)
 
     if (fHelp)
         return true;
-    if (!fServer)
-        throw JSONRPCError(RPC_SERVER_NOT_STARTED, "Error: RPC server was not started, use server=1 to change this.");
     if (!pwalletMain->IsCrypted())
         throw JSONRPCError(RPC_WALLET_WRONG_ENC_STATE, "Error: running with an unencrypted wallet, but walletpassphrase was called.");
 


### PR DESCRIPTION
Currently it is only possible to use `walletpassphrase` to unlock the wallet when bitcoin is started in server mode.

Almost everything that manipulates the wallet in the RPC console (for example, importprivkey) needs the wallet to be unlocked and is thus unusable without -server.

This is pretty unintuitive to me, and I'm sure it's even more confusing to users.

Solve this with a very minimal change: by making the GUI start a dummy RPC thread just to handle deadline timers.
