### PR TITLE
Report transaction conflicts, and tentative account balance fix

### DIFF
--- a/qa/rpc-tests/txnmall.sh
+++ b/qa/rpc-tests/txnmall.sh
@@ -88,8 +88,10 @@ B2ADDRESS=$( $CLI $B2ARGS getnewaddress )
 # Have B1 create two transactions; second will
 # spend change from first, since B1 starts with only a single
 # 50 bitcoin output:
-TXID1=$( $CLI $B1ARGS sendtoaddress $B2ADDRESS 1.0 )
-TXID2=$( $CLI $B1ARGS sendtoaddress $B2ADDRESS 2.0 )
+$CLI $B1ARGS move "" "foo" 10.0
+$CLI $B1ARGS move "" "bar" 10.0
+TXID1=$( $CLI $B1ARGS sendfrom foo $B2ADDRESS 1.0 0)
+TXID2=$( $CLI $B1ARGS sendfrom bar $B2ADDRESS 2.0 0)
 
 # Mutate TXID1 and add it to B2's memory pool:
 RAWTX1=$( $CLI $B1ARGS getrawtransaction $TXID1 )
@@ -122,7 +124,9 @@ echo "Mutated: " $MUTATEDTXID
 $CLI $B2ARGS addnode 127.0.0.1:11000 onetry
 WaitPeers "$B1ARGS" 1
 
-$CLI $B2ARGS setgenerate true 1
+$CLI $B2ARGS setgenerate true 3
+WaitBlocks
+$CLI $B1ARGS setgenerate true 3
 WaitBlocks
 
 $CLI $B2ARGS stop > /dev/null 2>&1

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -231,6 +231,82 @@ bool CWallet::SetMaxVersion(int nVersion)
     return true;
 }
 
+set<uint256> CWallet::GetConflicts(const uint256& txid) const
+{
+    set<uint256> result;
+    AssertLockHeld(cs_wallet);
+
+    std::map<uint256, CWalletTx>::const_iterator it = mapWallet.find(txid);
+    if (it == mapWallet.end())
+        return result;
+    const CWalletTx& wtx = it->second;
+
+    std::pair<TxConflicts::const_iterator, TxConflicts::const_iterator> range;
+
+    BOOST_FOREACH(const CTxIn& txin, wtx.vin)
+    {
+        range = mapTxConflicts.equal_range(txin.prevout);
+        for (TxConflicts::const_iterator it = range.first; it != range.second; ++it)
+            result.insert(it->second);
+    }
+    return result;
+}
+
+void CWallet::SyncMetaData(pair<TxConflicts::iterator, TxConflicts::iterator> range)
+{
+    // We want all the wallet transactions in range to have the same metadata as
+    // the oldest (smallest nOrderPos).
+    // So: find smallest nOrderPos:
+
+    int nMinOrderPos = std::numeric_limits<int>::max();
+    const CWalletTx* copyFrom = NULL;
+    for (TxConflicts::iterator it = range.first; it != range.second; ++it)
+    {
+        const uint256& hash = it->second;
+        int n = mapWallet[hash].nOrderPos;
+        if (n < nMinOrderPos)
+        {
+            nMinOrderPos = n;
+            copyFrom = &mapWallet[hash];
+        }
+    }
+    // Now copy data from copyFrom to rest:
+    for (TxConflicts::iterator it = range.first; it != range.second; ++it)
+    {
+        const uint256& hash = it->second;
+        CWalletTx* copyTo = &mapWallet[hash];
+        if (copyFrom == copyTo) continue;
+        copyTo->mapValue = copyFrom->mapValue;
+        copyTo->vOrderForm = copyFrom->vOrderForm;
+        // fTimeReceivedIsTxTime not copied on purpose
+        // nTimeReceived not copied on purpose
+        copyTo->nTimeSmart = copyFrom->nTimeSmart;
+        copyTo->fFromMe = copyFrom->fFromMe;
+        copyTo->strFromAccount = copyFrom->strFromAccount;
+        // vfSpent not copied on purpose
+        // nOrderPos not copied on purpose
+        // cached members not copied on purpose
+    }
+}
+
+void CWallet::AddToConflicts(const uint256& wtxhash)
+{
+    assert(mapWallet.count(wtxhash));
+    CWalletTx& thisTx = mapWallet[wtxhash];
+    if (thisTx.IsCoinBase())
+        return;
+
+    BOOST_FOREACH(const CTxIn& txin, thisTx.vin)
+    {
+        mapTxConflicts.insert(make_pair(txin.prevout, wtxhash));
+
+        pair<TxConflicts::iterator, TxConflicts::iterator> range;
+        range = mapTxConflicts.equal_range(txin.prevout);
+        if (range.first != range.second)
+            SyncMetaData(range);
+    }
+}
+
 bool CWallet::EncryptWallet(const SecureString& strWalletPassphrase)
 {
     if (IsCrypted())
@@ -385,9 +461,16 @@ void CWallet::MarkDirty()
     }
 }
 
