### PR TITLE
Add testnet DNS seed of Andreas Schildbach.

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -155,6 +155,7 @@ public:
         vSeeds.push_back(CDNSSeedData("alexykot.me", "testnet-seed.alexykot.me"));
         vSeeds.push_back(CDNSSeedData("bitcoin.petertodd.org", "testnet-seed.bitcoin.petertodd.org"));
         vSeeds.push_back(CDNSSeedData("bluematt.me", "testnet-seed.bluematt.me"));
+        vSeeds.push_back(CDNSSeedData("bitcoin.schildbach.de", "testnet-seed.bitcoin.schildbach.de"));
 
         base58Prefixes[PUBKEY_ADDRESS] = list_of(111);
         base58Prefixes[SCRIPT_ADDRESS] = list_of(196);


### PR DESCRIPTION
It runs sipas crawler, but rather than using its custom nameserver implementation it serves a generated zonefile via bind9. The zone always contains 25 IPv4 and 25 IPv6 peers. FWIW, the zone is secured using DNSSEC.
