### PR TITLE
Restore bitcoin: URIs determining network address

### DIFF
--- a/src/base58.cpp
+++ b/src/base58.cpp
@@ -215,9 +215,13 @@ bool CBitcoinAddress::Set(const CTxDestination &dest) {
 }
 
 bool CBitcoinAddress::IsValid() const {
+    return IsValid(Params());
+}
+
+bool CBitcoinAddress::IsValid(const CChainParams &params) const {
     bool fCorrectSize = vchData.size() == 20;
-    bool fKnownVersion = vchVersion == Params().Base58Prefix(CChainParams::PUBKEY_ADDRESS) ||
-                         vchVersion == Params().Base58Prefix(CChainParams::SCRIPT_ADDRESS);
+    bool fKnownVersion = vchVersion == params.Base58Prefix(CChainParams::PUBKEY_ADDRESS) ||
+                         vchVersion == params.Base58Prefix(CChainParams::SCRIPT_ADDRESS);
     return fCorrectSize && fKnownVersion;
 }
 

--- a/src/base58.h
+++ b/src/base58.h
@@ -104,6 +104,7 @@ public:
     bool Set(const CScriptID &id);
     bool Set(const CTxDestination &dest);
     bool IsValid() const;
+    bool IsValid(const CChainParams &params) const;
 
     CBitcoinAddress() {}
     CBitcoinAddress(const CTxDestination &dest) { Set(dest); }

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -220,22 +220,23 @@ const CChainParams &Params() {
     return *pCurrentParams;
 }
 
-void SelectParams(CBaseChainParams::Network network) {
-    SelectBaseParams(network);
+CChainParams &Params(CBaseChainParams::Network network) {
     switch (network) {
         case CBaseChainParams::MAIN:
-            pCurrentParams = &mainParams;
-            break;
+            return mainParams;
         case CBaseChainParams::TESTNET:
-            pCurrentParams = &testNetParams;
-            break;
+            return testNetParams;
         case CBaseChainParams::REGTEST:
-            pCurrentParams = &regTestParams;
-            break;
+            return regTestParams;
         default:
             assert(false && "Unimplemented network");
-            return;
+            return mainParams;
     }
+}
+
+void SelectParams(CBaseChainParams::Network network) {
+    SelectBaseParams(network);
+    pCurrentParams = &Params(network);
 }
 
 bool SelectParamsFromCommandLine() {

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -111,6 +111,9 @@ protected:
  */
 const CChainParams &Params();
 
+/** Return parameters for the given network. */
+CChainParams &Params(CBaseChainParams::Network network);
+
 /** Sets the params returned by Params() to those for the given network. */
 void SelectParams(CBaseChainParams::Network network);
 

--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -10,6 +10,7 @@
 #include "optionsmodel.h"
 
 #include "base58.h"
+#include "chainparams.h"
 #include "ui_interface.h"
 #include "wallet.h"
 
@@ -199,8 +200,11 @@ bool PaymentServer::ipcParseCommandLine(int argc, char* argv[])
             {
                 CBitcoinAddress address(r.address.toStdString());
 
-                SelectParams(CBaseChainParams::MAIN);
-                if (!address.IsValid())
+                if (address.IsValid(Params(CBaseChainParams::MAIN)))
+                {
+                    SelectParams(CBaseChainParams::MAIN);
+                }
+                else if (address.IsValid(Params(CBaseChainParams::TESTNET)))
                 {
                     SelectParams(CBaseChainParams::TESTNET);
                 }


### PR DESCRIPTION
Restored functionality where the network a Bitcoin URI address applies to is used to determine the network the client uses, altered such that invalid addresses do not incorrectly send the user to the test network. This avoids the previous issue where an invalid URI caused the client to open the wrong network, while also ensuring that the wallet opens a network appropriate to the URI where possible.
