### PR TITLE
We list X11, but are actually expat...switch to X11 for consistency

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -17,3 +17,8 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
+
+Except as contained in this notice, the name of the authors or copyright
+holders shall not be used in advertising or otherwise to promote the sale,
+use or other dealings in this Software without prior written authorization
+from the authors or copyright holders.


### PR DESCRIPTION
Justification for this being OK:

As X11 is strictly more restrictive, and things can be relicensed
under a strictly more restrictive license, we can clear up the
uncertainty with this commit without needing callbacks from everyone
defined under "The Bitcoin Core Developers".
