### PR TITLE
Mempool resurrect test

### DIFF
--- a/qa/pull-tester/rpc-tests.sh
+++ b/qa/pull-tester/rpc-tests.sh
@@ -18,6 +18,7 @@ fi
 if [ "x${ENABLE_BITCOIND}${ENABLE_UTILS}${ENABLE_WALLET}" = "x111" ]; then
   ${BUILDDIR}/qa/rpc-tests/wallet.py --srcdir "${BUILDDIR}/src"
   ${BUILDDIR}/qa/rpc-tests/listtransactions.py --srcdir "${BUILDDIR}/src"
+  ${BUILDDIR}/qa/rpc-tests/mempool_resurrect_test.py --srcdir "${BUILDDIR}/src"
   ${BUILDDIR}/qa/rpc-tests/txn_doublespend.py --srcdir "${BUILDDIR}/src"
   ${BUILDDIR}/qa/rpc-tests/txn_doublespend.py --mineblock --srcdir "${BUILDDIR}/src"
   #${BUILDDIR}/qa/rpc-tests/forknotify.py --srcdir "${BUILDDIR}/src"

--- a/qa/rpc-tests/mempool_resurrect_test.py
+++ b/qa/rpc-tests/mempool_resurrect_test.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python
+# Copyright (c) 2014 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#
+# Test resurrection of mined transactions when
+# the blockchain is re-organized.
+#
+
+from test_framework import BitcoinTestFramework
+from bitcoinrpc.authproxy import AuthServiceProxy, JSONRPCException
+from util import *
+import os
+import shutil
+
+# Create one-input, one-output, no-fee transaction:
+class MempoolCoinbaseTest(BitcoinTestFramework):
+
+    def setup_network(self):
+        # Just need one node for this test
+        args = ["-checkmempool", "-debug=mempool"]
+        self.nodes = []
+        self.nodes.append(start_node(0, self.options.tmpdir, args))
+        self.is_network_split = False
+
+    def create_tx(self, from_txid, to_address, amount):
+        inputs = [{ "txid" : from_txid, "vout" : 0}]
+        outputs = { to_address : amount }
+        rawtx = self.nodes[0].createrawtransaction(inputs, outputs)
+        signresult = self.nodes[0].signrawtransaction(rawtx)
+        assert_equal(signresult["complete"], True)
+        return signresult["hex"]
+
+    def run_test(self):
+        node0_address = self.nodes[0].getnewaddress()
+
+        # Spend block 1/2/3's coinbase transactions
+        # Mine a block.
+        # Create three more transactions, spending the spends
+        # Mine another block.
+        # ... make sure all the transactions are confirmed
+        # Invalidate both blocks
+        # ... make sure all the transactions are put back in the mempool
+        # Mine a new block
+        # ... make sure all the transactions are confirmed again.
+
+        b = [ self.nodes[0].getblockhash(n) for n in range(1, 4) ]
+        coinbase_txids = [ self.nodes[0].getblock(h)['tx'][0] for h in b ]
+        spends1_raw = [ self.create_tx(txid, node0_address, 50) for txid in coinbase_txids ]
+        spends1_id = [ self.nodes[0].sendrawtransaction(tx) for tx in spends1_raw ]
+
+        blocks = []
+        blocks.extend(self.nodes[0].setgenerate(True, 1))
+
+        spends2_raw = [ self.create_tx(txid, node0_address, 49.99) for txid in spends1_id ]
+        spends2_id = [ self.nodes[0].sendrawtransaction(tx) for tx in spends2_raw ]
+
+        blocks.extend(self.nodes[0].setgenerate(True, 1))
+
+        # mempool should be empty, all txns confirmed
+        assert_equal(set(self.nodes[0].getrawmempool()), set())
+        for txid in spends1_id+spends2_id:
+            tx = self.nodes[0].gettransaction(txid)
+            assert(tx["confirmations"] > 0)
+
+        # Use invalidateblock to re-org back; all transactions should
+        # end up unconfirmed and back in the mempool
+        for node in self.nodes:
+            node.invalidateblock(blocks[0])
+
+        # mempool should be empty, all txns confirmed
+        assert_equal(set(self.nodes[0].getrawmempool()), set(spends1_id+spends2_id))
+        for txid in spends1_id+spends2_id:
+            tx = self.nodes[0].gettransaction(txid)
+            assert(tx["confirmations"] == 0)
+
+        # Generate another block, they should all get mined
+        self.nodes[0].setgenerate(True, 1)
+        # mempool should be empty, all txns confirmed
+        assert_equal(set(self.nodes[0].getrawmempool()), set())
+        for txid in spends1_id+spends2_id:
+            tx = self.nodes[0].gettransaction(txid)
+            assert(tx["confirmations"] > 0)
+
+
+if __name__ == '__main__':
+    MempoolCoinbaseTest().main()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2137,17 +2137,13 @@ bool InvalidateBlock(CValidationState& state, CBlockIndex *pindex) {
 
     // Mark the block itself as invalid.
     pindex->nStatus |= BLOCK_FAILED_VALID;
-    if (!pblocktree->WriteBlockIndex(CDiskBlockIndex(pindex))) {
-        return state.Abort("Failed to update block index");
-    }
+    setDirtyBlockIndex.insert(pindex);
     setBlockIndexCandidates.erase(pindex);
 
     while (chainActive.Contains(pindex)) {
         CBlockIndex *pindexWalk = chainActive.Tip();
         pindexWalk->nStatus |= BLOCK_FAILED_CHILD;
-        if (!pblocktree->WriteBlockIndex(CDiskBlockIndex(pindexWalk))) {
-            return state.Abort("Failed to update block index");
-        }
+        setDirtyBlockIndex.insert(pindexWalk);
         setBlockIndexCandidates.erase(pindexWalk);
         // ActivateBestChain considers blocks already in chainActive
         // unconditionally valid already, so force disconnect away from it.
@@ -2180,9 +2176,7 @@ bool ReconsiderBlock(CValidationState& state, CBlockIndex *pindex) {
     while (it != mapBlockIndex.end()) {
         if (!it->second->IsValid() && it->second->GetAncestor(nHeight) == pindex) {
             it->second->nStatus &= ~BLOCK_FAILED_MASK;
-            if (!pblocktree->WriteBlockIndex(CDiskBlockIndex(pindex))) {
-                return state.Abort("Failed to update block index");
-            }
+            setDirtyBlockIndex.insert(it->second);
             if (it->second->IsValid(BLOCK_VALID_TRANSACTIONS) && it->second->nChainTx && setBlockIndexCandidates.value_comp()(chainActive.Tip(), it->second)) {
                 setBlockIndexCandidates.insert(it->second);
             }
@@ -2196,9 +2190,9 @@ bool ReconsiderBlock(CValidationState& state, CBlockIndex *pindex) {
 
     // Remove the invalidity flag from all ancestors too.
     while (pindex != NULL) {
-        pindex->nStatus &= ~BLOCK_FAILED_MASK;
-        if (!pblocktree->WriteBlockIndex(CDiskBlockIndex(pindex))) {
-            return state.Abort("Failed to update block index");
+        if (pindex->nStatus & BLOCK_FAILED_MASK) {
+            pindex->nStatus &= ~BLOCK_FAILED_MASK;
+            setDirtyBlockIndex.insert(pindex);
         }
         pindex = pindex->pprev;
     }

--- a/src/main.h
+++ b/src/main.h
@@ -609,6 +609,12 @@ public:
 /** Find the last common block between the parameter chain and a locator. */
 CBlockIndex* FindForkInGlobalIndex(const CChain& chain, const CBlockLocator& locator);
 
+/** Mark a block as invalid. */
+bool InvalidateBlock(CValidationState& state, CBlockIndex *pindex);
+
+/** Remove invalidity status from a block and its descendants. */
+bool ReconsiderBlock(CValidationState& state, CBlockIndex *pindex);
+
 /** The currently-connected chain of blocks. */
 extern CChain chainActive;
 

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -270,6 +270,8 @@ static const CRPCCommand vRPCCommands[] =
     { "blockchain",         "gettxout",               &gettxout,               true,      false,      false },
     { "blockchain",         "gettxoutsetinfo",        &gettxoutsetinfo,        true,      false,      false },
     { "blockchain",         "verifychain",            &verifychain,            true,      false,      false },
+    { "blockchain",         "invalidateblock",        &invalidateblock,        true,      true,       false },
+    { "blockchain",         "reconsiderblock",        &reconsiderblock,        true,      true,       false },
 
     /* Mining */
     { "mining",             "getblocktemplate",       &getblocktemplate,       true,      false,      false },

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -219,6 +219,8 @@ extern json_spirit::Value gettxoutsetinfo(const json_spirit::Array& params, bool
 extern json_spirit::Value gettxout(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value verifychain(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value getchaintips(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value invalidateblock(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value reconsiderblock(const json_spirit::Array& params, bool fHelp);
 
 // in rest.cpp
 extern bool HTTPReq_REST(AcceptedConnection *conn,


### PR DESCRIPTION
Simple regression test for the memory pool code that takes transactions confirmed in blocks and puts them back into the memory pool when re-orging away from those blocks.

Builds on #5316 
