### PR TITLE
Declare SignatureHash() in script.h

### DIFF
--- a/src/script.h
+++ b/src/script.h
@@ -809,6 +809,7 @@ bool IsCanonicalPubKey(const std::vector<unsigned char> &vchPubKey, unsigned int
 bool IsCanonicalSignature(const std::vector<unsigned char> &vchSig, unsigned int flags);
 
 bool EvalScript(std::vector<std::vector<unsigned char> >& stack, const CScript& script, const CTransaction& txTo, unsigned int nIn, unsigned int flags, int nHashType);
+uint256 SignatureHash(const CScript &scriptCode, const CTransaction& txTo, unsigned int nIn, int nHashType);
 bool Solver(const CScript& scriptPubKey, txnouttype& typeRet, std::vector<std::vector<unsigned char> >& vSolutionsRet);
 int ScriptSigArgsExpected(txnouttype t, const std::vector<std::vector<unsigned char> >& vSolutions);
 bool IsStandard(const CScript& scriptPubKey, txnouttype& whichType);

--- a/src/test/multisig_tests.cpp
+++ b/src/test/multisig_tests.cpp
@@ -17,8 +17,6 @@ using namespace boost::assign;
 
 typedef vector<unsigned char> valtype;
 
-extern uint256 SignatureHash(const CScript &scriptCode, const CTransaction& txTo, unsigned int nIn, int nHashType);
-
 BOOST_AUTO_TEST_SUITE(multisig_tests)
 
 CScript

--- a/src/test/script_P2SH_tests.cpp
+++ b/src/test/script_P2SH_tests.cpp
@@ -15,9 +15,6 @@
 
 using namespace std;
 
-// Test routines internal to script.cpp:
-extern uint256 SignatureHash(CScript scriptCode, const CTransaction& txTo, unsigned int nIn, int nHashType);
-
 // Helpers:
 static std::vector<unsigned char>
 Serialize(const CScript& s)

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -10,6 +10,7 @@
 #include "key.h"
 #include "keystore.h"
 #include "main.h"
+#include "script.h"
 #include "core_io.h"
 
 #include <fstream>
@@ -32,8 +33,6 @@
 using namespace std;
 using namespace json_spirit;
 using namespace boost::algorithm;
-
-extern uint256 SignatureHash(const CScript &scriptCode, const CTransaction& txTo, unsigned int nIn, int nHashType);
 
 static const unsigned int flags = SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_STRICTENC;
 

--- a/src/test/sighash_tests.cpp
+++ b/src/test/sighash_tests.cpp
@@ -6,6 +6,7 @@
 #include "main.h"
 #include "random.h"
 #include "serialize.h"
+#include "script.h"
 #include "util.h"
 #include "version.h"
 
@@ -18,8 +19,6 @@
 
 using namespace json_spirit;
 extern Array read_json(const std::string& jsondata);
-
-extern uint256 SignatureHash(const CScript &scriptCode, const CTransaction& txTo, unsigned int nIn, int nHashType);
 
 // Old script.cpp SignatureHash function
 uint256 static SignatureHashOld(CScript scriptCode, const CTransaction& txTo, unsigned int nIn, int nHashType)


### PR DESCRIPTION
There's no need to declare external headers in tests, you can just include them. 
