### PR TITLE
Fix -loadblock after partial IBD and init after kill -9

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3142,6 +3142,8 @@ bool LoadExternalBlockFile(FILE* fileIn, CDiskBlockPos *dbp)
                         nLoaded++;
                     if (state.IsError())
                         break;
+                } else if (hash != Params().HashGenesisBlock() && mapBlockIndex[hash]->nHeight % 1000 == 0) {
+                    LogPrintf("Block Import: already had block %s at height %d\n", hash.ToString(), mapBlockIndex[hash]->nHeight);
                 }
 
                 // Recursively process earlier encountered successors of this block

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3136,7 +3136,7 @@ bool LoadExternalBlockFile(FILE* fileIn, CDiskBlockPos *dbp)
                 }
 
                 // process in case the block isn't known yet
-                if (mapBlockIndex.count(hash) == 0) {
+                if (mapBlockIndex.count(hash) == 0 || (mapBlockIndex[hash]->nStatus & BLOCK_HAVE_DATA) == 0) {
                     CValidationState state;
                     if (ProcessBlock(state, NULL, &block, dbp))
                         nLoaded++;


### PR DESCRIPTION
You can currently kill -9 during IBD and will not be able to restart.
Also, if you let IBD start and then try to -loadblock afterwards it will not connect any of the blocks.
