### PR TITLE
don't assume the address of a uint256 is a pointer to its internal representation

### DIFF
--- a/src/base58.cpp
+++ b/src/base58.cpp
@@ -114,7 +114,7 @@ std::string EncodeBase58Check(const std::vector<unsigned char>& vchIn)
     // add 4-byte hash check to the end
     std::vector<unsigned char> vch(vchIn);
     uint256 hash = Hash(vch.begin(), vch.end());
-    vch.insert(vch.end(), (unsigned char*)&hash, (unsigned char*)&hash + 4);
+    vch.insert(vch.end(), hash.begin(), hash.begin() + 4);
     return EncodeBase58(vch);
 }
 

--- a/src/ecwrapper.cpp
+++ b/src/ecwrapper.cpp
@@ -118,7 +118,7 @@ bool CECKey::SetPubKey(const unsigned char* pubkey, size_t size) {
 
 bool CECKey::Verify(const uint256 &hash, const std::vector<unsigned char>& vchSig) {
     // -1 = error, 0 = bad sig, 1 = good
-    if (ECDSA_verify(0, (unsigned char*)&hash, sizeof(hash), &vchSig[0], vchSig.size(), pkey) != 1)
+    if (ECDSA_verify(0, hash.begin(), hash.size(), &vchSig[0], vchSig.size(), pkey) != 1)
         return false;
     return true;
 }
@@ -130,7 +130,7 @@ bool CECKey::Recover(const uint256 &hash, const unsigned char *p64, int rec)
     ECDSA_SIG *sig = ECDSA_SIG_new();
     BN_bin2bn(&p64[0],  32, sig->r);
     BN_bin2bn(&p64[32], 32, sig->s);
-    bool ret = ECDSA_SIG_recover_key_GFp(pkey, sig, (unsigned char*)&hash, sizeof(hash), rec, 0) == 1;
+    bool ret = ECDSA_SIG_recover_key_GFp(pkey, sig, hash.begin(), hash.size(), rec, 0) == 1;
     ECDSA_SIG_free(sig);
     return ret;
 }

--- a/src/hash.h
+++ b/src/hash.h
@@ -69,7 +69,7 @@ inline uint256 Hash(const T1 pbegin, const T1 pend)
     static const unsigned char pblank[1] = {};
     uint256 result;
     CHash256().Write(pbegin == pend ? pblank : (const unsigned char*)&pbegin[0], (pend - pbegin) * sizeof(pbegin[0]))
-              .Finalize((unsigned char*)&result);
+              .Finalize(result.begin());
     return result;
 }
 
@@ -81,7 +81,7 @@ inline uint256 Hash(const T1 p1begin, const T1 p1end,
     uint256 result;
     CHash256().Write(p1begin == p1end ? pblank : (const unsigned char*)&p1begin[0], (p1end - p1begin) * sizeof(p1begin[0]))
               .Write(p2begin == p2end ? pblank : (const unsigned char*)&p2begin[0], (p2end - p2begin) * sizeof(p2begin[0]))
-              .Finalize((unsigned char*)&result);
+              .Finalize(result.begin());
     return result;
 }
 
@@ -95,7 +95,7 @@ inline uint256 Hash(const T1 p1begin, const T1 p1end,
     CHash256().Write(p1begin == p1end ? pblank : (const unsigned char*)&p1begin[0], (p1end - p1begin) * sizeof(p1begin[0]))
               .Write(p2begin == p2end ? pblank : (const unsigned char*)&p2begin[0], (p2end - p2begin) * sizeof(p2begin[0]))
               .Write(p3begin == p3end ? pblank : (const unsigned char*)&p3begin[0], (p3end - p3begin) * sizeof(p3begin[0]))
-              .Finalize((unsigned char*)&result);
+              .Finalize(result.begin());
     return result;
 }
 
