### PR TITLE
Update OS X build instructions

### DIFF
--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -22,7 +22,7 @@ Xcode 4.3 or later, you'll need to install its command line tools. This can
 be done in `Xcode > Preferences > Downloads > Components` and generally must
 be re-done or updated every time Xcode is updated.
 
-There's an assumption that you already have `git` installed, as well. If
+There's also an assumption that you already have `git` installed. If
 not, it's the path of least resistance to install [Github for Mac](https://mac.github.com/)
 (OS X 10.7+) or
 [Git for OS X](https://code.google.com/p/git-osx-installer/). It is also
@@ -30,11 +30,8 @@ available via Homebrew or MacPorts.
 
 You will also need to install [Homebrew](http://brew.sh)
 or [MacPorts](https://www.macports.org/) in order to install library
-dependencies. It's largely a religious decision which to choose, but, as of
-December 2012, MacPorts is a little easier because you can just install the
-dependencies immediately - no other work required. If you're unsure, read
-the instructions through first in order to assess what you want to do.
-Homebrew is a little more popular among those newer to OS X.
+dependencies. It's largely a religious decision which to choose, however, Homebrew
+is now used for building release versions.
 
 The installation of the actual dependencies is covered in the Instructions
 sections below.
@@ -43,8 +40,6 @@ Instructions: MacPorts
 ----------------------
 
 ### Install dependencies
-
-Installing the dependencies using MacPorts is very straightforward.
 
     sudo port install boost db48@+no_java openssl miniupnpc autoconf pkgconfig automake
 
@@ -80,7 +75,7 @@ Note: After you have installed the dependencies, you should check that the Homeb
 
         openssl version
 
-into Terminal. You should see OpenSSL 1.0.1f 6 Jan 2014.
+into Terminal. You should see OpenSSL 1.0.1h 5 Jun 2014.
 
 If not, you can ensure that the Homebrew OpenSSL is correctly linked by running
 
@@ -103,7 +98,7 @@ PATH.
         ./configure
         make
 
-3.  It is a good idea to build and run the unit tests, too:
+3.  It is also a good idea to build and run the unit tests:
 
         make check
 
@@ -131,7 +126,7 @@ For MacPorts, that means editing your macports.conf and setting
 ... and then uninstalling and re-installing, or simply rebuilding, all ports.
 
 As of December 2012, the `boost` port does not obey `macosx_deployment_target`.
-Download `http://gavinandresen-bitcoin.s3.amazonaws.com/boost_macports_fix.zip`
+Download `https://gavinandresen-bitcoin.s3.amazonaws.com/boost_macports_fix.zip`
 for a fix.
 
 Once dependencies are compiled, see release-process.md for how the Bitcoin-Qt.app
@@ -149,13 +144,14 @@ commands:
     echo -e "rpcuser=bitcoinrpc\nrpcpassword=$(xxd -l 16 -p /dev/urandom)" > "/Users/${USER}/Library/Application Support/Bitcoin/bitcoin.conf"
     chmod 600 "/Users/${USER}/Library/Application Support/Bitcoin/bitcoin.conf"
 
-When next you run it, it will start downloading the blockchain, but it won't
+The next time you run it, it will start downloading the blockchain, but it won't
 output anything while it's doing this. This process may take several hours;
 you can monitor its process by looking at the debug.log file, like this:
 
     tail -f $HOME/Library/Application\ Support/Bitcoin/debug.log
 
 Other commands:
+-------
 
     ./bitcoind -daemon # to start the bitcoin daemon.
     ./bitcoin-cli --help  # for a list of command-line options.


### PR DESCRIPTION
Update OpenSSL version
Homebrew is now the preferred dependancy manager
Alternative to #4267
