### PR TITLE
tests: fix python test-runner for windows

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -793,7 +793,7 @@ AC_SUBST(BUILD_TEST)
 AC_SUBST(BUILD_QT)
 AC_SUBST(BUILD_TEST_QT)
 AC_SUBST(MINIUPNPC_CPPFLAGS)
-AC_CONFIG_FILES([Makefile src/Makefile share/setup.nsi share/qt/Info.plist])
+AC_CONFIG_FILES([Makefile src/Makefile share/setup.nsi share/qt/Info.plist src/test/buildenv.py])
 AC_CONFIG_FILES([qa/pull-tester/run-bitcoind-for-test.sh],[chmod +x qa/pull-tester/run-bitcoind-for-test.sh])
 AC_CONFIG_FILES([qa/pull-tester/build-tests.sh],[chmod +x qa/pull-tester/build-tests.sh])
 AC_OUTPUT

--- a/src/test/bctest.py
+++ b/src/test/bctest.py
@@ -7,9 +7,11 @@ import os
 import json
 import sys
 
-def bctest(testDir, testObj):
-	execargs = testObj['exec']
+def bctest(testDir, testObj, exeext):
 
+	execprog = testObj['exec'] + exeext
+	execargs = testObj['args']
+	execrun = [execprog] + execargs
 	stdinCfg = None
 	inputData = None
 	if "input" in testObj:
@@ -22,12 +24,11 @@ def bctest(testDir, testObj):
 	if "output_cmp" in testObj:
 		outputFn = testObj['output_cmp']
 		outputData = open(testDir + "/" + outputFn).read()
-
-	proc = subprocess.Popen(execargs, stdin=stdinCfg, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+	proc = subprocess.Popen(execrun, stdin=stdinCfg, stdout=subprocess.PIPE, stderr=subprocess.PIPE,universal_newlines=True)
 	try:
 		outs = proc.communicate(input=inputData)
 	except OSError:
-		print("OSError, Failed to execute " + execargs[0])
+		print("OSError, Failed to execute " + execprog)
 		sys.exit(1)
 
 	if outputData and (outs[0] != outputData):
@@ -41,13 +42,13 @@ def bctest(testDir, testObj):
 		print("Return code mismatch for " + outputFn)
 		sys.exit(1)
 
-def bctester(testDir, input_basename):
+def bctester(testDir, input_basename, buildenv):
 	input_filename = testDir + "/" + input_basename
 	raw_data = open(input_filename).read()
 	input_data = json.loads(raw_data)
 
 	for testObj in input_data:
-		bctest(testDir, testObj)
+		bctest(testDir, testObj, buildenv.exeext)
 
 	sys.exit(0)
 

--- a/src/test/bitcoin-util-test.py
+++ b/src/test/bitcoin-util-test.py
@@ -5,8 +5,9 @@
 
 import os
 import bctest
+import buildenv
 
 if __name__ == '__main__':
 	bctest.bctester(os.environ["srcdir"] + "/test/data",
-			"bitcoin-util-test.json")
+			"bitcoin-util-test.json",buildenv)
 

--- a/src/test/buildenv.py.in
+++ b/src/test/buildenv.py.in
@@ -1,0 +1,2 @@
+#!/usr/bin/python
+exeext="@EXEEXT@"

--- a/src/test/data/bitcoin-util-test.json
+++ b/src/test/data/bitcoin-util-test.json
@@ -1,33 +1,41 @@
 [
-  { "exec": ["./bitcoin-tx", "-create"],
+  { "exec": "././bitcoin-tx",
+    "args": ["-create"],
     "output_cmp": "blanktx.hex"
   },
-  { "exec": ["./bitcoin-tx", "-"],
+  { "exec": "./bitcoin-tx",
+    "args": ["-"],
     "input": "blanktx.hex",
     "output_cmp": "blanktx.hex"
   },
-  { "exec": ["./bitcoin-tx", "-", "delin=1"],
+  { "exec": "./bitcoin-tx",
+    "args": ["-", "delin=1"],
     "input": "tx394b54bb.hex",
     "output_cmp": "tt-delin1-out.hex"
   },
-  { "exec": ["./bitcoin-tx", "-", "delin=31"],
+  { "exec": "./bitcoin-tx",
+    "args": ["-", "delin=31"],
     "input": "tx394b54bb.hex",
     "return_code": 1
   },
-  { "exec": ["./bitcoin-tx", "-", "delout=1"],
+  { "exec": "./bitcoin-tx",
+    "args": ["-", "delout=1"],
     "input": "tx394b54bb.hex",
     "output_cmp": "tt-delout1-out.hex"
   },
-  { "exec": ["./bitcoin-tx", "-", "delout=2"],
+  { "exec": "./bitcoin-tx",
+    "args": ["-", "delout=2"],
     "input": "tx394b54bb.hex",
     "return_code": 1
   },
-  { "exec": ["./bitcoin-tx", "-", "locktime=317000"],
+  { "exec": "./bitcoin-tx",
+    "args": ["-", "locktime=317000"],
     "input": "tx394b54bb.hex",
     "output_cmp": "tt-locktime317000-out.hex"
   },
-  { "exec":
-    ["./bitcoin-tx", "-create",
+  { "exec": "./bitcoin-tx",
+    "args":
+    ["-create",
      "in=5897de6bd6027a475eadd57019d4e6872c396d0716c4875a5f1a6fcfdf385c1f:0",
      "in=bf829c6bcf84579331337659d31f89dfd138f7f7785802d5501c92333145ca7c:18",
      "in=22a6f904655d53ae2ff70e701a0bbd90aa3975c0f40bfc6cc996a9049e31cdfc:1",
@@ -35,7 +43,8 @@
      "outaddr=4:1P8yWvZW8jVihP1bzHeqfE4aoXNX8AVa46"],
     "output_cmp": "txcreate1.hex"
   },
-  { "exec": ["./bitcoin-tx", "-create", "outscript=0:"],
+  { "exec": "./bitcoin-tx",
+    "args": ["-create", "outscript=0:"],
     "output_cmp": "txcreate2.hex"
   }
 ]


### PR DESCRIPTION
Windows needed a few fixups to get the python tests running:
1. bitcoin-tx needs a file extension in Windows. Take this opportunity to
   add an env file, which pulls variables out of our build config. This can
   be extended as needed, for now it's very simple.
2. After #1, split the args out of the exec key in the test data.
3. Correct the line-endings from windows stdout
