### PR TITLE
Unit test fixes for AssertLockHeld / -DDEBUG_LOCKORDER

### DIFF
--- a/src/test/accounting_tests.cpp
+++ b/src/test/accounting_tests.cpp
@@ -34,6 +34,8 @@ BOOST_AUTO_TEST_CASE(acc_orderupgrade)
     CAccountingEntry ae;
     std::map<int64_t, CAccountingEntry> results;
 
+    LOCK(pwalletMain->cs_wallet);
+
     ae.strAccount = "";
     ae.nCreditDebit = 1;
     ae.nTime = 1333333333;

--- a/src/test/rpc_wallet_tests.cpp
+++ b/src/test/rpc_wallet_tests.cpp
@@ -2,6 +2,7 @@
 #include "rpcclient.h"
 
 #include "base58.h"
+#include "wallet.h"
 
 #include <boost/algorithm/string.hpp>
 #include <boost/test/unit_test.hpp>
@@ -12,10 +13,14 @@ using namespace json_spirit;
 extern Array createArgs(int nRequired, const char* address1=NULL, const char* address2=NULL);
 extern Value CallRPC(string args);
 
+extern CWallet* pwalletMain;
+
 BOOST_AUTO_TEST_SUITE(rpc_wallet_tests)
 
 BOOST_AUTO_TEST_CASE(rpc_addmultisig)
 {
+    LOCK(pwalletMain->cs_wallet);
+
     rpcfn_type addmultisig = tableRPC["addmultisigaddress"]->actor;
 
     // old, 65-byte-long:
@@ -55,6 +60,8 @@ BOOST_AUTO_TEST_CASE(rpc_wallet)
 {
     // Test RPC calls for various wallet statistics
     Value r;
+
+    LOCK(pwalletMain->cs_wallet);
 
     BOOST_CHECK_NO_THROW(CallRPC("listunspent"));
     BOOST_CHECK_THROW(CallRPC("listunspent string"), runtime_error);

--- a/src/test/wallet_tests.cpp
+++ b/src/test/wallet_tests.cpp
@@ -62,6 +62,8 @@ BOOST_AUTO_TEST_CASE(coin_selection_tests)
     CoinSet setCoinsRet, setCoinsRet2;
     int64_t nValueRet;
 
+    LOCK(wallet.cs_wallet);
+
     // test multiple times to allow for differences in the shuffle order
     for (int i = 0; i < RUN_TESTS; i++)
     {


### PR DESCRIPTION
Unit tests would fail if compiled with -DDEBUG_LOCKORDER (AssertLockHeld()
would fail; AssertLockHeld() relies on the DEBUG_LOCKORDER code to keep
track of locks held).

Fixed by LOCK'ing the wallet mutex in the unit tests that manipulate the
wallet.

This only changes the unit tests, so I plan on pulling as soon as pull-tester is happy.
