### PR TITLE
New -limitgetblock option to limit max number of blocks returned in getblocks

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -23,6 +23,7 @@
 #include "wallet.h"
 #include "walletdb.h"
 #endif
+#include "main.h"
 
 #include <stdint.h>
 
@@ -473,6 +474,9 @@ bool AppInit2(boost::thread_group& threadGroup)
         return InitError(_("Not enough file descriptors available."));
     if (nFD - MIN_CORE_FILEDESCRIPTORS < nMaxConnections)
         nMaxConnections = nFD - MIN_CORE_FILEDESCRIPTORS;
+
+    // Limit number of blocks that may be requested in one go.
+    nMaxGetBlock = GetArg("-limitgetblock", 500);
 
     // ********************************************************* Step 3: parameter-to-internal-flags
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -48,6 +48,7 @@ bool fReindex = false;
 bool fBenchmark = false;
 bool fTxIndex = false;
 unsigned int nCoinCacheSize = 5000;
+unsigned int nMaxGetBlock = 500;
 
 /** Fees smaller than this (in satoshi) are considered zero fee (for transaction creation) */
 int64_t CTransaction::nMinTxFee = 10000;  // Override with -mintxfee
@@ -3622,7 +3623,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
         // Send the rest of the chain
         if (pindex)
             pindex = chainActive.Next(pindex);
-        int nLimit = 500;
+        int nLimit = nMaxGetBlock;
         LogPrint("net", "getblocks %d to %s limit %d\n", (pindex ? pindex->nHeight : -1), hashStop.ToString(), nLimit);
         for (; pindex; pindex = chainActive.Next(pindex))
         {

--- a/src/main.h
+++ b/src/main.h
@@ -96,6 +96,7 @@ extern bool fBenchmark;
 extern int nScriptCheckThreads;
 extern bool fTxIndex;
 extern unsigned int nCoinCacheSize;
+extern unsigned int nMaxGetBlock;
 
 // Minimum disk space required - used in CheckDiskSpace()
 static const uint64_t nMinDiskSpace = 52428800;


### PR DESCRIPTION
primarily for slow connections to throttle blockchain transmissions which
otherwise easily chokes the whole connection.
