### PR TITLE
Build util and common before building server

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -36,13 +36,15 @@ LIBBITCOIN_CRYPTO=crypto/libbitcoin_crypto.a
 LIBBITCOIN_UNIVALUE=univalue/libbitcoin_univalue.a
 LIBBITCOINQT=qt/libbitcoinqt.a
 
+# Make is not made aware of per-object dependencies to avoid limiting building parallelization
+# But to build the less dependent modules first, we manually select their order here:
 noinst_LIBRARIES = \
-  libbitcoin_server.a \
-  libbitcoin_common.a \
-  libbitcoin_cli.a \
+  crypto/libbitcoin_crypto.a \
   libbitcoin_util.a \
+  libbitcoin_common.a \
   univalue/libbitcoin_univalue.a \
-  crypto/libbitcoin_crypto.a
+  libbitcoin_server.a \
+  libbitcoin_cli.a
 if ENABLE_WALLET
 BITCOIN_INCLUDES += $(BDB_CPPFLAGS)
 noinst_LIBRARIES += libbitcoin_wallet.a


### PR DESCRIPTION
If after compile one introduces errores in say, chainparams, make will compile main before founding the errors.
This change doesn't guarantee that the dependencies will compiled in the correct order, but it's a short term solution for convenience.
