### PR TITLE
Fix a few "Uninitialized scalar field" warnings

### DIFF
--- a/src/bloom.h
+++ b/src/bloom.h
@@ -60,7 +60,7 @@ public:
     // It should generally always be a random value (and is largely only exposed for unit testing)
     // nFlags should be one of the BLOOM_UPDATE_* enums (not _MASK)
     CBloomFilter(unsigned int nElements, double nFPRate, unsigned int nTweak, unsigned char nFlagsIn);
-    CBloomFilter() : isFull(true) {}
+    CBloomFilter() : isFull(true), isEmpty(false), nHashFuncs(0), nTweak(0), nFlags(0) {}
 
     IMPLEMENT_SERIALIZE
     (

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -227,10 +227,10 @@ CDB::CDB(const char *pszFile, const char* pszMode) :
     pdb(NULL), activeTxn(NULL)
 {
     int ret;
+    fReadOnly = (!strchr(pszMode, '+') && !strchr(pszMode, 'w'));
     if (pszFile == NULL)
         return;
 
-    fReadOnly = (!strchr(pszMode, '+') && !strchr(pszMode, 'w'));
     bool fCreate = strchr(pszMode, 'c');
     unsigned int nFlags = DB_THREAD;
     if (fCreate)

--- a/src/key.h
+++ b/src/key.h
@@ -189,7 +189,7 @@ private:
 public:
 
     // Construct an invalid private key.
-    CKey() : fValid(false) {
+    CKey() : fValid(false), fCompressed(false) {
         LockObject(vch);
     }
 

--- a/src/main.h
+++ b/src/main.h
@@ -328,7 +328,7 @@ private:
     int nHashType;
 
 public:
-    CScriptCheck() {}
+    CScriptCheck(): ptxTo(0), nIn(0), nFlags(0), nHashType(0) {}
     CScriptCheck(const CCoins& txFromIn, const CTransaction& txToIn, unsigned int nInIn, unsigned int nFlagsIn, int nHashTypeIn) :
         scriptPubKey(txFromIn.vout[txToIn.vin[nInIn].prevout.n].scriptPubKey),
         ptxTo(&txToIn), nIn(nInIn), nFlags(nFlagsIn), nHashType(nHashTypeIn) { }
@@ -876,7 +876,7 @@ private:
     unsigned char chRejectCode;
     bool corruptionPossible;
 public:
-    CValidationState() : mode(MODE_VALID), nDoS(0), corruptionPossible(false) {}
+    CValidationState() : mode(MODE_VALID), nDoS(0), chRejectCode(0), corruptionPossible(false) {}
     bool DoS(int level, bool ret = false,
              unsigned char chRejectCodeIn=0, std::string strRejectReasonIn="",
              bool corruptionIn=false) {

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -11,7 +11,8 @@
 
 using namespace std;
 
-CTxMemPoolEntry::CTxMemPoolEntry()
+CTxMemPoolEntry::CTxMemPoolEntry():
+    nFee(0), nTxSize(0), nTime(0), dPriority(0.0)
 {
     nHeight = MEMPOOL_HEIGHT;
 }
@@ -345,7 +346,9 @@ public:
 };
 
 
-CTxMemPool::CTxMemPool(const CFeeRate& _minRelayFee) : minRelayFee(_minRelayFee)
+CTxMemPool::CTxMemPool(const CFeeRate& _minRelayFee) :
+    nTransactionsUpdated(0),
+    minRelayFee(_minRelayFee)
 {
     // Sanity checks off by default for performance, because otherwise
     // accepting transactions becomes O(N^2) where N is the number

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -905,6 +905,7 @@ public:
         strOtherAccount.clear();
         strComment.clear();
         nOrderPos = -1;
+        nEntryNo = 0;
     }
 
     IMPLEMENT_SERIALIZE


### PR DESCRIPTION
Fix a few warnings reported by Coverity.
None of these is critical, but making sure that class fields are initialized can avoid heisenbugs.
