### PR TITLE
Add setban/listbanned RPC commands

### DIFF
--- a/qa/pull-tester/rpc-tests.sh
+++ b/qa/pull-tester/rpc-tests.sh
@@ -32,6 +32,7 @@ testScripts=(
     'merkle_blocks.py'
     'signrawtransactions.py'
     'walletbackup.py'
+    'nodehandling.py'
 );
 testScriptsExt=(
     'bipdersig-p2p.py'

--- a/qa/rpc-tests/httpbasics.py
+++ b/qa/rpc-tests/httpbasics.py
@@ -101,13 +101,28 @@ class HTTPBasicsTest (BitcoinTestFramework):
         ###########################
         # setban/listbanned tests #
         ###########################
-        assert_equal(len(self.nodes[2].getpeerinfo()), 4); #we should have 4 nodes at this point
+        assert_equal(len(self.nodes[2].getpeerinfo()), 4) #we should have 4 nodes at this point
         self.nodes[2].setban("127.0.0.1", "add")
         time.sleep(3) #wait till the nodes are disconected
-        assert_equal(len(self.nodes[2].getpeerinfo()), 0); #all nodes must be disconnected at this point
-        assert_equal(len(self.nodes[2].listbanned()), 1);
+        assert_equal(len(self.nodes[2].getpeerinfo()), 0) #all nodes must be disconnected at this point
+        assert_equal(len(self.nodes[2].listbanned()), 1)
         self.nodes[2].clearbanned()
-        assert_equal(len(self.nodes[2].listbanned()), 0);
-
+        assert_equal(len(self.nodes[2].listbanned()), 0)
+        self.nodes[2].setban("127.0.0.0/24", "add")
+        assert_equal(len(self.nodes[2].listbanned()), 1)
+        try:
+            self.nodes[2].setban("127.0.0.1", "add") #throws exception because 127.0.0.1 is within range 127.0.0.0/24
+        except:
+            pass
+        assert_equal(len(self.nodes[2].listbanned()), 1) #still only one banned ip because 127.0.0.1 is within the range of 127.0.0.0/24
+        try:
+            self.nodes[2].setban("127.0.0.1", "remove")
+        except:
+            pass
+        assert_equal(len(self.nodes[2].listbanned()), 1)
+        self.nodes[2].setban("127.0.0.0/24", "remove")
+        assert_equal(len(self.nodes[2].listbanned()), 0)
+        self.nodes[2].clearbanned()
+        assert_equal(len(self.nodes[2].listbanned()), 0)
 if __name__ == '__main__':
     HTTPBasicsTest ().main ()

--- a/qa/rpc-tests/httpbasics.py
+++ b/qa/rpc-tests/httpbasics.py
@@ -4,7 +4,7 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #
-# Test REST interface
+# Test rpc http basics
 #
 
 from test_framework.test_framework import BitcoinTestFramework
@@ -98,31 +98,5 @@ class HTTPBasicsTest (BitcoinTestFramework):
         assert_equal('"error":null' in out1, True)
         assert_equal(conn.sock!=None, True) #connection must be closed because bitcoind should use keep-alive by default
 
-        ###########################
-        # setban/listbanned tests #
-        ###########################
-        assert_equal(len(self.nodes[2].getpeerinfo()), 4) #we should have 4 nodes at this point
-        self.nodes[2].setban("127.0.0.1", "add")
-        time.sleep(3) #wait till the nodes are disconected
-        assert_equal(len(self.nodes[2].getpeerinfo()), 0) #all nodes must be disconnected at this point
-        assert_equal(len(self.nodes[2].listbanned()), 1)
-        self.nodes[2].clearbanned()
-        assert_equal(len(self.nodes[2].listbanned()), 0)
-        self.nodes[2].setban("127.0.0.0/24", "add")
-        assert_equal(len(self.nodes[2].listbanned()), 1)
-        try:
-            self.nodes[2].setban("127.0.0.1", "add") #throws exception because 127.0.0.1 is within range 127.0.0.0/24
-        except:
-            pass
-        assert_equal(len(self.nodes[2].listbanned()), 1) #still only one banned ip because 127.0.0.1 is within the range of 127.0.0.0/24
-        try:
-            self.nodes[2].setban("127.0.0.1", "remove")
-        except:
-            pass
-        assert_equal(len(self.nodes[2].listbanned()), 1)
-        self.nodes[2].setban("127.0.0.0/24", "remove")
-        assert_equal(len(self.nodes[2].listbanned()), 0)
-        self.nodes[2].clearbanned()
-        assert_equal(len(self.nodes[2].listbanned()), 0)
 if __name__ == '__main__':
     HTTPBasicsTest ().main ()

--- a/qa/rpc-tests/httpbasics.py
+++ b/qa/rpc-tests/httpbasics.py
@@ -20,83 +20,94 @@ try:
 except ImportError:
     import urlparse
 
-class HTTPBasicsTest (BitcoinTestFramework):        
+class HTTPBasicsTest (BitcoinTestFramework):
     def setup_nodes(self):
         return start_nodes(4, self.options.tmpdir, extra_args=[['-rpckeepalive=1'], ['-rpckeepalive=0'], [], []])
 
-    def run_test(self):        
-        
+    def run_test(self):
+
         #################################################
         # lowlevel check for http persistent connection #
         #################################################
         url = urlparse.urlparse(self.nodes[0].url)
         authpair = url.username + ':' + url.password
         headers = {"Authorization": "Basic " + base64.b64encode(authpair)}
-        
+
         conn = httplib.HTTPConnection(url.hostname, url.port)
         conn.connect()
         conn.request('POST', '/', '{"method": "getbestblockhash"}', headers)
         out1 = conn.getresponse().read();
         assert_equal('"error":null' in out1, True)
         assert_equal(conn.sock!=None, True) #according to http/1.1 connection must still be open!
-        
+
         #send 2nd request without closing connection
         conn.request('POST', '/', '{"method": "getchaintips"}', headers)
         out2 = conn.getresponse().read();
         assert_equal('"error":null' in out1, True) #must also response with a correct json-rpc message
         assert_equal(conn.sock!=None, True) #according to http/1.1 connection must still be open!
         conn.close()
-        
+
         #same should be if we add keep-alive because this should be the std. behaviour
         headers = {"Authorization": "Basic " + base64.b64encode(authpair), "Connection": "keep-alive"}
-        
+
         conn = httplib.HTTPConnection(url.hostname, url.port)
         conn.connect()
         conn.request('POST', '/', '{"method": "getbestblockhash"}', headers)
         out1 = conn.getresponse().read();
         assert_equal('"error":null' in out1, True)
         assert_equal(conn.sock!=None, True) #according to http/1.1 connection must still be open!
-        
+
         #send 2nd request without closing connection
         conn.request('POST', '/', '{"method": "getchaintips"}', headers)
         out2 = conn.getresponse().read();
         assert_equal('"error":null' in out1, True) #must also response with a correct json-rpc message
         assert_equal(conn.sock!=None, True) #according to http/1.1 connection must still be open!
         conn.close()
-        
+
         #now do the same with "Connection: close"
         headers = {"Authorization": "Basic " + base64.b64encode(authpair), "Connection":"close"}
-        
+
         conn = httplib.HTTPConnection(url.hostname, url.port)
         conn.connect()
         conn.request('POST', '/', '{"method": "getbestblockhash"}', headers)
         out1 = conn.getresponse().read();
         assert_equal('"error":null' in out1, True)
-        assert_equal(conn.sock!=None, False) #now the connection must be closed after the response        
-        
+        assert_equal(conn.sock!=None, False) #now the connection must be closed after the response
+
         #node1 (2nd node) is running with disabled keep-alive option
         urlNode1 = urlparse.urlparse(self.nodes[1].url)
         authpair = urlNode1.username + ':' + urlNode1.password
         headers = {"Authorization": "Basic " + base64.b64encode(authpair)}
-                
+
         conn = httplib.HTTPConnection(urlNode1.hostname, urlNode1.port)
         conn.connect()
         conn.request('POST', '/', '{"method": "getbestblockhash"}', headers)
         out1 = conn.getresponse().read();
         assert_equal('"error":null' in out1, True)
         assert_equal(conn.sock!=None, False) #connection must be closed because keep-alive was set to false
-        
+
         #node2 (third node) is running with standard keep-alive parameters which means keep-alive is off
         urlNode2 = urlparse.urlparse(self.nodes[2].url)
         authpair = urlNode2.username + ':' + urlNode2.password
         headers = {"Authorization": "Basic " + base64.b64encode(authpair)}
-                
+
         conn = httplib.HTTPConnection(urlNode2.hostname, urlNode2.port)
         conn.connect()
         conn.request('POST', '/', '{"method": "getbestblockhash"}', headers)
         out1 = conn.getresponse().read();
         assert_equal('"error":null' in out1, True)
         assert_equal(conn.sock!=None, True) #connection must be closed because bitcoind should use keep-alive by default
-        
+
+        ###########################
+        # setban/listbanned tests #
+        ###########################
+        assert_equal(len(self.nodes[2].getpeerinfo()), 4); #we should have 4 nodes at this point
+        self.nodes[2].setban("127.0.0.1", "add")
+        time.sleep(3) #wait till the nodes are disconected
+        assert_equal(len(self.nodes[2].getpeerinfo()), 0); #all nodes must be disconnected at this point
+        assert_equal(len(self.nodes[2].listbanned()), 1);
+        self.nodes[2].clearbanned()
+        assert_equal(len(self.nodes[2].listbanned()), 0);
+
 if __name__ == '__main__':
     HTTPBasicsTest ().main ()

--- a/qa/rpc-tests/nodehandling.py
+++ b/qa/rpc-tests/nodehandling.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python2
+# Copyright (c) 2014 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#
+# Test node handling
+#
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+import base64
+
+try:
+    import http.client as httplib
+except ImportError:
+    import httplib
+try:
+    import urllib.parse as urlparse
+except ImportError:
+    import urlparse
+
+class NodeHandlingTest (BitcoinTestFramework):
+    def run_test(self):
+        ###########################
+        # setban/listbanned tests #
+        ###########################
+        assert_equal(len(self.nodes[2].getpeerinfo()), 4) #we should have 4 nodes at this point
+        self.nodes[2].setban("127.0.0.1", "add")
+        time.sleep(3) #wait till the nodes are disconected
+        assert_equal(len(self.nodes[2].getpeerinfo()), 0) #all nodes must be disconnected at this point
+        assert_equal(len(self.nodes[2].listbanned()), 1)
+        self.nodes[2].clearbanned()
+        assert_equal(len(self.nodes[2].listbanned()), 0)
+        self.nodes[2].setban("127.0.0.0/24", "add")
+        assert_equal(len(self.nodes[2].listbanned()), 1)
+        try:
+            self.nodes[2].setban("127.0.0.1", "add") #throws exception because 127.0.0.1 is within range 127.0.0.0/24
+        except:
+            pass
+        assert_equal(len(self.nodes[2].listbanned()), 1) #still only one banned ip because 127.0.0.1 is within the range of 127.0.0.0/24
+        try:
+            self.nodes[2].setban("127.0.0.1", "remove")
+        except:
+            pass
+        assert_equal(len(self.nodes[2].listbanned()), 1)
+        self.nodes[2].setban("127.0.0.0/24", "remove")
+        assert_equal(len(self.nodes[2].listbanned()), 0)
+        self.nodes[2].clearbanned()
+        assert_equal(len(self.nodes[2].listbanned()), 0)
+        
+        ###########################
+        # RPC disconnectnode test #
+        ###########################
+        url = urlparse.urlparse(self.nodes[1].url)
+        self.nodes[0].disconnectnode(url.hostname+":"+str(p2p_port(1)))
+        time.sleep(2) #disconnecting a node needs a little bit of time
+        for node in self.nodes[0].getpeerinfo():
+            assert(node['addr'] != url.hostname+":"+str(p2p_port(1)))
+
+        connect_nodes_bi(self.nodes,0,1) #reconnect the node
+        found = False
+        for node in self.nodes[0].getpeerinfo():
+            if node['addr'] == url.hostname+":"+str(p2p_port(1)):
+                found = True
+        assert(found)
+
+if __name__ == '__main__':
+    NodeHandlingTest ().main ()

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -484,15 +484,15 @@ bool CNode::IsBanned(CSubNet subnet)
     return fResult;
 }
 
