### PR TITLE
Add `-stopafterblockimport` option

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -273,6 +273,7 @@ std::string HelpMessage(HelpMessageMode hmm)
         strUsage += "  -dropmessagestest=<n>  " + _("Randomly drop 1 of every <n> network messages") + "\n";
         strUsage += "  -fuzzmessagestest=<n>  " + _("Randomly fuzz 1 of every <n> network messages") + "\n";
         strUsage += "  -flushwallet           " + _("Run a thread to flush wallet periodically (default: 1)") + "\n";
+        strUsage += "  -stopafterblockimport  " + _("Stop running after importing blocks from disk (default: 0)") + "\n";
     }
     strUsage += "  -debug=<category>      " + _("Output debugging information (default: 0, supplying <category> is optional)") + "\n";
     strUsage += "                         " + _("If <category> is not supplied, output all debugging information.") + "\n";
@@ -403,6 +404,11 @@ void ThreadImport(std::vector<boost::filesystem::path> vImportFiles)
         } else {
             LogPrintf("Warning: Could not open blocks file %s\n", path.string());
         }
+    }
+
+    if (GetBoolArg("-stopafterblockimport", false)) {
+        LogPrintf("Stopping after block import\n");
+        StartShutdown();
     }
 }
 


### PR DESCRIPTION
Stop after importing blocks. This can be useful for development, batch testing and trouble shooting.
