### PR TITLE
Remove print() from core classes

### DIFF
--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -80,11 +80,6 @@ std::string CUnsignedAlert::ToString() const
         strStatusBar);
 }
 
-void CUnsignedAlert::print() const
-{
-    LogPrintf("%s", ToString());
-}
-
 void CAlert::SetNull()
 {
     CUnsignedAlert::SetNull();

--- a/src/alert.h
+++ b/src/alert.h
@@ -68,7 +68,6 @@ public:
     void SetNull();
 
     std::string ToString() const;
-    void print() const;
 };
 
 /** An alert is a combination of a serialized CUnsignedAlert and a signature. */

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -12,11 +12,6 @@ std::string COutPoint::ToString() const
     return strprintf("COutPoint(%s, %u)", hash.ToString().substr(0,10), n);
 }
 
-void COutPoint::print() const
-{
-    LogPrintf("%s\n", ToString());
-}
-
 CTxIn::CTxIn(COutPoint prevoutIn, CScript scriptSigIn, unsigned int nSequenceIn)
 {
     prevout = prevoutIn;
@@ -46,11 +41,6 @@ std::string CTxIn::ToString() const
     return str;
 }
 
-void CTxIn::print() const
-{
-    LogPrintf("%s\n", ToString());
-}
-
 CTxOut::CTxOut(int64_t nValueIn, CScript scriptPubKeyIn)
 {
     nValue = nValueIn;
@@ -65,11 +55,6 @@ uint256 CTxOut::GetHash() const
 std::string CTxOut::ToString() const
 {
     return strprintf("CTxOut(nValue=%d.%08d, scriptPubKey=%s)", nValue / COIN, nValue % COIN, scriptPubKey.ToString().substr(0,30));
-}
-
-void CTxOut::print() const
-{
-    LogPrintf("%s\n", ToString());
 }
 
 CFeeRate::CFeeRate(int64_t nFeePaid, size_t nSize)
@@ -92,8 +77,7 @@ int64_t CFeeRate::GetFee(size_t nSize) const
 
 std::string CFeeRate::ToString() const
 {
-    std::string result = FormatMoney(nSatoshisPerK) + " BTC/kB";
-    return result;
+    return strprintf("%d.%08d BTC/kB", nSatoshisPerK / COIN, nSatoshisPerK % COIN);
 }
 
 CMutableTransaction::CMutableTransaction() : nVersion(CTransaction::CURRENT_VERSION), nLockTime(0) {}
@@ -169,11 +153,6 @@ std::string CTransaction::ToString() const
     for (unsigned int i = 0; i < vout.size(); i++)
         str += "    " + vout[i].ToString() + "\n";
     return str;
-}
-
-void CTransaction::print() const
-{
-    LogPrintf("%s", ToString());
 }
 
 // Amount compression:
@@ -285,9 +264,10 @@ uint256 CBlock::CheckMerkleBranch(uint256 hash, const std::vector<uint256>& vMer
     return hash;
 }
 
-void CBlock::print() const
+std::string CBlock::ToString() const
 {
-    LogPrintf("CBlock(hash=%s, ver=%d, hashPrevBlock=%s, hashMerkleRoot=%s, nTime=%u, nBits=%08x, nNonce=%u, vtx=%u)\n",
+    std::stringstream s;
+    s << strprintf("CBlock(hash=%s, ver=%d, hashPrevBlock=%s, hashMerkleRoot=%s, nTime=%u, nBits=%08x, nNonce=%u, vtx=%u)\n",
         GetHash().ToString(),
         nVersion,
         hashPrevBlock.ToString(),
@@ -296,11 +276,11 @@ void CBlock::print() const
         vtx.size());
     for (unsigned int i = 0; i < vtx.size(); i++)
     {
-        LogPrintf("  ");
-        vtx[i].print();
+        s << "  " << vtx[i].ToString() << "\n";
     }
-    LogPrintf("  vMerkleTree: ");
+    s << "  vMerkleTree: ";
     for (unsigned int i = 0; i < vMerkleTree.size(); i++)
-        LogPrintf("%s ", vMerkleTree[i].ToString());
-    LogPrintf("\n");
+        s << " " << vMerkleTree[i].ToString();
+    s << "\n";
+    return s.str();
 }

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -5,7 +5,7 @@
 
 #include "core.h"
 
-#include "util.h"
+#include "tinyformat.h"
 
 std::string COutPoint::ToString() const
 {

--- a/src/core.h
+++ b/src/core.h
@@ -47,7 +47,6 @@ public:
     }
 
     std::string ToString() const;
-    void print() const;
 };
 
 /** An inpoint - a combination of a transaction and an index n into its vin */
