### PR TITLE
[Wallet] Simplify SetMerkleBranch(..) to SetHashBlock(..)

### DIFF
--- a/src/core.cpp
+++ b/src/core.cpp
@@ -226,52 +226,19 @@ uint256 CBlockHeader::GetHash() const
 
 uint256 CBlock::BuildMerkleTree() const
 {
-    vMerkleTree.clear();
-    BOOST_FOREACH(const CTransaction& tx, vtx)
+    std::vector<uint256> vMerkleTree;
+    vMerkleTree.reserve(vtx.size());
+    BOOST_FOREACH(const CTransaction& tx, vtx) {
         vMerkleTree.push_back(tx.GetHash());
-    int j = 0;
-    for (int nSize = vtx.size(); nSize > 1; nSize = (nSize + 1) / 2)
-    {
-        for (int i = 0; i < nSize; i += 2)
-        {
-            int i2 = std::min(i+1, nSize-1);
-            vMerkleTree.push_back(Hash(BEGIN(vMerkleTree[j+i]),  END(vMerkleTree[j+i]),
-                                       BEGIN(vMerkleTree[j+i2]), END(vMerkleTree[j+i2])));
+    }
+    for (int nSize = vtx.size(); nSize > 1; nSize = (nSize + 1) / 2) {
+        for (int i = 0; i < nSize; i += 2) {
+            int i2 = std::min(i + 1, nSize - 1);
+            vMerkleTree[i / 2] = Hash(BEGIN(vMerkleTree[i]),  END(vMerkleTree[i]),
+                                      BEGIN(vMerkleTree[i2]), END(vMerkleTree[i2]));
         }
-        j += nSize;
     }
-    return (vMerkleTree.empty() ? 0 : vMerkleTree.back());
-}
-
-std::vector<uint256> CBlock::GetMerkleBranch(int nIndex) const
-{
-    if (vMerkleTree.empty())
-        BuildMerkleTree();
-    std::vector<uint256> vMerkleBranch;
-    int j = 0;
-    for (int nSize = vtx.size(); nSize > 1; nSize = (nSize + 1) / 2)
-    {
-        int i = std::min(nIndex^1, nSize-1);
-        vMerkleBranch.push_back(vMerkleTree[j+i]);
-        nIndex >>= 1;
-        j += nSize;
-    }
-    return vMerkleBranch;
-}
-
-uint256 CBlock::CheckMerkleBranch(uint256 hash, const std::vector<uint256>& vMerkleBranch, int nIndex)
-{
-    if (nIndex == -1)
-        return 0;
-    BOOST_FOREACH(const uint256& otherside, vMerkleBranch)
-    {
-        if (nIndex & 1)
-            hash = Hash(BEGIN(otherside), END(otherside), BEGIN(hash), END(hash));
-        else
-            hash = Hash(BEGIN(hash), END(hash), BEGIN(otherside), END(otherside));
-        nIndex >>= 1;
-    }
-    return hash;
+    return (vMerkleTree.empty() ? 0 : vMerkleTree.front());
 }
 
 std::string CBlock::ToString() const
@@ -288,9 +255,6 @@ std::string CBlock::ToString() const
     {
         s << "  " << vtx[i].ToString() << "\n";
     }
-    s << "  vMerkleTree: ";
-    for (unsigned int i = 0; i < vMerkleTree.size(); i++)
-        s << " " << vMerkleTree[i].ToString();
     s << "\n";
     return s.str();
 }

--- a/src/core.h
+++ b/src/core.h
@@ -487,9 +487,6 @@ public:
     // network and disk
     std::vector<CTransaction> vtx;
 
-    // memory only
-    mutable std::vector<uint256> vMerkleTree;
-
     CBlock()
     {
         SetNull();
@@ -513,7 +510,6 @@ public:
     {
         CBlockHeader::SetNull();
         vtx.clear();
-        vMerkleTree.clear();
     }
 
     CBlockHeader GetBlockHeader() const
@@ -530,8 +526,6 @@ public:
 
     uint256 BuildMerkleTree() const;
 
-    std::vector<uint256> GetMerkleBranch(int nIndex) const;
-    static uint256 CheckMerkleBranch(uint256 hash, const std::vector<uint256>& vMerkleBranch, int nIndex);
     std::string ToString() const;
 };
 

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -643,9 +643,9 @@ bool CWallet::AddToWalletIfInvolvingMe(const CTransaction& tx, const CBlock* pbl
         if (fExisted || IsMine(tx) || IsFromMe(tx))
         {
             CWalletTx wtx(this,tx);
-            // Get merkle branch if transaction was found in a block
+
             if (pblock)
-                wtx.SetMerkleBranch(pblock);
+                wtx.SetHashBlock(pblock);
             return AddToWallet(wtx);
         }
     }
@@ -2228,48 +2228,19 @@ CWalletKey::CWalletKey(int64_t nExpires)
     nTimeExpires = nExpires;
 }
 
