### PR TITLE
Increase default rpcthreads to 8

### DIFF
--- a/contrib/debian/manpages/bitcoin-qt.1
+++ b/contrib/debian/manpages/bitcoin-qt.1
@@ -128,7 +128,7 @@ Listen for JSON\-RPC connections on <port> (default: 8332 or testnet: 18332)
 Allow JSON\-RPC connections from specified IP address
 .TP
 \fB\-rpcthreads=\fR<n>
-Set the number of threads to service RPC calls (default: 4)
+Set the number of threads to service RPC calls (default: 8)
 .TP
 \fB\-blocknotify=\fR<cmd>
 Execute command when the best block changes (%s in cmd is replaced by block hash)

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -362,7 +362,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += "  -rpcpassword=<pw>      " + _("Password for JSON-RPC connections") + "\n";
     strUsage += "  -rpcport=<port>        " + strprintf(_("Listen for JSON-RPC connections on <port> (default: %u or testnet: %u)"), 8332, 18332) + "\n";
     strUsage += "  -rpcallowip=<ip>       " + _("Allow JSON-RPC connections from specified source. Valid for <ip> are a single IP (e.g. 1.2.3.4), a network/netmask (e.g. 1.2.3.4/255.255.255.0) or a network/CIDR (e.g. 1.2.3.4/24). This option can be specified multiple times") + "\n";
-    strUsage += "  -rpcthreads=<n>        " + strprintf(_("Set the number of threads to service RPC calls (default: %d)"), 4) + "\n";
+    strUsage += "  -rpcthreads=<n>        " + strprintf(_("Set the number of threads to service RPC calls (default: %d)"), 8) + "\n";
 
     strUsage += "\n" + _("RPC SSL options: (see the Bitcoin Wiki for SSL setup instructions)") + "\n";
     strUsage += "  -rpcssl                                  " + _("Use OpenSSL (https) for JSON-RPC connections") + "\n";

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -690,7 +690,7 @@ void StartRPCThreads()
     }
 
     rpc_worker_group = new boost::thread_group();
-    for (int i = 0; i < GetArg("-rpcthreads", 4); i++)
+    for (int i = 0; i < GetArg("-rpcthreads", 8); i++)
         rpc_worker_group->create_thread(boost::bind(&asio::io_service::run, rpc_io_service));
     fRPCRunning = true;
 }


### PR DESCRIPTION
When solo mining, BFGMiner makes use of 3-4 long-lived connections: 1 for longpolling, 1 for submissions, and 1-2 for its own getblocktemplate calls. This barely fits with the default rpcthreads limit of 4, and means that when it has the total of 4 connections open, users cannot run any RPC calls of their own until one is closed by bitcoind timing it out. Ideally, we shouldn't block on idle connections, but while we do, increasing the default thread count to 8 seems reasonable IMO. Asked on #bitcoin-dev the other night and got no input, so I'm guessing nobody much cares.
