### PR TITLE
Changed bitrpc.py's raw_input to getpass for passwords to conceal command line input

### DIFF
--- a/contrib/bitrpc/bitrpc.py
+++ b/contrib/bitrpc/bitrpc.py
@@ -1,6 +1,7 @@
 from jsonrpc import ServiceProxy
 import sys
 import string
+import getpass
 
 # ===== BEGIN USER SETTINGS =====
 # if you do not set these you will be prompted for a password for every command
@@ -302,7 +303,7 @@ elif cmd == "validateaddress":
 
 elif cmd == "walletpassphrase":
     try:
-        pwd = raw_input("Enter wallet passphrase: ")
+        pwd = getpass.getpass(prompt="Enter wallet passphrase: ")
         access.walletpassphrase(pwd, 60)
         print "\n---Wallet unlocked---\n"
     except:
@@ -310,8 +311,8 @@ elif cmd == "walletpassphrase":
 
 elif cmd == "walletpassphrasechange":
     try:
-        pwd = raw_input("Enter old wallet passphrase: ")
-        pwd2 = raw_input("Enter new wallet passphrase: ")
+        pwd = getpass.getpass(prompt="Enter old wallet passphrase: ")
+        pwd2 = getpass.getpass(prompt="Enter new wallet passphrase: ")
         access.walletpassphrasechange(pwd, pwd2)
         print
         print "\n---Passphrase changed---\n"


### PR DESCRIPTION
Changed bitrpc.py's raw_input to getpass for passwords to conceal characters during command line input. Getpass is in Python stdlib so no additional dependencies required.

(first PR to Bitcoin, so hope the PR process and feature branch naming is OK -- I modelled the feature branch name format after laanwj's)
