### PR TITLE
Prevent DOS attacks on in-flight data structures

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3574,7 +3574,9 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                     // doing this will result in the received block being rejected as an orphan in case it is
                     // not a direct successor.
                     pfrom->PushMessage("getheaders", chainActive.GetLocator(pindexBestHeader), inv.hash);
-                    if (chainActive.Tip()->GetBlockTime() > GetAdjustedTime() - Params().TargetSpacing() * 20) {
+                    CNodeState *nodestate = State(pfrom->GetId());
+                    if (chainActive.Tip()->GetBlockTime() > GetAdjustedTime() - Params().TargetSpacing() * 20 &&
+                        nodestate->nBlocksInFlight < MAX_BLOCKS_IN_TRANSIT_PER_PEER) {
                         vToFetch.push_back(inv);
                         // Mark block as in flight already, even though the actual "getdata" message only goes out
                         // later (within the same cs_main lock, though).


### PR DESCRIPTION
This is a regression in 0.10 that does not appear in 0.9.x.

vBlocksInFlight, mapBlocksInFlight and friends can be remotely inflated by supplying an excessive number of block inv messages with garbage hashes.  In my local testing, it took about 10 minutes to pump in 1GB of bad inv messages, resulting in 6GB of memory usage and 30GB of outbound getheaders data from bitcoind.  After a malicious client disconnects, the memory may be reused, but does not appear to be released back to the operating system.

The 0.9.x code started applying a 10 point ban penalty at 5000 blocks in flight leading to a ban at 5010 , while under headers first we shouldn't see more than 16.  It's probably good to have some headroom to prevent buggy or older software from getting banned, but the numbers here are just reasonable guesstimates.

I don't like fixed constants, and while MAX_DOWNLOADS_PER_PEER seems to make sense here, I like the idea of leaving some headroom.  This bumps it down to 2000 blocks and uses an existing constant that won't be changing soon.  

This will probably be superceded by #4831, or something built upon it, but a patch for 0.10 seems prudent.

I've tested by sync'ing from genesis, and multiple runs catching up tip-48h to tip.  No problems were observed.
