### PR TITLE
Addition of a balance column in transaction history table

### DIFF
--- a/src/qt/bitcoinunits.cpp
+++ b/src/qt/bitcoinunits.cpp
@@ -199,6 +199,16 @@ QString BitcoinUnits::getAmountColumnTitle(int unit)
     return amountTitle;
 }
 
+QString BitcoinUnits::getBalanceColumnTitle(int unit)
+{
+    QString balanceTitle = QObject::tr("Balance");
+    if (BitcoinUnits::valid(unit))
+    {
+        balanceTitle += " ("+BitcoinUnits::name(unit) + ")";
+    }
+    return balanceTitle;
+}
+
 int BitcoinUnits::rowCount(const QModelIndex &parent) const
 {
     Q_UNUSED(parent);

--- a/src/qt/bitcoinunits.h
+++ b/src/qt/bitcoinunits.h
@@ -95,6 +95,8 @@ public:
     static bool parse(int unit, const QString &value, CAmount *val_out);
     //! Gets title for amount column including current display unit if optionsModel reference available */
     static QString getAmountColumnTitle(int unit);
+    //! Gets title for balance column including current display unit if optionsModel reference available */
+    static QString getBalanceColumnTitle(int unit);
     ///@}
 
     //! @name AbstractListModel implementation

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -428,21 +428,72 @@ bool ToolTipToRichTextFilter::eventFilter(QObject *obj, QEvent *evt)
     return QObject::eventFilter(obj, evt);
 }
 
-void TableViewLastColumnResizingFixer::connectViewHeadersSignals()
+/**
+ * Initializes all internal variables and set the handled
+ * columns into interactive mode.
+ */
+TableViewLastColumnResizingFixer::TableViewLastColumnResizingFixer(QTableView* table, int lastColumnIndex, int stretchColumnIndex, int minimumColumnWidth) :
+    tableView(table),
+    lastColIndex(lastColumnIndex),
+    stretchColIndex(stretchColumnIndex),
+    minColWidth(minimumColumnWidth)
 {
-    connect(tableView->horizontalHeader(), SIGNAL(sectionResized(int,int,int)), this, SLOT(on_sectionResized(int,int,int)));
-    connect(tableView->horizontalHeader(), SIGNAL(geometriesChanged()), this, SLOT(on_geometriesChanged()));
+    setViewHeaderResizeMode(stretchColumnIndex, QHeaderView::Interactive);
+    setViewHeaderResizeMode(lastColIndex, QHeaderView::Interactive);
 }
 
-// We need to disconnect these while handling the resize events, otherwise we can enter infinite loops.
-void TableViewLastColumnResizingFixer::disconnectViewHeadersSignals()
+/**
+ * Called by external sources such as TransactionView
+ * on a resizeEvent. Scales the stretch column to fill
+ * or give up the size change.
+ */
+void TableViewLastColumnResizingFixer::resized()
 {
-    disconnect(tableView->horizontalHeader(), SIGNAL(sectionResized(int,int,int)), this, SLOT(on_sectionResized(int,int,int)));
-    disconnect(tableView->horizontalHeader(), SIGNAL(geometriesChanged()), this, SLOT(on_geometriesChanged()));
+    resizeColumn(stretchColIndex, getAvailableWidthForColumn(stretchColIndex));
 }
 
