### PR TITLE
Update glibc-compat for new libstdc++ symbol

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -332,7 +332,10 @@ if test x$use_glibc_compat != xno; then
   #__fdelt_chk's params and return type have changed from long unsigned int to long int.
   # See which one is present here.
   AC_MSG_CHECKING(__fdelt_chk type)
-  AC_TRY_COMPILE([#define __USE_FORTIFY_LEVEL 2
+  AC_TRY_COMPILE([#ifdef _FORTIFY_SOURCE
+                    #undef _FORTIFY_SOURCE
+                  #endif
+                  #define _FORTIFY_SOURCE 2
                   #include <sys/select.h>
      extern "C" long unsigned int __fdelt_warn(long unsigned int);],[],
     [ fdelt_type="long unsigned int"],

--- a/src/compat/glibcxx_compat.cpp
+++ b/src/compat/glibcxx_compat.cpp
@@ -64,6 +64,8 @@ template istream& istream::_M_extract(unsigned short&);
 
 out_of_range::~out_of_range() _GLIBCXX_USE_NOEXCEPT { }
 
+length_error::~length_error() _GLIBCXX_USE_NOEXCEPT { }
+
 // Used with permission.
 // See: https://github.com/madlib/madlib/commit/c3db418c0d34d6813608f2137fef1012ce03043d
 


### PR DESCRIPTION
Sometime recently a new libstdc++ symbol has snuck in, leaving us depending on GLIBCXX_3.4.15. This avoids that dependency.
