### PR TITLE
Correct mistakes in #4377 and #4796

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -217,11 +217,6 @@ public:
         return (int64_t)nTime;
     }
 
-    uint256 GetBlockWork() const
-    {
-        return GetProofIncrement(nBits);
-    }
-
     enum { nMedianTimeSpan=11 };
 
     int64_t GetMedianTimePast() const

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1205,7 +1205,7 @@ void CheckForkWarningConditions()
     if (pindexBestForkTip && chainActive.Height() - pindexBestForkTip->nHeight >= 72)
         pindexBestForkTip = NULL;
 
-    if (pindexBestForkTip || (pindexBestInvalid && pindexBestInvalid->nChainWork > chainActive.Tip()->nChainWork + (chainActive.Tip()->GetBlockWork() * 6)))
+    if (pindexBestForkTip || (pindexBestInvalid && pindexBestInvalid->nChainWork > chainActive.Tip()->nChainWork + (GetBlockProof(*chainActive.Tip()) * 6)))
     {
         if (!fLargeWorkForkFound)
         {
@@ -1256,7 +1256,7 @@ void CheckForkWarningConditionsOnNewFork(CBlockIndex* pindexNewForkTip)
     // We define it this way because it allows us to only store the highest fork tip (+ base) which meets
     // the 7-block condition and from this always have the most-likely-to-cause-warning fork
     if (pfork && (!pindexBestForkTip || (pindexBestForkTip && pindexNewForkTip->nHeight > pindexBestForkTip->nHeight)) &&
-            pindexNewForkTip->nChainWork - pfork->nChainWork > (pfork->GetBlockWork() * 7) &&
+            pindexNewForkTip->nChainWork - pfork->nChainWork > (GetBlockProof(*pfork) * 7) &&
             chainActive.Height() - pindexNewForkTip->nHeight < 72)
     {
         pindexBestForkTip = pindexNewForkTip;
@@ -2095,7 +2095,7 @@ CBlockIndex* AddToBlockIndex(const CBlockHeader& block)
         pindexNew->nHeight = pindexNew->pprev->nHeight + 1;
         pindexNew->BuildSkip();
     }
-    pindexNew->nChainWork = (pindexNew->pprev ? pindexNew->pprev->nChainWork : 0) + pindexNew->GetBlockWork();
+    pindexNew->nChainWork = (pindexNew->pprev ? pindexNew->pprev->nChainWork : 0) + GetBlockProof(*pindexNew);
     pindexNew->RaiseValidity(BLOCK_VALID_TREE);
     if (pindexBestHeader == NULL || pindexBestHeader->nChainWork < pindexNew->nChainWork)
         pindexBestHeader = pindexNew;
@@ -2788,7 +2788,7 @@ bool static LoadBlockIndexDB()
     BOOST_FOREACH(const PAIRTYPE(int, CBlockIndex*)& item, vSortedByHeight)
     {
         CBlockIndex* pindex = item.second;
-        pindex->nChainWork = (pindex->pprev ? pindex->pprev->nChainWork : 0) + pindex->GetBlockWork();
+        pindex->nChainWork = (pindex->pprev ? pindex->pprev->nChainWork : 0) + GetBlockProof(*pindex);
         if (pindex->nStatus & BLOCK_HAVE_DATA) {
             if (pindex->pprev) {
                 if (pindex->pprev->nChainTx) {

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -12,6 +12,7 @@
 #include "main.h"
 #include "net.h"
 #include "pow.h"
+#include "timedata.h"
 #include "util.h"
 #include "utilmoneystr.h"
 #ifdef ENABLE_WALLET
@@ -77,6 +78,15 @@ public:
         }
     }
 };
+
+void UpdateTime(CBlockHeader* pblock, const CBlockIndex* pindexPrev)
+{
+    pblock->nTime = std::max(pindexPrev->GetMedianTimePast()+1, GetAdjustedTime());
+
+    // Updating time can change work required on testnet:
+    if (Params().AllowMinDifficultyBlocks())
+        pblock->nBits = GetNextWorkRequired(pindexPrev, pblock);
+}
 
 CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn)
 {

--- a/src/miner.h
+++ b/src/miner.h
@@ -9,6 +9,7 @@
 #include <stdint.h>
 
 class CBlock;
+class CBlockHeader;
 class CBlockIndex;
 class CReserveKey;
 class CScript;
@@ -25,6 +26,7 @@ CBlockTemplate* CreateNewBlockWithKey(CReserveKey& reservekey);
 void IncrementExtraNonce(CBlock* pblock, CBlockIndex* pindexPrev, unsigned int& nExtraNonce);
 /** Check mined block */
 bool CheckWork(CBlock* pblock, CWallet& wallet, CReserveKey& reservekey);
+void UpdateTime(CBlockHeader* block, const CBlockIndex* pindexPrev);
 
 extern double dHashesPerSec;
 extern int64_t nHPSTimerStart;

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -97,12 +97,12 @@ bool CheckProofOfWork(uint256 hash, unsigned int nBits)
     return true;
 }
 
-uint256 GetProofIncrement(unsigned int nBits)
+uint256 GetBlockProof(const CBlockIndex& block)
 {
     uint256 bnTarget;
     bool fNegative;
     bool fOverflow;
-    bnTarget.SetCompact(nBits, &fNegative, &fOverflow);
+    bnTarget.SetCompact(block.nBits, &fNegative, &fOverflow);
     if (fNegative || fOverflow || bnTarget == 0)
         return 0;
     // We need to compute 2**256 / (bnTarget+1), but we can't represent 2**256

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -5,10 +5,9 @@
 
 #include "pow.h"
 
+#include "chain.h"
 #include "chainparams.h"
 #include "core/block.h"
-#include "main.h"
-#include "timedata.h"
 #include "uint256.h"
 #include "util.h"
 
@@ -96,15 +95,6 @@ bool CheckProofOfWork(uint256 hash, unsigned int nBits)
         return error("CheckProofOfWork() : hash doesn't match nBits");
 
     return true;
-}
-
-void UpdateTime(CBlockHeader* pblock, const CBlockIndex* pindexPrev)
-{
-    pblock->nTime = std::max(pindexPrev->GetMedianTimePast()+1, GetAdjustedTime());
-
-    // Updating time can change work required on testnet:
-    if (Params().AllowMinDifficultyBlocks())
-        pblock->nBits = GetNextWorkRequired(pindexPrev, pblock);
 }
 
 uint256 GetProofIncrement(unsigned int nBits)

--- a/src/pow.h
+++ b/src/pow.h
@@ -16,7 +16,6 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHead
 
 /** Check whether a block hash satisfies the proof-of-work requirement specified by nBits */
 bool CheckProofOfWork(uint256 hash, unsigned int nBits);
-
-uint256 GetProofIncrement(unsigned int nBits);
+uint256 GetBlockProof(const CBlockIndex& block);
 
 #endif // BITCOIN_POW_H

--- a/src/pow.h
+++ b/src/pow.h
@@ -17,8 +17,6 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHead
 /** Check whether a block hash satisfies the proof-of-work requirement specified by nBits */
 bool CheckProofOfWork(uint256 hash, unsigned int nBits);
 
-void UpdateTime(CBlockHeader* block, const CBlockIndex* pindexPrev);
-
 uint256 GetProofIncrement(unsigned int nBits);
 
 #endif // BITCOIN_POW_H


### PR DESCRIPTION
1) In c2c02f3fa99385f5a5be722fda6f71522c93bdaa, UpdateTime() should have moved to miner.cpp directly instead of pow.o.
2) After #4796, pow.cpp doesn't depend on main.h but on chain.h.
3) In b343c1a1e34f851e70649ad1f49855a7d878f9ef, there was no need to conserve   CBlockIndex::GetBlockWork() as facade.

I'm sorry and I want to fix it.
