### PR TITLE
Add RPC call `getrawwallettransaction`

### DIFF
--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -163,6 +163,7 @@ Array RPCConvertValues(const std::string &strMethod, const std::vector<std::stri
     if (strMethod == "listunspent"            && n > 2) ConvertTo<Array>(params[2]);
     if (strMethod == "getblock"               && n > 1) ConvertTo<bool>(params[1]);
     if (strMethod == "getrawtransaction"      && n > 1) ConvertTo<boost::int64_t>(params[1]);
+    if (strMethod == "getrawwallettransaction"&& n > 1) ConvertTo<boost::int64_t>(params[1]);
     if (strMethod == "createrawtransaction"   && n > 0) ConvertTo<Array>(params[0]);
     if (strMethod == "createrawtransaction"   && n > 1) ConvertTo<Object>(params[1]);
     if (strMethod == "signrawtransaction"     && n > 1) ConvertTo<Array>(params[1], true);

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -296,6 +296,7 @@ static const CRPCCommand vRPCCommands[] =
     { "lockunspent",            &lockunspent,            false,     false,      true },
     { "listlockunspent",        &listlockunspent,        false,     false,      true },
     { "settxfee",               &settxfee,               false,     false,      true },
+    { "getrawwallettransaction",&getrawwallettransaction,false,     false,      true },
 
     /* Wallet-enabled mining */
     { "getgenerate",            &getgenerate,            true,      false,      false },

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -165,6 +165,7 @@ extern json_spirit::Value validateaddress(const json_spirit::Array& params, bool
 extern json_spirit::Value getinfo(const json_spirit::Array& params, bool fHelp);
 
 extern json_spirit::Value getrawtransaction(const json_spirit::Array& params, bool fHelp); // in rcprawtransaction.cpp
+extern json_spirit::Value getrawwallettransaction(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value listunspent(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value lockunspent(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value listlockunspent(const json_spirit::Array& params, bool fHelp);


### PR DESCRIPTION
This allows getting raw transaction data from the wallet even if the transaction is no longer in the blockchain / mempool (for example if it got orphaned due to malleability abuse).

Allows a verbose flag just like `getrawtransaction`.

![getrawwallettransaction](https://f.cloud.github.com/assets/126646/2157991/eaf0f836-948a-11e3-9027-f155c980f07e.png)

Was also proposed in #3220, but is urgently useful now.
