### PR TITLE
[Qt] change debug window tab ordering, move "console" at front

### DIFF
--- a/src/qt/forms/rpcconsole.ui
+++ b/src/qt/forms/rpcconsole.ui
@@ -19,343 +19,6 @@
      <property name="currentIndex">
       <number>0</number>
      </property>
-     <widget class="QWidget" name="tab_info">
-      <attribute name="title">
-       <string>&amp;Information</string>
-      </attribute>
-      <layout class="QGridLayout" name="gridLayout" columnstretch="0,1">
-       <property name="horizontalSpacing">
-        <number>12</number>
-       </property>
-       <item row="0" column="0">
-        <widget class="QLabel" name="label_9">
-         <property name="font">
-          <font>
-           <weight>75</weight>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>General</string>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="0">
-        <widget class="QLabel" name="label_5">
-         <property name="text">
-          <string>Client name</string>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="1">
-        <widget class="QLabel" name="clientName">
-         <property name="cursor">
-          <cursorShape>IBeamCursor</cursorShape>
-         </property>
-         <property name="text">
-          <string>N/A</string>
-         </property>
-         <property name="textFormat">
-          <enum>Qt::PlainText</enum>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="0">
-        <widget class="QLabel" name="label_6">
-         <property name="text">
-          <string>Client version</string>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="1">
-        <widget class="QLabel" name="clientVersion">
-         <property name="cursor">
-          <cursorShape>IBeamCursor</cursorShape>
-         </property>
-         <property name="text">
-          <string>N/A</string>
-         </property>
-         <property name="textFormat">
-          <enum>Qt::PlainText</enum>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="0">
-        <widget class="QLabel" name="label_14">
-         <property name="text">
-          <string>Using OpenSSL version</string>
-         </property>
-         <property name="indent">
-          <number>10</number>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="1">
-        <widget class="QLabel" name="openSSLVersion">
-         <property name="cursor">
-          <cursorShape>IBeamCursor</cursorShape>
-         </property>
-         <property name="text">
-          <string>N/A</string>
-         </property>
-         <property name="textFormat">
-          <enum>Qt::PlainText</enum>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="0">
-        <widget class="QLabel" name="label_berkeleyDBVersion">
-         <property name="text">
-          <string>Using BerkeleyDB version</string>
-         </property>
-         <property name="indent">
-          <number>10</number>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="1">
-        <widget class="QLabel" name="berkeleyDBVersion">
-         <property name="cursor">
-          <cursorShape>IBeamCursor</cursorShape>
-         </property>
-         <property name="text">
-          <string>N/A</string>
-         </property>
-         <property name="textFormat">
-          <enum>Qt::PlainText</enum>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="0">
-        <widget class="QLabel" name="label_12">
-         <property name="text">
-          <string>Build date</string>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="1">
-        <widget class="QLabel" name="buildDate">
-         <property name="cursor">
-          <cursorShape>IBeamCursor</cursorShape>
-         </property>
-         <property name="text">
-          <string>N/A</string>
-         </property>
-         <property name="textFormat">
-          <enum>Qt::PlainText</enum>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
-       <item row="6" column="0">
-        <widget class="QLabel" name="label_13">
-         <property name="text">
-          <string>Startup time</string>
-         </property>
-        </widget>
-       </item>
-       <item row="6" column="1">
-        <widget class="QLabel" name="startupTime">
-         <property name="cursor">
-          <cursorShape>IBeamCursor</cursorShape>
-         </property>
-         <property name="text">
-          <string>N/A</string>
-         </property>
-         <property name="textFormat">
-          <enum>Qt::PlainText</enum>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
-       <item row="7" column="0">
-        <widget class="QLabel" name="label_11">
-         <property name="font">
-          <font>
-           <weight>75</weight>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>Network</string>
-         </property>
-        </widget>
-       </item>
-       <item row="8" column="0">
-        <widget class="QLabel" name="label_8">
-         <property name="text">
-          <string>Name</string>
-         </property>
-        </widget>
-       </item>
-       <item row="8" column="1">
-        <widget class="QLabel" name="networkName">
-         <property name="cursor">
-          <cursorShape>IBeamCursor</cursorShape>
-         </property>
-         <property name="text">
-          <string>N/A</string>
-         </property>
-         <property name="textFormat">
-          <enum>Qt::PlainText</enum>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
-       <item row="9" column="0">
-        <widget class="QLabel" name="label_7">
-         <property name="text">
-          <string>Number of connections</string>
-         </property>
-        </widget>
-       </item>
-       <item row="9" column="1">
-        <widget class="QLabel" name="numberOfConnections">
-         <property name="cursor">
-          <cursorShape>IBeamCursor</cursorShape>
-         </property>
-         <property name="text">
-          <string>N/A</string>
-         </property>
-         <property name="textFormat">
-          <enum>Qt::PlainText</enum>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
-       <item row="10" column="0">
-        <widget class="QLabel" name="label_10">
-         <property name="font">
-          <font>
-           <weight>75</weight>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>Block chain</string>
-         </property>
-        </widget>
-       </item>
-       <item row="11" column="0">
-        <widget class="QLabel" name="label_3">
-         <property name="text">
-          <string>Current number of blocks</string>
-         </property>
-        </widget>
-       </item>
-       <item row="11" column="1">
-        <widget class="QLabel" name="numberOfBlocks">
-         <property name="cursor">
-          <cursorShape>IBeamCursor</cursorShape>
-         </property>
-         <property name="text">
-          <string>N/A</string>
-         </property>
-         <property name="textFormat">
-          <enum>Qt::PlainText</enum>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
-       <item row="12" column="0">
-        <widget class="QLabel" name="label_2">
-         <property name="text">
-          <string>Last block time</string>
-         </property>
-        </widget>
-       </item>
-       <item row="12" column="1">
-        <widget class="QLabel" name="lastBlockTime">
-         <property name="cursor">
-          <cursorShape>IBeamCursor</cursorShape>
-         </property>
-         <property name="text">
-          <string>N/A</string>
-         </property>
-         <property name="textFormat">
-          <enum>Qt::PlainText</enum>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
-       <item row="13" column="0">
-        <spacer name="verticalSpacer_2">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item row="14" column="0">
-        <widget class="QLabel" name="labelDebugLogfile">
-         <property name="font">
-          <font>
-           <weight>75</weight>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>Debug log file</string>
-         </property>
-        </widget>
-       </item>
-       <item row="15" column="0">
-        <widget class="QPushButton" name="openDebugLogfileButton">
-         <property name="toolTip">
-          <string>Open the Bitcoin Core debug log file from the current data directory. This can take a few seconds for large log files.</string>
-         </property>
-         <property name="text">
-          <string>&amp;Open</string>
-         </property>
-         <property name="autoDefault">
-          <bool>false</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="16" column="0">
-        <spacer name="verticalSpacer">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
-     </widget>
      <widget class="QWidget" name="tab_console">
       <attribute name="title">
        <string>&amp;Console</string>
