### PR TITLE
Improve askfor logging (show time it will be requested by)

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2117,7 +2117,6 @@ void CNode::AskFor(const CInv& inv)
         nRequestTime = it->second;
     else
         nRequestTime = 0;
-    LogPrint("net", "askfor %s  %d (%s) peer=%d\n", inv.ToString(), nRequestTime, DateTimeStrFormat("%H:%M:%S", nRequestTime/1000000).c_str(), id);
 
     // Make sure not to reuse time indexes to keep things in the same order
     int64_t nNow = GetTimeMicros() - 1000000;
@@ -2132,6 +2131,7 @@ void CNode::AskFor(const CInv& inv)
         mapAlreadyAskedFor.update(it, nRequestTime);
     else
         mapAlreadyAskedFor.insert(std::make_pair(inv, nRequestTime));
+    LogPrint("net", "askfor %s  (%s) peer=%d\n", inv.ToString(), DateTimeStrFormat("%H:%M:%S", nRequestTime/1000000).c_str(), id);
     mapAskFor.insert(std::make_pair(nRequestTime, inv));
 }
 


### PR DESCRIPTION
This improves logging of askfors. Firstly it now shows the time the request will be sent (rather than the incorrect time 2 minutes earlier). Also, the number of the time is now omitted since this now isn't useful since time went from seconds to microseconds.
