### PR TITLE
Restore RPC HTTP keepalives to default.

### DIFF
--- a/qa/rpc-tests/httpbasics.py
+++ b/qa/rpc-tests/httpbasics.py
@@ -35,13 +35,13 @@ class HTTPBasicsTest (BitcoinTestFramework):
         
         conn = httplib.HTTPConnection(url.hostname, url.port)
         conn.connect()
-        conn.request('GET', '/', '{"method": "getbestblockhash"}', headers)
+        conn.request('POST', '/', '{"method": "getbestblockhash"}', headers)
         out1 = conn.getresponse().read();
         assert_equal('"error":null' in out1, True)
         assert_equal(conn.sock!=None, True) #according to http/1.1 connection must still be open!
         
         #send 2nd request without closing connection
-        conn.request('GET', '/', '{"method": "getchaintips"}', headers)
+        conn.request('POST', '/', '{"method": "getchaintips"}', headers)
         out2 = conn.getresponse().read();
         assert_equal('"error":null' in out1, True) #must also response with a correct json-rpc message
         assert_equal(conn.sock!=None, True) #according to http/1.1 connection must still be open!
@@ -52,13 +52,13 @@ class HTTPBasicsTest (BitcoinTestFramework):
         
         conn = httplib.HTTPConnection(url.hostname, url.port)
         conn.connect()
-        conn.request('GET', '/', '{"method": "getbestblockhash"}', headers)
+        conn.request('POST', '/', '{"method": "getbestblockhash"}', headers)
         out1 = conn.getresponse().read();
         assert_equal('"error":null' in out1, True)
         assert_equal(conn.sock!=None, True) #according to http/1.1 connection must still be open!
         
         #send 2nd request without closing connection
-        conn.request('GET', '/', '{"method": "getchaintips"}', headers)
+        conn.request('POST', '/', '{"method": "getchaintips"}', headers)
         out2 = conn.getresponse().read();
         assert_equal('"error":null' in out1, True) #must also response with a correct json-rpc message
         assert_equal(conn.sock!=None, True) #according to http/1.1 connection must still be open!
@@ -69,7 +69,7 @@ class HTTPBasicsTest (BitcoinTestFramework):
         
         conn = httplib.HTTPConnection(url.hostname, url.port)
         conn.connect()
-        conn.request('GET', '/', '{"method": "getbestblockhash"}', headers)
+        conn.request('POST', '/', '{"method": "getbestblockhash"}', headers)
         out1 = conn.getresponse().read();
         assert_equal('"error":null' in out1, True)
         assert_equal(conn.sock!=None, False) #now the connection must be closed after the response        
@@ -81,7 +81,7 @@ class HTTPBasicsTest (BitcoinTestFramework):
                 
         conn = httplib.HTTPConnection(urlNode1.hostname, urlNode1.port)
         conn.connect()
-        conn.request('GET', '/', '{"method": "getbestblockhash"}', headers)
+        conn.request('POST', '/', '{"method": "getbestblockhash"}', headers)
         out1 = conn.getresponse().read();
         assert_equal('"error":null' in out1, True)
         assert_equal(conn.sock!=None, False) #connection must be closed because keep-alive was set to false
@@ -93,10 +93,10 @@ class HTTPBasicsTest (BitcoinTestFramework):
                 
         conn = httplib.HTTPConnection(urlNode2.hostname, urlNode2.port)
         conn.connect()
-        conn.request('GET', '/', '{"method": "getbestblockhash"}', headers)
+        conn.request('POST', '/', '{"method": "getbestblockhash"}', headers)
         out1 = conn.getresponse().read();
         assert_equal('"error":null' in out1, True)
-        assert_equal(conn.sock!=None, False) #connection must be closed because bitcoind should use keep-alive by default
+        assert_equal(conn.sock!=None, True) #connection must be closed because bitcoind should use keep-alive by default
         
 if __name__ == '__main__':
     HTTPBasicsTest ().main ()

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -380,7 +380,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += "  -rpcport=<port>        " + strprintf(_("Listen for JSON-RPC connections on <port> (default: %u or testnet: %u)"), 8332, 18332) + "\n";
     strUsage += "  -rpcallowip=<ip>       " + _("Allow JSON-RPC connections from specified source. Valid for <ip> are a single IP (e.g. 1.2.3.4), a network/netmask (e.g. 1.2.3.4/255.255.255.0) or a network/CIDR (e.g. 1.2.3.4/24). This option can be specified multiple times") + "\n";
     strUsage += "  -rpcthreads=<n>        " + strprintf(_("Set the number of threads to service RPC calls (default: %d)"), 4) + "\n";
-    strUsage += "  -rpckeepalive          " + strprintf(_("RPC support for HTTP persistent connections (default: %d)"), 0) + "\n";
+    strUsage += "  -rpckeepalive          " + strprintf(_("RPC support for HTTP persistent connections (default: %d)"), 1) + "\n";
 
     strUsage += "\n" + _("RPC SSL options: (see the Bitcoin Wiki for SSL setup instructions)") + "\n";
     strUsage += "  -rpcssl                                  " + _("Use OpenSSL (https) for JSON-RPC connections") + "\n";

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -953,7 +953,7 @@ void ServiceConnection(AcceptedConnection *conn)
         ReadHTTPMessage(conn->stream(), mapHeaders, strRequest, nProto, MAX_SIZE);
 
         // HTTP Keep-Alive is false; close connection immediately
-        if ((mapHeaders["connection"] == "close") || (!GetBoolArg("-rpckeepalive", false)))
+        if ((mapHeaders["connection"] == "close") || (!GetBoolArg("-rpckeepalive", true)))
             fRun = false;
 
         // Process via JSON-RPC API


### PR DESCRIPTION
This avoids a regression for issues like #334 where high speed
 repeated connections eventually run the HTTP client out of
 sockets because all of theirs end up in time_wait.

Maybe the trade-off here is suboptimal, but if both choices will
 fail then we prefer fewer changes until the root cause is solved.
