### PR TITLE
gitian: Add OSX build descriptors

### DIFF
--- a/contrib/gitian-descriptors/README.osx
+++ b/contrib/gitian-descriptors/README.osx
@@ -1,0 +1,99 @@
+Deterministic OSX Dmg Notes.
+
+tldr;
+ - Fetch the sources and move them to Gitian's input dir:
+  $ wget https://github.com/mingwandroid/toolchain4/archive/10cc648683617cca8bcbeae507888099b41b530c.tar.gz
+  $ wget http://sourceforge.net/projects/boost/files/boost/1.55.0/boost_1_55_0.tar.bz2
+  $ wget http://www.opensource.apple.com/tarballs/cctools/cctools-809.tar.gz
+  $ wget http://download.oracle.com/berkeley-db/db-4.8.30.NC.tar.gz
+  $ wget http://www.opensource.apple.com/tarballs/dyld/dyld-195.5.tar.gz
+  $ wget http://www.opensource.apple.com/tarballs/ld64/ld64-127.2.tar.gz
+  $ wget http://miniupnp.free.fr/files/miniupnpc-1.9.tar.gz
+  $ wget https://www.openssl.org/source/openssl-1.0.1g.tar.gz
+  $ wget https://protobuf.googlecode.com/files/protobuf-2.5.0.tar.bz2
+  $ wget https://fukuchi.org/works/qrencode/qrencode-3.4.3.tar.bz2
+  $ wget http://download.qt-project.org/official_releases/qt/5.2/5.2.1/single/qt-everywhere-opensource-src-5.2.1.tar.gz
+  $ wget http://cdrkit.org/releases/cdrkit-1.1.11.tar.gz
+  $ wget https://github.com/theuni/libdmg-hfsplus/archive/libdmg-hfsplus-v0.1.tar.gz
+  $ wget -O clang-llvm-3.2-x86-linux-ubuntu-12.04.tar.gz http://llvm.org/releases/3.2/clang+llvm-3.2-x86-linux-ubuntu-12.04.tar.gz
+  $ wget -O cdrkit-deterministic.patch https://raw.githubusercontent.com/theuni/osx-cross-depends/master/patches/cdrtools/genisoimage.diff
+
+ - Fetch and extract the .pkg from Apple's SDK (see below) and move it to Gitian's input dir
+
+ - Use gitian to build the descriptors in order (remembering to save the outputs):
+  $ gbuild gitian-osx-native.yml
+  $ gbuild gitian-osx-depends.yml
+  $ gbuild gitian-osx-qt.yml
+  $ gbuild gitian-osx-bitcoin.yml -c bitcoin=$COMMIT
+
+Details:
+
+Working OSX DMG's are created in Linux by combining a recent clang,
+the Apple's binutils (ld, ar, etc), and DMG authoring tools.
+
+Apple uses clang extensively for development and has upstreamed the necessary
+functionality so that a vanilla clang can take advantage. It supports the use
+of -F, -target, -mmacosx-version-min, and --sysroot, which are all necessary
+when building for OSX. A pre-compiled version of 3.2 is used because it was not
+available in the Precise repositories at the time this work was started. In the
+future, it can be switched to use system packages instead.
+
+Apple's version of binutils (called cctools) contains lots of functionality
+missing in the FSF's binutils. In addition to extra linker options for
+frameworks and sysroots, several other tools are needed as well such as
+install_name_tool, lipo, and nmedit. These do not build under linux, so they
+have been patched to do so. The work here was used as a starting point:
+https://github.com/mingwandroid/toolchain4
+
+In order to build a working toolchain, the following source packages are needed
+from Apple: cctools, dyld, and ld64.
+
+Beware. This part is ugly. Very very very ugly. In the future, this should be
+broken out into a new repository and cleaned up. Additionally, the binaries
+only work when built as x86 and not x86_64. This is an especially nasty
+limitation because it must be linked with the toolchain's libLTO.so, meaning
+that the entire toolchain must be x86. Gitian x86_64 should not be used until
+this has been fixed, because it would mean that several native dependencies
+(openssl, libuuid, etc) would need to be built as x86 first.
+
+These tools inject timestamps by default, which produce non-deterministic
+binaries. The ZERO_AR_DATE environment variable is used to disable that.
+
+This version of cctools has been patched to use the current version of clang's
+headers and and its libLTO.so rather than those from llvmgcc, as it was
+originally done in toolchain4.
+
+To complicate things further, all builds must target an Apple SDK. These SDKs
+are free to download, but not redistributable.
+To obtain it, register for a developer account, then download xcode_3.2.6_and_ios_sdk_4.3.dmg:
+https://developer.apple.com/devcenter/download.action?path=/Developer_Tools/xcode_3.2.6_and_ios_sdk_4.3__final/xcode_3.2.6_and_ios_sdk_4.3.dmg
+This file is several gigabytes in size, but only a single .pkg file inside is
+needed (MacOSX10.6.pkg). From Linux, 7-zip can be used to extract this file.
+The DMG can then be discarded.
+
+The gitian descriptors build 2 sets of files: Linux tools, then Apple binaries
+which are created using these tools. The build process has been designed to
+avoid including the SDK's files in Gitian's outputs. All interim tarballs are
+fully deterministic and may be freely redistributed.
+
+genisoimage is used to create the initial DMG. It is not deterministic as-is,
+so it has been patched. A system genisoimage will work fine, but it will not
+be deterministic because the file-order will change between invocations.
+The patch can be seen here:
+https://raw.githubusercontent.com/theuni/osx-cross-depends/master/patches/cdrtools/genisoimage.diff
+No effort was made to fix this cleanly, so it likely leaks memory badly. But
+it's only used for a single invocation, so that's no real concern.
+
+genisoimage cannot compress DMGs, so afterwards, the 'dmg' tool from the
+libdmg-hfsplus project is used to compress it. There are several bugs in this
+tool and its maintainer has seemingly abandoned the project. It has been forked
+and is available (with fixes) here: https://github.com/theuni/libdmg-hfsplus .
+
+The 'dmg' tool has the ability to create DMG's from scratch as well, but this
+functionality is broken. Only the compression feature is currently used.
+Ideally, the creation could be fixed and genisoimage would no longer be necessary.
+
+Background images and other features can be added to DMG files by inserting a
+.DS_Store before creation. The easiest way to create this file is to build a
+DMG without one, move it to a device running OSX, customize the layout, then
+grab the .DS_Store file for later use. That is the approach taken here.

