### PR TITLE
Fix nPayFee calculation

### DIFF
--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1348,7 +1348,7 @@ bool CWallet::CreateTransaction(const vector<pair<CScript, int64_t> >& vecSend,
                 dPriority = wtxNew.ComputePriority(dPriority, nBytes);
 
                 // Check that enough fee is included
-                int64_t nPayFee = nTransactionFee * (1 + (int64_t)nBytes / 1000);
+                int64_t nPayFee = nTransactionFee * (1 + ((int64_t)nBytes - 1) / 1000);
                 bool fAllowFree = AllowFree(dPriority);
                 int64_t nMinFee = GetMinFee(wtxNew, nBytes, fAllowFree, GMF_SEND);
                 if (nFeeRet < max(nPayFee, nMinFee))


### PR DESCRIPTION
nPayFee is more than intended if nBytes is exactly in multiples of 1000
bytes
