### PR TITLE
Add option `-rpcamount` for monetary amounts as strings/satoshis in RPC

### DIFF
--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -53,6 +53,12 @@ static bool AppInitRPC(int argc, char* argv[])
         fprintf(stdout, "%s", strUsage.c_str());
         return false;
     }
+    std::string strAmountMode = GetArg("-rpcamount", strRPCDefaultAmountMode);
+    if (!SetRPCAmountMode(strAmountMode))
+    {
+        fprintf(stderr, "Invalid -rpcamount setting: %s\n", strAmountMode.c_str());
+        return false;
+    }
     return true;
 }
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -304,6 +304,7 @@ std::string HelpMessage(HelpMessageMode hmm)
 
     strUsage += "\n" + _("RPC server options:") + "\n";
     strUsage += "  -server                " + _("Accept command line and JSON-RPC commands") + "\n";
+    strUsage += "  -rpcamount=<format>    " + strprintf(_("Use format for monetary amounts in RPC interface. Available options are number-decimal, number-satoshis, string-decimal, and string-satoshis (default: %s)"), strRPCDefaultAmountMode) + "\n";
     strUsage += "  -rpcbind=<addr>        " + _("Bind to given address to listen for JSON-RPC connections. Use [host]:port notation for IPv6. This option can be specified multiple times (default: bind to all interfaces)") + "\n";
     strUsage += "  -rpcuser=<user>        " + _("Username for JSON-RPC connections") + "\n";
     strUsage += "  -rpcpassword=<pw>      " + _("Password for JSON-RPC connections") + "\n";
@@ -585,6 +586,10 @@ bool AppInit2(boost::thread_group& threadGroup)
 
     strWalletFile = GetArg("-wallet", "wallet.dat");
 #endif
+    std::string strAmountMode = GetArg("-rpcamount", strRPCDefaultAmountMode);
+    if (!SetRPCAmountMode(strAmountMode))
+        return InitError(strprintf("Invalid -rpcamount setting: %s", strAmountMode.c_str()));
+
     // ********************************************************* Step 4: application initialization: dir lock, daemonize, pidfile, debug log
 
     std::string strDataDir = GetDataDir().string();

--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -113,6 +113,15 @@ void ConvertTo(Value& value, bool fAllowNull=false)
     }
 }
 
