### PR TITLE
Remove unused imports in macdeploy script

### DIFF
--- a/contrib/macdeploy/README.md
+++ b/contrib/macdeploy/README.md
@@ -1,9 +1,5 @@
 ### MacDeploy ###
 
-You will need the appscript package for the fancy disk image creation to work:
-
-	sudo easy_install appscript
-
 For Snow Leopard (which uses [Python 2.6](http://www.python.org/download/releases/2.6/)), you will need the param_parser package:
 	
 	sudo easy_install argparse

--- a/contrib/macdeploy/macdeployqtplus
+++ b/contrib/macdeploy/macdeployqtplus
@@ -19,7 +19,6 @@
 
 import subprocess, sys, re, os, shutil, stat, os.path
 from string import Template
-from time import sleep
 from argparse import ArgumentParser
 
 # This is ported from the original macdeployqt with modifications
@@ -486,16 +485,6 @@ if len(config.fancy) == 1:
     except ImportError:
         if verbose >= 1:
             sys.stderr.write("Error: Could not import plistlib which is required for fancy disk images.\n")
-        sys.exit(1)
-    
-    if verbose >= 3:
-        print "Fancy: Importing appscript..."
-    try:
-        import appscript
-    except ImportError:
-        if verbose >= 1:
-            sys.stderr.write("Error: Could not import appscript which is required for fancy disk images.\n")
-            sys.stderr.write("Please install it e.g. with \"sudo easy_install appscript\".\n")
         sys.exit(1)
     
     p = config.fancy[0]


### PR DESCRIPTION
appscript is no longer used since 33b377a0 so we can remove these imports safely.
