### PR TITLE
test: Adds additional zero checks for setCompact

### DIFF
--- a/src/test/bignum_tests.cpp
+++ b/src/test/bignum_tests.cpp
@@ -135,6 +135,42 @@ BOOST_AUTO_TEST_CASE(bignum_SetCompact)
     BOOST_CHECK_EQUAL(num.GetHex(), "0");
     BOOST_CHECK_EQUAL(num.GetCompact(), 0U);
 
+    num.SetCompact(0x01003456);
+    BOOST_CHECK_EQUAL(num.GetHex(), "0");
+    BOOST_CHECK_EQUAL(num.GetCompact(), 0U);
+
+    num.SetCompact(0x02000056);
+    BOOST_CHECK_EQUAL(num.GetHex(), "0");
+    BOOST_CHECK_EQUAL(num.GetCompact(), 0U);
+
+    num.SetCompact(0x03000000);
+    BOOST_CHECK_EQUAL(num.GetHex(), "0");
+    BOOST_CHECK_EQUAL(num.GetCompact(), 0U);
+
+    num.SetCompact(0x04000000);
+    BOOST_CHECK_EQUAL(num.GetHex(), "0");
+    BOOST_CHECK_EQUAL(num.GetCompact(), 0U);
+
+    num.SetCompact(0x00923456);
+    BOOST_CHECK_EQUAL(num.GetHex(), "0");
+    BOOST_CHECK_EQUAL(num.GetCompact(), 0U);
+
+    num.SetCompact(0x01803456);
+    BOOST_CHECK_EQUAL(num.GetHex(), "0");
+    BOOST_CHECK_EQUAL(num.GetCompact(), 0U);
+
+    num.SetCompact(0x02800056);
+    BOOST_CHECK_EQUAL(num.GetHex(), "0");
+    BOOST_CHECK_EQUAL(num.GetCompact(), 0U);
+
+    num.SetCompact(0x03800000);
+    BOOST_CHECK_EQUAL(num.GetHex(), "0");
+    BOOST_CHECK_EQUAL(num.GetCompact(), 0U);
+    
+    num.SetCompact(0x04800000);
+    BOOST_CHECK_EQUAL(num.GetHex(), "0");
+    BOOST_CHECK_EQUAL(num.GetCompact(), 0U);
+
     num.SetCompact(0x01123456);
     BOOST_CHECK_EQUAL(num.GetHex(), "12");
     BOOST_CHECK_EQUAL(num.GetCompact(), 0x01120000U);


### PR DESCRIPTION
This pull request adds additional checks to the setCompact() method for bignums.

It covers various valid representations of zero (positive and negative).  It tests that the non-zero portions of the encoding are correctly ignored and that they are re-encode back to all zeros.

   Positive Numbers
    0x01003456 (1 byte  0x00)
    0x02000056 (2 bytes 0x0000)
    0x03000000 (3 bytes 0x000000)
    0x04000000 (4 bytes 0x000000_00)

   Negative Numbers
    0x00923456 -(0 bytes, so zero)
    0x01803456 -(1 byte  0x00)
    0x02800056 -(2 bytes 0x0000)
    0x03800000 -(3 bytes 0x000000)
    0x04800000 -(4 bytes 0x000000_00)
