### PR TITLE
Parameter interaction: disable upnp if -proxy set

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -661,6 +661,10 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
         // to protect privacy, do not listen by default if a default proxy server is specified
         if (SoftSetBoolArg("-listen", false))
             LogPrintf("%s: parameter interaction: -proxy set -> setting -listen=0\n", __func__);
+        // to protect privacy, do not use UPNP when a proxy is set. The user may still specify -listen=1
+        // to listen locally, so don't rely on this happening through -listen below.
+        if (SoftSetBoolArg("-upnp", false))
+            LogPrintf("%s: parameter interaction: -proxy set -> setting -upnp=0\n", __func__);
         // to protect privacy, do not discover addresses by default
         if (SoftSetBoolArg("-discover", false))
             LogPrintf("%s: parameter interaction: -proxy set -> setting -discover=0\n", __func__);


### PR DESCRIPTION
To protect privacy, do not use UPNP when a proxy is set. The user may still specify `-listen=1` to listen locally (for a hidden service), so don't rely on this happening via the `-listen` case.

Fixes #2927.
