### PR TITLE
 Added warning about libtool

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
 set -e
+if which libtool >/dev/null; then
+    echo
+else
+    echo Libtool is Missing. Bitcoin Requires Libtool To Compile.
+fi
 srcdir="$(dirname $0)"
 cd "$srcdir"
 if [ -z ${LIBTOOLIZE} ] && GLIBTOOLIZE="`which glibtoolize 2>/dev/null`"; then


### PR DESCRIPTION
If libtool isn't installed ./configure results in some generic errors that don't explain the source of the problem. Added a check in autogen.sh to notify the user if they don't have Libtool.
