### PR TITLE
Fixing improper input syntax and failing bounds check

### DIFF
--- a/src/serialize.h
+++ b/src/serialize.h
@@ -921,7 +921,7 @@ public:
         Init(nTypeIn, nVersionIn);
     }
 
-    CDataStream(const std::vector<unsigned char>& vchIn, int nTypeIn, int nVersionIn) : vch((char*)&vchIn.begin()[0], (char*)&vchIn.end()[0])
+    CDataStream(const std::vector<unsigned char>& vchIn, int nTypeIn, int nVersionIn) : vch(vchIn.begin(), vchIn.end())
     {
         Init(nTypeIn, nVersionIn);
     }


### PR DESCRIPTION
This code does not make much sense from modern compiler point of view. 

I need to investigate further but it looks like under certain circumstances it might allow reading beyond **vch.end()** and could be similar to heart-bleed bug of OpenSSL http://en.wikipedia.org/wiki/Heartbleed

It might take me a bit to understand all of the cases this method is involved with, meanwhile here is the fix.
