### PR TITLE
Add HD/Bip32 support

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -75,6 +75,7 @@ if EXEEXT == ".exe" and "-win" not in opts:
 #Tests
 testScripts = [
     'wallet.py',
+    'hdwallet.py',
     'listtransactions.py',
     'receivedby.py',
     'mempool_resurrect_test.py',

--- a/qa/rpc-tests/hdwallet.py
+++ b/qa/rpc-tests/hdwallet.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python2
+# Copyright (c) 2014 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#
+# Exercise the wallet.  Ported from wallet.sh.  
+# Does the following:
+#   a) creates 3 nodes, with an empty chain (no blocks).
+#   b) node0 mines a block
+#   c) node1 mines 101 blocks, so now nodes 0 and 1 have 50btc, node2 has none. 
+#   d) node0 sends 21 btc to node2, in two transactions (11 btc, then 10 btc).
+#   e) node0 mines a block, collects the fee on the second transaction
+#   f) node1 mines 100 blocks, to mature node0's just-mined block
+#   g) check that node0 has 100-21, node2 has 21
+#   h) node0 should now have 2 unspent outputs;  send these to node2 via raw tx broadcast by node1
+#   i) have node1 mine a block
+#   j) check balances - node0 should have 0, node2 should have 100
+#   k) test ResendWalletTransactions - create transactions, startup fourth node, make sure it syncs
+#
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+
+class WalletTest (BitcoinTestFramework):
+
+    def setup_chain(self):
+        print("Initializing test directory "+self.options.tmpdir)
+        initialize_chain_clean(self.options.tmpdir, 4)
+
+    def setup_network(self, split=False):
+        
+
+        self.nodes = start_nodes(3, self.options.tmpdir)
+        
+        #connect to a local machine for debugging
+        # url = "http://bitcoinrpc:DP6DvqZtqXarpeNWyN3LZTFchCCyCUuHwNF7E8pX99x1@%s:%d" % ('127.0.0.1', 18332)
+        # proxy = AuthServiceProxy(url)
+        # proxy.url = url # store URL on proxy for info
+        # self.nodes.append(proxy)
+        
+        connect_nodes_bi(self.nodes,0,1)
+        connect_nodes_bi(self.nodes,1,2)
+        connect_nodes_bi(self.nodes,0,2)
+        self.is_network_split=False
+        self.sync_all()
+
+    def run_test (self):
+        print "Mining blocks..."
+
+        encrypt = True
+        self.nodes[0].generate(1)
+
+        walletinfo = self.nodes[0].getwalletinfo()
+        assert_equal(walletinfo['immature_balance'], 50)
+        assert_equal(walletinfo['balance'], 0)
+        self.nodes[0].generate(100)
+        self.sync_all()
+
+        self.nodes[2].hdaddchain('default', 'f81a7a4efdc29e54dcc739df87315a756038d0b68fbc4880ffbbbef222152e6a')
+        adr = self.nodes[2].hdgetaddress()
+        assert_equal(adr['address'], "n1hBoYyGjqkbC8kdKNAejuaNR19eoYCSoi");
+        assert_equal(adr['chainpath'], "m/44'/0'/0'/0/0");
+        
+        adr2 = self.nodes[2].hdgetaddress()
+        assert_equal(adr2['address'], "mvFePVSFGELgCDyLYrTJJ3tijnyeB9UF6p");
+        assert_equal(adr2['chainpath'], "m/44'/0'/0'/0/1");
+
+        self.nodes[0].sendtoaddress(adr['address'], 11);
+        self.sync_all()
+        self.nodes[1].generate(1)
+        self.sync_all()
+        walletinfo = self.nodes[2].getwalletinfo()
+        assert_equal(walletinfo['balance'], 11)
+            
+        stop_node(self.nodes[0], 0)
+        stop_node(self.nodes[1], 1)
+        stop_node(self.nodes[2], 2)
+
+        #try to cover over master seed
+        os.remove(self.options.tmpdir + "/node2/regtest/wallet.dat")
+        self.nodes[2] = start_node(2, self.options.tmpdir)
+        
+        if encrypt:
+            print "encrypt wallet"
+            self.nodes[2].encryptwallet("test")
+            bitcoind_processes[2].wait()
+            del bitcoind_processes[2]
+            
+            self.nodes[2] = start_node(2, self.options.tmpdir)
+            self.nodes[2].walletpassphrase("test", 100)
+            
+        self.nodes[2].hdaddchain('default', 'f81a7a4efdc29e54dcc739df87315a756038d0b68fbc4880ffbbbef222152e6a')
+        #generate address
+        adr = self.nodes[2].hdgetaddress()
+        assert_equal(adr['address'], "n1hBoYyGjqkbC8kdKNAejuaNR19eoYCSoi"); #must be deterministic
+        walletinfo = self.nodes[2].getwalletinfo()
+        assert_equal(walletinfo['balance'], 0) #balance should be o beause we need to rescan first
+
+        stop_node(self.nodes[2], 2)
+        self.nodes[0] = start_node(0, self.options.tmpdir)
+        self.nodes[1] = start_node(1, self.options.tmpdir)
+        self.nodes[2] = start_node(2, self.options.tmpdir, ['-rescan=1'])
+        connect_nodes_bi(self.nodes,0,1)
+        connect_nodes_bi(self.nodes,1,2)
+        connect_nodes_bi(self.nodes,0,2)
+        
+        walletinfo = self.nodes[2].getwalletinfo()
+        assert_equal(walletinfo['balance'], 11) #after rescan we should have detected the spendable coins
+
+        walletinfo = self.nodes[0].getwalletinfo()
+        balanceOld = walletinfo['balance'];
+        
+        if encrypt:
+            self.nodes[2].walletpassphrase("test", 100)
+            
+        self.nodes[2].sendtoaddress(self.nodes[0].getnewaddress(), 2.0); #try to send (sign) with HD keymaterial
+        self.sync_all()
+        self.nodes[1].generate(1)
+        self.sync_all()
+        walletinfo = self.nodes[0].getwalletinfo()
+        assert_equal(walletinfo['balance'], balanceOld+Decimal('52.00000000'))
+
+if __name__ == '__main__':
+    WalletTest ().main ()

--- a/qa/rpc-tests/hdwallet.py
+++ b/qa/rpc-tests/hdwallet.py
@@ -3,42 +3,27 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#
-# Exercise the wallet.  Ported from wallet.sh.  
-# Does the following:
-#   a) creates 3 nodes, with an empty chain (no blocks).
-#   b) node0 mines a block
-#   c) node1 mines 101 blocks, so now nodes 0 and 1 have 50btc, node2 has none. 
-#   d) node0 sends 21 btc to node2, in two transactions (11 btc, then 10 btc).
-#   e) node0 mines a block, collects the fee on the second transaction
-#   f) node1 mines 100 blocks, to mature node0's just-mined block
-#   g) check that node0 has 100-21, node2 has 21
-#   h) node0 should now have 2 unspent outputs;  send these to node2 via raw tx broadcast by node1
-#   i) have node1 mine a block
-#   j) check balances - node0 should have 0, node2 should have 100
-#   k) test ResendWalletTransactions - create transactions, startup fourth node, make sure it syncs
-#
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
 
-class WalletTest (BitcoinTestFramework):
+class HDWalletTest (BitcoinTestFramework):
 
     def setup_chain(self):
         print("Initializing test directory "+self.options.tmpdir)
         initialize_chain_clean(self.options.tmpdir, 4)
 
     def setup_network(self, split=False):
-        
+
 
         self.nodes = start_nodes(3, self.options.tmpdir)
-        
+
         #connect to a local machine for debugging
         # url = "http://bitcoinrpc:DP6DvqZtqXarpeNWyN3LZTFchCCyCUuHwNF7E8pX99x1@%s:%d" % ('127.0.0.1', 18332)
         # proxy = AuthServiceProxy(url)
         # proxy.url = url # store URL on proxy for info
         # self.nodes.append(proxy)
-        
+
         connect_nodes_bi(self.nodes,0,1)
         connect_nodes_bi(self.nodes,1,2)
         connect_nodes_bi(self.nodes,0,2)
@@ -57,11 +42,21 @@ class WalletTest (BitcoinTestFramework):
         self.nodes[0].generate(100)
         self.sync_all()
 
+        self.nodes[2].hdaddchain('default', 'tprv8ZgxMBicQKsPePWBxbX4F1arnkRyTvM3kVWgGJV2oNJ3abnwgWRhW1q9ruAaW2Y5Ffgak1PRemKd9LgJCrV2vWKeixAvrAAUtyktAMLv4YE');
+        adr = self.nodes[2].hdgetaddress()
+        assert_equal(adr['address'], "msXnguyqxBFdd7Y2zrsZTU3pKL6fpPCpzX");
+        assert_equal(adr['chainpath'], "m/44'/0'/0'/0/0");
+
+        self.nodes[2].hdaddchain("m/101/10'/c", 'tprv8ZgxMBicQKsPfJt4aGm5uB6STj5nCjLCH24rxgnpfusp38cHmcFNoTUan37ndbHCYcQMj544jjNJekSZcET4NoaVGA8s6atuzUHPQBG6mAp');
+        adr = self.nodes[2].hdgetaddress()
+        assert_equal(adr['address'], "mnvAsVFCiUXh9Sm86JV4EVLfwP9TRz6Yqf");
+        assert_equal(adr['chainpath'], "m/101/10'/0/0");
+
         self.nodes[2].hdaddchain('default', 'f81a7a4efdc29e54dcc739df87315a756038d0b68fbc4880ffbbbef222152e6a')
         adr = self.nodes[2].hdgetaddress()
         assert_equal(adr['address'], "n1hBoYyGjqkbC8kdKNAejuaNR19eoYCSoi");
         assert_equal(adr['chainpath'], "m/44'/0'/0'/0/0");
-        
+
         adr2 = self.nodes[2].hdgetaddress()
         assert_equal(adr2['address'], "mvFePVSFGELgCDyLYrTJJ3tijnyeB9UF6p");
         assert_equal(adr2['chainpath'], "m/44'/0'/0'/0/1");
@@ -72,7 +67,7 @@ class WalletTest (BitcoinTestFramework):
         self.sync_all()
         walletinfo = self.nodes[2].getwalletinfo()
         assert_equal(walletinfo['balance'], 11)
-            
+
         stop_node(self.nodes[0], 0)
         stop_node(self.nodes[1], 1)
         stop_node(self.nodes[2], 2)
@@ -80,16 +75,16 @@ class WalletTest (BitcoinTestFramework):
         #try to cover over master seed
         os.remove(self.options.tmpdir + "/node2/regtest/wallet.dat")
         self.nodes[2] = start_node(2, self.options.tmpdir)
-        
+
         if encrypt:
             print "encrypt wallet"
             self.nodes[2].encryptwallet("test")
             bitcoind_processes[2].wait()
             del bitcoind_processes[2]
-            
+
             self.nodes[2] = start_node(2, self.options.tmpdir)
             self.nodes[2].walletpassphrase("test", 100)
-            
+
         self.nodes[2].hdaddchain('default', 'f81a7a4efdc29e54dcc739df87315a756038d0b68fbc4880ffbbbef222152e6a')
         #generate address
         adr = self.nodes[2].hdgetaddress()
@@ -104,16 +99,16 @@ class WalletTest (BitcoinTestFramework):
         connect_nodes_bi(self.nodes,0,1)
         connect_nodes_bi(self.nodes,1,2)
         connect_nodes_bi(self.nodes,0,2)
-        
+
         walletinfo = self.nodes[2].getwalletinfo()
         assert_equal(walletinfo['balance'], 11) #after rescan we should have detected the spendable coins
 
         walletinfo = self.nodes[0].getwalletinfo()
         balanceOld = walletinfo['balance'];
-        
+
         if encrypt:
             self.nodes[2].walletpassphrase("test", 100)
-            
+
         self.nodes[2].sendtoaddress(self.nodes[0].getnewaddress(), 2.0); #try to send (sign) with HD keymaterial
         self.sync_all()
         self.nodes[1].generate(1)
@@ -122,4 +117,4 @@ class WalletTest (BitcoinTestFramework):
         assert_equal(walletinfo['balance'], balanceOld+Decimal('52.00000000'))
 
 if __name__ == '__main__':
-    WalletTest ().main ()
+    HDWalletTest ().main ()

--- a/qa/rpc-tests/hdwallet.py
+++ b/qa/rpc-tests/hdwallet.py
@@ -72,7 +72,7 @@ class HDWalletTest (BitcoinTestFramework):
         stop_node(self.nodes[1], 1)
         stop_node(self.nodes[2], 2)
 
-        #try to cover over master seed
+        #try to recover over master seed
         os.remove(self.options.tmpdir + "/node2/regtest/wallet.dat")
         self.nodes[2] = start_node(2, self.options.tmpdir)
 
@@ -115,6 +115,15 @@ class HDWalletTest (BitcoinTestFramework):
         self.sync_all()
         walletinfo = self.nodes[0].getwalletinfo()
         assert_equal(walletinfo['balance'], balanceOld+Decimal('52.00000000'))
+        
+        self.nodes[2].hdaddchain('m/ch', '9886e45b8435b488a4cb753121db41a07f66a6a73e0a705ce24cee3a3bce87db')
+        adr0 = self.nodes[2].hdgetaddress()
+        assert_equal(adr0['address'], "mhr4GkkutTAVQ2RQvqSYdrFyt7vtmrgJ6S");
+        assert_equal(adr0['chainpath'], "m/0'/0'");
+
+        adr1 = self.nodes[2].hdgetaddress()
+        assert_equal(adr1['address'], "mzSuRQocScfhoYufYE5Uc1E5JW8BJtnZFr");
+        assert_equal(adr1['chainpath'], "m/0'/1'");
 
 if __name__ == '__main__':
     HDWalletTest ().main ()

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -164,7 +164,7 @@ BITCOIN_CORE_H = \
   version.h \
   wallet/crypter.h \
   wallet/db.h \
-	wallet/hdkeystore.h \
+  wallet/hdkeystore.h \
   wallet/wallet.h \
   wallet/wallet_ismine.h \
   wallet/walletdb.h \
@@ -235,7 +235,7 @@ libbitcoin_wallet_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 libbitcoin_wallet_a_SOURCES = \
   wallet/crypter.cpp \
   wallet/db.cpp \
-	wallet/hdkeystore.cpp \
+  wallet/hdkeystore.cpp \
   wallet/rpcdump.cpp \
   wallet/rpcwallet.cpp \
   wallet/wallet.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -164,6 +164,7 @@ BITCOIN_CORE_H = \
   version.h \
   wallet/crypter.h \
   wallet/db.h \
+	wallet/hdkeystore.h \
   wallet/wallet.h \
   wallet/wallet_ismine.h \
   wallet/walletdb.h \
@@ -234,6 +235,7 @@ libbitcoin_wallet_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 libbitcoin_wallet_a_SOURCES = \
   wallet/crypter.cpp \
   wallet/db.cpp \
+	wallet/hdkeystore.cpp \
   wallet/rpcdump.cpp \
   wallet/rpcwallet.cpp \
   wallet/wallet.cpp \

--- a/src/base58.h
+++ b/src/base58.h
@@ -164,7 +164,7 @@ public:
     CBitcoinExtKeyBase() {}
 };
 
