### PR TITLE
Move checkpoint data selection to chainparams

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -70,6 +70,7 @@ BITCOIN_CORE_H = \
   chainparams.h \
   chainparamsbase.h \
   chainparamsseeds.h \
+  checkpoint_data.h \
   checkpoints.h \
   checkqueue.h \
   clientversion.h \

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -5,6 +5,7 @@
 
 #include "chainparams.h"
 
+#include "checkpoint_data.h"
 #include "random.h"
 #include "util.h"
 
@@ -117,6 +118,11 @@ public:
         fRequireStandard = true;
         fMineBlocksOnDemand = false;
     }
+
+    const CCheckpointData& Checkpoints() const 
+    {
+        return data;
+    }
 };
 static CMainParams mainParams;
 
@@ -172,6 +178,10 @@ public:
         fRequireStandard = false;
         fMineBlocksOnDemand = false;
     }
+    const CCheckpointData& Checkpoints() const 
+    {
+        return dataTestnet;
+    }
 };
 static CTestNetParams testNetParams;
 
@@ -210,6 +220,10 @@ public:
         fAllowMinDifficultyBlocks = true;
         fRequireStandard = false;
         fMineBlocksOnDemand = true;
+    }
+    const CCheckpointData& Checkpoints() const 
+    {
+        return dataRegtest;
     }
 };
 static CRegTestParams regTestParams;

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -13,6 +13,8 @@
 
 #include <vector>
 
