### PR TITLE
Relay alerts prior to MIN_PEER_PROTO_VERSION disconnect

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3260,6 +3260,12 @@ string GetWarnings(string strFor)
     return "error";
 }
 
+void static RelayAlerts(CNode* pfrom)
+{
+    LOCK(cs_mapAlerts);
+    BOOST_FOREACH(PAIRTYPE(const uint256, CAlert)& item, mapAlerts)
+        item.second.RelayTo(pfrom);
+}
 
 
 
@@ -3458,6 +3464,8 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         vRecv >> pfrom->nVersion >> pfrom->nServices >> nTime >> addrMe;
         if (pfrom->nVersion < MIN_PEER_PROTO_VERSION)
         {
+           // relay alerts prior to disconnection
+            RelayAlerts(pfrom);
             // disconnect from peers older than this proto version
             LogPrintf("peer=%d using obsolete version %i; disconnecting\n", pfrom->id, pfrom->nVersion);
             pfrom->PushMessage("reject", strCommand, REJECT_OBSOLETE,
@@ -3532,11 +3540,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         }
 
         // Relay alerts
-        {
-            LOCK(cs_mapAlerts);
-            BOOST_FOREACH(PAIRTYPE(const uint256, CAlert)& item, mapAlerts)
-                item.second.RelayTo(pfrom);
-        }
+        RelayAlerts(pfrom);
 
         pfrom->fSuccessfullyConnected = true;
 


### PR DESCRIPTION
Otherwise the old client may fail to receive an alert saying they need to upgrade.
