### PR TITLE
[Qt] fix Qt5 build by using correct .toStdString()

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -134,7 +134,7 @@ void DebugMessageHandler(QtMsgType type, const QMessageLogContext& context, cons
 {
     Q_UNUSED(context);
     const char *category = (type == QtDebugMsg) ? "qt" : NULL;
-    LogPrint(category, "GUI: %s\n", QString::toStdString(msg));
+    LogPrint(category, "GUI: %s\n", msg.toStdString());
 }
 #endif
 


### PR DESCRIPTION
Got a compilation error with the current master.
