### PR TITLE
Acquire CCheckQueue's lock to avoid race condition

### DIFF
--- a/src/checkqueue.h
+++ b/src/checkqueue.h
@@ -161,7 +161,12 @@ public:
     {
     }
 
-    friend class CCheckQueueControl<T>;
+    bool IsIdle()
+    {
+        boost::unique_lock<boost::mutex> lock(mutex);
+        return (nTotal == nIdle && nTodo == 0 && fAllOk == true);
+    }
+
 };
 
 /** 
@@ -180,9 +185,8 @@ public:
     {
         // passed queue is supposed to be unused, or NULL
         if (pqueue != NULL) {
-            assert(pqueue->nTotal == pqueue->nIdle);
-            assert(pqueue->nTodo == 0);
-            assert(pqueue->fAllOk == true);
+            bool isIdle = pqueue->IsIdle();
+            assert(isIdle);
         }
     }
 


### PR DESCRIPTION
This fixes a potential race condition in the CCheckQueueControl constructor,
which was looking directly at data in CCheckQueue without acquiring its lock.

Even though only one CCheckQueueControl exists at a time, one of the 
CCheckQueue threads may have completed work but not yet updated nIdle or
released its lock, so looking at that variable without acquiring the lock first is not 
safe.

Fixes #5703.
