### PR TITLE
keys: remove libsecp256k1 verification until it's actually supported

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -849,7 +849,6 @@ AM_CONDITIONAL([USE_LCOV],[test x$use_lcov = xyes])
 AM_CONDITIONAL([USE_COMPARISON_TOOL],[test x$use_comparison_tool != xno])
 AM_CONDITIONAL([USE_COMPARISON_TOOL_REORG_TESTS],[test x$use_comparison_tool_reorg_test != xno])
 AM_CONDITIONAL([GLIBC_BACK_COMPAT],[test x$use_glibc_compat = xyes])
-AM_CONDITIONAL([USE_LIBSECP256K1],[test x$use_libsecp256k1 = xyes])
 
 AC_DEFINE(CLIENT_VERSION_MAJOR, _CLIENT_VERSION_MAJOR, [Major version])
 AC_DEFINE(CLIENT_VERSION_MINOR, _CLIENT_VERSION_MINOR, [Minor version])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -379,9 +379,6 @@ libbitcoinconsensus_la_LDFLAGS = -no-undefined $(RELDFLAGS)
 libbitcoinconsensus_la_LIBADD = $(CRYPTO_LIBS)
 libbitcoinconsensus_la_CPPFLAGS = $(CRYPTO_CFLAGS) -I$(builddir)/obj -DBUILD_BITCOIN_INTERNAL
 
-if USE_LIBSECP256K1
-libbitcoinconsensus_la_LIBADD += secp256k1/libsecp256k1.la
-endif
 endif
 #
 

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -208,11 +208,9 @@ void CExtKey::Decode(const unsigned char code[74]) {
 }
 
 bool ECC_InitSanityCheck() {
-#if !defined(USE_SECP256K1)
     if (!CECKey::SanityCheck()) {
         return false;
     }
-#endif
     CKey key;
     key.MakeNewKey(true);
     CPubKey pubkey = key.GetPubKey();

--- a/src/pubkey.cpp
+++ b/src/pubkey.cpp
@@ -6,25 +6,16 @@
 
 #include "eccryptoverify.h"
 
-#ifdef USE_SECP256K1
-#include <secp256k1.h>
-#else
 #include "ecwrapper.h"
-#endif
 
 bool CPubKey::Verify(const uint256 &hash, const std::vector<unsigned char>& vchSig) const {
     if (!IsValid())
         return false;
-#ifdef USE_SECP256K1
-    if (secp256k1_ecdsa_verify((const unsigned char*)&hash, &vchSig[0], vchSig.size(), begin(), size()) != 1)
-        return false;
-#else
     CECKey key;
     if (!key.SetPubKey(begin(), size()))
         return false;
     if (!key.Verify(hash, vchSig))
         return false;
-#endif
     return true;
 }
 
@@ -33,52 +24,33 @@ bool CPubKey::RecoverCompact(const uint256 &hash, const std::vector<unsigned cha
         return false;
     int recid = (vchSig[0] - 27) & 3;
     bool fComp = ((vchSig[0] - 27) & 4) != 0;
-#ifdef USE_SECP256K1
-    int pubkeylen = 65;
-    if (!secp256k1_ecdsa_recover_compact((const unsigned char*)&hash, &vchSig[1], (unsigned char*)begin(), &pubkeylen, fComp, recid))
-        return false;
-    assert((int)size() == pubkeylen);
-#else
     CECKey key;
     if (!key.Recover(hash, &vchSig[1], recid))
         return false;
     std::vector<unsigned char> pubkey;
     key.GetPubKey(pubkey, fComp);
     Set(pubkey.begin(), pubkey.end());
-#endif
     return true;
 }
 
 bool CPubKey::IsFullyValid() const {
     if (!IsValid())
         return false;
-#ifdef USE_SECP256K1
-    if (!secp256k1_ecdsa_pubkey_verify(begin(), size()))
-        return false;
-#else
     CECKey key;
     if (!key.SetPubKey(begin(), size()))
         return false;
-#endif
     return true;
 }
 
 bool CPubKey::Decompress() {
     if (!IsValid())
         return false;
-#ifdef USE_SECP256K1
-    int clen = size();
-    int ret = secp256k1_ecdsa_pubkey_decompress((unsigned char*)begin(), &clen);
-    assert(ret);
-    assert(clen == (int)size());
-#else
     CECKey key;
     if (!key.SetPubKey(begin(), size()))
         return false;
     std::vector<unsigned char> pubkey;
     key.GetPubKey(pubkey, false);
     Set(pubkey.begin(), pubkey.end());
-#endif
     return true;
 }
 
@@ -89,17 +61,12 @@ bool CPubKey::Derive(CPubKey& pubkeyChild, unsigned char ccChild[32], unsigned i
     unsigned char out[64];
     BIP32Hash(cc, nChild, *begin(), begin()+1, out);
     memcpy(ccChild, out+32, 32);
-#ifdef USE_SECP256K1
-    pubkeyChild = *this;
-    bool ret = secp256k1_ecdsa_pubkey_tweak_add((unsigned char*)pubkeyChild.begin(), pubkeyChild.size(), out);
-#else
     CECKey key;
     bool ret = key.SetPubKey(begin(), size());
     ret &= key.TweakPublic(out);
     std::vector<unsigned char> pubkey;
     key.GetPubKey(pubkey, true);
     pubkeyChild.Set(pubkey.begin(), pubkey.end());
-#endif
     return ret;
 }
 


### PR DESCRIPTION
This was added a while ago for testing purposes, but was never intended to be used. Remove it until upstream libsecp256k1 decides that verification is stable/ready.

Because it appears as though it's optional for use, there have been several efforts to clean it up and get it back in working order. See #5837 #5838 #5811 for examples.

Until this is actually intended to be used, remove it to remove the temptation.
