### PR TITLE
minor rework of SendMoney in rpcwallet

### DIFF
--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -6,10 +6,10 @@
 #include "amount.h"
 #include "base58.h"
 #include "core_io.h"
-#include "rpcserver.h"
 #include "init.h"
 #include "net.h"
 #include "netbase.h"
+#include "rpcserver.h"
 #include "timedata.h"
 #include "util.h"
 #include "utilmoneystr.h"
@@ -19,13 +19,14 @@
 #include <stdint.h>
 
 #include <boost/assign/list_of.hpp>
+
 #include "json/json_spirit_utils.h"
 #include "json/json_spirit_value.h"
 
-using namespace std;
 using namespace boost;
 using namespace boost::assign;
 using namespace json_spirit;
+using namespace std;
 
 int64_t nWalletUnlockTime;
 static CCriticalSection cs_nWalletUnlockTime;


### PR DESCRIPTION
- rework the function to not log errors but use throw JSONRPCError
- remove a check for IsLocked() that is done in sendtoaddress and
  sendfrom RPC calls already
- cache GetBalance() return value, because it's possibly used twice

Intended for discussion, also I was thinking about extending our wallet error codes, as most errors in `SendMoney` use the generic `RPC_WALLET_ERROR`.
