### PR TITLE
[Qt] Fix coin control labels update

### DIFF
--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -516,6 +516,9 @@ void SendCoinsDialog::coinControlFeatureChanged(bool checked)
 
     if (!checked && model) // coin control features disabled
         CoinControlDialog::coinControl->SetNull();
+
+    if (checked)
+        coinControlUpdateLabels();
 }
 
 // Coin Control: button inputs -> show actual coin control dialog


### PR DESCRIPTION
When you start bitcoin without coin control and then enable it, the labels are not updated.
Also when disabling with labels shown and then enable again, the labels show wrong information.

So updating the labels whenever coin control is enabled is a good idea.
