### PR TITLE
TRIVIAL: fix link in qa/rpc-tests/README.md from util.sh -> util.py

### DIFF
--- a/qa/rpc-tests/README.md
+++ b/qa/rpc-tests/README.md
@@ -12,7 +12,7 @@ Base class for new regression tests.
 ### [listtransactions.py](listtransactions.py)
 Tests for the listtransactions RPC call.
 
-### [util.py](util.sh)
+### [util.py](util.py)
 Generally useful functions.
 
 Bash-based tests, to be ported to Python:


### PR DESCRIPTION
I just happened to notice that clicking on `util.py` in `README.md` takes you to `util.sh`. This fixes the link to take you to `util.py` instead.
