### PR TITLE
privacy: Stream isolation for Tor

### DIFF
--- a/qa/pull-tester/rpc-tests.sh
+++ b/qa/pull-tester/rpc-tests.sh
@@ -27,6 +27,7 @@ testScripts=(
     'mempool_coinbase_spends.py'
     'httpbasics.py'
     'zapwallettxes.py'
+    'proxy_test.py'
 #    'forknotify.py'
 );
 if [ "x${ENABLE_BITCOIND}${ENABLE_UTILS}${ENABLE_WALLET}" = "x111" ]; then

--- a/qa/rpc-tests/proxy_test.py
+++ b/qa/rpc-tests/proxy_test.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python2
+# Copyright (c) 2015 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+import socket
+import traceback, sys
+from binascii import hexlify
+import time, os
+
+from socks5 import Socks5Configuration, Socks5Command, Socks5Server, AddressType
+from test_framework import BitcoinTestFramework
+from util import *
+'''
+Test plan:
+- Start bitcoind's with different proxy configurations
+- Use addnode to initiate connections
+- Verify that proxies are connected to, and the right connection command is given
+- Proxy configurations to test on bitcoind side:
+    - `-proxy` (proxy everything)
+    - `-onion` (proxy just onions)
+    - `-proxyrandomize` Circuit randomization
+- Proxy configurations to test on proxy side,
+    - support no authentication (other proxy)
+    - support no authentication + user/pass authentication (Tor)
+    - proxy on IPv6
+
+- Create various proxies (as threads)
+- Create bitcoinds that connect to them
+- Manipulate the bitcoinds using addnode (onetry) an observe effects
+
+addnode connect to IPv4
+addnode connect to IPv6
+addnode connect to onion
+addnode connect to generic DNS name
+'''
+
+class ProxyTest(BitcoinTestFramework):        
+    def __init__(self):
+        # Create two proxies on different ports
+        # ... one unauthenticated
+        self.conf1 = Socks5Configuration()
+        self.conf1.addr = ('127.0.0.1', 13000 + (os.getpid() % 1000))
+        self.conf1.unauth = True
+        self.conf1.auth = False
+        # ... one supporting authenticated and unauthenticated (Tor)
+        self.conf2 = Socks5Configuration()
+        self.conf2.addr = ('127.0.0.1', 14000 + (os.getpid() % 1000))
+        self.conf2.unauth = True
+        self.conf2.auth = True
+        # ... one on IPv6 with similar configuration
+        self.conf3 = Socks5Configuration()
+        self.conf3.af = socket.AF_INET6
+        self.conf3.addr = ('::1', 15000 + (os.getpid() % 1000))
+        self.conf3.unauth = True
+        self.conf3.auth = True
+
+        self.serv1 = Socks5Server(self.conf1)
+        self.serv1.start()
+        self.serv2 = Socks5Server(self.conf2)
+        self.serv2.start()
+        self.serv3 = Socks5Server(self.conf3)
+        self.serv3.start()
+
+    def setup_nodes(self):
+        # Note: proxies are not used to connect to local nodes
+        # this is because the proxy to use is based on CService.GetNetwork(), which return NET_UNROUTABLE for localhost
+        return start_nodes(4, self.options.tmpdir, extra_args=[
+            ['-listen', '-debug=net', '-debug=proxy', '-proxy=%s:%i' % (self.conf1.addr),'-proxyrandomize=1'], 
+            ['-listen', '-debug=net', '-debug=proxy', '-proxy=%s:%i' % (self.conf1.addr),'-onion=%s:%i' % (self.conf2.addr),'-proxyrandomize=0'], 
+            ['-listen', '-debug=net', '-debug=proxy', '-proxy=%s:%i' % (self.conf2.addr),'-proxyrandomize=1'], 
+            ['-listen', '-debug=net', '-debug=proxy', '-proxy=[%s]:%i' % (self.conf3.addr),'-proxyrandomize=0']
+            ])
+
+    def node_test(self, node, proxies, auth):
+        rv = []
+        # Test: outgoing IPv4 connection through node
+        node.addnode("15.61.23.23:1234", "onetry")
+        cmd = proxies[0].queue.get()
+        assert(isinstance(cmd, Socks5Command))
+        # Note: bitcoind's SOCKS5 implementation only sends atyp DOMAINNAME, even if connecting directly to IPv4/IPv6
+        assert_equal(cmd.atyp, AddressType.DOMAINNAME)
+        assert_equal(cmd.addr, "15.61.23.23")
+        assert_equal(cmd.port, 1234)
+        if not auth:
+            assert_equal(cmd.username, None)
+            assert_equal(cmd.password, None)
+        rv.append(cmd)
+
+        # Test: outgoing IPv6 connection through node
+        node.addnode("[1233:3432:2434:2343:3234:2345:6546:4534]:5443", "onetry")
+        cmd = proxies[1].queue.get()
+        assert(isinstance(cmd, Socks5Command))
+        # Note: bitcoind's SOCKS5 implementation only sends atyp DOMAINNAME, even if connecting directly to IPv4/IPv6
+        assert_equal(cmd.atyp, AddressType.DOMAINNAME)
+        assert_equal(cmd.addr, "1233:3432:2434:2343:3234:2345:6546:4534")
+        assert_equal(cmd.port, 5443)
+        if not auth:
+            assert_equal(cmd.username, None)
+            assert_equal(cmd.password, None)
+        rv.append(cmd)
+
+        # Test: outgoing onion connection through node
+        node.addnode("bitcoinostk4e4re.onion:8333", "onetry")
+        cmd = proxies[2].queue.get()
+        assert(isinstance(cmd, Socks5Command))
+        assert_equal(cmd.atyp, AddressType.DOMAINNAME)
+        assert_equal(cmd.addr, "bitcoinostk4e4re.onion")
+        assert_equal(cmd.port, 8333)
+        if not auth:
+            assert_equal(cmd.username, None)
+            assert_equal(cmd.password, None)
+        rv.append(cmd)
+
+        # Test: outgoing DNS name connection through node
+        node.addnode("node.noumenon:8333", "onetry")
+        cmd = proxies[3].queue.get()
+        assert(isinstance(cmd, Socks5Command))
+        assert_equal(cmd.atyp, AddressType.DOMAINNAME)
+        assert_equal(cmd.addr, "node.noumenon")
+        assert_equal(cmd.port, 8333)
+        if not auth:
+            assert_equal(cmd.username, None)
+            assert_equal(cmd.password, None)
+        rv.append(cmd)
+
+        return rv
+
+    def run_test(self):
+        # basic -proxy
+        self.node_test(self.nodes[0], [self.serv1, self.serv1, self.serv1, self.serv1], False)
+
+        # -proxy plus -onion
+        self.node_test(self.nodes[1], [self.serv1, self.serv1, self.serv2, self.serv1], False)
+
+        # -proxy plus -onion, -proxyrandomize
+        rv = self.node_test(self.nodes[2], [self.serv2, self.serv2, self.serv2, self.serv2], True)
+        # Check that credentials as used for -proxyrandomize connections are unique
+        credentials = set((x.username,x.password) for x in rv)
+        assert_equal(len(credentials), 4)
+
+        # proxy on IPv6 localhost
+        self.node_test(self.nodes[3], [self.serv3, self.serv3, self.serv3, self.serv3], False)
+        
+if __name__ == '__main__':
+    ProxyTest().main()
+

