### PR TITLE
Remove the "OP_" prefix from transaction script decodes.

### DIFF
--- a/src/core_read.cpp
+++ b/src/core_read.cpp
@@ -39,12 +39,12 @@ CScript ParseScript(std::string s)
                 continue;
 
             const char* name = GetOpName((opcodetype)op);
-            if (strcmp(name, "OP_UNKNOWN") == 0)
+            if (strcmp(name, "UNKNOWN") == 0)
                 continue;
             string strName(name);
             mapOpNames[strName] = (opcodetype)op;
             // Convenience: OP_ADD and just ADD are both recognized:
-            replace_first(strName, "OP_", "");
+            strName = "OP_" + strName;
             mapOpNames[strName] = (opcodetype)op;
         }
     }

--- a/src/core_write.cpp
+++ b/src/core_write.cpp
@@ -36,10 +36,8 @@ string FormatScript(const CScript& script)
                 continue;
             } else if (op >= OP_NOP && op <= OP_CHECKMULTISIGVERIFY) {
                 string str(GetOpName(op));
-                if (str.substr(0, 3) == string("OP_")) {
-                    ret += str.substr(3, string::npos) + " ";
-                    continue;
-                }
+                ret += (str + " ");
+                continue;
             }
             if (vch.size() > 0) {
                 ret += strprintf("0x%x 0x%x ", HexStr(it2, it - vch.size()), HexStr(it - vch.size(), it));

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -26,11 +26,11 @@ const char* GetOpName(opcodetype opcode)
     {
     // push value
     case OP_0                      : return "0";
-    case OP_PUSHDATA1              : return "OP_PUSHDATA1";
-    case OP_PUSHDATA2              : return "OP_PUSHDATA2";
-    case OP_PUSHDATA4              : return "OP_PUSHDATA4";
+    case OP_PUSHDATA1              : return "PUSHDATA1";
+    case OP_PUSHDATA2              : return "PUSHDATA2";
+    case OP_PUSHDATA4              : return "PUSHDATA4";
     case OP_1NEGATE                : return "-1";
-    case OP_RESERVED               : return "OP_RESERVED";
+    case OP_RESERVED               : return "RESERVED";
     case OP_1                      : return "1";
     case OP_2                      : return "2";
     case OP_3                      : return "3";
@@ -49,109 +49,109 @@ const char* GetOpName(opcodetype opcode)
     case OP_16                     : return "16";
 
     // control
-    case OP_NOP                    : return "OP_NOP";
-    case OP_VER                    : return "OP_VER";
-    case OP_IF                     : return "OP_IF";
-    case OP_NOTIF                  : return "OP_NOTIF";
-    case OP_VERIF                  : return "OP_VERIF";
-    case OP_VERNOTIF               : return "OP_VERNOTIF";
-    case OP_ELSE                   : return "OP_ELSE";
-    case OP_ENDIF                  : return "OP_ENDIF";
-    case OP_VERIFY                 : return "OP_VERIFY";
-    case OP_RETURN                 : return "OP_RETURN";
+    case OP_NOP                    : return "NOP";
+    case OP_VER                    : return "VER";
+    case OP_IF                     : return "IF";
+    case OP_NOTIF                  : return "NOTIF";
+    case OP_VERIF                  : return "VERIF";
+    case OP_VERNOTIF               : return "VERNOTIF";
+    case OP_ELSE                   : return "ELSE";
+    case OP_ENDIF                  : return "ENDIF";
+    case OP_VERIFY                 : return "VERIFY";
+    case OP_RETURN                 : return "RETURN";
 
     // stack ops
-    case OP_TOALTSTACK             : return "OP_TOALTSTACK";
-    case OP_FROMALTSTACK           : return "OP_FROMALTSTACK";
-    case OP_2DROP                  : return "OP_2DROP";
-    case OP_2DUP                   : return "OP_2DUP";
-    case OP_3DUP                   : return "OP_3DUP";
-    case OP_2OVER                  : return "OP_2OVER";
-    case OP_2ROT                   : return "OP_2ROT";
-    case OP_2SWAP                  : return "OP_2SWAP";
-    case OP_IFDUP                  : return "OP_IFDUP";
-    case OP_DEPTH                  : return "OP_DEPTH";
-    case OP_DROP                   : return "OP_DROP";
-    case OP_DUP                    : return "OP_DUP";
-    case OP_NIP                    : return "OP_NIP";
-    case OP_OVER                   : return "OP_OVER";
-    case OP_PICK                   : return "OP_PICK";
-    case OP_ROLL                   : return "OP_ROLL";
-    case OP_ROT                    : return "OP_ROT";
-    case OP_SWAP                   : return "OP_SWAP";
-    case OP_TUCK                   : return "OP_TUCK";
+    case OP_TOALTSTACK             : return "TOALTSTACK";
+    case OP_FROMALTSTACK           : return "FROMALTSTACK";
+    case OP_2DROP                  : return "2DROP";
+    case OP_2DUP                   : return "2DUP";
+    case OP_3DUP                   : return "3DUP";
+    case OP_2OVER                  : return "2OVER";
+    case OP_2ROT                   : return "2ROT";
+    case OP_2SWAP                  : return "2SWAP";
+    case OP_IFDUP                  : return "IFDUP";
+    case OP_DEPTH                  : return "DEPTH";
+    case OP_DROP                   : return "DROP";
+    case OP_DUP                    : return "DUP";
+    case OP_NIP                    : return "NIP";
+    case OP_OVER                   : return "OVER";
+    case OP_PICK                   : return "PICK";
+    case OP_ROLL                   : return "ROLL";
+    case OP_ROT                    : return "ROT";
+    case OP_SWAP                   : return "SWAP";
+    case OP_TUCK                   : return "TUCK";
 
     // splice ops
-    case OP_CAT                    : return "OP_CAT";
-    case OP_SUBSTR                 : return "OP_SUBSTR";
-    case OP_LEFT                   : return "OP_LEFT";
-    case OP_RIGHT                  : return "OP_RIGHT";
-    case OP_SIZE                   : return "OP_SIZE";
+    case OP_CAT                    : return "CAT";
+    case OP_SUBSTR                 : return "SUBSTR";
+    case OP_LEFT                   : return "LEFT";
+    case OP_RIGHT                  : return "RIGHT";
+    case OP_SIZE                   : return "SIZE";
 
     // bit logic
-    case OP_INVERT                 : return "OP_INVERT";
-    case OP_AND                    : return "OP_AND";
-    case OP_OR                     : return "OP_OR";
-    case OP_XOR                    : return "OP_XOR";
-    case OP_EQUAL                  : return "OP_EQUAL";
-    case OP_EQUALVERIFY            : return "OP_EQUALVERIFY";
-    case OP_RESERVED1              : return "OP_RESERVED1";
-    case OP_RESERVED2              : return "OP_RESERVED2";
+    case OP_INVERT                 : return "INVERT";
+    case OP_AND                    : return "AND";
+    case OP_OR                     : return "OR";
+    case OP_XOR                    : return "XOR";
+    case OP_EQUAL                  : return "EQUAL";
+    case OP_EQUALVERIFY            : return "EQUALVERIFY";
+    case OP_RESERVED1              : return "RESERVED1";
+    case OP_RESERVED2              : return "RESERVED2";
 
     // numeric
-    case OP_1ADD                   : return "OP_1ADD";
-    case OP_1SUB                   : return "OP_1SUB";
-    case OP_2MUL                   : return "OP_2MUL";
-    case OP_2DIV                   : return "OP_2DIV";
-    case OP_NEGATE                 : return "OP_NEGATE";
-    case OP_ABS                    : return "OP_ABS";
-    case OP_NOT                    : return "OP_NOT";
-    case OP_0NOTEQUAL              : return "OP_0NOTEQUAL";
-    case OP_ADD                    : return "OP_ADD";
-    case OP_SUB                    : return "OP_SUB";
-    case OP_MUL                    : return "OP_MUL";
-    case OP_DIV                    : return "OP_DIV";
-    case OP_MOD                    : return "OP_MOD";
-    case OP_LSHIFT                 : return "OP_LSHIFT";
-    case OP_RSHIFT                 : return "OP_RSHIFT";
-    case OP_BOOLAND                : return "OP_BOOLAND";
-    case OP_BOOLOR                 : return "OP_BOOLOR";
-    case OP_NUMEQUAL               : return "OP_NUMEQUAL";
-    case OP_NUMEQUALVERIFY         : return "OP_NUMEQUALVERIFY";
-    case OP_NUMNOTEQUAL            : return "OP_NUMNOTEQUAL";
-    case OP_LESSTHAN               : return "OP_LESSTHAN";
-    case OP_GREATERTHAN            : return "OP_GREATERTHAN";
-    case OP_LESSTHANOREQUAL        : return "OP_LESSTHANOREQUAL";
-    case OP_GREATERTHANOREQUAL     : return "OP_GREATERTHANOREQUAL";
-    case OP_MIN                    : return "OP_MIN";
-    case OP_MAX                    : return "OP_MAX";
-    case OP_WITHIN                 : return "OP_WITHIN";
+    case OP_1ADD                   : return "1ADD";
+    case OP_1SUB                   : return "1SUB";
+    case OP_2MUL                   : return "2MUL";
+    case OP_2DIV                   : return "2DIV";
+    case OP_NEGATE                 : return "NEGATE";
+    case OP_ABS                    : return "ABS";
+    case OP_NOT                    : return "NOT";
+    case OP_0NOTEQUAL              : return "0NOTEQUAL";
+    case OP_ADD                    : return "ADD";
+    case OP_SUB                    : return "SUB";
+    case OP_MUL                    : return "MUL";
+    case OP_DIV                    : return "DIV";
+    case OP_MOD                    : return "MOD";
+    case OP_LSHIFT                 : return "LSHIFT";
+    case OP_RSHIFT                 : return "RSHIFT";
+    case OP_BOOLAND                : return "BOOLAND";
+    case OP_BOOLOR                 : return "BOOLOR";
+    case OP_NUMEQUAL               : return "NUMEQUAL";
+    case OP_NUMEQUALVERIFY         : return "NUMEQUALVERIFY";
+    case OP_NUMNOTEQUAL            : return "NUMNOTEQUAL";
+    case OP_LESSTHAN               : return "LESSTHAN";
+    case OP_GREATERTHAN            : return "GREATERTHAN";
+    case OP_LESSTHANOREQUAL        : return "LESSTHANOREQUAL";
+    case OP_GREATERTHANOREQUAL     : return "GREATERTHANOREQUAL";
+    case OP_MIN                    : return "MIN";
+    case OP_MAX                    : return "MAX";
+    case OP_WITHIN                 : return "WITHIN";
 
     // crypto
-    case OP_RIPEMD160              : return "OP_RIPEMD160";
-    case OP_SHA1                   : return "OP_SHA1";
-    case OP_SHA256                 : return "OP_SHA256";
-    case OP_HASH160                : return "OP_HASH160";
-    case OP_HASH256                : return "OP_HASH256";
-    case OP_CODESEPARATOR          : return "OP_CODESEPARATOR";
-    case OP_CHECKSIG               : return "OP_CHECKSIG";
-    case OP_CHECKSIGVERIFY         : return "OP_CHECKSIGVERIFY";
-    case OP_CHECKMULTISIG          : return "OP_CHECKMULTISIG";
-    case OP_CHECKMULTISIGVERIFY    : return "OP_CHECKMULTISIGVERIFY";
+    case OP_RIPEMD160              : return "RIPEMD160";
+    case OP_SHA1                   : return "SHA1";
+    case OP_SHA256                 : return "SHA256";
+    case OP_HASH160                : return "HASH160";
+    case OP_HASH256                : return "HASH256";
+    case OP_CODESEPARATOR          : return "CODESEPARATOR";
+    case OP_CHECKSIG               : return "CHECKSIG";
+    case OP_CHECKSIGVERIFY         : return "CHECKSIGVERIFY";
+    case OP_CHECKMULTISIG          : return "CHECKMULTISIG";
+    case OP_CHECKMULTISIGVERIFY    : return "CHECKMULTISIGVERIFY";
 
     // expanson
-    case OP_NOP1                   : return "OP_NOP1";
-    case OP_NOP2                   : return "OP_NOP2";
-    case OP_NOP3                   : return "OP_NOP3";
-    case OP_NOP4                   : return "OP_NOP4";
-    case OP_NOP5                   : return "OP_NOP5";
-    case OP_NOP6                   : return "OP_NOP6";
-    case OP_NOP7                   : return "OP_NOP7";
-    case OP_NOP8                   : return "OP_NOP8";
-    case OP_NOP9                   : return "OP_NOP9";
-    case OP_NOP10                  : return "OP_NOP10";
+    case OP_NOP1                   : return "NOP1";
+    case OP_NOP2                   : return "NOP2";
+    case OP_NOP3                   : return "NOP3";
+    case OP_NOP4                   : return "NOP4";
+    case OP_NOP5                   : return "NOP5";
+    case OP_NOP6                   : return "NOP6";
+    case OP_NOP7                   : return "NOP7";
+    case OP_NOP8                   : return "NOP8";
+    case OP_NOP9                   : return "NOP9";
+    case OP_NOP10                  : return "NOP10";
 
-    case OP_INVALIDOPCODE          : return "OP_INVALIDOPCODE";
+    case OP_INVALIDOPCODE          : return "INVALIDOPCODE";
 
     // Note:
     //  The template matching params OP_SMALLDATA/etc are defined in opcodetype enum
@@ -159,7 +159,7 @@ const char* GetOpName(opcodetype opcode)
     //  Script, just let the default: case deal with them.
 
     default:
-        return "OP_UNKNOWN";
+        return "UNKNOWN";
     }
 }
 

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -154,4 +154,21 @@ BOOST_AUTO_TEST_CASE(rpc_boostasiotocnetaddr)
     BOOST_CHECK_EQUAL(BoostAsioToCNetAddr(boost::asio::ip::address::from_string("::ffff:127.0.0.1")).ToString(), "127.0.0.1");
 }
 
