### PR TITLE
Floating fees for alternative target spacings

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1061,7 +1061,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
             LOCK(csFreeLimiter);
 
             // Use an exponentially decaying ~10-minute window:
-            dFreeCount *= pow(1.0 - 1.0/600.0, (double)(nNow - nLastTime));
+            dFreeCount *= pow(1.0 - 1.0 / (float)(Params().TargetSpacing()), (double)(nNow - nLastTime));
             nLastTime = nNow;
             // -limitfreerelay unit is thousand-bytes-per-minute
             // At default rate it would take over a month to fill 1GB


### PR DESCRIPTION
The exponentially decaying window should depend on the configured target spacing
