### PR TITLE
Bug fix for clearing fCheckForPruning

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1886,6 +1886,7 @@ bool static FlushStateToDisk(CValidationState &state, FlushStateMode mode) {
     try {
     if (fPruneMode && fCheckForPruning) {
         FindFilesToPrune(setFilesToPrune);
+        fCheckForPruning = false;
         if (!setFilesToPrune.empty()) {
             fFlushForPrune = true;
             if (!fHavePruned) {
@@ -1942,10 +1943,8 @@ bool static FlushStateToDisk(CValidationState &state, FlushStateMode mode) {
             }
         }
         // Finally remove any pruned files
-        if (fFlushForPrune) {
+        if (fFlushForPrune)
             UnlinkPrunedFiles(setFilesToPrune);
-            fCheckForPruning = false;
-        }
         nLastWrite = nNow;
     }
     // Flush best chain related state. This can only be done if the blocks / block index write was also done.


### PR DESCRIPTION
Previously this was cleared only after UnlinkPrunedFiles, but it should really be cleared after FindFilesToPrune, regardless of whether there are any files to be pruned.
