### PR TITLE
CTransaction: Skip hashing until it is needed

### DIFF
--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -70,6 +70,7 @@ uint256 CMutableTransaction::GetHash() const
 void CTransaction::UpdateHash() const
 {
     *const_cast<uint256*>(&hash) = SerializeHash(*this);
+    *const_cast<bool*>(&fHaveHash) = true;
 }
 
 CTransaction::CTransaction() : hash(0), nVersion(CTransaction::CURRENT_VERSION), vin(), vout(), nLockTime(0) { }

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -171,6 +171,7 @@ class CTransaction
 {
 private:
     /** Memory only. */
+    bool fHaveHash;
     const uint256 hash;
     void UpdateHash() const;
 
@@ -205,7 +206,7 @@ public:
         READWRITE(*const_cast<std::vector<CTxOut>*>(&vout));
         READWRITE(*const_cast<uint32_t*>(&nLockTime));
         if (ser_action.ForRead())
-            UpdateHash();
+            fHaveHash = false;
     }
 
     bool IsNull() const {
@@ -213,6 +214,8 @@ public:
     }
 
     const uint256& GetHash() const {
+        if (!fHaveHash)
+            UpdateHash();
         return hash;
     }
 


### PR DESCRIPTION
Quite often the hash is never used, and I cut down a custom RPC from 46 minutes to 21 by eliminating it. Adding a CTransaction destructor checking its final fHaveHash state shows it also occurs quite often with the master reference code.
