### PR TITLE
Fix many orphan problem and stuck block download problem

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -239,6 +239,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += "  -banscore=<n>          " + _("Threshold for disconnecting misbehaving peers (default: 100)") + "\n";
     strUsage += "  -bantime=<n>           " + _("Number of seconds to keep misbehaving peers from reconnecting (default: 86400)") + "\n";
     strUsage += "  -bind=<addr>           " + _("Bind to given address and always listen on it. Use [host]:port notation for IPv6") + "\n";
+    strUsage += "  -synctimeout=<n>       " + _("Specify block download timeout in seconds (default: 60)") + "\n";
     strUsage += "  -connect=<ip>          " + _("Connect only to the specified node(s)") + "\n";
     strUsage += "  -discover              " + _("Discover own IP address (default: 1 when listening and no -externalip)") + "\n";
     strUsage += "  -dns                   " + _("Allow DNS lookups for -addnode, -seednode and -connect") + " " + _("(default: 1)") + "\n";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4126,10 +4126,13 @@ bool ProcessMessages(CNode* pfrom)
 
         // get next message
         CNetMessage& msg = *it;
+        CMessageHeader& hdr = msg.hdr;
+        unsigned int nMessageSize = hdr.nMessageSize;
+        string strCommand = hdr.GetCommand();
 
         //if (fDebug)
         //    LogPrintf("ProcessMessages(message %u msgsz, %u bytes, complete:%s)\n",
-        //            msg.hdr.nMessageSize, msg.vRecv.size(),
+        //            nMessageSize, msg.vRecv.size(),
         //            msg.complete() ? "Y" : "N");
 
         // end, if an incomplete message is found
@@ -4146,17 +4149,11 @@ bool ProcessMessages(CNode* pfrom)
             break;
         }
 
-        // Read header
-        CMessageHeader& hdr = msg.hdr;
         if (!hdr.IsValid())
         {
-            LogPrintf("\n\nPROCESSMESSAGE: ERRORS IN HEADER %s\n\n\n", hdr.GetCommand());
+            LogPrintf("\n\nPROCESSMESSAGE: ERRORS IN HEADER %s\n\n\n", strCommand);
             continue;
         }
-        string strCommand = hdr.GetCommand();
-
-        // Message size
-        unsigned int nMessageSize = hdr.nMessageSize;
 
         // Checksum
         CDataStream& vRecv = msg.vRecv;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4409,27 +4409,28 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
 
         // Detect stalled peers.
         int64_t tNow = GetTimeMillis();
+        int nSyncTimeout = GetArg("-synctimeout", 60);
         if (pto->tGetblocks) {
             if (pto->tBlockRecving > pto->tBlockRecved) {
-                if (tNow-pto->tBlockRecving > BLOCK_DOWNLOAD_TIMEOUT * 1000) {
+                if (tNow-pto->tBlockRecving > nSyncTimeout * 1000) {
                     LogPrintf("sync peer=%d: Block download stalled for over %d seconds.\n",
-                        pto->id, BLOCK_DOWNLOAD_TIMEOUT);
+                        pto->id, nSyncTimeout);
                     pto->fDisconnect = true;
                 }
-            } else if (pto->tGetblocks > pto->tBlockInvs && tNow-pto->tGetblocks > BLOCK_DOWNLOAD_TIMEOUT * 1000) {
+            } else if (pto->tGetblocks > pto->tBlockInvs && tNow-pto->tGetblocks > nSyncTimeout * 1000) {
                 LogPrintf("sync peer=%d: No invs of new blocks received within %d seconds.\n",
-                    pto->id, BLOCK_DOWNLOAD_TIMEOUT);
+                    pto->id, nSyncTimeout);
                 pto->fDisconnect = true;
-            } else if (!CaughtUp() && pto->tBlockRecved && tNow-pto->tBlockRecved > BLOCK_DOWNLOAD_TIMEOUT * 1000) {
+            } else if (!CaughtUp() && pto->tBlockRecved && tNow-pto->tBlockRecved > nSyncTimeout * 1000) {
                 LogPrintf("sync peer=%d: No block reception for over %d seconds.\n",
-                    pto->id, BLOCK_DOWNLOAD_TIMEOUT);
+                    pto->id, nSyncTimeout);
                 if (state.nBlocksInFlight)
                     pto->fDisconnect = true;
                 else
                     pto->tGetblocks = 0; // shouldn't ever get here
