### PR TITLE
Only need to subtract 1 (originally time was in seconds).

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2120,7 +2120,7 @@ void CNode::AskFor(const CInv& inv)
     LogPrint("net", "askfor %s  %d (%s) peer=%d\n", inv.ToString(), nRequestTime, DateTimeStrFormat("%H:%M:%S", nRequestTime/1000000).c_str(), id);
 
     // Make sure not to reuse time indexes to keep things in the same order
-    int64_t nNow = GetTimeMicros() - 1000000;
+    int64_t nNow = GetTimeMicros() - 1;
     static int64_t nLastTime;
     ++nLastTime;
     nNow = std::max(nNow, nLastTime);


### PR DESCRIPTION
#3514 changed the time used with askfors from seconds to milliseconds but the change introduced an assumption that the time needed to be reduced by 1 second, when it fact it was the number that needed to be reduced by 1.
