### PR TITLE
[Wallet] replace BDB with internal append only (logdb) backend

### DIFF
--- a/qa/rpc-tests/util.py
+++ b/qa/rpc-tests/util.py
@@ -119,7 +119,6 @@ def initialize_chain(test_dir):
         wait_bitcoinds()
         for i in range(4):
             os.remove(log_filename("cache", i, "debug.log"))
-            os.remove(log_filename("cache", i, "db.log"))
             os.remove(log_filename("cache", i, "peers.dat"))
             os.remove(log_filename("cache", i, "fee_estimates.dat"))
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -195,6 +195,7 @@ libbitcoin_wallet_a_CPPFLAGS = $(BITCOIN_INCLUDES)
 libbitcoin_wallet_a_SOURCES = \
   db.cpp \
   crypter.cpp \
+  logdb.cpp \
   rpcdump.cpp \
   rpcwallet.cpp \
   wallet.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -99,6 +99,7 @@ BITCOIN_CORE_H = \
   keystore.h \
   leveldbwrapper.h \
   limitedmap.h \
+  logdb.h \
   main.h \
   merkleblock.h \
   miner.h \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -74,8 +74,9 @@ BITCOIN_TESTS =\
 if ENABLE_WALLET
 BITCOIN_TESTS += \
   test/accounting_tests.cpp \
-  test/wallet_tests.cpp \
-  test/rpc_wallet_tests.cpp
+  test/logdb_tests.cpp \
+  test/rpc_wallet_tests.cpp \
+  test/wallet_tests.cpp
 endif
 
 test_test_bitcoin_SOURCES = $(BITCOIN_TESTS) $(JSON_TEST_FILES) $(RAW_TEST_FILES)

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1126,10 +1126,7 @@ bool AppInit2(boost::thread_group& threadGroup)
         }
 
         if (GetBoolArg("-upgradewallet", fFirstRun))
-        {
             LogPrintf("There is no upgrade required (your version: %d)\n", pwalletMain->GetVersion());
-
-        }
 
         if (fFirstRun)
         {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -24,7 +24,6 @@
 #include "util.h"
 #include "utilmoneystr.h"
 #ifdef ENABLE_WALLET
-#include "db.h"
 #include "wallet.h"
 #include "walletdb.h"
 #endif
@@ -151,7 +150,7 @@ void Shutdown()
     StopRPCThreads();
 #ifdef ENABLE_WALLET
     if (pwalletMain)
-        bitdb.Flush(false);
+        pwalletMain->Flush(false);
     GenerateBitcoins(false, NULL, 0);
 #endif
     StopNode();
@@ -184,7 +183,7 @@ void Shutdown()
     }
 #ifdef ENABLE_WALLET
     if (pwalletMain)
-        bitdb.Flush(true);
+        pwalletMain->Flush(true);
 #endif
 #ifndef WIN32
     boost::filesystem::remove(GetPidFile());
@@ -798,7 +797,7 @@ bool AppInit2(boost::thread_group& threadGroup)
     LogPrintf("Bitcoin version %s (%s)\n", FormatFullVersion(), CLIENT_DATE);
     LogPrintf("Using OpenSSL version %s\n", SSLeay_version(SSLEAY_VERSION));
 #ifdef ENABLE_WALLET
-    LogPrintf("Using BerkeleyDB version %s\n", DbEnv::version(0, 0, 0));
+    LogPrintf("Using internal logdb as wallet backend");
 #endif
     if (!fLogTimestamps)
         LogPrintf("Startup time: %s\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()));
@@ -835,47 +834,7 @@ bool AppInit2(boost::thread_group& threadGroup)
         LogPrintf("Using wallet %s\n", strWalletFile);
         uiInterface.InitMessage(_("Verifying wallet..."));
 
-        if (!bitdb.Open(GetDataDir()))
-        {
-            // try moving the database env out of the way
-            boost::filesystem::path pathDatabase = GetDataDir() / "database";
-            boost::filesystem::path pathDatabaseBak = GetDataDir() / strprintf("database.%d.bak", GetTime());
-            try {
-                boost::filesystem::rename(pathDatabase, pathDatabaseBak);
-                LogPrintf("Moved old %s to %s. Retrying.\n", pathDatabase.string(), pathDatabaseBak.string());
-            } catch (const boost::filesystem::filesystem_error&) {
-                 // failure is ok (well, not really, but it's not worse than what we started with)
-            }
-
-            // try again
-            if (!bitdb.Open(GetDataDir())) {
-                // if it still fails, it probably means we can't even create the database env
-                string msg = strprintf(_("Error initializing wallet database environment %s!"), strDataDir);
-                return InitError(msg);
-            }
-        }
-
-        if (GetBoolArg("-salvagewallet", false))
-        {
-            // Recover readable keypairs:
-            if (!CWalletDB::Recover(bitdb, strWalletFile, true))
-                return false;
-        }
-
-        if (boost::filesystem::exists(GetDataDir() / strWalletFile))
-        {
-            CDBEnv::VerifyResult r = bitdb.Verify(strWalletFile, CWalletDB::Recover);
-            if (r == CDBEnv::RECOVER_OK)
-            {
-                string msg = strprintf(_("Warning: wallet.dat corrupt, data salvaged!"
-                                         " Original wallet.dat saved as wallet.{timestamp}.bak in %s; if"
-                                         " your balance or transactions are incorrect you should"
-                                         " restore from a backup."), strDataDir);
-                InitWarning(msg);
-            }
-            if (r == CDBEnv::RECOVER_FAIL)
-                return InitError(_("wallet.dat corrupt, salvage failed"));
-        }
+        CWalletDB::Verify(strWalletFile, GetBoolArg("-salvagewallet", false));
     } // (!fDisableWallet)
 #endif // ENABLE_WALLET
     // ********************************************************* Step 6: network initialization

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -834,7 +834,11 @@ bool AppInit2(boost::thread_group& threadGroup)
         LogPrintf("Using wallet %s\n", strWalletFile);
         uiInterface.InitMessage(_("Verifying wallet..."));
 
-        CWalletDB::Verify(strWalletFile, GetBoolArg("-salvagewallet", false));
+        if (!CWalletDB::Verify(strWalletFile, GetBoolArg("-salvagewallet", false)))
+        {
+            string msg = strprintf(_("Corrupt wallet detected (filename: %s)!"), strWalletFile);
+            return InitError(msg);
+        }
     } // (!fDisableWallet)
 #endif // ENABLE_WALLET
     // ********************************************************* Step 6: network initialization

