### PR TITLE
travis: If the comparison-tool fails, dump the tail of the debug log

### DIFF
--- a/qa/pull-tester/run-bitcoind-for-test.sh.in
+++ b/qa/pull-tester/run-bitcoind-for-test.sh.in
@@ -29,4 +29,8 @@ fi
 kill $BITCOIND && wait $BITCOIND
 
 # timeout returns 124 on timeout, otherwise the return value of the child
+
+# If $RETURN is not 0, the test failed. Dump the tail of the debug log.
+if [ $RETURN -ne 0 ]; then tail -n 200 $DATADIR/regtest/debug.log; fi
+
 exit $RETURN


### PR DESCRIPTION
The entire debug log would be huge, and could cause issues for automated tools
like travis. Printing 200 lines is an initial guess at a reasonable number,
more may be required.
