### PR TITLE
Implement watchonly for fundrawtransaction

### DIFF
--- a/qa/pull-tester/rpc-tests.sh
+++ b/qa/pull-tester/rpc-tests.sh
@@ -27,6 +27,7 @@ testScripts=(
     'mempool_coinbase_spends.py'
     'httpbasics.py'
     'zapwallettxes.py'
+    'rawtransactions.py'
 #    'forknotify.py'
 );
 if [ "x${ENABLE_BITCOIND}${ENABLE_UTILS}${ENABLE_WALLET}" = "x111" ]; then

--- a/qa/rpc-tests/rawtransactions.py
+++ b/qa/rpc-tests/rawtransactions.py
@@ -10,42 +10,277 @@
 
 from test_framework import BitcoinTestFramework
 from util import *
+from pprint import pprint
+from time import sleep
 
 # Create one-input, one-output, no-fee transaction:
 class RawTransactionsTest(BitcoinTestFramework):
     
+    def setup_chain(self):
+        print("Initializing test directory "+self.options.tmpdir)
+        initialize_chain_clean(self.options.tmpdir, 3)
+
+    def setup_network(self, split=False):
+        self.nodes = start_nodes(3, self.options.tmpdir)
+
+        # connect to a local machine for debugging
+        # url = "http://bitcoinrpc:DP6DvqZtqXarpeNWyN3LZTFchCCyCUuHwNF7E8pX99x1@%s:%d" % ('127.0.0.1', 18332)
+        # proxy = AuthServiceProxy(url)
+        # proxy.url = url # store URL on proxy for info
+        # self.nodes.append(proxy)
+        
+        connect_nodes_bi(self.nodes,0,1)
+        connect_nodes_bi(self.nodes,1,2)
+        connect_nodes_bi(self.nodes,0,2)
+        
+        self.is_network_split=False
+        self.sync_all()
+    
     def run_test(self):
         
-        newAddr = self.nodes[2].getnewaddress()
-        
-        inputs = []
-        outputs = { newAddr : 10 }
-        rawtx = self.nodes[0].createrawtransaction(inputs, outputs)
-        rawtxfund = self.nodes[0].fundrawtransaction(rawtx)
-        dec_rawtxfund = self.nodes[0].decoderawtransaction(rawtxfund['hex'])
-        
-        assert_equal(len(dec_rawtxfund['vin']), 1)
-        assert_equal(len(dec_rawtxfund['vout']), 2)
-        assert_equal(rawtxfund['fee'] > 0, True)
-        assert_equal(dec_rawtxfund['vin'][0]['scriptSig']['hex'], '')
-        
-        rawtxfundsigned = self.nodes[0].signrawtransaction(rawtxfund['hex'])
-        dec_rawtxfundsigned = self.nodes[0].decoderawtransaction(rawtxfundsigned['hex'])
-        
-        assert_equal(len(dec_rawtxfundsigned['vin'][0]['scriptSig']['hex']) > 20, True)
-        
-        
-        listunspent = self.nodes[2].listunspent()
-        inputs = [{'txid' : listunspent[0]['txid'], 'vout' : listunspent[0]['vout']}]
-        outputs = { newAddr : 10 }
-        rawtx = self.nodes[0].createrawtransaction(inputs, outputs)
-        aException = False
-        try:
-            rawtxfund = self.nodes[0].fundrawtransaction(rawtx)
-        except JSONRPCException,e:
-            aException = True
+        self.nodes[2].setgenerate(True, 1)
+        self.nodes[0].setgenerate(True, 101)
+        self.sync_all()
+        self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(),1.5);
+        self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(),1.0);
+        self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(),5.0);
+        self.sync_all()
+        self.nodes[0].setgenerate(True, 1)
+        self.sync_all()
 
