### PR TITLE
[Qt][WIP] allow possibility to add a comment to a WalletTx

### DIFF
--- a/src/qt/forms/sendcoinsdialog.ui
+++ b/src/qt/forms/sendcoinsdialog.ui
@@ -658,6 +658,68 @@
     </widget>
    </item>
    <item>
+    <widget class="QFrame" name="commentFrame">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Sunken</enum>
+     </property>
+     <layout class="QHBoxLayout" name="commentHLayout">
+      <property name="spacing">
+       <number>10</number>
+      </property>
+      <item>
+       <widget class="QLabel" name="labelComment">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="font">
+         <font>
+          <weight>75</weight>
+          <bold>true</bold>
+         </font>
+        </property>
+        <property name="styleSheet">
+         <string notr="true">font-weight:bold;</string>
+        </property>
+        <property name="text">
+         <string>Local Comment:</string>
+        </property>
+        <property name="toolTip">
+            <string>Add a comment to the transaction. The comment will not be transmitted.</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QTextEdit" name="commentTextEdit">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Maximum">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>16777215</width>
+          <height>50</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <widget class="QFrame" name="frameFee">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">

--- a/src/qt/forms/sendcoinsentry.ui
+++ b/src/qt/forms/sendcoinsentry.ui
@@ -23,6 +23,9 @@
    <property name="frameShape">
     <enum>QFrame::NoFrame</enum>
    </property>
+   <property name="frameShadow">
+    <enum>QFrame::Plain</enum>
+   </property>
    <layout class="QGridLayout" name="gridLayout">
     <property name="topMargin">
      <number>8</number>
@@ -708,6 +711,16 @@
       </property>
      </widget>
     </item>
+    <item row="5" column="0" colspan="2">
+        <widget class="Line" name="lineInsecPR">
+            <property name="lineWidth">
+                <number>1</number>
+            </property>
+            <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+            </property>
+        </widget>
+    </item>
    </layout>
   </widget>
   <widget class="QFrame" name="SendCoins_AuthenticatedPaymentRequest">
@@ -1240,6 +1253,16 @@
        <bool>false</bool>
       </property>
      </widget>
+    </item>
+    <item row="5" column="0" colspan="2">
+        <widget class="Line" name="lineSecPR">
+            <property name="lineWidth">
+                <number>1</number>
+            </property>
+            <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+            </property>
+        </widget>
     </item>
    </layout>
   </widget>

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -234,6 +234,10 @@ void SendCoinsDialog::on_sendButton_clicked()
 
     // prepare transaction for getting txFee earlier
     WalletModelTransaction currentTransaction(recipients);
+    
+    // add comment to wtx
+    currentTransaction.setComment(ui->commentTextEdit->toPlainText());
+    
     WalletModel::SendCoinsReturn prepareStatus;
     if (model->getOptionsModel()->getCoinControlFeatures()) // coin control enabled
         prepareStatus = model->prepareTransaction(currentTransaction, CoinControlDialog::coinControl);
@@ -350,6 +354,7 @@ void SendCoinsDialog::clear()
     }
     addEntry();
 
+    ui->commentTextEdit->clear();
     updateTabsAndLabels();
 }
 

--- a/src/qt/walletmodeltransaction.cpp
+++ b/src/qt/walletmodeltransaction.cpp
@@ -97,3 +97,8 @@ CReserveKey *WalletModelTransaction::getPossibleKeyChange()
 {
     return keyChange;
 }
+
+void WalletModelTransaction::setComment(const QString& comment)
+{
+    walletTransaction->mapValue["comment"] = comment.toStdString();
+}

--- a/src/qt/walletmodeltransaction.h
+++ b/src/qt/walletmodeltransaction.h
@@ -36,7 +36,8 @@ public:
     CReserveKey *getPossibleKeyChange();
 
     void reassignAmounts(int nChangePosRet); // needed for the subtract-fee-from-amount feature
-
+    void setComment(const QString& comment);
+    
 private:
     QList<SendCoinsRecipient> recipients;
     CWalletTx *walletTransaction;


### PR DESCRIPTION
Try to sync rpc/qt wallets implementations.
Solves #2086.

![bildschirmfoto 2015-03-15 um 16 40 49](https://cloud.githubusercontent.com/assets/178464/6656708/39c7695c-cb32-11e4-9b62-b2714af9c140.png)

![bildschirmfoto 2015-03-15 um 16 40 59](https://cloud.githubusercontent.com/assets/178464/6656707/39a5d45e-cb32-11e4-8e74-a4c55cac1f12.png)

```
    {
        "account" : "",
        "address" : "mm2STH7X3rbBVd73XaDrwdJHM69ukj31N8",
        "category" : "send",
        "amount" : -1.00000000,
        "vout" : 1,
        "fee" : -0.00000521,
        "confirmations" : 0,
        "txid" : "151e1e32090b765ebc30ebcc385bd79978081130b331972b94e142f3aeb85e10",
        "walletconflicts" : [
        ],
        "time" : 1426434053,
        "timereceived" : 1426434053,
        "comment" : "This is a test wtx comment."
    }
```
