### PR TITLE
Bugfix: Restore ProcessBlock's ability to return with CValidationState set properly

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1696,6 +1696,8 @@ bool ConnectBlock(CBlock& block, CValidationState& state, CBlockIndex* pindex, C
     int64_t nTime2 = GetTimeMicros(); nTimeVerify += nTime2 - nTimeStart;
     LogPrint("bench", "    - Verify %u txins: %.2fms (%.3fms/txin) [%.2fs]\n", nInputs - 1, 0.001 * (nTime2 - nTimeStart), nInputs <= 1 ? 0 : 0.001 * (nTime2 - nTimeStart) / (nInputs-1), nTimeVerify * 0.000001);
 
+    // The block has been fully checked for validity at this point
+    state.Conclude();
     if (fJustCheck)
         return true;
 

--- a/src/main.h
+++ b/src/main.h
@@ -454,6 +454,10 @@ bool ConnectBlock(CBlock& block, CValidationState& state, CBlockIndex* pindex, C
 bool CheckBlockHeader(const CBlockHeader& block, CValidationState& state, bool fCheckPOW = true);
 bool CheckBlock(const CBlock& block, CValidationState& state, bool fCheckPOW = true, bool fCheckMerkleRoot = true);
 
+// Context-dependent validity checks
+bool CtxCheckBlockHeader(const CBlockHeader& block, CValidationState& state, CBlockIndex **ppindex= NULL);
+bool CtxCheckBlock(const CBlock& block, CValidationState& state, CBlockIndex*& pindexPrev);
+
 // Store block on disk
 // if dbp is provided, the file is known to already reside on disk
 bool AcceptBlock(CBlock& block, CValidationState& state, CBlockIndex **pindex, CDiskBlockPos* dbp = NULL);

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -323,8 +323,18 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn)
         indexDummy.nHeight = pindexPrev->nHeight + 1;
         CCoinsViewCache viewNew(pcoinsTip);
         CValidationState state;
+        // NOTE: CheckBlockHeader is called by CheckBlock
+        // NOTE: CtxCheckBlockHeader only assigns ppindex, which we don't need/want
+        if (!CtxCheckBlockHeader(*pblock, state, NULL))
+            throw std::runtime_error("CreateNewBlock() : CtxCheckBlockHeader failed");
+        if (!CheckBlock(*pblock, state, false, false))
+            throw std::runtime_error("CreateNewBlock() : CheckBlock failed");
+        if (!CtxCheckBlock(*pblock, state, pindexPrev))
+            throw std::runtime_error("CreateNewBlock() : CtxCheckBlock failed");
         if (!ConnectBlock(*pblock, state, &indexDummy, viewNew, true))
             throw std::runtime_error("CreateNewBlock() : ConnectBlock failed");
+        if (!(state.IsValid() && state.IsConclusive()))
+            throw std::runtime_error("CreateNewBlock() : State is not conclusively valid");
     }
 
     return pblocktemplate.release();


### PR DESCRIPTION
In cases where ProcessBlock does not in fact complete validation, CValidationState returns with a "inconclusive" state.
