### PR TITLE
Change CNode::askFor to a deque

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4418,9 +4418,9 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
         //
         // Message: getdata (non-blocks)
         //
-        while (!pto->fDisconnect && !pto->mapAskFor.empty() && (*pto->mapAskFor.begin()).first <= nNow)
+        while (!pto->fDisconnect && !pto->toAskFor.empty() && (*pto->toAskFor.begin()).first <= nNow)
         {
-            const CInv& inv = (*pto->mapAskFor.begin()).second;
+            const CInv& inv = (*pto->toAskFor.begin()).second;
             if (!AlreadyHave(inv))
             {
                 if (fDebug)
@@ -4432,7 +4432,7 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
                     vGetData.clear();
                 }
             }
-            pto->mapAskFor.erase(pto->mapAskFor.begin());
+            pto->toAskFor.erase(pto->toAskFor.begin());
         }
         if (!vGetData.empty())
             pto->PushMessage("getdata", vGetData);

--- a/src/net.h
+++ b/src/net.h
@@ -51,6 +51,8 @@ static const bool DEFAULT_UPNP = USE_UPNP;
 #else
 static const bool DEFAULT_UPNP = false;
 #endif
+/** The maximum number of entries in mapAskFor */
+static const size_t ASKFOR_MAX_SZ = 2*MAX_INV_SZ;
 
 unsigned int ReceiveFloodSize();
 unsigned int SendBufferSize();
@@ -289,7 +291,7 @@ public:
     mruset<CInv> setInventoryKnown;
     std::vector<CInv> vInventoryToSend;
     CCriticalSection cs_inventory;
-    std::multimap<int64_t, CInv> mapAskFor;
+    std::deque<std::pair<int64_t, CInv> > toAskFor;
 
     // Ping time measurement:
     // The pong reply we're expecting, or 0 if no pong expected.


### PR DESCRIPTION
AskFor() guarantees that entries will always be added with a monotonically increasing timestamp. 

```
    int64_t nNow = GetTimeMicros() - 1000000;
    static int64_t nLastTime;
    ++nLastTime;
    nNow = std::max(nNow, nLastTime);
    nLastTime = nNow;
```

This means that there is no need to use a map as event queue. This avoids some overhead. Also limit the maximum size of the structure.
(see #4547 for further discussion)
