### PR TITLE
Policy: Create CPolicy interface and CStandardPolicy class implementing it

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -120,6 +120,7 @@ BITCOIN_CORE_H = \
   netbase.h \
   noui.h \
   policy/fees.h \
+  policy/interface.h \
   policy/policy.h \
   pow.h \
   primitives/block.h \

--- a/src/main.h
+++ b/src/main.h
@@ -32,6 +32,7 @@ class CBlockIndex;
 class CBlockTreeDB;
 class CBloomFilter;
 class CInv;
+class CStandardPolicy;
 class CScriptCheck;
 class CTxMemPool;
 class CValidationInterface;
@@ -106,6 +107,7 @@ extern bool fCheckpointsEnabled;
 extern size_t nCoinCacheUsage;
 extern CFeeRate minRelayTxFee;
 extern bool fAlerts;
+extern CStandardPolicy globalPolicy;
 
 /** Best header we've seen so far (used for getheaders queries' starting points). */
 extern CBlockIndex *pindexBestHeader;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -285,7 +285,7 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn)
             if (nBlockSigOps + nTxSigOps >= MAX_BLOCK_SIGOPS)
                 continue;
 
-            // Note that flags: we don't want to set mempool/IsStandard()
+            // Note that flags: we don't want to set mempool/CPolicy::ApproveScript()
             // policy here, but we still have to ensure that the block we
             // create only contains transactions that are valid in new blocks.
             CValidationState state;

--- a/src/policy/interface.h
+++ b/src/policy/interface.h
@@ -1,0 +1,38 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2014 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_POLICY_INTERFACE_H
+#define BITCOIN_POLICY_INTERFACE_H
+
+#include <string>
+
+class CCoinsViewCache;
+class CScript;
+class CTransaction;
+
+/**
+ * \class CPolicy
+ * Interface class for non-consensus-critical policy logic, like whether or not
+ * a transaction should be relayed and/or included in blocks created.
+ */
+class CPolicy
+{
+public:
+    virtual ~CPolicy() {};
+    virtual bool ApproveScript(const CScript& scriptPubKey) const = 0;
+    /**
+     * Check for standard transaction types
+     * @return True if all outputs (scriptPubKeys) use only standard transaction forms
+     */
+    virtual bool ApproveTx(const CTransaction& tx, std::string& reason) const = 0;
+    /**
+     * Check for standard transaction types
+     * @param[in] mapInputs    Map of previous transactions that have outputs we're spending
+     * @return True if all inputs (scriptSigs) use only standard transaction forms
+     */
+    virtual bool ApproveTxInputs(const CTransaction& tx, const CCoinsViewCache& mapInputs) const = 0;
+};
+
+#endif // BITCOIN_POLICY_INTERFACE_H

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -7,6 +7,7 @@
 #define BITCOIN_POLICY_H
 
 #include "consensus/consensus.h"
+#include "policy/interface.h"
 #include "script/interpreter.h"
 #include "script/standard.h"
 
@@ -21,7 +22,7 @@ static const unsigned int DEFAULT_BLOCK_MIN_SIZE = 0;
 static const unsigned int DEFAULT_BLOCK_PRIORITY_SIZE = 50000;
 /** The maximum size for transactions we're willing to relay/mine */
 static const unsigned int MAX_STANDARD_TX_SIZE = 100000;
-/** Maximum number of signature check operations in an IsStandard() P2SH script */
+/** Maximum number of signature check operations in an CPolicy::ApproveScript() P2SH script */
 static const unsigned int MAX_P2SH_SIGOPS = 15;
 /** The maximum number of sigops we're willing to relay/mine in a single tx */
 static const unsigned int MAX_STANDARD_TX_SIGOPS = MAX_BLOCK_SIGOPS/5;
@@ -42,17 +43,37 @@ static const unsigned int STANDARD_SCRIPT_VERIFY_FLAGS = MANDATORY_SCRIPT_VERIFY
 /** For convenience, standard but not mandatory verify flags. */
 static const unsigned int STANDARD_NOT_MANDATORY_VERIFY_FLAGS = STANDARD_SCRIPT_VERIFY_FLAGS & ~MANDATORY_SCRIPT_VERIFY_FLAGS;
 
