### PR TITLE
reorder includes to compile on OpenBSD

### DIFF
--- a/src/compat.h
+++ b/src/compat.h
@@ -28,16 +28,16 @@
 #include <windows.h>
 #include <ws2tcpip.h>
 #else
-#include <sys/types.h>
-#include <arpa/inet.h>
-#include <ifaddrs.h>
-#include <limits.h>
-#include <net/if.h>
-#include <netdb.h>
-#include <netinet/in.h>
 #include <sys/fcntl.h>
 #include <sys/mman.h>
 #include <sys/socket.h>
+#include <sys/types.h>
+#include <net/if.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <ifaddrs.h>
+#include <limits.h>
+#include <netdb.h>
 #include <unistd.h>
 #endif
 


### PR DESCRIPTION
From getifaddr(3) manual:

```
If both <net/if.h> and <ifaddrs.h> are being
included, <net/if.h> must be included before <ifaddrs.h>
```

http://www.openbsd.org/cgi-bin/man.cgi?query=getifaddrs&apropos=0&sektion=0&manpath=OpenBSD+Current&arch=i386&format=html
