### PR TITLE
Clean up release-process.md and make descriptors more consistent

### DIFF
--- a/contrib/gitian-descriptors/deps-linux.yml
+++ b/contrib/gitian-descriptors/deps-linux.yml
@@ -1,5 +1,5 @@
 ---
-name: "bitcoin"
+name: "bitcoin-deps"
 suites:
 - "precise"
 architectures:

--- a/contrib/gitian-descriptors/deps-osx.yml
+++ b/contrib/gitian-descriptors/deps-osx.yml
@@ -1,5 +1,5 @@
 ---
-name: "osx-depends"
+name: "bitcoin-deps"
 suites:
 - "precise"
 architectures:
@@ -8,7 +8,6 @@ packages:
 - "git-core"
 - "automake"
 - "p7zip-full"
-
 reference_datetime: "2013-06-01 00:00:00"
 remotes: []
 files:
@@ -19,10 +18,8 @@ files:
 - "protobuf-2.5.0.tar.bz2"
 - "qrencode-3.4.3.tar.bz2"
 - "MacOSX10.7.sdk.tar.gz"
-- "osx-native-depends-r3.tar.gz"
-
+- "osx-native-depends-gitian-r3.tar.gz"
 script: |
-
   echo "fff00023dd79486d444c8e29922f4072e1d451fc5a4d2b6075852ead7f2b7b52  boost_1_55_0.tar.bz2" | sha256sum -c
   echo "12edc0df75bf9abd7f82f821795bcee50f42cb2e5f76a6a281b85732798364ef  db-4.8.30.NC.tar.gz" | sha256sum -c
   echo "2923e453e880bb949e3d4da9f83dd3cb6f08946d35de0b864d0339cf70934464  miniupnpc-1.9.tar.gz" | sha256sum -c
@@ -72,7 +69,7 @@ script: |
   mkdir -p SDKs
   tar -C SDKs -xf ${SOURCES_PATH}/MacOSX10.7.sdk.tar.gz
 
-  tar xf /home/ubuntu/build/osx-native-depends-r3.tar.gz
+  tar xf /home/ubuntu/build/osx-native-depends-gitian-r3.tar.gz
 
   # bdb
   SOURCE_FILE=${SOURCES_PATH}/db-4.8.30.NC.tar.gz
@@ -154,6 +151,6 @@ script: |
   popd
 
   export GZIP="-9n"
-  find prefix | sort | tar --no-recursion -czf osx-depends-${REVISION}.tar.gz -T -
+  find prefix | sort | tar --no-recursion -czf bitcoin-deps-osx-gitian-${REVISION}.tar.gz -T -
 
-  mv osx-depends-${REVISION}.tar.gz $OUTDIR
+  mv bitcoin-deps-osx-gitian-${REVISION}.tar.gz $OUTDIR

--- a/contrib/gitian-descriptors/gitian-osx.yml
+++ b/contrib/gitian-descriptors/gitian-osx.yml
@@ -16,15 +16,9 @@ remotes:
 - "url": "https://github.com/bitcoin/bitcoin.git"
   "dir": "bitcoin"
 files:
-<<<<<<< HEAD:contrib/gitian-descriptors/gitian-osx-bitcoin.yml
-- "osx-native-depends-r3.tar.gz"
-- "osx-depends-r4.tar.gz"
-- "osx-depends-qt-5.2.1-r4.tar.gz"
-=======
 - "osx-native-depends-gitian-r3.tar.gz"
-- "bitcoin-deps-osx-gitian-r3.tar.gz"
-- "qt-osx-5.2.1-gitian-r3.tar.gz"
->>>>>>> Clean up release-process.md and make descriptors more consistent:contrib/gitian-descriptors/gitian-osx.yml
+- "bitcoin-deps-osx-gitian-r4.tar.gz"
+- "qt-osx-5.2.1-gitian-r4.tar.gz"
 - "MacOSX10.7.sdk.tar.gz"
 script: |
   HOST=x86_64-apple-darwin11

--- a/contrib/gitian-descriptors/gitian-osx.yml
+++ b/contrib/gitian-descriptors/gitian-osx.yml
@@ -11,19 +11,22 @@ packages:
 - "bsdmainutils"
 - "pkg-config"
 - "p7zip-full"
