### PR TITLE
Discuss: unify bip70 chain names, user-facing chain strings and default dir names

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -135,6 +135,7 @@ BITCOIN_CORE_H = \
   support/pagelocker.h \
   sync.h \
   threadsafety.h \
+  templates.hpp \
   timedata.h \
   tinyformat.h \
   txdb.h \

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -5,6 +5,7 @@
 
 #include "chainparams.h"
 
+#include "templates.hpp"
 #include "tinyformat.h"
 #include "util.h"
 #include "utilstrencodings.h"
@@ -129,7 +130,6 @@ public:
         };
     }
 };
-static CMainParams mainParams;
 
 /**
  * Testnet (v3)
@@ -189,7 +189,6 @@ public:
 
     }
 };
-static CTestNetParams testNetParams;
 
 /**
  * Regression test
@@ -235,30 +234,35 @@ public:
         };
     }
 };
-static CRegTestParams regTestParams;
 
-static CChainParams *pCurrentParams = 0;
+static Container<CChainParams> currentParams;
+static Container<CChainParams> switchingParams;
 
 const CChainParams &Params() {
-    assert(pCurrentParams);
-    return *pCurrentParams;
+    return currentParams.Get();
 }
 
-CChainParams& Params(std::string chain)
+CChainParams* ParamsFactory(std::string chain)
 {
     if (chain == CBaseChainParams::MAIN)
-            return mainParams;
+        return new CMainParams();
     else if (chain == CBaseChainParams::TESTNET)
-            return testNetParams;
+        return new CTestNetParams();
     else if (chain == CBaseChainParams::REGTEST)
-            return regTestParams;
+        return new CRegTestParams();
     throw std::runtime_error(strprintf(_("%s: Unknown chain %s."), __func__, chain));
+}
+
+const CChainParams& Params(std::string chain)
+{
+    switchingParams.Set(ParamsFactory(chain));
+    return switchingParams.Get();
 }
 
 void SelectParams(std::string chain)
 {
     SelectBaseParams(chain);
-    pCurrentParams = &Params(chain);
+    currentParams.Set(ParamsFactory(chain));
 }
 
 bool SelectParamsFromCommandLine()

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -5,6 +5,7 @@
 
 #include "chainparams.h"
 
+#include "tinyformat.h"
 #include "util.h"
 #include "utilstrencodings.h"
 
@@ -30,7 +31,7 @@ using namespace std;
 class CMainParams : public CChainParams {
 public:
     CMainParams() {
-        strNetworkID = "main";
+        strNetworkID = CBaseChainParams::MAIN;
         consensus.nSubsidyHalvingInterval = 210000;
         consensus.nMajorityEnforceBlockUpgrade = 750;
         consensus.nMajorityRejectBlockOutdated = 950;
@@ -136,7 +137,7 @@ static CMainParams mainParams;
 class CTestNetParams : public CMainParams {
 public:
     CTestNetParams() {
-        strNetworkID = "test";
+        strNetworkID = CBaseChainParams::TESTNET;
         consensus.nMajorityEnforceBlockUpgrade = 51;
         consensus.nMajorityRejectBlockOutdated = 75;
         consensus.nMajorityWindow = 100;
@@ -196,7 +197,7 @@ static CTestNetParams testNetParams;
 class CRegTestParams : public CTestNetParams {
 public:
     CRegTestParams() {
-        strNetworkID = "regtest";
+        strNetworkID = CBaseChainParams::REGTEST;
         consensus.nSubsidyHalvingInterval = 150;
         consensus.nMajorityEnforceBlockUpgrade = 750;
         consensus.nMajorityRejectBlockOutdated = 950;
@@ -243,31 +244,29 @@ const CChainParams &Params() {
     return *pCurrentParams;
 }
 
-CChainParams &Params(CBaseChainParams::Network network) {
-    switch (network) {
-        case CBaseChainParams::MAIN:
+CChainParams& Params(std::string chain)
+{
+    if (chain == CBaseChainParams::MAIN)
             return mainParams;
-        case CBaseChainParams::TESTNET:
+    else if (chain == CBaseChainParams::TESTNET)
             return testNetParams;
-        case CBaseChainParams::REGTEST:
+    else if (chain == CBaseChainParams::REGTEST)
             return regTestParams;
-        default:
-            assert(false && "Unimplemented network");
-            return mainParams;
-    }
+    throw std::runtime_error(strprintf(_("%s: Unknown chain %s."), __func__, chain));
 }
 
-void SelectParams(CBaseChainParams::Network network) {
-    SelectBaseParams(network);
-    pCurrentParams = &Params(network);
+void SelectParams(std::string chain)
+{
+    SelectBaseParams(chain);
+    pCurrentParams = &Params(chain);
 }
 
 bool SelectParamsFromCommandLine()
 {
-    CBaseChainParams::Network network = NetworkIdFromCommandLine();
-    if (network == CBaseChainParams::MAX_NETWORK_TYPES)
+    std::string chain = ChainNameFromCommandLine();
+    if (chain == CBaseChainParams::MAX_NETWORK_TYPES)
         return false;
 
-    SelectParams(network);
+    SelectParams(chain);
     return true;
 }

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -65,7 +65,7 @@ public:
     bool MineBlocksOnDemand() const { return fMineBlocksOnDemand; }
     /** In the future use NetworkIDString() for RPC fields */
     bool TestnetToBeDeprecatedFieldRPC() const { return fTestnetToBeDeprecatedFieldRPC; }
