### PR TITLE
Prevent socket leak in ThreadSocketHandler.

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -946,11 +946,7 @@ void ThreadSocketHandler()
             }
             else if (nInbound >= nMaxConnections - MAX_OUTBOUND_CONNECTIONS)
             {
-                {
-                    LOCK(cs_setservAddNodeAddresses);
-                    if (!setservAddNodeAddresses.count(addr))
-                        closesocket(hSocket);
-                }
+                closesocket(hSocket);
             }
             else if (CNode::IsBanned(addr))
             {

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -293,8 +293,10 @@ bool static Socks5(string strDest, int port, SOCKET& hSocket)
         case 0x03:
         {
             ret = recv(hSocket, pchRet3, 1, 0) != 1;
-            if (ret)
+            if (ret) {
+                closesocket(hSocket);
                 return error("Error reading from proxy");
+            }
             int nRecv = pchRet3[0];
             ret = recv(hSocket, pchRet3, nRecv, 0) != nRecv;
             break;
@@ -501,6 +503,7 @@ bool ConnectSocket(const CService &addrDest, SOCKET& hSocketRet, int nTimeout)
             return false;
         break;
     default:
+        closesocket(hSocket);
         return false;
     }
 
@@ -532,7 +535,9 @@ bool ConnectSocketByName(CService &addr, SOCKET& hSocketRet, const char *pszDest
 
     switch(nameproxy.second) {
         default:
-        case 4: return false;
+        case 4:
+            closesocket(hSocket);
+            return false;
         case 5:
             if (!Socks5(strDest, port, hSocket))
                 return false;


### PR DESCRIPTION
When we are over our outbound limit ThreadSocketHandler would try to
 keep the connection if the peer was addnoded.

This didn't actually work for two reasons: It didn't actually run
 the accept code due to mistaken code flow, and because we have a
 limited number of outbound semaphores it couldn't actually use the
 connection.

Instead it leaked the socket, which might have caused issue #4034.

This patch just takes out the non-functioning white-listing for now.