-bool IsStandard(const CScript& scriptPubKey, txnouttype& whichType);
+/**
+ * \class CStandardPolicy
+ * Standard implementation of CPolicy.
+ */
+class CStandardPolicy : public CPolicy
+{
+protected:
+    bool ApproveScript(const CScript&, txnouttype&) const;
+public:
+    virtual bool ApproveScript(const CScript& scriptPubKey) const;
+    virtual bool ApproveTx(const CTransaction& tx, std::string& reason) const;
     /**
-     * Check for standard transaction types
-     * @return True if all outputs (scriptPubKeys) use only standard transaction forms
+     * Check transaction inputs to mitigate two
+     * potential denial-of-service attacks:
+     * 
+     * 1. scriptSigs with extra data stuffed into them,
+     *    not consumed by scriptPubKey (or P2SH script)
+     * 2. P2SH scripts with a crazy number of expensive
+     *    CHECKSIG/CHECKMULTISIG operations
+     *
+     * Check transaction inputs, and make sure any
+     * pay-to-script-hash transactions are evaluating CPolicy::ApproveScript scripts
+     * 
+     * Why bother? To avoid denial-of-service attacks; an attacker
+     * can submit a standard HASH... OP_EQUAL transaction,
+     * which will get accepted into blocks. The redemption
+     * script can be anything; an attacker could use a very
+     * expensive-to-check-upon-redemption script like:
+     *   DUP CHECKSIG DROP ... repeated 100 times... OP_1
      */
-bool IsStandardTx(const CTransaction& tx, std::string& reason);
-    /**
-     * Check for standard transaction types
-     * @param[in] mapInputs    Map of previous transactions that have outputs we're spending
-     * @return True if all inputs (scriptSigs) use only standard transaction forms
-     */
-bool AreInputsStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs);
+    virtual bool ApproveTxInputs(const CTransaction& tx, const CCoinsViewCache& mapInputs) const;
+};
 
 #endif // BITCOIN_POLICY_H

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -587,7 +587,7 @@ public:
 
     bool IsPayToScriptHash() const;
 
-    /** Called by IsStandardTx and P2SH/BIP62 VerifyScript (which makes it consensus-critical). */
+    /** Called by CPolicy::ApproveTx() and P2SH/BIP62 VerifyScript (which makes it consensus-critical). */
     bool IsPushOnly(const_iterator pc) const;
     bool IsPushOnly() const;
 

--- a/src/test/multisig_tests.cpp
+++ b/src/test/multisig_tests.cpp
@@ -141,29 +141,28 @@ BOOST_AUTO_TEST_CASE(multisig_verify)
         }
 }
 
