### PR TITLE
Chainparams: Refactor: Decouple IsSuperMajority from Params()

### DIFF
--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -50,9 +50,6 @@ public:
     const std::vector<unsigned char>& AlertKey() const { return vAlertPubKey; }
     int GetDefaultPort() const { return nDefaultPort; }
     int SubsidyHalvingInterval() const { return consensus.nSubsidyHalvingInterval; }
-    int EnforceBlockUpgradeMajority() const { return consensus.nMajorityEnforceBlockUpgrade; }
-    int RejectBlockOutdatedMajority() const { return consensus.nMajorityRejectBlockOutdated; }
-    int ToCheckBlockUpgradeMajority() const { return consensus.nMajorityWindow; }
 
     /** Used if GenerateBitcoins is called with a negative number of threads */
     int DefaultMinerThreads() const { return nMinerThreads; }


### PR DESCRIPTION
After the struct Consensus::Params was created in #5812, there are some redundant getters in CChainParams. 
This is not the minimal way to remove it, but the fastest way would involve putting Params().GetConsensus() instead of params or params.GetConsensus().
With a few more extra changes we're going forward functions depending explicitly on CChainParams or Consensus::Params whenever it's possible.
@sipa suggested removing the redundancies in #5812, this is what I meant by doing it later, better.
@laanwj celebrated passing Consensus::Params as a parameter in that same PR, so I hope he likes this one too.
@theuni will probably be interested in this one as well since he is working on similar things.
