### PR TITLE
Only update last seen time when the node is actually being useful.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2725,6 +2725,9 @@ bool ProcessBlock(CValidationState &state, CNode* pfrom, CBlock* pblock, CDiskBl
     if (!ActivateBestChain(state))
         return error("ProcessBlock() : ActivateBestChain failed");
 
+    // Update the last seen time for this node's address
+    AddressCurrentlyConnected(pfrom->addr);
+
     return true;
 }
 
@@ -3907,6 +3910,8 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
             vWorkQueue.push_back(inv.hash);
             vEraseQueue.push_back(inv.hash);
 
+            // Update the last seen time for this node's address
+            AddressCurrentlyConnected(pfrom->addr);
 
             LogPrint("mempool", "AcceptToMemoryPool: %s %s : accepted %s (poolsz %u)\n",
                 pfrom->addr.ToString(), pfrom->cleanSubVer,
@@ -4216,13 +4221,6 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
         // Ignore unknown commands for extensibility
         LogPrint("net", "Unknown command \"%s\" from peer=%d\n", SanitizeString(strCommand), pfrom->id);
     }
-
-
-    // Update the last seen time for this node's address
-    if (pfrom->fNetworkNode)
-        if (strCommand == "version" || strCommand == "addr" || strCommand == "inv" || strCommand == "getdata" || strCommand == "ping")
-            AddressCurrentlyConnected(pfrom->addr);
-
 
     return true;
 }


### PR DESCRIPTION
More useful tracking of useful peers (ones that actually serve useable blocks and txs, rather than version messages, inv messages, getdata messages).

Gotta be honest, I don't fully understand what this code does - but somehow this change seems to intuitively make more sense than the current code.
