### PR TITLE
Bugfix: only remove actualy failed blocks from setBlockIndexValid

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2073,7 +2073,7 @@ static CBlockIndex* FindMostWorkChain() {
         CBlockIndex *pindexTest = pindexNew;
         bool fInvalidAncestor = false;
         while (pindexTest && !chainActive.Contains(pindexTest)) {
-            if (!pindexTest->IsValid(BLOCK_VALID_TRANSACTIONS) || !(pindexTest->nStatus & BLOCK_HAVE_DATA)) {
+            if (pindexTest->nStatus & BLOCK_FAILED_MASK) {
                 // Candidate has an invalid ancestor, remove entire chain from the set.
                 if (pindexBestInvalid == NULL || pindexNew->nChainWork > pindexBestInvalid->nChainWork)
                     pindexBestInvalid = pindexNew;
@@ -2083,6 +2083,7 @@ static CBlockIndex* FindMostWorkChain() {
                     setBlockIndexValid.erase(pindexFailed);
                     pindexFailed = pindexFailed->pprev;
                 }
+                setBlockIndexValid.erase(pindexTest);
                 fInvalidAncestor = true;
                 break;
             }


### PR DESCRIPTION
Fix an unexposed bug in dealing with invalid blocks: only chains with actually invalid blocks should be removed from the set of potentially new tips.

Also, in case an error is found, the failed block itself must be removed from that set.

This would be exposed by #4468.
