### PR TITLE
Checkpoints: The hash of the genesis block it's the genesis checkpoint

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -108,6 +108,7 @@ public:
 
         checkpointData = (Checkpoints::CCheckpointData) {
             boost::assign::map_list_of
+            (     0, consensus.hashGenesisBlock)
             ( 11111, uint256S("0x0000000069e244f73d78e8fd29ba2fd2ed618bd6fa2ee92559f542fdb26e7c1d"))
             ( 33333, uint256S("0x000000002dd5588a74784eaa7ab0507a18ad16a236e7b1ce69f00d7ddfb5d0a6"))
             ( 74000, uint256S("0x0000000000573993a3c9e41ce34471c079dcf5f52a0e824a81e7f953b8661a20"))
@@ -180,6 +181,7 @@ public:
 
         checkpointData = (Checkpoints::CCheckpointData) {
             boost::assign::map_list_of
+            (     0, consensus.hashGenesisBlock)
             ( 546, uint256S("000000002a936ca763904c3c35fce2f3556c559c0214345d31b1bcebf76acb70")),
             1337966069,
             1488,
@@ -227,7 +229,7 @@ public:
 
         checkpointData = (Checkpoints::CCheckpointData){
             boost::assign::map_list_of
-            ( 0, uint256S("0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206")),
+            (     0, consensus.hashGenesisBlock),
             0,
             0,
             0


### PR DESCRIPTION
It's nicer to have all the hardcoded hashes of the genesis blocks of the respective supported chains together.
More importantly, all chains should have the genesis block as checkpoint. That way the checkpoint logic can always trust the first checkpoint and hopefully we will be able to save some `if (block.GetHash() != chainparams.GetConsensus().hashGenesisBlock)` here and there.
I also add some tests to checkpoints. They're not very important since the asserts in chainparams would already detect any change in the genesis block, but it makes sure that "the checkpoint logic can always trust the first checkpoint".
In fact, the genesis checkpoint is that is immune to reorgs, by definition.
The genesis block is the first rule and the only true chain ID (because one based in names would require a memorable-ID system [and those are centralized and/or vulnerable to squatting]).
(Shares base commit with #6229)