-// Setup the resize mode, handles compatibility for Qt5 and below as the method signatures changed.
-// Refactored here for readability.
+/**
+ * Make sure the columns don't get wider than the viewport.
+ * Also, keey the last column's size snug against the right side.
+ */
+void TableViewLastColumnResizingFixer::adjustTableColumnsWidth()
+{
+    // We no longer stretch the last column here, since we have
+    // elaborated on on_sectionResized handling.
+    if (getColumnsWidth() > tableView->horizontalHeader()->width())
+        resizeColumn(stretchColIndex, getAvailableWidthForColumn(stretchColIndex));
+}
+
+/**
+ * Add up the total current width of all the columns.
+ */
+int TableViewLastColumnResizingFixer::getColumnsWidth()
+{
+    int totalWidth = 0;
+    for (int i = 0;i <= lastColIndex;i++)
+        totalWidth += tableView->horizontalHeader()->sectionSize(i);
+    return totalWidth;
+}
+
+/**
+ * Calculate the width availible for the specified column from the 
+ * availible width left after teh total column widths not including
+ * the column being determined.
+ */
+int TableViewLastColumnResizingFixer::getAvailableWidthForColumn(int colIndex)
+{
+    int width = tableView->horizontalHeader()->width();
+    if (width > 0) {
+        width -= (getColumnsWidth() - tableView->horizontalHeader()->sectionSize(colIndex));
+        return std::max(minColWidth, width);
+    }
+    return minColWidth;
+}
+
+/**
+ * Setup the resize mode, handles compatibility for Qt5 and below as the method signatures changed.
+ * Refactored here for readability.
+ */
 void TableViewLastColumnResizingFixer::setViewHeaderResizeMode(int logicalIndex, QHeaderView::ResizeMode resizeMode)
 {
 #if QT_VERSION < 0x050000
@@ -452,97 +503,81 @@ void TableViewLastColumnResizingFixer::setViewHeaderResizeMode(int logicalIndex,
 #endif
 }
 
-void TableViewLastColumnResizingFixer::resizeColumn(int nColumnIndex, int width)
-{
-    tableView->setColumnWidth(nColumnIndex, width);
-    tableView->horizontalHeader()->resizeSection(nColumnIndex, width);
-}
-
-int TableViewLastColumnResizingFixer::getColumnsWidth()
-{
-    int nColumnsWidthSum = 0;
-    for (int i = 0; i < columnCount; i++)
-    {
-        nColumnsWidthSum += tableView->horizontalHeader()->sectionSize(i);
-    }
-    return nColumnsWidthSum;
-}
-
-int TableViewLastColumnResizingFixer::getAvailableWidthForColumn(int column)
-{
-    int nResult = lastColumnMinimumWidth;
-    int nTableWidth = tableView->horizontalHeader()->width();
-
-    if (nTableWidth > 0)
-    {
-        int nOtherColsWidth = getColumnsWidth() - tableView->horizontalHeader()->sectionSize(column);
-        nResult = std::max(nResult, nTableWidth - nOtherColsWidth);
-    }
-
-    return nResult;
-}
-
-// Make sure we don't make the columns wider than the tables viewport width.
-void TableViewLastColumnResizingFixer::adjustTableColumnsWidth()
+/** 
+ * Manually sets a column's width while ignoring singnals
+ * the resize causes to prevent infinate loops.
+ */
+void TableViewLastColumnResizingFixer::resizeColumn(int colIndex, int width)
 {
     disconnectViewHeadersSignals();
-    resizeColumn(lastColumnIndex, getAvailableWidthForColumn(lastColumnIndex));
-    connectViewHeadersSignals();
-
-    int nTableWidth = tableView->horizontalHeader()->width();
-    int nColsWidth = getColumnsWidth();
-    if (nColsWidth > nTableWidth)
-    {
-        resizeColumn(secondToLastColumnIndex,getAvailableWidthForColumn(secondToLastColumnIndex));
-    }
-}
-
-// Make column use all the space available, useful during window resizing.
-void TableViewLastColumnResizingFixer::stretchColumnWidth(int column)
-{
-    disconnectViewHeadersSignals();
-    resizeColumn(column, getAvailableWidthForColumn(column));
+    tableView->setColumnWidth(colIndex, width);
+    tableView->horizontalHeader()->resizeSection(colIndex, width);
     connectViewHeadersSignals();
 }
 
-// When a section is resized this is a slot-proxy for ajustAmountColumnWidth().
+/**
+ * Connect to table view column header's relevant resizing signals.
+ */
+void TableViewLastColumnResizingFixer::connectViewHeadersSignals()
+{
+    connect(tableView->horizontalHeader(), SIGNAL(sectionResized(int,int,int)), this, SLOT(on_sectionResized(int,int,int)));
+    connect(tableView->horizontalHeader(), SIGNAL(geometriesChanged()), this, SLOT(on_geometriesChanged()));
+}
+
+/**
+ * Disconnect from table view column header's resizing signals
+ * so we can listen to and ignore these signals as we wish.
+ */
+void TableViewLastColumnResizingFixer::disconnectViewHeadersSignals()
+{
+    disconnect(tableView->horizontalHeader(), SIGNAL(sectionResized(int,int,int)), this, SLOT(on_sectionResized(int,int,int)));
+    disconnect(tableView->horizontalHeader(), SIGNAL(geometriesChanged()), this, SLOT(on_geometriesChanged()));
+}
+
+/**
+ * When a column section is resized we handle specific columns of interest
+ * with special handling to dictate which column fills the leftover space.
+ * Also use the stretch column to fill any caps or to shink incase we exceed
+ * availible space.
+ */
 void TableViewLastColumnResizingFixer::on_sectionResized(int logicalIndex, int oldSize, int newSize)
 {
-    adjustTableColumnsWidth();
-    int remainingWidth = getAvailableWidthForColumn(logicalIndex);
-    if (newSize > remainingWidth)
-    {
-       resizeColumn(logicalIndex, remainingWidth);
+    // Cause stretch column resizing to take and give width from its neighbor to the right.
+    if (logicalIndex == stretchColIndex) {
+        resizeColumn(stretchColIndex, newSize);
+        resizeColumn(stretchColIndex + 1, getAvailableWidthForColumn(stretchColIndex + 1));
     }
-}
-
-// When the tabless geometry is ready, we manually perform the stretch of the "Message" column,
-// as the "Stretch" resize mode does not allow for interactive resizing.
-void TableViewLastColumnResizingFixer::on_geometriesChanged()
-{
-    if ((getColumnsWidth() - this->tableView->horizontalHeader()->width()) != 0)
-    {
-        disconnectViewHeadersSignals();
-        resizeColumn(secondToLastColumnIndex, getAvailableWidthForColumn(secondToLastColumnIndex));
-        connectViewHeadersSignals();
+    else if (logicalIndex == lastColIndex -1){
+        // Special handling for the next to last column causes it to stretch the last column
+        // and bypass the standard handling.
+        resizeColumn(logicalIndex, newSize);
+        resizeColumn(lastColIndex, getAvailableWidthForColumn(lastColIndex));
+        adjustTableColumnsWidth();
+        return; // Special case bypasses standard handling.
+    }
+    else {
+        // Otherwise, the stretch column will give or take any slack.
+        resizeColumn(stretchColIndex, getAvailableWidthForColumn(stretchColIndex));
+    }
+    
+    adjustTableColumnsWidth();
+    int avail = getAvailableWidthForColumn(logicalIndex);
+    // logicalIndex column is already resized to newSize. Now we have expanded
+    // to fill in the leftover gaps or shrunk to give it space. If there is no
+    // longer enough space for this new size, we restrict it to what size we do have.
+    if (newSize > avail) {
+        resizeColumn(logicalIndex, avail);
+        resizeColumn(stretchColIndex, getAvailableWidthForColumn(stretchColIndex));	
     }
 }
 
 /**
- * Initializes all internal variables and prepares the
- * the resize modes of the last 2 columns of the table and
+ * When the table's geometry is ready, we stretch our intended column.
  */
-TableViewLastColumnResizingFixer::TableViewLastColumnResizingFixer(QTableView* table, int lastColMinimumWidth, int allColsMinimumWidth) :
-    tableView(table),
-    lastColumnMinimumWidth(lastColMinimumWidth),
-    allColumnsMinimumWidth(allColsMinimumWidth)
+void TableViewLastColumnResizingFixer::on_geometriesChanged()
 {
-    columnCount = tableView->horizontalHeader()->count();
-    lastColumnIndex = columnCount - 1;
-    secondToLastColumnIndex = columnCount - 2;
-    tableView->horizontalHeader()->setMinimumSectionSize(allColumnsMinimumWidth);
-    setViewHeaderResizeMode(secondToLastColumnIndex, QHeaderView::Interactive);
-    setViewHeaderResizeMode(lastColumnIndex, QHeaderView::Interactive);
+    if ((getColumnsWidth() - tableView->horizontalHeader()->width()) != 0)
+        resizeColumn(stretchColIndex, getAvailableWidthForColumn(stretchColIndex));
 }
 
 #ifdef WIN32

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -432,12 +432,12 @@ bool ToolTipToRichTextFilter::eventFilter(QObject *obj, QEvent *evt)
  * Initializes all internal variables and set the handled
  * columns into interactive mode.
  */
-TableViewLastColumnResizingFixer::TableViewLastColumnResizingFixer(QTableView* table, int lastColumnIndex, int stretchColumnIndex, int minimumColumnWidth) :
+TableViewLastColumnResizingFixer::TableViewLastColumnResizingFixer(QTableView* table, int stretchColumnIndex, int minimumColumnWidth) :
     tableView(table),
-    lastColIndex(lastColumnIndex),
     stretchColIndex(stretchColumnIndex),
     minColWidth(minimumColumnWidth)
 {
+    lastColIndex = tableView->horizontalHeader()->count() - 1;
     setViewHeaderResizeMode(stretchColumnIndex, QHeaderView::Interactive);
     setViewHeaderResizeMode(lastColIndex, QHeaderView::Interactive);
 }

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -142,7 +142,7 @@ namespace GUIUtil
         Q_OBJECT
 
         public:
-            TableViewLastColumnResizingFixer(QTableView* table, int lastColumnIndex, int stretchColumnIndex, int minimumColumnWidth);
+            TableViewLastColumnResizingFixer(QTableView* table, int stretchColumnIndex, int minimumColumnWidth);
             void resized();
 
         private:

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -126,7 +126,7 @@ namespace GUIUtil
     private:
         int size_threshold;
     };
-
+    
     /**
      * Makes a QTableView last column feel as if it was being resized from its left border.
      * Also makes sure the column widths are never larger than the table's viewport.
@@ -142,24 +142,22 @@ namespace GUIUtil
         Q_OBJECT
 
         public:
-            TableViewLastColumnResizingFixer(QTableView* table, int lastColMinimumWidth, int allColsMinimumWidth);
-            void stretchColumnWidth(int column);
+            TableViewLastColumnResizingFixer(QTableView* table, int lastColumnIndex, int stretchColumnIndex, int minimumColumnWidth);
+            void resized();
 
         private:
             QTableView* tableView;
-            int lastColumnMinimumWidth;
-            int allColumnsMinimumWidth;
-            int lastColumnIndex;
-            int columnCount;
-            int secondToLastColumnIndex;
-
+            int lastColIndex;
+            int stretchColIndex;
+            int minColWidth;
             void adjustTableColumnsWidth();
-            int getAvailableWidthForColumn(int column);
+            int getAvailableWidthForColumn(int colIndex);
             int getColumnsWidth();
+            void autosizeColumn(int colIndex);
+            void setViewHeaderResizeMode(int logicalIndex, QHeaderView::ResizeMode resizeMode);
+            void resizeColumn(int colIndex, int width);
             void connectViewHeadersSignals();
             void disconnectViewHeadersSignals();
-            void setViewHeaderResizeMode(int logicalIndex, QHeaderView::ResizeMode resizeMode);
-            void resizeColumn(int nColumnIndex, int width);
 
         private slots:
             void on_sectionResized(int logicalIndex, int oldSize, int newSize);

--- a/src/qt/receivecoinsdialog.cpp
+++ b/src/qt/receivecoinsdialog.cpp
@@ -80,7 +80,7 @@ void ReceiveCoinsDialog::setModel(WalletModel *model)
             SIGNAL(selectionChanged(QItemSelection, QItemSelection)), this,
             SLOT(recentRequestsView_selectionChanged(QItemSelection, QItemSelection)));
         // Last 2 columns are set by the columnResizingFixer, when the table geometry is ready.
-        columnResizingFixer = new GUIUtil::TableViewLastColumnResizingFixer(tableView, AMOUNT_MINIMUM_COLUMN_WIDTH, DATE_COLUMN_WIDTH);
+        columnResizingFixer = new GUIUtil::TableViewLastColumnResizingFixer(tableView, RecentRequestsTableModel::Amount, RecentRequestsTableModel::Message, MINIMUM_COLUMN_WIDTH);
     }
 }
 
@@ -202,7 +202,7 @@ void ReceiveCoinsDialog::on_removeRequestButton_clicked()
 void ReceiveCoinsDialog::resizeEvent(QResizeEvent *event)
 {
     QWidget::resizeEvent(event);
-    columnResizingFixer->stretchColumnWidth(RecentRequestsTableModel::Message);
+    columnResizingFixer->resized();
 }
 
 void ReceiveCoinsDialog::keyPressEvent(QKeyEvent *event)

--- a/src/qt/receivecoinsdialog.cpp
+++ b/src/qt/receivecoinsdialog.cpp
@@ -80,7 +80,7 @@ void ReceiveCoinsDialog::setModel(WalletModel *model)
             SIGNAL(selectionChanged(QItemSelection, QItemSelection)), this,
             SLOT(recentRequestsView_selectionChanged(QItemSelection, QItemSelection)));
         // Last 2 columns are set by the columnResizingFixer, when the table geometry is ready.
-        columnResizingFixer = new GUIUtil::TableViewLastColumnResizingFixer(tableView, RecentRequestsTableModel::Amount, RecentRequestsTableModel::Message, MINIMUM_COLUMN_WIDTH);
+        columnResizingFixer = new GUIUtil::TableViewLastColumnResizingFixer(tableView, RecentRequestsTableModel::Message, MINIMUM_COLUMN_WIDTH);
     }
 }
 

--- a/src/qt/transactionfilterproxy.cpp
+++ b/src/qt/transactionfilterproxy.cpp
@@ -24,6 +24,7 @@ TransactionFilterProxy::TransactionFilterProxy(QObject *parent) :
     typeFilter(ALL_TYPES),
     watchOnlyFilter(WatchOnlyFilter_All),
     minAmount(0),
+    minBalance(0),
     limitRows(-1),
     showInactive(true)
 {
@@ -39,6 +40,7 @@ bool TransactionFilterProxy::filterAcceptsRow(int sourceRow, const QModelIndex &
     QString address = index.data(TransactionTableModel::AddressRole).toString();
     QString label = index.data(TransactionTableModel::LabelRole).toString();
     qint64 amount = llabs(index.data(TransactionTableModel::AmountRole).toLongLong());
+    qint64 balance = llabs(index.data(TransactionTableModel::BalanceRole).toLongLong());
     int status = index.data(TransactionTableModel::StatusRole).toInt();
 
     if(!showInactive && status == TransactionStatus::Conflicted)
@@ -54,6 +56,8 @@ bool TransactionFilterProxy::filterAcceptsRow(int sourceRow, const QModelIndex &
     if (!address.contains(addrPrefix, Qt::CaseInsensitive) && !label.contains(addrPrefix, Qt::CaseInsensitive))
         return false;
     if(amount < minAmount)
+        return false;
+    if(balance < minBalance)
         return false;
 
     return true;
@@ -81,6 +85,12 @@ void TransactionFilterProxy::setTypeFilter(quint32 modes)
 void TransactionFilterProxy::setMinAmount(const CAmount& minimum)
 {
     this->minAmount = minimum;
+    invalidateFilter();
+}
+
+void TransactionFilterProxy::setMinBalance(const CAmount& minimum)
+{
+    this->minBalance = minimum;
     invalidateFilter();
 }
 

--- a/src/qt/transactionfilterproxy.h
+++ b/src/qt/transactionfilterproxy.h
@@ -41,6 +41,7 @@ public:
      */
     void setTypeFilter(quint32 modes);
     void setMinAmount(const CAmount& minimum);
+    void setMinBalance(const CAmount& minimum);
     void setWatchOnlyFilter(WatchOnlyFilter filter);
 
     /** Set maximum number of rows returned, -1 if unlimited. */
@@ -61,6 +62,7 @@ private:
     quint32 typeFilter;
     WatchOnlyFilter watchOnlyFilter;
     CAmount minAmount;
+    CAmount minBalance;
     int limitRows;
     bool showInactive;
 };

--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -83,13 +83,13 @@ public:
     static const int RecommendedNumConfirmations = 6;
 
     TransactionRecord():
-            hash(), time(0), type(Other), address(""), debit(0), credit(0), idx(0)
+            hash(), time(0), type(Other), address(""), debit(0), credit(0), idx(0), balance(0)
     {
     }
 
     TransactionRecord(uint256 hash, qint64 time):
             hash(hash), time(time), type(Other), address(""), debit(0),
-            credit(0), idx(0)
+            credit(0), idx(0), balance(0)
     {
     }
 
@@ -97,7 +97,7 @@ public:
                 Type type, const std::string &address,
                 const CAmount& debit, const CAmount& credit):
             hash(hash), time(time), type(type), address(address), debit(debit), credit(credit),
