### PR TITLE
Fixes for missing boost tuple.hpp header include.

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -17,6 +17,7 @@
 #endif
 
 #include <boost/thread.hpp>
+#include <boost/tuple/tuple.hpp>
 
 using namespace std;
 

--- a/src/test/bloom_tests.cpp
+++ b/src/test/bloom_tests.cpp
@@ -14,6 +14,7 @@
 #include <vector>
 
 #include <boost/test/unit_test.hpp>
+#include <boost/tuple/tuple.hpp>
 
 using namespace std;
 using namespace boost::tuples;


### PR DESCRIPTION
Doesn't build without these on older fedora system.
