### PR TITLE
depends: fix Boost 1.55 build on GCC 5

### DIFF
--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -3,7 +3,7 @@ $(package)_version=1_55_0
 $(package)_download_path=http://sourceforge.net/projects/boost/files/boost/1.55.0
 $(package)_file_name=$(package)_$($(package)_version).tar.bz2
 $(package)_sha256_hash=fff00023dd79486d444c8e29922f4072e1d451fc5a4d2b6075852ead7f2b7b52
-$(package)_patches=darwin_boost_atomic-1.patch darwin_boost_atomic-2.patch
+$(package)_patches=darwin_boost_atomic-1.patch darwin_boost_atomic-2.patch gcc_5_no_cxx11.patch
 
 define $(package)_set_vars
 $(package)_config_opts_release=variant=release
@@ -28,6 +28,7 @@ endef
 define $(package)_preprocess_cmds
   patch -p2 < $($(package)_patch_dir)/darwin_boost_atomic-1.patch && \
   patch -p2 < $($(package)_patch_dir)/darwin_boost_atomic-2.patch && \
+  patch -p2 < $($(package)_patch_dir)/gcc_5_no_cxx11.patch && \
   echo "using $(boost_toolset_$(host_os)) : : $($(package)_cxx) : <cxxflags>\"$($(package)_cxxflags) $($(package)_cppflags)\" <linkflags>\"$($(package)_ldflags)\" <archiver>\"$(boost_archiver_$(host_os))\" <striper>\"$(host_STRIP)\"  <ranlib>\"$(host_RANLIB)\" <rc>\"$(host_WINDRES)\" : ;" > user-config.jam
 endef
 

--- a/depends/patches/boost/gcc_5_no_cxx11.patch
+++ b/depends/patches/boost/gcc_5_no_cxx11.patch
@@ -1,0 +1,37 @@
+From eec808554936ae068b23df07ab54d4dc6302a695 Mon Sep 17 00:00:00 2001
+From: jzmaddock <jzmaddock@gmail.com>
+Date: Sat, 23 Aug 2014 09:38:02 +0100
+Subject: [PATCH] Fix BOOST_NO_CXX11_VARIADIC_TEMPLATES definition - the
+ feature was introduced in GCC 4.4.
+
+---
+ include/boost/config/compiler/gcc.hpp | 9 +--------
+ 1 file changed, 1 insertion(+), 8 deletions(-)
+
+diff --git a/include/boost/config/compiler/gcc.hpp b/include/boost/config/compiler/gcc.hpp
+index f37159d..97d8a18 100644
+--- a/include/boost/config/compiler/gcc.hpp
++++ b/include/boost/config/compiler/gcc.hpp
+@@ -154,14 +154,6 @@
+ #  define BOOST_NO_CXX11_FUNCTION_TEMPLATE_DEFAULT_ARGS
+ #  define BOOST_NO_CXX11_RVALUE_REFERENCES
+ #  define BOOST_NO_CXX11_STATIC_ASSERT
+-
+-// Variadic templates compiler:
+-//   http://www.generic-programming.org/~dgregor/cpp/variadic-templates.html
+-#  if defined(__VARIADIC_TEMPLATES) || (__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 4) && defined(__GXX_EXPERIMENTAL_CXX0X__))
+-#    define BOOST_HAS_VARIADIC_TMPL
+-#  else
+-#    define BOOST_NO_CXX11_VARIADIC_TEMPLATES
+-#  endif
+ #endif
+ 
+ // C++0x features in 4.4.n and later
+@@ -176,6 +168,7 @@
+ #  define BOOST_NO_CXX11_DELETED_FUNCTIONS
+ #  define BOOST_NO_CXX11_TRAILING_RESULT_TYPES
+ #  define BOOST_NO_CXX11_INLINE_NAMESPACES
++#  define BOOST_NO_CXX11_VARIADIC_TEMPLATES
+ #endif
+ 
+ #if __GNUC__ < 4 || (__GNUC__ == 4 && __GNUC_MINOR__ < 5)


### PR DESCRIPTION
Boost assumes variadic templates are always available in GCC 4.4+, but they aren't since we don't build with -std=c++11.

This applies the patch that fixed the issue in boost 1.57: https://github.com/boostorg/config/commit/eec808554936ae068b23df07ab54d4dc6302a695

See also: https://svn.boost.org/trac/boost/ticket/10500

(Or we could just bump the Boost version... I dunno how risky that is, so this is the conservative fix.)
