### PR TITLE
Encapsulate & protect members of CMessageHeader (kinda), CInv, CAddress

### DIFF
--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -279,7 +279,7 @@ void CAddrMan::Good_(const CService &addr, int64_t nTime)
     // update info
     info.nLastSuccess = nTime;
     info.nLastTry = nTime;
-    info.nTime = nTime;
+    info.SetTime(nTime);
     info.nAttempts = 0;
 
     // if it is already in the tried set, don't do anything else
@@ -322,16 +322,16 @@ bool CAddrMan::Add_(const CAddress &addr, const CNetAddr& source, int64_t nTimeP
     if (pinfo)
     {
         // periodically update nTime
-        bool fCurrentlyOnline = (GetAdjustedTime() - addr.nTime < 24 * 60 * 60);
+        bool fCurrentlyOnline = (GetAdjustedTime() - addr.GetTime() < 24 * 60 * 60);
         int64_t nUpdateInterval = (fCurrentlyOnline ? 60 * 60 : 24 * 60 * 60);
-        if (addr.nTime && (!pinfo->nTime || pinfo->nTime < addr.nTime - nUpdateInterval - nTimePenalty))
-            pinfo->nTime = max((int64_t)0, addr.nTime - nTimePenalty);
+        if (addr.GetTime() && (!pinfo->GetTime() || pinfo->GetTime() < addr.GetTime() - nUpdateInterval - nTimePenalty))
+            pinfo->SetTime(max((int64_t)0, addr.GetTime() - nTimePenalty));
 
         // add services
-        pinfo->nServices |= addr.nServices;
+        pinfo->AddServices(addr.GetServices());
 
         // do not update if no new information is present
-        if (!addr.nTime || (pinfo->nTime && addr.nTime <= pinfo->nTime))
+        if (!addr.GetTime() || (pinfo->GetTime() && addr.GetTime() <= pinfo->GetTime()))
             return false;
 
         // do not update if the entry was already in the "tried" table
@@ -350,7 +350,7 @@ bool CAddrMan::Add_(const CAddress &addr, const CNetAddr& source, int64_t nTimeP
             return false;
     } else {
         pinfo = Create(addr, source, &nId);
-        pinfo->nTime = max((int64_t)0, (int64_t)pinfo->nTime - nTimePenalty);
+        pinfo->SetTime(max((int64_t)0, (int64_t)pinfo->GetTime() - nTimePenalty));
         nNew++;
         fNew = true;
     }
@@ -528,6 +528,6 @@ void CAddrMan::Connected_(const CService &addr, int64_t nTime)
 
     // update info
     int64_t nUpdateInterval = 20 * 60;
-    if (nTime - info.nTime > nUpdateInterval)
-        info.nTime = nTime;
+    if (nTime - info.GetTime() > nUpdateInterval)
+        info.SetTime(nTime);
 }

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -38,7 +38,7 @@ static void convertSeed6(std::vector<CAddress> &vSeedsOut, const SeedSpec6 *data
         struct in6_addr ip;
         memcpy(&ip, data[i].addr, sizeof(ip));
         CAddress addr(CService(ip, data[i].port));
-        addr.nTime = GetTime() - GetRand(nOneWeek) - nOneWeek;
+        addr.SetTime(GetTime() - GetRand(nOneWeek) - nOneWeek);
         vSeedsOut.push_back(addr);
     }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3752,11 +3752,11 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         {
             boost::this_thread::interruption_point();
 
-            if (addr.nTime <= 100000000 || addr.nTime > nNow + 10 * 60)
-                addr.nTime = nNow - 5 * 24 * 60 * 60;
+            if (addr.GetTime() <= 100000000 || addr.GetTime() > nNow + 10 * 60)
+                addr.SetTime(nNow - 5 * 24 * 60 * 60);
             pfrom->AddAddressKnown(addr);
             bool fReachable = IsReachable(addr);
-            if (addr.nTime > nSince && !pfrom->fGetAddr && vAddr.size() <= 10 && addr.IsRoutable())
+            if (addr.GetTime() > nSince && !pfrom->fGetAddr && vAddr.size() <= 10 && addr.IsRoutable())
             {
                 // Relay to a limited number of other nodes
                 {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4364,17 +4364,17 @@ bool ProcessMessages(CNode* pfrom)
         string strCommand = hdr.GetCommand();
 
         // Message size
-        unsigned int nMessageSize = hdr.nMessageSize;
+        unsigned int nMessageSize = hdr.GetSize();
 
         // Checksum
         CDataStream& vRecv = msg.vRecv;
         uint256 hash = Hash(vRecv.begin(), vRecv.begin() + nMessageSize);
         unsigned int nChecksum = 0;
         memcpy(&nChecksum, &hash, sizeof(nChecksum));
-        if (nChecksum != hdr.nChecksum)
+        if (nChecksum != hdr.GetChecksum())
         {
             LogPrintf("ProcessMessages(%s, %u bytes) : CHECKSUM ERROR nChecksum=%08x hdr.nChecksum=%08x\n",
-               strCommand, nMessageSize, nChecksum, hdr.nChecksum);
+               strCommand, nMessageSize, nChecksum, hdr.GetChecksum());
             continue;
         }
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -693,7 +693,7 @@ int CNetMessage::readHeader(const char *pch, unsigned int nBytes)
     }
 
     // reject messages larger than MAX_SIZE
-    if (hdr.nMessageSize > MAX_SIZE)
+    if (hdr.GetSize() > MAX_SIZE)
             return -1;
 
     // switch state to reading message data
@@ -704,12 +704,12 @@ int CNetMessage::readHeader(const char *pch, unsigned int nBytes)
 
 int CNetMessage::readData(const char *pch, unsigned int nBytes)
 {
-    unsigned int nRemaining = hdr.nMessageSize - nDataPos;
+    unsigned int nRemaining = hdr.GetSize() - nDataPos;
     unsigned int nCopy = std::min(nRemaining, nBytes);
 
     if (vRecv.size() < nDataPos + nCopy) {
         // Allocate up to 256 KiB ahead, but never more than the total message size.
-        vRecv.resize(std::min(hdr.nMessageSize, nDataPos + nCopy + 256 * 1024));
+        vRecv.resize(std::min(hdr.GetSize(), nDataPos + nCopy + 256 * 1024));
     }
 
     memcpy(&vRecv[nDataPos], pch, nCopy);

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -147,8 +147,8 @@ CAddress GetLocalAddress(const CNetAddr *paddrPeer)
     if (GetLocal(addr, paddrPeer))
     {
         ret = CAddress(addr);
-        ret.nServices = nLocalServices;
-        ret.nTime = GetAdjustedTime();
+        ret.SetServices(nLocalServices);
+        ret.SetTime(GetAdjustedTime());
     }
     return ret;
 }
@@ -479,7 +479,7 @@ CNode* ConnectNode(CAddress addrConnect, const char *pszDest)
     /// debug print
     LogPrint("net", "trying connection %s lastseen=%.1fhrs\n",
         pszDest ? pszDest : addrConnect.ToString(),
-        pszDest ? 0.0 : (double)(GetAdjustedTime() - addrConnect.nTime)/3600.0);
+        pszDest ? 0.0 : (double)(GetAdjustedTime() - addrConnect.GetTime())/3600.0);
 
     // Connect
     SOCKET hSocket;
@@ -1237,7 +1237,7 @@ void ThreadDNSAddressSeed()
                 {
                     int nOneDay = 24*3600;
                     CAddress addr = CAddress(CService(ip, Params().GetDefaultPort()));
-                    addr.nTime = GetTime() - 3*nOneDay - GetRand(4*nOneDay); // use a random age between 3 and 7 days old
+                    addr.SetTime(GetTime() - 3*nOneDay - GetRand(4*nOneDay)); // use a random age between 3 and 7 days old
                     vAdd.push_back(addr);
                     found++;
                 }
@@ -1373,7 +1373,7 @@ void ThreadOpenConnections()
                 continue;
 
             // only consider very recently tried nodes after 30 failed attempts
-            if (nANow - addr.nLastTry < 600 && nTries < 30)
+            if (nANow - addr.GetLastTry() < 600 && nTries < 30)
                 continue;
 
             // do not allow non-default ports, unless after 50 invalid addresses selected already

--- a/src/net.h
+++ b/src/net.h
@@ -190,7 +190,7 @@ public:
     {
         if (!in_data)
             return false;
-        return (hdr.nMessageSize == nDataPos);
+        return (hdr.GetSize() == nDataPos);
     }
 
     void SetVersion(int nVersionIn)

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -37,14 +37,6 @@ CMessageHeader::CMessageHeader(const char* pszCommand, unsigned int nMessageSize
     nChecksum = 0;
 }
 
-std::string CMessageHeader::GetCommand() const
-{
-    if (pchCommand[COMMAND_SIZE-1] == 0)
-        return std::string(pchCommand, pchCommand + strlen(pchCommand));
-    else
-        return std::string(pchCommand, pchCommand + COMMAND_SIZE);
-}
-
 bool CMessageHeader::IsValid() const
 {
     // Check start string

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -37,6 +37,14 @@ CMessageHeader::CMessageHeader(const char* pszCommand, unsigned int nMessageSize
     nChecksum = 0;
 }
 
+std::string CMessageHeader::GetCommand() const
+{
+    if (pchCommand[COMMAND_SIZE-1] == 0)
+        return std::string(pchCommand, pchCommand + strlen(pchCommand));
+    else
+        return std::string(pchCommand, pchCommand + COMMAND_SIZE);
+}
+
 bool CMessageHeader::IsValid() const
 {
     // Check start string

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -139,7 +139,7 @@ class CInv
         const char* GetCommand() const;
         std::string ToString() const;
         int GetType() const { return type; }
-        uint256 GetHash() const { return hash; }
+        const uint256& GetHash() const { return hash; }
 
     protected:
         int type;

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -99,8 +99,14 @@ class CAddress : public CService
              READWRITE(*pip);
             )
 
-    // TODO: make private (improves encapsulation)
-    public:
+        uint64_t GetServices() const { return nServices; }
+        void SetServices(uint64_t mask) { nServices = mask; }
+        void AddServices(uint64_t mask) { nServices |= mask; }
+        unsigned int GetTime() const { return nTime; }
+        void SetTime(unsigned int nTime_) { nTime = nTime_; }
+        int64_t GetLastTry() const { return nLastTry; }
+
+    protected:
         uint64_t nServices;
 
         // disk and network only

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -32,7 +32,6 @@ class CMessageHeader
         CMessageHeader();
         CMessageHeader(const char* pszCommand, unsigned int nMessageSizeIn);
 
-        std::string GetCommand() const;
         bool IsValid() const;
 
         IMPLEMENT_SERIALIZE
@@ -58,6 +57,13 @@ class CMessageHeader
         char pchCommand[COMMAND_SIZE];
         unsigned int nMessageSize;
         unsigned int nChecksum;
+
+        unsigned int GetSize() const { return nMessageSize; }
+        unsigned int GetChecksum() const { return nChecksum; }
+        std::string GetCommand() const {
+            size_t cmdLen = strnlen(pchCommand, COMMAND_SIZE);
+            return std::string(pchCommand, cmdLen);
+        }
 };
 
 /** nServices flags */

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -16,6 +16,7 @@
 #include "version.h"
 
 #include <stdint.h>
+#include <string.h>
 #include <string>
 
 #define MESSAGE_START_SIZE 4

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -42,7 +42,7 @@ class CMessageHeader
              READWRITE(nChecksum);
             )
 
