### PR TITLE
build: fix osx determinism for OSX

### DIFF
--- a/contrib/gitian-descriptors/gitian-osx-bitcoin.yml
+++ b/contrib/gitian-descriptors/gitian-osx-bitcoin.yml
@@ -18,8 +18,8 @@ remotes:
   "dir": "bitcoin"
 files:
 - "osx-native-depends-r3.tar.gz"
-- "osx-depends-r7.tar.gz"
-- "osx-depends-qt-5.2.1-r6.tar.gz"
+- "osx-depends-r8.tar.gz"
+- "osx-depends-qt-5.2.1-r7.tar.gz"
 - "MacOSX10.7.sdk.tar.gz"
 
 script: |
@@ -37,8 +37,8 @@ script: |
   tar -C osx-cross-depends/SDKs -xf ${SOURCES_PATH}/MacOSX10.7.sdk.tar.gz
 
   tar -C osx-cross-depends -xf osx-native-depends-r3.tar.gz
-  tar -C osx-cross-depends -xf osx-depends-r7.tar.gz
-  tar -C osx-cross-depends -xf osx-depends-qt-5.2.1-r6.tar.gz
+  tar -C osx-cross-depends -xf osx-depends-r8.tar.gz
+  tar -C osx-cross-depends -xf osx-depends-qt-5.2.1-r7.tar.gz
   export PATH=`pwd`/osx-cross-depends/native-prefix/bin:$PATH
 
   cd bitcoin

--- a/contrib/gitian-descriptors/gitian-osx-depends.yml
+++ b/contrib/gitian-descriptors/gitian-osx-depends.yml
@@ -30,7 +30,7 @@ script: |
   echo "13bfc5ae543cf3aa180ac2485c0bc89495e3ae711fc6fab4f8ffe90dfb4bb677  protobuf-2.5.0.tar.bz2" | sha256sum -c
   echo "dfd71487513c871bad485806bfd1fdb304dedc84d2b01a8fb8e0940b50597a98  qrencode-3.4.3.tar.bz2" | sha256sum -c
 
-  REVISION=r7
+  REVISION=r8
   export SOURCES_PATH=`pwd`
   export TAR_OPTIONS="-m --mtime="$REFERENCE_DATE\\\ $REFERENCE_TIME""
   export PATH=$HOME:$PATH
@@ -95,9 +95,9 @@ script: |
   pushd ${BUILD_DIR}
   sed -ie "s|cc:|${INT_CC}:|" ${BUILD_DIR}/Configure
   sed -ie "s|\(-arch [_a-zA-Z0-9]*\)|\1 --sysroot ${SDK}  -target ${HOST} -msse2|" ${BUILD_DIR}/Configure
+  sed -i "/define DATE/d" ${BUILD_DIR}/util/mkbuildinf.pl
+  sed -i "s|engines apps test|engines|" ${BUILD_DIR}/Makefile.org
   AR="${INT_AR}" RANLIB="${INT_RANLIB}" ./Configure --prefix=${PREFIX} --openssldir=${PREFIX}/etc/openssl zlib shared no-krb5 darwin64-x86_64-cc ${INT_LDFLAGS} ${INT_CLANG_LDFLAGS} ${INT_CPPFLAGS}
-  sed -i "s|engines apps test|engines|" ${BUILD_DIR}/Makefile
-  sed -i "/define DATE/d" ${BUILD_DIR}/crypto/Makefile
   make -j1 build_libs libcrypto.pc libssl.pc openssl.pc
   make -j1 install_sw
   popd

--- a/contrib/gitian-descriptors/gitian-osx-qt.yml
+++ b/contrib/gitian-descriptors/gitian-osx-qt.yml
@@ -14,14 +14,14 @@ remotes: []
 files:
 - "qt-everywhere-opensource-src-5.2.1.tar.gz"
 - "osx-native-depends-r3.tar.gz"
-- "osx-depends-r7.tar.gz"
+- "osx-depends-r8.tar.gz"
 - "MacOSX10.7.sdk.tar.gz"
 
 script: |
 
   echo "84e924181d4ad6db00239d87250cc89868484a14841f77fb85ab1f1dbdcd7da1  qt-everywhere-opensource-src-5.2.1.tar.gz" | sha256sum -c
 
-  REVISION=r6
+  REVISION=r7
   export SOURCES_PATH=`pwd`
   export TAR_OPTIONS="-m --mtime="$REFERENCE_DATE\\\ $REFERENCE_TIME""
   export ZERO_AR_DATE=1
@@ -73,7 +73,7 @@ script: |
   tar xf /home/ubuntu/build/osx-native-depends-r3.tar.gz
 
   export PATH=`pwd`/native-prefix/bin:$PATH
-  tar xf /home/ubuntu/build/osx-depends-r7.tar.gz
+  tar xf /home/ubuntu/build/osx-depends-r8.tar.gz
 
   SOURCE_FILE=${SOURCES_PATH}/qt-everywhere-opensource-src-5.2.1.tar.gz
   BUILD_DIR=${BUILD_BASE}/qt-everywhere-opensource-src-5.2.1


### PR DESCRIPTION
v0.9.5rc1 is not deterministic for OSX. I believe this is enough to fix that.

Backport of 90c71548c795787b008bc337cb9332f75d1bccdb

Linux/Windows wrapped 'date' rather than patching the OpenSSL build.
