### PR TITLE
Truthier error message when rpcpassword is missing

### DIFF
--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -565,13 +565,8 @@ void StartRPCThreads()
     {
         unsigned char rand_pwd[32];
         GetRandBytes(rand_pwd, 32);
-        string strWhatAmI = "To use bitcoind";
-        if (mapArgs.count("-server"))
-            strWhatAmI = strprintf(_("To use the %s option"), "\"-server\"");
-        else if (mapArgs.count("-daemon"))
-            strWhatAmI = strprintf(_("To use the %s option"), "\"-daemon\"");
         uiInterface.ThreadSafeMessageBox(strprintf(
-            _("%s, you must set a rpcpassword in the configuration file:\n"
+            _("To use bitcoind, or the -server option to bitcoin-qt, you must set an rpcpassword in the configuration file:\n"
               "%s\n"
               "It is recommended you use the following random password:\n"
               "rpcuser=bitcoinrpc\n"
@@ -581,7 +576,6 @@ void StartRPCThreads()
               "If the file does not exist, create it with owner-readable-only file permissions.\n"
               "It is also recommended to set alertnotify so you are notified of problems;\n"
               "for example: alertnotify=echo %%s | mail -s \"Bitcoin Alert\" admin@foo.com\n"),
-                strWhatAmI,
                 GetConfigFile().string(),
                 EncodeBase58(&rand_pwd[0],&rand_pwd[0]+32)),
                 "", CClientUIInterface::MSG_ERROR | CClientUIInterface::SECURE);


### PR DESCRIPTION
See #5178 -- this change makes the error slightly more honest / less confusing. The message was always being displayed as "To use the -server option". The check for "-server" did not work as intended, because SoftSetBoolArg is used to enable -server anytime we run as bitcoind, so there's no way for this code to tell whether -server was actually passed by the user or not.

If there's some nice way to tell whether we're bitcoind or bitcoin-core, we could customize the error message accordingly; but it's probably not worth adding code in order to do that, so I've made a single error message that covers both.

I have removed all references to -daemon because as far as I can tell that flag has no effect on whether RPC is enabled or not. (RPC-enabling happens only on init.cpp:768, as far as I can tell, and is conditional only on whether -server is set, which happens if the user passes "-server", or if we are bitcoind. I couldn't find any way for -daemon to affect this.)

Previously, one of the possible messages was localized and the other was not. I have left the message localized, but I don't know what else I might need to touch since I changed it. (gmaxwell opined to me that it's better not to localize error messages at all; I'm happy to remove that here if it's undesired.)
