### PR TITLE
Don't reveal whether password is <20 or >20 characters in RPC

### DIFF
--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -849,11 +849,10 @@ static bool HTTPReq_JSONRPC(AcceptedConnection *conn,
     if (!HTTPAuthorized(mapHeaders))
     {
         LogPrintf("ThreadRPCServer incorrect password attempt from %s\n", conn->peer_address_to_string());
-        /* Deter brute-forcing short passwords.
+        /* Deter brute-forcing
            If this results in a DoS the user really
            shouldn't have their RPC port exposed. */
-        if (mapArgs["-rpcpassword"].size() < 20)
-            MilliSleep(250);
+        MilliSleep(250);
 
         conn->stream() << HTTPError(HTTP_UNAUTHORIZED, false) << std::flush;
         return false;


### PR DESCRIPTION
As discussed on IRC.

It seems bad to base a decision to delay on the password length, as it leaks a tiny bit of information.

This doesn't change DoS potential as it is trivial to hold up all RPC threads in another way for someone in the rpcallowip list.
