### PR TITLE
Fixed list's begin iterator after elements erase

### DIFF
--- a/src/script/script.h
+++ b/src/script/script.h
@@ -544,7 +544,7 @@ public:
         {
             while (end() - pc >= (long)b.size() && memcmp(&pc[0], &b[0], b.size()) == 0)
             {
-                erase(pc, pc + b.size());
+                pc = erase(pc, pc + b.size());
                 ++nFound;
             }
         }


### PR DESCRIPTION
Normally pc holds iterator to begin(). After line 547 is executed and few elements are erased from the head this variable needs to be re-initialized with iterator to a new head of the list.