-typedef CBitcoinExtKeyBase<CExtKey, 74, CChainParams::EXT_SECRET_KEY> CBitcoinExtKey;
-typedef CBitcoinExtKeyBase<CExtPubKey, 74, CChainParams::EXT_PUBLIC_KEY> CBitcoinExtPubKey;
+typedef CBitcoinExtKeyBase<CExtKey, BIP32_EXTKEY_SIZE, CChainParams::EXT_SECRET_KEY> CBitcoinExtKey;
+typedef CBitcoinExtKeyBase<CExtPubKey, BIP32_EXTKEY_SIZE, CChainParams::EXT_PUBLIC_KEY> CBitcoinExtPubKey;
 
 #endif // BITCOIN_BASE58_H

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -275,7 +275,7 @@ CExtPubKey CExtKey::Neuter() const {
     return ret;
 }
 
-void CExtKey::Encode(unsigned char code[74]) const {
+void CExtKey::Encode(unsigned char code[BIP32_EXTKEY_SIZE]) const {
     code[0] = nDepth;
     memcpy(code+1, vchFingerprint, 4);
     code[5] = (nChild >> 24) & 0xFF; code[6] = (nChild >> 16) & 0xFF;
@@ -286,12 +286,12 @@ void CExtKey::Encode(unsigned char code[74]) const {
     memcpy(code+42, key.begin(), 32);
 }
 
-void CExtKey::Decode(const unsigned char code[74]) {
+void CExtKey::Decode(const unsigned char code[BIP32_EXTKEY_SIZE]) {
     nDepth = code[0];
     memcpy(vchFingerprint, code+1, 4);
     nChild = (code[5] << 24) | (code[6] << 16) | (code[7] << 8) | code[8];
     memcpy(chaincode.begin(), code+9, 32);
-    key.Set(code+42, code+74, true);
+    key.Set(code+42, code+BIP32_EXTKEY_SIZE, true);
 }
 
 bool ECC_InitSanityCheck() {

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -291,7 +291,7 @@ void CExtKey::Decode(const unsigned char code[BIP32_EXTKEY_SIZE]) {
     memcpy(vchFingerprint, code+1, 4);
     nChild = (code[5] << 24) | (code[6] << 16) | (code[7] << 8) | code[8];
     memcpy(chaincode.begin(), code+9, 32);
-    key.Set(code+42, code+BIP32_EXTKEY_SIZE, true);
+    key.Set(code+42, code+74, true);
 }
 
 bool ECC_InitSanityCheck() {

--- a/src/key.h
+++ b/src/key.h
@@ -164,8 +164,8 @@ struct CExtKey {
                a.chaincode == b.chaincode && a.key == b.key;
     }
 
-    void Encode(unsigned char code[74]) const;
-    void Decode(const unsigned char code[74]);
+    void Encode(unsigned char code[BIP32_EXTKEY_SIZE]) const;
+    void Decode(const unsigned char code[BIP32_EXTKEY_SIZE]);
     bool Derive(CExtKey& out, unsigned int nChild) const;
     CExtPubKey Neuter() const;
     void SetMaster(const unsigned char* seed, unsigned int nSeedLen);

--- a/src/pubkey.cpp
+++ b/src/pubkey.cpp
@@ -246,7 +246,7 @@ bool CPubKey::Derive(CPubKey& pubkeyChild, ChainCode &ccChild, unsigned int nChi
     return true;
 }
 
-void CExtPubKey::Encode(unsigned char code[74]) const {
+void CExtPubKey::Encode(unsigned char code[BIP32_EXTKEY_SIZE]) const {
     code[0] = nDepth;
     memcpy(code+1, vchFingerprint, 4);
     code[5] = (nChild >> 24) & 0xFF; code[6] = (nChild >> 16) & 0xFF;
@@ -256,12 +256,12 @@ void CExtPubKey::Encode(unsigned char code[74]) const {
     memcpy(code+41, pubkey.begin(), 33);
 }
 
-void CExtPubKey::Decode(const unsigned char code[74]) {
+void CExtPubKey::Decode(const unsigned char code[BIP32_EXTKEY_SIZE]) {
     nDepth = code[0];
     memcpy(vchFingerprint, code+1, 4);
     nChild = (code[5] << 24) | (code[6] << 16) | (code[7] << 8) | code[8];
     memcpy(chaincode.begin(), code+9, 32);
-    pubkey.Set(code+41, code+74);
+    pubkey.Set(code+41, code+BIP32_EXTKEY_SIZE);
 }
 
 bool CExtPubKey::Derive(CExtPubKey &out, unsigned int nChild) const {

--- a/src/pubkey.h
+++ b/src/pubkey.h
@@ -208,6 +208,28 @@ struct CExtPubKey {
     void Encode(unsigned char code[74]) const;
     void Decode(const unsigned char code[74]);
     bool Derive(CExtPubKey& out, unsigned int nChild) const;
+
+    unsigned int GetSerializeSize(int nType, int nVersion) const
+    {
+        return 75;
+    }
+    template <typename Stream>
+    void Serialize(Stream& s, int nType, int nVersion) const
+    {
+        unsigned int len = 74;
+        ::WriteCompactSize(s, len);
+        unsigned char code[74];
+        Encode(code);
+        s.write((const char *)&code[0], len);
+    }
+    template <typename Stream>
+    void Unserialize(Stream& s, int nType, int nVersion)
+    {
+        unsigned int len = ::ReadCompactSize(s);
+        unsigned char code[74];
+        s.read((char *)&code[0], len);
+        Decode(code);
+    }
 };
 
 /** Users of this module must hold an ECCVerifyHandle. The constructor and

--- a/src/pubkey.h
+++ b/src/pubkey.h
@@ -23,6 +23,8 @@
  * script supports up to 75 for single byte push
  */
 
+const unsigned int BIP32_EXTKEY_SIZE = 74;
+
 /** A reference to a CKey: the Hash160 of its serialized public key */
 class CKeyID : public uint160
 {
@@ -205,20 +207,20 @@ struct CExtPubKey {
                a.chaincode == b.chaincode && a.pubkey == b.pubkey;
     }
 
-    void Encode(unsigned char code[74]) const;
-    void Decode(const unsigned char code[74]);
+    void Encode(unsigned char code[BIP32_EXTKEY_SIZE]) const;
+    void Decode(const unsigned char code[BIP32_EXTKEY_SIZE]);
     bool Derive(CExtPubKey& out, unsigned int nChild) const;
 
     unsigned int GetSerializeSize(int nType, int nVersion) const
     {
-        return 75;
+        return BIP32_EXTKEY_SIZE+1; //add one byte for the size (compact int)
     }
     template <typename Stream>
     void Serialize(Stream& s, int nType, int nVersion) const
     {
-        unsigned int len = 74;
+        unsigned int len = BIP32_EXTKEY_SIZE;
         ::WriteCompactSize(s, len);
-        unsigned char code[74];
+        unsigned char code[BIP32_EXTKEY_SIZE];
         Encode(code);
         s.write((const char *)&code[0], len);
     }
@@ -226,7 +228,7 @@ struct CExtPubKey {
     void Unserialize(Stream& s, int nType, int nVersion)
     {
         unsigned int len = ::ReadCompactSize(s);
-        unsigned char code[74];
+        unsigned char code[BIP32_EXTKEY_SIZE];
         s.read((char *)&code[0], len);
         Decode(code);
     }

--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -102,6 +102,8 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "prioritisetransaction", 2 },
     { "setban", 2 },
     { "setban", 3 },
+    { "hdsendtoaddress", 1 },
+    { "hdsendtoaddress", 4 },
 };
 
 class CRPCConvertTable

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -372,7 +372,7 @@ static const CRPCCommand vRPCCommands[] =
     { "wallet",             "walletlock",             &walletlock,             true  },
     { "wallet",             "walletpassphrasechange", &walletpassphrasechange, true  },
     { "wallet",             "walletpassphrase",       &walletpassphrase,       true  },
-    { "wallet",             "hdchainpath",            &hdchainpath,            true  },
+    { "wallet",             "hdaddchain",             &hdaddchain,             true  },
     { "wallet",             "hdgetaddress",           &hdgetaddress,           true  },
 #endif // ENABLE_WALLET
 };

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -372,6 +372,8 @@ static const CRPCCommand vRPCCommands[] =
     { "wallet",             "walletlock",             &walletlock,             true  },
     { "wallet",             "walletpassphrasechange", &walletpassphrasechange, true  },
     { "wallet",             "walletpassphrase",       &walletpassphrase,       true  },
+    { "wallet",             "hdchainpath",            &hdchainpath,            true  },
+    { "wallet",             "hdgetaddress",           &hdgetaddress,           true  },
 #endif // ENABLE_WALLET
 };
 

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -374,6 +374,9 @@ static const CRPCCommand vRPCCommands[] =
     { "wallet",             "walletpassphrase",       &walletpassphrase,       true  },
     { "wallet",             "hdaddchain",             &hdaddchain,             true  },
     { "wallet",             "hdgetaddress",           &hdgetaddress,           true  },
+    { "wallet",             "hdsendtoaddress",        &hdsendtoaddress,        false },
+    { "wallet",             "hdsetchain",             &hdsetchain,             false },
+    { "wallet",             "hdgetinfo",              &hdgetinfo,              false },
 #endif // ENABLE_WALLET
 };
 

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -236,6 +236,9 @@ extern UniValue setmocktime(const UniValue& params, bool fHelp);
 extern UniValue resendwallettransactions(const UniValue& params, bool fHelp);
 extern UniValue hdaddchain(const UniValue& params, bool fHelp);
 extern UniValue hdgetaddress(const UniValue& params, bool fHelp);
+extern UniValue hdsendtoaddress(const UniValue& params, bool fHelp);
+extern UniValue hdsetchain(const UniValue& params, bool fHelp);
+extern UniValue hdgetinfo(const UniValue& params, bool fHelp);
 
 extern UniValue getrawtransaction(const UniValue& params, bool fHelp); // in rcprawtransaction.cpp
 extern UniValue listunspent(const UniValue& params, bool fHelp);

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -234,7 +234,7 @@ extern UniValue getblockchaininfo(const UniValue& params, bool fHelp);
 extern UniValue getnetworkinfo(const UniValue& params, bool fHelp);
 extern UniValue setmocktime(const UniValue& params, bool fHelp);
 extern UniValue resendwallettransactions(const UniValue& params, bool fHelp);
-extern UniValue hdchainpath(const UniValue& params, bool fHelp);
+extern UniValue hdaddchain(const UniValue& params, bool fHelp);
 extern UniValue hdgetaddress(const UniValue& params, bool fHelp);
 
 extern UniValue getrawtransaction(const UniValue& params, bool fHelp); // in rcprawtransaction.cpp

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -234,6 +234,8 @@ extern UniValue getblockchaininfo(const UniValue& params, bool fHelp);
 extern UniValue getnetworkinfo(const UniValue& params, bool fHelp);
 extern UniValue setmocktime(const UniValue& params, bool fHelp);
 extern UniValue resendwallettransactions(const UniValue& params, bool fHelp);
+extern UniValue hdchainpath(const UniValue& params, bool fHelp);
+extern UniValue hdgetaddress(const UniValue& params, bool fHelp);
 
 extern UniValue getrawtransaction(const UniValue& params, bool fHelp); // in rcprawtransaction.cpp
 extern UniValue listunspent(const UniValue& params, bool fHelp);

--- a/src/test/bip32_tests.cpp
+++ b/src/test/bip32_tests.cpp
@@ -117,6 +117,10 @@ void RunTest(const TestVector &test) {
         }
         key = keyNew;
         pubkey = pubkeyNew;
+
+        CDataStream ss(SER_DISK, CLIENT_VERSION);
+        ss << pubkeyNew;
+        BOOST_CHECK(ss.size() == 75);
     }
 }
 

--- a/src/test/bip32_tests.cpp
+++ b/src/test/bip32_tests.cpp
@@ -88,7 +88,6 @@ void RunTest(const TestVector &test) {
         unsigned char data[74];
         key.Encode(data);
         pubkey.Encode(data);
-
         // Test private key
         CBitcoinExtKey b58key; b58key.SetKey(key);
         BOOST_CHECK(b58key.ToString() == derive.prv);

--- a/src/wallet/crypter.cpp
+++ b/src/wallet/crypter.cpp
@@ -292,3 +292,23 @@ bool CCryptoKeyStore::EncryptKeys(CKeyingMaterial& vMasterKeyIn)
     }
     return true;
 }
+
+bool CCryptoKeyStore::EncryptSeed(const CKeyingMaterial& seedIn, const uint256& seedPubHash, std::vector<unsigned char> &vchCiphertext) const
+{
+    LOCK(cs_KeyStore);
+
+    if (!EncryptSecret(vMasterKey, seedIn, seedPubHash, vchCiphertext))
+        return false;
+
+    return true;
+}
+
+bool CCryptoKeyStore::DecryptSeed(const std::vector<unsigned char>& vchCiphertextIn, const uint256& seedPubHash, CKeyingMaterial& seedOut) const
+{
+    LOCK(cs_KeyStore);
+
+    if(!DecryptSecret(vMasterKey, vchCiphertextIn, seedPubHash, seedOut))
+        return false;
+
+    return true;
+}

--- a/src/wallet/crypter.cpp
+++ b/src/wallet/crypter.cpp
@@ -307,7 +307,7 @@ bool CCryptoKeyStore::DecryptSeed(const std::vector<unsigned char>& vchCiphertex
 {
     LOCK(cs_KeyStore);
 
-    if(!DecryptSecret(vMasterKey, vchCiphertextIn, seedPubHash, seedOut))
+    if (!DecryptSecret(vMasterKey, vchCiphertextIn, seedPubHash, seedOut))
         return false;
 
     return true;

--- a/src/wallet/crypter.h
+++ b/src/wallet/crypter.h
@@ -191,6 +191,9 @@ public:
      * Note: Called without locks held.
      */
     boost::signals2::signal<void (CCryptoKeyStore* wallet)> NotifyStatusChanged;
+
+    bool EncryptSeed(const CKeyingMaterial& seedIn, const uint256& seedPubHash, std::vector<unsigned char> &vchCiphertext) const;
+    bool DecryptSeed(const std::vector<unsigned char>& vchCiphertextIn, const uint256& seedPubHash, CKeyingMaterial& seedOut) const;
 };
 
 #endif // BITCOIN_WALLET_CRYPTER_H

--- a/src/wallet/hdkeystore.cpp
+++ b/src/wallet/hdkeystore.cpp
@@ -164,7 +164,6 @@ bool CHDKeyStore::DeriveKey(const CHDPubKey hdPubKey, CKey& keyOut) const
     std::vector<std::string> pathFragments;
     boost::split(pathFragments, chainPath, boost::is_any_of("/"));
 
-    LogPrintf("hdwallet", "derive key %s\n", chainPath);
     CExtKey extKey;
     CExtKey parentKey;
     BOOST_FOREACH(std::string fragment, pathFragments)
@@ -203,7 +202,6 @@ bool CHDKeyStore::DeriveKey(const CHDPubKey hdPubKey, CKey& keyOut) const
         }
     }
     keyOut = parentKey.key;
-    LogPrintf("hdwallet", "derived key with adr: %s\n", CBitcoinAddress(keyOut.GetPubKey().GetID()).ToString());
     return true;
 }
 

--- a/src/wallet/hdkeystore.cpp
+++ b/src/wallet/hdkeystore.cpp
@@ -184,7 +184,14 @@ bool CHDKeyStore::DeriveKey(const CHDPubKey hdPubKey, CKey& keyOut) const
             if (!GetMasterSeed(hdPubKey.chainHash, masterSeed))
                 return false;
 
-            bip32MasterKey.SetMaster(&masterSeed[0], masterSeed.size());
+            if (masterSeed.size() == BIP32_EXTKEY_SIZE)
+            {
+                //if the seed size matches the BIP32_EXTKEY_SIZE, we assume its a encoded ext priv key
+                bip32MasterKey.Decode(&masterSeed[0]);
+            }
+            else
+                bip32MasterKey.SetMaster(&masterSeed[0], masterSeed.size());
+
             parentKey = bip32MasterKey;
         }
         else if (fragment == "c")

