### PR TITLE
If requested, actually treat uncomfirmed change as being uncomfirmed

### DIFF
--- a/src/wallet.h
+++ b/src/wallet.h
@@ -702,7 +702,7 @@ public:
             return false;
         if (GetDepthInMainChain() >= 1)
             return true;
-        if (!IsFromMe()) // using wtx's cached debit
+        if (!bSpendZeroConfChange || !IsFromMe()) // using wtx's cached debit
             return false;
 
         // If no confirmations but it's from us, we can still


### PR DESCRIPTION
This commit strengthens 1bbca249b202c4802cc2c4d4de4a26e6392b4d92 by updating the CWalletTx::IsConfirmed() function.

If (bSpendZeroConfChange==false), then IsConfirmed() should actually treat unconfirmed change as being unconfirmed.
