### PR TITLE
Make mempool-removed tracking much more explicit

### DIFF
--- a/qa/pull-tester/rpc-tests.sh
+++ b/qa/pull-tester/rpc-tests.sh
@@ -26,6 +26,7 @@ testScripts=(
     'rest.py'
     'mempool_spendcoinbase.py'
     'mempool_coinbase_spends.py'
+    'conflicted_txn.py'
     'httpbasics.py'
     'zapwallettxes.py'
     'proxy_test.py'

--- a/qa/rpc-tests/conflicted_txn.py
+++ b/qa/rpc-tests/conflicted_txn.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python2
+# Copyright (c) 2014 The Bitcoin Core developers
+# Distributed under the MIT/X11 software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+
+from test_framework import BitcoinTestFramework
+from util import *
+
+class RemoveTest(BitcoinTestFramework):
+    def setup_chain(self):
+        print("Initializing test directory "+self.options.tmpdir)
+        initialize_chain_clean(self.options.tmpdir, 3)
+
+    def setup_network(self, split=False):
+        self.nodes = start_nodes(3, self.options.tmpdir)
+        connect_nodes(self.nodes[0], 1)
+        connect_nodes(self.nodes[1], 2)
+        self.is_network_split = False
+        self.sync_all()
+
+    def run_test (self):
+        print("Mining blocks...")
+        self.nodes[2].setgenerate(True, 105)
+        self.nodes[2].sendtoaddress(self.nodes[1].getnewaddress(), 11)
+        self.nodes[2].sendtoaddress(self.nodes[1].getnewaddress(), 42)
+        self.nodes[2].sendtoaddress(self.nodes[1].getnewaddress(), 15)
+        self.nodes[2].setgenerate(True)
+        self.sync_all()
+
+        node1utxos = self.nodes[1].listunspent(1)
+
+        utxo = node1utxos.pop()
+        utxo2 = node1utxos.pop()
+        txto1_1_raw = self.nodes[1].createrawtransaction([{"txid": utxo["txid"], "vout": utxo["vout"]}, {"txid": utxo2["txid"], "vout": utxo2["vout"]}], {self.nodes[1].getnewaddress(): utxo["amount"] + utxo2["amount"]})
+        txto1_1_raw = self.nodes[1].signrawtransaction(txto1_1_raw)["hex"]
+        txto1_1_hash = self.nodes[1].sendrawtransaction(txto1_1_raw)
+
+        utxo3 = node1utxos.pop()
+        txto1_2_addr = self.nodes[1].getnewaddress()
+        txto1_2_raw = self.nodes[1].createrawtransaction([{"txid": txto1_1_hash, "vout": 0}, {"txid": utxo3["txid"], "vout": utxo3["vout"]}], {txto1_2_addr: utxo["amount"], self.nodes[1].getnewaddress(): utxo2["amount"], self.nodes[2].getnewaddress(): utxo3["amount"]})
+        txto1_2_raw = self.nodes[1].signrawtransaction(txto1_2_raw)["hex"]
+        txto1_2_hash = self.nodes[1].sendrawtransaction(txto1_2_raw)
+
+        txto1_2_vout = 0 if self.nodes[1].getrawtransaction(txto1_2_hash, 1)["vout"][0]["scriptPubKey"]["addresses"][0] == txto1_2_addr else 1
+        txto1_2_vout = txto1_2_vout if self.nodes[1].getrawtransaction(txto1_2_hash, 1)["vout"][2]["scriptPubKey"]["addresses"][0] != txto1_2_addr else 2
+        txto0_1_raw = self.nodes[1].createrawtransaction([{"txid": txto1_2_hash, "vout": txto1_2_vout}], {self.nodes[0].getnewaddress(): utxo["amount"]})
+        txto0_1_raw = self.nodes[1].signrawtransaction(txto0_1_raw)["hex"]
+        txto0_1_hash = self.nodes[1].sendrawtransaction(txto0_1_raw, True)
+
+        self.sync_all()
+
+        txto0_2_raw = self.nodes[0].createrawtransaction([{"txid": txto0_1_hash, "vout": 0}], {self.nodes[0].getnewaddress(): utxo["amount"] - 1, self.nodes[1].getnewaddress(): 1})
+        txto0_2_raw = self.nodes[0].signrawtransaction(txto0_2_raw)["hex"]
+        txto0_2_hash = self.nodes[0].sendrawtransaction(txto0_2_raw)
+
+        self.sync_all()
+        # txto0_2_raw should be untrusted as it depends on untrusted, unconfirmed inputs
+        #XXX: assert_equal(self.nodes[0].getbalance(), 0)
+        #XXX: assert_equal(self.nodes[0].getunconfirmedbalance(), utxo["amount"] - 1)
+        assert_equal(self.nodes[1].getbalance(), utxo2["amount"])
+        assert_equal(self.nodes[1].getunconfirmedbalance(), 1)
+
+        stop_node(self.nodes[0],0)
+        self.nodes[0] = start_node(0, self.options.tmpdir, ["-debug"])
+        stop_node(self.nodes[1],1)
+        self.nodes[1] = start_node(1, self.options.tmpdir, ["-debug"])
+        stop_node(self.nodes[2],2)
+        self.nodes[2] = start_node(2, self.options.tmpdir, ["-debug"])
+
+        self.nodes[0].getbalance()
+        self.nodes[0].getunconfirmedbalance()
+        self.nodes[1].getbalance()
+        self.nodes[1].getunconfirmedbalance()
+
+        txto1_1_ds_node2_addr = self.nodes[2].getnewaddress()
+        txto1_1_ds_raw = self.nodes[1].createrawtransaction([{"txid": utxo["txid"], "vout": utxo["vout"]}, {"txid": utxo3["txid"], "vout": utxo3["vout"]}], {self.nodes[1].getnewaddress(): utxo["amount"], txto1_1_ds_node2_addr: utxo3["amount"]})
+        txto1_1_ds_raw = self.nodes[1].signrawtransaction(txto1_1_ds_raw)["hex"]
+        txto1_1_ds_hash = self.nodes[2].sendrawtransaction(txto1_1_ds_raw)
+        self.nodes[2].setgenerate(True)
+
+        connect_nodes(self.nodes[1], 2)
+        connect_nodes(self.nodes[0], 1)
+        self.sync_all()
+
+        # We are now entirely conflicted and have no spendable outputs
+        assert_equal(self.nodes[0].getbalance(), 0)
+        assert_equal(self.nodes[0].getunconfirmedbalance(), 0)
+        assert_equal(self.nodes[0].gettransaction(txto0_1_hash)["confirmations"], -1)
+        assert_equal(self.nodes[0].gettransaction(txto0_2_hash)["confirmations"], -1)
+
+        assert_equal(self.nodes[1].getbalance(), utxo["amount"] + utxo2["amount"])
+        assert_equal(self.nodes[1].getunconfirmedbalance(), 0)
+
+        stop_node(self.nodes[2],2)
+        self.nodes[2] = start_node(2, self.options.tmpdir, ["-debug"])
+
+        txto1_1_ds_vout = 1 if self.nodes[1].getrawtransaction(txto1_1_ds_hash, 1)["vout"][0]["scriptPubKey"]["addresses"][0] == txto1_1_ds_node2_addr else 0
+        txto0_3_raw = self.nodes[1].createrawtransaction([{"txid": txto1_1_ds_hash, "vout": txto1_1_ds_vout}], {self.nodes[0].getnewaddress(): utxo["amount"]})
+        txto0_3_raw = self.nodes[1].signrawtransaction(txto0_3_raw)["hex"]
+        txto0_3_ds_raw = self.nodes[1].createrawtransaction([{"txid": txto1_1_ds_hash, "vout": txto1_1_ds_vout}], {self.nodes[1].getnewaddress(): utxo["amount"]})
+        txto0_3_ds_raw = self.nodes[1].signrawtransaction(txto0_3_ds_raw)["hex"]
+
+        txto0_3_hash = self.nodes[1].sendrawtransaction(txto0_3_raw)
+        self.nodes[1].setgenerate(True)
+
+        assert_equal(self.nodes[1].getbalance(), utxo2["amount"])
+        assert_equal(self.nodes[1].getunconfirmedbalance(), 0)
+
+        sync_blocks([self.nodes[0], self.nodes[1]])
+        txto1_3_hash = self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 1)
+        #self.nodes[0].setgenerate(True)
+        assert(self.nodes[0].getbalance() > utxo["amount"] - 2 and self.nodes[0].getbalance() < utxo["amount"] - 1)
+        assert_equal(self.nodes[0].getunconfirmedbalance(), 0)
+
+        txto0_3_ds_hash = self.nodes[2].sendrawtransaction(txto0_3_ds_raw)
+        self.nodes[2].setgenerate(True, 2)
+
+        connect_nodes(self.nodes[1], 2)
+        self.sync_all()
+
+        # We are now entirely conflicted and have no spendable outputs
+        assert_equal(self.nodes[0].getbalance(), 0)
+        assert_equal(self.nodes[0].getunconfirmedbalance(), 0)
+        assert_equal(self.nodes[0].gettransaction(txto0_3_hash)["confirmations"], -1)
+        assert_equal(self.nodes[0].gettransaction(txto1_3_hash)["confirmations"], -1)
+
+        assert_equal(self.nodes[1].getbalance(), utxo["amount"] + utxo2["amount"])
+        assert_equal(self.nodes[1].getunconfirmedbalance(), 0)
+
+
+if __name__ == '__main__':
+    RemoveTest().main ()

