### PR TITLE
remove include of chainparams.h

### DIFF
--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -8,7 +8,6 @@
 #include "rpcprotocol.h"
 #include "util.h"
 #include "ui_interface.h"
-#include "chainparams.h" // for Params().RPCPort()
 
 #include <set>
 #include <stdint.h>


### PR DESCRIPTION
chainparams.h has not been used in this cpp file already, consider to remove it for clean.
