### PR TITLE
Switch of the test framework from MAIN to REGTEST

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -38,6 +38,7 @@ BITCOIN_TESTS =\
   test/key_tests.cpp \
   test/main_tests.cpp \
   test/miner_tests.cpp \
+  test/blockv2_tests.cpp \
   test/mruset_tests.cpp \
   test/multisig_tests.cpp \
   test/netbase_tests.cpp \

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -193,13 +193,13 @@ public:
         nMinerThreads = 1;
         nTargetTimespan = 14 * 24 * 60 * 60; // two weeks
         nTargetSpacing = 10 * 60;
-        bnProofOfWorkLimit = ~uint256(0) >> 1;
+        bnProofOfWorkLimit = ~uint256(0); // No difficulty at all
         genesis.nTime = 1296688602;
-        genesis.nBits = 0x207fffff;
+        genesis.nBits = 0x2100FFFF; // use 1/-2^32 difficulty. Before 0x207fffff: This was 1-bit difficulty
         genesis.nNonce = 2;
         hashGenesisBlock = genesis.GetHash();
         nDefaultPort = 18444;
-        assert(hashGenesisBlock == uint256("0x0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206"));
+        assert(hashGenesisBlock == uint256("0x6aef2f4ed33f670b67505a79aa9bbff284c7bafb92f566736d095cf0acff1965"));
 
         vSeeds.clear();  // Regtest mode doesn't have any DNS seeds.
 

--- a/src/checkpoints.cpp
+++ b/src/checkpoints.cpp
@@ -74,7 +74,7 @@ namespace Checkpoints {
 
     static MapCheckpoints mapCheckpointsRegtest =
         boost::assign::map_list_of
-        ( 0, uint256("0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206"))
+        ( 0, uint256("0x6aef2f4ed33f670b67505a79aa9bbff284c7bafb92f566736d095cf0acff1965"))
         ;
     static const CCheckpointData dataRegtest = {
         &mapCheckpointsRegtest,

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -103,12 +103,12 @@ unsigned int ComputeMinWork(unsigned int nBase, int64_t nTime)
     // after Params().TargetSpacing()*2 time between blocks:
     if (Params().AllowMinDifficultyBlocks() && nTime > Params().TargetSpacing()*2)
         return bnLimit.GetCompact();
-	
-	// uint256 cannot multiply 0xfff...ff by 4, it overflows and returns a lower number
-	// so for RegTest at minimum difficulty, we must skip this
-	if (Params().NetworkID()==CBaseChainParams::REGTEST)
-		return bnLimit.GetCompact();
-		
+
+    // uint256 cannot multiply 0xfff...ff by 4, it overflows and returns a lower number
+    // so for RegTest at minimum difficulty, we must skip this
+    if (Params().NetworkID()==CBaseChainParams::REGTEST)
+        return bnLimit.GetCompact();
+
     uint256 bnResult;
     bnResult.SetCompact(nBase);
     while (nTime > 0 && bnResult < bnLimit)

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -103,7 +103,12 @@ unsigned int ComputeMinWork(unsigned int nBase, int64_t nTime)
     // after Params().TargetSpacing()*2 time between blocks:
     if (Params().AllowMinDifficultyBlocks() && nTime > Params().TargetSpacing()*2)
         return bnLimit.GetCompact();
-
+	
+	// uint256 cannot multiply 0xfff...ff by 4, it overflows and returns a lower number
+	// so for RegTest at minimum difficulty, we must skip this
+	if (Params().NetworkID()==CBaseChainParams::REGTEST)
+		return bnLimit.GetCompact();
+		
     uint256 bnResult;
     bnResult.SetCompact(nBase);
     while (nTime > 0 && bnResult < bnLimit)

--- a/src/test/Checkpoints_tests.cpp
+++ b/src/test/Checkpoints_tests.cpp
@@ -9,6 +9,7 @@
 #include "checkpoints.h"
 
 #include "uint256.h"
+#include "chainparams.h"
 
 #include <boost/test/unit_test.hpp>
 
@@ -20,6 +21,10 @@ BOOST_AUTO_TEST_CASE(sanity)
 {
     uint256 p11111 = uint256("0x0000000069e244f73d78e8fd29ba2fd2ed618bd6fa2ee92559f542fdb26e7c1d");
     uint256 p134444 = uint256("0x00000000000005b12ffd4cd315cd34ffd4a594f430ac814c91184a0d42d2b0fe");
+	
+	CBaseChainParams::Network prevParams = Params().NetworkID();
+	SelectParams(CBaseChainParams::MAIN);
+	
     BOOST_CHECK(Checkpoints::CheckBlock(11111, p11111));
     BOOST_CHECK(Checkpoints::CheckBlock(134444, p134444));
 
@@ -33,6 +38,8 @@ BOOST_AUTO_TEST_CASE(sanity)
     BOOST_CHECK(Checkpoints::CheckBlock(134444+1, p11111));
 
     BOOST_CHECK(Checkpoints::GetTotalBlocksEstimate() >= 134444);
+	
+	SelectParams(prevParams);
 }    
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/Checkpoints_tests.cpp
+++ b/src/test/Checkpoints_tests.cpp
@@ -21,10 +21,10 @@ BOOST_AUTO_TEST_CASE(sanity)
 {
     uint256 p11111 = uint256("0x0000000069e244f73d78e8fd29ba2fd2ed618bd6fa2ee92559f542fdb26e7c1d");
     uint256 p134444 = uint256("0x00000000000005b12ffd4cd315cd34ffd4a594f430ac814c91184a0d42d2b0fe");
-	
-	CBaseChainParams::Network prevParams = Params().NetworkID();
-	SelectParams(CBaseChainParams::MAIN);
-	
+
+    CBaseChainParams::Network prevParams = Params().NetworkID();
+    SelectParams(CBaseChainParams::MAIN);
+
     BOOST_CHECK(Checkpoints::CheckBlock(11111, p11111));
     BOOST_CHECK(Checkpoints::CheckBlock(134444, p134444));
 
@@ -38,8 +38,8 @@ BOOST_AUTO_TEST_CASE(sanity)
     BOOST_CHECK(Checkpoints::CheckBlock(134444+1, p11111));
 
     BOOST_CHECK(Checkpoints::GetTotalBlocksEstimate() >= 134444);
-	
-	SelectParams(prevParams);
+
+    SelectParams(prevParams);
 }    
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/DoS_tests.cpp
+++ b/src/test/DoS_tests.cpp
@@ -14,6 +14,7 @@
 #include "pow.h"
 #include "script.h"
 #include "serialize.h"
+#include "chainparams.h"
 
 #include <stdint.h>
 
@@ -126,6 +127,9 @@ BOOST_AUTO_TEST_CASE(DoS_checknbits)
         (1296207707,453179945)(1302624061,453036989)(1309640330,437004818)
         (1313172719,436789733);
 
+	CBaseChainParams::Network prevParams = Params().NetworkID();
+	SelectParams(CBaseChainParams::MAIN);
+	
     // Make sure CheckNBits considers every combination of block-chain-lock-in-points
     // "sane":
     BOOST_FOREACH(const BlockData::value_type& i, chainData)
@@ -147,6 +151,8 @@ BOOST_AUTO_TEST_CASE(DoS_checknbits)
 
     // ... but OK if enough time passed for difficulty to adjust downward:
     BOOST_CHECK(CheckNBits(firstcheck.second, lastcheck.first+60*60*24*365*4, lastcheck.second, lastcheck.first));
+	
+	SelectParams(prevParams);
 }
 
 CTransaction RandomOrphan()

--- a/src/test/DoS_tests.cpp
+++ b/src/test/DoS_tests.cpp
@@ -127,9 +127,9 @@ BOOST_AUTO_TEST_CASE(DoS_checknbits)
         (1296207707,453179945)(1302624061,453036989)(1309640330,437004818)
         (1313172719,436789733);
 
-	CBaseChainParams::Network prevParams = Params().NetworkID();
-	SelectParams(CBaseChainParams::MAIN);
-	
+    CBaseChainParams::Network prevParams = Params().NetworkID();
+    SelectParams(CBaseChainParams::MAIN);
+
     // Make sure CheckNBits considers every combination of block-chain-lock-in-points
     // "sane":
     BOOST_FOREACH(const BlockData::value_type& i, chainData)
@@ -151,8 +151,8 @@ BOOST_AUTO_TEST_CASE(DoS_checknbits)
 
     // ... but OK if enough time passed for difficulty to adjust downward:
     BOOST_CHECK(CheckNBits(firstcheck.second, lastcheck.first+60*60*24*365*4, lastcheck.second, lastcheck.first));
-	
-	SelectParams(prevParams);
+
+    SelectParams(prevParams);
 }
 
 CTransaction RandomOrphan()

