### PR TITLE
Show an init message while activating best chain

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1333,6 +1333,7 @@ bool AppInit2(boost::thread_group& threadGroup)
     if (mapArgs.count("-blocknotify"))
         uiInterface.NotifyBlockTip.connect(BlockNotifyCallback);
 
+    uiInterface.InitMessage(_("Activating best chain..."));
     // scan for better chains in the block chain database, that are not yet connected in the active best chain
     CValidationState state;
     if (!ActivateBestChain(state))


### PR DESCRIPTION
Connecting the chain can take quite a while.
All the while it is still showing `Loading wallet...`.
Add an init message to inform the user what is happening.
