### PR TITLE
Consensus: Refactor: Separate CheckFinalTx from main::IsFinalTx

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -656,16 +656,22 @@ bool IsStandardTx(const CTransaction& tx, string& reason)
     return true;
 }
 
+bool CheckFinalTx(const CTransaction &tx, int nBlockHeight, int64_t nBlockTime);
 bool IsFinalTx(const CTransaction &tx, int nBlockHeight, int64_t nBlockTime)
 {
     AssertLockHeld(cs_main);
-    // Time based nLockTime implemented in 0.1.6
-    if (tx.nLockTime == 0)
-        return true;
     if (nBlockHeight == 0)
         nBlockHeight = chainActive.Height();
     if (nBlockTime == 0)
         nBlockTime = GetAdjustedTime();
+    return CheckFinalTx(tx, nBlockHeight, nBlockTime);
+}
+
+bool CheckFinalTx(const CTransaction &tx, int nBlockHeight, int64_t nBlockTime)
+{
+    // Time based nLockTime implemented in 0.1.6
+    if (tx.nLockTime == 0)
+        return true;
     if ((int64_t)tx.nLockTime < ((int64_t)tx.nLockTime < LOCKTIME_THRESHOLD ? (int64_t)nBlockHeight : nBlockTime))
         return true;
     BOOST_FOREACH(const CTxIn& txin, tx.vin)


### PR DESCRIPTION
A simple refactor as preparation for moving consensus to code for transaction validation.
The consensus version of IsFinalTx() cannot use chainActive.Height() or GetAdjustedTime()

This is part of #6051 but can be merged independently.
