### PR TITLE
Track modified size in TxMemPoolEntry to correctly compute priority

### DIFF
--- a/src/core.cpp
+++ b/src/core.cpp
@@ -124,6 +124,14 @@ int64_t CTransaction::GetValueOut() const
 
 double CTransaction::ComputePriority(double dPriorityInputs, unsigned int nTxSize) const
 {
+    nTxSize = CalculateModifiedSize(nTxSize);
+    if (nTxSize == 0) return 0.0;
+
+    return dPriorityInputs / nTxSize;
+}
+
+unsigned int CTransaction::CalculateModifiedSize(unsigned int nTxSize) const
+{
     // In order to avoid disincentivizing cleaning up the UTXO set we don't count
     // the constant overhead for each txin and up to 110 bytes of scriptSig (which
     // is enough to cover a compressed pubkey p2sh redemption) for priority.
@@ -131,14 +139,14 @@ double CTransaction::ComputePriority(double dPriorityInputs, unsigned int nTxSiz
     // risk encouraging people to create junk outputs to redeem later.
     if (nTxSize == 0)
         nTxSize = ::GetSerializeSize(*this, SER_NETWORK, PROTOCOL_VERSION);
+
     BOOST_FOREACH(const CTxIn& txin, vin)
     {
         unsigned int offset = 41U + std::min(110U, (unsigned int)txin.scriptSig.size());
         if (nTxSize > offset)
             nTxSize -= offset;
     }
-    if (nTxSize == 0) return 0.0;
-    return dPriorityInputs / nTxSize;
+    return nTxSize;
 }
 
 std::string CTransaction::ToString() const

--- a/src/core.h
+++ b/src/core.h
@@ -284,6 +284,9 @@ public:
     // Compute priority, given priority of inputs and (optionally) tx size
     double ComputePriority(double dPriorityInputs, unsigned int nTxSize=0) const;
 
+    // Compute modified tx size for priority calculation (optionally given tx size)
+    unsigned int CalculateModifiedSize(unsigned int nTxSize=0) const;
+
     bool IsCoinBase() const
     {
         return (vin.size() == 1 && vin[0].prevout.IsNull());

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -23,6 +23,8 @@ CTxMemPoolEntry::CTxMemPoolEntry(const CTransaction& _tx, int64_t _nFee,
     tx(_tx), nFee(_nFee), nTime(_nTime), dPriority(_dPriority), nHeight(_nHeight)
 {
     nTxSize = ::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION);
+
+    nModSize = tx.CalculateModifiedSize(nTxSize);
 }
 
 CTxMemPoolEntry::CTxMemPoolEntry(const CTxMemPoolEntry& other)
@@ -34,7 +36,7 @@ double
 CTxMemPoolEntry::GetPriority(unsigned int currentHeight) const
 {
     int64_t nValueIn = tx.GetValueOut()+nFee;
-    double deltaPriority = ((double)(currentHeight-nHeight)*nValueIn)/nTxSize;
+    double deltaPriority = ((double)(currentHeight-nHeight)*nValueIn)/nModSize;
     double dResult = dPriority + deltaPriority;
     return dResult;
 }

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -31,6 +31,7 @@ private:
     CTransaction tx;
     int64_t nFee; // Cached to avoid expensive parent-transaction lookups
     size_t nTxSize; // ... and avoid recomputing tx size
+    size_t nModSize; // ... and modified size for priority
     int64_t nTime; // Local time when entering the mempool
     double dPriority; // Priority when entering the mempool
     unsigned int nHeight; // Chain height when entering the mempool


### PR DESCRIPTION
`CTxMemPoolEntry::GetPriority` was incorrectly using the full size of a transaction to caclulate a priority delta to figure out current priority as opposed to priority when the transaction entered the mempool.  I added `nModSize` to `CTxMemPoolEntry` and fixed `GetPriority`.
