### PR TITLE
Add wildcard support to rpcallowip

### DIFF
--- a/src/netbase.h
+++ b/src/netbase.h
@@ -105,6 +105,8 @@ class CSubNet
         uint8_t netmask[16];
         /// Is this value valid? (only used to signal parse errors)
         bool valid;
+        /// If not, why?
+        std::string invalidReason;
 
     public:
         CSubNet();
@@ -114,6 +116,7 @@ class CSubNet
 
         std::string ToString() const;
         bool IsValid() const;
+        std::string GetInvalidReason() const;
 
         friend bool operator==(const CSubNet& a, const CSubNet& b);
         friend bool operator!=(const CSubNet& a, const CSubNet& b);

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -543,7 +543,7 @@ void StartRPCThreads()
             if(!subnet.IsValid())
             {
                 uiInterface.ThreadSafeMessageBox(
-                    strprintf("Invalid -rpcallowip subnet specification: %s. Valid are a single IP (e.g. 1.2.3.4), a network/netmask (e.g. 1.2.3.4/255.255.255.0) or a network/CIDR (e.g. 1.2.3.4/24).", strAllow),
+                    strprintf("Invalid -rpcallowip option: %s. Reason: %s.", strAllow, subnet.GetInvalidReason().c_str()),
                     "", CClientUIInterface::MSG_ERROR);
                 StartShutdown();
                 return;

--- a/src/test/netbase_tests.cpp
+++ b/src/test/netbase_tests.cpp
@@ -116,6 +116,13 @@ BOOST_AUTO_TEST_CASE(subnet_test)
     BOOST_CHECK(CSubNet("1:2:3:4:5:6:7:8").Match(CNetAddr("1:2:3:4:5:6:7:8")));
     BOOST_CHECK(!CSubNet("1:2:3:4:5:6:7:8").Match(CNetAddr("1:2:3:4:5:6:7:9")));
     BOOST_CHECK(CSubNet("1:2:3:4:5:6:7:0/112").Match(CNetAddr("1:2:3:4:5:6:7:1234")));
+    // Check wildcards
+    BOOST_CHECK(CSubNet("*").Match(CNetAddr("1:2:3:4:5:6:7:8")));
+    BOOST_CHECK(CSubNet("*").Match(CNetAddr("1.2.3.4")));
+    BOOST_CHECK(CSubNet("192.*").Match(CNetAddr("192.168.1.1")));
+    BOOST_CHECK(!CSubNet("192.*").Match(CNetAddr("193.168.1.1")));
+    BOOST_CHECK(!CSubNet("192.*").Match(CNetAddr("192:2:3:4:5:6:7:8")));
+    BOOST_CHECK(!CSubNet("2001:*").Match(CNetAddr("2002:2:3:4:5:6:7:8")));
     // All-Matching IPv6 Matches arbitrary IPv4 and IPv6
     BOOST_CHECK(CSubNet("::/0").Match(CNetAddr("1:2:3:4:5:6:7:1234")));
     BOOST_CHECK(CSubNet("::/0").Match(CNetAddr("1.2.3.4")));

--- a/src/test/netbase_tests.cpp
+++ b/src/test/netbase_tests.cpp
@@ -117,6 +117,9 @@ BOOST_AUTO_TEST_CASE(subnet_test)
     BOOST_CHECK(!CSubNet("1:2:3:4:5:6:7:8").Match(CNetAddr("1:2:3:4:5:6:7:9")));
     BOOST_CHECK(CSubNet("1:2:3:4:5:6:7:0/112").Match(CNetAddr("1:2:3:4:5:6:7:1234")));
     // Check wildcards
+    BOOST_CHECK(CSubNet("*") == CSubNet("::/0"));
+    BOOST_CHECK(CSubNet("2001:*") == CSubNet("2001::/16"));
+    BOOST_CHECK(CSubNet("192.*") == CSubNet("192.0.0.0/8"));
     BOOST_CHECK(CSubNet("*").Match(CNetAddr("1:2:3:4:5:6:7:8")));
     BOOST_CHECK(CSubNet("*").Match(CNetAddr("1.2.3.4")));
     BOOST_CHECK(CSubNet("192.*").Match(CNetAddr("192.168.1.1")));


### PR DESCRIPTION
This patch allows you to use `*` with `-rpcallowip`

Internally , it converts a filter with wildcards to the internal ip address + netmask form. i.e. `192.168.*` becomes `192.168.0.0/16`

That means that this doesn't allow all uses of wildcards, but it's good enough 90% of the time.

It also improves the error message seen when parsing the subnet fails.

See also #4894.
