### PR TITLE
Increase DEFAULT_BLOCK_MAX_SIZE to 1MB

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -48,7 +48,7 @@ class CValidationState;
 struct CNodeStateStats;
 
 /** Default for -blockmaxsize and -blockminsize, which control the range of sizes the mining code will create **/
-static const unsigned int DEFAULT_BLOCK_MAX_SIZE = 750000;
+static const unsigned int DEFAULT_BLOCK_MAX_SIZE = 1000000;
 static const unsigned int DEFAULT_BLOCK_MIN_SIZE = 0;
 /** Default for -blockprioritysize, maximum space for zero/low-fee transactions **/
 static const unsigned int DEFAULT_BLOCK_PRIORITY_SIZE = 50000;


### PR DESCRIPTION
It seems a number of miners are using the default 750kb block size limit, why not set the default to 1MB? I realise it's not going to solve the current block size limit debate - but every little helps and, unless I'm mistaken, is a very simple/safe change?
