### PR TITLE
[QT] remove movable option for toolbar

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -414,6 +414,7 @@ void BitcoinGUI::createToolBars()
     if(walletFrame)
     {
         QToolBar *toolbar = addToolBar(tr("Tabs toolbar"));
+        toolbar->setMovable(false);
         toolbar->setToolButtonStyle(Qt::ToolButtonTextBesideIcon);
         toolbar->addAction(overviewAction);
         toolbar->addAction(sendCoinsAction);


### PR DESCRIPTION
I don't see any reason why the toolbar should be movable. It can result in ugly situations and could prevent from improving the UX.

![bildschirmfoto 2015-05-19 um 17 22 22](https://cloud.githubusercontent.com/assets/178464/7706642/f4b19912-fe4b-11e4-8adc-4b04bd8c62c3.png)

![bildschirmfoto 2015-05-19 um 17 20 34](https://cloud.githubusercontent.com/assets/178464/7706645/f762ca1e-fe4b-11e4-9e36-be73348637bb.png)
