### PR TITLE
[Qt] Fix Transaction details shows wrong To:

### DIFF
--- a/src/qt/transactiondesc.h
+++ b/src/qt/transactiondesc.h
@@ -8,6 +8,7 @@
 #include <QObject>
 #include <QString>
 
+class TransactionRecord;
 class CWallet;
 class CWalletTx;
 
@@ -18,7 +19,7 @@ class TransactionDesc: public QObject
     Q_OBJECT
 
 public:
-    static QString toHTML(CWallet *wallet, CWalletTx &wtx, int vout, int unit);
+    static QString toHTML(CWallet *wallet, CWalletTx &wtx, TransactionRecord *rec, int unit);
 
 private:
     TransactionDesc() {}

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -222,7 +222,7 @@ public:
             std::map<uint256, CWalletTx>::iterator mi = wallet->mapWallet.find(rec->hash);
             if(mi != wallet->mapWallet.end())
             {
-                return TransactionDesc::toHTML(wallet, mi->second, rec->idx, unit);
+                return TransactionDesc::toHTML(wallet, mi->second, rec, unit);
             }
         }
         return QString("");


### PR DESCRIPTION
Fixes #1725.

When we decompose a transaction into a TransactionRecord we already loop the outputs and assign
rec->address. In TransactionDesc we can simply show the value of rec->address.
What we currently do is loop the outputs again and always show the first of our outputs which results in the described bug.
