### PR TITLE
[Wallet] Replace OrderedTxItems(..) with in-memory map

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1195,6 +1195,7 @@ bool AppInit2(boost::thread_group& threadGroup)
                         copyTo->WriteToDisk();
                     }
                 }
+                pwalletMain->InitMapOrderedTxItems();
             }
         }
     } // (!fDisableWallet)

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -577,7 +577,13 @@ CAmount GetAccountBalance(CWalletDB& walletdb, const string& strAccount, int nMi
     }
 
     // Tally internal accounting entries
-    nBalance += walletdb.GetAccountCreditDebit(strAccount);
+    if (pwalletMain->mapAccountingEntries.count(strAccount))
+    {
+        std::pair <std::multimap<std::string, CAccountingEntry>::const_iterator, std::multimap<std::string, CAccountingEntry>::const_iterator> range;
+        range = pwalletMain->mapAccountingEntries.equal_range(strAccount);
+        for (std::multimap<std::string, CAccountingEntry>::const_iterator it = range.first; it != range.second; ++it)
+            nBalance += it->second.nCreditDebit;
+    }
 
     return nBalance;
 }
@@ -733,6 +739,9 @@ Value movecmd(const Array& params, bool fHelp)
 
     if (!walletdb.TxnCommit())
         throw JSONRPCError(RPC_DATABASE_ERROR, "database error");
+
+    pwalletMain->AddAccountingEntry(debit);
+    pwalletMain->AddAccountingEntry(credit);
 
     return true;
 }
@@ -1390,10 +1399,8 @@ Value listaccounts(const Array& params, bool fHelp)
         }
     }
 
