### PR TITLE
Test IsPushOnly() with invalid push

### DIFF
--- a/src/script.cpp
+++ b/src/script.cpp
@@ -1874,9 +1874,11 @@ bool CScript::IsPushOnly() const
     const_iterator pc = begin();
     while (pc < end())
     {
+        // Note how a script with an invalid PUSHDATA returns False.
         opcodetype opcode;
         if (!GetOp(pc, opcode))
             return false;
+
         // Note that IsPushOnly() *does* consider OP_RESERVED to be a
         // push-type opcode, however execution of OP_RESERVED fails, so
         // it's not relevant to P2SH as the scriptSig would fail prior to

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -394,4 +394,15 @@ BOOST_AUTO_TEST_CASE(script_standard_push)
     }
 }
 
+BOOST_AUTO_TEST_CASE(script_IsPushOnly_on_invalid_scripts)
+{
+    // IsPushOnly returns false when given a script containing only pushes that
+    // are invalid due to truncation. IsPushOnly() is consensus critical
+    // because P2SH evaluation uses it, although this specific behavior should
+    // not be consensus critical as the P2SH evaluation would fail first due to
+    // the invalid push. Still, it doesn't hurt to test it explicitly.
+    static const unsigned char direct[] = { 1 };
+    BOOST_CHECK(!CScript(direct, direct+sizeof(direct)).IsPushOnly());
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Interestingly my python-bitcoinlib library missed this case, resulting in an exception being inappropriately raised. https://github.com/petertodd/python-bitcoinlib/commit/70be1cc5d94fd374e312a050818a40c5047dc724