@@ -427,6 +90,343 @@
         </layout>
        </item>
       </layout>
+     </widget>
+     <widget class="QWidget" name="tab_info">
+         <attribute name="title">
+             <string>&amp;Information</string>
+         </attribute>
+         <layout class="QGridLayout" name="gridLayout" columnstretch="0,1">
+             <property name="horizontalSpacing">
+                 <number>12</number>
+             </property>
+             <item row="0" column="0">
+                 <widget class="QLabel" name="label_9">
+                     <property name="font">
+                         <font>
+                             <weight>75</weight>
+                             <bold>true</bold>
+                         </font>
+                     </property>
+                     <property name="text">
+                         <string>General</string>
+                     </property>
+                 </widget>
+             </item>
+             <item row="1" column="0">
+                 <widget class="QLabel" name="label_5">
+                     <property name="text">
+                         <string>Client name</string>
+                     </property>
+                 </widget>
+             </item>
+             <item row="1" column="1">
+                 <widget class="QLabel" name="clientName">
+                     <property name="cursor">
+                         <cursorShape>IBeamCursor</cursorShape>
+                     </property>
+                     <property name="text">
+                         <string>N/A</string>
+                     </property>
+                     <property name="textFormat">
+                         <enum>Qt::PlainText</enum>
+                     </property>
+                     <property name="textInteractionFlags">
+                         <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+                     </property>
+                 </widget>
+             </item>
+             <item row="2" column="0">
+                 <widget class="QLabel" name="label_6">
+                     <property name="text">
+                         <string>Client version</string>
+                     </property>
+                 </widget>
+             </item>
+             <item row="2" column="1">
+                 <widget class="QLabel" name="clientVersion">
+                     <property name="cursor">
+                         <cursorShape>IBeamCursor</cursorShape>
+                     </property>
+                     <property name="text">
+                         <string>N/A</string>
+                     </property>
+                     <property name="textFormat">
+                         <enum>Qt::PlainText</enum>
+                     </property>
+                     <property name="textInteractionFlags">
+                         <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+                     </property>
+                 </widget>
+             </item>
+             <item row="3" column="0">
+                 <widget class="QLabel" name="label_14">
+                     <property name="text">
+                         <string>Using OpenSSL version</string>
+                     </property>
+                     <property name="indent">
+                         <number>10</number>
+                     </property>
+                 </widget>
+             </item>
+             <item row="3" column="1">
+                 <widget class="QLabel" name="openSSLVersion">
+                     <property name="cursor">
+                         <cursorShape>IBeamCursor</cursorShape>
+                     </property>
+                     <property name="text">
+                         <string>N/A</string>
+                     </property>
+                     <property name="textFormat">
+                         <enum>Qt::PlainText</enum>
+                     </property>
+                     <property name="textInteractionFlags">
+                         <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+                     </property>
+                 </widget>
+             </item>
+             <item row="4" column="0">
+                 <widget class="QLabel" name="label_berkeleyDBVersion">
+                     <property name="text">
+                         <string>Using BerkeleyDB version</string>
+                     </property>
+                     <property name="indent">
+                         <number>10</number>
+                     </property>
+                 </widget>
+             </item>
+             <item row="4" column="1">
+                 <widget class="QLabel" name="berkeleyDBVersion">
+                     <property name="cursor">
+                         <cursorShape>IBeamCursor</cursorShape>
+                     </property>
+                     <property name="text">
+                         <string>N/A</string>
+                     </property>
+                     <property name="textFormat">
+                         <enum>Qt::PlainText</enum>
+                     </property>
+                     <property name="textInteractionFlags">
+                         <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+                     </property>
+                 </widget>
+             </item>
+             <item row="5" column="0">
+                 <widget class="QLabel" name="label_12">
+                     <property name="text">
+                         <string>Build date</string>
+                     </property>
+                 </widget>
+             </item>
+             <item row="5" column="1">
+                 <widget class="QLabel" name="buildDate">
+                     <property name="cursor">
+                         <cursorShape>IBeamCursor</cursorShape>
+                     </property>
+                     <property name="text">
+                         <string>N/A</string>
+                     </property>
+                     <property name="textFormat">
+                         <enum>Qt::PlainText</enum>
+                     </property>
+                     <property name="textInteractionFlags">
+                         <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+                     </property>
+                 </widget>
+             </item>
+             <item row="6" column="0">
+                 <widget class="QLabel" name="label_13">
+                     <property name="text">
+                         <string>Startup time</string>
+                     </property>
+                 </widget>
+             </item>
+             <item row="6" column="1">
+                 <widget class="QLabel" name="startupTime">
+                     <property name="cursor">
+                         <cursorShape>IBeamCursor</cursorShape>
+                     </property>
+                     <property name="text">
+                         <string>N/A</string>
+                     </property>
+                     <property name="textFormat">
+                         <enum>Qt::PlainText</enum>
+                     </property>
+                     <property name="textInteractionFlags">
+                         <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+                     </property>
+                 </widget>
+             </item>
+             <item row="7" column="0">
+                 <widget class="QLabel" name="label_11">
+                     <property name="font">
+                         <font>
+                             <weight>75</weight>
+                             <bold>true</bold>
+                         </font>
+                     </property>
+                     <property name="text">
+                         <string>Network</string>
+                     </property>
+                 </widget>
+             </item>
+             <item row="8" column="0">
+                 <widget class="QLabel" name="label_8">
+                     <property name="text">
+                         <string>Name</string>
+                     </property>
+                 </widget>
+             </item>
+             <item row="8" column="1">
+                 <widget class="QLabel" name="networkName">
+                     <property name="cursor">
+                         <cursorShape>IBeamCursor</cursorShape>
+                     </property>
+                     <property name="text">
+                         <string>N/A</string>
+                     </property>
+                     <property name="textFormat">
+                         <enum>Qt::PlainText</enum>
+                     </property>
+                     <property name="textInteractionFlags">
+                         <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+                     </property>
+                 </widget>
+             </item>
+             <item row="9" column="0">
+                 <widget class="QLabel" name="label_7">
+                     <property name="text">
+                         <string>Number of connections</string>
+                     </property>
+                 </widget>
+             </item>
+             <item row="9" column="1">
+                 <widget class="QLabel" name="numberOfConnections">
+                     <property name="cursor">
+                         <cursorShape>IBeamCursor</cursorShape>
+                     </property>
+                     <property name="text">
+                         <string>N/A</string>
+                     </property>
+                     <property name="textFormat">
+                         <enum>Qt::PlainText</enum>
+                     </property>
+                     <property name="textInteractionFlags">
+                         <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+                     </property>
+                 </widget>
+             </item>
+             <item row="10" column="0">
+                 <widget class="QLabel" name="label_10">
+                     <property name="font">
+                         <font>
+                             <weight>75</weight>
+                             <bold>true</bold>
+                         </font>
+                     </property>
+                     <property name="text">
+                         <string>Block chain</string>
+                     </property>
+                 </widget>
+             </item>
+             <item row="11" column="0">
+                 <widget class="QLabel" name="label_3">
+                     <property name="text">
+                         <string>Current number of blocks</string>
+                     </property>
+                 </widget>
+             </item>
+             <item row="11" column="1">
+                 <widget class="QLabel" name="numberOfBlocks">
+                     <property name="cursor">
+                         <cursorShape>IBeamCursor</cursorShape>
+                     </property>
+                     <property name="text">
+                         <string>N/A</string>
+                     </property>
+                     <property name="textFormat">
+                         <enum>Qt::PlainText</enum>
+                     </property>
+                     <property name="textInteractionFlags">
+                         <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+                     </property>
+                 </widget>
+             </item>
+             <item row="12" column="0">
+                 <widget class="QLabel" name="label_2">
+                     <property name="text">
+                         <string>Last block time</string>
+                     </property>
+                 </widget>
+             </item>
+             <item row="12" column="1">
+                 <widget class="QLabel" name="lastBlockTime">
+                     <property name="cursor">
+                         <cursorShape>IBeamCursor</cursorShape>
+                     </property>
+                     <property name="text">
+                         <string>N/A</string>
+                     </property>
+                     <property name="textFormat">
+                         <enum>Qt::PlainText</enum>
+                     </property>
+                     <property name="textInteractionFlags">
+                         <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+                     </property>
+                 </widget>
+             </item>
+             <item row="13" column="0">
+                 <spacer name="verticalSpacer_2">
+                     <property name="orientation">
+                         <enum>Qt::Vertical</enum>
+                     </property>
+                     <property name="sizeHint" stdset="0">
+                         <size>
+                             <width>20</width>
+                             <height>20</height>
+                         </size>
+                     </property>
+                 </spacer>
+             </item>
+             <item row="14" column="0">
+                 <widget class="QLabel" name="labelDebugLogfile">
+                     <property name="font">
+                         <font>
+                             <weight>75</weight>
+                             <bold>true</bold>
+                         </font>
+                     </property>
+                     <property name="text">
+                         <string>Debug log file</string>
+                     </property>
+                 </widget>
+             </item>
+             <item row="15" column="0">
+                 <widget class="QPushButton" name="openDebugLogfileButton">
+                     <property name="toolTip">
+                         <string>Open the Bitcoin Core debug log file from the current data directory. This can take a few seconds for large log files.</string>
+                     </property>
+                     <property name="text">
+                         <string>&amp;Open</string>
+                     </property>
+                     <property name="autoDefault">
+                         <bool>false</bool>
+                     </property>
+                 </widget>
+             </item>
+             <item row="16" column="0">
+                 <spacer name="verticalSpacer">
+                     <property name="orientation">
+                         <enum>Qt::Vertical</enum>
+                     </property>
+                     <property name="sizeHint" stdset="0">
+                         <size>
+                             <width>20</width>
+                             <height>40</height>
+                         </size>
+                     </property>
+                 </spacer>
+             </item>
+         </layout>
      </widget>
      <widget class="QWidget" name="tab_nettraffic">
       <attribute name="title">


### PR DESCRIPTION
I'm not sure what other think about this. But IMO it makes more sense to have the console at first pos.
Maybe it would even be better to have the console separated from the debug window.
Adding a separate menu entry "Help" -> "Console" could also make sense.
