### PR TITLE
header include cleanup

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -98,12 +98,11 @@ BITCOIN_CORE_H = \
   rpcclient.h \
   rpcprotocol.h \
   rpcserver.h \
-  script/interpreter.h \
   script/compressor.h \
+  script/interpreter.h \
   script/script.h \
   script/sign.h \
   script/standard.h \
-  wallet_ismine.h \
   serialize.h \
   sync.h \
   threadsafety.h \
@@ -118,8 +117,9 @@ BITCOIN_CORE_H = \
   utilmoneystr.h \
   utiltime.h \
   version.h \
-  walletdb.h \
   wallet.h \
+  wallet_ismine.h \
+  walletdb.h \
   compat/sanity.h
 
 JSON_H = \
@@ -173,8 +173,8 @@ libbitcoin_wallet_a_SOURCES = \
   crypter.cpp \
   rpcdump.cpp \
   rpcwallet.cpp \
-  wallet_ismine.cpp \
   wallet.cpp \
+  wallet_ismine.cpp \
   walletdb.cpp \
   $(BITCOIN_CORE_H)
 
@@ -212,8 +212,8 @@ libbitcoin_common_a_SOURCES = \
   keystore.cpp \
   netbase.cpp \
   protocol.cpp \
-  script/interpreter.cpp \
   script/compressor.cpp \
+  script/interpreter.cpp \
   script/script.cpp \
   script/sign.cpp \
   script/standard.cpp \

