### PR TITLE
[Qt] log cert errors for payment requests and harden test-cases

### DIFF
--- a/src/qt/paymentrequestplus.h
+++ b/src/qt/paymentrequestplus.h
@@ -15,6 +15,17 @@
 #include <QList>
 #include <QString>
 
+// Used in getMerchant() to return state
+enum GetMerchantStatus {
+    PR_NOTINITIALIZED = 0,
+    PR_PKIERROR = (1U << 0),
+    PR_CERTERROR = (1U << 1),
+    PR_UNAUTHENTICATED = (1U << 2),
+    PR_AUTHENTICATED = (1U << 3),
+
+    PR_ERROR = (PR_NOTINITIALIZED | PR_PKIERROR | PR_CERTERROR)
+};
+
 //
 // Wraps dumb protocol buffer paymentRequest
 // with extra methods
@@ -31,7 +42,7 @@ public:
     bool IsInitialized() const;
     // Returns true if merchant's identity is authenticated, and
     // returns human-readable merchant identity in merchant
-    bool getMerchant(X509_STORE* certStore, QString& merchant) const;
+    GetMerchantStatus getMerchant(X509_STORE* certStore, QString& merchant) const;
 
     // Returns list of outputs, amount
     QList<std::pair<CScript,CAmount> > getPayTo() const;

--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -555,7 +555,10 @@ bool PaymentServer::processPaymentRequest(const PaymentRequestPlus& request, Sen
     recipient.paymentRequest = request;
     recipient.message = GUIUtil::HtmlEscape(request.getDetails().memo());
 
-    request.getMerchant(PaymentServer::certStore, recipient.authenticatedMerchant);
+    // Allowed to silently fail! Treat invalid authenticated payment request as valid unauthenticated payment request.
+    if (request.getMerchant(PaymentServer::certStore, recipient.authenticatedMerchant) & PR_ERROR) {
+        qDebug() << QString("PaymentServer::%1: Invalid authenticated payment request now treated as valid unauthenticated payment request.").arg(__func__);
+    }
 
     QList<std::pair<CScript, CAmount> > sendingTos = request.getPayTo();
     QStringList addresses;

--- a/src/qt/test/paymentservertests.cpp
+++ b/src/qt/test/paymentservertests.cpp
@@ -83,31 +83,31 @@ void PaymentServerTests::paymentServerTests()
     // caCert1 certificate authority:
     data = DecodeBase64(paymentrequest1_cert1_BASE64);
     r = handleRequest(server, data);
-    r.paymentRequest.getMerchant(caStore, merchant);
+    QVERIFY(r.paymentRequest.getMerchant(caStore, merchant) & PR_AUTHENTICATED);
     QCOMPARE(merchant, QString("testmerchant.org"));
 
     // Signed, but expired, merchant cert in the request:
     data = DecodeBase64(paymentrequest2_cert1_BASE64);
     r = handleRequest(server, data);
-    r.paymentRequest.getMerchant(caStore, merchant);
+    QVERIFY(r.paymentRequest.getMerchant(caStore, merchant) & PR_ERROR);
     QCOMPARE(merchant, QString(""));
 
     // 10-long certificate chain, all intermediates valid:
     data = DecodeBase64(paymentrequest3_cert1_BASE64);
     r = handleRequest(server, data);
-    r.paymentRequest.getMerchant(caStore, merchant);
+    QVERIFY(r.paymentRequest.getMerchant(caStore, merchant) & PR_AUTHENTICATED);
     QCOMPARE(merchant, QString("testmerchant8.org"));
 
     // Long certificate chain, with an expired certificate in the middle:
     data = DecodeBase64(paymentrequest4_cert1_BASE64);
     r = handleRequest(server, data);
-    r.paymentRequest.getMerchant(caStore, merchant);
+    QVERIFY(r.paymentRequest.getMerchant(caStore, merchant) & PR_ERROR);
     QCOMPARE(merchant, QString(""));
 
     // Validly signed, but by a CA not in our root CA list:
     data = DecodeBase64(paymentrequest5_cert1_BASE64);
     r = handleRequest(server, data);
-    r.paymentRequest.getMerchant(caStore, merchant);
+    QVERIFY(r.paymentRequest.getMerchant(caStore, merchant) & PR_ERROR);
     QCOMPARE(merchant, QString(""));
 
     // Try again with no root CA's, verifiedMerchant should be empty:
@@ -115,7 +115,7 @@ void PaymentServerTests::paymentServerTests()
     PaymentServer::LoadRootCAs(caStore);
     data = DecodeBase64(paymentrequest1_cert1_BASE64);
     r = handleRequest(server, data);
-    r.paymentRequest.getMerchant(caStore, merchant);
+    QVERIFY(r.paymentRequest.getMerchant(caStore, merchant) & PR_ERROR);
     QCOMPARE(merchant, QString(""));
 
     // Load second root certificate

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -255,8 +255,8 @@ QString TransactionDesc::toHTML(CWallet *wallet, CWalletTx &wtx, TransactionReco
             PaymentRequestPlus req;
             req.parse(QByteArray::fromRawData(r.second.data(), r.second.size()));
             QString merchant;
-            if (req.getMerchant(PaymentServer::getCertStore(), merchant))
-                strHTML += "<b>" + tr("Merchant") + ":</b> " + GUIUtil::HtmlEscape(merchant) + "<br>";
+            if (req.getMerchant(PaymentServer::getCertStore(), merchant) & PR_AUTHENTICATED)
+                strHTML += "<b>" + tr("Authenticated merchant") + ":</b> " + GUIUtil::HtmlEscape(merchant) + "<br>";
         }
     }
 


### PR DESCRIPTION
- extend PaymentRequestPlus::getMerchant to return status of payment
  request errors related to certificates/PKIs etc.
- do a real check for errors, which was missing until now, in
  PaymentServer::processPaymentRequest and also extend our tests in
  paymentservertests.cpp to not only rely on the content of "merchant"
  passed to getMerchant
- this explicitly treats insecure payment requests not as errors, as they
  are allowed as per BIP70
