### PR TITLE
openssl: abstract out OPENSSL_cleanse

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -123,6 +123,7 @@ BITCOIN_CORE_H = \
   script/standard.h \
   serialize.h \
   streams.h \
+  support/cleanse.h \
   sync.h \
   threadsafety.h \
   timedata.h \
@@ -268,6 +269,7 @@ libbitcoin_util_a_SOURCES = \
   compat/strnlen.cpp \
   random.cpp \
   rpcprotocol.cpp \
+  support/cleanse.cpp \
   sync.cpp \
   uint256.cpp \
   util.cpp \

--- a/src/allocators.h
+++ b/src/allocators.h
@@ -6,6 +6,8 @@
 #ifndef BITCOIN_ALLOCATORS_H
 #define BITCOIN_ALLOCATORS_H
 
+#include "support/cleanse.h"
+
 #include <map>
 #include <string>
 #include <string.h>
@@ -13,8 +15,6 @@
 
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/once.hpp>
-
-#include <openssl/crypto.h> // for OPENSSL_cleanse()
 
 /**
  * Thread-safe class to keep track of locked (ie, non-swappable) memory pages.
@@ -174,7 +174,7 @@ void LockObject(const T& t)
 template <typename T>
 void UnlockObject(const T& t)
 {
-    OPENSSL_cleanse((void*)(&t), sizeof(T));
+    memory_cleanse((void*)(&t), sizeof(T));
     LockedPageManager::Instance().UnlockRange((void*)(&t), sizeof(T));
 }
 
@@ -217,7 +217,7 @@ struct secure_allocator : public std::allocator<T> {
     void deallocate(T* p, std::size_t n)
     {
         if (p != NULL) {
-            OPENSSL_cleanse(p, sizeof(T) * n);
+            memory_cleanse(p, sizeof(T) * n);
             LockedPageManager::Instance().UnlockRange(p, sizeof(T) * n);
         }
         std::allocator<T>::deallocate(p, n);
@@ -254,7 +254,7 @@ struct zero_after_free_allocator : public std::allocator<T> {
     void deallocate(T* p, std::size_t n)
     {
         if (p != NULL)
-            OPENSSL_cleanse(p, sizeof(T) * n);
+            memory_cleanse(p, sizeof(T) * n);
         std::allocator<T>::deallocate(p, n);
     }
 };

--- a/src/base58.cpp
+++ b/src/base58.cpp
@@ -172,7 +172,7 @@ bool CBase58Data::SetString(const char* psz, unsigned int nVersionBytes)
     vchData.resize(vchTemp.size() - nVersionBytes);
     if (!vchData.empty())
         memcpy(&vchData[0], &vchTemp[nVersionBytes], vchData.size());
-    OPENSSL_cleanse(&vchTemp[0], vchData.size());
+    memory_cleanse(&vchTemp[0], vchData.size());
     return true;
 }
 

--- a/src/crypter.cpp
+++ b/src/crypter.cpp
@@ -26,8 +26,8 @@ bool CCrypter::SetKeyFromPassphrase(const SecureString& strKeyData, const std::v
 
     if (i != (int)WALLET_CRYPTO_KEY_SIZE)
     {
-        OPENSSL_cleanse(chKey, sizeof(chKey));
-        OPENSSL_cleanse(chIV, sizeof(chIV));
+        memory_cleanse(chKey, sizeof(chKey));
+        memory_cleanse(chIV, sizeof(chIV));
         return false;
     }
 

--- a/src/crypter.h
+++ b/src/crypter.h
@@ -82,8 +82,8 @@ public:
 
     void CleanKey()
     {
-        OPENSSL_cleanse(chKey, sizeof(chKey));
-        OPENSSL_cleanse(chIV, sizeof(chIV));
+        memory_cleanse(chKey, sizeof(chKey));
+        memory_cleanse(chIV, sizeof(chIV));
         fKeySet = false;
     }
 

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -21,8 +21,6 @@
 #include <boost/thread.hpp>
 #include <boost/version.hpp>
 
-#include <openssl/rand.h>
-
 using namespace std;
 
 

--- a/src/qt/paymentrequestplus.cpp
+++ b/src/qt/paymentrequestplus.cpp
@@ -13,7 +13,6 @@
 
 #include <stdexcept>
 
-#include <openssl/x509.h>
 #include <openssl/x509_vfy.h>
 
 #include <QDateTime>

--- a/src/qt/paymentrequestplus.h
+++ b/src/qt/paymentrequestplus.h
@@ -9,6 +9,8 @@
 
 #include "base58.h"
 
+#include <openssl/x509.h>
+
 #include <QByteArray>
 #include <QList>
 #include <QString>

--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -16,7 +16,6 @@
 
 #include <cstdlib>
 
-#include <openssl/x509.h>
 #include <openssl/x509_vfy.h>
 
 #include <QApplication>

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -5,6 +5,7 @@
 
 #include "random.h"
 
+#include "support/cleanse.h"
 #ifdef WIN32
 #include "compat.h" // for Windows API
 #endif
@@ -18,7 +19,6 @@
 #include <sys/time.h>
 #endif
 
-#include <openssl/crypto.h>
 #include <openssl/err.h>
 #include <openssl/rand.h>
 
@@ -40,7 +40,7 @@ void RandAddSeed()
     // Seed with CPU performance counter
     int64_t nCounter = GetPerformanceCounter();
     RAND_add(&nCounter, sizeof(nCounter), 1.5);
-    OPENSSL_cleanse((void*)&nCounter, sizeof(nCounter));
+    memory_cleanse((void*)&nCounter, sizeof(nCounter));
 }
 
 void RandAddSeedPerfmon()
@@ -70,7 +70,7 @@ void RandAddSeedPerfmon()
     RegCloseKey(HKEY_PERFORMANCE_DATA);
     if (ret == ERROR_SUCCESS) {
         RAND_add(begin_ptr(vData), nSize, nSize / 100.0);
-        OPENSSL_cleanse(begin_ptr(vData), nSize);
+        memory_cleanse(begin_ptr(vData), nSize);
         LogPrint("rand", "%s: %lu bytes\n", __func__, nSize);
     } else {
         static bool warned = false; // Warn only once

--- a/src/streams.h
+++ b/src/streams.h
@@ -16,6 +16,7 @@
 #include <map>
 #include <set>
 #include <stdint.h>
+#include <stdio.h>
 #include <string>
 #include <string.h>
 #include <utility>

--- a/src/support/cleanse.cpp
+++ b/src/support/cleanse.cpp
@@ -1,0 +1,13 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2015 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "cleanse.h"
+
+#include <openssl/crypto.h>
+
+void memory_cleanse(void *ptr, size_t len)
+{
+    OPENSSL_cleanse(ptr, len);
+}

--- a/src/support/cleanse.h
+++ b/src/support/cleanse.h
@@ -1,0 +1,13 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2015 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_SUPPORT_CLEANSE_H
+#define BITCOIN_SUPPORT_CLEANSE_H
+
+#include <stdlib.h>
+
+void memory_cleanse(void *ptr, size_t len);
+
+#endif // BITCOIN_SUPPORT_CLEANSE_H


### PR DESCRIPTION
This makes it easier for us to replace it if desired, since it's now only in one spot. Also, it avoids the openssl include from allocators.h, which essentially forced openssl to be included from every compilation unit.

Also a few minor header cleanups.

I'm not a big fan of putting a single function in this object, but we use it at such low levels (allocators.h) that i don't want to stick it somewhere that would pull in other headers. Suggestions welcome.
