### PR TITLE
Fix crash in importwallet and dumpwallet formatting

### DIFF
--- a/src/rpcdump.cpp
+++ b/src/rpcdump.cpp
@@ -23,13 +23,13 @@ using namespace std;
 void EnsureWalletIsUnlocked();
 
 std::string static EncodeDumpTime(int64_t nTime) {
-    return DateTimeStrFormat("%Y-%m-%"PRId64"T%H:%M:%SZ", nTime);
+    return DateTimeStrFormat("%Y-%m-%dT%H:%M:%SZ", nTime);
 }
 
 int64_t static DecodeDumpTime(const std::string &str) {
-    static boost::posix_time::time_input_facet facet("%Y-%m-%dT%H:%M:%SZ");
     static const boost::posix_time::ptime epoch = boost::posix_time::from_time_t(0);
-    const std::locale loc(std::locale::classic(), &facet);
+    static const std::locale loc(std::locale::classic(),
+        new boost::posix_time::time_input_facet("%Y-%m-%dT%H:%M:%SZ"));
     std::istringstream iss(str);
     iss.imbue(loc);
     boost::posix_time::ptime ptime(boost::date_time::not_a_date_time);


### PR DESCRIPTION
- DecodeDumpTime was passing a statically allocated facet object to std::locale. However, "The constructed locale object takes over responsibility for deleting this facet object." causing a free()
  crash on scope exit. Fixes #3670.
- EncodeDumpTime was using the wrong format character for dates (appears accidentally introduced in 51ed9ec9)
