### PR TITLE
rpcwallet: Add txindex in ListTransaction

### DIFF
--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -1109,7 +1109,7 @@ void ListTransactions(const CWalletTx& wtx, const string& strAccount, int nMinDe
     // Sent
     if ((!listSent.empty() || nFee != 0) && (fAllAccounts || strAccount == strSentAccount))
     {
-        int vin = 0;
+        int vout = 0;
         BOOST_FOREACH(const PAIRTYPE(CTxDestination, int64_t)& s, listSent)
         {
             Object entry;
@@ -1124,10 +1124,10 @@ void ListTransactions(const CWalletTx& wtx, const string& strAccount, int nMinDe
             if (fLong)
             {
                 WalletTxToJSON(wtx, entry);
-                entry.push_back(Pair("vin", vin));
+                entry.push_back(Pair("vout", vout));
             }
             ret.push_back(entry);
-            vin++;
+            vout++;
         }
     }
 

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -1109,6 +1109,7 @@ void ListTransactions(const CWalletTx& wtx, const string& strAccount, int nMinDe
     // Sent
     if ((!listSent.empty() || nFee != 0) && (fAllAccounts || strAccount == strSentAccount))
     {
+        int txindex = 0;
         BOOST_FOREACH(const PAIRTYPE(CTxDestination, int64_t)& s, listSent)
         {
             Object entry;
@@ -1121,14 +1122,19 @@ void ListTransactions(const CWalletTx& wtx, const string& strAccount, int nMinDe
             entry.push_back(Pair("amount", ValueFromAmount(-s.second)));
             entry.push_back(Pair("fee", ValueFromAmount(-nFee)));
             if (fLong)
+            {
                 WalletTxToJSON(wtx, entry);
+                entry.push_back(Pair("txindex", txindex));
+            }
             ret.push_back(entry);
+            txindex++;
         }
     }
 
     // Received
     if (listReceived.size() > 0 && wtx.GetDepthInMainChain() >= nMinDepth)
     {
+        int txindex = 0;
         BOOST_FOREACH(const PAIRTYPE(CTxDestination, int64_t)& r, listReceived)
         {
             string account;
@@ -1157,9 +1163,13 @@ void ListTransactions(const CWalletTx& wtx, const string& strAccount, int nMinDe
                 }
                 entry.push_back(Pair("amount", ValueFromAmount(r.second)));
                 if (fLong)
+                {
                     WalletTxToJSON(wtx, entry);
+                    entry.push_back(Pair("txindex", txindex));
+                }
                 ret.push_back(entry);
             }
+            txindex++;
         }
     }
 }

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -1109,7 +1109,7 @@ void ListTransactions(const CWalletTx& wtx, const string& strAccount, int nMinDe
     // Sent
     if ((!listSent.empty() || nFee != 0) && (fAllAccounts || strAccount == strSentAccount))
     {
-        int txindex = 0;
+        int vin = 0;
         BOOST_FOREACH(const PAIRTYPE(CTxDestination, int64_t)& s, listSent)
         {
             Object entry;
@@ -1124,17 +1124,17 @@ void ListTransactions(const CWalletTx& wtx, const string& strAccount, int nMinDe
             if (fLong)
             {
                 WalletTxToJSON(wtx, entry);
-                entry.push_back(Pair("txindex", txindex));
+                entry.push_back(Pair("vin", vin));
             }
             ret.push_back(entry);
-            txindex++;
+            vin++;
         }
     }
 
     // Received
     if (listReceived.size() > 0 && wtx.GetDepthInMainChain() >= nMinDepth)
     {
-        int txindex = 0;
+        int vout = 0;
         BOOST_FOREACH(const PAIRTYPE(CTxDestination, int64_t)& r, listReceived)
         {
             string account;
@@ -1165,11 +1165,11 @@ void ListTransactions(const CWalletTx& wtx, const string& strAccount, int nMinDe
                 if (fLong)
                 {
                     WalletTxToJSON(wtx, entry);
-                    entry.push_back(Pair("txindex", txindex));
+                    entry.push_back(Pair("vout", vout));
                 }
                 ret.push_back(entry);
             }
-            txindex++;
+            vout++;
         }
     }
 }


### PR DESCRIPTION
"txindex" indicates location of a payment in transaction.
This and "txid" combined helps exchanges identify single payments.

Users could use "sendmany" to send 2 payments of the same amount to a single address in the same transaction, confuses exchange software.
