### PR TITLE
Wallet locking fixes for -DDEBUG_LOCKORDER

### DIFF
--- a/qa/rpc-tests/txnmall.sh
+++ b/qa/rpc-tests/txnmall.sh
@@ -8,6 +8,8 @@ if [ $# -lt 1 ]; then
         exit 1
 fi
 
+set -f
+
 BITCOIND=${1}/bitcoind
 CLI=${1}/bitcoin-cli
 
@@ -23,13 +25,13 @@ D=$(mktemp -d test.XXXXX)
 
 D1=${D}/node1
 CreateDataDir $D1 port=11000 rpcport=11001
-B1ARGS="-datadir=$D1 -debug"
+B1ARGS="-datadir=$D1"
 $BITCOIND $B1ARGS &
 B1PID=$!
 
 D2=${D}/node2
 CreateDataDir $D2 port=11010 rpcport=11011
-B2ARGS="-datadir=$D2 -debug"
+B2ARGS="-datadir=$D2"
 $BITCOIND $B2ARGS &
 B2PID=$!
 

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -140,8 +140,9 @@ void AssertLockHeldInternal(const char *pszName, const char* pszFile, int nLine,
 {
     BOOST_FOREACH(const PAIRTYPE(void*, CLockLocation)&i, *lockstack)
         if (i.first == cs) return;
-    LogPrintf("Lock %s not held in %s:%i; locks held:\n%s", pszName, pszFile, nLine, LocksHeld());
-    assert(0);
+    fprintf(stderr, "Assertion failed: lock %s not held in %s:%i; locks held:\n%s",
+            pszName, pszFile, nLine, LocksHeld().c_str());
+    abort();
 }
 
 #endif /* DEBUG_LOCKORDER */

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -363,7 +363,7 @@ public:
     bool SetMaxVersion(int nVersion);
 
     // get the current wallet format (the oldest client version guaranteed to understand this wallet)
-    int GetVersion() { AssertLockHeld(cs_wallet); return nWalletVersion; }
+    int GetVersion() { LOCK(cs_wallet); return nWalletVersion; }
 
     // Get wallet transactions that conflict with given transaction (spend same outputs)
     std::set<uint256> GetConflicts(const uint256& txid) const;


### PR DESCRIPTION
Compiling with -DDEBUG_LOCKORDER and running the qa/rpc-test/ regression
tests uncovered a couple of wallet methods that should (but didn't)
acquire the cs_wallet mutext.

I also changed the AssertLockHeld() routine print to stderr and
abort, instead of printing to debug.log and then assert()'ing.
It is annoying to look in debug.log to find out which
AssertLockHeld is failing.
