### PR TITLE
Add new command line option '-maxoutbound'

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -70,6 +70,7 @@ enum BindFlags {
 
 static const char* FEE_ESTIMATES_FILENAME="fee_estimates.dat";
 CClientUIInterface uiInterface;
+const int OUTBOUND_CONNECTIONS_UPPER_LIMIT = 8;
 
 //////////////////////////////////////////////////////////////////////////////
 //
@@ -261,6 +262,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += "  -forcednsseed          " + strprintf(_("Always query for peer addresses via DNS lookup (default: %u)"), 0) + "\n";
     strUsage += "  -listen                " + _("Accept connections from outside (default: 1 if no -proxy or -connect)") + "\n";
     strUsage += "  -maxconnections=<n>    " + strprintf(_("Maintain at most <n> connections to peers (default: %u)"), 125) + "\n";
+    strUsage += "  -maxoutbound=<n>       " + strprintf(_("Establish at most <n> _outbound_ connections to peers (default: %u)"),8) + "\n";
     strUsage += "  -maxreceivebuffer=<n>  " + strprintf(_("Maximum per-connection receive buffer, <n>*1000 bytes (default: %u)"), 5000) + "\n";
     strUsage += "  -maxsendbuffer=<n>     " + strprintf(_("Maximum per-connection send buffer, <n>*1000 bytes (default: %u)"), 1000) + "\n";
     strUsage += "  -onion=<ip:port>       " + strprintf(_("Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: %s)"), "-proxy") + "\n";
@@ -615,6 +617,17 @@ bool AppInit2(boost::thread_group& threadGroup)
         return InitError(_("Not enough file descriptors available."));
     if (nFD - MIN_CORE_FILEDESCRIPTORS < nMaxConnections)
         nMaxConnections = nFD - MIN_CORE_FILEDESCRIPTORS;
+
+    // Change the default number of outbound connections.  Setting it to more
+    // than 8 is a bad idea. The number of peers that are able to accept
+    // incoming connections is about 8,000 ('servers'). The number of peers that
+    // are behind NAT is about 100,000. If every NATed peer has 8 outgoing
+    // connections then each server will have 100+8 connections in average.
+    // This is close to maximum of 125. Increasing '-maxoutbound' to e.g. 10 at
+    // each client will result in that Bitcoin users will have problems
+    // connecting to the Bitcoin network.
+    nMaxOutboundConnections = GetArg("-maxoutbound", 8);
+    nMaxOutboundConnections = std::max(std::min(OUTBOUND_CONNECTIONS_UPPER_LIMIT,std::min(nMaxOutboundConnections, nMaxConnections)),0);
 
     // ********************************************************* Step 3: parameter-to-internal-flags
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -53,7 +53,6 @@ using namespace boost;
 using namespace std;
 
 namespace {
-    const int MAX_OUTBOUND_CONNECTIONS = 8;
 
     struct ListenSocket {
         SOCKET socket;
@@ -78,6 +77,7 @@ uint64_t nLocalHostNonce = 0;
 static std::vector<ListenSocket> vhListenSocket;
 CAddrMan addrman;
 int nMaxConnections = 125;
+int nMaxOutboundConnections = 8;
 bool fAddressesInitialized = false;
 
 vector<CNode*> vNodes;
@@ -860,7 +860,7 @@ void ThreadSocketHandler()
                     if (nErr != WSAEWOULDBLOCK)
                         LogPrintf("socket error accept failed: %s\n", NetworkErrorString(nErr));
                 }
-                else if (nInbound >= nMaxConnections - MAX_OUTBOUND_CONNECTIONS)
+                else if (nInbound >= nMaxConnections - nMaxOutboundConnections)
                 {
                     CloseSocket(hSocket);
                 }
@@ -1619,7 +1619,7 @@ void StartNode(boost::thread_group& threadGroup)
 
     if (semOutbound == NULL) {
         // initialize semaphore
-        int nMaxOutbound = min(MAX_OUTBOUND_CONNECTIONS, nMaxConnections);
+        int nMaxOutbound = min(nMaxOutboundConnections, nMaxConnections);
         semOutbound = new CSemaphore(nMaxOutbound);
     }
 
@@ -1661,7 +1661,7 @@ bool StopNode()
     LogPrintf("StopNode()\n");
     MapPort(false);
     if (semOutbound)
-        for (int i=0; i<MAX_OUTBOUND_CONNECTIONS; i++)
+        for (int i=0; i<nMaxOutboundConnections; i++)
             semOutbound->post();
 
     if (fAddressesInitialized)

--- a/src/net.h
+++ b/src/net.h
@@ -122,6 +122,7 @@ extern uint64_t nLocalServices;
 extern uint64_t nLocalHostNonce;
 extern CAddrMan addrman;
 extern int nMaxConnections;
+extern int nMaxOutboundConnections;
 
 extern std::vector<CNode*> vNodes;
 extern CCriticalSection cs_vNodes;


### PR DESCRIPTION
While there is a command line option to limit the total number of
connections ('-maxconnections'), the number of outbound connections is
controlled by a hard-coded constant 'MAX_OUTBOUND_CONNECTIONS=8'.
This number (8) of connections has a bad impact on user's privacy. Let's
keep the default number of outbound connections (of 8) but allow a user
to have more privacy by reducing this number (to 3 or 4) using
'-maxoutbound'.

Explanation: transactions that are first relayed by these 8 entry nodes
most probably belong to the same user. In fact, even a subset of these 8
entry nodes can uniquely identify a user. There is a cheap way for an
attacker to learn this set of entry nodes and the user's public IP and
use it to deanonymize the user (note that users by default advertise
their public IP addresses even when behind NAT).  If the user has 3-4
outbound connection the success rate of the attack becomes quite low.
Some details are here: https://www.cryptolux.org/index.php/Bitcoin
