### PR TITLE
build: Add travis build:passing/failing indicator to github front page.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Bitcoin Core integration/staging tree
 =====================================
 
+[![Build Status](https://travis-ci.org/bitcoin/bitcoin.svg?branch=master)](https://travis-ci.org/bitcoin/bitcoin)
+
 https://www.bitcoin.org
 
 Copyright (c) 2009-2014 Bitcoin Core Developers


### PR DESCRIPTION
As per title.
