### PR TITLE
CAutoFile: Explicit Get(), IsNull() and remove unused methods

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -139,7 +139,7 @@ void Shutdown()
     {
         boost::filesystem::path est_path = GetDataDir() / FEE_ESTIMATES_FILENAME;
         CAutoFile est_fileout(fopen(est_path.string().c_str(), "wb"), SER_DISK, CLIENT_VERSION);
-        if (est_fileout)
+        if (!est_fileout.IsNull())
             mempool.WriteFeeEstimates(est_fileout);
         else
             LogPrintf("%s: Failed to write fee estimates to %s\n", __func__, est_path.string());
@@ -1064,7 +1064,7 @@ bool AppInit2(boost::thread_group& threadGroup)
     boost::filesystem::path est_path = GetDataDir() / FEE_ESTIMATES_FILENAME;
     CAutoFile est_filein(fopen(est_path.string().c_str(), "rb"), SER_DISK, CLIENT_VERSION);
     // Allowed to fail as this file IS missing on first startup.
-    if (est_filein)
+    if (!est_filein.IsNull())
         mempool.ReadFeeEstimates(est_filein);
     fFeeEstimatesInitialized = true;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1106,7 +1106,7 @@ bool WriteBlockToDisk(CBlock& block, CDiskBlockPos& pos)
 {
     // Open history file to append
     CAutoFile fileout(OpenBlockFile(pos), SER_DISK, CLIENT_VERSION);
-    if (!fileout)
+    if (fileout.IsNull())
         return error("WriteBlockToDisk : OpenBlockFile failed");
 
     // Write index header
@@ -1134,7 +1134,7 @@ bool ReadBlockFromDisk(CBlock& block, const CDiskBlockPos& pos)
 
     // Open history file to read
     CAutoFile filein(OpenBlockFile(pos, true), SER_DISK, CLIENT_VERSION);
-    if (!filein)
+    if (filein.IsNull())
         return error("ReadBlockFromDisk : OpenBlockFile failed");
 
     // Read block
@@ -4548,7 +4548,7 @@ bool CBlockUndo::WriteToDisk(CDiskBlockPos &pos, const uint256 &hashBlock)
 {
     // Open history file to append
     CAutoFile fileout(OpenUndoFile(pos), SER_DISK, CLIENT_VERSION);
-    if (!fileout)
+    if (fileout.IsNull())
         return error("CBlockUndo::WriteToDisk : OpenUndoFile failed");
 
     // Write index header
@@ -4580,7 +4580,7 @@ bool CBlockUndo::ReadFromDisk(const CDiskBlockPos &pos, const uint256 &hashBlock
 {
     // Open history file to read
     CAutoFile filein(OpenUndoFile(pos, true), SER_DISK, CLIENT_VERSION);
-    if (!filein)
+    if (filein.IsNull())
         return error("CBlockUndo::ReadFromDisk : OpenBlockFile failed");
 
     // Read block

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1051,7 +1051,7 @@ bool GetTransaction(const uint256 &hash, CTransaction &txOut, uint256 &hashBlock
                 CBlockHeader header;
                 try {
                     file >> header;
-                    fseek(file, postx.nTxOffset, SEEK_CUR);
+                    fseek(file.Get(), postx.nTxOffset, SEEK_CUR);
                     file >> txOut;
                 } catch (std::exception &e) {
                     return error("%s : Deserialize or I/O error - %s", __func__, e.what());
@@ -1114,16 +1114,16 @@ bool WriteBlockToDisk(CBlock& block, CDiskBlockPos& pos)
     fileout << FLATDATA(Params().MessageStart()) << nSize;
 
     // Write block
-    long fileOutPos = ftell(fileout);
+    long fileOutPos = ftell(fileout.Get());
     if (fileOutPos < 0)
         return error("WriteBlockToDisk : ftell failed");
     pos.nPos = (unsigned int)fileOutPos;
     fileout << block;
 
     // Flush stdio buffers and commit to disk before returning
-    fflush(fileout);
+    fflush(fileout.Get());
     if (!IsInitialBlockDownload())
-        FileCommit(fileout);
+        FileCommit(fileout.Get());
 
     return true;
 }
@@ -2843,7 +2843,7 @@ bool static LoadBlockIndexDB()
     for (std::set<int>::iterator it = setBlkDataFiles.begin(); it != setBlkDataFiles.end(); it++)
     {
         CDiskBlockPos pos(*it, 0);
-        if (!CAutoFile(OpenBlockFile(pos, true), SER_DISK, CLIENT_VERSION)) {
+        if (CAutoFile(OpenBlockFile(pos, true), SER_DISK, CLIENT_VERSION).IsNull()) {
             return false;
         }
     }
@@ -4556,7 +4556,7 @@ bool CBlockUndo::WriteToDisk(CDiskBlockPos &pos, const uint256 &hashBlock)
     fileout << FLATDATA(Params().MessageStart()) << nSize;
 
     // Write undo data
-    long fileOutPos = ftell(fileout);
+    long fileOutPos = ftell(fileout.Get());
     if (fileOutPos < 0)
         return error("CBlockUndo::WriteToDisk : ftell failed");
     pos.nPos = (unsigned int)fileOutPos;
@@ -4569,9 +4569,9 @@ bool CBlockUndo::WriteToDisk(CDiskBlockPos &pos, const uint256 &hashBlock)
     fileout << hasher.GetHash();
 
     // Flush stdio buffers and commit to disk before returning
-    fflush(fileout);
+    fflush(fileout.Get());
     if (!IsInitialBlockDownload())
-        FileCommit(fileout);
+        FileCommit(fileout.Get());
 
     return true;
 }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1939,7 +1939,7 @@ bool CAddrDB::Write(const CAddrMan& addr)
     catch (std::exception &e) {
         return error("%s : Serialize or I/O error - %s", __func__, e.what());
     }
-    FileCommit(fileout);
+    FileCommit(fileout.Get());
     fileout.fclose();
 
     // replace existing peers.dat, if any, with new peers.dat.XXXX

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1929,7 +1929,7 @@ bool CAddrDB::Write(const CAddrMan& addr)
     boost::filesystem::path pathTmp = GetDataDir() / tmpfn;
     FILE *file = fopen(pathTmp.string().c_str(), "wb");
     CAutoFile fileout(file, SER_DISK, CLIENT_VERSION);
-    if (!fileout)
+    if (fileout.IsNull())
         return error("%s : Failed to open file %s", __func__, pathTmp.string());
 
     // Write and commit header, data
@@ -1954,7 +1954,7 @@ bool CAddrDB::Read(CAddrMan& addr)
     // open input file, and associate with CAutoFile
     FILE *file = fopen(pathAddr.string().c_str(), "rb");
     CAutoFile filein(file, SER_DISK, CLIENT_VERSION);
-    if (!filein)
+    if (filein.IsNull())
         return error("%s : Failed to open file %s", __func__, pathAddr.string());
 
     // use file size to size memory buffer

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -1116,14 +1116,21 @@ public:
         }
     }
 
+    /** Get wrapped FILE* with transfer of ownership.
+     * @note This will invalidate the CAutoFile object, and makes it the responsibility of the caller
+     * of this function to clean up the returned FILE*.
+     */
     FILE* release()             { FILE* ret = file; file = NULL; return ret; }
-    operator FILE*()            { return file; }
-    FILE* operator->()          { return file; }
-    FILE& operator*()           { return *file; }
-    FILE** operator&()          { return &file; }
-    FILE* operator=(FILE* pnew) { return file = pnew; }
-    bool IsNull() const         { return (file == NULL); }
 
+    /** Get wrapped FILE* without transfer of ownership.
+     * @note Ownership of the FILE* will remain with this class. Use this only if the scope of the
+     * CAutoFile outlives use of the passed pointer.
+     */
+    FILE* Get() const           { return file; }
+
+    /** Return true if the wrapped FILE* is NULL, false otherwise.
+     */
+    bool IsNull() const         { return (file == NULL); }
 
     //
     // Stream subset

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -1122,7 +1122,7 @@ public:
     FILE& operator*()           { return *file; }
     FILE** operator&()          { return &file; }
     FILE* operator=(FILE* pnew) { return file = pnew; }
-    bool operator!()            { return (file == NULL); }
+    bool IsNull() const         { return (file == NULL); }
 
 
     //

--- a/src/test/checkblock_tests.cpp
+++ b/src/test/checkblock_tests.cpp
@@ -36,7 +36,7 @@ bool read_block(const std::string& filename, CBlock& block)
     fseek(fp, 8, SEEK_SET); // skip msgheader/size
 
     CAutoFile filein(fp, SER_DISK, CLIENT_VERSION);
-    if (!filein) return false;
+    if (filein.IsNull()) return false;
 
     filein >> block;
 


### PR DESCRIPTION
Continues #5089 `Add IsNull() to class CAutoFile and remove operator !` by @rdponticelli, which was missing a few uses of `!`. This also removes operator FILE*, in favor of an explicit Get().

Without the "magical" behaviour, this makes CAutoFile more like a standard scoped_ptr<>, except that it wraps a FILE\* instead of an object, and that it adds serialize stream functionality.
