### PR TITLE
[Qt] Remove CAmount from BitcoinAmountField Q_PROPERTY

### DIFF
--- a/src/qt/bitcoinamountfield.h
+++ b/src/qt/bitcoinamountfield.h
@@ -21,7 +21,9 @@ class BitcoinAmountField: public QWidget
 {
     Q_OBJECT
 
-    Q_PROPERTY(CAmount value READ value WRITE setValue NOTIFY valueChanged USER true)
+    // ugly hack: for some unknown reason CAmount (instead of qint64) does not work here as expected
+    // discussion: https://github.com/bitcoin/bitcoin/pull/5117
+    Q_PROPERTY(qint64 value READ value WRITE setValue NOTIFY valueChanged USER true)
 
 public:
     explicit BitcoinAmountField(QWidget *parent = 0);


### PR DESCRIPTION
Fixes a bug, currently the fee field in the optionsdialog is always empty.