-
 reference_datetime: "2013-06-01 00:00:00"
 remotes:
 - "url": "https://github.com/bitcoin/bitcoin.git"
   "dir": "bitcoin"
 files:
+<<<<<<< HEAD:contrib/gitian-descriptors/gitian-osx-bitcoin.yml
 - "osx-native-depends-r3.tar.gz"
 - "osx-depends-r4.tar.gz"
 - "osx-depends-qt-5.2.1-r4.tar.gz"
+=======
+- "osx-native-depends-gitian-r3.tar.gz"
+- "bitcoin-deps-osx-gitian-r3.tar.gz"
+- "qt-osx-5.2.1-gitian-r3.tar.gz"
+>>>>>>> Clean up release-process.md and make descriptors more consistent:contrib/gitian-descriptors/gitian-osx.yml
 - "MacOSX10.7.sdk.tar.gz"
-
 script: |
-
   HOST=x86_64-apple-darwin11
   PREFIX=`pwd`/osx-cross-depends/prefix
   SDK=`pwd`/osx-cross-depends/SDKs/MacOSX10.7.sdk

--- a/contrib/gitian-descriptors/gitian-win.yml
+++ b/contrib/gitian-descriptors/gitian-win.yml
@@ -16,7 +16,6 @@ packages:
 - "automake"
 - "pkg-config"
 - "bsdmainutils"
-
 reference_datetime: "2013-06-01 00:00:00"
 remotes:
 - "url": "https://github.com/bitcoin/bitcoin.git"

--- a/contrib/gitian-descriptors/native-osx.yml
+++ b/contrib/gitian-descriptors/native-osx.yml
@@ -1,5 +1,5 @@
 ---
-name: "osx-native"
+name: "osx-native-depends"
 suites:
 - "precise"
 architectures:
@@ -15,7 +15,6 @@ packages:
 - "libcap-dev"
 - "p7zip-full"
 - "uuid-dev"
-
 reference_datetime: "2013-06-01 00:00:00"
 remotes: []
 files:
@@ -29,10 +28,7 @@ files:
 - "libdmg-hfsplus-v0.1.tar.gz"
 - "clang-llvm-3.2-x86-linux-ubuntu-12.04.tar.gz"
 - "cdrkit-deterministic.patch"
-
-
 script: |
-
   echo "18406961fd4a1ec5c7ea35c91d6a80a2f8bb797a2bd243a610bd75e13eff9aca  10cc648683617cca8bcbeae507888099b41b530c.tar.gz" | sha256sum -c
   echo "03ba62749b843b131c7304a044a98c6ffacd65b1399b921d69add0375f79d8ad  cctools-809.tar.gz" | sha256sum -c
   echo "2cf0484c87cf79b606b351a7055a247dae84093ae92c747a74e0cde2c8c8f83c  dyld-195.5.tar.gz" | sha256sum -c
@@ -174,5 +170,5 @@ script: |
   rm -rf native-prefix/docs
 
   export GZIP="-9n"
-  find native-prefix | sort | tar --no-recursion -czf osx-native-depends-$REVISION.tar.gz -T -
-  mv osx-native-depends-$REVISION.tar.gz $OUTDIR
+  find native-prefix | sort | tar --no-recursion -czf osx-native-depends-gitian-$REVISION.tar.gz -T -
+  mv osx-native-depends-gitian-$REVISION.tar.gz $OUTDIR

--- a/contrib/gitian-descriptors/protobuf-win.yml
+++ b/contrib/gitian-descriptors/protobuf-win.yml
@@ -1,5 +1,5 @@
 ---
-name: "protobuf-win32"
+name: "protobuf"
 suites:
 - "precise"
 architectures:

--- a/contrib/gitian-descriptors/qt-linux.yml
+++ b/contrib/gitian-descriptors/qt-linux.yml
@@ -1,5 +1,5 @@
 ---
-name: "qt-linux"
+name: "qt"
 suites:
 - "precise"
 architectures:

--- a/contrib/gitian-descriptors/qt-osx.yml
+++ b/contrib/gitian-descriptors/qt-osx.yml
@@ -1,5 +1,5 @@
 ---
