### PR TITLE
Remove global strWalletFile

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -40,7 +40,6 @@ using namespace std;
 using namespace boost;
 
 #ifdef ENABLE_WALLET
-std::string strWalletFile;
 CWallet* pwalletMain;
 #endif
 
@@ -584,7 +583,7 @@ bool AppInit2(boost::thread_group& threadGroup)
     }
     bSpendZeroConfChange = GetArg("-spendzeroconfchange", true);
 
-    strWalletFile = GetArg("-wallet", "wallet.dat");
+    std::string strWalletFile = GetArg("-wallet", "wallet.dat");
 #endif
     // ********************************************************* Step 4: application initialization: dir lock, daemonize, pidfile, debug log
 

--- a/src/init.h
+++ b/src/init.h
@@ -14,7 +14,6 @@ namespace boost {
     class thread_group;
 };
 
-extern std::string strWalletFile;
 extern CWallet* pwalletMain;
 
 void StartShutdown();


### PR DESCRIPTION
As it says on the tin. There is no need to have this variable be global, it's only used in AppInit2.
