### PR TITLE
Adding instructions to update the year on copyright headers.

### DIFF
--- a/doc/coding.md
+++ b/doc/coding.md
@@ -92,3 +92,10 @@ Threads
 - BitcoinMiner : Generates bitcoins (if wallet is enabled).
 
 - Shutdown : Does an orderly shutdown of everything.
+
+-----------------
+Copyright headers
+
+Resist the urge to fix copyright years in all the files in the source tree.
+If you can't resist, then run contrib/devtools/fix_copyright_headers.py
+inside of src/ to update them properly.


### PR DESCRIPTION
To avoid a common newbie mistake like the pull request rejected #3944, adding a simple instruction to the documentation Coding Convention of Bitcoin Core (doc/coding.md). The actual author of this short text (slightly modified) is Gavin Andresen sent by email to me as a tip.

Related:
- https://github.com/bitcoin/bitcoin/pull/3944#issuecomment-38467282
- https://github.com/bitcoin/bitcoin/pull/3646