--- a/src/wallet/hdkeystore.cpp
+++ b/src/wallet/hdkeystore.cpp
@@ -170,7 +170,7 @@ bool CHDKeyStore::DeriveKey(const CHDPubKey hdPubKey, CKey& keyOut) const
     BOOST_FOREACH(std::string fragment, pathFragments)
     {
         bool harden = false;
-        if (fragment.back() == '\'')
+        if (*fragment.rbegin() == '\'')
         {
             harden = true;
             fragment = fragment.substr(0,fragment.size()-1);

--- a/src/wallet/hdkeystore.cpp
+++ b/src/wallet/hdkeystore.cpp
@@ -1,0 +1,50 @@
+// Copyright (c) 2015 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "wallet/hdkeystore.h"
+
+bool CHDKeyStore::AddMasterSeed(const HDChainID& hash, const CKeyingMaterial& masterSeed)
+{
+    LOCK(cs_KeyStore);
+    if (!IsCrypted())
+    {
+        std::vector<unsigned char> vchCryptedSecret;
+        if (!EncryptSeed(masterSeed, hash, vchCryptedSecret))
+            return false;
+
+        mapHDCryptedMasterSeeds[hash] = vchCryptedSecret;
+        return true;
+    }
+    mapHDMasterSeeds[hash] = masterSeed;
+    return true;
+}
+
+bool CHDKeyStore::GetMasterSeed(const HDChainID& hash, CKeyingMaterial& seedOut) const
+{
+    {
+        LOCK(cs_KeyStore);
+        if (!IsCrypted())
+        {
+            std::map<HDChainID, CKeyingMaterial >::const_iterator it=mapHDMasterSeeds.find(hash);
+            if (it == mapHDMasterSeeds.end())
+                return false;
+
+            seedOut = it->second;
+            return true;
+        }
+        else
+        {
+            std::map<HDChainID, std::vector<unsigned char> >::const_iterator it=mapHDCryptedMasterSeeds.find(hash);
+            if (it == mapHDCryptedMasterSeeds.end())
+                return false;
+
+            std::vector<unsigned char> vchCryptedSecret = it->second;
+            if (!DecryptSeed(vchCryptedSecret, hash, seedOut))
+                return false;
+
+            return true;
+        }
+    }
+    return false;
+}

--- a/src/wallet/hdkeystore.cpp
+++ b/src/wallet/hdkeystore.cpp
@@ -7,7 +7,7 @@
 bool CHDKeyStore::AddMasterSeed(const HDChainID& hash, const CKeyingMaterial& masterSeed)
 {
     LOCK(cs_KeyStore);
-    if (!IsCrypted())
+    if (IsCrypted())
     {
         std::vector<unsigned char> vchCryptedSecret;
         if (!EncryptSeed(masterSeed, hash, vchCryptedSecret))

--- a/src/wallet/hdkeystore.cpp
+++ b/src/wallet/hdkeystore.cpp
@@ -4,6 +4,13 @@
 
 #include "wallet/hdkeystore.h"
 
+#include "base58.h"
+#include "util.h"
+#include "utilstrencodings.h"
+
+#include <boost/algorithm/string.hpp>
+#include <boost/foreach.hpp>
+
 bool CHDKeyStore::AddMasterSeed(const HDChainID& hash, const CKeyingMaterial& masterSeed)
 {
     LOCK(cs_KeyStore);
@@ -20,31 +27,230 @@ bool CHDKeyStore::AddMasterSeed(const HDChainID& hash, const CKeyingMaterial& ma
     return true;
 }
 
+bool CHDKeyStore::AddCryptedMasterSeed(const HDChainID& hash, const std::vector<unsigned char>& vchCryptedSecret)
+{
+    LOCK(cs_KeyStore);
+    mapHDCryptedMasterSeeds[hash] = vchCryptedSecret;
+    return true;
+}
+
 bool CHDKeyStore::GetMasterSeed(const HDChainID& hash, CKeyingMaterial& seedOut) const
 {
+    LOCK(cs_KeyStore);
+    if (!IsCrypted())
     {
-        LOCK(cs_KeyStore);
-        if (!IsCrypted())
+        std::map<HDChainID, CKeyingMaterial >::const_iterator it=mapHDMasterSeeds.find(hash);
+        if (it == mapHDMasterSeeds.end())
+            return false;
+
+        seedOut = it->second;
+        return true;
+    }
+    else
+    {
+        std::map<HDChainID, std::vector<unsigned char> >::const_iterator it=mapHDCryptedMasterSeeds.find(hash);
+        if (it == mapHDCryptedMasterSeeds.end())
+            return false;
+
+        std::vector<unsigned char> vchCryptedSecret = it->second;
+        if (!DecryptSeed(vchCryptedSecret, hash, seedOut))
+            return false;
+
+        return true;
+    }
+    return false;
+}
+
+bool CHDKeyStore::EncryptSeeds()
+{
+    LOCK(cs_KeyStore);
+    for (std::map<HDChainID, CKeyingMaterial >::iterator it = mapHDMasterSeeds.begin(); it != mapHDMasterSeeds.end(); ++it)
+    {
+        std::vector<unsigned char> vchCryptedSecret;
+        if (!EncryptSeed(it->second, it->first, vchCryptedSecret))
+            return false;
+        AddCryptedMasterSeed(it->first, vchCryptedSecret);
+    }
+    mapHDMasterSeeds.clear();
+    return true;
+}
+
+bool CHDKeyStore::GetCryptedMasterSeed(const HDChainID& hash, std::vector<unsigned char>& vchCryptedSecret) const
+{
+    LOCK(cs_KeyStore);
+    if (!IsCrypted())
+        return false;
+
+    std::map<HDChainID, std::vector<unsigned char> >::const_iterator it=mapHDCryptedMasterSeeds.find(hash);
+    if (it == mapHDCryptedMasterSeeds.end())
+        return false;
+
+    vchCryptedSecret = it->second;
+    return true;
+}
+
+bool CHDKeyStore::HaveKey(const CKeyID &address) const
+{
+    LOCK(cs_KeyStore);
+    if (mapHDPubKeys.count(address) > 0)
+        return true;
+
+    return CCryptoKeyStore::HaveKey(address);
+}
+
+bool CHDKeyStore::LoadHDPubKey(const CHDPubKey &pubkey)
+{
+    LOCK(cs_KeyStore);
+    mapHDPubKeys[pubkey.pubkey.GetID()] = pubkey;
+    return true;
+}
+
+bool CHDKeyStore::GetAvailableChainIDs(std::vector<HDChainID>& chainIDs)
+{
+    LOCK(cs_KeyStore);
+    chainIDs.clear();
+
+    if (IsCrypted())
+    {
+        for(std::map<HDChainID, std::vector<unsigned char> >::iterator it = mapHDCryptedMasterSeeds.begin(); it != mapHDCryptedMasterSeeds.end(); ++it) {
+            chainIDs.push_back(it->first);
+        }
+    }
+    else
+    {
+        for(std::map<HDChainID, CKeyingMaterial >::iterator it = mapHDMasterSeeds.begin(); it != mapHDMasterSeeds.end(); ++it) {
+            chainIDs.push_back(it->first);
+        }
+    }
+    
+    return true;
+}
+
+bool CHDKeyStore::GetKey(const CKeyID &address, CKey &keyOut) const
+{
+    LOCK(cs_KeyStore);
+
+    std::map<CKeyID, CHDPubKey>::const_iterator mi = mapHDPubKeys.find(address);
+    if (mi != mapHDPubKeys.end())
+    {
+        if (!DeriveKey(mi->second, keyOut))
+            return false;
+
+        return true;
+    }
+
+    return CCryptoKeyStore::GetKey(address, keyOut);
+}
+
+bool CHDKeyStore::DeriveKey(const CHDPubKey hdPubKey, CKey& keyOut) const
+{
+    //this methode required no locking
+    
+    std::string chainPath = hdPubKey.chainPath;
+    std::vector<std::string> pathFragments;
+    boost::split(pathFragments, chainPath, boost::is_any_of("/"));
+
+    CExtKey extKey;
+    CExtKey parentKey;
+    BOOST_FOREACH(std::string fragment, pathFragments)
+    {
+        bool harden = false;
+        if (fragment.back() == '\'')
         {
-            std::map<HDChainID, CKeyingMaterial >::const_iterator it=mapHDMasterSeeds.find(hash);
-            if (it == mapHDMasterSeeds.end())
+            harden = true;
+            fragment = fragment.substr(0,fragment.size()-1);
+        }
+
+        if (fragment == "m")
+        {
+            CExtKey bip32MasterKey;
+            CKeyingMaterial masterSeed;
+
+            // get master seed
+            if (!GetMasterSeed(hdPubKey.chainHash, masterSeed))
                 return false;
 
-            seedOut = it->second;
-            return true;
+            bip32MasterKey.SetMaster(&masterSeed[0], masterSeed.size());
+            parentKey = bip32MasterKey;
+        }
+        else if (fragment == "c")
+        {
+            return false;
         }
         else
         {
-            std::map<HDChainID, std::vector<unsigned char> >::const_iterator it=mapHDCryptedMasterSeeds.find(hash);
-            if (it == mapHDCryptedMasterSeeds.end())
+            CExtKey childKey;
+            int32_t nIndex;
+            if (!ParseInt32(fragment,&nIndex))
                 return false;
-
-            std::vector<unsigned char> vchCryptedSecret = it->second;
-            if (!DecryptSeed(vchCryptedSecret, hash, seedOut))
-                return false;
-
-            return true;
+            parentKey.Derive(childKey, (harden ? 0x80000000 : 0)+nIndex);
+            parentKey = childKey;
         }
     }
-    return false;
+    keyOut = parentKey.key;
+    return true;
+}
+
+bool CHDKeyStore::DeriveHDPubKeyAtIndex(const HDChainID chainId, CHDPubKey& hdPubKeyOut, unsigned int nIndex, bool internal) const
+{
+    CHDChain hdChain;
+    if (!GetChain(chainId, hdChain))
+        return false;
+
+    if ( (internal && !hdChain.internalPubKey.pubkey.IsValid()) || !hdChain.externalPubKey.pubkey.IsValid())
+        throw std::runtime_error("CHDKeyStore::HDGetChildPubKeyAtIndex(): Missing HD extended pubkey!");
+
+    if (nIndex >= 0x80000000)
+        throw std::runtime_error("CHDKeyStore::HDGetChildPubKeyAtIndex(): No more available keys!");
+
+    CExtPubKey useExtKey = internal ? hdChain.internalPubKey : hdChain.externalPubKey;
+    CExtPubKey childKey;
+    if (!useExtKey.Derive(childKey, nIndex))
+        throw std::runtime_error("CHDKeyStore::HDGetChildPubKeyAtIndex(): Key deriving failed!");
+
+    hdPubKeyOut.pubkey = childKey.pubkey;
+    hdPubKeyOut.chainHash = chainId;
+    hdPubKeyOut.nChild = nIndex;
+    hdPubKeyOut.chainPath = hdChain.chainPath;
+    boost::replace_all(hdPubKeyOut.chainPath, "c", itostr(internal)); //replace the chain switch index
+    hdPubKeyOut.chainPath += "/"+itostr(nIndex);
+
+    return true;
+}
+
+unsigned int CHDKeyStore::GetNextChildIndex(const HDChainID& chainId, bool internal)
+{
+    std::vector<unsigned int> vIndices;
+
+    {
+        LOCK(cs_KeyStore);
+        //get next unused child index
+        for(std::map<CKeyID, CHDPubKey>::iterator it = mapHDPubKeys.begin(); it != mapHDPubKeys.end(); ++it)
+            if (it->second.chainHash == chainId)
+                vIndices.push_back(it->second.nChild);
+    }
+
+    for(unsigned int i=0;i<0x80000000;i++)
+        if (std::find(vIndices.begin(), vIndices.end(), i) == vIndices.end())
+            return i;
+
+    return 0;
+}
+
+bool CHDKeyStore::AddChain(const CHDChain& chain)
+{
+    LOCK(cs_KeyStore);
+    mapChains[chain.chainHash] = chain;
+    return true;
+}
+
+bool CHDKeyStore::GetChain(const HDChainID chainId, CHDChain& chainOut) const
+{
+    LOCK(cs_KeyStore);
+    std::map<HDChainID, CHDChain>::const_iterator it=mapChains.find(hash);
+    if (it == mapChains.end())
+        return false;
+
+    chainOut = it->second;
+    return true;
 }

--- a/src/wallet/hdkeystore.cpp
+++ b/src/wallet/hdkeystore.cpp
@@ -122,7 +122,7 @@ bool CHDKeyStore::GetAvailableChainIDs(std::vector<HDChainID>& chainIDs)
             chainIDs.push_back(it->first);
         }
     }
-    
+
     return true;
 }
 
@@ -159,7 +159,7 @@ bool CHDKeyStore::GetPubKey(const CKeyID &address, CPubKey& vchPubKeyOut) const
 bool CHDKeyStore::DeriveKey(const CHDPubKey hdPubKey, CKey& keyOut) const
 {
     //this methode required no locking
-    
+
     std::string chainPath = hdPubKey.chainPath;
     std::vector<std::string> pathFragments;
     boost::split(pathFragments, chainPath, boost::is_any_of("/"));

--- a/src/wallet/hdkeystore.h
+++ b/src/wallet/hdkeystore.h
@@ -1,0 +1,69 @@
+// Copyright (c) 2015 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_WALLET_HDKEYSTORE_H
+#define BITCOIN_WALLET_HDKEYSTORE_H
+
+#include "keystore.h"
+#include "wallet/crypter.h"
+#include "serialize.h"
+#include "pubkey.h"
+
+typedef uint256 HDChainID;
+
+class CHDChain
+{
+public:
+    static const int CURRENT_VERSION=1;
+    int nVersion;
+    int64_t nCreateTime; // 0 means unknown
+
+    HDChainID chainHash; //hash() of the masterpubkey
+    std::string chainPath; //something like "m'/44'/0'/0'/c"
+    CExtPubKey externalPubKey;
+    CExtPubKey internalPubKey;
+
+    CHDChain()
+    {
+        SetNull();
+    }
+    CHDChain(int64_t nCreateTime_)
+    {
+        SetNull();
+        nCreateTime = nCreateTime_;
+    }
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
+        READWRITE(this->nVersion);
+        nVersion = this->nVersion;
+
+        READWRITE(nCreateTime);
+        READWRITE(chainHash);
+        READWRITE(chainPath);
+        READWRITE(externalPubKey);
+        READWRITE(internalPubKey);
+    }
+
+    void SetNull()
+    {
+        nVersion = CHDChain::CURRENT_VERSION;
+        nCreateTime = 0;
+        chainHash.SetNull();
+    }
+};
+
+class CHDKeyStore : public CCryptoKeyStore
+{
+protected:
+    std::map<HDChainID, std::vector<unsigned char> > mapHDCryptedMasterSeeds;
+    std::map<HDChainID, CKeyingMaterial > mapHDMasterSeeds;
+
+public:
+    virtual bool AddMasterSeed(const HDChainID& pubkeyhash, const CKeyingMaterial& masterSeed);
+    virtual bool GetMasterSeed(const HDChainID& hash, CKeyingMaterial& seedOut) const;
+};
+#endif // BITCOIN_WALLET_HDKEYSTORE_H

--- a/src/wallet/hdkeystore.h
+++ b/src/wallet/hdkeystore.h
@@ -12,6 +12,49 @@
 
 typedef uint256 HDChainID;
 
+/** hdpublic key for a persistant store. */
+class CHDPubKey
+{
+public:
+    static const int CURRENT_VERSION=1;
+    int nVersion;
+    CPubKey pubkey; //the acctual pubkey
+    unsigned int nChild; //child index
+    HDChainID chainHash; //hash of the chains master pubkey
+    std::string chainPath; //individual key chainpath like m/44'/0'/0'/0/1
+
+    CHDPubKey()
+    {
+        SetNull();
+    }
+
+    bool IsValid()
+    {
+        return pubkey.IsValid();
+    }
+
+    void SetNull()
+    {
+        nVersion = CHDPubKey::CURRENT_VERSION;
+        chainHash.SetNull();
+        chainPath.clear();
+    }
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
+        READWRITE(this->nVersion);
+        nVersion = this->nVersion;
+
+        READWRITE(pubkey);
+        READWRITE(chainHash);
+        READWRITE(chainPath);
+        READWRITE(nChild);
+    }
+};
+
+/** class for representing a hd chain of keys. */
 class CHDChain
 {
 public:
@@ -22,16 +65,22 @@ public:
     HDChainID chainHash; //hash() of the masterpubkey
     std::string chainPath; //something like "m'/44'/0'/0'/c"
     CExtPubKey externalPubKey;
-    CExtPubKey internalPubKey;
+    CExtPubKey internalPubKey; // pubkey.IsValid() == false means only use external chain
 
     CHDChain()
     {
         SetNull();
     }
+
     CHDChain(int64_t nCreateTime_)
     {
         SetNull();
         nCreateTime = nCreateTime_;
+    }
+
+    bool IsValid()
+    {
+        return externalPubKey.pubkey.IsValid();
     }
 
     ADD_SERIALIZE_METHODS;
@@ -59,11 +108,57 @@ public:
 class CHDKeyStore : public CCryptoKeyStore
 {
 protected:
+    std::map<HDChainID, CKeyingMaterial > mapHDMasterSeeds; //master seeds are stored outside of CHDChain (crypto)
     std::map<HDChainID, std::vector<unsigned char> > mapHDCryptedMasterSeeds;
-    std::map<HDChainID, CKeyingMaterial > mapHDMasterSeeds;
+    std::map<CKeyID, CHDPubKey> mapHDPubKeys; //all hd pubkeys of all chains
+    std::map<HDChainID, CHDChain> mapChains; //all available chains
+
+    //!derive key from a CHDPubKey object
+    bool DeriveKey(const CHDPubKey hdPubKey, CKey& keyOut) const;
 
 public:
+    //!add a master seed with a given pubkeyhash (memory only)
     virtual bool AddMasterSeed(const HDChainID& pubkeyhash, const CKeyingMaterial& masterSeed);
+
+    //!add a crypted master seed with a given pubkeyhash (memory only)
+    virtual bool AddCryptedMasterSeed(const HDChainID& hash, const std::vector<unsigned char>& vchCryptedSecret);
+
+    //!encrypt existing uncrypted seeds and remove unencrypted data
+    virtual bool EncryptSeeds();
+
+    //!export the master seed from a given chain id (hash of the master pub key)
     virtual bool GetMasterSeed(const HDChainID& hash, CKeyingMaterial& seedOut) const;
+
+    //!get the encrypted master seed of a giveb chain id
+    virtual bool GetCryptedMasterSeed(const HDChainID& hash, std::vector<unsigned char>& vchCryptedSecret) const;
+
+    //!writes all available chain ids to a vector
+    virtual bool GetAvailableChainIDs(std::vector<HDChainID>& chainIDs);
+
+    //!add a CHDPubKey object to the keystore (memory only)
+    bool LoadHDPubKey(const CHDPubKey &pubkey);
+
+
+    //!add a new chain to the keystore (memory only)
+    bool AddChain(const CHDChain& chain);
+
+    //!writes a chain defined by given chainId to chainOut, returns false if not found
+    bool GetChain(const HDChainID chainId, CHDChain& chainOut) const;
+
+    //!Derives a hdpubkey object in a given chain defined by chainId from the existing external oder internal chain root pub key
+    bool DeriveHDPubKeyAtIndex(const HDChainID chainId, CHDPubKey& hdPubKeyOut, unsigned int nIndex, bool internal) const;
+
+    /**
+     * Get next available index for a child key in chain defined by given chain id
+     * @return next available index
+     * @warning This will "fill gaps". If you have m/0/0, m/0/1, m/0/2, m/0/100 it will return 3 (m/0/3)
+     */
+    unsigned int GetNextChildIndex(const HDChainID& chainId, bool internal);
+
+    //!check if a wallet has a certain key
+    bool HaveKey(const CKeyID &address) const;
+
+    //!get a key with given keyid for signing, etc. (private key operation)
+    bool GetKey(const CKeyID &address, CKey &keyOut) const;
 };
 #endif // BITCOIN_WALLET_HDKEYSTORE_H

--- a/src/wallet/hdkeystore.h
+++ b/src/wallet/hdkeystore.h
@@ -22,6 +22,7 @@ public:
     unsigned int nChild; //child index
     HDChainID chainHash; //hash of the chains master pubkey
     std::string chainPath; //individual key chainpath like m/44'/0'/0'/0/1
+    bool internal;
 
     CHDPubKey()
     {
@@ -48,9 +49,10 @@ public:
         nVersion = this->nVersion;
 
         READWRITE(pubkey);
+        READWRITE(nChild);
         READWRITE(chainHash);
         READWRITE(chainPath);
-        READWRITE(nChild);
+        READWRITE(internal);
     }
 };
 
@@ -160,5 +162,8 @@ public:
 
     //!get a key with given keyid for signing, etc. (private key operation)
     bool GetKey(const CKeyID &address, CKey &keyOut) const;
+
+    //!get a pubkey with given keyid for verifiying, etc.
+    bool GetPubKey(const CKeyID &address, CPubKey& vchPubKeyOut) const;
 };
 #endif // BITCOIN_WALLET_HDKEYSTORE_H

