### PR TITLE
BUGFIX: Stack around the variable 'rv' was corrupted

### DIFF
--- a/src/uint256.cpp
+++ b/src/uint256.cpp
@@ -45,7 +45,7 @@ void base_blob<BITS>::SetHex(const char* psz)
         psz++;
     psz--;
     unsigned char* p1 = (unsigned char*)data;
-    unsigned char* pend = p1 + WIDTH * 4;
+    unsigned char* pend = p1 + WIDTH;
     while (psz >= pbegin && p1 < pend) {
         *p1 = ::HexDigit(*psz--);
         if (psz >= pbegin) {
@@ -128,7 +128,7 @@ uint64_t uint256::GetHash(const uint256& salt) const
     uint32_t a, b, c;
     const uint32_t *pn = (const uint32_t*)data;
     const uint32_t *salt_pn = (const uint32_t*)salt.data;
-    a = b = c = 0xdeadbeef + (WIDTH << 2);
+    a = b = c = 0xdeadbeef + WIDTH;
 
     a += pn[0] ^ salt_pn[0];
     b += pn[1] ^ salt_pn[1];


### PR DESCRIPTION
The bug had appeared here: https://github.com/bitcoin/bitcoin/commit/bfc6070342b9f43bcf125526e6a3c8ed34e29a71

https://github.com/bitcoin/bitcoin/commit/bfc6070342b9f43bcf125526e6a3c8ed34e29a71#diff-23a5eb4be66c42bad04bf3742c952bf9L26

We changed WIDTH (new WIDTH =  old WIDTH \* 4) but we didn't change the usage of WIDTH. 

I found the bug after launch unit tests in Debug Mode.(the bug appears if tests are compiled in Debug Mode, if tests are compiled in Release Mode the bug doesn't appear)

```
Running 148 test cases...
unknown location(0): fatal error in "basics": (0) : Run-Time Check Failure #2 - Stack around the variable 'rv' was corrupted.
c:\myprojects\bitcoin\src\test\uint256_tests.cpp(119): last checkpoint

*** 1 failure detected in test suite "Bitcoin Test Suite"
```
