### PR TITLE
gitian: add optimization to win32 protobuf

### DIFF
--- a/contrib/gitian-descriptors/gitian-win32.yml
+++ b/contrib/gitian-descriptors/gitian-win32.yml
@@ -25,7 +25,7 @@ files:
 - "qt-win32-5.2.0-gitian-r1.zip"
 - "boost-win32-1.55.0-gitian-r6.zip"
 - "bitcoin-deps-win32-gitian-r10.zip"
-- "protobuf-win32-2.5.0-gitian-r3.zip"
+- "protobuf-win32-2.5.0-gitian-r4.zip"
 script: |
   #
   STAGING=$HOME/staging
@@ -37,7 +37,7 @@ script: |
   unzip ../build/qt-win32-5.2.0-gitian-r1.zip
   unzip ../build/boost-win32-1.55.0-gitian-r6.zip
   unzip ../build/bitcoin-deps-win32-gitian-r10.zip
-  unzip ../build/protobuf-win32-2.5.0-gitian-r3.zip
+  unzip ../build/protobuf-win32-2.5.0-gitian-r4.zip
   cd $HOME/build/
   #
   cd bitcoin

--- a/contrib/gitian-descriptors/protobuf-win32.yml
+++ b/contrib/gitian-descriptors/protobuf-win32.yml
@@ -18,6 +18,7 @@ script: |
   export TZ=UTC
   export INSTALLPREFIX=$OUTDIR/staging/deps
   export HOST=i686-w64-mingw32
+  OPTFLAGS="-O2"
   # Integrity Check
   echo "13bfc5ae543cf3aa180ac2485c0bc89495e3ae711fc6fab4f8ffe90dfb4bb677  protobuf-2.5.0.tar.bz2" | sha256sum -c
 
@@ -33,12 +34,12 @@ script: |
   cp src/protoc $INSTALLPREFIX/host/bin
   # Now recompile with the mingw cross-compiler:
   make distclean
-  ./configure --prefix=$INSTALLPREFIX --enable-shared=no --disable-dependency-tracking --with-protoc=$INSTALLPREFIX/host/bin/protoc --host=$HOST CXXFLAGS=-frandom-seed=11
+  ./configure --prefix=$INSTALLPREFIX --enable-shared=no --disable-dependency-tracking --with-protoc=$INSTALLPREFIX/host/bin/protoc --host=$HOST CXXFLAGS="-frandom-seed=11 ${OPTFLAGS}"
   make
   make install
   cd $INSTALLPREFIX
   export LD_PRELOAD=/usr/lib/faketime/libfaketime.so.1
   export FAKETIME=$REFERENCE_DATETIME
-  zip -r $OUTDIR/protobuf-win32-2.5.0-gitian-r3.zip include lib host
+  zip -r $OUTDIR/protobuf-win32-2.5.0-gitian-r4.zip include lib host
   unset LD_PRELOAD
   unset FAKETIME


### PR DESCRIPTION
When overriding CXXFLAGS, also provide optimization flags, otherwise we're building without optimization.
