### PR TITLE
Use equivalent PoW for non-main-chain requests

### DIFF
--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -114,3 +114,20 @@ arith_uint256 GetBlockProof(const CBlockIndex& block)
     // or ~bnTarget / (nTarget+1) + 1.
     return (~bnTarget / (bnTarget + 1)) + 1;
 }
+
+int64_t GetBlockProofEquivalentTime(const CBlockIndex& to, const CBlockIndex& from, const CBlockIndex& tip, const Consensus::Params& params)
+{
+    arith_uint256 r;
+    int sign = 1;
+    if (to.nChainWork > from.nChainWork) {
+        r = to.nChainWork - from.nChainWork;
+    } else {
+        r = from.nChainWork - to.nChainWork;
+        sign = -1;
+    }
+    r = r * arith_uint256(params.nPowTargetSpacing) / GetBlockProof(tip);
+    if (r.bits() > 63) {
+        return sign * std::numeric_limits<int64_t>::max();
+    }
+    return sign * r.GetLow64();
+}

--- a/src/pow.h
+++ b/src/pow.h
@@ -22,4 +22,7 @@ unsigned int CalculateNextWorkRequired(const CBlockIndex* pindexLast, int64_t nF
 bool CheckProofOfWork(uint256 hash, unsigned int nBits, const Consensus::Params&);
 arith_uint256 GetBlockProof(const CBlockIndex& block);
 
+/** Return the time it would take to redo the work difference between from and to, assuming the current hashrate corresponds to the difficulty at tip, in seconds. */
+int64_t GetBlockProofEquivalentTime(const CBlockIndex& to, const CBlockIndex& from, const CBlockIndex& tip, const Consensus::Params&);
+
 #endif // BITCOIN_POW_H

--- a/src/test/pow_tests.cpp
+++ b/src/test/pow_tests.cpp
@@ -69,4 +69,28 @@ BOOST_AUTO_TEST_CASE(get_next_work_upper_limit_actual)
     BOOST_CHECK_EQUAL(CalculateNextWorkRequired(&pindexLast, nLastRetargetTime, params), 0x1d00e1fd);
 }
 
+BOOST_AUTO_TEST_CASE(GetBlockProofEquivalentTime_test)
+{
+    SelectParams(CBaseChainParams::MAIN);
+    const Consensus::Params& params = Params().GetConsensus();
+
+    std::vector<CBlockIndex> blocks(10000);
+    for (int i = 0; i < 10000; i++) {
+        blocks[i].pprev = i ? &blocks[i - 1] : NULL;
+        blocks[i].nHeight = i;
+        blocks[i].nTime = 1269211443 + i * params.nPowTargetSpacing;
+        blocks[i].nBits = 0x207fffff; /* target 0x7fffff000... */
+        blocks[i].nChainWork = i ? blocks[i - 1].nChainWork + GetBlockProof(blocks[i - 1]) : arith_uint256(0);
+    }
+
+    for (int j = 0; j < 1000; j++) {
+        CBlockIndex *p1 = &blocks[GetRand(10000)];
+        CBlockIndex *p2 = &blocks[GetRand(10000)];
+        CBlockIndex *p3 = &blocks[GetRand(10000)];
+
+        int64_t tdiff = GetBlockProofEquivalentTime(*p1, *p2, *p3, params);
+        BOOST_CHECK_EQUAL(tdiff, p1->GetBlockTime() - p2->GetBlockTime());
+    }
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
In addition to checking whether the age of the requested block isn't too old, also check whether its cummulative proof of work is not more than 1 month behind on the best chain (at its current speed).

This should prevent a fingerprinting attack described by @sergiodemianlerner on #5820.
