### PR TITLE
add header, which includes default values for certain parameters

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -40,6 +40,7 @@ BITCOIN_CORE_H = \
   core.h \
   crypter.h \
   db.h \
+  defaultvalues.h \
   hash.h \
   init.h \
   key.h \

--- a/src/defaultvalues.h
+++ b/src/defaultvalues.h
@@ -1,0 +1,30 @@
+// Copyright (c) 2009-2014 The Bitcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef DEFAULTVALUES_H
+#define DEFAULTVALUES_H
+
+#include <stdint.h>
+
+// This file covers our default values for command-line arguments that are used by core and GUI
+
+// -dbcache
+static const int nDefaultDbCache = 25;
+// max. -dbcache
+static const int nMaxDbCache = sizeof(void*) > 4 ? 4096 : 1024;
+
+// -par
+static const int nDefaultPar = 0;
+
+// -paytxfee
+static const int64_t nDefaultTransactionFee = 0;
+
+// -upnp
+#ifdef USE_UPNP
+static const bool fDefaultUpnp = true;
+#else
+static const bool fDefaultUpnp = false;
+#endif
+
+#endif // DEFAULTVALUES_H

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -12,6 +12,7 @@
 #include "addrman.h"
 #include "chainparams.h"
 #include "core.h"
+#include "defaultvalues.h"
 #include "ui_interface.h"
 
 #ifdef WIN32
@@ -1755,10 +1756,8 @@ void StartNode(boost::thread_group& threadGroup)
     else
         threadGroup.create_thread(boost::bind(&TraceThread<void (*)()>, "dnsseed", &ThreadDNSAddressSeed));
 
-#ifdef USE_UPNP
     // Map ports with UPnP
-    MapPort(GetBoolArg("-upnp", USE_UPNP));
-#endif
+    MapPort(GetBoolArg("-upnp", fDefaultUpnp));
 
     // Send and receive from sockets, accept connections
     threadGroup.create_thread(boost::bind(&TraceThread<void (*)()>, "net", &ThreadSocketHandler));

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -14,6 +14,7 @@
 #include "monitoreddatamapper.h"
 #include "optionsmodel.h"
 
+#include "defaultvalues.h"
 #include "netbase.h"
 
 #include <QDir>
@@ -33,7 +34,7 @@ OptionsDialog::OptionsDialog(QWidget *parent) :
     GUIUtil::restoreWindowGeometry("nOptionsDialogWindow", this->size(), this);
 
     /* Main elements init */
-    ui->databaseCache->setMaximum(sizeof(void*) > 4 ? 4096 : 1024);
+    ui->databaseCache->setMaximum(nMaxDbCache);
 
     /* Network elements init */
 #ifndef USE_UPNP

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -9,6 +9,7 @@
 #include "optionsmodel.h"
 
 #include "bitcoinunits.h"
+#include "defaultvalues.h"
 #include "guiutil.h"
 
 #include "init.h"
@@ -72,26 +73,22 @@ void OptionsModel::Init()
     // Main
 #ifdef ENABLE_WALLET
     if (!settings.contains("nTransactionFee"))
-        settings.setValue("nTransactionFee", 0);
+        settings.setValue("nTransactionFee", nDefaultTransactionFee);
 #endif
 
     if (!settings.contains("nDatabaseCache"))
-        settings.setValue("nDatabaseCache", 25);
+        settings.setValue("nDatabaseCache", nDefaultDbCache);
     if (!SoftSetArg("-dbcache", settings.value("nDatabaseCache").toString().toStdString()))
         strOverriddenByCommandLine += "-dbcache ";
 
     if (!settings.contains("nThreadsScriptVerif"))
-        settings.setValue("nThreadsScriptVerif", 0);
+        settings.setValue("nThreadsScriptVerif", nDefaultPar);
     if (!SoftSetArg("-par", settings.value("nThreadsScriptVerif").toString().toStdString()))
         strOverriddenByCommandLine += "-par ";
 
     // Network
     if (!settings.contains("fUseUPnP"))
-#ifdef USE_UPNP
-        settings.setValue("fUseUPnP", true);
-#else
-        settings.setValue("fUseUPnP", false);
-#endif	
+        settings.setValue("fUseUPnP", fDefaultUpnp);
     if (!SoftSetBoolArg("-upnp", settings.value("fUseUPnP").toBool()))
         strOverriddenByCommandLine += "-upnp ";
 

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -7,6 +7,7 @@
 
 #include "base58.h"
 #include "coincontrol.h"
+#include "defaultvalues.h"
 #include "net.h"
 
 #include <inttypes.h>
@@ -17,7 +18,7 @@
 using namespace std;
 
 // Settings
-int64_t nTransactionFee = 0;
+int64_t nTransactionFee = nDefaultTransactionFee;
 
 //////////////////////////////////////////////////////////////////////////////
 //
@@ -1534,7 +1535,6 @@ bool CWallet::SetAddressBook(const CTxDestination& address, const string& strNam
 
 bool CWallet::DelAddressBook(const CTxDestination& address)
 {
-
     AssertLockHeld(cs_wallet); // mapAddressBook
 
     if(fFileBacked)


### PR DESCRIPTION
- most of these are used in core and GUI, so it made sense to bring this
  together, as it removes the need to keep 2 places in sync
- also adds a new check to now set a -dbcache greater than what is
  allowed for x86 and x64 platforms
