### PR TITLE
txnotify command line option

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1070,6 +1070,9 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
 
     SyncWithWallets(tx, NULL);
 
+    // Notify external listeners about the new tx.
+    uiInterface.NotifyTx(hash);
+
     return true;
 }
 

--- a/src/ui_interface.h
+++ b/src/ui_interface.h
@@ -95,6 +95,9 @@ public:
 
     /** New block has been accepted */
     boost::signals2::signal<void (const uint256& hash)> NotifyBlockTip;
+
+    /** New transaction has been accepted */
+    boost::signals2::signal<void (const uint256& hash)> NotifyTx;
 };
 
 extern CClientUIInterface uiInterface;


### PR DESCRIPTION
similar to 'walletnotify' this command line option executes a command whenever a transaction enters the mempool
