### PR TITLE
[Qt] Base coin control priority labels always on max confirmation target

### DIFF
--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -533,7 +533,7 @@ void CoinControlDialog::updateLabels(WalletModel *model, QDialog* dialog)
         nBytes = nBytesInputs + ((CoinControlDialog::payAmounts.size() > 0 ? CoinControlDialog::payAmounts.size() + 1 : 2) * 34) + 10; // always assume +1 output for change here
 
         // Priority
-        double mempoolEstimatePriority = mempool.estimatePriority(nTxConfirmTarget);
+        double mempoolEstimatePriority = mempool.estimatePriority(MEMPOOL_ESTIMATE_MAXTARGET);
         dPriority = dPriorityInputs / (nBytes - nBytesInputs + (nQuantityUncompressed * 29)); // 29 = 180 - 151 (uncompressed public keys are over the limit. max 151 bytes of the input are ignored for priority)
         sPriorityLabel = CoinControlDialog::getPriorityLabel(dPriority, mempoolEstimatePriority);
 
@@ -541,7 +541,7 @@ void CoinControlDialog::updateLabels(WalletModel *model, QDialog* dialog)
         nPayFee = CWallet::GetMinimumFee(nBytes, nTxConfirmTarget, mempool);
 
         // Allow free?
-        double dPriorityNeeded = mempoolEstimatePriority;
+        double dPriorityNeeded = mempool.estimatePriority(nTxConfirmTarget);
         if (dPriorityNeeded <= 0)
             dPriorityNeeded = AllowFreeThreshold(); // not enough data, back to hard-coded
         fAllowFree = (dPriority >= dPriorityNeeded);
@@ -623,7 +623,7 @@ void CoinControlDialog::updateLabels(WalletModel *model, QDialog* dialog)
     toolTip1 += tr("Can vary +/- 1 byte per input.");
 
     QString toolTip2 = tr("Transactions with higher priority are more likely to get included into a block.") + "<br /><br />";
-    toolTip2 += tr("This label turns red, if the priority is smaller than \"medium\".") + "<br /><br />";
+    toolTip2 += tr("This label turns red, if the priority is too low to send as zero-fee transaction.") + "<br /><br />";
     toolTip2 += tr("This means a fee of at least %1 per kB is required.").arg(BitcoinUnits::formatWithUnit(nDisplayUnit, CWallet::minTxFee.GetFeePerK()));
 
     QString toolTip3 = tr("This label turns red, if any recipient receives an amount smaller than %1.").arg(BitcoinUnits::formatWithUnit(nDisplayUnit, ::minRelayTxFee.GetFee(546)));
@@ -669,7 +669,7 @@ void CoinControlDialog::updateView()
     QFlags<Qt::ItemFlag> flgTristate = Qt::ItemIsSelectable | Qt::ItemIsEnabled | Qt::ItemIsUserCheckable | Qt::ItemIsTristate;
 
     int nDisplayUnit = model->getOptionsModel()->getDisplayUnit();
-    double mempoolEstimatePriority = mempool.estimatePriority(nTxConfirmTarget);
+    double mempoolEstimatePriority = mempool.estimatePriority(MEMPOOL_ESTIMATE_MAXTARGET);
 
     map<QString, vector<COutput> > mapCoins;
     model->listCoins(mapCoins);

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -585,12 +585,12 @@ void SendCoinsDialog::updateGlobalFeeVariables()
 {
     if (ui->radioSmartFee->isChecked())
     {
-        nTxConfirmTarget = (int)25 - (int)std::max(0, std::min(24, ui->sliderSmartFee->value()));
+        nTxConfirmTarget = MEMPOOL_ESTIMATE_MAXTARGET - (unsigned int)std::max((unsigned int)0, std::min((MEMPOOL_ESTIMATE_MAXTARGET - 1), (unsigned int)ui->sliderSmartFee->value()));
         payTxFee = CFeeRate(0);
     }
     else
     {
-        nTxConfirmTarget = 25;
+        nTxConfirmTarget = MEMPOOL_ESTIMATE_MAXTARGET;
         payTxFee = CFeeRate(ui->customFee->value());
         fPayAtLeastCustomFee = ui->radioCustomAtLeast->isChecked();
     }

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -385,7 +385,7 @@ CTxMemPool::CTxMemPool(const CFeeRate& _minRelayFee) :
     // to wait a day or two to save a fraction of a penny in fees.
     // Confirmation times for very-low-fee transactions that take more
     // than an hour or three to confirm are highly variable.
-    minerPolicyEstimator = new CMinerPolicyEstimator(25);
+    minerPolicyEstimator = new CMinerPolicyEstimator(MEMPOOL_ESTIMATE_MAXTARGET);
 }
 
 CTxMemPool::~CTxMemPool()

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -30,6 +30,9 @@ inline bool AllowFree(double dPriority)
 /** Fake height value used in CCoins to signify they are only in the memory pool (since 0.8) */
 static const unsigned int MEMPOOL_HEIGHT = 0x7FFFFFFF;
 
+/** CMinerPolicyEstimator bucket count */
+static const unsigned int MEMPOOL_ESTIMATE_MAXTARGET = 25;
+
 /**
  * CTxMemPool stores these:
  */


### PR DESCRIPTION
The priority labels are based on nTxConfirmTarget, which seems to be confusing, as this makes the labels change when you move the slider. So change it to be based on fixed maxtarget(=25).
Only the label-turns-red functionality is still based on nTxConfirmTarget.

Fixes #5552