--- a/src/test/mempool_tests.cpp
+++ b/src/test/mempool_tests.cpp
@@ -52,7 +52,7 @@ BOOST_AUTO_TEST_CASE(MempoolRemoveTest)
 
 
     CTxMemPool testPool(CFeeRate(0));
-    std::list<CTransaction> removed;
+    std::list<uint256> removed;
 
     // Nothing in pool, remove should do nothing:
     testPool.remove(txParent, removed, true);

--- a/src/test/policyestimator_tests.cpp
+++ b/src/test/policyestimator_tests.cpp
@@ -44,7 +44,7 @@ BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
     for (unsigned int i = 0; i < 128; i++)
         garbage.push_back('X');
     CMutableTransaction tx;
-    std::list<CTransaction> dummyConflicted;
+    std::list<uint256> dummyConflicted;
     tx.vin.resize(1);
     tx.vin[0].scriptSig = garbage;
     tx.vout.resize(1);

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -117,11 +117,11 @@ public:
     void setSanityCheck(bool _fSanityCheck) { fSanityCheck = _fSanityCheck; }
 
     bool addUnchecked(const uint256& hash, const CTxMemPoolEntry &entry, bool fCurrentEstimate = true);
-    void remove(const CTransaction &tx, std::list<CTransaction>& removed, bool fRecursive = false);
+    void remove(const CTransaction &tx, std::list<uint256>& removed, bool fRecursive = false);
     void removeCoinbaseSpends(const CCoinsViewCache *pcoins, unsigned int nMemPoolHeight);
