### PR TITLE
fix rpcmining/getblocktemplate univalue transition logic error

### DIFF
--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -398,7 +398,7 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
         if (strMode == "proposal")
         {
             const UniValue& dataval = find_value(oparam, "data");
-            if (dataval.isStr())
+            if (!dataval.isStr())
                 throw JSONRPCError(RPC_TYPE_ERROR, "Missing data String key for proposal");
 
             CBlock block;


### PR DESCRIPTION
**Reported by @sdaftuar (Thanks!).**

This fixes a bug that was included in #6121 during the transition from Json Spirit to UniValue.
