### PR TITLE
fix WIN32 boost::filesystem::path issues when using special chars for datadir path

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -738,7 +738,9 @@ void SetupEnvironment()
 #endif
     // The path locale is lazy initialized and to avoid deinitialization errors 
     // in multithreading environments, it is set explicitly by the main thread.
+#if !defined(WIN32)
     boost::filesystem::path::imbue(loc);
+#endif
 }
 
 void SetThreadPriority(int nPriority)

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -726,21 +726,21 @@ void RenameThread(const char* name)
 
 void SetupEnvironment()
 {
-    std::locale loc("C");
     // On most POSIX systems (e.g. Linux, but not BSD) the environment's locale
     // may be invalid, in which case the "C" locale is used as fallback.
 #if !defined(WIN32) && !defined(MAC_OSX) && !defined(__FreeBSD__) && !defined(__OpenBSD__)
     try {
-        loc = std::locale(""); // Raises a runtime error if current locale is invalid
+        std::locale(""); // Raises a runtime error if current locale is invalid
     } catch (const std::runtime_error&) {
         setenv("LC_ALL", "C", 1);
     }
 #endif
-    // The path locale is lazy initialized and to avoid deinitialization errors 
+    // The path locale is lazy initialized and to avoid deinitialization errors
     // in multithreading environments, it is set explicitly by the main thread.
-#if !defined(WIN32)
+    // A dummy locale is used to extract the internal default locale, used by
+    // boost::filesystem::path, which is then used to explicitly imbue the path.
+    std::locale loc = boost::filesystem::path::imbue(std::locale::classic());
     boost::filesystem::path::imbue(loc);
-#endif
 }
 
 void SetThreadPriority(int nPriority)


### PR DESCRIPTION
fixes https://github.com/bitcoin/bitcoin/issues/6078
Meant for 0.11 branch.
