### PR TITLE
minor update to not select base params twice in a row

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -369,7 +369,6 @@ bool SelectParamsFromCommandLine()
     if (network == CBaseChainParams::MAX_NETWORK_TYPES)
         return false;
 
-    SelectBaseParams(network);
     SelectParams(network);
     return true;
 }


### PR DESCRIPTION
The first thing that SelectParams does is call SelectBaseParams. Therefore, we do not need to call SelectBaseParams immediately prior to calling SelectParams.
