### PR TITLE
univalue: avoid warning: array subscript is of type 'char'

### DIFF
--- a/src/univalue/univalue_write.cpp
+++ b/src/univalue/univalue_write.cpp
@@ -15,14 +15,14 @@ static const char *escapes[256];
 
 static void initJsonEscape()
 {
-    escapes['"'] = "\\\"";
-    escapes['\\'] = "\\\\";
-    escapes['/'] = "\\/";
-    escapes['\b'] = "\\b";
-    escapes['\f'] = "\\f";
-    escapes['\n'] = "\\n";
-    escapes['\r'] = "\\r";
-    escapes['\t'] = "\\t";
+    escapes[static_cast<unsigned char>('"')] = "\\\"";
+    escapes[static_cast<unsigned char>('\\')] = "\\\\";
+    escapes[static_cast<unsigned char>('/')] = "\\/";
+    escapes[static_cast<unsigned char>('\b')] = "\\b";
+    escapes[static_cast<unsigned char>('\f')] = "\\f";
+    escapes[static_cast<unsigned char>('\n')] = "\\n";
+    escapes[static_cast<unsigned char>('\r')] = "\\r";
+    escapes[static_cast<unsigned char>('\t')] = "\\t";
 
     initEscapes = true;
 }

--- a/src/univalue/univalue_write.cpp
+++ b/src/univalue/univalue_write.cpp
@@ -15,14 +15,14 @@ static const char *escapes[256];
 
 static void initJsonEscape()
 {
-    escapes['"'] = "\\\"";
-    escapes['\\'] = "\\\\";
-    escapes['/'] = "\\/";
-    escapes['\b'] = "\\b";
-    escapes['\f'] = "\\f";
-    escapes['\n'] = "\\n";
-    escapes['\r'] = "\\r";
-    escapes['\t'] = "\\t";
+    escapes[static_cast <unsigned char> ('"')] = "\\\"";
+    escapes[static_cast <unsigned char> ('\\')] = "\\\\";
+    escapes[static_cast <unsigned char> ('/')] = "\\/";
+    escapes[static_cast <unsigned char> ('\b')] = "\\b";
+    escapes[static_cast <unsigned char> ('\f')] = "\\f";
+    escapes[static_cast <unsigned char> ('\n')] = "\\n";
+    escapes[static_cast <unsigned char> ('\r')] = "\\r";
+    escapes[static_cast <unsigned char> ('\t')] = "\\t";
 
     initEscapes = true;
 }


### PR DESCRIPTION
To avoid on:
g++ --version
Configured with: --prefix=/Applications/Xcode.app/Contents/Developer/usr --with-gxx-include-dir=/usr/include/c++/4.2.1
Apple LLVM version 5.1 (clang-503.0.40) (based on LLVM 3.4svn)
Target: x86_64-apple-darwin13.3.0
Thread model: posix

the following warnings:
  CXX      univalue/univalue_write.o
univalue/univalue_write.cpp:33:12: warning: array subscript is of type 'char' [-Wchar-subscripts]
    escapes['"'] = "\\"";
           ^~~~
univalue/univalue_write.cpp:34:12: warning: array subscript is of type 'char' [-Wchar-subscripts]
    escapes['\'] = "\\";
           ^~~~~
univalue/univalue_write.cpp:35:12: warning: array subscript is of type 'char' [-Wchar-subscripts]
    escapes['/'] = "\/";
           ^~~~
univalue/univalue_write.cpp:36:12: warning: array subscript is of type 'char' [-Wchar-subscripts]
    escapes['\b'] = "\b";
           ^~~~~
univalue/univalue_write.cpp:37:12: warning: array subscript is of type 'char' [-Wchar-subscripts]
    escapes['\f'] = "\f";
           ^~~~~
univalue/univalue_write.cpp:38:12: warning: array subscript is of type 'char' [-Wchar-subscripts]
    escapes['\n'] = "\n";
           ^~~~~
univalue/univalue_write.cpp:39:12: warning: array subscript is of type 'char' [-Wchar-subscripts]
    escapes['\r'] = "\r";
           ^~~~~
univalue/univalue_write.cpp:40:12: warning: array subscript is of type 'char' [-Wchar-subscripts]
    escapes['\t'] = "\t";
           ^~~~~
8 warnings generated.
