### PR TITLE
contrib: show pull # in prompt for github-merge script

### DIFF
--- a/contrib/devtools/github-merge.sh
+++ b/contrib/devtools/github-merge.sh
@@ -136,6 +136,9 @@ else
   echo "Dropping you on a shell so you can try building/testing the merged source." >&2
   echo "Run 'git diff HEAD~' to show the changes being merged." >&2
   echo "Type 'exit' when done." >&2
+  if [[ -f /etc/debian_version ]]; then # Show pull number in prompt on Debian default prompt
+      export debian_chroot="$PULL"
+  fi
   bash -i
   read -p "Press 'm' to accept the merge. " -n 1 -r >&2
   echo


### PR DESCRIPTION
Puts the pull id in the prompt for the shell launched by `github-merge.sh`. This is useful as a reminder that you're _a)_ in a special shell _b)_ which pull you're working on.

```
user@asdf:/.../projects/bitcoin/bitcoin$ contrib/devtools/github-merge.sh 5427
Removing qa/rpc-tests/walletbackup.sh
Dropping you on a shell so you can try building/testing the merged source.
Run 'git diff HEAD~' to show the changes being merged.
Type 'exit' when done.

(5427)user@asdf:/.../projects/bitcoin/bitcoin$ 
```

The current solution is only triggered on Debian/Ubuntu, and makes use of the default PS1 building in `.bashrc` there. There may be a more general way, although I've tried overriding `RC1` manually then `bash --norc -i`, but that completely replaces the prompt instead of adding to it.
