### PR TITLE
Advertize all new block hashes in a reorganization

### DIFF
--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -51,6 +51,9 @@ CBlockLocator CChain::GetLocator(const CBlockIndex *pindex) const {
 }
 
 const CBlockIndex *CChain::FindFork(const CBlockIndex *pindex) const {
+    if (pindex == NULL) {
+        return NULL;
+    }
     if (pindex->nHeight > Height())
         pindex = pindex->GetAncestor(Height());
     while (pindex && !Contains(pindex))


### PR DESCRIPTION
Currently we only `inv` the hash of the new tip, which means that several round-trips are needed to first discover the hashes of all blocks in between. We can just announce all new hashes.

Just a minor improvement, not intended for 0.10.
