### PR TITLE
Remove CheckSig() dependence on CPubKey.IsValid()

### DIFF
--- a/src/script.cpp
+++ b/src/script.cpp
@@ -1157,7 +1157,7 @@ bool CheckSig(vector<unsigned char> vchSig, const vector<unsigned char> &vchPubK
     static CSignatureCache signatureCache;
 
     CPubKey pubkey(vchPubKey);
-    if (!pubkey.IsValid())
+    if (pubkey.size() == 0)
         return false;
 
     // Hash type is one byte tacked on to the end of the signature


### PR DESCRIPTION
This was a non-obvious consensus-critical dependence; just the kind of thing that could lead to consensus bug in the future if someone ever changed CPubKey.IsValid()
