### PR TITLE
set shutdown title to main window title

### DIFF
--- a/src/qt/utilitydialog.cpp
+++ b/src/qt/utilitydialog.cpp
@@ -117,6 +117,7 @@ void ShutdownWindow::showShutdownWindow(BitcoinGUI *window)
         tr("Bitcoin Core is shutting down...") + "<br /><br />" +
         tr("Do not shut down the computer until this window disappears.")));
     shutdownWindow->setLayout(layout);
+    shutdownWindow->setWindowTitle(window->windowTitle());
 
     // Center shutdown window at where main window was
     const QPoint global = window->mapToGlobal(window->rect().center());


### PR DESCRIPTION
- this ensures we don't show Bitcoin-Qt as that is still our
  internal application name
- fixes #4427