--- a/src/logdb.cpp
+++ b/src/logdb.cpp
@@ -1,0 +1,488 @@
+// Copyright (c) 2012 The Bitcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file license.txt or http://www.opensource.org/licenses/mit-license.php.
+
+#include <stdio.h>
+#include <unistd.h>
+
+#include "logdb.h"
+
+using namespace std;
+
+// Compact integers: least-significant digit first base-128 encoding.
+// The high bit in each byte signifies whether another digit follows.
+// To avoid redundancy, one is subtracted from all but the first digit.
+// Thus, the byte sequence a[] where all but the last has bit 128 set,
+// encodes the number (a[0] & 0x7F) + sum(i=1..n, 128^i*((a[i] & 0x7F)+1))
+
+size_t static WriteInt(FILE* file, uint64 n)
+{
+    int nRet = 0;
+    do
+    {
+        nRet++;
+        putc((n % 128) | (n>127)*128, file);
+        if (n<128)
+            break;
+        n = (n / 128)-1;
+    } while(1);
+    return nRet;
+}
+
+int static ReadInt(FILE *file)
+{
+    uint64_t nRet = 0;
+    uint64_t nBase = 1;
+    while (nBase)
+    {
+        int nByte = getc(file);
+        nRet += nBase * ((nByte & 127) + (nBase>1));
+        if (nByte < 128)
+            break;
+        nBase *= 128;
+    }
+    return nRet;
+}
+
+// File format
+// 
+// The file consists of a list of frames, each of which consists of:
+// 4 bytes magic: 0xCC 0xC4 0xE6 0xB0
+// N records, each of which consists of:
+//   1 byte mode: 1=insert/overwrite, 2=erase
+//   integer: key length (max 4 KiB)
+//   key
+//   if mode==1: integer: data length (max 1 MiB)
+//   if mode==1: data
+// 0 byte
+// 8 bytes checksum: first 8 bytes of running SHA256
+
+class CModEntry
+{
+public:
+    unsigned char nMode;
+    data_t key;
+    data_t value;
+};
+
+void CLogDBFile::Init_()
+{
+    file = NULL;
+    SHA256_Init(&ctxState);
+    mapData.clear();
+    nUsed = 0;
+    nWritten = 0;
+    setDirty.clear();
+}
+
+bool CLogDBFile::Write_(const data_t &key, const data_t &value, bool fOverwrite, bool fLoad)
+{
+    if (!fLoad)
+        return false;
+
+    // update nUsed
+    std::map<data_t, data_t>::iterator it = mapData.find(key);
+    if (it != mapData.end())
+    {
+        if ((*it).second == value)
+            return true;
+
+        if (!fOverwrite)
+            return false;
+        nUsed -= (*it).first.size() + (*it).second.size();
+    }
+    nUsed += key.size() + value.size();
+
+    // update data
+    mapData.insert(make_pair(key, value));
+    if (!fLoad)
+        setDirty.insert(key);
+
+    return true;
+}
+
+bool CLogDBFile::Read_(const data_t &key, data_t &value) const
+{
+    std::map<data_t, data_t>::const_iterator it = mapData.find(key);
+    if (it == mapData.end())
+        return false;
+
+    value = (*it).second;
+
+    return true;
+}
+
+bool CLogDBFile::Exists_(const data_t &key) const
+{
+    return mapData.count(key) > 0;
+}
+
+bool CLogDBFile::Erase_(const data_t &key, bool fLoad)
+{
+    if (!fLoad)
+        return false;
+
+    std::map<data_t, data_t>::iterator it = mapData.find(key);
+    if (it != mapData.end())
+    {
+        nUsed -= (*it).first.size() + (*it).second.size();
+        mapData.erase(it);
+        if (!fLoad)
+            setDirty.insert(key);
+    }
+
+    return true;
+}
+
+bool CLogDBFile::Close_()
+{
+    if (file)
+    {
+        Flush_();
+        fclose(file);
+        Init_();
+    }
+    return true;
+}
+
+bool CLogDBFile::Load_()
+{
+    do
+    {
+        if (feof(file))
+            return true;
+        if (getc(file) != 0xCC) return feof(file);
+        if (getc(file) != 0xC4) return false;
+        if (getc(file) != 0xE6) return false;
+        if (getc(file) != 0xB0) return false;
+
+        printf("CLogDB::Load(): frame header found\n");
+
+        vector<CModEntry> vMod;
+
+        // update a copy of the state, so we can revert in case of error
+        SHA256_CTX ctx = ctxState;
+
+        do
+        {
+            if (feof(file))
+            {
+                printf("CLogDB::Load(): unexpected eof at record start\n");
+                return false;
+            }
+
+            CModEntry entry;
+            entry.nMode = getc(file);
+            if (entry.nMode > 2)
+            {
+                printf("CLogDB::Load(): unknown record mode\n");
+                return false;
+            }
+
+            SHA256_Update(&ctx, &entry.nMode, 1);
+
+            if (entry.nMode == 0)
+                break;
+
+            printf("CLogDB::Load(): loading record mode %i\n", entry.nMode);
+
+            uint32_t nKeySize = ReadInt(file);
+            if (nKeySize >= 0x1000)
+            {
+                printf("CLogDB::Load(): oversizes key (%lu bytes)\n", (unsigned long)nKeySize);
+                return false;
+            }
+            entry.key.resize(nKeySize);
+            if (fread(&entry.key[0], nKeySize, 1, file) != 1)
+            {
+                printf("CLogDB::Load(): unable to read key (%lu bytes)\n", (unsigned long)nKeySize);
+                return false;
+            }
+
+            printf("CLogDB::load(): loading key (%.*s)\n", nKeySize, &entry.key[0]);
+
+            SHA256_Update(&ctx, &nKeySize, 4);
+            SHA256_Update(&ctx, &entry.key[0], nKeySize);
+
+            if (entry.nMode == 1)
+            {
+                int nValueSize = ReadInt(file);
+                if (nValueSize >= 0x100000)
+                {
+                    printf("CLogDB::Load(): oversized value (%lu bytes)\n", (unsigned long)nValueSize);
+                    return false;
+                }
+                entry.value.resize(nValueSize);
+                if (fread(&entry.value[0], nValueSize, 1, file) != 1)
+                {
+                    printf("CLogDB::Load(): unable to read value (%lu bytes)\n", (unsigned long)nValueSize);
+                    return false;
+                }
+
+                SHA256_Update(&ctx, &nValueSize, 4);
+                SHA256_Update(&ctx, &entry.value[0], nValueSize);
+            }
+
+            vMod.push_back(entry);
+        } while(true);
+
+        unsigned char check[8];
+        if (fread(check, 8, 1, file)!=1)
+        {
+            printf("CLogDB::Load(): unable to read checksum\n");
+            return false;
+        }
+
+        SHA256_CTX ctxFinal = ctx;
+
+        unsigned char checkx[32];
+        SHA256_Final(checkx, &ctxFinal);
+        if (memcmp(check,checkx,8))
+        {
+            printf("CLogDB::Load(): checksum failed\n");
+            return false;
+        }
+
+        // if we reach this point, the entire read frame was valid
+        ctxState = ctx;
+
+        for (vector<CModEntry>::iterator it = vMod.begin(); it != vMod.end(); it++)
+        {
+            CModEntry &mod = *it;
+            nWritten += mod.key.size() + mod.value.size();
+            switch (mod.nMode)
+            {
+                case 1:
+                    Write_(mod.key, mod.value, true, true);
+                    break;
+
+                case 2:
+                    Erase_(mod.key, true);
+                    break;
+            }
+        }
+
+    } while(true);
+
+    printf("CLogDB::Load(): done\n");
+}
+
+bool CLogDBFile::Flush_()
+{
+    printf("CLogDB::Flush_()\n");
+
+    if (setDirty.empty())
+        return true;
+
+    printf("CLogDB::Flush_(): not dirty\n");
+
+    unsigned char magic[4]={0xCC,0xC4,0xE6,0xB0};
+
+    if (fwrite(magic, 4, 1, file) != 1)
+    {
+        printf("CLogDB::Flush_(): error writing magic: %s\n", strerror(errno));
+    }
+
+    SHA256_CTX ctx = ctxState;
+
+    for (set<data_t>::iterator it = setDirty.begin(); it != setDirty.end(); it++)
+    {
+        map<data_t, data_t>::iterator it2 = mapData.find(*it);
+
+        if (it2 != mapData.end())
+        {
+            // update
+            unsigned char nMode = 1;
+            uint32_t nKeySize = (*it).size();
+            uint32_t nDataSize = (*it2).second.size();
+            nWritten += nKeySize + nDataSize;
+
+            printf("CLogDB::Flush(): writing update(%.*s)\n", nKeySize, &(*it)[0]);
+
+            putc(nMode, file);
+            WriteInt(file, nKeySize);
+            fwrite(&(*it)[0], nKeySize, 1, file);
+            WriteInt(file, nDataSize);
+            fwrite(&(*it2).second[0], nDataSize, 1, file);
+
+            SHA256_Update(&ctx, &nMode, 1);
+            SHA256_Update(&ctx, &nKeySize, 4);
+            SHA256_Update(&ctx, &(*it)[0], nKeySize);
+            SHA256_Update(&ctx, &nDataSize, 4);
+            SHA256_Update(&ctx, &(*it2).second[0], nDataSize);
+        }
+        else
+        {
+            // erase
+            unsigned char nMode = 2;
+            uint32_t nKeySize = (*it).size();
+            nWritten += nKeySize;
+
+            printf("CLogDB::Flush(): writing erase(%.*s)\n", nKeySize, &(*it)[0]);
+
+            putc(nMode, file);
+            WriteInt(file, nKeySize);
+            fwrite(&(*it)[0], nKeySize, 1, file);
+
+            SHA256_Update(&ctx, &nMode, 1);
+            SHA256_Update(&ctx, &nKeySize, 4);
+            SHA256_Update(&ctx, &(*it)[0], nKeySize);
+        }
+    }
+
+    unsigned char nMode = 0;
+    putc(nMode, file);
+    SHA256_Update(&ctx, &nMode, 1);
+
+    SHA256_CTX ctxFinal = ctx;
+    unsigned char buf[32];
+    SHA256_Final(buf, &ctxFinal);
+    fwrite(buf, 8, 1, file);
+    fflush(file);
+    fdatasync(fileno(file));
+    ctxState = ctx;
+
+    printf("CLogDB::Flush(): wrote frame\n");
+
+    setDirty.clear();
+
+    return true;
+}
+
+bool CLogDB::TxnAbort() {
+    LOCK(cs);
+
+    if (!fTransaction)
+        return false;
+
+    mapData.clear();
+    setDirty.clear();
+
+    fTransaction = false;
+    if (fReadOnly)
+        db->mutex.unlock_shared();
+    else
+        db->mutex.unlock();
+
+    return true;
+}
+
+bool CLogDB::TxnBegin() {
+    LOCK(cs);
+
+    if (fTransaction)
+        return false;
+
+    if (fReadOnly)
+        db->mutex.lock_shared();
+    else
+        db->mutex.lock();
+
+    fTransaction = true;
+    return true;
+}
+
+bool CLogDB::TxnCommit() {
+    LOCK(cs);
+
+    if (!fTransaction)
+        return false;
+
+    // commit modifications to backing CLogDBFile
+    for (std::set<data_t>::const_iterator it = setDirty.begin(); it != setDirty.end(); it++) {
+         std::map<data_t, data_t>::const_iterator it2 = mapData.find(*it);
+         if (it2 != mapData.end()) {
+             db->Erase_(*it);
+         } else {
+             db->Write_(*it, (*it2).second);
+         }
+    }
+    mapData.clear();
+    setDirty.clear();
+    if (!fReadOnly)
+        db->Flush_();
+
+    fTransaction = false;
+    if (fReadOnly)
+        db->mutex.unlock_shared();
+    else
+        db->mutex.unlock();
+
+    return true;
+}
+
+bool CLogDB::Write(const data_t &key, const data_t &value) {
+    if (fReadOnly)
+        return false;
+
+    LOCK(cs);
+
+    bool fAutoTransaction = TxnBegin();
+
+    mapData[key] = value;
+    setDirty.insert(key);
+
+    if (fAutoTransaction)
+        return TxnCommit();
+
+    return true;
+}
+
+bool CLogDB::Erase(const data_t &key) {
+    if (fReadOnly)
+        return false;
+
+    LOCK(cs);
+
+    bool fAutoTransaction = TxnBegin();
+
+    mapData.erase(key);
+    setDirty.insert(key);
+
+    if (fAutoTransaction)
+        return TxnCommit();
+    return true;
+}
+
+bool CLogDB::Read(const data_t &key, data_t &value) {
+    LOCK(cs);
+
+    bool fAutoTransaction = TxnBegin();
+    bool fOk = true;
+
+    // in readonly mode: no need to check for local modifications
+    if (!fReadOnly && setDirty.count(key)) {
+        std::map<data_t, data_t>::const_iterator it = mapData.find(key);
+        if (it != mapData.end()) {
+            value = (*it).second;
+        } else {
+            fOk = false;
+        }
+    } else {
+        fOk = db->Read_(key, value);
+    }
+
+    if (fAutoTransaction)
+        fOk &= TxnCommit();
+
+    return fOk;
+}
+
+bool CLogDB::Exists(const data_t &key) {
+    LOCK(cs);
+
+    bool fAutoTransaction = TxnBegin();
+
+    bool fRet;
+    // in readonly mode: no need to check for local modifications
+    if (!fReadOnly && setDirty.count(key) != 0) {
+        fRet = (mapData.count(key) != 0);
+    } else {
+        fRet = db->Exists_(key);
+    }
+
+    if (fAutoTransaction)
+        TxnCommit();
+
+    return fRet;
+}

--- a/src/logdb.h
+++ b/src/logdb.h
@@ -1,0 +1,177 @@
+// Copyright (c) 2012 The Bitcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file license.txt or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef _BITCOIN_LOGDB_H_
+#define _BITCOIN_LOGDB_H_
+
+#include <map>
+#include <set>
+
+#include <openssl/sha.h>
+#include <boost/thread/shared_mutex.hpp>
+#include <boost/thread/locks.hpp>
+
+#include "sync.h"
+#include "serialize.h"
+
+typedef std::vector<unsigned char> data_t;
+
+class CLogDB;
+
+class CLogDBFile
+{
+private:
+    mutable boost::shared_mutex mutex;
+
+    FILE *file;
+    SHA256_CTX ctxState;
+
+    // database
+    std::map<data_t, data_t> mapData;
+    size_t nUsed; // continuously updated
+    size_t nWritten; // updated when writing a new block
+
+    // cached changes
+    std::set<data_t> setDirty;
+
+    friend class CLogDB;
+
+protected:
+    void Init_();
+    bool Load_();
+    bool Write_(const data_t &key, const data_t &value, bool fOverwrite = true, bool fLoad = false);
+    bool Read_(const data_t &key, data_t &value) const;
+    bool Exists_(const data_t &key) const;
+    bool Erase_(const data_t &key, bool fLoad = false);
+    bool Flush_();
+    bool Close_();
+
+public:
+    CLogDBFile()
+    {
+        Init_();
+    }
+
+    ~CLogDBFile()
+    {
+        Close_();
+    }
+
+    bool Open(const char *pszFile, bool fCreate = true)
+    {
+        boost::lock_guard<boost::shared_mutex> lock(mutex);
+        Close_();
+
+        file = fopen(pszFile, fCreate ? "a+b" : "r+b");
+
+        if (file == NULL) {
+            printf("Error opening %s: %s\n", pszFile, strerror(errno));
+                return false;
+        }
+
+        return Load_();
+    }
+
+/*
+    template<typename K, typename V>
+    bool Write(const K &key, const V &value, bool fOverwrite = true)
+    {
+        CDataStream ssk(SER_DISK);
+        ssk << key;
+        data_t datak(ssk.begin(), ssk.end());
+        CDataStream ssv(SER_DISK);
+        ssv << value;
+        data_t datav(ssv.begin(), ssv.end());
+        CRITICAL_BLOCK(cs)
+            return Write_(datak, datav, fOverwrite);
+        return false;
+    }
+
+    template<typename K, typename V>
+    bool Read(const K &key, V &value) const
+    {
+        CDataStream ssk(SER_DISK);
+        ssk << key;
+        data_t datak(ssk.begin(), ssk.end());
+        data_t datav;
+        CRITICAL_BLOCK(cs)
+            if (!Read_(datak,datav))
+                return false;
+        CDataStream ssv(datav, SER_DISK);
+        ssv >> value;
+        return true;
+    }
+
+    template<typename K>
+    bool Exists(const K &key) const
+    {
+        CDataStream ssk(SER_DISK);
+        ssk << key;
+        data_t datak(ssk.begin(), ssk.end());
+        CRITICAL_BLOCK(cs)
+            return Exists_(datak);
+        return false;
+    }
+
+    template<typename K>
+    bool Erase(const K &key)
+    { 
+        CDataStream ssk(SER_DISK);
+        ssk << key;
+        data_t datak(ssk.begin(), ssk.end());
+        CRITICAL_BLOCK(cs)
+            return Erase_(datak);
+        return false;
+    }
+*/
+
+//    bool Flush()            { CRITICAL_BLOCK(cs) return Flush_();          return false; }
+//    bool Close()            { CRITICAL_BLOCK(cs) return Close_();          return false; }
+//    bool IsDirty() const    { CRITICAL_BLOCK(cs) return !setDirty.empty(); return false; }
+//    bool IsOpen() const     { return file != NULL; }
+
+    bool Close() {
+        boost::lock_guard<boost::shared_mutex> lock(mutex);
+        return Close_();
+    }
+};
+
+class CLogDB
+{
+public:
+    typedef data_t key_type;
+    typedef data_t value_type;
+    typedef std::map<key_type, value_type>::const_iterator const_iterator;
+
+private:
+    mutable CCriticalSection cs;
+    CLogDBFile * const db; // const pointer to non-const db
+    const bool fReadOnly; // readonly CLogDB's use a shared lock instead of a normal
+
+    bool fTransaction; // true inside a transaction
+    std::map<data_t, data_t> mapData; // must be empty outside transactions
+    std::set<data_t> setDirty;
+
+public:
+    bool TxnAbort();
+    bool TxnBegin();
+    bool TxnCommit();
+
+    CLogDB(CLogDBFile *dbIn, bool fReadOnlyIn = false) : db(dbIn), fReadOnly(fReadOnlyIn), fTransaction(false) { }
+
+    ~CLogDB() {
+        TxnAbort();
+    }
+
+    bool Write(const data_t &key, const data_t &value);
+    bool Erase(const data_t &key);
+    bool Read(const data_t &key, data_t &value);
+    bool Exists(const data_t &key);
+
+    // only reads committed data, no local modifications
+    const_iterator begin() const { return db->mapData.begin(); }
+    const_iterator end() const   { return db->mapData.end(); }
+};
+
+#endif

--- a/src/logdb.h
+++ b/src/logdb.h
@@ -34,6 +34,8 @@ private:
     mutable boost::shared_mutex mutex;
 
     FILE *file;
+    std::string fileName;
+    
     CSHA256 ctxState;
     uint64_t version;
     
