### PR TITLE
Use explicit fflush() instead of setvbuf()

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -630,7 +630,6 @@ bool AppInit2(boost::thread_group& threadGroup)
     fPrintToConsole = GetBoolArg("-printtoconsole", false);
     fLogTimestamps = GetBoolArg("-logtimestamps", true);
     fLogIPs = GetBoolArg("-logips", false);
-    setvbuf(stdout, NULL, _IOLBF, 0);
 #ifdef ENABLE_WALLET
     bool fDisableWallet = GetBoolArg("-disablewallet", false);
 #endif

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -211,6 +211,7 @@ int LogPrintStr(const std::string &str)
     {
         // print to console
         ret = fwrite(str.data(), 1, str.size(), stdout);
+        fflush(stdout);
     }
     else if (fPrintToDebugLog && AreBaseParamsConfigured())
     {


### PR DESCRIPTION
Flushing after every line when printing to console is desirable when
running with systemd but setvbuf() has slightly different semantics
on Windows that causes warnings.  Just do an explicit fflush() after
each line print to console instead.

Fixes https://github.com/bitcoin/bitcoin/issues/4884
