### PR TITLE
Enforce strict parsing of network names in payment request processing

### DIFF
--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -214,9 +214,13 @@ bool PaymentServer::ipcParseCommandLine(int argc, char* argv[])
             if (readPaymentRequest(arg, request))
             {
                 if (request.getDetails().network() == "main")
+                {
                     SelectParams(CBaseChainParams::MAIN);
-                else
+                }
+                else if (request.getDetails().network() == "test")
+                {
                     SelectParams(CBaseChainParams::TESTNET);
+                }
             }
         }
         else


### PR DESCRIPTION
Payment request parsing of network names is now strict (does not assume testnet if not main).
