### PR TITLE
Improvement to the Test Framework in the processing of test blocks

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -38,6 +38,7 @@ BITCOIN_TESTS =\
   test/key_tests.cpp \
   test/main_tests.cpp \
   test/miner_tests.cpp \
+  test/blockv2_tests.cpp \
   test/mruset_tests.cpp \
   test/multisig_tests.cpp \
   test/netbase_tests.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -21,6 +21,7 @@ GENERATED_TEST_FILES = $(JSON_TEST_FILES:.json=.json.h) $(RAW_TEST_FILES:.raw=.r
 
 BITCOIN_TESTS =\
   test/bignum.h \
+  test/test_bitcoin.h \
   test/alert_tests.cpp \
   test/allocator_tests.cpp \
   test/base32_tests.cpp \

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -41,6 +41,7 @@ void CDBEnv::EnvShutdown()
 
     fDbEnvInit = false;
     int ret = pdbenv->close(0);
+	delete pdbenv;
 	pdbenv = NULL;
     if (ret != 0)
         LogPrintf("CDBEnv::EnvShutdown : Error %d shutting down database environment: %s\n", ret, DbEnv::strerror(ret));

--- a/src/db.h
+++ b/src/db.h
@@ -38,7 +38,7 @@ private:
 
 public:
     mutable CCriticalSection cs_db;
-    DbEnv dbenv;
+    DbEnv * pdbenv;
     std::map<std::string, int> mapFileUseCount;
     std::map<std::string, Db*> mapDb;
 
@@ -76,7 +76,7 @@ public:
     DbTxn *TxnBegin(int flags=DB_TXN_WRITE_NOSYNC)
     {
         DbTxn* ptxn = NULL;
-        int ret = dbenv.txn_begin(NULL, &ptxn, flags);
+        int ret = pdbenv->txn_begin(NULL, &ptxn, flags);
         if (!ptxn || ret != 0)
             return NULL;
         return ptxn;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -49,6 +49,7 @@ bool fBenchmark = false;
 bool fTxIndex = false;
 bool fIsBareMultisigStd = true;
 unsigned int nCoinCacheSize = 5000;
+bool supressCheckBlockWork = false; // To allow fast dynamic block-checking test cases
 
 /** Fees smaller than this (in satoshi) are considered zero fee (for relaying and mining) */
 CFeeRate minRelayTxFee = CFeeRate(1000);
@@ -2407,6 +2408,7 @@ bool AcceptBlockHeader(CBlockHeader& block, CValidationState& state, CBlockIndex
         nHeight = pindexPrev->nHeight+1;
 
         // Check proof of work
+		if (!supressCheckBlockWork)
         if (block.nBits != GetNextWorkRequired(pindexPrev, &block))
             return state.DoS(100, error("AcceptBlock() : incorrect proof of work"),
                              REJECT_INVALID, "bad-diffbits");
@@ -3067,6 +3069,12 @@ bool LoadBlockIndex()
     return true;
 }
 
+void ResetBlockIndex()
+{
+	 nLastBlockFile = 0;
+	 infoLastBlockFile.SetNull();
+	 nBlockSequenceId = 1;
+}
 
 bool InitBlockIndex() {
     LOCK(cs_main);

--- a/src/main.h
+++ b/src/main.h
@@ -97,6 +97,7 @@ extern bool fTxIndex;
 extern bool fIsBareMultisigStd;
 extern unsigned int nCoinCacheSize;
 extern CFeeRate minRelayTxFee;
+extern bool supressCheckBlockWork;
 
 // Minimum disk space required - used in CheckDiskSpace()
 static const uint64_t nMinDiskSpace = 52428800;

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -79,6 +79,10 @@ bool CheckProofOfWork(uint256 hash, unsigned int nBits)
     bool fNegative;
     bool fOverflow;
     uint256 bnTarget;
+	
+	if (supressCheckBlockWork)
+		return true;
+		
     bnTarget.SetCompact(nBits, &fNegative, &fOverflow);
 
     // Check range

--- a/src/test/blockv2_tests.cpp
+++ b/src/test/blockv2_tests.cpp
@@ -1,0 +1,206 @@
+// Copyright (c) 2011-2014 The Bitcoin Core developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "main.h"
+#include "miner.h"
+#include "uint256.h"
+#include "util.h"
+#include "test_bitcoin.h"
+
+#include <boost/test/unit_test.hpp>
+
+// Tests the majority rule which states that after 1000 v2 blocks no v1 block can go
+BOOST_AUTO_TEST_SUITE(blockv2_tests)
+
+static void SetEmptyBlock(CBlock * pblock)
+{
+        pblock->nVersion = 2;
+        pblock->nTime = chainActive.Tip()->GetMedianTimePast()+1;
+		pblock->nNonce = 0;
+}
+		
+static void SetBlockDefaultAttributesAndHeight(CBlock * pblock,bool addHeight,int difValue)
+{
+		SetEmptyBlock(pblock);
+
+		// Add the coinbase
+        CMutableTransaction txCoinbase(pblock->vtx[0]);
+		
+		if (addHeight) 
+			txCoinbase.vin[0].scriptSig = (CScript() << (chainActive.Height()+1+difValue) << 0);
+			else
+			txCoinbase.vin[0].scriptSig = (CScript() << 0 << 0); // At least size 2, this is a protocol spec
+			
+        txCoinbase.vout[0].scriptPubKey = CScript();
+        pblock->vtx[0] = CTransaction(txCoinbase);
+        pblock->hashMerkleRoot = pblock->BuildMerkleTree();
+}
+
+void breakp()
+{
+	LogPrintf("Blockv2test breakp\n");	
+}
+
+void Blockv2test()
+{
+	assert(Params().NetworkID() == CBaseChainParams::MAIN);	
+	
+	
+	// if you want to debug the test case, uncomment this line, keep the evidence (the blockchain, including debug.log)
+	// testingSetupManager.keepTestEvidence = true;
+	
+	testingSetupManager.SetupGenesisBlockChain();	
+	LogPrintf("Blockv2test testcase starts\n");	
+	
+	CScript scriptPubKey = CScript() << ParseHex("04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5f") << OP_CHECKSIG;
+    CBlockTemplate *pblocktemplate;
+    CScript script;
+    uint256 hash;
+
+	
+    LOCK(cs_main);
+	
+	// Disable checking PoW so we can freely create blocks without effort here
+	supressCheckBlockWork = true;
+	
+    // Simple block creation, nothing special yet.
+    pblocktemplate = CreateNewBlock(scriptPubKey);   
+    CBlock *pblock = &pblocktemplate->block; // pointer for convenience
+   
+    LogPrintf("Blockv2test block v1 add begin\n");	
+    // First create a block v1, check that it is accepted
+	SetBlockDefaultAttributesAndHeight(pblock,false,0);
+	pblock->nVersion = 1;
+	CValidationState state1;
+	BOOST_CHECK(ProcessBlock(state1, NULL, pblock));
+    BOOST_CHECK(state1.IsValid());
+	pblock->hashPrevBlock = pblock->GetHash(); // update parent
+	
+	
+	// Now create exactly 1000 blocks v2
+	
+	// First check that the supermajority threshold is exactly 1000 blocks
+	BOOST_CHECK(Params().ToCheckBlockUpgradeMajority()==1000);  // 
+	BOOST_CHECK(Params().EnforceBlockUpgradeMajority()==750);
+	BOOST_CHECK(Params().RejectBlockOutdatedMajority()==950);
+	
+	// Over the last 1000 blocks, 750 blocks must be v2 to switch to v2-only mode.
+	// Here we're testing only the last 750, not any subset.
+    
+	LogPrintf("Blockv2test BIP30 repetition begin\n");	
+	// First, if we try to add a block v2 without heigh, we should get
+	// "bad-txns-BIP30" because the coinbase tx has the same hash as the previous.
+	// Unluckily, even if ConnectBlock returns a "bad-txns-BIP30", ActivateBestChainStep clears
+	// the state, so we get true here and the "bad-txns-BIP30" reason is lost.
+	// We verify instead that the chain heigh has not been incremented.
+	
+	CValidationState state7;
+	int PreviousHeght = chainActive.Height();
+	SetBlockDefaultAttributesAndHeight(pblock,false,0); //
+	pblock->nVersion = 2;
+	BOOST_CHECK(ProcessBlock(state7, NULL, pblock)); // should we care about the return value?
+	BOOST_CHECK(state7.IsValid());
+	BOOST_CHECK(PreviousHeght == chainActive.Height()); // we check the block has not been added.
+	
+	LogPrintf("Blockv2test 750 v2 blocks  begin\n");	
+	for (int i=0;i<750;i++) 
+    {
+		
+		LogPrintf("Blockv2test block %d begin\n",i);	
+		
+		// We add a value to the height to make is NOT equal to the actual height.
+		SetBlockDefaultAttributesAndHeight(pblock,true,1000); // blocks version 2 without height are allowed! for only 750 blocks
+		pblock->nVersion = 2;
+        CValidationState state;
+					
+        BOOST_CHECK(ProcessBlock(state, NULL, pblock));
+        BOOST_CHECK(state.IsValid());
+        pblock->hashPrevBlock = pblock->GetHash(); // update parent
+    }
+
+	LogPrintf("Blockv2test v2 without heigh rejected begin\n");	
+	
+	// Now we try to add a block v2, with an invalid height and it should be rejected. We use 2000 because is not in the range [1000..1750].
+	SetBlockDefaultAttributesAndHeight(pblock,true,2000); // 
+	pblock->nVersion = 2;
+    CValidationState state0;
+	BOOST_CHECK(ProcessBlock(state0, NULL, pblock)==false);
+	BOOST_CHECK(!state0.IsValid());
+	BOOST_CHECK(state0.GetRejectReason()=="bad-cb-height");	
+	// Do not update parent since block has failed
+	
+	LogPrintf("Blockv2test v2 with heigh accepted begin\n");	
+	
+	
+	// Now we add a block with height, must be ok.
+	for (int i=0;i<200;i++) 
+    {
+		
+		LogPrintf("Blockv2test v2block %d begin\n",i);		
+		SetBlockDefaultAttributesAndHeight(pblock,true,0);
+		pblock->nVersion = 2;
+        CValidationState state;
+        BOOST_CHECK(ProcessBlock(state, NULL, pblock));
+        BOOST_CHECK(state.IsValid());
+        pblock->hashPrevBlock = pblock->GetHash(); // update parent
+    }
+
+	breakp();
+	
+	LogPrintf("Blockv2test block v1 rejected\n");	
+	// Now we add 200 additional blocks, until we get 950 (the threshold were v1 blocks are not accepted anymore)
+	// Now we try to add a block v1, it should be rejected, even if it hash the height field
+	SetBlockDefaultAttributesAndHeight(pblock,true,0);
+	pblock->nVersion = 1;
+	CValidationState state2;
+	BOOST_CHECK(ProcessBlock(state2, NULL, pblock)==false);
+	BOOST_CHECK(!state2.IsValid());
+	BOOST_CHECK(state2.GetRejectReason()=="bad-version");
+	// Do not update parent since block has failed
+	
+	
+	
+	// Some other missing tests, added here as bonus...
+	
+	// Block time too old check
+	SetBlockDefaultAttributesAndHeight(pblock,true,0);
+	pblock->nVersion = 2;
+	pblock->nTime = chainActive.Tip()->GetMedianTimePast()-1;
+	CValidationState state4;
+	BOOST_CHECK(ProcessBlock(state4, NULL, pblock)==false);
+	BOOST_CHECK(!state4.IsValid());
+	BOOST_CHECK(state4.GetRejectReason()=="time-too-old");
+	// Do not update parent since block has failed
+	
+	// Adding a non-final coinbase, must modify coinbase
+	SetEmptyBlock(pblock);
+	// Use a mutable coinbase to change nLockTime and  nSequence
+	CMutableTransaction txCoinbase(pblock->vtx[0]);
+	txCoinbase.vin[0].scriptSig = (CScript() << chainActive.Height() << 0);	
+	txCoinbase.nLockTime = LOCKTIME_THRESHOLD-1; // refers to heigh
+	txCoinbase.vin[0].nSequence = 1; // non-zero sequence
+	pblock->vtx[0] = CTransaction(txCoinbase);
+	pblock->nVersion = 2;
+	pblock->hashMerkleRoot = pblock->BuildMerkleTree();
+	CValidationState state5;
+	BOOST_CHECK(ProcessBlock(state5, NULL, pblock)==false);
+	BOOST_CHECK(!state5.IsValid());
+	BOOST_CHECK(state5.GetRejectReason()=="bad-txns-nonfinal");
+	// Do not update parent since block has failed
+	
+	// Re-enable checking PoW for other tests
+	supressCheckBlockWork = false;
+	
+    delete pblocktemplate;
+	
+	
+	LogPrintf("Blockv2test testcase ends\n");	
+}
+
+BOOST_AUTO_TEST_CASE(Blockv2testcase)
+{
+	Blockv2test();
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/blockv2_tests.cpp
+++ b/src/test/blockv2_tests.cpp
@@ -17,190 +17,186 @@ static void SetEmptyBlock(CBlock * pblock)
 {
         pblock->nVersion = 2;
         pblock->nTime = chainActive.Tip()->GetMedianTimePast()+1;
-		pblock->nNonce = 0;
+        pblock->nNonce = 0;
 }
-		
+        
 static void SetBlockDefaultAttributesAndHeight(CBlock * pblock,bool addHeight,int difValue)
 {
-		SetEmptyBlock(pblock);
+        SetEmptyBlock(pblock);
 
-		// Add the coinbase
+        // Add the coinbase
         CMutableTransaction txCoinbase(pblock->vtx[0]);
-		
-		if (addHeight) 
-			txCoinbase.vin[0].scriptSig = (CScript() << (chainActive.Height()+1+difValue) << 0);
-			else
-			txCoinbase.vin[0].scriptSig = (CScript() << 0 << 0); // At least size 2, this is a protocol spec
-			
+        
+        if (addHeight) 
+            txCoinbase.vin[0].scriptSig = (CScript() << (chainActive.Height()+1+difValue) << 0);
+            else
+            txCoinbase.vin[0].scriptSig = (CScript() << 0 << 0); // At least size 2, this is a protocol spec
+            
         txCoinbase.vout[0].scriptPubKey = CScript();
         pblock->vtx[0] = CTransaction(txCoinbase);
         pblock->hashMerkleRoot = pblock->BuildMerkleTree();
 }
 
-void breakp()
-{
-	LogPrintf("Blockv2test breakp\n");	
-}
+
 
 void Blockv2test()
 {
-	assert(Params().NetworkID() == CBaseChainParams::MAIN);	
-	
-	
-	// if you want to debug the test case, uncomment this line, keep the evidence (the blockchain, including debug.log)
-	// testingSetupManager.keepTestEvidence = true;
-	
-	testingSetupManager.SetupGenesisBlockChain();	
-	LogPrintf("Blockv2test testcase starts\n");	
-	
-	CScript scriptPubKey = CScript() << ParseHex("04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5f") << OP_CHECKSIG;
+    assert(Params().NetworkID() == CBaseChainParams::MAIN); 
+    
+    
+    // if you want to debug the test case, uncomment this line, keep the evidence (the blockchain, including debug.log)
+    // testingSetupManager.keepTestEvidence = true;
+    
+    testingSetupManager.SetupGenesisBlockChain();   
+    LogPrintf("Blockv2test testcase starts\n"); 
+    
+    CScript scriptPubKey = CScript() << ParseHex("04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5f") << OP_CHECKSIG;
     CBlockTemplate *pblocktemplate;
     CScript script;
     uint256 hash;
 
-	
+    
     LOCK(cs_main);
-	
-	// Disable checking PoW so we can freely create blocks without effort here
-	supressCheckBlockWork = true;
-	
+    
+    // Disable checking PoW so we can freely create blocks without effort here
+    supressCheckBlockWork = true;
+    
     // Simple block creation, nothing special yet.
     pblocktemplate = CreateNewBlock(scriptPubKey);   
     CBlock *pblock = &pblocktemplate->block; // pointer for convenience
    
-    LogPrintf("Blockv2test block v1 add begin\n");	
+    LogPrintf("Blockv2test block v1 add begin\n");  
     // First create a block v1, check that it is accepted
-	SetBlockDefaultAttributesAndHeight(pblock,false,0);
-	pblock->nVersion = 1;
-	CValidationState state1;
-	BOOST_CHECK(ProcessBlock(state1, NULL, pblock));
+    SetBlockDefaultAttributesAndHeight(pblock,false,0);
+    pblock->nVersion = 1;
+    CValidationState state1;
+    BOOST_CHECK(ProcessBlock(state1, NULL, pblock));
     BOOST_CHECK(state1.IsValid());
-	pblock->hashPrevBlock = pblock->GetHash(); // update parent
-	
-	
-	// Now create exactly 1000 blocks v2
-	
-	// First check that the supermajority threshold is exactly 1000 blocks
-	BOOST_CHECK(Params().ToCheckBlockUpgradeMajority()==1000);  // 
-	BOOST_CHECK(Params().EnforceBlockUpgradeMajority()==750);
-	BOOST_CHECK(Params().RejectBlockOutdatedMajority()==950);
-	
-	// Over the last 1000 blocks, 750 blocks must be v2 to switch to v2-only mode.
-	// Here we're testing only the last 750, not any subset.
+    pblock->hashPrevBlock = pblock->GetHash(); // update parent
     
-	LogPrintf("Blockv2test BIP30 repetition begin\n");	
-	// First, if we try to add a block v2 without heigh, we should get
-	// "bad-txns-BIP30" because the coinbase tx has the same hash as the previous.
-	// Unluckily, even if ConnectBlock returns a "bad-txns-BIP30", ActivateBestChainStep clears
-	// the state, so we get true here and the "bad-txns-BIP30" reason is lost.
-	// We verify instead that the chain heigh has not been incremented.
-	
-	CValidationState state7;
-	int PreviousHeght = chainActive.Height();
-	SetBlockDefaultAttributesAndHeight(pblock,false,0); //
-	pblock->nVersion = 2;
-	BOOST_CHECK(ProcessBlock(state7, NULL, pblock)); // should we care about the return value?
-	BOOST_CHECK(state7.IsValid());
-	BOOST_CHECK(PreviousHeght == chainActive.Height()); // we check the block has not been added.
-	
-	LogPrintf("Blockv2test 750 v2 blocks  begin\n");	
-	for (int i=0;i<750;i++) 
+    
+    // Now create exactly 1000 blocks v2
+    
+    // First check that the supermajority threshold is exactly 1000 blocks
+    BOOST_CHECK(Params().ToCheckBlockUpgradeMajority()==1000);  // 
+    BOOST_CHECK(Params().EnforceBlockUpgradeMajority()==750);
+    BOOST_CHECK(Params().RejectBlockOutdatedMajority()==950);
+    
+    // Over the last 1000 blocks, 750 blocks must be v2 to switch to v2-only mode.
+    // Here we're testing only the last 750, not any subset.
+    
+    LogPrintf("Blockv2test BIP30 repetition begin\n");  
+    // First, if we try to add a block v2 without heigh, we should get
+    // "bad-txns-BIP30" because the coinbase tx has the same hash as the previous.
+    // Unluckily, even if ConnectBlock returns a "bad-txns-BIP30", ActivateBestChainStep clears
+    // the state, so we get true here and the "bad-txns-BIP30" reason is lost.
+    // We verify instead that the chain heigh has not been incremented.
+    
+    CValidationState state7;
+    int PreviousHeght = chainActive.Height();
+    SetBlockDefaultAttributesAndHeight(pblock,false,0); //
+    pblock->nVersion = 2;
+    BOOST_CHECK(ProcessBlock(state7, NULL, pblock)); // should we care about the return value?
+    BOOST_CHECK(state7.IsValid());
+    BOOST_CHECK(PreviousHeght == chainActive.Height()); // we check the block has not been added.
+    
+    LogPrintf("Blockv2test 750 v2 blocks  begin\n");    
+    for (int i=0;i<750;i++) 
     {
-		
-		LogPrintf("Blockv2test block %d begin\n",i);	
-		
-		// We add a value to the height to make is NOT equal to the actual height.
-		SetBlockDefaultAttributesAndHeight(pblock,true,1000); // blocks version 2 without height are allowed! for only 750 blocks
-		pblock->nVersion = 2;
+        
+        LogPrintf("Blockv2test block %d begin\n",i);    
+        
+        // We add a value to the height to make is NOT equal to the actual height.
+        SetBlockDefaultAttributesAndHeight(pblock,true,1000); // blocks version 2 without height are allowed! for only 750 blocks
+        pblock->nVersion = 2;
         CValidationState state;
-					
+                    
         BOOST_CHECK(ProcessBlock(state, NULL, pblock));
         BOOST_CHECK(state.IsValid());
         pblock->hashPrevBlock = pblock->GetHash(); // update parent
     }
 
-	LogPrintf("Blockv2test v2 without heigh rejected begin\n");	
-	
-	// Now we try to add a block v2, with an invalid height and it should be rejected. We use 2000 because is not in the range [1000..1750].
-	SetBlockDefaultAttributesAndHeight(pblock,true,2000); // 
-	pblock->nVersion = 2;
+    LogPrintf("Blockv2test v2 without heigh rejected begin\n"); 
+    
+    // Now we try to add a block v2, with an invalid height and it should be rejected. We use 2000 because is not in the range [1000..1750].
+    SetBlockDefaultAttributesAndHeight(pblock,true,2000); // 
+    pblock->nVersion = 2;
     CValidationState state0;
-	BOOST_CHECK(ProcessBlock(state0, NULL, pblock)==false);
-	BOOST_CHECK(!state0.IsValid());
-	BOOST_CHECK(state0.GetRejectReason()=="bad-cb-height");	
-	// Do not update parent since block has failed
-	
-	LogPrintf("Blockv2test v2 with heigh accepted begin\n");	
-	
-	
-	// Now we add a block with height, must be ok.
-	for (int i=0;i<200;i++) 
+    BOOST_CHECK(ProcessBlock(state0, NULL, pblock)==false);
+    BOOST_CHECK(!state0.IsValid());
+    BOOST_CHECK(state0.GetRejectReason()=="bad-cb-height"); 
+    // Do not update parent since block has failed
+    
+    LogPrintf("Blockv2test v2 with heigh accepted begin\n");    
+    
+    
+    // Now we add a block with height, must be ok.
+    for (int i=0;i<200;i++) 
     {
-		
-		LogPrintf("Blockv2test v2block %d begin\n",i);		
-		SetBlockDefaultAttributesAndHeight(pblock,true,0);
-		pblock->nVersion = 2;
+        
+        LogPrintf("Blockv2test v2block %d begin\n",i);      
+        SetBlockDefaultAttributesAndHeight(pblock,true,0);
+        pblock->nVersion = 2;
         CValidationState state;
         BOOST_CHECK(ProcessBlock(state, NULL, pblock));
         BOOST_CHECK(state.IsValid());
         pblock->hashPrevBlock = pblock->GetHash(); // update parent
     }
 
-	breakp();
-	
-	LogPrintf("Blockv2test block v1 rejected\n");	
-	// Now we add 200 additional blocks, until we get 950 (the threshold were v1 blocks are not accepted anymore)
-	// Now we try to add a block v1, it should be rejected, even if it hash the height field
-	SetBlockDefaultAttributesAndHeight(pblock,true,0);
-	pblock->nVersion = 1;
-	CValidationState state2;
-	BOOST_CHECK(ProcessBlock(state2, NULL, pblock)==false);
-	BOOST_CHECK(!state2.IsValid());
-	BOOST_CHECK(state2.GetRejectReason()=="bad-version");
-	// Do not update parent since block has failed
-	
-	
-	
-	// Some other missing tests, added here as bonus...
-	
-	// Block time too old check
-	SetBlockDefaultAttributesAndHeight(pblock,true,0);
-	pblock->nVersion = 2;
-	pblock->nTime = chainActive.Tip()->GetMedianTimePast()-1;
-	CValidationState state4;
-	BOOST_CHECK(ProcessBlock(state4, NULL, pblock)==false);
-	BOOST_CHECK(!state4.IsValid());
-	BOOST_CHECK(state4.GetRejectReason()=="time-too-old");
-	// Do not update parent since block has failed
-	
-	// Adding a non-final coinbase, must modify coinbase
-	SetEmptyBlock(pblock);
-	// Use a mutable coinbase to change nLockTime and  nSequence
-	CMutableTransaction txCoinbase(pblock->vtx[0]);
-	txCoinbase.vin[0].scriptSig = (CScript() << chainActive.Height() << 0);	
-	txCoinbase.nLockTime = LOCKTIME_THRESHOLD-1; // refers to heigh
-	txCoinbase.vin[0].nSequence = 1; // non-zero sequence
-	pblock->vtx[0] = CTransaction(txCoinbase);
-	pblock->nVersion = 2;
-	pblock->hashMerkleRoot = pblock->BuildMerkleTree();
-	CValidationState state5;
-	BOOST_CHECK(ProcessBlock(state5, NULL, pblock)==false);
-	BOOST_CHECK(!state5.IsValid());
-	BOOST_CHECK(state5.GetRejectReason()=="bad-txns-nonfinal");
-	// Do not update parent since block has failed
-	
-	// Re-enable checking PoW for other tests
-	supressCheckBlockWork = false;
-	
+    
+    LogPrintf("Blockv2test block v1 rejected\n");   
+    // Now we add 200 additional blocks, until we get 950 (the threshold were v1 blocks are not accepted anymore)
+    // Now we try to add a block v1, it should be rejected, even if it hash the height field
+    SetBlockDefaultAttributesAndHeight(pblock,true,0);
+    pblock->nVersion = 1;
+    CValidationState state2;
+    BOOST_CHECK(ProcessBlock(state2, NULL, pblock)==false);
+    BOOST_CHECK(!state2.IsValid());
+    BOOST_CHECK(state2.GetRejectReason()=="bad-version");
+    // Do not update parent since block has failed
+    
+    
+    
+    // Some other missing tests, added here as bonus...
+    
+    // Block time too old check
+    SetBlockDefaultAttributesAndHeight(pblock,true,0);
+    pblock->nVersion = 2;
+    pblock->nTime = chainActive.Tip()->GetMedianTimePast()-1;
+    CValidationState state4;
+    BOOST_CHECK(ProcessBlock(state4, NULL, pblock)==false);
+    BOOST_CHECK(!state4.IsValid());
+    BOOST_CHECK(state4.GetRejectReason()=="time-too-old");
+    // Do not update parent since block has failed
+    
+    // Adding a non-final coinbase, must modify coinbase
+    SetEmptyBlock(pblock);
+    // Use a mutable coinbase to change nLockTime and  nSequence
+    CMutableTransaction txCoinbase(pblock->vtx[0]);
+    txCoinbase.vin[0].scriptSig = (CScript() << chainActive.Height() << 0); 
+    txCoinbase.nLockTime = LOCKTIME_THRESHOLD-1; // refers to heigh
+    txCoinbase.vin[0].nSequence = 1; // non-zero sequence
+    pblock->vtx[0] = CTransaction(txCoinbase);
+    pblock->nVersion = 2;
+    pblock->hashMerkleRoot = pblock->BuildMerkleTree();
+    CValidationState state5;
+    BOOST_CHECK(ProcessBlock(state5, NULL, pblock)==false);
+    BOOST_CHECK(!state5.IsValid());
+    BOOST_CHECK(state5.GetRejectReason()=="bad-txns-nonfinal");
+    // Do not update parent since block has failed
+    
+    // Re-enable checking PoW for other tests
+    supressCheckBlockWork = false;
+    
     delete pblocktemplate;
-	
-	
-	LogPrintf("Blockv2test testcase ends\n");	
+    
+    
+    LogPrintf("Blockv2test testcase ends\n");   
 }
 
 BOOST_AUTO_TEST_CASE(Blockv2testcase)
 {
-	Blockv2test();
+    Blockv2test();
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -6,6 +6,7 @@
 #include "miner.h"
 #include "uint256.h"
 #include "util.h"
+#include "test_bitcoin.h"
 
 #include <boost/test/unit_test.hpp>
 
@@ -49,6 +50,9 @@ struct {
 // NOTE: These tests rely on CreateNewBlock doing its own self-validation!
 BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
 {
+	assert(Params().NetworkID() == CBaseChainParams::MAIN);	
+	testingSetupManager.SetupGenesisBlockChain();
+	
     CScript scriptPubKey = CScript() << ParseHex("04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5f") << OP_CHECKSIG;
     CBlockTemplate *pblocktemplate;
     CMutableTransaction tx,tx2;
@@ -253,6 +257,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
 
     chainActive.Tip()->nHeight--;
     SetMockTime(0);
+	mempool.clear();
 
     BOOST_FOREACH(CTransaction *tx, txFirst)
         delete tx;

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -3,19 +3,10 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #define BOOST_TEST_MODULE Bitcoin Test Suite
-
-#include "main.h"
-#include "random.h"
-#include "txdb.h"
-#include "ui_interface.h"
-#include "util.h"
-#ifdef ENABLE_WALLET
-#include "db.h"
-#include "wallet.h"
-#endif
-
-#include <boost/filesystem.hpp>
+#include "test_bitcoin.h"
 #include <boost/test/unit_test.hpp>
+
+TestingSetupManager testingSetupManager;
 
 CClientUIInterface uiInterface;
 CWallet* pwalletMain;
@@ -23,52 +14,106 @@ CWallet* pwalletMain;
 extern bool fPrintToConsole;
 extern void noui_connect();
 
-struct TestingSetup {
-    CCoinsViewDB *pcoinsdbview;
-    boost::filesystem::path pathTemp;
-    boost::thread_group threadGroup;
-
-    TestingSetup() {
-        fPrintToDebugLog = false; // don't want to write to debug.log file
-        SelectParams(CBaseChainParams::MAIN);
-        noui_connect();
-#ifdef ENABLE_WALLET
+bool keepTestEvidence = false;
+    
+	void TestingSetupManager::SetupGenesisBlockChain()
+	{
+		if (chainActive.Tip()->GetBlockHash()!=Params().HashGenesisBlock()) {
+			DestroyBlockChain();
+			CreateBlockChain();
+		}
+	
+	}
+	
+	void TestingSetupManager::CreateBlockChain()
+	{
+	#ifdef ENABLE_WALLET
         bitdb.MakeMock();
-#endif
-        pathTemp = GetTempPath() / strprintf("test_bitcoin_%lu_%i", (unsigned long)GetTime(), (int)(GetRand(100000)));
+	#endif
+		fReopenDebugLog =true; // Important when switching between two test block-chains, to move the debug.log to the new location
+	    pathTemp = GetTempPath() / strprintf("test_bitcoin_%lu_%i", (unsigned long)GetTime(), (int)(GetRand(100000)));
         boost::filesystem::create_directories(pathTemp);
         mapArgs["-datadir"] = pathTemp.string();
         pblocktree = new CBlockTreeDB(1 << 20, true);
         pcoinsdbview = new CCoinsViewDB(1 << 23, true);
         pcoinsTip = new CCoinsViewCache(*pcoinsdbview);
         InitBlockIndex();
-#ifdef ENABLE_WALLET
+		#ifdef ENABLE_WALLET
         bool fFirstRun;
         pwalletMain = new CWallet("wallet.dat");
         pwalletMain->LoadWallet(fFirstRun);
         RegisterWallet(pwalletMain);
-#endif
+		#endif
+	}
+	
+	void ResetBlockIndex();
+	
+	void TestingSetupManager::DestroyBlockChain()
+	{
+		// Clear the mempool so there are no transactions with missing inputs left.
+		mempool.clear();
+		
+	#ifdef ENABLE_WALLET
+	    UnregisterWallet(pwalletMain);
+        delete pwalletMain;
+        pwalletMain = NULL;
+	#endif
+	 
+		UnloadBlockIndex();
+		ResetBlockIndex();
+	
+	#ifdef ENABLE_WALLET
+        bitdb.Flush(true);
+	#endif
+	
+	    delete pcoinsTip;
+        delete pcoinsdbview;
+        delete pblocktree;		
+		ClearDatadirCache();
+		
+		if (!keepTestEvidence)
+			boost::filesystem::remove_all(pathTemp);
+		
+	}
+	
+    void TestingSetupManager::Start() {
+        //fPrintToDebugLog = false; // don't want to write to debug.log file
+        SelectParams(CBaseChainParams::MAIN);
+        noui_connect();
+
+        CreateBlockChain();
+
         nScriptCheckThreads = 3;
         for (int i=0; i < nScriptCheckThreads-1; i++)
             threadGroup.create_thread(&ThreadScriptCheck);
-        RegisterNodeSignals(GetNodeSignals());
+        RegisterNodeSignals(GetNodeSignals());		
     }
-    ~TestingSetup()
+	
+    void TestingSetupManager::Stop()
     {
         threadGroup.interrupt_all();
         threadGroup.join_all();
         UnregisterNodeSignals(GetNodeSignals());
-#ifdef ENABLE_WALLET
-        delete pwalletMain;
-        pwalletMain = NULL;
-#endif
-        delete pcoinsTip;
-        delete pcoinsdbview;
-        delete pblocktree;
-#ifdef ENABLE_WALLET
-        bitdb.Flush(true);
-#endif
-        boost::filesystem::remove_all(pathTemp);
+
+        DestroyBlockChain();
+    }
+	
+	TestingSetupManager::TestingSetupManager() 
+	{
+        keepTestEvidence =false;
+    }
+
+
+struct TestingSetup {
+    
+    TestingSetup() 
+	{
+        testingSetupManager.Start();
+    }
+	
+    ~TestingSetup()
+    {
+        testingSetupManager.Stop();
     }
 };
 

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -16,101 +16,101 @@ extern void noui_connect();
 
 bool keepTestEvidence = false;
     
-	void TestingSetupManager::SetupGenesisBlockChain()
-	{
-		if (chainActive.Tip()->GetBlockHash()!=Params().HashGenesisBlock()) {
-			DestroyBlockChain();
-			CreateBlockChain();
-		}
-	
+void TestingSetupManager::SetupGenesisBlockChain()
+{
+	if (chainActive.Tip()->GetBlockHash()!=Params().HashGenesisBlock()) {
+		DestroyBlockChain();
+		CreateBlockChain();
 	}
-	
-	void TestingSetupManager::CreateBlockChain()
-	{
-	#ifdef ENABLE_WALLET
-        bitdb.MakeMock();
-	#endif
-		fReopenDebugLog =true; // Important when switching between two test block-chains, to move the debug.log to the new location
-	    pathTemp = GetTempPath() / strprintf("test_bitcoin_%lu_%i", (unsigned long)GetTime(), (int)(GetRand(100000)));
-        boost::filesystem::create_directories(pathTemp);
-        mapArgs["-datadir"] = pathTemp.string();
-        pblocktree = new CBlockTreeDB(1 << 20, true);
-        pcoinsdbview = new CCoinsViewDB(1 << 23, true);
-        pcoinsTip = new CCoinsViewCache(*pcoinsdbview);
-        InitBlockIndex();
-		#ifdef ENABLE_WALLET
-        bool fFirstRun;
-        pwalletMain = new CWallet("wallet.dat");
-        pwalletMain->LoadWallet(fFirstRun);
-        RegisterWallet(pwalletMain);
-		#endif
-	}
-	
-	void ResetBlockIndex();
-	
-	void TestingSetupManager::DestroyBlockChain()
-	{
-		// Clear the mempool so there are no transactions with missing inputs left.
-		mempool.clear();
-		
-	#ifdef ENABLE_WALLET
-	    UnregisterWallet(pwalletMain);
-        delete pwalletMain;
-        pwalletMain = NULL;
-	#endif
-	 
-		UnloadBlockIndex();
-		ResetBlockIndex();
-	
-	#ifdef ENABLE_WALLET
-        bitdb.Flush(true);
-	#endif
-	
-	    delete pcoinsTip;
-        delete pcoinsdbview;
-        delete pblocktree;		
-		ClearDatadirCache();
-		
-		if (!keepTestEvidence)
-			boost::filesystem::remove_all(pathTemp);
-		
-	}
-	
-    void TestingSetupManager::Start() {
-        //fPrintToDebugLog = false; // don't want to write to debug.log file
-        SelectParams(CBaseChainParams::MAIN);
-        noui_connect();
 
-        CreateBlockChain();
+}
 
-        nScriptCheckThreads = 3;
-        for (int i=0; i < nScriptCheckThreads-1; i++)
-            threadGroup.create_thread(&ThreadScriptCheck);
-        RegisterNodeSignals(GetNodeSignals());		
-    }
-	
-    void TestingSetupManager::Stop()
-    {
-        threadGroup.interrupt_all();
-        threadGroup.join_all();
-        UnregisterNodeSignals(GetNodeSignals());
+void TestingSetupManager::CreateBlockChain()
+{
+#ifdef ENABLE_WALLET
+	bitdb.MakeMock();
+#endif
+	fReopenDebugLog =true; // Important when switching between two test block-chains, to move the debug.log to the new location
+	pathTemp = GetTempPath() / strprintf("test_bitcoin_%lu_%i", (unsigned long)GetTime(), (int)(GetRand(100000)));
+	boost::filesystem::create_directories(pathTemp);
+	mapArgs["-datadir"] = pathTemp.string();
+	pblocktree = new CBlockTreeDB(1 << 20, true);
+	pcoinsdbview = new CCoinsViewDB(1 << 23, true);
+	pcoinsTip = new CCoinsViewCache(*pcoinsdbview);
+	InitBlockIndex();
+	#ifdef ENABLE_WALLET
+	bool fFirstRun;
+	pwalletMain = new CWallet("wallet.dat");
+	pwalletMain->LoadWallet(fFirstRun);
+	RegisterWallet(pwalletMain);
+	#endif
+}
 
-        DestroyBlockChain();
-    }
+void ResetBlockIndex();
+
+void TestingSetupManager::DestroyBlockChain()
+{
+	// Clear the mempool so there are no transactions with missing inputs left.
+	mempool.clear();
 	
-	TestingSetupManager::TestingSetupManager() 
-	{
-        keepTestEvidence =false;
-    }
+#ifdef ENABLE_WALLET
+	UnregisterWallet(pwalletMain);
+	delete pwalletMain;
+	pwalletMain = NULL;
+#endif
+ 
+	UnloadBlockIndex();
+	ResetBlockIndex();
+
+#ifdef ENABLE_WALLET
+	bitdb.Flush(true);
+#endif
+
+	delete pcoinsTip;
+	delete pcoinsdbview;
+	delete pblocktree;      
+	ClearDatadirCache();
+	
+	if (!keepTestEvidence)
+		boost::filesystem::remove_all(pathTemp);
+	
+}
+
+void TestingSetupManager::Start() {
+	//fPrintToDebugLog = false; // don't want to write to debug.log file
+	SelectParams(CBaseChainParams::MAIN);
+	noui_connect();
+
+	CreateBlockChain();
+
+	nScriptCheckThreads = 3;
+	for (int i=0; i < nScriptCheckThreads-1; i++)
+		threadGroup.create_thread(&ThreadScriptCheck);
+	RegisterNodeSignals(GetNodeSignals());      
+}
+
+void TestingSetupManager::Stop()
+{
+	threadGroup.interrupt_all();
+	threadGroup.join_all();
+	UnregisterNodeSignals(GetNodeSignals());
+
+	DestroyBlockChain();
+}
+
+TestingSetupManager::TestingSetupManager() 
+{
+	keepTestEvidence =false;
+}
 
 
 struct TestingSetup {
     
     TestingSetup() 
-	{
+    {
         testingSetupManager.Start();
     }
-	
+    
     ~TestingSetup()
     {
         testingSetupManager.Stop();

--- a/src/test/test_bitcoin.h
+++ b/src/test/test_bitcoin.h
@@ -1,0 +1,29 @@
+
+
+#include "main.h"
+#include "random.h"
+#include "txdb.h"
+#include "ui_interface.h"
+#include "util.h"
+#ifdef ENABLE_WALLET
+#include "db.h"
+#include "wallet.h"
+#endif
+
+#include <boost/filesystem.hpp>
+
+struct TestingSetupManager {
+	CCoinsViewDB *pcoinsdbview;
+    boost::filesystem::path pathTemp;
+    boost::thread_group threadGroup;
+	bool keepTestEvidence;
+	
+	TestingSetupManager();
+	void CreateBlockChain();
+	void DestroyBlockChain();
+	void SetupGenesisBlockChain();
+	void Start();
+	void Stop();
+};
+	
+extern TestingSetupManager testingSetupManager;

--- a/src/util.h
+++ b/src/util.h
@@ -188,6 +188,7 @@ void SetMockTime(int64_t nMockTimeIn);
 std::string FormatFullVersion();
 std::string FormatSubVersion(const std::string& name, int nClientVersion, const std::vector<std::string>& comments);
 void runCommand(std::string strCommand);
+void ClearDatadirCache();
 
 inline std::string i64tostr(int64_t n)
 {

--- a/src/walletdb.cpp
+++ b/src/walletdb.cpp
@@ -900,7 +900,7 @@ bool CWalletDB::Recover(CDBEnv& dbenv, std::string filename, bool fOnlyKeys)
     int64_t now = GetTime();
     std::string newFilename = strprintf("wallet.%d.bak", now);
 
-    int result = dbenv.dbenv.dbrename(NULL, filename.c_str(), NULL,
+    int result = dbenv.pdbenv->dbrename(NULL, filename.c_str(), NULL,
                                       newFilename.c_str(), DB_AUTO_COMMIT);
     if (result == 0)
         LogPrintf("Renamed %s to %s\n", filename, newFilename);
@@ -920,7 +920,7 @@ bool CWalletDB::Recover(CDBEnv& dbenv, std::string filename, bool fOnlyKeys)
     LogPrintf("Salvage(aggressive) found %u records\n", salvagedData.size());
 
     bool fSuccess = allOK;
-    Db* pdbCopy = new Db(&dbenv.dbenv, 0);
+    Db* pdbCopy = new Db(dbenv.pdbenv, 0);
     int ret = pdbCopy->open(NULL,               // Txn pointer
                             filename.c_str(),   // Filename
                             "main",             // Logical db name


### PR DESCRIPTION
For several reasons the current test framework does not allow to easily incorporate new unit tests that append specially crafted blocks to the blockchain using ProcessBlock(). 
This was pointed out by Mike Hearn on the development list in the thread with subject "[Bitcoin-development] Question on creating test cases for block.CheckBlock()" (http://article.gmane.org/gmane.comp.bitcoin.devel/5939).

After debugging the Bitcoin core, we found that this is because of three reasons:
1. The miner_tests.cpp leaves the transaction pool in an invalid state and assumes the blockchain is empty on start. So other independent unit tests cannot be run before nor after (without proper cleaning) if they intend to use CreateNewBlock(), which collects transactions from the pool.
2. Creating test blocks requires proof-of-work. Even if the starting difficulty is low (1) the required proof-of-work is still too high to allow for the dynamic creation of test blocks. Instead, unit test have to be "pre-mined". This makes the code more opaque and increases the effort of changing the code.
3. Only the first unit test can start with an empty blockchain, all subsequent tests have to start with the blockchain in the state where the previous test left it. This has the following problematic consequences:
   a. Each unit test makes the blockchain longer. This breaks the test sequence when a checkpoint is reached because a checkpoint requires a pre-determined hash digest. Moreover, there are exception cases for certain block heights (e.g. regarding allowing two transactions with the same hash) which could be violated.
   b. Certain combinations of unit tests are inherently impossible to implement in a single block-chain if not run in an specific order.
   Other combinations may cause unexpected consequences. For example, since version 1 blocks do not have the height field included in the coinbase field of the generation transaction, a unit test may create a coinbase tx with a future height in the height field and prevent a coinbase tx with the same hash to be used afterward when only blocks v2 are accepted (this happened to us while testing). 
   c. The standard unit testing policy that unit tests should be not depend on each other's output is violated.
   This makes debugging more difficult.
   d. "Pre-mining" unit tests is impossible unless all previous unit tests are known and never change. (However, we are proposing to eliminate the proof-of-work check regardless.) 

We believe that testing the block acceptance rules is crucial for the safety of the application and so we wrote this patch.
By restarting the blockchain before every unit test that requires testing block acceptance we have the guarantee that all tests are independent, executed in a predefined reproducable environment, and don't unintentionally hit checkpoints or other exceptions. Nevertheless, each unit test decides whether to re-use or reset the block-chain. We haven't perceived any significant delay while performing the destruction and creation of the block-chain during the execution of the test application. This is because file space allocation functions are fast on modern filesystems. Nevertheless, UNDOFILE_CHUNK_SIZE/BLOCKFILE_CHUNK_SIZE can be reduced during test case execution if the block-chain is reset many times.

In detail, this patch solves 1.,2.,3. from above by:
- Providing a method to reset the blockchain to the starting state (testingSetupManager.SetupGenesisBlockChain())
- Allowing to dynamically skip the proof-of-work testing (supressCheckBlockWork = true)
- Fixing the bug in miner_tests.cpp which leaves in the memory pool invalid transactions (mempool.clear() missing).

We've also found the exact procedure that can be used to programmatically destroy and re-create the blockchain correctly, which was not implemented and nor documented. Some cleanup methods existed but some other were added because they were missing.

This could be of great help to re-create completely the blockchain in case a severe damage has been detected, without restarting the application.

As a bonus, 7 unit tests have been added:
- ToCheckBlockUpgradeMajority (untested before)
- EnforceBlockUpgradeMajority (untested before)
- RejectBlockOutdatedMajority (untested before)
- "bad-cb-height"
- "bad-version"
- "time-too-old"
- "bad-txns-nonfinal"

Last, we added a way to leave the blockchain unaltered after the test suite is over to debug the unit tests themselves (testingSetupManager.keepTestEvidence = true)

Note: The BerkeleyDB environment field was converted into a heap allocated object because BerkeleyDB handles are not meant to be re-used after close, and the block-chain environment can be closed and re-opened in the unit tests. This is explained in http://docs.oracle.com/cd/E17275_01/html/api_reference/CXX/envclose.html as
"After DbEnv::close() has been called, regardless of its return, the Berkeley DB environment handle may not be accessed again."

Sergio Demian Lerner & Timo Hanke
