### PR TITLE
Bypass reloading blocks from disk

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -160,7 +160,7 @@ std::string GetWarnings(std::string strFor);
 /** Retrieve a transaction (from memory pool, or from disk, if possible) */
 bool GetTransaction(const uint256 &hash, CTransaction &tx, uint256 &hashBlock, bool fAllowSlow = false);
 /** Find the best known block, and make it the tip of the block chain */
-bool ActivateBestChain(CValidationState &state);
+bool ActivateBestChain(CValidationState &state, CBlock *pblock = NULL);
 int64_t GetBlockValue(int nHeight, int64_t nFees);
 
 void UpdateTime(CBlockHeader& block, const CBlockIndex* pindexPrev);


### PR DESCRIPTION
Pass the currently-being-processed block down to ConnectTip, so it can avoid loading it again from disk.

This results in a 15% speedup for me for reindexing until block 172896 (134s vs 155s).
