### PR TITLE
Use boost::unordered_map in CCoinsView

### DIFF
--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -84,8 +84,8 @@ bool CCoinsViewCache::GetCoins(const uint256 &txid, CCoins &coins) {
 }
 
 CCoinsMap::iterator CCoinsViewCache::FetchCoins(const uint256 &txid) {
-    CCoinsMap::iterator it = cacheCoins.lower_bound(txid);
-    if (it != cacheCoins.end() && it->first == txid)
+    CCoinsMap::iterator it = cacheCoins.find(txid);
+    if (it != cacheCoins.end())
         return it;
     CCoins tmp;
     if (!base->GetCoins(txid,tmp))

--- a/src/coins.h
+++ b/src/coins.h
@@ -239,6 +239,7 @@ public:
     }
 };
 
+typedef std::map<uint256,CCoins> CCoinsMap;
 
 struct CCoinsStats
 {
@@ -275,7 +276,7 @@ public:
     virtual bool SetBestBlock(const uint256 &hashBlock);
 
     // Do a bulk modification (multiple SetCoins + one SetBestBlock)
-    virtual bool BatchWrite(const std::map<uint256, CCoins> &mapCoins, const uint256 &hashBlock);
+    virtual bool BatchWrite(const CCoinsMap &mapCoins, const uint256 &hashBlock);
 
     // Calculate statistics about the unspent transaction output set
     virtual bool GetStats(CCoinsStats &stats);
@@ -299,7 +300,7 @@ public:
     uint256 GetBestBlock();
     bool SetBestBlock(const uint256 &hashBlock);
     void SetBackend(CCoinsView &viewIn);
-    bool BatchWrite(const std::map<uint256, CCoins> &mapCoins, const uint256 &hashBlock);
+    bool BatchWrite(const CCoinsMap &mapCoins, const uint256 &hashBlock);
     bool GetStats(CCoinsStats &stats);
 };
 
@@ -309,7 +310,7 @@ class CCoinsViewCache : public CCoinsViewBacked
 {
 protected:
     uint256 hashBlock;
-    std::map<uint256,CCoins> cacheCoins;
+    CCoinsMap cacheCoins;
 
 public:
     CCoinsViewCache(CCoinsView &baseIn, bool fDummy = false);
@@ -320,7 +321,7 @@ public:
     bool HaveCoins(const uint256 &txid);
     uint256 GetBestBlock();
     bool SetBestBlock(const uint256 &hashBlock);
-    bool BatchWrite(const std::map<uint256, CCoins> &mapCoins, const uint256 &hashBlock);
+    bool BatchWrite(const CCoinsMap &mapCoins, const uint256 &hashBlock);
 
     // Return a modifiable reference to a CCoins. Check HaveCoins first.
     // Many methods explicitly require a CCoinsViewCache because of this method, to reduce
@@ -352,7 +353,7 @@ public:
     const CTxOut &GetOutputFor(const CTxIn& input);
 
 private:
-    std::map<uint256,CCoins>::iterator FetchCoins(const uint256 &txid);
+    CCoinsMap::iterator FetchCoins(const uint256 &txid);
 };
 
 #endif

--- a/src/coins.h
+++ b/src/coins.h
@@ -13,6 +13,7 @@
 #include <stdint.h>
 
 #include <boost/foreach.hpp>
+#include <boost/unordered_map.hpp>
 
 /** pruned version of CTransaction: only retains metadata and unspent transaction outputs
  *
@@ -239,7 +240,7 @@ public:
     }
 };
 
-typedef std::map<uint256,CCoins> CCoinsMap;
+typedef boost::unordered_map<uint256,CCoins> CCoinsMap;
 
 struct CCoinsStats
 {

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -54,11 +54,11 @@ bool CCoinsViewDB::SetBestBlock(const uint256 &hashBlock) {
     return db.WriteBatch(batch);
 }
 
-bool CCoinsViewDB::BatchWrite(const std::map<uint256, CCoins> &mapCoins, const uint256 &hashBlock) {
+bool CCoinsViewDB::BatchWrite(const CCoinsMap &mapCoins, const uint256 &hashBlock) {
     LogPrint("coindb", "Committing %u changed transactions to coin database...\n", (unsigned int)mapCoins.size());
 
     CLevelDBBatch batch;
-    for (std::map<uint256, CCoins>::const_iterator it = mapCoins.begin(); it != mapCoins.end(); it++)
+    for (CCoinsMap::const_iterator it = mapCoins.begin(); it != mapCoins.end(); it++)
         BatchWriteCoins(batch, it->first, it->second);
     if (hashBlock != uint256(0))
         BatchWriteHashBestChain(batch, hashBlock);

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -37,7 +37,7 @@ public:
     bool HaveCoins(const uint256 &txid);
     uint256 GetBestBlock();
     bool SetBestBlock(const uint256 &hashBlock);
-    bool BatchWrite(const std::map<uint256, CCoins> &mapCoins, const uint256 &hashBlock);
+    bool BatchWrite(const CCoinsMap &mapCoins, const uint256 &hashBlock);
     bool GetStats(CCoinsStats &stats);
 };
 

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -552,4 +552,9 @@ public:
     }
 };
 
+/** Return a hash value for boost::unordered_map.
+ * This trivial implementation is only useful if the uint256 itself represents a hash, which is always the case in bitcoin.
+ */
+static inline std::size_t hash_value(const uint256& x) { return x.GetLow64(); }
+
 #endif


### PR DESCRIPTION
As we are not dependent on the ordering, a hash map could improve performance here. As suggested by @sipa.

Consists of a first commit which makes the type easier to change - and should be easy to merge - and a second commit that actually changes the type. This needs benchmarking and extensive testing.