@@ -106,7 +106,7 @@ inline uint160 Hash160(const T1 pbegin, const T1 pend)
     static unsigned char pblank[1] = {};
     uint160 result;
     CHash160().Write(pbegin == pend ? pblank : (const unsigned char*)&pbegin[0], (pend - pbegin) * sizeof(pbegin[0]))
-              .Finalize((unsigned char*)&result);
+              .Finalize(result.begin());
     return result;
 }
 
@@ -136,7 +136,7 @@ public:
     // invalidates the object
     uint256 GetHash() {
         uint256 result;
-        ctx.Finalize((unsigned char*)&result);
+        ctx.Finalize(result.begin());
         return result;
     }
 

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -76,13 +76,13 @@ bool CKey::Sign(const uint256 &hash, std::vector<unsigned char>& vchSig, uint32_
     if (!fValid)
         return false;
     vchSig.resize(72);
-    RFC6979_HMAC_SHA256 prng(begin(), 32, (unsigned char*)&hash, 32);
+    RFC6979_HMAC_SHA256 prng(begin(), 32, hash.begin(), 32);
     do {
         uint256 nonce;
-        prng.Generate((unsigned char*)&nonce, 32);
+        prng.Generate(nonce.begin(), 32);
         nonce += test_case;
         int nSigLen = 72;
-        int ret = secp256k1_ecdsa_sign((const unsigned char*)&hash, (unsigned char*)&vchSig[0], &nSigLen, begin(), (unsigned char*)&nonce);
+        int ret = secp256k1_ecdsa_sign(hash.begin(), (unsigned char*)&vchSig[0], &nSigLen, begin(), nonce.begin());
         nonce = 0;
         if (ret) {
             vchSig.resize(nSigLen);
@@ -99,7 +99,7 @@ bool CKey::VerifyPubKey(const CPubKey& pubkey) const {
     std::string str = "Bitcoin key verification\n";
     GetRandBytes(rnd, sizeof(rnd));
     uint256 hash;
-    CHash256().Write((unsigned char*)str.data(), str.size()).Write(rnd, sizeof(rnd)).Finalize((unsigned char*)&hash);
+    CHash256().Write((unsigned char*)str.data(), str.size()).Write(rnd, sizeof(rnd)).Finalize(hash.begin());
     std::vector<unsigned char> vchSig;
     Sign(hash, vchSig);
     return pubkey.Verify(hash, vchSig);
@@ -110,11 +110,11 @@ bool CKey::SignCompact(const uint256 &hash, std::vector<unsigned char>& vchSig) 
         return false;
     vchSig.resize(65);
     int rec = -1;
-    RFC6979_HMAC_SHA256 prng(begin(), 32, (unsigned char*)&hash, 32);
+    RFC6979_HMAC_SHA256 prng(begin(), 32, hash.begin(), 32);
     do {
         uint256 nonce;
-        prng.Generate((unsigned char*)&nonce, 32);
-        int ret = secp256k1_ecdsa_sign_compact((const unsigned char*)&hash, &vchSig[1], begin(), (unsigned char*)&nonce, &rec);
+        prng.Generate(nonce.begin(), 32);
+        int ret = secp256k1_ecdsa_sign_compact(hash.begin(), &vchSig[1], begin(), nonce.begin(), &rec);
         nonce = 0;
         if (ret)
             break;

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -113,7 +113,7 @@ int GetRandInt(int nMax)
 uint256 GetRandHash()
 {
     uint256 hash;
-    GetRandBytes((unsigned char*)&hash, sizeof(hash));
+    GetRandBytes(hash.begin(), hash.size());
     return hash;
 }
 


### PR DESCRIPTION
I noticed this while reviewing #5478. Apparently it's safe enough, but it makes me uneasy anyway. If this is desired, I'm happy to rebase this after #5478's merge.

Since uint256 has .begin() and .size(), I don't see why we should trust that a pointer to the object lines up with the data we're after rather than using those functions.

I did a naive grep to find these, there are likely others as well.
