### PR TITLE
Fix `getaddednodeinfo` RPC call with dns=false

### DIFF
--- a/src/rpcnet.cpp
+++ b/src/rpcnet.cpp
@@ -255,15 +255,17 @@ Value getaddednodeinfo(const Array& params, bool fHelp)
             throw JSONRPCError(RPC_CLIENT_NODE_NOT_ADDED, "Error: Node has not been added.");
     }
 
+    Array ret;
     if (!fDns)
     {
-        Object ret;
         BOOST_FOREACH(string& strAddNode, laddedNodes)
-            ret.push_back(Pair("addednode", strAddNode));
+        {
+            Object obj;
+            obj.push_back(Pair("addednode", strAddNode));
+            ret.push_back(obj);
+        }
         return ret;
     }
-
-    Array ret;
 
     list<pair<string, vector<CService> > > laddedAddreses(0);
     BOOST_FOREACH(string& strAddNode, laddedNodes)


### PR DESCRIPTION
The getaddednodeinfo RPC call, when invoked with the dns flag set to false, returns a malformed JSON object with duplicate keys.

Change this to return an array of objects with one key as shown in the help message.

Fixes #3581.
