### PR TITLE
Log which wallet is used during init

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -593,6 +593,7 @@ bool AppInit2(boost::thread_group& threadGroup)
     // ********************************************************* Step 5: verify wallet database integrity
 #ifdef ENABLE_WALLET
     if (!fDisableWallet) {
+        LogPrintf("Using wallet %s\n", strWalletFile);
         uiInterface.InitMessage(_("Verifying wallet..."));
 
         if (!bitdb.Open(GetDataDir()))


### PR DESCRIPTION
Now that the wallet can be selected using -wallet it is important to log which wallet is being used for later troubleshooting.
