### PR TITLE
gitian: upgrade OpenSSL to 1.0.1h

### DIFF
--- a/contrib/gitian-descriptors/deps-linux.yml
+++ b/contrib/gitian-descriptors/deps-linux.yml
@@ -16,7 +16,7 @@ packages:
 reference_datetime: "2013-06-01 00:00:00"
 remotes: []
 files:
-- "openssl-1.0.1g.tar.gz"
+- "openssl-1.0.1h.tar.gz"
 - "miniupnpc-1.9.tar.gz"
 - "qrencode-3.4.3.tar.bz2"
 - "protobuf-2.5.0.tar.bz2"
@@ -30,15 +30,15 @@ script: |
   export TZ=UTC
   export LIBRARY_PATH="$STAGING/lib"
   # Integrity Check
-  echo "53cb818c3b90e507a8348f4f5eaedb05d8bfe5358aabb508b7263cc670c3e028  openssl-1.0.1g.tar.gz"  | sha256sum -c
+  echo "9d1c8a9836aa63e2c6adb684186cbd4371c9e9dcc01d6e3bb447abf2d4d3d093  openssl-1.0.1h.tar.gz"  | sha256sum -c
   echo "2923e453e880bb949e3d4da9f83dd3cb6f08946d35de0b864d0339cf70934464  miniupnpc-1.9.tar.gz"   | sha256sum -c
   echo "dfd71487513c871bad485806bfd1fdb304dedc84d2b01a8fb8e0940b50597a98  qrencode-3.4.3.tar.bz2" | sha256sum -c
   echo "13bfc5ae543cf3aa180ac2485c0bc89495e3ae711fc6fab4f8ffe90dfb4bb677  protobuf-2.5.0.tar.bz2" | sha256sum -c
   echo "12edc0df75bf9abd7f82f821795bcee50f42cb2e5f76a6a281b85732798364ef  db-4.8.30.NC.tar.gz"    | sha256sum -c
 
   #
-  tar xzf openssl-1.0.1g.tar.gz
-  cd openssl-1.0.1g
+  tar xzf openssl-1.0.1h.tar.gz
+  cd openssl-1.0.1h
   #   need -fPIC to avoid relocation error in 64 bit builds
   ./config no-shared no-zlib no-dso no-krb5 --openssldir=$STAGING -fPIC
   #   need to build OpenSSL with faketime because a timestamp is embedded into cversion.o
@@ -95,4 +95,4 @@ script: |
   done
   #
   cd $STAGING
-  find include lib bin host | sort | zip -X@ $OUTDIR/bitcoin-deps-linux${GBUILD_BITS}-gitian-r5.zip
+  find include lib bin host | sort | zip -X@ $OUTDIR/bitcoin-deps-linux${GBUILD_BITS}-gitian-r6.zip

--- a/contrib/gitian-descriptors/deps-win.yml
+++ b/contrib/gitian-descriptors/deps-win.yml
@@ -14,7 +14,7 @@ packages:
 reference_datetime: "2011-01-30 00:00:00"
 remotes: []
 files:
-- "openssl-1.0.1g.tar.gz"
+- "openssl-1.0.1h.tar.gz"
 - "db-4.8.30.NC.tar.gz"
 - "miniupnpc-1.9.tar.gz"
 - "zlib-1.2.8.tar.gz"
@@ -28,7 +28,7 @@ script: |
   INDIR=$HOME/build
   TEMPDIR=$HOME/tmp
   # Input Integrity Check
-  echo "53cb818c3b90e507a8348f4f5eaedb05d8bfe5358aabb508b7263cc670c3e028  openssl-1.0.1g.tar.gz"  | sha256sum -c
+  echo "9d1c8a9836aa63e2c6adb684186cbd4371c9e9dcc01d6e3bb447abf2d4d3d093  openssl-1.0.1h.tar.gz"  | sha256sum -c
   echo "12edc0df75bf9abd7f82f821795bcee50f42cb2e5f76a6a281b85732798364ef  db-4.8.30.NC.tar.gz"    | sha256sum -c
   echo "2923e453e880bb949e3d4da9f83dd3cb6f08946d35de0b864d0339cf70934464  miniupnpc-1.9.tar.gz"   | sha256sum -c
   echo "36658cb768a54c1d4dec43c3116c27ed893e88b02ecfcb44f2166f9c0b7f2a0d  zlib-1.2.8.tar.gz"      | sha256sum -c
@@ -48,8 +48,8 @@ script: |
     mkdir -p $INSTALLPREFIX $BUILDDIR
     cd $BUILDDIR
     #
-    tar xzf $INDIR/openssl-1.0.1g.tar.gz
-    cd openssl-1.0.1g
+    tar xzf $INDIR/openssl-1.0.1h.tar.gz
+    cd openssl-1.0.1h
     if [ "$BITS" == "32" ]; then
       OPENSSL_TGT=mingw
     else
