### PR TITLE
Making small part of development process clearer

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Development process
 -------------------
 
 Developers work in their own trees, then submit pull requests when they think
-their feature or bug fix is ready.
+that their feature or bug fix is ready.
 
 If it is a simple/trivial/non-controversial change, then one of the Bitcoin
 development team members simply pulls it.


### PR DESCRIPTION
Added "that" to make a sentence in the Development Process section more grammatically clear.
