### PR TITLE
[Qt, OSX] fix usage of osx 10.8+ user notification center

### DIFF
--- a/src/qt/macnotificationhandler.mm
+++ b/src/qt/macnotificationhandler.mm
@@ -5,7 +5,20 @@
 #include "macnotificationhandler.h"
 
 #undef slots
+#import <objc/runtime.h>
 #include <Cocoa/Cocoa.h>
+
+// Add an obj-c category (extension) to return the expected bundle identifier
+@implementation NSBundle(returnCorrectIdentifier)
+- (NSString *)__bundleIdentifier
+{
+    if (self == [NSBundle mainBundle]) {
+        return @"org.bitcoinfoundation.Bitcoin-Qt";
+    } else {
+        return [self __bundleIdentifier];
+    }
+}
+@end
 
 void MacNotificationHandler::showNotification(const QString &title, const QString &text)
 {
@@ -63,7 +76,16 @@ bool MacNotificationHandler::hasUserNotificationCenterSupport(void)
 MacNotificationHandler *MacNotificationHandler::instance()
 {
     static MacNotificationHandler *s_instance = NULL;
-    if (!s_instance)
+    if (!s_instance) {
         s_instance = new MacNotificationHandler();
+        
+        Class aPossibleClass = objc_getClass("NSBundle");
+        if (aPossibleClass) {
+            // change NSBundle -bundleIdentifier method to return a correct bundle identifier
+            // a bundle identifier is required to use OSXs User Notification Center
+            method_exchangeImplementations(class_getInstanceMethod(aPossibleClass, @selector(bundleIdentifier)),
+                                           class_getInstanceMethod(aPossibleClass, @selector(__bundleIdentifier)));
+        }
+    }
     return s_instance;
 }


### PR DESCRIPTION
Currently Bitcoin-Qts support for OSX User Notification Center is broken. This pull will fix a known issue of non-official-apple-built apps having problems sending user notifications.

Again this is a unloved platform dependent thing but we might continue to support this because we started this in #2615.
