### PR TITLE
Reset node

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -95,7 +95,8 @@ CCriticalSection cs_setservAddNodeAddresses;
 vector<std::string> vAddedNodes;
 CCriticalSection cs_vAddedNodes;
 
-NodeId nLastNodeId = 100;
+#define START_NODEID 100
+NodeId nLastNodeId = START_NODEID;
 CCriticalSection cs_nLastNodeId;
 
 static CSemaphore *semOutbound = NULL;
@@ -839,6 +840,10 @@ void ThreadSocketHandler()
         if(vNodes.size() != nPrevNodeCount) {
             nPrevNodeCount = vNodes.size();
             uiInterface.NotifyNumConnectionsChanged(nPrevNodeCount);
+            if (!vNodes.size()) {
+                LogPrint("net", "NO PEERS CONNECTED. Resetting NodeId\n");
+                nLastNodeId = START_NODEID;
+            }
         }
 
         //

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -95,7 +95,7 @@ CCriticalSection cs_setservAddNodeAddresses;
 vector<std::string> vAddedNodes;
 CCriticalSection cs_vAddedNodes;
 
-NodeId nLastNodeId = 0;
+NodeId nLastNodeId = 100;
 CCriticalSection cs_nLastNodeId;
 
 static CSemaphore *semOutbound = NULL;


### PR DESCRIPTION
When all connections are lost, we may as well reset the nodeid for logging and operational purposes, to avoid it getting excessively large. Also, start at 100 (makes searching the logs easier).
