### PR TITLE
Introduce basic modularization

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -102,6 +102,7 @@ BITCOIN_CORE_H = \
   main.h \
   merkleblock.h \
   miner.h \
+  module.h \
   mruset.h \
   netbase.h \
   net.h \
@@ -172,6 +173,7 @@ libbitcoin_server_a_SOURCES = \
   main.cpp \
   merkleblock.cpp \
   miner.cpp \
+  module.cpp \
   net.cpp \
   noui.cpp \
   pow.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -51,6 +51,7 @@ BITCOIN_TESTS =\
   test/key_tests.cpp \
   test/main_tests.cpp \
   test/miner_tests.cpp \
+  test/module_tests.cpp \
   test/mruset_tests.cpp \
   test/multisig_tests.cpp \
   test/netbase_tests.cpp \

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -7,6 +7,7 @@
 #include "rpcserver.h"
 #include "init.h"
 #include "main.h"
+#include "module.h"
 #include "noui.h"
 #include "ui_interface.h"
 #include "util.h"
@@ -65,7 +66,8 @@ bool AppInit(int argc, char* argv[])
     //
     // If Qt is used, parameters/bitcoin.conf are parsed in qt/bitcoin.cpp's main()
     ParseParameters(argc, argv);
-
+    Module::Signals.ParameterParsed();
+    
     // Process help and version before taking care about datadir
     if (mapArgs.count("-?") || mapArgs.count("-help") || mapArgs.count("-version"))
     {
@@ -97,6 +99,7 @@ bool AppInit(int argc, char* argv[])
         try
         {
             ReadConfigFile(mapArgs, mapMultiArgs);
+            Module::Signals.ConfigRead();
         } catch (const std::exception& e) {
             fprintf(stderr,"Error reading configuration file: %s\n", e.what());
             return false;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -16,6 +16,7 @@
 #include "key.h"
 #include "main.h"
 #include "miner.h"
+#include "module.h"
 #include "net.h"
 #include "rpcserver.h"
 #include "script/standard.h"
@@ -42,6 +43,7 @@
 #include <boost/interprocess/sync/file_lock.hpp>
 #include <boost/thread.hpp>
 #include <openssl/crypto.h>
+#include <boost/signals2/signal.hpp>
 
 using namespace std;
 
@@ -149,6 +151,7 @@ void Shutdown()
     RenameThread("bitcoin-shutoff");
     mempool.AddTransactionsUpdated(1);
     StopRPCThreads();
+    Module::Signals.Shutdown(Module::SignalStageStarted);
 #ifdef ENABLE_WALLET
     if (pwalletMain)
         bitdb.Flush(false);
@@ -182,6 +185,7 @@ void Shutdown()
         delete pblocktree;
         pblocktree = NULL;
     }
+    Module::Signals.Shutdown(Module::SignalStageStage0);
 #ifdef ENABLE_WALLET
     if (pwalletMain)
         bitdb.Flush(true);
@@ -190,6 +194,7 @@ void Shutdown()
     boost::filesystem::remove(GetPidFile());
 #endif
     UnregisterAllValidationInterfaces();
+    Module::Signals.Shutdown(Module::SignalStageFinished);
 #ifdef ENABLE_WALLET
     delete pwalletMain;
     pwalletMain = NULL;
@@ -316,6 +321,8 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += "  -zapwallettxes=<mode>  " + _("Delete all wallet transactions and only recover those parts of the blockchain through -rescan on startup") + "\n";
     strUsage += "                         " + _("(1 = keep tx meta data e.g. account owner and payment request information, 2 = drop tx meta data)") + "\n";
 #endif
+    
+    Module::Signals.AppendHelpMessage(strUsage);
 
     strUsage += "\n" + _("Debugging/Testing options:") + "\n";
     if (GetBoolArg("-help-debug", false))
@@ -617,6 +624,7 @@ bool AppInit2(boost::thread_group& threadGroup)
             LogPrintf("%s: parameter interaction: -externalip set -> setting -discover=0\n", __func__);
     }
 
+    Module::Signals.ValidateArguments();
     if (GetBoolArg("-salvagewallet", false)) {
         // Rewrite just private keys: rescan to find transactions
         if (SoftSetBoolArg("-rescan", true))
@@ -703,6 +711,15 @@ bool AppInit2(boost::thread_group& threadGroup)
             return InitError(strprintf(_("Invalid amount for -minrelaytxfee=<amount>: '%s'"), mapArgs["-minrelaytxfee"]));
     }
 