--- a/src/test/alert_tests.cpp
+++ b/src/test/alert_tests.cpp
@@ -12,12 +12,14 @@
 #include "serialize.h"
 #include "util.h"
 #include "version.h"
+#include "chainparams.h"
 
 #include <fstream>
 
 #include <boost/filesystem/operations.hpp>
 #include <boost/foreach.hpp>
 #include <boost/test/unit_test.hpp>
+
 
 #if 0
 //
@@ -78,8 +80,12 @@
 
 struct ReadAlerts
 {
+	CBaseChainParams::Network prevParams;
     ReadAlerts()
     {
+		prevParams = Params().NetworkID();
+		SelectParams(CBaseChainParams::MAIN);
+		
         std::vector<unsigned char> vch(alert_tests::alertTests, alert_tests::alertTests + sizeof(alert_tests::alertTests));
         CDataStream stream(vch, SER_DISK, CLIENT_VERSION);
         try {
@@ -92,7 +98,9 @@ struct ReadAlerts
         }
         catch (std::exception) { }
     }
-    ~ReadAlerts() { }
+    ~ReadAlerts() { 
+		SelectParams(prevParams);
+	}
 
     static std::vector<std::string> read_lines(boost::filesystem::path filepath)
     {
@@ -114,7 +122,10 @@ BOOST_FIXTURE_TEST_SUITE(Alert_tests, ReadAlerts)
 
 BOOST_AUTO_TEST_CASE(AlertApplies)
 {
+	
+	
     SetMockTime(11);
+
 
     BOOST_FOREACH(const CAlert& alert, alerts)
     {
@@ -149,6 +160,8 @@ BOOST_AUTO_TEST_CASE(AlertApplies)
     BOOST_CHECK(!alerts[2].AppliesTo(1, "/Satoshi:0.3.0/"));
 
     SetMockTime(0);
+	
+	
 }
 
 

--- a/src/test/alert_tests.cpp
+++ b/src/test/alert_tests.cpp
@@ -80,12 +80,12 @@
 
 struct ReadAlerts
 {
-	CBaseChainParams::Network prevParams;
+    CBaseChainParams::Network prevParams;
     ReadAlerts()
     {
-		prevParams = Params().NetworkID();
-		SelectParams(CBaseChainParams::MAIN);
-		
+        prevParams = Params().NetworkID();
+        SelectParams(CBaseChainParams::MAIN);
+
         std::vector<unsigned char> vch(alert_tests::alertTests, alert_tests::alertTests + sizeof(alert_tests::alertTests));
         CDataStream stream(vch, SER_DISK, CLIENT_VERSION);
         try {
@@ -99,8 +99,8 @@ struct ReadAlerts
         catch (std::exception) { }
     }
     ~ReadAlerts() { 
-		SelectParams(prevParams);
-	}
+    SelectParams(prevParams);
+    }
 
     static std::vector<std::string> read_lines(boost::filesystem::path filepath)
     {
@@ -122,10 +122,8 @@ BOOST_FIXTURE_TEST_SUITE(Alert_tests, ReadAlerts)
 
 BOOST_AUTO_TEST_CASE(AlertApplies)
 {
-	
-	
-    SetMockTime(11);
 
+    SetMockTime(11);
 
     BOOST_FOREACH(const CAlert& alert, alerts)
     {
@@ -160,8 +158,7 @@ BOOST_AUTO_TEST_CASE(AlertApplies)
     BOOST_CHECK(!alerts[2].AppliesTo(1, "/Satoshi:0.3.0/"));
 
     SetMockTime(0);
-	
-	
+
 }
 
 

--- a/src/test/base58_tests.cpp
+++ b/src/test/base58_tests.cpp
@@ -12,6 +12,7 @@
 #include "script.h"
 #include "uint256.h"
 #include "util.h"
+#include "chainparams.h"
 
 #include <boost/foreach.hpp>
 #include <boost/test/unit_test.hpp>
@@ -126,7 +127,7 @@ BOOST_AUTO_TEST_CASE(base58_keys_valid_parse)
     std::vector<unsigned char> result;
     CBitcoinSecret secret;
     CBitcoinAddress addr;
-
+	CBaseChainParams::Network prevParams = Params().NetworkID();
     BOOST_FOREACH(Value& tv, tests)
     {
         Array test = tv.get_array();
@@ -141,6 +142,7 @@ BOOST_AUTO_TEST_CASE(base58_keys_valid_parse)
         const Object &metadata = test[2].get_obj();
         bool isPrivkey = find_value(metadata, "isPrivkey").get_bool();
         bool isTestnet = find_value(metadata, "isTestnet").get_bool();
+		
         if (isTestnet)
             SelectParams(CBaseChainParams::TESTNET);
         else
@@ -175,7 +177,7 @@ BOOST_AUTO_TEST_CASE(base58_keys_valid_parse)
             BOOST_CHECK_MESSAGE(!secret.IsValid(), "IsValid pubkey as privkey:" + strTest);
         }
     }
-    SelectParams(CBaseChainParams::MAIN);
+    SelectParams(prevParams);
 }
 
 // Goal: check that generated keys match test vectors
@@ -183,6 +185,7 @@ BOOST_AUTO_TEST_CASE(base58_keys_valid_gen)
 {
     Array tests = read_json(std::string(json_tests::base58_keys_valid, json_tests::base58_keys_valid + sizeof(json_tests::base58_keys_valid)));
     std::vector<unsigned char> result;
+	CBaseChainParams::Network prevParams = Params().NetworkID();
     BOOST_FOREACH(Value& tv, tests)
     {
         Array test = tv.get_array();
@@ -197,6 +200,7 @@ BOOST_AUTO_TEST_CASE(base58_keys_valid_gen)
         const Object &metadata = test[2].get_obj();
         bool isPrivkey = find_value(metadata, "isPrivkey").get_bool();
         bool isTestnet = find_value(metadata, "isTestnet").get_bool();
+		
         if (isTestnet)
             SelectParams(CBaseChainParams::TESTNET);
         else
@@ -243,7 +247,7 @@ BOOST_AUTO_TEST_CASE(base58_keys_valid_gen)
     CTxDestination nodest = CNoDestination();
     BOOST_CHECK(!dummyAddr.Set(nodest));
 
-    SelectParams(CBaseChainParams::MAIN);
+    SelectParams(prevParams);
 }
 
 // Goal: check that base58 parsing code is robust against a variety of corrupted data

--- a/src/test/base58_tests.cpp
+++ b/src/test/base58_tests.cpp
@@ -127,7 +127,7 @@ BOOST_AUTO_TEST_CASE(base58_keys_valid_parse)
     std::vector<unsigned char> result;
     CBitcoinSecret secret;
     CBitcoinAddress addr;
-	CBaseChainParams::Network prevParams = Params().NetworkID();
+    CBaseChainParams::Network prevParams = Params().NetworkID();
     BOOST_FOREACH(Value& tv, tests)
     {
         Array test = tv.get_array();
@@ -142,7 +142,7 @@ BOOST_AUTO_TEST_CASE(base58_keys_valid_parse)
         const Object &metadata = test[2].get_obj();
         bool isPrivkey = find_value(metadata, "isPrivkey").get_bool();
         bool isTestnet = find_value(metadata, "isTestnet").get_bool();
-		
+
         if (isTestnet)
             SelectParams(CBaseChainParams::TESTNET);
         else
@@ -185,7 +185,7 @@ BOOST_AUTO_TEST_CASE(base58_keys_valid_gen)
 {
     Array tests = read_json(std::string(json_tests::base58_keys_valid, json_tests::base58_keys_valid + sizeof(json_tests::base58_keys_valid)));
     std::vector<unsigned char> result;
-	CBaseChainParams::Network prevParams = Params().NetworkID();
+    CBaseChainParams::Network prevParams = Params().NetworkID();
     BOOST_FOREACH(Value& tv, tests)
     {
         Array test = tv.get_array();
@@ -200,7 +200,7 @@ BOOST_AUTO_TEST_CASE(base58_keys_valid_gen)
         const Object &metadata = test[2].get_obj();
         bool isPrivkey = find_value(metadata, "isPrivkey").get_bool();
         bool isTestnet = find_value(metadata, "isTestnet").get_bool();
-		
+
         if (isTestnet)
             SelectParams(CBaseChainParams::TESTNET);
         else

--- a/src/test/blockv2_tests.cpp
+++ b/src/test/blockv2_tests.cpp
@@ -1,0 +1,231 @@
+// Copyright (c) 2011-2014 The Bitcoin Core developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "main.h"
+#include "miner.h"
+#include "uint256.h"
+#include "util.h"
+
+#include <boost/test/unit_test.hpp>
+
+// Tests the majority rule which states that after 1000 v2 blocks no v1 block can go
+BOOST_AUTO_TEST_SUITE(blockv2_tests)
+
+static CScript scriptPubKey = CScript() << ParseHex("04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5f") << OP_CHECKSIG;
+
+static void SetEmptyBlock(CBlock * pblock)
+{
+        pblock->nVersion = 2;
+        pblock->nTime = chainActive.Tip()->GetMedianTimePast()+1;
+        pblock->nNonce = 0;
+}
+        
+static void SetBlockDefaultAttributesAndHeight(CBlock * pblock,bool addHeight,int difValue)
+{
+        SetEmptyBlock(pblock);
+
+        // Add the coinbase
+        CMutableTransaction txCoinbase(pblock->vtx[0]);
+        
+        if (addHeight) 
+            txCoinbase.vin[0].scriptSig = (CScript() << (chainActive.Height()+1+difValue) << 0);
+            else
+            txCoinbase.vin[0].scriptSig = (CScript() << difValue << 0); // At least size 2, this is a protocol spec
+            
+        txCoinbase.vout[0].scriptPubKey = CScript();
+        pblock->vtx[0] = CTransaction(txCoinbase);
+        pblock->hashMerkleRoot = pblock->BuildMerkleTree();
+}
+
+void CheckSubsidyHalving(CBlockTemplate * &pblocktemplate, CBlock * &pblock)
+{
+	if ((chainActive.Height()+1) % Params().SubsidyHalvingInterval() == 0)
+		 {
+			// The RegTest network has a low subsidy halving interval (150) so 
+			// we must recompute the coinbase subsidy if we reach the boundary.
+			
+			// preserve parent hash
+			uint256 prevParent = pblock->hashPrevBlock;
+			delete pblocktemplate;
+			pblocktemplate = CreateNewBlock(scriptPubKey);   
+			pblock = &pblocktemplate->block; // pointer for convenience
+			pblock->hashPrevBlock = prevParent;
+		 }
+}
+
+void Blockv2test()
+{
+    assert(Params().NetworkID() == CBaseChainParams::REGTEST); 
+	
+	// We don't know the state of the block-chain here: it depends on which other tests are run before this test.
+	// See https://github.com/bitcoin/bitcoin/pull/4688 for a patch that allows the re-creation of the block-chain
+	// for each testcase that requires it.
+
+	// If miner_tests.cpp is run before, the chain will be 100 blocks long, and all of them will be v1
+	
+    
+    LogPrintf("Blockv2test testcase starts\n"); 
+        
+    CBlockTemplate *pblocktemplate;
+    CScript script;
+    uint256 hash;
+	int PreviousHeight;
+
+    
+    LOCK(cs_main);
+        
+    
+    // Simple block creation, nothing special yet.
+    pblocktemplate = CreateNewBlock(scriptPubKey);   
+    CBlock *pblock = &pblocktemplate->block; // pointer for convenience
+   
+    LogPrintf("Blockv2test block v1 add begin\n");  
+    // First create a block v1, check that it is accepted. The block has an invalid height
+    SetBlockDefaultAttributesAndHeight(pblock,false,5000);
+    pblock->nVersion = 1;
+    CValidationState state1;
+	PreviousHeight = chainActive.Height();
+    BOOST_CHECK(ProcessBlock(state1, NULL, pblock));
+    BOOST_CHECK(state1.IsValid());
+	BOOST_CHECK((PreviousHeight+1) == chainActive.Height()); // to differentiate from orphan blocks, which also get accepted in ProcessBlock()	
+    pblock->hashPrevBlock = pblock->GetHash(); // update parent
+    
+    
+    // Now create exactly 1000 blocks v2
+    
+    // First check that the supermajority threshold is exactly 1000 blocks
+    BOOST_CHECK(Params().ToCheckBlockUpgradeMajority()==1000);  // 
+    BOOST_CHECK(Params().EnforceBlockUpgradeMajority()==750);
+    BOOST_CHECK(Params().RejectBlockOutdatedMajority()==950);
+    
+    // Over the last 1000 blocks, 750 blocks must be v2 to switch to v2-only mode.
+    // Here we're testing only the last 750, not any subset.
+    
+    LogPrintf("Blockv2test BIP30 repetition begin\n");  
+	
+    // First, if we try to add a block v2 with the same coinbase tx, we should get
+    // "bad-txns-BIP30" because the coinbase tx has the same hash as the previous.
+    // Unluckily, even if ConnectBlock returns a "bad-txns-BIP30", ActivateBestChainStep clears
+    // the state, so we get true here and the "bad-txns-BIP30" reason is lost.
+    // We verify instead that the chain height has not been incremented.
+    
+    CValidationState state7;
+    PreviousHeight = chainActive.Height();
+	CheckSubsidyHalving(pblocktemplate,pblock);	
+    SetBlockDefaultAttributesAndHeight(pblock,false,5000); //
+    pblock->nVersion = 2;
+    BOOST_CHECK(ProcessBlock(state7, NULL, pblock)); // should we care about the return value?
+    BOOST_CHECK(state7.IsValid());
+    BOOST_CHECK(PreviousHeight == chainActive.Height()); // we check the block has not been added.
+    
+    LogPrintf("Blockv2test 750 v2 blocks  begin\n");    
+    for (int i=0;i<750;i++) 
+    {
+        
+        LogPrintf("Blockv2test block %d begin\n",i);    
+		
+		CheckSubsidyHalving(pblocktemplate,pblock);	
+       
+        // We add a value to the height to make is NOT equal to the actual height.
+        SetBlockDefaultAttributesAndHeight(pblock,true,1000); // blocks version 2 without height are allowed! for only 750 blocks
+        pblock->nVersion = 2;
+        CValidationState state;
+                    
+		PreviousHeight = chainActive.Height();
+        BOOST_CHECK(ProcessBlock(state, NULL, pblock));
+        BOOST_CHECK(state.IsValid());
+		BOOST_CHECK((PreviousHeight+1) == chainActive.Height()); // to differentiate from orphan blocks, which also get accepted in ProcessBlock()
+        pblock->hashPrevBlock = pblock->GetHash(); // update parent
+    }
+
+    LogPrintf("Blockv2test v2 without height rejected begin\n"); 
+    
+    // Now we try to add a block v2, with an invalid height and it should be rejected. We use 2000 because is not in the range [1000..1750].
+	CheckSubsidyHalving(pblocktemplate,pblock);	
+    SetBlockDefaultAttributesAndHeight(pblock,true,2000); // 
+    pblock->nVersion = 2;
+    CValidationState state0;
+    BOOST_CHECK(ProcessBlock(state0, NULL, pblock)==false);
+    BOOST_CHECK(!state0.IsValid());
+    BOOST_CHECK(state0.GetRejectReason()=="bad-cb-height"); 
+    // Do not update parent since block has failed
+    
+    LogPrintf("Blockv2test v2 with height accepted begin\n");    
+    
+    
+    // Now we add a block with height, must be ok.
+    for (int i=0;i<200;i++) 
+    {
+        
+        LogPrintf("Blockv2test v2block %d begin\n",i);      
+		CheckSubsidyHalving(pblocktemplate,pblock);
+        SetBlockDefaultAttributesAndHeight(pblock,true,0);
+        pblock->nVersion = 2;
+        CValidationState state;
+		PreviousHeight = chainActive.Height();
+        BOOST_CHECK(ProcessBlock(state, NULL, pblock));
+        BOOST_CHECK(state.IsValid());
+		BOOST_CHECK((PreviousHeight+1) == chainActive.Height()); // to differentiate from orphan blocks, which also get accepted in ProcessBlock()
+		
+        pblock->hashPrevBlock = pblock->GetHash(); // update parent
+    }
+
+    
+    LogPrintf("Blockv2test block v1 rejected\n");   
+    // Now we add 200 additional blocks, until we get 950 (the threshold were v1 blocks are not accepted anymore)
+    // Now we try to add a block v1, it should be rejected, even if it hash the height field
+	CheckSubsidyHalving(pblocktemplate,pblock);	
+    SetBlockDefaultAttributesAndHeight(pblock,true,0);
+    pblock->nVersion = 1;
+    CValidationState state2;
+    BOOST_CHECK(ProcessBlock(state2, NULL, pblock)==false);
+    BOOST_CHECK(!state2.IsValid());
+    BOOST_CHECK(state2.GetRejectReason()=="bad-version");
+    // Do not update parent since block has failed
+    
+    
+    
+    // Some other missing tests, added here as bonus...
+    
+	// Block time too old check
+	CheckSubsidyHalving(pblocktemplate,pblock);	
+    SetBlockDefaultAttributesAndHeight(pblock,true,0);
+    pblock->nVersion = 2;
+    pblock->nTime = chainActive.Tip()->GetMedianTimePast()-1;
+    CValidationState state4;
+    BOOST_CHECK(ProcessBlock(state4, NULL, pblock)==false);
+    BOOST_CHECK(!state4.IsValid());
+    BOOST_CHECK(state4.GetRejectReason()=="time-too-old");
+    // Do not update parent since block has failed
+    
+    // Adding a non-final coinbase, must modify coinbase
+	CheckSubsidyHalving(pblocktemplate,pblock);	
+    SetEmptyBlock(pblock);
+    // Use a mutable coinbase to change nLockTime and  nSequence
+    CMutableTransaction txCoinbase(pblock->vtx[0]);
+    txCoinbase.vin[0].scriptSig = (CScript() << chainActive.Height() << 0); 
+    txCoinbase.nLockTime = LOCKTIME_THRESHOLD-1; // refers to height
+    txCoinbase.vin[0].nSequence = 1; // non-zero sequence
+    pblock->vtx[0] = CTransaction(txCoinbase);
+    pblock->nVersion = 2;
+    pblock->hashMerkleRoot = pblock->BuildMerkleTree();
+    CValidationState state5;
+    BOOST_CHECK(ProcessBlock(state5, NULL, pblock)==false);
+    BOOST_CHECK(!state5.IsValid());
+    BOOST_CHECK(state5.GetRejectReason()=="bad-txns-nonfinal");
+    // Do not update parent since block has failed
+    
+    
+    delete pblocktemplate;
+    
+    
+    LogPrintf("Blockv2test testcase ends\n");   
+}
+
+BOOST_AUTO_TEST_CASE(Blockv2testcase)
+{
+    Blockv2test();
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/bloom_tests.cpp
+++ b/src/test/bloom_tests.cpp
@@ -83,10 +83,10 @@ BOOST_AUTO_TEST_CASE(bloom_create_insert_serialize_with_tweak)
 BOOST_AUTO_TEST_CASE(bloom_create_insert_key)
 {
     string strSecret = string("5Kg1gnAjaLfKiwhhPpGS3QfRg2m6awQvaj98JCZBZQ5SuS2F15C");
-	
-	CBaseChainParams::Network prevParams = Params().NetworkID();
-	SelectParams(CBaseChainParams::MAIN);
-	
+
+    CBaseChainParams::Network prevParams = Params().NetworkID();
+    SelectParams(CBaseChainParams::MAIN);
+
     CBitcoinSecret vchSecret;
     BOOST_CHECK(vchSecret.SetString(strSecret));
 
@@ -109,8 +109,8 @@ BOOST_AUTO_TEST_CASE(bloom_create_insert_key)
         expected[i] = (char)vch[i];
 
     BOOST_CHECK_EQUAL_COLLECTIONS(stream.begin(), stream.end(), expected.begin(), expected.end());
-	
-	SelectParams(prevParams);
+
+    SelectParams(prevParams);
 }
 
 BOOST_AUTO_TEST_CASE(bloom_match)

--- a/src/test/bloom_tests.cpp
+++ b/src/test/bloom_tests.cpp
@@ -10,6 +10,7 @@
 #include "serialize.h"
 #include "uint256.h"
 #include "util.h"
+#include "chainparams.h"
 
 #include <vector>
 
@@ -82,6 +83,10 @@ BOOST_AUTO_TEST_CASE(bloom_create_insert_serialize_with_tweak)
 BOOST_AUTO_TEST_CASE(bloom_create_insert_key)
 {
     string strSecret = string("5Kg1gnAjaLfKiwhhPpGS3QfRg2m6awQvaj98JCZBZQ5SuS2F15C");
+	
+	CBaseChainParams::Network prevParams = Params().NetworkID();
+	SelectParams(CBaseChainParams::MAIN);
+	
     CBitcoinSecret vchSecret;
     BOOST_CHECK(vchSecret.SetString(strSecret));
 
@@ -104,6 +109,8 @@ BOOST_AUTO_TEST_CASE(bloom_create_insert_key)
         expected[i] = (char)vch[i];
 
     BOOST_CHECK_EQUAL_COLLECTIONS(stream.begin(), stream.end(), expected.begin(), expected.end());
+	
+	SelectParams(prevParams);
 }
 
 BOOST_AUTO_TEST_CASE(bloom_match)

--- a/src/test/key_tests.cpp
+++ b/src/test/key_tests.cpp
@@ -63,10 +63,10 @@ BOOST_AUTO_TEST_SUITE(key_tests)
 BOOST_AUTO_TEST_CASE(key_test1)
 {
     CBitcoinSecret bsecret1, bsecret2, bsecret1C, bsecret2C, baddress1;
-	
-	CBaseChainParams::Network prevParams = Params().NetworkID();
-	SelectParams(CBaseChainParams::MAIN);
-	
+
+    CBaseChainParams::Network prevParams = Params().NetworkID();
+    SelectParams(CBaseChainParams::MAIN);
+
     BOOST_CHECK( bsecret1.SetString (strSecret1));
     BOOST_CHECK( bsecret2.SetString (strSecret2));
     BOOST_CHECK( bsecret1C.SetString(strSecret1C));
@@ -147,7 +147,7 @@ BOOST_AUTO_TEST_CASE(key_test1)
         BOOST_CHECK(rkey1C == pubkey1C);
         BOOST_CHECK(rkey2C == pubkey2C);
     }
-	SelectParams(prevParams);
+    SelectParams(prevParams);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/key_tests.cpp
+++ b/src/test/key_tests.cpp
@@ -8,6 +8,7 @@
 #include "script.h"
 #include "uint256.h"
 #include "util.h"
+#include "chainparams.h"
 
 #include <string>
 #include <vector>
@@ -62,6 +63,10 @@ BOOST_AUTO_TEST_SUITE(key_tests)
 BOOST_AUTO_TEST_CASE(key_test1)
 {
     CBitcoinSecret bsecret1, bsecret2, bsecret1C, bsecret2C, baddress1;
+	
+	CBaseChainParams::Network prevParams = Params().NetworkID();
+	SelectParams(CBaseChainParams::MAIN);
+	
     BOOST_CHECK( bsecret1.SetString (strSecret1));
     BOOST_CHECK( bsecret2.SetString (strSecret2));
     BOOST_CHECK( bsecret1C.SetString(strSecret1C));
@@ -142,6 +147,7 @@ BOOST_AUTO_TEST_CASE(key_test1)
         BOOST_CHECK(rkey1C == pubkey1C);
         BOOST_CHECK(rkey2C == pubkey2C);
     }
+	SelectParams(prevParams);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/main_tests.cpp
+++ b/src/test/main_tests.cpp
@@ -13,9 +13,9 @@ BOOST_AUTO_TEST_SUITE(main_tests)
 BOOST_AUTO_TEST_CASE(subsidy_limit_test)
 {
     uint64_t nSum = 0;
-	CBaseChainParams::Network prevParams = Params().NetworkID();
-	SelectParams(CBaseChainParams::MAIN);
-	
+    CBaseChainParams::Network prevParams = Params().NetworkID();
+    SelectParams(CBaseChainParams::MAIN);
+
     for (int nHeight = 0; nHeight < 14000000; nHeight += 1000) {
         uint64_t nSubsidy = GetBlockValue(nHeight, 0);
         BOOST_CHECK(nSubsidy <= 50 * COIN);
@@ -23,8 +23,8 @@ BOOST_AUTO_TEST_CASE(subsidy_limit_test)
         BOOST_CHECK(MoneyRange(nSum));
     }
     BOOST_CHECK(nSum == 2099999997690000ULL);
-	
-	SelectParams(prevParams);
+
+    SelectParams(prevParams);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/main_tests.cpp
+++ b/src/test/main_tests.cpp
@@ -4,6 +4,7 @@
 
 #include "core.h"
 #include "main.h"
+#include "chainparams.h"
 
 #include <boost/test/unit_test.hpp>
 
@@ -12,6 +13,9 @@ BOOST_AUTO_TEST_SUITE(main_tests)
 BOOST_AUTO_TEST_CASE(subsidy_limit_test)
 {
     uint64_t nSum = 0;
+	CBaseChainParams::Network prevParams = Params().NetworkID();
+	SelectParams(CBaseChainParams::MAIN);
+	
     for (int nHeight = 0; nHeight < 14000000; nHeight += 1000) {
         uint64_t nSubsidy = GetBlockValue(nHeight, 0);
         BOOST_CHECK(nSubsidy <= 50 * COIN);
@@ -19,6 +23,8 @@ BOOST_AUTO_TEST_CASE(subsidy_limit_test)
         BOOST_CHECK(MoneyRange(nSum));
     }
     BOOST_CHECK(nSum == 2099999997690000ULL);
+	
+	SelectParams(prevParams);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -11,40 +11,6 @@
 
 BOOST_AUTO_TEST_SUITE(miner_tests)
 
-static
-struct {
-    unsigned char extranonce;
-    unsigned int nonce;
-} blockinfo[] = {
-    {4, 0xa4a3e223}, {2, 0x15c32f9e}, {1, 0x0375b547}, {1, 0x7004a8a5},
-    {2, 0xce440296}, {2, 0x52cfe198}, {1, 0x77a72cd0}, {2, 0xbb5d6f84},
-    {2, 0x83f30c2c}, {1, 0x48a73d5b}, {1, 0xef7dcd01}, {2, 0x6809c6c4},
-    {2, 0x0883ab3c}, {1, 0x087bbbe2}, {2, 0x2104a814}, {2, 0xdffb6daa},
-    {1, 0xee8a0a08}, {2, 0xba4237c1}, {1, 0xa70349dc}, {1, 0x344722bb},
-    {3, 0xd6294733}, {2, 0xec9f5c94}, {2, 0xca2fbc28}, {1, 0x6ba4f406},
-    {2, 0x015d4532}, {1, 0x6e119b7c}, {2, 0x43e8f314}, {2, 0x27962f38},
-    {2, 0xb571b51b}, {2, 0xb36bee23}, {2, 0xd17924a8}, {2, 0x6bc212d9},
-    {1, 0x630d4948}, {2, 0x9a4c4ebb}, {2, 0x554be537}, {1, 0xd63ddfc7},
-    {2, 0xa10acc11}, {1, 0x759a8363}, {2, 0xfb73090d}, {1, 0xe82c6a34},
-    {1, 0xe33e92d7}, {3, 0x658ef5cb}, {2, 0xba32ff22}, {5, 0x0227a10c},
-    {1, 0xa9a70155}, {5, 0xd096d809}, {1, 0x37176174}, {1, 0x830b8d0f},
-    {1, 0xc6e3910e}, {2, 0x823f3ca8}, {1, 0x99850849}, {1, 0x7521fb81},
-    {1, 0xaacaabab}, {1, 0xd645a2eb}, {5, 0x7aea1781}, {5, 0x9d6e4b78},
-    {1, 0x4ce90fd8}, {1, 0xabdc832d}, {6, 0x4a34f32a}, {2, 0xf2524c1c},
-    {2, 0x1bbeb08a}, {1, 0xad47f480}, {1, 0x9f026aeb}, {1, 0x15a95049},
-    {2, 0xd1cb95b2}, {2, 0xf84bbda5}, {1, 0x0fa62cd1}, {1, 0xe05f9169},
-    {1, 0x78d194a9}, {5, 0x3e38147b}, {5, 0x737ba0d4}, {1, 0x63378e10},
-    {1, 0x6d5f91cf}, {2, 0x88612eb8}, {2, 0xe9639484}, {1, 0xb7fabc9d},
-    {2, 0x19b01592}, {1, 0x5a90dd31}, {2, 0x5bd7e028}, {2, 0x94d00323},
-    {1, 0xa9b9c01a}, {1, 0x3a40de61}, {1, 0x56e7eec7}, {5, 0x859f7ef6},
-    {1, 0xfd8e5630}, {1, 0x2b0c9f7f}, {1, 0xba700e26}, {1, 0x7170a408},
-    {1, 0x70de86a8}, {1, 0x74d64cd5}, {1, 0x49e738a1}, {2, 0x6910b602},
-    {0, 0x643c565f}, {1, 0x54264b3f}, {2, 0x97ea6396}, {2, 0x55174459},
-    {2, 0x03e8779a}, {1, 0x98f34d8f}, {1, 0xc07b2b07}, {1, 0xdfe29668},
-    {1, 0x3141c7c1}, {1, 0xb3b595f4}, {1, 0x735abf08}, {5, 0x623bfbce},
-    {2, 0xd351e722}, {1, 0xf4ca48c9}, {1, 0x5b19c670}, {1, 0xa164bf0e},
-    {2, 0xbbbeb305}, {2, 0xfe1c810a},
-};
 
 // NOTE: These tests rely on CreateNewBlock doing its own self-validation!
 BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
@@ -63,21 +29,20 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     // We can't make transactions until we have inputs
     // Therefore, load 100 blocks :)
     std::vector<CTransaction*>txFirst;
-    for (unsigned int i = 0; i < sizeof(blockinfo)/sizeof(*blockinfo); ++i)
+    for (unsigned int i = 0; i < 110; ++i)
     {
         CBlock *pblock = &pblocktemplate->block; // pointer for convenience
         pblock->nVersion = 1;
         pblock->nTime = chainActive.Tip()->GetMedianTimePast()+1;
-        CMutableTransaction txCoinbase(pblock->vtx[0]);
+		CMutableTransaction txCoinbase(pblock->vtx[0]);
         txCoinbase.vin[0].scriptSig = CScript();
-        txCoinbase.vin[0].scriptSig.push_back(blockinfo[i].extranonce);
+        txCoinbase.vin[0].scriptSig.push_back(i);
         txCoinbase.vin[0].scriptSig.push_back(chainActive.Height());
         txCoinbase.vout[0].scriptPubKey = CScript();
-        pblock->vtx[0] = CTransaction(txCoinbase);
+        pblock->vtx[0] = CTransaction(txCoinbase);		
         if (txFirst.size() < 2)
             txFirst.push_back(new CTransaction(pblock->vtx[0]));
         pblock->hashMerkleRoot = pblock->BuildMerkleTree();
-        pblock->nNonce = blockinfo[i].nonce;
         CValidationState state;
         BOOST_CHECK(ProcessBlock(state, NULL, pblock));
         BOOST_CHECK(state.IsValid());
@@ -253,6 +218,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
 
     chainActive.Tip()->nHeight--;
     SetMockTime(0);
+	mempool.clear();
 
     BOOST_FOREACH(CTransaction *tx, txFirst)
         delete tx;

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -34,12 +34,12 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
         CBlock *pblock = &pblocktemplate->block; // pointer for convenience
         pblock->nVersion = 1;
         pblock->nTime = chainActive.Tip()->GetMedianTimePast()+1;
-		CMutableTransaction txCoinbase(pblock->vtx[0]);
+        CMutableTransaction txCoinbase(pblock->vtx[0]);
         txCoinbase.vin[0].scriptSig = CScript();
         txCoinbase.vin[0].scriptSig.push_back(i);
         txCoinbase.vin[0].scriptSig.push_back(chainActive.Height());
         txCoinbase.vout[0].scriptPubKey = CScript();
-        pblock->vtx[0] = CTransaction(txCoinbase);		
+        pblock->vtx[0] = CTransaction(txCoinbase);
         if (txFirst.size() < 2)
             txFirst.push_back(new CTransaction(pblock->vtx[0]));
         pblock->hashMerkleRoot = pblock->BuildMerkleTree();
@@ -218,7 +218,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
 
     chainActive.Tip()->nHeight--;
     SetMockTime(0);
-	mempool.clear();
+    mempool.clear();
 
     BOOST_FOREACH(CTransaction *tx, txFirst)
         delete tx;

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -53,7 +53,7 @@ BOOST_AUTO_TEST_CASE(rpc_rawparams)
 {
     // Test raw transaction API argument handling
     Value r;
-	
+
     BOOST_CHECK_THROW(CallRPC("getrawtransaction"), runtime_error);
     BOOST_CHECK_THROW(CallRPC("getrawtransaction not_hex"), runtime_error);
     BOOST_CHECK_THROW(CallRPC("getrawtransaction a3b807410df0b60fcb9736768df5823938b2f838694939ba45f3c0a1bff150ed not_int"), runtime_error);
@@ -100,11 +100,11 @@ BOOST_AUTO_TEST_CASE(rpc_rawsign)
       "[{\"txid\":\"b4cc287e58f87cdae59417329f710f3ecd75a4ee1d2872b7248f50977c8493f3\","
       "\"vout\":1,\"scriptPubKey\":\"a914b10c9df5f7edf436c697f02f1efdba4cf399615187\","
       "\"redeemScript\":\"512103debedc17b3df2badbcdd86d5feb4562b86fe182e5998abd8bcd4f122c6155b1b21027e940bb73ab8732bfdf7f9216ecefca5b94d6df834e77e108f68e66f126044c052ae\"}]";
-	  
-	CBaseChainParams::Network prevParams = Params().NetworkID();
-	SelectParams(CBaseChainParams::MAIN);
+  
+    CBaseChainParams::Network prevParams = Params().NetworkID();
+    SelectParams(CBaseChainParams::MAIN);
 
-	
+
     r = CallRPC(string("createrawtransaction ")+prevout+" "+
       "{\"3HqAe9LtNBjnsfM4CyYaWTnvCaUYT7v4oZ\":11}");
     string notsigned = r.get_str();
@@ -114,8 +114,8 @@ BOOST_AUTO_TEST_CASE(rpc_rawsign)
     BOOST_CHECK(find_value(r.get_obj(), "complete").get_bool() == false);
     r = CallRPC(string("signrawtransaction ")+notsigned+" "+prevout+" "+"["+privkey1+","+privkey2+"]");
     BOOST_CHECK(find_value(r.get_obj(), "complete").get_bool() == true);
-	
-	SelectParams(prevParams);
+
+    SelectParams(prevParams);
 }
 
 BOOST_AUTO_TEST_CASE(rpc_format_monetary_values)

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -7,6 +7,7 @@
 
 #include "base58.h"
 #include "netbase.h"
+#include "chainparams.h"
 
 #include <boost/algorithm/string.hpp>
 #include <boost/test/unit_test.hpp>
@@ -52,7 +53,7 @@ BOOST_AUTO_TEST_CASE(rpc_rawparams)
 {
     // Test raw transaction API argument handling
     Value r;
-
+	
     BOOST_CHECK_THROW(CallRPC("getrawtransaction"), runtime_error);
     BOOST_CHECK_THROW(CallRPC("getrawtransaction not_hex"), runtime_error);
     BOOST_CHECK_THROW(CallRPC("getrawtransaction a3b807410df0b60fcb9736768df5823938b2f838694939ba45f3c0a1bff150ed not_int"), runtime_error);
@@ -87,6 +88,8 @@ BOOST_AUTO_TEST_CASE(rpc_rawparams)
     BOOST_CHECK_THROW(CallRPC("sendrawtransaction null"), runtime_error);
     BOOST_CHECK_THROW(CallRPC("sendrawtransaction DEADBEEF"), runtime_error);
     BOOST_CHECK_THROW(CallRPC(string("sendrawtransaction ")+rawtx+" extra"), runtime_error);
+	
+	
 }
 
 BOOST_AUTO_TEST_CASE(rpc_rawsign)
@@ -97,6 +100,11 @@ BOOST_AUTO_TEST_CASE(rpc_rawsign)
       "[{\"txid\":\"b4cc287e58f87cdae59417329f710f3ecd75a4ee1d2872b7248f50977c8493f3\","
       "\"vout\":1,\"scriptPubKey\":\"a914b10c9df5f7edf436c697f02f1efdba4cf399615187\","
       "\"redeemScript\":\"512103debedc17b3df2badbcdd86d5feb4562b86fe182e5998abd8bcd4f122c6155b1b21027e940bb73ab8732bfdf7f9216ecefca5b94d6df834e77e108f68e66f126044c052ae\"}]";
+	  
+	CBaseChainParams::Network prevParams = Params().NetworkID();
+	SelectParams(CBaseChainParams::MAIN);
+
+	
     r = CallRPC(string("createrawtransaction ")+prevout+" "+
       "{\"3HqAe9LtNBjnsfM4CyYaWTnvCaUYT7v4oZ\":11}");
     string notsigned = r.get_str();
@@ -106,6 +114,8 @@ BOOST_AUTO_TEST_CASE(rpc_rawsign)
     BOOST_CHECK(find_value(r.get_obj(), "complete").get_bool() == false);
     r = CallRPC(string("signrawtransaction ")+notsigned+" "+prevout+" "+"["+privkey1+","+privkey2+"]");
     BOOST_CHECK(find_value(r.get_obj(), "complete").get_bool() == true);
+	
+	SelectParams(prevParams);
 }
 
 BOOST_AUTO_TEST_CASE(rpc_format_monetary_values)

--- a/src/test/rpc_wallet_tests.cpp
+++ b/src/test/rpc_wallet_tests.cpp
@@ -7,6 +7,7 @@
 
 #include "base58.h"
 #include "wallet.h"
+#include "chainparams.h"
 
 #include <boost/algorithm/string.hpp>
 #include <boost/test/unit_test.hpp>
@@ -65,6 +66,9 @@ BOOST_AUTO_TEST_CASE(rpc_wallet)
     // Test RPC calls for various wallet statistics
     Value r;
 
+	CBaseChainParams::Network prevParams = Params().NetworkID();
+	SelectParams(CBaseChainParams::MAIN);
+	
     LOCK2(cs_main, pwalletMain->cs_wallet);
 
     CPubKey demoPubkey = pwalletMain->GenerateNewKey();
@@ -173,6 +177,8 @@ BOOST_AUTO_TEST_CASE(rpc_wallet)
 	Array arr = retValue.get_array();
 	BOOST_CHECK(arr.size() > 0);
 	BOOST_CHECK(CBitcoinAddress(arr[0].get_str()).Get() == demoAddress.Get());
+	
+	SelectParams(prevParams);
 
 }
 

--- a/src/test/rpc_wallet_tests.cpp
+++ b/src/test/rpc_wallet_tests.cpp
@@ -66,35 +66,35 @@ BOOST_AUTO_TEST_CASE(rpc_wallet)
     // Test RPC calls for various wallet statistics
     Value r;
 
-	CBaseChainParams::Network prevParams = Params().NetworkID();
-	SelectParams(CBaseChainParams::MAIN);
-	
+    CBaseChainParams::Network prevParams = Params().NetworkID();
+    SelectParams(CBaseChainParams::MAIN);
+
     LOCK2(cs_main, pwalletMain->cs_wallet);
 
     CPubKey demoPubkey = pwalletMain->GenerateNewKey();
-	CBitcoinAddress demoAddress = CBitcoinAddress(CTxDestination(demoPubkey.GetID()));
-	Value retValue;
-	string strAccount = "walletDemoAccount";
-	string strPurpose = "receive";
-	BOOST_CHECK_NO_THROW({ /*Initialize Wallet with an account */
-		CWalletDB walletdb(pwalletMain->strWalletFile);
-		CAccount account;
-		account.vchPubKey = demoPubkey;
-		pwalletMain->SetAddressBook(account.vchPubKey.GetID(), strAccount, strPurpose);
-		walletdb.WriteAccount(strAccount, account);
-	});
+    CBitcoinAddress demoAddress = CBitcoinAddress(CTxDestination(demoPubkey.GetID()));
+    Value retValue;
+    string strAccount = "walletDemoAccount";
+    string strPurpose = "receive";
+    BOOST_CHECK_NO_THROW({ /*Initialize Wallet with an account */
+        CWalletDB walletdb(pwalletMain->strWalletFile);
+        CAccount account;
+        account.vchPubKey = demoPubkey;
+        pwalletMain->SetAddressBook(account.vchPubKey.GetID(), strAccount, strPurpose);
+        walletdb.WriteAccount(strAccount, account);
+    });
 
-
-	/*********************************
-	 * 			setaccount
-	 *********************************/
-	BOOST_CHECK_NO_THROW(CallRPC("setaccount 1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XZ nullaccount"));
-	BOOST_CHECK_THROW(CallRPC("setaccount"), runtime_error);
-	/* 1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4X (33 chars) is an illegal address (should be 34 chars) */
-	BOOST_CHECK_THROW(CallRPC("setaccount 1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4X nullaccount"), runtime_error);
 
     /*********************************
-     * 			listunspent
+    * setaccount
+    *********************************/
+    BOOST_CHECK_NO_THROW(CallRPC("setaccount 1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XZ nullaccount"));
+    BOOST_CHECK_THROW(CallRPC("setaccount"), runtime_error);
+    /* 1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4X (33 chars) is an illegal address (should be 34 chars) */
+    BOOST_CHECK_THROW(CallRPC("setaccount 1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4X nullaccount"), runtime_error);
+
+    /*********************************
+     * listunspent
      *********************************/
     BOOST_CHECK_NO_THROW(CallRPC("listunspent"));
     BOOST_CHECK_THROW(CallRPC("listunspent string"), runtime_error);
@@ -105,8 +105,8 @@ BOOST_AUTO_TEST_CASE(rpc_wallet)
     BOOST_CHECK(r.get_array().empty());
 
     /*********************************
-	 * 		listreceivedbyaddress
-	 *********************************/
+    * listreceivedbyaddress
+    *********************************/
     BOOST_CHECK_NO_THROW(CallRPC("listreceivedbyaddress"));
     BOOST_CHECK_NO_THROW(CallRPC("listreceivedbyaddress 0"));
     BOOST_CHECK_THROW(CallRPC("listreceivedbyaddress not_int"), runtime_error);
@@ -115,8 +115,8 @@ BOOST_AUTO_TEST_CASE(rpc_wallet)
     BOOST_CHECK_THROW(CallRPC("listreceivedbyaddress 0 true extra"), runtime_error);
 
     /*********************************
-	 * 		listreceivedbyaccount
-	 *********************************/
+    * listreceivedbyaccount
+    *********************************/
     BOOST_CHECK_NO_THROW(CallRPC("listreceivedbyaccount"));
     BOOST_CHECK_NO_THROW(CallRPC("listreceivedbyaccount 0"));
     BOOST_CHECK_THROW(CallRPC("listreceivedbyaccount not_int"), runtime_error);
@@ -125,60 +125,60 @@ BOOST_AUTO_TEST_CASE(rpc_wallet)
     BOOST_CHECK_THROW(CallRPC("listreceivedbyaccount 0 true extra"), runtime_error);
 
     /*********************************
-	 * 		getrawchangeaddress
-	 *********************************/
+    * getrawchangeaddress
+    *********************************/
     BOOST_CHECK_NO_THROW(CallRPC("getrawchangeaddress"));
 
     /*********************************
-	 * 		getnewaddress
-	 *********************************/
+    * getnewaddress
+    *********************************/
     BOOST_CHECK_NO_THROW(CallRPC("getnewaddress"));
     BOOST_CHECK_NO_THROW(CallRPC("getnewaddress getnewaddress_demoaccount"));
 
     /*********************************
-	 * 		getaccountaddress
-	 *********************************/
+    * getaccountaddress
+    *********************************/
     BOOST_CHECK_NO_THROW(CallRPC("getaccountaddress \"\""));
-	BOOST_CHECK_NO_THROW(CallRPC("getaccountaddress accountThatDoesntExists")); // Should generate a new account
-	BOOST_CHECK_NO_THROW(retValue = CallRPC("getaccountaddress " + strAccount));
-	BOOST_CHECK(CBitcoinAddress(retValue.get_str()).Get() == demoAddress.Get());
+    BOOST_CHECK_NO_THROW(CallRPC("getaccountaddress accountThatDoesntExists")); // Should generate a new account
+    BOOST_CHECK_NO_THROW(retValue = CallRPC("getaccountaddress " + strAccount));
+    BOOST_CHECK(CBitcoinAddress(retValue.get_str()).Get() == demoAddress.Get());
 
-	/*********************************
-	 * 			getaccount
-	 *********************************/
-	BOOST_CHECK_THROW(CallRPC("getaccount"), runtime_error);
-	BOOST_CHECK_NO_THROW(CallRPC("getaccount " + demoAddress.ToString()));
+    /*********************************
+    * getaccount
+    *********************************/
+    BOOST_CHECK_THROW(CallRPC("getaccount"), runtime_error);
+    BOOST_CHECK_NO_THROW(CallRPC("getaccount " + demoAddress.ToString()));
 
-	/*********************************
-	 * 	signmessage + verifymessage
-	 *********************************/
-	BOOST_CHECK_NO_THROW(retValue = CallRPC("signmessage " + demoAddress.ToString() + " mymessage"));
-	BOOST_CHECK_THROW(CallRPC("signmessage"), runtime_error);
-	/* Should throw error because this address is not loaded in the wallet */
-	BOOST_CHECK_THROW(CallRPC("signmessage 1QFqqMUD55ZV3PJEJZtaKCsQmjLT6JkjvJ mymessage"), runtime_error);
+    /*********************************
+    * 	signmessage + verifymessage
+    *********************************/
+    BOOST_CHECK_NO_THROW(retValue = CallRPC("signmessage " + demoAddress.ToString() + " mymessage"));
+    BOOST_CHECK_THROW(CallRPC("signmessage"), runtime_error);
+    /* Should throw error because this address is not loaded in the wallet */
+    BOOST_CHECK_THROW(CallRPC("signmessage 1QFqqMUD55ZV3PJEJZtaKCsQmjLT6JkjvJ mymessage"), runtime_error);
 
-	/* missing arguments */
-	BOOST_CHECK_THROW(CallRPC("verifymessage "+ demoAddress.ToString()), runtime_error);
-	BOOST_CHECK_THROW(CallRPC("verifymessage "+ demoAddress.ToString() + " " + retValue.get_str()), runtime_error);
-	/* Illegal address */
-	BOOST_CHECK_THROW(CallRPC("verifymessage 1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4X " + retValue.get_str() + " mymessage"), runtime_error);
-	/* wrong address */
-	BOOST_CHECK(CallRPC("verifymessage 1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XZ " + retValue.get_str() + " mymessage").get_bool() == false);
-	/* Correct address and signature but wrong message */
-	BOOST_CHECK(CallRPC("verifymessage "+ demoAddress.ToString() + " " + retValue.get_str() + " wrongmessage").get_bool() == false);
-	/* Correct address, message and signature*/
-	BOOST_CHECK(CallRPC("verifymessage "+ demoAddress.ToString() + " " + retValue.get_str() + " mymessage").get_bool() == true);
+    /* missing arguments */
+    BOOST_CHECK_THROW(CallRPC("verifymessage "+ demoAddress.ToString()), runtime_error);
+    BOOST_CHECK_THROW(CallRPC("verifymessage "+ demoAddress.ToString() + " " + retValue.get_str()), runtime_error);
+    /* Illegal address */
+    BOOST_CHECK_THROW(CallRPC("verifymessage 1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4X " + retValue.get_str() + " mymessage"), runtime_error);
+    /* wrong address */
+    BOOST_CHECK(CallRPC("verifymessage 1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XZ " + retValue.get_str() + " mymessage").get_bool() == false);
+    /* Correct address and signature but wrong message */
+    BOOST_CHECK(CallRPC("verifymessage "+ demoAddress.ToString() + " " + retValue.get_str() + " wrongmessage").get_bool() == false);
+    /* Correct address, message and signature*/
+    BOOST_CHECK(CallRPC("verifymessage "+ demoAddress.ToString() + " " + retValue.get_str() + " mymessage").get_bool() == true);
 
-	/*********************************
-	 * 		getaddressesbyaccount
-	 *********************************/
-	BOOST_CHECK_THROW(CallRPC("getaddressesbyaccount"), runtime_error);
-	BOOST_CHECK_NO_THROW(retValue = CallRPC("getaddressesbyaccount " + strAccount));
-	Array arr = retValue.get_array();
-	BOOST_CHECK(arr.size() > 0);
-	BOOST_CHECK(CBitcoinAddress(arr[0].get_str()).Get() == demoAddress.Get());
-	
-	SelectParams(prevParams);
+    /*********************************
+    * getaddressesbyaccount
+    *********************************/
+    BOOST_CHECK_THROW(CallRPC("getaddressesbyaccount"), runtime_error);
+    BOOST_CHECK_NO_THROW(retValue = CallRPC("getaddressesbyaccount " + strAccount));
+    Array arr = retValue.get_array();
+    BOOST_CHECK(arr.size() > 0);
+    BOOST_CHECK(CBitcoinAddress(arr[0].get_str()).Get() == demoAddress.Get());
+    
+    SelectParams(prevParams);
 
 }
 

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -30,7 +30,8 @@ struct TestingSetup {
 
     TestingSetup() {
         fPrintToDebugLog = false; // don't want to write to debug.log file
-        SelectParams(CBaseChainParams::MAIN);
+		
+        SelectParams(CBaseChainParams::REGTEST);
         noui_connect();
 #ifdef ENABLE_WALLET
         bitdb.MakeMock();

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -30,7 +30,7 @@ struct TestingSetup {
 
     TestingSetup() {
         fPrintToDebugLog = false; // don't want to write to debug.log file
-		
+
         SelectParams(CBaseChainParams::REGTEST);
         noui_connect();
 #ifdef ENABLE_WALLET


### PR DESCRIPTION
For several reasons the current test framework does not allow to easily incorporate new unit tests that append specially crafted blocks to the blockchain using ProcessBlock().
In the pull request https://github.com/bitcoin/bitcoin/pull/4688 we described the reasons and proposed a solution.
While we think that is the optimum solution, @gmaxwell and @laanwj suggested not implementing the changes because many files not directly related to the testing framework were modified by the patch.
In this pull request we implement @gmaxwell suggestion that the test framework should run under the RegTest network parameters and not under the main network parameters. Allthough this seems to be a small change, it was not. First, the RegTest block solving probability was 1/2 which still requires "mining" during the test case validation in order to dynamically create a block, which adds unnecessary complications to simple testing code.
To overcome this problem, the RegTest difficulty was changed from 0x207fffff to 0x2100FFFF (in compact notation), which gives an approximate 1/2^16 probability not to solve a block. Happily there was no lucky test case.
Because the maximum possible target (0xff ... 0xff) cannot be multiplied by 4 without overflow, ComputeMinWork() had to be modified to always return ProofOfWorkLimit() for the RegTest.

Also we found that several test cases make explicit use of properties of the MainNet. Such test cases are:

alert_tests.cpp
rpc_wallet_tests.cpp
main_tests.cpp
key_tests.cpp
DoS_tests.cpp
Checkpoints_tests.cpp
base58_tests.cpp
bloom_tests.cpp
rpc_tests.cpp
miner_tests.cpp

All these test cases were added a temporary switch from the RegTest network to the Main network in order to leave them working. Re-writting all of them for the RegTest probably requires more than 40 hours of work.

The alert_tests.cpp test case is special, because it requires the alert private key to generate inputs to the test cases. We suggest to switch this test case to the RegNet and replace the current RegTest alert private key with a published key-pair, so everyone can generate more test cases and there is no opaque data.

As the 4688  pull request, we've:

a. fixed the bug in miner_tests.cpp which leaves in the memory pool invalid transactions (mempool.clear() missing).
b. Added 7 unit tests:

```
ToCheckBlockUpgradeMajority (untested before)
EnforceBlockUpgradeMajority (untested before)
RejectBlockOutdatedMajority (untested before)
"bad-cb-height"
"bad-version"
"time-too-old"
"bad-txns-nonfinal"
```

NOTE: In the file rpc_wallet_tests.cpp, the TABs were removed and replaced with whitespace indentation. This is the standard in the rest of the code. A whitespace-ignoring compare will show no important differences.

Sergio Demian Lerner & Timo Hanke