-void CNode::Ban(const CNetAddr& addr, int64_t bantimeoffset) {
+void CNode::Ban(const CNetAddr& addr, int64_t bantimeoffset, bool sinceUnixEpoch) {
     CSubNet subNet(addr.ToString()+(addr.IsIPv4() ? "/32" : "/128"));
-    Ban(subNet, bantimeoffset);
+    Ban(subNet, bantimeoffset, sinceUnixEpoch);
 }
 
-void CNode::Ban(const CSubNet& subNet, int64_t bantimeoffset) {
+void CNode::Ban(const CSubNet& subNet, int64_t bantimeoffset, bool sinceUnixEpoch) {
     int64_t banTime = GetTime()+GetArg("-bantime", 60*60*24);  // Default 24-hour ban
     if (bantimeoffset > 0)
-        banTime = GetTime()+bantimeoffset;
+        banTime = (sinceUnixEpoch ? 0 : GetTime() )+bantimeoffset;
 
     LOCK(cs_setBanned);
     if (setBanned[subNet] < banTime)

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -458,7 +458,7 @@ bool CNode::IsBanned(CNetAddr ip)
     return fResult;
 }
 
-bool CNode::Ban(const CNetAddr &addr, int64_t bantimeoffset) {
+void CNode::Ban(const CNetAddr &addr, int64_t bantimeoffset) {
     int64_t banTime = GetTime()+GetArg("-bantime", 60*60*24);  // Default 24-hour ban
     if (bantimeoffset > 0)
         banTime = GetTime()+bantimeoffset;
@@ -466,8 +466,6 @@ bool CNode::Ban(const CNetAddr &addr, int64_t bantimeoffset) {
     LOCK(cs_setBanned);
     if (setBanned[addr] < banTime)
         setBanned[addr] = banTime;
-
-    return true;
 }
 
 bool CNode::Unban(const CNetAddr &addr) {

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -458,14 +458,29 @@ bool CNode::IsBanned(CNetAddr ip)
     return fResult;
 }
 
-bool CNode::Ban(const CNetAddr &addr) {
+bool CNode::Ban(const CNetAddr &addr, int64_t bantimeoffset) {
     int64_t banTime = GetTime()+GetArg("-bantime", 60*60*24);  // Default 24-hour ban
-    {
-        LOCK(cs_setBanned);
-        if (setBanned[addr] < banTime)
-            setBanned[addr] = banTime;
-    }
+    if (bantimeoffset > 0)
+        banTime = GetTime()+bantimeoffset;
+
+    LOCK(cs_setBanned);
+    if (setBanned[addr] < banTime)
+        setBanned[addr] = banTime;
+
     return true;
+}
+
+bool CNode::Unban(const CNetAddr &addr) {
+    LOCK(cs_setBanned);
+    if (setBanned.erase(addr))
+        return true;
+    return false;
+}
+
+void CNode::GetBanned(std::map<CNetAddr, int64_t> &banMap)
+{
+    LOCK(cs_setBanned);
+    banMap = setBanned; //create a thread safe copy
 }
 
 

--- a/src/net.h
+++ b/src/net.h
@@ -66,6 +66,7 @@ unsigned int SendBufferSize();
 void AddOneShot(const std::string& strDest);
 void AddressCurrentlyConnected(const CService& addr);
 CNode* FindNode(const CNetAddr& ip);
+CNode* FindNode(const CSubNet& subNet);
 CNode* FindNode(const std::string& addrName);
 CNode* FindNode(const CService& ip);
 CNode* ConnectNode(CAddress addrConnect, const char *pszDest = NULL);
@@ -284,7 +285,7 @@ protected:
 
     // Denial-of-service detection/prevention
     // Key is IP address, value is banned-until-time
-    static std::map<CNetAddr, int64_t> setBanned;
+    static std::map<CSubNet, int64_t> setBanned;
     static CCriticalSection cs_setBanned;
 
     // Whitelisted ranges. Any node connecting from these is automatically
@@ -606,9 +607,12 @@ public:
     // new code.
     static void ClearBanned(); // needed for unit testing
     static bool IsBanned(CNetAddr ip);
+    static bool IsBanned(CSubNet subnet);
     static void Ban(const CNetAddr &ip, int64_t bantimeoffset = 0);
+    static void Ban(const CSubNet &subNet, int64_t bantimeoffset = 0);
     static bool Unban(const CNetAddr &ip);
-    static void GetBanned(std::map<CNetAddr, int64_t> &banmap);
+    static bool Unban(const CSubNet &ip);
+    static void GetBanned(std::map<CSubNet, int64_t> &banmap);
 
     void copyStats(CNodeStats &stats);
 

--- a/src/net.h
+++ b/src/net.h
@@ -606,7 +606,7 @@ public:
     // new code.
     static void ClearBanned(); // needed for unit testing
     static bool IsBanned(CNetAddr ip);
-    static bool Ban(const CNetAddr &ip, int64_t bantimeoffset = 0);
+    static void Ban(const CNetAddr &ip, int64_t bantimeoffset = 0);
     static bool Unban(const CNetAddr &ip);
     static void GetBanned(std::map<CNetAddr, int64_t> &banmap);
 

--- a/src/net.h
+++ b/src/net.h
@@ -606,7 +606,10 @@ public:
     // new code.
     static void ClearBanned(); // needed for unit testing
     static bool IsBanned(CNetAddr ip);
-    static bool Ban(const CNetAddr &ip);
+    static bool Ban(const CNetAddr &ip, int64_t bantimeoffset = 0);
+    static bool Unban(const CNetAddr &ip);
+    static void GetBanned(std::map<CNetAddr, int64_t> &banmap);
+
     void copyStats(CNodeStats &stats);
 
     static bool IsWhitelistedRange(const CNetAddr &ip);

--- a/src/net.h
+++ b/src/net.h
@@ -608,8 +608,8 @@ public:
     static void ClearBanned(); // needed for unit testing
     static bool IsBanned(CNetAddr ip);
     static bool IsBanned(CSubNet subnet);
-    static void Ban(const CNetAddr &ip, int64_t bantimeoffset = 0);
-    static void Ban(const CSubNet &subNet, int64_t bantimeoffset = 0);
+    static void Ban(const CNetAddr &ip, int64_t bantimeoffset = 0, bool sinceUnixEpoch = false);
+    static void Ban(const CSubNet &subNet, int64_t bantimeoffset = 0, bool sinceUnixEpoch = false);
     static bool Unban(const CNetAddr &ip);
     static bool Unban(const CSubNet &ip);
     static void GetBanned(std::map<CSubNet, int64_t> &banmap);

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -1332,7 +1332,7 @@ bool operator!=(const CSubNet& a, const CSubNet& b)
 
 bool operator<(const CSubNet& a, const CSubNet& b)
 {
-    return (a.network < b.network || (a.network == b.network && memcmp(a.netmask, b.netmask, 16)));
+    return (a.network < b.network || (a.network == b.network && memcmp(a.netmask, b.netmask, 16) < 0));
 }
 
 #ifdef WIN32

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -1330,6 +1330,11 @@ bool operator!=(const CSubNet& a, const CSubNet& b)
     return !(a==b);
 }
 
+bool operator<(const CSubNet& a, const CSubNet& b)
+{
+    return (a.network < b.network || (a.network == b.network && memcmp(a.netmask, b.netmask, 16)));
+}
+
 #ifdef WIN32
 std::string NetworkErrorString(int err)
 {

--- a/src/netbase.h
+++ b/src/netbase.h
@@ -125,6 +125,7 @@ class CSubNet
 
         friend bool operator==(const CSubNet& a, const CSubNet& b);
         friend bool operator!=(const CSubNet& a, const CSubNet& b);
+        friend bool operator<(const CSubNet& a, const CSubNet& b);
 };
 
 /** A combination of a network address (CNetAddr) and a (TCP) port */

--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -93,6 +93,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "estimatepriority", 0 },
     { "prioritisetransaction", 1 },
     { "prioritisetransaction", 2 },
+    { "setban", 2 },
 };
 
 class CRPCConvertTable

--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -94,6 +94,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "prioritisetransaction", 1 },
     { "prioritisetransaction", 2 },
     { "setban", 2 },
+    { "setban", 3 },
 };
 
 class CRPCConvertTable

