### PR TITLE
[contrib] New linearize format

### DIFF
--- a/contrib/linearize/README.md
+++ b/contrib/linearize/README.md
@@ -27,6 +27,7 @@ output.
 Optional config file setting for linearize-data:
 * "netmagic": network magic number
 * "max_out_sz": maximum output file size (default 1000*1000*1000)
-* "split_year": Split files when a new year is first seen, in addition to
+* "split_timestamp": Split files when a new year is first seen, in addition to
 reaching a maximum file size.
-
+* "file_timestamp": Set each file's last-modified time to that of the
+most recent block in that file.

--- a/contrib/linearize/linearize-data.py
+++ b/contrib/linearize/linearize-data.py
@@ -10,11 +10,13 @@
 import json
 import struct
 import re
+import os
 import base64
 import httplib
 import sys
 import hashlib
 import datetime
+import time
 
 settings = {}
 
@@ -60,9 +62,10 @@ def calc_hash_str(blk_hdr):
 
 def get_blk_dt(blk_hdr):
 	members = struct.unpack("<I", blk_hdr[68:68+4])
-	dt = datetime.datetime.fromtimestamp(members[0])
+	nTime = members[0]
+	dt = datetime.datetime.fromtimestamp(nTime)
 	dt_ym = datetime.datetime(dt.year, dt.month, 1)
-	return dt_ym
+	return (dt_ym, nTime)
 
 def get_block_hashes(settings):
 	blkindex = []
@@ -87,14 +90,19 @@ def copydata(settings, blkindex, blkset):
 	outFn = 0
 	outsz = 0
 	outF = None
+	outFname = None
 	blkCount = 0
 
 	lastDate = datetime.datetime(2000, 1, 1)
+	highTS = 1408893517 - 315360000
 	timestampSplit = False
 	fileOutput = True
+	setFileTime = False
 	maxOutSz = settings['max_out_sz']
 	if 'output' in settings:
 		fileOutput = False
+	if settings['file_timestamp'] != 0:
+		setFileTime = True
 	if settings['split_timestamp'] != 0:
 		timestampSplit = True
 
@@ -134,34 +142,41 @@ def copydata(settings, blkindex, blkset):
 
 		if not fileOutput and ((outsz + inLen) > maxOutSz):
 			outF.close()
+			if setFileTime:
+				os.utime(outFname, (int(time.time()), highTS))
 			outF = None
+			outFname = None
 			outFn = outFn + 1
 			outsz = 0
 
-		if timestampSplit:
-			blkDate = get_blk_dt(blk_hdr)
-			if blkDate > lastDate:
-				print("New month " + blkDate.strftime("%Y-%m") + " @ " + hash_str)
-				lastDate = blkDate
-				if outF:
-					outF.close()
-					outF = None
-					outFn = outFn + 1
-					outsz = 0
+		(blkDate, blkTS) = get_blk_dt(blk_hdr)
+		if timestampSplit and (blkDate > lastDate):
+			print("New month " + blkDate.strftime("%Y-%m") + " @ " + hash_str)
+			lastDate = blkDate
+			if outF:
+				outF.close()
+				if setFileTime:
+					os.utime(outFname, (int(time.time()), highTS))
+				outF = None
+				outFname = None
+				outFn = outFn + 1
+				outsz = 0
 
 		if not outF:
 			if fileOutput:
-				fname = settings['output_file']
+				outFname = settings['output_file']
 			else:
-				fname = "%s/blk%05d.dat" % (settings['output'], outFn)
-			print("Output file" + fname)
-			outF = open(fname, "wb")
+				outFname = "%s/blk%05d.dat" % (settings['output'], outFn)
+			print("Output file" + outFname)
+			outF = open(outFname, "wb")
 
 		outF.write(inhdr)
 		outF.write(rawblock)
 		outsz = outsz + inLen + 8
 
 		blkCount = blkCount + 1
+		if blkTS > highTS:
+			highTS = blkTS
 
 		if (blkCount % 1000) == 0:
 			print("Wrote " + str(blkCount) + " blocks")
@@ -191,6 +206,8 @@ if __name__ == '__main__':
 		settings['input'] = 'input'
 	if 'hashlist' not in settings:
 		settings['hashlist'] = 'hashlist.txt'
+	if 'file_timestamp' not in settings:
+		settings['file_timestamp'] = 0
 	if 'split_timestamp' not in settings:
 		settings['split_timestamp'] = 0
 	if 'max_out_sz' not in settings:
@@ -198,6 +215,7 @@ if __name__ == '__main__':
 
 	settings['max_out_sz'] = long(settings['max_out_sz'])
 	settings['split_timestamp'] = int(settings['split_timestamp'])
+	settings['file_timestamp'] = int(settings['file_timestamp'])
 	settings['netmagic'] = settings['netmagic'].decode('hex')
 
 	if 'output_file' not in settings and 'output' not in settings:

--- a/contrib/linearize/linearize-data.py
+++ b/contrib/linearize/linearize-data.py
@@ -58,10 +58,11 @@ def calc_hash_str(blk_hdr):
 	hash_str = hash.encode('hex')
 	return hash_str
 
