### PR TITLE
Keep walletpassphrase until the next api call it's used in

### DIFF
--- a/src/rpcdump.cpp
+++ b/src/rpcdump.cpp
@@ -132,6 +132,8 @@ Value importprivkey(const Array& params, bool fHelp)
         }
     }
 
+    if (nWalletUnlockTime == -1) LockWallet(pwalletMain);
+
     return Value::null;
 }
 
@@ -222,6 +224,8 @@ Value importwallet(const Array& params, bool fHelp)
     if (!fGood)
         throw JSONRPCError(RPC_WALLET_ERROR, "Error adding some keys to wallet");
 
+    if (nWalletUnlockTime == -1) LockWallet(pwalletMain);
+
     return Value::null;
 }
 
@@ -254,6 +258,9 @@ Value dumpprivkey(const Array& params, bool fHelp)
     CKey vchSecret;
     if (!pwalletMain->GetKey(keyID, vchSecret))
         throw JSONRPCError(RPC_WALLET_ERROR, "Private key for address " + strAddress + " is not known");
+
+    if (nWalletUnlockTime == -1) LockWallet(pwalletMain);
+
     return CBitcoinSecret(vchSecret).ToString();
 }
 
@@ -315,5 +322,8 @@ Value dumpwallet(const Array& params, bool fHelp)
     file << "\n";
     file << "# End of dump\n";
     file.close();
+
+    if (nWalletUnlockTime == -1) LockWallet(pwalletMain);
+
     return Value::null;
 }

--- a/src/rpcdump.cpp
+++ b/src/rpcdump.cpp
@@ -116,7 +116,11 @@ Value importprivkey(const Array& params, bool fHelp)
 
         // Don't throw error in case a key is already there
         if (pwalletMain->HaveKey(vchAddress))
+        {
+            if (nWalletUnlockTime == -1)
+                LockWallet(pwalletMain);
             return Value::null;
+        }
 
         pwalletMain->mapKeyMetadata[vchAddress].nCreateTime = 1;
 

--- a/src/rpcdump.cpp
+++ b/src/rpcdump.cpp
@@ -132,7 +132,8 @@ Value importprivkey(const Array& params, bool fHelp)
         }
     }
 
-    if (nWalletUnlockTime == -1) LockWallet(pwalletMain);
+    if (nWalletUnlockTime == -1)
+        LockWallet(pwalletMain);
 
     return Value::null;
 }
@@ -224,7 +225,8 @@ Value importwallet(const Array& params, bool fHelp)
     if (!fGood)
         throw JSONRPCError(RPC_WALLET_ERROR, "Error adding some keys to wallet");
 
-    if (nWalletUnlockTime == -1) LockWallet(pwalletMain);
+    if (nWalletUnlockTime == -1)
+        LockWallet(pwalletMain);
 
     return Value::null;
 }
@@ -259,7 +261,8 @@ Value dumpprivkey(const Array& params, bool fHelp)
     if (!pwalletMain->GetKey(keyID, vchSecret))
         throw JSONRPCError(RPC_WALLET_ERROR, "Private key for address " + strAddress + " is not known");
 
-    if (nWalletUnlockTime == -1) LockWallet(pwalletMain);
+    if (nWalletUnlockTime == -1)
+        LockWallet(pwalletMain);
 
     return CBitcoinSecret(vchSecret).ToString();
 }
@@ -323,7 +326,8 @@ Value dumpwallet(const Array& params, bool fHelp)
     file << "# End of dump\n";
     file.close();
 
-    if (nWalletUnlockTime == -1) LockWallet(pwalletMain);
+    if (nWalletUnlockTime == -1)
+        LockWallet(pwalletMain);
 
     return Value::null;
 }

--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -732,6 +732,9 @@ Value signrawtransaction(const Array& params, bool fHelp)
     result.push_back(Pair("hex", HexStr(ssTx.begin(), ssTx.end())));
     result.push_back(Pair("complete", fComplete));
 
+    if (!fGivenKeys && nWalletUnlockTime == -1)
+        LockWallet(pwalletMain);
+
     return result;
 }
 

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -19,6 +19,7 @@
 #include "json/json_spirit_writer_template.h"
 
 class CBlockIndex;
+class CWallet;
 
 /* Start RPC threads */
 void StartRPCThreads();
@@ -108,6 +109,7 @@ extern std::string HelpExampleCli(std::string methodname, std::string args);
 extern std::string HelpExampleRpc(std::string methodname, std::string args);
 
 extern void EnsureWalletIsUnlocked();
+extern void LockWallet(CWallet* pWallet);
 
 extern json_spirit::Value getconnectioncount(const json_spirit::Array& params, bool fHelp); // in rpcnet.cpp
 extern json_spirit::Value getpeerinfo(const json_spirit::Array& params, bool fHelp);

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -202,7 +202,8 @@ Value getrawchangeaddress(const Array& params, bool fHelp)
 
     CKeyID keyID = vchPubKey.GetID();
 
-    if (nWalletUnlockTime == -1) LockWallet(pwalletMain);
+    if (nWalletUnlockTime == -1)
+        LockWallet(pwalletMain);
 
     return CBitcoinAddress(keyID).ToString();
 }
@@ -347,7 +348,8 @@ Value sendtoaddress(const Array& params, bool fHelp)
     if (strError != "")
         throw JSONRPCError(RPC_WALLET_ERROR, strError);
 
