### PR TITLE
null pointer of pindexPrev crash.

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -450,9 +450,9 @@ void static BitcoinMiner(CWallet *pwallet)
             //
             unsigned int nTransactionsUpdatedLast = mempool.GetTransactionsUpdated();
             CBlockIndex* pindexPrev = chainActive.Tip();
-            if (NULL == pindexPrev) {
+            if (!pindexPrev) {
                 MilliSleep(1000);
-                continue ;
+                continue;
             }
 
             auto_ptr<CBlockTemplate> pblocktemplate(CreateNewBlockWithKey(reservekey));

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -450,6 +450,10 @@ void static BitcoinMiner(CWallet *pwallet)
             //
             unsigned int nTransactionsUpdatedLast = mempool.GetTransactionsUpdated();
             CBlockIndex* pindexPrev = chainActive.Tip();
+            if (NULL == pindexPrev) {
+                MilliSleep(1000);
+                continue ;
+            }
 
             auto_ptr<CBlockTemplate> pblocktemplate(CreateNewBlockWithKey(reservekey));
             if (!pblocktemplate.get())


### PR DESCRIPTION
i use bitcoind to mine, and if BitcoinMiner() is started before ConnectTip(), pindexPrev will be null pointer, and bitcoind will crash.
maybe this fix is not the optimized fix, although i have test it on my gentoobox and it seems working now.

here are logs and stack:

Starting program: /root/harrywu/build/tmp/native/run-0.9.99/bitcoind -datadir=/root/harrywu/build/tmp/native/run/data -conf=bitcoin.conf -server -gen -debug -checkpoints=0 -txindex=1 -reindex
warning: Could not load shared library symbols for linux-gate.so.1.
Do you need "set solib-search-path" or "set sysroot"?
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/libthread_db.so.1".
[New Thread 0xb7cc8b40 (LWP 25005)]
[New Thread 0xb72ffb40 (LWP 25006)]
[New Thread 0xb6afeb40 (LWP 25007)]
[New Thread 0xb60ffb40 (LWP 25008)]
[New Thread 0xb4ac0b40 (LWP 25009)]
[New Thread 0xb40d6b40 (LWP 25010)]
[New Thread 0xb38d5b40 (LWP 25011)]
[New Thread 0xb2effb40 (LWP 25012)]
[New Thread 0xb24ffb40 (LWP 25013)]
[New Thread 0xb1cfeb40 (LWP 25014)]
[New Thread 0xb14fdb40 (LWP 25015)]
[New Thread 0xb0cfcb40 (LWP 25016)]
[New Thread 0xb04fbb40 (LWP 25017)]
[New Thread 0xafcfab40 (LWP 25018)]
[New Thread 0xaf4f9b40 (LWP 25019)]
[New Thread 0xaecf8b40 (LWP 25020)]
[New Thread 0xae4f7b40 (LWP 25021)]
[New Thread 0xadcf6b40 (LWP 25022)]

Program received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0xae4f7b40 (LWP 25021)]
IncrementExtraNonce (pblock=0xb2501828, pindexPrev=0x0, nExtraNonce=@0xae4f6fc0: 1) at miner.cpp:338
338     unsigned int nHeight = pindexPrev->nHeight+1; // Height first in coinbase required for block.version=2
(gdb) bt
#0  IncrementExtraNonce (pblock=0xb2501828, pindexPrev=0x0, nExtraNonce=@0xae4f6fc0: 1) at miner.cpp:338
#1  0x80110240 in BitcoinMiner (pwallet=0x807c6a20) at miner.cpp:461
#2  0x80111c73 in operator()<void (*)(CWallet*), boost::_bi::list0> (this=0x80e18360, f=<optimized out>, a=...)

```
at /root/harrywu/build/3rd/boost-1.53/include/boost/bind/bind.hpp:253
```
#3  operator() (this=0x80e1835c) at /root/harrywu/build/3rd/boost-1.53/include/boost/bind/bind_template.hpp:20
#4  boost::detail::thread_data<boost::_bi::bind_t<void, void (*)(CWallet*), boost::_bi::list1<boost::_bi::value<CWallet*> > > >::run (this=0x80e18240)

```
at /root/harrywu/build/3rd/boost-1.53/include/boost/thread/detail/thread.hpp:117
```
#5  0x80324ebe in thread_proxy ()
#6  0xb7cd3d9f in start_thread () from /lib/libpthread.so.0
#7  0xb7dd4c8e in clone () from /lib/libc.so.6

(gdb) 

2014-09-28 08:30:17 

