### PR TITLE
Check for available funds before call to SendMoney.

### DIFF
--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -348,6 +348,10 @@ Value sendtoaddress(const Array& params, bool fHelp)
 
     EnsureWalletIsUnlocked();
 
+    // Check funds
+    if (nAmount > pwalletMain->GetBalance())
+        throw JSONRPCError(RPC_WALLET_INSUFFICIENT_FUNDS, "Insufficient funds");
+
     string strError = pwalletMain->SendMoney(address.Get(), nAmount, wtx);
     if (strError != "")
         throw JSONRPCError(RPC_WALLET_ERROR, strError);


### PR DESCRIPTION
RPC call sendtoaddress doesn't check for available funds before the call to SendMoney. This results in suboptimal RPC error code returned. RPC_WALLET_ERROR (-4) instead of RPC_WALLET_INSUFFICIENT_FUNDS (-6):

```
# Before:
pavel$ ./bitcoin-cli sendtoaddress m...address... 1000
error: {"code":-4,"message":"Insufficient funds"}
# After:
pavel$ ./bitcoin-cli sendtoaddress m...address... 1000
error: {"code":-6,"message":"Insufficient funds"}
```

This fixes issue #3007.