-name: "osx-qt"
+name: "qt"
 suites:
 - "precise"
 architectures:
@@ -8,17 +8,14 @@ packages:
 - "git-core"
 - "automake"
 - "p7zip-full"
-
 reference_datetime: "2013-06-01 00:00:00"
 remotes: []
 files:
 - "qt-everywhere-opensource-src-5.2.1.tar.gz"
-- "osx-native-depends-r3.tar.gz"
-- "osx-depends-r4.tar.gz"
+- "osx-native-depends-gitian-r3.tar.gz"
+- "bitcoin-deps-osx-gitian-r4.tar.gz"
 - "MacOSX10.7.sdk.tar.gz"
-
 script: |
-
   echo "84e924181d4ad6db00239d87250cc89868484a14841f77fb85ab1f1dbdcd7da1  qt-everywhere-opensource-src-5.2.1.tar.gz" | sha256sum -c
 
   REVISION=r4
@@ -70,10 +67,10 @@ script: |
   mkdir -p SDKs
   tar -C SDKs -xf ${SOURCES_PATH}/MacOSX10.7.sdk.tar.gz
 
-  tar xf /home/ubuntu/build/osx-native-depends-r3.tar.gz
+  tar xf /home/ubuntu/build/osx-native-depends-gitian-r3.tar.gz
 
   export PATH=`pwd`/native-prefix/bin:$PATH
-  tar xf /home/ubuntu/build/osx-depends-r4.tar.gz
+  tar xf /home/ubuntu/build/bitcoin-deps-osx-gitian-r4.tar.gz
 
   SOURCE_FILE=${SOURCES_PATH}/qt-everywhere-opensource-src-5.2.1.tar.gz
   BUILD_DIR=${BUILD_BASE}/qt-everywhere-opensource-src-5.2.1
@@ -181,6 +178,6 @@ script: |
   find ${PREFIX}/lib -name "*.prl" -delete
 
   export GZIP="-9n"
-  find native-prefix prefix | sort | tar --no-recursion -czf osx-depends-qt-5.2.1-${REVISION}.tar.gz -T -
+  find native-prefix prefix | sort | tar --no-recursion -czf qt-osx-5.2.1-gitian-${REVISION}.tar.gz -T -
 
-  mv osx-depends-qt-5.2.1-${REVISION}.tar.gz $OUTDIR
+  mv qt-osx-5.2.1-gitian-${REVISION}.tar.gz $OUTDIR

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -33,16 +33,21 @@ Release Process
 	git checkout v${VERSION}
 	popd
 	pushd ./gitian-builder
-        mkdir -p inputs; cd inputs/
-
- Register and download the Apple SDK (see OSX Readme for details)
-	visit https://developer.apple.com/downloads/download.action?path=Developer_Tools/xcode_4.6.3/xcode4630916281a.dmg
- 
- Using a Mac, create a tarball for the 10.7 SDK
-	tar -C /Volumes/Xcode/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/ -czf MacOSX10.7.sdk.tar.gz MacOSX10.7.sdk
 
  Fetch and build inputs: (first time, or when dependency versions change)
+ 
+	mkdir -p inputs; cd inputs/
 
+ Register and download the Apple SDK: (see OSX Readme for details)
+ 
+ https://developer.apple.com/downloads/download.action?path=Developer_Tools/xcode_4.6.3/xcode4630916281a.dmg
+ 
+ Using a Mac, create a tarball for the 10.7 SDK and copy it to the inputs directory:
+ 
+	tar -C /Volumes/Xcode/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/ -czf MacOSX10.7.sdk.tar.gz MacOSX10.7.sdk
+
+ Download remaining inputs, and build everything:
+ 
 	wget 'http://miniupnp.free.fr/files/download.php?file=miniupnpc-1.9.tar.gz' -O miniupnpc-1.9.tar.gz
 	wget 'https://www.openssl.org/source/openssl-1.0.1h.tar.gz'
 	wget 'http://download.oracle.com/berkeley-db/db-4.8.30.NC.tar.gz'
