### PR TITLE
mempool janitor: periodic sweep and clean of not-confirming transactions

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -96,6 +96,7 @@ BITCOIN_CORE_H = \
   net.h \
   noui.h \
   pow.h \
+  poolman.h \
   protocol.h \
   random.h \
   rpcclient.h \
@@ -204,6 +205,7 @@ libbitcoin_common_a_SOURCES = \
   key.cpp \
   keystore.cpp \
   netbase.cpp \
+  poolman.cpp \
   protocol.cpp \
   script.cpp \
   $(BITCOIN_CORE_H)

--- a/src/poolman.cpp
+++ b/src/poolman.cpp
@@ -1,0 +1,58 @@
+
+#include "poolman.h"
+#include "core.h"
+#include "main.h"
+#include "wallet.h"
+#include "init.h"
+
+using namespace std;
+
+int64_t janitorExpire; // global; expire TXs n seconds older than this
+
+static unsigned int IgnoreWalletTransactions(vector<CTransaction>& vtx)
+{
+    unsigned int nMine = 0;
+
+#ifdef ENABLE_WALLET
+    if (!pwalletMain)
+        return 0;
+
+    vector<CTransaction> vtxTmp;
+    BOOST_FOREACH(const CTransaction& tx, vtx) {
+        if (pwalletMain->IsMine(tx))
+            nMine++;
+        else
+            vtxTmp.push_back(tx);
+    }
+
+    if (nMine > 0)
+        vtx = vtxTmp;
+#endif // ENABLE_WALLET
+
+    return nMine;
+}
+
+void TxMempoolJanitor()
+{
+    int64_t nStart = GetTimeMillis();
+    int64_t expireTime = GetTime() - janitorExpire;
+
+    // pass 1: get matching transactions
+    vector<CTransaction> vtx;
+    mempool.queryOld(vtx, expireTime);
+    unsigned int nOld = vtx.size();
+
+    // pass 2: ignore wallet transactions (remove from vtx)
+    unsigned int nMine = IgnoreWalletTransactions(vtx);
+
+    // pass 3: remove old transactions from mempool
+    bool fRecursive = false;
+    std::list<CTransaction> removed;
+    mempool.removeBatch(vtx, removed, fRecursive);
+
+    LogPrint("mempool", "mempool janitor run complete,  %dms\n",
+             GetTimeMillis() - nStart);
+    LogPrint("mempool", "    %u old, %u old wallet, %u removed\n",
+             nOld, nMine, removed.size());
+}
+

--- a/src/poolman.h
+++ b/src/poolman.h
@@ -1,0 +1,9 @@
+#ifndef __BITCOIN_POOLMAN_H__
+#define __BITCOIN_POOLMAN_H__
+
+#include <stdint.h>
+
+extern void TxMempoolJanitor();
+extern int64_t janitorExpire;
+
+#endif // __BITCOIN_POOLMAN_H__

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -7,6 +7,7 @@
 #include "main.h"
 #include "rpcserver.h"
 #include "sync.h"
+#include "poolman.h"
 
 #include <stdint.h>
 
@@ -404,6 +405,24 @@ Value gettxout(const Array& params, bool fHelp)
     ret.push_back(Pair("coinbase", coins.fCoinBase));
 
     return ret;
+}
+
+Value sweepmempool(const Array& params, bool fHelp)
+{
+    if (fHelp || params.size() != 0)
+        throw runtime_error(
+            "sweepmempool\n"
+            "\nRemoves old, unconfirmed transactions from mempool\n"
+            "\nResult:\n"
+            "n    (bool) true\n"
+            "\nExamples:\n"
+            + HelpExampleCli("sweepmempool", "")
+            + HelpExampleRpc("sweepmempool", "")
+        );
+
+    TxMempoolJanitor();
+
+    return true;
 }
 
 Value verifychain(const Array& params, bool fHelp)

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -259,6 +259,7 @@ static const CRPCCommand vRPCCommands[] =
     { "blockchain",         "getrawmempool",          &getrawmempool,          true,      false,      false },
     { "blockchain",         "gettxout",               &gettxout,               true,      false,      false },
     { "blockchain",         "gettxoutsetinfo",        &gettxoutsetinfo,        true,      false,      false },
