### PR TITLE
Remove extraneous ERROR messages where they give no extra information

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3820,9 +3820,8 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         int nDoS = 0;
         if (state.IsInvalid(nDoS))
         {
-            LogPrint("mempool", "%s from peer=%d %s was not accepted into the memory pool: %s\n", tx.GetHash().ToString(),
-                pfrom->id, pfrom->cleanSubVer,
-                state.GetRejectReason());
+            LogPrintf("mempool: %s not accepted from peer=%d %s: %s\n", inv.ToString(),
+                pfrom->id, pfrom->cleanSubVer.substr(0,20), state.GetRejectReason());
             pfrom->PushMessage("reject", strCommand, state.GetRejectCode(),
                                state.GetRejectReason(), inv.hash);
             if (nDoS > 0)


### PR DESCRIPTION
This will help to reduce the debug.log output in some cases by two unnecessary additional lines.

(debug=mempool will need to be in bitcoin.conf to ensure the error is still captured in debug.log)