@@ -78,12 +83,12 @@ Release Process
 	mv build/out/qt-*.zip inputs/
 	./bin/gbuild ../bitcoin/contrib/gitian-descriptors/protobuf-win.yml
 	mv build/out/protobuf-*.zip inputs/
-	./bin/gbuild ../bitcoin/contrib/gitian-descriptors/gitian-osx-native.yml
+	./bin/gbuild ../bitcoin/contrib/gitian-descriptors/native-osx.yml
 	mv build/out/osx-*.tar.gz inputs/
-	./bin/gbuild ../bitcoin/contrib/gitian-descriptors/gitian-osx-depends.yml
-	mv build/out/osx-*.tar.gz inputs/
-	./bin/gbuild ../bitcoin/contrib/gitian-descriptors/gitian-osx-qt.yml
-	mv build/out/osx-*.tar.gz inputs/
+	./bin/gbuild ../bitcoin/contrib/gitian-descriptors/deps-osx.yml
+	mv build/out/bitcoin-deps-*.tar.gz inputs/
+	./bin/gbuild ../bitcoin/contrib/gitian-descriptors/qt-osx.yml
+	mv build/out/qt-*.tar.gz inputs/
 
  The expected SHA256 hashes of the intermediate inputs are:
 
@@ -106,10 +111,10 @@ Release Process
     ec95abef1df2b096a970359787c01d8c45e2a4475b7ae34e12c022634fbdba8a  osx-depends-qt-5.2.1-r4.tar.gz
 
 
- Build bitcoind and bitcoin-qt on Linux32, Linux64, and Win32:
+ Build Bitcoin Core for Linux, Windows, and OS X:
   
 	./bin/gbuild --commit bitcoin=v${VERSION} ../bitcoin/contrib/gitian-descriptors/gitian-linux.yml
-	./bin/gsign --signer $SIGNER --release ${VERSION} --destination ../gitian.sigs/ ../bitcoin/contrib/gitian-descriptors/gitian-linux.yml
+	./bin/gsign --signer $SIGNER --release ${VERSION}-linux --destination ../gitian.sigs/ ../bitcoin/contrib/gitian-descriptors/gitian-linux.yml
 	pushd build/out
 	zip -r bitcoin-${VERSION}-linux-gitian.zip *
 	mv bitcoin-${VERSION}-linux-gitian.zip ../../../
@@ -120,8 +125,8 @@ Release Process
 	zip -r bitcoin-${VERSION}-win-gitian.zip *
 	mv bitcoin-${VERSION}-win-gitian.zip ../../../
 	popd
-        ./bin/gbuild --commit bitcoin=v${VERSION} ../bitcoin/contrib/gitian-descriptors/gitian-osx-bitcoin.yml
-        ./bin/gsign --signer $SIGNER --release ${VERSION}-osx --destination ../gitian.sigs/ ../bitcoin/contrib/gitian-descriptors/gitian-osx-bitcoin.yml
+	./bin/gbuild --commit bitcoin=v${VERSION} ../bitcoin/contrib/gitian-descriptors/gitian-osx.yml
+	./bin/gsign --signer $SIGNER --release ${VERSION}-osx --destination ../gitian.sigs/ ../bitcoin/contrib/gitian-descriptors/gitian-osx.yml
 	pushd build/out
 	mv Bitcoin-Qt.dmg ../../../
 	popd
@@ -132,7 +137,7 @@ Release Process
   1. linux 32-bit and 64-bit binaries + source (bitcoin-${VERSION}-linux-gitian.zip)
   2. windows 32-bit and 64-bit binaries + installer + source (bitcoin-${VERSION}-win-gitian.zip)
   3. OSX installer (Bitcoin-Qt.dmg)
