### PR TITLE
Update brew instructions to build Boost from HEAD

### DIFF
--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -74,7 +74,8 @@ Instructions: Homebrew
 
 #### Install dependencies using Homebrew
 
-        brew install autoconf automake berkeley-db4 boost miniupnpc openssl pkg-config protobuf qt
+        brew install autoconf automake berkeley-db4 miniupnpc openssl pkg-config protobuf qt
+        brew install boost --HEAD
 
 Note: After you have installed the dependencies, you should check that the Homebrew installed version of OpenSSL is the one available for compilation. You can check this by typing
 


### PR DESCRIPTION
Previously, when trying to build master or v0.9.0, [compilation on OS X would
fail](https://gist.github.com/9704573). This commit resolves these errors by building Boost from source.
Building from HEAD removes the guarantee of a repeatable build, but this
appears to be a necessity until the next version of Boost is released.

At the time of this writing, the [current version of Boost is 1.55.0](http://www.boost.org/users/history). 
Presumably, the next release will include the changes now on HEAD, and once
that new version has been [made available in Homebrew](https://github.com/Homebrew/homebrew/commits/master/Library/Formula/boost.rb), this commit should
be reverted.
