### PR TITLE
Default to disable-wallet mode if the wallet doesn't exist

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -242,6 +242,7 @@ std::string HelpMessage(HelpMessageMode hmm)
 
 #ifdef ENABLE_WALLET
     strUsage += "\n" + _("Wallet options:") + "\n";
+    strUsage += "  -createwallet          " + _("Create a new wallet if it doesn't exist yet (default: 0)") + "\n";
     strUsage += "  -disablewallet         " + _("Do not load the wallet and disable wallet RPC calls") + "\n";
     strUsage += "  -paytxfee=<amt>        " + _("Fee per kB to add to transactions you send") + "\n";
     strUsage += "  -rescan                " + _("Rescan the block chain for missing wallet transactions") + " " + _("on startup") + "\n";
@@ -626,6 +627,13 @@ bool AppInit2(boost::thread_group& threadGroup)
 
     // ********************************************************* Step 5: verify wallet database integrity
 #ifdef ENABLE_WALLET
+    // Disable wallet if enabled but cannot be found, unless `-createwallet` is set
+    if (!fDisableWallet && !filesystem::exists(GetDataDir() / strWalletFile) && !GetBoolArg("-createwallet", false))
+    {
+        LogPrintf("Could not find wallet %s: disabling wallet functionality. Pass -createwallet to create it.\n", strWalletFile);
+        fDisableWallet = true;
+    }
+
     if (!fDisableWallet) {
         LogPrintf("Using wallet %s\n", strWalletFile);
         uiInterface.InitMessage(_("Verifying wallet..."));

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -464,6 +464,10 @@ int main(int argc, char *argv[])
     /// 1. Parse command-line options. These take precedence over anything else.
     // Command-line options take precedence:
     ParseParameters(argc, argv);
+    // For the GUI, default to creating the wallet if it doesn't exist, as anything else
+    // is going to confuse users. A menu option to create the wallet would be nice to have,
+    // but this will require being able to switch disable-wallet mode at runtime.
+    SoftSetBoolArg("-createwallet", true);
 
     // Do not refer to data directory yet, this can be overridden by Intro::pickDataDirectory
 


### PR DESCRIPTION
Default to disable-wallet mode if the wallet doesn't exist, and require the user to tell the daemon to create it.
I think this makes sense eventually, and is a further step toward removing the expectation that Bitcoin Core is a wallet.

Add a command line option `-createwallet` to create the wallet. Passing this option when the wallet already exists does nothing.

N.B.: The GUI still defaults to creating the wallet by default. There would first need to be a user-friendly way to create the wallet to change this behavior, for example through a menu option. This is going to be the
next step if the idea is accepted.
