### PR TITLE
Fix a bug in CChain::GetLocator

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -423,15 +423,13 @@ CBlockLocator CChain::GetLocator(const CBlockIndex *pindex) const {
             break;
         // Exponentially larger steps back, plus the genesis block.
         int nHeight = std::max(pindex->nHeight - nStep, 0);
-        // Jump back quickly to the same height as the chain.
-        if (pindex->nHeight > nHeight)
-            pindex = pindex->GetAncestor(nHeight);
-        // In case pindex is not in this chain, iterate pindex->pprev to find blocks.
-        while (!Contains(pindex))
-            pindex = pindex->pprev;
-        // If pindex is in this chain, use direct height-based access.
-        if (pindex->nHeight > nHeight)
+        if (Contains(pindex)) {
+            // Use O(1) CChain index if possible.
             pindex = (*this)[nHeight];
+        } else {
+            // Otherwise, use O(log n) skiplist.
+            pindex = pindex->GetAncestor(nHeight);
+        }
         if (vHave.size() > 10)
             nStep *= 2;
     }

--- a/src/test/skiplist_tests.cpp
+++ b/src/test/skiplist_tests.cpp
@@ -41,5 +41,61 @@ BOOST_AUTO_TEST_CASE(skiplist_test)
     }
 }
 
+BOOST_AUTO_TEST_CASE(getlocator_test)
+{
+    // Build a main chain 100000 blocks long.
+    std::vector<uint256> vHashMain(100000);
+    std::vector<CBlockIndex> vBlocksMain(100000);
+    for (unsigned int i=0; i<vBlocksMain.size(); i++) {
+        vHashMain[i] = i; // Set the hash equal to the height, so we can quickly check the distances.
+        vBlocksMain[i].nHeight = i;
+        vBlocksMain[i].pprev = i ? &vBlocksMain[i - 1] : NULL;
+        vBlocksMain[i].phashBlock = &vHashMain[i];
+        vBlocksMain[i].BuildSkip();
+        BOOST_CHECK_EQUAL((int)vBlocksMain[i].GetBlockHash().GetLow64(), vBlocksMain[i].nHeight);
+        BOOST_CHECK(vBlocksMain[i].pprev == NULL || vBlocksMain[i].nHeight == vBlocksMain[i].pprev->nHeight + 1);
+    }
+
+    // Build a branch that splits off at block 49999, 50000 blocks long.
+    std::vector<uint256> vHashSide(50000);
+    std::vector<CBlockIndex> vBlocksSide(50000);
+    for (unsigned int i=0; i<vBlocksSide.size(); i++) {
+        vHashSide[i] = i + 50000 + (uint256(1) << 128); // Add 1<<128 to the hashes, so GetLow64() still returns the height.
+        vBlocksSide[i].nHeight = i + 50000;
+        vBlocksSide[i].pprev = i ? &vBlocksSide[i - 1] : &vBlocksMain[49999];
+        vBlocksSide[i].phashBlock = &vHashSide[i];
+        vBlocksSide[i].BuildSkip();
+        BOOST_CHECK_EQUAL((int)vBlocksSide[i].GetBlockHash().GetLow64(), vBlocksSide[i].nHeight);
+        BOOST_CHECK(vBlocksSide[i].pprev == NULL || vBlocksSide[i].nHeight == vBlocksSide[i].pprev->nHeight + 1);
+    }
+
+    // Build a CChain for the main branch.
+    CChain chain;
+    chain.SetTip(&vBlocksMain.back());
+
+    // Test 100 random starting points for locators.
+    for (int n=0; n<100; n++) {
+        int r = insecure_rand() % 150000;
+        CBlockIndex* tip = (r < 100000) ? &vBlocksMain[r] : &vBlocksSide[r - 100000];
+        CBlockLocator locator = chain.GetLocator(tip);
+
+        // The first result must be the block itself, the last one must be genesis.
+        BOOST_CHECK(locator.vHave.front() == tip->GetBlockHash());
+        BOOST_CHECK(locator.vHave.back() == vBlocksMain[0].GetBlockHash());
+
+        // Entries 1 through 11 (inclusive) go back one step each.
+        for (unsigned int i = 1; i < 12 && i < locator.vHave.size() - 1; i++) {
+            BOOST_CHECK_EQUAL(locator.vHave[i].GetLow64(), tip->nHeight - i);
+        }
+
+        // The further ones (excluding the last one) go back with exponential steps.
+        unsigned int dist = 2;
+        for (unsigned int i = 12; i < locator.vHave.size() - 1; i++) {
+            BOOST_CHECK_EQUAL(locator.vHave[i - 1].GetLow64() - locator.vHave[i].GetLow64(), dist);
+            dist *= 2;
+        }
+    }
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 


### PR DESCRIPTION
Fix a bug introduced in #4420: it always walked back until it reaches blocks in the this chain.

This is currently not exposed, as we always call CChain::GetLocator with blocks in the main chain, but in #4468 it gets used for more.
