### PR TITLE
test: Revert unittest chain parameters

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -170,7 +170,6 @@ public:
         fAllowMinDifficultyBlocks = false;
         fRequireStandard = true;
         fMineBlocksOnDemand = false;
-        fSkipProofOfWorkCheck = false;
         fTestnetToBeDeprecatedFieldRPC = false;
     }
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -281,50 +281,7 @@ public:
 };
 static CRegTestParams regTestParams;
 
-/**
- * Unit test
- */
-class CUnitTestParams : public CMainParams, public CModifiableParams {
-public:
-    CUnitTestParams() {
-        strNetworkID = "unittest";
-        nDefaultPort = 18445;
-        vFixedSeeds.clear(); //! Unit test mode doesn't have any fixed seeds.
-        vSeeds.clear();  //! Unit test mode doesn't have any DNS seeds.
-
-        fRequireRPCPassword = false;
-        fMiningRequiresPeers = false;
-        fDefaultCheckMemPool = true;
-        fAllowMinDifficultyBlocks = false;
-        fMineBlocksOnDemand = true;
-    }
-
-    const Checkpoints::CCheckpointData& Checkpoints() const 
-    {
-        // UnitTest share the same checkpoints as MAIN
-        return data;
-    }
-
-    //! Published setters to allow changing values in unit test cases
-    virtual void setSubsidyHalvingInterval(int anSubsidyHalvingInterval)  { nSubsidyHalvingInterval=anSubsidyHalvingInterval; }
-    virtual void setEnforceBlockUpgradeMajority(int anEnforceBlockUpgradeMajority)  { nEnforceBlockUpgradeMajority=anEnforceBlockUpgradeMajority; }
-    virtual void setRejectBlockOutdatedMajority(int anRejectBlockOutdatedMajority)  { nRejectBlockOutdatedMajority=anRejectBlockOutdatedMajority; }
-    virtual void setToCheckBlockUpgradeMajority(int anToCheckBlockUpgradeMajority)  { nToCheckBlockUpgradeMajority=anToCheckBlockUpgradeMajority; }
-    virtual void setDefaultCheckMemPool(bool afDefaultCheckMemPool)  { fDefaultCheckMemPool=afDefaultCheckMemPool; }
-    virtual void setAllowMinDifficultyBlocks(bool afAllowMinDifficultyBlocks) {  fAllowMinDifficultyBlocks=afAllowMinDifficultyBlocks; }
-    virtual void setSkipProofOfWorkCheck(bool afSkipProofOfWorkCheck) { fSkipProofOfWorkCheck = afSkipProofOfWorkCheck; }
-};
-static CUnitTestParams unitTestParams;
-
-
 static CChainParams *pCurrentParams = 0;
-
-CModifiableParams *ModifiableParams()
-{
-   assert(pCurrentParams);
-   assert(pCurrentParams==&unitTestParams);
-   return (CModifiableParams*)&unitTestParams;
-}
 
 const CChainParams &Params() {
     assert(pCurrentParams);
@@ -339,8 +296,6 @@ CChainParams &Params(CBaseChainParams::Network network) {
             return testNetParams;
         case CBaseChainParams::REGTEST:
             return regTestParams;
-        case CBaseChainParams::UNITTEST:
-            return unitTestParams;
         default:
             assert(false && "Unimplemented network");
             return mainParams;

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -60,8 +60,6 @@ public:
     bool DefaultCheckMemPool() const { return fDefaultCheckMemPool; }
     /** Allow mining of a min-difficulty block */
     bool AllowMinDifficultyBlocks() const { return fAllowMinDifficultyBlocks; }
-    /** Skip proof-of-work check: allow mining of any difficulty block */
-    bool SkipProofOfWorkCheck() const { return fSkipProofOfWorkCheck; }
     /** Make standard checks */
     bool RequireStandard() const { return fRequireStandard; }
     int64_t TargetTimespan() const { return nTargetTimespan; }
@@ -104,7 +102,6 @@ protected:
     bool fAllowMinDifficultyBlocks;
     bool fRequireStandard;
     bool fMineBlocksOnDemand;
-    bool fSkipProofOfWorkCheck;
     bool fTestnetToBeDeprecatedFieldRPC;
 };
 

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -108,25 +108,6 @@ protected:
     bool fTestnetToBeDeprecatedFieldRPC;
 };
 
