### PR TITLE
release: Bump the OSX SDK to 10.7 for gitian builds

### DIFF
--- a/contrib/gitian-descriptors/gitian-osx-bitcoin.yml
+++ b/contrib/gitian-descriptors/gitian-osx-bitcoin.yml
@@ -17,33 +17,28 @@ remotes:
 - "url": "https://github.com/bitcoin/bitcoin.git"
   "dir": "bitcoin"
 files:
-- "osx-native-depends-r2.tar.gz"
-- "osx-depends-r2.tar.gz"
-- "osx-depends-qt-5.2.1-r2.tar.gz"
-- "MacOSX10.6.pkg"
+- "osx-native-depends-r3.tar.gz"
+- "osx-depends-r3.tar.gz"
+- "osx-depends-qt-5.2.1-r3.tar.gz"
+- "MacOSX10.7.sdk.tar.gz"
 
 script: |
 
-  echo "a2ccf2299de4e0bb88bd17a3355f02b747575b97492c7c2f5b789a64ccc4cbd6  MacOSX10.6.pkg" | sha256sum -c
-
   HOST=x86_64-apple-darwin11
   PREFIX=`pwd`/osx-cross-depends/prefix
-  SDK=`pwd`/osx-cross-depends/SDKs/MacOSX10.6.sdk
+  SDK=`pwd`/osx-cross-depends/SDKs/MacOSX10.7.sdk
   NATIVEPREFIX=`pwd`/osx-cross-depends/native-prefix
   export TAR_OPTIONS="-m --mtime="$REFERENCE_DATE\\\ $REFERENCE_TIME""
 
   export SOURCES_PATH=`pwd`
 
-  mkdir osx-cross-depends
+  mkdir -p osx-cross-depends/SDKs
 
-  cd osx-cross-depends
-  mkdir -p SDKs
-  7z -bd -so -y e ${SOURCES_PATH}/MacOSX10.6.pkg Payload | gzip -d -c | cpio -i
-  cd ..
+  tar -C osx-cross-depends/SDKs -xf ${SOURCES_PATH}/MacOSX10.7.sdk.tar.gz
 
-  tar -C osx-cross-depends -xf osx-native-depends-r2.tar.gz
-  tar -C osx-cross-depends -xf osx-depends-r2.tar.gz
-  tar -C osx-cross-depends -xf osx-depends-qt-5.2.1-r2.tar.gz
+  tar -C osx-cross-depends -xf osx-native-depends-r3.tar.gz
+  tar -C osx-cross-depends -xf osx-depends-r3.tar.gz
+  tar -C osx-cross-depends -xf osx-depends-qt-5.2.1-r3.tar.gz
   export PATH=`pwd`/osx-cross-depends/native-prefix/bin:$PATH
 
   cd bitcoin

--- a/contrib/gitian-descriptors/gitian-osx-depends.yml
+++ b/contrib/gitian-descriptors/gitian-osx-depends.yml
@@ -18,8 +18,8 @@ files:
 - "openssl-1.0.1g.tar.gz"
 - "protobuf-2.5.0.tar.bz2"
 - "qrencode-3.4.3.tar.bz2"
-- "MacOSX10.6.pkg"
-- "osx-native-depends-r2.tar.gz"
+- "MacOSX10.7.sdk.tar.gz"
+- "osx-native-depends-r3.tar.gz"
 
 script: |
 
@@ -29,9 +29,8 @@ script: |
   echo "53cb818c3b90e507a8348f4f5eaedb05d8bfe5358aabb508b7263cc670c3e028  openssl-1.0.1g.tar.gz" | sha256sum -c
   echo "13bfc5ae543cf3aa180ac2485c0bc89495e3ae711fc6fab4f8ffe90dfb4bb677  protobuf-2.5.0.tar.bz2" | sha256sum -c
   echo "dfd71487513c871bad485806bfd1fdb304dedc84d2b01a8fb8e0940b50597a98  qrencode-3.4.3.tar.bz2" | sha256sum -c
-  echo "a2ccf2299de4e0bb88bd17a3355f02b747575b97492c7c2f5b789a64ccc4cbd6  MacOSX10.6.pkg" | sha256sum -c
 
-  REVISION=r2
+  REVISION=r3
   export SOURCES_PATH=`pwd`
   export TAR_OPTIONS="-m --mtime="$REFERENCE_DATE\\\ $REFERENCE_TIME""
   export PATH=$HOME:$PATH
