### PR TITLE
Track peers' available blocks

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -185,6 +185,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
 
 struct CNodeStateStats {
     int nMisbehavior;
+    int nSyncHeight;
 };
 
 struct CDiskBlockPos

--- a/src/rpcnet.cpp
+++ b/src/rpcnet.cpp
@@ -134,6 +134,7 @@ Value getpeerinfo(const Array& params, bool fHelp)
         obj.push_back(Pair("startingheight", stats.nStartingHeight));
         if (fStateStats) {
             obj.push_back(Pair("banscore", statestats.nMisbehavior));
+            obj.push_back(Pair("syncheight", statestats.nSyncHeight));
         }
         obj.push_back(Pair("syncnode", stats.fSyncNode));
 


### PR DESCRIPTION
A small piece of logic that will be needed in headersfirst: knowing up to which point each peer is synchronized. As we no longer react on specific messages to trigger fetching blocks, but instead actively & asynchronously fetch what we're missing, we must know what we can ask from whom.

This is not very useful now, except that it adds 'syncheight' to getpeerinfo (which is much more meaningful than startingheight, imho).
