### PR TITLE
Update libsecp256k1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ bench_inv
 bench_sign
 bench_verify
 bench_recover
+bench_internal
 tests
 *.exe
 *.so

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,14 @@
 language: c
+sudo: false
+addons:
+  apt:
+    packages: libgmp-dev
 compiler:
   - clang
   - gcc
-install:
-  - sudo apt-get install -qq libssl-dev
-  - if [ "$BIGNUM" = "gmp" -o "$BIGNUM" = "auto" ]; then sudo apt-get install --no-install-recommends --no-upgrade -qq libgmp-dev; fi
-  - if [ -n "$EXTRAPACKAGES" ]; then sudo apt-get update && sudo apt-get install --no-install-recommends --no-upgrade $EXTRAPACKAGES; fi
 env:
   global:
-    - FIELD=auto  BIGNUM=auto  SCALAR=auto  ENDOMORPHISM=no  ASM=no  BUILD=check  EXTRAFLAGS= HOST= EXTRAPACKAGES=
+    - FIELD=auto  BIGNUM=auto  SCALAR=auto  ENDOMORPHISM=no  ASM=no  BUILD=check  EXTRAFLAGS= HOST=
   matrix:
     - SCALAR=32bit
     - SCALAR=64bit
@@ -22,8 +22,35 @@ env:
     - BIGNUM=no       ENDOMORPHISM=yes
     - BUILD=distcheck
     - EXTRAFLAGS=CFLAGS=-DDETERMINISTIC
-    - HOST=i686-linux-gnu EXTRAPACKAGES="gcc-multilib"
-    - HOST=i686-linux-gnu EXTRAPACKAGES="gcc-multilib" ENDOMORPHISM=yes
+matrix:
+  fast_finish: true
+  include:
+    - compiler: clang
+      env: HOST=i686-linux-gnu ENDOMORPHISM=yes
+      addons:
+        apt:
+          packages:
+            - gcc-multilib
+            - libgmp-dev:i386
+    - compiler: clang
+      env: HOST=i686-linux-gnu
+      addons:
+        apt:
+          packages:
+            - gcc-multilib
+    - compiler: gcc
+      env: HOST=i686-linux-gnu ENDOMORPHISM=yes
+      addons:
+        apt:
+          packages:
+            - gcc-multilib
+    - compiler: gcc
+      env: HOST=i686-linux-gnu
+      addons:
+        apt:
+          packages:
+            - gcc-multilib
+            - libgmp-dev:i386
 before_script: ./autogen.sh
 script:
  - if [ -n "$HOST" ]; then export USE_HOST="--host=$HOST"; fi

--- a/include/secp256k1.h
+++ b/include/secp256k1.h
@@ -40,42 +40,60 @@ extern "C" {
 #  define SECP256K1_ARG_NONNULL(_x)
 # endif
 
-
-/** Flags to pass to secp256k1_start. */
-# define SECP256K1_START_VERIFY (1 << 0)
-# define SECP256K1_START_SIGN   (1 << 1)
-
-/** Initialize the library. This may take some time (10-100 ms).
- *  You need to call this before calling any other function.
- *  It cannot run in parallel with any other functions, but once
- *  secp256k1_start() returns, all other functions are thread-safe.
+/** Opaque data structure that holds context information (precomputed tables etc.).
+ *  Only functions that take a pointer to a non-const context require exclusive
+ *  access to it. Multiple functions that take a pointer to a const context may
+ *  run simultaneously.
  */
-void secp256k1_start(unsigned int flags);
+typedef struct secp256k1_context_struct secp256k1_context_t;
 
-/** Free all memory associated with this library. After this, no
- *  functions can be called anymore, except secp256k1_start()
+/** Flags to pass to secp256k1_context_create. */
+# define SECP256K1_CONTEXT_VERIFY (1 << 0)
+# define SECP256K1_CONTEXT_SIGN   (1 << 1)
+
+/** Create a secp256k1 context object.
+ *  Returns: a newly created context object.
+ *  In:      flags: which parts of the context to initialize.
  */
-void secp256k1_stop(void);
+secp256k1_context_t* secp256k1_context_create(
+  int flags
+) SECP256K1_WARN_UNUSED_RESULT;
+
+/** Copies a secp256k1 context object.
+ *  Returns: a newly created context object.
+ *  In:      ctx: an existing context to copy
+ */
+secp256k1_context_t* secp256k1_context_clone(
+  const secp256k1_context_t* ctx
+) SECP256K1_WARN_UNUSED_RESULT;
+
+/** Destroy a secp256k1 context object.
+ *  The context pointer may not be used afterwards.
+ */
+void secp256k1_context_destroy(
+  secp256k1_context_t* ctx
+) SECP256K1_ARG_NONNULL(1);
 
 /** Verify an ECDSA signature.
  *  Returns: 1: correct signature
  *           0: incorrect signature
  *          -1: invalid public key
  *          -2: invalid signature
- * In:       msg32:     the 32-byte message hash being verified (cannot be NULL)
+ * In:       ctx:       a secp256k1 context object, initialized for verification.
+ *           msg32:     the 32-byte message hash being verified (cannot be NULL)
  *           sig:       the signature being verified (cannot be NULL)
  *           siglen:    the length of the signature
  *           pubkey:    the public key to verify with (cannot be NULL)
  *           pubkeylen: the length of pubkey
- * Requires starting using SECP256K1_START_VERIFY.
  */
 SECP256K1_WARN_UNUSED_RESULT int secp256k1_ecdsa_verify(
+  const secp256k1_context_t* ctx,
   const unsigned char *msg32,
   const unsigned char *sig,
   int siglen,
   const unsigned char *pubkey,
   int pubkeylen
-) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(4);
+) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3) SECP256K1_ARG_NONNULL(5);
 
 /** A pointer to a function to deterministically generate a nonce.
  * Returns: 1 if a nonce was successfully generated. 0 will cause signing to fail.
@@ -111,15 +129,14 @@ extern const secp256k1_nonce_function_t secp256k1_nonce_function_default;
  *  Returns: 1: signature created
  *           0: the nonce generation function failed, the private key was invalid, or there is not
  *              enough space in the signature (as indicated by siglen).
- *  In:      msg32:  the 32-byte message hash being signed (cannot be NULL)
+ *  In:      ctx:    pointer to a context object, initialized for signing (cannot be NULL)
+ *           msg32:  the 32-byte message hash being signed (cannot be NULL)
  *           seckey: pointer to a 32-byte secret key (cannot be NULL)
  *           noncefp:pointer to a nonce generation function. If NULL, secp256k1_nonce_function_default is used
  *           ndata:  pointer to arbitrary data used by the nonce generation function (can be NULL)
  *  Out:     sig:    pointer to an array where the signature will be placed (cannot be NULL)
  *  In/Out:  siglen: pointer to an int with the length of sig, which will be updated
- *                   to contain the actual signature length (<=72). If 0 is returned, this will be
- *                   set to zero.
- * Requires starting using SECP256K1_START_SIGN.
+ *                   to contain the actual signature length (<=72).
  *
  * The sig always has an s value in the lower half of the range (From 0x1
  * to 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0,
@@ -148,145 +165,180 @@ extern const secp256k1_nonce_function_t secp256k1_nonce_function_default;
  * be taken when this property is required for an application.
  */
 int secp256k1_ecdsa_sign(
+  const secp256k1_context_t* ctx,
   const unsigned char *msg32,
   unsigned char *sig,
   int *siglen,
   const unsigned char *seckey,
   secp256k1_nonce_function_t noncefp,
   const void *ndata
-) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3) SECP256K1_ARG_NONNULL(4);
+) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3) SECP256K1_ARG_NONNULL(4) SECP256K1_ARG_NONNULL(5);
 
 /** Create a compact ECDSA signature (64 byte + recovery id).
  *  Returns: 1: signature created
  *           0: the nonce generation function failed, or the secret key was invalid.
- *  In:      msg32:  the 32-byte message hash being signed (cannot be NULL)
+ *  In:      ctx:    pointer to a context object, initialized for signing (cannot be NULL)
+ *           msg32:  the 32-byte message hash being signed (cannot be NULL)
  *           seckey: pointer to a 32-byte secret key (cannot be NULL)
  *           noncefp:pointer to a nonce generation function. If NULL, secp256k1_nonce_function_default is used
  *           ndata:  pointer to arbitrary data used by the nonce generation function (can be NULL)
  *  Out:     sig:    pointer to a 64-byte array where the signature will be placed (cannot be NULL)
  *                   In case 0 is returned, the returned signature length will be zero.
  *           recid:  pointer to an int, which will be updated to contain the recovery id (can be NULL)
- * Requires starting using SECP256K1_START_SIGN.
  */
 int secp256k1_ecdsa_sign_compact(
+  const secp256k1_context_t* ctx,
   const unsigned char *msg32,
   unsigned char *sig64,
   const unsigned char *seckey,
   secp256k1_nonce_function_t noncefp,
   const void *ndata,
   int *recid
-) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3);
+) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3) SECP256K1_ARG_NONNULL(4);
 
 /** Recover an ECDSA public key from a compact signature.
  *  Returns: 1: public key successfully recovered (which guarantees a correct signature).
  *           0: otherwise.
- *  In:      msg32:      the 32-byte message hash assumed to be signed (cannot be NULL)
+ *  In:      ctx:        pointer to a context object, initialized for verification (cannot be NULL)
+ *           msg32:      the 32-byte message hash assumed to be signed (cannot be NULL)
  *           sig64:      signature as 64 byte array (cannot be NULL)
  *           compressed: whether to recover a compressed or uncompressed pubkey
  *           recid:      the recovery id (0-3, as returned by ecdsa_sign_compact)
  *  Out:     pubkey:     pointer to a 33 or 65 byte array to put the pubkey (cannot be NULL)
  *           pubkeylen:  pointer to an int that will contain the pubkey length (cannot be NULL)
- * Requires starting using SECP256K1_START_VERIFY.
  */
 SECP256K1_WARN_UNUSED_RESULT int secp256k1_ecdsa_recover_compact(
+  const secp256k1_context_t* ctx,
   const unsigned char *msg32,
   const unsigned char *sig64,
   unsigned char *pubkey,
   int *pubkeylen,
   int compressed,
   int recid
-) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3) SECP256K1_ARG_NONNULL(4);
+) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3) SECP256K1_ARG_NONNULL(4) SECP256K1_ARG_NONNULL(5);
 
 /** Verify an ECDSA secret key.
  *  Returns: 1: secret key is valid
  *           0: secret key is invalid
- *  In:      seckey: pointer to a 32-byte secret key (cannot be NULL)
+ *  In:      ctx: pointer to a context object (cannot be NULL)
+ *           seckey: pointer to a 32-byte secret key (cannot be NULL)
  */
-SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_seckey_verify(const unsigned char *seckey) SECP256K1_ARG_NONNULL(1);
+SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_seckey_verify(
+  const secp256k1_context_t* ctx,
+  const unsigned char *seckey
+) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2);
 
 /** Just validate a public key.
- *  Returns: 1: valid public key
- *           0: invalid public key
- *  In:      pubkey:    pointer to a 33-byte or 65-byte public key (cannot be NULL).
+ *  Returns: 1: public key is valid
+ *           0: public key is invalid
+ *  In:      ctx:       pointer to a context object (cannot be NULL)
+ *           pubkey:    pointer to a 33-byte or 65-byte public key (cannot be NULL).
  *           pubkeylen: length of pubkey
  */
-SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_pubkey_verify(const unsigned char *pubkey, int pubkeylen) SECP256K1_ARG_NONNULL(1);
+SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_pubkey_verify(
+  const secp256k1_context_t* ctx,
+  const unsigned char *pubkey,
+  int pubkeylen
+) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2);
 
 /** Compute the public key for a secret key.
- *  In:     compressed: whether the computed public key should be compressed
+ *  In:     ctx:        pointer to a context object, initialized for signing (cannot be NULL)
+ *          compressed: whether the computed public key should be compressed
  *          seckey:     pointer to a 32-byte private key (cannot be NULL)
  *  Out:    pubkey:     pointer to a 33-byte (if compressed) or 65-byte (if uncompressed)
  *                      area to store the public key (cannot be NULL)
  *          pubkeylen:  pointer to int that will be updated to contains the pubkey's
  *                      length (cannot be NULL)
  *  Returns: 1: secret was valid, public key stores
- *           0: secret was invalid, try again.
- * Requires starting using SECP256K1_START_SIGN.
+ *           0: secret was invalid, try again
  */
 SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_pubkey_create(
+  const secp256k1_context_t* ctx,
   unsigned char *pubkey,
   int *pubkeylen,
   const unsigned char *seckey,
   int compressed
-) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3);
+) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3) SECP256K1_ARG_NONNULL(4);
 
 /** Decompress a public key.
+ * In:     ctx:       pointer to a context object (cannot be NULL)
  * In/Out: pubkey:    pointer to a 65-byte array to put the decompressed public key.
-                      It must contain a 33-byte or 65-byte public key already (cannot be NULL)
+ *                    It must contain a 33-byte or 65-byte public key already (cannot be NULL)
  *         pubkeylen: pointer to the size of the public key pointed to by pubkey (cannot be NULL)
-                      It will be updated to reflect the new size.
- * Returns: 0 if the passed public key was invalid, 1 otherwise. If 1 is returned, the
-            pubkey is replaced with its decompressed version.
+ *                    It will be updated to reflect the new size.
+ * Returns: 0: pubkey was invalid
+ *          1: pubkey was valid, and was replaced with its decompressed version
  */
 SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_pubkey_decompress(
+  const secp256k1_context_t* ctx,
   unsigned char *pubkey,
   int *pubkeylen
-) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2);
+) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3);
 
-/** Export a private key in DER format. */
+/** Export a private key in DER format.
+ * In: ctx: pointer to a context object, initialized for signing (cannot be NULL)
+ */
 SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_privkey_export(
+  const secp256k1_context_t* ctx,
   const unsigned char *seckey,
   unsigned char *privkey,
   int *privkeylen,
   int compressed
-) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3);
+) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3) SECP256K1_ARG_NONNULL(4);
 
 /** Import a private key in DER format. */
 SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_privkey_import(
+  const secp256k1_context_t* ctx,
   unsigned char *seckey,
   const unsigned char *privkey,
   int privkeylen
-) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2);
+) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3);
 
 /** Tweak a private key by adding tweak to it. */
 SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_privkey_tweak_add(
+  const secp256k1_context_t* ctx,
   unsigned char *seckey,
   const unsigned char *tweak
-) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2);
+) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3);
 
 /** Tweak a public key by adding tweak times the generator to it.
- * Requires starting with SECP256K1_START_VERIFY.
+ * In: ctx: pointer to a context object, initialized for verification (cannot be NULL)
  */
 SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_pubkey_tweak_add(
+  const secp256k1_context_t* ctx,
   unsigned char *pubkey,
   int pubkeylen,
   const unsigned char *tweak
-) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(3);
+) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(4);
 
 /** Tweak a private key by multiplying it with tweak. */
 SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_privkey_tweak_mul(
+  const secp256k1_context_t* ctx,
   unsigned char *seckey,
   const unsigned char *tweak
-) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2);
+) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3);
 
 /** Tweak a public key by multiplying it with tweak.
- * Requires starting with SECP256K1_START_VERIFY.
+ * In: ctx: pointer to a context object, initialized for verification (cannot be NULL)
  */
 SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_pubkey_tweak_mul(
+  const secp256k1_context_t* ctx,
   unsigned char *pubkey,
   int pubkeylen,
   const unsigned char *tweak
-) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(3);
+) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(4);
+
+/** Updates the context randomization.
+ *  Returns: 1: randomization successfully updated
+ *           0: error
+ *  In:      ctx:       pointer to a context object (cannot be NULL)
+ *           seed32:    pointer to a 32-byte random seed (NULL resets to initial state)
+ */
+SECP256K1_WARN_UNUSED_RESULT int secp256k1_context_randomize(
+  secp256k1_context_t* ctx,
+  const unsigned char *seed32
+) SECP256K1_ARG_NONNULL(1);
+
 
 # ifdef __cplusplus
 }

--- a/src/bench.h
+++ b/src/bench.h
@@ -48,7 +48,7 @@ void run_benchmark(char *name, void (*benchmark)(void*), void (*setup)(void*), v
     print_number(min * 1000000.0 / iter);
     printf("us / avg ");
     print_number((sum / count) * 1000000.0 / iter);
-    printf("us / avg ");
+    printf("us / max ");
     print_number(max * 1000000.0 / iter);
     printf("us\n");
 }

--- a/src/bench_recover.c
+++ b/src/bench_recover.c
@@ -9,6 +9,7 @@
 #include "bench.h"
 
 typedef struct {
+    secp256k1_context_t *ctx;
     unsigned char msg[32];
     unsigned char sig[64];
 } bench_recover_t;