-            idx(0)
+            idx(0), balance(0)
     {
     }
 
@@ -124,6 +124,9 @@ public:
 
     /** Whether the transaction was sent/received with a watch-only address */
     bool involvesWatchAddress;
+
+    /** Balance as of this transaction */
+    CAmount balance;
 
     /** Return the unique identifier for this transaction (part) */
     QString getTxID() const;

--- a/src/qt/transactiontablemodel.h
+++ b/src/qt/transactiontablemodel.h
@@ -32,7 +32,8 @@ public:
         Date = 2,
         Type = 3,
         ToAddress = 4,
-        Amount = 5
+        Amount = 5,
+        Balance = 6
     };
 
     /** Roles to get specific information from a transaction row.
@@ -55,6 +56,8 @@ public:
         LabelRole,
         /** Net amount of transaction */
         AmountRole,
+        /** Balance at transaction */
+        BalanceRole,
         /** Unique identifier */
         TxIDRole,
         /** Transaction hash */
@@ -63,6 +66,8 @@ public:
         ConfirmedRole,
         /** Formatted amount, without brackets when unconfirmed */
         FormattedAmountRole,
+        /** Formatted balance */
+        FormattedBalanceRole,
         /** Transaction status (TransactionRecord::Status) */
         StatusRole
     };
