### PR TITLE
Qt: allow "emergency" shutdown during startup

### DIFF
--- a/src/qt/splashscreen.cpp
+++ b/src/qt/splashscreen.cpp
@@ -177,5 +177,6 @@ void SplashScreen::paintEvent(QPaintEvent *event)
 
 void SplashScreen::closeEvent(QCloseEvent *event)
 {
+    StartShutdown(); // allows an "emergency" shutdown during startup
     event->ignore();
 }


### PR DESCRIPTION
- allows closing our splash screen to abort startup

Tested by closing via startup, which worked without a crash. But it can't currently interrupted when the client is verifying blocks!