-    if (nWalletUnlockTime == -1) LockWallet(pwalletMain);
+    if (nWalletUnlockTime == -1)
+        LockWallet(pwalletMain);
 
     return wtx.GetHash().GetHex();
 }
@@ -447,7 +449,8 @@ Value signmessage(const Array& params, bool fHelp)
     if (!key.SignCompact(ss.GetHash(), vchSig))
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Sign failed");
 
-    if (nWalletUnlockTime == -1) LockWallet(pwalletMain);
+    if (nWalletUnlockTime == -1)
+        LockWallet(pwalletMain);
 
     return EncodeBase64(&vchSig[0], vchSig.size());
 }
@@ -791,7 +794,8 @@ Value sendfrom(const Array& params, bool fHelp)
     if (strError != "")
         throw JSONRPCError(RPC_WALLET_ERROR, strError);
 
-    if (nWalletUnlockTime == -1) LockWallet(pwalletMain);
+    if (nWalletUnlockTime == -1)
+        LockWallet(pwalletMain);
 
     return wtx.GetHash().GetHex();
 }
@@ -875,7 +879,8 @@ Value sendmany(const Array& params, bool fHelp)
     if (!pwalletMain->CommitTransaction(wtx, keyChange))
         throw JSONRPCError(RPC_WALLET_ERROR, "Transaction commit failed");
 
-    if (nWalletUnlockTime == -1) LockWallet(pwalletMain);
+    if (nWalletUnlockTime == -1)
+        LockWallet(pwalletMain);
 
     return wtx.GetHash().GetHex();
 }
@@ -1563,7 +1568,8 @@ Value keypoolrefill(const Array& params, bool fHelp)
     if (pwalletMain->GetKeyPoolSize() < kpSize)
         throw JSONRPCError(RPC_WALLET_ERROR, "Error refreshing keypool.");
 
-    if (nWalletUnlockTime == -1) LockWallet(pwalletMain);
+    if (nWalletUnlockTime == -1)
+        LockWallet(pwalletMain);
 
     return Value::null;
 }
@@ -1624,12 +1630,13 @@ Value walletpassphrase(const Array& params, bool fHelp)
 
     int64_t nSleepTime = params[1].get_int64();
     LOCK(cs_nWalletUnlockTime);
-    if (nSleepTime == -1) {
-        nWalletUnlockTime = -1;
-    } else {
+    if (nSleepTime != -1)
+    {
         nWalletUnlockTime = GetTime() + nSleepTime;
         RPCRunLater("lockwallet", boost::bind(LockWallet, pwalletMain), nSleepTime);
     }
+    else
+        nWalletUnlockTime = -1;
 
     return Value::null;
 }

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -1591,7 +1591,7 @@ Value walletpassphrase(const Array& params, bool fHelp)
             "This is needed prior to performing transactions related to private keys such as sending bitcoins\n"
             "\nArguments:\n"
             "1. \"passphrase\"     (string, required) The wallet passphrase\n"
-            "2. timeout            (numeric, required) The time to keep the decryption key in seconds.\n"
+            "2. timeout            (numeric, required) The time to keep the decryption key in seconds. If -1 is passed, the server will keep the key until the next api call that requires it.\n"
             "\nNote:\n"
             "Issuing the walletpassphrase command while the wallet is already unlocked will set a new unlock\n"
             "time that overrides the old one.\n"
@@ -1600,6 +1600,8 @@ Value walletpassphrase(const Array& params, bool fHelp)
             + HelpExampleCli("walletpassphrase", "\"my pass phrase\" 60") +
             "\nLock the wallet again (before 60 seconds)\n"
             + HelpExampleCli("walletlock", "") +
+            "\nunlock the wallet until the next key-using call\n"
+            + HelpExampleCli("walletpassphrase", "\"my pass phrase\" -1") +
             "\nAs json rpc call\n"
             + HelpExampleRpc("walletpassphrase", "\"my pass phrase\", 60")
         );


### PR DESCRIPTION
This patch will allow `-1` to be passed to walletpassphrase as the timeout. A timeout of `-1` will hold the passphrase in memory until the next api call is made that requires it.

Example:

``` bash
$ bitcoind walletpassphrase hunter2 -1
$ bitcoind getaccountaddress ''
1M72Sfpbz1BPpXFHz9m3CdqATR44Jvaydd
$ bitcoind signmessage 1M72Sfpbz1BPpXFHz9m3CdqATR44Jvaydd foo
H5UQlcIJjSWbNK/MFaP0LDGt8CSkbe9D8FbdGUFHM/hAQ0avEchg2sJ8v2db8ynOD2PqQwYuR/5tbbKl7LiMUEE=
$ bitcoind signmessage 1M72Sfpbz1BPpXFHz9m3CdqATR44Jvaydd foo
error: {"code":-13,"message":"Error: Please enter the wallet passphrase with walletpassphrase first."}
```

I realize something similar is doable with:

``` bash
$ bitcoind walletpassphrase hunter2 60
$ bitcoind signmessage 1M72Sfpbz1BPpXFHz9m3CdqATR44Jvaydd foo
H5UQlcIJjSWbNK/MFaP0LDGt8CSkbe9D8FbdGUFHM/hAQ0avEchg2sJ8v2db8ynOD2PqQwYuR/5tbbKl7LiMUEE=
$ bitcoind walletlock
```

The former just seems like it might be more convenient for some situations.
