### PR TITLE
Pow: Refactor: Encapsulate miner-related pow in GenerateProof (was ScanHash) and use it for regtest mining

### DIFF
--- a/src/miner.h
+++ b/src/miner.h
@@ -6,6 +6,7 @@
 #ifndef BITCOIN_MINER_H
 #define BITCOIN_MINER_H
 
+#include "consensus/params.h"
 #include "primitives/block.h"
 
 #include <stdint.h>
@@ -24,6 +25,12 @@ struct CBlockTemplate
     std::vector<int64_t> vTxSigOps;
 };
 
+/**
+ * Scans nonces looking for a hash with at least some zero bits.
+ * If it finds and the block passes CheckProofOfWork, returns
+ * true. Otherwise it returns false after some tries.
+ */
+bool GenerateProof(CBlockHeader* pblock, const Consensus::Params& params);
 /** Run the miner threads */
 void GenerateBitcoins(bool fGenerate, int nThreads, const CChainParams& chainparams);
 /** Generate a new block, without valid proof-of-work */

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -153,15 +153,10 @@ UniValue generate(const UniValue& params, bool fHelp)
         if (!pblocktemplate.get())
             throw JSONRPCError(RPC_INTERNAL_ERROR, "Couldn't create new block");
         CBlock *pblock = &pblocktemplate->block;
-        {
+        do {
             LOCK(cs_main);
             IncrementExtraNonce(pblock, chainActive.Tip(), nExtraNonce);
-        }
-        while (!CheckProofOfWork(pblock->GetHash(), pblock->nBits, Params().GetConsensus())) {
-            // Yes, there is a chance every nonce could fail to satisfy the -regtest
-            // target -- 1 in 2^(2^32). That ain't gonna happen.
-            ++pblock->nNonce;
-        }
+        } while (!GenerateProof(pblock, Params().GetConsensus()));
         CValidationState state;
         if (!ProcessNewBlock(state, NULL, pblock, true, NULL))
             throw JSONRPCError(RPC_INTERNAL_ERROR, "ProcessNewBlock, block not accepted");


### PR DESCRIPTION
Continues #4506.
Following @laanwj 's advice of only moving ScanHash, I found another solution to encapsulate the miner's pow without removing the miner's optimization, which was rejected in #4423 
But I would like to slightly change the behavior.
Commit "Replace proof.nNonce >= 0xffff000 with an iteration counter" should be either rejected or squashed into "proof.nNonce >= 0xffff0000 -> proof.OutOfRangeSolution()" (and of course that 1000 in the for is open for bike-shedding).
"Small miner optimization" also should be rejected or rebased in "Remove testnet's special case from miner.cpp".
I think these 2 functional changes are meaningless enough that can be safely accepted.
I would also be happy to just remove the hashmeter and the resulting PR would be simpler.
