### PR TITLE
Remove duplicate "Importing the blockchain" section title

### DIFF
--- a/doc/bootstrap.md
+++ b/doc/bootstrap.md
@@ -45,7 +45,6 @@ The directory is hidden in your User folder. Go to:
 
 	~/.bitcoin/
     
-### Importing the blockchain
 Now start the Bitcoin client software. It should show "Importing blocks from disk" like the image below. 
 ![Fig5](img/bootstrap5.png)
 


### PR DESCRIPTION
This fixes the ability to hyperlink directly to the #importing-the-blockchain section