-    list<CAccountingEntry> acentries;
-    CWalletDB(pwalletMain->strWalletFile).ListAccountCreditDebit("*", acentries);
-    BOOST_FOREACH(const CAccountingEntry& entry, acentries)
-        mapAccountBalances[entry.strAccount] += entry.nCreditDebit;
+    for (std::multimap<std::string, CAccountingEntry>::iterator it = pwalletMain->mapAccountingEntries.begin(); it != pwalletMain->mapAccountingEntries.end(); ++it)
+        mapAccountBalances[it->second.strAccount] += it->second.nCreditDebit;
 
     Object ret;
     BOOST_FOREACH(const PAIRTYPE(string, CAmount)& accountBalance, mapAccountBalances) {

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -1302,11 +1302,8 @@ Value listtransactions(const Array& params, bool fHelp)
 
     Array ret;
 
-    std::list<CAccountingEntry> acentries;
-    CWallet::TxItems txOrdered = pwalletMain->OrderedTxItems(acentries, strAccount);
-
     // iterate backwards until we have nCount items to return:
-    for (CWallet::TxItems::reverse_iterator it = txOrdered.rbegin(); it != txOrdered.rend(); ++it)
+    for (CWallet::TxItems::reverse_iterator it = pwalletMain->mapOrderedTxItems.rbegin(); it != pwalletMain->mapOrderedTxItems.rend(); ++it)
     {
         CWalletTx *const pwtx = (*it).second.first;
         if (pwtx != 0)

--- a/src/test/accounting_tests.cpp
+++ b/src/test/accounting_tests.cpp
@@ -17,15 +17,11 @@ BOOST_AUTO_TEST_SUITE(accounting_tests)
 static void
 GetResults(CWalletDB& walletdb, std::map<CAmount, CAccountingEntry>& results)
 {
-    std::list<CAccountingEntry> aes;
-
     results.clear();
     BOOST_CHECK(walletdb.ReorderTransactions(pwalletMain) == DB_LOAD_OK);
-    walletdb.ListAccountCreditDebit("", aes);
-    BOOST_FOREACH(CAccountingEntry& ae, aes)
-    {
-        results[ae.nOrderPos] = ae;
-    }
+
+    for (std::multimap<std::string, CAccountingEntry>::iterator it = pwalletMain->mapAccountingEntries.begin(); it != pwalletMain->mapAccountingEntries.end(); ++it)
+        results[it->second.nOrderPos] = it->second;
 }
 
 BOOST_AUTO_TEST_CASE(acc_orderupgrade)
@@ -43,7 +39,7 @@ BOOST_AUTO_TEST_CASE(acc_orderupgrade)
     ae.nTime = 1333333333;
     ae.strOtherAccount = "b";
     ae.strComment = "";
-    walletdb.WriteAccountingEntry(ae);
+    pwalletMain->AddAccountingEntry(ae);
 
     wtx.mapValue["comment"] = "z";
     pwalletMain->AddToWallet(wtx);
@@ -53,7 +49,7 @@ BOOST_AUTO_TEST_CASE(acc_orderupgrade)
 
     ae.nTime = 1333333336;
     ae.strOtherAccount = "c";
-    walletdb.WriteAccountingEntry(ae);
+    pwalletMain->AddAccountingEntry(ae);
 
     GetResults(walletdb, results);
 
@@ -69,7 +65,7 @@ BOOST_AUTO_TEST_CASE(acc_orderupgrade)
     ae.nTime = 1333333330;
     ae.strOtherAccount = "d";
     ae.nOrderPos = pwalletMain->IncOrderPosNext();
-    walletdb.WriteAccountingEntry(ae);
+    pwalletMain->AddAccountingEntry(ae);
 
     GetResults(walletdb, results);
 
@@ -119,7 +115,7 @@ BOOST_AUTO_TEST_CASE(acc_orderupgrade)
     ae.nTime = 1333333334;
     ae.strOtherAccount = "e";
     ae.nOrderPos = -1;
-    walletdb.WriteAccountingEntry(ae);
+    pwalletMain->AddAccountingEntry(ae);
 
     GetResults(walletdb, results);
 

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -681,6 +681,11 @@ void CWallet::EraseFromWallet(const uint256 &hash)
     return;
 }
 
+void CWallet::AddAccountingEntry(const CAccountingEntry& entry, bool fFromLoadWallet)
+{
+    AssertLockHeld(cs_wallet);
+    std::multimap<std::string, CAccountingEntry>::iterator it = mapAccountingEntries.insert(make_pair(entry.strAccount, entry));
+}
 
 isminetype CWallet::IsMine(const CTxIn &txin) const
 {

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -164,6 +164,7 @@ public:
     }
 
     std::map<uint256, CWalletTx> mapWallet;
+    std::multimap<std::string, CAccountingEntry> mapAccountingEntries;
 
     int64_t nOrderPosNext;
     std::map<uint256, int> mapRequestCount;
@@ -238,7 +239,6 @@ public:
 
     typedef std::pair<CWalletTx*, CAccountingEntry*> TxPair;
     typedef std::multimap<int64_t, TxPair > TxItems;
-
     /** Get the wallet's activity log
         @return multimap of ordered transactions and accounting entries
         @warning Returned pointers are *only* valid within the scope of passed acentries
@@ -247,6 +247,7 @@ public:
 
     void MarkDirty();
     bool AddToWallet(const CWalletTx& wtxIn, bool fFromLoadWallet=false);
+    void AddAccountingEntry(const CAccountingEntry& entry, bool fFromLoadWallet=false);
     void SyncTransaction(const CTransaction& tx, const CBlock* pblock);
     bool AddToWalletIfInvolvingMe(const CTransaction& tx, const CBlock* pblock, bool fUpdate);
     void EraseFromWallet(const uint256 &hash);

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -239,11 +239,10 @@ public:
 
     typedef std::pair<CWalletTx*, CAccountingEntry*> TxPair;
     typedef std::multimap<int64_t, TxPair > TxItems;
-    /** Get the wallet's activity log
-        @return multimap of ordered transactions and accounting entries
-        @warning Returned pointers are *only* valid within the scope of passed acentries
-     */
-    TxItems OrderedTxItems(std::list<CAccountingEntry>& acentries, std::string strAccount = "");
+    TxItems mapOrderedTxItems;
+    void InitMapOrderedTxItems();
+    void AddToOrderedTxItems(CWalletTx* wtx);
+    void AddToOrderedTxItems(CAccountingEntry* entry);
 
     void MarkDirty();
     bool AddToWallet(const CWalletTx& wtxIn, bool fFromLoadWallet=false);

--- a/src/walletdb.cpp
+++ b/src/walletdb.cpp
@@ -644,6 +644,8 @@ DBErrors CWalletDB::LoadWallet(CWallet* pwallet)
     if (wss.fAnyUnordered)
         result = ReorderTransactions(pwallet);
 
+    pwallet->InitMapOrderedTxItems();
+
     return result;
 }
 

--- a/src/walletdb.cpp
+++ b/src/walletdb.cpp
@@ -187,61 +187,6 @@ bool CWalletDB::WriteAccountingEntry(const CAccountingEntry& acentry)
     return WriteAccountingEntry(++nAccountingEntryNumber, acentry);
 }
 
