### PR TITLE
Resolve warnings in consensus lib builds.

### DIFF
--- a/src/amount.h
+++ b/src/amount.h
@@ -43,7 +43,7 @@ public:
     friend bool operator>=(const CFeeRate& a, const CFeeRate& b) { return a.nSatoshisPerK >= b.nSatoshisPerK; }
     std::string ToString() const;
 
-    ADD_SERIALIZE_METHODS;
+    ADD_SERIALIZE_METHODS
 
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {

--- a/src/crypto/common.h
+++ b/src/crypto/common.h
@@ -94,10 +94,10 @@ void static inline WriteBE32(unsigned char* ptr, uint32_t x)
 #if HAVE_DECL_HTOBE32 == 1
     *((uint32_t*)ptr) = htobe32(x);
 #else
-    ptr[0] = x >> 24;
-    ptr[1] = x >> 16;
-    ptr[2] = x >> 8;
-    ptr[3] = x;
+    ptr[0] = static_cast<unsigned char>(x >> 24);
+    ptr[1] = static_cast<unsigned char>(x >> 16);
+    ptr[2] = static_cast<unsigned char>(x >> 8);
+    ptr[3] = static_cast<unsigned char>(x);
 #endif
 }
 
@@ -106,14 +106,14 @@ void static inline WriteBE64(unsigned char* ptr, uint64_t x)
 #if HAVE_DECL_HTOBE64 == 1
     *((uint64_t*)ptr) = htobe64(x);
 #else
-    ptr[0] = x >> 56;
-    ptr[1] = x >> 48;
-    ptr[2] = x >> 40;
-    ptr[3] = x >> 32;
-    ptr[4] = x >> 24;
-    ptr[5] = x >> 16;
-    ptr[6] = x >> 8;
-    ptr[7] = x;
+    ptr[0] = static_cast<unsigned char>(x >> 56);
+    ptr[1] = static_cast<unsigned char>(x >> 48);
+    ptr[2] = static_cast<unsigned char>(x >> 40);
+    ptr[3] = static_cast<unsigned char>(x >> 32);
+    ptr[4] = static_cast<unsigned char>(x >> 24);
+    ptr[5] = static_cast<unsigned char>(x >> 16);
+    ptr[6] = static_cast<unsigned char>(x >> 8);
+    ptr[7] = static_cast<unsigned char>(x);
 #endif
 }
 

--- a/src/crypto/ripemd160.cpp
+++ b/src/crypto/ripemd160.cpp
@@ -32,7 +32,7 @@ void inline Initialize(uint32_t* s)
 
 uint32_t inline rol(uint32_t x, int i) { return (x << i) | (x >> (32 - i)); }
 
