### PR TITLE
CCoinsKeyHasher::operator() should return size_t

### DIFF
--- a/src/coins.h
+++ b/src/coins.h
@@ -247,7 +247,10 @@ private:
 
 public:
     CCoinsKeyHasher();
-    uint64_t operator()(const uint256& key) const {
+    // This *must* return size_t. With Boost 1.46 on 32-bit systems the
+    // unordered_map will behave unpredictably if the custom hasher returns a
+    // uint64_t, resulting in failures when syncing the chain (#4634).
+    size_t operator()(const uint256& key) const {
         return key.GetHash(salt);
     }
 };


### PR DESCRIPTION
It currently returns uint64_t, which on older boost (at least 1.46) causes failures on 32-bit systems. This problem was introduced in bc42503.

Fixes #4634.
