### PR TITLE
Make CCryptoKeyStore::Unlock check all keys.

### DIFF
--- a/src/crypter.cpp
+++ b/src/crypter.cpp
@@ -152,6 +152,8 @@ bool CCryptoKeyStore::Unlock(const CKeyingMaterial& vMasterKeyIn)
         if (!SetCrypted())
             return false;
 
+        bool keyPass = false;
+        bool keyFail = false;
         CryptedKeyMap::const_iterator mi = mapCryptedKeys.begin();
         for (; mi != mapCryptedKeys.end(); ++mi)
         {
@@ -159,15 +161,31 @@ bool CCryptoKeyStore::Unlock(const CKeyingMaterial& vMasterKeyIn)
             const std::vector<unsigned char> &vchCryptedSecret = (*mi).second.second;
             CKeyingMaterial vchSecret;
             if(!DecryptSecret(vMasterKeyIn, vchCryptedSecret, vchPubKey.GetHash(), vchSecret))
-                return false;
+            {
+                keyFail = true;
+                break;
+            }
             if (vchSecret.size() != 32)
-                return false;
+            {
+                keyFail = true;
+                break;
+            }
             CKey key;
             key.Set(vchSecret.begin(), vchSecret.end(), vchPubKey.IsCompressed());
-            if (key.GetPubKey() == vchPubKey)
+            if (key.GetPubKey() != vchPubKey)
+            {
+                keyFail = true;
                 break;
-            return false;
+            }
+            keyPass = true;
         }
+        if (keyPass && keyFail)
+        {
+            LogPrintf("The wallet is probably corrupted: Some keys decrypt but not all.");
+            assert(false);
+        }
+        if (keyFail || !keyPass)
+            return false;
         vMasterKey = vMasterKeyIn;
     }
     NotifyStatusChanged(this);


### PR DESCRIPTION
CCryptoKeyStore::Unlock has a loop to attempt decrypting each key which
 only executes once, likely due to a simple mistake when the code was
 originally written.

This patch fixes the behavior by making it check all keys. It also adds
 a fatal assertion in the case some decrypt but some do not, since that
 indicates that the wallet is in some kind of really bad state.

This may make unlocking noticeably slower on wallets with many keys.
