### PR TITLE
Sometimes nodes send many duplicate blocks. This patch disconnects the p...

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -208,6 +208,7 @@ public:
     std::string addrName;
     CService addrLocal;
     int nVersion;
+    int nDupBlocks;
     // strSubVer is whatever byte array we read from the wire. However, this field is intended
     // to be printed out, displayed to humans in various forms and so on. So we sanitize it and
     // store the sanitized version in cleanSubVer. The original should be used when dealing with
@@ -278,6 +279,7 @@ public:
         addr = addrIn;
         addrName = addrNameIn == "" ? addr.ToStringIPPort() : addrNameIn;
         nVersion = 0;
+        nDupBlocks = 0;
         strSubVer = "";
         fOneShot = false;
         fClient = false; // set by version message


### PR DESCRIPTION
...eer that's running behind. This shouldn't happen, but it can and does sometimes, so this code caters for that.

This code also becomes more important as the block download algorithm is changed in future,
such as concurrent block downloads from multiple peers, and retries are sent to other peers
when peers seem unresponsive, only to become responsive again later, by which time
they are sending duplicate blocks.

This was pull requested previously, but NACKed with the argument that we shouldn't punish peers for doing what was asked of them. However, although we may fix that in future, I still maintain this is for the overall health of the network, and may become redundant in future as the block download algorithm improves. Even if the algorithm is later improved, it would still be beneficial to have this code, although perhaps instead of simply disconnecting the nodes, it would be better to mark them as misbehaving (e.g. if they send blocks which were never requested).
