### PR TITLE
CCoinsViewCache: separate read and write caches

### DIFF
--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -99,7 +99,13 @@ CCoinsMap::iterator CCoinsViewCache::FetchCoins(const uint256 &txid) {
     return ret;
 }
 
-CCoins &CCoinsViewCache::GetCoins(const uint256 &txid) {
+const CCoins &CCoinsViewCache::GetCoins(const uint256 &txid) {
+    CCoinsMap::const_iterator it = FetchCoins(txid);
+    assert(it != cacheCoins.end());
+    return it->second;
+}
+
+CCoins &CCoinsViewCache::ModifyCoins(const uint256 &txid) {
     CCoinsMap::iterator it = FetchCoins(txid);
     assert(it != cacheCoins.end());
     return it->second;

--- a/src/coins.h
+++ b/src/coins.h
@@ -342,7 +342,8 @@ public:
     // Return a modifiable reference to a CCoins. Check HaveCoins first.
     // Many methods explicitly require a CCoinsViewCache because of this method, to reduce
     // copying.
-    CCoins &GetCoins(const uint256 &txid);
+    CCoins &ModifyCoins(const uint256 &txid);
+    const CCoins &GetCoins(const uint256 &txid);
 
     // Push the modifications applied to this cache to its base.
     // Failure to call this method before destruction will cause the changes to be forgotten.

--- a/src/coins.h
+++ b/src/coins.h
@@ -326,10 +326,13 @@ class CCoinsViewCache : public CCoinsViewBacked
 {
 protected:
     uint256 hashBlock;
-    CCoinsMap cacheCoins;
+    // Invariant: an entry should be in either the read cache or the write cache, or neither
+    CCoinsMap cacheRead;
+    CCoinsMap cacheWrite;
 
 public:
     CCoinsViewCache(CCoinsView &baseIn, bool fDummy = false);
+    ~CCoinsViewCache();
 
     // Standard CCoinsView methods
     bool GetCoins(const uint256 &txid, CCoins &coins);
@@ -370,7 +373,7 @@ public:
     const CTxOut &GetOutputFor(const CTxIn& input);
 
 private:
-    CCoinsMap::iterator FetchCoins(const uint256 &txid);
+    bool FetchCoins(const uint256 &txid, CCoinsMap::const_iterator &it);
 };
 
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1435,7 +1435,7 @@ void UpdateCoins(const CTransaction& tx, CValidationState &state, CCoinsViewCach
     // mark inputs spent
     if (!tx.IsCoinBase()) {
         BOOST_FOREACH(const CTxIn &txin, tx.vin) {
-            CCoins &coins = inputs.GetCoins(txin.prevout.hash);
+            CCoins &coins = inputs.ModifyCoins(txin.prevout.hash);
             CTxInUndo undo;
             ret = coins.Spend(txin.prevout, undo);
             assert(ret);
@@ -1590,7 +1590,7 @@ bool DisconnectBlock(CBlock& block, CValidationState& state, CBlockIndex* pindex
         // have outputs available even in the block itself, so we handle that case
         // specially with outsEmpty.
         CCoins outsEmpty;
-        CCoins &outs = view.HaveCoins(hash) ? view.GetCoins(hash) : outsEmpty;
+        CCoins &outs = view.HaveCoins(hash) ? view.ModifyCoins(hash) : outsEmpty;
         outs.ClearUnspendable();
 
         CCoins outsBlock = CCoins(tx, pindex->nHeight);

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -498,7 +498,7 @@ void CTxMemPool::check(CCoinsViewCache *pcoins) const
                 const CTransaction& tx2 = it2->second.GetTx();
                 assert(tx2.vout.size() > txin.prevout.n && !tx2.vout[txin.prevout.n].IsNull());
             } else {
-                CCoins &coins = pcoins->GetCoins(txin.prevout.hash);
+                const CCoins &coins = pcoins->GetCoins(txin.prevout.hash);
                 assert(coins.IsAvailable(txin.prevout.n));
             }
             // Check whether its inputs are marked in mapNextTx.


### PR DESCRIPTION
Keep track of entries that are read-only or r/w in separate caches. This is an optimization that avoids writing back all accessed entries back to the database on a flush.

Also makes the way clear for future optimizations such as putting a fixed limit on the size of the read cache, by using a different data structure for the read and write cache.

I've tested this with a full reindex on testnet and mainnet, as well as checkblocks. I wonder how it will fare under the pulltester.
