### PR TITLE
Replace uint256/uint160 by opaque blobs where possible

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -75,6 +75,7 @@ BITCOIN_CORE_H = \
   allocators.h \
   amount.h \
   base58.h \
+  blob256.h \
   bloom.h \
   chain.h \
   chainparams.h \
@@ -261,18 +262,19 @@ libbitcoin_common_a_SOURCES = \
 # backward-compatibility objects and their sanity checks are linked.
 libbitcoin_util_a_CPPFLAGS = $(BITCOIN_INCLUDES)
 libbitcoin_util_a_SOURCES = \
-  compat/strnlen.cpp \
-  compat/glibc_sanity.cpp \
-  compat/glibcxx_sanity.cpp \
+  blob256.cpp \
   chainparamsbase.cpp \
   clientversion.cpp \
+  compat/glibc_sanity.cpp \
+  compat/glibcxx_sanity.cpp \
+  compat/strnlen.cpp \
   random.cpp \
   rpcprotocol.cpp \
   sync.cpp \
   uint256.cpp \
   util.cpp \
-  utilstrencodings.cpp \
   utilmoneystr.cpp \
+  utilstrencodings.cpp \
   utiltime.cpp \
   $(BITCOIN_CORE_H)
 
@@ -352,19 +354,20 @@ bitcoin_cli_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
 if BUILD_BITCOIN_LIBS
 include_HEADERS = script/bitcoinconsensus.h
 libbitcoinconsensus_la_SOURCES = \
-  primitives/transaction.cpp \
+  blob256.cpp \
   crypto/hmac_sha512.cpp \
+  crypto/ripemd160.cpp \
   crypto/sha1.cpp \
   crypto/sha256.cpp \
   crypto/sha512.cpp \
-  crypto/ripemd160.cpp \
   eccryptoverify.cpp \
   ecwrapper.cpp \
   hash.cpp \
+  primitives/transaction.cpp \
   pubkey.cpp \
-  script/script.cpp \
-  script/interpreter.cpp \
   script/bitcoinconsensus.cpp \
+  script/interpreter.cpp \
+  script/script.cpp \
   uint256.cpp \
   utilstrencodings.cpp
 

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -39,6 +39,7 @@ BITCOIN_TESTS =\
   test/base32_tests.cpp \
   test/base58_tests.cpp \
   test/base64_tests.cpp \
+  test/blob256_tests.cpp \
   test/bloom_tests.cpp \
   test/checkblock_tests.cpp \
   test/Checkpoints_tests.cpp \

--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -15,12 +15,12 @@ int CAddrInfo::GetTriedBucket(const std::vector<unsigned char>& nKey) const
     CDataStream ss1(SER_GETHASH, 0);
     std::vector<unsigned char> vchKey = GetKey();
     ss1 << nKey << vchKey;
-    uint64_t hash1 = Hash(ss1.begin(), ss1.end()).GetLow64();
+    uint64_t hash1 = Hash(ss1.begin(), ss1.end()).GetCheapHash();
 
     CDataStream ss2(SER_GETHASH, 0);
     std::vector<unsigned char> vchGroupKey = GetGroup();
     ss2 << nKey << vchGroupKey << (hash1 % ADDRMAN_TRIED_BUCKETS_PER_GROUP);
-    uint64_t hash2 = Hash(ss2.begin(), ss2.end()).GetLow64();
+    uint64_t hash2 = Hash(ss2.begin(), ss2.end()).GetCheapHash();
     return hash2 % ADDRMAN_TRIED_BUCKET_COUNT;
 }
 
@@ -30,11 +30,11 @@ int CAddrInfo::GetNewBucket(const std::vector<unsigned char>& nKey, const CNetAd
     std::vector<unsigned char> vchGroupKey = GetGroup();
     std::vector<unsigned char> vchSourceGroupKey = src.GetGroup();
     ss1 << nKey << vchGroupKey << vchSourceGroupKey;
-    uint64_t hash1 = Hash(ss1.begin(), ss1.end()).GetLow64();
+    uint64_t hash1 = Hash(ss1.begin(), ss1.end()).GetCheapHash();
 
     CDataStream ss2(SER_GETHASH, 0);
     ss2 << nKey << vchSourceGroupKey << (hash1 % ADDRMAN_NEW_BUCKETS_PER_SOURCE_GROUP);
-    uint64_t hash2 = Hash(ss2.begin(), ss2.end()).GetLow64();
+    uint64_t hash2 = Hash(ss2.begin(), ss2.end()).GetCheapHash();
     return hash2 % ADDRMAN_NEW_BUCKET_COUNT;
 }
 

--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -24,7 +24,7 @@
 
 using namespace std;
 
-map<uint256, CAlert> mapAlerts;
+map<blob256, CAlert> mapAlerts;
 CCriticalSection cs_mapAlerts;
 
 void CUnsignedAlert::SetNull()
@@ -94,7 +94,7 @@ bool CAlert::IsNull() const
     return (nExpiration == 0);
 }
 
-uint256 CAlert::GetHash() const
+blob256 CAlert::GetHash() const
 {
     return Hash(this->vchMsg.begin(), this->vchMsg.end());
 }
@@ -157,12 +157,12 @@ bool CAlert::CheckSignature() const
     return true;
 }
 
