### PR TITLE
add key generation type

### DIFF
--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -134,6 +134,8 @@ UniValue importprivkey(const UniValue& params, bool fHelp)
             return NullUniValue;
 
         pwalletMain->mapKeyMetadata[vchAddress].nCreateTime = 1;
+        pwalletMain->mapKeyMetadata[vchAddress].keyFlags |= CKeyMetadata::KEY_GENERATION_TYPE_IMPORTED;
+        
 
         if (!pwalletMain->AddKeyPubKey(key, pubkey))
             throw JSONRPCError(RPC_WALLET_ERROR, "Error adding key to wallet");

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -134,8 +134,7 @@ UniValue importprivkey(const UniValue& params, bool fHelp)
             return NullUniValue;
 
         pwalletMain->mapKeyMetadata[vchAddress].nCreateTime = 1;
-        pwalletMain->mapKeyMetadata[vchAddress].keyFlags |= CKeyMetadata::KEY_GENERATION_TYPE_IMPORTED;
-        
+        pwalletMain->mapKeyMetadata[vchAddress].keyFlags |= CKeyMetadata::KEY_ORIGIN_IMPORTED;
 
         if (!pwalletMain->AddKeyPubKey(key, pubkey))
             throw JSONRPCError(RPC_WALLET_ERROR, "Error adding key to wallet");

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1166,6 +1166,22 @@ UniValue ListReceived(const UniValue& params, bool fByAccounts)
             fIsWatchonly = (*it).second.fIsWatchonly;
         }
 
