### PR TITLE
Travis: run unit tests in different orders

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
   global:
     - MAKEJOBS=-j3
     - RUN_TESTS=false
+    - BOOST_TEST_RANDOM=1$TRAVIS_BUILD_ID
     - CCACHE_SIZE=100M
     - CCACHE_TEMPDIR=/tmp/.ccache-temp
     - CCACHE_COMPRESS=1


### PR DESCRIPTION
Set the BOOST_TEST_RANDOM environment variable, to run unit tests in different orders for each test in the test matrix that runs tests.
