### PR TITLE
[QT] Fixes feel when resizing the last column on tables (issue #2862)

### DIFF
--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -8,6 +8,8 @@
 #include <QMessageBox>
 #include <QObject>
 #include <QString>
+#include <QTableView>
+#include <QHeaderView>
 
 class QValidatedLineEdit;
 class SendCoinsRecipient;
@@ -114,6 +116,44 @@ namespace GUIUtil
 
     private:
         int size_threshold;
+    };
+
+    /**
+     * Makes a QTableView last column feel as if it was being resized from its left border.
+     * Also makes sure the column widths are never larger than the table's viewport.
+     * In Qt, all columns are resizable from the right, but it's not intuitive resizing the last column from the right.
+     * Usually our second to last columns behave as if stretched, and when on strech mode, columns aren't resizable
+     * interactively or programatically.
+     *
+     * This helper object takes care of this issue.
+     *
+     */
+    class TableViewLastColumnResizingFixer: public QObject
+    {
+    Q_OBJECT
+    public:
+        TableViewLastColumnResizingFixer(QTableView* table, int lastColMinimumWidth, int allColsMinimumWidth);
+        void stretchColumnWidth(int column);
+
+    private:
+        QTableView* tableView;
+        int lastColumnMinimumWidth;
+        int allColumnsMinimumWidth;
+        int lastColumnIndex;
+        int columnCount;
+        int secondToLastColumnIndex;
+
+        void adjustTableColumnsWidth();
+        int getAvailableWidthForColumn(int column);
+        int getColumnsWidth();
+        void connectViewHeadersSignals();
+        void disconnectViewHeadersSignals();
+        void setViewHeaderResizeMode(int logicalIndex, QHeaderView::ResizeMode resizeMode);
+        void resizeColumn(int nColumnIndex, int width);
+
+    private slots:
+        void on_sectionResized(int logicalIndex, int oldSize, int newSize);
+        void on_geometriesChanged();
     };
 
     bool GetStartOnSystemStartup();

--- a/src/qt/receivecoinsdialog.h
+++ b/src/qt/receivecoinsdialog.h
@@ -10,7 +10,9 @@
 #include <QMenu>
 #include <QPoint>
 #include <QVariant>
+#include <QHeaderView>
 #include <QItemSelection>
+#include "guiutil.h"
 
 namespace Ui {
     class ReceiveCoinsDialog;
@@ -28,10 +30,17 @@ class ReceiveCoinsDialog : public QDialog
     Q_OBJECT
 
 public:
+    enum ColumnWidths {
+      DATE_COLUMN_WIDTH = 130,
+      LABEL_COLUMN_WIDTH = 120,
+      AMOUNT_MINIMUM_COLUMN_WIDTH = 160,
+      MINIMUM_COLUMN_WIDTH = 130
+    };
+
     explicit ReceiveCoinsDialog(QWidget *parent = 0);
     ~ReceiveCoinsDialog();
-
     void setModel(WalletModel *model);
+
 
 public slots:
     void clear();
@@ -43,9 +52,11 @@ protected:
 
 private:
     Ui::ReceiveCoinsDialog *ui;
+    GUIUtil::TableViewLastColumnResizingFixer *columnResizingFixer;
     WalletModel *model;
     QMenu *contextMenu;
     void copyColumnToClipboard(int column);
+    virtual void resizeEvent(QResizeEvent* event);
 
 private slots:
     void on_receiveButton_clicked();

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -168,6 +168,7 @@ void TransactionView::setModel(WalletModel *model)
 
         transactionProxyModel->setSortRole(Qt::EditRole);
 
+        transactionView->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
         transactionView->setModel(transactionProxyModel);
         transactionView->setAlternatingRowColors(true);
         transactionView->setSelectionBehavior(QAbstractItemView::SelectRows);
@@ -176,15 +177,12 @@ void TransactionView::setModel(WalletModel *model)
         transactionView->sortByColumn(TransactionTableModel::Status, Qt::DescendingOrder);
         transactionView->verticalHeader()->hide();
 
-        transactionView->horizontalHeader()->resizeSection(TransactionTableModel::Status, 23);
-        transactionView->horizontalHeader()->resizeSection(TransactionTableModel::Date, 120);
-        transactionView->horizontalHeader()->resizeSection(TransactionTableModel::Type, 120);
-#if QT_VERSION < 0x050000
-        transactionView->horizontalHeader()->setResizeMode(TransactionTableModel::ToAddress, QHeaderView::Stretch);
-#else
-        transactionView->horizontalHeader()->setSectionResizeMode(TransactionTableModel::ToAddress, QHeaderView::Stretch);
-#endif
-        transactionView->horizontalHeader()->resizeSection(TransactionTableModel::Amount, 100);
+        transactionView->setColumnWidth(TransactionTableModel::Status, STATUS_COLUMN_WIDTH);
+        transactionView->setColumnWidth(TransactionTableModel::Date, DATE_COLUMN_WIDTH);
+        transactionView->setColumnWidth(TransactionTableModel::Type, TYPE_COLUMN_WIDTH);
+        transactionView->setColumnWidth(TransactionTableModel::Amount, AMOUNT_MINIMUM_COLUMN_WIDTH);
+
+        columnResizingFixer = new GUIUtil::TableViewLastColumnResizingFixer(transactionView, AMOUNT_MINIMUM_COLUMN_WIDTH, MINIMUM_COLUMN_WIDTH);
     }
 }
 
