### PR TITLE
Assert inside leveldbwrapper to avoid continuing after failure.

### DIFF
--- a/src/leveldbwrapper.cpp
+++ b/src/leveldbwrapper.cpp
@@ -18,6 +18,8 @@ void HandleError(const leveldb::Status& status) throw(leveldb_error)
     if (status.ok())
         return;
     LogPrintf("%s\n", status.ToString());
+    /* This is not the most elegant approach. But it is important that we reliably shut down if the database begins failing at runtime. */
+    assert(false && "Database error. Hardware may be failing. Reindex is likely required.");
     if (status.IsCorruption())
         throw leveldb_error("Database corrupted");
     if (status.IsIOError())


### PR DESCRIPTION
Database failure due to faulty hardware could leave users on a fork where
 they are vulnerable to opportunistic attack because they are rejecting
 the longest chain.

If there is a software fault in the OS or LevelDB that causes many nodes
 to experience database failure at once its also important for overall
 consensus stability that the failing nodes shut down and not continue
 operating.

In theory, the exceptions in leveldbwrapper should cause shutdowns but
 in practice the software calls into that database from many places, some
 of which throw away all exceptions.

A more organized approach to errors should be used in the long-term,
 but this works for the moment.
