### PR TITLE
Set -discover=0 in regtest framework

### DIFF
--- a/qa/rpc-tests/util.py
+++ b/qa/rpc-tests/util.py
@@ -85,7 +85,7 @@ def initialize_chain(test_dir):
         # Create cache directories, run bitcoinds:
         for i in range(4):
             datadir=initialize_datadir("cache", i)
-            args = [ "bitcoind", "-keypool=1", "-datadir="+datadir ]
+            args = [ "bitcoind", "-keypool=1", "-datadir="+datadir, "-discover=0" ]
             if i > 0:
                 args.append("-connect=127.0.0.1:"+str(p2p_port(0)))
             bitcoind_processes[i] = subprocess.Popen(args)
@@ -147,7 +147,7 @@ def start_node(i, dir, extra_args=None, rpchost=None):
     Start a bitcoind and return RPC connection to it
     """
     datadir = os.path.join(dir, "node"+str(i))
-    args = [ "bitcoind", "-datadir="+datadir, "-keypool=1" ]
+    args = [ "bitcoind", "-datadir="+datadir, "-keypool=1", "-discover=0" ]
     if extra_args is not None: args.extend(extra_args)
     bitcoind_processes[i] = subprocess.Popen(args)
     devnull = open("/dev/null", "w+")


### PR DESCRIPTION
The regtest framework is local, so don't try to discover our external IP.  This should keep those writing regtests from spending time debugging to #4502.

I suspect this also caused the pulltester hang mentioned in #4485.

3rd party IP providers seem to be interpreting node stop/start activity, common in regtests, to be DoS, making shutdown problems more common that one might otherwise expect.
