### PR TITLE
Document new `walletpassphrase` behavior in 0.9

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -59,6 +59,27 @@ functioning both as a server and as a RPC client. The RPC client functionality
 executable, 'bitcoin-cli'. The RPC client code will eventually be removed from
 bitcoind, but will be kept for backwards compatibility for a release or two.
 
+`walletpassphrase` RPC
+-----------------------
+
+The behavior of the `walletpassphrase` RPC when the wallet is already unlocked
+has changed between 0.8 and 0.9.
+
+The 0.8 behavior of `walletpassphrase` is to fail when the wallet is already unlocked:
+
+    > walletpassphrase 1000
+    walletunlocktime = now + 1000
+    > walletpassphrase 10
+    Error: Wallet is already unlocked (old unlock time stays)
+
+The new behavior of `walletpassphrase` is to set a new unlock time overriding
+the old one:
+
+    > walletpassphrase 1000
+    walletunlocktime = now + 1000
+    > walletpassphrase 10
+    walletunlocktime = now + 10 (overriding the old unlock time)
+
 0.9.0rc1 Release notes
 =======================
 

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -1574,6 +1574,9 @@ Value walletpassphrase(const Array& params, bool fHelp)
             "\nArguments:\n"
             "1. \"passphrase\"     (string, required) The wallet passphrase\n"
             "2. timeout            (numeric, required) The time to keep the decryption key in seconds.\n"
+            "\nNote:\n"
+            "Issuing the walletpassphrase command while the wallet is already unlocked will set a new unlock\n"
+            "time that overrides the old one.\n"
             "\nExamples:\n"
             "\nunlock the wallet for 60 seconds\n"
             + HelpExampleCli("walletpassphrase", "\"my pass phrase\" 60") +


### PR DESCRIPTION
Also add a note to the release notes.
Fixes #3672.
