### PR TITLE
script.h: set_vch() should shift a >32 bit value

### DIFF
--- a/src/script.h
+++ b/src/script.h
@@ -166,7 +166,7 @@ private:
       // If the input vector's most significant byte is 0x80, remove it from
       // the result's msb and return a negative.
       if (vch.back() & 0x80)
-          return -(result & ~(0x80 << (8 * (vch.size() - 1))));
+          return -(result & ~(0x80ULL << (8 * (vch.size() - 1))));
 
       return result;
     }


### PR DESCRIPTION
Source: http://www.viva64.com/en/b/0268/