--- a/src/wallet/hdkeystore.h
+++ b/src/wallet/hdkeystore.h
@@ -18,7 +18,7 @@ class CHDPubKey
 public:
     static const int CURRENT_VERSION=1;
     int nVersion;
-    CPubKey pubkey; //the acctual pubkey
+    CPubKey pubkey; //the actual pubkey
     unsigned int nChild; //child index
     HDChainID chainHash; //hash of the chains master pubkey
     std::string chainPath; //individual key chainpath like m/44'/0'/0'/0/1
@@ -147,7 +147,7 @@ public:
     //!writes a chain defined by given chainId to chainOut, returns false if not found
     bool GetChain(const HDChainID chainId, CHDChain& chainOut) const;
 
-    //!Derives a hdpubkey object in a given chain defined by chainId from the existing external oder internal chain root pub key
+    //!Derives a hdpubkey object in a given chain defined by chainId from the existing external or internal chain root pub key
     bool DeriveHDPubKeyAtIndex(const HDChainID chainId, CHDPubKey& hdPubKeyOut, unsigned int nIndex, bool internal) const;
 
     /**

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2456,7 +2456,7 @@ m = master key
 c stands for internal/external chain switch
   c=0 for external addresses
   c=1 for internal addresses
-  
+
 example "m/44'/0'/0'/c" will result in m/44'/0'/0'/0/0 for the first external key
 example "m/44'/0'/0'/c" will result in m/44'/0'/0'/1/0 for the first internal key
 example "m/44'/0'/0'/c" will result in m/44'/0'/0'/0/1 for the second external key
@@ -2740,15 +2740,15 @@ UniValue hdsendtoaddress(const UniValue& params, bool fHelp)
         wtx.mapValue["comment"] = params[2].get_str();
     if (params.size() > 3 && !params[3].isNull() && !params[3].get_str().empty())
         wtx.mapValue["to"]      = params[3].get_str();
-    
+
     bool fSubtractFeeFromAmount = false;
     if (params.size() > 4)
         fSubtractFeeFromAmount = params[4].get_bool();
-    
+
     EnsureWalletIsUnlocked();
-    
+
     SendMoneyHD(address.Get(), nAmount, fSubtractFeeFromAmount, wtx);
-    
+
     return wtx.GetHash().GetHex();
 }
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2490,8 +2490,9 @@ UniValue hdaddchain(const UniValue& params, bool fHelp)
     UniValue result(UniValue::VOBJ);
 
     assert(pwalletMain != NULL);
-    const unsigned int bip32MasterSeedLength = 32;
+    EnsureWalletIsUnlocked();
 
+    const unsigned int bip32MasterSeedLength = 32;
     CKeyingMaterial vSeed = CKeyingMaterial(bip32MasterSeedLength);
     bool fGenerateMasterSeed = true;
     CExtPubKey masterPubKey;
@@ -2558,9 +2559,7 @@ UniValue hdgetaddress(const UniValue& params, bool fHelp)
     pwalletMain->SetAddressBook(keyID, "", "receive");
 
     std::string keysChainPath = pwalletMain->HDGetChainPath();
-    std::stringstream ss; ss << pwalletMain->mapKeyMetadata[keyID].nChild;
     boost::replace_all(keysChainPath, "c", "0");
-    boost::replace_all(keysChainPath, "k", ss.str());
 
     UniValue result(UniValue::VOBJ);
     result.push_back(Pair("address", CBitcoinAddress(keyID).ToString()));

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2531,14 +2531,14 @@ UniValue hdaddchain(const UniValue& params, bool fHelp)
     HDChainID chainId;
     std::string chainPath = hd_default_chainpath;
     if (params.size() > 0 && params[0].isStr() && params[0].get_str() != "default")
-        chainPath = params[1].get_str(); //todo bip32 chainpath sanity
+        chainPath = params[0].get_str(); //todo bip32 chainpath sanity
 
     std::string xpubOut;
     std::string xprivOut;
 
     if (params.size() > 1 && params[1].isStr())
     {
-        if (params[1].get_str().size() > 32)
+        if (params[1].get_str().size() > 32*2) //hex
         {
             //assume it's a base58check encoded key
             xprivOut = params[1].get_str();

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -131,6 +131,7 @@ UniValue getnewaddress(const UniValue& params, bool fHelp)
     return CBitcoinAddress(keyID).ToString();
 }
 
+
 CBitcoinAddress GetAccountAddress(string strAccount, bool bForceNew=false)
 {
     CWalletDB walletdb(pwalletMain->strWalletFile);
@@ -2463,6 +2464,37 @@ example "m/44'/0'/0'/c" will result in m/44'/0'/0'/1/1 for the second internal k
 */
 const std::string hd_default_chainpath = "m/44'/0'/0'/c";
 
