### PR TITLE
improve addr/inv trickle logic

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4776,8 +4776,12 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
 
         if (pto->nNextLocalAddrSend < GetTime()) {
             AdvertizeLocal(pto);
-            pto->setAddrKnown.clear();
             pto->nNextLocalAddrSend = GetTime() + GetRand(24 * 60 * 60);
+        }
+        
+        if (pto->nNextClearSetKnown < GetTime()) {
+            pto->setAddrKnown.clear();
+            pto->nNextClearSetKnown = GetTime() + GetRand(12 * 60 * 60);
         }
 
         if (pto->nNextAddrSend < GetTime()) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4780,8 +4780,8 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
             pto->nNextLocalAddrSend = GetTime() + GetRand(24 * 60 * 60);
         }
 
-        if (fSendTrickle)
-        {
+        if (pto->nNextAddrSend < GetTime()) {
+            pto->nNextAddrSend = GetTime() + GetRand(30);
             vector<CAddress> vAddr;
             vAddr.reserve(pto->vAddrToSend.size());
             BOOST_FOREACH(const CAddress& addr, pto->vAddrToSend)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4768,7 +4768,7 @@ bool SendMessages(CNode* pto)
         }
 
         if (pto->nNextClearSetKnown < nNowMicros) {
-            pto->setAddrKnown.clear();
+            pto->addrKnown.clear();
             pto->nNextClearSetKnown = nNowMicros + 1000 * (int64_t)GetRand(12 * 60 * 60 * 1000);
         }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4864,11 +4864,19 @@ bool SendMessages(CNode* pto)
 
         {
             LOCK(pto->cs_inventory);
-            
-            // TODO it would be sufficient to walk vInventoryToSend randomly, shuffling is relatively inefficient
-            std::random_shuffle(pto->vInventoryToSend.begin(), pto->vInventoryToSend.end());
 
-            BOOST_FOREACH(const CInv& inv, pto->vInventoryToSend) {
+            std::vector<int> vRandInv;
+            vRandInv.resize(pto->vInventoryToSend.size());
+
+            for (size_t i = 0; i < pto->vInventoryToSend.size(); i++)
+                vRandInv[i] = i;
+
+            for (size_t i = 0; i < vRandInv.size(); i++)
+                std::swap(vRandInv[i], vRandInv[i + GetRand(vRandInv.size() - i)]);
+
+            for (size_t i = 0; i < vRandInv.size(); i++) {
+                const CInv& inv = pto->vInventoryToSend[vRandInv[i]];
+
                 switch(inv.type) {
                     case MSG_TX:
                     {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3884,19 +3884,6 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
 
         if (!pfrom->fInbound)
         {
-            // Advertise our address
-            if (fListen && !IsInitialBlockDownload())
-            {
-                CAddress addr = GetLocalAddress(&pfrom->addr);
-                if (addr.IsRoutable())
-                {
-                    pfrom->PushAddress(addr);
-                } else if (IsPeerAddrLocalGood(pfrom)) {
-                    addr.SetIP(pfrom->addrLocal);
-                    pfrom->PushAddress(addr);
-                }
-            }
-
             // Get recent addresses
             if (pfrom->fOneShot || pfrom->nVersion >= CADDR_TIME_VERSION || addrman.size() < 1000)
             {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4847,6 +4847,9 @@ bool SendMessages(CNode* pto)
 
         {
             LOCK(pto->cs_inventory);
+            
+            // TODO it would be sufficient to walk vInventoryToSend randomly, shuffling is relatively inefficient
+            std::random_shuffle(pto->vInventoryToSend.begin(), pto->vInventoryToSend.end());
 
             BOOST_FOREACH(const CInv& inv, pto->vInventoryToSend) {
                 // Aggressively push MSG_BLOCK/MSG_FILTERED_BLOCK

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4774,7 +4774,7 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
         if (pto->nNextAddrSend < GetTime()) {
             pto->nNextAddrSend = GetTime() + GetRand(30);
             vector<CAddress> vAddr;
-            vAddr.reserve(pto->vAddrToSend.size());
+            vAddr.reserve(std::min(1000, static_cast<int>(pto->vAddrToSend.size())));
             BOOST_FOREACH(const CAddress& addr, pto->vAddrToSend)
             {
                 if (!pto->addrKnown.contains(addr.GetKey()))

--- a/src/main.h
+++ b/src/main.h
@@ -172,9 +172,8 @@ bool ProcessMessages(CNode* pfrom);
  * Send queued protocol messages to be sent to a give node.
  *
  * @param[in]   pto             The node which we are sending messages to.
- * @param[in]   fSendTrickle    When true send the trickled data, otherwise trickle the data until true.
  */
-bool SendMessages(CNode* pto, bool fSendTrickle);
+bool SendMessages(CNode* pto);
 /** Run an instance of the script checking thread */
 void ThreadScriptCheck();
 /** Try to detect Partition (network isolation) attacks against us */

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2069,6 +2069,7 @@ CNode::CNode(SOCKET hSocketIn, const CAddress& addrIn, const std::string& addrNa
     hashContinue = uint256();
     nStartingHeight = -1;
     fGetAddr = false;
+    nNextLocalAddrSend = GetTime() + GetRand(24 * 60 * 60);
     fRelayTxes = false;
     pfilter = new CBloomFilter();
     nPingNonceSent = 0;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1519,11 +1519,6 @@ void ThreadMessageHandler()
             }
         }
 
-        // Poll the connected nodes for messages
-        CNode* pnodeTrickle = NULL;
-        if (!vNodesCopy.empty())
-            pnodeTrickle = vNodesCopy[GetRand(vNodesCopy.size())];
-
         bool fSleep = true;
 
         BOOST_FOREACH(CNode* pnode, vNodesCopy)

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1554,7 +1554,7 @@ void ThreadMessageHandler()
             {
                 TRY_LOCK(pnode->cs_vSend, lockSend);
                 if (lockSend)
-                    g_signals.SendMessages(pnode, pnode == pnodeTrickle || pnode->fWhitelisted);
+                    g_signals.SendMessages(pnode);
             }
             boost::this_thread::interruption_point();
         }
@@ -2072,6 +2072,7 @@ CNode::CNode(SOCKET hSocketIn, const CAddress& addrIn, const std::string& addrNa
     nNextAddrSend = GetTime() + GetRand(30);
     nNextLocalAddrSend = GetTime() + GetRand(24 * 60 * 60);
     nNextClearSetKnown = GetTime() + GetRand(12 * 60 * 60);
+    nNextInvSend = GetTime() + GetRand(10);
     fRelayTxes = false;
     pfilter = new CBloomFilter();
     nPingNonceSent = 0;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2069,6 +2069,7 @@ CNode::CNode(SOCKET hSocketIn, const CAddress& addrIn, const std::string& addrNa
     hashContinue = uint256();
     nStartingHeight = -1;
     fGetAddr = false;
+    nNextAddrSend = GetTime() + GetRand(30);
     nNextLocalAddrSend = GetTime() + GetRand(24 * 60 * 60);
     fRelayTxes = false;
     pfilter = new CBloomFilter();

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2071,6 +2071,7 @@ CNode::CNode(SOCKET hSocketIn, const CAddress& addrIn, const std::string& addrNa
     fGetAddr = false;
     nNextAddrSend = GetTime() + GetRand(30);
     nNextLocalAddrSend = GetTime() + GetRand(24 * 60 * 60);
+    nNextClearSetKnown = GetTime() + GetRand(12 * 60 * 60);
     fRelayTxes = false;
     pfilter = new CBloomFilter();
     nPingNonceSent = 0;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2069,10 +2069,10 @@ CNode::CNode(SOCKET hSocketIn, const CAddress& addrIn, const std::string& addrNa
     hashContinue = uint256();
     nStartingHeight = -1;
     fGetAddr = false;
-    nNextAddrSend = GetTime() + GetRand(30);
-    nNextLocalAddrSend = GetTime() + GetRand(24 * 60 * 60);
-    nNextClearSetKnown = GetTime() + GetRand(12 * 60 * 60);
-    nNextInvSend = GetTime() + GetRand(10);
+    nNextAddrSend = GetTimeMicros() + GetRand(30 * 1000000);
+    nNextLocalAddrSend = GetTimeMicros() + 1000 * (int64_t)GetRand(24 * 60 * 60 * 1000);
+    nNextClearSetKnown = GetTimeMicros() + 1000 * (int64_t)GetRand(12 * 60 * 60 * 1000);
+    nNextInvSend = GetTimeMicros() + GetRand(10 * 1000000);
     fRelayTxes = false;
     pfilter = new CBloomFilter();
     nPingNonceSent = 0;

--- a/src/net.h
+++ b/src/net.h
@@ -377,6 +377,7 @@ public:
     CRollingBloomFilter addrKnown;
     bool fGetAddr;
     std::set<uint256> setKnown;
+    int64_t nNextLocalAddrSend;
 
     // inventory based relay
     mruset<CInv> setInventoryKnown;

--- a/src/net.h
+++ b/src/net.h
@@ -377,6 +377,7 @@ public:
     CRollingBloomFilter addrKnown;
     bool fGetAddr;
     std::set<uint256> setKnown;
+    int64_t nNextAddrSend;
     int64_t nNextLocalAddrSend;
 
     // inventory based relay

--- a/src/net.h
+++ b/src/net.h
@@ -379,6 +379,7 @@ public:
     std::set<uint256> setKnown;
     int64_t nNextAddrSend;
     int64_t nNextLocalAddrSend;
+    int64_t nNextClearSetKnown;
 
     // inventory based relay
     mruset<CInv> setInventoryKnown;

--- a/src/net.h
+++ b/src/net.h
@@ -384,6 +384,7 @@ public:
     // inventory based relay
     mruset<CInv> setInventoryKnown;
     std::vector<CInv> vInventoryToSend;
+    std::vector<CInv> vBlockInventoryToSend;
     CCriticalSection cs_inventory;
     std::multimap<int64_t, CInv> mapAskFor;
     int64_t nNextInvSend;
@@ -486,10 +487,23 @@ public:
 
     void PushInventory(const CInv& inv)
     {
+        switch(inv.type)
         {
-            LOCK(cs_inventory);
-            if (!setInventoryKnown.count(inv))
-                vInventoryToSend.push_back(inv);
+            case MSG_BLOCK:
+            case MSG_FILTERED_BLOCK:
+            {
+                LOCK(cs_inventory);
+                if (!setInventoryKnown.count(inv))
+                    vBlockInventoryToSend.push_back(inv);
+                break;
+            }
+            default:
+            {
+                LOCK(cs_inventory);
+                if (!setInventoryKnown.count(inv))
+                    vInventoryToSend.push_back(inv);
+                break;
+            }
         }
     }
 

--- a/src/net.h
+++ b/src/net.h
@@ -100,7 +100,7 @@ struct CNodeSignals
 {
     boost::signals2::signal<int ()> GetHeight;
     boost::signals2::signal<bool (CNode*), CombinerAll> ProcessMessages;
-    boost::signals2::signal<bool (CNode*, bool), CombinerAll> SendMessages;
+    boost::signals2::signal<bool (CNode*), CombinerAll> SendMessages;
     boost::signals2::signal<void (NodeId, const CNode*)> InitializeNode;
     boost::signals2::signal<void (NodeId)> FinalizeNode;
 };
@@ -386,6 +386,7 @@ public:
     std::vector<CInv> vInventoryToSend;
     CCriticalSection cs_inventory;
     std::multimap<int64_t, CInv> mapAskFor;
+    int64_t nNextInvSend;
 
     // Ping time measurement:
     // The pong reply we're expecting, or 0 if no pong expected.

--- a/src/test/DoS_tests.cpp
+++ b/src/test/DoS_tests.cpp
@@ -52,7 +52,7 @@ BOOST_AUTO_TEST_CASE(DoS_banning)
     CNode dummyNode1(INVALID_SOCKET, addr1, "", true);
     dummyNode1.nVersion = 1;
     Misbehaving(dummyNode1.GetId(), 100); // Should get banned
-    SendMessages(&dummyNode1, false);
+    SendMessages(&dummyNode1);
     BOOST_CHECK(CNode::IsBanned(addr1));
     BOOST_CHECK(!CNode::IsBanned(ip(0xa0b0c001|0x0000ff00))); // Different IP, not banned
 
@@ -60,11 +60,11 @@ BOOST_AUTO_TEST_CASE(DoS_banning)
     CNode dummyNode2(INVALID_SOCKET, addr2, "", true);
     dummyNode2.nVersion = 1;
     Misbehaving(dummyNode2.GetId(), 50);
-    SendMessages(&dummyNode2, false);
+    SendMessages(&dummyNode2);
     BOOST_CHECK(!CNode::IsBanned(addr2)); // 2 not banned yet...
     BOOST_CHECK(CNode::IsBanned(addr1));  // ... but 1 still should be
     Misbehaving(dummyNode2.GetId(), 50);
-    SendMessages(&dummyNode2, false);
+    SendMessages(&dummyNode2);
     BOOST_CHECK(CNode::IsBanned(addr2));
 }
 
@@ -76,13 +76,13 @@ BOOST_AUTO_TEST_CASE(DoS_banscore)
     CNode dummyNode1(INVALID_SOCKET, addr1, "", true);
     dummyNode1.nVersion = 1;
     Misbehaving(dummyNode1.GetId(), 100);
-    SendMessages(&dummyNode1, false);
+    SendMessages(&dummyNode1);
     BOOST_CHECK(!CNode::IsBanned(addr1));
     Misbehaving(dummyNode1.GetId(), 10);
-    SendMessages(&dummyNode1, false);
+    SendMessages(&dummyNode1);
     BOOST_CHECK(!CNode::IsBanned(addr1));
     Misbehaving(dummyNode1.GetId(), 1);
-    SendMessages(&dummyNode1, false);
+    SendMessages(&dummyNode1);
     BOOST_CHECK(CNode::IsBanned(addr1));
     mapArgs.erase("-banscore");
 }
@@ -98,7 +98,7 @@ BOOST_AUTO_TEST_CASE(DoS_bantime)
     dummyNode.nVersion = 1;
 
     Misbehaving(dummyNode.GetId(), 100);
-    SendMessages(&dummyNode, false);
+    SendMessages(&dummyNode);
     BOOST_CHECK(CNode::IsBanned(addr));
 
     SetMockTime(nStartTime+60*60);


### PR DESCRIPTION
The addr/msg_tx logic currently assumes that ProcessMEssage/SendMessage are called on a regular timer.

This was (sort of) true in the past but is not longer true after #5971

Critical analysis of this PR would be helpful as this goes beyond just fixing the timing issue.
