### PR TITLE
gitian: make linux qt intermediate deterministic

### DIFF
--- a/contrib/gitian-descriptors/qt-linux.yml
+++ b/contrib/gitian-descriptors/qt-linux.yml
@@ -40,6 +40,7 @@ script: |
   tar xzf qt-everywhere-opensource-src-4.6.4.tar.gz
   cd qt-everywhere-opensource-src-4.6.4
   QTBUILDDIR=$(pwd)
+  sed 's/TODAY=`date +%Y-%m-%d`/TODAY=2011-01-30/' -i configure
 
   # Need to build 4.6-versioned host utilities as well (lrelease/qrc/lupdate/...)
   ./configure -prefix $INSTALLPREFIX -confirm-license -release -opensource -no-qt3support -no-multimedia -no-audio-backend -no-phonon -no-phonon-backend -no-declarative -no-script -no-scripttools -no-javascript-jit -no-webkit -no-svg -no-xmlpatterns -no-sql-sqlite -no-nis -no-cups -no-iconv -no-dbus -no-gif -no-libtiff -no-opengl -nomake examples -nomake demos -nomake docs

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -97,8 +97,8 @@ Release Process
     60eb4b9c5779580b7d66529efa5b2836ba1a70edde2a0f3f696d647906a826be  qt-linux64-4.6.4-gitian-r1.tar.gz
     60dc2d3b61e9c7d5dbe2f90d5955772ad748a47918ff2d8b74e8db9b1b91c909  boost-win32-1.55.0-gitian-r6.zip
     f65fcaf346bc7b73bc8db3a8614f4f6bee2f61fcbe495e9881133a7c2612a167  boost-win64-1.55.0-gitian-r6.zip
-    97e62002d338885336bb24e7cbb9471491294bd8857af7a83d18c0961f864ec0  bitcoin-deps-win32-gitian-r11.zip
-    ee3ea2d5aac1a67ea6bfbea2c04068a7c0940616ce48ee4f37c264bb9d4438ef  bitcoin-deps-win64-gitian-r11.zip
+    acd59690a49dfbad6b436379843fe4ad1857ad91c603d52506690bc55f2a01a4  bitcoin-deps-win32-gitian-r12.zip
+    a3e5a62fcdad81f758e41848035e6a27be390981a14d590f2cf2509f87417a42  bitcoin-deps-win64-gitian-r12.zip
     963e3e5e85879010a91143c90a711a5d1d5aba992e38672cdf7b54e42c56b2f1  qt-win32-5.2.0-gitian-r3.zip
     751c579830d173ef3e6f194e83d18b92ebef6df03289db13ab77a52b6bc86ef0  qt-win64-5.2.0-gitian-r3.zip
     e2e403e1a08869c7eed4d4293bce13d51ec6a63592918b90ae215a0eceb44cb4  protobuf-win32-2.5.0-gitian-r4.zip

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -93,8 +93,8 @@ Release Process
     571789867d172500fa96d63d0ba8c5b1e1a3d6f44f720eddf2f93665affc88b3  bitcoin-deps-linux64-gitian-r5.zip
     f29b7d9577417333fb56e023c2977f5726a7c297f320b175a4108cf7cd4c2d29  boost-linux32-1.55.0-gitian-r1.zip
     88232451c4104f7eb16e469ac6474fd1231bd485687253f7b2bdf46c0781d535  boost-linux64-1.55.0-gitian-r1.zip
-    74ec2d301cf1a9d03b194153f545102ba45dad02b390485212fe6717de486361  qt-linux32-4.6.4-gitian-r1.tar.gz
-    01d0477e299467f09280f15424781154e2b1ea4072c5edb16e044c234954fd9a  qt-linux64-4.6.4-gitian-r1.tar.gz
+    57e57dbdadc818cd270e7e00500a5e1085b3bcbdef69a885f0fb7573a8d987e1  qt-linux32-4.6.4-gitian-r1.tar.gz
+    60eb4b9c5779580b7d66529efa5b2836ba1a70edde2a0f3f696d647906a826be  qt-linux64-4.6.4-gitian-r1.tar.gz
     60dc2d3b61e9c7d5dbe2f90d5955772ad748a47918ff2d8b74e8db9b1b91c909  boost-win32-1.55.0-gitian-r6.zip
     f65fcaf346bc7b73bc8db3a8614f4f6bee2f61fcbe495e9881133a7c2612a167  boost-win64-1.55.0-gitian-r6.zip
     97e62002d338885336bb24e7cbb9471491294bd8857af7a83d18c0961f864ec0  bitcoin-deps-win32-gitian-r11.zip


### PR DESCRIPTION
A qt installation date snuck into the host utils (lrelease etc). This doesn't affect the end product, so no dependency version bump.

It also doesn't explain why gavin's and mine bitcoin-qt build is different:
https://github.com/bitcoin/gitian.sigs/blob/master/0.9.2rc1/laanwj/bitcoin-build.assert
https://github.com/bitcoin/gitian.sigs/blob/master/0.9.2rc1/gavinandresen/bitcoin-build.assert

Let's wait for some further gitian builds to see if they converge into two groups, or everyone gets wildly different output.