+static void SendMoneyHD(const CTxDestination &address, CAmount nValue, bool fSubtractFeeFromAmount, CWalletTx& wtxNew)
+{
+    CAmount curBalance = pwalletMain->GetBalance();
+
+    // Check amount
+    if (nValue <= 0)
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid amount");
+
+    if (nValue > curBalance)
+        throw JSONRPCError(RPC_WALLET_INSUFFICIENT_FUNDS, "Insufficient funds");
+
+    // Parse Bitcoin address
+    CScript scriptPubKey = GetScriptForDestination(address);
+
+    // Create and send the transaction
+    CHDReserveKey reservekey(pwalletMain);
+    CAmount nFeeRequired;
+    std::string strError;
+    vector<CRecipient> vecSend;
+    int nChangePosRet = -1;
+    CRecipient recipient = {scriptPubKey, nValue, fSubtractFeeFromAmount};
+    vecSend.push_back(recipient);
+    if (!pwalletMain->CreateTransaction(vecSend, wtxNew, reservekey, nFeeRequired, nChangePosRet, strError)) {
+        if (!fSubtractFeeFromAmount && nValue + nFeeRequired > pwalletMain->GetBalance())
+            strError = strprintf("Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!", FormatMoney(nFeeRequired));
+        throw JSONRPCError(RPC_WALLET_ERROR, strError);
+    }
+    if (!pwalletMain->CommitTransaction(wtxNew, reservekey))
+        throw JSONRPCError(RPC_WALLET_ERROR, "Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.");
+}
+
 UniValue hdaddchain(const UniValue& params, bool fHelp)
 {
     if (!EnsureWalletIsAvailable(fHelp))
@@ -2495,7 +2527,7 @@ UniValue hdaddchain(const UniValue& params, bool fHelp)
     const unsigned int bip32MasterSeedLength = 32;
     CKeyingMaterial vSeed = CKeyingMaterial(bip32MasterSeedLength);
     bool fGenerateMasterSeed = true;
-    CExtPubKey masterPubKey;
+    HDChainID chainId;
     std::string chainPath = hd_default_chainpath;
     if (params.size() > 0 && params[0].isStr() && params[0].get_str() != "default")
         chainPath = params[1].get_str(); //todo bip32 chainpath sanity
@@ -2514,9 +2546,86 @@ UniValue hdaddchain(const UniValue& params, bool fHelp)
         fGenerateMasterSeed = false;
     }
 
