### PR TITLE
Avoid signed arithmetic undefined behaviour

### DIFF
--- a/src/core.cpp
+++ b/src/core.cpp
@@ -111,9 +111,12 @@ int64_t CTransaction::GetValueOut() const
     int64_t nValueOut = 0;
     BOOST_FOREACH(const CTxOut& txout, vout)
     {
-        nValueOut += txout.nValue;
-        if (!MoneyRange(txout.nValue) || !MoneyRange(nValueOut))
+        if (!MoneyRange(txout.nValue))
             throw std::runtime_error("CTransaction::GetValueOut() : value out of range");
+
+        nValueOut += txout.nValue;
+        if (!MoneyRange(nValueOut))
+            throw std::runtime_error("CTransaction::GetValueOut() : sum out of range");
     }
     return nValueOut;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1450,11 +1450,14 @@ bool CheckInputs(const CTransaction& tx, CValidationState &state, CCoinsViewCach
             }
 
             // Check for negative or overflow input values
-            nValueIn += coins.vout[prevout.n].nValue;
-            if (!MoneyRange(coins.vout[prevout.n].nValue) || !MoneyRange(nValueIn))
-                return state.DoS(100, error("CheckInputs() : txin values out of range"),
+            if (!MoneyRange(coins.vout[prevout.n].nValue))
+                return state.DoS(100, error("CheckInputs() : txin value out of range"),
                                  REJECT_INVALID, "bad-txns-inputvalues-outofrange");
 
+            nValueIn += coins.vout[prevout.n].nValue;
+            if (!MoneyRange(nValueIn))
+                return state.DoS(100, error("CheckInputs() : txin sum out of range"),
+                                 REJECT_INVALID, "bad-txns-inputvalues-outofrange");
         }
 
         if (nValueIn < tx.GetValueOut())


### PR DESCRIPTION
These two places look like they obviously rely on undefined behaviour to me. See e.g. http://blog.regehr.org/archives/213 for a primer. In short, the compiler is free to do pretty much whatever it wants if the sum of two signed integers overflows. This includes deleting your wallet file, stopping the process, or simply optimising out the check entirely.

Please review carefully.
