### PR TITLE
Increase block download timeout base from 10 to 20 minutes.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4534,12 +4534,12 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
             LogPrintf("Peer=%d is stalling block download, disconnecting\n", pto->id);
             pto->fDisconnect = true;
         }
-        // In case there is a block that has been in flight from this peer for (1 + 0.5 * N) times the block interval
+        // In case there is a block that has been in flight from this peer for (2 + 0.5 * N) times the block interval
         // (with N the number of validated blocks that were in flight at the time it was requested), disconnect due to
         // timeout. We compensate for in-flight blocks to prevent killing off peers due to our own downstream link
         // being saturated. We only count validated in-flight blocks so peers can't advertize nonexisting block hashes
         // to unreasonably increase our timeout.
-        if (!pto->fDisconnect && state.vBlocksInFlight.size() > 0 && state.vBlocksInFlight.front().nTime < nNow - 500000 * Params().TargetSpacing() * (2 + state.vBlocksInFlight.front().nValidatedQueuedBefore)) {
+        if (!pto->fDisconnect && state.vBlocksInFlight.size() > 0 && state.vBlocksInFlight.front().nTime < nNow - 500000 * Params().TargetSpacing() * (4 + state.vBlocksInFlight.front().nValidatedQueuedBefore)) {
             LogPrintf("Timeout downloading block %s from peer=%d, disconnecting\n", state.vBlocksInFlight.front().hash.ToString(), pto->id);
             pto->fDisconnect = true;
         }


### PR DESCRIPTION
This harmonizes the block fetch timeout with the existing ping timeout
 and eliminates a guaranteed eventual failure from congestion collapse
 for a network operating right at its limit.

It's unlikely that we wouldn't suffer other failures if we were really
 anywhere near the network's limit, and a complete avoidance of congestion
 collapse risk requires (I think) an exponential back-off. So this isn't
 a major concern, but I think it's also useful for reducing the complexity
 of understanding out timeouts.
