### PR TITLE
No longer check osx compatibility in RenameThread

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -698,13 +698,8 @@ void RenameThread(const char* name)
     //       removed.
     pthread_set_name_np(pthread_self(), name);
 
-#elif defined(MAC_OSX) && defined(__MAC_OS_X_VERSION_MAX_ALLOWED)
-
-// pthread_setname_np is XCode 10.6-and-later
-#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 1060
+#elif defined(MAC_OSX)
     pthread_setname_np(name);
-#endif
-
 #else
     // Prevent warnings for unused parameters...
     (void)name;


### PR DESCRIPTION
10.5 support has been dropped for some time now.