-    /** Return the BIP70 network string (main, test or regtest) */
+    /** Returns the BIP70 chain name string (main, test or regtest) */
     std::string NetworkIDString() const { return strNetworkID; }
     const std::vector<CDNSSeedData>& DNSSeeds() const { return vSeeds; }
     const std::vector<unsigned char>& Base58Prefix(Base58Type type) const { return base58Prefixes[type]; }
@@ -101,11 +101,15 @@ protected:
  */
 const CChainParams &Params();
 
-/** Return parameters for the given network. */
-CChainParams &Params(CBaseChainParams::Network network);
+/**
+ * Returns parameters for the given BIP70 chain name.
+ */
+CChainParams& Params(std::string chain);
 
-/** Sets the params returned by Params() to those for the given network. */
-void SelectParams(CBaseChainParams::Network network);
+/**
+ * Sets the params returned by Params() to those for the given BIP70 chain name.
+ */
+void SelectParams(std::string chain);
 
 /**
  * Looks for -regtest or -testnet and then calls SelectParams as appropriate.

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -65,7 +65,7 @@ public:
     bool MineBlocksOnDemand() const { return fMineBlocksOnDemand; }
     /** In the future use NetworkIDString() for RPC fields */
     bool TestnetToBeDeprecatedFieldRPC() const { return fTestnetToBeDeprecatedFieldRPC; }
-    /** Returns the BIP70 chain name string (main, test or regtest) */
+    /** Returns the BIP70 chain name string (main, testnet3 or regtest) */
     std::string NetworkIDString() const { return strNetworkID; }
     const std::vector<CDNSSeedData>& DNSSeeds() const { return vSeeds; }
     const std::vector<unsigned char>& Base58Prefix(Base58Type type) const { return base58Prefixes[type]; }

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -96,6 +96,14 @@ protected:
 };
 
 /**
+ * Creates a CChainParams of the chosen chain and returns a
+ * pointer to it. The caller has to delete the object.
+ * Raises a std::runtime_error if the chain is not supported.
+ */
+CChainParams* ParamsFactory(std::string chain);
+
+/** Functions that relay on internal state */
+/**
  * Return the currently selected parameters. This won't change after app
  * startup, except for unit tests.
  */
@@ -104,7 +112,7 @@ const CChainParams &Params();
 /**
  * Returns parameters for the given BIP70 chain name.
  */
