### PR TITLE
qt: Do proper boost::path conversion

### DIFF
--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -11,6 +11,8 @@
 #include <QTableView>
 #include <QHeaderView>
 
+#include <boost/filesystem.hpp>
+
 class QValidatedLineEdit;
 class SendCoinsRecipient;
 
@@ -163,6 +165,12 @@ namespace GUIUtil
     void saveWindowGeometry(const QString& strSetting, QWidget *parent);
     /** Restore window size and position */
     void restoreWindowGeometry(const QString& strSetting, const QSize &defaultSizeIn, QWidget *parent);
+
+    /* Convert QString to OS specific boost path through UTF-8 */
+    boost::filesystem::path qstringToBoostPath(const QString &path);
+
+    /* Convert OS specific boost path to QString through UTF-8 */
+    QString boostPathToQString(const boost::filesystem::path &path);
 
 } // namespace GUIUtil
 

--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -189,7 +189,12 @@ void Intro::pickDataDirectory()
 
         settings.setValue("strDataDir", dataDir);
     }
-    SoftSetArg("-datadir", GUIUtil::qstringToBoostPath(dataDir).string()); // use OS locale for path setting
+    /* Only override -datadir if different from the default, to make it possible to
+     * override -datadir in the bitcoin.conf file in the default data directory
+     * (to be consistent with bitcoind behavior)
+     */
+    if(dataDir != getDefaultDataDirectory())
+        SoftSetArg("-datadir", GUIUtil::qstringToBoostPath(dataDir).string()); // use OS locale for path setting
 }
 
 void Intro::setStatus(int status, const QString &message, quint64 bytesAvailable)

--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -5,9 +5,12 @@
 #include "intro.h"
 #include "ui_intro.h"
 
+#include "guiutil.h"
+
 #include "util.h"
 
 #include <boost/filesystem.hpp>
+
 #include <QFileDialog>
 #include <QSettings>
 #include <QMessageBox>
@@ -59,7 +62,7 @@ void FreespaceChecker::check()
 {
     namespace fs = boost::filesystem;
     QString dataDirStr = intro->getPathToCheck();
-    fs::path dataDir = fs::path(dataDirStr.toStdString());
+    fs::path dataDir = GUIUtil::qstringToBoostPath(dataDirStr);
     uint64_t freeBytesAvailable = 0;
     int replyStatus = ST_OK;
     QString replyMessage = tr("A new data directory will be created.");
@@ -143,7 +146,7 @@ void Intro::setDataDirectory(const QString &dataDir)
 
 QString Intro::getDefaultDataDirectory()
 {
-    return QString::fromStdString(GetDefaultDataDir().string());
+    return GUIUtil::boostPathToQString(GetDefaultDataDir());
 }
 
 void Intro::pickDataDirectory()
@@ -159,7 +162,7 @@ void Intro::pickDataDirectory()
     /* 2) Allow QSettings to override default dir */
     dataDir = settings.value("strDataDir", dataDir).toString();
 
-    if(!fs::exists(dataDir.toStdString()) || GetBoolArg("-choosedatadir", false))
+    if(!fs::exists(GUIUtil::qstringToBoostPath(dataDir)) || GetBoolArg("-choosedatadir", false))
     {
         /* If current default data directory does not exist, let the user choose one */
         Intro intro;
@@ -175,7 +178,7 @@ void Intro::pickDataDirectory()
             }
             dataDir = intro.getDataDirectory();
             try {
-                fs::create_directory(dataDir.toStdString());
+                fs::create_directory(GUIUtil::qstringToBoostPath(dataDir));
                 break;
             } catch(fs::filesystem_error &e) {
                 QMessageBox::critical(0, tr("Bitcoin"),
@@ -186,7 +189,7 @@ void Intro::pickDataDirectory()
 
         settings.setValue("strDataDir", dataDir);
     }
-    SoftSetArg("-datadir", dataDir.toStdString());
+    SoftSetArg("-datadir", GUIUtil::qstringToBoostPath(dataDir).string()); // use OS locale for path setting
 }
 
 void Intro::setStatus(int status, const QString &message, quint64 bytesAvailable)


### PR DESCRIPTION
Convert from QString unicode from/to the OS-dependent locale as used by boost::filesystem::path as needed.

This should make data directories with special characters in Windows work.

Should solve #3916 and #3905.

Test builds (windows) can be found here:
https://download.visucore.com/bitcoin/bitcoin-2014_03_qt_unicode_path_v3.zip
Signature:
https://download.visucore.com/bitcoin/bitcoin-2014_03_qt_unicode_path_v3.zip.sig