-void inline Round(uint32_t& a, uint32_t b, uint32_t& c, uint32_t d, uint32_t e, uint32_t f, uint32_t x, uint32_t k, int r)
+void inline Round(uint32_t& a, uint32_t, uint32_t& c, uint32_t, uint32_t e, uint32_t f, uint32_t x, uint32_t k, int r)
 {
     a = rol(a + f + x + k, r) + e;
     c = rol(c, 10);

--- a/src/crypto/sha1.cpp
+++ b/src/crypto/sha1.cpp
@@ -15,7 +15,7 @@ namespace
 namespace sha1
 {
 /** One round of SHA-1. */
-void inline Round(uint32_t a, uint32_t& b, uint32_t c, uint32_t d, uint32_t& e, uint32_t f, uint32_t k, uint32_t w)
+void inline Round(uint32_t a, uint32_t& b, uint32_t, uint32_t, uint32_t& e, uint32_t f, uint32_t k, uint32_t w)
 {
     e += ((a << 5) | (a >> 27)) + f + k + w;
     b = (b << 30) | (b >> 2);

--- a/src/ecwrapper.cpp
+++ b/src/ecwrapper.cpp
@@ -108,7 +108,10 @@ void CECKey::GetPubKey(std::vector<unsigned char> &pubkey, bool fCompressed) {
     pubkey.clear();
     pubkey.resize(nSize);
     unsigned char *pbegin(begin_ptr(pubkey));
-    int nSize2 = i2o_ECPublicKey(pkey, &pbegin);
+#ifndef NDEBUG
+    int nSize2 = 
+#endif
+        i2o_ECPublicKey(pkey, &pbegin);
     assert(nSize == nSize2);
 }
 

--- a/src/ecwrapper.cpp
+++ b/src/ecwrapper.cpp
@@ -108,10 +108,7 @@ void CECKey::GetPubKey(std::vector<unsigned char> &pubkey, bool fCompressed) {
     pubkey.clear();
     pubkey.resize(nSize);
     unsigned char *pbegin(begin_ptr(pubkey));
-#ifndef NDEBUG
-    int nSize2 = 
-#endif
-        i2o_ECPublicKey(pkey, &pbegin);
+    int nSize2 = i2o_ECPublicKey(pkey, &pbegin);
     assert(nSize == nSize2);
 }
 

--- a/src/ecwrapper.cpp
+++ b/src/ecwrapper.cpp
@@ -103,7 +103,7 @@ CECKey::~CECKey() {
 void CECKey::GetPubKey(std::vector<unsigned char> &pubkey, bool fCompressed) {
     EC_KEY_set_conv_form(pkey, fCompressed ? POINT_CONVERSION_COMPRESSED : POINT_CONVERSION_UNCOMPRESSED);
     int nSize = i2o_ECPublicKey(pkey, NULL);
-    assert(nSize);
+    assert(nSize != 0);
     assert(nSize <= 65);
     pubkey.clear();
     pubkey.resize(nSize);
@@ -113,7 +113,7 @@ void CECKey::GetPubKey(std::vector<unsigned char> &pubkey, bool fCompressed) {
 }
 
 bool CECKey::SetPubKey(const unsigned char* pubkey, size_t size) {
-    return o2i_ECPublicKey(&pkey, &pubkey, size) != NULL;
+    return o2i_ECPublicKey(&pkey, &pubkey, static_cast<long>(size)) != NULL;
 }
 
 bool CECKey::Verify(const uint256 &hash, const std::vector<unsigned char>& vchSig) {
@@ -125,7 +125,7 @@ bool CECKey::Verify(const uint256 &hash, const std::vector<unsigned char>& vchSi
     ECDSA_SIG *norm_sig = ECDSA_SIG_new();
     const unsigned char* sigptr = &vchSig[0];
     assert(norm_sig);
-    if (d2i_ECDSA_SIG(&norm_sig, &sigptr, vchSig.size()) == NULL)
+    if (d2i_ECDSA_SIG(&norm_sig, &sigptr, static_cast<long>(vchSig.size())) == NULL)
     {
         /* As of OpenSSL 1.0.0p d2i_ECDSA_SIG frees and nulls the pointer on
          * error. But OpenSSL's own use of this function redundantly frees the

--- a/src/hash.cpp
+++ b/src/hash.cpp
@@ -19,7 +19,7 @@ unsigned int MurmurHash3(unsigned int nHashSeed, const std::vector<unsigned char
         const uint32_t c1 = 0xcc9e2d51;
         const uint32_t c2 = 0x1b873593;
 
-        const int nblocks = vDataToHash.size() / 4;
+        const int nblocks = static_cast<int>(vDataToHash.size() / 4);
 
         //----------
         // body

--- a/src/hash.h
+++ b/src/hash.h
@@ -21,10 +21,11 @@ private:
 public:
     static const size_t OUTPUT_SIZE = CSHA256::OUTPUT_SIZE;
 
-    void Finalize(unsigned char hash[OUTPUT_SIZE]) {
-        unsigned char buf[sha.OUTPUT_SIZE];
+    void Finalize(unsigned char hash[CSHA256::OUTPUT_SIZE])
+    {
+        unsigned char buf[CSHA256::OUTPUT_SIZE];
         sha.Finalize(buf);
-        sha.Reset().Write(buf, sha.OUTPUT_SIZE).Finalize(hash);
+        sha.Reset().Write(buf, CSHA256::OUTPUT_SIZE).Finalize(hash);
     }
 
     CHash256& Write(const unsigned char *data, size_t len) {
@@ -45,10 +46,11 @@ private:
 public:
     static const size_t OUTPUT_SIZE = CRIPEMD160::OUTPUT_SIZE;
 
-    void Finalize(unsigned char hash[OUTPUT_SIZE]) {
-        unsigned char buf[sha.OUTPUT_SIZE];
+    void Finalize(unsigned char hash[CRIPEMD160::OUTPUT_SIZE])
+    {
+        unsigned char buf[CRIPEMD160::OUTPUT_SIZE];
         sha.Finalize(buf);
-        CRIPEMD160().Write(buf, sha.OUTPUT_SIZE).Finalize(hash);
+        CRIPEMD160().Write(buf, CRIPEMD160::OUTPUT_SIZE).Finalize(hash);
     }
 
     CHash160& Write(const unsigned char *data, size_t len) {

--- a/src/hash.h
+++ b/src/hash.h
@@ -48,9 +48,9 @@ public:
 
     void Finalize(unsigned char hash[CRIPEMD160::OUTPUT_SIZE])
     {
-        unsigned char buf[CRIPEMD160::OUTPUT_SIZE];
+        unsigned char buf[CSHA256::OUTPUT_SIZE];
         sha.Finalize(buf);
-        CRIPEMD160().Write(buf, CRIPEMD160::OUTPUT_SIZE).Finalize(hash);
+        CRIPEMD160().Write(buf, CSHA256::OUTPUT_SIZE).Finalize(hash);
     }
 
     CHash160& Write(const unsigned char *data, size_t len) {

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -208,11 +208,9 @@ void CExtKey::Decode(const unsigned char code[74]) {
 }
 
 bool ECC_InitSanityCheck() {
-#if !defined(USE_SECP256K1)
     if (!CECKey::SanityCheck()) {
         return false;
     }
-#endif
     CKey key;
     key.MakeNewKey(true);
     CPubKey pubkey = key.GetPubKey();

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -8,6 +8,7 @@
 #include "hash.h"
 #include "tinyformat.h"
 #include "utilstrencodings.h"
+#include "version.h"
 
 std::string COutPoint::ToString() const
 {

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -21,7 +21,7 @@ public:
     COutPoint() { SetNull(); }
     COutPoint(uint256 hashIn, uint32_t nIn) { hash = hashIn; n = nIn; }
 
-    ADD_SERIALIZE_METHODS;
+    ADD_SERIALIZE_METHODS
 
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
@@ -68,7 +68,7 @@ public:
     explicit CTxIn(COutPoint prevoutIn, CScript scriptSigIn=CScript(), uint32_t nSequenceIn=std::numeric_limits<unsigned int>::max());
     CTxIn(uint256 hashPrevTx, uint32_t nOut, CScript scriptSigIn=CScript(), uint32_t nSequenceIn=std::numeric_limits<uint32_t>::max());
 
-    ADD_SERIALIZE_METHODS;
+    ADD_SERIALIZE_METHODS
 
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
@@ -113,7 +113,7 @@ public:
 
     CTxOut(const CAmount& nValueIn, CScript scriptPubKeyIn);
 
-    ADD_SERIALIZE_METHODS;
+    ADD_SERIALIZE_METHODS
 
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
@@ -195,7 +195,7 @@ public:
 
     CTransaction& operator=(const CTransaction& tx);
 
-    ADD_SERIALIZE_METHODS;
+    ADD_SERIALIZE_METHODS
 
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
@@ -256,7 +256,7 @@ struct CMutableTransaction
     CMutableTransaction();
     CMutableTransaction(const CTransaction& tx);
 
-    ADD_SERIALIZE_METHODS;
+    ADD_SERIALIZE_METHODS
 
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {

--- a/src/pubkey.cpp
+++ b/src/pubkey.cpp
@@ -16,7 +16,7 @@ bool CPubKey::Verify(const uint256 &hash, const std::vector<unsigned char>& vchS
     if (!IsValid())
         return false;
 #ifdef USE_SECP256K1
-    if (secp256k1_ecdsa_verify((const unsigned char*)&hash, &vchSig[0], static_cast<int>(vchSig.size()), begin(), size()) == 0)
+    if (secp256k1_ecdsa_verify((const unsigned char*)&hash, &vchSig[0], static_cast<int>(vchSig.size()), begin(), size()) != 1)
         return false;
 #else
     CECKey key;

--- a/src/pubkey.cpp
+++ b/src/pubkey.cpp
@@ -5,26 +5,16 @@
 #include "pubkey.h"
 
 #include "eccryptoverify.h"
-
-#ifdef USE_SECP256K1
-#include <secp256k1.h>
-#else
 #include "ecwrapper.h"
-#endif
 
 bool CPubKey::Verify(const uint256 &hash, const std::vector<unsigned char>& vchSig) const {
     if (!IsValid())
         return false;
-#ifdef USE_SECP256K1
-    if (secp256k1_ecdsa_verify((const unsigned char*)&hash, &vchSig[0], static_cast<int>(vchSig.size()), begin(), size()) != 1)
-        return false;
-#else
     CECKey key;
     if (!key.SetPubKey(begin(), size()))
         return false;
     if (!key.Verify(hash, vchSig))
         return false;
-#endif
     return true;
 }
 
@@ -33,52 +23,33 @@ bool CPubKey::RecoverCompact(const uint256 &hash, const std::vector<unsigned cha
         return false;
     int recid = (vchSig[0] - 27) & 3;
     bool fComp = ((vchSig[0] - 27) & 4) != 0;
-#ifdef USE_SECP256K1
-    int pubkeylen = 65;
-    if (secp256k1_ecdsa_recover_compact((const unsigned char*)&hash, &vchSig[1], (unsigned char*)begin(), &pubkeylen, fComp, recid) == 0)
-        return false;
-    assert((int)size() == pubkeylen);
-#else
     CECKey key;
     if (!key.Recover(hash, &vchSig[1], recid))
         return false;
     std::vector<unsigned char> pubkey;
     key.GetPubKey(pubkey, fComp);
     Set(pubkey.begin(), pubkey.end());
-#endif
     return true;
 }
 
 bool CPubKey::IsFullyValid() const {
     if (!IsValid())
         return false;
-#ifdef USE_SECP256K1
-    if (secp256k1_ec_pubkey_verify(begin(), size()) == 0)
-        return false;
-#else
     CECKey key;
     if (!key.SetPubKey(begin(), size()))
         return false;
-#endif
     return true;
 }
 
 bool CPubKey::Decompress() {
     if (!IsValid())
         return false;
-#ifdef USE_SECP256K1
-    int clen = size();
-    if (secp256k1_ec_pubkey_decompress((unsigned char*)begin(), &clen) == 0)
-        return false;
-    assert(clen == (int)size());
-#else
     CECKey key;
     if (!key.SetPubKey(begin(), size()))
         return false;
     std::vector<unsigned char> pubkey;
     key.GetPubKey(pubkey, false);
     Set(pubkey.begin(), pubkey.end());
-#endif
     return true;
 }
 
@@ -89,17 +60,12 @@ bool CPubKey::Derive(CPubKey& pubkeyChild, unsigned char ccChild[32], unsigned i
     unsigned char out[64];
     BIP32Hash(cc, nChild, *begin(), begin()+1, out);
     memcpy(ccChild, out+32, 32);
-#ifdef USE_SECP256K1
-    pubkeyChild = *this;
-    bool ret = secp256k1_ec_pubkey_tweak_add((unsigned char*)pubkeyChild.begin(), pubkeyChild.size(), out) != 0;
-#else
     CECKey key;
     bool ret = key.SetPubKey(begin(), size());
     ret &= key.TweakPublic(out);
     std::vector<unsigned char> pubkey;
     key.GetPubKey(pubkey, true);
     pubkeyChild.Set(pubkey.begin(), pubkey.end());
-#endif
     return ret;
 }
 

--- a/src/pubkey.h
+++ b/src/pubkey.h
@@ -112,19 +112,19 @@ public:
     }
 
     //! Implement serialization, as if this was a byte vector.
-    unsigned int GetSerializeSize(int nType, int nVersion) const
+    unsigned int GetSerializeSize(int, int) const
     {
         return size() + 1;
     }
     template <typename Stream>
-    void Serialize(Stream& s, int nType, int nVersion) const
+    void Serialize(Stream& s, int, int) const
     {
         unsigned int len = size();
         ::WriteCompactSize(s, len);
         s.write((char*)vch, len);
     }
     template <typename Stream>
-    void Unserialize(Stream& s, int nType, int nVersion)
+    void Unserialize(Stream& s, int, int)
     {
         unsigned int len = ::ReadCompactSize(s);
         if (len <= 65) {

--- a/src/script/bitcoinconsensus.h
+++ b/src/script/bitcoinconsensus.h
@@ -19,7 +19,7 @@
   #elif defined(HAVE_FUNC_ATTRIBUTE_VISIBILITY)
     #define EXPORT_SYMBOL __attribute__ ((visibility ("default")))
   #endif
-#elif defined(MSC_VER) && !defined(STATIC_LIBBITCOINCONSENSUS)
+#elif defined(_MSC_VER) && !defined(STATIC_LIBBITCOINCONSENSUS)
   #define EXPORT_SYMBOL __declspec(dllimport)
 #endif
 

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -1017,12 +1017,12 @@ public:
         // Serialize nVersion
         ::Serialize(s, txTo.nVersion, nType, nVersion);
         // Serialize vin
-        unsigned int nInputs = fAnyoneCanPay ? 1 : txTo.vin.size();
+        unsigned int nInputs = fAnyoneCanPay ? 1u : static_cast<unsigned int>(txTo.vin.size());
         ::WriteCompactSize(s, nInputs);
         for (unsigned int nInput = 0; nInput < nInputs; nInput++)
              SerializeInput(s, nInput, nType, nVersion);
         // Serialize vout
-        unsigned int nOutputs = fHashNone ? 0 : (fHashSingle ? nIn+1 : txTo.vout.size());
+        unsigned int nOutputs = fHashNone ? 0 : (fHashSingle ? nIn+1u : static_cast<unsigned int>(txTo.vout.size()));
         ::WriteCompactSize(s, nOutputs);
         for (unsigned int nOutput = 0; nOutput < nOutputs; nOutput++)
              SerializeOutput(s, nOutput, nType, nVersion);

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -958,7 +958,7 @@ public:
 
     /** Serialize the passed scriptCode, skipping OP_CODESEPARATORs */
     template<typename S>
-    void SerializeScriptCode(S &s, int nType, int nVersion) const {
+    void SerializeScriptCode(S &s, int, int) const {
         CScript::const_iterator it = scriptCode.begin();
         CScript::const_iterator itBegin = it;
         opcodetype opcode;

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -24,7 +24,7 @@ enum
     SIGHASH_ALL = 1,
     SIGHASH_NONE = 2,
     SIGHASH_SINGLE = 3,
-    SIGHASH_ANYONECANPAY = 0x80,
+    SIGHASH_ANYONECANPAY = 0x80
 };
 
 /** Script verification flags */
@@ -75,7 +75,7 @@ enum
     // "Exactly one stack element must remain, and when interpreted as a boolean, it must be true".
     // (softfork safe, BIP62 rule 6)
     // Note: CLEANSTACK should never be used without P2SH.
-    SCRIPT_VERIFY_CLEANSTACK = (1U << 8),
+    SCRIPT_VERIFY_CLEANSTACK = (1U << 8)
 };
 
 uint256 SignatureHash(const CScript &scriptCode, const CTransaction& txTo, unsigned int nIn, int nHashType);

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -83,7 +83,7 @@ uint256 SignatureHash(const CScript &scriptCode, const CTransaction& txTo, unsig
 class BaseSignatureChecker
 {
 public:
-    virtual bool CheckSig(const std::vector<unsigned char>& scriptSig, const std::vector<unsigned char>& vchPubKey, const CScript& scriptCode) const
+    virtual bool CheckSig(const std::vector<unsigned char>&, const std::vector<unsigned char>&, const CScript&) const
     {
         return false;
     }

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -166,7 +166,7 @@ enum opcodetype
     OP_PUBKEYHASH = 0xfd,
     OP_PUBKEY = 0xfe,
 
-    OP_INVALIDOPCODE = 0xff,
+    OP_INVALIDOPCODE = 0xff
 };
 
 const char* GetOpName(opcodetype opcode);

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -429,7 +429,7 @@ public:
         return *this;
     }
 
-    CScript& operator<<(const CScript& b)
+    CScript& operator<<(const CScript&)
     {
         // I'm not sure if this should push the script or concatenate scripts.
         // If there's ever a use for pushing a script onto a script, delete this member fn

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -276,7 +276,7 @@ public:
             return std::numeric_limits<int>::max();
         else if (m_value < std::numeric_limits<int>::min())
             return std::numeric_limits<int>::min();
-        return m_value;
+        return static_cast<int>(m_value);
     }
 
     std::vector<unsigned char> getvch() const
@@ -348,7 +348,7 @@ protected:
     {
         if (n == -1 || (n >= 1 && n <= 16))
         {
-            push_back(n + (OP_1 - 1));
+            push_back(static_cast<unsigned char>(n + (OP_1 - 1)));
         }
         else if (n == 0)
         {
@@ -416,13 +416,13 @@ public:
         else if (b.size() <= 0xffff)
         {
             insert(end(), OP_PUSHDATA2);
-            unsigned short nSize = b.size();
+            unsigned short nSize = static_cast<unsigned short>(b.size());
             insert(end(), (unsigned char*)&nSize, (unsigned char*)&nSize + sizeof(nSize));
         }
         else
         {
             insert(end(), OP_PUSHDATA4);
-            unsigned int nSize = b.size();
+            unsigned int nSize = static_cast<unsigned int>(b.size());
             insert(end(), (unsigned char*)&nSize, (unsigned char*)&nSize + sizeof(nSize));
         }
         insert(end(), b.begin(), b.end());
@@ -543,7 +543,7 @@ public:
         opcodetype opcode;
         do
         {
-            while (end() - pc >= (long)b.size() && memcmp(&pc[0], &b[0], b.size()) == 0)
+            while (end() - pc >= static_cast<long>(b.size()) && memcmp(&pc[0], &b[0], b.size()) == 0)
             {
                 pc = erase(pc, pc + b.size());
                 ++nFound;

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -82,7 +82,7 @@ enum
     // primary actions
     SER_NETWORK         = (1 << 0),
     SER_DISK            = (1 << 1),
-    SER_GETHASH         = (1 << 2),
+    SER_GETHASH         = (1 << 2)
 };
 
 #define READWRITE(obj)      (::SerReadWrite(s, (obj), nType, nVersion, ser_action))

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -187,20 +187,20 @@ void WriteCompactSize(Stream& os, uint64_t nSize)
 {
     if (nSize < 253)
     {
-        unsigned char chSize = nSize;
+        unsigned char chSize = static_cast<unsigned char>(nSize);
         WRITEDATA(os, chSize);
     }
     else if (nSize <= std::numeric_limits<unsigned short>::max())
     {
         unsigned char chSize = 253;
-        unsigned short xSize = nSize;
+        unsigned short xSize = static_cast<unsigned short>(nSize);
         WRITEDATA(os, chSize);
         WRITEDATA(os, xSize);
     }
     else if (nSize <= std::numeric_limits<unsigned int>::max())
     {
         unsigned char chSize = 254;
-        unsigned int xSize = nSize;
+        unsigned int xSize = static_cast<unsigned short>(nSize);
         WRITEDATA(os, chSize);
         WRITEDATA(os, xSize);
     }
@@ -349,7 +349,7 @@ public:
 
     unsigned int GetSerializeSize(int, int=0) const
     {
-        return pend - pbegin;
+        return static_cast<unsigned int>(pend - pbegin);
     }
 
     template<typename Stream>
@@ -491,7 +491,7 @@ template<typename Stream, typename K, typename Pred, typename A> void Unserializ
 template<typename T>
 inline unsigned int GetSerializeSize(const T& a, long nType, int nVersion)
 {
-    return a.GetSerializeSize((int)nType, nVersion);
+    return static_cast<unsigned int>(a.GetSerializeSize((int)nType, nVersion));
 }
 
 template<typename Stream, typename T>
@@ -542,9 +542,9 @@ void Unserialize(Stream& is, std::basic_string<C>& str, int, int)
  * vector
  */
 template<typename T, typename A>
-unsigned int GetSerializeSize_impl(const std::vector<T, A>& v, int nType, int nVersion, const unsigned char&)
+unsigned int GetSerializeSize_impl(const std::vector<T, A>& v, int, int, const unsigned char&)
 {
-    return (GetSizeOfCompactSize(v.size()) + v.size() * sizeof(T));
+    return (static_cast<unsigned int>(GetSizeOfCompactSize(v.size()) + v.size() * sizeof(T)));
 }
 
 template<typename T, typename A, typename V>
@@ -591,7 +591,7 @@ void Unserialize_impl(Stream& is, std::vector<T, A>& v, int nType, int nVersion,
 {
     // Limit size per read so bogus size value won't cause out of memory
     v.clear();
-    unsigned int nSize = ReadCompactSize(is);
+    unsigned int nSize = static_cast<unsigned int>(ReadCompactSize(is));
     unsigned int i = 0;
     while (i < nSize)
     {
@@ -606,7 +606,7 @@ template<typename Stream, typename T, typename A, typename V>
 void Unserialize_impl(Stream& is, std::vector<T, A>& v, int nType, int nVersion, const V&)
 {
     v.clear();
-    unsigned int nSize = ReadCompactSize(is);
+    unsigned int nSize = static_cast<unsigned int>(ReadCompactSize(is));
     unsigned int i = 0;
     unsigned int nMid = 0;
     while (nMid < nSize)

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -90,10 +90,10 @@ enum
 /** 
  * Implement three methods for serializable objects. These are actually wrappers over
  * "SerializationOp" template, which implements the body of each class' serialization
- * code. Adding "ADD_SERIALIZE_METHODS" in the body of the class causes these wrappers to be
- * added as members. 
+ * code. Adding "ADD_SERIALIZE_METHODS" in the body of the class causes these wrappers
+ * to be added as members. 
  */
-#define ADD_SERIALIZE_METHODS                                                          \
+#define ADD_SERIALIZE_METHODS                                                        \
     size_t GetSerializeSize(int nType, int nVersion) const {                         \
         CSizeComputer s(nType, nVersion);                                            \
         NCONST_PTR(this)->SerializationOp(s, CSerActionSerialize(), nType, nVersion);\
@@ -158,7 +158,7 @@ template<typename Stream> inline void Unserialize(Stream& s, unsigned long long&
 template<typename Stream> inline void Unserialize(Stream& s, float& a,              int, int=0) { READDATA(s, a); }
 template<typename Stream> inline void Unserialize(Stream& s, double& a,             int, int=0) { READDATA(s, a); }
 
-inline unsigned int GetSerializeSize(bool a, int, int=0)                          { return sizeof(char); }
+inline unsigned int GetSerializeSize(bool, int, int=0)                            { return sizeof(char); }
 template<typename Stream> inline void Serialize(Stream& s, bool a, int, int=0)    { char f=a; WRITEDATA(s, f); }
 template<typename Stream> inline void Unserialize(Stream& s, bool& a, int, int=0) { char f; READDATA(s, f); a=f; }
 
@@ -564,7 +564,7 @@ inline unsigned int GetSerializeSize(const std::vector<T, A>& v, int nType, int 
 
 
 template<typename Stream, typename T, typename A>
-void Serialize_impl(Stream& os, const std::vector<T, A>& v, int nType, int nVersion, const unsigned char&)
+void Serialize_impl(Stream& os, const std::vector<T, A>& v, int, int, const unsigned char&)
 {
     WriteCompactSize(os, v.size());
     if (!v.empty())
@@ -587,7 +587,7 @@ inline void Serialize(Stream& os, const std::vector<T, A>& v, int nType, int nVe
 
 
 template<typename Stream, typename T, typename A>
-void Unserialize_impl(Stream& is, std::vector<T, A>& v, int nType, int nVersion, const unsigned char&)
+void Unserialize_impl(Stream& is, std::vector<T, A>& v, int, int, const unsigned char&)
 {
     // Limit size per read so bogus size value won't cause out of memory
     v.clear();
@@ -760,13 +760,13 @@ struct CSerActionUnserialize
 };
 
 template<typename Stream, typename T>
-inline void SerReadWrite(Stream& s, const T& obj, int nType, int nVersion, CSerActionSerialize ser_action)
+inline void SerReadWrite(Stream& s, const T& obj, int nType, int nVersion, CSerActionSerialize)
 {
     ::Serialize(s, obj, nType, nVersion);
 }
 
 template<typename Stream, typename T>
-inline void SerReadWrite(Stream& s, T& obj, int nType, int nVersion, CSerActionUnserialize ser_action)
+inline void SerReadWrite(Stream& s, T& obj, int nType, int nVersion, CSerActionUnserialize)
 {
     ::Unserialize(s, obj, nType, nVersion);
 }
@@ -790,7 +790,7 @@ public:
 
     CSizeComputer(int nTypeIn, int nVersionIn) : nSize(0), nType(nTypeIn), nVersion(nVersionIn) {}
 
-    CSizeComputer& write(const char *psz, size_t nSize)
+    CSizeComputer& write(const char *, size_t nSize)
     {
         this->nSize += nSize;
         return *this;

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -200,7 +200,7 @@ void WriteCompactSize(Stream& os, uint64_t nSize)
     else if (nSize <= std::numeric_limits<unsigned int>::max())
     {
         unsigned char chSize = 254;
-        unsigned int xSize = static_cast<unsigned short>(nSize);
+        unsigned int xSize = static_cast<unsigned int>(nSize);
         WRITEDATA(os, chSize);
         WRITEDATA(os, xSize);
     }

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -75,19 +75,19 @@ public:
         return sizeof(data);
     }
 
-    unsigned int GetSerializeSize(int nType, int nVersion) const
+    unsigned int GetSerializeSize(int, int) const
     {
         return sizeof(data);
     }
 
     template<typename Stream>
-    void Serialize(Stream& s, int nType, int nVersion) const
+    void Serialize(Stream& s, int, int) const
     {
         s.write((char*)data, sizeof(data));
     }
 
     template<typename Stream>
-    void Unserialize(Stream& s, int nType, int nVersion)
+    void Unserialize(Stream& s, int, int)
     {
         s.read((char*)data, sizeof(data));
     }


### PR DESCRIPTION
These changes are limited to issues affecting the consensus library build. As a library intended for developer use it should build cleanly on all intended platforms. These changes should not have any effect on execution.