@@ -124,5 +124,5 @@ script: |
     done
     #
     cd $INSTALLPREFIX
-    find include lib | sort | zip -X@ $OUTDIR/bitcoin-deps-win$BITS-gitian-r12.zip
+    find include lib | sort | zip -X@ $OUTDIR/bitcoin-deps-win$BITS-gitian-r13.zip
   done # for BITS in

--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -25,8 +25,8 @@ remotes:
 - "url": "https://github.com/bitcoin/bitcoin.git"
   "dir": "bitcoin"
 files:
-- "bitcoin-deps-linux32-gitian-r5.zip"
-- "bitcoin-deps-linux64-gitian-r5.zip"
+- "bitcoin-deps-linux32-gitian-r6.zip"
+- "bitcoin-deps-linux64-gitian-r6.zip"
 - "boost-linux32-1.55.0-gitian-r1.zip"
 - "boost-linux64-1.55.0-gitian-r1.zip"
 - "qt-linux32-4.6.4-gitian-r1.tar.gz"
@@ -43,7 +43,7 @@ script: |
   #
   mkdir -p $STAGING
   cd $STAGING
-  unzip ../build/bitcoin-deps-linux${GBUILD_BITS}-gitian-r5.zip
+  unzip ../build/bitcoin-deps-linux${GBUILD_BITS}-gitian-r6.zip
   unzip ../build/boost-linux${GBUILD_BITS}-1.55.0-gitian-r1.zip
   tar -zxf ../build/qt-linux${GBUILD_BITS}-4.6.4-gitian-r1.tar.gz
   cd ../build

--- a/contrib/gitian-descriptors/gitian-osx-bitcoin.yml
+++ b/contrib/gitian-descriptors/gitian-osx-bitcoin.yml
@@ -18,8 +18,8 @@ remotes:
   "dir": "bitcoin"
 files:
 - "osx-native-depends-r3.tar.gz"
-- "osx-depends-r3.tar.gz"
-- "osx-depends-qt-5.2.1-r3.tar.gz"
+- "osx-depends-r4.tar.gz"
+- "osx-depends-qt-5.2.1-r4.tar.gz"
 - "MacOSX10.7.sdk.tar.gz"
 
 script: |
@@ -37,8 +37,8 @@ script: |
   tar -C osx-cross-depends/SDKs -xf ${SOURCES_PATH}/MacOSX10.7.sdk.tar.gz
 
   tar -C osx-cross-depends -xf osx-native-depends-r3.tar.gz
-  tar -C osx-cross-depends -xf osx-depends-r3.tar.gz
-  tar -C osx-cross-depends -xf osx-depends-qt-5.2.1-r3.tar.gz
+  tar -C osx-cross-depends -xf osx-depends-r4.tar.gz
+  tar -C osx-cross-depends -xf osx-depends-qt-5.2.1-r4.tar.gz
   export PATH=`pwd`/osx-cross-depends/native-prefix/bin:$PATH
 
   cd bitcoin

--- a/contrib/gitian-descriptors/gitian-osx-depends.yml
+++ b/contrib/gitian-descriptors/gitian-osx-depends.yml
@@ -15,7 +15,7 @@ files:
 - "boost_1_55_0.tar.bz2"
 - "db-4.8.30.NC.tar.gz"
 - "miniupnpc-1.9.tar.gz"
-- "openssl-1.0.1g.tar.gz"
+- "openssl-1.0.1h.tar.gz"
 - "protobuf-2.5.0.tar.bz2"
 - "qrencode-3.4.3.tar.bz2"
 - "MacOSX10.7.sdk.tar.gz"
@@ -26,11 +26,11 @@ script: |
   echo "fff00023dd79486d444c8e29922f4072e1d451fc5a4d2b6075852ead7f2b7b52  boost_1_55_0.tar.bz2" | sha256sum -c
   echo "12edc0df75bf9abd7f82f821795bcee50f42cb2e5f76a6a281b85732798364ef  db-4.8.30.NC.tar.gz" | sha256sum -c
   echo "2923e453e880bb949e3d4da9f83dd3cb6f08946d35de0b864d0339cf70934464  miniupnpc-1.9.tar.gz" | sha256sum -c
-  echo "53cb818c3b90e507a8348f4f5eaedb05d8bfe5358aabb508b7263cc670c3e028  openssl-1.0.1g.tar.gz" | sha256sum -c
+  echo "9d1c8a9836aa63e2c6adb684186cbd4371c9e9dcc01d6e3bb447abf2d4d3d093  openssl-1.0.1h.tar.gz" | sha256sum -c
   echo "13bfc5ae543cf3aa180ac2485c0bc89495e3ae711fc6fab4f8ffe90dfb4bb677  protobuf-2.5.0.tar.bz2" | sha256sum -c
   echo "dfd71487513c871bad485806bfd1fdb304dedc84d2b01a8fb8e0940b50597a98  qrencode-3.4.3.tar.bz2" | sha256sum -c
 
