### PR TITLE
Update the address for downloading libpng

### DIFF
--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -43,7 +43,7 @@ Release Process
 	wget 'https://www.openssl.org/source/openssl-1.0.1e.tar.gz'
 	wget 'http://download.oracle.com/berkeley-db/db-4.8.30.NC.tar.gz'
 	wget 'http://zlib.net/zlib-1.2.8.tar.gz'
-	wget 'ftp://ftp.simplesystems.org/pub/png/src/libpng16/libpng-1.6.8.tar.gz'
+	wget 'ftp://ftp.simplesystems.org/pub/png/src/history/libpng16/libpng-1.6.8.tar.gz'
 	wget 'https://fukuchi.org/works/qrencode/qrencode-3.4.3.tar.bz2'
 	wget 'https://downloads.sourceforge.net/project/boost/boost/1.55.0/boost_1_55_0.tar.bz2'
 	wget 'https://svn.boost.org/trac/boost/raw-attachment/ticket/7262/boost-mingw.patch' -O \ 


### PR DESCRIPTION
The FTP server what we get libpng from only keeps the latest version in its main folder. Older versions are in the "history" folder. Apparently version 1.6.9 has been released, so 1.6.8 has moved to the history folder.
