### PR TITLE
Fixing error: 'vector out of bounds' issue in base 32 and 64

### DIFF
--- a/src/utilstrencodings.cpp
+++ b/src/utilstrencodings.cpp
@@ -224,7 +224,7 @@ vector<unsigned char> DecodeBase64(const char* p, bool* pfInvalid)
 string DecodeBase64(const string& str)
 {
     vector<unsigned char> vchRet = DecodeBase64(str.c_str());
-    return string((const char*)&vchRet[0], vchRet.size());
+    return (vchRet.size() == 0) ? string() : string((const char*)&vchRet[0], vchRet.size());
 }
 
 string EncodeBase32(const unsigned char* pch, size_t len)
@@ -411,7 +411,7 @@ vector<unsigned char> DecodeBase32(const char* p, bool* pfInvalid)
 string DecodeBase32(const string& str)
 {
     vector<unsigned char> vchRet = DecodeBase32(str.c_str());
-    return string((const char*)&vchRet[0], vchRet.size());
+    return (vchRet.size() == 0) ? string() : string((const char*)&vchRet[0], vchRet.size());
 }
 
 bool ParseInt32(const std::string& str, int32_t *out)


### PR DESCRIPTION
Running base64/32_tests revealed that empty string  **Test case: vstrOut[] = {"", .. };** generates an exception. <br>
If **vector** has no elements **(size == 0)** calling **vchRet[0]** throws an out of bounds exception.
