### PR TITLE
Autoprune

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1029,6 +1029,11 @@ bool AppInit2(boost::thread_group& threadGroup)
                     break;
                 }
 
+                if (!CheckBlockFiles()) {
+                    strLoadError = _("Error checking required block files. There must be missing or unreadable data");
+                    break;
+                }
+
                 // If the loaded chain has a wrong genesis, bail out immediately
                 // (we're likely using a testnet datadir, or the other way around).
                 if (!mapBlockIndex.empty() && mapBlockIndex.count(Params().HashGenesisBlock()) == 0)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2974,20 +2974,18 @@ bool CheckBlockFiles()
     // Check presence of blk files
     LogPrintf("Checking all blk files are present...\n");
     set<int> setRequiredDataFilesAreOpenable;
-    BOOST_FOREACH(const PAIRTYPE(uint256, CBlockIndex*)& item, mapBlockIndex)
-    {
-        CBlockIndex* pindex = item.second;
+    for (CBlockIndex* pindex = chainActive.Tip(); pindex && pindex->pprev; pindex = pindex->pprev) {
         if (pindex->nStatus & BLOCK_HAVE_DATA && pindex->nStatus & BLOCK_HAVE_UNDO) {
-            setRequiredDataFilesAreOpenable.insert(pindex->nFile);
+            if (!setRequiredDataFilesAreOpenable.count(pindex->nFile)) {
+                if (DataFilesAreOpenable(pindex->nFile))
+                    setRequiredDataFilesAreOpenable.insert(pindex->nFile);
+                else {
+                    LogPrintf("Error: Required file for block: %i can't be opened.\n", pindex->nHeight);
+                    return false;
+                }
+            }
         } else {
             LogPrintf("Error: Required data for block: %i is missing.\n", pindex->nHeight);
-            return false;
-        }
-    }
-    for (std::set<int>::iterator it = setRequiredDataFilesAreOpenable.begin(); it != setRequiredDataFilesAreOpenable.end(); it++)
-    {
-        if (!DataFilesAreOpenable(*it)) {
-            LogPrintf("Error: Can't open a required block file: %i.\n", *it);
             return false;
         }
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2956,21 +2956,38 @@ bool BlockFileIsOpenable(int nFile)
     return !CAutoFile(OpenBlockFile(pos, true), SER_DISK, CLIENT_VERSION).IsNull();
 }
 
+bool UndoFileIsOpenable(int nFile)
+{
+    CDiskBlockPos pos(nFile, 0);
+    return !CAutoFile(OpenUndoFile(pos, true), SER_DISK, CLIENT_VERSION).IsNull();
+}
+
+bool DataFilesAreOpenable(int nFile)
+{
+    if (BlockFileIsOpenable(nFile) && UndoFileIsOpenable(nFile))
+        return true;
+    return false;
+}
+
 bool CheckBlockFiles()
 {
     // Check presence of blk files
     LogPrintf("Checking all blk files are present...\n");
-    set<int> setBlkDataFiles;
+    set<int> setRequiredDataFilesAreOpenable;
     BOOST_FOREACH(const PAIRTYPE(uint256, CBlockIndex*)& item, mapBlockIndex)
     {
         CBlockIndex* pindex = item.second;
-        if (pindex->nStatus & BLOCK_HAVE_DATA) {
-            setBlkDataFiles.insert(pindex->nFile);
+        if (pindex->nStatus & BLOCK_HAVE_DATA && pindex->nStatus & BLOCK_HAVE_UNDO) {
+            setRequiredDataFilesAreOpenable.insert(pindex->nFile);
+        } else {
+            LogPrintf("Error: Required data for block: %i is missing.\n", pindex->nHeight);
+            return false;
         }
     }
-    for (std::set<int>::iterator it = setBlkDataFiles.begin(); it != setBlkDataFiles.end(); it++)
+    for (std::set<int>::iterator it = setRequiredDataFilesAreOpenable.begin(); it != setRequiredDataFilesAreOpenable.end(); it++)
     {
-        if (!BlockFileIsOpenable(*it)) {
+        if (!DataFilesAreOpenable(*it)) {
+            LogPrintf("Error: Can't open a required block file: %i.\n", *it);
             return false;
         }
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2950,6 +2950,12 @@ bool static LoadBlockIndexDB()
     return true;
 }
 
+bool BlockFileIsOpenable(int nFile)
+{
+    CDiskBlockPos pos(nFile, 0);
+    return !CAutoFile(OpenBlockFile(pos, true), SER_DISK, CLIENT_VERSION).IsNull();
+}
+
 bool CheckBlockFiles()
 {
     // Check presence of blk files
@@ -2964,8 +2970,7 @@ bool CheckBlockFiles()
     }
     for (std::set<int>::iterator it = setBlkDataFiles.begin(); it != setBlkDataFiles.end(); it++)
     {
-        CDiskBlockPos pos(*it, 0);
-        if (!CAutoFile(OpenBlockFile(pos, true), SER_DISK, CLIENT_VERSION)) {
+        if (!BlockFileIsOpenable(*it)) {
             return false;
         }
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2886,7 +2886,7 @@ bool static LoadBlockIndexDB()
     {
         CBlockIndex* pindex = item.second;
         pindex->nChainWork = (pindex->pprev ? pindex->pprev->nChainWork : 0) + GetBlockProof(*pindex);
-        if (pindex->nStatus & BLOCK_HAVE_DATA) {
+        if (pindex->nStatus & BLOCK_HAVE_DATA || pindex->nStatus & BLOCK_VALID_CHAIN) {
             if (pindex->pprev) {
                 if (pindex->pprev->nChainTx) {
                     pindex->nChainTx = pindex->pprev->nChainTx + pindex->nTx;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2925,24 +2925,6 @@ bool static LoadBlockIndexDB()
         }
     }
 
-    // Check presence of blk files
-    LogPrintf("Checking all blk files are present...\n");
-    set<int> setBlkDataFiles;
-    BOOST_FOREACH(const PAIRTYPE(uint256, CBlockIndex*)& item, mapBlockIndex)
-    {
-        CBlockIndex* pindex = item.second;
-        if (pindex->nStatus & BLOCK_HAVE_DATA) {
-            setBlkDataFiles.insert(pindex->nFile);
-        }
-    }
-    for (std::set<int>::iterator it = setBlkDataFiles.begin(); it != setBlkDataFiles.end(); it++)
-    {
-        CDiskBlockPos pos(*it, 0);
-        if (CAutoFile(OpenBlockFile(pos, true), SER_DISK, CLIENT_VERSION).IsNull()) {
-            return false;
-        }
-    }
-
     // Check whether we need to continue reindexing
     bool fReindexing = false;
     pblocktree->ReadReindexing(fReindexing);
@@ -2965,6 +2947,28 @@ bool static LoadBlockIndexDB()
         DateTimeStrFormat("%Y-%m-%d %H:%M:%S", chainActive.Tip()->GetBlockTime()),
         Checkpoints::GuessVerificationProgress(chainActive.Tip()));
 
+    return true;
+}
+
+bool CheckBlockFiles()
+{
+    // Check presence of blk files
+    LogPrintf("Checking all blk files are present...\n");
+    set<int> setBlkDataFiles;
+    BOOST_FOREACH(const PAIRTYPE(uint256, CBlockIndex*)& item, mapBlockIndex)
+    {
+        CBlockIndex* pindex = item.second;
+        if (pindex->nStatus & BLOCK_HAVE_DATA) {
+            setBlkDataFiles.insert(pindex->nFile);
+        }
+    }
+    for (std::set<int>::iterator it = setBlkDataFiles.begin(); it != setBlkDataFiles.end(); it++)
+    {
+        CDiskBlockPos pos(*it, 0);
+        if (!CAutoFile(OpenBlockFile(pos, true), SER_DISK, CLIENT_VERSION)) {
+            return false;
+        }
+    }
     return true;
 }
 

--- a/src/main.h
+++ b/src/main.h
@@ -95,6 +95,10 @@ static const unsigned int DATABASE_WRITE_INTERVAL = 3600;
 static const unsigned int MAX_REJECT_MESSAGE_LENGTH = 111;
 /** Minimum amount of blocks to keep unpruned, needed to afford deep reorganizations. */
 static const unsigned int MIN_BLOCKS_TO_KEEP = 288;
+/** Start autopruning after this height. */
+static const signed int AUTOPRUNE_AFTER_HEIGHT = 100000;
+/** Minimum amount of bytes needed for block files. */
+static const unsigned int MIN_BLOCK_FILES_SIZE = 300 * 1024 * 1024;
 
 /** "reject" message codes */
 static const unsigned char REJECT_MALFORMED = 0x01;
@@ -129,7 +133,7 @@ extern bool fTxIndex;
 extern bool fIsBareMultisigStd;
 extern unsigned int nCoinCacheSize;
 extern CFeeRate minRelayTxFee;
-extern bool fPruned;
+extern uintmax_t nPrune;
 
 /** Best header we've seen so far (used for getheaders queries' starting points). */
 extern CBlockIndex *pindexBestHeader;

--- a/src/main.h
+++ b/src/main.h
@@ -93,6 +93,8 @@ static const unsigned int BLOCK_DOWNLOAD_WINDOW = 1024;
 static const unsigned int DATABASE_WRITE_INTERVAL = 3600;
 /** Maximum length of reject messages. */
 static const unsigned int MAX_REJECT_MESSAGE_LENGTH = 111;
+/** Minimum amount of blocks to keep unpruned, needed to afford deep reorganizations. */
+static const unsigned int MIN_BLOCKS_TO_KEEP = 288;
 
 /** "reject" message codes */
 static const unsigned char REJECT_MALFORMED = 0x01;
@@ -127,6 +129,7 @@ extern bool fTxIndex;
 extern bool fIsBareMultisigStd;
 extern unsigned int nCoinCacheSize;
 extern CFeeRate minRelayTxFee;
+extern bool fPruned;
 
 /** Best header we've seen so far (used for getheaders queries' starting points). */
 extern CBlockIndex *pindexBestHeader;

--- a/src/main.h
+++ b/src/main.h
@@ -174,6 +174,8 @@ bool LoadExternalBlockFile(FILE* fileIn, CDiskBlockPos *dbp = NULL);
 bool InitBlockIndex();
 /** Load the block tree and coins database from disk */
 bool LoadBlockIndex();
+/** Check all required block files are present */
+bool CheckBlockFiles();
 /** Unload database information */
 void UnloadBlockIndex();
 /** Process protocol messages received from a given node */


### PR DESCRIPTION
This pull implements a new mode of operation which automatically removes old block files trying to maintain at most a maximum amount of disk space used by the node. This amount is configured by the user with the -prune switch.

There's also a lightweight sanity check which executes periodically during runtime to make sure the minimum block files required for the node to be operative are present.

This should allow to lower the amount of resources needed to run a node.

See the individual commits, about all the changes introduced.
