### PR TITLE
[Wallet] Improve ReorderTransactions(..)

### DIFF
--- a/src/walletdb.cpp
+++ b/src/walletdb.cpp
@@ -278,8 +278,12 @@ CWalletDB::ReorderTransactions(CWallet* pwallet)
             nOrderPos = nOrderPosNext++;
             nOrderPosOffsets.push_back(nOrderPos);
 
-            if (pacentry)
-                // Have to write accounting regardless, since we don't keep it in memory
+            if (pwtx)
+            {
+                if (!WriteTx(pwtx->GetHash(), *pwtx))
+                    return DB_LOAD_FAIL;
+            }
+            else
                 if (!WriteAccountingEntry(pacentry->nEntryNo, *pacentry))
                     return DB_LOAD_FAIL;
         }
@@ -308,6 +312,7 @@ CWalletDB::ReorderTransactions(CWallet* pwallet)
                     return DB_LOAD_FAIL;
         }
     }
+    WriteOrderPosNext(nOrderPosNext);
 
     return DB_LOAD_OK;
 }


### PR DESCRIPTION
ReorderTransactions is never called, unless someone would load a very old wallet. I couldnt even trigger ReorderTransactions by experimenting with zapwallettxs. And if it gets triggered somehow, it causes problems, see #3894. The function doesnt even write back txs to disk, if they have nOrderPos == -1, looks like a bug to me.

The worst thing that could happen, is that some txs/entries have nOrderPos = -1. But I dont see any problems with this, even if happen. At least those old transactions would always appear behind new ones.
