### PR TITLE
Add option to avoid spending unconfirmed change

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -274,6 +274,7 @@ std::string HelpMessage(HelpMessageMode hmm)
     strUsage += "  -upgradewallet         " + _("Upgrade wallet to latest format") + "\n";
     strUsage += "  -wallet=<file>         " + _("Specify wallet file (within data directory)") + "\n";
     strUsage += "  -walletnotify=<cmd>    " + _("Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)") + "\n";
+    strUsage += "  -spendzeroconfchange   " + _("Spend unconfirmed change when sending transactions (default: 1)") + "\n";
 #endif
     strUsage += "\n" + _("Block creation options:") + "\n";
     strUsage += "  -blockminsize=<n>      " + _("Set minimum block size in bytes (default: 0)") + "\n";
@@ -539,6 +540,7 @@ bool AppInit2(boost::thread_group& threadGroup)
         if (nTransactionFee > 0.25 * COIN)
             InitWarning(_("Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction."));
     }
+    bSpendZeroConfChange = GetArg("-spendzeroconfchange", true);
 
     strWalletFile = GetArg("-wallet", "wallet.dat");
 #endif

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -18,6 +18,7 @@ using namespace std;
 
 // Settings
 int64_t nTransactionFee = 0;
+bool bSpendZeroConfChange = true;
 
 //////////////////////////////////////////////////////////////////////////////
 //
@@ -1192,7 +1193,7 @@ bool CWallet::SelectCoins(int64_t nTargetValue, set<pair<const CWalletTx*,unsign
 
     return (SelectCoinsMinConf(nTargetValue, 1, 6, vCoins, setCoinsRet, nValueRet) ||
             SelectCoinsMinConf(nTargetValue, 1, 1, vCoins, setCoinsRet, nValueRet) ||
-            SelectCoinsMinConf(nTargetValue, 0, 1, vCoins, setCoinsRet, nValueRet));
+            (bSpendZeroConfChange && SelectCoinsMinConf(nTargetValue, 0, 1, vCoins, setCoinsRet, nValueRet)));
 }
 
 

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -25,6 +25,7 @@
 
 // Settings
 extern int64_t nTransactionFee;
+extern bool bSpendZeroConfChange;
 
 class CAccountingEntry;
 class CCoinControl;


### PR DESCRIPTION
Adds the option `-spendzeroconfchange=0` to make the wallet avoid spending zero conf change outputs.

Rough workaround to the problems with '-4. Error: The transaction was rejected!' and other problems with chains of unconfirmed transactions and malleability.

The drawback of this is that sending will run out of inputs sooner (resulting in unintuitive "insufficient balance" errors), so if you have a lot of sends you'll need to queue up sends and use sendmany.
