### PR TITLE
BUG: array bounds overflow

### DIFF
--- a/src/secp256k1/src/ecmult_gen_impl.h
+++ b/src/secp256k1/src/ecmult_gen_impl.h
@@ -43,7 +43,7 @@ static void secp256k1_ecmult_gen_start(void) {
     /* Construct a group element with no known corresponding scalar (nothing up my sleeve). */
     secp256k1_gej_t nums_gej;
     {
-        static const unsigned char nums_b32[32] = "The scalar for this x is unknown";
+        static const unsigned char nums_b32[32] = "The scalar for the x is unknown";
         secp256k1_fe_t nums_x;
         VERIFY_CHECK(secp256k1_fe_set_b32(&nums_x, nums_b32));
         secp256k1_ge_t nums_ge;


### PR DESCRIPTION
A value of type "const char [33]" cannot be used to initialize an entity of type "const unsigned char [32]"
(C string ends \0 symbol)
