### PR TITLE
Preemptively catch a few potential bugs

### DIFF
--- a/src/coins.h
+++ b/src/coins.h
@@ -441,6 +441,11 @@ public:
 private:
     CCoinsMap::iterator FetchCoins(const uint256 &txid);
     CCoinsMap::const_iterator FetchCoins(const uint256 &txid) const;
+
+    /**
+     * By making the copy constructor private, we prevent accidentally using it when one intends to create a cache on top of a base cache.
+     */
+    CCoinsViewCache(const CCoinsViewCache &);
 };
 
 #endif // BITCOIN_COINS_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1616,7 +1616,8 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     // Special case for the genesis block, skipping connection of its transactions
     // (its coinbase is unspendable)
     if (block.GetHash() == Params().HashGenesisBlock()) {
-        view.SetBestBlock(pindex->GetBlockHash());
+        if (!fJustCheck)
+            view.SetBestBlock(pindex->GetBlockHash());
         return true;
     }
 


### PR DESCRIPTION
This causes CCoinsViewCache(CCoinsViewCache) to fail at compile-time rather than copy an existing cache (most likely the caller intends to sub-cache it)

It also makes ConnectBlock's fJustCheck work correctly for the genesis block, just in case it gets in there somehow.
