### PR TITLE
Policy: Create CPolicy interface and CStandardPolicy class implementing it

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -87,6 +87,7 @@ BITCOIN_CORE_H = \
   coins.h \
   compat.h \
   compressor.h \
+  consensus/consensus.h \
   consensus/params.h \
   core_io.h \
   wallet/db.h \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -106,6 +106,7 @@ BITCOIN_CORE_H = \
   netbase.h \
   net.h \
   noui.h \
+  policy/policy.h \
   pow.h \
   primitives/block.h \
   primitives/transaction.h \
@@ -182,6 +183,7 @@ libbitcoin_server_a_SOURCES = \
   miner.cpp \
   net.cpp \
   noui.cpp \
+  policy/policy.cpp \
   pow.cpp \
   rest.cpp \
   rpcblockchain.cpp \

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -8,6 +8,7 @@
 #include "consensus/consensus.h"
 #include "core_io.h"
 #include "keystore.h"
+#include "policy/policy.h"
 #include "primitives/transaction.h"
 #include "script/script.h"
 #include "script/sign.h"

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -4,18 +4,18 @@
 
 #include "base58.h"
 #include "clientversion.h"
-#include "primitives/block.h" // for MAX_BLOCK_SIZE
-#include "primitives/transaction.h"
-#include "core_io.h"
 #include "coins.h"
+#include "consensus/consensus.h"
+#include "core_io.h"
 #include "keystore.h"
+#include "primitives/transaction.h"
 #include "script/script.h"
 #include "script/sign.h"
 #include "ui_interface.h" // for _(...)
 #include "univalue/univalue.h"
 #include "util.h"
-#include "utilstrencodings.h"
 #include "utilmoneystr.h"
+#include "utilstrencodings.h"
 
 #include <stdio.h>
 

--- a/src/consensus/consensus.h
+++ b/src/consensus/consensus.h
@@ -1,0 +1,18 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2014 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_CONSENSUS_CONSENSUS_H
+#define BITCOIN_CONSENSUS_CONSENSUS_H
+
+/** The maximum allowed size for a serialized block, in bytes (network rule) */
+static const unsigned int MAX_BLOCK_SIZE = 1000000;
+/** The maximum allowed number of signature check operations in a block (network rule) */
+static const unsigned int MAX_BLOCK_SIGOPS = MAX_BLOCK_SIZE/50;
+/** Coinbase transaction outputs can only be spent after this number of new blocks (network rule) */
+static const int COINBASE_MATURITY = 100;
+/** Threshold for nLockTime: below this value it is interpreted as block number, otherwise as UNIX timestamp. */
+static const unsigned int LOCKTIME_THRESHOLD = 500000000; // Tue Nov  5 00:53:20 1985 UTC
+
+#endif // BITCOIN_CONSENSUS_CONSENSUS_H

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -17,6 +17,7 @@
 #include "main.h"
 #include "miner.h"
 #include "net.h"
+#include "policy/policy.h"
 #include "rpcserver.h"
 #include "script/standard.h"
 #include "txdb.h"

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -384,6 +384,8 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-shrinkdebugfile", _("Shrink debug.log file on client startup (default: 1 when no -debug)"));
     strUsage += HelpMessageOpt("-testnet", _("Use the test network"));
 
+    strUsage += GetPolicyUsageStr(GetArg("-policy", "standard"));
+
     strUsage += HelpMessageGroup(_("Node relay options:"));
     strUsage += HelpMessageOpt("-datacarrier", strprintf(_("Relay and mine data carrier transactions (default: %u)"), 1));
     strUsage += HelpMessageOpt("-datacarriersize", strprintf(_("Maximum size of data in data carrier transactions we relay and mine (default: %u)"), MAX_OP_RETURN_RELAY));
@@ -724,6 +726,13 @@ bool AppInit2(boost::thread_group& threadGroup)
     // This can be removed eventually...
     const char* pszP2SH = "/P2SH/";
     COINBASE_FLAGS << std::vector<unsigned char>(pszP2SH, pszP2SH+strlen(pszP2SH));
