### PR TITLE
Bugfix: submitblock: Use a temporary CValidationState to determine accurately the outcome of ProcessBlock

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -148,8 +148,16 @@ void RegisterNodeSignals(CNodeSignals& nodeSignals);
 /** Unregister a network node */
 void UnregisterNodeSignals(CNodeSignals& nodeSignals);
 
-/** Process an incoming block */
-bool ProcessBlock(CValidationState &state, CNode* pfrom, CBlock* pblock, CDiskBlockPos *dbp = NULL);
+/** Process an incoming block. This only returns after the best known valid
+    block is made active. Note that it does not, however, guarantee that the
+    specific block passed to it has been checked for validity!
+    @param[out]  state   This may be set to an Error state if any error occurred processing it, including during validation/connection/etc of otherwise unrelated blocks during reorganisation; or it may be set to an Invalid state iff pblock is itself invalid (but this is not guaranteed even when the block is checked). If you want to *possibly* get feedback on whether pblock is valid, you must also install a CValidationInterface - this will have its BlockChecked method called whenever *any* block completes validation.
+    @param[in]   pfrom   The node which we are receiving the block from; it is added to mapBlockSource and may be penalised if the block is invalid.
+    @param[in]   pblock  The block we want to process.
+    @param[out]  dbp     If pblock is stored to disk (or already there), this will be set to its location.
+    @return True if state.IsValid()
+*/
+bool ProcessNewBlock(CValidationState &state, CNode* pfrom, CBlock* pblock, CDiskBlockPos *dbp = NULL);
 /** Check whether enough disk space is available for an incoming block */
 bool CheckDiskSpace(uint64_t nAdditionalBytes = 0);
 /** Open a block file (blk?????.dat) */

--- a/src/main.h
+++ b/src/main.h
@@ -648,6 +648,7 @@ protected:
     virtual void UpdatedTransaction(const uint256 &hash) {};
     virtual void Inventory(const uint256 &hash) {};
     virtual void ResendWalletTransactions() {};
+    virtual void BlockChecked(const CBlock&, const CValidationState&) {};
     friend void ::RegisterValidationInterface(CValidationInterface*);
     friend void ::UnregisterValidationInterface(CValidationInterface*);
     friend void ::UnregisterAllValidationInterfaces();

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -425,8 +425,8 @@ bool ProcessBlockFound(CBlock* pblock, CWallet& wallet, CReserveKey& reservekey)
 
     // Process this block the same as if we had received it from another node
     CValidationState state;
-    if (!ProcessBlock(state, NULL, pblock))
-        return error("BitcoinMiner : ProcessBlock, block not accepted");
+    if (!ProcessNewBlock(state, NULL, pblock))
+        return error("BitcoinMiner : ProcessNewBlock, block not accepted");
 
     return true;
 }

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -526,6 +526,24 @@ Value getblocktemplate(const Array& params, bool fHelp)
     return result;
 }
 
+class submitblock_StateCatcher : public CValidationInterface
+{
+public:
+    uint256 hash;
+    bool found;
+    CValidationState state;
+
+    submitblock_StateCatcher(const uint256 &hashIn) : hash(hashIn), found(false), state() {};
+
+protected:
+    virtual void BlockChecked(const CBlock& block, const CValidationState& stateIn) {
+        if (block.GetHash() != hash)
+            return;
+        found = true;
+        state = stateIn;
+    };
+};
+
 Value submitblock(const Array& params, bool fHelp)
 {
     if (fHelp || params.size() < 1 || params.size() > 2)
@@ -558,8 +576,22 @@ Value submitblock(const Array& params, bool fHelp)
     }
 
     CValidationState state;
+    submitblock_StateCatcher sc(pblock.GetHash());
+    RegisterValidationInterface(&sc);
     bool fAccepted = ProcessBlock(state, NULL, &pblock);
-    if (!fAccepted)
+    UnregisterValidationInterface(&sc);
+    if (fAccepted)
+    {
+        if (!sc.found)
+            return "inconclusive";
+        state = sc.state;
+    }
+    if (state.IsError())
+    {
+        std::string strRejectReason = state.GetRejectReason();
+        throw JSONRPCError(RPC_MISC_ERROR, strRejectReason);
+    }
+    if (state.IsInvalid())
         return "rejected"; // TODO: report validation state
 
     return Value::null;

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -578,7 +578,7 @@ Value submitblock(const Array& params, bool fHelp)
     CValidationState state;
     submitblock_StateCatcher sc(pblock.GetHash());
     RegisterValidationInterface(&sc);
-    bool fAccepted = ProcessBlock(state, NULL, &pblock);
+    bool fAccepted = ProcessNewBlock(state, NULL, &pblock);
     UnregisterValidationInterface(&sc);
     if (fAccepted)
     {

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -589,7 +589,7 @@ Value submitblock(const Array& params, bool fHelp)
     if (state.IsError())
     {
         std::string strRejectReason = state.GetRejectReason();
-        throw JSONRPCError(RPC_MISC_ERROR, strRejectReason);
+        throw JSONRPCError(RPC_VERIFY_ERROR, strRejectReason);
     }
     if (state.IsInvalid())
         return "rejected"; // TODO: report validation state

--- a/src/rpcprotocol.h
+++ b/src/rpcprotocol.h
@@ -49,9 +49,14 @@ enum RPCErrorCode
     RPC_INVALID_PARAMETER           = -8,  // Invalid, missing or duplicate parameter
     RPC_DATABASE_ERROR              = -20, // Database error
     RPC_DESERIALIZATION_ERROR       = -22, // Error parsing or validating structure in raw format
-    RPC_TRANSACTION_ERROR           = -25, // General error during transaction submission
-    RPC_TRANSACTION_REJECTED        = -26, // Transaction was rejected by network rules
-    RPC_TRANSACTION_ALREADY_IN_CHAIN= -27, // Transaction already in chain
+    RPC_VERIFY_ERROR                = -25, // General error during transaction or block submission
+    RPC_VERIFY_REJECTED             = -26, // Transaction or block was rejected by network rules
+    RPC_VERIFY_ALREADY_IN_CHAIN     = -27, // Transaction already in chain
+
+    // Aliases for backward compatibility
+    RPC_TRANSACTION_ERROR           = RPC_VERIFY_ERROR,
+    RPC_TRANSACTION_REJECTED        = RPC_VERIFY_REJECTED,
+    RPC_TRANSACTION_ALREADY_IN_CHAIN= RPC_VERIFY_ALREADY_IN_CHAIN,
 
     // P2P client errors
     RPC_CLIENT_NOT_CONNECTED        = -9,  // Bitcoin is not connected

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -79,7 +79,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
         pblock->hashMerkleRoot = pblock->BuildMerkleTree();
         pblock->nNonce = blockinfo[i].nonce;
         CValidationState state;
-        BOOST_CHECK(ProcessBlock(state, NULL, pblock));
+        BOOST_CHECK(ProcessNewBlock(state, NULL, pblock));
         BOOST_CHECK(state.IsValid());
         pblock->hashPrevBlock = pblock->GetHash();
     }


### PR DESCRIPTION
Fixes #5083 (based on #5105)