-    void removeConflicts(const CTransaction &tx, std::list<CTransaction>& removed);
+    void removeConflicts(const CTransaction &tx, std::list<uint256>& removed);
     void removeForBlock(const std::vector<CTransaction>& vtx, unsigned int nBlockHeight,
-                        std::list<CTransaction>& conflicts, bool fCurrentEstimate = true);
+                        std::list<uint256>& conflicts, bool fCurrentEstimate = true);
     void clear();
     void queryHashes(std::vector<uint256>& vtxid);
     void pruneSpent(const uint256& hash, CCoins &coins);

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -14,6 +14,7 @@ CMainSignals& GetMainSignals()
 
 void RegisterValidationInterface(CValidationInterface* pwalletIn) {
     g_signals.SyncTransaction.connect(boost::bind(&CValidationInterface::SyncTransaction, pwalletIn, _1, _2));
+    g_signals.TransactionConflicted.connect(boost::bind(&CValidationInterface::TransactionConflicted, pwalletIn, _1));
     g_signals.UpdatedTransaction.connect(boost::bind(&CValidationInterface::UpdatedTransaction, pwalletIn, _1));
     g_signals.SetBestChain.connect(boost::bind(&CValidationInterface::SetBestChain, pwalletIn, _1));
     g_signals.Inventory.connect(boost::bind(&CValidationInterface::Inventory, pwalletIn, _1));
@@ -31,6 +32,7 @@ void UnregisterValidationInterface(CValidationInterface* pwalletIn) {
     g_signals.Inventory.disconnect(boost::bind(&CValidationInterface::Inventory, pwalletIn, _1));
     g_signals.SetBestChain.disconnect(boost::bind(&CValidationInterface::SetBestChain, pwalletIn, _1));
     g_signals.UpdatedTransaction.disconnect(boost::bind(&CValidationInterface::UpdatedTransaction, pwalletIn, _1));
+    g_signals.TransactionConflicted.disconnect(boost::bind(&CValidationInterface::TransactionConflicted, pwalletIn, _1));
     g_signals.SyncTransaction.disconnect(boost::bind(&CValidationInterface::SyncTransaction, pwalletIn, _1, _2));
 }
 
@@ -42,6 +44,7 @@ void UnregisterAllValidationInterfaces() {
     g_signals.Inventory.disconnect_all_slots();
     g_signals.SetBestChain.disconnect_all_slots();
     g_signals.UpdatedTransaction.disconnect_all_slots();
+    g_signals.TransactionConflicted.disconnect_all_slots();
     g_signals.SyncTransaction.disconnect_all_slots();
 }
 

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -31,6 +31,7 @@ void SyncWithWallets(const CTransaction& tx, const CBlock* pblock = NULL);
 class CValidationInterface {
 protected:
     virtual void SyncTransaction(const CTransaction &tx, const CBlock *pblock) {}
+    virtual void TransactionConflicted(const uint256& txHash) {}
     virtual void SetBestChain(const CBlockLocator &locator) {}
     virtual void UpdatedTransaction(const uint256 &hash) {}
     virtual void Inventory(const uint256 &hash) {}
@@ -44,8 +45,10 @@ protected:
 };
 
 struct CMainSignals {
-    /** Notifies listeners of updated transaction data (transaction, and optionally the block it is found in. */
+    /** Notifies listeners of updated transaction data (transaction, and optionally the block it is found in). */
     boost::signals2::signal<void (const CTransaction &, const CBlock *)> SyncTransaction;
+    /** Notifies listeners of transaction invalidated by a double-spend (transaction hash) */
+    boost::signals2::signal<void (const uint256 &)> TransactionConflicted;
     /** Notifies listeners of an updated transaction without new data (for now: a coinbase potentially becoming visible). */
     boost::signals2::signal<void (const uint256 &)> UpdatedTransaction;
     /** Notifies listeners of a new active block chain. */

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -305,7 +305,6 @@ public:
             mapValue["fromaccount"] = strFromAccount;
 
             WriteOrderPos(nOrderPos, mapValue);
-
             if (nTimeSmart)
                 mapValue["timesmart"] = strprintf("%u", nTimeSmart);
         }
@@ -616,6 +615,7 @@ public:
     void MarkDirty();
     bool AddToWallet(const CWalletTx& wtxIn, bool fFromLoadWallet, CWalletDB* pwalletdb);
     void SyncTransaction(const CTransaction& tx, const CBlock* pblock);
+    void TransactionConflicted(const uint256& txid);
     bool AddToWalletIfInvolvingMe(const CTransaction& tx, const CBlock* pblock, bool fUpdate);
     int ScanForWalletTransactions(CBlockIndex* pindexStart, bool fUpdate = false);
     void ReacceptWalletTransactions();


### PR DESCRIPTION
Based on #5267. The conflicted transaction tracking during mempool remove is actually critical for balance stability, as @dgenr8 and @morcos pointed out previously...but for a very subtle reason. When we called SyncTransaction, it was doing a ton of work...just to uncache the balance. Instead, this pull replaces the SyncTransaction call with a new wallet signal, which only provides the transaction hash, making the removed tracking a bit lighter weight.

Also, it explains what is actually happening and adds a python test-case to test it out, instead of it being entirely opaque and marginally fragile.
