### PR TITLE
Add `resendwallettx` RPC

### DIFF
--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -296,6 +296,7 @@ static const CRPCCommand vRPCCommands[] =
     { "lockunspent",            &lockunspent,            false,     false,      true },
     { "listlockunspent",        &listlockunspent,        false,     false,      true },
     { "settxfee",               &settxfee,               false,     false,      true },
+    { "resendwallettx",         &resendwallettx,         false,     false,      true },
 
     /* Wallet-enabled mining */
     { "getgenerate",            &getgenerate,            true,      false,      false },

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -163,6 +163,7 @@ extern json_spirit::Value walletlock(const json_spirit::Array& params, bool fHel
 extern json_spirit::Value encryptwallet(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value validateaddress(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value getinfo(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value resendwallettx(const json_spirit::Array& params, bool fHelp);
 
 extern json_spirit::Value getrawtransaction(const json_spirit::Array& params, bool fHelp); // in rcprawtransaction.cpp
 extern json_spirit::Value listunspent(const json_spirit::Array& params, bool fHelp);

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -1869,4 +1869,28 @@ Value settxfee(const Array& params, bool fHelp)
     return true;
 }
 
+Value resendwallettx(const Array& params, bool fHelp)
+{
+    if (fHelp)
+        throw runtime_error(
+            "resendwallettx\n"
+            "\nRebroadcast a specific wallet transaction or all wallet transactions.\n"
+            "1. \"txid\"    (string, optional) The transaction id, match all unconfirmed transactions if not provided\n"
+            "\nExamples:\n"
+            + HelpExampleCli("resendwallettx", "1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d")
+            + HelpExampleRpc("resendwallettx", "")
+        );
+    if(params.size() > 0)
+    {
+        uint256 hash;
+        hash.SetHex(params[0].get_str());
+        std::map<uint256, CWalletTx>::iterator i = pwalletMain->mapWallet.find(hash);
+        if (i == pwalletMain->mapWallet.end())
+            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid or non-wallet transaction id");
+        i->second.RelayWalletTransaction();
+    } else {
+        pwalletMain->DoResendWalletTransactions(true);
+    }
+    return true;
+}
 

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -923,8 +923,13 @@ void CWallet::ResendWalletTransactions()
         return;
     nLastResend = GetTime();
 
+    DoResendWalletTransactions(false);
+}
+
+void CWallet::DoResendWalletTransactions(bool bForce)
+{
     // Rebroadcast any of our txes that aren't in a block yet
-    LogPrintf("ResendWalletTransactions()\n");
+    LogPrintf("DoResendWalletTransactions()\n");
     {
         LOCK(cs_wallet);
         // Sort them in chronological order
@@ -934,7 +939,7 @@ void CWallet::ResendWalletTransactions()
             CWalletTx& wtx = item.second;
             // Don't rebroadcast until it's had plenty of time that
             // it should have gotten in already by now.
-            if (nTimeBestReceived - (int64_t)wtx.nTimeReceived > 5 * 60)
+            if (bForce || (nTimeBestReceived - (int64_t)wtx.nTimeReceived > 5 * 60))
                 mapSorted.insert(make_pair(wtx.nTimeReceived, &wtx));
         }
         BOOST_FOREACH(PAIRTYPE(const unsigned int, CWalletTx*)& item, mapSorted)
@@ -944,7 +949,6 @@ void CWallet::ResendWalletTransactions()
         }
     }
 }
-
 
 
 

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -230,7 +230,11 @@ public:
     void WalletUpdateSpent(const CTransaction& prevout);
     int ScanForWalletTransactions(CBlockIndex* pindexStart, bool fUpdate = false);
     void ReacceptWalletTransactions();
+    /// Conditionally resend wallet transactions if it has been long enough ago
     void ResendWalletTransactions();
+    /// Resend wallet transactions now
+    /// @argument bForce flag to resend all wallet transactions, even those that have been sent less than 5 hours ago
+    void DoResendWalletTransactions(bool bForce);
     int64_t GetBalance() const;
     int64_t GetUnconfirmedBalance() const;
     int64_t GetImmatureBalance() const;


### PR DESCRIPTION
Add a RPC that can be used to force resend of a single, or all unconfirmed wallet transactions.

This can be useful for cases in which the transaction submit was lost and you're too impatient to wait for the automatic rebroadcast. It's also useful in testing and development.
