### PR TITLE
Don't relay alerts to peers before version negotiation

### DIFF
--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -127,6 +127,9 @@ bool CAlert::RelayTo(CNode* pnode) const
 {
     if (!IsInEffect())
         return false;
+    // don't relay to nodes which haven't sent their version message
+    if (pnode->nVersion == 0)
+        return false;
     // returns true if wasn't already contained in the set
     if (pnode->setKnown.insert(GetHash()).second)
     {


### PR DESCRIPTION
Fixes #1436.

Sending alert messages before the negotiation breaks protocol, causing them to be ignored as well as the sending peer to receive a Misbehaving score. This also erroneously prevents the alert from being sent again after version negotiation as it will be already in CNode::setKnown.
