### PR TITLE
net: Better askfor request management

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -91,6 +91,7 @@ BITCOIN_CORE_H = \
   mruset.h \
   netbase.h \
   net.h \
+  netaskfor.h \
   noui.h \
   pow.h \
   protocol.h \
@@ -151,6 +152,7 @@ libbitcoin_server_a_SOURCES = \
   main.cpp \
   miner.cpp \
   net.cpp \
+  netaskfor.cpp \
   noui.cpp \
   pow.cpp \
   rpcblockchain.cpp \

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -16,6 +16,7 @@
 #include "main.h"
 #include "miner.h"
 #include "net.h"
+#include "netaskfor.h"
 #include "rpcserver.h"
 #include "txdb.h"
 #include "ui_interface.h"
@@ -129,6 +130,7 @@ void Shutdown()
 #endif
     StopNode();
     UnregisterNodeSignals(GetNodeSignals());
+    NetAskFor::UnregisterNodeSignals(GetNodeSignals());
 
     {
         boost::filesystem::path est_path = GetDataDir() / FEE_ESTIMATES_FILENAME;
@@ -791,6 +793,7 @@ bool AppInit2(boost::thread_group& threadGroup)
     // ********************************************************* Step 6: network initialization
 
     RegisterNodeSignals(GetNodeSignals());
+    NetAskFor::RegisterNodeSignals(GetNodeSignals());
 
     if (mapArgs.count("-onlynet")) {
         std::set<enum Network> nets;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,6 +12,7 @@
 #include "checkqueue.h"
 #include "init.h"
 #include "net.h"
+#include "netaskfor.h"
 #include "pow.h"
 #include "txdb.h"
 #include "txmempool.h"
@@ -3656,7 +3657,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                     if (inv.type == MSG_BLOCK)
                         AddBlockToQueue(pfrom->GetId(), inv.hash);
                     else
-                        pfrom->AskFor(inv);
+                        NetAskFor::AskFor(pfrom, inv);
                 }
             } else if (inv.type == MSG_BLOCK && mapOrphanBlocks.count(inv.hash)) {
                 PushGetBlocks(pfrom, chainActive.Tip(), GetOrphanRoot(inv.hash));
@@ -3781,13 +3782,12 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
 
         CInv inv(MSG_TX, tx.GetHash());
         pfrom->AddInventoryKnown(inv);
+        NetAskFor::Completed(pfrom, inv);
 
         LOCK(cs_main);
 
         bool fMissingInputs = false;
         CValidationState state;
-
-        mapAlreadyAskedFor.erase(inv);
 
         if (AcceptToMemoryPool(mempool, state, tx, true, &fMissingInputs))
         {
@@ -4443,7 +4443,6 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
         // received a (requested) block in one minute, and that all blocks are
         // in flight for over two minutes, since we first had a chance to
         // process an incoming block.
-        int64_t nNow = GetTimeMicros();
         if (!pto->fDisconnect && state.nBlocksInFlight &&
             state.nLastBlockReceive < state.nLastBlockProcess - BLOCK_DOWNLOAD_TIMEOUT*1000000 &&
             state.vBlocksInFlight.front().nTime < state.nLastBlockProcess - 2*BLOCK_DOWNLOAD_TIMEOUT*1000000) {
@@ -4468,26 +4467,6 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
                 pto->PushMessage("getdata", vGetData);
                 vGetData.clear();
             }
-        }
-
-        //
-        // Message: getdata (non-blocks)
-        //
-        while (!pto->fDisconnect && !pto->mapAskFor.empty() && (*pto->mapAskFor.begin()).first <= nNow)
-        {
-            const CInv& inv = (*pto->mapAskFor.begin()).second;
-            if (!AlreadyHave(inv))
-            {
-                if (fDebug)
-                    LogPrint("net", "Requesting %s peer=%d\n", inv.ToString(), pto->id);
-                vGetData.push_back(inv);
-                if (vGetData.size() >= 1000)
-                {
-                    pto->PushMessage("getdata", vGetData);
-                    vGetData.clear();
-                }
-            }
-            pto->mapAskFor.erase(pto->mapAskFor.begin());
         }
         if (!vGetData.empty())
             pto->PushMessage("getdata", vGetData);

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -84,7 +84,6 @@ CCriticalSection cs_vNodes;
 map<CInv, CDataStream> mapRelay;
 deque<pair<int64_t, CInv> > vRelayExpiration;
 CCriticalSection cs_mapRelay;
-limitedmap<CInv, int64_t> mapAlreadyAskedFor(MAX_INV_SZ);
 
 static deque<string> vOneShots;
 CCriticalSection cs_vOneShots;
@@ -2105,36 +2104,6 @@ CNode::~CNode()
         delete pfilter;
 
     GetNodeSignals().FinalizeNode(GetId());
-}
-
-void CNode::AskFor(const CInv& inv)
-{
-    if (mapAskFor.size() > MAPASKFOR_MAX_SZ)
-        return;
-    // We're using mapAskFor as a priority queue,
-    // the key is the earliest time the request can be sent
-    int64_t nRequestTime;
-    limitedmap<CInv, int64_t>::const_iterator it = mapAlreadyAskedFor.find(inv);
-    if (it != mapAlreadyAskedFor.end())
-        nRequestTime = it->second;
-    else
-        nRequestTime = 0;
-    LogPrint("net", "askfor %s  %d (%s) peer=%d\n", inv.ToString(), nRequestTime, DateTimeStrFormat("%H:%M:%S", nRequestTime/1000000), id);
-
-    // Make sure not to reuse time indexes to keep things in the same order
-    int64_t nNow = GetTimeMicros() - 1000000;
-    static int64_t nLastTime;
-    ++nLastTime;
-    nNow = std::max(nNow, nLastTime);
-    nLastTime = nNow;
-
-    // Each retry is 2 minutes after the last
-    nRequestTime = std::max(nRequestTime + 2 * 60 * 1000000, nNow);
-    if (it != mapAlreadyAskedFor.end())
-        mapAlreadyAskedFor.update(it, nRequestTime);
-    else
-        mapAlreadyAskedFor.insert(std::make_pair(inv, nRequestTime));
-    mapAskFor.insert(std::make_pair(nRequestTime, inv));
 }
 
 void CNode::BeginMessage(const char* pszCommand) EXCLUSIVE_LOCK_FUNCTION(cs_vSend)

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1776,11 +1776,18 @@ void StartNode(boost::thread_group& threadGroup)
 
     // Dump network addresses
     threadGroup.create_thread(boost::bind(&LoopForever<void (*)()>, "dumpaddr", &DumpAddresses, DUMP_ADDRESSES_INTERVAL * 1000));
