### PR TITLE
Use 512-bit arithmetic for difficulty retarget calculation.

### DIFF
--- a/qa/pull-tester/rpc-tests.sh
+++ b/qa/pull-tester/rpc-tests.sh
@@ -35,6 +35,7 @@ testScripts=(
     'invalidblockrequest.py'
     'rawtransactions.py'
 #    'forknotify.py'
+#    'retarget-overflow.py'
 );
 if [ "x${ENABLE_BITCOIND}${ENABLE_UTILS}${ENABLE_WALLET}" = "x111" ]; then
     for (( i = 0; i < ${#testScripts[@]}; i++ ))

--- a/qa/rpc-tests/mininode.py
+++ b/qa/rpc-tests/mininode.py
@@ -110,6 +110,20 @@ def uint256_from_compact(c):
     return v
 
 
+def compact_from_uint256(v):
+    nbytes = (v.bit_length() + 7) / 8;
+    c = 0
+    if nbytes <= 3:
+        c = (v & 0xFFFFFFFF) << (8 * (3 - nbytes))
+    else:
+        c = v >> 8 * (nbytes - 3)
+    if c & 0x00800000:
+        c >>= 8
+        nbytes += 1
+    c |= nbytes << 24
+    return c
+
+
 def deser_vector(f, c):
     nit = struct.unpack("<B", f.read(1))[0]
     if nit == 253:

--- a/qa/rpc-tests/retarget-overflow.py
+++ b/qa/rpc-tests/retarget-overflow.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python2
+# Copyright (c) 2015 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#
+# Test that the difficulty retarget calculation cannot overflow
+# a 256-bit unsigned integer.
+#
+
+from test_framework import BitcoinTestFramework
+from util import *
+from mininode import compact_from_uint256, uint256_from_compact
+
+class RetargetOverflowTest(BitcoinTestFramework):
+    def setup_chain(self):
+        print("Initializing test directory "+self.options.tmpdir)
+        initialize_chain_clean(self.options.tmpdir, 2)
+
+    def setup_network(self, split=False):
+        self.nodes = start_nodes(2, self.options.tmpdir)
+
+        connect_nodes_bi(self.nodes,0,1)
+
+        self.is_network_split=False
+        self.sync_all()
+
+    def run_test(self):
+        # Generate a single block to leave IBD.  Without this, calls to
+        # getblocktemplate will fail.
+        self.nodes[0].generate(1)
+
+        # Fetch the first hash target.  This test is only valid for the
+        # regression test network, since the POW limits for main and
+        # testnet are too low to expose the overflow.
+        gbtResp = self.nodes[0].getblocktemplate()
+        prevTargetStr = gbtResp["target"]
+        assert_equal(prevTargetStr, "7fffff0000000000000000000000000000000000000000000000000000000000")
+        prevTarget = int(prevTargetStr, 16)
+        
+        # For 10 minute blocks and a target of 2 weeks between difficulty
+        # retargets, the first retarget will occur at block 2016
+        # (60 mins/hr * 24 hrs/day * 7 days/wk * 2 wks / 10 mins/block = 2016 blocks).
+        # Generate one less than this, and then verify that the next
+        # difficulty is within the expected bounds (indicating that the
+        # calculation did not ovewflow).
+        #
+        # One block has already been generated above to leave IBD, so only
+        # generate 2014 more.
+        #
+        # Use multiple calls to avoid RPC timeout in slow test environments.
+        self.nodes[0].generate(500)
+        self.nodes[0].generate(500)
+        self.nodes[0].generate(500)
+        self.nodes[0].generate(500)
+        self.nodes[0].generate(14)  # now at height 2015
+
+        # Fetch the next target difficulty for block 2016.
+        gbtResp = self.nodes[0].getblocktemplate()
+        retargetDifficultyStr = gbtResp["target"]
+        retargetDifficulty = int(retargetDifficultyStr, 16)
+
+        # A difficutly retarget should result in the next difficulty in
+        # the range [previous/4, previous*4].  However, since this is the
+        # first retarget, and the difficulty can never exceed the networks's
+        # POW limit, the next difficulty must be in [previous/4, compact(powLimit)].
+        minimum = uint256_from_compact(compact_from_uint256(prevTarget / 4))
+        maximum = uint256_from_compact(compact_from_uint256(prevTarget))
+        if retargetDifficulty < minimum or retargetDifficulty > maximum:
+            raise AssertionError("Retarget difficulty %s outside expected range (possible overflow detected)"%(retargetDifficultyStr))
+        prevTarget = retargetDifficulty
+
+        # Test a second retarget for block 4032.  While the first retarget
+        # likely kept the same difficulty due to the very early regtest
+        # genesis block timestamp, resulting in a very long timespan between
+        # retargets, the next retarget should use the timestamp in block 2016
+        # and have a very short timespan.
+        self.nodes[0].generate(500)
+        self.nodes[0].generate(500)
+        self.nodes[0].generate(500)
+        self.nodes[0].generate(500)
+        self.nodes[0].generate(16) # now at height 4031
+        
+        gbtResp = self.nodes[0].getblocktemplate()
+        retargetDifficultyStr = gbtResp["target"]
+        retargetDifficulty = int(retargetDifficultyStr, 16)
+
+        minimum = uint256_from_compact(compact_from_uint256(prevTarget / 4))
+        maximum = uint256_from_compact(compact_from_uint256(prevTarget))
+        if retargetDifficulty < minimum or retargetDifficulty > maximum:
+            raise AssertionError("Retarget difficulty %s outside expected range (possible overflow detected)"%(retargetDifficultyStr))
+
+if __name__ == '__main__':
+    RetargetOverflowTest().main()

--- a/src/arith_uint256.cpp
+++ b/src/arith_uint256.cpp
@@ -199,6 +199,11 @@ template void base_uint<256>::SetHex(const char*);
 template void base_uint<256>::SetHex(const std::string&);
 template unsigned int base_uint<256>::bits() const;
 
+// Instantiations for base_uint<512>
+template base_uint<512>& base_uint<512>::operator*=(unsigned int);
+template base_uint<512>& base_uint<512>::operator/=(const base_uint<512>& b);
+template int base_uint<512>::CompareTo(const base_uint<512>&) const;
+
 // This implementation directly uses shifts instead of going
 // through an intermediate MPI representation.
 arith_uint256& arith_uint256::SetCompact(uint32_t nCompact, bool* pfNegative, bool* pfOverflow)

--- a/src/arith_uint256.h
+++ b/src/arith_uint256.h
@@ -6,6 +6,7 @@
 #ifndef BITCOIN_ARITH_UINT256_H
 #define BITCOIN_ARITH_UINT256_H
 
+#include <algorithm>
 #include <assert.h>
 #include <cstring>
 #include <stdexcept>
@@ -24,6 +25,9 @@ public:
 template<unsigned int BITS>
 class base_uint
 {
+    template <unsigned int B>
+    friend class base_uint;
+
 protected:
     enum { WIDTH=BITS/32 };
     uint32_t pn[WIDTH];
@@ -39,6 +43,15 @@ public:
     {
         for (int i = 0; i < WIDTH; i++)
             pn[i] = b.pn[i];
+    }
+
+    template<unsigned int B>
+    static base_uint from_other_size(const base_uint<B>& b)
+    {
+        base_uint ret;
+        for (int i = 0; i < std::min((int)WIDTH, (int)b.WIDTH); i++)
+            ret.pn[i] = b.pn[i];
+        return ret;
     }
 
     base_uint& operator=(const base_uint& b)
@@ -282,6 +295,12 @@ public:
 
     friend uint256 ArithToUint256(const arith_uint256 &);
     friend arith_uint256 UintToArith256(const uint256 &);
+};
+
+class arith_uint512 : public base_uint<512> {
+public:
+    arith_uint512() {}
+    arith_uint512(const base_uint<512>& b) : base_uint<512>(b) {}
 };
 
 uint256 ArithToUint256(const arith_uint256 &);

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -62,15 +62,19 @@ unsigned int CalculateNextWorkRequired(const CBlockIndex* pindexLast, int64_t nF
 
     // Retarget
     const arith_uint256 bnPowLimit = UintToArith256(params.powLimit);
+    const arith_uint512 bnPowLimit512 = arith_uint512::from_other_size(bnPowLimit);
     arith_uint256 bnNew;
     arith_uint256 bnOld;
     bnNew.SetCompact(pindexLast->nBits);
     bnOld = bnNew;
-    bnNew *= nActualTimespan;
-    bnNew /= params.nPowTargetTimespan;
+    arith_uint512 bnNew512 = arith_uint512::from_other_size(bnNew);
+    bnNew512 *= nActualTimespan;
+    bnNew512 /= params.nPowTargetTimespan;
 
-    if (bnNew > bnPowLimit)
-        bnNew = bnPowLimit;
+    if (bnNew512 > bnPowLimit512)
+        bnNew512 = bnPowLimit512;
+
+    bnNew = arith_uint256::from_other_size(bnNew512);
 
     /// debug print
     LogPrintf("GetNextWorkRequired RETARGET\n");


### PR DESCRIPTION
This prevents an integer overflow during the difficulty retarget
calculation, and fixes a consensus-changing bug introduced by
df9eb5e14fa8072bc8a82b59e712c2ba36f13f4c.  While it is not possible to
hit this consensus bug on mainnet or testnet3 due to the higher
current difficulties, it is easily hit on regtest after generating
2016 blocks, forcing the retarget.

~~Note: to convert between the arith_uint256 and arith_uint512 classes, I created a new static function in the base_uint base class that copies the data from one to the other.  However, to do this, I had to make the protected members `WIDTH` and `pn` public, so they could be accessed.  Not too happy with this, and I think that I need to use `friend` to allow access, but I'm not sure exactly how to do that.  Suggestions welcome.~~
