### PR TITLE
Add rotation of outbound connections

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -300,6 +300,10 @@ public:
     // Whether a ping is requested.
     bool fPingQueued;
 
+    // We will drop a randomly chosen outbound connection at this time
+    static int64_t nTimeRotateOutbound;
+
+
     CNode(SOCKET hSocketIn, CAddress addrIn, std::string addrNameIn = "", bool fInboundIn=false) : ssSend(SER_NETWORK, INIT_PROTO_VERSION), setAddrKnown(5000)
     {
         nServices = 0;


### PR DESCRIPTION
Every 2-5 minutes choose a random outbound connection with probability
proportionally to its connected time and disconnect the corresponding
peer. This periodically rotates outbound connections and prevents a
Bitcoin client from being fingerprinted (the set of outbound connections
uniquely identifies a client). 
This is to initiate a discussion.