-        assert_equal(aException, True)
+        ###############
+        # simple test #
+        ###############
+        inputs  = [ ]
+        outputs = { self.nodes[0].getnewaddress() : 1.0 }
+        rawtx   = self.nodes[2].createrawtransaction(inputs, outputs)
+        dec_tx  = self.nodes[2].decoderawtransaction(rawtx)
+
+        rawtxfund = self.nodes[2].fundrawtransaction(rawtx)
+        fee = rawtxfund['fee']
+        dec_tx  = self.nodes[2].decoderawtransaction(rawtxfund['hex'])
+        totalOut = 0
+        for out in dec_tx['vout']:
+            totalOut += out['value']        
+        
+        assert_equal(len(dec_tx['vin']), 1) #one vin coin
+        assert_equal(fee*0.00000001+float(totalOut), 1.5) #the 1.5BTC coin must be taken
+        
+        ##############################
+        # simple test with two coins #
+        ##############################
+        inputs  = [ ]
+        outputs = { self.nodes[0].getnewaddress() : 2.2 }
+        rawtx   = self.nodes[2].createrawtransaction(inputs, outputs)
+        dec_tx  = self.nodes[2].decoderawtransaction(rawtx)
+
+        rawtxfund = self.nodes[2].fundrawtransaction(rawtx)
+        fee = rawtxfund['fee']
+        dec_tx  = self.nodes[2].decoderawtransaction(rawtxfund['hex'])
+        totalOut = 0
+        for out in dec_tx['vout']:
+            totalOut += out['value']        
+        
+        assert_equal(len(dec_tx['vin']), 2) #one vin coin
+        assert_equal(fee*0.00000001+float(totalOut), 2.5) #the 1.5BTC+1.0BTC coins must have be taken
+        
+        ##############################
+        # simple test with two coins #
+        ##############################
+        inputs  = [ ]
+        outputs = { self.nodes[0].getnewaddress() : 2.6 }
+        rawtx   = self.nodes[2].createrawtransaction(inputs, outputs)
+        dec_tx  = self.nodes[2].decoderawtransaction(rawtx)
+
+        rawtxfund = self.nodes[2].fundrawtransaction(rawtx)
+        fee = rawtxfund['fee']
+        dec_tx  = self.nodes[2].decoderawtransaction(rawtxfund['hex'])
+        totalOut = 0
+        for out in dec_tx['vout']:
+            totalOut += out['value']        
+        
+        assert_equal(len(dec_tx['vin']), 1) #one vin coin
+        assert_equal(fee*0.00000001+float(totalOut), 5.0) #the 5.0BTC coin must have be taken
+        
+        
+        ################################
+        # simple test with two outputs #
+        ################################
+        inputs  = [ ]
+        outputs = { self.nodes[0].getnewaddress() : 2.6, self.nodes[1].getnewaddress() : 2.5 }
+        rawtx   = self.nodes[2].createrawtransaction(inputs, outputs)
+        dec_tx  = self.nodes[2].decoderawtransaction(rawtx)
+
+        rawtxfund = self.nodes[2].fundrawtransaction(rawtx)
+        fee = rawtxfund['fee']
+        dec_tx  = self.nodes[2].decoderawtransaction(rawtxfund['hex'])
+        totalOut = 0
+        for out in dec_tx['vout']:
+            totalOut += out['value']        
+        
+        assert_equal(len(dec_tx['vin']), 2) #one vin coin
+        assert_equal(fee*0.00000001+float(totalOut), 6.0) #the 5.0BTC + 1.0BTC coins must have be taken
+        
+
+        
+        #########################################################################
+        # test a fundrawtransaction with a VIN greater than the required amount #
+        #########################################################################
+        utx = False
+        listunspent = self.nodes[2].listunspent()
+        for aUtx in listunspent:
+            if aUtx['amount'] == 5.0:
+                utx = aUtx
+                break;
+
+        assert_equal(utx!=False, True)
+        
+        inputs  = [ {'txid' : utx['txid'], 'vout' : utx['vout']}]
+        outputs = { self.nodes[0].getnewaddress() : 1.0 }
+        rawtx   = self.nodes[2].createrawtransaction(inputs, outputs)
+        dec_tx  = self.nodes[2].decoderawtransaction(rawtx)
+        assert_equal(utx['txid'], dec_tx['vin'][0]['txid'])
+
+        rawtxfund = self.nodes[2].fundrawtransaction(rawtx)
+        fee = rawtxfund['fee']
+        dec_tx  = self.nodes[2].decoderawtransaction(rawtxfund['hex'])
+        totalOut = 0
+        for out in dec_tx['vout']:
+            totalOut += out['value']        
+            
+        assert_equal(fee*0.00000001+float(totalOut), utx['amount']) #compare vin total and totalout+fee
+        
+        
+        #########################################################################
+        # test a fundrawtransaction with a VIN smaller than the required amount #
+        #########################################################################
+        utx = False
+        listunspent = self.nodes[2].listunspent()
+        for aUtx in listunspent:
+            if aUtx['amount'] == 1.0:
+                utx = aUtx
+                break;
+
+        assert_equal(utx!=False, True)
+        
+        inputs  = [ {'txid' : utx['txid'], 'vout' : utx['vout']}]
+        outputs = { self.nodes[0].getnewaddress() : 1.0 }
+        rawtx   = self.nodes[2].createrawtransaction(inputs, outputs)
+        dec_tx  = self.nodes[2].decoderawtransaction(rawtx)
+        assert_equal(utx['txid'], dec_tx['vin'][0]['txid'])
+
+        rawtxfund = self.nodes[2].fundrawtransaction(rawtx)
+        fee = rawtxfund['fee']
+        dec_tx  = self.nodes[2].decoderawtransaction(rawtxfund['hex'])
+        totalOut = 0
+        matchingOuts = 0
+        for out in dec_tx['vout']:
+            totalOut += out['value']
+            if outputs.has_key(out['scriptPubKey']['addresses'][0]):
+                matchingOuts+=1      
+        
+        assert_equal(matchingOuts, 1)
+        assert_equal(len(dec_tx['vout']), 2)
+            
+        assert_equal(fee*0.00000001+float(totalOut), 2.5) #this tx must use the 1.0BTC and the 1.5BTC coin
+        
+        
+        ###########################################
+        # test a fundrawtransaction with two VINs #
+        ###########################################
+        utx  = False
+        utx2 = False 
+        listunspent = self.nodes[2].listunspent()
+        for aUtx in listunspent:
+            if aUtx['amount'] == 1.0:
+                utx = aUtx
+            if aUtx['amount'] == 5.0:
+                utx2 = aUtx
+
+
+        assert_equal(utx!=False, True)
+        
+        inputs  = [ {'txid' : utx['txid'], 'vout' : utx['vout']},{'txid' : utx2['txid'], 'vout' : utx2['vout']} ]
+        outputs = { self.nodes[0].getnewaddress() : 6.0 }
+        rawtx   = self.nodes[2].createrawtransaction(inputs, outputs)
+        dec_tx  = self.nodes[2].decoderawtransaction(rawtx)
+        assert_equal(utx['txid'], dec_tx['vin'][0]['txid'])
+
+        rawtxfund = self.nodes[2].fundrawtransaction(rawtx)
+        fee = rawtxfund['fee']
+        dec_tx  = self.nodes[2].decoderawtransaction(rawtxfund['hex'])
+        totalOut = 0
+        matchingOuts = 0
+        for out in dec_tx['vout']:
+            totalOut += out['value']
+            if outputs.has_key(out['scriptPubKey']['addresses'][0]):
+                matchingOuts+=1      
+        
+        assert_equal(matchingOuts, 1)
+        assert_equal(len(dec_tx['vout']), 2)
+        
+        matchingIns = 0
+        for vinOut in dec_tx['vin']:
+            for vinIn in inputs:
+                if vinIn['txid'] == vinOut['txid']:
+                    matchingIns+=1
+        
+        assert_equal(matchingIns, 2) #we now must see two vins identical to vins given as params
+        assert_equal(fee*0.00000001+float(totalOut), 7.5) #this tx must use the 1.0BTC and the 1.5BTC coin
+        
+        
+        #########################################################
+        # test a fundrawtransaction with two VINs and two vOUTs #
+        #########################################################
+        utx  = False
+        utx2 = False 
+        listunspent = self.nodes[2].listunspent()
+        for aUtx in listunspent:
+            if aUtx['amount'] == 1.0:
+                utx = aUtx
+            if aUtx['amount'] == 5.0:
+                utx2 = aUtx
+
+
+        assert_equal(utx!=False, True)
+        
+        inputs  = [ {'txid' : utx['txid'], 'vout' : utx['vout']},{'txid' : utx2['txid'], 'vout' : utx2['vout']} ]
+        outputs = { self.nodes[0].getnewaddress() : 6.0, self.nodes[0].getnewaddress() : 1.0 }
+        rawtx   = self.nodes[2].createrawtransaction(inputs, outputs)
+        dec_tx  = self.nodes[2].decoderawtransaction(rawtx)
+        assert_equal(utx['txid'], dec_tx['vin'][0]['txid'])
+
+        rawtxfund = self.nodes[2].fundrawtransaction(rawtx)
+        fee = rawtxfund['fee']
+        dec_tx  = self.nodes[2].decoderawtransaction(rawtxfund['hex'])
+        totalOut = 0
+        matchingOuts = 0
+        for out in dec_tx['vout']:
+            totalOut += out['value']
+            if outputs.has_key(out['scriptPubKey']['addresses'][0]):
+                matchingOuts+=1
+        
+        assert_equal(matchingOuts, 2)
+        assert_equal(len(dec_tx['vout']), 3)
+        assert_equal(fee*0.00000001+float(totalOut), 7.5) #this tx must use the 1.0BTC and the 1.5BTC coin
+        
+        
+        ##############################################
+        # test a fundrawtransaction with invalid vin #
+        ##############################################
+        listunspent = self.nodes[2].listunspent()
+        inputs  = [ {'txid' : "1c7f966dab21119bac53213a2bc7532bff1fa844c124fd750a7d0b1332440bd1", 'vout' : 0} ] #invalid vin!
+        outputs = { self.nodes[0].getnewaddress() : 1.0}
+        rawtx   = self.nodes[2].createrawtransaction(inputs, outputs)
+        dec_tx  = self.nodes[2].decoderawtransaction(rawtx)
+        
+        errorString = ""
+        try:
+            rawtxfund = self.nodes[2].fundrawtransaction(rawtx)
+        except JSONRPCException,e:
+            errorString = e.error['message']
+        
+        assert_equal("Insufficient" in errorString, True);
         
 
 if __name__ == '__main__':