-  REVISION=r3
+  REVISION=r4
   export SOURCES_PATH=`pwd`
   export TAR_OPTIONS="-m --mtime="$REFERENCE_DATE\\\ $REFERENCE_TIME""
   export PATH=$HOME:$PATH
@@ -88,8 +88,8 @@ script: |
   popd
 
   # openssl
-  SOURCE_FILE=${SOURCES_PATH}/openssl-1.0.1g.tar.gz
-  BUILD_DIR=${BUILD_BASE}/openssl-1.0.1g
+  SOURCE_FILE=${SOURCES_PATH}/openssl-1.0.1h.tar.gz
+  BUILD_DIR=${BUILD_BASE}/openssl-1.0.1h
 
   tar -C ${BUILD_BASE} -xf ${SOURCE_FILE}
   pushd ${BUILD_DIR}

--- a/contrib/gitian-descriptors/gitian-osx-qt.yml
+++ b/contrib/gitian-descriptors/gitian-osx-qt.yml
@@ -14,14 +14,14 @@ remotes: []
 files:
 - "qt-everywhere-opensource-src-5.2.1.tar.gz"
 - "osx-native-depends-r3.tar.gz"
-- "osx-depends-r3.tar.gz"
+- "osx-depends-r4.tar.gz"
 - "MacOSX10.7.sdk.tar.gz"
 
 script: |
 
   echo "84e924181d4ad6db00239d87250cc89868484a14841f77fb85ab1f1dbdcd7da1  qt-everywhere-opensource-src-5.2.1.tar.gz" | sha256sum -c
 
-  REVISION=r3
+  REVISION=r4
   export SOURCES_PATH=`pwd`
   export TAR_OPTIONS="-m --mtime="$REFERENCE_DATE\\\ $REFERENCE_TIME""
   export ZERO_AR_DATE=1
@@ -73,7 +73,7 @@ script: |
   tar xf /home/ubuntu/build/osx-native-depends-r3.tar.gz
 
   export PATH=`pwd`/native-prefix/bin:$PATH
-  tar xf /home/ubuntu/build/osx-depends-r3.tar.gz
+  tar xf /home/ubuntu/build/osx-depends-r4.tar.gz
 
   SOURCE_FILE=${SOURCES_PATH}/qt-everywhere-opensource-src-5.2.1.tar.gz
   BUILD_DIR=${BUILD_BASE}/qt-everywhere-opensource-src-5.2.1

--- a/contrib/gitian-descriptors/gitian-win.yml
+++ b/contrib/gitian-descriptors/gitian-win.yml
@@ -26,8 +26,8 @@ files:
 - "qt-win64-5.2.0-gitian-r3.zip"
 - "boost-win32-1.55.0-gitian-r6.zip"
 - "boost-win64-1.55.0-gitian-r6.zip"
-- "bitcoin-deps-win32-gitian-r12.zip"
-- "bitcoin-deps-win64-gitian-r12.zip"
+- "bitcoin-deps-win32-gitian-r13.zip"
+- "bitcoin-deps-win64-gitian-r13.zip"
 - "protobuf-win32-2.5.0-gitian-r4.zip"
 - "protobuf-win64-2.5.0-gitian-r4.zip"
 script: |
@@ -61,7 +61,7 @@ script: |
     cd $STAGING
     unzip $INDIR/qt-win${BITS}-5.2.0-gitian-r3.zip
     unzip $INDIR/boost-win${BITS}-1.55.0-gitian-r6.zip
-    unzip $INDIR/bitcoin-deps-win${BITS}-gitian-r12.zip
+    unzip $INDIR/bitcoin-deps-win${BITS}-gitian-r13.zip
     unzip $INDIR/protobuf-win${BITS}-2.5.0-gitian-r4.zip
     if [ "$NEEDDIST" == "1" ]; then
       # Make source code archive which is architecture independent so it only needs to be done once

--- a/contrib/gitian-descriptors/qt-win.yml
+++ b/contrib/gitian-descriptors/qt-win.yml
@@ -15,8 +15,8 @@ reference_datetime: "2011-01-30 00:00:00"
 remotes: []
 files:
 - "qt-everywhere-opensource-src-5.2.0.tar.gz"
-- "bitcoin-deps-win32-gitian-r12.zip"
-- "bitcoin-deps-win64-gitian-r12.zip"
+- "bitcoin-deps-win32-gitian-r13.zip"
+- "bitcoin-deps-win64-gitian-r13.zip"
 script: |
   # Defines
   export TZ=UTC
