### PR TITLE
Check block header when accepting headers from peers.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2280,6 +2280,8 @@ bool CheckBlock(const CBlock& block, CValidationState& state, bool fCheckPOW, bo
 {
     // These are checks that are independent of context.
 
+    // Check that the header is valid (particularly PoW).  This is mostly
+    // redundant with the call in AcceptBlockHeader.
     if (!CheckBlockHeader(block, state, fCheckPOW))
         return false;
 
@@ -2350,6 +2352,9 @@ bool AcceptBlockHeader(const CBlockHeader& block, CValidationState& state, CBloc
             return state.Invalid(error("%s : block is marked invalid", __func__), 0, "duplicate");
         return true;
     }
+
+    if (!CheckBlockHeader(block, state))
+        return false;
 
     // Get prev block index
     CBlockIndex* pindexPrev = NULL;


### PR DESCRIPTION
Actually check block headers received from peers.  If a peer sends headers with invalid PoW, they were accepted and added to the disk block index previously.  This would then lead to a failure in checking the PoW
during the next startup while loading the block index.

This is a better version of https://github.com/bitcoin/bitcoin/pull/5269.
