### PR TITLE
rpc-tests: don't spew non-errors to stdout

### DIFF
--- a/qa/rpc-tests/send.sh
+++ b/qa/rpc-tests/send.sh
@@ -16,7 +16,7 @@ fi
 
 if [ $1 = "-STOP" ]; then
   if [ -s ${PIDFILE} ]; then
-      kill -s ${SIGNAL} $(<${PIDFILE})
+      kill -s ${SIGNAL} $(<$PIDFILE 2>/dev/null) 2>/dev/null
   fi
   exit 0
 fi


### PR DESCRIPTION
Very minor fix necessary before adding rpc tests to travis.

There's a brief race here, the process might've already exited and cleaned up
after itself. If that's the case, reading from the pidfile will harmlessly
fail. Keep those quiet.
