### PR TITLE
micro-memory optimization: change const int copy_depth to unsigned char

### DIFF
--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -808,7 +808,7 @@ void CWalletTx::AddSupportingTransactions()
 {
     vtxPrev.clear();
 
-    const int COPY_DEPTH = 3;
+    const unsigned char COPY_DEPTH = 3;
     if (SetMerkleBranch() < COPY_DEPTH)
     {
         vector<uint256> vWorkQueue;


### PR DESCRIPTION
b/c it fits in 8bit value
