### PR TITLE
Log warnings when bootstrap files are specified but cannot be opened

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -336,6 +336,8 @@ void ThreadImport(std::vector<boost::filesystem::path> vImportFiles)
             LogPrintf("Importing bootstrap.dat...\n");
             LoadExternalBlockFile(file);
             RenameOver(pathBootstrap, pathBootstrapOld);
+        } else {
+            LogPrintf("Warning: Could not open bootstrap file %s\n", pathBootstrap.string());
         }
     }
 
@@ -344,8 +346,10 @@ void ThreadImport(std::vector<boost::filesystem::path> vImportFiles)
         FILE *file = fopen(path.string().c_str(), "rb");
         if (file) {
             CImportingNow imp;
-            LogPrintf("Importing %s...\n", path.string());
+            LogPrintf("Importing blocks file %s...\n", path.string());
             LoadExternalBlockFile(file);
+        } else {
+            LogPrintf("Warning: Could not open blocks file %s\n", path.string());
         }
     }
 }


### PR DESCRIPTION
- Log a warning when bootstrap files are specified using `-loadblock` but cannot be opened.
- Log a warning when bootstrap.dat exists in the home directory but cannot be opened.

Makes it easier to debug problems where bitcoind somehow ignores the bootstrap.
