### PR TITLE
[Qt] Improve single step in bitcoinamountfield

### DIFF
--- a/src/qt/bitcoinamountfield.cpp
+++ b/src/qt/bitcoinamountfield.cpp
@@ -19,12 +19,12 @@ BitcoinAmountField::BitcoinAmountField(QWidget *parent) :
     amount(0),
     currentUnit(-1)
 {
+    nSingleStep = 100000; // satoshis
+
     amount = new QDoubleSpinBox(this);
     amount->setLocale(QLocale::c());
-    amount->setDecimals(8);
     amount->installEventFilter(this);
     amount->setMaximumWidth(170);
-    amount->setSingleStep(0.001);
 
     QHBoxLayout *layout = new QHBoxLayout(this);
     layout->addWidget(amount);
@@ -159,11 +159,7 @@ void BitcoinAmountField::unitChanged(int idx)
     // Set max length after retrieving the value, to prevent truncation
     amount->setDecimals(BitcoinUnits::decimals(currentUnit));
     amount->setMaximum(qPow(10, BitcoinUnits::amountDigits(currentUnit)) - qPow(10, -amount->decimals()));
-
-    if (currentUnit == BitcoinUnits::uBTC)
-        amount->setSingleStep(0.01);
-    else
-        amount->setSingleStep(0.001);
+    amount->setSingleStep((double)nSingleStep / (double)BitcoinUnits::factor(currentUnit));
 
     if (valid)
     {
@@ -181,4 +177,10 @@ void BitcoinAmountField::unitChanged(int idx)
 void BitcoinAmountField::setDisplayUnit(int newUnit)
 {
     unit->setValue(newUnit);
+}
+
+void BitcoinAmountField::setSingleStep(qint64 step)
+{
+    nSingleStep = step;
+    unitChanged(unit->currentIndex());
 }

--- a/src/qt/bitcoinamountfield.h
+++ b/src/qt/bitcoinamountfield.h
@@ -26,6 +26,9 @@ public:
     qint64 value(bool *valid=0) const;
     void setValue(qint64 value);
 
+    /** Set single step in satoshis **/
+    void setSingleStep(qint64 step);
+
     /** Make read-only **/
     void setReadOnly(bool fReadOnly);
 
@@ -56,6 +59,7 @@ private:
     QDoubleSpinBox *amount;
     QValueComboBox *unit;
     int currentUnit;
+    qint64 nSingleStep;
 
     void setText(const QString &text);
     QString text() const;

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -15,6 +15,7 @@
 #include "optionsmodel.h"
 
 #include "netbase.h"
+#include "main.h"
 
 #include <QDir>
 #include <QIntValidator>
@@ -93,6 +94,7 @@ OptionsDialog::OptionsDialog(QWidget *parent) :
     }
 
     ui->unit->setModel(new BitcoinUnits(this));
+    ui->transactionFee->setSingleStep(CTransaction::nMinTxFee);
 
     /* Widget-to-option mapper */
     mapper = new MonitoredDataMapper(this);


### PR DESCRIPTION
BEFORE:
Single step in sendcoins/receive/options dialog:
BTC: 100000 satoshis
mBTC: 100 satoshi
uBTC: 1 satoshi

AFTER:
Single step in sendcoins/receive dialog:
BTC/mBTC/uBTC: 100000 satoshis

Single step in options dialog:
BTC/mBTC/uBTC: CTransaction::nMinTxFee
