### PR TITLE
src/key.cpp: fix testsuite with libsecp256k1

### DIFF
--- a/src/key.cpp
+++ b/src/key.cpp
@@ -19,7 +19,7 @@ namespace {
 class CSecp256k1Init {
 public:
     CSecp256k1Init() {
-        secp256k1_start(SECP256K1_START_SIGN);
+        secp256k1_start(SECP256K1_START_SIGN | SECP256K1_START_VERIFY);
     }
     ~CSecp256k1Init() {
         secp256k1_stop();


### PR DESCRIPTION
call secp256k1_start() with SECP256K1_START_VERIFY,
otherwise, CPubKey::Verify() is called, which calls
secp256k1_ecdsa_verify() and aborts on
    DEBUG_CHECK(secp256k1_ecmult_consts != NULL);

because secp256k1_start() didn't call secp256k1_ecmult_start(), which
initializes secp256k1_ecmult_consts.
