### PR TITLE
doc: Add instructions for consistent Mac OS X build names

### DIFF
--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -154,6 +154,10 @@ repackage gitian builds for release as stand-alone zip/tar/installer exe
 	zip -r bitcoin-${VERSION}-win.zip bitcoin-${VERSION}-win
 	rm -rf bitcoin-${VERSION}-win
 
+**Mac OS X .dmg:**
+
+	mv Bitcoin-Qt.dmg bitcoin-${VERSION}-osx.dmg
+
 ###Next steps:
 
 Commit your signature to gitian.sigs:


### PR DESCRIPTION
As suggested by @laanwj on https://github.com/bitcoin/bitcoin.org/pull/572#issuecomment-57061541 .

I'm providing this change to the best of my understanding, but I did not test it.
