### PR TITLE
Make datadir handling more consistent

### DIFF
--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -22,23 +22,6 @@ static bool AppInitRPC(int argc, char* argv[])
     // Parameters
     //
     ParseParameters(argc, argv);
-    if (!boost::filesystem::is_directory(GetDataDir(false)))
-    {
-        fprintf(stderr, "Error: Specified data directory \"%s\" does not exist.\n", mapArgs["-datadir"].c_str());
-        return false;
-    }
-    try {
-        ReadConfigFile(mapArgs, mapMultiArgs);
-    } catch(std::exception &e) {
-        fprintf(stderr,"Error reading configuration file: %s\n", e.what());
-        return false;
-    }
-    // Check for -testnet or -regtest parameter (TestNet() calls are only valid after this clause)
-    if (!SelectParamsFromCommandLine()) {
-        fprintf(stderr, "Error: Invalid combination of -regtest and -testnet.\n");
-        return false;
-    }
-
     if (argc<2 || mapArgs.count("-?") || mapArgs.count("--help"))
     {
         // First part of help message is specific to RPC client
@@ -53,6 +36,23 @@ static bool AppInitRPC(int argc, char* argv[])
         fprintf(stdout, "%s", strUsage.c_str());
         return false;
     }
+    // Allow the data directory to not exist or not be creatable,
+    // in that case don't read the config file.
+    if (boost::filesystem::is_directory(GetDataDir(false)))
+    {
+        try {
+            ReadConfigFile(mapArgs, mapMultiArgs);
+        } catch(std::exception &e) {
+            fprintf(stderr,"Error reading configuration file: %s\n", e.what());
+            return false;
+        }
+    }
+    // Check for -testnet or -regtest parameter (TestNet() calls are only valid after this clause)
+    if (!SelectParamsFromCommandLine()) {
+        fprintf(stderr, "Error: Invalid combination of -regtest and -testnet.\n");
+        return false;
+    }
+
     return true;
 }
 

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -65,24 +65,6 @@ bool AppInit(int argc, char* argv[])
         //
         // If Qt is used, parameters/bitcoin.conf are parsed in qt/bitcoin.cpp's main()
         ParseParameters(argc, argv);
-        if (!boost::filesystem::is_directory(GetDataDir(false)))
-        {
-            fprintf(stderr, "Error: Specified data directory \"%s\" does not exist.\n", mapArgs["-datadir"].c_str());
-            return false;
-        }
-        try
-        {
-            ReadConfigFile(mapArgs, mapMultiArgs);
-        } catch(std::exception &e) {
-            fprintf(stderr,"Error reading configuration file: %s\n", e.what());
-            return false;
-        }
-        // Check for -testnet or -regtest parameter (TestNet() calls are only valid after this clause)
-        if (!SelectParamsFromCommandLine()) {
-            fprintf(stderr, "Error: Invalid combination of -regtest and -testnet.\n");
-            return false;
-        }
-
         if (mapArgs.count("-?") || mapArgs.count("--help"))
         {
             // First part of help message is specific to bitcoind / RPC client
@@ -98,6 +80,30 @@ bool AppInit(int argc, char* argv[])
             strUsage += "\n" + HelpMessageCli(false);
 
             fprintf(stdout, "%s", strUsage.c_str());
+            return false;
+        }
+
+        if (!boost::filesystem::is_directory(GetDataDir(false)))
+        {
+            if(mapArgs.count("-datadir"))
+            {
+                fprintf(stderr, "Error: Specified data directory \"%s\" does not exist.\n", mapArgs["-datadir"].c_str());
+            } else {
+                fprintf(stderr, "Error: Default data directory could not be created\n");
+            }
+            return false;
+        }
+
+        try
+        {
+            ReadConfigFile(mapArgs, mapMultiArgs);
+        } catch(std::exception &e) {
+            fprintf(stderr,"Error reading configuration file: %s\n", e.what());
+            return false;
+        }
+        // Check for -testnet or -regtest parameter (TestNet() calls are only valid after this clause)
+        if (!SelectParamsFromCommandLine()) {
+            fprintf(stderr, "Error: Invalid combination of -regtest and -testnet.\n");
             return false;
         }
 

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -290,10 +290,11 @@ BitcoinApplication::BitcoinApplication(int &argc, char **argv):
 
 BitcoinApplication::~BitcoinApplication()
 {
-    LogPrintf("Stopping thread\n");
+    /* Do not use logging here, as it will write to the data directory
+     * which may not even have been initialized yet.
+     */
     emit stopThread();
     coreThread->wait();
-    LogPrintf("Stopped thread\n");
 
     delete window;
     window = 0;

--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -32,7 +32,7 @@ Object CallRPC(const string& strMethod, const Array& params)
 {
     if (mapArgs["-rpcuser"] == "" && mapArgs["-rpcpassword"] == "")
         throw runtime_error(strprintf(
-            _("You must set rpcpassword=<password> in the configuration file:\n%s\n"
+            _("You must set rpcpassword=<password> in the configuration file or pass it on the command line:\n%s\n"
               "If the file does not exist, create it with owner-readable-only file permissions."),
                 GetConfigFile().string().c_str()));
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -939,7 +939,6 @@ boost::filesystem::path GetDefaultDataDir()
 #ifdef MAC_OSX
     // Mac
     pathRet /= "Library/Application Support";
-    TryCreateDirectory(pathRet);
     return pathRet / "Bitcoin";
 #else
     // Unix
@@ -979,7 +978,12 @@ const boost::filesystem::path &GetDataDir(bool fNetSpecific)
     if (fNetSpecific)
         path /= Params().DataDir();
 
-    fs::create_directories(path);
+    try {
+        fs::create_directories(path);
+    } catch(boost::filesystem::filesystem_error &e) {
+        path = "";
+        return path;
+    }
 
     return path;
 }


### PR DESCRIPTION
- Don't error out with an exception when it is impossible to create the default data directory, but return an empty datadir just like when otherwise passing an invalid datadir. Add a friendly error message for when this really becomes a problem.
- Move --help handling before data directory check and config file parsing.
- Don't check for existence of datadir in bitcoin-cli. It should be possible to run it without.
- Don't log in BitcoinApplication::~BitcoinApplication(), it's very possible that the data directory isn't set up. This avoids creating ~/.bitcoin on bitcoin-qt --help.

Fixes #3639
