### PR TITLE
Refactor EvalScript into a CScriptExecution class, so single-stepping can be done

### DIFF
--- a/src/script/bitcoinconsensus.cpp
+++ b/src/script/bitcoinconsensus.cpp
@@ -7,6 +7,7 @@
 
 #include "primitives/transaction.h"
 #include "script/interpreter.h"
+#include "script/script_error.h"
 #include "version.h"
 
 namespace {
@@ -102,7 +103,226 @@ bool bitcoinconsensus_parse_txTo(bitcoinconsensus_txTo_sigchecker& o, const unsi
     return true;
 }
 
+typedef std::vector<unsigned char> valtype;
+typedef std::vector<valtype> bitcoinconsensus_stack_t;
+
+class bitcoinconsensus_script_execution_data {
+public:
+    CScriptExecution *sexec;
+    bitcoinconsensus_stack_t stack;
+    CScript script;
+    ScriptError serror;
+    bitcoinconsensus_txTo_sigchecker tsc;
+
+    bitcoinconsensus_script_execution_data() : sexec(NULL) { }
+
+    ~bitcoinconsensus_script_execution_data() {
+        delete sexec;
+    };
+
+    bool parse_stackPos(bitcoinconsensus_stack_t*& stackp, bitcoinconsensus_script_execution_stack stackid, int& stackPos, bool allowEnd)
+    {
+        switch (stackid)
+        {
+            case bitcoinconsensus_SEXEC_STACK:
+                stackp = &stack;
+                break;
+            case bitcoinconsensus_SEXEC_ALTSTACK:
+                if (!sexec)
+                    return false;
+                stackp = &sexec->altstack;
+                break;
+            default:
+                return false;
+        }
+
+        if (stackPos < 0)
+        {
+            stackPos = stackp->size() + stackPos + 1;
+            if (stackPos < 0)
+                return false;
+        }
+        if ((unsigned int)stackPos + (allowEnd ? 0 : 1) > stackp->size())
+            return false;
+
+        return true;
+    }
+
+    void Terminate() {
+        delete sexec;
+        sexec = NULL;
+    };
+};
+
+
 } // anon namespace
