### PR TITLE
Fixed dependancy name on homebrew

### DIFF
--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -74,7 +74,7 @@ Instructions: Homebrew
 
 #### Install dependencies using Homebrew
 
-        brew install autoconf automake berkeley-db4 boost miniupnpc openssl pkg-config protobuf qt
+        brew install autoconf automake db48 boost miniupnpc openssl pkg-config protobuf qt
 
 Note: After you have installed the dependencies, you should check that the Homebrew installed version of OpenSSL is the one available for compilation. You can check this by typing
 


### PR DESCRIPTION
Homebrew does not have a package berkely-db4.  It is called db48
