### PR TITLE
Policy: Refactor: inline main:GetMinRelayFee() in main:AcceptToMemoryPool()

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -814,7 +814,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     if (mapArgs.count("-minrelaytxfee"))
     {
         CAmount n = 0;
-        if (ParseMoney(mapArgs["-minrelaytxfee"], n) && n > 0)
+        if (ParseMoney(mapArgs["-minrelaytxfee"], n) && MoneyRange(n))
             ::minRelayTxFee = CFeeRate(n);
         else
             return InitError(strprintf(_("Invalid amount for -minrelaytxfee=<amount>: '%s'"), mapArgs["-minrelaytxfee"]));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -831,14 +831,11 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
         unsigned int nSize = entry.GetTxSize();
 
         CAmount nMinFee = ::minRelayTxFee.GetFee(nSize);
-        {
-            LOCK(mempool.cs);
-            double dPriorityDelta = 0;
-            CAmount nFeeDelta = 0;
-            mempool.ApplyDeltas(hash, dPriorityDelta, nFeeDelta);
-            if (dPriorityDelta > 0 || nFeeDelta > 0)
-                nMinFee = 0;
-        }
+        double dPriorityDelta = 0;
+        CAmount nFeeDelta = 0;
+        mempool.ApplyDeltas(hash, dPriorityDelta, nFeeDelta);
+        if (dPriorityDelta > 0 || nFeeDelta > 0)
+            nMinFee = 0;
 
         if (fAllowFree) {
             // There is a free transaction area in blocks created by most miners,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -830,23 +830,25 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
         CTxMemPoolEntry entry(tx, nFees, GetTime(), dPriority, chainActive.Height(), mempool.HasNoInputsOf(tx));
         unsigned int nSize = entry.GetTxSize();
 
-        CAmount nMinFee = ::minRelayTxFee.GetFee(nSize);
-        double dPriorityDelta = 0;
-        CAmount nFeeDelta = 0;
-        mempool.ApplyDeltas(hash, dPriorityDelta, nFeeDelta);
-        if ((dPriorityDelta > 0 || nFeeDelta > 0) ||
-            // There is a free transaction area in blocks created by most miners,
-            // * If we are relaying we allow transactions up to DEFAULT_BLOCK_PRIORITY_SIZE - 1000
-            //   to be considered to fall into this category. We don't want to encourage sending
-            //   multiple transactions instead of one big transaction to avoid fees.
-            (fAllowFree && nSize < (DEFAULT_BLOCK_PRIORITY_SIZE - 1000)))
-            nMinFee = 0;
+        if (fLimitFree) {
+            CAmount nMinFee = ::minRelayTxFee.GetFee(nSize);
+            double dPriorityDelta = 0;
+            CAmount nFeeDelta = 0;
+            mempool.ApplyDeltas(hash, dPriorityDelta, nFeeDelta);
+            if ((dPriorityDelta > 0 || nFeeDelta > 0) ||
+                // There is a free transaction area in blocks created by most miners,
+                // * If we are relaying we allow transactions up to DEFAULT_BLOCK_PRIORITY_SIZE - 1000
+                //   to be considered to fall into this category. We don't want to encourage sending
+                //   multiple transactions instead of one big transaction to avoid fees.
+                (fAllowFree && nSize < (DEFAULT_BLOCK_PRIORITY_SIZE - 1000)))
+                nMinFee = 0;
 
-        // Don't accept it if it can't get into a block
-        if (fLimitFree && nFees < nMinFee)
-            return state.DoS(0, error("AcceptToMemoryPool: not enough fees %s, %d < %d",
-                                      hash.ToString(), nFees, nMinFee),
-                             REJECT_INSUFFICIENTFEE, "insufficient fee");
+            // Don't accept it if it can't get into a block
+            if (nFees < nMinFee)
+                return state.DoS(0, error("AcceptToMemoryPool: not enough fees %s, %d < %d",
+                                          hash.ToString(), nFees, nMinFee),
+                                 REJECT_INSUFFICIENTFEE, "insufficient fee");
+        }
 
         // Require that free transactions have sufficient priority to be mined in the next block.
         if (GetBoolArg("-relaypriority", true) && nFees < ::minRelayTxFee.GetFee(nSize) && !AllowFree(view.GetPriority(tx, chainActive.Height() + 1))) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -848,8 +848,6 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
             if (nSize < (DEFAULT_BLOCK_PRIORITY_SIZE - 1000))
                 nMinFee = 0;
         }
-        if (!MoneyRange(nMinFee))
-            nMinFee = MAX_MONEY;
 
         // Don't accept it if it can't get into a block
         if (fLimitFree && nFees < nMinFee)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -836,7 +836,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
         unsigned int nSize = entry.GetTxSize();
 
         bool fValidateFee = nFees >= ::minRelayTxFee.GetFee(nSize);
-        if (fLimitFree) {
+        if (fLimitFree && !fValidateFee) {
             double dPriorityDelta = 0;
             CAmount nFeeDelta = 0;
             mempool.ApplyDeltas(hash, dPriorityDelta, nFeeDelta);
@@ -846,10 +846,9 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
                 //   to be considered to fall into this category. We don't want to encourage sending
                 //   multiple transactions instead of one big transaction to avoid fees.
                   (fAllowFree && nSize < (DEFAULT_BLOCK_PRIORITY_SIZE - 1000))))
-                if (!fValidateFee)
-                    return state.DoS(0, error("AcceptToMemoryPool: not enough fees %s, %d < %d",
-                                              hash.ToString(), nFees, ::minRelayTxFee.GetFee(nSize)),
-                                     REJECT_INSUFFICIENTFEE, "insufficient fee");
+                return state.DoS(0, error("AcceptToMemoryPool: not enough fees %s, %d < %d",
+                                          hash.ToString(), nFees, ::minRelayTxFee.GetFee(nSize)),
+                                 REJECT_INSUFFICIENTFEE, "insufficient fee");
         }
 
         // Require that free transactions have sufficient priority to be mined in the next block.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -834,17 +834,13 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
         double dPriorityDelta = 0;
         CAmount nFeeDelta = 0;
         mempool.ApplyDeltas(hash, dPriorityDelta, nFeeDelta);