@@ -91,6 +96,7 @@ private:
     QString formatTxType(const TransactionRecord *wtx) const;
     QString formatTxToAddress(const TransactionRecord *wtx, bool tooltip) const;
     QString formatTxAmount(const TransactionRecord *wtx, bool showUnconfirmed=true, BitcoinUnits::SeparatorStyle separators=BitcoinUnits::separatorStandard) const;
+    QString formatTxBalance(const TransactionRecord *wtx, BitcoinUnits::SeparatorStyle separators=BitcoinUnits::separatorStandard) const;
     QString formatTooltip(const TransactionRecord *rec) const;
     QVariant txStatusDecoration(const TransactionRecord *wtx) const;
     QVariant txWatchonlyDecoration(const TransactionRecord *wtx) const;
@@ -103,6 +109,8 @@ public slots:
     void updateDisplayUnit();
     /** Updates the column title to "Amount (DisplayUnit)" and emits headerDataChanged() signal for table headers to react. */
     void updateAmountColumnTitle();
+    /** Updates the column title to "Balance (DisplayUnit)" and emits headerDataChanged() signal for table headers to react. */
+    void updateBalanceColumnTitle();
     /* Needed to update fProcessingQueuedTransactions through a QueuedConnection */
     void setProcessingQueuedTransactions(bool value) { fProcessingQueuedTransactions = value; }
 

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -217,7 +217,7 @@ void TransactionView::setModel(WalletModel *model)
         transactionView->setColumnWidth(TransactionTableModel::Amount, AMOUNT_MINIMUM_COLUMN_WIDTH);
         transactionView->setColumnWidth(TransactionTableModel::Balance, BALANCE_MINIMUM_COLUMN_WIDTH);
 
