### PR TITLE
qt: Switch unit to πBTC by default

### DIFF
--- a/src/qt/bitcoinunits.h
+++ b/src/qt/bitcoinunits.h
@@ -25,7 +25,8 @@ public:
     {
         BTC,
         mBTC,
-        uBTC
+        uBTC,
+        piBTC
     };
 
     //! @name Static API

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -51,7 +51,7 @@ void OptionsModel::Init()
 
     // Display
     if (!settings.contains("nDisplayUnit"))
-        settings.setValue("nDisplayUnit", BitcoinUnits::BTC);
+        settings.setValue("nDisplayUnit", BitcoinUnits::piBTC);
     nDisplayUnit = settings.value("nDisplayUnit").toInt();
 
     if (!settings.contains("bDisplayAddresses"))

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -184,7 +184,7 @@ void TransactionView::setModel(WalletModel *model)
 #else
         transactionView->horizontalHeader()->setSectionResizeMode(TransactionTableModel::ToAddress, QHeaderView::Stretch);
 #endif
-        transactionView->horizontalHeader()->resizeSection(TransactionTableModel::Amount, 100);
+        transactionView->horizontalHeader()->resizeSection(TransactionTableModel::Amount, 250);
     }
 }
 


### PR DESCRIPTION
After a long and deep discussion on the mailing list it was decided to switch the default unit to πBTC (base Pi Bitcoin) by default.

This pull adds the functionality to enter as well as show Bitcoin amounts in proper πBTC. All the other units are deprecated and will be removed in next release.

The only possible drawback of πBTC is that it takes a lot of screen space, so widen the amount column in the transaction table. This does make Bitcoin much better suited for microdonations as small amounts look so much longer.

![01](https://f.cloud.github.com/assets/126646/2420024/e32c5e34-ab68-11e3-969f-03f99b6d9ea0.png)

![02](https://f.cloud.github.com/assets/126646/2420025/e6fac8de-ab68-11e3-91f3-0d45c344b8e3.png)

![03](https://f.cloud.github.com/assets/126646/2420027/e9bc6f96-ab68-11e3-90f2-27c2564fbeee.png)

A patch to switch the RPC units to πBTC should be part of JSON API v2.
