### PR TITLE
Change default for -spendzeroconfchange to 0

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -274,7 +274,7 @@ std::string HelpMessage(HelpMessageMode hmm)
     strUsage += "  -upgradewallet         " + _("Upgrade wallet to latest format") + "\n";
     strUsage += "  -wallet=<file>         " + _("Specify wallet file (within data directory)") + "\n";
     strUsage += "  -walletnotify=<cmd>    " + _("Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)") + "\n";
-    strUsage += "  -spendzeroconfchange   " + _("Spend unconfirmed change when sending transactions (default: 1)") + "\n";
+    strUsage += "  -spendzeroconfchange   " + _("Spend unconfirmed change when sending transactions (default: 0)") + "\n";
 #endif
     strUsage += "\n" + _("Block creation options:") + "\n";
     strUsage += "  -blockminsize=<n>      " + _("Set minimum block size in bytes (default: 0)") + "\n";
@@ -540,7 +540,7 @@ bool AppInit2(boost::thread_group& threadGroup)
         if (nTransactionFee > 0.25 * COIN)
             InitWarning(_("Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction."));
     }
-    bSpendZeroConfChange = GetArg("-spendzeroconfchange", true);
+    bSpendZeroConfChange = GetArg("-spendzeroconfchange", false);
 
     strWalletFile = GetArg("-wallet", "wallet.dat");
 #endif


### PR DESCRIPTION
Changing the default to 0 is disruptive, but on the other hand with the current flurry of malleability abuse it is the safer option.

Edit: I do wonder, if this is to be the default do we want to change the output of getbalance as well to make sure it matches what can actually be spent? Currently it still shows unconfirmed change either way. On the other hand it is unintuitive to have the entire input disappear from the balance if you send. I think we do need some getbalance changes but I'm not entirely sure what...