-CAlert CAlert::getAlertByHash(const uint256 &hash)
+CAlert CAlert::getAlertByHash(const blob256 &hash)
 {
     CAlert retval;
     {
         LOCK(cs_mapAlerts);
-        map<uint256, CAlert>::iterator mi = mapAlerts.find(hash);
+        map<blob256, CAlert>::iterator mi = mapAlerts.find(hash);
         if(mi != mapAlerts.end())
             retval = mi->second;
     }
@@ -201,7 +201,7 @@ bool CAlert::ProcessAlert(bool fThread)
     {
         LOCK(cs_mapAlerts);
         // Cancel previous alerts
-        for (map<uint256, CAlert>::iterator mi = mapAlerts.begin(); mi != mapAlerts.end();)
+        for (map<blob256, CAlert>::iterator mi = mapAlerts.begin(); mi != mapAlerts.end();)
         {
             const CAlert& alert = (*mi).second;
             if (Cancels(alert))
@@ -221,7 +221,7 @@ bool CAlert::ProcessAlert(bool fThread)
         }
 
         // Check if this alert has been cancelled
-        BOOST_FOREACH(PAIRTYPE(const uint256, CAlert)& item, mapAlerts)
+        BOOST_FOREACH(PAIRTYPE(const blob256, CAlert)& item, mapAlerts)
         {
             const CAlert& alert = item.second;
             if (alert.Cancels(*this))

--- a/src/alert.h
+++ b/src/alert.h
@@ -16,9 +16,9 @@
 
 class CAlert;
 class CNode;
-class uint256;
+class blob256;
 
-extern std::map<uint256, CAlert> mapAlerts;
+extern std::map<blob256, CAlert> mapAlerts;
 extern CCriticalSection cs_mapAlerts;
 
 /** Alerts are for notifying old versions if they become too obsolete and
@@ -94,7 +94,7 @@ public:
 
     void SetNull();
     bool IsNull() const;
-    uint256 GetHash() const;
+    blob256 GetHash() const;
     bool IsInEffect() const;
     bool Cancels(const CAlert& alert) const;
     bool AppliesTo(int nVersion, std::string strSubVerIn) const;
@@ -107,7 +107,7 @@ public:
     /*
      * Get copy of (active) alert object by hash. Returns a null alert if it is not found.
      */
-    static CAlert getAlertByHash(const uint256 &hash);
+    static CAlert getAlertByHash(const blob256 &hash);
 };
 
 #endif // BITCOIN_ALERT_H

--- a/src/base58.cpp
+++ b/src/base58.cpp
@@ -5,7 +5,7 @@
 #include "base58.h"
 
 #include "hash.h"
-#include "uint256.h"
+#include "blob256.h"
 
 #include <assert.h>
 #include <stdint.h>
@@ -113,7 +113,7 @@ std::string EncodeBase58Check(const std::vector<unsigned char>& vchIn)
 {
     // add 4-byte hash check to the end
     std::vector<unsigned char> vch(vchIn);
-    uint256 hash = Hash(vch.begin(), vch.end());
+    blob256 hash = Hash(vch.begin(), vch.end());
     vch.insert(vch.end(), (unsigned char*)&hash, (unsigned char*)&hash + 4);
     return EncodeBase58(vch);
 }
@@ -126,7 +126,7 @@ bool DecodeBase58Check(const char* psz, std::vector<unsigned char>& vchRet)
         return false;
     }
     // re-calculate the checksum, insure it matches the included 4-byte checksum
-    uint256 hash = Hash(vchRet.begin(), vchRet.end() - 4);
+    blob256 hash = Hash(vchRet.begin(), vchRet.end() - 4);
     if (memcmp(&hash, &vchRet.end()[-4], 4) != 0) {
         vchRet.clear();
         return false;
@@ -252,7 +252,7 @@ CTxDestination CBitcoinAddress::Get() const
 {
     if (!IsValid())
         return CNoDestination();
-    uint160 id;
+    blob160 id;
     memcpy(&id, &vchData[0], 20);
     if (vchVersion == Params().Base58Prefix(CChainParams::PUBKEY_ADDRESS))
         return CKeyID(id);
@@ -266,7 +266,7 @@ bool CBitcoinAddress::GetKeyID(CKeyID& keyID) const
 {
     if (!IsValid() || vchVersion != Params().Base58Prefix(CChainParams::PUBKEY_ADDRESS))
         return false;
-    uint160 id;
+    blob160 id;
     memcpy(&id, &vchData[0], 20);
     keyID = CKeyID(id);
     return true;

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -315,7 +315,7 @@ static bool findSighashFlags(int& flags, const string& flagStr)
 uint256 ParseHashUO(map<string,UniValue>& o, string strKey)
 {
     if (!o.count(strKey))
-        return 0;
+        return uint256();
     return ParseHashUV(o[strKey], strKey);
 }
 
@@ -485,7 +485,7 @@ static void MutateTx(CMutableTransaction& tx, const string& command,
 static void OutputTxJSON(const CTransaction& tx)
 {
     UniValue entry(UniValue::VOBJ);
-    TxToUniv(tx, 0, entry);
+    TxToUniv(tx, uint256(), entry);
 
     string jsonOutput = entry.write(4);
     fprintf(stdout, "%s\n", jsonOutput.c_str());

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -312,10 +312,10 @@ static bool findSighashFlags(int& flags, const string& flagStr)
     return false;
 }
 
-uint256 ParseHashUO(map<string,UniValue>& o, string strKey)
+blob256 ParseHashUO(map<string,UniValue>& o, string strKey)
 {
     if (!o.count(strKey))
-        return uint256();
+        return blob256();
     return ParseHashUV(o[strKey], strKey);
 }
 
@@ -379,7 +379,7 @@ static void MutateTxSign(CMutableTransaction& tx, const string& flagStr)
             if (!prevOut.checkObject(types))
                 throw runtime_error("prevtxs internal object typecheck fail");
 
-            uint256 txid = ParseHashUV(prevOut, "txid");
+            blob256 txid = ParseHashUV(prevOut, "txid");
 
             int nOut = atoi(prevOut["vout"].getValStr());
             if (nOut < 0)
@@ -485,7 +485,7 @@ static void MutateTx(CMutableTransaction& tx, const string& command,
 static void OutputTxJSON(const CTransaction& tx)
 {
     UniValue entry(UniValue::VOBJ);
-    TxToUniv(tx, uint256(), entry);
+    TxToUniv(tx, blob256(), entry);
 
     string jsonOutput = entry.write(4);
     fprintf(stdout, "%s\n", jsonOutput.c_str());

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -191,7 +191,7 @@ static void MutateTxAddInput(CMutableTransaction& tx, const string& strInput)
     string strTxid = strInput.substr(0, pos);
     if ((strTxid.size() != 64) || !IsHex(strTxid))
         throw runtime_error("invalid TX input txid");
-    uint256 txid(strTxid);
+    blob256 txid(blob256S(strTxid));
 
     static const unsigned int minTxOutSz = 9;
     static const unsigned int maxVout = MAX_BLOCK_SIZE / minTxOutSz;

--- a/src/blob256.cpp
+++ b/src/blob256.cpp
@@ -1,0 +1,153 @@
+// Copyright (c) 2014 The Bitcoin developers
+// Distributed under the X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "blob256.h"
+
+#include "utilstrencodings.h"
+
+#include <stdio.h>
+#include <string.h>
+
+template <unsigned int BITS>
+base_blob<BITS>::base_blob(const std::string& str)
+{
+    SetHex(str);
+}
+
+template <unsigned int BITS>
+base_blob<BITS>::base_blob(const std::vector<unsigned char>& vch)
+{
+    assert(vch.size() == sizeof(data));
+    memcpy(data, &vch[0], sizeof(data));
+}
+
+template <unsigned int BITS>
+std::string base_blob<BITS>::GetHex() const
+{
+    char psz[sizeof(data) * 2 + 1];
+    for (unsigned int i = 0; i < sizeof(data); i++)
+        sprintf(psz + i * 2, "%02x", data[sizeof(data) - i - 1]);
+    return std::string(psz, psz + sizeof(data) * 2);
+}
+
+template <unsigned int BITS>
+void base_blob<BITS>::SetHex(const char* psz)
+{
+    memset(data, 0, sizeof(data));
+
+    // skip leading spaces
+    while (isspace(*psz))
+        psz++;
+
+    // skip 0x
+    if (psz[0] == '0' && tolower(psz[1]) == 'x')
+        psz += 2;
+
+    // hex string to uint
+    const char* pbegin = psz;
+    while (::HexDigit(*psz) != -1)
+        psz++;
+    psz--;
+    unsigned char* p1 = (unsigned char*)data;
+    unsigned char* pend = p1 + WIDTH * 4;
+    while (psz >= pbegin && p1 < pend) {
+        *p1 = ::HexDigit(*psz--);
+        if (psz >= pbegin) {
+            *p1 |= ((unsigned char)::HexDigit(*psz--) << 4);
+            p1++;
+        }
+    }
+}
+
+template <unsigned int BITS>
+void base_blob<BITS>::SetHex(const std::string& str)
+{
+    SetHex(str.c_str());
+}
+
+template <unsigned int BITS>
+std::string base_blob<BITS>::ToString() const
+{
+    return (GetHex());
+}
+
+// Explicit instantiations for base_blob<160>
+template base_blob<160>::base_blob(const std::string&);
+template base_blob<160>::base_blob(const std::vector<unsigned char>&);
+template std::string base_blob<160>::GetHex() const;
+template std::string base_blob<160>::ToString() const;
+template void base_blob<160>::SetHex(const char*);
+template void base_blob<160>::SetHex(const std::string&);
+
+// Explicit instantiations for base_blob<256>
+template base_blob<256>::base_blob(const std::string&);
+template base_blob<256>::base_blob(const std::vector<unsigned char>&);
+template std::string base_blob<256>::GetHex() const;
+template std::string base_blob<256>::ToString() const;
+template void base_blob<256>::SetHex(const char*);
+template void base_blob<256>::SetHex(const std::string&);
+
+static void inline HashMix(uint32_t& a, uint32_t& b, uint32_t& c)
+{
+    // Taken from lookup3, by Bob Jenkins.
+    a -= c;
+    a ^= ((c << 4) | (c >> 28));
+    c += b;
+    b -= a;
+    b ^= ((a << 6) | (a >> 26));
+    a += c;
+    c -= b;
+    c ^= ((b << 8) | (b >> 24));
+    b += a;
+    a -= c;
+    a ^= ((c << 16) | (c >> 16));
+    c += b;
+    b -= a;
+    b ^= ((a << 19) | (a >> 13));
+    a += c;
+    c -= b;
+    c ^= ((b << 4) | (b >> 28));
+    b += a;
+}
+
+static void inline HashFinal(uint32_t& a, uint32_t& b, uint32_t& c)
+{
+    // Taken from lookup3, by Bob Jenkins.
+    c ^= b;
+    c -= ((b << 14) | (b >> 18));
+    a ^= c;
+    a -= ((c << 11) | (c >> 21));
+    b ^= a;
+    b -= ((a << 25) | (a >> 7));
+    c ^= b;
+    c -= ((b << 16) | (b >> 16));
+    a ^= c;
+    a -= ((c << 4) | (c >> 28));
+    b ^= a;
+    b -= ((a << 14) | (a >> 18));
+    c ^= b;
+    c -= ((b << 24) | (b >> 8));
+}
+
+uint64_t blob256::GetHash(const blob256& salt) const
+{
+    uint32_t a, b, c;
+    const uint32_t *pn = (const uint32_t*)data;
+    const uint32_t *salt_pn = (const uint32_t*)salt.data;
+    a = b = c = 0xdeadbeef + (WIDTH << 2);
+
+    a += pn[0] ^ salt_pn[0];
+    b += pn[1] ^ salt_pn[1];
+    c += pn[2] ^ salt_pn[2];
+    HashMix(a, b, c);
+    a += pn[3] ^ salt_pn[3];
+    b += pn[4] ^ salt_pn[4];
+    c += pn[5] ^ salt_pn[5];
+    HashMix(a, b, c);
+    a += pn[6] ^ salt_pn[6];
+    b += pn[7] ^ salt_pn[7];
+    HashFinal(a, b, c);
+
+    return ((((uint64_t)b) << 32) | c);
+}

--- a/src/blob256.cpp
+++ b/src/blob256.cpp
@@ -10,12 +10,6 @@
 #include <string.h>
 
 template <unsigned int BITS>
-base_blob<BITS>::base_blob(const std::string& str)
-{
-    SetHex(str);
-}
-
-template <unsigned int BITS>
 base_blob<BITS>::base_blob(const std::vector<unsigned char>& vch)
 {
     assert(vch.size() == sizeof(data));
@@ -73,7 +67,6 @@ std::string base_blob<BITS>::ToString() const
 }
 
 // Explicit instantiations for base_blob<160>
-template base_blob<160>::base_blob(const std::string&);
 template base_blob<160>::base_blob(const std::vector<unsigned char>&);
 template std::string base_blob<160>::GetHex() const;
 template std::string base_blob<160>::ToString() const;
@@ -81,7 +74,6 @@ template void base_blob<160>::SetHex(const char*);
 template void base_blob<160>::SetHex(const std::string&);
 
 // Explicit instantiations for base_blob<256>
-template base_blob<256>::base_blob(const std::string&);
 template base_blob<256>::base_blob(const std::vector<unsigned char>&);
 template std::string base_blob<256>::GetHex() const;
 template std::string base_blob<256>::ToString() const;

--- a/src/blob256.h
+++ b/src/blob256.h
@@ -38,7 +38,6 @@ public:
             data[i] = b.data[i];
         return *this;
     }
-    explicit base_blob(const std::string& str);
     explicit base_blob(const std::vector<unsigned char>& vch);
 
     bool IsNull() const
@@ -131,7 +130,6 @@ class blob160 : public base_blob<160> {
 public:
     blob160() {}
     blob160(const base_blob<160>& b) : base_blob<160>(b) {}
-    explicit blob160(const std::string& str) : base_blob<160>(str) {}
     explicit blob160(const std::vector<unsigned char>& vch) : base_blob<160>(vch) {}
 };
 
@@ -140,7 +138,6 @@ class blob256 : public base_blob<256> {
 public:
     blob256() {}
     blob256(const base_blob<256>& b) : base_blob<256>(b) {}
-    explicit blob256(const std::string& str) : base_blob<256>(str) {}
     explicit blob256(const std::vector<unsigned char>& vch) : base_blob<256>(vch) {}
 
     /** A more secure, salted hash function.
@@ -148,5 +145,26 @@ public:
      */
     uint64_t GetHash(const blob256& salt) const;
 };
+
+/* blob256 from const char *.
+ * This is a separate function because the constructor blob256(const char*) can result
+ * in dangerously catching blob256(0).
+ */
+inline blob256 blob256S(const char *str)
+{
+    blob256 rv;
+    rv.SetHex(str);
+    return rv;
+}
+/* blob256 from std::string.
+ * This is a separate function because the constructor blob256(const std::string &str) can result
+ * in dangerously catching blob256(0) via std::string(const char*).
+ */
+inline blob256 blob256S(const std::string& str)
+{
+    blob256 rv;
+    rv.SetHex(str);
+    return rv;
+}
 
 #endif // BITCOIN_BLOB256_H

--- a/src/blob256.h
+++ b/src/blob256.h
@@ -1,0 +1,152 @@
+// Copyright (c) 2014 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_BLOB256_H
+#define BITCOIN_BLOB256_H
+
+#include <assert.h>
+#include <cstring>
+#include <stdexcept>
+#include <stdint.h>
+#include <string>
+#include <vector>
+
+/** Template base class for fixed-sized opaque blobs. */
+template<unsigned int BITS>
+class base_blob
+{
+protected:
+    enum { WIDTH=BITS/8 };
+    uint8_t data[WIDTH];
+public:
+    base_blob()
+    {
+        for (int i = 0; i < WIDTH; i++)
+            data[i] = 0;
+    }
+
+    base_blob(const base_blob& b)
+    {
+        for (int i = 0; i < WIDTH; i++)
+            data[i] = b.data[i];
+    }
+
+    base_blob& operator=(const base_blob& b)
+    {
+        for (int i = 0; i < WIDTH; i++)
+            data[i] = b.data[i];
+        return *this;
+    }
+    explicit base_blob(const std::string& str);
+    explicit base_blob(const std::vector<unsigned char>& vch);
+
+    bool IsNull() const
+    {
+        for (int i = 0; i < WIDTH; i++)
+            if (data[i] != 0)
+                return false;
+        return true;
+    }
+    void SetNull()
+    {
+        memset(data, 0, sizeof(data));
+    }
+
+    friend inline bool operator==(const base_blob& a, const base_blob& b) { return memcmp(a.data, b.data, sizeof(a.data)) == 0; }
+    friend inline bool operator!=(const base_blob& a, const base_blob& b) { return memcmp(a.data, b.data, sizeof(a.data)) != 0; }
+    friend inline bool operator<(const base_blob& a, const base_blob& b) {
+        for (int i = 0; i < WIDTH; i++)
+        {
+            if (a.data[i] < b.data[i])
+                return true;
+            else if (a.data[i] > b.data[i])
+                return false;
+        }
+        return false;
+    }
+
+    std::string GetHex() const;
+    void SetHex(const char* psz);
+    void SetHex(const std::string& str);
+    std::string ToString() const;
+
+    unsigned char* begin()
+    {
+        return &data[0];
+    }
+
+    unsigned char* end()
+    {
+        return &data[WIDTH];
+    }
+
+    const unsigned char* begin() const
+    {
+        return &data[0];
+    }
+
+    const unsigned char* end() const
+    {
+        return &data[WIDTH];
+    }
+
+    unsigned int size() const
+    {
+        return sizeof(data);
+    }
+    unsigned int GetSerializeSize(int nType, int nVersion) const
+    {
+        return sizeof(data);
+    }
+
+    template<typename Stream>
+    void Serialize(Stream& s, int nType, int nVersion) const
+    {
+        s.write((char*)data, sizeof(data));
+    }
+
+    template<typename Stream>
+    void Unserialize(Stream& s, int nType, int nVersion)
+    {
+        s.read((char*)data, sizeof(data));
+    }
+
+    /** A cheap hash function that just returns 64 bits from the result, it can be
+     * used when the contents are considered uniformly random. It is not appropriate
+     * when the value can easily be influenced from outside as e.g. a network adversary could
+     * provide values to trigger worst-case behavior.
+     * @note The result of this function is not stable between little and big endian.
+     */
+    uint64_t GetCheapHash() const
+    {
+        uint64_t result;
+        memcpy((void*)&result, (void*)data, 8);
+        return result;
+    }
+};
+
+/** 160-bit opaque blob. */
+class blob160 : public base_blob<160> {
+public:
+    blob160() {}
+    blob160(const base_blob<160>& b) : base_blob<160>(b) {}
+    explicit blob160(const std::string& str) : base_blob<160>(str) {}
+    explicit blob160(const std::vector<unsigned char>& vch) : base_blob<160>(vch) {}
+};
+
+/** 256-bit opaque blob. */
+class blob256 : public base_blob<256> {
+public:
+    blob256() {}
+    blob256(const base_blob<256>& b) : base_blob<256>(b) {}
+    explicit blob256(const std::string& str) : base_blob<256>(str) {}
+    explicit blob256(const std::vector<unsigned char>& vch) : base_blob<256>(vch) {}
+
+    /** A more secure, salted hash function.
+     * @note This hash is not stable between little and big endian.
+     */
+    uint64_t GetHash(const blob256& salt) const;
+};
+
+#endif // BITCOIN_BLOB256_H

--- a/src/bloom.cpp
+++ b/src/bloom.cpp
@@ -67,7 +67,7 @@ void CBloomFilter::insert(const COutPoint& outpoint)
     insert(data);
 }
 
-void CBloomFilter::insert(const uint256& hash)
+void CBloomFilter::insert(const blob256& hash)
 {
     vector<unsigned char> data(hash.begin(), hash.end());
     insert(data);
@@ -97,7 +97,7 @@ bool CBloomFilter::contains(const COutPoint& outpoint) const
     return contains(data);
 }
 
-bool CBloomFilter::contains(const uint256& hash) const
+bool CBloomFilter::contains(const blob256& hash) const
 {
     vector<unsigned char> data(hash.begin(), hash.end());
     return contains(data);
@@ -124,7 +124,7 @@ bool CBloomFilter::IsRelevantAndUpdate(const CTransaction& tx)
         return true;
     if (isEmpty)
         return false;
-    const uint256& hash = tx.GetHash();
+    const blob256& hash = tx.GetHash();
     if (contains(hash))
         fFound = true;
 

--- a/src/bloom.h
+++ b/src/bloom.h
@@ -11,7 +11,7 @@
 
 class COutPoint;
 class CTransaction;
-class uint256;
+class blob256;
 
 //! 20,000 items with fp rate < 0.1% or 10,000 items and <0.0001%
 static const unsigned int MAX_BLOOM_FILTER_SIZE = 36000; // bytes
@@ -78,11 +78,11 @@ public:
 
     void insert(const std::vector<unsigned char>& vKey);
     void insert(const COutPoint& outpoint);
-    void insert(const uint256& hash);
+    void insert(const blob256& hash);
 
     bool contains(const std::vector<unsigned char>& vKey) const;
     bool contains(const COutPoint& outpoint) const;
-    bool contains(const uint256& hash) const;
+    bool contains(const blob256& hash) const;
 
     void clear();
 

--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -24,7 +24,7 @@ void CChain::SetTip(CBlockIndex *pindex) {
 
 CBlockLocator CChain::GetLocator(const CBlockIndex *pindex) const {
     int nStep = 1;
-    std::vector<uint256> vHave;
+    std::vector<blob256> vHave;
     vHave.reserve(32);
 
     if (!pindex)

--- a/src/chain.h
+++ b/src/chain.h
@@ -150,14 +150,14 @@ public:
         nFile = 0;
         nDataPos = 0;
         nUndoPos = 0;
-        nChainWork = 0;
+        nChainWork = uint256();
         nTx = 0;
         nChainTx = 0;
         nStatus = 0;
         nSequenceId = 0;
 
         nVersion       = 0;
-        hashMerkleRoot = 0;
+        hashMerkleRoot = uint256();
         nTime          = 0;
         nBits          = 0;
         nNonce         = 0;
@@ -282,11 +282,11 @@ public:
     uint256 hashPrev;
 
     CDiskBlockIndex() {
-        hashPrev = 0;
+        hashPrev = uint256();
     }
 
     explicit CDiskBlockIndex(const CBlockIndex* pindex) : CBlockIndex(*pindex) {
-        hashPrev = (pprev ? pprev->GetBlockHash() : 0);
+        hashPrev = (pprev ? pprev->GetBlockHash() : uint256());
     }
 
     ADD_SERIALIZE_METHODS;

--- a/src/chain.h
+++ b/src/chain.h
@@ -96,7 +96,7 @@ class CBlockIndex
 {
 public:
     //! pointer to the hash of the block, if any. memory is owned by this CBlockIndex
-    const uint256* phashBlock;
+    const blob256* phashBlock;
 
     //! pointer to the index of the predecessor of this block
     CBlockIndex* pprev;
@@ -133,7 +133,7 @@ public:
 
     //! block header
     int nVersion;
-    uint256 hashMerkleRoot;
+    blob256 hashMerkleRoot;
     unsigned int nTime;
     unsigned int nBits;
     unsigned int nNonce;
@@ -157,7 +157,7 @@ public:
         nSequenceId = 0;
 
         nVersion       = 0;
-        hashMerkleRoot = uint256();
+        hashMerkleRoot = blob256();
         nTime          = 0;
         nBits          = 0;
         nNonce         = 0;
@@ -210,7 +210,7 @@ public:
         return block;
     }
 
-    uint256 GetBlockHash() const
+    blob256 GetBlockHash() const
     {
         return *phashBlock;
     }
@@ -279,14 +279,14 @@ public:
 class CDiskBlockIndex : public CBlockIndex
 {
 public:
-    uint256 hashPrev;
+    blob256 hashPrev;
 
     CDiskBlockIndex() {
-        hashPrev = uint256();
+        hashPrev = blob256();
     }
 
     explicit CDiskBlockIndex(const CBlockIndex* pindex) : CBlockIndex(*pindex) {
-        hashPrev = (pprev ? pprev->GetBlockHash() : uint256());
+        hashPrev = (pprev ? pprev->GetBlockHash() : blob256());
     }
 
     ADD_SERIALIZE_METHODS;
@@ -315,7 +315,7 @@ public:
         READWRITE(nNonce);
     }
 
-    uint256 GetBlockHash() const
+    blob256 GetBlockHash() const
     {
         CBlockHeader block;
         block.nVersion        = nVersion;

--- a/src/chain.h
+++ b/src/chain.h
@@ -6,6 +6,7 @@
 #ifndef BITCOIN_CHAIN_H
 #define BITCOIN_CHAIN_H
 
+#include "blob256.h"
 #include "primitives/block.h"
 #include "pow.h"
 #include "tinyformat.h"

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -141,7 +141,7 @@ public:
         txNew.vout[0].nValue = 50 * COIN;
         txNew.vout[0].scriptPubKey = CScript() << ParseHex("04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5f") << OP_CHECKSIG;
         genesis.vtx.push_back(txNew);
-        genesis.hashPrevBlock = 0;
+        genesis.hashPrevBlock.SetNull();
         genesis.hashMerkleRoot = genesis.BuildMerkleTree();
         genesis.nVersion = 1;
         genesis.nTime    = 1231006505;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -54,19 +54,19 @@ static void convertSeed6(std::vector<CAddress> &vSeedsOut, const SeedSpec6 *data
  */
 static Checkpoints::MapCheckpoints mapCheckpoints =
         boost::assign::map_list_of
-        ( 11111, uint256("0x0000000069e244f73d78e8fd29ba2fd2ed618bd6fa2ee92559f542fdb26e7c1d"))
-        ( 33333, uint256("0x000000002dd5588a74784eaa7ab0507a18ad16a236e7b1ce69f00d7ddfb5d0a6"))
-        ( 74000, uint256("0x0000000000573993a3c9e41ce34471c079dcf5f52a0e824a81e7f953b8661a20"))
-        (105000, uint256("0x00000000000291ce28027faea320c8d2b054b2e0fe44a773f3eefb151d6bdc97"))
-        (134444, uint256("0x00000000000005b12ffd4cd315cd34ffd4a594f430ac814c91184a0d42d2b0fe"))
-        (168000, uint256("0x000000000000099e61ea72015e79632f216fe6cb33d7899acb35b75c8303b763"))
-        (193000, uint256("0x000000000000059f452a5f7340de6682a977387c17010ff6e6c3bd83ca8b1317"))
-        (210000, uint256("0x000000000000048b95347e83192f69cf0366076336c639f9b7228e9ba171342e"))
-        (216116, uint256("0x00000000000001b4f4b433e81ee46494af945cf96014816a4e2370f11b23df4e"))
-        (225430, uint256("0x00000000000001c108384350f74090433e7fcf79a606b8e797f065b130575932"))
-        (250000, uint256("0x000000000000003887df1f29024b06fc2200b55f8af8f35453d7be294df2d214"))
-        (279000, uint256("0x0000000000000001ae8c72a0b0c301f67e3afca10e819efa9041e458e9bd7e40"))
-        (295000, uint256("0x00000000000000004d9b4ef50f0f9d686fd69db2e03af35a100370c64632a983"))
+        ( 11111, blob256S("0x0000000069e244f73d78e8fd29ba2fd2ed618bd6fa2ee92559f542fdb26e7c1d"))
+        ( 33333, blob256S("0x000000002dd5588a74784eaa7ab0507a18ad16a236e7b1ce69f00d7ddfb5d0a6"))
+        ( 74000, blob256S("0x0000000000573993a3c9e41ce34471c079dcf5f52a0e824a81e7f953b8661a20"))
+        (105000, blob256S("0x00000000000291ce28027faea320c8d2b054b2e0fe44a773f3eefb151d6bdc97"))
+        (134444, blob256S("0x00000000000005b12ffd4cd315cd34ffd4a594f430ac814c91184a0d42d2b0fe"))
+        (168000, blob256S("0x000000000000099e61ea72015e79632f216fe6cb33d7899acb35b75c8303b763"))
+        (193000, blob256S("0x000000000000059f452a5f7340de6682a977387c17010ff6e6c3bd83ca8b1317"))
+        (210000, blob256S("0x000000000000048b95347e83192f69cf0366076336c639f9b7228e9ba171342e"))
+        (216116, blob256S("0x00000000000001b4f4b433e81ee46494af945cf96014816a4e2370f11b23df4e"))
+        (225430, blob256S("0x00000000000001c108384350f74090433e7fcf79a606b8e797f065b130575932"))
+        (250000, blob256S("0x000000000000003887df1f29024b06fc2200b55f8af8f35453d7be294df2d214"))
+        (279000, blob256S("0x0000000000000001ae8c72a0b0c301f67e3afca10e819efa9041e458e9bd7e40"))
+        (295000, blob256S("0x00000000000000004d9b4ef50f0f9d686fd69db2e03af35a100370c64632a983"))
         ;
 static const Checkpoints::CCheckpointData data = {
         &mapCheckpoints,
@@ -78,7 +78,7 @@ static const Checkpoints::CCheckpointData data = {
 
 static Checkpoints::MapCheckpoints mapCheckpointsTestnet =
         boost::assign::map_list_of
-        ( 546, uint256("000000002a936ca763904c3c35fce2f3556c559c0214345d31b1bcebf76acb70"))
+        ( 546, blob256S("000000002a936ca763904c3c35fce2f3556c559c0214345d31b1bcebf76acb70"))
         ;
 static const Checkpoints::CCheckpointData dataTestnet = {
         &mapCheckpointsTestnet,
@@ -89,7 +89,7 @@ static const Checkpoints::CCheckpointData dataTestnet = {
 
 static Checkpoints::MapCheckpoints mapCheckpointsRegtest =
         boost::assign::map_list_of
-        ( 0, uint256("0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206"))
+        ( 0, blob256S("0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206"))
         ;
 static const Checkpoints::CCheckpointData dataRegtest = {
         &mapCheckpointsRegtest,
@@ -149,8 +149,8 @@ public:
         genesis.nNonce   = 2083236893;
 
         hashGenesisBlock = genesis.GetHash();
-        assert(hashGenesisBlock == uint256("0x000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"));
-        assert(genesis.hashMerkleRoot == uint256("0x4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"));
+        assert(hashGenesisBlock == blob256S("0x000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"));
+        assert(genesis.hashMerkleRoot == blob256S("0x4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"));
 
         vSeeds.push_back(CDNSSeedData("bitcoin.sipa.be", "seed.bitcoin.sipa.be"));
         vSeeds.push_back(CDNSSeedData("bluematt.me", "dnsseed.bluematt.me"));
@@ -209,7 +209,7 @@ public:
         genesis.nTime = 1296688602;
         genesis.nNonce = 414098458;
         hashGenesisBlock = genesis.GetHash();
-        assert(hashGenesisBlock == uint256("0x000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943"));
+        assert(hashGenesisBlock == blob256S("0x000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943"));
 
         vFixedSeeds.clear();
         vSeeds.clear();
@@ -266,7 +266,7 @@ public:
         genesis.nNonce = 2;
         hashGenesisBlock = genesis.GetHash();
         nDefaultPort = 18444;
-        assert(hashGenesisBlock == uint256("0x0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206"));
+        assert(hashGenesisBlock == blob256S("0x0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206"));
 
         vFixedSeeds.clear(); //! Regtest mode doesn't have any fixed seeds.
         vSeeds.clear();  //! Regtest mode doesn't have any DNS seeds.

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -41,7 +41,7 @@ public:
         MAX_BASE58_TYPES
     };
 
-    const uint256& HashGenesisBlock() const { return hashGenesisBlock; }
+    const blob256& HashGenesisBlock() const { return hashGenesisBlock; }
     const MessageStartChars& MessageStart() const { return pchMessageStart; }
     const std::vector<unsigned char>& AlertKey() const { return vAlertPubKey; }
     int GetDefaultPort() const { return nDefaultPort; }
@@ -82,7 +82,7 @@ public:
 protected:
     CChainParams() {}
 
-    uint256 hashGenesisBlock;
+    blob256 hashGenesisBlock;
     MessageStartChars pchMessageStart;
     //! Raw pub key bytes for the broadcast alert signing key.
     std::vector<unsigned char> vAlertPubKey;

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -6,6 +6,7 @@
 #ifndef BITCOIN_CHAINPARAMS_H
 #define BITCOIN_CHAINPARAMS_H
 
+#include "blob256.h"
 #include "chainparamsbase.h"
 #include "checkpoints.h"
 #include "primitives/block.h"

--- a/src/checkpoints.cpp
+++ b/src/checkpoints.cpp
@@ -6,7 +6,7 @@
 
 #include "chainparams.h"
 #include "main.h"
-#include "uint256.h"
+#include "blob256.h"
 
 #include <stdint.h>
 
@@ -25,7 +25,7 @@ namespace Checkpoints {
 
     bool fEnabled = true;
 
-    bool CheckBlock(int nHeight, const uint256& hash)
+    bool CheckBlock(int nHeight, const blob256& hash)
     {
         if (!fEnabled)
             return true;
@@ -88,7 +88,7 @@ namespace Checkpoints {
 
         BOOST_REVERSE_FOREACH(const MapCheckpoints::value_type& i, checkpoints)
         {
-            const uint256& hash = i.second;
+            const blob256& hash = i.second;
             BlockMap::const_iterator t = mapBlockIndex.find(hash);
             if (t != mapBlockIndex.end())
                 return t->second;

--- a/src/checkpoints.h
+++ b/src/checkpoints.h
@@ -5,7 +5,7 @@
 #ifndef BITCOIN_CHECKPOINTS_H
 #define BITCOIN_CHECKPOINTS_H
 
-#include "uint256.h"
+#include "blob256.h"
 
 #include <map>
 
@@ -17,7 +17,7 @@ class CBlockIndex;
  */
 namespace Checkpoints
 {
-typedef std::map<int, uint256> MapCheckpoints;
+typedef std::map<int, blob256> MapCheckpoints;
 
 struct CCheckpointData {
     const MapCheckpoints *mapCheckpoints;
@@ -27,7 +27,7 @@ struct CCheckpointData {
 };
 
 //! Returns true if block passes checkpoint checks
-bool CheckBlock(int nHeight, const uint256& hash);
+bool CheckBlock(int nHeight, const blob256& hash);
 
 //! Return conservative estimate of total number of blocks, 0 if unknown
 int GetTotalBlocksEstimate();

--- a/src/coincontrol.h
+++ b/src/coincontrol.h
@@ -29,7 +29,7 @@ public:
         return (setSelected.size() > 0);
     }
 
-    bool IsSelected(const uint256& hash, unsigned int n) const
+    bool IsSelected(const blob256& hash, unsigned int n) const
     {
         COutPoint outpt(hash, n);
         return (setSelected.count(outpt) > 0);

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -49,14 +49,14 @@ bool CCoins::Spend(const COutPoint &out, CTxInUndo &undo) {
 
 bool CCoins::Spend(int nPos) {
     CTxInUndo undo;
-    COutPoint out(0, nPos);
+    COutPoint out(uint256(), nPos);
     return Spend(out, undo);
 }
 
 
 bool CCoinsView::GetCoins(const uint256 &txid, CCoins &coins) const { return false; }
 bool CCoinsView::HaveCoins(const uint256 &txid) const { return false; }
-uint256 CCoinsView::GetBestBlock() const { return uint256(0); }
+uint256 CCoinsView::GetBestBlock() const { return uint256(); }
 bool CCoinsView::BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock) { return false; }
 bool CCoinsView::GetStats(CCoinsStats &stats) const { return false; }
 
@@ -71,7 +71,7 @@ bool CCoinsViewBacked::GetStats(CCoinsStats &stats) const { return base->GetStat
 
 CCoinsKeyHasher::CCoinsKeyHasher() : salt(GetRandHash()) {}
 
-CCoinsViewCache::CCoinsViewCache(CCoinsView *baseIn) : CCoinsViewBacked(baseIn), hasModifier(false), hashBlock(0) { }
+CCoinsViewCache::CCoinsViewCache(CCoinsView *baseIn) : CCoinsViewBacked(baseIn), hasModifier(false) { }
 
 CCoinsViewCache::~CCoinsViewCache()
 {
@@ -142,7 +142,7 @@ bool CCoinsViewCache::HaveCoins(const uint256 &txid) const {
 }
 
 uint256 CCoinsViewCache::GetBestBlock() const {
-    if (hashBlock == uint256(0))
+    if (hashBlock.IsNull())
         hashBlock = base->GetBestBlock();
     return hashBlock;
 }

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -49,24 +49,24 @@ bool CCoins::Spend(const COutPoint &out, CTxInUndo &undo) {
 
 bool CCoins::Spend(int nPos) {
     CTxInUndo undo;
-    COutPoint out(uint256(), nPos);
+    COutPoint out(blob256(), nPos);
     return Spend(out, undo);
 }
 
 
-bool CCoinsView::GetCoins(const uint256 &txid, CCoins &coins) const { return false; }
-bool CCoinsView::HaveCoins(const uint256 &txid) const { return false; }
-uint256 CCoinsView::GetBestBlock() const { return uint256(); }
-bool CCoinsView::BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock) { return false; }
+bool CCoinsView::GetCoins(const blob256 &txid, CCoins &coins) const { return false; }
+bool CCoinsView::HaveCoins(const blob256 &txid) const { return false; }
+blob256 CCoinsView::GetBestBlock() const { return blob256(); }
+bool CCoinsView::BatchWrite(CCoinsMap &mapCoins, const blob256 &hashBlock) { return false; }
 bool CCoinsView::GetStats(CCoinsStats &stats) const { return false; }
 
 
 CCoinsViewBacked::CCoinsViewBacked(CCoinsView *viewIn) : base(viewIn) { }
-bool CCoinsViewBacked::GetCoins(const uint256 &txid, CCoins &coins) const { return base->GetCoins(txid, coins); }
-bool CCoinsViewBacked::HaveCoins(const uint256 &txid) const { return base->HaveCoins(txid); }
-uint256 CCoinsViewBacked::GetBestBlock() const { return base->GetBestBlock(); }
+bool CCoinsViewBacked::GetCoins(const blob256 &txid, CCoins &coins) const { return base->GetCoins(txid, coins); }
+bool CCoinsViewBacked::HaveCoins(const blob256 &txid) const { return base->HaveCoins(txid); }
+blob256 CCoinsViewBacked::GetBestBlock() const { return base->GetBestBlock(); }
 void CCoinsViewBacked::SetBackend(CCoinsView &viewIn) { base = &viewIn; }
-bool CCoinsViewBacked::BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock) { return base->BatchWrite(mapCoins, hashBlock); }
+bool CCoinsViewBacked::BatchWrite(CCoinsMap &mapCoins, const blob256 &hashBlock) { return base->BatchWrite(mapCoins, hashBlock); }
 bool CCoinsViewBacked::GetStats(CCoinsStats &stats) const { return base->GetStats(stats); }
 
 CCoinsKeyHasher::CCoinsKeyHasher() : salt(GetRandHash()) {}
@@ -78,7 +78,7 @@ CCoinsViewCache::~CCoinsViewCache()
     assert(!hasModifier);
 }
 
-CCoinsMap::const_iterator CCoinsViewCache::FetchCoins(const uint256 &txid) const {
+CCoinsMap::const_iterator CCoinsViewCache::FetchCoins(const blob256 &txid) const {
     CCoinsMap::iterator it = cacheCoins.find(txid);
     if (it != cacheCoins.end())
         return it;
@@ -95,7 +95,7 @@ CCoinsMap::const_iterator CCoinsViewCache::FetchCoins(const uint256 &txid) const
     return ret;
 }
 
-bool CCoinsViewCache::GetCoins(const uint256 &txid, CCoins &coins) const {
+bool CCoinsViewCache::GetCoins(const blob256 &txid, CCoins &coins) const {
     CCoinsMap::const_iterator it = FetchCoins(txid);
     if (it != cacheCoins.end()) {
         coins = it->second.coins;
@@ -104,7 +104,7 @@ bool CCoinsViewCache::GetCoins(const uint256 &txid, CCoins &coins) const {
     return false;
 }
 
-CCoinsModifier CCoinsViewCache::ModifyCoins(const uint256 &txid) {
+CCoinsModifier CCoinsViewCache::ModifyCoins(const blob256 &txid) {
     assert(!hasModifier);
     hasModifier = true;
     std::pair<CCoinsMap::iterator, bool> ret = cacheCoins.insert(std::make_pair(txid, CCoinsCacheEntry()));
@@ -123,7 +123,7 @@ CCoinsModifier CCoinsViewCache::ModifyCoins(const uint256 &txid) {
     return CCoinsModifier(*this, ret.first);
 }
 
-const CCoins* CCoinsViewCache::AccessCoins(const uint256 &txid) const {
+const CCoins* CCoinsViewCache::AccessCoins(const blob256 &txid) const {
     CCoinsMap::const_iterator it = FetchCoins(txid);
     if (it == cacheCoins.end()) {
         return NULL;
@@ -132,7 +132,7 @@ const CCoins* CCoinsViewCache::AccessCoins(const uint256 &txid) const {
     }
 }
 
-bool CCoinsViewCache::HaveCoins(const uint256 &txid) const {
+bool CCoinsViewCache::HaveCoins(const blob256 &txid) const {
     CCoinsMap::const_iterator it = FetchCoins(txid);
     // We're using vtx.empty() instead of IsPruned here for performance reasons,
     // as we only care about the case where a transaction was replaced entirely
@@ -141,17 +141,17 @@ bool CCoinsViewCache::HaveCoins(const uint256 &txid) const {
     return (it != cacheCoins.end() && !it->second.coins.vout.empty());
 }
 
-uint256 CCoinsViewCache::GetBestBlock() const {
+blob256 CCoinsViewCache::GetBestBlock() const {
     if (hashBlock.IsNull())
         hashBlock = base->GetBestBlock();
     return hashBlock;
 }
 
-void CCoinsViewCache::SetBestBlock(const uint256 &hashBlockIn) {
+void CCoinsViewCache::SetBestBlock(const blob256 &hashBlockIn) {
     hashBlock = hashBlockIn;
 }
 
-bool CCoinsViewCache::BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlockIn) {
+bool CCoinsViewCache::BatchWrite(CCoinsMap &mapCoins, const blob256 &hashBlockIn) {
     assert(!hasModifier);
     for (CCoinsMap::iterator it = mapCoins.begin(); it != mapCoins.end();) {
         if (it->second.flags & CCoinsCacheEntry::DIRTY) { // Ignore non-dirty entries (optimization).

--- a/src/coins.h
+++ b/src/coins.h
@@ -301,7 +301,7 @@ struct CCoinsStats
     uint256 hashSerialized;
     CAmount nTotalAmount;
 
-    CCoinsStats() : nHeight(0), hashBlock(0), nTransactions(0), nTransactionOutputs(0), nSerializedSize(0), hashSerialized(0), nTotalAmount(0) {}
+    CCoinsStats() : nHeight(0), nTransactions(0), nTransactionOutputs(0), nSerializedSize(0), nTotalAmount(0) {}
 };
 
 

--- a/src/core_io.h
+++ b/src/core_io.h
@@ -11,14 +11,14 @@
 class CBlock;
 class CScript;
 class CTransaction;
-class uint256;
+class blob256;
 class UniValue;
 
 // core_read.cpp
 extern CScript ParseScript(std::string s);
 extern bool DecodeHexTx(CTransaction& tx, const std::string& strHexTx);
 extern bool DecodeHexBlk(CBlock&, const std::string& strHexBlk);
-extern uint256 ParseHashUV(const UniValue& v, const std::string& strName);
+extern blob256 ParseHashUV(const UniValue& v, const std::string& strName);
 extern std::vector<unsigned char> ParseHexUV(const UniValue& v, const std::string& strName);
 
 // core_write.cpp
@@ -26,6 +26,6 @@ extern std::string FormatScript(const CScript& script);
 extern std::string EncodeHexTx(const CTransaction& tx);
 extern void ScriptPubKeyToUniv(const CScript& scriptPubKey,
                         UniValue& out, bool fIncludeHex);
-extern void TxToUniv(const CTransaction& tx, const uint256& hashBlock, UniValue& entry);
+extern void TxToUniv(const CTransaction& tx, const blob256& hashBlock, UniValue& entry);
 
 #endif // BITCOIN_CORE_IO_H

--- a/src/core_read.cpp
+++ b/src/core_read.cpp
@@ -126,7 +126,7 @@ bool DecodeHexBlk(CBlock& block, const std::string& strHexBlk)
     return true;
 }
 
-uint256 ParseHashUV(const UniValue& v, const string& strName)
+blob256 ParseHashUV(const UniValue& v, const string& strName)
 {
     string strHex;
     if (v.isStr())
@@ -134,7 +134,7 @@ uint256 ParseHashUV(const UniValue& v, const string& strName)
     if (!IsHex(strHex)) // Note: IsHex("") is false
         throw runtime_error(strName+" must be hexadecimal string (not '"+strHex+"')");
 
-    uint256 result;
+    blob256 result;
     result.SetHex(strHex);
     return result;
 }

--- a/src/core_write.cpp
+++ b/src/core_write.cpp
@@ -127,7 +127,7 @@ void TxToUniv(const CTransaction& tx, const uint256& hashBlock, UniValue& entry)
     }
     entry.pushKV("vout", vout);
 
-    if (hashBlock != 0)
+    if (!hashBlock.IsNull())
         entry.pushKV("blockhash", hashBlock.GetHex());
 
     entry.pushKV("hex", EncodeHexTx(tx)); // the hex-encoded transaction. used the name "hex" to be consistent with the verbose output of "getrawtransaction".

--- a/src/core_write.cpp
+++ b/src/core_write.cpp
@@ -86,7 +86,7 @@ void ScriptPubKeyToUniv(const CScript& scriptPubKey,
     out.pushKV("addresses", a);
 }
 
-void TxToUniv(const CTransaction& tx, const uint256& hashBlock, UniValue& entry)
+void TxToUniv(const CTransaction& tx, const blob256& hashBlock, UniValue& entry)
 {
     entry.pushKV("txid", tx.GetHash().GetHex());
     entry.pushKV("version", tx.nVersion);

--- a/src/crypter.cpp
+++ b/src/crypter.cpp
@@ -102,7 +102,7 @@ bool CCrypter::Decrypt(const std::vector<unsigned char>& vchCiphertext, CKeyingM
 }
 
 
-bool EncryptSecret(const CKeyingMaterial& vMasterKey, const CKeyingMaterial &vchPlaintext, const uint256& nIV, std::vector<unsigned char> &vchCiphertext)
+bool EncryptSecret(const CKeyingMaterial& vMasterKey, const CKeyingMaterial &vchPlaintext, const blob256& nIV, std::vector<unsigned char> &vchCiphertext)
 {
     CCrypter cKeyCrypter;
     std::vector<unsigned char> chIV(WALLET_CRYPTO_KEY_SIZE);
@@ -112,7 +112,7 @@ bool EncryptSecret(const CKeyingMaterial& vMasterKey, const CKeyingMaterial &vch
     return cKeyCrypter.Encrypt(*((const CKeyingMaterial*)&vchPlaintext), vchCiphertext);
 }
 
-bool DecryptSecret(const CKeyingMaterial& vMasterKey, const std::vector<unsigned char>& vchCiphertext, const uint256& nIV, CKeyingMaterial& vchPlaintext)
+bool DecryptSecret(const CKeyingMaterial& vMasterKey, const std::vector<unsigned char>& vchCiphertext, const blob256& nIV, CKeyingMaterial& vchPlaintext)
 {
     CCrypter cKeyCrypter;
     std::vector<unsigned char> chIV(WALLET_CRYPTO_KEY_SIZE);

--- a/src/crypter.h
+++ b/src/crypter.h
@@ -9,7 +9,7 @@
 #include "keystore.h"
 #include "serialize.h"
 
-class uint256;
+class blob256;
 
 const unsigned int WALLET_CRYPTO_KEY_SIZE = 32;
 const unsigned int WALLET_CRYPTO_SALT_SIZE = 8;
@@ -107,8 +107,8 @@ public:
     }
 };
 
-bool EncryptSecret(const CKeyingMaterial& vMasterKey, const CKeyingMaterial &vchPlaintext, const uint256& nIV, std::vector<unsigned char> &vchCiphertext);
-bool DecryptSecret(const CKeyingMaterial& vMasterKey, const std::vector<unsigned char>& vchCiphertext, const uint256& nIV, CKeyingMaterial& vchPlaintext);
+bool EncryptSecret(const CKeyingMaterial& vMasterKey, const CKeyingMaterial &vchPlaintext, const blob256& nIV, std::vector<unsigned char> &vchCiphertext);
+bool DecryptSecret(const CKeyingMaterial& vMasterKey, const std::vector<unsigned char>& vchCiphertext, const blob256& nIV, CKeyingMaterial& vchPlaintext);
 
 /** Keystore which keeps the private keys encrypted.
  * It derives from the basic key store, which is used if no encryption is active.

--- a/src/eccryptoverify.h
+++ b/src/eccryptoverify.h
@@ -9,7 +9,7 @@
 #include <vector>
 #include <cstdlib>
 
-class uint256;
+class blob256;
 
 namespace eccrypto {
 

--- a/src/ecwrapper.cpp
+++ b/src/ecwrapper.cpp
@@ -5,7 +5,7 @@
 #include "ecwrapper.h"
 
 #include "serialize.h"
-#include "uint256.h"
+#include "blob256.h"
 
 #include <openssl/bn.h>
 #include <openssl/ecdsa.h>
@@ -116,14 +116,14 @@ bool CECKey::SetPubKey(const unsigned char* pubkey, size_t size) {
     return o2i_ECPublicKey(&pkey, &pubkey, size) != NULL;
 }
 
-bool CECKey::Verify(const uint256 &hash, const std::vector<unsigned char>& vchSig) {
+bool CECKey::Verify(const blob256 &hash, const std::vector<unsigned char>& vchSig) {
     // -1 = error, 0 = bad sig, 1 = good
     if (ECDSA_verify(0, (unsigned char*)&hash, sizeof(hash), &vchSig[0], vchSig.size(), pkey) != 1)
         return false;
     return true;
 }
 
-bool CECKey::Recover(const uint256 &hash, const unsigned char *p64, int rec)
+bool CECKey::Recover(const blob256 &hash, const unsigned char *p64, int rec)
 {
     if (rec<0 || rec>=3)
         return false;

--- a/src/ecwrapper.h
+++ b/src/ecwrapper.h
@@ -10,7 +10,7 @@
 
 #include <openssl/ec.h>
 
-class uint256;
+class blob256;
 
 /** RAII Wrapper around OpenSSL's EC_KEY */
 class CECKey {
@@ -23,7 +23,7 @@ public:
 
     void GetPubKey(std::vector<unsigned char>& pubkey, bool fCompressed);
     bool SetPubKey(const unsigned char* pubkey, size_t size);
-    bool Verify(const uint256 &hash, const std::vector<unsigned char>& vchSig);
+    bool Verify(const blob256 &hash, const std::vector<unsigned char>& vchSig);
 
     /**
      * reconstruct public key from a compact signature
@@ -31,7 +31,7 @@ public:
      * If this function succeeds, the recovered public key is guaranteed to be valid
      * (the signature is a valid signature of the given data for that key)
      */
-    bool Recover(const uint256 &hash, const unsigned char *p64, int rec);
+    bool Recover(const blob256 &hash, const unsigned char *p64, int rec);
 
     bool TweakPublic(const unsigned char vchTweak[32]);
     static bool SanityCheck();

--- a/src/hash.h
+++ b/src/hash.h
@@ -9,7 +9,7 @@
 #include "crypto/ripemd160.h"
 #include "crypto/sha256.h"
 #include "serialize.h"
-#include "uint256.h"
+#include "blob256.h"
 #include "version.h"
 
 #include <vector>
@@ -64,10 +64,10 @@ public:
 
 /** Compute the 256-bit hash of an object. */
 template<typename T1>
-inline uint256 Hash(const T1 pbegin, const T1 pend)
+inline blob256 Hash(const T1 pbegin, const T1 pend)
 {
     static const unsigned char pblank[1] = {};
-    uint256 result;
+    blob256 result;
     CHash256().Write(pbegin == pend ? pblank : (const unsigned char*)&pbegin[0], (pend - pbegin) * sizeof(pbegin[0]))
               .Finalize((unsigned char*)&result);
     return result;
@@ -75,10 +75,10 @@ inline uint256 Hash(const T1 pbegin, const T1 pend)
 
 /** Compute the 256-bit hash of the concatenation of two objects. */
 template<typename T1, typename T2>
-inline uint256 Hash(const T1 p1begin, const T1 p1end,
+inline blob256 Hash(const T1 p1begin, const T1 p1end,
                     const T2 p2begin, const T2 p2end) {
     static const unsigned char pblank[1] = {};
-    uint256 result;
+    blob256 result;
     CHash256().Write(p1begin == p1end ? pblank : (const unsigned char*)&p1begin[0], (p1end - p1begin) * sizeof(p1begin[0]))
               .Write(p2begin == p2end ? pblank : (const unsigned char*)&p2begin[0], (p2end - p2begin) * sizeof(p2begin[0]))
               .Finalize((unsigned char*)&result);
@@ -87,11 +87,11 @@ inline uint256 Hash(const T1 p1begin, const T1 p1end,
 
 /** Compute the 256-bit hash of the concatenation of three objects. */
 template<typename T1, typename T2, typename T3>
-inline uint256 Hash(const T1 p1begin, const T1 p1end,
+inline blob256 Hash(const T1 p1begin, const T1 p1end,
                     const T2 p2begin, const T2 p2end,
                     const T3 p3begin, const T3 p3end) {
     static const unsigned char pblank[1] = {};
-    uint256 result;
+    blob256 result;
     CHash256().Write(p1begin == p1end ? pblank : (const unsigned char*)&p1begin[0], (p1end - p1begin) * sizeof(p1begin[0]))
               .Write(p2begin == p2end ? pblank : (const unsigned char*)&p2begin[0], (p2end - p2begin) * sizeof(p2begin[0]))
               .Write(p3begin == p3end ? pblank : (const unsigned char*)&p3begin[0], (p3end - p3begin) * sizeof(p3begin[0]))
@@ -101,17 +101,17 @@ inline uint256 Hash(const T1 p1begin, const T1 p1end,
 
 /** Compute the 160-bit hash an object. */
 template<typename T1>
-inline uint160 Hash160(const T1 pbegin, const T1 pend)
+inline blob160 Hash160(const T1 pbegin, const T1 pend)
 {
     static unsigned char pblank[1] = {};
-    uint160 result;
+    blob160 result;
     CHash160().Write(pbegin == pend ? pblank : (const unsigned char*)&pbegin[0], (pend - pbegin) * sizeof(pbegin[0]))
               .Finalize((unsigned char*)&result);
     return result;
 }
 
 /** Compute the 160-bit hash of a vector. */
-inline uint160 Hash160(const std::vector<unsigned char>& vch)
+inline blob160 Hash160(const std::vector<unsigned char>& vch)
 {
     return Hash160(vch.begin(), vch.end());
 }
@@ -134,8 +134,8 @@ public:
     }
 
     // invalidates the object
-    uint256 GetHash() {
-        uint256 result;
+    blob256 GetHash() {
+        blob256 result;
         ctx.Finalize((unsigned char*)&result);
         return result;
     }
@@ -150,7 +150,7 @@ public:
 
 /** Compute the 256-bit hash of an object's serialization. */
 template<typename T>
-uint256 SerializeHash(const T& obj, int nType=SER_GETHASH, int nVersion=PROTOCOL_VERSION)
+blob256 SerializeHash(const T& obj, int nType=SER_GETHASH, int nVersion=PROTOCOL_VERSION)
 {
     CHashWriter ss(nType, nVersion);
     ss << obj;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -379,7 +379,7 @@ std::string LicenseInfo()
            "\n";
 }
 
-static void BlockNotifyCallback(const uint256& hashNewTip)
+static void BlockNotifyCallback(const blob256& hashNewTip)
 {
     std::string strCmd = GetArg("-blocknotify", "");
 
@@ -1168,8 +1168,8 @@ bool AppInit2(boost::thread_group& threadGroup)
             {
                 BOOST_FOREACH(const CWalletTx& wtxOld, vWtx)
                 {
-                    uint256 hash = wtxOld.GetHash();
-                    std::map<uint256, CWalletTx>::iterator mi = pwalletMain->mapWallet.find(hash);
+                    blob256 hash = wtxOld.GetHash();
+                    std::map<blob256, CWalletTx>::iterator mi = pwalletMain->mapWallet.find(hash);
                     if (mi != pwalletMain->mapWallet.end())
                     {
                         const CWalletTx* copyFrom = &wtxOld;

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -83,7 +83,7 @@ bool CKey::Sign(const uint256 &hash, std::vector<unsigned char>& vchSig, uint32_
         nonce += test_case;
         int nSigLen = 72;
         int ret = secp256k1_ecdsa_sign((const unsigned char*)&hash, (unsigned char*)&vchSig[0], &nSigLen, begin(), (unsigned char*)&nonce);
-        nonce = 0;
+        nonce = uint256();
         if (ret) {
             vchSig.resize(nSigLen);
             return true;
@@ -115,7 +115,7 @@ bool CKey::SignCompact(const uint256 &hash, std::vector<unsigned char>& vchSig) 
         uint256 nonce;
         prng.Generate((unsigned char*)&nonce, 32);
         int ret = secp256k1_ecdsa_sign_compact((const unsigned char*)&hash, &vchSig[1], begin(), (unsigned char*)&nonce, &rec);
-        nonce = 0;
+        nonce = uint256();
         if (ret)
             break;
     } while(true);

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -9,6 +9,7 @@
 #include "eccryptoverify.h"
 #include "pubkey.h"
 #include "random.h"
+#include "uint256.h"
 
 #include <secp256k1.h>
 #include "ecwrapper.h"

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -81,7 +81,7 @@ bool CKey::Sign(const blob256 &hash, std::vector<unsigned char>& vchSig, uint32_
     do {
         blob256 nonce;
         prng.Generate((unsigned char*)&nonce, 32);
-        nonce += test_case;
+        nonce = UintToBlob256(BlobToUint256(nonce) + test_case);
         int nSigLen = 72;
         int ret = secp256k1_ecdsa_sign((const unsigned char*)&hash, (unsigned char*)&vchSig[0], &nSigLen, begin(), (unsigned char*)&nonce);
         nonce = blob256();

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -72,18 +72,18 @@ CPubKey CKey::GetPubKey() const {
     return result;
 }
 
-bool CKey::Sign(const uint256 &hash, std::vector<unsigned char>& vchSig, uint32_t test_case) const {
+bool CKey::Sign(const blob256 &hash, std::vector<unsigned char>& vchSig, uint32_t test_case) const {
     if (!fValid)
         return false;
     vchSig.resize(72);
     RFC6979_HMAC_SHA256 prng(begin(), 32, (unsigned char*)&hash, 32);
     do {
-        uint256 nonce;
+        blob256 nonce;
         prng.Generate((unsigned char*)&nonce, 32);
         nonce += test_case;
         int nSigLen = 72;
         int ret = secp256k1_ecdsa_sign((const unsigned char*)&hash, (unsigned char*)&vchSig[0], &nSigLen, begin(), (unsigned char*)&nonce);
-        nonce = uint256();
+        nonce = blob256();
         if (ret) {
             vchSig.resize(nSigLen);
             return true;
@@ -98,24 +98,24 @@ bool CKey::VerifyPubKey(const CPubKey& pubkey) const {
     unsigned char rnd[8];
     std::string str = "Bitcoin key verification\n";
     GetRandBytes(rnd, sizeof(rnd));
-    uint256 hash;
+    blob256 hash;
     CHash256().Write((unsigned char*)str.data(), str.size()).Write(rnd, sizeof(rnd)).Finalize((unsigned char*)&hash);
     std::vector<unsigned char> vchSig;
     Sign(hash, vchSig);
     return pubkey.Verify(hash, vchSig);
 }
 
-bool CKey::SignCompact(const uint256 &hash, std::vector<unsigned char>& vchSig) const {
+bool CKey::SignCompact(const blob256 &hash, std::vector<unsigned char>& vchSig) const {
     if (!fValid)
         return false;
     vchSig.resize(65);
     int rec = -1;
     RFC6979_HMAC_SHA256 prng(begin(), 32, (unsigned char*)&hash, 32);
     do {
-        uint256 nonce;
+        blob256 nonce;
         prng.Generate((unsigned char*)&nonce, 32);
         int ret = secp256k1_ecdsa_sign_compact((const unsigned char*)&hash, &vchSig[1], begin(), (unsigned char*)&nonce, &rec);
-        nonce = uint256();
+        nonce = blob256();
         if (ret)
             break;
     } while(true);

--- a/src/key.h
+++ b/src/key.h
@@ -8,7 +8,7 @@
 
 #include "allocators.h"
 #include "serialize.h"
-#include "uint256.h"
+#include "blob256.h"
 
 #include <stdexcept>
 #include <vector>
@@ -127,7 +127,7 @@ public:
      * The test_case parameter tweaks the deterministic nonce, and is only for
      * testing. It should be zero for normal use.
      */
-    bool Sign(const uint256& hash, std::vector<unsigned char>& vchSig, uint32_t test_case = 0) const;
+    bool Sign(const blob256& hash, std::vector<unsigned char>& vchSig, uint32_t test_case = 0) const;
 
     /**
      * Create a compact signature (65 bytes), which allows reconstructing the used public key.
@@ -136,7 +136,7 @@ public:
      *                  0x1D = second key with even y, 0x1E = second key with odd y,
      *                  add 0x04 for compressed keys.
      */
-    bool SignCompact(const uint256& hash, std::vector<unsigned char>& vchSig) const;
+    bool SignCompact(const blob256& hash, std::vector<unsigned char>& vchSig) const;
 
     //! Derive BIP32 child key.
     bool Derive(CKey& keyChild, unsigned char ccChild[32], unsigned int nChild, const unsigned char cc[32]) const;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -260,7 +260,7 @@ struct CNodeState {
         nMisbehavior = 0;
         fShouldBan = false;
         pindexBestKnownBlock = NULL;
-        hashLastUnknownBlock = uint256(0);
+        hashLastUnknownBlock.SetNull();
         pindexLastCommonBlock = NULL;
         fSyncStarted = false;
         nStallingSince = 0;
@@ -348,12 +348,12 @@ void ProcessBlockAvailability(NodeId nodeid) {
     CNodeState *state = State(nodeid);
     assert(state != NULL);
 
-    if (state->hashLastUnknownBlock != 0) {
+    if (!state->hashLastUnknownBlock.IsNull()) {
         BlockMap::iterator itOld = mapBlockIndex.find(state->hashLastUnknownBlock);
         if (itOld != mapBlockIndex.end() && itOld->second->nChainWork > 0) {
             if (state->pindexBestKnownBlock == NULL || itOld->second->nChainWork >= state->pindexBestKnownBlock->nChainWork)
                 state->pindexBestKnownBlock = itOld->second;
-            state->hashLastUnknownBlock = uint256(0);
+            state->hashLastUnknownBlock.SetNull();
         }
     }
 }
@@ -1617,7 +1617,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
         return false;
 
     // verify that the view's current state corresponds to the previous block
-    uint256 hashPrevBlock = pindex->pprev == NULL ? uint256(0) : pindex->pprev->GetBlockHash();
+    uint256 hashPrevBlock = pindex->pprev == NULL ? uint256() : pindex->pprev->GetBlockHash();
     assert(hashPrevBlock == view.GetBestBlock());
 
     // Special case for the genesis block, skipping connection of its transactions
@@ -2737,7 +2737,7 @@ boost::filesystem::path GetBlockPosFilename(const CDiskBlockPos &pos, const char
 
 CBlockIndex * InsertBlockIndex(uint256 hash)
 {
-    if (hash == 0)
+    if (hash.IsNull())
         return NULL;
 
     // Return existing
@@ -3269,7 +3269,7 @@ void static ProcessGetData(CNode* pfrom)
                         vector<CInv> vInv;
                         vInv.push_back(CInv(MSG_BLOCK, chainActive.Tip()->GetBlockHash()));
                         pfrom->PushMessage("inv", vInv);
-                        pfrom->hashContinue = 0;
+                        pfrom->hashContinue.SetNull();
                     }
                 }
             }
@@ -3502,7 +3502,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                     // Use deterministic randomness to send to the same nodes for 24 hours
                     // at a time so the setAddrKnowns of the chosen nodes prevent repeats
                     static uint256 hashSalt;
-                    if (hashSalt == 0)
+                    if (hashSalt.IsNull())
                         hashSalt = GetRandHash();
                     uint64_t hashAddr = addr.GetHash();
                     uint256 hashRand = hashSalt ^ (hashAddr<<32) ^ ((GetTime()+hashAddr)/(24*60*60));
@@ -3634,7 +3634,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         if (pindex)
             pindex = chainActive.Next(pindex);
         int nLimit = 500;
-        LogPrint("net", "getblocks %d to %s limit %d from peer=%d\n", (pindex ? pindex->nHeight : -1), hashStop==uint256(0) ? "end" : hashStop.ToString(), nLimit, pfrom->id);
+        LogPrint("net", "getblocks %d to %s limit %d from peer=%d\n", (pindex ? pindex->nHeight : -1), hashStop.IsNull() ? "end" : hashStop.ToString(), nLimit, pfrom->id);
         for (; pindex; pindex = chainActive.Next(pindex))
         {
             if (pindex->GetBlockHash() == hashStop)
@@ -3850,7 +3850,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
             // TODO: optimize: if pindexLast is an ancestor of chainActive.Tip or pindexBestHeader, continue
             // from there instead.
             LogPrint("net", "more getheaders (%d) to end to peer=%d (startheight:%d)\n", pindexLast->nHeight, pfrom->id, pfrom->nStartingHeight);
-            pfrom->PushMessage("getheaders", chainActive.GetLocator(pindexLast), uint256(0));
+            pfrom->PushMessage("getheaders", chainActive.GetLocator(pindexLast), uint256());
         }
     }
 
@@ -4348,7 +4348,7 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
                 nSyncStarted++;
                 CBlockIndex *pindexStart = pindexBestHeader->pprev ? pindexBestHeader->pprev : pindexBestHeader;
                 LogPrint("net", "initial getheaders (%d) to peer=%d (startheight:%d)\n", pindexStart->nHeight, pto->id, pto->nStartingHeight);
-                pto->PushMessage("getheaders", chainActive.GetLocator(pindexStart), uint256(0));
+                pto->PushMessage("getheaders", chainActive.GetLocator(pindexStart), uint256());
             }
         }
 
@@ -4379,7 +4379,7 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
                 {
                     // 1/4 of tx invs blast to all immediately
                     static uint256 hashSalt;
-                    if (hashSalt == 0)
+                    if (hashSalt.IsNull())
                         hashSalt = GetRandHash();
                     uint256 hashRand = inv.hash ^ hashSalt;
                     hashRand = Hash(BEGIN(hashRand), END(hashRand));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3505,7 +3505,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                     if (hashSalt.IsNull())
                         hashSalt = GetRandHash();
                     uint64_t hashAddr = addr.GetHash();
-                    uint256 hashRand = hashSalt ^ (hashAddr<<32) ^ ((GetTime()+hashAddr)/(24*60*60));
+                    blob256 hashRand = UintToBlob256(BlobToUint256(hashSalt) ^ (hashAddr<<32) ^ ((GetTime()+hashAddr)/(24*60*60)));
                     hashRand = Hash(BEGIN(hashRand), END(hashRand));
                     multimap<blob256, CNode*> mapMix;
                     BOOST_FOREACH(CNode* pnode, vNodes)
@@ -3514,7 +3514,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                             continue;
                         unsigned int nPointer;
                         memcpy(&nPointer, &pnode, sizeof(nPointer));
-                        uint256 hashKey = hashRand ^ nPointer;
+                        blob256 hashKey = UintToBlob256(BlobToUint256(hashRand) ^ nPointer);
                         hashKey = Hash(BEGIN(hashKey), END(hashKey));
                         mapMix.insert(make_pair(hashKey, pnode));
                     }
@@ -4381,9 +4381,9 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
                     static blob256 hashSalt;
                     if (hashSalt.IsNull())
                         hashSalt = GetRandHash();
-                    uint256 hashRand = inv.hash ^ hashSalt;
+                    blob256 hashRand = UintToBlob256(BlobToUint256(inv.hash) ^ BlobToUint256(hashSalt));
                     hashRand = Hash(BEGIN(hashRand), END(hashRand));
-                    bool fTrickleWait = ((hashRand & 3) != 0);
+                    bool fTrickleWait = ((BlobToUint256(hashRand) & 3) != 0);
 
                     if (fTrickleWait)
                     {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1642,8 +1642,8 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     // two in the chain that violate it. This prevents exploiting the issue against nodes in their
     // initial block download.
     bool fEnforceBIP30 = (!pindex->phashBlock) || // Enforce on CreateNewBlock invocations which don't have a hash.
-                          !((pindex->nHeight==91842 && pindex->GetBlockHash() == uint256("0x00000000000a4d0a398161ffc163c503763b1f4360639393e0e4c8e300e0caec")) ||
-                           (pindex->nHeight==91880 && pindex->GetBlockHash() == uint256("0x00000000000743f190a18c5577a3c2d2a1f610ae9601ac046a38084ccb7cd721")));
+                          !((pindex->nHeight==91842 && pindex->GetBlockHash() == blob256S("0x00000000000a4d0a398161ffc163c503763b1f4360639393e0e4c8e300e0caec")) ||
+                           (pindex->nHeight==91880 && pindex->GetBlockHash() == blob256S("0x00000000000743f190a18c5577a3c2d2a1f610ae9601ac046a38084ccb7cd721")));
     if (fEnforceBIP30) {
         BOOST_FOREACH(const CTransaction& tx, block.vtx) {
             const CCoins* coins = view.AccessCoins(tx.GetHash());

--- a/src/main.h
+++ b/src/main.h
@@ -109,7 +109,7 @@ static const unsigned char REJECT_CHECKPOINT = 0x43;
 
 struct BlockHasher
 {
-    size_t operator()(const uint256& hash) const { return hash.GetLow64(); }
+    size_t operator()(const uint256& hash) const { return hash.GetCheapHash(); }
 };
 
 extern CScript COINBASE_FLAGS;

--- a/src/main.h
+++ b/src/main.h
@@ -24,7 +24,7 @@
 #include "sync.h"
 #include "tinyformat.h"
 #include "txmempool.h"
-#include "uint256.h"
+#include "blob256.h"
 #include "undo.h"
 
 #include <algorithm>
@@ -109,13 +109,13 @@ static const unsigned char REJECT_CHECKPOINT = 0x43;
 
 struct BlockHasher
 {
-    size_t operator()(const uint256& hash) const { return hash.GetCheapHash(); }
+    size_t operator()(const blob256& hash) const { return hash.GetCheapHash(); }
 };
 
 extern CScript COINBASE_FLAGS;
 extern CCriticalSection cs_main;
 extern CTxMemPool mempool;
-typedef boost::unordered_map<uint256, CBlockIndex*, BlockHasher> BlockMap;
+typedef boost::unordered_map<blob256, CBlockIndex*, BlockHasher> BlockMap;
 extern BlockMap mapBlockIndex;
 extern uint64_t nLastBlockTx;
 extern uint64_t nLastBlockSize;
@@ -190,13 +190,13 @@ bool IsInitialBlockDownload();
 /** Format a string that describes several potential problems detected by the core */
 std::string GetWarnings(std::string strFor);
 /** Retrieve a transaction (from memory pool, or from disk, if possible) */
-bool GetTransaction(const uint256 &hash, CTransaction &tx, uint256 &hashBlock, bool fAllowSlow = false);
+bool GetTransaction(const blob256 &hash, CTransaction &tx, blob256 &hashBlock, bool fAllowSlow = false);
 /** Find the best known block, and make it the tip of the block chain */
 bool ActivateBestChain(CValidationState &state, CBlock *pblock = NULL);
 CAmount GetBlockValue(int nHeight, const CAmount& nFees);
 
 /** Create a new block index entry for a given block hash */
-CBlockIndex * InsertBlockIndex(uint256 hash);
+CBlockIndex * InsertBlockIndex(blob256 hash);
 /** Abort with a message */
 bool AbortNode(const std::string &msg, const std::string &userMessage="");
 /** Get statistics from node state */
@@ -317,8 +317,8 @@ public:
         READWRITE(vtxundo);
     }
 
-    bool WriteToDisk(CDiskBlockPos &pos, const uint256 &hashBlock);
-    bool ReadFromDisk(const CDiskBlockPos &pos, const uint256 &hashBlock);
+    bool WriteToDisk(CDiskBlockPos &pos, const blob256 &hashBlock);
+    bool ReadFromDisk(const CDiskBlockPos &pos, const blob256 &hashBlock);
 };
 
 
@@ -549,10 +549,10 @@ struct CBlockTemplate
 class CValidationInterface {
 protected:
     virtual void SyncTransaction(const CTransaction &tx, const CBlock *pblock) {};
-    virtual void EraseFromWallet(const uint256 &hash) {};
+    virtual void EraseFromWallet(const blob256 &hash) {};
     virtual void SetBestChain(const CBlockLocator &locator) {};
-    virtual void UpdatedTransaction(const uint256 &hash) {};
-    virtual void Inventory(const uint256 &hash) {};
+    virtual void UpdatedTransaction(const blob256 &hash) {};
+    virtual void Inventory(const blob256 &hash) {};
     virtual void ResendWalletTransactions() {};
     virtual void BlockChecked(const CBlock&, const CValidationState&) {};
     friend void ::RegisterValidationInterface(CValidationInterface*);

--- a/src/merkleblock.cpp
+++ b/src/merkleblock.cpp
@@ -76,7 +76,7 @@ uint256 CPartialMerkleTree::TraverseAndExtract(int height, unsigned int pos, uns
     if (nBitsUsed >= vBits.size()) {
         // overflowed the bits array - failure
         fBad = true;
-        return 0;
+        return uint256();
     }
     bool fParentOfMatch = vBits[nBitsUsed++];
     if (height==0 || !fParentOfMatch) {
@@ -84,7 +84,7 @@ uint256 CPartialMerkleTree::TraverseAndExtract(int height, unsigned int pos, uns
         if (nHashUsed >= vHash.size()) {
             // overflowed the hash array - failure
             fBad = true;
-            return 0;
+            return uint256();
         }
         const uint256 &hash = vHash[nHashUsed++];
         if (height==0 && fParentOfMatch) // in case of height 0, we have a matched txid
@@ -122,16 +122,16 @@ uint256 CPartialMerkleTree::ExtractMatches(std::vector<uint256> &vMatch) {
     vMatch.clear();
     // An empty set will not work
     if (nTransactions == 0)
-        return 0;
+        return uint256();
     // check for excessively high numbers of transactions
     if (nTransactions > MAX_BLOCK_SIZE / 60) // 60 is the lower bound for the size of a serialized CTransaction
-        return 0;
+        return uint256();
     // there can never be more hashes provided than one for every txid
     if (vHash.size() > nTransactions)
-        return 0;
+        return uint256();
     // there must be at least one bit per node in the partial tree, and at least one node per hash
     if (vBits.size() < vHash.size())
-        return 0;
+        return uint256();
     // calculate height of tree
     int nHeight = 0;
     while (CalcTreeWidth(nHeight) > 1)
@@ -141,12 +141,12 @@ uint256 CPartialMerkleTree::ExtractMatches(std::vector<uint256> &vMatch) {
     uint256 hashMerkleRoot = TraverseAndExtract(nHeight, 0, nBitsUsed, nHashUsed, vMatch);
     // verify that no problems occured during the tree traversal
     if (fBad)
-        return 0;
+        return uint256();
     // verify that all bits were consumed (except for the padding caused by serializing it as a byte sequence)
     if ((nBitsUsed+7)/8 != (vBits.size()+7)/8)
-        return 0;
+        return uint256();
     // verify that all hashes were consumed
     if (nHashUsed != vHash.size())
-        return 0;
+        return uint256();
     return hashMerkleRoot;
 }

--- a/src/merkleblock.cpp
+++ b/src/merkleblock.cpp
@@ -16,14 +16,14 @@ CMerkleBlock::CMerkleBlock(const CBlock& block, CBloomFilter& filter)
     header = block.GetBlockHeader();
 
     vector<bool> vMatch;
-    vector<uint256> vHashes;
+    vector<blob256> vHashes;
 
     vMatch.reserve(block.vtx.size());
     vHashes.reserve(block.vtx.size());
 
     for (unsigned int i = 0; i < block.vtx.size(); i++)
     {
-        const uint256& hash = block.vtx[i].GetHash();
+        const blob256& hash = block.vtx[i].GetHash();
         if (filter.IsRelevantAndUpdate(block.vtx[i]))
         {
             vMatch.push_back(true);
@@ -37,13 +37,13 @@ CMerkleBlock::CMerkleBlock(const CBlock& block, CBloomFilter& filter)
     txn = CPartialMerkleTree(vHashes, vMatch);
 }
 
-uint256 CPartialMerkleTree::CalcHash(int height, unsigned int pos, const std::vector<uint256> &vTxid) {
+blob256 CPartialMerkleTree::CalcHash(int height, unsigned int pos, const std::vector<blob256> &vTxid) {
     if (height == 0) {
         // hash at height 0 is the txids themself
         return vTxid[pos];
     } else {
         // calculate left hash
-        uint256 left = CalcHash(height-1, pos*2, vTxid), right;
+        blob256 left = CalcHash(height-1, pos*2, vTxid), right;
         // calculate right hash if not beyond the end of the array - copy left hash otherwise1
         if (pos*2+1 < CalcTreeWidth(height-1))
             right = CalcHash(height-1, pos*2+1, vTxid);
@@ -54,7 +54,7 @@ uint256 CPartialMerkleTree::CalcHash(int height, unsigned int pos, const std::ve
     }
 }
 
-void CPartialMerkleTree::TraverseAndBuild(int height, unsigned int pos, const std::vector<uint256> &vTxid, const std::vector<bool> &vMatch) {
+void CPartialMerkleTree::TraverseAndBuild(int height, unsigned int pos, const std::vector<blob256> &vTxid, const std::vector<bool> &vMatch) {
     // determine whether this node is the parent of at least one matched txid
     bool fParentOfMatch = false;
     for (unsigned int p = pos << height; p < (pos+1) << height && p < nTransactions; p++)
@@ -72,11 +72,11 @@ void CPartialMerkleTree::TraverseAndBuild(int height, unsigned int pos, const st
     }
 }
 
-uint256 CPartialMerkleTree::TraverseAndExtract(int height, unsigned int pos, unsigned int &nBitsUsed, unsigned int &nHashUsed, std::vector<uint256> &vMatch) {
+blob256 CPartialMerkleTree::TraverseAndExtract(int height, unsigned int pos, unsigned int &nBitsUsed, unsigned int &nHashUsed, std::vector<blob256> &vMatch) {
     if (nBitsUsed >= vBits.size()) {
         // overflowed the bits array - failure
         fBad = true;
-        return uint256();
+        return blob256();
     }
     bool fParentOfMatch = vBits[nBitsUsed++];
     if (height==0 || !fParentOfMatch) {
@@ -84,15 +84,15 @@ uint256 CPartialMerkleTree::TraverseAndExtract(int height, unsigned int pos, uns
         if (nHashUsed >= vHash.size()) {
             // overflowed the hash array - failure
             fBad = true;
-            return uint256();
+            return blob256();
         }
-        const uint256 &hash = vHash[nHashUsed++];
+        const blob256 &hash = vHash[nHashUsed++];
         if (height==0 && fParentOfMatch) // in case of height 0, we have a matched txid
             vMatch.push_back(hash);
         return hash;
     } else {
         // otherwise, descend into the subtrees to extract matched txids and hashes
-        uint256 left = TraverseAndExtract(height-1, pos*2, nBitsUsed, nHashUsed, vMatch), right;
+        blob256 left = TraverseAndExtract(height-1, pos*2, nBitsUsed, nHashUsed, vMatch), right;
         if (pos*2+1 < CalcTreeWidth(height-1))
             right = TraverseAndExtract(height-1, pos*2+1, nBitsUsed, nHashUsed, vMatch);
         else
@@ -102,7 +102,7 @@ uint256 CPartialMerkleTree::TraverseAndExtract(int height, unsigned int pos, uns
     }
 }
 
-CPartialMerkleTree::CPartialMerkleTree(const std::vector<uint256> &vTxid, const std::vector<bool> &vMatch) : nTransactions(vTxid.size()), fBad(false) {
+CPartialMerkleTree::CPartialMerkleTree(const std::vector<blob256> &vTxid, const std::vector<bool> &vMatch) : nTransactions(vTxid.size()), fBad(false) {
     // reset state
     vBits.clear();
     vHash.clear();
@@ -118,35 +118,35 @@ CPartialMerkleTree::CPartialMerkleTree(const std::vector<uint256> &vTxid, const 
 
 CPartialMerkleTree::CPartialMerkleTree() : nTransactions(0), fBad(true) {}
 
-uint256 CPartialMerkleTree::ExtractMatches(std::vector<uint256> &vMatch) {
+blob256 CPartialMerkleTree::ExtractMatches(std::vector<blob256> &vMatch) {
     vMatch.clear();
     // An empty set will not work
     if (nTransactions == 0)
-        return uint256();
+        return blob256();
     // check for excessively high numbers of transactions
     if (nTransactions > MAX_BLOCK_SIZE / 60) // 60 is the lower bound for the size of a serialized CTransaction
-        return uint256();
+        return blob256();
     // there can never be more hashes provided than one for every txid
     if (vHash.size() > nTransactions)
-        return uint256();
+        return blob256();
     // there must be at least one bit per node in the partial tree, and at least one node per hash
     if (vBits.size() < vHash.size())
-        return uint256();
+        return blob256();
     // calculate height of tree
     int nHeight = 0;
     while (CalcTreeWidth(nHeight) > 1)
         nHeight++;
     // traverse the partial tree
     unsigned int nBitsUsed = 0, nHashUsed = 0;
-    uint256 hashMerkleRoot = TraverseAndExtract(nHeight, 0, nBitsUsed, nHashUsed, vMatch);
+    blob256 hashMerkleRoot = TraverseAndExtract(nHeight, 0, nBitsUsed, nHashUsed, vMatch);
     // verify that no problems occured during the tree traversal
     if (fBad)
-        return uint256();
+        return blob256();
     // verify that all bits were consumed (except for the padding caused by serializing it as a byte sequence)
     if ((nBitsUsed+7)/8 != (vBits.size()+7)/8)
-        return uint256();
+        return blob256();
     // verify that all hashes were consumed
     if (nHashUsed != vHash.size())
-        return uint256();
+        return blob256();
     return hashMerkleRoot;
 }

--- a/src/merkleblock.h
+++ b/src/merkleblock.h
@@ -7,7 +7,7 @@
 #define BITCOIN_MERKLEBLOCK_H
 
 #include "serialize.h"
-#include "uint256.h"
+#include "blob256.h"
 #include "primitives/block.h"
 #include "bloom.h"
 
@@ -42,7 +42,7 @@
  * The serialization format:
  *  - uint32     total_transactions (4 bytes)
  *  - varint     number of hashes   (1-3 bytes)
- *  - uint256[]  hashes in depth-first order (<= 32*N bytes)
+ *  - blob256[]  hashes in depth-first order (<= 32*N bytes)
  *  - varint     number of bytes of flag bits (1-3 bytes)
  *  - byte[]     flag bits, packed per 8 in a byte, least significant bit first (<= 2*N-1 bits)
  * The size constraints follow from this.
@@ -57,7 +57,7 @@ protected:
     std::vector<bool> vBits;
 
     /** txids and internal hashes */
-    std::vector<uint256> vHash;
+    std::vector<blob256> vHash;
 
     /** flag set when encountering invalid data */
     bool fBad;
@@ -68,16 +68,16 @@ protected:
     }
 
     /** calculate the hash of a node in the merkle tree (at leaf level: the txid's themselves) */
-    uint256 CalcHash(int height, unsigned int pos, const std::vector<uint256> &vTxid);
+    blob256 CalcHash(int height, unsigned int pos, const std::vector<blob256> &vTxid);
 
     /** recursive function that traverses tree nodes, storing the data as bits and hashes */
-    void TraverseAndBuild(int height, unsigned int pos, const std::vector<uint256> &vTxid, const std::vector<bool> &vMatch);
+    void TraverseAndBuild(int height, unsigned int pos, const std::vector<blob256> &vTxid, const std::vector<bool> &vMatch);
 
     /**
      * recursive function that traverses tree nodes, consuming the bits and hashes produced by TraverseAndBuild.
      * it returns the hash of the respective node.
      */
-    uint256 TraverseAndExtract(int height, unsigned int pos, unsigned int &nBitsUsed, unsigned int &nHashUsed, std::vector<uint256> &vMatch);
+    blob256 TraverseAndExtract(int height, unsigned int pos, unsigned int &nBitsUsed, unsigned int &nHashUsed, std::vector<blob256> &vMatch);
 
 public:
 
@@ -105,7 +105,7 @@ public:
     }
 
     /** Construct a partial merkle tree from a list of transaction id's, and a mask that selects a subset of them */
-    CPartialMerkleTree(const std::vector<uint256> &vTxid, const std::vector<bool> &vMatch);
+    CPartialMerkleTree(const std::vector<blob256> &vTxid, const std::vector<bool> &vMatch);
 
     CPartialMerkleTree();
 
@@ -113,7 +113,7 @@ public:
      * extract the matching txid's represented by this partial merkle tree.
      * returns the merkle root, or 0 in case of failure
      */
-    uint256 ExtractMatches(std::vector<uint256> &vMatch);
+    blob256 ExtractMatches(std::vector<blob256> &vMatch);
 };
 
 
@@ -130,7 +130,7 @@ public:
 
 public:
     /** Public only for unit testing and relay testing (not relayed) */
-    std::vector<std::pair<unsigned int, uint256> > vMatchedTxn;
+    std::vector<std::pair<unsigned int, blob256> > vMatchedTxn;
 
     /**
      * Create from a CBlock, filtering transactions according to filter

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -41,7 +41,7 @@ class COrphan
 {
 public:
     const CTransaction* ptx;
-    set<uint256> setDependsOn;
+    set<blob256> setDependsOn;
     CFeeRate feeRate;
     double dPriority;
 
@@ -139,13 +139,13 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn)
 
         // Priority order to process transactions
         list<COrphan> vOrphan; // list memory doesn't move
-        map<uint256, vector<COrphan*> > mapDependers;
+        map<blob256, vector<COrphan*> > mapDependers;
         bool fPrintPriority = GetBoolArg("-printpriority", false);
 
         // This vector will be sorted into a priority queue:
         vector<TxPriority> vecPriority;
         vecPriority.reserve(mempool.mapTx.size());
-        for (map<uint256, CTxMemPoolEntry>::iterator mi = mempool.mapTx.begin();
+        for (map<blob256, CTxMemPoolEntry>::iterator mi = mempool.mapTx.begin();
              mi != mempool.mapTx.end(); ++mi)
         {
             const CTransaction& tx = mi->second.GetTx();
@@ -202,7 +202,7 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn)
             unsigned int nTxSize = ::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION);
             dPriority = tx.ComputePriority(dPriority, nTxSize);
 
-            uint256 hash = tx.GetHash();
+            blob256 hash = tx.GetHash();
             mempool.ApplyDeltas(hash, dPriority, nTotalIn);
 
             CFeeRate feeRate(nTotalIn-tx.GetValueOut(), nTxSize);
@@ -246,7 +246,7 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn)
                 continue;
 
             // Skip free transactions if we're past the minimum block size:
-            const uint256& hash = tx.GetHash();
+            const blob256& hash = tx.GetHash();
             double dPriorityDelta = 0;
             CAmount nFeeDelta = 0;
             mempool.ApplyDeltas(hash, dPriorityDelta, nFeeDelta);
@@ -343,7 +343,7 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn)
 void IncrementExtraNonce(CBlock* pblock, CBlockIndex* pindexPrev, unsigned int& nExtraNonce)
 {
     // Update nExtraNonce
-    static uint256 hashPrevBlock;
+    static blob256 hashPrevBlock;
     if (hashPrevBlock != pblock->hashPrevBlock)
     {
         nExtraNonce = 0;
@@ -373,7 +373,7 @@ int64_t nHPSTimerStart = 0;
 // nonce is 0xffff0000 or above, the block is rebuilt and nNonce starts over at
 // zero.
 //
-bool static ScanHash(const CBlockHeader *pblock, uint32_t& nNonce, uint256 *phash)
+bool static ScanHash(const CBlockHeader *pblock, uint32_t& nNonce, blob256 *phash)
 {
     // Write the first 76 bytes of the block header to a double-SHA256 state.
     CHash256 hasher;
@@ -483,7 +483,7 @@ void static BitcoinMiner(CWallet *pwallet)
             //
             int64_t nStart = GetTime();
             uint256 hashTarget = uint256().SetCompact(pblock->nBits);
-            uint256 hash;
+            blob256 hash;
             uint32_t nNonce = 0;
             uint32_t nOldNonce = 0;
             while (true) {

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -494,7 +494,7 @@ void static BitcoinMiner(CWallet *pwallet)
                 // Check if something found
                 if (fFound)
                 {
-                    if (hash <= hashTarget)
+                    if (BlobToUint256(hash) <= hashTarget)
                     {
                         // Found a solution
                         pblock->nNonce = nNonce;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1948,7 +1948,7 @@ CNode::CNode(SOCKET hSocketIn, CAddress addrIn, std::string addrNameIn, bool fIn
     nRefCount = 0;
     nSendSize = 0;
     nSendOffset = 0;
-    hashContinue = 0;
+    hashContinue = uint256();
     nStartingHeight = -1;
     fGetAddr = false;
     fRelayTxes = false;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1840,7 +1840,7 @@ bool CAddrDB::Write(const CAddrMan& addr)
     CDataStream ssPeers(SER_DISK, CLIENT_VERSION);
     ssPeers << FLATDATA(Params().MessageStart());
     ssPeers << addr;
-    uint256 hash = Hash(ssPeers.begin(), ssPeers.end());
+    blob256 hash = Hash(ssPeers.begin(), ssPeers.end());
     ssPeers << hash;
 
     // open temp output file, and associate with CAutoFile
@@ -1877,13 +1877,13 @@ bool CAddrDB::Read(CAddrMan& addr)
 
     // use file size to size memory buffer
     int fileSize = boost::filesystem::file_size(pathAddr);
-    int dataSize = fileSize - sizeof(uint256);
+    int dataSize = fileSize - sizeof(blob256);
     // Don't try to resize to a negative number if file is small
     if (dataSize < 0)
         dataSize = 0;
     vector<unsigned char> vchData;
     vchData.resize(dataSize);
-    uint256 hashIn;
+    blob256 hashIn;
 
     // read data and checksum from file
     try {
@@ -1898,7 +1898,7 @@ bool CAddrDB::Read(CAddrMan& addr)
     CDataStream ssPeers(vchData, SER_DISK, CLIENT_VERSION);
 
     // verify stored checksum matches input data
-    uint256 hashTmp = Hash(ssPeers.begin(), ssPeers.end());
+    blob256 hashTmp = Hash(ssPeers.begin(), ssPeers.end());
     if (hashIn != hashTmp)
         return error("%s : Checksum mismatch, data corrupted", __func__);
 
@@ -1948,7 +1948,7 @@ CNode::CNode(SOCKET hSocketIn, CAddress addrIn, std::string addrNameIn, bool fIn
     nRefCount = 0;
     nSendSize = 0;
     nSendOffset = 0;
-    hashContinue = uint256();
+    hashContinue = blob256();
     nStartingHeight = -1;
     fGetAddr = false;
     fRelayTxes = false;
@@ -2055,7 +2055,7 @@ void CNode::EndMessage() UNLOCK_FUNCTION(cs_vSend)
     memcpy((char*)&ssSend[CMessageHeader::MESSAGE_SIZE_OFFSET], &nSize, sizeof(nSize));
 
     // Set the checksum
-    uint256 hash = Hash(ssSend.begin() + CMessageHeader::HEADER_SIZE, ssSend.end());
+    blob256 hash = Hash(ssSend.begin() + CMessageHeader::HEADER_SIZE, ssSend.end());
     unsigned int nChecksum = 0;
     memcpy(&nChecksum, &hash, sizeof(nChecksum));
     assert(ssSend.size () >= CMessageHeader::CHECKSUM_OFFSET + sizeof(nChecksum));

--- a/src/net.h
+++ b/src/net.h
@@ -16,7 +16,7 @@
 #include "random.h"
 #include "streams.h"
 #include "sync.h"
-#include "uint256.h"
+#include "blob256.h"
 #include "utilstrencodings.h"
 
 #include <deque>
@@ -277,14 +277,14 @@ protected:
     void Fuzz(int nChance); // modifies ssSend
 
 public:
-    uint256 hashContinue;
+    blob256 hashContinue;
     int nStartingHeight;
 
     // flood relay
     std::vector<CAddress> vAddrToSend;
     mruset<CAddress> setAddrKnown;
     bool fGetAddr;
-    std::set<uint256> setKnown;
+    std::set<blob256> setKnown;
 
     // inventory based relay
     mruset<CInv> setInventoryKnown;

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -11,7 +11,7 @@
 
 #include "hash.h"
 #include "sync.h"
-#include "uint256.h"
+#include "blob256.h"
 #include "util.h"
 #include "utilstrencodings.h"
 
@@ -951,7 +951,7 @@ std::vector<unsigned char> CNetAddr::GetGroup() const
 
 uint64_t CNetAddr::GetHash() const
 {
-    uint256 hash = Hash(&ip[0], &ip[16]);
+    blob256 hash = Hash(&ip[0], &ip[16]);
     uint64_t nRet;
     memcpy(&nRet, &hash, sizeof(nRet));
     return nRet;

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -92,7 +92,7 @@ bool CheckProofOfWork(blob256 hash, unsigned int nBits)
         return error("CheckProofOfWork() : nBits below minimum work");
 
     // Check proof of work matches claimed amount
-    if (hash > bnTarget)
+    if (BlobToUint256(hash) > bnTarget)
         return error("CheckProofOfWork() : hash doesn't match nBits");
 
     return true;

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -75,7 +75,7 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHead
     return bnNew.GetCompact();
 }
 
-bool CheckProofOfWork(uint256 hash, unsigned int nBits)
+bool CheckProofOfWork(blob256 hash, unsigned int nBits)
 {
     bool fNegative;
     bool fOverflow;

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -8,8 +8,9 @@
 #include "chain.h"
 #include "chainparams.h"
 #include "primitives/block.h"
-#include "uint256.h"
+#include "blob256.h"
 #include "util.h"
+#include "uint256.h"
 
 unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock)
 {

--- a/src/pow.h
+++ b/src/pow.h
@@ -8,6 +8,7 @@
 
 #include <stdint.h>
 
+class blob256;
 class CBlockHeader;
 class CBlockIndex;
 class uint256;

--- a/src/pow.h
+++ b/src/pow.h
@@ -15,7 +15,7 @@ class uint256;
 unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock);
 
 /** Check whether a block hash satisfies the proof-of-work requirement specified by nBits */
-bool CheckProofOfWork(uint256 hash, unsigned int nBits);
+bool CheckProofOfWork(blob256 hash, unsigned int nBits);
 uint256 GetBlockProof(const CBlockIndex& block);
 
 #endif // BITCOIN_POW_H

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -74,7 +74,7 @@ uint256 CBlock::BuildMerkleTree(bool* fMutated) const
     if (fMutated) {
         *fMutated = mutated;
     }
-    return (vMerkleTree.empty() ? 0 : vMerkleTree.back());
+    return (vMerkleTree.empty() ? uint256() : vMerkleTree.back());
 }
 
 std::vector<uint256> CBlock::GetMerkleBranch(int nIndex) const
@@ -96,7 +96,7 @@ std::vector<uint256> CBlock::GetMerkleBranch(int nIndex) const
 uint256 CBlock::CheckMerkleBranch(uint256 hash, const std::vector<uint256>& vMerkleBranch, int nIndex)
 {
     if (nIndex == -1)
-        return 0;
+        return uint256();
     for (std::vector<uint256>::const_iterator it(vMerkleBranch.begin()); it != vMerkleBranch.end(); ++it)
     {
         if (nIndex & 1)

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -9,12 +9,12 @@
 #include "tinyformat.h"
 #include "utilstrencodings.h"
 
-uint256 CBlockHeader::GetHash() const
+blob256 CBlockHeader::GetHash() const
 {
     return Hash(BEGIN(nVersion), END(nNonce));
 }
 
-uint256 CBlock::BuildMerkleTree(bool* fMutated) const
+blob256 CBlock::BuildMerkleTree(bool* fMutated) const
 {
     /* WARNING! If you're reading this because you're learning about crypto
        and/or designing a new system that will use merkle trees, keep in mind
@@ -74,14 +74,14 @@ uint256 CBlock::BuildMerkleTree(bool* fMutated) const
     if (fMutated) {
         *fMutated = mutated;
     }
-    return (vMerkleTree.empty() ? uint256() : vMerkleTree.back());
+    return (vMerkleTree.empty() ? blob256() : vMerkleTree.back());
 }
 
-std::vector<uint256> CBlock::GetMerkleBranch(int nIndex) const
+std::vector<blob256> CBlock::GetMerkleBranch(int nIndex) const
 {
     if (vMerkleTree.empty())
         BuildMerkleTree();
-    std::vector<uint256> vMerkleBranch;
+    std::vector<blob256> vMerkleBranch;
     int j = 0;
     for (int nSize = vtx.size(); nSize > 1; nSize = (nSize + 1) / 2)
     {
@@ -93,11 +93,11 @@ std::vector<uint256> CBlock::GetMerkleBranch(int nIndex) const
     return vMerkleBranch;
 }
 
-uint256 CBlock::CheckMerkleBranch(uint256 hash, const std::vector<uint256>& vMerkleBranch, int nIndex)
+blob256 CBlock::CheckMerkleBranch(blob256 hash, const std::vector<blob256>& vMerkleBranch, int nIndex)
 {
     if (nIndex == -1)
-        return uint256();
-    for (std::vector<uint256>::const_iterator it(vMerkleBranch.begin()); it != vMerkleBranch.end(); ++it)
+        return blob256();
+    for (std::vector<blob256>::const_iterator it(vMerkleBranch.begin()); it != vMerkleBranch.end(); ++it)
     {
         if (nIndex & 1)
             hash = Hash(BEGIN(*it), END(*it), BEGIN(hash), END(hash));

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -53,8 +53,8 @@ public:
     void SetNull()
     {
         nVersion = CBlockHeader::CURRENT_VERSION;
-        hashPrevBlock = 0;
-        hashMerkleRoot = 0;
+        hashPrevBlock.SetNull();
+        hashMerkleRoot.SetNull();
         nTime = 0;
         nBits = 0;
         nNonce = 0;

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -8,7 +8,7 @@
 
 #include "primitives/transaction.h"
 #include "serialize.h"
-#include "uint256.h"
+#include "blob256.h"
 
 /** The maximum allowed size for a serialized block, in bytes (network rule) */
 static const unsigned int MAX_BLOCK_SIZE = 1000000;
@@ -26,8 +26,8 @@ public:
     // header
     static const int32_t CURRENT_VERSION=2;
     int32_t nVersion;
-    uint256 hashPrevBlock;
-    uint256 hashMerkleRoot;
+    blob256 hashPrevBlock;
+    blob256 hashMerkleRoot;
     uint32_t nTime;
     uint32_t nBits;
     uint32_t nNonce;
@@ -65,7 +65,7 @@ public:
         return (nBits == 0);
     }
 
-    uint256 GetHash() const;
+    blob256 GetHash() const;
 
     int64_t GetBlockTime() const
     {
@@ -81,7 +81,7 @@ public:
     std::vector<CTransaction> vtx;
 
     // memory only
-    mutable std::vector<uint256> vMerkleTree;
+    mutable std::vector<blob256> vMerkleTree;
 
     CBlock()
     {
@@ -125,10 +125,10 @@ public:
     // If non-NULL, *mutated is set to whether mutation was detected in the merkle
     // tree (a duplication of transactions in the block leading to an identical
     // merkle root).
-    uint256 BuildMerkleTree(bool* mutated = NULL) const;
+    blob256 BuildMerkleTree(bool* mutated = NULL) const;
 
-    std::vector<uint256> GetMerkleBranch(int nIndex) const;
-    static uint256 CheckMerkleBranch(uint256 hash, const std::vector<uint256>& vMerkleBranch, int nIndex);
+    std::vector<blob256> GetMerkleBranch(int nIndex) const;
+    static blob256 CheckMerkleBranch(blob256 hash, const std::vector<blob256>& vMerkleBranch, int nIndex);
     std::string ToString() const;
 };
 
@@ -139,11 +139,11 @@ public:
  */
 struct CBlockLocator
 {
-    std::vector<uint256> vHave;
+    std::vector<blob256> vHave;
 
     CBlockLocator() {}
 
-    CBlockLocator(const std::vector<uint256>& vHaveIn)
+    CBlockLocator(const std::vector<blob256>& vHaveIn)
     {
         vHave = vHaveIn;
     }

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -72,7 +72,7 @@ void CTransaction::UpdateHash() const
     *const_cast<uint256*>(&hash) = SerializeHash(*this);
 }
 
-CTransaction::CTransaction() : hash(0), nVersion(CTransaction::CURRENT_VERSION), vin(), vout(), nLockTime(0) { }
+CTransaction::CTransaction() : nVersion(CTransaction::CURRENT_VERSION), vin(), vout(), nLockTime(0) { }
 
 CTransaction::CTransaction(const CMutableTransaction &tx) : nVersion(tx.nVersion), vin(tx.vin), vout(tx.vout), nLockTime(tx.nLockTime) {
     UpdateHash();

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -21,7 +21,7 @@ CTxIn::CTxIn(COutPoint prevoutIn, CScript scriptSigIn, uint32_t nSequenceIn)
     nSequence = nSequenceIn;
 }
 
-CTxIn::CTxIn(uint256 hashPrevTx, uint32_t nOut, CScript scriptSigIn, uint32_t nSequenceIn)
+CTxIn::CTxIn(blob256 hashPrevTx, uint32_t nOut, CScript scriptSigIn, uint32_t nSequenceIn)
 {
     prevout = COutPoint(hashPrevTx, nOut);
     scriptSig = scriptSigIn;
@@ -49,7 +49,7 @@ CTxOut::CTxOut(const CAmount& nValueIn, CScript scriptPubKeyIn)
     scriptPubKey = scriptPubKeyIn;
 }
 
-uint256 CTxOut::GetHash() const
+blob256 CTxOut::GetHash() const
 {
     return SerializeHash(*this);
 }
@@ -62,14 +62,14 @@ std::string CTxOut::ToString() const
 CMutableTransaction::CMutableTransaction() : nVersion(CTransaction::CURRENT_VERSION), nLockTime(0) {}
 CMutableTransaction::CMutableTransaction(const CTransaction& tx) : nVersion(tx.nVersion), vin(tx.vin), vout(tx.vout), nLockTime(tx.nLockTime) {}
 
-uint256 CMutableTransaction::GetHash() const
+blob256 CMutableTransaction::GetHash() const
 {
     return SerializeHash(*this);
 }
 
 void CTransaction::UpdateHash() const
 {
-    *const_cast<uint256*>(&hash) = SerializeHash(*this);
+    *const_cast<blob256*>(&hash) = SerializeHash(*this);
 }
 
 CTransaction::CTransaction() : nVersion(CTransaction::CURRENT_VERSION), vin(), vout(), nLockTime(0) { }
@@ -83,7 +83,7 @@ CTransaction& CTransaction::operator=(const CTransaction &tx) {
     *const_cast<std::vector<CTxIn>*>(&vin) = tx.vin;
     *const_cast<std::vector<CTxOut>*>(&vout) = tx.vout;
     *const_cast<unsigned int*>(&nLockTime) = tx.nLockTime;
-    *const_cast<uint256*>(&hash) = tx.hash;
+    *const_cast<blob256*>(&hash) = tx.hash;
     return *this;
 }
 

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -28,8 +28,8 @@ public:
         READWRITE(FLATDATA(*this));
     }
 
-    void SetNull() { hash = 0; n = (uint32_t) -1; }
-    bool IsNull() const { return (hash == 0 && n == (uint32_t) -1); }
+    void SetNull() { hash.SetNull(); n = (uint32_t) -1; }
+    bool IsNull() const { return (hash.IsNull() && n == (uint32_t) -1); }
 
     friend bool operator<(const COutPoint& a, const COutPoint& b)
     {

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -9,17 +9,17 @@
 #include "amount.h"
 #include "script/script.h"
 #include "serialize.h"
-#include "uint256.h"
+#include "blob256.h"
 
 /** An outpoint - a combination of a transaction hash and an index n into its vout */
 class COutPoint
 {
 public:
-    uint256 hash;
+    blob256 hash;
     uint32_t n;
 
     COutPoint() { SetNull(); }
-    COutPoint(uint256 hashIn, uint32_t nIn) { hash = hashIn; n = nIn; }
+    COutPoint(blob256 hashIn, uint32_t nIn) { hash = hashIn; n = nIn; }
 
     ADD_SERIALIZE_METHODS;
 
@@ -66,7 +66,7 @@ public:
     }
 
     explicit CTxIn(COutPoint prevoutIn, CScript scriptSigIn=CScript(), uint32_t nSequenceIn=std::numeric_limits<unsigned int>::max());
-    CTxIn(uint256 hashPrevTx, uint32_t nOut, CScript scriptSigIn=CScript(), uint32_t nSequenceIn=std::numeric_limits<uint32_t>::max());
+    CTxIn(blob256 hashPrevTx, uint32_t nOut, CScript scriptSigIn=CScript(), uint32_t nSequenceIn=std::numeric_limits<uint32_t>::max());
 
     ADD_SERIALIZE_METHODS;
 
@@ -132,7 +132,7 @@ public:
         return (nValue == -1);
     }
 
-    uint256 GetHash() const;
+    blob256 GetHash() const;
 
     bool IsDust(CFeeRate minRelayTxFee) const
     {
@@ -171,7 +171,7 @@ class CTransaction
 {
 private:
     /** Memory only. */
-    const uint256 hash;
+    const blob256 hash;
     void UpdateHash() const;
 
 public:
@@ -212,7 +212,7 @@ public:
         return vin.empty() && vout.empty();
     }
 
-    const uint256& GetHash() const {
+    const blob256& GetHash() const {
         return hash;
     }
 
@@ -270,7 +270,7 @@ struct CMutableTransaction
     /** Compute the hash of this CMutableTransaction. This is computed on the
      * fly, as opposed to GetHash() in CTransaction, which uses a cached result.
      */
-    uint256 GetHash() const;
+    blob256 GetHash() const;
 };
 
 #endif // BITCOIN_PRIMITIVES_TRANSACTION_H

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -96,7 +96,7 @@ void CAddress::Init()
 CInv::CInv()
 {
     type = 0;
-    hash = 0;
+    hash.SetNull();
 }
 
 CInv::CInv(int typeIn, const uint256& hashIn)

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -99,13 +99,13 @@ CInv::CInv()
     hash.SetNull();
 }
 
-CInv::CInv(int typeIn, const uint256& hashIn)
+CInv::CInv(int typeIn, const blob256& hashIn)
 {
     type = typeIn;
     hash = hashIn;
 }
 
-CInv::CInv(const std::string& strType, const uint256& hashIn)
+CInv::CInv(const std::string& strType, const blob256& hashIn)
 {
     unsigned int i;
     for (i = 1; i < ARRAYLEN(ppszTypeName); i++)
@@ -117,7 +117,7 @@ CInv::CInv(const std::string& strType, const uint256& hashIn)
         }
     }
     if (i == ARRAYLEN(ppszTypeName))
-        throw std::out_of_range(strprintf("CInv::CInv(string, uint256) : unknown type '%s'", strType));
+        throw std::out_of_range(strprintf("CInv::CInv(string, blob256) : unknown type '%s'", strType));
     hash = hashIn;
 }
 

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -12,7 +12,7 @@
 
 #include "netbase.h"
 #include "serialize.h"
-#include "uint256.h"
+#include "blob256.h"
 #include "version.h"
 
 #include <stdint.h>
@@ -117,8 +117,8 @@ class CInv
 {
 public:
     CInv();
-    CInv(int typeIn, const uint256& hashIn);
-    CInv(const std::string& strType, const uint256& hashIn);
+    CInv(int typeIn, const blob256& hashIn);
+    CInv(const std::string& strType, const blob256& hashIn);
 
     ADD_SERIALIZE_METHODS;
 
@@ -138,7 +138,7 @@ public:
     // TODO: make private (improves encapsulation)
 public:
     int type;
-    uint256 hash;
+    blob256 hash;
 };
 
 enum {

--- a/src/pubkey.cpp
+++ b/src/pubkey.cpp
@@ -12,7 +12,7 @@
 #include "ecwrapper.h"
 #endif
 
-bool CPubKey::Verify(const uint256 &hash, const std::vector<unsigned char>& vchSig) const {
+bool CPubKey::Verify(const blob256 &hash, const std::vector<unsigned char>& vchSig) const {
     if (!IsValid())
         return false;
 #ifdef USE_SECP256K1
@@ -28,7 +28,7 @@ bool CPubKey::Verify(const uint256 &hash, const std::vector<unsigned char>& vchS
     return true;
 }
 
-bool CPubKey::RecoverCompact(const uint256 &hash, const std::vector<unsigned char>& vchSig) {
+bool CPubKey::RecoverCompact(const blob256 &hash, const std::vector<unsigned char>& vchSig) {
     if (vchSig.size() != 65)
         return false;
     int recid = (vchSig[0] - 27) & 3;

--- a/src/pubkey.h
+++ b/src/pubkey.h
@@ -27,7 +27,7 @@
 class CKeyID : public uint160
 {
 public:
-    CKeyID() : uint160(0) {}
+    CKeyID() : uint160() {}
     CKeyID(const uint160& in) : uint160(in) {}
 };
 

--- a/src/pubkey.h
+++ b/src/pubkey.h
@@ -8,7 +8,7 @@
 
 #include "hash.h"
 #include "serialize.h"
-#include "uint256.h"
+#include "blob256.h"
 
 #include <stdexcept>
 #include <vector>
@@ -24,11 +24,11 @@
  */
 
 /** A reference to a CKey: the Hash160 of its serialized public key */
-class CKeyID : public uint160
+class CKeyID : public blob160
 {
 public:
-    CKeyID() : uint160() {}
-    CKeyID(const uint160& in) : uint160(in) {}
+    CKeyID() : blob160() {}
+    CKeyID(const blob160& in) : blob160(in) {}
 };
 
 /** An encapsulated public key. */
@@ -145,7 +145,7 @@ public:
     }
 
     //! Get the 256-bit hash of this public key.
-    uint256 GetHash() const
+    blob256 GetHash() const
     {
         return Hash(vch, vch + size());
     }
@@ -173,10 +173,10 @@ public:
      * Verify a DER signature (~72 bytes).
      * If this public key is not fully valid, the return value will be false.
      */
-    bool Verify(const uint256& hash, const std::vector<unsigned char>& vchSig) const;
+    bool Verify(const blob256& hash, const std::vector<unsigned char>& vchSig) const;
 
     //! Recover a public key from a compact signature.
-    bool RecoverCompact(const uint256& hash, const std::vector<unsigned char>& vchSig);
+    bool RecoverCompact(const blob256& hash, const std::vector<unsigned char>& vchSig);
 
     //! Turn this public key into an uncompressed public key.
     bool Decompress();

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -132,7 +132,7 @@ void ClientModel::updateAlert(const QString &hash, int status)
     // Show error message notification for new alert
     if(status == CT_NEW)
     {
-        uint256 hash_256;
+        blob256 hash_256;
         hash_256.SetHex(hash.toStdString());
         CAlert alert = CAlert::getAlertByHash(hash_256);
         if(!alert.IsNull())
@@ -217,7 +217,7 @@ static void NotifyNumConnectionsChanged(ClientModel *clientmodel, int newNumConn
                               Q_ARG(int, newNumConnections));
 }
 
-static void NotifyAlertChanged(ClientModel *clientmodel, const uint256 &hash, ChangeType status)
+static void NotifyAlertChanged(ClientModel *clientmodel, const blob256 &hash, ChangeType status)
 {
     qDebug() << "NotifyAlertChanged : " + QString::fromStdString(hash.GetHex()) + " status=" + QString::number(status);
     QMetaObject::invokeMethod(clientmodel, "updateAlert", Qt::QueuedConnection,

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -490,7 +490,7 @@ void CoinControlDialog::updateLabels(WalletModel *model, QDialog* dialog)
     {
         // unselect already spent, very unlikely scenario, this could happen
         // when selected are spent elsewhere, like rpc or another computer
-        uint256 txhash = out.tx->GetHash();
+        blob256 txhash = out.tx->GetHash();
         COutPoint outpt(txhash, out.i);
         if (model->isSpent(outpt))
         {
@@ -764,7 +764,7 @@ void CoinControlDialog::updateView()
             nInputSum    += nInputSize;
 
             // transaction hash
-            uint256 txhash = out.tx->GetHash();
+            blob256 txhash = out.tx->GetHash();
             itemOutput->setText(COLUMN_TXHASH, QString::fromStdString(txhash.GetHex()));
 
             // vout index

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -212,7 +212,7 @@ void CoinControlDialog::showMenu(const QPoint &point)
         if (item->text(COLUMN_TXHASH).length() == 64) // transaction hash is 64 characters (this means its a child node, so its not a parent node in tree mode)
         {
             copyTransactionHashAction->setEnabled(true);
-            if (model->isLockedCoin(uint256(item->text(COLUMN_TXHASH).toStdString()), item->text(COLUMN_VOUT_INDEX).toUInt()))
+            if (model->isLockedCoin(blob256S(item->text(COLUMN_TXHASH).toStdString()), item->text(COLUMN_VOUT_INDEX).toUInt()))
             {
                 lockAction->setEnabled(false);
                 unlockAction->setEnabled(true);
@@ -271,7 +271,7 @@ void CoinControlDialog::lockCoin()
     if (contextMenuItem->checkState(COLUMN_CHECKBOX) == Qt::Checked)
         contextMenuItem->setCheckState(COLUMN_CHECKBOX, Qt::Unchecked);
 
-    COutPoint outpt(uint256(contextMenuItem->text(COLUMN_TXHASH).toStdString()), contextMenuItem->text(COLUMN_VOUT_INDEX).toUInt());
+    COutPoint outpt(blob256S(contextMenuItem->text(COLUMN_TXHASH).toStdString()), contextMenuItem->text(COLUMN_VOUT_INDEX).toUInt());
     model->lockCoin(outpt);
     contextMenuItem->setDisabled(true);
     contextMenuItem->setIcon(COLUMN_CHECKBOX, QIcon(":/icons/lock_closed"));
@@ -281,7 +281,7 @@ void CoinControlDialog::lockCoin()
 // context menu action: unlock coin
 void CoinControlDialog::unlockCoin()
 {
-    COutPoint outpt(uint256(contextMenuItem->text(COLUMN_TXHASH).toStdString()), contextMenuItem->text(COLUMN_VOUT_INDEX).toUInt());
+    COutPoint outpt(blob256S(contextMenuItem->text(COLUMN_TXHASH).toStdString()), contextMenuItem->text(COLUMN_VOUT_INDEX).toUInt());
     model->unlockCoin(outpt);
     contextMenuItem->setDisabled(false);
     contextMenuItem->setIcon(COLUMN_CHECKBOX, QIcon());
@@ -387,7 +387,7 @@ void CoinControlDialog::viewItemChanged(QTreeWidgetItem* item, int column)
 {
     if (column == COLUMN_CHECKBOX && item->text(COLUMN_TXHASH).length() == 64) // transaction hash is 64 characters (this means its a child node, so its not a parent node in tree mode)
     {
-        COutPoint outpt(uint256(item->text(COLUMN_TXHASH).toStdString()), item->text(COLUMN_VOUT_INDEX).toUInt());
+        COutPoint outpt(blob256S(item->text(COLUMN_TXHASH).toStdString()), item->text(COLUMN_VOUT_INDEX).toUInt());
 
         if (item->checkState(COLUMN_CHECKBOX) == Qt::Unchecked)
             coinControl->UnSelect(outpt);

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -35,7 +35,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
     CAmount nCredit = wtx.GetCredit(ISMINE_ALL);
     CAmount nDebit = wtx.GetDebit(ISMINE_ALL);
     CAmount nNet = nCredit - nDebit;
-    uint256 hash = wtx.GetHash();
+    blob256 hash = wtx.GetHash();
     std::map<std::string, std::string> mapValue = wtx.mapValue;
 
     if (nNet > 0 || wtx.IsCoinBase())
@@ -259,7 +259,7 @@ QString TransactionRecord::getTxID() const
     return formatSubTxId(hash, idx);
 }
 
-QString TransactionRecord::formatSubTxId(const uint256 &hash, int vout)
+QString TransactionRecord::formatSubTxId(const blob256 &hash, int vout)
 {
     return QString::fromStdString(hash.ToString() + strprintf("-%03d", vout));
 }

--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -6,7 +6,7 @@
 #define BITCOIN_QT_TRANSACTIONRECORD_H
 
 #include "amount.h"
-#include "uint256.h"
+#include "blob256.h"
 
 #include <QList>
 #include <QString>
@@ -87,13 +87,13 @@ public:
     {
     }
 
-    TransactionRecord(uint256 hash, qint64 time):
+    TransactionRecord(blob256 hash, qint64 time):
             hash(hash), time(time), type(Other), address(""), debit(0),
             credit(0), idx(0)
     {
     }
 
-    TransactionRecord(uint256 hash, qint64 time,
+    TransactionRecord(blob256 hash, qint64 time,
                 Type type, const std::string &address,
                 const CAmount& debit, const CAmount& credit):
             hash(hash), time(time), type(type), address(address), debit(debit), credit(credit),
@@ -108,7 +108,7 @@ public:
 
     /** @name Immutable transaction attributes
       @{*/
-    uint256 hash;
+    blob256 hash;
     qint64 time;
     Type type;
     std::string address;
@@ -129,7 +129,7 @@ public:
     QString getTxID() const;
 
     /** Format subtransaction id */
-    static QString formatSubTxId(const uint256 &hash, int vout);
+    static QString formatSubTxId(const blob256 &hash, int vout);
 
     /** Update status from core wallet tx.
      */

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -455,7 +455,7 @@ static void NotifyAddressBookChanged(WalletModel *walletmodel, CWallet *wallet,
                               Q_ARG(int, status));
 }
 
-static void NotifyTransactionChanged(WalletModel *walletmodel, CWallet *wallet, const uint256 &hash, ChangeType status)
+static void NotifyTransactionChanged(WalletModel *walletmodel, CWallet *wallet, const blob256 &hash, ChangeType status)
 {
     Q_UNUSED(wallet);
     Q_UNUSED(hash);
@@ -597,7 +597,7 @@ void WalletModel::listCoins(std::map<QString, std::vector<COutput> >& mapCoins) 
     }
 }
 
-bool WalletModel::isLockedCoin(uint256 hash, unsigned int n) const
+bool WalletModel::isLockedCoin(blob256 hash, unsigned int n) const
 {
     LOCK2(cs_main, wallet->cs_wallet);
     return wallet->IsLockedCoin(hash, n);

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -27,7 +27,7 @@ class COutPoint;
 class COutput;
 class CPubKey;
 class CWallet;
-class uint256;
+class blob256;
 
 QT_BEGIN_NAMESPACE
 class QTimer;
@@ -187,7 +187,7 @@ public:
     bool isSpent(const COutPoint& outpoint) const;
     void listCoins(std::map<QString, std::vector<COutput> >& mapCoins) const;
 
-    bool isLockedCoin(uint256 hash, unsigned int n) const;
+    bool isLockedCoin(blob256 hash, unsigned int n) const;
     void lockCoin(COutPoint& output);
     void unlockCoin(COutPoint& output);
     void listLockedCoins(std::vector<COutPoint>& vOutpts);

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -110,9 +110,9 @@ int GetRandInt(int nMax)
     return GetRand(nMax);
 }
 
-uint256 GetRandHash()
+blob256 GetRandHash()
 {
-    uint256 hash;
+    blob256 hash;
     GetRandBytes((unsigned char*)&hash, sizeof(hash));
     return hash;
 }

--- a/src/random.h
+++ b/src/random.h
@@ -6,7 +6,7 @@
 #ifndef BITCOIN_RANDOM_H
 #define BITCOIN_RANDOM_H
 
-#include "uint256.h"
+#include "blob256.h"
 
 #include <stdint.h>
 
@@ -22,7 +22,7 @@ void RandAddSeedPerfmon();
 void GetRandBytes(unsigned char* buf, int num);
 uint64_t GetRand(uint64_t nMax);
 int GetRandInt(int nMax);
-uint256 GetRandHash();
+blob256 GetRandHash();
 
 /**
  * Seed insecure_rand using the random pool.

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -177,7 +177,7 @@ static bool rest_tx(AcceptedConnection* conn,
         throw RESTERR(HTTP_BAD_REQUEST, "Invalid hash: " + hashStr);
 
     CTransaction tx;
-    uint256 hashBlock = 0;
+    uint256 hashBlock = uint256();
     if (!GetTransaction(hash, tx, hashBlock, true))
         throw RESTERR(HTTP_NOT_FOUND, hashStr + " not found");
 

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -41,7 +41,7 @@ public:
     string message;
 };
 
-extern void TxToJSON(const CTransaction& tx, const uint256 hashBlock, Object& entry);
+extern void TxToJSON(const CTransaction& tx, const blob256 hashBlock, Object& entry);
 extern Object blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool txDetails = false);
 
 static RestErr RESTERR(enum HTTPStatusCode status, string message)
@@ -80,7 +80,7 @@ static string AvailableDataFormatsString()
     return formats;
 }
 
-static bool ParseHashStr(const string& strReq, uint256& v)
+static bool ParseHashStr(const string& strReq, blob256& v)
 {
     if (!IsHex(strReq) || (strReq.size() != 64))
         return false;
@@ -99,7 +99,7 @@ static bool rest_block(AcceptedConnection* conn,
     enum RetFormat rf = ParseDataFormat(params, strReq);
 
     string hashStr = params[0];
-    uint256 hash;
+    blob256 hash;
     if (!ParseHashStr(hashStr, hash))
         throw RESTERR(HTTP_BAD_REQUEST, "Invalid hash: " + hashStr);
 
@@ -172,12 +172,12 @@ static bool rest_tx(AcceptedConnection* conn,
     enum RetFormat rf = ParseDataFormat(params, strReq);
 
     string hashStr = params[0];
-    uint256 hash;
+    blob256 hash;
     if (!ParseHashStr(hashStr, hash))
         throw RESTERR(HTTP_BAD_REQUEST, "Invalid hash: " + hashStr);
 
     CTransaction tx;
-    uint256 hashBlock = uint256();
+    blob256 hashBlock = blob256();
     if (!GetTransaction(hash, tx, hashBlock, true))
         throw RESTERR(HTTP_NOT_FOUND, hashStr + " not found");
 

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -70,7 +70,7 @@ Object blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool txDe
         if(txDetails)
         {
             Object objTx;
-            TxToJSON(tx, uint256(0), objTx);
+            TxToJSON(tx, uint256(), objTx);
             txs.push_back(objTx);
         }
         else

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -16,7 +16,7 @@
 using namespace json_spirit;
 using namespace std;
 
-extern void TxToJSON(const CTransaction& tx, const uint256 hashBlock, Object& entry);
+extern void TxToJSON(const CTransaction& tx, const blob256 hashBlock, Object& entry);
 void ScriptPubKeyToJSON(const CScript& scriptPubKey, Object& out, bool fIncludeHex);
 
 double GetDifficulty(const CBlockIndex* blockindex)
@@ -70,7 +70,7 @@ Object blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool txDe
         if(txDetails)
         {
             Object objTx;
-            TxToJSON(tx, uint256(), objTx);
+            TxToJSON(tx, blob256(), objTx);
             txs.push_back(objTx);
         }
         else
@@ -181,9 +181,9 @@ Value getrawmempool(const Array& params, bool fHelp)
     {
         LOCK(mempool.cs);
         Object o;
-        BOOST_FOREACH(const PAIRTYPE(uint256, CTxMemPoolEntry)& entry, mempool.mapTx)
+        BOOST_FOREACH(const PAIRTYPE(blob256, CTxMemPoolEntry)& entry, mempool.mapTx)
         {
-            const uint256& hash = entry.first;
+            const blob256& hash = entry.first;
             const CTxMemPoolEntry& e = entry.second;
             Object info;
             info.push_back(Pair("size", (int)e.GetTxSize()));
@@ -207,11 +207,11 @@ Value getrawmempool(const Array& params, bool fHelp)
     }
     else
     {
-        vector<uint256> vtxid;
+        vector<blob256> vtxid;
         mempool.queryHashes(vtxid);
 
         Array a;
-        BOOST_FOREACH(const uint256& hash, vtxid)
+        BOOST_FOREACH(const blob256& hash, vtxid)
             a.push_back(hash.ToString());
 
         return a;
@@ -530,9 +530,9 @@ Value getchaintips(const Array& params, bool fHelp)
        known blocks, and successively remove blocks that appear as pprev
        of another block.  */
     std::set<const CBlockIndex*, CompareBlocksByHeight> setTips;
-    BOOST_FOREACH(const PAIRTYPE(const uint256, CBlockIndex*)& item, mapBlockIndex)
+    BOOST_FOREACH(const PAIRTYPE(const blob256, CBlockIndex*)& item, mapBlockIndex)
         setTips.insert(item.second);
-    BOOST_FOREACH(const PAIRTYPE(const uint256, CBlockIndex*)& item, mapBlockIndex)
+    BOOST_FOREACH(const PAIRTYPE(const blob256, CBlockIndex*)& item, mapBlockIndex)
     {
         const CBlockIndex* pprev = item.second->pprev;
         if (pprev)

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -278,7 +278,7 @@ Value getblock(const Array& params, bool fHelp)
         );
 
     std::string strHash = params[0].get_str();
-    uint256 hash(strHash);
+    blob256 hash(blob256S(strHash));
 
     bool fVerbose = true;
     if (params.size() > 1)
@@ -383,7 +383,7 @@ Value gettxout(const Array& params, bool fHelp)
     Object ret;
 
     std::string strHash = params[0].get_str();
-    uint256 hash(strHash);
+    blob256 hash(blob256S(strHash));
     int n = params[1].get_int();
     bool fMempool = true;
     if (params.size() > 2)
@@ -619,7 +619,7 @@ Value invalidateblock(const Array& params, bool fHelp)
         );
 
     std::string strHash = params[0].get_str();
-    uint256 hash(strHash);
+    blob256 hash(blob256S(strHash));
     CValidationState state;
 
     {
@@ -658,7 +658,7 @@ Value reconsiderblock(const Array& params, bool fHelp)
         );
 
     std::string strHash = params[0].get_str();
-    uint256 hash(strHash);
+    blob256 hash(blob256S(strHash));
     CValidationState state;
 
     {

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -288,7 +288,7 @@ Value prioritisetransaction(const Array& params, bool fHelp)
             + HelpExampleRpc("prioritisetransaction", "\"txid\", 0.0, 10000")
         );
 
-    uint256 hash;
+    blob256 hash;
     hash.SetHex(params[0].get_str());
 
     CAmount nAmount = params[2].get_int64();
@@ -405,7 +405,7 @@ Value getblocktemplate(const Array& params, bool fHelp)
             if (!DecodeHexBlk(block, dataval.get_str()))
                 throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "Block decode failed");
 
-            uint256 hash = block.GetHash();
+            blob256 hash = block.GetHash();
             BlockMap::iterator mi = mapBlockIndex.find(hash);
             if (mi != mapBlockIndex.end()) {
                 CBlockIndex *pindex = mi->second;
@@ -440,7 +440,7 @@ Value getblocktemplate(const Array& params, bool fHelp)
     if (lpval.type() != null_type)
     {
         // Wait to respond until either the best block changes, OR a minute has passed and there are more transactions
-        uint256 hashWatchedChain;
+        blob256 hashWatchedChain;
         boost::system_time checktxtime;
         unsigned int nTransactionsUpdatedLastLP;
 
@@ -529,11 +529,11 @@ Value getblocktemplate(const Array& params, bool fHelp)
     static const Array aCaps = boost::assign::list_of("proposal");
 
     Array transactions;
-    map<uint256, int64_t> setTxIndex;
+    map<blob256, int64_t> setTxIndex;
     int i = 0;
     BOOST_FOREACH (CTransaction& tx, pblock->vtx)
     {
-        uint256 txHash = tx.GetHash();
+        blob256 txHash = tx.GetHash();
         setTxIndex[txHash] = i++;
 
         if (tx.IsCoinBase())
@@ -597,11 +597,11 @@ Value getblocktemplate(const Array& params, bool fHelp)
 class submitblock_StateCatcher : public CValidationInterface
 {
 public:
-    uint256 hash;
+    blob256 hash;
     bool found;
     CValidationState state;
 
-    submitblock_StateCatcher(const uint256 &hashIn) : hash(hashIn), found(false), state() {};
+    submitblock_StateCatcher(const blob256 &hashIn) : hash(hashIn), found(false), state() {};
 
 protected:
     virtual void BlockChecked(const CBlock& block, const CValidationState& stateIn) {
@@ -637,7 +637,7 @@ Value submitblock(const Array& params, bool fHelp)
     if (!DecodeHexBlk(block, params[0].get_str()))
         throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "Block decode failed");
 
-    uint256 hash = block.GetHash();
+    blob256 hash = block.GetHash();
     BlockMap::iterator mi = mapBlockIndex.find(hash);
     if (mi != mapBlockIndex.end()) {
         CBlockIndex *pindex = mi->second;

--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -89,7 +89,7 @@ void TxToJSON(const CTransaction& tx, const uint256 hashBlock, Object& entry)
     }
     entry.push_back(Pair("vout", vout));
 
-    if (hashBlock != 0) {
+    if (!hashBlock.IsNull()) {
         entry.push_back(Pair("blockhash", hashBlock.GetHex()));
         BlockMap::iterator mi = mapBlockIndex.find(hashBlock);
         if (mi != mapBlockIndex.end() && (*mi).second) {
@@ -178,7 +178,7 @@ Value getrawtransaction(const Array& params, bool fHelp)
         fVerbose = (params[1].get_int() != 0);
 
     CTransaction tx;
-    uint256 hashBlock = 0;
+    uint256 hashBlock;
     if (!GetTransaction(hash, tx, hashBlock, true))
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "No information available about transaction");
 
@@ -438,7 +438,7 @@ Value decoderawtransaction(const Array& params, bool fHelp)
         throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "TX decode failed");
 
     Object result;
-    TxToJSON(tx, 0, result);
+    TxToJSON(tx, uint256(), result);
 
     return result;
 }

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -108,18 +108,18 @@ Value ValueFromAmount(const CAmount& amount)
     return (double)amount / (double)COIN;
 }
 
-uint256 ParseHashV(const Value& v, string strName)
+blob256 ParseHashV(const Value& v, string strName)
 {
     string strHex;
     if (v.type() == str_type)
         strHex = v.get_str();
     if (!IsHex(strHex)) // Note: IsHex("") is false
         throw JSONRPCError(RPC_INVALID_PARAMETER, strName+" must be hexadecimal string (not '"+strHex+"')");
-    uint256 result;
+    blob256 result;
     result.SetHex(strHex);
     return result;
 }
-uint256 ParseHashO(const Object& o, string strKey)
+blob256 ParseHashO(const Object& o, string strKey)
 {
     return ParseHashV(find_value(o, strKey), strKey);
 }

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -8,7 +8,7 @@
 
 #include "amount.h"
 #include "rpcprotocol.h"
-#include "uint256.h"
+#include "blob256.h"
 
 #include <list>
 #include <map>
@@ -120,8 +120,8 @@ extern const CRPCTable tableRPC;
  * Utilities: convert hex-encoded Values
  * (throws error if not hex).
  */
-extern uint256 ParseHashV(const json_spirit::Value& v, std::string strName);
-extern uint256 ParseHashO(const json_spirit::Object& o, std::string strKey);
+extern blob256 ParseHashV(const json_spirit::Value& v, std::string strName);
+extern blob256 ParseHashO(const json_spirit::Object& o, std::string strKey);
 extern std::vector<unsigned char> ParseHexV(const json_spirit::Value& v, std::string strName);
 extern std::vector<unsigned char> ParseHexO(const json_spirit::Object& o, std::string strKey);
 

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -1477,7 +1477,7 @@ Value listsinceblock(const Array& params, bool fHelp)
 
     if (params.size() > 0)
     {
-        uint256 blockId = 0;
+        uint256 blockId;
 
         blockId.SetHex(params[0].get_str());
         BlockMap::iterator it = mapBlockIndex.find(blockId);
@@ -1510,7 +1510,7 @@ Value listsinceblock(const Array& params, bool fHelp)
     }
 
     CBlockIndex *pblockLast = chainActive[chainActive.Height() + 1 - target_confirms];
-    uint256 lastblock = pblockLast ? pblockLast->GetBlockHash() : 0;
+    uint256 lastblock = pblockLast ? pblockLast->GetBlockHash() : uint256();
 
     Object ret;
     ret.push_back(Pair("transactions", transactions));

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -55,10 +55,10 @@ void WalletTxToJSON(const CWalletTx& wtx, Object& entry)
         entry.push_back(Pair("blockindex", wtx.nIndex));
         entry.push_back(Pair("blocktime", mapBlockIndex[wtx.hashBlock]->GetBlockTime()));
     }
-    uint256 hash = wtx.GetHash();
+    blob256 hash = wtx.GetHash();
     entry.push_back(Pair("txid", hash.GetHex()));
     Array conflicts;
-    BOOST_FOREACH(const uint256& conflict, wtx.GetConflicts())
+    BOOST_FOREACH(const blob256& conflict, wtx.GetConflicts())
         conflicts.push_back(conflict.GetHex());
     entry.push_back(Pair("walletconflicts", conflicts));
     entry.push_back(Pair("time", wtx.GetTxTime()));
@@ -127,7 +127,7 @@ CBitcoinAddress GetAccountAddress(string strAccount, bool bForceNew=false)
     if (account.vchPubKey.IsValid())
     {
         CScript scriptPubKey = GetScriptForDestination(account.vchPubKey.GetID());
-        for (map<uint256, CWalletTx>::iterator it = pwalletMain->mapWallet.begin();
+        for (map<blob256, CWalletTx>::iterator it = pwalletMain->mapWallet.begin();
              it != pwalletMain->mapWallet.end() && account.vchPubKey.IsValid();
              ++it)
         {
@@ -523,7 +523,7 @@ Value getreceivedbyaddress(const Array& params, bool fHelp)
 
     // Tally
     CAmount nAmount = 0;
-    for (map<uint256, CWalletTx>::iterator it = pwalletMain->mapWallet.begin(); it != pwalletMain->mapWallet.end(); ++it)
+    for (map<blob256, CWalletTx>::iterator it = pwalletMain->mapWallet.begin(); it != pwalletMain->mapWallet.end(); ++it)
     {
         const CWalletTx& wtx = (*it).second;
         if (wtx.IsCoinBase() || !IsFinalTx(wtx))
@@ -572,7 +572,7 @@ Value getreceivedbyaccount(const Array& params, bool fHelp)
 
     // Tally
     CAmount nAmount = 0;
-    for (map<uint256, CWalletTx>::iterator it = pwalletMain->mapWallet.begin(); it != pwalletMain->mapWallet.end(); ++it)
+    for (map<blob256, CWalletTx>::iterator it = pwalletMain->mapWallet.begin(); it != pwalletMain->mapWallet.end(); ++it)
     {
         const CWalletTx& wtx = (*it).second;
         if (wtx.IsCoinBase() || !IsFinalTx(wtx))
@@ -596,7 +596,7 @@ CAmount GetAccountBalance(CWalletDB& walletdb, const string& strAccount, int nMi
     CAmount nBalance = 0;
 
     // Tally wallet transactions
-    for (map<uint256, CWalletTx>::iterator it = pwalletMain->mapWallet.begin(); it != pwalletMain->mapWallet.end(); ++it)
+    for (map<blob256, CWalletTx>::iterator it = pwalletMain->mapWallet.begin(); it != pwalletMain->mapWallet.end(); ++it)
     {
         const CWalletTx& wtx = (*it).second;
         if (!IsFinalTx(wtx) || wtx.GetBlocksToMaturity() > 0 || wtx.GetDepthInMainChain() < 0)
@@ -667,7 +667,7 @@ Value getbalance(const Array& params, bool fHelp)
         // (GetBalance() sums up all unspent TxOuts)
         // getbalance and getbalance '*' 0 should return the same number
         CAmount nBalance = 0;
-        for (map<uint256, CWalletTx>::iterator it = pwalletMain->mapWallet.begin(); it != pwalletMain->mapWallet.end(); ++it)
+        for (map<blob256, CWalletTx>::iterator it = pwalletMain->mapWallet.begin(); it != pwalletMain->mapWallet.end(); ++it)
         {
             const CWalletTx& wtx = (*it).second;
             if (!wtx.IsTrusted() || wtx.GetBlocksToMaturity() > 0)
@@ -961,7 +961,7 @@ struct tallyitem
 {
     CAmount nAmount;
     int nConf;
-    vector<uint256> txids;
+    vector<blob256> txids;
     bool fIsWatchonly;
     tallyitem()
     {
@@ -990,7 +990,7 @@ Value ListReceived(const Array& params, bool fByAccounts)
 
     // Tally
     map<CBitcoinAddress, tallyitem> mapTally;
-    for (map<uint256, CWalletTx>::iterator it = pwalletMain->mapWallet.begin(); it != pwalletMain->mapWallet.end(); ++it)
+    for (map<blob256, CWalletTx>::iterator it = pwalletMain->mapWallet.begin(); it != pwalletMain->mapWallet.end(); ++it)
     {
         const CWalletTx& wtx = (*it).second;
 
@@ -1060,7 +1060,7 @@ Value ListReceived(const Array& params, bool fByAccounts)
             Array transactions;
             if (it != mapTally.end())
             {
-                BOOST_FOREACH(const uint256& item, (*it).second.txids)
+                BOOST_FOREACH(const blob256& item, (*it).second.txids)
                 {
                     transactions.push_back(item.GetHex());
                 }
@@ -1397,7 +1397,7 @@ Value listaccounts(const Array& params, bool fHelp)
             mapAccountBalances[entry.second.name] = 0;
     }
 
-    for (map<uint256, CWalletTx>::iterator it = pwalletMain->mapWallet.begin(); it != pwalletMain->mapWallet.end(); ++it)
+    for (map<blob256, CWalletTx>::iterator it = pwalletMain->mapWallet.begin(); it != pwalletMain->mapWallet.end(); ++it)
     {
         const CWalletTx& wtx = (*it).second;
         CAmount nFee;
@@ -1477,7 +1477,7 @@ Value listsinceblock(const Array& params, bool fHelp)
 
     if (params.size() > 0)
     {
-        uint256 blockId;
+        blob256 blockId;
 
         blockId.SetHex(params[0].get_str());
         BlockMap::iterator it = mapBlockIndex.find(blockId);
@@ -1501,7 +1501,7 @@ Value listsinceblock(const Array& params, bool fHelp)
 
     Array transactions;
 
-    for (map<uint256, CWalletTx>::iterator it = pwalletMain->mapWallet.begin(); it != pwalletMain->mapWallet.end(); it++)
+    for (map<blob256, CWalletTx>::iterator it = pwalletMain->mapWallet.begin(); it != pwalletMain->mapWallet.end(); it++)
     {
         CWalletTx tx = (*it).second;
 
@@ -1510,7 +1510,7 @@ Value listsinceblock(const Array& params, bool fHelp)
     }
 
     CBlockIndex *pblockLast = chainActive[chainActive.Height() + 1 - target_confirms];
-    uint256 lastblock = pblockLast ? pblockLast->GetBlockHash() : uint256();
+    blob256 lastblock = pblockLast ? pblockLast->GetBlockHash() : blob256();
 
     Object ret;
     ret.push_back(Pair("transactions", transactions));
@@ -1557,7 +1557,7 @@ Value gettransaction(const Array& params, bool fHelp)
             + HelpExampleRpc("gettransaction", "\"1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d\"")
         );
 
-    uint256 hash;
+    blob256 hash;
     hash.SetHex(params[0].get_str());
 
     isminefilter filter = ISMINE_SPENDABLE;

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -1902,7 +1902,7 @@ Value lockunspent(const Array& params, bool fHelp)
         if (nOutput < 0)
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, vout must be positive");
 
-        COutPoint outpt(uint256(txid), nOutput);
+        COutPoint outpt(blob256S(txid), nOutput);
 
         if (fUnlock)
             pwalletMain->UnlockCoin(outpt);

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -1030,16 +1030,17 @@ public:
 
 uint256 SignatureHash(const CScript& scriptCode, const CTransaction& txTo, unsigned int nIn, int nHashType)
 {
+    static const uint256 one("0000000000000000000000000000000000000000000000000000000000000001");
     if (nIn >= txTo.vin.size()) {
         //  nIn out of range
-        return 1;
+        return one;
     }
 
     // Check for invalid use of SIGHASH_SINGLE
     if ((nHashType & 0x1f) == SIGHASH_SINGLE) {
         if (nIn >= txTo.vout.size()) {
             //  nOut out of range
-            return 1;
+            return one;
         }
     }
 

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -12,7 +12,7 @@
 #include "eccryptoverify.h"
 #include "pubkey.h"
 #include "script/script.h"
-#include "uint256.h"
+#include "blob256.h"
 
 using namespace std;
 
@@ -1028,7 +1028,7 @@ public:
 
 } // anon namespace
 
-uint256 SignatureHash(const CScript& scriptCode, const CTransaction& txTo, unsigned int nIn, int nHashType)
+blob256 SignatureHash(const CScript& scriptCode, const CTransaction& txTo, unsigned int nIn, int nHashType)
 {
     static const uint256 one("0000000000000000000000000000000000000000000000000000000000000001");
     if (nIn >= txTo.vin.size()) {
@@ -1053,7 +1053,7 @@ uint256 SignatureHash(const CScript& scriptCode, const CTransaction& txTo, unsig
     return ss.GetHash();
 }
 
-bool SignatureChecker::VerifySignature(const std::vector<unsigned char>& vchSig, const CPubKey& pubkey, const uint256& sighash) const
+bool SignatureChecker::VerifySignature(const std::vector<unsigned char>& vchSig, const CPubKey& pubkey, const blob256& sighash) const
 {
     return pubkey.Verify(sighash, vchSig);
 }
@@ -1071,7 +1071,7 @@ bool SignatureChecker::CheckSig(const vector<unsigned char>& vchSigIn, const vec
     int nHashType = vchSig.back();
     vchSig.pop_back();
 
-    uint256 sighash = SignatureHash(scriptCode, txTo, nIn, nHashType);
+    blob256 sighash = SignatureHash(scriptCode, txTo, nIn, nHashType);
 
     if (!VerifySignature(vchSig, pubkey, sighash))
         return false;

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -1030,7 +1030,7 @@ public:
 
 blob256 SignatureHash(const CScript& scriptCode, const CTransaction& txTo, unsigned int nIn, int nHashType)
 {
-    static const uint256 one("0000000000000000000000000000000000000000000000000000000000000001");
+    static const blob256 one(blob256S("0000000000000000000000000000000000000000000000000000000000000001"));
     if (nIn >= txTo.vin.size()) {
         //  nIn out of range
         return one;

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -15,7 +15,7 @@
 class CPubKey;
 class CScript;
 class CTransaction;
-class uint256;
+class blob256;
 
 /** Signature hash types/flags */
 enum
@@ -71,7 +71,7 @@ enum
 
 };
 
-uint256 SignatureHash(const CScript &scriptCode, const CTransaction& txTo, unsigned int nIn, int nHashType);
+blob256 SignatureHash(const CScript &scriptCode, const CTransaction& txTo, unsigned int nIn, int nHashType);
 
 class BaseSignatureChecker
 {
@@ -91,7 +91,7 @@ private:
     unsigned int nIn;
 
 protected:
-    virtual bool VerifySignature(const std::vector<unsigned char>& vchSig, const CPubKey& vchPubKey, const uint256& sighash) const;
+    virtual bool VerifySignature(const std::vector<unsigned char>& vchSig, const CPubKey& vchPubKey, const blob256& sighash) const;
 
 public:
     SignatureChecker(const CTransaction& txToIn, unsigned int nInIn) : txTo(txToIn), nIn(nInIn) {}

--- a/src/script/sigcache.cpp
+++ b/src/script/sigcache.cpp
@@ -7,7 +7,7 @@
 
 #include "pubkey.h"
 #include "random.h"
-#include "uint256.h"
+#include "blob256.h"
 #include "util.h"
 
 #include <boost/thread.hpp>
@@ -24,13 +24,13 @@ class CSignatureCache
 {
 private:
      //! sigdata_type is (signature hash, signature, public key):
-    typedef boost::tuple<uint256, std::vector<unsigned char>, CPubKey> sigdata_type;
+    typedef boost::tuple<blob256, std::vector<unsigned char>, CPubKey> sigdata_type;
     std::set< sigdata_type> setValid;
     boost::shared_mutex cs_sigcache;
 
 public:
     bool
-    Get(const uint256 &hash, const std::vector<unsigned char>& vchSig, const CPubKey& pubKey)
+    Get(const blob256 &hash, const std::vector<unsigned char>& vchSig, const CPubKey& pubKey)
     {
         boost::shared_lock<boost::shared_mutex> lock(cs_sigcache);
 
@@ -41,7 +41,7 @@ public:
         return false;
     }
 
-    void Set(const uint256 &hash, const std::vector<unsigned char>& vchSig, const CPubKey& pubKey)
+    void Set(const blob256 &hash, const std::vector<unsigned char>& vchSig, const CPubKey& pubKey)
     {
         // DoS prevention: limit cache size to less than 10MB
         // (~200 bytes per cache entry times 50,000 entries)
@@ -58,7 +58,7 @@ public:
             // foil would-be DoS attackers who might try to pre-generate
             // and re-use a set of valid signatures just-slightly-greater
             // than our cache size.
-            uint256 randomHash = GetRandHash();
+            blob256 randomHash = GetRandHash();
             std::vector<unsigned char> unused;
             std::set<sigdata_type>::iterator it =
                 setValid.lower_bound(sigdata_type(randomHash, unused, unused));
@@ -74,7 +74,7 @@ public:
 
 }
 
-bool CachingSignatureChecker::VerifySignature(const std::vector<unsigned char>& vchSig, const CPubKey& pubkey, const uint256& sighash) const
+bool CachingSignatureChecker::VerifySignature(const std::vector<unsigned char>& vchSig, const CPubKey& pubkey, const blob256& sighash) const
 {
     static CSignatureCache signatureCache;
 

--- a/src/script/sigcache.h
+++ b/src/script/sigcache.h
@@ -20,7 +20,7 @@ private:
 public:
     CachingSignatureChecker(const CTransaction& txToIn, unsigned int nInIn, bool storeIn=true) : SignatureChecker(txToIn, nInIn), store(storeIn) {}
 
-    bool VerifySignature(const std::vector<unsigned char>& vchSig, const CPubKey& vchPubKey, const uint256& sighash) const;
+    bool VerifySignature(const std::vector<unsigned char>& vchSig, const CPubKey& vchPubKey, const blob256& sighash) const;
 };
 
 #endif // BITCOIN_SCRIPT_SIGCACHE_H

--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -18,7 +18,7 @@ typedef vector<unsigned char> valtype;
 
 unsigned nMaxDatacarrierBytes = MAX_OP_RETURN_RELAY;
 
-CScriptID::CScriptID(const CScript& in) : uint160(in.size() ? Hash160(in.begin(), in.end()) : 0) {}
+CScriptID::CScriptID(const CScript& in) : uint160(in.size() ? Hash160(in.begin(), in.end()) : uint160()) {}
 
 const char* GetTxnOutputType(txnouttype t)
 {

--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -18,7 +18,7 @@ typedef vector<unsigned char> valtype;
 
 unsigned nMaxDatacarrierBytes = MAX_OP_RETURN_RELAY;
 
-CScriptID::CScriptID(const CScript& in) : uint160(in.size() ? Hash160(in.begin(), in.end()) : uint160()) {}
+CScriptID::CScriptID(const CScript& in) : blob160(in.size() ? Hash160(in.begin(), in.end()) : blob160()) {}
 
 const char* GetTxnOutputType(txnouttype t)
 {
@@ -125,7 +125,7 @@ bool Solver(const CScript& scriptPubKey, txnouttype& typeRet, vector<vector<unsi
             }
             else if (opcode2 == OP_PUBKEYHASH)
             {
-                if (vch1.size() != sizeof(uint160))
+                if (vch1.size() != sizeof(blob160))
                     break;
                 vSolutionsRet.push_back(vch1);
             }
@@ -218,12 +218,12 @@ bool ExtractDestination(const CScript& scriptPubKey, CTxDestination& addressRet)
     }
     else if (whichType == TX_PUBKEYHASH)
     {
-        addressRet = CKeyID(uint160(vSolutions[0]));
+        addressRet = CKeyID(blob160(vSolutions[0]));
         return true;
     }
     else if (whichType == TX_SCRIPTHASH)
     {
-        addressRet = CScriptID(uint160(vSolutions[0]));
+        addressRet = CScriptID(blob160(vSolutions[0]));
         return true;
     }
     // Multisig txns have more than one address...

--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -20,7 +20,7 @@ class CScript;
 class CScriptID : public uint160
 {
 public:
-    CScriptID() : uint160(0) {}
+    CScriptID() : uint160() {}
     CScriptID(const CScript& in);
     CScriptID(const uint160& in) : uint160(in) {}
 };

--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -7,7 +7,7 @@
 #define BITCOIN_SCRIPT_STANDARD_H
 
 #include "script/interpreter.h"
-#include "uint256.h"
+#include "blob256.h"
 
 #include <boost/variant.hpp>
 
@@ -17,12 +17,12 @@ class CKeyID;
 class CScript;
 
 /** A reference to a CScript: the Hash160 of its serialization (see script.h) */
-class CScriptID : public uint160
+class CScriptID : public blob160
 {
 public:
-    CScriptID() : uint160() {}
+    CScriptID() : blob160() {}
     CScriptID(const CScript& in);
-    CScriptID(const uint160& in) : uint160(in) {}
+    CScriptID(const blob160& in) : blob160(in) {}
 };
 
 static const unsigned int MAX_OP_RETURN_RELAY = 40;      //! bytes

--- a/src/test/Checkpoints_tests.cpp
+++ b/src/test/Checkpoints_tests.cpp
@@ -18,8 +18,8 @@ BOOST_AUTO_TEST_SUITE(Checkpoints_tests)
 
 BOOST_AUTO_TEST_CASE(sanity)
 {
-    uint256 p11111 = uint256("0x0000000069e244f73d78e8fd29ba2fd2ed618bd6fa2ee92559f542fdb26e7c1d");
-    uint256 p134444 = uint256("0x00000000000005b12ffd4cd315cd34ffd4a594f430ac814c91184a0d42d2b0fe");
+    blob256 p11111 = blob256S("0x0000000069e244f73d78e8fd29ba2fd2ed618bd6fa2ee92559f542fdb26e7c1d");
+    blob256 p134444 = blob256S("0x00000000000005b12ffd4cd315cd34ffd4a594f430ac814c91184a0d42d2b0fe");
     BOOST_CHECK(Checkpoints::CheckBlock(11111, p11111));
     BOOST_CHECK(Checkpoints::CheckBlock(134444, p134444));
 

--- a/src/test/Checkpoints_tests.cpp
+++ b/src/test/Checkpoints_tests.cpp
@@ -8,7 +8,7 @@
 
 #include "checkpoints.h"
 
-#include "uint256.h"
+#include "blob256.h"
 
 #include <boost/test/unit_test.hpp>
 

--- a/src/test/DoS_tests.cpp
+++ b/src/test/DoS_tests.cpp
@@ -31,8 +31,8 @@ struct COrphanTx {
     CTransaction tx;
     NodeId fromPeer;
 };
-extern std::map<uint256, COrphanTx> mapOrphanTransactions;
-extern std::map<uint256, std::set<uint256> > mapOrphanTransactionsByPrev;
+extern std::map<blob256, COrphanTx> mapOrphanTransactions;
+extern std::map<blob256, std::set<blob256> > mapOrphanTransactionsByPrev;
 
 CService ip(uint32_t i)
 {
@@ -108,7 +108,7 @@ BOOST_AUTO_TEST_CASE(DoS_bantime)
 
 CTransaction RandomOrphan()
 {
-    std::map<uint256, COrphanTx>::iterator it;
+    std::map<blob256, COrphanTx>::iterator it;
     it = mapOrphanTransactions.lower_bound(GetRandHash());
     if (it == mapOrphanTransactions.end())
         it = mapOrphanTransactions.begin();

--- a/src/test/base58_tests.cpp
+++ b/src/test/base58_tests.cpp
@@ -10,7 +10,7 @@
 
 #include "key.h"
 #include "script/script.h"
-#include "uint256.h"
+#include "blob256.h"
 #include "util.h"
 #include "utilstrencodings.h"
 
@@ -106,12 +106,12 @@ public:
     TestPayloadVisitor(std::vector<unsigned char> &exp_payload) : exp_payload(exp_payload) { }
     bool operator()(const CKeyID &id) const
     {
-        uint160 exp_key(exp_payload);
+        blob160 exp_key(exp_payload);
         return exp_key == id;
     }
     bool operator()(const CScriptID &id) const
     {
-        uint160 exp_key(exp_payload);
+        blob160 exp_key(exp_payload);
         return exp_key == id;
     }
     bool operator()(const CNoDestination &no) const
@@ -218,11 +218,11 @@ BOOST_AUTO_TEST_CASE(base58_keys_valid_gen)
             CTxDestination dest;
             if(exp_addrType == "pubkey")
             {
-                dest = CKeyID(uint160(exp_payload));
+                dest = CKeyID(blob160(exp_payload));
             }
             else if(exp_addrType == "script")
             {
-                dest = CScriptID(uint160(exp_payload));
+                dest = CScriptID(blob160(exp_payload));
             }
             else if(exp_addrType == "none")
             {

--- a/src/test/bip32_tests.cpp
+++ b/src/test/bip32_tests.cpp
@@ -6,7 +6,7 @@
 
 #include "base58.h"
 #include "key.h"
-#include "uint256.h"
+#include "blob256.h"
 #include "util.h"
 
 #include <string>

--- a/src/test/blob256_tests.cpp
+++ b/src/test/blob256_tests.cpp
@@ -1,0 +1,269 @@
+// Copyright (c) 2011-2013 The Bitcoin Core developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <boost/test/unit_test.hpp>
+#include <stdint.h>
+#include <sstream>
+#include <iomanip>
+#include <limits>
+#include <cmath>
+#include "blob256.h"
+#include "uint256.h"
+#include <string>
+#include "version.h"
+#include <stdio.h>
+
+BOOST_AUTO_TEST_SUITE(blob256_tests)
+
+const unsigned char R1Array[] =
+    "\x9c\x52\x4a\xdb\xcf\x56\x11\x12\x2b\x29\x12\x5e\x5d\x35\xd2\xd2"
+    "\x22\x81\xaa\xb5\x33\xf0\x08\x32\xd5\x56\xb1\xf9\xea\xe5\x1d\x7d";
+const char R1ArrayHex[] = "7D1DE5EAF9B156D53208F033B5AA8122D2d2355d5e12292b121156cfdb4a529c";
+const blob256 R1L = blob256(std::vector<unsigned char>(R1Array,R1Array+32));
+const blob160 R1S = blob160(std::vector<unsigned char>(R1Array,R1Array+20));
+
+const unsigned char R2Array[] =
+    "\x70\x32\x1d\x7c\x47\xa5\x6b\x40\x26\x7e\x0a\xc3\xa6\x9c\xb6\xbf"
+    "\x13\x30\x47\xa3\x19\x2d\xda\x71\x49\x13\x72\xf0\xb4\xca\x81\xd7";
+const blob256 R2L = blob256(std::vector<unsigned char>(R2Array,R2Array+32));
+const blob160 R2S = blob160(std::vector<unsigned char>(R2Array,R2Array+20));
+
+const unsigned char ZeroArray[] =
+    "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+    "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00";
+const blob256 ZeroL = blob256(std::vector<unsigned char>(ZeroArray,ZeroArray+32));
+const blob160 ZeroS = blob160(std::vector<unsigned char>(ZeroArray,ZeroArray+20));
+
+const unsigned char OneArray[] =
+    "\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+    "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00";
+const blob256 OneL = blob256(std::vector<unsigned char>(OneArray,OneArray+32));
+const blob160 OneS = blob160(std::vector<unsigned char>(OneArray,OneArray+20));
+
+const unsigned char MaxArray[] =
+    "\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff"
+    "\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff";
+const blob256 MaxL = blob256(std::vector<unsigned char>(MaxArray,MaxArray+32));
+const blob160 MaxS = blob160(std::vector<unsigned char>(MaxArray,MaxArray+20));
+
+std::string ArrayToString(const unsigned char A[], unsigned int width)
+{
+    std::stringstream Stream;
+    Stream << std::hex;
+    for (unsigned int i = 0; i < width; ++i) 
+    {
+        Stream<<std::setw(2)<<std::setfill('0')<<(unsigned int)A[width-i-1];
+    }
+    return Stream.str();
+}
+
+inline blob160 blob160S(const char *str)
+{
+    blob160 rv;
+    rv.SetHex(str);
+    return rv;
+}
+inline blob160 blob160S(const std::string& str)
+{
+    blob160 rv;
+    rv.SetHex(str);
+    return rv;
+}
+
+BOOST_AUTO_TEST_CASE( basics ) // constructors, equality, inequality
+{
+    BOOST_CHECK(1 == 0+1);
+    // constructor blob256(vector<char>):
+    BOOST_CHECK(R1L.ToString() == ArrayToString(R1Array,32));
+    BOOST_CHECK(R1S.ToString() == ArrayToString(R1Array,20));
+    BOOST_CHECK(R2L.ToString() == ArrayToString(R2Array,32));
+    BOOST_CHECK(R2S.ToString() == ArrayToString(R2Array,20));
+    BOOST_CHECK(ZeroL.ToString() == ArrayToString(ZeroArray,32));
+    BOOST_CHECK(ZeroS.ToString() == ArrayToString(ZeroArray,20));
+    BOOST_CHECK(OneL.ToString() == ArrayToString(OneArray,32));
+    BOOST_CHECK(OneS.ToString() == ArrayToString(OneArray,20));
+    BOOST_CHECK(MaxL.ToString() == ArrayToString(MaxArray,32));
+    BOOST_CHECK(MaxS.ToString() == ArrayToString(MaxArray,20));
+    BOOST_CHECK(OneL.ToString() != ArrayToString(ZeroArray,32));
+    BOOST_CHECK(OneS.ToString() != ArrayToString(ZeroArray,20));
+
+    // == and !=
+    BOOST_CHECK(R1L != R2L && R1S != R2S);
+    BOOST_CHECK(ZeroL != OneL && ZeroS != OneS);
+    BOOST_CHECK(OneL != ZeroL && OneS != ZeroS);
+    BOOST_CHECK(MaxL != ZeroL && MaxS != ZeroS);
+
+    // String Constructor and Copy Constructor
+    BOOST_CHECK(blob256S("0x"+R1L.ToString()) == R1L);
+    BOOST_CHECK(blob256S("0x"+R2L.ToString()) == R2L);
+    BOOST_CHECK(blob256S("0x"+ZeroL.ToString()) == ZeroL);
+    BOOST_CHECK(blob256S("0x"+OneL.ToString()) == OneL);
+    BOOST_CHECK(blob256S("0x"+MaxL.ToString()) == MaxL);
+    BOOST_CHECK(blob256S(R1L.ToString()) == R1L);
+    BOOST_CHECK(blob256S("   0x"+R1L.ToString()+"   ") == R1L);
+    BOOST_CHECK(blob256S("") == ZeroL);
+    BOOST_CHECK(R1L == blob256S(R1ArrayHex));
+    BOOST_CHECK(blob256(R1L) == R1L);
+    BOOST_CHECK(blob256(ZeroL) == ZeroL);
+    BOOST_CHECK(blob256(OneL) == OneL);
+
+    BOOST_CHECK(blob160S("0x"+R1S.ToString()) == R1S);
+    BOOST_CHECK(blob160S("0x"+R2S.ToString()) == R2S);
+    BOOST_CHECK(blob160S("0x"+ZeroS.ToString()) == ZeroS);
+    BOOST_CHECK(blob160S("0x"+OneS.ToString()) == OneS);
+    BOOST_CHECK(blob160S("0x"+MaxS.ToString()) == MaxS);
+    BOOST_CHECK(blob160S(R1S.ToString()) == R1S);
+    BOOST_CHECK(blob160S("   0x"+R1S.ToString()+"   ") == R1S);
+    BOOST_CHECK(blob160S("") == ZeroS);
+    BOOST_CHECK(R1S == blob160S(R1ArrayHex));
+
+    BOOST_CHECK(blob160(R1S) == R1S);
+    BOOST_CHECK(blob160(ZeroS) == ZeroS);
+    BOOST_CHECK(blob160(OneS) == OneS);
+}
+
+BOOST_AUTO_TEST_CASE( comparison ) // <= >= < >
+{
+    blob256 LastL;
+    for (int i = 255; i >= 0; --i) {
+        blob256 TmpL;
+        *(TmpL.begin() + (i>>3)) |= 1<<(7-(i&7));
+        BOOST_CHECK( LastL < TmpL );
+        LastL = TmpL;
+    }
+
+    BOOST_CHECK( ZeroL < R1L );
+    BOOST_CHECK( R2L < R1L );
+    BOOST_CHECK( ZeroL < OneL );
+    BOOST_CHECK( OneL < MaxL );
+    BOOST_CHECK( R1L < MaxL );
+    BOOST_CHECK( R2L < MaxL );
+
+    blob160 LastS;
+    for (int i = 159; i >= 0; --i) {
+        blob160 TmpS;
+        *(TmpS.begin() + (i>>3)) |= 1<<(7-(i&7));
+        BOOST_CHECK( LastS < TmpS );
+        LastS = TmpS;
+    }
+    BOOST_CHECK( ZeroS < R1S );
+    BOOST_CHECK( R2S < R1S );
+    BOOST_CHECK( ZeroS < OneS );
+    BOOST_CHECK( OneS < MaxS );
+    BOOST_CHECK( R1S < MaxS );
+    BOOST_CHECK( R2S < MaxS );
+}
+
+BOOST_AUTO_TEST_CASE( methods ) // GetHex SetHex begin() end() size() GetLow64 GetSerializeSize, Serialize, Unserialize
+{
+    BOOST_CHECK(R1L.GetHex() == R1L.ToString());
+    BOOST_CHECK(R2L.GetHex() == R2L.ToString());
+    BOOST_CHECK(OneL.GetHex() == OneL.ToString());
+    BOOST_CHECK(MaxL.GetHex() == MaxL.ToString());
+    blob256 TmpL(R1L);
+    BOOST_CHECK(TmpL == R1L);
+    TmpL.SetHex(R2L.ToString());   BOOST_CHECK(TmpL == R2L);
+    TmpL.SetHex(ZeroL.ToString()); BOOST_CHECK(TmpL == blob256());
+
+    TmpL.SetHex(R1L.ToString());
+    BOOST_CHECK(memcmp(R1L.begin(), R1Array, 32)==0);
+    BOOST_CHECK(memcmp(TmpL.begin(), R1Array, 32)==0);
+    BOOST_CHECK(memcmp(R2L.begin(), R2Array, 32)==0);
+    BOOST_CHECK(memcmp(ZeroL.begin(), ZeroArray, 32)==0);
+    BOOST_CHECK(memcmp(OneL.begin(), OneArray, 32)==0);
+    BOOST_CHECK(R1L.size() == sizeof(R1L));
+    BOOST_CHECK(sizeof(R1L) == 32);
+    BOOST_CHECK(R1L.size() == 32);
+    BOOST_CHECK(R2L.size() == 32);
+    BOOST_CHECK(ZeroL.size() == 32);
+    BOOST_CHECK(MaxL.size() == 32);
+    BOOST_CHECK(R1L.begin() + 32 == R1L.end());
+    BOOST_CHECK(R2L.begin() + 32 == R2L.end());
+    BOOST_CHECK(OneL.begin() + 32 == OneL.end());
+    BOOST_CHECK(MaxL.begin() + 32 == MaxL.end());
+    BOOST_CHECK(TmpL.begin() + 32 == TmpL.end());
+    BOOST_CHECK(R1L.GetSerializeSize(0,PROTOCOL_VERSION) == 32);
+    BOOST_CHECK(ZeroL.GetSerializeSize(0,PROTOCOL_VERSION) == 32);
+
+    std::stringstream ss;
+    R1L.Serialize(ss,0,PROTOCOL_VERSION);
+    BOOST_CHECK(ss.str() == std::string(R1Array,R1Array+32));
+    TmpL.Unserialize(ss,0,PROTOCOL_VERSION);
+    BOOST_CHECK(R1L == TmpL);
+    ss.str("");
+    ZeroL.Serialize(ss,0,PROTOCOL_VERSION);
+    BOOST_CHECK(ss.str() == std::string(ZeroArray,ZeroArray+32));
+    TmpL.Unserialize(ss,0,PROTOCOL_VERSION);
+    BOOST_CHECK(ZeroL == TmpL);
+    ss.str("");
+    MaxL.Serialize(ss,0,PROTOCOL_VERSION);
+    BOOST_CHECK(ss.str() == std::string(MaxArray,MaxArray+32));
+    TmpL.Unserialize(ss,0,PROTOCOL_VERSION);
+    BOOST_CHECK(MaxL == TmpL);
+    ss.str("");
+
+    BOOST_CHECK(R1S.GetHex() == R1S.ToString());
+    BOOST_CHECK(R2S.GetHex() == R2S.ToString());
+    BOOST_CHECK(OneS.GetHex() == OneS.ToString());
+    BOOST_CHECK(MaxS.GetHex() == MaxS.ToString());
+    blob160 TmpS(R1S);
+    BOOST_CHECK(TmpS == R1S);
+    TmpS.SetHex(R2S.ToString());   BOOST_CHECK(TmpS == R2S);
+    TmpS.SetHex(ZeroS.ToString()); BOOST_CHECK(TmpS == blob160());
+
+    TmpS.SetHex(R1S.ToString());
+    BOOST_CHECK(memcmp(R1S.begin(), R1Array, 20)==0);
+    BOOST_CHECK(memcmp(TmpS.begin(), R1Array, 20)==0);
+    BOOST_CHECK(memcmp(R2S.begin(), R2Array, 20)==0);
+    BOOST_CHECK(memcmp(ZeroS.begin(), ZeroArray, 20)==0);
+    BOOST_CHECK(memcmp(OneS.begin(), OneArray, 20)==0);
+    BOOST_CHECK(R1S.size() == sizeof(R1S));
+    BOOST_CHECK(sizeof(R1S) == 20);
+    BOOST_CHECK(R1S.size() == 20);
+    BOOST_CHECK(R2S.size() == 20);
+    BOOST_CHECK(ZeroS.size() == 20);
+    BOOST_CHECK(MaxS.size() == 20);
+    BOOST_CHECK(R1S.begin() + 20 == R1S.end());
+    BOOST_CHECK(R2S.begin() + 20 == R2S.end());
+    BOOST_CHECK(OneS.begin() + 20 == OneS.end());
+    BOOST_CHECK(MaxS.begin() + 20 == MaxS.end());
+    BOOST_CHECK(TmpS.begin() + 20 == TmpS.end());
+    BOOST_CHECK(R1S.GetSerializeSize(0,PROTOCOL_VERSION) == 20);
+    BOOST_CHECK(ZeroS.GetSerializeSize(0,PROTOCOL_VERSION) == 20);
+
+    R1S.Serialize(ss,0,PROTOCOL_VERSION);
+    BOOST_CHECK(ss.str() == std::string(R1Array,R1Array+20));
+    TmpS.Unserialize(ss,0,PROTOCOL_VERSION);
+    BOOST_CHECK(R1S == TmpS);
+    ss.str("");
+    ZeroS.Serialize(ss,0,PROTOCOL_VERSION);
+    BOOST_CHECK(ss.str() == std::string(ZeroArray,ZeroArray+20));
+    TmpS.Unserialize(ss,0,PROTOCOL_VERSION);
+    BOOST_CHECK(ZeroS == TmpS);
+    ss.str("");
+    MaxS.Serialize(ss,0,PROTOCOL_VERSION);
+    BOOST_CHECK(ss.str() == std::string(MaxArray,MaxArray+20));
+    TmpS.Unserialize(ss,0,PROTOCOL_VERSION);
+    BOOST_CHECK(MaxS == TmpS);
+    ss.str("");
+}
+
+BOOST_AUTO_TEST_CASE( conversion )
+{
+    BOOST_CHECK(UintToBlob256(BlobToUint256(ZeroL)) == ZeroL);
+    BOOST_CHECK(UintToBlob256(BlobToUint256(OneL)) == OneL);
+    BOOST_CHECK(UintToBlob256(BlobToUint256(R1L)) == R1L);
+    BOOST_CHECK(UintToBlob256(BlobToUint256(R2L)) == R2L);
+    BOOST_CHECK(BlobToUint256(ZeroL) == 0);
+    BOOST_CHECK(BlobToUint256(OneL) == 1);
+    BOOST_CHECK(UintToBlob256(0) == ZeroL);
+    BOOST_CHECK(UintToBlob256(1) == OneL);
+    BOOST_CHECK(uint256(R1L.GetHex()) == BlobToUint256(R1L));
+    BOOST_CHECK(uint256(R2L.GetHex()) == BlobToUint256(R2L));
+    BOOST_CHECK(R1L.GetHex() == BlobToUint256(R1L).GetHex());
+    BOOST_CHECK(R2L.GetHex() == BlobToUint256(R2L).GetHex());
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+

--- a/src/test/bloom_tests.cpp
+++ b/src/test/bloom_tests.cpp
@@ -10,7 +10,7 @@
 #include "merkleblock.h"
 #include "serialize.h"
 #include "streams.h"
-#include "uint256.h"
+#include "blob256.h"
 #include "util.h"
 #include "utilstrencodings.h"
 
@@ -95,7 +95,7 @@ BOOST_AUTO_TEST_CASE(bloom_create_insert_key)
 
     CBloomFilter filter(2, 0.001, 0, BLOOM_UPDATE_ALL);
     filter.insert(vchPubKey);
-    uint160 hash = pubkey.GetID();
+    blob160 hash = pubkey.GetID();
     filter.insert(vector<unsigned char>(hash.begin(), hash.end()));
 
     CDataStream stream(SER_NETWORK, PROTOCOL_VERSION);
@@ -197,7 +197,7 @@ BOOST_AUTO_TEST_CASE(merkle_block_1)
     BOOST_CHECK(merkleBlock.header.GetHash() == block.GetHash());
 
     BOOST_CHECK(merkleBlock.vMatchedTxn.size() == 1);
-    pair<unsigned int, uint256> pair = merkleBlock.vMatchedTxn[0];
+    pair<unsigned int, blob256> pair = merkleBlock.vMatchedTxn[0];
 
     BOOST_CHECK(merkleBlock.vMatchedTxn[0].second == uint256("0x74d681e0e03bafa802c8aa084379aa98d9fcd632ddc2ed9782b586ec87451f20"));
     BOOST_CHECK(merkleBlock.vMatchedTxn[0].first == 8);
@@ -242,12 +242,12 @@ BOOST_AUTO_TEST_CASE(merkle_block_2)
     BOOST_CHECK(merkleBlock.header.GetHash() == block.GetHash());
 
     BOOST_CHECK(merkleBlock.vMatchedTxn.size() == 1);
-    pair<unsigned int, uint256> pair = merkleBlock.vMatchedTxn[0];
+    pair<unsigned int, blob256> pair = merkleBlock.vMatchedTxn[0];
 
     BOOST_CHECK(merkleBlock.vMatchedTxn[0].second == uint256("0xe980fe9f792d014e73b95203dc1335c5f9ce19ac537a419e6df5b47aecb93b70"));
     BOOST_CHECK(merkleBlock.vMatchedTxn[0].first == 0);
 
-    vector<uint256> vMatched;
+    vector<blob256> vMatched;
     BOOST_CHECK(merkleBlock.txn.ExtractMatches(vMatched) == block.hashMerkleRoot);
     BOOST_CHECK(vMatched.size() == merkleBlock.vMatchedTxn.size());
     for (unsigned int i = 0; i < vMatched.size(); i++)
@@ -296,12 +296,12 @@ BOOST_AUTO_TEST_CASE(merkle_block_2_with_update_none)
     BOOST_CHECK(merkleBlock.header.GetHash() == block.GetHash());
 
     BOOST_CHECK(merkleBlock.vMatchedTxn.size() == 1);
-    pair<unsigned int, uint256> pair = merkleBlock.vMatchedTxn[0];
+    pair<unsigned int, blob256> pair = merkleBlock.vMatchedTxn[0];
 
     BOOST_CHECK(merkleBlock.vMatchedTxn[0].second == uint256("0xe980fe9f792d014e73b95203dc1335c5f9ce19ac537a419e6df5b47aecb93b70"));
     BOOST_CHECK(merkleBlock.vMatchedTxn[0].first == 0);
 
-    vector<uint256> vMatched;
+    vector<blob256> vMatched;
     BOOST_CHECK(merkleBlock.txn.ExtractMatches(vMatched) == block.hashMerkleRoot);
     BOOST_CHECK(vMatched.size() == merkleBlock.vMatchedTxn.size());
     for (unsigned int i = 0; i < vMatched.size(); i++)
@@ -351,7 +351,7 @@ BOOST_AUTO_TEST_CASE(merkle_block_3_and_serialize)
     BOOST_CHECK(merkleBlock.vMatchedTxn[0].second == uint256("0x63194f18be0af63f2c6bc9dc0f777cbefed3d9415c4af83f3ee3a3d669c00cb5"));
     BOOST_CHECK(merkleBlock.vMatchedTxn[0].first == 0);
 
-    vector<uint256> vMatched;
+    vector<blob256> vMatched;
     BOOST_CHECK(merkleBlock.txn.ExtractMatches(vMatched) == block.hashMerkleRoot);
     BOOST_CHECK(vMatched.size() == merkleBlock.vMatchedTxn.size());
     for (unsigned int i = 0; i < vMatched.size(); i++)
@@ -385,12 +385,12 @@ BOOST_AUTO_TEST_CASE(merkle_block_4)
     BOOST_CHECK(merkleBlock.header.GetHash() == block.GetHash());
 
     BOOST_CHECK(merkleBlock.vMatchedTxn.size() == 1);
-    pair<unsigned int, uint256> pair = merkleBlock.vMatchedTxn[0];
+    pair<unsigned int, blob256> pair = merkleBlock.vMatchedTxn[0];
 
     BOOST_CHECK(merkleBlock.vMatchedTxn[0].second == uint256("0x0a2a92f0bda4727d0a13eaddf4dd9ac6b5c61a1429e6b2b818f19b15df0ac154"));
     BOOST_CHECK(merkleBlock.vMatchedTxn[0].first == 6);
 
-    vector<uint256> vMatched;
+    vector<blob256> vMatched;
     BOOST_CHECK(merkleBlock.txn.ExtractMatches(vMatched) == block.hashMerkleRoot);
     BOOST_CHECK(vMatched.size() == merkleBlock.vMatchedTxn.size());
     for (unsigned int i = 0; i < vMatched.size(); i++)

--- a/src/test/bloom_tests.cpp
+++ b/src/test/bloom_tests.cpp
@@ -125,7 +125,7 @@ BOOST_AUTO_TEST_CASE(bloom_match)
     spendStream >> spendingTx;
 
     CBloomFilter filter(10, 0.000001, 0, BLOOM_UPDATE_ALL);
-    filter.insert(uint256("0xb4749f017444b051c44dfd2720e88f314ff94f3dd6d56d40ef65854fcd7fff6b"));
+    filter.insert(blob256S("0xb4749f017444b051c44dfd2720e88f314ff94f3dd6d56d40ef65854fcd7fff6b"));
     BOOST_CHECK_MESSAGE(filter.IsRelevantAndUpdate(tx), "Simple Bloom filter didn't match tx hash");
 
     filter = CBloomFilter(10, 0.000001, 0, BLOOM_UPDATE_ALL);
@@ -151,11 +151,11 @@ BOOST_AUTO_TEST_CASE(bloom_match)
     BOOST_CHECK_MESSAGE(filter.IsRelevantAndUpdate(tx), "Simple Bloom filter didn't match output address");
 
     filter = CBloomFilter(10, 0.000001, 0, BLOOM_UPDATE_ALL);
-    filter.insert(COutPoint(uint256("0x90c122d70786e899529d71dbeba91ba216982fb6ba58f3bdaab65e73b7e9260b"), 0));
+    filter.insert(COutPoint(blob256S("0x90c122d70786e899529d71dbeba91ba216982fb6ba58f3bdaab65e73b7e9260b"), 0));
     BOOST_CHECK_MESSAGE(filter.IsRelevantAndUpdate(tx), "Simple Bloom filter didn't match COutPoint");
 
     filter = CBloomFilter(10, 0.000001, 0, BLOOM_UPDATE_ALL);
-    COutPoint prevOutPoint(uint256("0x90c122d70786e899529d71dbeba91ba216982fb6ba58f3bdaab65e73b7e9260b"), 0);
+    COutPoint prevOutPoint(blob256S("0x90c122d70786e899529d71dbeba91ba216982fb6ba58f3bdaab65e73b7e9260b"), 0);
     {
         vector<unsigned char> data(32 + sizeof(unsigned int));
         memcpy(&data[0], prevOutPoint.hash.begin(), 32);
@@ -165,7 +165,7 @@ BOOST_AUTO_TEST_CASE(bloom_match)
     BOOST_CHECK_MESSAGE(filter.IsRelevantAndUpdate(tx), "Simple Bloom filter didn't match manually serialized COutPoint");
 
     filter = CBloomFilter(10, 0.000001, 0, BLOOM_UPDATE_ALL);
-    filter.insert(uint256("00000009e784f32f62ef849763d4f45b98e07ba658647343b915ff832b110436"));
+    filter.insert(blob256S("00000009e784f32f62ef849763d4f45b98e07ba658647343b915ff832b110436"));
     BOOST_CHECK_MESSAGE(!filter.IsRelevantAndUpdate(tx), "Simple Bloom filter matched random tx hash");
 
     filter = CBloomFilter(10, 0.000001, 0, BLOOM_UPDATE_ALL);
@@ -173,11 +173,11 @@ BOOST_AUTO_TEST_CASE(bloom_match)
     BOOST_CHECK_MESSAGE(!filter.IsRelevantAndUpdate(tx), "Simple Bloom filter matched random address");
 
     filter = CBloomFilter(10, 0.000001, 0, BLOOM_UPDATE_ALL);
-    filter.insert(COutPoint(uint256("0x90c122d70786e899529d71dbeba91ba216982fb6ba58f3bdaab65e73b7e9260b"), 1));
+    filter.insert(COutPoint(blob256S("0x90c122d70786e899529d71dbeba91ba216982fb6ba58f3bdaab65e73b7e9260b"), 1));
     BOOST_CHECK_MESSAGE(!filter.IsRelevantAndUpdate(tx), "Simple Bloom filter matched COutPoint for an output we didn't care about");
 
     filter = CBloomFilter(10, 0.000001, 0, BLOOM_UPDATE_ALL);
-    filter.insert(COutPoint(uint256("0x000000d70786e899529d71dbeba91ba216982fb6ba58f3bdaab65e73b7e9260b"), 0));
+    filter.insert(COutPoint(blob256S("0x000000d70786e899529d71dbeba91ba216982fb6ba58f3bdaab65e73b7e9260b"), 0));
     BOOST_CHECK_MESSAGE(!filter.IsRelevantAndUpdate(tx), "Simple Bloom filter matched COutPoint for an output we didn't care about");
 }
 
@@ -191,7 +191,7 @@ BOOST_AUTO_TEST_CASE(merkle_block_1)
 
     CBloomFilter filter(10, 0.000001, 0, BLOOM_UPDATE_ALL);
     // Match the last transaction
-    filter.insert(uint256("0x74d681e0e03bafa802c8aa084379aa98d9fcd632ddc2ed9782b586ec87451f20"));
+    filter.insert(blob256S("0x74d681e0e03bafa802c8aa084379aa98d9fcd632ddc2ed9782b586ec87451f20"));
 
     CMerkleBlock merkleBlock(block, filter);
     BOOST_CHECK(merkleBlock.header.GetHash() == block.GetHash());
@@ -199,17 +199,17 @@ BOOST_AUTO_TEST_CASE(merkle_block_1)
     BOOST_CHECK(merkleBlock.vMatchedTxn.size() == 1);
     pair<unsigned int, blob256> pair = merkleBlock.vMatchedTxn[0];
 
-    BOOST_CHECK(merkleBlock.vMatchedTxn[0].second == uint256("0x74d681e0e03bafa802c8aa084379aa98d9fcd632ddc2ed9782b586ec87451f20"));
+    BOOST_CHECK(merkleBlock.vMatchedTxn[0].second == blob256S("0x74d681e0e03bafa802c8aa084379aa98d9fcd632ddc2ed9782b586ec87451f20"));
     BOOST_CHECK(merkleBlock.vMatchedTxn[0].first == 8);
 
-    vector<uint256> vMatched;
+    vector<blob256> vMatched;
     BOOST_CHECK(merkleBlock.txn.ExtractMatches(vMatched) == block.hashMerkleRoot);
     BOOST_CHECK(vMatched.size() == merkleBlock.vMatchedTxn.size());
     for (unsigned int i = 0; i < vMatched.size(); i++)
         BOOST_CHECK(vMatched[i] == merkleBlock.vMatchedTxn[i].second);
 
     // Also match the 8th transaction
-    filter.insert(uint256("0xdd1fd2a6fc16404faf339881a90adbde7f4f728691ac62e8f168809cdfae1053"));
+    filter.insert(blob256S("0xdd1fd2a6fc16404faf339881a90adbde7f4f728691ac62e8f168809cdfae1053"));
     merkleBlock = CMerkleBlock(block, filter);
     BOOST_CHECK(merkleBlock.header.GetHash() == block.GetHash());
 
@@ -217,7 +217,7 @@ BOOST_AUTO_TEST_CASE(merkle_block_1)
 
     BOOST_CHECK(merkleBlock.vMatchedTxn[1] == pair);
 
-    BOOST_CHECK(merkleBlock.vMatchedTxn[0].second == uint256("0xdd1fd2a6fc16404faf339881a90adbde7f4f728691ac62e8f168809cdfae1053"));
+    BOOST_CHECK(merkleBlock.vMatchedTxn[0].second == blob256S("0xdd1fd2a6fc16404faf339881a90adbde7f4f728691ac62e8f168809cdfae1053"));
     BOOST_CHECK(merkleBlock.vMatchedTxn[0].first == 7);
 
     BOOST_CHECK(merkleBlock.txn.ExtractMatches(vMatched) == block.hashMerkleRoot);
@@ -236,7 +236,7 @@ BOOST_AUTO_TEST_CASE(merkle_block_2)
 
     CBloomFilter filter(10, 0.000001, 0, BLOOM_UPDATE_ALL);
     // Match the first transaction
-    filter.insert(uint256("0xe980fe9f792d014e73b95203dc1335c5f9ce19ac537a419e6df5b47aecb93b70"));
+    filter.insert(blob256S("0xe980fe9f792d014e73b95203dc1335c5f9ce19ac537a419e6df5b47aecb93b70"));
 
     CMerkleBlock merkleBlock(block, filter);
     BOOST_CHECK(merkleBlock.header.GetHash() == block.GetHash());
@@ -244,7 +244,7 @@ BOOST_AUTO_TEST_CASE(merkle_block_2)
     BOOST_CHECK(merkleBlock.vMatchedTxn.size() == 1);
     pair<unsigned int, blob256> pair = merkleBlock.vMatchedTxn[0];
 
-    BOOST_CHECK(merkleBlock.vMatchedTxn[0].second == uint256("0xe980fe9f792d014e73b95203dc1335c5f9ce19ac537a419e6df5b47aecb93b70"));
+    BOOST_CHECK(merkleBlock.vMatchedTxn[0].second == blob256S("0xe980fe9f792d014e73b95203dc1335c5f9ce19ac537a419e6df5b47aecb93b70"));
     BOOST_CHECK(merkleBlock.vMatchedTxn[0].first == 0);
 
     vector<blob256> vMatched;
@@ -265,13 +265,13 @@ BOOST_AUTO_TEST_CASE(merkle_block_2)
 
     BOOST_CHECK(pair == merkleBlock.vMatchedTxn[0]);
 
-    BOOST_CHECK(merkleBlock.vMatchedTxn[1].second == uint256("0x28204cad1d7fc1d199e8ef4fa22f182de6258a3eaafe1bbe56ebdcacd3069a5f"));
+    BOOST_CHECK(merkleBlock.vMatchedTxn[1].second == blob256S("0x28204cad1d7fc1d199e8ef4fa22f182de6258a3eaafe1bbe56ebdcacd3069a5f"));
     BOOST_CHECK(merkleBlock.vMatchedTxn[1].first == 1);
 
-    BOOST_CHECK(merkleBlock.vMatchedTxn[2].second == uint256("0x6b0f8a73a56c04b519f1883e8aafda643ba61a30bd1439969df21bea5f4e27e2"));
+    BOOST_CHECK(merkleBlock.vMatchedTxn[2].second == blob256S("0x6b0f8a73a56c04b519f1883e8aafda643ba61a30bd1439969df21bea5f4e27e2"));
     BOOST_CHECK(merkleBlock.vMatchedTxn[2].first == 2);
 
-    BOOST_CHECK(merkleBlock.vMatchedTxn[3].second == uint256("0x3c1d7e82342158e4109df2e0b6348b6e84e403d8b4046d7007663ace63cddb23"));
+    BOOST_CHECK(merkleBlock.vMatchedTxn[3].second == blob256S("0x3c1d7e82342158e4109df2e0b6348b6e84e403d8b4046d7007663ace63cddb23"));
     BOOST_CHECK(merkleBlock.vMatchedTxn[3].first == 3);
 
     BOOST_CHECK(merkleBlock.txn.ExtractMatches(vMatched) == block.hashMerkleRoot);
@@ -290,7 +290,7 @@ BOOST_AUTO_TEST_CASE(merkle_block_2_with_update_none)
 
     CBloomFilter filter(10, 0.000001, 0, BLOOM_UPDATE_NONE);
     // Match the first transaction
-    filter.insert(uint256("0xe980fe9f792d014e73b95203dc1335c5f9ce19ac537a419e6df5b47aecb93b70"));
+    filter.insert(blob256S("0xe980fe9f792d014e73b95203dc1335c5f9ce19ac537a419e6df5b47aecb93b70"));
 
     CMerkleBlock merkleBlock(block, filter);
     BOOST_CHECK(merkleBlock.header.GetHash() == block.GetHash());
@@ -298,7 +298,7 @@ BOOST_AUTO_TEST_CASE(merkle_block_2_with_update_none)
     BOOST_CHECK(merkleBlock.vMatchedTxn.size() == 1);
     pair<unsigned int, blob256> pair = merkleBlock.vMatchedTxn[0];
 
-    BOOST_CHECK(merkleBlock.vMatchedTxn[0].second == uint256("0xe980fe9f792d014e73b95203dc1335c5f9ce19ac537a419e6df5b47aecb93b70"));
+    BOOST_CHECK(merkleBlock.vMatchedTxn[0].second == blob256S("0xe980fe9f792d014e73b95203dc1335c5f9ce19ac537a419e6df5b47aecb93b70"));
     BOOST_CHECK(merkleBlock.vMatchedTxn[0].first == 0);
 
     vector<blob256> vMatched;
@@ -319,10 +319,10 @@ BOOST_AUTO_TEST_CASE(merkle_block_2_with_update_none)
 
     BOOST_CHECK(pair == merkleBlock.vMatchedTxn[0]);
 
-    BOOST_CHECK(merkleBlock.vMatchedTxn[1].second == uint256("0x28204cad1d7fc1d199e8ef4fa22f182de6258a3eaafe1bbe56ebdcacd3069a5f"));
+    BOOST_CHECK(merkleBlock.vMatchedTxn[1].second == blob256S("0x28204cad1d7fc1d199e8ef4fa22f182de6258a3eaafe1bbe56ebdcacd3069a5f"));
     BOOST_CHECK(merkleBlock.vMatchedTxn[1].first == 1);
 
-    BOOST_CHECK(merkleBlock.vMatchedTxn[2].second == uint256("0x3c1d7e82342158e4109df2e0b6348b6e84e403d8b4046d7007663ace63cddb23"));
+    BOOST_CHECK(merkleBlock.vMatchedTxn[2].second == blob256S("0x3c1d7e82342158e4109df2e0b6348b6e84e403d8b4046d7007663ace63cddb23"));
     BOOST_CHECK(merkleBlock.vMatchedTxn[2].first == 3);
 
     BOOST_CHECK(merkleBlock.txn.ExtractMatches(vMatched) == block.hashMerkleRoot);
@@ -341,14 +341,14 @@ BOOST_AUTO_TEST_CASE(merkle_block_3_and_serialize)
 
     CBloomFilter filter(10, 0.000001, 0, BLOOM_UPDATE_ALL);
     // Match the only transaction
-    filter.insert(uint256("0x63194f18be0af63f2c6bc9dc0f777cbefed3d9415c4af83f3ee3a3d669c00cb5"));
+    filter.insert(blob256S("0x63194f18be0af63f2c6bc9dc0f777cbefed3d9415c4af83f3ee3a3d669c00cb5"));
 
     CMerkleBlock merkleBlock(block, filter);
     BOOST_CHECK(merkleBlock.header.GetHash() == block.GetHash());
 
     BOOST_CHECK(merkleBlock.vMatchedTxn.size() == 1);
 
-    BOOST_CHECK(merkleBlock.vMatchedTxn[0].second == uint256("0x63194f18be0af63f2c6bc9dc0f777cbefed3d9415c4af83f3ee3a3d669c00cb5"));
+    BOOST_CHECK(merkleBlock.vMatchedTxn[0].second == blob256S("0x63194f18be0af63f2c6bc9dc0f777cbefed3d9415c4af83f3ee3a3d669c00cb5"));
     BOOST_CHECK(merkleBlock.vMatchedTxn[0].first == 0);
 
     vector<blob256> vMatched;
@@ -379,7 +379,7 @@ BOOST_AUTO_TEST_CASE(merkle_block_4)
 
     CBloomFilter filter(10, 0.000001, 0, BLOOM_UPDATE_ALL);
     // Match the last transaction
-    filter.insert(uint256("0x0a2a92f0bda4727d0a13eaddf4dd9ac6b5c61a1429e6b2b818f19b15df0ac154"));
+    filter.insert(blob256S("0x0a2a92f0bda4727d0a13eaddf4dd9ac6b5c61a1429e6b2b818f19b15df0ac154"));
 
     CMerkleBlock merkleBlock(block, filter);
     BOOST_CHECK(merkleBlock.header.GetHash() == block.GetHash());
@@ -387,7 +387,7 @@ BOOST_AUTO_TEST_CASE(merkle_block_4)
     BOOST_CHECK(merkleBlock.vMatchedTxn.size() == 1);
     pair<unsigned int, blob256> pair = merkleBlock.vMatchedTxn[0];
 
-    BOOST_CHECK(merkleBlock.vMatchedTxn[0].second == uint256("0x0a2a92f0bda4727d0a13eaddf4dd9ac6b5c61a1429e6b2b818f19b15df0ac154"));
+    BOOST_CHECK(merkleBlock.vMatchedTxn[0].second == blob256S("0x0a2a92f0bda4727d0a13eaddf4dd9ac6b5c61a1429e6b2b818f19b15df0ac154"));
     BOOST_CHECK(merkleBlock.vMatchedTxn[0].first == 6);
 
     vector<blob256> vMatched;
@@ -397,13 +397,13 @@ BOOST_AUTO_TEST_CASE(merkle_block_4)
         BOOST_CHECK(vMatched[i] == merkleBlock.vMatchedTxn[i].second);
 
     // Also match the 4th transaction
-    filter.insert(uint256("0x02981fa052f0481dbc5868f4fc2166035a10f27a03cfd2de67326471df5bc041"));
+    filter.insert(blob256S("0x02981fa052f0481dbc5868f4fc2166035a10f27a03cfd2de67326471df5bc041"));
     merkleBlock = CMerkleBlock(block, filter);
     BOOST_CHECK(merkleBlock.header.GetHash() == block.GetHash());
 
     BOOST_CHECK(merkleBlock.vMatchedTxn.size() == 2);
 
-    BOOST_CHECK(merkleBlock.vMatchedTxn[0].second == uint256("0x02981fa052f0481dbc5868f4fc2166035a10f27a03cfd2de67326471df5bc041"));
+    BOOST_CHECK(merkleBlock.vMatchedTxn[0].second == blob256S("0x02981fa052f0481dbc5868f4fc2166035a10f27a03cfd2de67326471df5bc041"));
     BOOST_CHECK(merkleBlock.vMatchedTxn[0].first == 3);
 
     BOOST_CHECK(merkleBlock.vMatchedTxn[1] == pair);
@@ -432,9 +432,9 @@ BOOST_AUTO_TEST_CASE(merkle_block_4_test_p2pubkey_only)
     BOOST_CHECK(merkleBlock.header.GetHash() == block.GetHash());
 
     // We should match the generation outpoint
-    BOOST_CHECK(filter.contains(COutPoint(uint256("0x147caa76786596590baa4e98f5d9f48b86c7765e489f7a6ff3360fe5c674360b"), 0)));
+    BOOST_CHECK(filter.contains(COutPoint(blob256S("0x147caa76786596590baa4e98f5d9f48b86c7765e489f7a6ff3360fe5c674360b"), 0)));
     // ... but not the 4th transaction's output (its not pay-2-pubkey)
-    BOOST_CHECK(!filter.contains(COutPoint(uint256("0x02981fa052f0481dbc5868f4fc2166035a10f27a03cfd2de67326471df5bc041"), 0)));
+    BOOST_CHECK(!filter.contains(COutPoint(blob256S("0x02981fa052f0481dbc5868f4fc2166035a10f27a03cfd2de67326471df5bc041"), 0)));
 }
 
 BOOST_AUTO_TEST_CASE(merkle_block_4_test_update_none)
@@ -455,8 +455,8 @@ BOOST_AUTO_TEST_CASE(merkle_block_4_test_update_none)
     BOOST_CHECK(merkleBlock.header.GetHash() == block.GetHash());
 
     // We shouldn't match any outpoints (UPDATE_NONE)
-    BOOST_CHECK(!filter.contains(COutPoint(uint256("0x147caa76786596590baa4e98f5d9f48b86c7765e489f7a6ff3360fe5c674360b"), 0)));
-    BOOST_CHECK(!filter.contains(COutPoint(uint256("0x02981fa052f0481dbc5868f4fc2166035a10f27a03cfd2de67326471df5bc041"), 0)));
+    BOOST_CHECK(!filter.contains(COutPoint(blob256S("0x147caa76786596590baa4e98f5d9f48b86c7765e489f7a6ff3360fe5c674360b"), 0)));
+    BOOST_CHECK(!filter.contains(COutPoint(blob256S("0x02981fa052f0481dbc5868f4fc2166035a10f27a03cfd2de67326471df5bc041"), 0)));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/key_tests.cpp
+++ b/src/test/key_tests.cpp
@@ -6,7 +6,7 @@
 
 #include "base58.h"
 #include "script/script.h"
-#include "uint256.h"
+#include "blob256.h"
 #include "util.h"
 #include "utilstrencodings.h"
 
@@ -31,7 +31,7 @@ static const string strAddressBad("1HV9Lc3sNHZxwj4Zk6fB38tEmBryq2cBiF");
 
 
 #ifdef KEY_TESTS_DUMPINFO
-void dumpKeyInfo(uint256 privkey)
+void dumpKeyInfo(blob256 privkey)
 {
     CKey key;
     key.resize(32);
@@ -111,7 +111,7 @@ BOOST_AUTO_TEST_CASE(key_test1)
     for (int n=0; n<16; n++)
     {
         string strMsg = strprintf("Very secret message %i: 11", n);
-        uint256 hashMsg = Hash(strMsg.begin(), strMsg.end());
+        blob256 hashMsg = Hash(strMsg.begin(), strMsg.end());
 
         // normal signatures
 
@@ -168,7 +168,7 @@ BOOST_AUTO_TEST_CASE(key_test1)
 
     std::vector<unsigned char> detsig, detsigc;
     string strMsg = "Very deterministic message";
-    uint256 hashMsg = Hash(strMsg.begin(), strMsg.end());
+    blob256 hashMsg = Hash(strMsg.begin(), strMsg.end());
     BOOST_CHECK(key1.Sign(hashMsg, detsig));
     BOOST_CHECK(key1C.Sign(hashMsg, detsigc));
     BOOST_CHECK(detsig == detsigc);

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -5,7 +5,7 @@
 #include "main.h"
 #include "miner.h"
 #include "pubkey.h"
-#include "uint256.h"
+#include "blob256.h"
 #include "util.h"
 
 #include <boost/test/unit_test.hpp>
@@ -54,7 +54,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     CBlockTemplate *pblocktemplate;
     CMutableTransaction tx,tx2;
     CScript script;
-    uint256 hash;
+    blob256 hash;
 
     LOCK(cs_main);
     Checkpoints::fEnabled = false;

--- a/src/test/multisig_tests.cpp
+++ b/src/test/multisig_tests.cpp
@@ -9,7 +9,7 @@
 #include "script/script_error.h"
 #include "script/interpreter.h"
 #include "script/sign.h"
-#include "uint256.h"
+#include "blob256.h"
 
 #ifdef ENABLE_WALLET
 #include "wallet_ismine.h"
@@ -29,7 +29,7 @@ BOOST_AUTO_TEST_SUITE(multisig_tests)
 CScript
 sign_multisig(CScript scriptPubKey, vector<CKey> keys, CTransaction transaction, int whichIn)
 {
-    uint256 hash = SignatureHash(scriptPubKey, transaction, whichIn, SIGHASH_ALL);
+    blob256 hash = SignatureHash(scriptPubKey, transaction, whichIn, SIGHASH_ALL);
 
     CScript result;
     result << OP_0; // CHECKMULTISIG bug workaround

--- a/src/test/pmt_tests.cpp
+++ b/src/test/pmt_tests.cpp
@@ -45,7 +45,7 @@ BOOST_AUTO_TEST_CASE(pmt_test1)
 
         // calculate actual merkle root and height
         uint256 merkleRoot1 = block.BuildMerkleTree();
-        std::vector<uint256> vTxid(nTx, 0);
+        std::vector<uint256> vTxid(nTx, uint256());
         for (unsigned int j=0; j<nTx; j++)
             vTxid[j] = block.vtx[j].GetHash();
         int nHeight = 1, nTx_ = nTx;
@@ -87,7 +87,7 @@ BOOST_AUTO_TEST_CASE(pmt_test1)
 
             // check that it has the same merkle root as the original, and a valid one
             BOOST_CHECK(merkleRoot1 == merkleRoot2);
-            BOOST_CHECK(merkleRoot2 != 0);
+            BOOST_CHECK(!merkleRoot2.IsNull());
 
             // check that it contains the matched transactions (in the same order!)
             BOOST_CHECK(vMatchTxid1 == vMatchTxid2);

--- a/src/test/pmt_tests.cpp
+++ b/src/test/pmt_tests.cpp
@@ -21,8 +21,7 @@ public:
     void Damage() {
         unsigned int n = rand() % vHash.size();
         int bit = rand() % 256;
-        uint256 &hash = vHash[n];
-        hash ^= ((uint256)1 << bit);
+        *(vHash[n].begin() + (bit>>3)) ^= 1<<(bit&7);
     }
 };
 

--- a/src/test/pmt_tests.cpp
+++ b/src/test/pmt_tests.cpp
@@ -5,7 +5,7 @@
 #include "merkleblock.h"
 #include "serialize.h"
 #include "streams.h"
-#include "uint256.h"
+#include "blob256.h"
 #include "version.h"
 
 #include <vector>
@@ -44,8 +44,8 @@ BOOST_AUTO_TEST_CASE(pmt_test1)
         }
 
         // calculate actual merkle root and height
-        uint256 merkleRoot1 = block.BuildMerkleTree();
-        std::vector<uint256> vTxid(nTx, uint256());
+        blob256 merkleRoot1 = block.BuildMerkleTree();
+        std::vector<blob256> vTxid(nTx, blob256());
         for (unsigned int j=0; j<nTx; j++)
             vTxid[j] = block.vtx[j].GetHash();
         int nHeight = 1, nTx_ = nTx;
@@ -58,7 +58,7 @@ BOOST_AUTO_TEST_CASE(pmt_test1)
         for (int att = 1; att < 15; att++) {
             // build random subset of txid's
             std::vector<bool> vMatch(nTx, false);
-            std::vector<uint256> vMatchTxid1;
+            std::vector<blob256> vMatchTxid1;
             for (unsigned int j=0; j<nTx; j++) {
                 bool fInclude = (rand() & ((1 << (att/2)) - 1)) == 0;
                 vMatch[j] = fInclude;
@@ -82,8 +82,8 @@ BOOST_AUTO_TEST_CASE(pmt_test1)
             ss >> pmt2;
 
             // extract merkle root and matched txids from copy
-            std::vector<uint256> vMatchTxid2;
-            uint256 merkleRoot2 = pmt2.ExtractMatches(vMatchTxid2);
+            std::vector<blob256> vMatchTxid2;
+            blob256 merkleRoot2 = pmt2.ExtractMatches(vMatchTxid2);
 
             // check that it has the same merkle root as the original, and a valid one
             BOOST_CHECK(merkleRoot1 == merkleRoot2);
@@ -96,8 +96,8 @@ BOOST_AUTO_TEST_CASE(pmt_test1)
             for (int j=0; j<4; j++) {
                 CPartialMerkleTreeTester pmt3(pmt2);
                 pmt3.Damage();
-                std::vector<uint256> vMatchTxid3;
-                uint256 merkleRoot3 = pmt3.ExtractMatches(vMatchTxid3);
+                std::vector<blob256> vMatchTxid3;
+                blob256 merkleRoot3 = pmt3.ExtractMatches(vMatchTxid3);
                 BOOST_CHECK(merkleRoot3 != merkleRoot1);
             }
         }

--- a/src/test/script_P2SH_tests.cpp
+++ b/src/test/script_P2SH_tests.cpp
@@ -210,7 +210,7 @@ BOOST_AUTO_TEST_CASE(set)
 BOOST_AUTO_TEST_CASE(is)
 {
     // Test CScript::IsPayToScriptHash()
-    uint160 dummy(0);
+    uint160 dummy;
     CScript p2sh;
     p2sh << OP_HASH160 << ToByteVector(dummy) << OP_EQUAL;
     BOOST_CHECK(p2sh.IsPayToScriptHash());

--- a/src/test/script_P2SH_tests.cpp
+++ b/src/test/script_P2SH_tests.cpp
@@ -210,7 +210,7 @@ BOOST_AUTO_TEST_CASE(set)
 BOOST_AUTO_TEST_CASE(is)
 {
     // Test CScript::IsPayToScriptHash()
-    uint160 dummy;
+    blob160 dummy;
     CScript p2sh;
     p2sh << OP_HASH160 << ToByteVector(dummy) << OP_EQUAL;
     BOOST_CHECK(p2sh.IsPayToScriptHash());

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -246,7 +246,7 @@ public:
 
     TestBuilder& PushSig(const CKey& key, int nHashType = SIGHASH_ALL, unsigned int lenR = 32, unsigned int lenS = 32)
     {
-        uint256 hash = SignatureHash(scriptPubKey, spendTx, 0, nHashType);
+        blob256 hash = SignatureHash(scriptPubKey, spendTx, 0, nHashType);
         std::vector<unsigned char> vchSig, r, s;
         uint32_t iter = 0;
         do {
@@ -629,7 +629,7 @@ BOOST_AUTO_TEST_CASE(script_PushData)
 CScript
 sign_multisig(CScript scriptPubKey, std::vector<CKey> keys, CTransaction transaction)
 {
-    uint256 hash = SignatureHash(scriptPubKey, transaction, 0, SIGHASH_ALL);
+    blob256 hash = SignatureHash(scriptPubKey, transaction, 0, SIGHASH_ALL);
 
     CScript result;
     //
@@ -824,15 +824,15 @@ BOOST_AUTO_TEST_CASE(script_combineSigs)
 
     // A couple of partially-signed versions:
     vector<unsigned char> sig1;
-    uint256 hash1 = SignatureHash(scriptPubKey, txTo, 0, SIGHASH_ALL);
+    blob256 hash1 = SignatureHash(scriptPubKey, txTo, 0, SIGHASH_ALL);
     BOOST_CHECK(keys[0].Sign(hash1, sig1));
     sig1.push_back(SIGHASH_ALL);
     vector<unsigned char> sig2;
-    uint256 hash2 = SignatureHash(scriptPubKey, txTo, 0, SIGHASH_NONE);
+    blob256 hash2 = SignatureHash(scriptPubKey, txTo, 0, SIGHASH_NONE);
     BOOST_CHECK(keys[1].Sign(hash2, sig2));
     sig2.push_back(SIGHASH_NONE);
     vector<unsigned char> sig3;
-    uint256 hash3 = SignatureHash(scriptPubKey, txTo, 0, SIGHASH_SINGLE);
+    blob256 hash3 = SignatureHash(scriptPubKey, txTo, 0, SIGHASH_SINGLE);
     BOOST_CHECK(keys[2].Sign(hash3, sig3));
     sig3.push_back(SIGHASH_SINGLE);
 

--- a/src/test/sighash_tests.cpp
+++ b/src/test/sighash_tests.cpp
@@ -24,10 +24,11 @@ extern Array read_json(const std::string& jsondata);
 // Old script.cpp SignatureHash function
 uint256 static SignatureHashOld(CScript scriptCode, const CTransaction& txTo, unsigned int nIn, int nHashType)
 {
+    static const uint256 one("0000000000000000000000000000000000000000000000000000000000000001");
     if (nIn >= txTo.vin.size())
     {
         printf("ERROR: SignatureHash() : nIn=%d out of range\n", nIn);
-        return 1;
+        return one;
     }
     CMutableTransaction txTmp(txTo);
 
@@ -58,7 +59,7 @@ uint256 static SignatureHashOld(CScript scriptCode, const CTransaction& txTo, un
         if (nOut >= txTmp.vout.size())
         {
             printf("ERROR: SignatureHash() : nOut=%d out of range\n", nOut);
-            return 1;
+            return one;
         }
         txTmp.vout.resize(nOut+1);
         for (unsigned int i = 0; i < nOut; i++)

--- a/src/test/sighash_tests.cpp
+++ b/src/test/sighash_tests.cpp
@@ -22,7 +22,7 @@ using namespace json_spirit;
 extern Array read_json(const std::string& jsondata);
 
 // Old script.cpp SignatureHash function
-uint256 static SignatureHashOld(CScript scriptCode, const CTransaction& txTo, unsigned int nIn, int nHashType)
+blob256 static SignatureHashOld(CScript scriptCode, const CTransaction& txTo, unsigned int nIn, int nHashType)
 {
     static const uint256 one("0000000000000000000000000000000000000000000000000000000000000001");
     if (nIn >= txTo.vin.size())
@@ -138,7 +138,7 @@ BOOST_AUTO_TEST_CASE(sighash_test)
         RandomScript(scriptCode);
         int nIn = insecure_rand() % txTo.vin.size();
 
-        uint256 sh, sho;
+        blob256 sh, sho;
         sho = SignatureHashOld(scriptCode, txTo, nIn, nHashType);
         sh = SignatureHash(scriptCode, txTo, nIn, nHashType);
         #if defined(PRINT_SIGHASH_JSON)
@@ -181,7 +181,7 @@ BOOST_AUTO_TEST_CASE(sighash_from_data)
 
         std::string raw_tx, raw_script, sigHashHex;
         int nIn, nHashType;
-        uint256 sh;
+        blob256 sh;
         CTransaction tx;
         CScript scriptCode = CScript();
 
@@ -193,7 +193,7 @@ BOOST_AUTO_TEST_CASE(sighash_from_data)
           nHashType = test[3].get_int();
           sigHashHex = test[4].get_str();
 
-          uint256 sh;
+          blob256 sh;
           CDataStream stream(ParseHex(raw_tx), SER_NETWORK, PROTOCOL_VERSION);
           stream >> tx;
 

--- a/src/test/sighash_tests.cpp
+++ b/src/test/sighash_tests.cpp
@@ -24,7 +24,7 @@ extern Array read_json(const std::string& jsondata);
 // Old script.cpp SignatureHash function
 blob256 static SignatureHashOld(CScript scriptCode, const CTransaction& txTo, unsigned int nIn, int nHashType)
 {
-    static const uint256 one("0000000000000000000000000000000000000000000000000000000000000001");
+    static const blob256 one(blob256S("0000000000000000000000000000000000000000000000000000000000000001"));
     if (nIn >= txTo.vin.size())
     {
         printf("ERROR: SignatureHash() : nIn=%d out of range\n", nIn);

--- a/src/test/sigopcount_tests.cpp
+++ b/src/test/sigopcount_tests.cpp
@@ -32,7 +32,7 @@ BOOST_AUTO_TEST_CASE(GetSigOpCount)
     BOOST_CHECK_EQUAL(s1.GetSigOpCount(false), 0U);
     BOOST_CHECK_EQUAL(s1.GetSigOpCount(true), 0U);
 
-    uint160 dummy(0);
+    uint160 dummy;
     s1 << OP_1 << ToByteVector(dummy) << ToByteVector(dummy) << OP_2 << OP_CHECKMULTISIG;
     BOOST_CHECK_EQUAL(s1.GetSigOpCount(true), 2U);
     s1 << OP_IF << OP_CHECKSIG << OP_ENDIF;

--- a/src/test/sigopcount_tests.cpp
+++ b/src/test/sigopcount_tests.cpp
@@ -6,7 +6,7 @@
 #include "key.h"
 #include "script/script.h"
 #include "script/standard.h"
-#include "uint256.h"
+#include "blob256.h"
 
 #include <vector>
 
@@ -32,7 +32,7 @@ BOOST_AUTO_TEST_CASE(GetSigOpCount)
     BOOST_CHECK_EQUAL(s1.GetSigOpCount(false), 0U);
     BOOST_CHECK_EQUAL(s1.GetSigOpCount(true), 0U);
 
-    uint160 dummy;
+    blob160 dummy;
     s1 << OP_1 << ToByteVector(dummy) << ToByteVector(dummy) << OP_2 << OP_CHECKMULTISIG;
     BOOST_CHECK_EQUAL(s1.GetSigOpCount(true), 2U);
     s1 << OP_IF << OP_CHECKSIG << OP_ENDIF;

--- a/src/test/skiplist_tests.cpp
+++ b/src/test/skiplist_tests.cpp
@@ -49,12 +49,12 @@ BOOST_AUTO_TEST_CASE(getlocator_test)
     std::vector<blob256> vHashMain(100000);
     std::vector<CBlockIndex> vBlocksMain(100000);
     for (unsigned int i=0; i<vBlocksMain.size(); i++) {
-        vHashMain[i] = i; // Set the hash equal to the height, so we can quickly check the distances.
+        vHashMain[i] = UintToBlob256(i); // Set the hash equal to the height, so we can quickly check the distances.
         vBlocksMain[i].nHeight = i;
         vBlocksMain[i].pprev = i ? &vBlocksMain[i - 1] : NULL;
         vBlocksMain[i].phashBlock = &vHashMain[i];
         vBlocksMain[i].BuildSkip();
-        BOOST_CHECK_EQUAL((int)vBlocksMain[i].GetBlockHash().GetLow64(), vBlocksMain[i].nHeight);
+        BOOST_CHECK_EQUAL((int)BlobToUint256(vBlocksMain[i].GetBlockHash()).GetLow64(), vBlocksMain[i].nHeight);
         BOOST_CHECK(vBlocksMain[i].pprev == NULL || vBlocksMain[i].nHeight == vBlocksMain[i].pprev->nHeight + 1);
     }
 
@@ -62,12 +62,12 @@ BOOST_AUTO_TEST_CASE(getlocator_test)
     std::vector<blob256> vHashSide(50000);
     std::vector<CBlockIndex> vBlocksSide(50000);
     for (unsigned int i=0; i<vBlocksSide.size(); i++) {
-        vHashSide[i] = i + 50000 + (uint256(1) << 128); // Add 1<<128 to the hashes, so GetLow64() still returns the height.
+        vHashSide[i] = UintToBlob256(i + 50000 + (uint256(1) << 128)); // Add 1<<128 to the hashes, so GetLow64() still returns the height.
         vBlocksSide[i].nHeight = i + 50000;
         vBlocksSide[i].pprev = i ? &vBlocksSide[i - 1] : &vBlocksMain[49999];
         vBlocksSide[i].phashBlock = &vHashSide[i];
         vBlocksSide[i].BuildSkip();
-        BOOST_CHECK_EQUAL((int)vBlocksSide[i].GetBlockHash().GetLow64(), vBlocksSide[i].nHeight);
+        BOOST_CHECK_EQUAL((int)BlobToUint256(vBlocksSide[i].GetBlockHash()).GetLow64(), vBlocksSide[i].nHeight);
         BOOST_CHECK(vBlocksSide[i].pprev == NULL || vBlocksSide[i].nHeight == vBlocksSide[i].pprev->nHeight + 1);
     }
 
@@ -87,13 +87,13 @@ BOOST_AUTO_TEST_CASE(getlocator_test)
 
         // Entries 1 through 11 (inclusive) go back one step each.
         for (unsigned int i = 1; i < 12 && i < locator.vHave.size() - 1; i++) {
-            BOOST_CHECK_EQUAL(locator.vHave[i].GetLow64(), tip->nHeight - i);
+            BOOST_CHECK_EQUAL(BlobToUint256(locator.vHave[i]).GetLow64(), tip->nHeight - i);
         }
 
         // The further ones (excluding the last one) go back with exponential steps.
         unsigned int dist = 2;
         for (unsigned int i = 12; i < locator.vHave.size() - 1; i++) {
-            BOOST_CHECK_EQUAL(locator.vHave[i - 1].GetLow64() - locator.vHave[i].GetLow64(), dist);
+            BOOST_CHECK_EQUAL(BlobToUint256(locator.vHave[i - 1]).GetLow64() - BlobToUint256(locator.vHave[i]).GetLow64(), dist);
             dist *= 2;
         }
     }

--- a/src/test/skiplist_tests.cpp
+++ b/src/test/skiplist_tests.cpp
@@ -46,7 +46,7 @@ BOOST_AUTO_TEST_CASE(skiplist_test)
 BOOST_AUTO_TEST_CASE(getlocator_test)
 {
     // Build a main chain 100000 blocks long.
-    std::vector<uint256> vHashMain(100000);
+    std::vector<blob256> vHashMain(100000);
     std::vector<CBlockIndex> vBlocksMain(100000);
     for (unsigned int i=0; i<vBlocksMain.size(); i++) {
         vHashMain[i] = i; // Set the hash equal to the height, so we can quickly check the distances.
@@ -59,7 +59,7 @@ BOOST_AUTO_TEST_CASE(getlocator_test)
     }
 
     // Build a branch that splits off at block 49999, 50000 blocks long.
-    std::vector<uint256> vHashSide(50000);
+    std::vector<blob256> vHashSide(50000);
     std::vector<CBlockIndex> vBlocksSide(50000);
     for (unsigned int i=0; i<vBlocksSide.size(); i++) {
         vHashSide[i] = i + 50000 + (uint256(1) << 128); // Add 1<<128 to the hashes, so GetLow64() still returns the height.

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -118,7 +118,7 @@ BOOST_AUTO_TEST_CASE(tx_valid)
                     break;
                 }
 
-                mapprevOutScriptPubKeys[COutPoint(uint256(vinput[0].get_str()), vinput[1].get_int())] = ParseScript(vinput[2].get_str());
+                mapprevOutScriptPubKeys[COutPoint(blob256S(vinput[0].get_str()), vinput[1].get_int())] = ParseScript(vinput[2].get_str());
             }
             if (!fValid)
             {
@@ -194,7 +194,7 @@ BOOST_AUTO_TEST_CASE(tx_invalid)
                     break;
                 }
 
-                mapprevOutScriptPubKeys[COutPoint(uint256(vinput[0].get_str()), vinput[1].get_int())] = ParseScript(vinput[2].get_str());
+                mapprevOutScriptPubKeys[COutPoint(blob256S(vinput[0].get_str()), vinput[1].get_int())] = ParseScript(vinput[2].get_str());
             }
             if (!fValid)
             {

--- a/src/test/uint256_tests.cpp
+++ b/src/test/uint256_tests.cpp
@@ -19,16 +19,13 @@ const unsigned char R1Array[] =
     "\x22\x81\xaa\xb5\x33\xf0\x08\x32\xd5\x56\xb1\xf9\xea\xe5\x1d\x7d";
 const char R1ArrayHex[] = "7D1DE5EAF9B156D53208F033B5AA8122D2d2355d5e12292b121156cfdb4a529c";
 const double R1Ldouble = 0.4887374590559308955; // R1L equals roughly R1Ldouble * 2^256
-const double R1Sdouble = 0.7096329412477836074; 
 const uint256 R1L = uint256(std::vector<unsigned char>(R1Array,R1Array+32));
-const uint160 R1S = uint160(std::vector<unsigned char>(R1Array,R1Array+20));
 const uint64_t R1LLow64 = 0x121156cfdb4a529cULL;
 
 const unsigned char R2Array[] = 
     "\x70\x32\x1d\x7c\x47\xa5\x6b\x40\x26\x7e\x0a\xc3\xa6\x9c\xb6\xbf"
     "\x13\x30\x47\xa3\x19\x2d\xda\x71\x49\x13\x72\xf0\xb4\xca\x81\xd7";
 const uint256 R2L = uint256(std::vector<unsigned char>(R2Array,R2Array+32));
-const uint160 R2S = uint160(std::vector<unsigned char>(R2Array,R2Array+20));
 
 const char R1LplusR2L[] = "549FB09FEA236A1EA3E31D4D58F1B1369288D204211CA751527CFC175767850C";
 
@@ -36,22 +33,18 @@ const unsigned char ZeroArray[] =
     "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
     "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00";
 const uint256 ZeroL = uint256(std::vector<unsigned char>(ZeroArray,ZeroArray+32));
-const uint160 ZeroS = uint160(std::vector<unsigned char>(ZeroArray,ZeroArray+20));
                              
 const unsigned char OneArray[] = 
     "\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
     "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00";
 const uint256 OneL = uint256(std::vector<unsigned char>(OneArray,OneArray+32));
-const uint160 OneS = uint160(std::vector<unsigned char>(OneArray,OneArray+20));
 
 const unsigned char MaxArray[] = 
     "\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff"
     "\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff";
 const uint256 MaxL = uint256(std::vector<unsigned char>(MaxArray,MaxArray+32));
-const uint160 MaxS = uint160(std::vector<unsigned char>(MaxArray,MaxArray+20));
 
 const uint256 HalfL = (OneL << 255);
-const uint160 HalfS = (OneS << 159);
 std::string ArrayToString(const unsigned char A[], unsigned int width)
 {
     std::stringstream Stream;
@@ -68,26 +61,19 @@ BOOST_AUTO_TEST_CASE( basics ) // constructors, equality, inequality
     BOOST_CHECK(1 == 0+1);
     // constructor uint256(vector<char>):
     BOOST_CHECK(R1L.ToString() == ArrayToString(R1Array,32));
-    BOOST_CHECK(R1S.ToString() == ArrayToString(R1Array,20));
     BOOST_CHECK(R2L.ToString() == ArrayToString(R2Array,32));
-    BOOST_CHECK(R2S.ToString() == ArrayToString(R2Array,20));
     BOOST_CHECK(ZeroL.ToString() == ArrayToString(ZeroArray,32));
-    BOOST_CHECK(ZeroS.ToString() == ArrayToString(ZeroArray,20));
     BOOST_CHECK(OneL.ToString() == ArrayToString(OneArray,32));
-    BOOST_CHECK(OneS.ToString() == ArrayToString(OneArray,20));
     BOOST_CHECK(MaxL.ToString() == ArrayToString(MaxArray,32));
-    BOOST_CHECK(MaxS.ToString() == ArrayToString(MaxArray,20));
     BOOST_CHECK(OneL.ToString() != ArrayToString(ZeroArray,32));
-    BOOST_CHECK(OneS.ToString() != ArrayToString(ZeroArray,20));
 
     // == and !=
-    BOOST_CHECK(R1L != R2L && R1S != R2S);
-    BOOST_CHECK(ZeroL != OneL && ZeroS != OneS);
-    BOOST_CHECK(OneL != ZeroL && OneS != ZeroS);
-    BOOST_CHECK(MaxL != ZeroL && MaxS != ZeroS);
-    BOOST_CHECK(~MaxL == ZeroL && ~MaxS == ZeroS);
+    BOOST_CHECK(R1L != R2L);
+    BOOST_CHECK(ZeroL != OneL);
+    BOOST_CHECK(OneL != ZeroL);
+    BOOST_CHECK(MaxL != ZeroL);
+    BOOST_CHECK(~MaxL == ZeroL);
     BOOST_CHECK( ((R1L ^ R2L) ^ R1L) == R2L);
-    BOOST_CHECK( ((R1S ^ R2S) ^ R1S) == R2S);
     
     uint64_t Tmp64 = 0xc4dab720d9c7acaaULL;
     for (unsigned int i = 0; i < 256; ++i) 
@@ -98,15 +84,6 @@ BOOST_AUTO_TEST_CASE( basics ) // constructors, equality, inequality
         BOOST_CHECK(((uint256(Tmp64) ^ (OneL << i) ) != Tmp64 ));
     }
     BOOST_CHECK(ZeroL == (OneL << 256)); 
-
-    for (unsigned int i = 0; i < 160; ++i) 
-    {
-        BOOST_CHECK(ZeroS != (OneS << i)); 
-        BOOST_CHECK((OneS << i) != ZeroS); 
-        BOOST_CHECK(R1S != (R1S ^ (OneS << i)));
-        BOOST_CHECK(((uint160(Tmp64) ^ (OneS << i) ) != Tmp64 ));
-    }
-    BOOST_CHECK(ZeroS == (OneS << 256)); 
 
     // String Constructor and Copy Constructor
     BOOST_CHECK(uint256("0x"+R1L.ToString()) == R1L);
@@ -123,30 +100,11 @@ BOOST_AUTO_TEST_CASE( basics ) // constructors, equality, inequality
     BOOST_CHECK(uint256(ZeroL) == ZeroL);
     BOOST_CHECK(uint256(OneL) == OneL);
 
-    BOOST_CHECK(uint160("0x"+R1S.ToString()) == R1S);
-    BOOST_CHECK(uint160("0x"+R2S.ToString()) == R2S);
-    BOOST_CHECK(uint160("0x"+ZeroS.ToString()) == ZeroS);
-    BOOST_CHECK(uint160("0x"+OneS.ToString()) == OneS);
-    BOOST_CHECK(uint160("0x"+MaxS.ToString()) == MaxS);
-    BOOST_CHECK(uint160(R1S.ToString()) == R1S);
-    BOOST_CHECK(uint160("   0x"+R1S.ToString()+"   ") == R1S); 
-    BOOST_CHECK(uint160("") == ZeroS);
-    BOOST_CHECK(R1S == uint160(R1ArrayHex));
-
-    BOOST_CHECK(uint160(R1S) == R1S);
-    BOOST_CHECK((uint160(R1S^R2S)^R2S) == R1S);
-    BOOST_CHECK(uint160(ZeroS) == ZeroS);
-    BOOST_CHECK(uint160(OneS) == OneS);
-
     // uint64_t constructor
     BOOST_CHECK( (R1L & uint256("0xffffffffffffffff")) == uint256(R1LLow64));
     BOOST_CHECK(ZeroL == uint256(0));
     BOOST_CHECK(OneL == uint256(1));
     BOOST_CHECK(uint256("0xffffffffffffffff") = uint256(0xffffffffffffffffULL));
-    BOOST_CHECK( (R1S & uint160("0xffffffffffffffff")) == uint160(R1LLow64));
-    BOOST_CHECK(ZeroS == uint160(0));
-    BOOST_CHECK(OneS == uint160(1));
-    BOOST_CHECK(uint160("0xffffffffffffffff") = uint160(0xffffffffffffffffULL));
 
     // Assignment (from base_uint)
     uint256 tmpL = ~ZeroL; BOOST_CHECK(tmpL == ~ZeroL);
@@ -154,17 +112,10 @@ BOOST_AUTO_TEST_CASE( basics ) // constructors, equality, inequality
     tmpL = ~R1L; BOOST_CHECK(tmpL == ~R1L);
     tmpL = ~R2L; BOOST_CHECK(tmpL == ~R2L);
     tmpL = ~MaxL; BOOST_CHECK(tmpL == ~MaxL);
-    uint160 tmpS = ~ZeroS; BOOST_CHECK(tmpS == ~ZeroS);
-    tmpS = ~OneS; BOOST_CHECK(tmpS == ~OneS);
-    tmpS = ~R1S; BOOST_CHECK(tmpS == ~R1S);
-    tmpS = ~R2S; BOOST_CHECK(tmpS == ~R2S);
-    tmpS = ~MaxS; BOOST_CHECK(tmpS == ~MaxS);
 
     // Wrong length must throw exception.
     BOOST_CHECK_THROW(uint256(std::vector<unsigned char>(OneArray,OneArray+31)), uint_error);
     BOOST_CHECK_THROW(uint256(std::vector<unsigned char>(OneArray,OneArray+20)), uint_error);
-    BOOST_CHECK_THROW(uint160(std::vector<unsigned char>(OneArray,OneArray+32)), uint_error);
-    BOOST_CHECK_THROW(uint160(std::vector<unsigned char>(OneArray,OneArray+19)), uint_error);
 }
 
 void shiftArrayRight(unsigned char* to, const unsigned char* from, unsigned int arrayLength, unsigned int bitsToShift) 
@@ -239,74 +190,27 @@ BOOST_AUTO_TEST_CASE( shifts ) { // "<<"  ">>"  "<<="  ">>="
     for (unsigned int i = 128; i < 256; ++i) {
         BOOST_CHECK((c1L << i) == (c2L << (i-128)));
     }
-
-    uint160 TmpS;
-    for (unsigned int i = 0; i < 160; ++i)
-    {
-        shiftArrayLeft(TmpArray, OneArray, 20, i);
-        BOOST_CHECK(uint160(std::vector<unsigned char>(TmpArray,TmpArray+20)) == (OneS << i));
-        TmpS = OneS; TmpS <<= i;
-        BOOST_CHECK(TmpS == (OneS << i));
-        BOOST_CHECK((HalfS >> (159-i)) == (OneS << i));
-        TmpS = HalfS; TmpS >>= (159-i);
-        BOOST_CHECK(TmpS == (OneS << i));
-                    
-        shiftArrayLeft(TmpArray, R1Array, 20, i);
-        BOOST_CHECK(uint160(std::vector<unsigned char>(TmpArray,TmpArray+20)) == (R1S << i));
-        TmpS = R1S; TmpS <<= i;
-        BOOST_CHECK(TmpS == (R1S << i));
-
-        shiftArrayRight(TmpArray, R1Array, 20, i);
-        BOOST_CHECK(uint160(std::vector<unsigned char>(TmpArray,TmpArray+20)) == (R1S >> i)); 
-        TmpS = R1S; TmpS >>= i;
-        BOOST_CHECK(TmpS == (R1S >> i));
-
-        shiftArrayLeft(TmpArray, MaxArray, 20, i);
-        BOOST_CHECK(uint160(std::vector<unsigned char>(TmpArray,TmpArray+20)) == (MaxS << i));
-        TmpS = MaxS; TmpS <<= i;
-        BOOST_CHECK(TmpS == (MaxS << i));
-
-        shiftArrayRight(TmpArray, MaxArray, 20, i);
-        BOOST_CHECK(uint160(std::vector<unsigned char>(TmpArray,TmpArray+20)) == (MaxS >> i));
-        TmpS = MaxS; TmpS >>= i;
-        BOOST_CHECK(TmpS == (MaxS >> i));
-    }
-    uint160 c1S = uint160(0x0123456789abcdefULL);
-    uint160 c2S = c1S << 80;
-    for (unsigned int i = 0; i < 80; ++i) {
-        BOOST_CHECK((c1S << i) == (c2S >> (80-i)));
-    }
-    for (unsigned int i = 80; i < 160; ++i) {
-        BOOST_CHECK((c1S << i) == (c2S << (i-80)));
-    }
 }
 
 BOOST_AUTO_TEST_CASE( unaryOperators ) // !    ~    -
 {
-    BOOST_CHECK(!ZeroL);  BOOST_CHECK(!ZeroS);
-    BOOST_CHECK(!(!OneL));BOOST_CHECK(!(!OneS));
+    BOOST_CHECK(!ZeroL);
+    BOOST_CHECK(!(!OneL));
     for (unsigned int i = 0; i < 256; ++i) 
         BOOST_CHECK(!(!(OneL<<i)));
-    for (unsigned int i = 0; i < 160; ++i) 
-        BOOST_CHECK(!(!(OneS<<i)));
-    BOOST_CHECK(!(!R1L));BOOST_CHECK(!(!R1S));
-    BOOST_CHECK(!(!R2S));BOOST_CHECK(!(!R2S)); 
-    BOOST_CHECK(!(!MaxL));BOOST_CHECK(!(!MaxS));
+    BOOST_CHECK(!(!R1L));
+    BOOST_CHECK(!(!MaxL));
 
-    BOOST_CHECK(~ZeroL == MaxL); BOOST_CHECK(~ZeroS == MaxS);
+    BOOST_CHECK(~ZeroL == MaxL);
 
     unsigned char TmpArray[32];
     for (unsigned int i = 0; i < 32; ++i) { TmpArray[i] = ~R1Array[i]; } 
     BOOST_CHECK(uint256(std::vector<unsigned char>(TmpArray,TmpArray+32)) == (~R1L));
-    BOOST_CHECK(uint160(std::vector<unsigned char>(TmpArray,TmpArray+20)) == (~R1S));
 
-    BOOST_CHECK(-ZeroL == ZeroL); BOOST_CHECK(-ZeroS == ZeroS);
+    BOOST_CHECK(-ZeroL == ZeroL);
     BOOST_CHECK(-R1L == (~R1L)+1);
-    BOOST_CHECK(-R1S == (~R1S)+1);
     for (unsigned int i = 0; i < 256; ++i) 
         BOOST_CHECK(-(OneL<<i) == (MaxL << i));
-    for (unsigned int i = 0; i < 160; ++i) 
-        BOOST_CHECK(-(OneS<<i) == (MaxS << i));
 }
 
 
@@ -314,13 +218,10 @@ BOOST_AUTO_TEST_CASE( unaryOperators ) // !    ~    -
 // element of Aarray and Barray, and then converting the result into a uint256.
 #define CHECKBITWISEOPERATOR(_A_,_B_,_OP_)                              \
     for (unsigned int i = 0; i < 32; ++i) { TmpArray[i] = _A_##Array[i] _OP_ _B_##Array[i]; } \
-    BOOST_CHECK(uint256(std::vector<unsigned char>(TmpArray,TmpArray+32)) == (_A_##L _OP_ _B_##L)); \
-    for (unsigned int i = 0; i < 20; ++i) { TmpArray[i] = _A_##Array[i] _OP_ _B_##Array[i]; } \
-    BOOST_CHECK(uint160(std::vector<unsigned char>(TmpArray,TmpArray+20)) == (_A_##S _OP_ _B_##S));
+    BOOST_CHECK(uint256(std::vector<unsigned char>(TmpArray,TmpArray+32)) == (_A_##L _OP_ _B_##L));
 
 #define CHECKASSIGNMENTOPERATOR(_A_,_B_,_OP_)                           \
-    TmpL = _A_##L; TmpL _OP_##= _B_##L; BOOST_CHECK(TmpL == (_A_##L _OP_ _B_##L)); \
-    TmpS = _A_##S; TmpS _OP_##= _B_##S; BOOST_CHECK(TmpS == (_A_##S _OP_ _B_##S));
+    TmpL = _A_##L; TmpL _OP_##= _B_##L; BOOST_CHECK(TmpL == (_A_##L _OP_ _B_##L));
 
 BOOST_AUTO_TEST_CASE( bitwiseOperators ) 
 {
@@ -343,7 +244,6 @@ BOOST_AUTO_TEST_CASE( bitwiseOperators )
     CHECKBITWISEOPERATOR(Max,R1,&)
 
     uint256 TmpL;
-    uint160 TmpS;
     CHECKASSIGNMENTOPERATOR(R1,R2,|)
     CHECKASSIGNMENTOPERATOR(R1,R2,^)
     CHECKASSIGNMENTOPERATOR(R1,R2,&)
@@ -362,13 +262,9 @@ BOOST_AUTO_TEST_CASE( bitwiseOperators )
 
     uint64_t Tmp64 = 0xe1db685c9a0b47a2ULL; 
     TmpL = R1L; TmpL |= Tmp64;  BOOST_CHECK(TmpL == (R1L | uint256(Tmp64)));
-    TmpS = R1S; TmpS |= Tmp64;  BOOST_CHECK(TmpS == (R1S | uint160(Tmp64)));
     TmpL = R1L; TmpL |= 0; BOOST_CHECK(TmpL == R1L);
-    TmpS = R1S; TmpS |= 0; BOOST_CHECK(TmpS == R1S);
     TmpL ^= 0; BOOST_CHECK(TmpL == R1L);
-    TmpS ^= 0; BOOST_CHECK(TmpS == R1S);
     TmpL ^= Tmp64;  BOOST_CHECK(TmpL == (R1L ^ uint256(Tmp64)));
-    TmpS ^= Tmp64;  BOOST_CHECK(TmpS == (R1S ^ uint160(Tmp64)));
 }
 
 BOOST_AUTO_TEST_CASE( comparison ) // <= >= < >
@@ -382,16 +278,6 @@ BOOST_AUTO_TEST_CASE( comparison ) // <= >= < >
         BOOST_CHECK( TmpL >= R1L ); BOOST_CHECK( (TmpL == R1L) != (TmpL > R1L)); BOOST_CHECK( (TmpL == R1L) || !( TmpL <= R1L));
         BOOST_CHECK( R1L <= TmpL ); BOOST_CHECK( (R1L == TmpL) != (R1L < TmpL)); BOOST_CHECK( (TmpL == R1L) || !( R1L >= TmpL));
         BOOST_CHECK(! (TmpL < R1L)); BOOST_CHECK(! (R1L > TmpL));
-    }
-    uint160 TmpS;
-    for (unsigned int i = 0; i < 160; ++i) {
-        TmpS= OneS<< i;
-        BOOST_CHECK( TmpS >= ZeroS && TmpS > ZeroS && ZeroS < TmpS && ZeroS <= TmpS);
-        BOOST_CHECK( TmpS >= 0 && TmpS > 0 && 0 < TmpS && 0 <= TmpS);
-        TmpS |= R1S;
-        BOOST_CHECK( TmpS >= R1S ); BOOST_CHECK( (TmpS == R1S) != (TmpS > R1S)); BOOST_CHECK( (TmpS == R1S) || !( TmpS <= R1S));
-        BOOST_CHECK( R1S <= TmpS ); BOOST_CHECK( (R1S == TmpS) != (R1S < TmpS)); BOOST_CHECK( (TmpS == R1S) || !( R1S >= TmpS));
-        BOOST_CHECK(! (TmpS < R1S)); BOOST_CHECK(! (R1S > TmpS));
     }
 }
 
@@ -437,49 +323,6 @@ BOOST_AUTO_TEST_CASE( plusMinus )
     }
     TmpL = R1L;
     BOOST_CHECK(--TmpL == R1L-1);
-
-    // 160-bit; copy-pasted
-    uint160 TmpS = 0;
-    BOOST_CHECK(R1S+R2S == uint160(R1LplusR2L));
-    TmpS += R1S;
-    BOOST_CHECK(TmpS == R1S);
-    TmpS += R2S;
-    BOOST_CHECK(TmpS == R1S + R2S);
-    BOOST_CHECK(OneS+MaxS == ZeroS);
-    BOOST_CHECK(MaxS+OneS == ZeroS);
-    for (unsigned int i = 1; i < 160; ++i) {
-        BOOST_CHECK( (MaxS >> i) + OneS == (HalfS >> (i-1)) );
-        BOOST_CHECK( OneS + (MaxS >> i) == (HalfS >> (i-1)) );
-        TmpS = (MaxS>>i); TmpS += OneS;
-        BOOST_CHECK( TmpS == (HalfS >> (i-1)) );
-        TmpS = (MaxS>>i); TmpS += 1;
-        BOOST_CHECK( TmpS == (HalfS >> (i-1)) );
-        TmpS = (MaxS>>i); 
-        BOOST_CHECK( TmpS++ == (MaxS>>i) );
-        BOOST_CHECK( TmpS == (HalfS >> (i-1)));
-    }
-    BOOST_CHECK(uint160(0xbedc77e27940a7ULL) + 0xee8d836fce66fbULL == uint160(0xbedc77e27940a7ULL + 0xee8d836fce66fbULL));
-    TmpS = uint160(0xbedc77e27940a7ULL); TmpS += 0xee8d836fce66fbULL;
-    BOOST_CHECK(TmpS == uint160(0xbedc77e27940a7ULL+0xee8d836fce66fbULL));
-    TmpS -= 0xee8d836fce66fbULL;  BOOST_CHECK(TmpS == 0xbedc77e27940a7ULL);
-    TmpS = R1S;
-    BOOST_CHECK(++TmpS == R1S+1);
-
-    BOOST_CHECK(R1S -(-R2S) == R1S+R2S);
-    BOOST_CHECK(R1S -(-OneS) == R1S+OneS);
-    BOOST_CHECK(R1S - OneS == R1S+(-OneS));
-    for (unsigned int i = 1; i < 160; ++i) {
-        BOOST_CHECK((MaxS>>i) - (-OneS)  == (HalfS >> (i-1)));
-        BOOST_CHECK((HalfS >> (i-1)) - OneS == (MaxS>>i));
-        TmpS = (HalfS >> (i-1));
-        BOOST_CHECK(TmpS-- == (HalfS >> (i-1)));
-        BOOST_CHECK(TmpS == (MaxS >> i));
-        TmpS = (HalfS >> (i-1));
-        BOOST_CHECK(--TmpS == (MaxS >> i));
-    }
-    TmpS = R1S;
-    BOOST_CHECK(--TmpS == R1S-1);
-
 }
 
 BOOST_AUTO_TEST_CASE( multiply )
@@ -495,28 +338,12 @@ BOOST_AUTO_TEST_CASE( multiply )
     BOOST_CHECK((R2L * OneL) == R2L);
     BOOST_CHECK((R2L * MaxL) == -R2L);
 
-    BOOST_CHECK((R1S * R1S).ToString() == "a7761bf30d5237e9873f9bff3642a732c4d84f10");
-    BOOST_CHECK((R1S * R2S).ToString() == "ba51c008df851987d9dd323f0e5de07760529c40");
-    BOOST_CHECK((R1S * ZeroS) == ZeroS);
-    BOOST_CHECK((R1S * OneS) == R1S);
-    BOOST_CHECK((R1S * MaxS) == -R1S);
-    BOOST_CHECK((R2S * R1S) == (R1S * R2S));
-    BOOST_CHECK((R2S * R2S).ToString() == "c28bb2b45a1d85ab7996ccd3e102a650f74ff100");
-    BOOST_CHECK((R2S * ZeroS) == ZeroS);
-    BOOST_CHECK((R2S * OneS) == R2S);
-    BOOST_CHECK((R2S * MaxS) == -R2S);
-
     BOOST_CHECK(MaxL * MaxL == OneL);
-    BOOST_CHECK(MaxS * MaxS == OneS);
 
     BOOST_CHECK((R1L * 0) == 0);
     BOOST_CHECK((R1L * 1) == R1L);
     BOOST_CHECK((R1L * 3).ToString() == "7759b1c0ed14047f961ad09b20ff83687876a0181a367b813634046f91def7d4");
     BOOST_CHECK((R2L * 0x87654321UL).ToString() == "23f7816e30c4ae2017257b7a0fa64d60402f5234d46e746b61c960d09a26d070");
-    BOOST_CHECK((R1S * 0) == 0);
-    BOOST_CHECK((R1S * 1) == R1S);
-    BOOST_CHECK((R1S * 7).ToString() == "f7a987f3c3bf758d927f202d7e795faeff084244");
-    BOOST_CHECK((R2S * 0xFFFFFFFFUL).ToString() == "1c6f6c930353e17f7d6127213bb18d2883e2cd90");
 }
 
 BOOST_AUTO_TEST_CASE( divide )
@@ -535,21 +362,6 @@ BOOST_AUTO_TEST_CASE( divide )
     BOOST_CHECK(R2L / MaxL == ZeroL);
     BOOST_CHECK(MaxL / R2L == 1);
     BOOST_CHECK_THROW(R2L / ZeroL, uint_error);
-
-    uint160 D1S("D3C5EDCDEA54EB92679F0A4B4");
-    uint160 D2S("13037");
-    BOOST_CHECK((R1S / D1S).ToString() == "0000000000000000000000000db9af3beade6c02");
-    BOOST_CHECK((R1S / D2S).ToString() == "000098dfb6cc40ca592bf74366794f298ada205c");
-    BOOST_CHECK(R1S / OneS == R1S);
-    BOOST_CHECK(R1S / MaxS == ZeroS);
-    BOOST_CHECK(MaxS / R1S == 1);
-    BOOST_CHECK_THROW(R1S / ZeroS, uint_error);
-    BOOST_CHECK((R2S / D1S).ToString() == "0000000000000000000000000c5608e781182047");
-    BOOST_CHECK((R2S / D2S).ToString() == "00008966751b7187c3c67c1fda5cea7db2c1c069");
-    BOOST_CHECK(R2S / OneS == R2S);
-    BOOST_CHECK(R2S / MaxS == ZeroS);
-    BOOST_CHECK(MaxS / R2S == 1);
-    BOOST_CHECK_THROW(R2S / ZeroS, uint_error);
 }
 
 
@@ -598,59 +410,17 @@ BOOST_AUTO_TEST_CASE( methods ) // GetHex SetHex begin() end() size() GetLow64 G
     BOOST_CHECK(MaxL == TmpL);
     ss.str("");
 
-    BOOST_CHECK(R1S.GetHex() == R1S.ToString());
-    BOOST_CHECK(R2S.GetHex() == R2S.ToString());
-    BOOST_CHECK(OneS.GetHex() == OneS.ToString());
-    BOOST_CHECK(MaxS.GetHex() == MaxS.ToString());
-    uint160 TmpS(R1S);
-    BOOST_CHECK(TmpS == R1S);
-    TmpS.SetHex(R2S.ToString());   BOOST_CHECK(TmpS == R2S);
-    TmpS.SetHex(ZeroS.ToString()); BOOST_CHECK(TmpS == 0);
-    TmpS.SetHex(HalfS.ToString()); BOOST_CHECK(TmpS == HalfS);
-
-    TmpS.SetHex(R1S.ToString());
-    BOOST_CHECK(R1S.size() == 20);
-    BOOST_CHECK(R2S.size() == 20);
-    BOOST_CHECK(ZeroS.size() == 20);
-    BOOST_CHECK(MaxS.size() == 20);
-    BOOST_CHECK(HalfS.GetLow64() ==0x0000000000000000ULL); 
-    BOOST_CHECK(OneS.GetLow64() ==0x0000000000000001ULL);
-    BOOST_CHECK(R1S.GetSerializeSize(0,PROTOCOL_VERSION) == 20);
-    BOOST_CHECK(ZeroS.GetSerializeSize(0,PROTOCOL_VERSION) == 20);
-
-    R1S.Serialize(ss,0,PROTOCOL_VERSION);
-    BOOST_CHECK(ss.str() == std::string(R1Array,R1Array+20));
-    TmpS.Unserialize(ss,0,PROTOCOL_VERSION);
-    BOOST_CHECK(R1S == TmpS);
-    ss.str("");
-    ZeroS.Serialize(ss,0,PROTOCOL_VERSION);
-    BOOST_CHECK(ss.str() == std::string(ZeroArray,ZeroArray+20));
-    TmpS.Unserialize(ss,0,PROTOCOL_VERSION);
-    BOOST_CHECK(ZeroS == TmpS);
-    ss.str("");
-    MaxS.Serialize(ss,0,PROTOCOL_VERSION);
-    BOOST_CHECK(ss.str() == std::string(MaxArray,MaxArray+20));
-    TmpS.Unserialize(ss,0,PROTOCOL_VERSION);
-    BOOST_CHECK(MaxS == TmpS);
-    ss.str("");
-    
     for (unsigned int i = 0; i < 255; ++i) 
     {
         BOOST_CHECK((OneL << i).getdouble() == ldexp(1.0,i));
-        if (i < 160) BOOST_CHECK((OneS << i).getdouble() == ldexp(1.0,i));
     }
     BOOST_CHECK(ZeroL.getdouble() == 0.0);
-    BOOST_CHECK(ZeroS.getdouble() == 0.0);
     for (int i = 256; i > 53; --i) 
         BOOST_CHECK(almostEqual((R1L>>(256-i)).getdouble(), ldexp(R1Ldouble,i)));
-    for (int i = 160; i > 53; --i) 
-        BOOST_CHECK(almostEqual((R1S>>(160-i)).getdouble(), ldexp(R1Sdouble,i)));
     uint64_t R1L64part = (R1L>>192).GetLow64();
-    uint64_t R1S64part = (R1S>>96).GetLow64();
     for (int i = 53; i > 0; --i) // doubles can store all integers in {0,...,2^54-1} exactly
     {
         BOOST_CHECK((R1L>>(256-i)).getdouble() == (double)(R1L64part >> (64-i)));
-        BOOST_CHECK((R1S>>(160-i)).getdouble() == (double)(R1S64part >> (64-i)));
     }
 }
 
@@ -786,23 +556,20 @@ BOOST_AUTO_TEST_CASE(bignum_SetCompact)
 BOOST_AUTO_TEST_CASE( getmaxcoverage ) // some more tests just to get 100% coverage
 {
     // ~R1L give a base_uint<256>
-    BOOST_CHECK((~~R1L >> 10) == (R1L >> 10)); BOOST_CHECK((~~R1S >> 10) == (R1S >> 10));
-    BOOST_CHECK((~~R1L << 10) == (R1L << 10)); BOOST_CHECK((~~R1S << 10) == (R1S << 10));
-    BOOST_CHECK(!(~~R1L < R1L)); BOOST_CHECK(!(~~R1S < R1S)); 
-    BOOST_CHECK(~~R1L <= R1L); BOOST_CHECK(~~R1S <= R1S); 
-    BOOST_CHECK(!(~~R1L > R1L)); BOOST_CHECK(!(~~R1S > R1S)); 
-    BOOST_CHECK(~~R1L >= R1L); BOOST_CHECK(~~R1S >= R1S); 
-    BOOST_CHECK(!(R1L < ~~R1L)); BOOST_CHECK(!(R1S < ~~R1S)); 
-    BOOST_CHECK(R1L <= ~~R1L); BOOST_CHECK(R1S <= ~~R1S); 
-    BOOST_CHECK(!(R1L > ~~R1L)); BOOST_CHECK(!(R1S > ~~R1S)); 
-    BOOST_CHECK(R1L >= ~~R1L); BOOST_CHECK(R1S >= ~~R1S); 
+    BOOST_CHECK((~~R1L >> 10) == (R1L >> 10));
+    BOOST_CHECK((~~R1L << 10) == (R1L << 10));
+    BOOST_CHECK(!(~~R1L < R1L));
+    BOOST_CHECK(~~R1L <= R1L);
+    BOOST_CHECK(!(~~R1L > R1L));
+    BOOST_CHECK(~~R1L >= R1L);
+    BOOST_CHECK(!(R1L < ~~R1L));
+    BOOST_CHECK(R1L <= ~~R1L);
+    BOOST_CHECK(!(R1L > ~~R1L));
+    BOOST_CHECK(R1L >= ~~R1L);
     
     BOOST_CHECK(~~R1L + R2L == R1L + ~~R2L);
-    BOOST_CHECK(~~R1S + R2S == R1S + ~~R2S);
     BOOST_CHECK(~~R1L - R2L == R1L - ~~R2L);
-    BOOST_CHECK(~~R1S - R2S == R1S - ~~R2S);
     BOOST_CHECK(~R1L != R1L); BOOST_CHECK(R1L != ~R1L); 
-    BOOST_CHECK(~R1S != R1S); BOOST_CHECK(R1S != ~R1S); 
     unsigned char TmpArray[32];
     CHECKBITWISEOPERATOR(~R1,R2,|)
     CHECKBITWISEOPERATOR(~R1,R2,^)

--- a/src/test/uint256_tests.cpp
+++ b/src/test/uint256_tests.cpp
@@ -390,25 +390,6 @@ BOOST_AUTO_TEST_CASE( methods ) // GetHex SetHex begin() end() size() GetLow64 G
     BOOST_CHECK(R1L.GetLow64()  == R1LLow64);
     BOOST_CHECK(HalfL.GetLow64() ==0x0000000000000000ULL);
     BOOST_CHECK(OneL.GetLow64() ==0x0000000000000001ULL);
-    BOOST_CHECK(R1L.GetSerializeSize(0,PROTOCOL_VERSION) == 32);
-    BOOST_CHECK(ZeroL.GetSerializeSize(0,PROTOCOL_VERSION) == 32);
-
-    std::stringstream ss;
-    R1L.Serialize(ss,0,PROTOCOL_VERSION);
-    BOOST_CHECK(ss.str() == std::string(R1Array,R1Array+32));
-    TmpL.Unserialize(ss,0,PROTOCOL_VERSION);
-    BOOST_CHECK(R1L == TmpL);
-    ss.str("");
-    ZeroL.Serialize(ss,0,PROTOCOL_VERSION);
-    BOOST_CHECK(ss.str() == std::string(ZeroArray,ZeroArray+32));
-    TmpL.Unserialize(ss,0,PROTOCOL_VERSION);
-    BOOST_CHECK(ZeroL == TmpL);
-    ss.str("");
-    MaxL.Serialize(ss,0,PROTOCOL_VERSION);
-    BOOST_CHECK(ss.str() == std::string(MaxArray,MaxArray+32));
-    TmpL.Unserialize(ss,0,PROTOCOL_VERSION);
-    BOOST_CHECK(MaxL == TmpL);
-    ss.str("");
 
     for (unsigned int i = 0; i < 255; ++i) 
     {

--- a/src/test/uint256_tests.cpp
+++ b/src/test/uint256_tests.cpp
@@ -571,20 +571,10 @@ BOOST_AUTO_TEST_CASE( methods ) // GetHex SetHex begin() end() size() GetLow64 G
     TmpL.SetHex(HalfL.ToString()); BOOST_CHECK(TmpL == HalfL);
 
     TmpL.SetHex(R1L.ToString());
-    BOOST_CHECK(memcmp(R1L.begin(), R1Array, 32)==0);
-    BOOST_CHECK(memcmp(TmpL.begin(), R1Array, 32)==0);
-    BOOST_CHECK(memcmp(R2L.begin(), R2Array, 32)==0);
-    BOOST_CHECK(memcmp(ZeroL.begin(), ZeroArray, 32)==0);
-    BOOST_CHECK(memcmp(OneL.begin(), OneArray, 32)==0);
     BOOST_CHECK(R1L.size() == 32);
     BOOST_CHECK(R2L.size() == 32);
     BOOST_CHECK(ZeroL.size() == 32);
     BOOST_CHECK(MaxL.size() == 32);
-    BOOST_CHECK(R1L.begin() + 32 == R1L.end());
-    BOOST_CHECK(R2L.begin() + 32 == R2L.end());
-    BOOST_CHECK(OneL.begin() + 32 == OneL.end());
-    BOOST_CHECK(MaxL.begin() + 32 == MaxL.end());
-    BOOST_CHECK(TmpL.begin() + 32 == TmpL.end());
     BOOST_CHECK(R1L.GetLow64()  == R1LLow64);
     BOOST_CHECK(HalfL.GetLow64() ==0x0000000000000000ULL);
     BOOST_CHECK(OneL.GetLow64() ==0x0000000000000001ULL);
@@ -619,21 +609,10 @@ BOOST_AUTO_TEST_CASE( methods ) // GetHex SetHex begin() end() size() GetLow64 G
     TmpS.SetHex(HalfS.ToString()); BOOST_CHECK(TmpS == HalfS);
 
     TmpS.SetHex(R1S.ToString());
-    BOOST_CHECK(memcmp(R1S.begin(), R1Array, 20)==0);
-    BOOST_CHECK(memcmp(TmpS.begin(), R1Array, 20)==0);
-    BOOST_CHECK(memcmp(R2S.begin(), R2Array, 20)==0);
-    BOOST_CHECK(memcmp(ZeroS.begin(), ZeroArray, 20)==0);
-    BOOST_CHECK(memcmp(OneS.begin(), OneArray, 20)==0);
     BOOST_CHECK(R1S.size() == 20);
     BOOST_CHECK(R2S.size() == 20);
     BOOST_CHECK(ZeroS.size() == 20);
     BOOST_CHECK(MaxS.size() == 20);
-    BOOST_CHECK(R1S.begin() + 20 == R1S.end());
-    BOOST_CHECK(R2S.begin() + 20 == R2S.end());
-    BOOST_CHECK(OneS.begin() + 20 == OneS.end());
-    BOOST_CHECK(MaxS.begin() + 20 == MaxS.end());
-    BOOST_CHECK(TmpS.begin() + 20 == TmpS.end());
-    BOOST_CHECK(R1S.GetLow64()  == R1LLow64);
     BOOST_CHECK(HalfS.GetLow64() ==0x0000000000000000ULL); 
     BOOST_CHECK(OneS.GetLow64() ==0x0000000000000001ULL);
     BOOST_CHECK(R1S.GetSerializeSize(0,PROTOCOL_VERSION) == 20);

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -39,7 +39,7 @@ bool CCoinsViewDB::HaveCoins(const uint256 &txid) const {
 uint256 CCoinsViewDB::GetBestBlock() const {
     uint256 hashBestChain;
     if (!db.Read('B', hashBestChain))
-        return uint256(0);
+        return uint256();
     return hashBestChain;
 }
 
@@ -56,7 +56,7 @@ bool CCoinsViewDB::BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock) {
         CCoinsMap::iterator itOld = it++;
         mapCoins.erase(itOld);
     }
-    if (hashBlock != uint256(0))
+    if (!hashBlock.IsNull())
         BatchWriteHashBestChain(batch, hashBlock);
 
     LogPrint("coindb", "Committing %u changed transactions (out of %u) to coin database...\n", (unsigned int)changed, (unsigned int)count);
@@ -179,7 +179,7 @@ bool CBlockTreeDB::LoadBlockIndexGuts()
     boost::scoped_ptr<leveldb::Iterator> pcursor(NewIterator());
 
     CDataStream ssKeySet(SER_DISK, CLIENT_VERSION);
-    ssKeySet << make_pair('b', uint256(0));
+    ssKeySet << make_pair('b', uint256());
     pcursor->Seek(ssKeySet.str());
 
     // Load mapBlockIndex

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -15,7 +15,7 @@
 #include <vector>
 
 class CCoins;
-class uint256;
+class blob256;
 
 //! -dbcache default (MiB)
 static const int64_t nDefaultDbCache = 100;
@@ -32,10 +32,10 @@ protected:
 public:
     CCoinsViewDB(size_t nCacheSize, bool fMemory = false, bool fWipe = false);
 
-    bool GetCoins(const uint256 &txid, CCoins &coins) const;
-    bool HaveCoins(const uint256 &txid) const;
-    uint256 GetBestBlock() const;
-    bool BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock);
+    bool GetCoins(const blob256 &txid, CCoins &coins) const;
+    bool HaveCoins(const blob256 &txid) const;
+    blob256 GetBestBlock() const;
+    bool BatchWrite(CCoinsMap &mapCoins, const blob256 &hashBlock);
     bool GetStats(CCoinsStats &stats) const;
 };
 
@@ -53,8 +53,8 @@ public:
     bool ReadLastBlockFile(int &nFile);
     bool WriteReindexing(bool fReindex);
     bool ReadReindexing(bool &fReindex);
-    bool ReadTxIndex(const uint256 &txid, CDiskTxPos &pos);
-    bool WriteTxIndex(const std::vector<std::pair<uint256, CDiskTxPos> > &list);
+    bool ReadTxIndex(const blob256 &txid, CDiskTxPos &pos);
+    bool WriteTxIndex(const std::vector<std::pair<blob256, CDiskTxPos> > &list);
     bool WriteFlag(const std::string &name, bool fValue);
     bool ReadFlag(const std::string &name, bool &fValue);
     bool LoadBlockIndexGuts();

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -95,9 +95,9 @@ private:
 
 public:
     mutable CCriticalSection cs;
-    std::map<uint256, CTxMemPoolEntry> mapTx;
+    std::map<blob256, CTxMemPoolEntry> mapTx;
     std::map<COutPoint, CInPoint> mapNextTx;
-    std::map<uint256, std::pair<double, CAmount> > mapDeltas;
+    std::map<blob256, std::pair<double, CAmount> > mapDeltas;
 
     CTxMemPool(const CFeeRate& _minRelayFee);
     ~CTxMemPool();
@@ -111,22 +111,22 @@ public:
     void check(const CCoinsViewCache *pcoins) const;
     void setSanityCheck(bool _fSanityCheck) { fSanityCheck = _fSanityCheck; }
 
-    bool addUnchecked(const uint256& hash, const CTxMemPoolEntry &entry);
+    bool addUnchecked(const blob256& hash, const CTxMemPoolEntry &entry);
     void remove(const CTransaction &tx, std::list<CTransaction>& removed, bool fRecursive = false);
     void removeCoinbaseSpends(const CCoinsViewCache *pcoins, unsigned int nMemPoolHeight);
     void removeConflicts(const CTransaction &tx, std::list<CTransaction>& removed);
     void removeForBlock(const std::vector<CTransaction>& vtx, unsigned int nBlockHeight,
                         std::list<CTransaction>& conflicts);
     void clear();
-    void queryHashes(std::vector<uint256>& vtxid);
-    void pruneSpent(const uint256& hash, CCoins &coins);
+    void queryHashes(std::vector<blob256>& vtxid);
+    void pruneSpent(const blob256& hash, CCoins &coins);
     unsigned int GetTransactionsUpdated() const;
     void AddTransactionsUpdated(unsigned int n);
 
     /** Affect CreateNewBlock prioritisation of transactions */
-    void PrioritiseTransaction(const uint256 hash, const std::string strHash, double dPriorityDelta, const CAmount& nFeeDelta);
-    void ApplyDeltas(const uint256 hash, double &dPriorityDelta, CAmount &nFeeDelta);
-    void ClearPrioritisation(const uint256 hash);
+    void PrioritiseTransaction(const blob256 hash, const std::string strHash, double dPriorityDelta, const CAmount& nFeeDelta);
+    void ApplyDeltas(const blob256 hash, double &dPriorityDelta, CAmount &nFeeDelta);
+    void ClearPrioritisation(const blob256 hash);
 
     unsigned long size()
     {
@@ -139,13 +139,13 @@ public:
         return totalTxSize;
     }
 
-    bool exists(uint256 hash)
+    bool exists(blob256 hash)
     {
         LOCK(cs);
         return (mapTx.count(hash) != 0);
     }
 
-    bool lookup(uint256 hash, CTransaction& result) const;
+    bool lookup(blob256 hash, CTransaction& result) const;
 
     /** Estimate fee rate needed to get into the next nBlocks */
     CFeeRate estimateFee(int nBlocks) const;
@@ -169,8 +169,8 @@ protected:
 
 public:
     CCoinsViewMemPool(CCoinsView *baseIn, CTxMemPool &mempoolIn);
-    bool GetCoins(const uint256 &txid, CCoins &coins) const;
-    bool HaveCoins(const uint256 &txid) const;
+    bool GetCoins(const blob256 &txid, CCoins &coins) const;
+    bool HaveCoins(const blob256 &txid) const;
 };
 
 #endif // BITCOIN_TXMEMPOOL_H

--- a/src/ui_interface.h
+++ b/src/ui_interface.h
@@ -14,7 +14,7 @@
 
 class CBasicKeyStore;
 class CWallet;
-class uint256;
+class blob256;
 
 /** General change type (added, updated, removed). */
 enum ChangeType
@@ -88,7 +88,7 @@ public:
      * New, updated or cancelled alert.
      * @note called with lock cs_mapAlerts held.
      */
-    boost::signals2::signal<void (const uint256 &hash, ChangeType status)> NotifyAlertChanged;
+    boost::signals2::signal<void (const blob256 &hash, ChangeType status)> NotifyAlertChanged;
 
     /** A wallet has been loaded. */
     boost::signals2::signal<void (CWallet* wallet)> LoadWallet;
@@ -97,7 +97,7 @@ public:
     boost::signals2::signal<void (const std::string &title, int nProgress)> ShowProgress;
 
     /** New block has been accepted */
-    boost::signals2::signal<void (const uint256& hash)> NotifyBlockTip;
+    boost::signals2::signal<void (const blob256& hash)> NotifyBlockTip;
 };
 
 extern CClientUIInterface uiInterface;

--- a/src/uint256.cpp
+++ b/src/uint256.cpp
@@ -216,23 +216,6 @@ unsigned int base_uint<BITS>::bits() const
     return 0;
 }
 
-// Explicit instantiations for base_uint<160>
-template base_uint<160>::base_uint(const std::string&);
-template base_uint<160>::base_uint(const std::vector<unsigned char>&);
-template base_uint<160>& base_uint<160>::operator<<=(unsigned int);
-template base_uint<160>& base_uint<160>::operator>>=(unsigned int);
-template base_uint<160>& base_uint<160>::operator*=(uint32_t b32);
-template base_uint<160>& base_uint<160>::operator*=(const base_uint<160>& b);
-template base_uint<160>& base_uint<160>::operator/=(const base_uint<160>& b);
-template int base_uint<160>::CompareTo(const base_uint<160>&) const;
-template bool base_uint<160>::EqualTo(uint64_t) const;
-template double base_uint<160>::getdouble() const;
-template std::string base_uint<160>::GetHex() const;
-template std::string base_uint<160>::ToString() const;
-template void base_uint<160>::SetHex(const char*);
-template void base_uint<160>::SetHex(const std::string&);
-template unsigned int base_uint<160>::bits() const;
-
 // Explicit instantiations for base_uint<256>
 template base_uint<256>::base_uint(const std::string&);
 template base_uint<256>::base_uint(const std::vector<unsigned char>&);

--- a/src/uint256.cpp
+++ b/src/uint256.cpp
@@ -278,68 +278,6 @@ uint32_t uint256::GetCompact(bool fNegative) const
     return nCompact;
 }
 
-static void inline HashMix(uint32_t& a, uint32_t& b, uint32_t& c)
-{
-    // Taken from lookup3, by Bob Jenkins.
-    a -= c;
-    a ^= ((c << 4) | (c >> 28));
-    c += b;
-    b -= a;
-    b ^= ((a << 6) | (a >> 26));
-    a += c;
-    c -= b;
-    c ^= ((b << 8) | (b >> 24));
-    b += a;
-    a -= c;
-    a ^= ((c << 16) | (c >> 16));
-    c += b;
-    b -= a;
-    b ^= ((a << 19) | (a >> 13));
-    a += c;
-    c -= b;
-    c ^= ((b << 4) | (b >> 28));
-    b += a;
-}
-
-static void inline HashFinal(uint32_t& a, uint32_t& b, uint32_t& c)
-{
-    // Taken from lookup3, by Bob Jenkins.
-    c ^= b;
-    c -= ((b << 14) | (b >> 18));
-    a ^= c;
-    a -= ((c << 11) | (c >> 21));
-    b ^= a;
-    b -= ((a << 25) | (a >> 7));
-    c ^= b;
-    c -= ((b << 16) | (b >> 16));
-    a ^= c;
-    a -= ((c << 4) | (c >> 28));
-    b ^= a;
-    b -= ((a << 14) | (a >> 18));
-    c ^= b;
-    c -= ((b << 24) | (b >> 8));
-}
-
-uint64_t uint256::GetHash(const uint256& salt) const
-{
-    uint32_t a, b, c;
-    a = b = c = 0xdeadbeef + (WIDTH << 2);
-
-    a += pn[0] ^ salt.pn[0];
-    b += pn[1] ^ salt.pn[1];
-    c += pn[2] ^ salt.pn[2];
-    HashMix(a, b, c);
-    a += pn[3] ^ salt.pn[3];
-    b += pn[4] ^ salt.pn[4];
-    c += pn[5] ^ salt.pn[5];
-    HashMix(a, b, c);
-    a += pn[6] ^ salt.pn[6];
-    b += pn[7] ^ salt.pn[7];
-    HashFinal(a, b, c);
-
-    return ((((uint64_t)b) << 32) | c);
-}
-
 blob256 UintToBlob256(const uint256 &a)
 {
     blob256 b;

--- a/src/uint256.cpp
+++ b/src/uint256.cpp
@@ -5,6 +5,7 @@
 
 #include "uint256.h"
 
+#include "blob256.h" // TODO for BlobToUint256 and UintToBlob256
 #include "utilstrencodings.h"
 
 #include <stdio.h>
@@ -354,4 +355,19 @@ uint64_t uint256::GetHash(const uint256& salt) const
     HashFinal(a, b, c);
 
     return ((((uint64_t)b) << 32) | c);
+}
+
+blob256 UintToBlob256(const uint256 &a)
+{
+    blob256 b;
+    // TODO: needs bswap32 on big-endian
+    std::copy(a.begin(), a.end(), b.begin());
+    return b;
+}
+uint256 BlobToUint256(const blob256 &a)
+{
+    uint256 b;
+    // TODO: needs bswap32 on big-endian
+    std::copy(a.begin(), a.end(), b.begin());
+    return b;
 }

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -283,6 +283,23 @@ public:
     {
         s.read((char*)pn, sizeof(pn));
     }
+
+    // Temporary for migration to blob160/256
+    uint64_t GetCheapHash() const
+    {
+        return GetLow64();
+    }
+    void SetNull()
+    {
+        memset(pn, 0, sizeof(pn));
+    }
+    bool IsNull() const
+    {
+        for (int i = 0; i < WIDTH; i++)
+            if (pn[i] != 0)
+                return false;
+        return true;
+    }
 };
 
 /** 160-bit unsigned big integer. */

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -305,16 +305,6 @@ public:
     }
 };
 
-/** 160-bit unsigned big integer. */
-class uint160 : public base_uint<160> {
-public:
-    uint160() {}
-    uint160(const base_uint<160>& b) : base_uint<160>(b) {}
-    uint160(uint64_t b) : base_uint<160>(b) {}
-    explicit uint160(const std::string& str) : base_uint<160>(str) {}
-    explicit uint160(const std::vector<unsigned char>& vch) : base_uint<160>(vch) {}
-};
-
 /** 256-bit unsigned big integer. */
 class uint256 : public base_uint<256> {
 public:

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -269,40 +269,6 @@ public:
         assert(WIDTH >= 2);
         return pn[0] | (uint64_t)pn[1] << 32;
     }
-
-    unsigned int GetSerializeSize(int nType, int nVersion) const
-    {
-        return sizeof(pn);
-    }
-
-    template<typename Stream>
-    void Serialize(Stream& s, int nType, int nVersion) const
-    {
-        s.write((char*)pn, sizeof(pn));
-    }
-
-    template<typename Stream>
-    void Unserialize(Stream& s, int nType, int nVersion)
-    {
-        s.read((char*)pn, sizeof(pn));
-    }
-
-    // Temporary for migration to blob160/256
-    uint64_t GetCheapHash() const
-    {
-        return GetLow64();
-    }
-    void SetNull()
-    {
-        memset(pn, 0, sizeof(pn));
-    }
-    bool IsNull() const
-    {
-        for (int i = 0; i < WIDTH; i++)
-            if (pn[i] != 0)
-                return false;
-        return true;
-    }
 };
 
 /** 256-bit unsigned big integer. */
@@ -337,7 +303,6 @@ public:
     uint256& SetCompact(uint32_t nCompact, bool *pfNegative = NULL, bool *pfOverflow = NULL);
     uint32_t GetCompact(bool fNegative = false) const;
 
-    uint64_t GetHash(const uint256& salt) const;
     friend uint256 BlobToUint256(const blob256 &);
     friend blob256 UintToBlob256(const uint256 &);
 };

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -347,4 +347,8 @@ public:
     uint64_t GetHash(const uint256& salt) const;
 };
 
+/// TODO move these
+blob256 UintToBlob256(const uint256 &);
+uint256 BlobToUint256(const blob256 &);
+
 #endif // BITCOIN_UINT256_H

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -13,6 +13,9 @@
 #include <string>
 #include <vector>
 
+/// TODO move these
+class blob256;
+
 class uint_error : public std::runtime_error {
 public:
     explicit uint_error(const std::string& str) : std::runtime_error(str) {}
@@ -25,6 +28,26 @@ class base_uint
 protected:
     enum { WIDTH=BITS/32 };
     uint32_t pn[WIDTH];
+
+    unsigned char* begin()
+    {
+        return (unsigned char*)&pn[0];
+    }
+
+    unsigned char* end()
+    {
+        return (unsigned char*)&pn[WIDTH];
+    }
+
+    const unsigned char* begin() const
+    {
+        return (unsigned char*)&pn[0];
+    }
+
+    const unsigned char* end() const
+    {
+        return (unsigned char*)&pn[WIDTH];
+    }
 public:
 
     base_uint()
@@ -230,26 +253,6 @@ public:
     void SetHex(const std::string& str);
     std::string ToString() const;
 
-    unsigned char* begin()
-    {
-        return (unsigned char*)&pn[0];
-    }
-
-    unsigned char* end()
-    {
-        return (unsigned char*)&pn[WIDTH];
-    }
-
-    const unsigned char* begin() const
-    {
-        return (unsigned char*)&pn[0];
-    }
-
-    const unsigned char* end() const
-    {
-        return (unsigned char*)&pn[WIDTH];
-    }
-
     unsigned int size() const
     {
         return sizeof(pn);
@@ -345,6 +348,8 @@ public:
     uint32_t GetCompact(bool fNegative = false) const;
 
     uint64_t GetHash(const uint256& salt) const;
+    friend uint256 BlobToUint256(const blob256 &);
+    friend blob256 UintToBlob256(const uint256 &);
 };
 
 /// TODO move these

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -579,7 +579,7 @@ bool CWallet::AddToWallet(const CWalletTx& wtxIn, bool fFromLoadWallet)
             wtx.nOrderPos = IncOrderPosNext();
 
             wtx.nTimeSmart = wtx.nTimeReceived;
-            if (wtxIn.hashBlock != 0)
+            if (!wtxIn.hashBlock.IsNull())
             {
                 if (mapBlockIndex.count(wtxIn.hashBlock))
                 {
@@ -630,7 +630,7 @@ bool CWallet::AddToWallet(const CWalletTx& wtxIn, bool fFromLoadWallet)
         if (!fInsertedNew)
         {
             // Merge
-            if (wtxIn.hashBlock != 0 && wtxIn.hashBlock != wtx.hashBlock)
+            if (!wtxIn.hashBlock.IsNull() && wtxIn.hashBlock != wtx.hashBlock)
             {
                 wtx.hashBlock = wtxIn.hashBlock;
                 fUpdated = true;
@@ -795,7 +795,7 @@ int CWalletTx::GetRequestCount() const
         if (IsCoinBase())
         {
             // Generated block
-            if (hashBlock != 0)
+            if (!hashBlock.IsNull())
             {
                 map<uint256, int>::const_iterator mi = pwallet->mapRequestCount.find(hashBlock);
                 if (mi != pwallet->mapRequestCount.end())
@@ -811,7 +811,7 @@ int CWalletTx::GetRequestCount() const
                 nRequests = (*mi).second;
 
                 // How about the block it's in?
-                if (nRequests == 0 && hashBlock != 0)
+                if (nRequests == 0 && !hashBlock.IsNull())
                 {
                     map<uint256, int>::const_iterator mi = pwallet->mapRequestCount.find(hashBlock);
                     if (mi != pwallet->mapRequestCount.end())
@@ -2283,7 +2283,7 @@ int CMerkleTx::SetMerkleBranch(const CBlock& block)
 
 int CMerkleTx::GetDepthInMainChainINTERNAL(const CBlockIndex* &pindexRet) const
 {
-    if (hashBlock == 0 || nIndex == -1)
+    if (hashBlock.IsNull() || nIndex == -1)
         return 0;
     AssertLockHeld(cs_main);
 

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -56,10 +56,10 @@ std::string COutput::ToString() const
     return strprintf("COutput(%s, %d, %d) [%s]", tx->GetHash().ToString(), i, nDepth, FormatMoney(tx->vout[i].nValue));
 }
 
-const CWalletTx* CWallet::GetWalletTx(const uint256& hash) const
+const CWalletTx* CWallet::GetWalletTx(const blob256& hash) const
 {
     LOCK(cs_wallet);
-    std::map<uint256, CWalletTx>::const_iterator it = mapWallet.find(hash);
+    std::map<blob256, CWalletTx>::const_iterator it = mapWallet.find(hash);
     if (it == mapWallet.end())
         return NULL;
     return &(it->second);
@@ -316,12 +316,12 @@ bool CWallet::SetMaxVersion(int nVersion)
     return true;
 }
 
-set<uint256> CWallet::GetConflicts(const uint256& txid) const
+set<blob256> CWallet::GetConflicts(const blob256& txid) const
 {
-    set<uint256> result;
+    set<blob256> result;
     AssertLockHeld(cs_wallet);
 
-    std::map<uint256, CWalletTx>::const_iterator it = mapWallet.find(txid);
+    std::map<blob256, CWalletTx>::const_iterator it = mapWallet.find(txid);
     if (it == mapWallet.end())
         return result;
     const CWalletTx& wtx = it->second;
@@ -349,7 +349,7 @@ void CWallet::SyncMetaData(pair<TxSpends::iterator, TxSpends::iterator> range)
     const CWalletTx* copyFrom = NULL;
     for (TxSpends::iterator it = range.first; it != range.second; ++it)
     {
-        const uint256& hash = it->second;
+        const blob256& hash = it->second;
         int n = mapWallet[hash].nOrderPos;
         if (n < nMinOrderPos)
         {
@@ -360,7 +360,7 @@ void CWallet::SyncMetaData(pair<TxSpends::iterator, TxSpends::iterator> range)
     // Now copy data from copyFrom to rest:
     for (TxSpends::iterator it = range.first; it != range.second; ++it)
     {
-        const uint256& hash = it->second;
+        const blob256& hash = it->second;
         CWalletTx* copyTo = &mapWallet[hash];
         if (copyFrom == copyTo) continue;
         copyTo->mapValue = copyFrom->mapValue;
@@ -379,7 +379,7 @@ void CWallet::SyncMetaData(pair<TxSpends::iterator, TxSpends::iterator> range)
  * Outpoint is spent if any non-conflicted transaction
  * spends it:
  */
-bool CWallet::IsSpent(const uint256& hash, unsigned int n) const
+bool CWallet::IsSpent(const blob256& hash, unsigned int n) const
 {
     const COutPoint outpoint(hash, n);
     pair<TxSpends::const_iterator, TxSpends::const_iterator> range;
@@ -387,15 +387,15 @@ bool CWallet::IsSpent(const uint256& hash, unsigned int n) const
 
     for (TxSpends::const_iterator it = range.first; it != range.second; ++it)
     {
-        const uint256& wtxid = it->second;
-        std::map<uint256, CWalletTx>::const_iterator mit = mapWallet.find(wtxid);
+        const blob256& wtxid = it->second;
+        std::map<blob256, CWalletTx>::const_iterator mit = mapWallet.find(wtxid);
         if (mit != mapWallet.end() && mit->second.GetDepthInMainChain() >= 0)
             return true; // Spent
     }
     return false;
 }
 
-void CWallet::AddToSpends(const COutPoint& outpoint, const uint256& wtxid)
+void CWallet::AddToSpends(const COutPoint& outpoint, const blob256& wtxid)
 {
     mapTxSpends.insert(make_pair(outpoint, wtxid));
 
@@ -405,7 +405,7 @@ void CWallet::AddToSpends(const COutPoint& outpoint, const uint256& wtxid)
 }
 
 
-void CWallet::AddToSpends(const uint256& wtxid)
+void CWallet::AddToSpends(const blob256& wtxid)
 {
     assert(mapWallet.count(wtxid));
     CWalletTx& thisTx = mapWallet[wtxid];
@@ -531,7 +531,7 @@ CWallet::TxItems CWallet::OrderedTxItems(std::list<CAccountingEntry>& acentries,
 
     // Note: maintaining indices in the database of (account,time) --> txid and (account, time) --> acentry
     // would make this much faster for applications that do this a lot.
-    for (map<uint256, CWalletTx>::iterator it = mapWallet.begin(); it != mapWallet.end(); ++it)
+    for (map<blob256, CWalletTx>::iterator it = mapWallet.begin(); it != mapWallet.end(); ++it)
     {
         CWalletTx* wtx = &((*it).second);
         txOrdered.insert(make_pair(wtx->nOrderPos, TxPair(wtx, (CAccountingEntry*)0)));
@@ -550,14 +550,14 @@ void CWallet::MarkDirty()
 {
     {
         LOCK(cs_wallet);
-        BOOST_FOREACH(PAIRTYPE(const uint256, CWalletTx)& item, mapWallet)
+        BOOST_FOREACH(PAIRTYPE(const blob256, CWalletTx)& item, mapWallet)
             item.second.MarkDirty();
     }
 }
 
 bool CWallet::AddToWallet(const CWalletTx& wtxIn, bool fFromLoadWallet)
 {
-    uint256 hash = wtxIn.GetHash();
+    blob256 hash = wtxIn.GetHash();
 
     if (fFromLoadWallet)
     {
@@ -569,7 +569,7 @@ bool CWallet::AddToWallet(const CWalletTx& wtxIn, bool fFromLoadWallet)
     {
         LOCK(cs_wallet);
         // Inserts only if not already there, returns tx inserted or tx found
-        pair<map<uint256, CWalletTx>::iterator, bool> ret = mapWallet.insert(make_pair(hash, wtxIn));
+        pair<map<blob256, CWalletTx>::iterator, bool> ret = mapWallet.insert(make_pair(hash, wtxIn));
         CWalletTx& wtx = (*ret.first).second;
         wtx.BindWallet(this);
         bool fInsertedNew = ret.second;
@@ -714,7 +714,7 @@ void CWallet::SyncTransaction(const CTransaction& tx, const CBlock* pblock)
     }
 }
 
-void CWallet::EraseFromWallet(const uint256 &hash)
+void CWallet::EraseFromWallet(const blob256 &hash)
 {
     if (!fFileBacked)
         return;
@@ -731,7 +731,7 @@ isminetype CWallet::IsMine(const CTxIn &txin) const
 {
     {
         LOCK(cs_wallet);
-        map<uint256, CWalletTx>::const_iterator mi = mapWallet.find(txin.prevout.hash);
+        map<blob256, CWalletTx>::const_iterator mi = mapWallet.find(txin.prevout.hash);
         if (mi != mapWallet.end())
         {
             const CWalletTx& prev = (*mi).second;
@@ -746,7 +746,7 @@ CAmount CWallet::GetDebit(const CTxIn &txin, const isminefilter& filter) const
 {
     {
         LOCK(cs_wallet);
-        map<uint256, CWalletTx>::const_iterator mi = mapWallet.find(txin.prevout.hash);
+        map<blob256, CWalletTx>::const_iterator mi = mapWallet.find(txin.prevout.hash);
         if (mi != mapWallet.end())
         {
             const CWalletTx& prev = (*mi).second;
@@ -797,7 +797,7 @@ int CWalletTx::GetRequestCount() const
             // Generated block
             if (!hashBlock.IsNull())
             {
-                map<uint256, int>::const_iterator mi = pwallet->mapRequestCount.find(hashBlock);
+                map<blob256, int>::const_iterator mi = pwallet->mapRequestCount.find(hashBlock);
                 if (mi != pwallet->mapRequestCount.end())
                     nRequests = (*mi).second;
             }
@@ -805,7 +805,7 @@ int CWalletTx::GetRequestCount() const
         else
         {
             // Did anyone request this transaction?
-            map<uint256, int>::const_iterator mi = pwallet->mapRequestCount.find(GetHash());
+            map<blob256, int>::const_iterator mi = pwallet->mapRequestCount.find(GetHash());
             if (mi != pwallet->mapRequestCount.end())
             {
                 nRequests = (*mi).second;
@@ -813,7 +813,7 @@ int CWalletTx::GetRequestCount() const
                 // How about the block it's in?
                 if (nRequests == 0 && !hashBlock.IsNull())
                 {
-                    map<uint256, int>::const_iterator mi = pwallet->mapRequestCount.find(hashBlock);
+                    map<blob256, int>::const_iterator mi = pwallet->mapRequestCount.find(hashBlock);
                     if (mi != pwallet->mapRequestCount.end())
                         nRequests = (*mi).second;
                     else
@@ -969,9 +969,9 @@ int CWallet::ScanForWalletTransactions(CBlockIndex* pindexStart, bool fUpdate)
 void CWallet::ReacceptWalletTransactions()
 {
     LOCK2(cs_main, cs_wallet);
-    BOOST_FOREACH(PAIRTYPE(const uint256, CWalletTx)& item, mapWallet)
+    BOOST_FOREACH(PAIRTYPE(const blob256, CWalletTx)& item, mapWallet)
     {
-        const uint256& wtxid = item.first;
+        const blob256& wtxid = item.first;
         CWalletTx& wtx = item.second;
         assert(wtx.GetHash() == wtxid);
 
@@ -997,12 +997,12 @@ void CWalletTx::RelayWalletTransaction()
     }
 }
 
-set<uint256> CWalletTx::GetConflicts() const
+set<blob256> CWalletTx::GetConflicts() const
 {
-    set<uint256> result;
+    set<blob256> result;
     if (pwallet != NULL)
     {
-        uint256 myHash = GetHash();
+        blob256 myHash = GetHash();
         result = pwallet->GetConflicts(myHash);
         result.erase(myHash);
     }
@@ -1031,7 +1031,7 @@ void CWallet::ResendWalletTransactions()
         LOCK(cs_wallet);
         // Sort them in chronological order
         multimap<unsigned int, CWalletTx*> mapSorted;
-        BOOST_FOREACH(PAIRTYPE(const uint256, CWalletTx)& item, mapWallet)
+        BOOST_FOREACH(PAIRTYPE(const blob256, CWalletTx)& item, mapWallet)
         {
             CWalletTx& wtx = item.second;
             // Don't rebroadcast until it's had plenty of time that
@@ -1063,7 +1063,7 @@ CAmount CWallet::GetBalance() const
     CAmount nTotal = 0;
     {
         LOCK2(cs_main, cs_wallet);
-        for (map<uint256, CWalletTx>::const_iterator it = mapWallet.begin(); it != mapWallet.end(); ++it)
+        for (map<blob256, CWalletTx>::const_iterator it = mapWallet.begin(); it != mapWallet.end(); ++it)
         {
             const CWalletTx* pcoin = &(*it).second;
             if (pcoin->IsTrusted())
@@ -1079,7 +1079,7 @@ CAmount CWallet::GetUnconfirmedBalance() const
     CAmount nTotal = 0;
     {
         LOCK2(cs_main, cs_wallet);
-        for (map<uint256, CWalletTx>::const_iterator it = mapWallet.begin(); it != mapWallet.end(); ++it)
+        for (map<blob256, CWalletTx>::const_iterator it = mapWallet.begin(); it != mapWallet.end(); ++it)
         {
             const CWalletTx* pcoin = &(*it).second;
             if (!IsFinalTx(*pcoin) || (!pcoin->IsTrusted() && pcoin->GetDepthInMainChain() == 0))
@@ -1094,7 +1094,7 @@ CAmount CWallet::GetImmatureBalance() const
     CAmount nTotal = 0;
     {
         LOCK2(cs_main, cs_wallet);
-        for (map<uint256, CWalletTx>::const_iterator it = mapWallet.begin(); it != mapWallet.end(); ++it)
+        for (map<blob256, CWalletTx>::const_iterator it = mapWallet.begin(); it != mapWallet.end(); ++it)
         {
             const CWalletTx* pcoin = &(*it).second;
             nTotal += pcoin->GetImmatureCredit();
@@ -1108,7 +1108,7 @@ CAmount CWallet::GetWatchOnlyBalance() const
     CAmount nTotal = 0;
     {
         LOCK2(cs_main, cs_wallet);
-        for (map<uint256, CWalletTx>::const_iterator it = mapWallet.begin(); it != mapWallet.end(); ++it)
+        for (map<blob256, CWalletTx>::const_iterator it = mapWallet.begin(); it != mapWallet.end(); ++it)
         {
             const CWalletTx* pcoin = &(*it).second;
             if (pcoin->IsTrusted())
@@ -1124,7 +1124,7 @@ CAmount CWallet::GetUnconfirmedWatchOnlyBalance() const
     CAmount nTotal = 0;
     {
         LOCK2(cs_main, cs_wallet);
-        for (map<uint256, CWalletTx>::const_iterator it = mapWallet.begin(); it != mapWallet.end(); ++it)
+        for (map<blob256, CWalletTx>::const_iterator it = mapWallet.begin(); it != mapWallet.end(); ++it)
         {
             const CWalletTx* pcoin = &(*it).second;
             if (!IsFinalTx(*pcoin) || (!pcoin->IsTrusted() && pcoin->GetDepthInMainChain() == 0))
@@ -1139,7 +1139,7 @@ CAmount CWallet::GetImmatureWatchOnlyBalance() const
     CAmount nTotal = 0;
     {
         LOCK2(cs_main, cs_wallet);
-        for (map<uint256, CWalletTx>::const_iterator it = mapWallet.begin(); it != mapWallet.end(); ++it)
+        for (map<blob256, CWalletTx>::const_iterator it = mapWallet.begin(); it != mapWallet.end(); ++it)
         {
             const CWalletTx* pcoin = &(*it).second;
             nTotal += pcoin->GetImmatureWatchOnlyCredit();
@@ -1157,9 +1157,9 @@ void CWallet::AvailableCoins(vector<COutput>& vCoins, bool fOnlyConfirmed, const
 
     {
         LOCK2(cs_main, cs_wallet);
-        for (map<uint256, CWalletTx>::const_iterator it = mapWallet.begin(); it != mapWallet.end(); ++it)
+        for (map<blob256, CWalletTx>::const_iterator it = mapWallet.begin(); it != mapWallet.end(); ++it)
         {
-            const uint256& wtxid = it->first;
+            const blob256& wtxid = it->first;
             const CWalletTx* pcoin = &(*it).second;
 
             if (!IsFinalTx(*pcoin))
@@ -1861,7 +1861,7 @@ std::map<CTxDestination, CAmount> CWallet::GetAddressBalances()
 
     {
         LOCK(cs_wallet);
-        BOOST_FOREACH(PAIRTYPE(uint256, CWalletTx) walletEntry, mapWallet)
+        BOOST_FOREACH(PAIRTYPE(blob256, CWalletTx) walletEntry, mapWallet)
         {
             CWalletTx *pcoin = &walletEntry.second;
 
@@ -1901,7 +1901,7 @@ set< set<CTxDestination> > CWallet::GetAddressGroupings()
     set< set<CTxDestination> > groupings;
     set<CTxDestination> grouping;
 
-    BOOST_FOREACH(PAIRTYPE(uint256, CWalletTx) walletEntry, mapWallet)
+    BOOST_FOREACH(PAIRTYPE(blob256, CWalletTx) walletEntry, mapWallet)
     {
         CWalletTx *pcoin = &walletEntry.second;
 
@@ -2055,12 +2055,12 @@ void CWallet::GetAllReserveKeys(set<CKeyID>& setAddress) const
     }
 }
 
-void CWallet::UpdatedTransaction(const uint256 &hashTx)
+void CWallet::UpdatedTransaction(const blob256 &hashTx)
 {
     {
         LOCK(cs_wallet);
         // Only notify UI if this transaction is in this wallet
-        map<uint256, CWalletTx>::const_iterator mi = mapWallet.find(hashTx);
+        map<blob256, CWalletTx>::const_iterator mi = mapWallet.find(hashTx);
         if (mi != mapWallet.end())
             NotifyTransactionChanged(this, hashTx, CT_UPDATED);
     }
@@ -2084,7 +2084,7 @@ void CWallet::UnlockAllCoins()
     setLockedCoins.clear();
 }
 
-bool CWallet::IsLockedCoin(uint256 hash, unsigned int n) const
+bool CWallet::IsLockedCoin(blob256 hash, unsigned int n) const
 {
     AssertLockHeld(cs_wallet); // setLockedCoins
     COutPoint outpt(hash, n);
@@ -2162,7 +2162,7 @@ void CWallet::GetKeyBirthTimes(std::map<CKeyID, int64_t> &mapKeyBirth) const {
 
     // find first block that affects those keys, if there are any left
     std::vector<CKeyID> vAffected;
-    for (std::map<uint256, CWalletTx>::const_iterator it = mapWallet.begin(); it != mapWallet.end(); it++) {
+    for (std::map<blob256, CWalletTx>::const_iterator it = mapWallet.begin(); it != mapWallet.end(); it++) {
         // iterate over all wallet transactions...
         const CWalletTx &wtx = (*it).second;
         BlockMap::const_iterator blit = mapBlockIndex.find(wtx.hashBlock);

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -514,7 +514,7 @@ public:
 
     void Init()
     {
-        hashBlock = 0;
+        hashBlock = uint256();
         nIndex = -1;
         fMerkleVerified = false;
     }

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -123,10 +123,10 @@ private:
      * detect and report conflicts (double-spends or
      * mutated transactions where the mutant gets mined).
      */
-    typedef std::multimap<COutPoint, uint256> TxSpends;
+    typedef std::multimap<COutPoint, blob256> TxSpends;
     TxSpends mapTxSpends;
-    void AddToSpends(const COutPoint& outpoint, const uint256& wtxid);
-    void AddToSpends(const uint256& wtxid);
+    void AddToSpends(const COutPoint& outpoint, const blob256& wtxid);
+    void AddToSpends(const blob256& wtxid);
 
     void SyncMetaData(std::pair<TxSpends::iterator, TxSpends::iterator>);
 
@@ -182,10 +182,10 @@ public:
         nTimeFirstKey = 0;
     }
 
-    std::map<uint256, CWalletTx> mapWallet;
+    std::map<blob256, CWalletTx> mapWallet;
 
     int64_t nOrderPosNext;
-    std::map<uint256, int> mapRequestCount;
+    std::map<blob256, int> mapRequestCount;
 
     std::map<CTxDestination, CAddressBookData> mapAddressBook;
 
@@ -195,7 +195,7 @@ public:
 
     int64_t nTimeFirstKey;
 
-    const CWalletTx* GetWalletTx(const uint256& hash) const;
+    const CWalletTx* GetWalletTx(const blob256& hash) const;
 
     //! check whether we are allowed to upgrade (or already support) to the named feature
     bool CanSupportFeature(enum WalletFeature wf) { AssertLockHeld(cs_wallet); return nWalletMaxVersion >= wf; }
@@ -203,9 +203,9 @@ public:
     void AvailableCoins(std::vector<COutput>& vCoins, bool fOnlyConfirmed=true, const CCoinControl *coinControl = NULL) const;
     bool SelectCoinsMinConf(const CAmount& nTargetValue, int nConfMine, int nConfTheirs, std::vector<COutput> vCoins, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoinsRet, CAmount& nValueRet) const;
 
-    bool IsSpent(const uint256& hash, unsigned int n) const;
+    bool IsSpent(const blob256& hash, unsigned int n) const;
 
-    bool IsLockedCoin(uint256 hash, unsigned int n) const;
+    bool IsLockedCoin(blob256 hash, unsigned int n) const;
     void LockCoin(COutPoint& output);
     void UnlockCoin(COutPoint& output);
     void UnlockAllCoins();
@@ -273,7 +273,7 @@ public:
     bool AddToWallet(const CWalletTx& wtxIn, bool fFromLoadWallet=false);
     void SyncTransaction(const CTransaction& tx, const CBlock* pblock);
     bool AddToWalletIfInvolvingMe(const CTransaction& tx, const CBlock* pblock, bool fUpdate);
-    void EraseFromWallet(const uint256 &hash);
+    void EraseFromWallet(const blob256 &hash);
     int ScanForWalletTransactions(CBlockIndex* pindexStart, bool fUpdate = false);
     void ReacceptWalletTransactions();
     void ResendWalletTransactions();
@@ -379,13 +379,13 @@ public:
 
     bool DelAddressBook(const CTxDestination& address);
 
-    void UpdatedTransaction(const uint256 &hashTx);
+    void UpdatedTransaction(const blob256 &hashTx);
 
-    void Inventory(const uint256 &hash)
+    void Inventory(const blob256 &hash)
     {
         {
             LOCK(cs_wallet);
-            std::map<uint256, int>::iterator mi = mapRequestCount.find(hash);
+            std::map<blob256, int>::iterator mi = mapRequestCount.find(hash);
             if (mi != mapRequestCount.end())
                 (*mi).second++;
         }
@@ -409,7 +409,7 @@ public:
     int GetVersion() { LOCK(cs_wallet); return nWalletVersion; }
 
     //! Get wallet transactions that conflict with given transaction (spend same outputs)
-    std::set<uint256> GetConflicts(const uint256& txid) const;
+    std::set<blob256> GetConflicts(const blob256& txid) const;
 
     /** 
      * Address book entry changed.
@@ -424,7 +424,7 @@ public:
      * Wallet transaction added, removed or updated.
      * @note called with lock cs_wallet held.
      */
-    boost::signals2::signal<void (CWallet *wallet, const uint256 &hashTx,
+    boost::signals2::signal<void (CWallet *wallet, const blob256 &hashTx,
             ChangeType status)> NotifyTransactionChanged;
 
     /** Show progress e.g. for rescan */
@@ -494,8 +494,8 @@ private:
     int GetDepthInMainChainINTERNAL(const CBlockIndex* &pindexRet) const;
 
 public:
-    uint256 hashBlock;
-    std::vector<uint256> vMerkleBranch;
+    blob256 hashBlock;
+    std::vector<blob256> vMerkleBranch;
     int nIndex;
 
     // memory only
@@ -514,7 +514,7 @@ public:
 
     void Init()
     {
-        hashBlock = uint256();
+        hashBlock = blob256();
         nIndex = -1;
         fMerkleVerified = false;
     }
@@ -791,7 +791,7 @@ public:
             return nAvailableCreditCached;
 
         CAmount nCredit = 0;
-        uint256 hashTx = GetHash();
+        blob256 hashTx = GetHash();
         for (unsigned int i = 0; i < vout.size(); i++)
         {
             if (!pwallet->IsSpent(hashTx, i))
@@ -905,7 +905,7 @@ public:
 
     void RelayWalletTransaction();
 
-    std::set<uint256> GetConflicts() const;
+    std::set<blob256> GetConflicts() const;
 };
 
 

--- a/src/wallet_ismine.cpp
+++ b/src/wallet_ismine.cpp
@@ -56,13 +56,13 @@ isminetype IsMine(const CKeyStore &keystore, const CScript& scriptPubKey)
             return ISMINE_SPENDABLE;
         break;
     case TX_PUBKEYHASH:
-        keyID = CKeyID(uint160(vSolutions[0]));
+        keyID = CKeyID(blob160(vSolutions[0]));
         if (keystore.HaveKey(keyID))
             return ISMINE_SPENDABLE;
         break;
     case TX_SCRIPTHASH:
     {
-        CScriptID scriptID = CScriptID(uint160(vSolutions[0]));
+        CScriptID scriptID = CScriptID(blob160(vSolutions[0]));
         CScript subscript;
         if (keystore.GetCScript(scriptID, subscript)) {
             isminetype ret = IsMine(keystore, subscript);

--- a/src/walletdb.cpp
+++ b/src/walletdb.cpp
@@ -439,7 +439,7 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
             }
             CKey key;
             CPrivKey pkey;
-            uint256 hash = 0;
+            uint256 hash;
 
             if (strType == "key")
             {
@@ -464,7 +464,7 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
 
             bool fSkipCheck = false;
 
-            if (hash != 0)
+            if (!hash.IsNull())
             {
                 // hash pubkey/privkey to accelerate wallet load
                 std::vector<unsigned char> vchKey;

--- a/src/walletdb.cpp
+++ b/src/walletdb.cpp
@@ -53,13 +53,13 @@ bool CWalletDB::ErasePurpose(const string& strPurpose)
     return Erase(make_pair(string("purpose"), strPurpose));
 }
 
-bool CWalletDB::WriteTx(uint256 hash, const CWalletTx& wtx)
+bool CWalletDB::WriteTx(blob256 hash, const CWalletTx& wtx)
 {
     nWalletDBUpdated++;
     return Write(std::make_pair(std::string("tx"), hash), wtx);
 }
 
-bool CWalletDB::EraseTx(uint256 hash)
+bool CWalletDB::EraseTx(blob256 hash)
 {
     nWalletDBUpdated++;
     return Erase(std::make_pair(std::string("tx"), hash));
@@ -109,7 +109,7 @@ bool CWalletDB::WriteMasterKey(unsigned int nID, const CMasterKey& kMasterKey)
     return Write(std::make_pair(std::string("mkey"), nID), kMasterKey, true);
 }
 
-bool CWalletDB::WriteCScript(const uint160& hash, const CScript& redeemScript)
+bool CWalletDB::WriteCScript(const blob160& hash, const CScript& redeemScript)
 {
     nWalletDBUpdated++;
     return Write(std::make_pair(std::string("cscript"), hash), redeemScript, false);
@@ -259,7 +259,7 @@ DBErrors CWalletDB::ReorderTransactions(CWallet* pwallet)
     typedef multimap<int64_t, TxPair > TxItems;
     TxItems txByTime;
 
-    for (map<uint256, CWalletTx>::iterator it = pwallet->mapWallet.begin(); it != pwallet->mapWallet.end(); ++it)
+    for (map<blob256, CWalletTx>::iterator it = pwallet->mapWallet.begin(); it != pwallet->mapWallet.end(); ++it)
     {
         CWalletTx* wtx = &((*it).second);
         txByTime.insert(make_pair(wtx->nTimeReceived, TxPair(wtx, (CAccountingEntry*)0)));
@@ -332,7 +332,7 @@ public:
     bool fIsEncrypted;
     bool fAnyUnordered;
     int nFileVersion;
-    vector<uint256> vWalletUpgrade;
+    vector<blob256> vWalletUpgrade;
 
     CWalletScanState() {
         nKeys = nCKeys = nKeyMeta = 0;
@@ -365,7 +365,7 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
         }
         else if (strType == "tx")
         {
-            uint256 hash;
+            blob256 hash;
             ssKey >> hash;
             CWalletTx wtx;
             ssValue >> wtx;
@@ -439,7 +439,7 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
             }
             CKey key;
             CPrivKey pkey;
-            uint256 hash;
+            blob256 hash;
 
             if (strType == "key")
             {
@@ -564,7 +564,7 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
         }
         else if (strType == "cscript")
         {
-            uint160 hash;
+            blob160 hash;
             ssKey >> hash;
             CScript script;
             ssValue >> script;
@@ -688,7 +688,7 @@ DBErrors CWalletDB::LoadWallet(CWallet* pwallet)
     if ((wss.nKeys + wss.nCKeys) != wss.nKeyMeta)
         pwallet->nTimeFirstKey = 1; // 0 would be considered 'no value'
 
-    BOOST_FOREACH(uint256 hash, wss.vWalletUpgrade)
+    BOOST_FOREACH(blob256 hash, wss.vWalletUpgrade)
         WriteTx(hash, pwallet->mapWallet[hash]);
 
     // Rewrite encrypted wallets of versions 0.4.0 and 0.5.0rc:
@@ -704,7 +704,7 @@ DBErrors CWalletDB::LoadWallet(CWallet* pwallet)
     return result;
 }
 
-DBErrors CWalletDB::FindWalletTx(CWallet* pwallet, vector<uint256>& vTxHash, vector<CWalletTx>& vWtx)
+DBErrors CWalletDB::FindWalletTx(CWallet* pwallet, vector<blob256>& vTxHash, vector<CWalletTx>& vWtx)
 {
     pwallet->vchDefaultKey = CPubKey();
     bool fNoncriticalErrors = false;
@@ -745,7 +745,7 @@ DBErrors CWalletDB::FindWalletTx(CWallet* pwallet, vector<uint256>& vTxHash, vec
             string strType;
             ssKey >> strType;
             if (strType == "tx") {
-                uint256 hash;
+                blob256 hash;
                 ssKey >> hash;
 
                 CWalletTx wtx;
@@ -773,13 +773,13 @@ DBErrors CWalletDB::FindWalletTx(CWallet* pwallet, vector<uint256>& vTxHash, vec
 DBErrors CWalletDB::ZapWalletTx(CWallet* pwallet, vector<CWalletTx>& vWtx)
 {
     // build list of wallet TXs
-    vector<uint256> vTxHash;
+    vector<blob256> vTxHash;
     DBErrors err = FindWalletTx(pwallet, vTxHash, vWtx);
     if (err != DB_LOAD_OK)
         return err;
 
     // erase each wallet TX
-    BOOST_FOREACH (uint256& hash, vTxHash) {
+    BOOST_FOREACH (blob256& hash, vTxHash) {
         if (!EraseTx(hash))
             return DB_CORRUPT;
     }

--- a/src/walletdb.h
+++ b/src/walletdb.h
@@ -25,8 +25,8 @@ class CMasterKey;
 class CScript;
 class CWallet;
 class CWalletTx;
-class uint160;
-class uint256;
+class blob160;
+class blob256;
 
 /** Error statuses for the wallet database */
 enum DBErrors
@@ -86,14 +86,14 @@ public:
     bool WritePurpose(const std::string& strAddress, const std::string& purpose);
     bool ErasePurpose(const std::string& strAddress);
 
-    bool WriteTx(uint256 hash, const CWalletTx& wtx);
-    bool EraseTx(uint256 hash);
+    bool WriteTx(blob256 hash, const CWalletTx& wtx);
+    bool EraseTx(blob256 hash);
 
     bool WriteKey(const CPubKey& vchPubKey, const CPrivKey& vchPrivKey, const CKeyMetadata &keyMeta);
     bool WriteCryptedKey(const CPubKey& vchPubKey, const std::vector<unsigned char>& vchCryptedSecret, const CKeyMetadata &keyMeta);
     bool WriteMasterKey(unsigned int nID, const CMasterKey& kMasterKey);
 
-    bool WriteCScript(const uint160& hash, const CScript& redeemScript);
+    bool WriteCScript(const blob160& hash, const CScript& redeemScript);
 
     bool WriteWatchOnly(const CScript &script);
     bool EraseWatchOnly(const CScript &script);
@@ -125,7 +125,7 @@ public:
 
     DBErrors ReorderTransactions(CWallet* pwallet);
     DBErrors LoadWallet(CWallet* pwallet);
-    DBErrors FindWalletTx(CWallet* pwallet, std::vector<uint256>& vTxHash, std::vector<CWalletTx>& vWtx);
+    DBErrors FindWalletTx(CWallet* pwallet, std::vector<blob256>& vTxHash, std::vector<CWalletTx>& vWtx);
     DBErrors ZapWalletTx(CWallet* pwallet, std::vector<CWalletTx>& vWtx);
     static bool Recover(CDBEnv& dbenv, std::string filename, bool fOnlyKeys);
     static bool Recover(CDBEnv& dbenv, std::string filename);


### PR DESCRIPTION
This pull replaces almost all uses of `uint256` and all uses of `uint160` to use opaque byte blobs `blob256` and `blob160` with **only** the following operations: 
- Default initialization to 0, or from a vector of bytes
- Assignment from other blobXXXs
- `IsNull()` compare to special all-zeros value
- `SetNull()` clear to special all-zeros value: Bitcoin needs `IsNull()` / `SetNull()` because we often use the all-zeroes value as a marker for errors and empty values.
- `<` for sorting in maps.
- `!=` `==` test for (in)equality
- `GetHex`/`SetHex`/`ToString` because they're just so useful
- `begin()`/`end()` raw access to the data
- `size()` returns a fixed size
- `GetSerializeSize()` `Serialize` `Unserialize` serialization just reads and writes the bytes
- `GetCheapHash()` this is similar to `GetLow64()` and returns part of the value as uint64_t, for cheap hashing when the contents are assumed distributed uniformy random.

`uint256` (used for proof-of-work mainly), on the other hand, loses all functionality like raw bytes access and serialization. Its memory should not be accessed directly. This is necessary for #888 (big endian support).
`uint160` is completely removed as Bitcoin Core does no 160-bit integer arithmetic.
### Overall steps (see commits)

Even though the diff is huge, I've tried to follow a logical and easy to review process:
1. Introduce `base_uint::SetNull` and `base_uint::IsNull()` as well as other methods that will later be on `base_blob`, to prepare for migration
2. Replace x=0 with .SetNull(), x==0 with IsNull(), x!=0 with !IsNull().  Replace uses of uint256(0) with uint256().
3. Introduce blob256 and blob160 as well as conversion functions   (only needed for blob256, we don't ever compute with uint160).
4. Replace `GetLow64()` with `GetCheapHash()`
5. Rename uint256 and uint160 to blob256 and blob160 except where big integers are really necessary.   For reviewing convenience I separated this out into 
   
    A) pure renames uintXXX to blobXXX, can easily be verified (in reverse) with
       find -name *.h -print0 | xargs -0 sed -i 's/blob256/uint256/g'
       find -name *.cpp -print0 | xargs -0 sed -i 's/blob256/uint256/g'
       find -name *.h -print0 | xargs -0 sed -i 's/blob160/uint160/g'
       find -name *.cpp -print0 | xargs -0 sed -i 's/blob160/uint160/g'
   
    B) string conversions uint256("string") to blob256S("string")
   
    C) Added #includes and predeclared classes
   
    D) Necessary conversions between uint256 and blob256 **Focus reviewing here**
6. Remove now-unused methods from base_uint and blob160/blob256, eg GetHash, also remove unused uint160.
