### PR TITLE
Implement "getchains" RPC command to monitor blockchain forks.

### DIFF
--- a/qa/rpc-tests/getchaintips.py
+++ b/qa/rpc-tests/getchaintips.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+# Copyright (c) 2014 The Bitcoin Core developers
+# Distributed under the MIT/X11 software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+# Exercise the getchaintips API.
+
+# Since the test framework does not generate orphan blocks, we can
+# unfortunately not check for them!
+
+from test_framework import BitcoinTestFramework
+from util import assert_equal
+
+class GetChainTipsTest (BitcoinTestFramework):
+
+    def run_test (self, nodes):
+        res = nodes[0].getchaintips ()
+        assert_equal (len (res), 1)
+        res = res[0]
+        assert_equal (res['branchlen'], 0)
+        assert_equal (res['height'], 200)
+
+if __name__ == '__main__':
+    GetChainTipsTest ().main ()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -444,7 +444,7 @@ CBlockIndex *CChain::FindFork(const CBlockLocator &locator) const {
     return Genesis();
 }
 
-CBlockIndex *CChain::FindFork(CBlockIndex *pindex) const {
+const CBlockIndex *CChain::FindFork(const CBlockIndex *pindex) const {
     if (pindex->nHeight > Height())
         pindex = pindex->GetAncestor(Height());
     while (pindex && !Contains(pindex))
@@ -2067,8 +2067,8 @@ static CBlockIndex* FindMostWorkChain() {
 static bool ActivateBestChainStep(CValidationState &state, CBlockIndex *pindexMostWork) {
     AssertLockHeld(cs_main);
     bool fInvalidFound = false;
-    CBlockIndex *pindexOldTip = chainActive.Tip();
-    CBlockIndex *pindexFork = chainActive.FindFork(pindexMostWork);
+    const CBlockIndex *pindexOldTip = chainActive.Tip();
+    const CBlockIndex *pindexFork = chainActive.FindFork(pindexMostWork);
 
     // Disconnect active blocks which are no longer in the best chain.
     while (chainActive.Tip() && chainActive.Tip() != pindexFork) {

--- a/src/main.h
+++ b/src/main.h
@@ -1068,7 +1068,7 @@ public:
     CBlockIndex *FindFork(const CBlockLocator &locator) const;
 
     /** Find the last common block between this chain and a block index entry. */
-    CBlockIndex *FindFork(CBlockIndex *pindex) const;
+    const CBlockIndex *FindFork(const CBlockIndex *pindex) const;
 };
 
 /** The currently-connected chain of blocks. */

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -235,6 +235,7 @@ static const CRPCCommand vRPCCommands[] =
     { "getblockcount",          &getblockcount,          true,      false,      false },
     { "getblock",               &getblock,               true,      false,      false },
     { "getblockhash",           &getblockhash,           true,      false,      false },
+    { "getchaintips",           &getchaintips,           true,      false,      false },
     { "getdifficulty",          &getdifficulty,          true,      false,      false },
     { "getrawmempool",          &getrawmempool,          true,      false,      false },
     { "gettxout",               &gettxout,               true,      false,      false },

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -205,5 +205,6 @@ extern json_spirit::Value getblock(const json_spirit::Array& params, bool fHelp)
 extern json_spirit::Value gettxoutsetinfo(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value gettxout(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value verifychain(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value getchaintips(const json_spirit::Array& params, bool fHelp);
 
 #endif


### PR DESCRIPTION
Port over https://github.com/chronokings/huntercoin/pull/19 from
Huntercoin:  This implements a new RPC command "getchains" that can be
used to find all currently active chain heads.  This is similar to the
-printblocktree startup option, but it can be used without restarting
just via the RPC interface on a running daemon.
