### PR TITLE
Compiler Warning C4018 'expression' : signed/unsigned mismatch

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -48,7 +48,7 @@ struct CDiskBlockPos
     bool IsNull() const { return (nFile == -1); }
 };
 
-enum BlockStatus {
+enum BlockStatus : unsigned char {
     BLOCK_VALID_UNKNOWN      =    0,
     BLOCK_VALID_HEADER       =    1, // parsed, version ok, hash satisfies claimed PoW, 1 <= vtx count <= max, timestamp not in future
     BLOCK_VALID_TREE         =    2, // parent found, difficulty matches, timestamp >= median previous, checkpoint


### PR DESCRIPTION
By default enum is a signed integer. It creates signed/unsigned mismatch mismatch if used in expression like this:
        return ((nStatus & BLOCK_VALID_MASK) >= nUpTo); --(Main.h - line 737)

To avoid this condition making enum smallest unsigned type to hold all values 0 - 96 which is unsigned char.
For more info please see this: http://msdn.microsoft.com/en-us/library/y92ktdf2.aspx
