### PR TITLE
unresolved external symbol "CWallet * pwalletMain"

### DIFF
--- a/src/qt/signverifymessagedialog.cpp
+++ b/src/qt/signverifymessagedialog.cpp
@@ -129,7 +129,7 @@ void SignVerifyMessageDialog::on_signMessageButton_SM_clicked()
         ui->statusLabel_SM->setText(tr("Wallet unlock was cancelled."));
         return;
     }
-
+#ifdef ENABLE_WALLET
     CKey key;
     if (!pwalletMain->GetKey(keyID, key))
     {
@@ -154,6 +154,7 @@ void SignVerifyMessageDialog::on_signMessageButton_SM_clicked()
     ui->statusLabel_SM->setText(QString("<nobr>") + tr("Message signed.") + QString("</nobr>"));
 
     ui->signatureOut_SM->setText(QString::fromStdString(EncodeBase64(&vchSig[0], vchSig.size())));
+#endif    
 }
 
 void SignVerifyMessageDialog::on_copySignatureButton_SM_clicked()


### PR DESCRIPTION
when i don't define ENABLE_WALLET, it will link error( unresolved external symbol "class CWallet \* pwalletMain" ). the error in files ( rpcdump.cpp and rpcwallet.cpp and signverifymessagedialog.cpp ). I can change signverifymessagedialog.cpp (only one quote), but lots of quote in rpcdump.cpp and rpcwallet.cpp, i don't have ablity to modify.
