### PR TITLE
Fix priority calculation in CreateTransaction (0.9)

### DIFF
--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1281,10 +1281,14 @@ bool CWallet::CreateTransaction(const vector<pair<CScript, int64_t> >& vecSend,
                 BOOST_FOREACH(PAIRTYPE(const CWalletTx*, unsigned int) pcoin, setCoins)
                 {
                     int64_t nCredit = pcoin.first->vout[pcoin.second].nValue;
-                    //The priority after the next block (depth+1) is used instead of the current,
+                    //The coin age after the next block (depth+1) is used instead of the current,
                     //reflecting an assumption the user would accept a bit more delay for
                     //a chance at a free transaction.
-                    dPriority += (double)nCredit * (pcoin.first->GetDepthInMainChain()+1);
+                    //But mempool inputs might still be in the mempool, so their age stays 0
+                    int age = pcoin.first->GetDepthInMainChain();
+                    if (age != 0)
+                        age += 1;
+                    dPriority += (double)nCredit * age;
                 }
 
                 int64_t nChange = nValueIn - nValue - nFeeRet;


### PR DESCRIPTION
Make this projection of priority in 1 block match the calculation in the low priority reject code.

Rebased-From: 2d9b0b7f03a268e557c6dce1dfa29401b5c9178b
Github-Pull: #5675

Conflicts:
    src/wallet.cpp
