### PR TITLE
SanitizeString: allow '(' and ')'

### DIFF
--- a/src/utilstrencodings.cpp
+++ b/src/utilstrencodings.cpp
@@ -16,7 +16,7 @@ using namespace std;
 
 // safeChars chosen to allow simple messages/URLs/email addresses, but avoid anything
 // even possibly remotely dangerous like & or >
-static string safeChars("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890 .,;_/:?@");
+static string safeChars("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890 .,;_/:?@()");
 string SanitizeString(const string& str)
 {
     string strResult;


### PR DESCRIPTION
'(' and ')' are valid in user agent strings, so should be reported as such in RPC `getpeerinfo`.

Fixes #4537.
