### PR TITLE
Remove BIP34 switchover logic

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -109,6 +109,7 @@ public:
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
         consensus.nPowTargetSpacing = 10 * 60;
         consensus.fPowAllowMinDifficultyBlocks = false;
+        consensus.nBIP34Height = 227931;
         /** 
          * The message start string is designed to be unlikely to occur in normal data.
          * The characters are rarely used upper ASCII, not valid as UTF-8, and produce
@@ -191,6 +192,7 @@ public:
         consensus.nMajorityRejectBlockOutdated = 75;
         consensus.nMajorityWindow = 100;
         consensus.fPowAllowMinDifficultyBlocks = true;
+        consensus.nBIP34Height = 21111;
         pchMessageStart[0] = 0x0b;
         pchMessageStart[1] = 0x11;
         pchMessageStart[2] = 0x09;
@@ -246,6 +248,7 @@ public:
         consensus.nMajorityRejectBlockOutdated = 950;
         consensus.nMajorityWindow = 1000;
         consensus.powLimit = ~arith_uint256(0) >> 1;
+        consensus.nBIP34Height = 0;
         pchMessageStart[0] = 0xfa;
         pchMessageStart[1] = 0xbf;
         pchMessageStart[2] = 0xb5;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -20,6 +20,8 @@ struct Params {
     int nMajorityEnforceBlockUpgrade;
     int nMajorityRejectBlockOutdated;
     int nMajorityWindow;
+    /** Block height at which BIP34 becomes active */
+    int nBIP34Height;
     /** Proof of work parameters */
     arith_uint256 powLimit;
     bool fPowAllowMinDifficultyBlocks;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2569,8 +2569,8 @@ bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationState& sta
     if (pcheckpoint && nHeight < pcheckpoint->nHeight)
         return state.DoS(100, error("%s: forked chain older than last checkpoint (height %d)", __func__, nHeight));
 
-    // Reject block.nVersion=1 blocks when 95% (75% on testnet) of the network has upgraded:
-    if (block.nVersion < 2 && IsSuperMajority(2, pindexPrev, Params().RejectBlockOutdatedMajority()))
+    // Reject block.nVersion=1 blocks after the BIP34 switchover point.
+    if (block.nVersion < 2 && nHeight >= Params().GetConsensus().nBIP34Height)
     {
         return state.Invalid(error("%s: rejected nVersion=1 block", __func__),
                              REJECT_OBSOLETE, "bad-version");
@@ -2596,9 +2596,8 @@ bool ContextualCheckBlock(const CBlock& block, CValidationState& state, CBlockIn
             return state.DoS(10, error("%s: contains a non-final transaction", __func__), REJECT_INVALID, "bad-txns-nonfinal");
         }
 
-    // Enforce block.nVersion=2 rule that the coinbase starts with serialized block height
-    // if 750 of the last 1,000 blocks are version 2 or greater (51/100 if testnet):
-    if (block.nVersion >= 2 && IsSuperMajority(2, pindexPrev, Params().EnforceBlockUpgradeMajority()))
+    // Enforce block.nVersion=2 rule that the coinbase starts with serialized block height after the BIP34 switchover point.
+    if (block.nVersion >= 2 && nHeight >= Params().GetConsensus().nBIP34Height)
     {
         CScript expect = CScript() << nHeight;
         if (block.vtx[0].vin[0].scriptSig.size() < expect.size() ||


### PR DESCRIPTION
It's more than a year ago, so just replace the 75%/95% version counting logic with a static historic switchover point.

Rebase of  #5562:
- Kept IsSuperMajority as it's used by BIP66 checks
- Moved nBIP34Height to the new consensus params structure
