### PR TITLE
Add option to disable 077 umask (create new files with system default umask)

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -426,16 +426,14 @@ bool AppInit2(boost::thread_group& threadGroup)
 #endif
 #ifndef WIN32
 
+    if (GetBoolArg("-sysperms", false)) {
 #ifdef ENABLE_WALLET
-    if (!GetBoolArg("-sysperms", false) || !GetBoolArg("-disablewallet", false)) {
-        umask(077);
-        if (GetBoolArg("-sysperms", false))
+        if (!GetBoolArg("-disablewallet", false))
             return InitError("Error: -sysperms is not allowed in combination with enabled wallet functionality");
-    }
-#else
-    if (!GetBoolArg("-sysperms", false))
-        umask(077);
 #endif
+    } else {
+        umask(077);
+    }
 
     // Clean shutdown on SIGTERM
     struct sigaction sa;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -427,8 +427,11 @@ bool AppInit2(boost::thread_group& threadGroup)
 #ifndef WIN32
 
 #ifdef ENABLE_WALLET
-    if (!GetBoolArg("-sysperms", false) || !GetBoolArg("-disablewallet", false))
+    if (!GetBoolArg("-sysperms", false) || !GetBoolArg("-disablewallet", false)) {
         umask(077);
+        if (GetBoolArg("-sysperms", false))
+            return InitError("Error: -sysperms is not allowed in combination with enabled wallet functionality");
+    }
 #else
     if (!GetBoolArg("-sysperms", false))
         umask(077);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -209,10 +209,11 @@ std::string HelpMessage(HelpMessageMode hmm)
     strUsage += "  -par=<n>               " + strprintf(_("Set the number of script verification threads (%u to %d, 0 = auto, <0 = leave that many cores free, default: %d)"), -(int)boost::thread::hardware_concurrency(), MAX_SCRIPTCHECK_THREADS, DEFAULT_SCRIPTCHECK_THREADS) + "\n";
     strUsage += "  -pid=<file>            " + _("Specify pid file (default: bitcoind.pid)") + "\n";
     strUsage += "  -reindex               " + _("Rebuild block chain index from current blk000??.dat files") + " " + _("on startup") + "\n";
-    strUsage += "  -txindex               " + _("Maintain a full transaction index (default: 0)") + "\n";
 #if !defined(WIN32)
     strUsage += "  -sysperms              " + _("Create new files with system default permissions, instead of umask 077 (only effective with disabled wallet functionality)") + "\n";
 #endif
+    strUsage += "  -txindex               " + _("Maintain a full transaction index (default: 0)") + "\n";
+
 
     strUsage += "\n" + _("Connection options:") + "\n";
     strUsage += "  -addnode=<ip>          " + _("Add a node to connect to and attempt to keep the connection open") + "\n";


### PR DESCRIPTION
The option is only effective for either wallet-less builds or if
-disablewallet is specified as well.

This is useful when the wallet is handled by an application other than bitcoind (for example Armory). If bitcoind runs as a user different from the user that runs Armory, Armory is not able to read the blockchain files that it needs to. This allows bitcoind to be run as a separate user and function with Armory (and other applications that need to read bitcoind data files) at the same time.