--- a/qa/rpc-tests/rawtransactions.py
+++ b/qa/rpc-tests/rawtransactions.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python2
+# Copyright (c) 2014 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#
+# Test re-org scenarios with a mempool that contains transactions
+# that spend (directly or indirectly) coinbase transactions.
+#
+
+from test_framework import BitcoinTestFramework
+from util import *
+
+# Create one-input, one-output, no-fee transaction:
+class RawTransactionsTest(BitcoinTestFramework):
+    
+    def run_test(self):
+        
+        newAddr = self.nodes[2].getnewaddress()
+        
+        inputs = []
+        outputs = { newAddr : 10 }
+        rawtx = self.nodes[0].createrawtransaction(inputs, outputs)
+        rawtxfund = self.nodes[0].fundrawtransaction(rawtx)
+        dec_rawtxfund = self.nodes[0].decoderawtransaction(rawtxfund['hex'])
+        
+        assert_equal(len(dec_rawtxfund['vin']), 1)
+        assert_equal(len(dec_rawtxfund['vout']), 2)
+        assert_equal(rawtxfund['fee'] > 0, True)
+        assert_equal(dec_rawtxfund['vin'][0]['scriptSig']['hex'], '')
+        
+        rawtxfundsigned = self.nodes[0].signrawtransaction(rawtxfund['hex'])
+        dec_rawtxfundsigned = self.nodes[0].decoderawtransaction(rawtxfundsigned['hex'])
+        
+        assert_equal(len(dec_rawtxfundsigned['vin'][0]['scriptSig']['hex']) > 20, True)
+        
+        
+        listunspent = self.nodes[2].listunspent()
+        inputs = [{'txid' : listunspent[0]['txid'], 'vout' : listunspent[0]['vout']}]
+        outputs = { newAddr : 10 }
+        rawtx = self.nodes[0].createrawtransaction(inputs, outputs)
+        aException = False
+        try:
+            rawtxfund = self.nodes[0].fundrawtransaction(rawtx)
+        except JSONRPCException,e:
+            aException = True
+
+        assert_equal(aException, True)
+        
+
+if __name__ == '__main__':
+    RawTransactionsTest().main()

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -264,8 +264,9 @@ WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransact
         std::string strFailReason;
 
         CWalletTx *newTx = transaction.getTransaction();
