### PR TITLE
Fix for error in 'getbalance' when using watchonly addresses/scripts.

### DIFF
--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -845,7 +845,7 @@ void CWalletTx::GetAmounts(list<pair<CTxDestination, int64_t> >& listReceived,
             listSent.push_back(make_pair(address, txout.nValue));
 
         // If we are receiving the output, add it as a "received" entry
-        if (fIsMine)
+        if (fIsMine & filter)
             listReceived.push_back(make_pair(address, txout.nValue));
     }
 


### PR DESCRIPTION
This bug can result in too much watchonly balance being returned by the getbalance RPC call.
