### PR TITLE
Typo in GetRawMemPool RPC method documentation: "]" --> "}"

### DIFF
--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -170,7 +170,7 @@ Value getrawmempool(const Array& params, bool fHelp)
             "        \"transactionid\",    (string) parent transaction id\n"
             "       ... ]\n"
             "  }, ...\n"
-            "]\n"
+            "}\n"
             "\nExamples\n"
             + HelpExampleCli("getrawmempool", "true")
             + HelpExampleRpc("getrawmempool", "true")


### PR DESCRIPTION
The GetRawMemPool RPC method returns a JSON object ending in "}" when its "verbose" parameter is set to true.
