### PR TITLE
[RPC] Add optional locktime to createrawtransaction

### DIFF
--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -76,6 +76,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "getrawtransaction", 1 },
     { "createrawtransaction", 0 },
     { "createrawtransaction", 1 },
+    { "createrawtransaction", 2 },
     { "signrawtransaction", 1 },
     { "signrawtransaction", 2 },
     { "sendrawtransaction", 1 },


### PR DESCRIPTION
A non-zero locktime also causes input sequences to be set to non-max, activating the locktime.
