### PR TITLE
Fix bitcoin-cli exit status code

### DIFF
--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -6,6 +6,7 @@
 #include "util.h"
 #include "init.h"
 #include "rpcclient.h"
+#include "rpcprotocol.h"
 #include "ui_interface.h" /* for _(...) */
 #include "chainparams.h"
 
@@ -55,23 +56,25 @@ int main(int argc, char* argv[])
     try
     {
         if(!AppInitRPC(argc, argv))
-            return 1;
+            return abs(RPC_MISC_ERROR);
     }
     catch (std::exception& e) {
         PrintExceptionContinue(&e, "AppInitRPC()");
+        return abs(RPC_MISC_ERROR);
     } catch (...) {
         PrintExceptionContinue(NULL, "AppInitRPC()");
+        return abs(RPC_MISC_ERROR);
     }
 
+    int ret = abs(RPC_MISC_ERROR);
     try
     {
-        if(!CommandLineRPC(argc, argv))
-            return 1;
+        ret = CommandLineRPC(argc, argv);
     }
     catch (std::exception& e) {
         PrintExceptionContinue(&e, "CommandLineRPC()");
     } catch (...) {
         PrintExceptionContinue(NULL, "CommandLineRPC()");
     }
-    return 0;
+    return ret;
 }

--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -233,7 +233,7 @@ int CommandLineRPC(int argc, char *argv[])
     }
     catch (std::exception& e) {
         strPrint = string("error: ") + e.what();
-        nRet = 87;
+        nRet = abs(RPC_MISC_ERROR);
     }
     catch (...) {
         PrintException(NULL, "CommandLineRPC()");


### PR DESCRIPTION
bitcoin-cli returns 1 on success and 0 on error. By convention it should be the other way round.

It is not possible to distinguish between different error codes, all errors return 0.
But for an AppInitRPC error, we would return 1...
