### PR TITLE
qt: add network-specific style object

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -178,6 +178,7 @@ BITCOIN_QT_H = \
   qt/macdockiconhandler.h \
   qt/macnotificationhandler.h \
   qt/monitoreddatamapper.h \
+  qt/networkstyle.h \
   qt/notificator.h \
   qt/openuridialog.h \
   qt/optionsdialog.h \
@@ -269,6 +270,7 @@ BITCOIN_QT_CPP = \
   qt/guiutil.cpp \
   qt/intro.cpp \
   qt/monitoreddatamapper.cpp \
+  qt/networkstyle.cpp \
   qt/notificator.cpp \
   qt/optionsdialog.cpp \
   qt/optionsmodel.cpp \

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -12,6 +12,7 @@
 #include "guiconstants.h"
 #include "guiutil.h"
 #include "intro.h"
+#include "networkstyle.h"
 #include "optionsmodel.h"
 #include "splashscreen.h"
 #include "utilitydialog.h"
@@ -190,9 +191,9 @@ public:
     /// Create options model
     void createOptionsModel();
     /// Create main window
-    void createWindow(bool isaTestNet);
+    void createWindow(const NetworkStyle *networkStyle);
     /// Create splash screen
-    void createSplashScreen(bool isaTestNet);
+    void createSplashScreen(const NetworkStyle *networkStyle);
 
     /// Request core initialization
     void requestInitialize();
@@ -331,18 +332,18 @@ void BitcoinApplication::createOptionsModel()
     optionsModel = new OptionsModel();
 }
 
-void BitcoinApplication::createWindow(bool isaTestNet)
+void BitcoinApplication::createWindow(const NetworkStyle *networkStyle)
 {
-    window = new BitcoinGUI(isaTestNet, 0);
+    window = new BitcoinGUI(networkStyle, 0);
 
     pollShutdownTimer = new QTimer(window);
     connect(pollShutdownTimer, SIGNAL(timeout()), window, SLOT(detectShutdown()));
     pollShutdownTimer->start(200);
 }
 
-void BitcoinApplication::createSplashScreen(bool isaTestNet)
+void BitcoinApplication::createSplashScreen(const NetworkStyle *networkStyle)
 {
-    SplashScreen *splash = new SplashScreen(0, isaTestNet);
+    SplashScreen *splash = new SplashScreen(0, networkStyle);
     // We don't hold a direct pointer to the splash screen after creation, so use
     // Qt::WA_DeleteOnClose to make sure that the window will be deleted eventually.
     splash->setAttribute(Qt::WA_DeleteOnClose);
@@ -572,12 +573,10 @@ int main(int argc, char *argv[])
     if (!PaymentServer::ipcParseCommandLine(argc, argv))
         exit(0);
 #endif
-    bool isaTestNet = Params().NetworkID() != CBaseChainParams::MAIN;
+    const NetworkStyle *networkStyle = NetworkStyle::instantiate(QString::fromStdString(Params().NetworkIDString()));
+    assert(networkStyle);
     // Allow for separate UI settings for testnets
-    if (isaTestNet)
-        QApplication::setApplicationName(QAPP_APP_NAME_TESTNET);
-    else
-        QApplication::setApplicationName(QAPP_APP_NAME_DEFAULT);
+    QApplication::setApplicationName(networkStyle->getAppName());
     // Re-initialize translations after changing application name (language in network-specific settings can be different)
     initTranslations(qtTranslatorBase, qtTranslator, translatorBase, translator);
 
@@ -617,11 +616,11 @@ int main(int argc, char *argv[])
     uiInterface.InitMessage.connect(InitMessage);
 
     if (GetBoolArg("-splash", true) && !GetBoolArg("-min", false))
-        app.createSplashScreen(isaTestNet);
+        app.createSplashScreen(networkStyle);
 
     try
     {
-        app.createWindow(isaTestNet);
+        app.createWindow(networkStyle);
         app.requestInitialize();
 #if defined(Q_OS_WIN) && QT_VERSION >= 0x050000
         WinShutdownMonitor::registerShutdownBlockReason(QObject::tr("Bitcoin Core didn't yet exit safely..."), (HWND)app.getMainWinId());
@@ -636,6 +635,8 @@ int main(int argc, char *argv[])
         PrintExceptionContinue(NULL, "Runaway exception");
         app.handleRunawayException(QString::fromStdString(strMiscWarning));
     }
+    delete networkStyle;
+    networkStyle = 0;
     return app.getReturnValue();
 }
 #endif // BITCOIN_QT_TEST

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -19,6 +19,7 @@
 #include <QSystemTrayIcon>
 
 class ClientModel;
