### PR TITLE
Restore minimum feerate to 10000 satoshis

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -67,6 +67,24 @@ UTXO but where its block file has been pruned.
 
 Pruning is disabled by default.
 
+Transaction Fees
+----------------
+
+This release restores the default fee required to relay transactions across the
+network and for miners to consider the transaction in their blocks to
+0.1mBTC per kilobyte. The previous drop to 0.01mBTC in 0.9 only achieved
+technical consensus for the relay fee (not mining), and on the basis of a $500
+exchange rate. It was applied to mining policy defaults as a last minute
+workaround for a bug that occurs when relay fee and mining fee are mismatched,
+and since that bug has not yet been fixed, the default relay fee is herein also
+restored to its former fee rate. Miners and nodes are expected to override this
+default to a reasonable preference using the minrelaytxfee option.
+
+Note that getting a transaction relayed across the network does NOT guarantee
+that the transaction will be accepted by a miner; by default, miners fill
+their blocks with 50 kilobytes of high-priority transactions (controlled by
+the blockprioritysize option), and then with 700 kilobytes (controlled by the
+blockmaxsize option) of the highest-fee-per-kilobyte transactions.
 
 0.11.0 Change log
 =================

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -803,7 +803,10 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     {
         CAmount n = 0;
         if (ParseMoney(mapArgs["-minrelaytxfee"], n) && n > 0)
+        {
             ::minRelayTxFee = CFeeRate(n);
+            ::feerateAbsurd = CFeeRate(n * 10000);
+        }
         else
             return InitError(strprintf(_("Invalid amount for -minrelaytxfee=<amount>: '%s'"), mapArgs["-minrelaytxfee"]));
     }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -805,7 +805,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
         if (ParseMoney(mapArgs["-minrelaytxfee"], n) && n > 0)
         {
             ::minRelayTxFee = CFeeRate(n);
-            ::feerateAbsurd = CFeeRate(n * 10000);
+            ::feerateAbsurd = CFeeRate(n * 1000);
         }
         else
             return InitError(strprintf(_("Invalid amount for -minrelaytxfee=<amount>: '%s'"), mapArgs["-minrelaytxfee"]));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -65,6 +65,10 @@ uint64_t nPruneTarget = 0;
 /** Fees smaller than this (in satoshi) are considered zero fee (for relaying and mining) */
 CFeeRate minRelayTxFee = CFeeRate(1000);
 
+// NOTE: init.cpp sets this to -minrelaytxfee * 10000; keep that constant in sync
+/** Fees larger than this (in satoshi) are considered absurd */
+CFeeRate feerateAbsurd = CFeeRate(10000000);
+
 CTxMemPool mempool(::minRelayTxFee);
 
 struct COrphanTx {
@@ -1038,10 +1042,10 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
             dFreeCount += nSize;
         }
 
-        if (fRejectAbsurdFee && nFees > ::minRelayTxFee.GetFee(nSize) * 10000)
+        if (fRejectAbsurdFee && nFees > ::feerateAbsurd.GetFee(nSize))
             return error("AcceptToMemoryPool: absurdly high fees %s, %d > %d",
                          hash.ToString(),
-                         nFees, ::minRelayTxFee.GetFee(nSize) * 10000);
+                         nFees, ::feerateAbsurd.GetFee(nSize));
 
         // Check against previous transactions
         // This is done last to help prevent CPU exhaustion denial-of-service attacks.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -63,9 +63,9 @@ size_t nCoinCacheUsage = 5000 * 300;
 uint64_t nPruneTarget = 0;
 
 /** Fees smaller than this (in satoshi) are considered zero fee (for relaying and mining) */
-CFeeRate minRelayTxFee = CFeeRate(1000);
+CFeeRate minRelayTxFee = CFeeRate(10000);
 
-// NOTE: init.cpp sets this to -minrelaytxfee * 10000; keep that constant in sync
+// NOTE: init.cpp sets this to -minrelaytxfee * 1000; keep that constant in sync
 /** Fees larger than this (in satoshi) are considered absurd */
 CFeeRate feerateAbsurd = CFeeRate(10000000);
 

--- a/src/main.h
+++ b/src/main.h
@@ -113,6 +113,7 @@ extern bool fCheckBlockIndex;
 extern bool fCheckpointsEnabled;
 extern size_t nCoinCacheUsage;
 extern CFeeRate minRelayTxFee;
+extern CFeeRate feerateAbsurd;
 
 /** Best header we've seen so far (used for getheaders queries' starting points). */
 extern CBlockIndex *pindexBestHeader;

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -528,7 +528,7 @@ void SendCoinsDialog::processSendCoinsReturn(const WalletModel::SendCoinsReturn 
         msgParams.second = CClientUIInterface::MSG_ERROR;
         break;
     case WalletModel::AbsurdFee:
-        msgParams.first = tr("A fee higher than %1 is considered an absurdly high fee.").arg(BitcoinUnits::formatWithUnit(model->getOptionsModel()->getDisplayUnit(), 10000000));
+        msgParams.first = tr("A fee higher than %1 is considered an absurdly high fee.").arg(BitcoinUnits::formatWithUnit(model->getOptionsModel()->getDisplayUnit(), ::feerateAbsurd.GetFeePerK()));
         break;
     case WalletModel::PaymentRequestExpired:
         msgParams.first = tr("Payment request expired.");

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -290,8 +290,8 @@ WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransact
             return TransactionCreationFailed;
         }
 
-        // reject absurdly high fee > 0.1 bitcoin
-        if (nFeeRequired > 10000000)
+        // reject absurdly high fee
+        if (nFeeRequired > ::feerateAbsurd.GetFeePerK())
             return AbsurdFee;
     }
 

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -343,7 +343,7 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
     t.vout[0].nValue = 501; // dust
     BOOST_CHECK(!IsStandardTx(t, reason));
 
-    t.vout[0].nValue = 601; // not dust
+    t.vout[0].nValue = 6001; // not dust
     BOOST_CHECK(IsStandardTx(t, reason));
 
     t.vout[0].scriptPubKey = CScript() << OP_1;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -40,7 +40,7 @@ bool fPayAtLeastCustomFee = true;
  * Fees smaller than this (in satoshi) are considered zero fee (for transaction creation)
  * Override with -mintxfee
  */
-CFeeRate CWallet::minTxFee = CFeeRate(1000);
+CFeeRate CWallet::minTxFee = CFeeRate(10000);
 
 /** @defgroup mapWallet
  *


### PR DESCRIPTION
Only the minimum relay fee was intended to be reduced to 1000 satoshis, but due to mempool bugs, nodes can't handle divergent relay and mining fee rates properly yet.
A quick workaround was merged for 0.9 by using the relay fee for mining (PR #3838), but without any consensus for the actual mining default to be dropped.
Unfortunately, many miners seem to still run with default policies, and this fee rate makes spamming too cheap still.
This brings the minimum fee rate back to up 10000 satoshis, which reflects the last consensus for standard mining fee rate.
