### PR TITLE
Ignore ctags/etags tags file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,7 @@ qa/pull-tester/test.*/*
 /doc/doxygen/
 
 libbitcoinconsensus.pc
+
+# ctags/etags TAGS file
+tags
+TAGS


### PR DESCRIPTION
Make it easier to work with the source tree using ctags/etags, ignore their tags/TAGS files.
