### PR TITLE
Fix getblocktemplate_proposals test by mining one block

### DIFF
--- a/qa/rpc-tests/getblocktemplate_proposals.py
+++ b/qa/rpc-tests/getblocktemplate_proposals.py
@@ -95,6 +95,7 @@ class GetBlockTemplateProposalTest(BitcoinTestFramework):
 
     def run_test(self):
         node = self.nodes[0]
+        node.setgenerate(True, 1) # Mine a block to leave initial block download
         tmpl = node.getblocktemplate()
         if 'coinbasetxn' not in tmpl:
             rawcoinbase = encodeUNum(tmpl['height'])


### PR DESCRIPTION
This triggers the tested node to no longer be in initial
download, allowing the call to getblocktemplate() to succeed.
