### PR TITLE
Make qa/rpc-tests/ compatible with OSX

### DIFF
--- a/qa/rpc-tests/send.sh
+++ b/qa/rpc-tests/send.sh
@@ -1,14 +1,28 @@
 #!/bin/bash
 TIMEOUT=10
 SIGNAL=HUP
+PIDFILE=.send.pid
 if [ $# -eq 0 ]; then
   echo -e "Usage:\t$0 <cmd>"
   echo -e "\tRuns <cmd> and wait ${TIMEOUT} seconds or until SIG${SIGNAL} is received."
   echo -e "\tReturns: 0 if SIG${SIGNAL} is received, 1 otherwise."
+  echo -e "Or:\t$0 -STOP"
+  echo -e "\tsends SIG${SIGNAL} to running send.sh"
   exit 0
 fi
+
+if [ $1 == "-STOP" ]; then
+  if [ -s ${PIDFILE} ]; then
+      kill -s ${SIGNAL} $(<${PIDFILE})
+  fi
+  exit 0
+fi
+
 trap '[[ ${PID} ]] && kill ${PID}' ${SIGNAL}
+trap 'rm -f ${PIDFILE}' EXIT
+echo $$ > ${PIDFILE}
 "$@"
 sleep ${TIMEOUT} & PID=$!
 wait ${PID} && exit 1
+
 exit 0

--- a/qa/rpc-tests/util.sh
+++ b/qa/rpc-tests/util.sh
@@ -23,7 +23,7 @@ function CreateDataDir {
   echo "rpcuser=rt" >> $CONF
   echo "rpcpassword=rt" >> $CONF
   echo "rpcwait=1" >> $CONF
-  echo "walletnotify=killall -HUP `basename ${SENDANDWAIT}`" >> $CONF
+  echo "walletnotify=${SENDANDWAIT} -STOP" >> $CONF
   shift
   while (( "$#" )); do
       echo $1 >> $CONF


### PR DESCRIPTION
Reworked send.sh, so it works properly on my Mac (killall send.sh doesn't work, because the process name is 'bash' not 'send.sh').
So now send.sh writes a .send.pid file, and invoking it as send.sh -STOP (as the bitcoind -walletnotify) signals that PID.