+// Parse a monetary value from a string to the appropriate JSON type
+void ConvertMonetaryValue(Value &value, bool fAllowNull=false)
+{
+    int64_t nAmount;
+    if(!ParseMoney(value.get_str(), nAmount))
+        throw runtime_error(string("Error parsing monetary value:") + value.get_str());
+    value = ValueFromAmount(nAmount);
+}
+
 // Convert strings to command-specific RPC representation
 Array RPCConvertValues(const std::string &strMethod, const std::vector<std::string> &strParams)
 {
@@ -131,24 +140,24 @@ Array RPCConvertValues(const std::string &strMethod, const std::vector<std::stri
     if (strMethod == "setgenerate"            && n > 1) ConvertTo<int64_t>(params[1]);
     if (strMethod == "getnetworkhashps"       && n > 0) ConvertTo<int64_t>(params[0]);
     if (strMethod == "getnetworkhashps"       && n > 1) ConvertTo<int64_t>(params[1]);
-    if (strMethod == "sendtoaddress"          && n > 1) ConvertTo<double>(params[1]);
-    if (strMethod == "settxfee"               && n > 0) ConvertTo<double>(params[0]);
+    if (strMethod == "sendtoaddress"          && n > 1) ConvertMonetaryValue(params[1]);
+    if (strMethod == "settxfee"               && n > 0) ConvertMonetaryValue(params[0]);
     if (strMethod == "getreceivedbyaddress"   && n > 1) ConvertTo<int64_t>(params[1]);
     if (strMethod == "getreceivedbyaccount"   && n > 1) ConvertTo<int64_t>(params[1]);
     if (strMethod == "listreceivedbyaddress"  && n > 0) ConvertTo<int64_t>(params[0]);
     if (strMethod == "listreceivedbyaddress"  && n > 1) ConvertTo<bool>(params[1]);
     if (strMethod == "listreceivedbyaccount"  && n > 0) ConvertTo<int64_t>(params[0]);
     if (strMethod == "listreceivedbyaccount"  && n > 1) ConvertTo<bool>(params[1]);
-    if (strMethod == "getbalance"             && n > 1) ConvertTo<int64_t>(params[1]);
-    if (strMethod == "getblockhash"           && n > 0) ConvertTo<int64_t>(params[0]);
-    if (strMethod == "move"                   && n > 2) ConvertTo<double>(params[2]);
-    if (strMethod == "move"                   && n > 3) ConvertTo<int64_t>(params[3]);
-    if (strMethod == "sendfrom"               && n > 2) ConvertTo<double>(params[2]);
-    if (strMethod == "sendfrom"               && n > 3) ConvertTo<int64_t>(params[3]);
-    if (strMethod == "listtransactions"       && n > 1) ConvertTo<int64_t>(params[1]);
-    if (strMethod == "listtransactions"       && n > 2) ConvertTo<int64_t>(params[2]);
-    if (strMethod == "listaccounts"           && n > 0) ConvertTo<int64_t>(params[0]);
-    if (strMethod == "walletpassphrase"       && n > 1) ConvertTo<int64_t>(params[1]);
+    if (strMethod == "getbalance"             && n > 1) ConvertTo<boost::int64_t>(params[1]);
+    if (strMethod == "getblockhash"           && n > 0) ConvertTo<boost::int64_t>(params[0]);
+    if (strMethod == "move"                   && n > 2) ConvertMonetaryValue(params[2]);
+    if (strMethod == "move"                   && n > 3) ConvertTo<boost::int64_t>(params[3]);
+    if (strMethod == "sendfrom"               && n > 2) ConvertMonetaryValue(params[2]);
+    if (strMethod == "sendfrom"               && n > 3) ConvertTo<boost::int64_t>(params[3]);
+    if (strMethod == "listtransactions"       && n > 1) ConvertTo<boost::int64_t>(params[1]);
+    if (strMethod == "listtransactions"       && n > 2) ConvertTo<boost::int64_t>(params[2]);
+    if (strMethod == "listaccounts"           && n > 0) ConvertTo<boost::int64_t>(params[0]);
+    if (strMethod == "walletpassphrase"       && n > 1) ConvertTo<boost::int64_t>(params[1]);
     if (strMethod == "getblocktemplate"       && n > 0) ConvertTo<Object>(params[0]);
     if (strMethod == "listsinceblock"         && n > 1) ConvertTo<int64_t>(params[1]);
     if (strMethod == "sendmany"               && n > 1) ConvertTo<Object>(params[1]);

--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -271,6 +271,7 @@ std::string HelpMessageCli(bool mainProgram)
         strUsage += _("RPC client options:") + "\n";
     }
 
+    strUsage += "  -rpcamount=<format>    " + strprintf(_("Use format for monetary amounts in RPC interface. Available options are number-decimal, number-satoshis, string-decimal, and string-satoshis (default: %s)"), strRPCDefaultAmountMode) + "\n";
     strUsage += "  -rpcconnect=<ip>       " + _("Send commands to node running on <ip> (default: 127.0.0.1)") + "\n";
     strUsage += "  -rpcport=<port>        " + _("Connect to JSON-RPC on <port> (default: 8332 or testnet: 18332)") + "\n";
     strUsage += "  -rpcwait               " + _("Wait for RPC server to start") + "\n";

--- a/src/rpcprotocol.cpp
+++ b/src/rpcprotocol.cpp
@@ -5,6 +5,7 @@
 
 #include "rpcprotocol.h"
 
+#include "core.h"
 #include "util.h"
 
 #include <stdint.h>
@@ -250,4 +251,20 @@ Object JSONRPCError(int code, const string& message)
     error.push_back(Pair("code", code));
     error.push_back(Pair("message", message));
     return error;
+}
+
+int64_t AmountFromValue(const Value& value)
+{
+    double dAmount = value.get_real();
+    if (dAmount <= 0.0 || dAmount > 21000000.0)
+        throw JSONRPCError(RPC_TYPE_ERROR, "Invalid amount");
+    int64_t nAmount = roundint64(dAmount * COIN);
+    if (!MoneyRange(nAmount))
+        throw JSONRPCError(RPC_TYPE_ERROR, "Invalid amount");
+    return nAmount;
+}
+
+Value ValueFromAmount(int64_t amount)
+{
+    return (double)amount / (double)COIN;
 }

