### PR TITLE
Remove size limit in RPC client, keep it in server

### DIFF
--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -126,7 +126,7 @@ Object CallRPC(const string& strMethod, const Array& params)
     // Receive HTTP reply message headers and body
     map<string, string> mapHeaders;
     string strReply;
-    ReadHTTPMessage(stream, mapHeaders, strReply, nProto);
+    ReadHTTPMessage(stream, mapHeaders, strReply, nProto, std::numeric_limits<size_t>::max());
 
     if (nStatus == HTTP_UNAUTHORIZED)
         throw runtime_error("incorrect rpcuser or rpcpassword (authorization failed)");

--- a/src/rpcprotocol.cpp
+++ b/src/rpcprotocol.cpp
@@ -201,14 +201,14 @@ int ReadHTTPHeaders(std::basic_istream<char>& stream, map<string, string>& mapHe
 
 int ReadHTTPMessage(std::basic_istream<char>& stream, map<string,
                     string>& mapHeadersRet, string& strMessageRet,
-                    int nProto)
+                    int nProto, size_t max_size)
 {
     mapHeadersRet.clear();
     strMessageRet = "";
 
     // Read header
     int nLen = ReadHTTPHeaders(stream, mapHeadersRet);
-    if (nLen < 0 || nLen > (int)MAX_SIZE)
+    if (nLen < 0 || (size_t)nLen > max_size)
         return HTTP_INTERNAL_SERVER_ERROR;
 
     // Read message

--- a/src/rpcprotocol.h
+++ b/src/rpcprotocol.h
@@ -153,7 +153,7 @@ bool ReadHTTPRequestLine(std::basic_istream<char>& stream, int &proto,
 int ReadHTTPStatus(std::basic_istream<char>& stream, int &proto);
 int ReadHTTPHeaders(std::basic_istream<char>& stream, std::map<std::string, std::string>& mapHeadersRet);
 int ReadHTTPMessage(std::basic_istream<char>& stream, std::map<std::string, std::string>& mapHeadersRet,
-                    std::string& strMessageRet, int nProto);
+                    std::string& strMessageRet, int nProto, size_t max_size);
 std::string JSONRPCRequest(const std::string& strMethod, const json_spirit::Array& params, const json_spirit::Value& id);
 json_spirit::Object JSONRPCReplyObj(const json_spirit::Value& result, const json_spirit::Value& error, const json_spirit::Value& id);
 std::string JSONRPCReply(const json_spirit::Value& result, const json_spirit::Value& error, const json_spirit::Value& id);

--- a/src/rpcprotocol.h
+++ b/src/rpcprotocol.h
@@ -143,6 +143,8 @@ private:
 std::string HTTPPost(const std::string& strMsg, const std::map<std::string,std::string>& mapRequestHeaders);
 std::string HTTPError(int nStatus, bool keepalive,
                       bool headerOnly = false);
+std::string HTTPReplyHeader(int nStatus, bool keepalive, size_t contentLength,
+                      const char *contentType = "application/json");
 std::string HTTPReply(int nStatus, const std::string& strMsg, bool keepalive,
                       bool headerOnly = false,
                       const char *contentType = "application/json");

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -862,7 +862,7 @@ static bool HTTPReq_JSONRPC(AcceptedConnection *conn,
         else
             throw JSONRPCError(RPC_PARSE_ERROR, "Top-level object parse error");
 
-        conn->stream() << HTTPReply(HTTP_OK, strReply, fRun) << std::flush;
+        conn->stream() << HTTPReplyHeader(HTTP_OK, fRun, strReply.size()) << strReply << std::flush;
     }
     catch (Object& objError)
     {

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -891,7 +891,7 @@ void ServiceConnection(AcceptedConnection *conn)
             break;
 
         // Read HTTP message headers and body
-        ReadHTTPMessage(conn->stream(), mapHeaders, strRequest, nProto);
+        ReadHTTPMessage(conn->stream(), mapHeaders, strRequest, nProto, MAX_SIZE);
 
         // HTTP Keep-Alive is false; close connection immediately
         if (mapHeaders["connection"] == "close")


### PR DESCRIPTION
The size limit makes a lot of sense for the server, as it never has to accept very large data and has to protect against malicious clients.

The client, however, can request arbitrary amounts of data (for example with `listtransactions` on a large wallet). Having a strict size limit makes little sense.

Fixes #4604.

The second commit contains a slight optimization that prevents a redundent copy and removes a needless c_str which would mess with binary data.
