### PR TITLE
Fix CreateTransaction in the voluntary fee case

### DIFF
--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1233,7 +1233,7 @@ bool CWallet::CreateTransaction(const vector<pair<CScript, int64_t> >& vecSend,
     {
         LOCK2(cs_main, cs_wallet);
         {
-            nFeeRet = payTxFee.GetFeePerK();
+            nFeeRet = 0; // We do not know the txsize yet, so start with zero, even if we pay a voluntary fee (loop will always continue in that case)
             while (true)
             {
                 wtxNew.vin.clear();


### PR DESCRIPTION
A low priority tx of 226 bytes now pays 2260 satoshis in fee because of #3959.
But if you set the voluntary fee to 10000 satoshis per kilobyte, CreateTransaction adds 10000 satoshis as fee instead of 2260.

At the end of the loop we check both, nMinFee and nPayFee, so start the loop always with zero fee.
