### PR TITLE
depends: boost: hard-code hidden symbol visibility

### DIFF
--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -21,6 +21,7 @@ $(package)_archiver_$(host_os)=$($(package)_ar)
 $(package)_toolset_darwin=darwin
 $(package)_archiver_darwin=$($(package)_libtool)
 $(package)_config_libraries=chrono,filesystem,program_options,system,thread,test
+$(package)_cxxflags=-fvisibility=hidden
 $(package)_cxxflags_x86_64_linux=-fPIC
 $(package)_cxxflags_arm_linux=-fPIC
 endef


### PR DESCRIPTION
tl;dr: This solves boost visibility problems for default/release build configs
on non-Linux platforms.

When Bitcoin builds against boost's header-only classes, it ends up with
objects containing symbols that the upstream boost libs also have. Since
Bitcoin builds by default with hidden symbol visibility, it can end up trying
to link against a copy of the same symbols with default visibility.
This is not a problem on Linux because 3rd party static libs are un-exported
by default (--exclude-libs,ALL), but that is not available for MinGW and OSX.

Those platforms (and maybe others?) end up confused about which version to use.

The OSX linker spews hundreds of: "ld: warning: direct access in <foo> to
global weak symbol guard variable for <bar> means the weak symbol cannot be
overridden at runtime. This was likely caused by different translation units
being compiled with different visibility settings."

MinGW's linker complains similarly.

Since the default symbol visibility for Bitcoin is hidden and releases are
built that way as well, build Boost with hidden visibility. Linux builds Boost
this way also, but only for the sake of continuity.

This means that the linker confusion logic is reversed, so the problem will
will now be encountered if Bitcoin is built with --disable-reduce-exports, but
that's better than the current situation.
