### PR TITLE
Add "warmup mode" for RPC server.

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -84,3 +84,14 @@ Using wildcards will result in the rule being rejected with the following error 
 
     Error: Invalid -rpcallowip subnet specification: *. Valid are a single IP (e.g. 1.2.3.4), a network/netmask (e.g. 1.2.3.4/255.255.255.0) or a network/CIDR (e.g. 1.2.3.4/24).
 
+RPC Server "Warm-Up" Mode
+=========================
+
+The RPC server is started earlier now, before most of the expensive
+intialisations like loading the block index.  It is available now almost
+immediately after starting the process.  However, until all initialisations
+are done, it always returns an immediate error with code -28 to all calls.
+
+This new behaviour can be useful for clients to know that a server is already
+started and will be available soon (for instance, so that they do not
+have to start it themselves).

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -752,6 +752,17 @@ bool AppInit2(boost::thread_group& threadGroup)
             threadGroup.create_thread(&ThreadScriptCheck);
     }
 
+    /* Start the RPC server already.  It will be started in "warmup" mode
+     * and not really process calls already (but it will signify connections
+     * that the server is there and will be ready later).  Warmup mode will
+     * be disabled when initialisation is finished.
+     */
+    if (fServer)
+    {
+        uiInterface.InitMessage.connect(SetRPCWarmupStatus);
+        StartRPCThreads();
+    }
+
     int64_t nStart;
 
     // ********************************************************* Step 5: verify wallet database integrity
@@ -1248,8 +1259,6 @@ bool AppInit2(boost::thread_group& threadGroup)
 #endif
 
     StartNode(threadGroup);
-    if (fServer)
-        StartRPCThreads();
 
 #ifdef ENABLE_WALLET
     // Generate coins in the background
@@ -1259,6 +1268,7 @@ bool AppInit2(boost::thread_group& threadGroup)
 
     // ********************************************************* Step 11: finished
 
+    SetRPCWarmupFinished();
     uiInterface.InitMessage(_("Done loading"));
 
 #ifdef ENABLE_WALLET

--- a/src/rpcprotocol.h
+++ b/src/rpcprotocol.h
@@ -52,6 +52,7 @@ enum RPCErrorCode
     RPC_VERIFY_ERROR                = -25, // General error during transaction or block submission
     RPC_VERIFY_REJECTED             = -26, // Transaction or block was rejected by network rules
     RPC_VERIFY_ALREADY_IN_CHAIN     = -27, // Transaction already in chain
+    RPC_IN_WARMUP                   = -28, // Client still warming up
 
     // Aliases for backward compatibility
     RPC_TRANSACTION_ERROR           = RPC_VERIFY_ERROR,

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -45,6 +45,13 @@ void StopRPCThreads();
 /* Query whether RPC is running */
 bool IsRPCRunning();
 
+/* Set the RPC warmup status.  When this is done, all RPC calls will error out
+ * immediately with RPC_IN_WARMUP.
+ */
+void SetRPCWarmupStatus(const std::string& newStatus);
+/* Mark warmup as done.  RPC calls will be processed from now on.  */
+void SetRPCWarmupFinished();
+
 /**
  * Type-check arguments; throws JSONRPCError if wrong type given. Does not check that
  * the right number of arguments are passed, just that any passed are the correct type.


### PR DESCRIPTION
Start the RPC server before doing all the (expensive) startup initialisations like loading the block index.  Until the node is ready, return all calls immediately with a new error signalling "in warmup" with an appropriate status message (similar to the init message).

This is useful for RPC clients to know that the server is there (e. g., they don't have to start it) but not yet available.  It is used in Namecoin and Huntercoin already for some time, and there exists a UI hooked onto the RPC interface that actively uses this to its advantage.
