### PR TITLE
Disconnect node on addnode remove

### DIFF
--- a/src/rpcnet.cpp
+++ b/src/rpcnet.cpp
@@ -209,9 +209,7 @@ UniValue addnode(const UniValue& params, bool fHelp)
         CNode* pNode = FindNode(strNode.c_str());
 
         if (pNode != NULL)
-        {
             pNode->CloseSocketDisconnect();
-        }
 
         if (it == vAddedNodes.end())
             throw JSONRPCError(RPC_CLIENT_NODE_NOT_ADDED, "Error: Node has not been added.");

--- a/src/rpcnet.cpp
+++ b/src/rpcnet.cpp
@@ -206,6 +206,13 @@ UniValue addnode(const UniValue& params, bool fHelp)
     }
     else if(strCommand == "remove")
     {
+        CNode* pNode = FindNode(strNode.c_str());
+
+        if (pNode != NULL)
+        {
+            pNode->CloseSocketDisconnect();
+        }
+
         if (it == vAddedNodes.end())
             throw JSONRPCError(RPC_CLIENT_NODE_NOT_ADDED, "Error: Node has not been added.");
         vAddedNodes.erase(it);


### PR DESCRIPTION
On calling addnode <ip> remove, now disconnects from said node immediately per issue #2729. Requires the port to be specified in the IP parameter for it to be found and disconnected however.
