### PR TITLE
contrib: make github-merge require signing

### DIFF
--- a/contrib/devtools/github-merge.sh
+++ b/contrib/devtools/github-merge.sh
@@ -156,12 +156,17 @@ read -p "Press 's' to sign off on the merge. " -n 1 -r >&2
 echo
 if [[ "d$REPLY" =~ ^d[Ss]$ ]]; then
   if [[ "$(git config --get user.signingkey)" == "" ]]; then
-    echo "WARNING: No GPG signing key set, not signing. Set one using:" >&2
+    echo "ERROR: No GPG signing key set, not signing. Set one using:" >&2
     echo "git config --global user.signingkey <key>" >&2
-    git commit -q --signoff --amend --no-edit
+    cleanup
+    exit 1
   else
     git commit -q --gpg-sign --amend --no-edit
   fi
+else
+  echo "Not signing off on merge, exiting."
+  cleanup
+  exit 1
 fi
 
 # Clean up temporary branches, and put the result in $BRANCH.


### PR DESCRIPTION
- Exit when there is no signing key configured
- Exit when user does not want to sign off
