### PR TITLE
Introduce BitcoinTestFramework.get_node_args.

### DIFF
--- a/qa/rpc-tests/bipdersig-p2p.py
+++ b/qa/rpc-tests/bipdersig-p2p.py
@@ -49,11 +49,11 @@ class BIP66Test(ComparisonTestFramework):
     def __init__(self):
         self.num_nodes = 1
 
-    def setup_network(self):
+    def get_node_args(self, n):
+        args = ComparisonTestFramework.get_node_args(self, n)
         # Must set the blockversion for this test
-        self.nodes = start_nodes(1, self.options.tmpdir, 
-                                 extra_args=[['-debug', '-whitelist=127.0.0.1', '-blockversion=2']],
-                                 binary=[self.options.testbinary])
+        args.append('-blockversion=2')
+        return args
 
     def run_test(self):
         test = TestManager(self, self.options.tmpdir)

--- a/qa/rpc-tests/bipdersig.py
+++ b/qa/rpc-tests/bipdersig.py
@@ -15,11 +15,24 @@ import shutil
 
 class BIP66Test(BitcoinTestFramework):
 
+    def get_node_args(self, n):
+        args = BitcoinTestFramework.get_node_args(self, n)
+
+        if n == 1:
+          args.append("-blockversion=2")
+        elif n == 2:
+          args.append("-blockversion=3")
+
+        return args
+
     def setup_network(self):
         self.nodes = []
-        self.nodes.append(start_node(0, self.options.tmpdir, []))
-        self.nodes.append(start_node(1, self.options.tmpdir, ["-blockversion=2"]))
-        self.nodes.append(start_node(2, self.options.tmpdir, ["-blockversion=3"]))
+        self.nodes.append(start_node(0, self.options.tmpdir,
+                                     self.get_node_args(0)))
+        self.nodes.append(start_node(1, self.options.tmpdir,
+                                     self.get_node_args(1)))
+        self.nodes.append(start_node(2, self.options.tmpdir,
+                                     self.get_node_args(2)))
         connect_nodes(self.nodes[1], 0)
         connect_nodes(self.nodes[2], 0)
         self.is_network_split = False

--- a/qa/rpc-tests/forknotify.py
+++ b/qa/rpc-tests/forknotify.py
@@ -17,16 +17,28 @@ class ForkNotifyTest(BitcoinTestFramework):
 
     alert_filename = None  # Set by setup_network
 
+    def get_node_args(self, n):
+        args = BitcoinTestFramework.get_node_args(self, n)
+
+        if n == 0:
+            args.append("-blockversion=2")
+            if self.alert_filename is not None:
+                args.append("-alertnotify=echo %s >> \"" + self.alert_filename + "\"")
+        elif n == 1:
+            args.append("-blockversion=211")
+
+        return args
+
     def setup_network(self):
         self.nodes = []
         self.alert_filename = os.path.join(self.options.tmpdir, "alert.txt")
         with open(self.alert_filename, 'w') as f:
             pass  # Just open then close to create zero-length file
         self.nodes.append(start_node(0, self.options.tmpdir,
-                            ["-blockversion=2", "-alertnotify=echo %s >> \"" + self.alert_filename + "\""]))
+                                     self.get_node_args(0)))
         # Node1 mines block.version=211 blocks
         self.nodes.append(start_node(1, self.options.tmpdir,
-                                ["-blockversion=211"]))
+                                     self.get_node_args(1)))
         connect_nodes(self.nodes[1], 0)
 
         self.is_network_split = False

--- a/qa/rpc-tests/httpbasics.py
+++ b/qa/rpc-tests/httpbasics.py
@@ -21,8 +21,16 @@ except ImportError:
     import urlparse
 
 class HTTPBasicsTest (BitcoinTestFramework):        
-    def setup_nodes(self):
-        return start_nodes(4, self.options.tmpdir, extra_args=[['-rpckeepalive=1'], ['-rpckeepalive=0'], [], []])
+
+    def get_node_args(self, n):
+        args = BitcoinTestFramework.get_node_args(self, n)
+
+        if n == 0:
+            args.append('-rpckeepalive=1')
+        elif n == 1:
+            args.append('-rpckeepalive=0')
+
+        return args
 
     def run_test(self):        
         

--- a/qa/rpc-tests/invalidateblock.py
+++ b/qa/rpc-tests/invalidateblock.py
@@ -13,17 +13,21 @@ from util import *
 
 class InvalidateTest(BitcoinTestFramework):
     
