### PR TITLE
Add -zapwallettx function, a diagnostic tool to assist in wallet repair

### DIFF
--- a/src/wallet.h
+++ b/src/wallet.h
@@ -323,6 +323,7 @@ public:
     void SetBestChain(const CBlockLocator& loc);
 
     DBErrors LoadWallet(bool& fFirstRunRet);
+    DBErrors ZapWalletTx();
 
     bool SetAddressBook(const CTxDestination& address, const std::string& strName, const std::string& purpose);
 

--- a/src/walletdb.h
+++ b/src/walletdb.h
@@ -122,6 +122,8 @@ public:
 
     DBErrors ReorderTransactions(CWallet*);
     DBErrors LoadWallet(CWallet* pwallet);
+    DBErrors FindWalletTx(CWallet* pwallet, std::vector<uint256>& vTxHash);
+    DBErrors ZapWalletTx(CWallet* pwallet);
     static bool Recover(CDBEnv& dbenv, std::string filename, bool fOnlyKeys);
     static bool Recover(CDBEnv& dbenv, std::string filename);
 };


### PR DESCRIPTION
It is somewhat suboptimal in that it loads every wallet record, when it really should just scan keys.
