### PR TITLE
Introduce CNodePolicy for putting isolated node policy code and parameters on

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -94,6 +94,7 @@ BITCOIN_CORE_H = \
   netbase.h \
   net.h \
   noui.h \
+  policy.h \
   pow.h \
   protocol.h \
   random.h \
@@ -156,6 +157,7 @@ libbitcoin_server_a_SOURCES = \
   miner.cpp \
   net.cpp \
   noui.cpp \
+  policy.cpp \
   pow.cpp \
   rpcblockchain.cpp \
   rpcmining.cpp \

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -214,6 +214,11 @@ CAmount CCoinsViewCache::GetValueIn(const CTransaction& tx) const
     return nResult;
 }
 
+CAmount CCoinsViewCache::GetTxFees(const CTransaction& tx) const
+{
+    return GetValueIn(tx) - tx.GetValueOut();
+}
+
 bool CCoinsViewCache::HaveInputs(const CTransaction& tx) const
 {
     if (!tx.IsCoinBase()) {

--- a/src/coins.h
+++ b/src/coins.h
@@ -411,6 +411,7 @@ public:
         @return	Sum of value of all inputs (scriptSigs)
      */
     CAmount GetValueIn(const CTransaction& tx) const;
+    CAmount GetTxFees(const CTransaction& tx) const;
 
     // Check whether all prevouts of the transaction are present in the UTXO set represented by this view
     bool HaveInputs(const CTransaction& tx) const;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -657,6 +657,8 @@ bool AppInit2(boost::thread_group& threadGroup)
     const char* pszP2SH = "/P2SH/";
     COINBASE_FLAGS << std::vector<unsigned char>(pszP2SH, pszP2SH+strlen(pszP2SH));
 
+    policy.fRequireStandardTx = Params().RequireStandard();
+
     // Fee-per-kilobyte amount considered the same as "free"
     // If you are mining, be careful setting this:
     // if you set it to zero then

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -904,17 +904,10 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
         return false;
 
     // Check for conflicts with in-memory transactions
+    if (pool.lookupConflicts(tx, NULL))
     {
-    LOCK(pool.cs); // protect pool.mapNextTx
-    for (unsigned int i = 0; i < tx.vin.size(); i++)
-    {
-        COutPoint outpoint = tx.vin[i].prevout;
-        if (pool.mapNextTx.count(outpoint))
-        {
-            // Disable replacement feature for now
-            return false;
-        }
-    }
+        // Disable replacement feature for now
+        return false;
     }
 
     {

--- a/src/main.h
+++ b/src/main.h
@@ -15,6 +15,7 @@
 #include "coins.h"
 #include "core.h"
 #include "net.h"
+#include "policy.h"
 #include "pow.h"
 #include "script/script.h"
 #include "script/sigcache.h"
@@ -102,6 +103,7 @@ struct BlockHasher
 extern CScript COINBASE_FLAGS;
 extern CCriticalSection cs_main;
 extern CTxMemPool mempool;
+extern CNodePolicy policy;
 typedef boost::unordered_map<uint256, CBlockIndex*, BlockHasher> BlockMap;
 extern BlockMap mapBlockIndex;
 extern uint64_t nLastBlockTx;

--- a/src/policy.cpp
+++ b/src/policy.cpp
@@ -1,0 +1,103 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2014 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+// NOTE: This file is intended to be customised by the end user, and includes only local node policy logic
+
+#include "amount.h"
+#include "core.h"
+#include "main.h"
+#include "sync.h"
+#include "txmempool.h"
+#include "util.h"
+
+#include <cmath>
+#include <string>
+
+bool CNodePolicy::AcceptTxPoolPreInputs(CTxMemPool& pool, CValidationState& state, const CTransaction& tx)
+{
+    // Rather not work on nonstandard transactions (unless -testnet/-regtest)
+    std::string reason;
+    if (fRequireStandardTx && !IsStandardTx(tx, reason))
+        return state.DoS(0,
+                         error("%s : nonstandard transaction: %s", __func__, reason),
+                         REJECT_NONSTANDARD, reason);
+
+    // Check for conflicts with in-memory transactions
+    if (pool.lookupConflicts(tx, NULL))
+    {
+        // Disable replacement feature for now
+        return false;
+    }
+
+    return true;
+}
+
+bool CNodePolicy::AcceptTxWithInputs(CTxMemPool& pool, CValidationState& state, const CTransaction& tx, CCoinsViewCache& view)
+{
+    // Check for non-standard pay-to-script-hash in inputs
+    if (fRequireStandardTx && !AreInputsStandard(tx, view))
+        return error("%s : nonstandard transaction input", __func__);
+
+    // Check that the transaction doesn't have an excessive number of
+    // sigops, making it impossible to mine. Since the coinbase transaction
+    // itself can contain sigops MAX_TX_SIGOPS is less than
+    // MAX_BLOCK_SIGOPS; we still consider this an invalid rather than
+    // merely non-standard transaction.
+    unsigned int nSigOps = GetLegacySigOpCount(tx);
+    nSigOps += GetP2SHSigOpCount(tx, view);
+    if (nSigOps > MAX_TX_SIGOPS)
+        return state.DoS(0,
+                         error("%s : too many sigops %s, %d > %d",
+                               __func__, tx.GetHash().ToString(), nSigOps, MAX_TX_SIGOPS),
+                         REJECT_NONSTANDARD, "bad-txns-too-many-sigops");
+
+    return true;
+}
+
+bool CNodePolicy::AcceptMemPoolEntry(CTxMemPool& pool, CValidationState& state, CTxMemPoolEntry& entry, CCoinsViewCache& view, bool& fRateLimit)
+{
+    const CTransaction& tx = entry.GetTx();
+
+    CAmount nFees = entry.GetFee();
+    unsigned int nSize = entry.GetTxSize();
+
+    // Don't accept it if it can't get into a block
+    CAmount txMinFee = GetMinRelayFee(tx, nSize, true);
+    if (nFees < txMinFee)
+        return state.DoS(0, error("%s : not enough fees %s, %d < %d",
+                                  __func__, tx.GetHash().ToString(), nFees, txMinFee),
+                         REJECT_INSUFFICIENTFEE, "insufficient fee");
+
+    // Continuously rate-limit free (really, very-low-fee)transactions
+    // This mitigates 'penny-flooding' -- sending thousands of free transactions just to
+    // be annoying or make others' transactions take longer to confirm.
+    fRateLimit = (nFees < ::minRelayTxFee.GetFee(nSize));
+
+    return true;
+}
+
+bool CNodePolicy::RateLimitTx(CTxMemPool& pool, CValidationState& state, CTxMemPoolEntry& entry, CCoinsViewCache& view)
+{
+    static CCriticalSection csFreeLimiter;
+    static double dFreeCount;
+    static int64_t nLastTime;
+    int64_t nNow = GetTime();
+
+    LOCK(csFreeLimiter);
+
+    // Use an exponentially decaying ~10-minute window:
+    dFreeCount *= pow(1.0 - 1.0/600.0, (double)(nNow - nLastTime));
+    nLastTime = nNow;
+    // -limitfreerelay unit is thousand-bytes-per-minute
+    // At default rate it would take over a month to fill 1GB
+    if (dFreeCount >= GetArg("-limitfreerelay", 15)*10*1000)
+        return state.DoS(0, error("%s : free transaction rejected by rate limiter", __func__),
+                         REJECT_INSUFFICIENTFEE, "insufficient priority");
+    unsigned int nSize = entry.GetTxSize();
+    LogPrint("mempool", "Rate limit dFreeCount: %g => %g\n", dFreeCount, dFreeCount+nSize);
+    dFreeCount += nSize;
+
+    return true;
+}

--- a/src/policy.h
+++ b/src/policy.h
@@ -1,0 +1,37 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2014 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_POLICY_H
+#define BITCOIN_POLICY_H
+
+class CCoinsViewCache;
+class CTransaction;
+class CTxMemPool;
+class CTxMemPoolEntry;
+class CValidationState;
+
+class CNodePolicyBase
+{
+public:
+    virtual bool AcceptTxPoolPreInputs(CTxMemPool&, CValidationState&, const CTransaction&) = 0;
+    virtual bool AcceptTxWithInputs(CTxMemPool&, CValidationState&, const CTransaction&, CCoinsViewCache&) = 0;
+    virtual bool AcceptMemPoolEntry(CTxMemPool&, CValidationState&, CTxMemPoolEntry&, CCoinsViewCache&, bool& fRateLimit) = 0;
+    virtual bool RateLimitTx(CTxMemPool&, CValidationState&, CTxMemPoolEntry&, CCoinsViewCache&) = 0;
+};
+
+class CNodePolicy : CNodePolicyBase
+{
+public:
+    bool fRequireStandardTx;
+
+    CNodePolicy() : fRequireStandardTx(true) { };
+
+    virtual bool AcceptTxPoolPreInputs(CTxMemPool&, CValidationState&, const CTransaction&);
+    virtual bool AcceptTxWithInputs(CTxMemPool&, CValidationState&, const CTransaction&, CCoinsViewCache&);
+    virtual bool AcceptMemPoolEntry(CTxMemPool&, CValidationState&, CTxMemPoolEntry&, CCoinsViewCache&, bool& fRateLimit);
+    virtual bool RateLimitTx(CTxMemPool&, CValidationState&, CTxMemPoolEntry&, CCoinsViewCache&);
+};
+
+#endif // BITCOIN_POLICY_H

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -556,6 +556,25 @@ bool CTxMemPool::lookup(uint256 hash, CTransaction& result) const
     return true;
 }
 
+bool CTxMemPool::lookupConflicts(const CTransaction& tx, std::vector<const CTransaction *> *vtxConflicts) const
+{
+    bool rv = false;
+    LOCK(cs);
+    BOOST_FOREACH(const CTxIn& txin, tx.vin)
+    {
+        const COutPoint& outpoint = txin.prevout;
+        std::map<COutPoint, CInPoint>::const_iterator elem = mapNextTx.find(outpoint);
+        if (mapNextTx.end() != elem)
+        {
+            if (!vtxConflicts)
+                return true;
+            vtxConflicts->push_back(elem->second.ptx);
+            rv = true;
+        }
+    }
+    return rv;
+}
+
 CFeeRate CTxMemPool::estimateFee(int nBlocks) const
 {
     LOCK(cs);

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -137,6 +137,7 @@ public:
     }
 
     bool lookup(uint256 hash, CTransaction& result) const;
+    bool lookupConflicts(const CTransaction&, std::vector<const CTransaction *> *vtxConflicts) const;
 
     // Estimate fee rate needed to get into the next
     // nBlocks


### PR DESCRIPTION
Initially populated with policy-specific code moved from AcceptToMemoryPool.

This should make no _actual_ changes, just refactor code. If any change in behaviour is found, it is a bug in this pull request, please report it even if you think it's a good idea.