--- a/contrib/gitian-descriptors/gitian-osx-bitcoin.yml
+++ b/contrib/gitian-descriptors/gitian-osx-bitcoin.yml
@@ -1,0 +1,65 @@
+---
+name: "bitcoin"
+suites:
+- "precise"
+architectures:
+- "i386"
+packages:
+- "git-core"
+- "automake"
+- "faketime"
+- "bsdmainutils"
+- "pkg-config"
+- "p7zip-full"
+
+reference_datetime: "2013-06-01 00:00:00"
+remotes:
+- "url": "https://github.com/bitcoin/bitcoin.git"
+  "dir": "bitcoin"
+files:
+- "osx-native-depends-r2.tar.gz"
+- "osx-depends-r2.tar.gz"
+- "osx-depends-qt-5.2.1-r2.tar.gz"
+- "MacOSX10.6.pkg"
+
+script: |
+
+  echo "a2ccf2299de4e0bb88bd17a3355f02b747575b97492c7c2f5b789a64ccc4cbd6  MacOSX10.6.pkg" | sha256sum -c
+
+  HOST=x86_64-apple-darwin11
+  PREFIX=`pwd`/osx-cross-depends/prefix
+  SDK=`pwd`/osx-cross-depends/SDKs/MacOSX10.6.sdk
+  NATIVEPREFIX=`pwd`/osx-cross-depends/native-prefix
+  export TAR_OPTIONS="-m --mtime="$REFERENCE_DATE\\\ $REFERENCE_TIME""
+
+  export SOURCES_PATH=`pwd`
+
+  mkdir osx-cross-depends
+
+  cd osx-cross-depends
+  mkdir -p SDKs
+  7z -bd -so -y e ${SOURCES_PATH}/MacOSX10.6.pkg Payload | gzip -d -c | cpio -i
+  cd ..
+
+  tar -C osx-cross-depends -xf osx-native-depends-r2.tar.gz
+  tar -C osx-cross-depends -xf osx-depends-r2.tar.gz
+  tar -C osx-cross-depends -xf osx-depends-qt-5.2.1-r2.tar.gz
+  export PATH=`pwd`/osx-cross-depends/native-prefix/bin:$PATH
+
+  cd bitcoin
+
+  export ZERO_AR_DATE=1
+  export QT_RCC_TEST=1
+  ./autogen.sh
+  ./configure --host=${HOST} --with-boost=${PREFIX} CC=clang CXX=clang++ OBJC=clang OBJCXX=clang++ CFLAGS="-target ${HOST} -mmacosx-version-min=10.6 --sysroot ${SDK} -msse2 -Qunused-arguments" CXXFLAGS="-target ${HOST} -mmacosx-version-min=10.6 --sysroot ${SDK} -msse2 -Qunused-arguments" LDFLAGS="-B${NATIVEPREFIX}/bin -L${PREFIX}/lib -L${SDK}/usr/lib/i686-apple-darwin10/4.2.1" CPPFLAGS="-I${NATIVEPREFIX}/lib/clang/3.2/include -I${PREFIX}/include" SSL_LIBS="-lz -lssl -lcrypto" --disable-tests -with-gui=qt5 PKG_CONFIG_LIBDIR="${PREFIX}/lib/pkgconfig" --disable-dependency-tracking --disable-maintainer-mode
+  make dist
+  mkdir -p distsrc
+  cd distsrc
+  tar --strip-components=1 -xf ../bitcoin-*.tar*
+  ./configure --host=${HOST} --with-boost=${PREFIX} CC=clang CXX=clang++ OBJC=clang OBJCXX=clang++ CFLAGS="-target ${HOST} -mmacosx-version-min=10.6 --sysroot ${SDK} -msse2 -Qunused-arguments" CXXFLAGS="-target ${HOST} -mmacosx-version-min=10.6 --sysroot ${SDK} -msse2 -Qunused-arguments" LDFLAGS="-B${NATIVEPREFIX}/bin -L${PREFIX}/lib -L${SDK}/usr/lib/i686-apple-darwin10/4.2.1" CPPFLAGS="-I${NATIVEPREFIX}/lib/clang/3.2/include -I${PREFIX}/include" SSL_LIBS="-lz -lssl -lcrypto" --disable-tests -with-gui=qt5 PKG_CONFIG_LIBDIR="${PREFIX}/lib/pkgconfig"  --disable-dependency-tracking --disable-maintainer-mode
+  make $MAKEOPTS
+  export LD_PRELOAD=/usr/lib/faketime/libfaketime.so.1
+  export FAKETIME=$REFERENCE_DATETIME
+  export TZ=UTC
+  make deploy
+  dmg dmg Bitcoin-Qt.dmg $OUTDIR/Bitcoin-Qt.dmg

