### PR TITLE
[Qt] Fix segfault when launched with -disablewallet

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -159,10 +159,13 @@ BitcoinGUI::BitcoinGUI(bool fIsTestnet, QWidget *parent) :
     labelEncryptionIcon = new QLabel();
     labelConnectionsIcon = new QLabel();
     labelBlocksIcon = new QLabel();
-    frameBlocksLayout->addStretch();
-    frameBlocksLayout->addWidget(unitDisplayControl);
-    frameBlocksLayout->addStretch();
-    frameBlocksLayout->addWidget(labelEncryptionIcon);
+    if(enableWallet)
+    {
+        frameBlocksLayout->addStretch();
+        frameBlocksLayout->addWidget(unitDisplayControl);
+        frameBlocksLayout->addStretch();
+        frameBlocksLayout->addWidget(labelEncryptionIcon);
+    }
     frameBlocksLayout->addStretch();
     frameBlocksLayout->addWidget(labelConnectionsIcon);
     frameBlocksLayout->addStretch();

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -473,6 +473,10 @@ void RPCConsole::on_tabWidget_currentChanged(int index)
     {
         ui->lineEdit->setFocus();
     }
+    else if(ui->tabWidget->widget(index) == ui->tab_peers)
+    {
+        initPeerTable();
+    }
 }
 
 void RPCConsole::on_openDebugLogfileButton_clicked()
@@ -648,17 +652,10 @@ void RPCConsole::updateNodeDetail(const CNodeCombinedStats *combinedStats)
         ui->peerBanScore->setText(tr("Fetching..."));
 }
 
-// We override the virtual resizeEvent of the QWidget to adjust tables column
-// sizes as the tables width is proportional to the dialogs width.
-void RPCConsole::resizeEvent(QResizeEvent *event)
+void RPCConsole::initPeerTable()
 {
-    QWidget::resizeEvent(event);
-    columnResizingFixer->stretchColumnWidth(PeerTableModel::Address);
-}
-
-void RPCConsole::showEvent(QShowEvent *event)
-{
-    QWidget::showEvent(event);
+    if (!clientModel)
+        return;
 
     // peerWidget needs a resize in case the dialog has non-default geometry
     columnResizingFixer->stretchColumnWidth(PeerTableModel::Address);
@@ -667,9 +664,31 @@ void RPCConsole::showEvent(QShowEvent *event)
     clientModel->getPeerTableModel()->startAutoRefresh(1000);
 }
 
+// We override the virtual resizeEvent of the QWidget to adjust tables column
+// sizes as the tables width is proportional to the dialogs width.
+void RPCConsole::resizeEvent(QResizeEvent *event)
+{
+    QWidget::resizeEvent(event);
+
+    if (!clientModel)
+        return;
+
+    columnResizingFixer->stretchColumnWidth(PeerTableModel::Address);
+}
+
+void RPCConsole::showEvent(QShowEvent *event)
+{
+    QWidget::showEvent(event);
+
+    initPeerTable();
+}
+
 void RPCConsole::hideEvent(QHideEvent *event)
 {
     QWidget::hideEvent(event);
+
+    if (!clientModel)
+        return;
 
     // stop PeerTableModel auto refresh
     clientModel->getPeerTableModel()->stopAutoRefresh();

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -47,6 +47,8 @@ protected:
 private:
     /** show detailed information on ui about selected node */
     void updateNodeDetail(const CNodeCombinedStats *combinedStats);
+    /** initialize peer table */
+    void initPeerTable();
 
     enum ColumnWidths
     {


### PR DESCRIPTION
An early MessageBox triggers showNormalIfMinimized() which triggers the show-events in rpcconsole in disablewallet-mode causing segfaults when clientModel is not set.

Unrelated change, but I noticed the unitDisplay icon is shown in disablewallet-mode, doesnt make sense for now.

Fixes #4516
