### PR TITLE
Fixing base58_tests out of bounds run time error.

### DIFF
--- a/src/test/base58_tests.cpp
+++ b/src/test/base58_tests.cpp
@@ -39,8 +39,9 @@ BOOST_AUTO_TEST_CASE(base58_EncodeBase58)
         }
         std::vector<unsigned char> sourcedata = ParseHex(test[0].get_str());
         std::string base58string = test[1].get_str();
+        const unsigned char * pbegin = (sourcedata.size() != 0) ? &sourcedata.front() : nullptr;
         BOOST_CHECK_MESSAGE(
-                    EncodeBase58(&sourcedata[0], &sourcedata[sourcedata.size()]) == base58string,
+                    EncodeBase58(pbegin, pbegin + sourcedata.size()) == base58string,
                     strTest);
     }
 }

--- a/src/test/base58_tests.cpp
+++ b/src/test/base58_tests.cpp
@@ -39,7 +39,7 @@ BOOST_AUTO_TEST_CASE(base58_EncodeBase58)
         }
         std::vector<unsigned char> sourcedata = ParseHex(test[0].get_str());
         std::string base58string = test[1].get_str();
-        const unsigned char * pbegin = (sourcedata.size() != 0) ? &sourcedata.front() : nullptr;
+        const unsigned char * pbegin = (sourcedata.size() != 0) ? &sourcedata.front() : NULL;
         BOOST_CHECK_MESSAGE(
                     EncodeBase58(pbegin, pbegin + sourcedata.size()) == base58string,
                     strTest);


### PR DESCRIPTION
Empty test string generates empty vector. Referencing first element of empty vectors creates problem because in ms::std::vector in debug mode there are no allocated buffer to reference (Sort of &nullptr). So I changed the test a bit to accommodate this irregularity.
