### PR TITLE
No forking Extra nonce added to Bitcoin header.

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -129,7 +129,8 @@ public:
     unsigned int nStatus;
 
     // block header
-    int nVersion;
+    uint16_t nVersion;
+    uint16_t nNonce2;
     uint256 hashMerkleRoot;
     unsigned int nTime;
     unsigned int nBits;
@@ -154,6 +155,7 @@ public:
         nSequenceId = 0;
 
         nVersion       = 0;
+        nNonce2        = 0;
         hashMerkleRoot = 0;
         nTime          = 0;
         nBits          = 0;
@@ -170,6 +172,7 @@ public:
         SetNull();
 
         nVersion       = block.nVersion;
+        nNonce2        = block.nNonce2;
         hashMerkleRoot = block.hashMerkleRoot;
         nTime          = block.nTime;
         nBits          = block.nBits;
@@ -198,6 +201,7 @@ public:
     {
         CBlockHeader block;
         block.nVersion       = nVersion;
+        block.nNonce2        = nNonce2;
         if (pprev)
             block.hashPrevBlock = pprev->GetBlockHash();
         block.hashMerkleRoot = hashMerkleRoot;
@@ -243,7 +247,7 @@ public:
      * in the last Params().ToCheckBlockUpgradeMajority() blocks, starting at pstart 
      * and going backwards.
      */
-    static bool IsSuperMajority(int minVersion, const CBlockIndex* pstart,
+    static bool IsSuperMajority(uint16_t minVersion, const CBlockIndex* pstart,
                                 unsigned int nRequired);
 
     std::string ToString() const
@@ -318,6 +322,7 @@ public:
 
         // block header
         READWRITE(this->nVersion);
+        READWRITE(this->nNonce2);
         READWRITE(hashPrev);
         READWRITE(hashMerkleRoot);
         READWRITE(nTime);
@@ -329,6 +334,7 @@ public:
     {
         CBlockHeader block;
         block.nVersion        = nVersion;
+        block.nNonce2         = nNonce2;
         block.hashPrevBlock   = hashPrev;
         block.hashMerkleRoot  = hashMerkleRoot;
         block.nTime           = nTime;

--- a/src/core/block.cpp
+++ b/src/core/block.cpp
@@ -111,9 +111,10 @@ uint256 CBlock::CheckMerkleBranch(uint256 hash, const std::vector<uint256>& vMer
 std::string CBlock::ToString() const
 {
     std::stringstream s;
-    s << strprintf("CBlock(hash=%s, ver=%d, hashPrevBlock=%s, hashMerkleRoot=%s, nTime=%u, nBits=%08x, nNonce=%u, vtx=%u)\n",
+    s << strprintf("CBlock(hash=%s, ver=%u, nNonce2=%u, hashPrevBlock=%s, hashMerkleRoot=%s, nTime=%u, nBits=%08x, nNonce=%u, vtx=%u)\n",
         GetHash().ToString(),
         nVersion,
+        nNonce2,
         hashPrevBlock.ToString(),
         hashMerkleRoot.ToString(),
         nTime, nBits, nNonce,

--- a/src/core/block.h
+++ b/src/core/block.h
@@ -21,8 +21,9 @@ class CBlockHeader
 {
 public:
     // header
-    static const int32_t CURRENT_VERSION=2;
-    int32_t nVersion;
+    static const uint16_t CURRENT_VERSION=3;
+    uint16_t nVersion;
+    uint16_t nNonce2;
     uint256 hashPrevBlock;
     uint256 hashMerkleRoot;
     uint32_t nTime;
@@ -40,6 +41,7 @@ public:
     inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
         READWRITE(this->nVersion);
         nVersion = this->nVersion;
+        READWRITE(nNonce2);
         READWRITE(hashPrevBlock);
         READWRITE(hashMerkleRoot);
         READWRITE(nTime);
@@ -50,6 +52,7 @@ public:
     void SetNull()
     {
         nVersion = CBlockHeader::CURRENT_VERSION;
+        nNonce2 = 0;
         hashPrevBlock = 0;
         hashMerkleRoot = 0;
         nTime = 0;
@@ -110,6 +113,7 @@ public:
     {
         CBlockHeader block;
         block.nVersion       = nVersion;
+        block.nNonce2        = nNonce2;
         block.hashPrevBlock  = hashPrevBlock;
         block.hashMerkleRoot = hashMerkleRoot;
         block.nTime          = nTime;

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -62,6 +62,7 @@ Object blockToJSON(const CBlock& block, const CBlockIndex* blockindex)
     result.push_back(Pair("size", (int)::GetSerializeSize(block, SER_NETWORK, PROTOCOL_VERSION)));
     result.push_back(Pair("height", blockindex->nHeight));
     result.push_back(Pair("version", block.nVersion));
+    result.push_back(Pair("nonce2", block.nNonce2));
     result.push_back(Pair("merkleroot", block.hashMerkleRoot.GetHex()));
     Array txs;
     BOOST_FOREACH(const CTransaction&tx, block.vtx)


### PR DESCRIPTION
Block version set to 3.
Unittest included.
Re-define 15 unused bits of the version field as an extra nonce inside the block header.
Accompanied and explained by a BIP, see wiki (https://github.com/BlockheaderNonce2/bitcoin/wiki).
Not forking.
Backwards compatible with GBT clients that are not aware of this.

Timo Hanke & Sergio Lerner
