### PR TITLE
Removed passphrase as mandatory cli parameter

### DIFF
--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -149,6 +149,18 @@ Array RPCConvertValues(const std::string &strMethod, const std::vector<std::stri
     if (strMethod == "listtransactions"       && n > 2) ConvertTo<boost::int64_t>(params[2]);
     if (strMethod == "listaccounts"           && n > 0) ConvertTo<boost::int64_t>(params[0]);
     if (strMethod == "walletpassphrase"       && n > 1) ConvertTo<boost::int64_t>(params[1]);
+    if (strMethod == "walletpassphrase"       && n < 1) 
+    {
+        std::cout<<"Enter passphrase"<<std::endl;
+        std::string strPassphrase;
+        std::string strTimeOut;
+        std::getline(cin, strPassphrase);
+        params.push_back(strPassphrase);
+        std::cout<<"Enter timeout"<<std::endl;
+        std::getline(cin, strTimeOut);
+        params.push_back(strTimeOut);
+        ConvertTo<boost::int64_t>(params[1]);
+    }
     if (strMethod == "getblocktemplate"       && n > 0) ConvertTo<Object>(params[0]);
     if (strMethod == "listsinceblock"         && n > 1) ConvertTo<boost::int64_t>(params[1]);
     if (strMethod == "sendmany"               && n > 1) ConvertTo<Object>(params[1]);


### PR DESCRIPTION
With this the passphrase can also be entered in-program to avoid it showing up in the linux bash history and the likes by default
