### PR TITLE
build : fix CPPFLAGS for libbitcoin_cli

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -229,6 +229,7 @@ libbitcoin_util_a_SOURCES += compat/glibcxx_compat.cpp
 endif
 
 # cli: shared between bitcoin-cli and bitcoin-qt
+libbitcoin_cli_a_CPPFLAGS = $(BITCOIN_INCLUDES)
 libbitcoin_cli_a_SOURCES = \
   rpcclient.cpp \
   $(BITCOIN_CORE_H)


### PR DESCRIPTION
Passes $(BITCOIN_INCLUDES) to preprocessor for libbitcoin_cli, identically to other sublib builds.
