### PR TITLE
gitian: don't add . to tar list

### DIFF
--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -99,7 +99,7 @@ script: |
     find . -name "lib*.la" -delete
     find . -name "lib*.a" -delete
     rm -rf ${DISTNAME}/lib/pkgconfig
-    find . | sort | tar --no-recursion --mode='u+rw,go+r-w,a+X' --owner=0 --group=0 -c -T - | gzip -9n > ${OUTDIR}/${DISTNAME}-${i}.tar.gz
+    find ${DISTNAME} | sort | tar --no-recursion --mode='u+rw,go+r-w,a+X' --owner=0 --group=0 -c -T - | gzip -9n > ${OUTDIR}/${DISTNAME}-${i}.tar.gz
     cd ../../
   done
   mkdir -p $OUTDIR/src

--- a/contrib/gitian-descriptors/gitian-osx.yml
+++ b/contrib/gitian-descriptors/gitian-osx.yml
@@ -126,7 +126,7 @@ script: |
     find . -name "lib*.la" -delete
     find . -name "lib*.a" -delete
     rm -rf ${DISTNAME}/lib/pkgconfig
-    find . | sort | tar --no-recursion --mode='u+rw,go+r-w,a+X' --owner=0 --group=0 -c -T - | gzip -9n > ${OUTDIR}/${DISTNAME}-${i}.tar.gz
+    find ${DISTNAME} | sort | tar --no-recursion --mode='u+rw,go+r-w,a+X' --owner=0 --group=0 -c -T - | gzip -9n > ${OUTDIR}/${DISTNAME}-${i}.tar.gz
     cd ../../
   done
   mkdir -p $OUTDIR/src

--- a/contrib/gitian-descriptors/gitian-win.yml
+++ b/contrib/gitian-descriptors/gitian-win.yml
@@ -106,7 +106,7 @@ script: |
     find . -name "lib*.la" -delete
     find . -name "lib*.a" -delete
     rm -rf ${DISTNAME}/lib/pkgconfig
-    find . -type f | sort | zip -X@ ${OUTDIR}/${DISTNAME}-${i}.zip
+    find ${DISTNAME} -type f | sort | zip -X@ ${OUTDIR}/${DISTNAME}-${i}.zip
     cd ../..
   done
   mkdir -p $OUTDIR/src


### PR DESCRIPTION
Since permissions and timestamps are changed for the sake of determinism, . must not be added to the archive. Otherwise, tar may try to modify pwd when extracting.

Fixes #5789.

Ping @laanwj: Needs 0.10 cherry-pick.

Gitian build results:
https://bitcoincore.org/cfields/bitcoin-0.10.0rc4-tarfix/bitcoin-0.10.0-linux32.tar.gz
https://bitcoincore.org/cfields/bitcoin-0.10.0rc4-tarfix/bitcoin-0.10.0-linux64.tar.gz
https://bitcoincore.org/cfields/bitcoin-0.10.0rc4-tarfix/bitcoin-0.10.0-osx64.tar.gz
https://bitcoincore.org/cfields/bitcoin-0.10.0rc4-tarfix/bitcoin-0.10.0-osx-unsigned.tar.gz
https://bitcoincore.org/cfields/bitcoin-0.10.0rc4-tarfix/bitcoin-0.10.0-win32.zip
https://bitcoincore.org/cfields/bitcoin-0.10.0rc4-tarfix/bitcoin-0.10.0-win64.zip

This changes the osx-unsigned dir structure, but I was planning to do that in the future anyway. It doesn't harm anything.
