### PR TITLE
Fix scheduler build with some boost versions.

### DIFF
--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -50,8 +50,10 @@ void CScheduler::serviceQueue()
                 // Keep waiting until timeout
             }
 #else
+            // Some boost versions have a conflicting overload of wait_until that returns void.
+            // Explicitly use a template here to avoid hitting that overload.
             while (!shouldStop() && !taskQueue.empty() &&
-                   newTaskScheduled.wait_until(lock, taskQueue.begin()->first) != boost::cv_status::timeout) {
+                   newTaskScheduled.wait_until<>(lock, taskQueue.begin()->first) != boost::cv_status::timeout) {
                 // Keep waiting until timeout
             }
 #endif


### PR DESCRIPTION
Some boost versions have a conflicting public overload of wait_until that returns void. Explicitly use a template here to avoid hitting that overload.

Tested against boost 1.52, which is confirmed broken -> fixed.

For reference, here are the competing overloads (from thread/pthread/condition_variable_fwd.hpp):

``` c++
        template <class Duration>
        cv_status
        wait_until(
                unique_lock<mutex>& lock,
                const chrono::time_point<chrono::system_clock, Duration>& t)
        {
...
        inline void wait_until(
            unique_lock<mutex>& lk,
            chrono::time_point<chrono::system_clock, chrono::nanoseconds> tp)
        {
```

`boost::chrono::system_clock::duration` is typedef'd as chrono::nanoseconds, so without template params we end up falling into the void-return overload.
