### PR TITLE
Build bitcoin-cli unconditionally.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -512,12 +512,6 @@ if test x$boost_sleep != xyes; then
   AC_MSG_ERROR(No working boost sleep implementation found. If on ubuntu 13.10 with libboost1.54-all-dev remove libboost.1.54-all-dev and use libboost1.53-all-dev)
 fi
 
-AC_ARG_WITH([cli],
-  [AS_HELP_STRING([--with-cli],
-  [with CLI (default is yes)])],
-  [build_bitcoin_cli=$withval],
-  [build_bitcoin_cli=yes])
-
 AC_ARG_WITH([daemon],
   [AS_HELP_STRING([--with-daemon],
   [with daemon (default is yes)])],
@@ -563,10 +557,6 @@ BITCOIN_QT_PATH_PROGS([PROTOC], [protoc],$protoc_bin_path)
 AC_MSG_CHECKING([whether to build bitcoind])
 AM_CONDITIONAL([BUILD_BITCOIND], [test x$build_bitcoind = xyes])
 AC_MSG_RESULT($build_bitcoind)
-
-AC_MSG_CHECKING([whether to build bitcoin-cli])
-AM_CONDITIONAL([BUILD_BITCOIN_CLI], [test x$build_bitcoin_cli = xyes])
-AC_MSG_RESULT($build_bitcoin_cli)
 
 dnl sets $bitcoin_enable_qt, $bitcoin_enable_qt_test, $bitcoin_enable_qt_dbus
 BITCOIN_QT_CONFIGURE([$use_pkgconfig], [qt4])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -56,11 +56,7 @@ if BUILD_BITCOIND
   bin_PROGRAMS += bitcoind
 endif
 
-if BUILD_BITCOIN_CLI
-  bin_PROGRAMS += bitcoin-cli
-endif
-
-bin_PROGRAMS += bitcoin-tx
+bin_PROGRAMS += bitcoin-cli bitcoin-tx
 
 .PHONY: FORCE
 # bitcoin core #


### PR DESCRIPTION
Extremely small value in making this optional.  bitcoin-cli almost always has utility.

Further, distro builders and other packagers typically build everything, then cherry-pick if something needs to be elided.  Developers normally build bitcoin-cli.

The target audience for this option approaches zero.  I'm sure it satisfies some engineer's OCD somewhere, but is otherwise of little practical value.  :)
