### PR TITLE
Fix vector out of bounds in script tests

### DIFF
--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -108,20 +108,20 @@ struct KeyData
     KeyData()
     {
 
-        key0.Set(&vchKey0[0], &vchKey0[32], false);
-        key0C.Set(&vchKey0[0], &vchKey0[32], true);
+        key0.Set(vchKey0, vchKey0 + 32, false);
+        key0C.Set(vchKey0, vchKey0 + 32, true);
         pubkey0 = key0.GetPubKey();
         pubkey0H = key0.GetPubKey();
         pubkey0C = key0C.GetPubKey();
         *const_cast<unsigned char*>(&pubkey0H[0]) = 0x06 | (pubkey0H[64] & 1);
 
-        key1.Set(&vchKey1[0], &vchKey1[32], false);
-        key1C.Set(&vchKey1[0], &vchKey1[32], true);
+        key1.Set(vchKey1, vchKey1 + 32, false);
+        key1C.Set(vchKey1, vchKey1 + 32, true);
         pubkey1 = key1.GetPubKey();
         pubkey1C = key1C.GetPubKey();
 
-        key2.Set(&vchKey2[0], &vchKey2[32], false);
-        key2C.Set(&vchKey2[0], &vchKey2[32], true);
+        key2.Set(vchKey2, vchKey2 + 32, false);
+        key2C.Set(vchKey2, vchKey2 + 32, true);
         pubkey2 = key2.GetPubKey();
         pubkey2C = key2C.GetPubKey();
     }
@@ -190,8 +190,8 @@ public:
         std::vector<unsigned char> vchSig, r, s;
         do {
             key.Sign(hash, vchSig, lenS <= 32);
-            r = std::vector<unsigned char>(&vchSig[4], &vchSig[4 + vchSig[3]]);
-            s = std::vector<unsigned char>(&vchSig[6 + vchSig[3]], &vchSig[6 + vchSig[3] + vchSig[5 + vchSig[3]]]);
+            r = std::vector<unsigned char>(vchSig.begin() + 4, vchSig.begin() + 4 + vchSig[3]);
+            s = std::vector<unsigned char>(vchSig.begin() + 6 + vchSig[3], vchSig.begin() + 6 + vchSig[3] + vchSig[5 + vchSig[3]]);
         } while (lenR != r.size() || lenS != s.size());
         vchSig.push_back(static_cast<unsigned char>(nHashType));
         DoPush(vchSig);


### PR DESCRIPTION
Fixes references to the one-past-buffer position in std::vector, introduced in #4960.
