### PR TITLE
qt: Make it possible again to specify -testnet in config file

### DIFF
--- a/src/qt/guiconstants.h
+++ b/src/qt/guiconstants.h
@@ -41,4 +41,9 @@ static const int MAX_PAYMENT_REQUEST_SIZE = 50000; // bytes
 /* Number of frames in spinner animation */
 #define SPINNER_FRAMES 35
 
+#define QAPP_ORG_NAME "Bitcoin"
+#define QAPP_ORG_DOMAIN "bitcoin.org"
+#define QAPP_APP_NAME_DEFAULT "Bitcoin-Qt"
+#define QAPP_APP_NAME_TESTNET "Bitcoin-Qt-testnet"
+
 #endif // GUICONSTANTS_H

--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -146,7 +146,7 @@ QString Intro::getDefaultDataDirectory()
     return QString::fromStdString(GetDefaultDataDir().string());
 }
 
-void Intro::pickDataDirectory(bool fIsTestnet)
+void Intro::pickDataDirectory()
 {
     namespace fs = boost::filesystem;
     QSettings settings;
@@ -164,10 +164,7 @@ void Intro::pickDataDirectory(bool fIsTestnet)
         /* If current default data directory does not exist, let the user choose one */
         Intro intro;
         intro.setDataDirectory(dataDir);
-        if (!fIsTestnet)
-            intro.setWindowIcon(QIcon(":icons/bitcoin"));
-        else
-            intro.setWindowIcon(QIcon(":icons/bitcoin_testnet"));
+        intro.setWindowIcon(QIcon(":icons/bitcoin"));
 
         while(true)
         {

--- a/src/qt/intro.h
+++ b/src/qt/intro.h
@@ -36,7 +36,7 @@ public:
      * @note do NOT call global GetDataDir() before calling this function, this
      * will cause the wrong path to be cached.
      */
-    static void pickDataDirectory(bool fIsTestnet);
+    static void pickDataDirectory();
 
     /**
      * Determine default data directory for operating system.


### PR DESCRIPTION
Changes for the datadir chooser have made it impossible to specify the network (testnet/regtest) in the configuration file for the GUI.

Reorganize the initialization sequence to make this possible again.
- Moves the "datadir" QSetting so that is no longer dependent on the network-specific application name (doing otherwise would create a chicken-and-egg problem).
- Re-initialize translations after choosing network. There may be a different language configured in network-specific settings (slim chance, but handle it for sanity).

Fixes point 1 of #3840.