+    string errorString;
+    string warningString;
+    Module::Signals.ParseArguments(errorString, warningString);
+    //push message in case of received error/warnings
+    if(!warningString.empty())
+        InitWarning(warningString); //warning; pass
+    if(!errorString.empty())
+        return InitError(errorString); //stop on errors
+    
 #ifdef ENABLE_WALLET
     if (mapArgs.count("-mintxfee"))
     {
@@ -777,6 +794,7 @@ bool AppInit2(boost::thread_group& threadGroup)
     LogPrintf("\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n");
     LogPrintf("Bitcoin version %s (%s)\n", FormatFullVersion(), CLIENT_DATE);
     LogPrintf("Using OpenSSL version %s\n", SSLeay_version(SSLEAY_VERSION));
+    Module::Signals.DebugStartupInfo(Module::SignalStageStarted);
 #ifdef ENABLE_WALLET
     LogPrintf("Using BerkeleyDB version %s\n", DbEnv::version(0, 0, 0));
 #endif
@@ -808,6 +826,15 @@ bool AppInit2(boost::thread_group& threadGroup)
     int64_t nStart;
 
     // ********************************************************* Step 5: verify wallet database integrity
+    
+    errorString = string();
+    warningString = string();
+    Module::Signals.ModuleInit(Module::SignalStageStarted,errorString, warningString);
+    if(!warningString.empty())
+        InitWarning(warningString); //warning; pass
+    if(!errorString.empty())
+        return InitError(errorString); //stop on errors
+    
 #ifdef ENABLE_WALLET
     if (!fDisableWallet) {
         LogPrintf("Using wallet %s\n", strWalletFile);
@@ -1099,6 +1126,15 @@ bool AppInit2(boost::thread_group& threadGroup)
     fFeeEstimatesInitialized = true;
 
     // ********************************************************* Step 8: load wallet
+    
+    errorString = string();
+    warningString = string();
+    Module::Signals.ModuleInit(Module::SignalStageStage0,errorString, warningString);
+    if(!warningString.empty())
+        InitWarning(warningString); //warning; pass
+    if(!errorString.empty())
+        return InitError(errorString); //stop on errors
+    
 #ifdef ENABLE_WALLET
     if (fDisableWallet) {
         pwalletMain = NULL;
@@ -1273,6 +1309,7 @@ bool AppInit2(boost::thread_group& threadGroup)
     //// debug print
     LogPrintf("mapBlockIndex.size() = %u\n",   mapBlockIndex.size());
     LogPrintf("nBestHeight = %d\n",                   chainActive.Height());
+    Module::Signals.DebugStartupInfo(Module::SignalStageFinished);
 #ifdef ENABLE_WALLET
     LogPrintf("setKeyPool.size() = %u\n",      pwalletMain ? pwalletMain->setKeyPool.size() : 0);
     LogPrintf("mapWallet.size() = %u\n",       pwalletMain ? pwalletMain->mapWallet.size() : 0);
@@ -1280,6 +1317,7 @@ bool AppInit2(boost::thread_group& threadGroup)
 #endif
 
     StartNode(threadGroup);
+    Module::Signals.NodeStarted();
 
 #ifdef ENABLE_WALLET
     // Generate coins in the background
@@ -1291,7 +1329,15 @@ bool AppInit2(boost::thread_group& threadGroup)
 
     SetRPCWarmupFinished();
     uiInterface.InitMessage(_("Done loading"));
-
+    
+    errorString = string();
+    warningString = string();
+    Module::Signals.ModuleInit(Module::SignalStageFinished,errorString, warningString);
+    if(!warningString.empty())
+        InitWarning(warningString); //warning; pass
+    if(!errorString.empty())
+        return InitError(errorString); //stop on errors
+    
 #ifdef ENABLE_WALLET
     if (pwalletMain) {
         // Add wallet transactions that aren't already in a block to mapTransactions

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -1,0 +1,25 @@
+// Copyright (c) 2010 Satoshi Nakamoto
+// Copyright (c) 2009-2014 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "module.h"
+
+Module::ModuleSignals Module::Signals;
+std::vector<CModuleInterface *> Module::vLoadedModules;
+
+void Module::AddModule(CModuleInterface *module)
+{
+    module->registerModule();
+    vLoadedModules.push_back(module);
+}
+    
+void Module::RemoveAllModules()
+{
+    BOOST_FOREACH(CModuleInterface* module, vLoadedModules)
+    {
+        module->unregisterModule();
+    }
+    
+    vLoadedModules.clear();
+}

--- a/src/module.h
+++ b/src/module.h
@@ -1,0 +1,55 @@
+// Copyright (c) 2010 Satoshi Nakamoto
+// Copyright (c) 2009-2014 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_MODULE_H
+#define BITCOIN_MODULE_H
+
+#include <vector>
+
+#include <boost/foreach.hpp>
+#include <boost/signals2/signal.hpp>
+
+class CModuleInterface
+{
+public:
+    virtual ~CModuleInterface() {} ;
+    
+    virtual void registerModule() {};
+    virtual void unregisterModule() {};
+};
+
+class Module {
+public:
+
+    enum SignalStage
+    {
+        SignalStageStarted,
+        SignalStageStage0,
+        SignalStageFinished
+    };
+    
+    struct ModuleSignals {
+        boost::signals2::signal<void (std::string&)> AppendHelpMessage; //!append modules help to the global help string
+        boost::signals2::signal<void ()> ParameterParsed; //!signal after the parameters have been parsed
+        boost::signals2::signal<void ()> ConfigRead; //!signal after the config was read completely
+        boost::signals2::signal<void ()> ValidateArguments; //!possibility to validate arguments
+        
+        //!signal for parse startup arguments and possibility to stop the excution by adding a string to the error string
+        boost::signals2::signal<void (std::string&,std::string&)> ParseArguments;
+        boost::signals2::signal<void (SignalStage)> DebugStartupInfo; //! signal for pushing debug intos to the log
+        boost::signals2::signal<void ()> NodeStarted; //! signal after the node has started
+        boost::signals2::signal<void (SignalStage,std::string&,std::string&)> ModuleInit; //! signal for the init process
+        
+        boost::signals2::signal<void (SignalStage)> Shutdown; //! signal for the shutdown process
+    };
+    
+    static ModuleSignals Signals;
+
+    static std::vector<CModuleInterface *> vLoadedModules;
+
+    static void AddModule(CModuleInterface *module);
+    static void RemoveAllModules();
+};
+#endif // BITCOIN_MODULE_H

--- a/src/test/module_tests.cpp
+++ b/src/test/module_tests.cpp
@@ -1,0 +1,50 @@
+// Copyright (c) 2012-2013 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "module.h"
+
+#include <boost/test/unit_test.hpp>
+
+using namespace std;
+
+class AModule : public CModuleInterface
+{
+public:
+    void appendTest(string& aString)
+    {
+        aString += " test";
+    }
+    
+    void registerModule()
+    {
+        Module::Signals.AppendHelpMessage.connect(boost::bind(&AModule::appendTest, this, _1));
+    }
+    
+    void unregisterModule()
+    {
+        Module::Signals.AppendHelpMessage.disconnect(boost::bind(&AModule::appendTest, this, _1));
+    }
+};
+
+BOOST_AUTO_TEST_SUITE(module_tests)
+
+BOOST_AUTO_TEST_CASE(module_basics)
+{
+    AModule *newModule = new AModule();
+    Module::AddModule(newModule);
+    
+    string newStr("START");
+    Module::Signals.AppendHelpMessage(newStr);
+    BOOST_CHECK(newStr == "START test");
+    
+    Module::RemoveAllModules();
+    
+    newStr = string("");
+    Module::Signals.AppendHelpMessage(newStr);
+    BOOST_CHECK(newStr == "");
+    
+    delete newModule;
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
According to #3440 it would make sense to decouple the wallet and the miner (and maybe other things) from the init-/shutdown-process, etc.

This is related to #5686, #5744, #5745

If this gets merged, my plans are to first transform the miner into a module, then the wallet.
The goal should be to remove the `ENABLE_WALLET` ifdefs and make use of the modular concept.

If this looks to useless, i can transform the internal miner into a module within this PR (but it will be a harder review).
