### PR TITLE
Improve gitian build guide

### DIFF
--- a/doc/gitian-building.md
+++ b/doc/gitian-building.md
@@ -24,7 +24,7 @@ Table of Contents
 - [Connecting to the VM](#connecting-to-the-vm)
 - [Setting up Debian for gitian building](#setting-up-debian-for-gitian-building)
 - [Installing gitian](#installing-gitian)
-- [Setting up gitian images](#setting-up-gitian-images)
+- [Setting up the gitian image](#setting-up-the-gitian-image)
 - [Getting and building the inputs](#getting-and-building-the-inputs)
 - [Building Bitcoin](#building-bitcoin)
 - [Building an alternative repository](#building-an-alternative-repository)
@@ -74,11 +74,11 @@ In the VirtualBox GUI click "Create" and choose the following parameters in the 
 - Disk size: at least 40GB; as low as 20GB *may* be possible, but better to err on the safe side 
 - Push the `Create` button
 
-Get the [Debian 7.4 net installer](http://ftp.at.debian.org/debian-jigdo/current/amd64/iso-cd/debian-7.4.0-amd64-netinst.iso) (a more recent minor version should also work, see also [Debian Network installation](https://www.debian.org/CD/netinst/)).
+Get the [Debian 7.7 net installer](http://cdimage.debian.org/debian-cd/7.7.0/amd64/iso-cd/debian-7.7.0-amd64-netinst.iso) (a more recent minor version should also work, see also [Debian Network installation](https://www.debian.org/CD/netinst/)).
 This DVD image can be validated using a SHA256 hashing tool, for example on
 Unixy OSes by entering the following in a terminal:
 
-    echo "b712a141bc60269db217d3b3e456179bd6b181645f90e4aac9c42ed63de492e9  debian-7.4.0-amd64-netinst.iso" | sha256sum -c
+    echo "d440e85b4121f94608748139f25dbce1ad36771348b002fe07d4d44b9d9e623f  debian-7.7.0-amd64-netinst.iso" | sha256sum -c
     # (must return OK)
 
 After creating the VM, we need to configure it. 
@@ -109,7 +109,7 @@ Then start the VM. On the first launch you will be asked for a CD or DVD image. 
 Installing Debian
 ------------------
 
-In this section it will be explained how to install Debian on the newly created VM.
+This section will explain how to install Debian on the newly created VM.
 
 - Choose the non-graphical installer.  We do not need the graphical environment, it will only increase installation time and disk usage.
 
@@ -277,24 +277,21 @@ cd ..
 
 **Note**: When sudo asks for a password, enter the password for the user *debian* not for *root*.
 
-Clone the git repositories for bitcoin and gitian and then checkout the bitcoin version that you want to build.
+Clone the git repositories for bitcoin and gitian.
 
 ```bash
 git clone https://github.com/devrandom/gitian-builder.git
 git clone https://github.com/bitcoin/bitcoin
-cd bitcoin
-git checkout v${VERSION}
-cd ..
 ```
 
-Setting up gitian images
+Setting up the gitian image
 -------------------------
 
-Gitian needs virtual images of the operating system to build in.
-Currently this is Ubuntu Precise for x86_64.
-These images will be copied and used every time that a build is started to
+Gitian needs a virtual image of the operating system to build in.
+Currently this is Ubuntu Precise x86_64.
+This image will be copied and used every time that a build is started to
 make sure that the build is deterministic.
-Creating the images will take a while, but only has to be done once.
+Creating the image will take a while, but only has to be done once.
 
 Execute the following as user `debian`:
 
@@ -303,7 +300,7 @@ cd gitian-builder
 bin/make-base-vm --lxc --arch amd64 --suite precise
 ```
 
-There will be a lot of warnings printed during build of the images. These can be ignored.
+There will be a lot of warnings printed during build of the image. These can be ignored.
 
 **Note**: When sudo asks for a password, enter the password for the user *debian* not for *root*.
 
@@ -322,7 +319,7 @@ To build Bitcoin (for Linux, OSX and Windows) just follow the steps under 'perfo
 gitian builds' in [doc/release-process.md](release-process.md) in the bitcoin repository.
 
 This may take a long time as it also builds the dependencies needed for each descriptor.
-These dependencies will be cached after a successful build to avoid rebuilding them when possible.
+These dependencies will be cached after a successful build to avoid rebuilding them where possible.
 
 At any time you can check the package installation and build progress with
 
@@ -382,9 +379,9 @@ When you execute `gsign` you will get an error from GPG, which can be ignored. C
 in `gitian.sigs` to your signing machine and do
 
 ```bash
-    gpg --detach-sign ${VERSION}-linux/${SIGNER}/bitcoin-build.assert
-    gpg --detach-sign ${VERSION}-win/${SIGNER}/bitcoin-build.assert
-    gpg --detach-sign ${VERSION}-osx/${SIGNER}/bitcoin-build.assert
+    gpg --detach-sign ${VERSION}-linux/${SIGNER}/bitcoin-linux-build.assert
+    gpg --detach-sign ${VERSION}-win/${SIGNER}/bitcoin-win-build.assert
+    gpg --detach-sign ${VERSION}-osx-unsigned/${SIGNER}/bitcoin-osx-build.assert
 ```
 
 This will create the `.sig` files that can be committed together with the `.assert` files to assert your


### PR DESCRIPTION
Point to the Debian 7.7 installer (I used this to build my latest signatures)
Fix wording now that we only use a single image
Remove bitcoin checkout steps, they are covered in release-process

@Michagogo Feel free to cheery-pick this into #5527 