+
+    // Init Policy
+    try {
+        InitPolicyFromArgs(mapArgs, "standard");
+    } catch(std::exception &e) {
+        return InitError(strprintf(_("Error while initializing policy: %s"), e.what()));
+    }
 
     // Fee-per-kilobyte amount considered the same as "free"
     // If you are mining, be careful setting this:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -617,7 +617,7 @@ bool IsStandardTx(const CTransaction& tx, string& reason)
     unsigned int nDataOut = 0;
     txnouttype whichType;
     BOOST_FOREACH(const CTxOut& txout, tx.vout) {
-        if (!::IsStandard(txout.scriptPubKey, whichType)) {
+        if (!Policy().ApproveScript(txout.scriptPubKey, whichType)) {
             reason = "scriptpubkey";
             return false;
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,9 +11,11 @@
 #include "chainparams.h"
 #include "checkpoints.h"
 #include "checkqueue.h"
+#include "consensus/consensus.h"
 #include "init.h"
 #include "merkleblock.h"
 #include "net.h"
+#include "policy/policy.h"
 #include "pow.h"
 #include "txdb.h"
 #include "txmempool.h"
@@ -52,12 +54,8 @@ int nScriptCheckThreads = 0;
 bool fImporting = false;
 bool fReindex = false;
 bool fTxIndex = false;
-bool fIsBareMultisigStd = true;
 bool fCheckBlockIndex = false;
 unsigned int nCoinCacheSize = 5000;
-
-/** Fees smaller than this (in satoshi) are considered zero fee (for relaying and mining) */
-CFeeRate minRelayTxFee = CFeeRate(1000);
 
 CTxMemPool mempool(::minRelayTxFee);
 

--- a/src/main.h
+++ b/src/main.h
@@ -14,9 +14,10 @@
 #include "chain.h"
 #include "chainparams.h"
 #include "coins.h"
+#include "consensus/consensus.h"
+#include "net.h"
 #include "primitives/block.h"
 #include "primitives/transaction.h"
-#include "net.h"
 #include "script/script.h"
 #include "script/sigcache.h"
 #include "script/standard.h"
@@ -53,8 +54,6 @@ static const unsigned int DEFAULT_BLOCK_MIN_SIZE = 0;
 static const unsigned int DEFAULT_BLOCK_PRIORITY_SIZE = 50000;
 /** The maximum size for transactions we're willing to relay/mine */
 static const unsigned int MAX_STANDARD_TX_SIZE = 100000;
-/** The maximum allowed number of signature check operations in a block (network rule) */
-static const unsigned int MAX_BLOCK_SIGOPS = MAX_BLOCK_SIZE/50;
 /** Maximum number of signature check operations in an IsStandard() P2SH script */
 static const unsigned int MAX_P2SH_SIGOPS = 15;
 /** The maximum number of sigops we're willing to relay/mine in a single tx */
@@ -67,10 +66,6 @@ static const unsigned int MAX_BLOCKFILE_SIZE = 0x8000000; // 128 MiB
 static const unsigned int BLOCKFILE_CHUNK_SIZE = 0x1000000; // 16 MiB
 /** The pre-allocation chunk size for rev?????.dat files (since 0.8) */
 static const unsigned int UNDOFILE_CHUNK_SIZE = 0x100000; // 1 MiB
-/** Coinbase transaction outputs can only be spent after this number of new blocks (network rule) */
-static const int COINBASE_MATURITY = 100;
-/** Threshold for nLockTime: below this value it is interpreted as block number, otherwise as UNIX timestamp. */
-static const unsigned int LOCKTIME_THRESHOLD = 500000000; // Tue Nov  5 00:53:20 1985 UTC
 /** Maximum number of script-checking threads allowed */
 static const int MAX_SCRIPTCHECK_THREADS = 16;
 /** -par default (number of script-checking threads, 0 = auto) */

--- a/src/main.h
+++ b/src/main.h
@@ -14,7 +14,6 @@
 #include "chain.h"
 #include "chainparams.h"
 #include "coins.h"
-#include "consensus/consensus.h"
 #include "net.h"
 #include "primitives/block.h"
 #include "primitives/transaction.h"
@@ -47,17 +46,6 @@ class CValidationState;
 
 struct CNodeStateStats;
 
-/** Default for -blockmaxsize and -blockminsize, which control the range of sizes the mining code will create **/
-static const unsigned int DEFAULT_BLOCK_MAX_SIZE = 750000;
-static const unsigned int DEFAULT_BLOCK_MIN_SIZE = 0;
-/** Default for -blockprioritysize, maximum space for zero/low-fee transactions **/
-static const unsigned int DEFAULT_BLOCK_PRIORITY_SIZE = 50000;
-/** The maximum size for transactions we're willing to relay/mine */
-static const unsigned int MAX_STANDARD_TX_SIZE = 100000;
-/** Maximum number of signature check operations in an IsStandard() P2SH script */
-static const unsigned int MAX_P2SH_SIGOPS = 15;
-/** The maximum number of sigops we're willing to relay/mine in a single tx */
-static const unsigned int MAX_STANDARD_TX_SIGOPS = MAX_BLOCK_SIGOPS/5;
 /** Default for -maxorphantx, maximum number of orphan transactions kept in memory */
 static const unsigned int DEFAULT_MAX_ORPHAN_TRANSACTIONS = 100;
 /** The maximum size of a blk?????.dat file (since 0.8) */
@@ -116,10 +104,8 @@ extern bool fImporting;
 extern bool fReindex;
 extern int nScriptCheckThreads;
 extern bool fTxIndex;
-extern bool fIsBareMultisigStd;
 extern bool fCheckBlockIndex;
 extern unsigned int nCoinCacheSize;
-extern CFeeRate minRelayTxFee;
 
 /** Best header we've seen so far (used for getheaders queries' starting points). */
 extern CBlockIndex *pindexBestHeader;

--- a/src/merkleblock.cpp
+++ b/src/merkleblock.cpp
@@ -6,7 +6,7 @@
 #include "merkleblock.h"
 
 #include "hash.h"
-#include "primitives/block.h" // for MAX_BLOCK_SIZE
+#include "consensus/consensus.h"
 #include "utilstrencodings.h"
 
 using namespace std;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -7,6 +7,7 @@
 
 #include "amount.h"
 #include "chainparams.h"
+#include "consensus/consensus.h"
 #include "hash.h"
 #include "main.h"
 #include "net.h"

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -11,6 +11,7 @@
 #include "hash.h"
 #include "main.h"
 #include "net.h"
+#include "policy/policy.h"
 #include "pow.h"
 #include "primitives/transaction.h"
 #include "timedata.h"

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -8,7 +8,75 @@
 #include "policy/policy.h"
 
 #include "amount.h"
+#include "tinyformat.h"
+#include "ui_interface.h"
+#include "util.h"
+#include "utilstrencodings.h"
 
 bool fIsBareMultisigStd = true;
 /** Fees smaller than this (in satoshi) are considered zero fee (for relaying and mining) */
 CFeeRate minRelayTxFee = CFeeRate(1000);
+
+/** Declaration of Standard Policy implementing CPolicy */
+class CStandardPolicy : public CPolicy
+{
+public:
+    virtual std::vector<std::pair<std::string, std::string> > GetOptionsHelp() const;
+    virtual void InitFromArgs(const std::map<std::string, std::string>&);
+};
+
+/** Global variables and their interfaces */
+
+static CStandardPolicy standardPolicy;
+
+static CPolicy* pCurrentPolicy = 0;
+
+CPolicy& Policy(std::string policy)
+{
+    if (policy == "standard")
+        return standardPolicy;
+    throw std::runtime_error(strprintf(_("Unknown policy '%s'"), policy));
+}
+
+void SelectPolicy(std::string policy)
+{
+    pCurrentPolicy = &Policy(policy);
+}
+
+const CPolicy& Policy()
+{
+    assert(pCurrentPolicy);
+    return *pCurrentPolicy;
+}
+
+std::string GetPolicyUsageStr(std::string selectedPolicy)
+{
+    CPolicy& policy = standardPolicy;
+    try {
+        policy = Policy(selectedPolicy);
+    } catch(std::exception &e) {
+        selectedPolicy = "standard";
+    }
+    std::string strUsage = HelpMessageGroup(strprintf(_("Policy options (for policy: %s):"), selectedPolicy));
+    strUsage += HelpMessageOpt("-policy", strprintf(_("Select a specific type of policy (default: %s)"), "standard"));
+    strUsage += HelpMessagesOpt(policy.GetOptionsHelp());
+    return strUsage;
+}
+
+void InitPolicyFromArgs(const std::map<std::string, std::string>& mapArgs, std::string defaultPolicy)
+{
+    SelectPolicy(GetArg("-policy", defaultPolicy, mapArgs));
+    pCurrentPolicy->InitFromArgs(mapArgs);
+}
+
+/** CStandardPolicy implementation */
+
+std::vector<std::pair<std::string, std::string> > CStandardPolicy::GetOptionsHelp() const
+{
+    std::vector<std::pair<std::string, std::string> > optionsHelp;
+    return optionsHelp;
+}
+
+void CStandardPolicy::InitFromArgs(const std::map<std::string, std::string>& mapArgs)
+{
+}

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -1,0 +1,14 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2014 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+// NOTE: This file is intended to be customised by the end user, and includes only local node policy logic
+
+#include "policy/policy.h"
+
+#include "amount.h"
+
+bool fIsBareMultisigStd = true;
+/** Fees smaller than this (in satoshi) are considered zero fee (for relaying and mining) */
+CFeeRate minRelayTxFee = CFeeRate(1000);

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -52,6 +52,7 @@ class CPolicy
 public:
     virtual std::vector<std::pair<std::string, std::string> > GetOptionsHelp() const = 0;
     virtual void InitFromArgs(const std::map<std::string, std::string>&) = 0;
+    virtual bool ApproveScript(const CScript&, txnouttype&) const = 0;
 };
 
 /** Return a CPolicy of the type described in the parameter string */

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -10,6 +10,9 @@
 #include "script/interpreter.h"
 #include "script/standard.h"
 
+#include <map>
+#include <string>
+
 class CFeeRate;
 
 /** Default for -blockmaxsize and -blockminsize, which control the range of sizes the mining code will create **/
@@ -42,5 +45,32 @@ static const unsigned int STANDARD_NOT_MANDATORY_VERIFY_FLAGS = STANDARD_SCRIPT_
 
 extern bool fIsBareMultisigStd;
 extern CFeeRate minRelayTxFee;
+
+/** Abstract interface for Policy */
+class CPolicy
+{
+public:
+    virtual std::vector<std::pair<std::string, std::string> > GetOptionsHelp() const = 0;
+    virtual void InitFromArgs(const std::map<std::string, std::string>&) = 0;
+};
+
+/** Return a CPolicy of the type described in the parameter string */
+CPolicy& Policy(std::string);
+/** Returns the current CPolicy. Requires calling SelectPolicy() or InitPolicyFromArgs() first */
+const CPolicy& Policy();
+/** Selects the current CPolicy of the type described in the parameter string */
+void SelectPolicy(std::string);
+/**
+ * Returns a HelpMessage string with policy options
+ *
+ * @param selectedPolicy select a policy to show its options
+ * @return the formatted string
+ */
+std::string GetPolicyUsageStr(std::string selectedPolicy);
+/**
+ * Selects the current CPolicy of the type described in the string on key "-policy" mapArgs
+ * and calls CPolicy::InitFromArgs() with mapArgs.
+ */
+void InitPolicyFromArgs(const std::map<std::string, std::string>& mapArgs, std::string defaultPolicy);
 
 #endif // BITCOIN_POLICY_H

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -1,0 +1,46 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2014 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_POLICY_H
+#define BITCOIN_POLICY_H
+
+#include "consensus/consensus.h"
+#include "script/interpreter.h"
+#include "script/standard.h"
+
+class CFeeRate;
+
+/** Default for -blockmaxsize and -blockminsize, which control the range of sizes the mining code will create **/
+static const unsigned int DEFAULT_BLOCK_MAX_SIZE = 750000;
+static const unsigned int DEFAULT_BLOCK_MIN_SIZE = 0;
+/** Default for -blockprioritysize, maximum space for zero/low-fee transactions **/
+static const unsigned int DEFAULT_BLOCK_PRIORITY_SIZE = 50000;
+/** The maximum size for transactions we're willing to relay/mine */
+static const unsigned int MAX_STANDARD_TX_SIZE = 100000;
+/** Maximum number of signature check operations in an IsStandard() P2SH script */
+static const unsigned int MAX_P2SH_SIGOPS = 15;
+/** The maximum number of sigops we're willing to relay/mine in a single tx */
+static const unsigned int MAX_STANDARD_TX_SIGOPS = MAX_BLOCK_SIGOPS/5;
+/**
+ * Standard script verification flags that standard transactions will comply
+ * with. However scripts violating these flags may still be present in valid
+ * blocks and we must accept those blocks.
+ */
+static const unsigned int STANDARD_SCRIPT_VERIFY_FLAGS = MANDATORY_SCRIPT_VERIFY_FLAGS |
+                                                         SCRIPT_VERIFY_DERSIG |
+                                                         SCRIPT_VERIFY_STRICTENC |
+                                                         SCRIPT_VERIFY_MINIMALDATA |
+                                                         SCRIPT_VERIFY_NULLDUMMY |
+                                                         SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_NOPS |
+                                                         SCRIPT_VERIFY_CLEANSTACK;
+/** For convenience, standard but not mandatory verify flags. */
+static const unsigned int STANDARD_NOT_MANDATORY_VERIFY_FLAGS = STANDARD_SCRIPT_VERIFY_FLAGS & ~MANDATORY_SCRIPT_VERIFY_FLAGS;
+
+/** GLOBALS: These variables are supposed to become CStandardPolicy attributes */
+
+extern bool fIsBareMultisigStd;
+extern CFeeRate minRelayTxFee;
+
+#endif // BITCOIN_POLICY_H

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -10,9 +10,6 @@
 #include "serialize.h"
 #include "uint256.h"
 
-/** The maximum allowed size for a serialized block, in bytes (network rule) */
-static const unsigned int MAX_BLOCK_SIZE = 1000000;
-
 /** Nodes collect new transactions into a block, hash them into a hash tree,
  * and scan through nonce values to make the block's hash satisfy proof-of-work
  * requirements.  When they solve the proof-of-work, they broadcast the block

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -15,6 +15,7 @@
 #include "coincontrol.h"
 #include "init.h"
 #include "main.h"
+#include "policy/policy.h"
 #include "wallet/wallet.h"
 
 #include <boost/assign/list_of.hpp> // for 'map_list_of()'

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -9,9 +9,10 @@
 #include "qvalidatedlineedit.h"
 #include "walletmodel.h"
 
-#include "primitives/transaction.h"
 #include "init.h"
 #include "main.h"
+#include "policy/policy.h"
+#include "primitives/transaction.h"
 #include "protocol.h"
 #include "script/script.h"
 #include "script/standard.h"

--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -11,6 +11,7 @@
 #include "base58.h"
 #include "chainparams.h"
 #include "main.h"
+#include "policy/policy.h"
 #include "ui_interface.h"
 #include "util.h"
 #include "wallet/wallet.h"

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -10,11 +10,13 @@
 #include "transactionrecord.h"
 
 #include "base58.h"
+#include "consensus/consensus.h"
 #include "main.h"
 #include "script/script.h"
 #include "timedata.h"
 #include "ui_interface.h"
 #include "util.h"
+#include "wallet/db.h"
 #include "wallet/wallet.h"
 
 #include <stdint.h>

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -5,6 +5,7 @@
 #include "transactionrecord.h"
 
 #include "base58.h"
+#include "consensus/consensus.h"
 #include "main.h"
 #include "timedata.h"
 #include "wallet/wallet.h"

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -5,11 +5,12 @@
 
 #include "amount.h"
 #include "chainparams.h"
+#include "consensus/consensus.h"
 #include "core_io.h"
 #include "init.h"
-#include "net.h"
 #include "main.h"
 #include "miner.h"
+#include "net.h"
 #include "pow.h"
 #include "rpcserver.h"
 #include "util.h"

--- a/src/rpcmisc.cpp
+++ b/src/rpcmisc.cpp
@@ -9,6 +9,7 @@
 #include "main.h"
 #include "net.h"
 #include "netbase.h"
+#include "policy/policy.h"
 #include "rpcserver.h"
 #include "timedata.h"
 #include "util.h"

--- a/src/rpcnet.cpp
+++ b/src/rpcnet.cpp
@@ -8,6 +8,7 @@
 #include "main.h"
 #include "net.h"
 #include "netbase.h"
+#include "policy/policy.h"
 #include "protocol.h"
 #include "sync.h"
 #include "timedata.h"

--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -4,12 +4,13 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "base58.h"
-#include "primitives/transaction.h"
 #include "core_io.h"
 #include "init.h"
 #include "keystore.h"
 #include "main.h"
 #include "net.h"
+#include "policy/policy.h"
+#include "primitives/transaction.h"
 #include "rpcserver.h"
 #include "script/script.h"
 #include "script/sign.h"

--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -5,9 +5,10 @@
 
 #include "script/sign.h"
 
-#include "primitives/transaction.h"
 #include "key.h"
 #include "keystore.h"
+#include "policy/policy.h"
+#include "primitives/transaction.h"
 #include "script/standard.h"
 #include "uint256.h"
 

--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -180,26 +180,6 @@ int ScriptSigArgsExpected(txnouttype t, const std::vector<std::vector<unsigned c
     return -1;
 }
 
-bool IsStandard(const CScript& scriptPubKey, txnouttype& whichType)
-{
-    vector<valtype> vSolutions;
-    if (!Solver(scriptPubKey, whichType, vSolutions))
-        return false;
-
-    if (whichType == TX_MULTISIG)
-    {
-        unsigned char m = vSolutions.front()[0];
-        unsigned char n = vSolutions.back()[0];
-        // Support up to x-of-3 multisig txns as standard
-        if (n < 1 || n > 3)
-            return false;
-        if (m < 1 || m > n)
-            return false;
-    }
-
-    return whichType != TX_NONSTANDARD;
-}
-
 bool ExtractDestination(const CScript& scriptPubKey, CTxDestination& addressRet)
 {
     vector<valtype> vSolutions;

--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -69,7 +69,6 @@ const char* GetTxnOutputType(txnouttype t);
 
 bool Solver(const CScript& scriptPubKey, txnouttype& typeRet, std::vector<std::vector<unsigned char> >& vSolutionsRet);
 int ScriptSigArgsExpected(txnouttype t, const std::vector<std::vector<unsigned char> >& vSolutions);
-bool IsStandard(const CScript& scriptPubKey, txnouttype& whichType);
 bool ExtractDestination(const CScript& scriptPubKey, CTxDestination& addressRet);
 bool ExtractDestinations(const CScript& scriptPubKey, txnouttype& typeRet, std::vector<CTxDestination>& addressRet, int& nRequiredRet);
 

--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -39,22 +39,6 @@ extern unsigned nMaxDatacarrierBytes;
  */
 static const unsigned int MANDATORY_SCRIPT_VERIFY_FLAGS = SCRIPT_VERIFY_P2SH;
 
-/**
- * Standard script verification flags that standard transactions will comply
- * with. However scripts violating these flags may still be present in valid
- * blocks and we must accept those blocks.
- */
-static const unsigned int STANDARD_SCRIPT_VERIFY_FLAGS = MANDATORY_SCRIPT_VERIFY_FLAGS |
-                                                         SCRIPT_VERIFY_DERSIG |
-                                                         SCRIPT_VERIFY_STRICTENC |
-                                                         SCRIPT_VERIFY_MINIMALDATA |
-                                                         SCRIPT_VERIFY_NULLDUMMY |
-                                                         SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_NOPS |
-                                                         SCRIPT_VERIFY_CLEANSTACK;
-
-/** For convenience, standard but not mandatory verify flags. */
-static const unsigned int STANDARD_NOT_MANDATORY_VERIFY_FLAGS = STANDARD_SCRIPT_VERIFY_FLAGS & ~MANDATORY_SCRIPT_VERIFY_FLAGS;
-
 enum txnouttype
 {
     TX_NONSTANDARD,

--- a/src/test/multisig_tests.cpp
+++ b/src/test/multisig_tests.cpp
@@ -4,13 +4,13 @@
 
 #include "key.h"
 #include "keystore.h"
-#include "main.h"
+#include "policy/policy.h"
+#include "script/interpreter.h"
 #include "script/script.h"
 #include "script/script_error.h"
-#include "script/interpreter.h"
 #include "script/sign.h"
-#include "uint256.h"
 #include "test/test_bitcoin.h"
+#include "uint256.h"
 
 #ifdef ENABLE_WALLET
 #include "wallet/wallet_ismine.h"
@@ -143,6 +143,7 @@ BOOST_AUTO_TEST_CASE(multisig_verify)
 
 BOOST_AUTO_TEST_CASE(multisig_IsStandard)
 {
+    const CPolicy& policy = Policy("standard");
     CKey key[4];
     for (int i = 0; i < 4; i++)
         key[i].MakeNewKey(true);
@@ -151,19 +152,19 @@ BOOST_AUTO_TEST_CASE(multisig_IsStandard)
 
     CScript a_and_b;
     a_and_b << OP_2 << ToByteVector(key[0].GetPubKey()) << ToByteVector(key[1].GetPubKey()) << OP_2 << OP_CHECKMULTISIG;
-    BOOST_CHECK(::IsStandard(a_and_b, whichType));
+    BOOST_CHECK(policy.ApproveScript(a_and_b, whichType));
 
     CScript a_or_b;
     a_or_b  << OP_1 << ToByteVector(key[0].GetPubKey()) << ToByteVector(key[1].GetPubKey()) << OP_2 << OP_CHECKMULTISIG;
-    BOOST_CHECK(::IsStandard(a_or_b, whichType));
+    BOOST_CHECK(policy.ApproveScript(a_or_b, whichType));
 
     CScript escrow;
     escrow << OP_2 << ToByteVector(key[0].GetPubKey()) << ToByteVector(key[1].GetPubKey()) << ToByteVector(key[2].GetPubKey()) << OP_3 << OP_CHECKMULTISIG;
-    BOOST_CHECK(::IsStandard(escrow, whichType));
+    BOOST_CHECK(policy.ApproveScript(escrow, whichType));
 
     CScript one_of_four;
     one_of_four << OP_1 << ToByteVector(key[0].GetPubKey()) << ToByteVector(key[1].GetPubKey()) << ToByteVector(key[2].GetPubKey()) << ToByteVector(key[3].GetPubKey()) << OP_4 << OP_CHECKMULTISIG;
-    BOOST_CHECK(!::IsStandard(one_of_four, whichType));
+    BOOST_CHECK(!policy.ApproveScript(one_of_four, whichType));
 
     CScript malformed[6];
     malformed[0] << OP_3 << ToByteVector(key[0].GetPubKey()) << ToByteVector(key[1].GetPubKey()) << OP_2 << OP_CHECKMULTISIG;
@@ -174,7 +175,7 @@ BOOST_AUTO_TEST_CASE(multisig_IsStandard)
     malformed[5] << OP_1 << ToByteVector(key[0].GetPubKey()) << ToByteVector(key[1].GetPubKey());
 
     for (int i = 0; i < 6; i++)
-        BOOST_CHECK(!::IsStandard(malformed[i], whichType));
+        BOOST_CHECK(!policy.ApproveScript(malformed[i], whichType));
 }
 
 BOOST_AUTO_TEST_CASE(multisig_Solver1)

--- a/src/test/script_P2SH_tests.cpp
+++ b/src/test/script_P2SH_tests.cpp
@@ -5,6 +5,7 @@
 #include "key.h"
 #include "keystore.h"
 #include "main.h"
+#include "policy/policy.h"
 #include "script/script.h"
 #include "script/script_error.h"
 #include "script/sign.h"

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -7,6 +7,7 @@
 #include "test_bitcoin.h"
 
 #include "main.h"
+#include "policy/policy.h"
 #include "random.h"
 #include "txdb.h"
 #include "ui_interface.h"
@@ -32,6 +33,7 @@ BasicTestingSetup::BasicTestingSetup()
         fPrintToDebugLog = false; // don't want to write to debug.log file
         fCheckBlockIndex = true;
         SelectParams(CBaseChainParams::MAIN);
+        SelectPolicy("standard");
 }
 BasicTestingSetup::~BasicTestingSetup()
 {

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -6,6 +6,7 @@
 #include "txmempool.h"
 
 #include "clientversion.h"
+#include "consensus/consensus.h"
 #include "main.h"
 #include "streams.h"
 #include "util.h"

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -305,29 +305,47 @@ void ParseParameters(int argc, const char* const argv[])
     }
 }
 
+std::string GetArg(const std::string& strArg, const std::string& strDefault, const std::map<std::string, std::string>& mapArgs)
+{
+    std::map<std::string, std::string>::const_iterator it = mapArgs.find(strArg);
+    if (it != mapArgs.end())
+        return it->second;
+    return strDefault;
+}
+
+int64_t GetArg(const std::string& strArg, int64_t nDefault, const std::map<std::string, std::string>& mapArgs)
+{
+    std::map<std::string, std::string>::const_iterator it = mapArgs.find(strArg);
+    if (it != mapArgs.end())
+        return atoi64(it->second);
+    return nDefault;
+}
+
+bool GetBoolArg(const std::string& strArg, bool fDefault, const std::map<std::string, std::string>& mapArgs)
+{
+    std::map<std::string, std::string>::const_iterator it = mapArgs.find(strArg);
+    if (it != mapArgs.end())
+    {
+        if (it->second.empty())
+            return true;
+        return (atoi(it->second) != 0);
+    }
+    return fDefault;
+}
+
 std::string GetArg(const std::string& strArg, const std::string& strDefault)
 {
-    if (mapArgs.count(strArg))
-        return mapArgs[strArg];
-    return strDefault;
+    return GetArg(strArg, strDefault, mapArgs);
 }
 
 int64_t GetArg(const std::string& strArg, int64_t nDefault)
 {
-    if (mapArgs.count(strArg))
-        return atoi64(mapArgs[strArg]);
-    return nDefault;
+    return GetArg(strArg, nDefault, mapArgs);
 }
 
 bool GetBoolArg(const std::string& strArg, bool fDefault)
 {
-    if (mapArgs.count(strArg))
-    {
-        if (mapArgs[strArg].empty())
-            return true;
-        return (atoi(mapArgs[strArg]) != 0);
-    }
-    return fDefault;
+    return GetBoolArg(strArg, fDefault, mapArgs);
 }
 
 bool SoftSetArg(const std::string& strArg, const std::string& strValue)
@@ -359,6 +377,14 @@ std::string HelpMessageOpt(const std::string &option, const std::string &message
            std::string("\n") + std::string(msgIndent,' ') +
            FormatParagraph(message, screenWidth - msgIndent, msgIndent) +
            std::string("\n\n");
+}
+
+std::string HelpMessagesOpt(std::vector<std::pair<std::string, std::string> > optionsHelp)
+{
+    std::string strUsage;
+    for (unsigned int i=0; i < optionsHelp.size(); i++)
+        strUsage += HelpMessageOpt(optionsHelp[i].first, optionsHelp[i].second);
+    return strUsage;
 }
 
 static std::string FormatException(const std::exception* pex, const char* pszThread)

--- a/src/util.h
+++ b/src/util.h
@@ -125,6 +125,7 @@ inline bool IsSwitchChar(char c)
  * @return command-line argument or default value
  */
 std::string GetArg(const std::string& strArg, const std::string& strDefault);
+std::string GetArg(const std::string& strArg, const std::string& strDefault, const std::map<std::string, std::string>& mapArgs);
 
 /**
  * Return integer argument or default value
@@ -134,6 +135,7 @@ std::string GetArg(const std::string& strArg, const std::string& strDefault);
  * @return command-line argument (0 if invalid number) or default value
  */
 int64_t GetArg(const std::string& strArg, int64_t nDefault);
+int64_t GetArg(const std::string& strArg, int64_t nDefault, const std::map<std::string, std::string>& mapArgs);
 
 /**
  * Return boolean argument or default value
@@ -143,6 +145,7 @@ int64_t GetArg(const std::string& strArg, int64_t nDefault);
  * @return command-line argument or default value
  */
 bool GetBoolArg(const std::string& strArg, bool fDefault);
+bool GetBoolArg(const std::string& strArg, bool fDefault, const std::map<std::string, std::string>& mapArgs);
 
 /**
  * Set an argument if it doesn't already have a value
@@ -178,6 +181,12 @@ std::string HelpMessageGroup(const std::string& message);
  * @return the formatted string
  */
 std::string HelpMessageOpt(const std::string& option, const std::string& message);
+
+/**
+ * @param optionsHelp a vector of string pairs to iteratively call HelpMessageOpt
+ * @return the formatted string with all pairs
+ */
+std::string HelpMessagesOpt(std::vector<std::pair<std::string, std::string> > optionsHelp);
 
 void SetThreadPriority(int nPriority);
 void RenameThread(const char* name);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -8,6 +8,7 @@
 #include "base58.h"
 #include "checkpoints.h"
 #include "coincontrol.h"
+#include "consensus/consensus.h"
 #include "main.h"
 #include "net.h"
 #include "script/script.h"

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -11,6 +11,7 @@
 #include "consensus/consensus.h"
 #include "main.h"
 #include "net.h"
+#include "policy/policy.h"
 #include "script/script.h"
 #include "script/sign.h"
 #include "timedata.h"


### PR DESCRIPTION
First steps for encapsulating the policy code.
An interface (abstract class) CPolicy and a concrete implementation CStandardPolicy are created.
"Users" (people capable of modify and build Bitcoin core) can implement alternative policies and select them with the option -policy=<policy_name>. They can define new policy options and make their help messages be accesible to the users without having to touch init.cpp, only modifying policy.cpp is enough for all this. The help messages can also be accessed (per available policy) as a vector of string pairs to make it easier to implement a GUI to configure those options (although I don't plan to do that myself).
As more parts of the policy code move to policy.cpp, this encapsulation gets more useful.

To start using it. The function script/standard.o::IsStandard() is turned into a method: ApproveScript().
Many more policy-related improvements can be cleanly proposed after this first steps are merged.

OUTDATED:
This is an attempt to get a first commit for moving policy-related code together as proposed in #4943.
The main purpose of this PR is therefore discuss the commit "Policy: Create CPolicy interface and CStandardPolicy implemention" (https://github.com/jtimon/bitcoin/commit/572f12948285b14fcb2c2d1c9e2f51e749cc6cb6) which may change with suggestions.
The commit "Policy: MOVEONLY: script/standard.o::IsStandard() -> CPolicy::ValidateScript()" (https://github.com/jtimon/bitcoin/commit/9e99ebafc38718ca54730e764091a82a248a1a3c) acts as an example for adding a method to CPolicy. 
The commit "Policy: Refactor: Move datacarrier policy logic to policy.o" (https://github.com/jtimon/bitcoin/commit/f141dd0b9b4059c2d54d0762d5dd0fe86976a18a) is an example of adding an attribute to CStandardPolicy without exposing it on CPolicy or exposing CStandardPolicy itself.
An example of a crazy custom policy that a user could implement for its local node can be found in https://github.com/jtimon/bitcoin/compare/policy_example

The commit "Policy: Refactor: Move datacarrier policy logic to policy.o" may be considered too risky and may be left for later to avoid delaying the first step. 
Maybe https://github.com/jtimon/bitcoin/commit/a2954632879076d3b9763001aca21bf768797e54 is not welcomed. It is only necessary if you want to make InitPolicyFromArgs() and CPolicy::InitFromArgs() param mapArgs const and don't want to duplicate code.

I am very sorry for letting the ut acks rot.
