### PR TITLE
Disable -testnet and -regtest deprecated flags

### DIFF
--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -76,11 +76,9 @@ static bool AppInitRPC(int argc, char* argv[])
         fprintf(stderr,"Error reading configuration file: %s\n", e.what());
         return false;
     }
-    // Check for -testnet or -regtest parameter (BaseParams() calls are only valid after this clause)
-    if (!SelectBaseParamsFromCommandLine()) {
-        fprintf(stderr, "Error: Invalid combination of -regtest and -testnet.\n");
-        return false;
-    }
+    // Check for -network, -testnet or -regtest parameter (BaseParams() calls are only valid after this clause)
+    SelectBaseParamsFromCommandLine();
+
     if (argc<2 || mapArgs.count("-?") || mapArgs.count("-help") || mapArgs.count("-version")) {
         std::string strUsage = _("Bitcoin Core RPC client version") + " " + FormatFullVersion() + "\n";
         if (!mapArgs.count("-version")) {

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -77,7 +77,12 @@ static bool AppInitRPC(int argc, char* argv[])
         return false;
     }
     // Check for -network, -testnet or -regtest parameter (BaseParams() calls are only valid after this clause)
-    SelectBaseParamsFromCommandLine();
+    try {
+        SelectBaseParamsFromCommandLine();
+    } catch(std::exception &e) {
+        fprintf(stderr, "Error: %s\n", e.what());
+        return false;
+    }
 
     if (argc<2 || mapArgs.count("-?") || mapArgs.count("-help") || mapArgs.count("-version")) {
         std::string strUsage = _("Bitcoin Core RPC client version") + " " + FormatFullVersion() + "\n";

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -83,7 +83,6 @@ static bool AppInitRPC(int argc, char* argv[])
         fprintf(stderr, "Error: %s\n", e.what());
         return false;
     }
-
     if (argc<2 || mapArgs.count("-?") || mapArgs.count("-help") || mapArgs.count("-version")) {
         std::string strUsage = _("Bitcoin Core RPC client version") + " " + FormatFullVersion() + "\n";
         if (!mapArgs.count("-version")) {

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -34,11 +34,8 @@ static bool AppInitRawTx(int argc, char* argv[])
     //
     ParseParameters(argc, argv);
 
-    // Check for -testnet or -regtest parameter (Params() calls are only valid after this clause)
-    if (!SelectParamsFromCommandLine()) {
-        fprintf(stderr, "Error: Invalid combination of -regtest and -testnet.\n");
-        return false;
-    }
+    // Check for -network, -testnet or -regtest parameter (Params() calls are only valid after this clause)
+    SelectParamsFromCommandLine();
 
     fCreateBlank = GetBoolArg("-create", false);
 

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -35,7 +35,12 @@ static bool AppInitRawTx(int argc, char* argv[])
     ParseParameters(argc, argv);
 
     // Check for -network, -testnet or -regtest parameter (Params() calls are only valid after this clause)
-    SelectParamsFromCommandLine();
+    try {
+        SelectParamsFromCommandLine();
+    } catch(std::exception &e) {
+        fprintf(stderr, "Error: %s\n", e.what());
+        return false;
+    }
 
     fCreateBlank = GetBoolArg("-create", false);
 

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -78,11 +78,8 @@ bool AppInit(int argc, char* argv[])
             fprintf(stderr,"Error reading configuration file: %s\n", e.what());
             return false;
         }
-        // Check for -testnet or -regtest parameter (Params() calls are only valid after this clause)
-        if (!SelectParamsFromCommandLine()) {
-            fprintf(stderr, "Error: Invalid combination of -regtest and -testnet.\n");
-            return false;
-        }
+        // Check for -network, -testnet or -regtest parameter (Params() calls are only valid after this clause)
+        SelectParamsFromCommandLine();
 
         if (mapArgs.count("-?") || mapArgs.count("-help") || mapArgs.count("-version"))
         {

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -79,7 +79,12 @@ bool AppInit(int argc, char* argv[])
             return false;
         }
         // Check for -network, -testnet or -regtest parameter (Params() calls are only valid after this clause)
-        SelectParamsFromCommandLine();
+        try {
+            SelectParamsFromCommandLine();
+        } catch(std::exception &e) {
+            fprintf(stderr, "Error: %s\n", e.what());
+            return false;
+        }
 
         if (mapArgs.count("-?") || mapArgs.count("-help") || mapArgs.count("-version"))
         {

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -349,7 +349,7 @@ CChainParams &Params(CBaseChainParams::Network network) {
         case CBaseChainParams::UNITTEST:
             return unitTestParams;
         default:
-            throw std::runtime_error("Unimplemented network\n");
+            throw std::runtime_error("Unknown network\n");
     }
 }
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -349,8 +349,7 @@ CChainParams &Params(CBaseChainParams::Network network) {
         case CBaseChainParams::UNITTEST:
             return unitTestParams;
         default:
-            assert(false && "Unimplemented network");
-            return mainParams;
+            throw std::runtime_error("Unimplemented network\n");
     }
 }
 
@@ -359,13 +358,9 @@ void SelectParams(CBaseChainParams::Network network) {
     pCurrentParams = &Params(network);
 }
 
-bool SelectParamsFromCommandLine()
+void SelectParamsFromCommandLine()
 {
     CBaseChainParams::Network network = NetworkIdFromCommandLine();
-    if (network == CBaseChainParams::MAX_NETWORK_TYPES)
-        return false;
-
     SelectBaseParams(network);
     SelectParams(network);
-    return true;
 }

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -101,7 +101,6 @@ static const Checkpoints::CCheckpointData dataRegtest = {
 class CMainParams : public CChainParams {
 public:
     CMainParams() {
-        networkID = CBaseChainParams::MAIN;
         strNetworkID = "main";
         /** 
          * The message start string is designed to be unlikely to occur in normal data.
@@ -190,7 +189,6 @@ static CMainParams mainParams;
 class CTestNetParams : public CMainParams {
 public:
     CTestNetParams() {
-        networkID = CBaseChainParams::TESTNET;
         strNetworkID = "test";
         /** 
          * The message start string is designed to be unlikely to occur in normal data.
@@ -252,7 +250,6 @@ static CTestNetParams testNetParams;
 class CRegTestParams : public CTestNetParams {
 public:
     CRegTestParams() {
-        networkID = CBaseChainParams::REGTEST;
         strNetworkID = "regtest";
         pchMessageStart[0] = 0xfa;
         pchMessageStart[1] = 0xbf;
@@ -297,7 +294,6 @@ static CRegTestParams regTestParams;
 class CUnitTestParams : public CMainParams, public CModifiableParams {
 public:
     CUnitTestParams() {
-        networkID = CBaseChainParams::UNITTEST;
         strNetworkID = "unittest";
         nDefaultPort = 18445;
         vFixedSeeds.clear(); //! Unit test mode doesn't have any fixed seeds.

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -97,7 +97,6 @@ protected:
     int nMinerThreads;
     std::vector<CDNSSeedData> vSeeds;
     std::vector<unsigned char> base58Prefixes[MAX_BASE58_TYPES];
-    CBaseChainParams::Network networkID;
     std::string strNetworkID;
     CBlock genesis;
     std::vector<CAddress> vFixedSeeds;

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -145,10 +145,8 @@ CModifiableParams *ModifiableParams();
 void SelectParams(CBaseChainParams::Network network);
 
 /**
- * Returns the appropriate Network ID from the string provided in -network. 
- * If nothing is found, it also looks for -regtest or -testnet.
- * Returns MAIN by default.
- * Raises an error if an invalid combination is given or if the -network is not supported.
+ * Calls NetworkIdFromCommandLine() and then calls SelectBaseParams()
+ * and SelectParams() to select the appropriate network.
  */
 void SelectParamsFromCommandLine();
 

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -145,9 +145,11 @@ CModifiableParams *ModifiableParams();
 void SelectParams(CBaseChainParams::Network network);
 
 /**
- * Looks for -regtest or -testnet and then calls SelectParams as appropriate.
- * Returns false if an invalid combination is given.
+ * Returns the appropriate Network ID from the string provided in -network. 
+ * If nothing is found, it also looks for -regtest or -testnet.
+ * Returns MAIN by default.
+ * Raises an error if an invalid combination is given or if the -network is not supported.
  */
-bool SelectParamsFromCommandLine();
+void SelectParamsFromCommandLine();
 
 #endif // BITCOIN_CHAINPARAMS_H

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -21,7 +21,6 @@ class CBaseMainParams : public CBaseChainParams
 public:
     CBaseMainParams()
     {
-        networkID = CBaseChainParams::MAIN;
         nRPCPort = 8332;
     }
 };
@@ -35,7 +34,6 @@ class CBaseTestNetParams : public CBaseMainParams
 public:
     CBaseTestNetParams()
     {
-        networkID = CBaseChainParams::TESTNET;
         nRPCPort = 18332;
         strDataDir = "testnet3";
     }
@@ -50,7 +48,6 @@ class CBaseRegTestParams : public CBaseTestNetParams
 public:
     CBaseRegTestParams()
     {
-        networkID = CBaseChainParams::REGTEST;
         strDataDir = "regtest";
     }
 };
@@ -64,7 +61,6 @@ class CBaseUnitTestParams : public CBaseMainParams
 public:
     CBaseUnitTestParams()
     {
-        networkID = CBaseChainParams::UNITTEST;
         strDataDir = "unittest";
     }
 };

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -99,7 +99,7 @@ CBaseChainParams::Network NetworkIdFromCommandLine()
     std::string network = GetArg("-network", "");
     if (network == "main")
         return CBaseChainParams::MAIN;
-    if (network == "testnet")
+    if (network == "test")
         return CBaseChainParams::TESTNET;
     if (network == "regtest")
         return CBaseChainParams::REGTEST;
@@ -112,13 +112,13 @@ CBaseChainParams::Network NetworkIdFromCommandLine()
     bool fTestNet = GetBoolArg("-testnet", false);
 
     if (fTestNet && fRegTest)
-        throw std::runtime_error("Invalid combination of -regtest and -testnet. Additionally -testnet and -regtest are deprecated, use -network=testnet instead.\n");
+        throw std::runtime_error("Invalid combination of -regtest and -testnet. Additionally -testnet and -regtest are deprecated, use -network=test or -network=regtest instead.\n");
     if (fRegTest) {
         LogPrintStr("WARNING: -regtest is deprecated, use -network=regtest instead.");
         return CBaseChainParams::REGTEST;
     }
     if (fTestNet) {
-        LogPrintStr("WARNING: -testnet is deprecated, use -network=testnet instead.");
+        LogPrintStr("WARNING: -testnet is deprecated, use -network=test instead.");
         return CBaseChainParams::TESTNET;
     }
     return CBaseChainParams::MAIN;

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -96,18 +96,11 @@ void SelectBaseParams(CBaseChainParams::Network network)
 
 CBaseChainParams::Network NetworkIdFromCommandLine()
 {
-    bool fRegTest = GetBoolArg("-regtest", false);
-    bool fTestNet = GetBoolArg("-testnet", false);
-
-    if (fTestNet && fRegTest)
-        throw std::runtime_error("Invalid combination of -regtest and -testnet. Additionally -testnet and -regtest are deprecated, use -network=test or -network=regtest instead.\n");
-    if (fRegTest) {
-        LogPrintStr("WARNING: -regtest is deprecated, use -network=regtest instead.");
-        return CBaseChainParams::REGTEST;
+    if (GetBoolArg("-regtest", false)) {
+        LogPrintStr("WARNING: -regtest is disabled, use -network=regtest instead.");
     }
-    if (fTestNet) {
-        LogPrintStr("WARNING: -testnet is deprecated, use -network=test instead.");
-        return CBaseChainParams::TESTNET;
+    if (GetBoolArg("-testnet", false)) {
+        LogPrintStr("WARNING: -testnet is disabled, use -network=test instead.");
     }
     std::string network = GetArg("-network", "main");
     if (network == "main")

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -90,33 +90,44 @@ void SelectBaseParams(CBaseChainParams::Network network)
         pCurrentBaseParams = &unitTestParams;
         break;
     default:
-        assert(false && "Unimplemented network");
-        return;
+        throw std::runtime_error("Unimplemented network\n");
     }
 }
 
 CBaseChainParams::Network NetworkIdFromCommandLine()
 {
+    std::string network = GetArg("-network", "");
+    if (network == "main")
+        return CBaseChainParams::MAIN;
+    if (network == "testnet")
+        return CBaseChainParams::TESTNET;
+    if (network == "testnet")
+        return CBaseChainParams::REGTEST;
+    if (network == "unittest")
+        return CBaseChainParams::UNITTEST;
+    if (network != "") {
+        throw std::runtime_error("Unimplemented network " + network + "\n");
+    }
     bool fRegTest = GetBoolArg("-regtest", false);
     bool fTestNet = GetBoolArg("-testnet", false);
 
     if (fTestNet && fRegTest)
-        return CBaseChainParams::MAX_NETWORK_TYPES;
-    if (fRegTest)
+        throw std::runtime_error("Invalid combination of -regtest and -testnet. Additionally -testnet and -regtest are deprecated, use -network=testnet instead.\n");
+    if (fRegTest) {
+        LogPrintStr("WARNING: -regtest is deprecated, use -network=regtest instead.");
         return CBaseChainParams::REGTEST;
-    if (fTestNet)
+    }
+    if (fTestNet) {
+        LogPrintStr("WARNING: -testnet is deprecated, use -network=testnet instead.");
         return CBaseChainParams::TESTNET;
+    }
     return CBaseChainParams::MAIN;
 }
 
-bool SelectBaseParamsFromCommandLine()
+void SelectBaseParamsFromCommandLine()
 {
     CBaseChainParams::Network network = NetworkIdFromCommandLine();
-    if (network == CBaseChainParams::MAX_NETWORK_TYPES)
-        return false;
-
     SelectBaseParams(network);
-    return true;
 }
 
 bool AreBaseParamsConfigured()

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -96,18 +96,6 @@ void SelectBaseParams(CBaseChainParams::Network network)
 
 CBaseChainParams::Network NetworkIdFromCommandLine()
 {
-    std::string network = GetArg("-network", "");
-    if (network == "main")
-        return CBaseChainParams::MAIN;
-    if (network == "test")
-        return CBaseChainParams::TESTNET;
-    if (network == "regtest")
-        return CBaseChainParams::REGTEST;
-    if (network == "unittest")
-        return CBaseChainParams::UNITTEST;
-    if (network != "") {
-        throw std::runtime_error("Unknown network " + network + "\n");
-    }
     bool fRegTest = GetBoolArg("-regtest", false);
     bool fTestNet = GetBoolArg("-testnet", false);
 
@@ -121,7 +109,16 @@ CBaseChainParams::Network NetworkIdFromCommandLine()
         LogPrintStr("WARNING: -testnet is deprecated, use -network=test instead.");
         return CBaseChainParams::TESTNET;
     }
-    return CBaseChainParams::MAIN;
+    std::string network = GetArg("-network", "main");
+    if (network == "main")
+        return CBaseChainParams::MAIN;
+    if (network == "test")
+        return CBaseChainParams::TESTNET;
+    if (network == "regtest")
+        return CBaseChainParams::REGTEST;
+    if (network == "unittest")
+        return CBaseChainParams::UNITTEST;
+    throw std::runtime_error("Unknown network " + network + "\n");
 }
 
 void SelectBaseParamsFromCommandLine()

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -90,7 +90,7 @@ void SelectBaseParams(CBaseChainParams::Network network)
         pCurrentBaseParams = &unitTestParams;
         break;
     default:
-        throw std::runtime_error("Unimplemented network\n");
+        throw std::runtime_error("Unknown network\n");
     }
 }
 
