### PR TITLE
ui: Check for !pixmap() before trying to export QR code

### DIFF
--- a/src/qt/receiverequestdialog.cpp
+++ b/src/qt/receiverequestdialog.cpp
@@ -16,6 +16,7 @@
 #include <QMimeData>
 #include <QMouseEvent>
 #include <QPixmap>
+#include <QMenu>
 #if QT_VERSION < 0x050000
 #include <QUrl>
 #endif
@@ -29,26 +30,27 @@
 #endif
 
 QRImageWidget::QRImageWidget(QWidget *parent):
-    QLabel(parent)
+    QLabel(parent), contextMenu(0)
 {
-    setContextMenuPolicy(Qt::ActionsContextMenu);
-
+    contextMenu = new QMenu();
     QAction *saveImageAction = new QAction(tr("&Save Image..."), this);
     connect(saveImageAction, SIGNAL(triggered()), this, SLOT(saveImage()));
-    addAction(saveImageAction);
+    contextMenu->addAction(saveImageAction);
     QAction *copyImageAction = new QAction(tr("&Copy Image"), this);
     connect(copyImageAction, SIGNAL(triggered()), this, SLOT(copyImage()));
-    addAction(copyImageAction);
+    contextMenu->addAction(copyImageAction);
 }
 
 QImage QRImageWidget::exportImage()
 {
+    if(!pixmap())
+        return QImage();
     return pixmap()->toImage().scaled(EXPORT_IMAGE_SIZE, EXPORT_IMAGE_SIZE);
 }
 
 void QRImageWidget::mousePressEvent(QMouseEvent *event)
 {
-    if(event->button() == Qt::LeftButton)
+    if(event->button() == Qt::LeftButton && pixmap())
     {
         event->accept();
         QMimeData *mimeData = new QMimeData;
@@ -64,6 +66,8 @@ void QRImageWidget::mousePressEvent(QMouseEvent *event)
 
 void QRImageWidget::saveImage()
 {
+    if(!pixmap())
+        return;
     QString fn = GUIUtil::getSaveFileName(this, tr("Save QR Code"), QString(), tr("PNG Image (*.png)"), NULL);
     if (!fn.isEmpty())
     {
@@ -73,7 +77,16 @@ void QRImageWidget::saveImage()
 
 void QRImageWidget::copyImage()
 {
+    if(!pixmap())
+        return;
     QApplication::clipboard()->setImage(exportImage());
+}
+
+void QRImageWidget::contextMenuEvent(QContextMenuEvent *event)
+{
+    if(!pixmap())
+        return;
+    contextMenu->exec(event->globalPos());
 }
 
 ReceiveRequestDialog::ReceiveRequestDialog(QWidget *parent) :

--- a/src/qt/receiverequestdialog.h
+++ b/src/qt/receiverequestdialog.h
@@ -15,6 +15,9 @@ namespace Ui {
     class ReceiveRequestDialog;
 }
 class OptionsModel;
+QT_BEGIN_NAMESPACE
+class QMenu;
+QT_END_NAMESPACE
 
 /* Label widget for QR code. This image can be dragged, dropped, copied and saved
  * to disk.
@@ -33,6 +36,10 @@ public slots:
 
 protected:
     virtual void mousePressEvent(QMouseEvent *event);
+    virtual void contextMenuEvent(QContextMenuEvent *event);
+
+private:
+    QMenu *contextMenu;
 };
 
 class ReceiveRequestDialog : public QDialog


### PR DESCRIPTION
Adds null pointer checks as well as prevents the Save/Copy context menu from appearing at all if no image is shown.

Fixes issue #4140
