### PR TITLE
Update Debian packaging description for new bitcoin-cli

### DIFF
--- a/contrib/debian/control
+++ b/contrib/debian/control
@@ -39,8 +39,9 @@ Description: peer-to-peer network based digital currency - daemon
  Full transaction history is stored locally at each client.  This
  requires 20+ GB of space, slowly growing.
  .
- This package provides bitcoind, a combined daemon and CLI tool to
- interact with the daemon.
+
+ This package provides the daemon, bitcoind, and the CLI tool
+ bitcoin-cli to interact with the daemon.
 
 Package: bitcoin-qt
 Architecture: any


### PR DESCRIPTION
Minor, text-only change to update Debian package description to account for bitcoin-cli split.
