### PR TITLE
Remove assertion from ~LockedPageManager

### DIFF
--- a/src/support/pagelocker.h
+++ b/src/support/pagelocker.h
@@ -37,7 +37,6 @@ public:
 
     ~LockedPageManagerBase()
     {
-        assert(this->GetLockedPageCount() == 0);
     }
 
 


### PR DESCRIPTION
This assertion will fail any time that the client quits without shutting down properly due to an error condition. As the user will report this error (try googling for it!) instead of the error that was the root cause, it is better to remove it.
