### PR TITLE
Fix importwallet nTimeFirstKey

### DIFF
--- a/src/rpcdump.cpp
+++ b/src/rpcdump.cpp
@@ -212,6 +212,9 @@ Value importwallet(const Array& params, bool fHelp)
     while (pindex && pindex->pprev && pindex->nTime > nTimeBegin - 7200)
         pindex = pindex->pprev;
 
+    if (!pwalletMain->nTimeFirstKey || nTimeBegin < pwalletMain->nTimeFirstKey)
+        pwalletMain->nTimeFirstKey = nTimeBegin;
+
     LogPrintf("Rescanning last %i blocks\n", chainActive.Height() - pindex->nHeight + 1);
     pwalletMain->ScanForWalletTransactions(pindex);
     pwalletMain->MarkDirty();


### PR DESCRIPTION
importwallet does not set nTimeFirstKey. This can result in an incomplete rescan.