@@ -48,7 +48,7 @@ script: |
     #
     # Need mingw-compiled openssl from bitcoin-deps:
     cd $DEPSDIR
-    unzip $INDIR/bitcoin-deps-win${BITS}-gitian-r12.zip
+    unzip $INDIR/bitcoin-deps-win${BITS}-gitian-r13.zip
     #
     cd $BUILDDIR
     #

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -44,7 +44,7 @@ Release Process
  Fetch and build inputs: (first time, or when dependency versions change)
 
 	wget 'http://miniupnp.free.fr/files/download.php?file=miniupnpc-1.9.tar.gz' -O miniupnpc-1.9.tar.gz
-	wget 'https://www.openssl.org/source/openssl-1.0.1g.tar.gz'
+	wget 'https://www.openssl.org/source/openssl-1.0.1h.tar.gz'
 	wget 'http://download.oracle.com/berkeley-db/db-4.8.30.NC.tar.gz'
 	wget 'http://zlib.net/zlib-1.2.8.tar.gz'
 	wget 'ftp://ftp.simplesystems.org/pub/png/src/history/libpng16/libpng-1.6.8.tar.gz'
@@ -89,16 +89,16 @@ Release Process
 
  The expected SHA256 hashes of the intermediate inputs are:
 
-    35c3dfd8b9362f59e81b51881b295232e3bc9e286f1add193b59d486d9ac4a5c  bitcoin-deps-linux32-gitian-r5.zip
-    571789867d172500fa96d63d0ba8c5b1e1a3d6f44f720eddf2f93665affc88b3  bitcoin-deps-linux64-gitian-r5.zip
+    46710f673467e367738d8806e45b4cb5931aaeea61f4b6b55a68eea56d5006c5  bitcoin-deps-linux32-gitian-r6.zip
+    f03be39fb26670243d3a659e64d18e19d03dec5c11e9912011107768390b5268  bitcoin-deps-linux64-gitian-r6.zip
     f29b7d9577417333fb56e023c2977f5726a7c297f320b175a4108cf7cd4c2d29  boost-linux32-1.55.0-gitian-r1.zip
     88232451c4104f7eb16e469ac6474fd1231bd485687253f7b2bdf46c0781d535  boost-linux64-1.55.0-gitian-r1.zip
     57e57dbdadc818cd270e7e00500a5e1085b3bcbdef69a885f0fb7573a8d987e1  qt-linux32-4.6.4-gitian-r1.tar.gz
     60eb4b9c5779580b7d66529efa5b2836ba1a70edde2a0f3f696d647906a826be  qt-linux64-4.6.4-gitian-r1.tar.gz
     60dc2d3b61e9c7d5dbe2f90d5955772ad748a47918ff2d8b74e8db9b1b91c909  boost-win32-1.55.0-gitian-r6.zip
     f65fcaf346bc7b73bc8db3a8614f4f6bee2f61fcbe495e9881133a7c2612a167  boost-win64-1.55.0-gitian-r6.zip
-    acd59690a49dfbad6b436379843fe4ad1857ad91c603d52506690bc55f2a01a4  bitcoin-deps-win32-gitian-r12.zip
-    a3e5a62fcdad81f758e41848035e6a27be390981a14d590f2cf2509f87417a42  bitcoin-deps-win64-gitian-r12.zip
+    70de248cd0dd7e7476194129e818402e974ca9c5751cbf591644dc9f332d3b59  bitcoin-deps-win32-gitian-r13.zip
+    9eace4c76f639f4f3580a478eee4f50246e1bbb5ccdcf37a158261a5a3fa3e65  bitcoin-deps-win64-gitian-r13.zip
     963e3e5e85879010a91143c90a711a5d1d5aba992e38672cdf7b54e42c56b2f1  qt-win32-5.2.0-gitian-r3.zip
     751c579830d173ef3e6f194e83d18b92ebef6df03289db13ab77a52b6bc86ef0  qt-win64-5.2.0-gitian-r3.zip
     e2e403e1a08869c7eed4d4293bce13d51ec6a63592918b90ae215a0eceb44cb4  protobuf-win32-2.5.0-gitian-r4.zip


### PR DESCRIPTION
Upgrade for https://www.openssl.org/news/secadv_20140605.txt

First: there is no vulnerability that affects ecdsa signing or verification. However, the MITM attack vulnerability (CVE-2014-0224) may have some effect on our usage of SSL/TLS.

As long as payment requests are signed (which is the common case), usage of the payment protocol should also not be affected.

The TLS usage in RPC may be at risk for MITM attacks. If you have `-rpcssl` enabled, be sure to update OpenSSL as soon as possible.
- qt-win dependency version is not bumped, as the files remain the same
