### PR TITLE
cleaner serialization code

### DIFF
--- a/src/addrman.h
+++ b/src/addrman.h
@@ -49,14 +49,11 @@ public:
     IMPLEMENT_SERIALIZE;
 
     template <typename Stream, typename Operation>
-    inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
-        size_t nSerSize = 0;
-        CAddress* pthis = (CAddress*)(this);
-        READWRITE(*pthis);
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
+        READWRITE(*(CAddress*)this);
         READWRITE(source);
         READWRITE(nLastSuccess);
         READWRITE(nAttempts);
-        return nSerSize;
     }
 
     void Init()

--- a/src/addrman.h
+++ b/src/addrman.h
@@ -46,16 +46,16 @@ private:
 
 public:
 
-    IMPLEMENT_SERIALIZE
+    IMPLEMENT_SERIALIZE;
 
-    template <typename T, typename Stream, typename Operation>
-    inline static size_t SerializationOp(T thisPtr, Stream& s, Operation ser_action, int nType, int nVersion) {
+    template <typename Stream, typename Operation>
+    inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
         size_t nSerSize = 0;
-        CAddress* pthis = (CAddress*)(thisPtr);
+        CAddress* pthis = (CAddress*)(this);
         READWRITE(*pthis);
-        READWRITE(thisPtr->source);
-        READWRITE(thisPtr->nLastSuccess);
-        READWRITE(thisPtr->nAttempts);
+        READWRITE(source);
+        READWRITE(nLastSuccess);
+        READWRITE(nAttempts);
         return nSerSize;
     }
 

--- a/src/addrman.h
+++ b/src/addrman.h
@@ -46,13 +46,18 @@ private:
 
 public:
 
-    IMPLEMENT_SERIALIZE(
-        CAddress* pthis = (CAddress*)(this);
+    IMPLEMENT_SERIALIZE
+
+    template <typename T, typename Stream, typename Operation>
+    inline static size_t SerializationOp(T thisPtr, Stream& s, Operation ser_action, int nType, int nVersion) {
+        size_t nSerSize = 0;
+        CAddress* pthis = (CAddress*)(thisPtr);
         READWRITE(*pthis);
-        READWRITE(source);
-        READWRITE(nLastSuccess);
-        READWRITE(nAttempts);
-    )
+        READWRITE(thisPtr->source);
+        READWRITE(thisPtr->nLastSuccess);
+        READWRITE(thisPtr->nAttempts);
+        return nSerSize;
+    }
 
     void Init()
     {

--- a/src/alert.h
+++ b/src/alert.h
@@ -46,26 +46,26 @@ public:
     std::string strStatusBar;
     std::string strReserved;
 
-    IMPLEMENT_SERIALIZE
+    IMPLEMENT_SERIALIZE;
 
-    template <typename T, typename Stream, typename Operation>
-    inline static size_t SerializationOp(T thisPtr, Stream& s, Operation ser_action, int nType, int nVersion) {
+    template <typename Stream, typename Operation>
+    inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
         size_t nSerSize = 0;
-        READWRITE(thisPtr->nVersion);
-        nVersion = thisPtr->nVersion;
-        READWRITE(thisPtr->nRelayUntil);
-        READWRITE(thisPtr->nExpiration);
-        READWRITE(thisPtr->nID);
-        READWRITE(thisPtr->nCancel);
-        READWRITE(thisPtr->setCancel);
-        READWRITE(thisPtr->nMinVer);
-        READWRITE(thisPtr->nMaxVer);
-        READWRITE(thisPtr->setSubVer);
-        READWRITE(thisPtr->nPriority);
+        READWRITE(this->nVersion);
+        nVersion = this->nVersion;
+        READWRITE(nRelayUntil);
+        READWRITE(nExpiration);
+        READWRITE(nID);
+        READWRITE(nCancel);
+        READWRITE(setCancel);
+        READWRITE(nMinVer);
+        READWRITE(nMaxVer);
+        READWRITE(setSubVer);
+        READWRITE(nPriority);
 
-        READWRITE(LIMITED_STRING(thisPtr->strComment, 65536));
-        READWRITE(LIMITED_STRING(thisPtr->strStatusBar, 256));
-        READWRITE(LIMITED_STRING(thisPtr->strReserved, 256));
+        READWRITE(LIMITED_STRING(strComment, 65536));
+        READWRITE(LIMITED_STRING(strStatusBar, 256));
+        READWRITE(LIMITED_STRING(strReserved, 256));
         return nSerSize;
     }
 
@@ -86,13 +86,13 @@ public:
         SetNull();
     }
 
-    IMPLEMENT_SERIALIZE
+    IMPLEMENT_SERIALIZE;
 
-    template <typename T, typename Stream, typename Operation>
-    inline static size_t SerializationOp(T thisPtr, Stream& s, Operation ser_action, int nType, int nVersion) {
+    template <typename Stream, typename Operation>
+    inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
         size_t nSerSize = 0;
-        READWRITE(thisPtr->vchMsg);
-        READWRITE(thisPtr->vchSig);
+        READWRITE(vchMsg);
+        READWRITE(vchSig);
         return nSerSize;
     }
 

--- a/src/alert.h
+++ b/src/alert.h
@@ -47,23 +47,27 @@ public:
     std::string strReserved;
 
     IMPLEMENT_SERIALIZE
-    (
-        READWRITE(this->nVersion);
-        nVersion = this->nVersion;
-        READWRITE(nRelayUntil);
-        READWRITE(nExpiration);
-        READWRITE(nID);
-        READWRITE(nCancel);
-        READWRITE(setCancel);
-        READWRITE(nMinVer);
-        READWRITE(nMaxVer);
-        READWRITE(setSubVer);
-        READWRITE(nPriority);
 
-        READWRITE(LIMITED_STRING(strComment, 65536));
-        READWRITE(LIMITED_STRING(strStatusBar, 256));
-        READWRITE(LIMITED_STRING(strReserved, 256));
-    )
+    template <typename T, typename Stream, typename Operation>
+    inline static size_t SerializationOp(T thisPtr, Stream& s, Operation ser_action, int nType, int nVersion) {
+        size_t nSerSize = 0;
+        READWRITE(thisPtr->nVersion);
+        nVersion = thisPtr->nVersion;
+        READWRITE(thisPtr->nRelayUntil);
+        READWRITE(thisPtr->nExpiration);
+        READWRITE(thisPtr->nID);
+        READWRITE(thisPtr->nCancel);
+        READWRITE(thisPtr->setCancel);
+        READWRITE(thisPtr->nMinVer);
+        READWRITE(thisPtr->nMaxVer);
+        READWRITE(thisPtr->setSubVer);
+        READWRITE(thisPtr->nPriority);
+
+        READWRITE(LIMITED_STRING(thisPtr->strComment, 65536));
+        READWRITE(LIMITED_STRING(thisPtr->strStatusBar, 256));
+        READWRITE(LIMITED_STRING(thisPtr->strReserved, 256));
+        return nSerSize;
+    }
 
     void SetNull();
 
@@ -83,10 +87,14 @@ public:
     }
 
     IMPLEMENT_SERIALIZE
-    (
-        READWRITE(vchMsg);
-        READWRITE(vchSig);
-    )
+
+    template <typename T, typename Stream, typename Operation>
+    inline static size_t SerializationOp(T thisPtr, Stream& s, Operation ser_action, int nType, int nVersion) {
+        size_t nSerSize = 0;
+        READWRITE(thisPtr->vchMsg);
+        READWRITE(thisPtr->vchSig);
+        return nSerSize;
+    }
 
     void SetNull();
     bool IsNull() const;

--- a/src/alert.h
+++ b/src/alert.h
@@ -49,8 +49,7 @@ public:
     IMPLEMENT_SERIALIZE;
 
     template <typename Stream, typename Operation>
-    inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
-        size_t nSerSize = 0;
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
         READWRITE(this->nVersion);
         nVersion = this->nVersion;
         READWRITE(nRelayUntil);
@@ -66,7 +65,6 @@ public:
         READWRITE(LIMITED_STRING(strComment, 65536));
         READWRITE(LIMITED_STRING(strStatusBar, 256));
         READWRITE(LIMITED_STRING(strReserved, 256));
-        return nSerSize;
     }
 
     void SetNull();
@@ -89,11 +87,9 @@ public:
     IMPLEMENT_SERIALIZE;
 
     template <typename Stream, typename Operation>
-    inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
-        size_t nSerSize = 0;
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
         READWRITE(vchMsg);
         READWRITE(vchSig);
-        return nSerSize;
     }
 
     void SetNull();

--- a/src/bloom.h
+++ b/src/bloom.h
@@ -63,12 +63,16 @@ public:
     CBloomFilter() : isFull(true), isEmpty(false), nHashFuncs(0), nTweak(0), nFlags(0) {}
 
     IMPLEMENT_SERIALIZE
-    (
-        READWRITE(vData);
-        READWRITE(nHashFuncs);
-        READWRITE(nTweak);
-        READWRITE(nFlags);
-    )
+
+    template <typename T, typename Stream, typename Operation>
+    inline static size_t SerializationOp(T thisPtr, Stream& s, Operation ser_action, int nType, int nVersion) {
+        size_t nSerSize = 0;
+        READWRITE(thisPtr->vData);
+        READWRITE(thisPtr->nHashFuncs);
+        READWRITE(thisPtr->nTweak);
+        READWRITE(thisPtr->nFlags);
+        return nSerSize;
+    }
 
     void insert(const std::vector<unsigned char>& vKey);
     void insert(const COutPoint& outpoint);

--- a/src/bloom.h
+++ b/src/bloom.h
@@ -65,13 +65,11 @@ public:
     IMPLEMENT_SERIALIZE;
 
     template <typename Stream, typename Operation>
-    inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
-        size_t nSerSize = 0;
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
         READWRITE(vData);
         READWRITE(nHashFuncs);
         READWRITE(nTweak);
         READWRITE(nFlags);
-        return nSerSize;
     }
 
     void insert(const std::vector<unsigned char>& vKey);

--- a/src/bloom.h
+++ b/src/bloom.h
@@ -62,15 +62,15 @@ public:
     CBloomFilter(unsigned int nElements, double nFPRate, unsigned int nTweak, unsigned char nFlagsIn);
     CBloomFilter() : isFull(true), isEmpty(false), nHashFuncs(0), nTweak(0), nFlags(0) {}
 
-    IMPLEMENT_SERIALIZE
+    IMPLEMENT_SERIALIZE;
 
-    template <typename T, typename Stream, typename Operation>
-    inline static size_t SerializationOp(T thisPtr, Stream& s, Operation ser_action, int nType, int nVersion) {
+    template <typename Stream, typename Operation>
+    inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
         size_t nSerSize = 0;
-        READWRITE(thisPtr->vData);
-        READWRITE(thisPtr->nHashFuncs);
-        READWRITE(thisPtr->nTweak);
-        READWRITE(thisPtr->nFlags);
+        READWRITE(vData);
+        READWRITE(nHashFuncs);
+        READWRITE(nTweak);
+        READWRITE(nFlags);
         return nSerSize;
     }
 

--- a/src/core.h
+++ b/src/core.h
@@ -31,12 +31,12 @@ public:
     COutPoint() { SetNull(); }
     COutPoint(uint256 hashIn, uint32_t nIn) { hash = hashIn; n = nIn; }
 
