### PR TITLE
Show zero value txouts in listunspent.

### DIFF
--- a/qa/rpc-tests/wallet.py
+++ b/qa/rpc-tests/wallet.py
@@ -151,6 +151,33 @@ class WalletTest (BitcoinTestFramework):
 
         assert(txid1 in self.nodes[3].getrawmempool())
         
+        #check if we can list zero value tx as available coins
+        #1. create rawtx
+        #2. hex-changed one output to 0.0 
+        #3. sign and send
+        #4. check if recipient (node0) can list the zero value tx
+        usp = self.nodes[1].listunspent()
+        inputs = [{"txid":usp[0]['txid'], "vout":usp[0]['vout']}]
+        outputs = {self.nodes[1].getnewaddress(): 49.998, self.nodes[0].getnewaddress(): 11.11}
+        
+        rawTx = self.nodes[1].createrawtransaction(inputs, outputs).replace("c0833842", "00000000") #replace 11.11 with 0.0 (int32)
+        decRawTx = self.nodes[1].decoderawtransaction(rawTx)
+        signedRawTx = self.nodes[1].signrawtransaction(rawTx)
+        decRawTx = self.nodes[1].decoderawtransaction(signedRawTx['hex'])
+        zeroValueTxid= decRawTx['txid']
+        sendResp = self.nodes[1].sendrawtransaction(signedRawTx['hex'])
+        
+        self.sync_all()
+        self.nodes[1].generate(1) #mine a block
+        self.sync_all()
+        
+        unspentTxs = self.nodes[0].listunspent() #zero value tx must be in listunspents output
+        found = False
+        for uTx in unspentTxs:
+            if uTx['txid'] == zeroValueTxid:
+                found = True
+                assert_equal(uTx['amount'], Decimal('0.00000000'));
+        assert(found)
         
         #do some -walletbroadcast tests
         stop_nodes(self.nodes)

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2301,7 +2301,7 @@ Value listunspent(const Array& params, bool fHelp)
     vector<COutput> vecOutputs;
     assert(pwalletMain != NULL);
     LOCK2(cs_main, pwalletMain->cs_wallet);
-    pwalletMain->AvailableCoins(vecOutputs, false);
+    pwalletMain->AvailableCoins(vecOutputs, false, NULL, true);
     BOOST_FOREACH(const COutput& out, vecOutputs) {
         if (out.nDepth < nMinDepth || out.nDepth > nMaxDepth)
             continue;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1481,7 +1481,7 @@ CAmount CWallet::GetImmatureWatchOnlyBalance() const
 /**
  * populate vCoins with vector of available COutputs.
  */
-void CWallet::AvailableCoins(vector<COutput>& vCoins, bool fOnlyConfirmed, const CCoinControl *coinControl) const
+void CWallet::AvailableCoins(vector<COutput>& vCoins, bool fOnlyConfirmed, const CCoinControl *coinControl, bool fIncludeZeroValue) const
 {
     vCoins.clear();
 
@@ -1508,7 +1508,7 @@ void CWallet::AvailableCoins(vector<COutput>& vCoins, bool fOnlyConfirmed, const
             for (unsigned int i = 0; i < pcoin->vout.size(); i++) {
                 isminetype mine = IsMine(pcoin->vout[i]);
                 if (!(IsSpent(wtxid, i)) && mine != ISMINE_NO &&
-                    !IsLockedCoin((*it).first, i) && pcoin->vout[i].nValue > 0 &&
+                    !IsLockedCoin((*it).first, i) && (pcoin->vout[i].nValue > 0 || fIncludeZeroValue) &&
                     (!coinControl || !coinControl->HasSelected() || coinControl->IsSelected((*it).first, i)))
                         vCoins.push_back(COutput(pcoin, i, nDepth, (mine & ISMINE_SPENDABLE) != ISMINE_NO));
             }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -540,7 +540,7 @@ public:
     //! check whether we are allowed to upgrade (or already support) to the named feature
     bool CanSupportFeature(enum WalletFeature wf) { AssertLockHeld(cs_wallet); return nWalletMaxVersion >= wf; }
 
-    void AvailableCoins(std::vector<COutput>& vCoins, bool fOnlyConfirmed=true, const CCoinControl *coinControl = NULL) const;
+    void AvailableCoins(std::vector<COutput>& vCoins, bool fOnlyConfirmed=true, const CCoinControl *coinControl = NULL, bool fIncludeZeroValue=false) const;
     bool SelectCoinsMinConf(const CAmount& nTargetValue, int nConfMine, int nConfTheirs, std::vector<COutput> vCoins, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoinsRet, CAmount& nValueRet) const;
 
     bool IsSpent(const uint256& hash, unsigned int n) const;


### PR DESCRIPTION
It's reasonable that automatic coin selection will not pick a zero
 value txout, but they're actually  spendable; and you should know
 if you have them. Listing also makes them available to tools like
 dust-b-gone.
