### PR TITLE
Fixing runtime boundary violation

### DIFF
--- a/src/hash.cpp
+++ b/src/hash.cpp
@@ -9,45 +9,48 @@ unsigned int MurmurHash3(unsigned int nHashSeed, const std::vector<unsigned char
 {
     // The following is MurmurHash3 (x86_32), see http://code.google.com/p/smhasher/source/browse/trunk/MurmurHash3.cpp
     uint32_t h1 = nHashSeed;
-    const uint32_t c1 = 0xcc9e2d51;
-    const uint32_t c2 = 0x1b873593;
+    if (vDataToHash.size() > 0)
+    {
+        const uint32_t c1 = 0xcc9e2d51;
+        const uint32_t c2 = 0x1b873593;
 
-    const int nblocks = vDataToHash.size() / 4;
+        const int nblocks = vDataToHash.size() / 4;
 
-    //----------
-    // body
-    const uint32_t* blocks = (const uint32_t*)(&vDataToHash[0] + nblocks * 4);
+        //----------
+        // body
+        const uint32_t* blocks = (const uint32_t*)(&vDataToHash[0] + nblocks * 4);
 
-    for (int i = -nblocks; i; i++) {
-        uint32_t k1 = blocks[i];
+        for (int i = -nblocks; i; i++) {
+            uint32_t k1 = blocks[i];
 
-        k1 *= c1;
-        k1 = ROTL32(k1, 15);
-        k1 *= c2;
+            k1 *= c1;
+            k1 = ROTL32(k1, 15);
+            k1 *= c2;
 
-        h1 ^= k1;
-        h1 = ROTL32(h1, 13);
-        h1 = h1 * 5 + 0xe6546b64;
+            h1 ^= k1;
+            h1 = ROTL32(h1, 13);
+            h1 = h1 * 5 + 0xe6546b64;
+        }
+
+        //----------
+        // tail
+        const uint8_t* tail = (const uint8_t*)(&vDataToHash[0] + nblocks * 4);
+
+        uint32_t k1 = 0;
+
+        switch (vDataToHash.size() & 3) {
+        case 3:
+            k1 ^= tail[2] << 16;
+        case 2:
+            k1 ^= tail[1] << 8;
+        case 1:
+            k1 ^= tail[0];
+            k1 *= c1;
+            k1 = ROTL32(k1, 15);
+            k1 *= c2;
+            h1 ^= k1;
+        };
     }
-
-    //----------
-    // tail
-    const uint8_t* tail = (const uint8_t*)(&vDataToHash[0] + nblocks * 4);
-
-    uint32_t k1 = 0;
-
-    switch (vDataToHash.size() & 3) {
-    case 3:
-        k1 ^= tail[2] << 16;
-    case 2:
-        k1 ^= tail[1] << 8;
-    case 1:
-        k1 ^= tail[0];
-        k1 *= c1;
-        k1 = ROTL32(k1, 15);
-        k1 *= c2;
-        h1 ^= k1;
-    };
 
     //----------
     // finalization


### PR DESCRIPTION
Avoiding referencing elements of an empty vector
