### PR TITLE
qt: Modernize 'confirmed' terminology in shown tx status

### DIFF
--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -19,33 +19,32 @@ class TransactionStatus
 {
 public:
     TransactionStatus():
-        confirmed(false), sortKey(""), maturity(Mature),
+        countsForBalance(false), sortKey(""),
         matures_in(0), status(Offline), depth(0), open_for(0), cur_num_blocks(-1)
     { }
 
-    enum Maturity
-    {
-        Immature,
-        Mature,
-        MaturesWarning, /**< Transaction will likely not mature because no nodes have confirmed */
-        NotAccepted
-    };
-
     enum Status {
-        OpenUntilDate,
-        OpenUntilBlock,
-        Offline,
-        Unconfirmed,
-        HaveConfirmations,
-        Conflicted
+        Confirmed,          /**< Have 6 or more confirmations (normal tx) or fully mature (mined tx) **/
+        /// Normal (sent/received) transactions
+        OpenUntilDate,      /**< Transaction not yet final, waiting for date */
+        OpenUntilBlock,     /**< Transaction not yet final, waiting for block */
+        Offline,            /**< Not sent to any other nodes **/
+        Unconfirmed,        /**< Not yet mined into a block **/
+        Confirming,         /**< Confirmed, but waiting for the recommended number of confirmations **/
+        Conflicted,         /**< Conflicts with other transaction or mempool **/
+        /// Generated (mined) transactions
+        Immature,           /**< Mined but waiting for maturity */
+        MaturesWarning,     /**< Transaction will likely not mature because no nodes have confirmed */
+        NotAccepted         /**< Mined but not accepted */
     };
 
-    bool confirmed;
+    /// Transaction counts towards available balance
+    bool countsForBalance;
+    /// Sorting key based on status
     std::string sortKey;
 
     /** @name Generated (mined) transactions
        @{*/
-    Maturity maturity;
     int matures_in;
     /**@}*/
 
@@ -79,8 +78,8 @@ public:
         SendToSelf
     };
 
-    /** Number of confirmation needed for transaction */
-    static const int NumConfirmations = 6;
+    /** Number of confirmation recommended for accepting a transaction */
+    static const int RecommendedNumConfirmations = 6;
 
     TransactionRecord():
             hash(), time(0), type(Other), address(""), debit(0), credit(0), idx(0)


### PR DESCRIPTION
These days we regard transactions with one confirmation to be 'Confirmed'. Only transactions with 0 confirmations are 'Unconfirmed'.
Waiting for 6 confirmations is a recommendation but should not keep the transaction shown as unconfirmed.

Misc code sanity:
- Merge maturity/status enums, they had become completely disjunct
- 'confirmed' flag is now called 'countsForBalance' for clarity
