### PR TITLE
Fixing Compiler Error C2466 on MSVC toolset building key.cpp

### DIFF
--- a/src/key.cpp
+++ b/src/key.cpp
@@ -396,7 +396,7 @@ const unsigned char vchMaxModHalfOrder[32] = {
     0xDF,0xE9,0x2F,0x46,0x68,0x1B,0x20,0xA0
 };
 
-const unsigned char vchZero[0] = {};
+const unsigned char vchZero[1] = {0};
 
 } // anon namespace
 


### PR DESCRIPTION
Construct char vchZero[0] = {}; is illegal on Microsoft compiler. The constant expression for the array size must be an integer greater than zero. For more info please see: http://msdn.microsoft.com/en-us/library/6zxfydcs.aspx

Adding one element seams to be quick and safe fix.
