### PR TITLE
doc: Add historical release notes

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -1,3 +1,3 @@
-(note: this is a temporary file, to be added-to by anybody, and deleted at
-release time)
+(note: this is a temporary file, to be added-to by anybody, and moved to
+release-notes at release time)
 

--- a/doc/release-notes/release-notes-0.3.12.md
+++ b/doc/release-notes/release-notes-0.3.12.md
@@ -1,0 +1,13 @@
+Version 0.3.12 is now available.
+
+Features:
+* json-rpc errors return a more standard error object. (thanks to Gavin Andresen)
+* json-rpc command line returns exit codes.
+* json-rpc "backupwallet" command.
+* Recovers and continues if an exception is caused by a message you received.  Other nodes shouldn't be able to cause an exception, and it hasn't happened before, but if a way is found to cause an exception, this would keep it from being used to stop network nodes.
+
+If you have json-rpc code that checks the contents of the error string, you need to change it to expect error objects of the form {"code":<number>,"message":<string>}, which is the standard.  See this thread:
+http://www.bitcoin.org/smf/index.php?topic=969.0
+
+Download:
+http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.3.12/

--- a/doc/release-notes/release-notes-0.3.13.md
+++ b/doc/release-notes/release-notes-0.3.13.md
@@ -1,0 +1,26 @@
+Version 0.3.13 is now available.  You should upgrade to prevent potential problems with 0/unconfirmed transactions.  Note: 0.3.13 prevents problems if you haven't already spent a 0/unconfirmed transaction, but if that already happened, you need 0.3.13.2.
+
+Changes:
+* Don't count or spend payments until they have 1 confirmation.
+* Internal version number from 312 to 31300.
+* Only accept transactions sent by IP address if -allowreceivebyip is specified.
+* Dropped DB_PRIVATE Berkeley DB flag.
+* Fix problem sending the last cent with sub-cent fractional change.
+* Auto-detect whether to use 128-bit 4-way SSE2 on Linux.
+Gavin Andresen:
+* Option -rpcallowip= to accept json-rpc connections from another machine.
+* Clean shutdown on SIGTERM on Linux.
+
+Download:
+http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.3.13/
+
+(Thanks Laszlo for the Mac OSX build!)
+
+Note:
+The SSE2 auto-detect in the Linux 64-bit version doesn't work with AMD in 64-bit mode.  Please try this instead and let me know if it gets it right:
+http://www.bitcoin.org/download/bitcoin-0.3.13.1-specialbuild-linux64.tar.gz
+
+You can still control the SSE2 use manually with -4way and -4way=0.
+
+Version 0.3.13.2 (SVN rev 161) has improvements for the case where you already had 0/unconfirmed transactions that you might have already spent.  Here's a Windows build of it:
+http://www.bitcoin.org/download/bitcoin-0.3.13.2-win32-setup.exe

--- a/doc/release-notes/release-notes-0.3.14.md
+++ b/doc/release-notes/release-notes-0.3.14.md
@@ -1,0 +1,11 @@
+Version 0.3.14 is now available
+http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.3.14/
+
+Changes:
+* Key pool feature for safer wallet backup
+Gavin Andresen:
+* TEST network mode with switch -testnet
+* Option to use SSL for JSON-RPC connections on unix/osx
+* validateaddress RPC command
+eurekafag:
+* Russian translation

--- a/doc/release-notes/release-notes-0.3.15.md
+++ b/doc/release-notes/release-notes-0.3.15.md
@@ -1,0 +1,6 @@
+* paytxfee switch is now per KB, so it adds the correct fee for large transactions
+* sending avoids using coins with less than 6 confirmations if it can
+* BitcoinMiner processes transactions in priority order based on age of dependencies
+* make sure generation doesn't start before block 74000 downloaded
+* bugfixes by Dean Gores
+* testnet, keypoololdest and paytxfee added to getinfo

--- a/doc/release-notes/release-notes-0.3.16.md
+++ b/doc/release-notes/release-notes-0.3.16.md
@@ -1,0 +1,1 @@
+Never released.

--- a/doc/release-notes/release-notes-0.3.17.md
+++ b/doc/release-notes/release-notes-0.3.17.md
@@ -1,0 +1,12 @@
+Version 0.3.17 is now available.
+
+Changes:
+* new getwork, thanks m0mchil
+* added transaction fee setting in UI options menu
+* free transaction limits
+* sendtoaddress returns transaction id instead of "sent"
+* getaccountaddress <account>
+
+The UI transaction fee setting was easy since it was still there from 0.1.5 and all I had to do was re-enable it.
+
+The accounts-based commands: move, sendfrom and getbalance <account> will be in the next release.  We still have some more changes to make first.

--- a/doc/release-notes/release-notes-0.3.18.md
+++ b/doc/release-notes/release-notes-0.3.18.md
@@ -1,0 +1,11 @@
+Changes:
+* Fixed a wallet.dat compatibility problem if you downgraded from 0.3.17 and then upgraded again
+* IsStandard() check to only include known transaction types in blocks
+* Jgarzik's optimisation to speed up the initial block download a little
+
+The main addition in this release is the Accounts-Based JSON-RPC commands that Gavin's been working on (more details at http://www.bitcoin.org/smf/index.php?topic=1886.0).  
+* getaccountaddress
+* sendfrom
+* move
+* getbalance
+* listtransactions

--- a/doc/release-notes/release-notes-0.3.19.md
+++ b/doc/release-notes/release-notes-0.3.19.md
@@ -1,0 +1,9 @@
+There's more work to do on DoS, but I'm doing a quick build of what I have so far in case it's needed, before venturing into more complex ideas.  The build for this is version 0.3.19.
+
+- Added some DoS controls
+As Gavin and I have said clearly before, the software is not at all resistant to DoS attack.  This is one improvement, but there are still more ways to attack than I can count.  
+
+I'm leaving the -limitfreerelay part as a switch for now and it's there if you need it.
+
+- Removed "safe mode" alerts
+"safe mode" alerts was a temporary measure after the 0.3.9 overflow bug.  We can say all we want that users can just run with "-disablesafemode", but it's better just not to have it for the sake of appearances.  It was never intended as a long term feature.  Safe mode can still be triggered by seeing a longer (greater total PoW) invalid block chain.

--- a/doc/release-notes/release-notes-0.3.20.1.md
+++ b/doc/release-notes/release-notes-0.3.20.1.md
@@ -1,0 +1,1 @@
+Never released or release notes were lost.

--- a/doc/release-notes/release-notes-0.3.20.2.md
+++ b/doc/release-notes/release-notes-0.3.20.2.md
@@ -1,0 +1,17 @@
+The maxsendbuffer bug (0.3.20.1 clients not being able to download the block chain from other 0.3.20.1 clients) was only going to get
+worse as people upgraded, so I cherry-picked the bug fix and created a minor release yesterday.
+
+The Amazon Machine Images I used to do the builds are available:
+
+  ami-38a05251   Bitcoin-v0.3.20.2 Mingw    (Windows; Administrator password 'bitcoin development')
+  ami-30a05259   Bitcoin_0.3.20.2 Linux32
+  ami-8abc4ee3   Bitcoin_0.3.20.2 Linux64
+
+(mac build will be done soon)
+
+If you have already downloaded version 0.3.20.1, please either add this to your bitcoin.conf file:
+
+  maxsendbuffer=10000
+  maxreceivebuffer=10000
+
+... or download the new version.

--- a/doc/release-notes/release-notes-0.3.20.md
+++ b/doc/release-notes/release-notes-0.3.20.md
@@ -1,0 +1,22 @@
+Please checkout the git integration branch from:
+
+https://github.com/bitcoin/bitcoin
+
+... and help test.  The new features that need testing are:
+
+* -nolisten : https://github.com/bitcoin/bitcoin/pull/11
+* -rescan : scan block chain for missing wallet transactions
+* -printtoconsole : https://github.com/bitcoin/bitcoin/pull/37
+* RPC gettransaction details : https://github.com/bitcoin/bitcoin/pull/24
+* listtransactions new features : https://github.com/bitcoin/bitcoin/pull/10
+
+Bug fixes that also need testing:
+
+* -maxconnections= : https://github.com/bitcoin/bitcoin/pull/42
+* RPC listaccounts minconf : https://github.com/bitcoin/bitcoin/pull/27
+* RPC move, add time to output : https://github.com/bitcoin/bitcoin/pull/21
+* ...and several improvements to --help output.
+
+This needs more testing on Windows!  Please drop me a quick private message, email, or IRC message if you are able to do some testing.  If you find bugs, please open an issue at:
+
+https://github.com/bitcoin/bitcoin/issues

--- a/doc/release-notes/release-notes-0.3.21.md
+++ b/doc/release-notes/release-notes-0.3.21.md
@@ -1,0 +1,20 @@
+Binaries for Bitcoin version 0.3.21 are available at:
+  https://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.3.21/
+
+Changes and new features from the 0.3.20 release include:
+
+* Universal Plug and Play support.  Enable automatic opening of a port for incoming connections by running bitcoin or bitcoind with the - -upnp=1 command line switch or using the Options dialog box.
+
+* Support for full-precision bitcoin amounts.  You can now send, and bitcoin will display, bitcoin amounts smaller than 0.01.  However, sending fewer than 0.01 bitcoins still requires a 0.01 bitcoin fee (so you can send 1.0001 bitcoins without a fee, but you will be asked to pay a fee if you try to send 0.0001).
+
+* A new method of finding bitcoin nodes to connect with, via DNS A records. Use the -dnsseed option to enable.
+
+For developers, changes to bitcoin's remote-procedure-call API:
+
+* New rpc command "sendmany" to send bitcoins to more than one address in a single transaction.
+
+* Several bug fixes, including a serious intermittent bug that would sometimes cause bitcoind to stop accepting rpc requests. 
+
+* -logtimestamps option, to add a timestamp to each line in debug.log.
+
+* Immature blocks (newly generated, under 120 confirmations) are now shown in listtransactions.

