### PR TITLE
Script destinations break-out

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -99,6 +99,7 @@ BITCOIN_CORE_H = \
   rpcprotocol.h \
   rpcserver.h \
   script/compressor.h \
+  script/destination.h \
   script/interpreter.h \
   script/script.h \
   script/sign.h \
@@ -213,6 +214,7 @@ libbitcoin_common_a_SOURCES = \
   netbase.cpp \
   protocol.cpp \
   script/compressor.cpp \
+  script/destination.cpp \
   script/interpreter.cpp \
   script/script.cpp \
   script/sign.cpp \

--- a/src/base58.h
+++ b/src/base58.h
@@ -16,7 +16,7 @@
 
 #include "chainparams.h"
 #include "key.h"
-#include "script/script.h"
+#include "script/destination.h"
 
 #include <string>
 #include <vector>

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -224,9 +224,9 @@ static void MutateTxAddOutAddr(CMutableTransaction& tx, const string& strInput)
     if (!addr.IsValid())
         throw runtime_error("invalid TX output address");
 
-    // build standard output script via SetDestination()
+    // build standard output script via SetScriptDestination()
     CScript scriptPubKey;
-    scriptPubKey.SetDestination(addr.Get());
+    SetScriptDestination(scriptPubKey, addr.Get());
 
     // construct TxOut, append to transaction output list
     CTxOut txout(value, scriptPubKey);

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -222,7 +222,7 @@ QString formatBitcoinURI(const SendCoinsRecipient &info)
 bool isDust(const QString& address, qint64 amount)
 {
     CTxDestination dest = CBitcoinAddress(address.toStdString()).Get();
-    CScript script; script.SetDestination(dest);
+    CScript script; SetScriptDestination(script, dest);
     CTxOut txOut(amount, script);
     return txOut.IsDust(::minRelayTxFee);
 }

