### PR TITLE
Configure cppcheck make target to ignore bogus warning

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -196,6 +196,9 @@ check-local:
 	@qa/pull-tester/run-bitcoind-for-test.sh $(JAVA) -jar $(JAVA_COMPARISON_TOOL) qa/tmp/compTool $(COMPARISON_TOOL_REORG_TESTS) 2>&1
 endif
 
+cppcheck:
+	cppcheck ./src -j 4 --force --quiet --suppressions ./src/cppcheck-suppressions.txt
+
 EXTRA_DIST = $(top_srcdir)/share/genbuild.sh qa/pull-tester/rpc-tests.sh qa/pull-tester/run-bitcoin-cli qa/rpc-tests $(DIST_DOCS) $(WINDOWS_PACKAGING) $(OSX_PACKAGING)
 
 CLEANFILES = $(OSX_DMG) $(BITCOIN_WIN_INSTALLER)

--- a/src/cppcheck-suppressions.txt
+++ b/src/cppcheck-suppressions.txt
@@ -1,0 +1,1 @@
+resourceLeak:bitcoin-tx.cpp:149

--- a/src/cppcheck-suppressions.txt
+++ b/src/cppcheck-suppressions.txt
@@ -1,1 +1,1 @@
-resourceLeak:bitcoin-tx.cpp:149
+resourceLeak:src/bitcoin-tx.cpp:149


### PR DESCRIPTION
[cppcheck](cppcheck.sourceforge.net) currently runs almost completely cleanly, with only one error (which IMO should be left unfixed):

[[src/bitcoin-tx.cpp:149](https://github.com/bitcoin/bitcoin/blob/master/src/bitcoin-tx.cpp#L150)]`: (error) Resource leak: f`

This pull request automates running `cppcheck` and ignoring this specific error. This would be useful in continuous integration.

To run: `make cppcheck`
