### PR TITLE
Package libqt5core5 replaced with libqt5core5a

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -106,7 +106,7 @@ To build with Qt 4 you need the following:
 
 For Qt 5 you need the following:
 
-    sudo apt-get install libqt5gui5 libqt5core5 libqt5dbus5 qttools5-dev qttools5-dev-tools libprotobuf-dev protobuf-compiler
+    sudo apt-get install libqt5gui5 libqt5core5a libqt5dbus5 qttools5-dev qttools5-dev-tools libprotobuf-dev protobuf-compiler
 
 libqrencode (optional) can be installed with:
 


### PR DESCRIPTION
libqt5core5 installs failed.
Package libqt5core5 has replaced with libqt5core5a in ubuntu and debian. 
The website is:
http://packages.ubuntu.com/trusty/libqt5core5a
https://packages.debian.org/sid/libqt5core5a