@@ -101,12 +101,12 @@ CBaseChainParams::Network NetworkIdFromCommandLine()
         return CBaseChainParams::MAIN;
     if (network == "testnet")
         return CBaseChainParams::TESTNET;
-    if (network == "testnet")
+    if (network == "regtest")
         return CBaseChainParams::REGTEST;
     if (network == "unittest")
         return CBaseChainParams::UNITTEST;
     if (network != "") {
-        throw std::runtime_error("Unimplemented network " + network + "\n");
+        throw std::runtime_error("Unknown network " + network + "\n");
     }
     bool fRegTest = GetBoolArg("-regtest", false);
     bool fTestNet = GetBoolArg("-testnet", false);

--- a/src/chainparamsbase.h
+++ b/src/chainparamsbase.h
@@ -32,7 +32,6 @@ protected:
 
     int nRPCPort;
     std::string strDataDir;
-    Network networkID;
 };
 
 /**

--- a/src/chainparamsbase.h
+++ b/src/chainparamsbase.h
@@ -52,7 +52,8 @@ void SelectBaseParams(CBaseChainParams::Network network);
 CBaseChainParams::Network NetworkIdFromCommandLine();
 
 /**
- * Calls NetworkIdFromCommandLine() and then calls SelectParams as appropriate.
+ * Calls NetworkIdFromCommandLine() and then calls SelectBaseParams() 
+ * to select the appropriate network.
  */
 void SelectBaseParamsFromCommandLine();
 