@@ -44,7 +43,7 @@ script: |
   PREFIX=`pwd`/prefix
   NATIVEPREFIX=`pwd`/native-prefix
   BUILD_BASE=`pwd`/build
-  SDK=`pwd`/SDKs/MacOSX10.6.sdk
+  SDK=`pwd`/SDKs/MacOSX10.7.sdk
   HOST=x86_64-apple-darwin11
   MIN_VERSION=10.6
 
@@ -70,10 +69,10 @@ script: |
   mkdir -p ${PREFIX}/lib
   mkdir -p ${BUILD_BASE}
 
-  mkdir -p ${SDK}
-  7z -bd -so -y e ${SOURCES_PATH}/MacOSX10.6.pkg Payload | gzip -d -c | cpio -i
+  mkdir -p SDKs
+  tar -C SDKs -xf ${SOURCES_PATH}/MacOSX10.7.sdk.tar.gz
 
-  tar xf /home/ubuntu/build/osx-native-depends-r2.tar.gz
+  tar xf /home/ubuntu/build/osx-native-depends-r3.tar.gz
 
   # bdb
   SOURCE_FILE=${SOURCES_PATH}/db-4.8.30.NC.tar.gz

--- a/contrib/gitian-descriptors/gitian-osx-native.yml
+++ b/contrib/gitian-descriptors/gitian-osx-native.yml
@@ -24,7 +24,7 @@ files:
 - "dyld-195.5.tar.gz"
 - "ld64-127.2.tar.gz"
 - "protobuf-2.5.0.tar.bz2"
-- "MacOSX10.6.pkg"
+- "MacOSX10.7.sdk.tar.gz"
 - "cdrkit-1.1.11.tar.gz"
 - "libdmg-hfsplus-v0.1.tar.gz"
 - "clang-llvm-3.2-x86-linux-ubuntu-12.04.tar.gz"
@@ -38,14 +38,13 @@ script: |
   echo "2cf0484c87cf79b606b351a7055a247dae84093ae92c747a74e0cde2c8c8f83c  dyld-195.5.tar.gz" | sha256sum -c
   echo "97b75547b2bd761306ab3e15ae297f01e7ab9760b922bc657f4ef72e4e052142  ld64-127.2.tar.gz" | sha256sum -c
   echo "13bfc5ae543cf3aa180ac2485c0bc89495e3ae711fc6fab4f8ffe90dfb4bb677  protobuf-2.5.0.tar.bz2" | sha256sum -c
-  echo "a2ccf2299de4e0bb88bd17a3355f02b747575b97492c7c2f5b789a64ccc4cbd6  MacOSX10.6.pkg" | sha256sum -c
   echo "d1c030756ecc182defee9fe885638c1785d35a2c2a297b4604c0e0dcc78e47da  cdrkit-1.1.11.tar.gz" | sha256sum -c
   echo "6569a02eb31c2827080d7d59001869ea14484c281efab0ae7f2b86af5c3120b3  libdmg-hfsplus-v0.1.tar.gz" | sha256sum -c
   echo "b9d57a88f9514fa1f327a1a703756d0c1c960f4c58494a5bd80313245d13ffff  clang-llvm-3.2-x86-linux-ubuntu-12.04.tar.gz" | sha256sum -c
   echo "cc12bdbd7a09f71cb2a6a3e6ec3e0abe885ca7111c2b47857f5095e5980caf4f  cdrkit-deterministic.patch" | sha256sum -c
 
 
-  REVISION=r2
+  REVISION=r3
   export REFERENCE_DATETIME
   export TAR_OPTIONS="-m --mtime="$REFERENCE_DATE\\\ $REFERENCE_TIME""
   export FAKETIME=$REFERENCE_DATETIME
@@ -78,7 +77,7 @@ script: |
 
   NATIVEPREFIX=`pwd`/native-prefix
   BUILD_BASE=`pwd`/build
-  SDK=`pwd`/SDKs/MacOSX10.6.sdk
+  SDK=`pwd`/SDKs/MacOSX10.7.sdk
   HOST=x86_64-apple-darwin11
   MIN_VERSION=10.6
 
@@ -91,8 +90,8 @@ script: |
   mkdir -p ${NATIVEPREFIX}/bin
   mkdir -p ${NATIVEPREFIX}/lib
 
