### PR TITLE
Fixed compile error on Debian jessie (gcc version 4.8.2)

### DIFF
--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -10,6 +10,7 @@
 #include "ui_interface.h"
 #include "util.h"
 
+#include <stdint.h>
 #include <algorithm>
 #include <map>
 


### PR DESCRIPTION
Fixed compile error on Debian jessie (gcc version 4.8.2)

Missed stdint.h in alert.cpp