-CChainParams& Params(std::string chain);
+const CChainParams& Params(std::string chain);
 
 /**
  * Sets the params returned by Params() to those for the given BIP70 chain name.

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -5,9 +5,15 @@
 
 #include "chainparamsbase.h"
 
+#include "tinyformat.h"
 #include "util.h"
 
 #include <assert.h>
+
+const std::string CBaseChainParams::MAIN = "main";
+const std::string CBaseChainParams::TESTNET = "test";
+const std::string CBaseChainParams::REGTEST = "regtest";
+const std::string CBaseChainParams::MAX_NETWORK_TYPES = "unknown_chain";
 
 /**
  * Main network
@@ -44,7 +50,7 @@ class CBaseRegTestParams : public CBaseTestNetParams
 public:
     CBaseRegTestParams()
     {
-        strDataDir = "regtest";
+        strDataDir = CBaseChainParams::REGTEST;
     }
 };
 static CBaseRegTestParams regTestParams;
@@ -70,25 +76,19 @@ const CBaseChainParams& BaseParams()
     return *pCurrentBaseParams;
 }
 
-void SelectBaseParams(CBaseChainParams::Network network)
+void SelectBaseParams(std::string chain)
 {
-    switch (network) {
-    case CBaseChainParams::MAIN:
+    if (chain == CBaseChainParams::MAIN)
         pCurrentBaseParams = &mainParams;
-        break;
-    case CBaseChainParams::TESTNET:
+    else if (chain == CBaseChainParams::TESTNET)
         pCurrentBaseParams = &testNetParams;
-        break;
-    case CBaseChainParams::REGTEST:
+    else if (chain == CBaseChainParams::REGTEST)
         pCurrentBaseParams = &regTestParams;
-        break;
-    default:
-        assert(false && "Unimplemented network");
-        return;
-    }
+    else
+        throw std::runtime_error(strprintf(_("%s: Unknown chain %s."), __func__, chain));
 }
 
-CBaseChainParams::Network NetworkIdFromCommandLine()
+std::string ChainNameFromCommandLine()
 {
     bool fRegTest = GetBoolArg("-regtest", false);
     bool fTestNet = GetBoolArg("-testnet", false);
@@ -104,11 +104,11 @@ CBaseChainParams::Network NetworkIdFromCommandLine()
 
 bool SelectBaseParamsFromCommandLine()
 {
-    CBaseChainParams::Network network = NetworkIdFromCommandLine();
-    if (network == CBaseChainParams::MAX_NETWORK_TYPES)
+    std::string chain = ChainNameFromCommandLine();
+    if (chain == CBaseChainParams::MAX_NETWORK_TYPES)
         return false;
 
-    SelectBaseParams(network);
+    SelectBaseParams(chain);
     return true;
 }
 

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -5,10 +5,9 @@
 
 #include "chainparamsbase.h"
 
+#include "templates.hpp"
 #include "tinyformat.h"
 #include "util.h"
-
-#include <assert.h>
 
 const std::string CBaseChainParams::MAIN = "main";
 const std::string CBaseChainParams::TESTNET = "test";
@@ -26,7 +25,6 @@ public:
         nRPCPort = 8332;
     }
 };
-static CBaseMainParams mainParams;
 
 /**
  * Testnet (v3)
@@ -40,7 +38,6 @@ public:
         strDataDir = "testnet3";
     }
 };
-static CBaseTestNetParams testNetParams;
 
 /*
  * Regression test
@@ -53,7 +50,6 @@ public:
         strDataDir = CBaseChainParams::REGTEST;
     }
 };
-static CBaseRegTestParams regTestParams;
 
 /*
  * Unit test
@@ -68,24 +64,27 @@ public:
 };
 static CBaseUnitTestParams unitTestParams;
 
-static CBaseChainParams* pCurrentBaseParams = 0;
+static Container<CBaseChainParams> currentBaseParams;
 
 const CBaseChainParams& BaseParams()
 {
-    assert(pCurrentBaseParams);
-    return *pCurrentBaseParams;
+    return currentBaseParams.Get();
+}
+
+CBaseChainParams* FactoryBaseParams(std::string chain)
+{
+    if (chain == CBaseChainParams::MAIN)
+        return new CBaseMainParams();
+    else if (chain == CBaseChainParams::TESTNET)
+        return new CBaseTestNetParams();
+    else if (chain == CBaseChainParams::REGTEST)
+        return new CBaseRegTestParams();
+    throw std::runtime_error(strprintf(_("%s: Unknown chain %s."), __func__, chain));
 }
 
 void SelectBaseParams(std::string chain)
 {
-    if (chain == CBaseChainParams::MAIN)
-        pCurrentBaseParams = &mainParams;
-    else if (chain == CBaseChainParams::TESTNET)
-        pCurrentBaseParams = &testNetParams;
-    else if (chain == CBaseChainParams::REGTEST)
-        pCurrentBaseParams = &regTestParams;
-    else
-        throw std::runtime_error(strprintf(_("%s: Unknown chain %s."), __func__, chain));
+    currentBaseParams.Set(FactoryBaseParams(chain));
 }
 
 std::string ChainNameFromCommandLine()
@@ -114,5 +113,5 @@ bool SelectBaseParamsFromCommandLine()
 
 bool AreBaseParamsConfigured()
 {
-    return pCurrentBaseParams != NULL;
+    return !currentBaseParams.IsNull();
 }

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -10,7 +10,7 @@
 #include "util.h"
 
 const std::string CBaseChainParams::MAIN = "main";
-const std::string CBaseChainParams::TESTNET = "test";
+const std::string CBaseChainParams::TESTNET = "testnet3";
 const std::string CBaseChainParams::REGTEST = "regtest";
 const std::string CBaseChainParams::MAX_NETWORK_TYPES = "unknown_chain";
 
@@ -35,7 +35,7 @@ public:
     CBaseTestNetParams()
     {
         nRPCPort = 18332;
-        strDataDir = "testnet3";
+        strDataDir = CBaseChainParams::TESTNET;
     }
 };
 

--- a/src/chainparamsbase.h
+++ b/src/chainparamsbase.h
@@ -32,12 +32,19 @@ protected:
 };
 
 /**
+ * Creates a CBaseChainParams of the chosen chain and returns a
+ * pointer to it. The caller has to delete the object.
+ * Raises an error if the chain is not supported.
+ */
+CBaseChainParams* FactoryBaseParams(std::string chain);
+/**
  * Looks for -regtest, -testnet and returns the appropriate BIP70 chain name.
  * Returns CBaseChainParams::MAIN by default.
  * Returns CBaseChainParams::MAX_NETWORK_TYPES if an invalid combination is given.
  */
 std::string ChainNameFromCommandLine();
 