--- a/contrib/gitian-descriptors/gitian-osx-depends.yml
+++ b/contrib/gitian-descriptors/gitian-osx-depends.yml
@@ -1,0 +1,160 @@
+---
+name: "osx-depends"
+suites:
+- "precise"
+architectures:
+- "i386"
+packages:
+- "git-core"
+- "automake"
+- "p7zip-full"
+
+reference_datetime: "2013-06-01 00:00:00"
+remotes: []
+files:
+- "boost_1_55_0.tar.bz2"
+- "db-4.8.30.NC.tar.gz"
+- "miniupnpc-1.9.tar.gz"
+- "openssl-1.0.1g.tar.gz"
+- "protobuf-2.5.0.tar.bz2"
+- "qrencode-3.4.3.tar.bz2"
+- "MacOSX10.6.pkg"
+- "osx-native-depends-r2.tar.gz"
+
+script: |
+
+  echo "fff00023dd79486d444c8e29922f4072e1d451fc5a4d2b6075852ead7f2b7b52  boost_1_55_0.tar.bz2" | sha256sum -c
+  echo "12edc0df75bf9abd7f82f821795bcee50f42cb2e5f76a6a281b85732798364ef  db-4.8.30.NC.tar.gz" | sha256sum -c
+  echo "2923e453e880bb949e3d4da9f83dd3cb6f08946d35de0b864d0339cf70934464  miniupnpc-1.9.tar.gz" | sha256sum -c
+  echo "53cb818c3b90e507a8348f4f5eaedb05d8bfe5358aabb508b7263cc670c3e028  openssl-1.0.1g.tar.gz" | sha256sum -c
+  echo "13bfc5ae543cf3aa180ac2485c0bc89495e3ae711fc6fab4f8ffe90dfb4bb677  protobuf-2.5.0.tar.bz2" | sha256sum -c
+  echo "dfd71487513c871bad485806bfd1fdb304dedc84d2b01a8fb8e0940b50597a98  qrencode-3.4.3.tar.bz2" | sha256sum -c
+  echo "a2ccf2299de4e0bb88bd17a3355f02b747575b97492c7c2f5b789a64ccc4cbd6  MacOSX10.6.pkg" | sha256sum -c
+
+  REVISION=r2
+  export SOURCES_PATH=`pwd`
+  export TAR_OPTIONS="-m --mtime="$REFERENCE_DATE\\\ $REFERENCE_TIME""
+  export PATH=$HOME:$PATH
+  export SOURCES_PATH=`pwd`
+  export ZERO_AR_DATE=1
+
+  mkdir -p osx-cross-depends/build
+  cd osx-cross-depends
+
+  PREFIX=`pwd`/prefix
+  NATIVEPREFIX=`pwd`/native-prefix
+  BUILD_BASE=`pwd`/build
+  SDK=`pwd`/SDKs/MacOSX10.6.sdk
+  HOST=x86_64-apple-darwin11
+  MIN_VERSION=10.6
+
+  INT_CFLAGS="-target ${HOST} -mmacosx-version-min=${MIN_VERSION} --sysroot ${SDK} -msse2 -Qunused-arguments"
+  INT_CXXFLAGS="${INT_CFLAGS}"
+  INT_LDFLAGS="-L${PREFIX}/lib -L${SDK}/usr/lib/i686-apple-darwin10/4.2.1"
+  INT_LDFLAGS_CLANG="-B${NATIVEPREFIX}/bin"
+  INT_CPPFLAGS="-I${PREFIX}/include"
+  INT_CC=clang
+  INT_CXX=clang++
+  INT_OBJC=clang
+  INT_OBJCXX=clang++
+  INT_AR=${HOST}-ar
+  INT_RANLIB=${HOST}-ranlib
+  INT_LIBTOOL=${HOST}-libtool
+  INT_INSTALL_NAME_TOOL=${HOST}-install_name_tool
+
+  export PATH=${NATIVEPREFIX}/bin:${PATH}
+
+  mkdir -p ${NATIVEPREFIX}/bin
+  mkdir -p ${NATIVEPREFIX}/lib
+  mkdir -p ${PREFIX}/bin
+  mkdir -p ${PREFIX}/lib
+  mkdir -p ${BUILD_BASE}
+
+  mkdir -p ${SDK}
+  7z -bd -so -y e ${SOURCES_PATH}/MacOSX10.6.pkg Payload | gzip -d -c | cpio -i
+
+  tar xf /home/ubuntu/build/osx-native-depends-r2.tar.gz
+
+  # bdb
+  SOURCE_FILE=${SOURCES_PATH}/db-4.8.30.NC.tar.gz
+  BUILD_DIR=${BUILD_BASE}/db-4.8.30.NC
+
+  tar -C ${BUILD_BASE} -xf ${SOURCE_FILE}
+  sed -i 's/__atomic_compare_exchange/__atomic_compare_exchange_db/g' ${BUILD_DIR}/dbinc/atomic.h
+  pushd ${BUILD_DIR}
+  cd build_unix;
+  ../dist/configure --host=${HOST} --prefix="${PREFIX}" --disable-shared --enable-cxx CC="${INT_CC}" CXX="${INT_CXX}" AR="${INT_AR}" RANLIB="${INT_RANLIB}" OBJC="${INT_OBJC}" OBJCXX="${INT_OBJCXX}" CFLAGS="${INT_CFLAGS}" CXXFLAGS="${INT_CXXFLAGS}" LDFLAGS="${INT_CLANG_LDFLAGS} ${INT_LDFLAGS}" CPPFLAGS="${INT_CPPFLAGS}"
+  make $MAKEOPTS libdb.a libdb_cxx.a
+  make  install_lib install_include
+  popd
+
+  # openssl
+  SOURCE_FILE=${SOURCES_PATH}/openssl-1.0.1g.tar.gz
+  BUILD_DIR=${BUILD_BASE}/openssl-1.0.1g
+
+  tar -C ${BUILD_BASE} -xf ${SOURCE_FILE}
+  pushd ${BUILD_DIR}
+  sed -ie "s|cc:|${INT_CC}:|" ${BUILD_DIR}/Configure
+  sed -ie "s|\(-arch [_a-zA-Z0-9]*\)|\1 --sysroot ${SDK}  -target ${HOST} -msse2|" ${BUILD_DIR}/Configure
+  AR="${INT_AR}" RANLIB="${INT_RANLIB}" ./Configure --prefix=${PREFIX} --openssldir=${PREFIX}/etc/openssl zlib shared no-krb5 darwin64-x86_64-cc ${INT_LDFLAGS} ${INT_CLANG_LDFLAGS} ${INT_CPPFLAGS}
+  sed -i "s|engines apps test|engines|" ${BUILD_DIR}/Makefile
+  sed -i "/define DATE/d" ${BUILD_DIR}/crypto/Makefile
+  make -j1 build_libs libcrypto.pc libssl.pc openssl.pc
+  make -j1 install_sw
+  popd
+
+  #libminiupnpc
+  SOURCE_FILE=${SOURCES_PATH}/miniupnpc-1.9.tar.gz
+  BUILD_DIR=${BUILD_BASE}/miniupnpc-1.9
+
+  tar -C ${BUILD_BASE} -xf ${SOURCE_FILE}
+  pushd ${BUILD_DIR}
+  CFLAGS="${INT_CFLAGS} ${INT_CPPFLAGS}" make $MAKEOPTS OS=Darwin CC="${INT_CC}" AR="${INT_AR}" libminiupnpc.a
+  install -d ${PREFIX}/include/miniupnpc
+  install *.h ${PREFIX}/include/miniupnpc
+  install libminiupnpc.a  ${PREFIX}/lib
+  popd
+
+  # qrencode
+  SOURCE_FILE=${SOURCES_PATH}/qrencode-3.4.3.tar.bz2
+  BUILD_DIR=${BUILD_BASE}/qrencode-3.4.3
+  tar -C ${BUILD_BASE} -xf ${SOURCE_FILE}
+  pushd ${BUILD_DIR}
+
+  # m4 folder is not included in the stable release, which can confuse aclocal
+  # if its timestamp ends up being earlier than configure.ac when extracted
+  touch aclocal.m4
+  ./configure --host=${HOST} --prefix="${PREFIX}" --disable-shared CC="${INT_CC}" CXX="${INT_CXX}" AR="${INT_AR}" RANLIB="${INT_RANLIB}" OBJC="${INT_OBJC}" OBJCXX="${INT_OBJCXX}" CFLAGS="${INT_CFLAGS}" CXXFLAGS="${INT_CXXFLAGS}" LDFLAGS="${INT_CLANG_LDFLAGS} ${INT_LDFLAGS}" CPPFLAGS="${INT_CPPFLAGS}" --disable-shared -without-tools --disable-sdltest --disable-dependency-tracking
+  make $MAKEOPTS
+  make install
+  popd
+
+  # libprotobuf
+  SOURCE_FILE=${SOURCES_PATH}/protobuf-2.5.0.tar.bz2
+  BUILD_DIR=${BUILD_BASE}/protobuf-2.5.0
+
+  tar -C ${BUILD_BASE} -xjf ${SOURCE_FILE}
+  pushd ${BUILD_DIR}
+  ./configure --host=${HOST} --prefix="${PREFIX}" --disable-shared --enable-cxx CC="${INT_CC}" CXX="${INT_CXX}" AR="${INT_AR}" RANLIB="${INT_RANLIB}" OBJC="${INT_OBJC}" OBJCXX="${INT_OBJCXX}" CFLAGS="${INT_CFLAGS}" CXXFLAGS="${INT_CXXFLAGS}" LDFLAGS="${INT_CLANG_LDFLAGS} ${INT_LDFLAGS}" CPPFLAGS="${INT_CPPFLAGS}" --enable-shared=no --disable-dependency-tracking --with-protoc=${NATIVEPREFIX}/bin/protoc
+  cd src
+  make $MAKEOPTS libprotobuf.la
+  make install-libLTLIBRARIES install-nobase_includeHEADERS
+  cd ..
+  make install-pkgconfigDATA
+  popd
+
+  # boost
+  SOURCE_FILE=${SOURCES_PATH}/boost_1_55_0.tar.bz2
+  BUILD_DIR=${BUILD_BASE}/boost_1_55_0
+
+  tar -C ${BUILD_BASE} -xf ${SOURCE_FILE}
+  pushd ${BUILD_DIR}
+  ./bootstrap.sh --with-libraries=chrono,filesystem,program_options,system,thread,test
+  echo "using darwin : : ${INT_CXX} : <cxxflags>\"${INT_CFLAGS} ${INT_CPPFLAGS}\" <linkflags>\"${INT_LDFLAGS} ${INT_CLANG_LDFLAGS}\" <archiver>\"${INT_LIBTOOL}\" <striper>\"${INT_STRIP}\" : ;" > "user-config.jam"
+  ./b2 -d2 --layout=tagged --build-type=complete --prefix="${PREFIX}" --toolset=darwin-4.2.1 --user-config=user-config.jam variant=release threading=multi link=static install
+  popd
+
+  export GZIP="-9n"
+  find prefix | sort | tar --no-recursion -czf osx-depends-${REVISION}.tar.gz -T -
+
+  mv osx-depends-${REVISION}.tar.gz $OUTDIR

--- a/contrib/gitian-descriptors/gitian-osx-native.yml
+++ b/contrib/gitian-descriptors/gitian-osx-native.yml
@@ -157,7 +157,7 @@ script: |
   patch -p1 < ${SOURCES_PATH}/cdrkit-deterministic.patch
   cmake -DCMAKE_INSTALL_PREFIX=${NATIVEPREFIX}
   make $MAKEOPTS genisoimage
-  make install
+  make -C genisoimage install
   popd
 
   # libdmg-hfsplus

