### PR TITLE
Make sure that GetRandomBytes never fails

### DIFF
--- a/src/random.cpp
+++ b/src/random.cpp
@@ -82,13 +82,12 @@ void RandAddSeedPerfmon()
 #endif
 }
 
-bool GetRandBytes(unsigned char* buf, int num)
+void GetRandBytes(unsigned char* buf, int num)
 {
     if (RAND_bytes(buf, num) != 1) {
         LogPrintf("%s: OpenSSL RAND_bytes() failed with error: %s\n", __func__, ERR_error_string(ERR_get_error(), NULL));
-        return false;
+        assert(false);
     }
-    return true;
 }
 
 uint64_t GetRand(uint64_t nMax)

--- a/src/random.h
+++ b/src/random.h
@@ -19,7 +19,7 @@ void RandAddSeedPerfmon();
 /**
  * Functions to gather random data via the OpenSSL PRNG
  */
-bool GetRandBytes(unsigned char* buf, int num);
+void GetRandBytes(unsigned char* buf, int num);
 uint64_t GetRand(uint64_t nMax);
 int GetRandInt(int nMax);
 uint256 GetRandHash();

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -422,15 +422,13 @@ bool CWallet::EncryptWallet(const SecureString& strWalletPassphrase)
     RandAddSeedPerfmon();
 
     vMasterKey.resize(WALLET_CRYPTO_KEY_SIZE);
-    if (!GetRandBytes(&vMasterKey[0], WALLET_CRYPTO_KEY_SIZE))
-        return false;
+    GetRandBytes(&vMasterKey[0], WALLET_CRYPTO_KEY_SIZE);
 
     CMasterKey kMasterKey;
     RandAddSeedPerfmon();
 
     kMasterKey.vchSalt.resize(WALLET_CRYPTO_SALT_SIZE);
-    if (!GetRandBytes(&kMasterKey.vchSalt[0], WALLET_CRYPTO_SALT_SIZE))
-        return false;
+    GetRandBytes(&kMasterKey.vchSalt[0], WALLET_CRYPTO_SALT_SIZE);
 
     CCrypter crypter;
     int64_t nStartTime = GetTimeMillis();


### PR DESCRIPTION
The code uses GetRandomBytes in several contexts where it's either unwieldy to return an error, or an error would mean a fatal exception anyhow. Bitcoin can't cope gracefully with a failing RNG. So just fail with an assertion error.

@gmaxwell checked OpenSSL a while ago and discovered that it never actually fails, but it can't hurt to be a bit paranoid here.

(somehow this gives me a deja-vu, I remember we did this before? can't find it in git history though)
