### PR TITLE
[Qt] Revert overviewpage from QFormLayout to QVBoxLayout

### DIFF
--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -13,8 +13,8 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QFormLayout" name="formLayout_3">
-   <item row="0" column="0" colspan="2">
+  <layout class="QVBoxLayout" name="topLayout">
+   <item>
     <widget class="QLabel" name="labelAlerts">
      <property name="visible">
       <bool>false</bool>
@@ -30,7 +30,7 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="1">
+   <item>
     <layout class="QHBoxLayout" name="horizontalLayout" stretch="1,1">
      <item>
       <layout class="QVBoxLayout" name="verticalLayout_2">


### PR DESCRIPTION
It doesnt make much difference on my desktop, but maybe this fixes #4705 ?

Not sure, why we changed the outer layout to a formLayout in the first place though.
