### PR TITLE
remove an assignment which is never used.

### DIFF
--- a/src/serialize.h
+++ b/src/serialize.h
@@ -1038,10 +1038,7 @@ public:
         if (nReadPosNext >= vch.size())
         {
             if (nReadPosNext > vch.size())
-            {
                 setstate(std::ios::failbit, "CDataStream::ignore() : end of data");
-                nSize = vch.size() - nReadPos;
-            }
             nReadPos = 0;
             vch.clear();
             return (*this);


### PR DESCRIPTION
Just removes an assignment to a variable which is never used afterwards.
