### PR TITLE
Remove testnet-seed.bitcoin.petertodd.org from testnet seeds. That domai...

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -208,7 +208,6 @@ public:
 
         vFixedSeeds.clear();
         vSeeds.clear();
-        vSeeds.push_back(CDNSSeedData("bitcoin.petertodd.org", "testnet-seed.bitcoin.petertodd.org"));
         vSeeds.push_back(CDNSSeedData("bluematt.me", "testnet-seed.bluematt.me"));
 
         base58Prefixes[PUBKEY_ADDRESS] = list_of(111);


### PR DESCRIPTION
...n doesn't resolve for at least a week.
