### PR TITLE
build: disable optional use of gmp in internal secp256k1 build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -885,7 +885,7 @@ PKGCONFIG_LIBDIR_TEMP="$PKG_CONFIG_LIBDIR"
 unset PKG_CONFIG_LIBDIR
 PKG_CONFIG_LIBDIR="$PKGCONFIG_LIBDIR_TEMP"
 
-ac_configure_args="${ac_configure_args} --disable-shared --with-pic"
+ac_configure_args="${ac_configure_args} --disable-shared --with-pic --with-bignum=no"
 AC_CONFIG_SUBDIRS([src/secp256k1])
 
 AC_OUTPUT


### PR DESCRIPTION
Until secp256k1 is used for verification there is no reason for Bitcoin Core's secp256k1 to link against gmp, even if available. Pass a flag to configure to override the bignum implementation.

This fixes a crash at runtime on ppc64 reported by @gmaxwell.

Edit: tested and appears to work, after autogen and reconfigure, `src/secp256k1/config.log` contains

```
configure:13140: Using bignum implementation: no
```

... whereas it was using gmp before.
