### PR TITLE
fix permissions in application bundle

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -66,11 +66,11 @@ $(OSX_APP)/Contents/Resources/empty.lproj:
 
 $(OSX_APP)/Contents/Info.plist: $(OSX_PLIST)
 	$(MKDIR_P) $(@D)
-	$(INSTALL) $< $@
+	$(INSTALL_DATA) $< $@
 
 $(OSX_APP)/Contents/Resources/bitcoin.icns: $(OSX_INSTALLER_ICONS)
 	$(MKDIR_P) $(@D)
-	$(INSTALL) $< $@
+	$(INSTALL_DATA) $< $@
 
 $(OSX_APP)/Contents/MacOS/Bitcoin-Qt: $(BITCOIN_QT_BIN)
 	$(MKDIR_P) $(@D)


### PR DESCRIPTION
Use INSTALL_DATA rather than INSTALL for copying non executable files in OS X application bundle.

Tested by running "all appbundle" make target and trying the resulting application bundle, host system is OS X 10.9.2 .
