### PR TITLE
fix getblocktemplate lock issue

### DIFF
--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -446,10 +446,6 @@ Value getblocktemplate(const Array& params, bool fHelp)
         }
 
         // Release the wallet and main lock while waiting
-#ifdef ENABLE_WALLET
-        if(pwalletMain)
-            LEAVE_CRITICAL_SECTION(pwalletMain->cs_wallet);
-#endif
         LEAVE_CRITICAL_SECTION(cs_main);
         {
             checktxtime = boost::get_system_time() + boost::posix_time::minutes(1);
@@ -467,10 +463,6 @@ Value getblocktemplate(const Array& params, bool fHelp)
             }
         }
         ENTER_CRITICAL_SECTION(cs_main);
-#ifdef ENABLE_WALLET
-        if(pwalletMain)
-            ENTER_CRITICAL_SECTION(pwalletMain->cs_wallet);
-#endif
 
         if (!IsRPCRunning())
             throw JSONRPCError(RPC_CLIENT_NOT_CONNECTED, "Shutting down");


### PR DESCRIPTION
getblocktemplate didn't have a wallet lock before #5711 and IMO there is no need for LEAVE/ENTER critical section.
