### PR TITLE
[Wallet] Wallet-pruning

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -121,6 +121,7 @@ BITCOIN_CORE_H = \
   script/script_error.h \
   serialize.h \
   streams.h \
+  stxo.h \
   sync.h \
   threadsafety.h \
   timedata.h \
@@ -194,6 +195,7 @@ libbitcoin_wallet_a_SOURCES = \
   crypter.cpp \
   rpcdump.cpp \
   rpcwallet.cpp \
+  stxo.cpp \
   wallet.cpp \
   wallet_ismine.cpp \
   walletdb.cpp \

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -306,6 +306,11 @@ void CDB::Close()
     }
 }
 
+void CDB::Compact()
+{
+    pdb->compact(NULL, NULL, NULL, NULL, DB_FREE_SPACE, NULL);
+}
+
 void CDBEnv::CloseDb(const string& strFile)
 {
     {

--- a/src/db.h
+++ b/src/db.h
@@ -106,6 +106,7 @@ protected:
 public:
     void Flush();
     void Close();
+    void Compact();
 
 private:
     CDB(const CDB&);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -283,6 +283,7 @@ std::string HelpMessage(HelpMessageMode mode)
     if (GetBoolArg("-help-debug", false))
         strUsage += "  -mintxfee=<amt>        " + strprintf(_("Fees (in BTC/Kb) smaller than this are considered zero fee for transaction creation (default: %s)"), FormatMoney(CWallet::minTxFee.GetFeePerK())) + "\n";
     strUsage += "  -paytxfee=<amt>        " + strprintf(_("Fee (in BTC/kB) to add to transactions you send (default: %s)"), FormatMoney(payTxFee.GetFeePerK())) + "\n";
+    strUsage += "  -prunewallet=<n>       " + _("Erase transactions older than <n> days and without unspent outputs on startup. Useful to shrink and speed up large wallets. 0 means do not prune. (default: 0)") + "\n";
     strUsage += "  -rescan                " + _("Rescan the block chain for missing wallet transactions") + " " + _("on startup") + "\n";
     strUsage += "  -salvagewallet         " + _("Attempt to recover private keys from a corrupt wallet.dat") + " " + _("on startup") + "\n";
     strUsage += "  -sendfreetransactions  " + strprintf(_("Send transactions as zero-fee transactions if possible (default: %u)"), 0) + "\n";
@@ -310,7 +311,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += "  -debug=<category>      " + strprintf(_("Output debugging information (default: %u, supplying <category> is optional)"), 0) + "\n";
     strUsage += "                         " + _("If <category> is not supplied, output all debugging information.") + "\n";
     strUsage += "                         " + _("<category> can be:");
-    strUsage +=                                 " addrman, alert, bench, coindb, db, lock, rand, rpc, selectcoins, mempool, net"; // Don't translate these and qt below
+    strUsage +=                                 " addrman, alert, bench, coindb, db, lock, rand, rpc, selectcoins, mempool, net, wallet"; // Don't translate these and qt below
     if (mode == HMM_BITCOIN_QT)
         strUsage += ", qt";
     strUsage += ".\n";
@@ -700,6 +701,7 @@ bool AppInit2(boost::thread_group& threadGroup)
     nTxConfirmTarget = GetArg("-txconfirmtarget", 1);
     bSpendZeroConfChange = GetArg("-spendzeroconfchange", true);
     fSendFreeTransactions = GetArg("-sendfreetransactions", false);
+    nPruneWallet = GetArg("-prunewallet", 0);
 
     std::string strWalletFile = GetArg("-wallet", "wallet.dat");
 #endif // ENABLE_WALLET
@@ -1134,6 +1136,12 @@ bool AppInit2(boost::thread_group& threadGroup)
             }
 
             pwalletMain->SetBestChain(chainActive.GetLocator());
+        }
+
+        if (pwalletMain->PruneWallet(nPruneWallet) == -1)
+        {
+            nPruneWallet = 0;
+            strErrors << _("Error: Sorry, but wallet pruning is not supported if you are using the account-feature.") << "\n";
         }
 
         LogPrintf("%s", strErrors.str());

