### PR TITLE
Linux static qt5

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -254,6 +254,9 @@ case $host in
 
      CPPFLAGS="$CPPFLAGS -DMAC_OSX"
      ;;
+   *linux*)
+     TARGET_OS=linux
+     ;;
    *)
      ;;
 esac

--- a/configure.ac
+++ b/configure.ac
@@ -520,7 +520,7 @@ BITCOIN_QT_INIT
 
 if test x$use_pkgconfig = xyes; then
 
-  if test x$PKG_CONFIG == x; then
+  if test x"$PKG_CONFIG" == "x"; then
     AC_MSG_ERROR(pkg-config not found.)
   fi
 

--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -15,11 +15,8 @@ packages:
 - "automake"
 - "faketime"
 - "bsdmainutils"
-- "libqt4-core"
-- "libqt4-gui"
-- "libqt4-dbus"
-- "libqt4-network"
-- "libqt4-test"
+- "libxcb1-dev"
+- "libfontconfig1-dev"
 reference_datetime: "2013-06-01 00:00:00"
 remotes:
 - "url": "https://github.com/bitcoin/bitcoin.git"
@@ -29,8 +26,8 @@ files:
 - "bitcoin-deps-linux64-gitian-r6.zip"
 - "boost-linux32-1.55.0-gitian-r1.zip"
 - "boost-linux64-1.55.0-gitian-r1.zip"
-- "qt-linux32-4.6.4-gitian-r1.tar.gz"
-- "qt-linux64-4.6.4-gitian-r1.tar.gz"
+- "qt-linux32-5.2.1-gitian-r1.tar.gz"
+- "qt-linux64-5.2.1-gitian-r1.tar.gz"
 script: |
   STAGING="$HOME/install"
   OPTFLAGS='-O2'
@@ -45,7 +42,7 @@ script: |
   cd $STAGING
   unzip ../build/bitcoin-deps-linux${GBUILD_BITS}-gitian-r6.zip
   unzip ../build/boost-linux${GBUILD_BITS}-1.55.0-gitian-r1.zip
-  tar -zxf ../build/qt-linux${GBUILD_BITS}-4.6.4-gitian-r1.tar.gz
+  tar -zxf ../build/qt-linux${GBUILD_BITS}-5.2.1-gitian-r1.tar.gz
   cd ../build
 
   # Avoid exporting *any* symbols from the executable
@@ -59,7 +56,7 @@ script: |
     local: *;
   };' > $LINKER_SCRIPT
   function do_configure {
-      ./configure "$@" --enable-upnp-default --prefix=$STAGING --with-protoc-bindir=$STAGING/host/bin --with-qt-bindir=$STAGING/bin --with-boost=$STAGING --disable-maintainer-mode --disable-dependency-tracking PKG_CONFIG_PATH="$STAGING/lib/pkgconfig" CPPFLAGS="-I$STAGING/include ${OPTFLAGS}" LDFLAGS="-L$STAGING/lib -Wl,--version-script=$LINKER_SCRIPT ${OPTFLAGS}" CXXFLAGS="-frandom-seed=bitcoin ${OPTFLAGS}" BOOST_CHRONO_EXTRALIBS="-lrt" --enable-glibc-back-compat
+      ./configure "$@" --enable-upnp-default --prefix=$STAGING --with-protoc-bindir=$STAGING/host/bin --with-qt-bindir=$STAGING/bin --with-qt-plugindir=$STAGING/plugins --with-boost=$STAGING --disable-maintainer-mode --disable-dependency-tracking PKG_CONFIG="pkg-config --static" PKG_CONFIG_PATH="$STAGING/lib/pkgconfig" CPPFLAGS="-I$STAGING/include ${OPTFLAGS}" LDFLAGS="-L$STAGING/lib -Wl,--version-script=$LINKER_SCRIPT ${OPTFLAGS}" CXXFLAGS="-frandom-seed=bitcoin ${OPTFLAGS}" BOOST_CHRONO_EXTRALIBS="-lrt" --enable-glibc-back-compat LIBS="-ldl"
   }
   #
   cd bitcoin
@@ -73,7 +70,8 @@ script: |
   mkdir -p distsrc
   cd distsrc
   tar --strip-components=1 -xf ../$DISTNAME
-  do_configure --bindir=$BINDIR 
+  do_configure --bindir=$BINDIR
+  export QT_RCC_TEST=1
   make $MAKEOPTS
   make $MAKEOPTS install-strip
   make $MAKEOPTS clean

--- a/contrib/gitian-descriptors/qt-linux.yml
+++ b/contrib/gitian-descriptors/qt-linux.yml
@@ -10,255 +10,74 @@ packages:
 - "unzip"
 - "faketime"
 - "unzip"
-- "libxext-dev"
+- "libdbus-1-dev"
+- "libx11-dev"
+- "libxcb1-dev"
+- "libfontconfig1-dev"
 reference_datetime: "2011-01-30 00:00:00"
 remotes: []
 files:
-- "qt-everywhere-opensource-src-4.6.4.tar.gz"
+- "qt-everywhere-opensource-src-5.2.1.tar.gz"
+- "bitcoin-deps-linux32-gitian-r6.zip"
+- "bitcoin-deps-linux64-gitian-r6.zip"
 script: |
+
+  echo "84e924181d4ad6db00239d87250cc89868484a14841f77fb85ab1f1dbdcd7da1  qt-everywhere-opensource-src-5.2.1.tar.gz" | sha256sum -c
+
   export FAKETIME=$REFERENCE_DATETIME
   export TZ=UTC
