### PR TITLE
Python P2P testing bugfixes: rework locking to eliminate race conditions and fix comptool.py

### DIFF
--- a/qa/pull-tester/rpc-tests.sh
+++ b/qa/pull-tester/rpc-tests.sh
@@ -31,7 +31,7 @@ testScripts=(
     'merkle_blocks.py'
 #    'forknotify.py'
     'maxblocksinflight.py'
-    'invalidblockrequest.py'
+#    'invalidblockrequest.py'
 );
 if [ "x${ENABLE_BITCOIND}${ENABLE_UTILS}${ENABLE_WALLET}" = "x111" ]; then
     for (( i = 0; i < ${#testScripts[@]}; i++ ))

--- a/qa/pull-tester/rpc-tests.sh
+++ b/qa/pull-tester/rpc-tests.sh
@@ -31,7 +31,7 @@ testScripts=(
     'merkle_blocks.py'
 #    'forknotify.py'
     'maxblocksinflight.py'
-#    'invalidblockrequest.py'
+    'invalidblockrequest.py'
 );
 if [ "x${ENABLE_BITCOIND}${ENABLE_UTILS}${ENABLE_WALLET}" = "x111" ]; then
     for (( i = 0; i < ${#testScripts[@]}; i++ ))

--- a/qa/rpc-tests/comptool.py
+++ b/qa/rpc-tests/comptool.py
@@ -313,7 +313,7 @@ class TestManager(object):
                         invqueue.append(CInv(1, tx.sha256))
                 # Ensure we're not overflowing the inv queue
                 if len(invqueue) == MAX_INV_SZ:
-                    [ c.sb.send_message(msg_inv(invqueue)) for c in self.connections ]
+                    [ c.send_message(msg_inv(invqueue)) for c in self.connections ]
                     invqueue = []
 
             # Do final sync if we weren't syncing on every block or every tx.

--- a/qa/rpc-tests/comptool.py
+++ b/qa/rpc-tests/comptool.py
@@ -25,6 +25,8 @@ generator that returns TestInstance objects.  See below for definition.
 # on_getheaders: provide headers via BlockStore
 # on_getdata: provide blocks via BlockStore
 
+global mininode_lock
+
 class TestNode(NodeConnCB):
 
     def __init__(self, block_store, tx_store):
@@ -148,10 +150,11 @@ class TestManager(object):
         max_tries = 10 / sleep_time  # Wait at most 10 seconds
         while max_tries > 0:
             done = True
-            for c in self.connections:
-                if c.cb.verack_received is False:
-                    done = False
-                    break
+            with mininode_lock:
+                for c in self.connections:
+                    if c.cb.verack_received is False:
+                        done = False
+                        break
             if done:
                 break
             time.sleep(sleep_time)
@@ -161,10 +164,11 @@ class TestManager(object):
         while received_pongs is not True:
             time.sleep(0.05)
             received_pongs = True
-            for c in self.connections:
-                if c.cb.received_ping_response(counter) is not True:
-                    received_pongs = False
-                    break
+            with mininode_lock:
+                for c in self.connections:
+                    if c.cb.received_ping_response(counter) is not True:
+                        received_pongs = False
+                        break
 
     # sync_blocks: Wait for all connections to request the blockhash given
     # then send get_headers to find out the tip of each node, and synchronize
@@ -173,8 +177,9 @@ class TestManager(object):
         # Wait for nodes to request block (50ms sleep * 20 tries * num_blocks)
         max_tries = 20*num_blocks
         while max_tries > 0:
-            results = [ blockhash in c.cb.block_request_map and
-                        c.cb.block_request_map[blockhash] for c in self.connections ]
+            with mininode_lock:
+                results = [ blockhash in c.cb.block_request_map and
+                            c.cb.block_request_map[blockhash] for c in self.connections ]
             if False not in results:
                 break
             time.sleep(0.05)
@@ -199,8 +204,9 @@ class TestManager(object):
         # Wait for nodes to request transaction (50ms sleep * 20 tries * num_events)
         max_tries = 20*num_events
         while max_tries > 0:
-            results = [ txhash in c.cb.tx_request_map and
-                        c.cb.tx_request_map[txhash] for c in self.connections ]
+            with mininode_lock:
+                results = [ txhash in c.cb.tx_request_map and
+                            c.cb.tx_request_map[txhash] for c in self.connections ]
             if False not in results:
                 break
             time.sleep(0.05)
@@ -221,19 +227,21 @@ class TestManager(object):
         self.ping_counter += 1
 
         # Sort inv responses from each node
-        [ c.cb.lastInv.sort() for c in self.connections ]
+        with mininode_lock:
+            [ c.cb.lastInv.sort() for c in self.connections ]
 
     # Verify that the tip of each connection all agree with each other, and
     # with the expected outcome (if given)
     def check_results(self, blockhash, outcome):
-        for c in self.connections:
-            if outcome is None:
-                if c.cb.bestblockhash != self.connections[0].cb.bestblockhash:
+        with mininode_lock:
+            for c in self.connections:
+                if outcome is None:
+                    if c.cb.bestblockhash != self.connections[0].cb.bestblockhash:
+                        return False
+                elif ((c.cb.bestblockhash == blockhash) != outcome):
+                    # print c.cb.bestblockhash, blockhash, outcome
                     return False
-            elif ((c.cb.bestblockhash == blockhash) != outcome):
-                # print c.cb.bestblockhash, blockhash, outcome
-                return False
-        return True
+            return True
 
     # Either check that the mempools all agree with each other, or that
     # txhash's presence in the mempool matches the outcome specified.
@@ -242,16 +250,17 @@ class TestManager(object):
     # perhaps it would be useful to add the ability to check explicitly that
     # a particular tx's existence in the mempool is the same across all nodes.
     def check_mempool(self, txhash, outcome):
-        for c in self.connections:
-            if outcome is None:
-                # Make sure the mempools agree with each other
-                if c.cb.lastInv != self.connections[0].cb.lastInv:
-                    # print c.rpc.getrawmempool()
+        with mininode_lock:
+            for c in self.connections:
+                if outcome is None:
+                    # Make sure the mempools agree with each other
+                    if c.cb.lastInv != self.connections[0].cb.lastInv:
+                        # print c.rpc.getrawmempool()
+                        return False
+                elif ((txhash in c.cb.lastInv) != outcome):
+                    # print c.rpc.getrawmempool(), c.cb.lastInv
                     return False
-            elif ((txhash in c.cb.lastInv) != outcome):
-                # print c.rpc.getrawmempool(), c.cb.lastInv
-                return False
-        return True
+            return True
 
     def run(self):
         # Wait until verack is received
@@ -272,9 +281,10 @@ class TestManager(object):
                     block = b_or_t
                     block_outcome = outcome
                     # Add to shared block_store, set as current block
-                    self.block_store.add_block(block)
-                    for c in self.connections:
-                        c.cb.block_request_map[block.sha256] = False
+                    with mininode_lock:
+                        self.block_store.add_block(block)
+                        for c in self.connections:
+                            c.cb.block_request_map[block.sha256] = False
                     # Either send inv's to each node and sync, or add
                     # to invqueue for later inv'ing.
                     if (test_instance.sync_every_block):
@@ -288,10 +298,11 @@ class TestManager(object):
                     assert(isinstance(b_or_t, CTransaction))
                     tx = b_or_t
                     tx_outcome = outcome
-                    # Add to shared tx store
-                    self.tx_store.add_transaction(tx)
-                    for c in self.connections:
-                        c.cb.tx_request_map[tx.sha256] = False
+                    # Add to shared tx store and clear map entry
+                    with mininode_lock:
+                        self.tx_store.add_transaction(tx)
+                        for c in self.connections:
+                            c.cb.tx_request_map[tx.sha256] = False
                     # Again, either inv to all nodes or save for later
                     if (test_instance.sync_every_tx):
                         [ c.cb.send_inv(tx) for c in self.connections ]

--- a/qa/rpc-tests/maxblocksinflight.py
+++ b/qa/rpc-tests/maxblocksinflight.py
@@ -61,10 +61,11 @@ class TestManager(NodeConnCB):
                 time.sleep(2)
 
                 total_requests = 0
-                for key in self.blockReqCounts:
-                    total_requests += self.blockReqCounts[key]
-                    if self.blockReqCounts[key] > 1:
-                        raise AssertionError("Error, test failed: block %064x requested more than once" % key)
+                with mininode_lock:
+                    for key in self.blockReqCounts:
+                        total_requests += self.blockReqCounts[key]
+                        if self.blockReqCounts[key] > 1:
+                            raise AssertionError("Error, test failed: block %064x requested more than once" % key)
                 if total_requests > MAX_REQUESTS:
                     raise AssertionError("Error, too many blocks (%d) requested" % total_requests)
                 print "Round %d: success (total requests: %d)" % (count, total_requests)


### PR DESCRIPTION
This builds off of #6089, with more fixes for the python p2p testing framework (see #5981).

Previously, each `NodeConnCB` had its own lock to synchronize data structures used by the testing thread and the networking thread, and `NodeConn` provided a separate additional lock for synchronizing access to each send buffer.  However, there was no existing lock to protect other data structures that are not specific to a single `NodeConnCB`, such as `BlockStore` or `TxStore`, which are created in `comptool.py` and shared by all the `NodeConnCB` instances.

Moreover `comptool.py` had a race condition because it wasn't synchronizing access to the `BlockStore`, nor using the existing `NodeConnCB` locks before accessing the `block_request_map` inside the `comptool.py` `TestNode` objects.  I believe this type of race condition triggered a test failure reported in #5981.

This pull tries to simplify the synchronization and make the code more robust to race conditions by replacing all the individual locks one single global lock that we now use to synchronize the two threads.  The networking thread acquires this lock before delivering every message; `NodeConn.send_message()` uses this lock to synchronize access to the `sendbuf`; and the thread running the test logic will now acquire this lock before accessing any data shared with one or more `NodeConnCB` or `NodeConn` objects.
