### PR TITLE
rpc: add `getblockchaininfo` and `getnetworkinfo`

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -44,18 +44,13 @@ static const int MAX_OUTBOUND_CONNECTIONS = 8;
 bool OpenNetworkConnection(const CAddress& addrConnect, CSemaphoreGrant *grantOutbound = NULL, const char *strDest = NULL, bool fOneShot = false);
 
 
-struct LocalServiceInfo {
-    int nScore;
-    int nPort;
-};
-
 //
 // Global state variables
 //
 bool fDiscover = true;
 uint64_t nLocalServices = NODE_NETWORK;
-static CCriticalSection cs_mapLocalHost;
-static map<CNetAddr, LocalServiceInfo> mapLocalHost;
+CCriticalSection cs_mapLocalHost;
+map<CNetAddr, LocalServiceInfo> mapLocalHost;
 static bool vfReachable[NET_MAX] = {};
 static bool vfLimited[NET_MAX] = {};
 static CNode* pnodeLocalHost = NULL;

--- a/src/net.h
+++ b/src/net.h
@@ -116,6 +116,13 @@ extern CCriticalSection cs_vAddedNodes;
 extern NodeId nLastNodeId;
 extern CCriticalSection cs_nLastNodeId;
 
+struct LocalServiceInfo {
+    int nScore;
+    int nPort;
+};
+
+extern CCriticalSection cs_mapLocalHost;
+extern map<CNetAddr, LocalServiceInfo> mapLocalHost;
 
 class CNodeStats
 {

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -6,6 +6,7 @@
 #include "rpcserver.h"
 #include "main.h"
 #include "sync.h"
+#include "checkpoints.h"
 
 #include <stdint.h>
 
@@ -429,3 +430,38 @@ Value verifychain(const Array& params, bool fHelp)
     return VerifyDB(nCheckLevel, nCheckDepth);
 }
 
+Value getblockchaininfo(const Array& params, bool fHelp)
+{
+    if (fHelp || params.size() != 0)
+        throw runtime_error(
+            "getblockchaininfo\n"
+            "Returns an object containing various state info regarding block chain processing.\n"
+            "\nResult:\n"
+            "{\n"
+            "  \"chain\": \"xxxx\",        (string) current chain (main, testnet3, regtest)\n"
+            "  \"blocks\": xxxxxx,         (numeric) the current number of blocks processed in the server\n"
+            "  \"bestblockhash\": \"...\", (string) the hash of the currently best block\n"
+            "  \"difficulty\": xxxxxx,     (numeric) the current difficulty\n"
+            "  \"verificationprogress\": xxxx, (numeric) estimate of verification progress [0..1]\n"
+            "  \"chainwork\": \"xxxx\"     (string) total amount of work in active chain, in hexadecimal\n"
+            "}\n"
+            "\nExamples:\n"
+            + HelpExampleCli("getblockchaininfo", "")
+            + HelpExampleRpc("getblockchaininfo", "")
+        );
+
+    proxyType proxy;
+    GetProxy(NET_IPV4, proxy);
+
+    Object obj;
+    std::string chain = Params().DataDir();
+    if(chain.empty())
+        chain = "main";
+    obj.push_back(Pair("chain",         chain));
+    obj.push_back(Pair("blocks",        (int)chainActive.Height()));
+    obj.push_back(Pair("bestblockhash", chainActive.Tip()->GetBlockHash().GetHex()));
+    obj.push_back(Pair("difficulty",    (double)GetDifficulty()));
+    obj.push_back(Pair("verificationprogress", Checkpoints::GuessVerificationProgress(chainActive.Tip())));
+    obj.push_back(Pair("chainwork",     chainActive.Tip()->nChainWork.GetHex()));
+    return obj;
+}

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -228,6 +228,7 @@ static const CRPCCommand vRPCCommands[] =
     { "stop",                   &stop,                   true,      true,       false },
 
     /* P2P networking */
+    { "getnetworkinfo",         &getnetworkinfo,         true,      false,      false },
     { "addnode",                &addnode,                true,      true,       false },
     { "getaddednodeinfo",       &getaddednodeinfo,       true,      true,       false },
     { "getconnectioncount",     &getconnectioncount,     true,      false,      false },
@@ -236,6 +237,7 @@ static const CRPCCommand vRPCCommands[] =
     { "ping",                   &ping,                   true,      false,      false },
 
     /* Block chain and UTXO */
+    { "getblockchaininfo",      &getblockchaininfo,      true,      false,      false },
     { "getbestblockhash",       &getbestblockhash,       true,      false,      false },
     { "getblockcount",          &getblockcount,          true,      false,      false },
     { "getblock",               &getblock,               false,     false,      false },

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -164,6 +164,8 @@ extern json_spirit::Value encryptwallet(const json_spirit::Array& params, bool f
 extern json_spirit::Value validateaddress(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value getinfo(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value getwalletinfo(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value getblockchaininfo(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value getnetworkinfo(const json_spirit::Array& params, bool fHelp);
 
 extern json_spirit::Value getrawtransaction(const json_spirit::Array& params, bool fHelp); // in rcprawtransaction.cpp
 extern json_spirit::Value listunspent(const json_spirit::Array& params, bool fHelp);


### PR DESCRIPTION
Adds two new info query commands that take over information from hodge-podge `getinfo`.

Also some useful new information is added:
- `getblockchaininfo`
  - `chain`: (string) current chain (main, testnet3, regtest)
  - `verificationprogress`: (numeric) estimated verification progress
  - `bestblockhash`: (string) the hash of the currently best block
  - `chainwork`
- `getnetworkinfo`
  - ~~`numblocksofpeers`: (numeric) number of blocks of peers, as estimated from version messages; same as shown in the GUI~~
  - `localaddresses`: (array) local addresses, from mapLocalHost (fixes #1734)

Example `getnetworkinfo`:

``` js
{
    "version" : 99900,
    "protocolversion" : 70002,
    "timeoffset" : 0,
    "connections" : 8,
    "proxy" : "",
    "relayfee" : 0.00001000,
    "localaddresses" : [
        {
            "address" : "89.98.179.240",
            "port" : 8333,
            "score" : 4
        }
    ]
}
```

Example `getblockchaininfo`:

``` js
{
    "chain" : "main",
    "blocks" : 299320,
    "bestblockhash" : "00000000000000000fe7330173c917964dff6c763478a8ad7ee18998069bcfff",
    "difficulty" : 8000872135.96816349,
    "verificationprogress" : 0.99996298,
    "chainwork" : "0000000000000000000000000000000000000000000055887ab265d0a5977101"
}
```

This is analogous to `getwalletinfo` that was introduced by pull #3717.
