### PR TITLE
Adding license to file hash.cpp.

### DIFF
--- a/src/hash.cpp
+++ b/src/hash.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2013-2014 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include "hash.h"
 
 inline uint32_t ROTL32(uint32_t x, int8_t r)


### PR DESCRIPTION
It was missing. I checked other .cpp's.
