### PR TITLE
depends: sanity-check sources and cached builds

### DIFF
--- a/depends/Makefile
+++ b/depends/Makefile
@@ -91,12 +91,12 @@ include funcs.mk
 toolchain_path=$($($(host_arch)_$(host_os)_native_toolchain)_prefixbin)
 final_build_id_long+=$(shell $(build_SHA256SUM) config.site.in)
 final_build_id+=$(shell echo -n $(final_build_id_long) | $(build_SHA256SUM) | cut -c-$(HASH_LENGTH))
-$(host_prefix)/.stamp_$(final_build_id): | $(native_packages) $(packages)
+$(host_prefix)/.stamp_$(final_build_id): $(native_packages) $(packages)
 	$(AT)rm -rf $(@D)
 	$(AT)mkdir -p $(@D)
-	$(AT)echo copying packages: $|
+	$(AT)echo copying packages: $^
 	$(AT)echo to: $(@D)
-	$(AT)cd $(@D); $(foreach package,$|, tar xf $($(package)_cached); )
+	$(AT)cd $(@D); $(foreach package,$^, tar xf $($(package)_cached); )
 	$(AT)touch $@
 
 $(host_prefix)/share/config.site : config.site.in $(host_prefix)/.stamp_$(final_build_id)
@@ -121,8 +121,35 @@ $(host_prefix)/share/config.site : config.site.in $(host_prefix)/.stamp_$(final_
             $< > $@
 	$(AT)touch $@
 
-install: $(host_prefix)/share/config.site
-download-one: $(all_sources)
+
+define check_or_remove_cached
+  mkdir -p $(BASE_CACHE)/$(host)/$(package) && cd $(BASE_CACHE)/$(host)/$(package); \
+  $(build_SHA256SUM) -c $($(package)_cached_checksum) >/dev/null 2>/dev/null || \
+  ( rm -f $($(package)_cached_checksum); \
+    if test -f "$($(package)_cached)"; then echo "Checksum mismatch for $(package). Forcing rebuild.."; rm -f $($(package)_cached_checksum) $($(package)_cached); fi )
+endef
+
+define check_or_remove_sources
+  mkdir -p $($(package)_source_dir); cd $($(package)_source_dir); \
+  $(build_SHA256SUM) -c $($(package)_fetched) >/dev/null 2>/dev/null || \
+    ( if test -f $($(package)_all_sources); then echo "Checksum missing or mismatched for $(package) source. Forcing re-download."; fi; \
+      rm -f $($(package)_all_sources) $($(1)_fetched))
+endef
+
+check-packages:
+	@$(foreach package,$(all_packages),$(call check_or_remove_cached,$(package));)
+check-sources:
+	@$(foreach package,$(all_packages),$(call check_or_remove_sources,$(package));)
+
+$(host_prefix)/share/config.site: check-packages
+
+check-packages: check-sources
+
+install: check-packages $(host_prefix)/share/config.site
+
+
+download-one: check-sources $(all_sources)
+
 download-osx:
 	@$(MAKE) -s HOST=x86_64-apple-darwin11 download-one
 download-linux:
@@ -130,4 +157,5 @@ download-linux:
 download-win:
 	@$(MAKE) -s HOST=x86_64-w64-mingw32 download-one
 download: download-osx download-linux download-win
-.PHONY: install cached download-one download-osx download-linux download-win download
+
+.PHONY: install cached download-one download-osx download-linux download-win download check-packages check-sources

--- a/depends/README.packages
+++ b/depends/README.packages
@@ -30,7 +30,9 @@ These variables are optional:
     Names of any other packages that this one depends on.
   $(package)_patches:
     Filenames of any patches needed to build the package
-
+  $(package)_extra_sources:
+    Any extra files that will be fetched via $(package)_fetch_cmds. These are
+    specified so that they can be fetched and verified via 'make download'.
 
 Build Variables:
 After defining the main identifiers, build variables may be added or customized

--- a/depends/packages/native_cctools.mk
+++ b/depends/packages/native_cctools.mk
@@ -9,6 +9,8 @@ $(package)_clang_download_path=http://llvm.org/releases/$($(package)_clang_versi
 $(package)_clang_download_file=clang+llvm-$($(package)_clang_version)-amd64-Ubuntu-12.04.2.tar.gz
 $(package)_clang_file_name=clang-llvm-$($(package)_clang_version)-amd64-Ubuntu-12.04.2.tar.gz
 $(package)_clang_sha256_hash=60d8f69f032d62ef61bf527857ebb933741ec3352d4d328c5516aa520662dab7
+$(package)_extra_sources=$($(package)_clang_file_name)
+
 define $(package)_fetch_cmds
 $(call fetch_file,$(package),$($(package)_download_path),$($(package)_download_file),$($(package)_file_name),$($(package)_sha256_hash)) && \
 $(call fetch_file,$(package),$($(package)_clang_download_path),$($(package)_clang_download_file),$($(package)_clang_file_name),$($(package)_clang_sha256_hash))


### PR DESCRIPTION
I'm pushing this up before bed in case the breakage gets worse as Europe wakes up and starts PR'ing. I'd prefer to check the build log of this PR itself before merge, but I think all should be OK as-is.

In some cases (Travis), sources and build caches may be moved around in-between builds, and we can't necessarily trust that everything is still intact. In particular, this should properly detect and recover from Travis corruption that came up this week.

This introduces pre-build checks that verify against stashed checksums.

Note that this will cause all sources to be re-downloaded, since (moved) cached sources weren't completely trustworthy before this.
