### PR TITLE
qt: Use locale-specific number formatting

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -94,6 +94,9 @@ static void initTranslations(QTranslator &qtTranslatorBase, QTranslator &qtTrans
     // 3) -lang command line argument
     lang_territory = QString::fromStdString(GetArg("-lang", lang_territory.toStdString()));
 
+    // Set default locale for amount and date formatting according to the selected language
+    QLocale::setDefault(QLocale(lang_territory));
+
     // Convert to "de" only by truncating "_DE"
     QString lang = lang_territory;
     lang.truncate(lang_territory.lastIndexOf('_'));

--- a/src/qt/bitcoinunits.cpp
+++ b/src/qt/bitcoinunits.cpp
@@ -41,7 +41,7 @@ QString BitcoinUnits::name(int unit)
     {
     case BTC: return QString("BTC");
     case mBTC: return QString("mBTC");
-    case uBTC: return QString::fromUtf8("μBTC");
+    case uBTC: return QChar(0x03BC) + QString("BTC");
     default: return QString("???");
     }
 }
@@ -50,9 +50,9 @@ QString BitcoinUnits::description(int unit)
 {
     switch(unit)
     {
-    case BTC: return QString("Bitcoins");
-    case mBTC: return QString("Milli-Bitcoins (1 / 1,000)");
-    case uBTC: return QString("Micro-Bitcoins (1 / 1,000,000)");
+    case BTC: return tr("Bitcoins");
+    case mBTC: return tr("Milli-Bitcoins (1 / 1,000)");
+    case uBTC: return tr("Micro-Bitcoins (1 / 1,000,000)");
     default: return QString("???");
     }
 }

--- a/src/qt/bitcoinunits.cpp
+++ b/src/qt/bitcoinunits.cpp
@@ -5,6 +5,7 @@
 #include "bitcoinunits.h"
 
 #include <QStringList>
+#include <QLocale>
 
 BitcoinUnits::BitcoinUnits(QObject *parent):
         QAbstractListModel(parent),
@@ -100,71 +101,89 @@ int BitcoinUnits::decimals(int unit)
     }
 }
 
-QString BitcoinUnits::format(int unit, qint64 n, bool fPlus)
+QString BitcoinUnits::format(int unit, qint64 n, bool fPlus, bool fTrim, const QLocale &locale_in)
 {
     // Note: not using straight sprintf here because we do NOT want
     // localized number formatting.
     if(!valid(unit))
         return QString(); // Refuse to format invalid unit
+    QLocale locale(locale_in);
     qint64 coin = factor(unit);
     int num_decimals = decimals(unit);
+
     qint64 n_abs = (n > 0 ? n : -n);
     qint64 quotient = n_abs / coin;
     qint64 remainder = n_abs % coin;
-    QString quotient_str = QString::number(quotient);
-    QString remainder_str = QString::number(remainder).rightJustified(num_decimals, '0');
+    // Quotient has group (decimal) separators if locale has this enabled
+    QString quotient_str = locale.toString(quotient);
+    // Remainder does not have group separators
+    locale.setNumberOptions(QLocale::OmitGroupSeparator | QLocale::RejectGroupSeparator);
+    QString remainder_str = locale.toString(remainder).rightJustified(num_decimals, '0');
 
-    // Right-trim excess zeros after the decimal point
-    int nTrim = 0;
-    for (int i = remainder_str.size()-1; i>=2 && (remainder_str.at(i) == '0'); --i)
-        ++nTrim;
-    remainder_str.chop(nTrim);
+    if(fTrim)
+    {
+        // Right-trim excess zeros after the decimal point
+        int nTrim = 0;
+        for (int i = remainder_str.size()-1; i>=2 && (remainder_str.at(i) == '0'); --i)
+            ++nTrim;
+        remainder_str.chop(nTrim);
+    }
 
     if (n < 0)
         quotient_str.insert(0, '-');
-    else if (fPlus && n > 0)
+    else if (fPlus && n >= 0)
         quotient_str.insert(0, '+');
-    return quotient_str + QString(".") + remainder_str;
+    return quotient_str + locale.decimalPoint() + remainder_str;
 }
 