-bool CWallet::AddToWallet(const CWalletTx& wtxIn)
+bool CWallet::AddToWallet(const CWalletTx& wtxIn, bool fFromLoadWallet)
 {
     uint256 hash = wtxIn.GetHash();
+
+    if (fFromLoadWallet)
+    {
+        mapWallet[hash] = wtxIn;
+        AddToConflicts(hash);
+    }
+    else
     {
         LOCK(cs_wallet);
         // Inserts only if not already there, returns tx inserted or tx found
@@ -445,6 +528,7 @@ bool CWallet::AddToWallet(const CWalletTx& wtxIn)
                              wtxIn.GetHash().ToString(),
                              wtxIn.hashBlock.ToString());
             }
+            AddToConflicts(hash);
         }
 
         bool fUpdated = false;
@@ -907,6 +991,18 @@ void CWalletTx::RelayWalletTransaction()
     }
 }
 
+set<uint256> CWalletTx::GetConflicts() const
+{
+    set<uint256> result;
+    if (pwallet != NULL)
+    {
+        uint256 myHash = GetHash();
+        result = pwallet->GetConflicts(myHash);
+        result.erase(myHash);
+    }
+    return result;
+}
+
 void CWallet::ResendWalletTransactions()
 {
     // Do this infrequently and randomly to avoid giving away
@@ -980,7 +1076,7 @@ int64_t CWallet::GetUnconfirmedBalance() const
         for (map<uint256, CWalletTx>::const_iterator it = mapWallet.begin(); it != mapWallet.end(); ++it)
         {
             const CWalletTx* pcoin = &(*it).second;
-            if (!IsFinalTx(*pcoin) || !pcoin->IsTrusted())
+            if (!IsFinalTx(*pcoin) || (!pcoin->IsTrusted() && pcoin->GetDepthInMainChain() == 0))
                 nTotal += pcoin->GetAvailableCredit();
         }
     }

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -108,6 +108,12 @@ private:
     int64_t nNextResend;
     int64_t nLastResend;
 
+    // Used to detect and report conflicted transactions:
+    typedef std::multimap<COutPoint, uint256> TxConflicts;
+    TxConflicts mapTxConflicts;
+    void AddToConflicts(const uint256& wtxhash);
+    void SyncMetaData(std::pair<TxConflicts::iterator, TxConflicts::iterator>);
+
 public:
     /// Main wallet lock.
     /// This lock protects all the fields added by CWallet
@@ -151,6 +157,7 @@ public:
     }
 
     std::map<uint256, CWalletTx> mapWallet;
+
     int64_t nOrderPosNext;
     std::map<uint256, int> mapRequestCount;
 
@@ -223,7 +230,7 @@ public:
     TxItems OrderedTxItems(std::list<CAccountingEntry>& acentries, std::string strAccount = "");
 
     void MarkDirty();