-  if [ "$GBUILD_BITS" == "32" ]; then
-    ARCH='i386-linux-gnu'
-  else
-    ARCH='x86_64-linux-gnu'
-  fi
-  # The purpose of this gitian build is not to actually build Qt, but to export
-  # the headers as well as pkgconfig files in a useable format so that we can
-  # pretend to link against an older version. The goal is to link to the
-  # system version of Qt 4.
-  # Also build development tools.
-  INSTALLPREFIX="$HOME/install"
-  # Integrity Check
-  echo "9ad4d46c721b53a429ed5a2eecfd3c239a9ab566562f183f99d3125f1a234250  qt-everywhere-opensource-src-4.6.4.tar.gz" | sha256sum -c
-  # Make install directories
-  mkdir -p $INSTALLPREFIX
-  mkdir -p $INSTALLPREFIX/include
-  PKGCONFIGDIR=$INSTALLPREFIX/lib/pkgconfig
-  mkdir -p $PKGCONFIGDIR
-  #
-  tar xzf qt-everywhere-opensource-src-4.6.4.tar.gz
-  cd qt-everywhere-opensource-src-4.6.4
-  QTBUILDDIR=$(pwd)
-  sed 's/TODAY=`date +%Y-%m-%d`/TODAY=2011-01-30/' -i configure
+  PREFIX="$HOME/install"
 
-  # Need to build 4.6-versioned host utilities as well (lrelease/qrc/lupdate/...)
-  ./configure -prefix $INSTALLPREFIX -confirm-license -release -opensource -no-qt3support -no-multimedia -no-audio-backend -no-phonon -no-phonon-backend -no-declarative -no-script -no-scripttools -no-javascript-jit -no-webkit -no-svg -no-xmlpatterns -no-sql-sqlite -no-nis -no-cups -no-iconv -no-dbus -no-gif -no-libtiff -no-opengl -nomake examples -nomake demos -nomake docs
-  #
-  make $MAKEOPTS -C src/tools install  # (rcc, uic, moc)
-  make $MAKEOPTS -C tools/linguist/lrelease install  # (lrelease)
-  # install includes and pkgconfig files
-  for DIR in src/corelib src/gui src/testlib src/dbus src/network; do
-    (
-    cd $DIR
-    # extract module (QtCore/QtNetwork/...) from Makefile
-    MODULE=$(grep "QMAKE_TARGET *=" Makefile | cut -d = -f 2 | xargs)
-    # patch makefile so that not everything is build first
-    sed -i 's/first: all/first:/g' Makefile
-    make install_flat_headers install_class_headers install_targ_headers
-    # create and install pkgconfig descriptor
-    make ../../lib/pkgconfig/$MODULE.pc
-    sed -e "s,$QTBUILDDIR,$INSTALLPREFIX,g" ../../lib/pkgconfig/$MODULE.pc > $PKGCONFIGDIR/$MODULE.pc
-    # create links to existing Qt libraries
-    ln -sf /usr/lib/${ARCH}/lib${MODULE}.so.4 ${INSTALLPREFIX}/lib/lib${MODULE}.so
-    )
-  done
+  export TAR_OPTIONS="-m --mtime="$REFERENCE_DATE\\\ $REFERENCE_TIME""
+  export GZIP="-9n"
 
-  # Write our own configuration header, same as Ubuntu
-  # When we don't do this, the configuration will be without STL support (the QString from/to stdString methods)
-  QCONFIG=$INSTALLPREFIX/include/Qt/qconfig.h
-  echo '
-  /* Qt Edition */
-  #ifndef QT_EDITION
-  #  define QT_EDITION QT_EDITION_OPENSOURCE
-  #endif
-  ' > $QCONFIG
+  REAL_AR=`which ar`
+  REAL_DATE=`which date`
+  REAL_RANLIB=`which ranlib`
 
-  if [ "$GBUILD_BITS" == "32" ]; then
-    echo '
-  /* Machine byte-order */
-  #define Q_BIG_ENDIAN 4321
-  #define Q_LITTLE_ENDIAN 1234
-  #define QT_BUILD_KEY "i386 linux g++-4 full-config"
-  #define QT_BUILD_KEY_COMPAT "i686 Linux g++-4 full-config"
+  echo '#!/bin/bash' > $HOME/ar
+  echo 'export LD_PRELOAD=/usr/lib/faketime/libfaketime.so.1' >> $HOME/ar
+  echo "export FAKETIME=\"${REFERENCE_DATETIME}\"" >> $HOME/ar
+  echo "$REAL_AR \$@" >> $HOME/ar
 
-  #ifdef QT_BOOTSTRAPPED
-  #define Q_BYTE_ORDER Q_LITTLE_ENDIAN
-  #else
-  #define Q_BYTE_ORDER Q_LITTLE_ENDIAN
-  #endif
-  /* Machine Architecture */
-  #ifndef QT_BOOTSTRAPPED
-  # define QT_ARCH_I386
-  #else
-  # define QT_ARCH_I386
-  #endif
-  /* Compile time features */
-  #define QT_LARGEFILE_SUPPORT 64
-  #define QT_POINTER_SIZE 4
-  ' >> $QCONFIG
-  else
-    echo '
-  /* Machine byte-order */
-  #define Q_BIG_ENDIAN 4321
-  #define Q_LITTLE_ENDIAN 1234
-  #define QT_BUILD_KEY "x86_64 linux g++-4 full-config"
-  #define QT_BUILD_KEY_COMPAT "x86_64 Linux g++-4 full-config"
+  echo '#!/bin/bash' > $HOME/ranlib
+  echo 'export LD_PRELOAD=/usr/lib/faketime/libfaketime.so.1' >> $HOME/ranlib
+  echo "export FAKETIME=\"${REFERENCE_DATETIME}\"" >> $HOME/ranlib
+  echo "$REAL_RANLIB \$@" >> $HOME/ranlib
 
