### PR TITLE
Make mapNextTx private within CTxMemPool

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -56,6 +56,7 @@ testScripts = [
     'rest.py',
     'mempool_spendcoinbase.py',
     'mempool_coinbase_spends.py',
+    'mempool_reject_doublespend.py',
     'httpbasics.py',
     'zapwallettxes.py',
     'proxy_test.py',

--- a/qa/rpc-tests/mempool_reject_doublespend.py
+++ b/qa/rpc-tests/mempool_reject_doublespend.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python2
+# Copyright (c) 2014 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#
+# Test rejection of double-spends in mempool
+# Brought on by bugs in the original #5347
+#
+
+from test_framework import BitcoinTestFramework
+from bitcoinrpc.authproxy import AuthServiceProxy, JSONRPCException
+from util import *
+import os
+import shutil
+
+# Create one-input, one-output, no-fee transaction:
+class MempoolSpendCoinbaseTest(BitcoinTestFramework):
+
+    def setup_network(self):
+        # Just need one node for this test
+        args = ["-checkmempool", "-debug=mempool", "-relaypriority=0"]
+        self.nodes = []
+        self.nodes.append(start_node(0, self.options.tmpdir, args))
+        self.is_network_split = False
+
+    def create_tx(self, from_txid, to_address, amount):
+        inputs = [{ "txid" : from_txid, "vout" : 0}]
+        outputs = { to_address : amount }
+        rawtx = self.nodes[0].createrawtransaction(inputs, outputs)
+        signresult = self.nodes[0].signrawtransaction(rawtx)
+        assert_equal(signresult["complete"], True)
+        return signresult["hex"]
+
+    def run_test(self):
+        chain_height = self.nodes[0].getblockcount()
+        assert_equal(chain_height, 200)
+
+        coinbase_txid = self.nodes[0].getblock(self.nodes[0].getblockhash(101))['tx'][0]
+        tx1 = self.create_tx(coinbase_txid, self.nodes[0].getnewaddress(), 50)
+        tx2 = self.create_tx(coinbase_txid, self.nodes[0].getnewaddress(), 50)
+
+        spend_id = self.nodes[0].sendrawtransaction(tx1)
+        assert_raises(JSONRPCException, self.nodes[0].sendrawtransaction, tx2)
+
+        # mempool should have just spend_101:
+        assert_equal(self.nodes[0].getrawmempool(), [ spend_id ])
+
+        tx3 = self.create_tx(spend_id, self.nodes[0].getnewaddress(), 50)
+        tx4 = self.create_tx(spend_id, self.nodes[0].getnewaddress(), 50)
+
+        spend2_id = self.nodes[0].sendrawtransaction(tx3)
+        assert_raises(JSONRPCException, self.nodes[0].sendrawtransaction, tx4)
+
+        assert_equal(sorted(self.nodes[0].getrawmempool()), sorted([ spend_id, spend2_id ]))
+
+        # mine a block, spend_101 should get confirmed
+        self.nodes[0].setgenerate(True, 1)
+        assert_equal(set(self.nodes[0].getrawmempool()), set())
+
+if __name__ == '__main__':
+    MempoolSpendCoinbaseTest().main()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -830,20 +830,6 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
     if (pool.exists(hash))
         return state.Invalid(false, REJECT_ALREADY_KNOWN, "txn-already-in-mempool");
 
-    // Check for conflicts with in-memory transactions
-    {
-    LOCK(pool.cs); // protect pool.mapNextTx
-    for (unsigned int i = 0; i < tx.vin.size(); i++)
-    {
-        COutPoint outpoint = tx.vin[i].prevout;
-        if (pool.mapNextTx.count(outpoint))
-        {
-            // Disable replacement feature for now
-            return state.Invalid(false, REJECT_CONFLICT, "txn-mempool-conflict");
-        }
-    }
-    }
-
     {
         CCoinsView dummy;
         CCoinsViewCache view(&dummy);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -850,7 +850,6 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
 
         CAmount nValueIn = 0;
         {
-        LOCK(pool.cs);
         CCoinsViewMemPool viewMemPool(pcoinsTip, pool);
         view.SetBackend(viewMemPool);
 

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -508,11 +508,9 @@ UniValue gettxout(const UniValue& params, bool fHelp)
 
     CCoins coins;
     if (fMempool) {
-        LOCK(mempool.cs);
         CCoinsViewMemPool view(pcoinsTip, mempool);
         if (!view.GetCoins(hash, coins))
             return NullUniValue;
-        mempool.pruneSpent(hash, coins); // TODO: this should be done by the CCoinsViewMemPool
     } else {
         if (!pcoinsTip->GetCoins(hash, coins))
             return NullUniValue;

--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -627,7 +627,6 @@ UniValue signrawtransaction(const UniValue& params, bool fHelp)
     CCoinsView viewDummy;
     CCoinsViewCache view(&viewDummy);
     {
-        LOCK(mempool.cs);
         CCoinsViewCache &viewChain = *pcoinsTip;
         CCoinsViewMemPool viewMempool(&viewChain, mempool);
         view.SetBackend(viewMempool); // temporarily switch cache backend to db+mempool view

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -788,12 +788,12 @@ bool CCoinsViewMemPool::GetCoins(const uint256 &txid, CCoins &coins) const {
     // conflict with the underlying cache, and it cannot have pruned entries (as it contains full)
     // transactions. First checking the underlying cache risks returning a pruned entry instead.
     CTransaction tx;
-    if (mempool.lookup(txid, tx)) {
+    if (mempool.lookup(txid, tx))
         coins = CCoins(tx, MEMPOOL_HEIGHT);
-        mempool.pruneSpent(txid, coins);
-        return true;
-    }
-    return (base->GetCoins(txid, coins) && !coins.IsPruned());
+    else if (!base->GetCoins(txid, coins) || coins.IsPruned())
+        return false;
+    mempool.pruneSpent(txid, coins);
+    return true;
 }
 
 bool CCoinsViewMemPool::HaveCoins(const uint256 &txid) const {

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -778,7 +778,10 @@ bool CTxMemPool::HasNoInputsOf(const CTransaction &tx) const
     return true;
 }
 
-CCoinsViewMemPool::CCoinsViewMemPool(CCoinsView *baseIn, CTxMemPool &mempoolIn) : CCoinsViewBacked(baseIn), mempool(mempoolIn) { }
+CCoinsViewMemPool::CCoinsViewMemPool(CCoinsView *baseIn, CTxMemPool &mempoolIn)
+    : CCoinsViewBacked(baseIn),
+      criticalBlock(mempoolIn.cs, "CCoinsViewMemPool_lock", __FILE__, __LINE__),
+      mempool(mempoolIn) {}
 
 bool CCoinsViewMemPool::GetCoins(const uint256 &txid, CCoins &coins) const {
     // If an entry in the mempool exists, always return that one, as it's guaranteed to never
@@ -787,6 +790,7 @@ bool CCoinsViewMemPool::GetCoins(const uint256 &txid, CCoins &coins) const {
     CTransaction tx;
     if (mempool.lookup(txid, tx)) {
         coins = CCoins(tx, MEMPOOL_HEIGHT);
+        mempool.pruneSpent(txid, coins);
         return true;
     }
     return (base->GetCoins(txid, coins) && !coins.IsPruned());

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -516,6 +516,7 @@ private:
 class CCoinsViewMemPool : public CCoinsViewBacked
 {
 protected:
+    CCriticalBlock criticalBlock;
     CTxMemPool &mempool;
 
 public:

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -327,6 +327,7 @@ public:
 
 private:
     typedef std::map<txiter, setEntries, CompareIteratorByHash> cacheMap;
+    std::map<COutPoint, CInPoint> mapNextTx;
 
     struct TxLinks {
         setEntries parents;
@@ -342,7 +343,6 @@ private:
     void UpdateChild(txiter entry, txiter child, bool add);
 
 public:
-    std::map<COutPoint, CInPoint> mapNextTx;
     std::map<uint256, std::pair<double, CAmount> > mapDeltas;
 
     /** Create a new CTxMemPool.


### PR DESCRIPTION
This builds on #5206, removing the (now duplicate) check from AcceptToMemoryPool and makes mapNextTx private in CTxMemPool.
