### PR TITLE
[Modularization] add possibility to extend or overwrite RPC calls

### DIFF
--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -98,6 +98,10 @@ private:
 public:
     CRPCConvertTable();
 
+    void add(const std::string& method, int idx) {
+        members.insert(std::make_pair(method, idx));
+    }
+
     bool convert(const std::string& method, int idx) {
         return (members.count(std::make_pair(method, idx)) > 0);
     }
@@ -115,6 +119,12 @@ CRPCConvertTable::CRPCConvertTable()
 }
 
 static CRPCConvertTable rpcCvtTable;
+
+/** Add new conversion to the JSON RPC conversion table */
+void RPCAddConversion(const std::string& method, int idx)
+{
+    rpcCvtTable.add(method, idx);
+}
 
 /** Convert strings to command-specific RPC representation */
 Array RPCConvertValues(const std::string &strMethod, const std::vector<std::string> &strParams)

--- a/src/rpcclient.h
+++ b/src/rpcclient.h
@@ -10,6 +10,16 @@
 #include "json/json_spirit_utils.h"
 #include "json/json_spirit_writer_template.h"
 
+/**
+ * Add new conversion to the JSON RPC conversion table
+ * @param method name of the method
+ * @param idx    0-based index of the paramter
+ */
+void RPCAddConversion(const std::string& method, int idx);
+
+/**
+ * Convert strings to command-specific RPC representation
+ **/
 json_spirit::Array RPCConvertValues(const std::string& strMethod, const std::vector<std::string>& strParams);
 
 #endif // BITCOIN_RPCCLIENT_H

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -398,10 +398,10 @@ const CRPCCommand *CRPCTable::operator[](string name) const
     return (*it).second;
 }
 
-void CRPCTable::AddOrReplaceCommand(const CRPCCommand command)
+void CRPCTable::AddOrReplaceCommand(const CRPCCommand* pcommand)
 {
     // add new command to the dispatch table
-    mapCommands[command.name] = &command;
+    mapCommands[pcommand->name] = pcommand;
 }
 
 bool HTTPAuthorized(map<string, string>& mapHeaders)

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -398,6 +398,16 @@ const CRPCCommand *CRPCTable::operator[](string name) const
     return (*it).second;
 }
 
