### PR TITLE
Out of sync warning update

### DIFF
--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -70,7 +70,7 @@
                <string notr="true">QLabel { color: red; }</string>
               </property>
               <property name="text">
-               <string notr="true">(out of sync)</string>
+               <string notr="true">(out of sync, please allow a few days to become synchronized)</string>
               </property>
               <property name="alignment">
                <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
@@ -442,7 +442,7 @@
                <string notr="true">QLabel { color: red; }</string>
               </property>
               <property name="text">
-               <string notr="true">(out of sync)</string>
+               <string notr="true">(out of sync, please allow a few days to become synchronized)</string>
               </property>
               <property name="alignment">
                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -130,10 +130,10 @@ OverviewPage::OverviewPage(QWidget *parent) :
     connect(ui->listTransactions, SIGNAL(clicked(QModelIndex)), this, SLOT(handleTransactionClicked(QModelIndex)));
 
     // init "out of sync" warning labels
-    ui->labelWalletStatus->setText("(" + tr("out of sync") + ")");
-    ui->labelTransactionsStatus->setText("(" + tr("out of sync") + ")");
+    ui->labelWalletStatus->setText("(" + tr("out of sync, please allow a few days to become synchronized") + ")");
+    ui->labelTransactionsStatus->setText("(" + tr("out of sync, please allow a few days to become synchronized") + ")");
 
-    // start with displaying the "out of sync" warnings
+    // start with displaying the "out of sync" warning labels
     showOutOfSyncWarning(true);
 }
 


### PR DESCRIPTION
Updates out of sync warnings in order to mitigate confusion caused by the time it takes to sync with the Network.

"(out of sync)" warning label changed to "(out of sync, please allow a few days to become synchronized)."

In response to issue #6106 
