### PR TITLE
Do not use hard-coded AllowFree for free transactions.

### DIFF
--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -552,9 +552,8 @@ void CoinControlDialog::updateLabels(WalletModel *model, QDialog* dialog)
 
         // Allow free?
         double dPriorityNeeded = mempoolEstimatePriority;
-        if (dPriorityNeeded <= 0)
-            dPriorityNeeded = AllowFreeThreshold(); // not enough data, back to hard-coded
-        fAllowFree = (dPriority >= dPriorityNeeded);
+        // Allow free if we have priority greater than valid priority estimate
+        fAllowFree = (dPriorityNeeded > 0) && (dPriority >= dPriorityNeeded);
 
         if (fSendFreeTransactions)
             if (fAllowFree && nBytes <= MAX_FREE_TRANSACTION_CREATE_SIZE)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1923,13 +1923,9 @@ bool CWallet::CreateTransaction(const vector<CRecipient>& vecSend,
                 // Can we complete this as a free transaction?
                 if (fSendFreeTransactions && nBytes <= MAX_FREE_TRANSACTION_CREATE_SIZE)
                 {
-                    // Not enough fee: enough priority?
                     double dPriorityNeeded = mempool.estimatePriority(nTxConfirmTarget);
-                    // Not enough mempool history to estimate: use hard-coded AllowFree.
-                    if (dPriorityNeeded <= 0 && AllowFree(dPriority))
-                        break;
-
-                    // Small enough, and priority high enough, to send for free
+                    // We have a priority estimate for the desired confirm target and
+                    // the tx has enough priority and is small enough to send for free
                     if (dPriorityNeeded > 0 && dPriority >= dPriorityNeeded)
                         break;
                 }


### PR DESCRIPTION
The hard coded AllowFree threshold is not suitable for determining whether a free transaction will be confirmed in a reasonable time.

If `estimatePriority` returns -1 it either means there isn't yet enough data to estimate or there is no priority that is high enough to be confirmed by the desired target, in either case it's better to not send a zero fee transaction.
