### PR TITLE
build: fix: remove error output

### DIFF
--- a/share/genbuild.sh
+++ b/share/genbuild.sh
@@ -16,7 +16,7 @@ fi
 DESC=""
 SUFFIX=""
 LAST_COMMIT_DATE=""
-if [ -e "$(which git)" -a -d ".git" ]; then
+if [ -e "$(which git 2>/dev/null)" -a -d ".git" ]; then
     # clean 'dirty' status of touched files that haven't been modified
     git diff >/dev/null 2>/dev/null 
 


### PR DESCRIPTION
while git not found in path, error is output to console.
