### PR TITLE
[Qt] Add TRY_LOCK back to peertablemodel

### DIFF
--- a/src/qt/peertablemodel.cpp
+++ b/src/qt/peertablemodel.cpp
@@ -75,8 +75,14 @@ public:
         }
 
         // Try to retrieve the CNodeStateStats for each node.
-        BOOST_FOREACH(CNodeCombinedStats &stats, cachedNodeStats)
-            stats.fNodeStateStatsAvailable = GetNodeStateStats(stats.nodeStats.nodeid, stats.nodeStateStats);
+        {
+            TRY_LOCK(cs_main, lockMain);
+            if (lockMain)
+            {
+                BOOST_FOREACH(CNodeCombinedStats &stats, cachedNodeStats)
+                    stats.fNodeStateStatsAvailable = GetNodeStateStats(stats.nodeStats.nodeid, stats.nodeStateStats);
+            }
+        }
 
         if (sortColumn >= 0)
             // sort cacheNodeStats (use stable sort to prevent rows jumping around unneceesarily)


### PR DESCRIPTION
TRY_LOCK has been removed recently, but this causes the progressbars to freeze, because the GUI-thread is waiting for cs_main.