@@ -107,7 +106,6 @@ public:
     }
 
     std::string ToString() const;
-    void print() const;
 };
 
 
@@ -200,7 +198,6 @@ public:
     }
 
     std::string ToString() const;
-    void print() const;
 };
 
 
@@ -279,7 +276,6 @@ public:
     }
 
     std::string ToString() const;
-    void print() const;
 };
 
 /** A mutable version of CTransaction. */
@@ -497,7 +493,7 @@ public:
 
     std::vector<uint256> GetMerkleBranch(int nIndex) const;
     static uint256 CheckMerkleBranch(uint256 hash, const std::vector<uint256>& vMerkleBranch, int nIndex);
-    void print() const;
+    std::string ToString() const;
 };
 
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1029,8 +1029,7 @@ bool AppInit2(boost::thread_group& threadGroup)
                 CBlock block;
                 ReadBlockFromDisk(block, pindex);
                 block.BuildMerkleTree();
-                block.print();
-                LogPrintf("\n");
+                LogPrintf("%s\n", block.ToString());
                 nFound++;
             }
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3968,7 +3968,6 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         vRecv >> block;
 
         LogPrint("net", "received block %s peer=%d\n", block.GetHash().ToString(), pfrom->id);
-        // block.print();
 
         CInv inv(MSG_BLOCK, block.GetHash());
         pfrom->AddInventoryKnown(inv);

--- a/src/main.h
+++ b/src/main.h
@@ -839,11 +839,6 @@ public:
             GetBlockHash().ToString());
     }
 
-    void print() const
-    {
-        LogPrintf("%s\n", ToString());
-    }
-
     // Check whether this block index entry is valid up to the passed validity level.
     bool IsValid(enum BlockStatus nUpTo = BLOCK_VALID_TRANSACTIONS) const
     {
@@ -934,11 +929,6 @@ public:
             GetBlockHash().ToString(),
             hashPrev.ToString());
         return str;
-    }
-
-    void print() const
-    {
-        LogPrintf("%s\n", ToString());
     }
 };
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -42,14 +42,6 @@ public:
     COrphan(const CTransaction* ptxIn) : ptx(ptxIn), feeRate(0), dPriority(0)
     {
     }
-
-    void print() const
-    {
-        LogPrintf("COrphan(hash=%s, dPriority=%.1f, fee=%s)\n",
-                  ptx->GetHash().ToString(), dPriority, feeRate.ToString());
-        BOOST_FOREACH(uint256 hash, setDependsOn)
-            LogPrintf("   setDependsOn %s\n", hash.ToString());
-    }
 };
 
 uint64_t nLastBlockTx = 0;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -404,7 +404,7 @@ CBlockTemplate* CreateNewBlockWithKey(CReserveKey& reservekey)
 
 bool ProcessBlockFound(CBlock* pblock, CWallet& wallet, CReserveKey& reservekey)
 {
-    pblock->print();
+    LogPrintf("%s\n", pblock->ToString());
     LogPrintf("generated %s\n", FormatMoney(pblock->vtx[0].vout[0].nValue));
 
     // Found a solution

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -874,11 +874,6 @@ uint64_t CNetAddr::GetHash() const
     return nRet;
 }
 
-void CNetAddr::print() const
-{
-    LogPrintf("CNetAddr(%s)\n", ToString());
-}
-
 // private extensions to enum Network, only returned by GetExtNetwork,
 // and only used in GetReachabilityFrom
 static const int NET_UNKNOWN = NET_MAX + 0;
