### PR TITLE
build: libtoolize bitcoin core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,11 @@ src/qt/test/moc*.cpp
 *.pb.cc
 *.pb.h
 
+# libtool
+*.lo
+*.la
+.libs
+
 *.log
 *.trs
 *.dmg

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,9 @@ src/qt/test/moc*.cpp
 *.la
 .libs
 
+# pkgconfig
+*.pc
+
 *.log
 *.trs
 *.dmg

--- a/Makefile.am
+++ b/Makefile.am
@@ -33,6 +33,12 @@ COVERAGE_INFO = baseline_filtered_combined.info baseline.info block_test.info \
   baseline_filtered.info block_test_filtered.info \
   leveldb_baseline_filtered.info test_bitcoin_coverage.info test_bitcoin.info
 
+pkgconfigdir = $(libdir)/pkgconfig
+pkgconfig_DATA = share/bitcoincore_common.pc share/bitcoincore_server.pc share/bitcoincore_cli.pc
+if ENABLE_WALLET
+pkgconfig_DATA += share/bitcoincore_wallet.pc
+endif
+
 dist-hook:
 	-$(MAKE) -C $(top_distdir)/src/leveldb clean
 	-$(GIT) archive --format=tar HEAD -- src/version.cpp | $(AMTAR) -C $(top_distdir) -xf -

--- a/configure.ac
+++ b/configure.ac
@@ -6,6 +6,14 @@ define(_CLIENT_VERSION_REVISION, 99)
 define(_CLIENT_VERSION_BUILD, 0)
 define(_CLIENT_VERSION_IS_RELEASE, false)
 define(_COPYRIGHT_YEAR, 2014)
+
+# Dynamic library version: this is not the same as the version number of the
+# package as a whole.  The library version number uses an established scheme to
+# indicate what type of changes happened to your library's interface. The
+# scheme is documented in
+# https://www.gnu.org/software/libtool/manual/html_node/Libtool-versioning.html
+define(_CLIENT_VERSION_DYNLIB, 1:0:0)
+
 AC_INIT([Bitcoin Core],[_CLIENT_VERSION_MAJOR._CLIENT_VERSION_MINOR._CLIENT_VERSION_REVISION],[info@bitcoin.org],[bitcoin])
 AC_CONFIG_AUX_DIR([src/build-aux])
 AC_CONFIG_MACRO_DIR([src/m4])