+
+bitcoinconsensus_script_execution_t *bitcoinconsensus_script_execution(const unsigned char *script, unsigned int scriptLen, const unsigned char *txTo, unsigned int txToLen, unsigned int nIn, bitcoinconsensus_error* err)
+{
+    bitcoinconsensus_script_execution_data *o = NULL;
+    try {
+        o = new bitcoinconsensus_script_execution_data();
+
+        {
+            std::vector<unsigned char> vchScript;
+            vchScript.assign(script, &script[scriptLen]);
+            o->script = CScript(vchScript);
+        }
+
+        if (txTo) {
+            if (!bitcoinconsensus_parse_txTo(o->tsc, txTo, txToLen, nIn, err))
+                return NULL;
+        } else {
+            o->tsc.checker = new BaseSignatureChecker();
+        }
+
+        return (bitcoinconsensus_script_execution_t *)o;
+    } catch (...) {
+        delete o;
+        set_error(err, bitcoinconsensus_ERR_UNKNOWN);
+        return NULL;
+    }
+}
+
+int bitcoinconsensus_script_execution_stack_insert(bitcoinconsensus_script_execution_t *po, bitcoinconsensus_script_execution_stack stackid, int stackPos, const void *datap, size_t dataLen, bitcoinconsensus_error* err)
+{
+    try {
+        bitcoinconsensus_script_execution_data *o = (bitcoinconsensus_script_execution_data *)po;
+        const unsigned char *data = (const unsigned char *)datap;
+        bitcoinconsensus_stack_t *stack;
+
+        if (!o->parse_stackPos(stack, stackid, stackPos, true))
+            return set_error(err, bitcoinconsensus_ERR_BAD_INDEX);
+
+        valtype vchData;
+        vchData.assign(data, &data[dataLen]);
+
+        stack->insert(stack->begin() + stackPos, vchData);
+
+        return 1;
+    } catch (...) {
+        return set_error(err, bitcoinconsensus_ERR_UNKNOWN);
+    }
+}
+
+int bitcoinconsensus_script_execution_stack_delete(bitcoinconsensus_script_execution_t *po, bitcoinconsensus_script_execution_stack stackid, int stackPos, bitcoinconsensus_error* err)
+{
+    try {
+        bitcoinconsensus_script_execution_data *o = (bitcoinconsensus_script_execution_data *)po;
+        bitcoinconsensus_stack_t *stack;
+
+        if (!o->parse_stackPos(stack, stackid, stackPos, false))
+            return set_error(err, bitcoinconsensus_ERR_BAD_INDEX);
+
+        stack->erase(stack->begin() + stackPos);
+
+        return 1;
+    } catch (...) {
+        return set_error(err, bitcoinconsensus_ERR_UNKNOWN);
+    }
+}
+
+int bitcoinconsensus_script_execution_stack_get(bitcoinconsensus_script_execution_t *po, bitcoinconsensus_script_execution_stack stackid, int stackPos, const void **datap, size_t *dataLen, bitcoinconsensus_error* err)
+{
+    try {
+        bitcoinconsensus_script_execution_data *o = (bitcoinconsensus_script_execution_data *)po;
+        bitcoinconsensus_stack_t *stack;
+
+        if (!o->parse_stackPos(stack, stackid, stackPos, false))
+            return set_error(err, bitcoinconsensus_ERR_BAD_INDEX);
+
+        valtype& vchStackElem = *(stack->begin() + stackPos);
+
+        *datap = vchStackElem.data();
+        *dataLen = vchStackElem.size();
+
+        return 1;
+    } catch (...) {
+        return set_error(err, bitcoinconsensus_ERR_UNKNOWN);
+    }
+}
+
+int bitcoinconsensus_script_execution_start(bitcoinconsensus_script_execution_t *po, unsigned int flags, bitcoinconsensus_error* err)
+{
+    try {
+        bitcoinconsensus_script_execution_data *o = (bitcoinconsensus_script_execution_data *)po;
+
+        if (o->sexec)
+            return set_error(err, bitcoinconsensus_ERR_UNKNOWN);
+
+        o->sexec = new CScriptExecution(o->stack, o->script, flags, *o->tsc.checker, &o->serror);
+        if (!o->sexec->Start())
+        {
+            o->Terminate();
+            return set_error(err, bitcoinconsensus_ERR_SCRIPT_EXECUTION);
+        }
+
+        return 1;
+    } catch (...) {
+        return set_error(err, bitcoinconsensus_ERR_UNKNOWN);
+    }
+}
+
+int bitcoinconsensus_script_execution_step(bitcoinconsensus_script_execution_t *po, int *fEof, bitcoinconsensus_error* err)
+{
+    try {
+        bitcoinconsensus_script_execution_data *o = (bitcoinconsensus_script_execution_data *)po;
+
+        if (!o->sexec->Step())
+            return set_error(err, bitcoinconsensus_ERR_SCRIPT_EXECUTION);
+
+        *fEof = o->sexec->fEof;
+        return 1;
+    } catch (...) {
+        return set_error(err, bitcoinconsensus_ERR_UNKNOWN);
+    }
+}
+
+int bitcoinconsensus_script_execution_terminate(bitcoinconsensus_script_execution_t *po, bitcoinconsensus_error* err)
+{
+    try {
+        bitcoinconsensus_script_execution_data *o = (bitcoinconsensus_script_execution_data *)po;
+        o->Terminate();
+        return 1;
+    } catch (...) {
+        return set_error(err, bitcoinconsensus_ERR_UNKNOWN);
+    }
+}
+
+int bitcoinconsensus_script_execution_get_pc(bitcoinconsensus_script_execution_t *po, bitcoinconsensus_error* err)
+{
+    try {
+        bitcoinconsensus_script_execution_data *o = (bitcoinconsensus_script_execution_data *)po;
+        std::vector<unsigned char>::const_iterator cbegin = o->script.begin();
+        return std::distance(cbegin, o->sexec->pc);
+    } catch (...) {
+        set_error(err, bitcoinconsensus_ERR_UNKNOWN);
+        return -1;
+    }
+}
+
+int bitcoinconsensus_script_execution_get_codehash_pos(bitcoinconsensus_script_execution_t *po, bitcoinconsensus_error* err)
+{
+    try {
+        bitcoinconsensus_script_execution_data *o = (bitcoinconsensus_script_execution_data *)po;
+        std::vector<unsigned char>::const_iterator cbegin = o->script.begin();
+        return std::distance(cbegin, o->sexec->pbegincodehash);
+    } catch (...) {
+        set_error(err, bitcoinconsensus_ERR_UNKNOWN);
+        return -1;
+    }
+}
+
+int bitcoinconsensus_script_execution_get_sigop_count(bitcoinconsensus_script_execution_t *po, bitcoinconsensus_error* err)
+{
+    try {
+        bitcoinconsensus_script_execution_data *o = (bitcoinconsensus_script_execution_data *)po;
+        return o->sexec->nOpCount;
+    } catch (...) {
+        set_error(err, bitcoinconsensus_ERR_UNKNOWN);
+        return -1;
+    }
+}
 
 int bitcoinconsensus_verify_script(const unsigned char *scriptPubKey, unsigned int scriptPubKeyLen,
                                     const unsigned char *txTo        , unsigned int txToLen,

--- a/src/script/bitcoinconsensus.h
+++ b/src/script/bitcoinconsensus.h
@@ -39,6 +39,7 @@ typedef enum bitcoinconsensus_error_t
     bitcoinconsensus_ERR_TX_INDEX,
     bitcoinconsensus_ERR_TX_SIZE_MISMATCH,
     bitcoinconsensus_ERR_TX_DESERIALIZE,
+    bitcoinconsensus_ERR_UNKNOWN,
 } bitcoinconsensus_error;
 
 /** Script verification flags */

