### PR TITLE
Use complete path to include bitcoin-config.h.

### DIFF
--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -4,7 +4,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #ifdef HAVE_CONFIG_H
-#include "bitcoin-config.h"
+#include "config/bitcoin-config.h"
 #endif
 
 #include "netbase.h"


### PR DESCRIPTION
bitcoin-config.h should be included from config/ to prevent compiler using the old file from the previous location. See #5340 for detailed description.
