### PR TITLE
qt: add proxy to options overridden if necessary. Fixes #4975

### DIFF
--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -119,6 +119,8 @@ void OptionsModel::Init()
     // Only try to set -proxy, if user has enabled fUseProxy
     if (settings.value("fUseProxy").toBool() && !SoftSetArg("-proxy", settings.value("addrProxy").toString().toStdString()))
         addOverriddenOption("-proxy");
+    else if(!settings.value("fUseProxy").toBool() && !GetArg("-proxy", "").empty())
+        addOverriddenOption("-proxy");
 
     // Display
     if (!settings.contains("language"))


### PR DESCRIPTION
If proxy is disabled in the gui but enabled via the command line, it needs to
be added to the override list.
