### PR TITLE
build: fix link error on some platforms. Fixes #5235

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -86,7 +86,7 @@ test_test_bitcoin_LDADD += $(LIBBITCOIN_WALLET)
 endif
 
 test_test_bitcoin_LDADD += $(LIBBITCOIN_CONSENSUS) $(BDB_LIBS) $(SSL_LIBS) $(CRYPTO_LIBS) $(MINIUPNPC_LIBS)
-test_test_bitcoin_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS) -static-libtool-libs
+test_test_bitcoin_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS) -static
 
 nodist_test_test_bitcoin_SOURCES = $(GENERATED_TEST_FILES)
 


### PR DESCRIPTION
Some users may have libtool libs (.la) installed in their linker search paths.
In this case, using -static-libtool-libs would try to link in .a's instead of
shared libs. That would be harmless unless the .a was built in a way that
would break linking, like non-fpic.

What we really want is "-static" here. Despite its name, it's actually less
aggressive than -static-libtool-libs. It causes only internal libs to be linked
statically (libbitcoinconsensus is the one were'a after).
