### PR TITLE
Relay first double-spend as alert, notify wallet

### DIFF
--- a/contrib/debian/manpages/bitcoin-qt.1
+++ b/contrib/debian/manpages/bitcoin-qt.1
@@ -136,6 +136,9 @@ Execute command when the best block changes (%s in cmd is replaced by block hash
 \fB\-walletnotify=\fR<cmd>
 Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)
 .TP
+\fB\-respendnotify=\fR<cmd>
+Execute command when a network tx respends wallet tx input (%s=respend TxID, %t=wallet TxID)
+.TP
 \fB\-alertnotify=\fR<cmd>
 Execute command when a relevant alert is received (%s in cmd is replaced by message)
 .TP

--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -25,6 +25,52 @@ git merge commit are mentioned.
 
 ### P2P protocol and network code
 
+Double-Spend Relay and Alerts
+=============================
+VERY IMPORTANT: *It has never been safe, and remains unsafe, to rely*
+*on unconfirmed transactions.*
+
+Relay
+-----
+When an attempt is seen on the network to spend the same unspent funds
+more than once, it is no longer ignored.  Instead, it is broadcast, to
+serve as an alert.  This broadcast is subject to protections against
+denial-of-service attacks.
+
+Wallets and other bitcoin services should alert their users to
+double-spends that affect them.  Merchants and other users may have
+enough time to withhold goods or services when payment becomes
+uncertain, until confirmation.
+
+Bitcoin Core Wallet Alerts
+--------------------------
+The Bitcoin Core wallet now makes respend attempts visible in several
+ways.
+
+If you are online, and a respend affecting one of your wallet
+transactions is seen, a notification is immediately issued to the
+command registered with `-respendnotify=<cmd>`.  Additionally, if
+using the GUI:
+ - An alert box is immediately displayed.
+ - The affected wallet transaction is highlighted in red until it is
+   confirmed (and it may never be confirmed).
+
+A `respendsobserved` array is added to `gettransaction`, `listtransactions`,
+and `listsinceblock` RPC results.
+
+Warning
+-------
+*If you rely on an unconfirmed transaction, these changes do VERY*
+*LITTLE to protect you from a malicious double-spend, because:*
+
+ - You may learn about the respend too late to avoid doing whatever
+   you were being paid for.
+ - Using other relay rules, a double-spender can craft the double- 
+   spend to resist broadcast.
+ - Miners can choose which conflicting spend to confirm, and some
+   miners may not confirm the first acceptable spend they see.
+
+
 ### Validation
 
 ### Build system

