### PR TITLE
CAmount: Small improvements related to CAmount

### DIFF
--- a/src/compressor.cpp
+++ b/src/compressor.cpp
@@ -139,8 +139,10 @@ bool CScriptCompressor::Decompress(unsigned int nSize, const std::vector<unsigne
 // * if e==9, we only know the resulting number is not zero, so output 1 + 10*(n - 1) + 9
 // (this is decodable, as d is in [1-9] and e is in [0-9])
 
-uint64_t CTxOutCompressor::CompressAmount(uint64_t n)
+uint64_t CTxOutCompressor::CompressAmount(const CAmount& _n)
 {
+    // Cast from CAmount (int64_t) to uint64_t
+    uint64_t n = _n;
     if (n == 0)
         return 0;
     int e = 0;
@@ -158,7 +160,7 @@ uint64_t CTxOutCompressor::CompressAmount(uint64_t n)
     }
 }
 
-uint64_t CTxOutCompressor::DecompressAmount(uint64_t x)
+CAmount CTxOutCompressor::DecompressAmount(uint64_t x)
 {
     // x = 0  OR  x = 1+10*(9*n + d - 1) + e  OR  x = 1+10*(n - 1) + 9
     if (x == 0)
@@ -181,5 +183,6 @@ uint64_t CTxOutCompressor::DecompressAmount(uint64_t x)
         n *= 10;
         e--;
     }
+    // Cast from uint64_t to CAmount (int64_t)
     return n;
 }

--- a/src/compressor.h
+++ b/src/compressor.h
@@ -98,8 +98,8 @@ private:
     CTxOut &txout;
 
 public:
-    static uint64_t CompressAmount(uint64_t nAmount);
-    static uint64_t DecompressAmount(uint64_t nAmount);
+    static uint64_t CompressAmount(const CAmount& nAmount);
+    static CAmount DecompressAmount(uint64_t nAmount);
 
     CTxOutCompressor(CTxOut &txoutIn) : txout(txoutIn) { }
 

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -198,7 +198,7 @@ QString formatBitcoinURI(const SendCoinsRecipient &info)
     QString ret = QString("bitcoin:%1").arg(info.address);
     int paramCount = 0;
 
-    if (info.amount)
+    if (info.amount != 0)
     {
         ret += QString("?amount=%1").arg(BitcoinUnits::format(BitcoinUnits::BTC, info.amount, false, BitcoinUnits::separatorNever));
         paramCount++;

--- a/src/qt/receiverequestdialog.cpp
+++ b/src/qt/receiverequestdialog.cpp
@@ -143,7 +143,7 @@ void ReceiveRequestDialog::update()
     html += "<b>"+tr("URI")+"</b>: ";
     html += "<a href=\""+uri+"\">" + GUIUtil::HtmlEscape(uri) + "</a><br>";
     html += "<b>"+tr("Address")+"</b>: " + GUIUtil::HtmlEscape(info.address) + "<br>";
-    if(info.amount)
+    if(info.amount != 0)
         html += "<b>"+tr("Amount")+"</b>: " + BitcoinUnits::formatWithUnit(model->getDisplayUnit(), info.amount) + "<br>";
     if(!info.label.isEmpty())
         html += "<b>"+tr("Label")+"</b>: " + GUIUtil::HtmlEscape(info.label) + "<br>";

--- a/src/test/compress_tests.cpp
+++ b/src/test/compress_tests.cpp
@@ -23,7 +23,7 @@
 
 BOOST_AUTO_TEST_SUITE(compress_tests)
 
-bool static TestEncode(uint64_t in) {
+bool static TestEncode(const CAmount& in) {
     return in == CTxOutCompressor::DecompressAmount(CTxOutCompressor::CompressAmount(in));
 }
 
@@ -31,7 +31,7 @@ bool static TestDecode(uint64_t in) {
     return in == CTxOutCompressor::CompressAmount(CTxOutCompressor::DecompressAmount(in));
 }
 
-bool static TestPair(uint64_t dec, uint64_t enc) {
+bool static TestPair(const CAmount& dec, uint64_t enc) {
     return CTxOutCompressor::CompressAmount(dec) == enc &&
            CTxOutCompressor::DecompressAmount(enc) == dec;
 }

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -737,7 +737,7 @@ public:
         if (IsCoinBase() && GetBlocksToMaturity() > 0)
             return 0;
 
-        int64_t credit = 0;
+        CAmount credit = 0;
         if (filter & ISMINE_SPENDABLE)
         {
             // GetBalance can assume transactions in mapWallet won't change


### PR DESCRIPTION
`if (info.amount != 0)` is more readable than `if (info.amount)`. Also if CAmount was a class instead of a typedef, the conditional operator cannot be overloaded.
The wallet should be using CAmount instead of int64_t.
