### PR TITLE
gitian: Make linux build of dependencies deterministic

### DIFF
--- a/contrib/gitian-descriptors/boost-linux.yml
+++ b/contrib/gitian-descriptors/boost-linux.yml
@@ -20,11 +20,14 @@ files:
 script: |
   STAGING="$HOME/install"
   export LIBRARY_PATH="$STAGING/lib"
+  export LD_PRELOAD=/usr/lib/faketime/libfaketime.so.1
+  export FAKETIME=$REFERENCE_DATETIME
+  export TZ=UTC
   # Input Integrity Check
   echo "fff00023dd79486d444c8e29922f4072e1d451fc5a4d2b6075852ead7f2b7b52  boost_1_55_0.tar.bz2" | shasum -c
 
   mkdir -p "$STAGING"
-  tar xjf boost_1_55_0.tar.bz2
+  tar --warning=no-timestamp -xjf boost_1_55_0.tar.bz2
   cd boost_1_55_0
   GCCVERSION=$(g++ -E -dM $(mktemp --suffix=.h) | grep __VERSION__ | cut -d ' ' -f 3 | cut -d '"' -f 2)
   # note: bjam with -d+2 reveals that -O3 is implied by default, no need to provide it in cxxflags
@@ -38,6 +41,4 @@ script: |
   ./bjam toolset=gcc threadapi=pthread threading=multi variant=release link=static runtime-link=shared --user-config=user-config.jam --without-mpi --without-python -sNO_BZIP2=1 --layout=tagged --build-type=complete --prefix="$STAGING" $MAKEOPTS install
 
   cd "$STAGING"
-  export LD_PRELOAD=/usr/lib/faketime/libfaketime.so.1
-  export FAKETIME=$REFERENCE_DATETIME
-  zip -r $OUTDIR/boost-linux${GBUILD_BITS}-1.55.0-gitian-r1.zip *
+  find -type f | sort | zip -X@ $OUTDIR/boost-linux${GBUILD_BITS}-1.55.0-gitian-r1.zip

--- a/contrib/gitian-descriptors/boost-linux.yml
+++ b/contrib/gitian-descriptors/boost-linux.yml
@@ -19,6 +19,7 @@ files:
 - "boost_1_55_0.tar.bz2"
 script: |
   STAGING="$HOME/install"
+  TEMPDIR="$HOME/tmp"
   export LIBRARY_PATH="$STAGING/lib"
   export LD_PRELOAD=/usr/lib/faketime/libfaketime.so.1
   export FAKETIME=$REFERENCE_DATETIME
@@ -38,7 +39,16 @@ script: |
 
   ./bootstrap.sh --without-icu
 
-  ./bjam toolset=gcc threadapi=pthread threading=multi variant=release link=static runtime-link=shared --user-config=user-config.jam --without-mpi --without-python -sNO_BZIP2=1 --layout=tagged --build-type=complete --prefix="$STAGING" $MAKEOPTS install
+  ./bjam toolset=gcc threadapi=pthread threading=multi variant=release link=static runtime-link=shared --user-config=user-config.jam --without-mpi --without-python -sNO_BZIP2=1 --layout=tagged --build-type=complete --prefix="$STAGING" $MAKEOPTS -d+2 install
 
+  # post-process all generated libraries to be deterministic
+  # extract them to a temporary directory then re-build them deterministically
+  for LIB in $(find $STAGING -name \*.a); do
+    rm -rf $TEMPDIR && mkdir $TEMPDIR && cd $TEMPDIR
+    ar xv $LIB | cut -b5- > /tmp/list.txt
+    rm $LIB
+    ar crsD $LIB $(cat /tmp/list.txt)
+  done
+  #
   cd "$STAGING"
-  find -type f | sort | zip -X@ $OUTDIR/boost-linux${GBUILD_BITS}-1.55.0-gitian-r1.zip
+  find | sort | zip -X@ $OUTDIR/boost-linux${GBUILD_BITS}-1.55.0-gitian-r1.zip

--- a/contrib/gitian-descriptors/deps-linux.yml
+++ b/contrib/gitian-descriptors/deps-linux.yml
@@ -24,6 +24,9 @@ files:
 script: |
   STAGING="$HOME/install"
   OPTFLAGS='-O2'
