### PR TITLE
Remove fDaemon flag checking on return from main(), which is useless and...

### DIFF
--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -174,15 +174,8 @@ int main(int argc, char* argv[])
 {
     SetupEnvironment();
 
-    bool fRet = false;
-
     // Connect bitcoind signal handlers
     noui_connect();
 
-    fRet = AppInit(argc, argv);
-
-    if (fRet && fDaemon)
-        return 0;
-
-    return (fRet ? 0 : 1);
+    return (AppInit(argc, argv) ? 0 : 1);
 }


### PR DESCRIPTION
... looks really strange.

Logically nothing is done by the checking, removing it makes things simpler and clearer.

Signed-off-by: Huang Le 4tarhl@gmail.com
