### PR TITLE
[Qt] minor receive tab improvements

### DIFF
--- a/src/qt/forms/receivecoinsdialog.ui
+++ b/src/qt/forms/receivecoinsdialog.ui
@@ -10,8 +10,23 @@
     <height>364</height>
    </rect>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,1">
    <item>
+   <widget class="QFrame" name="frame2">
+    <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+      </sizepolicy>
+    </property>
+    <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+    </property>
+    <property name="frameShadow">
+      <enum>QFrame::Sunken</enum>
+    </property>
+    <layout class="QVBoxLayout" name="verticalLayout_3">
+    <item>
     <layout class="QGridLayout" name="gridLayout">
      <item row="7" column="2">
       <widget class="QCheckBox" name="reuseAddress">
@@ -32,6 +47,9 @@
      </item>
      <item row="6" column="0">
       <widget class="QLabel" name="label_3">
+       <property name="toolTip">
+        <string>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</string>
+       </property>
        <property name="text">
         <string>&amp;Message:</string>
        </property>
@@ -46,7 +64,7 @@
      <item row="4" column="2">
       <widget class="QLineEdit" name="reqLabel">
        <property name="toolTip">
-        <string>An optional label to associate with the new receiving address</string>
+        <string>An optional label to associate with the new receiving address.</string>
        </property>
       </widget>
      </item>
@@ -66,6 +84,9 @@
      </item>
      <item row="4" column="0">
       <widget class="QLabel" name="label_2">
+       <property name="toolTip">
+        <string>An optional label to associate with the new receiving address.</string>
+       </property>
        <property name="text">
         <string>&amp;Label:</string>
        </property>
@@ -79,6 +100,9 @@
      </item>
      <item row="5" column="0">
       <widget class="QLabel" name="label">
+       <property name="toolTip">
+        <string>An optional amount to request. Leave this empty or zero to not request a specific amount.</string>
+       </property>
        <property name="text">
         <string>&amp;Amount:</string>
        </property>
@@ -103,10 +127,25 @@
        </property>
       </widget>
      </item>
-    </layout>
-   </item>
-   <item>
+    <item row="8" column="2">
     <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QPushButton" name="receiveButton">
+       <property name="minimumSize">
+        <size>
+         <width>150</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>&amp;Request payment</string>
+       </property>
+       <property name="icon">
+        <iconset resource="../bitcoin.qrc">
+         <normaloff>:/icons/receiving_addresses</normaloff>:/icons/receiving_addresses</iconset>
+       </property>
+      </widget>
+     </item>
      <item>
       <widget class="QPushButton" name="clearButton">
        <property name="sizePolicy">
@@ -146,24 +185,19 @@
        </property>
       </spacer>
      </item>
-     <item>
-      <widget class="QPushButton" name="receiveButton">
-       <property name="minimumSize">
-        <size>
-         <width>150</width>
-         <height>0</height>
-        </size>
-       </property>
+    </layout>
+     </item>
+     <item row="8" column="0">
+      <widget class="QLabel" name="label_7">
        <property name="text">
-        <string>&amp;Request payment</string>
-       </property>
-       <property name="icon">
-        <iconset resource="../bitcoin.qrc">
-         <normaloff>:/icons/receiving_addresses</normaloff>:/icons/receiving_addresses</iconset>
+        <string/>
        </property>
       </widget>
      </item>
     </layout>
+   </item>
+   </layout>
+   </widget>
    </item>
    <item>
     <spacer name="verticalSpacer_2">
@@ -173,7 +207,7 @@
      <property name="sizeHint" stdset="0">
       <size>
        <width>20</width>
-       <height>40</height>
+       <height>10</height>
       </size>
      </property>
     </spacer>
@@ -202,12 +236,15 @@
          </font>
         </property>
         <property name="text">
-         <string>Requested payments</string>
+         <string>Requested payments history</string>
         </property>
        </widget>
       </item>
       <item>
        <widget class="QTableView" name="recentRequestsView">
+        <property name="contextMenuPolicy">
+         <enum>Qt::CustomContextMenu</enum>
+        </property>
         <property name="sortingEnabled">
          <bool>true</bool>
         </property>

--- a/src/qt/forms/sendcoinsdialog.ui
+++ b/src/qt/forms/sendcoinsdialog.ui
@@ -657,19 +657,25 @@
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
-      <widget class="QPushButton" name="addButton">
+      <widget class="QPushButton" name="sendButton">
+       <property name="minimumSize">
+        <size>
+         <width>150</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="toolTip">
-        <string>Send to multiple recipients at once</string>
+        <string>Confirm the send action</string>
        </property>
        <property name="text">
