### PR TITLE
[backups] Automatic backups basics

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -412,6 +412,15 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-rpcsslprivatekeyfile=<file.pem>", strprintf(_("Server private key (default: %s)"), "server.pem"));
     strUsage += HelpMessageOpt("-rpcsslciphers=<ciphers>", strprintf(_("Acceptable ciphers (default: %s)"), "TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH"));
 
+#ifdef ENABLE_WALLET
+    strUsage += HelpMessageGroup(_("Backup options:"));
+    strUsage += HelpMessageOpt("-backups", strprintf(_("Enable auto creation of UNENCRYPTED backups (dumps) (default: %u)"), DEFAULT_BACKUPS_ENABLED));
+    strUsage += HelpMessageOpt("-backupsallowunencrypted", strprintf(_("Allow backups of unencrypted wallets (default: %u)"), DEFAULT_ALLOW_UNENCRYPTED_BACKUPS));
+    strUsage += HelpMessageOpt("-backupspath=<dir> ", strprintf(_("Specify absolut path to backups directory (default: %s)"), strprintf("<datadir>/%s", DEFAULT_BACKUPS_DIR)));
+    strUsage += HelpMessageOpt("-backupsmax=<n>", strprintf(_("Set the number of maximal kept backups (default: %d)"), DEFAULT_BACKUPS_MAX));
+    strUsage += HelpMessageOpt("-backupsdumps=0|1", strprintf(_("If set, walletdumps are created instead of a wallet.dat copy (default: %u)"), DEFAULT_BACKUPS_DUMP));
+#endif
+    
     if (mode == HMM_BITCOIN_QT)
     {
         strUsage += HelpMessageGroup(_("UI Options:"));
@@ -424,7 +433,7 @@ std::string HelpMessage(HelpMessageMode mode)
         strUsage += HelpMessageOpt("-rootcertificates=<file>", _("Set SSL root certificates for payment request (default: -system-)"));
         strUsage += HelpMessageOpt("-splash", _("Show splash screen on startup (default: 1)"));
     }
-
+    
     return strUsage;
 }
 
@@ -1219,6 +1228,10 @@ bool AppInit2(boost::thread_group& threadGroup)
 
             pwalletMain->SetBestChain(chainActive.GetLocator());
         }
+        
+        // create a backup when no backup is yet created
+        if(CWalletDB::GetAvailableBackups().size() == 0)
+            CWalletDB::CreateNewBackup(*pwalletMain);
 
         LogPrintf("%s", strErrors.str());
         LogPrintf(" wallet      %15dms\n", GetTimeMillis() - nStart);

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -2503,7 +2503,7 @@ bool CWallet::DumpToStream(std::ostream& stream)
     std::sort(vKeyBirth.begin(), vKeyBirth.end());
 
     // produce output
-    stream << strprintf("# Wallet dump created by Bitcoin %s (%s)\n", CLIENT_BUILD, CLIENT_DATE);
+    stream << strprintf("# Wallet dump created by Bitcoin Core %s (%s)\n", CLIENT_BUILD, CLIENT_DATE);
     stream << strprintf("# * Created on %s\n", EncodeDumpTime(GetTime()));
     stream << strprintf("# * Best block at time of backup was %i (%s),\n", chainActive.Height(), chainActive.Tip()->GetBlockHash().ToString());
     stream << strprintf("#   mined on %s\n", EncodeDumpTime(chainActive.Tip()->GetBlockTime()));

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -736,6 +736,9 @@ public:
     //! get the current wallet format (the oldest client version guaranteed to understand this wallet)
     int GetVersion() { LOCK(cs_wallet); return nWalletVersion; }
 
+    //! dump wallet to a stream
+    bool DumpToStream(std::ostream& stream);
+    
     //! Get wallet transactions that conflict with given transaction (spend same outputs)
     std::set<uint256> GetConflicts(const uint256& txid) const;
 

