### PR TITLE
Check whether C++ compiler works.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -24,6 +24,13 @@ case $host in
   ;;
 esac
 
+if test "x${CXXFLAGS+set}" = "xset"; then
+  CXXFLAGS_overridden=yes
+else
+  CXXFLAGS_overridden=no
+fi
+
+AC_PROG_CXX
 LT_INIT([disable-shared])
 
 AH_TOP([#ifndef BITCOIN_CONFIG_H])
@@ -40,12 +47,6 @@ m4_include([pkg.m4])
 dnl faketime breaks configure and is only needed for make. Disable it here.
 unset FAKETIME
 
-if test "x${CXXFLAGS+set}" = "xset"; then
-  CXXFLAGS_overridden=yes
-else
-  CXXFLAGS_overridden=no
-fi
-
 dnl ==============================================================
 dnl Setup for automake
 dnl ==============================================================
@@ -60,7 +61,6 @@ dnl make the compilation flags quiet unless V=1 is used
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
 dnl Checks for programs.
-AC_PROG_CXX
 AC_PROG_CC
 AC_PROG_CPP
 AC_PROG_CXXCPP


### PR DESCRIPTION
The macro AC_PROG_CXX doesn't really check whether the C++ compiler works (compare with AC_PROG_CC). This change adds a new local macro AC_PROG_CXX_WORKS that is really checking whether C++ compiler works. See #5177.
If there is no C++ compiler installed, configure prints

checking whether the C++ compiler works... no
configure: error: C++ compiler doesn't work.