@@ -57,6 +59,7 @@ protected:
     bool Flush_();
     bool Open_(const char *pszFile, bool fCreate = true);
     bool Close_();
+    bool Reopen_(bool readOnly);
     
 public:
     CLogDBFile()
@@ -129,6 +132,8 @@ public:
     bool Read(const data_t &key, data_t &value);
     bool Exists(const data_t &key);
     bool Load();
+    bool Rewrite(const std::string &file); //rewrite and compact to a new file
+    bool ReloadDB(const std::string& walletFile); //!reload the db file
     
     bool Close() {
         boost::lock_guard<boost::shared_mutex> lock(db->mutex);

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -434,7 +434,7 @@ bool WalletModel::changePassphrase(const SecureString &oldPass, const SecureStri
 
 bool WalletModel::backupWallet(const QString &filename)
 {
-    return BackupWallet(*wallet, filename.toLocal8Bit().data());
+    return wallet->BackupWallet(filename.toLocal8Bit().data());
 }
 
 // Handlers for core signals

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -14,7 +14,6 @@
 #include "util.h"
 #include "utilmoneystr.h"
 #include "wallet.h"
-#include "walletdb.h"
 
 #include <stdint.h>
 
@@ -114,10 +113,8 @@ Value getnewaddress(const Array& params, bool fHelp)
 
 CBitcoinAddress GetAccountAddress(string strAccount, bool bForceNew=false)
 {
-    CWalletDB walletdb(pwalletMain->strWalletFile);
-
     CAccount account;
-    walletdb.ReadAccount(strAccount, account);
+    pwalletMain->ReadAccount(strAccount, account);
 
     bool bKeyUsed = false;
 
@@ -143,7 +140,7 @@ CBitcoinAddress GetAccountAddress(string strAccount, bool bForceNew=false)
             throw JSONRPCError(RPC_WALLET_KEYPOOL_RAN_OUT, "Error: Keypool ran out, please call keypoolrefill first");
 
         pwalletMain->SetAddressBook(account.vchPubKey.GetID(), strAccount, "receive");
-        walletdb.WriteAccount(strAccount, account);
+        pwalletMain->WriteAccount(strAccount, account);
     }
 
     return CBitcoinAddress(account.vchPubKey.GetID());
@@ -607,7 +604,7 @@ Value getreceivedbyaccount(const Array& params, bool fHelp)
 }
 
 
-CAmount GetAccountBalance(CWalletDB& walletdb, const string& strAccount, int nMinDepth, const isminefilter& filter)
+CAmount GetAccountBalance(const string& strAccount, int nMinDepth, const isminefilter& filter)
 {
     CAmount nBalance = 0;
 
@@ -627,17 +624,10 @@ CAmount GetAccountBalance(CWalletDB& walletdb, const string& strAccount, int nMi
     }
 
     // Tally internal accounting entries
-    nBalance += walletdb.GetAccountCreditDebit(strAccount);
+    nBalance += pwalletMain->GetAccountCreditDebit(strAccount);
 
     return nBalance;
 }
-
-CAmount GetAccountBalance(const string& strAccount, int nMinDepth, const isminefilter& filter)
-{
-    CWalletDB walletdb(pwalletMain->strWalletFile);
-    return GetAccountBalance(walletdb, strAccount, nMinDepth, filter);
-}
-
 
 Value getbalance(const Array& params, bool fHelp)
 {
@@ -758,35 +748,9 @@ Value movecmd(const Array& params, bool fHelp)
     if (params.size() > 4)
         strComment = params[4].get_str();
 
-    CWalletDB walletdb(pwalletMain->strWalletFile);
-    if (!walletdb.TxnBegin())
-        throw JSONRPCError(RPC_DATABASE_ERROR, "database error");
 
-    int64_t nNow = GetAdjustedTime();
-
-    // Debit
-    CAccountingEntry debit;
-    debit.nOrderPos = pwalletMain->IncOrderPosNext(&walletdb);
-    debit.strAccount = strFrom;
-    debit.nCreditDebit = -nAmount;
-    debit.nTime = nNow;
-    debit.strOtherAccount = strTo;
-    debit.strComment = strComment;
-    walletdb.WriteAccountingEntry(debit);
-
-    // Credit
-    CAccountingEntry credit;
-    credit.nOrderPos = pwalletMain->IncOrderPosNext(&walletdb);
-    credit.strAccount = strTo;
-    credit.nCreditDebit = nAmount;
-    credit.nTime = nNow;
-    credit.strOtherAccount = strFrom;
-    credit.strComment = strComment;
-    walletdb.WriteAccountingEntry(credit);
-
-    if (!walletdb.TxnCommit())
-        throw JSONRPCError(RPC_DATABASE_ERROR, "database error");
-
+    pwalletMain->MoveAccount(strFrom, strTo, nAmount, strComment);
+    
     return true;
 }
 
@@ -1452,7 +1416,7 @@ Value listaccounts(const Array& params, bool fHelp)
     }
 
     list<CAccountingEntry> acentries;
-    CWalletDB(pwalletMain->strWalletFile).ListAccountCreditDebit("*", acentries);
+    pwalletMain->ListAccountCreditDebit("*", acentries);
     BOOST_FOREACH(const CAccountingEntry& entry, acentries)
         mapAccountBalances[entry.strAccount] += entry.nCreditDebit;
 

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -1606,7 +1606,7 @@ Value backupwallet(const Array& params, bool fHelp)
     LOCK2(cs_main, pwalletMain->cs_wallet);
 
     string strDest = params[0].get_str();
-    if (!BackupWallet(*pwalletMain, strDest))
+    if (!pwalletMain->BackupWallet(strDest))
         throw JSONRPCError(RPC_WALLET_ERROR, "Error: Wallet backup failed!");
 
     return Value::null;

--- a/src/test/accounting_tests.cpp
+++ b/src/test/accounting_tests.cpp
@@ -31,6 +31,8 @@ GetResults(CWalletDB& walletdb, std::map<CAmount, CAccountingEntry>& results)
 BOOST_AUTO_TEST_CASE(acc_orderupgrade)
 {
     CWalletDB walletdb(pwalletMain->strWalletFile);
+    walletdb.Load();
+    
     std::vector<CWalletTx*> vpwtx;
     CWalletTx wtx;
     CAccountingEntry ae;

--- a/src/test/logdb_tests.cpp
+++ b/src/test/logdb_tests.cpp
@@ -1,0 +1,140 @@
+// Copyright (c) 2013 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "base58.h"
+#include "key.h"
+#include "logdb.h"
+#include "random.h"
+#include "util.h"
+
+#include <boost/test/unit_test.hpp>
+
+using namespace std;
+static const string strSecret1     ("Kwr371tjA9u2rFSMZjTNun2PXXP3WPZu2afRHTcta6KxEUdm1vEw");
+static const string strSecret2    ("L3Hq7a8FEQwJkW1M2GNKDW28546Vp5miewcCzSqUD9kCAXrJdS3g");
+
+BOOST_AUTO_TEST_SUITE(logdb_tests)
+
+BOOST_AUTO_TEST_CASE(logdb_test_1)
+{
+    boost::filesystem::path tmpPath = GetTempPath() / strprintf("test_bitcoin_logdb_%lu_%i.logdb", (unsigned long)GetTime(), (int)(GetRand(100000)));    
+    std::string dbFile = tmpPath.string();
+    
+    int max_loops = 1;
+    
+    for(int i = 0;i<max_loops;i++)
+    {
+        
+        // simple value test
+        CLogDB *aDB = new CLogDB(dbFile, false);
+        aDB->Load();
+        aDB->Write(std::string("testvalue"), std::string("aValue"));
+        aDB->Flush(true); //shutdown, close the file
+        aDB->Close();
+        delete aDB;
+        
+        aDB = new CLogDB(dbFile, false);
+        aDB->Load();
+        std::string returnString;
+        aDB->Read(std::string("testvalue"), returnString);
+        BOOST_CHECK_EQUAL(returnString, std::string("aValue"));
+        aDB->Write(std::string("testvalue"), std::string("aValue2"));
+        aDB->Read(std::string("testvalue"), returnString);
+        BOOST_CHECK_EQUAL(returnString, std::string("aValue2"));
+        aDB->Flush(true); //shutdown, close the file
+        aDB->Close();
+        delete aDB;
+        
+        aDB = new CLogDB(dbFile, false);
+        aDB->Load();
+        aDB->Erase(std::string("testvalue"));
+        
+        std::string returnString2;
+        aDB->Read(std::string("testvalue"), returnString2);
+        BOOST_CHECK(returnString2 == "");
+        aDB->Flush(true); //shutdown, close the file
+        aDB->Close();
+        delete aDB;
+
+        // store a key
+        CLogDB *aDB2 = new CLogDB(dbFile, false);
+        aDB2->Load();
+        aDB2->Read(std::string("testvalue"), returnString);
+        BOOST_CHECK_EQUAL(returnString, std::string("aValue2"));
+        
+        CBitcoinSecret bsecret;
+        BOOST_CHECK( bsecret.SetString (strSecret1));
+        CKey key1  = bsecret.GetKey();
+        CPubKey pKey = key1.GetPubKey();
+        aDB2->Write(std::string("keyOverwriteTest"), pKey);
+        aDB2->Flush(true); //shutdown, close the file
+        aDB2->Close();
+        delete aDB2;
+        
+        // overwrite existing key with a new pubkey
+        aDB2 = new CLogDB(dbFile, false);
+        aDB2->Load();
+        bsecret.SetString(strSecret2);
+        CKey key2  = bsecret.GetKey();
+        CPubKey pKey2 = key2.GetPubKey();
+        aDB2->Write(std::string("keyOverwriteTest"), pKey2);
+        aDB2->Flush(true); //shutdown, close the file
+        aDB2->Close();
+        delete aDB2;
+
+        // persistance and erase test
+        aDB2 = new CLogDB(dbFile, false);
+        aDB2->Load();
+        CPubKey pKeyTest;
+        aDB2->Read(std::string("keyOverwriteTest"), pKeyTest);
+        
+        BOOST_CHECK(pKey2 == pKeyTest);
+        BOOST_CHECK(pKey != pKeyTest);
+        BOOST_CHECK(pKeyTest.IsValid() == true);
+
+        aDB2->Erase(std::string("keyOverwriteTest"));
+        CPubKey pKeyTestEmpty;
+        aDB2->Read(std::string("keyOverwriteTest"), pKeyTestEmpty);
+        BOOST_CHECK(pKeyTestEmpty.IsValid() == false);
+        aDB2->Flush(true); //shutdown, close the file
+        aDB2->Close();
+        delete aDB2;
+        
+        // check persistance of Erase
+        aDB2 = new CLogDB(dbFile, false);
+        aDB2->Load();
+        CPubKey pKeyTestEmpty2;
+        aDB2->Read(std::string("keyOverwriteTest"), pKeyTestEmpty2);
+        BOOST_CHECK(pKeyTestEmpty2.IsValid() == false);
+        
+        //maxKeySize
+        std::string longKey = std::string(999,'a');
+        bool state = aDB2->Write(longKey, std::string("newValue"));
+        BOOST_CHECK(state);
+        aDB2->Flush(true); //shutdown, close the file
+        aDB2->Close();
+        delete aDB2;
+        
+        aDB2 = new CLogDB(dbFile, false);
+        aDB2->Load();
+        std::string newString;
+        aDB2->Read(longKey, newString);
+        BOOST_CHECK(newString == "newValue");
+        aDB2->Flush(true); //shutdown, close the file
+        
+        std::string longKey2 = std::string(0x1001,'b');
+        state = aDB2->Write(longKey2, std::string("newValue2"));
+        BOOST_CHECK(state == false);
+        
+        std::string newString2;
+        aDB2->Read(longKey2, newString2);
+        BOOST_CHECK(newString2 == "");
+        
+        aDB2->Close();
+        delete aDB2;
+    }
+    
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/logdb_tests.cpp
+++ b/src/test/logdb_tests.cpp
@@ -18,8 +18,6 @@ BOOST_AUTO_TEST_SUITE(logdb_tests)
 
 BOOST_AUTO_TEST_CASE(logdb_test_1)
 {
-    fPrintToConsole = true;
-    
     boost::filesystem::path tmpPath = GetTempPath() / strprintf("test_bitcoin_logdb_%lu_%i.logdb", (unsigned long)GetTime(), (int)(GetRand(100000)));    
     std::string dbFile = tmpPath.string();
     

--- a/src/test/rpc_wallet_tests.cpp
+++ b/src/test/rpc_wallet_tests.cpp
@@ -73,11 +73,10 @@ BOOST_AUTO_TEST_CASE(rpc_wallet)
     string strAccount = "walletDemoAccount";
     string strPurpose = "receive";
     BOOST_CHECK_NO_THROW({ /*Initialize Wallet with an account */
-        CWalletDB walletdb(pwalletMain->strWalletFile);
         CAccount account;
         account.vchPubKey = demoPubkey;
         pwalletMain->SetAddressBook(account.vchPubKey.GetID(), strAccount, strPurpose);
-        walletdb.WriteAccount(strAccount, account);
+        pwalletMain->WriteAccount(strAccount, account);
     });
 
     CPubKey setaccountDemoPubkey = pwalletMain->GenerateNewKey();

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -10,7 +10,6 @@
 #include "ui_interface.h"
 #include "util.h"
 #ifdef ENABLE_WALLET
-#include "db.h"
 #include "wallet.h"
 #endif
 
@@ -33,9 +32,6 @@ struct TestingSetup {
         fPrintToDebugLog = false; // don't want to write to debug.log file
         SelectParams(CBaseChainParams::UNITTEST);
         noui_connect();
-#ifdef ENABLE_WALLET
-        bitdb.MakeMock();
-#endif
         pathTemp = GetTempPath() / strprintf("test_bitcoin_%lu_%i", (unsigned long)GetTime(), (int)(GetRand(100000)));
         boost::filesystem::create_directories(pathTemp);
         mapArgs["-datadir"] = pathTemp.string();
@@ -45,7 +41,7 @@ struct TestingSetup {
         InitBlockIndex();
 #ifdef ENABLE_WALLET
         bool fFirstRun;
-        pwalletMain = new CWallet("wallet.dat");
+        pwalletMain = new CWallet("wallet.wal");
         pwalletMain->LoadWallet(fFirstRun);
         RegisterValidationInterface(pwalletMain);
 #endif
@@ -66,9 +62,6 @@ struct TestingSetup {
         delete pcoinsTip;
         delete pcoinsdbview;
         delete pblocktree;
-#ifdef ENABLE_WALLET
-        bitdb.Flush(true);
-#endif
         boost::filesystem::remove_all(pathTemp);
     }
 };

--- a/src/test/wallet_tests.cpp
+++ b/src/test/wallet_tests.cpp
@@ -305,4 +305,51 @@ BOOST_AUTO_TEST_CASE(coin_selection_tests)
     empty_wallet();
 }
 
+//BOOST_AUTO_TEST_CASE(encrypt_wallet_tests)
+//{
+//    SecureString strWalletPass;
+//    strWalletPass.reserve(100);
+//    strWalletPass = "test";
+//    
+//    std::string dbFile = strprintf("test_bitcoin_logdb_%lu_%i.logdb", (unsigned long)GetTime(), (int)(GetRand(100000)));
+//    
+//    bool fFirstRun = true;
+//    CWallet *newWallet = new CWallet(dbFile);
+//    newWallet->LoadWallet(fFirstRun);
+//    
+//    CPubKey newDefaultKey;
+//    {
+//        LOCK(newWallet->cs_wallet);
+//
+//        newDefaultKey = newWallet->GenerateNewKey();
+//        newWallet->SetDefaultKey(newDefaultKey);
+//        newWallet->TopUpKeyPool(10); //add 10 keys
+//        
+//        BOOST_CHECK(newWallet->IsLocked() == false);
+//        BOOST_CHECK(newWallet->EncryptWallet(strWalletPass));
+//        BOOST_CHECK(newWallet->IsLocked() == true);
+//
+//        BOOST_CHECK(newWallet->Unlock(strWalletPass));
+//        BOOST_CHECK(newWallet->IsLocked() == false);
+//        
+//        BOOST_CHECK(newWallet->Lock());
+//        BOOST_CHECK(newWallet->IsLocked() == true);
+//        
+//        BOOST_CHECK_THROW(newWallet->GenerateNewKey(), std::runtime_error); // must trigger a assertion because wallet is locked
+//        BOOST_CHECK(newWallet->Unlock(strWalletPass));
+//        BOOST_CHECK_NO_THROW(newWallet->GenerateNewKey()); // must trigger a assertion because wallet is locked
+//    }
+//    
+//    delete newWallet;
+//
+//    newWallet = new CWallet(dbFile);
+//    newWallet->LoadWallet(fFirstRun);
+//    {
+//        LOCK(newWallet->cs_wallet);
+//        BOOST_CHECK(newWallet->vchDefaultKey == newDefaultKey); // after the encryption, default key must still be readable
+//    }
+//    delete newWallet;
+//    
+//}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -501,7 +501,8 @@ bool CWallet::EncryptWallet(const SecureString& strWalletPassphrase)
 
         // Need to completely rewrite the wallet file; if we don't, bdb might keep
         // bits of the unencrypted private key in slack space in the database file.
-        CDB::Rewrite(strWalletFile);
+        //CDB::Rewrite(strWalletFile);
+        //^^TODO
 
     }
     NotifyStatusChanged(this);
@@ -784,6 +785,12 @@ bool CWallet::IsChange(const CTxOut& txout) const
             return true;
     }
     return false;
+}
+
+bool CWallet::Flush(bool shutdown)
+{
+    //TODO: implement
+    return true;
 }
 
 int64_t CWalletTx::GetTxTime() const
