### PR TITLE
Issue#1643: Coinselection prunes extraneous inputs from ApproximateBestSubset

### DIFF
--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -328,4 +328,22 @@ BOOST_AUTO_TEST_CASE(coin_selection_tests)
     empty_wallet();
 }
 
+BOOST_AUTO_TEST_CASE(pruning_in_ApproximateBestSet)
+{
+    CoinSet setCoinsRet;
+    CAmount nValueRet;
+
+    LOCK(wallet.cs_wallet);
+
+    empty_wallet();
+    for (int i = 0; i < 12; i++) 
+    {
+        add_coin(10*CENT);
+    }
+    add_coin(100*CENT);
+    add_coin(100*CENT);
+    BOOST_CHECK(wallet.SelectCoinsMinConf(221*CENT, 1, 6, vCoins, setCoinsRet, nValueRet));
+    BOOST_CHECK_EQUAL(nValueRet, 230*CENT);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1620,6 +1620,19 @@ static void ApproximateBestSubset(vector<pair<CAmount, pair<const CWalletTx*,uns
                     if (nTotal >= nTargetValue)
                     {
                         fReachedTarget = true;
+
+                        for (unsigned int i = 0; i < vValue.size(); i++)
+                        {                        
+                            //The target has been reached, but the candidate set may contain extraneous inputs.
+                            //This iterates over all inputs and deducts any that are included, but smaller 
+                            //than the amount nTargetValue is still exceeded by.
+                            if (vfIncluded[i] && (nTotal - vValue[i].first) >= nTargetValue )
+                            {
+                                vfIncluded[i] = false;
+                                nTotal -= vValue[i].first;
+                            }
+                        }
+                        
                         if (nTotal < nBest)
                         {
                             nBest = nTotal;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1605,7 +1605,7 @@ static void ApproximateBestSubset(vector<pair<CAmount, pair<const CWalletTx*,uns
         bool fReachedTarget = false;
         for (int nPass = 0; nPass < 2 && !fReachedTarget; nPass++)
         {
-            for (unsigned int i = 0; i < vValue.size(); i++)
+            for (unsigned int i = 0; i < vValue.size() && !fReachedTarget; i++)
             {
                 //The solver here uses a randomized algorithm,
                 //the randomness serves no real security purpose but is just
@@ -1620,30 +1620,25 @@ static void ApproximateBestSubset(vector<pair<CAmount, pair<const CWalletTx*,uns
                     if (nTotal >= nTargetValue)
                     {
                         fReachedTarget = true;
-
-                        for (unsigned int i = 0; i < vValue.size(); i++)
-                        {                        
-                            //The target has been reached, but the candidate set may contain extraneous inputs.
-                            //This iterates over all inputs and deducts any that are included, but smaller 
-                            //than the amount nTargetValue is still exceeded by.
-                            if (vfIncluded[i] && (nTotal - vValue[i].first) >= nTargetValue )
-                            {
-                                vfIncluded[i] = false;
-                                nTotal -= vValue[i].first;
-                            }
-                        }
-                        
                         if (nTotal < nBest)
                         {
                             nBest = nTotal;
                             vfBest = vfIncluded;
                         }
-                        nTotal -= vValue[i].first;
-                        vfIncluded[i] = false;
                     }
                 }
             }
         }
+    }
+
+    //Reduces the approximate best subset by removing any inputs that are smaller than the surplus of nTotal beyond nTargetValue. 
+    for (unsigned int i = 0; i < vValue.size(); i++)
+    {                        
+	if (vfBest[i] && (nBest - vValue[i].first) >= nTargetValue )
+	{
+	    vfBest[i] = false;
+	    nBest -= vValue[i].first;
+	}
     }
 }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1605,7 +1605,7 @@ static void ApproximateBestSubset(vector<pair<CAmount, pair<const CWalletTx*,uns
         bool fReachedTarget = false;
         for (int nPass = 0; nPass < 2 && !fReachedTarget; nPass++)
         {
-            for (unsigned int i = 0; i < vValue.size() && !fReachedTarget; i++)
+            for (unsigned int i = 0; i < vValue.size(); i++)
             {
                 //The solver here uses a randomized algorithm,
                 //the randomness serves no real security purpose but is just
@@ -1625,6 +1625,8 @@ static void ApproximateBestSubset(vector<pair<CAmount, pair<const CWalletTx*,uns
                             nBest = nTotal;
                             vfBest = vfIncluded;
                         }
+                        nTotal -= vValue[i].first;
+                        vfIncluded[i] = false;
                     }
                 }
             }
@@ -1634,11 +1636,11 @@ static void ApproximateBestSubset(vector<pair<CAmount, pair<const CWalletTx*,uns
     //Reduces the approximate best subset by removing any inputs that are smaller than the surplus of nTotal beyond nTargetValue. 
     for (unsigned int i = 0; i < vValue.size(); i++)
     {                        
-	if (vfBest[i] && (nBest - vValue[i].first) >= nTargetValue )
-	{
-	    vfBest[i] = false;
-	    nBest -= vValue[i].first;
-	}
+        if (vfBest[i] && (nBest - vValue[i].first) >= nTargetValue )
+        {
+            vfBest[i] = false;
+            nBest -= vValue[i].first;
+        }
     }
 }
 


### PR DESCRIPTION
Improvement for [Issue#1643](https://github.com/bitcoin/bitcoin/issues/1643):
A further pass over the available inputs has been added to ApproximateBestSubset after a candidate set has been found. It will prune any extraneous inputs in the selected subset, in order to decrease the number of inputs and the resulting change.