-CAmount CWalletDB::GetAccountCreditDebit(const string& strAccount)
-{
-    list<CAccountingEntry> entries;
-    ListAccountCreditDebit(strAccount, entries);
-
-    CAmount nCreditDebit = 0;
-    BOOST_FOREACH (const CAccountingEntry& entry, entries)
-        nCreditDebit += entry.nCreditDebit;
-
-    return nCreditDebit;
-}
-
-void CWalletDB::ListAccountCreditDebit(const string& strAccount, list<CAccountingEntry>& entries)
-{
-    bool fAllAccounts = (strAccount == "*");
-
-    Dbc* pcursor = GetCursor();
-    if (!pcursor)
-        throw runtime_error("CWalletDB::ListAccountCreditDebit() : cannot create DB cursor");
-    unsigned int fFlags = DB_SET_RANGE;
-    while (true)
-    {
-        // Read next record
-        CDataStream ssKey(SER_DISK, CLIENT_VERSION);
-        if (fFlags == DB_SET_RANGE)
-            ssKey << boost::make_tuple(string("acentry"), (fAllAccounts? string("") : strAccount), uint64_t(0));
-        CDataStream ssValue(SER_DISK, CLIENT_VERSION);
-        int ret = ReadAtCursor(pcursor, ssKey, ssValue, fFlags);
-        fFlags = DB_NEXT;
-        if (ret == DB_NOTFOUND)
-            break;
-        else if (ret != 0)
-        {
-            pcursor->close();
-            throw runtime_error("CWalletDB::ListAccountCreditDebit() : error scanning DB");
-        }
-
-        // Unserialize
-        string strType;
-        ssKey >> strType;
-        if (strType != "acentry")
-            break;
-        CAccountingEntry acentry;
-        ssKey >> acentry.strAccount;
-        if (!fAllAccounts && acentry.strAccount != strAccount)
-            break;
-
-        ssValue >> acentry;
-        ssKey >> acentry.nEntryNo;
-        entries.push_back(acentry);
-    }
-
-    pcursor->close();
-}
-
 DBErrors CWalletDB::ReorderTransactions(CWallet* pwallet)
 {
     LOCK(pwallet->cs_wallet);
@@ -258,11 +203,10 @@ DBErrors CWalletDB::ReorderTransactions(CWallet* pwallet)
         CWalletTx* wtx = &((*it).second);
         txByTime.insert(make_pair(wtx->nTimeReceived, TxPair(wtx, (CAccountingEntry*)0)));
     }
-    list<CAccountingEntry> acentries;
-    ListAccountCreditDebit("", acentries);
-    BOOST_FOREACH(CAccountingEntry& entry, acentries)
+    for (std::multimap<std::string, CAccountingEntry>::iterator it = pwallet->mapAccountingEntries.begin(); it != pwallet->mapAccountingEntries.end(); ++it)
     {
-        txByTime.insert(make_pair(entry.nTime, TxPair((CWalletTx*)0, &entry)));
+        CAccountingEntry* entry = &((*it).second);
+        txByTime.insert(make_pair(entry->nTime, TxPair((CWalletTx*)0, entry)));
     }
 
     int64_t& nOrderPosNext = pwallet->nOrderPosNext;
@@ -401,13 +345,18 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
             if (nNumber > nAccountingEntryNumber)
                 nAccountingEntryNumber = nNumber;
 
+            CAccountingEntry acentry;
+            ssValue >> acentry;
+
             if (!wss.fAnyUnordered)
             {
-                CAccountingEntry acentry;
-                ssValue >> acentry;
                 if (acentry.nOrderPos == -1)
                     wss.fAnyUnordered = true;
             }
+
+            acentry.strAccount = strAccount;
+            acentry.nEntryNo = nNumber;
+            pwallet->AddAccountingEntry(acentry, true);
         }
         else if (strType == "watchs")
         {

--- a/src/walletdb.h
+++ b/src/walletdb.h
@@ -119,8 +119,6 @@ public:
     bool EraseDestData(const std::string &address, const std::string &key);
 
     bool WriteAccountingEntry(const CAccountingEntry& acentry);
-    CAmount GetAccountCreditDebit(const std::string& strAccount);
-    void ListAccountCreditDebit(const std::string& strAccount, std::list<CAccountingEntry>& acentries);
 
     DBErrors ReorderTransactions(CWallet* pwallet);
     DBErrors LoadWallet(CWallet* pwallet);


### PR DESCRIPTION
I was wondering why adding 18000 transactions to the wallet takes ages.
One of the reasons is CWallet::OrderedTxItems(..).
So maintain the map in-memory instead of generating it all the time.
This pull should not change any functionality.