--- a/qa/pull-tester/rpc-tests.sh
+++ b/qa/pull-tester/rpc-tests.sh
@@ -21,6 +21,7 @@ testScripts=(
     'mempool_resurrect_test.py'
     'txn_doublespend.py --mineblock'
     'txn_clone.py'
+    'txn_doublespendrelay.py'
     'getchaintips.py'
     'rawtransactions.py'
     'rest.py'

--- a/qa/rpc-tests/txn_clone.py
+++ b/qa/rpc-tests/txn_clone.py
@@ -8,9 +8,8 @@
 #
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.authproxy import AuthServiceProxy, JSONRPCException
-from decimal import Decimal
 from test_framework.util import *
+from decimal import Decimal
 import os
 import shutil
 

--- a/qa/rpc-tests/txn_doublespendrelay.py
+++ b/qa/rpc-tests/txn_doublespendrelay.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python
+
+#
+# Test double-spend-relay and notification code
+#
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+from decimal import Decimal
+
+class DoubleSpendRelay(BitcoinTestFramework):
+
+    #
+    # Create a 4-node network; roles for the nodes are:
+    # [0] : transaction creator
+    # [1] : respend sender
+    # [2] : relay node
+    # [3] : receiver, should detect/notify of double-spends
+    #
+    # Node connectivity is:
+    # [0,1] <--> [2] <--> [3]
+    #
+    def setup_network(self):
+        self.is_network_split = False
+        self.nodes = []
+        for i in range(0,4):
+            self.nodes.append(start_node(i, self.options.tmpdir))
+        connect_nodes(self.nodes[0], 2)
+        connect_nodes(self.nodes[1], 2)
+        connect_nodes(self.nodes[3], 2)
+        return self.nodes
+
+    def run_test(self):
+        fee = Decimal("0.01")
+
+        nodes = self.nodes
+        # Test 1: First spend
+        # shutdown nodes[1] so it is not aware of the first spend
+        # and will be willing to broadcast a respend
+        stop_node(nodes[1], 1)
+        # First spend: nodes[0] -> nodes[3]
+        amount = Decimal("144") # We rely on this requiring 3 50-BTC inputs
+        (total_in, tx1_inputs) = gather_inputs(nodes[0], amount+fee)
+        change_outputs = make_change(nodes[0], total_in, amount, fee)
+        outputs = dict(change_outputs)
+        outputs[nodes[3].getnewaddress()] = amount
+        signed = nodes[0].signrawtransaction(nodes[0].createrawtransaction(tx1_inputs, outputs))
+        txid1 = nodes[0].sendrawtransaction(signed["hex"], True)
+        sync_mempools([nodes[0], nodes[3]])
+        
+        txid1_info = nodes[3].gettransaction(txid1)
+        assert_equal(txid1_info["respendsobserved"], [])
+
+        # Test 2: Is double-spend of tx1_inputs[0] relayed?
+        # Restart nodes[1]
+        nodes[1] = start_node(1, self.options.tmpdir)
+        connect_nodes(nodes[1], 2)
+        # Second spend: nodes[0] -> nodes[0]
+        amount = Decimal("40")
+        total_in = Decimal("50")
+        inputs2 = [tx1_inputs[0]]
+        change_outputs = make_change(nodes[0], total_in, amount, fee)
+        outputs = dict(change_outputs)
+        outputs[nodes[0].getnewaddress()] = amount
+        signed = nodes[0].signrawtransaction(nodes[0].createrawtransaction(inputs2, outputs))
+        txid2 = nodes[1].sendrawtransaction(signed["hex"], True)
+        # Wait until txid2 is relayed to nodes[3] (but don't wait forever):
+        # Note we can't use sync_mempools, because the respend isn't added to
+        # the mempool.
+        for i in range(1,7):
+            txid1_info = nodes[3].gettransaction(txid1)
+            if txid1_info["respendsobserved"] != []:
+                break
+            time.sleep(0.1 * i**2) # geometric back-off
+        assert_equal(txid1_info["respendsobserved"], [txid2])
+
+        # Test 3: Is triple-spend of tx1_inputs[0] not relayed?
+        # Clear node1 mempool
+        stop_node(nodes[1], 1)
+        nodes[1] = start_node(1, self.options.tmpdir)
+        connect_nodes(nodes[1], 2)
+        # Third spend: nodes[0] -> nodes[0]
+        outputs = dict(change_outputs)
+        outputs[nodes[0].getnewaddress()] = amount
+        signed = nodes[0].signrawtransaction(nodes[0].createrawtransaction(inputs2, outputs))
+        txid3 = nodes[1].sendrawtransaction(signed["hex"], True)
+        # Ensure txid3 not relayed to nodes[3]:
+        time.sleep(9.1)
+        txid1_info = nodes[3].gettransaction(txid1)
+        assert_equal(txid1_info["respendsobserved"], [txid2])
+
+        # Test 4: Is double-spend of tx1_inputs[1] relayed when triple-spend of tx1_inputs[0] precedes it?
+        # Clear node1 mempool
+        stop_node(nodes[1], 1)
+        nodes[1] = start_node(1, self.options.tmpdir)
+        connect_nodes(nodes[1], 2)
+        # Inputs are third spend, second spend
+        amount = Decimal("89")
+        total_in = Decimal("100")
+        inputs4 = [tx1_inputs[0],tx1_inputs[1]]
+        change_outputs = make_change(nodes[0], total_in, amount, fee)
+        outputs = dict(change_outputs)
+        outputs[nodes[0].getnewaddress()] = amount
+        signed = nodes[0].signrawtransaction(nodes[0].createrawtransaction(inputs4, outputs))
+        txid4 = nodes[1].sendrawtransaction(signed["hex"], True)
+        # Wait until txid4 is relayed to nodes[3] (but don't wait forever):
+        for i in range(1,7):
+            txid1_info = nodes[3].gettransaction(txid1)
+            if txid1_info["respendsobserved"] != [txid2]:
+                break
+            time.sleep(0.1 * i**2) # geometric back-off
+        assert_equal(sorted(txid1_info["respendsobserved"]), sorted([txid2,txid4]))
+
+        # Test 5: Is double-spend of tx1_inputs[2] relayed when triple-spend of tx1_inputs[0] follows it?
+        # Clear node1 mempool
+        stop_node(nodes[1], 1)
+        nodes[1] = start_node(1, self.options.tmpdir)
+        connect_nodes(nodes[1], 2)
+        # Inputs are second spend, third spend
+        amount = Decimal("88")
+        total_in = Decimal("100")
+        inputs5 = [tx1_inputs[2],tx1_inputs[0]]
+        change_outputs = make_change(nodes[0], total_in, amount, fee)
+        outputs = dict(change_outputs)
+        outputs[nodes[0].getnewaddress()] = amount
+        signed = nodes[0].signrawtransaction(nodes[0].createrawtransaction(inputs5, outputs))
+        txid5 = nodes[1].sendrawtransaction(signed["hex"], True)
+        # Wait until txid5 is relayed to nodes[3] (but don't wait forever):
+        for i in range(1,7):
+            txid1_info = nodes[3].gettransaction(txid1)
+            if sorted(txid1_info["respendsobserved"]) != sorted([txid2,txid4]):
+                break
+            time.sleep(0.1 * i**2) # geometric back-off
+        assert_equal(sorted(txid1_info["respendsobserved"]), sorted([txid2,txid4,txid5]))
+
+if __name__ == '__main__':
+    DoubleSpendRelay().main()
+

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -351,6 +351,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-wallet=<file>", _("Specify wallet file (within data directory)") + " " + strprintf(_("(default: %s)"), "wallet.dat"));
     strUsage += HelpMessageOpt("-walletbroadcast", _("Make the wallet broadcast transactions") + " " + strprintf(_("(default: %u)"), true));
     strUsage += HelpMessageOpt("-walletnotify=<cmd>", _("Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)"));
+    strUsage += HelpMessageOpt("-respendnotify=<cmd>", _("Execute command when a network tx respends wallet tx input (%s=respend TxID, %t=wallet TxID)"));
     strUsage += HelpMessageOpt("-zapwallettxes=<mode>", _("Delete all wallet transactions and only recover those parts of the blockchain through -rescan on startup") +
         " " + _("(1 = keep tx meta data e.g. account owner and payment request information, 2 = drop tx meta data)"));
 #endif

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1470,6 +1470,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     LogPrintf("mapAddressBook.size() = %u\n",  pwalletMain ? pwalletMain->mapAddressBook.size() : 0);
 #endif
 
+    InitRespendFilter();
     StartNode(threadGroup, scheduler);
 
     // Monitor the chain, and alert if we get blocks much quicker or slower than expected

--- a/src/main.h
+++ b/src/main.h
@@ -112,6 +112,9 @@ extern CBlockIndex *pindexBestHeader;
 /** Minimum disk space required - used in CheckDiskSpace() */
 static const uint64_t nMinDiskSpace = 52428800;
 
+/** Initialize respend bloom filter **/
+void InitRespendFilter();
+
 /** Pruning-related variables and constants */
 /** True if any block files have ever been pruned. */
 extern bool fHavePruned;

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -92,6 +92,15 @@ CTransaction& CTransaction::operator=(const CTransaction &tx) {
     return *this;
 }
 
+bool CTransaction::IsEquivalentTo(const CTransaction& tx) const
+{
+	CMutableTransaction tx1 = *this;
+	CMutableTransaction tx2 = tx;
+	for (unsigned int i = 0; i < tx1.vin.size(); i++) tx1.vin[i].scriptSig = CScript();
+	for (unsigned int i = 0; i < tx2.vin.size(); i++) tx2.vin[i].scriptSig = CScript();
+	return CTransaction(tx1) == CTransaction(tx2);
+}
+
 CAmount CTransaction::GetValueOut() const
 {
     CAmount nValueOut = 0;

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -229,6 +229,9 @@ public:
         return hash;
     }
 
+    // True if only scriptSigs are different
+    bool IsEquivalentTo(const CTransaction& tx) const;
+
     // Return sum of txouts.
     CAmount GetValueOut() const;
     // GetValueIn() is a method on CCoinsViewCache, because

--- a/src/qt/guiconstants.h
+++ b/src/qt/guiconstants.h
@@ -29,6 +29,10 @@ static const int STATUSBAR_ICONSIZE = 16;
 #define COLOR_TX_STATUS_OFFLINE QColor(192, 192, 192)
 /* Transaction list -- TX status decoration - default color */
 #define COLOR_BLACK QColor(0, 0, 0)
+/* Transaction list -- has conflicting transactions */
+#define COLOR_HASCONFLICTING QColor(255, 255, 255)
+/* Transaction list -- has conflicting transactions - background */
+#define COLOR_HASCONFLICTING_BG QColor(192, 0, 0)
 
 /* Tooltips longer than this (in characters) are converted into rich text,
    so that they can be word-wrapped.

--- a/src/qt/transactionfilterproxy.cpp
+++ b/src/qt/transactionfilterproxy.cpp
@@ -25,7 +25,7 @@ TransactionFilterProxy::TransactionFilterProxy(QObject *parent) :
     watchOnlyFilter(WatchOnlyFilter_All),
     minAmount(0),
     limitRows(-1),
-    showInactive(true)
+    showInactive(false)
 {
 }
 
@@ -41,7 +41,7 @@ bool TransactionFilterProxy::filterAcceptsRow(int sourceRow, const QModelIndex &
     qint64 amount = llabs(index.data(TransactionTableModel::AmountRole).toLongLong());
     int status = index.data(TransactionTableModel::StatusRole).toInt();
 
-    if(!showInactive && status == TransactionStatus::Conflicted)
+    if(!showInactive && status == TransactionStatus::Conflicted && type == TransactionRecord::Other)
         return false;
     if(!(TYPE(type) & typeFilter))
         return false;

--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -20,9 +20,17 @@ class TransactionStatus
 {
 public:
     TransactionStatus():
-        countsForBalance(false), sortKey(""),
-        matures_in(0), status(Offline), depth(0), open_for(0), cur_num_blocks(-1)
-    { }
+        countsForBalance(false),
+        sortKey(""),
+        matures_in(0),
+        status(Offline),
+        hasConflicting(false),
+        depth(0),
+        open_for(0),
+        cur_num_blocks(-1),
+        cur_num_conflicts(-1)
+    {
+    }
 
     enum Status {
         Confirmed,          /**< Have 6 or more confirmations (normal tx) or fully mature (mined tx) **/
@@ -52,6 +60,10 @@ public:
     /** @name Reported status
        @{*/
     Status status;
+
+    // Has conflicting transactions spending same prevout
+    bool hasConflicting;
+
     qint64 depth;
     qint64 open_for; /**< Timestamp if status==OpenUntilDate, otherwise number
                       of additional blocks that need to be mined before
@@ -60,6 +72,10 @@ public:
 
     /** Current number of blocks (to know whether cached status is still valid) */
     int cur_num_blocks;
+
+    /** Number of conflicts received into wallet as of last status update */
+    int64_t cur_num_conflicts;
+
 };
 
 /** UI model for a transaction. A core transaction can be represented by multiple UI transactions if it has
@@ -137,7 +153,7 @@ public:
 
     /** Return whether a status update is needed.
      */
