### PR TITLE
travis: attempt fix spurious test failures

### DIFF
--- a/qa/pull-tester/run-bitcoind-for-test.sh.in
+++ b/qa/pull-tester/run-bitcoind-for-test.sh.in
@@ -7,10 +7,10 @@ DATADIR="@abs_top_builddir@/.bitcoin"
 rm -rf "$DATADIR"
 mkdir -p "$DATADIR"/regtest
 touch "$DATADIR/regtest/debug.log"
-tail -q -n 1 -F "$DATADIR/regtest/debug.log" | grep -m 1 -q "Done loading" &
+grep -m1 -q 'Done loading' <(tail -F -q "$DATADIR/regtest/debug.log" ) &
 WAITER=$!
 PORT=`expr 10000 + $$ % 55536`
-"@abs_top_builddir@/src/bitcoind@EXEEXT@" -connect=0.0.0.0 -datadir="$DATADIR" -rpcuser=user -rpcpassword=pass -listen -keypool=3 -debug -debug=net -logtimestamps -checkmempool=0 -relaypriority=0 -port=$PORT -whitelist=127.0.0.1 -regtest -rpcport=`expr $PORT + 1` &
+"@abs_top_builddir@/src/bitcoind@EXEEXT@" -discover=0 -datadir="$DATADIR" -rpcuser=user -rpcpassword=pass -listen -keypool=3 -debug -debug=net -logtimestamps -checkmempool=0 -relaypriority=0 -port=$PORT -whitelist=127.0.0.1 -regtest -rpcport=`expr $PORT + 1` &
 BITCOIND=$!
 
 #Install a watchdog.


### PR DESCRIPTION
There have been a few travis failures lately caused by the comparison tool losing its connection to bitcoind. Sample failure here: https://travis-ci.org/bitcoin/bitcoin/jobs/52724160

I believe I've been able to reproduce locally, and these changes fixed the issue I was experiencing.
- don't use -connect=0.0.0.0. This actually causes attempted connections to 0.0.0.0.
- Don't attempt to discover our IP. That's not needed here.
- With those two removed, the timings are changed such that the previous watchdog didn't always work. Use proper tail/grep semantics to ensure that grep always exits quickly.

Before these changes, I was able to locally reproduce a test failure ~10% of the time. After, I'm unable to see a failure.
