### PR TITLE
Show NodeId in misbehaving debug messages

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1282,12 +1282,11 @@ void Misbehaving(NodeId pnode, int howmuch)
 
     state->nMisbehavior += howmuch;
     int banscore = GetArg("-banscore", 100);
-    if (state->nMisbehavior >= banscore && state->nMisbehavior - howmuch < banscore)
-    {
-        LogPrintf("Misbehaving: %s (%d -> %d) BAN THRESHOLD EXCEEDED\n", state->name, state->nMisbehavior-howmuch, state->nMisbehavior);
+    if (state->nMisbehavior >= banscore && state->nMisbehavior - howmuch < banscore) {
+        LogPrintf("Misbehaving: peer=%d (%d -> %d) BAN THRESHOLD EXCEEDED\n", state->id, state->nMisbehavior-howmuch, state->nMisbehavior);
         state->fShouldBan = true;
     } else
-        LogPrintf("Misbehaving: %s (%d -> %d)\n", state->name, state->nMisbehavior-howmuch, state->nMisbehavior);
+        LogPrintf("Misbehaving: peer=%d (%d -> %d)\n", state->id, state->nMisbehavior-howmuch, state->nMisbehavior);
 }
 
 void static InvalidChainFound(CBlockIndex* pindexNew)


### PR DESCRIPTION
Not quite ready to pull yet, as needs a few lines from commit 7c76839072bf84e493ab2c88c2726ffaae5e2154 first...
