### PR TITLE
gitian: add libz-dev dependency package for linux boost

### DIFF
--- a/contrib/gitian-descriptors/boost-linux.yml
+++ b/contrib/gitian-descriptors/boost-linux.yml
@@ -13,6 +13,7 @@ packages:
 - "faketime"
 - "bsdmainutils"
 - "zip"
+- "libz-dev"
 reference_datetime: "2011-01-30 00:00:00"
 remotes: []
 files:


### PR DESCRIPTION
Boost iostreams was picking up libz-dev in VirtualBox, as the recommended way to build is now to make a VM with all dependency packages installed.

This caused a divergence between KVM/LXC build and VirtualBox build results.

Fix this in the simplest possible way: add the libz-dev package.

Alternative to #3726, fixes a non-determinism issue in #3725.

Expected output now is (thanks @int03h):

```
f29b7d9577417333fb56e023c2977f5726a7c297f320b175a4108cf7cd4c2d29 boost-linux32- 1.55.0-gitian-r1.zip
88232451c4104f7eb16e469ac6474fd1231bd485687253f7b2bdf46c0781d535 boost-linux64- 1.55.0-gitian-r1.zip
```

As the compression part of boost::iostreams is not used by bitcoin, this should not affect the eventual build result (tested: final output is still same as mentioned in #3622).