-    pwalletMain->HDSetChainPath(chainPath, fGenerateMasterSeed, vSeed, masterPubKey);
+    pwalletMain->HDSetChainPath(chainPath, fGenerateMasterSeed, vSeed, chainId);
     if (fGenerateMasterSeed)
         result.push_back(Pair("seed_hex", HexStr(vSeed)));
+    result.push_back(Pair("chainid", chainId.GetHex()));
+    return result;
+}
+
+UniValue hdsetchain(const UniValue& params, bool fHelp)
+{
+    if (!EnsureWalletIsAvailable(fHelp))
+        return NullUniValue;
+
+    if (fHelp || params.size() != 1)
+        throw runtime_error(
+                            "hdsetchain <chainid>\n"
+                            "\nReturns some hd relevant information.\n"
+                            "\nArguments:\n"
+                            "1. \"chainid\"        (string|hex, required) chainid is a bitcoin hash of the master public key of the corresponding chain.\n"
+                            "\nExamples:\n"
+                            + HelpExampleCli("hdsetchain", "")
+                            + HelpExampleCli("hdgetinfo", "True")
+                            + HelpExampleRpc("hdgetinfo", "")
+                            );
+
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
+    HDChainID chainId;
+    if (!IsHex(params[0].get_str()))
+        throw runtime_error("Chain id format is invalid");
+
+    chainId.SetHex(params[0].get_str());
+
+    if (!pwalletMain->HDSetActiveChainID(chainId))
+        throw runtime_error("Could not set active chain");
+
+    return NullUniValue;
+}
+
+UniValue hdgetinfo(const UniValue& params, bool fHelp)
+{
+    if (!EnsureWalletIsAvailable(fHelp))
+        return NullUniValue;
+
+    if (fHelp || params.size() != 0)
+        throw runtime_error(
+                            "hdgetinfo\n"
+                            "\nReturns some hd relevant information.\n"
+                            "\nArguments:\n"
+                            "{\n"
+                            "  \"chainid\" : \"<chainid>\",  string) A bitcoinhash of the master public key\n"
+                            "  \"creationtime\" : The creation time in seconds since epoch (midnight Jan 1 1970 GMT).\n"
+                            "  \"chainpath\" : \"<keyschainpath>\",  string) The chainpath (like m/44'/0'/0'/c)\n"
+                            "}\n"
+                            "\nExamples:\n"
+                            + HelpExampleCli("hdgetinfo", "")
+                            + HelpExampleCli("hdgetinfo", "True")
+                            + HelpExampleRpc("hdgetinfo", "")
+                            );
+
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
+    std::vector<HDChainID> chainIDs;
+    if (!pwalletMain->GetAvailableChainIDs(chainIDs))
+        throw runtime_error("Could not load chain ids");
+
+    UniValue result(UniValue::VARR);
+    BOOST_FOREACH(const HDChainID& chainId, chainIDs)
+    {
+        CHDChain chain;
+        if (!pwalletMain->GetChain(chainId, chain))
+            throw runtime_error("Could not load chain");
+
+        UniValue chainObject(UniValue::VOBJ);
+        chainObject.push_back(Pair("chainid", chainId.GetHex()));
+        chainObject.push_back(Pair("creationtime", chain.nCreateTime));
+        chainObject.push_back(Pair("chainpath", chain.chainPath));
+
+        result.push_back(chainObject);
+    }
+
     return result;
 }
 
@@ -2542,6 +2651,7 @@ UniValue hdgetaddress(const UniValue& params, bool fHelp)
     LOCK2(cs_main, pwalletMain->cs_wallet);
 
     CPubKey newKey;
+    std::string keyChainPath;
     if (params.size() == 1 && params[0].isNum())
     {
         HDChainID emptyId;
@@ -2551,19 +2661,73 @@ UniValue hdgetaddress(const UniValue& params, bool fHelp)
     else
     {
         HDChainID emptyId;
-        if (!pwalletMain->HDGetNextChildPubKey(emptyId, newKey))
+        if (!pwalletMain->HDGetNextChildPubKey(emptyId, newKey, keyChainPath))
             throw JSONRPCError(RPC_WALLET_KEYPOOL_RAN_OUT, "Error: Can't generate HD child key");
     }
     CKeyID keyID = newKey.GetID();
     
     pwalletMain->SetAddressBook(keyID, "", "receive");
 
-    std::string keysChainPath = pwalletMain->HDGetChainPath();
-    boost::replace_all(keysChainPath, "c", "0");
-
     UniValue result(UniValue::VOBJ);
     result.push_back(Pair("address", CBitcoinAddress(keyID).ToString()));
-    result.push_back(Pair("chainpath", keysChainPath));
+    result.push_back(Pair("chainpath", keyChainPath));
     return result;
 }
+
+UniValue hdsendtoaddress(const UniValue& params, bool fHelp)
+{
+    if (!EnsureWalletIsAvailable(fHelp))
+        return NullUniValue;
+
+    if (fHelp || params.size() < 2 || params.size() > 5)
+        throw runtime_error(
+                            "hdsendtoaddress \"bitcoinaddress\" amount ( \"comment\" \"comment-to\" subtractfeefromamount )\n"
+                            "\nSend an amount to a given address. The amount is a real and is rounded to the nearest 0.00000001\n"
+                            + HelpRequiringPassphrase() +
+                            "\nArguments:\n"
+                            "1. \"bitcoinaddress\"  (string, required) The bitcoin address to send to.\n"
+                            "2. \"amount\"      (numeric, required) The amount in btc to send. eg 0.1\n"
+                            "3. \"comment\"     (string, optional) A comment used to store what the transaction is for. \n"
+                            "                             This is not part of the transaction, just kept in your wallet.\n"
+                            "4. \"comment-to\"  (string, optional) A comment to store the name of the person or organization \n"
+                            "                             to which you're sending the transaction. This is not part of the \n"
+                            "                             transaction, just kept in your wallet.\n"
+                            "5. subtractfeefromamount  (boolean, optional, default=false) The fee will be deducted from the amount being sent.\n"
+                            "                             The recipient will receive less bitcoins than you enter in the amount field.\n"
+                            "\nResult:\n"
+                            "\"transactionid\"  (string) The transaction id.\n"
+                            "\nExamples:\n"
+                            + HelpExampleCli("hdsendtoaddress", "\"1M72Sfpbz1BPpXFHz9m3CdqATR44Jvaydd\" 0.1")
+                            + HelpExampleCli("hdsendtoaddress", "\"1M72Sfpbz1BPpXFHz9m3CdqATR44Jvaydd\" 0.1 \"donation\" \"seans outpost\"")
+                            + HelpExampleCli("hdsendtoaddress", "\"1M72Sfpbz1BPpXFHz9m3CdqATR44Jvaydd\" 0.1 \"\" \"\" true")
+                            + HelpExampleRpc("hdsendtoaddress", "\"1M72Sfpbz1BPpXFHz9m3CdqATR44Jvaydd\", 0.1, \"donation\", \"seans outpost\"")
+                            );
+
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
+    CBitcoinAddress address(params[0].get_str());
+    if (!address.IsValid())
+        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid Bitcoin address");
+
+    // Amount
+    CAmount nAmount = AmountFromValue(params[1]);
+
+    // Wallet comments
+    CWalletTx wtx;
+    if (params.size() > 2 && !params[2].isNull() && !params[2].get_str().empty())
+        wtx.mapValue["comment"] = params[2].get_str();
+    if (params.size() > 3 && !params[3].isNull() && !params[3].get_str().empty())
+        wtx.mapValue["to"]      = params[3].get_str();
+    
+    bool fSubtractFeeFromAmount = false;
+    if (params.size() > 4)
+        fSubtractFeeFromAmount = params[4].get_bool();
+    
+    EnsureWalletIsUnlocked();
+    
+    SendMoneyHD(address.Get(), nAmount, fSubtractFeeFromAmount, wtx);
+    
+    return wtx.GetHash().GetHex();
+}
+
 /* end BIP32 stack */

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2546,10 +2546,21 @@ UniValue hdaddchain(const UniValue& params, bool fHelp)
         fGenerateMasterSeed = false;
     }
 
-    pwalletMain->HDSetChainPath(chainPath, fGenerateMasterSeed, vSeed, chainId);
+    std::string xpubOut;
+    std::string xprivOut;
+
+    pwalletMain->HDAddHDChain(chainPath, fGenerateMasterSeed, vSeed, chainId, xprivOut, xpubOut);
     if (fGenerateMasterSeed)
         result.push_back(Pair("seed_hex", HexStr(vSeed)));
+
+    result.push_back(Pair("extended_master_pubkey", xpubOut));
+    result.push_back(Pair("extended_master_privkey", xprivOut));
     result.push_back(Pair("chainid", chainId.GetHex()));
+
+    memory_cleanse(&vSeed[0], bip32MasterSeedLength);
+    memory_cleanse(&xprivOut[0], xpubOut.size());
+    memory_cleanse(&xpubOut[0], xpubOut.size());
+
     return result;
 }
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2514,9 +2514,9 @@ UniValue hdaddchain(const UniValue& params, bool fHelp)
                             "}\n"
 
                             "\nExamples\n"
-                            + HelpExampleCli("hdaddchain", "set")
-                            + HelpExampleCli("hdaddchain", "set m/44'/0'/0'/c/k")
-                            + HelpExampleRpc("hdaddchain", "set m/44'/0'/0'/c/k")
+                            + HelpExampleCli("hdaddchain", "")
+                            + HelpExampleCli("hdaddchain", "m/44'/0'/0'/c/k")
+                            + HelpExampleRpc("hdaddchain", "m/44'/0'/0'/c/k")
                             );
 
     UniValue result(UniValue::VOBJ);

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2462,7 +2462,7 @@ example "m/44'/0'/0'/c" will result in m/44'/0'/0'/1/0 for the first internal ke
 example "m/44'/0'/0'/c" will result in m/44'/0'/0'/0/1 for the second external key
 example "m/44'/0'/0'/c" will result in m/44'/0'/0'/1/1 for the second internal key
 */
