### PR TITLE
build: fix 'make distcheck'

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -1,4 +1,4 @@
-TESTS += test/test_bitcoin test/bitcoin-util-test.py
+TESTS += test/test_bitcoin
 bin_PROGRAMS += test/test_bitcoin
 TEST_SRCDIR = test
 TEST_BINARY=test/test_bitcoin$(EXEEXT)
@@ -105,6 +105,8 @@ bitcoin_test_clean : FORCE
 	rm -f $(CLEAN_BITCOIN_TEST) $(test_test_bitcoin_OBJECTS) $(TEST_BINARY)
 
 check-local:
+	@echo "Running test/bitcoin-util-test.py..."
+	$(AM_V_at)srcdir=$(srcdir) PYTHONPATH=$(builddir)/test $(srcdir)/test/bitcoin-util-test.py
 	$(AM_V_at)$(MAKE) $(AM_MAKEFLAGS) -C secp256k1 check
 
 %.json.h: %.json


### PR DESCRIPTION
Rather than treating the .py as a regularly built test, run it from check-local
so that we can better control the paths used.

Fixes "make distcheck" since it's now able to find the environment vars.