@@ -1849,14 +1856,15 @@ DBErrors CWallet::LoadWallet(bool& fFirstRunRet)
     DBErrors nLoadWalletRet = CWalletDB(strWalletFile,"cr+").LoadWallet(this);
     if (nLoadWalletRet == DB_NEED_REWRITE)
     {
-        if (CDB::Rewrite(strWalletFile, "\x04pool"))
-        {
-            LOCK(cs_wallet);
-            setKeyPool.clear();
-            // Note: can't top-up keypool here, because wallet is locked.
-            // User will be prompted to unlock wallet the next operation
-            // the requires a new key.
-        }
+        // TODO
+//        if (CDB::Rewrite(strWalletFile, "\x04pool"))
+//        {
+//            LOCK(cs_wallet);
+//            setKeyPool.clear();
+//            // Note: can't top-up keypool here, because wallet is locked.
+//            // User will be prompted to unlock wallet the next operation
+//            // the requires a new key.
+//        }
     }
 
     if (nLoadWalletRet != DB_LOAD_OK)
@@ -1876,14 +1884,15 @@ DBErrors CWallet::ZapWalletTx(std::vector<CWalletTx>& vWtx)
     DBErrors nZapWalletTxRet = CWalletDB(strWalletFile,"cr+").ZapWalletTx(this, vWtx);
     if (nZapWalletTxRet == DB_NEED_REWRITE)
     {
-        if (CDB::Rewrite(strWalletFile, "\x04pool"))
-        {
-            LOCK(cs_wallet);
-            setKeyPool.clear();
-            // Note: can't top-up keypool here, because wallet is locked.
-            // User will be prompted to unlock wallet the next operation
-            // that requires a new key.
-        }
+        // TODO
+//        if (CDB::Rewrite(strWalletFile, "\x04pool"))
+//        {
+//            LOCK(cs_wallet);
+//            setKeyPool.clear();
+//            // Note: can't top-up keypool here, because wallet is locked.
+//            // User will be prompted to unlock wallet the next operation
+//            // that requires a new key.
+//        }
     }
 
     if (nZapWalletTxRet != DB_LOAD_OK)

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -498,12 +498,9 @@ bool CWallet::EncryptWallet(const SecureString& strWalletPassphrase)
         Unlock(strWalletPassphrase);
         NewKeyPool();
         Lock();
-
-        // Need to completely rewrite the wallet file; if we don't, bdb might keep
-        // bits of the unencrypted private key in slack space in the database file.
-        //CDB::Rewrite(strWalletFile);
-        //^^TODO
-
+        
+        // Rewrite wallet because we may use a append only backend
+        CWalletDB(strWalletFile).Rewrite();
     }
     NotifyStatusChanged(this);
 
@@ -789,8 +786,7 @@ bool CWallet::IsChange(const CTxOut& txout) const
 
 bool CWallet::Flush(bool shutdown)
 {
-    //TODO: implement
-    return true;
+    return CWalletDB(strWalletFile).Flush(shutdown);
 }
 
 int64_t CWalletTx::GetTxTime() const

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -433,8 +433,6 @@ private:
     //! handle to the wallet backend
     CWalletDB *walletDB;
 
-    CWalletDB *pwalletdbEncryption;
-
     //! the current wallet version: clients below this version are not able to load the wallet
     int nWalletVersion;
 
@@ -461,12 +459,10 @@ public:
      * Main wallet lock.
      * This lock protects all the fields added by CWallet
      *   except for:
-     *      fFileBacked (immutable after instantiation)
      *      strWalletFile (immutable after instantiation)
      */
     mutable CCriticalSection cs_wallet;
 
-    bool fFileBacked;
     std::string strWalletFile;
 
     std::set<int64_t> setKeyPool;
@@ -489,15 +485,10 @@ public:
         
         //instantiate a wallet backend object and maps the stored values
         walletDB = new CWalletDB(strWalletFile);
-        
-        fFileBacked = true;
     }
 
     ~CWallet()
     {
-        delete pwalletdbEncryption;
-        pwalletdbEncryption = NULL;
-        
         // make sure to discard the handle (it might close the db/file)
         delete walletDB;
     }
