### PR TITLE
Update build instructions for Berkeley DB

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -137,17 +137,33 @@ miniupnpc
 
 Berkeley DB
 -----------
-You need Berkeley DB 4.8.  If you have to build it yourself:
+It is recommended to use Berkeley DB 4.8. If you have to build it yourself:
 
-	wget 'http://download.oracle.com/berkeley-db/db-4.8.30.NC.tar.gz'
-	echo '12edc0df75bf9abd7f82f821795bcee50f42cb2e5f76a6a281b85732798364ef  db-4.8.30.NC.tar.gz' | sha256sum -c
-	# -> db-4.8.30.NC.tar.gz: OK
-	tar -xzvf db-4.8.30.NC.tar.gz
-	cd build_unix/
-	../dist/configure --enable-cxx
-	make
-	sudo make install
+```bash
+BITCOIN_ROOT=$(pwd)
 
+# Pick some path to install BDB to, here we create a directory within the bitcoin directory
+BDB_PREFIX="${BITCOIN_ROOT}/db4"
+mkdir -p $BDB_PREFIX
+
+# Fetch the source and verify that it is not tampered with
+wget 'http://download.oracle.com/berkeley-db/db-4.8.30.NC.tar.gz'
+echo '12edc0df75bf9abd7f82f821795bcee50f42cb2e5f76a6a281b85732798364ef  db-4.8.30.NC.tar.gz' | sha256sum -c
+# -> db-4.8.30.NC.tar.gz: OK
+tar -xzvf db-4.8.30.NC.tar.gz
+
+# Build the library and install to our prefix
+cd db-4.8.30.NC/build_unix/
+#  Note: Do a static build so that it can be embedded into the exectuable, instead of having to find a .so at runtime
+../dist/configure --enable-cxx --disable-shared --with-pic --prefix=$BDB_PREFIX
+make install
+
+# Configure Bitcoin Core to use our own-built instance of BDB
+cd $BITCOIN_ROOT
+./configure (other args...) LDFLAGS="-L${BDB_PREFIX}/lib/" CPPFLAGS="-I${BDB_PREFIX}/include/"
+```
+
+**Note**: You only need Berkeley DB if the wallet is enabled (see the section *Disable-Wallet mode* below).
 
 Boost
 -----

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -603,6 +603,9 @@ bool AppInit2(boost::thread_group& threadGroup)
     LogPrintf("\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n");
     LogPrintf("Bitcoin version %s (%s)\n", FormatFullVersion(), CLIENT_DATE);
     LogPrintf("Using OpenSSL version %s\n", SSLeay_version(SSLEAY_VERSION));
+#ifdef ENABLE_WALLET
+    LogPrintf("Using BerkeleyDB version %s\n", DbEnv::version(0, 0, 0));
+#endif
     if (!fLogTimestamps)
         LogPrintf("Startup time: %s\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()));
     LogPrintf("Default data directory %s\n", GetDefaultDataDir().string());


### PR DESCRIPTION
- People were having problems with the .so when installing in alternative locations.
  Like gitian, build a static library with -fPIC that can be embedded into the executables
- Add some missing steps, and mention how to use our self-built version of BDB in the bitcoin build
- Add reminder that BerkeleyDB is only needed when wallet support is enabled
- Log BerkeleyDB version at startup (if wallet support enabled)

https://github.com/laanwj/bitcoin/blob/2014_05_berkeleydb_version/doc/build-unix.md
