### PR TITLE
added missing homebrew qt dependency on mac osx build documentation.

### DIFF
--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -69,7 +69,7 @@ Instructions: Homebrew
 
 #### Install dependencies using Homebrew
 
-        brew install autoconf automake berkeley-db4 boost miniupnpc openssl pkg-config protobuf
+        brew install autoconf automake berkeley-db4 boost miniupnpc openssl pkg-config protobuf qt
 
 Note: After you have installed the dependencies, you should check that the Homebrew installed version of OpenSSL is the one available for compilation. You can check this by typing
 


### PR DESCRIPTION
after dealing with several linking issues to build on osx and sucessfully building bitcoin, I found out the qt client hadn't been built (which is where I intend to contribute). Thought this might be a necessary dependency specified on the OSX documentation. I did not touch the Macports section as I don't work with macports and it might be different.

Cheers.
