### PR TITLE
Evict coinbase spends from memory pool during re-org

### DIFF
--- a/qa/pull-tester/rpc-tests.sh
+++ b/qa/pull-tester/rpc-tests.sh
@@ -19,6 +19,7 @@ if [ "x${ENABLE_BITCOIND}${ENABLE_UTILS}${ENABLE_WALLET}" = "x111" ]; then
   ${BUILDDIR}/qa/rpc-tests/wallet.py --srcdir "${BUILDDIR}/src"
   ${BUILDDIR}/qa/rpc-tests/listtransactions.py --srcdir "${BUILDDIR}/src"
   ${BUILDDIR}/qa/rpc-tests/mempool_resurrect_test.py --srcdir "${BUILDDIR}/src"
+  ${BUILDDIR}/qa/rpc-tests/mempool_coinbase_reorg.py --srcdir "${BUILDDIR}/src"
   ${BUILDDIR}/qa/rpc-tests/txn_doublespend.py --srcdir "${BUILDDIR}/src"
   ${BUILDDIR}/qa/rpc-tests/txn_doublespend.py --mineblock --srcdir "${BUILDDIR}/src"
   ${BUILDDIR}/qa/rpc-tests/getchaintips.py --srcdir "${BUILDDIR}/src"

--- a/qa/rpc-tests/mempool_coinbase_reorg.py
+++ b/qa/rpc-tests/mempool_coinbase_reorg.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+# Copyright (c) 2014 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#
+# Test re-org scenarios with a mempool that contains transactions
+# that spend (directly or indirectly) coinbase transactions.
+#
+
+from test_framework import BitcoinTestFramework
+from util import *
+
+class MempoolCoinbaseReorgTest(BitcoinTestFramework):
+
+    def setup_network(self):
+        args = ["-checkmempool", "-debug=mempool"]
+        self.nodes = []
+        self.nodes.append(start_node(0, self.options.tmpdir, args))
+        self.nodes.append(start_node(1, self.options.tmpdir, args))
+        connect_nodes(self.nodes[1], 0)
+        self.is_network_split = False
+        self.sync_all
+
+    def create_tx(self, from_txid, to_address, amount):
+        inputs = [{ "txid" : from_txid, "vout" : 0}]
+        outputs = { to_address : amount }
+        rawtx = self.nodes[0].createrawtransaction(inputs, outputs)
+        signresult = self.nodes[0].signrawtransaction(rawtx)
+        assert_equal(signresult["complete"], True)
+        return signresult["hex"]
+
+    def run_test(self):
+        # At start, chain height is 200. Next block will be 201,
+        # so coinbase 101 is allowed into the mempool.
+
+        # Mine two blocks. Height is 202, so coinbases 102 and 103
+        # can be in mempool.
+        new_blocks = self.nodes[1].setgenerate(True, 2)
+        self.sync_all()
+
+        node0_address = self.nodes[0].getnewaddress()
+        node1_address = self.nodes[1].getnewaddress()
+
+        # Three scenarios for re-orging coinbase spends in the memory pool:
+        # 1. Direct coinbase spend  :  spend_101
+        # 2. Indirect (coinbase spend in chain, child in mempool) : spend_102 and spend_102_1
+        # 3. Indirect (coinbase and child both in chain) : spend_103 and spend_103_1
+        # Use invalidatblock to make all of the above coinbase spends invalid (immature coinbase),
+        # and make sure the mempool code behaves correctly.
+        b = [ self.nodes[0].getblockhash(n) for n in range(101, 104) ]
+        coinbase_txids = [ self.nodes[0].getblock(h)['tx'][0] for h in b ]
+        spend_101_raw = self.create_tx(coinbase_txids[0], node1_address, 50)
+        spend_102_raw = self.create_tx(coinbase_txids[1], node0_address, 50)
+        spend_103_raw = self.create_tx(coinbase_txids[2], node0_address, 50)
+
+        # Broadcast and mine spend_102 and 103:
+        spend_102_id = self.nodes[0].sendrawtransaction(spend_102_raw)
+        spend_103_id = self.nodes[0].sendrawtransaction(spend_103_raw)
+        self.nodes[0].setgenerate(True, 1)
+        
+        # Create 102_1 and 103_1:
+        spend_102_1_raw = self.create_tx(spend_102_id, node1_address, 50)
+        spend_103_1_raw = self.create_tx(spend_103_id, node1_address, 50)
+
+        # Broadcast and mine 103_1:
+        spend_103_1_id = self.nodes[0].sendrawtransaction(spend_103_1_raw)
+        self.nodes[0].setgenerate(True, 1)
+
+        # ... now put spend_101 and spend_102_1 in memory pools:
+        spend_101_id = self.nodes[0].sendrawtransaction(spend_101_raw)
+        spend_102_1_id = self.nodes[0].sendrawtransaction(spend_102_1_raw)
+
+        self.sync_all()
+
+        assert_equal(set(self.nodes[0].getrawmempool()), set([ spend_101_id, spend_102_1_id ]))
+
+        # Use invalidateblock to re-org; only spend_101 should be left:
+        for node in self.nodes:
+            node.invalidateblock(new_blocks[0])
+
+        self.sync_all()
+
+        assert_equal(self.nodes[0].getrawmempool(), [ spend_101_id ])
+
+if __name__ == '__main__':
+    MempoolCoinbaseReorgTest().main()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1890,9 +1890,8 @@ bool static DisconnectTip(CValidationState &state) {
         // ignore validation errors in resurrected transactions
         list<CTransaction> removed;
         CValidationState stateDummy;
-        if (!tx.IsCoinBase())
-            if (!AcceptToMemoryPool(mempool, stateDummy, tx, false, NULL))
-                mempool.remove(tx, removed, true);
+        if (tx.IsCoinBase() || !AcceptToMemoryPool(mempool, stateDummy, tx, false, NULL))
+            mempool.remove(tx, removed, true);
     }
     mempool.check(pcoinsTip);
     // Update chainActive and related variables.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1873,6 +1873,23 @@ bool static DisconnectTip(CValidationState &state) {
     CBlock block;
     if (!ReadBlockFromDisk(block, pindexDelete))
         return state.Abort("Failed to read block");
