### PR TITLE
getblocktemplate: longpolling support (v2)

### DIFF
--- a/qa/rpc-tests/getblocktemplate.py
+++ b/qa/rpc-tests/getblocktemplate.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python
+# Copyright (c) 2014 The Bitcoin Core developers
+# Distributed under the MIT/X11 software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+# Exercise the listtransactions API
+
+from test_framework import BitcoinTestFramework
+from bitcoinrpc.authproxy import AuthServiceProxy, JSONRPCException
+from util import *
+
+
+def check_array_result(object_array, to_match, expected):
+    """
+    Pass in array of JSON objects, a dictionary with key/value pairs
+    to match against, and another dictionary with expected key/value
+    pairs.
+    """
+    num_matched = 0
+    for item in object_array:
+        all_match = True
+        for key,value in to_match.items():
+            if item[key] != value:
+                all_match = False
+        if not all_match:
+            continue
+        for key,value in expected.items():
+            if item[key] != value:
+                raise AssertionError("%s : expected %s=%s"%(str(item), str(key), str(value)))
+            num_matched = num_matched+1
+    if num_matched == 0:
+        raise AssertionError("No objects matched %s"%(str(to_match)))
+
+import threading
+
+class LongpollThread(threading.Thread):
+    def __init__(self, node):
+        threading.Thread.__init__(self)
+        # query current longpollid
+        templat = node.getblocktemplate()
+        self.longpollid = templat['longpollid']
+        # create a new connection to the node, we can't use the same
+        # connection from two threads
+        self.node = AuthServiceProxy(node.url, timeout=600)
+
+    def run(self):
+        self.node.getblocktemplate({'longpollid':self.longpollid})
+
+class GetBlockTemplateTest(BitcoinTestFramework):
+    '''
+    Test longpolling with getblocktemplate.
+    '''
+
+    def run_test(self, nodes):
+        print "Warning: this test will take about 70 seconds in the best case. Be patient."
+        nodes[0].setgenerate(True, 10)
+        templat = nodes[0].getblocktemplate()
+        longpollid = templat['longpollid']
+        # longpollid should not change between successive invocations if nothing else happens
+        templat2 = nodes[0].getblocktemplate()
+        assert(templat2['longpollid'] == longpollid)
+
+        # Test 1: test that the longpolling wait if we do nothing
+        thr = LongpollThread(nodes[0])
+        thr.start()
+        # check that thread still lives
+        thr.join(5)  # wait 5 seconds or until thread exits
+        assert(thr.is_alive())
+
+        # Test 2: test that longpoll will terminate if another node generates a block
+        nodes[1].setgenerate(True, 1)  # generate a block on another node
+        # check that thread will exit now that new transaction entered mempool
+        thr.join(5)  # wait 5 seconds or until thread exits
+        assert(not thr.is_alive())
+
+        # Test 3: test that longpoll will terminate if we generate a block ourselves
+        thr = LongpollThread(nodes[0])
+        thr.start()
+        nodes[0].setgenerate(True, 1)  # generate a block on another node
+        thr.join(5)  # wait 5 seconds or until thread exits
+        assert(not thr.is_alive())
+
+        # Test 4: test that introducing a new transaction into the mempool will terminate the longpoll
+        thr = LongpollThread(nodes[0])
+        thr.start()
+        # generate a random transaction and submit it
+        (txid, txhex, fee) = random_transaction(nodes, Decimal("1.1"), Decimal("0.0"), Decimal("0.001"), 20)
+        # after one minute, every 10 seconds the mempool is probed, so in 80 seconds it should have returned
+        thr.join(60 + 20)
+        assert(not thr.is_alive())
+
+if __name__ == '__main__':
+    GetBlockTemplateTest().main()
+

--- a/qa/rpc-tests/util.py
+++ b/qa/rpc-tests/util.py
@@ -156,7 +156,9 @@ def start_node(i, dir, extra_args=None, rpchost=None):
                           ["-rpcwait", "getblockcount"], stdout=devnull)
     devnull.close()
     url = "http://rt:rt@%s:%d" % (rpchost or '127.0.0.1', rpc_port(i))
-    return AuthServiceProxy(url)
+    proxy = AuthServiceProxy(url)
+    proxy.url = url # store URL on proxy for info
+    return proxy
 
 def start_nodes(num_nodes, dir, extra_args=None, rpchost=None):
     """

--- a/src/main.h
+++ b/src/main.h
@@ -87,6 +87,8 @@ extern uint64_t nLastBlockTx;
 extern uint64_t nLastBlockSize;
 extern const std::string strMessageMagic;
 extern int64_t nTimeBestReceived;
+extern CWaitableCriticalSection csBestBlock;
+extern CConditionVariable cvBlockChange;
 extern bool fImporting;
 extern bool fReindex;
 extern bool fBenchmark;

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -40,6 +40,8 @@ void StartRPCThreads();
 void StartDummyRPCThread();
 /* Stop RPC threads */
 void StopRPCThreads();
+/* Query whether RPC is running */
+bool IsRPCRunning();
 
 /*
   Type-check arguments; throws JSONRPCError if wrong type given. Does not check that

--- a/src/sync.h
+++ b/src/sync.h
@@ -84,6 +84,9 @@ typedef AnnotatedMixin<boost::recursive_mutex> CCriticalSection;
 /** Wrapped boost mutex: supports waiting but not recursive locking */
 typedef AnnotatedMixin<boost::mutex> CWaitableCriticalSection;
 
+/** Just a typedef for boost::condition_variable, can be wrapped later if desired */
+typedef boost::condition_variable CConditionVariable;
+
 #ifdef DEBUG_LOCKORDER
 void EnterCritical(const char* pszName, const char* pszFile, int nLine, void* cs, bool fTry = false);
 void LeaveCritical();


### PR DESCRIPTION
A bit reworked version of #2834 'getblocktemplate: longpolling support'. Just a final push in trying to get it merged.
- Add a function `IsRPCRunning()`
- Remove unnecessary added includes
- Use our own `CWaitableCriticalSection` instead of `boost::mutex` (amounts to the same, ours is a wrapper)
- Add our own typedef `CConditionVariable` for `boost::condition_variable`
- Make it compile and work in disable-wallet builds, as well as when running in runtime disable-wallet mode

Note: currently untested! I still need to find something to test this with @luke-jr.
