### PR TITLE
Fix build in OS X 10.9

### DIFF
--- a/src/test/bignum.h
+++ b/src/test/bignum.h
@@ -10,6 +10,7 @@
 #include <limits>
 #include <stdexcept>
 #include <stdint.h>
+#include <string>
 #include <vector>
 
 #include <openssl/bn.h>


### PR DESCRIPTION
This fixes the following build errors for Mavericks:
https://gist.github.com/federicobond/fe75ae7a418d072186cb

Compiler version:

```
Configured with: --prefix=/Applications/Xcode.app/Contents/Developer/usr --with-gxx-include-dir=/usr/include/c++/4.2.1
Apple LLVM version 5.1 (clang-503.0.40) (based on LLVM 3.4svn)
Target: x86_64-apple-darwin13.1.0
Thread model: posix
```
