### PR TITLE
Do not check twice for empty set of transactions.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2406,7 +2406,7 @@ bool CheckBlock(const CBlock& block, CValidationState& state, bool fCheckPOW, bo
                          REJECT_INVALID, "bad-blk-length");
 
     // First transaction must be coinbase, the rest must not be
-    if (block.vtx.empty() || !block.vtx[0].IsCoinBase())
+    if (!block.vtx[0].IsCoinBase())
         return state.DoS(100, error("CheckBlock() : first tx is not coinbase"),
                          REJECT_INVALID, "bad-cb-missing");
     for (unsigned int i = 1; i < block.vtx.size(); i++)


### PR DESCRIPTION
We have the same check a few/five lines above this line, in the section "Size limits" and such block is already bad-blk-length. Looks like bad merge or something.
