### PR TITLE
consensus lib work: Separate protocol versioning from clientversion

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-src/version.cpp export-subst
+src/clientversion.cpp export-subst

--- a/Makefile.am
+++ b/Makefile.am
@@ -36,7 +36,7 @@ COVERAGE_INFO = baseline_filtered_combined.info baseline.info block_test.info \
 dist-hook:
 	-$(MAKE) -C $(top_distdir)/src/leveldb clean
 	-$(MAKE) -C $(top_distdir)/src/secp256k1 distclean
-	-$(GIT) archive --format=tar HEAD -- src/version.cpp | $(AMTAR) -C $(top_distdir) -xf -
+	-$(GIT) archive --format=tar HEAD -- src/clientversion.cpp | $(AMTAR) -C $(top_distdir) -xf -
 
 distcheck-hook:
 	$(MKDIR_P) $(top_distdir)/_build/src/leveldb

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -146,7 +146,7 @@ obj/build.h: FORCE
 	@$(MKDIR_P) $(builddir)/obj
 	@$(top_srcdir)/share/genbuild.sh $(abs_top_builddir)/src/obj/build.h \
 	  $(abs_top_srcdir)
-libbitcoin_util_a-version.$(OBJEXT): obj/build.h
+libbitcoin_util_a-clientversion.$(OBJEXT): obj/build.h
 
 # server: shared between bitcoind and bitcoin-qt
 libbitcoin_server_a_CPPFLAGS = $(BITCOIN_INCLUDES) $(MINIUPNPC_CPPFLAGS)
@@ -241,6 +241,7 @@ libbitcoin_util_a_SOURCES = \
   compat/glibc_sanity.cpp \
   compat/glibcxx_sanity.cpp \
   chainparamsbase.cpp \
+  clientversion.cpp \
   random.cpp \
   rpcprotocol.cpp \
   sync.cpp \
@@ -249,7 +250,6 @@ libbitcoin_util_a_SOURCES = \
   utilstrencodings.cpp \
   utilmoneystr.cpp \
   utiltime.cpp \
-  version.cpp \
   $(BITCOIN_CORE_H)
 
 if GLIBC_BACK_COMPAT
@@ -354,7 +354,7 @@ clean-local:
 
 .rc.o:
 	@test -f $(WINDRES)
-	$(AM_V_GEN) $(WINDRES) -i $< -o $@
+	$(AM_V_GEN) $(WINDRES) -DWINDRES_PREPROC -i $< -o $@
 
 .mm.o:
 	$(AM_V_CXX) $(OBJCXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) \

--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -6,6 +6,7 @@
 #include "alert.h"
 
 #include "chainparams.h"
+#include "clientversion.h"
 #include "key.h"
 #include "net.h"
 #include "timedata.h"

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -4,12 +4,12 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "chainparamsbase.h"
+#include "clientversion.h"
 #include "init.h"
 #include "rpcclient.h"
 #include "rpcprotocol.h"
 #include "util.h"
 #include "utilstrencodings.h"
-#include "version.h"
 
 #include <boost/filesystem/operations.hpp>
 

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "base58.h"
+#include "clientversion.h"
 #include "core/transaction.h"
 #include "core_io.h"
 #include "keystore.h"

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -3,6 +3,7 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include "clientversion.h"
 #include "rpcserver.h"
 #include "init.h"
 #include "main.h"

--- a/src/clientversion.cpp
+++ b/src/clientversion.cpp
@@ -2,7 +2,7 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include "version.h"
+#include "clientversion.h"
 
 #include "tinyformat.h"
 

--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -35,4 +35,31 @@
 // Copyright string used in Windows .rc files
 #define COPYRIGHT_STR "2009-" STRINGIZE(COPYRIGHT_YEAR) " The Bitcoin Core Developers"
 
+/*
+  bitcoind-res.rc includes this file, but it cannot cope with real c++ code.
+  WINDRES_PREPROC is defined to indicate that its pre-processor is running.
+  Anything other than a define should be guarded below.
+*/
+
+#if !defined(WINDRES_PREPROC)
+
+#include <string>
+#include <vector>
+
+static const int CLIENT_VERSION =
+                           1000000 * CLIENT_VERSION_MAJOR
+                         +   10000 * CLIENT_VERSION_MINOR
+                         +     100 * CLIENT_VERSION_REVISION
+                         +       1 * CLIENT_VERSION_BUILD;
+
+extern const std::string CLIENT_NAME;
+extern const std::string CLIENT_BUILD;
+extern const std::string CLIENT_DATE;
+
+
+std::string FormatFullVersion();
+std::string FormatSubVersion(const std::string& name, int nClientVersion, const std::vector<std::string>& comments);
+
+#endif // WINDRES_PREPROC
+
 #endif // CLIENTVERSION_H

--- a/src/db.h
+++ b/src/db.h
@@ -6,6 +6,7 @@
 #ifndef BITCOIN_DB_H
 #define BITCOIN_DB_H
 
+#include "clientversion.h"
 #include "serialize.h"
 #include "streams.h"
 #include "sync.h"

--- a/src/leveldbwrapper.h
+++ b/src/leveldbwrapper.h
@@ -5,6 +5,7 @@
 #ifndef BITCOIN_LEVELDBWRAPPER_H
 #define BITCOIN_LEVELDBWRAPPER_H
 