@@ -1105,11 +1100,6 @@ std::string CService::ToStringIPPort() const
 std::string CService::ToString() const
 {
     return ToStringIPPort();
-}
-
-void CService::print() const
-{
-    LogPrintf("CService(%s)\n", ToString());
 }
 
 void CService::SetPort(unsigned short portIn)

--- a/src/netbase.h
+++ b/src/netbase.h
@@ -80,7 +80,6 @@ class CNetAddr
         bool GetInAddr(struct in_addr* pipv4Addr) const;
         std::vector<unsigned char> GetGroup() const;
         int GetReachabilityFrom(const CNetAddr *paddrPartner = NULL) const;
-        void print() const;
 
         CNetAddr(const struct in6_addr& pipv6Addr);
         bool GetIn6Addr(struct in6_addr* pipv6Addr) const;
@@ -145,7 +144,6 @@ class CService : public CNetAddr
         std::string ToString() const;
         std::string ToStringPort() const;
         std::string ToStringIPPort() const;
-        void print() const;
 
         CService(const struct in6_addr& ipv6Addr, unsigned short port);
         CService(const struct sockaddr_in6& addr);

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -144,9 +144,3 @@ std::string CInv::ToString() const
 {
     return strprintf("%s %s", GetCommand(), hash.ToString());
 }
-
-void CInv::print() const
-{
-    LogPrintf("CInv(%s)\n", ToString());
-}
-

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -98,8 +98,6 @@ class CAddress : public CService
              READWRITE(*pip);
             )
 
-        void print() const;
-
     // TODO: make private (improves encapsulation)
     public:
         uint64_t nServices;
@@ -130,7 +128,6 @@ class CInv
         bool IsKnownType() const;
         const char* GetCommand() const;
         std::string ToString() const;
-        void print() const;
 
     // TODO: make private (improves encapsulation)
     public:

--- a/src/tinyformat.h
+++ b/src/tinyformat.h
@@ -1007,4 +1007,6 @@ TINYFORMAT_WRAP_FORMAT_N(16, returnType, funcName, funcDeclSuffix, bodyPrefix, s
 
 } // namespace tinyformat
 
+#define strprintf tfm::format
+
 #endif // TINYFORMAT_H_INCLUDED

--- a/src/util.h
+++ b/src/util.h
@@ -108,7 +108,6 @@ bool LogAcceptCategory(const char* category);
 /* Send a string to the log output */
 int LogPrintStr(const std::string &str);
 
-#define strprintf tfm::format
 #define LogPrintf(...) LogPrint(NULL, __VA_ARGS__)
 
 /* When we switch to C++11, this can be switched to variadic templates instead

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -824,11 +824,6 @@ public:
     {
         return strprintf("COutput(%s, %d, %d) [%s]", tx->GetHash().ToString(), i, nDepth, FormatMoney(tx->vout[i].nValue).c_str());
     }
-
-    void print() const
-    {
-        LogPrintf("%s\n", ToString());
-    }
 };
 
 


### PR DESCRIPTION
Remove unused print()s and change the instance on CBlock to ToString().
Breaks dependency from `core.o` on `util.o`.

Before:

```
src/libbitcoin_common_a-core.o
  src/crypto/crypto_libbitcoin_crypto_a-sha2.o
    CSHA256::Reset(...)
    CSHA256::Write(...)
    CSHA256::Finalize(...)
    CSHA256::CSHA256(...)
  src/libbitcoin_common_a-script.o
    GetOpName(...)
  src/libbitcoin_util_a-uint256.o
    base_uint<256u>::EqualTo(...)
    base_uint<256u>::ToString(...)
  src/libbitcoin_util_a-util.o
    FormatMoney(...)
    LogPrintStr(...)
    LogAcceptCategory(...)
```

After:

```
src/libbitcoin_common_a-core.o
  src/crypto/crypto_libbitcoin_crypto_a-sha2.o
    CSHA256::Reset(...)
    CSHA256::Write(...)
    CSHA256::Finalize(...)
    CSHA256::CSHA256(...)
  src/libbitcoin_common_a-script.o
    GetOpName(...)
  src/libbitcoin_util_a-uint256.o
    base_uint<256u>::EqualTo(...)
    base_uint<256u>::ToString(...)
```
