### PR TITLE
Cap nAttempts penalty at 8 and switch to pow instead of a division loop.

### DIFF
--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -67,9 +67,8 @@ double CAddrInfo::GetChance(int64_t nNow) const
     if (nSinceLastTry < 60 * 10)
         fChance *= 0.01;
 
-    // deprioritize 50% after each failed attempt
-    for (int n = 0; n < nAttempts; n++)
-        fChance /= 1.5;
+    // deprioritize 66% after each failed attempt, but at most 1/28th to avoid the search taking forever or overly penalizing outages.
+    fChance *= pow(0.66, min(nAttempts, 8));
 
     return fChance;
 }


### PR DESCRIPTION
On hosts that had spent some time with a failed internet connection their
 nAttempts penalty was going through the roof (e.g. thousands for all peers)
 and as a result the connect search was pegging the CPU and failing to get
 more than a 4 connections after days of running (because it was taking so
 long per try).
