### PR TITLE
[Qt] prefer CRecipient over std::pair like in walletmodel

### DIFF
--- a/src/qt/paymentrequestplus.cpp
+++ b/src/qt/paymentrequestplus.cpp
@@ -10,6 +10,7 @@
 #include "paymentrequestplus.h"
 
 #include "util.h"
+#include "wallet/wallet.h"
 
 #include <stdexcept>
 
@@ -195,15 +196,15 @@ bool PaymentRequestPlus::getMerchant(X509_STORE* certStore, QString& merchant) c
     return fResult;
 }
 
-QList<std::pair<CScript,CAmount> > PaymentRequestPlus::getPayTo() const
+QList<CRecipient> PaymentRequestPlus::getPayTo() const
 {
-    QList<std::pair<CScript,CAmount> > result;
-    for (int i = 0; i < details.outputs_size(); i++)
-    {
+    QList<CRecipient> result;
+    for (int i = 0; i < details.outputs_size(); i++) {
         const unsigned char* scriptStr = (const unsigned char*)details.outputs(i).script().data();
-        CScript s(scriptStr, scriptStr+details.outputs(i).script().size());
+        CScript s(scriptStr, scriptStr + details.outputs(i).script().size());
 
-        result.append(make_pair(s, details.outputs(i).amount()));
+        CRecipient recipient = {s, (CAmount)details.outputs(i).amount(), false};
+        result.append(recipient);
     }
     return result;
 }

--- a/src/qt/paymentrequestplus.h
+++ b/src/qt/paymentrequestplus.h
@@ -15,6 +15,8 @@
 #include <QList>
 #include <QString>
 
+struct CRecipient;
+
 //
 // Wraps dumb protocol buffer paymentRequest
 // with extra methods
@@ -34,7 +36,7 @@ public:
     bool getMerchant(X509_STORE* certStore, QString& merchant) const;
 
     // Returns list of outputs, amount
-    QList<std::pair<CScript,CAmount> > getPayTo() const;
+    QList<CRecipient> getPayTo() const;
 
     const payments::PaymentDetails& getDetails() const { return details; }
 

--- a/src/qt/paymentserver.h
+++ b/src/qt/paymentserver.h
@@ -32,13 +32,14 @@
 // sends them to the server.
 //
 
-#include "paymentrequestplus.h"
+#include "paymentrequest.pb.h"
 #include "walletmodel.h"
 
 #include <QObject>
 #include <QString>
 
 class OptionsModel;
+class PaymentRequestPlus;
 
 class CWallet;
 

--- a/src/qt/test/paymentservertests.cpp
+++ b/src/qt/test/paymentservertests.cpp
@@ -13,6 +13,7 @@
 #include "script/standard.h"
 #include "util.h"
 #include "utilstrencodings.h"
+#include "wallet/wallet.h"
 
 #include <openssl/x509.h>
 #include <openssl/x509_vfy.h>
@@ -194,11 +195,11 @@ void PaymentServerTests::paymentServerTests()
     // Ensure the request is initialized
     QVERIFY(r.paymentRequest.IsInitialized());
     // Extract address and amount from the request
-    QList<std::pair<CScript, CAmount> > sendingTos = r.paymentRequest.getPayTo();
-    foreach (const PAIRTYPE(CScript, CAmount)& sendingTo, sendingTos) {
+    QList<CRecipient> sendingTos = r.paymentRequest.getPayTo();
+    foreach (const CRecipient& sendingTo, sendingTos) {
         CTxDestination dest;
-        if (ExtractDestination(sendingTo.first, dest))
-            QCOMPARE(PaymentServer::verifyAmount(sendingTo.second), false);
+        if (ExtractDestination(sendingTo.scriptPubKey, dest))
+            QCOMPARE(PaymentServer::verifyAmount(sendingTo.nAmount), false);
     }
 
     delete server;

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -6,6 +6,7 @@
 
 #include "bitcoinunits.h"
 #include "guiutil.h"
+#include "paymentrequestplus.h"
 #include "paymentserver.h"
 #include "transactionrecord.h"
 
@@ -15,7 +16,6 @@
 #include "script/script.h"
 #include "timedata.h"
 #include "util.h"
-#include "wallet/db.h"
 #include "wallet/wallet.h"
 
 #include <stdint.h>

--- a/src/qt/walletmodeltransaction.cpp
+++ b/src/qt/walletmodeltransaction.cpp
@@ -4,6 +4,8 @@
 
 #include "walletmodeltransaction.h"
 
+#include "walletmodel.h"
+
 #include "wallet/wallet.h"
 
 WalletModelTransaction::WalletModelTransaction(const QList<SendCoinsRecipient> &recipients) :

--- a/src/qt/walletmodeltransaction.h
+++ b/src/qt/walletmodeltransaction.h
@@ -5,7 +5,7 @@
 #ifndef BITCOIN_QT_WALLETMODELTRANSACTION_H
 #define BITCOIN_QT_WALLETMODELTRANSACTION_H
 
-#include "walletmodel.h"
+#include "amount.h"
 
 #include <QObject>
 


### PR DESCRIPTION
- this updates Qt code to core code, where CRecipient is used in wallet
- also makes things e.g. in paymentserver.cpp much more readable
