### PR TITLE
Change debug.log from UTC to localtime. Fixes #3872.

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -334,7 +334,7 @@ inline int64_t GetTimeMicros()
 inline std::string DateTimeStrFormat(const char* pszFormat, int64_t nTime)
 {
     time_t n = nTime;
-    struct tm* ptmTime = gmtime(&n);
+    struct tm* ptmTime = localtime(&n);
     char pszTime[200];
     strftime(pszTime, sizeof(pszTime), pszFormat, ptmTime);
     return pszTime;


### PR DESCRIPTION
I don't know if we actually want to change this, just preparing a commit just in case. We also may want to add a ISO 8601 +02:00 type thing, but I'm yet to work that out. I've tested and it seems localtime gives that same type of output as gmtime.

<b>EDIT: Do Not Merge! Creates wrong behaviour in `EncodeDumpTime` which relies on this being UTC.</b>