--- a/src/script/bitcoinconsensus.h
+++ b/src/script/bitcoinconsensus.h
@@ -6,6 +6,8 @@
 #ifndef BITCOIN_BITCOINCONSENSUS_H
 #define BITCOIN_BITCOINCONSENSUS_H
 
+#include <stddef.h>
+
 #if defined(BUILD_BITCOIN_INTERNAL) && defined(HAVE_CONFIG_H)
 #include "config/bitcoin-config.h"
   #if defined(_WIN32)
@@ -40,6 +42,8 @@ typedef enum bitcoinconsensus_error_t
     bitcoinconsensus_ERR_TX_SIZE_MISMATCH,
     bitcoinconsensus_ERR_TX_DESERIALIZE,
     bitcoinconsensus_ERR_UNKNOWN,
+    bitcoinconsensus_ERR_BAD_INDEX,
+    bitcoinconsensus_ERR_SCRIPT_EXECUTION,
 } bitcoinconsensus_error;
 
 /** Script verification flags */
@@ -49,6 +53,62 @@ enum
     bitcoinconsensus_SCRIPT_FLAGS_VERIFY_P2SH      = (1U << 0), // evaluate P2SH (BIP16) subscripts
     bitcoinconsensus_SCRIPT_FLAGS_VERIFY_DERSIG    = (1U << 2), // enforce strict DER (BIP66) compliance
 };
