### PR TITLE
Removed \n inside method declaration

### DIFF
--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -37,8 +37,7 @@ static const unsigned int flags = SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_STRICTENC;
 
 unsigned int ParseScriptFlags(string strFlags);
 
-Array
-read_json(const std::string& jsondata)
+Array read_json(const std::string& jsondata)
 {
     Value v;
 


### PR DESCRIPTION
Although technically it is not an error to declare method like this but it is rather unconventional. 
It would also be useful to be able to use grep/search when looking for this method

```
Array read_json(const std::string& jsondata)
```
