### PR TITLE
[Qt] fix debug console window handling when e.g. minimized

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -212,7 +212,7 @@ BitcoinGUI::BitcoinGUI(const NetworkStyle *networkStyle, QWidget *parent) :
     statusBar()->addWidget(progressBar);
     statusBar()->addPermanentWidget(frameBlocks);
 
-    connect(openRPCConsoleAction, SIGNAL(triggered()), rpcConsole, SLOT(show()));
+    connect(openRPCConsoleAction, SIGNAL(triggered()), rpcConsole, SLOT(showNormalIfMinimized()));
 
     // prevents an open debug window from becoming stuck/unusable on client shutdown
     connect(quitAction, SIGNAL(triggered()), rpcConsole, SLOT(hide()));

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -699,3 +699,21 @@ void RPCConsole::clearSelectedNode()
     ui->detailWidget->hide();
     ui->peerHeading->setText(tr("Select a peer to view detailed information."));
 }
+
+void RPCConsole::showNormalIfMinimized()
+{
+    if(!clientModel)
+        return;
+
+    // activateWindow() (sometimes) helps with keyboard focus on Windows
+    if (isHidden()) {
+        show();
+        activateWindow();
+    } else if (isMinimized()) {
+        showNormal();
+        activateWindow();
+    } else if (GUIUtil::isObscured(this)) {
+        raise();
+        activateWindow();
+    }
+}

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -60,6 +60,8 @@ private slots:
     void hideEvent(QHideEvent *event);
     /** Show custom context menu on Peers tab */
     void showMenu(const QPoint& point);
+    /** Show window if hidden, unminimize when minimized, rise when obscured */
+    void showNormalIfMinimized();
 
 public slots:
     void clear();


### PR DESCRIPTION
- this applies the same functionality we have for the main window
- when the window was e.g. hidden and you clicked Help - Debug window, the
  window wasn't shown at all