+  export LD_PRELOAD=/usr/lib/faketime/libfaketime.so.1
+  export FAKETIME=$REFERENCE_DATETIME
+  export TZ=UTC
   export LIBRARY_PATH="$STAGING/lib"
   # Integrity Check
   echo "f74f15e8c8ff11aa3d5bb5f276d202ec18d7246e95f961db76054199c69c1ae3  openssl-1.0.1e.tar.gz"  | sha256sum -c
@@ -37,6 +40,7 @@ script: |
   cd openssl-1.0.1e
   #   need -fPIC to avoid relocation error in 64 bit builds
   ./config no-shared no-zlib no-dso no-krb5 --openssldir=$STAGING -fPIC
+  #   need to build OpenSSL with faketime because a timestamp is embedded into cversion.o
   make
   make install_sw
   cd ..
@@ -48,18 +52,26 @@ script: |
   rm -f $STAGING/lib/libminiupnpc.so* # no way to skip shared lib build
   cd ..
   #
-  tar xjfm qrencode-3.4.3.tar.bz2
+  tar xjf qrencode-3.4.3.tar.bz2
   cd qrencode-3.4.3
+  unset FAKETIME # unset fake time during configure, as it does some clock sanity tests
   #   need --with-pic to avoid relocation error in 64 bit builds
-  ./configure --prefix=$STAGING --enable-static --disable-shared --with-pic --without-tools --disable-maintainer-mode --disable-dependency-tracking
+  ./configure --prefix=$STAGING --enable-static --disable-shared --with-pic --without-tools --disable-dependency-tracking --without-zlib
+  # Workaround to prevent re-configuring by make; make all files have a date in the past
+  find . -print0 | xargs -r0 touch -t 200001010000
+  export FAKETIME=$REFERENCE_DATETIME
   make $MAKEOPTS install
   cd ..
   #
-  tar xjfm protobuf-2.5.0.tar.bz2
+  tar xjf protobuf-2.5.0.tar.bz2
   cd protobuf-2.5.0
   mkdir -p $STAGING/host/bin
+  unset FAKETIME # unset fake time during configure, as it does some clock sanity tests
   #   need --with-pic to avoid relocation error in 64 bit builds
   ./configure --prefix=$STAGING --bindir=$STAGING/host/bin --enable-static --disable-shared --with-pic
+  # Workaround to prevent re-configuring by make; make all files have a date in the past
+  find . -print0 | xargs -r0 touch -t 200001010000
+  export FAKETIME=$REFERENCE_DATETIME
   make $MAKEOPTS install
   cd ..
   #
@@ -67,9 +79,11 @@ script: |
   cd db-4.8.30.NC/build_unix
   #   need --with-pic to avoid relocation error in 64 bit builds
   ../dist/configure --prefix=$STAGING --enable-cxx --disable-shared --with-pic
+  # Workaround to prevent re-configuring by make; make all files have a date in the past
+  find . -print0 | xargs -r0 touch -t 200001010000
   make $MAKEOPTS library_build
   make install_lib install_include
   cd ../..
   #
   cd $STAGING
-  zip -r $OUTDIR/bitcoin-deps-linux${GBUILD_BITS}-gitian-r2.zip include lib bin host
+  find include lib bin host -type f | sort | zip -X@ $OUTDIR/bitcoin-deps-linux${GBUILD_BITS}-gitian-r3.zip

--- a/contrib/gitian-descriptors/deps-linux.yml
+++ b/contrib/gitian-descriptors/deps-linux.yml
@@ -56,7 +56,7 @@ script: |
   cd qrencode-3.4.3
   unset FAKETIME # unset fake time during configure, as it does some clock sanity tests
   #   need --with-pic to avoid relocation error in 64 bit builds
-  ./configure --prefix=$STAGING --enable-static --disable-shared --with-pic --without-tools --disable-dependency-tracking --without-zlib
+  ./configure --prefix=$STAGING --enable-static --disable-shared --with-pic --without-tools --disable-dependency-tracking
   # Workaround to prevent re-configuring by make; make all files have a date in the past
   find . -print0 | xargs -r0 touch -t 200001010000
   export FAKETIME=$REFERENCE_DATETIME