--- a/src/rpcnet.cpp
+++ b/src/rpcnet.cpp
@@ -466,7 +466,7 @@ UniValue getnetworkinfo(const UniValue& params, bool fHelp)
     return obj;
 }
 
-Value setban(const Array& params, bool fHelp)
+UniValue setban(const UniValue& params, bool fHelp)
 {
     string strCommand;
     if (params.size() >= 2)
@@ -474,12 +474,13 @@ Value setban(const Array& params, bool fHelp)
     if (fHelp || params.size() < 2 ||
         (strCommand != "add" && strCommand != "remove"))
         throw runtime_error(
-                            "setban \"ip(/netmask)\" \"add|remove\" (bantime)\n"
+                            "setban \"ip(/netmask)\" \"add|remove\" (bantime) (absolute)\n"
                             "\nAttempts add or remove a IP/Subnet from the banned list.\n"
                             "\nArguments:\n"
                             "1. \"ip(/netmask)\" (string, required) The IP/Subnet (see getpeerinfo for nodes ip) with a optional netmask (default is /32 = single ip)\n"
                             "2. \"command\"      (string, required) 'add' to add a IP/Subnet to the list, 'remove' to remove a IP/Subnet from the list\n"
-                            "1. \"bantime\"      (numeric, optional) time in seconds how long the ip is banned (0 or empty means using the default time of 24h which can also be overwritten by the -bantime startup argument)\n"
+                            "3. \"bantime\"      (numeric, optional) time in seconds how long (or until when if [absolute] is set) the ip is banned (0 or empty means using the default time of 24h which can also be overwritten by the -bantime startup argument)\n"
+                            "4. \"absolute\"     (boolean, optional) If set, the bantime must be a absolute timestamp in seconds since epoch (Jan 1 1970 GMT)\n"
                             "\nExamples:\n"
                             + HelpExampleCli("setban", "\"192.168.0.6\" \"add\" 86400")
                             + HelpExampleCli("setban", "\"192.168.0.0/24\" \"add\"")
@@ -507,10 +508,14 @@ Value setban(const Array& params, bool fHelp)
             throw JSONRPCError(RPC_CLIENT_NODE_ALREADY_ADDED, "Error: IP/Subnet already banned");
 
         int64_t banTime = 0; //use standard bantime if not specified
-        if (params.size() == 3 && !params[2].is_null())
+        if (params.size() >= 3 && !params[2].isNull())
             banTime = params[2].get_int64();
 
-        isSubnet ? CNode::Ban(subNet, banTime) : CNode::Ban(netAddr, banTime);
+        bool absolute = false;
+        if (params.size() == 4 && params[3].isTrue())
+            absolute = true;
+
+        isSubnet ? CNode::Ban(subNet, banTime, absolute) : CNode::Ban(netAddr, banTime, absolute);
 
         //disconnect possible nodes
         while(CNode *bannedNode = (isSubnet ? FindNode(subNet) : FindNode(netAddr)))
@@ -522,10 +527,10 @@ Value setban(const Array& params, bool fHelp)
             throw JSONRPCError(RPC_CLIENT_NODE_ALREADY_ADDED, "Error: Unban failed");
     }
 
-    return Value::null;
+    return NullUniValue;
 }
 
