### PR TITLE
Introduce strNetworkID to chainID map in chainparams.cpp

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -23,6 +23,22 @@ struct SeedSpec6 {
 
 #include "chainparamsseeds.h"
 
+// Maps strNetworkID to chainID (unittest shares main's chainID)
+static std::map<std::string, uint256> chainIdsMap =
+        boost::assign::map_list_of
+        ("main", uint256("0x000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"))
+        ("test", uint256("0x000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943"))
+        ("regtest", uint256("0x0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206"))
+        ;
+
+uint256 ChainId(std::string strNetworkID)
+{
+    if (!chainIdsMap.count(strNetworkID)) {
+        throw std::runtime_error("Unkown network " + strNetworkID + "\n");
+    }
+    return chainIdsMap[strNetworkID];
+}
+
 /**
  * Main network
  */
@@ -149,7 +165,7 @@ public:
         genesis.nNonce   = 2083236893;
 
         hashGenesisBlock = genesis.GetHash();
-        assert(hashGenesisBlock == uint256("0x000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"));
+        assert(hashGenesisBlock == ChainId(strNetworkID));
         assert(genesis.hashMerkleRoot == uint256("0x4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"));
 
         vSeeds.push_back(CDNSSeedData("bitcoin.sipa.be", "seed.bitcoin.sipa.be"));
@@ -214,7 +230,7 @@ public:
         genesis.nTime = 1296688602;
         genesis.nNonce = 414098458;
         hashGenesisBlock = genesis.GetHash();
-        assert(hashGenesisBlock == uint256("0x000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943"));
+        assert(hashGenesisBlock == ChainId(strNetworkID));
 
         vFixedSeeds.clear();
         vSeeds.clear();
@@ -271,7 +287,7 @@ public:
         genesis.nNonce = 2;
         hashGenesisBlock = genesis.GetHash();
         nDefaultPort = 18444;
-        assert(hashGenesisBlock == uint256("0x0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206"));
+        assert(hashGenesisBlock == ChainId(strNetworkID));
 
         vFixedSeeds.clear(); //! Regtest mode doesn't have any fixed seeds.
         vSeeds.clear();  //! Regtest mode doesn't have any DNS seeds.


### PR DESCRIPTION
The chainID is the hash of the genesis block and strNetworkID is the string used in BIP70.