-    IMPLEMENT_SERIALIZE
+    IMPLEMENT_SERIALIZE;
 
-    template <typename T, typename Stream, typename Operation>
-    inline static size_t SerializationOp(T thisPtr, Stream& s, Operation ser_action, int nType, int nVersion) {
+    template <typename Stream, typename Operation>
+    inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
         size_t nSerSize = 0;
-        READWRITE(FLATDATA(*thisPtr));
+        READWRITE(FLATDATA(*this));
         return nSerSize;
     }
 
@@ -93,14 +93,14 @@ public:
     explicit CTxIn(COutPoint prevoutIn, CScript scriptSigIn=CScript(), uint32_t nSequenceIn=std::numeric_limits<unsigned int>::max());
     CTxIn(uint256 hashPrevTx, uint32_t nOut, CScript scriptSigIn=CScript(), uint32_t nSequenceIn=std::numeric_limits<uint32_t>::max());
 
-    IMPLEMENT_SERIALIZE
+    IMPLEMENT_SERIALIZE;
 
-    template <typename T, typename Stream, typename Operation>
-    inline static size_t SerializationOp(T thisPtr, Stream& s, Operation ser_action, int nType, int nVersion) {
+    template <typename Stream, typename Operation>
+    inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
         size_t nSerSize = 0;
-        READWRITE(thisPtr->prevout);
-        READWRITE(thisPtr->scriptSig);
-        READWRITE(thisPtr->nSequence);
+        READWRITE(prevout);
+        READWRITE(scriptSig);
+        READWRITE(nSequence);
         return nSerSize;
     }
 
@@ -149,12 +149,12 @@ public:
     friend bool operator>=(const CFeeRate& a, const CFeeRate& b) { return a.nSatoshisPerK >= b.nSatoshisPerK; }
     std::string ToString() const;
 
-    IMPLEMENT_SERIALIZE
+    IMPLEMENT_SERIALIZE;
 
-    template <typename T, typename Stream, typename Operation>
-    inline static size_t SerializationOp(T thisPtr, Stream& s, Operation ser_action, int nType, int nVersion) {
+    template <typename Stream, typename Operation>
+    inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
         size_t nSerSize = 0;
-        READWRITE(thisPtr->nSatoshisPerK);
+        READWRITE(nSatoshisPerK);
         return nSerSize;
     }
 };
@@ -176,13 +176,13 @@ public:
 
     CTxOut(int64_t nValueIn, CScript scriptPubKeyIn);
 
-    IMPLEMENT_SERIALIZE
+    IMPLEMENT_SERIALIZE;
 
-    template <typename T, typename Stream, typename Operation>
-    inline static size_t SerializationOp(T thisPtr, Stream& s, Operation ser_action, int nType, int nVersion) {
+    template <typename Stream, typename Operation>
+    inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
         size_t nSerSize = 0;
-        READWRITE(thisPtr->nValue);
-        READWRITE(thisPtr->scriptPubKey);
+        READWRITE(nValue);
+        READWRITE(scriptPubKey);
         return nSerSize;
     }
 
@@ -261,20 +261,20 @@ public:
 
     CTransaction& operator=(const CTransaction& tx);
 
-    IMPLEMENT_SERIALIZE
+    IMPLEMENT_SERIALIZE;
 
-    template <typename T, typename Stream, typename Operation>
-    inline static size_t SerializationOp(T thisPtr, Stream& s, Operation ser_action, int nType, int nVersion) {
+    template <typename Stream, typename Operation>
+    inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
         size_t nSerSize = 0;
         bool fRead = boost::is_same<Operation, CSerActionUnserialize>();
 
-        READWRITE(*const_cast<int32_t*>(&thisPtr->nVersion));
-        nVersion = thisPtr->nVersion;
-        READWRITE(*const_cast<std::vector<CTxIn>*>(&thisPtr->vin));
-        READWRITE(*const_cast<std::vector<CTxOut>*>(&thisPtr->vout));
-        READWRITE(*const_cast<uint32_t*>(&thisPtr->nLockTime));
+        READWRITE(*const_cast<int32_t*>(&this->nVersion));
+        nVersion = this->nVersion;
+        READWRITE(*const_cast<std::vector<CTxIn>*>(&vin));
+        READWRITE(*const_cast<std::vector<CTxOut>*>(&vout));
+        READWRITE(*const_cast<uint32_t*>(&nLockTime));
         if (fRead)
-            thisPtr->UpdateHash();
+            UpdateHash();
 
         return nSerSize;
     }
@@ -324,17 +324,17 @@ struct CMutableTransaction
     CMutableTransaction();
     CMutableTransaction(const CTransaction& tx);
 
-    IMPLEMENT_SERIALIZE
+    IMPLEMENT_SERIALIZE;
 
-    template <typename T, typename Stream, typename Operation>
-    inline static size_t SerializationOp(T thisPtr, Stream& s, Operation ser_action, int nType, int nVersion) {
+    template <typename Stream, typename Operation>
+    inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
         size_t nSerSize = 0;
 
-        READWRITE(thisPtr->nVersion);
-        nVersion = thisPtr->nVersion;
-        READWRITE(thisPtr->vin);
-        READWRITE(thisPtr->vout);
-        READWRITE(thisPtr->nLockTime);
+        READWRITE(this->nVersion);
+        nVersion = this->nVersion;
+        READWRITE(vin);
+        READWRITE(vout);
+        READWRITE(nLockTime);
 
         return nSerSize;
     }
@@ -357,21 +357,21 @@ public:
 
     CTxOutCompressor(CTxOut &txoutIn) : txout(txoutIn) { }
 
-    IMPLEMENT_SERIALIZE
+    IMPLEMENT_SERIALIZE;
 
-    template <typename T, typename Stream, typename Operation>
-    inline static size_t SerializationOp(T thisPtr, Stream& s, Operation ser_action, int nType, int nVersion) {
+    template <typename Stream, typename Operation>
+    inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
         bool fRead = boost::is_same<Operation, CSerActionUnserialize>();
         size_t nSerSize = 0;
         if (!fRead) {
-            uint64_t nVal = CompressAmount(thisPtr->txout.nValue);
+            uint64_t nVal = CompressAmount(txout.nValue);
             READWRITE(VARINT(nVal));
         } else {
             uint64_t nVal = 0;
             READWRITE(VARINT(nVal));
-            thisPtr->txout.nValue = DecompressAmount(nVal);
+            txout.nValue = DecompressAmount(nVal);
         }
-        CScriptCompressor cscript(REF(thisPtr->txout.scriptPubKey));
+        CScriptCompressor cscript(REF(txout.scriptPubKey));
         READWRITE(cscript);
         return nSerSize;
     }
@@ -427,12 +427,12 @@ public:
     // undo information for all txins
     std::vector<CTxInUndo> vprevout;
 
-    IMPLEMENT_SERIALIZE
+    IMPLEMENT_SERIALIZE;
 
-    template <typename T, typename Stream, typename Operation>
-    inline static size_t SerializationOp(T thisPtr, Stream& s, Operation ser_action, int nType, int nVersion) {
+    template <typename Stream, typename Operation>
+    inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
         size_t nSerSize = 0;
-        READWRITE(thisPtr->vprevout);
+        READWRITE(vprevout);
         return nSerSize;
     }
 };
@@ -462,19 +462,19 @@ public:
         SetNull();
     }
 
-    IMPLEMENT_SERIALIZE
+    IMPLEMENT_SERIALIZE;
 
-    template <typename T, typename Stream, typename Operation>
-    inline static size_t SerializationOp(T thisPtr, Stream& s, Operation ser_action, int nType, int nVersion) {
+    template <typename Stream, typename Operation>
+    inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
         size_t nSerSize = 0;
 
-        READWRITE(thisPtr->nVersion);
-        nVersion = thisPtr->nVersion;
-        READWRITE(thisPtr->hashPrevBlock);
-        READWRITE(thisPtr->hashMerkleRoot);
-        READWRITE(thisPtr->nTime);
-        READWRITE(thisPtr->nBits);
-        READWRITE(thisPtr->nNonce);
+        READWRITE(this->nVersion);
+        nVersion = this->nVersion;
+        READWRITE(hashPrevBlock);
+        READWRITE(hashMerkleRoot);
+        READWRITE(nTime);
+        READWRITE(nBits);
+        READWRITE(nNonce);
 
         return nSerSize;
     }
@@ -523,14 +523,14 @@ public:
         *((CBlockHeader*)this) = header;
     }
 
-    IMPLEMENT_SERIALIZE
+    IMPLEMENT_SERIALIZE;
 
-    template <typename T, typename Stream, typename Operation>
-    inline static size_t SerializationOp(T thisPtr, Stream& s, Operation ser_action, int nType, int nVersion) {
+    template <typename Stream, typename Operation>
+    inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
         size_t nSerSize = 0;
 
-        READWRITE(*(CBlockHeader*)thisPtr);
-        READWRITE(thisPtr->vtx);
+        READWRITE(*(CBlockHeader*)this);
+        READWRITE(vtx);
 
         return nSerSize;
     }
@@ -577,15 +577,15 @@ struct CBlockLocator
         vHave = vHaveIn;
     }
 
-    IMPLEMENT_SERIALIZE
+    IMPLEMENT_SERIALIZE;
 
-    template <typename T, typename Stream, typename Operation>
-    inline static size_t SerializationOp(T thisPtr, Stream& s, Operation ser_action, int nType, int nVersion) {
+    template <typename Stream, typename Operation>
+    inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
         size_t nSerSize = 0;
 
         if (!(nType & SER_GETHASH))
             READWRITE(nVersion);
-        READWRITE(thisPtr->vHave);
+        READWRITE(vHave);
 
         return nSerSize;
     }

--- a/src/core.h
+++ b/src/core.h
@@ -34,10 +34,8 @@ public:
     IMPLEMENT_SERIALIZE;
 
     template <typename Stream, typename Operation>
-    inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
-        size_t nSerSize = 0;
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
         READWRITE(FLATDATA(*this));
-        return nSerSize;
     }
 
     void SetNull() { hash = 0; n = (uint32_t) -1; }
@@ -96,12 +94,10 @@ public:
     IMPLEMENT_SERIALIZE;
 
     template <typename Stream, typename Operation>
-    inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
-        size_t nSerSize = 0;
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
         READWRITE(prevout);
         READWRITE(scriptSig);
         READWRITE(nSequence);
-        return nSerSize;
     }
 
     bool IsFinal() const
@@ -152,10 +148,8 @@ public:
     IMPLEMENT_SERIALIZE;
 
     template <typename Stream, typename Operation>
-    inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
-        size_t nSerSize = 0;
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
         READWRITE(nSatoshisPerK);
-        return nSerSize;
     }
 };
 
@@ -179,11 +173,9 @@ public:
     IMPLEMENT_SERIALIZE;
 
     template <typename Stream, typename Operation>
-    inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
-        size_t nSerSize = 0;
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
         READWRITE(nValue);
         READWRITE(scriptPubKey);
-        return nSerSize;
     }
 
     void SetNull()
@@ -264,9 +256,8 @@ public:
     IMPLEMENT_SERIALIZE;
 
     template <typename Stream, typename Operation>
-    inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
-        size_t nSerSize = 0;
-        bool fRead = boost::is_same<Operation, CSerActionUnserialize>();
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
+        bool fRead = ser_action.ForRead();
 
         READWRITE(*const_cast<int32_t*>(&this->nVersion));
         nVersion = this->nVersion;