--- a/doc/release-notes/release-notes-0.3.22.md
+++ b/doc/release-notes/release-notes-0.3.22.md
@@ -1,0 +1,16 @@
+Download URL: https://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.3.22/
+
+This is largely a bugfix and TX fee schedule release.  We also hope to make 0.3.23 a quick release, to fix problems that the network has seen due to explosive growth in the past week.
+
+Notable changes:
+* Client will accept and relay TX's with 0.0005 BTC fee schedule (users still pay 0.01 BTC per kb, until next version)
+* Non-standard transactions accepted on testnet
+* Source code tree reorganized (prep for autotools build)
+* Remove "Generate Coins" option from GUI, and remove 4way SSE miner.  Internal reference CPU miner remains available, but users are directed to external miners for best hash production.
+* IRC is overflowing.  Client now bootstraps to channels #bitcoin00 - #bitcoin99
+* DNS names now may be used with -addnode, -connect (requires -dns to enable)
+
+RPC changes:
+* 'listtransactions' adds 'from' param, for range queries
+* 'move' may take account balances negative
+* 'settxfee' added, to manually set TX fee

--- a/doc/release-notes/release-notes-0.3.23.md
+++ b/doc/release-notes/release-notes-0.3.23.md
@@ -1,0 +1,10 @@
+Win32, Linux, MacOSX and source releases for bitcoin v0.3.23 have been uploaded to
+https://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.3.23/
+
+This is another quick bugfix release, trying to deal with the influx of new bitcoin users.
+
+Main items of note:
+
+* P2P connect-to-node logic changed to reduce timeout a bit.  The network saw a huge influx of new users, who do not permit incoming connections.  This change is a short-term hack, to more quickly hunt for useful P2P connections.  Better "leaf node" logic is in the works, but this should let us limp along until then.  One may use -upnp to properly forward ports, and help the network.
+* Transaction fee reduced to 0.0005 for new transactions
+* Client will relay transactions with fees as low as 0.0001 BTC

--- a/doc/release-notes/release-notes-0.3.24.md
+++ b/doc/release-notes/release-notes-0.3.24.md
@@ -1,0 +1,20 @@
+Bitcoin v0.3.24 is now available for download at
+https://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.3.24/
+
+This is another bug fix release.  We had hoped to have wallet encryption ready for release, but more urgent fixes for existing clients were needed -- most notably block download problems were getting severe.  Wallet encryption is ready for testing at https://github.com/bitcoin/bitcoin/pull/352 for the git-savvy, and hopefully will follow shortly in the next release, v0.4.
+
+Notable fixes in v0.3.24, and the main reasons for this release:
+
+F1) Block downloads were failing or taking unreasonable amounts of time to complete, because the increased size of the block chain was bumping up against some earlier buffer-size DoS limits.
+
+F2) Fix crash caused by loss/lack of network connection.
+
+Notable changes in v0.3.24:
+
+C1) DNS seeding enabled by default.
+
+C2) UPNP enabled by default in the GUI client.  The percentage of bitcoin clients that accept incoming connections is quite small, and that is a problem.  This should help.  bitcoind, and unofficial builds, are unchanged (though we encourage use of "-upnp" to help the network!)
+
+C3) Initial unit testing framework.  Bitcoin sorely needs automated tests, and this is a beginning.  Contributions welcome.
+
+C4) Internal wallet code cleanup.  While invisible to an end user, this change provides the basis for v0.4's wallet encryption.

--- a/doc/release-notes/release-notes-0.4.0.md
+++ b/doc/release-notes/release-notes-0.4.0.md
@@ -1,0 +1,70 @@
+Bitcoin version 0.4.0 is now available for download at:
+http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.4.0/
+
+The main feature in this release is wallet private key encryption;
+you can set a passphrase that must be entered before sending coins.
+See below for more information; if you decide to encrypt your wallet,
+WRITE DOWN YOUR PASSPHRASE AND PUT IT IN A SECURE LOCATION. If you
+forget or lose your wallet passphrase, you lose your bitcoins.
+Previous versions of bitcoin are unable to read encrypted wallets,
+and will crash on startup if the wallet is encrypted.
+
+Also note: bitcoin version 0.4 uses a newer version of Berkeley DB
+(bdb version 4.8) than previous versions (bdb 4.7). If you upgrade
+to version 0.4 and then revert back to an earlier version of bitcoin
+the it may be unable to start because bdb 4.7 cannot read bdb 4.8
+"log" files.
+
+
+Notable bug fixes from version 0.3.24:
+
+Fix several bitcoin-becomes-unresponsive bugs due to multithreading
+deadlocks.
+
+Optimize database writes for large (lots of inputs) transactions
+(fixes a potential denial-of-service attack)
+
+
+Wallet Encryption
+
+Bitcoin supports native wallet encryption so that people who steal your
+wallet file don't automatically get access to all of your Bitcoins.
+In order to enable this feature, choose "Encrypt Wallet" from the
+Options menu.  You will be prompted to enter a passphrase, which
+will be used as the key to encrypt your wallet and will be needed
+every time you wish to send Bitcoins.  If you lose this passphrase,
+you will lose access to spend all of the bitcoins in your wallet,
+no one, not even the Bitcoin developers can recover your Bitcoins.
+This means you are responsible for your own security, store your
+passphrase in a secure location and do not forget it.
+
+Remember that the encryption built into bitcoin only encrypts the
+actual keys which are required to send your bitcoins, not the full
+wallet.  This means that someone who steals your wallet file will
+be able to see all the addresses which belong to you, as well as the
+relevant transactions, you are only protected from someone spending
+your coins.
+
+It is recommended that you backup your wallet file before you
+encrypt your wallet.  To do this, close the Bitcoin client and
+copy the wallet.dat file from ~/.bitcoin/ on Linux, /Users/(user
+name)/Application Support/Bitcoin/ on Mac OSX, and %APPDATA%/Bitcoin/
+on Windows (that is /Users/(user name)/AppData/Roaming/Bitcoin on
+Windows Vista and 7 and /Documents and Settings/(user name)/Application
+Data/Bitcoin on Windows XP).  Once you have copied that file to a
+safe location, reopen the Bitcoin client and Encrypt your wallet.
+If everything goes fine, delete the backup and enjoy your encrypted
+wallet.  Note that once you encrypt your wallet, you will never be
+able to go back to a version of the Bitcoin client older than 0.4.
+
+Keep in mind that you are always responsible for your own security.
+All it takes is a slightly more advanced wallet-stealing trojan which
+installs a keylogger to steal your wallet passphrase as you enter it
+in addition to your wallet file and you have lost all your Bitcoins.
+Wallet encryption cannot keep you safe if you do not practice
+good security, such as running up-to-date antivirus software, only
+entering your wallet passphrase in the Bitcoin client and using the
+same passphrase only as your wallet passphrase.
+
+See the doc/README file in the bitcoin source for technical details
+of wallet encryption.

--- a/doc/release-notes/release-notes-0.4.1.md
+++ b/doc/release-notes/release-notes-0.4.1.md
@@ -1,0 +1,38 @@
+Bitcoin version 0.4.1 is now available for download at:
+http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.4.1/
+
+This is a bugfix only release based on 0.4.0.
+
+Please report bugs by replying to this forum thread.
+
+MAJOR BUG FIX  (CVE-2011-4447)
+
+The wallet encryption feature introduced in Bitcoin version 0.4.0 did not sufficiently secure the private keys. An attacker who
+managed to get a copy of your encrypted wallet.dat file might be able to recover some or all of the unencrypted keys and steal the
+associated coins.
+
+If you have a previously encrypted wallet.dat, the first time you run wxbitcoin or bitcoind the wallet will be rewritten, Bitcoin will
+shut down, and you will be prompted to restart it to run with the new, properly encrypted file.
+
+If you had a previously encrypted wallet.dat that might have been copied or stolen (for example, you backed it up to a public
+location) you should send all of your bitcoins to yourself using a new bitcoin address and stop using any previously generated addresses.
+
+Wallets encrypted with this version of Bitcoin are written properly.
+
+Technical note: the encrypted wallet's 'keypool' will be regenerated the first time you request a new bitcoin address; to be certain that the
+new private keys are properly backed up you should:
+
+1. Run Bitcoin and let it rewrite the wallet.dat file
+
+2. Run it again, then ask it for a new bitcoin address.
+wxBitcoin: new address visible on main window
+bitcoind: run the 'walletpassphrase' RPC command to unlock the wallet,  then run the 'getnewaddress' RPC command.
+
+3. If your encrypted wallet.dat may have been copied or stolen, send all of your bitcoins to the new bitcoin address.
+
+4. Shut down Bitcoin, then backup the wallet.dat file.
+IMPORTANT: be sure to request a new bitcoin address before backing up, so that the 'keypool' is regenerated and backed up.
+
+"Security in depth" is always a good idea, so choosing a secure location for the backup and/or encrypting the backup before uploading it is recommended. And as in previous releases, if your machine is infected by malware there are several ways an attacker might steal your bitcoins.
+
+Thanks to Alan Reiner (etotheipi) for finding and reporting this bug.

--- a/doc/release-notes/release-notes-0.4.2.md
+++ b/doc/release-notes/release-notes-0.4.2.md
@@ -1,0 +1,1 @@
+Never released or release notes were lost.

--- a/doc/release-notes/release-notes-0.4.3.md
+++ b/doc/release-notes/release-notes-0.4.3.md
@@ -1,0 +1,21 @@
+bitcoind version 0.4.3 is now available for download at:
+http://luke.dashjr.org/programs/bitcoin/files/bitcoind-0.4.3/ (until Gavin uploads to SourceForge)
+
+This is a bugfix-only release based on 0.4.0.
+
+Please note that the wxBitcoin GUI client is no longer maintained nor supported. If someone would like to step up to maintain this, they should contact Luke-Jr.
+
+Please report bugs for the daemon only using the issue tracker at github:
+https://github.com/bitcoin/bitcoin/issues
+
+Stable source code is hosted at Gitorious:
+http://gitorious.org/bitcoin/bitcoind-stable/archive-tarball/v0.4.3#.tar.gz
+
+BUG FIXES
+
+Cease locking memory used by non-sensitive information (this caused a huge performance hit on some platforms, especially noticable during initial blockchain download).
+Fixed some address-handling deadlocks (client freezes).
+No longer accept inbound connections over the internet when Bitcoin is being used with Tor (identity leak).
+Use the correct base transaction fee of 0.0005 BTC for accepting transactions into mined blocks (since 0.4.0, it was incorrectly accepting 0.0001 BTC which was only meant to be relayed).
+Add new DNS seeds (maintained by Pieter Wuille and Luke Dashjr).
+

