### PR TITLE
TRIVIAL: fix misleading comment

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -744,7 +744,7 @@ bool AreInputsStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs)
         // non-standard. Note that this EvalScript() call will
         // be quick, because if there are any operations
         // beside "push data" in the scriptSig
-        // IsStandard() will have already returned false
+        // IsStandardTx() will have already returned false
         // and this method isn't called.
         vector<vector<unsigned char> > stack;
         if (!EvalScript(stack, tx.vin[i].scriptSig, SCRIPT_VERIFY_NONE, BaseSignatureChecker()))


### PR DESCRIPTION
I was reading through source code to get good understanding of what exactly is considered to be standard transaction and found this misleading comment. I could not get what has IsStandard to do with scriptSig validation, it checks scriptPubKey only!
Obviously, the check for push-only ops in scriptSig is in IsStandardTx, not in IsStandard.
