### PR TITLE
tests: run sanity checks in tests too

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -58,6 +58,7 @@ BITCOIN_TESTS =\
   test/netbase_tests.cpp \
   test/pmt_tests.cpp \
   test/rpc_tests.cpp \
+  test/sanity_tests.cpp \
   test/script_P2SH_tests.cpp \
   test/script_tests.cpp \
   test/scriptnum_tests.cpp \

--- a/src/test/sanity_tests.cpp
+++ b/src/test/sanity_tests.cpp
@@ -1,0 +1,18 @@
+// Copyright (c) 2012-2013 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "compat/sanity.h"
+#include "key.h"
+
+#include <boost/test/unit_test.hpp>
+BOOST_AUTO_TEST_SUITE(sanity_tests)
+
+BOOST_AUTO_TEST_CASE(basic_sanity)
+{
+  BOOST_CHECK_MESSAGE(glibc_sanity_test() == true, "libc sanity test");
+  BOOST_CHECK_MESSAGE(glibcxx_sanity_test() == true, "stdlib sanity test");
+  BOOST_CHECK_MESSAGE(ECC_InitSanityCheck() == true, "openssl ECC test");
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
I've recently stumbled upon a bad compiler/libstdc++ runtime combination where these sanity checks fail in bitcoind. If they are going to fail in bitcoind, they should fail in the tests as well.

Confirmed failing as expected on this combination (osx 10.9 + vanilla clang 3.4 + macosx-version-min=10.8).
