### PR TITLE
Add two interruption points in dnsseed thread to make shutdown in early ...

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -367,7 +367,7 @@ if test x$TARGET_OS = xdarwin; then
 fi
 
 AC_CHECK_HEADERS([stdio.h stdlib.h unistd.h strings.h sys/types.h sys/stat.h])
-AC_CHECK_LIB(anl, getaddrinfo_a)
+AC_SEARCH_LIBS([getaddrinfo_a], [anl], [AC_DEFINE(HAVE_GETADDRINFO_A, 1, [Define this symbol if you have getaddrinfo_a])])
 
 dnl Check for MSG_NOSIGNAL
 AC_MSG_CHECKING(for MSG_NOSIGNAL)

--- a/configure.ac
+++ b/configure.ac
@@ -370,6 +370,7 @@ fi
 
 AC_CHECK_HEADERS([stdio.h stdlib.h unistd.h strings.h sys/types.h sys/stat.h])
 AC_SEARCH_LIBS([getaddrinfo_a], [anl], [AC_DEFINE(HAVE_GETADDRINFO_A, 1, [Define this symbol if you have getaddrinfo_a])])
+AC_SEARCH_LIBS([inet_pton], [], [AC_DEFINE(HAVE_INET_PTON, 1, [Define this symbol if you have inet_pton])])
 
 dnl Check for MSG_NOSIGNAL
 AC_MSG_CHECKING(for MSG_NOSIGNAL)

--- a/configure.ac
+++ b/configure.ac
@@ -367,6 +367,7 @@ if test x$TARGET_OS = xdarwin; then
 fi
 
 AC_CHECK_HEADERS([stdio.h stdlib.h unistd.h strings.h sys/types.h sys/stat.h])
+AC_CHECK_LIB(anl, getaddrinfo_a)
 
 dnl Check for MSG_NOSIGNAL
 AC_MSG_CHECKING(for MSG_NOSIGNAL)

--- a/configure.ac
+++ b/configure.ac
@@ -370,7 +370,7 @@ fi
 
 AC_CHECK_HEADERS([stdio.h stdlib.h unistd.h strings.h sys/types.h sys/stat.h])
 AC_SEARCH_LIBS([getaddrinfo_a], [anl], [AC_DEFINE(HAVE_GETADDRINFO_A, 1, [Define this symbol if you have getaddrinfo_a])])
-AC_SEARCH_LIBS([inet_pton], [], [AC_DEFINE(HAVE_INET_PTON, 1, [Define this symbol if you have inet_pton])])
+AC_SEARCH_LIBS([inet_pton], [nsl resolv], [AC_DEFINE(HAVE_INET_PTON, 1, [Define this symbol if you have inet_pton])])
 
 dnl Check for MSG_NOSIGNAL
 AC_MSG_CHECKING(for MSG_NOSIGNAL)

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1196,6 +1196,7 @@ void ThreadDNSAddressSeed()
         } else {
             vector<CNetAddr> vIPs;
             vector<CAddress> vAdd;
+            boost::this_thread::interruption_point();
             if (LookupHost(seed.host.c_str(), vIPs))
             {
                 BOOST_FOREACH(CNetAddr& ip, vIPs)
@@ -1207,6 +1208,7 @@ void ThreadDNSAddressSeed()
                     found++;
                 }
             }
+            boost::this_thread::interruption_point();
             addrman.Add(vAdd, CNetAddr(seed.name, true));
         }
     }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1196,7 +1196,6 @@ void ThreadDNSAddressSeed()
         } else {
             vector<CNetAddr> vIPs;
             vector<CAddress> vAdd;
-            boost::this_thread::interruption_point();
             if (LookupHost(seed.host.c_str(), vIPs))
             {
                 BOOST_FOREACH(CNetAddr& ip, vIPs)
@@ -1208,7 +1207,6 @@ void ThreadDNSAddressSeed()
                     found++;
                 }
             }
-            boost::this_thread::interruption_point();
             addrman.Add(vAdd, CNetAddr(seed.name, true));
         }
     }

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -3,6 +3,10 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#ifdef HAVE_CONFIG_H
+#include "bitcoin-config.h"
+#endif
+
 #include "netbase.h"
 
 #include "hash.h"
@@ -12,7 +16,7 @@
 
 #ifndef WIN32
 #include <fcntl.h>
