### PR TITLE
Some coin database memory usage tweaks.

### DIFF
--- a/src/coins.h
+++ b/src/coins.h
@@ -291,8 +291,9 @@ public:
     // Modify the currently active block hash
     virtual bool SetBestBlock(const uint256 &hashBlock);
 
-    // Do a bulk modification (multiple SetCoins + one SetBestBlock)
-    virtual bool BatchWrite(const CCoinsMap &mapCoins, const uint256 &hashBlock);
+    // Do a bulk modification (multiple SetCoins + one SetBestBlock).
+    // The passed mapCoins can be modified.
+    virtual bool BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock);
 
     // Calculate statistics about the unspent transaction output set
     virtual bool GetStats(CCoinsStats &stats);
@@ -316,7 +317,7 @@ public:
     uint256 GetBestBlock();
     bool SetBestBlock(const uint256 &hashBlock);
     void SetBackend(CCoinsView &viewIn);
-    bool BatchWrite(const CCoinsMap &mapCoins, const uint256 &hashBlock);
+    bool BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock);
     bool GetStats(CCoinsStats &stats);
 };
 
@@ -337,7 +338,7 @@ public:
     bool HaveCoins(const uint256 &txid);
     uint256 GetBestBlock();
     bool SetBestBlock(const uint256 &hashBlock);
-    bool BatchWrite(const CCoinsMap &mapCoins, const uint256 &hashBlock);
+    bool BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock);
 
     // Return a modifiable reference to a CCoins. Check HaveCoins first.
     // Many methods explicitly require a CCoinsViewCache because of this method, to reduce
@@ -346,6 +347,7 @@ public:
 
     // Push the modifications applied to this cache to its base.
     // Failure to call this method before destruction will cause the changes to be forgotten.
+    // If false is returned, the state of this cache (and its backing view) will be undefined.
     bool Flush();
 
     // Calculate the size of the cache (in number of transactions)

--- a/src/script.h
+++ b/src/script.h
@@ -730,6 +730,12 @@ public:
     {
         return CScriptID(Hash160(*this));
     }
+
+    void clear()
+    {
+        // The default std::vector::clear() does not release memory.
+        std::vector<unsigned char>().swap(*this);
+    }
 };
 
 /** Compact serializer for scripts.

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -54,12 +54,15 @@ bool CCoinsViewDB::SetBestBlock(const uint256 &hashBlock) {
     return db.WriteBatch(batch);
 }
 
-bool CCoinsViewDB::BatchWrite(const CCoinsMap &mapCoins, const uint256 &hashBlock) {
+bool CCoinsViewDB::BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock) {
     LogPrint("coindb", "Committing %u changed transactions to coin database...\n", (unsigned int)mapCoins.size());
 
     CLevelDBBatch batch;
-    for (CCoinsMap::const_iterator it = mapCoins.begin(); it != mapCoins.end(); it++)
+    for (CCoinsMap::iterator it = mapCoins.begin(); it != mapCoins.end();) {
         BatchWriteCoins(batch, it->first, it->second);
+        CCoinsMap::iterator itOld = it++;
+        mapCoins.erase(itOld);
+    }
     if (hashBlock != uint256(0))
         BatchWriteHashBestChain(batch, hashBlock);
 

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -37,7 +37,7 @@ public:
     bool HaveCoins(const uint256 &txid);
     uint256 GetBestBlock();
     bool SetBestBlock(const uint256 &hashBlock);
-    bool BatchWrite(const CCoinsMap &mapCoins, const uint256 &hashBlock);
+    bool BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock);
     bool GetStats(CCoinsStats &stats);
 };
 


### PR DESCRIPTION
- Make CScript::clear() release memory (indirectly causing transaction outputs being
  spent to release associated heap memory).
- Make CCoinsView::BatchWrite consume the passed CCoinsMap, rather than copy from it.
  - As a result, CCoinsViewDb now progressively converts the map to LevelDB entries,
    rather than copying.
  - Merging a CCoinsViewCache into a parent cache uses CCoins::swap + release rather
    than copy + bulk release at the end.

Untested, but should reduce peak memory usage and some CPU time.