+    { "blockchain",         "sweepmempool",           &sweepmempool,           true,      true,       false },
     { "blockchain",         "verifychain",            &verifychain,            true,      false,      false },
 
     /* Mining */

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -205,6 +205,7 @@ extern json_spirit::Value getblockhash(const json_spirit::Array& params, bool fH
 extern json_spirit::Value getblock(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value gettxoutsetinfo(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value gettxout(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value sweepmempool(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value verifychain(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value getchaintips(const json_spirit::Array& params, bool fHelp);
 

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -407,11 +407,10 @@ bool CTxMemPool::addUnchecked(const uint256& hash, const CTxMemPoolEntry &entry)
 }
 
 
-void CTxMemPool::remove(const CTransaction &tx, std::list<CTransaction>& removed, bool fRecursive)
+void CTxMemPool::removeUnlocked(const CTransaction &tx, std::list<CTransaction>& removed, bool fRecursive)
 {
     // Remove transaction from memory pool
     {
-        LOCK(cs);
         uint256 hash = tx.GetHash();
         if (fRecursive) {
             for (unsigned int i = 0; i < tx.vout.size(); i++) {
@@ -429,6 +428,22 @@ void CTxMemPool::remove(const CTransaction &tx, std::list<CTransaction>& removed
             mapTx.erase(hash);
             nTransactionsUpdated++;
         }
+    }
+}
+
+void CTxMemPool::remove(const CTransaction &tx, std::list<CTransaction>& removed, bool fRecursive)
+{
+    LOCK(cs);
+    removeUnlocked(tx, removed, fRecursive);
+}
+
+void CTxMemPool::removeBatch(vector<CTransaction>& vtx, std::list<CTransaction>& removed, bool fRecursive)
+{
+    LOCK(cs);
+    BOOST_FOREACH(const CTransaction& tx, vtx) {
+        uint256 hash = tx.GetHash();
+        if (mapTx.count(hash))
+            removeUnlocked(tx, removed, fRecursive);
     }
 }
 
@@ -528,6 +543,17 @@ void CTxMemPool::queryHashes(vector<uint256>& vtxid)
     vtxid.reserve(mapTx.size());
     for (map<uint256, CTxMemPoolEntry>::iterator mi = mapTx.begin(); mi != mapTx.end(); ++mi)
         vtxid.push_back((*mi).first);
+}
+
+void CTxMemPool::queryOld(vector<CTransaction>& vtx, int64_t matchTime)
+{
+    LOCK(cs);
+
+    for (map<uint256, CTxMemPoolEntry>::iterator mi = mapTx.begin(); mi != mapTx.end(); ++mi) {
+        CTxMemPoolEntry& mpe = (*mi).second;
+        if (mpe.GetTime() <= matchTime)
+            vtx.push_back(mpe.GetTx());
+    }
 }
 
 bool CTxMemPool::lookup(uint256 hash, CTransaction& result) const

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -69,6 +69,8 @@ private:
 
     CFeeRate minRelayFee; // Passed to constructor to avoid dependency on main
 
+    void removeUnlocked(const CTransaction &tx, std::list<CTransaction>& removed, bool fRecursive = false);
+
 public:
     mutable CCriticalSection cs;
     std::map<uint256, CTxMemPoolEntry> mapTx;
@@ -92,8 +94,10 @@ public:
     void removeConflicts(const CTransaction &tx, std::list<CTransaction>& removed);
     void removeForBlock(const std::vector<CTransaction>& vtx, unsigned int nBlockHeight,
                         std::list<CTransaction>& conflicts);
+    void removeBatch(std::vector<CTransaction>& vtx, std::list<CTransaction>& removed, bool fRecursive = false);
     void clear();
     void queryHashes(std::vector<uint256>& vtxid);
+    void queryOld(std::vector<CTransaction>& vtx, int64_t matchTime);
     void pruneSpent(const uint256& hash, CCoins &coins);
     unsigned int GetTransactionsUpdated() const;
     void AddTransactionsUpdated(unsigned int n);


### PR DESCRIPTION
The mempool janitor ("poolman") is a thread that runs every -janitorinterval
seconds.  The janitor scans and removes memory pool transactions
older than current time minus -janitorexpire seconds.

By default, janitor runs every 24 hrs, expiring TXs older than 72 hrs [and have failed to make it into a block in that time].

IsMine() transactions are not touched.

This is _intentionally crude_: easily reviewed, reasoned and tested; fitting easily within the current framework, or being backported to an older bitcoind.  A key goal was _not_ rewriting mempool.

Comments:
- One alternative implementation was considered:

```
     while (mempool byte size > limit)
            expire oldest !ismine
```

This would work, but require a sort step, as mempool is not time-ordered.  There is also the question of how often to run such a while{} loop, likely leading to some sort of high-water/low-water system.

The sweep implementation presented seemed more straightforward.
