### PR TITLE
Fix intermittent failures in scheduler test

### DIFF
--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -96,3 +96,11 @@ void CScheduler::scheduleEvery(CScheduler::Function f, int64_t deltaSeconds)
 {
     scheduleFromNow(boost::bind(&Repeat, this, f, deltaSeconds), deltaSeconds);
 }
+
+size_t CScheduler::numTasksInQueue()
+{
+    {
+        boost::unique_lock<boost::mutex> lock(newTaskMutex);
+        return taskQueue.size();
+    }
+}

--- a/src/scheduler.h
+++ b/src/scheduler.h
@@ -60,6 +60,9 @@ public:
     // and interrupted using boost::interrupt_thread
     void serviceQueue();
 
+    // Return the number of tasks left in the queue
+    size_t numTasksInQueue();
+
 private:
     std::multimap<boost::chrono::system_clock::time_point, Function> taskQueue;
     boost::condition_variable newTaskScheduled;

--- a/src/test/scheduler_tests.cpp
+++ b/src/test/scheduler_tests.cpp
@@ -94,7 +94,8 @@ BOOST_AUTO_TEST_CASE(manythreads)
     }
 
     // All 2,000 tasks should be finished within 2 milliseconds. Sleep a bit longer.
-    MicroSleep(2100);
+    while (microTasks.numTasksInQueue())
+        MicroSleep(2100);
 
     microThreads.interrupt_all();
     microThreads.join_all();


### PR DESCRIPTION
The scheduler test currently relies on exact timings, this is not workable in the busy Travis environment (or anything but a real-time operating system) resulting in random errors.

Ideally such a test would use mock times, but this is very invasive. For now, fix it by waiting until the number of tasks left to execute is zero before tearing down the threads.
