### PR TITLE
fix crash: CoinControl "space" bug

### DIFF
--- a/src/qt/coincontroltreewidget.cpp
+++ b/src/qt/coincontroltreewidget.cpp
@@ -17,7 +17,8 @@ void CoinControlTreeWidget::keyPressEvent(QKeyEvent *event)
     {
         event->ignore();
         int COLUMN_CHECKBOX = 0;
-        this->currentItem()->setCheckState(COLUMN_CHECKBOX, ((this->currentItem()->checkState(COLUMN_CHECKBOX) == Qt::Checked) ? Qt::Unchecked : Qt::Checked));
+        if(this->currentItem())
+            this->currentItem()->setCheckState(COLUMN_CHECKBOX, ((this->currentItem()->checkState(COLUMN_CHECKBOX) == Qt::Checked) ? Qt::Unchecked : Qt::Checked));
     }
     else if (event->key() == Qt::Key_Escape) // press esc -> close dialog
     {


### PR DESCRIPTION
Bug description:
1. Run Bitcoin-Qt
2. Open CoinControl
3. Click mouse here(Don't select any input) ![here](http://i60.tinypic.com/oabzux.jpg)
4. Press "space"
5. Result ![result](http://i60.tinypic.com/2m5yvqe.jpg)

Fix:
this->currentItem() returns the current item in the tree widget and NULL if no selected items.
So we don't try setCheckState for NULL.

As 
https://github.com/novacoin-project/novacoin/commit/baf80c26a2e7f1ba6061d63d174eff0a09111e6f
https://github.com/novacoin-project/novacoin/pull/120
