### PR TITLE
URLs containing a / after the address no longer cause parsing errors.

### DIFF
--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -117,6 +117,10 @@ bool parseBitcoinURI(const QUrl &uri, SendCoinsRecipient *out)
 
     SendCoinsRecipient rv;
     rv.address = uri.path();
+    // Trim any following forward slash which may have been added by the OS
+    if (rv.address.endsWith("/")) {
+        rv.address.truncate(rv.address.length() - 1);
+    }
     rv.amount = 0;
 
 #if QT_VERSION < 0x050000


### PR DESCRIPTION
In some cases under Windows a / is appended to bitcoin: URIs sent from browser to the client. This patch catches that case and removes the /.
