### PR TITLE
[Qt] minor changes in splashscreen.cpp

### DIFF
--- a/src/qt/splashscreen.cpp
+++ b/src/qt/splashscreen.cpp
@@ -22,8 +22,6 @@
 SplashScreen::SplashScreen(Qt::WindowFlags f, bool isTestNet) :
     QWidget(0, f), curAlignment(0)
 {
-    //setAutoFillBackground(true);
-
     // set reference point, paddings
     int paddingRight            = 50;
     int paddingTop              = 50;
@@ -114,6 +112,7 @@ SplashScreen::~SplashScreen()
 
 void SplashScreen::slotFinish(QWidget *mainWin)
 {
+    Q_UNUSED(mainWin);
     hide();
 }
 
@@ -180,4 +179,3 @@ void SplashScreen::closeEvent(QCloseEvent *event)
 {
     event->ignore();
 }
-


### PR DESCRIPTION
- guard an unused variable with Q_UNUSED() macro
- remove a commented out line of code
