### PR TITLE
[Qt] Improve rpc console history behavior

### DIFF
--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -415,8 +415,8 @@ void RPCConsole::on_lineEdit_returnPressed()
     {
         message(CMD_REQUEST, cmd);
         emit cmdRequest(cmd);
-        // Truncate history from current position
-        history.erase(history.begin() + historyPtr, history.end());
+        // Remove command, if already in history
+        history.removeOne(cmd);
         // Append command to history
         history.append(cmd);
         // Enforce maximum history size


### PR DESCRIPTION
The current behavior of the history in rpcconsole with the up and down keys is a little bit annoying,
because entries are unexpectedly removed from the history.

I compared the behavior after this patch with my local bash and it seems to be the same.
