### PR TITLE
Allow peers to determine how much they are seen to be misbehaving.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -196,6 +196,8 @@ struct CBlockReject {
 struct CNodeState {
     // Accumulated misbehaviour score for this peer.
     int nMisbehavior;
+    // Last change to misbehaviour score for this peer.
+    int nMisbehaveDelta;
     // Whether this peer should be disconnected and banned.
     bool fShouldBan;
     // String name of this peer (debugging/logging purposes).
@@ -211,6 +213,7 @@ struct CNodeState {
 
     CNodeState() {
         nMisbehavior = 0;
+        nMisbehaveDelta = 0;
         fShouldBan = false;
         nBlocksToDownload = 0;
         nBlocksInFlight = 0;
@@ -1416,6 +1419,7 @@ void Misbehaving(NodeId pnode, int howmuch)
         return;
 
     state->nMisbehavior += howmuch;
+    state->nMisbehaveDelta = howmuch;
     if (state->nMisbehavior >= GetArg("-banscore", 100))
     {
         LogPrintf("Misbehaving: %s (%d -> %d) BAN THRESHOLD EXCEEDED\n", state->name, state->nMisbehavior-howmuch, state->nMisbehavior);
@@ -3607,6 +3611,11 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
         pfrom->SetRecvVersion(min(pfrom->nVersion, PROTOCOL_VERSION));
     }
 
+    else if (strCommand == "misbehave") {
+        int howmuch;
+        vRecv >> howmuch;
+        LogPrint("net", "peer=%d says we are misbehaving %d\n", pfrom->id, howmuch);
+    }
 
     else if (strCommand == "addr")
     {
@@ -4364,6 +4373,10 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
         }
 
         CNodeState &state = *State(pto->GetId());
+        if (state.nMisbehaveDelta) {
+            pto->PushMessage("misbehave", state.nMisbehaveDelta);
+            state.nMisbehaveDelta = 0;
+        }
         if (state.fShouldBan) {
             if (pto->addr.IsLocal())
                 LogPrintf("Warning: not banning local node %s!\n", pto->addr.ToString());


### PR DESCRIPTION
This can allow peers in future to modify their behaviour to avoid netsplits.
