### PR TITLE
gitian: Bump cache dir for 0.11

### DIFF
--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -1,5 +1,5 @@
 ---
-name: "bitcoin-linux-0.10"
+name: "bitcoin-linux-0.11"
 enable_cache: true
 suites:
 - "precise"

--- a/contrib/gitian-descriptors/gitian-osx.yml
+++ b/contrib/gitian-descriptors/gitian-osx.yml
@@ -1,5 +1,5 @@
 ---
-name: "bitcoin-osx-0.10"
+name: "bitcoin-osx-0.11"
 enable_cache: true
 suites:
 - "precise"

--- a/contrib/gitian-descriptors/gitian-win.yml
+++ b/contrib/gitian-descriptors/gitian-win.yml
@@ -1,5 +1,5 @@
 ---
-name: "bitcoin-win-0.10"
+name: "bitcoin-win-0.11"
 enable_cache: true
 suites:
 - "precise"


### PR DESCRIPTION
Bump the gitian cache dir for the 0.11 series. These act as a namespace for the build caches, which are almost guaranteed to be completely different between major releases. Older caches can be deleted at will, or kept around to speed up future point-releases.
