### PR TITLE
Limit message sizes before receiving.

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -523,6 +523,11 @@ bool CNode::ReceiveMsgBytes(const char *pch, unsigned int nBytes)
         if (handled < 0)
                 return false;
 
+        if (msg.in_data && msg.hdr.nMessageSize > MAX_PROTOCOL_MESSAGE_LENGTH) {
+            LogPrint("net", "Oversized message from peer=%i, disconnecting", GetId());
+            return false;
+        }
+
         pch += handled;
         nBytes -= handled;
 

--- a/src/net.h
+++ b/src/net.h
@@ -46,6 +46,8 @@ static const int TIMEOUT_INTERVAL = 20 * 60;
 static const unsigned int MAX_INV_SZ = 50000;
 /** The maximum number of new addresses to accumulate before announcing. */
 static const unsigned int MAX_ADDR_TO_SEND = 1000;
+/** Maximum length of incoming protocol messages (no message over 2 MiB is currently acceptable). */
+static const unsigned int MAX_PROTOCOL_MESSAGE_LENGTH = 2 * 1024 * 1024;
 /** -listen default */
 static const bool DEFAULT_LISTEN = true;
 /** -upnp default */


### PR DESCRIPTION
There is currently no message over 2 MiB that is acceptable anyway, no need to support them inside our network buffers.

This is done by a dispatch mechanism in net, rather than a direct check, to support future modularity (where message handling is split over different modules). It's also required to deal with DoS management correctly (which is done outside of net).

It also doesn't touch serialize.h's MAX_SIZE, as it's a global for all serialization usage, including non-protocol processing.