-    bool statusUpdateNeeded();
+    bool statusUpdateNeeded(int64_t nConflictsReceived);
 };
 
 #endif // BITCOIN_QT_TRANSACTIONRECORD_H

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -163,8 +163,12 @@ public:
             parent->endRemoveRows();
             break;
         case CT_UPDATED:
-            // Miscellaneous updates -- nothing to do, status update will take care of this, and is only computed for
-            // visible transactions.
+            emit parent->dataChanged(parent->index(lowerIndex, parent->Status), parent->index(upperIndex-1, parent->Amount));
+            break;
+        case CT_GOT_CONFLICT:
+            emit parent->message(parent->tr("Conflict Received"),
+                                 parent->tr("WARNING: Transaction may never be confirmed. Its input was seen being spent by another transaction on the network."),
+                                 CClientUIInterface::MSG_WARNING);
             break;
         }
     }
@@ -184,20 +188,21 @@ public:
             // stuck if the core is holding the locks for a longer time - for
             // example, during a wallet rescan.
             //
-            // If a status update is needed (blocks came in since last check),
-            //  update the status of this transaction from the wallet. Otherwise,
+            // If a status update is needed (blocks or conflicts came in since last check),
+            // update the status of this transaction from the wallet. Otherwise,
             // simply re-use the cached status.
             TRY_LOCK(cs_main, lockMain);
             if(lockMain)
             {
                 TRY_LOCK(wallet->cs_wallet, lockWallet);
-                if(lockWallet && rec->statusUpdateNeeded())
+                if(lockWallet && rec->statusUpdateNeeded(wallet->nConflictsReceived))
                 {
                     std::map<uint256, CWalletTx>::iterator mi = wallet->mapWallet.find(rec->hash);
 
                     if(mi != wallet->mapWallet.end())
                     {
                         rec->updateStatus(mi->second);
+                        rec->status.cur_num_conflicts = wallet->nConflictsReceived;
                     }
                 }
             }