@@ -275,8 +266,6 @@ public:
         READWRITE(*const_cast<uint32_t*>(&nLockTime));
         if (fRead)
             UpdateHash();
-
-        return nSerSize;
     }
 
     bool IsNull() const {
@@ -327,16 +316,12 @@ struct CMutableTransaction
     IMPLEMENT_SERIALIZE;
 
     template <typename Stream, typename Operation>
-    inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
-        size_t nSerSize = 0;
-
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
         READWRITE(this->nVersion);
         nVersion = this->nVersion;
         READWRITE(vin);
         READWRITE(vout);
         READWRITE(nLockTime);
-
-        return nSerSize;
     }
 
     /** Compute the hash of this CMutableTransaction. This is computed on the
@@ -360,9 +345,8 @@ public:
     IMPLEMENT_SERIALIZE;
 
     template <typename Stream, typename Operation>
-    inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
-        bool fRead = boost::is_same<Operation, CSerActionUnserialize>();
-        size_t nSerSize = 0;
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
+        bool fRead = ser_action.ForRead();
         if (!fRead) {
             uint64_t nVal = CompressAmount(txout.nValue);
             READWRITE(VARINT(nVal));
@@ -373,7 +357,6 @@ public:
         }
         CScriptCompressor cscript(REF(txout.scriptPubKey));
         READWRITE(cscript);
-        return nSerSize;
     }
 };
 
@@ -430,10 +413,8 @@ public:
     IMPLEMENT_SERIALIZE;
 
     template <typename Stream, typename Operation>
-    inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
-        size_t nSerSize = 0;
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
         READWRITE(vprevout);
-        return nSerSize;
     }
 };
 
@@ -465,9 +446,7 @@ public:
     IMPLEMENT_SERIALIZE;
 
     template <typename Stream, typename Operation>
-    inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
-        size_t nSerSize = 0;
-
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
         READWRITE(this->nVersion);
         nVersion = this->nVersion;
         READWRITE(hashPrevBlock);
@@ -475,8 +454,6 @@ public:
         READWRITE(nTime);
         READWRITE(nBits);
         READWRITE(nNonce);
-
-        return nSerSize;
     }
 
     void SetNull()
@@ -526,13 +503,9 @@ public:
     IMPLEMENT_SERIALIZE;
 
     template <typename Stream, typename Operation>
-    inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
-        size_t nSerSize = 0;
-
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
         READWRITE(*(CBlockHeader*)this);
         READWRITE(vtx);
-
-        return nSerSize;
     }
 
     void SetNull()
@@ -580,14 +553,10 @@ struct CBlockLocator
     IMPLEMENT_SERIALIZE;
 
     template <typename Stream, typename Operation>
-    inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
-        size_t nSerSize = 0;
-
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
         if (!(nType & SER_GETHASH))
             READWRITE(nVersion);
         READWRITE(vHave);
-
-        return nSerSize;
     }
 
     void SetNull()

--- a/src/crypter.h
+++ b/src/crypter.h
@@ -46,14 +46,12 @@ public:
     IMPLEMENT_SERIALIZE;
 
     template <typename Stream, typename Operation>
-    inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
-        size_t nSerSize = 0;
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
         READWRITE(vchCryptedKey);
         READWRITE(vchSalt);
         READWRITE(nDerivationMethod);
         READWRITE(nDeriveIterations);
         READWRITE(vchOtherDerivationParameters);
-        return nSerSize;
     }
 
     CMasterKey()

--- a/src/crypter.h
+++ b/src/crypter.h
@@ -43,16 +43,16 @@ public:
     // such as the various parameters to scrypt
     std::vector<unsigned char> vchOtherDerivationParameters;
 
-    IMPLEMENT_SERIALIZE
+    IMPLEMENT_SERIALIZE;
 
-    template <typename T, typename Stream, typename Operation>
-    inline static size_t SerializationOp(T thisPtr, Stream& s, Operation ser_action, int nType, int nVersion) {
+    template <typename Stream, typename Operation>
+    inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
         size_t nSerSize = 0;
-        READWRITE(thisPtr->vchCryptedKey);
-        READWRITE(thisPtr->vchSalt);
-        READWRITE(thisPtr->nDerivationMethod);
-        READWRITE(thisPtr->nDeriveIterations);
-        READWRITE(thisPtr->vchOtherDerivationParameters);
+        READWRITE(vchCryptedKey);
+        READWRITE(vchSalt);
+        READWRITE(nDerivationMethod);
+        READWRITE(nDeriveIterations);
+        READWRITE(vchOtherDerivationParameters);
         return nSerSize;
     }
 

--- a/src/crypter.h
+++ b/src/crypter.h
@@ -44,13 +44,18 @@ public:
     std::vector<unsigned char> vchOtherDerivationParameters;
 
     IMPLEMENT_SERIALIZE
-    (
-        READWRITE(vchCryptedKey);
-        READWRITE(vchSalt);
-        READWRITE(nDerivationMethod);
-        READWRITE(nDeriveIterations);
-        READWRITE(vchOtherDerivationParameters);
-    )
+
+    template <typename T, typename Stream, typename Operation>
+    inline static size_t SerializationOp(T thisPtr, Stream& s, Operation ser_action, int nType, int nVersion) {
+        size_t nSerSize = 0;
+        READWRITE(thisPtr->vchCryptedKey);
+        READWRITE(thisPtr->vchSalt);
+        READWRITE(thisPtr->nDerivationMethod);
+        READWRITE(thisPtr->nDeriveIterations);
+        READWRITE(thisPtr->vchOtherDerivationParameters);
+        return nSerSize;
+    }
+
     CMasterKey()
     {
         // 25000 rounds is just under 0.1 seconds on a 1.86 GHz Pentium M

--- a/src/main.h
+++ b/src/main.h
@@ -200,11 +200,9 @@ struct CDiskBlockPos
     IMPLEMENT_SERIALIZE;
 
     template <typename Stream, typename Operation>
-    inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
-        size_t nSerSize = 0;
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
         READWRITE(VARINT(nFile));
         READWRITE(VARINT(nPos));
-        return nSerSize;
     }
 
     CDiskBlockPos() {
@@ -235,11 +233,9 @@ struct CDiskTxPos : public CDiskBlockPos
     IMPLEMENT_SERIALIZE;
 
     template <typename Stream, typename Operation>
-    inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
-        size_t nSerSize = 0;
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
         READWRITE(*(CDiskBlockPos*)this);
         READWRITE(VARINT(nTxOffset));
-        return nSerSize;
     }
 
     CDiskTxPos(const CDiskBlockPos &blockIn, unsigned int nTxOffsetIn) : CDiskBlockPos(blockIn.nFile, blockIn.nPos), nTxOffset(nTxOffsetIn) {
@@ -320,10 +316,8 @@ public:
     IMPLEMENT_SERIALIZE;
 
     template <typename Stream, typename Operation>
-    inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
-        size_t nSerSize = 0;
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
         READWRITE(vtxundo);
-        return nSerSize;
     }
 
     bool WriteToDisk(CDiskBlockPos &pos, const uint256 &hashBlock);
@@ -429,9 +423,8 @@ public:
     IMPLEMENT_SERIALIZE;
 
     template <typename Stream, typename Operation>
-    inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
-        size_t nSerSize = 0;
-        bool fRead = boost::is_same<Operation, CSerActionUnserialize>();
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
+        bool fRead = ser_action.ForRead();
 
         READWRITE(nTransactions);
         READWRITE(vHash);
@@ -449,8 +442,6 @@ public:
                 vBytes[p / 8] |= vBits[p] << (p % 8);
             READWRITE(vBytes);
         }
-
-        return nSerSize;
     }
 
     // Construct a partial merkle tree from a list of transaction id's, and a mask that selects a subset of them
@@ -510,9 +501,7 @@ public:
     IMPLEMENT_SERIALIZE;
 
     template <typename Stream, typename Operation>
-    inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
-        size_t nSerSize = 0;
-
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
         READWRITE(VARINT(nBlocks));
         READWRITE(VARINT(nSize));
         READWRITE(VARINT(nUndoSize));
@@ -520,8 +509,6 @@ public:
         READWRITE(VARINT(nHeightLast));
         READWRITE(VARINT(nTimeFirst));
         READWRITE(VARINT(nTimeLast));
-
-        return nSerSize;
     }
 
      void SetNull() {
@@ -788,9 +775,7 @@ public:
     IMPLEMENT_SERIALIZE;
 
     template <typename Stream, typename Operation>
-    inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
-        size_t nSerSize = 0;
-
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
         if (!(nType & SER_GETHASH))
             READWRITE(VARINT(nVersion));
 
@@ -811,8 +796,6 @@ public:
         READWRITE(nTime);
         READWRITE(nBits);
         READWRITE(nNonce);
-
-        return nSerSize;
     }
 
     uint256 GetBlockHash() const
@@ -1014,11 +997,9 @@ public:
     IMPLEMENT_SERIALIZE;
 
     template <typename Stream, typename Operation>
-    inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
-        size_t nSerSize = 0;
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
         READWRITE(header);
         READWRITE(txn);
-        return nSerSize;
     }
 };
 

--- a/src/main.h
+++ b/src/main.h
@@ -197,13 +197,13 @@ struct CDiskBlockPos
     int nFile;
     unsigned int nPos;
 
-    IMPLEMENT_SERIALIZE
+    IMPLEMENT_SERIALIZE;
 
-    template <typename T, typename Stream, typename Operation>
-    inline static size_t SerializationOp(T thisPtr, Stream& s, Operation ser_action, int nType, int nVersion) {
+    template <typename Stream, typename Operation>
+    inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
         size_t nSerSize = 0;
-        READWRITE(VARINT(thisPtr->nFile));
-        READWRITE(VARINT(thisPtr->nPos));
+        READWRITE(VARINT(nFile));
+        READWRITE(VARINT(nPos));
         return nSerSize;
     }
 
@@ -232,13 +232,13 @@ struct CDiskTxPos : public CDiskBlockPos
 {
     unsigned int nTxOffset; // after header
 
-    IMPLEMENT_SERIALIZE
+    IMPLEMENT_SERIALIZE;
 
-    template <typename T, typename Stream, typename Operation>
-    inline static size_t SerializationOp(T thisPtr, Stream& s, Operation ser_action, int nType, int nVersion) {
+    template <typename Stream, typename Operation>
+    inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
         size_t nSerSize = 0;
-        READWRITE(*(CDiskBlockPos*)thisPtr);
-        READWRITE(VARINT(thisPtr->nTxOffset));
+        READWRITE(*(CDiskBlockPos*)this);
+        READWRITE(VARINT(nTxOffset));
         return nSerSize;
     }
 
@@ -317,12 +317,12 @@ class CBlockUndo
 public:
     std::vector<CTxUndo> vtxundo; // for all but the coinbase
 
-    IMPLEMENT_SERIALIZE
+    IMPLEMENT_SERIALIZE;
 
-    template <typename T, typename Stream, typename Operation>
-    inline static size_t SerializationOp(T thisPtr, Stream& s, Operation ser_action, int nType, int nVersion) {
+    template <typename Stream, typename Operation>
+    inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
         size_t nSerSize = 0;
-        READWRITE(thisPtr->vtxundo);
+        READWRITE(vtxundo);
         return nSerSize;
     }
 
@@ -426,27 +426,27 @@ protected:
 public:
 
     // serialization implementation
-    IMPLEMENT_SERIALIZE
+    IMPLEMENT_SERIALIZE;
 
-    template <typename T, typename Stream, typename Operation>
-    inline static size_t SerializationOp(T thisPtr, Stream& s, Operation ser_action, int nType, int nVersion) {
+    template <typename Stream, typename Operation>
+    inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
         size_t nSerSize = 0;
         bool fRead = boost::is_same<Operation, CSerActionUnserialize>();
 
-        READWRITE(thisPtr->nTransactions);
-        READWRITE(thisPtr->vHash);
+        READWRITE(nTransactions);
+        READWRITE(vHash);
         std::vector<unsigned char> vBytes;
         if (fRead) {
             READWRITE(vBytes);
-            CPartialMerkleTree &us = *(const_cast<CPartialMerkleTree*>(thisPtr));
+            CPartialMerkleTree &us = *(const_cast<CPartialMerkleTree*>(this));
             us.vBits.resize(vBytes.size() * 8);
             for (unsigned int p = 0; p < us.vBits.size(); p++)
                 us.vBits[p] = (vBytes[p / 8] & (1 << (p % 8))) != 0;
             us.fBad = false;
         } else {
-            vBytes.resize((thisPtr->vBits.size()+7)/8);
-            for (unsigned int p = 0; p < thisPtr->vBits.size(); p++)
-                vBytes[p / 8] |= thisPtr->vBits[p] << (p % 8);
+            vBytes.resize((vBits.size()+7)/8);
+            for (unsigned int p = 0; p < vBits.size(); p++)
+                vBytes[p / 8] |= vBits[p] << (p % 8);
             READWRITE(vBytes);
         }
 
@@ -507,19 +507,19 @@ public:
     uint64_t nTimeFirst;         // earliest time of block in file
     uint64_t nTimeLast;          // latest time of block in file
 
-    IMPLEMENT_SERIALIZE
+    IMPLEMENT_SERIALIZE;
 
-    template <typename T, typename Stream, typename Operation>
-    inline static size_t SerializationOp(T thisPtr, Stream& s, Operation ser_action, int nType, int nVersion) {
+    template <typename Stream, typename Operation>
+    inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
         size_t nSerSize = 0;
 
-        READWRITE(VARINT(thisPtr->nBlocks));
-        READWRITE(VARINT(thisPtr->nSize));
-        READWRITE(VARINT(thisPtr->nUndoSize));
-        READWRITE(VARINT(thisPtr->nHeightFirst));
-        READWRITE(VARINT(thisPtr->nHeightLast));
-        READWRITE(VARINT(thisPtr->nTimeFirst));
-        READWRITE(VARINT(thisPtr->nTimeLast));
+        READWRITE(VARINT(nBlocks));
+        READWRITE(VARINT(nSize));
+        READWRITE(VARINT(nUndoSize));
+        READWRITE(VARINT(nHeightFirst));
+        READWRITE(VARINT(nHeightLast));
+        READWRITE(VARINT(nTimeFirst));
+        READWRITE(VARINT(nTimeLast));
 
         return nSerSize;
     }
@@ -785,32 +785,32 @@ public:
         hashPrev = (pprev ? pprev->GetBlockHash() : 0);
     }
 
-    IMPLEMENT_SERIALIZE
+    IMPLEMENT_SERIALIZE;
 
-    template <typename T, typename Stream, typename Operation>
-    inline static size_t SerializationOp(T thisPtr, Stream& s, Operation ser_action, int nType, int nVersion) {
+    template <typename Stream, typename Operation>
+    inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
         size_t nSerSize = 0;
 
         if (!(nType & SER_GETHASH))
             READWRITE(VARINT(nVersion));
 
-        READWRITE(VARINT(thisPtr->nHeight));
-        READWRITE(VARINT(thisPtr->nStatus));
-        READWRITE(VARINT(thisPtr->nTx));
-        if (thisPtr->nStatus & (BLOCK_HAVE_DATA | BLOCK_HAVE_UNDO))
-            READWRITE(VARINT(thisPtr->nFile));
-        if (thisPtr->nStatus & BLOCK_HAVE_DATA)
-            READWRITE(VARINT(thisPtr->nDataPos));
-        if (thisPtr->nStatus & BLOCK_HAVE_UNDO)
-            READWRITE(VARINT(thisPtr->nUndoPos));
+        READWRITE(VARINT(nHeight));
+        READWRITE(VARINT(nStatus));
+        READWRITE(VARINT(nTx));
+        if (nStatus & (BLOCK_HAVE_DATA | BLOCK_HAVE_UNDO))
+            READWRITE(VARINT(nFile));
+        if (nStatus & BLOCK_HAVE_DATA)
+            READWRITE(VARINT(nDataPos));
+        if (nStatus & BLOCK_HAVE_UNDO)
+            READWRITE(VARINT(nUndoPos));
 
         // block header
-        READWRITE(thisPtr->nVersion);
-        READWRITE(thisPtr->hashPrev);
-        READWRITE(thisPtr->hashMerkleRoot);
-        READWRITE(thisPtr->nTime);
-        READWRITE(thisPtr->nBits);
-        READWRITE(thisPtr->nNonce);
+        READWRITE(this->nVersion);
+        READWRITE(hashPrev);
+        READWRITE(hashMerkleRoot);
+        READWRITE(nTime);
+        READWRITE(nBits);
+        READWRITE(nNonce);
 
         return nSerSize;
     }
@@ -1011,13 +1011,13 @@ public:
     // thus the filter will likely be modified.
     CMerkleBlock(const CBlock& block, CBloomFilter& filter);
 
-    IMPLEMENT_SERIALIZE
+    IMPLEMENT_SERIALIZE;
 
-    template <typename T, typename Stream, typename Operation>
-    inline static size_t SerializationOp(T thisPtr, Stream& s, Operation ser_action, int nType, int nVersion) {
+    template <typename Stream, typename Operation>
+    inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
         size_t nSerSize = 0;
-        READWRITE(thisPtr->header);
-        READWRITE(thisPtr->txn);
+        READWRITE(header);
+        READWRITE(txn);
         return nSerSize;
     }
 };

--- a/src/netbase.h
+++ b/src/netbase.h
@@ -91,10 +91,8 @@ class CNetAddr
         IMPLEMENT_SERIALIZE;
 
         template <typename Stream, typename Operation>
-        inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
-            size_t nSerSize = 0;
+        inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
             READWRITE(FLATDATA(ip));
-            return nSerSize;
         }
 };
 
@@ -155,16 +153,13 @@ class CService : public CNetAddr
         IMPLEMENT_SERIALIZE;
 
         template <typename Stream, typename Operation>
-        inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
-            bool fRead = boost::is_same<Operation, CSerActionUnserialize>();
-            size_t nSerSize = 0;
-            CService* pthis = const_cast<CService*>(this);
+        inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
+            bool fRead = ser_action.ForRead();
             READWRITE(FLATDATA(ip));
             unsigned short portN = htons(port);
             READWRITE(portN);
             if (fRead)
-                 pthis->port = ntohs(portN);
-            return nSerSize;
+                 port = ntohs(portN);
         }
 };
 

--- a/src/netbase.h
+++ b/src/netbase.h
@@ -88,12 +88,12 @@ class CNetAddr
         friend bool operator!=(const CNetAddr& a, const CNetAddr& b);
         friend bool operator<(const CNetAddr& a, const CNetAddr& b);
 
-        IMPLEMENT_SERIALIZE
+        IMPLEMENT_SERIALIZE;
 
-        template <typename T, typename Stream, typename Operation>
-        inline static size_t SerializationOp(T thisPtr, Stream& s, Operation ser_action, int nType, int nVersion) {
+        template <typename Stream, typename Operation>
+        inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
             size_t nSerSize = 0;
-            READWRITE(FLATDATA(thisPtr->ip));
+            READWRITE(FLATDATA(ip));
             return nSerSize;
         }
 };
@@ -152,15 +152,15 @@ class CService : public CNetAddr
         CService(const struct in6_addr& ipv6Addr, unsigned short port);
         CService(const struct sockaddr_in6& addr);
 
-        IMPLEMENT_SERIALIZE
+        IMPLEMENT_SERIALIZE;
 
-        template <typename T, typename Stream, typename Operation>
-        inline static size_t SerializationOp(T thisPtr, Stream& s, Operation ser_action, int nType, int nVersion) {
+        template <typename Stream, typename Operation>
+        inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
             bool fRead = boost::is_same<Operation, CSerActionUnserialize>();
             size_t nSerSize = 0;
-            CService* pthis = const_cast<CService*>(thisPtr);
-            READWRITE(FLATDATA(thisPtr->ip));
-            unsigned short portN = htons(thisPtr->port);
+            CService* pthis = const_cast<CService*>(this);
+            READWRITE(FLATDATA(ip));
+            unsigned short portN = htons(port);
             READWRITE(portN);
             if (fRead)
                  pthis->port = ntohs(portN);

--- a/src/netbase.h
+++ b/src/netbase.h
@@ -89,9 +89,13 @@ class CNetAddr
         friend bool operator<(const CNetAddr& a, const CNetAddr& b);
 
         IMPLEMENT_SERIALIZE
-            (
-             READWRITE(FLATDATA(ip));
-            )
+
+        template <typename T, typename Stream, typename Operation>
+        inline static size_t SerializationOp(T thisPtr, Stream& s, Operation ser_action, int nType, int nVersion) {
+            size_t nSerSize = 0;
+            READWRITE(FLATDATA(thisPtr->ip));
+            return nSerSize;
+        }
 };
 
 class CSubNet
@@ -149,14 +153,19 @@ class CService : public CNetAddr
         CService(const struct sockaddr_in6& addr);
 
         IMPLEMENT_SERIALIZE
-            (
-             CService* pthis = const_cast<CService*>(this);
-             READWRITE(FLATDATA(ip));
-             unsigned short portN = htons(port);
-             READWRITE(portN);
-             if (fRead)
+
+        template <typename T, typename Stream, typename Operation>
+        inline static size_t SerializationOp(T thisPtr, Stream& s, Operation ser_action, int nType, int nVersion) {
+            bool fRead = boost::is_same<Operation, CSerActionUnserialize>();
+            size_t nSerSize = 0;
+            CService* pthis = const_cast<CService*>(thisPtr);
+            READWRITE(FLATDATA(thisPtr->ip));
+            unsigned short portN = htons(thisPtr->port);
+            READWRITE(portN);
+            if (fRead)
                  pthis->port = ntohs(portN);
-            )
+            return nSerSize;
+        }
 };
 
 typedef CService proxyType;

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -35,15 +35,15 @@ class CMessageHeader
         std::string GetCommand() const;
         bool IsValid() const;
 
-        IMPLEMENT_SERIALIZE
+        IMPLEMENT_SERIALIZE;
 
-        template <typename T, typename Stream, typename Operation>
-        inline static size_t SerializationOp(T thisPtr, Stream& s, Operation ser_action, int nType, int nVersion) {
+        template <typename Stream, typename Operation>
+        inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
             size_t nSerSize = 0;
-            READWRITE(FLATDATA(thisPtr->pchMessageStart));
-            READWRITE(FLATDATA(thisPtr->pchCommand));
-            READWRITE(thisPtr->nMessageSize);
-            READWRITE(thisPtr->nChecksum);
+            READWRITE(FLATDATA(pchMessageStart));
+            READWRITE(FLATDATA(pchCommand));
+            READWRITE(nMessageSize);
+            READWRITE(nChecksum);
             return nSerSize;
         }
 
@@ -87,14 +87,14 @@ class CAddress : public CService
 
         void Init();
 
-        IMPLEMENT_SERIALIZE
+        IMPLEMENT_SERIALIZE;
 
-        template <typename T, typename Stream, typename Operation>
-        inline static size_t SerializationOp(T thisPtr, Stream& s, Operation ser_action, int nType, int nVersion) {
+        template <typename Stream, typename Operation>
+        inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
             size_t nSerSize = 0;
             bool fRead = boost::is_same<Operation, CSerActionUnserialize>();
 
-            CAddress* pthis = const_cast<CAddress*>(thisPtr);
+            CAddress* pthis = const_cast<CAddress*>(this);
             CService* pip = (CService*)pthis;
             if (fRead)
                 pthis->Init();
@@ -102,8 +102,8 @@ class CAddress : public CService
                 READWRITE(nVersion);
             if ((nType & SER_DISK) ||
                 (nVersion >= CADDR_TIME_VERSION && !(nType & SER_GETHASH)))
-            READWRITE(thisPtr->nTime);
-            READWRITE(thisPtr->nServices);
+            READWRITE(nTime);
+            READWRITE(nServices);
             READWRITE(*pip);
 
             return nSerSize;
@@ -128,13 +128,13 @@ class CInv
         CInv(int typeIn, const uint256& hashIn);
         CInv(const std::string& strType, const uint256& hashIn);
 
-        IMPLEMENT_SERIALIZE
+        IMPLEMENT_SERIALIZE;
 
-        template <typename T, typename Stream, typename Operation>
-        inline static size_t SerializationOp(T thisPtr, Stream& s, Operation ser_action, int nType, int nVersion) {
+        template <typename Stream, typename Operation>
+        inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
             size_t nSerSize = 0;
-            READWRITE(thisPtr->type);
-            READWRITE(thisPtr->hash);
+            READWRITE(type);
+            READWRITE(hash);
             return nSerSize;
         }
 

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -38,13 +38,11 @@ class CMessageHeader
         IMPLEMENT_SERIALIZE;
 
         template <typename Stream, typename Operation>
-        inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
-            size_t nSerSize = 0;
+        inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
             READWRITE(FLATDATA(pchMessageStart));
             READWRITE(FLATDATA(pchCommand));
             READWRITE(nMessageSize);
             READWRITE(nChecksum);
-            return nSerSize;
         }
 
     // TODO: make private (improves encapsulation)
@@ -90,12 +88,10 @@ class CAddress : public CService
         IMPLEMENT_SERIALIZE;
 
         template <typename Stream, typename Operation>
-        inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
-            size_t nSerSize = 0;
-            bool fRead = boost::is_same<Operation, CSerActionUnserialize>();
+        inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
+            bool fRead = ser_action.ForRead();
 
             CAddress* pthis = const_cast<CAddress*>(this);
-            CService* pip = (CService*)pthis;
             if (fRead)
                 pthis->Init();
             if (nType & SER_DISK)
@@ -104,9 +100,7 @@ class CAddress : public CService
                 (nVersion >= CADDR_TIME_VERSION && !(nType & SER_GETHASH)))
             READWRITE(nTime);
             READWRITE(nServices);
-            READWRITE(*pip);
-
-            return nSerSize;
+            READWRITE(*(CService*)this);
         }
 
     // TODO: make private (improves encapsulation)
@@ -131,11 +125,9 @@ class CInv
         IMPLEMENT_SERIALIZE;
 
         template <typename Stream, typename Operation>
-        inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
-            size_t nSerSize = 0;
+        inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
             READWRITE(type);
             READWRITE(hash);
-            return nSerSize;
         }
 
         friend bool operator<(const CInv& a, const CInv& b);

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -36,12 +36,16 @@ class CMessageHeader
         bool IsValid() const;
 
         IMPLEMENT_SERIALIZE
-            (
-             READWRITE(FLATDATA(pchMessageStart));
-             READWRITE(FLATDATA(pchCommand));
-             READWRITE(nMessageSize);
-             READWRITE(nChecksum);
-            )
+
+        template <typename T, typename Stream, typename Operation>
+        inline static size_t SerializationOp(T thisPtr, Stream& s, Operation ser_action, int nType, int nVersion) {
+            size_t nSerSize = 0;
+            READWRITE(FLATDATA(thisPtr->pchMessageStart));
+            READWRITE(FLATDATA(thisPtr->pchCommand));
+            READWRITE(thisPtr->nMessageSize);
+            READWRITE(thisPtr->nChecksum);
+            return nSerSize;
+        }
 
     // TODO: make private (improves encapsulation)
     public:
@@ -84,19 +88,26 @@ class CAddress : public CService
         void Init();
 
         IMPLEMENT_SERIALIZE
-            (
-             CAddress* pthis = const_cast<CAddress*>(this);
-             CService* pip = (CService*)pthis;
-             if (fRead)
-                 pthis->Init();
-             if (nType & SER_DISK)
-                 READWRITE(nVersion);
-             if ((nType & SER_DISK) ||
-                 (nVersion >= CADDR_TIME_VERSION && !(nType & SER_GETHASH)))
-                 READWRITE(nTime);
-             READWRITE(nServices);
-             READWRITE(*pip);
-            )
+
+        template <typename T, typename Stream, typename Operation>
+        inline static size_t SerializationOp(T thisPtr, Stream& s, Operation ser_action, int nType, int nVersion) {
+            size_t nSerSize = 0;
+            bool fRead = boost::is_same<Operation, CSerActionUnserialize>();
+
+            CAddress* pthis = const_cast<CAddress*>(thisPtr);
+            CService* pip = (CService*)pthis;
+            if (fRead)
+                pthis->Init();
+            if (nType & SER_DISK)
+                READWRITE(nVersion);
+            if ((nType & SER_DISK) ||
+                (nVersion >= CADDR_TIME_VERSION && !(nType & SER_GETHASH)))
+            READWRITE(thisPtr->nTime);
+            READWRITE(thisPtr->nServices);
+            READWRITE(*pip);
+
+            return nSerSize;
+        }
 
     // TODO: make private (improves encapsulation)
     public:
@@ -118,10 +129,14 @@ class CInv
         CInv(const std::string& strType, const uint256& hashIn);
 
         IMPLEMENT_SERIALIZE
-        (
-            READWRITE(type);
-            READWRITE(hash);
-        )
+
+        template <typename T, typename Stream, typename Operation>
+        inline static size_t SerializationOp(T thisPtr, Stream& s, Operation ser_action, int nType, int nVersion) {
+            size_t nSerSize = 0;
+            READWRITE(thisPtr->type);
+            READWRITE(thisPtr->hash);
+            return nSerSize;
+        }
 
         friend bool operator<(const CInv& a, const CInv& b);
 

--- a/src/qt/recentrequeststablemodel.h
+++ b/src/qt/recentrequeststablemodel.h
@@ -27,9 +27,8 @@ public:
     IMPLEMENT_SERIALIZE;
 
     template <typename Stream, typename Operation>
-    inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
-        size_t nSerSize = 0;
-        bool fRead = boost::is_same<Operation, CSerActionUnserialize>();
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
+        bool fRead = ser_action.ForRead();
 
         RecentRequestEntry* pthis = const_cast<RecentRequestEntry*>(this);
 
@@ -42,9 +41,7 @@ public:
         READWRITE(recipient);
 
         if (fRead)
-            pthis->date = QDateTime::fromTime_t(nDate);
-
-        return nSerSize;
+            date = QDateTime::fromTime_t(nDate);
     }
 };
 

--- a/src/qt/recentrequeststablemodel.h
+++ b/src/qt/recentrequeststablemodel.h
@@ -24,22 +24,22 @@ public:
     QDateTime date;
     SendCoinsRecipient recipient;
 
-    IMPLEMENT_SERIALIZE
+    IMPLEMENT_SERIALIZE;
 
-    template <typename T, typename Stream, typename Operation>
-    inline static size_t SerializationOp(T thisPtr, Stream& s, Operation ser_action, int nType, int nVersion) {
+    template <typename Stream, typename Operation>
+    inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
         size_t nSerSize = 0;
         bool fRead = boost::is_same<Operation, CSerActionUnserialize>();
 
-        RecentRequestEntry* pthis = const_cast<RecentRequestEntry*>(thisPtr);
+        RecentRequestEntry* pthis = const_cast<RecentRequestEntry*>(this);
 
-        unsigned int nDate = thisPtr->date.toTime_t();
+        unsigned int nDate = date.toTime_t();
 
         READWRITE(pthis->nVersion);
         nVersion = pthis->nVersion;
-        READWRITE(thisPtr->id);
+        READWRITE(id);
         READWRITE(nDate);
-        READWRITE(thisPtr->recipient);
+        READWRITE(recipient);
 
         if (fRead)
             pthis->date = QDateTime::fromTime_t(nDate);

--- a/src/qt/recentrequeststablemodel.h
+++ b/src/qt/recentrequeststablemodel.h
@@ -25,20 +25,27 @@ public:
     SendCoinsRecipient recipient;
 
     IMPLEMENT_SERIALIZE
-    (
-        RecentRequestEntry* pthis = const_cast<RecentRequestEntry*>(this);
 
-        unsigned int nDate = date.toTime_t();
+    template <typename T, typename Stream, typename Operation>
+    inline static size_t SerializationOp(T thisPtr, Stream& s, Operation ser_action, int nType, int nVersion) {
+        size_t nSerSize = 0;
+        bool fRead = boost::is_same<Operation, CSerActionUnserialize>();
+
+        RecentRequestEntry* pthis = const_cast<RecentRequestEntry*>(thisPtr);
+
+        unsigned int nDate = thisPtr->date.toTime_t();
 
         READWRITE(pthis->nVersion);
         nVersion = pthis->nVersion;
-        READWRITE(id);
+        READWRITE(thisPtr->id);
         READWRITE(nDate);
-        READWRITE(recipient);
+        READWRITE(thisPtr->recipient);
 
         if (fRead)
             pthis->date = QDateTime::fromTime_t(nDate);
-    )
+
+        return nSerSize;
+    }
 };
 
 class RecentRequestEntryLessThan

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -62,9 +62,8 @@ public:
     IMPLEMENT_SERIALIZE;
 
     template <typename Stream, typename Operation>
-    inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
-        size_t nSerSize = 0;
-        bool fRead = boost::is_same<Operation, CSerActionUnserialize>();
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
+        bool fRead = ser_action.ForRead();
 
         SendCoinsRecipient* pthis = const_cast<SendCoinsRecipient*>(this);
 
@@ -94,8 +93,6 @@ public:
                 pthis->paymentRequest.parse(QByteArray::fromRawData(sPaymentRequest.data(), sPaymentRequest.size()));
             pthis->authenticatedMerchant = QString::fromStdString(sAuthenticatedMerchant);
         }
-
-        return nSerSize;
     }
 };
 

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -59,14 +59,14 @@ public:
     static const int CURRENT_VERSION = 1;
     int nVersion;
 
-    IMPLEMENT_SERIALIZE
+    IMPLEMENT_SERIALIZE;
 
-    template <typename T, typename Stream, typename Operation>
-    inline static size_t SerializationOp(T thisPtr, Stream& s, Operation ser_action, int nType, int nVersion) {
+    template <typename Stream, typename Operation>
+    inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
         size_t nSerSize = 0;
         bool fRead = boost::is_same<Operation, CSerActionUnserialize>();
 
-        SendCoinsRecipient* pthis = const_cast<SendCoinsRecipient*>(thisPtr);
+        SendCoinsRecipient* pthis = const_cast<SendCoinsRecipient*>(this);
 
         std::string sAddress = pthis->address.toStdString();
         std::string sLabel = pthis->label.toStdString();
@@ -80,7 +80,7 @@ public:
         nVersion = pthis->nVersion;
         READWRITE(sAddress);
         READWRITE(sLabel);
-        READWRITE(thisPtr->amount);
+        READWRITE(amount);
         READWRITE(sMessage);
         READWRITE(sPaymentRequest);
         READWRITE(sAuthenticatedMerchant);

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -60,8 +60,13 @@ public:
     int nVersion;
 
     IMPLEMENT_SERIALIZE
-    (
-        SendCoinsRecipient* pthis = const_cast<SendCoinsRecipient*>(this);
+
+    template <typename T, typename Stream, typename Operation>
+    inline static size_t SerializationOp(T thisPtr, Stream& s, Operation ser_action, int nType, int nVersion) {
+        size_t nSerSize = 0;
+        bool fRead = boost::is_same<Operation, CSerActionUnserialize>();
+
+        SendCoinsRecipient* pthis = const_cast<SendCoinsRecipient*>(thisPtr);
 
         std::string sAddress = pthis->address.toStdString();
         std::string sLabel = pthis->label.toStdString();
@@ -75,7 +80,7 @@ public:
         nVersion = pthis->nVersion;
         READWRITE(sAddress);
         READWRITE(sLabel);
-        READWRITE(amount);
+        READWRITE(thisPtr->amount);
         READWRITE(sMessage);
         READWRITE(sPaymentRequest);
         READWRITE(sAuthenticatedMerchant);
@@ -89,7 +94,9 @@ public:
                 pthis->paymentRequest.parse(QByteArray::fromRawData(sPaymentRequest.data(), sPaymentRequest.size()));
             pthis->authenticatedMerchant = QString::fromStdString(sAuthenticatedMerchant);
         }
-    )
+
+        return nSerSize;
+    }
 };
 
 /** Interface to Bitcoin wallet from Qt view code. */

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -22,7 +22,6 @@
 
 #include <boost/tuple/tuple.hpp>
 #include <boost/type_traits/is_fundamental.hpp>
