### PR TITLE
Add /opt/local/include/db48 only if it exists.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -244,8 +244,12 @@ case $host in
        AC_CHECK_PROG([PORT],port, port)
        if test x$PORT = xport; then
          dnl add default macports paths
-         CPPFLAGS="$CPPFLAGS -isystem /opt/local/include -I/opt/local/include/db48"
-         LIBS="$LIBS -L/opt/local/lib -L/opt/local/lib/db48"
+         CPPFLAGS="$CPPFLAGS -isystem /opt/local/include"
+         LIBS="$LIBS -L/opt/local/lib"
+         if test -d /opt/local/include/db48; then
+           CPPFLAGS="$CPPFLAGS -I/opt/local/include/db48"
+           LIBS="$LIBS -L/opt/local/lib/db48"
+         fi
        fi
 
        AC_CHECK_PROG([BREW],brew, brew)


### PR DESCRIPTION
On one of my Mac OS X machines, I do have MacPorts installed, but no Berkeley DB (it is elsewhere). Thus /opt/local/include/db48 doesn't exist and our build shows too many warnings for that. Silence them.
Low prio.
