### PR TITLE
Check for strnlen and provide it if it is not found

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -421,6 +421,8 @@ AC_CHECK_HEADERS([endian.h stdio.h stdlib.h unistd.h strings.h sys/types.h sys/s
 AC_SEARCH_LIBS([getaddrinfo_a], [anl], [AC_DEFINE(HAVE_GETADDRINFO_A, 1, [Define this symbol if you have getaddrinfo_a])])
 AC_SEARCH_LIBS([inet_pton], [nsl resolv], [AC_DEFINE(HAVE_INET_PTON, 1, [Define this symbol if you have inet_pton])])
 
+AC_CHECK_DECLS([strnlen])
+
 AC_CHECK_DECLS([le32toh, le64toh, htole32, htole64, be32toh, be64toh, htobe32, htobe64],,,
 		[#if HAVE_ENDIAN_H
                  #include <endian.h>

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -251,6 +251,7 @@ libbitcoin_common_a_SOURCES = \
 # backward-compatibility objects and their sanity checks are linked.
 libbitcoin_util_a_CPPFLAGS = $(BITCOIN_INCLUDES)
 libbitcoin_util_a_SOURCES = \
+  compat/strnlen.cpp \
   compat/glibc_sanity.cpp \
   compat/glibcxx_sanity.cpp \
   chainparamsbase.cpp \

--- a/src/compat.h
+++ b/src/compat.h
@@ -84,4 +84,8 @@ typedef u_int SOCKET;
 #define THREAD_PRIORITY_ABOVE_NORMAL    (-2)
 #endif
 
+#if HAVE_DECL_STRNLEN == 0
+size_t strnlen( const char *start, size_t max_len);
+#endif // HAVE_DECL_STRNLEN
+
 #endif // BITCOIN_COMPAT_H

--- a/src/compat.h
+++ b/src/compat.h
@@ -6,6 +6,10 @@
 #ifndef BITCOIN_COMPAT_H
 #define BITCOIN_COMPAT_H
 
+#if defined(HAVE_CONFIG_H)
+#include "config/bitcoin-config.h"
+#endif
+
 #ifdef WIN32
 #ifdef _WIN32_WINNT
 #undef _WIN32_WINNT

--- a/src/compat/strnlen.cpp
+++ b/src/compat/strnlen.cpp
@@ -1,0 +1,18 @@
+// Copyright (c) 2009-2014 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#if defined(HAVE_CONFIG_H)
+#include "config/bitcoin-config.h"
+#endif
+
+#include <cstring>
+
+#if HAVE_DECL_STRNLEN == 0
+size_t strnlen( const char *start, size_t max_len)
+{
+    const char *end = (const char *)memchr(start, '\0', max_len);
+
+    return end ? (size_t)(end - start) : max_len;
+}
+#endif // HAVE_DECL_STRNLEN


### PR DESCRIPTION
strnlen is POSIX.1-2008. Thus on some older/incompatible systems, this function is not defined. E.g. current mingw (see http://sourceforge.net/p/mingw/bugs/1912/) or on older Mac OS X. Check for such conditions and use memchr based implementation instead. This should fix #5338.
