### PR TITLE
Clarify 'compressed nor uncompressed' error message

### DIFF
--- a/src/script.cpp
+++ b/src/script.cpp
@@ -238,7 +238,7 @@ bool IsCanonicalPubKey(const valtype &vchPubKey, unsigned int flags) {
         if (vchPubKey.size() != 33)
             return error("Non-canonical public key: invalid length for compressed key");
     } else {
-        return error("Non-canonical public key: compressed nor uncompressed");
+        return error("Non-canonical public key: neither compressed nor uncompressed");
     }
     return true;
 }


### PR DESCRIPTION
Easier to understand with the 'neither' added to the message.
