### PR TITLE
Fix typo in doc/build-unix.md regarding building without UPnP

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -28,7 +28,7 @@ Dependencies
 http://miniupnp.tuxfamily.org/files/).  UPnP support is compiled in and
 turned off by default.  See the configure options for upnp behavior desired:
 
-	--with-miniupnpc         No UPnP support miniupnp not required
+	--without-miniupnpc      No UPnP support miniupnp not required
 	--disable-upnp-default   (the default) UPnP support turned off by default at runtime
 	--enable-upnp-default    UPnP support turned on by default at runtime
 


### PR DESCRIPTION
UPnP is disabled by passing --without-miniupnpc to the configure script, not --with-miniupnpc.
