### PR TITLE
Get rid of DetectShutdownThread

### DIFF
--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -33,7 +33,7 @@
 
 static bool fDaemon;
 
-void DetectShutdownThread(boost::thread_group* threadGroup)
+void WaitForShutdown(boost::thread_group* threadGroup)
 {
     bool fShutdown = ShutdownRequested();
     // Tell the main threads to shutdown.
@@ -56,7 +56,6 @@ void DetectShutdownThread(boost::thread_group* threadGroup)
 bool AppInit(int argc, char* argv[])
 {
     boost::thread_group threadGroup;
-    boost::thread* detectShutdownThread = NULL;
 
     bool fRet = false;
 
@@ -144,7 +143,6 @@ bool AppInit(int argc, char* argv[])
 #endif
         SoftSetBoolArg("-server", true);
 
-        detectShutdownThread = new boost::thread(boost::bind(&DetectShutdownThread, &threadGroup));
         fRet = AppInit2(threadGroup);
     }
     catch (const std::exception& e) {
@@ -155,20 +153,12 @@ bool AppInit(int argc, char* argv[])
 
     if (!fRet)
     {
-        if (detectShutdownThread)
-            detectShutdownThread->interrupt();
-
         threadGroup.interrupt_all();
         // threadGroup.join_all(); was left out intentionally here, because we didn't re-test all of
         // the startup-failure cases to make sure they don't result in a hang due to some
         // thread-blocking-waiting-for-another-thread-during-startup case
-    }
-
-    if (detectShutdownThread)
-    {
-        detectShutdownThread->join();
-        delete detectShutdownThread;
-        detectShutdownThread = NULL;
+    } else {
+        WaitForShutdown(&threadGroup);
     }
     Shutdown();
 


### PR DESCRIPTION
The main thread spends time waiting for the DetectShutdownThread. So why not just run this waiting loop function in the main thread?

One thread-stack less saves 4MB of virtual memory on 32-bit, and 8MB on 64-bit.