--- a/src/chainparamsbase.h
+++ b/src/chainparamsbase.h
@@ -44,16 +44,17 @@ const CBaseChainParams& BaseParams();
 void SelectBaseParams(CBaseChainParams::Network network);
 
 /**
- * Looks for -regtest or -testnet and returns the appropriate Network ID.
- * Returns MAX_NETWORK_TYPES if an invalid combination is given.
+ * Returns the appropriate Network ID from the string provided in -network. 
+ * If nothing is found, it also looks for -regtest or -testnet.
+ * Returns MAIN by default.
+ * Raises an error if an invalid combination is given or if the -network is not supported.
  */
 CBaseChainParams::Network NetworkIdFromCommandLine();
 
 /**
  * Calls NetworkIdFromCommandLine() and then calls SelectParams as appropriate.
- * Returns false if an invalid combination is given.
  */
-bool SelectBaseParamsFromCommandLine();
+void SelectBaseParamsFromCommandLine();
 
 /**
  * Return true if SelectBaseParamsFromCommandLine() has been called to select

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -563,10 +563,12 @@ int main(int argc, char *argv[])
     // - QSettings() will use the new application name after this, resulting in network-specific settings
     // - Needs to be done before createOptionsModel
 
-    // Check for -testnet or -regtest parameter (Params() calls are only valid after this clause)
-    if (!SelectParamsFromCommandLine()) {
-        QMessageBox::critical(0, QObject::tr("Bitcoin Core"), QObject::tr("Error: Invalid combination of -regtest and -testnet."));
-        return 1;
+    // Check for -network, -testnet or -regtest parameter (Params() calls are only valid after this clause)
+    try {
+        SelectParamsFromCommandLine();
+    } catch(std::exception &e) {
+        QMessageBox::critical(0, QObject::tr("Bitcoin Core"), QObject::tr("Error: %1.").arg(e.what()));
+        return false;
     }
 #ifdef ENABLE_WALLET
     // Parse URIs on command line -- this can affect Params()


### PR DESCRIPTION
Continues #5229 
Closing until at least one release has been supporting -network and warning about -testnet and -regtest
