### PR TITLE
Remove side effect in assertion in ProcessGetData

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3390,7 +3390,8 @@ void static ProcessGetData(CNode* pfrom)
                 {
                     // Send block from disk
                     CBlock block;
-                    assert(ReadBlockFromDisk(block, (*mi).second));
+                    if (!ReadBlockFromDisk(block, (*mi).second))
+                        assert(!"cannot load block from disk");
                     if (inv.type == MSG_BLOCK)
                         pfrom->PushMessage("block", block);
                     else // MSG_FILTERED_BLOCK)


### PR DESCRIPTION
A side-effect was introduced into an assertion in 7a0e84d. This commit fixes that.
