### PR TITLE
build: build qt tests after qt libs/executable

### DIFF
--- a/src/qt/Makefile.am
+++ b/src/qt/Makefile.am
@@ -7,8 +7,8 @@ AM_CPPFLAGS += -I$(top_srcdir)/src \
   $(QR_CFLAGS)
 bin_PROGRAMS = bitcoin-qt
 noinst_LIBRARIES = libbitcoinqt.a
-SUBDIRS = $(BUILD_TEST_QT)
-DIST_SUBDIRS = test
+SUBDIRS = . $(BUILD_TEST_QT)
+DIST_SUBDIRS = . test
 
 # bitcoin qt core #
 QT_TS = \


### PR DESCRIPTION
Trivial change to build system.

Autotools defaults to a depth-first recursion which causes the qt tests to be built before the executables and libraries.

This is inconvenient as make needs to be called twice to make sure the tests are up to date after changing a source file.

Update the Makefile.am to change this order.
