### PR TITLE
Serialize only CTransaction data in gettransaction RPC hex

### DIFF
--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -1496,7 +1496,7 @@ Value gettransaction(const Array& params, bool fHelp)
     entry.push_back(Pair("details", details));
 
     CDataStream ssTx(SER_NETWORK, PROTOCOL_VERSION);
-    ssTx << wtx;
+    ssTx << static_cast<CTransaction>(wtx);
     string strHex = HexStr(ssTx.begin(), ssTx.end());
     entry.push_back(Pair("hex", strHex));
 


### PR DESCRIPTION
Don't include trailing implementation-specific wallet metadata.
Fixes 3a1c20b.
