### PR TITLE
Remove tx from AlreadyAskedFor list once we receive it, not when we process it.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3894,14 +3894,15 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
 
         bool fMissingInputs = false;
         CValidationState state;
+
+        mapAlreadyAskedFor.erase(inv);
+
         if (AcceptToMemoryPool(mempool, state, tx, true, &fMissingInputs))
         {
             mempool.check(pcoinsTip);
             RelayTransaction(tx);
-            mapAlreadyAskedFor.erase(inv);
             vWorkQueue.push_back(inv.hash);
             vEraseQueue.push_back(inv.hash);
-
 
             LogPrint("mempool", "AcceptToMemoryPool: peer=%d %s : accepted %s (poolsz %u)\n",
                 pfrom->id, pfrom->cleanSubVer,
@@ -3928,7 +3929,6 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                     {
                         LogPrint("mempool", "   accepted orphan tx %s\n", orphanHash.ToString());
                         RelayTransaction(orphanTx);
-                        mapAlreadyAskedFor.erase(CInv(MSG_TX, orphanHash));
                         vWorkQueue.push_back(orphanHash);
                         vEraseQueue.push_back(orphanHash);
                     }


### PR DESCRIPTION
I see no reason not to erase a requested tx this from the AlreadyAskedFor list at the point the tx is received. Otherwise the risk is that the node continues requesting it from peers. (It will of course get re-added if its inv is seen and it's not processed, but this is already the case also).
