### PR TITLE
Check PoW in AcceptBlockHeader and not LoadBlockIndex.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2363,7 +2363,8 @@ bool AcceptBlockHeader(const CBlockHeader& block, CValidationState& state, CBloc
 
         // Check proof of work
         if ((!Params().SkipProofOfWorkCheck()) &&
-           (block.nBits != GetNextWorkRequired(pindexPrev, &block)))
+           (block.nBits != GetNextWorkRequired(pindexPrev, &block)
+            || !CheckProofOfWork(block.GetHash(), block.nBits)))
             return state.DoS(100, error("%s : incorrect proof of work", __func__),
                              REJECT_INVALID, "bad-diffbits");
 

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -212,9 +212,6 @@ bool CBlockTreeDB::LoadBlockIndexGuts()
                 pindexNew->nStatus        = diskindex.nStatus;
                 pindexNew->nTx            = diskindex.nTx;
 
-                if (!CheckProofOfWork(pindexNew->GetBlockHash(), pindexNew->nBits))
-                    return error("LoadBlockIndex() : CheckProofOfWork failed: %s", pindexNew->ToString());
-
                 pcursor->Next();
             } else {
                 break; // if shutdown requested or finished loading block index


### PR DESCRIPTION
Add a check for the PoW's validity to `AcceptBlockHeader`, and disable the check during `LoadBlockIndex`.  Previously, if a peer sends headers with invalid PoW, they would be accepted to the on-disk block index, but then loading it on the next start would fail.

Not sure if the proposed patch is the perfect solution.  Maybe the check in `LoadBlockIndex` should stay and just the one in `AcceptBlockHeader` be added?