-#include <boost/typeof/typeof.hpp>
 
 class CAutoFile;
 class CDataStream;
@@ -88,24 +87,25 @@ enum
     SER_GETHASH         = (1 << 2),
 };
 
-#define READWRITE(obj)      (nSerSize += ::SerReadWrite(s, (obj), nType, nVersion, ser_action))
+#define READWRITE(obj)      (::SerReadWrite(s, (obj), nType, nVersion, ser_action))
 
 /* Implement three methods for serializable objects. These are actually wrappers over
  * "SerializationOp" template, which implements the body of each class' serialization
  * code. Adding "IMPLEMENT_SERIALIZE" in the body of the class causes these wrappers to be
  * added as members. */
-#define IMPLEMENT_SERIALIZE                                                                         \
-    size_t GetSerializeSize(int nType, int nVersion) const {                                        \
-        ser_streamplaceholder s;                                                                    \
-        return NCONST_PTR(this)->SerializationOp(s, CSerActionGetSerializeSize(), nType, nVersion); \
-    }                                                                                               \
-    template<typename Stream>                                                                       \
-    void Serialize(Stream& s, int nType, int nVersion) const {                                      \
-        NCONST_PTR(this)->SerializationOp(s, CSerActionSerialize(), nType, nVersion);               \
-    }                                                                                               \
-    template<typename Stream>                                                                       \
-    void Unserialize(Stream& s, int nType, int nVersion) {                                          \
-        SerializationOp(s, CSerActionUnserialize(), nType, nVersion);                               \
+#define IMPLEMENT_SERIALIZE                                                          \
+    size_t GetSerializeSize(int nType, int nVersion) const {                         \
+        CSizeComputer s(nType, nVersion);                                            \
+        NCONST_PTR(this)->SerializationOp(s, CSerActionSerialize(), nType, nVersion);\
+        return s.size();                                                             \
+    }                                                                                \
+    template<typename Stream>                                                        \
+    void Serialize(Stream& s, int nType, int nVersion) const {                       \
+        NCONST_PTR(this)->SerializationOp(s, CSerActionSerialize(), nType, nVersion);\
+    }                                                                                \
+    template<typename Stream>                                                        \
+    void Unserialize(Stream& s, int nType, int nVersion) {                           \
+        SerializationOp(s, CSerActionUnserialize(), nType, nVersion);                \
     }
 
 
@@ -809,31 +809,26 @@ void Unserialize(Stream& is, std::set<K, Pred, A>& m, int nType, int nVersion)
 //
 // Support for IMPLEMENT_SERIALIZE and READWRITE macro
 //
-class CSerActionGetSerializeSize { };
-class CSerActionSerialize { };
-class CSerActionUnserialize { };
-
-template<typename Stream, typename T>
-inline unsigned int SerReadWrite(Stream& s, const T& obj, int nType, int nVersion, CSerActionGetSerializeSize ser_action)
+struct CSerActionSerialize
 {
-    return ::GetSerializeSize(obj, nType, nVersion);
-}
+    bool ForRead() const { return false; }
+};
+struct CSerActionUnserialize
+{
+    bool ForRead() const { return true; }
+};
 
 template<typename Stream, typename T>
