### PR TITLE
RFC: Remove logging from script interpreter

### DIFF
--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -12,7 +12,6 @@
 #include "key.h"
 #include "script/script.h"
 #include "uint256.h"
-#include "util.h"
 
 using namespace std;
 
@@ -38,8 +37,6 @@ inline bool set_error(ScriptError* ret, const ScriptError serror = SCRIPT_UNKNOW
 {
     if (ret)
         *ret = serror;
-    if (serror != UNKNOWN_ERROR)
-        return error(ScriptErrorString(serror));
     return false;
 }
 
@@ -989,14 +986,12 @@ public:
 uint256 SignatureHash(const CScript& scriptCode, const CTransaction& txTo, unsigned int nIn, int nHashType)
 {
     if (nIn >= txTo.vin.size()) {
-        LogPrintf("ERROR: SignatureHash() : nIn=%d out of range\n", nIn);
         return 1;
     }
 
     // Check for invalid use of SIGHASH_SINGLE
     if ((nHashType & 0x1f) == SIGHASH_SINGLE) {
         if (nIn >= txTo.vout.size()) {
-            LogPrintf("ERROR: SignatureHash() : nOut=%d out of range\n", nIn);
             return 1;
         }
     }

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -58,7 +58,38 @@ enum
     SCRIPT_VERIFY_MINIMALDATA = (1U << 6)
 };
 
+enum ScriptError
+{
+    SCRIPT_NO_ERROR = 0,
+    SCRIPT_UNKNOWN_ERROR,
+    PUBKEY_TOO_SHORT,
+    PUBKEY_BAD_UNCOMPRESSED_LENGTH,
+    PUBKEY_BAD_COMPRESSED_LENGTH,
+    PUBKEY_UNKNOWN_LENGTH,
+    SIG_TOO_SHORT,
+    SIG_TOO_LONG,
+    SIG_BAD_TYPE,
+    SIG_BAD_LENGTH_MARKER,
+    SIG_S_LENGTH_MISPLACED,
+    SIG_R_S_LENGTH_MISMATCH,
+    SIG_R_TYPE_MISMATCH,
+    SIG_R_ZERO_LENGTH,
+    SIG_R_NEGATIVE,
+    SIG_R_EXCESSIVE_PADDING,
+    SIG_S_TOO_HIGH,
+    SIG_S_TYPE_MISMATCH,
+    SIG_S_ZERO_LENGTH,
+    SIG_S_NEGATIVE,
+    SIG_S_EXCESSIVE_PADDING,
+    SIG_BAD_HASHTYPE,
+    SIG_CHECKMULTISIG_DUMMY_NONNULL,
+    SIG_BAD,
+    SCRIPT_ERROR_COUNT
+};
+
 uint256 SignatureHash(const CScript &scriptCode, const CTransaction& txTo, unsigned int nIn, int nHashType);
+
+const char* ScriptErrorString(ScriptError error);
 
 class BaseSignatureChecker
 {
@@ -85,7 +116,7 @@ public:
     bool CheckSig(const std::vector<unsigned char>& scriptSig, const std::vector<unsigned char>& vchPubKey, const CScript& scriptCode) const;
 };
 
-bool EvalScript(std::vector<std::vector<unsigned char> >& stack, const CScript& script, unsigned int flags, const BaseSignatureChecker& checker);
-bool VerifyScript(const CScript& scriptSig, const CScript& scriptPubKey, unsigned int flags, const BaseSignatureChecker& checker);
+bool EvalScript(std::vector<std::vector<unsigned char> >& stack, const CScript& script, unsigned int flags, const BaseSignatureChecker& checker, ScriptError* error = NULL);
+bool VerifyScript(const CScript& scriptSig, const CScript& scriptPubKey, unsigned int flags, const BaseSignatureChecker& checker, ScriptError* error = NULL);
 
 #endif // H_BITCOIN_SCRIPT_INTERPRETER


### PR DESCRIPTION
I believe this is on-par feature-wise with what's in master, but it's incomplete as far as error codes go.

As suggested by @gmaxwell and @sipa, remove logging in favor of well-defined error codes for the script interpreter. This is necessary for the consensus lib, in order to remove the last bits of application state (along with #5162).

Every possible exit path of EvalScript() sets a ScriptError to indicate if/why it failed. I quickly enumerated the cases that had existing log messages, but the rest still need to be filled in. For every undefined failure, SCRIPT_UNKNOWN_ERROR is returned. It's important to keep in mind that these values will be part of the lib's stable external API, so it's necessary to put some thought into how they're defined.

Before continuing, I'd like to know that others are comfortable with this approach.
