### PR TITLE
Remove stale and redundant src/.gitignore file

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,3 +1,0 @@
-
-test_bitcoin
-


### PR DESCRIPTION
This commit removes completely the src/.gitignore file, given that the 
precedent for ignoring artifacts within the `src` directory is to add entries
for them to the root .gitignore file.

Note also that the lone entry in src/.gitignore is stale anyway. As of the
switch to Autotools in 35b8af9, the build no longer build creates artifacts
in `src/test_bitcoin`. They are now written to
`src/test/test_bitcoin`, and this latter path is already ignored in the root
.gitignore file.
