### PR TITLE
Add buildenv.py to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,7 @@ Bitcoin-Qt.app
 # Unit-tests
 Makefile.test
 bitcoin-qt_test
+src/test/buildenv.py
 
 # Resources cpp
 qrc_*.cpp


### PR DESCRIPTION
It's generation was added in #5014 as part of the fix for the Windows test runner.
