### PR TITLE
Excluding unistd.h from build on Windows platform

### DIFF
--- a/src/leveldb/db/c.cc
+++ b/src/leveldb/db/c.cc
@@ -5,7 +5,9 @@
 #include "leveldb/c.h"
 
 #include <stdlib.h>
+#ifndef _MSC_VER
 #include <unistd.h>
+#endif
 #include "leveldb/cache.h"
 #include "leveldb/comparator.h"
 #include "leveldb/db.h"


### PR DESCRIPTION
Building project with Microsoft tools choke on this include file. It should be excluded if being compiled with Visual Studio compiler.
