### PR TITLE
Display blocks received without needing debug=net

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3690,7 +3690,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
         CBlock block;
         vRecv >> block;
 
-        LogPrint("net", "received block %s\n", block.GetHash().ToString());
+        LogPrintf("received block %s\n", block.GetHash().ToString());
         // block.print();
 
         CInv inv(MSG_BLOCK, block.GetHash());


### PR DESCRIPTION
Too much debug info is shown when debug=net, but blocks received is useful info that most people will want to see without debug=net set.