@@ -231,6 +236,7 @@ TransactionTableModel::TransactionTableModel(CWallet* wallet, WalletModel *paren
     priv->refreshWallet();
 
     connect(walletModel->getOptionsModel(), SIGNAL(displayUnitChanged(int)), this, SLOT(updateDisplayUnit()));
+    connect(this, SIGNAL(message(QString,QString,unsigned int)), walletModel, SIGNAL(message(QString,QString,unsigned int)));
 
     subscribeToCoreSignals();
 }
@@ -361,6 +367,8 @@ QString TransactionTableModel::formatTxType(const TransactionRecord *wtx) const
         return tr("Payment to yourself");
     case TransactionRecord::Generated:
         return tr("Mined");
+    case TransactionRecord::Other:
+        return tr("Other");
     default:
         return QString();
     }
@@ -556,7 +564,13 @@ QVariant TransactionTableModel::data(const QModelIndex &index, int role) const
         return formatTooltip(rec);
     case Qt::TextAlignmentRole:
         return column_alignments[index.column()];
+    case Qt::BackgroundColorRole:
+        if (rec->status.hasConflicting)
+            return COLOR_HASCONFLICTING_BG;
+        break;
     case Qt::ForegroundRole:
+        if (rec->status.hasConflicting)
+            return COLOR_HASCONFLICTING;
         // Non-confirmed (but not immature) as transactions are grey
         if(!rec->status.countsForBalance && rec->status.status != TransactionStatus::Immature)
         {

--- a/src/qt/transactiontablemodel.h
+++ b/src/qt/transactiontablemodel.h
@@ -98,6 +98,10 @@ private:
     QVariant txWatchonlyDecoration(const TransactionRecord *wtx) const;
     QVariant txAddressDecoration(const TransactionRecord *wtx) const;
 
+signals:
+    // Fired when a message should be reported to the user
+    void message(const QString &title, const QString &message, unsigned int style);
+
 public slots:
     /* New transaction, or transaction changed status */
     void updateTransaction(const QString &hash, int status, bool showTransaction);

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -184,7 +184,6 @@ void CTxMemPool::removeCoinbaseSpends(const CCoinsViewCache *pcoins, unsigned in
 void CTxMemPool::removeConflicts(const CTransaction &tx, std::list<CTransaction>& removed)
 {
     // Remove transactions which depend on inputs of tx, recursively
-    list<CTransaction> result;
     LOCK(cs);
     BOOST_FOREACH(const CTxIn &txin, tx.vin) {
         std::map<COutPoint, CInPoint>::iterator it = mapNextTx.find(txin.prevout);

--- a/src/ui_interface.h
+++ b/src/ui_interface.h
@@ -21,7 +21,8 @@ enum ChangeType
 {
     CT_NEW,
     CT_UPDATED,
-    CT_DELETED
+    CT_DELETED,
+    CT_GOT_CONFLICT
 };
 
 /** Signals for UI communication. */

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -13,7 +13,7 @@ CMainSignals& GetMainSignals()
 }
 
 void RegisterValidationInterface(CValidationInterface* pwalletIn) {
-    g_signals.SyncTransaction.connect(boost::bind(&CValidationInterface::SyncTransaction, pwalletIn, _1, _2));
+    g_signals.SyncTransaction.connect(boost::bind(&CValidationInterface::SyncTransaction, pwalletIn, _1, _2, _3));
     g_signals.UpdatedTransaction.connect(boost::bind(&CValidationInterface::UpdatedTransaction, pwalletIn, _1));
     g_signals.SetBestChain.connect(boost::bind(&CValidationInterface::SetBestChain, pwalletIn, _1));
     g_signals.Inventory.connect(boost::bind(&CValidationInterface::Inventory, pwalletIn, _1));
@@ -31,7 +31,7 @@ void UnregisterValidationInterface(CValidationInterface* pwalletIn) {
     g_signals.Inventory.disconnect(boost::bind(&CValidationInterface::Inventory, pwalletIn, _1));
     g_signals.SetBestChain.disconnect(boost::bind(&CValidationInterface::SetBestChain, pwalletIn, _1));
     g_signals.UpdatedTransaction.disconnect(boost::bind(&CValidationInterface::UpdatedTransaction, pwalletIn, _1));
-    g_signals.SyncTransaction.disconnect(boost::bind(&CValidationInterface::SyncTransaction, pwalletIn, _1, _2));
+    g_signals.SyncTransaction.disconnect(boost::bind(&CValidationInterface::SyncTransaction, pwalletIn, _1, _2, _3));
 }
 
 void UnregisterAllValidationInterfaces() {
@@ -45,6 +45,6 @@ void UnregisterAllValidationInterfaces() {
     g_signals.SyncTransaction.disconnect_all_slots();
 }
 
-void SyncWithWallets(const CTransaction &tx, const CBlock *pblock) {
-    g_signals.SyncTransaction(tx, pblock);
+void SyncWithWallets(const CTransaction &tx, const CBlock *pblock, bool fRespend) {
+    g_signals.SyncTransaction(tx, pblock, fRespend);
 }

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -26,11 +26,11 @@ void UnregisterValidationInterface(CValidationInterface* pwalletIn);
 /** Unregister all wallets from core */
 void UnregisterAllValidationInterfaces();
 /** Push an updated transaction to all registered wallets */
-void SyncWithWallets(const CTransaction& tx, const CBlock* pblock = NULL);
+void SyncWithWallets(const CTransaction& tx, const CBlock* pblock = NULL, bool fRespend = false);
 
 class CValidationInterface {
 protected:
-    virtual void SyncTransaction(const CTransaction &tx, const CBlock *pblock) {}
+    virtual void SyncTransaction(const CTransaction &tx, const CBlock *pblock, bool fRespend) {}
     virtual void SetBestChain(const CBlockLocator &locator) {}
     virtual void UpdatedTransaction(const uint256 &hash) {}
     virtual void Inventory(const uint256 &hash) {}
@@ -44,8 +44,8 @@ protected:
 };
 
 struct CMainSignals {
-    /** Notifies listeners of updated transaction data (transaction, and optionally the block it is found in. */
-    boost::signals2::signal<void (const CTransaction &, const CBlock *)> SyncTransaction;
+    /** Notifies listeners of updated transaction data (transaction, optionally the block it is found in, and whether this is a known respend. */
+    boost::signals2::signal<void (const CTransaction &, const CBlock *, bool)> SyncTransaction;
     /** Notifies listeners of an updated transaction without new data (for now: a coinbase potentially becoming visible). */
     boost::signals2::signal<void (const uint256 &)> UpdatedTransaction;
     /** Notifies listeners of a new active block chain. */

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -71,6 +71,10 @@ void WalletTxToJSON(const CWalletTx& wtx, UniValue& entry)
     BOOST_FOREACH(const uint256& conflict, wtx.GetConflicts())
         conflicts.push_back(conflict.GetHex());
     entry.push_back(Pair("walletconflicts", conflicts));
+    UniValue respends(UniValue::VARR);
+    BOOST_FOREACH(const uint256& respend, wtx.GetConflicts(false))
+        respends.push_back(respend.GetHex());
+    entry.push_back(Pair("respendsobserved", respends));
     entry.push_back(Pair("time", wtx.GetTxTime()));
     entry.push_back(Pair("timereceived", (int64_t)wtx.nTimeReceived));
     BOOST_FOREACH(const PAIRTYPE(string,string)& item, wtx.mapValue)
@@ -1418,6 +1422,12 @@ UniValue listtransactions(const UniValue& params, bool fHelp)
             "    \"blockindex\": n,          (numeric) The block index containing the transaction. Available for 'send' and 'receive'\n"
             "                                          category of transactions.\n"
             "    \"txid\": \"transactionid\", (string) The transaction id. Available for 'send' and 'receive' category of transactions.\n"
+            "    \"walletconflicts\" : [\n"
+            "        \"conflictid\",  (string) Ids of transactions, including equivalent clones, that re-spend a txid input.\n"
+            "    ],\n"
+            "    \"respendsobserved\" : [\n"
+            "        \"respendid\",  (string) Ids of transactions, NOT equivalent clones, that re-spend a txid input. \"Double-spends.\"\n"
+            "    ],\n"
             "    \"time\": xxx,              (numeric) The transaction time in seconds since epoch (midnight Jan 1 1970 GMT).\n"
             "    \"timereceived\": xxx,      (numeric) The time received in seconds since epoch (midnight Jan 1 1970 GMT). Available \n"
             "                                          for 'send' and 'receive' category of transactions.\n"
@@ -1609,6 +1619,12 @@ UniValue listsinceblock(const UniValue& params, bool fHelp)
             "    \"blockindex\": n,          (numeric) The block index containing the transaction. Available for 'send' and 'receive' category of transactions.\n"
             "    \"blocktime\": xxx,         (numeric) The block time in seconds since epoch (1 Jan 1970 GMT).\n"
             "    \"txid\": \"transactionid\",  (string) The transaction id. Available for 'send' and 'receive' category of transactions.\n"
+            "    \"walletconflicts\" : [\n"
+            "        \"conflictid\",  (string) Ids of transactions, including equivalent clones, that re-spend a txid input.\n"
+            "    ],\n"
+            "    \"respendsobserved\" : [\n"
+            "        \"respendid\",  (string) Ids of transactions, NOT equivalent clones, that re-spend a txid input. \"Double-spends.\"\n"
+            "    ],\n"
             "    \"time\": xxx,              (numeric) The transaction time in seconds since epoch (Jan 1 1970 GMT).\n"
             "    \"timereceived\": xxx,      (numeric) The time received in seconds since epoch (Jan 1 1970 GMT). Available for 'send' and 'receive' category of transactions.\n"
             "    \"comment\": \"...\",       (string) If a comment is associated with the transaction.\n"
@@ -1692,6 +1708,12 @@ UniValue gettransaction(const UniValue& params, bool fHelp)
             "  \"blockindex\" : xx,       (numeric) The block index\n"
             "  \"blocktime\" : ttt,       (numeric) The time in seconds since epoch (1 Jan 1970 GMT)\n"
             "  \"txid\" : \"transactionid\",   (string) The transaction id.\n"
+            "  \"walletconflicts\" : [\n"
+            "      \"conflictid\",  (string) Ids of transactions, including equivalent clones, that re-spend a txid input.\n"
+            "  ],\n"
+            "  \"respendsobserved\" : [\n"
+            "      \"respendid\",  (string) Ids of transactions, NOT equivalent clones, that re-spend a txid input. \"Double-spends.\"\n"
+            "  ],\n"
             "  \"time\" : ttt,            (numeric) The transaction time in seconds since epoch (1 Jan 1970 GMT)\n"
             "  \"timereceived\" : ttt,    (numeric) The time received in seconds since epoch (1 Jan 1970 GMT)\n"
             "  \"details\" : [\n"

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -321,7 +321,7 @@ bool CWallet::SetMaxVersion(int nVersion)
     return true;
 }
 
-set<uint256> CWallet::GetConflicts(const uint256& txid) const
+set<uint256> CWallet::GetConflicts(const uint256& txid, bool includeEquivalent) const
 {
     set<uint256> result;
     AssertLockHeld(cs_wallet);
@@ -339,7 +339,8 @@ set<uint256> CWallet::GetConflicts(const uint256& txid) const
             continue;  // No conflict if zero or one spends
         range = mapTxSpends.equal_range(txin.prevout);
         for (TxSpends::const_iterator it = range.first; it != range.second; ++it)
-            result.insert(it->second);
+            if (includeEquivalent || !wtx.IsEquivalentTo(mapWallet.at(it->second)))
+                result.insert(it->second);
     }
     return result;
 }
@@ -720,6 +721,20 @@ bool CWallet::AddToWallet(const CWalletTx& wtxIn, bool fFromLoadWallet, CWalletD
         // Notify UI of new or updated transaction
         NotifyTransactionChanged(this, hash, fInsertedNew ? CT_NEW : CT_UPDATED);
 
+        // Notifications for existing transactions that now have conflicts with this one
+        if (fInsertedNew)
+        {
+            BOOST_FOREACH(const uint256& conflictHash, wtxIn.GetConflicts(false))
+            {
+                CWalletTx& txConflict = mapWallet[conflictHash];
+                NotifyTransactionChanged(this, conflictHash, CT_UPDATED); //Updates UI table
+                if (IsFromMe(txConflict) || IsMine(txConflict))
+                {
+                    NotifyTransactionChanged(this, conflictHash, CT_GOT_CONFLICT);  //Throws dialog
+                }
+            }
+        }
+
         // notify an external script when a wallet transaction comes in or is updated
         std::string strCmd = GetArg("-walletnotify", "");
 
@@ -738,13 +753,21 @@ bool CWallet::AddToWallet(const CWalletTx& wtxIn, bool fFromLoadWallet, CWalletD
  * pblock is optional, but should be provided if the transaction is known to be in a block.
  * If fUpdate is true, existing transactions will be updated.
  */
-bool CWallet::AddToWalletIfInvolvingMe(const CTransaction& tx, const CBlock* pblock, bool fUpdate)
+bool CWallet::AddToWalletIfInvolvingMe(const CTransaction& tx, const CBlock* pblock, bool fUpdate, bool fRespend)
 {
     {
         AssertLockHeld(cs_wallet);
         bool fExisted = mapWallet.count(tx.GetHash()) != 0;
         if (fExisted && !fUpdate) return false;
-        if (fExisted || IsMine(tx) || IsFromMe(tx))
+
+        bool fIsConflicting = IsConflicting(tx);
+        // Don't add respends that pay us, unless they conflict with us.  Prevents resource exhaustion.
+        if (!fIsConflicting && fRespend) return false;
+
+        if (fIsConflicting)
+            nConflictsReceived++;
+
+        if (fExisted || IsMine(tx) || IsFromMe(tx) || fIsConflicting)
         {
             CWalletTx wtx(this,tx);
 
@@ -762,10 +785,10 @@ bool CWallet::AddToWalletIfInvolvingMe(const CTransaction& tx, const CBlock* pbl
     return false;
 }
 
-void CWallet::SyncTransaction(const CTransaction& tx, const CBlock* pblock)
+void CWallet::SyncTransaction(const CTransaction& tx, const CBlock* pblock, bool fRespend)
 {
     LOCK2(cs_main, cs_wallet);
-    if (!AddToWalletIfInvolvingMe(tx, pblock, true))
+    if (!AddToWalletIfInvolvingMe(tx, pblock, true, fRespend))
         return; // Not one of ours
 
     // If a transaction changes 'conflicted' state, that changes the balance
@@ -862,6 +885,14 @@ bool CWallet::IsMine(const CTransaction& tx) const
 bool CWallet::IsFromMe(const CTransaction& tx) const
 {
     return (GetDebit(tx, ISMINE_ALL) > 0);
+}
+
+bool CWallet::IsConflicting(const CTransaction& tx) const
+{
+	    BOOST_FOREACH(const CTxIn& txin, tx.vin)
+	    if (mapTxSpends.count(txin.prevout))
+	        return true;
+	    return false;
 }
 
 CAmount CWallet::GetDebit(const CTransaction& tx, const isminefilter& filter) const
@@ -1073,7 +1104,7 @@ int CWallet::ScanForWalletTransactions(CBlockIndex* pindexStart, bool fUpdate)
             ReadBlockFromDisk(block, pindex);
             BOOST_FOREACH(CTransaction& tx, block.vtx)
             {
-                if (AddToWalletIfInvolvingMe(tx, &block, fUpdate))
+                if (AddToWalletIfInvolvingMe(tx, &block, fUpdate, false))
                     ret++;
             }
             pindex = chainActive.Next(pindex);
@@ -1104,7 +1135,7 @@ void CWallet::ReacceptWalletTransactions()
 
         int nDepth = wtx.GetDepthInMainChain();
 
-        if (!wtx.IsCoinBase() && nDepth < 0) {
+        if (!wtx.IsCoinBase() && nDepth < 0 && (IsMine(wtx) || IsFromMe(wtx))) {
             mapSorted.insert(std::make_pair(wtx.nOrderPos, &wtx));
         }
     }
@@ -1133,13 +1164,13 @@ bool CWalletTx::RelayWalletTransaction()
     return false;
 }
 
-set<uint256> CWalletTx::GetConflicts() const
+set<uint256> CWalletTx::GetConflicts(bool includeEquivalent) const
 {
     set<uint256> result;
     if (pwallet != NULL)
     {
         uint256 myHash = GetHash();
-        result = pwallet->GetConflicts(myHash);
+        result = pwallet->GetConflicts(myHash, includeEquivalent);
         result.erase(myHash);
     }
     return result;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -731,6 +731,14 @@ bool CWallet::AddToWallet(const CWalletTx& wtxIn, bool fFromLoadWallet, CWalletD
                 if (IsFromMe(txConflict) || IsMine(txConflict))
                 {
                     NotifyTransactionChanged(this, conflictHash, CT_GOT_CONFLICT);  //Throws dialog
+                    // external respend notify
+                    std::string strCmd = GetArg("-respendnotify", "");
+                    if (!strCmd.empty())
+                    {
+                        boost::replace_all(strCmd, "%s", wtxIn.GetHash().GetHex());
+                        boost::replace_all(strCmd, "%t", conflictHash.GetHex());
+                        boost::thread t(runCommand, strCmd); // thread runs free
+                    }
                 }
             }
         }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -160,7 +160,6 @@ public:
     // memory only
     mutable bool fMerkleVerified;
 
-
     CMerkleTx()
     {
         Init();
@@ -390,7 +389,7 @@ public:
 
     bool RelayWalletTransaction();
 
-    std::set<uint256> GetConflicts() const;
+    std::set<uint256> GetConflicts(bool includeEquivalent=true) const;
 };
 
 
@@ -496,6 +495,9 @@ public:
     MasterKeyMap mapMasterKeys;
     unsigned int nMasterKeyMaxID;
 
+    // Increment to cause UI refresh, similar to new block
+    int64_t nConflictsReceived;
+
     CWallet()
     {
         SetNull();
@@ -527,6 +529,7 @@ public:
         nLastResend = 0;
         nTimeFirstKey = 0;
         fBroadcastTransactions = false;
+        nConflictsReceived = 0;
     }
 
     std::map<uint256, CWalletTx> mapWallet;
@@ -618,8 +621,8 @@ public:
 
     void MarkDirty();
     bool AddToWallet(const CWalletTx& wtxIn, bool fFromLoadWallet, CWalletDB* pwalletdb);
-    void SyncTransaction(const CTransaction& tx, const CBlock* pblock);
-    bool AddToWalletIfInvolvingMe(const CTransaction& tx, const CBlock* pblock, bool fUpdate);
+    void SyncTransaction(const CTransaction& tx, const CBlock* pblock, bool fRespend);
+    bool AddToWalletIfInvolvingMe(const CTransaction& tx, const CBlock* pblock, bool fUpdate, bool fRespend);
     int ScanForWalletTransactions(CBlockIndex* pindexStart, bool fUpdate = false);
     void ReacceptWalletTransactions();
     void ResendWalletTransactions(int64_t nBestBlockTime);
@@ -661,6 +664,7 @@ public:
     bool IsMine(const CTransaction& tx) const;
     /** should probably be renamed to IsRelevantToMe */
     bool IsFromMe(const CTransaction& tx) const;
+    bool IsConflicting(const CTransaction& tx) const;
     CAmount GetDebit(const CTransaction& tx, const isminefilter& filter) const;
     CAmount GetCredit(const CTransaction& tx, const isminefilter& filter) const;
     CAmount GetChange(const CTransaction& tx) const;
@@ -710,7 +714,7 @@ public:
     int GetVersion() { LOCK(cs_wallet); return nWalletVersion; }
 
     //! Get wallet transactions that conflict with given transaction (spend same outputs)
-    std::set<uint256> GetConflicts(const uint256& txid) const;
+    std::set<uint256> GetConflicts(const uint256& txid, bool includeEquivalent) const;
 
     //! Flush wallet (bitdb flush)
     void Flush(bool shutdown=false);


### PR DESCRIPTION
Relay at most one double-spend per unspent output, subject to anti-DoS provisions.

Unconfirmed double-spends carry information that is time-critical to the payee of the first spend, but today, they are silently dropped.

Add a -respendnotify option that can immediately notify a user-supplied command when a double-spend affecting the wallet is received.

Change the GUI wallet to highlight a transaction in red when a transaction that double-spends it has been seen.  When the conflict first occurs, display a warning dialog.

![alertshot](https://cloud.githubusercontent.com/assets/4284124/3654442/eb871ada-1169-11e4-97e6-1dd049d1c15f.png)

This change has been running on mainnet since 2014-05-02.  Relayable double-spends seen by the change are [recorded here](http://respends.thinlink.com) in realtime.
