### PR TITLE
[Qt] Clarify: smartfee button name "Minimize"

### DIFF
--- a/src/qt/forms/sendcoinsdialog.ui
+++ b/src/qt/forms/sendcoinsdialog.ui
@@ -807,7 +807,7 @@
              <string>collapse fee-settings</string>
             </property>
             <property name="text">
-             <string>Minimize</string>
+             <string>Hide</string>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
As mentioned earlier by @luke-jr in #5200 the "Minimize" button can be mistakenly assumed to minimize the fee. Though, the tool tip makes it clear that the button shrinks the dialog, I'd still prefer a non ambiguous label.
