### PR TITLE
Fix misbehave disconnect bug introduced in #4378

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1427,9 +1427,7 @@ void Misbehaving(NodeId pnode, int howmuch)
         return;
 
     state->nMisbehavior += howmuch;
-    int banscore = GetArg("-banscore", 100);
-    if (state->nMisbehavior >= banscore && state->nMisbehavior - howmuch < banscore)
-    {
+    if (state->nMisbehavior >= GetArg("-banscore", 100)) {
         LogPrintf("Misbehaving: %s (%d -> %d) BAN THRESHOLD EXCEEDED\n", state->name, state->nMisbehavior-howmuch, state->nMisbehavior);
         state->fShouldBan = true;
     } else


### PR DESCRIPTION
#4378 introduced a bug so that a node would never be disconnected if any single instance of misbehavior was equal to or greater than the total amount of misbehavior permitted.
