### PR TITLE
Makebootstrap

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -344,10 +344,15 @@ std::string HelpMessage(HelpMessageMode mode)
     }
     strUsage += "  -shrinkdebugfile       " + _("Shrink debug.log file on client startup (default: 1 when no -debug)") + "\n";
     strUsage += "  -testnet               " + _("Use the test network") + "\n";
+    strUsage += "  -makebootstrap=<file>  " + _("Create a bootstrap file") + "\n";
 
     strUsage += "\n" + _("Node relay options:") + "\n";
     strUsage += "  -datacarrier           " + strprintf(_("Relay and mine data carrier transactions (default: %u)"), 1) + "\n";
     strUsage += "  -datacarriersize       " + strprintf(_("Maximum size of data in data carrier transactions we relay and mine (default: %u)"), MAX_OP_RETURN_RELAY) + "\n";
+
+    strUsage += "\n" + _("Bootstrap creation options:") + "\n";
+    strUsage += "  -bootstrapmin=<n>      " + strprintf(_("Set minimum height for bootstrap (default: %u)"), 1) + "\n";
+    strUsage += "  -bootstrapmax=<n>      " + _("Set maximum height for bootstrap (default: latest height)") + "\n";
 
     strUsage += "\n" + _("Block creation options:") + "\n";
     strUsage += "  -blockminsize=<n>      " + strprintf(_("Set minimum block size in bytes (default: %u)"), 0) + "\n";
@@ -1053,6 +1058,21 @@ bool AppInit2(boost::thread_group& threadGroup)
     {
         PrintBlockTree();
         return false;
+    }
+
+    if (mapArgs.count("-mkbootstrap"))
+    {
+        string strBootstrap = GetArg("-mkbootstrap", "bootstrap.new.dat");
+
+        int nMaxHeight = GetArg("-bootstrapmax", chainActive.Height());
+        if (nMaxHeight < 1 || nMaxHeight > chainActive.Height())
+            return InitError(_("Max block number out of range"));
+
+        int nMinHeight = GetArg("-bootstrapmin", 1);
+        if (nMinHeight < 1 || nMinHeight > chainActive.Height())
+            return InitError(_("Min block number out of range"));
+
+        return MakeBootstrap(strBootstrap, nMinHeight, nMaxHeight);
     }
 
     if (mapArgs.count("-printblock"))

--- a/src/main.h
+++ b/src/main.h
@@ -175,6 +175,8 @@ bool InitBlockIndex();
 bool LoadBlockIndex();
 /** Unload database information */
 void UnloadBlockIndex();
+/** Make a bootstrap file */
+bool MakeBootstrap(std::string strBootstrap, int nMinHeight, int nMaxHeight);
 /** Print the loaded block tree */
 void PrintBlockTree();
 /** Process protocol messages received from a given node */
@@ -444,6 +446,7 @@ public:
 
 /** Functions for disk access for blocks */
 bool WriteBlockToDisk(CBlock& block, CDiskBlockPos& pos);
+bool WriteBlockToDisk(CBlock& block, CAutoFile& fileout, CDiskBlockPos& pos);
 bool ReadBlockFromDisk(CBlock& block, const CDiskBlockPos& pos);
 bool ReadBlockFromDisk(CBlock& block, const CBlockIndex* pindex);
 

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -269,6 +269,7 @@ static const CRPCCommand vRPCCommands[] =
     { "blockchain",         "gettxout",               &gettxout,               true,      false,      false },
     { "blockchain",         "gettxoutsetinfo",        &gettxoutsetinfo,        true,      false,      false },
     { "blockchain",         "verifychain",            &verifychain,            true,      false,      false },
+    { "blockchain",         "makebootstrap",          &makebootstrap,          true,      false,      false },
 
     /* Mining */
     { "mining",             "getblocktemplate",       &getblocktemplate,       true,      false,      false },

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -217,5 +217,6 @@ extern json_spirit::Value gettxoutsetinfo(const json_spirit::Array& params, bool
 extern json_spirit::Value gettxout(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value verifychain(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value getchaintips(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value makebootstrap(const json_spirit::Array& params, bool fHelp);
 
 #endif // BITCOIN_RPCSERVER_H

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -435,6 +435,15 @@ void ClearDatadirCache()
     pathCachedNetSpecific = boost::filesystem::path();
 }
 
+boost::filesystem::path GetCustomFile(const std::string& strArg)
+{
+    boost::filesystem::path pathCustomFile(strArg);
+    if (!pathCustomFile.is_complete())
+        pathCustomFile = GetDataDir(false) / pathCustomFile;
+
+    return pathCustomFile;
+}
+
 boost::filesystem::path GetConfigFile()
 {
     boost::filesystem::path pathConfigFile(GetArg("-conf", "bitcoin.conf"));

--- a/src/util.h
+++ b/src/util.h
@@ -92,6 +92,7 @@ bool RenameOver(boost::filesystem::path src, boost::filesystem::path dest);
 bool TryCreateDirectory(const boost::filesystem::path& p);
 boost::filesystem::path GetDefaultDataDir();
 const boost::filesystem::path &GetDataDir(bool fNetSpecific = true);
+boost::filesystem::path GetCustomFile(const std::string& strArg);
 boost::filesystem::path GetConfigFile();
 #ifndef WIN32
 boost::filesystem::path GetPidFile();


### PR DESCRIPTION
Hi,

i had to export bootstrap file from some favorite altcoins. There is already an export script, but that is very slow, because blocks are queried from rpc. So i added some funcions to the coin's codebase, so the bootstrap export is accelerated by this. I want to share my code.

The are two commit in this push: one made the export by running the daemon/wallet. the second allow made the bootstrap in a running daemon/wallet.

The command line parameter required a filename or filepath. The bootstrap data is exported to this file. There are another two helper parameter, this allow exporting a part of the blockchain: the first blocks (minheight) and the last blocks (maxheight).

The rpc command do the same: require a filename/filepath parameter, and the optional first/last blockheight.
If no first/last are given, the whole blockchain is exported (1..bestblockheight).

If you like this feature, feel free to give some notes.

Note: the rpc exporting sould made by a separete thread, but i dont know how to modify the [TraceThread](https://github.com/bitcoin/bitcoin/blob/master/src/util.h#L200) function to pass parameter(s).
