### PR TITLE
Unify and simplify CScript push methods

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -132,12 +132,14 @@ public:
          *     CTxIn(COutPoint(000000, -1), coinbase 04ffff001d0104455468652054696d65732030332f4a616e2f32303039204368616e63656c6c6f72206f6e206272696e6b206f66207365636f6e64206261696c6f757420666f722062616e6b73)
          *     CTxOut(nValue=50.00000000, scriptPubKey=0x5F1DF16B2B704C8A578D0B)
          *   vMerkleTree: 4a5e1e
+         *
+         * The coinbase genesis input consists of a pushes of: number 486604799, number 4 (without using OP_4), and the string "The Times 03/Jan/2009 Chancellor on brink of second bailout for banks".
          */
-        const char* pszTimestamp = "The Times 03/Jan/2009 Chancellor on brink of second bailout for banks";
+        const unsigned char pszCoinbase[] = "\x04\xff\xff\x00\x1d\x01\x04\x45The Times 03/Jan/2009 Chancellor on brink of second bailout for banks";
         CMutableTransaction txNew;
         txNew.vin.resize(1);
         txNew.vout.resize(1);
-        txNew.vin[0].scriptSig = CScript() << 486604799 << CScriptNum(4) << vector<unsigned char>((const unsigned char*)pszTimestamp, (const unsigned char*)pszTimestamp + strlen(pszTimestamp));
+        txNew.vin[0].scriptSig = CScript(pszCoinbase, pszCoinbase + 77);
         txNew.vout[0].nValue = 50 * COIN;
         txNew.vout[0].scriptPubKey = CScript() << ParseHex("04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5f") << OP_CHECKSIG;
         genesis.vtx.push_back(txNew);

