### PR TITLE
Fee fixes

### DIFF
--- a/src/core.cpp
+++ b/src/core.cpp
@@ -82,7 +82,12 @@ CFeeRate::CFeeRate(int64_t nFeePaid, size_t nSize)
 
 int64_t CFeeRate::GetFee(size_t nSize) const
 {
-    return nSatoshisPerK*nSize / 1000;
+    int64_t nFee = nSatoshisPerK*nSize / 1000;
+
+    if (nFee == 0 && nSatoshisPerK > 0)
+        nFee = nSatoshisPerK;
+
+    return nFee;
 }
 
 std::string CFeeRate::ToString() const

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -253,7 +253,8 @@ std::string HelpMessage(HelpMessageMode mode)
 #ifdef ENABLE_WALLET
     strUsage += "\n" + _("Wallet options:") + "\n";
     strUsage += "  -disablewallet         " + _("Do not load the wallet and disable wallet RPC calls") + "\n";
-    strUsage += "  -mintxfee=<amt>        " + strprintf(_("Fees (in BTC/Kb) smaller than this are considered zero fee for transaction creation (default: %s)"), FormatMoney(CWallet::minTxFee.GetFeePerK())) + "\n";
+    if (GetBoolArg("-help-debug", false))
+        strUsage += "  -mintxfee=<amt>        " + strprintf(_("Fees (in BTC/Kb) smaller than this are considered zero fee for transaction creation (default: %s)"), FormatMoney(CWallet::minTxFee.GetFeePerK())) + "\n";
     strUsage += "  -paytxfee=<amt>        " + strprintf(_("Fee (in BTC/kB) to add to transactions you send (default: %s)"), FormatMoney(payTxFee.GetFeePerK())) + "\n";
     strUsage += "  -rescan                " + _("Rescan the block chain for missing wallet transactions") + " " + _("on startup") + "\n";
     strUsage += "  -respendnotify=<cmd>   " + _("Execute command when a network tx respends wallet tx input (%s=respend TxID, %t=wallet TxID)") + "\n";

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1484,7 +1484,7 @@ bool CWallet::CreateTransaction(const vector<pair<CScript, int64_t> >& vecSend,
                     break;
 
                 // Small enough, and priority high enough, to send for free
-                if (dPriority >= dPriorityNeeded)
+                if (dPriorityNeeded > 0 && dPriority >= dPriorityNeeded)
                     break;
 
                 // Include more fee and try again.


### PR DESCRIPTION
- fix bug in CWallet::CreateTransaction. If dPriorityNeeded is -1, then dPriority >= dPriorityNeeded is always true,
  so we always "break;"
- CFeeRate::GetFee(..) currently returns zero for very small nSatoshisPerK.
  For example, if you set the voluntary fee to 1 satoshi, and the tx has less than 1000 bytes,
  payTxFee.GetFee(nTxBytes) returns zero, this results in CWallet::GetMinimumFee(..) to return
  pool.estimateFee(..) instead of the voluntary fee. So its not possible to set the voluntary fee as low as 1 satoshi.
- Add fallback hard-coded AllowFree to coin control, because CreateTransaction also does.
- Handle voluntary fee case in coin control. nPayFee was set to zero if
  dPriority >= dPriorityNeeded, even in the voluntary fee case. And we need to consider, that
  CreateTransaction pays at least for 1000 bytes in the voluntary fee case.

Just a question, why did -mintxfee move from Testing options to Wallet options?
I dont think we should bother people with this, otherwise we wouldnt need smart fee in the first place.
