### PR TITLE
Fix warning when compiling in OS X

### DIFF
--- a/src/qt/notificator.cpp
+++ b/src/qt/notificator.cpp
@@ -28,8 +28,10 @@
 #endif
 
 
+#ifdef USE_DBUS
 // https://wiki.ubuntu.com/NotificationDevelopmentGuidelines recommends at least 128
 const int FREEDESKTOP_NOTIFICATION_ICON_SIZE = 128;
+#endif
 
 Notificator::Notificator(const QString &programName, QSystemTrayIcon *trayicon, QWidget *parent) :
     QObject(parent),


### PR DESCRIPTION
```
notificator.cpp:32:11: warning: unused variable 'FREEDESKTOP_NOTIFICATION_ICON_SIZE' [-Wunused-const-variable]
const int FREEDESKTOP_NOTIFICATION_ICON_SIZE = 128;
          ^
1 warning generated.
```
