### PR TITLE
osx: disable app-nap programatically

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -304,9 +304,9 @@ case $host in
            old_striplib=
            ;;
        esac
-     AX_CHECK_LINK_FLAG([[-framework Foundation]], [LDFLAGS="$LDFLAGS -framework Foundation"])
      fi
 
+     AX_CHECK_LINK_FLAG([[-framework Foundation]], [LDFLAGS="$LDFLAGS -framework Foundation"])
      AX_CHECK_LINK_FLAG([[-Wl,-headerpad_max_install_names]], [LDFLAGS="$LDFLAGS -Wl,-headerpad_max_install_names"])
      CPPFLAGS="$CPPFLAGS -DMAC_OSX"
      ;;

--- a/configure.ac
+++ b/configure.ac
@@ -304,6 +304,7 @@ case $host in
            old_striplib=
            ;;
        esac
+     AX_CHECK_LINK_FLAG([[-framework Foundation]], [LDFLAGS="$LDFLAGS -framework Foundation"])
      fi
 
      AX_CHECK_LINK_FLAG([[-Wl,-headerpad_max_install_names]], [LDFLAGS="$LDFLAGS -Wl,-headerpad_max_install_names"])

--- a/share/qt/Info.plist.in
+++ b/share/qt/Info.plist.in
@@ -91,9 +91,6 @@
   <key>NSHighResolutionCapable</key>
     <string>True</string>
 
-  <key>LSAppNapIsDisabled</key>
-    <string>True</string>
-  
   <key>LSApplicationCategoryType</key>
     <string>public.app-category.finance</string>
 </dict>

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -70,6 +70,7 @@ endif
 .PHONY: FORCE
 # bitcoin core #
 BITCOIN_CORE_H = \
+  appnap.h \
   addrman.h \
   alert.h \
   allocators.h \
@@ -188,6 +189,10 @@ libbitcoin_server_a_SOURCES = \
   txmempool.cpp \
   $(JSON_H) \
   $(BITCOIN_CORE_H)
+
+if TARGET_DARWIN
+  libbitcoin_server_a_SOURCES += appnap.mm
+endif
 
 # wallet: shared between bitcoind and bitcoin-qt, but only linked
 # when wallet enabled

--- a/src/appnap.h
+++ b/src/appnap.h
@@ -1,0 +1,20 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2014 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_APPNAPINHIBITOR_H
+#define BITCOIN_APPNAPINHIBITOR_H
+
+class CAppNapInhibitorInt;
+
+class CAppNapInhibitor
+{
+public:
+    CAppNapInhibitor(const char* strReason);
+    ~CAppNapInhibitor();
+private:
+    CAppNapInhibitorInt *priv;
+};
+
+#endif // BITCOIN_APPNAPINHIBITOR_H

--- a/src/appnap.mm
+++ b/src/appnap.mm
@@ -1,0 +1,28 @@
+#include "appnap.h"
+
+#include <AvailabilityMacros.h>
+#include <Foundation/NSProcessInfo.h>
+#include <Foundation/Foundation.h>
+
+class CAppNapInhibitorInt
+{
+public:
+    id<NSObject> activityId;
+};
+
+CAppNapInhibitor::CAppNapInhibitor(const char* strReason) : priv(new CAppNapInhibitorInt)
+{
+#if defined(MAC_OS_X_VERSION_MAX_ALLOWED) &&  MAC_OS_X_VERSION_MAX_ALLOWED >= 1090
+    if ([[NSProcessInfo processInfo] respondsToSelector:@selector(beginActivityWithOptions:reason:)])
+        priv->activityId = [[NSProcessInfo processInfo ] beginActivityWithOptions: NSActivityUserInitiatedAllowingIdleSystemSleep reason:@(strReason)];
+#endif
+}
+
+CAppNapInhibitor::~CAppNapInhibitor()
+{
+#if defined(MAC_OS_X_VERSION_MAX_ALLOWED) &&  MAC_OS_X_VERSION_MAX_ALLOWED >= 1090
+    if ([[NSProcessInfo processInfo] respondsToSelector:@selector(endActivity:)])
+        [[NSProcessInfo processInfo] endActivity:priv->activityId];
+#endif
+    delete priv;
+}

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -59,6 +59,8 @@ bool AppInit(int argc, char* argv[])
 
     bool fRet = false;
 
+    CIdleInhibitor noIdle("bitcoind");
+
     //
     // Parameters
     //

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -490,6 +490,8 @@ int main(int argc, char *argv[])
 {
     SetupEnvironment();
 
+    CIdleInhibitor noIdle("bitcoin-qt");
+
     /// 1. Parse command-line options. These take precedence over anything else.
     // Command-line options take precedence:
     ParseParameters(argc, argv);

--- a/src/util.h
+++ b/src/util.h
@@ -18,6 +18,10 @@
 #include "tinyformat.h"
 #include "utiltime.h"
 
+#ifdef MAC_OSX
+#include "appnap.h"
+#endif
+
 #include <exception>
 #include <map>
 #include <stdint.h>
@@ -228,5 +232,24 @@ template <typename Callable> void TraceThread(const char* name,  Callable func)
         throw;
     }
 }
+
+// A RAII wrapper around calls to forbid and re-allow entering into
+// low-priority states, specifically OSX's app-nap. For the scope of
+// the object, napping is disabled. Several objects may co-exist, napping is
+// allowed when the last one is destroyed.
+
+class CIdleInhibitor
+{
+public:
+#ifdef MAC_OSX
+    CIdleInhibitor(const char* strReason) : inhibit(strReason){}
+#else
+    CIdleInhibitor(const char*){}
+#endif
+private:
+#ifdef MAC_OSX
+    CAppNapInhibitor inhibit;
+#endif
+};
 
 #endif // BITCOIN_UTIL_H


### PR DESCRIPTION
Currently for OSX we're disabling [app-nap](https://developer.apple.com/library/mac/documentation/Performance/Conceptual/power_efficiency_guidelines_osx/AppNap/AppNap.html) globally via the app's plist. If enabled, app-nap slows down performance badly for long-running activities. See https://github.com/bitcoin/bitcoin/pull/5041 for more background.

Disabling via the plist has a few draw-backs:
- The plist setting only has an effect when running from an .app bundle. In practice, that means only when running from a packaged release
- We don't distribute bitcoind in the bundle and likely never will. So app-nap is always enabled for bitcoind.
- App-nap can actually be a useful feature. It would be helpful to only disable it at certain times (initial sync for example)

These changes add runtime functionality so that we can turn it on/off at-will. For now, it's enabled for the life-time of the programs, but that can be changed once we decide how to regulate it.

The CIdleInhibitor class is very ugly, but I assume that at some point we'll add similar features for other operating systems. I think this is nicer than osx ifdefs all over the place. I avoided inheritance and virtuals since we're interfacing with objc.

Needs testing on < 10.9 systems.
