### PR TITLE
Remove leftover strlcpy.h copyright

### DIFF
--- a/contrib/debian/copyright
+++ b/contrib/debian/copyright
@@ -15,10 +15,6 @@ Files: src/json/*
 Copyright: 2007-2009, John W. Wilkinson
 License: Expat
 
-Files: src/strlcpy.h
-Copyright: 1998, Todd C. Miller <Todd.Miller@courtesan.com>
-License: ISC
-
 Files: debian/*
 Copyright: 2010-2011, Jonas Smedegaard <dr@jones.dk>
            2011, Matt Corallo <matt@bluematt.me>


### PR DESCRIPTION
src/strlcpy.h was removed by https://github.com/bitcoin/bitcoin/commit/6032e4f4e7c1892a4e3f0a1a2007e4cd0fe99937
