### PR TITLE
Fix priority calculation in CreateTransaction

### DIFF
--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1439,10 +1439,14 @@ bool CWallet::CreateTransaction(const vector<pair<CScript, CAmount> >& vecSend,
                 BOOST_FOREACH(PAIRTYPE(const CWalletTx*, unsigned int) pcoin, setCoins)
                 {
                     CAmount nCredit = pcoin.first->vout[pcoin.second].nValue;
-                    //The priority after the next block (depth+1) is used instead of the current,
+                    //The coin age after the next block (depth+1) is used instead of the current,
                     //reflecting an assumption the user would accept a bit more delay for
                     //a chance at a free transaction.
-                    dPriority += (double)nCredit * (pcoin.first->GetDepthInMainChain()+1);
+                    //But mempool inputs might still be in the mempool, so their age stays 0
+                    int age = pcoin.first->GetDepthInMainChain();
+                    if (age != 0)
+                        age += 1;
+                    dPriority += (double)nCredit * age;
                 }
 
                 CAmount nChange = nValueIn - nValue - nFeeRet;


### PR DESCRIPTION
The wallet code optimistically assumes that all coin ages will increase at the next block, but this is not true for inputs that are in the mempool.   This change should match the calculation for the low priority reject code and prevent the wallet from thinking it can send a free transaction when it wouldn't be accepted to the mempool.
