### PR TITLE
[GUI] Move fee dialog minimise button away from "Transaction Fee:"

### DIFF
--- a/src/qt/forms/sendcoinsdialog.ui
+++ b/src/qt/forms/sendcoinsdialog.ui
@@ -771,16 +771,6 @@
                 </property>
                </widget>
               </item>
-              <item>
-               <widget class="QPushButton" name="buttonMinimizeFee">
-                <property name="toolTip">
-                 <string>collapse fee-settings</string>
-                </property>
-                <property name="text">
-                 <string>Minimize</string>
-                </property>
-               </widget>
-              </item>
              </layout>
             </item>
             <item>
@@ -810,6 +800,16 @@
              </size>
             </property>
            </spacer>
+          </item>
+          <item>
+           <widget class="QPushButton" name="buttonMinimizeFee">
+            <property name="toolTip">
+             <string>collapse fee-settings</string>
+            </property>
+            <property name="text">
+             <string>Minimize</string>
+            </property>
+           </widget>
           </item>
          </layout>
         </item>


### PR DESCRIPTION
Original placement seems to be causing some confusion among users.
Before
![screen shot 1](https://cloud.githubusercontent.com/assets/863730/6246598/c557f7c0-b7a5-11e4-9804-882dc295007c.png)

After
![screen shot 3](https://cloud.githubusercontent.com/assets/863730/6246600/c92f484e-b7a5-11e4-878e-97a4be33b12f.png)
