### PR TITLE
In Windows, attempt to use CreateProcess to launch [block|wallet|alert] notifications

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -723,7 +723,7 @@ void runCommand(std::string strCommand)
     else
     {
         // CreateProcess failed.
-        nErr = -1;
+        nErr = ::system(strCommand.c_str());
     }
 #else
     nErr = ::system(strCommand.c_str());


### PR DESCRIPTION
Motivation: In Windows, ::system() causes a terminal console window to pop up. This window grabs the focus away from the user, an irritating interruption to workflow.

Solution: Attempt to use CreateProcess() first. If this doesn't work for any reason, fall back to the previous solution and call ::system().
