### PR TITLE
[Qt] Prevent balloon-spam after rescan

### DIFF
--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -133,6 +133,7 @@ public:
     qint64 getWatchImmatureBalance() const;
     int getNumTransactions() const;
     EncryptionStatus getEncryptionStatus() const;
+    bool processingQueuedTransactions() { return fProcessingQueuedTransactions; }
 
     // Check address for validity
     bool validateAddress(const QString &address);
@@ -196,6 +197,7 @@ public:
 
 private:
     CWallet *wallet;
+    bool fProcessingQueuedTransactions;
 
     // Wallet has an options model for wallet-specific options
     // (transaction fee, for example)
@@ -256,6 +258,8 @@ public slots:
     void updateAddressBook(const QString &address, const QString &label, bool isMine, const QString &purpose, int status);
     /* Current, immature or unconfirmed balance might have changed - emit 'balanceChanged' if so */
     void pollBalanceChanged();
+    /* Needed to update fProcessingQueuedTransactions through a QueuedConnection */
+    void setProcessingQueuedTransactions(bool value) { fProcessingQueuedTransactions = value; }
 };
 
 #endif // WALLETMODEL_H

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -137,7 +137,7 @@ void WalletView::setWalletModel(WalletModel *walletModel)
 void WalletView::processNewTransaction(const QModelIndex& parent, int start, int /*end*/)
 {
     // Prevent balloon-spam when initial block download is in progress
-    if (!walletModel || !clientModel || clientModel->inInitialBlockDownload())
+    if (!walletModel || walletModel->processingQueuedTransactions() || !clientModel || clientModel->inInitialBlockDownload())
         return;
 
     TransactionTableModel *ttm = walletModel->getTransactionTableModel();


### PR DESCRIPTION
`importaddress mrhz5ZgSF3C1BSdyCKt3gEdhKoRL5BNfJV`
adds like 2500 transactions to the wallet, this caused my desktop-panel to freeze, because of the balloon spam,
so show maximum of 100 balloons after rescan.
