### PR TITLE
gui: remove redundant numTransactions tracking

### DIFF
--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -31,7 +31,6 @@ WalletModel::WalletModel(CWallet *wallet, OptionsModel *optionsModel, QObject *p
     transactionTableModel(0),
     recentRequestsTableModel(0),
     cachedBalance(0), cachedUnconfirmedBalance(0), cachedImmatureBalance(0),
-    cachedNumTransactions(0),
     cachedEncryptionStatus(Unencrypted),
     cachedNumBlocks(0)
 {
@@ -96,18 +95,6 @@ qint64 WalletModel::getWatchImmatureBalance() const
     return wallet->GetImmatureWatchOnlyBalance();
 }
 
-int WalletModel::getNumTransactions() const
-{
-    int numTransactions = 0;
-    {
-        LOCK(wallet->cs_wallet);
-        // the size of mapWallet contains the number of unique transaction IDs
-        // (e.g. payments to yourself generate 2 transactions, but both share the same transaction ID)
-        numTransactions = wallet->mapWallet.size();
-    }
-    return numTransactions;
-}
-
 void WalletModel::updateStatus()
 {
     EncryptionStatus newEncryptionStatus = getEncryptionStatus();
@@ -169,13 +156,6 @@ void WalletModel::updateTransaction(const QString &hash, int status)
 
     // Balance and number of transactions might have changed
     checkBalanceChanged();
-
-    int newNumTransactions = getNumTransactions();
-    if(cachedNumTransactions != newNumTransactions)
-    {
-        cachedNumTransactions = newNumTransactions;
-        emit numTransactionsChanged(newNumTransactions);
-    }
 }
 
 void WalletModel::updateAddressBook(const QString &address, const QString &label,

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -131,7 +131,6 @@ public:
     qint64 getWatchBalance() const;
     qint64 getWatchUnconfirmedBalance() const;
     qint64 getWatchImmatureBalance() const;
-    int getNumTransactions() const;
     EncryptionStatus getEncryptionStatus() const;
     bool processingQueuedTransactions() { return fProcessingQueuedTransactions; }
 
@@ -214,7 +213,6 @@ private:
     qint64 cachedWatchOnlyBalance;
     qint64 cachedWatchUnconfBalance;
     qint64 cachedWatchImmatureBalance;
-    qint64 cachedNumTransactions;
     EncryptionStatus cachedEncryptionStatus;
     int cachedNumBlocks;
 
@@ -228,9 +226,6 @@ signals:
     // Signal that balance in wallet changed
     void balanceChanged(qint64 balance, qint64 unconfirmedBalance, qint64 immatureBalance,
                         qint64 watchOnlyBalance, qint64 watchUnconfBalance, qint64 watchImmatureBalance);
-
-    // Number of transactions in wallet changed
-    void numTransactionsChanged(int count);
 
     // Encryption status of wallet changed
     void encryptionStatusChanged(int status);


### PR DESCRIPTION
This number was still tracked even though it's shown nowhere in the UI
anymore. It was originally removed because it didn't match the actual number of
records in the view (which contains outputs, not transactions) thus was
confusing people.