+BOOST_AUTO_TEST_CASE(rpc_decoderawtransaction_scriptPubKey)
+{
+    Value result;
+    Value scriptPubKeyAsm;
+    string tx;
+    Value txid;
+    // this test case uses a main net transaction that has both P2PKH and P2SH outputs. it's from james d'angelo's awesome video about multisig -- https://www.youtube.com/watch?v=zIbUSaZBJgU.
+    tx = std::string("010000000214e74c8aa195fd544715fb4401008a7e139b23804e8c07b6bb538989270ebbdf000000008b48304502205192c9c285f47be0f0dc34cdfb6e2093b0b09d58cb361e7a996ce6d9d5bda1c2022100e82562a42ffb27e9da98eb086f5376efc3eb534b2bbee410dd1436406be2613501410460f8395ff5b0db8cac5a471d11066fb1598411153b04d76984b7c36bc01dc0699b83d995333dc513d082f423c20a4b2d1a6753daccecbf9ee01cb15af97c9fc2ffffffffcfcd79a7e8c838a08587ab9347dce1a0420a43ca4cae73b2e1b7d797b46e2a07010000008b483045022001ba3879426b190c6bf82adc91af4f58eecd27c61c6603604de5f4c1c0052f59022100e3af7e854e437fa57cf2081ab67911063d9fbd78a9050687df4da9dafeb538ba014104983fd4a1ffa71bfe7dfd623b39ba27a735b6ceb70931a25acdad529cf06d7ab454cc47bb81e1da0a0d00cb00d4085b75a1f46ef84ffe566cdc6624709c2c56dfffffffff02a45e02000000000017a9142a5edea39971049a540474c6a99edf0aa4074c58874b920000000000001976a914b9c670c7aa955c9808af7eeb9643b9fd6285cbf588ac00000000");
+    BOOST_CHECK_NO_THROW(result = CallRPC(string("decoderawtransaction ") + tx));
+    txid = find_value(result.get_obj(), "txid");
+    BOOST_CHECK_EQUAL(txid.get_str(), "73926d12845ecf0dbb51abe0d64a1e11deb385dc58df2d7e2c6ed0ab35561f8d");
+    scriptPubKeyAsm = find_value(find_value(find_value(result.get_obj(), "vout").get_array().at(0).get_obj(), "scriptPubKey").get_obj(), "asm");
+    BOOST_CHECK_EQUAL(scriptPubKeyAsm.get_str(), "HASH160 2a5edea39971049a540474c6a99edf0aa4074c58 EQUAL");
+    scriptPubKeyAsm = find_value(find_value(find_value(result.get_obj(), "vout").get_array().at(1).get_obj(), "scriptPubKey").get_obj(), "asm");
+    BOOST_CHECK_EQUAL(scriptPubKeyAsm.get_str(), "DUP HASH160 b9c670c7aa955c9808af7eeb9643b9fd6285cbf5 EQUALVERIFY CHECKSIG");
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This set of changes was born out of the discussion of #5264.

The main impact of these changes is on the scriptPubKey "asm" value in the output for transaction decodes. There are also more minor logging and bitcoin-tx references.

Basically, the goal was to just remove the "OP_" prefixes.

1) Example P2PKH
Before:
OP_DUP OP_HASH160 b9c670c7aa955c9808af7eeb9643b9fd6285cbf5 OP_EQUALVERIFY OP_CHECKSIG
After:
DUP HASH160 b9c670c7aa955c9808af7eeb9643b9fd6285cbf5 EQUALVERIFY CHECKSIG

2) Example P2SH
Before:
OP_HASH160 2a5edea39971049a540474c6a99edf0aa4074c58 OP_EQUAL
After:
HASH160 2a5edea39971049a540474c6a99edf0aa4074c58 EQUAL

If these changes gain acceptance, I'll add some release notes too when that time comes.
