### PR TITLE
Clean-up SyncWithWallets/SyncTransaction

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1022,7 +1022,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
         pool.addUnchecked(hash, entry);
     }
 
-    g_signals.SyncTransaction(tx, NULL);
+    SyncWithWallets(tx, NULL);
 
     return true;
 }
@@ -1856,10 +1856,6 @@ bool ConnectBlock(CBlock& block, CValidationState& state, CBlockIndex* pindex, C
 
     int64_t nTime3 = GetTimeMicros(); nTimeIndex += nTime3 - nTime2;
     LogPrint("bench", "    - Index writing: %.2fms [%.2fs]\n", 0.001 * (nTime3 - nTime2), nTimeIndex * 0.000001);
-
-    // Watch for transactions paying to me
-    BOOST_FOREACH(const CTransaction& tx, block.vtx)
-        g_signals.SyncTransaction(tx, &block);
 
     // Watch for changes to the previous coinbase transaction.
     static uint256 hashPrevBestCoinBase;

--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -738,9 +738,7 @@ Value sendrawtransaction(const Array& params, bool fHelp)
     if (!fHaveMempool && !fHaveChain) {
         // push to local node and sync with wallets
         CValidationState state;
-        if (AcceptToMemoryPool(mempool, state, tx, false, NULL, !fOverrideFees))
-            SyncWithWallets(tx, NULL);
-        else {
+        if (!AcceptToMemoryPool(mempool, state, tx, false, NULL, !fOverrideFees)) {
             if(state.IsInvalid())
                 throw JSONRPCError(RPC_TRANSACTION_REJECTED, strprintf("%i: %s", state.GetRejectCode(), state.GetRejectReason()));
             else


### PR DESCRIPTION
- replace g_signals.SyncTransaction with SyncWithWallets for consistence
- remove SyncTransaction from ConnectBlock. ConnectBlock is called from ConnectTip, we already sync there, no need to sync the txs twice.
- remove SyncWithWallets from sendrawtransaction. We call SyncWithWallets in AcceptToMemoryPool.

I tested sendrawtransaction, tx showed up in the GUI. Tested sending a tx, then start new wallet and wait for tx from block, tx showed up in the GUI.
