### PR TITLE
build: gitian-osx: remove old hard-coded sdk path

### DIFF
--- a/contrib/gitian-descriptors/gitian-osx-bitcoin.yml
+++ b/contrib/gitian-descriptors/gitian-osx-bitcoin.yml
@@ -18,8 +18,8 @@ remotes:
   "dir": "bitcoin"
 files:
 - "osx-native-depends-r3.tar.gz"
-- "osx-depends-r4.tar.gz"
-- "osx-depends-qt-5.2.1-r4.tar.gz"
+- "osx-depends-r5.tar.gz"
+- "osx-depends-qt-5.2.1-r5.tar.gz"
 - "MacOSX10.7.sdk.tar.gz"
 
 script: |
@@ -37,8 +37,8 @@ script: |
   tar -C osx-cross-depends/SDKs -xf ${SOURCES_PATH}/MacOSX10.7.sdk.tar.gz
 
   tar -C osx-cross-depends -xf osx-native-depends-r3.tar.gz
-  tar -C osx-cross-depends -xf osx-depends-r4.tar.gz
-  tar -C osx-cross-depends -xf osx-depends-qt-5.2.1-r4.tar.gz
+  tar -C osx-cross-depends -xf osx-depends-r5.tar.gz
+  tar -C osx-cross-depends -xf osx-depends-qt-5.2.1-r5.tar.gz
   export PATH=`pwd`/osx-cross-depends/native-prefix/bin:$PATH
 
   cd bitcoin

--- a/contrib/gitian-descriptors/gitian-osx-depends.yml
+++ b/contrib/gitian-descriptors/gitian-osx-depends.yml
@@ -30,7 +30,7 @@ script: |
   echo "13bfc5ae543cf3aa180ac2485c0bc89495e3ae711fc6fab4f8ffe90dfb4bb677  protobuf-2.5.0.tar.bz2" | sha256sum -c
   echo "dfd71487513c871bad485806bfd1fdb304dedc84d2b01a8fb8e0940b50597a98  qrencode-3.4.3.tar.bz2" | sha256sum -c
 
-  REVISION=r4
+  REVISION=r5
   export SOURCES_PATH=`pwd`
   export TAR_OPTIONS="-m --mtime="$REFERENCE_DATE\\\ $REFERENCE_TIME""
   export PATH=$HOME:$PATH
@@ -49,8 +49,7 @@ script: |
 
   INT_CFLAGS="-target ${HOST} -mmacosx-version-min=${MIN_VERSION} --sysroot ${SDK} -msse2 -Qunused-arguments"
   INT_CXXFLAGS="${INT_CFLAGS}"
-  INT_LDFLAGS="-L${PREFIX}/lib -L${SDK}/usr/lib/i686-apple-darwin10/4.2.1"
-  INT_LDFLAGS_CLANG="-B${NATIVEPREFIX}/bin"
+  INT_LDFLAGS="-L${PREFIX}/lib"
   INT_CPPFLAGS="-I${PREFIX}/include"
   INT_CC=clang
   INT_CXX=clang++
@@ -82,7 +81,7 @@ script: |
   sed -i 's/__atomic_compare_exchange/__atomic_compare_exchange_db/g' ${BUILD_DIR}/dbinc/atomic.h
   pushd ${BUILD_DIR}
   cd build_unix;
-  ../dist/configure --host=${HOST} --prefix="${PREFIX}" --disable-shared --enable-cxx CC="${INT_CC}" CXX="${INT_CXX}" AR="${INT_AR}" RANLIB="${INT_RANLIB}" OBJC="${INT_OBJC}" OBJCXX="${INT_OBJCXX}" CFLAGS="${INT_CFLAGS}" CXXFLAGS="${INT_CXXFLAGS}" LDFLAGS="${INT_CLANG_LDFLAGS} ${INT_LDFLAGS}" CPPFLAGS="${INT_CPPFLAGS}"
+  ../dist/configure --host=${HOST} --prefix="${PREFIX}" --disable-shared --enable-cxx CC="${INT_CC}" CXX="${INT_CXX}" AR="${INT_AR}" RANLIB="${INT_RANLIB}" OBJC="${INT_OBJC}" OBJCXX="${INT_OBJCXX}" CFLAGS="${INT_CFLAGS}" CXXFLAGS="${INT_CXXFLAGS}" LDFLAGS="${INT_LDFLAGS}" CPPFLAGS="${INT_CPPFLAGS}"
   make $MAKEOPTS libdb.a libdb_cxx.a
   make  install_lib install_include
   popd