-        
     def setup_chain(self):
         print("Initializing test directory "+self.options.tmpdir)
         initialize_chain_clean(self.options.tmpdir, 3)
+
+    def get_node_args(self, n):
+        args = BitcoinTestFramework.get_node_args(self, n)
+        args.append("-debug")
+        return args
                  
     def setup_network(self):
         self.nodes = []
         self.is_network_split = False 
-        self.nodes.append(start_node(0, self.options.tmpdir, ["-debug"]))
-        self.nodes.append(start_node(1, self.options.tmpdir, ["-debug"]))
-        self.nodes.append(start_node(2, self.options.tmpdir, ["-debug"]))
+        for i in range(3):
+            self.nodes.append(start_node(i, self.options.tmpdir,
+                                         self.get_node_args(i)))
         
     def run_test(self):
         print "Make sure we repopulate setBlockIndexCandidates after InvalidateBlock:"

--- a/qa/rpc-tests/maxblocksinflight.py
+++ b/qa/rpc-tests/maxblocksinflight.py
@@ -85,9 +85,14 @@ class MaxBlocksInFlightTest(BitcoinTestFramework):
         print "Initializing test directory "+self.options.tmpdir
         initialize_chain_clean(self.options.tmpdir, 1)
 
+    def get_node_args(self, n):
+        args = BitcoinTestFramework.get_node_args(self, n)
+        args.extend(['-debug', '-whitelist=127.0.0.1'])
+        return args
+
     def setup_network(self):
         self.nodes = start_nodes(1, self.options.tmpdir, 
-                                 extra_args=[['-debug', '-whitelist=127.0.0.1']],
+                                 extra_args=self.get_extra_args(),
                                  binary=[self.options.testbinary])
 
     def run_test(self):

--- a/qa/rpc-tests/mempool_coinbase_spends.py
+++ b/qa/rpc-tests/mempool_coinbase_spends.py
@@ -19,11 +19,16 @@ class MempoolCoinbaseTest(BitcoinTestFramework):
 
     alert_filename = None  # Set by setup_network
 
+    def get_node_args(self, n):
+        args = BitcoinTestFramework.get_node_args(self, n)
+        args.extend(['-checkmempool', '-debug=mempool'])
+        return args
+
     def setup_network(self):
-        args = ["-checkmempool", "-debug=mempool"]
         self.nodes = []
-        self.nodes.append(start_node(0, self.options.tmpdir, args))
-        self.nodes.append(start_node(1, self.options.tmpdir, args))
+        for i in range(2):
+            self.nodes.append(start_node(i, self.options.tmpdir,
+                                         self.get_node_args(i)))
         connect_nodes(self.nodes[1], 0)
         self.is_network_split = False
         self.sync_all

--- a/qa/rpc-tests/mempool_resurrect_test.py
+++ b/qa/rpc-tests/mempool_resurrect_test.py
@@ -17,11 +17,16 @@ import shutil
 # Create one-input, one-output, no-fee transaction:
 class MempoolCoinbaseTest(BitcoinTestFramework):
 
+    def get_node_args(self, n):
+        args = BitcoinTestFramework.get_node_args(self, n)
+        args.extend(['-checkmempool', '-debug=mempool'])
+        return args
+
     def setup_network(self):
         # Just need one node for this test
-        args = ["-checkmempool", "-debug=mempool"]
         self.nodes = []
-        self.nodes.append(start_node(0, self.options.tmpdir, args))
+        self.nodes.append(start_node(0, self.options.tmpdir,
+                                     self.get_node_args(0)))
         self.is_network_split = False
 
     def create_tx(self, from_txid, to_address, amount):

--- a/qa/rpc-tests/mempool_spendcoinbase.py
+++ b/qa/rpc-tests/mempool_spendcoinbase.py
@@ -22,11 +22,16 @@ import shutil
 # Create one-input, one-output, no-fee transaction:
 class MempoolSpendCoinbaseTest(BitcoinTestFramework):
 
+    def get_node_args(self, n):
+        args = BitcoinTestFramework.get_node_args(self, n)
+        args.extend(['-checkmempool', '-debug=mempool'])
+        return args
+
     def setup_network(self):
         # Just need one node for this test
-        args = ["-checkmempool", "-debug=mempool"]
         self.nodes = []
-        self.nodes.append(start_node(0, self.options.tmpdir, args))
+        self.nodes.append(start_node(0, self.options.tmpdir,
+                                     self.get_node_args(0)))
         self.is_network_split = False
 
     def create_tx(self, from_txid, to_address, amount):

