### PR TITLE
[Qt] Fix height of BitcoinAmountField

### DIFF
--- a/src/qt/bitcoinamountfield.cpp
+++ b/src/qt/bitcoinamountfield.cpp
@@ -130,6 +130,7 @@ public:
             extra += hint - style()->subControlRect(QStyle::CC_SpinBox, &opt,
                                                     QStyle::SC_SpinBoxEditField, this).size();
             hint += extra;
+            hint.setHeight(h);
 
             opt.rect = rect();
 


### PR DESCRIPTION
Since #4556 the amountfield is too big under qt5 for me.

Before:
![toobig](https://cloud.githubusercontent.com/assets/2814559/5059815/7b0429c2-6d2d-11e4-934c-504e591f7404.png)

After:
![toobig1](https://cloud.githubusercontent.com/assets/2814559/5059814/7b027f14-6d2d-11e4-84ac-c5e65e44d25f.png)
