### PR TITLE
Fix locale fallback and guard tests against invalid locale settings

### DIFF
--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -6,6 +6,7 @@
 #include "config/bitcoin-config.h"
 #endif
 
+#include "util.h"
 #include "uritests.h"
 
 #ifdef ENABLE_WALLET
@@ -27,6 +28,7 @@ Q_IMPORT_PLUGIN(qkrcodecs)
 // This is all you need to run all the tests
 int main(int argc, char *argv[])
 {
+    SetupEnvironment();
     bool fInvalid = false;
 
     // Don't remove this, it's needed to access

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -30,6 +30,7 @@ struct TestingSetup {
     boost::thread_group threadGroup;
 
     TestingSetup() {
+        SetupEnvironment();
         fPrintToDebugLog = false; // don't want to write to debug.log file
         fCheckBlockIndex = true;
         SelectParams(CBaseChainParams::UNITTEST);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -713,18 +713,19 @@ void RenameThread(const char* name)
 
 void SetupEnvironment()
 {
+    std::locale loc("C");
     // On most POSIX systems (e.g. Linux, but not BSD) the environment's locale
     // may be invalid, in which case the "C" locale is used as fallback.
 #if !defined(WIN32) && !defined(MAC_OSX) && !defined(__FreeBSD__) && !defined(__OpenBSD__)
     try {
-        std::locale(""); // Raises a runtime error if current locale is invalid
+        loc = std::locale(""); // Raises a runtime error if current locale is invalid
     } catch (const std::runtime_error&) {
-        std::locale::global(std::locale("C"));
+        setenv("LC_ALL", "C", 1);
     }
 #endif
     // The path locale is lazy initialized and to avoid deinitialization errors 
     // in multithreading environments, it is set explicitly by the main thread.
-    boost::filesystem::path::imbue(std::locale());    
+    boost::filesystem::path::imbue(loc);
 }
 
 void SetThreadPriority(int nPriority)


### PR DESCRIPTION
This is a copy of #5950, but for the 0.10 branch.

---

Unfortually a fallback to "C" locale via `std::locale::global` does not cover all scenarios with messed up environment locale settings and on Ubuntu 14.01 (with `LANG=en_US.UTF-8, LANGUAGE=en_US, LC_* empty`) setting `LANG=invalid` triggers a crash right at the start of `bitcoind` and `bitcoin-qt`.

This also affects `test_bitcoin` and `test_bitcoin-qt`, which were not guarded at all.

The PR expands the scope of the locale fallback and prevents crashes due to invalid locale settings of `bitcoind`, `bitcoin-qt`, `test_bitcoin` and `test_bitcoin-qt`.

---

I used the RPC test [test_locale.py](https://gist.github.com/dexX7/ab3f7411a9040e96d55c) to confirm the 0.10 branch is affected by bad locale environment settings in [this build](https://travis-ci.org/dexX7/bitcoin/builds/59031023), and that this PR does what it should in [another build](https://travis-ci.org/dexX7/bitcoin/builds/59031275).

The test was not added to this PR, because it executes the Boost tests a few times, which seems too expensive and wasteful.
