### PR TITLE
Add a new checkpoint at block 295,000

### DIFF
--- a/src/checkpoints.cpp
+++ b/src/checkpoints.cpp
@@ -51,11 +51,12 @@ namespace Checkpoints {
         (225430, uint256("0x00000000000001c108384350f74090433e7fcf79a606b8e797f065b130575932"))
         (250000, uint256("0x000000000000003887df1f29024b06fc2200b55f8af8f35453d7be294df2d214"))
         (279000, uint256("0x0000000000000001ae8c72a0b0c301f67e3afca10e819efa9041e458e9bd7e40"))
+        (295000, uint256("0x00000000000000004d9b4ef50f0f9d686fd69db2e03af35a100370c64632a983"))
         ;
     static const CCheckpointData data = {
         &mapCheckpoints,
-        1389047471, // * UNIX timestamp of last checkpoint block
-        30549816,   // * total number of transactions between genesis and last checkpoint
+        1397080064, // * UNIX timestamp of last checkpoint block
+        36544669,   // * total number of transactions between genesis and last checkpoint
                     //   (the tx=... number in the SetBestChain debug.log lines)
         60000.0     // * estimated number of transactions per day after checkpoint
     };


### PR DESCRIPTION
Block 295,000 seems to meet the criteria of a reasonable timestamp and
no strange transactions. 295,000 is the current block height in the
bootstrap.dat torrent provided by jgarzik.
