### PR TITLE
bitcoin-tx: Add the "-txid" option and add hex-encoded transaction to JSON

### DIFF
--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -57,6 +57,7 @@ static bool AppInitRawTx(int argc, char* argv[])
         strUsage += "  -?                      " + _("This help message") + "\n";
         strUsage += "  -create                 " + _("Create new, empty TX.") + "\n";
         strUsage += "  -json                   " + _("Select JSON output") + "\n";
+        strUsage += "  -txid                   " + _("Output only the hex-encoded transaction id of the resultant transaction.") + "\n";
         strUsage += "  -regtest                " + _("Enter regression test mode, which uses a special chain in which blocks can be solved instantly.") + "\n";
         strUsage += "  -testnet                " + _("Use the test network") + "\n";
         strUsage += "\n";
@@ -488,6 +489,13 @@ static void OutputTxJSON(const CTransaction& tx)
     fprintf(stdout, "%s\n", jsonOutput.c_str());
 }
 
+static void OutputTxHash(const CTransaction& tx)
+{
+    string strHexHash = tx.GetHash().GetHex(); // the hex-encoded transaction hash (aka the transaction id)
+
+    fprintf(stdout, "%s\n", strHexHash.c_str());
+}
+
 static void OutputTxHex(const CTransaction& tx)
 {
     string strHex = EncodeHexTx(tx);
@@ -499,6 +507,8 @@ static void OutputTx(const CTransaction& tx)
 {
     if (GetBoolArg("-json", false))
         OutputTxJSON(tx);
+    else if (GetBoolArg("-txid", false))
+        OutputTxHash(tx);
     else
         OutputTxHex(tx);
 }

--- a/src/core_write.cpp
+++ b/src/core_write.cpp
@@ -129,4 +129,6 @@ void TxToUniv(const CTransaction& tx, const uint256& hashBlock, UniValue& entry)
 
     if (hashBlock != 0)
         entry.pushKV("blockhash", hashBlock.GetHex());
+
+    entry.pushKV("hex", EncodeHexTx(tx)); // the hex-encoded transaction. used the name "hex" to be consistent with the verbose output of "getrawtransaction".
 }


### PR DESCRIPTION
Add option to include computed transaction hash in output when hex-encoding is selected.

The hash gets output already for JSON.

When selected, the hex tx hash will be output on another line so as to not break things that are already scripted to the output of this utility.
