### PR TITLE
gitian: Make protobuf win32 intermediate output deterministic

### DIFF
--- a/contrib/gitian-descriptors/protobuf-win.yml
+++ b/contrib/gitian-descriptors/protobuf-win.yml
@@ -38,13 +38,13 @@ script: |
     tar xjf $INDIR/protobuf-2.5.0.tar.bz2
     cd protobuf-2.5.0
     # First: build a native (linux) protoc
-    ./configure --enable-shared=no --disable-dependency-tracking
+    ./configure --enable-shared=no --disable-dependency-tracking --without-zlib CXXFLAGS="-frandom-seed=11 ${OPTFLAGS}"
     make
     mkdir -p $INSTALLPREFIX/host/bin
     cp src/protoc $INSTALLPREFIX/host/bin
     # Now recompile with the mingw cross-compiler:
     make distclean
-    ./configure --prefix=$INSTALLPREFIX --enable-shared=no --disable-dependency-tracking --with-protoc=$INSTALLPREFIX/host/bin/protoc --host=$HOST CXXFLAGS="-frandom-seed=11 ${OPTFLAGS}"
+    ./configure --prefix=$INSTALLPREFIX --enable-shared=no --disable-dependency-tracking --without-zlib --with-protoc=$INSTALLPREFIX/host/bin/protoc --host=$HOST CXXFLAGS="-frandom-seed=11 ${OPTFLAGS}"
     export LD_PRELOAD=/usr/lib/faketime/libfaketime.so.1
     export FAKETIME=$REFERENCE_DATETIME
     make


### PR DESCRIPTION
While building protobuf in different environments we noticed that the host tool protoc was slightly different between builds (a symbol table sorting issue).
Add a deterministic seed for gcc as well as disable zlib support just in case.

Exected output is now:

```
e2e403e1a08869c7eed4d4293bce13d51ec6a63592918b90ae215a0eceb44cb4 protobuf-win32-2.5.0-gitian-r4.zip
a0999037e8b0ef9ade13efd88fee261ba401f5ca910068b7e0cd3262ba667db0 protobuf-win64-2.5.0-gitian-r4.zip
```

No effect on final executables so no version bump.
