### PR TITLE
Fixed link to Xcode 6.1.1

### DIFF
--- a/doc/README_osx.txt
+++ b/doc/README_osx.txt
@@ -29,8 +29,7 @@ originally done in toolchain4.
 
 To complicate things further, all builds must target an Apple SDK. These SDKs
 are free to download, but not redistributable.
-To obtain it, register for a developer account, then download the XCode 6.1.1 dmg:
-https://developer.apple.com/downloads/download.action?path=Developer_Tools/xcode_6.1.1/xcode_6.1.1.dmg
+To obtain it, register for a developer account, sign in to https://developer.apple.com/downloads/, then download the XCode 6.1.1 dmg.
 
 This file is several gigabytes in size, but only a single directory inside is
 needed: Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.9.sdk

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -44,7 +44,7 @@ Release Process
 
  Register and download the Apple SDK: (see OSX Readme for details)
  
- https://developer.apple.com/downloads/download.action?path=Developer_Tools/xcode_6.1.1/xcode_6.1.1.dmg
+ Sign in to https://developer.apple.com/downloads/ and download Xcode 6.1.1.
  
  Using a Mac, create a tarball for the 10.9 SDK and copy it to the inputs directory:
  


### PR DESCRIPTION
Previous link was dead.
