### PR TITLE
Ignore temporary object files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ src/qt/test/moc*.cpp
 *.rej
 *.orig
 *.o
+*.o-*
 *.patch
 .bitcoin
 *.a


### PR DESCRIPTION
Prior to this change, `git status` would report untracked files of the 
following sort if run during a build:

```
?? src/rpcprotocol.o-e628def3
```

These files should be explicitly ignored not only because they are a 
nuisance, but given that they appear and disappear quickly, they may be 
inadvertently added to the index even if one has been careful to check for
untracked files with `git status` prior to a `git add .`.
