### PR TITLE
Fixed the broken `brew` shell command in the build-for-Mac guide

### DIFF
--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -80,7 +80,7 @@ Running this command takes you into brew's interactive mode, which allows you to
 $ brew install https://raw.github.com/mxcl/homebrew/master/Library/Formula/berkeley-db4.rb -–without-java 
 ```
 
-These rest of these commands are run inside brew interactive mode:
+The rest of these commands is run inside brew interactive mode:
 ```
 /private/tmp/berkeley-db4-UGpd0O/db-4.8.30 $ cd ..
 /private/tmp/berkeley-db4-UGpd0O $ db-4.8.30/dist/configure --prefix=/usr/local/Cellar/berkeley-db4/4.8.30 --mandir=/usr/local/Cellar/berkeley-db4/4.8.30/share/man --enable-cxx

--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -91,7 +91,7 @@ These rest of these commands are run inside brew interactive mode:
 
 After exiting, you'll get a warning that the install is keg-only, which means it wasn't symlinked to `/usr/local`.  You don't need it to link it to build bitcoin, but if you want to, here's how:
 
-    $ brew --force link berkeley-db4
+    $ brew link --force berkeley-db4
 
 
 ### Building `bitcoind`


### PR DESCRIPTION
Plus, a typo/grammar fix.
