### PR TITLE
Add shell null to else block

### DIFF
--- a/src/m4/ax_boost_base.m4
+++ b/src/m4/ax_boost_base.m4
@@ -155,7 +155,7 @@ if test "x$want_boost" = "xyes"; then
         AC_MSG_RESULT(yes)
     succeeded=yes
     found_system=yes
-        ],[
+        ],[:
         ])
     AC_LANG_POP([C++])
 
@@ -238,7 +238,7 @@ if test "x$want_boost" = "xyes"; then
             AC_MSG_RESULT(yes)
         succeeded=yes
         found_system=yes
-            ],[
+            ],[:
             ])
         AC_LANG_POP([C++])
     fi


### PR DESCRIPTION
MinGW-W64-builds-4.2.0 shell doesn't like the empty else blocks.
