### PR TITLE
Add LIBTOOLFLAGS CXX tag to qt makefile include

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -368,6 +368,7 @@ if USE_LIBSECP256K1
   qt_bitcoin_qt_LDADD += secp256k1/libsecp256k1.la
 endif
 qt_bitcoin_qt_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(QT_LDFLAGS)
+qt_bitcoin_qt_LIBTOOLFLAGS = --tag CXX
 
 #locale/foo.ts -> locale/foo.qm
 QT_QM=$(QT_TS:.ts=.qm)


### PR DESCRIPTION
Related #4993 

@theuni As far as I can tell it's only needed in this spot. Test bitcoin_bitcoin-qt seems to run fine. 

I'm guessing because 

```
OBJCXXLD qt/bitcoin-qt
CXXLD    qt/test/test_bitcoin-qt
```
