### PR TITLE
Clarify that redeemScript is often optional

### DIFF
--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -523,7 +523,7 @@ Value signrawtransaction(const Array& params, bool fHelp)
             "         \"txid\":\"id\",             (string, required) The transaction id\n"
             "         \"vout\":n,                  (numeric, required) The output number\n"
             "         \"scriptPubKey\": \"hex\",   (string, required) script key\n"
-            "         \"redeemScript\": \"hex\"    (string, required) redeem script\n"
+            "         \"redeemScript\": \"hex\"    (string, required for P2SH) redeem script\n"
             "       }\n"
             "       ,...\n"
             "    ]\n"


### PR DESCRIPTION
If described as "required", folks like me who know only enough to be dangerous sit there scratching our heads/trawling the web for a while trying to work out what to put there and where to get it from (although recently I spotted that the developer docs have [an example of not supplying it](https://bitcoin.org/en/developer-examples#offline-signing)).
