### PR TITLE
remove useless millisleep

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1080,8 +1080,6 @@ void ThreadSocketHandler()
             BOOST_FOREACH(CNode* pnode, vNodesCopy)
                 pnode->Release();
         }
-
-        MilliSleep(10);
     }
 }
 


### PR DESCRIPTION
reduces time to service requests improving performance

calls is unnecessary as select() blocks and on select() failure there is another MilliSleep()
