### PR TITLE
Add removeaddress RPC call (remove watch-only address)

### DIFF
--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -370,6 +370,7 @@ static const CRPCCommand vRPCCommands[] =
     { "wallet",             "listunspent",            &listunspent,            false },
     { "wallet",             "lockunspent",            &lockunspent,            true  },
     { "wallet",             "move",                   &movecmd,                false },
+    { "wallet",             "removeaddress",          &removeaddress,          true  },
     { "wallet",             "sendfrom",               &sendfrom,               false },
     { "wallet",             "sendmany",               &sendmany,               false },
     { "wallet",             "sendtoaddress",          &sendtoaddress,          false },

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -161,6 +161,7 @@ extern UniValue clearbanned(const UniValue& params, bool fHelp);
 extern UniValue dumpprivkey(const UniValue& params, bool fHelp); // in rpcdump.cpp
 extern UniValue importprivkey(const UniValue& params, bool fHelp);
 extern UniValue importaddress(const UniValue& params, bool fHelp);
+extern UniValue removeaddress(const UniValue& params, bool fHelp);
 extern UniValue dumpwallet(const UniValue& params, bool fHelp);
 extern UniValue importwallet(const UniValue& params, bool fHelp);
 

--- a/src/test/rpc_wallet_tests.cpp
+++ b/src/test/rpc_wallet_tests.cpp
@@ -76,7 +76,7 @@ BOOST_AUTO_TEST_CASE(rpc_wallet)
     UniValue retValue;
     string strAccount = "walletDemoAccount";
     string strPurpose = "receive";
-    BOOST_CHECK_NO_THROW({ /*Initialize Wallet with an account */
+    BOOST_CHECK_NO_THROW({ /* Initialize Wallet with an account */
         CWalletDB walletdb(pwalletMain->strWalletFile);
         CAccount account;
         account.vchPubKey = demoPubkey;

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -222,6 +222,52 @@ UniValue importaddress(const UniValue& params, bool fHelp)
     return NullUniValue;
 }
 
+UniValue removeaddress(const UniValue& params, bool fHelp)
+{
+    if (!EnsureWalletIsAvailable(fHelp))
+        return NullUniValue;
+
+    if (fHelp || params.size() != 1)
+        throw runtime_error(
+            "removeaddress \"address\"\n"
+            "\nRemoves watch-only address or script (in hex) added by importaddress.\n"
+            "\nArguments:\n"
+            "1. \"address\"          (string, required) The address\n"
+            "\nExamples:\n"
+            "\nRemove watch-only address\n"
+            + HelpExampleCli("removeaddress", "\"myaddress\"") +
+            "\nAs a JSON-RPC call\n"
+            + HelpExampleRpc("removeaddress", "\"myaddress\"")
+        );
+
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
+    CScript script;
+
+    CBitcoinAddress address(params[0].get_str());
+    if (address.IsValid()) {
+        script = GetScriptForDestination(address.Get());
+    } else if (IsHex(params[0].get_str())) {
+        std::vector<unsigned char> data(ParseHex(params[0].get_str()));
+        script = CScript(data.begin(), data.end());
+    } else {
+        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid Bitcoin address or script");
+    }
+
+    if (::IsMine(*pwalletMain, script) == ISMINE_SPENDABLE)
+        throw JSONRPCError(RPC_WALLET_ERROR, "The wallet contains the private key for this address or script - can't remove it");
+
+    if (!pwalletMain->HaveWatchOnly(script))
+        throw JSONRPCError(RPC_WALLET_ERROR, "The wallet does not contain this address or script");
+
+    pwalletMain->MarkDirty();
+
+    if (!pwalletMain->RemoveWatchOnly(script))
+        throw JSONRPCError(RPC_WALLET_ERROR, "Error removing address from wallet");
+
+    return NullUniValue;
+}
+
 UniValue importwallet(const UniValue& params, bool fHelp)
 {
     if (!EnsureWalletIsAvailable(fHelp))


### PR DESCRIPTION
The current master has the feature to add watch-only addresses (RPC `importaddress`). There is no way to remove watch-only addresses (looks like the unwritten law to not remove/erase anything from the wallet ;-). This PR adds it. The RPC call is named `removeaddress`. It has only one argument, the address/script to be removed.

You can't remove the address you don't watch in the wallet, you can't remove the address with a privkey.

Problems/questions:
1. After the call, your walletdb contains transactions added by previous (optional) rescan of the call `importaddress`. I do not touch them, because you can always run `bitcoind -zapwallettxes=1` to get rid of them.
2. Qt GUI needs a small fix in `TransactionFilterProxy::filterAcceptsRow()`:

```
if(address.isEmpty())
    return false;
```

(or similar...) to not display these transactions after watch-only addresses are removed.
3. Qt GUI needs to auto-refresh the list of Recent transactions (the right tab on the main screen) because after `removeaddress` the list is not updated (watch-only transactions are still shown). Or you can restart GUI...
4. I do not remove the address from addressbook, because it could have been added even before adding it in `importaddress`.
