### PR TITLE
Rename dir to dirname in qa/rpc-tests/util.py

### DIFF
--- a/qa/rpc-tests/util.py
+++ b/qa/rpc-tests/util.py
@@ -61,8 +61,8 @@ def sync_mempools(rpc_connections):
 
 bitcoind_processes = {}
 
-def initialize_datadir(dir, n):
-    datadir = os.path.join(dir, "node"+str(n))
+def initialize_datadir(dirname, n):
+    datadir = os.path.join(dirname, "node"+str(n))
     if not os.path.isdir(datadir):
         os.makedirs(datadir)
     with open(os.path.join(datadir, "bitcoin.conf"), 'w') as f:
@@ -145,11 +145,11 @@ def _rpchost_to_args(rpchost):
         rv += ['-rpcport=' + rpcport]
     return rv
 
-def start_node(i, dir, extra_args=None, rpchost=None):
+def start_node(i, dirname, extra_args=None, rpchost=None):
     """
     Start a bitcoind and return RPC connection to it
     """
-    datadir = os.path.join(dir, "node"+str(i))
+    datadir = os.path.join(dirname, "node"+str(i))
     args = [ os.getenv("BITCOIND", "bitcoind"), "-datadir="+datadir, "-keypool=1", "-discover=0" ]
     if extra_args is not None: args.extend(extra_args)
     bitcoind_processes[i] = subprocess.Popen(args)
@@ -163,15 +163,15 @@ def start_node(i, dir, extra_args=None, rpchost=None):
     proxy.url = url # store URL on proxy for info
     return proxy
 
-def start_nodes(num_nodes, dir, extra_args=None, rpchost=None):
+def start_nodes(num_nodes, dirname, extra_args=None, rpchost=None):
     """
     Start multiple bitcoinds, return RPC connections to them
     """
     if extra_args is None: extra_args = [ None for i in range(num_nodes) ]
-    return [ start_node(i, dir, extra_args[i], rpchost) for i in range(num_nodes) ]
+    return [ start_node(i, dirname, extra_args[i], rpchost) for i in range(num_nodes) ]
 
-def log_filename(dir, n_node, logname):
-    return os.path.join(dir, "node"+str(n_node), "regtest", logname)
+def log_filename(dirname, n_node, logname):
+    return os.path.join(dirname, "node"+str(n_node), "regtest", logname)
 
 def stop_node(node, i):
     node.stop()


### PR DESCRIPTION
Rename "dir" to "dirname" because "dir" is the name of a function in python, and it is a generally good idea to not override existing functions, even if dir is unlikely to be used.