2014-09-28 08:30:17 Bitcoin version v0.9.99.0-gae9966e (Sun, 21 Sep 2014 21:25:25 +0200)
2014-09-28 08:30:17 Using OpenSSL version OpenSSL 1.0.1g 7 Apr 2014
2014-09-28 08:30:17 Using BerkeleyDB version Berkeley DB 4.8.30: (April  9, 2010)
2014-09-28 08:30:17 Default data directory /root/.bitcoin
2014-09-28 08:30:17 Using data directory /root/harrywu/build/tmp/native/run/data
2014-09-28 08:30:17 Using config file /root/harrywu/build/tmp/native/run/data/bitcoin.conf
2014-09-28 08:30:17 Using at most 125 connections (1024 file descriptors available)
2014-09-28 08:30:17 Using 4 threads for script verification
2014-09-28 08:30:17 Using wallet wallet.dat
2014-09-28 08:30:17 init message: Verifying wallet...
2014-09-28 08:30:17 CDBEnv::Open : LogDir=/root/harrywu/build/tmp/native/run/data/database ErrorFile=/root/harrywu/build/tmp/native/run/data/db.log
2014-09-28 08:30:17 Bound to [::]:7333
2014-09-28 08:30:17 Bound to 0.0.0.0:7333
2014-09-28 08:30:17 init message: Loading block index...
2014-09-28 08:30:17 Wiping LevelDB in /root/harrywu/build/tmp/native/run/data/blocks/index
2014-09-28 08:30:17 Opening LevelDB in /root/harrywu/build/tmp/native/run/data/blocks/index
2014-09-28 08:30:17 Opened LevelDB successfully
2014-09-28 08:30:17 Wiping LevelDB in /root/harrywu/build/tmp/native/run/data/chainstate
2014-09-28 08:30:17 Opening LevelDB in /root/harrywu/build/tmp/native/run/data/chainstate
2014-09-28 08:30:17 Opened LevelDB successfully
2014-09-28 08:30:17 Initializing databases...
2014-09-28 08:30:17 init message: Verifying blocks...
2014-09-28 08:30:17  block index              10ms
2014-09-28 08:30:17 init message: Loading wallet...
2014-09-28 08:30:17 nFileVersion = 99900
2014-09-28 08:30:17 Keys: 105 plaintext, 0 encrypted, 105 w/ metadata, 105 total
2014-09-28 08:30:17  wallet                   90ms
2014-09-28 08:30:17 init message: Loading addresses...
2014-09-28 08:30:17 Reindexing block file blk00000.dat...
2014-09-28 08:30:17 Loaded 1 addresses from peers.dat  0ms
2014-09-28 08:30:17 mapBlockIndex.size() = 0
2014-09-28 08:30:17 nBestHeight = -1
2014-09-28 08:30:17 setKeyPool.size() = 102
2014-09-28 08:30:17 mapWallet.size() = 2
2014-09-28 08:30:17 mapAddressBook.size() = 1
2014-09-28 08:30:17 Added connection peer=0
2014-09-28 08:30:17 ext-ip thread start
2014-09-28 08:30:17 dnsseed thread start
2014-09-28 08:30:17 net thread start
2014-09-28 08:30:17 addcon thread start
2014-09-28 08:30:17 opencon thread start
2014-09-28 08:30:17 trying connection 10.12.23.47:7333 lastseen=364414.7hrs
2014-09-28 08:30:17 msghand thread start
2014-09-28 08:30:17 dumpaddr thread start
2014-09-28 08:30:17 Allowing RPC connections from: 127.0.0.0/255.0.0.0 ::1/ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff 
2014-09-28 08:30:17 Added connection peer=1
2014-09-28 08:30:17 send version message: version 70002, blocks=-1, us=0.0.0.0:0, peer=1
2014-09-28 08:30:17 Binding RPC on address ::1 port 8332 (IPv4+IPv6 bind any: 0)
2014-09-28 08:30:17 sending: version (102 bytes) peer=1
2014-09-28 08:30:17 Binding RPC on address 127.0.0.1 port 8332 (IPv4+IPv6 bind any: 0)
2014-09-28 08:30:17   - Load block from disk: 0.00ms [0.00s]
2014-09-28 08:30:17   - Connect total: 0.00ms [0.00s]
2014-09-28 08:30:17 init message: Done loading
2014-09-28 08:30:17 BitcoinMiner started
2014-09-28 08:30:17   - Flush: 0.00ms [0.00s]
2014-09-28 08:30:17 keypool reserve 4
2014-09-28 08:30:17   - Writing chainstate: 0.00ms [0.00s]
2014-09-28 08:30:17 UpdateTip: new best=0000000061b1aca334b059920fed7bace2336ea4d23d63428c7aee04da49e942  height=0  log2_work=32.000022  tx=1  date=2014-09-25 17:32:11 progress=0.000000
2014-09-28 08:30:17   - Connect postprocess: 0.00ms [0.00s]
2014-09-28 08:30:17 - Connect block: 0.00ms [0.00s]
2014-09-28 08:30:17   - Load block from disk: 0.00ms [0.00s]
2014-09-28 08:30:17       - Connect 1 transactions: 0.00ms (0.000ms/tx, 0.000ms/txin) [0.00s]
2014-09-28 08:30:17     - Verify 0 txins: 0.00ms (0.000ms/txin) [0.00s]
2014-09-28 08:30:17 Pre-allocating up to position 0x100000 in rev00000.dat
2014-09-28 08:30:17     - Index writing: 0.00ms [0.00s]
2014-09-28 08:30:17     - Callbacks: 0.00ms [0.00s]
2014-09-28 08:30:17   - Connect total: 0.00ms [0.00s]
2014-09-28 08:30:17   - Flush: 0.00ms [0.00s]
2014-09-28 08:30:17   - Writing chainstate: 0.00ms [0.00s]
2014-09-28 08:30:17 UpdateTip: new best=00000000923c935006272f11b781421bb9c40670aec27ed716eedb48b3790e38  height=1  log2_work=33.000022  tx=2  date=2014-09-26 02:34:14 progress=0.000000
2014-09-28 08:30:17   - Connect postprocess: 0.00ms [0.00s]
2014-09-28 08:30:17 - Connect block: 0.00ms [0.00s]
2014-09-28 08:30:17 CreateNewBlock(): total size 1000
2014-09-28 08:30:17       - Connect 1 transactions: 0.00ms (0.000ms/tx, 0.000ms/txin) [0.00s]
2014-09-28 08:30:17     - Verify 0 txins: 0.00ms (0.000ms/txin) [0.00s]
