### PR TITLE
Optimize block validation code and block propagation speed

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -68,6 +68,7 @@ BITCOIN_TESTS =\
   test/test_bitcoin.h \
   test/timedata_tests.cpp \
   test/transaction_tests.cpp \
+  test/txvalidationcache_tests.cpp \
   test/uint256_tests.cpp \
   test/univalue_tests.cpp \
   test/util_tests.cpp

--- a/src/limitedmap.h
+++ b/src/limitedmap.h
@@ -38,11 +38,11 @@ public:
     {
         std::pair<iterator, bool> ret = map.insert(x);
         if (ret.second) {
-            if (nMaxSize && map.size() == nMaxSize) {
+            rmap.insert(make_pair(x.second, ret.first));
+            if (nMaxSize && map.size() > nMaxSize) {
                 map.erase(rmap.begin()->second);
                 rmap.erase(rmap.begin());
             }
-            rmap.insert(make_pair(x.second, ret.first));
         }
         return;
     }

--- a/src/test/README.md
+++ b/src/test/README.md
@@ -19,3 +19,15 @@ uint256_tests.cpp.
 For further reading, I found the following website to be helpful in
 explaining how the boost unit test framework works:
 [http://www.alittlemadness.com/2009/03/31/c-unit-testing-with-boosttest/](http://www.alittlemadness.com/2009/03/31/c-unit-testing-with-boosttest/).
+
+test_bitcoin has some built-in command-line arguments; for
+example, to run just the getarg_tests verbosely:
+
+    test_bitcoin --log_level=all --run_test=getarg_tests
+
+... or to run just the doubledash test:
+
+    test_bitcoin --run_test=getarg_tests/doubledash
+
+Run  test_bitcoin --help   for the full list.
+

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -105,7 +105,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     {
         tx.vout[0].nValue -= 1000000;
         hash = tx.GetHash();
-        mempool.addUnchecked(hash, CTxMemPoolEntry(tx, 11, GetTime(), 111.0, 11));
+        mempool.addUnchecked(hash, CTxMemPoolEntry(tx, 11, GetTime(), 111.0, 11, STANDARD_SCRIPT_VERIFY_FLAGS));
         tx.vin[0].prevout.hash = hash;
     }
     BOOST_CHECK(pblocktemplate = CreateNewBlock(scriptPubKey));
@@ -125,7 +125,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     {
         tx.vout[0].nValue -= 10000000;
         hash = tx.GetHash();
-        mempool.addUnchecked(hash, CTxMemPoolEntry(tx, 11, GetTime(), 111.0, 11));
+        mempool.addUnchecked(hash, CTxMemPoolEntry(tx, 11, GetTime(), 111.0, 11, STANDARD_SCRIPT_VERIFY_FLAGS));
         tx.vin[0].prevout.hash = hash;
     }
     BOOST_CHECK(pblocktemplate = CreateNewBlock(scriptPubKey));
@@ -134,7 +134,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
 
     // orphan in mempool
     hash = tx.GetHash();
-    mempool.addUnchecked(hash, CTxMemPoolEntry(tx, 11, GetTime(), 111.0, 11));
+    mempool.addUnchecked(hash, CTxMemPoolEntry(tx, 11, GetTime(), 111.0, 11, STANDARD_SCRIPT_VERIFY_FLAGS));
     BOOST_CHECK(pblocktemplate = CreateNewBlock(scriptPubKey));
     delete pblocktemplate;
     mempool.clear();
@@ -144,7 +144,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     tx.vin[0].prevout.hash = txFirst[1]->GetHash();
     tx.vout[0].nValue = 4900000000LL;
     hash = tx.GetHash();
-    mempool.addUnchecked(hash, CTxMemPoolEntry(tx, 11, GetTime(), 111.0, 11));
+    mempool.addUnchecked(hash, CTxMemPoolEntry(tx, 11, GetTime(), 111.0, 11, STANDARD_SCRIPT_VERIFY_FLAGS));
     tx.vin[0].prevout.hash = hash;
     tx.vin.resize(2);
     tx.vin[1].scriptSig = CScript() << OP_1;
@@ -152,7 +152,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     tx.vin[1].prevout.n = 0;
     tx.vout[0].nValue = 5900000000LL;
     hash = tx.GetHash();
-    mempool.addUnchecked(hash, CTxMemPoolEntry(tx, 11, GetTime(), 111.0, 11));
+    mempool.addUnchecked(hash, CTxMemPoolEntry(tx, 11, GetTime(), 111.0, 11, STANDARD_SCRIPT_VERIFY_FLAGS));
     BOOST_CHECK(pblocktemplate = CreateNewBlock(scriptPubKey));
     delete pblocktemplate;
     mempool.clear();
@@ -163,7 +163,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     tx.vin[0].scriptSig = CScript() << OP_0 << OP_1;
     tx.vout[0].nValue = 0;
     hash = tx.GetHash();
-    mempool.addUnchecked(hash, CTxMemPoolEntry(tx, 11, GetTime(), 111.0, 11));
+    mempool.addUnchecked(hash, CTxMemPoolEntry(tx, 11, GetTime(), 111.0, 11, STANDARD_SCRIPT_VERIFY_FLAGS));
     BOOST_CHECK(pblocktemplate = CreateNewBlock(scriptPubKey));
     delete pblocktemplate;
     mempool.clear();
@@ -176,12 +176,12 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     script = CScript() << OP_0;
     tx.vout[0].scriptPubKey = GetScriptForDestination(CScriptID(script));
     hash = tx.GetHash();
-    mempool.addUnchecked(hash, CTxMemPoolEntry(tx, 11, GetTime(), 111.0, 11));
+    mempool.addUnchecked(hash, CTxMemPoolEntry(tx, 11, GetTime(), 111.0, 11, STANDARD_SCRIPT_VERIFY_FLAGS));
     tx.vin[0].prevout.hash = hash;
     tx.vin[0].scriptSig = CScript() << (std::vector<unsigned char>)script;
     tx.vout[0].nValue -= 1000000;
     hash = tx.GetHash();
-    mempool.addUnchecked(hash, CTxMemPoolEntry(tx, 11, GetTime(), 111.0, 11));
+    mempool.addUnchecked(hash, CTxMemPoolEntry(tx, 11, GetTime(), 111.0, 11, STANDARD_SCRIPT_VERIFY_FLAGS));
     BOOST_CHECK(pblocktemplate = CreateNewBlock(scriptPubKey));
     delete pblocktemplate;
     mempool.clear();
@@ -192,10 +192,10 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     tx.vout[0].nValue = 4900000000LL;
     tx.vout[0].scriptPubKey = CScript() << OP_1;
     hash = tx.GetHash();
-    mempool.addUnchecked(hash, CTxMemPoolEntry(tx, 11, GetTime(), 111.0, 11));
+    mempool.addUnchecked(hash, CTxMemPoolEntry(tx, 11, GetTime(), 111.0, 11, STANDARD_SCRIPT_VERIFY_FLAGS));
     tx.vout[0].scriptPubKey = CScript() << OP_2;
     hash = tx.GetHash();
-    mempool.addUnchecked(hash, CTxMemPoolEntry(tx, 11, GetTime(), 111.0, 11));
+    mempool.addUnchecked(hash, CTxMemPoolEntry(tx, 11, GetTime(), 111.0, 11, STANDARD_SCRIPT_VERIFY_FLAGS));
     BOOST_CHECK(pblocktemplate = CreateNewBlock(scriptPubKey));
     delete pblocktemplate;
     mempool.clear();
@@ -221,7 +221,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     tx.vout[0].scriptPubKey = CScript() << OP_1;
     tx.nLockTime = chainActive.Tip()->nHeight+1;
     hash = tx.GetHash();
-    mempool.addUnchecked(hash, CTxMemPoolEntry(tx, 11, GetTime(), 111.0, 11));
+    mempool.addUnchecked(hash, CTxMemPoolEntry(tx, 11, GetTime(), 111.0, 11, STANDARD_SCRIPT_VERIFY_FLAGS));
     BOOST_CHECK(!IsFinalTx(tx, chainActive.Tip()->nHeight + 1));
 
     // time locked
@@ -235,7 +235,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     tx2.vout[0].scriptPubKey = CScript() << OP_1;
     tx2.nLockTime = chainActive.Tip()->GetMedianTimePast()+1;
     hash = tx2.GetHash();
-    mempool.addUnchecked(hash, CTxMemPoolEntry(tx2, 11, GetTime(), 111.0, 11));
+    mempool.addUnchecked(hash, CTxMemPoolEntry(tx2, 11, GetTime(), 111.0, 11, STANDARD_SCRIPT_VERIFY_FLAGS));
     BOOST_CHECK(!IsFinalTx(tx2));
 
     BOOST_CHECK(pblocktemplate = CreateNewBlock(scriptPubKey));

--- a/src/test/test_bitcoin.h
+++ b/src/test/test_bitcoin.h
@@ -1,18 +1,53 @@
 #ifndef BITCOIN_TEST_TEST_BITCOIN_H
 #define BITCOIN_TEST_TEST_BITCOIN_H
 
+#include "key.h"
 #include "txdb.h"
 
 #include <boost/filesystem.hpp>
 #include <boost/thread.hpp>
 
+#include <vector>
+
+//
+// Testing fixture for unit tests that need
+// a UNITTEST block chain.
+//
 struct TestingSetup {
+public:
+    TestingSetup();
+    TestingSetup(CBaseChainParams::Network network);
+    ~TestingSetup();
+
+protected:
+    void Init(CBaseChainParams::Network network);
+
+private:
     CCoinsViewDB *pcoinsdbview;
     boost::filesystem::path pathTemp;
     boost::thread_group threadGroup;
+};
 
-    TestingSetup();
-    ~TestingSetup();
+class CBlock;
+struct CMutableTransaction;
+class CScript;
+
+//
+// Testing fixture that pre-creates a
+// 100-block REGTEST-mode block chain
+//
+struct TestChain100Setup : public TestingSetup {
+    TestChain100Setup();
+
+    // Create a new block with just given transactions, coinbase paying to
+    // scriptPubKey, and try to add it to the current chain.
+    CBlock CreateAndProcessBlock(const std::vector<CMutableTransaction>& txns,
+                                 const CScript& scriptPubKey);
+
+    ~TestChain100Setup();
+
+    std::vector<CTransaction> coinbaseTxns; // For convenience, coinbase transactions
+    CKey coinbaseKey; // private/public key needed to spend coinbase transactions
 };
 
 #endif

--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -1,0 +1,56 @@
+// Copyright (c) 2011-2014 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "txmempool.h"
+#include "random.h"
+#include "script/standard.h"
+#include "utiltime.h"
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_SUITE(tx_validationcache_tests)
+
+BOOST_AUTO_TEST_CASE(tx_validationcache)
+{
+    // Start with an empty memory pool
+    CTxMemPool pool(CFeeRate(0));
+
+    // Create eleven transactions, add five of them to the pool:
+    CMutableTransaction txs[11];
+    for (int i = 0; i < 11; i++)
+    {
+        txs[i].vin.resize(1);
+        txs[i].vin[0].scriptSig = CScript() << OP_11;
+        txs[i].vin[0].prevout.hash = GetRandHash();
+        txs[i].vin[0].prevout.n = 0;
+        txs[i].vout.resize(1);
+        txs[i].vout[0].nValue = 5000000000LL;
+        txs[i].vout[0].scriptPubKey = CScript() << OP_EQUAL;
+        if (i < 5)
+            pool.addUnchecked(txs[i].GetHash(),
+                                 CTxMemPoolEntry(txs[i], 11, GetTime(), 111.0, 11, STANDARD_SCRIPT_VERIFY_FLAGS));
+    }
+
+    unsigned int nHits[3] = { 0, 0, 0 }; // Test three different sets of flags
+    for (int i = 0; i < 11; i++)
+    {
+        uint256 txid = txs[i].GetHash();
+        if (pool.validated(txid, STANDARD_SCRIPT_VERIFY_FLAGS)) ++nHits[0];
+        if (pool.validated(txid, SCRIPT_VERIFY_NONE)) ++nHits[1];
+        if (pool.validated(txid, SCRIPT_VERIFY_P2SH)) ++nHits[2];
+    }
+    BOOST_CHECK_EQUAL(nHits[0], 5);
+    BOOST_CHECK_EQUAL(nHits[1], 5);
+    BOOST_CHECK_EQUAL(nHits[2], 5);
+
+    // Add txs[5] with less-strict validation flag, and
+    // make sure validation caching code Does The Right Thing:
+    pool.addUnchecked(txs[5].GetHash(),
+                         CTxMemPoolEntry(txs[5], 11, GetTime(), 111.0, 11, SCRIPT_VERIFY_P2SH));
+
+    BOOST_CHECK(!pool.validated(txs[5].GetHash(), STANDARD_SCRIPT_VERIFY_FLAGS));
+    BOOST_CHECK(pool.validated(txs[5].GetHash(), SCRIPT_VERIFY_NONE));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -2,9 +2,14 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include "key.h"
+#include "main.h"
+#include "miner.h"
+#include "pubkey.h"
 #include "txmempool.h"
 #include "random.h"
 #include "script/standard.h"
+#include "test/test_bitcoin.h"
 #include "utiltime.h"
 
 #include <boost/test/unit_test.hpp>
@@ -51,6 +56,73 @@ BOOST_AUTO_TEST_CASE(tx_validationcache)
 
     BOOST_CHECK(!pool.validated(txs[5].GetHash(), STANDARD_SCRIPT_VERIFY_FLAGS));
     BOOST_CHECK(pool.validated(txs[5].GetHash(), SCRIPT_VERIFY_NONE));
+}
+
+static bool
+ToMemPool(CMutableTransaction& tx)
+{
+    LOCK(cs_main);
+
+    CValidationState state;
+    return AcceptToMemoryPool(mempool, state, tx, false, NULL, false);
+}
+
+BOOST_FIXTURE_TEST_CASE(tx_mempool_block_doublespend, TestChain100Setup)
+{
+    // Make sure skipping validation of transctions that were
+    // validated going into the memory pool does not allow
+    // double-spends in blocks to pass validation when they should not.
+    unsigned int startingHeight = chainActive.Height();
+
+    CScript scriptPubKey = CScript() <<  ToByteVector(coinbaseKey.GetPubKey()) << OP_CHECKSIG;
+
+    // Create a double-spend of mature coinbase txn:
+    std::vector<CMutableTransaction> spends;
+    spends.resize(2);
+    for (int i = 0; i < 2; i++)
+    {
+        spends[i].vin.resize(1);
+        spends[i].vin[0].prevout.hash = coinbaseTxns[0].GetHash();
+        spends[i].vin[0].prevout.n = 0;
+        spends[i].vout.resize(1);
+        spends[i].vout[0].nValue = 11*CENT;
+        spends[i].vout[0].scriptPubKey = scriptPubKey;
+
+        // Sign:
+        std::vector<unsigned char> vchSig;
+        uint256 hash = SignatureHash(scriptPubKey, spends[i], 0, SIGHASH_ALL);
+        BOOST_CHECK(coinbaseKey.Sign(hash, vchSig));
+        vchSig.push_back((unsigned char)SIGHASH_ALL);
+        spends[i].vin[0].scriptSig << vchSig;
+    }
+
+    CBlock block;
+
+    // Test 1: block with both of those transactions should be rejected.
+    block = CreateAndProcessBlock(spends, scriptPubKey);
+    BOOST_CHECK(chainActive.Tip()->GetBlockHash() != block.GetHash());
+
+    // Test 2: ... and should be rejected if spend1 is in the memory pool
+    BOOST_CHECK(ToMemPool(spends[0]));
+    block = CreateAndProcessBlock(spends, scriptPubKey);
+    BOOST_CHECK(chainActive.Tip()->GetBlockHash() != block.GetHash());
+    mempool.clear();
+
+    // Test 3: ... and should be rejected if spend2 is in the memory pool
+    BOOST_CHECK(ToMemPool(spends[1]));
+    block = CreateAndProcessBlock(spends, scriptPubKey);
+    BOOST_CHECK(chainActive.Tip()->GetBlockHash() != block.GetHash());
+    mempool.clear();
+
+    // Final sanity test: first spend in mempool, second in block, that's OK:
+    std::vector<CMutableTransaction> oneSpend;
+    oneSpend.push_back(spends[0]);
+    BOOST_CHECK(ToMemPool(spends[1]));
+    block = CreateAndProcessBlock(oneSpend, scriptPubKey);
+    BOOST_CHECK(chainActive.Tip()->GetBlockHash() == block.GetHash());
+    // spends[1] should have been removed from the mempool when the
+    // block with spends[0] is accepted:
+    BOOST_CHECK_EQUAL(mempool.size(), 0);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -24,8 +24,9 @@ CTxMemPoolEntry::CTxMemPoolEntry():
 
 CTxMemPoolEntry::CTxMemPoolEntry(const CTransaction& _tx, const CAmount& _nFee,
                                  int64_t _nTime, double _dPriority,
-                                 unsigned int _nHeight):
-    tx(_tx), nFee(_nFee), nTime(_nTime), dPriority(_dPriority), nHeight(_nHeight)
+                                 unsigned int _nHeight, unsigned int _flags):
+    tx(_tx), nFee(_nFee), nTime(_nTime), dPriority(_dPriority), nHeight(_nHeight),
+    validationFlags(_flags)
 {
     nTxSize = ::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION);
 
@@ -635,6 +636,15 @@ bool CTxMemPool::lookup(uint256 hash, CTransaction& result) const
     if (i == mapTx.end()) return false;
     result = i->second.GetTx();
     return true;
+}
+
+bool CTxMemPool::validated(const uint256& hash, unsigned int validationFlags) const
+{
+    LOCK(cs);
+    map<uint256, CTxMemPoolEntry>::const_iterator i = mapTx.find(hash);
+    if (i == mapTx.end()) return false;
+    unsigned int prevFlags = i->second.GetValidationFlags();
+    return (prevFlags & validationFlags) == validationFlags;
 }
 
 CFeeRate CTxMemPool::estimateFee(int nBlocks) const

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -43,10 +43,12 @@ private:
     int64_t nTime; //! Local time when entering the mempool
     double dPriority; //! Priority when entering the mempool
     unsigned int nHeight; //! Chain height when entering the mempool
+    unsigned int validationFlags; //! SCRIPT_VERIFY flags tx was validated against
 
 public:
     CTxMemPoolEntry(const CTransaction& _tx, const CAmount& _nFee,
-                    int64_t _nTime, double _dPriority, unsigned int _nHeight);
+                    int64_t _nTime, double _dPriority,
+                    unsigned int _nHeight, unsigned int _flags);
     CTxMemPoolEntry();
     CTxMemPoolEntry(const CTxMemPoolEntry& other);
 
