### PR TITLE
Enable customising node policy for datacarrier data size with a -datacarriersize option

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -17,6 +17,7 @@
 #include "miner.h"
 #include "net.h"
 #include "rpcserver.h"
+#include "script/standard.h"
 #include "txdb.h"
 #include "ui_interface.h"
 #include "util.h"
@@ -345,6 +346,7 @@ std::string HelpMessage(HelpMessageMode mode)
 
     strUsage += "\n" + _("Node relay options:") + "\n";
     strUsage += "  -datacarrier           " + strprintf(_("Relay and mine data carrier transactions (default: %u)"), 1) + "\n";
+    strUsage += "  -datacarriersize       " + strprintf(_("Maximum size of data in data carrier transactions we relay and mine (default: %u)"), MAX_OP_RETURN_RELAY) + "\n";
 
     strUsage += "\n" + _("Block creation options:") + "\n";
     strUsage += "  -blockminsize=<n>      " + strprintf(_("Set minimum block size in bytes (default: %u)"), 0) + "\n";
@@ -702,6 +704,7 @@ bool AppInit2(boost::thread_group& threadGroup)
 #endif // ENABLE_WALLET
 
     fIsBareMultisigStd = GetArg("-permitbaremultisig", true) != 0;
+    nMaxDatacarrierBytes = GetArg("-datacarriersize", nMaxDatacarrierBytes);
 
     // ********************************************************* Step 4: application initialization: dir lock, daemonize, pidfile, debug log
 

--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -15,6 +15,8 @@ using namespace std;
 
 typedef vector<unsigned char> valtype;
 
+unsigned nMaxDatacarrierBytes = MAX_OP_RETURN_RELAY;
+
 CScriptID::CScriptID(const CScript& in) : uint160(in.size() ? Hash160(in.begin(), in.end()) : 0) {}
 
 const char* GetTxnOutputType(txnouttype t)
@@ -139,8 +141,8 @@ bool Solver(const CScript& scriptPubKey, txnouttype& typeRet, vector<vector<unsi
             }
             else if (opcode2 == OP_SMALLDATA)
             {
-                // small pushdata, <= MAX_OP_RETURN_RELAY bytes
-                if (vch1.size() > MAX_OP_RETURN_RELAY)
+                // small pushdata, <= nMaxDatacarrierBytes
+                if (vch1.size() > nMaxDatacarrierBytes)
                     break;
             }
             else if (opcode1 != opcode2 || vch1 != vch2)

--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -26,6 +26,7 @@ public:
 };
 
 static const unsigned int MAX_OP_RETURN_RELAY = 40;      // bytes
+extern unsigned nMaxDatacarrierBytes;
 
 // Mandatory script verification flags that all new blocks must comply with for
 // them to be valid. (but old blocks may not comply with) Currently just P2SH,


### PR DESCRIPTION
This seems to be something miners want control over.
