### PR TITLE
setmocktime RPC command for regression testing

### DIFF
--- a/qa/pull-tester/rpc-tests.sh
+++ b/qa/pull-tester/rpc-tests.sh
@@ -8,6 +8,11 @@ CURDIR=$(cd $(dirname "$0"); pwd)
 export BITCOINCLI=${BUILDDIR}/qa/pull-tester/run-bitcoin-cli
 export BITCOIND=${REAL_BITCOIND}
 
+if [ "x${EXEEXT}" = "x.exe" ]; then
+  echo "Win tests currently disabled"
+  exit 0
+fi
+
 #Run the tests
 
 if [ "x${ENABLE_BITCOIND}${ENABLE_UTILS}${ENABLE_WALLET}" = "x111" ]; then

--- a/qa/rpc-tests/util.py
+++ b/qa/rpc-tests/util.py
@@ -103,12 +103,17 @@ def initialize_chain(test_dir):
 
         # Create a 200-block-long chain; each of the 4 nodes
         # gets 25 mature blocks and 25 immature.
-        for i in range(4):
-            rpcs[i].setgenerate(True, 25)
-            sync_blocks(rpcs)
-        for i in range(4):
-            rpcs[i].setgenerate(True, 25)
-            sync_blocks(rpcs)
+        # blocks are created with timestamps 10 minutes apart, starting
+        # at 1 Jan 2014
+        block_time = 1388534400
+        for i in range(2):
+            for peer in range(4):
+                for j in range(25):
+                    set_node_times(rpcs, block_time)
+                    rpcs[peer].setgenerate(True, 1)
+                    block_time += 10*60
+                # Must sync before next peer starts generating blocks
+                sync_blocks(rpcs)
 
         # Shut them down, and clean up cache directories:
         stop_nodes(rpcs)
@@ -179,9 +184,13 @@ def stop_node(node, i):
     del bitcoind_processes[i]
 
 def stop_nodes(nodes):
-    for i in range(len(nodes)):
-        nodes[i].stop()
+    for node in nodes:
+        node.stop()
     del nodes[:] # Emptying array closes connections as a side effect
+
+def set_node_times(nodes, t):
+    for node in nodes:
+        node.setmocktime(t)
 
 def wait_bitcoinds():
     # Wait for all bitcoinds to cleanly exit

--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -25,6 +25,7 @@ public:
 static const CRPCConvertParam vRPCConvertParams[] =
 {
     { "stop", 0 },
+    { "setmocktime", 0 },
     { "getaddednodeinfo", 0 },
     { "setgenerate", 0 },
     { "setgenerate", 1 },

--- a/src/rpcmisc.cpp
+++ b/src/rpcmisc.cpp
@@ -354,3 +354,23 @@ Value verifymessage(const Array& params, bool fHelp)
 
     return (pubkey.GetID() == keyID);
 }
+
+Value setmocktime(const Array& params, bool fHelp)
+{
+    if (fHelp || params.size() != 1)
+        throw runtime_error(
+            "setmocktime timestamp\n"
+            "\nSet the local time to given timestamp (-regtest only)\n"
+            "\nArguments:\n"
+            "1. timestamp  (integer, required) Unix seconds-since-epoch timestamp\n"
+            "   Pass 0 to go back to using the system time."
+        );
+
+    if (!Params().MineBlocksOnDemand())
+        throw runtime_error("setmocktime for regression testing (-regtest mode) only");
+
+    RPCTypeCheck(params, boost::assign::list_of(int_type));
+    SetMockTime(params[0].get_int64());
+
+    return Value::null;
+}

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -246,6 +246,7 @@ static const CRPCCommand vRPCCommands[] =
     { "control",            "getinfo",                &getinfo,                true,      false,      false }, /* uses wallet if enabled */
     { "control",            "help",                   &help,                   true,      true,       false },
     { "control",            "stop",                   &stop,                   true,      true,       false },
+    { "control",            "setmocktime",            &setmocktime,            true,      false,      false },
 
     /* P2P networking */
     { "network",            "getnetworkinfo",         &getnetworkinfo,         true,      false,      false },

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -194,6 +194,7 @@ extern json_spirit::Value getinfo(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value getwalletinfo(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value getblockchaininfo(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value getnetworkinfo(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value setmocktime(const json_spirit::Array& params, bool fHelp);
 
 extern json_spirit::Value getrawtransaction(const json_spirit::Array& params, bool fHelp); // in rcprawtransaction.cpp
 extern json_spirit::Value listunspent(const json_spirit::Array& params, bool fHelp);


### PR DESCRIPTION
Two changes:

Adds a -regtest-only-mode `setmocktime timestamp` RPC call that causes all subsequent internal GetTime() calls to return that time. This uses the same code as some of the unit tests; it will let us do more thorough testing of scenarios with peers that have different notions of the current time.

The last commit modifies the regression test initial blockchain (stored in the qa/rpc-tests/cache/ directory) so those blocks are created with fixed, known timestamps (will be important for code that tests difficulty adjustment / re-org scenarios).

Builds on #5275 
