### PR TITLE
Use bounded network response buffers.

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2046,6 +2046,7 @@ CNode::CNode(SOCKET hSocketIn, CAddress addrIn, std::string addrNameIn, bool fIn
 {
     nServices = 0;
     hSocket = hSocketIn;
+    ssSend.SetMaxSize(24 + 32*1024*1024); // Message header + 32MB payload
     nRecvVersion = INIT_PROTO_VERSION;
     nLastSend = 0;
     nLastRecv = 0;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2054,7 +2054,7 @@ unsigned int SendBufferSize() { return 1000*GetArg("-maxsendbuffer", 1*1000); }
 //
 // NOTE: This value is currently less than the largest enforced receivable
 // message, which at the time of writing is no more than a 32MB payload.
-static const size_t SEND_BUFFER_MAX_SIZE = 24 + 3 + (50000 * (4+32))
+static const size_t SEND_BUFFER_MAX_SIZE = 24 + 3 + (50000 * (4+32));
 
 CNode::CNode(SOCKET hSocketIn, CAddress addrIn, std::string addrNameIn, bool fInboundIn) : ssSend(SER_NETWORK, INIT_PROTO_VERSION), setAddrKnown(5000)
 {

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2043,9 +2043,9 @@ unsigned int ReceiveFloodSize() { return 1000*GetArg("-maxreceivebuffer", 5*1000
 unsigned int SendBufferSize() { return 1000*GetArg("-maxsendbuffer", 1*1000); }
 
 // SEND_BUFFER_MAX_SIZE is the size in bytes that a P2P message is expected to
-// never exceed, and is used as the maximum allowed value a CDataStream buffer
-// may expand to.  This is currently calculated as the sum of the message header
-// size (24 bytes) plus the payload for a maximum sized inv:
+// never exceed, and is used as the maximum allowed value a CDataStream send
+// buffer may expand to.  This is currently calculated as the sum of the message
+// header size (24 bytes) plus the payload for a maximum sized inv:
 //
 //  50000 as varint (3 bytes)
 //  50000 inv vector entries (1800000 bytes):

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2042,11 +2042,25 @@ bool CAddrDB::Read(CAddrMan& addr)
 unsigned int ReceiveFloodSize() { return 1000*GetArg("-maxreceivebuffer", 5*1000); }
 unsigned int SendBufferSize() { return 1000*GetArg("-maxsendbuffer", 1*1000); }
 
+// SEND_BUFFER_MAX_SIZE is the size in bytes that a P2P message is expected to
+// never exceed, and is used as the maximum allowed value a CDataStream buffer
+// may expand to.  This is currently calculated as the sum of the message header
+// size (24 bytes) plus the payload for a maximum sized inv:
+//
+//  50000 as varint (3 bytes)
+//  50000 inv vector entries (1800000 bytes):
+//   - Inv type (4 bytes)
+//   - Hash (32 bytes)
+//
+// NOTE: This value is currently less than the largest enforced receivable
+// message, which at the time of writing is no more than a 32MB payload.
+static const size_t SEND_BUFFER_MAX_SIZE = 24 + 3 + (50000 * (4+32))
+
 CNode::CNode(SOCKET hSocketIn, CAddress addrIn, std::string addrNameIn, bool fInboundIn) : ssSend(SER_NETWORK, INIT_PROTO_VERSION), setAddrKnown(5000)
 {
     nServices = 0;
     hSocket = hSocketIn;
-    ssSend.SetMaxSize(24 + 32*1024*1024); // Message header + 32MB payload
+    ssSend.SetMaxSize(SEND_BUFFER_MAX_SIZE);
     nRecvVersion = INIT_PROTO_VERSION;
     nLastSend = 0;
     nLastRecv = 0;


### PR DESCRIPTION
I think that the memory buffer used to serialize peer responses should limit the total length to the maximum the peer is willing to accept.  This can help prevent easily DoS-able requests from being added in the future and bringing down every Bitcoin Core node on the network, rather the relying on a soft limit of how big a response can actually be.

Opening this PR so more eyes can look at this, but I'm not able to test whether it actually works as intended.  Don't merge until the error case is actually hit and the behavior is as intended.  In particular, I don't know if that exception is actually caught anywhere, but I have received confirmation that the patch at least compiles.