-const std::string hd_default_chainpath = "m/44'/0'/0'/c";
+const std::string hd_default_chainpath = "m/c'";
 
 static void SendMoneyHD(const CTxDestination &address, CAmount nValue, bool fSubtractFeeFromAmount, CWalletTx& wtxNew)
 {
@@ -2558,8 +2558,6 @@ UniValue hdaddchain(const UniValue& params, bool fHelp)
         }
     }
 
-
-
     pwalletMain->HDAddHDChain(chainPath, fGenerateMasterSeed, vSeed, chainId, xprivOut, xpubOut);
     if (fGenerateMasterSeed)
         result.push_back(Pair("seed_hex", HexStr(vSeed)));
@@ -2567,6 +2565,7 @@ UniValue hdaddchain(const UniValue& params, bool fHelp)
     result.push_back(Pair("extended_master_pubkey", xpubOut));
     result.push_back(Pair("extended_master_privkey", xprivOut));
     result.push_back(Pair("chainid", chainId.GetHex()));
+    result.push_back(Pair("keypath", chainPath));
 
     memory_cleanse(&vSeed[0], bip32MasterSeedLength);
     memory_cleanse(&xprivOut[0], xpubOut.size());
@@ -2677,7 +2676,7 @@ UniValue hdgetaddress(const UniValue& params, bool fHelp)
     if (params.size() == 1 && params[0].isNum())
     {
         HDChainID emptyId;
-        if (!pwalletMain->HDGetChildPubKeyAtIndex(emptyId, newKey, params[0].get_int()))
+        if (!pwalletMain->HDGetChildPubKeyAtIndex(emptyId, newKey, keyChainPath, params[0].get_int()))
             throw JSONRPCError(RPC_WALLET_KEYPOOL_RAN_OUT, "Error: Can't generate HD child key");
     }
     else

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2914,7 +2914,7 @@ bool CWallet::HDSetChainPath(const std::string& chainPathIn, bool generateMaster
     boost::to_lower(newChainPath);
     boost::erase_all(newChainPath, " ");
     boost::replace_all(newChainPath, "h", "'"); //support h instead of ' to allow easy JSON input over cmd line
-    if (newChainPath.size() > 0 && newChainPath.back() == '/')
+    if (newChainPath.size() > 0 && *newChainPath.rbegin() == '/')
         newChainPath.resize(newChainPath.size() - 1);
 
     std::vector<std::string> pathFragments;
@@ -2930,7 +2930,7 @@ bool CWallet::HDSetChainPath(const std::string& chainPathIn, bool generateMaster
     BOOST_FOREACH(std::string fragment, pathFragments)
     {
         bool harden = false;
-        if (fragment.back() == '\'')
+        if (*fragment.rbegin() == '\'')
         {
             harden = true;
             fragment = fragment.substr(0,fragment.size()-1);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -13,7 +13,6 @@
 #include "consensus/validation.h"
 #include "key.h"
 #include "keystore.h"
-#include "eccryptoverify.h"
 #include "main.h"
 #include "net.h"
 #include "policy/policy.h"
@@ -2960,13 +2959,12 @@ bool CWallet::HDAddHDChain(const std::string& chainPathIn, bool generateMaster, 
                 assert(vSeed.size() == 32);
                 if (generateMaster)
                 {
-                    RandAddSeedPerfmon();
-                    do {
-                        GetRandBytes(&vSeed[0], vSeed.size());
-                    } while (!eccrypto::Check(&vSeed[0]));
+                    CKey masterKey;
+                    masterKey.MakeNewKey(true);
+                    bip32MasterKey.SetMaster(masterKey.begin(),masterKey.size());
                 }
-
-                bip32MasterKey.SetMaster(&vSeed[0], vSeed.size());
+                else
+                    bip32MasterKey.SetMaster(&vSeed[0], vSeed.size());
             }
 
             CExtPubKey masterPubKey = bip32MasterKey.Neuter();

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -790,7 +790,7 @@ public:
 
 
     //!adds a hd chain of keys to the wallet
-    bool HDSetChainPath(const std::string& chainPath, bool generateMaster, CKeyingMaterial& vSeed, HDChainID& chainId, bool overwrite = false);
+    bool HDAddHDChain(const std::string& chainPath, bool generateMaster, CKeyingMaterial& vSeed, HDChainID& chainId, std::string &xprivOut, std::string &xpubOut, bool overwrite = false);
 
     //!gets a child key from the internal or external chain at given index
     bool HDGetChildPubKeyAtIndex(const HDChainID& chainID, CPubKey &pubKeyOut, unsigned int nIndex, bool internal = false);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -790,7 +790,7 @@ public:
 
 
     //!adds a hd chain of keys to the wallet
-    bool HDAddHDChain(const std::string& chainPath, bool generateMaster, CKeyingMaterial& vSeed, HDChainID& chainId, std::string &xprivOut, std::string &xpubOut, bool overwrite = false);
+    bool HDAddHDChain(const std::string& chainPath, bool generateMaster, CKeyingMaterial& vSeed, HDChainID& chainId, std::string &strBase58ExtPrivKey, std::string &strBase58ExtPubKey, bool overwrite = false);
 
     //!gets a child key from the internal or external chain at given index
     bool HDGetChildPubKeyAtIndex(const HDChainID& chainID, CPubKey &pubKeyOut, unsigned int nIndex, bool internal = false);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -13,6 +13,7 @@
 #include "utilstrencodings.h"
 #include "validationinterface.h"
 #include "wallet/crypter.h"
+#include "wallet/hdkeystore.h"
 #include "wallet/wallet_ismine.h"
 #include "wallet/walletdb.h"
 
@@ -451,7 +452,7 @@ public:
  * A CWallet is an extension of a keystore, which also maintains a set of transactions and balances,
  * and provides the ability to create new transactions.
  */
-class CWallet : public CCryptoKeyStore, public CValidationInterface
+class CWallet : public CHDKeyStore, public CValidationInterface
 {
 private:
     /**
@@ -784,17 +785,12 @@ public:
     /** Set whether this wallet broadcasts transactions. */
     void SetBroadcastTransactions(bool broadcast) { fBroadcastTransactions = broadcast; }
 
-
-    std::string HDchainPath;
-    CExtPubKey HDexternalPubKey;
-    CExtPubKey HDinternalPubKey;
-    unsigned char HDmasterSeed[32];
-    CKeyID HDmasterKeyID;
-    CKeyingMaterial vMasterSeed;
+    std::map<uint256, CHDChain> hdChains;
+    uint256 HDactiveChain;
 
     bool HDSetChainPath(const std::string& chainPath, bool generateMaster, CKeyingMaterial& vSeed, const CExtPubKey& pubMasterKey, bool overwrite = false);
-    bool HDGetChildPubKeyAtIndex(CPubKey &pubKeyOut, unsigned int index, bool internal = false);
-    bool HDGetNextChildPubKey(CPubKey &pubKeyOut, bool internal = false);
+    bool HDGetChildPubKeyAtIndex(const HDChainID& chainID, CPubKey &pubKeyOut, unsigned int nIndex, bool internal = false);
+    bool HDGetNextChildPubKey(const HDChainID& chainIDIn, CPubKey &pubKeyOut, bool internal = false);
     bool HDDeriveKeyFromKeyID(CKey& keyOut, CKeyID keyId) const;
     bool GetKey(const CKeyID &address, CKey &keyOut) const;
     std::string HDGetChainPath();

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -793,7 +793,7 @@ public:
     bool HDAddHDChain(const std::string& chainPath, bool generateMaster, CKeyingMaterial& vSeed, HDChainID& chainId, std::string &strBase58ExtPrivKey, std::string &strBase58ExtPubKey, bool overwrite = false);
 
     //!gets a child key from the internal or external chain at given index
-    bool HDGetChildPubKeyAtIndex(const HDChainID& chainID, CPubKey &pubKeyOut, unsigned int nIndex, bool internal = false);
+    bool HDGetChildPubKeyAtIndex(const HDChainID& chainID, CPubKey &pubKeyOut, std::string& newKeysChainpath, unsigned int nIndex, bool internal = false);
 
     //!get next free child key
     bool HDGetNextChildPubKey(const HDChainID& chainId, CPubKey &pubKeyOut, std::string& newKeysChainpathOut, bool internal = false);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -783,6 +783,21 @@ public:
     bool GetBroadcastTransactions() const { return fBroadcastTransactions; }
     /** Set whether this wallet broadcasts transactions. */
     void SetBroadcastTransactions(bool broadcast) { fBroadcastTransactions = broadcast; }
+
+
+    std::string HDchainPath;
+    CExtPubKey HDexternalPubKey;
+    CExtPubKey HDinternalPubKey;
+    unsigned char HDmasterSeed[32];
+    CKeyID HDmasterKeyID;
+    CKeyingMaterial vMasterSeed;
+
+    bool HDSetChainPath(const std::string& chainPath, bool generateMaster, CKeyingMaterial& vSeed, const CExtPubKey& pubMasterKey, bool overwrite = false);
+    bool HDGetChildPubKeyAtIndex(CPubKey &pubKeyOut, unsigned int index, bool internal = false);
+    bool HDGetNextChildPubKey(CPubKey &pubKeyOut, bool internal = false);
+    bool HDDeriveKeyFromKeyID(CKey& keyOut, CKeyID keyId) const;
+    bool GetKey(const CKeyID &address, CKey &keyOut) const;
+    std::string HDGetChainPath();
 };
 
 /** A key allocated from the key pool. */

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -596,6 +596,7 @@ public:
     bool AddKeyPubKey(const CKey& key, const CPubKey &pubkey);
     //! Adds a key to the store, without saving it to disk (used by LoadWallet)
     bool LoadKey(const CKey& key, const CPubKey &pubkey) { return CCryptoKeyStore::AddKeyPubKey(key, pubkey); }
+
     //! Load metadata (used by LoadWallet)
     bool LoadKeyMetadata(const CPubKey &pubkey, const CKeyMetadata &metadata);
 
@@ -785,14 +786,12 @@ public:
     /** Set whether this wallet broadcasts transactions. */
     void SetBroadcastTransactions(bool broadcast) { fBroadcastTransactions = broadcast; }
 
-    std::map<uint256, CHDChain> hdChains;
-    uint256 HDactiveChain;
+    uint256 activeHDChain;
 
     bool HDSetChainPath(const std::string& chainPath, bool generateMaster, CKeyingMaterial& vSeed, const CExtPubKey& pubMasterKey, bool overwrite = false);
     bool HDGetChildPubKeyAtIndex(const HDChainID& chainID, CPubKey &pubKeyOut, unsigned int nIndex, bool internal = false);
-    bool HDGetNextChildPubKey(const HDChainID& chainIDIn, CPubKey &pubKeyOut, bool internal = false);
-    bool HDDeriveKeyFromKeyID(CKey& keyOut, CKeyID keyId) const;
-    bool GetKey(const CKeyID &address, CKey &keyOut) const;
+    bool HDGetNextChildPubKey(const HDChainID& chainId, CPubKey &pubKeyOut, std::string& newKeysChainpathOut, bool internal = false);
+    bool EncryptHDSeeds(CKeyingMaterial& vMasterKeyIn);
     std::string HDGetChainPath();
 };
 

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -153,25 +153,7 @@ bool CWalletDB::EraseHDMasterSeed(const uint256& hash)
     return Erase(std::make_pair(std::string("hdmasterseed"), hash));
 }
 
-bool CWalletDB::WriteHDExternalPubKey(const uint256& hash, const CExtPubKey &externalPubKey)
-{
-    nWalletDBUpdated++;
-    return Write(std::make_pair(std::string("hdexternalpubkey"), hash), externalPubKey);
-}
-
-bool CWalletDB::WriteHDInternalPubKey(const uint256& hash, const CExtPubKey &internalPubKey)
-{
-    nWalletDBUpdated++;
-    return Write(std::make_pair(std::string("hdinternalpubkey"), hash), internalPubKey);
-}
-
-bool CWalletDB::WriteHDChainPath(const uint256& hash, const std::string &chainPath)
-{
-    nWalletDBUpdated++;
-    return Write(std::make_pair(std::string("hdchainpath"), hash), chainPath);
-}
-
-bool CWalletDB::WriteHDChainPath(const CHDChain &chain)
+bool CWalletDB::WriteHDChain(const CHDChain &chain)
 {
     nWalletDBUpdated++;
     return Write(std::make_pair(std::string("hdchain"), chain.chainHash), chain);
@@ -665,32 +647,6 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
                 return false;
             }
         }
-        else if (strType == "hdexternalpubkey")
-        {
-            uint256 chainHash;
-            CExtPubKey extPubKey;
-            ssKey >> chainHash;
-            ssValue >> extPubKey;
-
-            pwallet->hdChains[chainHash].externalPubKey = extPubKey;
-        }
-        else if (strType == "hdinternalpubkey")
-        {
-            uint256 chainHash;
-            CExtPubKey extPubKey;
-            ssKey >> chainHash;
-            ssValue >> extPubKey;
-
-            pwallet->hdChains[chainHash].internalPubKey = extPubKey;
-        }
-        else if (strType == "hdchainpath")
-        {
-            uint256 chainHash;
-            std::string chainPath;
-            ssKey >> chainHash;
-            ssValue >> chainPath;
-            pwallet->hdChains[chainHash].chainPath = chainPath;
-        }
         else if (strType == "hdmasterseed")
         {
             uint256 masterPubKeyHash;
@@ -709,7 +665,9 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
         }
         else if (strType == "hdactivechain")
         {
-            ssValue >> pwallet->activeHDChain;
+            HDChainID chainID;
+            ssValue >> chainID;
+            pwallet->HDSetActiveChainID(chainID, false); //don't check if the chain exists because this record could come in before the CHDChain object itself
         }
         else if (strType == "hdpubkey")
         {

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -49,6 +49,7 @@ public:
 
     unsigned int nChild;
     CKeyID parentKeyID;
+    uint256 chainHash;
 
     CKeyMetadata()
     {
@@ -71,6 +72,7 @@ public:
         {
             READWRITE(nChild);
             READWRITE(parentKeyID);
+            READWRITE(chainHash);
         }
 
     }
@@ -110,14 +112,17 @@ public:
     bool WriteWatchOnly(const CScript &script);
     bool EraseWatchOnly(const CScript &script);
 
-    bool WriteHDMasterSeed(const CKeyingMaterial& masterSeed);
-    bool EraseHDMasterSeed();
+    bool WriteHDMasterSeed(const uint256& hash, const CKeyingMaterial& masterSeed);
+    bool WriteHDCryptedMasterSeed(const uint256& hash, const std::vector<unsigned char>& vchCryptedSecret);
+    bool EraseHDMasterSeed(const uint256& hash);
 
-    bool WriteHDExternalPubKey(const CExtPubKey &externalPubKey);
-    bool WriteHDInternalPubKey(const CExtPubKey &internalPubKey);
+    bool WriteHDExternalPubKey(const uint256& hash, const CExtPubKey &externalPubKey);
+    bool WriteHDInternalPubKey(const uint256& hash, const CExtPubKey &internalPubKey);
 
-    bool WriteHDChainPath(const std::string &chainPath);
+    bool WriteHDChainPath(const uint256& hash, const std::string &chainPath);
     bool WriteHDPubKey(const CPubKey& vchPubKey, const CKeyMetadata& keyMeta);
+
+    bool WriteHDAchiveChain(const uint256& hash);
 
     bool WriteBestBlock(const CBlockLocator& locator);
     bool ReadBestBlock(CBlockLocator& locator);

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -43,9 +43,12 @@ enum DBErrors
 class CKeyMetadata
 {
 public:
-    static const int CURRENT_VERSION=1;
+    static const int CURRENT_VERSION=2;
     int nVersion;
     int64_t nCreateTime; // 0 means unknown
+
+    unsigned int nChild;
+    CKeyID parentKeyID;
 
     CKeyMetadata()
     {
@@ -53,7 +56,7 @@ public:
     }
     CKeyMetadata(int64_t nCreateTime_)
     {
-        nVersion = CKeyMetadata::CURRENT_VERSION;
+        SetNull();
         nCreateTime = nCreateTime_;
     }
 
@@ -64,12 +67,20 @@ public:
         READWRITE(this->nVersion);
         nVersion = this->nVersion;
         READWRITE(nCreateTime);
+        if(nVersion >= 2)
+        {
+            READWRITE(nChild);
+            READWRITE(parentKeyID);
+        }
+
     }
 
     void SetNull()
     {
         nVersion = CKeyMetadata::CURRENT_VERSION;
         nCreateTime = 0;
+        nChild = 0;
+        parentKeyID = CKeyID();
     }
 };
 

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -9,6 +9,8 @@
 #include "amount.h"
 #include "wallet/db.h"
 #include "key.h"
+#include "keystore.h"
+#include "hdkeystore.h"
 
 #include <list>
 #include <stdint.h>
@@ -43,13 +45,9 @@ enum DBErrors
 class CKeyMetadata
 {
 public:
-    static const int CURRENT_VERSION=2;
+    static const int CURRENT_VERSION=1;
     int nVersion;
     int64_t nCreateTime; // 0 means unknown
-
-    unsigned int nChild;
-    CKeyID parentKeyID;
-    uint256 chainHash;
 
     CKeyMetadata()
     {
@@ -68,21 +66,12 @@ public:
         READWRITE(this->nVersion);
         nVersion = this->nVersion;
         READWRITE(nCreateTime);
-        if(nVersion >= 2)
-        {
-            READWRITE(nChild);
-            READWRITE(parentKeyID);
-            READWRITE(chainHash);
-        }
-
     }
 
     void SetNull()
     {
         nVersion = CKeyMetadata::CURRENT_VERSION;
         nCreateTime = 0;
-        nChild = 0;
-        parentKeyID = CKeyID();
     }
 };
 
@@ -120,7 +109,8 @@ public:
     bool WriteHDInternalPubKey(const uint256& hash, const CExtPubKey &internalPubKey);
 
     bool WriteHDChainPath(const uint256& hash, const std::string &chainPath);
-    bool WriteHDPubKey(const CPubKey& vchPubKey, const CKeyMetadata& keyMeta);
+    bool WriteHDChain(const CHDChain& chain);
+    bool WriteHDPubKey(const CHDPubKey& hdPubKey, const CKeyMetadata& keyMeta);
 
     bool WriteHDAchiveChain(const uint256& hash);
 

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -55,7 +55,7 @@ public:
     }
     CKeyMetadata(int64_t nCreateTime_)
     {
-        SetNull();
+        nVersion = CKeyMetadata::CURRENT_VERSION;
         nCreateTime = nCreateTime_;
     }
 
