### PR TITLE
[Qt, OSX] QProgressBar CPU-Issue workaround

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -58,20 +58,6 @@
 #include <QUrlQuery>
 #endif
 
-#ifdef Q_OS_MAC
-#include <QEvent>
-
-// workaround for Qt OSX Bug:
-// https://bugreports.qt-project.org/browse/QTBUG-15631
-// QProgressBar uses around 10% CPU even when app is in background
-class QProgressBarMac : public QProgressBar
-{
-    bool event(QEvent *e) {
-        return (e->type() != QEvent::StyleAnimationUpdate) ? QProgressBar::event(e) : false;
-    }
-};
-#endif
-
 const QString BitcoinGUI::DEFAULT_WALLET = "~Default";
 
 BitcoinGUI::BitcoinGUI(const NetworkStyle *networkStyle, QWidget *parent) :
@@ -204,11 +190,7 @@ BitcoinGUI::BitcoinGUI(const NetworkStyle *networkStyle, QWidget *parent) :
     // Progress bar and label for blocks download
     progressBarLabel = new QLabel();
     progressBarLabel->setVisible(false);
-#ifdef Q_OS_MAC
-    progressBar = new QProgressBarMac();
-#else
-    progressBar = new QProgressBar();
-#endif
+    progressBar = new GUIUtil::ProgressBar();
     progressBar->setAlignment(Qt::AlignCenter);
     progressBar->setVisible(false);
 

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -58,6 +58,20 @@
 #include <QUrlQuery>
 #endif
 
+#ifdef Q_OS_MAC
+#include <QEvent>
+
+// workaround for Qt OSX Bug:
+// https://bugreports.qt-project.org/browse/QTBUG-15631
+// QProgressBar uses around 10% CPU even when app is in background
+class QProgressBarMac : public QProgressBar
+{
+    bool event(QEvent *e) {
+        return (e->type() != QEvent::StyleAnimationUpdate) ? QProgressBar::event(e) : false;
+    }
+};
+#endif
+
 const QString BitcoinGUI::DEFAULT_WALLET = "~Default";
 
 BitcoinGUI::BitcoinGUI(const NetworkStyle *networkStyle, QWidget *parent) :
@@ -190,7 +204,11 @@ BitcoinGUI::BitcoinGUI(const NetworkStyle *networkStyle, QWidget *parent) :
     // Progress bar and label for blocks download
     progressBarLabel = new QLabel();
     progressBarLabel->setVisible(false);
+#ifdef Q_OS_MAC
+    progressBar = new QProgressBarMac();
+#else
     progressBar = new QProgressBar();
+#endif
     progressBar->setAlignment(Qt::AlignCenter);
     progressBar->setVisible(false);
 

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -7,9 +7,11 @@
 
 #include "amount.h"
 
+#include <QEvent>
 #include <QHeaderView>
 #include <QMessageBox>
 #include <QObject>
+#include <QProgressBar>
 #include <QString>
 #include <QTableView>
 
@@ -186,6 +188,21 @@ namespace GUIUtil
 
     /* Format a CNodeCombinedStats.dPingTime into a user-readable string or display N/A, if 0*/
     QString formatPingTime(double dPingTime);
+    
+#ifdef Q_OS_MAC
+    // workaround for Qt OSX Bug:
+    // https://bugreports.qt-project.org/browse/QTBUG-15631
+    // QProgressBar uses around 10% CPU even when app is in background
+    class ProgressBar : public QProgressBar
+    {
+        bool event(QEvent *e) {
+            return (e->type() != QEvent::StyleAnimationUpdate) ? QProgressBar::event(e) : false;
+        }
+    };
+#else
+    typedef QProgressBar ProgressBar;
+#endif
+    
 } // namespace GUIUtil
 
 #endif // BITCOIN_QT_GUIUTIL_H


### PR DESCRIPTION
fixes #5295 

I know it's a bit of a hack. But it saves a lot of CPU ticks on OSX.
You might decide to take this in because it does the job and the QTBUG-15631 seams to be open and untouched since 2010.
