### PR TITLE
Error: Vector out of bounds in GetKey()

### DIFF
--- a/src/base58.cpp
+++ b/src/base58.cpp
@@ -288,7 +288,7 @@ void CBitcoinSecret::SetKey(const CKey& vchSecret)
 CKey CBitcoinSecret::GetKey()
 {
     CKey ret;
-    ret.Set(&vchData[0], &vchData[32], vchData.size() > 32 && vchData[32] == 1);
+    ret.Set(vchData.begin(), vchData.begin() + 32, vchData.size() > 32 && vchData[32] == 1);
     return ret;
 }
 


### PR DESCRIPTION
If 32 == vchData.size():
    vchData[32] -> Out of bounds (Runtime error)
    vchData.begin() + 32 -> vchData.end() (Perfectly valid operation)

If 33 == vchData.size(): - both notations work.
