### PR TITLE
[Qt] Fix bitcoin-qt --help Assertion failed

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -507,6 +507,7 @@ int main(int argc, char *argv[])
     {
         HelpMessageDialog help(NULL, mapArgs.count("-version"));
         help.showOrPrint();
+        SelectParamsFromCommandLine();
         return 1;
     }
 
@@ -520,6 +521,7 @@ int main(int argc, char *argv[])
     {
         QMessageBox::critical(0, QObject::tr("Bitcoin"),
                               QObject::tr("Error: Specified data directory \"%1\" does not exist.").arg(QString::fromStdString(mapArgs["-datadir"])));
+        SelectParamsFromCommandLine();
         return 1;
     }
     try {
@@ -527,6 +529,7 @@ int main(int argc, char *argv[])
     } catch(std::exception &e) {
         QMessageBox::critical(0, QObject::tr("Bitcoin"),
                               QObject::tr("Error: Cannot parse configuration file: %1. Only use key=value syntax.").arg(e.what()));
+        SelectParamsFromCommandLine();
         return false;
     }
 


### PR DESCRIPTION
`bitcoin-qt --help` shows error
`bitcoin-qt: chainparamsbase.cpp:56: const CBaseChainParams& BaseParams(): Assertion 'pCurrentBaseParams' failed.
Aborted`

after the help is printed. The reason is we return before SelectParamsFromCommandLine(), not sure if there is a cleaner fix to this problem though.
