### PR TITLE
CMessageHeader sanity changes

### DIFF
--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -24,7 +24,6 @@ CMessageHeader::CMessageHeader()
 {
     memcpy(pchMessageStart, Params().MessageStart(), MESSAGE_START_SIZE);
     memset(pchCommand, 0, sizeof(pchCommand));
-    pchCommand[1] = 1;
     nMessageSize = -1;
     nChecksum = 0;
 }
@@ -32,6 +31,7 @@ CMessageHeader::CMessageHeader()
 CMessageHeader::CMessageHeader(const char* pszCommand, unsigned int nMessageSizeIn)
 {
     memcpy(pchMessageStart, Params().MessageStart(), MESSAGE_START_SIZE);
+    memset(pchCommand, 0, sizeof(pchCommand));
     strncpy(pchCommand, pszCommand, COMMAND_SIZE);
     nMessageSize = nMessageSizeIn;
     nChecksum = 0;
@@ -39,10 +39,7 @@ CMessageHeader::CMessageHeader(const char* pszCommand, unsigned int nMessageSize
 
 std::string CMessageHeader::GetCommand() const
 {
-    if (pchCommand[COMMAND_SIZE-1] == 0)
-        return std::string(pchCommand, pchCommand + strlen(pchCommand));
-    else
-        return std::string(pchCommand, pchCommand + COMMAND_SIZE);
+    return std::string(pchCommand, pchCommand + strnlen(pchCommand, COMMAND_SIZE));
 }
 
 bool CMessageHeader::IsValid() const


### PR DESCRIPTION
- Remove spurious `pchCommand[1] = 1` in CMessageHeader()
- Make sure that pchCommand is zero-padded if length is shorter than COMMAND_SIZE
- Use strnlen to determine length of pchCommand in GetCommand

I'm afraid that pulltester's old mingw will complain about lack of `strnlen`. This is not actually a problem with more recent compilers on windows: I verified that it works fine with gitian's version, and it should work with Travis.
