### PR TITLE
gitian: build against Qt 4.6

### DIFF
--- a/contrib/devtools/symbol-check.py
+++ b/contrib/devtools/symbol-check.py
@@ -98,10 +98,15 @@ if __name__ == '__main__':
     cppfilt = CPPFilt()
     retval = 0
     for filename in sys.argv[1:]:
+        # Check imported symbols
         for sym,version in read_symbols(filename, True):
             if version and not check_version(MAX_VERSIONS, version):
                 print('%s: symbol %s from unsupported version %s' % (filename, cppfilt(sym), version))
                 retval = 1
+        # Check exported symbols
+        for sym,version in read_symbols(filename, False):
+            print('%s: export of symbol %s not allowed' % (filename, cppfilt(sym)))
+            retval = 1
 
     exit(retval)
 

--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -7,7 +7,6 @@ architectures:
 - "amd64"
 packages: 
 - "g++"
-- "libqt4-dev"
 - "git-core"
 - "unzip"
 - "pkg-config"
@@ -16,6 +15,11 @@ packages:
 - "automake"
 - "faketime"
 - "bsdmainutils"
+- "libqt4-core"
+- "libqt4-gui"
+- "libqt4-dbus"
+- "libqt4-network"
+- "libqt4-test"
 reference_datetime: "2013-06-01 00:00:00"
 remotes:
 - "url": "https://github.com/bitcoin/bitcoin.git"
@@ -25,6 +29,8 @@ files:
 - "bitcoin-deps-linux64-gitian-r5.zip"
 - "boost-linux32-1.55.0-gitian-r1.zip"
 - "boost-linux64-1.55.0-gitian-r1.zip"
+- "qt-linux32-4.6.4-gitian-r1.tar.gz"
+- "qt-linux64-4.6.4-gitian-r1.tar.gz"
 script: |
   STAGING="$HOME/install"
   OPTFLAGS='-O2'
@@ -32,12 +38,14 @@ script: |
   TEMPDIR="$HOME/tempdir"
   export TZ=UTC
   export LIBRARY_PATH="$STAGING/lib"
+  export PATH="$STAGING/bin:$PATH"
   mkdir -p ${BINDIR}
   #
   mkdir -p $STAGING
   cd $STAGING
   unzip ../build/bitcoin-deps-linux${GBUILD_BITS}-gitian-r5.zip
   unzip ../build/boost-linux${GBUILD_BITS}-1.55.0-gitian-r1.zip
