### PR TITLE
depends: disable unused bdb replication manager. Fixes new mingw builds

### DIFF
--- a/depends/packages/bdb.mk
+++ b/depends/packages/bdb.mk
@@ -6,7 +6,7 @@ $(package)_sha256_hash=12edc0df75bf9abd7f82f821795bcee50f42cb2e5f76a6a281b857327
 $(package)_build_subdir=build_unix
 
 define $(package)_set_vars
-$(package)_config_opts=--disable-shared --enable-cxx
+$(package)_config_opts=--disable-shared --enable-cxx --disable-replication
 $(package)_config_opts_mingw32=--enable-mingw
 $(package)_config_opts_x86_64_linux=--with-pic
 $(package)_config_opts_arm_linux=--with-pic


### PR DESCRIPTION
Should fix #5033. Untested though, because I can't reproduce with my version of mingw.

Newer mingw supports the features necessary to enable this api, whereas older
versions didn't. However once enabled (automatically by configure), it triggers
an unrelated build bug.

Since it was not enabled previously anyway, and we don't depend on the
functionality, just disable it across the board.