@@ -104,14 +104,8 @@ public:
     bool WriteHDMasterSeed(const uint256& hash, const CKeyingMaterial& masterSeed);
     bool WriteHDCryptedMasterSeed(const uint256& hash, const std::vector<unsigned char>& vchCryptedSecret);
     bool EraseHDMasterSeed(const uint256& hash);
-
-    bool WriteHDExternalPubKey(const uint256& hash, const CExtPubKey &externalPubKey);
-    bool WriteHDInternalPubKey(const uint256& hash, const CExtPubKey &internalPubKey);
-
-    bool WriteHDChainPath(const uint256& hash, const std::string &chainPath);
     bool WriteHDChain(const CHDChain& chain);
     bool WriteHDPubKey(const CHDPubKey& hdPubKey, const CKeyMetadata& keyMeta);
-
     bool WriteHDAchiveChain(const uint256& hash);
 
     bool WriteBestBlock(const CBlockLocator& locator);

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -110,8 +110,8 @@ public:
     bool WriteWatchOnly(const CScript &script);
     bool EraseWatchOnly(const CScript &script);
 
-    bool WriteHDMasterSeed(const std::string &masterSeedHex);
-    bool EraseHDMasterSeed(const CScript &dest);
+    bool WriteHDMasterSeed(const CKeyingMaterial& masterSeed);
+    bool EraseHDMasterSeed();
 
     bool WriteHDExternalPubKey(const CExtPubKey &externalPubKey);
     bool WriteHDInternalPubKey(const CExtPubKey &internalPubKey);

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -110,6 +110,15 @@ public:
     bool WriteWatchOnly(const CScript &script);
     bool EraseWatchOnly(const CScript &script);
 
+    bool WriteHDMasterSeed(const std::string &masterSeedHex);
+    bool EraseHDMasterSeed(const CScript &dest);
+
+    bool WriteHDExternalPubKey(const CExtPubKey &externalPubKey);
+    bool WriteHDInternalPubKey(const CExtPubKey &internalPubKey);
+
+    bool WriteHDChainPath(const std::string &chainPath);
+    bool WriteHDPubKey(const CPubKey& vchPubKey, const CKeyMetadata& keyMeta);
+
     bool WriteBestBlock(const CBlockLocator& locator);
     bool ReadBestBlock(CBlockLocator& locator);
 


### PR DESCRIPTION
This will add basic bip32 support for the current wallet. I testes the PR in serval environments, but, still needs more testing.
Feedback of any type is highly welcome.
## Concept
- At the moment, all HD operations are independent/separated from the existing normal single key operations (allows better testing and a smother transition to HD wallets).
- The wallet is still capable of using and producing single keys.
- The user can define his desired chainpath like `m/44'/0'/0'/c` or `m/0'/c`
  - "m" stands for master, "c" for switch between internal (1) and external (0) chain
- HD private keys are not stored in the database. If they are required, they get derived via the stored master seed and the available metadata (child index, chain path).
- When creating a new hd chain of keys (`hdaddchain add <chainpath> <masterseed>`), the rpc command will add the generated master seed as hex to the response (user can store it and use it as backup).
- Bip39 is not supported (and I don't plan to support it). ~~Instead of bip39 i'd like to use @maaku base-32 error correction encoding (https://gist.github.com/maaku/8996338). Users could write down the used master seed (or print if we would add a such option to the GUI).~~ (not sure about that but i think users should create a print of the seeds 32byte hex representation. Brainwallets tend to have weak security and are social-conceptual a bad idea).
- There is one new wallet state variable (`activeHDChain`) which is somehow unavoidable (change addresses, etc.).
## Persistance
- HD pub keys are stored within a new object CHDPubKey. Additional to the raw pub key there is also information about the chain, depth, etc.
- HD master seeds are stored as a 32byte raw data blob (encrypted with the given masterkey if wallet is/gets encrypted)
## RPC

This adds 5 new rpc commands
1. `hdaddchain` allows to add a new hd chain of keys
2. `hdgetaddress` get next available external key
3. `hdsetchain` set the active chain of keys (enables basic chain rotation)
4. `hdsendtoaddress` copy of sendtoaddress but uses a hd pub key for the change address
5. `hdgetinfo` list the available chains of keys
## GUI

The UI still uses normal key operation. Switch to HD would be trivial, but, i'd like to extend the "first start wizard" to allow selecting a chain and encrypt before writing unencrypted data to the database.
## What's next
- The rpc test is a little bit mininalistic and I have plans to extend the test
- Support for pub key only wallets (basically this is trivial, it only needs to allow master pub key or extended int./ext. chain pub keys as input for `hdaddchain` RPC. Signing would fail in a such case.
- Support for HDM (allow one or two additional master pub keys per chain of keys to allow creating of multisigaddresses with standard `hdgetaddress` call [as well as change output keys]).
