### PR TITLE
wallet: make it possible to disable transaction broadcast

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -337,6 +337,7 @@ std::string HelpMessage(HelpMessageMode mode)
         FormatMoney(maxTxFee)));
     strUsage += HelpMessageOpt("-upgradewallet", _("Upgrade wallet to latest format") + " " + _("on startup"));
     strUsage += HelpMessageOpt("-wallet=<file>", _("Specify wallet file (within data directory)") + " " + strprintf(_("(default: %s)"), "wallet.dat"));
+    strUsage += HelpMessageOpt("-walletbroadcast", _("Make the wallet broadcast transactions") + " " + strprintf(_("(default: %u)"), true));
     strUsage += HelpMessageOpt("-walletnotify=<cmd>", _("Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)"));
     strUsage += HelpMessageOpt("-zapwallettxes=<mode>", _("Delete all wallet transactions and only recover those parts of the blockchain through -rescan on startup") +
         " " + _("(1 = keep tx meta data e.g. account owner and payment request information, 2 = drop tx meta data)"));
@@ -1242,6 +1243,7 @@ bool AppInit2(boost::thread_group& threadGroup)
                 }
             }
         }
+        pwalletMain->SetBroadcastTransactions(GetBoolArg("-walletbroadcast", true));
     } // (!fDisableWallet)
 #else // ENABLE_WALLET
     LogPrintf("No wallet compiled in!\n");

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -455,6 +455,7 @@ private:
 
     int64_t nNextResend;
     int64_t nLastResend;
+    bool fBroadcastTransactions;
 
     /**
      * Used to keep track of spent outpoints, and
@@ -518,6 +519,7 @@ public:
         nNextResend = 0;
         nLastResend = 0;
         nTimeFirstKey = 0;
+        fBroadcastTransactions = false;
     }
 
     std::map<uint256, CWalletTx> mapWallet;
@@ -723,6 +725,11 @@ public:
 
     /** Watch-only address added */
     boost::signals2::signal<void (bool fHaveWatchOnly)> NotifyWatchonlyChanged;
+
+    /** Inquire whether this wallet broadcasts transactions. */
+    bool GetBroadcastTransactions() const { return fBroadcastTransactions; }
+    /** Set whether this wallet broadcasts transactions. */
+    void SetBroadcastTransactions(bool broadcast) { fBroadcastTransactions = broadcast; }
 };
 
 /** A key allocated from the key pool. */


### PR DESCRIPTION
This is an advanced feature which will disable any kind of automatic transaction broadcasting in the wallet. It gives the user full control of how their transactions are sent.

They can broadcast a new transaction through some other mechanism, or send it to the recipient directly, after getting the transaction hex through `gettransaction`. This can be used to do #4564.

It is an important step toward addressing #3828.

This just adds the option `-walletbroadcast=<0,1>`. Right now with `-walletbroadcast=0` new transactions will get the status

```
Status: conflicted, has not been successfully broadcast yet
```

...which is a tad strange. This is just a visual issue, though, and goes away when the transaction is received through the network.

Edit: discussing with @gmaxwell on IRC we thought of a way to avoid this without arcane changes to conflict handling: keep track of the seen-the-network status of transactions internally. If the transaction was not seen on the network, either through our own broadcasting or from a third-party, show it with a different status