+        // convert keyflags into a string
+        CKeyID keyID;
+        uint8_t keyFlags = 0;
+        if (address.GetKeyID(keyID))
+            keyFlags = pwalletMain->mapKeyMetadata[keyID].keyFlags;
+
+        std::string keyGenerationType;
+        if (keyFlags & CKeyMetadata::KEY_GENERATION_TYPE_UNKNOWN)
+            keyGenerationType = "unknown";
+        if (keyFlags & CKeyMetadata::KEY_GENERATION_TYPE_ENC_WALLET)
+            keyGenerationType = "encrypted";
+        else if (keyFlags & CKeyMetadata::KEY_GENERATION_TYPE_UNENC_WALLET)
+            keyGenerationType = "unencrypted";
+        if (keyFlags & CKeyMetadata::KEY_GENERATION_TYPE_IMPORTED)
+            keyGenerationType = "imported";
+        
         if (fByAccounts)
         {
             tallyitem& item = mapAccountTally[strAccount];
@@ -1181,6 +1197,7 @@ UniValue ListReceived(const UniValue& params, bool fByAccounts)
             obj.push_back(Pair("address",       address.ToString()));
             obj.push_back(Pair("account",       strAccount));
             obj.push_back(Pair("amount",        ValueFromAmount(nAmount)));
+            obj.push_back(Pair("key_generation_type", keyGenerationType));
             obj.push_back(Pair("confirmations", (nConf == std::numeric_limits<int>::max() ? 0 : nConf)));
             UniValue transactions(UniValue::VARR);
             if (it != mapTally.end())

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1172,16 +1172,16 @@ UniValue ListReceived(const UniValue& params, bool fByAccounts)
         if (address.GetKeyID(keyID))
             keyFlags = pwalletMain->mapKeyMetadata[keyID].keyFlags;
 
-        std::string keyGenerationType;
-        if (keyFlags & CKeyMetadata::KEY_GENERATION_TYPE_UNKNOWN)
-            keyGenerationType = "unknown";
-        if (keyFlags & CKeyMetadata::KEY_GENERATION_TYPE_ENC_WALLET)
-            keyGenerationType = "encrypted";
-        else if (keyFlags & CKeyMetadata::KEY_GENERATION_TYPE_UNENC_WALLET)
-            keyGenerationType = "unencrypted";
-        if (keyFlags & CKeyMetadata::KEY_GENERATION_TYPE_IMPORTED)
-            keyGenerationType = "imported";
-        
+        std::string keyOrigin;
+        if (keyFlags & CKeyMetadata::KEY_ORIGIN_UNKNOWN)
+            keyOrigin = "unknown";
+        if (keyFlags & CKeyMetadata::KEY_ORIGIN_ENC_WALLET)
+            keyOrigin = "encrypted";
+        else if (keyFlags & CKeyMetadata::KEY_ORIGIN_UNENC_WALLET)
+            keyOrigin = "unencrypted";
+        if (keyFlags & CKeyMetadata::KEY_ORIGIN_IMPORTED)
+            keyOrigin = "imported";
+
         if (fByAccounts)
         {
             tallyitem& item = mapAccountTally[strAccount];
@@ -1197,7 +1197,7 @@ UniValue ListReceived(const UniValue& params, bool fByAccounts)
             obj.push_back(Pair("address",       address.ToString()));
             obj.push_back(Pair("account",       strAccount));
             obj.push_back(Pair("amount",        ValueFromAmount(nAmount)));
-            obj.push_back(Pair("key_generation_type", keyGenerationType));
+            obj.push_back(Pair("key_origin", keyOrigin));
             obj.push_back(Pair("confirmations", (nConf == std::numeric_limits<int>::max() ? 0 : nConf)));
             UniValue transactions(UniValue::VARR);
             if (it != mapTally.end())

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -94,11 +94,16 @@ CPubKey CWallet::GenerateNewKey()
 
     // Create new metadata
     int64_t nCreationTime = GetTime();
-    
+
     CKeyMetadata metadata = CKeyMetadata(nCreationTime);
-    metadata.keyFlags |= IsCrypted() ? CKeyMetadata::KEY_GENERATION_TYPE_ENC_WALLET : CKeyMetadata::KEY_GENERATION_TYPE_UNENC_WALLET;
+    //check if the wallet supports keyflags
+    if (CanSupportFeature(FEATURE_KEYFLAGS))
+    {
+        metadata.nVersion = CKeyMetadata::VERSION_SUPPORT_FLAGS;
+        metadata.keyFlags |= IsCrypted() ? CKeyMetadata::KEY_ORIGIN_ENC_WALLET : CKeyMetadata::KEY_ORIGIN_UNENC_WALLET;
+    }
     mapKeyMetadata[pubkey.GetID()] = metadata;
-    
+
     if (!nTimeFirstKey || nCreationTime < nTimeFirstKey)
         nTimeFirstKey = nCreationTime;
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -94,7 +94,11 @@ CPubKey CWallet::GenerateNewKey()
 
     // Create new metadata
     int64_t nCreationTime = GetTime();
-    mapKeyMetadata[pubkey.GetID()] = CKeyMetadata(nCreationTime);
+    
+    CKeyMetadata metadata = CKeyMetadata(nCreationTime);
+    metadata.keyFlags |= IsCrypted() ? CKeyMetadata::KEY_GENERATION_TYPE_ENC_WALLET : CKeyMetadata::KEY_GENERATION_TYPE_UNENC_WALLET;
+    mapKeyMetadata[pubkey.GetID()] = metadata;
+    
     if (!nTimeFirstKey || nCreationTime < nTimeFirstKey)
         nTimeFirstKey = nCreationTime;
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -66,8 +66,9 @@ enum WalletFeature
 
     FEATURE_WALLETCRYPT = 40000, // wallet encryption
     FEATURE_COMPRPUBKEY = 60000, // compressed public keys
+    FEATURE_KEYFLAGS    = 70000, // key metadata flags for storing informations like key origin
 
-    FEATURE_LATEST = 60000
+    FEATURE_LATEST = 70000
 };
 
 

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -41,12 +41,14 @@ enum DBErrors
 class CKeyMetadata
 {
 public:
-    static const int CURRENT_VERSION=2;
-    static const uint8_t KEY_GENERATION_TYPE_UNKNOWN       = 0x0001;
-    static const uint8_t KEY_GENERATION_TYPE_IMPORTED      = 0x0002;
-    static const uint8_t KEY_GENERATION_TYPE_UNENC_WALLET  = 0x0004;
-    static const uint8_t KEY_GENERATION_TYPE_ENC_WALLET    = 0x0008;
-    
+    static const int CURRENT_VERSION=1;
+    static const int VERSION_SUPPORT_FLAGS=2;
+    static const uint8_t KEY_ORIGIN_UNSET         = 0x0000;
+    static const uint8_t KEY_ORIGIN_UNKNOWN       = 0x0001;
+    static const uint8_t KEY_ORIGIN_IMPORTED      = 0x0002;
+    static const uint8_t KEY_ORIGIN_UNENC_WALLET  = 0x0004;
+    static const uint8_t KEY_ORIGIN_ENC_WALLET    = 0x0008;
+
     int nVersion;
     int64_t nCreateTime; // 0 means unknown
     uint8_t keyFlags;
@@ -59,7 +61,7 @@ public:
     {
         nVersion = CKeyMetadata::CURRENT_VERSION;
         nCreateTime = nCreateTime_;
-        keyFlags = KEY_GENERATION_TYPE_UNKNOWN;
+        keyFlags = KEY_ORIGIN_UNSET;
     }
 
     ADD_SERIALIZE_METHODS;
@@ -69,7 +71,7 @@ public:
         READWRITE(this->nVersion);
         nVersion = this->nVersion;
         READWRITE(nCreateTime);
-        if (nVersion >= 2)
+        if (nVersion >= VERSION_SUPPORT_FLAGS)
             READWRITE(keyFlags);
     }
 
@@ -77,7 +79,7 @@ public:
     {
         nVersion = CKeyMetadata::CURRENT_VERSION;
         nCreateTime = 0;
-        keyFlags = KEY_GENERATION_TYPE_UNKNOWN;
+        keyFlags = KEY_ORIGIN_UNSET;
     }
 };
 

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -41,9 +41,15 @@ enum DBErrors
 class CKeyMetadata
 {
 public:
-    static const int CURRENT_VERSION=1;
+    static const int CURRENT_VERSION=2;
+    static const uint8_t KEY_GENERATION_TYPE_UNKNOWN       = 0x0001;
+    static const uint8_t KEY_GENERATION_TYPE_IMPORTED      = 0x0002;
+    static const uint8_t KEY_GENERATION_TYPE_UNENC_WALLET  = 0x0004;
+    static const uint8_t KEY_GENERATION_TYPE_ENC_WALLET    = 0x0008;
+    
     int nVersion;
     int64_t nCreateTime; // 0 means unknown
+    uint8_t keyFlags;
 
     CKeyMetadata()
     {
@@ -53,6 +59,7 @@ public:
     {
         nVersion = CKeyMetadata::CURRENT_VERSION;
         nCreateTime = nCreateTime_;
+        keyFlags = KEY_GENERATION_TYPE_UNKNOWN;
     }
 
     ADD_SERIALIZE_METHODS;
@@ -62,12 +69,15 @@ public:
         READWRITE(this->nVersion);
         nVersion = this->nVersion;
         READWRITE(nCreateTime);
+        if (nVersion >= 2)
+            READWRITE(keyFlags);
     }
 
     void SetNull()
     {
         nVersion = CKeyMetadata::CURRENT_VERSION;
         nCreateTime = 0;
+        keyFlags = KEY_GENERATION_TYPE_UNKNOWN;
     }
 };
 

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -43,15 +43,14 @@ class CKeyMetadata
 public:
     static const int CURRENT_VERSION=1;
     static const int VERSION_SUPPORT_FLAGS=2;
