### PR TITLE
Add a skiplist to the CBlockIndex structure.

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -47,6 +47,7 @@ BITCOIN_TESTS =\
   test/script_tests.cpp \
   test/serialize_tests.cpp \
   test/sigopcount_tests.cpp \
+  test/skiplist_tests.cpp \
   test/test_bitcoin.cpp \
   test/transaction_tests.cpp \
   test/uint256_tests.cpp \

--- a/src/main.h
+++ b/src/main.h
@@ -677,6 +677,9 @@ public:
     // pointer to the index of the predecessor of this block
     CBlockIndex* pprev;
 
+    // pointer to the index of some further predecessor of this block
+    CBlockIndex* pskip;
+
     // height of the entry in the chain. The genesis block has height 0
     int nHeight;
 
@@ -716,6 +719,7 @@ public:
     {
         phashBlock = NULL;
         pprev = NULL;
+        pskip = NULL;
         nHeight = 0;
         nFile = 0;
         nDataPos = 0;
@@ -737,6 +741,7 @@ public:
     {
         phashBlock = NULL;
         pprev = NULL;
+        pskip = NULL;
         nHeight = 0;
         nFile = 0;
         nDataPos = 0;
@@ -869,9 +874,14 @@ public:
         }
         return false;
     }
+
+    // Build the skiplist pointer for this entry.
+    void BuildSkip();
+
+    // Efficiently find an ancestor of this block.
+    CBlockIndex* GetAncestor(int height);
+    const CBlockIndex* GetAncestor(int height) const;
 };
-
-
 
 /** Used to marshal pointers into hashes for db storage. */
 class CDiskBlockIndex : public CBlockIndex

--- a/src/main.h
+++ b/src/main.h
@@ -185,6 +185,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
 
 struct CNodeStateStats {
     int nMisbehavior;
+    int nSyncHeight;
 };
 
 struct CDiskBlockPos

--- a/src/rpcnet.cpp
+++ b/src/rpcnet.cpp
@@ -134,6 +134,7 @@ Value getpeerinfo(const Array& params, bool fHelp)
         obj.push_back(Pair("startingheight", stats.nStartingHeight));
         if (fStateStats) {
             obj.push_back(Pair("banscore", statestats.nMisbehavior));
+            obj.push_back(Pair("syncheight", statestats.nSyncHeight));
         }
         obj.push_back(Pair("syncnode", stats.fSyncNode));
 

--- a/src/test/skiplist_tests.cpp
+++ b/src/test/skiplist_tests.cpp
@@ -1,0 +1,45 @@
+// Copyright (c) 2014 The Bitcoin Core developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <boost/test/unit_test.hpp>
+#include <vector>
+#include "main.h"
+#include "util.h"
+
+
+#define SKIPLIST_LENGTH 300000
+
+BOOST_AUTO_TEST_SUITE(skiplist_tests)
+
+BOOST_AUTO_TEST_CASE(skiplist_test)
+{
+    std::vector<CBlockIndex> vIndex(SKIPLIST_LENGTH);
+
+    for (int i=0; i<SKIPLIST_LENGTH; i++) {
+        vIndex[i].nHeight = i;
+        vIndex[i].pprev = (i == 0) ? NULL : &vIndex[i - 1];
+        vIndex[i].BuildSkip();
+    }
+
+    for (int i=0; i<SKIPLIST_LENGTH; i++) {
+        if (i > 0) {
+            BOOST_CHECK(vIndex[i].pskip == &vIndex[vIndex[i].pskip->nHeight]);
+            BOOST_CHECK(vIndex[i].pskip->nHeight < i);
+        } else {
+            BOOST_CHECK(vIndex[i].pskip == NULL);
+        }
+    }
+
+    for (int i=0; i < 1000; i++) {
+        int from = insecure_rand() % (SKIPLIST_LENGTH - 1);
+        int to = insecure_rand() % (from + 1);
+
+        BOOST_CHECK(vIndex[SKIPLIST_LENGTH - 1].GetAncestor(from) == &vIndex[from]);
+        BOOST_CHECK(vIndex[from].GetAncestor(to) == &vIndex[to]);
+        BOOST_CHECK(vIndex[from].GetAncestor(0) == &vIndex[0]);
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+


### PR DESCRIPTION
Another piece of logic that is needed in headersfirst: a fast way to determine whether a tip of the header chain is an descendant of what a particular peer has available.

A skip list is easy to add to the existing structure, and allows fast (O(log n)) access to far predecessor blocks. 

The current code only uses it to speed up CChain::FindFork and CChain::GetLocator.
