### PR TITLE
gitian: add statically built variant of bitcoind/bitcoin-cli for linux build

### DIFF
--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -39,18 +39,39 @@ script: |
   unzip ../build/bitcoin-deps-linux${GBUILD_BITS}-gitian-r3.zip
   unzip ../build/boost-linux${GBUILD_BITS}-1.55.0-gitian-r1.zip
   cd ../build
+
+  function do_configure {
+    ./configure "$@" --enable-upnp-default --prefix=$STAGING --with-protoc-bindir=$STAGING/host/bin --with-boost=$STAGING --disable-maintainer-mode --disable-dependency-tracking PKG_CONFIG_PATH="$STAGING/lib/pkgconfig" CPPFLAGS="-I$STAGING/include ${OPTFLAGS}" LDFLAGS="-L$STAGING/lib ${OPTFLAGS}" CXXFLAGS="-frandom-seed=bitcoin ${OPTFLAGS}" BOOST_CHRONO_EXTRALIBS="-lrt"
+  }
   #
   cd bitcoin
   ./autogen.sh
-  ./configure --prefix=$STAGING --bindir=$BINDIR --with-protoc-bindir=$STAGING/host/bin --with-boost=$STAGING --disable-maintainer-mode --disable-dependency-tracking PKG_CONFIG_PATH="$STAGING/lib/pkgconfig" CPPFLAGS="-I$STAGING/include ${OPTFLAGS}" LDFLAGS="-L$STAGING/lib ${OPTFLAGS}" CXXFLAGS="-frandom-seed=bitcoin ${OPTFLAGS}" BOOST_CHRONO_EXTRALIBS="-lrt"
+  do_configure
   make dist
   DISTNAME=`echo bitcoin-*.tar.gz`
+
+  # Build dynamic versions of everything
+  # (with static linking to boost and openssl as well a some non-OS deps)
   mkdir -p distsrc
   cd distsrc
   tar --strip-components=1 -xf ../$DISTNAME
-  ./configure --enable-upnp-default --prefix=$STAGING --bindir=$BINDIR --with-protoc-bindir=$STAGING/host/bin --with-boost=$STAGING --disable-maintainer-mode --disable-dependency-tracking PKG_CONFIG_PATH="$STAGING/lib/pkgconfig" CPPFLAGS="-I$STAGING/include ${OPTFLAGS}" LDFLAGS="-L$STAGING/lib ${OPTFLAGS}" CXXFLAGS="-frandom-seed=bitcoin ${OPTFLAGS}" BOOST_CHRONO_EXTRALIBS="-lrt"
+  do_configure --bindir=$BINDIR 
   make $MAKEOPTS
   make $MAKEOPTS install-strip
+  make $MAKEOPTS clean
+
+  # Build fully static versions of bitcoind and bitcoin-cli for older Linux distros
+  STATIC_BINDIR="$HOME/bindir.static"
+  mkdir -p $STATIC_BINDIR
+  # For 32-bit, -pie cannot be used with -static, as invalid executables are generated
+  # For 64-bit, -pie with -static causes a link error
+  # Disable hardening in configure and manually pass 'static-safe' hardening flags
+  OPTFLAGS='-O2 -static -Wstack-protector -fstack-protector-all -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2 -Wl,-z,relro -Wl,-z,now'
+  do_configure --bindir=$STATIC_BINDIR --disable-tests --enable-upnp-default --without-gui --disable-hardening
+  make $MAKEOPTS
+  make $MAKEOPTS install-strip
+  cp $STATIC_BINDIR/bitcoind $BINDIR/bitcoind.static
+  cp $STATIC_BINDIR/bitcoin-cli $BINDIR/bitcoin-cli.static
   
   # sort distribution tar file and normalize user/group/mtime information for deterministic output
   mkdir -p $OUTDIR/src


### PR DESCRIPTION
See #3803 and #3781.

This increases compatibility with older linux distributions.

```
  2943584 Mar 20 11:43 32/bitcoin-cli
  4376728 Mar 20 11:43 32/bitcoin-cli.static
  7748512 Mar 20 11:43 32/bitcoind
  9140856 Mar 20 11:43 32/bitcoind.static
 12164000 Mar 20 11:43 32/bitcoin-qt
  9740608 Mar 20 11:43 32/test_bitcoin
  8420256 Mar 20 11:43 32/test_bitcoin-qt
  3103728 Mar 20 11:53 64/bitcoin-cli
  4355112 Mar 20 11:53 64/bitcoin-cli.static
  7773680 Mar 20 11:53 64/bitcoind
  8890088 Mar 20 11:53 64/bitcoind.static
 12226032 Mar 20 11:53 64/bitcoin-qt
  9860528 Mar 20 11:53 64/test_bitcoin
  8457776 Mar 20 11:53 64/test_bitcoin-qt
```

A warning shown during build is:

```
 warning: Using 'getaddrinfo' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
```

~~**Note** I have not explicitly disabled hardening/-pie in this build. This makes that the 32-bit version still has a dependency on dynamic libc.so even though it is statically linked:~~

```
$ ldd 32/bitcoind.static
    statically linked
$ readelf -a 32/bitcoind.static |grep interpreter
      [Requesting program interpreter: /usr/lib/libc.so.1]
```

~~Not sure how much of an issue this is on true 32-bit systems. It needs to be tested. This is not the case for the 64-bit build:~~

```
$ ldd 64/bitcoind.static                                                       
    not a dynamic executable
$ readelf -a 64/bitcoind.static |grep interpreter
(nothing)
```

Edit: v2: -pie now explicitly disabled for 32-bit build as it was unusable otherwise.

Tested on:
- Debian 7.2 64-bit: OK (tested by me)
- Ubuntu 10.04.4 LTS 64-bit: OK (tested by me)
- Ubuntu 10.04.4 LTS 32-bit: OK (tested by me, v2)
- CentOS 6.5 64bit: OK (tested by alexeft on forums and anton000, v2)
- CentOS 6.5 32bit: OK (tested by anton000, v2)