-QString BitcoinUnits::formatWithUnit(int unit, qint64 amount, bool plussign)
+QString BitcoinUnits::formatWithUnit(int unit, qint64 amount, bool plussign, bool trim, const QLocale &locale)
 {
-    return format(unit, amount, plussign) + QString(" ") + name(unit);
+    return format(unit, amount, plussign, trim) + QString(" ") + name(unit);
 }
-
-bool BitcoinUnits::parse(int unit, const QString &value, qint64 *val_out)
+bool BitcoinUnits::parse(int unit, const QString &value, qint64 *val_out, const QLocale &locale_in)
 {
     if(!valid(unit) || value.isEmpty())
         return false; // Refuse to parse invalid unit or empty string
+
+    QLocale locale(locale_in);
+    qint64 coin = factor(unit);
     int num_decimals = decimals(unit);
-    QStringList parts = value.split(".");
+    QStringList parts = value.split(locale.decimalPoint());
+    bool ok = false;
 
     if(parts.size() > 2)
-    {
-        return false; // More than one dot
-    }
-    QString whole = parts[0];
-    QString decimals;
+        return false; // More than one decimal point
 
+    // Parse whole part (may include locale-specific group separators)
+#if QT_VERSION < 0x050000
+    qint64 whole = locale.toLongLong(parts[0], &ok, 10);
+#else
+    qint64 whole = locale.toLongLong(parts[0], &ok);
+#endif
+    if(!ok)
+        return false; // Parse error
+    if(whole > maxAmount(unit) || whole < 0)
+        return false; // Overflow or underflow
+
+    // Parse decimals part (if present, may not include group separators)
+    qint64 decimals = 0;
     if(parts.size() > 1)
     {
-        decimals = parts[1];
+        if(parts[1].size() > num_decimals)
+            return false; // Exceeds max precision
+        locale.setNumberOptions(QLocale::OmitGroupSeparator | QLocale::RejectGroupSeparator);
+#if QT_VERSION < 0x050000
+        decimals = locale.toLongLong(parts[1].leftJustified(num_decimals, '0'), &ok, 10);
+#else
+        decimals = locale.toLongLong(parts[1].leftJustified(num_decimals, '0'), &ok);
+#endif
+        if(!ok || decimals < 0)
+            return false; // Parse error
     }
-    if(decimals.size() > num_decimals)
-    {
-        return false; // Exceeds max precision
-    }
-    bool ok = false;
-    QString str = whole + decimals.leftJustified(num_decimals, '0');
 
-    if(str.size() > 18)
-    {
-        return false; // Longer numbers will exceed 63 bits
-    }
-    qint64 retvalue = str.toLongLong(&ok);
     if(val_out)
     {
-        *val_out = retvalue;
+        *val_out = whole * coin + decimals;
     }
     return ok;
 }

--- a/src/qt/bitcoinunits.h
+++ b/src/qt/bitcoinunits.h
@@ -7,6 +7,7 @@
 
 #include <QAbstractListModel>
 #include <QString>