--- a/src/walletdb.cpp
+++ b/src/walletdb.cpp
@@ -15,12 +15,12 @@
 
 #include <fstream>
 
+#include <boost/algorithm/string.hpp>
+#include <boost/algorithm/string/predicate.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/foreach.hpp>
 #include <boost/scoped_ptr.hpp>
 #include <boost/thread.hpp>
-#include <boost/algorithm/string.hpp>
-#include <boost/algorithm/string/predicate.hpp>
 
 using namespace std;
 
@@ -892,9 +892,9 @@ bool BackupWallet(const CWallet& wallet, const string& strDest)
     return false;
 }
 
-std::map<std::time_t, filesystem::path> CWalletDB::GetAvailableBackups()
+std::map<std::time_t, boost::filesystem::path> CWalletDB::GetAvailableBackups()
 {
-    filesystem::path backupDir;
+    boost::filesystem::path backupDir;
     std::string strBackupsDir   = GetArg("-backupspath", "");
     if(strBackupsDir != "")
         backupDir = boost::filesystem::path(strBackupsDir);
@@ -903,20 +903,22 @@ std::map<std::time_t, filesystem::path> CWalletDB::GetAvailableBackups()
         backupDir = GetDataDir() / DEFAULT_BACKUPS_DIR;
     }
     
-    std::map<std::time_t, filesystem::path> backupFiles;
-    
+    // now search after available backups
+    std::map<std::time_t, boost::filesystem::path> backupFiles;
     try {
-        if(!filesystem::is_directory(backupDir))
+        if(!boost::filesystem::is_directory(backupDir))
             return backupFiles;
         
-        filesystem::directory_iterator it(backupDir), eod;
-        BOOST_FOREACH(filesystem::path const &p, std::make_pair(it, eod))
+        boost::filesystem::directory_iterator it(backupDir), eod;
+        BOOST_FOREACH(boost::filesystem::path const &p, std::make_pair(it, eod))
         {
-            if(is_regular_file(p) && (ends_with(p.string(), BACKUP_BDB_EXTENSION) || ends_with(p.string(), BACKUP_DUMP_EXTENSION)))
-                backupFiles.insert(std::pair<std::time_t, filesystem::path>(filesystem::last_write_time( p ), p));
+            // only add a file to the backup-hashlist when they match a possible file extension
+            if(is_regular_file(p) && (boost::ends_with(p.string(), BACKUP_BDB_EXTENSION) || boost::ends_with(p.string(), BACKUP_DUMP_EXTENSION)))
+                backupFiles.insert(std::pair<std::time_t, boost::filesystem::path>(boost::filesystem::last_write_time( p ), p));
         }
     }
