### PR TITLE
Fix bug #4355

### DIFF
--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -195,11 +195,10 @@ bool PaymentServer::ipcParseCommandLine(int argc, char* argv[])
             savedPaymentRequests.append(arg);
 
             SendCoinsRecipient r;
-            if (GUIUtil::parseBitcoinURI(arg, &r))
+            SelectParams(CChainParams::MAIN);
+            if (GUIUtil::parseBitcoinURI(arg, &r) && r.address.toStdString() != "")
             {
                 CBitcoinAddress address(r.address.toStdString());
-
-                SelectParams(CChainParams::MAIN);
                 if (!address.IsValid())
                 {
                     SelectParams(CChainParams::TESTNET);

--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -195,7 +195,6 @@ bool PaymentServer::ipcParseCommandLine(int argc, char* argv[])
             savedPaymentRequests.append(arg);
 
             SendCoinsRecipient r;
-            SelectParams(CChainParams::MAIN);
             if (GUIUtil::parseBitcoinURI(arg, &r) && r.address.toStdString() != "")
             {
                 CBitcoinAddress address(r.address.toStdString());


### PR DESCRIPTION
No longer start up in testnet mode when presented with a BIP 72 link that has no fallback address.