@@ -95,7 +94,7 @@ script: |
   pushd ${BUILD_DIR}
   sed -ie "s|cc:|${INT_CC}:|" ${BUILD_DIR}/Configure
   sed -ie "s|\(-arch [_a-zA-Z0-9]*\)|\1 --sysroot ${SDK}  -target ${HOST} -msse2|" ${BUILD_DIR}/Configure
-  AR="${INT_AR}" RANLIB="${INT_RANLIB}" ./Configure --prefix=${PREFIX} --openssldir=${PREFIX}/etc/openssl zlib shared no-krb5 darwin64-x86_64-cc ${INT_LDFLAGS} ${INT_CLANG_LDFLAGS} ${INT_CPPFLAGS}
+  AR="${INT_AR}" RANLIB="${INT_RANLIB}" ./Configure --prefix=${PREFIX} --openssldir=${PREFIX}/etc/openssl zlib shared no-krb5 darwin64-x86_64-cc ${INT_LDFLAGS} ${INT_CPPFLAGS}
   sed -i "s|engines apps test|engines|" ${BUILD_DIR}/Makefile
   sed -i "/define DATE/d" ${BUILD_DIR}/crypto/Makefile
   make -j1 build_libs libcrypto.pc libssl.pc openssl.pc
@@ -123,7 +122,7 @@ script: |
   # m4 folder is not included in the stable release, which can confuse aclocal
   # if its timestamp ends up being earlier than configure.ac when extracted
   touch aclocal.m4
-  ./configure --host=${HOST} --prefix="${PREFIX}" --disable-shared CC="${INT_CC}" CXX="${INT_CXX}" AR="${INT_AR}" RANLIB="${INT_RANLIB}" OBJC="${INT_OBJC}" OBJCXX="${INT_OBJCXX}" CFLAGS="${INT_CFLAGS}" CXXFLAGS="${INT_CXXFLAGS}" LDFLAGS="${INT_CLANG_LDFLAGS} ${INT_LDFLAGS}" CPPFLAGS="${INT_CPPFLAGS}" --disable-shared -without-tools --disable-sdltest --disable-dependency-tracking
+  ./configure --host=${HOST} --prefix="${PREFIX}" --disable-shared CC="${INT_CC}" CXX="${INT_CXX}" AR="${INT_AR}" RANLIB="${INT_RANLIB}" OBJC="${INT_OBJC}" OBJCXX="${INT_OBJCXX}" CFLAGS="${INT_CFLAGS}" CXXFLAGS="${INT_CXXFLAGS}" LDFLAGS="${INT_LDFLAGS}" CPPFLAGS="${INT_CPPFLAGS}" --disable-shared -without-tools --disable-sdltest --disable-dependency-tracking
   make $MAKEOPTS
   make install
   popd
@@ -134,7 +133,7 @@ script: |
 
   tar -C ${BUILD_BASE} -xjf ${SOURCE_FILE}
   pushd ${BUILD_DIR}
-  ./configure --host=${HOST} --prefix="${PREFIX}" --disable-shared --enable-cxx CC="${INT_CC}" CXX="${INT_CXX}" AR="${INT_AR}" RANLIB="${INT_RANLIB}" OBJC="${INT_OBJC}" OBJCXX="${INT_OBJCXX}" CFLAGS="${INT_CFLAGS}" CXXFLAGS="${INT_CXXFLAGS}" LDFLAGS="${INT_CLANG_LDFLAGS} ${INT_LDFLAGS}" CPPFLAGS="${INT_CPPFLAGS}" --enable-shared=no --disable-dependency-tracking --with-protoc=${NATIVEPREFIX}/bin/protoc
+  ./configure --host=${HOST} --prefix="${PREFIX}" --disable-shared --enable-cxx CC="${INT_CC}" CXX="${INT_CXX}" AR="${INT_AR}" RANLIB="${INT_RANLIB}" OBJC="${INT_OBJC}" OBJCXX="${INT_OBJCXX}" CFLAGS="${INT_CFLAGS}" CXXFLAGS="${INT_CXXFLAGS}" LDFLAGS="${INT_LDFLAGS}" CPPFLAGS="${INT_CPPFLAGS}" --enable-shared=no --disable-dependency-tracking --with-protoc=${NATIVEPREFIX}/bin/protoc
   cd src
   make $MAKEOPTS libprotobuf.la
   make install-libLTLIBRARIES install-nobase_includeHEADERS
