### PR TITLE
ensure clean and consistent "namespace" usage

### DIFF
--- a/doc/coding.md
+++ b/doc/coding.md
@@ -4,44 +4,65 @@ Coding
 Please be consistent with the existing coding style.
 
 Block style:
+```c++
+    bool Function(char* psz, int n)
+    {
+        // Comment summarising what this section of code does
+        for (int i = 0; i < n; i++)
+        {
+            // When something fails, return early
+            if (!Something())
+                return false;
+            ...
+        }
 
-	bool Function(char* psz, int n)
-	{
-	    // Comment summarising what this section of code does
-	    for (int i = 0; i < n; i++)
-	    {
-	        // When something fails, return early
-	        if (!Something())
-	            return false;
-	        ...
-	    }
-	
-	    // Success return is usually at the end
-	    return true;
-	}
-
+        // Success return is usually at the end
+        return true;
+    }
+```
 - ANSI/Allman block style
 - 4 space indenting, no tabs
 - No extra spaces inside parenthesis; please don't do ( this )
 - No space after function names, one space after if, for and while
+- Includes need to be ordered alphabetically, separate own and foreign headers with a new-line (example key.cpp):
+```c++
+#include "key.h"
 
+#include "crypto/sha2.h"
+#include "util.h"
+
+#include <openssl/foo.h>
+```
+- Class or struct keywords in header files need to be ordered alphabetically:
+```c++
+class CAlpha;
+class CBeta;
+```
+- When using namespace keyword use the following form:
+```c++
+namespace Foo {
+
+...
+
+} // Foo
+```
 Variable names begin with the type in lowercase, like nSomeVariable.
 Please don't put the first word of the variable name in lowercase like
 someVariable.
 
 Common types:
 
-	n       integer number: short, unsigned short, int, unsigned int, int64, uint64, sometimes char if used as a number
-	d       double, float
-	f       flag
-	hash    uint256
-	p       pointer or array, one p for each level of indirection
-	psz     pointer to null terminated string
-	str     string object
-	v       vector or similar list objects
-	map     map or multimap
-	set     set or multiset
-	bn      CBigNum
+    n       integer number: short, unsigned short, int, unsigned int, int64, uint64, sometimes char if used as a number
+    d       double, float
+    f       flag
+    hash    uint256
+    p       pointer or array, one p for each level of indirection
+    psz     pointer to null terminated string
+    str     string object
+    v       vector or similar list objects
+    map     map or multimap
+    set     set or multiset
+    bn      CBigNum
 
 Doxygen comments
 -----------------

--- a/src/base58.cpp
+++ b/src/base58.cpp
@@ -186,6 +186,7 @@ int CBase58Data::CompareTo(const CBase58Data& b58) const {
 }
 
 namespace {
+
     class CBitcoinAddressVisitor : public boost::static_visitor<bool> {
     private:
         CBitcoinAddress *addr;
@@ -196,7 +197,8 @@ namespace {
         bool operator()(const CScriptID &id) const { return addr->Set(id); }
         bool operator()(const CNoDestination &no) const { return false; }
     };
-};
+
+} // anon namespace
 
 bool CBitcoinAddress::Set(const CKeyID &id) {
     SetData(Params().Base58Prefix(CChainParams::PUBKEY_ADDRESS), &id, 20);

--- a/src/checkpoints.cpp
+++ b/src/checkpoints.cpp
@@ -12,8 +12,8 @@
 #include <boost/assign/list_of.hpp> // for 'map_list_of()'
 #include <boost/foreach.hpp>
 
-namespace Checkpoints
-{
+namespace Checkpoints {
+
     typedef std::map<int, uint256> MapCheckpoints;
 
     // How many times we expect transactions after the last checkpoint to
@@ -161,4 +161,5 @@ namespace Checkpoints
         }
         return NULL;
     }
-}
+
+} // namespace Checkpoints

--- a/src/checkpoints.h
+++ b/src/checkpoints.h
@@ -13,8 +13,8 @@ class uint256;
 /** Block-chain checkpoints are compiled-in sanity checks.
  * They are updated every release or three.
  */
-namespace Checkpoints
-{
+namespace Checkpoints {
+
     // Returns true if block passes checkpoint checks
     bool CheckBlock(int nHeight, const uint256& hash);
 
@@ -27,6 +27,7 @@ namespace Checkpoints
     double GuessVerificationProgress(CBlockIndex *pindex, bool fSigchecks = true);
 
     extern bool fEnabled;
-}
+
+} //namespace Checkpoints
 
 #endif