--- a/src/rpcprotocol.cpp
+++ b/src/rpcprotocol.cpp
@@ -26,6 +26,10 @@ using namespace boost;
 using namespace boost::asio;
 using namespace json_spirit;
 
+/// How to represent monetary amounts in RPC protocol
+RPCAmountMode nRPCAmountMode = RPC_AMOUNT_NUMBER_BTC;
+std::string strRPCDefaultAmountMode = "number-btc";
+
 //
 // HTTP protocol
 //
@@ -255,16 +259,64 @@ Object JSONRPCError(int code, const string& message)
 
 int64_t AmountFromValue(const Value& value)
 {
-    double dAmount = value.get_real();
-    if (dAmount <= 0.0 || dAmount > 21000000.0)
-        throw JSONRPCError(RPC_TYPE_ERROR, "Invalid amount");
-    int64_t nAmount = roundint64(dAmount * COIN);
-    if (!MoneyRange(nAmount))
-        throw JSONRPCError(RPC_TYPE_ERROR, "Invalid amount");
+    int64_t nAmount = 0;
+    switch(nRPCAmountMode)
+    {
+    case RPC_AMOUNT_NUMBER_BTC:
+        {
+            double dAmount = value.get_real();
+            if (dAmount < 0.0 || dAmount > 21000000.0)
+                throw JSONRPCError(RPC_TYPE_ERROR, "Invalid amount");
+            nAmount = roundint64(dAmount * COIN);
+        }
+        break;
+    case RPC_AMOUNT_NUMBER_SATOSHIS:
+        nAmount = value.get_int64();
+        break;
+    case RPC_AMOUNT_STRING_BTC:
+        if (!ParseMoney(value.get_str(), nAmount))
+            throw JSONRPCError(RPC_TYPE_ERROR, "Invalid amount");
+        break;
+    case RPC_AMOUNT_STRING_SATOSHIS:
+        if (!atoi64_err(value.get_str(), nAmount))
+            throw JSONRPCError(RPC_TYPE_ERROR, "Invalid amount");
+        break;
+    default:
+        throw std::runtime_error("Invalid amount mode");
+    }
+    if (!MoneyRange(nAmount)) // Check for overflow
+        throw JSONRPCError(RPC_TYPE_ERROR, "Amount out of range");
     return nAmount;
 }
 
 Value ValueFromAmount(int64_t amount)
 {
-    return (double)amount / (double)COIN;
+    switch(nRPCAmountMode)
+    {
+    case RPC_AMOUNT_NUMBER_BTC:
+        return (double)amount / (double)COIN;
+    case RPC_AMOUNT_NUMBER_SATOSHIS:
+        return (boost::int64_t)amount;
+    case RPC_AMOUNT_STRING_BTC:
+        return FormatMoney(amount, false, false); /* no +, no right-trimming zeroes */
+    case RPC_AMOUNT_STRING_SATOSHIS:
+        return i64tostr(amount);
+    default:
+        throw std::runtime_error("Invalid amount mode");
+    }
+}
+
+bool SetRPCAmountMode(const std::string name)
+{
+    if (name == "number-btc")
+        nRPCAmountMode = RPC_AMOUNT_NUMBER_BTC;
+    else if (name == "number-satoshis")
+        nRPCAmountMode = RPC_AMOUNT_NUMBER_SATOSHIS;
+    else if (name == "string-btc")
+        nRPCAmountMode = RPC_AMOUNT_STRING_BTC;
+    else if (name == "string-satoshis")
+        nRPCAmountMode = RPC_AMOUNT_STRING_SATOSHIS;
+    else
+        return false;
+    return true;
 }

