### PR TITLE
Tighten up message size sanity checking

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -63,6 +63,7 @@ BITCOIN_TESTS =\
   test/policyestimator_tests.cpp \
   test/pow_tests.cpp \
   test/reverselock_tests.cpp \
+  test/ReceiveMsgBytes_tests.cpp \
   test/rpc_tests.cpp \
   test/sanity_tests.cpp \
   test/scheduler_tests.cpp \

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -37,6 +37,7 @@
 #include <sstream>
 
 #include <boost/algorithm/string/replace.hpp>
+#include <boost/assign/list_of.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/filesystem/fstream.hpp>
 #include <boost/math/distributions/poisson.hpp>
@@ -86,6 +87,8 @@ struct COrphanTx {
 map<uint256, COrphanTx> mapOrphanTransactions GUARDED_BY(cs_main);;
 map<uint256, set<uint256> > mapOrphanTransactionsByPrev GUARDED_BY(cs_main);;
 void EraseOrphansFor(NodeId peer) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+
+static bool SanityCheckMessage(CNode* peer, const CNetMessage& msg);
 
 /**
  * Returns true if there are nRequired or more blocks of minVersion or above
@@ -567,6 +570,7 @@ bool GetNodeStateStats(NodeId nodeid, CNodeStateStats &stats) {
 void RegisterNodeSignals(CNodeSignals& nodeSignals)
 {
     nodeSignals.GetHeight.connect(&GetHeight);
+    nodeSignals.SanityCheckMessages.connect(&SanityCheckMessage);
     nodeSignals.ProcessMessages.connect(&ProcessMessages);
     nodeSignals.SendMessages.connect(&SendMessages);
     nodeSignals.InitializeNode.connect(&InitializeNode);
@@ -576,6 +580,7 @@ void RegisterNodeSignals(CNodeSignals& nodeSignals)
 void UnregisterNodeSignals(CNodeSignals& nodeSignals)
 {
     nodeSignals.GetHeight.disconnect(&GetHeight);
+    nodeSignals.SanityCheckMessages.disconnect(&SanityCheckMessage);
     nodeSignals.ProcessMessages.disconnect(&ProcessMessages);
     nodeSignals.SendMessages.disconnect(&SendMessages);
     nodeSignals.InitializeNode.disconnect(&InitializeNode);
@@ -3752,6 +3757,30 @@ std::string GetWarnings(const std::string& strFor)
 //
 // Messages
 //
+
+static std::map<std::string, size_t> maxMessageSizes = boost::assign::map_list_of
+    ("getaddr",0)
+    ("mempool",0)
+    ("ping",8)
+    ("pong",8)
+    ("verack", 0)
+    ;
+
+bool static SanityCheckMessage(CNode* peer, const CNetMessage& msg)
+{
+    const std::string& strCommand = msg.hdr.GetCommand();
+    if (msg.hdr.nMessageSize > MAX_PROTOCOL_MESSAGE_LENGTH ||
+        (maxMessageSizes.count(strCommand) && msg.hdr.nMessageSize > maxMessageSizes[strCommand])) {
+        LogPrint("net", "Oversized %s message from peer=%i (%d bytes)\n",
+                 SanitizeString(strCommand), peer->GetId(), msg.hdr.nMessageSize);
+        Misbehaving(peer->GetId(), 20);
+        return msg.hdr.nMessageSize <= MAX_PROTOCOL_MESSAGE_LENGTH;
+    }
+    // This would be a good place for more sophisticated DoS detection/prevention.
+    // (e.g. disconnect a peer that is flooding us with excessive messages)
+
+    return true;
+}
 
 
 bool static AlreadyHave(const CInv& inv) EXCLUSIVE_LOCKS_REQUIRED(cs_main)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -271,16 +271,63 @@ struct CNodeState {
     }
 };
 
-/** Map maintaining per-node state. Requires cs_main. */
-map<NodeId, CNodeState> mapNodeState;
+// Class that maintains per-node state, and
+// acts as a RAII smart-pointer that make sure
+// the state stays consistent.
+class NodeStatePtr {
+private:
+    static CCriticalSection cs_mapNodeState;
+    static map<NodeId, CNodeState> mapNodeState;
+    CNodeState* s;
+    NodeId id;
+public:
+    static void insert(NodeId nodeid, const CNode *pnode) {
+        LOCK(cs_mapNodeState);
+        CNodeState &state = mapNodeState.insert(std::make_pair(nodeid, CNodeState())).first->second;
+        state.name = pnode->addrName;
+        state.address = pnode->addr;
+    }
 
-// Requires cs_main.
-CNodeState *State(NodeId pnode) {
-    map<NodeId, CNodeState>::iterator it = mapNodeState.find(pnode);
-    if (it == mapNodeState.end())
-        return NULL;
-    return &it->second;
-}
+    NodeStatePtr(NodeId nodeid) {
+        LOCK(cs_mapNodeState);
+        map<NodeId, CNodeState>::iterator it = mapNodeState.find(nodeid);
+        if (it == mapNodeState.end())
+            s = NULL;
+        else {
+            s = &it->second;
+            id = nodeid;
+            cs_mapNodeState.lock();
+        }
+    }
+    ~NodeStatePtr() {
+        if (s)
+            cs_mapNodeState.unlock();
+    }
+    bool IsNull() const { return s == NULL; }
+
+    CNodeState* operator ->() { return s; }
+    const CNodeState* operator ->() const { return s; }
+
+    void erase() {
+        if (s) {
+            mapNodeState.erase(id);
+            s = NULL;
+            cs_mapNodeState.unlock();
+        }
+    }
+
+    static void clear() {
+        LOCK(cs_mapNodeState);
+        mapNodeState.clear();
+    }
+
+private:
+    // disallow copy/assignment
+    NodeStatePtr(const NodeStatePtr&) {}
+    NodeStatePtr& operator=(const NodeStatePtr& p) { return *this; }
+};
+CCriticalSection NodeStatePtr::cs_mapNodeState;
+map<NodeId, CNodeState> NodeStatePtr::mapNodeState;
 
 int GetHeight()
 {
@@ -288,7 +335,7 @@ int GetHeight()
     return chainActive.Height();
 }
 
-void UpdatePreferredDownload(CNode* node, CNodeState* state)
+void UpdatePreferredDownload(CNode* node, NodeStatePtr& state)
 {
     nPreferredDownload -= state->fPreferredDownload;
 
@@ -305,15 +352,12 @@ int64_t GetBlockTimeout(int64_t nTime, int nValidatedQueuedBefore, const Consens
 }
 
 void InitializeNode(NodeId nodeid, const CNode *pnode) {
-    LOCK(cs_main);
-    CNodeState &state = mapNodeState.insert(std::make_pair(nodeid, CNodeState())).first->second;
-    state.name = pnode->addrName;
-    state.address = pnode->addr;
+    NodeStatePtr::insert(nodeid, pnode);
 }
 
 void FinalizeNode(NodeId nodeid) {
     LOCK(cs_main);
-    CNodeState *state = State(nodeid);
+    NodeStatePtr state(nodeid);
 
     if (state->fSyncStarted)
         nSyncStarted--;
@@ -327,15 +371,16 @@ void FinalizeNode(NodeId nodeid) {
     EraseOrphansFor(nodeid);
     nPreferredDownload -= state->fPreferredDownload;
 
-    mapNodeState.erase(nodeid);
+    state.erase();
 }
 
 // Requires cs_main.
 // Returns a bool indicating whether we requested this block.
 bool MarkBlockAsReceived(const uint256& hash) {
+    AssertLockHeld(cs_main);
     map<uint256, pair<NodeId, list<QueuedBlock>::iterator> >::iterator itInFlight = mapBlocksInFlight.find(hash);
     if (itInFlight != mapBlocksInFlight.end()) {
-        CNodeState *state = State(itInFlight->second.first);
+        NodeStatePtr state(itInFlight->second.first);
         nQueuedValidatedHeaders -= itInFlight->second.second->fValidatedHeaders;
         state->nBlocksInFlightValidHeaders -= itInFlight->second.second->fValidatedHeaders;
         state->vBlocksInFlight.erase(itInFlight->second.second);
@@ -349,11 +394,13 @@ bool MarkBlockAsReceived(const uint256& hash) {
 
 // Requires cs_main.
 void MarkBlockAsInFlight(NodeId nodeid, const uint256& hash, const Consensus::Params& consensusParams, CBlockIndex *pindex = NULL) {
-    CNodeState *state = State(nodeid);
-    assert(state != NULL);
+    AssertLockHeld(cs_main);
 
     // Make sure it's not listed somewhere already.
     MarkBlockAsReceived(hash);
+
+    NodeStatePtr state(nodeid);
+    assert(!state.IsNull());
 
     int64_t nNow = GetTimeMicros();
     QueuedBlock newentry = {hash, pindex, nNow, pindex != NULL, GetBlockTimeout(nNow, nQueuedValidatedHeaders, consensusParams)};
@@ -365,9 +412,8 @@ void MarkBlockAsInFlight(NodeId nodeid, const uint256& hash, const Consensus::Pa
 }
 
 /** Check whether the last unknown block a peer advertized is not yet known. */
-void ProcessBlockAvailability(NodeId nodeid) {
-    CNodeState *state = State(nodeid);
-    assert(state != NULL);
+static void ProcessBlockAvailability(NodeStatePtr& state) {
+    AssertLockHeld(cs_main);
 
     if (!state->hashLastUnknownBlock.IsNull()) {
         BlockMap::iterator itOld = mapBlockIndex.find(state->hashLastUnknownBlock);
@@ -381,10 +427,11 @@ void ProcessBlockAvailability(NodeId nodeid) {
 
 /** Update tracking information about which blocks a peer is assumed to have. */
 void UpdateBlockAvailability(NodeId nodeid, const uint256 &hash) {
-    CNodeState *state = State(nodeid);
-    assert(state != NULL);
+    AssertLockHeld(cs_main);
+    NodeStatePtr state(nodeid);
+    assert(!state.IsNull());
 
-    ProcessBlockAvailability(nodeid);
+    ProcessBlockAvailability(state);
 
     BlockMap::iterator it = mapBlockIndex.find(hash);
     if (it != mapBlockIndex.end() && it->second->nChainWork > 0) {
@@ -422,12 +469,13 @@ void FindNextBlocksToDownload(NodeId nodeid, unsigned int count, std::vector<CBl
     if (count == 0)
         return;
 
+    AssertLockHeld(cs_main);
     vBlocks.reserve(vBlocks.size() + count);
-    CNodeState *state = State(nodeid);
-    assert(state != NULL);
+    NodeStatePtr state(nodeid);
+    assert(!state.IsNull());
 
     // Make sure pindexBestKnownBlock is up to date, we'll need it.
-    ProcessBlockAvailability(nodeid);
+    ProcessBlockAvailability(state);
 
     if (state->pindexBestKnownBlock == NULL || state->pindexBestKnownBlock->nChainWork < chainActive.Tip()->nChainWork) {
         // This peer has nothing interesting.
@@ -503,9 +551,8 @@ void FindNextBlocksToDownload(NodeId nodeid, unsigned int count, std::vector<CBl
 } // anon namespace
 
 bool GetNodeStateStats(NodeId nodeid, CNodeStateStats &stats) {
-    LOCK(cs_main);
-    CNodeState *state = State(nodeid);
-    if (state == NULL)
+    NodeStatePtr state(nodeid);
+    if (state.IsNull())
         return false;
     stats.nMisbehavior = state->nMisbehavior;
     stats.nSyncHeight = state->pindexBestKnownBlock ? state->pindexBestKnownBlock->nHeight : -1;
@@ -1196,14 +1243,13 @@ void CheckForkWarningConditionsOnNewFork(CBlockIndex* pindexNewForkTip)
     CheckForkWarningConditions();
 }
 
-// Requires cs_main.
 void Misbehaving(NodeId pnode, int howmuch)
 {
     if (howmuch == 0)
         return;
 
-    CNodeState *state = State(pnode);
-    if (state == NULL)
+    NodeStatePtr state(pnode);
+    if (state.IsNull())
         return;
 
     state->nMisbehavior += howmuch;
@@ -1237,10 +1283,11 @@ void static InvalidBlockFound(CBlockIndex *pindex, const CValidationState &state
     int nDoS = 0;
     if (state.IsInvalid(nDoS)) {
         std::map<uint256, NodeId>::iterator it = mapBlockSource.find(pindex->GetBlockHash());
-        if (it != mapBlockSource.end() && State(it->second)) {
+        NodeStatePtr nodeState(it->second);
             assert (state.GetRejectCode() < REJECT_INTERNAL); // Blocks are never rejected with internal reject codes
+        if (it != mapBlockSource.end() && !nodeState.IsNull()) {
             CBlockReject reject = {(unsigned char)state.GetRejectCode(), state.GetRejectReason().substr(0, MAX_REJECT_MESSAGE_LENGTH), pindex->GetBlockHash()};
-            State(it->second)->rejects.push_back(reject);
+            nodeState->rejects.push_back(reject);
             if (nDoS > 0)
                 Misbehaving(it->second, nDoS);
         }
@@ -3285,7 +3332,7 @@ void UnloadBlockIndex()
     nPreferredDownload = 0;
     setDirtyBlockIndex.clear();
     setDirtyFileInfo.clear();
-    mapNodeState.clear();
+    NodeStatePtr::clear();
     recentRejects.reset(NULL);
 
     BOOST_FOREACH(BlockMap::value_type& entry, mapBlockIndex) {
@@ -3944,7 +3991,10 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         pfrom->fClient = !(pfrom->nServices & NODE_NETWORK);
 
         // Potentially mark this peer as a preferred download peer.
-        UpdatePreferredDownload(pfrom, State(pfrom->GetId()));
+        {
+            NodeStatePtr nodeState(pfrom->GetId());
+            UpdatePreferredDownload(pfrom, nodeState);
+        }
 
         // Change version
         pfrom->PushMessage("verack");
@@ -4018,8 +4068,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
 
         // Mark this node as currently connected, so we update its timestamp later.
         if (pfrom->fNetworkNode) {
-            LOCK(cs_main);
-            State(pfrom->GetId())->fCurrentlyConnected = true;
+            NodeStatePtr(pfrom->GetId())->fCurrentlyConnected = true;
         }
     }
 
@@ -4130,7 +4179,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                     // doing this will result in the received block being rejected as an orphan in case it is
                     // not a direct successor.
                     pfrom->PushMessage("getheaders", chainActive.GetLocator(pindexBestHeader), inv.hash);
-                    CNodeState *nodestate = State(pfrom->GetId());
+                    NodeStatePtr nodestate(pfrom->GetId());
                     if (chainActive.Tip()->GetBlockTime() > GetAdjustedTime() - chainparams.GetConsensus().nPowTargetSpacing * 20 &&
                         nodestate->nBlocksInFlight < MAX_BLOCKS_IN_TRANSIT_PER_PEER) {
                         vToFetch.push_back(inv);
@@ -4926,8 +4975,8 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
                 pto->PushMessage("addr", vAddr);
         }
 
-        CNodeState &state = *State(pto->GetId());
-        if (state.fShouldBan) {
+        NodeStatePtr statePtr(pto->GetId());
+        if (statePtr->fShouldBan) {
             if (pto->fWhitelisted)
                 LogPrintf("Warning: not punishing whitelisted peer %s!\n", pto->addr.ToString());
             else {
@@ -4939,21 +4988,21 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
                     CNode::Ban(pto->addr, BanReasonNodeMisbehaving);
                 }
             }
-            state.fShouldBan = false;
+            statePtr->fShouldBan = false;
         }
 
-        BOOST_FOREACH(const CBlockReject& reject, state.rejects)
+        BOOST_FOREACH(const CBlockReject& reject, statePtr->rejects)
             pto->PushMessage("reject", (string)"block", reject.chRejectCode, reject.strRejectReason, reject.hashBlock);
-        state.rejects.clear();
+        statePtr->rejects.clear();
 
         // Start block sync
         if (pindexBestHeader == NULL)
             pindexBestHeader = chainActive.Tip();
-        bool fFetch = state.fPreferredDownload || (nPreferredDownload == 0 && !pto->fClient && !pto->fOneShot); // Download if this is a nice peer, or we have no nice peers and this one might do.
-        if (!state.fSyncStarted && !pto->fClient && !fImporting && !fReindex) {
+        bool fFetch = statePtr->fPreferredDownload || (nPreferredDownload == 0 && !pto->fClient && !pto->fOneShot); // Download if this is a nice peer, or we have no nice peers and this one might do.
+        if (!statePtr->fSyncStarted && !pto->fClient && !fImporting && !fReindex) {
             // Only actively request headers from a single peer, unless we're close to today.
             if ((nSyncStarted == 0 && fFetch) || pindexBestHeader->GetBlockTime() > GetAdjustedTime() - 24 * 60 * 60) {
-                state.fSyncStarted = true;
+                statePtr->fSyncStarted = true;
                 nSyncStarted++;
                 CBlockIndex *pindexStart = pindexBestHeader->pprev ? pindexBestHeader->pprev : pindexBestHeader;
                 LogPrint("net", "initial getheaders (%d) to peer=%d (startheight:%d)\n", pindexStart->nHeight, pto->id, pto->nStartingHeight);
@@ -5019,7 +5068,7 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
 
         // Detect whether we're stalling
         int64_t nNow = GetTimeMicros();
-        if (!pto->fDisconnect && state.nStallingSince && state.nStallingSince < nNow - 1000000 * BLOCK_STALLING_TIMEOUT) {
+        if (!pto->fDisconnect && statePtr->nStallingSince && statePtr->nStallingSince < nNow - 1000000 * BLOCK_STALLING_TIMEOUT) {
             // Stalling only triggers when the block download window cannot move. During normal steady state,
             // the download window should be much larger than the to-be-downloaded set of blocks, so disconnection
             // should only happen during initial block download.
@@ -5036,9 +5085,9 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
         // only looking at this peer's oldest request).  This way a large queue in the past doesn't result in a
         // permanently large window for this block to be delivered (ie if the number of blocks in flight is decreasing
         // more quickly than once every 5 minutes, then we'll shorten the download window for this block).
-        if (!pto->fDisconnect && state.vBlocksInFlight.size() > 0) {
-            QueuedBlock &queuedBlock = state.vBlocksInFlight.front();
-            int64_t nTimeoutIfRequestedNow = GetBlockTimeout(nNow, nQueuedValidatedHeaders - state.nBlocksInFlightValidHeaders, consensusParams);
+        if (!pto->fDisconnect && statePtr->vBlocksInFlight.size() > 0) {
+            QueuedBlock &queuedBlock = statePtr->vBlocksInFlight.front();
+            int64_t nTimeoutIfRequestedNow = GetBlockTimeout(nNow, nQueuedValidatedHeaders - statePtr->nBlocksInFlightValidHeaders, consensusParams);
             if (queuedBlock.nTimeDisconnect > nTimeoutIfRequestedNow) {
                 LogPrint("net", "Reducing block download timeout for peer=%d block=%s, orig=%d new=%d\n", pto->id, queuedBlock.hash.ToString(), queuedBlock.nTimeDisconnect, nTimeoutIfRequestedNow);
                 queuedBlock.nTimeDisconnect = nTimeoutIfRequestedNow;
@@ -5053,19 +5102,19 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
         // Message: getdata (blocks)
         //
         vector<CInv> vGetData;
-        if (!pto->fDisconnect && !pto->fClient && (fFetch || !IsInitialBlockDownload()) && state.nBlocksInFlight < MAX_BLOCKS_IN_TRANSIT_PER_PEER) {
+        if (!pto->fDisconnect && !pto->fClient && (fFetch || !IsInitialBlockDownload()) && statePtr->nBlocksInFlight < MAX_BLOCKS_IN_TRANSIT_PER_PEER) {
             vector<CBlockIndex*> vToDownload;
             NodeId staller = -1;
-            FindNextBlocksToDownload(pto->GetId(), MAX_BLOCKS_IN_TRANSIT_PER_PEER - state.nBlocksInFlight, vToDownload, staller);
+            FindNextBlocksToDownload(pto->GetId(), MAX_BLOCKS_IN_TRANSIT_PER_PEER - statePtr->nBlocksInFlight, vToDownload, staller);
             BOOST_FOREACH(CBlockIndex *pindex, vToDownload) {
                 vGetData.push_back(CInv(MSG_BLOCK, pindex->GetBlockHash()));
                 MarkBlockAsInFlight(pto->GetId(), pindex->GetBlockHash(), consensusParams, pindex);
                 LogPrint("net", "Requesting block %s (%d) peer=%d\n", pindex->GetBlockHash().ToString(),
                     pindex->nHeight, pto->id);
             }
-            if (state.nBlocksInFlight == 0 && staller != -1) {
-                if (State(staller)->nStallingSince == 0) {
-                    State(staller)->nStallingSince = nNow;
+            if (statePtr->nBlocksInFlight == 0 && staller != -1) {
+                if (NodeStatePtr(staller)->nStallingSince == 0) {
+                    NodeStatePtr(staller)->nStallingSince = nNow;
                     LogPrint("net", "Stall started peer=%d\n", staller);
                 }
             }

--- a/src/main.h
+++ b/src/main.h
@@ -79,6 +79,8 @@ static const unsigned int DATABASE_WRITE_INTERVAL = 60 * 60;
 static const unsigned int DATABASE_FLUSH_INTERVAL = 24 * 60 * 60;
 /** Maximum length of reject messages. */
 static const unsigned int MAX_REJECT_MESSAGE_LENGTH = 111;
+/** Maximum length of incoming protocol messages (no message over 2 MiB is currently acceptable). */
+static const unsigned int MAX_PROTOCOL_MESSAGE_LENGTH = 2 * 1024 * 1024;
 
 struct BlockHasher
 {

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -656,12 +656,10 @@ bool CNode::ReceiveMsgBytes(const char *pch, unsigned int nBytes)
             handled = msg.readData(pch, nBytes);
 
         if (handled < 0)
-                return false;
-
-        if (msg.in_data && msg.hdr.nMessageSize > MAX_PROTOCOL_MESSAGE_LENGTH) {
-            LogPrint("net", "Oversized message from peer=%i, disconnecting\n", GetId());
             return false;
-        }
+
+        if (msg.in_data && !g_signals.SanityCheckMessages(this, boost::ref(msg)))
+            return false;
 
         pch += handled;
         nBytes -= handled;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -675,6 +675,22 @@ bool CNode::ReceiveMsgBytes(const char *pch, unsigned int nBytes)
     return true;
 }
 
+unsigned int CNetMessage::FinalizeHeader(CDataStream& s)
+{
+    // Set the size
+    unsigned int nSize = s.size() - CMessageHeader::HEADER_SIZE;
+    WriteLE32((uint8_t*)&s[CMessageHeader::MESSAGE_SIZE_OFFSET], nSize);
+
+    // Set the checksum
+    uint256 hash = Hash(s.begin() + CMessageHeader::HEADER_SIZE, s.end());
+    unsigned int nChecksum = 0;
+    memcpy(&nChecksum, &hash, sizeof(nChecksum));
+    assert(s.size () >= CMessageHeader::CHECKSUM_OFFSET + sizeof(nChecksum));
+    memcpy((char*)&s[CMessageHeader::CHECKSUM_OFFSET], &nChecksum, sizeof(nChecksum));
+
+    return nSize;
+}
+
 int CNetMessage::readHeader(const char *pch, unsigned int nBytes)
 {
     // copy data to temporary parsing buffer
@@ -2356,16 +2372,8 @@ void CNode::EndMessage() UNLOCK_FUNCTION(cs_vSend)
         LEAVE_CRITICAL_SECTION(cs_vSend);
         return;
     }
-    // Set the size
-    unsigned int nSize = ssSend.size() - CMessageHeader::HEADER_SIZE;
-    WriteLE32((uint8_t*)&ssSend[CMessageHeader::MESSAGE_SIZE_OFFSET], nSize);
 
-    // Set the checksum
-    uint256 hash = Hash(ssSend.begin() + CMessageHeader::HEADER_SIZE, ssSend.end());
-    unsigned int nChecksum = 0;
-    memcpy(&nChecksum, &hash, sizeof(nChecksum));
-    assert(ssSend.size () >= CMessageHeader::CHECKSUM_OFFSET + sizeof(nChecksum));
-    memcpy((char*)&ssSend[CMessageHeader::CHECKSUM_OFFSET], &nChecksum, sizeof(nChecksum));
+    unsigned int nSize = CNetMessage::FinalizeHeader(ssSend);
 
     LogPrint("net", "(%d bytes) peer=%d\n", nSize, id);
 

--- a/src/net.h
+++ b/src/net.h
@@ -30,6 +30,7 @@
 
 class CAddrMan;
 class CScheduler;
+class CNetMessage;
 class CNode;
 
 namespace boost {
@@ -44,8 +45,6 @@ static const int TIMEOUT_INTERVAL = 20 * 60;
 static const unsigned int MAX_INV_SZ = 50000;
 /** The maximum number of new addresses to accumulate before announcing. */
 static const unsigned int MAX_ADDR_TO_SEND = 1000;
-/** Maximum length of incoming protocol messages (no message over 2 MiB is currently acceptable). */
-static const unsigned int MAX_PROTOCOL_MESSAGE_LENGTH = 2 * 1024 * 1024;
 /** Maximum length of strSubVer in `version` message */
 static const unsigned int MAX_SUBVERSION_LENGTH = 256;
 /** -listen default */
@@ -96,10 +95,14 @@ struct CombinerAll
     }
 };
 
-// Signals for message handling
+// Signals are used to communicate with higher-level code.
 struct CNodeSignals
 {
     boost::signals2::signal<int ()> GetHeight;
+    // register a handler for this signal to do sanity checks as the bytes of a message are being
+    // received. Note that the message may not be completely read (so this can be
+    // used to prevent DoS attacks using over-size messages).
+    boost::signals2::signal<bool (CNode*, const CNetMessage&), CombinerAll> SanityCheckMessages;
     boost::signals2::signal<bool (CNode*), CombinerAll> ProcessMessages;
     boost::signals2::signal<bool (CNode*, bool), CombinerAll> SendMessages;
     boost::signals2::signal<void (NodeId, const CNode*)> InitializeNode;

--- a/src/net.h
+++ b/src/net.h
@@ -217,6 +217,9 @@ public:
         nTime = 0;
     }
 
+    // Called by CNode::EndMessage() and unit tests: modify stream to set size/checksum of header
+    static unsigned int FinalizeHeader(CDataStream& s);
+
     bool complete() const
     {
         if (!in_data)

--- a/src/test/ReceiveMsgBytes_tests.cpp
+++ b/src/test/ReceiveMsgBytes_tests.cpp
@@ -1,0 +1,90 @@
+// Copyright (c) 2011-2014 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+//
+// Unit tests for CNode::ReceiveMsgBytes
+//
+
+
+#include "chainparams.h"
+#include "main.h"
+#include "net.h"
+#include "pow.h"
+#include "serialize.h"
+#include "util.h"
+
+#include "test/test_bitcoin.h"
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(ReceiveMsgBytes_tests, TestingSetup)
+
+BOOST_AUTO_TEST_CASE(FullMessages)
+{
+    CNode testNode(INVALID_SOCKET, CAddress(CService("127.0.0.1", 0), NODE_NETWORK));
+    testNode.nVersion = 1;
+
+    CDataStream s(SER_NETWORK, PROTOCOL_VERSION);
+    s << CMessageHeader(Params(CBaseChainParams::MAIN).MessageStart(), "ping", 0);
+    s << (uint64_t)11; // ping nonce
+    CNetMessage::FinalizeHeader(s);
+
+    LOCK(testNode.cs_vRecvMsg);
+
+    // Receive a full 'ping' message
+    {
+        BOOST_CHECK(testNode.ReceiveMsgBytes(&s[0], s.size()));
+        BOOST_CHECK_EQUAL(testNode.vRecvMsg.size(), 1);
+        CNetMessage& msg = testNode.vRecvMsg[0];
+        BOOST_CHECK(msg.complete());
+        BOOST_CHECK_EQUAL(msg.hdr.GetCommand(), "ping");
+        uint64_t nonce;
+        msg.vRecv >> nonce;
+        BOOST_CHECK_EQUAL(nonce, (uint64_t)11);
+    }
+
+
+    testNode.vRecvMsg.clear();
+
+    // ...receive it one byte at a time:
+    {
+        for (size_t i = 0; i < s.size(); i++) {
+            BOOST_CHECK(testNode.ReceiveMsgBytes(&s[i], 1));
+        }
+        BOOST_CHECK_EQUAL(testNode.vRecvMsg.size(), 1);
+        CNetMessage& msg = testNode.vRecvMsg[0];
+        BOOST_CHECK(msg.complete());
+        BOOST_CHECK_EQUAL(msg.hdr.GetCommand(), "ping");
+        uint64_t nonce;
+        msg.vRecv >> nonce;
+        BOOST_CHECK_EQUAL(nonce, (uint64_t)11);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(TooLarge)
+{
+    CNode testNode(INVALID_SOCKET, CAddress(CService("127.0.0.1", 0), NODE_NETWORK));
+    testNode.nVersion = 1;
+
+    CDataStream s(SER_NETWORK, PROTOCOL_VERSION);
+    s << CMessageHeader(Params(CBaseChainParams::MAIN).MessageStart(), "ping", 0);
+    size_t headerLen = s.size();
+    s << (uint64_t)11; // ping nonce
+
+    // Test: too large
+    s.resize(MAX_PROTOCOL_MESSAGE_LENGTH+headerLen+1);
+    CNetMessage::FinalizeHeader(s);
+
+    BOOST_CHECK(!testNode.ReceiveMsgBytes(&s[0], s.size()));
+
+    testNode.vRecvMsg.clear();
+
+    // Test: exactly at max:
+    s.resize(MAX_PROTOCOL_MESSAGE_LENGTH+headerLen);
+    CNetMessage::FinalizeHeader(s);
+
+    BOOST_CHECK(testNode.ReceiveMsgBytes(&s[0], s.size()));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/ReceiveMsgBytes_tests.cpp
+++ b/src/test/ReceiveMsgBytes_tests.cpp
@@ -12,7 +12,7 @@
 #include "net.h"
 #include "pow.h"
 #include "serialize.h"
-#include "util.h"
+#include "utilstrencodings.h"
 
 #include "test/test_bitcoin.h"
 
@@ -35,7 +35,7 @@ BOOST_AUTO_TEST_CASE(FullMessages)
     // Receive a full 'ping' message
     {
         BOOST_CHECK(testNode.ReceiveMsgBytes(&s[0], s.size()));
-        BOOST_CHECK_EQUAL(testNode.vRecvMsg.size(), 1);
+        BOOST_CHECK_EQUAL(testNode.vRecvMsg.size(),1UL);
         CNetMessage& msg = testNode.vRecvMsg[0];
         BOOST_CHECK(msg.complete());
         BOOST_CHECK_EQUAL(msg.hdr.GetCommand(), "ping");
@@ -52,25 +52,31 @@ BOOST_AUTO_TEST_CASE(FullMessages)
         for (size_t i = 0; i < s.size(); i++) {
             BOOST_CHECK(testNode.ReceiveMsgBytes(&s[i], 1));
         }
-        BOOST_CHECK_EQUAL(testNode.vRecvMsg.size(), 1);
+        BOOST_CHECK_EQUAL(testNode.vRecvMsg.size(),1UL);
         CNetMessage& msg = testNode.vRecvMsg[0];
         BOOST_CHECK(msg.complete());
         BOOST_CHECK_EQUAL(msg.hdr.GetCommand(), "ping");
         uint64_t nonce;
         msg.vRecv >> nonce;
         BOOST_CHECK_EQUAL(nonce, (uint64_t)11);
-    }
+   }
 }
 
-BOOST_AUTO_TEST_CASE(TooLarge)
+BOOST_AUTO_TEST_CASE(TooLargeBlock)
 {
+    // Random real block (000000000000dab0130bbcc991d3d7ae6b81aa6f50a798888dfe62337458dc45)
+    // With one tx
+    CBlock block;
+    CDataStream stream(ParseHex("0100000079cda856b143d9db2c1caff01d1aecc8630d30625d10e8b4b8b0000000000000b50cc069d6a3e33e3ff84a5c41d9d3febe7c770fdcc96b2c3ff60abe184f196367291b4d4c86041b8fa45d630101000000010000000000000000000000000000000000000000000000000000000000000000ffffffff08044c86041b020a02ffffffff0100f2052a01000000434104ecd3229b0571c3be876feaac0442a9f13c5a572742927af1dc623353ecf8c202225f64868137a18cdd85cbbb4c74fbccfd4f49639cf1bdc94a5672bb15ad5d4cac00000000"), SER_NETWORK, PROTOCOL_VERSION);
+    stream >> block;
+
     CNode testNode(INVALID_SOCKET, CAddress(CService("127.0.0.1", 0), NODE_NETWORK));
     testNode.nVersion = 1;
 
     CDataStream s(SER_NETWORK, PROTOCOL_VERSION);
-    s << CMessageHeader(Params(CBaseChainParams::MAIN).MessageStart(), "ping", 0);
+    s << CMessageHeader(Params(CBaseChainParams::MAIN).MessageStart(), "block", 0);
     size_t headerLen = s.size();
-    s << (uint64_t)11; // ping nonce
+    s << block;
 
     // Test: too large
     s.resize(MAX_PROTOCOL_MESSAGE_LENGTH+headerLen+1);
@@ -85,6 +91,48 @@ BOOST_AUTO_TEST_CASE(TooLarge)
     CNetMessage::FinalizeHeader(s);
 
     BOOST_CHECK(testNode.ReceiveMsgBytes(&s[0], s.size()));
+}
+
+BOOST_AUTO_TEST_CASE(TooLargeVerack)
+{
+    CNode testNode(INVALID_SOCKET, CAddress(CService("127.0.0.1", 0), NODE_NETWORK));
+    testNode.nVersion = 1;
+
+    CDataStream s(SER_NETWORK, PROTOCOL_VERSION);
+    s << CMessageHeader(Params().MessageStart(), "verack", 0);
+    size_t headerLen = s.size();
+
+    CNetMessage::FinalizeHeader(s);
+    BOOST_CHECK(testNode.ReceiveMsgBytes(&s[0], s.size()));
+
+    // verack is zero-length, so even one byte bigger is too big:
+    s.resize(headerLen+1);
+    CNetMessage::FinalizeHeader(s);
+    BOOST_CHECK(testNode.ReceiveMsgBytes(&s[0], s.size()));
+    CNodeStateStats stats;
+    GetNodeStateStats(testNode.GetId(), stats);
+    BOOST_CHECK(stats.nMisbehavior > 0);
+}
+
+BOOST_AUTO_TEST_CASE(TooLargePing)
+{
+    CNode testNode(INVALID_SOCKET, CAddress(CService("127.0.0.1", 0), NODE_NETWORK));
+    testNode.nVersion = 1;
+
+    CDataStream s(SER_NETWORK, PROTOCOL_VERSION);
+    s << CMessageHeader(Params().MessageStart(), "ping", 0);
+    s << (uint64_t)11; // 8-byte nonce
+
+    CNetMessage::FinalizeHeader(s);
+    BOOST_CHECK(testNode.ReceiveMsgBytes(&s[0], s.size()));
+
+    // Add another nonce, sanity check should fail
+    s << (uint64_t)11; // 8-byte nonce
+    CNetMessage::FinalizeHeader(s);
+    BOOST_CHECK(testNode.ReceiveMsgBytes(&s[0], s.size()));
+    CNodeStateStats stats;
+    GetNodeStateStats(testNode.GetId(), stats);
+    BOOST_CHECK(stats.nMisbehavior > 0);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
These commits tighten up message size sanity checking by:
- Adding a new signal (SanityCheckMessages) to the networking code
- Refactoring MAX_PROTOCOL_MESSAGE_SIZE from the networking code to main
- Adding additional checks for several messages (e.g. ping messages are at most 8 bytes) to the main signal handler (next to the code that handles each message type)

Extending the SanityCheckMessages signal handler (or adding an additional handler) to do more sophisticated DoS detection/prevention is on my longer-term TODO list.
