### PR TITLE
Remove 'ProcessBlock: ACCEPTED' messages

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2563,7 +2563,6 @@ bool ProcessBlock(CValidationState &state, CNode* pfrom, CBlock* pblock, CDiskBl
         mapOrphanBlocksByPrev.erase(hashPrev);
     }
 
-    LogPrintf("ProcessBlock: ACCEPTED\n");
     return true;
 }
 


### PR DESCRIPTION
I think this line could be removed, so that this:

2014-03-30 16:52:57 received block 000000000000000055fd58a596c921f789b3785c0e84242f87981f7762117f73 node=1
2014-03-30 16:52:59 UpdateTip: new best=000000000000000055fd58a596c921f789b3785c0e84242f87981f7762117f73  height=292899  log2_work=77.586222  tx=35771262  date=2014-03-28 11:46:26 progress=0.988418
2014-03-30 16:52:59 ProcessBlock: ACCEPTED
2014-03-30 16:53:02 received block 00000000000000001544a7fce213d98be118f550c792624758d2015165d003ab node=1
2014-03-30 16:53:04 UpdateTip: new best=00000000000000001544a7fce213d98be118f550c792624758d2015165d003ab  height=292900  log2_work=77.586358  tx=35771641  date=2014-03-28 11:51:47 progress=0.988438
2014-03-30 16:53:04 ProcessBlock: ACCEPTED
2014-03-30 16:53:05 received block 0000000000000000475115027af8b17991c8c5ed424f08472c7518cbd524a9fa node=1
2014-03-30 16:53:06 UpdateTip: new best=0000000000000000475115027af8b17991c8c5ed424f08472c7518cbd524a9fa  height=292901  log2_work=77.586495  tx=35771875  date=2014-03-28 11:56:48 progress=0.988456
2014-03-30 16:53:06 ProcessBlock: ACCEPTED
2014-03-30 16:53:09 received block 0000000000000000da52112a8558dc772049eee77a0a6f3fddfdebfda18ed36b node=1
2014-03-30 16:53:10 UpdateTip: new best=0000000000000000da52112a8558dc772049eee77a0a6f3fddfdebfda18ed36b  height=292902  log2_work=77.586632  tx=35772180  date=2014-03-28 12:03:23 progress=0.988480
2014-03-30 16:53:10 ProcessBlock: ACCEPTED

becomes this:-

2014-03-30 16:52:57 received block 000000000000000055fd58a596c921f789b3785c0e84242f87981f7762117f73 node=1
2014-03-30 16:52:59 UpdateTip: new best=000000000000000055fd58a596c921f789b3785c0e84242f87981f7762117f73  height=292899  log2_work=77.586222  tx=35771262  date=2014-03-28 11:46:26 progress=0.988418
2014-03-30 16:53:02 received block 00000000000000001544a7fce213d98be118f550c792624758d2015165d003ab node=1
2014-03-30 16:53:04 UpdateTip: new best=00000000000000001544a7fce213d98be118f550c792624758d2015165d003ab  height=292900  log2_work=77.586358  tx=35771641  date=2014-03-28 11:51:47 progress=0.988438
2014-03-30 16:53:05 received block 0000000000000000475115027af8b17991c8c5ed424f08472c7518cbd524a9fa node=1
2014-03-30 16:53:06 UpdateTip: new best=0000000000000000475115027af8b17991c8c5ed424f08472c7518cbd524a9fa  height=292901  log2_work=77.586495  tx=35771875  date=2014-03-28 11:56:48 progress=0.988456
2014-03-30 16:53:09 received block 0000000000000000da52112a8558dc772049eee77a0a6f3fddfdebfda18ed36b node=1
2014-03-30 16:53:10 UpdateTip: new best=0000000000000000da52112a8558dc772049eee77a0a6f3fddfdebfda18ed36b  height=292902  log2_work=77.586632  tx=35772180  date=2014-03-28 12:03:23 progress=0.988480

We know a ProcessBlock is accepted when we see a new Updated Tip or Orphan block added, and if it fails we see an error message, so the line is kinda redundant.