+
+    // Start miscellaneous threads
+    g_signals.StartThreads(threadGroup);
 }
 
 bool StopNode()
 {
     LogPrintf("StopNode()\n");
+
+    // Stop miscellaneous threads
+    g_signals.StopThreads();
+
     MapPort(false);
     if (semOutbound)
         for (int i=0; i<MAX_OUTBOUND_CONNECTIONS; i++)

--- a/src/net.h
+++ b/src/net.h
@@ -129,7 +129,6 @@ extern CCriticalSection cs_vNodes;
 extern std::map<CInv, CDataStream> mapRelay;
 extern std::deque<std::pair<int64_t, CInv> > vRelayExpiration;
 extern CCriticalSection cs_mapRelay;
-extern limitedmap<CInv, int64_t> mapAlreadyAskedFor;
 
 extern std::vector<std::string> vAddedNodes;
 extern CCriticalSection cs_vAddedNodes;
@@ -293,7 +292,6 @@ public:
     mruset<CInv> setInventoryKnown;
     std::vector<CInv> vInventoryToSend;
     CCriticalSection cs_inventory;
-    std::multimap<int64_t, CInv> mapAskFor;
 
     // Ping time measurement:
     // The pong reply we're expecting, or 0 if no pong expected.
@@ -394,8 +392,6 @@ public:
                 vInventoryToSend.push_back(inv);
         }
     }