-    bool AddToWallet(const CWalletTx& wtxIn);
+    bool AddToWallet(const CWalletTx& wtxIn, bool fFromLoadWallet=false);
     void SyncTransaction(const uint256 &hash, const CTransaction& tx, const CBlock* pblock);
     bool AddToWalletIfInvolvingMe(const uint256 &hash, const CTransaction& tx, const CBlock* pblock, bool fUpdate);
     void EraseFromWallet(const uint256 &hash);
@@ -356,6 +363,9 @@ public:
 
     // get the current wallet format (the oldest client version guaranteed to understand this wallet)
     int GetVersion() { AssertLockHeld(cs_wallet); return nWalletVersion; }
+
+    // Get wallet transactions that conflict with given transaction (spend same outputs)
+    std::set<uint256> GetConflicts(const uint256& txid) const;
 
     /** Address book entry changed.
      * @note called with lock cs_wallet held.
@@ -752,6 +762,8 @@ public:
     void AddSupportingTransactions();
     bool AcceptWalletTransaction();
     void RelayWalletTransaction();
+
+    std::set<uint256> GetConflicts() const;
 };
 
 

--- a/src/walletdb.cpp
+++ b/src/walletdb.cpp
@@ -382,7 +382,7 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
             if (wtx.nOrderPos == -1)
                 wss.fAnyUnordered = true;
 
-            pwallet->mapWallet[hash] = wtx;
+            pwallet->AddToWallet(wtx, true);
             //// debug print
             //LogPrintf("LoadWallet  %s\n", wtx.GetHash().ToString());
             //LogPrintf(" %12"PRId64"  %s  %s  %s\n",


### PR DESCRIPTION
This adds a "walletconflicts" array to wallet transaction JSON output, identifying other wallet transactions that also spend one of the inputs of this transaction.

Example output from the txnmall.sh regression test, spending 1 BTC from account "foo", then spending 2 BTC of the change from that transaction and spending it from account "bar".  After a mutant of the "foo" transaction is then mined listtransactions reports:

```
    {
        "account" : "foo",
        "address" : "n2rhjnG8Gg24Dcx66u4KrtiUfxPhPw7suV",
        "category" : "conflicted",
        "amount" : -1.00000000,
        "fee" : 0.00000000,
        "confirmations" : -1,
        "txid" : "650e1c572593ba03e407faebb613c1d449dfc450d3d3f3868566367f482a105b",
        "walletconflicts" : [
            "587573bb1b620604eb39f75377358411f34dd133a8846d50e8947091b208eb1b"
        ],
        "time" : 1392405954,
        "timereceived" : 1392405954
    },
    {
        "account" : "bar",
        "address" : "n2rhjnG8Gg24Dcx66u4KrtiUfxPhPw7suV",
        "category" : "conflicted",
        "amount" : -2.00000000,
        "fee" : 0.00000000,
        "confirmations" : -1,
        "txid" : "222b3d25454a38de6ecd1c493692c7fce8848a2f8586825e4b32fe63c1f41d43",
        "walletconflicts" : [
        ],
        "time" : 1392405954,
        "timereceived" : 1392405954
    },
    {
        "account" : "foo",
        "address" : "n2rhjnG8Gg24Dcx66u4KrtiUfxPhPw7suV",
        "category" : "send",
        "amount" : -1.00000000,
        "fee" : 0.00000000,
        "confirmations" : 1,
        "blockhash" : "0000996962dbab0bf203ab187a683e7c610b2e946b3027c7ef167977dc1ea317",
        "blockindex" : 1,
        "blocktime" : 1392405954,
        "txid" : "587573bb1b620604eb39f75377358411f34dd133a8846d50e8947091b208eb1b",
        "walletconflicts" : [
            "650e1c572593ba03e407faebb613c1d449dfc450d3d3f3868566367f482a105b"
        ],
        "time" : 1392405954,
        "timereceived" : 1392405954
    }
```
