### PR TITLE
Avoid reference trap in SignatureChecker

### DIFF
--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -7,6 +7,7 @@
 #define BITCOIN_SCRIPT_INTERPRETER_H
 
 #include "script_error.h"
+#include "primitives/transaction.h"
 
 #include <vector>
 #include <stdint.h>
@@ -14,7 +15,6 @@
 
 class CPubKey;
 class CScript;
-class CTransaction;
 class uint256;
 
 /** Signature hash types/flags */
@@ -93,7 +93,7 @@ public:
 class SignatureChecker : public BaseSignatureChecker
 {
 private:
-    const CTransaction& txTo;
+    const CTransaction txTo;
     unsigned int nIn;
 
 protected:


### PR DESCRIPTION
Fixes #5715. Keeping around references on a class is extremely dangerous, due to C++'s  behavior with regard to temporaries. This is a cruel trap for (unwary) programmers. I see two solutions:
- a) change the argument (and property on SignatureChecker) to a pointer instead of a reference, and manually manage lifetime
- b) make a copy

(b) is a one-line change without changes to the interface, so at least for 0.10 has my preference. 

There could be performance impact, but to avoid premature optimization, I'd I'd like to see concrete numbers to warrant a more impactful, error-prone solution.
