### PR TITLE
Add MESSAGE_START_SIZE from chainparams when loading external blocks.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3092,11 +3092,11 @@ bool LoadExternalBlockFile(FILE* fileIn, CDiskBlockPos *dbp)
             unsigned int nSize = 0;
             try {
                 // locate a header
-                unsigned char buf[4];
+                unsigned char buf[MESSAGE_START_SIZE];
                 blkdat.FindByte(Params().MessageStart()[0]);
                 nRewind = blkdat.GetPos()+1;
                 blkdat >> FLATDATA(buf);
-                if (memcmp(buf, Params().MessageStart(), 4))
+                if (memcmp(buf, Params().MessageStart(), MESSAGE_START_SIZE))
                     continue;
                 // read size
                 blkdat >> nSize;


### PR DESCRIPTION
When loading blocks externally, it still used the pre-set 4, instead of using the MESSAGE_START_SIZE in chainparams.