-
-    void AskFor(const CInv& inv);
 
     // TODO: Document the postcondition of this function.  Is cs_vSend locked?
     void BeginMessage(const char* pszCommand) EXCLUSIVE_LOCK_FUNCTION(cs_vSend);

--- a/src/net.h
+++ b/src/net.h
@@ -83,6 +83,8 @@ struct CNodeSignals
     boost::signals2::signal<bool (CNode*, bool)> SendMessages;
     boost::signals2::signal<void (NodeId, const CNode*)> InitializeNode;
     boost::signals2::signal<void (NodeId)> FinalizeNode;
+    boost::signals2::signal<void (boost::thread_group& threadGroup)> StartThreads;
+    boost::signals2::signal<void ()> StopThreads;
 };
 
 

--- a/src/netaskfor.cpp
+++ b/src/netaskfor.cpp
@@ -1,0 +1,360 @@
+// Copyright (c) 2009-2014 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#if defined(HAVE_CONFIG_H)
+#include "config/bitcoin-config.h"
+#endif
+
+#include "netaskfor.h"
+
+#include <boost/thread.hpp>
+
+#include "net.h"
+#include "util.h"
+
+/**
+ * Inventory item request management.
+ *
+ * Maintains state separate from CNode.
+ * There is a two-way mapping between CNodeAskForState and mapInvRequests.
+ */
+namespace {
+
+/** Node specific state for netaskfor module */
+class CNodeAskForState
+{
+public:
+    CNodeAskForState(): node(0) {}
+
+    /** Set of inv items that are being requested from this node */
+    std::set<CInv> setAskFor;
+
+    /** Group up to 1000 outgoing requests per node */
+    std::vector<CInv> outgoingRequests;
+
+    /** Network connection associated with this node */
+    CNode *node; /// TODO ugly but needed for sending getdata
+};
+
+typedef std::multimap<int64_t, CInv> InvRequestsWorkQueue;
+
+/** State of one inventory item request.
+ * @note in this structure we store NodeIds instead of CNodeAskForState*, as this
+ * would double memory usage on 64-bit (on the other hand, that would reduce the number of map
+ * lookups needed...)
+ */
+class CInvState
+{
+public:
+    typedef std::set<NodeId> NodeSet;
+    /** IDs of nodes that have this item */
+    NodeSet nodes;
+    /** IDs of nodes that we have not tried requesting this inv from already */
+    NodeSet notRequestedFrom;
+    /** Current node that this is being requested from */
+    NodeId beingRequestedFrom;
+    /** Must correspond to current entry in work queue for this
+     *  inventory item (or invRequestsWorkQueue.end())
+     */
+    InvRequestsWorkQueue::iterator workQueueIter;
+};
+typedef std::map<CInv, CInvState> MapInvRequests;
+
+/** Local data, all protected by cs_invRequests */
+CCriticalSection cs_invRequests;
+/** Map node id to local state */
+std::map<NodeId, CNodeAskForState> mapNodeAskForState;
+/** Map inv to current request state */
+MapInvRequests mapInvRequests;
+/** The work queue keeps track of when is the next time a request needs
+ * to be revisited.
+ * @invariant Each request has at most one entry.
+ * @note Theoretically this could be a deque instead of a map, as we only add to
+ * the end (assuming monotonic time) and to the beginning (first tries have
+ * t=0), and remove from the beginning. However std::deque invalidates
+ * iterators so we cannot keep around an iterator to remove the work queue item
+ * on cancel.
+ */
+InvRequestsWorkQueue invRequestsWorkQueue;
+CTimeoutCondition condInvRequests;
+/** Exit thread flag */
+bool fStopThread;
+
+/** Get local state for a node id.
+ * @note Requires that cs_invRequests is held
+ */
+CNodeAskForState *State(NodeId pnode)
+{
+    std::map<NodeId, CNodeAskForState>::iterator it = mapNodeAskForState.find(pnode);
+    if (it == mapNodeAskForState.end())
+        return NULL;
+    return &it->second;
+}
+
+/** Handler for when a new node appears */
+void InitializeNode(NodeId nodeid, const CNode *pnode)
+{
+    LOCK(cs_invRequests);
+    mapNodeAskForState.insert(std::make_pair(nodeid, CNodeAskForState()));
+}
+
+/** Handler to clean up when a node goes away */
+void FinalizeNode(NodeId nodeid)
+{
+    LOCK(cs_invRequests);
+    CNodeAskForState *state = State(nodeid);
+    assert(state);
+
+    /// Clean up any requests that were underway to the node,
+    /// or refer to the node.
+    BOOST_FOREACH(const CInv &inv, state->setAskFor)
+    {
+        MapInvRequests::iterator i = mapInvRequests.find(inv);
+        if (i != mapInvRequests.end())
+        {
+            i->second.nodes.erase(nodeid);
+            i->second.notRequestedFrom.erase(nodeid);
+
+            if (i->second.beingRequestedFrom == nodeid)
+            {
+                LogPrint("netaskfor", "%s: Inv item %s was being requested from destructing node %i\n",
+                        __func__,
+                        inv.ToString(), nodeid);
+                i->second.beingRequestedFrom = 0;
+                /// Make sure the old workqueue item for the inv is removed,
+                /// to avoid spurious retries
+                if (i->second.workQueueIter != invRequestsWorkQueue.end())
+                    invRequestsWorkQueue.erase(i->second.workQueueIter);
+                /// Re-trigger request logic
+                i->second.workQueueIter = invRequestsWorkQueue.insert(std::make_pair(0, inv));
+                condInvRequests.notify_one();
+            }
+        }
+    }
+    mapNodeAskForState.erase(nodeid);
+}
+
+/** Forget a certain inventory item request
+ * @note requires that cs_invRequests lock is held.
+ */
+void Forget(MapInvRequests::iterator i)
+{
+    /// Remove reference to this inventory item request from nodes
+    BOOST_FOREACH(NodeId nodeid, i->second.nodes)
+    {
+        CNodeAskForState *state = State(nodeid);
+        assert(state);
+        state->setAskFor.erase(i->first);
+    }
+    /// Remove from workqueue
+    if (i->second.workQueueIter != invRequestsWorkQueue.end())
+        invRequestsWorkQueue.erase(i->second.workQueueIter);
+    /// Remove from map
+    mapInvRequests.erase(i);
+}
+
+/** Flushes queued getdatas to a node by id.
+ * @note requires that cs_invRequests lock is held.
+ */
+void FlushGetdata(NodeId nodeid)
+{
+    CNodeAskForState *state = State(nodeid);
+    assert(state && state->node);
+    CNode *node = state->node;
+
+    /// Don't send empty getdatas, ever
+    if (state->outgoingRequests.empty())
+        return;
+
+    std::stringstream debug;
+    BOOST_FOREACH(const CInv &inv, state->outgoingRequests)
+        debug << inv.ToString() << " ";
+    LogPrint("netaskfor", "%s: peer=%i getdata %s\n", __func__, nodeid, debug.str());
+
+    node->PushMessage("getdata", state->outgoingRequests);
+    state->outgoingRequests.clear();
+}
+
+/** Queues a getdata to a node by id
+ * @note requires that cs_invRequests lock is held.
+ */
+void QueueGetdata(NodeId nodeid, const CInv &inv, bool isRetry)
+{
+    CNodeAskForState *state = State(nodeid);
+    assert(state);
+
+    LogPrint("netaskfor", "%s: Requesting item %s from node %i (%s)\n", __func__,
+            inv.ToString(), nodeid,
+            isRetry ? "retry" : "first request");
+
+    state->outgoingRequests.push_back(inv);
+
+    /// Make sure a getdata request doesn't contain more than 1000 entries
+    /// Flush prematurely if this is going to be the case.
+    if(state->outgoingRequests.size() >= 1000)
+        FlushGetdata(nodeid);
+}
+
+void ThreadHandleAskFor()
+{
+    while (!fStopThread)
+    {
+        LogPrint("netaskfor", "%s: iteration\n", __func__);
+        int64_t timeToNext = std::numeric_limits<int64_t>::max();
+
+        {
+            LOCK(cs_invRequests);
+            int64_t now = GetTimeMillis();
+            std::set<NodeId> nodesToFlush;
+            /// Process work queue entries that are timestamped either now or before now
+            while (!invRequestsWorkQueue.empty() && invRequestsWorkQueue.begin()->first <= now)
+            {
+                const CInv &inv = invRequestsWorkQueue.begin()->second;
+                MapInvRequests::iterator it = mapInvRequests.find(inv);
+                LogPrint("netaskfor", "%s: processing item %s\n", __func__, inv.ToString());
+                if (it != mapInvRequests.end())
+                {
+                    CInvState &invstate = it->second;
+                    invstate.workQueueIter = invRequestsWorkQueue.end();
+                    /// Pick a node to request from, if available
+                    ///
+                    /// Currently this picks the node with the lowest node id
+                    /// (notRequestedFrom is an ordered set) that offers the item
+                    /// that we haven't tried yet. This is usually the
+                    /// longest-connected node that we know to have the data.
+                    if (invstate.notRequestedFrom.empty())
+                    {
+                        LogPrint("netaskfor", "%s: No more nodes to request item %s from, discarding request\n", __func__, inv.ToString());
+                        Forget(it);
+                    } else {
+                        CInvState::NodeSet::iterator first = invstate.notRequestedFrom.begin();
+                        NodeId nodeid = *first;
+                        invstate.notRequestedFrom.erase(first);
+                        invstate.beingRequestedFrom = nodeid;
+
+                        QueueGetdata(nodeid, inv, invRequestsWorkQueue.begin()->first != 0);
+                        nodesToFlush.insert(nodeid);
+
+                        /// Need to revisit this request after timeout
+                        invstate.workQueueIter = invRequestsWorkQueue.insert(std::make_pair(now + NetAskFor::REQUEST_TIMEOUT, inv));
+                    }
+                } else {
+                    LogPrint("netaskfor", "%s: request for item %s is missing!\n", __func__, inv.ToString());
+                }
+                invRequestsWorkQueue.erase(invRequestsWorkQueue.begin());
+            }
+
+            /// Send remaining outgoing requests to nodes
+            /// Not doing this after every iteration could save a few bytes at the
+            /// expense of delaying getdatas for longer (would need to be taken into
+            /// account in the timeout logic!).
+            BOOST_FOREACH(NodeId nodeid, nodesToFlush)
+                FlushGetdata(nodeid);
+
+            /// Compute time to next event
+            if (!invRequestsWorkQueue.empty())
+                timeToNext = invRequestsWorkQueue.begin()->first - GetTimeMillis();
+        }
+
+
+        /// If we don't know how long until next work item, wait until woken up
+        if (timeToNext == std::numeric_limits<int64_t>::max())
+        {
+            LogPrint("netaskfor", "%s: blocking\n", __func__);
+            condInvRequests.wait();
+        } else if (timeToNext > 0)
+        {
+            LogPrint("netaskfor", "%s: waiting for %d ms\n", __func__, timeToNext);
+            condInvRequests.timed_wait(timeToNext);
+        }
+    }
+}
+
+void StartThreads(boost::thread_group& threadGroup)
+{
+    fStopThread = false;
+    /// Inventory management thread
+    threadGroup.create_thread(boost::bind(&TraceThread<void (*)()>, "askfor", &ThreadHandleAskFor));
+}
+
+void StopThreads()
+{
+    fStopThread = true;
+    condInvRequests.notify_one();
+}
+
+}
+
+namespace NetAskFor
+{
+
+void Completed(CNode *node, const CInv& inv)
+{
+    /// As soon as this is possible this should be subscribed to the 'tx' P2P
+    /// message directly, instead of rely on being called from main.
+    LOCK(cs_invRequests);
+    MapInvRequests::iterator i = mapInvRequests.find(inv);
+    if (i != mapInvRequests.end())
+    {
+        LogPrint("netaskfor", "%s: %s peer=%i\n", __func__, inv.ToString(), node->GetId());
+        Forget(i);
+    } else {
+        /// This can happen if a node sends a transaction without unannouncing it with 'inv'
+        /// first, or then we retry a request, which completes (and thus forget about), and then
+        /// the original node comes back and sends our requested data anyway.
+        LogPrint("netaskfor", "%s: %s not found! peer=%i\n", __func__, inv.ToString(), node->GetId());
+    }
+}
+
+void AskFor(CNode *node, const CInv& inv)
+{
+    LOCK(cs_invRequests);
+    NodeId nodeid = node->GetId();
+    CNodeAskForState *state = State(nodeid);
+    assert(state);
+    state->node = node;
+
+    /// Bound number of concurrent inventory requests to each node, this has
+    /// the indirect effect of bounding all data structures.
+    if (state->setAskFor.size() > MAX_SETASKFOR_SZ)
+        return;
+
+    LogPrint("netaskfor", "askfor %s  peer=%d\n", inv.ToString(), nodeid);
+
+    MapInvRequests::iterator it = mapInvRequests.find(inv);
+    if (it == mapInvRequests.end())
+    {
+        std::pair<MapInvRequests::iterator, bool> ins = mapInvRequests.insert(std::make_pair(inv, CInvState()));
+        it = ins.first;
+        /// As this is the first time that this item gets announced by anyone, add it to the work queue immediately
+        it->second.workQueueIter = invRequestsWorkQueue.insert(std::make_pair(0, inv));
+        condInvRequests.notify_one();
+    }
+    std::pair<CInvState::NodeSet::iterator, bool> ins2 = it->second.nodes.insert(nodeid);
+    if (ins2.second)
+    {
+        /// If this is the first time this node announces the inv item, add it to the set of untried nodes
+        /// for the item.
+        it->second.notRequestedFrom.insert(nodeid);
+    }
+    state->setAskFor.insert(inv);
+}
+
+void RegisterNodeSignals(CNodeSignals& nodeSignals)
+{
+    nodeSignals.InitializeNode.connect(&InitializeNode);
+    nodeSignals.FinalizeNode.connect(&FinalizeNode);
+    nodeSignals.StartThreads.connect(&StartThreads);
+    nodeSignals.StopThreads.connect(&StopThreads);
+}
+
+void UnregisterNodeSignals(CNodeSignals& nodeSignals)
+{
+    nodeSignals.InitializeNode.disconnect(&InitializeNode);
+    nodeSignals.FinalizeNode.disconnect(&FinalizeNode);
+    nodeSignals.StartThreads.disconnect(&StartThreads);
+    nodeSignals.StopThreads.disconnect(&StopThreads);
+}
+
+};

