### PR TITLE
P2P testing cleanups

### DIFF
--- a/qa/pull-tester/rpc-tests.sh
+++ b/qa/pull-tester/rpc-tests.sh
@@ -31,7 +31,7 @@ testScripts=(
     'merkle_blocks.py'
 #    'forknotify.py'
     'maxblocksinflight.py'
-    'invalidblockrequest.py'
+#    'invalidblockrequest.py'
 );
 if [ "x${ENABLE_BITCOIND}${ENABLE_UTILS}${ENABLE_WALLET}" = "x111" ]; then
     for (( i = 0; i < ${#testScripts[@]}; i++ ))


### PR DESCRIPTION
@jonasschnelli The first commit should fix the asyncore issue you encountered.  I investigated what happens inside asyncore when it uses select instead of poll, and the bug is a subtle race condition: it appears to me that it's not safe to call `close()` while `asyncore.loop()` is running when using `select()`.   Merely increasing the timeout would only reduce the likelihood of the bug triggering, not eliminate it, so instead I reworked the disconnect logic to happen outside of `asyncore.loop()` to eliminate that bug altogether.

The second commit takes `invalidblockrequest.py` out of travis until I am able to offer up a proper fix to a different race condition that could cause that test to spuriously fail -- that should be soon, but I worry that this could break travis for people in the meantime.  Thanks again @jonasschnelli for reporting this in  #5981.
