### PR TITLE
Add sample address to NetworkStyles

### DIFF
--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -103,7 +103,7 @@ void setupAddressWidget(QValidatedLineEdit *widget, QWidget *parent)
 #if QT_VERSION >= 0x040700
     // We don't want translators to use own addresses in translations
     // and this is the only place, where this address is supplied.
-    widget->setPlaceholderText(QObject::tr("Enter a Bitcoin address (e.g. %1)").arg("1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L"));
+    widget->setPlaceholderText(QObject::tr("Enter a Bitcoin address (e.g. %1)").arg((Params().NetworkIDString() == std::string("main")) ? QString("1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L") : QString("mNS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L")));
 #endif
     widget->setValidator(new BitcoinAddressEntryValidator(parent));
     widget->setCheckValidator(new BitcoinAddressCheckValidator(parent));


### PR DESCRIPTION
Label: GUI
GUI application displays sample address in the Pay To input box. It displays main net address even when running on testnet:
![screen shot 2014-12-15 at 20 34 49](https://cloud.githubusercontent.com/assets/6848764/5443077/fc86e9de-849e-11e4-87bb-40dc9dd398b8.png)
This PR adds sampleAddress to the NetworkStyles - it allows for different address for every network.

What address should I use for testnet and regtest?
