### PR TITLE
fix crash: RPC "createmultisig" and "addmultisigaddress"

### DIFF
--- a/src/rpcmisc.cpp
+++ b/src/rpcmisc.cpp
@@ -216,6 +216,8 @@ CScript _createmultisig_redeemScript(const Array& params)
         throw runtime_error(
             strprintf("not enough keys supplied "
                       "(got %u keys, but need at least %d to redeem)", keys.size(), nRequired));
+    if (keys.size() > 16)
+        throw runtime_error("Number of addresses involved in the multisignature address creation > 16\nReduce the number");
     std::vector<CPubKey> pubkeys;
     pubkeys.resize(keys.size());
     for (unsigned int i = 0; i < keys.size(); i++)


### PR DESCRIPTION
Bug description:
1) Open Bitcoin-Qt(or bitcoind)
2) Open "Debug window"
3) Enter 

```
createmultisig 17 '["0227d09df34a6eca0e2009663d2f0c6edc97314f78f308f53b7c8ffa7c552c1014","0227d09df34a6eca0e2009663d2f0c6edc97314f78f308f53b7c8ffa7c552c1014","0227d09df34a6eca0e2009663d2f0c6edc97314f78f308f53b7c8ffa7c552c1014","0227d09df34a6eca0e2009663d2f0c6edc97314f78f308f53b7c8ffa7c552c1014","0227d09df34a6eca0e2009663d2f0c6edc97314f78f308f53b7c8ffa7c552c1014","0227d09df34a6eca0e2009663d2f0c6edc97314f78f308f53b7c8ffa7c552c1014","0227d09df34a6eca0e2009663d2f0c6edc97314f78f308f53b7c8ffa7c552c1014","0227d09df34a6eca0e2009663d2f0c6edc97314f78f308f53b7c8ffa7c552c1014","0227d09df34a6eca0e2009663d2f0c6edc97314f78f308f53b7c8ffa7c552c1014","0227d09df34a6eca0e2009663d2f0c6edc97314f78f308f53b7c8ffa7c552c1014","0227d09df34a6eca0e2009663d2f0c6edc97314f78f308f53b7c8ffa7c552c1014","0227d09df34a6eca0e2009663d2f0c6edc97314f78f308f53b7c8ffa7c552c1014","0227d09df34a6eca0e2009663d2f0c6edc97314f78f308f53b7c8ffa7c552c1014","0227d09df34a6eca0e2009663d2f0c6edc97314f78f308f53b7c8ffa7c552c1014","0227d09df34a6eca0e2009663d2f0c6edc97314f78f308f53b7c8ffa7c552c1014","0227d09df34a6eca0e2009663d2f0c6edc97314f78f308f53b7c8ffa7c552c1014","0227d09df34a6eca0e2009663d2f0c6edc97314f78f308f53b7c8ffa7c552c1014"]'
```

or

```
addmultisigaddress 17 '["0227d09df34a6eca0e2009663d2f0c6edc97314f78f308f53b7c8ffa7c552c1014","0227d09df34a6eca0e2009663d2f0c6edc97314f78f308f53b7c8ffa7c552c1014","0227d09df34a6eca0e2009663d2f0c6edc97314f78f308f53b7c8ffa7c552c1014","0227d09df34a6eca0e2009663d2f0c6edc97314f78f308f53b7c8ffa7c552c1014","0227d09df34a6eca0e2009663d2f0c6edc97314f78f308f53b7c8ffa7c552c1014","0227d09df34a6eca0e2009663d2f0c6edc97314f78f308f53b7c8ffa7c552c1014","0227d09df34a6eca0e2009663d2f0c6edc97314f78f308f53b7c8ffa7c552c1014","0227d09df34a6eca0e2009663d2f0c6edc97314f78f308f53b7c8ffa7c552c1014","0227d09df34a6eca0e2009663d2f0c6edc97314f78f308f53b7c8ffa7c552c1014","0227d09df34a6eca0e2009663d2f0c6edc97314f78f308f53b7c8ffa7c552c1014","0227d09df34a6eca0e2009663d2f0c6edc97314f78f308f53b7c8ffa7c552c1014","0227d09df34a6eca0e2009663d2f0c6edc97314f78f308f53b7c8ffa7c552c1014","0227d09df34a6eca0e2009663d2f0c6edc97314f78f308f53b7c8ffa7c552c1014","0227d09df34a6eca0e2009663d2f0c6edc97314f78f308f53b7c8ffa7c552c1014","0227d09df34a6eca0e2009663d2f0c6edc97314f78f308f53b7c8ffa7c552c1014","0227d09df34a6eca0e2009663d2f0c6edc97314f78f308f53b7c8ffa7c552c1014","0227d09df34a6eca0e2009663d2f0c6edc97314f78f308f53b7c8ffa7c552c1014"]' "bug"
```

4) Result
![createmultisig](http://i62.tinypic.com/3312bup.jpg)
or
![addmultisigaddress](http://i61.tinypic.com/iojhq0.jpg)

About the fix:
1) function **_createmultisig_redeemScriptCScript** has line (file src/rpcmisc.cpp)

``` c
result = GetScriptForMultisig(nRequired, pubkeys);
```

2) function **GetScriptForMultisig** has lines (file src/script/standard.cpp)

``` c
script << CScript::EncodeOP_N(nRequired);
```

and

``` c
script << CScript::EncodeOP_N(keys.size()) << OP_CHECKMULTISIG;
```

3) function **EncodeOP_N** has the assert(file src/script/script.h)

``` c
assert(n >= 0 && n <= 16);
```

4) We don't need check **nRequired** because it checks here:

``` c
if ((int)keys.size() < nRequired)
        throw runtime_error(
            strprintf("not enough keys supplied "
                      "(got %" PRIszu " keys, but need at least %d to redeem)", keys.size(), nRequired));
```

5) English is not my native, so ,maybe, error message should be improved...

similar to https://github.com/novacoin-project/novacoin/pull/125
