### PR TITLE
Do not overwrite mempool transactions with equivalent double-spends

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -964,11 +964,12 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
     {
         COutPoint outpoint = tx.vin[i].prevout;
         // Does tx conflict with a member of the pool, and is it not equivalent to that member?
-        if (pool.mapNextTx.count(outpoint) && !tx.IsEquivalentTo(*pool.mapNextTx[outpoint].ptx))
-        {
-            relayableRespend = RelayableRespend(outpoint, tx, false, doubleSpendFilter);
-            if (!relayableRespend)
+        if (pool.mapNextTx.count(outpoint)) {
+            if (!tx.IsEquivalentTo(*pool.mapNextTx[outpoint].ptx) && RelayableRespend(outpoint, tx, false, doubleSpendFilter)) {
+                relayableRespend = true;
+            } else {
                 return false;
+            }
         }
     }
     }


### PR DESCRIPTION
#4450 introduced a check for non-equivalent double spends and relaying, but for _equivalent_ double spends it changed existing behaviour by still calling mempool.addUnchecked() on them. This breaks mempool consistency (detected using -checkmempool after a few days of running), which could be exploited to crash miner's nodes.