-  mkdir -p ${SDK}
-  7z -bd -so -y e ${SOURCES_PATH}/MacOSX10.6.pkg Payload | gzip -d -c | cpio -i
+  mkdir -p SDKs
+  tar -C SDKs -xf ${SOURCES_PATH}/MacOSX10.7.sdk.tar.gz
 
   #  Clang
   SOURCE_FILE=${SOURCES_PATH}/clang-llvm-3.2-x86-linux-ubuntu-12.04.tar.gz
@@ -112,7 +111,7 @@ script: |
   tar -C ${BUILD_BASE} -xf ${SOURCE_FILE}
   mkdir -p ${BUILD_DIR}/sdks
   pushd ${BUILD_DIR}/sdks;
-  ln -sf ${SDK} MacOSX10.6.sdk
+  ln -sf ${SDK} MacOSX10.7.sdk
   ln -sf ${SOURCES_PATH}/cctools-809.tar.gz ${BUILD_DIR}/cctools2odcctools/cctools-809.tar.gz
   ln -sf ${SOURCES_PATH}/ld64-127.2.tar.gz ${BUILD_DIR}/cctools2odcctools/ld64-127.2.tar.gz
   ln -sf ${SOURCES_PATH}/dyld-195.5.tar.gz ${BUILD_DIR}/cctools2odcctools/dyld-195.5.tar.gz
@@ -127,7 +126,7 @@ script: |
   sed -i 's/\# Dynamically linked LTO/\t ;\&\n\t linux*)\n# Dynamically linked LTO/' ${BUILD_DIR}/cctools2odcctools/files/configure.ac
 
   cd ${BUILD_DIR}/cctools2odcctools
-  ./extract.sh --osxver 10.6
+  ./extract.sh --osxver 10.7
   cd odcctools-809
   ./configure --prefix=${NATIVEPREFIX} --target=${HOST} CFLAGS="${CFLAGS} -I${NATIVEPREFIX}/include -D__DARWIN_UNIX03 -D__STDC_CONSTANT_MACROS -D__STDC_LIMIT_MACROS" LDFLAGS="${LDFLAGS} -Wl,-rpath=\\\$\$ORIGIN/../lib" --with-sysroot=${SDK}
 

--- a/contrib/gitian-descriptors/gitian-osx-qt.yml
+++ b/contrib/gitian-descriptors/gitian-osx-qt.yml
@@ -13,16 +13,15 @@ reference_datetime: "2013-06-01 00:00:00"
 remotes: []
 files:
 - "qt-everywhere-opensource-src-5.2.1.tar.gz"
-- "osx-native-depends-r2.tar.gz"
-- "osx-depends-r2.tar.gz"
-- "MacOSX10.6.pkg"
+- "osx-native-depends-r3.tar.gz"
+- "osx-depends-r3.tar.gz"
+- "MacOSX10.7.sdk.tar.gz"
 
 script: |
 
   echo "84e924181d4ad6db00239d87250cc89868484a14841f77fb85ab1f1dbdcd7da1  qt-everywhere-opensource-src-5.2.1.tar.gz" | sha256sum -c
-  echo "a2ccf2299de4e0bb88bd17a3355f02b747575b97492c7c2f5b789a64ccc4cbd6  MacOSX10.6.pkg" | sha256sum -c
 
-  REVISION=r2
+  REVISION=r3
   export SOURCES_PATH=`pwd`
   export TAR_OPTIONS="-m --mtime="$REFERENCE_DATE\\\ $REFERENCE_TIME""
   export ZERO_AR_DATE=1
@@ -42,7 +41,7 @@ script: |
   PREFIX=`pwd`/prefix
   NATIVEPREFIX=`pwd`/native-prefix
   BUILD_BASE=`pwd`/build
-  SDK=`pwd`/SDKs/MacOSX10.6.sdk
+  SDK=`pwd`/SDKs/MacOSX10.7.sdk
   HOST=x86_64-apple-darwin11
   MIN_VERSION=10.6
 
@@ -68,18 +67,13 @@ script: |
   mkdir -p ${PREFIX}/lib
   mkdir -p ${BUILD_BASE}
 