-        <string>Add &amp;Recipient</string>
+        <string>S&amp;end</string>
        </property>
        <property name="icon">
         <iconset resource="../bitcoin.qrc">
-         <normaloff>:/icons/add</normaloff>:/icons/add</iconset>
+         <normaloff>:/icons/send</normaloff>:/icons/send</iconset>
        </property>
-       <property name="autoDefault">
-        <bool>false</bool>
+       <property name="default">
+        <bool>true</bool>
        </property>
       </widget>
      </item>
@@ -700,6 +706,36 @@
       </widget>
      </item>
      <item>
+      <widget class="QPushButton" name="addButton">
+       <property name="toolTip">
+        <string>Send to multiple recipients at once</string>
+       </property>
+       <property name="text">
+        <string>Add &amp;Recipient</string>
+       </property>
+       <property name="icon">
+        <iconset resource="../bitcoin.qrc">
+         <normaloff>:/icons/add</normaloff>:/icons/add</iconset>
+       </property>
+       <property name="autoDefault">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
       <layout class="QHBoxLayout" name="horizontalLayout_2">
        <property name="spacing">
         <number>3</number>
@@ -725,42 +761,6 @@
         </widget>
        </item>
       </layout>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QPushButton" name="sendButton">
-       <property name="minimumSize">
-        <size>
-         <width>150</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="toolTip">
-        <string>Confirm the send action</string>
-       </property>
-       <property name="text">
-        <string>S&amp;end</string>
-       </property>
-       <property name="icon">
-        <iconset resource="../bitcoin.qrc">
-         <normaloff>:/icons/send</normaloff>:/icons/send</iconset>
-       </property>
-       <property name="default">
-        <bool>true</bool>
-       </property>
-      </widget>
      </item>
     </layout>
    </item>

--- a/src/qt/receivecoinsdialog.cpp
+++ b/src/qt/receivecoinsdialog.cpp
@@ -14,6 +14,8 @@
 #include "addresstablemodel.h"
 #include "recentrequeststablemodel.h"
 
+#include <QAction>
+#include <QCursor>
 #include <QMessageBox>
 #include <QTextDocument>
 #include <QScrollBar>
@@ -31,6 +33,24 @@ ReceiveCoinsDialog::ReceiveCoinsDialog(QWidget *parent) :
     ui->showRequestButton->setIcon(QIcon());
     ui->removeRequestButton->setIcon(QIcon());
 #endif
+
+    // context menu actions
+    QAction *copyLabelAction = new QAction(tr("Copy label"), this);
+    QAction *copyMessageAction = new QAction(tr("Copy message"), this);
+    QAction *copyAmountAction = new QAction(tr("Copy amount"), this);
+
+    // context menu
+    contextMenu = new QMenu();
+    contextMenu->addAction(copyLabelAction);
+    contextMenu->addAction(copyMessageAction);
+    contextMenu->addAction(copyAmountAction);
+
+    // context menu signals
+    connect(ui->recentRequestsView, SIGNAL(customContextMenuRequested(QPoint)), this, SLOT(showMenu(QPoint)));
+    connect(copyLabelAction, SIGNAL(triggered()), this, SLOT(copyLabel()));
+    connect(copyMessageAction, SIGNAL(triggered()), this, SLOT(copyMessage()));
+    connect(copyAmountAction, SIGNAL(triggered()), this, SLOT(copyAmount()));
+
     connect(ui->clearButton, SIGNAL(clicked()), this, SLOT(clear()));
 }
 
@@ -163,4 +183,62 @@ void ReceiveCoinsDialog::on_removeRequestButton_clicked()
     // correct for selection mode ContiguousSelection
     QModelIndex firstIndex = selection.at(0);
     model->getRecentRequestsTableModel()->removeRows(firstIndex.row(), selection.length(), firstIndex.parent());
