### PR TITLE
Coin Control: Fix fee labels with Custom Fees

### DIFF
--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -604,7 +604,7 @@ void CoinControlDialog::updateLabels(WalletModel *model, QDialog* dialog)
     l6->setText(sPriorityLabel);                                             // Priority
     l7->setText(fDust ? tr("yes") : tr("no"));                               // Dust
     l8->setText(BitcoinUnits::formatWithUnit(nDisplayUnit, nChange));        // Change
-    if (nPayFee > 0 && !(payTxFee.GetFeePerK() > 0 && fPayAtLeastCustomFee && nBytes < 1000))
+    if (nPayFee > 0 && !(payTxFee.GetFeePerK() > 0 && fPayAtLeastCustomFee))
     {
         l3->setText(ASYMP_UTF8 + l3->text());
         l4->setText(ASYMP_UTF8 + l4->text());

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -592,7 +592,7 @@ void SendCoinsDialog::updateGlobalFeeVariables()
     {
         nTxConfirmTarget = 25;
         payTxFee = CFeeRate(ui->customFee->value());
-        fPayAtLeastCustomFee = ui->radioCustomAtLeast->isChecked();
+        fPayAtLeastCustomFee = !ui->radioCustomAtLeast->isChecked();
     }
 
     fSendFreeTransactions = ui->checkBoxFreeTx->isChecked();


### PR DESCRIPTION
# Coin Control: Fix fee labels when switching between Smart and Custom Fees

The logic was just backwards.

Before:
![screenshot from 2015-01-26 20 34 38](https://cloud.githubusercontent.com/assets/93665/5914520/085f4df6-a59b-11e4-84bf-93632e72fa15.png)

After:
![screenshot from 2015-01-26 20 35 31](https://cloud.githubusercontent.com/assets/93665/5914521/0e074bbe-a59b-11e4-9032-ea4ae514eb82.png)
# Coin Control: Fix fee labels when nBytes >= 1000

It appears that nBytes < 1000 was intended to compare to MAX_FREE_TRANSACTION_CREATE_SIZE for the purpose of excluding free transactions.  It turns out however that the byte size of the transaction is irrelevant to the desired purpose of this conditional.

Before:
![screenshot from 2015-01-26 20 42 03](https://cloud.githubusercontent.com/assets/93665/5914588/8bd7a8c6-a59c-11e4-83cf-f1af846de9ca.png)

After:
![screenshot from 2015-01-26 20 43 42](https://cloud.githubusercontent.com/assets/93665/5914593/9676ce7e-a59c-11e4-9fa4-5d0c70aba9f5.png)

Tested:
- Before this patch the Smart Fee label prefix happens when you cross the nBytes > 1000 boundary.
- If you check the "Send as zero-fee if possible" box it behaves as expected.
