### PR TITLE
Don't use PRI?64 formatting derives from inttypes.h

### DIFF
--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -11,7 +11,6 @@
 #include "util.h"
 
 #include <algorithm>
-#include <inttypes.h>
 #include <map>
 
 #include <boost/algorithm/string/classification.hpp>

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -10,7 +10,6 @@
 #include "protocol.h"
 #include "util.h"
 
-#include <inttypes.h>
 #include <stdint.h>
 
 #ifndef WIN32

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -24,7 +24,6 @@
 #include "walletdb.h"
 #endif
 
-#include <inttypes.h>
 #include <stdint.h>
 
 #ifndef WIN32

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,7 +17,6 @@
 #include "ui_interface.h"
 #include "util.h"
 
-#include <inttypes.h>
 #include <sstream>
 
 #include <boost/algorithm/string/replace.hpp>

--- a/src/net.h
+++ b/src/net.h
@@ -18,7 +18,6 @@
 #include "util.h"
 
 #include <deque>
-#include <inttypes.h>
 #include <stdint.h>
 
 #ifndef WIN32

--- a/src/rpcnet.cpp
+++ b/src/rpcnet.cpp
@@ -15,8 +15,6 @@
 #include "wallet.h" // for getinfo
 #endif
 
-#include <inttypes.h>
-
 #include <boost/foreach.hpp>
 #include "json/json_spirit_value.h"
 

--- a/src/util.h
+++ b/src/util.h
@@ -16,7 +16,6 @@
 
 #include <cstdio>
 #include <exception>
-#include <inttypes.h>
 #include <map>
 #include <stdarg.h>
 #include <stdint.h>
@@ -45,13 +44,25 @@ static const int64_t CENT = 1000000;
 #define UEND(a)             ((unsigned char*)&((&(a))[1]))
 #define ARRAYLEN(array)     (sizeof(array)/sizeof((array)[0]))
 
-/* Format characters for (s)size_t and ptrdiff_t (C99 standard) */
-#define PRIszx    "zx"
-#define PRIszu    "zu"
-#define PRIszd    "zd"
-#define PRIpdx    "tx"
-#define PRIpdu    "tu"
-#define PRIpdd    "td"
+/* Format characters for (s)size_t, ptrdiff_t, uint64_t.
+ *
+ * As the tinyformat-based formatting system is type-safe, no special format
+ * characters are really needed to specify sizes. Tinyformat can support
+ * (ignores) the C99 prefixes such as "ll" but chokes on MSVC's inttypes
+ * defines prefixes such as "I64X".  So don't include inttypes.h and define our
+ * own for compatibility.
+ * If you get a warning here about a redefine of PRI?64, make sure that
+ * inttypes.h is not included.
+ */
+#define PRIszx    "x"
+#define PRIszu    "u"
+#define PRIszd    "d"
+#define PRIpdx    "x"
+#define PRIpdu    "u"
+#define PRIpdd    "d"
+#define PRIx64    "x"
+#define PRIu64    "u"
+#define PRId64    "d"
 
 // This is needed because the foreach macro can't get over the comma in pair<t1, t2>
 #define PAIRTYPE(t1, t2)    std::pair<t1, t2>

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -9,8 +9,6 @@
 #include "coincontrol.h"
 #include "net.h"
 
-#include <inttypes.h>
-
 #include <boost/algorithm/string/replace.hpp>
 #include <openssl/rand.h>
 

--- a/src/walletdb.cpp
+++ b/src/walletdb.cpp
@@ -11,8 +11,6 @@
 #include "sync.h"
 #include "wallet.h"
 
-#include <inttypes.h>
-
 #include <boost/filesystem.hpp>
 #include <boost/foreach.hpp>
 


### PR DESCRIPTION
As the tinyformat-based formatting system (introduced in b77dfdc) is type-safe, no special format characters are needed to specify sizes.

Tinyformat can support (ignore) the C99 prefixes such as "ll" but chokes on mingw's inttypes.h  prefixes such as "I64X". So don't include inttypes.h and define our own for compatibility. This also further reduces C99 dependency and platform variability.

(a possibly better alternative would be to sweep the entire codebase using sed -i to get rid of the special size specifiers but this has less diff impact)

Tested by strprintf numbers test: https://github.com/bitcoin/bitcoin/blob/master/src/test/util_tests.cpp#L310

Fixes an issue in getpeerinfo on Windows noticed on the mailing list by Ronald Hoffman.
