### PR TITLE
Make -proxy set all network types, avoiding a connect leak.

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -854,10 +854,8 @@ bool AppInit2(boost::thread_group& threadGroup)
         if (!addrProxy.IsValid())
             return InitError(strprintf(_("Invalid -proxy address: '%s'"), mapArgs["-proxy"]));
 
-        if (!IsLimited(NET_IPV4))
-            SetProxy(NET_IPV4, addrProxy);
-        if (!IsLimited(NET_IPV6))
-            SetProxy(NET_IPV6, addrProxy);
+        SetProxy(NET_IPV4, addrProxy);
+        SetProxy(NET_IPV6, addrProxy);
         SetNameProxy(addrProxy);
         fProxy = true;
     }


### PR DESCRIPTION
Previously -proxy was not setting the proxy for IsLimited networks, so
 if you set your configuration to be onlynet=tor you wouldn't get an
 IPv4 proxy set.

The payment protocol gets its proxy configuration from the IPv4 proxy,
 and so it would experience a connection leak.

This addresses issue #5355 and also clears up a cosmetic bug where
 getinfo proxy output shows nothing when onlynet=tor is set.
