### PR TITLE
Fix RandAddSeedPerfMon and move large stack objects to heap

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -168,15 +168,14 @@ void RandAddSeedPerfmon()
 #ifdef WIN32
     // Don't need this on Linux, OpenSSL automatically uses /dev/urandom
     // Seed with the entire set of perfmon data
-    unsigned char pdata[250000];
-    memset(pdata, 0, sizeof(pdata));
-    unsigned long nSize = sizeof(pdata);
-    long ret = RegQueryValueExA(HKEY_PERFORMANCE_DATA, "Global", NULL, NULL, pdata, &nSize);
+    std::vector <unsigned char> vData(250000,0);
+    unsigned long nSize = vData.size();
+    long ret = RegQueryValueExA(HKEY_PERFORMANCE_DATA, "Global", NULL, NULL, begin_ptr(vData), &nSize);
     RegCloseKey(HKEY_PERFORMANCE_DATA);
     if (ret == ERROR_SUCCESS)
     {
-        RAND_add(pdata, nSize, nSize/100.0);
-        OPENSSL_cleanse(pdata, nSize);
+        RAND_add(begin_ptr(vData), nSize, nSize/100.0);
+        OPENSSL_cleanse(begin_ptr(vData), nSize);
         LogPrint("rand", "RandAddSeed() %lu bytes\n", nSize);
     }
 #endif
@@ -1141,15 +1140,15 @@ void ShrinkDebugFile()
     if (file && boost::filesystem::file_size(pathLog) > 10 * 1000000)
     {
         // Restart the file with some of the end
-        char pch[200000];
-        fseek(file, -sizeof(pch), SEEK_END);
-        int nBytes = fread(pch, 1, sizeof(pch), file);
+        std::vector <char> vch(200000,0);
+        fseek(file, -vch.size(), SEEK_END);
+        int nBytes = fread(begin_ptr(vch), 1, vch.size(), file);
         fclose(file);
 
         file = fopen(pathLog.string().c_str(), "w");
         if (file)
         {
-            fwrite(pch, 1, nBytes, file);
+            fwrite(begin_ptr(vch), 1, nBytes, file);
             fclose(file);
         }
     }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -176,7 +176,14 @@ void RandAddSeedPerfmon()
     {
         RAND_add(begin_ptr(vData), nSize, nSize/100.0);
         OPENSSL_cleanse(begin_ptr(vData), nSize);
-        LogPrint("rand", "RandAddSeed() %lu bytes\n", nSize);
+        LogPrint("rand", "%s: %lu bytes\n", __func__, nSize);
+    } else {
+        static bool warned = false; // Warn only once
+        if (!warned)
+        {
+            LogPrintf("%s: Warning: RegQueryValueExA(HKEY_PERFORMANCE_DATA) failed with code %i\n", __func__, ret);
+            warned = true;
+        }
     }
 #endif
 }


### PR DESCRIPTION
Rebased version of #4236 by @arowser, changed to use begin_ptr from #4293. Also use vXXXX variable name syntax for the vectors...

**Testing:** I'm a bit wary to merge as it affects entropy collection for randomness. I'd like someone with windows to verify that this does the right thing (so, start with `-debug=rand` and look for the `RandAddSeed() XXX bytes` message).
