### PR TITLE
depends: fix major regression after d546191dc.

### DIFF
--- a/depends/funcs.mk
+++ b/depends/funcs.mk
@@ -31,8 +31,8 @@ define fetch_file
 endef
 
 define int_get_build_recipe_hash
-$(eval $(1)_all_file_checksums:=$(shell $(build_SHA256SUM) $(meta_depends) packages/$(1).mk $(addprefix $(PATCHES_PATH)/$(1)/,$($(1)_patches))))
-$(eval $(1)_recipe_hash:=$(shell echo -n "$($(1)_all_file_checksums)" | cut -d" " -f1 | $(build_SHA256SUM)))
+$(eval $(1)_all_file_checksums:=$(shell $(build_SHA256SUM) $(meta_depends) packages/$(1).mk $(addprefix $(PATCHES_PATH)/$(1)/,$($(1)_patches)) | cut -d" " -f1))
+$(eval $(1)_recipe_hash:=$(shell echo -n "$($(1)_all_file_checksums)" | $(build_SHA256SUM) | cut -d" " -f1))
 endef
 
 define int_get_build_id


### PR DESCRIPTION
This is included in #5582, but I'm PRing separately because it is a badly needed fix. It also needs backport to 0.10. Unfortunately, this will force all dependencies to be rebuilt. I'll accept lashings as penance...

Will rebase #5882 after merge.

Broken hash logic caused all depends on some platforms (osx at least) to end up with the same build-id. Without this fix, nothing will be rebuilt when recipes or dependencies change. The 'cut' was put in the wrong place, so rather than hashing the hashes, it hashed the filename which was always "-" (stdin). Probably a stupid c/p mistake. 