@@ -68,7 +68,7 @@ script: |
   mkdir -p $STAGING/host/bin
   unset FAKETIME # unset fake time during configure, as it does some clock sanity tests
   #   need --with-pic to avoid relocation error in 64 bit builds
-  ./configure --prefix=$STAGING --bindir=$STAGING/host/bin --enable-static --disable-shared --with-pic
+  ./configure --prefix=$STAGING --bindir=$STAGING/host/bin --enable-static --disable-shared --with-pic --without-zlib
   # Workaround to prevent re-configuring by make; make all files have a date in the past
   find . -print0 | xargs -r0 touch -t 200001010000
   export FAKETIME=$REFERENCE_DATETIME

--- a/contrib/gitian-descriptors/deps-linux.yml
+++ b/contrib/gitian-descriptors/deps-linux.yml
@@ -23,6 +23,7 @@ files:
 - "db-4.8.30.NC.tar.gz"
 script: |
   STAGING="$HOME/install"
+  TEMPDIR="$HOME/tmp"
   OPTFLAGS='-O2'
   export LD_PRELOAD=/usr/lib/faketime/libfaketime.so.1
   export FAKETIME=$REFERENCE_DATETIME
@@ -84,6 +85,14 @@ script: |
   make $MAKEOPTS library_build
   make install_lib install_include
   cd ../..
+  # post-process all generated libraries to be deterministic
+  # extract them to a temporary directory then re-build them deterministically
+  for LIB in $(find $STAGING -name \*.a); do
+    rm -rf $TEMPDIR && mkdir $TEMPDIR && cd $TEMPDIR
+    ar xv $LIB | cut -b5- > /tmp/list.txt
+    rm $LIB
+    ar crsD $LIB $(cat /tmp/list.txt)
+  done
   #
   cd $STAGING
-  find include lib bin host -type f | sort | zip -X@ $OUTDIR/bitcoin-deps-linux${GBUILD_BITS}-gitian-r3.zip
+  find include lib bin host | sort | zip -X@ $OUTDIR/bitcoin-deps-linux${GBUILD_BITS}-gitian-r3.zip

--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -21,8 +21,8 @@ remotes:
 - "url": "https://github.com/bitcoin/bitcoin.git"
   "dir": "bitcoin"
 files:
-- "bitcoin-deps-linux32-gitian-r2.zip"
-- "bitcoin-deps-linux64-gitian-r2.zip"
+- "bitcoin-deps-linux32-gitian-r3.zip"
+- "bitcoin-deps-linux64-gitian-r3.zip"
 - "boost-linux32-1.55.0-gitian-r1.zip"
 - "boost-linux64-1.55.0-gitian-r1.zip"
 script: |
@@ -34,7 +34,7 @@ script: |
   #
   mkdir -p $STAGING
   cd $STAGING
-  unzip ../build/bitcoin-deps-linux${GBUILD_BITS}-gitian-r2.zip
+  unzip ../build/bitcoin-deps-linux${GBUILD_BITS}-gitian-r3.zip
   unzip ../build/boost-linux${GBUILD_BITS}-1.55.0-gitian-r1.zip
   cd ../build
   #

--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -29,6 +29,8 @@ script: |
   STAGING="$HOME/install"
   OPTFLAGS='-O2'
   BINDIR="${OUTDIR}/bin/${GBUILD_BITS}" # 32/64 bit build specific output directory
+  TEMPDIR="$HOME/tempdir"
+  export TZ=UTC
   export LIBRARY_PATH="$STAGING/lib"
   mkdir -p ${BINDIR}
   #
@@ -39,15 +41,20 @@ script: |
   cd ../build
   #
   cd bitcoin
-  export TAR_OPTIONS=--mtime=`echo $REFERENCE_DATETIME | awk '{ print $1 }'`
   ./autogen.sh
   ./configure --prefix=$STAGING --bindir=$BINDIR --with-protoc-bindir=$STAGING/host/bin --with-boost=$STAGING --disable-maintainer-mode --disable-dependency-tracking PKG_CONFIG_PATH="$STAGING/lib/pkgconfig" CPPFLAGS="-I$STAGING/include ${OPTFLAGS}" LDFLAGS="-L$STAGING/lib ${OPTFLAGS}" CXXFLAGS="-frandom-seed=bitcoin ${OPTFLAGS}" BOOST_CHRONO_EXTRALIBS="-lrt"
   make dist
