### PR TITLE
Add warning about the merkle-tree algorithm duplicate txid flaw

### DIFF
--- a/src/core.cpp
+++ b/src/core.cpp
@@ -226,6 +226,13 @@ uint256 CBlockHeader::GetHash() const
 
 uint256 CBlock::BuildMerkleTree() const
 {
+    // WARNING! If you're reading this because you're learning about crypto
+    // and/or designing a new system that will use merkle trees, keep in mind
+    // that the following merkle tree algorithm has a serious flaw related to
+    // duplicate txids, resulting in a vulnerability. (CVE-2012-2459) Bitcoin
+    // has since worked around the flaw, but for new applications you should
+    // use something different; don't just copy-and-paste this code without
+    // understanding the problem first.
     vMerkleTree.clear();
     BOOST_FOREACH(const CTransaction& tx, vtx)
         vMerkleTree.push_back(tx.GetHash());


### PR DESCRIPTION
Lots of people read the Bitcoin Core codebase to learn more about crypto; better to warn about flaws explicitly so they don't blindly copy the code for other uses and create broken systems.

Example: https://www.mail-archive.com/bitcoin-development@lists.sourceforge.net/msg06219.html
