### PR TITLE
Add -onion=noproxy for unproxied *.onion connections

### DIFF
--- a/doc/tor.md
+++ b/doc/tor.md
@@ -19,6 +19,9 @@ outgoing connections be anonymized, but more is possible.
 	-onion=ip:port  Set the proxy server to use for tor hidden services. You do not
 	                need to set this if it's the same as -proxy. You can use -noonion
 	                to explicitly disable access to hidden service.
+	                Setting -onion=noproxy will attempt to resolve hidden services
+	                and connect to them directly (for those with transparent tor
+	                proxies installed).
 	
 	-listen         When using -proxy, listening is disabled by default. If you want
 	                to run a hidden service (see next section), you'll need to enable

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -263,7 +263,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += "  -maxconnections=<n>    " + strprintf(_("Maintain at most <n> connections to peers (default: %u)"), 125) + "\n";
     strUsage += "  -maxreceivebuffer=<n>  " + strprintf(_("Maximum per-connection receive buffer, <n>*1000 bytes (default: %u)"), 5000) + "\n";
     strUsage += "  -maxsendbuffer=<n>     " + strprintf(_("Maximum per-connection send buffer, <n>*1000 bytes (default: %u)"), 1000) + "\n";
-    strUsage += "  -onion=<ip:port>       " + strprintf(_("Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: %s)"), "-proxy") + "\n";
+    strUsage += "  -onion=<ip:port>       " + strprintf(_("Use separate SOCKS5 proxy (or \"noproxy\") to reach peers via Tor hidden services (default: %s)"), "-proxy") + "\n";
     strUsage += "  -onlynet=<net>         " + _("Only connect to nodes in network <net> (ipv4, ipv6 or onion)") + "\n";
     strUsage += "  -permitbaremultisig    " + strprintf(_("Relay non-P2SH multisig (default: %u)"), 1) + "\n";
     strUsage += "  -port=<port>           " + strprintf(_("Listen for connections on <port> (default: %u or testnet: %u)"), 8333, 18333) + "\n";
@@ -861,7 +861,10 @@ bool AppInit2(boost::thread_group& threadGroup)
     }
 
     // -onion can override normal proxy, -noonion disables tor entirely
-    if (!(mapArgs.count("-onion") && mapArgs["-onion"] == "0") &&
+    if (mapArgs.count("-onion") && mapArgs["-onion"] == "noproxy") {
+        fTorNoProxy = true;
+        SetReachable(NET_TOR);
+    } else if ((!mapArgs.count("-onion") || mapArgs["-onion"] != "0") &&
         (fProxy || mapArgs.count("-onion"))) {
         CService addrOnion;
         if (!mapArgs.count("-onion"))

--- a/src/netbase.h
+++ b/src/netbase.h
@@ -18,6 +18,7 @@
 
 extern int nConnectTimeout;
 extern bool fNameLookup;
+extern bool fTorNoProxy;
 
 /** -timeout default */
 static const int DEFAULT_CONNECT_TIMEOUT = 5000;
@@ -46,8 +47,8 @@ class CNetAddr
     public:
         CNetAddr();
         CNetAddr(const struct in_addr& ipv4Addr);
-        explicit CNetAddr(const char *pszIp, bool fAllowLookup = false);
-        explicit CNetAddr(const std::string &strIp, bool fAllowLookup = false);
+        explicit CNetAddr(const char *pszIp, bool fAllowLookup = false, bool fTorLookup = false);
+        explicit CNetAddr(const std::string &strIp, bool fAllowLookup = false, bool fTorLookup = false);
         void Init();
         void SetIP(const CNetAddr& ip);
 
@@ -178,7 +179,7 @@ bool GetProxy(enum Network net, proxyType &proxyInfoOut);
 bool IsProxy(const CNetAddr &addr);
 bool SetNameProxy(CService addrProxy);
 bool HaveNameProxy();
-bool LookupHost(const char *pszName, std::vector<CNetAddr>& vIP, unsigned int nMaxSolutions = 0, bool fAllowLookup = true);
+bool LookupHost(const char *pszName, std::vector<CNetAddr>& vIP, unsigned int nMaxSolutions = 0, bool fAllowLookup = true, bool fTorLookup = false);
 bool Lookup(const char *pszName, CService& addr, int portDefault = 0, bool fAllowLookup = true);
 bool Lookup(const char *pszName, std::vector<CService>& vAddr, int portDefault = 0, bool fAllowLookup = true, unsigned int nMaxSolutions = 0);
 bool LookupNumeric(const char *pszName, CService& addr, int portDefault = 0);


### PR DESCRIPTION
Kind of ugly hack to pass a fWeAreUsingThisAtConnecTime flag through to LookupIntern which disables the resgular tor-lookup bypass.
With this I can successfully connect to *.onion from my machines (which are always behind a VPN which has a *.onion transparent proxy setup).
