### PR TITLE
Limit mempool size

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -283,6 +283,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-dbcache=<n>", strprintf(_("Set database cache size in megabytes (%d to %d, default: %d)"), nMinDbCache, nMaxDbCache, nDefaultDbCache));
     strUsage += HelpMessageOpt("-loadblock=<file>", _("Imports blocks from external blk000??.dat file") + " " + _("on startup"));
     strUsage += HelpMessageOpt("-maxorphantx=<n>", strprintf(_("Keep at most <n> unconnectable transactions in memory (default: %u)"), DEFAULT_MAX_ORPHAN_TRANSACTIONS));
+    strUsage += HelpMessageOpt("-maxmempool=<n>", strprintf(_("Keep at most <n> bytes of transactions in memory (default: %u)"), DEFAULT_MAX_MEMPOOL_SIZE));
     strUsage += HelpMessageOpt("-par=<n>", strprintf(_("Set the number of script verification threads (%u to %d, 0 = auto, <0 = leave that many cores free, default: %d)"),
         -GetNumCores(), MAX_SCRIPTCHECK_THREADS, DEFAULT_SCRIPTCHECK_THREADS));
 #ifndef WIN32

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -923,6 +923,11 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
 
         // Store transaction in memory
         pool.addUnchecked(hash, entry, !IsInitialBlockDownload());
+
+        pool.removeOldTransactions(GetTime());
+        pool.trimToMaxSize(chainActive.Height());
+        if (!pool.exists(hash))
+            return error("AcceptToMemoryPool: fee too small");
     }
 
     SyncWithWallets(tx, NULL);

--- a/src/main.h
+++ b/src/main.h
@@ -13,6 +13,7 @@
 #include "amount.h"
 #include "chain.h"
 #include "chainparams.h"
+#include "consensus/consensus.h"
 #include "coins.h"
 #include "net.h"
 #include "primitives/block.h"
@@ -50,6 +51,8 @@ struct CNodeStateStats;
 static const bool DEFAULT_ALERTS = true;
 /** Default for -maxorphantx, maximum number of orphan transactions kept in memory */
 static const unsigned int DEFAULT_MAX_ORPHAN_TRANSACTIONS = 100;
+/** Default for -maxmempool, maximum bytes of transactions kept in memory */
+static const unsigned int DEFAULT_MAX_MEMPOOL_SIZE = 288 * MAX_BLOCK_SIZE; // 48 hours worth of blocks
 /** The maximum size of a blk?????.dat file (since 0.8) */
 static const unsigned int MAX_BLOCKFILE_SIZE = 0x8000000; // 128 MiB
 /** The pre-allocation chunk size for blk?????.dat files (since 0.8) */

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -162,6 +162,9 @@ public:
     /** Write/Read estimates to disk */
     bool WriteFeeEstimates(CAutoFile& fileout) const;
     bool ReadFeeEstimates(CAutoFile& filein);
+
+    void removeOldTransactions(int64_t nTime);
+    void trimToMaxSize(unsigned int currentHeight);
 };
 
 /** 


### PR DESCRIPTION
Restrict the maximum memory pool size to avoid potential DoS issues.

The mechanism is simply to recursively remove the transactions which have the lowest priority until the memory pool is below the maximum size.

compiles and passes tests, but has not been extensively tested

this is intended to replace #3753
