### PR TITLE
Get rid of stored merkle branches

### DIFF
--- a/src/core.h
+++ b/src/core.h
@@ -487,9 +487,6 @@ public:
     // network and disk
     std::vector<CTransaction> vtx;
 
-    // memory only
-    mutable std::vector<uint256> vMerkleTree;
-
     CBlock()
     {
         SetNull();
@@ -513,7 +510,6 @@ public:
     {
         CBlockHeader::SetNull();
         vtx.clear();
-        vMerkleTree.clear();
     }
 
     CBlockHeader GetBlockHeader() const
@@ -530,8 +526,6 @@ public:
 
     uint256 BuildMerkleTree() const;
 
-    std::vector<uint256> GetMerkleBranch(int nIndex) const;
-    static uint256 CheckMerkleBranch(uint256 hash, const std::vector<uint256>& vMerkleBranch, int nIndex);
     std::string ToString() const;
 };
 

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -592,9 +592,8 @@ bool CWallet::AddToWallet(const CWalletTx& wtxIn, bool fFromLoadWallet)
                 wtx.hashBlock = wtxIn.hashBlock;
                 fUpdated = true;
             }
-            if (wtxIn.nIndex != -1 && (wtxIn.vMerkleBranch != wtx.vMerkleBranch || wtxIn.nIndex != wtx.nIndex))
+            if (wtxIn.nIndex != -1 && wtxIn.nIndex != wtx.nIndex)
             {
-                wtx.vMerkleBranch = wtxIn.vMerkleBranch;
                 wtx.nIndex = wtxIn.nIndex;
                 fUpdated = true;
             }
@@ -2249,9 +2248,6 @@ int CMerkleTx::SetMerkleBranch(const CBlock& block)
         return 0;
     }
 
-    // Fill in merkle branch
-    vMerkleBranch = block.GetMerkleBranch(nIndex);
-
     // Is the tx in a block that's in the main chain
     BlockMap::iterator mi = mapBlockIndex.find(hashBlock);
     if (mi == mapBlockIndex.end())
@@ -2276,14 +2272,6 @@ int CMerkleTx::GetDepthInMainChainINTERNAL(CBlockIndex* &pindexRet) const
     CBlockIndex* pindex = (*mi).second;
     if (!pindex || !chainActive.Contains(pindex))
         return 0;
-
-    // Make sure the merkle branch connects to this block
-    if (!fMerkleVerified)
-    {
-        if (CBlock::CheckMerkleBranch(GetHash(), vMerkleBranch, nIndex) != pindex->hashMerkleRoot)
-            return 0;
-        fMerkleVerified = true;
-    }
 
     pindexRet = pindex;
     return chainActive.Height() - pindex->nHeight + 1;

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -469,12 +469,7 @@ private:
 
 public:
     uint256 hashBlock;
-    std::vector<uint256> vMerkleBranch;
     int nIndex;
-
-    // memory only
-    mutable bool fMerkleVerified;
-
 
     CMerkleTx()
     {
@@ -490,7 +485,6 @@ public:
     {
         hashBlock = 0;
         nIndex = -1;
-        fMerkleVerified = false;
     }
 
     ADD_SERIALIZE_METHODS;
@@ -500,7 +494,11 @@ public:
         READWRITE(*(CTransaction*)this);
         nVersion = this->nVersion;
         READWRITE(hashBlock);
-        READWRITE(vMerkleBranch);
+        {
+            // Ignore merkle branch.
+            std::vector<uint256> vMerkleBranch;
+            READWRITE(vMerkleBranch);
+        }
         READWRITE(nIndex);
     }
 


### PR DESCRIPTION
Do not store merkle branches inside the wallet. This means removing the check that someone might have inserted an unconfirmed transaction in your wallet and making it look like a confirmed one.

This means we don't need to keep the merkle branch in wallets (which takes up to half a kilobyte per transactions), we don't need to validate it (which requires a dozen sha256 operation per wallet transaction), remove the need to keep the merkle tree in blocks (the case where it's needed is done separately in CPartialMerkleTree), and simplifies the merkle root computation.

This may be controversial, as it weakens the security assumption slightly, but simplifies the code.
