### PR TITLE
Add check for valid keys in `importprivkey`

### DIFF
--- a/src/rpcdump.cpp
+++ b/src/rpcdump.cpp
@@ -101,9 +101,11 @@ Value importprivkey(const Array& params, bool fHelp)
     CBitcoinSecret vchSecret;
     bool fGood = vchSecret.SetString(strSecret);
 
-    if (!fGood) throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid private key");
+    if (!fGood) throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid private key encoding");
 
     CKey key = vchSecret.GetKey();
+    if (!key.IsValid()) throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Private key outside allowed range");
+
     CPubKey pubkey = key.GetPubKey();
     CKeyID vchAddress = pubkey.GetID();
     {


### PR DESCRIPTION
The base58 armoring was checked, but not the resulting private key, which could be out of range. Fix this by adding a check.

check errors due to wrong encoding

```
importprivkey foo
error: {"code":-5,"message":"Invalid private key encoding"}
```

=0x00....

```
importprivkey cMahea7zqjxrtgAbB7LSGbcQUr1uX1ojuat9jZodMN87J7g8rY9t
error: {"code":-5,"message":"Private key outside allowed range"}
```

=0xFF....

```
importprivkey cWALDjUu1tszsCBMjBjL4mhtjHDZMS5U52WHJ29iqqspZx2Er6J2
error: {"code":-5,"message":"Private key outside allowed range"}
```

=n-1

```
importprivkey cWALDjUu1tszsCBMjBjL4mhYj2wHUWYDR8Q8aSjLKzjkW5eBtpzu
(ok)
```

=n

```
importprivkey cWALDjUu1tszsCBMjBjL4mhYj2wHUWYDR8Q8aSjLKzjkWaXMLRaY
error: {"code":-5,"message":"Private key outside allowed range"}
```
