### PR TITLE
ensure consistent header comment naming conventions

### DIFF
--- a/src/arith_uint256.h
+++ b/src/arith_uint256.h
@@ -287,4 +287,4 @@ public:
 uint256 ArithToUint256(const arith_uint256 &);
 arith_uint256 UintToArith256(const uint256 &);
 
-#endif // BITCOIN_UINT256_H
+#endif // BITCOIN_ARITH_UINT256_H

--- a/src/hash.cpp
+++ b/src/hash.cpp
@@ -6,7 +6,6 @@
 #include "crypto/common.h"
 #include "crypto/hmac_sha512.h"
 
-
 inline uint32_t ROTL32(uint32_t x, int8_t r)
 {
     return (x << r) | (x >> (32 - r));

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -6,6 +6,8 @@
 #ifndef BITCOIN_SCRIPT_SCRIPT_H
 #define BITCOIN_SCRIPT_SCRIPT_H
 
+#include "crypto/common.h"
+
 #include <assert.h>
 #include <climits>
 #include <limits>
@@ -14,7 +16,6 @@
 #include <string.h>
 #include <string>
 #include <vector>
-#include "crypto/common.h"
 
 static const unsigned int MAX_SCRIPT_ELEMENT_SIZE = 520; // bytes
 

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -6,6 +6,8 @@
 #ifndef BITCOIN_SERIALIZE_H
 #define BITCOIN_SERIALIZE_H
 
+#include "compat/endian.h"
+
 #include <algorithm>
 #include <assert.h>
 #include <ios>
@@ -17,8 +19,6 @@
 #include <string.h>
 #include <utility>
 #include <vector>
-
-#include "compat/endian.h"
 
 class CScript;
 

--- a/src/support/allocators/secure.h
+++ b/src/support/allocators/secure.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_ALLOCATORS_SECURE_H
-#define BITCOIN_ALLOCATORS_SECURE_H
+#ifndef BITCOIN_SUPPORT_ALLOCATORS_SECURE_H
+#define BITCOIN_SUPPORT_ALLOCATORS_SECURE_H
 
 #include "support/pagelocker.h"
 
@@ -59,4 +59,4 @@ struct secure_allocator : public std::allocator<T> {
 // This is exactly like std::string, but with a custom allocator.
 typedef std::basic_string<char, std::char_traits<char>, secure_allocator<char> > SecureString;
 
-#endif // BITCOIN_ALLOCATORS_SECURE_H
+#endif // BITCOIN_SUPPORT_ALLOCATORS_SECURE_H

--- a/src/support/allocators/zeroafterfree.h
+++ b/src/support/allocators/zeroafterfree.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_ALLOCATORS_ZEROAFTERFREE_H
-#define BITCOIN_ALLOCATORS_ZEROAFTERFREE_H
+#ifndef BITCOIN_SUPPORT_ALLOCATORS_ZEROAFTERFREE_H
+#define BITCOIN_SUPPORT_ALLOCATORS_ZEROAFTERFREE_H
 
 #include "support/cleanse.h"
 
@@ -45,4 +45,4 @@ struct zero_after_free_allocator : public std::allocator<T> {
 // Byte-vector that clears its contents before deletion.
 typedef std::vector<char, zero_after_free_allocator<char> > CSerializeData;
 
-#endif // BITCOIN_ALLOCATORS_ZEROAFTERFREE_H
+#endif // BITCOIN_SUPPORT_ALLOCATORS_ZEROAFTERFREE_H

--- a/src/support/pagelocker.h
+++ b/src/support/pagelocker.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_ALLOCATORS_PAGELOCKER_H
-#define BITCOIN_ALLOCATORS_PAGELOCKER_H
+#ifndef BITCOIN_SUPPORT_PAGELOCKER_H
+#define BITCOIN_SUPPORT_PAGELOCKER_H
 
 #include "support/cleanse.h"
 
@@ -175,4 +175,4 @@ void UnlockObject(const T& t)
     LockedPageManager::Instance().UnlockRange((void*)(&t), sizeof(T));
 }
 
-#endif // BITCOIN_ALLOCATORS_PAGELOCKER_H
+#endif // BITCOIN_SUPPORT_PAGELOCKER_H

--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_DB_H
-#define BITCOIN_DB_H
+#ifndef BITCOIN_WALLET_DB_H
+#define BITCOIN_WALLET_DB_H
 
 #include "clientversion.h"
 #include "serialize.h"
@@ -310,4 +310,4 @@ public:
     bool static Rewrite(const std::string& strFile, const char* pszSkip = NULL);
 };
 
-#endif // BITCOIN_DB_H
+#endif // BITCOIN_WALLET_DB_H

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_WALLET_H
-#define BITCOIN_WALLET_H
+#ifndef BITCOIN_WALLET_WALLET_H
+#define BITCOIN_WALLET_WALLET_H
 
 #include "amount.h"
 #include "primitives/block.h"
@@ -909,4 +909,4 @@ private:
     std::vector<char> _ssExtra;
 };
 
-#endif // BITCOIN_WALLET_H
+#endif // BITCOIN_WALLET_WALLET_H

--- a/src/wallet/wallet_ismine.h
+++ b/src/wallet/wallet_ismine.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_WALLET_ISMINE_H
-#define BITCOIN_WALLET_ISMINE_H
+#ifndef BITCOIN_WALLET_WALLET_ISMINE_H
+#define BITCOIN_WALLET_WALLET_ISMINE_H
 
 #include "key.h"
 #include "script/standard.h"
@@ -26,4 +26,4 @@ typedef uint8_t isminefilter;
 isminetype IsMine(const CKeyStore& keystore, const CScript& scriptPubKey);
 isminetype IsMine(const CKeyStore& keystore, const CTxDestination& dest);
 
-#endif // BITCOIN_WALLET_ISMINE_H
+#endif // BITCOIN_WALLET_WALLET_ISMINE_H

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_WALLETDB_H
-#define BITCOIN_WALLETDB_H
+#ifndef BITCOIN_WALLET_WALLETDB_H
+#define BITCOIN_WALLET_WALLETDB_H
 
 #include "amount.h"
 #include "wallet/db.h"
@@ -139,4 +139,4 @@ private:
 
 bool BackupWallet(const CWallet& wallet, const std::string& strDest);
 
-#endif // BITCOIN_WALLETDB_H
+#endif // BITCOIN_WALLET_WALLETDB_H


### PR DESCRIPTION
- BITCOIN_FOLDER_SUBFOLDER_FILENAME_H
- also correct header groupings in core files
