### PR TITLE
doc: remove versions from build-unix.md, just refer to release-process.md

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -42,15 +42,7 @@ Licenses of statically linked libraries:
  Boost         MIT-like license
  miniupnpc     New (3-clause) BSD license
 
-- Versions used in this release:
--  GCC           4.3.3
--  OpenSSL       1.0.1c
--  Berkeley DB   4.8.30.NC
--  Boost         1.55
--  miniupnpc     1.6
--  qt            4.8.3
--  protobuf      2.5.0
--  libqrencode   3.2.0
+- For the versions used in this release, see doc/release-process.md under *Fetch and build inputs*.
 
 System requirements
 --------------------


### PR DESCRIPTION
No one bothers to keep this up to date. It's easy to forget, and doesn't scale to more platforms.
Better to refer to another file than give wrong information.
