### PR TITLE
Convert remaining comments in /src to doxygen format

### DIFF
--- a/src/base58.cpp
+++ b/src/base58.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2014 The Bitcoin developers
-// Distributed under the MIT/X11 software license, see the accompanying
+// Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "base58.h"
@@ -15,7 +15,7 @@
 #include <boost/variant/apply_visitor.hpp>
 #include <boost/variant/static_visitor.hpp>
 
-/* All alphanumeric characters except for "0", "I", "O", and "l" */
+/** All alphanumeric characters except for "0", "I", "O", and "l" */
 static const char* pszBase58 = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
 
 bool DecodeBase58(const char* psz, std::vector<unsigned char>& vch)

--- a/src/base58.h
+++ b/src/base58.h
@@ -1,16 +1,16 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
-// Copyright (c) 2009-2013 The Bitcoin developers
-// Distributed under the MIT/X11 software license, see the accompanying
+// Copyright (c) 2009-2014 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-//
-// Why base-58 instead of standard base-64 encoding?
-// - Don't want 0OIl characters that look the same in some fonts and
-//      could be used to create visually identical looking account numbers.
-// - A string with non-alphanumeric characters is not as easily accepted as an account number.
-// - E-mail usually won't line-break if there's no punctuation to break at.
-// - Double-clicking selects the whole number as one word if it's all alphanumeric.
-//
+/**
+ * Why base-58 instead of standard base-64 encoding?
+ * - Don't want 0OIl characters that look the same in some fonts and
+ *      could be used to create visually identical looking account numbers.
+ * - A string with non-alphanumeric characters is not as easily accepted as an account number.
+ * - E-mail usually won't line-break if there's no punctuation to break at.
+ * - Double-clicking selects the whole number as one word if it's all alphanumeric.
+ */
 #ifndef BITCOIN_BASE58_H
 #define BITCOIN_BASE58_H
 
