### PR TITLE
miner.h: fix clang warning because of class/struct mix

### DIFF
--- a/src/miner.h
+++ b/src/miner.h
@@ -14,7 +14,7 @@ class CBlockIndex;
 class CReserveKey;
 class CScript;
 class CWallet;
-namespace Consensus { class Params; };
+namespace Consensus { struct Params; };
 
 struct CBlockTemplate
 {


### PR DESCRIPTION
- class 'Params' was previously declared as a struct