@@ -13,6 +21,7 @@ AC_CANONICAL_HOST
 AH_TOP([#ifndef BITCOIN_CONFIG_H])
 AH_TOP([#define BITCOIN_CONFIG_H])
 AH_BOTTOM([#endif //BITCOIN_CONFIG_H])
+LT_INIT([disable-shared])
 
 # This m4 will only be used if a system copy cannot be found. This is helpful
 # on systems where autotools are installed but the pkg-config macros are not in
@@ -370,6 +379,15 @@ AC_SUBST(LEVELDB_CPPFLAGS)
 AC_SUBST(LIBLEVELDB)
 AC_SUBST(LIBMEMENV)
 
+dnl If shared library is requested, build leveldb with -fPIC so that it can be
+dnl linked as part of shared library.
+if test "x$enable_shared" = xyes; then
+    LEVELDB_EXTRA_CXXFLAGS="-fPIC"
+else
+    LEVELDB_EXTRA_CXXFLAGS=""
+fi
+AC_SUBST(LEVELDB_EXTRA_CXXFLAGS)
+
 if test x$enable_wallet != xno; then
     dnl Check for libdb_cxx only if wallet enabled
     BITCOIN_FIND_BDB48
@@ -703,6 +721,7 @@ AC_SUBST(CLIENT_VERSION_MINOR, _CLIENT_VERSION_MINOR)
 AC_SUBST(CLIENT_VERSION_REVISION, _CLIENT_VERSION_REVISION)
 AC_SUBST(CLIENT_VERSION_BUILD, _CLIENT_VERSION_BUILD)
 AC_SUBST(CLIENT_VERSION_IS_RELEASE, _CLIENT_VERSION_IS_RELEASE)
+AC_SUBST(CLIENT_VERSION_DYNLIB, _CLIENT_VERSION_DYNLIB)
 AC_SUBST(COPYRIGHT_YEAR, _COPYRIGHT_YEAR)
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -738,4 +738,5 @@ AC_SUBST(BUILD_TEST_QT)
 AC_CONFIG_FILES([Makefile src/Makefile src/test/Makefile src/qt/Makefile src/qt/test/Makefile share/setup.nsi share/qt/Info.plist])
 AC_CONFIG_FILES([qa/pull-tester/run-bitcoind-for-test.sh],[chmod +x qa/pull-tester/run-bitcoind-for-test.sh])
 AC_CONFIG_FILES([qa/pull-tester/build-tests.sh],[chmod +x qa/pull-tester/build-tests.sh])
+AC_CONFIG_FILES([share/bitcoincore_common.pc share/bitcoincore_server.pc share/bitcoincore_cli.pc share/bitcoincore_wallet.pc])
 AC_OUTPUT

--- a/share/bitcoincore_cli.pc.in
+++ b/share/bitcoincore_cli.pc.in
@@ -1,0 +1,11 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: bitcoincore_cli
+Description: Bitcoin Core RPC Client
+Requires: bitcoincore_common
+Version: @PACKAGE_VERSION@
+Libs: -L${libdir} -lbitcoincore_cli
+Cflags: -I${includedir}/@PACKAGE@

--- a/share/bitcoincore_common.pc.in
+++ b/share/bitcoincore_common.pc.in
@@ -1,0 +1,11 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: bitcoincore_common
+Description: Bitcoin Core Common
+Requires:
+Version: @PACKAGE_VERSION@
+Libs: -L${libdir} -lbitcoincore_common @BOOST_LIBS@
+Cflags: -I${includedir}/@PACKAGE@ @BOOST_CPPFLAGS@ -DHAVE_CONFIG_H

--- a/share/bitcoincore_server.pc.in
+++ b/share/bitcoincore_server.pc.in
@@ -1,0 +1,11 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: bitcoincore_server
+Description: Bitcoin Core Server
+Requires: bitcoincore_common
+Version: @PACKAGE_VERSION@
+Libs: -L${libdir} -lbitcoincore_server
+Cflags: -I${includedir}/@PACKAGE@

--- a/share/bitcoincore_wallet.pc.in
+++ b/share/bitcoincore_wallet.pc.in
@@ -1,0 +1,11 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: bitcoincore_wallet
+Description: Bitcoin Core Wallet
+Requires: bitcoincore_common bitcoincore_server
+Version: @PACKAGE_VERSION@
+Libs: -L${libdir} -lbitcoincore_wallet
+Cflags: -I${includedir}/@PACKAGE@

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -90,9 +90,7 @@ version.o: obj/build.h
 libbitcoin_server_a_SOURCES = \
   addrman.cpp \
   alert.cpp \
-  rpcserver.cpp \
   bloom.cpp \
-  chainparams.cpp \
   checkpoints.cpp \
   coins.cpp \
   init.cpp \
@@ -107,6 +105,7 @@ libbitcoin_server_a_SOURCES = \
   rpcmisc.cpp \
   rpcnet.cpp \
   rpcrawtransaction.cpp \
+  rpcserver.cpp \
   txdb.cpp \
   txmempool.cpp \
   $(JSON_H) \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -84,6 +84,7 @@ libbitcoincore_common_la_SOURCES = \
 libbitcoincore_common_la_LDFLAGS = -version-info $(CLIENT_VERSION_DYNLIB)
 libbitcoincore_common_la_LIBADD = $(BOOST_LIBS)
 nodist_libbitcoincore_common_la_SOURCES = $(top_srcdir)/src/obj/build.h
+nodist_libbitcoincore_common_include_HEADERS = bitcoin-config.h
 
 # server library #
 libbitcoincore_server_includedir = $(includedir)/$(PACKAGE)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -2,12 +2,12 @@ include Makefile.include
 
 AM_CPPFLAGS += -I$(builddir)
 
-noinst_LIBRARIES = \
-  libbitcoin_server.a \
-  libbitcoin_common.a \
-  libbitcoin_cli.a
+lib_LTLIBRARIES = \
+  libbitcoincore_common.la \
+  libbitcoincore_server.la \
+  libbitcoincore_cli.la
 if ENABLE_WALLET
-noinst_LIBRARIES += libbitcoin_wallet.a
+lib_LTLIBRARIES += libbitcoincore_wallet.la
 endif
 
 bin_PROGRAMS =
@@ -23,54 +23,9 @@ endif
 SUBDIRS = . $(BUILD_QT) $(BUILD_TEST)
 DIST_SUBDIRS = . qt test
 .PHONY: FORCE
-# bitcoin core #
-BITCOIN_CORE_H = \
-  addrman.h \
-  alert.h \
-  allocators.h \
-  base58.h bignum.h \
-  bloom.h \
-  chainparams.h \
-  checkpoints.h \
-  checkqueue.h \
-  clientversion.h \
-  coincontrol.h \
-  coins.h \
-  compat.h \
-  core.h \
-  crypter.h \
-  db.h \
-  hash.h \
-  init.h \
-  key.h \
-  keystore.h \
-  leveldbwrapper.h \
-  limitedmap.h \
-  main.h \
-  miner.h \
-  mruset.h \
-  netbase.h \
-  net.h \
-  noui.h \
-  protocol.h \
-  rpcclient.h \
-  rpcprotocol.h \
-  rpcserver.h \
-  script.h \
-  serialize.h \
-  sync.h \
-  threadsafety.h \
-  tinyformat.h \
-  txdb.h \
-  txmempool.h \
-  ui_interface.h \
-  uint256.h \
-  util.h \
-  version.h \
-  walletdb.h \
-  wallet.h
 
-JSON_H = \
+libbitcoincore_json_includedir = $(includedir)/$(PACKAGE)/json
+libbitcoincore_json_include_HEADERS = \
   json/json_spirit.h \
   json/json_spirit_error_position.h \
   json/json_spirit_reader.h \
@@ -85,9 +40,73 @@ obj/build.h: FORCE
 	@$(MKDIR_P) $(abs_top_builddir)/src/obj
 	@$(top_srcdir)/share/genbuild.sh $(abs_top_builddir)/src/obj/build.h \
 	  $(abs_top_srcdir)
-version.o: obj/build.h
+version.lo: obj/build.h
 
-libbitcoin_server_a_SOURCES = \
+# common utilities library #
+libbitcoincore_common_includedir = $(includedir)/$(PACKAGE)
+libbitcoincore_common_include_HEADERS = \
+  allocators.h \
+  base58.h \
+  bignum.h \
+  chainparams.h \
+  clientversion.h \
+  compat.h \
+  core.h \
+  hash.h \
+  key.h \
+  limitedmap.h \
+  netbase.h \
+  protocol.h \
+  rpcprotocol.h \
+  script.h \
+  serialize.h \
+  sync.h \
+  threadsafety.h \
+  tinyformat.h \
+  uint256.h \
+  util.h \
+  version.h
+libbitcoincore_common_la_SOURCES = \
+  allocators.cpp \
+  chainparams.cpp \
+  core.cpp \
+  hash.cpp \
+  key.cpp \
+  netbase.cpp \
+  protocol.cpp \
+  rpcprotocol.cpp \
+  script.cpp \
+  sync.cpp \
+  util.cpp \
+  version.cpp \
+  $(libbitcoincore_json_include_HEADERS) \
+  $(libbitcoincore_common_include_HEADERS)
+libbitcoincore_common_la_LDFLAGS = -version-info $(CLIENT_VERSION_DYNLIB)
+libbitcoincore_common_la_LIBADD = $(BOOST_LIBS)
+nodist_libbitcoincore_common_la_SOURCES = $(top_srcdir)/src/obj/build.h
+
+# server library #
+libbitcoincore_server_includedir = $(includedir)/$(PACKAGE)
+libbitcoincore_server_include_HEADERS = \
+  addrman.h \
+  alert.h \
+  bloom.h \
+  checkpoints.h \
+  checkqueue.h \
+  coincontrol.h \
+  coins.h \
+  init.h \
+  keystore.h \
+  leveldbwrapper.h \
+  main.h \
+  miner.h \
+  net.h \
+  noui.h \
+  rpcclient.h \
+  rpcserver.h \
+  txdb.h \
+  ui_interface.h
+libbitcoincore_server_la_SOURCES = \
   addrman.cpp \
   alert.cpp \
   bloom.cpp \
@@ -108,49 +127,61 @@ libbitcoin_server_a_SOURCES = \
   rpcserver.cpp \
   txdb.cpp \
   txmempool.cpp \
-  $(JSON_H) \
-  $(BITCOIN_CORE_H)
+  $(libbitcoincore_json_include_HEADERS) \
+  $(libbitcoincore_common_include_HEADERS) \
+  $(libbitcoincore_server_include_HEADERS)
+libbitcoincore_server_la_LDFLAGS = -version-info $(CLIENT_VERSION_DYNLIB)
+libbitcoincore_server_la_LIBADD = \
+  libbitcoincore_common.la \
+  $(BOOST_LIBS) $(LIBLEVELDB) $(LIBMEMENV)
 
-libbitcoin_wallet_a_SOURCES = \
+# wallet library #
+libbitcoincore_wallet_includedir = $(includedir)/$(PACKAGE)
+libbitcoincore_wallet_include_HEADERS = \
+  crypter.h \
+  db.h \
+  mruset.h \
+  txmempool.h \
+  walletdb.h \
+  wallet.h
+libbitcoincore_wallet_la_SOURCES = \
   db.cpp \
   crypter.cpp \
   rpcdump.cpp \
   rpcwallet.cpp \
   wallet.cpp \
   walletdb.cpp \
-  $(BITCOIN_CORE_H)
+  $(libbitcoincore_json_include_HEADERS) \
+  $(libbitcoincore_common_include_HEADERS) \
+  $(libbitcoincore_server_include_HEADERS) \
+  $(libbitcoincore_wallet_include_HEADERS)
+libbitcoincore_wallet_la_LDFLAGS = -version-info $(CLIENT_VERSION_DYNLIB)
+libbitcoincore_wallet_la_LIBADD = \
+  libbitcoincore_server.la \
+  libbitcoincore_common.la \
+  $(BOOST_LIBS) $(BDB_LIBS)
 
-libbitcoin_common_a_SOURCES = \
-  allocators.cpp \
-  chainparams.cpp \
-  core.cpp \
-  hash.cpp \
-  key.cpp \
-  netbase.cpp \
-  protocol.cpp \
-  rpcprotocol.cpp \
-  script.cpp \
-  sync.cpp \
-  util.cpp \
-  version.cpp \
-  $(BITCOIN_CORE_H)
-
-libbitcoin_cli_a_SOURCES = \
+# RPC client library #
+libbitcoincore_cli_includedir = $(includedir)/$(PACKAGE)
+libbitcoincore_cli_include_HEADERS =
+libbitcoincore_cli_la_SOURCES = \
   rpcclient.cpp \
-  $(BITCOIN_CORE_H)
-
-nodist_libbitcoin_common_a_SOURCES = $(top_srcdir)/src/obj/build.h
-#
+  $(libbitcoincore_json_include_HEADERS) \
+  $(libbitcoincore_common_include_HEADERS)
+libbitcoincore_cli_la_LDFLAGS = -version-info $(CLIENT_VERSION_DYNLIB)
+libbitcoincore_cli_la_LIBADD = \
+  libbitcoincore_common.la \
+  $(BOOST_LIBS)
 
 # bitcoind binary #
 bitcoind_LDADD = \
-  libbitcoin_server.a \
-  libbitcoin_cli.a \
-  libbitcoin_common.a \
-  $(LIBLEVELDB) \
-  $(LIBMEMENV)
+  libbitcoincore_server.la \
+  libbitcoincore_cli.la \
+  libbitcoincore_common.la \
+  $(LIBLEVELDB) $(LIBMEMENV) \
+  $(BOOST_LIBS)
 if ENABLE_WALLET
-bitcoind_LDADD += libbitcoin_wallet.a
+bitcoind_LDADD += libbitcoincore_wallet.la
 endif
 bitcoind_SOURCES = bitcoind.cpp
 #
@@ -160,12 +191,11 @@ bitcoind_SOURCES += bitcoind-res.rc
 endif
 
 AM_CPPFLAGS += $(BDB_CPPFLAGS)
-bitcoind_LDADD += $(BOOST_LIBS) $(BDB_LIBS)
 
 # bitcoin-cli binary #
 bitcoin_cli_LDADD = \
-  libbitcoin_cli.a \
-  libbitcoin_common.a \
+  libbitcoincore_cli.la \
+  libbitcoincore_common.la \
   $(BOOST_LIBS)
 bitcoin_cli_SOURCES = bitcoin-cli.cpp
 #
@@ -180,9 +210,9 @@ leveldb/libleveldb.a: leveldb/libmemenv.a
 leveldb/%.a:
 	@echo "Building LevelDB ..." && $(MAKE) -C $(@D) $(@F) CXX="$(CXX)" \
 	  CC="$(CC)" PLATFORM=$(TARGET_OS) AR="$(AR)" $(LEVELDB_TARGET_FLAGS) \
-	  OPT="$(CXXFLAGS) $(CPPFLAGS)"
+	  OPT="$(CXXFLAGS) $(CPPFLAGS) $(LEVELDB_EXTRA_CXXFLAGS)"
 
-qt/bitcoinstrings.cpp: $(libbitcoin_server_a_SOURCES) $(libbitcoin_common_a_SOURCES) $(libbitcoin_cli_a_SOURCES)
+qt/bitcoinstrings.cpp: $(libbitcoincore_server_la_SOURCES) $(libbitcoincore_common_la_SOURCES) $(libbitcoincore_cli_la_SOURCES)
 	@test -n $(XGETTEXT) || echo "xgettext is required for updating translations"
 	@cd $(top_srcdir); XGETTEXT=$(XGETTEXT) share/qt/extract_strings_qt.py
 

--- a/src/Makefile.include
+++ b/src/Makefile.include
@@ -12,10 +12,10 @@ AM_CPPFLAGS =  $(INCLUDES) \
 AM_CPPFLAGS += $(LEVELDB_CPPFLAGS)
 AM_LDFLAGS = $(PTHREAD_CFLAGS)
 
-LIBBITCOIN_SERVER=$(top_builddir)/src/libbitcoin_server.a
-LIBBITCOIN_WALLET=$(top_builddir)/src/libbitcoin_wallet.a
-LIBBITCOIN_COMMON=$(top_builddir)/src/libbitcoin_common.a
-LIBBITCOIN_CLI=$(top_builddir)/src/libbitcoin_cli.a
+LIBBITCOIN_SERVER=$(top_builddir)/src/libbitcoincore_server.la
+LIBBITCOIN_WALLET=$(top_builddir)/src/libbitcoincore_wallet.la
+LIBBITCOIN_COMMON=$(top_builddir)/src/libbitcoincore_common.la
+LIBBITCOIN_CLI=$(top_builddir)/src/libbitcoincore_cli.la
 LIBBITCOINQT=$(top_builddir)/src/qt/libbitcoinqt.a
 
 $(LIBBITCOIN):


### PR DESCRIPTION
Minimal changes to make it possible to build shared libraries from Bitcoin Core:
- `libbitcoincore_server.so.1`
- `libbitcoincore_wallet.so.1` (if --enable-wallet)
- `libbitcoincore_cli.so.1`
- `libbitcoincore_common.so.1`

Libtool automagically adds `--enable-shared` and `--enable-static` options. Bitcoind and the other executables link against the shared libraries if available.

This is a step towards being able to split off the wallet or in general to make it possible to develop other Bitcoin-based stuff outside the core repository. It is a minimal change contained to the build system. The current division into libraries may not be ideal for external usage, this can be improved later.

Default behaviour should be unchanged: building shared libraries is disabled by default.
One step in implementing #3882 .