-  #ifdef QT_BOOTSTRAPPED
-  #define Q_BYTE_ORDER Q_LITTLE_ENDIAN
-  #else
-  #define Q_BYTE_ORDER Q_LITTLE_ENDIAN
-  #endif
-  /* Machine Architecture */
-  #ifndef QT_BOOTSTRAPPED
-  # define QT_ARCH_X86_64
-  #else
-  # define QT_ARCH_X86_64
-  #endif
-  /* Compile time features */
-  #define QT_LARGEFILE_SUPPORT 64
-  #define QT_POINTER_SIZE 8
-  ' >> $QCONFIG
-  fi
+  echo '#!/bin/bash' > $HOME/date
+  echo "$REAL_DATE -d \"${REFERENCE_DATETIME}\" \"\$@\"" >> $HOME/date
 
-  echo '
-  #ifndef QT_BOOTSTRAPPED
+  chmod +x $HOME/ar $HOME/ranlib $HOME/date
 
-  #if defined(QT_NO_EGL) && defined(QT_EGL)
-  # undef QT_NO_EGL
-  #elif !defined(QT_NO_EGL) && !defined(QT_EGL)
-  # define QT_NO_EGL
-  #endif
+  export PATH=$HOME:$PATH
 
-  #if defined(QT_NO_GSTREAMER) && defined(QT_GSTREAMER)
-  # undef QT_NO_GSTREAMER
-  #elif !defined(QT_NO_GSTREAMER) && !defined(QT_GSTREAMER)
-  # define QT_NO_GSTREAMER
-  #endif
+  pushd $PREFIX
+  unzip ~/build/bitcoin-deps-linux${GBUILD_BITS}-gitian-r6.zip
+  popd
 
-  #if defined(QT_NO_ICD) && defined(QT_ICD)
-  # undef QT_NO_ICD
-  #elif !defined(QT_NO_ICD) && !defined(QT_ICD)
-  # define QT_NO_ICD
-  #endif
+  tar xzf qt-everywhere-opensource-src-5.2.1.tar.gz
+  pushd qt-everywhere-opensource-src-5.2.1
 
-  #if defined(QT_NO_IMAGEFORMAT_JPEG) && defined(QT_IMAGEFORMAT_JPEG)
-  # undef QT_NO_IMAGEFORMAT_JPEG
-  #elif !defined(QT_NO_IMAGEFORMAT_JPEG) && !defined(QT_IMAGEFORMAT_JPEG)
-  # define QT_NO_IMAGEFORMAT_JPEG
-  #endif
 
-  #if defined(QT_NO_IMAGEFORMAT_MNG) && defined(QT_IMAGEFORMAT_MNG)
-  # undef QT_NO_IMAGEFORMAT_MNG
-  #elif !defined(QT_NO_IMAGEFORMAT_MNG) && !defined(QT_IMAGEFORMAT_MNG)
-  # define QT_NO_IMAGEFORMAT_MNG
-  #endif
+  OPENSSL_LIBS="-L$PREFIX/lib -lssl -lcrypto" ./configure -release -opensource -no-audio-backend -no-sql-sqlite -no-sql-tds -no-cups -no-iconv -no-gif -no-sql-sqlite -no-nis -no-cups -no-iconv -no-pch -no-sm -nomake examples -no-feature-style-plastique -no-qml-debug -no-pch -no-nis -no-feature-style-cde -no-feature-style-s60 -no-feature-style-motif -no-feature-style-windowsmobile -no-feature-style-windowsce -no-feature-style-cleanlooks -no-sql-db2 -no-sql-ibase -no-sql-oci -no-sql-tds -no-sql-mysql -no-sql-odbc -no-sql-psql -no-sql-sqlite -no-sql-sqlite2 -skip qtsvg -skip qtwebkit -skip qtwebkit-examples -skip qtserialport -skip qtdeclarative -skip qtmultimedia -skip qtimageformats -skip qtlocation -skip qtsensors -skip qtquick1 -skip qtxmlpatterns -skip qtquickcontrols -skip qtactiveqt -skip qtconnectivity -skip qtwinextras -skip qtscript -qt-xcb  -no-eglfs -no-linuxfb -no-icu -no-glib -qt-xkbcommon -no-feature-audio-backend -openssl-linked -no-c++11 -qt-freetype -v -static -prefix $PREFIX -confirm-license -L$PREFIX/lib -I$PREFIX/include
 
-  #if defined(QT_NO_IMAGEFORMAT_TIFF) && defined(QT_IMAGEFORMAT_TIFF)
-  # undef QT_NO_IMAGEFORMAT_TIFF
-  #elif !defined(QT_NO_IMAGEFORMAT_TIFF) && !defined(QT_IMAGEFORMAT_TIFF)
-  # define QT_NO_IMAGEFORMAT_TIFF
-  #endif
+  QT_RCC_TEST=1 make $MAKEOPTS
 
