### PR TITLE
[Qt] remove space from translation of client bitness

### DIFF
--- a/src/qt/utilitydialog.cpp
+++ b/src/qt/utilitydialog.cpp
@@ -38,9 +38,9 @@ void AboutDialog::setModel(ClientModel *model)
          * 32 and 64 bit builds. On other architectures, 32/64 bit may be more ambigious.
          */
 #if defined(__x86_64__)
-        version += tr(" (%1-bit)").arg(64);
+        version += " " + tr("(%1-bit)").arg(64);
 #elif defined(__i386__ )
-        version += tr(" (%1-bit)").arg(32);
+        version += " " + tr("(%1-bit)").arg(32);
 #endif
         ui->versionLabel->setText(version);
     }


### PR DESCRIPTION
- its rather easy to leave out the space on Transifex, so remove it from
  the string
