### PR TITLE
Improved getblocks logging.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2460,15 +2460,16 @@ int64_t CBlockIndex::GetMedianTime() const
     return pindex->GetMedianTimePast();
 }
 
-void PushGetBlocks(CNode* pnode, CBlockIndex* pindexBegin, uint256 hashEnd)
+bool PushGetBlocks(CNode* pnode, CBlockIndex* pindexBegin, uint256 hashEnd)
 {
     // Filter out duplicate requests
     if (pindexBegin == pnode->pindexLastGetBlocksBegin && hashEnd == pnode->hashLastGetBlocksEnd)
-        return;
+        return false;
     pnode->pindexLastGetBlocksBegin = pindexBegin;
     pnode->hashLastGetBlocksEnd = hashEnd;
 
     pnode->PushMessage("getblocks", chainActive.GetLocator(pindexBegin), hashEnd);
+    return true;
 }
 
 bool ProcessBlock(CValidationState &state, CNode* pfrom, CBlock* pblock, CDiskBlockPos *dbp)
@@ -2528,7 +2529,8 @@ bool ProcessBlock(CValidationState &state, CNode* pfrom, CBlock* pblock, CDiskBl
             mapOrphanBlocksByPrev.insert(make_pair(pblock2->hashPrev, pblock2));
 
             // Ask this guy to fill in what we're missing
-            PushGetBlocks(pfrom, chainActive.Tip(), GetOrphanRoot(hash));
+            if (PushGetBlocks(pfrom, chainActive.Tip(), GetOrphanRoot(hash)))
+                LogPrint("net", "send fill-in getblocks for %s\n", hash.ToString());
         }
         return true;
     }
@@ -3578,7 +3580,8 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
                         pfrom->AskFor(inv);
                 }
             } else if (inv.type == MSG_BLOCK && mapOrphanBlocks.count(inv.hash)) {
-                PushGetBlocks(pfrom, chainActive.Tip(), GetOrphanRoot(inv.hash));
+                if (PushGetBlocks(pfrom, chainActive.Tip(), GetOrphanRoot(inv.hash)))
+                    LogPrint("net", "send getblocks for %s\n", inv.hash.ToString());
             }
 
             // Track requests for our stuff
@@ -4253,7 +4256,8 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
         // Start block sync
         if (pto->fStartSync && !fImporting && !fReindex) {
             pto->fStartSync = false;
-            PushGetBlocks(pto, chainActive.Tip(), uint256(0));
+            if (PushGetBlocks(pto, chainActive.Tip(), uint256(0)))
+                LogPrint("net", "send initial getblocks\n");
         }
 
         // Resend wallet transactions that haven't gotten in a block yet

--- a/src/main.h
+++ b/src/main.h
@@ -128,7 +128,7 @@ void RegisterNodeSignals(CNodeSignals& nodeSignals);
 /** Unregister a network node */
 void UnregisterNodeSignals(CNodeSignals& nodeSignals);
 
-void PushGetBlocks(CNode* pnode, CBlockIndex* pindexBegin, uint256 hashEnd);
+bool PushGetBlocks(CNode* pnode, CBlockIndex* pindexBegin, uint256 hashEnd);
 
 /** Process an incoming block */
 bool ProcessBlock(CValidationState &state, CNode* pfrom, CBlock* pblock, CDiskBlockPos *dbp = NULL);


### PR DESCRIPTION
Logs a message when a getblocks request is sent.

This line can later be changed to include the peer number (I am about to edit that other pull request to address the issues raised).
