### PR TITLE
Fix semantic typo in state.CorruptionPossible check

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2517,7 +2517,7 @@ bool AcceptBlock(CBlock& block, CValidationState& state, CBlockIndex** ppindex, 
         return false;
 
     if (!CheckBlock(block, state)) {
-        if (state.Invalid() && !state.CorruptionPossible()) {
+        if (state.IsInvalid() && !state.CorruptionPossible()) {
             pindex->nStatus |= BLOCK_FAILED_VALID;
         }
         return false;


### PR DESCRIPTION
state.Invalid() is always false and alters state, check should be IsInvalid()

Broken since 942b33a
