### PR TITLE
qt: Rename 'Confirmed' balance to 'Spendable' on overview page

### DIFF
--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -105,7 +105,7 @@
             <item row="0" column="0">
              <widget class="QLabel" name="label">
               <property name="text">
-               <string>Confirmed:</string>
+               <string>Available:</string>
               </property>
              </widget>
             </item>
@@ -137,7 +137,7 @@
             <item row="1" column="0">
              <widget class="QLabel" name="label_3">
               <property name="text">
-               <string>Unconfirmed:</string>
+               <string>Pending:</string>
               </property>
              </widget>
             </item>


### PR DESCRIPTION
The word 'Spendable' more precisely says what the balance actually means. It is not always 'confirmed' (for example in the case of spending unconfirmed change #3676).

![scr2](https://f.cloud.github.com/assets/126646/2195082/06fd9006-9897-11e3-9c72-67b220ce7e86.png)
