### PR TITLE
Build doc fix for debian/ubuntu+qt5

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -108,7 +108,7 @@ To build with Qt 4 you need the following:
 
 For Qt 5 you need the following:
 
-    apt-get install libqt5gui5 libqt5core5 libqt5dbus5 qttools5-dev-tools libprotobuf-dev
+    apt-get install libqt5gui5 libqt5core5 libqt5dbus5 qttools5-dev qttools5-dev-tools libprotobuf-dev
 
 libqrencode (optional) can be installed with:
 


### PR DESCRIPTION
Trying to build master on latest Ubuntu against qt5 while following build-unix.md, configure could not find qt5. This resolved itself when I installed qttools5-dev, which contains qt5 headers and a few build-related tools. So this seems like an omission, and here's the world's smallest pull request to fix it.
