### PR TITLE
Fix CheckBlockIndex for reindex.

### DIFF
--- a/qa/rpc-tests/reindex.py
+++ b/qa/rpc-tests/reindex.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python2
+# Copyright (c) 2014 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#
+# Test -reindex with CheckBlockIndex
+#
+from test_framework import BitcoinTestFramework
+from bitcoinrpc.authproxy import AuthServiceProxy, JSONRPCException
+from util import *
+import os.path
+
+class ReindexTest(BitcoinTestFramework):
+
+    def setup_chain(self):
+        print("Initializing test directory "+self.options.tmpdir)
+        initialize_chain_clean(self.options.tmpdir, 1)
+
+    def setup_network(self):
+        self.nodes = []
+        self.is_network_split = False
+        self.nodes.append(start_node(0, self.options.tmpdir))
+
+    def run_test(self):
+        self.nodes[0].generate(3)
+        stop_node(self.nodes[0], 0)
+        wait_bitcoinds()
+        self.nodes[0]=start_node(0, self.options.tmpdir, ["-debug", "-reindex", "-checkblockindex=1"])
+        assert_equal(self.nodes[0].getblockcount(), 3)
+        print "Success"
+
+if __name__ == '__main__':
+    ReindexTest().main()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3227,6 +3227,14 @@ void static CheckBlockIndex()
 
     LOCK(cs_main);
 
+    // During a reindex, we read the genesis block and call CheckBlockIndex before ActivateBestChain,
+    // so we have the genesis block in mapBlockIndex but no active chain.  (A few of the tests when
+    // iterating the block tree require that chainActive has been initialized.)
+    if (chainActive.Height() < 0) {
+        assert(mapBlockIndex.size() <= 1);
+        return;
+    }
+
     // Build forward-pointing map of the entire block tree.
     std::multimap<CBlockIndex*,CBlockIndex*> forward;
     for (BlockMap::iterator it = mapBlockIndex.begin(); it != mapBlockIndex.end(); it++) {


### PR DESCRIPTION
Some tests in CheckBlockIndex require chainActive.Tip(), but when reindexing, chainActive has not been set on the first call to CheckBlockIndex.

reindex.py starts a node, mines 3 blocks, stops, and reindexes with CheckBlockIndex enabled.