--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -609,7 +609,7 @@ void PaymentServer::fetchPaymentACK(CWallet* wallet, SendCoinsRecipient recipien
     std::string strAccount = account.toStdString();
     set<CTxDestination> refundAddresses = wallet->GetAccountAddresses(strAccount);
     if (!refundAddresses.empty()) {
-        CScript s; s.SetDestination(*refundAddresses.begin());
+        CScript s; SetScriptDestination(s, *refundAddresses.begin());
         payments::Output* refund_to = payment.add_refund_to();
         refund_to->set_script(&s[0], s.size());
     }
@@ -620,7 +620,7 @@ void PaymentServer::fetchPaymentACK(CWallet* wallet, SendCoinsRecipient recipien
             CKeyID keyID = newKey.GetID();
             wallet->SetAddressBook(keyID, strAccount, "refund");
 
-            CScript s; s.SetDestination(keyID);
+            CScript s; SetScriptDestination(s, keyID);
             payments::Output* refund_to = payment.add_refund_to();
             refund_to->set_script(&s[0], s.size());
         }

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -242,7 +242,7 @@ WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransact
             ++nAddresses;
 
             CScript scriptPubKey;
-            scriptPubKey.SetDestination(CBitcoinAddress(rcp.address.toStdString()).Get());
+            SetScriptDestination(scriptPubKey, CBitcoinAddress(rcp.address.toStdString()).Get());
             vecSend.push_back(std::pair<CScript, int64_t>(scriptPubKey, rcp.amount));
 
             total += rcp.amount;

--- a/src/rpcdump.cpp
+++ b/src/rpcdump.cpp
@@ -161,7 +161,7 @@ Value importaddress(const Array& params, bool fHelp)
 
     CBitcoinAddress address(params[0].get_str());
     if (address.IsValid()) {
-        script.SetDestination(address.Get());
+        SetScriptDestination(script, address.Get());
     } else if (IsHex(params[0].get_str())) {
         std::vector<unsigned char> data(ParseHex(params[0].get_str()));
         script = CScript(data.begin(), data.end());

--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -367,7 +367,7 @@ Value createrawtransaction(const Array& params, bool fHelp)
         setAddress.insert(address);
 
         CScript scriptPubKey;
-        scriptPubKey.SetDestination(address.Get());
+        SetScriptDestination(scriptPubKey, address.Get());
         int64_t nAmount = AmountFromValue(s.value_);
 
         CTxOut out(nAmount, scriptPubKey);

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -125,7 +125,7 @@ CBitcoinAddress GetAccountAddress(string strAccount, bool bForceNew=false)
     if (account.vchPubKey.IsValid())
     {
         CScript scriptPubKey;
-        scriptPubKey.SetDestination(account.vchPubKey.GetID());
+        SetScriptDestination(scriptPubKey, account.vchPubKey.GetID());
         for (map<uint256, CWalletTx>::iterator it = pwalletMain->mapWallet.begin();
              it != pwalletMain->mapWallet.end() && account.vchPubKey.IsValid();
              ++it)
@@ -475,7 +475,7 @@ Value getreceivedbyaddress(const Array& params, bool fHelp)
     CScript scriptPubKey;
     if (!address.IsValid())
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid Bitcoin address");
-    scriptPubKey.SetDestination(address.Get());
+    SetScriptDestination(scriptPubKey, address.Get());
     if (!IsMine(*pwalletMain,scriptPubKey))
         return (double)0.0;
 
@@ -850,7 +850,7 @@ Value sendmany(const Array& params, bool fHelp)
         setAddress.insert(address);
 
         CScript scriptPubKey;
-        scriptPubKey.SetDestination(address.Get());
+        SetScriptDestination(scriptPubKey, address.Get());
         int64_t nAmount = AmountFromValue(s.value_);
         totalAmount += nAmount;
 

--- a/src/script/destination.cpp
+++ b/src/script/destination.cpp
@@ -1,0 +1,47 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2014 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "script/destination.h"
+
+#include "script/script.h"
+#include "key.h"
+
+bool ScriptDestinationVisitor::operator()(const CNoDestination &dest) const
+{
+    SetScriptDestination(m_script, dest);
+    return false;
+}
+
+bool ScriptDestinationVisitor::operator()(const CKeyID &keyID) const
+{
+    SetScriptDestination(m_script, keyID);
+    return true;
+}
+
+bool ScriptDestinationVisitor::operator()(const CScriptID &scriptID) const
+{
+    SetScriptDestination(m_script, scriptID);
+    return true;
+}
+
+void SetScriptDestination(CScript& script, const CNoDestination& dest)
+{
+    script.SetDestinationNone();
+}
+
+void SetScriptDestination(CScript& script, const CKeyID& keyID)
+{
+    script.SetDestinationKeyID(keyID);
+}
+
+void SetScriptDestination(CScript& script, const CScriptID& scriptID)
+{
+    script.SetDestinationScriptID(scriptID);
+}
+
+bool SetScriptDestination(CScript& script, const CTxDestination& dest)
+{
+    return boost::apply_visitor(ScriptDestinationVisitor(script), dest);
+}

--- a/src/script/destination.cpp
+++ b/src/script/destination.cpp
@@ -33,12 +33,14 @@ void SetScriptDestination(CScript& script, const CNoDestination& dest)
 
 void SetScriptDestination(CScript& script, const CKeyID& keyID)
 {
-    script.SetDestinationKeyID(keyID);
+    std::vector<unsigned char> vch(keyID.begin(), keyID.end());
+    script.SetDestinationKeyID(vch);
 }
 
 void SetScriptDestination(CScript& script, const CScriptID& scriptID)
 {
-    script.SetDestinationScriptID(scriptID);
+    std::vector<unsigned char> vch(scriptID.begin(), scriptID.end());
+    script.SetDestinationScriptID(vch);
 }
 
 bool SetScriptDestination(CScript& script, const CTxDestination& dest)

--- a/src/script/destination.h
+++ b/src/script/destination.h
@@ -1,0 +1,37 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2014 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef H_BITCOIN_SCRIPT_DESTINATION
+#define H_BITCOIN_SCRIPT_DESTINATION
+#include "key.h"
+#include <boost/variant.hpp>
+
+class CScript;
+
+class CNoDestination {
+public:
+    friend bool operator==(const CNoDestination &a, const CNoDestination &b) { return true; }
+    friend bool operator<(const CNoDestination &a, const CNoDestination &b) { return true; }
+};
+
+class ScriptDestinationVisitor : public boost::static_visitor<bool>
+{
+private:
+    CScript& m_script;
+public:
+    ScriptDestinationVisitor(CScript& script) : m_script(script) {}
+    bool operator()(const CNoDestination &dest) const;
+    bool operator()(const CKeyID &keyID) const;
+    bool operator()(const CScriptID &scriptID) const;
+};
+
+typedef boost::variant<CNoDestination, CKeyID, CScriptID> CTxDestination;
+
+
+bool SetScriptDestination(CScript& script, const CTxDestination& dest);
+void SetScriptDestination(CScript& script, const CKeyID& keyID);
+void SetScriptDestination(CScript& script, const CScriptID& scriptID);
+void SetScriptDestination(CScript& script, const CNoDestination& dest);
+#endif

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -259,16 +259,22 @@ void CScript::SetDestinationNone()
     clear();
 }
 
-void CScript::SetDestinationKeyID(const CKeyID& keyID)
+void CScript::SetDestinationKeyID(const std::vector<unsigned char>& keyID)
 {
     clear();
-    *this << OP_DUP << OP_HASH160 << keyID << OP_EQUALVERIFY << OP_CHECKSIG;
+    *this << OP_DUP << OP_HASH160;
+    insert(end(), keyID.size());
+    insert(end(), keyID.begin(), keyID.end());
+    *this << OP_EQUALVERIFY << OP_CHECKSIG;
 }
 
-void CScript::SetDestinationScriptID(const CScriptID& scriptID)
+void CScript::SetDestinationScriptID(const std::vector<unsigned char>& scriptID)
 {
     clear();
-    *this << OP_HASH160 << scriptID << OP_EQUAL;
+    *this << OP_HASH160;
+    insert(end(), scriptID.size());
+    insert(end(), scriptID.begin(), scriptID.end());
+    *this << OP_EQUAL;
 }
 
 void CScript::SetMultisig(int nRequired, const std::vector<CPubKey>& keys)

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -254,34 +254,21 @@ bool CScript::HasCanonicalPushes() const
     return true;
 }
 
-class CScriptVisitor : public boost::static_visitor<bool>
+void CScript::SetDestinationNone()
 {
-private:
-    CScript *script;
-public:
-    CScriptVisitor(CScript *scriptin) { script = scriptin; }
+    clear();
+}
 
-    bool operator()(const CNoDestination &dest) const {
-        script->clear();
-        return false;
-    }
-
-    bool operator()(const CKeyID &keyID) const {
-        script->clear();
-        *script << OP_DUP << OP_HASH160 << keyID << OP_EQUALVERIFY << OP_CHECKSIG;
-        return true;
-    }
-
-    bool operator()(const CScriptID &scriptID) const {
-        script->clear();
-        *script << OP_HASH160 << scriptID << OP_EQUAL;
-        return true;
-    }
-};
-
-void CScript::SetDestination(const CTxDestination& dest)
+void CScript::SetDestinationKeyID(const CKeyID& keyID)
 {
-    boost::apply_visitor(CScriptVisitor(this), dest);
+    clear();
+    *this << OP_DUP << OP_HASH160 << keyID << OP_EQUALVERIFY << OP_CHECKSIG;
+}
+
+void CScript::SetDestinationScriptID(const CScriptID& scriptID)
+{
+    clear();
+    *this << OP_HASH160 << scriptID << OP_EQUAL;
 }
 
 void CScript::SetMultisig(int nRequired, const std::vector<CPubKey>& keys)

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -597,8 +597,8 @@ public:
     }
 
     void SetDestinationNone();