+
+typedef enum bitcoinconsensus_script_execution_stack
+{
+    bitcoinconsensus_SEXEC_STACK,
+    bitcoinconsensus_SEXEC_ALTSTACK,
+} bitcoinconsensus_script_execution_stack;
+
+typedef struct bitcoinconsensus_script_execution_t_ bitcoinconsensus_script_execution_t;
+
+/// Returns an opaque pointer representing a context for execution of the given script for a given transaction.
+/// If txTo is NULL, all operations that access the transaction will fail.
+/// If not NULL, err will contain an error/success code for the operation
+EXPORT_SYMBOL bitcoinconsensus_script_execution_t *bitcoinconsensus_script_execution(const unsigned char *script, unsigned int scriptLen, const unsigned char *txTo, unsigned int txToLen, unsigned int nIn, bitcoinconsensus_error*);
+
+/// Inserts a blob of data at a given position on one of the stacks.
+/// To access the altstack, the execution context must already be started.
+/// A negative stackPos will insert at the end of the stack.
+/// If not NULL, err will contain an error/success code for the operation
+EXPORT_SYMBOL int bitcoinconsensus_script_execution_stack_insert(bitcoinconsensus_script_execution_t *, bitcoinconsensus_script_execution_stack, int stackPos, const void *data, size_t dataLen, bitcoinconsensus_error*);
+
+/// Deletes the element at a given position of one of the stacks.
+/// A negative stackPos will insert at the end of the stack.
+/// If not NULL, err will contain an error/success code for the operation
+EXPORT_SYMBOL int bitcoinconsensus_script_execution_stack_delete(bitcoinconsensus_script_execution_t *, bitcoinconsensus_script_execution_stack, int stackPos, bitcoinconsensus_error*);
+
+/// Accesses the element at a given position of one of the stacks.
+/// A negative stackPos will insert at the end of the stack.
+/// When successful (indicated by a non-zero return value), data will receive a pointer to the stack element, and dataLen will be set to its size.
+/// If not NULL, err will contain an error/success code for the operation
+EXPORT_SYMBOL int bitcoinconsensus_script_execution_stack_get(bitcoinconsensus_script_execution_t *, bitcoinconsensus_script_execution_stack, int stackPos, const void **data, size_t *dataLen, bitcoinconsensus_error*);
+
+/// Starts execution of the script.
+/// If not NULL, err will contain an error/success code for the operation
+EXPORT_SYMBOL int bitcoinconsensus_script_execution_start(bitcoinconsensus_script_execution_t *, unsigned int flags, bitcoinconsensus_error*);
+
+/// Executes a single instruction of the script.
+/// When successful, fEof will be assigned to false if there is more to do, or true when the script has completed.
+/// If not NULL, err will contain an error/success code for the operation
+EXPORT_SYMBOL int bitcoinconsensus_script_execution_step(bitcoinconsensus_script_execution_t *, int *fEof, bitcoinconsensus_error*);
+
+/// Immediately terminates the execution.
+/// Unless bitcoinconsensus_script_execution_start returned true, this will crash your program.
+/// If not NULL, err will contain an error/success code for the operation
+EXPORT_SYMBOL int bitcoinconsensus_script_execution_terminate(bitcoinconsensus_script_execution_t *, bitcoinconsensus_error*);
+
+/// Returns the current execution offset in the script.
+/// If not NULL, err will contain an error/success code for the operation
+EXPORT_SYMBOL int bitcoinconsensus_script_execution_get_pc(bitcoinconsensus_script_execution_t *, bitcoinconsensus_error*);
+
+/// Returns the position in the script following the last OP_CODESEPARATOR executed, or zero if none have executed.
+/// If not NULL, err will contain an error/success code for the operation
+EXPORT_SYMBOL int bitcoinconsensus_script_execution_get_codehash_pos(bitcoinconsensus_script_execution_t *, bitcoinconsensus_error*);
+
+/// Returns the number of "sigops" executed thus far.
+/// If not NULL, err will contain an error/success code for the operation
+EXPORT_SYMBOL int bitcoinconsensus_script_execution_get_sigop_count(bitcoinconsensus_script_execution_t *, bitcoinconsensus_error*);
 
 /// Returns 1 if the input nIn of the serialized transaction pointed to by
 /// txTo correctly spends the scriptPubKey pointed to by scriptPubKey under

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -235,7 +235,20 @@ bool static CheckMinimalPush(const valtype& data, opcodetype opcode) {
     return true;
 }
 
