### PR TITLE
Added encryptwallet call to bitrpc.py

### DIFF
--- a/contrib/bitrpc/bitrpc.py
+++ b/contrib/bitrpc/bitrpc.py
@@ -22,6 +22,18 @@ if cmd == "backupwallet":
         print access.backupwallet(path)
     except:
         print "\n---An error occurred---\n"
+        
+elif cmd == "encryptwallet":
+    try:
+        pwd = getpass.getpass(prompt="Enter passphrase: ")
+        pwd2 = getpass.getpass(prompt="Repeat passphrase: ")
+        if pwd == pwd2:
+            access.encryptwallet(pwd)
+            print "\n---Wallet encrypted. Server stopping, restart to run with encrypted wallet---\n"
+        else:
+            print "\n---Passphrases do not match---\n"
+    except:
+        print "\n---An error occurred---\n"
 
 elif cmd == "getaccount":
     try:


### PR DESCRIPTION
This was the only call requiring password input which was still missing. Much useful to avoid leaving a plain text passphrase in the shell log.
