### PR TITLE
gitian: Use the new bitcoin-detached-sigs git repo for OSX signatures

### DIFF
--- a/contrib/gitian-descriptors/gitian-osx-signer.yml
+++ b/contrib/gitian-descriptors/gitian-osx-signer.yml
@@ -8,10 +8,11 @@ packages:
 - "libc6:i386"
 - "faketime"
 reference_datetime: "2015-06-01 00:00:00"
-remotes: []
+remotes:
+- "url": "https://github.com/bitcoin/bitcoin-detached-sigs.git"
+  "dir": "signature"
 files:
 - "bitcoin-osx-unsigned.tar.gz"
-- "signature.tar.gz"
 script: |
   WRAP_DIR=$HOME/wrapped
   mkdir -p ${WRAP_DIR}
@@ -32,6 +33,6 @@ script: |
   SIGNED=bitcoin-osx-signed.dmg
 
   tar -xf ${UNSIGNED}
-  ./detached-sig-apply.sh ${UNSIGNED} signature.tar.gz
+  ./detached-sig-apply.sh ${UNSIGNED} signature/osx
   ${WRAP_DIR}/genisoimage -no-cache-inodes -D -l -probe -V "Bitcoin-Core" -no-pad -r -apple -o uncompressed.dmg signed-app
   ${WRAP_DIR}/dmg dmg uncompressed.dmg ${OUTDIR}/${SIGNED}

--- a/contrib/macdeploy/detached-sig-apply.sh
+++ b/contrib/macdeploy/detached-sig-apply.sh
@@ -20,7 +20,7 @@ fi
 
 rm -rf ${TEMPDIR} && mkdir -p ${TEMPDIR}
 tar -C ${TEMPDIR} -xf ${UNSIGNED}
-tar -C ${TEMPDIR} -xf ${SIGNATURE}
+cp -rf "${SIGNATURE}"/* ${TEMPDIR}
 
 if [ -z "${PAGESTUFF}" ]; then
   PAGESTUFF=${TEMPDIR}/pagestuff

--- a/contrib/macdeploy/detached-sig-create.sh
+++ b/contrib/macdeploy/detached-sig-create.sh
@@ -7,6 +7,7 @@ CODESIGN=codesign
 TEMPDIR=sign.temp
 TEMPLIST=${TEMPDIR}/signatures.txt
 OUT=signature.tar.gz
+OUTROOT=osx
 
 if [ ! -n "$1" ]; then
   echo "usage: $0 <codesign args>"
@@ -23,7 +24,7 @@ grep -v CodeResources < "${TEMPLIST}" | while read i; do
   TARGETFILE="${BUNDLE}/`echo "${i}" | sed "s|.*${BUNDLE}/||"`"
   SIZE=`pagestuff "$i" -p | tail -2 | grep size | sed 's/[^0-9]*//g'`
   OFFSET=`pagestuff "$i" -p | tail -2 | grep offset | sed 's/[^0-9]*//g'`
-  SIGNFILE="${TEMPDIR}/${TARGETFILE}.sign"
+  SIGNFILE="${TEMPDIR}/${OUTROOT}/${TARGETFILE}.sign"
   DIRNAME="`dirname "${SIGNFILE}"`"
   mkdir -p "${DIRNAME}"
   echo "Adding detached signature for: ${TARGETFILE}. Size: ${SIZE}. Offset: ${OFFSET}"
@@ -32,7 +33,7 @@ done
 
 grep CodeResources < "${TEMPLIST}" | while read i; do
   TARGETFILE="${BUNDLE}/`echo "${i}" | sed "s|.*${BUNDLE}/||"`"
-  RESOURCE="${TEMPDIR}/${TARGETFILE}"
+  RESOURCE="${TEMPDIR}/${OUTROOT}/${TARGETFILE}"
   DIRNAME="`dirname "${RESOURCE}"`"
   mkdir -p "${DIRNAME}"
   echo "Adding resource for: "${TARGETFILE}""

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -92,15 +92,13 @@ Commit your signature to gitian.sigs:
 	popd
 
   Wait for OSX detached signature:
-	Once the OSX build has 3 matching signatures, Gavin will sign it with the apple App-Store key.
-	He will then upload a detached signature to be combined with the unsigned app to create a signed binary.
+	Once the OSX build has 3 matching signatures, it will be signed with the Apple App-Store key.
+	A detached signature will then be committed to the bitcoin-detached-sigs repository, which can be combined with the unsigned app to create a signed binary.
 
   Create the signed OSX binary:
 
 	pushd ./gitian-builder
-	# Fetch the signature as instructed by Gavin
-	cp signature.tar.gz inputs/
-	./bin/gbuild -i ../bitcoin/contrib/gitian-descriptors/gitian-osx-signer.yml
+	./bin/gbuild -i --commit signature=v${VERSION} ../bitcoin/contrib/gitian-descriptors/gitian-osx-signer.yml
 	./bin/gsign --signer $SIGNER --release ${VERSION}-osx-signed --destination ../gitian.sigs/ ../bitcoin/contrib/gitian-descriptors/gitian-osx-signer.yml
 	mv build/out/bitcoin-osx-signed.dmg ../bitcoin-${VERSION}-osx.dmg
 	popd


### PR DESCRIPTION
Rather than fetching a signature.tar.gz from somewhere on the net, instruct Gitian to use a signature from a tag in the bitcoin-detached-sigs repository which corresponds to the tag of the release being built.

Gitian should then be run something like:

``` bash
./bin/gbuild --commit signature=v0.11.0rc2 ../bitcoin/contrib/gitian-descriptors/gitian-osx-signer.yml
```

This changes detached-sig-apply.sh to take a dirname rather than a tarball as an argument, though detached-sig-create.sh still outputs a tarball for convenience.

The dir structure was also altered to add an 'osx' prefix, so that detached win signatures may be added in the future without clashing.

I've successfully tested by creating tags in local bitcoin/bitcoin-detached-sigs repos and walking through the build process like a real release.

Safe for 0.11 backport.
