### PR TITLE
Small build and doc improvements

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -52,6 +52,13 @@ Licenses of statically linked libraries:
 -  protobuf      2.5.0
 -  libqrencode   3.2.0
 
+System requirements
+--------------------
+
+C++ compilers are memory-hungry. It is recommended to have at least 1 GB of
+memory available when compiling Bitcoin Core. With 512MB of memory or less
+compilation will take much longer due to swap thrashing.
+
 Dependency Build Instructions: Ubuntu & Debian
 ----------------------------------------------
 Build requirements:

--- a/src/m4/ax_boost_chrono.m4
+++ b/src/m4/ax_boost_chrono.m4
@@ -81,6 +81,7 @@ AC_DEFUN([AX_BOOST_CHRONO],
 
 			LDFLAGS_SAVE=$LDFLAGS
             if test "x$ax_boost_user_chrono_lib" = "x"; then
+                ax_lib=
                 for libextension in `ls $BOOSTLIBDIR/libboost_chrono*.so* $BOOSTLIBDIR/libboost_chrono*.dylib* $BOOSTLIBDIR/libboost_chrono*.a* 2>/dev/null | sed 's,.*/,,' | sed -e 's;^lib\(boost_chrono.*\)\.so.*$;\1;' -e 's;^lib\(boost_chrono.*\)\.dylib.*$;\1;' -e 's;^lib\(boost_chrono.*\)\.a.*$;\1;'` ; do
                      ax_lib=${libextension}
 				    AC_CHECK_LIB($ax_lib, exit,
@@ -105,7 +106,7 @@ AC_DEFUN([AX_BOOST_CHRONO],
 
             fi
             if test "x$ax_lib" = "x"; then
-                AC_MSG_ERROR(Could not find a version of the library!)
+                AC_MSG_ERROR(Could not find a version of the boost_chrono library!)
             fi
 			if test "x$link_chrono" = "xno"; then
 				AC_MSG_ERROR(Could not link against $ax_lib !)

--- a/src/m4/ax_boost_filesystem.m4
+++ b/src/m4/ax_boost_filesystem.m4
@@ -80,6 +80,7 @@ AC_DEFUN([AX_BOOST_FILESYSTEM],
 		if test "x$ax_cv_boost_filesystem" = "xyes"; then
 			AC_DEFINE(HAVE_BOOST_FILESYSTEM,,[define if the Boost::Filesystem library is available])
             BOOSTLIBDIR=`echo $BOOST_LDFLAGS | sed -e 's/@<:@^\/@:>@*//'`
+            ax_lib=
             if test "x$ax_boost_user_filesystem_lib" = "x"; then
                 for libextension in `ls -r $BOOSTLIBDIR/libboost_filesystem* 2>/dev/null | sed 's,.*/lib,,' | sed 's,\..*,,'` ; do
                      ax_lib=${libextension}
@@ -104,7 +105,7 @@ AC_DEFUN([AX_BOOST_FILESYSTEM],
 
             fi
             if test "x$ax_lib" = "x"; then
-                AC_MSG_ERROR(Could not find a version of the library!)
+                AC_MSG_ERROR(Could not find a version of the boost_filesystem library!)
             fi
 			if test "x$link_filesystem" != "xyes"; then
 				AC_MSG_ERROR(Could not link against $ax_lib !)

--- a/src/m4/ax_boost_program_options.m4
+++ b/src/m4/ax_boost_program_options.m4
@@ -74,6 +74,7 @@ AC_DEFUN([AX_BOOST_PROGRAM_OPTIONS],
 				AC_DEFINE(HAVE_BOOST_PROGRAM_OPTIONS,,[define if the Boost::PROGRAM_OPTIONS library is available])
                   BOOSTLIBDIR=`echo $BOOST_LDFLAGS | sed -e 's/@<:@^\/@:>@*//'`
                 if test "x$ax_boost_user_program_options_lib" = "x"; then
+                ax_lib=
                 for libextension in `ls $BOOSTLIBDIR/libboost_program_options*.so* 2>/dev/null | sed 's,.*/,,' | sed -e 's;^lib\(boost_program_options.*\)\.so.*$;\1;'` `ls $BOOSTLIBDIR/libboost_program_options*.dylib* 2>/dev/null | sed 's,.*/,,' | sed -e 's;^lib\(boost_program_options.*\)\.dylib.*$;\1;'` `ls $BOOSTLIBDIR/libboost_program_options*.a* 2>/dev/null | sed 's,.*/,,' | sed -e 's;^lib\(boost_program_options.*\)\.a.*$;\1;'` ; do
                      ax_lib=${libextension}
 				    AC_CHECK_LIB($ax_lib, exit,
@@ -96,7 +97,7 @@ AC_DEFUN([AX_BOOST_PROGRAM_OPTIONS],
                   done
                 fi
             if test "x$ax_lib" = "x"; then
-                AC_MSG_ERROR(Could not find a version of the library!)
+                AC_MSG_ERROR(Could not find a version of the boost_program_options library!)
             fi
 				if test "x$link_program_options" != "xyes"; then
 					AC_MSG_ERROR([Could not link against [$ax_lib] !])

--- a/src/m4/ax_boost_system.m4
+++ b/src/m4/ax_boost_system.m4
@@ -83,6 +83,7 @@ AC_DEFUN([AX_BOOST_SYSTEM],
 
 			LDFLAGS_SAVE=$LDFLAGS
             if test "x$ax_boost_user_system_lib" = "x"; then
+                ax_lib=
                 for libextension in `ls -r $BOOSTLIBDIR/libboost_system* 2>/dev/null | sed 's,.*/lib,,' | sed 's,\..*,,'` ; do
                      ax_lib=${libextension}
 				    AC_CHECK_LIB($ax_lib, exit,
@@ -107,7 +108,7 @@ AC_DEFUN([AX_BOOST_SYSTEM],
 
             fi
             if test "x$ax_lib" = "x"; then
-                AC_MSG_ERROR(Could not find a version of the library!)
+                AC_MSG_ERROR(Could not find a version of the boost_system library!)
             fi
 			if test "x$link_system" = "xno"; then
 				AC_MSG_ERROR(Could not link against $ax_lib !)

--- a/src/m4/ax_boost_thread.m4
+++ b/src/m4/ax_boost_thread.m4
@@ -104,6 +104,7 @@ AC_DEFUN([AX_BOOST_THREAD],
                           ;;
                         esac
             if test "x$ax_boost_user_thread_lib" = "x"; then
+                ax_lib=
                 for libextension in `ls -r $BOOSTLIBDIR/libboost_thread* 2>/dev/null | sed 's,.*/lib,,' | sed 's,\..*,,'`; do
                      ax_lib=${libextension}
 				    AC_CHECK_LIB($ax_lib, exit,
@@ -128,7 +129,7 @@ AC_DEFUN([AX_BOOST_THREAD],
 
             fi
             if test "x$ax_lib" = "x"; then
-                AC_MSG_ERROR(Could not find a version of the library!)
+                AC_MSG_ERROR(Could not find a version of the boost_thread library!)
             fi
 			if test "x$link_thread" = "xno"; then
 				AC_MSG_ERROR(Could not link against $ax_lib !)

--- a/src/m4/ax_boost_unit_test_framework.m4
+++ b/src/m4/ax_boost_unit_test_framework.m4
@@ -76,6 +76,7 @@ AC_DEFUN([AX_BOOST_UNIT_TEST_FRAMEWORK],
 
             if test "x$ax_boost_user_unit_test_framework_lib" = "x"; then
 			saved_ldflags="${LDFLAGS}"
+                ax_lib=
                 for monitor_library in `ls $BOOSTLIBDIR/libboost_unit_test_framework*.so* $BOOSTLIBDIR/libboost_unit_test_framework*.dylib* $BOOSTLIBDIR/libboost_unit_test_framework*.a* 2>/dev/null` ; do
                     if test -r $monitor_library ; then
                        libextension=`echo $monitor_library | sed 's,.*/,,' | sed -e 's;^lib\(boost_unit_test_framework.*\)\.so.*$;\1;' -e 's;^lib\(boost_unit_test_framework.*\)\.dylib.*$;\1;' -e 's;^lib\(boost_unit_test_framework.*\)\.a.*$;\1;'`
@@ -124,7 +125,7 @@ AC_DEFUN([AX_BOOST_UNIT_TEST_FRAMEWORK],
                done
             fi
             if test "x$ax_lib" = "x"; then
-                AC_MSG_ERROR(Could not find a version of the library!)
+                AC_MSG_ERROR(Could not find a version of the boost_unit_test_framework library!)
             fi
 			if test "x$link_unit_test_framework" != "xyes"; then
 				AC_MSG_ERROR(Could not link against $ax_lib !)

--- a/src/qt/Makefile.am
+++ b/src/qt/Makefile.am
@@ -276,7 +276,6 @@ BITCOIN_QT_CPP = \
   qvalidatedlineedit.cpp \
   qvaluecombobox.cpp \
   rpcconsole.cpp \
-  signverifymessagedialog.cpp \
   splashscreen.cpp \
   trafficgraphwidget.cpp \
   utilitydialog.cpp
@@ -298,6 +297,7 @@ BITCOIN_QT_CPP += \
   recentrequeststablemodel.cpp \
   sendcoinsdialog.cpp \
   sendcoinsentry.cpp \
+  signverifymessagedialog.cpp \
   transactiondesc.cpp \
   transactiondescdialog.cpp \
   transactionfilterproxy.cpp \

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -25,7 +25,9 @@
 #include "rpcserver.h"
 #include "ui_interface.h"
 #include "util.h"
+#ifdef ENABLE_WALLET
 #include "wallet.h"
+#endif
 
 #include <stdint.h>
 


### PR DESCRIPTION
- Improve error reporting when missing boost libraries (avoid 'Could not link against' with the wrong library name and unspecific 'Could not find a version of _the_ library')
- Add note about memory requirements for compilation
- Don't require db_cxx.h when wallet disable (Fix #3978)
