### PR TITLE
prevent peer flooding request queue for an inv

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4583,6 +4583,7 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
                     vGetData.clear();
                 }
             }
+            pto->setAskFor.erase(inv.hash);
             pto->mapAskFor.erase(pto->mapAskFor.begin());
         }
         if (!vGetData.empty())

--- a/src/net.h
+++ b/src/net.h
@@ -286,6 +286,7 @@ public:
     mruset<CInv> setInventoryKnown;
     std::vector<CInv> vInventoryToSend;
     CCriticalSection cs_inventory;
+    std::set<uint256> setAskFor;
     std::multimap<int64_t, CInv> mapAskFor;
 
     // Ping time measurement:
@@ -453,6 +454,10 @@ public:
 
     void AskFor(const CInv& inv)
     {
+        // a peer may not occupy multiple positions in an inv's request queue
+        if (!setAskFor.insert(inv.hash).second)
+            return;
+
         // We're using mapAskFor as a priority queue,
         // the key is the earliest time the request can be sent
         int64_t nRequestTime;


### PR DESCRIPTION
mapAlreadyAskedFor does not keep track of which peer has a request queued for a particular tx. As a result, a peer can blind a node to a tx indefinitely by sending many invs for the same tx, and then never replying to getdatas for it. Each inv received will be placed 2 minutes farther back in mapAlreadyAskedFor, so a short message containing 10 invs would render that tx unavailable for 20 minutes.

This is fixed by disallowing a peer from having more than one entry for a particular inv in mapAlreadyAskedFor at a time.