+  DISTNAME=`echo bitcoin-*.tar.gz`
   mkdir -p distsrc
   cd distsrc
-  tar --strip-components=1 -xf ../bitcoin-*.tar.*
+  tar --strip-components=1 -xf ../$DISTNAME
   ./configure --prefix=$STAGING --bindir=$BINDIR --with-protoc-bindir=$STAGING/host/bin --with-boost=$STAGING --disable-maintainer-mode --disable-dependency-tracking PKG_CONFIG_PATH="$STAGING/lib/pkgconfig" CPPFLAGS="-I$STAGING/include ${OPTFLAGS}" LDFLAGS="-L$STAGING/lib ${OPTFLAGS}" CXXFLAGS="-frandom-seed=bitcoin ${OPTFLAGS}" BOOST_CHRONO_EXTRALIBS="-lrt"
   make $MAKEOPTS
   make $MAKEOPTS install-strip
+  
+  # sort distribution tar file and normalize user/group/mtime information for deterministic output
   mkdir -p $OUTDIR/src
-  cp ../bitcoin-*.tar.* $OUTDIR/src
+  rm -rf $TEMPDIR
+  mkdir -p $TEMPDIR
+  cd $TEMPDIR
+  tar -xvf $HOME/build/bitcoin/$DISTNAME | sort | tar --no-recursion -cT /dev/stdin --mode='u+rw,go+r-w,a+X' --owner=0 --group=0 --mtime="$REFERENCE_DATETIME" | gzip -n > $OUTDIR/src/$DISTNAME


### PR DESCRIPTION
OpenSSL was embedding a timestamp causing its build to be non-deterministic.
Change deps-linux to be deterministic by using FAKETIME as needed and disabling it when it gets in the way.

Outputs when built w/ KVM (and repeated with LXC), built a few times and they match every time:

Deps:

```
05fe8e9aef00d295f24a94deef7d3a918af5aeef371ba57fdd5a6acd8c51f6cb  bitcoin-deps-linux32-gitian-r3.zip
4227aa9d9fedbb4265b8d10a4f78b7435f34b00a54eb4d662bf78f59c6e70c27  bitcoin-deps-linux64-gitian-r3.zip
```

Boost:

```
149a464f02aa809a340306d13fc0ecb1a347057ca99daf846100e7e3c53d85c2  boost-linux32-1.55.0-gitian-r1.zip
c47bc1a5ffa5097c10280fb2fffb462a925cac5873c4ce7268e404281bddd133  boost-linux64-1.55.0-gitian-r1.zip
```

Result from building 0.9.0rc1 (15ec451) using the descriptors in this pull:

```
20b208827262ad4a4afb2419e60bf27c16e96406e3df518f77d56771e22ab13f  bin/32/bitcoin-cli
5d1f2a19bad40fb1c7f6ea0edaddf750820d8d1f5e17ab6071f88df8e174ca34  bin/32/bitcoin-qt
260d5b0cdc10a7b7ea81f5cc51a8fe1533b3ca43e5470c78b830683e7d0ec354  bin/32/bitcoind
557671b4ae41fb4561d83360e9da917a5b29a1c315fcf470d16230e4a5e64548  bin/32/test_bitcoin
ab9b1078841c5d25cb9c05b3baf214e789b1640d5fab535c86191be4cccd0221  bin/32/test_bitcoin-qt
20a93099050df6176afa3a5745b15e54be88831bd7deb91398038d6b57013917  bin/64/bitcoin-cli
685784a29cd9d33b28c23cb1690e1bca4ae820c42c2f3a3dab8592236a10c050  bin/64/bitcoin-qt
fafa628df8411c5b44bc770010ae577377d812548c10ef9e06f8b7f9a916b1e7  bin/64/bitcoind
b62e830e6560fba96075964d406f9948b53fafd6c9009cd98caa1b87c4e87171  bin/64/test_bitcoin
1427bba689501d22e16f2c380d7b45a247afbf84be222f692354eee4a7f5038e  bin/64/test_bitcoin-qt
848875dca917077a5419e876e0ef234cd6b375a55904d08f8706d861eaa57f6b  bin/bitcoin-0.9.0.tar.gz
```
