### PR TITLE
[Qt] add option to allow self signed root certs (for testing)

### DIFF
--- a/src/qt/utilitydialog.cpp
+++ b/src/qt/utilitydialog.cpp
@@ -12,6 +12,7 @@
 
 #include "clientversion.h"
 #include "init.h"
+#include "util.h"
 
 #include <stdio.h>
 
@@ -108,6 +109,12 @@ HelpMessageDialog::HelpMessageDialog(QWidget *parent, bool about) :
         cursor.movePosition(QTextCursor::NextRow);
         cursor.insertText(tr("UI options") + ":", bold);
         cursor.movePosition(QTextCursor::NextRow);
+        if (GetBoolArg("-help-debug", false)) {
+            cursor.insertText("-allowselfsignedrootcertificates");
+            cursor.movePosition(QTextCursor::NextCell);
+            cursor.insertText(tr("Allow self signed root certificates (default: 0)"));
+            cursor.movePosition(QTextCursor::NextCell);
+        }
         cursor.insertText("-choosedatadir");
         cursor.movePosition(QTextCursor::NextCell);
         cursor.insertText(tr("Choose data directory on startup (default: 0)"));


### PR DESCRIPTION
- it is helpful to be able to test and verify payment request processing
  by allowing self signed root certificates (e.g. generated by Gavins
  "certificate authority in a box")
- This option is just shown in the UI options, if -help-debug is enabled.

@gavinandresen @laanwj This is a preparation to assist adding extended unit-testing for payment requests, as I intend to add new tests for e.g. #5629 and #5620.

See https://www.openssl.org/docs/apps/verify.html (bottom), which is listing error 18 for self signed certificates (I verified that already).

I already tested this pull, which allows me, that the client treats self signed payment requests as authenticated ones!
