### PR TITLE
net: Remove MilliSleep from StopNode

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1791,7 +1791,6 @@ bool StopNode()
     if (semOutbound)
         for (int i=0; i<MAX_OUTBOUND_CONNECTIONS; i++)
             semOutbound->post();
-    MilliSleep(50);
     DumpAddresses();
 
     return true;


### PR DESCRIPTION
I don't understand why it would be there in the first place. This looks like voodoo, not programming.
