### PR TITLE
--tracerpc option for regression tests

### DIFF
--- a/qa/rpc-tests/test_framework.py
+++ b/qa/rpc-tests/test_framework.py
@@ -48,8 +48,14 @@ class BitcoinTestFramework(object):
                           help="Source directory containing bitcoind/bitcoin-cli (default: %default%)")
         parser.add_option("--tmpdir", dest="tmpdir", default=tempfile.mkdtemp(prefix="test"),
                           help="Root directory for datadirs")
+        parser.add_option("--tracerpc", dest="trace_rpc", default=False, action="store_true",
+                          help="Print out all RPC calls as they are made")
         self.add_options(parser)
         (self.options, self.args) = parser.parse_args()
+
+        if self.options.trace_rpc:
+            import logging
+            logging.basicConfig(level=logging.DEBUG)
 
         os.environ['PATH'] = self.options.srcdir+":"+os.environ['PATH']
 


### PR DESCRIPTION
Run tests with --tracerpc and all RPC calls will dump to the console.
Very helpful for debugging.