+class CCheckpointData;
+
 typedef unsigned char MessageStartChars[MESSAGE_START_SIZE];
 
 struct CDNSSeedData {
@@ -75,6 +77,7 @@ public:
     const std::vector<CDNSSeedData>& DNSSeeds() const { return vSeeds; }
     const std::vector<unsigned char>& Base58Prefix(Base58Type type) const { return base58Prefixes[type]; }
     const std::vector<CAddress>& FixedSeeds() const { return vFixedSeeds; }
+    virtual const CCheckpointData& Checkpoints() const = 0;
 protected:
     CChainParams() {}
 

--- a/src/checkpoint_data.h
+++ b/src/checkpoint_data.h
@@ -1,0 +1,74 @@
+// Copyright (c) 2009-2013 The Bitcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef H_BITCOIN_CHECKPOINT_DATA
+#define H_BITCOIN_CHECKPOINT_DATA
+
+#include "uint256.h"
+
+#include <map>
+
+#include <boost/assign/list_of.hpp> // for 'map_list_of()'
+
+typedef std::map<int, uint256> MapCheckpoints;
+
+struct CCheckpointData {
+    const MapCheckpoints *mapCheckpoints;
+    int64_t nTimeLastCheckpoint;
+    int64_t nTransactionsLastCheckpoint;
+    double fTransactionsPerDay;
+};
+
+// What makes a good checkpoint block?
+// + Is surrounded by blocks with reasonable timestamps
+//   (no blocks before with a timestamp after, none after with
+//    timestamp before)
+// + Contains no strange transactions
+static MapCheckpoints mapCheckpoints =
+    boost::assign::map_list_of
+    ( 11111, uint256("0x0000000069e244f73d78e8fd29ba2fd2ed618bd6fa2ee92559f542fdb26e7c1d"))
+    ( 33333, uint256("0x000000002dd5588a74784eaa7ab0507a18ad16a236e7b1ce69f00d7ddfb5d0a6"))
+    ( 74000, uint256("0x0000000000573993a3c9e41ce34471c079dcf5f52a0e824a81e7f953b8661a20"))
+    (105000, uint256("0x00000000000291ce28027faea320c8d2b054b2e0fe44a773f3eefb151d6bdc97"))
+    (134444, uint256("0x00000000000005b12ffd4cd315cd34ffd4a594f430ac814c91184a0d42d2b0fe"))
+    (168000, uint256("0x000000000000099e61ea72015e79632f216fe6cb33d7899acb35b75c8303b763"))
+    (193000, uint256("0x000000000000059f452a5f7340de6682a977387c17010ff6e6c3bd83ca8b1317"))
+    (210000, uint256("0x000000000000048b95347e83192f69cf0366076336c639f9b7228e9ba171342e"))
+    (216116, uint256("0x00000000000001b4f4b433e81ee46494af945cf96014816a4e2370f11b23df4e"))
+    (225430, uint256("0x00000000000001c108384350f74090433e7fcf79a606b8e797f065b130575932"))
+    (250000, uint256("0x000000000000003887df1f29024b06fc2200b55f8af8f35453d7be294df2d214"))
+    (279000, uint256("0x0000000000000001ae8c72a0b0c301f67e3afca10e819efa9041e458e9bd7e40"))
+    (295000, uint256("0x00000000000000004d9b4ef50f0f9d686fd69db2e03af35a100370c64632a983"))
+    ;
+static const CCheckpointData data = {
+    &mapCheckpoints,
+    1397080064, // * UNIX timestamp of last checkpoint block
+    36544669,   // * total number of transactions between genesis and last checkpoint
+    //   (the tx=... number in the SetBestChain debug.log lines)
+    60000.0     // * estimated number of transactions per day after checkpoint
+};
+
+static MapCheckpoints mapCheckpointsTestnet =
+    boost::assign::map_list_of
+    ( 546, uint256("000000002a936ca763904c3c35fce2f3556c559c0214345d31b1bcebf76acb70"))
+    ;
+static const CCheckpointData dataTestnet = {
+    &mapCheckpointsTestnet,
+    1337966069,
+    1488,
+    300
+};
+
+static MapCheckpoints mapCheckpointsRegtest =
+    boost::assign::map_list_of
+    ( 0, uint256("0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206"))
+    ;
+static const CCheckpointData dataRegtest = {
+    &mapCheckpointsRegtest,
+    0,
+    0,
+    0
+};
+
+#endif

--- a/src/checkpoints.cpp
+++ b/src/checkpoints.cpp
@@ -4,17 +4,15 @@
 
 #include "checkpoints.h"
 
+#include "checkpoint_data.h"
 #include "main.h"
 #include "uint256.h"
 
 #include <stdint.h>
 
-#include <boost/assign/list_of.hpp> // for 'map_list_of()'
 #include <boost/foreach.hpp>
 
 namespace Checkpoints {
-
-    typedef std::map<int, uint256> MapCheckpoints;
 
     // How many times we expect transactions after the last checkpoint to
     // be slower. This number is a compromise, as it can't be accurate for
@@ -23,65 +21,7 @@ namespace Checkpoints {
     // fast multicore CPU, it won't be much higher than 1.
     static const double SIGCHECK_VERIFICATION_FACTOR = 5.0;
 
-    struct CCheckpointData {
-        const MapCheckpoints *mapCheckpoints;
-        int64_t nTimeLastCheckpoint;
-        int64_t nTransactionsLastCheckpoint;
-        double fTransactionsPerDay;
-    };
-
     bool fEnabled = true;
-
-    // What makes a good checkpoint block?
-    // + Is surrounded by blocks with reasonable timestamps
-    //   (no blocks before with a timestamp after, none after with
-    //    timestamp before)
-    // + Contains no strange transactions
-    static MapCheckpoints mapCheckpoints =
-        boost::assign::map_list_of
-        ( 11111, uint256("0x0000000069e244f73d78e8fd29ba2fd2ed618bd6fa2ee92559f542fdb26e7c1d"))
-        ( 33333, uint256("0x000000002dd5588a74784eaa7ab0507a18ad16a236e7b1ce69f00d7ddfb5d0a6"))
-        ( 74000, uint256("0x0000000000573993a3c9e41ce34471c079dcf5f52a0e824a81e7f953b8661a20"))
-        (105000, uint256("0x00000000000291ce28027faea320c8d2b054b2e0fe44a773f3eefb151d6bdc97"))
-        (134444, uint256("0x00000000000005b12ffd4cd315cd34ffd4a594f430ac814c91184a0d42d2b0fe"))
-        (168000, uint256("0x000000000000099e61ea72015e79632f216fe6cb33d7899acb35b75c8303b763"))
-        (193000, uint256("0x000000000000059f452a5f7340de6682a977387c17010ff6e6c3bd83ca8b1317"))
-        (210000, uint256("0x000000000000048b95347e83192f69cf0366076336c639f9b7228e9ba171342e"))
-        (216116, uint256("0x00000000000001b4f4b433e81ee46494af945cf96014816a4e2370f11b23df4e"))
-        (225430, uint256("0x00000000000001c108384350f74090433e7fcf79a606b8e797f065b130575932"))
-        (250000, uint256("0x000000000000003887df1f29024b06fc2200b55f8af8f35453d7be294df2d214"))
-        (279000, uint256("0x0000000000000001ae8c72a0b0c301f67e3afca10e819efa9041e458e9bd7e40"))
-        (295000, uint256("0x00000000000000004d9b4ef50f0f9d686fd69db2e03af35a100370c64632a983"))
-        ;
-    static const CCheckpointData data = {
-        &mapCheckpoints,
-        1397080064, // * UNIX timestamp of last checkpoint block
-        36544669,   // * total number of transactions between genesis and last checkpoint
-                    //   (the tx=... number in the SetBestChain debug.log lines)
-        60000.0     // * estimated number of transactions per day after checkpoint
-    };
-
-    static MapCheckpoints mapCheckpointsTestnet =
-        boost::assign::map_list_of
-        ( 546, uint256("000000002a936ca763904c3c35fce2f3556c559c0214345d31b1bcebf76acb70"))
-        ;
-    static const CCheckpointData dataTestnet = {
-        &mapCheckpointsTestnet,
-        1337966069,
-        1488,
-        300
-    };
-
-    static MapCheckpoints mapCheckpointsRegtest =
-        boost::assign::map_list_of
-        ( 0, uint256("0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206"))
-        ;
-    static const CCheckpointData dataRegtest = {
-        &mapCheckpointsRegtest,
-        0,
-        0,
-        0
-    };
 
     const CCheckpointData &Checkpoints() {
         if (Params().NetworkID() == CBaseChainParams::TESTNET)

--- a/src/checkpoints.cpp
+++ b/src/checkpoints.cpp
@@ -4,6 +4,7 @@
 
 #include "checkpoints.h"
 
+#include "chainparams.h"
 #include "checkpoint_data.h"
 #include "main.h"
 #include "uint256.h"
@@ -23,21 +24,12 @@ namespace Checkpoints {
 
     bool fEnabled = true;
 
-    const CCheckpointData &Checkpoints() {
-        if (Params().NetworkID() == CBaseChainParams::TESTNET)
-            return dataTestnet;
-        else if (Params().NetworkID() == CBaseChainParams::MAIN)
-            return data;
-        else
-            return dataRegtest;
-    }
-
     bool CheckBlock(int nHeight, const uint256& hash)
     {
         if (!fEnabled)
             return true;
 
-        const MapCheckpoints& checkpoints = *Checkpoints().mapCheckpoints;
+        const MapCheckpoints& checkpoints = *Params().Checkpoints().mapCheckpoints;
 
         MapCheckpoints::const_iterator i = checkpoints.find(nHeight);
         if (i == checkpoints.end()) return true;
@@ -57,7 +49,7 @@ namespace Checkpoints {
         // Work is defined as: 1.0 per transaction before the last checkpoint, and
         // fSigcheckVerificationFactor per transaction after.
 
-        const CCheckpointData &data = Checkpoints();
+        const CCheckpointData &data = Params().Checkpoints();
 
         if (pindex->nChainTx <= data.nTransactionsLastCheckpoint) {
             double nCheapBefore = pindex->nChainTx;
@@ -81,7 +73,7 @@ namespace Checkpoints {
         if (!fEnabled)
             return 0;
 
-        const MapCheckpoints& checkpoints = *Checkpoints().mapCheckpoints;
+        const MapCheckpoints& checkpoints = *Params().Checkpoints().mapCheckpoints;
 
         return checkpoints.rbegin()->first;
     }
@@ -91,7 +83,7 @@ namespace Checkpoints {
         if (!fEnabled)
             return NULL;
 
-        const MapCheckpoints& checkpoints = *Checkpoints().mapCheckpoints;
+        const MapCheckpoints& checkpoints = *Params().Checkpoints().mapCheckpoints;
 
         BOOST_REVERSE_FOREACH(const MapCheckpoints::value_type& i, checkpoints)
         {


### PR DESCRIPTION
This way we avoid the calls to Params().NetworkID() in checkpoints.cpp.
If at some point we're going to read the chainparams from data files, we probably want to put the checkpoint data there as well 
