### PR TITLE
Remove unused variable nFee from coincontroldialog

### DIFF
--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -523,9 +523,6 @@ void CoinControlDialog::updateLabels(WalletModel *model, QDialog* dialog)
         dPriority = dPriorityInputs / (nBytes - nBytesInputs + (nQuantityUncompressed * 29)); // 29 = 180 - 151 (uncompressed public keys are over the limit. max 151 bytes of the input are ignored for priority)
         sPriorityLabel = CoinControlDialog::getPriorityLabel(mempool, dPriority);
 
-        // Fee
-        int64_t nFee = payTxFee.GetFee(max((unsigned int)1000, nBytes));
-
         // Min Fee
         nPayFee = CWallet::GetMinimumFee(nBytes, nTxConfirmTarget, mempool);
 


### PR DESCRIPTION
Unused since the new fee/priority estimate code was merged in b33d1f5e
