### PR TITLE
qt: Remove thousands separators after decimal point

### DIFF
--- a/src/qt/bitcoinunits.cpp
+++ b/src/qt/bitcoinunits.cpp
@@ -115,11 +115,6 @@ QString BitcoinUnits::format(int unit, qint64 n, bool fPlus, SeparatorStyle sepa
         for (int i = 3; i < q_size; i += 3)
             quotient_str.insert(q_size - i, thin_sp);
 
-    int r_size = remainder_str.size();
-    if (separators == separatorAlways || (separators == separatorStandard && r_size > 4))
-        for (int i = 3, adj = 0; i < r_size ; i += 3, adj++)
-            remainder_str.insert(i + adj, thin_sp);
-
     if (n < 0)
         quotient_str.insert(0, '-');
     else if (fPlus && n > 0)


### PR DESCRIPTION
Revert thousands separators after decimal point, as introduced in #4167.

I've tried and tried and just cannot get used to these. And if someone like me with a scientific background can't get used to them, I'm sure many other people will have problems with them.

If you don't want to see a long string of decimal digits, switch your unit to mBTC or muBTC.

Before
![with](https://cloud.githubusercontent.com/assets/126646/4182905/d7743c66-3735-11e4-97d0-b2805931423f.png)

After
![without](https://cloud.githubusercontent.com/assets/126646/4182906/dadd08ec-3735-11e4-8191-379e1d5fdf28.png)