+  tar -zxf ../build/qt-linux${GBUILD_BITS}-4.6.4-gitian-r1.tar.gz
   cd ../build
 
   function do_configure {

--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -48,8 +48,18 @@ script: |
   tar -zxf ../build/qt-linux${GBUILD_BITS}-4.6.4-gitian-r1.tar.gz
   cd ../build
 
+  # Avoid exporting *any* symbols from the executable
+  # This avoids conflicts between the libraries statically linked into bitcoin and any
+  # libraries we may link dynamically (such as Qt and OpenSSL, see issue #4094).
+  # It also avoids start-up overhead to not export any unnecessary symbols.
+  # To do this, build a linker script that marks all symbols as local.
+  LINKER_SCRIPT=$HOME/build/linker_version_script
+  echo '
+  {
+    local: *;
+  };' > $LINKER_SCRIPT
   function do_configure {
-    ./configure "$@" --enable-upnp-default --prefix=$STAGING --with-protoc-bindir=$STAGING/host/bin --with-boost=$STAGING --disable-maintainer-mode --disable-dependency-tracking PKG_CONFIG_PATH="$STAGING/lib/pkgconfig" CPPFLAGS="-I$STAGING/include ${OPTFLAGS}" LDFLAGS="-L$STAGING/lib ${OPTFLAGS}" CXXFLAGS="-frandom-seed=bitcoin ${OPTFLAGS}" BOOST_CHRONO_EXTRALIBS="-lrt" --enable-glibc-back-compat
+      ./configure "$@" --enable-upnp-default --prefix=$STAGING --with-protoc-bindir=$STAGING/host/bin --with-boost=$STAGING --disable-maintainer-mode --disable-dependency-tracking PKG_CONFIG_PATH="$STAGING/lib/pkgconfig" CPPFLAGS="-I$STAGING/include ${OPTFLAGS}" LDFLAGS="-L$STAGING/lib -Wl,--version-script=$LINKER_SCRIPT ${OPTFLAGS}" CXXFLAGS="-frandom-seed=bitcoin ${OPTFLAGS}" BOOST_CHRONO_EXTRALIBS="-lrt" --enable-glibc-back-compat
   }
   #
   cd bitcoin

--- a/contrib/gitian-descriptors/qt-linux.yml
+++ b/contrib/gitian-descriptors/qt-linux.yml
@@ -1,0 +1,263 @@
+---
+name: "qt-linux"
+suites:
+- "precise"
+architectures:
+- "i386"
+- "amd64"
+packages:
+- "zip"
+- "unzip"
+- "faketime"
+- "unzip"
+- "libxext-dev"
+reference_datetime: "2011-01-30 00:00:00"
+remotes: []
+files:
+- "qt-everywhere-opensource-src-4.6.4.tar.gz"
+script: |
+  export FAKETIME=$REFERENCE_DATETIME
+  export TZ=UTC
+  if [ "$GBUILD_BITS" == "32" ]; then
+    ARCH='i386-linux-gnu'
+  else
+    ARCH='x86_64-linux-gnu'
+  fi
+  # The purpose of this gitian build is not to actually build Qt, but to export
+  # the headers as well as pkgconfig files in a useable format so that we can
+  # pretend to link against an older version. The goal is to link to the
+  # system version of Qt 4.
+  # Also build development tools.
+  INSTALLPREFIX="$HOME/install"
+  # Integrity Check
+  echo "9ad4d46c721b53a429ed5a2eecfd3c239a9ab566562f183f99d3125f1a234250  qt-everywhere-opensource-src-4.6.4.tar.gz" | sha256sum -c
+  # Make install directories
+  mkdir -p $INSTALLPREFIX
+  mkdir -p $INSTALLPREFIX/include
+  PKGCONFIGDIR=$INSTALLPREFIX/lib/pkgconfig
+  mkdir -p $PKGCONFIGDIR
+  #
+  tar xzf qt-everywhere-opensource-src-4.6.4.tar.gz
+  cd qt-everywhere-opensource-src-4.6.4
+  QTBUILDDIR=$(pwd)
+
+  # Need to build 4.6-versioned host utilities as well (lrelease/qrc/lupdate/...)
+  ./configure -prefix $INSTALLPREFIX -confirm-license -release -opensource -no-qt3support -no-multimedia -no-audio-backend -no-phonon -no-phonon-backend -no-declarative -no-script -no-scripttools -no-javascript-jit -no-webkit -no-svg -no-xmlpatterns -no-sql-sqlite -no-nis -no-cups -no-iconv -no-dbus -no-gif -no-libtiff -no-opengl -nomake examples -nomake demos -nomake docs
+  #
+  make $MAKEOPTS -C src/tools install  # (rcc, uic, moc)
+  make $MAKEOPTS -C tools/linguist/lrelease install  # (lrelease)
+  # install includes and pkgconfig files
+  for DIR in src/corelib src/gui src/testlib src/dbus src/network; do
+    (
+    cd $DIR
+    # extract module (QtCore/QtNetwork/...) from Makefile
+    MODULE=$(grep "QMAKE_TARGET *=" Makefile | cut -d = -f 2 | xargs)
+    # patch makefile so that not everything is build first
+    sed -i 's/first: all/first:/g' Makefile
+    make install_flat_headers install_class_headers install_targ_headers
+    # create and install pkgconfig descriptor
+    make ../../lib/pkgconfig/$MODULE.pc
+    sed -e "s,$QTBUILDDIR,$INSTALLPREFIX,g" ../../lib/pkgconfig/$MODULE.pc > $PKGCONFIGDIR/$MODULE.pc
+    # create links to existing Qt libraries
+    ln -sf /usr/lib/${ARCH}/lib${MODULE}.so.4 ${INSTALLPREFIX}/lib/lib${MODULE}.so
+    )
+  done
+
+  # Write our own configuration header, same as Ubuntu
+  # When we don't do this, the configuration will be without STL support (the QString from/to stdString methods)
+  QCONFIG=$INSTALLPREFIX/include/Qt/qconfig.h
+  echo '
+  /* Qt Edition */
+  #ifndef QT_EDITION
+  #  define QT_EDITION QT_EDITION_OPENSOURCE
+  #endif
+  ' > $QCONFIG
+
+  if [ "$GBUILD_BITS" == "32" ]; then
+    echo '
+  /* Machine byte-order */
+  #define Q_BIG_ENDIAN 4321
+  #define Q_LITTLE_ENDIAN 1234
+  #define QT_BUILD_KEY "i386 linux g++-4 full-config"
+  #define QT_BUILD_KEY_COMPAT "i686 Linux g++-4 full-config"
+
+  #ifdef QT_BOOTSTRAPPED
+  #define Q_BYTE_ORDER Q_LITTLE_ENDIAN
+  #else
+  #define Q_BYTE_ORDER Q_LITTLE_ENDIAN
+  #endif
+  /* Machine Architecture */
+  #ifndef QT_BOOTSTRAPPED
+  # define QT_ARCH_I386
+  #else
+  # define QT_ARCH_I386
+  #endif
+  /* Compile time features */
+  #define QT_LARGEFILE_SUPPORT 64
+  #define QT_POINTER_SIZE 4
+  ' >> $QCONFIG
+  else
+    echo '
+  /* Machine byte-order */
+  #define Q_BIG_ENDIAN 4321
+  #define Q_LITTLE_ENDIAN 1234
+  #define QT_BUILD_KEY "x86_64 linux g++-4 full-config"
+  #define QT_BUILD_KEY_COMPAT "x86_64 Linux g++-4 full-config"
+
+  #ifdef QT_BOOTSTRAPPED
+  #define Q_BYTE_ORDER Q_LITTLE_ENDIAN
+  #else
+  #define Q_BYTE_ORDER Q_LITTLE_ENDIAN
+  #endif
+  /* Machine Architecture */
+  #ifndef QT_BOOTSTRAPPED
+  # define QT_ARCH_X86_64
+  #else
+  # define QT_ARCH_X86_64
+  #endif
+  /* Compile time features */
+  #define QT_LARGEFILE_SUPPORT 64
+  #define QT_POINTER_SIZE 8
+  ' >> $QCONFIG
+  fi
+
+  echo '
+  #ifndef QT_BOOTSTRAPPED
+
+  #if defined(QT_NO_EGL) && defined(QT_EGL)
+  # undef QT_NO_EGL
+  #elif !defined(QT_NO_EGL) && !defined(QT_EGL)
+  # define QT_NO_EGL
+  #endif
+
+  #if defined(QT_NO_GSTREAMER) && defined(QT_GSTREAMER)
+  # undef QT_NO_GSTREAMER
+  #elif !defined(QT_NO_GSTREAMER) && !defined(QT_GSTREAMER)
+  # define QT_NO_GSTREAMER
+  #endif
+
+  #if defined(QT_NO_ICD) && defined(QT_ICD)
+  # undef QT_NO_ICD
+  #elif !defined(QT_NO_ICD) && !defined(QT_ICD)
+  # define QT_NO_ICD
+  #endif
+
+  #if defined(QT_NO_IMAGEFORMAT_JPEG) && defined(QT_IMAGEFORMAT_JPEG)
+  # undef QT_NO_IMAGEFORMAT_JPEG
+  #elif !defined(QT_NO_IMAGEFORMAT_JPEG) && !defined(QT_IMAGEFORMAT_JPEG)
+  # define QT_NO_IMAGEFORMAT_JPEG
+  #endif
+
+  #if defined(QT_NO_IMAGEFORMAT_MNG) && defined(QT_IMAGEFORMAT_MNG)
+  # undef QT_NO_IMAGEFORMAT_MNG
+  #elif !defined(QT_NO_IMAGEFORMAT_MNG) && !defined(QT_IMAGEFORMAT_MNG)
+  # define QT_NO_IMAGEFORMAT_MNG
+  #endif
+
+  #if defined(QT_NO_IMAGEFORMAT_TIFF) && defined(QT_IMAGEFORMAT_TIFF)
+  # undef QT_NO_IMAGEFORMAT_TIFF
+  #elif !defined(QT_NO_IMAGEFORMAT_TIFF) && !defined(QT_IMAGEFORMAT_TIFF)
+  # define QT_NO_IMAGEFORMAT_TIFF
+  #endif
+
+  #if defined(QT_NO_MULTIMEDIA) && defined(QT_MULTIMEDIA)
+  # undef QT_NO_MULTIMEDIA
+  #elif !defined(QT_NO_MULTIMEDIA) && !defined(QT_MULTIMEDIA)
+  # define QT_NO_MULTIMEDIA
+  #endif
+
+  #if defined(QT_NO_OPENVG) && defined(QT_OPENVG)
+  # undef QT_NO_OPENVG
+  #elif !defined(QT_NO_OPENVG) && !defined(QT_OPENVG)
+  # define QT_NO_OPENVG
+  #endif
+
+  #if defined(QT_NO_PHONON) && defined(QT_PHONON)
+  # undef QT_NO_PHONON
+  #elif !defined(QT_NO_PHONON) && !defined(QT_PHONON)
+  # define QT_NO_PHONON
+  #endif
+
+  #if defined(QT_NO_PULSEAUDIO) && defined(QT_PULSEAUDIO)
+  # undef QT_NO_PULSEAUDIO
+  #elif !defined(QT_NO_PULSEAUDIO) && !defined(QT_PULSEAUDIO)
+  # define QT_NO_PULSEAUDIO
+  #endif
+
+  #if defined(QT_NO_S60) && defined(QT_S60)
+  # undef QT_NO_S60
+  #elif !defined(QT_NO_S60) && !defined(QT_S60)
+  # define QT_NO_S60
+  #endif
+
+  #if defined(QT_NO_STYLE_S60) && defined(QT_STYLE_S60)
+  # undef QT_NO_STYLE_S60
+  #elif !defined(QT_NO_STYLE_S60) && !defined(QT_STYLE_S60)
+  # define QT_NO_STYLE_S60
+  #endif
+
+  #if defined(QT_NO_SXE) && defined(QT_SXE)
+  # undef QT_NO_SXE
+  #elif !defined(QT_NO_SXE) && !defined(QT_SXE)
+  # define QT_NO_SXE
+  #endif
+
+  #if defined(QT_NO_WEBKIT) && defined(QT_WEBKIT)
+  # undef QT_NO_WEBKIT
+  #elif !defined(QT_NO_WEBKIT) && !defined(QT_WEBKIT)
+  # define QT_NO_WEBKIT
+  #endif
+
+  #if defined(QT_NO_ZLIB) && defined(QT_ZLIB)
+  # undef QT_NO_ZLIB
+  #elif !defined(QT_NO_ZLIB) && !defined(QT_ZLIB)
+  # define QT_NO_ZLIB
+  #endif
+
+  #if defined(QT_RUNTIME_XCURSOR) && defined(QT_NO_RUNTIME_XCURSOR)
+  # undef QT_RUNTIME_XCURSOR
+  #elif !defined(QT_RUNTIME_XCURSOR) && !defined(QT_NO_RUNTIME_XCURSOR)
+  # define QT_RUNTIME_XCURSOR
+  #endif
+
+  #if defined(QT_RUNTIME_XFIXES) && defined(QT_NO_RUNTIME_XFIXES)
+  # undef QT_RUNTIME_XFIXES
+  #elif !defined(QT_RUNTIME_XFIXES) && !defined(QT_NO_RUNTIME_XFIXES)
+  # define QT_RUNTIME_XFIXES
+  #endif
+
+  #if defined(QT_RUNTIME_XINERAMA) && defined(QT_NO_RUNTIME_XINERAMA)
+  # undef QT_RUNTIME_XINERAMA
+  #elif !defined(QT_RUNTIME_XINERAMA) && !defined(QT_NO_RUNTIME_XINERAMA)
+  # define QT_RUNTIME_XINERAMA
+  #endif
+
+  #if defined(QT_RUNTIME_XINPUT) && defined(QT_NO_RUNTIME_XINPUT)
+  # undef QT_RUNTIME_XINPUT
+  #elif !defined(QT_RUNTIME_XINPUT) && !defined(QT_NO_RUNTIME_XINPUT)
+  # define QT_RUNTIME_XINPUT
+  #endif
+
+  #if defined(QT_RUNTIME_XRANDR) && defined(QT_NO_RUNTIME_XRANDR)
+  # undef QT_RUNTIME_XRANDR
+  #elif !defined(QT_RUNTIME_XRANDR) && !defined(QT_NO_RUNTIME_XRANDR)
+  # define QT_RUNTIME_XRANDR
+  #endif
+
+  #if defined(QT_USE_MATH_H_FLOATS) && defined(QT_NO_USE_MATH_H_FLOATS)
+  # undef QT_USE_MATH_H_FLOATS
+  #elif !defined(QT_USE_MATH_H_FLOATS) && !defined(QT_NO_USE_MATH_H_FLOATS)
+  # define QT_USE_MATH_H_FLOATS
+  #endif
+
+  #endif // QT_BOOTSTRAPPED
+
+  #define QT_VISIBILITY_AVAILABLE
+  ' >> $QCONFIG
+  cp $QCONFIG $INSTALLPREFIX/include/QtCore/qconfig.h
+
+  cd $INSTALLPREFIX
+  # as zip stores file timestamps, use faketime to intercept stat calls to set dates for all files to reference date
+  export LD_PRELOAD=/usr/lib/faketime/libfaketime.so.1
+  # Create a .tar.gz because .zip has problems with symbolic links
+  find | sort | tar --no-recursion -cT /dev/stdin --mode='u+rw,go+r-w,a+X' --owner=0 --group=0 --mtime="$REFERENCE_DATETIME" | gzip -n > $OUTDIR/qt-linux${GBUILD_BITS}-4.6.4-gitian-r1.tar.gz

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -47,12 +47,15 @@ Release Process
 	wget 'https://svn.boost.org/trac/boost/raw-attachment/ticket/7262/boost-mingw.patch' -O \ 
 	     boost-mingw-gas-cross-compile-2013-03-03.patch
 	wget 'https://download.qt-project.org/official_releases/qt/5.2/5.2.0/single/qt-everywhere-opensource-src-5.2.0.tar.gz'
+	wget 'https://download.qt-project.org/archive/qt/4.6/qt-everywhere-opensource-src-4.6.4.tar.gz'
 	wget 'https://protobuf.googlecode.com/files/protobuf-2.5.0.tar.bz2'
 	cd ..
 	./bin/gbuild ../bitcoin/contrib/gitian-descriptors/boost-linux.yml
 	mv build/out/boost-*.zip inputs/
 	./bin/gbuild ../bitcoin/contrib/gitian-descriptors/deps-linux.yml
 	mv build/out/bitcoin-deps-*.zip inputs/
+	./bin/gbuild ../bitcoin/contrib/gitian-descriptors/qt-linux.yml
+	mv build/out/qt-*.tar.gz inputs/
 	./bin/gbuild ../bitcoin/contrib/gitian-descriptors/boost-win.yml
 	mv build/out/boost-*.zip inputs/
 	./bin/gbuild ../bitcoin/contrib/gitian-descriptors/deps-win.yml
@@ -68,6 +71,8 @@ Release Process
     571789867d172500fa96d63d0ba8c5b1e1a3d6f44f720eddf2f93665affc88b3  bitcoin-deps-linux64-gitian-r5.zip
     f29b7d9577417333fb56e023c2977f5726a7c297f320b175a4108cf7cd4c2d29  boost-linux32-1.55.0-gitian-r1.zip
     88232451c4104f7eb16e469ac6474fd1231bd485687253f7b2bdf46c0781d535  boost-linux64-1.55.0-gitian-r1.zip
+    74ec2d301cf1a9d03b194153f545102ba45dad02b390485212fe6717de486361  qt-linux32-4.6.4-gitian-r1.tar.gz
+    01d0477e299467f09280f15424781154e2b1ea4072c5edb16e044c234954fd9a  qt-linux64-4.6.4-gitian-r1.tar.gz
     60dc2d3b61e9c7d5dbe2f90d5955772ad748a47918ff2d8b74e8db9b1b91c909  boost-win32-1.55.0-gitian-r6.zip
     f65fcaf346bc7b73bc8db3a8614f4f6bee2f61fcbe495e9881133a7c2612a167  boost-win64-1.55.0-gitian-r6.zip
     97e62002d338885336bb24e7cbb9471491294bd8857af7a83d18c0961f864ec0  bitcoin-deps-win32-gitian-r11.zip


### PR DESCRIPTION
Should make it possible to run the resulting GUI executable on Linux distributions that use Qt 4.6, such as Debian Wheezy and Tails.

Builds a mini-SDK for building against Qt 4.6. This includes the headers as well as host utilities such as `lrelease`, `qrc` and `moc`.

This speeds up the gitian build a bit - libqt4-dev pulled in a lot of packages, and is no longer needed as this provides a replacement of our own.

Note: This does not replace the Qt build with at static library. After this commit we still build dynamically against the system Qt library. The only difference is that compatibility with an older version is maintained. This loses minor GUI functionality (such as setPlaceholderText) but still allows integration into the theming and window management of the host OS, unlike when statically linking.

Test build:
https://download.visucore.com/bitcoin/linux-gitian-1b2454a.tar.gz (sigs: https://download.visucore.com/bitcoin/linux-gitian-1b2454a.tar.gz.sig )
