### PR TITLE
osx: Fix missing dock menu with qt5

### DIFF
--- a/src/qt/macdockiconhandler.mm
+++ b/src/qt/macdockiconhandler.mm
@@ -62,6 +62,8 @@ MacDockIconHandler::MacDockIconHandler() : QObject()
     this->setMainWindow(NULL);
 #if QT_VERSION < 0x050000
     qt_mac_set_dock_menu(this->m_dockMenu);
+#elif QT_VERSION >= 0x050200
+    this->m_dockMenu->setAsDockMenu();
 #endif
     [pool release];
 }


### PR DESCRIPTION
Qt5 Removed the qt_mac_set_dock_menu function and left no replacement.

Qt5.2 adds QMenu::setAsDockMenu() to handle this. Use that when possible. Current Gitian uses Qt5.2, so this fixes release builds.
