### PR TITLE
[Qt] show fee warnings in optionsdialog

### DIFF
--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>560</width>
-    <height>400</height>
+    <height>420</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -28,100 +28,122 @@
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_Main">
        <item>
-        <widget class="QCheckBox" name="bitcoinAtStartup">
-         <property name="toolTip">
-          <string>Automatically start Bitcoin after logging in to the system.</string>
+        <widget class="QFrame" name="frame_2">
+         <property name="frameShape">
+          <enum>QFrame::NoFrame</enum>
          </property>
-         <property name="text">
-          <string>&amp;Start Bitcoin on system login</string>
+         <property name="frameShadow">
+          <enum>QFrame::Sunken</enum>
          </property>
+         <property name="lineWidth">
+          <number>1</number>
+         </property>
+         <property name="midLineWidth">
+          <number>0</number>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_4">
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <item>
+           <layout class="QFormLayout" name="formLayout">
+            <property name="fieldGrowthPolicy">
+             <enum>QFormLayout::ExpandingFieldsGrow</enum>
+            </property>
+            <property name="labelAlignment">
+             <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+            </property>
+            <property name="horizontalSpacing">
+             <number>20</number>
+            </property>
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <item row="0" column="0">
+             <widget class="QCheckBox" name="bitcoinAtStartup">
+              <property name="toolTip">
+               <string>Automatically start Bitcoin after logging in to the system.</string>
+              </property>
+              <property name="text">
+               <string>&amp;Start Bitcoin on system login</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="0">
+             <widget class="QLabel" name="databaseCacheLabel">
+              <property name="text">
+               <string>Size of &amp;database cache</string>
+              </property>
+              <property name="textFormat">
+               <enum>Qt::PlainText</enum>
+              </property>
+              <property name="buddy">
+               <cstring>databaseCache</cstring>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <layout class="QHBoxLayout" name="horizontalLayout_2_Main">
+              <property name="spacing">
+               <number>5</number>
+              </property>
+              <item>
+               <widget class="QSpinBox" name="databaseCache"/>
+              </item>
+              <item>
+               <widget class="QLabel" name="databaseCacheUnitLabel">
+                <property name="text">
+                 <string>MB</string>
+                </property>
+                <property name="textFormat">
+                 <enum>Qt::PlainText</enum>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item row="2" column="0">
+             <widget class="QLabel" name="threadsScriptVerifLabel">
+              <property name="text">
+               <string>Number of script &amp;verification threads</string>
+              </property>
+              <property name="textFormat">
+               <enum>Qt::PlainText</enum>
+              </property>
+              <property name="buddy">
+               <cstring>threadsScriptVerif</cstring>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="1">
+             <widget class="QSpinBox" name="threadsScriptVerif">
+              <property name="toolTip">
+               <string>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</string>
+              </property>
+              <property name="minimum">
+               <number>-16</number>
+              </property>
+              <property name="maximum">
+               <number>16</number>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
         </widget>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_2_Main">
-         <item>
-          <widget class="QLabel" name="databaseCacheLabel">
-           <property name="text">
-            <string>Size of &amp;database cache</string>
-           </property>
-           <property name="textFormat">
-            <enum>Qt::PlainText</enum>
-           </property>
-           <property name="buddy">
-            <cstring>databaseCache</cstring>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QSpinBox" name="databaseCache"/>
-         </item>
-         <item>
-          <widget class="QLabel" name="databaseCacheUnitLabel">
-           <property name="text">
-            <string>MB</string>
-           </property>
-           <property name="textFormat">
-            <enum>Qt::PlainText</enum>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <spacer name="horizontalSpacer_2_Main">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_3_Main">
-         <item>
-          <widget class="QLabel" name="threadsScriptVerifLabel">
-           <property name="text">
-            <string>Number of script &amp;verification threads</string>
-           </property>
-           <property name="textFormat">
-            <enum>Qt::PlainText</enum>
-           </property>
-           <property name="buddy">
-            <cstring>threadsScriptVerif</cstring>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QSpinBox" name="threadsScriptVerif">
-           <property name="toolTip">
-            <string>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</string>
-           </property>
-           <property name="minimum">
-            <number>-16</number>
-           </property>
-           <property name="maximum">
-            <number>16</number>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <spacer name="horizontalSpacer_3_Main">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-        </layout>
        </item>
        <item>
         <spacer name="verticalSpacer_Main">
@@ -131,7 +153,7 @@
          <property name="sizeHint" stdset="0">
           <size>
            <width>20</width>
-           <height>40</height>
+           <height>5</height>
           </size>
          </property>
         </spacer>
@@ -144,50 +166,105 @@
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_Wallet">
        <item>
