### PR TITLE
Add RPC `reissuetransaction`

### DIFF
--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -274,7 +274,7 @@ WalletModel::SendCoinsReturn WalletModel::sendCoins(WalletModelTransaction &tran
         }
 
         CReserveKey *keyChange = transaction.getPossibleKeyChange();
-        if(!wallet->CommitTransaction(*newTx, *keyChange))
+        if(!wallet->CommitTransaction(*newTx, keyChange))
             return TransactionCommitFailed;
 
         CTransaction* t = (CTransaction*)newTx;

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -296,6 +296,7 @@ static const CRPCCommand vRPCCommands[] =
     { "lockunspent",            &lockunspent,            false,     false,      true },
     { "listlockunspent",        &listlockunspent,        false,     false,      true },
     { "settxfee",               &settxfee,               false,     false,      true },
+    { "reissuetransaction",     &reissuetransaction,     false,     false,      true },
 
     /* Wallet-enabled mining */
     { "getgenerate",            &getgenerate,            true,      false,      false },

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -163,6 +163,7 @@ extern json_spirit::Value walletlock(const json_spirit::Array& params, bool fHel
 extern json_spirit::Value encryptwallet(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value validateaddress(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value getinfo(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value reissuetransaction(const json_spirit::Array& params, bool fHelp);
 
 extern json_spirit::Value getrawtransaction(const json_spirit::Array& params, bool fHelp); // in rcprawtransaction.cpp
 extern json_spirit::Value listunspent(const json_spirit::Array& params, bool fHelp);

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -245,7 +245,7 @@ public:
                            CWalletTx& wtxNew, CReserveKey& reservekey, int64_t& nFeeRet, std::string& strFailReason, const CCoinControl *coinControl = NULL);
     bool CreateTransaction(CScript scriptPubKey, int64_t nValue,
                            CWalletTx& wtxNew, CReserveKey& reservekey, int64_t& nFeeRet, std::string& strFailReason, const CCoinControl *coinControl = NULL);
-    bool CommitTransaction(CWalletTx& wtxNew, CReserveKey& reservekey);
+    bool CommitTransaction(CWalletTx& wtxNew, CReserveKey* reservekey);
     std::string SendMoney(CScript scriptPubKey, int64_t nValue, CWalletTx& wtxNew);
     std::string SendMoneyToDestination(const CTxDestination &address, int64_t nValue, CWalletTx& wtxNew);
 
@@ -367,6 +367,9 @@ public:
 
     // Get wallet transactions that conflict with given transaction (spend same outputs)
     std::set<uint256> GetConflicts(const uint256& txid) const;
+
+    /// Reissue a wallet transaction.
+    bool ReissueTransaction(const CWalletTx& wtx, CWalletTx& wtxNew);
 
     /** Address book entry changed.
      * @note called with lock cs_wallet held.


### PR DESCRIPTION
Add a new wallet RPC call `reissuetransaction`. Implements #3677.

The is make it possible to re-issue transactions that got stuck because they built on unconfirmed change transactions that were malleated.
- For conflicted transactions:
  - Iterate over inputs, find variants of parent transactions that made
    it into the block chain, create a new transaction with updated prevouts
  - Re-sign transaction
  - Commit new transaction to wallet and broadcast it to network
- For normal unconfirmed transactions:
  - Rebroadcast transaction to network
- For confirmed transaction:
  - Do nothing