-BOOST_AUTO_TEST_CASE(multisig_IsStandard)
+BOOST_AUTO_TEST_CASE(multisig__policy_ApproveScript)
 {
+    const CStandardPolicy testPolicy;
     CKey key[4];
     for (int i = 0; i < 4; i++)
         key[i].MakeNewKey(true);
 
-    txnouttype whichType;
-
     CScript a_and_b;
     a_and_b << OP_2 << ToByteVector(key[0].GetPubKey()) << ToByteVector(key[1].GetPubKey()) << OP_2 << OP_CHECKMULTISIG;
-    BOOST_CHECK(::IsStandard(a_and_b, whichType));
+    BOOST_CHECK(testPolicy.ApproveScript(a_and_b));
 
     CScript a_or_b;
     a_or_b  << OP_1 << ToByteVector(key[0].GetPubKey()) << ToByteVector(key[1].GetPubKey()) << OP_2 << OP_CHECKMULTISIG;
-    BOOST_CHECK(::IsStandard(a_or_b, whichType));
+    BOOST_CHECK(testPolicy.ApproveScript(a_or_b));
 
     CScript escrow;
     escrow << OP_2 << ToByteVector(key[0].GetPubKey()) << ToByteVector(key[1].GetPubKey()) << ToByteVector(key[2].GetPubKey()) << OP_3 << OP_CHECKMULTISIG;
-    BOOST_CHECK(::IsStandard(escrow, whichType));
+    BOOST_CHECK(testPolicy.ApproveScript(escrow));
 
     CScript one_of_four;
     one_of_four << OP_1 << ToByteVector(key[0].GetPubKey()) << ToByteVector(key[1].GetPubKey()) << ToByteVector(key[2].GetPubKey()) << ToByteVector(key[3].GetPubKey()) << OP_4 << OP_CHECKMULTISIG;
-    BOOST_CHECK(!::IsStandard(one_of_four, whichType));
+    BOOST_CHECK(!testPolicy.ApproveScript(one_of_four));
 
     CScript malformed[6];
     malformed[0] << OP_3 << ToByteVector(key[0].GetPubKey()) << ToByteVector(key[1].GetPubKey()) << OP_2 << OP_CHECKMULTISIG;
@@ -174,7 +173,7 @@ BOOST_AUTO_TEST_CASE(multisig_IsStandard)
     malformed[5] << OP_1 << ToByteVector(key[0].GetPubKey()) << ToByteVector(key[1].GetPubKey());
 
     for (int i = 0; i < 6; i++)
-        BOOST_CHECK(!::IsStandard(malformed[i], whichType));
+        BOOST_CHECK(!testPolicy.ApproveScript(malformed[i]));
 }
 
 BOOST_AUTO_TEST_CASE(multisig_Solver1)

--- a/src/test/script_P2SH_tests.cpp
+++ b/src/test/script_P2SH_tests.cpp
@@ -53,6 +53,7 @@ BOOST_FIXTURE_TEST_SUITE(script_P2SH_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(sign)
 {
+    const CStandardPolicy testPolicy;
     LOCK(cs_main);
     // Pay-to-script-hash looks like this:
     // scriptSig:    <sig> <sig...> <serialized_script>
@@ -91,7 +92,7 @@ BOOST_AUTO_TEST_CASE(sign)
         txFrom.vout[i+4].scriptPubKey = standardScripts[i];
         txFrom.vout[i+4].nValue = COIN;
     }
-    BOOST_CHECK(IsStandardTx(txFrom, reason));
+    BOOST_CHECK(testPolicy.ApproveTx(txFrom, reason));
 
     CMutableTransaction txTo[8]; // Spending transactions
     for (int i = 0; i < 8; i++)
@@ -154,6 +155,7 @@ BOOST_AUTO_TEST_CASE(norecurse)
 
 BOOST_AUTO_TEST_CASE(set)
 {
+    const CStandardPolicy testPolicy;
     LOCK(cs_main);
     // Test the CScript::Set* methods
     CBasicKeyStore keystore;
@@ -187,7 +189,7 @@ BOOST_AUTO_TEST_CASE(set)
         txFrom.vout[i].scriptPubKey = outer[i];
         txFrom.vout[i].nValue = CENT;
     }
-    BOOST_CHECK(IsStandardTx(txFrom, reason));
+    BOOST_CHECK(testPolicy.ApproveTx(txFrom, reason));
 
     CMutableTransaction txTo[4]; // Spending transactions
     for (int i = 0; i < 4; i++)
@@ -205,7 +207,7 @@ BOOST_AUTO_TEST_CASE(set)
     for (int i = 0; i < 4; i++)
     {
         BOOST_CHECK_MESSAGE(SignSignature(keystore, txFrom, txTo[i], 0), strprintf("SignSignature %d", i));
-        BOOST_CHECK_MESSAGE(IsStandardTx(txTo[i], reason), strprintf("txTo[%d].IsStandard", i));
+        BOOST_CHECK_MESSAGE(testPolicy.ApproveTx(txTo[i], reason), strprintf("CPolicy::ApproveScript(txTo[%d])", i));
     }
 }
 
@@ -260,8 +262,9 @@ BOOST_AUTO_TEST_CASE(switchover)
     BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_EQUALVERIFY, ScriptErrorString(err));
 }
 