-/** 
- * Modifiable parameters interface is used by test cases to adapt the parameters in order
- * to test specific features more easily. Test cases should always restore the previous
- * values after finalization.
- */
-
-class CModifiableParams {
-public:
-    //! Published setters to allow changing values in unit test cases
-    virtual void setSubsidyHalvingInterval(int anSubsidyHalvingInterval) =0;
-    virtual void setEnforceBlockUpgradeMajority(int anEnforceBlockUpgradeMajority)=0;
-    virtual void setRejectBlockOutdatedMajority(int anRejectBlockOutdatedMajority)=0;
-    virtual void setToCheckBlockUpgradeMajority(int anToCheckBlockUpgradeMajority)=0;
-    virtual void setDefaultCheckMemPool(bool aDefaultCheckMemPool)=0;
-    virtual void setAllowMinDifficultyBlocks(bool aAllowMinDifficultyBlocks)=0;
-    virtual void setSkipProofOfWorkCheck(bool aSkipProofOfWorkCheck)=0;
-};
-
-
 /**
  * Return the currently selected parameters. This won't change after app startup
  * outside of the unit tests.
@@ -135,9 +116,6 @@ const CChainParams &Params();
 
 /** Return parameters for the given network. */
 CChainParams &Params(CBaseChainParams::Network network);
-
-/** Get modifiable network parameters (UNITTEST only) */
-CModifiableParams *ModifiableParams();
 
 /** Sets the params returned by Params() to those for the given network. */
 void SelectParams(CBaseChainParams::Network network);

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -82,9 +82,6 @@ void SelectBaseParams(CBaseChainParams::Network network)
     case CBaseChainParams::REGTEST:
         pCurrentBaseParams = &regTestParams;
         break;
-    case CBaseChainParams::UNITTEST:
-        pCurrentBaseParams = &unitTestParams;
-        break;
     default:
         assert(false && "Unimplemented network");
         return;

--- a/src/chainparamsbase.h
+++ b/src/chainparamsbase.h
@@ -19,7 +19,6 @@ public:
         MAIN,
         TESTNET,
         REGTEST,
-        UNITTEST,
 
         MAX_NETWORK_TYPES
     };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2593,8 +2593,7 @@ bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationState& sta
     int nHeight = pindexPrev->nHeight+1;
 
     // Check proof of work
-    if ((!Params().SkipProofOfWorkCheck()) &&
-       (block.nBits != GetNextWorkRequired(pindexPrev, &block)))
+    if ((block.nBits != GetNextWorkRequired(pindexPrev, &block)))
         return state.DoS(100, error("%s: incorrect proof of work", __func__),
                          REJECT_INVALID, "bad-diffbits");
 

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -87,9 +87,6 @@ bool CheckProofOfWork(uint256 hash, unsigned int nBits)
     bool fOverflow;
     arith_uint256 bnTarget;
 
-    if (Params().SkipProofOfWorkCheck())
-       return true;
-
     bnTarget.SetCompact(nBits, &fNegative, &fOverflow);
 
     // Check range

--- a/src/test/base58_tests.cpp
+++ b/src/test/base58_tests.cpp
@@ -127,6 +127,7 @@ BOOST_AUTO_TEST_CASE(base58_keys_valid_parse)
     std::vector<unsigned char> result;
     CBitcoinSecret secret;
     CBitcoinAddress addr;
+    SelectParams(CBaseChainParams::MAIN);
 
     BOOST_FOREACH(Value& tv, tests)
     {
@@ -176,7 +177,6 @@ BOOST_AUTO_TEST_CASE(base58_keys_valid_parse)
             BOOST_CHECK_MESSAGE(!secret.IsValid(), "IsValid pubkey as privkey:" + strTest);
         }
     }
-    SelectParams(CBaseChainParams::UNITTEST);
 }
 
 // Goal: check that generated keys match test vectors
@@ -244,7 +244,7 @@ BOOST_AUTO_TEST_CASE(base58_keys_valid_gen)
     CTxDestination nodest = CNoDestination();
     BOOST_CHECK(!dummyAddr.Set(nodest));
 
-    SelectParams(CBaseChainParams::UNITTEST);
+    SelectParams(CBaseChainParams::MAIN);
 }
 
 // Goal: check that base58 parsing code is robust against a variety of corrupted data

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -29,7 +29,7 @@ extern void noui_connect();
 TestingSetup::TestingSetup()
 {
         fPrintToDebugLog = false; // don't want to write to debug.log file
-        SelectParams(CBaseChainParams::UNITTEST);
+        SelectParams(CBaseChainParams::MAIN);
         noui_connect();
 #ifdef ENABLE_WALLET
         bitdb.MakeMock();


### PR DESCRIPTION
UNITTEST parameters are not used by any current tests, and the model (modifyable parameters) is inconvenient when unit-testing in random order. As they are stored in a global structure every test would have to (re)set up its own parameters. This reverts #5030.

For consistency it is better, too, to test with the actual MAIN parameters and not a variation.

Also removes related (and unused) fSkipProofOfWork parameter.