@@ -21,7 +22,7 @@ void bench_recover(void* arg) {
     for (i = 0; i < 20000; i++) {
         int j;
         int pubkeylen = 33;
-        CHECK(secp256k1_ecdsa_recover_compact(data->msg, data->sig, pubkey, &pubkeylen, 1, i % 2));
+        CHECK(secp256k1_ecdsa_recover_compact(data->ctx, data->msg, data->sig, pubkey, &pubkeylen, 1, i % 2));
         for (j = 0; j < 32; j++) {
             data->sig[j + 32] = data->msg[j];    /* Move former message to S. */
             data->msg[j] = data->sig[j];         /* Move former R to message. */
@@ -40,10 +41,11 @@ void bench_recover_setup(void* arg) {
 
 int main(void) {
     bench_recover_t data;
-    secp256k1_start(SECP256K1_START_VERIFY);
+
+    data.ctx = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY);
 
     run_benchmark("ecdsa_recover", bench_recover, bench_recover_setup, NULL, &data, 10, 20000);
 
-    secp256k1_stop();
+    secp256k1_context_destroy(data.ctx);
     return 0;
 }

--- a/src/bench_sign.c
+++ b/src/bench_sign.c
@@ -9,6 +9,7 @@
 #include "bench.h"
 
 typedef struct {
+    secp256k1_context_t* ctx;
     unsigned char msg[32];
     unsigned char key[32];
 } bench_sign_t;
@@ -29,7 +30,7 @@ static void bench_sign(void* arg) {
     for (i = 0; i < 20000; i++) {
         int j;
         int recid = 0;
-        CHECK(secp256k1_ecdsa_sign_compact(data->msg, sig, data->key, NULL, NULL, &recid));
+        CHECK(secp256k1_ecdsa_sign_compact(data->ctx, data->msg, sig, data->key, NULL, NULL, &recid));
         for (j = 0; j < 32; j++) {
             data->msg[j] = sig[j];             /* Move former R to message. */
             data->key[j] = sig[j + 32];        /* Move former S to key.     */
@@ -39,10 +40,11 @@ static void bench_sign(void* arg) {
 
 int main(void) {
     bench_sign_t data;
-    secp256k1_start(SECP256K1_START_SIGN);
+
+    data.ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
 
     run_benchmark("ecdsa_sign", bench_sign, bench_sign_setup, NULL, &data, 10, 20000);
 
-    secp256k1_stop();
+    secp256k1_context_destroy(data.ctx);
     return 0;
 }

--- a/src/bench_verify.c
+++ b/src/bench_verify.c
@@ -12,6 +12,7 @@
 #include "bench.h"
 
 typedef struct {
+    secp256k1_context_t *ctx;
     unsigned char msg[32];
     unsigned char key[32];
     unsigned char sig[72];
@@ -28,7 +29,7 @@ static void benchmark_verify(void* arg) {
         data->sig[data->siglen - 1] ^= (i & 0xFF);
         data->sig[data->siglen - 2] ^= ((i >> 8) & 0xFF);
         data->sig[data->siglen - 3] ^= ((i >> 16) & 0xFF);
-        CHECK(secp256k1_ecdsa_verify(data->msg, data->sig, data->siglen, data->pubkey, data->pubkeylen) == (i == 0));
+        CHECK(secp256k1_ecdsa_verify(data->ctx, data->msg, data->sig, data->siglen, data->pubkey, data->pubkeylen) == (i == 0));
         data->sig[data->siglen - 1] ^= (i & 0xFF);
         data->sig[data->siglen - 2] ^= ((i >> 8) & 0xFF);
         data->sig[data->siglen - 3] ^= ((i >> 16) & 0xFF);
@@ -39,17 +40,17 @@ int main(void) {
     int i;
     benchmark_verify_t data;
 
-    secp256k1_start(SECP256K1_START_VERIFY | SECP256K1_START_SIGN);
+    data.ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
 
     for (i = 0; i < 32; i++) data.msg[i] = 1 + i;
     for (i = 0; i < 32; i++) data.key[i] = 33 + i;
     data.siglen = 72;
-    secp256k1_ecdsa_sign(data.msg, data.sig, &data.siglen, data.key, NULL, NULL);
+    secp256k1_ecdsa_sign(data.ctx, data.msg, data.sig, &data.siglen, data.key, NULL, NULL);
     data.pubkeylen = 33;
-    CHECK(secp256k1_ec_pubkey_create(data.pubkey, &data.pubkeylen, data.key, 1));
+    CHECK(secp256k1_ec_pubkey_create(data.ctx, data.pubkey, &data.pubkeylen, data.key, 1));
 
     run_benchmark("ecdsa_verify", benchmark_verify, NULL, NULL, &data, 10, 20000);
 
-    secp256k1_stop();
+    secp256k1_context_destroy(data.ctx);
     return 0;
 }

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -444,9 +444,18 @@ static void MutateTxSign(CMutableTransaction& tx, const string& flagStr)
     tx = mergedTx;
 }
 
+class Secp256k1Init
+{
+public:
+    Secp256k1Init() { ECC_Start(); }
+    ~Secp256k1Init() { ECC_Stop(); }
+};
+
 static void MutateTx(CMutableTransaction& tx, const string& command,
                      const string& commandVal)
 {
+    boost::scoped_ptr<Secp256k1Init> ecc;
+
     if (command == "nversion")
         MutateTxVersion(tx, commandVal);
     else if (command == "locktime")
@@ -464,8 +473,10 @@ static void MutateTx(CMutableTransaction& tx, const string& command,
     else if (command == "outscript")
         MutateTxAddOutScript(tx, commandVal);
 
-    else if (command == "sign")
+    else if (command == "sign") {
+        if (!ecc) { ecc.reset(new Secp256k1Init()); }
         MutateTxSign(tx, commandVal);
+    }
 
     else if (command == "load")
         RegisterLoad(commandVal);

--- a/src/ecdsa.h
+++ b/src/ecdsa.h
@@ -9,6 +9,7 @@
 
 #include "scalar.h"
 #include "group.h"
+#include "ecmult.h"
 
 typedef struct {
     secp256k1_scalar_t r, s;
@@ -16,8 +17,8 @@ typedef struct {
 
 static int secp256k1_ecdsa_sig_parse(secp256k1_ecdsa_sig_t *r, const unsigned char *sig, int size);
 static int secp256k1_ecdsa_sig_serialize(unsigned char *sig, int *size, const secp256k1_ecdsa_sig_t *a);
-static int secp256k1_ecdsa_sig_verify(const secp256k1_ecdsa_sig_t *sig, const secp256k1_ge_t *pubkey, const secp256k1_scalar_t *message);
-static int secp256k1_ecdsa_sig_sign(secp256k1_ecdsa_sig_t *sig, const secp256k1_scalar_t *seckey, const secp256k1_scalar_t *message, const secp256k1_scalar_t *nonce, int *recid);
-static int secp256k1_ecdsa_sig_recover(const secp256k1_ecdsa_sig_t *sig, secp256k1_ge_t *pubkey, const secp256k1_scalar_t *message, int recid);
+static int secp256k1_ecdsa_sig_verify(const secp256k1_ecmult_context_t *ctx, const secp256k1_ecdsa_sig_t *sig, const secp256k1_ge_t *pubkey, const secp256k1_scalar_t *message);
+static int secp256k1_ecdsa_sig_sign(const secp256k1_ecmult_gen_context_t *ctx, secp256k1_ecdsa_sig_t *sig, const secp256k1_scalar_t *seckey, const secp256k1_scalar_t *message, const secp256k1_scalar_t *nonce, int *recid);
+static int secp256k1_ecdsa_sig_recover(const secp256k1_ecmult_context_t *ctx, const secp256k1_ecdsa_sig_t *sig, secp256k1_ge_t *pubkey, const secp256k1_scalar_t *message, int recid);
 
 #endif

--- a/src/ecdsa_impl.h
+++ b/src/ecdsa_impl.h
@@ -53,35 +53,59 @@ static int secp256k1_ecdsa_sig_parse(secp256k1_ecdsa_sig_t *r, const unsigned ch
     int lenr;
     int lens;
     int overflow;
-    if (sig[0] != 0x30) return 0;
+    if (sig[0] != 0x30) {
+        return 0;
+    }
     lenr = sig[3];
-    if (5+lenr >= size) return 0;
+    if (5+lenr >= size) {
+        return 0;
+    }
     lens = sig[lenr+5];
-    if (sig[1] != lenr+lens+4) return 0;
-    if (lenr+lens+6 > size) return 0;
-    if (sig[2] != 0x02) return 0;
-    if (lenr == 0) return 0;
-    if (sig[lenr+4] != 0x02) return 0;
-    if (lens == 0) return 0;
+    if (sig[1] != lenr+lens+4) {
+        return 0;
+    }
+    if (lenr+lens+6 > size) {
+        return 0;
+    }
+    if (sig[2] != 0x02) {
+        return 0;
+    }
+    if (lenr == 0) {
+        return 0;
+    }
+    if (sig[lenr+4] != 0x02) {
+        return 0;
+    }
+    if (lens == 0) {
+        return 0;
+    }
     sp = sig + 6 + lenr;
     while (lens > 0 && sp[0] == 0) {
         lens--;
         sp++;
     }
-    if (lens > 32) return 0;
+    if (lens > 32) {
+        return 0;
+    }
     rp = sig + 4;
     while (lenr > 0 && rp[0] == 0) {
         lenr--;
         rp++;
     }
-    if (lenr > 32) return 0;
+    if (lenr > 32) {
+        return 0;
+    }
     memcpy(ra + 32 - lenr, rp, lenr);
     memcpy(sa + 32 - lens, sp, lens);
     overflow = 0;
     secp256k1_scalar_set_b32(&r->r, ra, &overflow);
-    if (overflow) return 0;
+    if (overflow) {
+        return 0;
+    }
     secp256k1_scalar_set_b32(&r->s, sa, &overflow);
-    if (overflow) return 0;
+    if (overflow) {
+        return 0;
+    }
     return 1;
 }
 
@@ -93,8 +117,9 @@ static int secp256k1_ecdsa_sig_serialize(unsigned char *sig, int *size, const se
     secp256k1_scalar_get_b32(&s[1], &a->s);
     while (lenR > 1 && rp[0] == 0 && rp[1] < 0x80) { lenR--; rp++; }
     while (lenS > 1 && sp[0] == 0 && sp[1] < 0x80) { lenS--; sp++; }
-    if (*size < 6+lenS+lenR)
+    if (*size < 6+lenS+lenR) {
         return 0;
+    }
     *size = 6 + lenS + lenR;
     sig[0] = 0x30;
     sig[1] = 4 + lenS + lenR;
@@ -107,21 +132,22 @@ static int secp256k1_ecdsa_sig_serialize(unsigned char *sig, int *size, const se
     return 1;
 }
 
-static int secp256k1_ecdsa_sig_verify(const secp256k1_ecdsa_sig_t *sig, const secp256k1_ge_t *pubkey, const secp256k1_scalar_t *message) {
+static int secp256k1_ecdsa_sig_verify(const secp256k1_ecmult_context_t *ctx, const secp256k1_ecdsa_sig_t *sig, const secp256k1_ge_t *pubkey, const secp256k1_scalar_t *message) {
     unsigned char c[32];
     secp256k1_scalar_t sn, u1, u2;
     secp256k1_fe_t xr;
     secp256k1_gej_t pubkeyj;
     secp256k1_gej_t pr;
 
-    if (secp256k1_scalar_is_zero(&sig->r) || secp256k1_scalar_is_zero(&sig->s))
+    if (secp256k1_scalar_is_zero(&sig->r) || secp256k1_scalar_is_zero(&sig->s)) {
         return 0;
+    }
 
     secp256k1_scalar_inverse_var(&sn, &sig->s);
     secp256k1_scalar_mul(&u1, &sn, message);
     secp256k1_scalar_mul(&u2, &sn, &sig->r);
     secp256k1_gej_set_ge(&pubkeyj, pubkey);
-    secp256k1_ecmult(&pr, &pubkeyj, &u2, &u1);
+    secp256k1_ecmult(ctx, &pr, &pubkeyj, &u2, &u1);
     if (secp256k1_gej_is_infinity(&pr)) {
         return 0;
     }
@@ -160,7 +186,7 @@ static int secp256k1_ecdsa_sig_verify(const secp256k1_ecdsa_sig_t *sig, const se
     return 0;
 }
 
-static int secp256k1_ecdsa_sig_recover(const secp256k1_ecdsa_sig_t *sig, secp256k1_ge_t *pubkey, const secp256k1_scalar_t *message, int recid) {
+static int secp256k1_ecdsa_sig_recover(const secp256k1_ecmult_context_t *ctx, const secp256k1_ecdsa_sig_t *sig, secp256k1_ge_t *pubkey, const secp256k1_scalar_t *message, int recid) {
     unsigned char brx[32];
     secp256k1_fe_t fx;
     secp256k1_ge_t x;
@@ -168,36 +194,39 @@ static int secp256k1_ecdsa_sig_recover(const secp256k1_ecdsa_sig_t *sig, secp256
     secp256k1_scalar_t rn, u1, u2;
     secp256k1_gej_t qj;
 
-    if (secp256k1_scalar_is_zero(&sig->r) || secp256k1_scalar_is_zero(&sig->s))
+    if (secp256k1_scalar_is_zero(&sig->r) || secp256k1_scalar_is_zero(&sig->s)) {
         return 0;
+    }
 
     secp256k1_scalar_get_b32(brx, &sig->r);
     VERIFY_CHECK(secp256k1_fe_set_b32(&fx, brx)); /* brx comes from a scalar, so is less than the order; certainly less than p */
     if (recid & 2) {
-        if (secp256k1_fe_cmp_var(&fx, &secp256k1_ecdsa_const_p_minus_order) >= 0)
+        if (secp256k1_fe_cmp_var(&fx, &secp256k1_ecdsa_const_p_minus_order) >= 0) {
             return 0;
+        }
         secp256k1_fe_add(&fx, &secp256k1_ecdsa_const_order_as_fe);
     }
-    if (!secp256k1_ge_set_xo_var(&x, &fx, recid & 1))
+    if (!secp256k1_ge_set_xo_var(&x, &fx, recid & 1)) {
         return 0;
+    }
     secp256k1_gej_set_ge(&xj, &x);
     secp256k1_scalar_inverse_var(&rn, &sig->r);
     secp256k1_scalar_mul(&u1, &rn, message);
     secp256k1_scalar_negate(&u1, &u1);
     secp256k1_scalar_mul(&u2, &rn, &sig->s);
-    secp256k1_ecmult(&qj, &xj, &u2, &u1);
+    secp256k1_ecmult(ctx, &qj, &xj, &u2, &u1);
     secp256k1_ge_set_gej_var(pubkey, &qj);
     return !secp256k1_gej_is_infinity(&qj);
 }
 
-static int secp256k1_ecdsa_sig_sign(secp256k1_ecdsa_sig_t *sig, const secp256k1_scalar_t *seckey, const secp256k1_scalar_t *message, const secp256k1_scalar_t *nonce, int *recid) {
+static int secp256k1_ecdsa_sig_sign(const secp256k1_ecmult_gen_context_t *ctx, secp256k1_ecdsa_sig_t *sig, const secp256k1_scalar_t *seckey, const secp256k1_scalar_t *message, const secp256k1_scalar_t *nonce, int *recid) {
     unsigned char b[32];
     secp256k1_gej_t rp;
     secp256k1_ge_t r;
     secp256k1_scalar_t n;
     int overflow = 0;
 
-    secp256k1_ecmult_gen(&rp, nonce);
+    secp256k1_ecmult_gen(ctx, &rp, nonce);
     secp256k1_ge_set_gej(&r, &rp);
     secp256k1_fe_normalize(&r.x);
     secp256k1_fe_normalize(&r.y);
@@ -209,8 +238,9 @@ static int secp256k1_ecdsa_sig_sign(secp256k1_ecdsa_sig_t *sig, const secp256k1_
         secp256k1_ge_clear(&r);
         return 0;
     }
-    if (recid)
+    if (recid) {
         *recid = (overflow ? 2 : 0) | (secp256k1_fe_is_odd(&r.y) ? 1 : 0);
+    }
     secp256k1_scalar_mul(&n, &sig->r, seckey);
     secp256k1_scalar_add(&n, &n, message);
     secp256k1_scalar_inverse(&sig->s, nonce);
@@ -218,12 +248,14 @@ static int secp256k1_ecdsa_sig_sign(secp256k1_ecdsa_sig_t *sig, const secp256k1_
     secp256k1_scalar_clear(&n);
     secp256k1_gej_clear(&rp);
     secp256k1_ge_clear(&r);
-    if (secp256k1_scalar_is_zero(&sig->s))
+    if (secp256k1_scalar_is_zero(&sig->s)) {
         return 0;
+    }
     if (secp256k1_scalar_is_high(&sig->s)) {
         secp256k1_scalar_negate(&sig->s, &sig->s);
-        if (recid)
+        if (recid) {
             *recid ^= 1;
+        }
     }
     return 1;
 }

--- a/src/eckey.h
+++ b/src/eckey.h
@@ -9,16 +9,18 @@
 
 #include "group.h"
 #include "scalar.h"
+#include "ecmult.h"
+#include "ecmult_gen.h"
 
 static int secp256k1_eckey_pubkey_parse(secp256k1_ge_t *elem, const unsigned char *pub, int size);
 static int secp256k1_eckey_pubkey_serialize(secp256k1_ge_t *elem, unsigned char *pub, int *size, int compressed);
 
 static int secp256k1_eckey_privkey_parse(secp256k1_scalar_t *key, const unsigned char *privkey, int privkeylen);
-static int secp256k1_eckey_privkey_serialize(unsigned char *privkey, int *privkeylen, const secp256k1_scalar_t *key, int compressed);
+static int secp256k1_eckey_privkey_serialize(const secp256k1_ecmult_gen_context_t *ctx, unsigned char *privkey, int *privkeylen, const secp256k1_scalar_t *key, int compressed);
 
 static int secp256k1_eckey_privkey_tweak_add(secp256k1_scalar_t *key, const secp256k1_scalar_t *tweak);
-static int secp256k1_eckey_pubkey_tweak_add(secp256k1_ge_t *key, const secp256k1_scalar_t *tweak);
+static int secp256k1_eckey_pubkey_tweak_add(const secp256k1_ecmult_context_t *ctx, secp256k1_ge_t *key, const secp256k1_scalar_t *tweak);
 static int secp256k1_eckey_privkey_tweak_mul(secp256k1_scalar_t *key, const secp256k1_scalar_t *tweak);
-static int secp256k1_eckey_pubkey_tweak_mul(secp256k1_ge_t *key, const secp256k1_scalar_t *tweak);
+static int secp256k1_eckey_pubkey_tweak_mul(const secp256k1_ecmult_context_t *ctx, secp256k1_ge_t *key, const secp256k1_scalar_t *tweak);
 
 #endif

--- a/src/ecmult.h
+++ b/src/ecmult.h
@@ -10,10 +10,22 @@
 #include "num.h"
 #include "group.h"
 
-static void secp256k1_ecmult_start(void);
-static void secp256k1_ecmult_stop(void);
+typedef struct {
+    /* For accelerating the computation of a*P + b*G: */
+    secp256k1_ge_storage_t (*pre_g)[];    /* odd multiples of the generator */
+#ifdef USE_ENDOMORPHISM
+    secp256k1_ge_storage_t (*pre_g_128)[]; /* odd multiples of 2^128*generator */
+#endif
+} secp256k1_ecmult_context_t;
+
+static void secp256k1_ecmult_context_init(secp256k1_ecmult_context_t *ctx);
+static void secp256k1_ecmult_context_build(secp256k1_ecmult_context_t *ctx);
+static void secp256k1_ecmult_context_clone(secp256k1_ecmult_context_t *dst,
+                                           const secp256k1_ecmult_context_t *src);
+static void secp256k1_ecmult_context_clear(secp256k1_ecmult_context_t *ctx);
+static int secp256k1_ecmult_context_is_built(const secp256k1_ecmult_context_t *ctx);
 
 /** Double multiply: R = na*A + ng*G */
-static void secp256k1_ecmult(secp256k1_gej_t *r, const secp256k1_gej_t *a, const secp256k1_scalar_t *na, const secp256k1_scalar_t *ng);
+static void secp256k1_ecmult(const secp256k1_ecmult_context_t *ctx, secp256k1_gej_t *r, const secp256k1_gej_t *a, const secp256k1_scalar_t *na, const secp256k1_scalar_t *ng);
 
 #endif

--- a/src/ecmult_gen.h
+++ b/src/ecmult_gen.h
@@ -10,10 +10,34 @@
 #include "scalar.h"
 #include "group.h"
 
-static void secp256k1_ecmult_gen_start(void);
-static void secp256k1_ecmult_gen_stop(void);
+typedef struct {
+    /* For accelerating the computation of a*G:
+     * To harden against timing attacks, use the following mechanism:
+     * * Break up the multiplicand into groups of 4 bits, called n_0, n_1, n_2, ..., n_63.
+     * * Compute sum(n_i * 16^i * G + U_i, i=0..63), where:
+     *   * U_i = U * 2^i (for i=0..62)
+     *   * U_i = U * (1-2^63) (for i=63)
+     *   where U is a point with no known corresponding scalar. Note that sum(U_i, i=0..63) = 0.
+     * For each i, and each of the 16 possible values of n_i, (n_i * 16^i * G + U_i) is
+     * precomputed (call it prec(i, n_i)). The formula now becomes sum(prec(i, n_i), i=0..63).
+     * None of the resulting prec group elements have a known scalar, and neither do any of
+     * the intermediate sums while computing a*G.
+     */
+    secp256k1_ge_storage_t (*prec)[64][16]; /* prec[j][i] = 16^j * i * G + U_i */
+    secp256k1_scalar_t blind;
+    secp256k1_gej_t initial;
+} secp256k1_ecmult_gen_context_t;
+
+static void secp256k1_ecmult_gen_context_init(secp256k1_ecmult_gen_context_t* ctx);
+static void secp256k1_ecmult_gen_context_build(secp256k1_ecmult_gen_context_t* ctx);
+static void secp256k1_ecmult_gen_context_clone(secp256k1_ecmult_gen_context_t *dst,
+                                               const secp256k1_ecmult_gen_context_t* src);
+static void secp256k1_ecmult_gen_context_clear(secp256k1_ecmult_gen_context_t* ctx);
+static int secp256k1_ecmult_gen_context_is_built(const secp256k1_ecmult_gen_context_t* ctx);
 
 /** Multiply with the generator: R = a*G */
-static void secp256k1_ecmult_gen(secp256k1_gej_t *r, const secp256k1_scalar_t *a);
+static void secp256k1_ecmult_gen(const secp256k1_ecmult_gen_context_t* ctx, secp256k1_gej_t *r, const secp256k1_scalar_t *a);
+
+static void secp256k1_ecmult_gen_blind(secp256k1_ecmult_gen_context_t *ctx, const unsigned char *seed32);
 
 #endif

--- a/src/ecmult_gen_impl.h
+++ b/src/ecmult_gen_impl.h
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2013, 2014 Pieter Wuille                             *
+ * Copyright (c) 2013, 2014, 2015 Pieter Wuille, Gregory Maxwell      *
  * Distributed under the MIT software license, see the accompanying   *
  * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
@@ -10,36 +10,23 @@
 #include "scalar.h"
 #include "group.h"
 #include "ecmult_gen.h"
+#include "hash_impl.h"
 
-typedef struct {
-    /* For accelerating the computation of a*G:
-     * To harden against timing attacks, use the following mechanism:
-     * * Break up the multiplicand into groups of 4 bits, called n_0, n_1, n_2, ..., n_63.
-     * * Compute sum(n_i * 16^i * G + U_i, i=0..63), where:
-     *   * U_i = U * 2^i (for i=0..62)
-     *   * U_i = U * (1-2^63) (for i=63)
-     *   where U is a point with no known corresponding scalar. Note that sum(U_i, i=0..63) = 0.
-     * For each i, and each of the 16 possible values of n_i, (n_i * 16^i * G + U_i) is
-     * precomputed (call it prec(i, n_i)). The formula now becomes sum(prec(i, n_i), i=0..63).
-     * None of the resulting prec group elements have a known scalar, and neither do any of
-     * the intermediate sums while computing a*G.
-     */
-    secp256k1_ge_storage_t prec[64][16]; /* prec[j][i] = 16^j * i * G + U_i */
-} secp256k1_ecmult_gen_consts_t;
+static void secp256k1_ecmult_gen_context_init(secp256k1_ecmult_gen_context_t *ctx) {
+    ctx->prec = NULL;
+}
 
-static const secp256k1_ecmult_gen_consts_t *secp256k1_ecmult_gen_consts = NULL;
-
-static void secp256k1_ecmult_gen_start(void) {
+static void secp256k1_ecmult_gen_context_build(secp256k1_ecmult_gen_context_t *ctx) {
     secp256k1_ge_t prec[1024];
     secp256k1_gej_t gj;
     secp256k1_gej_t nums_gej;
-    secp256k1_ecmult_gen_consts_t *ret;
     int i, j;
-    if (secp256k1_ecmult_gen_consts != NULL)
-        return;
 
-    /* Allocate the precomputation table. */
-    ret = (secp256k1_ecmult_gen_consts_t*)checked_malloc(sizeof(secp256k1_ecmult_gen_consts_t));
+    if (ctx->prec != NULL) {
+        return;
+    }
+
+    ctx->prec = (secp256k1_ge_storage_t (*)[64][16])checked_malloc(sizeof(*ctx->prec));
 
     /* get the generator */
     secp256k1_gej_set_ge(&gj, &secp256k1_ge_const_g);
@@ -85,42 +72,113 @@ static void secp256k1_ecmult_gen_start(void) {
     }
     for (j = 0; j < 64; j++) {
         for (i = 0; i < 16; i++) {
-            secp256k1_ge_to_storage(&ret->prec[j][i], &prec[j*16 + i]);
+            secp256k1_ge_to_storage(&(*ctx->prec)[j][i], &prec[j*16 + i]);
         }
     }
-
-    /* Set the global pointer to the precomputation table. */
-    secp256k1_ecmult_gen_consts = ret;
+    secp256k1_ecmult_gen_blind(ctx, NULL);
 }
 
-static void secp256k1_ecmult_gen_stop(void) {
-    secp256k1_ecmult_gen_consts_t *c;
-    if (secp256k1_ecmult_gen_consts == NULL)
-        return;
-
-    c = (secp256k1_ecmult_gen_consts_t*)secp256k1_ecmult_gen_consts;
-    secp256k1_ecmult_gen_consts = NULL;
-    free(c);
+static int secp256k1_ecmult_gen_context_is_built(const secp256k1_ecmult_gen_context_t* ctx) {
+    return ctx->prec != NULL;
 }
 
-static void secp256k1_ecmult_gen(secp256k1_gej_t *r, const secp256k1_scalar_t *gn) {
-    const secp256k1_ecmult_gen_consts_t *c = secp256k1_ecmult_gen_consts;
+static void secp256k1_ecmult_gen_context_clone(secp256k1_ecmult_gen_context_t *dst,
+                                               const secp256k1_ecmult_gen_context_t *src) {
+    if (src->prec == NULL) {
+        dst->prec = NULL;
+    } else {
+        dst->prec = (secp256k1_ge_storage_t (*)[64][16])checked_malloc(sizeof(*dst->prec));
+        memcpy(dst->prec, src->prec, sizeof(*dst->prec));
+        dst->initial = src->initial;
+        dst->blind = src->blind;
+    }
+}
+
+static void secp256k1_ecmult_gen_context_clear(secp256k1_ecmult_gen_context_t *ctx) {
+    free(ctx->prec);
+    secp256k1_scalar_clear(&ctx->blind);
+    secp256k1_gej_clear(&ctx->initial);
+    ctx->prec = NULL;
+}
+
+static void secp256k1_ecmult_gen(const secp256k1_ecmult_gen_context_t *ctx, secp256k1_gej_t *r, const secp256k1_scalar_t *gn) {
     secp256k1_ge_t add;
     secp256k1_ge_storage_t adds;
+    secp256k1_scalar_t gnb;
     int bits;
     int i, j;
-    secp256k1_gej_set_infinity(r);
+    memset(&adds, 0, sizeof(adds));
+    *r = ctx->initial;
+    /* Blind scalar/point multiplication by computing (n-b)G + bG instead of nG. */
+    secp256k1_scalar_add(&gnb, gn, &ctx->blind);
     add.infinity = 0;
     for (j = 0; j < 64; j++) {
-        bits = secp256k1_scalar_get_bits(gn, j * 4, 4);
+        bits = secp256k1_scalar_get_bits(&gnb, j * 4, 4);
         for (i = 0; i < 16; i++) {
-            secp256k1_ge_storage_cmov(&adds, &c->prec[j][i], i == bits);
+            /** This uses a conditional move to avoid any secret data in array indexes.
+             *   _Any_ use of secret indexes has been demonstrated to result in timing
+             *   sidechannels, even when the cache-line access patterns are uniform.
+             *  See also:
+             *   "A word of warning", CHES 2013 Rump Session, by Daniel J. Bernstein and Peter Schwabe
+             *    (https://cryptojedi.org/peter/data/chesrump-20130822.pdf) and
+             *   "Cache Attacks and Countermeasures: the Case of AES", RSA 2006,
+             *    by Dag Arne Osvik, Adi Shamir, and Eran Tromer
+             *    (http://www.tau.ac.il/~tromer/papers/cache.pdf)
+             */
+            secp256k1_ge_storage_cmov(&adds, &(*ctx->prec)[j][i], i == bits);
         }
         secp256k1_ge_from_storage(&add, &adds);
         secp256k1_gej_add_ge(r, r, &add);
     }
     bits = 0;
     secp256k1_ge_clear(&add);
+    secp256k1_scalar_clear(&gnb);
+}
+
+/* Setup blinding values for secp256k1_ecmult_gen. */
+static void secp256k1_ecmult_gen_blind(secp256k1_ecmult_gen_context_t *ctx, const unsigned char *seed32) {
+    secp256k1_scalar_t b;
+    secp256k1_gej_t gb;
+    secp256k1_fe_t s;
+    unsigned char nonce32[32];
+    secp256k1_rfc6979_hmac_sha256_t rng;
+    int retry;
+    if (!seed32) {
+        /* When seed is NULL, reset the initial point and blinding value. */
+        secp256k1_gej_set_ge(&ctx->initial, &secp256k1_ge_const_g);
+        secp256k1_gej_neg(&ctx->initial, &ctx->initial);
+        secp256k1_scalar_set_int(&ctx->blind, 1);
+    }
+    /* The prior blinding value (if not reset) is chained forward by including it in the hash. */
+    secp256k1_scalar_get_b32(nonce32, &ctx->blind);
+    /** Using a CSPRNG allows a failure free interface, avoids needing large amounts of random data,
+     *   and guards against weak or adversarial seeds.  This is a simpler and safer interface than
+     *   asking the caller for blinding values directly and expecting them to retry on failure.
+     */
+    secp256k1_rfc6979_hmac_sha256_initialize(&rng, seed32 ? seed32 : nonce32, 32, nonce32, 32, NULL, 0);
+    /* Retry for out of range results to achieve uniformity. */
+    do {
+        secp256k1_rfc6979_hmac_sha256_generate(&rng, nonce32, 32);
+        retry = !secp256k1_fe_set_b32(&s, nonce32);
+        retry |= secp256k1_fe_is_zero(&s);
+    } while (retry);
+    /* Randomize the projection to defend against multiplier sidechannels. */
+    secp256k1_gej_rescale(&ctx->initial, &s);
+    secp256k1_fe_clear(&s);
+    do {
+        secp256k1_rfc6979_hmac_sha256_generate(&rng, nonce32, 32);
+        secp256k1_scalar_set_b32(&b, nonce32, &retry);
+        /* A blinding value of 0 works, but would undermine the projection hardening. */
+        retry |= secp256k1_scalar_is_zero(&b);
+    } while (retry);
+    secp256k1_rfc6979_hmac_sha256_finalize(&rng);
+    memset(nonce32, 0, 32);
+    secp256k1_ecmult_gen(ctx, &gb, &b);
+    secp256k1_scalar_negate(&b, &b);
+    ctx->blind = b;
+    ctx->initial = gb;
+    secp256k1_scalar_clear(&b);
+    secp256k1_gej_clear(&gb);
 }
 
 #endif

--- a/src/field.h
+++ b/src/field.h
@@ -113,4 +113,7 @@ static void secp256k1_fe_from_storage(secp256k1_fe_t *r, const secp256k1_fe_stor
 /** If flag is true, set *r equal to *a; otherwise leave it. Constant-time. */
 static void secp256k1_fe_storage_cmov(secp256k1_fe_storage_t *r, const secp256k1_fe_storage_t *a, int flag);
 
+/** If flag is true, set *r equal to *a; otherwise leave it. Constant-time. */
+static void secp256k1_fe_cmov(secp256k1_fe_t *r, const secp256k1_fe_t *a, int flag);
+
 #endif

--- a/src/field_10x26_impl.h
+++ b/src/field_10x26_impl.h
@@ -236,8 +236,9 @@ static int secp256k1_fe_normalizes_to_zero_var(secp256k1_fe_t *r) {
     z1 = z0 ^ 0x3D0UL;
 
     /* Fast return path should catch the majority of cases */
-    if ((z0 != 0UL) & (z1 != 0x3FFFFFFUL))
+    if ((z0 != 0UL) & (z1 != 0x3FFFFFFUL)) {
         return 0;
+    }
 
     t1 = r->n[1];
     t2 = r->n[2];
@@ -315,8 +316,12 @@ static int secp256k1_fe_cmp_var(const secp256k1_fe_t *a, const secp256k1_fe_t *b
     secp256k1_fe_verify(b);
 #endif
     for (i = 9; i >= 0; i--) {
-        if (a->n[i] > b->n[i]) return 1;
-        if (a->n[i] < b->n[i]) return -1;
+        if (a->n[i] > b->n[i]) {
+            return 1;
+        }
+        if (a->n[i] < b->n[i]) {
+            return -1;
+        }
     }
     return 0;
 }
@@ -1060,6 +1065,26 @@ static void secp256k1_fe_sqr(secp256k1_fe_t *r, const secp256k1_fe_t *a) {
     r->magnitude = 1;
     r->normalized = 0;
     secp256k1_fe_verify(r);
+#endif
+}
+
+static SECP256K1_INLINE void secp256k1_fe_cmov(secp256k1_fe_t *r, const secp256k1_fe_t *a, int flag) {
+    uint32_t mask0, mask1;
+    mask0 = flag + ~((uint32_t)0);
+    mask1 = ~mask0;
+    r->n[0] = (r->n[0] & mask0) | (a->n[0] & mask1);
+    r->n[1] = (r->n[1] & mask0) | (a->n[1] & mask1);
+    r->n[2] = (r->n[2] & mask0) | (a->n[2] & mask1);
+    r->n[3] = (r->n[3] & mask0) | (a->n[3] & mask1);
+    r->n[4] = (r->n[4] & mask0) | (a->n[4] & mask1);
+    r->n[5] = (r->n[5] & mask0) | (a->n[5] & mask1);
+    r->n[6] = (r->n[6] & mask0) | (a->n[6] & mask1);
+    r->n[7] = (r->n[7] & mask0) | (a->n[7] & mask1);
+    r->n[8] = (r->n[8] & mask0) | (a->n[8] & mask1);
+    r->n[9] = (r->n[9] & mask0) | (a->n[9] & mask1);
+#ifdef VERIFY
+    r->magnitude = (r->magnitude & mask0) | (a->magnitude & mask1);
+    r->normalized = (r->normalized & mask0) | (a->normalized & mask1);
 #endif
 }
 

--- a/src/field_5x52_impl.h
+++ b/src/field_5x52_impl.h
@@ -209,8 +209,9 @@ static int secp256k1_fe_normalizes_to_zero_var(secp256k1_fe_t *r) {
     z1 = z0 ^ 0x1000003D0ULL;
 
     /* Fast return path should catch the majority of cases */
-    if ((z0 != 0ULL) & (z1 != 0xFFFFFFFFFFFFFULL))
+    if ((z0 != 0ULL) & (z1 != 0xFFFFFFFFFFFFFULL)) {
         return 0;
+    }
 
     t1 = r->n[1];
     t2 = r->n[2];
@@ -277,8 +278,12 @@ static int secp256k1_fe_cmp_var(const secp256k1_fe_t *a, const secp256k1_fe_t *b
     secp256k1_fe_verify(b);
 #endif
     for (i = 4; i >= 0; i--) {
-        if (a->n[i] > b->n[i]) return 1;
-        if (a->n[i] < b->n[i]) return -1;
+        if (a->n[i] > b->n[i]) {
+            return 1;
+        }
+        if (a->n[i] < b->n[i]) {
+            return -1;
+        }
     }
     return 0;
 }
@@ -396,6 +401,21 @@ static void secp256k1_fe_sqr(secp256k1_fe_t *r, const secp256k1_fe_t *a) {
     r->magnitude = 1;
     r->normalized = 0;
     secp256k1_fe_verify(r);
+#endif
+}
+
+static SECP256K1_INLINE void secp256k1_fe_cmov(secp256k1_fe_t *r, const secp256k1_fe_t *a, int flag) {
+    uint64_t mask0, mask1;
+    mask0 = flag + ~((uint64_t)0);
+    mask1 = ~mask0;
+    r->n[0] = (r->n[0] & mask0) | (a->n[0] & mask1);
+    r->n[1] = (r->n[1] & mask0) | (a->n[1] & mask1);
+    r->n[2] = (r->n[2] & mask0) | (a->n[2] & mask1);
+    r->n[3] = (r->n[3] & mask0) | (a->n[3] & mask1);
+    r->n[4] = (r->n[4] & mask0) | (a->n[4] & mask1);
+#ifdef VERIFY
+    r->magnitude = (r->magnitude & mask0) | (a->magnitude & mask1);
+    r->normalized = (r->normalized & mask0) | (a->normalized & mask1);
 #endif
 }
 

--- a/src/field_impl.h
+++ b/src/field_impl.h
@@ -44,47 +44,69 @@ static int secp256k1_fe_sqrt_var(secp256k1_fe_t *r, const secp256k1_fe_t *a) {
     secp256k1_fe_mul(&x3, &x3, a);
 
     x6 = x3;
-    for (j=0; j<3; j++) secp256k1_fe_sqr(&x6, &x6);
+    for (j=0; j<3; j++) {
+        secp256k1_fe_sqr(&x6, &x6);
+    }
     secp256k1_fe_mul(&x6, &x6, &x3);
 
     x9 = x6;
-    for (j=0; j<3; j++) secp256k1_fe_sqr(&x9, &x9);
+    for (j=0; j<3; j++) {
+        secp256k1_fe_sqr(&x9, &x9);
+    }
     secp256k1_fe_mul(&x9, &x9, &x3);
 
     x11 = x9;
-    for (j=0; j<2; j++) secp256k1_fe_sqr(&x11, &x11);
+    for (j=0; j<2; j++) {
+        secp256k1_fe_sqr(&x11, &x11);
+    }
     secp256k1_fe_mul(&x11, &x11, &x2);
 
     x22 = x11;
-    for (j=0; j<11; j++) secp256k1_fe_sqr(&x22, &x22);
+    for (j=0; j<11; j++) {
+        secp256k1_fe_sqr(&x22, &x22);
+    }
     secp256k1_fe_mul(&x22, &x22, &x11);
 
     x44 = x22;
-    for (j=0; j<22; j++) secp256k1_fe_sqr(&x44, &x44);
+    for (j=0; j<22; j++) {
+        secp256k1_fe_sqr(&x44, &x44);
+    }
     secp256k1_fe_mul(&x44, &x44, &x22);
 
     x88 = x44;
-    for (j=0; j<44; j++) secp256k1_fe_sqr(&x88, &x88);
+    for (j=0; j<44; j++) {
+        secp256k1_fe_sqr(&x88, &x88);
+    }
     secp256k1_fe_mul(&x88, &x88, &x44);
 
     x176 = x88;
-    for (j=0; j<88; j++) secp256k1_fe_sqr(&x176, &x176);
+    for (j=0; j<88; j++) {
+        secp256k1_fe_sqr(&x176, &x176);
+    }
     secp256k1_fe_mul(&x176, &x176, &x88);
 
     x220 = x176;
-    for (j=0; j<44; j++) secp256k1_fe_sqr(&x220, &x220);
+    for (j=0; j<44; j++) {
+        secp256k1_fe_sqr(&x220, &x220);
+    }
     secp256k1_fe_mul(&x220, &x220, &x44);
 
     x223 = x220;
-    for (j=0; j<3; j++) secp256k1_fe_sqr(&x223, &x223);
+    for (j=0; j<3; j++) {
+        secp256k1_fe_sqr(&x223, &x223);
+    }
     secp256k1_fe_mul(&x223, &x223, &x3);
 
     /* The final result is then assembled using a sliding window over the blocks. */
 
     t1 = x223;
-    for (j=0; j<23; j++) secp256k1_fe_sqr(&t1, &t1);
+    for (j=0; j<23; j++) {
+        secp256k1_fe_sqr(&t1, &t1);
+    }
     secp256k1_fe_mul(&t1, &t1, &x22);
-    for (j=0; j<6; j++) secp256k1_fe_sqr(&t1, &t1);
+    for (j=0; j<6; j++) {
+        secp256k1_fe_sqr(&t1, &t1);
+    }
     secp256k1_fe_mul(&t1, &t1, &x2);
     secp256k1_fe_sqr(&t1, &t1);
     secp256k1_fe_sqr(r, &t1);
@@ -111,51 +133,77 @@ static void secp256k1_fe_inv(secp256k1_fe_t *r, const secp256k1_fe_t *a) {
     secp256k1_fe_mul(&x3, &x3, a);
 
     x6 = x3;
-    for (j=0; j<3; j++) secp256k1_fe_sqr(&x6, &x6);
+    for (j=0; j<3; j++) {
+        secp256k1_fe_sqr(&x6, &x6);
+    }
     secp256k1_fe_mul(&x6, &x6, &x3);
 
     x9 = x6;
-    for (j=0; j<3; j++) secp256k1_fe_sqr(&x9, &x9);
+    for (j=0; j<3; j++) {
+        secp256k1_fe_sqr(&x9, &x9);
+    }
     secp256k1_fe_mul(&x9, &x9, &x3);
 
     x11 = x9;
-    for (j=0; j<2; j++) secp256k1_fe_sqr(&x11, &x11);
+    for (j=0; j<2; j++) {
+        secp256k1_fe_sqr(&x11, &x11);
+    }
     secp256k1_fe_mul(&x11, &x11, &x2);
 
     x22 = x11;
-    for (j=0; j<11; j++) secp256k1_fe_sqr(&x22, &x22);
+    for (j=0; j<11; j++) {
+        secp256k1_fe_sqr(&x22, &x22);
+    }
     secp256k1_fe_mul(&x22, &x22, &x11);
 
     x44 = x22;
-    for (j=0; j<22; j++) secp256k1_fe_sqr(&x44, &x44);
+    for (j=0; j<22; j++) {
+        secp256k1_fe_sqr(&x44, &x44);
+    }
     secp256k1_fe_mul(&x44, &x44, &x22);
 
     x88 = x44;
-    for (j=0; j<44; j++) secp256k1_fe_sqr(&x88, &x88);
+    for (j=0; j<44; j++) {
+        secp256k1_fe_sqr(&x88, &x88);
+    }
     secp256k1_fe_mul(&x88, &x88, &x44);
 
     x176 = x88;
-    for (j=0; j<88; j++) secp256k1_fe_sqr(&x176, &x176);
+    for (j=0; j<88; j++) {
+        secp256k1_fe_sqr(&x176, &x176);
+    }
     secp256k1_fe_mul(&x176, &x176, &x88);
 
     x220 = x176;
-    for (j=0; j<44; j++) secp256k1_fe_sqr(&x220, &x220);
+    for (j=0; j<44; j++) {
+        secp256k1_fe_sqr(&x220, &x220);
+    }
     secp256k1_fe_mul(&x220, &x220, &x44);
 
     x223 = x220;
-    for (j=0; j<3; j++) secp256k1_fe_sqr(&x223, &x223);
+    for (j=0; j<3; j++) {
+        secp256k1_fe_sqr(&x223, &x223);
+    }
     secp256k1_fe_mul(&x223, &x223, &x3);
 
     /* The final result is then assembled using a sliding window over the blocks. */
 
     t1 = x223;
-    for (j=0; j<23; j++) secp256k1_fe_sqr(&t1, &t1);
+    for (j=0; j<23; j++) {
+        secp256k1_fe_sqr(&t1, &t1);
+    }
     secp256k1_fe_mul(&t1, &t1, &x22);
-    for (j=0; j<5; j++) secp256k1_fe_sqr(&t1, &t1);
+    for (j=0; j<5; j++) {
+        secp256k1_fe_sqr(&t1, &t1);
+    }
     secp256k1_fe_mul(&t1, &t1, a);
-    for (j=0; j<3; j++) secp256k1_fe_sqr(&t1, &t1);
+    for (j=0; j<3; j++) {
+        secp256k1_fe_sqr(&t1, &t1);
+    }
     secp256k1_fe_mul(&t1, &t1, &x2);
-    for (j=0; j<2; j++) secp256k1_fe_sqr(&t1, &t1);
+    for (j=0; j<2; j++) {
+        secp256k1_fe_sqr(&t1, &t1);
+    }
     secp256k1_fe_mul(r, a, &t1);
 }
 
@@ -188,8 +236,9 @@ static void secp256k1_fe_inv_var(secp256k1_fe_t *r, const secp256k1_fe_t *a) {
 static void secp256k1_fe_inv_all_var(size_t len, secp256k1_fe_t *r, const secp256k1_fe_t *a) {
     secp256k1_fe_t u;
     size_t i;
-    if (len < 1)
+    if (len < 1) {
         return;
+    }
 
     VERIFY_CHECK((r + len <= a) || (a + len <= r));
 

--- a/src/group.h
+++ b/src/group.h
@@ -115,4 +115,7 @@ static void secp256k1_ge_from_storage(secp256k1_ge_t *r, const secp256k1_ge_stor
 /** If flag is true, set *r equal to *a; otherwise leave it. Constant-time. */
 static void secp256k1_ge_storage_cmov(secp256k1_ge_storage_t *r, const secp256k1_ge_storage_t *a, int flag);
 
+/** Rescale a jacobian point by b which must be non-zero. Constant-time. */
+static void secp256k1_gej_rescale(secp256k1_gej_t *r, const secp256k1_fe_t *b);
+
 #endif

--- a/src/hash_impl.h
+++ b/src/hash_impl.h
@@ -176,13 +176,15 @@ static void secp256k1_hmac_sha256_initialize(secp256k1_hmac_sha256_t *hash, cons
     }
 
     secp256k1_sha256_initialize(&hash->outer);
-    for (n = 0; n < 64; n++)
+    for (n = 0; n < 64; n++) {
         rkey[n] ^= 0x5c;
+    }
     secp256k1_sha256_write(&hash->outer, rkey, 64);
 
     secp256k1_sha256_initialize(&hash->inner);
-    for (n = 0; n < 64; n++)
+    for (n = 0; n < 64; n++) {
         rkey[n] ^= 0x5c ^ 0x36;
+    }
     secp256k1_sha256_write(&hash->inner, rkey, 64);
     memset(rkey, 0, 64);
 }
@@ -205,15 +207,17 @@ static void secp256k1_rfc6979_hmac_sha256_initialize(secp256k1_rfc6979_hmac_sha2
     static const unsigned char zero[1] = {0x00};
     static const unsigned char one[1] = {0x01};
 
-    memset(rng->v, 0x01, 32);
-    memset(rng->k, 0x00, 32);
+    memset(rng->v, 0x01, 32); /* RFC6979 3.2.b. */
+    memset(rng->k, 0x00, 32); /* RFC6979 3.2.c. */
 
+    /* RFC6979 3.2.d. */
     secp256k1_hmac_sha256_initialize(&hmac, rng->k, 32);
     secp256k1_hmac_sha256_write(&hmac, rng->v, 32);
     secp256k1_hmac_sha256_write(&hmac, zero, 1);
     secp256k1_hmac_sha256_write(&hmac, key, keylen);
     secp256k1_hmac_sha256_write(&hmac, msg, msglen);
     if (rnd && rndlen) {
+        /* RFC6979 3.6 "Additional data". */
         secp256k1_hmac_sha256_write(&hmac, rnd, rndlen);
     }
     secp256k1_hmac_sha256_finalize(&hmac, rng->k);
@@ -221,12 +225,14 @@ static void secp256k1_rfc6979_hmac_sha256_initialize(secp256k1_rfc6979_hmac_sha2
     secp256k1_hmac_sha256_write(&hmac, rng->v, 32);
     secp256k1_hmac_sha256_finalize(&hmac, rng->v);
 
+    /* RFC6979 3.2.f. */
     secp256k1_hmac_sha256_initialize(&hmac, rng->k, 32);
     secp256k1_hmac_sha256_write(&hmac, rng->v, 32);
     secp256k1_hmac_sha256_write(&hmac, one, 1);
     secp256k1_hmac_sha256_write(&hmac, key, keylen);
     secp256k1_hmac_sha256_write(&hmac, msg, msglen);
     if (rnd && rndlen) {
+        /* RFC6979 3.6 "Additional data". */
         secp256k1_hmac_sha256_write(&hmac, rnd, rndlen);
     }
     secp256k1_hmac_sha256_finalize(&hmac, rng->k);
@@ -237,6 +243,7 @@ static void secp256k1_rfc6979_hmac_sha256_initialize(secp256k1_rfc6979_hmac_sha2
 }
 
 static void secp256k1_rfc6979_hmac_sha256_generate(secp256k1_rfc6979_hmac_sha256_t *rng, unsigned char *out, size_t outlen) {
+    /* RFC6979 3.2.h. */
     static const unsigned char zero[1] = {0x00};
     if (rng->retry) {
         secp256k1_hmac_sha256_t hmac;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -194,6 +194,7 @@ void Shutdown()
     delete pwalletMain;
     pwalletMain = NULL;
 #endif
+    ECC_Stop();
     LogPrintf("%s: done\n", __func__);
 }
 
@@ -787,6 +788,9 @@ bool AppInit2(boost::thread_group& threadGroup)
     nMaxDatacarrierBytes = GetArg("-datacarriersize", nMaxDatacarrierBytes);
 
     // ********************************************************* Step 4: application initialization: dir lock, daemonize, pidfile, debug log
+
+    // Initialize elliptic curve code
+    ECC_Start();
 
     // Sanity check
     if (!InitSanityCheck())

--- a/src/key.h
+++ b/src/key.h
@@ -173,7 +173,13 @@ struct CExtKey {
     void SetMaster(const unsigned char* seed, unsigned int nSeedLen);
 };
 
-/** Check that required EC support is available at runtime */
+/** Initialize the elliptic curve support. May not be called twice without calling ECC_Stop first. */
+void ECC_Start(void);
+
+/** Deinitialize the elliptic curve support. No-op if ECC_Start wasn't called first. */
+void ECC_Stop(void);
+
+/** Check that required EC support is available at runtime. */
 bool ECC_InitSanityCheck(void);
 
 #endif // BITCOIN_KEY_H

--- a/src/num_gmp_impl.h
+++ b/src/num_gmp_impl.h
@@ -54,7 +54,9 @@ static void secp256k1_num_set_bin(secp256k1_num_t *r, const unsigned char *a, un
     VERIFY_CHECK(len <= NUM_LIMBS*2);
     r->limbs = len;
     r->neg = 0;
-    while (r->limbs > 1 && r->data[r->limbs-1]==0) r->limbs--;
+    while (r->limbs > 1 && r->data[r->limbs-1]==0) {
+        r->limbs--;
+    }
 }
 
 static void secp256k1_num_add_abs(secp256k1_num_t *r, const secp256k1_num_t *a, const secp256k1_num_t *b) {
@@ -70,7 +72,9 @@ static void secp256k1_num_sub_abs(secp256k1_num_t *r, const secp256k1_num_t *a, 
     mp_limb_t c = mpn_sub(r->data, a->data, a->limbs, b->data, b->limbs);
     VERIFY_CHECK(c == 0);
     r->limbs = a->limbs;
-    while (r->limbs > 1 && r->data[r->limbs-1]==0) r->limbs--;
+    while (r->limbs > 1 && r->data[r->limbs-1]==0) {
+        r->limbs--;
+    }
 }
 
 static void secp256k1_num_mod(secp256k1_num_t *r, const secp256k1_num_t *m) {
@@ -82,7 +86,9 @@ static void secp256k1_num_mod(secp256k1_num_t *r, const secp256k1_num_t *m) {
         mpn_tdiv_qr(t, r->data, 0, r->data, r->limbs, m->data, m->limbs);
         memset(t, 0, sizeof(t));
         r->limbs = m->limbs;
-        while (r->limbs > 1 && r->data[r->limbs-1]==0) r->limbs--;
+        while (r->limbs > 1 && r->data[r->limbs-1]==0) {
+            r->limbs--;
+        }
     }
 
     if (r->neg && (r->limbs > 1 || r->data[0] != 0)) {
@@ -125,7 +131,9 @@ static void secp256k1_num_mod_inverse(secp256k1_num_t *r, const secp256k1_num_t 
     if (sn < 0) {
         mpn_sub(r->data, m->data, m->limbs, r->data, -sn);
         r->limbs = m->limbs;
-        while (r->limbs > 1 && r->data[r->limbs-1]==0) r->limbs--;
+        while (r->limbs > 1 && r->data[r->limbs-1]==0) {
+            r->limbs--;
+        }
     } else {
         r->limbs = sn;
     }
@@ -143,15 +151,25 @@ static int secp256k1_num_is_neg(const secp256k1_num_t *a) {
 }
 
 static int secp256k1_num_cmp(const secp256k1_num_t *a, const secp256k1_num_t *b) {
-    if (a->limbs > b->limbs) return 1;
-    if (a->limbs < b->limbs) return -1;
+    if (a->limbs > b->limbs) {
+        return 1;
+    }
+    if (a->limbs < b->limbs) {
+        return -1;
+    }
     return mpn_cmp(a->data, b->data, a->limbs);
 }
 
 static int secp256k1_num_eq(const secp256k1_num_t *a, const secp256k1_num_t *b) {
-    if (a->limbs > b->limbs) return 0;
-    if (a->limbs < b->limbs) return 0;
-    if ((a->neg && !secp256k1_num_is_zero(a)) != (b->neg && !secp256k1_num_is_zero(b))) return 0;
+    if (a->limbs > b->limbs) {
+        return 0;
+    }
+    if (a->limbs < b->limbs) {
+        return 0;
+    }
+    if ((a->neg && !secp256k1_num_is_zero(a)) != (b->neg && !secp256k1_num_is_zero(b))) {
+        return 0;
+    }
     return mpn_cmp(a->data, b->data, a->limbs) == 0;
 }
 
@@ -198,12 +216,15 @@ static void secp256k1_num_mul(secp256k1_num_t *r, const secp256k1_num_t *a, cons
         r->data[0] = 0;
         return;
     }
-    if (a->limbs >= b->limbs)
+    if (a->limbs >= b->limbs) {
         mpn_mul(tmp, a->data, a->limbs, b->data, b->limbs);
-    else
+    } else {
         mpn_mul(tmp, b->data, b->limbs, a->data, a->limbs);
+    }
     r->limbs = a->limbs + b->limbs;
-    if (r->limbs > 1 && tmp[r->limbs - 1]==0) r->limbs--;
+    if (r->limbs > 1 && tmp[r->limbs - 1]==0) {
+        r->limbs--;
+    }
     VERIFY_CHECK(r->limbs <= 2*NUM_LIMBS);
     mpn_copyi(r->data, tmp, r->limbs);
     r->neg = a->neg ^ b->neg;
@@ -227,7 +248,9 @@ static void secp256k1_num_shift(secp256k1_num_t *r, int bits) {
             }
         }
     }
-    while (r->limbs>1 && r->data[r->limbs-1]==0) r->limbs--;
+    while (r->limbs>1 && r->data[r->limbs-1]==0) {
+        r->limbs--;
+    }
 }
 
 static void secp256k1_num_negate(secp256k1_num_t *r) {

--- a/src/scalar_impl.h
+++ b/src/scalar_impl.h
@@ -69,130 +69,168 @@ static void secp256k1_scalar_inverse(secp256k1_scalar_t *r, const secp256k1_scal
     secp256k1_scalar_mul(&x8, &x8,  x);
 
     secp256k1_scalar_sqr(&x15, &x8);
-    for (i = 0; i < 6; i++)
+    for (i = 0; i < 6; i++) {
         secp256k1_scalar_sqr(&x15, &x15);
+    }
     secp256k1_scalar_mul(&x15, &x15, &x7);
 
     secp256k1_scalar_sqr(&x30, &x15);
-    for (i = 0; i < 14; i++)
+    for (i = 0; i < 14; i++) {
         secp256k1_scalar_sqr(&x30, &x30);
+    }
     secp256k1_scalar_mul(&x30, &x30, &x15);
 
     secp256k1_scalar_sqr(&x60, &x30);
-    for (i = 0; i < 29; i++)
+    for (i = 0; i < 29; i++) {
         secp256k1_scalar_sqr(&x60, &x60);
+    }
     secp256k1_scalar_mul(&x60, &x60, &x30);
 
     secp256k1_scalar_sqr(&x120, &x60);
-    for (i = 0; i < 59; i++)
+    for (i = 0; i < 59; i++) {
         secp256k1_scalar_sqr(&x120, &x120);
+    }
     secp256k1_scalar_mul(&x120, &x120, &x60);
 
     secp256k1_scalar_sqr(&x127, &x120);
-    for (i = 0; i < 6; i++)
+    for (i = 0; i < 6; i++) {
         secp256k1_scalar_sqr(&x127, &x127);
+    }
     secp256k1_scalar_mul(&x127, &x127, &x7);
 
     /* Then accumulate the final result (t starts at x127). */
     t = &x127;
-    for (i = 0; i < 2; i++) /* 0 */
+    for (i = 0; i < 2; i++) { /* 0 */
         secp256k1_scalar_sqr(t, t);
+    }
     secp256k1_scalar_mul(t, t, x); /* 1 */
-    for (i = 0; i < 4; i++) /* 0 */
+    for (i = 0; i < 4; i++) { /* 0 */
         secp256k1_scalar_sqr(t, t);
+    }
     secp256k1_scalar_mul(t, t, &x3); /* 111 */
-    for (i = 0; i < 2; i++) /* 0 */
+    for (i = 0; i < 2; i++) { /* 0 */
         secp256k1_scalar_sqr(t, t);
+    }
     secp256k1_scalar_mul(t, t, x); /* 1 */
-    for (i = 0; i < 2; i++) /* 0 */
+    for (i = 0; i < 2; i++) { /* 0 */
         secp256k1_scalar_sqr(t, t);
+    }
     secp256k1_scalar_mul(t, t, x); /* 1 */
-    for (i = 0; i < 2; i++) /* 0 */
+    for (i = 0; i < 2; i++) { /* 0 */
         secp256k1_scalar_sqr(t, t);
+    }
     secp256k1_scalar_mul(t, t, x); /* 1 */
-    for (i = 0; i < 4; i++) /* 0 */
+    for (i = 0; i < 4; i++) { /* 0 */
         secp256k1_scalar_sqr(t, t);
+    }
     secp256k1_scalar_mul(t, t, &x3); /* 111 */
-    for (i = 0; i < 3; i++) /* 0 */
+    for (i = 0; i < 3; i++) { /* 0 */
         secp256k1_scalar_sqr(t, t);
+    }
     secp256k1_scalar_mul(t, t, &x2); /* 11 */
-    for (i = 0; i < 4; i++) /* 0 */
+    for (i = 0; i < 4; i++) { /* 0 */
         secp256k1_scalar_sqr(t, t);
+    }
     secp256k1_scalar_mul(t, t, &x3); /* 111 */
-    for (i = 0; i < 5; i++) /* 00 */
+    for (i = 0; i < 5; i++) { /* 00 */
         secp256k1_scalar_sqr(t, t);
+    }
     secp256k1_scalar_mul(t, t, &x3); /* 111 */
-    for (i = 0; i < 4; i++) /* 00 */
+    for (i = 0; i < 4; i++) { /* 00 */
         secp256k1_scalar_sqr(t, t);
+    }
     secp256k1_scalar_mul(t, t, &x2); /* 11 */
-    for (i = 0; i < 2; i++) /* 0 */
+    for (i = 0; i < 2; i++) { /* 0 */
         secp256k1_scalar_sqr(t, t);
+    }
     secp256k1_scalar_mul(t, t, x); /* 1 */
-    for (i = 0; i < 2; i++) /* 0 */
+    for (i = 0; i < 2; i++) { /* 0 */
         secp256k1_scalar_sqr(t, t);
+    }
     secp256k1_scalar_mul(t, t, x); /* 1 */
-    for (i = 0; i < 5; i++) /* 0 */
+    for (i = 0; i < 5; i++) { /* 0 */
         secp256k1_scalar_sqr(t, t);
+    }
     secp256k1_scalar_mul(t, t, &x4); /* 1111 */
-    for (i = 0; i < 2; i++) /* 0 */
+    for (i = 0; i < 2; i++) { /* 0 */
         secp256k1_scalar_sqr(t, t);
+    }
     secp256k1_scalar_mul(t, t, x); /* 1 */
-    for (i = 0; i < 3; i++) /* 00 */
+    for (i = 0; i < 3; i++) { /* 00 */
         secp256k1_scalar_sqr(t, t);
+    }
     secp256k1_scalar_mul(t, t, x); /* 1 */
-    for (i = 0; i < 4; i++) /* 000 */
+    for (i = 0; i < 4; i++) { /* 000 */
         secp256k1_scalar_sqr(t, t);
+    }
     secp256k1_scalar_mul(t, t, x); /* 1 */
-    for (i = 0; i < 2; i++) /* 0 */
+    for (i = 0; i < 2; i++) { /* 0 */
         secp256k1_scalar_sqr(t, t);
+    }
     secp256k1_scalar_mul(t, t, x); /* 1 */
-    for (i = 0; i < 10; i++) /* 0000000 */
+    for (i = 0; i < 10; i++) { /* 0000000 */
         secp256k1_scalar_sqr(t, t);
+    }
     secp256k1_scalar_mul(t, t, &x3); /* 111 */
-    for (i = 0; i < 4; i++) /* 0 */
+    for (i = 0; i < 4; i++) { /* 0 */
         secp256k1_scalar_sqr(t, t);
+    }
     secp256k1_scalar_mul(t, t, &x3); /* 111 */
-    for (i = 0; i < 9; i++) /* 0 */
+    for (i = 0; i < 9; i++) { /* 0 */
         secp256k1_scalar_sqr(t, t);
+    }
     secp256k1_scalar_mul(t, t, &x8); /* 11111111 */
-    for (i = 0; i < 2; i++) /* 0 */
+    for (i = 0; i < 2; i++) { /* 0 */
         secp256k1_scalar_sqr(t, t);
+    }
     secp256k1_scalar_mul(t, t, x); /* 1 */
-    for (i = 0; i < 3; i++) /* 00 */
+    for (i = 0; i < 3; i++) { /* 00 */
         secp256k1_scalar_sqr(t, t);
+    }
     secp256k1_scalar_mul(t, t, x); /* 1 */
-    for (i = 0; i < 3; i++) /* 00 */
+    for (i = 0; i < 3; i++) { /* 00 */
         secp256k1_scalar_sqr(t, t);
+    }
     secp256k1_scalar_mul(t, t, x); /* 1 */
-    for (i = 0; i < 5; i++) /* 0 */
+    for (i = 0; i < 5; i++) { /* 0 */
         secp256k1_scalar_sqr(t, t);
+    }
     secp256k1_scalar_mul(t, t, &x4); /* 1111 */
-    for (i = 0; i < 2; i++) /* 0 */
+    for (i = 0; i < 2; i++) { /* 0 */
         secp256k1_scalar_sqr(t, t);
+    }
     secp256k1_scalar_mul(t, t, x); /* 1 */
-    for (i = 0; i < 5; i++) /* 000 */
+    for (i = 0; i < 5; i++) { /* 000 */
         secp256k1_scalar_sqr(t, t);
+    }
     secp256k1_scalar_mul(t, t, &x2); /* 11 */
-    for (i = 0; i < 4; i++) /* 00 */
+    for (i = 0; i < 4; i++) { /* 00 */
         secp256k1_scalar_sqr(t, t);
+    }
     secp256k1_scalar_mul(t, t, &x2); /* 11 */
-    for (i = 0; i < 2; i++) /* 0 */
+    for (i = 0; i < 2; i++) { /* 0 */
         secp256k1_scalar_sqr(t, t);
+    }
     secp256k1_scalar_mul(t, t, x); /* 1 */
-    for (i = 0; i < 8; i++) /* 000000 */
+    for (i = 0; i < 8; i++) { /* 000000 */
         secp256k1_scalar_sqr(t, t);
+    }
     secp256k1_scalar_mul(t, t, &x2); /* 11 */
-    for (i = 0; i < 3; i++) /* 0 */
+    for (i = 0; i < 3; i++) { /* 0 */
         secp256k1_scalar_sqr(t, t);
+    }
     secp256k1_scalar_mul(t, t, &x2); /* 11 */
-    for (i = 0; i < 3; i++) /* 00 */
+    for (i = 0; i < 3; i++) { /* 00 */
         secp256k1_scalar_sqr(t, t);
+    }
     secp256k1_scalar_mul(t, t, x); /* 1 */
-    for (i = 0; i < 6; i++) /* 00000 */
+    for (i = 0; i < 6; i++) { /* 00000 */
         secp256k1_scalar_sqr(t, t);
+    }
     secp256k1_scalar_mul(t, t, x); /* 1 */
-    for (i = 0; i < 8; i++) /* 00 */
+    for (i = 0; i < 8; i++) { /* 00 */
         secp256k1_scalar_sqr(t, t);
+    }
     secp256k1_scalar_mul(r, t, &x6); /* 111111 */
 }
 

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -6,6 +6,7 @@
 
 #include "test_bitcoin.h"
 
+#include "key.h"
 #include "main.h"
 #include "random.h"
 #include "txdb.h"
@@ -28,6 +29,7 @@ extern void noui_connect();
 
 BasicTestingSetup::BasicTestingSetup()
 {
+        ECC_Start();
         SetupEnvironment();
         fPrintToDebugLog = false; // don't want to write to debug.log file
         fCheckBlockIndex = true;
@@ -35,6 +37,7 @@ BasicTestingSetup::BasicTestingSetup()
 }
 BasicTestingSetup::~BasicTestingSetup()
 {
+        ECC_Stop();
 }
 
 TestingSetup::TestingSetup()


### PR DESCRIPTION
Libsecp256k1 now has explicit context objects, which makes it completely thread-safe. In turn, keep an explicit context object in key.cpp, which is explicitly initialized destroyed. This is not really pretty now, but it's more efficient than the static initialized object in key.cpp (which made for example bitcoin-tx slow, as for most of its calls, libsecp256k1 wasn't actually needed).

This also brings in the new blinding support in libsecp256k1. By passing in a random seed, temporary variables during the elliptic curve computations are altered, in such a way that if an attacker does not know the blind, observing the internal operations leaks even less information about the keys used. This was implemented by Greg Maxwell.
