### PR TITLE
Set default wallet custom tx fee to minTxFee instead of zero.

### DIFF
--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -98,7 +98,7 @@ SendCoinsDialog::SendCoinsDialog(QWidget *parent) :
     if (!settings.contains("nSmartFeeSliderPosition"))
         settings.setValue("nSmartFeeSliderPosition", 0);
     if (!settings.contains("nTransactionFee"))
-        settings.setValue("nTransactionFee", (qint64)DEFAULT_TRANSACTION_FEE);
+        settings.setValue("nTransactionFee", (qint64)CWallet::minTxFee.GetFeePerK());
     if (!settings.contains("fPayOnlyMinFee"))
         settings.setValue("fPayOnlyMinFee", false);
     if (!settings.contains("fSendFreeTransactions"))


### PR DESCRIPTION
The default of zero is never correct nor desired.

Edit Bitcoin-Qt.conf and remove "nTransactionFee" to see the effect of this change which is limited to the default value in the custom fee of the send coins dialog.

Related question: It is additionally unclear why `wallet.h` contains this.  Wouldn't it make more sense to define this as the min fee as well or get rid of it?

``` c++
//! -paytxfee default
static const CAmount DEFAULT_TRANSACTION_FEE = 0;
```
