### PR TITLE
update bash-completion for v0.9

### DIFF
--- a/contrib/bitcoind.bash-completion
+++ b/contrib/bitcoind.bash-completion
@@ -1,5 +1,5 @@
-# bash programmable completion for bitcoind(1)
-# Copyright (c) 2012 Christian von Roques <roques@mti.ag>
+# bash programmable completion for bitcoind(1) and bitcoin-cli(1)
+# Copyright (c) 2012,2014 Christian von Roques <roques@mti.ag>
 # Distributed under the MIT/X11 software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -37,9 +37,35 @@ _bitcoind() {
     COMPREPLY=()
     _get_comp_words_by_ref -n = cur prev words cword
 
+    if ((cword > 4)); then
+        case ${words[cword-4]} in
+            signrawtransaction)
+                COMPREPLY=( $( compgen -W "ALL NONE SINGLE ALL|ANYONECANPAY NONE|ANYONECANPAY SINGLE|ANYONECANPAY" -- "$cur" ) )
+                return 0
+                ;;
+        esac
+    fi
+
+    if ((cword > 3)); then
+        case ${words[cword-3]} in
+            addmultisigaddress)
+                _bitcoin_accounts
+                return 0
+                ;;
+            gettxout|importprivkey)
+                COMPREPLY=( $( compgen -W "true false" -- "$cur" ) )
+                return 0
+                ;;
+        esac
+    fi
+
     if ((cword > 2)); then
         case ${words[cword-2]} in
-            listreceivedbyaccount|listreceivedbyaddress)
+            addnode)
+                COMPREPLY=( $( compgen -W "add remove onetry" -- "$cur" ) )
+                return 0
+                ;;
+            getblock|getrawtransaction|listreceivedbyaccount|listreceivedbyaddress|sendrawtransaction)
                 COMPREPLY=( $( compgen -W "true false" -- "$cur" ) )
                 return 0
                 ;;
@@ -51,11 +77,11 @@ _bitcoind() {
     fi
 
     case "$prev" in
-        backupwallet)
+        backupwallet|dumpwallet|importwallet)
             _filedir
             return 0
             ;;
-        setgenerate)
+        getmempool|lockunspent|setgenerate)
             COMPREPLY=( $( compgen -W "true false" -- "$cur" ) )
             return 0
             ;;
@@ -66,7 +92,7 @@ _bitcoind() {
     esac
 
     case "$cur" in
-        -conf=*|-pid=*|-rpcsslcertificatechainfile=*|-rpcsslprivatekeyfile=*)
+        -conf=*|-pid=*|-loadblock=*|-wallet=*|-rpcsslcertificatechainfile=*|-rpcsslprivatekeyfile=*)
             cur="${cur#*=}"
             _filedir
             return 0
@@ -103,7 +129,7 @@ _bitcoind() {
     esac
 }
 
-complete -F _bitcoind bitcoind
+complete -F _bitcoind bitcoind bitcoin-cli
 }
 
 # Local variables:


### PR DESCRIPTION
Recognize completable arguments of new and expanded commands.
Now that `bitcoin-cli` exists, add completion for it as well.