--- a/doc/release-notes/release-notes-0.4.4.md
+++ b/doc/release-notes/release-notes-0.4.4.md
@@ -1,0 +1,30 @@
+Bitcoin version 0.4.4 is now available for download at:
+http://luke.dashjr.org/programs/bitcoin/files/bitcoind-0.4.4/
+
+This is a bugfix-only release based on 0.4.0.
+
+Please note that the wxBitcoin GUI client is no longer maintained nor supported. If someone would like to step up to maintain this, they should contact Luke-Jr.
+
+Please report bugs for the daemon only using the issue tracker at github:
+https://github.com/bitcoin/bitcoin/issues
+
+Stable source code is hosted at Gitorious:
+http://gitorious.org/bitcoin/bitcoind-stable/archive-tarball/v0.4.4#.tar.gz
+
+BUG FIXES
+
+Limit the number of orphan transactions stored in memory, to prevent a potential denial-of-service attack by flooding orphan transactions. Also never store invalid transactions at all.
+Fix possible buffer overflow on systems with very long application data paths. This is not exploitable.
+Resolved multiple bugs preventing long-term unlocking of encrypted wallets (issue #922).
+Only send local IP in "version" messages if it is globally routable (ie, not private), and try to get such an IP from UPnP if applicable.
+Reannounce UPnP port forwards every 20 minutes, to workaround routers expiring old entries, and allow the -upnp option to override any stored setting.
+Various memory leaks and potential null pointer deferences have been
+fixed.
+Several shutdown issues have been fixed.
+Check that keys stored in the wallet are valid at startup, and if not,
+report corruption.
+Various build fixes.
+If no password is specified to bitcoind, recommend a secure password.
+Update hard-coded fallback seed nodes, choosing recent ones with long uptime and versions at least 0.4.0.
+Add checkpoint at block 168,000.
+

--- a/doc/release-notes/release-notes-0.4.5.md
+++ b/doc/release-notes/release-notes-0.4.5.md
@@ -1,0 +1,1 @@
+Never released or release notes were lost.

--- a/doc/release-notes/release-notes-0.4.6.md
+++ b/doc/release-notes/release-notes-0.4.6.md
@@ -1,0 +1,37 @@
+bitcoind version 0.4.6 is now available for download at:
+Windows: installer | zip (sig)
+Source: tar.gz
+bitcoind and Bitcoin-Qt version 0.6.0.7 are also tagged in git, but it is recommended to upgrade to 0.6.1.
+
+These are bugfix-only releases.
+
+Please report bugs by replying to this forum thread. Note that the 0.4.x wxBitcoin GUI client is no longer maintained nor supported. If someone would like to step up to maintain this, they should contact Luke-Jr.
+
+BUG FIXES
+
+Version 0.6.0 allowed importing invalid "private keys", which would be unspendable; 0.6.0.7 will now verify the private key is valid, and refuse to import an invalid one
+Verify status of encrypt/decrypt calls to detect failed padding
+Check blocks for duplicate transactions earlier. Fixes #1167
+Upgrade Windows builds to OpenSSL 1.0.1b
+Set label when selecting an address that already has a label. Fixes #1080 (Bitcoin-Qt)
+JSON-RPC listtransactions's from/count handling is now fixed
+Optimize and fix multithreaded access, when checking whether we already know about transactions
+Fix potential networking deadlock
+Proper support for Growl 1.3 notifications
+Display an error, rather than crashing, if encoding a QR Code failed (0.6.0.7)
+Don't erroneously set "Display addresses" for users who haven't explicitly enabled it (Bitcoin-Qt)
+Some non-ASCII input in JSON-RPC expecting hexadecimal may have been misinterpreted rather than rejected
+Missing error condition checking added
+Do not show green tick unless all known blocks are downloaded. Fixes #921 (Bitcoin-Qt)
+Increase time ago of last block for "up to date" status from 30 to 90 minutes
+Show a message box when runaway exception happens (Bitcoin-Qt)
+Use a messagebox to display the error when -server is provided without providing a rpc password
+Show error message instead of exception crash when unable to bind RPC port (Bitcoin-Qt)
+Correct sign message bitcoin address tooltip. Fixes #1050 (Bitcoin-Qt)
+Removed "(no label)" from QR Code dialog titlebar if we have no label (0.6.0.7)
+Removed an ugly line break in tooltip for mature transactions (0.6.0.7)
+Add missing tooltip and key shortcut in settings dialog (part of #1088) (Bitcoin-Qt)
+Work around issue in boost::program_options that prevents from compiling in clang
+Fixed bugs occurring only on platforms with unsigned characters (such as ARM).
+Rename make_windows_icon.py to .sh as it is a shell script. Fixes #1099 (Bitcoin-Qt)
+Various trivial internal corrections to types used for counting/size loops and warnings

--- a/doc/release-notes/release-notes-0.5.0.md
+++ b/doc/release-notes/release-notes-0.5.0.md
@@ -1,0 +1,70 @@
+Bitcoin version 0.5.0 is now available for download at:
+http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.5.0/
+
+The major change for this release is a completely new graphical interface that uses the Qt user interface toolkit.
+
+This release include German, Spanish, Spanish-Castilian, Norwegian and Dutch translations. More translations are welcome; join the project at Transifex if you can help:
+https://www.transifex.net/projects/p/bitcoin/
+
+Please report bugs using the issue tracker at github:
+https://github.com/bitcoin/bitcoin/issues
+
+For Ubuntu users, there is a new ppa maintained by Matt Corallo which you can add to your system so that it will automatically keep bitcoin up-to-date.  Just type "sudo apt-add-repository ppa:bitcoin/bitcoin" in your terminal, then install the bitcoin-qt package.
+
+MAJOR BUG FIX  (CVE-2011-4447)
+
+The wallet encryption feature introduced in Bitcoin version 0.4.0 did not sufficiently secure the private keys. An attacker who
+managed to get a copy of your encrypted wallet.dat file might be able to recover some or all of the unencrypted keys and steal the
+associated coins.
+
+If you have a previously encrypted wallet.dat, the first time you run bitcoin-qt or bitcoind the wallet will be rewritten, Bitcoin will
+shut down, and you will be prompted to restart it to run with the new, properly encrypted file.
+
+If you had a previously encrypted wallet.dat that might have been copied or stolen (for example, you backed it up to a public
+location) you should send all of your bitcoins to yourself using a new bitcoin address and stop using any previously generated addresses.
+
+Wallets encrypted with this version of Bitcoin are written properly.
+
+Technical note: the encrypted wallet's 'keypool' will be regenerated the first time you request a new bitcoin address; to be certain that the
+new private keys are properly backed up you should:
+
+1. Run Bitcoin and let it rewrite the wallet.dat file
+
+2. Run it again, then ask it for a new bitcoin address.
+Bitcoin-Qt: Address Book, then New Address...
+bitcoind: run the 'walletpassphrase' RPC command to unlock the wallet,  then run the 'getnewaddress' RPC command.
+
+3. If your encrypted wallet.dat may have been copied or stolen, send  all of your bitcoins to the new bitcoin address.
+
+4. Shut down Bitcoin, then backup the wallet.dat file.
+IMPORTANT: be sure to request a new bitcoin address before backing up, so that the 'keypool' is regenerated and backed up.
+
+"Security in depth" is always a good idea, so choosing a secure location for the backup and/or encrypting the backup before uploading it is recommended. And as in previous releases, if your machine is infected by malware there are several ways an attacker might steal your bitcoins.
+
+Thanks to Alan Reiner (etotheipi) for finding and reporting this bug.
+
+MAJOR GUI CHANGES
+
+"Splash" graphics at startup that show address/wallet/blockchain loading progress.
+
+"Synchronizing with network" progress bar to show block-chain download progress.
+
+Icons at the bottom of the window that show how well connected you are to the network, with tooltips to display details.
+
+Drag and drop support for bitcoin: URIs on web pages.
+
+Export transactions as a .csv file.
+
+Many other GUI improvements, large and small.
+
+RPC CHANGES
+
+getmemorypool : new RPC command, provides everything needed to construct a block with a custom generation transaction and submit a solution
+
+listsinceblock : new RPC command, list transactions since given block
+
+signmessage/verifymessage : new RPC commands to sign a message with one of your private keys or verify that a message signed by the private key associated with a bitcoin address.
+
+GENERAL CHANGES
+
+Faster initial block download.

--- a/doc/release-notes/release-notes-0.5.1.md
+++ b/doc/release-notes/release-notes-0.5.1.md
@@ -1,0 +1,43 @@
+Bitcoin version 0.5.1 is now available for download at:
+http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.5.1/
+
+This is a bugfix-only release.
+
+This release includes 13 translations, including 5 new translations:
+Italian, Hungarian, Ukranian, Portuguese (Brazilian) and Simplified Chinese.
+More translations are welcome; join the project at Transifex if you can help:
+https://www.transifex.net/projects/p/bitcoin/
+
+Please report bugs using the issue tracker at github:
+https://github.com/bitcoin/bitcoin/issues
+
+Project source code is hosted at github; we are no longer
+distributing .tar.gz files here, you can get them
+directly from github:
+https://github.com/bitcoin/bitcoin/tarball/v0.5.1  # .tar.gz
+https://github.com/bitcoin/bitcoin/zipball/v0.5.1  # .zip
+
+For Ubuntu users, there is a new ppa maintained by Matt Corallo which
+you can add to your system so that it will automatically keep
+bitcoin up-to-date.  Just type
+sudo apt-add-repository ppa:bitcoin/bitcoin
+in your terminal, then install the bitcoin-qt package.
+
+
+BUG FIXES
+
+Re-enable SSL support for the JSON-RPC interface (it was unintentionally
+disabled for the 0.5.0 release binaries).
+
+The code that finds peers via "dns seeds" no longer stops bitcoin startup
+if one of the dns seed machines is down.
+
+Tooltips on the transaction list view were rendering incorrectly (as black boxes
+or with a transparent background).
+
+Prevent a denial-of-service attack involving flooding a bitcoin node with
+orphan blocks.
+
+The wallet passphrase dialog now warns you if the caps lock key was pressed.
+
+Improved searching in addresses and labels in bitcoin-qt.

--- a/doc/release-notes/release-notes-0.5.2.md
+++ b/doc/release-notes/release-notes-0.5.2.md
@@ -1,0 +1,22 @@
+Bitcoin version 0.5.2 is now available for download at:
+http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.5.2/
+
+This is a bugfix-only release based on 0.5.1.
+
+Please report bugs using the issue tracker at github:
+https://github.com/bitcoin/bitcoin/issues
+
+Stable source code is hosted at Gitorious:
+http://gitorious.org/bitcoin/bitcoind-stable/archive-tarball/v0.5.2#.tar.gz
+
+BUG FIXES
+
+Check all transactions in blocks after the last checkpoint (0.5.0 and 0.5.1 skipped checking ECDSA signatures during initial blockchain download).
+Cease locking memory used by non-sensitive information (this caused a huge performance hit on some platforms, especially noticable during initial blockchain download; this was
+not a security vulnerability).
+Fixed some address-handling deadlocks (client freezes).
+No longer accept inbound connections over the internet when Bitcoin is being used with Tor (identity leak).
+Re-enable SSL support for the JSON-RPC interface (it was unintentionally disabled for the 0.5.0 and 0.5.1 release Linux binaries).
+Use the correct base transaction fee of 0.0005 BTC for accepting transactions into mined blocks (since 0.4.0, it was incorrectly accepting 0.0001 BTC which was only meant to be relayed).
+Don't show "IP" for transactions which are not necessarily IP transactions.
+Add new DNS seeds (maintained by Pieter Wuille and Luke Dashjr).

--- a/doc/release-notes/release-notes-0.5.3.md
+++ b/doc/release-notes/release-notes-0.5.3.md
@@ -1,0 +1,42 @@
+Bitcoin version 0.5.3 is now available for download at:
+http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.5.3/
+
+This is a bugfix-only release based on 0.5.1.
+It also includes a few protocol updates.
+
+Please report bugs using the issue tracker at github:
+https://github.com/bitcoin/bitcoin/issues
+
+Stable source code is hosted at Gitorious:
+http://gitorious.org/bitcoin/bitcoind-stable/archive-tarball/v0.5.3#.tar.gz
+
+PROTOCOL UPDATES
+
+BIP 30: Introduce a new network rule: "a block is not valid if it contains a transaction whose hash already exists in the block chain, unless all that transaction's outputs were already spent before said block" beginning on March 15, 2012, 00:00 UTC.
+On testnet, allow mining of min-difficulty blocks if 20 minutes have gone by without mining a regular-difficulty block. This is to make testing Bitcoin easier, and will not affect normal mode.
+
+BUG FIXES
+
+Limit the number of orphan transactions stored in memory, to prevent a potential denial-of-service attack by flooding orphan transactions. Also never store invalid transactions at all.
+Fix possible buffer overflow on systems with very long application data paths. This is not exploitable.
+Resolved multiple bugs preventing long-term unlocking of encrypted wallets
+(issue #922).
+Only send local IP in "version" messages if it is globally routable (ie, not private), and try to get such an IP from UPnP if applicable.
+Reannounce UPnP port forwards every 20 minutes, to workaround routers expiring old entries, and allow the -upnp option to override any stored setting.
+Skip splash screen when -min is used, and fix Minimize to Tray function.
+Do not blank "label" in Bitcoin-Qt "Send" tab, if the user has already entered something.
+Correct various labels and messages.
+Various memory leaks and potential null pointer deferences have been fixed.
+Handle invalid Bitcoin URIs using "bitcoin://" instead of "bitcoin:".
+Several shutdown issues have been fixed.
+Revert to "global progress indication", as starting from zero every time was considered too confusing for many users.
+Check that keys stored in the wallet are valid at startup, and if not, report corruption.
+Enable accessible widgets on Windows, so that people with screen readers such as NVDA can make sense of it.
+Various build fixes.
+If no password is specified to bitcoind, recommend a secure password.
+Automatically focus and scroll to new "Send coins" entries in Bitcoin-Qt.
+Show a message box for --help on Windows, for Bitcoin-Qt.
+Add missing "About Qt" menu option to show built-in Qt About dialog.
+Don't show "-daemon" as an option for Bitcoin-Qt, since it isn't available.
+Update hard-coded fallback seed nodes, choosing recent ones with long uptime and versions at least 0.4.0.
+Add checkpoint at block 168,000.

--- a/doc/release-notes/release-notes-0.5.4.md
+++ b/doc/release-notes/release-notes-0.5.4.md
@@ -1,0 +1,39 @@
+Bitcoin version 0.5.4 is now available for download at:
+http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.5.4/
+NOTE: 0.5.4rc3 is being renamed to 0.5.4 final with no changes.
+
+This is a bugfix-only release in the 0.5.x series, plus a few protocol updates.
+
+Please report bugs using the issue tracker at github:
+https://github.com/bitcoin/bitcoin/issues
+
+Stable source code is hosted at Gitorious:
+http://gitorious.org/bitcoin/bitcoind-stable/archive-tarball/v0.5.4#.tar.gz
+
+PROTOCOL UPDATES
+
+BIP 16: Special-case "pay to script hash" logic to enable minimal validation of new transactions.
+Support for validating message signatures produced with compressed public keys.
+
+BUG FIXES
+
+Build with thread-safe MingW libraries for Windows, fixing a dangerous memory corruption scenario when exceptions are thrown.
+Fix broken testnet mining.
+Stop excess inventory relay during initial block download.
+When disconnecting a node, clear the received buffer so that we do not process any already received messages.
+Yet another attempt at implementing "minimize to tray" that works on all operating systems.
+Fix Bitcoin-Qt notifications under Growl 1.3.
+Increase required age of Bitcoin-Qt's "not up to date" status from 30 to 90 minutes.
+Implemented missing verifications that led to crash on entering some wrong passphrases for encrypted wallets.
+Fix default filename suffixes in GNOME save dialog.
+Make the "Send coins" tab use the configured unit type, even on the first attempt.
+Print detailed wallet loading errors to debug.log when it is corrupt.
+Allocate exactly the amount of space needed for signing transactions, instead of a fixed 10k buffer.
+Workaround for improbable memory access violation.
+Check wallet's minimum version before trying to load it.
+Remove wxBitcoin properly when installing Bitcoin-Qt over it. (Windows)
+Detail reorganization information better in debug log.
+Use a messagebox to display the error when -server is provided without configuring a RPC password.
+Testing suite build now honours provided CXXFLAGS.
+Removed an extraneous line-break in mature transaction tooltips.
+Fix some grammatical errors in translation process documentation.

--- a/doc/release-notes/release-notes-0.5.5.md
+++ b/doc/release-notes/release-notes-0.5.5.md
@@ -1,0 +1,37 @@
+bitcoind and Bitcoin-Qt version 0.5.5 are now available for download at:
+Windows: installer | zip (sig)
+Source: tar.gz
+bitcoind and Bitcoin-Qt version 0.6.0.7 are also tagged in git, but it is recommended to upgrade to 0.6.1.
+
+These are bugfix-only releases.
+
+Please report bugs by replying to this forum thread. Note that the 0.4.x wxBitcoin GUI client is no longer maintained nor supported. If someone would like to step up to maintain this, they should contact Luke-Jr.
+
+BUG FIXES
+
+Version 0.6.0 allowed importing invalid "private keys", which would be unspendable; 0.6.0.7 will now verify the private key is valid, and refuse to import an invalid one
+Verify status of encrypt/decrypt calls to detect failed padding
+Check blocks for duplicate transactions earlier. Fixes #1167
+Upgrade Windows builds to OpenSSL 1.0.1b
+Set label when selecting an address that already has a label. Fixes #1080 (Bitcoin-Qt)
+JSON-RPC listtransactions's from/count handling is now fixed
+Optimize and fix multithreaded access, when checking whether we already know about transactions
+Fix potential networking deadlock
+Proper support for Growl 1.3 notifications
+Display an error, rather than crashing, if encoding a QR Code failed (0.6.0.7)
+Don't erroneously set "Display addresses" for users who haven't explicitly enabled it (Bitcoin-Qt)
+Some non-ASCII input in JSON-RPC expecting hexadecimal may have been misinterpreted rather than rejected
+Missing error condition checking added
+Do not show green tick unless all known blocks are downloaded. Fixes #921 (Bitcoin-Qt)
+Increase time ago of last block for "up to date" status from 30 to 90 minutes
+Show a message box when runaway exception happens (Bitcoin-Qt)
+Use a messagebox to display the error when -server is provided without providing a rpc password
+Show error message instead of exception crash when unable to bind RPC port (Bitcoin-Qt)
+Correct sign message bitcoin address tooltip. Fixes #1050 (Bitcoin-Qt)
+Removed "(no label)" from QR Code dialog titlebar if we have no label (0.6.0.7)
+Removed an ugly line break in tooltip for mature transactions (0.6.0.7)
+Add missing tooltip and key shortcut in settings dialog (part of #1088) (Bitcoin-Qt)
+Work around issue in boost::program_options that prevents from compiling in clang
+Fixed bugs occurring only on platforms with unsigned characters (such as ARM).
+Rename make_windows_icon.py to .sh as it is a shell script. Fixes #1099 (Bitcoin-Qt)
+Various trivial internal corrections to types used for counting/size loops and warnings

--- a/doc/release-notes/release-notes-0.6.0.md
+++ b/doc/release-notes/release-notes-0.6.0.md
@@ -1,0 +1,138 @@
+Bitcoin version 0.6.0 is now available for download at:
+http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.6.0/test/
+
+This release includes more than 20 language localizations.
+More translations are welcome; join the
+project at Transifex to help:
+https://www.transifex.net/projects/p/bitcoin/
+
+Please report bugs using the issue tracker at github:
+https://github.com/bitcoin/bitcoin/issues
+
+Project source code is hosted at github; we are no longer
+distributing .tar.gz files here, you can get them
+directly from github:
+https://github.com/bitcoin/bitcoin/tarball/v0.6.0  # .tar.gz
+https://github.com/bitcoin/bitcoin/zipball/v0.6.0  # .zip
+
+For Ubuntu users, there is a ppa maintained by Matt Corallo which
+you can add to your system so that it will automatically keep
+bitcoin up-to-date.  Just type
+sudo apt-add-repository ppa:bitcoin/bitcoin
+in your terminal, then install the bitcoin-qt package.
+
+
+KNOWN ISSUES
+
+Shutting down while synchronizing with the network
+(downloading the blockchain) can take more than a minute,
+because database writes are queued to speed up download
+time.
+
+
+NEW FEATURES SINCE BITCOIN VERSION 0.5
+
+Initial network synchronization should be much faster
+(one or two hours on a typical machine instead of ten or more
+hours).
+
+Backup Wallet menu option.
+
+Bitcoin-Qt can display and save QR codes for sending
+and receiving addresses.
+
+New context menu on addresses to copy/edit/delete them.
+
+New Sign Message dialog that allows you to prove that you
+own a bitcoin address by creating a digital
+signature.
+
+New wallets created with this version will
+use 33-byte 'compressed' public keys instead of
+65-byte public keys, resulting in smaller
+transactions and less traffic on the bitcoin
+network. The shorter keys are already supported
+by the network but wallet.dat files containing
+short keys are not compatible with earlier
+versions of Bitcoin-Qt/bitcoind.
+
+New command-line argument -blocknotify=<command>
+that will spawn a shell process to run <command> 
+when a new block is accepted.
+
+New command-line argument -splash=0 to disable
+Bitcoin-Qt's initial splash screen
+
+validateaddress JSON-RPC api command output includes
+two new fields for addresses in the wallet:
+pubkey : hexadecimal public key
+iscompressed : true if pubkey is a short 33-byte key
+
+New JSON-RPC api commands for dumping/importing
+private keys from the wallet (dumprivkey, importprivkey).
+
+New JSON-RPC api command for getting information about
+blocks (getblock, getblockhash).
+
+New JSON-RPC api command (getmininginfo) for getting
+extra information related to mining. The getinfo
+JSON-RPC command no longer includes mining-related
+information (generate/genproclimit/hashespersec).
+
+
+
+NOTABLE CHANGES
+
+BIP30 implemented (security fix for an attack involving
+duplicate "coinbase transactions").
+
+The -nolisten, -noupnp and -nodnsseed command-line
+options were renamed to -listen, -upnp and -dnsseed,
+with a default value of 1. The old names are still
+supported for compatibility (so specifying -nolisten
+is automatically interpreted as -listen=0; every
+boolean argument can now be specified as either
+-foo or -nofoo).
+
+The -noirc command-line options was renamed to
+-irc, with a default value of 0. Run -irc=1 to
+get the old behavior.
+
+Three fill-up-available-memory denial-of-service
+attacks were fixed.
+
+
+NOT YET IMPLEMENTED FEATURES
+
+Support for clicking on bitcoin: URIs and
+opening/launching Bitcoin-Qt is available only on Linux,
+and only if you configure your desktop to launch
+Bitcoin-Qt. All platforms support dragging and dropping
+bitcoin: URIs onto the Bitcoin-Qt window to start
+payment.
+
+
+PRELIMINARY SUPPORT FOR MULTISIGNATURE TRANSACTIONS
+
+This release has preliminary support for multisignature
+transactions-- transactions that require authorization
+from more than one person or device before they
+will be accepted by the bitcoin network.
+
+Prior to this release, multisignature transactions
+were considered 'non-standard' and were ignored;
+with this release multisignature transactions are
+considered standard and will start to be relayed
+and accepted into blocks.
+
+It is expected that future releases of Bitcoin-Qt
+will support the creation of multisignature transactions,
+once enough of the network has upgraded so relaying
+and validating them is robust.
+
+For this release, creation and testing of multisignature
+transactions is limited to the bitcoin test network using
+the "addmultisigaddress" JSON-RPC api call.
+
+Short multisignature address support is included in this
+release, as specified in BIP 13 and BIP 16.

--- a/doc/release-notes/release-notes-0.6.1.md
+++ b/doc/release-notes/release-notes-0.6.1.md
@@ -1,0 +1,2 @@
+Never released
+

--- a/doc/release-notes/release-notes-0.6.2.md
+++ b/doc/release-notes/release-notes-0.6.2.md
@@ -1,0 +1,50 @@
+Bitcoin version 0.6.2 is now available for download at:
+http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.6.2/
+
+This is a bug-fix and code-cleanup release, with no major new features.
+
+Please report bugs using the github issue tracker at:
+https://github.com/bitcoin/bitcoin/issues
+
+
+NOTABLE CHANGES
+
+Much faster shutdowns. However, the blkindex.dat file is no longer
+portable to different data directories by default. If you need a
+portable blkindex.dat file then run with the new -detachdb=1 option
+or the "Detach databases at shutdown" GUI preference.
+
+Fixed https://github.com/bitcoin/bitcoin/issues/1065, a bug that
+could cause long-running nodes to crash.
+
+Mac and Windows binaries are compiled against OpenSSL 1.0.1b (Linux
+binaries are dynamically linked to the version of OpenSSL on the system).
+
+
+CHANGE SUMMARY
+
+Use 'git shortlog --no-merges v0.6.0..' for a summary of this release.
+
+Source codebase changes:
+- Many source code cleanups and warnings fixes.  Close to building with -Wall
+- Locking overhaul, and several minor locking fixes
+- Several source code portability fixes, e.g. FreeBSD
+
+JSON-RPC interface changes:
+- addmultisigaddress enabled for mainnet (previously only enabled for testnet)
+
+Network protocol changes:
+- protocol version 60001
+- added nonce value to "ping" message (BIP 31)
+- added new "pong" message (BIP 31)
+
+Backend storage changes:
+- Less redundant database flushing, especially during initial block download
+- Shutdown improvements (see above)
+
+Qt user interface:
+- minor URI handling improvements
+- progressbar improvements
+- error handling improvements (show message box rather than console exception,
+etc.)
+- by popular request, make 4th bar of connection icon green

--- a/doc/release-notes/release-notes-0.6.3.md
+++ b/doc/release-notes/release-notes-0.6.3.md
@@ -1,0 +1,29 @@
+Bitcoin version 0.6.3 is now available for download at:
+  http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.6.3/
+
+This is a bug-fix release, with no new features.
+
+Please report bugs using the issue tracker at github:
+  https://github.com/bitcoin/bitcoin/issues
+
+CHANGE SUMMARY
+
+Fixed a serious denial-of-service attack that could cause the
+bitcoin process to become unresponsive. Thanks to Sergio Lerner
+for finding and responsibly reporting the problem. (CVE-2012-3789)
+
+Optimized the process of checking transaction signatures, to
+speed up processing of new block messages and make propagating
+blocks across the network faster.
+
+Fixed an obscure bug that could cause the bitcoin process to get
+stuck on an invalid block-chain, if the invalid chain was
+hundreds of blocks long.
+
+Bitcoin-Qt no longer automatically selects the first address
+in the address book (Issue #1384).
+
+Fixed minimize-to-dock behavior of Bitcon-Qt on the Mac.
+
+Added a block checkpoint at block 185,333 to speed up initial
+blockchain download.

--- a/doc/release-notes/release-notes-0.7.0.md
+++ b/doc/release-notes/release-notes-0.7.0.md
@@ -1,0 +1,169 @@
+Bitcoin version 0.7.0 is now available for download at:
+  http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.7.0/
+
+We recommend that everybody running prior versions of bitcoind/Bitcoin-Qt
+upgrade to this release, except for users running Mac OSX 10.5.
+
+Please report bugs using the issue tracker at github:
+  https://github.com/bitcoin/bitcoin/issues
+
+Project source code is hosted at github; you can get
+source-only tarballs/zipballs directly from there:
+  https://github.com/bitcoin/bitcoin/tarball/v0.7.0  # .tar.gz
+  https://github.com/bitcoin/bitcoin/zipball/v0.7.0  # .zip
+
+Ubuntu Linux users can use the "Personal Package Archive" (PPA)
+maintained by Matt Corallo to automatically keep 
+bitcoin up-to-date.  Just type
+  sudo apt-add-repository ppa:bitcoin/bitcoin
+  sudo apt-get update
+in your terminal, then install the bitcoin-qt package:
+  sudo apt-get install bitcoin-qt
+
+
+How to Upgrade
+
+If you are running an older version, shut it down. Wait
+until it has completely shut down (which might take a few minutes for older
+versions), then run the installer (on Windows) or just copy over
+Code:
+/Applications/Bitcoin-Qt
+(on Mac) or
+Code:
+bitcoind/bitcoin-qt
+(on Linux).
+
+If you were running on Linux with a version that might have been compiled
+with a different version of Berkeley DB (for example, if you were using the
+PPA and are switching to the binary release), then run the old version again
+with the -detachdb argument and shut it down; if you do not, then the new
+version will not be able to read the database files and will exit with an error.
+
+Incompatible Changes
+
+* Replaced the 'getmemorypool' RPC command with 'getblocktemplate/submitblock'
+  and 'getrawmempool' commands.
+* Remove deprecated RPC 'getblocknumber'
+
+Bitcoin Improvement Proposals implemented
+
+BIP 22 - 'getblocktemplate', 'submitblock' RPCs
+BIP 34 - block version 2, height in coinbase
+BIP 35 - 'mempool' message, extended 'getdata' message behavior
+
+
+Core bitcoin handling and blockchain database
+
+* Reduced CPU usage, by eliminating some redundant hash calculations
+* Cache signature verifications, to eliminate redundant signature checks
+* Transactions with zero-value outputs are considered non-standard
+* Mining: when creating new blocks, sort 'paid' area by fee-per-kb
+* Database: better validation of on-disk stored data
+* Database: minor optimizations and reliability improvements
+* -loadblock=FILE will import an external block file
+* Additional DoS (denial-of-service) prevention measures
+* New blockchain checkpoint at block 193,000
+
+
+JSON-RPC API
+
+* Internal HTTP server is now thread-per-connection, rather than
+  a single-threaded queue that would stall on network I/O.
+* Internal HTTP server supports HTTP/1.1, pipelined requests and
+  connection keep-alive.
+* Support JSON-RPC 2.0 batches, to encapsulate multiple JSON-RPC requests
+  within a single HTTP request.
+* IPv6 support
+* Added raw transaction API.  See https://gist.github.com/2839617
+* Added 'getrawmempool', to list contents of TX memory pool
+* Added 'getpeerinfo', to list data about each connected network peer
+* Added 'listaddressgroupings' for better coin control
+* Rework getblock call.
+* Remove deprecated RPC 'getblocknumber'
+* Remove superceded RPC 'getmemorypool' (see BIP 22, above)
+* listtransactions output now displays "smart" times for transactions,
+  and 'blocktime' and 'timereceived' fields were added
+
+
+P2P networking
+
+* IPv6 support
+* Tor hidden service support (see doc/Tor.txt)
+* Attempts to fix "stuck blockchain download" problems
+* Replace BDB database "addr.dat" with internally-managed "peers.dat"
+  file containing peer address data.
+* Lower default send buffer from 10MB to 1MB
+* proxy: SOCKS5 by default
+* Support connecting by hostnames passed to proxy
+* Add -seednode connections, and use this instead of DNS seeds when proxied
+* Added -externalip and -discover
+* Add -onlynet to connect only to a given network (IPv4, IPv6, or Tor)
+* Separate listening sockets, -bind=<addr>
+
+
+Qt GUI
+
+* Add UI RPC console / debug window
+* Re-Enable URI handling on Windows, add safety checks and tray-notifications
+* Harmonize the use of ellipsis ("...") to be used in menus, but not on buttons
+* Add 2 labels to the overviewpage that display Wallet and Transaction status (obsolete or current)
+* Extend the optionsdialog (e.g. language selection) and re-work it to a tabbed UI
+* Merge sign/verify message into a single window with tabbed UI
+* Ensure a changed bitcoin unit immediately updates all GUI elements that use units
+* Update QR Code dialog
+* Improve error reporting at startup
+* Fine-grained UI updates for a much smoother UI during block downloads
+* Remove autocorrection of 0/i in addresses in UI
+* Reorganize tray icon menu into more logical order
+* Persistently poll for balance change when number of blocks changed
+* Much better translations
+* Override progress bar design on platforms with segmented progress bars to assist with readability
+* Added 'immature balance' display on the overview page
+* (Windows only): enable ASLR and DEP for bitcoin-qt.exe
+* (Windows only): add meta-data to bitcoin-qt.exe (e.g. description)
+
+Internal codebase
+
+* Additional unit tests
+* Compile warning fixes
+
+
+Miscellaneous
+
+* Reopen debug.log upon SIGHUP
+* Bash programmable completion for bitcoind(1)
+* On supported OS's, each thread is given a useful name
+
+
+Thanks to everybody who contributed to this release:
+
+Chris Moore
+Christian von Roques
+David Joel Schwartz
+Douglas Huff
+Fordy
+Gavin Andresen
+Giel van Schijndel
+Gregory Maxwell
+Jeff Garzik
+Luke Dashjr
+Matt Corallo
+Michael Ford
+Michael Hendricks
+Peter Todd
+Philip Kaufmann
+Pieter Wuille
+R E Broadley
+Ricardo M. Correia
+Rune K. Svendsen
+Scott Ellis
+Stephane Glondu
+Wladimir J. van der Laan
+cardpuncher
+coderrr
+fanquake
+grimd34th
+sje397
+xanatos
+
+Thanks to Sergio Lerner for reporting denial-of-service vulnerabilities fixed in this release.

--- a/doc/release-notes/release-notes-0.7.1.md
+++ b/doc/release-notes/release-notes-0.7.1.md
@@ -1,0 +1,110 @@
+Bitcoin version 0.7.1 is now available from:
+  http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.7.1/
+
+This is a bug-fix minor release.
+
+Please report bugs using the issue tracker at github:
+  https://github.com/bitcoin/bitcoin/issues
+
+Project source code is hosted at github; you can get
+source-only tarballs/zipballs directly from there:
+  https://github.com/bitcoin/bitcoin/tarball/v0.7.1  # .tar.gz
+  https://github.com/bitcoin/bitcoin/zipball/v0.7.1  # .zip
+
+Ubuntu Linux users can use the "Personal Package Archive" (PPA)
+maintained by Matt Corallo to automatically keep 
+up-to-date.  Just type:
+  sudo apt-add-repository ppa:bitcoin/bitcoin
+  sudo apt-get update
+in your terminal, then install the bitcoin-qt package:
+  sudo apt-get install bitcoin-qt
+
+KNOWN ISSUES
+------------
+
+Mac OSX 10.5 is no longer supported.
+
+How to Upgrade
+--------------
+
+If you are running an older version, shut it down. Wait
+until it has completely shut down (which might take a few minutes for older
+versions), then run the installer (on Windows) or just copy over
+/Applications/Bitcoin-Qt (on Mac) or bitcoind/bitcoin-qt (on Linux).
+
+If you were running on Linux with a version that might have been compiled
+with a different version of Berkeley DB (for example, if you were using an
+Ubuntu PPA version), then run the old version again with the -detachdb
+argument and shut it down; if you do not, then the new version will not
+be able to read the database files and will exit with an error.
+
+Explanation of -detachdb (and the new "stop true" RPC command):
+The Berkeley DB database library stores data in both ".dat" and
+"log" files, so the database is always in a consistent state,
+even in case of power failure or other sudden shutdown. The
+format of the ".dat" files is portable between different
+versions of Berkeley DB, but the "log" files are not-- even minor
+version differences may have incompatible "log" files. The
+-detachdb option moves any pending changes from the "log" files
+to the "blkindex.dat" file for maximum compatibility, but makes
+shutdown much slower. Note that the "wallet.dat" file is always
+detached, and versions prior to 0.6.0 detached all databases
+at shutdown.
+
+New features
+------------
+
+* Added a boolean argument to the RPC 'stop' command, if true sets
+  -detachdb to create standalone database .dat files before shutting down.
+
+* -salvagewallet command-line option, which moves any existing wallet.dat
+  to wallet.{timestamp}.dat and then attempts to salvage public/private
+  keys and master encryption keys (if the wallet is encrypted) into
+  a new wallet.dat. This should only be used if your wallet becomes
+  corrupted, and is not intended to replace regular wallet backups.
+
+* Import $DataDir/bootstrap.dat automatically, if it exists.
+
+Dependency changes
+------------------
+
+* Qt 4.8.2 for Windows builds
+
+* openssl 1.0.1c
+
+Bug fixes
+---------
+
+* Clicking on a bitcoin: URI on Windows should now launch Bitcoin-Qt properly.
+
+* When running -testnet, use RPC port 18332 by default.
+
+* Better detection and handling of corrupt wallet.dat and blkindex.dat files.
+  Previous versions would crash with a DB_RUNRECOVERY exception, this
+  version detects most problems and tells you how to recover if it
+  cannot recover itself.
+
+* Fixed an uninitialized variable bug that could cause transactions to
+  be reported out of order.
+
+* Fixed a bug that could cause occasional crashes on exit.
+
+* Warn the user that they need to create fresh wallet backups after they
+  encrypt their wallet.
+
+----------------------------------------------------
+Thanks to everybody who contributed to this release:
+
+Gavin Andresen
+Jeff Garzik
+Luke Dashjr
+Mark Friedenbach
+Matt Corallo
+Philip Kaufmann
+Pieter Wuille
+Rune K. Svendsen
+Virgil Dupras
+Wladimir J. van der Laan
+fanquake
+kjj2
+xanatos

--- a/doc/release-notes/release-notes-0.7.2.md
+++ b/doc/release-notes/release-notes-0.7.2.md
@@ -1,0 +1,68 @@
+Bitcoin version 0.7.2 is now available from:
+  http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.7.2
+
+This is a bug-fix minor release.
+
+Please report bugs using the issue tracker at github:
+  https://github.com/bitcoin/bitcoin/issues
+
+How to Upgrade
+--------------
+
+If you are running an older version, shut it down. Wait
+until it has completely shut down (which might take a few minutes for older
+versions), then run the installer (on Windows) or just copy over
+/Applications/Bitcoin-Qt (on Mac) or bitcoind/bitcoin-qt (on Linux).
+
+If you were running on Linux with a version that might have been compiled
+with a different version of Berkeley DB (for example, if you were using an
+Ubuntu PPA version), then run the old version again with the -detachdb
+argument and shut it down; if you do not, then the new version will not
+be able to read the database files and will exit with an error.
+
+Explanation of -detachdb (and the new "stop true" RPC command):
+The Berkeley DB database library stores data in both ".dat" and
+"log" files, so the database is always in a consistent state,
+even in case of power failure or other sudden shutdown. The
+format of the ".dat" files is portable between different
+versions of Berkeley DB, but the "log" files are not-- even minor
+version differences may have incompatible "log" files. The
+-detachdb option moves any pending changes from the "log" files
+to the "blkindex.dat" file for maximum compatibility, but makes
+shutdown much slower. Note that the "wallet.dat" file is always
+detached, and versions prior to 0.6.0 detached all databases
+at shutdown.
+
+Bug fixes
+---------
+
+* Prevent RPC 'move' from deadlocking. This was caused by trying to lock the
+  database twice.
+
+* Fix use-after-free problems in initialization and shutdown, the latter of
+  which caused Bitcoin-Qt to crash on Windows when exiting.
+
+* Correct library linking so building on Windows natively works.
+
+* Avoid a race condition and out-of-bounds read in block creation/mining code.
+
+* Improve platform compatibility quirks, including fix for 100% CPU utilization
+  on FreeBSD 9.
+
+* A few minor corrections to error handling, and updated translations.
+
+* OSX 10.5 supported again
+
+----------------------------------------------------
+Thanks to everybody who contributed to this release:
+
+Alex
+dansmith
+Gavin Andresen
+Gregory Maxwell
+Jeff Garzik
+Luke Dashjr
+Philip Kaufmann
+Pieter Wuille
+Wladimir J. van der Laan
+grimd34th

--- a/doc/release-notes/release-notes-0.8.0.md
+++ b/doc/release-notes/release-notes-0.8.0.md
@@ -1,0 +1,139 @@
+Bitcoin-Qt version 0.8.0 is now available from:
+  http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.8.0/
+
+This is a major release designed to improve performance and handle the
+increasing volume of transactions on the network.
+
+Please report bugs using the issue tracker at github:
+  https://github.com/bitcoin/bitcoin/issues
+
+How to Upgrade
+--------------
+
+If you are running an older version, shut it down. Wait
+until it has completely shut down (which might take a few minutes for older
+versions), then run the installer (on Windows) or just copy over
+/Applications/Bitcoin-Qt (on Mac) or bitcoind/bitcoin-qt (on Linux).
+
+The first time you run after the upgrade a re-indexing process will be
+started that will take anywhere from 30 minutes to several hours,
+depending on the speed of your machine.
+
+Incompatible Changes
+--------------------
+
+This release no longer maintains a full index of historical transaction ids
+by default, so looking up an arbitrary transaction using the getrawtransaction
+RPC call will not work. If you need that functionality, you must run once
+with -txindex=1 -reindex=1 to rebuild block-chain indices (see below for more
+details).
+
+Improvements
+------------
+
+Mac and Windows binaries are signed with certificates owned by the Bitcoin
+Foundation, to be compatible with the new security features in OSX 10.8 and
+Windows 8.
+
+LevelDB, a fast, open-source, non-relational database from Google, is
+now used to store transaction and block indices.  LevelDB works much better
+on machines with slow I/O and is faster in general. Berkeley DB is now only
+used for the wallet.dat file (public and private wallet keys and transactions
+relevant to you).
+
+Pieter Wuille implemented many optimizations to the way transactions are
+verified, so a running, synchronized node uses less working memory and does
+much less I/O. He also implemented parallel signature checking, so if you
+have a multi-CPU machine all CPUs will be used to verify transactions.
+
+New Features
+------------
+
+"Bloom filter" support in the network protocol for sending only relevant transactions to
+lightweight clients.
+
+contrib/verifysfbinaries is a shell-script to verify that the binary downloads
+at sourceforge have not been tampered with. If you are able, you can help make
+everybody's downloads more secure by running this occasionally to check PGP
+signatures against download file checksums.
+
+contrib/spendfrom is a python-language command-line utility that demonstrates
+how to use the "raw transactions" JSON-RPC api to send coins received from particular
+addresses (also known as "coin control").
+
+New/changed settings (command-line or bitcoin.conf file)
+--------------------------------------------------------
+
+dbcache : controls LevelDB memory usage.
+
+par : controls how many threads to use to validate transactions. Defaults to the number
+of CPUs on your machine, use -par=1 to limit to a single CPU.
+
+txindex : maintains an extra index of old, spent transaction ids so they will be found
+by the getrawtransaction JSON-RPC method.
+
+reindex : rebuild block and transaction indices from the downloaded block data.
+
+New JSON-RPC API Features
+-------------------------
+
+lockunspent / listlockunspent allow locking transaction outputs for a period of time so
+they will not be spent by other processes that might be accessing the same wallet.
+
+addnode / getaddednodeinfo methods, to connect to specific peers without restarting.
+
+importprivkey now takes an optional boolean parameter (default true) to control whether
+or not to rescan the blockchain for transactions after importing a new private key.
+
+Important Bug Fixes
+-------------------
+
+Privacy leak: the position of the "change" output in most transactions was not being
+properly randomized, making network analysis of the transaction graph to identify
+users' wallets easier. 
+
+Zero-confirmation transaction vulnerability: accepting zero-confirmation transactions
+(transactions that have not yet been included in a block) from somebody you do not
+trust is still not recommended, because there will always be ways for attackers to
+double-spend zero-confirmation transactions. However, this release includes a bug
+fix that makes it a little bit more difficult for attackers to double-spend a
+certain type ("lockTime in the future") of zero-confirmation transaction.
+
+Dependency Changes
+------------------
+
+Qt 4.8.3 (compiling against older versions of Qt 4 should continue to work)
+
+
+Thanks to everybody who contributed to this release:
+----------------------------------------------------
+
+Alexander Kjeldaas
+Andrey Alekseenko
+Arnav Singh
+Christian von Roques
+Eric Lombrozo
+Forrest Voight
+Gavin Andresen
+Gregory Maxwell
+Jeff Garzik
+Luke Dashjr
+Matt Corallo
+Mike Cassano
+Mike Hearn
+Peter Todd
+Philip Kaufmann
+Pieter Wuille
+Richard Schwab
+Robert Backhaus
+Rune K. Svendsen
+Sergio Demian Lerner
+Wladimir J. van der Laan
+burger2
+default
+fanquake
+grimd34th
+justmoon
+redshark1802
+tucenaber
+xanatos

--- a/doc/release-notes/release-notes-0.8.1.md
+++ b/doc/release-notes/release-notes-0.8.1.md
@@ -1,0 +1,22 @@
+Bitcoin-Qt/bitcoind version 0.8.1 is now available from:
+  http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.8.1/
+
+This is a maintenance release that adds a new network rule to avoid
+a chain-forking incompatibility with versions 0.7.2 and earlier.
+
+Please report bugs using the issue tracker at github:
+  https://github.com/bitcoin/bitcoin/issues
+
+
+How to Upgrade
+--------------
+
+If you are running an older version, shut it down. Wait
+until it has completely shut down (which might take a few minutes for older
+versions), then run the installer (on Windows) or just copy over
+/Applications/Bitcoin-Qt (on Mac) or bitcoind/bitcoin-qt (on Linux).
+
+If you are upgrading from version 0.7.2 or earlier, the first time you
+run 0.8.1 your blockchain files will be re-indexed, which will take
+anywhere from 30 minutes to several hours, depending on the speed of
+your machine.

--- a/doc/release-notes/release-notes-0.8.2.md
+++ b/doc/release-notes/release-notes-0.8.2.md
@@ -1,0 +1,137 @@
+Bitcoin-Qt version 0.8.2 is now available from:
+  http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.8.2/
+
+This is a maintenance release that fixes many bugs and includes
+a few small new features.
+
+Please report bugs using the issue tracker at github:
+  https://github.com/bitcoin/bitcoin/issues
+
+
+How to Upgrade
+
+If you are running an older version, shut it down. Wait
+until it has completely shut down (which might take a few minutes for older
+versions), then run the installer (on Windows) or just copy over
+/Applications/Bitcoin-Qt (on Mac) or bitcoind/bitcoin-qt (on Linux).
+
+If you are upgrading from version 0.7.2 or earlier, the first time you
+run 0.8.2 your blockchain files will be re-indexed, which will take
+anywhere from 30 minutes to several hours, depending on the speed of
+your machine.
+
+0.8.2 Release notes
+
+Fee Policy changes
+
+The default fee for low-priority transactions is lowered from 0.0005 BTC 
+(for each 1,000 bytes in the transaction; an average transaction is
+about 500 bytes) to 0.0001 BTC.
+
+Payments (transaction outputs) of 0.543 times the minimum relay fee
+(0.00005430 BTC) are now considered 'non-standard', because storing them
+costs the network more than they are worth and spending them will usually
+cost their owner more in transaction fees than they are worth.
+
+Non-standard transactions are not relayed across the network, are not included
+in blocks by most miners, and will not show up in your wallet until they are
+included in a block.
+
+The default fee policy can be overridden using the -mintxfee and -minrelaytxfee
+command-line options, but note that we intend to replace the hard-coded fees
+with code that automatically calculates and suggests appropriate fees in the
+0.9 release and note that if you set a fee policy significantly different from
+the rest of the network your transactions may never confirm.
+
+Bitcoin-Qt changes
+
+* New icon and splash screen
+* Improve reporting of synchronization process
+* Remove hardcoded fee recommendations
+* Improve metadata of executable on MacOSX and Windows
+* Move export button to individual tabs instead of toolbar
+* Add "send coins" command to context menu in address book
+* Add "copy txid" command to copy transaction IDs from transaction overview
+* Save & restore window size and position when showing & hiding window
+* New translations: Arabic (ar), Bosnian (bs), Catalan (ca), Welsh (cy),
+  Esperanto (eo), Interlingua (la), Latvian (lv) and many improvements
+  to current translations
+
+MacOSX:
+* OSX support for click-to-pay (bitcoin:) links
+* Fix GUI disappearing problem on MacOSX (issue #1522)
+
+Linux/Unix:
+* Copy addresses to middle-mouse-button clipboard
+
+
+Command-line options
+
+* -walletnotify will call a command on receiving transactions that affect the wallet.
+* -alertnotify will call a command on receiving an alert from the network.
+* -par now takes a negative number, to leave a certain amount of cores free.
+
+JSON-RPC API changes
+
+* fixed a getblocktemplate bug that caused excessive CPU creating blocks.
+* listunspent now lists account and address infromation.
+* getinfo now also returns the time adjustment estimated from your peers.
+* getpeerinfo now returns bytessent, bytesrecv and syncnode.
+* gettxoutsetinfo returns statistics about the unspent transaction output database.
+* gettxout returns information about a specific unspent transaction output.
+
+
+Networking changes
+
+* Significant changes to the networking code, reducing latency and memory consumption.
+* Avoid initial block download stalling.
+* Remove IRC seeding support.
+* Performance tweaks.
+* Added testnet DNS seeds.
+
+Wallet compatibility/rescuing
+
+* Cases where wallets cannot be opened in another version/installation should be reduced.
+* -salvagewallet now works for encrypted wallets.
+
+
+Known Bugs
+
+* Entering the 'getblocktemplate' or 'getwork' RPC commands into the Bitcoin-Qt debug
+console will cause Bitcoin-Qt to crash. Run Bitcoin-Qt with the -server command-line
+option to workaround.
+
+Thanks to everybody who contributed to the 0.8.2 release!
+
+APerson241
+Andrew Poelstra
+Calvin Owens
+Chuck LeDuc Díaz
+Colin Dean
+David Griffith
+David Serrano
+Eric Lombrozo
+Gavin Andresen
+Gregory Maxwell
+Jeff Garzik
+Jonas Schnelli
+Larry Gilbert
+Luke Dashjr
+Matt Corallo
+Michael Ford
+Mike Hearn
+Patrick Brown
+Peter Todd
+Philip Kaufmann
+Pieter Wuille
+Richard Schwab
+Roman Mindalev
+Scott Howard
+Tariq Bashir
+Warren Togami
+Wladimir J. van der Laan
+freewil
+gladoscc
+kjj2
+mb300sd
+super3

--- a/doc/release-notes/release-notes-0.8.3.md
+++ b/doc/release-notes/release-notes-0.8.3.md
@@ -1,0 +1,18 @@
+Bitcoin-Qt version 0.8.3 is now available from:
+  http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.8.3/
+
+This is a maintenance release to fix a denial-of-service attack that
+can cause nodes to crash.
+
+Please report bugs using the issue tracker at github:
+  https://github.com/bitcoin/bitcoin/issues
+
+0.8.3 Release notes
+
+Truncate over-size messages to prevent a memory exhaustion attack.
+
+Fix a regression that causes excessive re-writing of the 'peers.dat' file.
+
+
+Thanks to Peter Todd for responsibly disclosing the vulnerability
+( CVE-2013-4627 ) and creating a fix.

--- a/doc/release-notes/release-notes-0.8.4.md
+++ b/doc/release-notes/release-notes-0.8.4.md
@@ -1,0 +1,83 @@
+Bitcoin-Qt version 0.8.4 is now available from:
+  http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.8.4/
+
+This is a maintenance release to fix a critical bug and three
+security issues; we urge all users to upgrade.
+
+Please report bugs using the issue tracker at github:
+  https://github.com/bitcoin/bitcoin/issues
+
+
+How to Upgrade
+--------------
+
+If you are running an older version, shut it down. Wait
+until it has completely shut down (which might take a few minutes for older
+versions), then run the installer (on Windows) or just copy over
+/Applications/Bitcoin-Qt (on Mac) or bitcoind/bitcoin-qt (on Linux).
+
+If you are upgrading from version 0.7.2 or earlier, the first time you
+run 0.8.4 your blockchain files will be re-indexed, which will take
+anywhere from 30 minutes to several hours, depending on the speed of
+your machine.
+
+0.8.4 Release notes
+===================
+
+Security issues
+---------------
+
+An attacker could send a series of messages that resulted in
+an integer division-by-zero error in the Bloom Filter handling
+code, causing the Bitcoin-Qt or bitcoind process to crash.
+Bloom filters were introduced with version 0.8, so versions 0.8.0
+through 0.8.3 are vulnerable to this critical denial-of-service attack.
+
+A constant-time algorithm is now used to check RPC password
+guess attempts; fixes https://github.com/bitcoin/bitcoin/issues/2838
+(CVE-2013-4165)
+
+Implement a better fix for the fill-memory-with-orphan-transactions
+attack that was fixed in 0.8.3. See
+https://bitslog.wordpress.com/2013/07/18/buggy-cve-2013-4627-patch-open-new-vectors-of-attack/
+for a description of the weaknesses of the previous fix.
+(CVE-2013-4627)
+
+Bugs fixed
+----------
+
+Fix multi-block reorg transaction resurrection.
+
+Fix non-standard disconnected transactions causing mempool orphans.
+This bug could cause nodes running with the -debug flag to crash.
+
+OSX: use 'FD_FULLSYNC' with LevelDB, which will (hopefully!)
+prevent the database corruption issues many people have
+experienced on OSX.
+
+Linux: clicking on bitcoin: links was broken if you were using
+a Gnome-based desktop.
+
+Fix a hang-at-shutdown bug that only affects users that compile
+their own version of Bitcoin against Boost versions 1.50-1.52.
+
+Other changes
+-------------
+
+Checkpoint at block 250,000 to speed up initial block downloads
+and make the progress indicator when downloading more accurate.
+
+
+Thanks to everybody who contributed to the 0.8.4 releases!
+----------------------------------------------------------
+
+Pieter Wuille
+Warren Togami
+Patrick Strateman
+pakt
+Gregory Maxwell
+Sergio Demian Lerner
+grayleonard
+Cory Fields
+Matt Corallo
+Gavin Andresen

--- a/doc/release-notes/release-notes-0.8.5.md
+++ b/doc/release-notes/release-notes-0.8.5.md
@@ -1,0 +1,44 @@
+Bitcoin-Qt version 0.8.5 is now available from:
+  http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.8.5/
+
+This is a maintenance release to fix a critical bug;
+we urge all users to upgrade.
+
+Please report bugs using the issue tracker at github:
+  https://github.com/bitcoin/bitcoin/issues
+
+
+How to Upgrade
+--------------
+
+If you are running an older version, shut it down. Wait
+until it has completely shut down (which might take a few minutes for older
+versions), then run the installer (on Windows) or just copy over
+/Applications/Bitcoin-Qt (on Mac) or bitcoind/bitcoin-qt (on Linux).
+
+If you are upgrading from version 0.7.2 or earlier, the first time you
+run 0.8.5 your blockchain files will be re-indexed, which will take
+anywhere from 30 minutes to several hours, depending on the speed of
+your machine.
+
+0.8.5 Release notes
+===================
+
+Bugs fixed
+----------
+
+Transactions with version numbers larger than 0x7fffffff were
+incorrectly being relayed and included in blocks.
+
+Blocks containing transactions with version numbers larger
+than 0x7fffffff caused the code that checks for LevelDB database
+inconsistencies at startup to erroneously report database
+corruption and suggest that you reindex your database.
+
+This release also contains a non-critical fix to the code that
+enforces BIP 34 (block height in the coinbase transaction).
+
+--
+
+Thanks to Gregory Maxwell and Pieter Wuille for quickly
+identifying and fixing the transaction version number bug.

--- a/doc/release-notes/release-notes-0.8.6.md
+++ b/doc/release-notes/release-notes-0.8.6.md
@@ -1,0 +1,66 @@
+Bitcoin-Qt version 0.8.6 final is now available from:
+
+  http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.8.6/
+
+This is a maintenance release to fix a critical bug; we urge all users to upgrade.
+
+Please report bugs using the issue tracker at github:
+
+  https://github.com/bitcoin/bitcoin/issues
+
+How to Upgrade
+--------------
+
+If you already downloaded 0.8.6rc1 you do not need to re-download. This release is exactly the same.
+
+If you are running an older version, shut it down. Wait
+until it has completely shut down (which might take a few minutes for older
+versions), then run the installer (on Windows) or just copy over
+/Applications/Bitcoin-Qt (on Mac) or bitcoind/bitcoin-qt (on Linux).
+
+If you are upgrading from version 0.7.2 or earlier, the first time you
+run 0.8.6 your blockchain files will be re-indexed, which will take
+anywhere from 30 minutes to several hours, depending on the speed of
+your machine.
+
+0.8.6 Release notes
+===================
+
+- Default block size increase for miners.
+  (see https://gist.github.com/gavinandresen/7670433#086-accept-into-block)
+
+- Remove the all-outputs-must-be-greater-than-CENT-to-qualify-as-free rule for relaying
+  (see https://gist.github.com/gavinandresen/7670433#086-relaying)
+
+- Lower maximum size for free transaction creation
+  (see https://gist.github.com/gavinandresen/7670433#086-wallet)
+
+- OSX block chain database corruption fixes
+  - Update leveldb to 1.13
+  - Use fcntl with `F_FULLSYNC` instead of fsync on OSX
+  - Use native Darwin memory barriers
+  - Replace use of mmap in leveldb for improved reliability (only on OSX)
+
+- Fix nodes forwarding transactions with empty vins and getting banned
+
+- Network code performance and robustness improvements
+
+- Additional debug.log logging for diagnosis of network problems, log timestamps by default
+
+- Fix Bitcoin-Qt startup crash when clicking dock icon on OSX 
+
+- Fix memory leaks in CKey::SetCompactSignature() and Key::SignCompact()
+
+- Fix rare GUI crash on send
+
+- Various small GUI, documentation and build fixes
+
+Warning
+-------
+
+- There have been frequent reports of users running out of virtual memory on 32-bit systems
+  during the initial sync.
+  Hence it is recommended to use a 64-bit executable if possible.
+  A 64-bit executable for Windows is planned for 0.9.
+
+Note: Gavin Andresen's GPG signing key for SHA256SUMS.asc has been changed from  key id 1FC730C1 to sub key 7BF6E212 (see https://github.com/bitcoin/bitcoin.org/pull/279).


### PR DESCRIPTION
As discussed on IRC: Add all known release notes for versions since 0.3.12, thanks to Matt Corallo for collecting them on the wiki.
