### PR TITLE
Fix `-printblocktree` output

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3021,7 +3021,7 @@ void PrintBlockTree()
         // print item
         CBlock block;
         ReadBlockFromDisk(block, pindex);
-        LogPrintf("%d (blk%05u.dat:0x%x)  %s  tx %"PRIszu"",
+        LogPrintf("%d (blk%05u.dat:0x%x)  %s  tx %"PRIszu"\n",
             pindex->nHeight,
             pindex->GetBlockPos().nFile, pindex->GetBlockPos().nPos,
             DateTimeStrFormat("%Y-%m-%d %H:%M:%S", block.GetBlockTime()),


### PR DESCRIPTION
PrintBlockTree output was broken starting from e010af70. Everything appears on one line.

PrintWallet() added the newline after a block, but this functionality was removed and no newline was added.

Seemingly, no one noticed. Add a newline after the block information to fix this.
