### PR TITLE
Getrawtransactionsinblock

### DIFF
--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -261,6 +261,9 @@ static const CRPCCommand vRPCCommands[] =
     { "decoderawtransaction",   &decoderawtransaction,   false,     false,      false },
     { "decodescript",           &decodescript,           false,     false,      false },
     { "getrawtransaction",      &getrawtransaction,      false,     false,      false },
+    { "getrawtransactionsinblock",
+                                &getrawtransactionsinblock,
+                                                         false,     false,      false },
     { "sendrawtransaction",     &sendrawtransaction,     false,     false,      false },
     { "signrawtransaction",     &signrawtransaction,     false,     false,      false }, /* uses wallet if enabled */
 

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -174,6 +174,7 @@ extern json_spirit::Value getblockchaininfo(const json_spirit::Array& params, bo
 extern json_spirit::Value getnetworkinfo(const json_spirit::Array& params, bool fHelp);
 
 extern json_spirit::Value getrawtransaction(const json_spirit::Array& params, bool fHelp); // in rcprawtransaction.cpp
+extern json_spirit::Value getrawtransactionsinblock(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value listunspent(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value lockunspent(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value listlockunspent(const json_spirit::Array& params, bool fHelp);

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -57,6 +57,9 @@ BOOST_AUTO_TEST_CASE(rpc_rawparams)
     BOOST_CHECK_THROW(CallRPC("getrawtransaction not_hex"), runtime_error);
     BOOST_CHECK_THROW(CallRPC("getrawtransaction a3b807410df0b60fcb9736768df5823938b2f838694939ba45f3c0a1bff150ed not_int"), runtime_error);
 
+    BOOST_CHECK_THROW(CallRPC("getrawtransactionsinblock"), runtime_error);
+    BOOST_CHECK_THROW(CallRPC("getrawtransactionsinblock not_valid_block"), runtime_error);
+
     BOOST_CHECK_THROW(CallRPC("createrawtransaction"), runtime_error);
     BOOST_CHECK_THROW(CallRPC("createrawtransaction null null"), runtime_error);
     BOOST_CHECK_THROW(CallRPC("createrawtransaction not_array"), runtime_error);


### PR DESCRIPTION
This adds a new 'getrawtransactionsinblock' rpc command.
The use case for this is essentially for any application that connects over RPC to process transactions in each new block, as they come in (for example, for a wallet application).
(I use this in the SwapBill client, but essentially just because the SwapBill client needs to maintain it's own wallet separately from the wallet in bitcoind or litecoind.)
This is only possible through the current RPC interface if txindex is turned on. But in fact a full transaction index should not be necessary for this, because we already know the hash of the block containing the transactions.
A second reason is then that it is also much more efficient to obtain all of the transactions in a block this way, rather than querying for the set of txids in a block and then making a whole bunch of calls to getrawtransaction.
See https://bitcointalk.org/index.php?topic=630370.0 for some more discussion!
