### PR TITLE
Fix addnode "onetry": Connect with OpenNetworkConnection

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -41,9 +41,6 @@ using namespace boost;
 
 static const int MAX_OUTBOUND_CONNECTIONS = 8;
 
-bool OpenNetworkConnection(const CAddress& addrConnect, CSemaphoreGrant *grantOutbound = NULL, const char *strDest = NULL, bool fOneShot = false);
-
-
 //
 // Global state variables
 //

--- a/src/net.h
+++ b/src/net.h
@@ -49,6 +49,7 @@ void AddressCurrentlyConnected(const CService& addr);
 CNode* FindNode(const CNetAddr& ip);
 CNode* FindNode(const CService& ip);
 CNode* ConnectNode(CAddress addrConnect, const char *strDest = NULL);
+bool OpenNetworkConnection(const CAddress& addrConnect, CSemaphoreGrant *grantOutbound = NULL, const char *strDest = NULL, bool fOneShot = false);
 void MapPort(bool fUseUPnP);
 unsigned short GetListenPort();
 bool BindListenPort(const CService &bindAddr, std::string& strError=REF(std::string()));

--- a/src/rpcnet.cpp
+++ b/src/rpcnet.cpp
@@ -166,7 +166,7 @@ Value addnode(const Array& params, bool fHelp)
     if (strCommand == "onetry")
     {
         CAddress addr;
-        ConnectNode(addr, strNode.c_str());
+        OpenNetworkConnection(addr, NULL, strNode.c_str());
         return Value::null;
     }
 


### PR DESCRIPTION
Nodes added with "onetry" do not get deleted from memory when they get disconnected.
This causes FinalizeNode and so some clean up code to not get called.

The reason is for onetry nodes fNetworkNode is false, because we connect them with ConnectNode.
The nodes get disconnected but still stay in the disconnected pool forever.

So use OpenNetworkConnection instead of ConnectNode.
The only difference now is that fNetworkNode is true.
