### PR TITLE
Make tinyformat errors raise an exception instead of assert()ing

### DIFF
--- a/src/tinyformat.h
+++ b/src/tinyformat.h
@@ -109,7 +109,7 @@ namespace tinyformat {}
 namespace tfm = tinyformat;
 
 // Error handling; calls assert() by default.
-// #define TINYFORMAT_ERROR(reasonString) your_error_handler(reasonString)
+#define TINYFORMAT_ERROR(reasonString) throw std::runtime_error(reasonString)
 
 // Define for C++11 variadic templates which make the code shorter & more
 // general.  If you don't define this, C++11 support is autodetected below.


### PR DESCRIPTION
By default tinyformat errors such as 'wrong number of conversion specifiers in format string' cause an assertion failure.

Raise an exception instead so that error handling can recover or can show an appropriate error.