-def get_blk_year(blk_hdr):
+def get_blk_dt(blk_hdr):
 	members = struct.unpack("<I", blk_hdr[68:68+4])
 	dt = datetime.datetime.fromtimestamp(members[0])
-	return dt.year
+	dt_ym = datetime.datetime(dt.year, dt.month, 1)
+	return dt_ym
 
 def get_block_hashes(settings):
 	blkindex = []
@@ -88,14 +89,14 @@ def copydata(settings, blkindex, blkset):
 	outF = None
 	blkCount = 0
 
-	lastYear = 0
-	splitYear = False
+	lastDate = datetime.datetime(2000, 1, 1)
+	timestampSplit = False
 	fileOutput = True
 	maxOutSz = settings['max_out_sz']
 	if 'output' in settings:
 		fileOutput = False
-	if settings['split_year'] != 0:
-		splitYear = True
+	if settings['split_timestamp'] != 0:
+		timestampSplit = True
 
 	while True:
 		if not inF:
@@ -137,11 +138,11 @@ def copydata(settings, blkindex, blkset):
 			outFn = outFn + 1
 			outsz = 0
 
-		if splitYear:
-			blkYear = get_blk_year(blk_hdr)
-			if blkYear > lastYear:
-				print("New year " + str(blkYear) + " @ " + hash_str)
-				lastYear = blkYear
+		if timestampSplit:
+			blkDate = get_blk_dt(blk_hdr)
+			if blkDate > lastDate:
+				print("New month " + blkDate.strftime("%Y-%m") + " @ " + hash_str)
+				lastDate = blkDate
 				if outF:
 					outF.close()
 					outF = None
@@ -190,13 +191,13 @@ if __name__ == '__main__':
 		settings['input'] = 'input'
 	if 'hashlist' not in settings:
 		settings['hashlist'] = 'hashlist.txt'
-	if 'split_year' not in settings:
-		settings['split_year'] = 0
+	if 'split_timestamp' not in settings:
+		settings['split_timestamp'] = 0
 	if 'max_out_sz' not in settings:
 		settings['max_out_sz'] = 1000L * 1000 * 1000
 
 	settings['max_out_sz'] = long(settings['max_out_sz'])
-	settings['split_year'] = int(settings['split_year'])
+	settings['split_timestamp'] = int(settings['split_timestamp'])
 	settings['netmagic'] = settings['netmagic'].decode('hex')
 
 	if 'output_file' not in settings and 'output' not in settings:

--- a/contrib/linearize/linearize-data.py
+++ b/contrib/linearize/linearize-data.py
@@ -125,6 +125,12 @@ def copydata(settings, blkindex, blkset):
 			print("Skipping unknown block " + hash_str)
 			continue
 
+		if blkindex[blkCount] != hash_str:
+			print("Out of order block.")
+			print("Expected " + blkindex[blkCount])
+			print("Got " + hash_str)
+			sys.exit(1)
+
 		if not fileOutput and ((outsz + inLen) > maxOutSz):
 			outF.close()
 			outF = None


### PR DESCRIPTION
The new linearize format outputs one month's worth of bitcoin transactions, as determined by the timestamp inside the block.  The file last-modified time is set to the highest timestamp seen thusfar in the processing:

```
-rw-rw-r-- 1 jgarzik jgarzik    512129 Sep 30  2009 blk00008.dat
-rw-rw-r-- 1 jgarzik jgarzik    522737 Oct 31  2009 blk00009.dat
-rw-rw-r-- 1 jgarzik jgarzik    521531 Nov 30  2009 blk00010.dat
-rw-rw-r-- 1 jgarzik jgarzik    992159 Dec 31  2009 blk00011.dat
-rw-rw-r-- 1 jgarzik jgarzik   1190943 Jan 31  2010 blk00012.dat
-rw-rw-r-- 1 jgarzik jgarzik   1580654 Feb 28  2010 blk00013.dat
-rw-rw-r-- 1 jgarzik jgarzik   1435103 Mar 31  2010 blk00014.dat
-rw-rw-r-- 1 jgarzik jgarzik   2646319 Apr 30  2010 blk00015.dat
-rw-rw-r-- 1 jgarzik jgarzik   2040834 May 31  2010 blk00016.dat
-rw-rw-r-- 1 jgarzik jgarzik   1911267 Jun 30  2010 blk00017.dat
-rw-rw-r-- 1 jgarzik jgarzik   7862024 Jul 31  2010 blk00018.dat
```

A check is added to verify that blocks remain in the proper order.  Previously this was guaranteed by bitcoind anyway, and so is a simply a sanity check.  ~~Who knows what weird input people might feed to this.~~  Headers-first will change this, sometimes storing blocks out of order on disk.  linearize will need a future update to buffer blocks.

This new format is suitable for researchers performing lots of raw block processing, and bitcoind users importing via "-reindex".  The reindex import method is superior to bootstrap.dat.
