### PR TITLE
Updated copyright dates on various readme files

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -1,7 +1,7 @@
 Bitcoin 0.10.99
 =====================
 
-Copyright (c) 2009-2014 Bitcoin Developers
+Copyright (c) 2009-2015 Bitcoin Developers
 
 
 Setup

--- a/doc/README_windows.txt
+++ b/doc/README_windows.txt
@@ -1,6 +1,6 @@
 Bitcoin 0.10.99
 
-Copyright (c) 2009-2014 Bitcoin Core Developers
+Copyright (c) 2009-2015 Bitcoin Core Developers
 
 Distributed under the MIT software license, see the accompanying
 file COPYING or http://www.opensource.org/licenses/mit-license.php.

--- a/src/test/data/README.md
+++ b/src/test/data/README.md
@@ -8,7 +8,7 @@ License
 
 The data files in this directory are
 
-    Copyright (c) 2012-2014 The Bitcoin Core developers
+    Copyright (c) 2012-2015 The Bitcoin Core developers
     Distributed under the MIT software license, see the accompanying
     file COPYING or http://www.opensource.org/licenses/mit-license.php.
 


### PR DESCRIPTION
Not including `README.md` in the root directory, as it is covered by #5590
