### PR TITLE
Add -requirestandard command line option

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -394,6 +394,7 @@ std::string HelpMessage(HelpMessageMode mode)
     }
     strUsage += HelpMessageOpt("-shrinkdebugfile", _("Shrink debug.log file on client startup (default: 1 when no -debug)"));
     strUsage += HelpMessageOpt("-testnet", _("Use the test network"));
+    strUsage += HelpMessageOpt("-requirestandard", _("Require transactions to be standard even in testnet/regtest"));
 
     strUsage += HelpMessageGroup(_("Node relay options:"));
     strUsage += HelpMessageOpt("-datacarrier", strprintf(_("Relay and mine data carrier transactions (default: %u)"), 1));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -898,7 +898,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
 
     // Rather not work on nonstandard transactions (unless -testnet/-regtest)
     string reason;
-    if (Params().RequireStandard() && !IsStandardTx(tx, reason))
+    if ((Params().RequireStandard() || GetBoolArg("-requirestandard", false)) && !IsStandardTx(tx, reason))
         return state.DoS(0,
                          error("AcceptToMemoryPool: nonstandard transaction: %s", reason),
                          REJECT_NONSTANDARD, reason);
@@ -969,7 +969,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
         }
 
         // Check for non-standard pay-to-script-hash in inputs
-        if (Params().RequireStandard() && !AreInputsStandard(tx, view))
+        if ((Params().RequireStandard() || GetBoolArg("-requirestandard", false)) && !AreInputsStandard(tx, view))
             return error("AcceptToMemoryPool: nonstandard transaction input");
 
         // Check that the transaction doesn't have an excessive number of


### PR DESCRIPTION
Previousy there was no way to enable IsStandard() in testnet or regtest, making testing related to standardness difficult. This new option lets you (optionally) enable IsStandard() during testing, better approximating the behavior of mainnet.