-    void SetDestinationKeyID(const CKeyID& keyID);
-    void SetDestinationScriptID(const CScriptID& scriptID);
+    void SetDestinationKeyID(const std::vector<unsigned char>& keyID);
+    void SetDestinationScriptID(const std::vector<unsigned char>& ScriptID);
 
     void SetMultisig(int nRequired, const std::vector<CPubKey>& keys);
 

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -12,10 +12,9 @@
 
 #include <stdexcept>
 
-#include <boost/variant.hpp>
-
 static const unsigned int MAX_SCRIPT_ELEMENT_SIZE = 520; // bytes
 
+class CNoDestination;
 /** Script opcodes */
 enum opcodetype
 {
@@ -320,19 +319,12 @@ inline std::string ValueString(const std::vector<unsigned char>& vch)
         return HexStr(vch);
 }
 
-class CNoDestination {
-public:
-    friend bool operator==(const CNoDestination &a, const CNoDestination &b) { return true; }
-    friend bool operator<(const CNoDestination &a, const CNoDestination &b) { return true; }
-};
-
 /** A txout script template with a specific destination. It is either:
  *  * CNoDestination: no destination set
  *  * CKeyID: TX_PUBKEYHASH destination
  *  * CScriptID: TX_SCRIPTHASH destination
  *  A CTxDestination is the internal data type encoded in a CBitcoinAddress
  */