--- a/src/netaskfor.h
+++ b/src/netaskfor.h
@@ -1,0 +1,46 @@
+// Copyright (c) 2009-2014 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+/** Inventory request management */
+#ifndef BITCOIN_NETASKFOR_H
+#define BITCOIN_NETASKFOR_H
+
+#include "protocol.h"
+#include "sync.h"
+
+#include <map>
+#include <set>
+
+class CNode;
+class CNodeSignals;
+
+namespace NetAskFor
+{
+/** Retry ask for inventory item to a different node if node doesn't
+ * respond with data within this time (in ms)
+ */
+const int64_t REQUEST_TIMEOUT = 2 * 60 * 1000;
+
+/** The maximum number of inv requests that can be in flight from a node */
+static const unsigned int MAX_SETASKFOR_SZ = 10000;
+
+/** Register node signals for inventory request handling */
+void RegisterNodeSignals(CNodeSignals& nodeSignals);
+
+/** Unregister node signals for inventory request handling */
+void UnregisterNodeSignals(CNodeSignals& nodeSignals);
+
+/** Notify that a node owns a certain inventory item,
+ * also initiate a inventory item request if none exists yet for it.
+ */
+void AskFor(CNode *node, const CInv &inv);
+
+/** Forget an inventory item request. This must be called from the
+ *  'tx' message handler.
+ */
+void Completed(CNode *node, const CInv &inv);
+
+};
+
+#endif // BITCOIN_NETASKFOR

