### PR TITLE
Move pruning enabled log message beneath the cut

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -763,7 +763,6 @@ bool AppInit2(boost::thread_group& threadGroup)
         if (nPruneTarget < MIN_DISK_SPACE_FOR_BLOCK_FILES) {
             return InitError(strprintf(_("Prune configured below the minimum of %d MB.  Please use a higher number."), MIN_DISK_SPACE_FOR_BLOCK_FILES / 1024 / 1024));
         }
-        LogPrintf("Prune configured to target %uMiB on disk for block and undo files.\n", nPruneTarget / 1024 / 1024);
         fPruneMode = true;
     }
 
@@ -885,6 +884,9 @@ bool AppInit2(boost::thread_group& threadGroup)
     std::ostringstream strErrors;
 
     LogPrintf("Using %u threads for script verification\n", nScriptCheckThreads);
+    if (fPruneMode)
+        LogPrintf("Using %uMiB as target for pruning block and undo files\n", nPruneTarget / 1024 / 1024);
+
     if (nScriptCheckThreads) {
         for (int i=0; i<nScriptCheckThreads-1; i++)
             threadGroup.create_thread(&ThreadScriptCheck);


### PR DESCRIPTION
We should print it with startup messages for the current run, not
before the cut and at the end of the last run.
