### PR TITLE
Remove unnecessary pow updates in rpc

### DIFF
--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -365,10 +365,6 @@ Value getblocktemplate(const Array& params, bool fHelp)
     }
     CBlock* pblock = &pblocktemplate->block; // pointer for convenience
 
-    // Update nTime
-    UpdateTime(*pblock, pindexPrev);
-    pblock->nNonce = 0;
-
     Array transactions;
     map<uint256, int64_t> setTxIndex;
     int i = 0;


### PR DESCRIPTION
The time is already set in CreateNewBlock and the nonce is set to zero for no reason (never used after that assignment).
In testnet mode the nbits (and thefore target, which is the same with another type) could be affected in testnet mode after finding the block with that additional UpdateTime (which may update nBits), which doesn't seem very safe.
This is not tested yet, but seems straightforward to review and test.
