### PR TITLE
Add raw transaction hex to `gettransaction` wallet RPC

### DIFF
--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -1448,7 +1448,8 @@ Value gettransaction(const Array& params, bool fHelp)
             "      \"amount\" : x.xxx                  (numeric) The amount in btc\n"
             "    }\n"
             "    ,...\n"
-            "  ]\n"
+            "  ],\n"
+            "  \"hex\" : \"data\"         (string) Raw data for transaction\n"
             "}\n"
 
             "\nbExamples\n"
@@ -1478,6 +1479,11 @@ Value gettransaction(const Array& params, bool fHelp)
     Array details;
     ListTransactions(wtx, "*", 0, false, details);
     entry.push_back(Pair("details", details));
+
+    CDataStream ssTx(SER_NETWORK, PROTOCOL_VERSION);
+    ssTx << wtx;
+    string strHex = HexStr(ssTx.begin(), ssTx.end());
+    entry.push_back(Pair("hex", strHex));
 
     return entry;
 }


### PR DESCRIPTION
This allows getting raw transaction data from the wallet even if the transaction is no longer in the blockchain / mempool (for example if it got orphaned due to malleability abuse).

Alternative to #3663
