### PR TITLE
Create MiningRequiresPeers chain param

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -245,6 +245,7 @@ public:
     }
 
     virtual bool RequireRPCPassword() const { return false; }
+    virtual bool MiningRequiresPeers() const { return false; }
     virtual Network NetworkID() const { return CChainParams::REGTEST; }
 };
 static CRegTestParams regTestParams;

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -60,6 +60,7 @@ public:
     int SubsidyHalvingInterval() const { return nSubsidyHalvingInterval; }
     virtual const CBlock& GenesisBlock() const = 0;
     virtual bool RequireRPCPassword() const { return true; }
+    virtual bool MiningRequiresPeers() const { return true; }
     const string& DataDir() const { return strDataDir; }
     virtual Network NetworkID() const = 0;
     const vector<CDNSSeedData>& DNSSeeds() const { return vSeeds; }

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -509,7 +509,7 @@ void static BitcoinMiner(CWallet *pwallet)
     unsigned int nExtraNonce = 0;
 
     try { while (true) {
-        if (Params().NetworkID() != CChainParams::REGTEST) {
+        if (Params().MiningRequiresPeers()) {
             // Busy-wait for the network to come online so we don't waste time mining
             // on an obsolete chain. In regtest mode we expect to fly solo.
             while (vNodes.empty())
@@ -617,7 +617,7 @@ void static BitcoinMiner(CWallet *pwallet)
 
             // Check for stop or if block needs to be rebuilt
             boost::this_thread::interruption_point();
-            if (vNodes.empty() && Params().NetworkID() != CChainParams::REGTEST)
+            if (vNodes.empty() && Params().MiningRequiresPeers())
                 break;
             if (nBlockNonce >= 0xffff0000)
                 break;


### PR DESCRIPTION
This removes two direct references to CChainParams::REGTEST and helps move towards the goal of chainparams working with the "quacks like a duck" philosophy.