-    // TODO: make private (improves encapsulation)
+    // TODO: make protected (improves encapsulation)
     public:
         enum {
             COMMAND_SIZE=12,
@@ -141,9 +141,10 @@ class CInv
         bool IsKnownType() const;
         const char* GetCommand() const;
         std::string ToString() const;
+        int GetType() const { return type; }
+        uint256 GetHash() const { return hash; }
 
-    // TODO: make private (improves encapsulation)
-    public:
+    protected:
         int type;
         uint256 hash;
 };

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -16,7 +16,6 @@
 #include "version.h"
 
 #include <stdint.h>
-#include <string.h>
 #include <string>
 
 #define MESSAGE_START_SIZE 4
@@ -33,6 +32,7 @@ class CMessageHeader
         CMessageHeader();
         CMessageHeader(const char* pszCommand, unsigned int nMessageSizeIn);
 
+        std::string GetCommand() const;
         bool IsValid() const;
 
         IMPLEMENT_SERIALIZE
@@ -61,10 +61,6 @@ class CMessageHeader
 
         unsigned int GetSize() const { return nMessageSize; }
         unsigned int GetChecksum() const { return nChecksum; }
-        std::string GetCommand() const {
-            size_t cmdLen = strnlen(pchCommand, COMMAND_SIZE);
-            return std::string(pchCommand, cmdLen);
-        }
 };
 
 /** nServices flags */


### PR DESCRIPTION
CMessageHeader is directly accessed, so the conversion was merely done for non-direct-access callsites.