+        CMutableTransaction newMTx;
         CReserveKey *keyChange = transaction.getPossibleKeyChange();
-        bool fCreated = wallet->CreateTransaction(vecSend, *newTx, *keyChange, nFeeRequired, strFailReason, coinControl);
+        bool fCreated = wallet->CreateTransaction(vecSend, *newTx, newMTx, *keyChange, nFeeRequired, strFailReason, coinControl);
         transaction.setTransactionFee(nFeeRequired);
 
         if(!fCreated)

--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -74,6 +74,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "signrawtransaction", 1 },
     { "signrawtransaction", 2 },
     { "sendrawtransaction", 1 },
+    { "fundrawtransaction", 1 },
     { "gettxout", 1 },
     { "gettxout", 2 },
     { "lockunspent", 0 },

--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -770,13 +770,14 @@ Value sendrawtransaction(const Array& params, bool fHelp)
 #ifdef ENABLE_WALLET
 Value fundrawtransaction(const Array& params, bool fHelp)
 {
-    if (fHelp || params.size() != 1)
+    if (fHelp || params.size() < 1 || params.size() > 2)
         throw runtime_error(
                             "fundrawtransaction \"hexstring\"\n"
                             "\nAdd vIns to a raw transaction.\n"
                             "\nAlso see createrawtransaction and signrawtransaction calls.\n"
                             "\nArguments:\n"
                             "1. \"hexstring\"    (string, required) The hex string of the raw transaction\n"
+                            "2. includeWatching    (boolean, optional, default=false) Use watchonly outputs\n"
                             "\nResult:\n"
                             "{\n"
                             "  \"hex\": \"value\",   (string) The raw transaction with vIns (hex-encoded string)\n"
@@ -802,11 +803,15 @@ Value fundrawtransaction(const Array& params, bool fHelp)
     CTransaction tx;
     if (!DecodeHexTx(tx, params[0].get_str()))
         throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "TX decode failed");
-    
+
+    bool includeWatching = false;
+    if (params.size() > 1)
+        includeWatching = params[1].get_bool();
+
     CMutableTransaction txNew;
     CAmount nFeeRet;
     string strFailReason;
-    if(!pwalletMain->FundTransaction(tx, txNew, nFeeRet, strFailReason))
+    if(!pwalletMain->FundTransaction(tx, txNew, nFeeRet, strFailReason, includeWatching))
         throw JSONRPCError(RPC_INTERNAL_ERROR, strFailReason);
     
     Object result;

--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -766,3 +766,57 @@ Value sendrawtransaction(const Array& params, bool fHelp)
 
     return hashTx.GetHex();
 }