-        if (dPriorityDelta > 0 || nFeeDelta > 0)
-            nMinFee = 0;
-
-        if (fAllowFree) {
+        if ((dPriorityDelta > 0 || nFeeDelta > 0) ||
             // There is a free transaction area in blocks created by most miners,
             // * If we are relaying we allow transactions up to DEFAULT_BLOCK_PRIORITY_SIZE - 1000
             //   to be considered to fall into this category. We don't want to encourage sending
             //   multiple transactions instead of one big transaction to avoid fees.
-            if (nSize < (DEFAULT_BLOCK_PRIORITY_SIZE - 1000))
-                nMinFee = 0;
-        }
+            (fAllowFree && nSize < (DEFAULT_BLOCK_PRIORITY_SIZE - 1000)))
+            nMinFee = 0;
 
         // Don't accept it if it can't get into a block
         if (fLimitFree && nFees < nMinFee)

--- a/src/main.h
+++ b/src/main.h
@@ -259,9 +259,6 @@ struct CDiskTxPos : public CDiskBlockPos
     }
 };
 
-
-CAmount GetMinRelayFee(const CTransaction& tx, unsigned int nBytes, bool fAllowFree);
-
 /** 
  * Count ECDSA signature operations the old-fashioned (pre-0.6) way
  * @return number of sigops this transaction's outputs will produce when spent


### PR DESCRIPTION
main::GetMinRelayFee() is only called from main::AcceptToMemoryPool().
By in-lining in we can make some code simplifications and test that no new money is being created before calling main::AreInputsStandard(), instead of doing it in https://github.com/bitcoin/bitcoin/blob/master/src/main.cpp#L1032 after all those free transaction special cases. 
Even removing the `nFees < 0` check would be safe since it is repeated in https://github.com/bitcoin/bitcoin/blob/master/src/main.cpp#L1073 via https://github.com/bitcoin/bitcoin/blob/master/src/main.cpp#L1471
But moving it up seems more DoS-safe.
I've done the refactor step by step to to help with review. 
