### PR TITLE
Check signatures before double-spend relay

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1176,7 +1176,7 @@ bool AppInit2(boost::thread_group& threadGroup)
     LogPrintf("mapAddressBook.size() = %u\n",  pwalletMain ? pwalletMain->mapAddressBook.size() : 0);
 #endif
 
-    RegisterInternalSignals();
+    InitRespendFilter();
     StartNode(threadGroup);
     if (fServer)
         StartRPCThreads();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -127,7 +127,7 @@ namespace {
 
 // Forward reference functions defined here:
 static const unsigned int MAX_DOUBLESPEND_BLOOM = 1000;
-static void RelayDoubleSpend(const COutPoint& outPoint, const CTransaction& doubleSpend, bool fInBlock, CBloomFilter& filter);
+static bool RelayableRespend(const COutPoint& outPoint, const CTransaction& doubleSpend, bool fInBlock, CBloomFilter& filter);
 
 //////////////////////////////////////////////////////////////////////////////
 //
@@ -156,7 +156,7 @@ struct CMainSignals {
     // transaction was first seen in a block.
     // Note: only notifies if the previous transaction is in the memory pool; if previous transction was in a block,
     // then the double-spend simply fails when we try to lookup the inputs in the current UTXO set.
-    boost::signals2::signal<void (const COutPoint&, const CTransaction&, bool)> DetectedDoubleSpend;
+    boost::signals2::signal<bool (const COutPoint&, const CTransaction&, bool)> DetectedDoubleSpend;
 } g_signals;
 
 } // anon namespace
@@ -166,7 +166,7 @@ void RegisterInternalSignals() {
     seed_insecure_rand();
     doubleSpendFilter = CBloomFilter(MAX_DOUBLESPEND_BLOOM, 0.01, insecure_rand(), BLOOM_UPDATE_NONE);
 
-    g_signals.DetectedDoubleSpend.connect(boost::bind(RelayDoubleSpend, _1, _2, _3, doubleSpendFilter));
+    g_signals.DetectedDoubleSpend.connect(boost::bind(RelayableRespend, _1, _2, _3, doubleSpendFilter));
 }
 
 
@@ -936,6 +936,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
         return false;
 
     // Check for conflicts with in-memory transactions
+    bool relayableRespend = false;
     {
     LOCK(pool.cs); // protect pool.mapNextTx
     for (unsigned int i = 0; i < tx.vin.size(); i++)
@@ -944,8 +945,9 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
         // Does tx conflict with a member of the pool, and is it not equivalent to that member?
         if (pool.mapNextTx.count(outpoint) && !tx.IsEquivalentTo(*pool.mapNextTx[outpoint].ptx))
         {
-            g_signals.DetectedDoubleSpend(outpoint, tx, false);
-            return false;
+            relayableRespend = g_signals.DetectedDoubleSpend(outpoint, tx, false);
+            if (!relayableRespend)
+                return false;
         }
     }
     }
@@ -1038,16 +1040,24 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
         {
             return error("AcceptToMemoryPool: : ConnectInputs failed %s", hash.ToString());
         }
-        // Store transaction in memory
-        pool.addUnchecked(hash, entry);
+
+        if (relayableRespend)
+        {
+            RelayTransaction(tx);
+        }
+        else
+        {
+            // Store transaction in memory
+            pool.addUnchecked(hash, entry);
+        }
     }
 
     g_signals.SyncTransaction(tx, NULL);
 
-    return true;
+    return !relayableRespend;
 }
 
-static void RelayDoubleSpend(const COutPoint& outPoint, const CTransaction& doubleSpend, bool fInBlock, CBloomFilter& filter)
+static bool RelayableRespend(const COutPoint& outPoint, const CTransaction& doubleSpend, bool fInBlock, CBloomFilter& filter)
 {
     // Relaying double-spend attempts to our peers lets them detect when
     // somebody might be trying to cheat them. However, blindly relaying
@@ -1060,7 +1070,7 @@ static void RelayDoubleSpend(const COutPoint& outPoint, const CTransaction& doub
     // from us they are very likely to hear about it from another peer, since
     // each peer uses a different, randomized bloom filter.
 
-    if (fInBlock || filter.contains(outPoint)) return;
+    if (fInBlock || filter.contains(outPoint)) return false;
 
     // Apply an independent rate limit to double-spend relays
     static double dRespendCount;
@@ -1071,7 +1081,7 @@ static void RelayDoubleSpend(const COutPoint& outPoint, const CTransaction& doub
     if (RateLimitExceeded(dRespendCount, nLastRespendTime, nRespendLimit, nSize))
     {
         LogPrint("mempool", "Double-spend relay rejected by rate limiter\n");
-        return;
+        return false;
     }
 
     LogPrint("mempool", "Rate limit dRespendCount: %g => %g\n", dRespendCount, dRespendCount+nSize);
@@ -1083,10 +1093,7 @@ static void RelayDoubleSpend(const COutPoint& outPoint, const CTransaction& doub
 
     filter.insert(outPoint);
 
-    RelayTransaction(doubleSpend);
-
-    // Share conflict with wallet
-    g_signals.SyncTransaction(doubleSpend, NULL);
+    return true;
 }
 
 

--- a/src/main.h
+++ b/src/main.h
@@ -108,8 +108,8 @@ struct CNodeStateStats;
 
 struct CBlockTemplate;
 
-/** Set up internal signal handlers **/
-void RegisterInternalSignals();
+/** Initialize respend bloom filter **/
+void InitRespendFilter();
 
 /** Register a wallet to receive updates from core */
 void RegisterWallet(CWalletInterface* pwalletIn);


### PR DESCRIPTION
After it passes anti-DoS checks, mark a respend as relayable, but do not actually relay it until after the inputs are completely checked (for valid signatures especially).

This fixes a problem with #3883.
