### PR TITLE
Remove duplicate from src/makefile.am

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -90,9 +90,7 @@ version.o: obj/build.h
 libbitcoin_server_a_SOURCES = \
   addrman.cpp \
   alert.cpp \
-  rpcserver.cpp \
   bloom.cpp \
-  chainparams.cpp \
   checkpoints.cpp \
   coins.cpp \
   init.cpp \
@@ -107,6 +105,7 @@ libbitcoin_server_a_SOURCES = \
   rpcmisc.cpp \
   rpcnet.cpp \
   rpcrawtransaction.cpp \
+  rpcserver.cpp \
   txdb.cpp \
   txmempool.cpp \
   $(JSON_H) \


### PR DESCRIPTION
chainparams.cpp should not be in both libbitcoin_common and libbitcoin_server. Also re-sort the sources list.
