### PR TITLE
Fix CScriptID(const CScript& in) in empty script case

### DIFF
--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -18,7 +18,7 @@ typedef vector<unsigned char> valtype;
 
 unsigned nMaxDatacarrierBytes = MAX_OP_RETURN_RELAY;
 
-CScriptID::CScriptID(const CScript& in) : uint160(in.size() ? Hash160(in.begin(), in.end()) : 0) {}
+CScriptID::CScriptID(const CScript& in) : uint160(Hash160(in.begin(), in.end())) {}
 
 const char* GetTxnOutputType(txnouttype t)
 {


### PR DESCRIPTION
Previously an empty script wouldn't be hashed, and CScriptID would be assigned the incorrect value of 0 instead. This bug can be seen in the RPC decodescript command:

```
$ btc decodescript ""
{
    "asm" : "",
    "type" : "nonstandard",
    "p2sh" : "31h1vYVSYuKP6AhS86fbRdMw9XHieotbST"
}
```

Correct output:

```
$ btc decodescript ""
{
    "asm" : "",
    "type" : "nonstandard",
    "p2sh" : "3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy"
}
```

This bug was introduced by recent refactoring work in commit 066e2a1403fe306787a2ce0c8571aa9de57386cf I did a grep to check and CScriptID does get used in the consensus-critical CScriptCompressor code, although fortunately not in a way that is affected by this bug.
