### PR TITLE
Qt: Add support for missing scrollbar in peers table

### DIFF
--- a/src/qt/forms/rpcconsole.ui
+++ b/src/qt/forms/rpcconsole.ui
@@ -689,7 +689,7 @@
        <item row="0" column="0" rowspan="2">
         <widget class="QTableView" name="peerWidget">
          <property name="horizontalScrollBarPolicy">
-          <enum>Qt::ScrollBarAlwaysOff</enum>
+          <enum>Qt::ScrollBarAsNeeded</enum>
          </property>
          <property name="sortingEnabled">
           <bool>true</bool>


### PR DESCRIPTION
I just checked the peers window and could not find a horizontal scroll bar.
This commit should fix this and show scrollbar whenever they make sense.
