### PR TITLE
Prioritize and display -testsafemode status in UI

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3221,11 +3221,11 @@ string GetWarnings(string strFor)
     string strStatusBar;
     string strRPC;
 
-    if (GetBoolArg("-testsafemode", false))
-        strRPC = "test";
-
     if (!CLIENT_VERSION_IS_RELEASE)
         strStatusBar = _("This is a pre-release test build - use at your own risk - do not use for mining or merchant applications");
+
+    if (GetBoolArg("-testsafemode", false))
+        strStatusBar = strRPC = "testsafemode enabled";
 
     // Misc warnings like out of disk space and clock is wrong
     if (strMiscWarning != "")


### PR DESCRIPTION
Like in a real world situation, a safe mode test should also be visible in the
UI. A test of safe mode is furthermore mostly relevant for developers, so it
should not be overwritten by a warning about a pre-release test build.