--- a/qa/rpc-tests/merkle_blocks.py
+++ b/qa/rpc-tests/merkle_blocks.py
@@ -19,14 +19,22 @@ class MerkleBlockTest(BitcoinTestFramework):
         print("Initializing test directory "+self.options.tmpdir)
         initialize_chain_clean(self.options.tmpdir, 4)
 
+    def get_node_args(self, n):
+        args = BitcoinTestFramework.get_node_args(self, n)
+        args.append('-debug')
+
+        if n == 3:
+            args.append('-txindex')
+
+        return args
+
     def setup_network(self):
         self.nodes = []
         # Nodes 0/1 are "wallet" nodes
-        self.nodes.append(start_node(0, self.options.tmpdir, ["-debug"]))
-        self.nodes.append(start_node(1, self.options.tmpdir, ["-debug"]))
         # Nodes 2/3 are used for testing
-        self.nodes.append(start_node(2, self.options.tmpdir, ["-debug"]))
-        self.nodes.append(start_node(3, self.options.tmpdir, ["-debug", "-txindex"]))
+        for i in range(4):
+            self.nodes.append(start_node(i, self.options.tmpdir,
+                                         self.get_node_args(i)))
         connect_nodes(self.nodes[0], 1)
         connect_nodes(self.nodes[0], 2)
         connect_nodes(self.nodes[0], 3)

--- a/qa/rpc-tests/proxy_test.py
+++ b/qa/rpc-tests/proxy_test.py
@@ -61,15 +61,27 @@ class ProxyTest(BitcoinTestFramework):
         self.serv3 = Socks5Server(self.conf3)
         self.serv3.start()
 
-    def setup_nodes(self):
+    def get_node_args(self, n):
+        args = BitcoinTestFramework.get_node_args(self, n)
+        args.extend(["-listen", "-debug=net", "-debug=proxy"])
+
         # Note: proxies are not used to connect to local nodes
         # this is because the proxy to use is based on CService.GetNetwork(), which return NET_UNROUTABLE for localhost
-        return start_nodes(4, self.options.tmpdir, extra_args=[
-            ['-listen', '-debug=net', '-debug=proxy', '-proxy=%s:%i' % (self.conf1.addr),'-proxyrandomize=1'], 
-            ['-listen', '-debug=net', '-debug=proxy', '-proxy=%s:%i' % (self.conf1.addr),'-onion=%s:%i' % (self.conf2.addr),'-proxyrandomize=0'], 
-            ['-listen', '-debug=net', '-debug=proxy', '-proxy=%s:%i' % (self.conf2.addr),'-proxyrandomize=1'], 
-            ['-listen', '-debug=net', '-debug=proxy', '-proxy=[%s]:%i' % (self.conf3.addr),'-proxyrandomize=0']
-            ])
+        if n == 0:
+            args.append("-proxy=%s:%i" % self.conf1.addr)
+            args.append("-proxyrandomize=1")
+        elif n == 1:
+            args.append("-proxy=%s:%i" % self.conf1.addr)
+            args.append("-onion=%s:%i" % self.conf2.addr)
+            args.append("-proxyrandomize=0")
+        elif n == 2:
+            args.append("-proxy=%s:%i" % self.conf2.addr)
+            args.append("-proxyrandomize=1")
+        elif n == 3:
+            args.append("-proxy=[%s]:%i" % self.conf3.addr)
+            args.append("-proxyrandomize=0")
+
+        return args
 
     def node_test(self, node, proxies, auth):
         rv = []

--- a/qa/rpc-tests/pruning.py
+++ b/qa/rpc-tests/pruning.py
@@ -46,16 +46,27 @@ class PruneTest(BitcoinTestFramework):
         print("Initializing test directory "+self.options.tmpdir)
         initialize_chain_clean(self.options.tmpdir, 3)
 
+    def get_node_args(self, n):
+        args = BitcoinTestFramework.get_node_args(self, n)
+        args.extend(['-debug', '-maxreceivebuffer=20000'])
+
+        if n == 0 or n == 1:
+            args.extend(['-blockmaxsize=999000', '-checkblocks=5'])
+        elif n == 2:
+            args.append('-prune=550')
+
+        return args
+
     def setup_network(self):
         self.nodes = []
         self.is_network_split = False
 
         # Create nodes 0 and 1 to mine
