### PR TITLE
gitian: attempt to fix tarball determinisim

### DIFF
--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -79,7 +79,7 @@ script: |
   mkdir -p temp
   pushd temp
   tar xf ../$SOURCEDIST
-  find bitcoin-* | sort | tar --no-recursion -c -T - | gzip -9n > ../$SOURCEDIST
+  find bitcoin-* | sort | tar --no-recursion --mode='u+rw,go+r-w,a+X' --owner=0 --group=0 -c -T - | gzip -9n > ../$SOURCEDIST
   popd
 
   ORIGPATH="$PATH"
@@ -99,7 +99,7 @@ script: |
     find . -name "lib*.la" -delete
     find . -name "lib*.a" -delete
     rm -rf ${DISTNAME}/lib/pkgconfig
-    find . | sort | tar --no-recursion -c -T - | gzip -9n > ${OUTDIR}/${DISTNAME}-${i}.tar.gz
+    find . | sort | tar --no-recursion --mode='u+rw,go+r-w,a+X' --owner=0 --group=0 -c -T - | gzip -9n > ${OUTDIR}/${DISTNAME}-${i}.tar.gz
     cd ../../
   done
   mkdir -p $OUTDIR/src

--- a/contrib/gitian-descriptors/gitian-osx.yml
+++ b/contrib/gitian-descriptors/gitian-osx.yml
@@ -90,7 +90,7 @@ script: |
   mkdir -p temp
   pushd temp
   tar xf ../$SOURCEDIST
-  find bitcoin-* | sort | tar --no-recursion -c -T - | gzip -9n > ../$SOURCEDIST
+  find bitcoin-* | sort | tar --no-recursion --mode='u+rw,go+r-w,a+X' --owner=0 --group=0 -c -T - | gzip -9n > ../$SOURCEDIST
   popd
 
   ORIGPATH="$PATH"
@@ -116,7 +116,7 @@ script: |
     cp ${BASEPREFIX}/${i}/native/bin/${i}-pagestuff unsigned-app-${i}/pagestuff
     mv dist unsigned-app-${i}
     pushd unsigned-app-${i}
-    find . | sort | tar --no-recursion -czf ${OUTDIR}/${DISTNAME}-osx-unsigned.tar.gz -T -
+    find . | sort | tar --no-recursion --mode='u+rw,go+r-w,a+X' --owner=0 --group=0 -c -T - | gzip -9n > ${OUTDIR}/${DISTNAME}-osx-unsigned.tar.gz
     popd
 
     make deploy
@@ -126,7 +126,7 @@ script: |
     find . -name "lib*.la" -delete
     find . -name "lib*.a" -delete
     rm -rf ${DISTNAME}/lib/pkgconfig
-    find . | sort | tar --no-recursion -c -T - | gzip -9n > ${OUTDIR}/${DISTNAME}-${i}.tar.gz
+    find . | sort | tar --no-recursion --mode='u+rw,go+r-w,a+X' --owner=0 --group=0 -c -T - | gzip -9n > ${OUTDIR}/${DISTNAME}-${i}.tar.gz
     cd ../../
   done
   mkdir -p $OUTDIR/src

--- a/contrib/gitian-descriptors/gitian-win.yml
+++ b/contrib/gitian-descriptors/gitian-win.yml
@@ -83,7 +83,7 @@ script: |
   mkdir -p temp
   pushd temp
   tar xf ../$SOURCEDIST
-  find bitcoin-* | sort | tar --no-recursion -c -T - | gzip -9n > ../$SOURCEDIST
+  find bitcoin-* | sort | tar --no-recursion --mode='u+rw,go+r-w,a+X' --owner=0 --group=0 -c -T - | gzip -9n > ../$SOURCEDIST
   popd
 
   ORIGPATH="$PATH"


### PR DESCRIPTION
Needs 0.10 backport.

Rebuilding v0.10.0rc1 with these changes yields:

```
e4b60408c8917c3a1420529b6b4d9eff6fe080e4c7db86240effd0903f341dda  bitcoin-0.10.0-osx-unsigned.dmg
8cf94292cd7b936aa8f70cc3a550120842206e577cb22d448211093a57b95a48  bitcoin-0.10.0-osx-unsigned.tar.gz
26f5aa7914e2a25112b01bb5920d87e003e49c806c9a489ab80edbe7e1e47595  bitcoin-0.10.0-osx64.tar.gz
b074c4ba6c03b6045de61e521c6d47b2764a33a6c7d4f102dcdb72a9fec75601  src/bitcoin-0.10.0.tar.gz

504b6cb989b2f6967e3aa9ef1fd9ec15aaa28b060351f064323f3972cc199320  bitcoin-0.10.0-win32-setup.exe
24a94035641cbb84d9f8d04e290e1aa008346fc8b867029717475e2991d510a6  bitcoin-0.10.0-win32.zip
835559d963cb7d1e6fb594f15e19b4c46b811deb6b78afa25621f62af8be73ae  bitcoin-0.10.0-win64-setup.exe
d89d976778c8c1fd752e1171a4221bdfa26c626b342a9d5c21570c66903ea76f  bitcoin-0.10.0-win64.zip
b074c4ba6c03b6045de61e521c6d47b2764a33a6c7d4f102dcdb72a9fec75601  src/bitcoin-0.10.0.tar.gz

bad06e24032c6aafaeae21a44a1001de5d049191a86f61261e046c4b92796767  bitcoin-0.10.0-linux32.tar.gz
f1d016975a99910c7a7037fca0b3837446e56f17675f160597e10c5ef2c81a5d  bitcoin-0.10.0-linux64.tar.gz
b074c4ba6c03b6045de61e521c6d47b2764a33a6c7d4f102dcdb72a9fec75601  src/bitcoin-0.10.0.tar.gz
```

I'm testing locally with lxc, but it'd be nice to have someone else with lxc confirm they match.
