### PR TITLE
Fix missing gettransaction entries in rpcclient

### DIFF
--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -67,6 +67,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "listunspent", 1 },
     { "listunspent", 2 },
     { "getblock", 1 },
+    { "gettransaction", 1 },
     { "getrawtransaction", 1 },
     { "createrawtransaction", 0 },
     { "createrawtransaction", 1 },

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -1490,7 +1490,7 @@ Value gettransaction(const Array& params, bool fHelp)
 {
     if (fHelp || params.size() < 1 || params.size() > 2)
         throw runtime_error(
-            "gettransaction \"txid\"\n"
+            "gettransaction \"txid\" ( includeWatchonly )\n"
             "\nGet detailed information about in-wallet transaction <txid>\n"
             "\nArguments:\n"
             "1. \"txid\"    (string, required) The transaction id\n"
@@ -1520,6 +1520,7 @@ Value gettransaction(const Array& params, bool fHelp)
 
             "\nExamples:\n"
             + HelpExampleCli("gettransaction", "\"1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d\"")
+            + HelpExampleCli("gettransaction", "\"1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d\" true")
             + HelpExampleRpc("gettransaction", "\"1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d\"")
         );
 


### PR DESCRIPTION
When getting a transaction to a watch-only wallet, the gettransaction RPC call should show transaction details (amount, address, received). This won't happen unless the true "includewatchonly" param is true. 

But, when doing 
bitcoin-cli gettransaction "7b38c67e8f32678bd19ad3537b384f7a619ba1e5bdacac983c9a4cc2c16b657e" true

we currently get an error:
error: {"code":-1,"message":"value is type str, expected bool"}

This is the result of the "true" value method not being serialized to json properly in the rpc client due to the gettransaction entry being missing in rpcclient vRPCConvertParams. I believe this was a bug here on at src/rpcclient.cpp:68 https://github.com/bitcoin/bitcoin/commit/0fa2f8899adf8f9f0ead29ba5d708ead6c5d4eaf

I added the entries correctly (for both 1 and 2 arguments) and also updated the rpc help message for gettransaction to let users know about the includeWatchonly param, following the conventions for the other rpc calls. 
