### PR TITLE
Add a SECURE style flag for ThreadSafeMessageBox, which indicates that the message contains sensitive information

### DIFF
--- a/src/noui.cpp
+++ b/src/noui.cpp
@@ -14,6 +14,9 @@
 
 static bool noui_ThreadSafeMessageBox(const std::string& message, const std::string& caption, unsigned int style)
 {
+    bool fSecure = style & CClientUIInterface::SECURE;
+    style &= ~CClientUIInterface::SECURE;
+
     std::string strCaption;
     // Check for usage of predefined caption
     switch (style) {
@@ -30,7 +33,8 @@ static bool noui_ThreadSafeMessageBox(const std::string& message, const std::str
         strCaption += caption; // Use supplied caption (can be empty)
     }
 
-    LogPrintf("%s: %s\n", strCaption, message);
+    if (!fSecure)
+        LogPrintf("%s: %s\n", strCaption, message);
     fprintf(stderr, "%s: %s\n", strCaption.c_str(), message.c_str());
     return false;
 }

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -992,6 +992,9 @@ void BitcoinGUI::showProgress(const QString &title, int nProgress)
 static bool ThreadSafeMessageBox(BitcoinGUI *gui, const std::string& message, const std::string& caption, unsigned int style)
 {
     bool modal = (style & CClientUIInterface::MODAL);
+    // The SECURE flag has no effect in the Qt GUI.
+    // bool secure = (style & CClientUIInterface::SECURE);
+    style &= ~CClientUIInterface::SECURE;
     bool ret = false;
     // In case of modal message, use blocking connection to wait for user to click a button
     QMetaObject::invokeMethod(gui, "message",

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -581,7 +581,7 @@ void StartRPCThreads()
                 strWhatAmI,
                 GetConfigFile().string(),
                 EncodeBase58(&rand_pwd[0],&rand_pwd[0]+32)),
-                "", CClientUIInterface::MSG_ERROR);
+                "", CClientUIInterface::MSG_ERROR | CClientUIInterface::SECURE);
         StartShutdown();
         return;
     }

--- a/src/ui_interface.h
+++ b/src/ui_interface.h
@@ -63,6 +63,9 @@ public:
         /** Force blocking, modal message box dialog (not just OS notification) */
         MODAL               = 0x10000000U,
 
+        /** Do not print contents of message to debug log */
+        SECURE              = 0x40000000U,
+
         /** Predefined combinations for certain default usage cases */
         MSG_INFORMATION = ICON_INFORMATION,
         MSG_WARNING = (ICON_WARNING | BTN_OK | MODAL),


### PR DESCRIPTION
This keeps the message from being output to the debug log by bitcoind. Fixes a possible security risk when starting bitcoind in server mode without the 'rpcpassword' option configured, resulting in the "suggested" password being output to the debug log.

Fixes #5094.
