### PR TITLE
Fix null pointer in IsTrusted()

### DIFF
--- a/src/wallet.h
+++ b/src/wallet.h
@@ -675,8 +675,10 @@ public:
         {
             // Transactions not sent by us: not trusted
             const CWalletTx* parent = pwallet->GetWalletTx(txin.prevout.hash);
+            if (parent == NULL)
+                return false;
             const CTxOut& parentOut = parent->vout[txin.prevout.n];
-            if (parent == NULL || !pwallet->IsMine(parentOut))
+            if (!pwallet->IsMine(parentOut))
                 return false;
         }
         return true;


### PR DESCRIPTION
Use case:
- create a rawtransaction with 2 inputs from 2 different private keys
- start bitcoin with a new wallet
- import 1 of the private keys
- sendrawtransaction
- => segfault

I guess the reason is that IsFromMe() is true for the transaction, but the parent transaction
of the other input is not part of the wallet.
I have currently a state on my pc, where I can trigger a segfault everytime with a new wallet,
just by importing a private key and then send a rawtransaction. Did not segfault with this fix applied.
