### PR TITLE
[Qt] Fix nTransactionFee in qt-settings

### DIFF
--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -73,6 +73,9 @@ void OptionsModel::Init()
 #ifdef ENABLE_WALLET
     if (!settings.contains("nTransactionFee"))
         settings.setValue("nTransactionFee", 0);
+    nTransactionFee = settings.value("nTransactionFee").toLongLong(); // if -paytxfee is set, this will be overridden later in init.cpp
+    if (mapArgs.count("-paytxfee"))
+        strOverriddenByCommandLine += "-paytxfee ";
 #endif
 
     if (!settings.contains("nDatabaseCache"))


### PR DESCRIPTION
When setting a fee in GUI and then restart bitcoin-qt, the fee is not applied. Its always zero.
