### PR TITLE
Do signature-s negation inside the tests

### DIFF
--- a/src/ecwrapper.cpp
+++ b/src/ecwrapper.cpp
@@ -193,7 +193,7 @@ bool CECKey::SetPubKey(const unsigned char* pubkey, size_t size) {
     return o2i_ECPublicKey(&pkey, &pubkey, size) != NULL;
 }
 
-bool CECKey::Sign(const uint256 &hash, std::vector<unsigned char>& vchSig, bool lowS) {
+bool CECKey::Sign(const uint256 &hash, std::vector<unsigned char>& vchSig) {
     vchSig.clear();
     ECDSA_SIG *sig = ECDSA_do_sign((unsigned char*)&hash, sizeof(hash), pkey);
     if (sig == NULL)
@@ -205,7 +205,7 @@ bool CECKey::Sign(const uint256 &hash, std::vector<unsigned char>& vchSig, bool 
     BIGNUM *halforder = BN_CTX_get(ctx);
     EC_GROUP_get_order(group, order, ctx);
     BN_rshift1(halforder, order);
-    if (lowS && BN_cmp(sig->s, halforder) > 0) {
+    if (BN_cmp(sig->s, halforder) > 0) {
         // enforce low S values, by negating the value (modulo the order) if above order/2.
         BN_sub(sig->s, order, sig->s);
     }

--- a/src/ecwrapper.h
+++ b/src/ecwrapper.h
@@ -28,7 +28,7 @@ public:
     bool SetPrivKey(const unsigned char* privkey, size_t size, bool fSkipCheck=false);
     void GetPubKey(std::vector<unsigned char>& pubkey, bool fCompressed);
     bool SetPubKey(const unsigned char* pubkey, size_t size);
-    bool Sign(const uint256 &hash, std::vector<unsigned char>& vchSig, bool lowS);
+    bool Sign(const uint256 &hash, std::vector<unsigned char>& vchSig);
     bool Verify(const uint256 &hash, const std::vector<unsigned char>& vchSig);
     bool SignCompact(const uint256 &hash, unsigned char *p64, int &rec);
 

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -102,7 +102,7 @@ CPubKey CKey::GetPubKey() const {
     return result;
 }
 
-bool CKey::Sign(const uint256 &hash, std::vector<unsigned char>& vchSig, bool lowS) const {
+bool CKey::Sign(const uint256 &hash, std::vector<unsigned char>& vchSig) const {
     if (!fValid)
         return false;
 #ifdef USE_SECP256K1
@@ -119,7 +119,7 @@ bool CKey::Sign(const uint256 &hash, std::vector<unsigned char>& vchSig, bool lo
 #else
     CECKey key;
     key.SetSecretBytes(vch);
-    return key.Sign(hash, vchSig, lowS);
+    return key.Sign(hash, vchSig);
 #endif
 }
 

--- a/src/key.h
+++ b/src/key.h
@@ -122,7 +122,7 @@ public:
     CPubKey GetPubKey() const;
 
     //! Create a DER-serialized signature.
-    bool Sign(const uint256& hash, std::vector<unsigned char>& vchSig, bool lowS = true) const;
+    bool Sign(const uint256& hash, std::vector<unsigned char>& vchSig) const;
 
     /**
      * Create a compact signature (65 bytes), which allows reconstructing the used public key.


### PR DESCRIPTION
To avoid the need for libsecp256k1 to expose such functionality.