-Value listbanned(const Array& params, bool fHelp)
+UniValue listbanned(const UniValue& params, bool fHelp)
 {
     if (fHelp || params.size() != 0)
         throw runtime_error(
@@ -539,10 +544,10 @@ Value listbanned(const Array& params, bool fHelp)
     std::map<CSubNet, int64_t> banMap;
     CNode::GetBanned(banMap);
 
-    Array bannedAddresses;
+    UniValue bannedAddresses(UniValue::VARR);
     for (std::map<CSubNet, int64_t>::iterator it = banMap.begin(); it != banMap.end(); it++)
     {
-        Object rec;
+        UniValue rec(UniValue::VOBJ);
         rec.push_back(Pair("address", (*it).first.ToString()));
         rec.push_back(Pair("banned_untill", (*it).second));
         bannedAddresses.push_back(rec);
@@ -551,7 +556,7 @@ Value listbanned(const Array& params, bool fHelp)
     return bannedAddresses;
 }
 
-Value clearbanned(const Array& params, bool fHelp)
+UniValue clearbanned(const UniValue& params, bool fHelp)
 {
     if (fHelp || params.size() != 0)
         throw runtime_error(
@@ -564,5 +569,5 @@ Value clearbanned(const Array& params, bool fHelp)
 
     CNode::ClearBanned();
 
-    return Value::null;
+    return NullUniValue;
 }

--- a/src/rpcnet.cpp
+++ b/src/rpcnet.cpp
@@ -544,7 +544,7 @@ Value listbanned(const Array& params, bool fHelp)
     {
         Object rec;
         rec.push_back(Pair("address", (*it).first.ToString()));
-        rec.push_back(Pair("bannedtill", (*it).second));
+        rec.push_back(Pair("banned_untill", (*it).second));
         bannedAddresses.push_back(rec);
     }
 

--- a/src/rpcnet.cpp
+++ b/src/rpcnet.cpp
@@ -524,7 +524,7 @@ UniValue setban(const UniValue& params, bool fHelp)
     else if(strCommand == "remove")
     {
         if (!( isSubnet ? CNode::Unban(subNet) : CNode::Unban(netAddr) ))
-            throw JSONRPCError(RPC_CLIENT_NODE_ALREADY_ADDED, "Error: Unban failed");
+            throw JSONRPCError(RPC_MISC_ERROR, "Error: Unban failed");
     }
 
     return NullUniValue;

--- a/src/rpcprotocol.h
+++ b/src/rpcprotocol.h
@@ -64,6 +64,7 @@ enum RPCErrorCode
     RPC_CLIENT_NODE_ALREADY_ADDED   = -23, //! Node is already added
     RPC_CLIENT_NODE_NOT_ADDED       = -24, //! Node has not been added before
     RPC_CLIENT_NODE_NOT_CONNECTED   = -29, //! Node to disconnect not found in connected nodes
+    RPC_CLIENT_INVALID_IP_OR_SUBNET = -30, //! Invalid IP/Subnet
 
     //! Wallet errors
     RPC_WALLET_ERROR                = -4,  //! Unspecified problem with wallet (key not found etc.)

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -279,6 +279,9 @@ static const CRPCCommand vRPCCommands[] =
     { "network",            "getnettotals",           &getnettotals,           true  },
     { "network",            "getpeerinfo",            &getpeerinfo,            true  },
     { "network",            "ping",                   &ping,                   true  },
+    { "network",            "setban",                 &setban,                 true  },
+    { "network",            "listbanned",             &listbanned,             true  },
+    { "network",            "clearbanned",            &clearbanned,            true  },
 
     /* Block chain and UTXO */
     { "blockchain",         "getblockchaininfo",      &getblockchaininfo,      true  },

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -154,9 +154,9 @@ extern UniValue addnode(const UniValue& params, bool fHelp);
 extern UniValue disconnectnode(const UniValue& params, bool fHelp);
 extern UniValue getaddednodeinfo(const UniValue& params, bool fHelp);
 extern UniValue getnettotals(const UniValue& params, bool fHelp);
-extern UniValue setban(const json_spirit::Array& params, bool fHelp);
-extern UniValue listbanned(const json_spirit::Array& params, bool fHelp);
-extern UniValue clearbanned(const json_spirit::Array& params, bool fHelp);
+extern UniValue setban(const UniValue& params, bool fHelp);
+extern UniValue listbanned(const UniValue& params, bool fHelp);
+extern UniValue clearbanned(const UniValue& params, bool fHelp);
 
 extern UniValue dumpprivkey(const UniValue& params, bool fHelp); // in rpcdump.cpp
 extern UniValue importprivkey(const UniValue& params, bool fHelp);

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -154,6 +154,9 @@ extern UniValue addnode(const UniValue& params, bool fHelp);
 extern UniValue disconnectnode(const UniValue& params, bool fHelp);
 extern UniValue getaddednodeinfo(const UniValue& params, bool fHelp);
 extern UniValue getnettotals(const UniValue& params, bool fHelp);
+extern UniValue setban(const json_spirit::Array& params, bool fHelp);
+extern UniValue listbanned(const json_spirit::Array& params, bool fHelp);
+extern UniValue clearbanned(const json_spirit::Array& params, bool fHelp);
 
 extern UniValue dumpprivkey(const UniValue& params, bool fHelp); // in rpcdump.cpp
 extern UniValue importprivkey(const UniValue& params, bool fHelp);

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -177,4 +177,13 @@ BOOST_AUTO_TEST_CASE(rpc_boostasiotocnetaddr)
     BOOST_CHECK_EQUAL(BoostAsioToCNetAddr(boost::asio::ip::address::from_string("::ffff:127.0.0.1")).ToString(), "127.0.0.1");
 }
 
+BOOST_AUTO_TEST_CASE(rpc_ban)
+{
+    BOOST_CHECK_NO_THROW(CallRPC(string("setban 127.0.0.1 add")));
+    BOOST_CHECK_THROW(CallRPC(string("setban 127.0.0.1:8334")), runtime_error); //portnumber for setban not allowed
+    BOOST_CHECK_NO_THROW(CallRPC(string("listbanned")));
+    BOOST_CHECK_NO_THROW(CallRPC(string("setban 127.0.0.1 remove")));
+    BOOST_CHECK_NO_THROW(CallRPC(string("clearbanned")));
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -181,25 +181,40 @@ BOOST_AUTO_TEST_CASE(rpc_ban)
 {
     BOOST_CHECK_NO_THROW(CallRPC(string("clearbanned")));
     
-    Value r;
+    UniValue r;
     BOOST_CHECK_NO_THROW(r = CallRPC(string("setban 127.0.0.0 add")));
     BOOST_CHECK_THROW(r = CallRPC(string("setban 127.0.0.0:8334")), runtime_error); //portnumber for setban not allowed
     BOOST_CHECK_NO_THROW(r = CallRPC(string("listbanned")));
-    Array ar = r.get_array();
-    Object o1 = ar[0].get_obj();
-    Value adr = find_value(o1, "address");
+    UniValue ar = r.get_array();
+    UniValue o1 = ar[0].get_obj();
+    UniValue adr = find_value(o1, "address");
     BOOST_CHECK_EQUAL(adr.get_str(), "127.0.0.0/255.255.255.255");
     BOOST_CHECK_NO_THROW(CallRPC(string("setban 127.0.0.0 remove")));;
     BOOST_CHECK_NO_THROW(r = CallRPC(string("listbanned")));
     ar = r.get_array();
     BOOST_CHECK_EQUAL(ar.size(), 0);
 
-    BOOST_CHECK_NO_THROW(r = CallRPC(string("setban 127.0.0.0/24 add")));
+    BOOST_CHECK_NO_THROW(r = CallRPC(string("setban 127.0.0.0/24 add 1607731200 true")));
     BOOST_CHECK_NO_THROW(r = CallRPC(string("listbanned")));
     ar = r.get_array();
     o1 = ar[0].get_obj();
     adr = find_value(o1, "address");
+    UniValue banned_until = find_value(o1, "banned_untill");
     BOOST_CHECK_EQUAL(adr.get_str(), "127.0.0.0/255.255.255.0");
+    BOOST_CHECK_EQUAL(banned_until.get_int64(), 1607731200); // absolute time check
+
+    BOOST_CHECK_NO_THROW(CallRPC(string("clearbanned")));
+
+    BOOST_CHECK_NO_THROW(r = CallRPC(string("setban 127.0.0.0/24 add 200")));
+    BOOST_CHECK_NO_THROW(r = CallRPC(string("listbanned")));
+    ar = r.get_array();
+    o1 = ar[0].get_obj();
+    adr = find_value(o1, "address");
+    banned_until = find_value(o1, "banned_untill");
+    BOOST_CHECK_EQUAL(adr.get_str(), "127.0.0.0/255.255.255.0");
+    int64_t now = GetTime();    
+    BOOST_CHECK(banned_until.get_int64() > now);
+    BOOST_CHECK(banned_until.get_int64()-now <= 200);
 
     // must throw an exception because 127.0.0.1 is in already banned suubnet range
     BOOST_CHECK_THROW(r = CallRPC(string("setban 127.0.0.1 add")), runtime_error);


### PR DESCRIPTION
Groundwork for #5866.
If this makes it into master i'd like to add a GUI context menu for the peers table.
A simple disconnect (without banning) would be possible with `setban <ip> add 1` (where 1 is the bantime).

At the moment the banned set does not survive a restart (should be added once).
Also currently banning is per IP and not per Node which results in disconnecting all nodes of a given IP (if the nodes uses the same ip but different ports).

Also includes some whitespace fixes for `httpbasics.py` test.
