### PR TITLE
OS X Homebrew Installation

### DIFF
--- a/contrib/homebrew/makefile.osx.patch
+++ b/contrib/homebrew/makefile.osx.patch
@@ -1,0 +1,48 @@
+diff --git a/src/makefile.osx b/src/makefile.osx
+index bef0ef3..07ef8d3 100644
+--- a/src/makefile.osx
++++ b/src/makefile.osx
+@@ -7,17 +7,21 @@
+ # Originally by Laszlo Hanyecz (solar@heliacal.net)
+ 
+ CXX=llvm-g++
+-DEPSDIR=/opt/local
++DEPSDIR=/usr/local
++DB4DIR=/usr/local/opt/berkeley-db4
++OPENSSLDIR=/usr/local/opt/openssl
+ 
+ INCLUDEPATHS= \
+  -I"$(CURDIR)" \
+- -I"$(CURDIR)"/obj \
++ -I"$(CURDIR)/obj" \
+  -I"$(DEPSDIR)/include" \
+- -I"$(DEPSDIR)/include/db48"
++ -I"$(DB4DIR)/include" \
++ -I"$(OPENSSLDIR)/include"
+ 
+ LIBPATHS= \
+  -L"$(DEPSDIR)/lib" \
+- -L"$(DEPSDIR)/lib/db48"
++ -L"$(DB4DIR)/lib" \
++ -L"$(OPENSSLDIR)/lib"
+ 
+ USE_UPNP:=1
+ USE_IPV6:=1
+@@ -31,14 +35,14 @@ ifdef STATIC
+ TESTLIBS += \
+  $(DEPSDIR)/lib/libboost_unit_test_framework-mt.a
+ LIBS += \
+- $(DEPSDIR)/lib/db48/libdb_cxx-4.8.a \
++ $(DB4DIR)/lib/libdb_cxx-4.8.a \
+  $(DEPSDIR)/lib/libboost_system-mt.a \
+  $(DEPSDIR)/lib/libboost_filesystem-mt.a \
+  $(DEPSDIR)/lib/libboost_program_options-mt.a \
+  $(DEPSDIR)/lib/libboost_thread-mt.a \
+  $(DEPSDIR)/lib/libboost_chrono-mt.a \
+- $(DEPSDIR)/lib/libssl.a \
+- $(DEPSDIR)/lib/libcrypto.a \
++ $(OPENSSLDIR)/lib/libssl.a \
++ $(OPENSSLDIR)/lib/libcrypto.a \
+  -lz
+ else
+ TESTLIBS += \

--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -73,17 +73,17 @@ Instructions: Homebrew
 
 Note: After you have installed the dependencies, you should check that the Homebrew installed version of OpenSSL is the one available for compilation. You can check this by typing
 
-        openssl version
+    /usr/local/cellar/openssl/*/bin/openssl version
 
-into Terminal. You should see OpenSSL 1.0.1h 5 Jun 2014.
+into Terminal. You should see OpenSSL 1.0.1i 6 Aug 2014.
 
-If not, you can ensure that the Homebrew OpenSSL is correctly linked by running
+You can invoke the Homebrew OpenSSL at build-time by exercising the following lines:
 
-        brew link openssl --force
+* OPENSSLDIR=/usr/local/opt/openssl
+* -L/usr/local/opt/openssl/lib
+* -I/usr/local/opt/openssl/include
 
-Rerunning "openssl version" should now return the correct version. If it
-doesn't, make sure `/usr/local/bin` comes before `/usr/bin` in your
-PATH. 
+But you don't need to do this if you use the patch provided for Homebrew in /contrib/homebrew/makefile.osx.patch - It is automatically done for you in that case. Exercise the patch with "patch -p1 /contrib/homebrew/makefile.osx.patch".
 
 ### Building `bitcoind`
 

--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -83,7 +83,7 @@ You can invoke the Homebrew OpenSSL at build-time by exercising the following li
 * -L/usr/local/opt/openssl/lib
 * -I/usr/local/opt/openssl/include
 
-But you don't need to do this if you use the patch provided for Homebrew in /contrib/homebrew/makefile.osx.patch - It is automatically done for you in that case. Exercise the patch with "patch -p1 /contrib/homebrew/makefile.osx.patch".
+But you don't need to do this if you use the patch provided for Homebrew in /contrib/homebrew/makefile.osx.patch - It is automatically done for you in that case. Exercise the patch with "patch -p1 -i /contrib/homebrew/makefile.osx.patch".
 
 ### Building `bitcoind`
 


### PR DESCRIPTION
This removes & rebuilds the current instructions for installing Homebrew dependencies on OS X, particular the instructions around exercising the `--force` command from inside Homebrew to link OpenSSL. This is irresponsible and dangerous to advise, on several levels, and it’s also completely unnecessary. The patch is borrowed from Litecoin, and retains the attribution to the original author inside the document. The patch is much _much_ safer than the current suggested alternative.