-#ifdef _GNU_SOURCE
+#if defined(_GNU_SOURCE) && defined(HAVE_LIBANL)
 #include <netdb.h>
 #endif
 #endif
@@ -86,7 +90,7 @@ bool static LookupIntern(const char *pszName, std::vector<CNetAddr>& vIP, unsign
 #endif
 
     struct addrinfo *aiRes = NULL;
-#ifdef _GNU_SOURCE
+#if defined(_GNU_SOURCE) && defined(HAVE_LIBANL)
     struct gaicb gcb, *query = &gcb;
     memset(query, 0, sizeof(struct gaicb));
     gcb.ar_name = pszName;

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -7,6 +7,8 @@
 #include "bitcoin-config.h"
 #endif
 
+#include <arpa/inet.h>
+
 #include "netbase.h"
 
 #include "hash.h"

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -78,6 +78,20 @@ bool static LookupIntern(const char *pszName, std::vector<CNetAddr>& vIP, unsign
         }
     }
 
+    {
+        struct in_addr ipv4_addr;
+        if (inet_pton(AF_INET, pszName, &ipv4_addr) > 0) {
+            vIP.push_back(CNetAddr(ipv4_addr));
+            return true;
+        }
+
+        struct in6_addr ipv6_addr;
+        if (inet_pton(AF_INET6, pszName, &ipv6_addr) > 0) {
+           vIP.push_back(CNetAddr(ipv6_addr));
+           return true;
+        }
+    }
+
     struct addrinfo aiHint;
     memset(&aiHint, 0, sizeof(struct addrinfo));
     aiHint.ai_socktype = SOCK_STREAM;
@@ -98,6 +112,7 @@ bool static LookupIntern(const char *pszName, std::vector<CNetAddr>& vIP, unsign
     int nErr = getaddrinfo_a(GAI_NOWAIT, &query, 1, NULL);
     if (nErr)
         return false;
+
     do {
         // Should set the timeout limit to a resonable value to avoid
         // generating unnecessary checking call during the polling loop,

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -16,7 +16,7 @@
 
 #ifndef WIN32
 #include <fcntl.h>
-#if defined(_GNU_SOURCE) && defined(HAVE_LIBANL)
+#if defined(_GNU_SOURCE) && defined(HAVE_GETADDRINFO_A)
 #include <netdb.h>
 #endif
 #endif
@@ -90,7 +90,7 @@ bool static LookupIntern(const char *pszName, std::vector<CNetAddr>& vIP, unsign
 #endif
 
     struct addrinfo *aiRes = NULL;
-#if defined(_GNU_SOURCE) && defined(HAVE_LIBANL)
+#if defined(_GNU_SOURCE) && defined(HAVE_GETADDRINFO_A)
     struct gaicb gcb, *query = &gcb;
     memset(query, 0, sizeof(struct gaicb));
     gcb.ar_name = pszName;

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -16,7 +16,7 @@
 
 #ifndef WIN32
 #include <fcntl.h>
-#if defined(_GNU_SOURCE) && defined(HAVE_GETADDRINFO_A)
+#ifdef HAVE_GETADDRINFO_A
 #include <netdb.h>
 #endif
 #endif
@@ -90,7 +90,7 @@ bool static LookupIntern(const char *pszName, std::vector<CNetAddr>& vIP, unsign
 #endif
 
     struct addrinfo *aiRes = NULL;
-#if defined(_GNU_SOURCE) && defined(HAVE_GETADDRINFO_A)
+#ifdef HAVE_GETADDRINFO_A
     struct gaicb gcb, *query = &gcb;
     memset(query, 0, sizeof(struct gaicb));
     gcb.ar_name = pszName;


### PR DESCRIPTION
...stage quickly

The dnsseed thread is starting by default and takes quick some time, if the user wants to stop the bitcoind by Ctrl-C in command line or a kill in daemon mode when the dnsseed is still working, s/he would have to wait for it to finish all the job, in such situation, an extra 'kill -9' would be expected.

By adding two interruption points just before the time-consuming operations we give the dnsseed thread a chance to realize the user's intention and quit its job much quickly, usually in seconds instead of several minutes or more depends on network situation.

Signed-off-by: Huang Le 4tarhl@gmail.com
