### PR TITLE
Compiler warning C4099: type name first seen using 'class' now seen using 'struct'

### DIFF
--- a/src/key.h
+++ b/src/key.h
@@ -13,7 +13,7 @@
 #include <stdexcept>
 #include <vector>
 
-class CExtPubKey;
+struct CExtPubKey;
 class CPubKey;
 
 /** 


### PR DESCRIPTION
CExtPubKey: type name first seen using 'class' now seen using 'struct'

For more info see: http://msdn.microsoft.com/en-us/library/695x5bes.aspx