+/** Functions that relay on internal state */
 /**
  * Return the currently selected parameters. This won't change after app
  * startup, except for unit tests.

--- a/src/chainparamsbase.h
+++ b/src/chainparamsbase.h
@@ -15,13 +15,11 @@
 class CBaseChainParams
 {
 public:
-    enum Network {
-        MAIN,
-        TESTNET,
-        REGTEST,
-
-        MAX_NETWORK_TYPES
-    };
+    /** BIP70 chain name strings (main, test or regtest) */
+    static const std::string MAIN;
+    static const std::string TESTNET;
+    static const std::string REGTEST;
+    static const std::string MAX_NETWORK_TYPES;
 
     const std::string& DataDir() const { return strDataDir; }
     int RPCPort() const { return nRPCPort; }
@@ -34,19 +32,23 @@ protected:
 };
 
 /**
+ * Looks for -regtest, -testnet and returns the appropriate BIP70 chain name.
+ * Returns CBaseChainParams::MAIN by default.
+ * Returns CBaseChainParams::MAX_NETWORK_TYPES if an invalid combination is given.
+ */
+std::string ChainNameFromCommandLine();
+
+/**
  * Return the currently selected parameters. This won't change after app
  * startup, except for unit tests.
  */
 const CBaseChainParams& BaseParams();
 
-/** Sets the params returned by Params() to those for the given network. */
-void SelectBaseParams(CBaseChainParams::Network network);
-
 /**
- * Looks for -regtest or -testnet and returns the appropriate Network ID.
- * Returns MAX_NETWORK_TYPES if an invalid combination is given.
+ * Sets the params returned by BaseParams() to those for the appropriate chain returned by ChainNameFromCommandLine().
+ * Raises a std::runtime_error if an unsupported chain name is given.
  */
