### PR TITLE
Build winshutdownmonitor.cpp on Windows only.

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -279,8 +279,11 @@ BITCOIN_QT_CPP = \
   qt/rpcconsole.cpp \
   qt/splashscreen.cpp \
   qt/trafficgraphwidget.cpp \
-  qt/utilitydialog.cpp \
-  qt/winshutdownmonitor.cpp
+  qt/utilitydialog.cpp
+
+if TARGET_WINDOWS
+BITCOIN_QT_CPP += qt/winshutdownmonitor.cpp
+endif
 
 if ENABLE_WALLET
 BITCOIN_QT_CPP += \


### PR DESCRIPTION
The file `qt/winshutdownmonitor.cpp` is for Windows only. It is marked as such inside (completely #ifdef Windows). But it is compiled and linked in even on non-Windows OS. This change marks it Windows only completely and thus prevents linker warning on newer systems:

```
/usr/bin/ranlib: file: qt/libbitcoinqt.a(qt_libbitcoinqt_a-winshutdownmonitor.o) has no symbols
```

What can be done more: the file `bitcoind.cpp` contains: `#include "winshutdownmonitor.h"` - this can be also #ifdefed, but as the included header file is itself #ifdef Windows only, it does not have any effect.