--- a/src/core_read.cpp
+++ b/src/core_read.cpp
@@ -61,8 +61,7 @@ CScript ParseScript(std::string s)
             (starts_with(*w, "-") && all(string(w->begin()+1, w->end()), is_digit())))
         {
             // Number
-            int64_t n = atoi64(*w);
-            result << n;
+            result << CScriptNum(atoi64(*w));
         }
         else if (starts_with(*w, "0x") && (w->begin()+2 != w->end()) && IsHex(string(w->begin()+2, w->end())))
         {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2437,7 +2437,7 @@ bool AcceptBlock(CBlock& block, CValidationState& state, CBlockIndex** ppindex, 
     if (block.nVersion >= 2 && 
         CBlockIndex::IsSuperMajority(2, pindex->pprev, Params().EnforceBlockUpgradeMajority()))
     {
-        CScript expect = CScript() << nHeight;
+        CScript expect = CScript() << CScriptNum(nHeight);
         if (block.vtx[0].vin[0].scriptSig.size() < expect.size() ||
             !std::equal(expect.begin(), expect.end(), block.vtx[0].vin[0].scriptSig.begin())) {
             pindex->nStatus |= BLOCK_FAILED_VALID;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -345,7 +345,7 @@ void IncrementExtraNonce(CBlock* pblock, CBlockIndex* pindexPrev, unsigned int& 
     ++nExtraNonce;
     unsigned int nHeight = pindexPrev->nHeight+1; // Height first in coinbase required for block.version=2
     CMutableTransaction txCoinbase(pblock->vtx[0]);
-    txCoinbase.vin[0].scriptSig = (CScript() << nHeight << CScriptNum(nExtraNonce)) + COINBASE_FLAGS;
+    txCoinbase.vin[0].scriptSig = (CScript() << CScriptNum(nHeight) << CScriptNum(nExtraNonce)) + COINBASE_FLAGS;
     assert(txCoinbase.vin[0].scriptSig.size() <= 100);
 
     pblock->vtx[0] = txCoinbase;

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -452,7 +452,7 @@ void CoinControlDialog::updateLabels(WalletModel *model, QDialog* dialog)
 
         if (amount > 0)
         {
-            CTxOut txout(amount, (CScript)vector<unsigned char>(24, 0));
+            CTxOut txout(amount, CScript() << vector<unsigned char>(24, 0));
             txDummy.vout.push_back(txout);
             if (txout.IsDust(::minRelayTxFee))
                fDust = true;
@@ -548,7 +548,7 @@ void CoinControlDialog::updateLabels(WalletModel *model, QDialog* dialog)
             // Never create dust outputs; if we would, just add the dust to the fee.
             if (nChange > 0 && nChange < CENT)
             {
-                CTxOut txout(nChange, (CScript)vector<unsigned char>(24, 0));
+                CTxOut txout(nChange, CScript() << vector<unsigned char>(24, 0));
                 if (txout.IsDust(::minRelayTxFee))
                 {
                     nPayFee += nChange;

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -727,7 +727,7 @@ bool EvalScript(vector<vector<unsigned char> >& stack, const CScript& script, un
                     CScript scriptCode(pbegincodehash, pend);
 
                     // Drop the signature, since there's no way for a signature to sign itself
-                    scriptCode.FindAndDelete(CScript(vchSig));
+                    scriptCode.FindAndDelete(CScript() << vchSig);
 
                     if (!CheckSignatureEncoding(vchSig, flags)) {
                         return false;
@@ -783,7 +783,7 @@ bool EvalScript(vector<vector<unsigned char> >& stack, const CScript& script, un
                     for (int k = 0; k < nSigsCount; k++)
                     {
                         valtype& vchSig = stacktop(-isig-k);
-                        scriptCode.FindAndDelete(CScript(vchSig));
+                        scriptCode.FindAndDelete(CScript() << vchSig);
                     }
 
                     bool fSuccess = true;

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -20,6 +20,55 @@ inline std::string ValueString(const std::vector<unsigned char>& vch)
 
 using namespace std;
 
+std::vector<unsigned char> CScriptNum::serialize(const int64_t& value)
+{
+    if (value == 0)
+        return std::vector<unsigned char>();
+
+    std::vector<unsigned char> result;
+    const bool neg = value < 0;
+    uint64_t absvalue = neg ? -value : value;
+
+    while (absvalue) {
+        result.push_back(absvalue & 0xff);
+        absvalue >>= 8;
+    }
+
+//    - If the most significant byte is >= 0x80 and the value is positive, push a
+//    new zero-byte to make the significant byte < 0x80 again.
+
+//    - If the most significant byte is >= 0x80 and the value is negative, push a
+//    new 0x80 byte that will be popped off when converting to an integral.
+
+//    - If the most significant byte is < 0x80 and the value is negative, add
+//    0x80 to it, since it will be subtracted and interpreted as a negative when
+//    converting to an integral.
+
+    if (result.back() & 0x80)
+        result.push_back(neg ? 0x80 : 0);
+    else if (neg)
+        result.back() |= 0x80;
+
+    return result;
+}
+
+int64_t CScriptNum::set_vch(const std::vector<unsigned char>& vch)
+{
+    if (vch.empty())
+        return 0;
+
+    int64_t result = 0;
+    for (size_t i = 0; i != vch.size(); ++i)
+        result |= static_cast<int64_t>(vch[i]) << 8*i;
+
+    // If the input vector's most significant byte is 0x80, remove it from
+    // the result's msb and return a negative.
+    if (vch.back() & 0x80)
+        return -((int64_t)(result & ~(0x80ULL << (8 * (vch.size() - 1)))));
+
+    return result;
+}
+
 const char* GetOpName(opcodetype opcode)
 {
     switch (opcode)
@@ -161,6 +210,128 @@ const char* GetOpName(opcodetype opcode)
     default:
         return "OP_UNKNOWN";
     }
+}
+
+CScript& CScript::operator+=(const CScript& b)
+{
+    insert(end(), b.begin(), b.end());
+    return *this;
+}
+
+CScript& CScript::operator<<(opcodetype opcode)
+{
+    if (opcode < 0 || opcode > 0xff)
+        throw std::runtime_error("CScript::operator<<() : invalid opcode");
+    insert(end(), (unsigned char)opcode);
+    return *this;
+}
+
+CScript& CScript::operator<<(const CScriptNum& b)
+{
+    *this << b.getvch();
+    return *this;
+}
+
+CScript& CScript::operator<<(const std::vector<unsigned char>& b)
+{
+    // Special cases (OP_0, OP_1NEGATE, OP_1..OP_16).
+    if (b.size() == 0) {
+        insert(end(), OP_0);
+        return *this;
+    }
+    if (b.size() == 1 && b[0] == 0x81) {
+        insert(end(), OP_1NEGATE);
+        return *this;
+    }
+    if (b.size() == 1 && b[0] >= 1 && b[0] <= 16) {
+        insert(end(), b[0] + (OP_1 - 1));
+        return *this;
+    }
+    // Normal pushes.
+    if (b.size() < OP_PUSHDATA1) {
+        insert(end(), (unsigned char)b.size());
+    } else if (b.size() <= 0xff) {
+        insert(end(), OP_PUSHDATA1);
+        insert(end(), (unsigned char)b.size());
+    } else if (b.size() <= 0xffff) {
+        insert(end(), OP_PUSHDATA2);
+        unsigned short nSize = b.size();
+        insert(end(), (unsigned char*)&nSize, (unsigned char*)&nSize + sizeof(nSize));
+    } else {
+        insert(end(), OP_PUSHDATA4);
+        unsigned int nSize = b.size();
+        insert(end(), (unsigned char*)&nSize, (unsigned char*)&nSize + sizeof(nSize));
+    }
+    insert(end(), b.begin(), b.end());
+    return *this;
+}
+
+CScript& CScript::operator<<(const CScript& b) {
+    // I'm not sure if this should push the script or concatenate scripts.
+    // If there's ever a use for pushing a script onto a script, delete this member fn
+    assert(!"Warning: Pushing a CScript onto a CScript with << is probably not intended, use + to concatenate!");
+    return *this;
+}
+
+bool CScript::GetOp2(const_iterator& pc, opcodetype& opcodeRet, std::vector<unsigned char>* pvchRet) const
+{
+    opcodeRet = OP_INVALIDOPCODE;
+    if (pvchRet)
+        pvchRet->clear();
+    if (pc >= end())
+        return false;
+
+    // Read instruction
+    if (end() - pc < 1)
+        return false;
+    unsigned int opcode = *pc++;
+
+    // Immediate operand
+    if (opcode <= OP_PUSHDATA4) {
+        unsigned int nSize = 0;
+        if (opcode < OP_PUSHDATA1) {
+            nSize = opcode;
+        } else if (opcode == OP_PUSHDATA1) {
+            if (end() - pc < 1)
+                return false;
+            nSize = *pc++;
+        } else if (opcode == OP_PUSHDATA2) {
+            if (end() - pc < 2)
+                return false;
+            nSize = 0;
+            memcpy(&nSize, &pc[0], 2);
+            pc += 2;
+        } else if (opcode == OP_PUSHDATA4) {
+            if (end() - pc < 4)
+                return false;
+            memcpy(&nSize, &pc[0], 4);
+            pc += 4;
+        }
+        if (end() - pc < 0 || (unsigned int)(end() - pc) < nSize)
+            return false;
+        if (pvchRet)
+            pvchRet->assign(pc, pc + nSize);
+        pc += nSize;
+    }
+
+    opcodeRet = (opcodetype)opcode;
+    return true;
+}
+
+int CScript::FindAndDelete(const CScript& b)
+{
+    int nFound = 0;
+    if (b.empty())
+        return nFound;
+    iterator pc = begin();
+    opcodetype opcode;
+    do {
+        while (end() - pc >= (long)b.size() && memcmp(&pc[0], &b[0], b.size()) == 0) {
+            pc = erase(pc, pc + b.size());
+            ++nFound;
+        }
+    } while (GetOp(pc, opcode));
+    return nFound;
 }
 
 unsigned int CScript::GetSigOpCount(bool fAccurate) const

--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -310,9 +310,9 @@ CScript GetScriptForMultisig(int nRequired, const std::vector<CPubKey>& keys)
 {
     CScript script;
 
-    script << CScript::EncodeOP_N(nRequired);
+    script << CScriptNum(nRequired);
     BOOST_FOREACH(const CPubKey& key, keys)
         script << ToByteVector(key);
-    script << CScript::EncodeOP_N(keys.size()) << OP_CHECKMULTISIG;
+    script << CScriptNum(keys.size()) << OP_CHECKMULTISIG;
     return script;
 }

--- a/src/test/script_P2SH_tests.cpp
+++ b/src/test/script_P2SH_tests.cpp
@@ -341,7 +341,7 @@ BOOST_AUTO_TEST_CASE(AreInputsStandard)
     for (int i = 0; i < 3; i++)
     {
         CScript t = txTo.vin[i].scriptSig;
-        txTo.vin[i].scriptSig = (CScript() << 11) + t;
+        txTo.vin[i].scriptSig = (CScript() << CScriptNum(11)) + t;
         BOOST_CHECK(!::AreInputsStandard(txTo, coins));
         txTo.vin[i].scriptSig = t;
     }

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -179,7 +179,7 @@ public:
     TestBuilder& Num(int num)
     {
         DoPush();
-        spendTx.vin[0].scriptSig << num;
+        spendTx.vin[0].scriptSig << CScriptNum(num);
         return *this;
     }
 
@@ -790,7 +790,7 @@ BOOST_AUTO_TEST_CASE(script_standard_push)
 {
     for (int i=0; i<67000; i++) {
         CScript script;
-        script << i;
+        script << CScriptNum(i);
         BOOST_CHECK_MESSAGE(script.IsPushOnly(), "Number " << i << " is not pure push.");
         BOOST_CHECK_MESSAGE(VerifyScript(script, CScript() << OP_1, SCRIPT_VERIFY_MINIMALDATA, BaseSignatureChecker()), "Number " << i << " push is not minimal data.");
     }

--- a/src/test/sighash_tests.cpp
+++ b/src/test/sighash_tests.cpp
@@ -33,7 +33,7 @@ uint256 static SignatureHashOld(CScript scriptCode, const CTransaction& txTo, un
 
     // In case concatenating two scripts ends up with two codeseparators,
     // or an extra one at the end, this prevents all those possible incompatibilities.
-    scriptCode.FindAndDelete(CScript(OP_CODESEPARATOR));
+    scriptCode.FindAndDelete(CScript() << OP_CODESEPARATOR);
 
     // Blank out other inputs' signatures
     for (unsigned int i = 0; i < txTmp.vin.size(); i++)


### PR DESCRIPTION
- Make CScript::operator<<(const std::vector<unsigned char>&) cover all push operations (including OP_0, OP_1..OP_16 and OP_1NEGATE), and make the push for numbers use that.
- Convert the uint256, uint160 and CPubKey into a single templated one using the vector push code.
- Get rid of the int64_t operator<<; better be explicit about what needs pushing, so change all number pushes to use CScriptNum (which, due to the generic vector push now also correctly uses OP_n).
- Get rid of some unused methods and constructors as a result.