--- a/contrib/gitian-descriptors/gitian-osx-native.yml
+++ b/contrib/gitian-descriptors/gitian-osx-native.yml
@@ -1,0 +1,179 @@
+---
+name: "osx-native"
+suites:
+- "precise"
+architectures:
+- "i386"
+packages:
+- "git-core"
+- "automake"
+- "faketime"
+- "libssl-dev"
+- "libbz2-dev"
+- "libz-dev"
+- "cmake"
+- "libcap-dev"
+- "p7zip-full"
+- "uuid-dev"
+
+reference_datetime: "2013-06-01 00:00:00"
+remotes: []
+files:
+- "10cc648683617cca8bcbeae507888099b41b530c.tar.gz"
+- "cctools-809.tar.gz"
+- "dyld-195.5.tar.gz"
+- "ld64-127.2.tar.gz"
+- "protobuf-2.5.0.tar.bz2"
+- "MacOSX10.6.pkg"
+- "cdrkit-1.1.11.tar.gz"
+- "libdmg-hfsplus-v0.1.tar.gz"
+- "clang-llvm-3.2-x86-linux-ubuntu-12.04.tar.gz"
+- "cdrkit-deterministic.patch"
+
+
+script: |
+
+  echo "18406961fd4a1ec5c7ea35c91d6a80a2f8bb797a2bd243a610bd75e13eff9aca  10cc648683617cca8bcbeae507888099b41b530c.tar.gz" | sha256sum -c
+  echo "03ba62749b843b131c7304a044a98c6ffacd65b1399b921d69add0375f79d8ad  cctools-809.tar.gz" | sha256sum -c
+  echo "2cf0484c87cf79b606b351a7055a247dae84093ae92c747a74e0cde2c8c8f83c  dyld-195.5.tar.gz" | sha256sum -c
+  echo "97b75547b2bd761306ab3e15ae297f01e7ab9760b922bc657f4ef72e4e052142  ld64-127.2.tar.gz" | sha256sum -c
+  echo "13bfc5ae543cf3aa180ac2485c0bc89495e3ae711fc6fab4f8ffe90dfb4bb677  protobuf-2.5.0.tar.bz2" | sha256sum -c
+  echo "a2ccf2299de4e0bb88bd17a3355f02b747575b97492c7c2f5b789a64ccc4cbd6  MacOSX10.6.pkg" | sha256sum -c
+  echo "d1c030756ecc182defee9fe885638c1785d35a2c2a297b4604c0e0dcc78e47da  cdrkit-1.1.11.tar.gz" | sha256sum -c
+  echo "6569a02eb31c2827080d7d59001869ea14484c281efab0ae7f2b86af5c3120b3  libdmg-hfsplus-v0.1.tar.gz" | sha256sum -c
+  echo "b9d57a88f9514fa1f327a1a703756d0c1c960f4c58494a5bd80313245d13ffff  clang-llvm-3.2-x86-linux-ubuntu-12.04.tar.gz" | sha256sum -c
+  echo "cc12bdbd7a09f71cb2a6a3e6ec3e0abe885ca7111c2b47857f5095e5980caf4f  cdrkit-deterministic.patch" | sha256sum -c
+
+
+  REVISION=r2
+  export REFERENCE_DATETIME
+  export TAR_OPTIONS="-m --mtime="$REFERENCE_DATE\\\ $REFERENCE_TIME""
+  export FAKETIME=$REFERENCE_DATETIME
+  export TZ=UTC
+
+  REAL_AR=`which ar`
+  REAL_RANLIB=`which ranlib`
+  REAL_DATE=`which date`
+
+  echo '#!/bin/bash' > $HOME/ar
+  echo 'export LD_PRELOAD=/usr/lib/faketime/libfaketime.so.1' >> $HOME/ar
+  echo "$REAL_AR \"\$@\"" >> $HOME/ar
+
+  echo '#!/bin/bash' > $HOME/ranlib
+  echo 'export LD_PRELOAD=/usr/lib/faketime/libfaketime.so.1' >> $HOME/ranlib
+  echo "$REAL_RANLIB \"\$@\"" >> $HOME/ranlib
+
+  echo '#!/bin/bash' > $HOME/date
+  echo 'export LD_PRELOAD=/usr/lib/faketime/libfaketime.so.1' >> $HOME/date
+  echo "$REAL_DATE \"\$@\"" >> $HOME/date
+
+  chmod +x $HOME/ar $HOME/ranlib $HOME/date
+
+
+  export PATH=$HOME:$PATH
+  export SOURCES_PATH=`pwd`
+
+  mkdir -p osx-cross-depends/build
+  cd osx-cross-depends
+
+  NATIVEPREFIX=`pwd`/native-prefix
+  BUILD_BASE=`pwd`/build
+  SDK=`pwd`/SDKs/MacOSX10.6.sdk
+  HOST=x86_64-apple-darwin11
+  MIN_VERSION=10.6
+
+  CFLAGS=""
+  CXXFLAGS="${CFLAGS}"
+  LDFLAGS="-L${NATIVEPREFIX}/lib"
+
+  export PATH=${NATIVEPREFIX}/bin:${PATH}
+
+  mkdir -p ${NATIVEPREFIX}/bin
+  mkdir -p ${NATIVEPREFIX}/lib
+
+  mkdir -p ${SDK}
+  7z -bd -so -y e ${SOURCES_PATH}/MacOSX10.6.pkg Payload | gzip -d -c | cpio -i
+
+  #  Clang
+  SOURCE_FILE=${SOURCES_PATH}/clang-llvm-3.2-x86-linux-ubuntu-12.04.tar.gz
+  BUILD_DIR=${BUILD_BASE}/clang+llvm-3.2-x86-linux-ubuntu-12.04
+
+  mkdir -p ${NATIVEPREFIX}/lib/clang/3.2/include
+  tar -C ${BUILD_BASE} -xf ${SOURCE_FILE}
+  cp ${BUILD_DIR}/bin/clang ${NATIVEPREFIX}/bin/
+  cp ${BUILD_DIR}/bin/clang++ ${NATIVEPREFIX}/bin/
+  cp ${BUILD_DIR}/lib/libLTO.so ${NATIVEPREFIX}/lib/
+  cp ${BUILD_DIR}/lib/clang/3.2/include/* ${NATIVEPREFIX}/lib/clang/3.2/include
+
+  # cctools
+  SOURCE_FILE=${SOURCES_PATH}/10cc648683617cca8bcbeae507888099b41b530c.tar.gz
+  BUILD_DIR=${BUILD_BASE}/toolchain4-10cc648683617cca8bcbeae507888099b41b530c
+
+  tar -C ${BUILD_BASE} -xf ${SOURCE_FILE}
+  mkdir -p ${BUILD_DIR}/sdks
+  pushd ${BUILD_DIR}/sdks;
+  ln -sf ${SDK} MacOSX10.6.sdk
+  ln -sf ${SOURCES_PATH}/cctools-809.tar.gz ${BUILD_DIR}/cctools2odcctools/cctools-809.tar.gz
+  ln -sf ${SOURCES_PATH}/ld64-127.2.tar.gz ${BUILD_DIR}/cctools2odcctools/ld64-127.2.tar.gz
+  ln -sf ${SOURCES_PATH}/dyld-195.5.tar.gz ${BUILD_DIR}/cctools2odcctools/dyld-195.5.tar.gz
+
+  tar -C ${BUILD_DIR} -xf ${SOURCES_PATH}/clang-llvm-3.2-x86-linux-ubuntu-12.04.tar.gz
+  #   Hack in the use of our llvm headers rather than grabbing the old llvm-gcc.
+  sed -i "s|GCC_DIR|LLVM_CLANG_DIR|g" ${BUILD_DIR}/cctools2odcctools/extract.sh
+  sed -i "s|llvmgcc42-2336.1|clang+llvm-3.2-x86-linux-ubuntu-12.04|g" ${BUILD_DIR}/cctools2odcctools/extract.sh
+  sed -i "s|\${LLVM_CLANG_DIR}/llvmCore/include/llvm-c|\${LLVM_CLANG_DIR}/include/llvm-c \${LLVM_CLANG_DIR}/include/llvm |" ${BUILD_DIR}/cctools2odcctools/extract.sh
+
+  sed -i "s|fAC_INIT|AC_INIT|" ${BUILD_DIR}/cctools2odcctools/files/configure.ac
+  sed -i 's/\# Dynamically linked LTO/\t ;\&\n\t linux*)\n# Dynamically linked LTO/' ${BUILD_DIR}/cctools2odcctools/files/configure.ac
+
+  cd ${BUILD_DIR}/cctools2odcctools
+  ./extract.sh --osxver 10.6
+  cd odcctools-809
+  ./configure --prefix=${NATIVEPREFIX} --target=${HOST} CFLAGS="${CFLAGS} -I${NATIVEPREFIX}/include -D__DARWIN_UNIX03 -D__STDC_CONSTANT_MACROS -D__STDC_LIMIT_MACROS" LDFLAGS="${LDFLAGS} -Wl,-rpath=\\\$\$ORIGIN/../lib" --with-sysroot=${SDK}
+
+  #   The 'PC' define in sparc/reg.h conflicts but doesn't get used anyway. Just rename it.
+  sed -i "s|define\tPC|define\tPC_|"  ${BUILD_DIR}/cctools2odcctools/odcctools-809/include/architecture/sparc/reg.h
+  make $MAKEOPTS
+  make install
+  popd
+
+  # protoc
+  SOURCE_FILE=${SOURCES_PATH}/protobuf-2.5.0.tar.bz2
+  BUILD_DIR=${BUILD_BASE}/protobuf-2.5.0
+
+  tar -C ${BUILD_BASE} -xjf ${SOURCE_FILE}
+  pushd ${BUILD_DIR};
+  ./configure --enable-shared=no --disable-dependency-tracking --prefix=${NATIVEPREFIX}
+  make $MAKEOPTS
+  cp ${BUILD_DIR}/src/protoc ${NATIVEPREFIX}/bin/
+  popd
+
+  # cdrkit
+  SOURCE_FILE=${SOURCES_PATH}/cdrkit-1.1.11.tar.gz
+  BUILD_DIR=${BUILD_BASE}/cdrkit-1.1.11
+
+  tar -C ${BUILD_BASE} -xf ${SOURCE_FILE}
+  pushd ${BUILD_DIR}
+  patch -p1 < ${SOURCES_PATH}/cdrkit-deterministic.patch
+  cmake -DCMAKE_INSTALL_PREFIX=${NATIVEPREFIX}
+  make $MAKEOPTS genisoimage
+  make install
+  popd
+
+  # libdmg-hfsplus
+  SOURCE_FILE=${SOURCES_PATH}/libdmg-hfsplus-v0.1.tar.gz
+  BUILD_DIR=${BUILD_BASE}/libdmg-hfsplus-libdmg-hfsplus-v0.1
+
+  tar -C ${BUILD_BASE} -xf ${SOURCE_FILE}
+  mkdir -p ${BUILD_DIR}/build
+  pushd ${BUILD_DIR}/build
+  cmake -DCMAKE_INSTALL_PREFIX:PATH=${NATIVEPREFIX}/bin ..
+  make $MAKEOPTS
+  make install
+  popd
+
+  rm -rf native-prefix/docs
+
+  export GZIP="-9n"
+  find native-prefix | sort | tar --no-recursion -czf osx-native-depends-$REVISION.tar.gz -T -
+  mv osx-native-depends-$REVISION.tar.gz $OUTDIR

--- a/contrib/gitian-descriptors/gitian-osx-qt.yml
+++ b/contrib/gitian-descriptors/gitian-osx-qt.yml
@@ -1,0 +1,195 @@
+---
+name: "osx-qt"
+suites:
+- "precise"
+architectures:
+- "i386"
+packages:
+- "git-core"
+- "automake"
+- "faketime"
+- "p7zip-full"
+
+reference_datetime: "2013-06-01 00:00:00"
+remotes: []
+files:
+- "qt-everywhere-opensource-src-5.2.1.tar.gz"
+- "osx-native-depends-r2.tar.gz"
+- "osx-depends-r2.tar.gz"
+- "MacOSX10.6.pkg"
+
+script: |
+
+  echo "84e924181d4ad6db00239d87250cc89868484a14841f77fb85ab1f1dbdcd7da1  qt-everywhere-opensource-src-5.2.1.tar.gz" | sha256sum -c
+  echo "a2ccf2299de4e0bb88bd17a3355f02b747575b97492c7c2f5b789a64ccc4cbd6  MacOSX10.6.pkg" | sha256sum -c
+
+  REVISION=r2
+  export SOURCES_PATH=`pwd`
+  export TAR_OPTIONS="-m --mtime="$REFERENCE_DATE\\\ $REFERENCE_TIME""
+  export ZERO_AR_DATE=1
+
+  export REFERENCE_DATETIME
+  export TZ=UTC
+
+  REAL_DATE=`which date`
+  echo '#!/bin/bash' > $HOME/date
+  echo 'export LD_PRELOAD=/usr/lib/faketime/libfaketime.so.1' >> $HOME/date
+  echo "$REAL_DATE \"\$@\"" >> $HOME/date
+
+  chmod +x $HOME/date
+  export PATH=$HOME:$PATH
+
+  mkdir -p osx-cross-depends/build
+  cd osx-cross-depends
+
+  PREFIX=`pwd`/prefix
+  NATIVEPREFIX=`pwd`/native-prefix
+  BUILD_BASE=`pwd`/build
+  SDK=`pwd`/SDKs/MacOSX10.6.sdk
+  HOST=x86_64-apple-darwin11
+  MIN_VERSION=10.6
+
+  INT_CFLAGS="-target ${HOST} -mmacosx-version-min=${MIN_VERSION} --sysroot ${SDK} -msse2 -Qunused-arguments"
+  INT_CXXFLAGS="${INT_CFLAGS}"
+  INT_LDFLAGS="-L${PREFIX}/lib -L${SDK}/usr/lib/i686-apple-darwin10/4.2.1"
+  INT_LDFLAGS_CLANG="-B${NATIVEPREFIX}/bin"
+  INT_CPPFLAGS="-I${PREFIX}/include"
+  INT_CC=clang
+  INT_CXX=clang++
+  INT_OBJC=clang
+  INT_OBJCXX=clang++
+  INT_AR=${HOST}-ar
+  INT_RANLIB=${HOST}-ranlib
+  INT_LIBTOOL=${HOST}-libtool
+  INT_INSTALL_NAME_TOOL=${HOST}-install_name_tool
+
+  export PATH=${NATIVEPREFIX}/bin:${PATH}
+
+  mkdir -p ${NATIVEPREFIX}/bin
+  mkdir -p ${NATIVEPREFIX}/lib
+  mkdir -p ${PREFIX}/bin
+  mkdir -p ${PREFIX}/lib
+  mkdir -p ${BUILD_BASE}
+
+  mkdir -p ${SDK}
+  7z -bd -so -y e ${SOURCES_PATH}/MacOSX10.6.pkg Payload | gzip -d -c | cpio -i
+
+  tar xf /home/ubuntu/build/osx-native-depends-r2.tar.gz
+
+
+  mkdir -p SDKs
+  7z -bd -so -y e ${SOURCES_PATH}/MacOSX10.6.pkg Payload | gzip -d -c | cpio -i
+
+  tar xf /home/ubuntu/build/osx-native-depends-r2.tar.gz
+  export PATH=`pwd`/native-prefix/bin:$PATH
+  tar xf /home/ubuntu/build/osx-depends-r2.tar.gz
+
+  SOURCE_FILE=${SOURCES_PATH}/qt-everywhere-opensource-src-5.2.1.tar.gz
+  BUILD_DIR=${BUILD_BASE}/qt-everywhere-opensource-src-5.2.1
+
+
+  tar -C ${BUILD_BASE} -xf ${SOURCE_FILE}
+
+  # Install our mkspec. All files are pulled from the macx-clang spec, except for
+  # our custom qmake.conf
+  SPECFILE=${BUILD_DIR}/qtbase/mkspecs/macx-clang-linux/qmake.conf
+
+  mkdir -p ${BUILD_DIR}/qtbase/mkspecs/macx-clang-linux
+  cp -f ${BUILD_DIR}/qtbase/mkspecs/macx-clang/Info.plist.lib ${BUILD_DIR}/qtbase/mkspecs/macx-clang-linux/
+  cp -f ${BUILD_DIR}/qtbase/mkspecs/macx-clang/Info.plist.app ${BUILD_DIR}/qtbase/mkspecs/macx-clang-linux/
+  cp -f ${BUILD_DIR}/qtbase/mkspecs/macx-clang/qplatformdefs.h ${BUILD_DIR}/qtbase/mkspecs/macx-clang-linux/
+
+  cat > ${SPECFILE} <<ENDCONF
+ 
+  MAKEFILE_GENERATOR      = UNIX
+  CONFIG                 += app_bundle incremental global_init_link_order lib_version_first plugin_no_soname absolute_library_soname
+  QMAKE_INCREMENTAL_STYLE = sublib
+
+  include(../common/macx.conf)
+  include(../common/gcc-base-mac.conf)
+  include(../common/clang.conf)
+  include(../common/clang-mac.conf)
+
+  QMAKE_XCODE_VERSION=4.3
+  QMAKE_XCODE_DEVELOPER_PATH=/Developer
+
+  QMAKE_MACOSX_DEPLOYMENT_TARGET = ${MIN_VERSION}
+
+  QMAKE_MAC_SDK=macosx
+  QMAKE_MAC_SDK.macosx.path = ${SDK}
+  QMAKE_MAC_SDK.macosx.platform_name = macosx
+  QMAKE_MAC_SDK_PATH=${SDK}
+
+  QMAKE_CFLAGS += -target ${HOST}
+  QMAKE_OBJECTIVE_CFLAGS += -target ${HOST}
+  QMAKE_CXXFLAGS += -target ${HOST}
+
+  QMAKE_LFLAGS += -target ${HOST}
+  QMAKE_AR = ${HOST}-ar cq
+  QMAKE_RANLIB=${HOST}-ranlib
+  QMAKE_LIBTOOL=${HOST}-libtool
+  QMAKE_INSTALL_NAME_TOOL=${HOST}-install_name_tool
+
+  load(qt_config)
+ 
+  ENDCONF
+
+  pushd ${BUILD_DIR}
+  ./configure -release -opensource -openssl-linked \
+  -no-audio-backend  -no-javascript-jit -no-sql-sqlite -no-sql-tds \
+  -no-cups -no-iconv -no-dbus -no-gif -no-audio-backend -no-freetype \
+  -no-javascript-jit -no-sql-sqlite -no-nis -no-cups -no-iconv -no-pch \
+  -no-dbus -no-gif -no-sm -nomake examples -no-feature-style-plastique \
+  -no-xcb -no-qml-debug -no-pch -no-nis \
+  -no-feature-style-cde -no-feature-style-s60 -no-feature-style-motif \
+  -no-feature-style-windowsmobile -no-feature-style-windowsce \
+  -no-feature-style-cleanlooks \
+  -no-sql-db2 -no-sql-ibase -no-sql-oci -no-sql-tds -no-sql-mysql \
+  -no-sql-odbc -no-sql-psql -no-sql-sqlite -no-sql-sqlite2 \
+  -skip qtsvg -skip qtwebkit -skip qtwebkit-examples -skip qtserialport \
+  -skip qtdeclarative -skip qtmultimedia -skip qtimageformats \
+  -skip qtlocation -skip qtsensors -skip qtquick1 -skip qtxmlpatterns \
+  -skip qtquickcontrols -skip qtactiveqt -skip qtconnectivity \
+  -skip qtwinextras -skip qtscript \
+  -prefix ${PREFIX} -bindir ${NATIVEPREFIX}/bin \
+  -confirm-license -xplatform macx-clang-linux -v ${INT_LDFLAGS}
+
+  # RCC's output is sorted using each file entry's hash as the key. Unfortunately,
+  # the hash function uses a random seed for each run so the results aren't
+  # deterministic. This leads to static resources being defined in a random order,
+  # which in-turn means that object files are not predictable.
+  # Fortunately, this upsets Qt's unit tests as well, so they've added the
+  # QT_RCC_TEST environment variable to set a pre-defined seed. Here, do the same
+  # thing for the same reason.
+  QT_RCC_TEST=1 make $MAKEOPTS module-qtbase-make_first
+
+
+  make $MAKEOPTS module-qttranslations-make_first
+  make $MAKEOPTS module-qttools-make_first
+  make $MAKEOPTS -C qtbase
+  make -C qtbase install
+  make -C qttranslations install
+  make -C qttools/src/linguist install
+  popd
+
+  # This file should not be installed to the destination. It's native and
+  # non-deterministic. Remove it.
+  # See: https://bugreports.qt-project.org/browse/QTBUG-31393
+  rm -f ${PREFIX}/lib/libQt5Bootstrap.a
+
+  rm -f ${PREFIX}/lib/Qt*.framework/Qt*.prl
+  pushd ${PREFIX}/include
+  ln -sf ../lib/QtNetwork.framework/Headers/ QtNetwork
+  ln -sf ../lib/QtWidgets.framework/Headers/ QtWidgets
+  ln -sf ../lib/QtGui.framework/Headers/ QtGui
+  ln -sf ../lib/QtCore.framework/Headers/ QtCore
+  ln -sf ../lib/QtTest.framework/Headers/ QtTest
+  popd
+
+  rm -f ${PREFIX}/lib/*.la
+  find ${PREFIX}/lib -name "*.prl" -delete
+
+  export GZIP="-9n"
+  find native-prefix prefix | sort | tar --no-recursion -czf osx-depends-qt-5.2.1-${REVISION}.tar.gz -T -
+
+  mv osx-depends-qt-5.2.1-${REVISION}.tar.gz $OUTDIR

--- a/contrib/gitian-descriptors/gitian-osx-qt.yml
+++ b/contrib/gitian-descriptors/gitian-osx-qt.yml
@@ -12,14 +12,14 @@ packages:
 reference_datetime: "2013-06-01 00:00:00"
 remotes: []
 files:
-- "qt-everywhere-opensource-src-5.2.0.tar.gz"
+- "qt-everywhere-opensource-src-5.2.1.tar.gz"
 - "osx-native-depends-r2.tar.gz"
 - "osx-depends-r2.tar.gz"
 - "MacOSX10.6.pkg"
 
 script: |
 
-  echo "395ec72277c5786c65b8163ef5817fd03d0a1f524a6d47f53624baf8056f1081  qt-everywhere-opensource-src-5.2.0.tar.gz" | sha256sum -c
+  echo "84e924181d4ad6db00239d87250cc89868484a14841f77fb85ab1f1dbdcd7da1  qt-everywhere-opensource-src-5.2.1.tar.gz" | sha256sum -c
   echo "a2ccf2299de4e0bb88bd17a3355f02b747575b97492c7c2f5b789a64ccc4cbd6  MacOSX10.6.pkg" | sha256sum -c
 
   REVISION=r2
@@ -81,8 +81,8 @@ script: |
   export PATH=`pwd`/native-prefix/bin:$PATH
   tar xf /home/ubuntu/build/osx-depends-r2.tar.gz
 
-  SOURCE_FILE=${SOURCES_PATH}/qt-everywhere-opensource-src-5.2.0.tar.gz
-  BUILD_DIR=${BUILD_BASE}/qt-everywhere-opensource-src-5.2.0
+  SOURCE_FILE=${SOURCES_PATH}/qt-everywhere-opensource-src-5.2.1.tar.gz
+  BUILD_DIR=${BUILD_BASE}/qt-everywhere-opensource-src-5.2.1
 
 
   tar -C ${BUILD_BASE} -xf ${SOURCE_FILE}
@@ -187,6 +187,6 @@ script: |
   find ${PREFIX}/lib -name "*.prl" -delete
 
   export GZIP="-9n"
-  find native-prefix prefix | sort | tar --no-recursion -czf osx-depends-qt-5.2.0-${REVISION}.tar.gz -T -
+  find native-prefix prefix | sort | tar --no-recursion -czf osx-depends-qt-5.2.1-${REVISION}.tar.gz -T -
 
-  mv osx-depends-qt-5.2.0-${REVISION}.tar.gz $OUTDIR
+  mv osx-depends-qt-5.2.1-${REVISION}.tar.gz $OUTDIR

--- a/contrib/gitian-descriptors/gitian-osx-qt.yml
+++ b/contrib/gitian-descriptors/gitian-osx-qt.yml
@@ -7,7 +7,6 @@ architectures:
 packages:
 - "git-core"
 - "automake"
-- "faketime"
 - "p7zip-full"
 
 reference_datetime: "2013-06-01 00:00:00"
@@ -28,13 +27,11 @@ script: |
   export TAR_OPTIONS="-m --mtime="$REFERENCE_DATE\\\ $REFERENCE_TIME""
   export ZERO_AR_DATE=1
 
-  export REFERENCE_DATETIME
   export TZ=UTC
 
   REAL_DATE=`which date`
   echo '#!/bin/bash' > $HOME/date
-  echo 'export LD_PRELOAD=/usr/lib/faketime/libfaketime.so.1' >> $HOME/date
-  echo "$REAL_DATE \"\$@\"" >> $HOME/date
+  echo "$REAL_DATE -d \"${REFERENCE_DATETIME}\" \"\$@\"" >> $HOME/date
 
   chmod +x $HOME/date
   export PATH=$HOME:$PATH

--- a/contrib/gitian-descriptors/gitian-osx-qt.yml
+++ b/contrib/gitian-descriptors/gitian-osx-qt.yml
@@ -12,14 +12,14 @@ packages:
 reference_datetime: "2013-06-01 00:00:00"
 remotes: []
 files:
-- "qt-everywhere-opensource-src-5.2.1.tar.gz"
+- "qt-everywhere-opensource-src-5.2.0.tar.gz"
 - "osx-native-depends-r2.tar.gz"
 - "osx-depends-r2.tar.gz"
 - "MacOSX10.6.pkg"
 
 script: |
 
-  echo "84e924181d4ad6db00239d87250cc89868484a14841f77fb85ab1f1dbdcd7da1  qt-everywhere-opensource-src-5.2.1.tar.gz" | sha256sum -c
+  echo "395ec72277c5786c65b8163ef5817fd03d0a1f524a6d47f53624baf8056f1081  qt-everywhere-opensource-src-5.2.0.tar.gz" | sha256sum -c
   echo "a2ccf2299de4e0bb88bd17a3355f02b747575b97492c7c2f5b789a64ccc4cbd6  MacOSX10.6.pkg" | sha256sum -c
 
   REVISION=r2
@@ -81,8 +81,8 @@ script: |
   export PATH=`pwd`/native-prefix/bin:$PATH
   tar xf /home/ubuntu/build/osx-depends-r2.tar.gz
 
-  SOURCE_FILE=${SOURCES_PATH}/qt-everywhere-opensource-src-5.2.1.tar.gz
-  BUILD_DIR=${BUILD_BASE}/qt-everywhere-opensource-src-5.2.1
+  SOURCE_FILE=${SOURCES_PATH}/qt-everywhere-opensource-src-5.2.0.tar.gz
+  BUILD_DIR=${BUILD_BASE}/qt-everywhere-opensource-src-5.2.0
 
 
   tar -C ${BUILD_BASE} -xf ${SOURCE_FILE}
@@ -187,6 +187,6 @@ script: |
   find ${PREFIX}/lib -name "*.prl" -delete
 
   export GZIP="-9n"
-  find native-prefix prefix | sort | tar --no-recursion -czf osx-depends-qt-5.2.1-${REVISION}.tar.gz -T -
+  find native-prefix prefix | sort | tar --no-recursion -czf osx-depends-qt-5.2.0-${REVISION}.tar.gz -T -
 
-  mv osx-depends-qt-5.2.1-${REVISION}.tar.gz $OUTDIR
+  mv osx-depends-qt-5.2.0-${REVISION}.tar.gz $OUTDIR

--- a/doc/README_osx.txt
+++ b/doc/README_osx.txt
@@ -1,33 +1,5 @@
 Deterministic OSX Dmg Notes.
 
-tldr;
- - Fetch the sources and move them to Gitian's input dir:
-  $ wget https://github.com/mingwandroid/toolchain4/archive/10cc648683617cca8bcbeae507888099b41b530c.tar.gz
-  $ wget http://sourceforge.net/projects/boost/files/boost/1.55.0/boost_1_55_0.tar.bz2
-  $ wget http://www.opensource.apple.com/tarballs/cctools/cctools-809.tar.gz
-  $ wget http://download.oracle.com/berkeley-db/db-4.8.30.NC.tar.gz
-  $ wget http://www.opensource.apple.com/tarballs/dyld/dyld-195.5.tar.gz
-  $ wget http://www.opensource.apple.com/tarballs/ld64/ld64-127.2.tar.gz
-  $ wget http://miniupnp.free.fr/files/miniupnpc-1.9.tar.gz
-  $ wget https://www.openssl.org/source/openssl-1.0.1g.tar.gz
-  $ wget https://protobuf.googlecode.com/files/protobuf-2.5.0.tar.bz2
-  $ wget https://fukuchi.org/works/qrencode/qrencode-3.4.3.tar.bz2
-  $ wget http://download.qt-project.org/official_releases/qt/5.2/5.2.1/single/qt-everywhere-opensource-src-5.2.1.tar.gz
-  $ wget http://cdrkit.org/releases/cdrkit-1.1.11.tar.gz
-  $ wget https://github.com/theuni/libdmg-hfsplus/archive/libdmg-hfsplus-v0.1.tar.gz
-  $ wget -O clang-llvm-3.2-x86-linux-ubuntu-12.04.tar.gz http://llvm.org/releases/3.2/clang+llvm-3.2-x86-linux-ubuntu-12.04.tar.gz
-  $ wget -O cdrkit-deterministic.patch https://raw.githubusercontent.com/theuni/osx-cross-depends/master/patches/cdrtools/genisoimage.diff
-
- - Fetch and extract the .pkg from Apple's SDK (see below) and move it to Gitian's input dir
-
- - Use gitian to build the descriptors in order (remembering to save the outputs):
-  $ gbuild gitian-osx-native.yml
-  $ gbuild gitian-osx-depends.yml
-  $ gbuild gitian-osx-qt.yml
-  $ gbuild gitian-osx-bitcoin.yml -c bitcoin=$COMMIT
-
-Details:
-
 Working OSX DMG's are created in Linux by combining a recent clang,
 the Apple's binutils (ld, ar, etc), and DMG authoring tools.
 

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -33,6 +33,15 @@ Release Process
 	git checkout v${VERSION}
 	popd
 	pushd ./gitian-builder
+        mkdir -p inputs; cd inputs/
+
+ Register and download the Apple SDK (see OSX Readme for details)
+        visit https://developer.apple.com/devcenter/download.action?path=/Developer_Tools/xcode_3.2.6_and_ios_sdk_4.3__final/xcode_3.2.6_and_ios_sdk_4.3.dmg
+ 
+ Extract MacOSX10.6.pkg using 7zip
+        7z e -y xcode_3.2.6_and_ios_sdk_4.3.dmg 5.hfs
+        7z -y e 5.hfs "Xcode and iOS SDK/Packages/MacOSX10.6.pkg"
+        rm 5.hfs
 
  Fetch and build inputs: (first time, or when dependency versions change)
 
@@ -49,6 +58,16 @@ Release Process
 	wget 'https://download.qt-project.org/official_releases/qt/5.2/5.2.0/single/qt-everywhere-opensource-src-5.2.0.tar.gz'
 	wget 'https://download.qt-project.org/archive/qt/4.6/qt-everywhere-opensource-src-4.6.4.tar.gz'
 	wget 'https://protobuf.googlecode.com/files/protobuf-2.5.0.tar.bz2'
+        wget 'https://github.com/mingwandroid/toolchain4/archive/10cc648683617cca8bcbeae507888099b41b530c.tar.gz'
+        wget 'http://www.opensource.apple.com/tarballs/cctools/cctools-809.tar.gz'
+        wget 'http://www.opensource.apple.com/tarballs/dyld/dyld-195.5.tar.gz'
+        wget 'http://www.opensource.apple.com/tarballs/ld64/ld64-127.2.tar.gz'
+        wget 'http://cdrkit.org/releases/cdrkit-1.1.11.tar.gz'
+        wget 'https://github.com/theuni/libdmg-hfsplus/archive/libdmg-hfsplus-v0.1.tar.gz'
+        wget 'http://llvm.org/releases/3.2/clang+llvm-3.2-x86-linux-ubuntu-12.04.tar.gz' -O \
+             clang-llvm-3.2-x86-linux-ubuntu-12.04.tar.gz
+        wget 'https://raw.githubusercontent.com/theuni/osx-cross-depends/master/patches/cdrtools/genisoimage.diff' -O \
+             cdrkit-deterministic.patch
 	cd ..
 	./bin/gbuild ../bitcoin/contrib/gitian-descriptors/boost-linux.yml
 	mv build/out/boost-*.zip inputs/
@@ -64,6 +83,12 @@ Release Process
 	mv build/out/qt-*.zip inputs/
 	./bin/gbuild ../bitcoin/contrib/gitian-descriptors/protobuf-win.yml
 	mv build/out/protobuf-*.zip inputs/
+        ./bin/gbuild ../bitcoin/contrib/gitian-descriptors/gitian-osx-native.yml
+        mv build/out/osx-*.tar.gz inputs/
+        ./bin/gbuild ../bitcoin/contrib/gitian-descriptors/gitian-osx-depends.yml
+        mv build/out/osx-*.tar.gz inputs/
+        ./bin/gbuild ../bitcoin/contrib/gitian-descriptors/gitian-osx-qt.yml
+        mv build/out/osx-*.tar.gz inputs/
 
  The expected SHA256 hashes of the intermediate inputs are:
 

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -45,7 +45,6 @@ Release Process
 
  Fetch and build inputs: (first time, or when dependency versions change)
 
-	mkdir -p inputs; cd inputs/
 	wget 'http://miniupnp.free.fr/files/download.php?file=miniupnpc-1.9.tar.gz' -O miniupnpc-1.9.tar.gz
 	wget 'https://www.openssl.org/source/openssl-1.0.1g.tar.gz'
 	wget 'http://download.oracle.com/berkeley-db/db-4.8.30.NC.tar.gz'
@@ -58,16 +57,16 @@ Release Process
 	wget 'https://download.qt-project.org/official_releases/qt/5.2/5.2.0/single/qt-everywhere-opensource-src-5.2.0.tar.gz'
 	wget 'https://download.qt-project.org/archive/qt/4.6/qt-everywhere-opensource-src-4.6.4.tar.gz'
 	wget 'https://protobuf.googlecode.com/files/protobuf-2.5.0.tar.bz2'
-        wget 'https://github.com/mingwandroid/toolchain4/archive/10cc648683617cca8bcbeae507888099b41b530c.tar.gz'
-        wget 'http://www.opensource.apple.com/tarballs/cctools/cctools-809.tar.gz'
-        wget 'http://www.opensource.apple.com/tarballs/dyld/dyld-195.5.tar.gz'
-        wget 'http://www.opensource.apple.com/tarballs/ld64/ld64-127.2.tar.gz'
-        wget 'http://cdrkit.org/releases/cdrkit-1.1.11.tar.gz'
-        wget 'https://github.com/theuni/libdmg-hfsplus/archive/libdmg-hfsplus-v0.1.tar.gz'
-        wget 'http://llvm.org/releases/3.2/clang+llvm-3.2-x86-linux-ubuntu-12.04.tar.gz' -O \
-             clang-llvm-3.2-x86-linux-ubuntu-12.04.tar.gz
+	wget 'https://github.com/mingwandroid/toolchain4/archive/10cc648683617cca8bcbeae507888099b41b530c.tar.gz'
+	wget 'http://www.opensource.apple.com/tarballs/cctools/cctools-809.tar.gz'
+	wget 'http://www.opensource.apple.com/tarballs/dyld/dyld-195.5.tar.gz'
+	wget 'http://www.opensource.apple.com/tarballs/ld64/ld64-127.2.tar.gz'
+	wget 'http://cdrkit.org/releases/cdrkit-1.1.11.tar.gz'
+	wget 'https://github.com/theuni/libdmg-hfsplus/archive/libdmg-hfsplus-v0.1.tar.gz'
+	wget 'http://llvm.org/releases/3.2/clang+llvm-3.2-x86-linux-ubuntu-12.04.tar.gz' -O \
+	     clang-llvm-3.2-x86-linux-ubuntu-12.04.tar.gz
         wget 'https://raw.githubusercontent.com/theuni/osx-cross-depends/master/patches/cdrtools/genisoimage.diff' -O \
-             cdrkit-deterministic.patch
+	     cdrkit-deterministic.patch
 	cd ..
 	./bin/gbuild ../bitcoin/contrib/gitian-descriptors/boost-linux.yml
 	mv build/out/boost-*.zip inputs/
@@ -83,12 +82,12 @@ Release Process
 	mv build/out/qt-*.zip inputs/
 	./bin/gbuild ../bitcoin/contrib/gitian-descriptors/protobuf-win.yml
 	mv build/out/protobuf-*.zip inputs/
-        ./bin/gbuild ../bitcoin/contrib/gitian-descriptors/gitian-osx-native.yml
-        mv build/out/osx-*.tar.gz inputs/
-        ./bin/gbuild ../bitcoin/contrib/gitian-descriptors/gitian-osx-depends.yml
-        mv build/out/osx-*.tar.gz inputs/
-        ./bin/gbuild ../bitcoin/contrib/gitian-descriptors/gitian-osx-qt.yml
-        mv build/out/osx-*.tar.gz inputs/
+	./bin/gbuild ../bitcoin/contrib/gitian-descriptors/gitian-osx-native.yml
+	mv build/out/osx-*.tar.gz inputs/
+	./bin/gbuild ../bitcoin/contrib/gitian-descriptors/gitian-osx-depends.yml
+	mv build/out/osx-*.tar.gz inputs/
+	./bin/gbuild ../bitcoin/contrib/gitian-descriptors/gitian-osx-qt.yml
+	mv build/out/osx-*.tar.gz inputs/
 
  The expected SHA256 hashes of the intermediate inputs are:
 
@@ -121,13 +120,19 @@ Release Process
 	zip -r bitcoin-${VERSION}-win-gitian.zip *
 	mv bitcoin-${VERSION}-win-gitian.zip ../../../
 	popd
+        ./bin/gbuild --commit bitcoin=v${VERSION} ../bitcoin/contrib/gitian-descriptors/gitian-osx-bitcoin.yml
+        ./bin/gsign --signer $SIGNER --release ${VERSION}-osx --destination ../gitian.sigs/ ../bitcoin/contrib/gitian-descriptors/gitian-osx-bitcoin.yml
+	pushd build/out
+	mv Bitcoin-Qt.dmg ../../../
+	popd
 	popd
 
   Build output expected:
 
   1. linux 32-bit and 64-bit binaries + source (bitcoin-${VERSION}-linux-gitian.zip)
   2. windows 32-bit and 64-bit binaries + installer + source (bitcoin-${VERSION}-win-gitian.zip)
-  3. Gitian signatures (in gitian.sigs/${VERSION}[-win]/(your gitian key)/
+  3. OSX installer (Bitcoin-Qt.dmg)
+  4. Gitian signatures (in gitian.sigs/${VERSION}[-win|-osx]/(your gitian key)/
 
 repackage gitian builds for release as stand-alone zip/tar/installer exe
 
@@ -143,21 +148,6 @@ repackage gitian builds for release as stand-alone zip/tar/installer exe
 	mv bitcoin-${VERSION}-win/bitcoin-*-setup.exe .
 	zip -r bitcoin-${VERSION}-win.zip bitcoin-${VERSION}-win
 	rm -rf bitcoin-${VERSION}-win
-
-**Perform Mac build:**
-
-  OSX binaries are created by Gavin Andresen on a 64-bit, OSX 10.6 machine.
-
-	./autogen.sh
-        SDK=$(xcode-select --print-path)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.6.sdk
-        CXXFLAGS="-mmacosx-version-min=10.6 -isysroot $SDK" ./configure --enable-upnp-default
-	make
-	export QTDIR=/opt/local/share/qt4  # needed to find translations/qt_*.qm files
-	T=$(contrib/qt_translations.py $QTDIR/translations src/qt/locale)
-        export CODESIGNARGS='--keychain ...path_to_keychain --sign "Developer ID Application: BITCOIN FOUNDATION, INC., THE"'
-	python2.7 contrib/macdeploy/macdeployqtplus Bitcoin-Qt.app -sign -add-qt-tr $T -dmg -fancy contrib/macdeploy/fancy.plist
-
- Build output expected: Bitcoin-Qt.dmg
 
 ###Next steps:
 


### PR DESCRIPTION
This is a set of descriptors for building an OSX DMG without the need for OSX. The descriptors are quite large and unruly, but this seemed like the most reasonable first step towards releasing builds created this way.

These have been ported to monolithic descriptors from the work done in my repo here:
https://github.com/theuni/osx-cross-depends/

I've included a Readme that attempts to cover the most obvious questions. After some major changes in the last week, the process is actually rather clean now and contains very few nasty hacks. The exception to that is cctools, which is... gross. See the readme for details.

Unfortunately my macbook completely died yesterday (new one is on the way), so I'm unable to help with testing until next week. Though I've made no major functional changes since then (worked fine as of yesterday), so I'm confident that the resulting installer is in good shape. Much testing is needed, of course.

There are still plenty of warts in the process, and I have plans for addressing them. As discussed with @laanwj, this is intended to be only the first step.
