### PR TITLE
netbase: Make SOCKS5 negotiation interruptible

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -488,10 +488,6 @@ CNode* ConnectNode(CAddress addrConnect, const char *pszDest)
     {
         addrman.Attempt(addrConnect);
 
-        // Set to non-blocking
-        if (!SetSocketNonBlocking(hSocket, true))
-            LogPrintf("ConnectNode: Setting socket to non-blocking failed, error %s\n", NetworkErrorString(WSAGetLastError()));
-
         // Add node
         CNode* pnode = new CNode(hSocket, addrConnect, pszDest ? pszDest : "", false);
         pnode->AddRef();


### PR DESCRIPTION
Avoids that SOCKS5 negotiation will hold up the shutdown process.
- Sockets can stay in non-blocking mode, no need to switch it on/off anymore
- Adds a timeout (20 seconds) on SOCKS5 negotiation. This should be enough for even Tor to get a connection to a hidden service, and avoids blocking the opencon thread indefinitely on a hanging proxy.

Fixes #2954.

Should also solve #4502 by making sure that the socket for GetMyExternalIP2 stays in non-blocking mode (would be even better to use InterruptibleRecv in RecvLine for proper timeout/interruption handling, but this is going away anyway...).