-  4. Gitian signatures (in gitian.sigs/${VERSION}[-win|-osx]/(your gitian key)/
+  4. Gitian signatures (in gitian.sigs/${VERSION}-<linux|win|osx>/(your gitian key)/
 
 repackage gitian builds for release as stand-alone zip/tar/installer exe
 
@@ -172,8 +177,9 @@ repackage gitian builds for release as stand-alone zip/tar/installer exe
 Commit your signature to gitian.sigs:
 
 	pushd gitian.sigs
-	git add ${VERSION}/${SIGNER}
+	git add ${VERSION}-linux/${SIGNER}
 	git add ${VERSION}-win/${SIGNER}
+	git add ${VERSION}-osx/${SIGNER}
 	git commit -a
 	git push  # Assuming you can push to the gitian.sigs tree
 	popd

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -92,10 +92,10 @@ Release Process
 
  The expected SHA256 hashes of the intermediate inputs are:
 
-    46710f673467e367738d8806e45b4cb5931aaeea61f4b6b55a68eea56d5006c5  bitcoin-deps-linux32-gitian-r6.zip
-    f03be39fb26670243d3a659e64d18e19d03dec5c11e9912011107768390b5268  bitcoin-deps-linux64-gitian-r6.zip
     f29b7d9577417333fb56e023c2977f5726a7c297f320b175a4108cf7cd4c2d29  boost-linux32-1.55.0-gitian-r1.zip
     88232451c4104f7eb16e469ac6474fd1231bd485687253f7b2bdf46c0781d535  boost-linux64-1.55.0-gitian-r1.zip
+    46710f673467e367738d8806e45b4cb5931aaeea61f4b6b55a68eea56d5006c5  bitcoin-deps-linux32-gitian-r6.zip
+    f03be39fb26670243d3a659e64d18e19d03dec5c11e9912011107768390b5268  bitcoin-deps-linux64-gitian-r6.zip
     57e57dbdadc818cd270e7e00500a5e1085b3bcbdef69a885f0fb7573a8d987e1  qt-linux32-4.6.4-gitian-r1.tar.gz
     60eb4b9c5779580b7d66529efa5b2836ba1a70edde2a0f3f696d647906a826be  qt-linux64-4.6.4-gitian-r1.tar.gz
     60dc2d3b61e9c7d5dbe2f90d5955772ad748a47918ff2d8b74e8db9b1b91c909  boost-win32-1.55.0-gitian-r6.zip
@@ -106,9 +106,9 @@ Release Process
     751c579830d173ef3e6f194e83d18b92ebef6df03289db13ab77a52b6bc86ef0  qt-win64-5.2.0-gitian-r3.zip
     e2e403e1a08869c7eed4d4293bce13d51ec6a63592918b90ae215a0eceb44cb4  protobuf-win32-2.5.0-gitian-r4.zip
     a0999037e8b0ef9ade13efd88fee261ba401f5ca910068b7e0cd3262ba667db0  protobuf-win64-2.5.0-gitian-r4.zip
-    512bc0622c883e2e0f4cbc3fedfd8c2402d06c004ce6fb32303cc2a6f405b6df  osx-native-depends-r3.tar.gz
-    927e4b222be6d590b4bc2fc185872a5d0ca5c322adb983764d3ed84be6bdbc81  osx-depends-r4.tar.gz
-    ec95abef1df2b096a970359787c01d8c45e2a4475b7ae34e12c022634fbdba8a  osx-depends-qt-5.2.1-r4.tar.gz
+    512bc0622c883e2e0f4cbc3fedfd8c2402d06c004ce6fb32303cc2a6f405b6df  osx-native-depends-gitian-r3.tar.gz
+    927e4b222be6d590b4bc2fc185872a5d0ca5c322adb983764d3ed84be6bdbc81  bitcoin-deps-osx-gitian-r4.tar.gz
+    ec95abef1df2b096a970359787c01d8c45e2a4475b7ae34e12c022634fbdba8a  qt-osx-5.2.1-gitian-r4.tar.gz
 
 
  Build Bitcoin Core for Linux, Windows, and OS X:


### PR DESCRIPTION
This addresses some (but not all) of the issues in #4185. It cleans up a
few things in release-process.md (such as indents) and makes the
descriptors more consistent, in terms of style and also naming (both of
the descriptors and the intermediate inputs). This doesn't change any of
the actual build scripts, other than to change the file names -- I didn't
want to accidentally break anything, though it looks like there are a few
things that could be improved and made more consistent. The big change
that it would be nice if someone were to make is to switch the OS X
intermediates from tarballs to zips for more consistency. I didn't do
that, because I don't know the details of how tar and zip/unzip work on
the command line, especially when it comes to determinism.
