### PR TITLE
Reserve only one network specific cached path per session

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -394,7 +394,7 @@ boost::filesystem::path GetDefaultDataDir()
 #endif
 }
 
-static boost::filesystem::path pathCached[CBaseChainParams::MAX_NETWORK_TYPES+1];
+static boost::filesystem::path pathCached[2];
 static CCriticalSection csPathCached;
 
 const boost::filesystem::path &GetDataDir(bool fNetSpecific)
@@ -403,10 +403,7 @@ const boost::filesystem::path &GetDataDir(bool fNetSpecific)
 
     LOCK(csPathCached);
 
-    int nNet = CBaseChainParams::MAX_NETWORK_TYPES;
-    if (fNetSpecific) nNet = BaseParams().NetworkID();
-
-    fs::path &path = pathCached[nNet];
+    fs::path &path = pathCached[fNetSpecific ? 1 : 0];
 
     // This can be called during exceptions by LogPrintf(), so we cache the
     // value so we don't have to do memory allocations after that.
@@ -432,8 +429,7 @@ const boost::filesystem::path &GetDataDir(bool fNetSpecific)
 
 void ClearDatadirCache()
 {
-    std::fill(&pathCached[0], &pathCached[CBaseChainParams::MAX_NETWORK_TYPES+1],
-        boost::filesystem::path());
+    std::fill(&pathCached[0], &pathCached[2], boost::filesystem::path());
 }
 
 boost::filesystem::path GetConfigFile()


### PR DESCRIPTION
One cannot change the network without restarting, so the only positions in the array that are used are the network you selected and CBaseChainParams::MAX_NETWORK_TYPES. Let's simplify and just have positions 0 and 1.