+class NetworkStyle;
 class Notificator;
 class OptionsModel;
 class RPCConsole;
@@ -46,7 +47,7 @@ class BitcoinGUI : public QMainWindow
 public:
     static const QString DEFAULT_WALLET;
 
-    explicit BitcoinGUI(bool fIsTestnet = false, QWidget *parent = 0);
+    explicit BitcoinGUI(const NetworkStyle *networkStyle, QWidget *parent = 0);
     ~BitcoinGUI();
 
     /** Set the client model.
@@ -114,13 +115,13 @@ private:
     int spinnerFrame;
 
     /** Create the main UI actions. */
-    void createActions(bool fIsTestnet);
+    void createActions(const NetworkStyle *networkStyle);
     /** Create the menu bar and sub-menus. */
     void createMenuBar();
     /** Create the toolbars */
     void createToolBars();
     /** Create system tray icon and notification */
-    void createTrayIcon(bool fIsTestnet);
+    void createTrayIcon(const NetworkStyle *networkStyle);
     /** Create system tray menu (or setup the dock menu) */
     void createTrayIconMenu();
 

--- a/src/qt/networkstyle.cpp
+++ b/src/qt/networkstyle.cpp
@@ -1,0 +1,47 @@
+// Copyright (c) 2014 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "networkstyle.h"
+
+#include "guiconstants.h"
+
+#include <QApplication>
+
+static const struct {
+    const char *networkId;
+    const char *appName;
+    const char *appIcon;
+    const char *titleAddText;
+    const char *splashImage;
+} network_styles[] = {
+    {"main", QAPP_APP_NAME_DEFAULT, ":/icons/bitcoin", "", ":/images/splash"},
+    {"test", QAPP_APP_NAME_TESTNET, ":/icons/bitcoin_testnet", QT_TRANSLATE_NOOP("SplashScreen", "[testnet]"), ":/images/splash_testnet"},
+    {"regtest", QAPP_APP_NAME_TESTNET, ":/icons/bitcoin_testnet", "[regtest]", ":/images/splash_testnet"}
+};
+static const unsigned network_styles_count = sizeof(network_styles)/sizeof(*network_styles);
+
+// titleAddText needs to be const char* for tr()
+NetworkStyle::NetworkStyle(const QString &appName, const QString &appIcon, const char *titleAddText, const QString &splashImage):
+    appName(appName),
+    appIcon(appIcon),
+    titleAddText(qApp->translate("SplashScreen", titleAddText)),
+    splashImage(splashImage)
+{
+}
+
+const NetworkStyle *NetworkStyle::instantiate(const QString &networkId)
+{
+    for (unsigned x=0; x<network_styles_count; ++x)
+    {
+        if (networkId == network_styles[x].networkId)
+        {
+            return new NetworkStyle(
+                    network_styles[x].appName,
+                    network_styles[x].appIcon,
+                    network_styles[x].titleAddText,
+                    network_styles[x].splashImage);
+        }
+    }
+    return 0;
+}

--- a/src/qt/networkstyle.h
+++ b/src/qt/networkstyle.h
@@ -1,0 +1,33 @@
+// Copyright (c) 2014 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef H_NETWORKSTYLE
+#define H_NETWORKSTYLE
+
+#include <QIcon>
+#include <QPixmap>
+#include <QString>
+
+/* Coin network-specific GUI style information */
+class NetworkStyle
+{
+public:
+    /** Get style associated with provided BIP70 network id, or 0 if not known */
+    static const NetworkStyle *instantiate(const QString &networkId);
+
+    const QString &getAppName() const { return appName; }
+    const QIcon &getAppIcon() const { return appIcon; }
+    const QString &getTitleAddText() const { return titleAddText; }
+    const QPixmap &getSplashImage() const { return splashImage; }
+
+private:
+    NetworkStyle(const QString &appName, const QString &appIcon, const char *titleAddText, const QString &splashImage);
+
+    QString appName;
+    QIcon appIcon;
+    QString titleAddText;
+    QPixmap splashImage;
+};
+
+#endif // H_NETWORKSTYLE