+
+#ifdef ENABLE_WALLET
+Value fundrawtransaction(const Array& params, bool fHelp)
+{
+    if (fHelp || params.size() != 1)
+        throw runtime_error(
+                            "fundrawtransaction \"hexstring\"\n"
+                            "\nAdd vIns to a raw transaction.\n"
+                            "\nAlso see createrawtransaction and signrawtransaction calls.\n"
+                            "\nArguments:\n"
+                            "1. \"hexstring\"    (string, required) The hex string of the raw transaction\n"
+                            "\nResult:\n"
+                            "{\n"
+                            "  \"hex\": \"value\",   (string) The raw transaction with vIns (hex-encoded string)\n"
+                            "  \"fee\": n       calculated fee\n"
+                            "}\n"
+                            "\"hex\"             \n"
+                            "\nExamples:\n"
+                            "\nCreate a transaction with empty vIns\n"
+                            + HelpExampleCli("createrawtransaction", "\"[]\" \"{\\\"myaddress\\\":0.01}\"") +
+                            "\nFund the transaction, and get back the hex\n"
+                            + HelpExampleCli("fundrawtransaction", "\"myhex\"") +
+                            "\nSign the transaction, and get back the hex\n"
+                            + HelpExampleCli("signrawtransaction", "\"myhex\"") +
+                            "\nSend the transaction (signed hex)\n"
+                            + HelpExampleCli("sendrawtransaction", "\"signedhex\"") +
+                            "\nAs a json rpc call\n"
+                            + HelpExampleRpc("sendrawtransaction", "\"signedhex\"")
+                            );
+    
+    RPCTypeCheck(params, list_of(str_type)(bool_type));
+    
+    // parse hex string from parameter
+    CTransaction tx;
+    if (!DecodeHexTx(tx, params[0].get_str()))
+        throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "TX decode failed");
+    
+    if (tx.vin.size() > 0)
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "fundrawtransaction only supports transactions with zero exiting vins");
+    
+    CMutableTransaction txNew;
+    CAmount nFeeRet;
+    string strFailReason;
+    if(!pwalletMain->FundTransaction(tx, txNew, nFeeRet, strFailReason))
+        throw JSONRPCError(RPC_INTERNAL_ERROR, strFailReason);
+    
+    Object result;
+    result.push_back(Pair("hex", EncodeHexTx(txNew)));
+    result.push_back(Pair("fee", nFeeRet));
+
+    return result;
+}
+
+#endif