-            } else if (pto->tGetdataBlock > pto->tBlockRecving && tNow-pto->tGetdataBlock > BLOCK_DOWNLOAD_TIMEOUT * 1000) {
+            } else if (pto->tGetdataBlock > pto->tBlockRecving && tNow-pto->tGetdataBlock > nSyncTimeout * 1000) {
                 LogPrintf("sync peer=%d: No block download started for over %d seconds.\n",
-                    pto->id, BLOCK_DOWNLOAD_TIMEOUT);
+                    pto->id, nSyncTimeout);
                 pto->fDisconnect = true;
             }
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4125,6 +4125,15 @@ bool ProcessMessages(CNode* pfrom)
     // this maintains the order of responses
     if (!pfrom->vRecvGetData.empty()) return fOk;
 
+    int nBlocksToDownload = State(pfrom->id)->nBlocksToDownload;
+    int nBlocksInFlight = State(pfrom->id)->nBlocksInFlight;
+
+    // Cause a new syncnode to be reselected since we're about to stop receiving blocks
+    // (and we'll be ignoring the inv the current syncnode sends in favour of selecting
+    // a potentially better syncnode.
+    if (nBlocksInFlight + nBlocksToDownload == 1 && !CaughtUp())
+        pfrom->tGetblocks = 0;
+
     std::deque<CNetMessage>::iterator it = pfrom->vRecvMsg.begin();
     while (!pfrom->fDisconnect && it != pfrom->vRecvMsg.end()) {
         // Don't bother if send buffer is too full to respond anyway

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -269,7 +269,7 @@ void FinalizeNode(NodeId nodeid) {
 }
 
 // Requires cs_main.
-void MarkBlockAsReceived(const uint256 &hash, NodeId nodeFrom = -1) {
+void MarkBlockAsRequested(const uint256 &hash, NodeId nodeFrom = -1) {
     map<uint256, pair<NodeId, list<uint256>::iterator> >::iterator itToDownload = mapBlocksToDownload.find(hash);
     if (itToDownload != mapBlocksToDownload.end()) {
         CNodeState *state = State(itToDownload->second.first);
@@ -277,7 +277,9 @@ void MarkBlockAsReceived(const uint256 &hash, NodeId nodeFrom = -1) {
         state->nBlocksToDownload--;
         mapBlocksToDownload.erase(itToDownload);
     }
+}
 
+void MarkBlockAsReceived(const uint256 &hash, NodeId nodeFrom = -1) {
     map<uint256, pair<NodeId, list<QueuedBlock>::iterator> >::iterator itInFlight = mapBlocksInFlight.find(hash);
     if (itInFlight != mapBlocksInFlight.end()) {
         CNodeState *state = State(itInFlight->second.first);
@@ -312,7 +314,7 @@ void MarkBlockAsInFlight(NodeId nodeid, const uint256 &hash) {
     assert(state != NULL);
 
     // Make sure it's not listed somewhere already.
-    MarkBlockAsReceived(hash);
+    MarkBlockAsRequested(hash);
 
     QueuedBlock newentry = {hash, GetTimeMicros(), state->nBlocksInFlight};
     if (state->nBlocksInFlight == 0)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4156,8 +4156,13 @@ bool ProcessMessages(CNode* pfrom)
         //            msg.complete() ? "Y" : "N");
         if (msg.nDataPos != msg.nLastDataPos) {
             if (strCommand == "block") {
-                if (msg.nLastDataPos == 0)
+                if (msg.nLastDataPos == 0) {
                     pfrom->tBlockRecvStart = GetTimeMillis();
+                    if (pfrom->tBlockRecved)
+                        LogPrint("net", "%ums later, ", pfrom->tBlockRecvStart - pfrom->tBlockRecved);
+                    LogPrint("net", "incoming block (%u bytes) (%d still to get, %d in flight) peer=%d\n",
+                        nMessageSize, nBlocksToDownload, nBlocksInFlight, pfrom->id);
+                }
                 pfrom->tBlockRecving = GetTimeMillis();
             }
             msg.nLastDataPos = msg.nDataPos;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1166,6 +1166,11 @@ int64_t GetBlockValue(int nHeight, int64_t nFees)
     return nSubsidy + nFees;
 }
 
+bool CaughtUp()
+{
+    return ((chainActive.Height() >= Checkpoints::GetTotalBlocksEstimate()) && chainActive.Tip()->GetBlockTime() > GetTime() - 90 * 60);
+}
+
 bool IsInitialBlockDownload()
 {
     LOCK(cs_main);

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2052,6 +2052,12 @@ CNode::CNode(SOCKET hSocketIn, CAddress addrIn, std::string addrNameIn, bool fIn
     nSendBytes = 0;
     nRecvBytes = 0;
     nTimeConnected = GetTime();
+    tGetblocks = 0;
+    tBlockInvs = 0;
+    tGetdataBlock = 0;
+    tBlockRecvStart = 0;
+    tBlockRecving = 0;
+    tBlockRecved = 0;
     addr = addrIn;
     addrName = addrNameIn == "" ? addr.ToStringIPPort() : addrNameIn;
     nVersion = 0;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1509,7 +1509,7 @@ void static StartSync(const vector<CNode*> &vNodes) {
         // check preconditions for allowing a sync
         if (!pnode->fClient && !pnode->fOneShot &&
             !pnode->fDisconnect && pnode->fSuccessfullyConnected &&
-            (pnode->nStartingHeight > (nBestHeight - 144)) &&
+            (pnode->nStartingHeight > nBestHeight) &&
             (pnode->nVersion < NOBLKS_VERSION_START || pnode->nVersion >= NOBLKS_VERSION_END)) {
             // if ok, compare node's score with the best so far
             int64_t nScore = NodeSyncScore(pnode);
@@ -1521,8 +1521,9 @@ void static StartSync(const vector<CNode*> &vNodes) {
     }
     // if a new sync candidate was found, start sync!
     if (pnodeNewSync) {
-        pnodeNewSync->fStartSync = true;
         pnodeSync = pnodeNewSync;
+        pnodeSync->fStartSync = true;
+        LogPrint("net", "Setting peer=%d as syncnode.\n", pnodeSync->id);
     }
 }
 
@@ -1539,7 +1540,7 @@ void ThreadMessageHandler()
             vNodesCopy = vNodes;
             BOOST_FOREACH(CNode* pnode, vNodesCopy) {
                 pnode->AddRef();
-                if (pnode == pnodeSync)
+                if (pnode == pnodeSync && (pnode->fStartSync || pnode->tGetblocks))
                     fHaveSyncNode = true;
             }
         }

--- a/src/net.h
+++ b/src/net.h
@@ -230,9 +230,15 @@ public:
     uint64_t nRecvBytes;
     int nRecvVersion;
 
-    int64_t nLastSend;
-    int64_t nLastRecv;
-    int64_t nTimeConnected;
+    int64_t nLastSend;       // Time data last sent to peer.
+    int64_t nLastRecv;       // Time data last received from peer.
+    int64_t nTimeConnected;  // Time connection to peer was established.
+    int64_t tGetblocks;      // When we became a sync node.
+    int64_t tBlockInvs;      // Time new block invs arrived from peer.
+    int64_t tGetdataBlock;   // Time getdata block sent.
+    int64_t tBlockRecvStart; // Time block reception first detected.
+    int64_t tBlockRecving;   // Time block reception last progressed.
+    int64_t tBlockRecved;    // Time last complete block received.
     CAddress addr;
     std::string addrName;
     CService addrLocal;

--- a/src/net.h
+++ b/src/net.h
@@ -176,6 +176,7 @@ public:
 
     CDataStream vRecv;              // received message data
     unsigned int nDataPos;
+    unsigned int nLastDataPos;
 
     int64_t nTime;                  // time (in microseconds) of message receipt.
 
@@ -184,6 +185,7 @@ public:
         in_data = false;
         nHdrPos = 0;
         nDataPos = 0;
+        nLastDataPos = 0;
         nTime = 0;
     }
 


### PR DESCRIPTION
This has taken me several days to code and test, and I've tested it thoroughly.

With the current code, that uses only one syncnode, with these changes, the node will never download orphan blocks. With net debugging enabled, you will get a good view of what it's doing.

It also downloads the blockchain very fast, and never allows more than 60 seconds (the default) of inactivity to occur, so recovers very quickly from stuck downloads. With my testing, this can safely be reduced to 10 seconds as if a downloads sticks for as long as 10 seconds, it never recovers, so rather than wait two minutes as the current code does (well, tries to do), it quickly switches to a new syncnode.

Please do test, and give comments. So far, with the orphan problem, many people are unable to run the node without limiting orphan blocks (which still doesn't fix the stuck download anyway).

Feel free to copy this branch and improve it. I've included quite a few commits to make it easier to see the development process, but I won't always have time to make the changes needed that people ask for, and from experience my pull requests often don't get pulled for some reason. I think this functionality is needed now based upon the issues people have been raising.
