### PR TITLE
Fix intermittent issue in scheduler_tests

### DIFF
--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -29,8 +29,6 @@ void CScheduler::serviceQueue()
 {
     boost::unique_lock<boost::mutex> lock(newTaskMutex);
     ++nThreadsServicingQueue;
-    stopRequested = false;
-    stopWhenEmpty = false;
 
     // newTaskMutex is locked throughout this loop EXCEPT
     // when the thread is waiting or when the user's function


### PR DESCRIPTION
Don't clear `stopRequested` and `stopWhenEmpty` at the top of `serviceQueue`, as this results in a race condition: on systems under heavy load, some of the threads only get scheduled on the CPU when the other threads have already finished their work. This causes the flags to be cleared post-hoc and thus those threads to wait forever.

The potential drawback of this change is that the scheduler cannot be restarted after being stopped (an explicit `reset` method would be needed), but we don't use this functionality anyway.
