### PR TITLE
Rework block processing benchmark code

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -285,7 +285,6 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += "\n" + _("Debugging/Testing options:") + "\n";
     if (GetBoolArg("-help-debug", false))
     {
-        strUsage += "  -benchmark             " + _("Show benchmark information (default: 0)") + "\n";
         strUsage += "  -checkpoints           " + _("Only accept block chain matching built-in checkpoints (default: 1)") + "\n";
         strUsage += "  -dblogsize=<n>         " + _("Flush database activity from memory pool to disk log every <n> megabytes (default: 100)") + "\n";
         strUsage += "  -disablesafemode       " + _("Disable safemode, override a real safe mode event (default: 0)") + "\n";
@@ -298,7 +297,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += "  -debug=<category>      " + _("Output debugging information (default: 0, supplying <category> is optional)") + "\n";
     strUsage += "                         " + _("If <category> is not supplied, output all debugging information.") + "\n";
     strUsage += "                         " + _("<category> can be:");
-    strUsage +=                                 " addrman, alert, coindb, db, lock, rand, rpc, selectcoins, mempool, net"; // Don't translate these and qt below
+    strUsage +=                                 " addrman, alert, bench, coindb, db, lock, rand, rpc, selectcoins, mempool, net"; // Don't translate these and qt below
     if (mode == HMM_BITCOIN_QT)
         strUsage += ", qt";
     strUsage += ".\n";
@@ -599,7 +598,9 @@ bool AppInit2(boost::thread_group& threadGroup)
     if (GetBoolArg("-tor", false))
         return InitError(_("Error: Unsupported argument -tor found, use -onion."));
 
-    fBenchmark = GetBoolArg("-benchmark", false);
+    if (GetBoolArg("-benchmark", false))
+        InitWarning(_("Warning: Unsupported argument -benchmark ignored, use -debug=bench."));
+
     // Checkmempool defaults to true in regtest mode
     mempool.setSanityCheck(GetBoolArg("-checkmempool", Params().DefaultCheckMemPool()));
     Checkpoints::fEnabled = GetBoolArg("-checkpoints", true);

--- a/src/main.h
+++ b/src/main.h
@@ -91,7 +91,6 @@ extern CWaitableCriticalSection csBestBlock;
 extern CConditionVariable cvBlockChange;
 extern bool fImporting;
 extern bool fReindex;
-extern bool fBenchmark;
 extern int nScriptCheckThreads;
 extern bool fTxIndex;
 extern bool fIsBareMultisigStd;


### PR DESCRIPTION
- Replace -benchmark (and the related fBenchmark) with a regular debug option, -debug=bench.
- Increase coverage and granularity of individual block processing steps.
- Add cummulative times.

Example output:

```
   - Load block from disk: 3.11ms [51.13s]
       - Connect 484 transactions: 4.14ms (0.009ms/tx, 0.005ms/txin) [64.37s]
     - Verify 860 txins: 4.25ms (0.005ms/txin) [66.98s]
     - Index writing: 1.22ms [33.53s]
     - Callbacks: 0.10ms [2.15s]
   - Connect total: 14.17ms [203.69s]
   - Flush: 1.00ms [19.88s]
   - Writing chainstate: 0.09ms [33.30s]
   - Connect postprocess: 0.23ms [5.15s]
 - Connect block: 11.96ms [313.16s]
```

Note that the subdivisions work backwards: the grand total is the last item, 'Connect transactions' is a part of 'Verify transactions', and 'Verify transactions', 'Index writing', and 'Callbacks' are part of 'Connect total'.
