### PR TITLE
Properly initialize CWallet::nTimeFirstKey

### DIFF
--- a/src/wallet.h
+++ b/src/wallet.h
@@ -151,6 +151,7 @@ public:
         nOrderPosNext = 0;
         nNextResend = 0;
         nLastResend = 0;
+        nTimeFirstKey = 0;
     }
     CWallet(std::string strWalletFileIn)
     {


### PR DESCRIPTION
Fixes valgrind warning about "conditional jump or move depends on uninitialised value(s)".