--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -54,6 +54,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "listaccounts", 0 },
     { "listaccounts", 1 },
     { "walletpassphrase", 1 },
+    { "prunewallet", 0 },
     { "getblocktemplate", 0 },
     { "listsinceblock", 1 },
     { "listsinceblock", 2 },

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -332,6 +332,7 @@ static const CRPCCommand vRPCCommands[] =
     { "wallet",             "listunspent",            &listunspent,            false,     false,      true },
     { "wallet",             "lockunspent",            &lockunspent,            true,      false,      true },
     { "wallet",             "move",                   &movecmd,                false,     false,      true },
+    { "wallet",             "prunewallet",            &prunewallet,            false,     false,      true },
     { "wallet",             "sendfrom",               &sendfrom,               false,     false,      true },
     { "wallet",             "sendmany",               &sendmany,               false,     false,      true },
     { "wallet",             "sendtoaddress",          &sendtoaddress,          false,     false,      true },

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -188,6 +188,7 @@ extern json_spirit::Value listaccounts(const json_spirit::Array& params, bool fH
 extern json_spirit::Value listsinceblock(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value gettransaction(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value backupwallet(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value prunewallet(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value keypoolrefill(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value walletpassphrase(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value walletpassphrasechange(const json_spirit::Array& params, bool fHelp);

--- a/src/stxo.cpp
+++ b/src/stxo.cpp
@@ -1,0 +1,29 @@
+// Copyright (c) 2014 The Bitcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "stxo.h"
+#include "main.h"
+
+CSTXO::CSTXO(CBlockIndex* pIndexBest, unsigned int nNumberOfBlocks)
+{
+    unsigned int i = 0;
+    CBlockIndex* pindex = pIndexBest;
+    while (pindex && pindex->pprev)
+    {
+        CBlock block;
+        ReadBlockFromDisk(block, pindex);
+        BOOST_FOREACH(const CTransaction& tx, block.vtx)
+        {
+            if (!tx.IsCoinBase())
+            {
+                BOOST_FOREACH(const CTxIn& txin, tx.vin)
+                    setSpentCoins.insert(txin.prevout);
+            }
+        }
+
+        pindex = pindex->pprev;
+        if (++i == nNumberOfBlocks)
+            break;
+    }
+}

--- a/src/stxo.h
+++ b/src/stxo.h
@@ -1,0 +1,26 @@
+// Copyright (c) 2014 The Bitcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_STXO_H
+#define BITCOIN_STXO_H
+
+#include <set>
+
+class CBlockIndex;
+class COutPoint;
+
+class CSTXO
+{
+private:
+    std::set<COutPoint> setSpentCoins; // spent transaction outputs
+public:
+
+    CSTXO(CBlockIndex* pIndexBest, unsigned int nNumberOfBlocks);
+
+    bool IsRecentlySpent(const COutPoint& outpoint) const {
+        return (setSpentCoins.count(outpoint) == 1);
+    }
+};
+
+#endif // BITCOIN_STXO_H

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -34,6 +34,7 @@ extern unsigned int nTxConfirmTarget;
 extern bool bSpendZeroConfChange;
 extern bool fSendFreeTransactions;
 extern bool fPayAtLeastCustomFee;
+extern int nPruneWallet;
 
 //! -paytxfee default
 static const CAmount DEFAULT_TRANSACTION_FEE = 0;
@@ -47,6 +48,7 @@ class CCoinControl;
 class COutput;
 class CReserveKey;
 class CScript;
+class CSTXO;
 class CWalletTx;
 
 /** (client) version numbers for particular wallet features */
@@ -142,6 +144,7 @@ public:
 
     bool fFileBacked;
     std::string strWalletFile;
+    bool fUsingAccounts;
 
     std::set<int64_t> setKeyPool;
     std::map<CKeyID, CKeyMetadata> mapKeyMetadata;
@@ -180,6 +183,7 @@ public:
         nNextResend = 0;
         nLastResend = 0;
         nTimeFirstKey = 0;
+        fUsingAccounts = false;
     }
 
     std::map<uint256, CWalletTx> mapWallet;
@@ -203,7 +207,7 @@ public:
     void AvailableCoins(std::vector<COutput>& vCoins, bool fOnlyConfirmed=true, const CCoinControl *coinControl = NULL) const;
     bool SelectCoinsMinConf(const CAmount& nTargetValue, int nConfMine, int nConfTheirs, std::vector<COutput> vCoins, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoinsRet, CAmount& nValueRet) const;
 
-    bool IsSpent(const uint256& hash, unsigned int n) const;
+    bool IsSpent(const uint256& hash, unsigned int n, int nMinConf = 0) const;
 
     bool IsLockedCoin(uint256 hash, unsigned int n) const;
     void LockCoin(COutPoint& output);
@@ -272,8 +276,10 @@ public:
     void MarkDirty();
     bool AddToWallet(const CWalletTx& wtxIn, bool fFromLoadWallet=false);
     void SyncTransaction(const CTransaction& tx, const CBlock* pblock);
-    bool AddToWalletIfInvolvingMe(const CTransaction& tx, const CBlock* pblock, bool fUpdate);
+    bool AddToWalletIfInvolvingMe(const CTransaction& tx, const CBlock* pblock, bool fUpdate, CSTXO* pstxo = NULL);
     void EraseFromWallet(const uint256 &hash);
+    void EraseFromWallet(std::map<uint256, CWalletTx>::iterator it, CWalletDB& walletdb);
+    int64_t PruneWallet(int nDays);
     int ScanForWalletTransactions(CBlockIndex* pindexStart, bool fUpdate = false);
     void ReacceptWalletTransactions();
     void ResendWalletTransactions();
@@ -907,6 +913,8 @@ public:
     void RelayWalletTransaction();
 
     std::set<uint256> GetConflicts() const;
+
+    bool IsPrunable(int nDays, CSTXO* pstxo = NULL, std::set<const CWalletTx*> *pIsPrunableCache = NULL) const;
 };
 
 

--- a/src/walletdb.cpp
+++ b/src/walletdb.cpp
@@ -397,6 +397,9 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
                 wss.fAnyUnordered = true;
 
             pwallet->AddToWallet(wtx, true);
+
+            if (!wtx.strFromAccount.empty())
+                pwallet->fUsingAccounts = true;
         }
         else if (strType == "acentry")
         {
@@ -414,6 +417,8 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
                 if (acentry.nOrderPos == -1)
                     wss.fAnyUnordered = true;
             }
+
+            pwallet->fUsingAccounts = true;
         }
         else if (strType == "watchs")
         {


### PR DESCRIPTION
Wallet pruning can be used to speed up and shrink large wallets.

Transactions will only be removed, if this for sure does not affect your balance.

RPC prunewallet(n) removes transactions older than n days (n >= 1). Or adding prunewallet=n to bitcoin.conf prunes on startup. Note that the latter is required to prevent rescan from readding the transactions.

A transaction is pruned, if the following conditions are met
- at least 100 confirmations
- older than n days according to block-timestamp (n >= 1)
- our outputs must be completely spent and also the spending transaction must
  have at least 100 confirmations
- the inputs we spent are also pruned/prunable transactions, so that they dont require us as a spent-flag anymore

A new class STXO has been introduced, which loops over the last 100 blocks and builds a temporary recently-spent-outputs index.
Its only used on rescan, if wallet pruning is enabled. This is necessary to answer the question
"has the spending transaction at least 100 confirmations?".
Because if not, a rescan wants to always add the transaction to the wallet, and not skip.
This is because, when we rescan, we dont have the spending transaction anymore in the wallet, to check how many confirmations it has.
Also a rescan checks if spent or not in our coins-utxo, because the wallet does not know if spent or not while rescaning.

Note that the feature is disabled if someone uses the account-feature. I could add support for this, but I am not bothering if our plan is to remove the account-feature. Because pruning as is, would destroy account-balances.