-bool EvalScript(vector<vector<unsigned char> >& stack, const CScript& script, unsigned int flags, const BaseSignatureChecker& checker, ScriptError* serror)
+CScriptExecution::CScriptExecution(std::vector<valtype>& stackIn, const CScript& scriptIn, unsigned int flagsIn, const BaseSignatureChecker& checkerIn, ScriptError* serrorIn)
+: stack(stackIn), script(scriptIn), flags(flagsIn), checker(checkerIn), serror(serrorIn), pc(script.begin()), pbegincodehash(pc), vfExec(), altstack(), nOpCount(0), fEof(false)
+{
+}
+
+bool CScriptExecution::Start()
+{
+    set_error(serror, SCRIPT_ERR_UNKNOWN_ERROR);
+    if (script.size() > 10000)
+        return set_error(serror, SCRIPT_ERR_SCRIPT_SIZE);
+    return true;
+}
+
+bool CScriptExecution::Step()
 {
     static const CScriptNum bnZero(0);
     static const CScriptNum bnOne(1);
@@ -245,22 +258,15 @@ bool EvalScript(vector<vector<unsigned char> >& stack, const CScript& script, un
     static const valtype vchZero(0);
     static const valtype vchTrue(1, 1);
 
-    CScript::const_iterator pc = script.begin();
     CScript::const_iterator pend = script.end();
-    CScript::const_iterator pbegincodehash = script.begin();
     opcodetype opcode;
     valtype vchPushValue;
-    vector<bool> vfExec;
-    vector<valtype> altstack;
-    set_error(serror, SCRIPT_ERR_UNKNOWN_ERROR);
-    if (script.size() > 10000)
-        return set_error(serror, SCRIPT_ERR_SCRIPT_SIZE);
-    int nOpCount = 0;
     bool fRequireMinimal = (flags & SCRIPT_VERIFY_MINIMALDATA) != 0;
 
+    fEof = (pc >= pend);
     try
     {
-        while (pc < pend)
+        if (!fEof)
         {
             bool fExec = !count(vfExec.begin(), vfExec.end(), false);
 
@@ -921,6 +927,8 @@ bool EvalScript(vector<vector<unsigned char> >& stack, const CScript& script, un
             // Size limits
             if (stack.size() + altstack.size() > 1000)
                 return set_error(serror, SCRIPT_ERR_STACK_SIZE);
+
+            return true;
         }
     }
     catch (...)
@@ -932,6 +940,20 @@ bool EvalScript(vector<vector<unsigned char> >& stack, const CScript& script, un
         return set_error(serror, SCRIPT_ERR_UNBALANCED_CONDITIONAL);
 
     return set_success(serror);
+}
+
+bool EvalScript(std::vector<valtype>& stack, const CScript& script, unsigned int flags, const BaseSignatureChecker& checker, ScriptError* serror)
+{
+    CScriptExecution sexec(stack, script, flags, checker, serror);
+
+    if (!sexec.Start())
+        return false;
+
+    while (!sexec.fEof)
+        if (!sexec.Step())
+            return false;
+
+    return true;
 }
 
 namespace {

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -114,6 +114,31 @@ public:
     MutableTransactionSignatureChecker(const CMutableTransaction* txToIn, unsigned int nInIn) : TransactionSignatureChecker(&txTo, nInIn), txTo(*txToIn) {}
 };
 
+class CScriptExecution {
+public:
+    typedef std::vector<unsigned char> valtype;
+
+    std::vector<valtype>& stack;
+    const CScript& script;
+    unsigned int flags;
+    const BaseSignatureChecker& checker;
+    ScriptError* serror;
+
+    CScript::const_iterator pc;
+    CScript::const_iterator pbegincodehash;
+
+    std::vector<bool> vfExec;
+    std::vector<valtype> altstack;
+    int nOpCount;
+
+    CScriptExecution(std::vector<valtype>& stack, const CScript& script, unsigned int flags, const BaseSignatureChecker& checker, ScriptError* error = NULL);
+
+    bool fEof;
+
+    bool Start();
+    bool Step();
+};
+
 bool EvalScript(std::vector<std::vector<unsigned char> >& stack, const CScript& script, unsigned int flags, const BaseSignatureChecker& checker, ScriptError* error = NULL);
 bool VerifyScript(const CScript& scriptSig, const CScript& scriptPubKey, unsigned int flags, const BaseSignatureChecker& checker, ScriptError* error = NULL);
 


### PR DESCRIPTION
Rebased #3901, and exposed to libbitcoinconsensus. This should be sufficient for implementing a basic Script debugger outside of Bitcoin Core.
