### PR TITLE
Docs: Use new Bitcoin.org download URLs

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -1,6 +1,6 @@
 Bitcoin Core version 0.10.1 is now available from:
 
-  https://bitcoin.org/bin/0.10.1/
+  <https://bitcoin.org/bin/bitcoin-core-0.10.1/>
 
 This is a new minor version release, bringing bug fixes and translation 
 updates. If you are using 0.10.0, it is recommended to upgrade to this
@@ -8,7 +8,7 @@ version.
 
 Please report bugs using the issue tracker at github:
 
-  https://github.com/bitcoin/bitcoin/issues
+  <https://github.com/bitcoin/bitcoin/issues>
 
 Upgrading and downgrading
 =========================

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -132,15 +132,22 @@ rm SHA256SUMS
 (the digest algorithm is forced to sha256 to avoid confusion of the `Hash:` header that GPG adds with the SHA256 used for the files)
 
 - Upload zips and installers, as well as `SHA256SUMS.asc` from last step, to the bitcoin.org server
+  into `/var/www/bin/bitcoin-core-${VERSION}`
 
 - Update bitcoin.org version
 
-  - Make a pull request to add a file named `YYYY-MM-DD-vX.Y.Z.md` with the release notes
-  to https://github.com/bitcoin/bitcoin.org/tree/master/_releases
-   ([Example for 0.9.2.1](https://raw.githubusercontent.com/bitcoin/bitcoin.org/master/_releases/2014-06-19-v0.9.2.1.md)).
+  - First, check to see if the Bitcoin.org maintainers have prepared a
+    release: https://github.com/bitcoin/bitcoin.org/labels/Releases
 
-  - After the pull request is merged, the website will automatically show the newest version, as well
-    as update the OS download links. Ping Saivann in case anything goes wrong
+      - If they have, it will have previously failed their Travis CI
+        checks because the final release files weren't uploaded.
+        Trigger a Travis CI rebuild---if it passes, merge.
+
+  - If they have not prepared a release, follow the Bitcoin.org release
+    instructions: https://github.com/bitcoin/bitcoin.org#release-notes
+
+  - After the pull request is merged, the website will automatically show the newest version within 15 minutes, as well
+    as update the OS download links. Ping @saivann/@harding (saivann/harding on Freenode) in case anything goes wrong
 
 - Announce the release:
 


### PR DESCRIPTION
As of 0.10.0, Bitcoin.org began serving a torrent of all the release files.  Because the torrent uses web seeding, it had to have the same name as the directory holding the files, which was `0.10.0`.  @laanwj requested a more descriptive name in https://github.com/bitcoin/bitcoin.org/issues/748, so we renamed all the directories to `bitcoin-core-VERSION` and created redirects for old links.

This commit updates the 0.10.1 release notes and release process documentation to use the `bitcoin-core-VERSION` directory natively from now on.  I also updated some other Bitcoin.org-related information in the release process to describe our current process.

Please let me know if you need a separate PR to update the release process in master so these steps don't get forgotten.
