### PR TITLE
Better logging of ProcessMessages() progress

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4165,10 +4165,15 @@ bool ProcessMessages(CNode* pfrom)
         // get next message
         CNetMessage& msg = *it;
 
-        //if (fDebug)
-        //    LogPrintf("ProcessMessages(message %u msgsz, %u bytes, complete:%s)\n",
-        //            msg.hdr.nMessageSize, msg.vRecv.size(),
-        //            msg.complete() ? "Y" : "N");
+        CMessageHeader& hdr = msg.hdr;
+        unsigned int nMessageSize = hdr.nMessageSize;
+        string strCommand = hdr.GetCommand();
+        if (msg.nDataPos != msg.nLastDataPos) {
+            msg.nLastDataPos = msg.nDataPos;
+            LogPrintf("net2", "ProcessMessages(%u of %u bytes, complete:%s) strCommand=%s\n",
+                    msg.nDataPos, nMessageSize,
+                    msg.complete() ? "Y" : "N", strCommand);
+        }
 
         // end, if an incomplete message is found
         if (!msg.complete())
@@ -4184,17 +4189,11 @@ bool ProcessMessages(CNode* pfrom)
             break;
         }
 
-        // Read header
-        CMessageHeader& hdr = msg.hdr;
         if (!hdr.IsValid())
         {
-            LogPrintf("\n\nPROCESSMESSAGE: ERRORS IN HEADER %s\n\n\n", hdr.GetCommand());
+            LogPrintf("\n\nPROCESSMESSAGE: ERRORS IN HEADER %s\n\n\n", strCommand);
             continue;
         }
-        string strCommand = hdr.GetCommand();
-
-        // Message size
-        unsigned int nMessageSize = hdr.nMessageSize;
 
         // Checksum
         CDataStream& vRecv = msg.vRecv;

--- a/src/net.h
+++ b/src/net.h
@@ -158,12 +158,14 @@ public:
 
     CDataStream vRecv;              // received message data
     unsigned int nDataPos;
+    unsigned int nLastDataPos;
 
     CNetMessage(int nTypeIn, int nVersionIn) : hdrbuf(nTypeIn, nVersionIn), vRecv(nTypeIn, nVersionIn) {
         hdrbuf.resize(24);
         in_data = false;
         nHdrPos = 0;
         nDataPos = 0;
+        nLastDataPos = 0;
     }
 
     bool complete() const


### PR DESCRIPTION
Previous code was commented out and didn't quite work (the bytes received shown was the same as the message size). Code now works, and only displays when bytes received increases, and can now be activated with the debug=net2 option.