@@ -506,9 +497,7 @@ public:
     {
         nWalletVersion = FEATURE_BASE;
         nWalletMaxVersion = FEATURE_BASE;
-        fFileBacked = false;
         nMasterKeyMaxID = 0;
-        pwalletdbEncryption = NULL;
         nOrderPosNext = 0;
         nNextResend = 0;
         nLastResend = 0;
@@ -555,9 +544,6 @@ public:
     bool LoadKey(const CKey& key, const CPubKey &pubkey) { return CCryptoKeyStore::AddKeyPubKey(key, pubkey); }
     //! Load metadata (used by LoadWallet)
     bool LoadKeyMetadata(const CPubKey &pubkey, const CKeyMetadata &metadata);
-
-    bool LoadMinVersion(int nVersion) { AssertLockHeld(cs_wallet); nWalletVersion = nVersion; nWalletMaxVersion = std::max(nWalletMaxVersion, nVersion); return true; }
-
     //! Adds an encrypted key to the store, and saves it to disk.
     bool AddCryptedKey(const CPubKey &vchPubKey, const std::vector<unsigned char> &vchCryptedSecret);
     //! Adds an encrypted key to the store, without saving it to disk (used by LoadWallet)
@@ -737,9 +723,6 @@ public:
 
     bool SetDefaultKey(const CPubKey &vchPubKey);
 
-    //! change which version we're allowed to upgrade to (note that this does not immediately imply upgrading to that format)
-    bool SetMaxVersion(int nVersion);
-
     //! get the current wallet format (the oldest client version guaranteed to understand this wallet)
     int GetVersion() { LOCK(cs_wallet); return nWalletVersion; }
 
@@ -752,385 +735,9 @@ public:
     //! Write down a specific wallet transaction
     bool WriteTxToDisk(const CWalletTx& wtx);
     
-    /** 
-     * Address book entry changed.
-     * @note called with lock cs_wallet held.
-     */
-    boost::signals2::signal<void (CWallet *wallet, const CTxDestination
-            &address, const std::string &label, bool isMine,
-            const std::string &purpose,
-            ChangeType status)> NotifyAddressBookChanged;
-
-    /** 
-     * Wallet transaction added, removed or updated.
-     * @note called with lock cs_wallet held.
-     */
-    boost::signals2::signal<void (CWallet *wallet, const uint256 &hashTx,
-            ChangeType status)> NotifyTransactionChanged;
-
-    /** Show progress e.g. for rescan */
-    boost::signals2::signal<void (const std::string &title, int nProgress)> ShowProgress;
-
-    /** Watch-only address added */
-    boost::signals2::signal<void (bool fHaveWatchOnly)> NotifyWatchonlyChanged;
-};
-
-/** A key allocated from the key pool. */
-class CReserveKey
-{
-protected:
-    CWallet* pwallet;
-    int64_t nIndex;
-    CPubKey vchPubKey;
-public:
-    CReserveKey(CWallet* pwalletIn)
-    {
-        nIndex = -1;
-        pwallet = pwalletIn;
-    }
-
-    ~CReserveKey()
-    {
-        ReturnKey();
-    }
-
-    void ReturnKey();
-    bool GetReservedKey(CPubKey &pubkey);
-    void KeepKey();
-};
-
-
-typedef std::map<std::string, std::string> mapValue_t;
-
-
-static void ReadOrderPos(int64_t& nOrderPos, mapValue_t& mapValue)
-{
-    if (!mapValue.count("n"))
-    {
-        nOrderPos = -1; // TODO: calculate elsewhere
-        return;
-    }
-    nOrderPos = atoi64(mapValue["n"].c_str());
-}
-
-
-static void WriteOrderPos(const int64_t& nOrderPos, mapValue_t& mapValue)
-{
-    if (nOrderPos == -1)
-        return;
-    mapValue["n"] = i64tostr(nOrderPos);
-}
-
-struct COutputEntry
-{
-    CTxDestination destination;
-    CAmount amount;
-    int vout;
-};
-
-/** A transaction with a merkle branch linking it to the block chain. */
-class CMerkleTx : public CTransaction
-{
-private:
-    int GetDepthInMainChainINTERNAL(const CBlockIndex* &pindexRet) const;
-
-public:
-    uint256 hashBlock;
-    std::vector<uint256> vMerkleBranch;
-    int nIndex;
-
-    // memory only
-    mutable bool fMerkleVerified;
-
-
-    CMerkleTx()
-    {
-        Init();
-    }
-
-    CMerkleTx(const CTransaction& txIn) : CTransaction(txIn)
-    {
-        Init();
-    }
-
-    void Init()
-    {
-        hashBlock = uint256();
-        nIndex = -1;
-        fMerkleVerified = false;
-    }
-
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
-        READWRITE(*(CTransaction*)this);
-        nVersion = this->nVersion;
-        READWRITE(hashBlock);
-        READWRITE(vMerkleBranch);
-        READWRITE(nIndex);
-    }
-
-    int SetMerkleBranch(const CBlock& block);
-
-
-    /**
-     * Return depth of transaction in blockchain:
-     * -1  : not in blockchain, and not in memory pool (conflicted transaction)
-     *  0  : in memory pool, waiting to be included in a block
-     * >=1 : this many blocks deep in the main chain
-     */
-    int GetDepthInMainChain(const CBlockIndex* &pindexRet) const;
-    int GetDepthInMainChain() const { const CBlockIndex *pindexRet; return GetDepthInMainChain(pindexRet); }
-    bool IsInMainChain() const { const CBlockIndex *pindexRet; return GetDepthInMainChainINTERNAL(pindexRet) > 0; }
-    int GetBlocksToMaturity() const;
-    bool AcceptToMemoryPool(bool fLimitFree=true, bool fRejectInsaneFee=true);
-};
-
-/** 
- * A transaction with a bunch of additional info that only the owner cares about.
- * It includes any unrecorded transactions needed to link it back to the block chain.
- */
-class CWalletTx : public CMerkleTx
-{
-private:
-    const CWallet* pwallet;
-
-public:
-    mapValue_t mapValue;
-    std::vector<std::pair<std::string, std::string> > vOrderForm;
-    unsigned int fTimeReceivedIsTxTime;
-    unsigned int nTimeReceived; //! time received by this node
-    unsigned int nTimeSmart;
-    char fFromMe;
-    std::string strFromAccount;
-    int64_t nOrderPos; //! position in ordered transaction list
-
-    // memory only
-    mutable bool fDebitCached;
-    mutable bool fCreditCached;
-    mutable bool fImmatureCreditCached;
-    mutable bool fAvailableCreditCached;
-    mutable bool fWatchDebitCached;
-    mutable bool fWatchCreditCached;
-    mutable bool fImmatureWatchCreditCached;
-    mutable bool fAvailableWatchCreditCached;
-    mutable bool fChangeCached;
-    mutable CAmount nDebitCached;
-    mutable CAmount nCreditCached;
-    mutable CAmount nImmatureCreditCached;
-    mutable CAmount nAvailableCreditCached;
-    mutable CAmount nWatchDebitCached;
-    mutable CAmount nWatchCreditCached;
-    mutable CAmount nImmatureWatchCreditCached;
-    mutable CAmount nAvailableWatchCreditCached;
-    mutable CAmount nChangeCached;
-
-    CWalletTx()
-    {
-        Init(NULL);
-    }
-
-    CWalletTx(const CWallet* pwalletIn)
-    {
-        Init(pwalletIn);
-    }
-
-    CWalletTx(const CWallet* pwalletIn, const CMerkleTx& txIn) : CMerkleTx(txIn)
-    {
-        Init(pwalletIn);
-    }
-
-    CWalletTx(const CWallet* pwalletIn, const CTransaction& txIn) : CMerkleTx(txIn)
-    {
-        Init(pwalletIn);
-    }
-
-    void Init(const CWallet* pwalletIn)
-    {
-        pwallet = pwalletIn;
-        mapValue.clear();
-        vOrderForm.clear();
-        fTimeReceivedIsTxTime = false;
-        nTimeReceived = 0;
-        nTimeSmart = 0;
-        fFromMe = false;
-        strFromAccount.clear();
-        fDebitCached = false;
-        fCreditCached = false;
-        fImmatureCreditCached = false;
-        fAvailableCreditCached = false;
-        fWatchDebitCached = false;
-        fWatchCreditCached = false;
-        fImmatureWatchCreditCached = false;
-        fAvailableWatchCreditCached = false;
-        fChangeCached = false;
-        nDebitCached = 0;
-        nCreditCached = 0;
-        nImmatureCreditCached = 0;
-        nAvailableCreditCached = 0;
-        nWatchDebitCached = 0;
-        nWatchCreditCached = 0;
-        nAvailableWatchCreditCached = 0;
-        nImmatureWatchCreditCached = 0;
-        nChangeCached = 0;
-        nOrderPos = -1;
-    }
-
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
-        if (ser_action.ForRead())
-            Init(NULL);
-        char fSpent = false;
-
-        if (!ser_action.ForRead())
-        {
-            mapValue["fromaccount"] = strFromAccount;
-
-            WriteOrderPos(nOrderPos, mapValue);
-
-            if (nTimeSmart)
-                mapValue["timesmart"] = strprintf("%u", nTimeSmart);
-        }
-
-    static CFeeRate minTxFee;
-    static CAmount GetMinimumFee(unsigned int nTxBytes, unsigned int nConfirmTarget, const CTxMemPool& pool);
-
-    bool NewKeyPool();
-    bool TopUpKeyPool(unsigned int kpSize = 0);
-    void ReserveKeyFromKeyPool(int64_t& nIndex, CKeyPool& keypool);
-    void KeepKey(int64_t nIndex);
-    void ReturnKey(int64_t nIndex);
-    bool GetKeyFromPool(CPubKey &key);
-    int64_t GetOldestKeyPoolTime();
-    void GetAllReserveKeys(std::set<CKeyID>& setAddress) const;
-
-    std::set< std::set<CTxDestination> > GetAddressGroupings();
-    std::map<CTxDestination, CAmount> GetAddressBalances();
-
-    std::set<CTxDestination> GetAccountAddresses(std::string strAccount) const;
-
-    isminetype IsMine(const CTxIn& txin) const;
-    CAmount GetDebit(const CTxIn& txin, const isminefilter& filter) const;
-    isminetype IsMine(const CTxOut& txout) const
-    {
-        return ::IsMine(*this, txout.scriptPubKey);
-    }
-    CAmount GetCredit(const CTxOut& txout, const isminefilter& filter) const
-    {
-        if (!MoneyRange(txout.nValue))
-            throw std::runtime_error("CWallet::GetCredit(): value out of range");
-        return ((IsMine(txout) & filter) ? txout.nValue : 0);
-    }
-    bool IsChange(const CTxOut& txout) const;
-    CAmount GetChange(const CTxOut& txout) const
-    {
-        if (!MoneyRange(txout.nValue))
-            throw std::runtime_error("CWallet::GetChange(): value out of range");
-        return (IsChange(txout) ? txout.nValue : 0);
-    }
-    bool IsMine(const CTransaction& tx) const
-    {
-        BOOST_FOREACH(const CTxOut& txout, tx.vout)
-            if (IsMine(txout))
-                return true;
-        return false;
-    }
-    /** should probably be renamed to IsRelevantToMe */
-    bool IsFromMe(const CTransaction& tx) const
-    {
-        return (GetDebit(tx, ISMINE_ALL) > 0);
-    }
-    CAmount GetDebit(const CTransaction& tx, const isminefilter& filter) const
-    {
-        CAmount nDebit = 0;
-        BOOST_FOREACH(const CTxIn& txin, tx.vin)
-        {
-            nDebit += GetDebit(txin, filter);
-            if (!MoneyRange(nDebit))
-                throw std::runtime_error("CWallet::GetDebit(): value out of range");
-        }
-        return nDebit;
-    }
-    CAmount GetCredit(const CTransaction& tx, const isminefilter& filter) const
-    {
-        CAmount nCredit = 0;
-        BOOST_FOREACH(const CTxOut& txout, tx.vout)
-        {
-            nCredit += GetCredit(txout, filter);
-            if (!MoneyRange(nCredit))
-                throw std::runtime_error("CWallet::GetCredit(): value out of range");
-        }
-        return nCredit;
-    }
-    CAmount GetChange(const CTransaction& tx) const
-    {
-        CAmount nChange = 0;
-        BOOST_FOREACH(const CTxOut& txout, tx.vout)
-        {
-            nChange += GetChange(txout);
-            if (!MoneyRange(nChange))
-                throw std::runtime_error("CWallet::GetChange(): value out of range");
-        }
-        return nChange;
-    }
-    void SetBestChain(const CBlockLocator& loc);
-
-    DBErrors LoadWallet(bool& fFirstRunRet);
-    DBErrors ZapWalletTx(std::vector<CWalletTx>& vWtx);
-
-    bool SetAddressBook(const CTxDestination& address, const std::string& strName, const std::string& purpose);
-
-    bool DelAddressBook(const CTxDestination& address);
-
-    void UpdatedTransaction(const uint256 &hashTx);
-
-    void Inventory(const uint256 &hash)
-    {
-        {
-            LOCK(cs_wallet);
-            std::map<uint256, int>::iterator mi = mapRequestCount.find(hash);
-            if (mi != mapRequestCount.end())
-                (*mi).second++;
-        }
-    }
-
-    unsigned int GetKeyPoolSize()
-    {
-        AssertLockHeld(cs_wallet); // setKeyPool
-        return setKeyPool.size();
-    }
-
-    bool SetDefaultKey(const CPubKey &vchPubKey);
-
-    void GetAmounts(std::list<COutputEntry>& listReceived,
-                    std::list<COutputEntry>& listSent, CAmount& nFee, std::string& strSentAccount, const isminefilter& filter) const;
-
-    void GetAccountAmounts(const std::string& strAccount, CAmount& nReceived,
-                           CAmount& nSent, CAmount& nFee, const isminefilter& filter) const;
+    //! Create a backup of the wallet file
+    bool BackupWallet(const std::string& strDest);
     
-    bool IsFromMe(const isminefilter& filter) const
-    {
-        return (GetDebit(filter) > 0);
-    }
-
-    //! signify that a particular wallet feature is now used. this may change nWalletVersion and nWalletMaxVersion if those are lower
-    bool SetMinVersion(enum WalletFeature, CWalletDB* pwalletdbIn = NULL, bool fExplicit = false);
-
-    //! change which version we're allowed to upgrade to (note that this does not immediately imply upgrading to that format)
-    bool SetMaxVersion(int nVersion);
-
-    //! get the current wallet format (the oldest client version guaranteed to understand this wallet)
-    int GetVersion() { LOCK(cs_wallet); return nWalletVersion; }
-        
-    int64_t GetTxTime() const;
-    int GetRequestCount() const;
-
-    //! Get wallet transactions that conflict with given transaction (spend same outputs)
-    std::set<uint256> GetConflicts(const uint256& txid) const;
-
     /** 
      * Address book entry changed.
      * @note called with lock cs_wallet held.
@@ -1177,7 +784,6 @@ public:
     bool GetReservedKey(CPubKey &pubkey);
     void KeepKey();
 };
-
 
 /** 
  * Account information.

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -643,6 +643,374 @@ public:
     CAmount GetCredit(const CTxOut& txout, const isminefilter& filter) const
     {
         if (!MoneyRange(txout.nValue))
+            throw std::runtime_error("CWallet::GetCredit() : value out of range");
+        return ((IsMine(txout) & filter) ? txout.nValue : 0);
+    }
+    bool IsChange(const CTxOut& txout) const;
+    CAmount GetChange(const CTxOut& txout) const
+    {
+        if (!MoneyRange(txout.nValue))
+            throw std::runtime_error("CWallet::GetChange() : value out of range");
+        return (IsChange(txout) ? txout.nValue : 0);
+    }
+    bool IsMine(const CTransaction& tx) const
+    {
+        BOOST_FOREACH(const CTxOut& txout, tx.vout)
+            if (IsMine(txout))
+                return true;
+        return false;
+    }
+    /** should probably be renamed to IsRelevantToMe */
+    bool IsFromMe(const CTransaction& tx) const
+    {
+        return (GetDebit(tx, ISMINE_ALL) > 0);
+    }
+    CAmount GetDebit(const CTransaction& tx, const isminefilter& filter) const
+    {
+        CAmount nDebit = 0;
+        BOOST_FOREACH(const CTxIn& txin, tx.vin)
+        {
+            nDebit += GetDebit(txin, filter);
+            if (!MoneyRange(nDebit))
+                throw std::runtime_error("CWallet::GetDebit() : value out of range");
+        }
+        return nDebit;
+    }
+    CAmount GetCredit(const CTransaction& tx, const isminefilter& filter) const
+    {
+        CAmount nCredit = 0;
+        BOOST_FOREACH(const CTxOut& txout, tx.vout)
+        {
+            nCredit += GetCredit(txout, filter);
+            if (!MoneyRange(nCredit))
+                throw std::runtime_error("CWallet::GetCredit() : value out of range");
+        }
+        return nCredit;
+    }
+    CAmount GetChange(const CTransaction& tx) const
+    {
+        CAmount nChange = 0;
+        BOOST_FOREACH(const CTxOut& txout, tx.vout)
+        {
+            nChange += GetChange(txout);
+            if (!MoneyRange(nChange))
+                throw std::runtime_error("CWallet::GetChange() : value out of range");
+        }
+        return nChange;
+    }
+    void SetBestChain(const CBlockLocator& loc);
+
+    DBErrors LoadWallet(bool& fFirstRunRet);
+    DBErrors ZapWalletTx(std::vector<CWalletTx>& vWtx);
+
+    bool SetAddressBook(const CTxDestination& address, const std::string& strName, const std::string& purpose);
+
+    bool DelAddressBook(const CTxDestination& address);
+
+    void UpdatedTransaction(const uint256 &hashTx);
+
+    void Inventory(const uint256 &hash)
+    {
+        {
+            LOCK(cs_wallet);
+            std::map<uint256, int>::iterator mi = mapRequestCount.find(hash);
+            if (mi != mapRequestCount.end())
+                (*mi).second++;
+        }
+    }
+
+    unsigned int GetKeyPoolSize()
+    {
+        AssertLockHeld(cs_wallet); // setKeyPool
+        return setKeyPool.size();
+    }
+
+    bool SetDefaultKey(const CPubKey &vchPubKey);
+
+    //! signify that a particular wallet feature is now used. this may change nWalletVersion and nWalletMaxVersion if those are lower
+    bool SetMinVersion(enum WalletFeature, CWalletDB* pwalletdbIn = NULL, bool fExplicit = false);
+
+    //! change which version we're allowed to upgrade to (note that this does not immediately imply upgrading to that format)
+    bool SetMaxVersion(int nVersion);
+
+    //! get the current wallet format (the oldest client version guaranteed to understand this wallet)
+    int GetVersion() { LOCK(cs_wallet); return nWalletVersion; }
+
+    //! Get wallet transactions that conflict with given transaction (spend same outputs)
+    std::set<uint256> GetConflicts(const uint256& txid) const;
+
+    //! Flush wallet
+    bool Flush(bool shutdown);
+    
+    /** 
+     * Address book entry changed.
+     * @note called with lock cs_wallet held.
+     */
+    boost::signals2::signal<void (CWallet *wallet, const CTxDestination
+            &address, const std::string &label, bool isMine,
+            const std::string &purpose,
+            ChangeType status)> NotifyAddressBookChanged;
+
+    /** 
+     * Wallet transaction added, removed or updated.
+     * @note called with lock cs_wallet held.
+     */
+    boost::signals2::signal<void (CWallet *wallet, const uint256 &hashTx,
+            ChangeType status)> NotifyTransactionChanged;
+
+    /** Show progress e.g. for rescan */
+    boost::signals2::signal<void (const std::string &title, int nProgress)> ShowProgress;
+
+    /** Watch-only address added */
+    boost::signals2::signal<void (bool fHaveWatchOnly)> NotifyWatchonlyChanged;
+};
+
+/** A key allocated from the key pool. */
+class CReserveKey
+{
+protected:
+    CWallet* pwallet;
+    int64_t nIndex;
+    CPubKey vchPubKey;
+public:
+    CReserveKey(CWallet* pwalletIn)
+    {
+        nIndex = -1;
+        pwallet = pwalletIn;
+    }
+
+    ~CReserveKey()
+    {
+        ReturnKey();
+    }
+
+    void ReturnKey();
+    bool GetReservedKey(CPubKey &pubkey);
+    void KeepKey();
+};
+
+
+typedef std::map<std::string, std::string> mapValue_t;
+
+
+static void ReadOrderPos(int64_t& nOrderPos, mapValue_t& mapValue)
+{
+    if (!mapValue.count("n"))
+    {
+        nOrderPos = -1; // TODO: calculate elsewhere
+        return;
+    }
+    nOrderPos = atoi64(mapValue["n"].c_str());
+}
+
+
+static void WriteOrderPos(const int64_t& nOrderPos, mapValue_t& mapValue)
+{
+    if (nOrderPos == -1)
+        return;
+    mapValue["n"] = i64tostr(nOrderPos);
+}
+
+struct COutputEntry
+{
+    CTxDestination destination;
+    CAmount amount;
+    int vout;
+};
+
+/** A transaction with a merkle branch linking it to the block chain. */
+class CMerkleTx : public CTransaction
+{
+private:
+    int GetDepthInMainChainINTERNAL(const CBlockIndex* &pindexRet) const;
+
+public:
+    uint256 hashBlock;
+    std::vector<uint256> vMerkleBranch;
+    int nIndex;
+
+    // memory only
+    mutable bool fMerkleVerified;
+
+
+    CMerkleTx()
+    {
+        Init();
+    }
+
+    CMerkleTx(const CTransaction& txIn) : CTransaction(txIn)
+    {
+        Init();
+    }
+
+    void Init()
+    {
+        hashBlock = uint256();
+        nIndex = -1;
+        fMerkleVerified = false;
+    }
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
+        READWRITE(*(CTransaction*)this);
+        nVersion = this->nVersion;
+        READWRITE(hashBlock);
+        READWRITE(vMerkleBranch);
+        READWRITE(nIndex);
+    }
+
+    int SetMerkleBranch(const CBlock& block);
+
+
+    /**
+     * Return depth of transaction in blockchain:
+     * -1  : not in blockchain, and not in memory pool (conflicted transaction)
+     *  0  : in memory pool, waiting to be included in a block
+     * >=1 : this many blocks deep in the main chain
+     */
+    int GetDepthInMainChain(const CBlockIndex* &pindexRet) const;
+    int GetDepthInMainChain() const { const CBlockIndex *pindexRet; return GetDepthInMainChain(pindexRet); }
+    bool IsInMainChain() const { const CBlockIndex *pindexRet; return GetDepthInMainChainINTERNAL(pindexRet) > 0; }
+    int GetBlocksToMaturity() const;
+    bool AcceptToMemoryPool(bool fLimitFree=true, bool fRejectInsaneFee=true);
+};
+
+/** 
+ * A transaction with a bunch of additional info that only the owner cares about.
+ * It includes any unrecorded transactions needed to link it back to the block chain.
+ */
+class CWalletTx : public CMerkleTx
+{
+private:
+    const CWallet* pwallet;
+
+public:
+    mapValue_t mapValue;
+    std::vector<std::pair<std::string, std::string> > vOrderForm;
+    unsigned int fTimeReceivedIsTxTime;
+    unsigned int nTimeReceived; //! time received by this node
+    unsigned int nTimeSmart;
+    char fFromMe;
+    std::string strFromAccount;
+    int64_t nOrderPos; //! position in ordered transaction list
+
+    // memory only
+    mutable bool fDebitCached;
+    mutable bool fCreditCached;
+    mutable bool fImmatureCreditCached;
+    mutable bool fAvailableCreditCached;
+    mutable bool fWatchDebitCached;
+    mutable bool fWatchCreditCached;
+    mutable bool fImmatureWatchCreditCached;
+    mutable bool fAvailableWatchCreditCached;
+    mutable bool fChangeCached;
+    mutable CAmount nDebitCached;
+    mutable CAmount nCreditCached;
+    mutable CAmount nImmatureCreditCached;
+    mutable CAmount nAvailableCreditCached;
+    mutable CAmount nWatchDebitCached;
+    mutable CAmount nWatchCreditCached;
+    mutable CAmount nImmatureWatchCreditCached;
+    mutable CAmount nAvailableWatchCreditCached;
+    mutable CAmount nChangeCached;
+
+    CWalletTx()
+    {
+        Init(NULL);
+    }
+
+    CWalletTx(const CWallet* pwalletIn)
+    {
+        Init(pwalletIn);
+    }
+
+    CWalletTx(const CWallet* pwalletIn, const CMerkleTx& txIn) : CMerkleTx(txIn)
+    {
+        Init(pwalletIn);
+    }
+
+    CWalletTx(const CWallet* pwalletIn, const CTransaction& txIn) : CMerkleTx(txIn)
+    {
+        Init(pwalletIn);
+    }
+
+    void Init(const CWallet* pwalletIn)
+    {
+        pwallet = pwalletIn;
+        mapValue.clear();
+        vOrderForm.clear();
+        fTimeReceivedIsTxTime = false;
+        nTimeReceived = 0;
+        nTimeSmart = 0;
+        fFromMe = false;
+        strFromAccount.clear();
+        fDebitCached = false;
+        fCreditCached = false;
+        fImmatureCreditCached = false;
+        fAvailableCreditCached = false;
+        fWatchDebitCached = false;
+        fWatchCreditCached = false;
+        fImmatureWatchCreditCached = false;
+        fAvailableWatchCreditCached = false;
+        fChangeCached = false;
+        nDebitCached = 0;
+        nCreditCached = 0;
+        nImmatureCreditCached = 0;
+        nAvailableCreditCached = 0;
+        nWatchDebitCached = 0;
+        nWatchCreditCached = 0;
+        nAvailableWatchCreditCached = 0;
+        nImmatureWatchCreditCached = 0;
+        nChangeCached = 0;
+        nOrderPos = -1;
+    }
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
+        if (ser_action.ForRead())
+            Init(NULL);
+        char fSpent = false;
+
+        if (!ser_action.ForRead())
+        {
+            mapValue["fromaccount"] = strFromAccount;
+
+            WriteOrderPos(nOrderPos, mapValue);
+
+            if (nTimeSmart)
+                mapValue["timesmart"] = strprintf("%u", nTimeSmart);
+        }
+
+    static CFeeRate minTxFee;
+    static CAmount GetMinimumFee(unsigned int nTxBytes, unsigned int nConfirmTarget, const CTxMemPool& pool);
+
+    bool NewKeyPool();
+    bool TopUpKeyPool(unsigned int kpSize = 0);
+    void ReserveKeyFromKeyPool(int64_t& nIndex, CKeyPool& keypool);
+    void KeepKey(int64_t nIndex);
+    void ReturnKey(int64_t nIndex);
+    bool GetKeyFromPool(CPubKey &key);
+    int64_t GetOldestKeyPoolTime();
+    void GetAllReserveKeys(std::set<CKeyID>& setAddress) const;
+
+    std::set< std::set<CTxDestination> > GetAddressGroupings();
+    std::map<CTxDestination, CAmount> GetAddressBalances();
+
+    std::set<CTxDestination> GetAccountAddresses(std::string strAccount) const;
+
+    isminetype IsMine(const CTxIn& txin) const;
+    CAmount GetDebit(const CTxIn& txin, const isminefilter& filter) const;
+    isminetype IsMine(const CTxOut& txout) const
+    {
+        return ::IsMine(*this, txout.scriptPubKey);
+    }
+    CAmount GetCredit(const CTxOut& txout, const isminefilter& filter) const
+    {
+        if (!MoneyRange(txout.nValue))
             throw std::runtime_error("CWallet::GetCredit(): value out of range");
         return ((IsMine(txout) & filter) ? txout.nValue : 0);
     }

--- a/src/walletdb.cpp
+++ b/src/walletdb.cpp
@@ -28,7 +28,6 @@ static uint64_t nAccountingEntryNumber = 0;
 
 bool CWalletDB::WriteName(const string& strAddress, const string& strName)
 {
-    nWalletDBUpdated++;
     return Write(make_pair(string("name"), strAddress), strName);
 }
 
@@ -36,38 +35,31 @@ bool CWalletDB::EraseName(const string& strAddress)
 {
     // This should only be used for sending addresses, never for receiving addresses,
     // receiving addresses must always have an address book entry if they're not change return.
-    nWalletDBUpdated++;
     return Erase(make_pair(string("name"), strAddress));
 }
 
 bool CWalletDB::WritePurpose(const string& strAddress, const string& strPurpose)
 {
-    nWalletDBUpdated++;
     return Write(make_pair(string("purpose"), strAddress), strPurpose);
 }
 
 bool CWalletDB::ErasePurpose(const string& strPurpose)
 {
-    nWalletDBUpdated++;
     return Erase(make_pair(string("purpose"), strPurpose));
 }
 
 bool CWalletDB::WriteTx(uint256 hash, const CWalletTx& wtx)
 {
-    nWalletDBUpdated++;
     return Write(std::make_pair(std::string("tx"), hash), wtx);
 }
 
 bool CWalletDB::EraseTx(uint256 hash)
 {
-    nWalletDBUpdated++;
     return Erase(std::make_pair(std::string("tx"), hash));
 }
 
 bool CWalletDB::WriteKey(const CPubKey& vchPubKey, const CPrivKey& vchPrivKey, const CKeyMetadata& keyMeta)
 {
-    nWalletDBUpdated++;
-
     if (!Write(std::make_pair(std::string("keymeta"), vchPubKey),
                keyMeta, false))
         return false;
@@ -86,7 +78,6 @@ bool CWalletDB::WriteCryptedKey(const CPubKey& vchPubKey,
                                 const CKeyMetadata &keyMeta)
 {
     const bool fEraseUnencryptedKey = true;
-    nWalletDBUpdated++;
 
     if (!Write(std::make_pair(std::string("keymeta"), vchPubKey),
             keyMeta))
@@ -104,31 +95,26 @@ bool CWalletDB::WriteCryptedKey(const CPubKey& vchPubKey,
 
 bool CWalletDB::WriteMasterKey(unsigned int nID, const CMasterKey& kMasterKey)
 {
-    nWalletDBUpdated++;
     return Write(std::make_pair(std::string("mkey"), nID), kMasterKey, true);
 }
 
 bool CWalletDB::WriteCScript(const uint160& hash, const CScript& redeemScript)
 {
-    nWalletDBUpdated++;
     return Write(std::make_pair(std::string("cscript"), hash), redeemScript, false);
 }
 
 bool CWalletDB::WriteWatchOnly(const CScript &dest)
 {
-    nWalletDBUpdated++;
     return Write(std::make_pair(std::string("watchs"), dest), '1');
 }
 
 bool CWalletDB::EraseWatchOnly(const CScript &dest)
 {
-    nWalletDBUpdated++;
     return Erase(std::make_pair(std::string("watchs"), dest));
 }
 
 bool CWalletDB::WriteBestBlock(const CBlockLocator& locator)
 {
-    nWalletDBUpdated++;
     return Write(std::string("bestblock"), locator);
 }
 
@@ -139,13 +125,11 @@ bool CWalletDB::ReadBestBlock(CBlockLocator& locator)
 
 bool CWalletDB::WriteOrderPosNext(int64_t nOrderPosNext)
 {
-    nWalletDBUpdated++;
     return Write(std::string("orderposnext"), nOrderPosNext);
 }
 
 bool CWalletDB::WriteDefaultKey(const CPubKey& vchPubKey)
 {
-    nWalletDBUpdated++;
     return Write(std::string("defaultkey"), vchPubKey);
 }
 
@@ -156,13 +140,11 @@ bool CWalletDB::ReadPool(int64_t nPool, CKeyPool& keypool)
 
 bool CWalletDB::WritePool(int64_t nPool, const CKeyPool& keypool)
 {
-    nWalletDBUpdated++;
     return Write(std::make_pair(std::string("pool"), nPool), keypool);
 }
 
 bool CWalletDB::ErasePool(int64_t nPool)
 {
-    nWalletDBUpdated++;
     return Erase(std::make_pair(std::string("pool"), nPool));
 }
 
@@ -192,61 +174,31 @@ bool CWalletDB::WriteAccountingEntry(const CAccountingEntry& acentry)
     return WriteAccountingEntry(++nAccountingEntryNumber, acentry);
 }
 
-CAmount CWalletDB::GetAccountCreditDebit(const string& strAccount)
-{
-    list<CAccountingEntry> entries;
-    ListAccountCreditDebit(strAccount, entries);
-
-    CAmount nCreditDebit = 0;
-    BOOST_FOREACH (const CAccountingEntry& entry, entries)
-        nCreditDebit += entry.nCreditDebit;
-
-    return nCreditDebit;
-}
-
 void CWalletDB::ListAccountCreditDebit(const string& strAccount, list<CAccountingEntry>& entries)
 {
-    /*
     bool fAllAccounts = (strAccount == "*");
 
-    Dbc* pcursor = GetCursor();
-    if (!pcursor)
-        throw runtime_error("CWalletDB::ListAccountCreditDebit(): cannot create DB cursor");
-    unsigned int fFlags = DB_SET_RANGE;
-    while (true)
+    for (CWalletDB::const_iterator it = begin(); it != end(); it++)
     {
         // Read next record
-        CDataStream ssKey(SER_DISK, CLIENT_VERSION);
-        if (fFlags == DB_SET_RANGE)
-            ssKey << std::make_pair(std::string("acentry"), std::make_pair((fAllAccounts ? string("") : strAccount), uint64_t(0)));
-        CDataStream ssValue(SER_DISK, CLIENT_VERSION);
-        int ret = ReadAtCursor(pcursor, ssKey, ssValue, fFlags);
-        fFlags = DB_NEXT;
-        if (ret == DB_NOTFOUND)
-            break;
-        else if (ret != 0)
-        {
-            pcursor->close();
-            throw runtime_error("CWalletDB::ListAccountCreditDebit(): error scanning DB");
-        }
+        CDataStream ssKey((*it).first, SER_DISK, CLIENT_VERSION);
+        CDataStream ssValue((*it).second, SER_DISK, CLIENT_VERSION);
 
         // Unserialize
         string strType;
         ssKey >> strType;
         if (strType != "acentry")
-            break;
+            continue;
+        
         CAccountingEntry acentry;
         ssKey >> acentry.strAccount;
         if (!fAllAccounts && acentry.strAccount != strAccount)
-            break;
+            continue;
 
         ssValue >> acentry;
         ssKey >> acentry.nEntryNo;
         entries.push_back(acentry);
     }
-
-    pcursor->close();
-     */
 }
 
 DBErrors CWalletDB::ReorderTransactions(CWallet* pwallet)
@@ -606,6 +558,9 @@ static bool IsKeyType(string strType)
 
 DBErrors CWalletDB::LoadWallet(CWallet* pwallet)
 {
+    if(!Load())
+        return DB_CORRUPT;
+    
     pwallet->vchDefaultKey = CPubKey();
     CWalletScanState wss;
     bool fNoncriticalErrors = false;
@@ -735,21 +690,21 @@ DBErrors CWalletDB::FindWalletTx(CWallet* pwallet, vector<uint256>& vTxHash, vec
     return result;
 }
 
-DBErrors CWalletDB::ZapWalletTx(CWallet* pwallet, vector<CWalletTx>& vWtx)
+bool CWalletDB::ZapWalletTx(CWallet* pwallet, vector<CWalletTx>& vWtx)
 {
     // build list of wallet TXs
     vector<uint256> vTxHash;
     DBErrors err = FindWalletTx(pwallet, vTxHash, vWtx);
     if (err != DB_LOAD_OK)
-        return err;
+        return false;
 
     // erase each wallet TX
     BOOST_FOREACH (uint256& hash, vTxHash) {
         if (!EraseTx(hash))
-            return DB_CORRUPT;
+            return false;
     }
 
-    return DB_LOAD_OK;
+    return true;
 }
 
 DBErrors CWalletDB::Rewrite()
@@ -759,68 +714,6 @@ DBErrors CWalletDB::Rewrite()
     //Flush_() needs to be rewritten
     
     return DB_LOAD_OK;
-}
-
-void ThreadFlushWalletDB(const string& strFile)
-{
-//    // Make this thread recognisable as the wallet flushing thread
-//    RenameThread("bitcoin-wallet");
-//
-//    static bool fOneThread;
-//    if (fOneThread)
-//        return;
-//    fOneThread = true;
-//    if (!GetBoolArg("-flushwallet", true))
-//        return;
-//
-//    unsigned int nLastSeen = nWalletDBUpdated;
-//    unsigned int nLastFlushed = nWalletDBUpdated;
-//    int64_t nLastWalletUpdate = GetTime();
-//    while (true)
-//    {
-//        MilliSleep(500);
-//
-//        if (nLastSeen != nWalletDBUpdated)
-//        {
-//            nLastSeen = nWalletDBUpdated;
-//            nLastWalletUpdate = GetTime();
-//        }
-//
-//        if (nLastFlushed != nWalletDBUpdated && GetTime() - nLastWalletUpdate >= 2)
-//        {
-//            TRY_LOCK(bitdb.cs_db,lockDb);
-//            if (lockDb)
-//            {
-//                // Don't do this if any databases are in use
-//                int nRefCount = 0;
-//                map<string, int>::iterator mi = bitdb.mapFileUseCount.begin();
-//                while (mi != bitdb.mapFileUseCount.end())
-//                {
-//                    nRefCount += (*mi).second;
-//                    mi++;
-//                }
-//
-//                if (nRefCount == 0)
-//                {
-//                    boost::this_thread::interruption_point();
-//                    map<string, int>::iterator mi = bitdb.mapFileUseCount.find(strFile);
-//                    if (mi != bitdb.mapFileUseCount.end())
-//                    {
-//                        LogPrint("db", "Flushing wallet.dat\n");
-//                        nLastFlushed = nWalletDBUpdated;
-//                        int64_t nStart = GetTimeMillis();
-//
-//                        // Flush wallet.dat so it's self contained
-//                        bitdb.CloseDb(strFile);
-//                        bitdb.CheckpointLSN(strFile);
-//
-//                        bitdb.mapFileUseCount.erase(mi++);
-//                        LogPrint("db", "Flushed wallet.dat %dms\n", GetTimeMillis() - nStart);
-//                    }
-//                }
-//            }
-//        }
-//    }
 }
 
 bool BackupWallet(const CWallet& wallet, const string& strDest)
@@ -870,146 +763,28 @@ bool BackupWallet(const CWallet& wallet, const string& strDest)
 //
 bool CWalletDB::Recover(std::string filename, bool fOnlyKeys)
 {
-    /*
-    // Recovery procedure:
-    // move wallet.dat to wallet.timestamp.bak
-    // Call Salvage with fAggressive=true to
-    // get as much data as possible.
-    // Rewrite salvaged data to wallet.dat
-    // Set -rescan so any missing transactions will be
-    // found.
-    int64_t now = GetTime();
-    std::string newFilename = strprintf("wallet.%d.bak", now);
-
-    int result = dbenv.dbenv.dbrename(NULL, filename.c_str(), NULL,
-                                      newFilename.c_str(), DB_AUTO_COMMIT);
-    if (result == 0)
-        LogPrintf("Renamed %s to %s\n", filename, newFilename);
-    else
-    {
-        LogPrintf("Failed to rename %s to %s\n", filename, newFilename);
-        return false;
-    }
-
-    std::vector<CDBEnv::KeyValPair> salvagedData;
-    bool allOK = dbenv.Salvage(newFilename, true, salvagedData);
-    if (salvagedData.empty())
-    {
-        LogPrintf("Salvage(aggressive) found no records in %s.\n", newFilename);
-        return false;
-    }
-    LogPrintf("Salvage(aggressive) found %u records\n", salvagedData.size());
-
-    bool fSuccess = allOK;
-    boost::scoped_ptr<Db> pdbCopy(new Db(&dbenv.dbenv, 0));
-    int ret = pdbCopy->open(NULL,               // Txn pointer
-                            filename.c_str(),   // Filename
-                            "main",             // Logical db name
-                            DB_BTREE,           // Database type
-                            DB_CREATE,          // Flags
-                            0);
-    if (ret > 0)
-    {
-        LogPrintf("Cannot create database file %s\n", filename);
-        return false;
-    }
-    CWallet dummyWallet;
-    CWalletScanState wss;
-
-    DbTxn* ptxn = dbenv.TxnBegin();
-    BOOST_FOREACH(CDBEnv::KeyValPair& row, salvagedData)
-    {
-        if (fOnlyKeys)
-        {
-            CDataStream ssKey(row.first, SER_DISK, CLIENT_VERSION);
-            CDataStream ssValue(row.second, SER_DISK, CLIENT_VERSION);
-            string strType, strErr;
-            bool fReadOK = ReadKeyValue(&dummyWallet, ssKey, ssValue,
-                                        wss, strType, strErr);
-            if (!IsKeyType(strType))
-                continue;
-            if (!fReadOK)
-            {
-                LogPrintf("WARNING: CWalletDB::Recover skipping %s: %s\n", strType, strErr);
-                continue;
-            }
-        }
-        Dbt datKey(&row.first[0], row.first.size());
-        Dbt datValue(&row.second[0], row.second.size());
-        int ret2 = pdbCopy->put(ptxn, &datKey, &datValue, DB_NOOVERWRITE);
-        if (ret2 > 0)
-            fSuccess = false;
-    }
-    ptxn->commit(0);
-    pdbCopy->close(0);
-
-    return fSuccess;
-     */
+    //TODO
     return false;
 }
 
 bool CWalletDB::Recover(std::string filename)
 {
+    //TODO
     return CWalletDB::Recover(filename, false);
 }
 
 bool CWalletDB::Verify(std::string filename, bool salvage)
 {
-    //TODO: implement
-    
-    //        if (!bitdb.Open(GetDataDir()))
-    //        {
-    //            // try moving the database env out of the way
-    //            boost::filesystem::path pathDatabase = GetDataDir() / "database";
-    //            boost::filesystem::path pathDatabaseBak = GetDataDir() / strprintf("database.%d.bak", GetTime());
-    //            try {
-    //                boost::filesystem::rename(pathDatabase, pathDatabaseBak);
-    //                LogPrintf("Moved old %s to %s. Retrying.\n", pathDatabase.string(), pathDatabaseBak.string());
-    //            } catch (const boost::filesystem::filesystem_error&) {
-    //                 // failure is ok (well, not really, but it's not worse than what we started with)
-    //            }
-    //
-    //            // try again
-    //            if (!bitdb.Open(GetDataDir())) {
-    //                // if it still fails, it probably means we can't even create the database env
-    //                string msg = strprintf(_("Error initializing wallet database environment %s!"), strDataDir);
-    //                return InitError(msg);
-    //            }
-    //        }
-    //
-    //        if (GetBoolArg("-salvagewallet", false))
-    //        {
-    //            // Recover readable keypairs:
-    //            if (!CWalletDB::Recover(strWalletFile, true))
-    //                return false;
-    //        }
-    //
-    //        if (filesystem::exists(GetDataDir() / strWalletFile))
-    //        {
-    //            CDBEnv::VerifyResult r = bitdb.Verify(strWalletFile, CWalletDB::Recover);
-    //            if (r == CDBEnv::RECOVER_OK)
-    //            {
-    //                string msg = strprintf(_("Warning: wallet.dat corrupt, data salvaged!"
-    //                                         " Original wallet.dat saved as wallet.{timestamp}.bak in %s; if"
-    //                                         " your balance or transactions are incorrect you should"
-    //                                         " restore from a backup."), strDataDir);
-    //                InitWarning(msg);
-    //            }
-    //            if (r == CDBEnv::RECOVER_FAIL)
-    //                return InitError(_("wallet.dat corrupt, salvage failed"));
-    //        }
-    
-    return true;
+    //TODO
+    return false;
 }
 
 bool CWalletDB::WriteDestData(const std::string &address, const std::string &key, const std::string &value)
 {
-    nWalletDBUpdated++;
     return Write(std::make_pair(std::string("destdata"), std::make_pair(address, key)), value);
 }
 
 bool CWalletDB::EraseDestData(const std::string &address, const std::string &key)
 {
-    nWalletDBUpdated++;
     return Erase(std::make_pair(std::string("destdata"), std::make_pair(address, key)));
 }

--- a/src/walletdb.cpp
+++ b/src/walletdb.cpp
@@ -148,11 +148,6 @@ bool CWalletDB::ErasePool(int64_t nPool)
     return Erase(std::make_pair(std::string("pool"), nPool));
 }
 
-bool CWalletDB::WriteMinVersion(int nVersion)
-{
-    return Write(std::string("minversion"), nVersion);
-}
-
 bool CWalletDB::ReadAccount(const string& strAccount, CAccount& account)
 {
     account.SetNull();
@@ -570,14 +565,6 @@ DBErrors CWalletDB::LoadWallet(CWallet* pwallet)
     
     try {
         LOCK(pwallet->cs_wallet);
-        int nMinVersion = 0;
-        if (Read((string)"minversion", nMinVersion))
-        {
-            if (nMinVersion > CLIENT_VERSION)
-                return DB_TOO_NEW;
-            pwallet->LoadMinVersion(nMinVersion);
-        }
-
         for (CWalletDB::const_iterator it = begin(); it != end(); it++)
         {
             // Read next record
@@ -649,14 +636,6 @@ DBErrors CWalletDB::FindWalletTx(CWallet* pwallet, vector<uint256>& vTxHash, vec
 
     try {
         LOCK(pwallet->cs_wallet);
-        int nMinVersion = 0;
-        if (Read((string)"minversion", nMinVersion))
-        {
-            if (nMinVersion > CLIENT_VERSION)
-                return DB_TOO_NEW;
-            pwallet->LoadMinVersion(nMinVersion);
-        }
-
         for (CWalletDB::const_iterator it = begin(); it != end(); it++)
         {
             // Read next record
@@ -733,48 +712,6 @@ DBErrors CWalletDB::RewriteAndReplace(const string& walletFile)
     }
     
     return DB_LOAD_OK;
-}
-
-bool BackupWallet(const CWallet& wallet, const string& strDest)
-{
-    /*
-    if (!wallet.fFileBacked)
-        return false;
-    while (true)
-    {
-        {
-            LOCK(bitdb.cs_db);
-            if (!bitdb.mapFileUseCount.count(wallet.strWalletFile) || bitdb.mapFileUseCount[wallet.strWalletFile] == 0)
-            {
-                // Flush log data to the dat file
-                bitdb.CloseDb(wallet.strWalletFile);
-                bitdb.CheckpointLSN(wallet.strWalletFile);
-                bitdb.mapFileUseCount.erase(wallet.strWalletFile);
-
-                // Copy wallet.dat
-                boost::filesystem::path pathSrc = GetDataDir() / wallet.strWalletFile;
-                boost::filesystem::path pathDest(strDest);
-                if (boost::filesystem::is_directory(pathDest))
-                    pathDest /= wallet.strWalletFile;
-
-                try {
-#if BOOST_VERSION >= 104000
-                    boost::filesystem::copy_file(pathSrc, pathDest, boost::filesystem::copy_option::overwrite_if_exists);
-#else
-                    boost::filesystem::copy_file(pathSrc, pathDest);
-#endif
-                    LogPrintf("copied wallet.dat to %s\n", pathDest.string());
-                    return true;
-                } catch (const boost::filesystem::filesystem_error& e) {
-                    LogPrintf("error copying wallet.dat to %s - %s\n", pathDest.string(), e.what());
-                    return false;
-                }
-            }
-        }
-        MilliSleep(100);
-    }
-     */
-    return false;
 }
 
 //

--- a/src/walletdb.cpp
+++ b/src/walletdb.cpp
@@ -752,6 +752,15 @@ DBErrors CWalletDB::ZapWalletTx(CWallet* pwallet, vector<CWalletTx>& vWtx)
     return DB_LOAD_OK;
 }
 
+DBErrors CWalletDB::Rewrite()
+{
+    //TODO: implement
+    //Here we need a way of write down the whole mapData to a new file
+    //Flush_() needs to be rewritten
+    
+    return DB_LOAD_OK;
+}
+
 void ThreadFlushWalletDB(const string& strFile)
 {
 //    // Make this thread recognisable as the wallet flushing thread

--- a/src/walletdb.h
+++ b/src/walletdb.h
@@ -121,13 +121,12 @@ public:
     bool EraseDestData(const std::string &address, const std::string &key);
 
     bool WriteAccountingEntry(const CAccountingEntry& acentry);
-    CAmount GetAccountCreditDebit(const std::string& strAccount);
     void ListAccountCreditDebit(const std::string& strAccount, std::list<CAccountingEntry>& acentries);
 
     DBErrors ReorderTransactions(CWallet* pwallet);
     DBErrors LoadWallet(CWallet* pwallet);
     DBErrors FindWalletTx(CWallet* pwallet, std::vector<uint256>& vTxHash, std::vector<CWalletTx>& vWtx);
-    DBErrors ZapWalletTx(CWallet* pwallet, std::vector<CWalletTx>& vWtx);
+    bool ZapWalletTx(CWallet* pwallet, std::vector<CWalletTx>& vWtx);
     
     DBErrors Rewrite();
     
@@ -144,6 +143,5 @@ private:
 };
 
 bool BackupWallet(const CWallet& wallet, const std::string& strDest);
-void ThreadFlushWalletDB(const std::string& strWalletFile);
 
 #endif // BITCOIN_WALLETDB_H

--- a/src/walletdb.h
+++ b/src/walletdb.h
@@ -7,9 +7,10 @@
 #define BITCOIN_WALLETDB_H
 
 #include "amount.h"
-#include "db.h"
 #include "key.h"
 #include "keystore.h"
+#include "logdb.h"
+#include "util.h"
 
 #include <list>
 #include <stdint.h>
@@ -72,11 +73,11 @@ public:
     }
 };
 
-/** Access to the wallet database (wallet.dat) */
-class CWalletDB : public CDB
+/** Access to the wallet database */
+class CWalletDB : public CLogDB
 {
 public:
-    CWalletDB(const std::string& strFilename, const char* pszMode = "r+", bool fFlushOnClose = true) : CDB(strFilename, pszMode, fFlushOnClose)
+    CWalletDB(const std::string& strFilename, const char* pszMode = "r+", bool fFlushOnClose = true) : CLogDB( (GetDataDir() / strFilename).string(), (!strchr(pszMode, '+') && !strchr(pszMode, 'w')))
     {
     }
 
@@ -127,8 +128,10 @@ public:
     DBErrors LoadWallet(CWallet* pwallet);
     DBErrors FindWalletTx(CWallet* pwallet, std::vector<uint256>& vTxHash, std::vector<CWalletTx>& vWtx);
     DBErrors ZapWalletTx(CWallet* pwallet, std::vector<CWalletTx>& vWtx);
-    static bool Recover(CDBEnv& dbenv, std::string filename, bool fOnlyKeys);
-    static bool Recover(CDBEnv& dbenv, std::string filename);
+    static bool Recover(std::string filename, bool fOnlyKeys);
+    static bool Recover(std::string filename);
+    
+    static bool Verify(std::string filename, bool salvage);
 
 private:
     CWalletDB(const CWalletDB&);
@@ -138,5 +141,6 @@ private:
 };
 
 bool BackupWallet(const CWallet& wallet, const std::string& strDest);
+void ThreadFlushWalletDB(const std::string& strWalletFile);
 
 #endif // BITCOIN_WALLETDB_H

--- a/src/walletdb.h
+++ b/src/walletdb.h
@@ -128,7 +128,7 @@ public:
     DBErrors FindWalletTx(CWallet* pwallet, std::vector<uint256>& vTxHash, std::vector<CWalletTx>& vWtx);
     bool ZapWalletTx(CWallet* pwallet, std::vector<CWalletTx>& vWtx);
     
-    DBErrors Rewrite();
+    DBErrors RewriteAndReplace(const std::string& walletFile); //rewrites and compacts database, will replace existing wallet file
     
     static bool Recover(std::string filename, bool fOnlyKeys);
     static bool Recover(std::string filename);

--- a/src/walletdb.h
+++ b/src/walletdb.h
@@ -110,8 +110,6 @@ public:
     bool WritePool(int64_t nPool, const CKeyPool& keypool);
     bool ErasePool(int64_t nPool);
 
-    bool WriteMinVersion(int nVersion);
-
     bool ReadAccount(const std::string& strAccount, CAccount& account);
     bool WriteAccount(const std::string& strAccount, const CAccount& account);
 
@@ -141,7 +139,5 @@ private:
 
     bool WriteAccountingEntry(const uint64_t nAccEntryNum, const CAccountingEntry& acentry);
 };
-
-bool BackupWallet(const CWallet& wallet, const std::string& strDest);
 
 #endif // BITCOIN_WALLETDB_H

--- a/src/walletdb.h
+++ b/src/walletdb.h
@@ -128,11 +128,14 @@ public:
     DBErrors LoadWallet(CWallet* pwallet);
     DBErrors FindWalletTx(CWallet* pwallet, std::vector<uint256>& vTxHash, std::vector<CWalletTx>& vWtx);
     DBErrors ZapWalletTx(CWallet* pwallet, std::vector<CWalletTx>& vWtx);
+    
+    DBErrors Rewrite();
+    
     static bool Recover(std::string filename, bool fOnlyKeys);
     static bool Recover(std::string filename);
     
     static bool Verify(std::string filename, bool salvage);
-
+    
 private:
     CWalletDB(const CWalletDB&);
     void operator=(const CWalletDB&);


### PR DESCRIPTION
This pull request is in early stage but discussions could help driving this into the right direction.

It will basically remove bdb (currently not on compile level) and make use of a internal key/value store.
Logdb (the internal key/value store) is a append only store where every key/value-frame contains a sha256 checksum all available frames. Consistency is guaranteed.

The current implementation passes all tests but has lack of recover/rewrite possibilities.
### Why this
- IMO BerkleyDB is oversized for a "reference wallet implementation". This append-only file-store could prevent from corruptions and relieves compile stress.
- wallet flush threads are no longer required.
- remove another dependency and get more control over our stack
### What's next / ToDos
- ~~add compact `Rewrite()` function (save whole memory map atomically to a clean file): this is required after encrypting the wallet~~ (added 2015/01/22)
- add thread safe / concurrency tests for logdb
- add `Recover()` function: scan through a corrupt wallet file and try to recover keys even when some key/value-frames and/or checksums are corrupted
- add more tests
-   add wallet encryption test 

---

This is on my internal roadmap:
- > remove bdb
- transform account to labels
- implement bip32
- add spv mode
