### PR TITLE
configure: BITCOIN_SUBDIR_TO_INCLUDE: Improve compatibility with paths including space and multiline cpp output

### DIFF
--- a/build-aux/m4/bitcoin_subdir_to_include.m4
+++ b/build-aux/m4/bitcoin_subdir_to_include.m4
@@ -5,7 +5,7 @@ AC_DEFUN([BITCOIN_SUBDIR_TO_INCLUDE],[
     AC_MSG_RESULT([default])
   else
     echo "#include <$2$3.h>" >conftest.cpp
-    newinclpath=`${CXXCPP} ${CPPFLAGS} -M conftest.cpp 2>/dev/null | [ tr -d '\\n\\r\\\\' | sed -e 's/^.*[[:space:]:]\(\/[^[:space:]]*\)]$3[\.h[[:space:]].*$/\1/' -e t -e d`]
+    newinclpath=$(${CXXCPP} ${CPPFLAGS} -M conftest.cpp 2>/dev/null | sed [-E -e ':a' -e '/\\$/!b b' -e N -e 's/\\\n/ /' -e 't a' -e ':b' -e 's/^[^:]*:[[:space:]]*(([^[:space:]\]|\\.)*[[:space:]])*(([^[:space:]\]|\\.)*)]$3\.h[([[:space:]].*)?$/\3/' -e 't' -e d])
     AC_MSG_RESULT([${newinclpath}])
     if test "x${newinclpath}" != "x"; then
       eval "$1=\"\$$1\"' -I${newinclpath}'"

--- a/build-aux/m4/bitcoin_subdir_to_include.m4
+++ b/build-aux/m4/bitcoin_subdir_to_include.m4
@@ -1,14 +1,48 @@
 dnl BITCOIN_SUBDIR_TO_INCLUDE([CPPFLAGS-VARIABLE-NAME],[SUBDIRECTORY-NAME],[HEADER-FILE])
 dnl SUBDIRECTORY-NAME must end with a path separator
 AC_DEFUN([BITCOIN_SUBDIR_TO_INCLUDE],[
-  if test "x$2" = "x"; then
+  m4_pushdef([_result_var],[$1])
+  m4_pushdef([_rel_path],[$2])
+  m4_pushdef([_header_file],[$3.h])
+  if test "x[]_rel_path" = "x"; then
     AC_MSG_RESULT([default])
   else
-    echo "#include <$2$3.h>" >conftest.cpp
-    newinclpath=$(${CXXCPP} ${CPPFLAGS} -M conftest.cpp 2>/dev/null | sed [-E -e ':a' -e '/\\$/!b b' -e N -e 's/\\\n/ /' -e 't a' -e ':b' -e 's/^[^:]*:[[:space:]]*(([^[:space:]\]|\\.)*[[:space:]])*(([^[:space:]\]|\\.)*)]$3\.h[([[:space:]].*)?$/\3/' -e 't' -e d])
+    echo '[#]include <'"_rel_path"'/_header_file>' >conftest.cpp
+    newinclpath=$(
+      ${CXXCPP} ${CPPFLAGS} -M conftest.cpp 2>/dev/null |
+      ${SED} -E m4_bpatsubsts([[
+        :build_line
+# If the line doesn't end with a backslash, it is complete; go on to process it
+        /\\$/!b have_complete_line
+# Otherwise, read the next line, and concatenate it to the current one with a space
+        N
+        s/\\\n/ /
+# Then go back and check for a trailing backslash again.
+        t build_line
+
+# When we get here, we have the completed line, with all continuations collapsed.
+        :have_complete_line
+        s/^[^:]*:[[:space:]]*(([^[:space:]\]|\\.)*[[:space:]])*(([^[:space:]\]|\\.)*)(\\|\\\\|\/)?]]patsubst(]_header_file[,[\.],[\\.])[[([[:space:]].*)?$/\3/
+#         ^^^^^^^ The Make line begins with a target (which we don't care about)
+#                ^^^^^^^^^^^^ Ignore any spaces following it
+#                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Match any number of other dependencies
+#                                                              ^^^^^^^^^^^^^^^^^^^^^^ Match any path components for our dependency; note this is reference 3, which we are replacing with
+#                                                                                    ^^^^^^^^^^^^^ Accept the path ending in a backslash, a double-backslash (ie escaped), or a forward slash
+#                                                                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The filename must match exactly (periods are escaped, since a normal period matches any character in regex)
+#                                                                                                                                      ^^^^^^^^^^^^^^^^^ Filename must be followed by a space, but after that we don't care; we still need to match it all so it gets replaced, however
+# Delete the line, but only if we failed to find the directory (t jumps past the d if we matched)
+        t
+        d
+]],[
+\s*\(#.*\)?$],[],[
+        \(.*\)],[ -e '\1'])
+dnl ^^^^^^^^^^^^^^^^^^^^^^^ Deletes comments and processes sed expressions into -e arguments
+    )
+
     AC_MSG_RESULT([${newinclpath}])
     if test "x${newinclpath}" != "x"; then
-      eval "$1=\"\$$1\"' -I${newinclpath}'"
+      eval "_result_var=\"\$_result_var\"' -I${newinclpath}'"
     fi
   fi
+  m4_popdef([_result_var],[_rel_path],[_header_file])
 ])


### PR DESCRIPTION
This fixes a number of bugs in the BITCOIN_SUBDIR_TO_INCLUDE macro:
- tr was deleting all 'n' and 'r' characters in addition to the backslash, due to too much escaping.
- Escaped spaces in paths were ignored, parsing the space as a delimiter
- Multiline output from cpp (used when there are a number of includes being listed) weren't handled correctly.

The new sed takes two steps:
1. Translate escaped newlines into a space, to work with single lines.
2. Search for the file we want and return the complete path for it.
