### PR TITLE
Do not use libgmp automatically in libsecp256k1

### DIFF
--- a/src/secp256k1/configure.ac
+++ b/src/secp256k1/configure.ac
@@ -119,13 +119,6 @@ if test x"$req_field" = x"auto"; then
   fi
 
   if test x"$set_field" = x; then
-    SECP_GMP_CHECK
-    if test x"$has_gmp" = x"yes"; then
-      set_field=gmp
-    fi
-  fi
-
-  if test x"$set_field" = x; then
     set_field=32bit
   fi
 else
@@ -173,11 +166,6 @@ else
 fi
 
 if test x"$req_bignum" = x"auto"; then
-  SECP_GMP_CHECK
-  if test x"$has_gmp" = x"yes"; then
-    set_bignum=gmp
-  fi
-
   if test x"$set_bignum" = x; then
     set_bignum=none
   fi


### PR DESCRIPTION
Hotfix the libsecp256k1 subtree to not automatically use gmp when it is available, to avoid an unwanted dependency.
