### PR TITLE
build: Sync ax_boost_base.m4 with upstream.

### DIFF
--- a/src/m4/ax_boost_base.m4
+++ b/src/m4/ax_boost_base.m4
@@ -33,7 +33,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 22
+#serial 23
 
 AC_DEFUN([AX_BOOST_BASE],
 [
@@ -102,6 +102,12 @@ if test "x$want_boost" = "xyes"; then
     dnl are almost assuredly the ones desired.
     AC_REQUIRE([AC_CANONICAL_HOST])
     libsubdirs="lib/${host_cpu}-${host_os} $libsubdirs"
+
+    case ${host_cpu} in
+      i?86)
+        libsubdirs="lib/i386-${host_os} $libsubdirs"
+        ;;
+    esac
 
     dnl first we check the system location for boost libraries
     dnl this location ist chosen if boost libraries are installed with the --layout=system option


### PR DESCRIPTION
This should fix 32bit boost detection on Ubuntu Saucy+. Fixes #3945.
