### PR TITLE
Report status of chain tips

### DIFF
--- a/qa/pull-tester/rpc-tests.sh
+++ b/qa/pull-tester/rpc-tests.sh
@@ -20,6 +20,7 @@ if [ "x${ENABLE_BITCOIND}${ENABLE_UTILS}${ENABLE_WALLET}" = "x111" ]; then
   ${BUILDDIR}/qa/rpc-tests/listtransactions.py --srcdir "${BUILDDIR}/src"
   ${BUILDDIR}/qa/rpc-tests/txn_doublespend.py --srcdir "${BUILDDIR}/src"
   ${BUILDDIR}/qa/rpc-tests/txn_doublespend.py --mineblock --srcdir "${BUILDDIR}/src"
+  ${BUILDDIR}/qa/rpc-tests/getchaintips.py --srcdir "${BUILDDIR}/src"
   #${BUILDDIR}/qa/rpc-tests/forknotify.py --srcdir "${BUILDDIR}/src"
 else
   echo "No rpc tests to run. Wallet, utils, and bitcoind must all be enabled"

--- a/qa/rpc-tests/getchaintips.py
+++ b/qa/rpc-tests/getchaintips.py
@@ -19,6 +19,7 @@ class GetChainTipsTest (BitcoinTestFramework):
         assert_equal (len (tips), 1)
         assert_equal (tips[0]['branchlen'], 0)
         assert_equal (tips[0]['height'], 200)
+        assert_equal (tips[0]['status'], 'active')
 
         # Split the network and build two chains of different lengths.
         self.split_network ()
@@ -31,12 +32,14 @@ class GetChainTipsTest (BitcoinTestFramework):
         shortTip = tips[0]
         assert_equal (shortTip['branchlen'], 0)
         assert_equal (shortTip['height'], 210)
+        assert_equal (tips[0]['status'], 'active')
 
         tips = self.nodes[3].getchaintips ()
         assert_equal (len (tips), 1)
         longTip = tips[0]
         assert_equal (longTip['branchlen'], 0)
         assert_equal (longTip['height'], 220)
+        assert_equal (tips[0]['status'], 'active')
 
         # Join the network halves and check that we now have two tips
         # (at least at the nodes that previously had the short chain).
@@ -47,7 +50,9 @@ class GetChainTipsTest (BitcoinTestFramework):
         assert_equal (tips[0], longTip)
 
         assert_equal (tips[1]['branchlen'], 10)
-        tips[1]['branchlen'] = 0;
+        assert_equal (tips[1]['status'], 'valid-fork')
+        tips[1]['branchlen'] = 0
+        tips[1]['status'] = 'active'
         assert_equal (tips[1], shortTip)
 
 if __name__ == '__main__':


### PR DESCRIPTION
This makes the output a bit more intuitive when running on a synchronizing headers-first client:

```
[
    {
        "height" : 310985,
        "hash" : "000000004b9d96cf156f9e74acdf03647a2f8665c5d98693ef5a9130efcc0106",
        "branchlen" : 182402,
        "status" : "headers-only"
    },
    {
        "height" : 128583,
        "hash" : "00000000119df3d17af48af07480d3d5a5966cfad28f40b08a79b55b02fd8df2",
        "branchlen" : 0,
        "status" : "active"
    }
]
```