-inline unsigned int SerReadWrite(Stream& s, const T& obj, int nType, int nVersion, CSerActionSerialize ser_action)
+inline void SerReadWrite(Stream& s, const T& obj, int nType, int nVersion, CSerActionSerialize ser_action)
 {
     ::Serialize(s, obj, nType, nVersion);
-    return 0;
 }
 
 template<typename Stream, typename T>
-inline unsigned int SerReadWrite(Stream& s, T& obj, int nType, int nVersion, CSerActionUnserialize ser_action)
+inline void SerReadWrite(Stream& s, T& obj, int nType, int nVersion, CSerActionUnserialize ser_action)
 {
     ::Unserialize(s, obj, nType, nVersion);
-    return 0;
 }
-
-struct ser_streamplaceholder { };
 
 
 

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -97,8 +97,6 @@ enum
 #define IMPLEMENT_SERIALIZE                                                                         \
     size_t GetSerializeSize(int nType, int nVersion) const {                                        \
         ser_streamplaceholder s;                                                                    \
-        s.nType = nType;                                                                            \
-        s.nVersion = nVersion;                                                                      \
         return SerializationOp(MAKE_CONST(this), s, CSerActionGetSerializeSize(), nType, nVersion); \
     }                                                                                               \
     template<typename Stream>                                                                       \
