### PR TITLE
0.10 fix for crashes on OSX 10.6

### DIFF
--- a/src/compat.h
+++ b/src/compat.h
@@ -88,8 +88,6 @@ typedef u_int SOCKET;
 #define THREAD_PRIORITY_ABOVE_NORMAL    (-2)
 #endif
 
-#if HAVE_DECL_STRNLEN == 0
-size_t strnlen( const char *start, size_t max_len);
-#endif // HAVE_DECL_STRNLEN
+size_t strnlen_int( const char *start, size_t max_len);
 
 #endif // BITCOIN_COMPAT_H

--- a/src/compat/strnlen.cpp
+++ b/src/compat/strnlen.cpp
@@ -7,12 +7,11 @@
 #endif
 
 #include <cstring>
-
-#if HAVE_DECL_STRNLEN == 0
-size_t strnlen( const char *start, size_t max_len)
+// OSX 10.6 is missing strnlen at runtime, but builds targetting it will still
+// succeed. Define our own version here to avoid a crash.
+size_t strnlen_int( const char *start, size_t max_len)
 {
     const char *end = (const char *)memchr(start, '\0', max_len);
 
     return end ? (size_t)(end - start) : max_len;
 }
-#endif // HAVE_DECL_STRNLEN

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -40,7 +40,7 @@ CMessageHeader::CMessageHeader(const char* pszCommand, unsigned int nMessageSize
 
 std::string CMessageHeader::GetCommand() const
 {
-    return std::string(pchCommand, pchCommand + strnlen(pchCommand, COMMAND_SIZE));
+    return std::string(pchCommand, pchCommand + strnlen_int(pchCommand, COMMAND_SIZE));
 }
 
 bool CMessageHeader::IsValid() const


### PR DESCRIPTION
As discussed with @laanwj on IRC. Fixes #5797. This is a hammer approach, but it's the most straightforward.

strnlen is available at build-time but not at runtime, causing a crash.

0.11 drops support for 10.6, so this is not needed in master.
