### PR TITLE
qa/rpc-tests: Test prioritisetransaction

### DIFF
--- a/qa/rpc-tests/prioritisetransaction.py
+++ b/qa/rpc-tests/prioritisetransaction.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python2
+# Copyright (c) 2014 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from test_framework import BitcoinTestFramework
+from bitcoinrpc.authproxy import AuthServiceProxy, JSONRPCException
+from util import *
+
+def fresh_gbt(anode):
+    tmpl = anode.getblocktemplate({"use_cache": False})
+    return tmpl
+
+def tmpl_tx(tmpl, txid):
+    for tx in tmpl['transactions']:
+        if tx['hash'] == txid:
+            return tx
+
+class PrioritiseTransactionTest(BitcoinTestFramework):
+    '''
+    Test prioritisetransaction with getblocktemplate.
+    '''
+
+    def run_test(self):
+        node = self.nodes[0]
+
+        node.setgenerate(True, 10)
+
+        (txid_a, txhex, fee) = random_transaction(self.nodes, Decimal("1.1"), 1, 0, 20)
+        (txid_b, txhex, fee) = random_transaction(self.nodes, Decimal("1.1"), 2, 0, 20)
+        sync_blocks(self.nodes)
+        sync_mempools(self.nodes)
+
+        # Put both transactions at the same base priority/fee level
+        tmpl = fresh_gbt(node)
+        prio_a = tmpl_tx(tmpl, txid_a)['priority_adjusted']
+        prio_b = tmpl_tx(tmpl, txid_b)['priority_adjusted']
+        base_prio = max(prio_a, prio_b) + 1000000
+        assert(node.prioritisetransaction(txid_a, base_prio - prio_a, 200000000))
+        assert(node.prioritisetransaction(txid_b, base_prio - prio_b, 100000000))
+
+        if len(fresh_gbt(node)['transactions']) != 2:
+            raise AssertionError('Unexpected transaction count in template')
+
+        def testadj(txid, prio, fee):
+            assert(node.prioritisetransaction(txid, prio, fee))
+            tmpl = fresh_gbt(node)
+            tx = tmpl_tx(tmpl, txid)
+            assert(tx['fee_adjusted'] == 300000000 + fee)
+            assert(tx['priority_adjusted'] == base_prio + prio)
+            # NOTE: Fees don't actually affect block ordering
+            if prio and tmpl['transactions'][0]['hash'] != txid:
+                raise AssertionError('Higher priority ignored')
+            assert(node.prioritisetransaction(txid, -prio * 2, -fee * 2))
+            tmpl = fresh_gbt(node)
+            tx = tmpl_tx(tmpl, txid)
+            assert(tx['fee_adjusted'] == 300000000 - fee)
+            assert(tx['priority_adjusted'] == base_prio - prio)
+            if prio and tmpl['transactions'][0]['hash'] == txid:
+                raise AssertionError('Lower priority ignored')
+            assert(node.prioritisetransaction(txid, prio, fee))
+
+        testadj(txid_a, 1, 0)
+        testadj(txid_b, 1, 0)
+        testadj(txid_a, 0, 1)
+        testadj(txid_b, 0, 1)
+
+if __name__ == '__main__':
+    PrioritiseTransactionTest().main()

--- a/src/main.h
+++ b/src/main.h
@@ -627,6 +627,8 @@ struct CBlockTemplate
     CBlock block;
     std::vector<CAmount> vTxFees;
     std::vector<int64_t> vTxSigOps;
+    std::vector<CAmount> vTxFeesAdjusted;
+    std::vector<double> vTxPrioritiesAdjusted;
 };
 
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -112,6 +112,8 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn)
     pblock->vtx.push_back(CTransaction());
     pblocktemplate->vTxFees.push_back(-1); // updated at end
     pblocktemplate->vTxSigOps.push_back(-1); // updated at end
+    pblocktemplate->vTxFeesAdjusted.push_back(-1);  // updated at end
+    pblocktemplate->vTxPrioritiesAdjusted.push_back(0);
 
     // Largest block you're willing to create:
     unsigned int nBlockMaxSize = GetArg("-blockmaxsize", DEFAULT_BLOCK_MAX_SIZE);
@@ -286,6 +288,13 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn)
             pblock->vtx.push_back(tx);
             pblocktemplate->vTxFees.push_back(nTxFees);
             pblocktemplate->vTxSigOps.push_back(nTxSigOps);
+            {
+                CAmount nTxFeesAdj = nTxFees;
+                double dummy;
+                mempool.ApplyDeltas(hash, dummy, nTxFeesAdj);
+                pblocktemplate->vTxFeesAdjusted.push_back(nTxFeesAdj);
+            }
+            pblocktemplate->vTxPrioritiesAdjusted.push_back(dPriority);
             nBlockSize += nTxSize;
             ++nBlockTx;
             nBlockSigOps += nTxSigOps;

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -559,6 +559,8 @@ Value getblocktemplate(const Array& params, bool fHelp)
         int index_in_template = i - 1;
         entry.push_back(Pair("fee", pblocktemplate->vTxFees[index_in_template]));
         entry.push_back(Pair("sigops", pblocktemplate->vTxSigOps[index_in_template]));
+        entry.push_back(Pair("fee_adjusted", pblocktemplate->vTxFeesAdjusted[index_in_template]));
+        entry.push_back(Pair("priority_adjusted", pblocktemplate->vTxPrioritiesAdjusted[index_in_template]));
 
         transactions.push_back(entry);
     }

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -381,6 +381,7 @@ Value getblocktemplate(const Array& params, bool fHelp)
 
     std::string strMode = "template";
     Value lpval = Value::null;
+    Value use_cache = Value::null;
     if (params.size() > 0)
     {
         const Object& oparam = params[0].get_obj();
@@ -424,6 +425,7 @@ Value getblocktemplate(const Array& params, bool fHelp)
             TestBlockValidity(state, block, pindexPrev, false, true);
             return BIP22ValidationResult(state);
         }
+        use_cache = find_value(oparam, "use_cache");
     }
 
     if (strMode != "template")
@@ -495,8 +497,9 @@ Value getblocktemplate(const Array& params, bool fHelp)
     static CBlockIndex* pindexPrev;
     static int64_t nStart;
     static CBlockTemplate* pblocktemplate;
-    if (pindexPrev != chainActive.Tip() ||
+    if ((use_cache.type() == null_type) ? (pindexPrev != chainActive.Tip() ||
         (mempool.GetTransactionsUpdated() != nTransactionsUpdatedLast && GetTime() - nStart > 5))
+        : (!use_cache.get_bool()))
     {
         // Clear pindexPrev so future calls make a new block, despite any failures from here on
         pindexPrev = NULL;


### PR DESCRIPTION
Built on top of #5398 for now; if we decide not to merge that, this needs to be refactored.

This also adds non-standard extensions to getblocktemplate to override its caching and provide the adjusted priority/fee values used. It might be desirable to add an option so the latter is only added for this test - thoughts?