--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -803,9 +803,6 @@ Value fundrawtransaction(const Array& params, bool fHelp)
     if (!DecodeHexTx(tx, params[0].get_str()))
         throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "TX decode failed");
     
-    if (tx.vin.size() > 0)
-        throw JSONRPCError(RPC_INVALID_PARAMETER, "fundrawtransaction only supports transactions with zero exiting vins");
-    
     CMutableTransaction txNew;
     CAmount nFeeRet;
     string strFailReason;

--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -796,7 +796,7 @@ Value fundrawtransaction(const Array& params, bool fHelp)
                             + HelpExampleRpc("sendrawtransaction", "\"signedhex\"")
                             );
     
-    RPCTypeCheck(params, list_of(str_type)(bool_type));
+    RPCTypeCheck(params, boost::assign::list_of(int_type)(int_type)(array_type));
     
     // parse hex string from parameter
     CTransaction tx;

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -321,7 +321,9 @@ static const CRPCCommand vRPCCommands[] =
     { "rawtransactions",    "getrawtransaction",      &getrawtransaction,      true,      false },
     { "rawtransactions",    "sendrawtransaction",     &sendrawtransaction,     false,     false },
     { "rawtransactions",    "signrawtransaction",     &signrawtransaction,     false,     false }, /* uses wallet if enabled */