-  mkdir -p ${SDK}
-  7z -bd -so -y e ${SOURCES_PATH}/MacOSX10.6.pkg Payload | gzip -d -c | cpio -i
-
-  tar xf /home/ubuntu/build/osx-native-depends-r2.tar.gz
-
-
   mkdir -p SDKs
-  7z -bd -so -y e ${SOURCES_PATH}/MacOSX10.6.pkg Payload | gzip -d -c | cpio -i
+  tar -C SDKs -xf ${SOURCES_PATH}/MacOSX10.7.sdk.tar.gz
 
-  tar xf /home/ubuntu/build/osx-native-depends-r2.tar.gz
+  tar xf /home/ubuntu/build/osx-native-depends-r3.tar.gz
+
   export PATH=`pwd`/native-prefix/bin:$PATH
-  tar xf /home/ubuntu/build/osx-depends-r2.tar.gz
+  tar xf /home/ubuntu/build/osx-depends-r3.tar.gz
 
   SOURCE_FILE=${SOURCES_PATH}/qt-everywhere-opensource-src-5.2.1.tar.gz
   BUILD_DIR=${BUILD_BASE}/qt-everywhere-opensource-src-5.2.1

--- a/doc/README_osx.txt
+++ b/doc/README_osx.txt
@@ -37,11 +37,15 @@ originally done in toolchain4.
 
 To complicate things further, all builds must target an Apple SDK. These SDKs
 are free to download, but not redistributable.
-To obtain it, register for a developer account, then download xcode_3.2.6_and_ios_sdk_4.3.dmg:
-https://developer.apple.com/devcenter/download.action?path=/Developer_Tools/xcode_3.2.6_and_ios_sdk_4.3__final/xcode_3.2.6_and_ios_sdk_4.3.dmg
-This file is several gigabytes in size, but only a single .pkg file inside is
-needed (MacOSX10.6.pkg). From Linux, 7-zip can be used to extract this file.
-The DMG can then be discarded.
+To obtain it, register for a developer account, then download xcode4630916281a.dmg:
+https://developer.apple.com/downloads/download.action?path=Developer_Tools/xcode_4.6.3/xcode4630916281a.dmg
+This file is several gigabytes in size, but only a single directory inside is
+needed: Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.7.sdk
+
+Unfortunately, the usual linux tools (7zip, hpmount, loopback mount) are incapable of opening this file.
+To create a tarball suitable for gitian input, mount the dmg in OSX, then create it with:
+  $ tar -C /Volumes/Xcode/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/ -czf MacOSX10.7.sdk.tar.gz MacOSX10.7.sdk
+
 
 The gitian descriptors build 2 sets of files: Linux tools, then Apple binaries
 which are created using these tools. The build process has been designed to

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -36,12 +36,10 @@ Release Process
         mkdir -p inputs; cd inputs/
 
  Register and download the Apple SDK (see OSX Readme for details)
-        visit https://developer.apple.com/devcenter/download.action?path=/Developer_Tools/xcode_3.2.6_and_ios_sdk_4.3__final/xcode_3.2.6_and_ios_sdk_4.3.dmg
+	visit https://developer.apple.com/downloads/download.action?path=Developer_Tools/xcode_4.6.3/xcode4630916281a.dmg
  
- Extract MacOSX10.6.pkg using 7zip
-        7z e -y xcode_3.2.6_and_ios_sdk_4.3.dmg 5.hfs
-        7z -y e 5.hfs "Xcode and iOS SDK/Packages/MacOSX10.6.pkg"
-        rm 5.hfs
+ Using a Mac, create a tarball for the 10.7 SDK
+	tar -C /Volumes/Xcode/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/ -czf MacOSX10.7.sdk.tar.gz MacOSX10.7.sdk
 
  Fetch and build inputs: (first time, or when dependency versions change)
 


### PR DESCRIPTION
This fixes the display on Retina Macbooks. It also moves us away from depending on the ancient XCode3 sdk.

The only downside is that the 10.7 sdk is not easily separated from the rest of the dmg:
https://developer.apple.com/downloads/download.action?path=Developer_Tools/xcode_4.6.3/xcode4630916281a.dmg

That means, unfortunately, that a Mac is required to create a tarball from the MacOSX10.7.sdk directory in that dmg, which will likely not be a deterministic process. I don't believe that should affect the final output, though.

I would be very grateful if someone managed to crack open the dmg and extract the SDK from Linux, but none of the usual tools work on this one.
