### PR TITLE
change "char pch[200000]" to "new char[200000]"

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -169,15 +169,14 @@ void RandAddSeedPerfmon()
 #ifdef WIN32
     // Don't need this on Linux, OpenSSL automatically uses /dev/urandom
     // Seed with the entire set of perfmon data
-    unsigned char pdata[250000];
-    memset(pdata, 0, sizeof(pdata));
-    unsigned long nSize = sizeof(pdata);
-    long ret = RegQueryValueExA(HKEY_PERFORMANCE_DATA, "Global", NULL, NULL, pdata, &nSize);
+    std::vector <unsigned char> pdata(250000,0);
+    unsigned long nSize = pdata.size();
+    long ret = RegQueryValueExA(HKEY_PERFORMANCE_DATA, "Global", NULL, NULL, &pdata.front(), &nSize);
     RegCloseKey(HKEY_PERFORMANCE_DATA);
     if (ret == ERROR_SUCCESS)
     {
-        RAND_add(pdata, nSize, nSize/100.0);
-        OPENSSL_cleanse(pdata, nSize);
+        RAND_add(&pdata.front(), nSize, nSize/100.0);
+        OPENSSL_cleanse(&pdata.front(), nSize);
         LogPrint("rand", "RandAddSeed() %lu bytes\n", nSize);
     }
 #endif
@@ -1144,15 +1143,15 @@ void ShrinkDebugFile()
     if (file && boost::filesystem::file_size(pathLog) > 10 * 1000000)
     {
         // Restart the file with some of the end
-        char pch[200000];
-        fseek(file, -sizeof(pch), SEEK_END);
-        int nBytes = fread(pch, 1, sizeof(pch), file);
+        std::vector <char> pch(200000,0);
+        fseek(file, -pch.size(), SEEK_END);
+        int nBytes = fread(&pch.front(), 1, pch.size(), file);
         fclose(file);
 
         file = fopen(pathLog.string().c_str(), "w");
         if (file)
         {
-            fwrite(pch, 1, nBytes, file);
+            fwrite(&pch.front(), 1, nBytes, file);
             fclose(file);
         }
     }


### PR DESCRIPTION
Change the big size local var  "char pch[200000]" to "new char[200000]" to avoid the possibly stack overflow.
