### PR TITLE
qt: fix tablet crash. closes #4854.

### DIFF
--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -7,7 +7,7 @@ $(package)_dependencies=openssl
 $(package)_linux_dependencies=freetype fontconfig dbus libxcb libX11 xproto libXext
 $(package)_build_subdir=qtbase
 $(package)_qt_libs=corelib network widgets gui plugins testlib
-$(package)_patches=mac-qmake.conf fix-xcb-include-order.patch
+$(package)_patches=mac-qmake.conf fix-xcb-include-order.patch qt5-tablet-osx.patch
 
 define $(package)_set_vars
 $(package)_config_opts  = -release -opensource -confirm-license
@@ -52,7 +52,8 @@ define $(package)_preprocess_cmds
   cp -f qtbase/mkspecs/macx-clang/Info.plist.app qtbase/mkspecs/macx-clang-linux/ &&\
   cp -f qtbase/mkspecs/macx-clang/qplatformdefs.h qtbase/mkspecs/macx-clang-linux/ &&\
   cp -f $($(package)_patch_dir)/mac-qmake.conf qtbase/mkspecs/macx-clang-linux/qmake.conf && \
-  patch -p1 < $($(package)_patch_dir)/fix-xcb-include-order.patch
+  patch -p1 < $($(package)_patch_dir)/fix-xcb-include-order.patch && \
+  patch -p1 < $($(package)_patch_dir)/qt5-tablet-osx.patch
 endef
 
 define $(package)_config_cmds

--- a/depends/patches/qt/qt5-tablet-osx.patch
+++ b/depends/patches/qt/qt5-tablet-osx.patch
@@ -1,0 +1,20 @@
+--- old/qtbase/src/widgets/kernel/qwidgetwindow.cpp	2014-09-05 20:45:18.717570370 -0400
++++ new/qtbase/src/widgets/kernel/qwidgetwindow.cpp	2014-09-05 20:52:38.653576561 -0400
+@@ -57,7 +57,7 @@
+ Q_WIDGETS_EXPORT extern bool qt_tab_all_widgets();
+ 
+ QWidget *qt_button_down = 0; // widget got last button-down
+-static QWidget *qt_tablet_target = 0;
++static QPointer<QWidget> qt_tablet_target = 0;
+ 
+ // popup control
+ QWidget *qt_popup_down = 0; // popup that contains the pressed widget
+@@ -96,8 +96,6 @@
+ 
+ QWidgetWindow::~QWidgetWindow()
+ {
+-    if (m_widget == qt_tablet_target)
+-        qt_tablet_target = 0;
+ }
+ 
+ #ifndef QT_NO_ACCESSIBILITY


### PR DESCRIPTION
This backports the relevant parts of: https://codereview.qt-project.org/#/c/82689/
