### PR TITLE
Limit amount of memory used in large re-orgs

### DIFF
--- a/qa/rpc-tests/test_framework.py
+++ b/qa/rpc-tests/test_framework.py
@@ -140,6 +140,8 @@ class BitcoinTestFramework(object):
         if not self.options.nocleanup and not self.options.noshutdown:
             print("Cleaning up")
             shutil.rmtree(self.options.tmpdir)
+        else:
+            print("Test directory was "+self.options.tmpdir)
 
         if success:
             print("Tests successful")

--- a/qa/rpc-tests/util.py
+++ b/qa/rpc-tests/util.py
@@ -33,7 +33,7 @@ def check_json_precision():
     if satoshis != 2000000000000003:
         raise RuntimeError("JSON encode/decode loses precision")
 
-def sync_blocks(rpc_connections):
+def sync_blocks(rpc_connections, max_wait=10):
     """
     Wait until everybody has the same block count
     """
@@ -42,8 +42,11 @@ def sync_blocks(rpc_connections):
         if counts == [ counts[0] ]*len(counts):
             break
         time.sleep(1)
+        max_wait = max_wait-1
+        if max_wait <= 0:
+            raise RuntimeError("sync_blocks: failed to sync")
 
-def sync_mempools(rpc_connections):
+def sync_mempools(rpc_connections, max_wait=10):
     """
     Wait until everybody has the same transactions in their memory
     pools
@@ -57,6 +60,9 @@ def sync_mempools(rpc_connections):
         if num_match == len(rpc_connections):
             break
         time.sleep(1)
+        max_wait = max_wait-1
+        if max_wait <= 0:
+            raise RuntimeError("sync_mempools: failed to sync")
 
 bitcoind_processes = {}
 

--- a/src/main.h
+++ b/src/main.h
@@ -86,6 +86,8 @@ static const unsigned int BLOCK_DOWNLOAD_WINDOW = 1024;
 static const unsigned int DATABASE_WRITE_INTERVAL = 3600;
 /** Maximum length of reject messages. */
 static const unsigned int MAX_REJECT_MESSAGE_LENGTH = 111;
+/** When re-organizing away from a chain, put at most this many block's transactions in memory pool */
+static const unsigned int MAX_REORG_TX_RESURRECT = 6;
 
 /** "reject" message codes */
 static const unsigned char REJECT_MALFORMED = 0x01;

--- a/src/mruset.h
+++ b/src/mruset.h
@@ -59,6 +59,20 @@ public:
         }
         return ret;
     }
+    size_type erase(const key_type& x)
+    {
+        for (size_type i = 0; i < order.size(); i++) {
+            if (*order[i] == x) {
+                set.erase(order[i]);
+                order.erase(order.begin()+i);
+                if (first_unused == 0) first_unused = order.size();
+                else --first_unused;
+                if (first_used > i) --first_used;
+                return 1;
+            }
+        }
+        return 0;
+    }
     size_type max_size() const { return nMaxSize; }
 };
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1742,6 +1742,14 @@ void RelayTransaction(const CTransaction& tx, const CDataStream& ss)
     }
 }
 
+void ForgetTransaction(const CTransaction& tx)
+{
+    CInv inv(MSG_TX, tx.GetHash());
+    LOCK(cs_vNodes);
+    BOOST_FOREACH(CNode* pnode, vNodes)
+        pnode->RemoveInventory(inv);
+}
+
 void CNode::RecordBytesRecv(uint64_t bytes)
 {
     LOCK(cs_totalBytesRecv);

--- a/src/net.h
+++ b/src/net.h
@@ -415,6 +415,12 @@ public:
         }
     }
 
+    void RemoveInventory(const CInv& inv)
+    {
+        LOCK(cs_inventory);
+        setInventoryKnown.erase(inv);
+    }
+
     void AskFor(const CInv& inv);
 
     // TODO: Document the postcondition of this function.  Is cs_vSend locked?
@@ -624,6 +630,7 @@ public:
 class CTransaction;
 void RelayTransaction(const CTransaction& tx);
 void RelayTransaction(const CTransaction& tx, const CDataStream& ss);
+void ForgetTransaction(const CTransaction& tx);
 
 /** Access to the (IP) address database (peers.dat) */
 class CAddrDB

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -123,6 +123,10 @@ bool operator<(const CInv& a, const CInv& b)
 {
     return (a.type < b.type || (a.type == b.type && a.hash < b.hash));
 }
+bool operator==(const CInv& a, const CInv& b)
+{
+    return a.hash == b.hash;
+}
 
 bool CInv::IsKnownType() const
 {

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -136,6 +136,7 @@ public:
     }
 
     friend bool operator<(const CInv& a, const CInv& b);
+    friend bool operator==(const CInv& a, const CInv& b);
 
     bool IsKnownType() const;
     const char* GetCommand() const;

--- a/src/test/mruset_tests.cpp
+++ b/src/test/mruset_tests.cpp
@@ -12,9 +12,6 @@
 
 #include <boost/test/unit_test.hpp>
 
-#define NUM_TESTS 16
-#define MAX_SIZE 100
-
 using namespace std;
 
 BOOST_FIXTURE_TEST_SUITE(mruset_tests, BasicTestingSetup)
@@ -76,6 +73,55 @@ BOOST_AUTO_TEST_CASE(mruset_test)
             }
         }
     }
+}
+
+// Test erase functionality
+BOOST_AUTO_TEST_CASE(mruset_erase)
+{
+    static const int MAX_SIZE=100;
+
+    mruset<int> mru(MAX_SIZE);
+    for (int n=0; n<MAX_SIZE; n++)
+    {
+        mru.insert(n);
+    }
+    // Remove elevenses:
+    int nRemoved = 0;
+    for (int n=11; n<MAX_SIZE; n+=11)
+    {
+        mru.erase(n);
+        ++nRemoved;
+    }
+    BOOST_CHECK(mru.size() == MAX_SIZE-nRemoved);
+    BOOST_CHECK(mru.find(0) != mru.end());
+    BOOST_CHECK(mru.find(10) != mru.end());
+    BOOST_CHECK(mru.find(11) == mru.end());
+    BOOST_CHECK(mru.find(12) != mru.end());
+    BOOST_CHECK(mru.find(98) != mru.end());
+    BOOST_CHECK(mru.find(99) == mru.end());
+
+    // Re-insert elevenses:
+    for (int n=11; n<MAX_SIZE; n+=11)
+    {
+        mru.insert(n);
+    }
+    BOOST_CHECK(mru.size() == MAX_SIZE);
+
+    // Overflow by 20.
+    // Should evict 0-10 and 12-20, should not evict 11 (it was just inserted)
+    for (int n = 0; n < 20; n++)
+    {
+        mru.insert(MAX_SIZE+n);
+    }
+    BOOST_CHECK(mru.size() == MAX_SIZE);
+    BOOST_CHECK(mru.find(0) == mru.end());
+    BOOST_CHECK(mru.find(1) == mru.end());
+    BOOST_CHECK(mru.find(10) == mru.end());
+    BOOST_CHECK(mru.find(11) != mru.end());
+    BOOST_CHECK(mru.find(12) == mru.end());
+    BOOST_CHECK(mru.find(20) == mru.end());
+    BOOST_CHECK(mru.find(21) != mru.end());
+    BOOST_CHECK(mru.find(MAX_SIZE) != mru.end());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1359,6 +1359,8 @@ std::vector<uint256> CWallet::ResendWalletTransactionsBefore(int64_t nTime)
     BOOST_FOREACH(PAIRTYPE(const unsigned int, CWalletTx*)& item, mapSorted)
     {
         CWalletTx& wtx = *item.second;
+        if (!mempool.exists(wtx.GetHash())) // If it dropped out of mempool, try to put it back in:
+            wtx.AcceptToMemoryPool(false, true);
         if (wtx.RelayWalletTransaction())
             result.push_back(wtx.GetHash());
     }
@@ -2750,9 +2752,21 @@ int CMerkleTx::GetBlocksToMaturity() const
 }
 
 
-bool CMerkleTx::AcceptToMemoryPool(bool fLimitFree, bool fRejectAbsurdFee)
+bool CMerkleTx::AcceptToMemoryPool(bool fLimitFree, bool fRejectAbsurdFee) const
 {
     CValidationState state;
-    return ::AcceptToMemoryPool(mempool, state, *this, fLimitFree, NULL, fRejectAbsurdFee);
+    bool fMissingInputs;
+    bool fResult = ::AcceptToMemoryPool(mempool, state, *this, fLimitFree, &fMissingInputs, fRejectAbsurdFee);
+    if (!fResult)
+    {
+        string strErr = strprintf("%s: transaction %s not accepted to mempool ",
+                                  __func__, GetHash().ToString());
+        if (fMissingInputs)
+            strErr += "(missing inputs) ";
+        if (state.IsError() || state.IsInvalid())
+            strErr += state.GetRejectReason();
+        LogPrintf("%s\n", strErr);
+    }
+    return fResult;
 }
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -198,7 +198,7 @@ public:
     int GetDepthInMainChain() const { const CBlockIndex *pindexRet; return GetDepthInMainChain(pindexRet); }
     bool IsInMainChain() const { const CBlockIndex *pindexRet; return GetDepthInMainChainINTERNAL(pindexRet) > 0; }
     int GetBlocksToMaturity() const;
-    bool AcceptToMemoryPool(bool fLimitFree=true, bool fRejectAbsurdFee=true);
+    bool AcceptToMemoryPool(bool fLimitFree=true, bool fRejectAbsurdFee=true) const;
 };
 
 /** 


### PR DESCRIPTION
This pull request was inspired by three things:

1) Large block testing, where stress testing 100-block-long re-orgs with 100+ megabyte blocks used enormous amounts of memory.
2) Planning for implementing a memory-limited memory pool.
3) The general principle that using arbitrarily large amounts of memory is bad.

Block re-org code before this pull request saves all transactions in the old fork to the memory pool before adding all the blocks on the new fork to the chain. That can use arbitrary amounts of memory if the re-org is arbitrarily long; for 'reasonable' re-orgs almost all of the transactions will be in blocks on the new fork, so you eventually end up with a small memory pool, and allocated a lot of memory for nothing.

This pull request has almost identical behavior for short (6-or-fewer block-deep) re-orgs. But for deeper re-orgs, it does not add transactions to the memory pool-- it assumes that the transactions are likely to be on the new fork, and, if they are not, that either the sender or the receiver of the transaction will re-broadcast.

I made changes to the transaction relaying code that make transaction re-broadcast more robust; if for any reason a transaction is not added to the memory pool during a re-org, it is also cleared from the networking layer's 'setInventoryKnown' so a later re-broadcast will be successful.

Builds on #5940 and #5945

Tested using mempool_resurrect_test.py and also manual testing to make sure the wallet's automatic rebroadcast of unconfirmed transactions Does The Right Thing.
