### PR TITLE
Fixed very misleading Hebrew translation

### DIFF
--- a/src/qt/locale/bitcoin_he.ts
+++ b/src/qt/locale/bitcoin_he.ts
@@ -1244,7 +1244,7 @@ Address: %4
     <message>
         <location line="+6"/>
         <source>Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB.</source>
-        <translation>עמלת פעולה אופציונלית לכל kB תבטיח שהפעולה שלך תעובד בזריזות. רוב הפעולות הן 1 kB. מומלצת עמלה בסך 0.01.</translation>
+        <translation>עמלת פעולה אופציונלית לכל kB תבטיח שהפעולה שלך תעובד בזריזות. רוב הפעולות הן 1 kB.</translation>
     </message>
     <message>
         <location line="+15"/>


### PR DESCRIPTION
Someone took the liberty of adding the following text in Hebrew to the message about optional transaction fees: "The recommended fee is 0.01."
First, this recommendation does not appear in the English text.
Second, this is extremely misleading, since the default unit for the fee input field is BTC, and the recommendation is thus interpreted as "0.01 BTC", which is outrageous.
Naive users who would accept this suggestion would lose money, so I ask that this be merged quickly.