--- a/src/allocators.h
+++ b/src/allocators.h
@@ -12,6 +12,7 @@
 
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/once.hpp>
+
 #include <openssl/crypto.h> // for OPENSSL_cleanse()
 
 /**

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -3,11 +3,11 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include "util.h"
+#include "chainparamsbase.h"
 #include "init.h"
 #include "rpcclient.h"
 #include "rpcprotocol.h"
-#include "chainparamsbase.h"
+#include "util.h"
 #include "utilstrencodings.h"
 #include "version.h"
 

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -3,23 +3,24 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "base58.h"
-#include "util.h"
-#include "utilmoneystr.h"
 #include "core.h"
-#include "main.h"         // for MAX_BLOCK_SIZE
+#include "core_io.h"
 #include "keystore.h"
+#include "main.h" // for MAX_BLOCK_SIZE
 #include "script/script.h"
 #include "script/sign.h"
 #include "ui_interface.h" // for _(...)
 #include "univalue/univalue.h"
-#include "core_io.h"
+#include "util.h"
+#include "utilmoneystr.h"
 
 #include <stdio.h>
-#include <boost/assign/list_of.hpp>
-#include <boost/algorithm/string.hpp>
 
-using namespace std;
+#include <boost/algorithm/string.hpp>
+#include <boost/assign/list_of.hpp>
+
 using namespace boost::assign;
+using namespace std;
 
 static bool fCreateBlank;
 static map<string,UniValue> registers;

--- a/src/chainparamsbase.h
+++ b/src/chainparamsbase.h
@@ -5,8 +5,8 @@
 #ifndef BITCOIN_CHAIN_PARAMS_BASE_H
 #define BITCOIN_CHAIN_PARAMS_BASE_H
 
-#include <vector>
 #include <string>
+#include <vector>
 
 /**
  * CBaseChainParams defines the base parameters (shared between bitcoin-cli and bitcoind)

--- a/src/core_io.h
+++ b/src/core_io.h
@@ -8,9 +8,9 @@
 #include <string>
 #include <vector>
 
-class uint256;
 class CScript;
 class CTransaction;
+class uint256;
 class UniValue;
 
 // core_read.cpp

--- a/src/core_read.cpp
+++ b/src/core_read.cpp
@@ -3,21 +3,22 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "core_io.h"
+
 #include "core.h"
-#include "serialize.h"
 #include "script/script.h"
+#include "serialize.h"
+#include "univalue/univalue.h"
 #include "util.h"
 
-#include <boost/assign/list_of.hpp>
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/predicate.hpp>
-#include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/replace.hpp>
-#include "univalue/univalue.h"
+#include <boost/algorithm/string/split.hpp>
+#include <boost/assign/list_of.hpp>
 
-using namespace std;
 using namespace boost;
 using namespace boost::algorithm;
+using namespace std;
 
 CScript ParseScript(std::string s)
 {

--- a/src/core_write.cpp
+++ b/src/core_write.cpp
@@ -3,14 +3,15 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "core_io.h"
-#include "univalue/univalue.h"
+
+#include "base58.h"
+#include "core.h"
 #include "script/script.h"
 #include "script/standard.h"
-#include "core.h"
 #include "serialize.h"
+#include "univalue/univalue.h"
 #include "util.h"
 #include "utilmoneystr.h"
-#include "base58.h"
 
 #include <boost/foreach.hpp>
 

--- a/src/crypto/ripemd160.cpp
+++ b/src/crypto/ripemd160.cpp
@@ -5,6 +5,7 @@
 #include "crypto/ripemd160.h"
 
 #include "crypto/common.h"
+
 #include <string.h>
 
 // Internal implementation code.

--- a/src/crypto/sha1.cpp
+++ b/src/crypto/sha1.cpp
@@ -5,6 +5,7 @@
 #include "crypto/sha1.h"
 
 #include "crypto/common.h"
+
 #include <string.h>
 
 // Internal implementation code.

--- a/src/crypto/sha2.cpp
+++ b/src/crypto/sha2.cpp
@@ -5,6 +5,7 @@
 #include "crypto/sha2.h"
 
 #include "crypto/common.h"
+
 #include <string.h>
 
 // Internal implementation code.

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -20,6 +20,7 @@
 #include <boost/filesystem.hpp>
 #include <boost/thread.hpp>
 #include <boost/version.hpp>
+
 #include <openssl/rand.h>
 
 using namespace std;

--- a/src/db.h
+++ b/src/db.h
@@ -15,11 +15,13 @@
 #include <vector>
 
 #include <boost/filesystem/path.hpp>
+
 #include <db_cxx.h>
 
-struct CBlockLocator;
 class CDiskBlockIndex;
 class COutPoint;
+
+struct CBlockLocator;
 
 extern unsigned int nWalletDBUpdated;
 

--- a/src/hash.h
+++ b/src/hash.h
@@ -6,8 +6,8 @@
 #ifndef BITCOIN_HASH_H
 #define BITCOIN_HASH_H
 
-#include "crypto/sha2.h"
 #include "crypto/ripemd160.h"
+#include "crypto/sha2.h"
 #include "serialize.h"
 #include "uint256.h"
 #include "version.h"

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -11,6 +11,7 @@
 
 #include "addrman.h"
 #include "checkpoints.h"
+#include "compat/sanity.h"
 #include "key.h"
 #include "main.h"
 #include "miner.h"
@@ -32,7 +33,6 @@
 #ifndef WIN32
 #include <signal.h>
 #endif
-#include "compat/sanity.h"
 
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/algorithm/string/replace.hpp>

--- a/src/leveldbwrapper.h
+++ b/src/leveldbwrapper.h
@@ -10,6 +10,7 @@
 #include "version.h"
 
 #include <boost/filesystem/path.hpp>
+
 #include <leveldb/db.h>
 #include <leveldb/write_batch.h>
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -48,8 +48,8 @@
 #endif
 #endif
 
-using namespace std;
 using namespace boost;
+using namespace std;
 
 namespace {
     const int MAX_OUTBOUND_CONNECTIONS = 8;

--- a/src/pow.h
+++ b/src/pow.h
@@ -8,8 +8,8 @@
 
 #include <stdint.h>
 
-class CBlockIndex;
 class CBlockHeader;
+class CBlockIndex;
 class uint256;
 
 unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock);

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -12,10 +12,12 @@
 #include "util.h" // for LogPrint()
 #include "utilstrencodings.h" // for GetTime()
 
+#include <limits>
+
 #ifndef WIN32
 #include <sys/time.h>
 #endif
-#include <limits>
+
 #include <openssl/crypto.h>
 #include <openssl/err.h>
 #include <openssl/rand.h>

--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -3,7 +3,6 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <set>
 #include "rpcclient.h"
 
 #include "rpcprotocol.h"
@@ -11,6 +10,7 @@
 #include "ui_interface.h"
 #include "chainparams.h" // for Params().RPCPort()
 
+#include <set>
 #include <stdint.h>
 
 using namespace std;

--- a/src/rpcdump.cpp
+++ b/src/rpcdump.cpp
@@ -7,8 +7,8 @@
 #include "init.h"
 #include "main.h"
 #include "sync.h"
-#include "utiltime.h"
 #include "util.h"
+#include "utiltime.h"
 #include "wallet.h"
 
 #include <fstream>
@@ -16,6 +16,7 @@
 
 #include <boost/algorithm/string.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
+
 #include "json/json_spirit_value.h"
 
 using namespace json_spirit;

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -3,14 +3,14 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include "rpcserver.h"
 #include "chainparams.h"
+#include "core_io.h"
 #include "init.h"
 #include "net.h"
 #include "main.h"
 #include "miner.h"
 #include "pow.h"
-#include "core_io.h"
+#include "rpcserver.h"
 #include "util.h"
 #ifdef ENABLE_WALLET
 #include "db.h"

--- a/src/rpcnet.cpp
+++ b/src/rpcnet.cpp
@@ -13,6 +13,7 @@
 #include "util.h"
 
 #include <boost/foreach.hpp>
+
 #include "json/json_spirit_value.h"
 
 using namespace json_spirit;

--- a/src/rpcprotocol.cpp
+++ b/src/rpcprotocol.cpp
@@ -5,8 +5,8 @@
 
 #include "rpcprotocol.h"
 
-#include "util.h"
 #include "tinyformat.h"
+#include "util.h"
 #include "utilstrencodings.h"
 #include "utiltime.h"
 #include "version.h"

--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -12,8 +12,8 @@
 #include "net.h"
 #include "rpcserver.h"
 #include "script/script.h"
-#include "script/standard.h"
 #include "script/sign.h"
+#include "script/standard.h"
 #include "uint256.h"
 #ifdef ENABLE_WALLET
 #include "wallet.h"
@@ -25,10 +25,10 @@
 #include "json/json_spirit_utils.h"
 #include "json/json_spirit_value.h"
 
-using namespace std;
 using namespace boost;
 using namespace boost::assign;
 using namespace json_spirit;
+using namespace std;
 
 void ScriptPubKeyToJSON(const CScript& scriptPubKey, Object& out, bool fIncludeHex)
 {

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -10,8 +10,8 @@
 
 #include <algorithm>
 #include <assert.h>
-#include <limits>
 #include <ios>
+#include <limits>
 #include <map>
 #include <set>
 #include <stdint.h>

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -7,9 +7,10 @@
 #include "util.h"
 #include "utilstrencodings.h"
 
+#include <stdio.h>
+
 #include <boost/foreach.hpp>
 #include <boost/thread.hpp>
-#include <stdio.h>
 
 #ifdef DEBUG_LOCKCONTENTION
 void PrintLockContention(const char* pszName, const char* pszFile, int nLine)

--- a/src/timedata.h
+++ b/src/timedata.h
@@ -5,10 +5,10 @@
 #ifndef BITCOIN_TIMEDATA_H
 #define BITCOIN_TIMEDATA_H
 
-#include <stdint.h>
-#include <vector>
 #include <algorithm>
 #include <assert.h>
+#include <stdint.h>
+#include <vector>
 
 class CNetAddr;
 

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -9,8 +9,9 @@
 #include "pow.h"
 #include "uint256.h"
 
-#include <boost/thread.hpp>
 #include <stdint.h>
+
+#include <boost/thread.hpp>
 
 using namespace std;
 

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -3,8 +3,9 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include "core.h"
 #include "txmempool.h"
+
+#include "core.h"
 #include "util.h"
 
 #include <boost/circular_buffer.hpp>
@@ -644,4 +645,3 @@ bool CCoinsViewMemPool::GetCoins(const uint256 &txid, CCoins &coins) const {
 bool CCoinsViewMemPool::HaveCoins(const uint256 &txid) const {
     return mempool.exists(txid) || base->HaveCoins(txid);
 }
-

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -7,10 +7,10 @@
 #define BITCOIN_UINT256_H
 
 #include <assert.h>
+#include <cstring>
 #include <stdexcept>
 #include <stdint.h>
 #include <string>
-#include <cstring>
 #include <vector>
 
 class uint_error : public std::runtime_error {

--- a/src/util.h
+++ b/src/util.h
@@ -15,8 +15,8 @@
 #endif
 
 #include "compat.h"
-#include "utiltime.h"
 #include "tinyformat.h"
+#include "utiltime.h"
 
 #include <exception>
 #include <map>

--- a/src/utilstrencodings.cpp
+++ b/src/utilstrencodings.cpp
@@ -7,9 +7,10 @@
 
 #include "tinyformat.h"
 
-#include <boost/foreach.hpp>
 #include <errno.h>
 #include <limits>
+
+#include <boost/foreach.hpp>
 
 using namespace std;
 

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -7,6 +7,7 @@
 #include "tinyformat.h"
 
 #include <string>
+
 #include <boost/algorithm/string/join.hpp>
 
 // Name of client reported in the 'version' message. Report the same name

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -11,8 +11,8 @@
 #include "key.h"
 #include "keystore.h"
 #include "main.h"
-#include "wallet_ismine.h"
 #include "ui_interface.h"
+#include "wallet_ismine.h"
 #include "walletdb.h"
 
 #include <algorithm>

--- a/src/walletdb.cpp
+++ b/src/walletdb.cpp
@@ -9,8 +9,8 @@
 #include "protocol.h"
 #include "serialize.h"
 #include "sync.h"
-#include "utiltime.h"
 #include "util.h"
+#include "utiltime.h"
 #include "wallet.h"
 
 #include <boost/filesystem.hpp>


### PR DESCRIPTION
- ensures alphabetical ordering for includes etc. in source file headers

I know this will create (once more) some controversial feelings, but I'm going to keep it up-to-date for a while. No need to hurry, no need to rush... but let's please consider cleaning that up ONCE and use that style "forever", thanks.