-        columnResizingFixer = new GUIUtil::TableViewLastColumnResizingFixer(transactionView, AMOUNT_MINIMUM_COLUMN_WIDTH, MINIMUM_COLUMN_WIDTH);
+        columnResizingFixer = new GUIUtil::TableViewLastColumnResizingFixer(transactionView, TransactionTableModel::Balance, TransactionTableModel::ToAddress, MINIMUM_COLUMN_WIDTH);
 
         if (model->getOptionsModel())
         {
@@ -369,7 +369,6 @@ void TransactionView::exportClicked()
     writer.addColumn(tr("Label"), 0, TransactionTableModel::LabelRole);
     writer.addColumn(tr("Address"), 0, TransactionTableModel::AddressRole);
     writer.addColumn(BitcoinUnits::getAmountColumnTitle(model->getOptionsModel()->getDisplayUnit()), 0, TransactionTableModel::FormattedAmountRole);
-    writer.addColumn(tr("Balance"), 0, TransactionTableModel::BalanceRole);
     writer.addColumn(BitcoinUnits::getBalanceColumnTitle(model->getOptionsModel()->getDisplayUnit()), 0, TransactionTableModel::FormattedBalanceRole);
     writer.addColumn(tr("ID"), 0, TransactionTableModel::TxIDRole);
 
@@ -544,7 +543,7 @@ void TransactionView::focusTransaction(const QModelIndex &idx)
 void TransactionView::resizeEvent(QResizeEvent* event)
 {
     QWidget::resizeEvent(event);
-    columnResizingFixer->stretchColumnWidth(TransactionTableModel::ToAddress);
+    columnResizingFixer->resized();
 }
 
 // Need to override default Ctrl+C action for amount as default behaviour is just to copy DisplayRole text

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -217,7 +217,7 @@ void TransactionView::setModel(WalletModel *model)
         transactionView->setColumnWidth(TransactionTableModel::Amount, AMOUNT_MINIMUM_COLUMN_WIDTH);
         transactionView->setColumnWidth(TransactionTableModel::Balance, BALANCE_MINIMUM_COLUMN_WIDTH);
 
-        columnResizingFixer = new GUIUtil::TableViewLastColumnResizingFixer(transactionView, TransactionTableModel::Balance, TransactionTableModel::ToAddress, MINIMUM_COLUMN_WIDTH);
+        columnResizingFixer = new GUIUtil::TableViewLastColumnResizingFixer(transactionView, TransactionTableModel::ToAddress, MINIMUM_COLUMN_WIDTH);
 
         if (model->getOptionsModel())
         {

--- a/src/qt/transactionview.h
+++ b/src/qt/transactionview.h
@@ -54,6 +54,7 @@ public:
         DATE_COLUMN_WIDTH = 120,
         TYPE_COLUMN_WIDTH = 120,
         AMOUNT_MINIMUM_COLUMN_WIDTH = 120,
+        BALANCE_MINIMUM_COLUMN_WIDTH = 120,
         MINIMUM_COLUMN_WIDTH = 23
     };
 
@@ -67,6 +68,7 @@ private:
     QComboBox *watchOnlyWidget;
     QLineEdit *addressWidget;
     QLineEdit *amountWidget;
+    QLineEdit *balanceWidget;
 
     QMenu *contextMenu;
     QSignalMapper *mapperThirdPartyTxUrls;
@@ -91,6 +93,7 @@ private slots:
     void editLabel();
     void copyLabel();
     void copyAmount();
+    void copyBalance();
     void copyTxID();
     void openThirdPartyTxUrl(QString url);
     void updateWatchOnlyColumn(bool fHaveWatchOnly);
@@ -107,6 +110,7 @@ public slots:
     void chooseWatchonly(int idx);
     void changedPrefix(const QString &prefix);
     void changedAmount(const QString &amount);
+    void changedBalance(const QString &balance);
     void exportClicked();
     void focusTransaction(const QModelIndex&);
 


### PR DESCRIPTION
I created a running balance column in the transaction table, like you would see on most financial ledgers. This came into complications with the table's column re-size fixer system. I updated that as well to support multiple columns to the right of the column you want to stretch.

Balance column details:

This was accomplished by adding a balance variable to the TransactionRecord class, but the main code which fills those variables is in (/src/qt/transactiontablemodel.cpp) TransactionTablePriv::updateWalletBalances() which is called in reaction to TransactionTablePriv::refreshWallet() and new/deleted transactions detected in TransactionTablePriv::updateWallet(). 

TransactionTablePriv::updateWalletBalances() builds a list of pointers to the transactions in the TransactionTablePriv::cachedWallet list, sorts them by time as they are already ordered by hash, then iterates them calculating the balance at the time that transaction came in the list.

Many changes were made to support adding the GUI column and all the features that go with that. This includes filtering support, Bitcoin units support, CSV export support, and column sorting support.

Column size fixer details:

The (src/qt/guiutil.cpp) TableViewLastColumnResizingFixer was created expecting the RecentRequestsTableModel::Message to be the main stretching column and only the RecentRequestsTableModel::Amount column to be to the right of it as well as being the right most column. 

I updated this to allow you to specify the stretch column index. It handles the special cases of re-sizing the stretch column, the last column, and the second last column. Aside from restoring the same functionality with support for the additional column (and future column additions), it also restores the ability to re-size the last column from the right side. This isn't an intuitive way to do it, but there seems no benefit from preventing doing so. I think preventing this was just a side effect of the previous code.

This column size fixer is used on the transaction table (src/qt/transactionview.cpp) and the received coins table (src/qt/receivecoinsdialog.cpp).

I put together a quick video comparing the column re-sizing Qt default behavior, the original Bitcoin column size fixer, what happens to the original fixer when the new balance column is added, and how it works with the balance column and the updated column fixer.

http://youtu.be/7N-c9p-YNCQ
