### PR TITLE
Using Boost Asio to do async resolving

### DIFF
--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -65,6 +65,8 @@ static void resolve_handler(std::vector<CNetAddr>* vIP, unsigned int nMax, const
     if (ec)
         return;
 
+    boost::this_thread::interruption_point();
+
     boost::asio::ip::tcp::resolver::iterator end;
     for (; (nMax == 0 || vIP->size() < nMax) && itr != end; ++itr)
         vIP->push_back(CNetAddr(itr->endpoint().address()));
@@ -92,10 +94,7 @@ bool static LookupIntern(const char *pszName, std::vector<CNetAddr>& vIP, unsign
 
         resolver.async_resolve(query, boost::bind(resolve_handler, &vIP, nMaxSolutions, boost::asio::placeholders::error, boost::asio::placeholders::iterator));
 
-        while (!ios.poll(ec) && !ec) {
-            boost::this_thread::interruption_point();
-            MilliSleep(500);
-        }
+        ios.run();
     } else {
         addr = boost::asio::ip::address::from_string(pszName, ec);
         if (!ec)

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -16,7 +16,7 @@
 
 #include <boost/algorithm/string/case_conv.hpp> // for to_lower()
 #include <boost/algorithm/string/predicate.hpp> // for startswith() and endswith()
-#include <boost/bind.hpp>
+#include <boost/bind.hpp> // for async_resolve_handler of LookupIntern()
 
 #if !defined(HAVE_MSG_NOSIGNAL) && !defined(MSG_NOSIGNAL)
 #define MSG_NOSIGNAL 0

--- a/src/netbase.h
+++ b/src/netbase.h
@@ -15,6 +15,7 @@
 #include <stdint.h>
 #include <string>
 #include <vector>
+#include <boost/asio.hpp>
 
 extern int nConnectTimeout;
 
@@ -45,6 +46,8 @@ class CNetAddr
     public:
         CNetAddr();
         CNetAddr(const struct in_addr& ipv4Addr);
+        CNetAddr(const struct in6_addr& ipv6Addr);
+        CNetAddr(const boost::asio::ip::address& asioAddr);
         explicit CNetAddr(const char *pszIp, bool fAllowLookup = false);
         explicit CNetAddr(const std::string &strIp, bool fAllowLookup = false);
         void Init();
@@ -80,12 +83,10 @@ class CNetAddr
         unsigned int GetByte(int n) const;
         uint64_t GetHash() const;
         bool GetInAddr(struct in_addr* pipv4Addr) const;
+        bool GetIn6Addr(struct in6_addr* pipv6Addr) const;
         std::vector<unsigned char> GetGroup() const;
         int GetReachabilityFrom(const CNetAddr *paddrPartner = NULL) const;
         void print() const;
-
-        CNetAddr(const struct in6_addr& pipv6Addr);
-        bool GetIn6Addr(struct in6_addr* pipv6Addr) const;
 
         friend bool operator==(const CNetAddr& a, const CNetAddr& b);
         friend bool operator!=(const CNetAddr& a, const CNetAddr& b);

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -360,31 +360,9 @@ void ErrorReply(std::ostream& stream, const Object& objError, const Value& id)
     stream << HTTPReply(nStatus, strReply, false) << std::flush;
 }
 
-CNetAddr BoostAsioToCNetAddr(boost::asio::ip::address address)
-{
-    CNetAddr netaddr;
-    // Make sure that IPv4-compatible and IPv4-mapped IPv6 addresses are treated as IPv4 addresses
-    if (address.is_v6()
-     && (address.to_v6().is_v4_compatible()
-      || address.to_v6().is_v4_mapped()))
-        address = address.to_v6().to_v4();
-
-    if(address.is_v4())
-    {
-        boost::asio::ip::address_v4::bytes_type bytes = address.to_v4().to_bytes();
-        netaddr.SetRaw(NET_IPV4, &bytes[0]);
-    }
-    else
-    {
-        boost::asio::ip::address_v6::bytes_type bytes = address.to_v6().to_bytes();
-        netaddr.SetRaw(NET_IPV6, &bytes[0]);
-    }
-    return netaddr;
-}
-
 bool ClientAllowed(const boost::asio::ip::address& address)
 {
-    CNetAddr netaddr = BoostAsioToCNetAddr(address);
+    CNetAddr netaddr(address);
     BOOST_FOREACH(const CSubNet &subnet, rpc_allow_subnets)
         if (subnet.Match(netaddr))
             return true;

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -19,7 +19,6 @@
 #include "json/json_spirit_writer_template.h"
 
 class CBlockIndex;
-class CNetAddr;
 
 /* Start RPC threads */
 void StartRPCThreads();
@@ -50,9 +49,6 @@ void RPCTypeCheck(const json_spirit::Object& o,
   Overrides previous timer <name> (if any).
  */
 void RPCRunLater(const std::string& name, boost::function<void(void)> func, int64_t nSeconds);
-
-//! Convert boost::asio address to CNetAddr
-extern CNetAddr BoostAsioToCNetAddr(boost::asio::ip::address address);
 
 typedef json_spirit::Value(*rpcfn_type)(const json_spirit::Array& params, bool fHelp);
 

--- a/src/test/netbase_tests.cpp
+++ b/src/test/netbase_tests.cpp
@@ -139,4 +139,19 @@ BOOST_AUTO_TEST_CASE(subnet_test)
     BOOST_CHECK(!CSubNet("fuzzy").IsValid());
 }
 
+BOOST_AUTO_TEST_CASE(cnetaddr_from_boostasio)
+{
+    // Check IPv4 addresses
+    BOOST_CHECK_EQUAL(CNetAddr(boost::asio::ip::address::from_string("1.2.3.4")).ToString(), "1.2.3.4");
+    BOOST_CHECK_EQUAL(CNetAddr(boost::asio::ip::address::from_string("127.0.0.1")).ToString(), "127.0.0.1");
+    // Check IPv6 addresses
+    BOOST_CHECK_EQUAL(CNetAddr(boost::asio::ip::address::from_string("::1")).ToString(), "::1");
+    BOOST_CHECK_EQUAL(CNetAddr(boost::asio::ip::address::from_string("123:4567:89ab:cdef:123:4567:89ab:cdef")).ToString(),
+                                         "123:4567:89ab:cdef:123:4567:89ab:cdef");
+    // v4 compatible must be interpreted as IPv4
+    BOOST_CHECK_EQUAL(CNetAddr(boost::asio::ip::address::from_string("::0:127.0.0.1")).ToString(), "127.0.0.1");
+    // v4 mapped must be interpreted as IPv4
+    BOOST_CHECK_EQUAL(CNetAddr(boost::asio::ip::address::from_string("::ffff:127.0.0.1")).ToString(), "127.0.0.1");
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -139,19 +139,4 @@ BOOST_AUTO_TEST_CASE(rpc_parse_monetary_values)
     BOOST_CHECK(AmountFromValue(ValueFromString("20999999.99999999")) == 2099999999999999LL);
 }
 
-BOOST_AUTO_TEST_CASE(rpc_boostasiotocnetaddr)
-{
-    // Check IPv4 addresses
-    BOOST_CHECK_EQUAL(BoostAsioToCNetAddr(boost::asio::ip::address::from_string("1.2.3.4")).ToString(), "1.2.3.4");
-    BOOST_CHECK_EQUAL(BoostAsioToCNetAddr(boost::asio::ip::address::from_string("127.0.0.1")).ToString(), "127.0.0.1");
-    // Check IPv6 addresses
-    BOOST_CHECK_EQUAL(BoostAsioToCNetAddr(boost::asio::ip::address::from_string("::1")).ToString(), "::1");
-    BOOST_CHECK_EQUAL(BoostAsioToCNetAddr(boost::asio::ip::address::from_string("123:4567:89ab:cdef:123:4567:89ab:cdef")).ToString(),
-                                         "123:4567:89ab:cdef:123:4567:89ab:cdef");
-    // v4 compatible must be interpreted as IPv4
-    BOOST_CHECK_EQUAL(BoostAsioToCNetAddr(boost::asio::ip::address::from_string("::0:127.0.0.1")).ToString(), "127.0.0.1");
-    // v4 mapped must be interpreted as IPv4
-    BOOST_CHECK_EQUAL(BoostAsioToCNetAddr(boost::asio::ip::address::from_string("::ffff:127.0.0.1")).ToString(), "127.0.0.1");
-}
-
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Also create a new CNetAddr() constructor from the BoostAsioToCNetAddr() method.

NOTE: This PR is related to another one (https://github.com/bitcoin/bitcoin/pull/4259).

Using boost::asio but not getaddrinfo_a() might improve the portability (I'm wondering actually...) but there are two regressions:
  1) Doesn't like the getaddrinfo_a(), the asio interface provides no timed wait/loop method, so we have to explicitly sleep when waiting for the result, which is known to be not efficient;  And refactor all places which need a dns resolving would be an obvious overkill;
  2) Doesn't like the getaddrinfo_a(), the asio::async_resolve() is implemented by calling getaddrinfo() in a newly created thread which would block on the call, so for our original purpose, to improve the net thread responsiveness, it only helps when more than one resolving jobs are issued by one thread sequentially (e.g. dnsseed thread), because only when after a resolving job (the blocking call) the thread gets its chance to response for interruption, while the getaddrinfo_a() doesn't block and can be interrupted at any time.

Base on these two issues above, I personally prefer the original PR 4259, and I'd like to submit another PR for the change of a new CNetAddr() constructor which I think is clearer than an independent method.

Signed-off-by: Huang Le 4tarhl@gmail.com
