### PR TITLE
Encapsulate coin balances within a new CMoney type.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -48,6 +48,7 @@ BITCOIN_CORE_H = \
   limitedmap.h \
   main.h \
   miner.h \
+  money.h \
   mruset.h \
   netbase.h \
   net.h \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -128,6 +128,7 @@ libbitcoin_common_a_SOURCES = \
   core.cpp \
   hash.cpp \
   key.cpp \
+  money.cpp \
   netbase.cpp \
   protocol.cpp \
   rpcprotocol.cpp \

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -189,7 +189,7 @@ double CCoinsViewCache::GetPriority(const CTransaction &tx, int nHeight)
         const CCoins &coins = GetCoins(txin.prevout.hash);
         if (!coins.IsAvailable(txin.prevout.n)) continue;
         if (coins.nHeight < nHeight) {
-            dResult += coins.vout[txin.prevout.n].nValue * (nHeight-coins.nHeight);
+            dResult += coins.vout[txin.prevout.n].nValue.ToDouble() * (nHeight-coins.nHeight);
         }
     }
     return tx.ComputePriority(dResult);

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -146,12 +146,12 @@ const CTxOut &CCoinsViewCache::GetOutputFor(const CTxIn& input)
     return coins.vout[input.prevout.n];
 }
 
-int64_t CCoinsViewCache::GetValueIn(const CTransaction& tx)
+CMoney CCoinsViewCache::GetValueIn(const CTransaction& tx)
 {
     if (tx.IsCoinBase())
         return 0;
 
-    int64_t nResult = 0;
+    CMoney nResult = 0;
     for (unsigned int i = 0; i < tx.vin.size(); i++)
         nResult += GetOutputFor(tx.vin[i]).nValue;
 

--- a/src/coins.h
+++ b/src/coins.h
@@ -248,7 +248,7 @@ struct CCoinsStats
     uint64_t nTransactionOutputs;
     uint64_t nSerializedSize;
     uint256 hashSerialized;
-    int64_t nTotalAmount;
+    CMoney nTotalAmount;
 
     CCoinsStats() : nHeight(0), hashBlock(0), nTransactions(0), nTransactionOutputs(0), nSerializedSize(0), hashSerialized(0), nTotalAmount(0) {}
 };
@@ -341,7 +341,7 @@ public:
         @param[in] tx	transaction for which we are checking input total
         @return	Sum of value of all inputs (scriptSigs)
      */
-    int64_t GetValueIn(const CTransaction& tx);
+    CMoney GetValueIn(const CTransaction& tx);
 
     // Check whether all prevouts of the transaction are present in the UTXO set represented by this view
     bool HaveInputs(const CTransaction& tx);

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -64,7 +64,7 @@ uint256 CTxOut::GetHash() const
 
 std::string CTxOut::ToString() const
 {
-    return strprintf("CTxOut(nValue=%d.%08d, scriptPubKey=%s)", nValue / COIN, nValue % COIN, scriptPubKey.ToString().substr(0,30));
+    return strprintf("CTxOut(nValue=%s, scriptPubKey=%s)", FormatMoney(nValue), scriptPubKey.ToString().substr(0,30));
 }
 
 void CTxOut::print() const
@@ -156,60 +156,6 @@ std::string CTransaction::ToString() const
 void CTransaction::print() const
 {
     LogPrintf("%s", ToString());
-}
-
-// Amount compression:
-// * If the amount is 0, output 0
-// * first, divide the amount (in base units) by the largest power of 10 possible; call the exponent e (e is max 9)
-// * if e<9, the last digit of the resulting number cannot be 0; store it as d, and drop it (divide by 10)
-//   * call the result n
-//   * output 1 + 10*(9*n + d - 1) + e
-// * if e==9, we only know the resulting number is not zero, so output 1 + 10*(n - 1) + 9
-// (this is decodable, as d is in [1-9] and e is in [0-9])
-
-uint64_t CTxOutCompressor::CompressAmount(uint64_t n)
-{
-    if (n == 0)
-        return 0;
-    int e = 0;
-    while (((n % 10) == 0) && e < 9) {
-        n /= 10;
-        e++;
-    }
-    if (e < 9) {
-        int d = (n % 10);
-        assert(d >= 1 && d <= 9);
-        n /= 10;
-        return 1 + (n*9 + d - 1)*10 + e;
-    } else {
-        return 1 + (n - 1)*10 + 9;
-    }
-}
-
-uint64_t CTxOutCompressor::DecompressAmount(uint64_t x)
-{
-    // x = 0  OR  x = 1+10*(9*n + d - 1) + e  OR  x = 1+10*(n - 1) + 9
-    if (x == 0)
-        return 0;
-    x--;
-    // x = 10*(9*n + d - 1) + e
-    int e = x % 10;
-    x /= 10;
-    uint64_t n = 0;
-    if (e < 9) {
-        // x = 9*n + d - 1
-        int d = (x % 9) + 1;
-        x /= 9;
-        // x = n
-        n = x*10 + d;
-    } else {
-        n = x+1;
-    }
-    while (e) {
-        n *= 10;
-        e--;
-    }
-    return n;
 }
 
 uint256 CBlockHeader::GetHash() const

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -51,7 +51,7 @@ void CTxIn::print() const
     LogPrintf("%s\n", ToString());
 }
 
-CTxOut::CTxOut(int64_t nValueIn, CScript scriptPubKeyIn)
+CTxOut::CTxOut(const CMoney& nValueIn, CScript scriptPubKeyIn)
 {
     nValue = nValueIn;
     scriptPubKey = scriptPubKeyIn;
@@ -106,9 +106,9 @@ bool CTransaction::IsNewerThan(const CTransaction& old) const
     return fNewer;
 }
 
