### PR TITLE
Coin Control UI fixes

### DIFF
--- a/src/qt/forms/coincontroldialog.ui
+++ b/src/qt/forms/coincontroldialog.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Coin Control Address Selection</string>
+   <string>Coin Selection</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
@@ -451,12 +451,12 @@
      </column>
      <column>
       <property name="text">
-       <string notr="true">Label</string>
+       <string>Received with label</string>
       </property>
      </column>
      <column>
       <property name="text">
-       <string>Address</string>
+       <string>Received with address</string>
       </property>
      </column>
      <column>

--- a/src/qt/forms/coincontroldialog.ui
+++ b/src/qt/forms/coincontroldialog.ui
@@ -379,9 +379,6 @@
           <property name="text">
            <string>Tree mode</string>
           </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
          </widget>
         </item>
         <item>
@@ -394,6 +391,9 @@
           </property>
           <property name="text">
            <string>List mode</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
           </property>
          </widget>
         </item>


### PR DESCRIPTION
Some users seem to get confused and thinking coin control implies they can send from addresses and such. This aims to clarify the language used.

It also sets "List mode" to the default, since it makes more sense than "Tree mode" (at least to me, as a regular user of it - I'm always switching to List mode immediately).
