### PR TITLE
fix:previous label remained for an address without a label

### DIFF
--- a/src/qt/sendcoinsentry.cpp
+++ b/src/qt/sendcoinsentry.cpp
@@ -250,9 +250,9 @@ bool SendCoinsEntry::updateLabel(const QString &address)
     if(!model)
         return false;
 
-    // Fill in label from address book, if address has an associated label
+    // Fill in label from address book
     QString associatedLabel = model->getAddressTableModel()->labelForAddress(address);
-    if(!associatedLabel.isEmpty())
+    if(ui->addAsLabel->text() != associatedLabel)
     {
         ui->addAsLabel->setText(associatedLabel);
         return true;


### PR DESCRIPTION
Bug description
1. Run Bitcoin-Qt
2. Go to the tab "Send coins"
3. Press "Address book button"
4. Choose address **with** label
5. Again press "Address book button" for the same recipient
6. Choose address **without** label
7. The previous label remained for the address without a label