-
+#ifdef ENABLE_WALLET
+    { "rawtransactions",    "fundrawtransaction",     &fundrawtransaction,     false,     false },
+#endif
     /* Utility functions */
     { "util",               "createmultisig",         &createmultisig,         true,      false },
     { "util",               "validateaddress",        &validateaddress,        true,      false }, /* uses wallet if enabled */

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -215,6 +215,7 @@ extern json_spirit::Value listlockunspent(const json_spirit::Array& params, bool
 extern json_spirit::Value createrawtransaction(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value decoderawtransaction(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value decodescript(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value fundrawtransaction(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value signrawtransaction(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value sendrawtransaction(const json_spirit::Array& params, bool fHelp);
 

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -919,7 +919,8 @@ Value sendmany(const Array& params, bool fHelp)
     CReserveKey keyChange(pwalletMain);
     CAmount nFeeRequired = 0;
     string strFailReason;
-    bool fCreated = pwalletMain->CreateTransaction(vecSend, wtx, keyChange, nFeeRequired, strFailReason);
+    CMutableTransaction newTx;
+    bool fCreated = pwalletMain->CreateTransaction(vecSend, wtx, newTx, keyChange, nFeeRequired, strFailReason);
     if (!fCreated)
         throw JSONRPCError(RPC_WALLET_INSUFFICIENT_FUNDS, strFailReason);
     if (!pwalletMain->CommitTransaction(wtx, keyChange))

--- a/src/test/rpc_wallet_tests.cpp
+++ b/src/test/rpc_wallet_tests.cpp
@@ -213,6 +213,12 @@ BOOST_AUTO_TEST_CASE(rpc_wallet)
     Array arr = retValue.get_array();
     BOOST_CHECK(arr.size() > 0);
     BOOST_CHECK(CBitcoinAddress(arr[0].get_str()).Get() == demoAddress.Get());
+    
+    /*********************************
+     * 	     fundrawtransaction
+     *********************************/
+    BOOST_CHECK_THROW(CallRPC("fundrawtransaction 28z"), runtime_error);
+    BOOST_CHECK_THROW(CallRPC("fundrawtransaction 01000000000180969800000000001976a91450ce0a4b0ee0ddeb633da85199728b940ac3fe9488ac00000000"), runtime_error);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1563,7 +1563,7 @@ bool CWallet::SelectCoins(const CAmount& nTargetValue, set<pair<const CWalletTx*
                 
                 nValueTroughVINs    += out.tx->vout[out.i].nValue;
                 
-                // temporary keep the coin to add them later after SelectCoinsMinConf has added some
+                // temporarily keep the coin to add them later after SelectCoinsMinConf has added some
                 setTempCoins.insert(make_pair(out.tx, out.i));
                 vinOk = true;
                 

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -433,7 +433,7 @@ public:
 class CWallet : public CCryptoKeyStore, public CValidationInterface
 {
 private:
-    bool SelectCoins(const CAmount& nTargetValue, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoinsRet, CAmount& nValueRet, const std::vector<CTxIn> vPresetVINs, const CCoinControl *coinControl = NULL) const;
+    bool SelectCoins(const CAmount& nTargetValue, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoinsRet, CAmount& nValueRet, const std::vector<CTxIn> vPresetVINs, const CCoinControl *coinControl = NULL, bool includeWatching = false) const;
 
     CWalletDB *pwalletdbEncryption;
 
@@ -528,7 +528,7 @@ public:
     //! check whether we are allowed to upgrade (or already support) to the named feature
     bool CanSupportFeature(enum WalletFeature wf) { AssertLockHeld(cs_wallet); return nWalletMaxVersion >= wf; }
 
-    void AvailableCoins(std::vector<COutput>& vCoins, bool fOnlyConfirmed=true, const CCoinControl *coinControl = NULL) const;
+    void AvailableCoins(std::vector<COutput>& vCoins, bool fOnlyConfirmed=true, const CCoinControl *coinControl = NULL, bool includeWatching = false) const;
     bool SelectCoinsMinConf(const CAmount& nTargetValue, int nConfMine, int nConfTheirs, std::vector<COutput> vCoins, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoinsRet, CAmount& nValueRet) const;
 
     bool IsSpent(const uint256& hash, unsigned int n) const;
@@ -611,13 +611,13 @@ public:
     CAmount GetWatchOnlyBalance() const;
     CAmount GetUnconfirmedWatchOnlyBalance() const;
     CAmount GetImmatureWatchOnlyBalance() const;
-    bool FundTransaction(const CTransaction& txToFund, CMutableTransaction& txNew, CAmount& nFeeRet, std::string& strFailReason);
+    bool FundTransaction(const CTransaction& txToFund, CMutableTransaction& txNew, CAmount& nFeeRet, std::string& strFailReason, bool includeWatching = false);
     bool CreateTransaction(const std::vector<std::pair<CScript, CAmount> >& vecSend, const std::vector<CTxIn> vins,
-                           CWalletTx& wtxNew, CMutableTransaction& txNew, CReserveKey& reservekey, CAmount& nFeeRet, std::string& strFailReason, const CCoinControl *coinControl = NULL, bool sign = true);
+                           CWalletTx& wtxNew, CMutableTransaction& txNew, CReserveKey& reservekey, CAmount& nFeeRet, std::string& strFailReason, const CCoinControl *coinControl = NULL, bool sign = true, bool includeWatching = false);
     bool CreateTransaction(const std::vector<std::pair<CScript, CAmount> >& vecSend,
-                           CWalletTx& wtxNew, CMutableTransaction& txNew, CReserveKey& reservekey, CAmount& nFeeRet, std::string& strFailReason, const CCoinControl *coinControl = NULL, bool sign = true);
+                           CWalletTx& wtxNew, CMutableTransaction& txNew, CReserveKey& reservekey, CAmount& nFeeRet, std::string& strFailReason, const CCoinControl *coinControl = NULL, bool sign = true, bool includeWatching = false);
     bool CreateTransaction(CScript scriptPubKey, const CAmount& nValue,
-                           CWalletTx& wtxNew, CReserveKey& reservekey, CAmount& nFeeRet, std::string& strFailReason, const CCoinControl *coinControl = NULL, bool sign = true);
+                           CWalletTx& wtxNew, CReserveKey& reservekey, CAmount& nFeeRet, std::string& strFailReason, const CCoinControl *coinControl = NULL, bool sign = true, bool includeWatching = false);
     bool CommitTransaction(CWalletTx& wtxNew, CReserveKey& reservekey);
 
     static CFeeRate minTxFee;

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -611,10 +611,11 @@ public:
     CAmount GetWatchOnlyBalance() const;
     CAmount GetUnconfirmedWatchOnlyBalance() const;
     CAmount GetImmatureWatchOnlyBalance() const;
+    bool FundTransaction(const CTransaction& txToFund, CMutableTransaction& txNew, CAmount& nFeeRet, std::string& strFailReason);
     bool CreateTransaction(const std::vector<std::pair<CScript, CAmount> >& vecSend,
-                           CWalletTx& wtxNew, CReserveKey& reservekey, CAmount& nFeeRet, std::string& strFailReason, const CCoinControl *coinControl = NULL);
+                           CWalletTx& wtxNew, CMutableTransaction& txNew, CReserveKey& reservekey, CAmount& nFeeRet, std::string& strFailReason, const CCoinControl *coinControl = NULL, bool sign = false);
     bool CreateTransaction(CScript scriptPubKey, const CAmount& nValue,
-                           CWalletTx& wtxNew, CReserveKey& reservekey, CAmount& nFeeRet, std::string& strFailReason, const CCoinControl *coinControl = NULL);
+                           CWalletTx& wtxNew, CReserveKey& reservekey, CAmount& nFeeRet, std::string& strFailReason, const CCoinControl *coinControl = NULL, bool sign = false);
     bool CommitTransaction(CWalletTx& wtxNew, CReserveKey& reservekey);
 
     static CFeeRate minTxFee;

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -433,7 +433,7 @@ public:
 class CWallet : public CCryptoKeyStore, public CValidationInterface
 {
 private:
-    bool SelectCoins(const CAmount& nTargetValue, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoinsRet, CAmount& nValueRet, const CCoinControl *coinControl = NULL) const;
+    bool SelectCoins(const CAmount& nTargetValue, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoinsRet, CAmount& nValueRet, const std::vector<CTxIn> vPresetVINs, const CCoinControl *coinControl = NULL) const;
 
     CWalletDB *pwalletdbEncryption;
 
@@ -612,10 +612,12 @@ public:
     CAmount GetUnconfirmedWatchOnlyBalance() const;
     CAmount GetImmatureWatchOnlyBalance() const;
     bool FundTransaction(const CTransaction& txToFund, CMutableTransaction& txNew, CAmount& nFeeRet, std::string& strFailReason);
+    bool CreateTransaction(const std::vector<std::pair<CScript, CAmount> >& vecSend, const std::vector<CTxIn> vins,
+                           CWalletTx& wtxNew, CMutableTransaction& txNew, CReserveKey& reservekey, CAmount& nFeeRet, std::string& strFailReason, const CCoinControl *coinControl = NULL, bool sign = true);
     bool CreateTransaction(const std::vector<std::pair<CScript, CAmount> >& vecSend,
-                           CWalletTx& wtxNew, CMutableTransaction& txNew, CReserveKey& reservekey, CAmount& nFeeRet, std::string& strFailReason, const CCoinControl *coinControl = NULL, bool sign = false);
+                           CWalletTx& wtxNew, CMutableTransaction& txNew, CReserveKey& reservekey, CAmount& nFeeRet, std::string& strFailReason, const CCoinControl *coinControl = NULL, bool sign = true);
     bool CreateTransaction(CScript scriptPubKey, const CAmount& nValue,
-                           CWalletTx& wtxNew, CReserveKey& reservekey, CAmount& nFeeRet, std::string& strFailReason, const CCoinControl *coinControl = NULL, bool sign = false);
+                           CWalletTx& wtxNew, CReserveKey& reservekey, CAmount& nFeeRet, std::string& strFailReason, const CCoinControl *coinControl = NULL, bool sign = true);
     bool CommitTransaction(CWalletTx& wtxNew, CReserveKey& reservekey);
 
     static CFeeRate minTxFee;


### PR DESCRIPTION
Support watchonly in fundrawtransaction, CreateTransaction, SelectCoins and coin selection in general.

Coin selection is exposed over RPC through fundrawtransaction, and watchonly can be enabled by passing includeWatching true (defaults to false).

fundrawtransaction will first attempt to fund a transaction without using watchonly, even when includeWatching is enabled. When this fails, an includeWatching attempt is made.

When an includeWatching attempt at coin selection is performed (in CreateTransaction), and all watchonlys are consumed leaving no funds available for a fee, then CreateTransaction will not include a fee in the transaction.

Also, includeWatching tests (for fundrawtransaction) added here are passing.

Reviewers! Here are some things I would especially appreciate eyelooking for: suggestions for more edge cases for the tests, other RPC commands that should be tested, other tests for other features that I should double check for whether or not this makes any impacts, locations or existence of any sort of documentation I should be updating, unintended side effects introduced in CreateTransaction like by multiple parameters that may eventually be used simultaneously in ways that I am failing to anticipate....

I received a few suggestions from others that SignSignature should be replaced with an estimator in CreateTransaction. However, this estimator apparently does not seem to be necessary for implementing watchonly-support here, so this suggestion may go into another ticket instead.

This requires #5503 to be merged (I wouldn't mind this getting merged into #5503).
