### PR TITLE
tests: Error when setgenerate is used on regtest

### DIFF
--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -196,6 +196,8 @@ Value setgenerate(const Array& params, bool fHelp)
 
     if (pwalletMain == NULL)
         throw JSONRPCError(RPC_METHOD_NOT_FOUND, "Method not found (disabled)");
+    if (Params().MineBlocksOnDemand())
+        throw JSONRPCError(RPC_METHOD_NOT_FOUND, "Use the generate method instead of setgenerate on this network");
 
     bool fGenerate = true;
     if (params.size() > 0)


### PR DESCRIPTION
Ever since #5957 there has been the problem that older RPC test cases (as can be found plenty in open pulls) use setgenerate() on regtest, assuming a different interpretation of the arguments. Directly generating a number of blocks has been split off into a new method `generate` - however using `setgenerate` with the previous arguments will result in spawning an unreasonable number of threads, and well, simply not work as expected without clear indication of the error.

Add an error to point the user at the right method.