-typedef boost::variant<CNoDestination, CKeyID, CScriptID> CTxDestination;
 
 /** Serialized script, used inside transaction inputs and outputs */
 class CScript : public std::vector<unsigned char>
@@ -604,7 +596,10 @@ public:
         return (size() > 0 && *begin() == OP_RETURN);
     }
 
-    void SetDestination(const CTxDestination& address);
+    void SetDestinationNone();
+    void SetDestinationKeyID(const CKeyID& keyID);
+    void SetDestinationScriptID(const CScriptID& scriptID);
+
     void SetMultisig(int nRequired, const std::vector<CPubKey>& keys);
 
     std::string ToString() const

--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -6,7 +6,7 @@
 #ifndef H_BITCOIN_SCRIPT_STANDARD
 #define H_BITCOIN_SCRIPT_STANDARD
 
-#include "script/script.h"
+#include "script/destination.h"
 #include "script/interpreter.h"
 
 #include <stdint.h>

--- a/src/test/DoS_tests.cpp
+++ b/src/test/DoS_tests.cpp
@@ -173,8 +173,8 @@ BOOST_AUTO_TEST_CASE(DoS_mapOrphans)
         tx.vin[0].scriptSig << OP_1;
         tx.vout.resize(1);
         tx.vout[0].nValue = 1*CENT;
-        tx.vout[0].scriptPubKey.SetDestination(key.GetPubKey().GetID());
 
+        SetScriptDestination(tx.vout[0].scriptPubKey, key.GetPubKey().GetID());
         AddOrphanTx(tx, i);
     }
 
@@ -189,7 +189,7 @@ BOOST_AUTO_TEST_CASE(DoS_mapOrphans)
         tx.vin[0].prevout.hash = txPrev.GetHash();
         tx.vout.resize(1);
         tx.vout[0].nValue = 1*CENT;
-        tx.vout[0].scriptPubKey.SetDestination(key.GetPubKey().GetID());
+        SetScriptDestination(tx.vout[0].scriptPubKey,key.GetPubKey().GetID());
         SignSignature(keystore, txPrev, tx, 0);
 
         AddOrphanTx(tx, i);
