### PR TITLE
Move uint256.cpp from util to common lib

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -190,6 +190,7 @@ libbitcoin_common_a_SOURCES = \
   keystore.cpp \
   netbase.cpp \
   protocol.cpp \
+  uint256.cpp \
   script.cpp \
   $(BITCOIN_CORE_H)
 
@@ -204,7 +205,6 @@ libbitcoin_util_a_SOURCES = \
   random.cpp \
   rpcprotocol.cpp \
   sync.cpp \
-  uint256.cpp \
   util.cpp \
   version.cpp \
   $(BITCOIN_CORE_H)

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -8,7 +8,6 @@
 #include "chainparamsbase.h"
 #include "random.h"
 #include "sync.h"
-#include "uint256.h"
 #include "version.h"
 
 #include <stdarg.h>

--- a/src/util.h
+++ b/src/util.h
@@ -32,8 +32,6 @@
 #include <boost/filesystem/path.hpp>
 #include <boost/thread.hpp>
 
-class uint256;
-
 static const int64_t COIN = 100000000;
 static const int64_t CENT = 1000000;
 


### PR DESCRIPTION
After #4400 util does not need to depend on uint256 anymore, so it can move up.
