### PR TITLE
fixed small typo (%1 KB instead of 1% KB)

### DIFF
--- a/src/qt/locale/bitcoin_pt_BR.ts
+++ b/src/qt/locale/bitcoin_pt_BR.ts
@@ -1507,7 +1507,7 @@ Endereço: %4</translation>
     </message>
     <message>
         <source>%1 KB</source>
-        <translation>1% KB</translation>
+        <translation>%1 KB</translation>
     </message>
     <message>
         <source>%1 MB</source>


### PR DESCRIPTION
the %1 argument had a typo reading as 1%.
