### PR TITLE
fix a static qt5 crash when using certain versions of libxcb

### DIFF
--- a/depends/packages/libxcb.mk
+++ b/depends/packages/libxcb.mk
@@ -13,8 +13,13 @@ define $(package)_preprocess_cmds
   sed "s/pthread-stubs//" -i configure
 endef
 
+# Don't install xcb headers to the default path in order to work around a qt
+# build issue: https://bugreports.qt.io/browse/QTBUG-34748
+# When using qt's internal libxcb, it may end up finding the real headers in
+# depends staging. Use a non-default path to avoid that.
+
 define $(package)_config_cmds
-  $($(package)_autoconf)
+  $($(package)_autoconf) --includedir=$(host_prefix)/include/xcb-shared
 endef
 
 define $(package)_build_cmds

--- a/depends/patches/qt/fix-xcb-include-order.patch
+++ b/depends/patches/qt/fix-xcb-include-order.patch
@@ -1,21 +1,31 @@
---- old/qtbase/src/plugins/platforms/xcb/xcb-plugin.pro	2014-07-30 18:17:27.384458441 -0400
-+++ new/qtbase/src/plugins/platforms/xcb/xcb-plugin.pro	2014-07-30 18:18:28.620459303 -0400
-@@ -101,10 +101,6 @@
-     }
- }
- 
--DEFINES += $$QMAKE_DEFINES_XCB
--LIBS += $$QMAKE_LIBS_XCB
+--- old/qtbase/src/plugins/platforms/xcb/xcb-plugin.pro 2015-03-17 02:06:42.705930685 +0000
++++ new/qtbase/src/plugins/platforms/xcb/xcb-plugin.pro 2015-03-17 02:08:41.281926351 +0000
+@@ -103,7 +103,6 @@
+
+ DEFINES += $$QMAKE_DEFINES_XCB
+ LIBS += $$QMAKE_LIBS_XCB
 -QMAKE_CXXFLAGS += $$QMAKE_CFLAGS_XCB
--
+
  CONFIG += qpa/genericunixfontdatabase
- 
- contains(QT_CONFIG, dbus) {
-@@ -141,3 +137,7 @@
-         INCLUDEPATH += ../../../3rdparty/xkbcommon/xkbcommon/
-     }
- }
-+
-+DEFINES += $$QMAKE_DEFINES_XCB
-+LIBS += $$QMAKE_LIBS_XCB
-+INCLUDEPATH += $$QMAKE_CFLAGS_XCB
+
+@@ -118,7 +117,8 @@
+ contains(QT_CONFIG, xcb-qt) {
+     DEFINES += XCB_USE_RENDER
+     XCB_DIR = ../../../3rdparty/xcb
+-    INCLUDEPATH += $$XCB_DIR/include $$XCB_DIR/sysinclude
++    QMAKE_CFLAGS += -I$$XCB_DIR/include -I$$XCB_DIR/sysinclude $$QMAKE_CFLAGS_XCB
++    QMAKE_CXXFLAGS += -I$$XCB_DIR/include -I$$XCB_DIR/sysinclude $$QMAKE_CFLAGS_XCB
+     LIBS += -lxcb -L$$OUT_PWD/xcb-static -lxcb-static
+ } else {
+     LIBS += -lxcb -lxcb-image -lxcb-icccm -lxcb-sync -lxcb-xfixes -lxcb-shm -lxcb-randr
+--- old/qtbase/src/plugins/platforms/xcb/xcb-static/xcb-static.pro      2015-03-17 02:07:04.641929383 +0000
++++ new/qtbase/src/plugins/platforms/xcb/xcb-static/xcb-static.pro      2015-03-17 02:10:15.485922059 +0000
+@@ -8,7 +8,7 @@
+
+ XCB_DIR = ../../../../3rdparty/xcb
+
+-INCLUDEPATH += $$XCB_DIR/include $$XCB_DIR/include/xcb $$XCB_DIR/sysinclude
++QMAKE_CFLAGS += -I$$XCB_DIR/include -I$$XCB_DIR/include/xcb -I$$XCB_DIR/sysinclude $$QMAKE_CFLAGS_XCB
+
+ # ignore compiler warnings in 3rdparty code
+ QMAKE_CFLAGS_STATIC_LIB+=-w


### PR DESCRIPTION
This one's really subtle. Fixes #5910. Confirmed fixed in gitian.

See here for background: https://bugreports.qt.io/browse/QTBUG-34748

libxcb temporarily had an abi breakage which caused crashes when qt was compiled against a non-compatible version. Building qt with -qt-xcb should have shielded us from this issue, except that incompatible headers were used when building qt's wrapper.

Make sure those headers aren't picked up by qt's build.

Details:

qt's build adds a wrapper around the xcb libs when -qt-xcb is used. This is done to avoid having to link to a handful of different libs, which may not be api/abi stable. This build depends on include-order, so that its files are found before the real libxcb headers.

Our build (for other reasons related to qt's complicated build-system) injects our prefix into CXXFLAGS. Because libxcb is found in this path, that reverses the include-order, negating the purpose of the wrapper.

To fix, libxcb's includes are simply moved to a subdir. pkg-config ensures that they're still found properly when needed.

To make things even more interesting, this behavior in qt's .pro files is broken:
INCLUDEPATH += $$QMAKE_CFLAGS_XCB

The INCLUDEPATH variable is processed by qmake which automatically prefixes each entry with "-I". The QMAKE_CFLAGS_XCB variable comes from pkg-config and already contains -I, making the path look like "-I-I/path/to/xcb/headers".

To work around that, CFLAGS/CXXFLAGS are used here rather than INCLUDEPATH.
