### PR TITLE
Less getblocks zeros

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3652,7 +3652,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
         if (pindex)
             pindex = chainActive.Next(pindex);
         int nLimit = 500;
-        LogPrint("net", "getblocks %d to %s limit %d\n", (pindex ? pindex->nHeight : -1), hashStop.ToString(), nLimit);
+        LogPrint("net", "getblocks %d to %s limit %d\n", (pindex ? pindex->nHeight : -1), hashStop==uint256(0) ? "end" : hashStop.ToString(), nLimit);
         for (; pindex; pindex = chainActive.Next(pindex))
         {
             if (pindex->GetBlockHash() == hashStop)


### PR DESCRIPTION
Change these lines:

getblocks 293326 to 0000000000000000000000000000000000000000000000000000000000000000 limit 500

to these lines:

getblocks 293326 to end limit 500

(i.e. no need to display an expanded hash of NULL)