@@ -835,13 +833,7 @@ inline unsigned int SerReadWrite(Stream& s, T& obj, int nType, int nVersion, CSe
     return 0;
 }
 
-struct ser_streamplaceholder
-{
-    int nType;
-    int nVersion;
-};
-
-
+struct ser_streamplaceholder { };
 
 
 

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -38,12 +38,12 @@ inline T& REF(const T& val)
     return const_cast<T&>(val);
 }
 
-// Used to acquire a const pointer "this" and generate a const
-// serialization operation from a template
+// Used to acquire a non-const pointer "this" to generate bodies
+// of const serialization operations from a template
 template<typename T>
-inline T MAKE_CONST(T val)
+inline T* NCONST_PTR(const T* val)
 {
-    return const_cast<const T>(val);
+    return const_cast<T*>(val);
 }
 
 /** Get begin pointer of vector (non-const version).
@@ -97,15 +97,15 @@ enum
 #define IMPLEMENT_SERIALIZE                                                                         \
     size_t GetSerializeSize(int nType, int nVersion) const {                                        \
         ser_streamplaceholder s;                                                                    \
-        return SerializationOp(MAKE_CONST(this), s, CSerActionGetSerializeSize(), nType, nVersion); \
+        return NCONST_PTR(this)->SerializationOp(s, CSerActionGetSerializeSize(), nType, nVersion); \
     }                                                                                               \
     template<typename Stream>                                                                       \
     void Serialize(Stream& s, int nType, int nVersion) const {                                      \
-        SerializationOp(MAKE_CONST(this), s, CSerActionSerialize(), nType, nVersion);               \
+        NCONST_PTR(this)->SerializationOp(s, CSerActionSerialize(), nType, nVersion);               \
     }                                                                                               \
     template<typename Stream>                                                                       \
     void Unserialize(Stream& s, int nType, int nVersion) {                                          \
-        SerializationOp(this, s, CSerActionUnserialize(), nType, nVersion);                         \
+        SerializationOp(s, CSerActionUnserialize(), nType, nVersion);                               \
     }
 
 

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -66,13 +66,11 @@ public:
     IMPLEMENT_SERIALIZE;
 
     template <typename Stream, typename Operation>
-    inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
-        size_t nSerSize = 0;
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
         if (!(nType & SER_GETHASH))
             READWRITE(nVersion);
         READWRITE(nTime);
         READWRITE(vchPubKey);
-        return nSerSize;
     }
 };
 
@@ -496,16 +494,12 @@ public:
     IMPLEMENT_SERIALIZE;
 
     template <typename Stream, typename Operation>
-    inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
-        size_t nSerSize = 0;
-
-        nSerSize += SerReadWrite(s, *(CTransaction*)this, nType, nVersion, ser_action);
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
+        READWRITE(*(CTransaction*)this);
         nVersion = this->nVersion;
         READWRITE(hashBlock);
         READWRITE(vMerkleBranch);
         READWRITE(nIndex);
-
-        return nSerSize;
     }
 
     int SetMerkleBranch(const CBlock* pblock=NULL);
@@ -613,9 +607,8 @@ public:
     IMPLEMENT_SERIALIZE;
 
     template <typename Stream, typename Operation>
-    inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
-        size_t nSerSize = 0;
-        bool fRead = boost::is_same<Operation, CSerActionUnserialize>();
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
+        bool fRead = ser_action.ForRead();
 
         CWalletTx* pthis = const_cast<CWalletTx*>(this);
         if (fRead)
@@ -632,7 +625,7 @@ public:
                 pthis->mapValue["timesmart"] = strprintf("%u", nTimeSmart);
         }
 
-        nSerSize += SerReadWrite(s, *(CMerkleTx*)this, nType, nVersion,ser_action);
+        READWRITE(*(CMerkleTx*)this);
         std::vector<CMerkleTx> vUnused; // Used to be vtxPrev
         READWRITE(vUnused);
         READWRITE(mapValue);
@@ -651,13 +644,11 @@ public:
             pthis->nTimeSmart = mapValue.count("timesmart") ? (unsigned int)atoi64(pthis->mapValue["timesmart"]) : 0;
         }
 
-        pthis->mapValue.erase("fromaccount");
-        pthis->mapValue.erase("version");
-        pthis->mapValue.erase("spent");
-        pthis->mapValue.erase("n");
-        pthis->mapValue.erase("timesmart");
-
-        return nSerSize;
+        mapValue.erase("fromaccount");
+        mapValue.erase("version");
+        mapValue.erase("spent");
+        mapValue.erase("n");
+        mapValue.erase("timesmart");
     }
 
     // make sure balances are recalculated
@@ -907,15 +898,13 @@ public:
     IMPLEMENT_SERIALIZE;
 
     template <typename Stream, typename Operation>
-    inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
-        size_t nSerSize = 0;
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
         if (!(nType & SER_GETHASH))
             READWRITE(nVersion);
         READWRITE(vchPrivKey);
         READWRITE(nTimeCreated);
         READWRITE(nTimeExpires);
         READWRITE(LIMITED_STRING(strComment, 65536));
-        return nSerSize;
     }
 };
 
@@ -945,12 +934,10 @@ public:
     IMPLEMENT_SERIALIZE;
 
     template <typename Stream, typename Operation>
-    inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
-        size_t nSerSize = 0;
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
         if (!(nType & SER_GETHASH))
             READWRITE(nVersion);
         READWRITE(vchPubKey);
-        return nSerSize;
     }
 };
 
@@ -990,9 +977,8 @@ public:
     IMPLEMENT_SERIALIZE;
 
     template <typename Stream, typename Operation>
-    inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
-        size_t nSerSize = 0;
-        bool fRead = boost::is_same<Operation, CSerActionUnserialize>();
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
+        bool fRead = ser_action.ForRead();
 
         CAccountingEntry& me = *const_cast<CAccountingEntry*>(this);
         if (!(nType & SER_GETHASH))
@@ -1033,9 +1019,7 @@ public:
         if (std::string::npos != nSepPos)
             me.strComment.erase(nSepPos);
 
-        me.mapValue.erase("n");
-
-        return nSerSize;
+        mapValue.erase("n");
     }
 
 private:

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -64,12 +64,16 @@ public:
     CKeyPool(const CPubKey& vchPubKeyIn);
 
     IMPLEMENT_SERIALIZE
-    (
+
+    template <typename T, typename Stream, typename Operation>
+    inline static size_t SerializationOp(T thisPtr, Stream& s, Operation ser_action, int nType, int nVersion) {
+        size_t nSerSize = 0;
         if (!(nType & SER_GETHASH))
             READWRITE(nVersion);
-        READWRITE(nTime);
-        READWRITE(vchPubKey);
-    )
+        READWRITE(thisPtr->nTime);
+        READWRITE(thisPtr->vchPubKey);
+        return nSerSize;
+    }
 };
 
 /** Address book data */
