### PR TITLE
Initialization: set Boost path locale in main thread

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -723,18 +723,18 @@ void RenameThread(const char* name)
 
 void SetupEnvironment()
 {
-#ifndef WIN32
-    try
-    {
-#if BOOST_FILESYSTEM_VERSION == 3
-            boost::filesystem::path::codecvt(); // Raises runtime error if current locale is invalid
-#else // boost filesystem v2
-            std::locale();                      // Raises runtime error if current locale is invalid
-#endif
+    // On most POSIX systems (e.g. Linux, but not BSD) the environment's locale
+    // may be invalid, in which case the "C" locale is used as fallback.
+#if !defined(WIN32) && !defined(MAC_OSX) && !defined(__FreeBSD__) && !defined(__OpenBSD__)
+    try {
+        std::locale(""); // Raises a runtime error if current locale is invalid
     } catch (const std::runtime_error&) {
-        setenv("LC_ALL", "C", 1); // Force C locale
+        std::locale::global(std::locale("C"));
     }
 #endif
+    // The path locale is lazy initialized and to avoid deinitialization errors 
+    // in multithreading environments, it is set explicitly by the main thread.
+    boost::filesystem::path::imbue(std::locale());    
 }
 
 void SetThreadPriority(int nPriority)


### PR DESCRIPTION
1. Boost path seems to use variables which are lazy initialized and not thread safe, and in particular this results in leaks and unexpected behavior, if they are not explicitly initialized by the main thread, because resources may no longer be accessible, if the related thread isn't either. This is basically the underlying issue I'm trying to address, and related issues affected by this are #3136 and #5380.
2. path::imbue(std::locale()) appears to initialize those.
3. std::locale() constructs a copy of the current global locale. The global locale is the locale set by a previous call to std::locale::global, or std::locale::classic ("C"), if std::locale::global has not been called. std::locale("") however uses the default environment value.
4. Setting locale::global(loc) also sets the C global locale, as if the C library function setlocale was called with LC_ALL, which appears to be more robust, while setenv may not be available in any case.
5. locale("") throw exceptions, if invalid environment locales are used, but locale() does only so, if locale::global was set with an invalid locale before, which should not be the case in Bitcoin Core, so I'd assume the old L732 never throws at all.
6. I tested it with several build configurations, but I'm not entirely sure, if this is 100 % side effect free. 
