### PR TITLE
[Qt] remove broken OptionsModel::Upgrade()

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -376,9 +376,6 @@ void BitcoinApplication::initializeResult(int retval)
     returnValue = retval ? 0 : 1;
     if(retval)
     {
-        // Miscellaneous initialization after core is initialized
-        optionsModel->Upgrade(); // Must be done after AppInit2
-
 #ifdef ENABLE_WALLET
         PaymentServer::LoadRootCAs();
         paymentServer->setOptionsModel(optionsModel);

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -130,69 +130,6 @@ void OptionsModel::Reset()
     // default setting for OptionsModel::StartAtStartup - disabled
     if (GUIUtil::GetStartOnSystemStartup())
         GUIUtil::SetStartOnSystemStartup(false);
-
-    // Ensure Upgrade() is not running again by setting the bImportFinished flag
-    settings.setValue("bImportFinished", true);
-}
-
-void OptionsModel::Upgrade()
-{
-    QSettings settings;
-
-    // Already upgraded
-    if (settings.contains("bImportFinished"))
-        return;
-
-    settings.setValue("bImportFinished", true);
-
-#ifdef ENABLE_WALLET
-    // Move settings from old wallet.dat (if any):
-    CWalletDB walletdb(strWalletFile);
-
-    QList<QString> intOptions;
-    intOptions << "nDisplayUnit" << "nTransactionFee";
-    foreach(QString key, intOptions)
-    {
-        int value = 0;
-        if (walletdb.ReadSetting(key.toStdString(), value))
-        {
-            settings.setValue(key, value);
-            walletdb.EraseSetting(key.toStdString());
-        }
-    }
-    QList<QString> boolOptions;
-    boolOptions << "bDisplayAddresses" << "fMinimizeToTray" << "fMinimizeOnClose" << "fUseProxy" << "fUseUPnP";
-    foreach(QString key, boolOptions)
-    {
-        bool value = false;
-        if (walletdb.ReadSetting(key.toStdString(), value))
-        {
-            settings.setValue(key, value);
-            walletdb.EraseSetting(key.toStdString());
-        }
-    }
-    try
-    {
-        CAddress addrProxyAddress;
-        if (walletdb.ReadSetting("addrProxy", addrProxyAddress))
-        {
-            settings.setValue("addrProxy", addrProxyAddress.ToStringIPPort().c_str());
-            walletdb.EraseSetting("addrProxy");
-        }
-    }
-    catch (std::ios_base::failure &e)
-    {
-        // 0.6.0rc1 saved this as a CService, which causes failure when parsing as a CAddress
-        CService addrProxy;
-        if (walletdb.ReadSetting("addrProxy", addrProxy))
-        {
-            settings.setValue("addrProxy", addrProxy.ToStringIPPort().c_str());
-            walletdb.EraseSetting("addrProxy");
-        }
-    }
-#endif
-
-    Init();
 }
 
 int OptionsModel::rowCount(const QModelIndex & parent) const

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -46,9 +46,6 @@ public:
     void Init();
     void Reset();
 
-    /* Migrate settings from wallet.dat after app initialization */
-    void Upgrade();
-
     int rowCount(const QModelIndex & parent = QModelIndex()) const;
     QVariant data(const QModelIndex & index, int role = Qt::DisplayRole) const;
     bool setData(const QModelIndex & index, const QVariant & value, int role = Qt::EditRole);

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -191,18 +191,6 @@ void CWallet::SetBestChain(const CBlockLocator& loc)
     walletdb.WriteBestBlock(loc);
 }
 
-// This class implements an addrIncoming entry that causes pre-0.4
-// clients to crash on startup if reading a private-key-encrypted wallet.
-class CCorruptAddress
-{
-public:
-    IMPLEMENT_SERIALIZE
-    (
-        if (nType & SER_DISK)
-            READWRITE(nVersion);
-    )
-};
-
 bool CWallet::SetMinVersion(enum WalletFeature nVersion, CWalletDB* pwalletdbIn, bool fExplicit)
 {
     AssertLockHeld(cs_wallet); // nWalletVersion
@@ -221,13 +209,6 @@ bool CWallet::SetMinVersion(enum WalletFeature nVersion, CWalletDB* pwalletdbIn,
     if (fFileBacked)
     {
         CWalletDB* pwalletdb = pwalletdbIn ? pwalletdbIn : new CWalletDB(strWalletFile);
-        if (nWalletVersion >= 40000)
-        {
-            // Versions prior to 0.4.0 did not support the "minversion" record.
-            // Use a CCorruptAddress to make them crash instead.
-            CCorruptAddress corruptAddress;
-            pwalletdb->WriteSetting("addrIncoming", corruptAddress);
-        }
         if (nWalletVersion > 40000)
             pwalletdb->WriteMinVersion(nWalletVersion);
         if (!pwalletdbIn)

--- a/src/walletdb.cpp
+++ b/src/walletdb.cpp
@@ -154,12 +154,6 @@ bool CWalletDB::ErasePool(int64_t nPool)
     return Erase(std::make_pair(std::string("pool"), nPool));
 }
 
-bool CWalletDB::EraseSetting(const std::string& strKey)
-{
-    nWalletDBUpdated++;
-    return Erase(std::make_pair(std::string("setting"), strKey));
-}
-
 bool CWalletDB::WriteMinVersion(int nVersion)
 {
     return Write(std::string("minversion"), nVersion);

--- a/src/walletdb.h
+++ b/src/walletdb.h
@@ -104,22 +104,6 @@ public:
     bool WritePool(int64_t nPool, const CKeyPool& keypool);
     bool ErasePool(int64_t nPool);
 
-    // Settings are no longer stored in wallet.dat; these are
-    // used only for backwards compatibility:
-    template<typename T>
-    bool ReadSetting(const std::string& strKey, T& value)
-    {
-        return Read(std::make_pair(std::string("setting"), strKey), value);
-    }
-    template<typename T>
-    bool WriteSetting(const std::string& strKey, const T& value)
-    {
-        nWalletDBUpdated++;
-        return Write(std::make_pair(std::string("setting"), strKey), value);
-    }
- 
-    bool EraseSetting(const std::string& strKey);
-
     bool WriteMinVersion(int nVersion);
 
     bool ReadAccount(const std::string& strAccount, CAccount& account);


### PR DESCRIPTION
When starting bitcoin-qt without a qt-settings file, strOverriddenByCommandLine contains some false values,
because OptionsModel::Upgrade() calls OptionsModel::Init() a second time and SoftSetArgs have been set before with default values.

Also to me it looks like OptionsModel::Init() assumes that AppInit2 is called after,
but OptionsModel::Upgrade() is called after AppInit2. This would mean that some options set in OptionsModel::Upgrade() are not even applied.
For example setting the proxy options through Upgrade() is broken, I assume (havent tested).

So my suggestion is to remove OptionsModel::Upgrade() completely.
