### PR TITLE
No need for such accuracy (and reduces readability of debug.log)

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -446,14 +446,9 @@ public:
             nRequestTime = it->second;
         else
             nRequestTime = 0;
-        LogPrint("net", "askfor %s   %d (%s)\n", inv.ToString(), nRequestTime, DateTimeStrFormat("%H:%M:%S", nRequestTime/1000000).c_str());
+        LogPrint("net", "askfor %s  (%s)\n", inv.ToString(), DateTimeStrFormat("%H:%M:%S", nRequestTime/1000000).c_str());
 
-        // Make sure not to reuse time indexes to keep things in the same order
-        int64_t nNow = GetTimeMicros() - 1000000;
-        static int64_t nLastTime;
-        ++nLastTime;
-        nNow = std::max(nNow, nLastTime);
-        nLastTime = nNow;
+        int64_t nNow = GetTimeMicros();
 
         // Each retry is 2 minutes after the last
         nRequestTime = std::max(nRequestTime + 2 * 60 * 1000000, nNow);


### PR DESCRIPTION
Revert to previous behaviour. This way the ++nLastTime number can be viewed within debug.log. If the GetTimeMicros() is kept, then there is no need to display the number (not converted to a time) since this provides no useful information any longer.
