### PR TITLE
qt: Change splash screen to normal window

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -338,8 +338,7 @@ void BitcoinApplication::createWindow(bool isaTestNet)
 
 void BitcoinApplication::createSplashScreen(bool isaTestNet)
 {
-    SplashScreen *splash = new SplashScreen(QPixmap(), 0, isaTestNet);
-    splash->setAttribute(Qt::WA_DeleteOnClose);
+    SplashScreen *splash = new SplashScreen(0, isaTestNet);
     splash->show();
     connect(this, SIGNAL(splashFinished(QWidget*)), splash, SLOT(slotFinish(QWidget*)));
 }
@@ -423,8 +422,6 @@ void BitcoinApplication::initializeResult(int retval)
         }
 #endif
 
-        emit splashFinished(window);
-
         // If -min option passed, start window minimized.
         if(GetBoolArg("-min", false))
         {
@@ -434,6 +431,8 @@ void BitcoinApplication::initializeResult(int retval)
         {
             window->show();
         }
+        emit splashFinished(window);
+
 #ifdef ENABLE_WALLET
         // Now that initialization/startup is done, process any command-line
         // bitcoin: URIs or payment requests:

--- a/src/qt/splashscreen.h
+++ b/src/qt/splashscreen.h
@@ -9,23 +9,34 @@
 
 /** class for the splashscreen with information of the running client
  */
-class SplashScreen : public QSplashScreen
+class SplashScreen : public QWidget
 {
     Q_OBJECT
 
 public:
-    explicit SplashScreen(const QPixmap &pixmap, Qt::WindowFlags f, bool isTestNet);
+    explicit SplashScreen(Qt::WindowFlags f, bool isTestNet);
     ~SplashScreen();
+
+protected:
+     void paintEvent(QPaintEvent *event);
 
 public slots:
     /** Slot to call finish() method as it's not defined as slot */
     void slotFinish(QWidget *mainWin);
+
+    /** Show message and progress */
+    void showMessage(const QString &message, int alignment, const QColor &color);
 
 private:
     /** Connect core signals to splash screen */
     void subscribeToCoreSignals();
     /** Disconnect core signals to splash screen */
     void unsubscribeFromCoreSignals();
+
+    QPixmap pixmap;
+    QString curMessage;
+    QColor curColor;
+    int curAlignment;
 };
 
 #endif // SPLASHSCREEN_H


### PR DESCRIPTION
Makes it possible to move, minimize, unminimize the window while Bitcoin Core is initializing.

Fixes: any splash-screen related issue ever; at least #4915 #4644 
