### PR TITLE
Added libtool generated files to ignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ autom4te.cache/
 config.log
 config.status
 configure
+libtool
+src/m4/lt*.m4
+src/m4/libtool.m4
 src/config/bitcoin-config.h
 src/config/bitcoin-config.h.in
 src/config/stamp-h1


### PR DESCRIPTION
Libtool creates several files during build that should not show up as unversioned files for commit; this adds them to the top-level .gitignore.
