### PR TITLE
Remove obsolete pubsub method definitions

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -570,9 +570,6 @@ public:
         }
     }
 
-    bool IsSubscribed(unsigned int nChannel);
-    void Subscribe(unsigned int nChannel, unsigned int nHops=0);
-    void CancelSubscribe(unsigned int nChannel);
     void CloseSocketDisconnect();
 
     // Denial-of-service detection/prevention


### PR DESCRIPTION
Their code was removed in #1036, 2.5 years ago.
