### PR TITLE
Correct logic so that not both lines are displayed

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3528,7 +3528,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
             return error("message getdata size() = %"PRIszu"", vInv.size());
         }
 
-        if (fDebug || (vInv.size() != 1))
+        if (fDebug && (vInv.size() != 1))
             LogPrint("net", "received getdata (%"PRIszu" invsz)\n", vInv.size());
 
         if ((fDebug && vInv.size() > 0) || (vInv.size() == 1))


### PR DESCRIPTION
e.g.:-
2014-02-25 06:56:39 received getdata (1 invsz)
2014-02-25 06:56:39 received getdata for: tx 8e2e08d1d851eb1ac800e814796dd7b86fd6d3a8fad41d5bdcb873ac6f4aba8d

The first line isn't necessary since the 2nd line includes the same information, and more.
