### PR TITLE
Ignore getheaders requests when not synced

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4174,6 +4174,9 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
 
         LOCK(cs_main);
 
+        if (IsInitialBlockDownload())
+            return true;
+
         CBlockIndex* pindex = NULL;
         if (locator.IsNull())
         {


### PR DESCRIPTION
Sending headers suggests to our peers that they can download from us, so don't respond to getheaders requests while in initial block download (just as we don't relay blocks on tip updates either).
