### PR TITLE
The lengthy word "microbitcoin" should be shortened to "zibcoin" or just "zib".

### DIFF
--- a/src/qt/bitcoinunits.cpp
+++ b/src/qt/bitcoinunits.cpp
@@ -35,8 +35,8 @@ QString BitcoinUnits::name(int unit)
     switch(unit)
     {
     case BTC: return QString("BTC");
-    case mBTC: return QString("mBTC");
-    case uBTC: return QString::fromUtf8("μBTC");
+    case mBTC: return QString("kZBC");
+    case uBTC: return QString("ZBC");
     default: return QString("???");
     }
 }
@@ -45,9 +45,9 @@ QString BitcoinUnits::description(int unit)
 {
     switch(unit)
     {
-    case BTC: return QString("Bitcoins");
-    case mBTC: return QString("Milli-Bitcoins (1 / 1,000)");
-    case uBTC: return QString("Micro-Bitcoins (1 / 1,000,000)");
+    case BTC: return QString("Bitcoins (100 000 000 atomic units)");
+    case mBTC: return QString("Kilo-Zibcoins (100 000 atomic units)");
+    case uBTC: return QString("Zibcoins (100 atomic units)");
     default: return QString("???");
     }
 }


### PR DESCRIPTION
The following is requested:
-  The lengthy word "microbitcoin" is shortened to "zibcoin" or just "zib".
-  Accordingly, "millibitcoin" is renamed to "kilozibcoin" or just "k zib", because multiples are more intuitive than fractions.

For more information about Zibcoin, please visit this website:
http://zibcoin.org/

For discussion about this request, please use this thread:
https://bitcointalk.org/index.php?topic=522958.0