--- a/src/sync.h
+++ b/src/sync.h
@@ -103,6 +103,41 @@ void static inline AssertLockHeldInternal(const char* pszName, const char* pszFi
 void PrintLockContention(const char* pszName, const char* pszFile, int nLine);
 #endif
 
+class CTimeoutCondition
+{
+private:
+    boost::condition_variable condition;
+    boost::mutex mutex;
+    bool fHasWork;
+    boost::posix_time::ptime alarm;
+
+public:
+    void wait() {
+        boost::unique_lock<boost::mutex> lock(mutex);
+        while (!fHasWork) {
+            condition.wait(lock);
+        }
+        fHasWork = false;
+    }
+
+    void timed_wait(int milliseconds) {
+        boost::unique_lock<boost::mutex> lock(mutex);
+        boost::posix_time::ptime now = boost::posix_time::microsec_clock::universal_time();
+        alarm = now + boost::posix_time::milliseconds(milliseconds);
+        while (!fHasWork && now < alarm) {
+            condition.timed_wait(lock, alarm);
+            now = boost::posix_time::microsec_clock::universal_time();
+        }
+        fHasWork = false;
+    }
+
+    void notify_one() {
+        boost::unique_lock<boost::mutex> lock(mutex);
+        fHasWork = true;
+        condition.notify_one();
+    }
+};
+
 /** Wrapper around boost::unique_lock<Mutex> */
 template<typename Mutex>
 class CMutexLock


### PR DESCRIPTION
- Instead of naively planning requests every two minutes into (potentially) the far future w/ mapAlreadyAskedFor, actively keep track of requests, and which nodes offer the requested items
- Better handles the case where nodes announce an inv and go away, or stop responding
- Maintains state separate from CNode, which makes it easier to review and understand separately from the rest, as well as localizes changes if extension of the logic is necessary

I also think it can serve as an example of how to 'peel off' a single concern from net/main.

Uses CTimeoutCondition from @ashleyholman (#4230).

Cases to test:
- Announce and don't reply to getdata, make sure retry chooses different node after `REQUEST_TIMEOUT`
- Node disconnects and was the current node requested from - should immediately try to get from different node
- Last node that had announced a certain transaction goes away - request should be discarded 
  I've tested these cases using custom pynode clients, as well as by running this with full debugging on my node to see how it behaves,
- Premature flushing if more than 1000 getdatas queued to a node (this is a very unlikely path but it needs to be tested)

TODO:
- Slim down debug logging (this is initially useful for testing and checking, but too much in production)
- Make sure `FlushGetdata`'s handling of CNode locking is correct
- Don't request from nodes whose sendbuffer is full

Known issues:
- ~~Doesn't currently group getdata requests (sends a getdata request per item instead of one getdata for many invs) - wouldn't be too difficult to fit in but I'm not sure it is worth the complexity, as usually only one inv is sent at a time~~ (done now)

Supercedes: #4828 #4547 #4827