-int CMerkleTx::SetMerkleBranch(const CBlock* pblock)
+void CMerkleTx::SetHashBlock(const CBlock* pblock)
 {
-    AssertLockHeld(cs_main);
-    CBlock blockTmp;
+    hashBlock = pblock->GetHash();
 
-    if (pblock == NULL) {
-        CCoins coins;
-        if (pcoinsTip->GetCoins(GetHash(), coins)) {
-            CBlockIndex *pindex = chainActive[coins.nHeight];
-            if (pindex) {
-                if (!ReadBlockFromDisk(blockTmp, pindex))
-                    return 0;
-                pblock = &blockTmp;
-            }
-        }
+    // Locate the transaction
+    for (nIndex = 0; nIndex < (int)pblock->vtx.size(); nIndex++)
+        if (pblock->vtx[nIndex] == *(CTransaction*)this)
+            break;
+    if (nIndex == (int)pblock->vtx.size())
+    {
+        nIndex = -1;
+        LogPrintf("ERROR: SetHashBlock() : couldn't find tx in block\n");
     }
-
-    if (pblock) {
-        // Update the tx's hashBlock
-        hashBlock = pblock->GetHash();
-
-        // Locate the transaction
-        for (nIndex = 0; nIndex < (int)pblock->vtx.size(); nIndex++)
-            if (pblock->vtx[nIndex] == *(CTransaction*)this)
-                break;
-        if (nIndex == (int)pblock->vtx.size())
-        {
-            nIndex = -1;
-            LogPrintf("ERROR: SetMerkleBranch() : couldn't find tx in block\n");
-            return 0;
-        }
-    }
-
-    // Is the tx in a block that's in the main chain
-    BlockMap::iterator mi = mapBlockIndex.find(hashBlock);
-    if (mi == mapBlockIndex.end())
-        return 0;
-    CBlockIndex* pindex = (*mi).second;
-    if (!pindex || !chainActive.Contains(pindex))
-        return 0;
-
-    return chainActive.Height() - pindex->nHeight + 1;
 }
 
 int CMerkleTx::GetDepthInMainChainINTERNAL(CBlockIndex* &pindexRet) const

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -592,9 +592,8 @@ bool CWallet::AddToWallet(const CWalletTx& wtxIn, bool fFromLoadWallet)
                 wtx.hashBlock = wtxIn.hashBlock;
                 fUpdated = true;
             }
-            if (wtxIn.nIndex != -1 && (wtxIn.vMerkleBranch != wtx.vMerkleBranch || wtxIn.nIndex != wtx.nIndex))
+            if (wtxIn.nIndex != -1 && wtxIn.nIndex != wtx.nIndex)
             {
-                wtx.vMerkleBranch = wtxIn.vMerkleBranch;
                 wtx.nIndex = wtxIn.nIndex;
                 fUpdated = true;
             }
@@ -2256,14 +2255,10 @@ int CMerkleTx::SetMerkleBranch(const CBlock* pblock)
                 break;
         if (nIndex == (int)pblock->vtx.size())
         {
-            vMerkleBranch.clear();
             nIndex = -1;
             LogPrintf("ERROR: SetMerkleBranch() : couldn't find tx in block\n");
             return 0;
         }
-
-        // Fill in merkle branch
-        vMerkleBranch = pblock->GetMerkleBranch(nIndex);
     }
 
     // Is the tx in a block that's in the main chain
@@ -2290,14 +2285,6 @@ int CMerkleTx::GetDepthInMainChainINTERNAL(CBlockIndex* &pindexRet) const
     CBlockIndex* pindex = (*mi).second;
     if (!pindex || !chainActive.Contains(pindex))
         return 0;
-
-    // Make sure the merkle branch connects to this block
-    if (!fMerkleVerified)
-    {
-        if (CBlock::CheckMerkleBranch(GetHash(), vMerkleBranch, nIndex) != pindex->hashMerkleRoot)
-            return 0;
-        fMerkleVerified = true;
-    }
 
     pindexRet = pindex;
     return chainActive.Height() - pindex->nHeight + 1;

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -469,12 +469,7 @@ private:
 
 public:
     uint256 hashBlock;
-    std::vector<uint256> vMerkleBranch;
     int nIndex;
-
-    // memory only
-    mutable bool fMerkleVerified;
-
 
     CMerkleTx()
     {
@@ -490,7 +485,6 @@ public:
     {
         hashBlock = 0;
         nIndex = -1;
-        fMerkleVerified = false;
     }
 
     ADD_SERIALIZE_METHODS;
@@ -500,7 +494,11 @@ public:
         READWRITE(*(CTransaction*)this);
         nVersion = this->nVersion;
         READWRITE(hashBlock);
-        READWRITE(vMerkleBranch);
+        {
+            // Ignore merkle branch.
+            std::vector<uint256> vMerkleBranch;
+            READWRITE(vMerkleBranch);
+        }
         READWRITE(nIndex);
     }
 

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -502,7 +502,7 @@ public:
         READWRITE(nIndex);
     }
 
-    int SetMerkleBranch(const CBlock* pblock=NULL);
+    void SetHashBlock(const CBlock* pblock);
 
     // Return depth of transaction in blockchain:
     // -1  : not in blockchain, and not in memory pool (conflicted transaction)


### PR DESCRIPTION
Builds on top of #4925

We do not need the return value of SetMerkleBranch(..) and we only call it with NON-NULL pointer.
The only thing thats left what we need is to set hashBlock.