--- a/qa/rpc-tests/socks5.py
+++ b/qa/rpc-tests/socks5.py
@@ -1,0 +1,160 @@
+# Copyright (c) 2015 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+'''
+Dummy Socks5 server for testing.
+'''
+from __future__ import print_function, division, unicode_literals
+import socket, threading, Queue
+import traceback, sys
+
+### Protocol constants
+class Command:
+    CONNECT = 0x01
+
+class AddressType:
+    IPV4 = 0x01
+    DOMAINNAME = 0x03
+    IPV6 = 0x04
+
+### Utility functions
+def recvall(s, n):
+    '''Receive n bytes from a socket, or fail'''
+    rv = bytearray()
+    while n > 0:
+        d = s.recv(n)
+        if not d:
+            raise IOError('Unexpected end of stream')
+        rv.extend(d)
+        n -= len(d)
+    return rv
+
+### Implementation classes
+class Socks5Configuration(object):
+    '''Proxy configuration'''
+    def __init__(self):
+        self.addr = None # Bind address (must be set)
+        self.af = socket.AF_INET # Bind address family
+        self.unauth = False  # Support unauthenticated
+        self.auth = False  # Support authentication
+
+class Socks5Command(object):
+    '''Information about an incoming socks5 command'''
+    def __init__(self, cmd, atyp, addr, port, username, password):
+        self.cmd = cmd # Command (one of Command.*)
+        self.atyp = atyp # Address type (one of AddressType.*)
+        self.addr = addr # Address
+        self.port = port # Port to connect to
+        self.username = username
+        self.password = password
+    def __repr__(self):
+        return 'Socks5Command(%s,%s,%s,%s,%s,%s)' % (self.cmd, self.atyp, self.addr, self.port, self.username, self.password)
+
+class Socks5Connection(object):
+    def __init__(self, serv, conn, peer):
+        self.serv = serv
+        self.conn = conn
+        self.peer = peer
+
+    def handle(self):
+        '''
+        Handle socks5 request according to RFC1928
+        '''
+        try:
+            # Verify socks version
+            ver = recvall(self.conn, 1)[0]
+            if ver != 0x05:
+                raise IOError('Invalid socks version %i' % ver)
+            # Choose authentication method
+            nmethods = recvall(self.conn, 1)[0]
+            methods = bytearray(recvall(self.conn, nmethods))
+            method = None
+            if 0x02 in methods and self.serv.conf.auth:
+                method = 0x02 # username/password
+            elif 0x00 in methods and self.serv.conf.unauth:
+                method = 0x00 # unauthenticated
+            if method is None:
+                raise IOError('No supported authentication method was offered')
+            # Send response
+            self.conn.sendall(bytearray([0x05, method]))
+            # Read authentication (optional)
+            username = None
+            password = None
+            if method == 0x02:
+                ver = recvall(self.conn, 1)[0]
+                if ver != 0x01:
+                    raise IOError('Invalid auth packet version %i' % ver)
+                ulen = recvall(self.conn, 1)[0]
+                username = str(recvall(self.conn, ulen))
+                plen = recvall(self.conn, 1)[0]
+                password = str(recvall(self.conn, plen))
+                # Send authentication response
+                self.conn.sendall(bytearray([0x01, 0x00]))
+
+            # Read connect request
+            (ver,cmd,rsv,atyp) = recvall(self.conn, 4)
+            if ver != 0x05:
+                raise IOError('Invalid socks version %i in connect request' % ver)
+            if cmd != Command.CONNECT:
+                raise IOError('Unhandled command %i in connect request' % cmd)
+
+            if atyp == AddressType.IPV4:
+                addr = recvall(self.conn, 4)
+            elif atyp == AddressType.DOMAINNAME:
+                n = recvall(self.conn, 1)[0]
+                addr = str(recvall(self.conn, n))
+            elif atyp == AddressType.IPV6:
+                addr = recvall(self.conn, 16)
+            else:
+                raise IOError('Unknown address type %i' % atyp)
+            port_hi,port_lo = recvall(self.conn, 2)
+            port = (port_hi << 8) | port_lo
+
+            # Send dummy response
+            self.conn.sendall(bytearray([0x05, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]))
+
+            cmdin = Socks5Command(cmd, atyp, addr, port, username, password)
+            self.serv.queue.put(cmdin)
+            print('Proxy: ', cmdin)
+            # Fall through to disconnect
+        except Exception,e:
+            traceback.print_exc(file=sys.stderr)
+            self.serv.queue.put(e)
+        finally:
+            self.conn.close()
+
+class Socks5Server(object):
+    def __init__(self, conf):
+        self.conf = conf
+        self.s = socket.socket(conf.af)
+        self.s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self.s.bind(conf.addr)
+        self.s.listen(5)
+        self.running = False
+        self.thread = None
+        self.queue = Queue.Queue() # report connections and exceptions to client
+
+    def run(self):
+        while self.running:
+            (sockconn, peer) = self.s.accept()
+            if self.running:
+                conn = Socks5Connection(self, sockconn, peer)
+                thread = threading.Thread(None, conn.handle)
+                thread.daemon = True
+                thread.start()
+    
+    def start(self):
+        assert(not self.running)
+        self.running = True
+        self.thread = threading.Thread(None, self.run)
+        self.thread.daemon = True
+        self.thread.start()
+
+    def stop(self):
+        self.running = False
+        # connect to self to end run loop
+        s = socket.socket(self.conf.af)
+        s.connect(self.conf.addr)
+        s.close()
+        self.thread.join()
+

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -12,6 +12,7 @@
 #include "hash.h"
 #include "sync.h"
 #include "uint256.h"
+#include "random.h"
 #include "util.h"
 #include "utilstrencodings.h"
 
@@ -38,7 +39,7 @@ using namespace std;
 
 // Settings
 static proxyType proxyInfo[NET_MAX];
-static CService nameProxy;
+static proxyType nameProxy;
 static CCriticalSection cs_proxyInfos;
 int nConnectTimeout = DEFAULT_CONNECT_TIMEOUT;
 bool fNameLookup = false;
@@ -285,59 +286,100 @@ bool static InterruptibleRecv(char* data, size_t len, int timeout, SOCKET& hSock
     return len == 0;
 }
 
-bool static Socks5(string strDest, int port, SOCKET& hSocket)
+struct ProxyCredentials
+{
+    std::string username;
+    std::string password;
+};
+
+/** Connect using SOCKS5 (as described in RFC1928) */
+bool static Socks5(string strDest, int port, const ProxyCredentials *auth, SOCKET& hSocket)
 {
     LogPrintf("SOCKS5 connecting %s\n", strDest);
-    if (strDest.size() > 255)
-    {
+    if (strDest.size() > 255) {
         CloseSocket(hSocket);
         return error("Hostname too long");
     }
-    char pszSocks5Init[] = "\5\1\0";
-    ssize_t nSize = sizeof(pszSocks5Init) - 1;
-
-    ssize_t ret = send(hSocket, pszSocks5Init, nSize, MSG_NOSIGNAL);
-    if (ret != nSize)
-    {
+    // Accepted authentication methods
+    std::vector<uint8_t> vSocks5Init;
+    vSocks5Init.push_back(0x05);
+    if (auth) {
+        vSocks5Init.push_back(0x02); // # METHODS
+        vSocks5Init.push_back(0x00); // X'00' NO AUTHENTICATION REQUIRED
+        vSocks5Init.push_back(0x02); // X'02' USERNAME/PASSWORD (RFC1929)
+    } else {
+        vSocks5Init.push_back(0x01); // # METHODS
+        vSocks5Init.push_back(0x00); // X'00' NO AUTHENTICATION REQUIRED
+    }
+    ssize_t ret = send(hSocket, (const char*)begin_ptr(vSocks5Init), vSocks5Init.size(), MSG_NOSIGNAL);
+    if (ret != (ssize_t)vSocks5Init.size()) {
         CloseSocket(hSocket);
         return error("Error sending to proxy");
     }
     char pchRet1[2];
-    if (!InterruptibleRecv(pchRet1, 2, SOCKS5_RECV_TIMEOUT, hSocket))
-    {
+    if (!InterruptibleRecv(pchRet1, 2, SOCKS5_RECV_TIMEOUT, hSocket)) {
         CloseSocket(hSocket);
         return error("Error reading proxy response");
     }
-    if (pchRet1[0] != 0x05 || pchRet1[1] != 0x00)
-    {
+    if (pchRet1[0] != 0x05) {
         CloseSocket(hSocket);
         return error("Proxy failed to initialize");
     }
-    string strSocks5("\5\1");
-    strSocks5 += '\000'; strSocks5 += '\003';
-    strSocks5 += static_cast<char>(std::min((int)strDest.size(), 255));
-    strSocks5 += strDest;
-    strSocks5 += static_cast<char>((port >> 8) & 0xFF);
-    strSocks5 += static_cast<char>((port >> 0) & 0xFF);
-    ret = send(hSocket, strSocks5.data(), strSocks5.size(), MSG_NOSIGNAL);
-    if (ret != (ssize_t)strSocks5.size())
-    {
+    if (pchRet1[1] == 0x02 && auth) {
+        // Perform username/password authentication (as described in RFC1929)
+        std::vector<uint8_t> vAuth;
+        vAuth.push_back(0x01);
+        if (auth->username.size() > 255 || auth->password.size() > 255)
+            return error("Proxy username or password too long");
+        vAuth.push_back(auth->username.size());
+        vAuth.insert(vAuth.end(), auth->username.begin(), auth->username.end());
+        vAuth.push_back(auth->password.size());
+        vAuth.insert(vAuth.end(), auth->password.begin(), auth->password.end());
+        ret = send(hSocket, (const char*)begin_ptr(vAuth), vAuth.size(), MSG_NOSIGNAL);
+        if (ret != (ssize_t)vAuth.size()) {
+            CloseSocket(hSocket);
+            return error("Error sending authentication to proxy");
+        }
+        LogPrint("proxy", "SOCKS5 sending proxy authentication %s:%s\n", auth->username, auth->password);
+        char pchRetA[2];
+        if (!InterruptibleRecv(pchRetA, 2, SOCKS5_RECV_TIMEOUT, hSocket)) {
+            CloseSocket(hSocket);
+            return error("Error reading proxy authentication response");
+        }
+        if (pchRetA[0] != 0x01 || pchRetA[1] != 0x00) {
+            CloseSocket(hSocket);
+            return error("Proxy authentication unsuccesful");
+        }
+    } else if (pchRet1[1] == 0x00) {
+        // Perform no authentication
+    } else {
+        CloseSocket(hSocket);
+        return error("Proxy requested wrong authentication method %02x", pchRet1[1]);
+    }
+    std::vector<uint8_t> vSocks5;
+    vSocks5.push_back(0x05); // VER protocol version
+    vSocks5.push_back(0x01); // CMD CONNECT
+    vSocks5.push_back(0x00); // RSV Reserved
+    vSocks5.push_back(0x03); // ATYP DOMAINNAME
+    vSocks5.push_back(strDest.size()); // Length<=255 is checked at beginning of function
+    vSocks5.insert(vSocks5.end(), strDest.begin(), strDest.end());
+    vSocks5.push_back((port >> 8) & 0xFF);
+    vSocks5.push_back((port >> 0) & 0xFF);
+    ret = send(hSocket, (const char*)begin_ptr(vSocks5), vSocks5.size(), MSG_NOSIGNAL);
+    if (ret != (ssize_t)vSocks5.size()) {
         CloseSocket(hSocket);
         return error("Error sending to proxy");
     }
     char pchRet2[4];
-    if (!InterruptibleRecv(pchRet2, 4, SOCKS5_RECV_TIMEOUT, hSocket))
-    {
+    if (!InterruptibleRecv(pchRet2, 4, SOCKS5_RECV_TIMEOUT, hSocket)) {
         CloseSocket(hSocket);
         return error("Error reading proxy response");
     }
-    if (pchRet2[0] != 0x05)
-    {
+    if (pchRet2[0] != 0x05) {
         CloseSocket(hSocket);
         return error("Proxy failed to accept request");
     }
-    if (pchRet2[1] != 0x00)
-    {
+    if (pchRet2[1] != 0x00) {
         CloseSocket(hSocket);
         switch (pchRet2[1])
         {
@@ -352,8 +394,7 @@ bool static Socks5(string strDest, int port, SOCKET& hSocket)
             default:   return error("Proxy error: unknown");
         }
     }
-    if (pchRet2[2] != 0x00)
-    {
+    if (pchRet2[2] != 0x00) {
         CloseSocket(hSocket);
         return error("Error: malformed proxy response");
     }
@@ -375,13 +416,11 @@ bool static Socks5(string strDest, int port, SOCKET& hSocket)
         }
         default: CloseSocket(hSocket); return error("Error: malformed proxy response");
     }
-    if (!ret)
-    {
+    if (!ret) {
         CloseSocket(hSocket);
         return error("Error reading from proxy");
     }
-    if (!InterruptibleRecv(pchRet3, 2, SOCKS5_RECV_TIMEOUT, hSocket))
-    {
+    if (!InterruptibleRecv(pchRet3, 2, SOCKS5_RECV_TIMEOUT, hSocket)) {
         CloseSocket(hSocket);
         return error("Error reading from proxy");
     }
@@ -471,7 +510,7 @@ bool static ConnectSocketDirectly(const CService &addrConnect, SOCKET& hSocketRe
     return true;
 }
 
-bool SetProxy(enum Network net, CService addrProxy) {
+bool SetProxy(enum Network net, const proxyType &addrProxy) {
     assert(net >= 0 && net < NET_MAX);
     if (!addrProxy.IsValid())
         return false;
@@ -489,7 +528,7 @@ bool GetProxy(enum Network net, proxyType &proxyInfoOut) {
     return true;
 }
 
-bool SetNameProxy(CService addrProxy) {
+bool SetNameProxy(const proxyType &addrProxy) {
     if (!addrProxy.IsValid())
         return false;
     LOCK(cs_proxyInfos);
@@ -497,7 +536,7 @@ bool SetNameProxy(CService addrProxy) {
     return true;
 }
 
-bool GetNameProxy(CService &nameProxyOut) {
+bool GetNameProxy(proxyType &nameProxyOut) {
     LOCK(cs_proxyInfos);
     if(!nameProxy.IsValid())
         return false;
@@ -513,10 +552,35 @@ bool HaveNameProxy() {
 bool IsProxy(const CNetAddr &addr) {
     LOCK(cs_proxyInfos);
     for (int i = 0; i < NET_MAX; i++) {
-        if (addr == (CNetAddr)proxyInfo[i])
+        if (addr == (CNetAddr)proxyInfo[i].proxy)
             return true;
     }
     return false;
+}
+
+static bool ConnectThroughProxy(const proxyType &proxy, const std::string strDest, int port, SOCKET& hSocketRet, int nTimeout, bool *outProxyConnectionFailed)
+{
+    SOCKET hSocket = INVALID_SOCKET;
+    // first connect to proxy server
+    if (!ConnectSocketDirectly(proxy.proxy, hSocket, nTimeout)) {
+        if (outProxyConnectionFailed)
+            *outProxyConnectionFailed = true;
+        return false;
+    }
+    // do socks negotiation
+    if (proxy.randomize_credentials) {
+        ProxyCredentials random_auth;
+        random_auth.username = strprintf("%i", insecure_rand());
+        random_auth.password = strprintf("%i", insecure_rand());
+        if (!Socks5(strDest, (unsigned short)port, &random_auth, hSocket))
+            return false;
+    } else {
+        if (!Socks5(strDest, (unsigned short)port, 0, hSocket))
+            return false;
+    }
+
+    hSocketRet = hSocket;
+    return true;
 }
 
 bool ConnectSocket(const CService &addrDest, SOCKET& hSocketRet, int nTimeout, bool *outProxyConnectionFailed)
@@ -524,24 +588,11 @@ bool ConnectSocket(const CService &addrDest, SOCKET& hSocketRet, int nTimeout, b
     proxyType proxy;
     if (outProxyConnectionFailed)
         *outProxyConnectionFailed = false;
-    // no proxy needed (none set for target network)
-    if (!GetProxy(addrDest.GetNetwork(), proxy))
+
+    if (GetProxy(addrDest.GetNetwork(), proxy))
+        return ConnectThroughProxy(proxy, addrDest.ToStringIP(), addrDest.GetPort(), hSocketRet, nTimeout, outProxyConnectionFailed);
+    else // no proxy needed (none set for target network)
         return ConnectSocketDirectly(addrDest, hSocketRet, nTimeout);
-
-    SOCKET hSocket = INVALID_SOCKET;
-
-    // first connect to proxy server
-    if (!ConnectSocketDirectly(proxy, hSocket, nTimeout)) {
-        if (outProxyConnectionFailed)
-            *outProxyConnectionFailed = true;
-        return false;
-    }
-    // do socks negotiation
-    if (!Socks5(addrDest.ToStringIP(), addrDest.GetPort(), hSocket))
-        return false;
-
-    hSocketRet = hSocket;
-    return true;
 }
 
 bool ConnectSocketByName(CService &addr, SOCKET& hSocketRet, const char *pszDest, int portDefault, int nTimeout, bool *outProxyConnectionFailed)
@@ -554,9 +605,7 @@ bool ConnectSocketByName(CService &addr, SOCKET& hSocketRet, const char *pszDest
 
     SplitHostPort(string(pszDest), port, strDest);
 
-    SOCKET hSocket = INVALID_SOCKET;
-
-    CService nameProxy;
+    proxyType nameProxy;
     GetNameProxy(nameProxy);
 
     CService addrResolved(CNetAddr(strDest, fNameLookup && !HaveNameProxy()), port);
@@ -569,18 +618,7 @@ bool ConnectSocketByName(CService &addr, SOCKET& hSocketRet, const char *pszDest
 
     if (!HaveNameProxy())
         return false;
-    // first connect to name proxy server
-    if (!ConnectSocketDirectly(nameProxy, hSocket, nTimeout)) {
-        if (outProxyConnectionFailed)
-            *outProxyConnectionFailed = true;
-        return false;
-    }
-    // do socks negotiation
-    if (!Socks5(strDest, (unsigned short)port, hSocket))
-        return false;
-
-    hSocketRet = hSocket;
-    return true;
+    return ConnectThroughProxy(nameProxy, strDest, port, hSocketRet, nTimeout, outProxyConnectionFailed);
 }
 
 void CNetAddr::Init()

--- a/src/netbase.h
+++ b/src/netbase.h
@@ -168,15 +168,25 @@ class CService : public CNetAddr
         }
 };
 
-typedef CService proxyType;
+class proxyType
+{
+public:
+    proxyType(): randomize_credentials(false) {}
+    proxyType(const CService &proxy, bool randomize_credentials=false): proxy(proxy), randomize_credentials(randomize_credentials) {}
+
+    bool IsValid() const { return proxy.IsValid(); }
+
+    CService proxy;
+    bool randomize_credentials;
+};
 
 enum Network ParseNetwork(std::string net);
 std::string GetNetworkName(enum Network net);
 void SplitHostPort(std::string in, int &portOut, std::string &hostOut);
-bool SetProxy(enum Network net, CService addrProxy);
+bool SetProxy(enum Network net, const proxyType &addrProxy);
 bool GetProxy(enum Network net, proxyType &proxyInfoOut);
 bool IsProxy(const CNetAddr &addr);
-bool SetNameProxy(CService addrProxy);
+bool SetNameProxy(const proxyType &addrProxy);
 bool HaveNameProxy();
 bool LookupHost(const char *pszName, std::vector<CNetAddr>& vIP, unsigned int nMaxSolutions = 0, bool fAllowLookup = true);
 bool Lookup(const char *pszName, CService& addr, int portDefault = 0, bool fAllowLookup = true);

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -335,8 +335,8 @@ bool OptionsModel::getProxySettings(QNetworkProxy& proxy) const
     proxyType curProxy;
     if (GetProxy(NET_IPV4, curProxy)) {
         proxy.setType(QNetworkProxy::Socks5Proxy);
-        proxy.setHostName(QString::fromStdString(curProxy.ToStringIP()));
-        proxy.setPort(curProxy.GetPort());
+        proxy.setHostName(QString::fromStdString(curProxy.proxy.ToStringIP()));
+        proxy.setPort(curProxy.proxy.GetPort());
 
         return true;
     }

--- a/src/rpcmisc.cpp
+++ b/src/rpcmisc.cpp
@@ -90,7 +90,7 @@ Value getinfo(const Array& params, bool fHelp)
     obj.push_back(Pair("blocks",        (int)chainActive.Height()));
     obj.push_back(Pair("timeoffset",    GetTimeOffset()));
     obj.push_back(Pair("connections",   (int)vNodes.size()));
-    obj.push_back(Pair("proxy",         (proxy.IsValid() ? proxy.ToStringIPPort() : string())));
+    obj.push_back(Pair("proxy",         (proxy.IsValid() ? proxy.proxy.ToStringIPPort() : string())));
     obj.push_back(Pair("difficulty",    (double)GetDifficulty()));
     obj.push_back(Pair("testnet",       Params().TestnetToBeDeprecatedFieldRPC()));
 #ifdef ENABLE_WALLET

--- a/src/rpcnet.cpp
+++ b/src/rpcnet.cpp
@@ -371,7 +371,8 @@ static Array GetNetworksInfo()
         obj.push_back(Pair("name", GetNetworkName(network)));
         obj.push_back(Pair("limited", IsLimited(network)));
         obj.push_back(Pair("reachable", IsReachable(network)));
-        obj.push_back(Pair("proxy", proxy.IsValid() ? proxy.ToStringIPPort() : string()));
+        obj.push_back(Pair("proxy", proxy.IsValid() ? proxy.proxy.ToStringIPPort() : string()));
+        obj.push_back(Pair("proxy_randomize_credentials", proxy.randomize_credentials));
         networks.push_back(obj);
     }
     return networks;


### PR DESCRIPTION
According to Tor's extensions to the SOCKS protocol (https://gitweb.torproject.org/torspec.git/tree/socks-extensions.txt) it is possible to perform stream isolation by providing authentication to the proxy. Each set of credentials will create a new circuit, which makes it harder to correlate connections.

This patch adds an option, `-proxyrandomize` (on by default) that randomizes credentials for every outgoing connection, thus creating a new circuit for every peer connection.

```
2015-03-16 15:29:59 SOCKS5 Sending proxy authentication 3842137544:3256031132
```

Aside: we really need tests for the proxy functionality (as mentioned in other proxy-related pulls #5298, #4871, #4587), and I plan on adding a few, but I've put this up so it can already get some review and manual testing.