-int64_t CTransaction::GetValueOut() const
+CMoney CTransaction::GetValueOut() const
 {
-    int64_t nValueOut = 0;
+    CMoney nValueOut = 0;
     BOOST_FOREACH(const CTxOut& txout, vout)
     {
         nValueOut += txout.nValue;

--- a/src/core.h
+++ b/src/core.h
@@ -15,8 +15,8 @@
 class CTransaction;
 
 /** No amount larger than this (in satoshi) is valid */
-static const int64_t MAX_MONEY = 21000000 * COIN;
-inline bool MoneyRange(int64_t nValue) { return (nValue >= 0 && nValue <= MAX_MONEY); }
+static const CMoney MAX_MONEY = 21000000 * COIN;
+inline bool MoneyRange(const CMoney& nValue) { return (nValue >= 0 && nValue <= MAX_MONEY); }
 
 /** An outpoint - a combination of a transaction hash and an index n into its vout */
 class COutPoint
@@ -119,7 +119,7 @@ public:
 class CTxOut
 {
 public:
-    int64_t nValue;
+    CMoney nValue;
     CScript scriptPubKey;
 
     CTxOut()
@@ -127,7 +127,7 @@ public:
         SetNull();
     }
 
-    CTxOut(int64_t nValueIn, CScript scriptPubKeyIn);
+    CTxOut(const CMoney& nValueIn, CScript scriptPubKeyIn);
 
     IMPLEMENT_SERIALIZE
     (
@@ -148,7 +148,7 @@ public:
 
     uint256 GetHash() const;
 
-    bool IsDust(int64_t nMinRelayTxFee) const
+    bool IsDust(const CMoney& nMinRelayTxFee) const
     {
         // "Dust" is defined in terms of CTransaction::nMinRelayTxFee,
         // which has units satoshis-per-kilobyte.
@@ -183,8 +183,8 @@ public:
 class CTransaction
 {
 public:
-    static int64_t nMinTxFee;
-    static int64_t nMinRelayTxFee;
+    static CMoney nMinTxFee;
+    static CMoney nMinRelayTxFee;
     static const int CURRENT_VERSION=1;
     int nVersion;
     std::vector<CTxIn> vin;
@@ -222,7 +222,7 @@ public:
     bool IsNewerThan(const CTransaction& old) const;
 
     // Return sum of txouts.
-    int64_t GetValueOut() const;
+    CMoney GetValueOut() const;
     // GetValueIn() is a method on CCoinsViewCache, because
     // inputs must be known to compute value in.
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -558,7 +558,7 @@ bool AppInit2(boost::thread_group& threadGroup)
     // cost to you of processing a transaction.
     if (mapArgs.count("-mintxfee"))
     {
-        int64_t n = 0;
+        CMoney n = 0;
         if (ParseMoney(mapArgs["-mintxfee"], n) && n > 0)
             CTransaction::nMinTxFee = n;
         else
@@ -566,7 +566,7 @@ bool AppInit2(boost::thread_group& threadGroup)
     }
     if (mapArgs.count("-minrelaytxfee"))
     {
-        int64_t n = 0;
+        CMoney n = 0;
         if (ParseMoney(mapArgs["-minrelaytxfee"], n) && n > 0)
             CTransaction::nMinRelayTxFee = n;
         else

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -50,9 +50,9 @@ bool fTxIndex = false;
 unsigned int nCoinCacheSize = 5000;
 
 /** Fees smaller than this (in satoshi) are considered zero fee (for transaction creation) */
-int64_t CTransaction::nMinTxFee = 10000;  // Override with -mintxfee
+CMoney CTransaction::nMinTxFee = 10000;  // Override with -mintxfee
 /** Fees smaller than this (in satoshi) are considered zero fee (for relaying and mining) */
-int64_t CTransaction::nMinRelayTxFee = 1000;
+CMoney CTransaction::nMinRelayTxFee = 1000;
 
 struct COrphanBlock {
     uint256 hashBlock;
@@ -739,7 +739,7 @@ bool CheckTransaction(const CTransaction& tx, CValidationState &state)
                          REJECT_INVALID, "bad-txns-oversize");
 
     // Check for negative or overflow output values
-    int64_t nValueOut = 0;
+    CMoney nValueOut = 0;
     BOOST_FOREACH(const CTxOut& txout, tx.vout)
     {
         if (txout.nValue < 0)
@@ -781,12 +781,12 @@ bool CheckTransaction(const CTransaction& tx, CValidationState &state)
     return true;
 }
 
-int64_t GetMinFee(const CTransaction& tx, unsigned int nBytes, bool fAllowFree, enum GetMinFee_mode mode)
+CMoney GetMinFee(const CTransaction& tx, unsigned int nBytes, bool fAllowFree, enum GetMinFee_mode mode)
 {
     // Base fee is either nMinTxFee or nMinRelayTxFee
-    int64_t nBaseFee = (mode == GMF_RELAY) ? tx.nMinRelayTxFee : tx.nMinTxFee;
+    CMoney nBaseFee = (mode == GMF_RELAY) ? tx.nMinRelayTxFee : tx.nMinTxFee;
 
-    int64_t nMinFee = (1 + (int64_t)nBytes / 1000) * nBaseFee;
+    CMoney nMinFee = (1 + nBytes / 1000) * nBaseFee;
 
     if (fAllowFree)
     {
@@ -901,16 +901,16 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
         // you should add code here to check that the transaction does a
         // reasonable number of ECDSA signature verifications.
 
-        int64_t nValueIn = view.GetValueIn(tx);
-        int64_t nValueOut = tx.GetValueOut();
-        int64_t nFees = nValueIn-nValueOut;
+        CMoney nValueIn = view.GetValueIn(tx);
+        CMoney nValueOut = tx.GetValueOut();
+        CMoney nFees = nValueIn-nValueOut;
         double dPriority = view.GetPriority(tx, chainActive.Height());
 
         CTxMemPoolEntry entry(tx, nFees, GetTime(), dPriority, chainActive.Height());
         unsigned int nSize = entry.GetTxSize();
 
         // Don't accept it if it can't get into a block
-        int64_t txMinFee = GetMinFee(tx, nSize, true, GMF_RELAY);
+        CMoney txMinFee = GetMinFee(tx, nSize, true, GMF_RELAY);
         if (fLimitFree && nFees < txMinFee)
             return state.DoS(0, error("AcceptToMemoryPool : not enough fees %s, %d < %d",
                                       hash.ToString(), nFees, txMinFee),
@@ -1182,7 +1182,7 @@ void static PruneOrphanBlocks()
     mapOrphanBlocks.erase(hash);
 }
 
-int64_t GetBlockValue(int nHeight, int64_t nFees)
+CMoney GetBlockValue(int nHeight, const CMoney& nFees)
 {
     int64_t nSubsidy = 50 * COIN;
     int halvings = nHeight / Params().SubsidyHalvingInterval();
@@ -1529,8 +1529,8 @@ bool CheckInputs(const CTransaction& tx, CValidationState &state, CCoinsViewCach
         // This is also true for mempool checks.
         CBlockIndex *pindexPrev = mapBlockIndex.find(inputs.GetBestBlock())->second;
         int nSpendHeight = pindexPrev->nHeight + 1;
-        int64_t nValueIn = 0;
-        int64_t nFees = 0;
+        CMoney nValueIn = 0;
+        CMoney nFees = 0;
         for (unsigned int i = 0; i < tx.vin.size(); i++)
         {
             const COutPoint &prevout = tx.vin[i].prevout;
@@ -1557,7 +1557,7 @@ bool CheckInputs(const CTransaction& tx, CValidationState &state, CCoinsViewCach
                              REJECT_INVALID, "bad-txns-in-belowout");
 
         // Tally transaction fees
-        int64_t nTxFee = nValueIn - tx.GetValueOut();
+        CMoney nTxFee = nValueIn - tx.GetValueOut();
         if (nTxFee < 0)
             return state.DoS(100, error("CheckInputs() : %s nTxFee < 0", tx.GetHash().ToString()),
                              REJECT_INVALID, "bad-txns-fee-negative");
@@ -1790,7 +1790,7 @@ bool ConnectBlock(CBlock& block, CValidationState& state, CBlockIndex* pindex, C
     CCheckQueueControl<CScriptCheck> control(fScriptChecks && nScriptCheckThreads ? &scriptcheckqueue : NULL);
 
     int64_t nStart = GetTimeMicros();
-    int64_t nFees = 0;
+    CMoney nFees = 0;
     int nInputs = 0;
     unsigned int nSigOps = 0;
     CDiskTxPos pos(pindex->GetBlockPos(), GetSizeOfCompactSize(block.vtx.size()));

--- a/src/main.h
+++ b/src/main.h
@@ -166,7 +166,7 @@ std::string GetWarnings(std::string strFor);
 bool GetTransaction(const uint256 &hash, CTransaction &tx, uint256 &hashBlock, bool fAllowSlow = false);
 /** Find the best known block, and make it the tip of the block chain */
 bool ActivateBestChain(CValidationState &state);
-int64_t GetBlockValue(int nHeight, int64_t nFees);
+CMoney GetBlockValue(int nHeight, const CMoney& nFees);
 unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock);
 
 void UpdateTime(CBlockHeader& block, const CBlockIndex* pindexPrev);
@@ -259,7 +259,7 @@ enum GetMinFee_mode
     GMF_SEND,
 };
 
-int64_t GetMinFee(const CTransaction& tx, unsigned int nBytes, bool fAllowFree, enum GetMinFee_mode mode);
+CMoney GetMinFee(const CTransaction& tx, unsigned int nBytes, bool fAllowFree, enum GetMinFee_mode mode);
 
 //
 // Check transaction inputs, and make sure any
@@ -1098,7 +1098,7 @@ extern CBlockTreeDB *pblocktree;
 struct CBlockTemplate
 {
     CBlock block;
-    std::vector<int64_t> vTxFees;
+    std::vector<CMoney> vTxFees;
     std::vector<int64_t> vTxSigOps;
 };
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -202,7 +202,7 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn)
 
                 int nConf = pindexPrev->nHeight - coins.nHeight + 1;
 
-                dPriority += (double)nValueIn * nConf;
+                dPriority += nValueIn.ToDouble() * nConf;
             }
             if (fMissingInputs) continue;
 
@@ -213,7 +213,7 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn)
             // This is a more accurate fee-per-kilobyte than is used by the client code, because the
             // client code rounds up the size to the nearest 1K. That's good, because it gives an
             // incentive to create smaller transactions.
-            double dFeePerKb =  double(nTotalIn-tx.GetValueOut()) / (double(nTxSize)/1000.0);
+            double dFeePerKb = (nTotalIn-tx.GetValueOut()).ToDouble() / (double(nTxSize)/1000.0);
 
             if (porphan)
             {

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -140,7 +140,7 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn)
     nBlockMinSize = std::min(nBlockMaxSize, nBlockMinSize);
 
     // Collect memory pool transactions into the block
-    int64_t nFees = 0;
+    CMoney nFees = 0;
     {
         LOCK2(cs_main, mempool.cs);
         CBlockIndex* pindexPrev = chainActive.Tip();
@@ -163,7 +163,7 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn)
 
             COrphan* porphan = NULL;
             double dPriority = 0;
-            int64_t nTotalIn = 0;
+            CMoney nTotalIn = 0;
             bool fMissingInputs = false;
             BOOST_FOREACH(const CTxIn& txin, tx.vin)
             {
@@ -197,7 +197,7 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn)
                 }
                 const CCoins &coins = view.GetCoins(txin.prevout.hash);
 
-                int64_t nValueIn = coins.vout[txin.prevout.n].nValue;
+                CMoney nValueIn = coins.vout[txin.prevout.n].nValue;
                 nTotalIn += nValueIn;
 
                 int nConf = pindexPrev->nHeight - coins.nHeight + 1;
@@ -270,7 +270,7 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn)
             if (!view.HaveInputs(tx))
                 continue;
 
-            int64_t nTxFees = view.GetValueIn(tx)-tx.GetValueOut();
+            CMoney nTxFees = view.GetValueIn(tx)-tx.GetValueOut();
 
             nTxSigOps += GetP2SHSigOpCount(tx, view);
             if (nBlockSigOps + nTxSigOps >= MAX_BLOCK_SIGOPS)

--- a/src/money.cpp
+++ b/src/money.cpp
@@ -1,0 +1,60 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2014 The Bitcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "money.h"
+
+// Amount compression:
+// * If the amount is 0, output 0
+// * first, divide the amount (in base units) by the largest power of 10 possible; call the exponent e (e is max 9)
+// * if e<9, the last digit of the resulting number cannot be 0; store it as d, and drop it (divide by 10)
+//   * call the result n
+//   * output 1 + 10*(9*n + d - 1) + e
+// * if e==9, we only know the resulting number is not zero, so output 1 + 10*(n - 1) + 9
+// (this is decodable, as d is in [1-9] and e is in [0-9])
+
+uint64_t CCompressedMoney::CompressAmount(uint64_t n)
+{
+    if (n == 0)
+        return 0;
+    int e = 0;
+    while (((n % 10) == 0) && e < 9) {
+        n /= 10;
+        e++;
+    }
+    if (e < 9) {
+        int d = (n % 10);
+        assert(d >= 1 && d <= 9);
+        n /= 10;
+        return 1 + (n*9 + d - 1)*10 + e;
+    } else {
+        return 1 + (n - 1)*10 + 9;
+    }
+}
+
+uint64_t CCompressedMoney::DecompressAmount(uint64_t x)
+{
+    // x = 0  OR  x = 1+10*(9*n + d - 1) + e  OR  x = 1+10*(n - 1) + 9
+    if (x == 0)
+        return 0;
+    x--;
+    // x = 10*(9*n + d - 1) + e
+    int e = x % 10;
+    x /= 10;
+    uint64_t n = 0;
+    if (e < 9) {
+        // x = 9*n + d - 1
+        int d = (x % 9) + 1;
+        x /= 9;
+        // x = n
+        n = x*10 + d;
+    } else {
+        n = x+1;
+    }
+    while (e) {
+        n *= 10;
+        e--;
+    }
+    return n;
+}

--- a/src/money.h
+++ b/src/money.h
@@ -1,0 +1,13 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2014 The Bitcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_MONEY_H
+#define BITCOIN_MONEY_H
+
+#include <stdint.h>
+
+typedef int64_t CMoney;
+
+#endif

--- a/src/money.h
+++ b/src/money.h
@@ -6,8 +6,224 @@
 #ifndef BITCOIN_MONEY_H
 #define BITCOIN_MONEY_H
 
-#include <stdint.h>
+#include "serialize.h"
 
-typedef int64_t CMoney;
+#include <algorithm> // for swap
+#include <stdint.h>
+#include <stdexcept>
+#include <string>
+
+enum RoundingMode
+{
+    ROUND_TIES_TO_EVEN,
+    ROUND_TOWARDS_ZERO,
+    ROUND_AWAY_FROM_ZERO,
+    ROUND_TOWARD_POSITIVE,
+    ROUND_TOWARD_NEGATIVE,
+    ROUND_SIGNAL,
+};
+
+class money_error : public std::runtime_error
+{
+public:
+    explicit money_error(const std::string& str)
+        : std::runtime_error(str) {}
+};
+
+class invalid_money_format : public money_error
+{
+public:
+    explicit invalid_money_format(const std::string& str)
+        : money_error(str) {}
+};
+
+class money_overflow : public money_error
+                     , public std::overflow_error
+{
+public:
+    explicit money_overflow(const std::string& str)
+        : money_error(str)
+        , std::overflow_error(str) {}
+};
+
+class money_underflow : public money_error
+                      , public std::underflow_error
+{
+public:
+    explicit money_underflow(const std::string& str)
+        : money_error(str)
+        , std::underflow_error(str) {}
+};
+
+class CMoney
+{
+protected:
+    int64_t n;
+
+public:
+    CMoney() : n(0) {}
+    CMoney(int64_t nIn) : n(nIn) {}
+    CMoney(const CMoney& other) : n(other.n) {}
+
+    CMoney& operator=(const CMoney& other)
+    {
+        n = other.n;
+        return *this;
+    }
+
+    CMoney& swap(CMoney& other)
+    {
+        std::swap(n, other.n);
+        return *this;
+    }
+
+    // In units of 1 satoshi
+    double ToDouble(RoundingMode mode=ROUND_TIES_TO_EVEN) const
+    {
+        return static_cast<double>(n);
+    }
+
+    // In units of 1 satoshi
+    int64_t ToInt64(RoundingMode mode=ROUND_TIES_TO_EVEN) const
+    {
+        return n;
+    }
+
+    CMoney& operator+=(const CMoney& other)
+    {
+        n += other.n;
+        return *this;
+    }
+
+    CMoney& operator-=(const CMoney& other)
+    {
+        n -= other.n;
+        return *this;
+    }
+
+    CMoney& operator*=(int64_t other)
+    {
+        n *= other;
+        return *this;
+    }
+
+    friend std::ostream& operator<<(std::ostream &o, const CMoney& n);
+
+    friend bool operator! (const CMoney& a);
+    friend bool operator< (const CMoney& a, const CMoney& b);
+    friend bool operator<=(const CMoney& a, const CMoney& b);
+    friend bool operator==(const CMoney& a, const CMoney& b);
+    friend bool operator!=(const CMoney& a, const CMoney& b);
+    friend bool operator>=(const CMoney& a, const CMoney& b);
+    friend bool operator> (const CMoney& a, const CMoney& b);
+
+    friend const CMoney operator-(const CMoney& a);
+    friend const CMoney operator+(const CMoney& a, const CMoney& b);
+    friend const CMoney operator-(const CMoney& a, const CMoney& b);
+    friend const CMoney operator*(int64_t a, const CMoney& b);
+    friend const CMoney operator*(const CMoney& a, int64_t b);
+    friend const CMoney abs(const CMoney& a);
+};
+
+namespace std {
+template<> inline CMoney numeric_limits<CMoney>::min()
+    { return CMoney(std::numeric_limits<int64_t>::min()); }
+template<> inline CMoney numeric_limits<CMoney>::max()
+    { return CMoney(std::numeric_limits<int64_t>::max()); }
+}
+
+// Required by use of Boost unit testing libraries
+std::string FormatMoney(const CMoney& a, bool fPlus);
+inline std::ostream& operator<<(std::ostream &o, const CMoney& n)
+{
+    o << FormatMoney(n, false);
+    return o;
+}
+
+inline bool operator!(const CMoney& a)
+{
+    return a.n == 0;
+}
+
+inline bool operator<(const CMoney& a, const CMoney& b)
+{
+    return a.n < b.n;
+}
+
+inline bool operator<=(const CMoney& a, const CMoney& b)
+{
+    return a.n <= b.n;
+}
+
+inline bool operator==(const CMoney& a, const CMoney& b)
+{
+    return a.n == b.n;
+}
+
+inline bool operator!=(const CMoney& a, const CMoney& b)
+{
+    return a.n != b.n;
+}
+
+inline bool operator>=(const CMoney& a, const CMoney& b)
+{
+    return a.n >= b.n;
+}
+
+inline bool operator>(const CMoney& a, const CMoney& b)
+{
+    return a.n > b.n;
+}
+
+inline const CMoney operator-(const CMoney& a)
+{
+    return CMoney(-a.n);
+}
+
+inline const CMoney operator+(const CMoney& a, const CMoney& b)
+{
+    return CMoney(a.n + b.n);
+}
+
+inline const CMoney operator-(const CMoney& a, const CMoney& b)
+{
+    return CMoney(a.n - b.n);
+}
+
+inline const CMoney operator*(int64_t a, const CMoney& b)
+{
+    return CMoney(a * b.n);
+}
+
+inline const CMoney operator*(const CMoney& a, int64_t b)
+{
+    return CMoney(a.n * b);
+}
+
+inline const CMoney abs(const CMoney& a)
+{
+    return CMoney(std::abs(a.n));
+}
+
+class CCompressedMoney
+{
+protected:
+    CMoney& n;
+
+public:
+    static uint64_t CompressAmount(uint64_t nAmount);
+    static uint64_t DecompressAmount(uint64_t nAmount);
+
+    CCompressedMoney(CMoney& nIn) : n(nIn) {}
+
+    IMPLEMENT_SERIALIZE(
+        uint64_t nVal = 0;
+        if (fWrite)
+            nVal = CompressAmount(static_cast<uint64_t>(n.ToInt64(ROUND_SIGNAL)));
+        READWRITE(VARINT(nVal));
+        if (fRead)
+            n = static_cast<int64_t>(DecompressAmount(nVal));
+    )
+};
 
 #endif

--- a/src/qt/bitcoinamountfield.cpp
+++ b/src/qt/bitcoinamountfield.cpp
@@ -120,9 +120,9 @@ QWidget *BitcoinAmountField::setupTabChain(QWidget *prev)
     return unit;
 }
 
-qint64 BitcoinAmountField::value(bool *valid_out) const
+CMoney BitcoinAmountField::value(bool *valid_out) const
 {
-    qint64 val_out = 0;
+    CMoney val_out = 0;
     bool valid = BitcoinUnits::parse(currentUnit, text(), &val_out);
     if (valid_out)
     {
@@ -131,7 +131,7 @@ qint64 BitcoinAmountField::value(bool *valid_out) const
     return val_out;
 }
 
-void BitcoinAmountField::setValue(qint64 value)
+void BitcoinAmountField::setValue(const CMoney& value)
 {
     setText(BitcoinUnits::format(currentUnit, value));
 }
@@ -152,7 +152,7 @@ void BitcoinAmountField::unitChanged(int idx)
 
     // Parse current value and convert to new unit
     bool valid = false;
-    qint64 currentValue = value(&valid);
+    CMoney currentValue = value(&valid);
 
     currentUnit = newUnit;
 
@@ -179,7 +179,7 @@ void BitcoinAmountField::setDisplayUnit(int newUnit)
     unit->setValue(newUnit);
 }
 
-void BitcoinAmountField::setSingleStep(qint64 step)
+void BitcoinAmountField::setSingleStep(const CMoney& step)
 {
     nSingleStep = step;
     unitChanged(unit->currentIndex());

--- a/src/qt/bitcoinamountfield.cpp
+++ b/src/qt/bitcoinamountfield.cpp
@@ -159,7 +159,7 @@ void BitcoinAmountField::unitChanged(int idx)
     // Set max length after retrieving the value, to prevent truncation
     amount->setDecimals(BitcoinUnits::decimals(currentUnit));
     amount->setMaximum(qPow(10, BitcoinUnits::amountDigits(currentUnit)) - qPow(10, -amount->decimals()));
-    amount->setSingleStep((double)nSingleStep / (double)BitcoinUnits::factor(currentUnit));
+    amount->setSingleStep(nSingleStep.ToDouble() / (double)BitcoinUnits::factor(currentUnit));
 
     if (valid)
     {

--- a/src/qt/bitcoinamountfield.h
+++ b/src/qt/bitcoinamountfield.h
@@ -5,6 +5,8 @@
 #ifndef BITCOINAMOUNTFIELD_H
 #define BITCOINAMOUNTFIELD_H
 
+#include "money.h"
+
 #include <QWidget>
 
 QT_BEGIN_NAMESPACE
@@ -18,16 +20,16 @@ class BitcoinAmountField: public QWidget
 {
     Q_OBJECT
 
-    Q_PROPERTY(qint64 value READ value WRITE setValue NOTIFY textChanged USER true)
+    Q_PROPERTY(CMoney value READ value WRITE setValue NOTIFY textChanged USER true)
 
 public:
     explicit BitcoinAmountField(QWidget *parent = 0);
 
-    qint64 value(bool *valid=0) const;
-    void setValue(qint64 value);
+    CMoney value(bool *value=0) const;
+    void setValue(const CMoney& value);
 
     /** Set single step in satoshis **/
-    void setSingleStep(qint64 step);
+    void setSingleStep(const CMoney& step);
 
     /** Make read-only **/
     void setReadOnly(bool fReadOnly);
@@ -59,7 +61,7 @@ private:
     QDoubleSpinBox *amount;
     QValueComboBox *unit;
     int currentUnit;
-    qint64 nSingleStep;
+    CMoney nSingleStep;
 
     void setText(const QString &text);
     QString text() const;

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -822,7 +822,7 @@ void BitcoinGUI::closeEvent(QCloseEvent *event)
 }
 
 #ifdef ENABLE_WALLET
-void BitcoinGUI::incomingTransaction(const QString& date, int unit, qint64 amount, const QString& type, const QString& address)
+void BitcoinGUI::incomingTransaction(const QString& date, int unit, const CMoney& amount, const QString& type, const QString& address)
 {
     // On new transaction, make an info balloon
     message((amount)<0 ? tr("Sent transaction") : tr("Incoming transaction"),

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -9,6 +9,8 @@
 #include "bitcoin-config.h"
 #endif
 
+#include "money.h"
+
 #include <QMainWindow>
 #include <QMap>
 #include <QSystemTrayIcon>
@@ -151,7 +153,7 @@ public slots:
     bool handlePaymentRequest(const SendCoinsRecipient& recipient);
 
     /** Show incoming transaction notification for new transactions. */
-    void incomingTransaction(const QString& date, int unit, qint64 amount, const QString& type, const QString& address);
+    void incomingTransaction(const QString& date, int unit, const CMoney& amount, const QString& type, const QString& address);
 #endif
 
 private slots:

--- a/src/qt/bitcoinunits.cpp
+++ b/src/qt/bitcoinunits.cpp
@@ -6,6 +6,8 @@
 
 #include <QStringList>
 
+#include "util.h"
+
 BitcoinUnits::BitcoinUnits(QObject *parent):
         QAbstractListModel(parent),
         unitlist(availableUnits())
@@ -106,25 +108,12 @@ QString BitcoinUnits::format(int unit, const CMoney& n, bool fPlus)
     // localized number formatting.
     if(!valid(unit))
         return QString(); // Refuse to format invalid unit
-    qint64 coin = factor(unit);
-    int num_decimals = decimals(unit);
-    qint64 n_abs = (n > 0 ? n : -n);
-    qint64 quotient = n_abs / coin;
-    qint64 remainder = n_abs % coin;
-    QString quotient_str = QString::number(quotient);
-    QString remainder_str = QString::number(remainder).rightJustified(num_decimals, '0');
-
-    // Right-trim excess zeros after the decimal point
-    int nTrim = 0;
-    for (int i = remainder_str.size()-1; i>=2 && (remainder_str.at(i) == '0'); --i)
-        ++nTrim;
-    remainder_str.chop(nTrim);
-
-    if (n < 0)
-        quotient_str.insert(0, '-');
-    else if (fPlus && n > 0)
-        quotient_str.insert(0, '+');
-    return quotient_str + QString(".") + remainder_str;
+    CMoney q = n * (COIN / factor(unit));
+    std::string str = FormatMoney(q, fPlus);
+    int diff = 8 - decimals(unit);
+    if(diff > 0)
+        str.erase(str.length() - diff, diff);
+    return QString::fromStdString(str);
 }
 
 QString BitcoinUnits::formatWithUnit(int unit, const CMoney& amount, bool plussign)
@@ -134,37 +123,11 @@ QString BitcoinUnits::formatWithUnit(int unit, const CMoney& amount, bool plussi
 
 bool BitcoinUnits::parse(int unit, const QString &value, CMoney *val_out)
 {
-    if(!valid(unit) || value.isEmpty())
-        return false; // Refuse to parse invalid unit or empty string
-    int num_decimals = decimals(unit);
-    QStringList parts = value.split(".");
-
-    if(parts.size() > 2)
-    {
-        return false; // More than one dot
-    }
-    QString whole = parts[0];
-    QString decimals;
-
-    if(parts.size() > 1)
-    {
-        decimals = parts[1];
-    }
-    if(decimals.size() > num_decimals)
-    {
-        return false; // Exceeds max precision
-    }
-    bool ok = false;
-    QString str = whole + decimals.leftJustified(num_decimals, '0');
-
-    if(str.size() > 18)
-    {
-        return false; // Longer numbers will exceed 63 bits
-    }
-    qint64 retvalue = str.toLongLong(&ok);
+    CMoney ret_value = 0;
+    bool ok = ParseMoney(value.toStdString(), ret_value);
     if(val_out)
     {
-        *val_out = retvalue;
+        *val_out = ret_value * (factor(unit) / COIN);
     }
     return ok;
 }

--- a/src/qt/bitcoinunits.cpp
+++ b/src/qt/bitcoinunits.cpp
@@ -67,14 +67,14 @@ qint64 BitcoinUnits::factor(int unit)
     }
 }
 
-qint64 BitcoinUnits::maxAmount(int unit)
+CMoney BitcoinUnits::maxAmount(int unit)
 {
     switch(unit)
     {
-    case BTC:  return Q_INT64_C(21000000);
-    case mBTC: return Q_INT64_C(21000000000);
-    case uBTC: return Q_INT64_C(21000000000000);
-    default:   return 0;
+    case BTC:  return 21000000LL;
+    case mBTC: return 21000000000LL;
+    case uBTC: return 21000000000000LL;
+    default:   return 0LL;
     }
 }
 
@@ -100,7 +100,7 @@ int BitcoinUnits::decimals(int unit)
     }
 }
 
-QString BitcoinUnits::format(int unit, qint64 n, bool fPlus)
+QString BitcoinUnits::format(int unit, const CMoney& n, bool fPlus)
 {
     // Note: not using straight sprintf here because we do NOT want
     // localized number formatting.
@@ -127,12 +127,12 @@ QString BitcoinUnits::format(int unit, qint64 n, bool fPlus)
     return quotient_str + QString(".") + remainder_str;
 }
 
-QString BitcoinUnits::formatWithUnit(int unit, qint64 amount, bool plussign)
+QString BitcoinUnits::formatWithUnit(int unit, const CMoney& amount, bool plussign)
 {
     return format(unit, amount, plussign) + QString(" ") + name(unit);
 }
 
-bool BitcoinUnits::parse(int unit, const QString &value, qint64 *val_out)
+bool BitcoinUnits::parse(int unit, const QString &value, CMoney *val_out)
 {
     if(!valid(unit) || value.isEmpty())
         return false; // Refuse to parse invalid unit or empty string

--- a/src/qt/bitcoinunits.h
+++ b/src/qt/bitcoinunits.h
@@ -5,6 +5,8 @@
 #ifndef BITCOINUNITS_H
 #define BITCOINUNITS_H
 
+#include "money.h"
+
 #include <QAbstractListModel>
 #include <QString>
 
@@ -43,17 +45,17 @@ public:
     //! Number of Satoshis (1e-8) per unit
     static qint64 factor(int unit);
     //! Max amount per unit
-    static qint64 maxAmount(int unit);
+    static CMoney maxAmount(int unit);
     //! Number of amount digits (to represent max number of coins)
     static int amountDigits(int unit);
     //! Number of decimals left
     static int decimals(int unit);
     //! Format as string
-    static QString format(int unit, qint64 amount, bool plussign=false);
+    static QString format(int unit, const CMoney& amount, bool plussign=false);
     //! Format as string (with unit)
-    static QString formatWithUnit(int unit, qint64 amount, bool plussign=false);
+    static QString formatWithUnit(int unit, const CMoney& amount, bool plussign=false);
     //! Parse string to coin amount
-    static bool parse(int unit, const QString &value, qint64 *val_out);
+    static bool parse(int unit, const QString &value, CMoney *val_out);
     ///@}
 
     //! @name AbstractListModel implementation

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -494,7 +494,7 @@ void CoinControlDialog::updateLabels(WalletModel *model, QDialog* dialog)
         nAmount += out.tx->vout[out.i].nValue;
 
         // Priority
-        dPriorityInputs += (double)out.tx->vout[out.i].nValue * (out.nDepth+1);
+        dPriorityInputs += out.tx->vout[out.i].nValue.ToDouble() * (out.nDepth+1);
 
         // Bytes
         CTxDestination address;
@@ -731,7 +731,7 @@ void CoinControlDialog::updateView()
 
             // amount
             itemOutput->setText(COLUMN_AMOUNT, BitcoinUnits::format(nDisplayUnit, out.tx->vout[out.i].nValue));
-            itemOutput->setText(COLUMN_AMOUNT_INT64, strPad(QString::number(out.tx->vout[out.i].nValue), 15, " ")); // padding so that sorting works correctly
+            itemOutput->setText(COLUMN_AMOUNT_INT64, strPad(QString::number(EncodeDouble(out.tx->vout[out.i].nValue.ToDouble())), 20, " ")); // padding so that sorting works correctly
 
             // date
             itemOutput->setText(COLUMN_DATE, GUIUtil::dateTimeStr(out.tx->GetTxTime()));
@@ -741,10 +741,10 @@ void CoinControlDialog::updateView()
             itemOutput->setText(COLUMN_CONFIRMATIONS, strPad(QString::number(out.nDepth), 8, " "));
 
             // priority
-            double dPriority = ((double)out.tx->vout[out.i].nValue  / (nInputSize + 78)) * (out.nDepth+1); // 78 = 2 * 34 + 10
+            double dPriority = (out.tx->vout[out.i].nValue.ToDouble() / (nInputSize + 78)) * (out.nDepth+1); // 78 = 2 * 34 + 10
             itemOutput->setText(COLUMN_PRIORITY, CoinControlDialog::getPriorityLabel(dPriority));
             itemOutput->setText(COLUMN_PRIORITY_INT64, strPad(QString::number((int64_t)dPriority), 20, " "));
-            dPrioritySum += (double)out.tx->vout[out.i].nValue  * (out.nDepth+1);
+            dPrioritySum += out.tx->vout[out.i].nValue.ToDouble() * (out.nDepth+1);
             nInputSum    += nInputSize;
 
             // transaction hash
@@ -774,7 +774,7 @@ void CoinControlDialog::updateView()
             dPrioritySum = dPrioritySum / (nInputSum + 78);
             itemWalletAddress->setText(COLUMN_CHECKBOX, "(" + QString::number(nChildren) + ")");
             itemWalletAddress->setText(COLUMN_AMOUNT, BitcoinUnits::format(nDisplayUnit, nSum));
-            itemWalletAddress->setText(COLUMN_AMOUNT_INT64, strPad(QString::number(nSum), 15, " "));
+            itemWalletAddress->setText(COLUMN_AMOUNT_INT64, strPad(QString::number(EncodeDouble(nSum.ToDouble())), 20, " "));
             itemWalletAddress->setText(COLUMN_PRIORITY, CoinControlDialog::getPriorityLabel(dPrioritySum));
             itemWalletAddress->setText(COLUMN_PRIORITY_INT64, strPad(QString::number((int64_t)dPrioritySum), 20, " "));
         }

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -27,7 +27,7 @@
 #include <QTreeWidgetItem>
 
 using namespace std;
-QList<qint64> CoinControlDialog::payAmounts;
+QList<CMoney> CoinControlDialog::payAmounts;
 CCoinControl* CoinControlDialog::coinControl = new CCoinControl();
 
 CoinControlDialog::CoinControlDialog(QWidget *parent) :
@@ -438,11 +438,11 @@ void CoinControlDialog::updateLabels(WalletModel *model, QDialog* dialog)
         return;
 
     // nPayAmount
-    qint64 nPayAmount = 0;
+    CMoney nPayAmount = 0;
     bool fLowOutput = false;
     bool fDust = false;
     CTransaction txDummy;
-    foreach(const qint64 &amount, CoinControlDialog::payAmounts)
+    foreach(const CMoney &amount, CoinControlDialog::payAmounts)
     {
         nPayAmount += amount;
 
@@ -459,10 +459,10 @@ void CoinControlDialog::updateLabels(WalletModel *model, QDialog* dialog)
     }
 
     QString sPriorityLabel      = tr("none");
-    int64_t nAmount             = 0;
-    int64_t nPayFee             = 0;
-    int64_t nAfterFee           = 0;
-    int64_t nChange             = 0;
+    CMoney nAmount              = 0;
+    CMoney nPayFee              = 0;
+    CMoney nAfterFee            = 0;
+    CMoney nChange              = 0;
     unsigned int nBytes         = 0;
     unsigned int nBytesInputs   = 0;
     double dPriority            = 0;
@@ -525,10 +525,10 @@ void CoinControlDialog::updateLabels(WalletModel *model, QDialog* dialog)
         sPriorityLabel = CoinControlDialog::getPriorityLabel(dPriority);
 
         // Fee
-        int64_t nFee = nTransactionFee * (1 + (int64_t)nBytes / 1000);
+        CMoney nFee = nTransactionFee * (1 + nBytes / 1000);
 
         // Min Fee
-        int64_t nMinFee = GetMinFee(txDummy, nBytes, AllowFree(dPriority), GMF_SEND);
+        CMoney nMinFee = GetMinFee(txDummy, nBytes, AllowFree(dPriority), GMF_SEND);
 
         nPayFee = max(nFee, nMinFee);
 
@@ -681,7 +681,7 @@ void CoinControlDialog::updateView()
             itemWalletAddress->setText(COLUMN_ADDRESS, sWalletAddress);
         }
 
-        int64_t nSum = 0;
+        CMoney nSum = 0;
         double dPrioritySum = 0;
         int nChildren = 0;
         int nInputSum = 0;

--- a/src/qt/coincontroldialog.h
+++ b/src/qt/coincontroldialog.h
@@ -5,6 +5,8 @@
 #ifndef COINCONTROLDIALOG_H
 #define COINCONTROLDIALOG_H
 
+#include "money.h"
+
 #include <QAbstractButton>
 #include <QAction>
 #include <QDialog>
@@ -34,7 +36,7 @@ public:
     static void updateLabels(WalletModel*, QDialog*);
     static QString getPriorityLabel(double);
 
-    static QList<qint64> payAmounts;
+    static QList<CMoney> payAmounts;
     static CCoinControl *coinControl;
 
 private:

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -177,7 +177,7 @@ QString formatBitcoinURI(const SendCoinsRecipient &info)
     QString ret = QString("bitcoin:%1").arg(info.address);
     int paramCount = 0;
 
-    if (info.amount)
+    if (info.amount != 0)
     {
         ret += QString("?amount=%1").arg(BitcoinUnits::format(BitcoinUnits::BTC, info.amount));
         paramCount++;

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -200,7 +200,7 @@ QString formatBitcoinURI(const SendCoinsRecipient &info)
     return ret;
 }
 
-bool isDust(const QString& address, qint64 amount)
+bool isDust(const QString& address, const CMoney& amount)
 {
     CTxDestination dest = CBitcoinAddress(address.toStdString()).Get();
     CScript script; script.SetDestination(dest);

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -5,6 +5,8 @@
 #ifndef GUIUTIL_H
 #define GUIUTIL_H
 
+#include "money.h"
+
 #include <QHeaderView>
 #include <QMessageBox>
 #include <QObject>
@@ -46,7 +48,7 @@ namespace GUIUtil
     QString formatBitcoinURI(const SendCoinsRecipient &info);
 
     // Returns true if given address+amount meets "dust" definition
-    bool isDust(const QString& address, qint64 amount);
+    bool isDust(const QString& address, const CMoney& amount);
 
     // HTML escaping for rich text controls
     QString HtmlEscape(const QString& str, bool fMultiLine=false);

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -5,6 +5,8 @@
 #ifndef OPTIONSMODEL_H
 #define OPTIONSMODEL_H
 
+#include "money.h"
+
 #include <QAbstractListModel>
 
 QT_BEGIN_NAMESPACE
@@ -83,7 +85,7 @@ private:
 
 signals:
     void displayUnitChanged(int unit);
-    void transactionFeeChanged(qint64);
+    void transactionFeeChanged(const CMoney&);
     void coinControlFeaturesChanged(bool);
 };
 

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -35,7 +35,7 @@ public:
         ProxyIP,                // QString
         ProxyPort,              // int
         ProxySocksVersion,      // int
-        Fee,                    // qint64
+        Fee,                    // CMoney serialized as QString
         DisplayUnit,            // BitcoinUnits::Unit
         DisplayAddresses,       // bool
         ThirdPartyTxUrls,       // QString

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -46,7 +46,7 @@ public:
 
         QDateTime date = index.data(TransactionTableModel::DateRole).toDateTime();
         QString address = index.data(Qt::DisplayRole).toString();
-        qint64 amount = index.data(TransactionTableModel::AmountRole).toLongLong();
+        CMoney amount = 0; ParseMoney(index.data(TransactionTableModel::AmountRole).toString().toStdString(), amount);
         bool confirmed = index.data(TransactionTableModel::ConfirmedRole).toBool();
         QVariant value = index.data(Qt::ForegroundRole);
         QColor foreground = option.palette.color(QPalette::Text);

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -135,7 +135,7 @@ OverviewPage::~OverviewPage()
     delete ui;
 }
 
-void OverviewPage::setBalance(qint64 balance, qint64 unconfirmedBalance, qint64 immatureBalance)
+void OverviewPage::setBalance(const CMoney& balance, const CMoney& unconfirmedBalance, const CMoney& immatureBalance)
 {
     int unit = walletModel->getOptionsModel()->getDisplayUnit();
     currentBalance = balance;
@@ -183,7 +183,7 @@ void OverviewPage::setWalletModel(WalletModel *model)
 
         // Keep up to date with wallet
         setBalance(model->getBalance(), model->getUnconfirmedBalance(), model->getImmatureBalance());
-        connect(model, SIGNAL(balanceChanged(qint64, qint64, qint64)), this, SLOT(setBalance(qint64, qint64, qint64)));
+        connect(model, SIGNAL(balanceChanged(const CMoney&, const CMoney&, const CMoney&)), this, SLOT(setBalance(const CMoney&, const CMoney&, const CMoney&)));
 
         connect(model->getOptionsModel(), SIGNAL(displayUnitChanged(int)), this, SLOT(updateDisplayUnit()));
     }

--- a/src/qt/overviewpage.h
+++ b/src/qt/overviewpage.h
@@ -5,6 +5,8 @@
 #ifndef OVERVIEWPAGE_H
 #define OVERVIEWPAGE_H
 
+#include "money.h"
+
 #include <QWidget>
 
 class ClientModel;
@@ -34,7 +36,7 @@ public:
     void showOutOfSyncWarning(bool fShow);
 
 public slots:
-    void setBalance(qint64 balance, qint64 unconfirmedBalance, qint64 immatureBalance);
+    void setBalance(const CMoney& balance, const CMoney& unconfirmedBalance, const CMoney& immatureBalance);
 
 signals:
     void transactionClicked(const QModelIndex &index);
@@ -43,9 +45,9 @@ private:
     Ui::OverviewPage *ui;
     ClientModel *clientModel;
     WalletModel *walletModel;
-    qint64 currentBalance;
-    qint64 currentUnconfirmedBalance;
-    qint64 currentImmatureBalance;
+    CMoney currentBalance;
+    CMoney currentUnconfirmedBalance;
+    CMoney currentImmatureBalance;
 
     TxViewDelegate *txdelegate;
     TransactionFilterProxy *filter;

--- a/src/qt/paymentrequestplus.cpp
+++ b/src/qt/paymentrequestplus.cpp
@@ -194,9 +194,9 @@ bool PaymentRequestPlus::getMerchant(X509_STORE* certStore, QString& merchant) c
     return fResult;
 }
 
-QList<std::pair<CScript,qint64> > PaymentRequestPlus::getPayTo() const
+QList<std::pair<CScript,CMoney> > PaymentRequestPlus::getPayTo() const
 {
-    QList<std::pair<CScript,qint64> > result;
+    QList<std::pair<CScript,CMoney> > result;
     for (int i = 0; i < details.outputs_size(); i++)
     {
         const unsigned char* scriptStr = (const unsigned char*)details.outputs(i).script().data();

--- a/src/qt/paymentrequestplus.h
+++ b/src/qt/paymentrequestplus.h
@@ -33,7 +33,7 @@ public:
     bool getMerchant(X509_STORE* certStore, QString& merchant) const;
 
     // Returns list of outputs, amount
-    QList<std::pair<CScript,qint64> > getPayTo() const;
+    QList<std::pair<CScript,CMoney> > getPayTo() const;
 
     const payments::PaymentDetails& getDetails() const { return details; }
 

--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -487,10 +487,10 @@ bool PaymentServer::processPaymentRequest(PaymentRequestPlus& request, SendCoins
 
     request.getMerchant(PaymentServer::certStore, recipient.authenticatedMerchant);
 
-    QList<std::pair<CScript, qint64> > sendingTos = request.getPayTo();
+    QList<std::pair<CScript, CMoney> > sendingTos = request.getPayTo();
     QStringList addresses;
 
-    foreach(const PAIRTYPE(CScript, qint64)& sendingTo, sendingTos) {
+    foreach(const PAIRTYPE(CScript, CMoney)& sendingTo, sendingTos) {
         // Extract and check destination addresses
         CTxDestination dest;
         if (ExtractDestination(sendingTo.first, dest)) {

--- a/src/qt/receiverequestdialog.cpp
+++ b/src/qt/receiverequestdialog.cpp
@@ -143,7 +143,7 @@ void ReceiveRequestDialog::update()
     html += "<b>"+tr("URI")+"</b>: ";
     html += "<a href=\""+uri+"\">" + GUIUtil::HtmlEscape(uri) + "</a><br>";
     html += "<b>"+tr("Address")+"</b>: " + GUIUtil::HtmlEscape(info.address) + "<br>";
-    if(info.amount)
+    if(info.amount != 0)
         html += "<b>"+tr("Amount")+"</b>: " + BitcoinUnits::formatWithUnit(model->getDisplayUnit(), info.amount) + "<br>";
     if(!info.label.isEmpty())
         html += "<b>"+tr("Label")+"</b>: " + GUIUtil::HtmlEscape(info.label) + "<br>";

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -91,7 +91,7 @@ void SendCoinsDialog::setModel(WalletModel *model)
         }
 
         setBalance(model->getBalance(), model->getUnconfirmedBalance(), model->getImmatureBalance());
-        connect(model, SIGNAL(balanceChanged(qint64, qint64, qint64)), this, SLOT(setBalance(qint64, qint64, qint64)));
+        connect(model, SIGNAL(balanceChanged(const CMoney&, const CMoney&, const CMoney&)), this, SLOT(setBalance(const CMoney&, const CMoney&, const CMoney&)));
         connect(model->getOptionsModel(), SIGNAL(displayUnitChanged(int)), this, SLOT(updateDisplayUnit()));
 
         // Coin Control
@@ -202,7 +202,7 @@ void SendCoinsDialog::on_sendButton_clicked()
         return;
     }
 
-    qint64 txFee = currentTransaction.getTransactionFee();
+    CMoney txFee = currentTransaction.getTransactionFee();
     QString questionString = tr("Are you sure you want to send?");
     questionString.append("<br /><br />%1");
 
@@ -217,7 +217,7 @@ void SendCoinsDialog::on_sendButton_clicked()
 
     // add total amount in all subdivision units
     questionString.append("<hr />");
-    qint64 totalAmount = currentTransaction.getTotalTransactionAmount() + txFee;
+    CMoney totalAmount = currentTransaction.getTotalTransactionAmount() + txFee;
     QStringList alternativeUnits;
     foreach(BitcoinUnits::Unit u, BitcoinUnits::availableUnits())
     {
@@ -401,7 +401,7 @@ bool SendCoinsDialog::handlePaymentRequest(const SendCoinsRecipient &rv)
     return true;
 }
 
-void SendCoinsDialog::setBalance(qint64 balance, qint64 unconfirmedBalance, qint64 immatureBalance)
+void SendCoinsDialog::setBalance(const CMoney& balance, const CMoney& unconfirmedBalance, const CMoney& immatureBalance)
 {
     Q_UNUSED(unconfirmedBalance);
     Q_UNUSED(immatureBalance);

--- a/src/qt/sendcoinsdialog.h
+++ b/src/qt/sendcoinsdialog.h
@@ -47,7 +47,7 @@ public slots:
     void accept();
     SendCoinsEntry *addEntry();
     void updateTabsAndLabels();
-    void setBalance(qint64 balance, qint64 unconfirmedBalance, qint64 immatureBalance);
+    void setBalance(const CMoney& balance, const CMoney& unconfirmedBalance, const CMoney& immatureBalance);
 
 private:
     Ui::SendCoinsDialog *ui;

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -51,9 +51,9 @@ QString TransactionDesc::toHTML(CWallet *wallet, CWalletTx &wtx, int vout, int u
     strHTML += "<html><font face='verdana, arial, helvetica, sans-serif'>";
 
     int64_t nTime = wtx.GetTxTime();
-    int64_t nCredit = wtx.GetCredit();
-    int64_t nDebit = wtx.GetDebit();
-    int64_t nNet = nCredit - nDebit;
+    CMoney nCredit = wtx.GetCredit();
+    CMoney nDebit = wtx.GetDebit();
+    CMoney nNet = nCredit - nDebit;
 
     strHTML += "<b>" + tr("Status") + ":</b> " + FormatTxStatus(wtx);
     int nRequests = wtx.GetRequestCount();
@@ -133,7 +133,7 @@ QString TransactionDesc::toHTML(CWallet *wallet, CWalletTx &wtx, int vout, int u
         //
         // Coinbase
         //
-        int64_t nUnmatured = 0;
+        CMoney nUnmatured = 0;
         BOOST_FOREACH(const CTxOut& txout, wtx.vout)
             nUnmatured += wallet->GetCredit(txout);
         strHTML += "<b>" + tr("Credit") + ":</b> ";
@@ -190,13 +190,13 @@ QString TransactionDesc::toHTML(CWallet *wallet, CWalletTx &wtx, int vout, int u
             if (fAllToMe)
             {
                 // Payment to self
-                int64_t nChange = wtx.GetChange();
-                int64_t nValue = nCredit - nChange;
+                CMoney nChange = wtx.GetChange();
+                CMoney nValue = nCredit - nChange;
                 strHTML += "<b>" + tr("Debit") + ":</b> " + BitcoinUnits::formatWithUnit(unit, -nValue) + "<br>";
                 strHTML += "<b>" + tr("Credit") + ":</b> " + BitcoinUnits::formatWithUnit(unit, nValue) + "<br>";
             }
 
-            int64_t nTxFee = nDebit - wtx.GetValueOut();
+            CMoney nTxFee = nDebit - wtx.GetValueOut();
             if (nTxFee > 0)
                 strHTML += "<b>" + tr("Transaction fee") + ":</b> " + BitcoinUnits::formatWithUnit(unit, -nTxFee) + "<br>";
         }

--- a/src/qt/transactionfilterproxy.cpp
+++ b/src/qt/transactionfilterproxy.cpp
@@ -7,6 +7,8 @@
 #include "transactiontablemodel.h"
 #include "transactionrecord.h"
 
+#include "util.h"
+
 #include <cstdlib>
 
 #include <QDateTime>
@@ -36,7 +38,9 @@ bool TransactionFilterProxy::filterAcceptsRow(int sourceRow, const QModelIndex &
     QDateTime datetime = index.data(TransactionTableModel::DateRole).toDateTime();
     QString address = index.data(TransactionTableModel::AddressRole).toString();
     QString label = index.data(TransactionTableModel::LabelRole).toString();
-    qint64 amount = llabs(index.data(TransactionTableModel::AmountRole).toLongLong());
+    CMoney amount;
+    if (!ParseMoney(index.data(TransactionTableModel::AmountRole).toString().toStdString(), amount))
+        return false;
     int status = index.data(TransactionTableModel::StatusRole).toInt();
 
     if(!showInactive && status == TransactionStatus::Conflicted)
@@ -47,7 +51,7 @@ bool TransactionFilterProxy::filterAcceptsRow(int sourceRow, const QModelIndex &
         return false;
     if (!address.contains(addrPrefix, Qt::CaseInsensitive) && !label.contains(addrPrefix, Qt::CaseInsensitive))
         return false;
-    if(amount < minAmount)
+    if(abs(amount) < minAmount)
         return false;
 
     return true;

--- a/src/qt/transactionfilterproxy.cpp
+++ b/src/qt/transactionfilterproxy.cpp
@@ -72,7 +72,7 @@ void TransactionFilterProxy::setTypeFilter(quint32 modes)
     invalidateFilter();
 }
 
-void TransactionFilterProxy::setMinAmount(qint64 minimum)
+void TransactionFilterProxy::setMinAmount(const CMoney& minimum)
 {
     this->minAmount = minimum;
     invalidateFilter();

--- a/src/qt/transactionfilterproxy.h
+++ b/src/qt/transactionfilterproxy.h
@@ -5,6 +5,8 @@
 #ifndef TRANSACTIONFILTERPROXY_H
 #define TRANSACTIONFILTERPROXY_H
 
+#include "money.h"
+
 #include <QDateTime>
 #include <QSortFilterProxyModel>
 
@@ -31,7 +33,7 @@ public:
       @note Type filter takes a bit field created with TYPE() or ALL_TYPES
      */
     void setTypeFilter(quint32 modes);
-    void setMinAmount(qint64 minimum);
+    void setMinAmount(const CMoney& minimum);
 
     /** Set maximum number of rows returned, -1 if unlimited. */
     void setLimit(int limit);
@@ -49,7 +51,7 @@ private:
     QDateTime dateTo;
     QString addrPrefix;
     quint32 typeFilter;
-    qint64 minAmount;
+    CMoney minAmount;
     int limitRows;
     bool showInactive;
 };

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -31,9 +31,9 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
 {
     QList<TransactionRecord> parts;
     int64_t nTime = wtx.GetTxTime();
-    int64_t nCredit = wtx.GetCredit(true);
-    int64_t nDebit = wtx.GetDebit();
-    int64_t nNet = nCredit - nDebit;
+    CMoney nCredit = wtx.GetCredit(true);
+    CMoney nDebit = wtx.GetDebit();
+    CMoney nNet = nCredit - nDebit;
     uint256 hash = wtx.GetHash();
     std::map<std::string, std::string> mapValue = wtx.mapValue;
 
@@ -85,7 +85,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
         if (fAllFromMe && fAllToMe)
         {
             // Payment to self
-            int64_t nChange = wtx.GetChange();
+            CMoney nChange = wtx.GetChange();
 
             parts.append(TransactionRecord(hash, nTime, TransactionRecord::SendToSelf, "",
                             -(nDebit - nChange), nCredit - nChange));
@@ -95,7 +95,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
             //
             // Debit
             //
-            int64_t nTxFee = nDebit - wtx.GetValueOut();
+            CMoney nTxFee = nDebit - wtx.GetValueOut();
 
             for (unsigned int nOut = 0; nOut < wtx.vout.size(); nOut++)
             {
@@ -124,7 +124,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
                     sub.address = mapValue["to"];
                 }
 
-                int64_t nValue = txout.nValue;
+                CMoney nValue = txout.nValue;
                 /* Add fee to first output */
                 if (nTxFee > 0)
                 {

--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -6,6 +6,7 @@
 #define TRANSACTIONRECORD_H
 
 #include "uint256.h"
+#include "money.h"
 
 #include <QList>
 #include <QString>
@@ -94,7 +95,7 @@ public:
 
     TransactionRecord(uint256 hash, qint64 time,
                 Type type, const std::string &address,
-                qint64 debit, qint64 credit):
+                const CMoney& debit, const CMoney& credit):
             hash(hash), time(time), type(type), address(address), debit(debit), credit(credit),
             idx(0)
     {
@@ -111,8 +112,8 @@ public:
     qint64 time;
     Type type;
     std::string address;
-    qint64 debit;
-    qint64 credit;
+    CMoney debit;
+    CMoney credit;
     /**@}*/
 
     /** Subtransaction index, for sort key */

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -528,7 +528,7 @@ QVariant TransactionTableModel::data(const QModelIndex &index, int role) const
         case ToAddress:
             return formatTxToAddress(rec, true);
         case Amount:
-            return rec->credit + rec->debit;
+            return QString::fromStdString(FormatMoney(rec->credit + rec->debit));
         }
         break;
     case Qt::ToolTipRole:
@@ -561,7 +561,7 @@ QVariant TransactionTableModel::data(const QModelIndex &index, int role) const
     case LabelRole:
         return walletModel->getAddressTableModel()->labelForAddress(QString::fromStdString(rec->address));
     case AmountRole:
-        return rec->credit + rec->debit;
+        return QString::fromStdString(FormatMoney(rec->credit + rec->debit));
     case TxIDRole:
         return rec->getTxID();
     case TxHashRole:

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -279,7 +279,7 @@ void TransactionView::changedAmount(const QString &amount)
 {
     if(!transactionProxyModel)
         return;
-    qint64 amount_parsed = 0;
+    CMoney amount_parsed = 0;
     if(BitcoinUnits::parse(model->getOptionsModel()->getDisplayUnit(), amount, &amount_parsed))
     {
         transactionProxyModel->setMinAmount(amount_parsed);

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -37,7 +37,7 @@ class SendCoinsRecipient
 {
 public:
     explicit SendCoinsRecipient() : amount(0), nVersion(SendCoinsRecipient::CURRENT_VERSION) { }
-    explicit SendCoinsRecipient(const QString &addr, const QString &label, quint64 amount, const QString &message):
+    explicit SendCoinsRecipient(const QString &addr, const QString &label, const CMoney& amount, const QString &message):
         address(addr), label(label), amount(amount), message(message), nVersion(SendCoinsRecipient::CURRENT_VERSION) {}
 
     // If from an insecure payment request, this is used for storing
@@ -47,7 +47,7 @@ public:
     // Todo: This is a hack, should be replaced with a cleaner solution!
     QString address;
     QString label;
-    qint64 amount;
+    CMoney amount;
     // If from a payment request, this is used for storing the memo
     QString message;
 
@@ -125,9 +125,9 @@ public:
     TransactionTableModel *getTransactionTableModel();
     RecentRequestsTableModel *getRecentRequestsTableModel();
 
-    qint64 getBalance(const CCoinControl *coinControl = NULL) const;
-    qint64 getUnconfirmedBalance() const;
-    qint64 getImmatureBalance() const;
+    CMoney getBalance(const CCoinControl *coinControl = NULL) const;
+    CMoney getUnconfirmedBalance() const;
+    CMoney getImmatureBalance() const;
     int getNumTransactions() const;
     EncryptionStatus getEncryptionStatus() const;
 
@@ -203,9 +203,9 @@ private:
     RecentRequestsTableModel *recentRequestsTableModel;
 
     // Cache some values to be able to detect changes
-    qint64 cachedBalance;
-    qint64 cachedUnconfirmedBalance;
-    qint64 cachedImmatureBalance;
+    CMoney cachedBalance;
+    CMoney cachedUnconfirmedBalance;
+    CMoney cachedImmatureBalance;
     qint64 cachedNumTransactions;
     EncryptionStatus cachedEncryptionStatus;
     int cachedNumBlocks;
@@ -218,7 +218,7 @@ private:
 
 signals:
     // Signal that balance in wallet changed
-    void balanceChanged(qint64 balance, qint64 unconfirmedBalance, qint64 immatureBalance);
+    void balanceChanged(const CMoney& balance, const CMoney& unconfirmedBalance, const CMoney& immatureBalance);
 
     // Number of transactions in wallet changed
     void numTransactionsChanged(int count);

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -75,7 +75,12 @@ public:
         nVersion = pthis->nVersion;
         READWRITE(sAddress);
         READWRITE(sLabel);
-        READWRITE(amount);
+        int64_t amountI64;
+        if (fWrite)
+            amountI64 = amount.ToInt64(ROUND_SIGNAL);
+        READWRITE(amountI64);
+        if (fRead)
+            pthis->amount = amountI64;
         READWRITE(sMessage);
         READWRITE(sPaymentRequest);
         READWRITE(sAuthenticatedMerchant);

--- a/src/qt/walletmodeltransaction.cpp
+++ b/src/qt/walletmodeltransaction.cpp
@@ -31,19 +31,19 @@ CWalletTx *WalletModelTransaction::getTransaction()
     return walletTransaction;
 }
 
-qint64 WalletModelTransaction::getTransactionFee()
+CMoney WalletModelTransaction::getTransactionFee()
 {
     return fee;
 }
 
-void WalletModelTransaction::setTransactionFee(qint64 newFee)
+void WalletModelTransaction::setTransactionFee(const CMoney& newFee)
 {
     fee = newFee;
 }
 
-qint64 WalletModelTransaction::getTotalTransactionAmount()
+CMoney WalletModelTransaction::getTotalTransactionAmount()
 {
-    qint64 totalTransactionAmount = 0;
+    CMoney totalTransactionAmount = 0;
     foreach(const SendCoinsRecipient &rcp, recipients)
     {
         totalTransactionAmount += rcp.amount;

--- a/src/qt/walletmodeltransaction.h
+++ b/src/qt/walletmodeltransaction.h
@@ -26,10 +26,10 @@ public:
 
     CWalletTx *getTransaction();
 
-    void setTransactionFee(qint64 newFee);
-    qint64 getTransactionFee();
+    void setTransactionFee(const CMoney& newFee);
+    CMoney getTransactionFee();
 
-    qint64 getTotalTransactionAmount();
+    CMoney getTotalTransactionAmount();
 
     void newPossibleKeyChange(CWallet *wallet);
     CReserveKey *getPossibleKeyChange();
@@ -38,7 +38,7 @@ private:
     const QList<SendCoinsRecipient> recipients;
     CWalletTx *walletTransaction;
     CReserveKey *keyChange;
-    qint64 fee;
+    CMoney fee;
 };
 
 #endif // WALLETMODELTRANSACTION_H

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -143,7 +143,7 @@ void WalletView::processNewTransaction(const QModelIndex& parent, int start, int
     TransactionTableModel *ttm = walletModel->getTransactionTableModel();
 
     QString date = ttm->index(start, TransactionTableModel::Date, parent).data().toString();
-    qint64 amount = ttm->index(start, TransactionTableModel::Amount, parent).data(Qt::EditRole).toULongLong();
+    CMoney amount = 0; ParseMoney(ttm->index(start, TransactionTableModel::Amount, parent).data(Qt::EditRole).toString().toStdString(), amount);
     QString type = ttm->index(start, TransactionTableModel::Type, parent).data().toString();
     QString address = ttm->index(start, TransactionTableModel::ToAddress, parent).data().toString();
 

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -92,7 +92,7 @@ void WalletView::setBitcoinGUI(BitcoinGUI *gui)
         connect(this, SIGNAL(encryptionStatusChanged(int)), gui, SLOT(setEncryptionStatus(int)));
 
         // Pass through transaction notifications
-        connect(this, SIGNAL(incomingTransaction(QString,int,qint64,QString,QString)), gui, SLOT(incomingTransaction(QString,int,qint64,QString,QString)));
+        connect(this, SIGNAL(incomingTransaction(QString,int,const CMoney&,QString,QString)), gui, SLOT(incomingTransaction(QString,int,const CMoney&,QString,QString)));
     }
 }
 

--- a/src/qt/walletview.h
+++ b/src/qt/walletview.h
@@ -5,6 +5,8 @@
 #ifndef WALLETVIEW_H
 #define WALLETVIEW_H
 
+#include "money.h"
+
 #include <QStackedWidget>
 
 class BitcoinGUI;
@@ -111,7 +113,7 @@ signals:
     /** Encryption status of wallet changed */
     void encryptionStatusChanged(int status);
     /** Notify that a new transaction appeared */
-    void incomingTransaction(const QString& date, int unit, qint64 amount, const QString& type, const QString& address);
+    void incomingTransaction(const QString& date, int unit, const CMoney& amount, const QString& type, const QString& address);
 };
 
 #endif // WALLETVIEW_H

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -550,7 +550,7 @@ Value getblocktemplate(const Array& params, bool fHelp)
         entry.push_back(Pair("depends", deps));
 
         int index_in_template = i - 1;
-        entry.push_back(Pair("fee", pblocktemplate->vTxFees[index_in_template]));
+        entry.push_back(Pair("fee", ValueFromAmount(pblocktemplate->vTxFees[index_in_template])));
         entry.push_back(Pair("sigops", pblocktemplate->vTxSigOps[index_in_template]));
 
         transactions.push_back(entry);
@@ -574,7 +574,7 @@ Value getblocktemplate(const Array& params, bool fHelp)
     result.push_back(Pair("previousblockhash", pblock->hashPrevBlock.GetHex()));
     result.push_back(Pair("transactions", transactions));
     result.push_back(Pair("coinbaseaux", aux));
-    result.push_back(Pair("coinbasevalue", (int64_t)pblock->vtx[0].vout[0].nValue));
+    result.push_back(Pair("coinbasevalue", pblock->vtx[0].vout[0].nValue.ToInt64(ROUND_TOWARDS_ZERO)));
     result.push_back(Pair("target", hashTarget.GetHex()));
     result.push_back(Pair("mintime", (int64_t)pindexPrev->GetMedianTimePast()+1));
     result.push_back(Pair("mutable", aMutable));

--- a/src/rpcmisc.cpp
+++ b/src/rpcmisc.cpp
@@ -65,7 +65,7 @@ Value getinfo(const Array& params, bool fHelp)
 #ifdef ENABLE_WALLET
     if (pwalletMain) {
         obj.push_back(Pair("walletversion", pwalletMain->GetVersion()));
-        obj.push_back(Pair("balance",       ValueFromAmount(pwalletMain->GetBalance())));
+        obj.push_back(Pair("balance",       ValueFromAmount(pwalletMain->GetBalance(), ROUND_TOWARDS_ZERO)));
     }
 #endif
     obj.push_back(Pair("blocks",        (int)chainActive.Height()));
@@ -81,9 +81,9 @@ Value getinfo(const Array& params, bool fHelp)
     }
     if (pwalletMain && pwalletMain->IsCrypted())
         obj.push_back(Pair("unlocked_until", nWalletUnlockTime));
-    obj.push_back(Pair("paytxfee",      ValueFromAmount(nTransactionFee)));
+    obj.push_back(Pair("paytxfee",      ValueFromAmount(nTransactionFee, ROUND_AWAY_FROM_ZERO)));
 #endif
-    obj.push_back(Pair("relayfee",      ValueFromAmount(CTransaction::nMinRelayTxFee)));
+    obj.push_back(Pair("relayfee",      ValueFromAmount(CTransaction::nMinRelayTxFee, ROUND_AWAY_FROM_ZERO)));
     obj.push_back(Pair("errors",        GetWarnings("statusbar")));
     return obj;
 }

--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -278,7 +278,7 @@ Value listunspent(const Array& params, bool fHelp)
                 continue;
         }
 
-        int64_t nValue = out.tx->vout[out.i].nValue;
+        CMoney nValue = out.tx->vout[out.i].nValue;
         const CScript& pk = out.tx->vout[out.i].scriptPubKey;
         Object entry;
         entry.push_back(Pair("txid", out.tx->GetHash().GetHex()));
@@ -381,7 +381,7 @@ Value createrawtransaction(const Array& params, bool fHelp)
 
         CScript scriptPubKey;
         scriptPubKey.SetDestination(address.Get());
-        int64_t nAmount = AmountFromValue(s.value_);
+        CMoney nAmount = AmountFromValue(s.value_);
 
         CTxOut out(nAmount, scriptPubKey);
         rawTx.vout.push_back(out);

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -83,18 +83,16 @@ void RPCTypeCheck(const Object& o,
 
 CMoney AmountFromValue(const Value& value)
 {
-    double dAmount = value.get_real();
-    if (dAmount <= 0.0 || dAmount > 21000000.0)
-        throw JSONRPCError(RPC_TYPE_ERROR, "Invalid amount");
-    CMoney nAmount = roundint64(dAmount * COIN);
-    if (!MoneyRange(nAmount))
-        throw JSONRPCError(RPC_TYPE_ERROR, "Invalid amount");
+    CMoney nAmount;
+    if (!ParseMoney(write_string(value, false), nAmount) || !nAmount)
+        throw JSONRPCError(RPC_TYPE_ERROR,
+                           strprintf("Invalid amount: %s", write_string(value, false)));
     return nAmount;
 }
 
-Value ValueFromAmount(const CMoney& amount)
+Value ValueFromAmount(const CMoney& amount, RoundingMode mode)
 {
-    return (double)amount / (double)COIN;
+    return amount.ToDouble(mode) / static_cast<double>(COIN);
 }
 
 std::string HexBits(unsigned int nBits)

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -81,18 +81,18 @@ void RPCTypeCheck(const Object& o,
     }
 }
 
-int64_t AmountFromValue(const Value& value)
+CMoney AmountFromValue(const Value& value)
 {
     double dAmount = value.get_real();
     if (dAmount <= 0.0 || dAmount > 21000000.0)
         throw JSONRPCError(RPC_TYPE_ERROR, "Invalid amount");
-    int64_t nAmount = roundint64(dAmount * COIN);
+    CMoney nAmount = roundint64(dAmount * COIN);
     if (!MoneyRange(nAmount))
         throw JSONRPCError(RPC_TYPE_ERROR, "Invalid amount");
     return nAmount;
 }
 
-Value ValueFromAmount(int64_t amount)
+Value ValueFromAmount(const CMoney& amount)
 {
     return (double)amount / (double)COIN;
 }

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -105,7 +105,7 @@ extern void ShutdownRPCMining();
 
 extern int64_t nWalletUnlockTime;
 extern CMoney AmountFromValue(const json_spirit::Value& value);
-extern json_spirit::Value ValueFromAmount(const CMoney& amount);
+extern json_spirit::Value ValueFromAmount(const CMoney& amount, RoundingMode mode=ROUND_TIES_TO_EVEN);
 extern double GetDifficulty(const CBlockIndex* blockindex = NULL);
 extern std::string HexBits(unsigned int nBits);
 extern std::string HelpRequiringPassphrase();

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -8,6 +8,7 @@
 
 #include "uint256.h"
 #include "rpcprotocol.h"
+#include "money.h"
 
 #include <list>
 #include <map>
@@ -103,8 +104,8 @@ extern void InitRPCMining();
 extern void ShutdownRPCMining();
 
 extern int64_t nWalletUnlockTime;
-extern int64_t AmountFromValue(const json_spirit::Value& value);
-extern json_spirit::Value ValueFromAmount(int64_t amount);
+extern CMoney AmountFromValue(const json_spirit::Value& value);
+extern json_spirit::Value ValueFromAmount(const CMoney& amount);
 extern double GetDifficulty(const CBlockIndex* blockindex = NULL);
 extern std::string HexBits(unsigned int nBits);
 extern std::string HelpRequiringPassphrase();

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -330,7 +330,7 @@ Value sendtoaddress(const Array& params, bool fHelp)
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid Bitcoin address");
 
     // Amount
-    int64_t nAmount = AmountFromValue(params[1]);
+    CMoney nAmount = AmountFromValue(params[1]);
 
     // Wallet comments
     CWalletTx wtx;
@@ -374,7 +374,7 @@ Value listaddressgroupings(const Array& params, bool fHelp)
         );
 
     Array jsonGroupings;
-    map<CTxDestination, int64_t> balances = pwalletMain->GetAddressBalances();
+    map<CTxDestination, CMoney> balances = pwalletMain->GetAddressBalances();
     BOOST_FOREACH(set<CTxDestination> grouping, pwalletMain->GetAddressGroupings())
     {
         Array jsonGrouping;
@@ -483,7 +483,7 @@ Value getreceivedbyaddress(const Array& params, bool fHelp)
         nMinDepth = params[1].get_int();
 
     // Tally
-    int64_t nAmount = 0;
+    CMoney nAmount = 0;
     for (map<uint256, CWalletTx>::iterator it = pwalletMain->mapWallet.begin(); it != pwalletMain->mapWallet.end(); ++it)
     {
         const CWalletTx& wtx = (*it).second;
@@ -532,7 +532,7 @@ Value getreceivedbyaccount(const Array& params, bool fHelp)
     set<CTxDestination> setAddress = pwalletMain->GetAccountAddresses(strAccount);
 
     // Tally
-    int64_t nAmount = 0;
+    CMoney nAmount = 0;
     for (map<uint256, CWalletTx>::iterator it = pwalletMain->mapWallet.begin(); it != pwalletMain->mapWallet.end(); ++it)
     {
         const CWalletTx& wtx = (*it).second;
@@ -552,9 +552,9 @@ Value getreceivedbyaccount(const Array& params, bool fHelp)
 }
 
 
-int64_t GetAccountBalance(CWalletDB& walletdb, const string& strAccount, int nMinDepth)
+CMoney GetAccountBalance(CWalletDB& walletdb, const string& strAccount, int nMinDepth)
 {
-    int64_t nBalance = 0;
+    CMoney nBalance = 0;
 
     // Tally wallet transactions
     for (map<uint256, CWalletTx>::iterator it = pwalletMain->mapWallet.begin(); it != pwalletMain->mapWallet.end(); ++it)
@@ -563,7 +563,7 @@ int64_t GetAccountBalance(CWalletDB& walletdb, const string& strAccount, int nMi
         if (!IsFinalTx(wtx) || wtx.GetBlocksToMaturity() > 0 || wtx.GetDepthInMainChain() < 0)
             continue;
 
-        int64_t nReceived, nSent, nFee;
+        CMoney nReceived, nSent, nFee;
         wtx.GetAccountAmounts(strAccount, nReceived, nSent, nFee);
 
         if (nReceived != 0 && wtx.GetDepthInMainChain() >= nMinDepth)
@@ -577,7 +577,7 @@ int64_t GetAccountBalance(CWalletDB& walletdb, const string& strAccount, int nMi
     return nBalance;
 }
 
-int64_t GetAccountBalance(const string& strAccount, int nMinDepth)
+CMoney GetAccountBalance(const string& strAccount, int nMinDepth)
 {
     CWalletDB walletdb(pwalletMain->strWalletFile);
     return GetAccountBalance(walletdb, strAccount, nMinDepth);
@@ -622,24 +622,24 @@ Value getbalance(const Array& params, bool fHelp)
         // Calculate total balance a different way from GetBalance()
         // (GetBalance() sums up all unspent TxOuts)
         // getbalance and getbalance '*' 0 should return the same number
-        int64_t nBalance = 0;
+        CMoney nBalance = 0;
         for (map<uint256, CWalletTx>::iterator it = pwalletMain->mapWallet.begin(); it != pwalletMain->mapWallet.end(); ++it)
         {
             const CWalletTx& wtx = (*it).second;
             if (!wtx.IsTrusted() || wtx.GetBlocksToMaturity() > 0)
                 continue;
 
-            int64_t allFee;
+            CMoney allFee;
             string strSentAccount;
-            list<pair<CTxDestination, int64_t> > listReceived;
-            list<pair<CTxDestination, int64_t> > listSent;
+            list<pair<CTxDestination, CMoney> > listReceived;
+            list<pair<CTxDestination, CMoney> > listSent;
             wtx.GetAmounts(listReceived, listSent, allFee, strSentAccount);
             if (wtx.GetDepthInMainChain() >= nMinDepth)
             {
-                BOOST_FOREACH(const PAIRTYPE(CTxDestination,int64_t)& r, listReceived)
+                BOOST_FOREACH(const PAIRTYPE(CTxDestination,CMoney)& r, listReceived)
                     nBalance += r.second;
             }
-            BOOST_FOREACH(const PAIRTYPE(CTxDestination,int64_t)& r, listSent)
+            BOOST_FOREACH(const PAIRTYPE(CTxDestination,CMoney)& r, listSent)
                 nBalance -= r.second;
             nBalance -= allFee;
         }
@@ -648,7 +648,7 @@ Value getbalance(const Array& params, bool fHelp)
 
     string strAccount = AccountFromValue(params[0]);
 
-    int64_t nBalance = GetAccountBalance(strAccount, nMinDepth);
+    CMoney nBalance = GetAccountBalance(strAccount, nMinDepth);
 
     return ValueFromAmount(nBalance);
 }
@@ -687,7 +687,7 @@ Value movecmd(const Array& params, bool fHelp)
 
     string strFrom = AccountFromValue(params[0]);
     string strTo = AccountFromValue(params[1]);
-    int64_t nAmount = AmountFromValue(params[2]);
+    CMoney nAmount = AmountFromValue(params[2]);
     if (params.size() > 3)
         // unused parameter, used to be nMinDepth, keep type-checking it though
         (void)params[3].get_int();
@@ -761,7 +761,7 @@ Value sendfrom(const Array& params, bool fHelp)
     CBitcoinAddress address(params[1].get_str());
     if (!address.IsValid())
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid Bitcoin address");
-    int64_t nAmount = AmountFromValue(params[2]);
+    CMoney nAmount = AmountFromValue(params[2]);
     int nMinDepth = 1;
     if (params.size() > 3)
         nMinDepth = params[3].get_int();
@@ -776,7 +776,7 @@ Value sendfrom(const Array& params, bool fHelp)
     EnsureWalletIsUnlocked();
 
     // Check funds
-    int64_t nBalance = GetAccountBalance(strAccount, nMinDepth);
+    CMoney nBalance = GetAccountBalance(strAccount, nMinDepth);
     if (nAmount > nBalance)
         throw JSONRPCError(RPC_WALLET_INSUFFICIENT_FUNDS, "Account has insufficient funds");
 
@@ -829,9 +829,9 @@ Value sendmany(const Array& params, bool fHelp)
         wtx.mapValue["comment"] = params[3].get_str();
 
     set<CBitcoinAddress> setAddress;
-    vector<pair<CScript, int64_t> > vecSend;
+    vector<pair<CScript, CMoney> > vecSend;
 
-    int64_t totalAmount = 0;
+    CMoney totalAmount = 0;
     BOOST_FOREACH(const Pair& s, sendTo)
     {
         CBitcoinAddress address(s.name_);
@@ -844,7 +844,7 @@ Value sendmany(const Array& params, bool fHelp)
 
         CScript scriptPubKey;
         scriptPubKey.SetDestination(address.Get());
-        int64_t nAmount = AmountFromValue(s.value_);
+        CMoney nAmount = AmountFromValue(s.value_);
         totalAmount += nAmount;
 
         vecSend.push_back(make_pair(scriptPubKey, nAmount));
@@ -853,13 +853,13 @@ Value sendmany(const Array& params, bool fHelp)
     EnsureWalletIsUnlocked();
 
     // Check funds
-    int64_t nBalance = GetAccountBalance(strAccount, nMinDepth);
+    CMoney nBalance = GetAccountBalance(strAccount, nMinDepth);
     if (totalAmount > nBalance)
         throw JSONRPCError(RPC_WALLET_INSUFFICIENT_FUNDS, "Account has insufficient funds");
 
     // Send
     CReserveKey keyChange(pwalletMain);
-    int64_t nFeeRequired = 0;
+    CMoney nFeeRequired = 0;
     string strFailReason;
     bool fCreated = pwalletMain->CreateTransaction(vecSend, wtx, keyChange, nFeeRequired, strFailReason);
     if (!fCreated)
@@ -919,7 +919,7 @@ Value addmultisigaddress(const Array& params, bool fHelp)
 
 struct tallyitem
 {
-    int64_t nAmount;
+    CMoney nAmount;
     int nConf;
     vector<uint256> txids;
     tallyitem()
@@ -978,7 +978,7 @@ Value ListReceived(const Array& params, bool fByAccounts)
         if (it == mapTally.end() && !fIncludeEmpty)
             continue;
 
-        int64_t nAmount = 0;
+        CMoney nAmount = 0;
         int nConf = std::numeric_limits<int>::max();
         if (it != mapTally.end())
         {
@@ -1016,7 +1016,7 @@ Value ListReceived(const Array& params, bool fByAccounts)
     {
         for (map<string, tallyitem>::iterator it = mapAccountTally.begin(); it != mapAccountTally.end(); ++it)
         {
-            int64_t nAmount = (*it).second.nAmount;
+            CMoney nAmount = (*it).second.nAmount;
             int nConf = (*it).second.nConf;
             Object obj;
             obj.push_back(Pair("account",       (*it).first));
@@ -1097,10 +1097,10 @@ static void MaybePushAddress(Object & entry, const CTxDestination &dest)
 
 void ListTransactions(const CWalletTx& wtx, const string& strAccount, int nMinDepth, bool fLong, Array& ret)
 {
-    int64_t nFee;
+    CMoney nFee;
     string strSentAccount;
-    list<pair<CTxDestination, int64_t> > listReceived;
-    list<pair<CTxDestination, int64_t> > listSent;
+    list<pair<CTxDestination, CMoney> > listReceived;
+    list<pair<CTxDestination, CMoney> > listSent;
 
     wtx.GetAmounts(listReceived, listSent, nFee, strSentAccount);
 
@@ -1109,7 +1109,7 @@ void ListTransactions(const CWalletTx& wtx, const string& strAccount, int nMinDe
     // Sent
     if ((!listSent.empty() || nFee != 0) && (fAllAccounts || strAccount == strSentAccount))
     {
-        BOOST_FOREACH(const PAIRTYPE(CTxDestination, int64_t)& s, listSent)
+        BOOST_FOREACH(const PAIRTYPE(CTxDestination, CMoney)& s, listSent)
         {
             Object entry;
             entry.push_back(Pair("account", strSentAccount));
@@ -1126,7 +1126,7 @@ void ListTransactions(const CWalletTx& wtx, const string& strAccount, int nMinDe
     // Received
     if (listReceived.size() > 0 && wtx.GetDepthInMainChain() >= nMinDepth)
     {
-        BOOST_FOREACH(const PAIRTYPE(CTxDestination, int64_t)& r, listReceived)
+        BOOST_FOREACH(const PAIRTYPE(CTxDestination, CMoney)& r, listReceived)
         {
             string account;
             if (pwalletMain->mapAddressBook.count(r.first))
@@ -1311,7 +1311,7 @@ Value listaccounts(const Array& params, bool fHelp)
     if (params.size() > 0)
         nMinDepth = params[0].get_int();
 
-    map<string, int64_t> mapAccountBalances;
+    map<string, CMoney> mapAccountBalances;
     BOOST_FOREACH(const PAIRTYPE(CTxDestination, CAddressBookData)& entry, pwalletMain->mapAddressBook) {
         if (IsMine(*pwalletMain, entry.first)) // This address belongs to me
             mapAccountBalances[entry.second.name] = 0;
@@ -1320,20 +1320,20 @@ Value listaccounts(const Array& params, bool fHelp)
     for (map<uint256, CWalletTx>::iterator it = pwalletMain->mapWallet.begin(); it != pwalletMain->mapWallet.end(); ++it)
     {
         const CWalletTx& wtx = (*it).second;
-        int64_t nFee;
+        CMoney nFee;
         string strSentAccount;
-        list<pair<CTxDestination, int64_t> > listReceived;
-        list<pair<CTxDestination, int64_t> > listSent;
+        list<pair<CTxDestination, CMoney> > listReceived;
+        list<pair<CTxDestination, CMoney> > listSent;
         int nDepth = wtx.GetDepthInMainChain();
         if (wtx.GetBlocksToMaturity() > 0 || nDepth < 0)
             continue;
         wtx.GetAmounts(listReceived, listSent, nFee, strSentAccount);
         mapAccountBalances[strSentAccount] -= nFee;
-        BOOST_FOREACH(const PAIRTYPE(CTxDestination, int64_t)& s, listSent)
+        BOOST_FOREACH(const PAIRTYPE(CTxDestination, CMoney)& s, listSent)
             mapAccountBalances[strSentAccount] -= s.second;
         if (nDepth >= nMinDepth)
         {
-            BOOST_FOREACH(const PAIRTYPE(CTxDestination, int64_t)& r, listReceived)
+            BOOST_FOREACH(const PAIRTYPE(CTxDestination, CMoney)& r, listReceived)
                 if (pwalletMain->mapAddressBook.count(r.first))
                     mapAccountBalances[pwalletMain->mapAddressBook[r.first].name] += r.second;
                 else
@@ -1347,7 +1347,7 @@ Value listaccounts(const Array& params, bool fHelp)
         mapAccountBalances[entry.strAccount] += entry.nCreditDebit;
 
     Object ret;
-    BOOST_FOREACH(const PAIRTYPE(string, int64_t)& accountBalance, mapAccountBalances) {
+    BOOST_FOREACH(const PAIRTYPE(string, CMoney)& accountBalance, mapAccountBalances) {
         ret.push_back(Pair(accountBalance.first, ValueFromAmount(accountBalance.second)));
     }
     return ret;
@@ -1475,10 +1475,10 @@ Value gettransaction(const Array& params, bool fHelp)
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid or non-wallet transaction id");
     const CWalletTx& wtx = pwalletMain->mapWallet[hash];
 
-    int64_t nCredit = wtx.GetCredit();
-    int64_t nDebit = wtx.GetDebit();
-    int64_t nNet = nCredit - nDebit;
-    int64_t nFee = (wtx.IsFromMe() ? wtx.GetValueOut() - nDebit : 0);
+    CMoney nCredit = wtx.GetCredit();
+    CMoney nDebit = wtx.GetDebit();
+    CMoney nNet = nCredit - nDebit;
+    CMoney nFee = (wtx.IsFromMe() ? wtx.GetValueOut() - nDebit : 0);
 
     entry.push_back(Pair("amount", ValueFromAmount(nNet - nFee)));
     if (wtx.IsFromMe())
@@ -1880,7 +1880,7 @@ Value settxfee(const Array& params, bool fHelp)
         );
 
     // Amount
-    int64_t nAmount = 0;
+    CMoney nAmount = 0;
     if (params[0].get_real() != 0.0)
         nAmount = AmountFromValue(params[0]);        // rejects 0.0 amounts
 

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -548,7 +548,7 @@ Value getreceivedbyaccount(const Array& params, bool fHelp)
         }
     }
 
-    return (double)nAmount / (double)COIN;
+    return ValueFromAmount(nAmount);
 }
 
 
@@ -612,7 +612,7 @@ Value getbalance(const Array& params, bool fHelp)
         );
 
     if (params.size() == 0)
-        return  ValueFromAmount(pwalletMain->GetBalance());
+        return  ValueFromAmount(pwalletMain->GetBalance(), ROUND_TOWARDS_ZERO);
 
     int nMinDepth = 1;
     if (params.size() > 1)
@@ -643,14 +643,14 @@ Value getbalance(const Array& params, bool fHelp)
                 nBalance -= r.second;
             nBalance -= allFee;
         }
-        return  ValueFromAmount(nBalance);
+        return  ValueFromAmount(nBalance, ROUND_TOWARDS_ZERO);
     }
 
     string strAccount = AccountFromValue(params[0]);
 
     CMoney nBalance = GetAccountBalance(strAccount, nMinDepth);
 
-    return ValueFromAmount(nBalance);
+    return ValueFromAmount(nBalance, ROUND_TOWARDS_ZERO);
 }
 
 Value getunconfirmedbalance(const Array &params, bool fHelp)
@@ -1879,10 +1879,10 @@ Value settxfee(const Array& params, bool fHelp)
             + HelpExampleRpc("settxfee", "0.00001")
         );
 
-    // Amount
-    CMoney nAmount = 0;
-    if (params[0].get_real() != 0.0)
-        nAmount = AmountFromValue(params[0]);        // rejects 0.0 amounts
+    CMoney nAmount = AmountFromValue(params[0]); // rejects !MoneyRange
+    if (nAmount == 0)
+        throw JSONRPCError(RPC_TYPE_ERROR,
+                           "Zero transaction fee not allowed.");
 
     nTransactionFee = nAmount;
     return true;

--- a/src/test/accounting_tests.cpp
+++ b/src/test/accounting_tests.cpp
@@ -15,7 +15,7 @@ extern CWallet* pwalletMain;
 BOOST_AUTO_TEST_SUITE(accounting_tests)
 
 static void
-GetResults(CWalletDB& walletdb, std::map<int64_t, CAccountingEntry>& results)
+GetResults(CWalletDB& walletdb, std::map<CMoney, CAccountingEntry>& results)
 {
     std::list<CAccountingEntry> aes;
 
@@ -34,7 +34,7 @@ BOOST_AUTO_TEST_CASE(acc_orderupgrade)
     std::vector<CWalletTx*> vpwtx;
     CWalletTx wtx;
     CAccountingEntry ae;
-    std::map<int64_t, CAccountingEntry> results;
+    std::map<CMoney, CAccountingEntry> results;
 
     LOCK(pwalletMain->cs_wallet);
 

--- a/src/test/compress_tests.cpp
+++ b/src/test/compress_tests.cpp
@@ -24,16 +24,16 @@
 BOOST_AUTO_TEST_SUITE(compress_tests)
 
 bool static TestEncode(uint64_t in) {
-    return in == CTxOutCompressor::DecompressAmount(CTxOutCompressor::CompressAmount(in));
+    return in == CCompressedMoney::DecompressAmount(CCompressedMoney::CompressAmount(in));
 }
 
 bool static TestDecode(uint64_t in) {
-    return in == CTxOutCompressor::CompressAmount(CTxOutCompressor::DecompressAmount(in));
+    return in == CCompressedMoney::CompressAmount(CCompressedMoney::DecompressAmount(in));
 }
 
 bool static TestPair(uint64_t dec, uint64_t enc) {
-    return CTxOutCompressor::CompressAmount(dec) == enc &&
-           CTxOutCompressor::DecompressAmount(enc) == dec;
+    return CCompressedMoney::CompressAmount(dec) == enc &&
+           CCompressedMoney::DecompressAmount(enc) == dec;
 }
 
 BOOST_AUTO_TEST_CASE(compress_amounts)

--- a/src/test/main_tests.cpp
+++ b/src/test/main_tests.cpp
@@ -11,9 +11,9 @@ BOOST_AUTO_TEST_SUITE(main_tests)
 
 BOOST_AUTO_TEST_CASE(subsidy_limit_test)
 {
-    uint64_t nSum = 0;
+    CMoney nSum = 0;
     for (int nHeight = 0; nHeight < 14000000; nHeight += 1000) {
-        uint64_t nSubsidy = GetBlockValue(nHeight, 0);
+        CMoney nSubsidy = GetBlockValue(nHeight, 0);
         BOOST_CHECK(nSubsidy <= 50 * COIN);
         nSum += nSubsidy * 1000;
         BOOST_CHECK(MoneyRange(nSum));

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -165,6 +165,47 @@ BOOST_AUTO_TEST_CASE(util_GetArg)
     BOOST_CHECK_EQUAL(GetBoolArg("booltest4", false), true);
 }
 
+BOOST_AUTO_TEST_CASE(util_EncodeDouble)
+{
+    for (int i = -8; i <= 8; ++i)
+    for (int j = -8; j <= 8; ++j)
+    {
+        BOOST_CHECK((i==j) == (EncodeDouble(i)==EncodeDouble(j)));
+        BOOST_CHECK((i< j) == (EncodeDouble(i)< EncodeDouble(j)));
+    }
+}
+
+BOOST_AUTO_TEST_CASE(util_DecodeDouble)
+{
+    for (uint64_t i = 0x7ffeffffffffffffLL - 8; i <= 0x7ffeffffffffffffLL; ++i)
+    for (uint64_t j = 0x7ffeffffffffffffLL - 8; j <= 0x7ffeffffffffffffLL; ++j)
+    {
+        BOOST_CHECK((i==j) == (DecodeDouble(i)==DecodeDouble(j)));
+        BOOST_CHECK((i< j) == (DecodeDouble(i)< DecodeDouble(j)));
+    }
+
+    for (uint64_t i = 0x7ffeffffffffffffLL - 8; i <= 0x7ffeffffffffffffLL; ++i)
+    for (uint64_t j = 0x8ffeffffffffffffLL - 8; j <= 0x8ffeffffffffffffLL; ++j)
+    {
+        BOOST_CHECK((i==j) == (DecodeDouble(i)==DecodeDouble(j)));
+        BOOST_CHECK((i< j) == (DecodeDouble(i)< DecodeDouble(j)));
+    }
+
+    for (uint64_t i = 0x8ffeffffffffffffLL - 8; i <= 0x8ffeffffffffffffLL; ++i)
+    for (uint64_t j = 0x7ffeffffffffffffLL - 8; j <= 0x7ffeffffffffffffLL; ++j)
+    {
+        BOOST_CHECK((i==j) == (DecodeDouble(i)==DecodeDouble(j)));
+        BOOST_CHECK((i< j) == (DecodeDouble(i)< DecodeDouble(j)));
+    }
+
+    for (uint64_t i = 0x8ffeffffffffffffLL - 8; i <= 0x8ffeffffffffffffLL; ++i)
+    for (uint64_t j = 0x8ffeffffffffffffLL - 8; j <= 0x8ffeffffffffffffLL; ++j)
+    {
+        BOOST_CHECK((i==j) == (DecodeDouble(i)==DecodeDouble(j)));
+        BOOST_CHECK((i< j) == (DecodeDouble(i)< DecodeDouble(j)));
+    }
+}
+
 BOOST_AUTO_TEST_CASE(util_FormatMoney)
 {
     BOOST_CHECK_EQUAL(FormatMoney(0, false), "0.00");

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -194,7 +194,7 @@ BOOST_AUTO_TEST_CASE(util_FormatMoney)
 
 BOOST_AUTO_TEST_CASE(util_ParseMoney)
 {
-    int64_t ret = 0;
+    CMoney ret = 0;
     BOOST_CHECK(ParseMoney("0.0", ret));
     BOOST_CHECK_EQUAL(ret, 0);
 

--- a/src/test/wallet_tests.cpp
+++ b/src/test/wallet_tests.cpp
@@ -28,7 +28,7 @@ BOOST_AUTO_TEST_SUITE(wallet_tests)
 static CWallet wallet;
 static vector<COutput> vCoins;
 
-static void add_coin(int64_t nValue, int nAge = 6*24, bool fIsFromMe = false, int nInput=0)
+static void add_coin(const CMoney& nValue, int nAge = 6*24, bool fIsFromMe = false, int nInput=0)
 {
     static int nextLockTime = 0;
     CTransaction tx;
@@ -64,7 +64,7 @@ static bool equal_sets(CoinSet a, CoinSet b)
 BOOST_AUTO_TEST_CASE(coin_selection_tests)
 {
     CoinSet setCoinsRet, setCoinsRet2;
-    int64_t nValueRet;
+    CMoney nValueRet;
 
     LOCK(wallet.cs_wallet);
 

--- a/src/test/wallet_tests.cpp
+++ b/src/test/wallet_tests.cpp
@@ -183,11 +183,11 @@ BOOST_AUTO_TEST_CASE(coin_selection_tests)
 
         // empty the wallet and start again, now with fractions of a cent, to test sub-cent change avoidance
         empty_wallet();
-        add_coin(0.1*CENT);
-        add_coin(0.2*CENT);
-        add_coin(0.3*CENT);
-        add_coin(0.4*CENT);
-        add_coin(0.5*CENT);
+        add_coin(CENT     / 10);
+        add_coin(CENT * 2 / 10);
+        add_coin(CENT * 3 / 10);
+        add_coin(CENT * 4 / 10);
+        add_coin(CENT * 5 / 10);
 
         // try making 1 cent from 0.1 + 0.2 + 0.3 + 0.4 + 0.5 = 1.5 cents
         // we'll get sub-cent change whatever happens, so can expect 1.0 exactly
@@ -202,8 +202,8 @@ BOOST_AUTO_TEST_CASE(coin_selection_tests)
         BOOST_CHECK_EQUAL(nValueRet, 1 * CENT); // we should get the exact amount
 
         // if we add more sub-cent coins:
-        add_coin(0.6*CENT);
-        add_coin(0.7*CENT);
+        add_coin(CENT * 6 / 10);
+        add_coin(CENT * 7 / 10);
 
         // and try again to make 1.0 cents, we can still make 1.0 cents
         BOOST_CHECK( wallet.SelectCoinsMinConf(1 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
@@ -224,9 +224,9 @@ BOOST_AUTO_TEST_CASE(coin_selection_tests)
 
         // sometimes it will fail, and so we use the next biggest coin:
         empty_wallet();
-        add_coin(0.5 * CENT);
-        add_coin(0.6 * CENT);
-        add_coin(0.7 * CENT);
+        add_coin(CENT * 5 / 10);
+        add_coin(CENT * 6 / 10);
+        add_coin(CENT * 7 / 10);
         add_coin(1111 * CENT);
         BOOST_CHECK( wallet.SelectCoinsMinConf(1 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
         BOOST_CHECK_EQUAL(nValueRet, 1111 * CENT); // we get the bigger coin
@@ -234,9 +234,9 @@ BOOST_AUTO_TEST_CASE(coin_selection_tests)
 
         // but sometimes it's possible, and we use an exact subset (0.4 + 0.6 = 1.0)
         empty_wallet();
-        add_coin(0.4 * CENT);
-        add_coin(0.6 * CENT);
-        add_coin(0.8 * CENT);
+        add_coin(CENT * 4 / 10);
+        add_coin(CENT * 6 / 10);
+        add_coin(CENT * 8 / 10);
         add_coin(1111 * CENT);
         BOOST_CHECK( wallet.SelectCoinsMinConf(1 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
         BOOST_CHECK_EQUAL(nValueRet, 1 * CENT);   // we should get the exact amount
@@ -244,18 +244,18 @@ BOOST_AUTO_TEST_CASE(coin_selection_tests)
 
         // test avoiding sub-cent change
         empty_wallet();
-        add_coin(0.0005 * COIN);
-        add_coin(0.01 * COIN);
-        add_coin(1 * COIN);
+        add_coin(COIN * 5 / 10000);
+        add_coin(COIN * 1 / 100);
+        add_coin(COIN);
 
         // trying to make 1.0001 from these three coins
-        BOOST_CHECK( wallet.SelectCoinsMinConf(1.0001 * COIN, 1, 1, vCoins, setCoinsRet, nValueRet));
-        BOOST_CHECK_EQUAL(nValueRet, 1.0105 * COIN);   // we should get all coins
+        BOOST_CHECK( wallet.SelectCoinsMinConf(COIN * 10001 / 10000, 1, 1, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK_EQUAL(nValueRet, COIN * 10105 / 10000);   // we should get all coins
         BOOST_CHECK_EQUAL(setCoinsRet.size(), 3U);
 
         // but if we try to make 0.999, we should take the bigger of the two small coins to avoid sub-cent change
-        BOOST_CHECK( wallet.SelectCoinsMinConf(0.999 * COIN, 1, 1, vCoins, setCoinsRet, nValueRet));
-        BOOST_CHECK_EQUAL(nValueRet, 1.01 * COIN);   // we should get 1 + 0.01
+        BOOST_CHECK( wallet.SelectCoinsMinConf(COIN * 999 / 1000, 1, 1, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK_EQUAL(nValueRet, COIN * 101 / 100);   // we should get 1 + 0.01
         BOOST_CHECK_EQUAL(setCoinsRet.size(), 2U);
 
         // test randomness

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -108,7 +108,7 @@ bool CCoinsViewDB::GetStats(CCoinsStats &stats) {
     CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
     stats.hashBlock = GetBestBlock();
     ss << stats.hashBlock;
-    int64_t nTotalAmount = 0;
+    CMoney nTotalAmount = 0;
     while (pcursor->Valid()) {
         boost::this_thread::interruption_point();
         try {

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -13,7 +13,7 @@ CTxMemPoolEntry::CTxMemPoolEntry()
     nHeight = MEMPOOL_HEIGHT;
 }
 
-CTxMemPoolEntry::CTxMemPoolEntry(const CTransaction& _tx, int64_t _nFee,
+CTxMemPoolEntry::CTxMemPoolEntry(const CTransaction& _tx, const CMoney& _nFee,
                                  int64_t _nTime, double _dPriority,
                                  unsigned int _nHeight):
     tx(_tx), nFee(_nFee), nTime(_nTime), dPriority(_dPriority), nHeight(_nHeight)
@@ -29,7 +29,7 @@ CTxMemPoolEntry::CTxMemPoolEntry(const CTxMemPoolEntry& other)
 double
 CTxMemPoolEntry::GetPriority(unsigned int currentHeight) const
 {
-    int64_t nValueIn = tx.GetValueOut()+nFee;
+    CMoney nValueIn = tx.GetValueOut()+nFee;
     double deltaPriority = ((double)(currentHeight-nHeight)*nValueIn)/nTxSize;
     double dResult = dPriority + deltaPriority;
     return dResult;

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -30,7 +30,7 @@ double
 CTxMemPoolEntry::GetPriority(unsigned int currentHeight) const
 {
     CMoney nValueIn = tx.GetValueOut()+nFee;
-    double deltaPriority = ((double)(currentHeight-nHeight)*nValueIn)/nTxSize;
+    double deltaPriority = ((double)(currentHeight-nHeight)*nValueIn.ToDouble())/nTxSize;
     double dResult = dPriority + deltaPriority;
     return dResult;
 }

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -21,21 +21,21 @@ class CTxMemPoolEntry
 {
 private:
     CTransaction tx;
-    int64_t nFee; // Cached to avoid expensive parent-transaction lookups
+    CMoney nFee; // Cached to avoid expensive parent-transaction lookups
     size_t nTxSize; // ... and avoid recomputing tx size
     int64_t nTime; // Local time when entering the mempool
     double dPriority; // Priority when entering the mempool
     unsigned int nHeight; // Chain height when entering the mempool
 
 public:
-    CTxMemPoolEntry(const CTransaction& _tx, int64_t _nFee,
+    CTxMemPoolEntry(const CTransaction& _tx, const CMoney& _nFee,
                     int64_t _nTime, double _dPriority, unsigned int _nHeight);
     CTxMemPoolEntry();
     CTxMemPoolEntry(const CTxMemPoolEntry& other);
 
     const CTransaction& GetTx() const { return this->tx; }
     double GetPriority(unsigned int currentHeight) const;
-    int64_t GetFee() const { return nFee; }
+    CMoney GetFee() const { return nFee; }
     size_t GetTxSize() const { return nTxSize; }
     int64_t GetTime() const { return nTime; }
     unsigned int GetHeight() const { return nHeight; }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -303,10 +303,43 @@ int LogPrintStr(const std::string &str)
     return ret;
 }
 
-string FormatMoney(const CMoney& n, bool fPlus)
+
+/* EncodeDouble() transforms a 64-bit IEEE floating-point value into an
+ * equal-width integer by means of a 1:1 function which preserves sort
+ * ordering, at least for non-NaN values. For two floating point values
+ * a and b, if a < b, then EncodeDouble(a) < EncodeDouble(b). This is
+ * useful for circumstances such as the coin-control dialog where it
+ * makes sense to maintain an hidden integer-valued sort field for the
+ * GUI display (see qt/coincontroldialog.cpp).
+ *
+ * For positive values the floating point format is already defined to
+ * be sortable based on encoded representation. Since the result is
+ * unsigned, the sign bit is flipped so that negative values sort
+ * before positive values. The non-sign bits of negative values also
+ * need to be flipped in order to ensure proper ordering of that
+ * sequence.
+ */
+uint64_t EncodeDouble(double d)
+{
+    const uint64_t wide0 = 0;
+    const uint64_t wide1 = 1;
+    uint64_t ieee = *(uint64_t*)&d;
+    return (((wide1<<63) & ieee)? wide0: ((~wide0) >> 1)) ^ ~ieee;
+}
+
+double DecodeDouble(uint64_t lex)
+{
+    const uint64_t wide0 = 0;
+    const uint64_t wide1 = 1;
+    uint64_t ieee = (((wide1<<63) & lex)? ((~wide0) >> 1): wide0) ^ ~lex;
+    return *(double*)&ieee;
+}
+
+string FormatMoney(const CMoney& nIn, bool fPlus)
 {
     // Note: not using straight sprintf here because we do NOT want
     // localized number formatting.
+    int64_t n = nIn.ToInt64();
     int64_t n_abs = (n > 0 ? n : -n);
     int64_t quotient = n_abs/COIN;
     int64_t remainder = n_abs%COIN;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -303,7 +303,7 @@ int LogPrintStr(const std::string &str)
     return ret;
 }
 
-string FormatMoney(int64_t n, bool fPlus)
+string FormatMoney(const CMoney& n, bool fPlus)
 {
     // Note: not using straight sprintf here because we do NOT want
     // localized number formatting.
@@ -327,12 +327,12 @@ string FormatMoney(int64_t n, bool fPlus)
 }
 
 
-bool ParseMoney(const string& str, int64_t& nRet)
+bool ParseMoney(const string& str, CMoney& nRet)
 {
     return ParseMoney(str.c_str(), nRet);
 }
 
-bool ParseMoney(const char* pszIn, int64_t& nRet)
+bool ParseMoney(const char* pszIn, CMoney& nRet)
 {
     string strWhole;
     int64_t nUnits = 0;
@@ -366,7 +366,7 @@ bool ParseMoney(const char* pszIn, int64_t& nRet)
     if (nUnits < 0 || nUnits > COIN)
         return false;
     int64_t nWhole = atoi64(strWhole);
-    int64_t nValue = nWhole*COIN + nUnits;
+    CMoney nValue = nWhole*COIN + nUnits;
 
     nRet = nValue;
     return true;

--- a/src/util.h
+++ b/src/util.h
@@ -155,6 +155,8 @@ static inline bool error(const char* format)
 
 void LogException(std::exception* pex, const char* pszThread);
 void PrintExceptionContinue(std::exception* pex, const char* pszThread);
+uint64_t EncodeDouble(double d);
+double DecodeDouble(uint64_t lex);
 std::string FormatMoney(const CMoney& n, bool fPlus=false);
 bool ParseMoney(const std::string& str, CMoney& nRet);
 bool ParseMoney(const char* pszIn, CMoney& nRet);

--- a/src/util.h
+++ b/src/util.h
@@ -11,6 +11,7 @@
 #endif
 
 #include "compat.h"
+#include "money.h"
 #include "serialize.h"
 #include "tinyformat.h"
 
@@ -154,9 +155,9 @@ static inline bool error(const char* format)
 
 void LogException(std::exception* pex, const char* pszThread);
 void PrintExceptionContinue(std::exception* pex, const char* pszThread);
-std::string FormatMoney(int64_t n, bool fPlus=false);
-bool ParseMoney(const std::string& str, int64_t& nRet);
-bool ParseMoney(const char* pszIn, int64_t& nRet);
+std::string FormatMoney(const CMoney& n, bool fPlus=false);
+bool ParseMoney(const std::string& str, CMoney& nRet);
+bool ParseMoney(const char* pszIn, CMoney& nRet);
 std::string SanitizeString(const std::string& str);
 std::vector<unsigned char> ParseHex(const char* psz);
 std::vector<unsigned char> ParseHex(const std::string& str);

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1268,7 +1268,7 @@ bool CWallet::CreateTransaction(const vector<pair<CScript, CMoney> >& vecSend,
                     //The priority after the next block (depth+1) is used instead of the current,
                     //reflecting an assumption the user would accept a bit more delay for
                     //a chance at a free transaction.
-                    dPriority += (double)nCredit * (pcoin.first->GetDepthInMainChain()+1);
+                    dPriority += nCredit.ToDouble() * (pcoin.first->GetDepthInMainChain()+1);
                 }
 
                 CMoney nChange = nValueIn - nValue - nFeeRet;

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -829,7 +829,12 @@ public:
         if (!(nType & SER_GETHASH))
             READWRITE(nVersion);
         // Note: strAccount is serialized as part of the key, not here.
-        READWRITE(nCreditDebit);
+        int64_t nCreditDebitI64;
+        if (fWrite)
+            nCreditDebitI64 = nCreditDebit.ToInt64(ROUND_SIGNAL);
+        READWRITE(nCreditDebitI64);
+        if (fRead)
+            me.nCreditDebit = nCreditDebitI64;
         READWRITE(nTime);
         READWRITE(strOtherAccount);
 

--- a/src/walletdb.cpp
+++ b/src/walletdb.cpp
@@ -178,12 +178,12 @@ bool CWalletDB::WriteAccountingEntry(const CAccountingEntry& acentry)
     return WriteAccountingEntry(++nAccountingEntryNumber, acentry);
 }
 
-int64_t CWalletDB::GetAccountCreditDebit(const string& strAccount)
+CMoney CWalletDB::GetAccountCreditDebit(const string& strAccount)
 {
     list<CAccountingEntry> entries;
     ListAccountCreditDebit(strAccount, entries);
 
-    int64_t nCreditDebit = 0;
+    CMoney nCreditDebit = 0;
     BOOST_FOREACH (const CAccountingEntry& entry, entries)
         nCreditDebit += entry.nCreditDebit;
 

--- a/src/walletdb.h
+++ b/src/walletdb.h
@@ -7,6 +7,7 @@
 
 #include "db.h"
 #include "key.h"
+#include "money.h"
 
 #include <list>
 #include <stdint.h>
@@ -117,7 +118,7 @@ private:
     bool WriteAccountingEntry(const uint64_t nAccEntryNum, const CAccountingEntry& acentry);
 public:
     bool WriteAccountingEntry(const CAccountingEntry& acentry);
-    int64_t GetAccountCreditDebit(const std::string& strAccount);
+    CMoney GetAccountCreditDebit(const std::string& strAccount);
     void ListAccountCreditDebit(const std::string& strAccount, std::list<CAccountingEntry>& acentries);
 
     DBErrors ReorderTransactions(CWallet*);


### PR DESCRIPTION
Provides code parity between bitcoin and side chains which use a different type for representing and performing arithmetic on coin balances, e.g. Freicoin's use of the GMP library's arbitrary-precision rational number type for increased divisibility and interest calculations. This greatly reduces the friction in sharing code and submitting code upstream. Also organizes related functionality such as FormatMoney and ParseMoney into a single class framework.