@@ -149,7 +148,7 @@ script: |
   tar -C ${BUILD_BASE} -xf ${SOURCE_FILE}
   pushd ${BUILD_DIR}
   ./bootstrap.sh --with-libraries=chrono,filesystem,program_options,system,thread,test
-  echo "using darwin : : ${INT_CXX} : <cxxflags>\"${INT_CFLAGS} ${INT_CPPFLAGS}\" <linkflags>\"${INT_LDFLAGS} ${INT_CLANG_LDFLAGS}\" <archiver>\"${INT_LIBTOOL}\" <striper>\"${INT_STRIP}\" : ;" > "user-config.jam"
+  echo "using darwin : : ${INT_CXX} : <cxxflags>\"${INT_CFLAGS} ${INT_CPPFLAGS}\" <linkflags>\"${INT_LDFLAGS}\" <archiver>\"${INT_LIBTOOL}\" <striper>\"${INT_STRIP}\" : ;" > "user-config.jam"
   ./b2 -d2 --layout=tagged --build-type=complete --prefix="${PREFIX}" --toolset=darwin-4.2.1 --user-config=user-config.jam variant=release threading=multi link=static install
   popd
 

--- a/contrib/gitian-descriptors/gitian-osx-qt.yml
+++ b/contrib/gitian-descriptors/gitian-osx-qt.yml
@@ -14,14 +14,14 @@ remotes: []
 files:
 - "qt-everywhere-opensource-src-5.2.1.tar.gz"
 - "osx-native-depends-r3.tar.gz"
-- "osx-depends-r4.tar.gz"
+- "osx-depends-r5.tar.gz"
 - "MacOSX10.7.sdk.tar.gz"
 
 script: |
 
   echo "84e924181d4ad6db00239d87250cc89868484a14841f77fb85ab1f1dbdcd7da1  qt-everywhere-opensource-src-5.2.1.tar.gz" | sha256sum -c
 
-  REVISION=r4
+  REVISION=r5
   export SOURCES_PATH=`pwd`
   export TAR_OPTIONS="-m --mtime="$REFERENCE_DATE\\\ $REFERENCE_TIME""
   export ZERO_AR_DATE=1
@@ -47,8 +47,7 @@ script: |
 
   INT_CFLAGS="-target ${HOST} -mmacosx-version-min=${MIN_VERSION} --sysroot ${SDK} -msse2 -Qunused-arguments"
   INT_CXXFLAGS="${INT_CFLAGS}"
-  INT_LDFLAGS="-L${PREFIX}/lib -L${SDK}/usr/lib/i686-apple-darwin10/4.2.1"
-  INT_LDFLAGS_CLANG="-B${NATIVEPREFIX}/bin"
+  INT_LDFLAGS="-L${PREFIX}/lib"
   INT_CPPFLAGS="-I${PREFIX}/include"
   INT_CC=clang
   INT_CXX=clang++
@@ -73,7 +72,7 @@ script: |
   tar xf /home/ubuntu/build/osx-native-depends-r3.tar.gz
 
   export PATH=`pwd`/native-prefix/bin:$PATH
-  tar xf /home/ubuntu/build/osx-depends-r4.tar.gz
+  tar xf /home/ubuntu/build/osx-depends-r5.tar.gz
 
   SOURCE_FILE=${SOURCES_PATH}/qt-everywhere-opensource-src-5.2.1.tar.gz
   BUILD_DIR=${BUILD_BASE}/qt-everywhere-opensource-src-5.2.1


### PR DESCRIPTION
This path was added to work around a bug in the 10.6 sdk that is no longer
present in 10.7 or later. Also, remove the -B path in LDFLAGS, since it's not
needed and wasn't used anyway.

Bumped revisions because the intermediates change, but the final dmg is
unaffected.
