### PR TITLE
[Qt] Call checkBalanceChanged() periodically instead for every updated tx

### DIFF
--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -36,6 +36,7 @@ WalletModel::WalletModel(CWallet *wallet, OptionsModel *optionsModel, QObject *p
 {
     fProcessingQueuedTransactions = false;
     fHaveWatchOnly = wallet->HaveWatchOnly();
+    fForceCheckBalanceChanged = false;
 
     addressTableModel = new AddressTableModel(wallet, this);
     transactionTableModel = new TransactionTableModel(wallet, this);
@@ -121,8 +122,10 @@ void WalletModel::pollBalanceChanged()
     if(!lockWallet)
         return;
 
-    if(chainActive.Height() != cachedNumBlocks)
+    if(fForceCheckBalanceChanged || chainActive.Height() != cachedNumBlocks)
     {
+        fForceCheckBalanceChanged = false;
+
         // Balance and number of transactions might have changed
         cachedNumBlocks = chainActive.Height();
 
@@ -167,7 +170,7 @@ void WalletModel::updateTransaction(const QString &hash, int status)
         transactionTableModel->updateTransaction(hash, status);
 
     // Balance and number of transactions might have changed
-    checkBalanceChanged();
+    fForceCheckBalanceChanged = true;
 }
 
 void WalletModel::updateAddressBook(const QString &address, const QString &label,
@@ -344,6 +347,7 @@ WalletModel::SendCoinsReturn WalletModel::sendCoins(WalletModelTransaction &tran
         }
         emit coinsSent(wallet, rcp, transaction_array);
     }
+    checkBalanceChanged(); // update balance immediately, otherwise there could be a short noticeable delay until pollBalanceChanged hits
 
     return SendCoinsReturn(OK);
 }
@@ -473,11 +477,6 @@ static void NotifyTransactionChanged(WalletModel *walletmodel, CWallet *wallet, 
 
 static void ShowProgress(WalletModel *walletmodel, const std::string &title, int nProgress)
 {
-    // emits signal "showProgress"
-    QMetaObject::invokeMethod(walletmodel, "showProgress", Qt::QueuedConnection,
-                              Q_ARG(QString, QString::fromStdString(title)),
-                              Q_ARG(int, nProgress));
-
     if (nProgress == 0)
         fQueueNotifications = true;
 
@@ -495,6 +494,11 @@ static void ShowProgress(WalletModel *walletmodel, const std::string &title, int
         }
         std::vector<std::pair<uint256, ChangeType> >().swap(vQueueNotifications); // clear
     }
+
+    // emits signal "showProgress"
+    QMetaObject::invokeMethod(walletmodel, "showProgress", Qt::QueuedConnection,
+                              Q_ARG(QString, QString::fromStdString(title)),
+                              Q_ARG(int, nProgress));
 }
 
 static void NotifyWatchonlyChanged(WalletModel *walletmodel, bool fHaveWatchonly)

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -199,6 +199,7 @@ private:
     CWallet *wallet;
     bool fProcessingQueuedTransactions;
     bool fHaveWatchOnly;
+    bool fForceCheckBalanceChanged;
 
     // Wallet has an options model for wallet-specific options
     // (transaction fee, for example)


### PR DESCRIPTION
checkBalanceChanged() is quite expensive on larger wallets as we loop mapWallet
several times for each balance-type.

There already is a periodical function pollBalanceChanged().
So instead of calling checkBalanceChanged() for each updated transaction, set a flag
fForceCheckBalanceChanged, which forces pollBalanceChanged() to check the balance
on the next run.

For example
importaddress mvqaxopu9Uef2qjXSV3fGrp6DcEYnCoYWK
adds like 20000 transactions to the wallet.
This means after rescan currently we loop mapWallet 120000 times,
just to check the balance, which causes 100% cpu for a while.

Unrelated change: Move showProgress signal after the QueueProcessing, so that the progressbar is still shown, while the 20000 txs get added to the GUI.
