### PR TITLE
Implement memory locks on passphrase input

### DIFF
--- a/src/qt/askpassphrasedialog.cpp
+++ b/src/qt/askpassphrasedialog.cpp
@@ -36,6 +36,11 @@ AskPassphraseDialog::AskPassphraseDialog(Mode mode, QWidget *parent) :
     ui->passEdit2->installEventFilter(this);
     ui->passEdit3->installEventFilter(this);
 
+    // Lock the memory
+    LockObject(ui->passEdit1->text());
+    LockObject(ui->passEdit2->text());
+    LockObject(ui->passEdit3->text());
+
     switch(mode)
     {
         case Encrypt: // Ask passphrase x2
@@ -77,6 +82,10 @@ AskPassphraseDialog::~AskPassphraseDialog()
     ui->passEdit1->setText(QString(" ").repeated(ui->passEdit1->text().size()));
     ui->passEdit2->setText(QString(" ").repeated(ui->passEdit2->text().size()));
     ui->passEdit3->setText(QString(" ").repeated(ui->passEdit3->text().size()));
+    // Don't cleanse the memory, QString's destructor doesn't like that
+    UnlockObject(ui->passEdit1->text(), false);
+    UnlockObject(ui->passEdit2->text(), false);
+    UnlockObject(ui->passEdit3->text(), false);
     delete ui;
 }
 
@@ -93,8 +102,7 @@ void AskPassphraseDialog::accept()
     oldpass.reserve(MAX_PASSPHRASE_SIZE);
     newpass1.reserve(MAX_PASSPHRASE_SIZE);
     newpass2.reserve(MAX_PASSPHRASE_SIZE);
-    // TODO: get rid of this .c_str() by implementing SecureString::operator=(std::string)
-    // Alternately, find a way to make this input mlock()'d to begin with.
+
     oldpass.assign(ui->passEdit1->text().toStdString().c_str());
     newpass1.assign(ui->passEdit2->text().toStdString().c_str());
     newpass2.assign(ui->passEdit3->text().toStdString().c_str());

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -872,8 +872,11 @@ static Object JSONRPCExecOne(const Value& req)
     JSONRequest jreq;
     try {
         jreq.parse(req);
+        LockObject(jreq.params);
 
         Value result = tableRPC.execute(jreq.strMethod, jreq.params);
+        UnlockObject(jreq.params);
+        
         rpc_result = JSONRPCReplyObj(result, Value::null, jreq.id);
     }
     catch (const Object& objError)

--- a/src/support/pagelocker.h
+++ b/src/support/pagelocker.h
@@ -169,9 +169,10 @@ void LockObject(const T& t)
 }
 
 template <typename T>
-void UnlockObject(const T& t)
+void UnlockObject(const T& t, bool cleanse = true)
 {
-    memory_cleanse((void*)(&t), sizeof(T));
+    if(cleanse)
+        memory_cleanse((void*)(&t), sizeof(T));
     LockedPageManager::Instance().UnlockRange((void*)(&t), sizeof(T));
 }
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1746,11 +1746,8 @@ Value walletpassphrase(const Array& params, bool fHelp)
     if (!pwalletMain->IsCrypted())
         throw JSONRPCError(RPC_WALLET_WRONG_ENC_STATE, "Error: running with an unencrypted wallet, but walletpassphrase was called.");
 
-    // Note that the walletpassphrase is stored in params[0] which is not mlock()ed
     SecureString strWalletPass;
     strWalletPass.reserve(100);
-    // TODO: get rid of this .c_str() by implementing SecureString::operator=(std::string)
-    // Alternately, find a way to make params[0] mlock()'d to begin with.
     strWalletPass = params[0].get_str().c_str();
 
     if (strWalletPass.length() > 0)
@@ -1795,8 +1792,6 @@ Value walletpassphrasechange(const Array& params, bool fHelp)
     if (!pwalletMain->IsCrypted())
         throw JSONRPCError(RPC_WALLET_WRONG_ENC_STATE, "Error: running with an unencrypted wallet, but walletpassphrasechange was called.");
 
-    // TODO: get rid of these .c_str() calls by implementing SecureString::operator=(std::string)
-    // Alternately, find a way to make params[0] mlock()'d to begin with.
     SecureString strOldWalletPass;
     strOldWalletPass.reserve(100);
     strOldWalletPass = params[0].get_str().c_str();
@@ -1886,8 +1881,6 @@ Value encryptwallet(const Array& params, bool fHelp)
     if (pwalletMain->IsCrypted())
         throw JSONRPCError(RPC_WALLET_WRONG_ENC_STATE, "Error: running with an encrypted wallet, but encryptwallet was called.");
 
-    // TODO: get rid of this .c_str() by implementing SecureString::operator=(std::string)
-    // Alternately, find a way to make params[0] mlock()'d to begin with.
     SecureString strWalletPass;
     strWalletPass.reserve(100);
     strWalletPass = params[0].get_str().c_str();


### PR DESCRIPTION
As requested in comments, lock the memory used to store the encryption passphrases.