-        self.nodes.append(start_node(0, self.options.tmpdir, ["-debug","-maxreceivebuffer=20000","-blockmaxsize=999000", "-checkblocks=5"], timewait=300))
-        self.nodes.append(start_node(1, self.options.tmpdir, ["-debug","-maxreceivebuffer=20000","-blockmaxsize=999000", "-checkblocks=5"], timewait=300))
-
         # Create node 2 to test pruning
-        self.nodes.append(start_node(2, self.options.tmpdir, ["-debug","-maxreceivebuffer=20000","-prune=550"], timewait=300))
+        for i in range(3):
+            self.nodes.append(start_node(i, self.options.tmpdir,
+                                         self.get_node_args(i),
+                                         timewait=300))
         self.prunedir = self.options.tmpdir+"/node2/regtest/blocks/"
 
         self.address[0] = self.nodes[0].getnewaddress()

--- a/qa/rpc-tests/smartfees.py
+++ b/qa/rpc-tests/smartfees.py
@@ -13,24 +13,34 @@ from util import *
 
 class EstimateFeeTest(BitcoinTestFramework):
 
+    def get_node_args(self, n):
+        args = BitcoinTestFramework.get_node_args(self, n)
+        args.extend(["-debug=mempool", "-debug=estimatefee",
+                     "-relaypriority=0"])
+
+        if n == 1:
+            args.extend(["-blockprioritysize=1500", "-blockmaxsize=2000"])
+        elif n == 2:
+            args.extend(["-blockprioritysize=0", "-blockmaxsize=1500"])
+
+        return args
+
     def setup_network(self):
         self.nodes = []
         self.nodes.append(start_node(0, self.options.tmpdir,
-                            ["-debug=mempool", "-debug=estimatefee", "-relaypriority=0"]))
+                                     self.get_node_args(0)))
         # Node1 mines small-but-not-tiny blocks, and allows free transactions.
         # NOTE: the CreateNewBlock code starts counting block size at 1,000 bytes,
         # so blockmaxsize of 2,000 is really just 1,000 bytes (room enough for
         # 6 or 7 transactions)
         self.nodes.append(start_node(1, self.options.tmpdir,
-                                ["-blockprioritysize=1500", "-blockmaxsize=2000",
-                                 "-debug=mempool", "-debug=estimatefee", "-relaypriority=0"]))
+                                     self.get_node_args(1)))
         connect_nodes(self.nodes[1], 0)
 
         # Node2 is a stingy miner, that
         # produces very small blocks (room for only 3 or so transactions)
-        node2args = [ "-blockprioritysize=0", "-blockmaxsize=1500",
-                      "-debug=mempool", "-debug=estimatefee", "-relaypriority=0"]
-        self.nodes.append(start_node(2, self.options.tmpdir, node2args))
+        self.nodes.append(start_node(2, self.options.tmpdir,
+                                     self.get_node_args(2)))
         connect_nodes(self.nodes[2], 0)
 
         self.is_network_split = False

--- a/qa/rpc-tests/walletbackup.py
+++ b/qa/rpc-tests/walletbackup.py
@@ -45,11 +45,18 @@ class WalletBackupTest(BitcoinTestFramework):
         logging.info("Initializing test directory "+self.options.tmpdir)
         initialize_chain_clean(self.options.tmpdir, 4)
 
+    def get_node_args(self, n):
+        args = BitcoinTestFramework.get_node_args(self, n)
+
+        # nodes 1, 2,3 are spenders, let's give them a keypool=100
+        if n != 3:
+            args.append('-keypool=100')
+
+        return args
+
     # This mirrors how the network was setup in the bash test
     def setup_network(self, split=False):
-        # nodes 1, 2,3 are spenders, let's give them a keypool=100
-        extra_args = [["-keypool=100"], ["-keypool=100"], ["-keypool=100"], []]
-        self.nodes = start_nodes(4, self.options.tmpdir, extra_args)
+        self.nodes = start_nodes(4, self.options.tmpdir, self.get_extra_args())
         connect_nodes(self.nodes[0], 3)
         connect_nodes(self.nodes[1], 3)
         connect_nodes(self.nodes[2], 3)


### PR DESCRIPTION
Use a new function in BitcoinTestFramework (get_node_args) to specify which options each node should have.

I guess this is a matter of taste, but in my opinion this makes the code cleaner (also for future changes to the options).  It would even allow to specify "general" options that are set differently for the four nodes (e. g., two could always have -txindex and two not, so that both behaviours can be tested).
