### PR TITLE
Clean up wallet encryption code.

### DIFF
--- a/src/crypter.h
+++ b/src/crypter.h
@@ -107,9 +107,6 @@ public:
     }
 };
 
-bool EncryptSecret(const CKeyingMaterial& vMasterKey, const CKeyingMaterial &vchPlaintext, const uint256& nIV, std::vector<unsigned char> &vchCiphertext);
-bool DecryptSecret(const CKeyingMaterial& vMasterKey, const std::vector<unsigned char>& vchCiphertext, const uint256& nIV, CKeyingMaterial& vchPlaintext);
-
 /** Keystore which keeps the private keys encrypted.
  * It derives from the basic key store, which is used if no encryption is active.
  */


### PR DESCRIPTION
Add a new method `DecryptKey` in `crypter.cpp`, that combines the logic for decrypting, initialising and validating a `CKey` object.  This was previously duplicated.

Note that the verification of the public key was not done for `GetKey` before (only while unlocking).  I don't think that it is a problem to check the validity of the key also in `GetKey`, though.
