### PR TITLE
Remove DNS Seeds run by entities which were never well-established.

### DIFF
--- a/doc/dnsseed-policy.md
+++ b/doc/dnsseed-policy.md
@@ -3,6 +3,9 @@ Expectations for DNS Seed operators
 
 Bitcoin Core attempts to minimize the level of trust in DNS seeds,
 but DNS seeds still pose a small amount of risk for the network.
+As such, DNS seeds must be run by entities which have some minimum
+level of trust within the Bitcoin community.
+
 Other implementations of Bitcoin software may also use the same
 seeds and may be more exposed. In light of this exposure this
 document establishes some basic expectations for the expectations

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -99,7 +99,6 @@ public:
         vSeeds.push_back(CDNSSeedData("dashjr.org", "dnsseed.bitcoin.dashjr.org"));
         vSeeds.push_back(CDNSSeedData("bitcoinstats.com", "seed.bitcoinstats.com"));
         vSeeds.push_back(CDNSSeedData("bitnodes.io", "seed.bitnodes.io"));
-        vSeeds.push_back(CDNSSeedData("open-nodes.org", "seeds.bitcoin.open-nodes.org"));
         vSeeds.push_back(CDNSSeedData("xf2.org", "bitseed.xf2.org"));
 
         base58Prefixes[PUBKEY_ADDRESS] = list_of(0);


### PR DESCRIPTION
As there is a clear policy DNS Seeds should be adhering to, they also need to be run by community members which are semi-trusted to act according to this policy. These two nodes were submitted without any clear evidence of community trust in their organizations and, as such, should either provide such evidence, or be removed.

@ayeowch and @bitkevin were the original submitters of the pull requests which added these nodes. Note that they are both part of projects to add more full nodes to the network, which they can continue to do with or without a DNS Seed.

Also, blog.open-nodes.org seems to indicate they are running nodes with aggressive outbound connection counts, amounting to attacking the network and replacing diversely-operated nodes with ones they run :(.
