### PR TITLE
Ignore and log errors during RPC cancel

### DIFF
--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -642,7 +642,6 @@ void StartRPCThreads()
         LogPrintf("Binding RPC on address %s port %i (IPv4+IPv6 bind any: %i)\n", bindAddress.to_string(), endpoint.port(), bBindAny);
         boost::system::error_code v6_only_error;
         boost::shared_ptr<ip::tcp::acceptor> acceptor(new ip::tcp::acceptor(*rpc_io_service));
-        rpc_acceptors.push_back(acceptor);
 
         try {
             acceptor->open(endpoint.protocol());
@@ -658,6 +657,7 @@ void StartRPCThreads()
             RPCListen(acceptor, *rpc_ssl_context, fUseSSL);
 
             fListening = true;
+            rpc_acceptors.push_back(acceptor);
             // If dual IPv6/IPv4 bind succesful, skip binding to IPv4 separately
             if(bBindAny && bindAddress == asio::ip::address_v6::any() && !v6_only_error)
                 break;

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -700,11 +700,20 @@ void StopRPCThreads()
     // First, cancel all timers and acceptors
     // This is not done automatically by ->stop(), and in some cases the destructor of
     // asio::io_service can hang if this is skipped.
+    boost::system::error_code ec;
     BOOST_FOREACH(const boost::shared_ptr<ip::tcp::acceptor> &acceptor, rpc_acceptors)
-        acceptor->cancel();
+    {
+        acceptor->cancel(ec);
+        if (ec)
+            LogPrintf("%s: Warning: %s when cancelling acceptor", __func__, ec.message());
+    }
     rpc_acceptors.clear();
     BOOST_FOREACH(const PAIRTYPE(std::string, boost::shared_ptr<deadline_timer>) &timer, deadlineTimers)
-        timer.second->cancel();
+    {
+        timer.second->cancel(ec);
+        if (ec)
+            LogPrintf("%s: Warning: %s when cancelling timer", __func__, ec.message());
+    }
     deadlineTimers.clear();
 
     rpc_io_service->stop();


### PR DESCRIPTION
Cancelling the RPC acceptors can sometimes result in an error about a bad file descriptor.

As this is the shutdown sequence we need to continue nevertheless, ignore these errors, log a warning and proceed.

As suggested by @theuni.

Fixes #4352.