-    catch(const filesystem::filesystem_error &e) {
+    catch(const boost::filesystem::filesystem_error &e) {
+        // in case of a invalid backup path
         LogPrintf("error retrieving available backups (%s)\n", e.what());
         return backupFiles;
     }
@@ -926,23 +928,27 @@ std::map<std::time_t, filesystem::path> CWalletDB::GetAvailableBackups()
 
 bool CWalletDB::CreateNewBackup(CWallet& wallet)
 {
+    // check for the possibility if the users whishes dumps instead of wallet.dat copies
     bool useDumpsInstedOfBDBFiles = GetBoolArg("-backupsdumps", DEFAULT_BACKUPS_DUMP);
     
     if(!GetBoolArg("-backups", DEFAULT_BACKUPS_ENABLED))
         return false;
     
+    // don't allow backups of unencrypted wallet when -backupsallowunencrypted is not set
     if(!wallet.IsCrypted() && !GetBoolArg("-backupsallowunencrypted", DEFAULT_ALLOW_UNENCRYPTED_BACKUPS))
         return false;
     
     if (!wallet.fFileBacked)
         return false;
     
+    // dumps are not allowed when -backupsallowunencrypted is unset
     if(!GetBoolArg("-backupsallowunencrypted", DEFAULT_ALLOW_UNENCRYPTED_BACKUPS) && useDumpsInstedOfBDBFiles)
     {
         LogPrintf("dumping wallet as backup is only allowed when enabling -backupsallowunencrypted\n");
         return false;
     }
     
+    // locked wallets result in empty dumps, avoid that:
     if(useDumpsInstedOfBDBFiles && wallet.IsLocked())
     {
         LogPrintf("cannot create backup: wallet is locked\n");
@@ -959,8 +965,8 @@ bool CWalletDB::CreateNewBackup(CWallet& wallet)
                 bitdb.CheckpointLSN(wallet.strWalletFile);
                 bitdb.mapFileUseCount.erase(wallet.strWalletFile);
                 
-                filesystem::path pathSrc    = GetDataDir() / wallet.strWalletFile;
-                filesystem::path backupDir;
+                boost::filesystem::path pathSrc    = GetDataDir() / wallet.strWalletFile;
+                boost::filesystem::path backupDir;
                 std::string strBackupsDir   = GetArg("-backupspath", "");
                 if(strBackupsDir != "")
                     backupDir = boost::filesystem::path(strBackupsDir);
@@ -969,30 +975,31 @@ bool CWalletDB::CreateNewBackup(CWallet& wallet)
                     backupDir = GetDataDir() / DEFAULT_BACKUPS_DIR;
                 }
                 
+                // try to create the backupdir
                 try {
                     TryCreateDirectory(backupDir);
                 }
-                catch(const filesystem::filesystem_error &e) {
+                catch(const boost::filesystem::filesystem_error &e) {
                     LogPrintf("error creating backups directory %s - %s\n", backupDir.string(), e.what());
                     return false;
                 }
                 
                 // delete backups over the set trashold
                 int keepMaxBackups = GetArg("-backupsmax", DEFAULT_BACKUPS_MAX);
-                std::map<std::time_t, filesystem::path> backupFiles = GetAvailableBackups();
+                std::map<std::time_t, boost::filesystem::path> backupFiles = GetAvailableBackups();
                 int cnt  = 0;
                 
                 try {
-                    for (std::map<std::time_t, filesystem::path>::reverse_iterator i = backupFiles.rbegin(); i != backupFiles.rend(); ++i) {
+                    for (std::map<std::time_t, boost::filesystem::path>::reverse_iterator i = backupFiles.rbegin(); i != backupFiles.rend(); ++i) {
                         
                         // now we might end up having less then keepMaxBackups in dir because it could be possible that a wallet file gets overwritten when making a backup during the same second (=same filename)
                         if(cnt+1 >= keepMaxBackups)
-                            filesystem::remove(i->second);
+                            boost::filesystem::remove(i->second);
 
                         cnt++;
                     }
                 }
-                catch(const filesystem::filesystem_error &e) {
+                catch(const boost::filesystem::filesystem_error &e) {
                     LogPrintf("error removing old backups (%s)\n", e.what());
                     return false;
                 }
@@ -1001,8 +1008,10 @@ bool CWalletDB::CreateNewBackup(CWallet& wallet)
                 
                 if(useDumpsInstedOfBDBFiles) {
                     std::string newFilename = strprintf("%s.%s%s", wallet.strWalletFile, DateTimeStrFormat("%Y-%m-%d_%H-%M-%S", GetTime()), BACKUP_DUMP_EXTENSION);
-                    replace_last(newFilename, ".dat", "");
-                    filesystem::path pathDest = backupDir / newFilename;
+                    
+                    // remove the unsexy .dat fileextension from the backup (because it's a dump!)
+                    boost::replace_last(newFilename, ".dat", "");
+                    boost::filesystem::path pathDest = backupDir / newFilename;
                     try {
                         ofstream file;
                         file.open(pathDest.string().c_str());
@@ -1022,16 +1031,16 @@ bool CWalletDB::CreateNewBackup(CWallet& wallet)
                 }
                 else {
                     std::string newFilename = strprintf("%s.%s%s", wallet.strWalletFile, DateTimeStrFormat("%Y-%m-%d_%H-%M-%S", GetTime()), BACKUP_BDB_EXTENSION);
-                    filesystem::path pathDest = backupDir / newFilename;
+                    boost::filesystem::path pathDest = backupDir / newFilename;
                     try {
 #if BOOST_VERSION >= 104000
-                        filesystem::copy_file(pathSrc, pathDest, filesystem::copy_option::overwrite_if_exists);
+                        boost::filesystem::copy_file(pathSrc, pathDest, boost::filesystem::copy_option::overwrite_if_exists);
 #else
-                        filesystem::copy_file(pathSrc, pathDest);
+                        boost::filesystem::copy_file(pathSrc, pathDest);
 #endif
                         LogPrintf("copied wallet.dat to %s\n", pathDest.string());
                         return true;
-                    } catch(const filesystem::filesystem_error &e) {
+                    } catch(const boost::filesystem::filesystem_error &e) {
                         LogPrintf("error copying wallet.dat to %s - %s\n", pathDest.string(), e.what());
                         return false;
                     }

--- a/src/walletdb.h
+++ b/src/walletdb.h
@@ -17,7 +17,7 @@
 #include <utility>
 #include <vector>
 
-//
+// define default values for backups
 static const std::string    DEFAULT_BACKUPS_DIR                 = "backups";
 static const std::string    BACKUP_BDB_EXTENSION                = ".bak";
 static const std::string    BACKUP_DUMP_EXTENSION               = ".dump";
@@ -138,7 +138,11 @@ public:
     DBErrors ZapWalletTx(CWallet* pwallet, std::vector<CWalletTx>& vWtx);
     static bool Recover(CDBEnv& dbenv, std::string filename, bool fOnlyKeys);
     static bool Recover(CDBEnv& dbenv, std::string filename);
+    
+    //! create a new backup or dump (configurable through args)
     static bool CreateNewBackup(CWallet& wallet);
+    
+    //! resturn a list of available backups
     static std::map<std::time_t, boost::filesystem::path> GetAvailableBackups();
 
 private:

--- a/src/walletdb.h
+++ b/src/walletdb.h
@@ -17,6 +17,15 @@
 #include <utility>
 #include <vector>
 
+//
+static const std::string    DEFAULT_BACKUPS_DIR                 = "backups";
+static const std::string    BACKUP_BDB_EXTENSION                = ".bak";
+static const std::string    BACKUP_DUMP_EXTENSION               = ".dump";
+static const int            DEFAULT_BACKUPS_MAX                 = 10;
+static const bool           DEFAULT_BACKUPS_ENABLED             = false;
+static const bool           DEFAULT_ALLOW_UNENCRYPTED_BACKUPS   = false;
+static const bool           DEFAULT_BACKUPS_DUMP                = false;
+
 class CAccount;
 class CAccountingEntry;
 struct CBlockLocator;
@@ -129,6 +138,8 @@ public:
     DBErrors ZapWalletTx(CWallet* pwallet, std::vector<CWalletTx>& vWtx);
     static bool Recover(CDBEnv& dbenv, std::string filename, bool fOnlyKeys);
     static bool Recover(CDBEnv& dbenv, std::string filename);
+    static bool CreateNewBackup(CWallet& wallet);
+    static std::map<std::time_t, boost::filesystem::path> GetAvailableBackups();
 
 private:
     CWalletDB(const CWalletDB&);


### PR DESCRIPTION
- allow to do automatic backups when keypool gets refilled
- by default backups are turned off
- by default only encrypted wallets are allowed for backup (configurable)

This could be the basic for later adding backup possibilities for Bitcoin-Qt including visual elements for latest and amount of backups as also validity-check-display of backup files.
