### PR TITLE
OS X 10.10: LSSharedFileListItemResolve() is deprecated

### DIFF
--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -696,7 +696,18 @@ LSSharedFileListItemRef findStartupItemInList(LSSharedFileListRef list, CFURLRef
         LSSharedFileListItemRef item = (LSSharedFileListItemRef)CFArrayGetValueAtIndex(listSnapshot, i);
         UInt32 resolutionFlags = kLSSharedFileListNoUserInteraction | kLSSharedFileListDoNotMountVolumes;
         CFURLRef currentItemURL = NULL;
-        LSSharedFileListItemResolve(item, resolutionFlags, &currentItemURL, NULL);
+
+#if defined(MAC_OS_X_VERSION_MAX_ALLOWED) && MAC_OS_X_VERSION_MAX_ALLOWED >= 10100
+	if(&LSSharedFileListItemCopyResolvedURL)
+	    currentItemURL = LSSharedFileListItemCopyResolvedURL(item, resolutionFlags, NULL);
+#if defined(MAC_OS_X_VERSION_MIN_REQUIRED) && MAC_OS_X_VERSION_MIN_REQUIRED < 10100
+	else
+	    LSSharedFileListItemResolve(item, resolutionFlags, &currentItemURL, NULL);
+#endif
+#else
+	LSSharedFileListItemResolve(item, resolutionFlags, &currentItemURL, NULL);
+#endif
+
         if(currentItemURL && CFEqual(currentItemURL, findUrl)) {
             // found
             CFRelease(currentItemURL);


### PR DESCRIPTION
LABEL: Mac
The current master emits this warning on OS X Yosemite Version 10.10:

```
qt/guiutil.cpp:699:9: warning: 'LSSharedFileListItemResolve' is deprecated: first deprecated in OS X 10.10 - Use LSSharedFileListItemCopyResolvedURL instead. [-Wdeprecated-declarations]
        LSSharedFileListItemResolve(item, resolutionFlags, &currentItemURL, __null);
        ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.10.sdk/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Headers/LSSharedFileList.h:943:1: note: 'LSSharedFileListItemResolve' has been explicitly marked deprecated here
LSSharedFileListItemResolve(
^
1 warning generated.
```

Change the code to use the new semantics on the 10.10 and higher systems.
