### PR TITLE
[Qt] add verifySize() function to PaymentServer

### DIFF
--- a/src/qt/paymentserver.h
+++ b/src/qt/paymentserver.h
@@ -88,13 +88,12 @@ public:
     // OptionsModel is used for getting proxy settings and display unit
     void setOptionsModel(OptionsModel *optionsModel);
 
-    // This is now public, because we use it in paymentservertests.cpp
-    static bool readPaymentRequestFromFile(const QString& filename, PaymentRequestPlus& request);
-
     // Verify that the payment request network matches the client network
     static bool verifyNetwork(const payments::PaymentDetails& requestDetails);
     // Verify if the payment request is expired
     static bool verifyExpired(const payments::PaymentDetails& requestDetails);
+    // Verify the payment request size is valid as per BIP70
+    static bool verifySize(qint64 requestSize);
     // Verify the payment request amount is valid
     static bool verifyAmount(const CAmount& requestAmount);
 
@@ -131,6 +130,7 @@ protected:
     bool eventFilter(QObject *object, QEvent *event);
 
 private:
+    static bool readPaymentRequestFromFile(const QString& filename, PaymentRequestPlus& request);
     bool processPaymentRequest(const PaymentRequestPlus& request, SendCoinsRecipient& recipient);
     void fetchRequest(const QUrl& url);
 

--- a/src/qt/test/paymentservertests.cpp
+++ b/src/qt/test/paymentservertests.cpp
@@ -185,7 +185,8 @@ void PaymentServerTests::paymentServerTests()
     tempFile.open();
     tempFile.write((const char*)randData, sizeof(randData));
     tempFile.close();
-    QCOMPARE(PaymentServer::readPaymentRequestFromFile(tempFile.fileName(), r.paymentRequest), false);
+    // compares 50001 <= BIP70_MAX_PAYMENTREQUEST_SIZE == false
+    QCOMPARE(PaymentServer::verifySize(tempFile.size()), false);
 
     // Payment request with amount overflow (amount is set to 21000001 BTC):
     data = DecodeBase64(paymentrequest5_cert2_BASE64);


### PR DESCRIPTION
- add static verifySize() function to PaymentServer and move the logging
  on error into the function
- the function checks if the size is allowed as per BIP70
