### PR TITLE
Upgrade gitian windows to qt-5.2.1

### DIFF
--- a/contrib/gitian-descriptors/gitian-win.yml
+++ b/contrib/gitian-descriptors/gitian-win.yml
@@ -22,8 +22,8 @@ remotes:
 - "url": "https://github.com/bitcoin/bitcoin.git"
   "dir": "bitcoin"
 files:
-- "qt-win32-5.2.0-gitian-r3.zip"
-- "qt-win64-5.2.0-gitian-r3.zip"
+- "qt-win32-5.2.1-gitian-r3.zip"
+- "qt-win64-5.2.1-gitian-r3.zip"
 - "boost-win32-1.55.0-gitian-r6.zip"
 - "boost-win64-1.55.0-gitian-r6.zip"
 - "bitcoin-deps-win32-gitian-r12.zip"
@@ -59,7 +59,7 @@ script: |
     mkdir -p $STAGING $BUILDDIR $BINDIR
     #
     cd $STAGING
-    unzip $INDIR/qt-win${BITS}-5.2.0-gitian-r3.zip
+    unzip $INDIR/qt-win${BITS}-5.2.1-gitian-r3.zip
     unzip $INDIR/boost-win${BITS}-1.55.0-gitian-r6.zip
     unzip $INDIR/bitcoin-deps-win${BITS}-gitian-r12.zip
     unzip $INDIR/protobuf-win${BITS}-2.5.0-gitian-r4.zip

--- a/contrib/gitian-descriptors/qt-win.yml
+++ b/contrib/gitian-descriptors/qt-win.yml
@@ -14,7 +14,7 @@ packages:
 reference_datetime: "2011-01-30 00:00:00"
 remotes: []
 files:
-- "qt-everywhere-opensource-src-5.2.0.tar.gz"
+- "qt-everywhere-opensource-src-5.2.1.tar.gz"
 - "bitcoin-deps-win32-gitian-r12.zip"
 - "bitcoin-deps-win64-gitian-r12.zip"
 script: |
@@ -31,7 +31,7 @@ script: |
   #  For now luckily there is a test mode that forces a fixed seed.
   export QT_RCC_TEST=1
   # Integrity Check
-  echo "395ec72277c5786c65b8163ef5817fd03d0a1f524a6d47f53624baf8056f1081  qt-everywhere-opensource-src-5.2.0.tar.gz" | sha256sum -c
+  echo "84e924181d4ad6db00239d87250cc89868484a14841f77fb85ab1f1dbdcd7da1  qt-everywhere-opensource-src-5.2.1.tar.gz" | sha256sum -c
 
   for BITS in 32 64; do # for architectures
     #
@@ -52,8 +52,8 @@ script: |
     #
     cd $BUILDDIR
     #
-    tar xzf $INDIR/qt-everywhere-opensource-src-5.2.0.tar.gz
-    cd qt-everywhere-opensource-src-5.2.0
+    tar xzf $INDIR/qt-everywhere-opensource-src-5.2.1.tar.gz
+    cd qt-everywhere-opensource-src-5.2.1
     SPECNAME="win32-g++"
     SPECFILE="qtbase/mkspecs/${SPECNAME}/qmake.conf"
     sed 's/qt_instdate=`date +%Y-%m-%d`/qt_instdate=2011-01-30/' -i qtbase/configure
@@ -86,7 +86,7 @@ script: |
     export LD_PRELOAD=/usr/lib/faketime/libfaketime.so.1
     export FAKETIME=$REFERENCE_DATETIME
     find -print0 | xargs -r0 touch # fix up timestamps before packaging
-    find | sort | zip -X@ $OUTDIR/qt-win${BITS}-5.2.0-gitian-r3.zip
+    find | sort | zip -X@ $OUTDIR/qt-win${BITS}-5.2.1-gitian-r3.zip
     unset LD_PRELOAD
     unset FAKETIME
   done # for BITS in

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -46,7 +46,7 @@ Release Process
 	wget 'https://downloads.sourceforge.net/project/boost/boost/1.55.0/boost_1_55_0.tar.bz2'
 	wget 'https://svn.boost.org/trac/boost/raw-attachment/ticket/7262/boost-mingw.patch' -O \ 
 	     boost-mingw-gas-cross-compile-2013-03-03.patch
-	wget 'https://download.qt-project.org/official_releases/qt/5.2/5.2.0/single/qt-everywhere-opensource-src-5.2.0.tar.gz'
+	wget 'https://download.qt-project.org/official_releases/qt/5.2/5.2.1/single/qt-everywhere-opensource-src-5.2.1.tar.gz'
 	wget 'https://download.qt-project.org/archive/qt/4.6/qt-everywhere-opensource-src-4.6.4.tar.gz'
 	wget 'https://protobuf.googlecode.com/files/protobuf-2.5.0.tar.bz2'
 	cd ..


### PR DESCRIPTION
This PR corresponds with the qt-5.2.1 for gitian OS X in #4185.

Please verify that your build matches this.

```
27d005789086973fe3cad1a0fd840fa0596725e7503161f5a3322094e0b86925  qt-win32-5.2.1-gitian-r3.zip
4b824fde7345e13f69d20d3298c80ee100b2c2a9499ae1e4c6ac73f28f046bb8  qt-win64-5.2.1-gitian-r3.zip
```