--- a/src/rpcprotocol.h
+++ b/src/rpcprotocol.h
@@ -153,4 +153,7 @@ json_spirit::Object JSONRPCReplyObj(const json_spirit::Value& result, const json
 std::string JSONRPCReply(const json_spirit::Value& result, const json_spirit::Value& error, const json_spirit::Value& id);
 json_spirit::Object JSONRPCError(int code, const std::string& message);
 
+extern int64_t AmountFromValue(const json_spirit::Value& value);
+extern json_spirit::Value ValueFromAmount(int64_t amount);
+
 #endif

--- a/src/rpcprotocol.h
+++ b/src/rpcprotocol.h
@@ -125,8 +125,7 @@ public:
         boost::system::error_code error = boost::asio::error::host_not_found;
         tcp::resolver::iterator end;
         while (error && endpoint_iterator != end)
-        {
-            stream.lowest_layer().close();
+        { stream.lowest_layer().close();
             stream.lowest_layer().connect(*endpoint_iterator++, error);
         }
         if (error)
@@ -140,6 +139,18 @@ private:
     boost::asio::ssl::stream<typename Protocol::socket>& stream;
 };
 
+/// How to format and parse monetary amounts in RPC protocol
+enum RPCAmountMode
+{
+    RPC_AMOUNT_NUMBER_BTC = 0,  /// Format as number in decimal BTC (default)
+    RPC_AMOUNT_NUMBER_SATOSHIS, /// Format as number in satoshis
+    RPC_AMOUNT_STRING_BTC,      /// Format as string in decimal BTC
+    RPC_AMOUNT_STRING_SATOSHIS  /// Format as string in satoshis
+};
+
+extern std::string strRPCDefaultAmountMode;
+
+bool SetRPCAmountMode(const std::string name);
 std::string HTTPPost(const std::string& strMsg, const std::map<std::string,std::string>& mapRequestHeaders);
 std::string HTTPReply(int nStatus, const std::string& strMsg, bool keepalive);
 bool ReadHTTPRequestLine(std::basic_istream<char>& stream, int &proto,

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -81,22 +81,6 @@ void RPCTypeCheck(const Object& o,
     }
 }
 
-int64_t AmountFromValue(const Value& value)
-{
-    double dAmount = value.get_real();
-    if (dAmount <= 0.0 || dAmount > 21000000.0)
-        throw JSONRPCError(RPC_TYPE_ERROR, "Invalid amount");
-    int64_t nAmount = roundint64(dAmount * COIN);
-    if (!MoneyRange(nAmount))
-        throw JSONRPCError(RPC_TYPE_ERROR, "Invalid amount");
-    return nAmount;
-}
-
-Value ValueFromAmount(int64_t amount)
-{
-    return (double)amount / (double)COIN;
-}
-
 std::string HexBits(unsigned int nBits)
 {
     union {

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -103,8 +103,6 @@ extern void InitRPCMining();
 extern void ShutdownRPCMining();
 
 extern int64_t nWalletUnlockTime;
-extern int64_t AmountFromValue(const json_spirit::Value& value);
-extern json_spirit::Value ValueFromAmount(int64_t amount);
 extern double GetDifficulty(const CBlockIndex* blockindex = NULL);
 extern std::string HexBits(unsigned int nBits);
 extern std::string HelpRequiringPassphrase();

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -108,8 +108,17 @@ BOOST_AUTO_TEST_CASE(rpc_rawsign)
     BOOST_CHECK(find_value(r.get_obj(), "complete").get_bool() == true);
 }
 
-BOOST_AUTO_TEST_CASE(rpc_format_monetary_values)
+static Value ValueFromString(const std::string &str)
 {
+    Value value;
+    BOOST_CHECK(read_string(str, value));
+    return value;
+}
+
+BOOST_AUTO_TEST_CASE(rpc_monetary_values_number_btc)
+{
+    BOOST_CHECK(SetRPCAmountMode("number-btc"));
+
     BOOST_CHECK(write_string(ValueFromAmount(0LL), false) == "0.00000000");
     BOOST_CHECK(write_string(ValueFromAmount(1LL), false) == "0.00000001");
     BOOST_CHECK(write_string(ValueFromAmount(17622195LL), false) == "0.17622195");
@@ -118,17 +127,8 @@ BOOST_AUTO_TEST_CASE(rpc_format_monetary_values)
     BOOST_CHECK(write_string(ValueFromAmount(100000000LL), false) == "1.00000000");
     BOOST_CHECK(write_string(ValueFromAmount(2099999999999990LL), false) == "20999999.99999990");
     BOOST_CHECK(write_string(ValueFromAmount(2099999999999999LL), false) == "20999999.99999999");
-}
 
-static Value ValueFromString(const std::string &str)
-{
-    Value value;
-    BOOST_CHECK(read_string(str, value));
-    return value;
-}
-
-BOOST_AUTO_TEST_CASE(rpc_parse_monetary_values)
-{
+    BOOST_CHECK(AmountFromValue(ValueFromString("0.00000000")) == 0LL);
     BOOST_CHECK(AmountFromValue(ValueFromString("0.00000001")) == 1LL);
     BOOST_CHECK(AmountFromValue(ValueFromString("0.17622195")) == 17622195LL);
     BOOST_CHECK(AmountFromValue(ValueFromString("0.5")) == 50000000LL);
@@ -137,6 +137,138 @@ BOOST_AUTO_TEST_CASE(rpc_parse_monetary_values)
     BOOST_CHECK(AmountFromValue(ValueFromString("1.00000000")) == 100000000LL);
     BOOST_CHECK(AmountFromValue(ValueFromString("20999999.9999999")) == 2099999999999990LL);
     BOOST_CHECK(AmountFromValue(ValueFromString("20999999.99999999")) == 2099999999999999LL);
+
+    // Negative values not allowed
+    BOOST_CHECK_THROW(AmountFromValue(ValueFromString("-1.0")), Object);
+
+    // Integers will not cause a parsing error (should they?)
+    // BOOST_CHECK_THROW(AmountFromValue(ValueFromString("100")), std::runtime_error);
+
+    // Strings with and without decimal point should cause a parsing error
+    BOOST_CHECK_THROW(AmountFromValue(ValueFromString("\"100\"")), std::runtime_error);
+    BOOST_CHECK_THROW(AmountFromValue(ValueFromString("\"100.100\"")), std::runtime_error);
+}
+
+BOOST_AUTO_TEST_CASE(rpc_monetary_values_string_btc)
+{
+    BOOST_CHECK(SetRPCAmountMode("string-btc"));
+
+    BOOST_CHECK(write_string(ValueFromAmount(0LL), false) == "\"0.00000000\"");
+    BOOST_CHECK(write_string(ValueFromAmount(1LL), false) == "\"0.00000001\"");
+    BOOST_CHECK(write_string(ValueFromAmount(17622195LL), false) == "\"0.17622195\"");
+    BOOST_CHECK(write_string(ValueFromAmount(50000000LL), false) == "\"0.50000000\"");
+    BOOST_CHECK(write_string(ValueFromAmount(89898989LL), false) == "\"0.89898989\"");
+    BOOST_CHECK(write_string(ValueFromAmount(100000000LL), false) == "\"1.00000000\"");
+    BOOST_CHECK(write_string(ValueFromAmount(2099999999999990LL), false) == "\"20999999.99999990\"");
+    BOOST_CHECK(write_string(ValueFromAmount(2099999999999999LL), false) == "\"20999999.99999999\"");
+
+    BOOST_CHECK(AmountFromValue(ValueFromString("\"0.00000000\"")) == 0LL);
+    BOOST_CHECK(AmountFromValue(ValueFromString("\"0.00000001\"")) == 1LL);
+    BOOST_CHECK(AmountFromValue(ValueFromString("\"0.17622195\"")) == 17622195LL);
+    BOOST_CHECK(AmountFromValue(ValueFromString("\"0.5\"")) == 50000000LL);
+    BOOST_CHECK(AmountFromValue(ValueFromString("\"0.50000000\"")) == 50000000LL);
+    BOOST_CHECK(AmountFromValue(ValueFromString("\"0.89898989\"")) == 89898989LL);
+    BOOST_CHECK(AmountFromValue(ValueFromString("\"1.00000000\"")) == 100000000LL);
+    BOOST_CHECK(AmountFromValue(ValueFromString("\"20999999.9999999\"")) == 2099999999999990LL);
+    BOOST_CHECK(AmountFromValue(ValueFromString("\"20999999.99999999\"")) == 2099999999999999LL);
+
+    // Negative values not allowed
+    BOOST_CHECK_THROW(AmountFromValue(ValueFromString("\"-1.0\"")), Object);
+
+    // Doubles will cause a parsing error
+    BOOST_CHECK_THROW(AmountFromValue(ValueFromString("100.100")), std::runtime_error);
+
+    // Integers will cause a parsing error
+    BOOST_CHECK_THROW(AmountFromValue(ValueFromString("100100")), std::runtime_error);
+
+    // Strings without decimal point do not cause a parsing error (should they?)
+    //BOOST_CHECK_THROW(AmountFromValue(ValueFromString("\"100\"")), std::runtime_error);
+
+    // Strings with a comma will cause a parsing error
+    BOOST_CHECK_THROW(AmountFromValue(ValueFromString("\"100,100\"")), Object);
+    // Noise at the end will cause a parsing error
+    BOOST_CHECK_THROW(AmountFromValue(ValueFromString("\"100100a\"")), Object);
+
+    // Overflow/underflow
+    BOOST_CHECK_THROW(AmountFromValue(ValueFromString("\"999999999999999999999999999999\"")), Object);
+    BOOST_CHECK_THROW(AmountFromValue(ValueFromString("\"-999999999999999999999999999999\"")), Object);
+}
+
+BOOST_AUTO_TEST_CASE(rpc_monetary_values_number_satoshis)
+{
+    BOOST_CHECK(SetRPCAmountMode("number-satoshis"));
+
+    BOOST_CHECK(write_string(ValueFromAmount(0LL), false) == "0");
+    BOOST_CHECK(write_string(ValueFromAmount(1LL), false) == "1");
+    BOOST_CHECK(write_string(ValueFromAmount(17622195LL), false) == "17622195");
+    BOOST_CHECK(write_string(ValueFromAmount(50000000LL), false) == "50000000");
+    BOOST_CHECK(write_string(ValueFromAmount(89898989LL), false) == "89898989");
+    BOOST_CHECK(write_string(ValueFromAmount(100000000LL), false) == "100000000");
+    BOOST_CHECK(write_string(ValueFromAmount(2099999999999990LL), false) == "2099999999999990");
+    BOOST_CHECK(write_string(ValueFromAmount(2099999999999999LL), false) == "2099999999999999");
+
+    BOOST_CHECK(AmountFromValue(ValueFromString("0")) == 0LL);
+    BOOST_CHECK(AmountFromValue(ValueFromString("1")) == 1LL);
+    BOOST_CHECK(AmountFromValue(ValueFromString("17622195")) == 17622195LL);
+    BOOST_CHECK(AmountFromValue(ValueFromString("00000050000000")) == 50000000LL);
+    BOOST_CHECK(AmountFromValue(ValueFromString("50000000")) == 50000000LL);
+    BOOST_CHECK(AmountFromValue(ValueFromString("89898989")) == 89898989LL);
+    BOOST_CHECK(AmountFromValue(ValueFromString("100000000")) == 100000000LL);
+    BOOST_CHECK(AmountFromValue(ValueFromString("2099999999999990")) == 2099999999999990LL);
+    BOOST_CHECK(AmountFromValue(ValueFromString("2099999999999999")) == 2099999999999999LL);
+
+    // Negative values not allowed
+    BOOST_CHECK_THROW(AmountFromValue(ValueFromString("-1")), Object);
+
+    // Floats will cause a parsing error
+    BOOST_CHECK_THROW(AmountFromValue(ValueFromString("100.100")), std::runtime_error);
+
+    // Strings with and without decimal point should cause a parsing error
+    BOOST_CHECK_THROW(AmountFromValue(ValueFromString("\"100\"")), std::runtime_error);
+    BOOST_CHECK_THROW(AmountFromValue(ValueFromString("\"100.100\"")), std::runtime_error);
+}
+
+BOOST_AUTO_TEST_CASE(rpc_monetary_values_string_satoshis)
+{
+    BOOST_CHECK(SetRPCAmountMode("string-satoshis"));
+
+    BOOST_CHECK(write_string(ValueFromAmount(0LL), false) == "\"0\"");
+    BOOST_CHECK(write_string(ValueFromAmount(1LL), false) == "\"1\"");
+    BOOST_CHECK(write_string(ValueFromAmount(17622195LL), false) == "\"17622195\"");
+    BOOST_CHECK(write_string(ValueFromAmount(50000000LL), false) == "\"50000000\"");
+    BOOST_CHECK(write_string(ValueFromAmount(89898989LL), false) == "\"89898989\"");
+    BOOST_CHECK(write_string(ValueFromAmount(100000000LL), false) == "\"100000000\"");
+    BOOST_CHECK(write_string(ValueFromAmount(2099999999999990LL), false) == "\"2099999999999990\"");
+    BOOST_CHECK(write_string(ValueFromAmount(2099999999999999LL), false) == "\"2099999999999999\"");
+
+    BOOST_CHECK(AmountFromValue(ValueFromString("\"0\"")) == 0LL);
+    BOOST_CHECK(AmountFromValue(ValueFromString("\"1\"")) == 1LL);
+    BOOST_CHECK(AmountFromValue(ValueFromString("\"17622195\"")) == 17622195LL);
+    BOOST_CHECK(AmountFromValue(ValueFromString("\"50000000\"")) == 50000000LL);
+    BOOST_CHECK(AmountFromValue(ValueFromString("\"000000050000000\"")) == 50000000LL);
+    BOOST_CHECK(AmountFromValue(ValueFromString("\"89898989\"")) == 89898989LL);
+    BOOST_CHECK(AmountFromValue(ValueFromString("\"100000000\"")) == 100000000LL);
+    BOOST_CHECK(AmountFromValue(ValueFromString("\"2099999999999990\"")) == 2099999999999990LL);
+    BOOST_CHECK(AmountFromValue(ValueFromString("\"2099999999999999\"")) == 2099999999999999LL);
+
+    // Negative values not allowed
+    BOOST_CHECK_THROW(AmountFromValue(ValueFromString("\"-1\"")), Object);
+
+    // Doubles will cause a parsing error
+    BOOST_CHECK_THROW(AmountFromValue(ValueFromString("100.100")), std::runtime_error);
+
+    // Integers will cause a parsing error
+    BOOST_CHECK_THROW(AmountFromValue(ValueFromString("100100")), std::runtime_error);
+
+    // Strings with decimal point or comma cause a parsing error
+    BOOST_CHECK_THROW(AmountFromValue(ValueFromString("\"100.100\"")), Object);
+    BOOST_CHECK_THROW(AmountFromValue(ValueFromString("\"100,100\"")), Object);
+    // Noise at the end will cause a parsing error
+    BOOST_CHECK_THROW(AmountFromValue(ValueFromString("\"100100a\"")), Object);
+
+    // Overflow/underflow
+    BOOST_CHECK_THROW(AmountFromValue(ValueFromString("\"999999999999999999999999999999\"")), Object);
+    BOOST_CHECK_THROW(AmountFromValue(ValueFromString("\"-999999999999999999999999999999\"")), Object);
 }
 
 BOOST_AUTO_TEST_CASE(rpc_boostasiotocnetaddr)

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -305,7 +305,7 @@ int LogPrintStr(const std::string &str)
     return ret;
 }
 
-string FormatMoney(int64_t n, bool fPlus)
+string FormatMoney(int64_t n, bool fPlus, bool fTrim)
 {
     // Note: not using straight sprintf here because we do NOT want
     // localized number formatting.
@@ -314,12 +314,15 @@ string FormatMoney(int64_t n, bool fPlus)
     int64_t remainder = n_abs%COIN;
     string str = strprintf("%d.%08d", quotient, remainder);
 
-    // Right-trim excess zeros before the decimal point:
-    int nTrim = 0;
-    for (int i = str.size()-1; (str[i] == '0' && isdigit(str[i-2])); --i)
-        ++nTrim;
-    if (nTrim)
-        str.erase(str.size()-nTrim, nTrim);
+    if(fTrim)
+    {
+        // Right-trim excess zeros after the decimal point:
+        int nTrim = 0;
+        for (int i = str.size()-1; (str[i] == '0' && isdigit(str[i-2])); --i)
+            ++nTrim;
+        if (nTrim)
+            str.erase(str.size()-nTrim, nTrim);
+    }
 
     if (n < 0)
         str.insert((unsigned int)0, 1, '-');

--- a/src/util.h
+++ b/src/util.h
@@ -235,6 +235,19 @@ inline int64_t atoi64(const std::string& str)
 #endif
 }
 
+/// Variant of atoi64 with parse error flag return
+/// Returns minimum or maximum integer respectively on overflow
+inline bool atoi64_err(const std::string& str, int64_t &out)
+{
+    char *endptr = NULL;
+#if defined(_MSC_VER)
+    out = _strtoi64(str.c_str(), &endptr, 10);
+#else
+    out = strtoll(str.c_str(), &endptr, 10);
+#endif
+    return *endptr == '\0';
+}
+
 inline int atoi(const std::string& str)
 {
     return atoi(str.c_str());

--- a/src/util.h
+++ b/src/util.h
@@ -152,7 +152,7 @@ static inline bool error(const char* format)
 }
 
 void PrintExceptionContinue(std::exception* pex, const char* pszThread);
-std::string FormatMoney(int64_t n, bool fPlus=false);
+std::string FormatMoney(int64_t n, bool fPlus=false, bool fTrim=true);
 bool ParseMoney(const std::string& str, int64_t& nRet);
 bool ParseMoney(const char* pszIn, int64_t& nRet);
 std::string SanitizeString(const std::string& str);


### PR DESCRIPTION
See this report: https://bitcoin.stackexchange.com/questions/22716/bitcoind-sendfrom-round-amount-error

I've been unable to reproduce it in either master or 0.8.6. However, in theory this could happen on architectures that have imprecise floating point types. Even though bitcoind itself doesn't rely on floating point types anywhere, Spirit JSON does use doubles internally for parsing values like 123.456 (and so do we in ValueFromAmount / AmountFromValue).

My first attempt was to try to fix this and make the parser use a fixed-point or string representation for JSON numbers (ie https://github.com/bitcoin/bitcoin/blob/master/src/json/json_spirit_reader_template.h#L499 ), but turned out to be a deep rabbit hole and doesn't solve the issue at the client side.

So this is my solution: add an option `-rpcstringamounts` to represent monetary amounts as strings in RPC. With this option any monetary amount will be emitted as a string with fixed 8 decimals, very easy to parse. Also this changes the parsing to accept the same format (by using the existing ParseMoney function).

Example getinfo:

```
{
    ...
    "balance" : "0.29099995",
    ...
}
```

Commits should be self-documenting.
