### PR TITLE
Build-osx: Force Fix.

### DIFF
--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -71,8 +71,6 @@ Instructions: Homebrew
 
         brew install autoconf automake libtool boost miniupnpc openssl pkg-config protobuf qt
 
-Make sure `/usr/local/bin` comes before `/usr/bin` in your PATH. 
-
 #### Installing berkeley-db4 using Homebrew
 
 The homebrew package for berkeley-db4 has been broken for some time.  It will install without Java though.

--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -71,19 +71,7 @@ Instructions: Homebrew
 
         brew install autoconf automake libtool boost miniupnpc openssl pkg-config protobuf qt
 
-Note: After you have installed the dependencies, you should check that the Homebrew installed version of OpenSSL is the one available for compilation. You can check this by typing
-
-        openssl version
-
-into Terminal. You should see OpenSSL 1.0.1h 5 Jun 2014.
-
-If not, you can ensure that the Homebrew OpenSSL is correctly linked by running
-
-        brew link openssl --force
-
-Rerunning "openssl version" should now return the correct version. If it
-doesn't, make sure `/usr/local/bin` comes before `/usr/bin` in your
-PATH. 
+Make sure `/usr/local/bin` comes before `/usr/bin` in your PATH. 
 
 #### Installing berkeley-db4 using Homebrew
 


### PR DESCRIPTION
Removes the unnecessary directions that encourage people to force install openssl into /usr/local with Homebrew. Unnecessary, and potentially quite risky. @theuni okayed this removal [here](https://github.com/bitcoin/bitcoin/pull/4740#issuecomment-53076840).
