### PR TITLE
Check against MANDATORY flags prior to accepting to mempool

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1039,6 +1039,21 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
         {
             return error("AcceptToMemoryPool: : ConnectInputs failed %s", hash.ToString());
         }
+
+        // Check again against just the consensus-critical mandatory script
+        // verification flags, in case of bugs in the standard flags that cause
+        // transactions to pass as valid when they're actually invalid. For
+        // instance the STRICTENC flag was incorrectly allowing certain
+        // CHECKSIG NOT scripts to pass, even though they were invalid.
+        //
+        // There is a similar check in CreateNewBlock() to prevent creating
+        // invalid blocks, however allowing such transactions into the mempool
+        // can be exploited as a DoS attack.
+        if (!CheckInputs(tx, state, view, true, MANDATORY_SCRIPT_VERIFY_FLAGS, true))
+        {
+            return error("AcceptToMemoryPool: : BUG! PLEASE REPORT THIS! ConnectInputs failed against MANDATORY but not STANDARD flags %s", hash.ToString());
+        }
+
         // Store transaction in memory
         pool.addUnchecked(hash, entry);
     }


### PR DESCRIPTION
Previously transactions were only tested again the STANDARD_SCRIPT_VERIFY_FLAGS prior to mempool acceptance, so any bugs in those flags that allowed actually-invalid transactions to pass would
result in allowing invalid transactions into the mempool. Fortunately there is a second check in CreateNewBlock() that would prevent those transactions from being mined, resulting in an invalid block, however this could still be exploited as a DoS attack.

An example transaction failing this test that was previously allowed into the mempool is:

0100000001db7f1e5f08248867e5825fdb24e6d8ce4de652e27f6c22a26e3c9380866ea3e6000000008e0047304402203d82f29cdff31153f533039fe7c3dd854e899b7372b8f1d22c50839bbb9481490220425c983fc9ae879853da193b83aecac8b64825ab01583f4ec10a6b18ae51ced60144410778d430274f8c5ec1321338151e9f27f4c676a008bdf8638d07c0b6be9ab35c71a1518063243acd4dfe96b66e3f2ec8013c8e072cd09b3834a19f81f659cc3455ac91ffffffff01881300000000000017a914e661a2229cc824329c9409f49d99cb5ac350c9288700000000

which spends:

0778d430274f8c5ec1321338151e9f27f4c676a008bdf8638d07c0b6be9ab35c71a1518063243acd4dfe96b66e3f2ec8013c8e072cd09b3834a19f81f659cc3455 CHECKSIG NOT

with a valid signature. The existing, broken, STRICTENC, implementation causes the CHECKSIG to return false even though the signature is valid against the mandatory flags.

(FWIW @sipa is fixing this in https://github.com/bitcoin/bitcoin/pull/5247)