@@ -70,10 +70,10 @@ inline bool DecodeBase58Check(const std::string& str, std::vector<unsigned char>
 class CBase58Data
 {
 protected:
-    // the version byte(s)
+    //! the version byte(s)
     std::vector<unsigned char> vchVersion;
 
-    // the actually encoded data
+    //! the actually encoded data
     typedef std::vector<unsigned char, zero_after_free_allocator<unsigned char> > vector_uchar;
     vector_uchar vchData;
 

--- a/src/bloom.cpp
+++ b/src/bloom.cpp
@@ -1,5 +1,5 @@
-// Copyright (c) 2012 The Bitcoin developers
-// Distributed under the MIT/X11 software license, see the accompanying
+// Copyright (c) 2012-2014 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "bloom.h"
@@ -21,13 +21,17 @@
 using namespace std;
 
 CBloomFilter::CBloomFilter(unsigned int nElements, double nFPRate, unsigned int nTweakIn, unsigned char nFlagsIn) :
-// The ideal size for a bloom filter with a given number of elements and false positive rate is:
-// - nElements * log(fp rate) / ln(2)^2
-// We ignore filter parameters which will create a bloom filter larger than the protocol limits
+/**
+ * The ideal size for a bloom filter with a given number of elements and false positive rate is:
+ * - nElements * log(fp rate) / ln(2)^2
+ * We ignore filter parameters which will create a bloom filter larger than the protocol limits
+ */
 vData(min((unsigned int)(-1  / LN2SQUARED * nElements * log(nFPRate)), MAX_BLOOM_FILTER_SIZE * 8) / 8),
-// The ideal number of hash functions is filter size * ln(2) / number of elements
-// Again, we ignore filter parameters which will create a bloom filter with more hash functions than the protocol limits
-// See http://en.wikipedia.org/wiki/Bloom_filter for an explanation of these formulas
+/**
+ * The ideal number of hash functions is filter size * ln(2) / number of elements
+ * Again, we ignore filter parameters which will create a bloom filter with more hash functions than the protocol limits
+ * See https://en.wikipedia.org/wiki/Bloom_filter for an explanation of these formulas
+ */
 isFull(false),
 isEmpty(false),
 nHashFuncs(min((unsigned int)(vData.size() * 8 / nElements * LN2), MAX_HASH_FUNCS)),

--- a/src/bloom.h
+++ b/src/bloom.h
@@ -1,5 +1,5 @@
-// Copyright (c) 2012 The Bitcoin developers
-// Distributed under the MIT/X11 software license, see the accompanying
+// Copyright (c) 2012-2014 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #ifndef BITCOIN_BLOOM_H
@@ -13,12 +13,14 @@ class COutPoint;
 class CTransaction;
 class uint256;
 
-// 20,000 items with fp rate < 0.1% or 10,000 items and <0.0001%
+//! 20,000 items with fp rate < 0.1% or 10,000 items and <0.0001%
 static const unsigned int MAX_BLOOM_FILTER_SIZE = 36000; // bytes
 static const unsigned int MAX_HASH_FUNCS = 50;
 
-// First two bits of nFlags control how much IsRelevantAndUpdate actually updates
-// The remaining bits are reserved
+/**
+ * First two bits of nFlags control how much IsRelevantAndUpdate actually updates
+ * The remaining bits are reserved
+ */
 enum bloomflags
 {
     BLOOM_UPDATE_NONE = 0,
@@ -52,13 +54,15 @@ private:
     unsigned int Hash(unsigned int nHashNum, const std::vector<unsigned char>& vDataToHash) const;
 
 public:
-    // Creates a new bloom filter which will provide the given fp rate when filled with the given number of elements
-    // Note that if the given parameters will result in a filter outside the bounds of the protocol limits,
-    // the filter created will be as close to the given parameters as possible within the protocol limits.
-    // This will apply if nFPRate is very low or nElements is unreasonably high.
-    // nTweak is a constant which is added to the seed value passed to the hash function
-    // It should generally always be a random value (and is largely only exposed for unit testing)
-    // nFlags should be one of the BLOOM_UPDATE_* enums (not _MASK)
+    /**
+     * Creates a new bloom filter which will provide the given fp rate when filled with the given number of elements
+     * Note that if the given parameters will result in a filter outside the bounds of the protocol limits,
+     * the filter created will be as close to the given parameters as possible within the protocol limits.
+     * This will apply if nFPRate is very low or nElements is unreasonably high.
+     * nTweak is a constant which is added to the seed value passed to the hash function
+     * It should generally always be a random value (and is largely only exposed for unit testing)
+     * nFlags should be one of the BLOOM_UPDATE_* enums (not _MASK)
+     */
     CBloomFilter(unsigned int nElements, double nFPRate, unsigned int nTweak, unsigned char nFlagsIn);
     CBloomFilter() : isFull(true), isEmpty(false), nHashFuncs(0), nTweak(0), nFlags(0) {}
 
@@ -82,14 +86,14 @@ public:
 
     void clear();
 
-    // True if the size is <= MAX_BLOOM_FILTER_SIZE and the number of hash functions is <= MAX_HASH_FUNCS
-    // (catch a filter which was just deserialized which was too big)
+    //! True if the size is <= MAX_BLOOM_FILTER_SIZE and the number of hash functions is <= MAX_HASH_FUNCS
+    //! (catch a filter which was just deserialized which was too big)
     bool IsWithinSizeConstraints() const;
 
-    // Also adds any outputs which match the filter to the filter (to match their spending txes)
+    //! Also adds any outputs which match the filter to the filter (to match their spending txes)
     bool IsRelevantAndUpdate(const CTransaction& tx);
 
-    // Checks for empty and full filters to avoid wasting cpu
+    //! Checks for empty and full filters to avoid wasting cpu
     void UpdateEmptyFull();
 };
 

--- a/src/compressor.h
+++ b/src/compressor.h
@@ -28,19 +28,23 @@ class CScriptID;
 class CScriptCompressor
 {
 private:
-    // make this static for now (there are only 6 special scripts defined)
-    // this can potentially be extended together with a new nVersion for
-    // transactions, in which case this value becomes dependent on nVersion
-    // and nHeight of the enclosing transaction.
+    /**
+     * make this static for now (there are only 6 special scripts defined)
+     * this can potentially be extended together with a new nVersion for
+     * transactions, in which case this value becomes dependent on nVersion
+     * and nHeight of the enclosing transaction.
+     */
     static const unsigned int nSpecialScripts = 6;
 
     CScript &script;
 protected:
-    // These check for scripts for which a special case with a shorter encoding is defined.
-    // They are implemented separately from the CScript test, as these test for exact byte
-    // sequence correspondences, and are more strict. For example, IsToPubKey also verifies
-    // whether the public key is valid (as invalid ones cannot be represented in compressed
-    // form).
+    /**
+     * These check for scripts for which a special case with a shorter encoding is defined.
+     * They are implemented separately from the CScript test, as these test for exact byte
+     * sequence correspondences, and are more strict. For example, IsToPubKey also verifies
+     * whether the public key is valid (as invalid ones cannot be represented in compressed
+     * form).
+     */
     bool IsToKeyID(CKeyID &hash) const;
     bool IsToScriptID(CScriptID &hash) const;
     bool IsToPubKey(CPubKey &pubkey) const;

--- a/src/crypter.h
+++ b/src/crypter.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2009-2013 The Bitcoin developers
+// Copyright (c) 2009-2014 The Bitcoin developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -14,20 +14,20 @@ class uint256;
 const unsigned int WALLET_CRYPTO_KEY_SIZE = 32;
 const unsigned int WALLET_CRYPTO_SALT_SIZE = 8;
 
-/*
-Private key encryption is done based on a CMasterKey,
-which holds a salt and random encryption key.
-
-CMasterKeys are encrypted using AES-256-CBC using a key
-derived using derivation method nDerivationMethod
-(0 == EVP_sha512()) and derivation iterations nDeriveIterations.
-vchOtherDerivationParameters is provided for alternative algorithms
-which may require more parameters (such as scrypt).
-
-Wallet Private Keys are then encrypted using AES-256-CBC
-with the double-sha256 of the public key as the IV, and the
-master key's key as the encryption key (see keystore.[ch]).
-*/
+/**
+ * Private key encryption is done based on a CMasterKey,
+ * which holds a salt and random encryption key.
+ * 
+ * CMasterKeys are encrypted using AES-256-CBC using a key
+ * derived using derivation method nDerivationMethod
+ * (0 == EVP_sha512()) and derivation iterations nDeriveIterations.
+ * vchOtherDerivationParameters is provided for alternative algorithms
+ * which may require more parameters (such as scrypt).
+ * 
+ * Wallet Private Keys are then encrypted using AES-256-CBC
+ * with the double-sha256 of the public key as the IV, and the
+ * master key's key as the encryption key (see keystore.[ch]).
+ */
 
 /** Master key for wallet encryption */
 class CMasterKey
@@ -35,12 +35,12 @@ class CMasterKey
 public:
     std::vector<unsigned char> vchCryptedKey;
     std::vector<unsigned char> vchSalt;
-    // 0 = EVP_sha512()
-    // 1 = scrypt()
+    //! 0 = EVP_sha512()
+    //! 1 = scrypt()
     unsigned int nDerivationMethod;
     unsigned int nDeriveIterations;
-    // Use this for more parameters to key derivation,
-    // such as the various parameters to scrypt
+    //! Use this for more parameters to key derivation,
+    //! such as the various parameters to scrypt
     std::vector<unsigned char> vchOtherDerivationParameters;
 
     ADD_SERIALIZE_METHODS;
@@ -120,17 +120,17 @@ private:
 
     CKeyingMaterial vMasterKey;
 
-    // if fUseCrypto is true, mapKeys must be empty
-    // if fUseCrypto is false, vMasterKey must be empty
+    //! if fUseCrypto is true, mapKeys must be empty
+    //! if fUseCrypto is false, vMasterKey must be empty
     bool fUseCrypto;
 
-    // keeps track of whether Unlock has run a thourough check before
+    //! keeps track of whether Unlock has run a thorough check before
     bool fDecryptionThoroughlyChecked;
 
 protected:
     bool SetCrypted();
 
-    // will encrypt previously unencrypted keys
+    //! will encrypt previously unencrypted keys
     bool EncryptKeys(CKeyingMaterial& vMasterKeyIn);
 
     bool Unlock(const CKeyingMaterial& vMasterKeyIn);
@@ -189,7 +189,8 @@ public:
         }
     }
 
-    /* Wallet status (encrypted, locked) changed.
+    /**
+     * Wallet status (encrypted, locked) changed.
      * Note: Called without locks held.
      */
     boost::signals2::signal<void (CCryptoKeyStore* wallet)> NotifyStatusChanged;

--- a/src/db.h
+++ b/src/db.h
@@ -1,6 +1,6 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
-// Copyright (c) 2009-2013 The Bitcoin developers
-// Distributed under the MIT/X11 software license, see the accompanying
+// Copyright (c) 2009-2014 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #ifndef BITCOIN_DB_H
@@ -50,7 +50,7 @@ public:
     void MakeMock();
     bool IsMock() { return fMockDb; }
 
-    /*
+    /**
      * Verify that database file strFile is OK. If it is not,
      * call the callback to try to recover.
      * This must be called BEFORE strFile is opened.
@@ -60,7 +60,7 @@ public:
                         RECOVER_OK,
                         RECOVER_FAIL };
     VerifyResult Verify(std::string strFile, bool (*recoverFunc)(CDBEnv& dbenv, std::string strFile));
-    /*
+    /**
      * Salvage data from a file that Verify says is bad.
      * fAggressive sets the DB_AGGRESSIVE flag (see berkeley DB->verify() method documentation).
      * Appends binary key/value pairs to vResult, returns true if successful.

--- a/src/ecwrapper.cpp
+++ b/src/ecwrapper.cpp
@@ -13,9 +13,11 @@
 
 namespace {
 
-// Perform ECDSA key recovery (see SEC1 4.1.6) for curves over (mod p)-fields
-// recid selects which key is recovered
-// if check is non-zero, additional checks are performed
+/**
+ * Perform ECDSA key recovery (see SEC1 4.1.6) for curves over (mod p)-fields
+ * recid selects which key is recovered
+ * if check is non-zero, additional checks are performed
+ */
 int ECDSA_SIG_recover_key_GFp(EC_KEY *eckey, ECDSA_SIG *ecsig, const unsigned char *msg, int msglen, int recid, int check)
 {
     if (!eckey) return 0;

--- a/src/ecwrapper.h
+++ b/src/ecwrapper.h
@@ -12,7 +12,7 @@
 
 class uint256;
 
-// RAII Wrapper around OpenSSL's EC_KEY
+/** RAII Wrapper around OpenSSL's EC_KEY */
 class CECKey {
 private:
     EC_KEY *pkey;
@@ -25,10 +25,12 @@ public:
     bool SetPubKey(const unsigned char* pubkey, size_t size);
     bool Verify(const uint256 &hash, const std::vector<unsigned char>& vchSig);
 
-    // reconstruct public key from a compact signature
-    // This is only slightly more CPU intensive than just verifying it.
-    // If this function succeeds, the recovered public key is guaranteed to be valid
-    // (the signature is a valid signature of the given data for that key)
+    /**
+     * reconstruct public key from a compact signature
+     * This is only slightly more CPU intensive than just verifying it.
+     * If this function succeeds, the recovered public key is guaranteed to be valid
+     * (the signature is a valid signature of the given data for that key)
+     */
     bool Recover(const uint256 &hash, const unsigned char *p64, int rec);
 
     bool TweakPublic(const unsigned char vchTweak[32]);

--- a/src/leveldbwrapper.h
+++ b/src/leveldbwrapper.h
@@ -1,5 +1,5 @@
-// Copyright (c) 2012-2013 The Bitcoin developers
-// Distributed under the MIT/X11 software license, see the accompanying
+// Copyright (c) 2012-2014 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #ifndef BITCOIN_LEVELDBWRAPPER_H
@@ -24,7 +24,7 @@ public:
 
 void HandleError(const leveldb::Status& status) throw(leveldb_error);
 
-// Batch of changes queued to be written to a CLevelDBWrapper
+/** Batch of changes queued to be written to a CLevelDBWrapper */
 class CLevelDBBatch
 {
     friend class CLevelDBWrapper;
@@ -64,25 +64,25 @@ public:
 class CLevelDBWrapper
 {
 private:
-    // custom environment this database is using (may be NULL in case of default environment)
+    //! custom environment this database is using (may be NULL in case of default environment)
     leveldb::Env* penv;
 
-    // database options used
+    //! database options used
     leveldb::Options options;
 
-    // options used when reading from the database
+    //! options used when reading from the database
     leveldb::ReadOptions readoptions;
 
-    // options used when iterating over values of the database
+    //! options used when iterating over values of the database
     leveldb::ReadOptions iteroptions;
 
-    // options used when writing to the database
+    //! options used when writing to the database
     leveldb::WriteOptions writeoptions;
 
-    // options used when sync writing to the database
+    //! options used when sync writing to the database
     leveldb::WriteOptions syncoptions;
 
-    // the database itself
+    //! the database itself
     leveldb::DB* pdb;
 
 public:

--- a/src/timedata.cpp
+++ b/src/timedata.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2014 The Bitcoin developers
-// Distributed under the MIT/X11 software license, see the accompanying
+// Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "timedata.h"
@@ -17,14 +17,13 @@ using namespace std;
 static CCriticalSection cs_nTimeOffset;
 static int64_t nTimeOffset = 0;
 
-//
-// "Never go to sea with two chronometers; take one or three."
-// Our three time sources are:
-//  - System clock
-//  - Median of other nodes clocks
-//  - The user (asking the user to fix the system clock if the first two disagree)
-//
-//
+/**
+ * "Never go to sea with two chronometers; take one or three."
+ * Our three time sources are:
+ *  - System clock
+ *  - Median of other nodes clocks
+ *  - The user (asking the user to fix the system clock if the first two disagree)
+ */
 int64_t GetTimeOffset()
 {
     LOCK(cs_nTimeOffset);

--- a/src/timedata.h
+++ b/src/timedata.h
@@ -1,5 +1,5 @@
 // Copyright (c) 2014 The Bitcoin developers
-// Distributed under the MIT/X11 software license, see the accompanying
+// Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #ifndef BITCOIN_TIMEDATA_H
@@ -12,7 +12,8 @@
 
 class CNetAddr;
 
-/** Median filter over a stream of values.
+/** 
+ * Median filter over a stream of values.
  * Returns the median of the last N numbers
  */
 template <typename T>
@@ -67,7 +68,7 @@ public:
     }
 };
 
-/* Functions to keep track of adjusted P2P time */
+/** Functions to keep track of adjusted P2P time */
 int64_t GetTimeOffset();
 int64_t GetAdjustedTime();
 void AddTimeData(const CNetAddr& ip, int64_t nTime);

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -1,6 +1,6 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
-// Copyright (c) 2009-2013 The Bitcoin developers
-// Distributed under the MIT/X11 software license, see the accompanying
+// Copyright (c) 2009-2014 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #ifndef BITCOIN_TXDB_H
@@ -17,11 +17,11 @@
 class CCoins;
 class uint256;
 
-// -dbcache default (MiB)
+//! -dbcache default (MiB)
 static const int64_t nDefaultDbCache = 100;
-// max. -dbcache in (MiB)
+//! max. -dbcache in (MiB)
 static const int64_t nMaxDbCache = sizeof(void*) > 4 ? 4096 : 1024;
-// min. -dbcache in (MiB)
+//! min. -dbcache in (MiB)
 static const int64_t nMinDbCache = 4;
 
 /** CCoinsView backed by the LevelDB coin database (chainstate/) */

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -1,6 +1,6 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2014 The Bitcoin developers
-// Distributed under the MIT/X11 software license, see the accompanying
+// Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #ifndef BITCOIN_UINT256_H
@@ -255,8 +255,10 @@ public:
         return sizeof(pn);
     }
 
-    // Returns the position of the highest bit set plus one, or zero if the
-    // value is zero.
+    /**
+     * Returns the position of the highest bit set plus one, or zero if the
+     * value is zero.
+     */
     unsigned int bits() const;
 
     uint64_t GetLow64() const
@@ -301,26 +303,27 @@ public:
     uint256(uint64_t b) : base_uint<256>(b) {}
     explicit uint256(const std::string& str) : base_uint<256>(str) {}
     explicit uint256(const std::vector<unsigned char>& vch) : base_uint<256>(vch) {}
-
-    // The "compact" format is a representation of a whole
-    // number N using an unsigned 32bit number similar to a
-    // floating point format.
-    // The most significant 8 bits are the unsigned exponent of base 256.
-    // This exponent can be thought of as "number of bytes of N".
-    // The lower 23 bits are the mantissa.
-    // Bit number 24 (0x800000) represents the sign of N.
-    // N = (-1^sign) * mantissa * 256^(exponent-3)
-    //
-    // Satoshi's original implementation used BN_bn2mpi() and BN_mpi2bn().
-    // MPI uses the most significant bit of the first byte as sign.
-    // Thus 0x1234560000 is compact (0x05123456)
-    // and  0xc0de000000 is compact (0x0600c0de)
-    // (0x05c0de00) would be -0x40de000000
-    //
-    // Bitcoin only uses this "compact" format for encoding difficulty
-    // targets, which are unsigned 256bit quantities.  Thus, all the
-    // complexities of the sign bit and using base 256 are probably an
-    // implementation accident.
+    
+    /**
+     * The "compact" format is a representation of a whole
+     * number N using an unsigned 32bit number similar to a
+     * floating point format.
+     * The most significant 8 bits are the unsigned exponent of base 256.
+     * This exponent can be thought of as "number of bytes of N".
+     * The lower 23 bits are the mantissa.
+     * Bit number 24 (0x800000) represents the sign of N.
+     * N = (-1^sign) * mantissa * 256^(exponent-3)
+     * 
+     * Satoshi's original implementation used BN_bn2mpi() and BN_mpi2bn().
+     * MPI uses the most significant bit of the first byte as sign.
+     * Thus 0x1234560000 is compact (0x05123456)
+     * and  0xc0de000000 is compact (0x0600c0de)
+     * 
+     * Bitcoin only uses this "compact" format for encoding difficulty
+     * targets, which are unsigned 256bit quantities.  Thus, all the
+     * complexities of the sign bit and using base 256 are probably an
+     * implementation accident.
+     */
     uint256& SetCompact(uint32_t nCompact, bool *pfNegative = NULL, bool *pfOverflow = NULL);
     uint32_t GetCompact(bool fNegative = false) const;
 


### PR DESCRIPTION
Fix comment typo in crypter.h
Update licenses/copyright dates
