### PR TITLE
Bugfix: send rejects and apply DoS scoring for errors in direct block validation.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3984,6 +3984,16 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
 
         CValidationState state;
         ProcessBlock(state, pfrom, &block);
+        int nDoS;
+        if (state.IsInvalid(nDoS)) {
+            pfrom->PushMessage("reject", strCommand, state.GetRejectCode(),
+                               state.GetRejectReason(), inv.hash);
+            if (nDoS > 0) {
+                LOCK(cs_main);
+                Misbehaving(pfrom->GetId(), nDoS);
+            }
+        }
+
     }
 
 


### PR DESCRIPTION
#3370 introduced asynchronous processing for blocks, where reject messages and DoS scoring could be applied outside of ProcessBlock, because block validation may happen later.

However, some types of errors are still detected immediately (in particular, CheckBlock violations), which need acting after ProcessBlock returns.
