### PR TITLE
Remove file and class order guidelines

### DIFF
--- a/doc/coding.md
+++ b/doc/coding.md
@@ -12,20 +12,6 @@ gradually.
   - No indentation for public/protected/private or for namespaces.
   - No extra spaces inside parenthesis; don't do ( this )
   - No space after function names; one space after if, for and while.
-- Includes need to be ordered alphabetically, separate own and foreign headers with a new-line (example key.cpp):
-```c++
-#include "key.h"
-
-#include "crypto/sha2.h"
-#include "util.h"
-
-#include <openssl/foo.h>
-```
-- Class or struct keywords in header files need to be ordered alphabetically:
-```c++
-class CAlpha;
-class CBeta;
-```
 
 Block style example:
 ```c++


### PR DESCRIPTION
These cause too much nagging that make comments about correctness go lost in the noise.
