### PR TITLE
Gitian fixes for 0.9.0rc1 build

### DIFF
--- a/contrib/gitian-descriptors/boost-linux.yml
+++ b/contrib/gitian-descriptors/boost-linux.yml
@@ -6,6 +6,7 @@ architectures:
 - "i386"
 - "amd64"
 packages:
+- "g++"
 - "unzip"
 - "pkg-config"
 - "libtool"

--- a/contrib/gitian-descriptors/deps-linux.yml
+++ b/contrib/gitian-descriptors/deps-linux.yml
@@ -6,6 +6,7 @@ architectures:
 - "i386"
 - "amd64"
 packages:
+- "g++"
 - "unzip"
 - "zip"
 - "pkg-config"
@@ -50,7 +51,7 @@ script: |
   tar xjfm qrencode-3.4.3.tar.bz2
   cd qrencode-3.4.3
   #   need --with-pic to avoid relocation error in 64 bit builds
-  ./configure --prefix=$STAGING --enable-static --disable-shared -with-pic --without-tools
+  ./configure --prefix=$STAGING --enable-static --disable-shared --with-pic --without-tools --disable-maintainer-mode --disable-dependency-tracking
   make $MAKEOPTS install
   cd ..
   #

--- a/contrib/gitian-descriptors/deps-win.yml
+++ b/contrib/gitian-descriptors/deps-win.yml
@@ -107,7 +107,7 @@ script: |
     #
     tar xjf $INDIR/qrencode-3.4.3.tar.bz2
     cd qrencode-3.4.3
-    png_CFLAGS="-I$INSTALLPREFIX/include" png_LIBS="-L$INSTALLPREFIX/lib -lpng" ./configure --prefix=$INSTALLPREFIX --host=$HOST
+    png_CFLAGS="-I$INSTALLPREFIX/include" png_LIBS="-L$INSTALLPREFIX/lib -lpng" ./configure --prefix=$INSTALLPREFIX --host=$HOST --enable-static --disable-shared --without-tools --disable-maintainer-mode --disable-dependency-tracking
     make
     make install
     cd ..

--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -6,6 +6,7 @@ architectures:
 - "i386"
 - "amd64"
 packages: 
+- "g++"
 - "libqt4-dev"
 - "git-core"
 - "unzip"

--- a/contrib/gitian-descriptors/gitian-win.yml
+++ b/contrib/gitian-descriptors/gitian-win.yml
@@ -22,8 +22,8 @@ remotes:
 - "url": "https://github.com/bitcoin/bitcoin.git"
   "dir": "bitcoin"
 files:
-- "qt-win32-5.2.0-gitian-r1.zip"
-- "qt-win64-5.2.0-gitian-r1.zip"
+- "qt-win32-5.2.0-gitian-r2.zip"
+- "qt-win64-5.2.0-gitian-r2.zip"
 - "boost-win32-1.55.0-gitian-r6.zip"
 - "boost-win64-1.55.0-gitian-r6.zip"
 - "bitcoin-deps-win32-gitian-r10.zip"
@@ -36,6 +36,14 @@ script: |
   INDIR=$HOME/build
   OPTFLAGS='-O2'
   NEEDDIST=1
+  # Qt: workaround for determinism in resource ordering
+  #  Qt5's rcc uses a QHash to store the files for the resource.
+  #  A security fix in QHash makes the ordering of keys to be different on every run
+  #  (https://qt.gitorious.org/qt/qtbase/commit/c01eaa438200edc9a3bbcd8ae1e8ded058bea268).
+  #  This is good in general but qrc shouldn't be doing a traversal over a randomized container.
+  #  The thorough solution would be to use QMap instead of QHash, but this requires patching Qt.
+  #  For now luckily there is a test mode that forces a fixed seed.
+  export QT_RCC_TEST=1
   for BITS in 32 64; do # for architectures
     #
     STAGING=$HOME/staging${BITS}
@@ -49,7 +57,7 @@ script: |
     mkdir -p $STAGING $BUILDDIR $BINDIR
     #
     cd $STAGING
-    unzip $INDIR/qt-win${BITS}-5.2.0-gitian-r1.zip
+    unzip $INDIR/qt-win${BITS}-5.2.0-gitian-r2.zip
     unzip $INDIR/boost-win${BITS}-1.55.0-gitian-r6.zip
     unzip $INDIR/bitcoin-deps-win${BITS}-gitian-r10.zip
     unzip $INDIR/protobuf-win${BITS}-2.5.0-gitian-r4.zip

--- a/contrib/gitian-descriptors/qt-win.yml
+++ b/contrib/gitian-descriptors/qt-win.yml
@@ -21,6 +21,14 @@ script: |
   # Defines
   export TZ=UTC
   INDIR=$HOME/build
+  # Qt: workaround for determinism in resource ordering
+  #  Qt5's rcc uses a QHash to store the files for the resource.
+  #  A security fix in QHash makes the ordering of keys to be different on every run
+  #  (https://qt.gitorious.org/qt/qtbase/commit/c01eaa438200edc9a3bbcd8ae1e8ded058bea268).
+  #  This is good in general but qrc shouldn't be doing a traversal over a randomized container.
+  #  The thorough solution would be to use QMap instead of QHash, but this requires patching Qt.
+  #  For now luckily there is a test mode that forces a fixed seed.
+  export QT_RCC_TEST=1
   # Integrity Check
   echo "395ec72277c5786c65b8163ef5817fd03d0a1f524a6d47f53624baf8056f1081  qt-everywhere-opensource-src-5.2.0.tar.gz" | sha256sum -c
 
@@ -71,7 +79,7 @@ script: |
 
     # as zip stores file timestamps, use faketime to intercept stat calls to set dates for all files to reference date
     export LD_PRELOAD=/usr/lib/faketime/libfaketime.so.1
-    zip -r $OUTDIR/qt-win${BITS}-5.2.0-gitian-r1.zip *
+    zip -r $OUTDIR/qt-win${BITS}-5.2.0-gitian-r2.zip *
     unset LD_PRELOAD
     unset FAKETIME
   done # for BITS in


### PR DESCRIPTION
- Add 'g++' package (virtualbox images don't have this by default)
- Workaround for determinism in Qt5 resources
- Pass --disable-maintainer-mode --disable-dependency-tracking to
  configure for libqrencode to avoid random errors about missing m4
  directory
- Fix typo -with-pic -> --with-pic

It is ~~not~~ necessary to rebuild dependencies after this commit.
Fixes #3610 and #3612.
