### PR TITLE
test: Move reindex test to standard tests

### DIFF
--- a/qa/pull-tester/rpc-tests.sh
+++ b/qa/pull-tester/rpc-tests.sh
@@ -32,6 +32,7 @@ testScripts=(
     'merkle_blocks.py'
     'signrawtransactions.py'
     'walletbackup.py'
+    'reindex.py'
 );
 testScriptsExt=(
     'bipdersig-p2p.py'
@@ -43,7 +44,6 @@ testScriptsExt=(
     'invalidateblock.py'
     'keypool.py'
     'receivedby.py'
-    'reindex.py'
     'rpcbind_test.py'
 #   'script_test.py'
     'smartfees.py'


### PR DESCRIPTION
This test finishes very quickly, so it should be part of the default set of tests in rpc-tests.

As #5975 broke reindexing (see #6294),  this will currently fail. Better to merge this only after that is fixed.
