### PR TITLE
Add another CNetAddr constructor which accepts boost::asio::ip::address

### DIFF
--- a/src/netbase.h
+++ b/src/netbase.h
@@ -16,6 +16,9 @@
 #include <string>
 #include <vector>
 
+// Pre-declare the boost::asio::ip::address class here
+namespace boost { namespace asio { namespace ip { class address; } } }
+
 extern int nConnectTimeout;
 
 #ifdef WIN32
@@ -45,6 +48,8 @@ class CNetAddr
     public:
         CNetAddr();
         CNetAddr(const struct in_addr& ipv4Addr);
+        CNetAddr(const struct in6_addr& ipv6Addr);
+        CNetAddr(const boost::asio::ip::address& asioAddr);
         explicit CNetAddr(const char *pszIp, bool fAllowLookup = false);
         explicit CNetAddr(const std::string &strIp, bool fAllowLookup = false);
         void Init();
@@ -80,12 +85,10 @@ class CNetAddr
         unsigned int GetByte(int n) const;
         uint64_t GetHash() const;
         bool GetInAddr(struct in_addr* pipv4Addr) const;
+        bool GetIn6Addr(struct in6_addr* pipv6Addr) const;
         std::vector<unsigned char> GetGroup() const;
         int GetReachabilityFrom(const CNetAddr *paddrPartner = NULL) const;
         void print() const;
-
-        CNetAddr(const struct in6_addr& pipv6Addr);
-        bool GetIn6Addr(struct in6_addr* pipv6Addr) const;
 
         friend bool operator==(const CNetAddr& a, const CNetAddr& b);
         friend bool operator!=(const CNetAddr& a, const CNetAddr& b);

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -360,31 +360,9 @@ void ErrorReply(std::ostream& stream, const Object& objError, const Value& id)
     stream << HTTPReply(nStatus, strReply, false) << std::flush;
 }
 