@@ -438,4 +436,10 @@ void TransactionView::focusTransaction(const QModelIndex &idx)
     transactionView->scrollTo(targetIdx);
     transactionView->setCurrentIndex(targetIdx);
     transactionView->setFocus();
+}
+
+//We override the virtual resizeEvent of the QWidget to adjust tablet's column sizes as the table's width is proportional to the dialog's.
+void TransactionView::resizeEvent(QResizeEvent* event) {
+  QWidget::resizeEvent(event);
+  columnResizingFixer->stretchColumnWidth(TransactionTableModel::ToAddress);
 }

--- a/src/qt/transactionview.h
+++ b/src/qt/transactionview.h
@@ -6,6 +6,7 @@
 #define TRANSACTIONVIEW_H
 
 #include <QWidget>
+#include "guiutil.h"
 
 class TransactionFilterProxy;
 class WalletModel;
@@ -44,6 +45,14 @@ public:
         Range
     };
 
+    enum ColumnWidths {
+      STATUS_COLUMN_WIDTH = 23,
+      DATE_COLUMN_WIDTH = 120,
+      TYPE_COLUMN_WIDTH = 120,
+      AMOUNT_MINIMUM_COLUMN_WIDTH = 120,
+      MINIMUM_COLUMN_WIDTH = 23
+    };
+
 private:
     WalletModel *model;
     TransactionFilterProxy *transactionProxyModel;
@@ -61,6 +70,10 @@ private:
     QDateTimeEdit *dateTo;
 
     QWidget *createDateRangeWidget();
+
+    GUIUtil::TableViewLastColumnResizingFixer *columnResizingFixer;
+
+    virtual void resizeEvent(QResizeEvent* event);
 
 private slots:
     void contextualMenu(const QPoint &);


### PR DESCRIPTION
Re-submitting this pull request with a single commit.

This patch introduces a GUIUtil class that is used when setting up the 2 tables we have so far on the Qt-GUI.
In the past you could only resize the last column, which has BTC amounts from the right border of the column header, something that was rather unnatural.

If a new table were ever to be added to the interface, fixing the last columns resizing behavior is rather simple. Just look at how we initialize here a TableViewLastColumnResizingFixer object when setting up the table header's behavior, and then how we override the resize event of the component (can be the table, or the dialog) and we invoke columnResizingFixer->stretchColumnWidth(columnIndex);

When the window is resized, the second to last column is stretched like before, this was the last fix done.

Video demoing fix here: https://www.youtube.com/watch?v=rkcPO1sLGX8&feature=youtu.be