-CBaseChainParams::Network NetworkIdFromCommandLine();
+void SelectBaseParams(std::string chain);
 
 /**
  * Calls NetworkIdFromCommandLine() and then calls SelectParams as appropriate.
@@ -55,8 +57,7 @@ CBaseChainParams::Network NetworkIdFromCommandLine();
 bool SelectBaseParamsFromCommandLine();
 
 /**
- * Return true if SelectBaseParamsFromCommandLine() has been called to select
- * a network.
+ * Return true if SelectBaseParamsFromCommandLine() has been called to select a chain.
  */
 bool AreBaseParamsConfigured();
 

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -581,12 +581,10 @@ TableViewLastColumnResizingFixer::TableViewLastColumnResizingFixer(QTableView* t
 #ifdef WIN32
 boost::filesystem::path static StartupShortcutPath()
 {
-    if (GetBoolArg("-testnet", false))
-        return GetSpecialFolderPath(CSIDL_STARTUP) / "Bitcoin (testnet).lnk";
-    else if (GetBoolArg("-regtest", false))
-        return GetSpecialFolderPath(CSIDL_STARTUP) / "Bitcoin (regtest).lnk";
-
-    return GetSpecialFolderPath(CSIDL_STARTUP) / "Bitcoin.lnk";
+    std::string chain = ChainNameFromCommandLine();
+    if (chain == CBaseChainParams::MAIN)
+        return GetSpecialFolderPath(CSIDL_STARTUP) / "Bitcoin.lnk";
+    return GetSpecialFolderPath(CSIDL_STARTUP) / strprintf("Bitcoin (%s).lnk", chain);
 }
 
 bool GetStartOnSystemStartup()
@@ -719,15 +717,14 @@ bool SetStartOnSystemStartup(bool fAutoStart)
         boost::filesystem::ofstream optionFile(GetAutostartFilePath(), std::ios_base::out|std::ios_base::trunc);
         if (!optionFile.good())
             return false;
+        std::string chain = ChainNameFromCommandLine();
         // Write a bitcoin.desktop file to the autostart directory:
         optionFile << "[Desktop Entry]\n";
         optionFile << "Type=Application\n";
-        if (GetBoolArg("-testnet", false))
-            optionFile << "Name=Bitcoin (testnet)\n";
-        else if (GetBoolArg("-regtest", false))
-            optionFile << "Name=Bitcoin (regtest)\n";
-        else
+        if (chain == CBaseChainParams::MAIN)
             optionFile << "Name=Bitcoin\n";
+        else
+            optionFile << strprintf("Name=Bitcoin (%s)\n", chain);
         optionFile << "Exec=" << pszExePath << strprintf(" -min -testnet=%d -regtest=%d\n", GetBoolArg("-testnet", false), GetBoolArg("-regtest", false));
         optionFile << "Terminal=false\n";
         optionFile << "Hidden=false\n";

--- a/src/qt/networkstyle.cpp
+++ b/src/qt/networkstyle.cpp
@@ -17,7 +17,7 @@ static const struct {
     const char *titleAddText;
 } network_styles[] = {
     {"main", QAPP_APP_NAME_DEFAULT, 0, 0, ""},
-    {"test", QAPP_APP_NAME_TESTNET, 70, 30, QT_TRANSLATE_NOOP("SplashScreen", "[testnet]")},
+    {"testnet3", QAPP_APP_NAME_TESTNET, 70, 30, QT_TRANSLATE_NOOP("SplashScreen", "[testnet3]")},
     {"regtest", QAPP_APP_NAME_TESTNET, 160, 30, "[regtest]"}
 };
 static const unsigned network_styles_count = sizeof(network_styles)/sizeof(*network_styles);

--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -241,14 +241,10 @@ void PaymentServer::ipcParseCommandLine(int argc, char* argv[])
             PaymentRequestPlus request;
             if (readPaymentRequestFromFile(arg, request))
             {
-                if (request.getDetails().network() == "main")
-                {
-                    SelectParams(CBaseChainParams::MAIN);
-                }
-                else if (request.getDetails().network() == "test")
-                {
-                    SelectParams(CBaseChainParams::TESTNET);
-                }
+                // TODO find out why this excludes regtest
+                std::string chainStr = request.getDetails().network();
+                if (chainStr == CBaseChainParams::MAIN || chainStr == CBaseChainParams::TESTNET)
+                    SelectParams(chainStr);
             }
         }
         else