+}
+
+void ReceiveCoinsDialog::keyPressEvent(QKeyEvent *event)
+{
+    if (event->key() == Qt::Key_Return)
+    {
+        // press return -> submit form
+        if (ui->reqLabel->hasFocus() || ui->reqAmount->hasFocus() || ui->reqMessage->hasFocus())
+        {
+            event->ignore();
+            on_receiveButton_clicked();
+            return;
+        }
+    }
+
+    this->QDialog::keyPressEvent(event);
+}
+
+// copy column of selected row to clipboard
+void ReceiveCoinsDialog::copyColumnToClipboard(int column)
+{
+    if(!model || !model->getRecentRequestsTableModel() || !ui->recentRequestsView->selectionModel())
+        return;
+    QModelIndexList selection = ui->recentRequestsView->selectionModel()->selectedRows();
+    if(selection.empty())
+        return;
+    // correct for selection mode ContiguousSelection
+    QModelIndex firstIndex = selection.at(0);
+    GUIUtil::setClipboard(model->getRecentRequestsTableModel()->data(firstIndex.child(firstIndex.row(), column), Qt::EditRole).toString());
+}
+
+// context menu
+void ReceiveCoinsDialog::showMenu(const QPoint &point)
+{
+    if(!model || !model->getRecentRequestsTableModel() || !ui->recentRequestsView->selectionModel())
+        return;
+    QModelIndexList selection = ui->recentRequestsView->selectionModel()->selectedRows();
+    if(selection.empty())
+        return;
+    contextMenu->exec(QCursor::pos());
+}
+
+// context menu action: copy label
+void ReceiveCoinsDialog::copyLabel()
+{
+    copyColumnToClipboard(RecentRequestsTableModel::Label);
+}
+
+// context menu action: copy message
+void ReceiveCoinsDialog::copyMessage()
+{
+    copyColumnToClipboard(RecentRequestsTableModel::Message);
+}
+
+// context menu action: copy amount
+void ReceiveCoinsDialog::copyAmount()
+{
+    copyColumnToClipboard(RecentRequestsTableModel::Amount);
 }

--- a/src/qt/receivecoinsdialog.h
+++ b/src/qt/receivecoinsdialog.h
@@ -6,6 +6,9 @@
 #define RECEIVECOINSDIALOG_H
 
 #include <QDialog>
+#include <QKeyEvent>
+#include <QMenu>
+#include <QPoint>
 #include <QVariant>
 
 namespace Ui {
@@ -34,9 +37,14 @@ public slots:
     void reject();
     void accept();
 
+protected:
+    virtual void keyPressEvent(QKeyEvent *event);
+
 private:
     Ui::ReceiveCoinsDialog *ui;
     WalletModel *model;
+    QMenu *contextMenu;
+    void copyColumnToClipboard(int column);
 
 private slots:
     void on_receiveButton_clicked();
@@ -44,6 +52,10 @@ private slots:
     void on_removeRequestButton_clicked();
     void on_recentRequestsView_doubleClicked(const QModelIndex &index);
     void updateDisplayUnit();
+    void showMenu(const QPoint &);
+    void copyLabel();
+    void copyMessage();
+    void copyAmount();
 };
 
 #endif // RECEIVECOINSDIALOG_H

--- a/src/qt/recentrequeststablemodel.cpp
+++ b/src/qt/recentrequeststablemodel.cpp
@@ -75,7 +75,10 @@ QVariant RecentRequestsTableModel::data(const QModelIndex &index, int role) cons
                 return rec->recipient.message;
             }
         case Amount:
-            return BitcoinUnits::format(walletModel->getOptionsModel()->getDisplayUnit(), rec->recipient.amount);
+            if (rec->recipient.amount == 0 && role == Qt::DisplayRole)
+                return tr("(no amount)");
+            else
+                return BitcoinUnits::format(walletModel->getOptionsModel()->getDisplayUnit(), rec->recipient.amount);
         }
     }
     return QVariant();


### PR DESCRIPTION
- draw border around upper form
- align clear button with form elements
- set stretch on the Requested payments table in vertical layout.
  This is to have better looking and more useful behavior, when resizing/maximizing the window
- show tooltips also for the labels itself (label,amount,message)
- show (no amount) instead of 0.00, similar to (no label) and (no message)
- add keyboard support for pressing return.
  When upper form focused and return pressed -> submit form (Request payment)
- rename "Requested payments" to "Requested payments history"

@laanwj
What do you think about removing the "Requested payments" table from the front page and put it in a popup instead, by clicking a button "Requested payments history".
Currently the table looks very important, but its only a history, in case you want to look something up.
Also when adding the real payment request to the form, we need more space anyway...

Before:
![receive1](https://f.cloud.github.com/assets/2814559/2003390/26574e76-864d-11e3-859b-1ee367b8b0d8.png)

After:
![receive2](https://f.cloud.github.com/assets/2814559/2003391/2cace2fe-864d-11e3-9bec-6e9b87ae1ccf.png)
