### PR TITLE
Fix missing wallet lock in CWallet::SyncTransaction(..)

### DIFF
--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -589,7 +589,7 @@ bool CWallet::AddToWallet(const CWalletTx& wtxIn, bool fFromLoadWallet)
 bool CWallet::AddToWalletIfInvolvingMe(const uint256 &hash, const CTransaction& tx, const CBlock* pblock, bool fUpdate)
 {
     {
-        LOCK(cs_wallet);
+        AssertLockHeld(cs_wallet);
         bool fExisted = mapWallet.count(hash);
         if (fExisted && !fUpdate) return false;
         if (fExisted || IsMine(tx) || IsFromMe(tx))
@@ -606,9 +606,8 @@ bool CWallet::AddToWalletIfInvolvingMe(const uint256 &hash, const CTransaction& 
 
 void CWallet::SyncTransaction(const uint256 &hash, const CTransaction& tx, const CBlock* pblock)
 {
-    AddToWalletIfInvolvingMe(hash, tx, pblock, true);
-
-    if (mapWallet.count(hash) == 0)
+    LOCK(cs_wallet);
+    if (!AddToWalletIfInvolvingMe(hash, tx, pblock, true))
         return; // Not one of ours
 
     // If a transaction changes 'conflicted' state, that changes the balance


### PR DESCRIPTION
Looks like we are currently accessing mapWallet without a lock held in CWallet::SyncTransaction(..).
I tested this with AssertLockHeld(cs_wallet) and indeed, no lock.
- moved the lock from AddToWalletIfInvolvingMe(..) to SyncTransaction(..)
- using return value of AddToWalletIfInvolvingMe(..) to determine whether the tx is in the wallet