--- a/src/init.h
+++ b/src/init.h
@@ -12,7 +12,7 @@ class CWallet;
 
 namespace boost {
     class thread_group;
-};
+} // namespace boost
 
 extern CWallet* pwalletMain;
 

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -377,8 +377,7 @@ const unsigned char vchMaxModHalfOrder[32] = {
 
 const unsigned char vchZero[0] = {};
 
-
-}; // end of anonymous namespace
+} // anon namespace
 
 bool CKey::Check(const unsigned char *vch) {
     return CompareBigEndian(vch, 32, vchZero, 0) > 0 &&

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -72,6 +72,7 @@ const string strMessageMagic = "Bitcoin Signed Message:\n";
 
 // Internal stuff
 namespace {
+
     struct CBlockIndexWorkComparator
     {
         bool operator()(CBlockIndex *pa, CBlockIndex *pb) {
@@ -120,7 +121,8 @@ namespace {
     };
     map<uint256, pair<NodeId, list<QueuedBlock>::iterator> > mapBlocksInFlight;
     map<uint256, pair<NodeId, list<uint256>::iterator> > mapBlocksToDownload;
-}
+
+} // anon namespace
 
 //////////////////////////////////////////////////////////////////////////////
 //
@@ -130,6 +132,7 @@ namespace {
 // These functions dispatch to one or all registered wallets
 
 namespace {
+
 struct CMainSignals {
     // Notifies listeners of updated transaction data (transaction, and optionally the block it is found in.
     boost::signals2::signal<void (const CTransaction &, const CBlock *)> SyncTransaction;
@@ -144,7 +147,8 @@ struct CMainSignals {
     // Tells listeners to broadcast their data.
     boost::signals2::signal<void ()> Broadcast;
 } g_signals;
-}
+
+} // anon namespace
 
 void RegisterWallet(CWalletInterface* pwalletIn) {
     g_signals.SyncTransaction.connect(boost::bind(&CWalletInterface::SyncTransaction, pwalletIn, _1, _2));
@@ -274,7 +278,6 @@ void MarkBlockAsReceived(const uint256 &hash, NodeId nodeFrom = -1) {
             state->nLastBlockReceive = GetTimeMicros();
         mapBlocksInFlight.erase(itInFlight);
     }
-
 }
 
 // Requires cs_main.
@@ -310,7 +313,7 @@ void MarkBlockAsInFlight(NodeId nodeid, const uint256 &hash) {
     mapBlocksInFlight[hash] = std::make_pair(nodeid, it);
 }
 
-}
+} // anon namespace
 
 bool GetNodeStateStats(NodeId nodeid, CNodeStateStats &stats) {
     LOCK(cs_main);

--- a/src/net.h
+++ b/src/net.h
@@ -28,14 +28,13 @@
 #include <boost/signals2/signal.hpp>
 #include <openssl/rand.h>
 
-
 class CAddrMan;
 class CBlockIndex;
 class CNode;
 
 namespace boost {
     class thread_group;
-}
+} // namespace boost
 
 /** Time between pings automatically sent out for latency probing and keepalive (in seconds). */
 static const int PING_INTERVAL = 2 * 60;

--- a/src/script.cpp
+++ b/src/script.cpp
@@ -974,6 +974,7 @@ bool EvalScript(vector<vector<unsigned char> >& stack, const CScript& script, co
 
 
 namespace {
+
 /** Wrapper that serializes like CTransaction, but with the modifications
  *  required for the signature hash done in-place
  */
@@ -1066,7 +1067,8 @@ public:
         ::Serialize(s, txTo.nLockTime, nType, nVersion);
     }
 };
-}
+
+} // anon namespace
 
 uint256 SignatureHash(const CScript &scriptCode, const CTransaction& txTo, unsigned int nIn, int nHashType)
 {
@@ -1091,7 +1093,6 @@ uint256 SignatureHash(const CScript &scriptCode, const CTransaction& txTo, unsig
     ss << txTmp << nHashType;
     return ss.GetHash();
 }
-
 
 // Valid signature cache, to avoid doing expensive ECDSA signature checking
 // twice for every transaction (once when accepted into memory pool, and

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -77,11 +77,12 @@
 // See also: http://stackoverflow.com/questions/10020179/compilation-fail-in-boost-librairies-program-options
 //           http://clang.debian.net/status.php?version=3.0&key=CANNOT_FIND_FUNCTION
 namespace boost {
+
     namespace program_options {
         std::string to_internal(const std::string&);
     }
-}
 
+} // namespace boost
 
 using namespace std;
 


### PR DESCRIPTION
- remove some missplaced ;
- ensure end of a namespace is clearly visible
- use same formatting when using namespace