--- a/src/qt/test/paymentservertests.cpp
+++ b/src/qt/test/paymentservertests.cpp
@@ -141,7 +141,7 @@ void PaymentServerTests::paymentServerTests()
     data = DecodeBase64(paymentrequest1_cert2_BASE64);
     byteArray = QByteArray((const char*)&data[0], data.size());
     r.paymentRequest.parse(byteArray);
-    // Ensure the request is initialized, because network "main" is default, even for
+    // Ensure the request is initialized, because network CBaseChainParams::MAIN is default, even for
     // uninizialized payment requests and that will fail our test here.
     QVERIFY(r.paymentRequest.IsInitialized());
     QCOMPARE(PaymentServer::verifyNetwork(r.paymentRequest.getDetails()), false);

--- a/src/templates.hpp
+++ b/src/templates.hpp
@@ -1,0 +1,42 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2014 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_TEMPLATES_H
+#define BITCOIN_TEMPLATES_H
+
+#include <assert.h>
+#include <cstddef>
+
+template<typename T>
+class Container
+{
+    T* pObj;
+public:
+    Container() : pObj(NULL) {}
+    Container(T* pObjIn) : pObj(pObjIn) {}
+    ~Container()
+    {
+        if (!IsNull())
+            delete(pObj);
+    }
+
+    bool IsNull()
+    {
+        return pObj == NULL;
+    }
+    const T& Get()
+    {
+        assert(!IsNull());
+        return *pObj;
+    }
+    void Set(T* pObjIn)
+    {
+        if (!IsNull())
+            delete(pObj);
+        pObj = pObjIn;
+    }
+};
+
+#endif // BITCOIN_TEMPLATES_H

--- a/src/test/alert_tests.cpp
+++ b/src/test/alert_tests.cpp
@@ -202,7 +202,7 @@ BOOST_AUTO_TEST_CASE(PartitionAlert)
     // Test PartitionCheck
     CCriticalSection csDummy;
     CBlockIndex indexDummy[100];
-    CChainParams& params = Params(CBaseChainParams::MAIN);
+    const CChainParams& params = Params(CBaseChainParams::MAIN);
     int64_t nPowTargetSpacing = params.GetConsensus().nPowTargetSpacing;
 
     // Generate fake blockchain timestamps relative to


### PR DESCRIPTION
Several improvements related to chainparams were accumulating in #5229, but they don't need to add a new option for them to make sense, so I'm taking them ot for discussion.
Since there are several somewhat-orthogonal changes here, the scope of the PR will probably be reduced after discussion.
There are several changes:
- The use of a more conventional factory is interesting for separating the stateless parts of chainparams later like @theuni planned to do (the stateless factory could remain where it is).
- Replacing the enum with constant strings (suggested by @laanwj ) may not seem very useful by itself, but it allows to unify some things (also simplifies things for the factory).

The most controversial thing is proposing to unify some things for testnet that are already unified for regtest.
The first step would be to replace the user-facing strings (including windows' direct access names) to fit the chain names described in bip70 (use "test" instead of "testnet").
We could also unify the default name for the data directory. That would mean either change the directory file from "testnet3" to "test" (not retro-compatible) or changing the chain name "test" to "testnet3" in BIP70. I don't understand why "test" was chosen instead of "testnet" for bip70 in the first place so my preference is the later.
For the user-facing strings, that would be like having changed directly from "testnet" to "testnet3" (without passing through the current bip70-compatible "test").
