### PR TITLE
Add a method for removing a single wallet tx.

### DIFF
--- a/qa/rpc-tests/README.md
+++ b/qa/rpc-tests/README.md
@@ -1,6 +1,13 @@
 Regression tests of RPC interface
 =================================
 
-wallet.sh : Test wallet send/receive code (see comments for details)
+Bash scripts that use the RPC interface and command-line bitcoin-cli to test
+full functionality in -regtest mode.
 
-util.sh : useful re-usable functions 
+wallet.sh : Exercise wallet send/receive code.
+
+txnmall.sh : Test proper accounting of malleable transactions
+
+conflictedbalance.sh : More testing of malleable transaction handling
+
+util.sh : useful re-usable bash functions 

--- a/qa/rpc-tests/conflictedbalance.sh
+++ b/qa/rpc-tests/conflictedbalance.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+
+# Test marking of spent outputs
+
+# Create a transaction graph with four transactions,
+# A/B/C/D
+# C spends A
+# D spends B and C
+
+# Then simulate C being mutated, to create C'
+#  that is mined.
+# A is still (correctly) considered spent.
+# B should be treated as unspent
+
+if [ $# -lt 1 ]; then
+        echo "Usage: $0 path_to_binaries"
+        echo "e.g. $0 ../../src"
+        exit 1
+fi
+
+set -f
+
+BITCOIND=${1}/bitcoind
+CLI=${1}/bitcoin-cli
+
+DIR="${BASH_SOURCE%/*}"
+SENDANDWAIT="${DIR}/send.sh"
+if [[ ! -d "$DIR" ]]; then DIR="$PWD"; fi
+. "$DIR/util.sh"
+
+D=$(mktemp -d test.XXXXX)
+
+# Two nodes; one will play the part of merchant, the
+# other an evil transaction-mutating miner.
+
+D1=${D}/node1
+CreateDataDir $D1 port=11000 rpcport=11001
+B1ARGS="-datadir=$D1 -debug=mempool"
+$BITCOIND $B1ARGS &
+B1PID=$!
+
+D2=${D}/node2
+CreateDataDir $D2 port=11010 rpcport=11011
+B2ARGS="-datadir=$D2 -debug=mempool"
+$BITCOIND $B2ARGS &
+B2PID=$!
+
+# Wait until all four nodes are at the same block number
+function WaitBlocks {
+    while :
+    do
+        sleep 1
+        declare -i BLOCKS1=$( GetBlocks $B1ARGS )
+        declare -i BLOCKS2=$( GetBlocks $B2ARGS )
+        if (( BLOCKS1 == BLOCKS2 ))
+        then
+            break
+        fi
+    done
+}
+
+# Wait until node has $N peers
+function WaitPeers {
+    while :
+    do
+        declare -i PEERS=$( $CLI $1 getconnectioncount )
+        if (( PEERS == "$2" ))
+        then
+            break
+        fi
+        sleep 1
+    done
+}
+
+echo "Generating test blockchain..."
+
+# Start with B2 connected to B1:
+$CLI $B2ARGS addnode 127.0.0.1:11000 onetry
+WaitPeers "$B1ARGS" 1
+
+# 2 block, 50 XBT each == 100 XBT
+# These will be transactions "A" and "B"
+$CLI $B1ARGS setgenerate true 2
+
+WaitBlocks
+# 100 blocks, 0 mature == 0 XBT
+$CLI $B2ARGS setgenerate true 100
+WaitBlocks
+
+CheckBalance "$B1ARGS" 100
+CheckBalance "$B2ARGS" 0
+
+# restart B2 with no connection
+$CLI $B2ARGS stop > /dev/null 2>&1
+wait $B2PID
+$BITCOIND $B2ARGS &
+B2PID=$!
+
+B1ADDRESS=$( $CLI $B1ARGS getnewaddress )
+B2ADDRESS=$( $CLI $B2ARGS getnewaddress )
+
+# Transaction C: send-to-self, spend A
+TXID_C=$( $CLI $B1ARGS sendtoaddress $B1ADDRESS 50.0)
+
+# Transaction D: spends B and C
+TXID_D=$( $CLI $B1ARGS sendtoaddress $B2ADDRESS 100.0)
+
+CheckBalance "$B1ARGS" 0
+
+# Mutate TXID_C and add it to B2's memory pool:
+RAWTX_C=$( $CLI $B1ARGS getrawtransaction $TXID_C )
+
+# ... mutate C to create C'
+L=${RAWTX_C:82:2}
+NEWLEN=$( printf "%x" $(( 16#$L + 1 )) )
+MUTATEDTX_C=${RAWTX_C:0:82}${NEWLEN}4c${RAWTX_C:84}
+# ... give mutated tx1 to B2:
+MUTATEDTXID=$( $CLI $B2ARGS sendrawtransaction $MUTATEDTX_C )
+
+echo "TXID_C: " $TXID_C
+echo "Mutated: " $MUTATEDTXID
+
+# Re-connect nodes, and have both nodes mine some blocks:
+$CLI $B2ARGS addnode 127.0.0.1:11000 onetry
+WaitPeers "$B1ARGS" 1
+
+# Having B2 mine the next block puts the mutated
+# transaction C in the chain:
+$CLI $B2ARGS setgenerate true 1
+WaitBlocks
+
+# B1 should still be able to spend 100, because D is conflicted
+# so does not count as a spend of B
+CheckBalance "$B1ARGS" 100
+
+$CLI $B2ARGS stop > /dev/null 2>&1
+wait $B2PID
+$CLI $B1ARGS stop > /dev/null 2>&1
+wait $B1PID
+
+echo "Tests successful, cleaning up"
+rm -rf $D
+exit 0

--- a/qa/rpc-tests/txnmall.sh
+++ b/qa/rpc-tests/txnmall.sh
@@ -1,12 +1,14 @@
 #!/usr/bin/env bash
 
-# Test block generation and basic wallet sending
+# Test proper accounting with malleable transactions
 
 if [ $# -lt 1 ]; then
         echo "Usage: $0 path_to_binaries"
         echo "e.g. $0 ../../src"
         exit 1
 fi
+
+set -f
 
 BITCOIND=${1}/bitcoind
 CLI=${1}/bitcoin-cli
@@ -33,16 +35,14 @@ B2ARGS="-datadir=$D2 -debug"
 $BITCOIND $B2ARGS &
 B2PID=$!
 
-trap "kill -9 $B1PID $B2PID; rm -rf $D" EXIT
-
-# Wait until all four nodes are at the same block number
+# Wait until both nodes are at the same block number
 function WaitBlocks {
     while :
     do
         sleep 1
-        BLOCKS1=$( GetBlocks $B1ARGS )
-        BLOCKS2=$( GetBlocks $B2ARGS )
-        if (( $BLOCKS1 == $BLOCKS2 ))
+        declare -i BLOCKS1=$( GetBlocks $B1ARGS )
+        declare -i BLOCKS2=$( GetBlocks $B2ARGS )
+        if (( BLOCKS1 == BLOCKS2 ))
         then
             break
         fi
@@ -53,14 +53,16 @@ function WaitBlocks {
 function WaitPeers {
     while :
     do
-        PEERS=$( $CLI $1 getconnectioncount )
-        if (( "$PEERS" == $2 ))
+        declare -i PEERS=$( $CLI $1 getconnectioncount )
+        if (( PEERS == "$2" ))
         then
             break
         fi
         sleep 1
     done
 }
+
+echo "Generating test blockchain..."
 
 # Start with B2 connected to B1:
 $CLI $B2ARGS addnode 127.0.0.1:11000 onetry
@@ -74,8 +76,8 @@ WaitBlocks
 $CLI $B2ARGS setgenerate true 100
 WaitBlocks
 
-CheckBalance $B1ARGS 50
-CheckBalance $B2ARGS 0
+CheckBalance "$B1ARGS" 50
+CheckBalance "$B2ARGS" 0
 
 # restart B2 with no connection
 $CLI $B2ARGS stop > /dev/null 2>&1
@@ -83,20 +85,18 @@ wait $B2PID
 $BITCOIND $B2ARGS &
 B2PID=$!
 
-B2ADDRESS=$( $CLI $B2ARGS getnewaddress )
+B2ADDRESS=$( $CLI $B2ARGS getaccountaddress "from1" )
 
 # Have B1 create two transactions; second will
 # spend change from first, since B1 starts with only a single
 # 50 bitcoin output:
-$CLI $B1ARGS move "" "foo" 10.0
-$CLI $B1ARGS move "" "bar" 10.0
+$CLI $B1ARGS move "" "foo" 10.0 > /dev/null
+$CLI $B1ARGS move "" "bar" 10.0 > /dev/null
 TXID1=$( $CLI $B1ARGS sendfrom foo $B2ADDRESS 1.0 0)
 TXID2=$( $CLI $B1ARGS sendfrom bar $B2ADDRESS 2.0 0)
 
 # Mutate TXID1 and add it to B2's memory pool:
 RAWTX1=$( $CLI $B1ARGS getrawtransaction $TXID1 )
-RAWTX2=$( $CLI $B1ARGS getrawtransaction $TXID2 )
-# ... mutate RAWTX1:
 # RAWTX1 is hex-encoded, serialized transaction. So each
 # byte is two characters; we'll prepend the first
 # "push" in the scriptsig with OP_PUSHDATA1 (0x4c),
@@ -121,27 +121,27 @@ echo "TXID1: " $TXID1
 echo "Mutated: " $MUTATEDTXID
 
 # Re-connect nodes, and have B2 mine a block
+# containing the mutant:
 $CLI $B2ARGS addnode 127.0.0.1:11000 onetry
-WaitPeers "$B1ARGS" 1
+$CLI $B2ARGS setgenerate true 1
+WaitBlocks
 
-$CLI $B2ARGS setgenerate true 3
-WaitBlocks
-$CLI $B1ARGS setgenerate true 3
-WaitBlocks
+# B1 should have 49 BTC; the 2 BTC send is
+# conflicted, and should not count in
+# balances.
+CheckBalance "$B1ARGS" 49
+CheckBalance "$B1ARGS" 49 "*"
+CheckBalance "$B1ARGS" 9 "foo"
+CheckBalance "$B1ARGS" 10 "bar"
+
+# B2 should have 51 BTC
+CheckBalance "$B2ARGS" 51
+CheckBalance "$B2ARGS" 1 "from1"
 
 $CLI $B2ARGS stop > /dev/null 2>&1
 wait $B2PID
 $CLI $B1ARGS stop > /dev/null 2>&1
 wait $B1PID
-
-trap "" EXIT
-
-echo "Done, bitcoind's shut down. To rerun/poke around:"
-echo "${1}/bitcoind -datadir=$D1 -daemon"
-echo "${1}/bitcoind -datadir=$D2 -daemon -connect=127.0.0.1:11000"
-echo "To cleanup:"
-echo "killall bitcoind; rm -rf test.*"
-exit 0
 
 echo "Tests successful, cleaning up"
 rm -rf $D

--- a/qa/rpc-tests/util.sh
+++ b/qa/rpc-tests/util.sh
@@ -41,8 +41,9 @@ function AssertEqual {
 
 # CheckBalance -datadir=... amount account minconf
 function CheckBalance {
+  declare -i EXPECT="$2"
   B=$( $CLI $1 getbalance $3 $4 )
-  if (( $( echo "$B == $2" | bc ) == 0 ))
+  if (( $( echo "$B == $EXPECT" | bc ) == 0 ))
   then
     echoerr "bad balance: $B (expected $2)"
     exit 1
@@ -87,5 +88,5 @@ function SendRawTxn {
 # Use: GetBlocks <datadir>
 # returns number of blocks from getinfo
 function GetBlocks {
-    ExtractKey blocks "$( $CLI $1 getinfo )"
+    $CLI $1 getblockcount
 }

--- a/qa/rpc-tests/util.sh
+++ b/qa/rpc-tests/util.sh
@@ -60,7 +60,7 @@ function Send {
   to=$2
   amount=$3
   address=$(Address $to)
-  txid=$( ${SENDANDWAIT} $CLI $from sendtoaddress $address $amount )
+  ${SENDANDWAIT} $CLI $from sendtoaddress $address $amount
 }
 
 # Use: Unspent <datadir> <n'th-last-unspent> <var>

--- a/qa/rpc-tests/zapwallettx.sh
+++ b/qa/rpc-tests/zapwallettx.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+
+# Test zapping a single wallet transaction
+
+if [ $# -lt 1 ]; then
+        echo "Usage: $0 path_to_binaries"
+        echo "e.g. $0 ../../src"
+        exit 1
+fi
+
+set -f
+
+BITCOIND=${1}/bitcoind
+CLI=${1}/bitcoin-cli
+
+DIR="${BASH_SOURCE%/*}"
+SENDANDWAIT="${DIR}/send.sh"
+if [[ ! -d "$DIR" ]]; then DIR="$PWD"; fi
+. "$DIR/util.sh"
+
+D=$(mktemp -d test.XXXXX)
+
+D1=${D}/node1
+CreateDataDir "$D1" port=11000 rpcport=11001
+B1ARGS="-datadir=$D1"
+$BITCOIND $B1ARGS &
+B1PID=$!
+
+D2=${D}/node2
+CreateDataDir "$D2" port=11010 rpcport=11011 connect=127.0.0.1:11000
+B2ARGS="-datadir=$D2"
+$BITCOIND $B2ARGS &
+B2PID=$!
+
+D3=${D}/node3
+CreateDataDir "$D3" port=11020 rpcport=11021 connect=127.0.0.1:11000
+B3ARGS="-datadir=$D3"
+$BITCOIND $BITCOINDARGS $B3ARGS &
+B3PID=$!
+
+# Wait until all three nodes are at the same block number
+function WaitBlocks {
+    while :
+    do
+        sleep 1
+        declare -i BLOCKS1=$( GetBlocks $B1ARGS )
+        declare -i BLOCKS2=$( GetBlocks $B2ARGS )
+        declare -i BLOCKS3=$( GetBlocks $B3ARGS )
+        if (( BLOCKS1 == BLOCKS2 && BLOCKS2 == BLOCKS3 ))
+        then
+            break
+        fi
+    done
+}
+
+echo "Generating test blockchain..."
+
+# 1 block, 50 XBT each == 50 XBT
+$CLI $B1ARGS setgenerate true 1
+WaitBlocks
+# 101 blocks, 1 mature == 50 XBT
+$CLI $B2ARGS setgenerate true 101
+WaitBlocks
+
+CheckBalance "$B1ARGS" 50
+CheckBalance "$B2ARGS" 50
+
+# Send 21 XBT from 1 to 3
+TXID=$(Send $B1ARGS $B3ARGS 21)
+
+# Have B2 mine 100 blocks so B1 transactions are mature:
+$CLI $B2ARGS setgenerate true 100
+WaitBlocks
+
+# B1 should end up with 50 XBT in block rewards,
+# minus the 21 XBT sent to B3:
+CheckBalance "$B1ARGS" "50-21"
+CheckBalance "$B3ARGS" "21"
+
+# Zap send tx from B1, balance should again be 50 XBT
+$CLI "$B1ARGS" zapwallettx $TXID
+CheckBalance "$B1ARGS" "50"
+
+$CLI $B3ARGS stop > /dev/null 2>&1
+wait $B3PID
+$CLI $B2ARGS stop > /dev/null 2>&1
+wait $B2PID
+$CLI $B1ARGS stop > /dev/null 2>&1
+wait $B1PID
+
+echo "Tests successful, cleaning up"
+rm -rf $D
+exit 0

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -455,7 +455,7 @@ bool AppInit2(boost::thread_group& threadGroup)
             LogPrintf("AppInit2 : parameter interaction: -salvagewallet=1 -> setting -rescan=1\n");
     }
 
-    // -zapwallettx implies a rescan
+    // -zapwallettxes implies a rescan
     if (GetBoolArg("-zapwallettxes", false)) {
         if (SoftSetBoolArg("-rescan", true))
             LogPrintf("AppInit2 : parameter interaction: -zapwallettxes=1 -> setting -rescan=1\n");
@@ -910,7 +910,7 @@ bool AppInit2(boost::thread_group& threadGroup)
             uiInterface.InitMessage(_("Zapping all transactions from wallet..."));
 
             pwalletMain = new CWallet(strWalletFile);
-            DBErrors nZapWalletRet = pwalletMain->ZapWalletTx();
+            DBErrors nZapWalletRet = pwalletMain->ZapWalletTxes();
             if (nZapWalletRet != DB_LOAD_OK) {
                 uiInterface.InitMessage(_("Error loading wallet.dat: Wallet corrupted"));
                 return false;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -271,6 +271,7 @@ std::string HelpMessage(HelpMessageMode hmm)
     strUsage += "  -paytxfee=<amt>        " + _("Fee per kB to add to transactions you send") + "\n";
     strUsage += "  -rescan                " + _("Rescan the block chain for missing wallet transactions") + "\n";
     strUsage += "  -zapwallettxes         " + _("Clear list of wallet transactions (diagnostic tool; implies -rescan)") + "\n";
+    strUsage += "  -zapwallettx=<txid>    " + _("Clear single wallet transaction <txid> (diagnostic tool; implies -rescan)") + "\n";
     strUsage += "  -salvagewallet         " + _("Attempt to recover private keys from a corrupt wallet.dat") + "\n";
     strUsage += "  -upgradewallet         " + _("Upgrade wallet to latest format") + "\n";
     strUsage += "  -wallet=<file>         " + _("Specify wallet file (within data directory)") + "\n";
@@ -459,6 +460,12 @@ bool AppInit2(boost::thread_group& threadGroup)
     if (GetBoolArg("-zapwallettxes", false)) {
         if (SoftSetBoolArg("-rescan", true))
             LogPrintf("AppInit2 : parameter interaction: -zapwallettxes=1 -> setting -rescan=1\n");
+    }
+
+    // -zapwallettx implies a rescan
+    if (mapArgs.count("-zapwallettx")) {
+        if (SoftSetBoolArg("-rescan", true))
+            LogPrintf("AppInit2 : parameter interaction: -zapwallettx -> setting -rescan=1\n");
     }
 
     // Make sure enough file descriptors are available
@@ -911,6 +918,28 @@ bool AppInit2(boost::thread_group& threadGroup)
 
             pwalletMain = new CWallet(strWalletFile);
             DBErrors nZapWalletRet = pwalletMain->ZapWalletTxes();
+            if (nZapWalletRet != DB_LOAD_OK) {
+                uiInterface.InitMessage(_("Error loading wallet.dat: Wallet corrupted"));
+                return false;
+            }
+
+            delete pwalletMain;
+            pwalletMain = NULL;
+        }
+        if (mapArgs.count("-zapwallettx")) {
+            uiInterface.InitMessage(_("Zapping transaction from wallet..."));
+
+            // txid
+            uint256 hash;
+            hash.SetHex(GetArg("-zapwallettx", ""));
+
+            pwalletMain = new CWallet(strWalletFile);
+            if (!pwalletMain->mapWallet.count(hash)) {
+                uiInterface.InitMessage(_("Invalid or non-wallet transaction id"));
+                return false;
+            }
+            const CWalletTx& wtx = pwalletMain->mapWallet[hash];
+            DBErrors nZapWalletRet = pwalletMain->ZapWalletTx(wtx);
             if (nZapWalletRet != DB_LOAD_OK) {
                 uiInterface.InitMessage(_("Error loading wallet.dat: Wallet corrupted"));
                 return false;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1927,6 +1927,10 @@ bool static ConnectTip(CValidationState &state, CBlockIndex *pindexNew) {
     BOOST_FOREACH(const CTransaction &tx, txConflicted) {
         SyncWithWallets(tx.GetHash(), tx, NULL);
     }
+    // ... and about transactions that got confirmed:
+    BOOST_FOREACH(const CTransaction &tx, block.vtx) {
+        SyncWithWallets(tx.GetHash(), tx, &block);
+    }
     return true;
 }
 

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -468,11 +468,12 @@ void CoinControlDialog::updateLabels(WalletModel *model, QDialog* dialog)
 
     BOOST_FOREACH(const COutput& out, vOutputs)
     {
-        // unselect already spent, very unlikely scenario, this could happen when selected are spent elsewhere, like rpc or another computer
-        if (out.tx->IsSpent(out.i))
+        // unselect already spent, very unlikely scenario, this could happen
+        // when selected are spent elsewhere, like rpc or another computer
+        uint256 txhash = out.tx->GetHash();
+        COutPoint outpt(txhash, out.i);
+        if (model->isSpent(outpt))
         {
-            uint256 txhash = out.tx->GetHash();
-            COutPoint outpt(txhash, out.i);
             coinControl->UnSelect(outpt);
             continue;
         }

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -501,6 +501,12 @@ void WalletModel::getOutputs(const std::vector<COutPoint>& vOutpoints, std::vect
     }
 }
 
+bool WalletModel::isSpent(const COutPoint& outpoint) const
+{
+    LOCK(wallet->cs_wallet);
+    return wallet->IsSpent(outpoint);
+}
+
 // AvailableCoins + LockedCoins grouped by wallet address (put change in one group with wallet address)
 void WalletModel::listCoins(std::map<QString, std::vector<COutput> >& mapCoins) const
 {

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -180,6 +180,7 @@ public:
 
     bool getPubKey(const CKeyID &address, CPubKey& vchPubKeyOut) const;
     void getOutputs(const std::vector<COutPoint>& vOutpoints, std::vector<COutput>& vOutputs);
+    bool isSpent(const COutPoint& outpoint) const;
     void listCoins(std::map<QString, std::vector<COutput> >& mapCoins) const;
 
     bool isLockedCoin(uint256 hash, unsigned int n) const;

--- a/src/rpcdump.cpp
+++ b/src/rpcdump.cpp
@@ -128,7 +128,6 @@ Value importprivkey(const Array& params, bool fHelp)
 
         if (fRescan) {
             pwalletMain->ScanForWalletTransactions(chainActive.Genesis(), true);
-            pwalletMain->ReacceptWalletTransactions();
         }
     }
 
@@ -216,7 +215,6 @@ Value importwallet(const Array& params, bool fHelp)
 
     LogPrintf("Rescanning last %i blocks\n", chainActive.Height() - pindex->nHeight + 1);
     pwalletMain->ScanForWalletTransactions(pindex);
-    pwalletMain->ReacceptWalletTransactions();
     pwalletMain->MarkDirty();
 
     if (!fGood)

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -296,6 +296,7 @@ static const CRPCCommand vRPCCommands[] =
     { "lockunspent",            &lockunspent,            false,     false,      true },
     { "listlockunspent",        &listlockunspent,        false,     false,      true },
     { "settxfee",               &settxfee,               false,     false,      true },
+    { "zapwallettx",            &zapwallettx,            false,     false,      true },
 
     /* Wallet-enabled mining */
     { "getgenerate",            &getgenerate,            true,      false,      false },

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -163,6 +163,7 @@ extern json_spirit::Value walletlock(const json_spirit::Array& params, bool fHel
 extern json_spirit::Value encryptwallet(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value validateaddress(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value getinfo(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value zapwallettx(const json_spirit::Array& params, bool fHelp);
 
 extern json_spirit::Value getrawtransaction(const json_spirit::Array& params, bool fHelp); // in rcprawtransaction.cpp
 extern json_spirit::Value listunspent(const json_spirit::Array& params, bool fHelp);

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -1902,11 +1902,11 @@ Value zapwallettx(const Array& params, bool fHelp)
     uint256 hash;
     hash.SetHex(params[0].get_str());
 
-    Object entry;
     if (!pwalletMain->mapWallet.count(hash))
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid or non-wallet transaction id");
+    const CWalletTx& wtx = pwalletMain->mapWallet[hash];
 
-    return pwalletMain->ZapWalletTx(hash) == DB_LOAD_OK;
+    return pwalletMain->ZapWalletTx(wtx) == DB_LOAD_OK;
 }
 
 

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -1883,4 +1883,30 @@ Value settxfee(const Array& params, bool fHelp)
     return true;
 }
 
+Value zapwallettx(const Array& params, bool fHelp)
+{
+    if (fHelp || params.size() < 1 || params.size() > 1)
+        throw runtime_error(
+            "zapwallettx txid\n"
+            "\nRemove a wallet transaction.\n"
+            "\nArguments:\n"
+            "1. txid           (string) The transaction id.\n"
+            "\nResult\n"
+            "true|false        (boolean) Returns true if successful\n"
+            "\nExamples:\n"
+            + HelpExampleCli("zapwallettx", "00e3c3ec61422aa4e597beceac7f06c771a8024dee38c5ffa413336341befa72")
+            + HelpExampleRpc("zapwallettx", "00e3c3ec61422aa4e597beceac7f06c771a8024dee38c5ffa413336341befa72")
+        );
+
+    // txid
+    uint256 hash;
+    hash.SetHex(params[0].get_str());
+
+    Object entry;
+    if (!pwalletMain->mapWallet.count(hash))
+        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid or non-wallet transaction id");
+
+    return pwalletMain->ZapWalletTx(hash) == DB_LOAD_OK;
+}
+
 

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -560,7 +560,7 @@ int64_t GetAccountBalance(CWalletDB& walletdb, const string& strAccount, int nMi
     for (map<uint256, CWalletTx>::iterator it = pwalletMain->mapWallet.begin(); it != pwalletMain->mapWallet.end(); ++it)
     {
         const CWalletTx& wtx = (*it).second;
-        if (!IsFinalTx(wtx))
+        if (!IsFinalTx(wtx) || wtx.GetBlocksToMaturity() > 0 || wtx.GetDepthInMainChain() < 0)
             continue;
 
         int64_t nReceived, nSent, nFee;
@@ -1330,13 +1330,14 @@ Value listaccounts(const Array& params, bool fHelp)
         string strSentAccount;
         list<pair<CTxDestination, int64_t> > listReceived;
         list<pair<CTxDestination, int64_t> > listSent;
-        if (wtx.GetBlocksToMaturity() > 0)
+        int nDepth = wtx.GetDepthInMainChain();
+        if (wtx.GetBlocksToMaturity() > 0 || nDepth < 0)
             continue;
         wtx.GetAmounts(listReceived, listSent, nFee, strSentAccount);
         mapAccountBalances[strSentAccount] -= nFee;
         BOOST_FOREACH(const PAIRTYPE(CTxDestination, int64_t)& s, listSent)
             mapAccountBalances[strSentAccount] -= s.second;
-        if (wtx.GetDepthInMainChain() >= nMinDepth)
+        if (nDepth >= nMinDepth)
         {
             BOOST_FOREACH(const PAIRTYPE(CTxDestination, int64_t)& r, listReceived)
                 if (pwalletMain->mapAddressBook.count(r.first))

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -5,6 +5,8 @@
 #ifndef BITCOIN_TXMEMPOOL_H
 #define BITCOIN_TXMEMPOOL_H
 
+#include <list>
+
 #include "coins.h"
 #include "core.h"
 #include "sync.h"
@@ -72,8 +74,8 @@ public:
     void setSanityCheck(bool _fSanityCheck) { fSanityCheck = _fSanityCheck; }
 
     bool addUnchecked(const uint256& hash, const CTxMemPoolEntry &entry);
-    bool remove(const CTransaction &tx, bool fRecursive = false);
-    bool removeConflicts(const CTransaction &tx);
+    std::list<CTransaction> remove(const CTransaction &tx, bool fRecursive = false);
+    std::list<CTransaction> removeConflicts(const CTransaction &tx);
     void clear();
     void queryHashes(std::vector<uint256>& vtxid);
     void pruneSpent(const uint256& hash, CCoins &coins);

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1525,11 +1525,11 @@ DBErrors CWallet::ZapWalletTxes()
 }
 
 
-DBErrors CWallet::ZapWalletTx(uint256 hash)
+DBErrors CWallet::ZapWalletTx(const CWalletTx& wtx)
 {
     if (!fFileBacked)
         return DB_LOAD_OK;
-    DBErrors nZapWalletTxRet = CWalletDB(strWalletFile,"cr+").ZapWalletTx(this, hash);
+    DBErrors nZapWalletTxRet = CWalletDB(strWalletFile,"cr+").ZapWalletTx(this, wtx);
     if (nZapWalletTxRet == DB_NEED_REWRITE)
     {
         if (CDB::Rewrite(strWalletFile, "\x04pool"))

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1592,13 +1592,13 @@ DBErrors CWallet::ZapWalletTx(const CWalletTx& wtx)
 {
     if (!fFileBacked)
         return DB_LOAD_OK;
+    LOCK(cs_wallet);
     vector<CWalletTx> vErasedTxes;
     DBErrors nZapWalletTxRet = CWalletDB(strWalletFile,"cr+").ZapWalletTx(this, wtx, vErasedTxes);
     if (nZapWalletTxRet == DB_NEED_REWRITE)
     {
         if (CDB::Rewrite(strWalletFile, "\x04pool"))
         {
-            LOCK(cs_wallet);
             setKeyPool.clear();
             // Note: can't top-up keypool here, because wallet is locked.
             // User will be prompted to unlock wallet the next operation
@@ -1608,7 +1608,6 @@ DBErrors CWallet::ZapWalletTx(const CWalletTx& wtx)
 
     {
         // remove zapped CWalletDB txes from mapWallet also
-        LOCK(cs_wallet);
         BOOST_FOREACH(const CWalletTx& tx, vErasedTxes)
             mapWallet.erase(tx.GetHash());
         // clear tx cache variables

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -241,18 +241,20 @@ set<uint256> CWallet::GetConflicts(const uint256& txid) const
         return result;
     const CWalletTx& wtx = it->second;
 
-    std::pair<TxConflicts::const_iterator, TxConflicts::const_iterator> range;
+    std::pair<TxSpends::const_iterator, TxSpends::const_iterator> range;
 
     BOOST_FOREACH(const CTxIn& txin, wtx.vin)
     {
-        range = mapTxConflicts.equal_range(txin.prevout);
-        for (TxConflicts::const_iterator it = range.first; it != range.second; ++it)
+        if (mapTxSpends.count(txin.prevout) <= 1)
+            continue;  // No conflict if zero or one spends
+        range = mapTxSpends.equal_range(txin.prevout);
+        for (TxSpends::const_iterator it = range.first; it != range.second; ++it)
             result.insert(it->second);
     }
     return result;
 }
 
-void CWallet::SyncMetaData(pair<TxConflicts::iterator, TxConflicts::iterator> range)
+void CWallet::SyncMetaData(pair<TxSpends::iterator, TxSpends::iterator> range)
 {
     // We want all the wallet transactions in range to have the same metadata as
     // the oldest (smallest nOrderPos).
@@ -260,7 +262,7 @@ void CWallet::SyncMetaData(pair<TxConflicts::iterator, TxConflicts::iterator> ra
 
     int nMinOrderPos = std::numeric_limits<int>::max();
     const CWalletTx* copyFrom = NULL;
-    for (TxConflicts::iterator it = range.first; it != range.second; ++it)
+    for (TxSpends::iterator it = range.first; it != range.second; ++it)
     {
         const uint256& hash = it->second;
         int n = mapWallet[hash].nOrderPos;
@@ -271,7 +273,7 @@ void CWallet::SyncMetaData(pair<TxConflicts::iterator, TxConflicts::iterator> ra
         }
     }
     // Now copy data from copyFrom to rest:
-    for (TxConflicts::iterator it = range.first; it != range.second; ++it)
+    for (TxSpends::iterator it = range.first; it != range.second; ++it)
     {
         const uint256& hash = it->second;
         CWalletTx* copyTo = &mapWallet[hash];
@@ -283,28 +285,47 @@ void CWallet::SyncMetaData(pair<TxConflicts::iterator, TxConflicts::iterator> ra
         copyTo->nTimeSmart = copyFrom->nTimeSmart;
         copyTo->fFromMe = copyFrom->fFromMe;
         copyTo->strFromAccount = copyFrom->strFromAccount;
-        // vfSpent not copied on purpose
         // nOrderPos not copied on purpose
         // cached members not copied on purpose
     }
 }
 
-void CWallet::AddToConflicts(const uint256& wtxhash)
+// Outpoint is spent if any non-conflicted transaction
+// spends it:
+bool CWallet::IsSpent(const COutPoint& outpoint) const
 {
-    assert(mapWallet.count(wtxhash));
-    CWalletTx& thisTx = mapWallet[wtxhash];
-    if (thisTx.IsCoinBase())
+    pair<TxSpends::const_iterator, TxSpends::const_iterator> range;
+    range = mapTxSpends.equal_range(outpoint);
+
+    for (TxSpends::const_iterator it = range.first; it != range.second; ++it)
+    {
+        const uint256& wtxid = it->second;
+        std::map<uint256, CWalletTx>::const_iterator mit = mapWallet.find(wtxid);
+        if (mit != mapWallet.end() && mit->second.GetDepthInMainChain() >= 0)
+            return true; // Spent
+    }
+    return false;
+}
+
+void CWallet::AddToSpends(const COutPoint& outpoint, const uint256& wtxid)
+{
+    mapTxSpends.insert(make_pair(outpoint, wtxid));
+
+    pair<TxSpends::iterator, TxSpends::iterator> range;
+    range = mapTxSpends.equal_range(outpoint);
+    SyncMetaData(range);
+}
+
+
+void CWallet::AddToSpends(const uint256& wtxid)
+{
+    assert(mapWallet.count(wtxid));
+    CWalletTx& thisTx = mapWallet[wtxid];
+    if (thisTx.IsCoinBase()) // Coinbases don't spend anything!
         return;
 
     BOOST_FOREACH(const CTxIn& txin, thisTx.vin)
-    {
-        mapTxConflicts.insert(make_pair(txin.prevout, wtxhash));
-
-        pair<TxConflicts::iterator, TxConflicts::iterator> range;
-        range = mapTxConflicts.equal_range(txin.prevout);
-        if (range.first != range.second)
-            SyncMetaData(range);
-    }
+        AddToSpends(txin.prevout, wtxid);
 }
 
 bool CWallet::EncryptWallet(const SecureString& strWalletPassphrase)
@@ -425,33 +446,6 @@ CWallet::TxItems CWallet::OrderedTxItems(std::list<CAccountingEntry>& acentries,
     return txOrdered;
 }
 
-void CWallet::WalletUpdateSpent(const CTransaction &tx)
-{
-    // Anytime a signature is successfully verified, it's proof the outpoint is spent.
-    // Update the wallet spent flag if it doesn't know due to wallet.dat being
-    // restored from backup or the user making copies of wallet.dat.
-    {
-        LOCK(cs_wallet);
-        BOOST_FOREACH(const CTxIn& txin, tx.vin)
-        {
-            map<uint256, CWalletTx>::iterator mi = mapWallet.find(txin.prevout.hash);
-            if (mi != mapWallet.end())
-            {
-                CWalletTx& wtx = (*mi).second;
-                if (txin.prevout.n >= wtx.vout.size())
-                    LogPrintf("WalletUpdateSpent: bad wtx %s\n", wtx.GetHash().ToString());
-                else if (!wtx.IsSpent(txin.prevout.n) && IsMine(wtx.vout[txin.prevout.n]))
-                {
-                    LogPrintf("WalletUpdateSpent found spent coin %sbc %s\n", FormatMoney(wtx.GetCredit()), wtx.GetHash().ToString());
-                    wtx.MarkSpent(txin.prevout.n);
-                    wtx.WriteToDisk();
-                    NotifyTransactionChanged(this, txin.prevout.hash, CT_UPDATED);
-                }
-            }
-        }
-    }
-}
-
 void CWallet::MarkDirty()
 {
     {
@@ -468,7 +462,7 @@ bool CWallet::AddToWallet(const CWalletTx& wtxIn, bool fFromLoadWallet)
     if (fFromLoadWallet)
     {
         mapWallet[hash] = wtxIn;
-        AddToConflicts(hash);
+        AddToSpends(hash);
     }
     else
     {
@@ -528,7 +522,7 @@ bool CWallet::AddToWallet(const CWalletTx& wtxIn, bool fFromLoadWallet)
                              wtxIn.GetHash().ToString(),
                              wtxIn.hashBlock.ToString());
             }
-            AddToConflicts(hash);
+            AddToSpends(hash);
         }
 
         bool fUpdated = false;
@@ -551,7 +545,6 @@ bool CWallet::AddToWallet(const CWalletTx& wtxIn, bool fFromLoadWallet)
                 wtx.fFromMe = wtxIn.fFromMe;
                 fUpdated = true;
             }
-            fUpdated |= wtx.UpdateSpent(wtxIn.vfSpent);
         }
 
         //// debug print
@@ -561,9 +554,6 @@ bool CWallet::AddToWallet(const CWalletTx& wtxIn, bool fFromLoadWallet)
         if (fInsertedNew || fUpdated)
             if (!wtx.WriteToDisk())
                 return false;
-
-        // since AddToWallet is called directly for self-originating transactions, check for consumption of own coins
-        WalletUpdateSpent(wtx);
 
         // Notify UI of new or updated transaction
         NotifyTransactionChanged(this, hash, fInsertedNew ? CT_NEW : CT_UPDATED);
@@ -598,14 +588,27 @@ bool CWallet::AddToWalletIfInvolvingMe(const uint256 &hash, const CTransaction& 
                 wtx.SetMerkleBranch(pblock);
             return AddToWallet(wtx);
         }
-        else
-            WalletUpdateSpent(tx);
     }
     return false;
 }
 
-void CWallet::SyncTransaction(const uint256 &hash, const CTransaction& tx, const CBlock* pblock) {
+void CWallet::SyncTransaction(const uint256 &hash, const CTransaction& tx, const CBlock* pblock)
+{
     AddToWalletIfInvolvingMe(hash, tx, pblock, true);
+
+    if (mapWallet.count(hash) == 0)
+        return; // Not one of ours
+
+    // Break debit/credit balance caches:
+    mapWallet[hash].MarkDirty();
+    // If a transaction changes 'conflicted' state, that changes the balance
+    // available of the outputs it spends. So force those to be
+    // recomputed, also:
+    BOOST_FOREACH(const CTxIn& txin, tx.vin)
+    {
+        if (mapWallet.count(txin.prevout.hash))
+            mapWallet[txin.prevout.hash].MarkDirty();
+    }
 }
 
 void CWallet::EraseFromWallet(const uint256 &hash)
@@ -918,54 +921,19 @@ int CWallet::ScanForWalletTransactions(CBlockIndex* pindexStart, bool fUpdate)
 
 void CWallet::ReacceptWalletTransactions()
 {
-    bool fRepeat = true;
-    while (fRepeat)
+    LOCK(cs_wallet);
+    BOOST_FOREACH(PAIRTYPE(const uint256, CWalletTx)& item, mapWallet)
     {
-        LOCK(cs_wallet);
-        fRepeat = false;
-        bool fMissing = false;
-        BOOST_FOREACH(PAIRTYPE(const uint256, CWalletTx)& item, mapWallet)
-        {
-            CWalletTx& wtx = item.second;
-            if (wtx.IsCoinBase() && wtx.IsSpent(0))
-                continue;
+        const uint256& wtxid = item.first;
+        CWalletTx& wtx = item.second;
+        assert(wtx.GetHash() == wtxid);
 
-            CCoins coins;
-            bool fUpdated = false;
-            bool fFound = pcoinsTip->GetCoins(wtx.GetHash(), coins);
-            if (fFound || wtx.GetDepthInMainChain() > 0)
-            {
-                // Update fSpent if a tx got spent somewhere else by a copy of wallet.dat
-                for (unsigned int i = 0; i < wtx.vout.size(); i++)
-                {
-                    if (wtx.IsSpent(i))
-                        continue;
-                    if ((i >= coins.vout.size() || coins.vout[i].IsNull()) && IsMine(wtx.vout[i]))
-                    {
-                        wtx.MarkSpent(i);
-                        fUpdated = true;
-                        fMissing = true;
-                    }
-                }
-                if (fUpdated)
-                {
-                    LogPrintf("ReacceptWalletTransactions found spent coin %sbc %s\n", FormatMoney(wtx.GetCredit()), wtx.GetHash().ToString());
-                    wtx.MarkDirty();
-                    wtx.WriteToDisk();
-                }
-            }
-            else
-            {
-                // Re-accept any txes of ours that aren't already in a block
-                if (!wtx.IsCoinBase())
-                    wtx.AcceptWalletTransaction();
-            }
-        }
-        if (fMissing)
+        int nDepth = wtx.GetDepthInMainChain();
+
+        if (!wtx.IsCoinBase() && nDepth < 0)
         {
-            // TODO: optimize this to scan just part of the block chain?
-            if (ScanForWalletTransactions(chainActive.Genesis()))
-                fRepeat = true;  // Found missing transactions: re-do re-accept.
+            // Try to add to memory pool
+            wtx.AcceptWalletTransaction();
         }
     }
 }
@@ -1106,6 +1074,7 @@ void CWallet::AvailableCoins(vector<COutput>& vCoins, bool fOnlyConfirmed, const
         LOCK(cs_wallet);
         for (map<uint256, CWalletTx>::const_iterator it = mapWallet.begin(); it != mapWallet.end(); ++it)
         {
+            const uint256& wtxid = it->first;
             const CWalletTx* pcoin = &(*it).second;
 
             if (!IsFinalTx(*pcoin))
@@ -1122,7 +1091,7 @@ void CWallet::AvailableCoins(vector<COutput>& vCoins, bool fOnlyConfirmed, const
                 continue;
 
             for (unsigned int i = 0; i < pcoin->vout.size(); i++) {
-                if (!(pcoin->IsSpent(i)) && IsMine(pcoin->vout[i]) &&
+                if (!(IsSpent(COutPoint(wtxid, i))) && IsMine(pcoin->vout[i]) &&
                     !IsLockedCoin((*it).first, i) && pcoin->vout[i].nValue > 0 &&
                     (!coinControl || !coinControl->HasSelected() || coinControl->IsSelected((*it).first, i)))
                         vCoins.push_back(COutput(pcoin, i, nDepth));
@@ -1492,14 +1461,12 @@ bool CWallet::CommitTransaction(CWalletTx& wtxNew, CReserveKey& reservekey)
             // otherwise just for transaction history.
             AddToWallet(wtxNew);
 
-            // Mark old coins as spent
+            // Notify that old coins are spent
             set<CWalletTx*> setCoins;
             BOOST_FOREACH(const CTxIn& txin, wtxNew.vin)
             {
                 CWalletTx &coin = mapWallet[txin.prevout.hash];
                 coin.BindWallet(this);
-                coin.MarkSpent(txin.prevout.n);
-                coin.WriteToDisk();
                 NotifyTransactionChanged(this, coin.GetHash(), CT_UPDATED);
             }
 
@@ -1852,7 +1819,7 @@ std::map<CTxDestination, int64_t> CWallet::GetAddressBalances()
                 if(!ExtractDestination(pcoin->vout[i].scriptPubKey, addr))
                     continue;
 
-                int64_t n = pcoin->IsSpent(i) ? 0 : pcoin->vout[i].nValue;
+                int64_t n = IsSpent(COutPoint(walletEntry.first, i)) ? 0 : pcoin->vout[i].nValue;
 
                 if (!balances.count(addr))
                     balances[addr] = 0;

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -34,6 +34,15 @@ struct CompareValueOnly
     }
 };
 
+const CWalletTx* CWallet::GetWalletTx(const uint256& hash) const
+{
+    LOCK(cs_wallet);
+    std::map<uint256, CWalletTx>::const_iterator it = mapWallet.find(hash);
+    if (it == mapWallet.end())
+        return NULL;
+    return &(it->second);
+}
+
 CPubKey CWallet::GenerateNewKey()
 {
     AssertLockHeld(cs_wallet); // mapKeyMetadata
@@ -809,78 +818,6 @@ void CWalletTx::GetAccountAmounts(const string& strAccount, int64_t& nReceived,
     }
 }
 
-void CWalletTx::AddSupportingTransactions()
-{
-    vtxPrev.clear();
-
-    const int COPY_DEPTH = 3;
-    if (SetMerkleBranch() < COPY_DEPTH)
-    {
-        vector<uint256> vWorkQueue;
-        BOOST_FOREACH(const CTxIn& txin, vin)
-            vWorkQueue.push_back(txin.prevout.hash);
-
-        {
-            LOCK(pwallet->cs_wallet);
-            map<uint256, const CMerkleTx*> mapWalletPrev;
-            set<uint256> setAlreadyDone;
-            for (unsigned int i = 0; i < vWorkQueue.size(); i++)
-            {
-                uint256 hash = vWorkQueue[i];
-                if (setAlreadyDone.count(hash))
-                    continue;
-                setAlreadyDone.insert(hash);
-
-                CMerkleTx tx;
-                map<uint256, CWalletTx>::const_iterator mi = pwallet->mapWallet.find(hash);
-                if (mi != pwallet->mapWallet.end())
-                {
-                    tx = (*mi).second;
-                    BOOST_FOREACH(const CMerkleTx& txWalletPrev, (*mi).second.vtxPrev)
-                        mapWalletPrev[txWalletPrev.GetHash()] = &txWalletPrev;
-                }
-                else if (mapWalletPrev.count(hash))
-                {
-                    tx = *mapWalletPrev[hash];
-                }
-                else
-                {
-                    continue;
-                }
-
-                int nDepth = tx.SetMerkleBranch();
-                vtxPrev.push_back(tx);
-
-                if (nDepth < COPY_DEPTH)
-                {
-                    BOOST_FOREACH(const CTxIn& txin, tx.vin)
-                        vWorkQueue.push_back(txin.prevout.hash);
-                }
-            }
-        }
-    }
-
-    reverse(vtxPrev.begin(), vtxPrev.end());
-}
-
-bool CWalletTx::AcceptWalletTransaction()
-{
-    {
-        LOCK(mempool.cs);
-        // Add previous supporting transactions first
-        BOOST_FOREACH(CMerkleTx& tx, vtxPrev)
-        {
-            if (!tx.IsCoinBase())
-            {
-                uint256 hash = tx.GetHash();
-                if (!mempool.exists(hash) && pcoinsTip->HaveCoins(hash))
-                    tx.AcceptToMemoryPool(false);
-            }
-        }
-        return AcceptToMemoryPool(false);
-    }
-    return false;
-}
 
 bool CWalletTx::WriteToDisk()
 {
@@ -933,22 +870,14 @@ void CWallet::ReacceptWalletTransactions()
         if (!wtx.IsCoinBase() && nDepth < 0)
         {
             // Try to add to memory pool
-            wtx.AcceptWalletTransaction();
+            LOCK(mempool.cs);
+            wtx.AcceptToMemoryPool(false);
         }
     }
 }
 
 void CWalletTx::RelayWalletTransaction()
 {
-    BOOST_FOREACH(const CMerkleTx& tx, vtxPrev)
-    {
-        // Important: versions of bitcoin before 0.8.6 had a bug that inserted
-        // empty transactions into the vtxPrev, which will cause the node to be
-        // banned when retransmitted, hence the check for !tx.vin.empty()
-        if (!tx.IsCoinBase() && !tx.vin.empty())
-            if (tx.GetDepthInMainChain() == 0)
-                RelayTransaction((CTransaction)tx, tx.GetHash());
-    }
     if (!IsCoinBase())
     {
         if (GetDepthInMainChain() == 0) {
@@ -1423,8 +1352,6 @@ bool CWallet::CreateTransaction(const vector<pair<CScript, int64_t> >& vecSend,
                     continue;
                 }
 
-                // Fill vtxPrev by copying from previous transactions vtxPrev
-                wtxNew.AddSupportingTransactions();
                 wtxNew.fTimeReceivedIsTxTime = true;
 
                 break;

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -323,7 +323,8 @@ public:
     void SetBestChain(const CBlockLocator& loc);
 
     DBErrors LoadWallet(bool& fFirstRunRet);
-    DBErrors ZapWalletTx();
+    DBErrors ZapWalletTxes();
+    DBErrors ZapWalletTx(uint256 hash);
 
     bool SetAddressBook(const CTxDestination& address, const std::string& strName, const std::string& purpose);
 

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -324,7 +324,7 @@ public:
 
     DBErrors LoadWallet(bool& fFirstRunRet);
     DBErrors ZapWalletTxes();
-    DBErrors ZapWalletTx(uint256 hash);
+    DBErrors ZapWalletTx(const CWalletTx& wtx);
 
     bool SetAddressBook(const CTxDestination& address, const std::string& strName, const std::string& purpose);
 
@@ -598,6 +598,18 @@ public:
         if (!vfSpent[nOut])
         {
             vfSpent[nOut] = true;
+            fAvailableCreditCached = false;
+        }
+    }
+
+    void MarkUnspent(unsigned int nOut)
+    {
+        if (nOut >= vout.size())
+            throw std::runtime_error("CWalletTx::MarkUnspent() : nOut out of range");
+        vfSpent.resize(vout.size());
+        if (vfSpent[nOut])
+        {
+            vfSpent[nOut] = false;
             fAvailableCreditCached = false;
         }
     }

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -173,6 +173,8 @@ public:
 
     int64_t nTimeFirstKey;
 
+    const CWalletTx* GetWalletTx(const uint256& hash) const;
+
     // check whether we are allowed to upgrade (or already support) to the named feature
     bool CanSupportFeature(enum WalletFeature wf) { AssertLockHeld(cs_wallet); return nWalletMaxVersion >= wf; }
 
@@ -444,7 +446,7 @@ private:
     const CWallet* pwallet;
 
 public:
-    std::vector<CMerkleTx> vtxPrev;
+    std::vector<CMerkleTx> vUnused;// Used to be vtxPrev
     mapValue_t mapValue;
     std::vector<std::pair<std::string, std::string> > vOrderForm;
     unsigned int fTimeReceivedIsTxTime;
@@ -489,7 +491,6 @@ public:
     void Init(const CWallet* pwalletIn)
     {
         pwallet = pwalletIn;
-        vtxPrev.clear();
         mapValue.clear();
         vOrderForm.clear();
         fTimeReceivedIsTxTime = false;
@@ -528,7 +529,7 @@ public:
         }
 
         nSerSize += SerReadWrite(s, *(CMerkleTx*)this, nType, nVersion,ser_action);
-        READWRITE(vtxPrev);
+        READWRITE(vUnused);
         READWRITE(mapValue);
         READWRITE(vOrderForm);
         READWRITE(fTimeReceivedIsTxTime);
@@ -669,38 +670,13 @@ public:
         if (!bSpendZeroConfChange || !IsFromMe()) // using wtx's cached debit
             return false;
 
-        // If no confirmations but it's from us, we can still
-        // consider it confirmed if all dependencies are confirmed
-        std::map<uint256, const CMerkleTx*> mapPrev;
-        std::vector<const CMerkleTx*> vWorkQueue;
-        vWorkQueue.reserve(vtxPrev.size()+1);
-        vWorkQueue.push_back(this);
-        for (unsigned int i = 0; i < vWorkQueue.size(); i++)
+        // Trusted if all inputs are trusted (recursively)
+        BOOST_FOREACH(const CTxIn& txin, vin)
         {
-            const CMerkleTx* ptx = vWorkQueue[i];
-
-            if (!IsFinalTx(*ptx))
+            // Transactions not from us: not trusted
+            const CWalletTx* parent = pwallet->GetWalletTx(txin.prevout.hash);
+            if (parent == NULL || !parent->IsTrusted())
                 return false;
-            int nPDepth = ptx->GetDepthInMainChain();
-            if (nPDepth >= 1)
-                continue;
-            if (nPDepth < 0)
-                return false;
-            if (!pwallet->IsFromMe(*ptx))
-                return false;
-
-            if (mapPrev.empty())
-            {
-                BOOST_FOREACH(const CMerkleTx& tx, vtxPrev)
-                    mapPrev[tx.GetHash()] = &tx;
-            }
-
-            BOOST_FOREACH(const CTxIn& txin, ptx->vin)
-            {
-                if (!mapPrev.count(txin.prevout.hash))
-                    return false;
-                vWorkQueue.push_back(mapPrev[txin.prevout.hash]);
-            }
         }
         return true;
     }
@@ -710,8 +686,6 @@ public:
     int64_t GetTxTime() const;
     int GetRequestCount() const;
 
-    void AddSupportingTransactions();
-    bool AcceptWalletTransaction();
     void RelayWalletTransaction();
 
     std::set<uint256> GetConflicts() const;

--- a/src/walletdb.cpp
+++ b/src/walletdb.cpp
@@ -684,7 +684,7 @@ DBErrors CWalletDB::LoadWallet(CWallet* pwallet)
     return result;
 }
 
-DBErrors CWalletDB::FindWalletTx(CWallet* pwallet, vector<uint256>& vTxHash)
+DBErrors CWalletDB::FindWalletTxes(CWallet* pwallet, vector<uint256>& vTxHash)
 {
     pwallet->vchDefaultKey = CPubKey();
     CWalletScanState wss;
@@ -747,11 +747,11 @@ DBErrors CWalletDB::FindWalletTx(CWallet* pwallet, vector<uint256>& vTxHash)
     return result;
 }
 
-DBErrors CWalletDB::ZapWalletTx(CWallet* pwallet)
+DBErrors CWalletDB::ZapWalletTxes(CWallet* pwallet)
 {
     // build list of wallet TXs
     vector<uint256> vTxHash;
-    DBErrors err = FindWalletTx(pwallet, vTxHash);
+    DBErrors err = FindWalletTxes(pwallet, vTxHash);
     if (err != DB_LOAD_OK)
         return err;
 
@@ -760,6 +760,15 @@ DBErrors CWalletDB::ZapWalletTx(CWallet* pwallet)
         if (!EraseTx(hash))
             return DB_CORRUPT;
     }
+
+    return DB_LOAD_OK;
+}
+
+DBErrors CWalletDB::ZapWalletTx(CWallet* pwallet, uint256 hash)
+{
+    // erase wallet TX
+    if (!EraseTx(hash))
+        return DB_CORRUPT;
 
     return DB_LOAD_OK;
 }

--- a/src/walletdb.h
+++ b/src/walletdb.h
@@ -122,8 +122,9 @@ public:
 
     DBErrors ReorderTransactions(CWallet*);
     DBErrors LoadWallet(CWallet* pwallet);
-    DBErrors FindWalletTx(CWallet* pwallet, std::vector<uint256>& vTxHash);
-    DBErrors ZapWalletTx(CWallet* pwallet);
+    DBErrors FindWalletTxes(CWallet* pwallet, std::vector<uint256>& vTxHash);
+    DBErrors ZapWalletTxes(CWallet* pwallet);
+    DBErrors ZapWalletTx(CWallet* pwallet, uint256 hash);
     static bool Recover(CDBEnv& dbenv, std::string filename, bool fOnlyKeys);
     static bool Recover(CDBEnv& dbenv, std::string filename);
 };

--- a/src/walletdb.h
+++ b/src/walletdb.h
@@ -124,7 +124,7 @@ public:
     DBErrors LoadWallet(CWallet* pwallet);
     DBErrors FindWalletTxes(CWallet* pwallet, std::vector<uint256>& vTxHash);
     DBErrors ZapWalletTxes(CWallet* pwallet);
-    DBErrors ZapWalletTx(CWallet* pwallet, const CWalletTx& wtx);
+    DBErrors ZapWalletTx(CWallet* pwallet, const CWalletTx& wtx, std::vector<CWalletTx>& vErasedTxes);
     static bool Recover(CDBEnv& dbenv, std::string filename, bool fOnlyKeys);
     static bool Recover(CDBEnv& dbenv, std::string filename);
 };

--- a/src/walletdb.h
+++ b/src/walletdb.h
@@ -124,7 +124,7 @@ public:
     DBErrors LoadWallet(CWallet* pwallet);
     DBErrors FindWalletTxes(CWallet* pwallet, std::vector<uint256>& vTxHash);
     DBErrors ZapWalletTxes(CWallet* pwallet);
-    DBErrors ZapWalletTx(CWallet* pwallet, uint256 hash);
+    DBErrors ZapWalletTx(CWallet* pwallet, const CWalletTx& wtx);
     static bool Recover(CDBEnv& dbenv, std::string filename, bool fOnlyKeys);
     static bool Recover(CDBEnv& dbenv, std::string filename);
 };


### PR DESCRIPTION
Also changes old ZapWalletTx function names to ZapWalletTxes to match the
command line argument (-zapwallettxes)

This could be a nice conservative option for those who have zombie transactions and need to get rid of them to get an accurate account balance. I think the user might need to perform a rescan once removing the offending tx's.

I have not tested this yet, I need to figure out how to get a testnet wallet with some zombie transactions in it.
