### PR TITLE
CSubNet: fix CIDR netmask calculation and match() function

### DIFF
--- a/src/test/netbase_tests.cpp
+++ b/src/test/netbase_tests.cpp
@@ -109,6 +109,11 @@ BOOST_AUTO_TEST_CASE(subnet_test)
     BOOST_CHECK(CSubNet("1.2.3.0/24") != CSubNet("1.2.4.0/255.255.255.0"));
     BOOST_CHECK(CSubNet("1.2.3.0/24").Match(CNetAddr("1.2.3.4")));
     BOOST_CHECK(!CSubNet("1.2.2.0/24").Match(CNetAddr("1.2.3.4")));
+
+    BOOST_CHECK(CSubNet("1.2.2.1/24").Match(CNetAddr("1.2.2.4")));
+    BOOST_CHECK(CSubNet("1.2.2.110/31").Match(CNetAddr("1.2.2.111")));
+    BOOST_CHECK(CSubNet("1.2.2.20/26").Match(CNetAddr("1.2.2.63")));
+
     BOOST_CHECK(CSubNet("1.2.3.4").Match(CNetAddr("1.2.3.4")));
     BOOST_CHECK(CSubNet("1.2.3.4/32").Match(CNetAddr("1.2.3.4")));
     BOOST_CHECK(!CSubNet("1.2.3.4").Match(CNetAddr("5.6.7.8")));


### PR DESCRIPTION
While working on the RPC ban function, i have detected the the `CSubNet` CIDR netmask calculations as well as the `CSubNet::Match()` function are buggy.

Edit: fixes #6179
