### PR TITLE
dmg: fix deterministic dmg creation and docs

### DIFF
--- a/contrib/gitian-descriptors/gitian-osx-signer.yml
+++ b/contrib/gitian-descriptors/gitian-osx-signer.yml
@@ -10,7 +10,7 @@ packages:
 reference_datetime: "2013-06-01 00:00:00"
 remotes: []
 files:
-- "bitcoin-0.9.99-osx-unsigned.tar.gz"
+- "bitcoin-osx-unsigned.tar.gz"
 - "signature.tar.gz"
 script: |
   WRAP_DIR=$HOME/wrapped
@@ -28,8 +28,8 @@ script: |
     chmod +x ${WRAP_DIR}/${prog}
   done
 
-  UNSIGNED=`echo bitcoin-*.tar.gz`
-  SIGNED=`echo ${UNSIGNED} | sed 's/.tar.*//' | sed 's/-unsigned//'`.dmg
+  UNSIGNED=bitcoin-osx-unsigned.tar.gz
+  SIGNED=bitcoin-osx-signed.dmg
 
   tar -xf ${UNSIGNED}
   ./detached-sig-apply.sh ${UNSIGNED} signature.tar.gz

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -68,7 +68,7 @@ Release Process
 	mv build/out/bitcoin-*.zip build/out/bitcoin-*.exe ../
 	./bin/gbuild --commit bitcoin=v${VERSION} ../bitcoin/contrib/gitian-descriptors/gitian-osx.yml
 	./bin/gsign --signer $SIGNER --release ${VERSION}-osx-unsigned --destination ../gitian.sigs/ ../bitcoin/contrib/gitian-descriptors/gitian-osx.yml
-	mv build/out/bitcoin-*-unsigned.tar.gz inputs
+	mv build/out/bitcoin-*-unsigned.tar.gz inputs/bitcoin-osx-unsigned.tar.gz
 	mv build/out/bitcoin-*.tar.gz build/out/bitcoin-*.dmg ../
 	popd
   Build output expected:
@@ -102,7 +102,7 @@ Commit your signature to gitian.sigs:
 	cp signature.tar.gz inputs/
 	./bin/gbuild -i ../bitcoin/contrib/gitian-descriptors/gitian-osx-signer.yml
 	./bin/gsign --signer $SIGNER --release ${VERSION}-osx-signed --destination ../gitian.sigs/ ../bitcoin/contrib/gitian-descriptors/gitian-osx-signer.yml
-	mv build/out/bitcoin-${VERSION}-osx.dmg ../
+	mv build/out/bitcoin-osx-signed.dmg ../bitcoin-${VERSION}-osx.dmg
 	popd
 
 Commit your signature for the signed OSX binary:


### PR DESCRIPTION
I've verified that the process works by manually extracting the signature from rc1 and running it through the re-attaching procedure. Updated the docs and descriptors to fix versioning. Rather than bumping the version for each build, make the inputs version-less. Obviously they must match anyway.

In case anyone wishes to test (I've verified that the dmg works fine)
The detached signature can be found here:
https://bitcoincore.org/cfields/bitcoin-0.10.0rc1/signature.tar.gz

And the final deterministic dmg is here:
https://bitcoincore.org/cfields/bitcoin-0.10.0rc1/bitcoin-0.10.0rc1-osx-signed.dmg

Needs backport to 0.10.
