### PR TITLE
don't trickle messages for whitelisted nodes

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -177,7 +177,12 @@ bool LoadBlockIndex();
 void UnloadBlockIndex();
 /** Process protocol messages received from a given node */
 bool ProcessMessages(CNode* pfrom);
-/** Send queued protocol messages to be sent to a give node */
+/**
+ * Send queued protocol messages to be sent to a give node.
+ *
+ * @param[in]   pto             The node which we are sending messages to.
+ * @param[in]   fSendTrickle    When true send the trickled data, otherwise trickle the data until true.
+ */
 bool SendMessages(CNode* pto, bool fSendTrickle);
 /** Run an instance of the script checking thread */
 void ThreadScriptCheck();

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1406,7 +1406,7 @@ void ThreadMessageHandler()
             {
                 TRY_LOCK(pnode->cs_vSend, lockSend);
                 if (lockSend)
-                    g_signals.SendMessages(pnode, pnode == pnodeTrickle);
+                    g_signals.SendMessages(pnode, pnode == pnodeTrickle || pnode->fWhitelisted);
             }
             boost::this_thread::interruption_point();
         }


### PR DESCRIPTION
I think we don't have to protect our privacy to whitelisted nodes so there's no need to trickle message and we can always send the data.

I also added a comment to the param, it was unclear to me that `fSendTrickle=true` meant sending out the previously trickled data instead of meaning that is should send data trickled ;)