@@ -56,6 +58,7 @@ public:
     size_t GetTxSize() const { return nTxSize; }
     int64_t GetTime() const { return nTime; }
     unsigned int GetHeight() const { return nHeight; }
+    unsigned int GetValidationFlags() const { return validationFlags; }
 };
 
 class CMinerPolicyEstimator;
@@ -146,6 +149,8 @@ public:
     }
 
     bool lookup(uint256 hash, CTransaction& result) const;
+    /** returns true if transaction is in mempool and is valid with respect to validationFlags */
+    bool validated(const uint256& hash, unsigned int validationFlags) const;
 
     /** Estimate fee rate needed to get into the next nBlocks */
     CFeeRate estimateFee(int nBlocks) const;


### PR DESCRIPTION
I was running some benchmarks on 20MB blocks, and was surprised at how long block validation took even when all transactions had already been seen and were in the signature cache.

So I moved caching up from being a low-level signature cache to a high-level "have we already validated this txid."

Benchmark results on a recent 365K block with all transactions already in the memory pool / signature cache:

Old code: (results from running with -debug=bench and hacked code to make sure all txn pre-validated):
      - Verify 1839 txins: 191.66ms (0.104ms/txin)
New code:
    - Verify 1839 txins: 2.06ms (0.001ms/txin)

Extrapolating to full (1MB) blocks, the old code would spend about 600ms CPU time per hop propagating blocks with already-seen transactions, this new code will spend under 10ms.

Memory usage is about 60 times smaller, also:
Old code:  (sizeof(scriptSig)+std::set overhead) \* number of txins  (about 200K for the 365K block)
New code: an extra 4 bytes per transaction in the mempool  (about 3K for the 365K block)

I first wrote this as a standalone CTxValidationCache class, but it is simpler and more efficient to extend the mempool. The second commit in this pull request fixes two bugs in limitedmap I stumbled across when testing that code.

REBASED to keep the old signature cache (see discussion below)