@@ -203,7 +203,7 @@ BOOST_AUTO_TEST_CASE(DoS_mapOrphans)
         CMutableTransaction tx;
         tx.vout.resize(1);
         tx.vout[0].nValue = 1*CENT;
-        tx.vout[0].scriptPubKey.SetDestination(key.GetPubKey().GetID());
+        SetScriptDestination(tx.vout[0].scriptPubKey,key.GetPubKey().GetID());
         tx.vin.resize(500);
         for (unsigned int j = 0; j < tx.vin.size(); j++)
         {

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -170,7 +170,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     tx.vin[0].scriptSig = CScript() << OP_1;
     tx.vout[0].nValue = 4900000000LL;
     script = CScript() << OP_0;
-    tx.vout[0].scriptPubKey.SetDestination(script.GetID());
+    SetScriptDestination(tx.vout[0].scriptPubKey,script.GetID());
     hash = tx.GetHash();
     mempool.addUnchecked(hash, CTxMemPoolEntry(tx, 11, GetTime(), 111.0, 11));
     tx.vin[0].prevout.hash = hash;

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -280,7 +280,7 @@ BOOST_AUTO_TEST_CASE(script_combineSigs)
 
     CMutableTransaction txFrom;
     txFrom.vout.resize(1);
-    txFrom.vout[0].scriptPubKey.SetDestination(keys[0].GetPubKey().GetID());
+    SetScriptDestination(txFrom.vout[0].scriptPubKey, keys[0].GetPubKey().GetID());
     CScript& scriptPubKey = txFrom.vout[0].scriptPubKey;
     CMutableTransaction txTo;
     txTo.vin.resize(1);
@@ -309,7 +309,7 @@ BOOST_AUTO_TEST_CASE(script_combineSigs)
     // P2SH, single-signature case:
     CScript pkSingle; pkSingle << keys[0].GetPubKey() << OP_CHECKSIG;
     keystore.AddCScript(pkSingle);
-    scriptPubKey.SetDestination(pkSingle.GetID());
+    SetScriptDestination(scriptPubKey, pkSingle.GetID());
     SignSignature(keystore, txFrom, txTo, 0);
     combined = CombineSignatures(scriptPubKey, txTo, 0, scriptSig, empty);
     BOOST_CHECK(combined == scriptSig);

--- a/src/test/sigopcount_tests.cpp
+++ b/src/test/sigopcount_tests.cpp
@@ -4,6 +4,7 @@
 
 #include "key.h"
 #include "script/script.h"
+#include "script/destination.h"
 #include "uint256.h"
 
 #include <vector>
@@ -38,7 +39,7 @@ BOOST_AUTO_TEST_CASE(GetSigOpCount)
     BOOST_CHECK_EQUAL(s1.GetSigOpCount(false), 21U);
 
     CScript p2sh;
-    p2sh.SetDestination(s1.GetID());
+    SetScriptDestination(p2sh,s1.GetID());
     CScript scriptSig;
     scriptSig << OP_0 << Serialize(s1);
     BOOST_CHECK_EQUAL(p2sh.GetSigOpCount(scriptSig), 3U);
@@ -55,7 +56,7 @@ BOOST_AUTO_TEST_CASE(GetSigOpCount)
     BOOST_CHECK_EQUAL(s2.GetSigOpCount(true), 3U);
     BOOST_CHECK_EQUAL(s2.GetSigOpCount(false), 20U);
 
-    p2sh.SetDestination(s2.GetID());
+    SetScriptDestination(p2sh,s2.GetID());
     BOOST_CHECK_EQUAL(p2sh.GetSigOpCount(true), 0U);
     BOOST_CHECK_EQUAL(p2sh.GetSigOpCount(false), 0U);
     CScript scriptSig2;

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -248,9 +248,9 @@ SetupDummyInputs(CBasicKeyStore& keystoreRet, CCoinsView & coinsRet)
 
     dummyTransactions[1].vout.resize(2);
     dummyTransactions[1].vout[0].nValue = 21*CENT;
-    dummyTransactions[1].vout[0].scriptPubKey.SetDestination(key[2].GetPubKey().GetID());
+    SetScriptDestination(dummyTransactions[1].vout[0].scriptPubKey, key[2].GetPubKey().GetID());
     dummyTransactions[1].vout[1].nValue = 22*CENT;
-    dummyTransactions[1].vout[1].scriptPubKey.SetDestination(key[3].GetPubKey().GetID());
+    SetScriptDestination(dummyTransactions[1].vout[1].scriptPubKey, key[3].GetPubKey().GetID());
     coinsRet.SetCoins(dummyTransactions[1].GetHash(), CCoins(dummyTransactions[1], 0));
 
     return dummyTransactions;
@@ -307,7 +307,7 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
     t.vout[0].nValue = 90*CENT;
     CKey key;
     key.MakeNewKey(true);
-    t.vout[0].scriptPubKey.SetDestination(key.GetPubKey().GetID());
+    SetScriptDestination(t.vout[0].scriptPubKey, key.GetPubKey().GetID());
 
     string reason;
     BOOST_CHECK(IsStandardTx(t, reason));

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1385,7 +1385,7 @@ bool CWallet::CreateTransaction(const vector<pair<CScript, int64_t> >& vecSend,
 
                     // coin control: send change to custom address
                     if (coinControl && !boost::get<CNoDestination>(&coinControl->destChange))
-                        scriptChange.SetDestination(coinControl->destChange);
+                        SetScriptDestination(scriptChange, coinControl->destChange);
 
                     // no coin control: send change to newly generated address
                     else
@@ -1403,7 +1403,7 @@ bool CWallet::CreateTransaction(const vector<pair<CScript, int64_t> >& vecSend,
                         ret = reservekey.GetReservedKey(vchPubKey);
                         assert(ret); // should never fail, as we just unlocked
 
-                        scriptChange.SetDestination(vchPubKey.GetID());
+                        SetScriptDestination(scriptChange,vchPubKey.GetID());
                     }
 
                     CTxOut newTxOut(nChange, scriptChange);
@@ -1557,7 +1557,7 @@ string CWallet::SendMoney(const CTxDestination &address, int64_t nValue, CWallet
 
     // Parse Bitcoin address
     CScript scriptPubKey;
-    scriptPubKey.SetDestination(address);
+    SetScriptDestination(scriptPubKey, address);
 
     // Create and send the transaction
     CReserveKey reservekey(this);

--- a/src/wallet_ismine.cpp
+++ b/src/wallet_ismine.cpp
@@ -7,6 +7,7 @@
 
 #include "key.h"
 #include "keystore.h"
+#include "script/script.h"
 #include "script/standard.h"
 
 #include <boost/foreach.hpp>
@@ -30,7 +31,7 @@ unsigned int HaveKeys(const vector<valtype>& pubkeys, const CKeyStore& keystore)
 isminetype IsMine(const CKeyStore &keystore, const CTxDestination& dest)
 {
     CScript script;
-    script.SetDestination(dest);
+    SetScriptDestination(script, dest);
     return IsMine(keystore, script);
 }
 

--- a/src/wallet_ismine.h
+++ b/src/wallet_ismine.h
@@ -7,7 +7,7 @@
 #define H_BITCOIN_WALLET_ISMINE
 
 #include "key.h"
-#include "script/script.h"
+#include "script/destination.h"
 
 class CKeyStore;
 


### PR DESCRIPTION
More work on reducing script dependencies. I'm not sure if this is wanted yet, if not I'm fine with holding off.

This allows CScript to work without knowledge of CTxDestination. Most of the dependencies on key.h are dropped, and a boost dependency is dropped as well. Next obvious steps would be to do the same for CPubKey, move SetMultisig() out, etc. This seemed like a good stopping point before continuing with those.
