### PR TITLE
Chainparams: Generic chainparam selection with -chain=<strNetworkID>

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -135,6 +135,7 @@ BITCOIN_CORE_H = \
   support/pagelocker.h \
   sync.h \
   threadsafety.h \
+  templates.hpp \
   timedata.h \
   tinyformat.h \
   txdb.h \

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -84,7 +84,7 @@ static bool AppInitRPC(int argc, char* argv[])
         fprintf(stderr,"Error reading configuration file: %s\n", e.what());
         return false;
     }
-    // Check for -testnet or -regtest parameter (BaseParams() calls are only valid after this clause)
+    // Check for -chain, -testnet or -regtest parameter (BaseParams() calls are only valid after this clause)
     try {
         SelectBaseParamsFromCommandLine();
     } catch(std::exception &e) {

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -85,8 +85,10 @@ static bool AppInitRPC(int argc, char* argv[])
         return false;
     }
     // Check for -testnet or -regtest parameter (BaseParams() calls are only valid after this clause)
-    if (!SelectBaseParamsFromCommandLine()) {
-        fprintf(stderr, "Error: Invalid combination of -regtest and -testnet.\n");
+    try {
+        SelectBaseParamsFromCommandLine();
+    } catch(std::exception &e) {
+        fprintf(stderr, "Error: %s\n", e.what());
         return false;
     }
     return true;

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -22,9 +22,7 @@ std::string HelpMessageCli()
     strUsage += HelpMessageOpt("-?", _("This help message"));
     strUsage += HelpMessageOpt("-conf=<file>", strprintf(_("Specify configuration file (default: %s)"), "bitcoin.conf"));
     strUsage += HelpMessageOpt("-datadir=<dir>", _("Specify data directory"));
-    strUsage += HelpMessageOpt("-testnet", _("Use the test network"));
-    strUsage += HelpMessageOpt("-regtest", _("Enter regression test mode, which uses a special chain in which blocks can be "
-                                             "solved instantly. This is intended for regression testing tools and app development."));
+    strUsage += GetParamsHelpMessages();
     strUsage += HelpMessageOpt("-rpcconnect=<ip>", strprintf(_("Send commands to node running on <ip> (default: %s)"), "127.0.0.1"));
     strUsage += HelpMessageOpt("-rpcport=<port>", strprintf(_("Connect to JSON-RPC on <port> (default: %u or testnet: %u)"), 8332, 18332));
     strUsage += HelpMessageOpt("-rpcwait", _("Wait for RPC server to start"));

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -34,8 +34,10 @@ static bool AppInitRawTx(int argc, char* argv[])
     ParseParameters(argc, argv);
 
     // Check for -testnet or -regtest parameter (Params() calls are only valid after this clause)
-    if (!SelectParamsFromCommandLine()) {
-        fprintf(stderr, "Error: Invalid combination of -regtest and -testnet.\n");
+    try {
+        SelectParamsFromCommandLine();
+    } catch(std::exception &e) {
+        fprintf(stderr, "Error: %s\n", e.what());
         return false;
     }
 

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -57,8 +57,7 @@ static bool AppInitRawTx(int argc, char* argv[])
         strUsage += HelpMessageOpt("-create", _("Create new, empty TX."));
         strUsage += HelpMessageOpt("-json", _("Select JSON output"));
         strUsage += HelpMessageOpt("-txid", _("Output only the hex-encoded transaction id of the resultant transaction."));
-        strUsage += HelpMessageOpt("-regtest", _("Enter regression test mode, which uses a special chain in which blocks can be solved instantly."));
-        strUsage += HelpMessageOpt("-testnet", _("Use the test network"));
+        strUsage += GetParamsHelpMessages();
 
         fprintf(stdout, "%s", strUsage.c_str());
 

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -33,7 +33,7 @@ static bool AppInitRawTx(int argc, char* argv[])
     //
     ParseParameters(argc, argv);
 
-    // Check for -testnet or -regtest parameter (Params() calls are only valid after this clause)
+    // Check for -chain, -testnet or -regtest parameter (Params() calls are only valid after this clause)
     try {
         SelectParamsFromCommandLine();
     } catch(std::exception &e) {

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -102,8 +102,10 @@ bool AppInit(int argc, char* argv[])
             return false;
         }
         // Check for -testnet or -regtest parameter (Params() calls are only valid after this clause)
-        if (!SelectParamsFromCommandLine()) {
-            fprintf(stderr, "Error: Invalid combination of -regtest and -testnet.\n");
+        try {
+            SelectParamsFromCommandLine();
+        } catch(std::exception &e) {
+            fprintf(stderr, "Error: %s\n", e.what());
             return false;
         }
 

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -101,7 +101,7 @@ bool AppInit(int argc, char* argv[])
             fprintf(stderr,"Error reading configuration file: %s\n", e.what());
             return false;
         }
-        // Check for -testnet or -regtest parameter (Params() calls are only valid after this clause)
+        // Check for -chain, -testnet or -regtest parameter (Params() calls are only valid after this clause)
         try {
             SelectParamsFromCommandLine();
         } catch(std::exception &e) {

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -16,6 +16,13 @@ using namespace std;
 
 #include "chainparamsseeds.h"
 
+const std::map<std::string, uint256> CChainParams::supportedChains =
+    boost::assign::map_list_of
+    ( "main", uint256S("0x000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"))
+    ( "test", uint256S("0x000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943"))
+    ( "regtest", uint256S("0x0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206"))
+    ;
+
 /**
  * Main network
  */
@@ -80,8 +87,7 @@ public:
         genesis.nNonce   = 2083236893;
 
         consensus.hashGenesisBlock = genesis.GetHash();
-        assert(consensus.hashGenesisBlock == uint256S("0x000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"));
-        assert(genesis.hashMerkleRoot == uint256S("0x4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"));
+        assert(consensus.hashGenesisBlock == supportedChains.find(strNetworkID)->second);
 
         vSeeds.push_back(CDNSSeedData("bitcoin.sipa.be", "seed.bitcoin.sipa.be")); // Pieter Wuille
         vSeeds.push_back(CDNSSeedData("bluematt.me", "dnsseed.bluematt.me")); // Matt Corallo
@@ -107,6 +113,7 @@ public:
 
         checkpointData = (Checkpoints::CCheckpointData) {
             boost::assign::map_list_of
+            (     0, consensus.hashGenesisBlock)
             ( 11111, uint256S("0x0000000069e244f73d78e8fd29ba2fd2ed618bd6fa2ee92559f542fdb26e7c1d"))
             ( 33333, uint256S("0x000000002dd5588a74784eaa7ab0507a18ad16a236e7b1ce69f00d7ddfb5d0a6"))
             ( 74000, uint256S("0x0000000000573993a3c9e41ce34471c079dcf5f52a0e824a81e7f953b8661a20"))
@@ -153,7 +160,7 @@ public:
         genesis.nTime = 1296688602;
         genesis.nNonce = 414098458;
         consensus.hashGenesisBlock = genesis.GetHash();
-        assert(consensus.hashGenesisBlock == uint256S("0x000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943"));
+        assert(consensus.hashGenesisBlock == supportedChains.find(strNetworkID)->second);
 
         vFixedSeeds.clear();
         vSeeds.clear();
@@ -179,6 +186,7 @@ public:
 
         checkpointData = (Checkpoints::CCheckpointData) {
             boost::assign::map_list_of
+            (     0, consensus.hashGenesisBlock)
             ( 546, uint256S("000000002a936ca763904c3c35fce2f3556c559c0214345d31b1bcebf76acb70")),
             1337966069,
             1488,
@@ -210,8 +218,8 @@ public:
         genesis.nBits = 0x207fffff;
         genesis.nNonce = 2;
         consensus.hashGenesisBlock = genesis.GetHash();
+        assert(consensus.hashGenesisBlock == supportedChains.find(strNetworkID)->second);
         nDefaultPort = 18444;
-        assert(consensus.hashGenesisBlock == uint256S("0x0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206"));
         nPruneAfterHeight = 1000;
 
         vFixedSeeds.clear(); //! Regtest mode doesn't have any fixed seeds.
@@ -226,7 +234,7 @@ public:
 
         checkpointData = (Checkpoints::CCheckpointData){
             boost::assign::map_list_of
-            ( 0, uint256S("0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206")),
+            (     0, consensus.hashGenesisBlock),
             0,
             0,
             0

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -38,7 +38,7 @@ const std::map<std::string, uint256> CChainParams::supportedChains =
 class CMainParams : public CChainParams {
 public:
     CMainParams() {
-        strNetworkID = "main";
+        strNetworkID = CBaseChainParams::MAIN;
         consensus.nSubsidyHalvingInterval = 210000;
         consensus.nMajorityEnforceBlockUpgrade = 750;
         consensus.nMajorityRejectBlockOutdated = 950;
@@ -143,7 +143,7 @@ static CMainParams mainParams;
 class CTestNetParams : public CMainParams {
 public:
     CTestNetParams() {
-        strNetworkID = "test";
+        strNetworkID = CBaseChainParams::TESTNET;
         consensus.nMajorityEnforceBlockUpgrade = 51;
         consensus.nMajorityRejectBlockOutdated = 75;
         consensus.nMajorityWindow = 100;
@@ -204,7 +204,7 @@ static CTestNetParams testNetParams;
 class CRegTestParams : public CTestNetParams {
 public:
     CRegTestParams() {
-        strNetworkID = "regtest";
+        strNetworkID = CBaseChainParams::REGTEST;
         consensus.nSubsidyHalvingInterval = 150;
         consensus.nMajorityEnforceBlockUpgrade = 750;
         consensus.nMajorityRejectBlockOutdated = 950;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -5,6 +5,7 @@
 
 #include "chainparams.h"
 
+#include "templates.hpp"
 #include "tinyformat.h"
 #include "util.h"
 #include "utilstrencodings.h"
@@ -135,7 +136,6 @@ public:
         };
     }
 };
-static CMainParams mainParams;
 
 /**
  * Testnet (v3)
@@ -196,7 +196,6 @@ public:
 
     }
 };
-static CTestNetParams testNetParams;
 
 /**
  * Regression test
@@ -242,30 +241,35 @@ public:
         };
     }
 };
-static CRegTestParams regTestParams;
 
-static CChainParams *pCurrentParams = 0;
+static Container<CChainParams> currentParams;
+static Container<CChainParams> switchingParams;
 
 const CChainParams &Params() {
-    assert(pCurrentParams);
-    return *pCurrentParams;
+    return currentParams.Get();
 }
 
-CChainParams& Params(std::string chain)
+CChainParams* ParamsFactory(std::string chain)
 {
     if (chain == CBaseChainParams::MAIN)
-            return mainParams;
+        return new CMainParams();
     else if (chain == CBaseChainParams::TESTNET)
-            return testNetParams;
+        return new CTestNetParams();
     else if (chain == CBaseChainParams::REGTEST)
-            return regTestParams;
+        return new CRegTestParams();
     throw std::runtime_error(strprintf(_("%s: Unknown chain %s."), __func__, chain));
+}
+
+const CChainParams& Params(std::string chain)
+{
+    switchingParams.Set(ParamsFactory(chain));
+    return switchingParams.Get();
 }
 
 void SelectParams(std::string chain)
 {
     SelectBaseParams(chain);
-    pCurrentParams = &Params(chain);
+    currentParams.Set(ParamsFactory(chain));
 }
 
 void SelectParamsFromCommandLine()

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -5,6 +5,7 @@
 
 #include "chainparams.h"
 
+#include "tinyformat.h"
 #include "util.h"
 #include "utilstrencodings.h"
 
@@ -250,31 +251,29 @@ const CChainParams &Params() {
     return *pCurrentParams;
 }
 
-CChainParams &Params(CBaseChainParams::Network network) {
-    switch (network) {
-        case CBaseChainParams::MAIN:
+CChainParams& Params(std::string chain)
+{
+    if (chain == CBaseChainParams::MAIN)
             return mainParams;
-        case CBaseChainParams::TESTNET:
+    else if (chain == CBaseChainParams::TESTNET)
             return testNetParams;
-        case CBaseChainParams::REGTEST:
+    else if (chain == CBaseChainParams::REGTEST)
             return regTestParams;
-        default:
-            assert(false && "Unimplemented network");
-            return mainParams;
-    }
+    throw std::runtime_error(strprintf(_("%s: Unknown chain %s."), __func__, chain));
 }
 
-void SelectParams(CBaseChainParams::Network network) {
-    SelectBaseParams(network);
-    pCurrentParams = &Params(network);
+void SelectParams(std::string chain)
+{
+    SelectBaseParams(chain);
+    pCurrentParams = &Params(chain);
 }
 
 bool SelectParamsFromCommandLine()
 {
-    CBaseChainParams::Network network = NetworkIdFromCommandLine();
-    if (network == CBaseChainParams::MAX_NETWORK_TYPES)
+    std::string chain = ChainNameFromCommandLine();
+    if (chain == CBaseChainParams::MAX_NETWORK_TYPES)
         return false;
 
-    SelectParams(network);
+    SelectParams(chain);
     return true;
 }

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -21,7 +21,7 @@ using namespace std;
 const std::map<std::string, uint256> CChainParams::supportedChains =
     boost::assign::map_list_of
     ( "main", uint256S("0x000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"))
-    ( "test", uint256S("0x000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943"))
+    ( "testnet3", uint256S("0x000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943"))
     ( "regtest", uint256S("0x0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206"))
     ;
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -268,12 +268,7 @@ void SelectParams(std::string chain)
     pCurrentParams = &Params(chain);
 }
 
-bool SelectParamsFromCommandLine()
+void SelectParamsFromCommandLine()
 {
-    std::string chain = ChainNameFromCommandLine();
-    if (chain == CBaseChainParams::MAX_NETWORK_TYPES)
-        return false;
-
-    SelectParams(chain);
-    return true;
+    SelectParams(ChainNameFromCommandLine());
 }

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -101,6 +101,14 @@ protected:
 };
 
 /**
+ * Creates a CChainParams of the chosen chain and returns a
+ * pointer to it. The caller has to delete the object.
+ * Raises a std::runtime_error if the chain is not supported.
+ */
+CChainParams* ParamsFactory(std::string chain);
+
+/** Functions that relay on internal state */
+/**
  * Return the currently selected parameters. This won't change after app
  * startup, except for unit tests.
  */
@@ -109,7 +117,7 @@ const CChainParams &Params();
 /**
  * Returns parameters for the given BIP70 chain name.
  */
-CChainParams& Params(std::string chain);
+const CChainParams& Params(std::string chain);
 
 /**
  * Sets the params returned by Params() to those for the given BIP70 chain name.

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -70,7 +70,7 @@ public:
     bool MineBlocksOnDemand() const { return fMineBlocksOnDemand; }
     /** In the future use NetworkIDString() for RPC fields */
     bool TestnetToBeDeprecatedFieldRPC() const { return fTestnetToBeDeprecatedFieldRPC; }
-    /** Returns the BIP70 chain name string (main, test or regtest) */
+    /** Returns the BIP70 chain name string (main, testnet3 or regtest) */
     std::string NetworkIDString() const { return strNetworkID; }
     const std::vector<CDNSSeedData>& DNSSeeds() const { return vSeeds; }
     const std::vector<unsigned char>& Base58Prefix(Base58Type type) const { return base58Prefixes[type]; }

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -117,9 +117,9 @@ CChainParams& Params(std::string chain);
 void SelectParams(std::string chain);
 
 /**
- * Looks for -regtest or -testnet and then calls SelectParams as appropriate.
- * Returns false if an invalid combination is given.
+ * Calls NetworkIdFromCommandLine() and then calls SelectParams as appropriate.
+ * Raises a std::runtime_error if an invalid combination is given or if the chain is not supported.
  */
-bool SelectParamsFromCommandLine();
+void SelectParamsFromCommandLine();
 
 #endif // BITCOIN_CHAINPARAMS_H

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -45,6 +45,11 @@ public:
         MAX_BASE58_TYPES
     };
 
+    /**
+     * Maps strNetworkID [see BIP70] to chainID (hashGenesisBlock and genesis checkpoint)
+     */
+    static const std::map<std::string, uint256> supportedChains;
+
     const Consensus::Params& GetConsensus() const { return consensus; }
     const CMessageHeader::MessageStartChars& MessageStart() const { return pchMessageStart; }
     const std::vector<unsigned char>& AlertKey() const { return vAlertPubKey; }

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -70,7 +70,7 @@ public:
     bool MineBlocksOnDemand() const { return fMineBlocksOnDemand; }
     /** In the future use NetworkIDString() for RPC fields */
     bool TestnetToBeDeprecatedFieldRPC() const { return fTestnetToBeDeprecatedFieldRPC; }
-    /** Return the BIP70 network string (main, test or regtest) */
+    /** Returns the BIP70 chain name string (main, test or regtest) */
     std::string NetworkIDString() const { return strNetworkID; }
     const std::vector<CDNSSeedData>& DNSSeeds() const { return vSeeds; }
     const std::vector<unsigned char>& Base58Prefix(Base58Type type) const { return base58Prefixes[type]; }
@@ -106,11 +106,15 @@ protected:
  */
 const CChainParams &Params();
 
-/** Return parameters for the given network. */
-CChainParams &Params(CBaseChainParams::Network network);
+/**
+ * Returns parameters for the given BIP70 chain name.
+ */
+CChainParams& Params(std::string chain);
 
-/** Sets the params returned by Params() to those for the given network. */
-void SelectParams(CBaseChainParams::Network network);
+/**
+ * Sets the params returned by Params() to those for the given BIP70 chain name.
+ */
+void SelectParams(std::string chain);
 
 /**
  * Looks for -regtest or -testnet and then calls SelectParams as appropriate.

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -10,7 +10,7 @@
 #include "util.h"
 
 const std::string CBaseChainParams::MAIN = "main";
-const std::string CBaseChainParams::TESTNET = "test";
+const std::string CBaseChainParams::TESTNET = "testnet3";
 const std::string CBaseChainParams::REGTEST = "regtest";
 const std::string CBaseChainParams::MAX_NETWORK_TYPES = "unknown_chain";
 
@@ -45,7 +45,7 @@ public:
     CBaseTestNetParams()
     {
         nRPCPort = 18332;
-        strDataDir = "testnet3";
+        strDataDir = CBaseChainParams::TESTNET;
     }
 };
 

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -5,10 +5,9 @@
 
 #include "chainparamsbase.h"
 
+#include "templates.hpp"
 #include "tinyformat.h"
 #include "util.h"
-
-#include <assert.h>
 
 const std::string CBaseChainParams::MAIN = "main";
 const std::string CBaseChainParams::TESTNET = "test";
@@ -36,7 +35,6 @@ public:
         nRPCPort = 8332;
     }
 };
-static CBaseMainParams mainParams;
 
 /**
  * Testnet (v3)
@@ -50,7 +48,6 @@ public:
         strDataDir = "testnet3";
     }
 };
-static CBaseTestNetParams testNetParams;
 
 /*
  * Regression test
@@ -63,7 +60,6 @@ public:
         strDataDir = CBaseChainParams::REGTEST;
     }
 };
-static CBaseRegTestParams regTestParams;
 
 /*
  * Unit test
@@ -78,24 +74,27 @@ public:
 };
 static CBaseUnitTestParams unitTestParams;
 
-static CBaseChainParams* pCurrentBaseParams = 0;
+static Container<CBaseChainParams> currentBaseParams;
 
 const CBaseChainParams& BaseParams()
 {
-    assert(pCurrentBaseParams);
-    return *pCurrentBaseParams;
+    return currentBaseParams.Get();
+}
+
+CBaseChainParams* FactoryBaseParams(std::string chain)
+{
+    if (chain == CBaseChainParams::MAIN)
+        return new CBaseMainParams();
+    else if (chain == CBaseChainParams::TESTNET)
+        return new CBaseTestNetParams();
+    else if (chain == CBaseChainParams::REGTEST)
+        return new CBaseRegTestParams();
+    throw std::runtime_error(strprintf(_("%s: Unknown chain %s."), __func__, chain));
 }
 
 void SelectBaseParams(std::string chain)
 {
-    if (chain == CBaseChainParams::MAIN)
-        pCurrentBaseParams = &mainParams;
-    else if (chain == CBaseChainParams::TESTNET)
-        pCurrentBaseParams = &testNetParams;
-    else if (chain == CBaseChainParams::REGTEST)
-        pCurrentBaseParams = &regTestParams;
-    else
-        throw std::runtime_error(strprintf(_("%s: Unknown chain %s."), __func__, chain));
+    currentBaseParams.Set(FactoryBaseParams(chain));
 }
 
 std::string ChainNameFromCommandLine()
@@ -119,5 +118,5 @@ void SelectBaseParamsFromCommandLine()
 
 bool AreBaseParamsConfigured()
 {
-    return pCurrentBaseParams != NULL;
+    return !currentBaseParams.IsNull();
 }

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -15,6 +15,16 @@ const std::string CBaseChainParams::TESTNET = "test";
 const std::string CBaseChainParams::REGTEST = "regtest";
 const std::string CBaseChainParams::MAX_NETWORK_TYPES = "unknown_chain";
 
+std::string GetParamsHelpMessages()
+{
+    std::string strUsage = "";
+    strUsage += HelpMessageOpt("-testnet", _("Use the test chain"));
+    strUsage += HelpMessageOpt("-regtest", _("Enter regression test mode, which uses a special chain in which blocks can be solved instantly.") + " " +
+        _("This is intended for regression testing tools and app development.") + " " +
+        _("In this mode -genproclimit controls how many blocks are generated immediately."));
+    return strUsage;
+}
+
 /**
  * Main network
  */

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -16,7 +16,7 @@ const std::string CBaseChainParams::MAX_NETWORK_TYPES = "unknown_chain";
 
 std::string GetParamsHelpMessages()
 {
-    std::string strUsage = "";
+    std::string strUsage = HelpMessageOpt("-chain=<chain>", _("Use the chain <chain> (default: main). Allowed values: main, testnet, regtest"));
     strUsage += HelpMessageOpt("-testnet", _("Use the test chain"));
     strUsage += HelpMessageOpt("-regtest", _("Enter regression test mode, which uses a special chain in which blocks can be solved instantly.") + " " +
         _("This is intended for regression testing tools and app development.") + " " +
@@ -108,7 +108,7 @@ std::string ChainNameFromCommandLine()
         return CBaseChainParams::REGTEST;
     if (fTestNet)
         return CBaseChainParams::TESTNET;
-    return CBaseChainParams::MAIN;
+    return GetArg("-chain", CBaseChainParams::MAIN);
 }
 
 void SelectBaseParamsFromCommandLine()

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -104,7 +104,7 @@ std::string ChainNameFromCommandLine()
     bool fTestNet = GetBoolArg("-testnet", false);
 
     if (fTestNet && fRegTest)
-        return CBaseChainParams::MAX_NETWORK_TYPES;
+        throw std::runtime_error(_("Invalid combination of -regtest and -testnet."));
     if (fRegTest)
         return CBaseChainParams::REGTEST;
     if (fTestNet)
@@ -112,14 +112,9 @@ std::string ChainNameFromCommandLine()
     return CBaseChainParams::MAIN;
 }
 
-bool SelectBaseParamsFromCommandLine()
+void SelectBaseParamsFromCommandLine()
 {
-    std::string chain = ChainNameFromCommandLine();
-    if (chain == CBaseChainParams::MAX_NETWORK_TYPES)
-        return false;
-
-    SelectBaseParams(chain);
-    return true;
+    SelectBaseParams(ChainNameFromCommandLine());
 }
 
 bool AreBaseParamsConfigured()

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -5,9 +5,15 @@
 
 #include "chainparamsbase.h"
 
+#include "tinyformat.h"
 #include "util.h"
 
 #include <assert.h>
+
+const std::string CBaseChainParams::MAIN = "main";
+const std::string CBaseChainParams::TESTNET = "test";
+const std::string CBaseChainParams::REGTEST = "regtest";
+const std::string CBaseChainParams::MAX_NETWORK_TYPES = "unknown_chain";
 
 /**
  * Main network
@@ -70,25 +76,19 @@ const CBaseChainParams& BaseParams()
     return *pCurrentBaseParams;
 }
 
-void SelectBaseParams(CBaseChainParams::Network network)
+void SelectBaseParams(std::string chain)
 {
-    switch (network) {
-    case CBaseChainParams::MAIN:
+    if (chain == CBaseChainParams::MAIN)
         pCurrentBaseParams = &mainParams;
-        break;
-    case CBaseChainParams::TESTNET:
+    else if (chain == CBaseChainParams::TESTNET)
         pCurrentBaseParams = &testNetParams;
-        break;
-    case CBaseChainParams::REGTEST:
+    else if (chain == CBaseChainParams::REGTEST)
         pCurrentBaseParams = &regTestParams;
-        break;
-    default:
-        assert(false && "Unimplemented network");
-        return;
-    }
+    else
+        throw std::runtime_error(strprintf(_("%s: Unknown chain %s."), __func__, chain));
 }
 
-CBaseChainParams::Network NetworkIdFromCommandLine()
+std::string ChainNameFromCommandLine()
 {
     bool fRegTest = GetBoolArg("-regtest", false);
     bool fTestNet = GetBoolArg("-testnet", false);
@@ -104,11 +104,11 @@ CBaseChainParams::Network NetworkIdFromCommandLine()
 
 bool SelectBaseParamsFromCommandLine()
 {
-    CBaseChainParams::Network network = NetworkIdFromCommandLine();
-    if (network == CBaseChainParams::MAX_NETWORK_TYPES)
+    std::string chain = ChainNameFromCommandLine();
+    if (chain == CBaseChainParams::MAX_NETWORK_TYPES)
         return false;
 
-    SelectBaseParams(network);
+    SelectBaseParams(chain);
     return true;
 }
 

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -50,7 +50,7 @@ class CBaseRegTestParams : public CBaseTestNetParams
 public:
     CBaseRegTestParams()
     {
-        strDataDir = "regtest";
+        strDataDir = CBaseChainParams::REGTEST;
     }
 };
 static CBaseRegTestParams regTestParams;

--- a/src/chainparamsbase.h
+++ b/src/chainparamsbase.h
@@ -56,9 +56,9 @@ void SelectBaseParams(std::string chain);
 
 /**
  * Calls NetworkIdFromCommandLine() and then calls SelectParams as appropriate.
- * Returns false if an invalid combination is given.
+ * Raises a std::runtime_error if an invalid combination is given or if the chain is not supported.
  */
-bool SelectBaseParamsFromCommandLine();
+void SelectBaseParamsFromCommandLine();
 
 /**
  * Return true if SelectBaseParamsFromCommandLine() has been called to select a chain.

--- a/src/chainparamsbase.h
+++ b/src/chainparamsbase.h
@@ -32,6 +32,10 @@ protected:
 };
 
 /**
+ * Returns a string with the help messages for the chainparams options. 
+ */
+std::string GetParamsHelpMessages();
+/**
  * Looks for -regtest, -testnet and returns the appropriate BIP70 chain name.
  * Returns CBaseChainParams::MAIN by default.
  * Returns CBaseChainParams::MAX_NETWORK_TYPES if an invalid combination is given.

--- a/src/chainparamsbase.h
+++ b/src/chainparamsbase.h
@@ -32,6 +32,12 @@ protected:
 };
 
 /**
+ * Creates a CBaseChainParams of the chosen chain and returns a
+ * pointer to it. The caller has to delete the object.
+ * Raises an error if the chain is not supported.
+ */
+CBaseChainParams* FactoryBaseParams(std::string chain);
+/**
  * Returns a string with the help messages for the chainparams options. 
  */
 std::string GetParamsHelpMessages();
@@ -42,6 +48,7 @@ std::string GetParamsHelpMessages();
  */
 std::string ChainNameFromCommandLine();
 
+/** Functions that relay on internal state */
 /**
  * Return the currently selected parameters. This won't change after app
  * startup, except for unit tests.

--- a/src/chainparamsbase.h
+++ b/src/chainparamsbase.h
@@ -15,13 +15,11 @@
 class CBaseChainParams
 {
 public:
-    enum Network {
-        MAIN,
-        TESTNET,
-        REGTEST,
-
-        MAX_NETWORK_TYPES
-    };
+    /** BIP70 chain name strings (main, test or regtest) */
+    static const std::string MAIN;
+    static const std::string TESTNET;
+    static const std::string REGTEST;
+    static const std::string MAX_NETWORK_TYPES;
 
     const std::string& DataDir() const { return strDataDir; }
     int RPCPort() const { return nRPCPort; }
@@ -34,19 +32,23 @@ protected:
 };
 
 /**
+ * Looks for -regtest, -testnet and returns the appropriate BIP70 chain name.
+ * Returns CBaseChainParams::MAIN by default.
+ * Returns CBaseChainParams::MAX_NETWORK_TYPES if an invalid combination is given.
+ */
+std::string ChainNameFromCommandLine();
+
+/**
  * Return the currently selected parameters. This won't change after app
  * startup, except for unit tests.
  */
 const CBaseChainParams& BaseParams();
 
-/** Sets the params returned by Params() to those for the given network. */
-void SelectBaseParams(CBaseChainParams::Network network);
-
 /**
- * Looks for -regtest or -testnet and returns the appropriate Network ID.
- * Returns MAX_NETWORK_TYPES if an invalid combination is given.
+ * Sets the params returned by BaseParams() to those for the appropriate chain returned by ChainNameFromCommandLine().
+ * Raises a std::runtime_error if an unsupported chain name is given.
  */
-CBaseChainParams::Network NetworkIdFromCommandLine();
+void SelectBaseParams(std::string chain);
 
 /**
  * Calls NetworkIdFromCommandLine() and then calls SelectParams as appropriate.
@@ -55,8 +57,7 @@ CBaseChainParams::Network NetworkIdFromCommandLine();
 bool SelectBaseParamsFromCommandLine();
 
 /**
- * Return true if SelectBaseParamsFromCommandLine() has been called to select
- * a network.
+ * Return true if SelectBaseParamsFromCommandLine() has been called to select a chain.
  */
 bool AreBaseParamsConfigured();
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -388,12 +388,9 @@ std::string HelpMessage(HelpMessageMode mode)
     {
         strUsage += HelpMessageOpt("-printpriority", strprintf(_("Log transaction priority and fee per kB when mining blocks (default: %u)"), 0));
         strUsage += HelpMessageOpt("-privdb", strprintf(_("Sets the DB_PRIVATE flag in the wallet db environment (default: %u)"), 1));
-        strUsage += HelpMessageOpt("-regtest", _("Enter regression test mode, which uses a special chain in which blocks can be solved instantly.") + " " +
-            _("This is intended for regression testing tools and app development.") + " " +
-            _("In this mode -genproclimit controls how many blocks are generated immediately."));
     }
     strUsage += HelpMessageOpt("-shrinkdebugfile", _("Shrink debug.log file on client startup (default: 1 when no -debug)"));
-    strUsage += HelpMessageOpt("-testnet", _("Use the test network"));
+    strUsage += GetParamsHelpMessages();
 
     strUsage += HelpMessageGroup(_("Node relay options:"));
     strUsage += HelpMessageOpt("-datacarrier", strprintf(_("Relay and mine data carrier transactions (default: %u)"), 1));

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -572,8 +572,10 @@ int main(int argc, char *argv[])
     // - Needs to be done before createOptionsModel
 
     // Check for -testnet or -regtest parameter (Params() calls are only valid after this clause)
-    if (!SelectParamsFromCommandLine()) {
-        QMessageBox::critical(0, QObject::tr("Bitcoin Core"), QObject::tr("Error: Invalid combination of -regtest and -testnet."));
+    try {
+        SelectParamsFromCommandLine();
+    } catch(std::exception &e) {
+        QMessageBox::critical(0, QObject::tr("Bitcoin Core"), QObject::tr("Error: %1.").arg(e.what()));
         return 1;
     }
 #ifdef ENABLE_WALLET

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -571,7 +571,7 @@ int main(int argc, char *argv[])
     // - QSettings() will use the new application name after this, resulting in network-specific settings
     // - Needs to be done before createOptionsModel
 
-    // Check for -testnet or -regtest parameter (Params() calls are only valid after this clause)
+    // Check for -chain, -testnet or -regtest parameter (Params() calls are only valid after this clause)
     try {
         SelectParamsFromCommandLine();
     } catch(std::exception &e) {

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -604,7 +604,7 @@ bool SetStartOnSystemStartup(bool fAutoStart)
             // Start client minimized
             QString strArgs = "-min";
             // Set -testnet /-regtest options
-            strArgs += QString::fromStdString(strprintf(" -testnet=%d -regtest=%d", GetBoolArg("-testnet", false), GetBoolArg("-regtest", false)));
+            strArgs += QString::fromStdString(strprintf(" -chain=%s", ChainNameFromCommandLine()));
 
 #ifdef UNICODE
             boost::scoped_array<TCHAR> args(new TCHAR[strArgs.length() + 1]);
@@ -712,7 +712,7 @@ bool SetStartOnSystemStartup(bool fAutoStart)
             optionFile << "Name=Bitcoin\n";
         else
             optionFile << strprintf("Name=Bitcoin (%s)\n", chain);
-        optionFile << "Exec=" << pszExePath << strprintf(" -min -testnet=%d -regtest=%d\n", GetBoolArg("-testnet", false), GetBoolArg("-regtest", false));
+        optionFile << "Exec=" << pszExePath << strprintf(" -min -chain=%s\n", chain);
         optionFile << "Terminal=false\n";
         optionFile << "Hidden=false\n";
         optionFile.close();

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -568,12 +568,10 @@ TableViewLastColumnResizingFixer::TableViewLastColumnResizingFixer(QTableView* t
 #ifdef WIN32
 boost::filesystem::path static StartupShortcutPath()
 {
-    if (GetBoolArg("-testnet", false))
-        return GetSpecialFolderPath(CSIDL_STARTUP) / "Bitcoin (testnet).lnk";
-    else if (GetBoolArg("-regtest", false))
-        return GetSpecialFolderPath(CSIDL_STARTUP) / "Bitcoin (regtest).lnk";
-
-    return GetSpecialFolderPath(CSIDL_STARTUP) / "Bitcoin.lnk";
+    std::string chain = ChainNameFromCommandLine();
+    if (chain == CBaseChainParams::MAIN)
+        return GetSpecialFolderPath(CSIDL_STARTUP) / "Bitcoin.lnk";
+    return GetSpecialFolderPath(CSIDL_STARTUP) / strprintf("Bitcoin (%s).lnk", chain);
 }
 
 bool GetStartOnSystemStartup()
@@ -706,15 +704,14 @@ bool SetStartOnSystemStartup(bool fAutoStart)
         boost::filesystem::ofstream optionFile(GetAutostartFilePath(), std::ios_base::out|std::ios_base::trunc);
         if (!optionFile.good())
             return false;
+        std::string chain = ChainNameFromCommandLine();
         // Write a bitcoin.desktop file to the autostart directory:
         optionFile << "[Desktop Entry]\n";
         optionFile << "Type=Application\n";
-        if (GetBoolArg("-testnet", false))
-            optionFile << "Name=Bitcoin (testnet)\n";
-        else if (GetBoolArg("-regtest", false))
-            optionFile << "Name=Bitcoin (regtest)\n";
-        else
+        if (chain == CBaseChainParams::MAIN)
             optionFile << "Name=Bitcoin\n";
+        else
+            optionFile << strprintf("Name=Bitcoin (%s)\n", chain);
         optionFile << "Exec=" << pszExePath << strprintf(" -min -testnet=%d -regtest=%d\n", GetBoolArg("-testnet", false), GetBoolArg("-regtest", false));
         optionFile << "Terminal=false\n";
         optionFile << "Hidden=false\n";

--- a/src/qt/networkstyle.cpp
+++ b/src/qt/networkstyle.cpp
@@ -17,7 +17,7 @@ static const struct {
     const char *titleAddText;
 } network_styles[] = {
     {"main", QAPP_APP_NAME_DEFAULT, 0, 0, ""},
-    {"test", QAPP_APP_NAME_TESTNET, 70, 30, QT_TRANSLATE_NOOP("SplashScreen", "[testnet]")},
+    {"testnet3", QAPP_APP_NAME_TESTNET, 70, 30, QT_TRANSLATE_NOOP("SplashScreen", "[testnet3]")},
     {"regtest", QAPP_APP_NAME_TESTNET, 160, 30, "[regtest]"}
 };
 static const unsigned network_styles_count = sizeof(network_styles)/sizeof(*network_styles);

--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -241,14 +241,10 @@ void PaymentServer::ipcParseCommandLine(int argc, char* argv[])
             PaymentRequestPlus request;
             if (readPaymentRequestFromFile(arg, request))
             {
-                if (request.getDetails().network() == "main")
-                {
-                    SelectParams(CBaseChainParams::MAIN);
-                }
-                else if (request.getDetails().network() == "test")
-                {
-                    SelectParams(CBaseChainParams::TESTNET);
-                }
+                // TODO find out why this excludes regtest
+                std::string chainStr = request.getDetails().network();
+                if (chainStr == CBaseChainParams::MAIN || chainStr == CBaseChainParams::TESTNET)
+                    SelectParams(chainStr);
             }
         }
         else

--- a/src/qt/test/paymentservertests.cpp
+++ b/src/qt/test/paymentservertests.cpp
@@ -141,7 +141,7 @@ void PaymentServerTests::paymentServerTests()
     data = DecodeBase64(paymentrequest1_cert2_BASE64);
     byteArray = QByteArray((const char*)&data[0], data.size());
     r.paymentRequest.parse(byteArray);
-    // Ensure the request is initialized, because network "main" is default, even for
+    // Ensure the request is initialized, because network CBaseChainParams::MAIN is default, even for
     // uninizialized payment requests and that will fail our test here.
     QVERIFY(r.paymentRequest.IsInitialized());
     QCOMPARE(PaymentServer::verifyNetwork(r.paymentRequest.getDetails()), false);

--- a/src/templates.hpp
+++ b/src/templates.hpp
@@ -1,0 +1,41 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2014 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_TEMPLATES_H
+#define BITCOIN_TEMPLATES_H
+
+#include <assert.h>
+
+template<typename T>
+class Container
+{
+    T* pObj;
+public:
+    Container() : pObj(NULL) { };
+
+    bool IsNull()
+    {
+        return pObj == NULL;
+    }
+    void Set(T* pObjIn)
+    {
+        if (pObj)
+            delete(pObj);
+        pObj = pObjIn;
+    }
+    const T& Get()
+    {
+        assert(pObj);
+        return *pObj;
+    }
+
+    ~Container()
+    {
+        if (pObj)
+            delete(pObj);
+    }
+};
+
+#endif // BITCOIN_TEMPLATES_H

--- a/src/test/Checkpoints_tests.cpp
+++ b/src/test/Checkpoints_tests.cpp
@@ -2,21 +2,29 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-//
-// Unit tests for block-chain checkpoints
-//
-
 #include "checkpoints.h"
-
 #include "uint256.h"
 #include "test/test_bitcoin.h"
 #include "chainparams.h"
 
+#include <boost/assign/list_of.hpp>
 #include <boost/test/unit_test.hpp>
 
-using namespace std;
-
 BOOST_FIXTURE_TEST_SUITE(Checkpoints_tests, BasicTestingSetup)
+
+// The hash of the genesis block it's the genesis checkpoint and chain id
+BOOST_AUTO_TEST_CASE(genesisblockhash_test)
+{
+    std::map<std::string, uint256>::const_iterator iter;
+    for (iter = CChainParams::supportedChains.begin(); iter != CChainParams::supportedChains.end(); ++iter) {
+        const CChainParams& chainparams = Params(iter->first);
+        std::string hashStr = chainparams.GenesisBlock().GetHash().GetHex();
+        BOOST_CHECK_EQUAL(hashStr, iter->second.GetHex());
+        BOOST_CHECK_EQUAL(hashStr, chainparams.GetConsensus().hashGenesisBlock.GetHex());
+        const uint256& genesisCheckpoint = chainparams.Checkpoints().mapCheckpoints.find(0)->second;
+        BOOST_CHECK_EQUAL(hashStr, genesisCheckpoint.GetHex());
+    }
+}    
 
 BOOST_AUTO_TEST_CASE(sanity)
 {

--- a/src/test/alert_tests.cpp
+++ b/src/test/alert_tests.cpp
@@ -203,7 +203,7 @@ BOOST_AUTO_TEST_CASE(PartitionAlert)
     CCriticalSection csDummy;
     CChain chainDummy;
     CBlockIndex indexDummy[100];
-    CChainParams& params = Params(CBaseChainParams::MAIN);
+    const CChainParams& params = Params(CBaseChainParams::MAIN);
     int64_t nPowTargetSpacing = params.GetConsensus().nPowTargetSpacing;
 
     // Generate fake blockchain timestamps relative to


### PR DESCRIPTION
Continues #4804.
Deprecate -testnet and -regtest in favor of -network=testnet and -network=regtest.
When the old args are used a warning will be logged.
The repetition of the invalid combination error string is also avoided.
Additionally, the chainparam networkID is removed since it's not used anymore (as it shouldn't).
