### PR TITLE
CBlockLocator minor cleanup

### DIFF
--- a/src/db.h
+++ b/src/db.h
@@ -23,8 +23,6 @@
 class CDiskBlockIndex;
 class COutPoint;
 
-struct CBlockLocator;
-
 extern unsigned int nWalletDBUpdated;
 
 void ThreadFlushWalletDB(const std::string& strWalletFile);

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -162,7 +162,7 @@ struct CBlockLocator
         vHave.clear();
     }
 
-    bool IsNull()
+    bool IsNull() const
     {
         return vHave.empty();
     }


### PR DESCRIPTION
Two minor separate changes. Forward declaration of `CBlockLocator` no longer needed in `db.h`. Const to give a hint to the compiler about `IsNull()`.
