### PR TITLE
Change new constants in txdb.h to int64_t

### DIFF
--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -85,7 +85,7 @@ void OptionsModel::Init()
 #endif
 
     if (!settings.contains("nDatabaseCache"))
-        settings.setValue("nDatabaseCache", nDefaultDbCache);
+        settings.setValue("nDatabaseCache", (qint64)nDefaultDbCache);
     if (!SoftSetArg("-dbcache", settings.value("nDatabaseCache").toString().toStdString()))
         strOverriddenByCommandLine += "-dbcache ";
 

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -19,11 +19,11 @@ class CCoins;
 class uint256;
 
 // -dbcache default (MiB)
-static const int nDefaultDbCache = 100;
+static const int64_t nDefaultDbCache = 100;
 // max. -dbcache in (MiB)
-static const int nMaxDbCache = sizeof(void*) > 4 ? 4096 : 1024;
+static const int64_t nMaxDbCache = sizeof(void*) > 4 ? 4096 : 1024;
 // min. -dbcache in (MiB)
-static const int nMinDbCache = 4;
+static const int64_t nMinDbCache = 4;
 
 /** CCoinsView backed by the LevelDB coin database (chainstate/) */
 class CCoinsViewDB : public CCoinsView


### PR DESCRIPTION
A shift overflow was happening when using these to check against in init.cpp.
Fixes #3702.