+#include <QLocale>
 
 /** Bitcoin unit definitions. Encapsulates parsing and formatting
    and serves as list model for drop-down selection boxes.
@@ -49,11 +50,11 @@ public:
     //! Number of decimals left
     static int decimals(int unit);
     //! Format as string
-    static QString format(int unit, qint64 amount, bool plussign=false);
+    static QString format(int unit, qint64 amount, bool plussign=false, bool trim=true, const QLocale &locale=QLocale());
     //! Format as string (with unit)
-    static QString formatWithUnit(int unit, qint64 amount, bool plussign=false);
+    static QString formatWithUnit(int unit, qint64 amount, bool plussign=false, bool trim=true, const QLocale &locale=QLocale());
     //! Parse string to coin amount
-    static bool parse(int unit, const QString &value, qint64 *val_out);
+    static bool parse(int unit, const QString &value, qint64 *val_out, const QLocale &locale=QLocale());
     ///@}
 
     //! @name AbstractListModel implementation

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -58,7 +58,7 @@ namespace GUIUtil {
 
 QString dateTimeStr(const QDateTime &date)
 {
-    return date.date().toString(Qt::SystemLocaleShortDate) + QString(" ") + date.toString("hh:mm");
+    return date.date().toString(Qt::DefaultLocaleShortDate) + QString(" ") + date.toString("hh:mm");
 }
 
 QString dateTimeStr(qint64 nTime)
@@ -133,7 +133,10 @@ bool parseBitcoinURI(const QUrl &uri, SendCoinsRecipient *out)
         {
             if(!i->second.isEmpty())
             {
-                if(!BitcoinUnits::parse(BitcoinUnits::BTC, i->second, &rv.amount))
+                // Parse amount in C locale with no number separators
+                QLocale locale(QLocale::c());
+                locale.setNumberOptions(QLocale::OmitGroupSeparator | QLocale::RejectGroupSeparator);
+                if(!BitcoinUnits::parse(BitcoinUnits::BTC, i->second, &rv.amount, locale))
                 {
                     return false;
                 }

--- a/src/qt/test/Makefile.am
+++ b/src/qt/test/Makefile.am
@@ -8,13 +8,16 @@ AM_CPPFLAGS += -I$(top_srcdir)/src \
 bin_PROGRAMS = test_bitcoin-qt
 TESTS = test_bitcoin-qt
 
-TEST_QT_MOC_CPP = moc_uritests.cpp
+TEST_QT_MOC_CPP = \
+  moc_bitcoinunitstests.cpp \
+  moc_uritests.cpp
 
 if ENABLE_WALLET
 TEST_QT_MOC_CPP += moc_paymentservertests.cpp
 endif
 
 TEST_QT_H = \
+  bitcoinunitstests.h \
   uritests.h \
   paymentrequestdata.h \
   paymentservertests.h
@@ -24,6 +27,7 @@ BUILT_SOURCES = $(TEST_QT_MOC_CPP)
 test_bitcoin_qt_CPPFLAGS = $(AM_CPPFLAGS) $(QT_INCLUDES) $(QT_TEST_INCLUDES)
 
 test_bitcoin_qt_SOURCES = \
+  bitcoinunitstests.cpp \
   test_main.cpp \
   uritests.cpp \
   $(TEST_QT_H)

--- a/src/qt/test/bitcoinunitstests.cpp
+++ b/src/qt/test/bitcoinunitstests.cpp
@@ -1,0 +1,104 @@
+#include "bitcoinunitstests.h"
+
+#include "bitcoinunits.h"
+
+#include <QUrl>
+
+void BitcoinUnitsTests::parseTests()
+{
+    qint64 value = 0;
+
+    /// Tests with en_US locale
+    QLocale locale1("en_US");
+    QVERIFY(BitcoinUnits::parse(BitcoinUnits::BTC, "0", &value, locale1));
+    QCOMPARE(value, 0LL);
+    QVERIFY(BitcoinUnits::parse(BitcoinUnits::BTC, "1", &value, locale1));
+    QCOMPARE(value, 100000000LL);
+    QVERIFY(BitcoinUnits::parse(BitcoinUnits::BTC, "1.0", &value, locale1));
+    QCOMPARE(value, 100000000LL);
+    QVERIFY(BitcoinUnits::parse(BitcoinUnits::uBTC, "1,000,000.0", &value, locale1));
+    QCOMPARE(value, 100000000LL);
+    QVERIFY(BitcoinUnits::parse(BitcoinUnits::uBTC, "1,000.0", &value, locale1));
+    QCOMPARE(value, 100000LL);
+    QVERIFY(BitcoinUnits::parse(BitcoinUnits::mBTC, "1,000.0", &value, locale1));
+    QCOMPARE(value, 100000000LL);
+    QVERIFY(BitcoinUnits::parse(BitcoinUnits::BTC, "0.00000001", &value, locale1));
+    QCOMPARE(value, 1LL);
+    QVERIFY(BitcoinUnits::parse(BitcoinUnits::mBTC, "0.00001", &value, locale1));
+    QCOMPARE(value, 1LL);
+    QVERIFY(BitcoinUnits::parse(BitcoinUnits::uBTC, "0.01", &value, locale1));
+    QCOMPARE(value, 1LL);
+    // Fail: group separator in wrong place
+    QVERIFY(!BitcoinUnits::parse(BitcoinUnits::BTC, "0,00", &value, locale1));
+    // Fail: group separator in decimals
+    QVERIFY(!BitcoinUnits::parse(BitcoinUnits::BTC, "0.0,000", &value, locale1));
+    // Fail: multiple decimal separators
+    QVERIFY(!BitcoinUnits::parse(BitcoinUnits::BTC, "0.000.000", &value, locale1));
+
+    /// Tests with nl_NL locale
+    QLocale locale2("nl_NL");
+    QVERIFY(BitcoinUnits::parse(BitcoinUnits::BTC, "1", &value, locale2));
+    QCOMPARE(value, 100000000LL);
+    QVERIFY(BitcoinUnits::parse(BitcoinUnits::BTC, "1,0", &value, locale2));
+    QCOMPARE(value, 100000000LL);
+    QVERIFY(BitcoinUnits::parse(BitcoinUnits::uBTC, "1.000.000,0", &value, locale2));
+    QCOMPARE(value, 100000000LL);
+    // Fail: multiple decimal separators
+    QVERIFY(!BitcoinUnits::parse(BitcoinUnits::BTC, "0,000,000", &value, locale2));
+
+    /// Tests with de_CH locale
+    QLocale locale3("de_CH");
+    QVERIFY(BitcoinUnits::parse(BitcoinUnits::uBTC, "123'456.78", &value, locale3));
+    QCOMPARE(value, 12345678LL);
+    // Fail: multiple decimal separators
+    QVERIFY(!BitcoinUnits::parse(BitcoinUnits::BTC, "0.000.000", &value, locale3));
+
+    /// Tests with c locale
+    QLocale locale4(QLocale::c());
+    locale4.setNumberOptions(QLocale::OmitGroupSeparator | QLocale::RejectGroupSeparator);
+    QVERIFY(BitcoinUnits::parse(BitcoinUnits::BTC, "1000.00000000", &value, locale4));
+    QCOMPARE(value, 100000000000LL);
+    // Fail: group separator
+    QVERIFY(!BitcoinUnits::parse(BitcoinUnits::BTC, "1,000.00", &value, locale4));
+    // Fail: too many decimals
+    QVERIFY(!BitcoinUnits::parse(BitcoinUnits::BTC, "1000.000000000", &value, locale4));
+    // Fail: overflow
+    QVERIFY(!BitcoinUnits::parse(BitcoinUnits::BTC, "21000001.0", &value, locale4));
+    QVERIFY(!BitcoinUnits::parse(BitcoinUnits::BTC, "92233720368547758090.0", &value, locale4));
+    // Fail: underflow
+    QVERIFY(!BitcoinUnits::parse(BitcoinUnits::BTC, "-1000000.0", &value, locale4));
+    // Fail: sign in decimals
+    QVERIFY(!BitcoinUnits::parse(BitcoinUnits::BTC, "0.-1000000", &value, locale4));
+}
+
+void BitcoinUnitsTests::formatTests()
+{
+    /// Tests with en_US locale
+    QLocale locale1("en_US");
+    QCOMPARE(BitcoinUnits::format(BitcoinUnits::BTC, 0, false, false, locale1), QString("0.00000000"));
+    QCOMPARE(BitcoinUnits::format(BitcoinUnits::BTC, 0, false, true, locale1), QString("0.00"));
+    QCOMPARE(BitcoinUnits::format(BitcoinUnits::mBTC, 0, false, false, locale1), QString("0.00000"));
+    QCOMPARE(BitcoinUnits::format(BitcoinUnits::uBTC, 0, false, false, locale1), QString("0.00"));
+    QCOMPARE(BitcoinUnits::format(BitcoinUnits::uBTC, 0, true, false, locale1), QString("+0.00"));
+    QCOMPARE(BitcoinUnits::format(BitcoinUnits::uBTC, 100000000, false, true, locale1), QString("1,000,000.00"));
+    QCOMPARE(BitcoinUnits::format(BitcoinUnits::uBTC, 100000000, true, true, locale1), QString("+1,000,000.00"));
+
+    QCOMPARE(BitcoinUnits::formatWithUnit(BitcoinUnits::BTC, 100000000, false, true, locale1), QString("1.00 BTC"));
+    QCOMPARE(BitcoinUnits::formatWithUnit(BitcoinUnits::mBTC, 100000000, false, true, locale1), QString("1,000.00 mBTC"));
+    QCOMPARE(BitcoinUnits::formatWithUnit(BitcoinUnits::uBTC, 100000000, false, true, locale1), QString("1,000,000.00 μBTC"));
+
+    /// Tests with nl_NL locale
+    QLocale locale2("nl_NL");
+    QCOMPARE(BitcoinUnits::format(BitcoinUnits::uBTC, 100000000, false, true, locale2), QString("1.000.000,00"));
+
+    /// Tests with de_CH locale
+    QLocale locale3("de_CH");
+    QCOMPARE(BitcoinUnits::format(BitcoinUnits::uBTC, 100000000, false, true, locale3), QString("1'000'000.00"));
+
+    /// Tests with c locale (with and without group separators)
+    QLocale locale4(QLocale::c());
+    locale4.setNumberOptions(QLocale::OmitGroupSeparator | QLocale::RejectGroupSeparator);
+    QCOMPARE(BitcoinUnits::format(BitcoinUnits::uBTC, 100000000, false, true, QLocale::c()), QString("1,000,000.00"));
+    QCOMPARE(BitcoinUnits::format(BitcoinUnits::uBTC, 100000000, false, true, locale4), QString("1000000.00"));
+}
+

--- a/src/qt/test/bitcoinunitstests.cpp
+++ b/src/qt/test/bitcoinunitstests.cpp
@@ -85,7 +85,7 @@ void BitcoinUnitsTests::formatTests()
 
     QCOMPARE(BitcoinUnits::formatWithUnit(BitcoinUnits::BTC, 100000000, false, true, locale1), QString("1.00 BTC"));
     QCOMPARE(BitcoinUnits::formatWithUnit(BitcoinUnits::mBTC, 100000000, false, true, locale1), QString("1,000.00 mBTC"));
-    QCOMPARE(BitcoinUnits::formatWithUnit(BitcoinUnits::uBTC, 100000000, false, true, locale1), QString("1,000,000.00 μBTC"));
+    QCOMPARE(BitcoinUnits::formatWithUnit(BitcoinUnits::uBTC, 100000000, false, true, locale1), QString("1,000,000.00 ")+QChar(0x03BC)+QString("BTC"));
 
     /// Tests with nl_NL locale
     QLocale locale2("nl_NL");

--- a/src/qt/test/bitcoinunitstests.h
+++ b/src/qt/test/bitcoinunitstests.h
@@ -1,0 +1,16 @@
+#ifndef BITCOINUNITSTESTS_H
+#define BITCOINUNITSTESTS_H
+
+#include <QObject>
+#include <QTest>
+
+class BitcoinUnitsTests : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void formatTests();
+    void parseTests();
+};
+
+#endif // BITCOINUNITSTESTS_H

--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -3,10 +3,11 @@
 #include "bitcoin-config.h"
 #endif
 
+#include "bitcoinunitstests.h"
+#include "uritests.h"
 #ifdef ENABLE_WALLET
 #include "paymentservertests.h"
 #endif
-#include "uritests.h"
 
 #include <QCoreApplication>
 #include <QObject>
@@ -38,6 +39,9 @@ int main(int argc, char *argv[])
     if (QTest::qExec(&test2) != 0)
         fInvalid = true;
 #endif
+    BitcoinUnitsTests test3;
+    if (QTest::qExec(&test3) != 0)
+        fInvalid = true;
 
     return fInvalid;
 }


### PR DESCRIPTION
- Change bitcoinamountfield to use locale-specific number format
- Change bitcoinunits to show and parse locale-specific numbers
- If a language/territory is selected in options, this is set as default locale (overrides system locale)

Examples:
- US: 123,456.78 μBTC
- Dutch: 123.456,78 μBTC
- German (Switzerland): 123'456.78
  ...

Fixes #3887
