### PR TITLE
NODE_EXT_SERVICE: Advertise other services also available at this node.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -83,6 +83,7 @@ BITCOIN_CORE_H = \
   core_io.h \
   crypter.h \
   db.h \
+  extservices.h \
   hash.h \
   init.h \
   key.h \
@@ -141,6 +142,7 @@ libbitcoin_server_a_SOURCES = \
   alert.cpp \
   bloom.cpp \
   checkpoints.cpp \
+  extservices.cpp \
   init.cpp \
   leveldbwrapper.cpp \
   main.cpp \

--- a/src/extservices.cpp
+++ b/src/extservices.cpp
@@ -1,0 +1,195 @@
+
+#include <vector>
+#include "serialize.h"
+#include "util.h"
+#include "version.h"
+#include "net.h"
+#include "extservices.h"
+#include <boost/foreach.hpp>
+#include "json/json_spirit_value.h"
+#include "json/json_spirit_reader_template.h"
+#include "json/json_spirit_utils.h"
+
+using namespace std;
+using namespace json_spirit;
+
+static const unsigned int MAX_JSON_SRV_SZ = (640 * 1024); // enough for anybody
+
+class CExtServices {
+private:
+    vector<CExtService> srvList;
+
+public:
+    void getArray(Array& arr);
+    void getVec(vector<CExtService>& vec);
+    void add(const CExtService& val) { srvList.push_back(val); }
+    size_t count() const { return srvList.size(); }
+};
+
+static CExtServices extServices;
+
+bool CExtService::parseValue(const Value& val)
+{
+    if (val.type() != obj_type)
+        return false;
+
+    const Object& srvObj = val.get_obj();
+
+    const Value& vName = find_value(srvObj, "name");
+    if (vName.type() != str_type)
+        return false;
+
+    name = vName.get_str();
+
+    const Value& vPort = find_value(srvObj, "port");
+    if (vPort.type() == null_type) {
+        // do nothing
+    } else if (vPort.type() == int_type) {
+        int i = vPort.get_int();
+        if (i < 1 || i > 65535)
+            return false;
+
+        port = i;
+    } else
+        return false;
+
+    const Value& vAttrib = find_value(srvObj, "attrib");
+    if (vAttrib.type() == null_type) {
+        // do nothing
+    } else if (vAttrib.type() == obj_type) {
+        const Object& attribObj = vAttrib.get_obj();
+        BOOST_FOREACH(const Pair& s, attribObj) {
+            const Value& av = s.value_;
+            if (av.type() != str_type)
+                return false;
+
+            CKeyValue kv(s.name_, av.get_str());
+            if (kv.key.size() < 1 || kv.key.size() > 100 ||
+                kv.value.size() > 1000)
+                return false;
+
+            attrib.push_back(kv);
+        }
+    } else
+        return false;
+
+    return true;
+}
+
+void CExtServices::getArray(Array& arr)
+{
+    BOOST_FOREACH(const CExtService& srv, srvList) {
+        Object obj;
+        obj.push_back(Pair("name", srv.name));
+        if (srv.port > 0)
+            obj.push_back(Pair("port", srv.port));
+
+        arr.push_back(obj);
+    }
+}
+
+void CExtServices::getVec(vector<CExtService>& vec)
+{
+    BOOST_FOREACH(const CExtService& srv, srvList) {
+        vec.push_back(srv);
+    }
+}
+
+static bool ReadJsonFile(const string& filename, size_t maxSz,
+                         Value& valOut, string& strErr)
+{
+    CAutoFile srvfile(fopen(filename.c_str(), "r"), SER_DISK, CLIENT_VERSION);
+    if (!srvfile) {
+        strErr = strprintf("Cannot open %s\n", filename);
+        return false;
+    }
+
+    string rawJson;
+    while (1) {
+        char buf[4096];
+
+        size_t bread = fread(buf, 1, sizeof(buf), srvfile);
+        rawJson.append(buf, bread);
+
+        if (maxSz && (rawJson.size() > maxSz)) {
+            strErr = strprintf("Error reading %s, too large\n", filename);
+            return false;
+        }
+
+        if (bread < sizeof(buf)) {
+            if (ferror(srvfile)) {
+                strErr = strprintf("Error reading %s\n", filename);
+                return false;
+            }
+
+            // eof
+            break;
+        }
+    }
+
+    if (!read_string(rawJson, valOut) ||
+        (valOut.type() != obj_type)) {
+        strErr = strprintf("Error parsing JSON in %s\n", filename);
+        return false;
+    }
+
+    return true;
+}
+
+static bool ReadExtServiceFile(const string& filename)
+{
+    Value valSrv;
+    string strErr;
+    if (!ReadJsonFile(filename, MAX_JSON_SRV_SZ, valSrv, strErr)) {
+        LogPrintf("%s: %s", filename, strErr);
+        return false;
+    }
+
+    CExtService srv;
+    if (!srv.parseValue(valSrv) ||
+        (valSrv.type() != array_type)) {
+        LogPrintf("Unable to parse value in %s\n", filename);
+        return false;
+    }
+
+    const Array& serviceList = valSrv.get_array();
+    for (unsigned int i = 0; i < serviceList.size(); i++) {
+        if (serviceList[i].type() != obj_type) {
+            LogPrintf("Service list member not object\n");
+            return false;
+        }
+
+        CExtService srv;
+        if (!srv.parseValue(serviceList[i]))
+            return false;
+
+        extServices.add(srv);
+    }
+
+    return true;
+}
+
+bool ReadExtServices()
+{
+    if (!mapArgs.count("-extservices"))
+        return true;
+    if (!ReadExtServiceFile(mapArgs["-extservice"]))
+        return false;
+
+    if (extServices.count() > 0)
+        nLocalServices |= NODE_EXT_SERVICES;
+
+    return true;
+}
+
+Array ListExtServices()
+{
+    Array ret;
+    extServices.getArray(ret);
+    return ret;
+}
+
+void GetExtServicesVec(vector<CExtService>& vec)
+{
+    extServices.getVec(vec);
+}

