### PR TITLE
Make addnode nodes more insisting on being connected

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1382,7 +1382,7 @@ void ThreadOpenAddedConnections()
             }
             BOOST_FOREACH(string& strAddNode, lAddresses) {
                 CAddress addr;
-                CSemaphoreGrant grant(*semOutbound);
+                CSemaphoreGrant grant(*semOutbound, true);
                 OpenNetworkConnection(addr, &grant, strAddNode.c_str());
                 MilliSleep(500);
             }
@@ -1429,7 +1429,7 @@ void ThreadOpenAddedConnections()
         }
         BOOST_FOREACH(vector<CService>& vserv, lservAddressesToAdd)
         {
-            CSemaphoreGrant grant(*semOutbound);
+            CSemaphoreGrant grant(*semOutbound, true);
             OpenNetworkConnection(CAddress(vserv[i % vserv.size()]), &grant);
             MilliSleep(500);
         }


### PR DESCRIPTION
addnode are administratively added connections that the operator prefers to have connected. Make bitcoind a bit more insisting on having these connected.
- Bypass outgoing connections limit for addnode nodes
- Reduce retry interval to 5 seconds to quickly reconnect again
  should the connection close for some reason
