### PR TITLE
regtest : specify timestamp of created blocks

### DIFF
--- a/src/miner.h
+++ b/src/miner.h
@@ -17,7 +17,7 @@ class CWallet;
 struct CBlockTemplate;
 
 /** Run the miner threads */
-void GenerateBitcoins(bool fGenerate, CWallet* pwallet, int nThreads);
+void GenerateBitcoins(bool fGenerate, CWallet* pwallet, int nThreads, uint32_t nBlockTime=0);
 /** Generate a new block, without valid proof-of-work */
 CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn);
 CBlockTemplate* CreateNewBlockWithKey(CReserveKey& reservekey);

--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -28,6 +28,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "getaddednodeinfo", 0 },
     { "setgenerate", 0 },
     { "setgenerate", 1 },
+    { "setgenerate", 2 }, // -regtest only argument
     { "getnetworkhashps", 0 },
     { "getnetworkhashps", 1 },
     { "sendtoaddress", 1 },

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -12,6 +12,7 @@
 #include "miner.h"
 #include "pow.h"
 #include "rpcserver.h"
+#include "timedata.h"
 #include "util.h"
 #ifdef ENABLE_WALLET
 #include "db.h"
@@ -111,7 +112,9 @@ Value getgenerate(const Array& params, bool fHelp)
 
 Value setgenerate(const Array& params, bool fHelp)
 {
-    if (fHelp || params.size() < 1 || params.size() > 2)
+    size_t nMaxArgs = Params().MineBlocksOnDemand() ? 3 : 2;
+
+    if (fHelp || params.size() < 1 || params.size() > nMaxArgs)
         throw runtime_error(
             "setgenerate generate ( genproclimit )\n"
             "\nSet 'generate' true or false to turn generation on or off.\n"
@@ -121,6 +124,9 @@ Value setgenerate(const Array& params, bool fHelp)
             "1. generate         (boolean, required) Set to true to turn on generation, off to turn off.\n"
             "2. genproclimit     (numeric, optional) Set the processor limit for when generation is on. Can be -1 for unlimited.\n"
             "                    Note: in -regtest mode, genproclimit controls how many blocks are generated immediately.\n"
+            "3. blocktimestamp   (numeric, -regtest only) Create blocks with given timestamp.\n"
+            "\nResult\n"
+            "[ blockhashes ]     (array, -regtest only) hashes of blocks generated\n"
             "\nExamples:\n"
             "\nSet the generation on with a limit of one processor\n"
             + HelpExampleCli("setgenerate", "true 1") +
@@ -154,6 +160,13 @@ Value setgenerate(const Array& params, bool fHelp)
         int nHeightEnd = 0;
         int nHeight = 0;
         int nGenerate = (nGenProcLimit > 0 ? nGenProcLimit : 1);
+        uint64_t nFirstBlockTime = (params.size() > 2 ? params[2].get_int64() : 0);
+        // Block times must be after the genesis block time, and not more than 2 hours in the future:
+        uint64_t nMinTime = Params().GenesisBlock().nTime + 1;
+        uint64_t nMaxTime = GetAdjustedTime() + 2 * 60 * 60 - Params().TargetSpacing()*nGenerate;
+        if (nFirstBlockTime > 0 && (nFirstBlockTime < nMinTime || nFirstBlockTime > nMaxTime))
+            throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("block time out of range: %d to %d", nMinTime, nMaxTime));
+
         {   // Don't keep cs_main locked
             LOCK(cs_main);
             nHeightStart = chainActive.Height();
@@ -163,10 +176,17 @@ Value setgenerate(const Array& params, bool fHelp)
         int nHeightLast = -1;
         while (nHeight < nHeightEnd)
         {
+            // if given block time, simulate 10-minute-apart blocks
+            uint64_t nBlockTime = 0;
+            if (nFirstBlockTime > 0)
+            {
+                nBlockTime = nFirstBlockTime + Params().TargetSpacing()*(nHeight-nHeightStart);
+            }
+
             if (nHeightLast != nHeight)
             {
                 nHeightLast = nHeight;
-                GenerateBitcoins(fGenerate, pwalletMain, 1);
+                GenerateBitcoins(fGenerate, pwalletMain, 1, (uint32_t)nBlockTime);
             }
             MilliSleep(1);
             {   // Don't keep cs_main locked
@@ -174,6 +194,13 @@ Value setgenerate(const Array& params, bool fHelp)
                 nHeight = chainActive.Height();
             }
         }
+        Array blockHashes;
+        {
+            LOCK(cs_main);
+            for (int i = nHeightStart+1; i <= nHeightEnd; i++)
+                blockHashes.push_back(chainActive[i]->GetBlockHash().GetHex());
+        }
+        return blockHashes;
     }
     else // Not -regtest: start generate thread, return immediately
     {


### PR DESCRIPTION
Add a third parameter to setgenerate in -regtest mode that sets the timestamp for created blocks.

Also returns the hashes of blocks created in -regtest mode instead of null (only possible in regtest mode, because the RPC calls waits until the blocks are generated before returning).

I decided to submit this as a separate pull request because I'm in the middle of writing a couple of regression tests that depend on it.