+#include "clientversion.h"
 #include "serialize.h"
 #include "streams.h"
 #include "util.h"

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -11,6 +11,7 @@
 
 #include "addrman.h"
 #include "chainparams.h"
+#include "clientversion.h"
 #include "core/transaction.h"
 #include "ui_interface.h"
 

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -10,6 +10,7 @@
 #include "alert.h"
 #include "chainparams.h"
 #include "checkpoints.h"
+#include "clientversion.h"
 #include "main.h"
 #include "net.h"
 #include "ui_interface.h"

--- a/src/qt/recentrequeststablemodel.cpp
+++ b/src/qt/recentrequeststablemodel.cpp
@@ -5,6 +5,7 @@
 #include "recentrequeststablemodel.h"
 
 #include "bitcoinunits.h"
+#include "clientversion.h"
 #include "guiutil.h"
 #include "optionsmodel.h"
 #include "streams.h"

--- a/src/qt/utilitydialog.cpp
+++ b/src/qt/utilitydialog.cpp
@@ -10,8 +10,8 @@
 #include "clientmodel.h"
 #include "guiutil.h"
 
+#include "clientversion.h"
 #include "init.h"
-#include "version.h"
 
 #include <stdio.h>
 

--- a/src/rpcmisc.cpp
+++ b/src/rpcmisc.cpp
@@ -4,6 +4,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "base58.h"
+#include "clientversion.h"
 #include "init.h"
 #include "main.h"
 #include "net.h"

--- a/src/rpcnet.cpp
+++ b/src/rpcnet.cpp
@@ -4,6 +4,7 @@
 
 #include "rpcserver.h"
 
+#include "clientversion.h"
 #include "main.h"
 #include "net.h"
 #include "netbase.h"

--- a/src/rpcprotocol.cpp
+++ b/src/rpcprotocol.cpp
@@ -5,6 +5,7 @@
 
 #include "rpcprotocol.h"
 
+#include "clientversion.h"
 #include "tinyformat.h"
 #include "util.h"
 #include "utilstrencodings.h"

--- a/src/test/alert_tests.cpp
+++ b/src/test/alert_tests.cpp
@@ -7,13 +7,13 @@
 //
 
 #include "alert.h"
+#include "clientversion.h"
 #include "data/alertTests.raw.h"
 
 #include "serialize.h"
 #include "streams.h"
 #include "util.h"
 #include "utilstrencodings.h"
-#include "version.h"
 
 #include <fstream>
 

--- a/src/test/bloom_tests.cpp
+++ b/src/test/bloom_tests.cpp
@@ -5,6 +5,7 @@
 #include "bloom.h"
 
 #include "base58.h"
+#include "clientversion.h"
 #include "key.h"
 #include "main.h"
 #include "serialize.h"

--- a/src/test/checkblock_tests.cpp
+++ b/src/test/checkblock_tests.cpp
@@ -8,6 +8,7 @@
 
 
 
+#include "clientversion.h"
 #include "main.h"
 #include "utiltime.h"
 

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -5,6 +5,7 @@
 #include "data/tx_invalid.json.h"
 #include "data/tx_valid.json.h"
 
+#include "clientversion.h"
 #include "key.h"
 #include "keystore.h"
 #include "main.h"

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -4,12 +4,12 @@
 
 #include "util.h"
 
+#include "clientversion.h"
 #include "core/transaction.h"
 #include "random.h"
 #include "sync.h"
 #include "utilstrencodings.h"
 #include "utilmoneystr.h"
-#include "version.h"
 
 #include <stdint.h>
 #include <vector>

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -5,6 +5,7 @@
 
 #include "txmempool.h"
 
+#include "clientversion.h"
 #include "streams.h"
 #include "util.h"
 #include "utilmoneystr.h"

--- a/src/version.h
+++ b/src/version.h
@@ -5,25 +5,6 @@
 #ifndef BITCOIN_VERSION_H
 #define BITCOIN_VERSION_H
 
-#include "clientversion.h"
-
-#include <string>
-#include <vector>
-
-//
-// client versioning
-//
-
-static const int CLIENT_VERSION =
-                           1000000 * CLIENT_VERSION_MAJOR
-                         +   10000 * CLIENT_VERSION_MINOR
-                         +     100 * CLIENT_VERSION_REVISION
-                         +       1 * CLIENT_VERSION_BUILD;
-
-extern const std::string CLIENT_NAME;
-extern const std::string CLIENT_BUILD;
-extern const std::string CLIENT_DATE;
-
 //
 // network protocol versioning
 //
@@ -52,8 +33,5 @@ static const int BIP0031_VERSION = 60000;
 
 // "mempool" command, enhanced "getdata" behavior starts with this version
 static const int MEMPOOL_GD_VERSION = 60002;
-
-std::string FormatFullVersion();
-std::string FormatSubVersion(const std::string& name, int nClientVersion, const std::vector<std::string>& comments);
 
 #endif // BITCOIN_VERSION_H


### PR DESCRIPTION
As subject implies. Libs need to be aware of the protocol version. Together with #5162, this is the last of the big code movement for the lib for 0.10.

This is move-only. Git even detects the file movement, so this one is easy enough to verify via the web interface.
