### PR TITLE
secp256k1 benchmarking programs can now accept parameters

### DIFF
--- a/src/secp256k1/Makefile.am
+++ b/src/secp256k1/Makefile.am
@@ -60,7 +60,7 @@ bench_sign_SOURCES = src/bench_sign.c
 bench_sign_LDADD = libsecp256k1.la $(SECP_LIBS)
 bench_sign_LDFLAGS = -static
 bench_inv_SOURCES = src/bench_inv.c
-bench_inv_LDADD = $(SECP_LIBS)
+bench_inv_LDADD = libsecp256k1.la $(SECP_LIBS)
 bench_inv_LDFLAGS = -static
 bench_inv_CPPFLAGS = $(SECP_INCLUDES)
 endif

--- a/src/secp256k1/include/secp256k1.h
+++ b/src/secp256k1/include/secp256k1.h
@@ -51,6 +51,10 @@ extern "C" {
  *  secp256k1_start() returns, all other functions are thread-safe.
  */
 void secp256k1_start(unsigned int flags);
+#ifndef SECP256K1_PRIMARY
+extern unsigned int ecmult_impl_windowG;
+#endif
+
 
 /** Free all memory associated with this library. After this, no
  *  functions can be called anymore, except secp256k1_start()

--- a/src/secp256k1/src/bench.h
+++ b/src/secp256k1/src/bench.h
@@ -17,21 +17,21 @@ static double gettimedouble(void) {
     return tv.tv_usec * 0.000001 + tv.tv_sec;
 }
 
-void run_benchmark(void (*benchmark)(void*), void (*setup)(void*), void (*teardown)(void*), void* data, int count, int iter) {
+void run_benchmark(void (*benchmark)(void*,int), void (*setup)(void*), void (*teardown)(void*), void* data, int count, int iters) {
     double min = HUGE_VAL;
     double sum = 0.0;
     double max = 0.0;
     for (int i = 0; i < count; i++) {
         if (setup) setup(data);
         double begin = gettimedouble();
-        benchmark(data);
+        benchmark(data, iters);
         double total = gettimedouble() - begin;
         if (teardown) teardown(data);
         if (total < min) min = total;
         if (total > max) max = total;
         sum += total;
     }
-    printf("min %.3fus / avg %.3fus / max %.3fus\n", min * 1000000.0 / iter, (sum / count) * 1000000.0 / iter, max * 1000000.0 / iter);
+    printf("min %.3fus / avg %.3fus / max %.3fus\n", min * 1000000.0 / iters, (sum / count) * 1000000.0 / iters, max * 1000000.0 / iters);
 }
 
 #endif

--- a/src/secp256k1/src/bench_inv.c
+++ b/src/secp256k1/src/bench_inv.c
@@ -4,6 +4,10 @@
  * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 #include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <getopt.h>
 
 #include "include/secp256k1.h"
 
@@ -32,20 +36,43 @@ void bench_inv_setup(void* arg) {
     secp256k1_scalar_set_b32(&data->x, init, NULL);
 }
 
-void bench_inv(void* arg) {
+void bench_inv(void* arg, int iters) {
     bench_inv_t *data = (bench_inv_t*)arg;
 
-    for (int i=0; i<20000; i++) {
+    for (int i=0; i<iters; i++) {
         secp256k1_scalar_inverse(&data->x, &data->x);
         secp256k1_scalar_add(&data->x, &data->x, &data->base);
     }
 }
 
-int main(void) {
+int main(int argc, char **argv) {
+    int iters=20000; int count=10;
+    int oa;
+    while ((oa = getopt(argc, argv, "c:i:w:")) != -1) {
+        switch (oa) {
+        case 'c':
+            count=atoi(optarg);
+            ( count<0 || count > 5000 ) ? (printf("Count %d out of sane bounds. Resetting to 10.\n",count),(count=10)):0x0;
+            break;
+        case 'i':
+            iters=atoi(optarg);
+            ( iters<0 || iters > 200000 ) ? (printf("Iterations %d out of sane bounds. Resetting to 20000.\n",iters),iters=20000):0x0;
+            break;
+        case 'w':
+            ecmult_impl_windowG=atoi(optarg);
+            ( ecmult_impl_windowG<2 || ecmult_impl_windowG > 30) ? (printf("WINDOW_G cache %d out of sane bounds. Resetting to 16.\n",ecmult_impl_windowG),ecmult_impl_windowG=16):0x0;
+            break;
+        case '?':
+            printf("Missing argument to %c.", (char)optopt);
+        default:
+            return 1;
+        }
+    }
+
     secp256k1_ge_start();
 
     bench_inv_t data;
-    run_benchmark(bench_inv, bench_inv_setup, NULL, &data, 10, 20000);
+    run_benchmark(bench_inv, bench_inv_setup, NULL, &data, count, iters);
 
     secp256k1_ge_stop();
     return 0;

--- a/src/secp256k1/src/bench_sign.c
+++ b/src/secp256k1/src/bench_sign.c
@@ -4,6 +4,12 @@
  * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <getopt.h>
+
 #include "include/secp256k1.h"
 #include "util.h"
 #include "bench.h"
@@ -22,11 +28,11 @@ static void bench_sign_setup(void* arg) {
     for (int i = 0; i < 32; i++) data->key[i] = i + 65;
 }
 
-static void bench_sign(void* arg) {
+static void bench_sign(void* arg, int iters) {
     bench_sign_t *data = (bench_sign_t*)arg;
 
     unsigned char sig[64];
-    for (int i=0; i<20000; i++) {
+    for (int i=0; i<iters; i++) {
         int recid = 0;
         CHECK(secp256k1_ecdsa_sign_compact(data->msg, sig, data->key, data->nonce, &recid));
         for (int j = 0; j < 32; j++) {
@@ -37,11 +43,34 @@ static void bench_sign(void* arg) {
     }
 }
 
-int main(void) {
+int main(int argc, char **argv) {
+    int iters=20000; int count=10;
+    int oa;
+    while ((oa = getopt(argc, argv, "c:i:w:")) != -1) {
+        switch (oa) {
+        case 'c':
+            count=atoi(optarg);
+            ( count<0 || count > 5000 ) ? (printf("Count %d out of sane bounds. Resetting to 10.\n",count),(count=10)):0x0;
+            break;
+        case 'i':
+            iters=atoi(optarg);
+            ( iters<0 || iters > 200000 ) ? (printf("Iterations %d out of sane bounds. Resetting to 20000.\n",iters),iters=20000):0x0;
+            break;
+        case 'w':
+            ecmult_impl_windowG=atoi(optarg);
+            ( ecmult_impl_windowG<2 || ecmult_impl_windowG > 30) ? (printf("WINDOW_G cache %d out of sane bounds. Resetting to 16.\n",ecmult_impl_windowG),ecmult_impl_windowG=16):0x0;
+            break;
+        case '?':
+            printf("Missing argument to %c.", (char)optopt);
+        default:
+            return 1;
+        }
+    }
+
     secp256k1_start(SECP256K1_START_SIGN);
 
     bench_sign_t data;
-    run_benchmark(bench_sign, bench_sign_setup, NULL, &data, 10, 20000);
+    run_benchmark(bench_sign, bench_sign_setup, NULL, &data, count, iters);
 
     secp256k1_stop();
     return 0;

--- a/src/secp256k1/src/bench_verify.c
+++ b/src/secp256k1/src/bench_verify.c
@@ -6,6 +6,9 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <getopt.h>
 
 #include "include/secp256k1.h"
 #include "util.h"
@@ -21,10 +24,10 @@ typedef struct {
     int pubkeylen;
 } benchmark_verify_t;
 
-static void benchmark_verify(void* arg) {
+static void benchmark_verify(void* arg, int iters) {
     benchmark_verify_t* data = (benchmark_verify_t*)arg;
 
-    for (int i=0; i<20000; i++) {
+    for (int i=0; i<iters; i++) {
         data->sig[data->siglen - 1] ^= (i & 0xFF);
         data->sig[data->siglen - 2] ^= ((i >> 8) & 0xFF);
         data->sig[data->siglen - 3] ^= ((i >> 16) & 0xFF);
@@ -35,7 +38,30 @@ static void benchmark_verify(void* arg) {
     }
 }
 
-int main(void) {
+int main(int argc, char **argv) {
+    int iters=20000; int count=10;
+    int oa;
+    while ((oa = getopt(argc, argv, "c:i:w:")) != -1) {
+        switch (oa) {
+        case 'c':
+            count=atoi(optarg);
+            ( count<0 || count > 5000 ) ? (printf("Count %d out of sane bounds. Resetting to 10.\n",count),(count=10)):0x0;
+            break;
+        case 'i':
+            iters=atoi(optarg);
+            ( iters<0 || iters > 200000 ) ? (printf("Iterations %d out of sane bounds. Resetting to 20000.\n",iters),iters=20000):0x0;
+            break;
+        case 'w':
+            ecmult_impl_windowG=atoi(optarg);
+            ( ecmult_impl_windowG<2 || ecmult_impl_windowG > 30) ? (printf("WINDOW_G cache %d out of sane bounds. Resetting to 16.\n",ecmult_impl_windowG),ecmult_impl_windowG=16):0x0;
+            break;
+        case '?':
+            printf("Missing argument to %c.", (char)optopt);
+        default:
+            return 1;
+        }
+    }
+
     secp256k1_start(SECP256K1_START_VERIFY | SECP256K1_START_SIGN);
 
     benchmark_verify_t data;
@@ -48,7 +74,7 @@ int main(void) {
     data.pubkeylen = 33;
     CHECK(secp256k1_ec_pubkey_create(data.pubkey, &data.pubkeylen, data.key, 1));
 
-    run_benchmark(benchmark_verify, NULL, NULL, &data, 10, 20000);
+    run_benchmark(benchmark_verify, NULL, NULL, &data, count, iters);
 
     secp256k1_stop();
     return 0;

--- a/src/secp256k1/src/secp256k1.c
+++ b/src/secp256k1/src/secp256k1.c
@@ -6,7 +6,9 @@
 
 #define SECP256K1_BUILD (1)
 
+#define SECP256K1_PRIMARY (1)
 #include "include/secp256k1.h"
+#undef SECP256K1_PRIMARY
 
 #include "util.h"
 #include "num_impl.h"


### PR DESCRIPTION
-c will vary the loop counter
-i will vary the iterations per-loop
-w will change the WINDOW_G table size setting at runtime (primary reason for patch)