+
+    // Remove any will-be-too-immature-to-include-in-next-block spends from mempool:
+    list<CTransaction> removedFromMempool;
+    int immatureHeight = pindexDelete->nHeight-COINBASE_MATURITY+1;
+    if (immatureHeight > 0)
+    {
+        const CBlockIndex* immatureIndex = pindexDelete->GetAncestor(immatureHeight);
+        CBlock immatureBlock;
+        if (ReadBlockFromDisk(immatureBlock, immatureIndex))
+        {
+            const CTransaction& immatureCoinbase = immatureBlock.vtx[0];
+            mempool.remove(immatureCoinbase, removedFromMempool, true);
+        }
+        else
+            return state.Abort(strprintf("Failed to read block at height %d", immatureHeight));
+    }
+
     // Apply the block atomically to the chain state.
     int64_t nStart = GetTimeMicros();
     {
@@ -1885,17 +1902,21 @@ bool static DisconnectTip(CValidationState &state) {
     // Write the chain state to disk, if necessary.
     if (!FlushStateToDisk(state, FLUSH_STATE_IF_NEEDED))
         return false;
+
     // Resurrect mempool transactions from the disconnected block.
     BOOST_FOREACH(const CTransaction &tx, block.vtx) {
         // ignore validation errors in resurrected transactions
-        list<CTransaction> removed;
         CValidationState stateDummy;
         if (tx.IsCoinBase() || !AcceptToMemoryPool(mempool, stateDummy, tx, false, NULL))
-            mempool.remove(tx, removed, true);
+            mempool.remove(tx, removedFromMempool, true);
     }
     mempool.check(pcoinsTip);
+
     // Update chainActive and related variables.
     UpdateTip(pindexDelete->pprev);
+
+    mempool.check(pcoinsTip);
+
     // Let wallets know transactions went from 1-confirmed to
     // 0-confirmed or conflicted:
     BOOST_FOREACH(const CTransaction &tx, block.vtx) {

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -448,7 +448,7 @@ void CTxMemPool::remove(const CTransaction &origTx, std::list<CTransaction>& rem
         if (!mapTx.count(hash))
             continue;
         const CTransaction& tx = mapTx[hash].GetTx();
-        removed.push_front(tx);
+        removed.push_back(tx);
         if (fRecursive) {
             for (unsigned int i = 0; i < tx.vout.size(); i++) {
                 std::map<COutPoint, CInPoint>::iterator it = mapNextTx.find(COutPoint(hash, i));

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -6,6 +6,7 @@
 #include "txmempool.h"
 
 #include "clientversion.h"
+#include "main.h"
 #include "streams.h"
 #include "util.h"
 #include "utilmoneystr.h"
@@ -524,17 +525,22 @@ void CTxMemPool::check(const CCoinsViewCache *pcoins) const
 
     uint64_t checkTotal = 0;
 
+    CCoinsViewCache mempoolDuplicate(const_cast<CCoinsViewCache*>(pcoins));
+
     LOCK(cs);
+    list<const CTxMemPoolEntry*> waitingOnDependants;
     for (std::map<uint256, CTxMemPoolEntry>::const_iterator it = mapTx.begin(); it != mapTx.end(); it++) {
         unsigned int i = 0;
         checkTotal += it->second.GetTxSize();
         const CTransaction& tx = it->second.GetTx();
+        bool fDependsWait = false;
         BOOST_FOREACH(const CTxIn &txin, tx.vin) {
             // Check that every mempool transaction's inputs refer to available coins, or other mempool tx's.
             std::map<uint256, CTxMemPoolEntry>::const_iterator it2 = mapTx.find(txin.prevout.hash);
             if (it2 != mapTx.end()) {
                 const CTransaction& tx2 = it2->second.GetTx();
                 assert(tx2.vout.size() > txin.prevout.n && !tx2.vout[txin.prevout.n].IsNull());
+                fDependsWait = true;
             } else {
                 const CCoins* coins = pcoins->AccessCoins(txin.prevout.hash);
                 assert(coins && coins->IsAvailable(txin.prevout.n));
@@ -545,6 +551,29 @@ void CTxMemPool::check(const CCoinsViewCache *pcoins) const
             assert(it3->second.ptx == &tx);
             assert(it3->second.n == i);
             i++;
+        }
+        if (fDependsWait)
+            waitingOnDependants.push_back(&it->second);
+        else {
+            CValidationState state; CTxUndo undo;
+            assert(CheckInputs(tx, state, mempoolDuplicate, false, 0, false, NULL));
+            UpdateCoins(tx, state, mempoolDuplicate, undo, 1000000);
+        }
+    }
+    unsigned int stepsSinceLastRemove = 0;
+    while (!waitingOnDependants.empty()) {
+        const CTxMemPoolEntry* entry = waitingOnDependants.front();
+        waitingOnDependants.pop_front();
+        CValidationState state;
+        if (!mempoolDuplicate.HaveInputs(entry->GetTx())) {
+            waitingOnDependants.push_back(entry);
+            stepsSinceLastRemove++;
+            assert(stepsSinceLastRemove < waitingOnDependants.size());
+        } else {
+            assert(CheckInputs(entry->GetTx(), state, mempoolDuplicate, false, 0, false, NULL));
+            CTxUndo undo;
+            UpdateCoins(entry->GetTx(), state, mempoolDuplicate, undo, 1000000);
+            stepsSinceLastRemove = 0;
         }
     }
     for (std::map<COutPoint, CInPoint>::const_iterator it = mapNextTx.begin(); it != mapNextTx.end(); it++) {


### PR DESCRIPTION
This is an alternative version of #5267 

It works by having DisconnectTip() lookup the block at height current-COINBASE_MATURITY, and then removing any transactions spending that coinbase (recursively) from the memory pool.

Since re-orgs happen by repeated calls to DisconnectTip(), this will keep the memory pool always consistent, even in the middle of a re-org.

Builds on #5316 

Includes a new regression test.
