### PR TITLE
Rename and comment priority calculation in TxMemPoolEntry

### DIFF
--- a/src/policy/fees.cpp
+++ b/src/policy/fees.cpp
@@ -375,7 +375,8 @@ void CBlockPolicyEstimator::processTransaction(const CTxMemPoolEntry& entry, boo
     // Want the priority of the tx at confirmation. However we don't know
     // what that will be and its too hard to continue updating it
     // so use starting priority as a proxy
-    double curPri = entry.GetPriority(txHeight);
+    // GetPriorityUpperBound returns the correct priority at tx height
+    double curPri = entry.GetPriorityUpperBound(txHeight);
     mapMemPoolTxs[hash].blockHeight = txHeight;
 
     LogPrint("estimatefee", "Blockpolicy mempool tx %s ", hash.ToString().substr(0,10));
@@ -419,7 +420,8 @@ void CBlockPolicyEstimator::processBlockTx(unsigned int nBlockHeight, const CTxM
 
     // Want the priority of the tx at confirmation.  The priority when it
     // entered the mempool could easily be very small and change quickly
-    double curPri = entry.GetPriority(nBlockHeight);
+    // GetPriorityUpperBound returns the correct priority when tx WasClearAtEntry
+    double curPri = entry.GetPriorityUpperBound(nBlockHeight);
 
     // Record this as a priority estimate
     if (entry.GetFee() == 0 || isPriDataPoint(feeRate, curPri)) {

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -166,7 +166,7 @@ UniValue getrawmempool(const UniValue& params, bool fHelp)
             "    \"time\" : n,             (numeric) local time transaction entered pool in seconds since 1 Jan 1970 GMT\n"
             "    \"height\" : n,           (numeric) block height when transaction entered pool\n"
             "    \"startingpriority\" : n, (numeric) priority when transaction entered pool\n"
-            "    \"currentpriority\" : n,  (numeric) transaction priority now\n"
+            "    \"currentpriority\" : n,  (numeric) upper bound of transaction priority now\n"
             "    \"depends\" : [           (array) unconfirmed transactions used as inputs for this transaction\n"
             "        \"transactionid\",    (string) parent transaction id\n"
             "       ... ]\n"
@@ -196,8 +196,8 @@ UniValue getrawmempool(const UniValue& params, bool fHelp)
             info.push_back(Pair("fee", ValueFromAmount(e.GetFee())));
             info.push_back(Pair("time", e.GetTime()));
             info.push_back(Pair("height", (int)e.GetHeight()));
-            info.push_back(Pair("startingpriority", e.GetPriority(e.GetHeight())));
-            info.push_back(Pair("currentpriority", e.GetPriority(chainActive.Height())));
+            info.push_back(Pair("startingpriority", e.GetPriorityUpperBound(e.GetHeight())));
+            info.push_back(Pair("currentpriority", e.GetPriorityUpperBound(chainActive.Height())));
             const CTransaction& tx = e.GetTx();
             set<string> setDepends;
             BOOST_FOREACH(const CTxIn& txin, tx.vin)

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -39,7 +39,7 @@ CTxMemPoolEntry::CTxMemPoolEntry(const CTxMemPoolEntry& other)
 }
 
 double
-CTxMemPoolEntry::GetPriority(unsigned int currentHeight) const
+CTxMemPoolEntry::GetPriorityUpperBound(unsigned int currentHeight) const
 {
     CAmount nValueIn = tx.GetValueOut()+nFee;
     double deltaPriority = ((double)(currentHeight-nHeight)*nValueIn)/nModSize;

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -52,7 +52,14 @@ public:
     CTxMemPoolEntry(const CTxMemPoolEntry& other);
 
     const CTransaction& GetTx() const { return this->tx; }
-    double GetPriority(unsigned int currentHeight) const;
+    /** This function will return the correct priority of the
+     *  transaction if it's called on a transaction whose inputs were
+     *  all in the blockchain at the time the transaction entered the
+     *  mempool.  Otherwise if currentHeight is greater than the height
+     *  of the transaction it will overestimate priority by assuming
+     *  all inputs have aged.
+     */
+    double GetPriorityUpperBound(unsigned int currentHeight) const;
     CAmount GetFee() const { return nFee; }
     size_t GetTxSize() const { return nTxSize; }
     int64_t GetTime() const { return nTime; }


### PR DESCRIPTION
The GetPriority calculation in CTxMemPoolEntry is incorrect. Instead of a more complicated and extensive fix which may be unnecessary, just rename the function and document its current behavior.
