### PR TITLE
Adjust high nTransactionFee warning to reflect market prices.

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -575,7 +575,7 @@ bool AppInit2(boost::thread_group& threadGroup)
     {
         if (!ParseMoney(mapArgs["-paytxfee"], nTransactionFee))
             return InitError(strprintf(_("Invalid amount for -paytxfee=<amount>: '%s'"), mapArgs["-paytxfee"]));
-        if (nTransactionFee > 0.25 * COIN)
+        if (nTransactionFee > nHighTransactionFeeWarning)
             InitWarning(_("Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction."));
     }
     bSpendZeroConfChange = GetArg("-spendzeroconfchange", true);

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -27,6 +27,9 @@
 extern int64_t nTransactionFee;
 extern bool bSpendZeroConfChange;
 
+// -paytxfee will warn if called with a higher fee than this amount (in satoshis) per KB
+static const int nHighTransactionFeeWarning = 0.01 * COIN;
+
 class CAccountingEntry;
 class CCoinControl;
 class COutput;


### PR DESCRIPTION
The 0.25BTC -paytxfee warning has been there since at least commit 7d80d2e3d7ecceb5a99fef357b118949f6dd8a79 in 2012. In line with new market prices, I've adjusted it to 0.01BTC or $4.75USD at time of writing.
