### PR TITLE
[Qt] Fill in label from address book also for URIs

### DIFF
--- a/src/qt/sendcoinsentry.cpp
+++ b/src/qt/sendcoinsentry.cpp
@@ -195,8 +195,10 @@ void SendCoinsEntry::setValue(const SendCoinsRecipient &value)
         ui->messageTextLabel->setVisible(!recipient.message.isEmpty());
         ui->messageLabel->setVisible(!recipient.message.isEmpty());
 
-        ui->payTo->setText(recipient.address);
-        ui->addAsLabel->setText(recipient.label);
+        ui->addAsLabel->clear();
+        ui->payTo->setText(recipient.address); // this may set a label from addressbook
+        if (!recipient.label.isEmpty()) // if a label had been set from the addressbook, dont overwrite with an empty label
+            ui->addAsLabel->setText(recipient.label);
         ui->payAmount->setValue(recipient.amount);
     }
 }


### PR DESCRIPTION
Fixes #3814.

Picked up on @Massimo80 last comment about the "easy fix".

Label had been set from addressbook all the time. The problem was, we have overwritten it again with an empty label. So if the URI contains a label, this is used. Else use the one from addess book (if any).
