### PR TITLE
Replace PrintException with PrintExceptionContinue + throw

### DIFF
--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -236,7 +236,8 @@ int CommandLineRPC(int argc, char *argv[])
         nRet = abs(RPC_MISC_ERROR);
     }
     catch (...) {
-        PrintException(NULL, "CommandLineRPC()");
+        PrintExceptionContinue(NULL, "CommandLineRPC()");
+        throw;
     }
 
     if (strPrint != "")

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -948,15 +948,6 @@ void LogException(std::exception* pex, const char* pszThread)
     LogPrintf("\n%s", message);
 }
 
-void PrintException(std::exception* pex, const char* pszThread)
-{
-    std::string message = FormatException(pex, pszThread);
-    LogPrintf("\n\n************************\n%s\n", message);
-    fprintf(stderr, "\n\n************************\n%s\n", message.c_str());
-    strMiscWarning = message;
-    throw;
-}
-
 void PrintExceptionContinue(std::exception* pex, const char* pszThread)
 {
     std::string message = FormatException(pex, pszThread);

--- a/src/util.h
+++ b/src/util.h
@@ -172,7 +172,6 @@ static inline bool error(const char* format)
 
 
 void LogException(std::exception* pex, const char* pszThread);
-void PrintException(std::exception* pex, const char* pszThread);
 void PrintExceptionContinue(std::exception* pex, const char* pszThread);
 void ParseString(const std::string& str, char c, std::vector<std::string>& v);
 std::string FormatMoney(int64_t n, bool fPlus=false);
@@ -566,10 +565,12 @@ template <typename Callable> void LoopForever(const char* name,  Callable func, 
         throw;
     }
     catch (std::exception& e) {
-        PrintException(&e, name);
+        PrintExceptionContinue(&e, name);
+        throw;
     }
     catch (...) {
-        PrintException(NULL, name);
+        PrintExceptionContinue(NULL, name);
+        throw;
     }
 }
 // .. and a wrapper that just calls func once
@@ -589,10 +590,12 @@ template <typename Callable> void TraceThread(const char* name,  Callable func)
         throw;
     }
     catch (std::exception& e) {
-        PrintException(&e, name);
+        PrintExceptionContinue(&e, name);
+        throw;
     }
     catch (...) {
-        PrintException(NULL, name);
+        PrintExceptionContinue(NULL, name);
+        throw;
     }
 }
 


### PR DESCRIPTION
Just a pet peeve (@cozz likely agrees).

(PrintException has exactly the same body as PrintExceptionContinue but does a re-throw at the end. Move these re-throws to the call site, this aids understanding what is going on as well as eliminates a
bit of code duplication in util.cpp)
