### PR TITLE
More test cases for transaction scripts

### DIFF
--- a/src/test/data/script_invalid.json
+++ b/src/test/data/script_invalid.json
@@ -272,6 +272,9 @@
 ["2147483647", "1ADD 1SUB 1", "We cannot do math on 5-byte integers, even if the result is 4-bytes"],
 ["2147483648", "1SUB 1", "We cannot do math on 5-byte integers, even if the result is 4-bytes"],
 
+["2147483648 1", "BOOLOR 1", "We cannot do BOOLOR on 5-byte integers (but we can still do IF etc)"],
+["2147483648 1", "BOOLAND 1", "We cannot do BOOLAND on 5-byte integers"],
+
 ["1", "1 ENDIF", "ENDIF without IF"],
 ["1", "IF 1", "IF without ENDIF"],
 ["1 IF 1", "ENDIF", "IFs don't carry over"],

--- a/src/test/data/script_invalid.json
+++ b/src/test/data/script_invalid.json
@@ -352,6 +352,9 @@
 "NOP NOP NOP NOP NOP NOP NOP NOP NOP NOP NOP NOP NOP 0 0 'a' 'b' 'c' 'd' 'e' 'f' 'g' 'h' 'i' 'j' 'k' 'l' 'm' 'n' 'o' 'p' 'q' 'r' 's' 't' 20 CHECKMULTISIGVERIFY 0 0 'a' 'b' 'c' 'd' 'e' 'f' 'g' 'h' 'i' 'j' 'k' 'l' 'm' 'n' 'o' 'p' 'q' 'r' 's' 't' 20 CHECKMULTISIGVERIFY 0 0 'a' 'b' 'c' 'd' 'e' 'f' 'g' 'h' 'i' 'j' 'k' 'l' 'm' 'n' 'o' 'p' 'q' 'r' 's' 't' 20 CHECKMULTISIGVERIFY 0 0 'a' 'b' 'c' 'd' 'e' 'f' 'g' 'h' 'i' 'j' 'k' 'l' 'm' 'n' 'o' 'p' 'q' 'r' 's' 't' 20 CHECKMULTISIGVERIFY 0 0 'a' 'b' 'c' 'd' 'e' 'f' 'g' 'h' 'i' 'j' 'k' 'l' 'm' 'n' 'o' 'p' 'q' 'r' 's' 't' 20 CHECKMULTISIGVERIFY 0 0 'a' 'b' 'c' 'd' 'e' 'f' 'g' 'h' 'i' 'j' 'k' 'l' 'm' 'n' 'o' 'p' 'q' 'r' 's' 't' 20 CHECKMULTISIGVERIFY 0 0 'a' 'b' 'c' 'd' 'e' 'f' 'g' 'h' 'i' 'j' 'k' 'l' 'm' 'n' 'o' 'p' 'q' 'r' 's' 't' 20 CHECKMULTISIGVERIFY 0 0 'a' 'b' 'c' 'd' 'e' 'f' 'g' 'h' 'i' 'j' 'k' 'l' 'm' 'n' 'o' 'p' 'q' 'r' 's' 't' 20 CHECKMULTISIGVERIFY 0 0 'a' 'b' 'c' 'd' 'e' 'f' 'g' 'h' 'i' 'j' 'k' 'l' 'm' 'n' 'o' 'p' 'q' 'r' 's' 't' 20 CHECKMULTISIGVERIFY"],
 
 
+["0 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21", "21 CHECKMULTISIG 1", "nPubKeys > 20"],
+["0 'sig' 1 0", "CHECKMULTISIG 1", "nSigs > nPubKeys"],
+
 
 ["NOP 0x01 1", "HASH160 0x14 0xda1745e9b549bd0bfa1a569971c77eba30cd5a4b EQUAL", "Tests for Script.IsPushOnly()"],
 ["NOP1 0x01 1", "HASH160 0x14 0xda1745e9b549bd0bfa1a569971c77eba30cd5a4b EQUAL"],

--- a/src/test/data/script_valid.json
+++ b/src/test/data/script_valid.json
@@ -126,6 +126,7 @@
 ["-9223372036854775807", "SIZE 8 EQUAL"],
 ["'abcdefghijklmnopqrstuvwxyz'", "SIZE 26 EQUAL"],
 
+["42", "SIZE 1 EQUALVERIFY 42 EQUAL", "SIZE does not consume argument"],
 
 ["2 -2 ADD", "0 EQUAL"],
 ["2147483647 -2147483647 ADD", "0 EQUAL"],

--- a/src/test/data/script_valid.json
+++ b/src/test/data/script_valid.json
@@ -66,6 +66,7 @@
 ["0", "IF RETURN ENDIF 1", "RETURN only works if executed"],
 
 ["1 1", "VERIFY"],
+["1 0x05 0x01 0x00 0x00 0x00 0x00", "VERIFY", "values >4 bytes can be cast to boolean"],
 
 ["10 0 11 TOALTSTACK DROP FROMALTSTACK", "ADD 21 EQUAL"],
 ["'gavin_was_here' TOALTSTACK 11 FROMALTSTACK", "'gavin_was_here' EQUALVERIFY 11 EQUAL"],

--- a/src/test/data/script_valid.json
+++ b/src/test/data/script_valid.json
@@ -10,6 +10,7 @@
 ["  1  2  ", "2 EQUALVERIFY 1 EQUAL"],
 
 ["1", ""],
+["0x09 0x00000000 0x00000000 0x10", "", "equals zero when cast to Int64"],
 
 ["0x01 0x0b", "11 EQUAL", "push 1 byte"],
 ["0x02 0x417a", "'Az' EQUAL"],

--- a/src/test/data/script_valid.json
+++ b/src/test/data/script_valid.json
@@ -10,6 +10,7 @@
 ["  1  2  ", "2 EQUALVERIFY 1 EQUAL"],
 
 ["1", ""],
+["0x02 0x01 0x00", "", "all bytes are significant, not only the last one"],
 ["0x09 0x00000000 0x00000000 0x10", "", "equals zero when cast to Int64"],
 
 ["0x01 0x0b", "11 EQUAL", "push 1 byte"],


### PR DESCRIPTION
These are some edge cases that I have detected using QuickCheck in the Haskoin project which are not covered by the existing test suite. 

In `script_valid.json`:
1. All bytes of a boolean constant are significant, not only the last one. I had a dumb bug where I only checked the last byte, but it passed the test suite.
2. Also casting the stack value to a 64 bit int works _most_ of the time, unless the value overflows to 0. Added a test for that. 
3. `SIZE` does not consume the argument. Many commands consume the input argument, some don't, I think generally there could be more test coverage of that. Maybe build a test that puts a bunch of constants on the stack, execute a bunch of operations (for which the test makes sense) and test the value and stack depth in the end.

In `script_invalid.json`: 
1. `BOOLAND` + `BOOLOR` have a slightly different conception of boolean values: these functions cast inputs to `int64` and compare against zero, so they must fail for five-byte stack values. 
2. Limits for `CHECKMULTISIG` were not tested:  `(nKeys < 20)` and `(nSigs <= nKeys)`