@@ -489,16 +493,20 @@ public:
         fMerkleVerified = false;
     }
 
-
     IMPLEMENT_SERIALIZE
-    (
-        nSerSize += SerReadWrite(s, *(CTransaction*)this, nType, nVersion, ser_action);
-        nVersion = this->nVersion;
-        READWRITE(hashBlock);
-        READWRITE(vMerkleBranch);
-        READWRITE(nIndex);
-    )
 
+    template <typename T, typename Stream, typename Operation>
+    inline static size_t SerializationOp(T thisPtr, Stream& s, Operation ser_action, int nType, int nVersion) {
+        size_t nSerSize = 0;
+
+        nSerSize += SerReadWrite(s, *(CTransaction*)thisPtr, nType, nVersion, ser_action);
+        nVersion = thisPtr->nVersion;
+        READWRITE(thisPtr->hashBlock);
+        READWRITE(thisPtr->vMerkleBranch);
+        READWRITE(thisPtr->nIndex);
+
+        return nSerSize;
+    }
 
     int SetMerkleBranch(const CBlock* pblock=NULL);
 
@@ -512,7 +520,6 @@ public:
     int GetBlocksToMaturity() const;
     bool AcceptToMemoryPool(bool fLimitFree=true, bool fRejectInsaneFee=true);
 };
