### PR TITLE
travis-ci integration (pull-tester replacement)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,57 @@
+# errata:
+# - A travis bug causes caches to trample eachother when using the same
+#   compiler key (which we don't use anyway). This is worked around for now by
+#   using the phony compilers "true X". These can be removed when the travis
+#   bug is fixed. See: https://github.com/travis-ci/casher/issues/6
+
+os: linux
+language: cpp
+env:
+  global:
+    - MAKEJOBS=-j3
+    - RUN_TESTS=false
+    - CCACHE_SIZE=100M
+    - CCACHE_TEMPDIR=/tmp/.ccache-temp
+    - CCACHE_COMPRESS=1
+    - BASE_OUTDIR=$TRAVIS_BUILD_DIR/out
+cache:
+  apt: true
+  directories:
+  - depends/built
+  - $HOME/.ccache
+matrix:
+  fast_finish: true
+  include:
+    - compiler: "true 1"
+      env: HOST=arm-linux-gnueabihf PACKAGES="g++-arm-linux-gnueabihf" DEP_OPTS="NO_QT=1" GOAL="install" BITCOIN_CONFIG"--enable-glibc-back-compat"
+    - compiler: "true 2"
+      env: HOST=x86_64-unknown-linux-gnu DEP_OPTS="NO_QT=1 NO_WALLET=1 NO_UPNP=1" RUN_TESTS=true GOAL="install" BITCOIN_CONFIG="--enable-glibc-back-compat"
+    - compiler: "true 3"
+      env: HOST=x86_64-unknown-linux-gnu RUN_TESTS=true GOAL="install" BITCOIN_CONFIG="--enable-glibc-back-compat"
+    - compiler: "true 4"
+      env: HOST=i686-pc-linux-gnu PACKAGES="g++-multilib" RUN_TESTS=true GOAL="install" BITCOIN_CONFIG="--enable-glibc-back-compat"
+    - compiler: "true 6"
+      env: HOST=x86_64-w64-mingw32 PACKAGES="nsis gcc-mingw-w64-x86-64 g++-mingw-w64-x86-64 binutils-mingw-w64-x86-64 mingw-w64-dev" GOAL="deploy"
+    - compiler: "true 7"
+      env: HOST=i686-w64-mingw32 PACKAGES="nsis gcc-mingw-w64-i686 g++-mingw-w64-i686 binutils-mingw-w64-i686 mingw-w64-dev" GOAL="deploy"
+install:
+    - if [ -n "$PACKAGES" ]; then travis_retry sudo apt-get update; fi
+    - if [ -n "$PACKAGES" ]; then travis_retry sudo apt-get install --no-upgrade -qq $PACKAGES; fi
+before_script:
+    - unset CC; unset CXX
+    - mkdir -p depends/SDKs
+    - make $MAKEJOBS -C depends HOST=$HOST $DEP_OPTS || (echo "Build failure. Verbose build follows." && make -C depends V=1 HOST=$HOST $DEP_OPTS)
+script:
+    - OUTDIR=$BASE_OUTDIR/$TRAVIS_PULL_REQUEST/$TRAVIS_JOB_NUMBER-$HOST
+    - BITCOIN_CONFIG_ALL="--disable-dependency-tracking --prefix=$TRAVIS_BUILD_DIR/depends/$HOST --bindir=$OUTDIR/bin --libdir=$OUTDIR/lib"
+    - depends/$HOST/native/bin/ccache --max-size=$CCACHE_SIZE
+    - if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then export CCACHE_READONLY=1; fi
+    - ./autogen.sh
+    - ./configure --cache-file=config.cache $BITCOIN_CONFIG_ALL $BITCOIN_CONFIG || ( cat config.log && false)
+    - make distdir PACKAGE=bitcoin VERSION=$HOST
+    - cd bitcoin-$HOST
+    - ./configure --cache-file=../config.cache $BITCOIN_CONFIG_ALL $BITCOIN_CONFIG || ( cat config.log && false)
+    - make $MAKEJOBS $GOAL || ( echo "Build failure. Verbose build follows." && make $GOAL V=1 ; false )
+    - if [ "$RUN_TESTS" = "true" ]; then make check; fi
+after_script:
+    - if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then (echo "Upload goes here. Something like: scp -r $BASE_OUTDIR server" || echo "upload failed"); fi

--- a/configure.ac
+++ b/configure.ac
@@ -656,6 +656,9 @@ if test "x$use_ccache" != "xno"; then
   fi
   AC_MSG_RESULT($use_ccache)
 fi
+if test "x$use_ccache" = "xyes"; then
+    AX_CHECK_PREPROC_FLAG([-Qunused-arguments],[CPPFLAGS="-Qunused-arguments $CPPFLAGS"])
+fi
 
 dnl enable wallet
 AC_MSG_CHECKING([if wallet should be enabled])

--- a/doc/travis-ci.txt
+++ b/doc/travis-ci.txt
@@ -1,0 +1,39 @@
+Support for using travis-ci has been added in order to automate pull-testing.
+See https://travis-ci.org/ for more info
+
+This procedure is different than the pull-tester that came before it in a few
+ways.
+
+There is nothing to administer. This is a major feature as it means
+that builds have no local state. Because there is no ability to login to the
+builders to install packages (tools, dependencies, etc), the entire build
+procedure must instead be controlled by a declarative script (.travis.yml).
+This script declares each build configuration, creates virtual machines as
+necessary, builds, then discards the virtual machines.
+
+A build matrix is constructed to test a wide range of configurations, rather
+than a single pass/fail. This helps to catch build failures and logic errors
+that present on platforms other than the ones the author has tested. This
+matrix is defined in the build script and can be changed at any time.
+
+All builders use the dependency-generator in the depends dir, rather than
+using apt-get to install build dependencies. This guarantees that the tester
+is using the same versions as Gitian, so the build results are nearly identical
+to what would be found in a final release. However, this also means that builds
+will fail if new dependencies are introduced without being added to the
+dependency generator.
+
+In order to avoid rebuilding all dependencies for each build, the binaries are
+cached and re-used when possible. Changes in the dependency-generator will
+trigger cache-invalidation and rebuilds as necessary.
+
+These caches can be manually removed if necessary. This is one of the the very few
+manual operations that is possible with Travis, and it can be done by the
+Bitcoin Core committer via the Travis web interface.
+
+In some cases, secure strings may be needed for hiding sensitive info such as
+private keys or URLs. The travis client may be used to create these strings:
+http://docs.travis-ci.com/user/encryption-keys/
+
+For the details of the build descriptor, see the official docs:
+http://docs.travis-ci.com/user/build-configuration/


### PR DESCRIPTION
See the doc/travis.txt for a description of what travis is and how it works.

This is an initial descriptor to get things going. It can be changed around at any time, so discussions about what build configs to use, notifications, etc, can all take place in the form of pull-requests in the future.

At the moment, each pull-request will kick off 7 builds:
- linux x86_64 full
- linux x86_64 minimal
- linux i686 full
- linux arm no-qt
- osx x86_64 full
- win x86_64 full
- win i686 full

Build results will be similar to this: https://travis-ci.org/coryfields/bitcoin/builds/33137850 .

There are lots of features and bells/whistles to play with down the road, see [notifications](http://docs.travis-ci.com/user/notifications/) for an example.

There's also a quick build change in here to make osx build logs actually useful.
