### PR TITLE
Make CCryptoKeyStore::Unlock check all keys (but only once)

### DIFF
--- a/src/crypter.cpp
+++ b/src/crypter.cpp
@@ -178,6 +178,8 @@ bool CCryptoKeyStore::Unlock(const CKeyingMaterial& vMasterKeyIn)
                 break;
             }
             keyPass = true;
+            if (fDecryptionThoroughlyChecked)
+                break;
         }
         if (keyPass && keyFail)
         {
@@ -187,6 +189,7 @@ bool CCryptoKeyStore::Unlock(const CKeyingMaterial& vMasterKeyIn)
         if (keyFail || !keyPass)
             return false;
         vMasterKey = vMasterKeyIn;
+        fDecryptionThoroughlyChecked = true;
     }
     NotifyStatusChanged(this);
     return true;

--- a/src/crypter.cpp
+++ b/src/crypter.cpp
@@ -152,6 +152,8 @@ bool CCryptoKeyStore::Unlock(const CKeyingMaterial& vMasterKeyIn)
         if (!SetCrypted())
             return false;
 
+        bool keyPass = false;
+        bool keyFail = false;
         CryptedKeyMap::const_iterator mi = mapCryptedKeys.begin();
         for (; mi != mapCryptedKeys.end(); ++mi)
         {
@@ -159,15 +161,31 @@ bool CCryptoKeyStore::Unlock(const CKeyingMaterial& vMasterKeyIn)
             const std::vector<unsigned char> &vchCryptedSecret = (*mi).second.second;
             CKeyingMaterial vchSecret;
             if(!DecryptSecret(vMasterKeyIn, vchCryptedSecret, vchPubKey.GetHash(), vchSecret))
-                return false;
+            {
+                keyFail = true;
+                break;
+            }
             if (vchSecret.size() != 32)
-                return false;
+            {
+                keyFail = true;
+                break;
+            }
             CKey key;
             key.Set(vchSecret.begin(), vchSecret.end(), vchPubKey.IsCompressed());
-            if (key.GetPubKey() == vchPubKey)
+            if (key.GetPubKey() != vchPubKey)
+            {
+                keyFail = true;
                 break;
-            return false;
+            }
+            keyPass = true;
         }
+        if (keyPass && keyFail)
+        {
+            LogPrintf("The wallet is probably corrupted: Some keys decrypt but not all.");
+            assert(false);
+        }
+        if (keyFail || !keyPass)
+            return false;
         vMasterKey = vMasterKeyIn;
     }
     NotifyStatusChanged(this);

--- a/src/crypter.h
+++ b/src/crypter.h
@@ -121,6 +121,9 @@ private:
     // if fUseCrypto is false, vMasterKey must be empty
     bool fUseCrypto;
 
+    // keeps track of whether Unlock has run a thourough check before
+    bool fDecryptionThoroughlyChecked;
+
 protected:
     bool SetCrypted();
 
@@ -130,7 +133,7 @@ protected:
     bool Unlock(const CKeyingMaterial& vMasterKeyIn);
 
 public:
-    CCryptoKeyStore() : fUseCrypto(false)
+    CCryptoKeyStore() : fUseCrypto(false), fDecryptionThoroughlyChecked(false)
     {
     }
 


### PR DESCRIPTION
Extends #4011 by three lines.
I know we have multiple wallet support in theory, but until it actually appears, a static should be fine.
