### PR TITLE
Remove bitnodes.io from dnsseeds.

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -156,7 +156,6 @@ public:
         vSeeds.push_back(CDNSSeedData("bluematt.me", "dnsseed.bluematt.me"));
         vSeeds.push_back(CDNSSeedData("dashjr.org", "dnsseed.bitcoin.dashjr.org"));
         vSeeds.push_back(CDNSSeedData("bitcoinstats.com", "seed.bitcoinstats.com"));
-        vSeeds.push_back(CDNSSeedData("bitnodes.io", "seed.bitnodes.io"));
         vSeeds.push_back(CDNSSeedData("xf2.org", "bitseed.xf2.org"));
 
         base58Prefixes[PUBKEY_ADDRESS] = list_of(0);


### PR DESCRIPTION
Sadly, bitnodes.io has shown lack of understanding of what
constitutes abusive behavior on the network and, as such, cannot
be supported in any way.

I know it doesnt really mean anything to remove them from this list but, if nothing else, it removes some small amount of credibility they might have.

See http://www.reddit.com/r/Bitcoin/comments/2pcsbr/new_bitnodes_feature_see_new_transactions/ for context (they're holding dedicated connections open to the whole network to show transaction propagation)