-CNetAddr BoostAsioToCNetAddr(boost::asio::ip::address address)
-{
-    CNetAddr netaddr;
-    // Make sure that IPv4-compatible and IPv4-mapped IPv6 addresses are treated as IPv4 addresses
-    if (address.is_v6()
-     && (address.to_v6().is_v4_compatible()
-      || address.to_v6().is_v4_mapped()))
-        address = address.to_v6().to_v4();
-
-    if(address.is_v4())
-    {
-        boost::asio::ip::address_v4::bytes_type bytes = address.to_v4().to_bytes();
-        netaddr.SetRaw(NET_IPV4, &bytes[0]);
-    }
-    else
-    {
-        boost::asio::ip::address_v6::bytes_type bytes = address.to_v6().to_bytes();
-        netaddr.SetRaw(NET_IPV6, &bytes[0]);
-    }
-    return netaddr;
-}
-
 bool ClientAllowed(const boost::asio::ip::address& address)
 {
-    CNetAddr netaddr = BoostAsioToCNetAddr(address);
+    CNetAddr netaddr(address);
     BOOST_FOREACH(const CSubNet &subnet, rpc_allow_subnets)
         if (subnet.Match(netaddr))
             return true;

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -19,7 +19,6 @@
 #include "json/json_spirit_writer_template.h"
 
 class CBlockIndex;
-class CNetAddr;
 
 /* Start RPC threads */
 void StartRPCThreads();
@@ -50,9 +49,6 @@ void RPCTypeCheck(const json_spirit::Object& o,
   Overrides previous timer <name> (if any).
  */
 void RPCRunLater(const std::string& name, boost::function<void(void)> func, int64_t nSeconds);
-
-//! Convert boost::asio address to CNetAddr
-extern CNetAddr BoostAsioToCNetAddr(boost::asio::ip::address address);
 
 typedef json_spirit::Value(*rpcfn_type)(const json_spirit::Array& params, bool fHelp);
 

--- a/src/test/netbase_tests.cpp
+++ b/src/test/netbase_tests.cpp
@@ -7,6 +7,7 @@
 #include <string>
 
 #include <boost/test/unit_test.hpp>
+#include <boost/asio.hpp>
 
 using namespace std;
 
@@ -137,6 +138,21 @@ BOOST_AUTO_TEST_CASE(subnet_test)
     BOOST_CHECK(CSubNet("1:2:3:4:5:6:7:8/128").IsValid());
     BOOST_CHECK(!CSubNet("1:2:3:4:5:6:7:8/129").IsValid());
     BOOST_CHECK(!CSubNet("fuzzy").IsValid());
+}
+
+BOOST_AUTO_TEST_CASE(cnetaddr_from_boostasio)
+{
+    // Check IPv4 addresses
+    BOOST_CHECK_EQUAL(CNetAddr(boost::asio::ip::address::from_string("1.2.3.4")).ToString(), "1.2.3.4");
+    BOOST_CHECK_EQUAL(CNetAddr(boost::asio::ip::address::from_string("127.0.0.1")).ToString(), "127.0.0.1");
+    // Check IPv6 addresses
+    BOOST_CHECK_EQUAL(CNetAddr(boost::asio::ip::address::from_string("::1")).ToString(), "::1");
+    BOOST_CHECK_EQUAL(CNetAddr(boost::asio::ip::address::from_string("123:4567:89ab:cdef:123:4567:89ab:cdef")).ToString(),
+                                         "123:4567:89ab:cdef:123:4567:89ab:cdef");
+    // v4 compatible must be interpreted as IPv4
+    BOOST_CHECK_EQUAL(CNetAddr(boost::asio::ip::address::from_string("::0:127.0.0.1")).ToString(), "127.0.0.1");
+    // v4 mapped must be interpreted as IPv4
+    BOOST_CHECK_EQUAL(CNetAddr(boost::asio::ip::address::from_string("::ffff:127.0.0.1")).ToString(), "127.0.0.1");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -139,19 +139,4 @@ BOOST_AUTO_TEST_CASE(rpc_parse_monetary_values)
     BOOST_CHECK(AmountFromValue(ValueFromString("20999999.99999999")) == 2099999999999999LL);
 }
 
-BOOST_AUTO_TEST_CASE(rpc_boostasiotocnetaddr)
-{
-    // Check IPv4 addresses
-    BOOST_CHECK_EQUAL(BoostAsioToCNetAddr(boost::asio::ip::address::from_string("1.2.3.4")).ToString(), "1.2.3.4");
-    BOOST_CHECK_EQUAL(BoostAsioToCNetAddr(boost::asio::ip::address::from_string("127.0.0.1")).ToString(), "127.0.0.1");
-    // Check IPv6 addresses
-    BOOST_CHECK_EQUAL(BoostAsioToCNetAddr(boost::asio::ip::address::from_string("::1")).ToString(), "::1");
-    BOOST_CHECK_EQUAL(BoostAsioToCNetAddr(boost::asio::ip::address::from_string("123:4567:89ab:cdef:123:4567:89ab:cdef")).ToString(),
-                                         "123:4567:89ab:cdef:123:4567:89ab:cdef");
-    // v4 compatible must be interpreted as IPv4
-    BOOST_CHECK_EQUAL(BoostAsioToCNetAddr(boost::asio::ip::address::from_string("::0:127.0.0.1")).ToString(), "127.0.0.1");
-    // v4 mapped must be interpreted as IPv4
-    BOOST_CHECK_EQUAL(BoostAsioToCNetAddr(boost::asio::ip::address::from_string("::ffff:127.0.0.1")).ToString(), "127.0.0.1");
-}
-
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
By merging the independent BoostAsioToCNetAddr() function, this makes things a little bit more straightforward and clearer I think.

This is a renew of PR 4301 (https://github.com/bitcoin/bitcoin/pull/4301), the only change is to pre-declare the boost::asio::ip::address class instead of including asio.hpp in netbase.h to avoid increasing compiling time of those source files including it.

Signed-off-by: Huang Le 4tarhl@gmail.com
