### PR TITLE
Fix for GetBlockValue() after block 13,440,000

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1176,9 +1176,14 @@ void static PruneOrphanBlocks()
 int64_t GetBlockValue(int nHeight, int64_t nFees)
 {
     int64_t nSubsidy = 50 * COIN;
+    int halvings = nHeight / Params().SubsidyHalvingInterval();
+
+    // Force block reward to zero when right shift is undefined.
+    if (halvings >= 64)
+        return nFees;
 
     // Subsidy is cut in half every 210,000 blocks which will occur approximately every 4 years.
-    nSubsidy >>= (nHeight / Params().SubsidyHalvingInterval());
+    nSubsidy >>= halvings;
 
     return nSubsidy + nFees;
 }

--- a/src/test/main_tests.cpp
+++ b/src/test/main_tests.cpp
@@ -8,7 +8,7 @@ BOOST_AUTO_TEST_SUITE(main_tests)
 BOOST_AUTO_TEST_CASE(subsidy_limit_test)
 {
     uint64_t nSum = 0;
-    for (int nHeight = 0; nHeight < 7000000; nHeight += 1000) {
+    for (int nHeight = 0; nHeight < 14000000; nHeight += 1000) {
         uint64_t nSubsidy = GetBlockValue(nHeight, 0);
         BOOST_CHECK(nSubsidy <= 50 * COIN);
         nSum += nSubsidy * 1000;


### PR DESCRIPTION
Forces the block reward to zero when right shift in GetBlockValue() is
undefined, after 64 reward halvings (block height 13,440,000).
