### PR TITLE
Keep symlinks when copying into .app bundle

### DIFF
--- a/contrib/macdeploy/macdeployqtplus
+++ b/contrib/macdeploy/macdeployqtplus
@@ -292,7 +292,7 @@ def copyFramework(framework, path, verbose):
         fromResourcesDir = framework.sourceResourcesDirectory
         if os.path.exists(fromResourcesDir):
             toResourcesDir = os.path.join(path, framework.destinationResourcesDirectory)
-            shutil.copytree(fromResourcesDir, toResourcesDir)
+            shutil.copytree(fromResourcesDir, toResourcesDir, symlinks=True)
             if verbose >= 3:
                 print "Copied resources:", fromResourcesDir
                 print " to:", toResourcesDir
@@ -301,7 +301,7 @@ def copyFramework(framework, path, verbose):
             fromContentsDir = framework.sourceContentsDirectory
         if os.path.exists(fromContentsDir):
             toContentsDir = os.path.join(path, framework.destinationVersionContentsDirectory)
-            shutil.copytree(fromContentsDir, toContentsDir)
+            shutil.copytree(fromContentsDir, toContentsDir, symlinks=True)
             contentslinkfrom = os.path.join(path, framework.destinationContentsDirectory)
             if verbose >= 3:
                 print "Copied Contents:", fromContentsDir
@@ -310,7 +310,7 @@ def copyFramework(framework, path, verbose):
         qtMenuNibSourcePath = os.path.join(framework.frameworkDirectory, "Resources", "qt_menu.nib")
         qtMenuNibDestinationPath = os.path.join(path, "Contents", "Resources", "qt_menu.nib")
         if os.path.exists(qtMenuNibSourcePath) and not os.path.exists(qtMenuNibDestinationPath):
-            shutil.copytree(qtMenuNibSourcePath, qtMenuNibDestinationPath)
+            shutil.copytree(qtMenuNibSourcePath, qtMenuNibDestinationPath, symlinks=True)
             if verbose >= 3:
                 print "Copied for libQtGui:", qtMenuNibSourcePath
                 print " to:", qtMenuNibDestinationPath
@@ -584,7 +584,7 @@ if verbose >= 3:
     print app_bundle, "->", target
 
 os.mkdir("dist")
-shutil.copytree(app_bundle, target)
+shutil.copytree(app_bundle, target, symlinks=True)
 
 applicationBundle = ApplicationBundleInfo(target)
 
@@ -671,7 +671,7 @@ for p in config.add_resources:
     if verbose >= 3:
         print p, "->", t
     if os.path.isdir(p):
-        shutil.copytree(p, t)
+        shutil.copytree(p, t, symlinks=True)
     else:
         shutil.copy2(p, t)
 


### PR DESCRIPTION
I need this change for the current OSX code-signing process, which looks like:
1. Deterministically gitian-build an .osx.tar.gz
2. Extract the .dmg and then the .app from the .dmg
3. Re-run macdeployqtplus -sign using the extracted, deterministic .app to create a code-signed app inside a .dmg that is actually released.

Step 3 broke with OSX 10.9.5, because symbolic links inside the .app were not preserved. This fixes that.

@laanwj : this should be cherry-picked to the 0.9.3 branch in case there is a 0.9.4.

The plan is to change the code-signing process to something like:
1. Code-signer gitian builds first, producing a .osx.tar.gz that has a .dmg that is signed.
2. Everybody else uses the signatures produced in (1) as an input to the gitian-building process and verifies that end results match.
