### PR TITLE
Remove unused includes of boost lexical_cast

### DIFF
--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -20,7 +20,6 @@
 #include <boost/foreach.hpp>
 #include <boost/iostreams/concepts.hpp>
 #include <boost/iostreams/stream.hpp>
-#include <boost/lexical_cast.hpp>
 #include <boost/shared_ptr.hpp>
 #include "json/json_spirit_writer_template.h"
 

--- a/src/rpcdump.cpp
+++ b/src/rpcdump.cpp
@@ -14,7 +14,6 @@
 
 #include <boost/algorithm/string.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
-#include <boost/lexical_cast.hpp>
 #include "json/json_spirit_value.h"
 
 using namespace json_spirit;

--- a/src/rpcprotocol.cpp
+++ b/src/rpcprotocol.cpp
@@ -17,7 +17,6 @@
 #include <boost/foreach.hpp>
 #include <boost/iostreams/concepts.hpp>
 #include <boost/iostreams/stream.hpp>
-#include <boost/lexical_cast.hpp>
 #include <boost/shared_ptr.hpp>
 #include "json/json_spirit_writer_template.h"
 

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -22,7 +22,6 @@
 #include <boost/foreach.hpp>
 #include <boost/iostreams/concepts.hpp>
 #include <boost/iostreams/stream.hpp>
-#include <boost/lexical_cast.hpp>
 #include <boost/shared_ptr.hpp>
 #include "json/json_spirit_writer_template.h"
 


### PR DESCRIPTION
We don't use lexical_cast anywhere, no need to include it.
