### PR TITLE
Lazily update CBlockIndex entries when pruning

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -85,9 +85,9 @@ enum BlockStatus {
     BLOCK_VALID_MASK         =   BLOCK_VALID_HEADER | BLOCK_VALID_TREE | BLOCK_VALID_TRANSACTIONS |
                                  BLOCK_VALID_CHAIN | BLOCK_VALID_SCRIPTS,
 
-    BLOCK_HAVE_DATA          =    8, //! full block available in blk*.dat
-    BLOCK_HAVE_UNDO          =   16, //! undo data available in rev*.dat
-    BLOCK_HAVE_MASK          =   BLOCK_HAVE_DATA | BLOCK_HAVE_UNDO,
+    BLOCK_STORED_DATA        =    8, //! full block was stored in blk*.dat; pruning may have deleted
+    BLOCK_STORED_UNDO        =   16, //! undo data was stored in rev*.dat; pruning may have deleted
+    BLOCK_STORED_MASK        =   BLOCK_STORED_DATA | BLOCK_STORED_UNDO,
 
     BLOCK_FAILED_VALID       =   32, //! stage after last reached validness failed
     BLOCK_FAILED_CHILD       =   64, //! descends from failed block
@@ -188,7 +188,7 @@ public:
 
     CDiskBlockPos GetBlockPos() const {
         CDiskBlockPos ret;
-        if (nStatus & BLOCK_HAVE_DATA) {
+        if (nStatus & BLOCK_STORED_DATA) {
             ret.nFile = nFile;
             ret.nPos  = nDataPos;
         }
@@ -197,7 +197,7 @@ public:
 
     CDiskBlockPos GetUndoPos() const {
         CDiskBlockPos ret;
-        if (nStatus & BLOCK_HAVE_UNDO) {
+        if (nStatus & BLOCK_STORED_UNDO) {
             ret.nFile = nFile;
             ret.nPos  = nUndoPos;
         }
@@ -306,11 +306,11 @@ public:
         READWRITE(VARINT(nHeight));
         READWRITE(VARINT(nStatus));
         READWRITE(VARINT(nTx));
-        if (nStatus & (BLOCK_HAVE_DATA | BLOCK_HAVE_UNDO))
+        if (nStatus & (BLOCK_STORED_DATA | BLOCK_STORED_UNDO))
             READWRITE(VARINT(nFile));
-        if (nStatus & BLOCK_HAVE_DATA)
+        if (nStatus & BLOCK_STORED_DATA)
             READWRITE(VARINT(nDataPos));
-        if (nStatus & BLOCK_HAVE_UNDO)
+        if (nStatus & BLOCK_STORED_UNDO)
             READWRITE(VARINT(nUndoPos));
 
         // block header

--- a/src/main.h
+++ b/src/main.h
@@ -148,6 +148,12 @@ static const signed int MIN_BLOCKS_TO_KEEP = 288;
 // Setting the target to > than 550MB will make it likely we can respect the target.
 static const signed int MIN_DISK_SPACE_FOR_BLOCK_FILES = 550 * 1024 * 1024;
 
+/**
+ * Check whether we have data for a block, and update the CBlockIndex
+ * by unsetting STORED_DATA and STORED_UNDO if the block was pruned.
+ */
+bool HaveBlockData(CBlockIndex *pindex);
+
 /** Register with a network node to receive its signals */
 void RegisterNodeSignals(CNodeSignals& nodeSignals);
 /** Unregister a network node */
@@ -212,7 +218,8 @@ CAmount GetBlockValue(int nHeight, const CAmount& nFees);
  * Block and undo files are deleted in lock-step (when blk00003.dat is deleted, so is rev00003.dat.)
  * Pruning cannot take place until the longest chain is at least a certain length (100000 on mainnet, 1000 on testnet, 10 on regtest).
  * Pruning will never delete a block within a defined distance (currently 288) from the active chain's tip.
- * The block index is updated by unsetting HAVE_DATA and HAVE_UNDO for any blocks that were stored in the deleted files.
+ * The block index is updated by setting the CBlockFileInfo for a given file to NULL.
+ * The CBlockIndex BLOCK_STORED_DATA/STORED_UNDO information is lazily updated after files are deleted.
  * A db flag records the fact that at least some block files have been pruned.
  *
  * @param[out]   setFilesToPrune   The set of file indices that can be unlinked will be returned

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -197,7 +197,7 @@ static bool rest_block(AcceptedConnection* conn,
             throw RESTERR(HTTP_NOT_FOUND, hashStr + " not found");
 
         pblockindex = mapBlockIndex[hash];
-        if (fHavePruned && !(pblockindex->nStatus & BLOCK_HAVE_DATA) && pblockindex->nTx > 0)
+        if (fHavePruned && !HaveBlockData(pblockindex) && pblockindex->nTx > 0)
             throw RESTERR(HTTP_NOT_FOUND, hashStr + " not available (pruned data)");
 
         if (!ReadBlockFromDisk(block, pblockindex))

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -299,7 +299,7 @@ Value getblock(const Array& params, bool fHelp)
     CBlock block;
     CBlockIndex* pblockindex = mapBlockIndex[hash];
 
-    if (fHavePruned && !(pblockindex->nStatus & BLOCK_HAVE_DATA) && pblockindex->nTx > 0)
+    if (fHavePruned && !HaveBlockData(pblockindex) && pblockindex->nTx > 0)
         throw JSONRPCError(RPC_INTERNAL_ERROR, "Block not available (pruned data)");
 
     if(!ReadBlockFromDisk(block, pblockindex))
@@ -499,7 +499,7 @@ Value getblockchaininfo(const Array& params, bool fHelp)
     if (fPruneMode)
     {
         CBlockIndex *block = chainActive.Tip();
-        while (block && block->pprev && (block->pprev->nStatus & BLOCK_HAVE_DATA))
+        while (block && block->pprev && HaveBlockData(block->pprev))
             block = block->pprev;
 
         obj.push_back(Pair("pruneheight",        block->nHeight));


### PR DESCRIPTION
Rename `BLOCK_HAVE_DATA` and `BLOCK_HAVE_UNDO` to `BLOCK_STORED_DATA/ BLOCK_STORED_UNDO`.

These status values now indicate that a block or its undo information has been
stored on disk, but pruning could cause that data to no longer be present.

`HaveBlockData()` uses `vinfoBlockFile` to determine whether we actually have block
data for a given block, and updates the `CBlockIndex` passed in when `BLOCK_STORED_DATA`
was set to true but the block file has been pruned.

Also remove the iteration of `mapBlockIndex` in `PruneOneBlockFile()`, as we no
longer need to update the `CBlockIndex` entries of the blocks referenced in a
pruned file.

@sipa  Is this along the lines of what you had in mind?
