### PR TITLE
CCoinsViewMemPool cleanup

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -940,7 +940,6 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
 
         CAmount nValueIn = 0;
         {
-        LOCK(pool.cs);
         CCoinsViewMemPool viewMemPool(pcoinsTip, pool);
         view.SetBackend(viewMemPool);
 

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -381,11 +381,9 @@ Value gettxout(const Array& params, bool fHelp)
 
     CCoins coins;
     if (fMempool) {
-        LOCK(mempool.cs);
         CCoinsViewMemPool view(pcoinsTip, mempool);
         if (!view.GetCoins(hash, coins))
             return Value::null;
-        mempool.pruneSpent(hash, coins); // TODO: this should be done by the CCoinsViewMemPool
     } else {
         if (!pcoinsTip->GetCoins(hash, coins))
             return Value::null;

--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -562,7 +562,6 @@ Value signrawtransaction(const Array& params, bool fHelp)
     CCoinsView viewDummy;
     CCoinsViewCache view(&viewDummy);
     {
-        LOCK(mempool.cs);
         CCoinsViewCache &viewChain = *pcoinsTip;
         CCoinsViewMemPool viewMempool(&viewChain, mempool);
         view.SetBackend(viewMempool); // temporarily switch cache backend to db+mempool view

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -157,6 +157,7 @@ public:
 class CCoinsViewMemPool : public CCoinsViewBacked
 {
 protected:
+    CCriticalBlock criticalBlock;
     CTxMemPool &mempool;
 
 public:


### PR DESCRIPTION
Move the mempool lock into CCoinsViewMemPool, since the existing code
always manually locks the mempool (with the lock having same lifetime
as the view!).

Move a call to CMempool::pruneSpent into CCoinsViewMemPool::GetCoins,
since CCoinsViewMemPool::GetCoins is called only once in the codebase,
followed by a call to pruneSpent with a `TODO` suggesting it be moved.
