### PR TITLE
libc/libstdc++ sanity checks

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -368,7 +368,7 @@ if test x$TARGET_OS = xdarwin; then
   AX_CHECK_LINK_FLAG([[-Wl,-dead_strip]], [LDFLAGS="$LDFLAGS -Wl,-dead_strip"])
 fi
 
-AC_CHECK_HEADERS([stdio.h stdlib.h unistd.h strings.h sys/types.h sys/stat.h])
+AC_CHECK_HEADERS([stdio.h stdlib.h unistd.h strings.h sys/types.h sys/stat.h sys/select.h])
 
 dnl Check for MSG_NOSIGNAL
 AC_MSG_CHECKING(for MSG_NOSIGNAL)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -85,7 +85,8 @@ BITCOIN_CORE_H = \
   util.h \
   version.h \
   walletdb.h \
-  wallet.h
+  wallet.h \
+  compat/sanity.h
 
 JSON_H = \
   json/json_spirit.h \
@@ -154,6 +155,8 @@ libbitcoin_common_a_SOURCES = \
   sync.cpp \
   util.cpp \
   version.cpp \
+  compat/glibc_sanity.cpp \
+  compat/glibcxx_sanity.cpp \
   $(BITCOIN_CORE_H)
 
 if GLIBC_BACK_COMPAT

--- a/src/compat/glibc_sanity.cpp
+++ b/src/compat/glibc_sanity.cpp
@@ -1,0 +1,61 @@
+#include "bitcoin-config.h"
+
+#include <cstddef>
+#if defined(HAVE_SYS_SELECT_H)
+#include <sys/select.h>
+#endif
+
+extern "C" void* memcpy(void* a, const void* b, size_t c);
+void* memcpy_int(void* a, const void* b, size_t c)
+{
+  return memcpy(a,b,c);
+}
+
+namespace {
+// trigger: Use the memcpy_int wrapper which calls our internal memcpy.
+//   A direct call to memcpy may be optimized away by the compiler.
+// test: Fill an array with a sequence of integers. memcpy to a new empty array.
+//   Verify that the arrays are equal. Use an odd size to decrease the odds of
+//   the call being optimized away.
+template <unsigned int T>
+bool sanity_test_memcpy()
+{
+    unsigned int memcpy_test[T];
+    unsigned int memcpy_verify[T] = {};
+    for (unsigned int i = 0; i != T; ++i)
+        memcpy_test[i] = i;
+
+    memcpy_int(memcpy_verify,memcpy_test,sizeof(memcpy_test));
+
+    for (unsigned int i = 0; i != T; ++i)
+    {
+        if(memcpy_verify[i] != i)
+            return false;
+    }
+    return true;
+}
+
+#if defined(HAVE_SYS_SELECT_H)
+// trigger: Call FD_SET to trigger __fdelt_chk. FORTIFY_SOURCE must be defined
+//   as >0 and optimizations must be set to at least -O2.
+// test: Add a file descriptor to an empty fd_set. Verify that it has been
+//   correctly added.
+bool sanity_test_fdelt()
+{
+    fd_set fds;
+    FD_ZERO(&fds);
+    FD_SET(0, &fds);
+    return FD_ISSET(0,&fds);
+}
+#endif
+
+} // anon namespace
+
+bool glibc_sanity_test()
+{
+#if defined(HAVE_SYS_SELECT_H)
+    if (!sanity_test_fdelt())
+        return false;
+#endif
+    return sanity_test_memcpy<1025>();
+}

--- a/src/compat/glibcxx_sanity.cpp
+++ b/src/compat/glibcxx_sanity.cpp
@@ -1,0 +1,61 @@
+#include <locale>
+#include <list>
+#include <stdexcept>
+
+namespace{
+
+// trigger: use ctype<char>::widen to trigger ctype<char>::_M_widen_init().
+// test: convert a char from narrow to wide and back. Verify that the result
+//   matches the original.
+bool sanity_test_widen(char testchar)
+{
+    const std::ctype<char>& test(std::use_facet< std::ctype<char> >(std::locale()));
+    return test.narrow(test.widen(testchar),'b') == testchar;
+}
+
+// trigger: use list::push_back and list::pop_back to trigger _M_hook and
+//   _M_unhook.
+// test: Push a sequence of integers into a list. Pop them off and verify that
+//   they match the original sequence.
+bool sanity_test_list(unsigned int size)
+{
+    std::list<unsigned int> test;
+    for (unsigned int i = 0; i != size; ++i)
+        test.push_back(i+1);
+
+    if (test.size() != size)
+        return false;
+
+    while (!test.empty())
+    {
+        if(test.back() != test.size())
+            return false;
+        test.pop_back();
+    }
+    return true;
+}
+
+} // anon namespace
+
+// trigger: string::at(x) on an empty string to trigger __throw_out_of_range_fmt.
+// test: force std::string to throw an out_of_range exception. Verify that
+//   it's caught correctly.
+bool sanity_test_range_fmt()
+{
+    std::string test;
+    try
+    {
+        test.at(1);
+    }
+    catch (const std::out_of_range&)
+    {
+        return true;
+    }
+    catch (...){}
+    return false;
+}
+
+bool glibcxx_sanity_test()
+{
+    return sanity_test_widen('a') && sanity_test_list(100) && sanity_test_range_fmt();
+}

--- a/src/compat/sanity.h
+++ b/src/compat/sanity.h
@@ -1,0 +1,7 @@
+#ifndef BITCON_COMPAT_SANITY_H
+#define BITCON_COMPAT_SANITY_H
+
+bool glibc_sanity_test();
+bool glibcxx_sanity_test();
+
+#endif

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -31,6 +31,7 @@
 #ifndef WIN32
 #include <signal.h>
 #endif
+#include "compat/sanity.h"
 
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/filesystem.hpp>
@@ -417,8 +418,8 @@ bool InitSanityCheck(void)
                   "information, visit https://en.bitcoin.it/wiki/OpenSSL_and_EC_Libraries");
         return false;
     }
-
-    // TODO: remaining sanity checks, see #4081
+    if (!glibc_sanity_test() || !glibcxx_sanity_test())
+        return false;
 
     return true;
 }


### PR DESCRIPTION
Addresses #4081.

These are always enabled on all platforms, with the exception of the FD_SET test, which is irrelevant on platforms that don't use select().

Great care was taken to ensure that the tests (memcpy in particular) are not optimized away by the compiler, which would obviously defeat the purpose of the runtime checks.
