### PR TITLE
qt: Enable/disable Show/Remove buttons in ReceiveCoinsDialog

### DIFF
--- a/src/qt/forms/receivecoinsdialog.ui
+++ b/src/qt/forms/receivecoinsdialog.ui
@@ -263,6 +263,9 @@
           <property name="text">
            <string>Show</string>
           </property>
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
           <property name="icon">
            <iconset resource="../bitcoin.qrc">
             <normaloff>:/icons/edit</normaloff>:/icons/edit</iconset>
@@ -276,6 +279,9 @@
           </property>
           <property name="text">
            <string>Remove</string>
+          </property>
+          <property name="enabled">
+           <bool>false</bool>
           </property>
           <property name="icon">
            <iconset resource="../bitcoin.qrc">

--- a/src/qt/receivecoinsdialog.cpp
+++ b/src/qt/receivecoinsdialog.cpp
@@ -19,6 +19,7 @@
 #include <QMessageBox>
 #include <QTextDocument>
 #include <QScrollBar>
+#include <QItemSelection>
 
 ReceiveCoinsDialog::ReceiveCoinsDialog(QWidget *parent) :
     QDialog(parent),
@@ -77,6 +78,11 @@ void ReceiveCoinsDialog::setModel(WalletModel *model)
         ui->recentRequestsView->horizontalHeader()->resizeSection(RecentRequestsTableModel::Amount, 100);
 
         model->getRecentRequestsTableModel()->sort(RecentRequestsTableModel::Date, Qt::DescendingOrder);
+
+        connect(ui->recentRequestsView->selectionModel(),
+            SIGNAL(selectionChanged(QItemSelection, QItemSelection)),
+            this,
+            SLOT(on_recentRequestsView_selectionChanged(QItemSelection, QItemSelection)));
     }
 }
 
@@ -159,6 +165,15 @@ void ReceiveCoinsDialog::on_recentRequestsView_doubleClicked(const QModelIndex &
     dialog->setInfo(submodel->entry(index.row()).recipient);
     dialog->setAttribute(Qt::WA_DeleteOnClose);
     dialog->show();
+}
+
+void ReceiveCoinsDialog::on_recentRequestsView_selectionChanged(const QItemSelection &selected,
+                                                                const QItemSelection &deselected)
+{
+    // Enable Show/Remove buttons only if anything is selected.
+    bool enable = !ui->recentRequestsView->selectionModel()->selectedRows().isEmpty();
+    ui->showRequestButton->setEnabled(enable);
+    ui->removeRequestButton->setEnabled(enable);
 }
 
 void ReceiveCoinsDialog::on_showRequestButton_clicked()

--- a/src/qt/receivecoinsdialog.h
+++ b/src/qt/receivecoinsdialog.h
@@ -10,6 +10,7 @@
 #include <QMenu>
 #include <QPoint>
 #include <QVariant>
+#include <QItemSelection>
 
 namespace Ui {
     class ReceiveCoinsDialog;
@@ -51,6 +52,7 @@ private slots:
     void on_showRequestButton_clicked();
     void on_removeRequestButton_clicked();
     void on_recentRequestsView_doubleClicked(const QModelIndex &index);
+    void on_recentRequestsView_selectionChanged(const QItemSelection &, const QItemSelection &);
     void updateDisplayUnit();
     void showMenu(const QPoint &);
     void copyLabel();


### PR DESCRIPTION
The Show and Remove buttons under Receive are currently clickable even if no entry is selected in the list. They should be enabled only as long as anything is selected.

Tested on Qt 4 and 5 on Ubuntu 13.10.
