### PR TITLE
AddToWallet implies BindWallet

### DIFF
--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -470,6 +470,7 @@ bool CWallet::AddToWallet(const CWalletTx& wtxIn, bool fFromLoadWallet)
     if (fFromLoadWallet)
     {
         mapWallet[hash] = wtxIn;
+        mapWallet[hash].BindWallet(this);
         AddToSpends(hash);
     }
     else

--- a/src/walletdb.cpp
+++ b/src/walletdb.cpp
@@ -352,9 +352,7 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
             CWalletTx wtx;
             ssValue >> wtx;
             CValidationState state;
-            if (CheckTransaction(wtx, state) && (wtx.GetHash() == hash) && state.IsValid())
-                wtx.BindWallet(pwallet);
-            else
+            if (!(CheckTransaction(wtx, state) && (wtx.GetHash() == hash) && state.IsValid()))
                 return false;
 
             // Undo serialize changes in 31600


### PR DESCRIPTION
Now that AddToWallet is called when loading transactions from the wallet database, BindWallet can be integrated into that and does not need to be an extra step.

Leaves behaviour unchanged, but makes the fFromLoadWallet/!fFromLoadWallet paths in AddToWallet a bit more symmetric and avoids leaking implementation details out of CWallet.