-  #if defined(QT_NO_MULTIMEDIA) && defined(QT_MULTIMEDIA)
-  # undef QT_NO_MULTIMEDIA
-  #elif !defined(QT_NO_MULTIMEDIA) && !defined(QT_MULTIMEDIA)
-  # define QT_NO_MULTIMEDIA
-  #endif
+  make -C qtbase install
+  make -C qttranslations install
+  make -C qttools/src/linguist install
 
-  #if defined(QT_NO_OPENVG) && defined(QT_OPENVG)
-  # undef QT_NO_OPENVG
-  #elif !defined(QT_NO_OPENVG) && !defined(QT_OPENVG)
-  # define QT_NO_OPENVG
-  #endif
 
-  #if defined(QT_NO_PHONON) && defined(QT_PHONON)
-  # undef QT_NO_PHONON
-  #elif !defined(QT_NO_PHONON) && !defined(QT_PHONON)
-  # define QT_NO_PHONON
-  #endif
+  # libxcb-static is not installed due to a qt bug so it needs to be manually
+  # installed: https://bugreports.qt-project.org/browse/QTBUG-32519
+  # This has been fixed in 5.3.
+  install qtbase/src/plugins/platforms/xcb/xcb-static/libxcb-static.a $PREFIX/lib/
 
-  #if defined(QT_NO_PULSEAUDIO) && defined(QT_PULSEAUDIO)
-  # undef QT_NO_PULSEAUDIO
-  #elif !defined(QT_NO_PULSEAUDIO) && !defined(QT_PULSEAUDIO)
-  # define QT_NO_PULSEAUDIO
-  #endif
+  rm -f ${PREFIX}/lib/*.la
+  find ${PREFIX}/lib -name "*.prl" -delete
 
-  #if defined(QT_NO_S60) && defined(QT_S60)
-  # undef QT_NO_S60
-  #elif !defined(QT_NO_S60) && !defined(QT_S60)
-  # define QT_NO_S60
-  #endif
+  popd
 
-  #if defined(QT_NO_STYLE_S60) && defined(QT_STYLE_S60)
-  # undef QT_NO_STYLE_S60
-  #elif !defined(QT_NO_STYLE_S60) && !defined(QT_STYLE_S60)
-  # define QT_NO_STYLE_S60
-  #endif
-
-  #if defined(QT_NO_SXE) && defined(QT_SXE)
-  # undef QT_NO_SXE
-  #elif !defined(QT_NO_SXE) && !defined(QT_SXE)
-  # define QT_NO_SXE
-  #endif
-
-  #if defined(QT_NO_WEBKIT) && defined(QT_WEBKIT)
-  # undef QT_NO_WEBKIT
-  #elif !defined(QT_NO_WEBKIT) && !defined(QT_WEBKIT)
-  # define QT_NO_WEBKIT
-  #endif
-
-  #if defined(QT_NO_ZLIB) && defined(QT_ZLIB)
-  # undef QT_NO_ZLIB
-  #elif !defined(QT_NO_ZLIB) && !defined(QT_ZLIB)
-  # define QT_NO_ZLIB
-  #endif
-
-  #if defined(QT_RUNTIME_XCURSOR) && defined(QT_NO_RUNTIME_XCURSOR)
-  # undef QT_RUNTIME_XCURSOR
-  #elif !defined(QT_RUNTIME_XCURSOR) && !defined(QT_NO_RUNTIME_XCURSOR)
-  # define QT_RUNTIME_XCURSOR
-  #endif
-
-  #if defined(QT_RUNTIME_XFIXES) && defined(QT_NO_RUNTIME_XFIXES)
-  # undef QT_RUNTIME_XFIXES
-  #elif !defined(QT_RUNTIME_XFIXES) && !defined(QT_NO_RUNTIME_XFIXES)
-  # define QT_RUNTIME_XFIXES
-  #endif
-
-  #if defined(QT_RUNTIME_XINERAMA) && defined(QT_NO_RUNTIME_XINERAMA)
-  # undef QT_RUNTIME_XINERAMA
-  #elif !defined(QT_RUNTIME_XINERAMA) && !defined(QT_NO_RUNTIME_XINERAMA)
-  # define QT_RUNTIME_XINERAMA
-  #endif
-
-  #if defined(QT_RUNTIME_XINPUT) && defined(QT_NO_RUNTIME_XINPUT)
-  # undef QT_RUNTIME_XINPUT
-  #elif !defined(QT_RUNTIME_XINPUT) && !defined(QT_NO_RUNTIME_XINPUT)
-  # define QT_RUNTIME_XINPUT
-  #endif
-
-  #if defined(QT_RUNTIME_XRANDR) && defined(QT_NO_RUNTIME_XRANDR)
-  # undef QT_RUNTIME_XRANDR
-  #elif !defined(QT_RUNTIME_XRANDR) && !defined(QT_NO_RUNTIME_XRANDR)
-  # define QT_RUNTIME_XRANDR
-  #endif
-
-  #if defined(QT_USE_MATH_H_FLOATS) && defined(QT_NO_USE_MATH_H_FLOATS)
-  # undef QT_USE_MATH_H_FLOATS
-  #elif !defined(QT_USE_MATH_H_FLOATS) && !defined(QT_NO_USE_MATH_H_FLOATS)
-  # define QT_USE_MATH_H_FLOATS
-  #endif
-
-  #endif // QT_BOOTSTRAPPED
-
-  #define QT_VISIBILITY_AVAILABLE
-  ' >> $QCONFIG
-  cp $QCONFIG $INSTALLPREFIX/include/QtCore/qconfig.h
-
-  cd $INSTALLPREFIX
-  # as zip stores file timestamps, use faketime to intercept stat calls to set dates for all files to reference date
-  export LD_PRELOAD=/usr/lib/faketime/libfaketime.so.1
-  # Create a .tar.gz because .zip has problems with symbolic links
-  find | sort | tar --no-recursion -cT /dev/stdin --mode='u+rw,go+r-w,a+X' --owner=0 --group=0 --mtime="$REFERENCE_DATETIME" | gzip -n > $OUTDIR/qt-linux${GBUILD_BITS}-4.6.4-gitian-r1.tar.gz
+  cd $PREFIX/../
+  find install | sort | tar --no-recursion -czf $OUTDIR/qt-linux${GBUILD_BITS}-5.2.1-gitian-r1.tar.gz -T -

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -53,7 +53,6 @@ Release Process
 	wget 'https://svn.boost.org/trac/boost/raw-attachment/ticket/7262/boost-mingw.patch' -O boost-mingw-gas-cross-compile-2013-03-03.patch
 	wget 'https://download.qt-project.org/official_releases/qt/5.2/5.2.0/single/qt-everywhere-opensource-src-5.2.0.tar.gz'
 	wget 'https://download.qt-project.org/official_releases/qt/5.2/5.2.1/single/qt-everywhere-opensource-src-5.2.1.tar.gz'
-	wget 'https://download.qt-project.org/archive/qt/4.6/qt-everywhere-opensource-src-4.6.4.tar.gz'
 	wget 'https://protobuf.googlecode.com/files/protobuf-2.5.0.tar.bz2'
 	wget 'https://github.com/mingwandroid/toolchain4/archive/10cc648683617cca8bcbeae507888099b41b530c.tar.gz'
 	wget 'http://www.opensource.apple.com/tarballs/cctools/cctools-809.tar.gz'
@@ -91,8 +90,8 @@ Release Process
     f03be39fb26670243d3a659e64d18e19d03dec5c11e9912011107768390b5268  bitcoin-deps-linux64-gitian-r6.zip
     f29b7d9577417333fb56e023c2977f5726a7c297f320b175a4108cf7cd4c2d29  boost-linux32-1.55.0-gitian-r1.zip
     88232451c4104f7eb16e469ac6474fd1231bd485687253f7b2bdf46c0781d535  boost-linux64-1.55.0-gitian-r1.zip
-    57e57dbdadc818cd270e7e00500a5e1085b3bcbdef69a885f0fb7573a8d987e1  qt-linux32-4.6.4-gitian-r1.tar.gz
-    60eb4b9c5779580b7d66529efa5b2836ba1a70edde2a0f3f696d647906a826be  qt-linux64-4.6.4-gitian-r1.tar.gz
+    7f48d7512c1739f9f69e26dc835de5e7cd813b0951b59c5fde4ef9e60e6b15ce  qt-linux32-5.2.1-gitian-r1.tar.gz
+    98520bb6f60a0fe3ae82a36eb6209e3f167c508d01a0aa2c4e62ed0f279adc2e  qt-linux64-5.2.1-gitian-r1.tar.gz
     60dc2d3b61e9c7d5dbe2f90d5955772ad748a47918ff2d8b74e8db9b1b91c909  boost-win32-1.55.0-gitian-r6.zip
     f65fcaf346bc7b73bc8db3a8614f4f6bee2f61fcbe495e9881133a7c2612a167  boost-win64-1.55.0-gitian-r6.zip
     70de248cd0dd7e7476194129e818402e974ca9c5751cbf591644dc9f332d3b59  bitcoin-deps-win32-gitian-r13.zip

--- a/src/m4/bitcoin_qt.m4
+++ b/src/m4/bitcoin_qt.m4
@@ -86,9 +86,6 @@ AC_DEFUN([BITCOIN_QT_CONFIGURE],[
   fi
 
   if test x$use_pkgconfig = xyes; then
-    if test x$PKG_CONFIG == x; then
-      AC_MSG_ERROR(pkg-config not found.)
-    fi
     BITCOIN_QT_CHECK([_BITCOIN_QT_FIND_LIBS_WITH_PKGCONFIG([$2])])
   else
     BITCOIN_QT_CHECK([_BITCOIN_QT_FIND_LIBS_WITHOUT_PKGCONFIG])

--- a/src/m4/bitcoin_qt.m4
+++ b/src/m4/bitcoin_qt.m4
@@ -128,6 +128,13 @@ AC_DEFUN([BITCOIN_QT_CONFIGURE],[
       elif test x$TARGET_OS == xlinux; then
         _BITCOIN_QT_CHECK_STATIC_PLUGINS([Q_IMPORT_PLUGIN(QXcbIntegrationPlugin)],[-lqxcb -lxcb-static -lxcb])
         AC_DEFINE(QT_QPA_PLATFORM_XCB, 1, [Define this symbol if the qt platform is xcb])
+      elif test x$TARGET_OS == xdarwin; then
+        if test x$use_pkgconfig = xyes; then
+          PKG_CHECK_MODULES([QTPRINT], [Qt5PrintSupport], [QT_LIBS="$QTPRINT_LIBS $QT_LIBS"])
+        fi
+        AX_CHECK_LINK_FLAG([[-framework IOKit]],[QT_LIBS="$QT_LIBS -framework IOKit"],[AC_MSG_ERROR(could not iokit framework)])
+        _BITCOIN_QT_CHECK_STATIC_PLUGINS([Q_IMPORT_PLUGIN(QCocoaIntegrationPlugin)],[-lqcocoa])
+        AC_DEFINE(QT_QPA_PLATFORM_COCOA, 1, [Define this symbol if the qt platform is cocoa])
       fi
     fi
   else

--- a/src/m4/bitcoin_qt.m4
+++ b/src/m4/bitcoin_qt.m4
@@ -94,6 +94,56 @@ AC_DEFUN([BITCOIN_QT_CONFIGURE],[
     BITCOIN_QT_CHECK([_BITCOIN_QT_FIND_LIBS_WITHOUT_PKGCONFIG])
   fi
 
+  dnl This is ugly and complicated. Yuck. Works as follows:
+  dnl We can't discern whether Qt4 builds are static or not. For Qt5, we can
+  dnl check a header to find out. When Qt is built statically, some plugins must
+  dnl be linked into the final binary as well. These plugins have changed between
+  dnl Qt4 and Qt5. With Qt5, languages moved into core and the WindowsIntegration
+  dnl plugin was added. Since we can't tell if Qt4 is static or not, it is
+  dnl assumed for windows builds.
+  dnl _BITCOIN_QT_CHECK_STATIC_PLUGINS does a quick link-check and appends the
+  dnl results to QT_LIBS.
+  BITCOIN_QT_CHECK([
+  TEMP_CPPFLAGS=$CPPFLAGS
+  CPPFLAGS=$QT_INCLUDES
+  if test x$bitcoin_qt_got_major_vers == x5; then
+    _BITCOIN_QT_IS_STATIC
+    if test x$bitcoin_cv_static_qt == xyes; then
+      AC_DEFINE(QT_STATICPLUGIN, 1, [Define this symbol if qt plugins are static])
+      if test x$qt_plugin_path != x; then
+        QT_LIBS="$QT_LIBS -L$qt_plugin_path/accessible"
+        if test x$bitcoin_qt_got_major_vers == x5; then
+          QT_LIBS="$QT_LIBS -L$qt_plugin_path/platforms"
+        else
+          QT_LIBS="$QT_LIBS -L$qt_plugin_path/codecs"
+        fi
+      fi
+      if test x$use_pkgconfig = xyes; then
+        PKG_CHECK_MODULES([QTPLATFORM], [Qt5PlatformSupport], [QT_LIBS="$QTPLATFORM_LIBS $QT_LIBS"])
+      fi
+      _BITCOIN_QT_CHECK_STATIC_PLUGINS([Q_IMPORT_PLUGIN(AccessibleFactory)], [-lqtaccessiblewidgets])
+      if test x$TARGET_OS == xwindows; then
+        _BITCOIN_QT_CHECK_STATIC_PLUGINS([Q_IMPORT_PLUGIN(QWindowsIntegrationPlugin)],[-lqwindows])
+        AC_DEFINE(QT_QPA_PLATFORM_WINDOWS, 1, [Define this symbol if the qt platform is windows])
+      elif test x$TARGET_OS == xlinux; then
+        _BITCOIN_QT_CHECK_STATIC_PLUGINS([Q_IMPORT_PLUGIN(QXcbIntegrationPlugin)],[-lqxcb -lxcb-static -lxcb])
+        AC_DEFINE(QT_QPA_PLATFORM_XCB, 1, [Define this symbol if the qt platform is xcb])
+      fi
+    fi
+  else
+    if test x$TARGET_OS == xwindows; then
+      AC_DEFINE(QT_STATICPLUGIN, 1, [Define this symbol if qt plugins are static])
+      _BITCOIN_QT_CHECK_STATIC_PLUGINS([
+         Q_IMPORT_PLUGIN(qcncodecs)
+         Q_IMPORT_PLUGIN(qjpcodecs)
+         Q_IMPORT_PLUGIN(qtwcodecs)
+         Q_IMPORT_PLUGIN(qkrcodecs)
+         Q_IMPORT_PLUGIN(AccessibleFactory)],
+         [-lqcncodecs -lqjpcodecs -lqtwcodecs -lqkrcodecs -lqtaccessiblewidgets])
+    fi
+  fi
+  CPPFLAGS=$TEMP_CPPFLAGS
+  ])
   BITCOIN_QT_PATH_PROGS([MOC], [moc-qt${bitcoin_qt_got_major_vers} moc${bitcoin_qt_got_major_vers} moc], $qt_bin_path)
   BITCOIN_QT_PATH_PROGS([UIC], [uic-qt${bitcoin_qt_got_major_vers} uic${bitcoin_qt_got_major_vers} uic], $qt_bin_path)
   BITCOIN_QT_PATH_PROGS([RCC], [rcc-qt${bitcoin_qt_got_major_vers} rcc${bitcoin_qt_got_major_vers} rcc], $qt_bin_path)
@@ -303,19 +353,6 @@ AC_DEFUN([_BITCOIN_QT_FIND_LIBS_WITHOUT_PKGCONFIG],[
   ])
 
   BITCOIN_QT_CHECK([
-    LIBS=
-    if test x$qt_lib_path != x; then
-      LIBS="$LIBS -L$qt_lib_path"
-    fi
-    if test x$qt_plugin_path != x; then
-      LIBS="$LIBS -L$qt_plugin_path/accessible"
-      if test x$bitcoin_qt_got_major_vers == x5; then
-        LIBS="$LIBS -L$qt_plugin_path/platforms"
-      else
-        LIBS="$LIBS -L$qt_plugin_path/codecs"
-      fi
-    fi
-
     if test x$TARGET_OS == xwindows; then
       AC_CHECK_LIB([imm32],      [main],, BITCOIN_QT_FAIL(libimm32 not found))
     fi
@@ -331,37 +368,6 @@ AC_DEFUN([_BITCOIN_QT_FIND_LIBS_WITHOUT_PKGCONFIG],[
   fi
   QT_LIBS="$LIBS"
   LIBS="$TEMP_LIBS"
-
-  dnl This is ugly and complicated. Yuck. Works as follows:
-  dnl We can't discern whether Qt4 builds are static or not. For Qt5, we can
-  dnl check a header to find out. When Qt is built statically, some plugins must
-  dnl be linked into the final binary as well. These plugins have changed between
-  dnl Qt4 and Qt5. With Qt5, languages moved into core and the WindowsIntegration
-  dnl plugin was added. Since we can't tell if Qt4 is static or not, it is 
-  dnl assumed for all non-pkg-config builds.
-  dnl _BITCOIN_QT_CHECK_STATIC_PLUGINS does a quick link-check and appends the
-  dnl results to QT_LIBS.
-  BITCOIN_QT_CHECK([
-    if test x$bitcoin_qt_got_major_vers == x5; then
-      _BITCOIN_QT_IS_STATIC
-      if test x$bitcoin_cv_static_qt == xyes; then 
-        AC_DEFINE(QT_STATICPLUGIN, 1, [Define this symbol if qt plugins are static])
-        _BITCOIN_QT_CHECK_STATIC_PLUGINS([Q_IMPORT_PLUGIN(AccessibleFactory)], [-lqtaccessiblewidgets])
-        if test x$TARGET_OS == xwindows; then
-          _BITCOIN_QT_CHECK_STATIC_PLUGINS([Q_IMPORT_PLUGIN(QWindowsIntegrationPlugin)],[-lqwindows])
-        fi
-      fi
-    else
-      AC_DEFINE(QT_STATICPLUGIN, 1, [Define this symbol if qt plugins are static])
-      _BITCOIN_QT_CHECK_STATIC_PLUGINS([
-         Q_IMPORT_PLUGIN(qcncodecs)
-         Q_IMPORT_PLUGIN(qjpcodecs)
-         Q_IMPORT_PLUGIN(qtwcodecs)
-         Q_IMPORT_PLUGIN(qkrcodecs)
-         Q_IMPORT_PLUGIN(AccessibleFactory)],
-         [-lqcncodecs -lqjpcodecs -lqtwcodecs -lqkrcodecs -lqtaccessiblewidgets])
-    fi
-  ])
 
   BITCOIN_QT_CHECK([
     LIBS=

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -52,7 +52,11 @@ Q_IMPORT_PLUGIN(qkrcodecs)
 Q_IMPORT_PLUGIN(qtaccessiblewidgets)
 #else
 Q_IMPORT_PLUGIN(AccessibleFactory)
+#if defined(QT_QPA_PLATFORM_XCB)
+Q_IMPORT_PLUGIN(QXcbIntegrationPlugin);
+#elif defined(QT_QPA_PLATFORM_WINDOWS)
 Q_IMPORT_PLUGIN(QWindowsIntegrationPlugin);
+#endif
 #endif
 #endif
 

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -56,6 +56,8 @@ Q_IMPORT_PLUGIN(AccessibleFactory)
 Q_IMPORT_PLUGIN(QXcbIntegrationPlugin);
 #elif defined(QT_QPA_PLATFORM_WINDOWS)
 Q_IMPORT_PLUGIN(QWindowsIntegrationPlugin);
+#elif defined(QT_QPA_PLATFORM_COCOA)
+Q_IMPORT_PLUGIN(QCocoaIntegrationPlugin);
 #endif
 #endif
 #endif


### PR DESCRIPTION
This bumps linux+qt up to static 5.2.1 to match osx and (soon) windows. It should result in a much more portable release binary, since it does not depend on the user having qt installed. It does away with the current scary combination of qt4.6 headers and qt4.8 libs.

The nasty graphics dependencies (x11, xcb, etc) are kept to an absolute minimum. This build uses qt's built-in xcb libs and dyloaders in order to reduce the runtime dependencies on xcb\* and x11. The end-result is that only libxcb is required at runtime. Other dependencies on freetype/fontconfig may be reduced to static libs as well if desired.

From my quick tests, this is fully working. All builds are deterministic, and no new glibc/libstdc++ symbols have been introduced as far as I can tell.

The only thing that I'm aware of which requires more testing is qt's internal translations, which may need to be statically linked as well.

Full dependencies:

Before:

```
        linux-gate.so.1 =>  (0xf7715000)
        librt.so.1 => /lib/i386-linux-gnu/librt.so.1 (0xf6b3c000)
        libQtGui.so.4 => /usr/lib/i386-linux-gnu/libQtGui.so.4 (0xf606b000)
        libQtNetwork.so.4 => /usr/lib/i386-linux-gnu/libQtNetwork.so.4 (0xf5f27000)
        libQtCore.so.4 => /usr/lib/i386-linux-gnu/libQtCore.so.4 (0xf5c3f000)
        libQtDBus.so.4 => /usr/lib/i386-linux-gnu/libQtDBus.so.4 (0xf5bc1000)
        libpthread.so.0 => /lib/i386-linux-gnu/libpthread.so.0 (0xf5ba6000)
        libstdc++.so.6 => /usr/lib/i386-linux-gnu/libstdc++.so.6 (0xf5abd000)
        libm.so.6 => /lib/i386-linux-gnu/libm.so.6 (0xf5a79000)
        libgcc_s.so.1 => /lib/i386-linux-gnu/libgcc_s.so.1 (0xf5a5c000)
        libc.so.6 => /lib/i386-linux-gnu/libc.so.6 (0xf58a8000)
        libfontconfig.so.1 => /usr/lib/i386-linux-gnu/libfontconfig.so.1 (0xf586f000)
        libaudio.so.2 => /usr/lib/i386-linux-gnu/libaudio.so.2 (0xf5856000)
        libglib-2.0.so.0 => /lib/i386-linux-gnu/libglib-2.0.so.0 (0xf5754000)
        libpng12.so.0 => /lib/i386-linux-gnu/libpng12.so.0 (0xf572b000)
        libz.so.1 => /lib/i386-linux-gnu/libz.so.1 (0xf5712000)
        libfreetype.so.6 => /usr/lib/i386-linux-gnu/libfreetype.so.6 (0xf5677000)
        libgobject-2.0.so.0 => /usr/lib/i386-linux-gnu/libgobject-2.0.so.0 (0xf5627000)
        libSM.so.6 => /usr/lib/i386-linux-gnu/libSM.so.6 (0xf561d000)
        libICE.so.6 => /usr/lib/i386-linux-gnu/libICE.so.6 (0xf5603000)
        libXi.so.6 => /usr/lib/i386-linux-gnu/libXi.so.6 (0xf55f3000)
        libXrender.so.1 => /usr/lib/i386-linux-gnu/libXrender.so.1 (0xf55e9000)
        libXext.so.6 => /usr/lib/i386-linux-gnu/libXext.so.6 (0xf55d7000)
        libX11.so.6 => /usr/lib/i386-linux-gnu/libX11.so.6 (0xf549f000)
        libdl.so.2 => /lib/i386-linux-gnu/libdl.so.2 (0xf549a000)
        /lib/ld-linux.so.2 (0xf7716000)
        libQtXml.so.4 => /usr/lib/i386-linux-gnu/libQtXml.so.4 (0xf545a000)
        libdbus-1.so.3 => /lib/i386-linux-gnu/libdbus-1.so.3 (0xf5410000)
        libexpat.so.1 => /lib/i386-linux-gnu/libexpat.so.1 (0xf53e8000)
        libXt.so.6 => /usr/lib/i386-linux-gnu/libXt.so.6 (0xf538b000)
        libXau.so.6 => /usr/lib/i386-linux-gnu/libXau.so.6 (0xf5387000)
        libpcre.so.3 => /lib/i386-linux-gnu/libpcre.so.3 (0xf5346000)
        libffi.so.6 => /usr/lib/i386-linux-gnu/libffi.so.6 (0xf533f000)
        libuuid.so.1 => /lib/i386-linux-gnu/libuuid.so.1 (0xf5339000)
        libxcb.so.1 => /usr/lib/i386-linux-gnu/libxcb.so.1 (0xf5316000)
        libXdmcp.so.6 => /usr/lib/i386-linux-gnu/libXdmcp.so.6 (0xf530f000)
```

After:

```
        linux-gate.so.1 =>  (0xf7707000)
        librt.so.1 => /lib/i386-linux-gnu/librt.so.1 (0xf5b5a000)
        libxcb.so.1 => /usr/lib/i386-linux-gnu/libxcb.so.1 (0xf5b38000)
        libfontconfig.so.1 => /usr/lib/i386-linux-gnu/libfontconfig.so.1 (0xf5afe000)
        libfreetype.so.6 => /usr/lib/i386-linux-gnu/libfreetype.so.6 (0xf5a63000)
        libpthread.so.0 => /lib/i386-linux-gnu/libpthread.so.0 (0xf5a48000)
        libz.so.1 => /lib/i386-linux-gnu/libz.so.1 (0xf5a2f000)
        libdl.so.2 => /lib/i386-linux-gnu/libdl.so.2 (0xf5a2a000)
        libm.so.6 => /lib/i386-linux-gnu/libm.so.6 (0xf59e6000)
        libstdc++.so.6 => /usr/lib/i386-linux-gnu/libstdc++.so.6 (0xf58fd000)
        libgcc_s.so.1 => /lib/i386-linux-gnu/libgcc_s.so.1 (0xf58e0000)
        libc.so.6 => /lib/i386-linux-gnu/libc.so.6 (0xf572c000)
        /lib/ld-linux.so.2 (0xf7708000)
        libXau.so.6 => /usr/lib/i386-linux-gnu/libXau.so.6 (0xf5728000)
        libXdmcp.so.6 => /usr/lib/i386-linux-gnu/libXdmcp.so.6 (0xf5720000)
        libexpat.so.1 => /lib/i386-linux-gnu/libexpat.so.1 (0xf56f8000)
```

Note that libXau.so, libXdmcp.so, and libexpat.so are indirect dependencies.