--- a/src/extservices.cpp
+++ b/src/extservices.cpp
@@ -145,10 +145,8 @@ static bool ReadExtServiceFile(const string& filename)
         return false;
     }
 
-    CExtService srv;
-    if (!srv.parseValue(valSrv) ||
-        (valSrv.type() != array_type)) {
-        LogPrintf("Unable to parse value in %s\n", filename);
+    if (valSrv.type() != array_type) {
+        LogPrintf("Unable to parse array in %s\n", filename);
         return false;
     }
 

--- a/src/extservices.h
+++ b/src/extservices.h
@@ -1,0 +1,62 @@
+#ifndef __BITCOIN_EXTSERVICES_H__
+#define __BITCOIN_EXTSERVICES_H__
+
+#include <stdint.h>
+#include <string>
+#include <vector>
+#include "json/json_spirit_value.h"
+#include "serialize.h"
+
+class CKeyValue {
+public:
+    std::string key;
+    std::string value;
+
+    CKeyValue()
+    {
+        SetNull();
+    }
+    CKeyValue(std::string key_, std::string value_)
+    {
+        key = key_;
+	value = value_;
+    }
+
+    IMPLEMENT_SERIALIZE
+    (
+        READWRITE(key);
+        READWRITE(value);
+    )
+
+    void SetNull()
+    {
+        key.clear();
+        value.clear();
+    }
+};
+
+class CExtService {
+public:
+    std::string name;
+    int32_t port;
+    std::vector<CKeyValue> attrib;
+
+    CExtService(const std::string& name_ = "", int32_t port_ = -1) {
+        name = name_;
+        port = port_;
+    }
+    bool parseValue(const json_spirit::Value& val);
+
+    IMPLEMENT_SERIALIZE
+    (
+        READWRITE(name);
+        READWRITE(port);
+        READWRITE(attrib);
+    )
+};
+
+extern bool ReadExtServices();
+extern json_spirit::Array ListExtServices();
+extern void GetExtServicesVec(std::vector<CExtService>& vec);
+
+#endif // __BITCOIN_EXTSERVICES_H__

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -19,6 +19,7 @@
 #include "txdb.h"
 #include "ui_interface.h"
 #include "util.h"
+#include "extservices.h"
 #ifdef ENABLE_WALLET
 #include "db.h"
 #include "wallet.h"
@@ -241,6 +242,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += "  -dns                   " + _("Allow DNS lookups for -addnode, -seednode and -connect") + " " + _("(default: 1)") + "\n";
     strUsage += "  -dnsseed               " + _("Query for peer addresses via DNS lookup, if low on addresses (default: 1 unless -connect)") + "\n";
     strUsage += "  -externalip=<ip>       " + _("Specify your own public address") + "\n";
+    strUsage += "  -extservices=<file>    " + _("Specify JSON file containing array of external/extended service descriptions") + "\n";
     strUsage += "  -forcednsseed          " + _("Always query for peer addresses via DNS lookup (default: 0)") + "\n";
     strUsage += "  -listen                " + _("Accept connections from outside (default: 1 if no -proxy or -connect)") + "\n";
     strUsage += "  -maxconnections=<n>    " + _("Maintain at most <n> connections to peers (default: 125)") + "\n";
@@ -1044,6 +1046,9 @@ bool AppInit2(boost::thread_group& threadGroup)
     // Allowed to fail as this file IS missing on first startup.
     if (est_filein)
         mempool.ReadFeeEstimates(est_filein);
+
+    if (!ReadExtServices())
+        return false;
 
     // ********************************************************* Step 8: load wallet
 #ifdef ENABLE_WALLET

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,6 +17,7 @@
 #include "txmempool.h"
 #include "ui_interface.h"
 #include "util.h"
+#include "extservices.h"
 
 #include <sstream>
 
@@ -3652,6 +3653,14 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
     else if (strCommand == "verack")
     {
         pfrom->SetRecvVersion(min(pfrom->nVersion, PROTOCOL_VERSION));
+    }
+
+
+    else if ((strCommand == "getextsrv") && (nLocalServices & NODE_EXT_SERVICES))
+    {
+        vector<CExtService> vSrv;
+        GetExtServicesVec(vSrv);
+        pfrom->PushMessage("extservices", vSrv);
     }
 
 

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -64,6 +64,7 @@ class CMessageHeader
 enum
 {
     NODE_NETWORK = (1 << 0),
+    NODE_EXT_SERVICES = (1 << 1),
 
     // Bits 24-31 are reserved for temporary experiments. Just pick a bit that
     // isn't getting used, or one not being used much, and notify the

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -64,7 +64,7 @@ class CMessageHeader
 enum
 {
     NODE_NETWORK = (1 << 0),
-    NODE_EXT_SERVICES = (1 << 1),
+    NODE_EXT_SERVICES = (1 << 2),
 
     // Bits 24-31 are reserved for temporary experiments. Just pick a bit that
     // isn't getting used, or one not being used much, and notify the

--- a/src/rpcnet.cpp
+++ b/src/rpcnet.cpp
@@ -11,6 +11,7 @@
 #include "sync.h"
 #include "timedata.h"
 #include "util.h"
+#include "extservices.h"
 
 #include <boost/foreach.hpp>
 #include "json/json_spirit_value.h"
@@ -371,6 +372,7 @@ Value getnetworkinfo(const Array& params, bool fHelp)
     obj.push_back(Pair("version",       (int)CLIENT_VERSION));
     obj.push_back(Pair("protocolversion",(int)PROTOCOL_VERSION));
     obj.push_back(Pair("localservices",       strprintf("%016x", nLocalServices)));
+    obj.push_back(Pair("extservices",   ListExtServices()));
     obj.push_back(Pair("timeoffset",    GetTimeOffset()));
     obj.push_back(Pair("connections",   (int)vNodes.size()));
     obj.push_back(Pair("proxy",         (proxy.IsValid() ? proxy.ToStringIPPort() : string())));


### PR DESCRIPTION
It is not necessary to build all functionality into bitcoind, to form a decentralized network.  <vendor hat: on>  BitPay's insight open source block explorer API project requires, and runs on top of, bitcoind.  Therefore, at the same IP address as bitcoind, other services are made available to the public (scriptPubkey queries, other added-value queries).  This results in a decentralized network of "anyone running a full node _and_ an insight server", as a subset of the whole P2P net.  </vendor hat>

Obviously, we want to build this in a generic, vendor-neutral way.

Services may only advertise added services **if and only if** the external services are at the same IP address that is being advertised.