--- a/src/qt/splashscreen.cpp
+++ b/src/qt/splashscreen.cpp
@@ -6,6 +6,7 @@
 
 #include "clientversion.h"
 #include "init.h"
+#include "networkstyle.h"
 #include "ui_interface.h"
 #include "util.h"
 #include "version.h"
@@ -19,7 +20,7 @@
 #include <QDesktopWidget>
 #include <QPainter>
 
-SplashScreen::SplashScreen(Qt::WindowFlags f, bool isTestNet) :
+SplashScreen::SplashScreen(Qt::WindowFlags f, const NetworkStyle *networkStyle) :
     QWidget(0, f), curAlignment(0)
 {
     // set reference point, paddings
@@ -34,17 +35,12 @@ SplashScreen::SplashScreen(Qt::WindowFlags f, bool isTestNet) :
     QString titleText       = tr("Bitcoin Core");
     QString versionText     = QString("Version %1").arg(QString::fromStdString(FormatFullVersion()));
     QString copyrightText   = QChar(0xA9)+QString(" 2009-%1 ").arg(COPYRIGHT_YEAR) + QString(tr("The Bitcoin Core developers"));
-    QString testnetAddText  = QString(tr("[testnet]")); // define text to place as single text object
+    QString titleAddText    = networkStyle->getTitleAddText();
 
     QString font            = "Arial";
 
     // load the bitmap for writing some text over it
-    if(isTestNet) {
-        pixmap     = QPixmap(":/images/splash_testnet");
-    }
-    else {
-        pixmap     = QPixmap(":/images/splash");
-    }
+    pixmap     = networkStyle->getSplashImage();
 
     QPainter pixPaint(&pixmap);
     pixPaint.setPen(QColor(100,100,100));
@@ -78,23 +74,20 @@ SplashScreen::SplashScreen(Qt::WindowFlags f, bool isTestNet) :
     pixPaint.setFont(QFont(font, 10*fontFactor));
     pixPaint.drawText(pixmap.width()-titleTextWidth-paddingRight,paddingTop+titleCopyrightVSpace,copyrightText);
 
-    // draw testnet string if testnet is on
-    if(isTestNet) {
+    // draw additional text if special network
+    if(!titleAddText.isEmpty()) {
         QFont boldFont = QFont(font, 10*fontFactor);
         boldFont.setWeight(QFont::Bold);
         pixPaint.setFont(boldFont);
         fm = pixPaint.fontMetrics();
-        int testnetAddTextWidth  = fm.width(testnetAddText);
-        pixPaint.drawText(pixmap.width()-testnetAddTextWidth-10,15,testnetAddText);
+        int titleAddTextWidth  = fm.width(titleAddText);
+        pixPaint.drawText(pixmap.width()-titleAddTextWidth-10,15,titleAddText);
     }
 
     pixPaint.end();
 
     // Set window title
-    if(isTestNet)
-        setWindowTitle(titleText + " " + testnetAddText);
-    else
-        setWindowTitle(titleText);
+    setWindowTitle(titleText + " " + titleAddText);
 
     // Resize window and move to center of desktop, disallow resizing
     QRect r(QPoint(), pixmap.size());

--- a/src/qt/splashscreen.h
+++ b/src/qt/splashscreen.h
@@ -7,6 +7,8 @@
 
 #include <QSplashScreen>
 
+class NetworkStyle;
+
 /** Class for the splashscreen with information of the running client.
  *
  * @note this is intentionally not a QSplashScreen. Bitcoin Core initialization
@@ -18,7 +20,7 @@ class SplashScreen : public QWidget
     Q_OBJECT
 
 public:
-    explicit SplashScreen(Qt::WindowFlags f, bool isTestNet);
+    explicit SplashScreen(Qt::WindowFlags f, const NetworkStyle *networkStyle);
     ~SplashScreen();
 
 protected:


### PR DESCRIPTION
Mainly cleanups: Gets rid of isTestNet everywhere, by keeping track of network-specific theming in a central place.

Also makes GUI no longer dependent on the network ID enumeration, which alleviates concerns about #4802.