-        <widget class="QLabel" name="transactionFeeInfoLabel">
-         <property name="text">
-          <string>Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB.</string>
+        <widget class="QGroupBox" name="groupBoxFee">
+         <property name="title">
+          <string>Fee</string>
          </property>
-         <property name="textFormat">
-          <enum>Qt::PlainText</enum>
-         </property>
-         <property name="wordWrap">
-          <bool>true</bool>
-         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_2">
+          <item>
+           <widget class="QLabel" name="transactionFeeInfoLabel">
+            <property name="text">
+             <string>Transaction fee per kB that is paid to bitcoin miners for confirming your transactions. Most transactions are 1 kB.</string>
+            </property>
+            <property name="textFormat">
+             <enum>Qt::PlainText</enum>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="labelCurrentDefaultFee">
+            <property name="text">
+             <string/>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+            <property name="textInteractionFlags">
+             <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_1_Wallet">
+            <item>
+             <widget class="QLabel" name="transactionFeeLabel">
+              <property name="text">
+               <string>Pay transaction &amp;fee</string>
+              </property>
+              <property name="textFormat">
+               <enum>Qt::PlainText</enum>
+              </property>
+              <property name="buddy">
+               <cstring>transactionFee</cstring>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="BitcoinAmountField" name="transactionFee"/>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_1_Wallet">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_4_Main">
+            <item>
+             <widget class="QLabel" name="labelFeeWarningHead">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="styleSheet">
+               <string notr="true">color:red;</string>
+              </property>
+              <property name="text">
+               <string>Warning:</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="labelFeeWarning">
+              <property name="text">
+               <string>You currently pay zero transaction fee. This may result in very long confirmation times.</string>
+              </property>
+              <property name="wordWrap">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
         </widget>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_1_Wallet">
-         <item>
-          <widget class="QLabel" name="transactionFeeLabel">
-           <property name="text">
-            <string>Pay transaction &amp;fee</string>
-           </property>
-           <property name="textFormat">
-            <enum>Qt::PlainText</enum>
-           </property>
-           <property name="buddy">
-            <cstring>transactionFee</cstring>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="BitcoinAmountField" name="transactionFee"/>
-         </item>
-         <item>
-          <spacer name="horizontalSpacer_1_Wallet">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-        </layout>
        </item>
        <item>
         <widget class="QLabel" name="spendZeroConfChangeInfoLabel">
@@ -498,6 +575,12 @@
    <item>
     <widget class="QFrame" name="frame">
      <layout class="QVBoxLayout" name="verticalLayout_Bottom">
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
       <item>
        <layout class="QHBoxLayout" name="horizontalLayout_Bottom">
         <item>

--- a/src/qt/optionsdialog.h
+++ b/src/qt/optionsdialog.h
@@ -45,6 +45,7 @@ private slots:
     void clearStatusLabel();
     void updateDisplayUnit();
     void doProxyIpChecks(QValidatedLineEdit *pUiProxyIp, int nProxyPort);
+    void updateFeeWarning();
 
 signals:
     void proxyIpChecks(QValidatedLineEdit *pUiProxyIp, int nProxyPort);
@@ -54,6 +55,7 @@ private:
     OptionsModel *model;
     MonitoredDataMapper *mapper;
     bool fProxyIpValid;
+    void updateCurrentDefaultFee();
 };
 
 #endif // OPTIONSDIALOG_H


### PR DESCRIPTION
(pull request title has also been edited)
- ~~set default fee to CTransaction::nMinTxFee instead of zero, for both bitcoin-qt and bitcoind. For bitcoin-qt only new installations are affected
  while for bitcoind, everbody who has not set -paytxfee is affected~~
- ~~add default value to --help output for -paytxfee~~
- qt-optionsdialog: change fee description 
- qt-optionsdialog: add fee warnings
- qt-optionsdialog: minor design improvements: added borders and aligned the database and verification threads controls

Before:
![defaultfee1](https://f.cloud.github.com/assets/2814559/2118889/776743b4-912b-11e3-9c50-c0cb99d6af0e.png)

After:
![defaultfee20](https://f.cloud.github.com/assets/2814559/2118890/7dea0320-912b-11e3-8b2a-7f10effbf33c.png)

Warning if fee >= 5 \* minFee. Useful for people who still have the old 50000 satoshis value.
Also useful for people confusing BTC and mBTC...
![defaultfee21](https://f.cloud.github.com/assets/2814559/2118891/8a8dc666-912b-11e3-9de4-1edf1ee92e98.png)

Warning if fee = nonsense value. 0 < fee < minFee
![defaultfee22](https://f.cloud.github.com/assets/2814559/2118893/ae9b588e-912b-11e3-9362-f943e26c2f09.png)

Warning if fee = zero
![defaultfee23](https://f.cloud.github.com/assets/2814559/2118894/b7343aba-912b-11e3-906a-0c9d2f197a87.png)