-
 
 /** A transaction with a bunch of additional info that only the owner cares about.
  * It includes any unrecorded transactions needed to link it back to the block chain.
@@ -604,8 +611,13 @@ public:
     }
 
     IMPLEMENT_SERIALIZE
-    (
-        CWalletTx* pthis = const_cast<CWalletTx*>(this);
+
+    template <typename T, typename Stream, typename Operation>
+    inline static size_t SerializationOp(T thisPtr, Stream& s, Operation ser_action, int nType, int nVersion) {
+        size_t nSerSize = 0;
+        bool fRead = boost::is_same<Operation, CSerActionUnserialize>();
+
+        CWalletTx* pthis = const_cast<CWalletTx*>(thisPtr);
         if (fRead)
             pthis->Init(NULL);
         char fSpent = false;
@@ -616,18 +628,18 @@ public:
 
             WriteOrderPos(pthis->nOrderPos, pthis->mapValue);
 
-            if (nTimeSmart)
-                pthis->mapValue["timesmart"] = strprintf("%u", nTimeSmart);
+            if (thisPtr->nTimeSmart)
+                pthis->mapValue["timesmart"] = strprintf("%u", thisPtr->nTimeSmart);
         }
 
-        nSerSize += SerReadWrite(s, *(CMerkleTx*)this, nType, nVersion,ser_action);
+        nSerSize += SerReadWrite(s, *(CMerkleTx*)thisPtr, nType, nVersion,ser_action);
         std::vector<CMerkleTx> vUnused; // Used to be vtxPrev
         READWRITE(vUnused);
-        READWRITE(mapValue);
-        READWRITE(vOrderForm);
-        READWRITE(fTimeReceivedIsTxTime);
-        READWRITE(nTimeReceived);
-        READWRITE(fFromMe);
+        READWRITE(thisPtr->mapValue);
+        READWRITE(thisPtr->vOrderForm);
+        READWRITE(thisPtr->fTimeReceivedIsTxTime);
+        READWRITE(thisPtr->nTimeReceived);
+        READWRITE(thisPtr->fFromMe);
         READWRITE(fSpent);
 
         if (fRead)
@@ -636,7 +648,7 @@ public:
 
             ReadOrderPos(pthis->nOrderPos, pthis->mapValue);
 
-            pthis->nTimeSmart = mapValue.count("timesmart") ? (unsigned int)atoi64(pthis->mapValue["timesmart"]) : 0;
+            pthis->nTimeSmart = thisPtr->mapValue.count("timesmart") ? (unsigned int)atoi64(pthis->mapValue["timesmart"]) : 0;
         }
 
         pthis->mapValue.erase("fromaccount");
@@ -644,7 +656,9 @@ public:
         pthis->mapValue.erase("spent");
         pthis->mapValue.erase("n");
         pthis->mapValue.erase("timesmart");
-    )
+
+        return nSerSize;
+    }
 
     // make sure balances are recalculated
     void MarkDirty()
@@ -891,14 +905,18 @@ public:
     CWalletKey(int64_t nExpires=0);
 
     IMPLEMENT_SERIALIZE
-    (
+
+    template <typename T, typename Stream, typename Operation>
+    inline static size_t SerializationOp(T thisPtr, Stream& s, Operation ser_action, int nType, int nVersion) {
+        size_t nSerSize = 0;
         if (!(nType & SER_GETHASH))
             READWRITE(nVersion);
-        READWRITE(vchPrivKey);
-        READWRITE(nTimeCreated);
-        READWRITE(nTimeExpires);
-        READWRITE(LIMITED_STRING(strComment, 65536));
-    )
+        READWRITE(thisPtr->vchPrivKey);
+        READWRITE(thisPtr->nTimeCreated);
+        READWRITE(thisPtr->nTimeExpires);
+        READWRITE(LIMITED_STRING(thisPtr->strComment, 65536));
+        return nSerSize;
+    }
 };
 
 
@@ -925,11 +943,15 @@ public:
     }
 
     IMPLEMENT_SERIALIZE
-    (
+
+    template <typename T, typename Stream, typename Operation>
+    inline static size_t SerializationOp(T thisPtr, Stream& s, Operation ser_action, int nType, int nVersion) {
+        size_t nSerSize = 0;
         if (!(nType & SER_GETHASH))
             READWRITE(nVersion);
-        READWRITE(vchPubKey);
-    )
+        READWRITE(thisPtr->vchPubKey);
+        return nSerSize;
+    }
 };
 
 
@@ -966,38 +988,43 @@ public:
     }
 
     IMPLEMENT_SERIALIZE
-    (
-        CAccountingEntry& me = *const_cast<CAccountingEntry*>(this);
+
+    template <typename T, typename Stream, typename Operation>
+    inline static size_t SerializationOp(T thisPtr, Stream& s, Operation ser_action, int nType, int nVersion) {
+        size_t nSerSize = 0;
+        bool fRead = boost::is_same<Operation, CSerActionUnserialize>();
+
+        CAccountingEntry& me = *const_cast<CAccountingEntry*>(thisPtr);
         if (!(nType & SER_GETHASH))
             READWRITE(nVersion);
         // Note: strAccount is serialized as part of the key, not here.
-        READWRITE(nCreditDebit);
-        READWRITE(nTime);
-        READWRITE(LIMITED_STRING(strOtherAccount, 65536));
+        READWRITE(thisPtr->nCreditDebit);
+        READWRITE(thisPtr->nTime);
+        READWRITE(LIMITED_STRING(thisPtr->strOtherAccount, 65536));
 
         if (!fRead)
         {
-            WriteOrderPos(nOrderPos, me.mapValue);
+            WriteOrderPos(thisPtr->nOrderPos, me.mapValue);
 
-            if (!(mapValue.empty() && _ssExtra.empty()))
+            if (!(thisPtr->mapValue.empty() && thisPtr->_ssExtra.empty()))
             {
                 CDataStream ss(nType, nVersion);
                 ss.insert(ss.begin(), '\0');
-                ss << mapValue;
-                ss.insert(ss.end(), _ssExtra.begin(), _ssExtra.end());
+                ss << thisPtr->mapValue;
+                ss.insert(ss.end(), thisPtr->_ssExtra.begin(), thisPtr->_ssExtra.end());
                 me.strComment.append(ss.str());
             }
         }
 
-        READWRITE(LIMITED_STRING(strComment, 65536));
+        READWRITE(LIMITED_STRING(thisPtr->strComment, 65536));
 
-        size_t nSepPos = strComment.find("\0", 0, 1);
+        size_t nSepPos = thisPtr->strComment.find("\0", 0, 1);
         if (fRead)
         {
             me.mapValue.clear();
             if (std::string::npos != nSepPos)
             {
-                CDataStream ss(std::vector<char>(strComment.begin() + nSepPos + 1, strComment.end()), nType, nVersion);
+                CDataStream ss(std::vector<char>(thisPtr->strComment.begin() + nSepPos + 1, thisPtr->strComment.end()), nType, nVersion);
                 ss >> me.mapValue;
                 me._ssExtra = std::vector<char>(ss.begin(), ss.end());
             }
@@ -1007,7 +1034,9 @@ public:
             me.strComment.erase(nSepPos);
 
         me.mapValue.erase("n");
-    )
+
+        return nSerSize;
+    }
 
 private:
     std::vector<char> _ssExtra;

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -63,15 +63,15 @@ public:
     CKeyPool();
     CKeyPool(const CPubKey& vchPubKeyIn);
 
-    IMPLEMENT_SERIALIZE
+    IMPLEMENT_SERIALIZE;
 
-    template <typename T, typename Stream, typename Operation>
-    inline static size_t SerializationOp(T thisPtr, Stream& s, Operation ser_action, int nType, int nVersion) {
+    template <typename Stream, typename Operation>
+    inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
         size_t nSerSize = 0;
         if (!(nType & SER_GETHASH))
             READWRITE(nVersion);
-        READWRITE(thisPtr->nTime);
-        READWRITE(thisPtr->vchPubKey);
+        READWRITE(nTime);
+        READWRITE(vchPubKey);
         return nSerSize;
     }
 };
@@ -493,17 +493,17 @@ public:
         fMerkleVerified = false;
     }
 
-    IMPLEMENT_SERIALIZE
+    IMPLEMENT_SERIALIZE;
 
-    template <typename T, typename Stream, typename Operation>
-    inline static size_t SerializationOp(T thisPtr, Stream& s, Operation ser_action, int nType, int nVersion) {
+    template <typename Stream, typename Operation>
+    inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
         size_t nSerSize = 0;
 
-        nSerSize += SerReadWrite(s, *(CTransaction*)thisPtr, nType, nVersion, ser_action);
-        nVersion = thisPtr->nVersion;
-        READWRITE(thisPtr->hashBlock);
-        READWRITE(thisPtr->vMerkleBranch);
-        READWRITE(thisPtr->nIndex);
+        nSerSize += SerReadWrite(s, *(CTransaction*)this, nType, nVersion, ser_action);
+        nVersion = this->nVersion;
+        READWRITE(hashBlock);
+        READWRITE(vMerkleBranch);
+        READWRITE(nIndex);
 
         return nSerSize;
     }
@@ -610,14 +610,14 @@ public:
         nOrderPos = -1;
     }
 
-    IMPLEMENT_SERIALIZE
+    IMPLEMENT_SERIALIZE;
 
-    template <typename T, typename Stream, typename Operation>
-    inline static size_t SerializationOp(T thisPtr, Stream& s, Operation ser_action, int nType, int nVersion) {
+    template <typename Stream, typename Operation>
+    inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
         size_t nSerSize = 0;
         bool fRead = boost::is_same<Operation, CSerActionUnserialize>();
 
-        CWalletTx* pthis = const_cast<CWalletTx*>(thisPtr);
+        CWalletTx* pthis = const_cast<CWalletTx*>(this);
         if (fRead)
             pthis->Init(NULL);
         char fSpent = false;
@@ -628,18 +628,18 @@ public:
 
             WriteOrderPos(pthis->nOrderPos, pthis->mapValue);
 
-            if (thisPtr->nTimeSmart)
-                pthis->mapValue["timesmart"] = strprintf("%u", thisPtr->nTimeSmart);
+            if (nTimeSmart)
+                pthis->mapValue["timesmart"] = strprintf("%u", nTimeSmart);
         }
 
-        nSerSize += SerReadWrite(s, *(CMerkleTx*)thisPtr, nType, nVersion,ser_action);
+        nSerSize += SerReadWrite(s, *(CMerkleTx*)this, nType, nVersion,ser_action);
         std::vector<CMerkleTx> vUnused; // Used to be vtxPrev
         READWRITE(vUnused);
-        READWRITE(thisPtr->mapValue);
-        READWRITE(thisPtr->vOrderForm);
-        READWRITE(thisPtr->fTimeReceivedIsTxTime);
-        READWRITE(thisPtr->nTimeReceived);
-        READWRITE(thisPtr->fFromMe);
+        READWRITE(mapValue);
+        READWRITE(vOrderForm);
+        READWRITE(fTimeReceivedIsTxTime);
+        READWRITE(nTimeReceived);
+        READWRITE(fFromMe);
         READWRITE(fSpent);
 
         if (fRead)
@@ -648,7 +648,7 @@ public:
 
             ReadOrderPos(pthis->nOrderPos, pthis->mapValue);
 
-            pthis->nTimeSmart = thisPtr->mapValue.count("timesmart") ? (unsigned int)atoi64(pthis->mapValue["timesmart"]) : 0;
+            pthis->nTimeSmart = mapValue.count("timesmart") ? (unsigned int)atoi64(pthis->mapValue["timesmart"]) : 0;
         }
 
         pthis->mapValue.erase("fromaccount");
@@ -904,17 +904,17 @@ public:
 
     CWalletKey(int64_t nExpires=0);
 
-    IMPLEMENT_SERIALIZE
+    IMPLEMENT_SERIALIZE;
 
-    template <typename T, typename Stream, typename Operation>
-    inline static size_t SerializationOp(T thisPtr, Stream& s, Operation ser_action, int nType, int nVersion) {
+    template <typename Stream, typename Operation>
+    inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
         size_t nSerSize = 0;
         if (!(nType & SER_GETHASH))
             READWRITE(nVersion);
-        READWRITE(thisPtr->vchPrivKey);
-        READWRITE(thisPtr->nTimeCreated);
-        READWRITE(thisPtr->nTimeExpires);
-        READWRITE(LIMITED_STRING(thisPtr->strComment, 65536));
+        READWRITE(vchPrivKey);
+        READWRITE(nTimeCreated);
+        READWRITE(nTimeExpires);
+        READWRITE(LIMITED_STRING(strComment, 65536));
         return nSerSize;
     }
 };
@@ -942,14 +942,14 @@ public:
         vchPubKey = CPubKey();
     }
 
-    IMPLEMENT_SERIALIZE
+    IMPLEMENT_SERIALIZE;
 
-    template <typename T, typename Stream, typename Operation>
-    inline static size_t SerializationOp(T thisPtr, Stream& s, Operation ser_action, int nType, int nVersion) {
+    template <typename Stream, typename Operation>
+    inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
         size_t nSerSize = 0;
         if (!(nType & SER_GETHASH))
             READWRITE(nVersion);
-        READWRITE(thisPtr->vchPubKey);
+        READWRITE(vchPubKey);
         return nSerSize;
     }
 };
@@ -987,44 +987,44 @@ public:
         nEntryNo = 0;
     }
 
-    IMPLEMENT_SERIALIZE
+    IMPLEMENT_SERIALIZE;
 
-    template <typename T, typename Stream, typename Operation>
-    inline static size_t SerializationOp(T thisPtr, Stream& s, Operation ser_action, int nType, int nVersion) {
+    template <typename Stream, typename Operation>
+    inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
         size_t nSerSize = 0;
         bool fRead = boost::is_same<Operation, CSerActionUnserialize>();
 
-        CAccountingEntry& me = *const_cast<CAccountingEntry*>(thisPtr);
+        CAccountingEntry& me = *const_cast<CAccountingEntry*>(this);
         if (!(nType & SER_GETHASH))
             READWRITE(nVersion);
         // Note: strAccount is serialized as part of the key, not here.
-        READWRITE(thisPtr->nCreditDebit);
-        READWRITE(thisPtr->nTime);
-        READWRITE(LIMITED_STRING(thisPtr->strOtherAccount, 65536));
+        READWRITE(nCreditDebit);
+        READWRITE(nTime);
+        READWRITE(LIMITED_STRING(strOtherAccount, 65536));
 
         if (!fRead)
         {
-            WriteOrderPos(thisPtr->nOrderPos, me.mapValue);
+            WriteOrderPos(nOrderPos, me.mapValue);
 
-            if (!(thisPtr->mapValue.empty() && thisPtr->_ssExtra.empty()))
+            if (!(mapValue.empty() && _ssExtra.empty()))
             {
                 CDataStream ss(nType, nVersion);
                 ss.insert(ss.begin(), '\0');
-                ss << thisPtr->mapValue;
-                ss.insert(ss.end(), thisPtr->_ssExtra.begin(), thisPtr->_ssExtra.end());
+                ss << mapValue;
+                ss.insert(ss.end(), _ssExtra.begin(), _ssExtra.end());
                 me.strComment.append(ss.str());
             }
         }
 
-        READWRITE(LIMITED_STRING(thisPtr->strComment, 65536));
+        READWRITE(LIMITED_STRING(strComment, 65536));
 
-        size_t nSepPos = thisPtr->strComment.find("\0", 0, 1);
+        size_t nSepPos = strComment.find("\0", 0, 1);
         if (fRead)
         {
             me.mapValue.clear();
             if (std::string::npos != nSepPos)
             {
-                CDataStream ss(std::vector<char>(thisPtr->strComment.begin() + nSepPos + 1, thisPtr->strComment.end()), nType, nVersion);
+                CDataStream ss(std::vector<char>(strComment.begin() + nSepPos + 1, strComment.end()), nType, nVersion);
                 ss >> me.mapValue;
                 me._ssExtra = std::vector<char>(ss.begin(), ss.end());
             }

--- a/src/walletdb.h
+++ b/src/walletdb.h
@@ -54,14 +54,14 @@ public:
         nCreateTime = nCreateTime_;
     }
 
-    IMPLEMENT_SERIALIZE
+    IMPLEMENT_SERIALIZE;
 
-    template <typename T, typename Stream, typename Operation>
-    inline static size_t SerializationOp(T thisPtr, Stream& s, Operation ser_action, int nType, int nVersion) {
+    template <typename Stream, typename Operation>
+    inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
         size_t nSerSize = 0;
-        READWRITE(thisPtr->nVersion);
-        nVersion = thisPtr->nVersion;
-        READWRITE(thisPtr->nCreateTime);
+        READWRITE(this->nVersion);
+        nVersion = this->nVersion;
+        READWRITE(nCreateTime);
         return nSerSize;
     }
 

--- a/src/walletdb.h
+++ b/src/walletdb.h
@@ -57,12 +57,10 @@ public:
     IMPLEMENT_SERIALIZE;
 
     template <typename Stream, typename Operation>
-    inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
-        size_t nSerSize = 0;
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
         READWRITE(this->nVersion);
         nVersion = this->nVersion;
         READWRITE(nCreateTime);
-        return nSerSize;
     }
 
     void SetNull()

--- a/src/walletdb.h
+++ b/src/walletdb.h
@@ -55,11 +55,15 @@ public:
     }
 
     IMPLEMENT_SERIALIZE
-    (
-        READWRITE(this->nVersion);
-        nVersion = this->nVersion;
-        READWRITE(nCreateTime);
-    )
+
+    template <typename T, typename Stream, typename Operation>
+    inline static size_t SerializationOp(T thisPtr, Stream& s, Operation ser_action, int nType, int nVersion) {
+        size_t nSerSize = 0;
+        READWRITE(thisPtr->nVersion);
+        nVersion = thisPtr->nVersion;
+        READWRITE(thisPtr->nCreateTime);
+        return nSerSize;
+    }
 
     void SetNull()
     {


### PR DESCRIPTION
The implementation of each class' serialization/deserialization is no longer passed within a macro.
The implementation now lies within a template of form:

```
template <typename Stream, typename Operation>
inline size_t SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
    /* CODE */
}
```

In cases when codepath should depend on whether or not we are just deserializing
(old **fGetSize**, **fWrite**, **fRead** flags) an additional clause can be used:

```
bool fRead = ser_action.ForRead();
```

The **IMPLEMENT_SERIALIZE** macro will now be a freestanding clause added within class' body
(similiar to Qt's **Q_OBJECT**) to implement **GetSerializeSize**, **Serialize** and **Unserialize**.
These are now wrappers around the **SerializationOp** template.