+void CRPCTable::AddOrReplaceCommand(const CRPCCommand command)
+{
+    // search after existing key in hashmap and remove it
+    map<string, const CRPCCommand*>::iterator it = mapCommands.find(command.name);
+    if (it != mapCommands.end())
+        mapCommands.erase(it);
+    
+    // add new command to the dispatch table
+    mapCommands[command.name] = &command;
+}
 
 bool HTTPAuthorized(map<string, string>& mapHeaders)
 {
@@ -1034,4 +1044,4 @@ std::string HelpExampleRpc(string methodname, string args){
         "\"method\": \"" + methodname + "\", \"params\": [" + args + "] }' -H 'content-type: text/plain;' http://127.0.0.1:8332/\n";
 }
 
-const CRPCTable tableRPC;
+CRPCTable tableRPC;

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -400,11 +400,6 @@ const CRPCCommand *CRPCTable::operator[](string name) const
 
 void CRPCTable::AddOrReplaceCommand(const CRPCCommand command)
 {
-    // search after existing key in hashmap and remove it
-    map<string, const CRPCCommand*>::iterator it = mapCommands.find(command.name);
-    if (it != mapCommands.end())
-        mapCommands.erase(it);
-    
     // add new command to the dispatch table
     mapCommands[command.name] = &command;
 }

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -114,10 +114,10 @@ public:
     std::string help(std::string name) const;
 
     /**
-     * add or replace a CRPCCommand to the dispatch table
-     * @param command rpc command to add or replace
-     */ 
-    void AddOrReplaceCommand(const CRPCCommand command);
+     * Add or replace a CRPCCommand to the dispatch table
+     * @param pcommand RPC command to add or replace
+     */
+    void AddOrReplaceCommand(const CRPCCommand* pcommand);
 
     /**
      * Execute a method.

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -114,6 +114,12 @@ public:
     std::string help(std::string name) const;
 
     /**
+     * add or replace a CRPCCommand to the dispatch table
+     * @param command rpc command to add or replace
+     */ 
+    void AddOrReplaceCommand(const CRPCCommand command);
+
+    /**
      * Execute a method.
      * @param method   Method to execute
      * @param params   Array of arguments (JSON objects)
@@ -123,7 +129,7 @@ public:
     json_spirit::Value execute(const std::string &method, const json_spirit::Array &params) const;
 };
 
-extern const CRPCTable tableRPC;
+extern CRPCTable tableRPC;
 
 /**
  * Utilities: convert hex-encoded Values

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -167,13 +167,13 @@ BOOST_AUTO_TEST_CASE(rpc_flex_table)
     Value r = CallRPC(string("ping"));
     BOOST_CHECK(r.is_null());
  
-    const CRPCCommand newCmd = { "network","testcmd",  &ping_overwrite_tests,true,false,false };
+    const CRPCCommand newCmd = { "network","testcmd",  &ping_overwrite_tests,true,false };
     tableRPC.AddOrReplaceCommand(newCmd);
     
     BOOST_CHECK_NO_THROW(r = CallRPC(string("testcmd")));
     BOOST_CHECK_EQUAL(find_value(r.get_obj(), "Test").get_str(), "123");
     
-    const CRPCCommand newPingCmd = { "network","ping",  &ping_overwrite_tests,true,false,false };
+    const CRPCCommand newPingCmd = { "network","ping",  &ping_overwrite_tests,true,false };
     tableRPC.AddOrReplaceCommand(newPingCmd);
     
     BOOST_CHECK_NO_THROW(r = CallRPC(string("ping")));

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -180,6 +180,28 @@ BOOST_AUTO_TEST_CASE(rpc_flex_table)
     BOOST_CHECK_EQUAL(find_value(r.get_obj(), "Test").get_str(), "123");
 }
 
+BOOST_AUTO_TEST_CASE(rpc_add_conversion)
+{
+    RPCAddConversion("testcommand", 1);
+    RPCAddConversion("testcommand", 2);
 
+    std::vector<std::string> vstrParams;
+
+    vstrParams.push_back("1234");
+    vstrParams.push_back("false");
+    vstrParams.push_back("481516");
+
+    Array params = RPCConvertValues("testcommand", vstrParams);
+
+    BOOST_CHECK_NO_THROW(params[0].get_str());
+    BOOST_CHECK_NO_THROW(params[1].get_bool());
+    BOOST_CHECK_NO_THROW(params[2].get_int());
+
+    BOOST_CHECK_THROW(params[0].get_int(), std::runtime_error);
+
+    BOOST_CHECK_EQUAL(params[0].get_str(), "1234");
+    BOOST_CHECK_EQUAL(params[1].get_bool(), false);
+    BOOST_CHECK_EQUAL(params[2].get_int(), 481516);
+}
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -166,16 +166,16 @@ BOOST_AUTO_TEST_CASE(rpc_flex_table)
 {
     Value r = CallRPC(string("ping"));
     BOOST_CHECK(r.is_null());
- 
-    const CRPCCommand newCmd = { "network","testcmd",  &ping_overwrite_tests,true,false };
-    tableRPC.AddOrReplaceCommand(newCmd);
-    
+
+    const CRPCCommand newCmd = { "network", "testcmd", &ping_overwrite_tests, true, false };
+    tableRPC.AddOrReplaceCommand(&newCmd);
+
     BOOST_CHECK_NO_THROW(r = CallRPC(string("testcmd")));
     BOOST_CHECK_EQUAL(find_value(r.get_obj(), "Test").get_str(), "123");
-    
-    const CRPCCommand newPingCmd = { "network","ping",  &ping_overwrite_tests,true,false };
-    tableRPC.AddOrReplaceCommand(newPingCmd);
-    
+
+    const CRPCCommand newPingCmd = { "network", "ping", &ping_overwrite_tests, true, false };
+    tableRPC.AddOrReplaceCommand(&newPingCmd);
+
     BOOST_CHECK_NO_THROW(r = CallRPC(string("ping")));
     BOOST_CHECK_EQUAL(find_value(r.get_obj(), "Test").get_str(), "123");
 }


### PR DESCRIPTION
This will allow a upcomming modularization of the wallet or other components.
Currently there is no use of the flexible RPC dispatch table.

Because #5686 is getting to big, it might be a better approach to slice out independent changes which can be easily reviewed and tested.
