### PR TITLE
Chainparams: Explicit CMessageHeader::MessageStartChars to functions in main:

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -362,7 +362,7 @@ public:
 
 
 /** Functions for disk access for blocks */
-bool WriteBlockToDisk(CBlock& block, CDiskBlockPos& pos);
+bool WriteBlockToDisk(CBlock& block, CDiskBlockPos& pos, const CMessageHeader::MessageStartChars& messageStart);
 bool ReadBlockFromDisk(CBlock& block, const CDiskBlockPos& pos);
 bool ReadBlockFromDisk(CBlock& block, const CBlockIndex* pindex);
 


### PR DESCRIPTION
-UndoWriteToDisk
-WriteBlockToDisk

It also contains a commit from #5669 (to avoid the later rebase conflict if that gets merged sooner).
