### PR TITLE
Add application category for OSX

### DIFF
--- a/share/qt/Info.plist.in
+++ b/share/qt/Info.plist.in
@@ -90,5 +90,8 @@
 
   <key>NSHighResolutionCapable</key>
     <string>True</string>
+
+  <key>LSApplicationCategoryType</key>
+    <string>public.app-category.finance</string>
 </dict>
 </plist>


### PR DESCRIPTION
In "View by Category" without this metadata the app gets sorted into "Other" at the bottom.
