### PR TITLE
RPC command getmininginfo showing right genproclimit

### DIFF
--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -204,6 +204,7 @@ Value setgenerate(const Array& params, bool fHelp)
     else // Not -regtest: start generate thread, return immediately
     {
         mapArgs["-gen"] = (fGenerate ? "1" : "0");
+        mapArgs ["-genproclimit"] = itostr(nGenProcLimit);
         GenerateBitcoins(fGenerate, pwalletMain, nGenProcLimit);
     }
 


### PR DESCRIPTION
With tag version v0.9.0, getmininginfo was showing always genproclimit -1.
$ ./bitcoind setgenerate true 1
$ ./bitcoind getmininginfo
{
 ...
    "genproclimit" : -1,
...
}

with this patch, now it is showing the right value:
$ ./bitcoind setgenerate true 1
$ ./bitcoind getmininginfo
{
 ...
    "genproclimit" : 1,
...
}
