### PR TITLE
fix and enable bip32 unit test

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -39,6 +39,7 @@ BITCOIN_TESTS =\
   test/base32_tests.cpp \
   test/base58_tests.cpp \
   test/base64_tests.cpp \
+  test/bip32_tests.cpp \
   test/bloom_tests.cpp \
   test/checkblock_tests.cpp \
   test/Checkpoints_tests.cpp \

--- a/src/test/bip32_tests.cpp
+++ b/src/test/bip32_tests.cpp
@@ -8,6 +8,7 @@
 #include "key.h"
 #include "uint256.h"
 #include "util.h"
+#include "utilstrencodings.h"
 #include "test/test_bitcoin.h"
 
 #include <string>


### PR DESCRIPTION
the bip32 unit test was not included in the make process
