### PR TITLE
[Qt] ensure BIP70 certificate problems are shown to user

### DIFF
--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -527,7 +527,13 @@ bool PaymentServer::processPaymentRequest(PaymentRequestPlus& request, SendCoins
     recipient.paymentRequest = request;
     recipient.message = GUIUtil::HtmlEscape(request.getDetails().memo());
 
-    request.getMerchant(PaymentServer::certStore, recipient.authenticatedMerchant);
+    if (!request.getMerchant(PaymentServer::certStore, recipient.authenticatedMerchant))
+    {
+        emit message(tr("Payment request rejected"), tr("Failed to query merchant because of certificate related errors."),
+            CClientUIInterface::MSG_ERROR);
+
+        return false;
+    }
 
     QList<std::pair<CScript, qint64> > sendingTos = request.getPayTo();
     QStringList addresses;

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -238,7 +238,7 @@ QString TransactionDesc::toHTML(CWallet *wallet, CWalletTx &wtx, TransactionReco
             req.parse(QByteArray::fromRawData(r.second.data(), r.second.size()));
             QString merchant;
             if (req.getMerchant(PaymentServer::getCertStore(), merchant))
-                strHTML += "<b>" + tr("Merchant") + ":</b> " + GUIUtil::HtmlEscape(merchant) + "<br>";
+                strHTML += "<b>" + tr("Authenticated merchant") + ":</b> " + GUIUtil::HtmlEscape(merchant) + "<br>";
         }
     }
 


### PR DESCRIPTION
- fixes #3628 by showing certificate error(s) to user
- prevents accepting payment requests when certificate error(s) occur
- insecure payment requests are still possible with this, if they
  correctly set paymentRequest.pki_type() == "none"

Don't merge, NEEDS TO BE REWORKED!
