### PR TITLE
Fix getbalance handling of spent, unconfirmed change

### DIFF
--- a/qa/rpc-tests/send.sh
+++ b/qa/rpc-tests/send.sh
@@ -1,14 +1,28 @@
 #!/bin/bash
 TIMEOUT=10
 SIGNAL=HUP
+PIDFILE=.send.pid
 if [ $# -eq 0 ]; then
   echo -e "Usage:\t$0 <cmd>"
   echo -e "\tRuns <cmd> and wait ${TIMEOUT} seconds or until SIG${SIGNAL} is received."
   echo -e "\tReturns: 0 if SIG${SIGNAL} is received, 1 otherwise."
+  echo -e "Or:\t$0 -STOP"
+  echo -e "\tsends SIG${SIGNAL} to running send.sh"
   exit 0
 fi
+
+if [ $1 == "-STOP" ]; then
+  if [ -s ${PIDFILE} ]; then
+      kill -s ${SIGNAL} $(<${PIDFILE})
+  fi
+  exit 0
+fi
+
 trap '[[ ${PID} ]] && kill ${PID}' ${SIGNAL}
+trap 'rm -f ${PIDFILE}' EXIT
+echo $$ > ${PIDFILE}
 "$@"
 sleep ${TIMEOUT} & PID=$!
 wait ${PID} && exit 1
+
 exit 0

--- a/qa/rpc-tests/txnmall.sh
+++ b/qa/rpc-tests/txnmall.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+
+# Test block generation and basic wallet sending
+
+if [ $# -lt 1 ]; then
+        echo "Usage: $0 path_to_binaries"
+        echo "e.g. $0 ../../src"
+        exit 1
+fi
+
+BITCOIND=${1}/bitcoind
+CLI=${1}/bitcoin-cli
+
+DIR="${BASH_SOURCE%/*}"
+SENDANDWAIT="${DIR}/send.sh"
+if [[ ! -d "$DIR" ]]; then DIR="$PWD"; fi
+. "$DIR/util.sh"
+
+D=$(mktemp -d test.XXXXX)
+
+# Two nodes; one will play the part of merchant, the
+# other an evil transaction-mutating miner.
+
+D1=${D}/node1
+CreateDataDir $D1 port=11000 rpcport=11001
+B1ARGS="-datadir=$D1 -debug"
+$BITCOIND $B1ARGS &
+B1PID=$!
+
+D2=${D}/node2
+CreateDataDir $D2 port=11010 rpcport=11011
+B2ARGS="-datadir=$D2 -debug"
+$BITCOIND $B2ARGS &
+B2PID=$!
+
+trap "kill -9 $B1PID $B2PID; rm -rf $D" EXIT
+
+# Wait until all four nodes are at the same block number
+function WaitBlocks {
+    while :
+    do
+        sleep 1
+        BLOCKS1=$( GetBlocks $B1ARGS )
+        BLOCKS2=$( GetBlocks $B2ARGS )
+        if (( $BLOCKS1 == $BLOCKS2 ))
+        then
+            break
+        fi
+    done
+}
+
+# Wait until node has $N peers
+function WaitPeers {
+    while :
+    do
+        PEERS=$( $CLI $1 getconnectioncount )
+        if (( "$PEERS" == $2 ))
+        then
+            break
+        fi
+        sleep 1
+    done
+}
+
+# Start with B2 connected to B1:
+$CLI $B2ARGS addnode 127.0.0.1:11000 onetry
+WaitPeers "$B1ARGS" 1
+
+# 1 block, 50 XBT each == 50 XBT
+$CLI $B1ARGS setgenerate true 1
+
+WaitBlocks
+# 100 blocks, 0 mature == 0 XBT
+$CLI $B2ARGS setgenerate true 100
+WaitBlocks
+
+CheckBalance $B1ARGS 50
+CheckBalance $B2ARGS 0
+
+# restart B2 with no connection
+$CLI $B2ARGS stop > /dev/null 2>&1
+wait $B2PID
+$BITCOIND $B2ARGS &
+B2PID=$!
+
+B2ADDRESS=$( $CLI $B2ARGS getnewaddress )
+
+# Have B1 create two transactions; second will
+# spend change from first, since B1 starts with only a single
+# 50 bitcoin output:
+TXID1=$( $CLI $B1ARGS sendtoaddress $B2ADDRESS 1.0 )
+TXID2=$( $CLI $B1ARGS sendtoaddress $B2ADDRESS 2.0 )
+
+# Mutate TXID1 and add it to B2's memory pool:
+RAWTX1=$( $CLI $B1ARGS getrawtransaction $TXID1 )
+RAWTX2=$( $CLI $B1ARGS getrawtransaction $TXID2 )
+# ... mutate RAWTX1:
+# RAWTX1 is hex-encoded, serialized transaction. So each
+# byte is two characters; we'll prepend the first
+# "push" in the scriptsig with OP_PUSHDATA1 (0x4c),
+# and add one to the length of the signature.
+# Fields are fixed; from the beginning:
+# 4-byte version
+# 1-byte varint number-of inputs (one in this case)
+# 32-byte previous txid
+# 4-byte previous output
+# 1-byte varint length-of-scriptsig
+# 1-byte PUSH this many bytes onto stack
+#  ... etc
+# So: to mutate, we want to get byte 41 (hex characters 82-83),
+# increment it, and insert 0x4c after it.
+L=${RAWTX1:82:2}
+NEWLEN=$( printf "%x" $(( 16#$L + 1 )) )
+MUTATEDTX1=${RAWTX1:0:82}${NEWLEN}4c${RAWTX1:84}
+# ... give mutated tx1 to B2:
+MUTATEDTXID=$( $CLI $B2ARGS sendrawtransaction $MUTATEDTX1 )
+
+echo "TXID1: " $TXID1
+echo "Mutated: " $MUTATEDTXID
+
+# Re-connect nodes, and have B2 mine a block
+$CLI $B2ARGS addnode 127.0.0.1:11000 onetry
+WaitPeers "$B1ARGS" 1
+
+$CLI $B2ARGS setgenerate true 1
+WaitBlocks
+
+$CLI $B2ARGS stop > /dev/null 2>&1
+wait $B2PID
+$CLI $B1ARGS stop > /dev/null 2>&1
+wait $B1PID
+
+trap "" EXIT
+
+echo "Done, bitcoind's shut down. To rerun/poke around:"
+echo "${1}/bitcoind -datadir=$D1 -daemon"
+echo "${1}/bitcoind -datadir=$D2 -daemon -connect=127.0.0.1:11000"
+echo "To cleanup:"
+echo "killall bitcoind; rm -rf test.*"
+exit 0
+
+echo "Tests successful, cleaning up"
+rm -rf $D
+exit 0

--- a/qa/rpc-tests/util.sh
+++ b/qa/rpc-tests/util.sh
@@ -23,7 +23,7 @@ function CreateDataDir {
   echo "rpcuser=rt" >> $CONF
   echo "rpcpassword=rt" >> $CONF
   echo "rpcwait=1" >> $CONF
-  echo "walletnotify=killall -HUP `basename ${SENDANDWAIT}`" >> $CONF
+  echo "walletnotify=${SENDANDWAIT} -STOP" >> $CONF
   shift
   while (( "$#" )); do
       echo $1 >> $CONF

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -872,7 +872,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
 }
 
 
-int CMerkleTx::GetDepthInMainChain(CBlockIndex* &pindexRet) const
+int CMerkleTx::GetDepthInMainChainINTERNAL(CBlockIndex* &pindexRet) const
 {
     if (hashBlock == 0 || nIndex == -1)
         return 0;
@@ -897,6 +897,14 @@ int CMerkleTx::GetDepthInMainChain(CBlockIndex* &pindexRet) const
     return chainActive.Height() - pindex->nHeight + 1;
 }
 
+int CMerkleTx::GetDepthInMainChain(CBlockIndex* &pindexRet) const
+{
+    int nResult = GetDepthInMainChainINTERNAL(pindexRet);
+    if (nResult == 0 && !mempool.exists(GetHash()))
+        return -1; // Not in chain, not in mempool
+
+    return nResult;
+}
 
 int CMerkleTx::GetBlocksToMaturity() const
 {

--- a/src/main.h
+++ b/src/main.h
@@ -423,6 +423,8 @@ public:
 /** A transaction with a merkle branch linking it to the block chain. */
 class CMerkleTx : public CTransaction
 {
+private:
+    int GetDepthInMainChainINTERNAL(CBlockIndex* &pindexRet) const;
 public:
     uint256 hashBlock;
     std::vector<uint256> vMerkleBranch;
@@ -461,9 +463,14 @@ public:
 
 
     int SetMerkleBranch(const CBlock* pblock=NULL);
+
+    // Return depth of transaction in blockchain:
+    // -1 : not in blockchain, and not in memory pool (dead transaction)
+    // 0 : in memory pool, waiting to be included in a block
+    // >1 : this many blocks deep in the main chain
     int GetDepthInMainChain(CBlockIndex* &pindexRet) const;
     int GetDepthInMainChain() const { CBlockIndex *pindexRet; return GetDepthInMainChain(pindexRet); }
-    bool IsInMainChain() const { return GetDepthInMainChain() > 0; }
+    bool IsInMainChain() const { CBlockIndex *pindexRet; return GetDepthInMainChainINTERNAL(pindexRet) > 0; }
     int GetBlocksToMaturity() const;
     bool AcceptToMemoryPool(bool fLimitFree=true);
 };

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -30,7 +30,9 @@ QString TransactionDesc::FormatTxStatus(const CWalletTx& wtx)
     else
     {
         int nDepth = wtx.GetDepthInMainChain();
-        if (GetAdjustedTime() - wtx.nTimeReceived > 2 * 60 && wtx.GetRequestCount() == 0)
+        if (nDepth < 0)
+            return tr("dead");
+        else if (GetAdjustedTime() - wtx.nTimeReceived > 2 * 60 && wtx.GetRequestCount() == 0)
             return tr("%1/offline").arg(nDepth);
         else if (nDepth < 6)
             return tr("%1/unconfirmed").arg(nDepth);

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -45,7 +45,7 @@ void WalletTxToJSON(const CWalletTx& wtx, Object& entry)
     entry.push_back(Pair("confirmations", confirms));
     if (wtx.IsCoinBase())
         entry.push_back(Pair("generated", true));
-    if (confirms)
+    if (confirms > 0)
     {
         entry.push_back(Pair("blockhash", wtx.hashBlock.GetHex()));
         entry.push_back(Pair("blockindex", wtx.nIndex));
@@ -1109,7 +1109,10 @@ void ListTransactions(const CWalletTx& wtx, const string& strAccount, int nMinDe
             Object entry;
             entry.push_back(Pair("account", strSentAccount));
             MaybePushAddress(entry, s.first);
-            entry.push_back(Pair("category", "send"));
+            if (wtx.GetDepthInMainChain() < 0)
+                entry.push_back(Pair("category", "dead"));
+            else
+                entry.push_back(Pair("category", "send"));
             entry.push_back(Pair("amount", ValueFromAmount(-s.second)));
             entry.push_back(Pair("fee", ValueFromAmount(-nFee)));
             if (fLong)
@@ -1141,7 +1144,12 @@ void ListTransactions(const CWalletTx& wtx, const string& strAccount, int nMinDe
                         entry.push_back(Pair("category", "generate"));
                 }
                 else
-                    entry.push_back(Pair("category", "receive"));
+                {
+                    if (wtx.GetDepthInMainChain() < 0)
+                        entry.push_back(Pair("category", "dead"));
+                    else
+                        entry.push_back(Pair("category", "receive"));
+                }
                 entry.push_back(Pair("amount", ValueFromAmount(r.second)));
                 if (fLong)
                     WalletTxToJSON(wtx, entry);

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1021,11 +1021,15 @@ void CWallet::AvailableCoins(vector<COutput>& vCoins, bool fOnlyConfirmed, const
             if (pcoin->IsCoinBase() && pcoin->GetBlocksToMaturity() > 0)
                 continue;
 
+            int nDepth = pcoin->GetDepthInMainChain();
+            if (nDepth < 0)
+                continue;
+
             for (unsigned int i = 0; i < pcoin->vout.size(); i++) {
                 if (!(pcoin->IsSpent(i)) && IsMine(pcoin->vout[i]) &&
                     !IsLockedCoin((*it).first, i) && pcoin->vout[i].nValue > 0 &&
                     (!coinControl || !coinControl->HasSelected() || coinControl->IsSelected((*it).first, i)))
-                        vCoins.push_back(COutput(pcoin, i, pcoin->GetDepthInMainChain()));
+                        vCoins.push_back(COutput(pcoin, i, nDepth));
             }
         }
     }

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -700,8 +700,11 @@ public:
         // Quick answer in most cases
         if (!IsFinalTx(*this))
             return false;
-        if (GetDepthInMainChain() >= 1)
+        int nDepth = GetDepthInMainChain();
+        if (nDepth >= 1)
             return true;
+        if (nDepth < 0)
+            return false;
         if (!bSpendZeroConfChange || !IsFromMe()) // using wtx's cached debit
             return false;
 
@@ -717,8 +720,11 @@ public:
 
             if (!IsFinalTx(*ptx))
                 return false;
-            if (ptx->GetDepthInMainChain() >= 1)
+            int nPDepth = ptx->GetDepthInMainChain();
+            if (nPDepth >= 1)
                 continue;
+            if (nPDepth < 0)
+                return false;
             if (!pwallet->IsFromMe(*ptx))
                 return false;
 


### PR DESCRIPTION
First: txnmall.sh is the start of an integration test for wallet handling of
mutated (malleable) transaction handling.

Second is a one-line change to IsConfirmed that adds a condition when
considering change outputs : only consider them confirmed if they are
in the memory pool (inspired by a comment sipa made yesterday).

This makes getbalance, getbalance '*', and listunspent all agree when run on the txnmall.sh test wallets. Before this fix, those three would return three different results.

Before:
 listunspent: one 49BTC output
 getbalance: 96 BTC (change counted twice)
 getbalance '*': 46 BTC (spends counted twice)

After: all agree, 49 BTC available to spend.
