### PR TITLE
Use the new name Bitcoin Core Daemon instead of Bitcoin server

### DIFF
--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -37,7 +37,7 @@ static bool AppInitRPC(int argc, char* argv[])
     if (argc<2 || mapArgs.count("-?") || mapArgs.count("--help"))
     {
         // First part of help message is specific to RPC client
-        std::string strUsage = _("Bitcoin RPC client version") + " " + FormatFullVersion() + "\n\n" +
+        std::string strUsage = _("Bitcoin Core version") + " " + FormatFullVersion() + "\n\n" +
             _("Usage:") + "\n" +
               "  bitcoin-cli [options] <command> [params]  " + _("Send command to Bitcoin server") + "\n" +
               "  bitcoin-cli [options] help                " + _("List commands") + "\n" +

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -39,7 +39,7 @@ static bool AppInitRPC(int argc, char* argv[])
         // First part of help message is specific to RPC client
         std::string strUsage = _("Bitcoin Core RPC client version") + " " + FormatFullVersion() + "\n\n" +
             _("Usage:") + "\n" +
-              "  bitcoin-cli [options] <command> [params]  " + _("Send command to Bitcoin server") + "\n" +
+              "  bitcoin-cli [options] <command> [params]  " + _("Send command to Bitcoin Core") + "\n" +
               "  bitcoin-cli [options] help                " + _("List commands") + "\n" +
               "  bitcoin-cli [options] help <command>      " + _("Get help for a command") + "\n";
 

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -37,7 +37,7 @@ static bool AppInitRPC(int argc, char* argv[])
     if (argc<2 || mapArgs.count("-?") || mapArgs.count("--help"))
     {
         // First part of help message is specific to RPC client
-        std::string strUsage = _("Bitcoin Core version") + " " + FormatFullVersion() + "\n\n" +
+        std::string strUsage = _("Bitcoin Core RPC client version") + " " + FormatFullVersion() + "\n\n" +
             _("Usage:") + "\n" +
               "  bitcoin-cli [options] <command> [params]  " + _("Send command to Bitcoin server") + "\n" +
               "  bitcoin-cli [options] help                " + _("List commands") + "\n" +

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -82,9 +82,9 @@ bool AppInit(int argc, char* argv[])
             // First part of help message is specific to bitcoind / RPC client
             std::string strUsage = _("Bitcoin Core Daemon") + " " + _("version") + " " + FormatFullVersion() + "\n\n" +
                 _("Usage:") + "\n" +
-                  "  bitcoind [options]                     " + _("Start Bitcoin server") + "\n" +
+                  "  bitcoind [options]                     " + _("Start Bitcoin Core Daemon") + "\n" +
                 _("Usage (deprecated, use bitcoin-cli):") + "\n" +
-                  "  bitcoind [options] <command> [params]  " + _("Send command to Bitcoin server") + "\n" +
+                  "  bitcoind [options] <command> [params]  " + _("Send command to Bitcoin Core Daemon") + "\n" +
                   "  bitcoind [options] help                " + _("List commands") + "\n" +
                   "  bitcoind [options] help <command>      " + _("Get help for a command") + "\n";
 

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -84,7 +84,7 @@ bool AppInit(int argc, char* argv[])
                 _("Usage:") + "\n" +
                   "  bitcoind [options]                     " + _("Start Bitcoin Core Daemon") + "\n" +
                 _("Usage (deprecated, use bitcoin-cli):") + "\n" +
-                  "  bitcoind [options] <command> [params]  " + _("Send command to Bitcoin Core Daemon") + "\n" +
+                  "  bitcoind [options] <command> [params]  " + _("Send command to Bitcoin Core") + "\n" +
                   "  bitcoind [options] help                " + _("List commands") + "\n" +
                   "  bitcoind [options] help <command>      " + _("Get help for a command") + "\n";
 


### PR DESCRIPTION
The name of the daemon was changed from Bitcoin server to Bitcoin Core Daemon. This change fixes the --help usage text accordingly.