-BOOST_AUTO_TEST_CASE(AreInputsStandard)
+BOOST_AUTO_TEST_CASE(policy_ApproveTxInputs)
 {
+    const CStandardPolicy testPolicy;
     LOCK(cs_main);
     CCoinsView coinsDummy;
     CCoinsViewCache coins(&coinsDummy);
@@ -342,7 +345,7 @@ BOOST_AUTO_TEST_CASE(AreInputsStandard)
     txTo.vin[3].scriptSig << OP_11 << OP_11 << static_cast<vector<unsigned char> >(oneAndTwo);
     txTo.vin[4].scriptSig << static_cast<vector<unsigned char> >(fifteenSigops);
 
-    BOOST_CHECK(::AreInputsStandard(txTo, coins));
+    BOOST_CHECK(testPolicy.ApproveTxInputs(txTo, coins));
     // 22 P2SH sigops for all inputs (1 for vin[0], 6 for vin[3], 15 for vin[4]
     BOOST_CHECK_EQUAL(GetP2SHSigOpCount(txTo, coins), 22U);
 
@@ -351,7 +354,7 @@ BOOST_AUTO_TEST_CASE(AreInputsStandard)
     {
         CScript t = txTo.vin[i].scriptSig;
         txTo.vin[i].scriptSig = (CScript() << 11) + t;
-        BOOST_CHECK(!::AreInputsStandard(txTo, coins));
+        BOOST_CHECK(!testPolicy.ApproveTxInputs(txTo, coins));
         txTo.vin[i].scriptSig = t;
     }
 
@@ -364,7 +367,7 @@ BOOST_AUTO_TEST_CASE(AreInputsStandard)
     txToNonStd1.vin[0].prevout.hash = txFrom.GetHash();
     txToNonStd1.vin[0].scriptSig << static_cast<vector<unsigned char> >(sixteenSigops);
 
-    BOOST_CHECK(!::AreInputsStandard(txToNonStd1, coins));
+    BOOST_CHECK(!testPolicy.ApproveTxInputs(txToNonStd1, coins));
     BOOST_CHECK_EQUAL(GetP2SHSigOpCount(txToNonStd1, coins), 16U);
 
     CMutableTransaction txToNonStd2;
@@ -376,7 +379,7 @@ BOOST_AUTO_TEST_CASE(AreInputsStandard)
     txToNonStd2.vin[0].prevout.hash = txFrom.GetHash();
     txToNonStd2.vin[0].scriptSig << static_cast<vector<unsigned char> >(twentySigops);
 
-    BOOST_CHECK(!::AreInputsStandard(txToNonStd2, coins));
+    BOOST_CHECK(!testPolicy.ApproveTxInputs(txToNonStd2, coins));
     BOOST_CHECK_EQUAL(GetP2SHSigOpCount(txToNonStd2, coins), 20U);
 }
 


### PR DESCRIPTION
Minimal changes to create a CPolicy interface and a CStandardPolicy implementation.
No policy globals are encapsulated as CStandardPolicy attributes yet.
CPolicy is not made a parameter of main::AcceptToMemoryPool() yet.
No factory (to select another implementation other than CStandardPolicy) nor -policy=<string> runtime argument are created yet.

Outdated:

This is a reopen of #5595. Even though I knew I had to reopen it before force-pushing to it, I forgot about it. I think I solved this problem once by pushing the old branch back, reopening and then pushing the new branch, but the first step doesn't seem to be working. I'm happy to close this and reopen #5595 if somebody gives me a solution.

Text from the other PR:

First steps for encapsulating the policy code.
An interface (abstract class) CPolicy and a concrete implementation CStandardPolicy are created.
"Users" (people capable of modify and build Bitcoin core) can implement alternative policies and select them with the option -policy=<policy_name>. They can define new policy options and make their help messages be accesible to the users without having to touch init.cpp, only modifying policy.cpp is enough for all this. The help messages can also be accessed (per available policy) as a vector of string pairs to make it easier to implement a GUI to configure those options (although I don't plan to do that myself).
As more parts of the policy code move to policy.cpp, this encapsulation gets more useful.

To start using it. The function script/standard.o::IsStandard() is turned into a method: ApproveScript().
Many more policy-related improvements can be cleanly proposed after this first steps are merged.
