### PR TITLE
Fix the comment of testnet's message start string to match the reality.

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -192,11 +192,6 @@ public:
     CTestNetParams() {
         networkID = CBaseChainParams::TESTNET;
         strNetworkID = "test";
-        /** 
-         * The message start string is designed to be unlikely to occur in normal data.
-         * The characters are rarely used upper ASCII, not valid as UTF-8, and produce
-         * a large 4-byte int at any alignment.
-         */
         pchMessageStart[0] = 0x0b;
         pchMessageStart[1] = 0x11;
         pchMessageStart[2] = 0x09;


### PR DESCRIPTION
Testnet's message start comment was probably cut&pasted from the main network, but message start bytes do not match the comments.
