### PR TITLE
MOVEONLY: Move struct CBlockTemplate to miner.h (from main.h)

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -45,7 +45,6 @@ class CScriptCheck;
 class CValidationInterface;
 class CValidationState;
 
-struct CBlockTemplate;
 struct CNodeStateStats;
 
 /** Default for -blockmaxsize and -blockminsize, which control the range of sizes the mining code will create **/
@@ -512,17 +511,6 @@ extern CCoinsViewCache *pcoinsTip;
 
 /** Global variable that points to the active block tree (protected by cs_main) */
 extern CBlockTreeDB *pblocktree;
-
-struct CBlockTemplate
-{
-    CBlock block;
-    std::vector<CAmount> vTxFees;
-    std::vector<int64_t> vTxSigOps;
-};
-
-
-
-
 
 
 class CValidationInterface {

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -6,7 +6,6 @@
 #include "miner.h"
 
 #include "amount.h"
-#include "primitives/block.h"
 #include "primitives/transaction.h"
 #include "hash.h"
 #include "main.h"

--- a/src/miner.h
+++ b/src/miner.h
@@ -6,16 +6,21 @@
 #ifndef BITCOIN_MINER_H
 #define BITCOIN_MINER_H
 
+#include "primitives/block.h"
+
 #include <stdint.h>
 
-class CBlock;
-class CBlockHeader;
 class CBlockIndex;
 class CReserveKey;
 class CScript;
 class CWallet;
 
-struct CBlockTemplate;
+struct CBlockTemplate
+{
+    CBlock block;
+    std::vector<CAmount> vTxFees;
+    std::vector<int64_t> vTxSigOps;
+};
 
 /** Run the miner threads */
 void GenerateBitcoins(bool fGenerate, CWallet* pwallet, int nThreads);


### PR DESCRIPTION
CBlockTemplate is only used in miner.o, rpcmining.cpp and test/miner_tests.cpp.
It doesn't need to be in main.
Also, advanced patches related to policy encapsulation use this commit for better readability of later commits (see https://github.com/jtimon/bitcoin/tree/luke_policy2 for example).
