### PR TITLE
[Qt] support for persisted rpc console history

### DIFF
--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -53,6 +53,9 @@ const struct {
     {NULL, NULL}
 };
 
+//don't add private key handling cmd's to the history
+const QStringList RPCConsole::historyBlacklist = QStringList() << "importprivkey" << "signrawtransaction" << "walletpassphrase" << "walletpassphrasechange" << "encryptwallet";
+
 /* Object for executing console RPC commands in a separate thread.
 */
 class RPCExecutor : public QObject
@@ -238,11 +241,32 @@ RPCConsole::RPCConsole(QWidget *parent) :
     ui->peerHeading->setText(tr("Select a peer to view detailed information."));
 
     clear();
+    
+    //load history
+    QSettings settings;
+    int size = settings.beginReadArray("nRPCConsoleWindowHistory");
+    history.clear();
+    for (int i=0; i<size; i++){
+        settings.setArrayIndex(i);
+        history.append(settings.value("cmd").toString());
+    }
+    historyPtr = history.size();
+    settings.endArray();
 }
 
 RPCConsole::~RPCConsole()
 {
     GUIUtil::saveWindowGeometry("nRPCConsoleWindow", this);
+    
+    //persist history
+    QSettings settings;
+    settings.beginWriteArray("nRPCConsoleWindowHistory");
+    for (int i = 0; i < history.size(); ++i) {
+        settings.setArrayIndex(i);
+        settings.setValue("cmd", history.at(i));
+    }
+    settings.endArray();
+    
     emit stopExecutor();
     delete ui;
 }
@@ -417,17 +441,30 @@ void RPCConsole::on_lineEdit_returnPressed()
 
     if(!cmd.isEmpty())
     {
+        cmdBeforeBrowsing = QString();
+        
         message(CMD_REQUEST, cmd);
         emit cmdRequest(cmd);
-        // Remove command, if already in history
-        history.removeOne(cmd);
-        // Append command to history
-        history.append(cmd);
-        // Enforce maximum history size
-        while(history.size() > CONSOLE_HISTORY)
-            history.removeFirst();
-        // Set pointer to end of history
-        historyPtr = history.size();
+        
+        bool storeHistory = true;
+        foreach(QString blacklistedCmd, historyBlacklist)
+        {
+            if(cmd.trimmed().startsWith(blacklistedCmd))
+                storeHistory = false; break;
+        }
+        
+        if (storeHistory)
+        {
+            // Remove command, if already in history
+            history.removeOne(cmd);
+            // Append command to history
+            history.append(cmd);
+            // Enforce maximum history size
+            while(history.size() > CONSOLE_HISTORY)
+                history.removeFirst();
+            // Set pointer to end of history
+            historyPtr = history.size();
+        }
         // Scroll console view to end
         scrollToEnd();
     }
@@ -435,6 +472,10 @@ void RPCConsole::on_lineEdit_returnPressed()
 
 void RPCConsole::browseHistory(int offset)
 {
+    // store current text when start browsing through the history
+    if(historyPtr == history.size())
+        cmdBeforeBrowsing = ui->lineEdit->text();
+    
     historyPtr += offset;
     if(historyPtr < 0)
         historyPtr = 0;
@@ -443,6 +484,8 @@ void RPCConsole::browseHistory(int offset)
     QString cmd;
     if(historyPtr < history.size())
         cmd = history.at(historyPtr);
+    else if(historyPtr == history.size() && !cmdBeforeBrowsing.isNull())
+        cmd = cmdBeforeBrowsing;
     ui->lineEdit->setText(cmd);
 }
 

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -54,7 +54,7 @@ const struct {
 };
 
 //don't add private key handling cmd's to the history
-const QStringList RPCConsole::historyBlacklist = QStringList() << "importprivkey" << "signrawtransaction" << "walletpassphrase" << "walletpassphrasechange" << "encryptwallet";
+const QStringList RPCConsole::historyFilter = QStringList() << "importprivkey" << "signrawtransaction" << "walletpassphrase" << "walletpassphrasechange" << "encryptwallet";
 
 /* Object for executing console RPC commands in a separate thread.
 */
@@ -447,9 +447,9 @@ void RPCConsole::on_lineEdit_returnPressed()
         emit cmdRequest(cmd);
         
         bool storeHistory = true;
-        foreach(QString blacklistedCmd, historyBlacklist)
+        foreach(QString unallowedCmd, historyFilter)
         {
-            if(cmd.trimmed().startsWith(blacklistedCmd))
+            if(cmd.trimmed().startsWith(unallowedCmd))
                 storeHistory = false; break;
         }
         

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -97,7 +97,7 @@ private:
     ClientModel *clientModel;
     QStringList history;
     int historyPtr;
-    const static QStringList historyBlacklist;
+    const static QStringList historyFilter;
     QString cmdBeforeBrowsing;
     NodeId cachedNodeid;
 };

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -97,6 +97,8 @@ private:
     ClientModel *clientModel;
     QStringList history;
     int historyPtr;
+    const static QStringList historyBlacklist;
+    QString cmdBeforeBrowsing;
     NodeId cachedNodeid;
 };
 


### PR DESCRIPTION
While developing i often use the rpc console for some quick checks. I always missed a persisted history.
- This will add storing of the history.
- `importprivkey` and `signrawtransaction` are blacklisted for the history (new: blacklisted also for the in-memory-history).
- Last command will not get overwritten when browsing the history (shell like, but currently not possibility to store changed history commands till executing a new command)
