### PR TITLE
Format paragraphs properly - count the space between words.

### DIFF
--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -340,6 +340,7 @@ BOOST_AUTO_TEST_CASE(test_FormatParagraph)
     BOOST_CHECK_EQUAL(FormatParagraph("test test", 4, 0), "test\ntest");
     BOOST_CHECK_EQUAL(FormatParagraph("testerde test ", 4, 0), "testerde\ntest");
     BOOST_CHECK_EQUAL(FormatParagraph("test test", 4, 4), "test\n    test");
+    BOOST_CHECK_EQUAL(FormatParagraph("This is a very long test string. This is a second sentence in the very long test string."), "This is a very long test string. This is a second sentence in the very long\ntest string.");
 }
 
 BOOST_AUTO_TEST_CASE(test_FormatSubVersion)

--- a/src/utilstrencodings.cpp
+++ b/src/utilstrencodings.cpp
@@ -459,7 +459,7 @@ std::string FormatParagraph(const std::string in, size_t width, size_t indent)
         }
         // Append word
         out << in.substr(ptr, endword - ptr);
-        col += endword - ptr;
+        col += endword - ptr + 1;
         ptr = endword;
     }
     return out.str();


### PR DESCRIPTION
bitcoind --version returns this in the terminal with 80x25 chars despite the fact that FormatParagraph is setup to default to width=79:

![screen shot 2014-12-06 at 9 18 10 pm](https://cloud.githubusercontent.com/assets/6848764/5328791/e019e18c-7d8e-11e4-9356-8597e9805217.png)

This is because col is not updated for the space between words. Expected behavior is:

![screen shot 2014-12-06 at 9 19 18 pm](https://cloud.githubusercontent.com/assets/6848764/5328795/16688734-7d8f-11e4-9024-4de816251eee.png)
