### PR TITLE
[Qt] Fix No such slot UnitDisplayStatusBarControl::onDisplayUnitsClicked

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1012,7 +1012,7 @@ UnitDisplayStatusBarControl::UnitDisplayStatusBarControl():QLabel()
     setToolTip(tr("Unit to show amounts in. Click to select another unit."));
 }
 
-/** So that it responds to left-button clicks */
+/** So that it responds to button clicks */
 void UnitDisplayStatusBarControl::mousePressEvent(QMouseEvent *event)
 {
     onDisplayUnitsClicked(event->pos());
@@ -1029,10 +1029,6 @@ void UnitDisplayStatusBarControl::createContextMenu()
         menu->addAction(menuAction);
     }
     connect(menu,SIGNAL(triggered(QAction*)),this,SLOT(onMenuSelection(QAction*)));
-
-    // what happens on right click.
-    setContextMenuPolicy(Qt::CustomContextMenu);
-    connect(this,SIGNAL(customContextMenuRequested(const QPoint&)),this,SLOT(onDisplayUnitsClicked(const QPoint&)));
 }
 
 /** Lets the control know about the Options Model (and its signals) */


### PR DESCRIPTION
debug.log currently shows a warning

`Object::connect: No such slot UnitDisplayStatusBarControl::onDisplayUnitsClicked(const QPoint&) in qt/bitcoingui.cpp:1043`

So the line does not work anyway, it can be removed because right-click is also triggered through mousePressEvent.
