### PR TITLE
[Qt] Payment request expiration bug fix

### DIFF
--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -239,6 +239,20 @@ void SendCoinsDialog::on_sendButton_clicked()
         return;
     }
 
+    // make sure any payment requests involved are still valid.
+    foreach(const SendCoinsRecipient &rcp, recipients)
+    {
+        if (rcp.paymentRequest.IsInitialized())
+        {
+            const payments::PaymentDetails& details = rcp.paymentRequest.getDetails();
+            if (details.has_expires() && (int64_t)details.expires() < GetTime())
+            {
+                emit message(tr("Payment request error"), tr("Payment request expired"), CClientUIInterface::MSG_ERROR);
+                return;
+            }
+        }
+    }
+
     // now send the prepared transaction
     WalletModel::SendCoinsReturn sendStatus = model->sendCoins(currentTransaction);
     // process sendStatus and on error generate message shown to user


### PR DESCRIPTION
Currently a payment request is only checked for expiration upon receipt.
It should be checked again immediately before sending coins to prevent
the user from paying to an expired invoice which would then require a
customer service interaction.
