### PR TITLE
Install bitcoind into ${prefix}/sbin instead of ${prefix}/bin.

### DIFF
--- a/contrib/debian/bitcoind.install
+++ b/contrib/debian/bitcoind.install
@@ -1,2 +1,2 @@
-usr/local/bin/bitcoind usr/bin
+usr/local/sbin/bitcoind usr/sbin
 usr/local/bin/bitcoin-cli usr/bin

--- a/contrib/init/bitcoind.conf
+++ b/contrib/init/bitcoind.conf
@@ -3,7 +3,7 @@ description "Bitcoin Core Daemon"
 start on runlevel [2345]
 stop on starting rc RUNLEVEL=[016]
 
-env BITCOIND_BIN="/usr/bin/bitcoind"
+env BITCOIND_BIN="/usr/sbin/bitcoind"
 env BITCOIND_USER="bitcoin"
 env BITCOIND_GROUP="bitcoin"
 env BITCOIND_PIDDIR="/var/run/bitcoind"

--- a/contrib/init/bitcoind.openrc
+++ b/contrib/init/bitcoind.openrc
@@ -14,12 +14,12 @@ BITCOIND_PIDFILE=${BITCOIND_PIDFILE:-${BITCOIND_PIDDIR}/bitcoind.pid}
 BITCOIND_DATADIR=${BITCOIND_DATADIR:-${BITCOIND_DEFAULT_DATADIR}}
 BITCOIND_USER=${BITCOIND_USER:-bitcoin}
 BITCOIND_GROUP=${BITCOIND_GROUP:-bitcoin}
-BITCOIND_BIN=${BITCOIND_BIN:-/usr/bin/bitcoind}
+BITCOIND_BIN=${BITCOIND_BIN:-/usr/sbin/bitcoind}
 
 name="Bitcoin Core Daemon"
 description="Bitcoin crypto-currency p2p network daemon"
 
-command="/usr/bin/bitcoind"
+command="/usr/sbin/bitcoind"
 command_args="-pid=\"${BITCOIND_PIDFILE}\" \
 		-conf=\"${BITCOIND_CONFIGFILE}\" \
 		-datadir=\"${BITCOIND_DATADIR}\" \

--- a/contrib/init/bitcoind.openrcconf
+++ b/contrib/init/bitcoind.openrcconf
@@ -17,7 +17,7 @@
 #BITCOIND_GROUP="bitcoin"
 
 # Path to bitcoind executable
-#BITCOIND_BIN="/usr/bin/bitcoind"
+#BITCOIND_BIN="/usr/sbin/bitcoind"
 
 # Nice value to run bitcoind under
 #BITCOIND_NICE=0

--- a/contrib/init/bitcoind.service
+++ b/contrib/init/bitcoind.service
@@ -8,7 +8,7 @@ Group=bitcoin
 
 Type=forking
 PIDFile=/var/lib/bitcoind/bitcoind.pid
-ExecStart=/usr/bin/bitcoind -daemon -pid=/var/lib/bitcoind/bitcoind.pid \
+ExecStart=/usr/sbin/bitcoind -daemon -pid=/var/lib/bitcoind/bitcoind.pid \
 -conf=/etc/bitcoin/bitcoin.conf -datadir=/var/lib/bitcoind -disablewallet
 
 Restart=always

--- a/doc/init.md
+++ b/doc/init.md
@@ -44,7 +44,7 @@ see contrib/debian/examples/bitcoin.conf.
 
 All three configurations assume several paths that might need to be adjusted.
 
-Binary:              /usr/bin/bitcoind
+Binary:              /usr/sbin/bitcoind
 Configuration file:  /etc/bitcoin/bitcoin.conf
 Data directory:      /var/lib/bitcoind
 PID file:            /var/run/bitcoind/bitcoind.pid (OpenRC and Upstart)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -57,10 +57,11 @@ LIBBITCOIN_CONSENSUS=
 endif
 
 bin_PROGRAMS =
+sbin_PROGRAMS =
 TESTS =
 
 if BUILD_BITCOIND
-  bin_PROGRAMS += bitcoind
+  sbin_PROGRAMS += bitcoind
 endif
 
 if BUILD_BITCOIN_UTILS


### PR DESCRIPTION
Install bitcoind into ${prefix}/sbin instead of ${prefix}/bin. bitcoind is a daemon, installing it into .../bin looks strange.
