### PR TITLE
rpc: make `gettxoutsettinfo` run lock-free

### DIFF
--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -345,8 +345,6 @@ UniValue gettxoutsetinfo(const UniValue& params, bool fHelp)
             + HelpExampleRpc("gettxoutsetinfo", "")
         );
 
-    LOCK(cs_main);
-
     UniValue ret(UniValue::VOBJ);
 
     CCoinsStats stats;

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -147,7 +147,10 @@ bool CCoinsViewDB::GetStats(CCoinsStats &stats) const {
             return error("%s: Deserialize or I/O error - %s", __func__, e.what());
         }
     }
-    stats.nHeight = mapBlockIndex.find(GetBestBlock())->second->nHeight;
+    {
+        LOCK(cs_main);
+        stats.nHeight = mapBlockIndex.find(stats.hashBlock)->second->nHeight;
+    }
     stats.hashSerialized = ss.GetHash();
     stats.nTotalAmount = nTotalAmount;
     return true;


### PR DESCRIPTION
For leveldb "An iterator operates on a snapshot of the database taken when the iterator is created". This means that it is unnecessary to lock out other threads while computing statistics, and neither to hold cs_main for the whole time. Let the thread run free.

I've been using this patch for about 8 months without issues, including on a node that automatically dumps the information for every N blocks.
