### PR TITLE
Support unicode characters in paths in Windows

### DIFF
--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -18,6 +18,8 @@
 //
 static bool AppInitRPC(int argc, char* argv[])
 {
+    BoostFilesystemToUTF8();
+
     //
     // Parameters
     //

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -60,6 +60,7 @@ bool AppInit(int argc, char* argv[])
     bool fRet = false;
     try
     {
+        BoostFilesystemToUTF8();
         //
         // Parameters
         //

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -30,6 +30,7 @@
 #include <stdint.h>
 
 #include <boost/filesystem/operations.hpp>
+#include <boost/filesystem/detail/utf8_codecvt_facet.hpp>
 #include <QApplication>
 #include <QLibraryInfo>
 #include <QLocale>
@@ -457,6 +458,7 @@ int main(int argc, char *argv[])
     QTextCodec::setCodecForTr(QTextCodec::codecForName("UTF-8"));
     QTextCodec::setCodecForCStrings(QTextCodec::codecForTr());
 #endif
+    BoostFilesystemToUTF8();
 
     Q_INIT_RESOURCE(bitcoin);
     BitcoinApplication app(argc, argv);

--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -7,6 +7,7 @@
 #include "paymentservertests.h"
 #endif
 #include "uritests.h"
+#include "util.h"
 
 #include <QCoreApplication>
 #include <QObject>
@@ -29,6 +30,8 @@ int main(int argc, char *argv[])
     // QCoreApplication:: in the tests
     QCoreApplication app(argc, argv);
     app.setApplicationName("Bitcoin-Qt-test");
+
+    BoostFilesystemToUTF8();
 
     URITests test1;
     if (QTest::qExec(&test1) != 0)

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -31,6 +31,8 @@ struct TestingSetup {
 
     TestingSetup() {
         fPrintToDebugLog = false; // don't want to write to debug.log file
+
+        BoostFilesystemToUTF8();
         noui_connect();
 #ifdef ENABLE_WALLET
         bitdb.MakeMock();

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -68,6 +68,7 @@
 #include <boost/foreach.hpp>
 #include <boost/program_options/detail/config_file.hpp>
 #include <boost/program_options/parsers.hpp>
+#include <boost/filesystem/detail/utf8_codecvt_facet.hpp>
 #include <openssl/crypto.h>
 #include <openssl/rand.h>
 
@@ -1425,5 +1426,14 @@ void RenameThread(const char* name)
     // Prevent warnings for unused parameters...
     (void)name;
 #endif
+}
+
+void BoostFilesystemToUTF8()
+{
+    // Convince boost::filesystem globally that all standard strings (both those passed in and
+    // retrieved) are UTF-8
+    std::locale global_loc = std::locale();
+    std::locale loc(global_loc, new boost::filesystem::detail::utf8_codecvt_facet);
+    boost::filesystem::path::imbue(loc);
 }
 

--- a/src/util.h
+++ b/src/util.h
@@ -439,6 +439,12 @@ bool TimingResistantEqual(const T& a, const T& b)
     return accumulator == 0;
 }
 
+/**
+ * Convince boost::filesystem that all standard strings are UTF-8.
+ * Call this before using any boost::filesystem functions.
+ */
+void BoostFilesystemToUTF8();
+
 /** Median filter over a stream of values.
  * Returns the median of the last N numbers
  */


### PR DESCRIPTION
Set boost::filesystem locale to UTF-8 at start of program, independent of operating system. This wiil allows for unicode chars in file and directory names in Windows.

Attempt at fixing #3916.

Just seeing what the pulltester will do.

Testing is welcome, but do not merge. This is frought with edge cases and I'm not sure this is the best solution.