-    static const uint8_t KEY_ORIGIN_UNSET         = 0x0000;
-    static const uint8_t KEY_ORIGIN_UNKNOWN       = 0x0001;
-    static const uint8_t KEY_ORIGIN_IMPORTED      = 0x0002;
-    static const uint8_t KEY_ORIGIN_UNENC_WALLET  = 0x0004;
-    static const uint8_t KEY_ORIGIN_ENC_WALLET    = 0x0008;
+    static const uint32_t KEY_ORIGIN_UNKNOWN       = 0x00000000;
+    static const uint32_t KEY_ORIGIN_IMPORTED      = 0x00000001;
+    static const uint32_t KEY_ORIGIN_UNENC_WALLET  = 0x00000002;
+    static const uint32_t KEY_ORIGIN_ENC_WALLET    = 0x00000004;
 
     int nVersion;
     int64_t nCreateTime; // 0 means unknown
-    uint8_t keyFlags;
+    uint32_t keyFlags;
 
     CKeyMetadata()
     {
@@ -59,9 +58,8 @@ public:
     }
     CKeyMetadata(int64_t nCreateTime_)
     {
-        nVersion = CKeyMetadata::CURRENT_VERSION;
+        SetNull();
         nCreateTime = nCreateTime_;
-        keyFlags = KEY_ORIGIN_UNSET;
     }
 
     ADD_SERIALIZE_METHODS;
@@ -79,7 +77,7 @@ public:
     {
         nVersion = CKeyMetadata::CURRENT_VERSION;
         nCreateTime = 0;
-        keyFlags = KEY_ORIGIN_UNSET;
+        keyFlags = KEY_ORIGIN_UNKNOWN;
     }
 };
 


### PR DESCRIPTION
A encrypted wallet can still hold keys which where created when the wallet was unencrypted.
Could solve #3314.

This PR will add a 8bit-flags-int to the CKeyMetadata class.

`listreceivedbyaddress` will report whether the key was generated within a encrypted wallet or if it was imported throught `importprivkey`.

If this gets conceptual ACKs id like to extend this to the UI level.
