### PR TITLE
build: disable static lib stripping during osx make install-strip

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -281,6 +281,12 @@ case $host in
            AC_PATH_TOOL([INSTALLNAMETOOL], [install_name_tool], install_name_tool)
            AC_PATH_TOOL([OTOOL], [otool], otool)
            AC_PATH_PROGS([GENISOIMAGE], [genisoimage mkisofs],genisoimage)
+
+           dnl libtool will try to strip the static lib, which is a problem for
+           dnl cross-builds because strip attempts to call a hard-coded ld,
+           dnl which may not exist in the path. Stripping the .a is not
+           dnl necessary, so just disable it.
+           old_striplib=
            ;;
        esac
      fi


### PR DESCRIPTION
The comment explains the issue. Gitian builds for OSX are broken without this. #5363 contains this fix, and another (incoming) PR depends on it as well. I've pulled it out of #5363 to avoid juggling it. I'll nuke it there.
