### PR TITLE
[Wallet] Call SetBestChain before and after rescan

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1162,8 +1162,6 @@ bool AppInit2(boost::thread_group& threadGroup)
             nStart = GetTimeMillis();
             pwalletMain->ScanForWalletTransactions(pindexRescan, true);
             LogPrintf(" rescan      %15dms\n", GetTimeMillis() - nStart);
-            pwalletMain->SetBestChain(chainActive.GetLocator());
-            nWalletDBUpdated++;
 
             // Restore wallet transaction metadata after -zapwallettxes=1
             if (GetBoolArg("-zapwallettxes", false) && GetArg("-zapwallettxes", "1") != "2")

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -892,6 +892,7 @@ int CWallet::ScanForWalletTransactions(CBlockIndex* pindexStart, bool fUpdate)
             pindex = chainActive.Next(pindex);
 
         ShowProgress(_("Rescanning..."), 0); // show rescan progress in GUI as dialog or on splashscreen, if -rescan on startup
+        SetBestChain(chainActive.GetLocator(pindex)); // this ensures to redo rescan in case of a crash while rescanning
         double dProgressStart = Checkpoints::GuessVerificationProgress(pindex, false);
         double dProgressTip = Checkpoints::GuessVerificationProgress(chainActive.Tip(), false);
         while (pindex)
@@ -912,6 +913,7 @@ int CWallet::ScanForWalletTransactions(CBlockIndex* pindexStart, bool fUpdate)
                 LogPrintf("Still rescanning. At block %d. Progress=%f\n", pindex->nHeight, Checkpoints::GuessVerificationProgress(pindex));
             }
         }
+        SetBestChain(chainActive.GetLocator());
         ShowProgress(_("Rescanning..."), 100); // hide progress dialog in GUI
     }
     return ret;


### PR DESCRIPTION
This ensures to redo rescan, in case of an incomplete rescan.
