### PR TITLE
Added missing german translation for Available and Pending.

### DIFF
--- a/src/qt/locale/bitcoin_de.ts
+++ b/src/qt/locale/bitcoin_de.ts
@@ -1502,9 +1502,19 @@ Adresse: %4</translation>
         <translation>Bestätigt:</translation>
     </message>
     <message>
+        <location line="+51"/>
+        <source>Available:</source>
+        <translation>Verfügbar:</translation>
+    </message>
+    <message>
         <location line="+16"/>
         <source>Your current spendable balance</source>
         <translation>Ihr aktuell verfügbarer Kontostand</translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Pending:</source>
+        <translation>Anstehend:</translation>
     </message>
     <message>
         <location line="+32"/>


### PR DESCRIPTION
The 0.9 release is missing german translations for the new states "Available" and "Pending".

This PR provides corresponding translations. 

I would like to get some Feedback from other native speakers which word would be the best translation of "Pending".

Candidates in my opinion:
- anstehend
- schwebend
- bevorstehend
- eingehend

![missing-translation](https://cloud.githubusercontent.com/assets/559823/2555352/c23f8538-b6bd-11e3-91c5-33d44832558c.png)
