### PR TITLE
CCoinsCache: Split read and write caches, MRU cache for read, add stats to RPC

### DIFF
--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -75,18 +75,6 @@ CCoinsKeyHasher::CCoinsKeyHasher() : salt(GetRandHash()) {}
 
 CCoinsViewCache::CCoinsViewCache(CCoinsView &baseIn, bool fDummy) : CCoinsViewBacked(baseIn), hashBlock(0) { }
 
-bool CCoinsViewCache::GetCoins(const uint256 &txid, CCoins &coins) {
-    if (cacheCoins.count(txid)) {
-        coins = cacheCoins[txid];
-        return true;
-    }
-    if (base->GetCoins(txid, coins)) {
-        cacheCoins[txid] = coins;
-        return true;
-    }
-    return false;
-}
-
 CCoinsMap::iterator CCoinsViewCache::FetchCoins(const uint256 &txid) {
     CCoinsMap::iterator it = cacheCoins.find(txid);
     if (it != cacheCoins.end())
@@ -97,6 +85,15 @@ CCoinsMap::iterator CCoinsViewCache::FetchCoins(const uint256 &txid) {
     CCoinsMap::iterator ret = cacheCoins.insert(it, std::make_pair(txid, CCoins()));
     tmp.swap(ret->second);
     return ret;
+}
+
+bool CCoinsViewCache::GetCoins(const uint256 &txid, CCoins &coins) {
+    CCoinsMap::iterator it = FetchCoins(txid);
+    if (it != cacheCoins.end()) {
+        coins = it->second;
+        return true;
+    }
+    return false;
 }
 
 const CCoins &CCoinsViewCache::GetCoins(const uint256 &txid) {

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -99,7 +99,13 @@ CCoinsMap::iterator CCoinsViewCache::FetchCoins(const uint256 &txid) {
     return ret;
 }
 
-CCoins &CCoinsViewCache::GetCoins(const uint256 &txid) {
+const CCoins &CCoinsViewCache::GetCoins(const uint256 &txid) {
+    CCoinsMap::const_iterator it = FetchCoins(txid);
+    assert(it != cacheCoins.end());
+    return it->second;
+}
+
+CCoins &CCoinsViewCache::ModifyCoins(const uint256 &txid) {
     CCoinsMap::iterator it = FetchCoins(txid);
     assert(it != cacheCoins.end());
     return it->second;

--- a/src/coins.h
+++ b/src/coins.h
@@ -336,9 +336,18 @@ class CCoinsViewCache : public CCoinsViewBacked
 {
 protected:
     uint256 hashBlock;
-    CCoinsMap cacheCoins;
     CCoinsCacheStats stats;
+    // Invariant: an entry should be in either the read cache or the write cache, or neither
+    CCoinsMap cacheRead;
+    CCoinsMap cacheWrite;
+
 public:
+    enum CacheFlags
+    {
+        READ = 1,
+        WRITE = 2,
+        READ_AND_WRITE = READ|WRITE
+    };
     CCoinsViewCache(CCoinsView &baseIn, bool fDummy = false);
 
     // Standard CCoinsView methods
@@ -357,10 +366,10 @@ public:
 
     // Push the modifications applied to this cache to its base.
     // Failure to call this method before destruction will cause the changes to be forgotten.
-    bool Flush();
+    bool Flush(unsigned int flags = READ_AND_WRITE);
 
     // Calculate the size of the cache (in number of transactions)
-    unsigned int GetCacheSize();
+    unsigned int GetCacheSize(unsigned int flags = READ_AND_WRITE);
 
     /** Amount of bitcoins coming in to a transaction
         Note that lightweight clients may not know anything besides the hash of previous transactions,
@@ -382,7 +391,7 @@ public:
     const CCoinsCacheStats &GetCacheStats() { return stats; }
 
 private:
-    CCoins *FetchCoins(const uint256 &txid);
+    const CCoins *FetchCoins(const uint256 &txid);
 };
 
 #endif

--- a/src/coins.h
+++ b/src/coins.h
@@ -320,6 +320,16 @@ public:
     bool GetStats(CCoinsStats &stats);
 };
 
+struct CCoinsCacheStats
+{
+    CCoinsCacheStats(): positive_hits(0), negative_hits(0), positive_misses(0), negative_misses(0), writes(0) {}
+    // Counters
+    uint64_t positive_hits;
+    uint64_t negative_hits;
+    uint64_t positive_misses;
+    uint64_t negative_misses;
+    uint64_t writes;
+};
 
 /** CCoinsView that adds a memory cache for transactions to another CCoinsView */
 class CCoinsViewCache : public CCoinsViewBacked
@@ -327,7 +337,7 @@ class CCoinsViewCache : public CCoinsViewBacked
 protected:
     uint256 hashBlock;
     CCoinsMap cacheCoins;
-
+    CCoinsCacheStats stats;
 public:
     CCoinsViewCache(CCoinsView &baseIn, bool fDummy = false);
 
@@ -367,6 +377,8 @@ public:
     double GetPriority(const CTransaction &tx, int nHeight);
 
     const CTxOut &GetOutputFor(const CTxIn& input);
+
+    const CCoinsCacheStats &GetCacheStats() { return stats; }
 
 private:
     CCoinsMap::iterator FetchCoins(const uint256 &txid);

--- a/src/coins.h
+++ b/src/coins.h
@@ -352,7 +352,8 @@ public:
     // Return a modifiable reference to a CCoins. Check HaveCoins first.
     // Many methods explicitly require a CCoinsViewCache because of this method, to reduce
     // copying.
-    CCoins &GetCoins(const uint256 &txid);
+    CCoins &ModifyCoins(const uint256 &txid);
+    const CCoins &GetCoins(const uint256 &txid);
 
     // Push the modifications applied to this cache to its base.
     // Failure to call this method before destruction will cause the changes to be forgotten.

--- a/src/coins.h
+++ b/src/coins.h
@@ -382,7 +382,7 @@ public:
     const CCoinsCacheStats &GetCacheStats() { return stats; }
 
 private:
-    CCoinsMap::iterator FetchCoins(const uint256 &txid);
+    CCoins *FetchCoins(const uint256 &txid);
 };
 
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1866,7 +1866,7 @@ bool ConnectBlock(CBlock& block, CValidationState& state, CBlockIndex* pindex, C
 // Update the on-disk chain state.
 bool static WriteChainState(CValidationState &state) {
     static int64_t nLastWrite = 0;
-    if (pcoinsTip->GetCacheSize() > nCoinCacheSize || (!IsInitialBlockDownload() && GetTimeMicros() > nLastWrite + 600*1000000)) {
+    if (pcoinsTip->GetCacheSize() > nCoinCacheSize || (!IsInitialBlockDownload() && GetTimeMicros() > nLastWrite + CHAINSTATE_WRITE_PERIOD*1000000)) {
         // Typical CCoins structures on disk are around 100 bytes in size.
         // Pushing a new one to the database can cause it to be written
         // twice (once in the log, and once in the tables). This is already

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1435,7 +1435,7 @@ void UpdateCoins(const CTransaction& tx, CValidationState &state, CCoinsViewCach
     // mark inputs spent
     if (!tx.IsCoinBase()) {
         BOOST_FOREACH(const CTxIn &txin, tx.vin) {
-            CCoins &coins = inputs.GetCoins(txin.prevout.hash);
+            CCoins &coins = inputs.ModifyCoins(txin.prevout.hash);
             CTxInUndo undo;
             ret = coins.Spend(txin.prevout, undo);
             assert(ret);
@@ -1590,7 +1590,7 @@ bool DisconnectBlock(CBlock& block, CValidationState& state, CBlockIndex* pindex
         // have outputs available even in the block itself, so we handle that case
         // specially with outsEmpty.
         CCoins outsEmpty;
-        CCoins &outs = view.HaveCoins(hash) ? view.GetCoins(hash) : outsEmpty;
+        CCoins &outs = view.HaveCoins(hash) ? view.ModifyCoins(hash) : outsEmpty;
         outs.ClearUnspendable();
 
         CCoins outsBlock = CCoins(tx, pindex->nHeight);

--- a/src/main.h
+++ b/src/main.h
@@ -67,6 +67,8 @@ static const int DEFAULT_SCRIPTCHECK_THREADS = 0;
 static const int MAX_BLOCKS_IN_TRANSIT_PER_PEER = 128;
 /** Timeout in seconds before considering a block download peer unresponsive. */
 static const unsigned int BLOCK_DOWNLOAD_TIMEOUT = 60;
+/** Time in seconds between chain state flushes, if not in initial block download */
+static const unsigned int CHAINSTATE_WRITE_PERIOD = 600;
 
 /** "reject" message codes **/
 static const unsigned char REJECT_MALFORMED = 0x01;

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -452,6 +452,16 @@ Value getblockchaininfo(const Array& params, bool fHelp)
             + HelpExampleRpc("getblockchaininfo", "")
         );
 
+    Object cache_info;
+    const CCoinsCacheStats &stats = pcoinsTip->GetCacheStats();
+    cache_info.push_back(Pair("positive_hits", stats.positive_hits));
+    cache_info.push_back(Pair("negative_hits", stats.negative_hits));
+    cache_info.push_back(Pair("positive_misses", stats.positive_misses));
+    cache_info.push_back(Pair("negative_misses", stats.negative_misses));
+    cache_info.push_back(Pair("writes", stats.writes));
+    cache_info.push_back(Pair("cache_size", (int64_t)pcoinsTip->GetCacheSize()));
+    cache_info.push_back(Pair("cache_limit", (int64_t)nCoinCacheSize));
+
     Object obj;
     obj.push_back(Pair("chain",                 Params().NetworkIDString()));
     obj.push_back(Pair("blocks",                (int)chainActive.Height()));
@@ -459,6 +469,8 @@ Value getblockchaininfo(const Array& params, bool fHelp)
     obj.push_back(Pair("difficulty",            (double)GetDifficulty()));
     obj.push_back(Pair("verificationprogress",  Checkpoints::GuessVerificationProgress(chainActive.Tip())));
     obj.push_back(Pair("chainwork",             chainActive.Tip()->nChainWork.GetHex()));
+    obj.push_back(Pair("coinscache",            cache_info));
+
     return obj;
 }
 

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -460,6 +460,8 @@ Value getblockchaininfo(const Array& params, bool fHelp)
     cache_info.push_back(Pair("negative_misses", stats.negative_misses));
     cache_info.push_back(Pair("writes", stats.writes));
     cache_info.push_back(Pair("cache_size", (int64_t)pcoinsTip->GetCacheSize()));
+    cache_info.push_back(Pair("rcache_size", (int64_t)pcoinsTip->GetCacheSize(CCoinsViewCache::READ)));
+    cache_info.push_back(Pair("wcache_size", (int64_t)pcoinsTip->GetCacheSize(CCoinsViewCache::WRITE)));
     cache_info.push_back(Pair("cache_limit", (int64_t)nCoinCacheSize));
 
     Object obj;

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -498,7 +498,7 @@ void CTxMemPool::check(CCoinsViewCache *pcoins) const
                 const CTransaction& tx2 = it2->second.GetTx();
                 assert(tx2.vout.size() > txin.prevout.n && !tx2.vout[txin.prevout.n].IsNull());
             } else {
-                CCoins &coins = pcoins->GetCoins(txin.prevout.hash);
+                const CCoins &coins = pcoins->GetCoins(txin.prevout.hash);
                 assert(coins.IsAvailable(txin.prevout.n));
             }
             // Check whether its inputs are marked in mapNextTx.


### PR DESCRIPTION
Most of these changes depend on each other, but are in separate commits and can be split off into separate pulls if this is deemed too high-impact to apply at once.
### Track cache statistics in `getblockchaininfo`

This makes it possible to measure and compare caching strategies.

```
"coinscache" : {
    "positive_hits" : 9186,
    "negative_hits" : 7579,
    "positive_misses" : 50791,
    "negative_misses" : 43200,
    "writes" : 8569,
    "cache_size" : 93722,
    "rcache_size" : 91207,
    "wcache_size" : 2515,
    "cache_limit" : 171267
}
```

Currently this is part of `getblockchaininfo`. I'm not sure about that, it probably should get its own RPC.
### Separate read and write cache

Keep track of entries that are read-only or r/w in separate caches. This is an optimization that avoids writing back all accessed entries back to the database on a flush.

The read and write cache can be flushed separately. Only the write entries will be written back.

This also opens the door to using a different data structure for the read and
write cache later on.
### Cache negative hits

Currently the cache doesn't remember when a coin was not found. It could cache negative results as well.

Looking at the statistics this can make a difference in number of database queries almost as large as positive caching during normal node operation.

The implementation makes use of the fact that a a CCoins with 'pcoins->vout.empty()' is regarded as non-existent.
### Change read cache to MRU cache

Changes the read cache to a MRU cache implemented using `boost::bimap`. This allows cleaning up the cache to a fixed size instead of flushing the entire cache periodically, and should result in more effective caching.
Write cache flushes are done with the same frequency as before, and are still all-or-nothing.
### Flush write cache into read cache

After writing the entries to the underlying store, move them to the read cache. It is likely that they will be accessed again soon. If not, the entries will be evicted eventually.
### Memory usage

Peak memory usage hasn't changed compared to before. However, the evolution of memory usage in time has changed. Before, the cache was flushed completely every 10 minutes (when not in initial block sync) or when the cache was full (when initial block sync). Now, instead of alternating between empty and full it will plateau.
### Testing

I did quite a bit of testing with these changes, amongst others various reindexes of the mainnet and testnet block chains as well as tests with `-checkblocks` and running a node for a while.
Still, especially the MRU cache switch needs to be tested much more extensively before it can be merged.
