### PR TITLE
qa/rpc_tests: Wait for handshake to complete in connect_nodes

### DIFF
--- a/qa/rpc-tests/util.py
+++ b/qa/rpc-tests/util.py
@@ -182,6 +182,10 @@ def wait_bitcoinds():
 def connect_nodes(from_connection, node_num):
     ip_port = "127.0.0.1:"+str(p2p_port(node_num))
     from_connection.addnode(ip_port, "onetry")
+    # poll until version handshake complete to avoid race conditions
+    # with transaction relaying
+    while any(peer['version'] == 0 for peer in from_connection.getpeerinfo()):
+        time.sleep(0.1)
 
 def find_output(node, txid, amount):
     """


### PR DESCRIPTION
This avoids a race condition in which the connection was made but the version handshake is not completed yet. In that case transactions won't be broadcasted to a peer yet, and the nodes will wait forever for their mempools to sync.
