### PR TITLE
getblockhash: Return RPC_NOT_FOUND when nHeight > chainActive.Height()

### DIFF
--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -248,8 +248,10 @@ UniValue getblockhash(const UniValue& params, bool fHelp)
     LOCK(cs_main);
 
     int nHeight = params[0].get_int();
-    if (nHeight < 0 || nHeight > chainActive.Height())
-        throw JSONRPCError(RPC_INVALID_PARAMETER, "Block height out of range");
+    if (nHeight < 0)
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Negative block height");
+    if (nHeight > chainActive.Height())
+        throw JSONRPCError(RPC_NOT_FOUND, "Block height out of range");
 
     CBlockIndex* pblockindex = chainActive[nHeight];
     return pblockindex->GetBlockHash().GetHex();

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -301,7 +301,7 @@ UniValue getblock(const UniValue& params, bool fHelp)
         fVerbose = params[1].get_bool();
 
     if (mapBlockIndex.count(hash) == 0)
-        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found");
+        throw JSONRPCError(RPC_NOT_FOUND, "Block not found");
 
     CBlock block;
     CBlockIndex* pblockindex = mapBlockIndex[hash];
@@ -663,7 +663,7 @@ UniValue invalidateblock(const UniValue& params, bool fHelp)
     {
         LOCK(cs_main);
         if (mapBlockIndex.count(hash) == 0)
-            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found");
+            throw JSONRPCError(RPC_NOT_FOUND, "Block not found");
 
         CBlockIndex* pblockindex = mapBlockIndex[hash];
         InvalidateBlock(state, pblockindex);
@@ -702,7 +702,7 @@ UniValue reconsiderblock(const UniValue& params, bool fHelp)
     {
         LOCK(cs_main);
         if (mapBlockIndex.count(hash) == 0)
-            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found");
+            throw JSONRPCError(RPC_NOT_FOUND, "Block not found");
 
         CBlockIndex* pblockindex = mapBlockIndex[hash];
         ReconsiderBlock(state, pblockindex);

--- a/src/rpcmisc.cpp
+++ b/src/rpcmisc.cpp
@@ -360,7 +360,7 @@ UniValue verifymessage(const UniValue& params, bool fHelp)
     vector<unsigned char> vchSig = DecodeBase64(strSign.c_str(), &fInvalid);
 
     if (fInvalid)
-        throw JSONRPCError(RPC_NOT_FOUND, "Malformed base64 encoding");
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Malformed base64 encoding");
 
     CHashWriter ss(SER_GETHASH, 0);
     ss << strMessageMagic;

--- a/src/rpcmisc.cpp
+++ b/src/rpcmisc.cpp
@@ -360,7 +360,7 @@ UniValue verifymessage(const UniValue& params, bool fHelp)
     vector<unsigned char> vchSig = DecodeBase64(strSign.c_str(), &fInvalid);
 
     if (fInvalid)
-        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Malformed base64 encoding");
+        throw JSONRPCError(RPC_NOT_FOUND, "Malformed base64 encoding");
 
     CHashWriter ss(SER_GETHASH, 0);
     ss << strMessageMagic;

--- a/src/rpcprotocol.h
+++ b/src/rpcprotocol.h
@@ -43,7 +43,7 @@ enum RPCErrorCode
     RPC_MISC_ERROR                  = -1,  //! std::exception thrown in command handling
     RPC_FORBIDDEN_BY_SAFE_MODE      = -2,  //! Server is in safe mode, and command is not allowed in safe mode
     RPC_TYPE_ERROR                  = -3,  //! Unexpected type was passed as parameter
-    RPC_NOT_FOUND                   = -5,  //! Invalid address or key
+    RPC_NOT_FOUND                   = -5,  //! Non-existent address or key
     RPC_OUT_OF_MEMORY               = -7,  //! Ran out of memory during operation
     RPC_INVALID_PARAMETER           = -8,  //! Invalid, missing or duplicate parameter
     RPC_DATABASE_ERROR              = -20, //! Database error

--- a/src/rpcprotocol.h
+++ b/src/rpcprotocol.h
@@ -43,7 +43,7 @@ enum RPCErrorCode
     RPC_MISC_ERROR                  = -1,  //! std::exception thrown in command handling
     RPC_FORBIDDEN_BY_SAFE_MODE      = -2,  //! Server is in safe mode, and command is not allowed in safe mode
     RPC_TYPE_ERROR                  = -3,  //! Unexpected type was passed as parameter
-    RPC_INVALID_ADDRESS_OR_KEY      = -5,  //! Invalid address or key
+    RPC_NOT_FOUND                   = -5,  //! Invalid address or key
     RPC_OUT_OF_MEMORY               = -7,  //! Ran out of memory during operation
     RPC_INVALID_PARAMETER           = -8,  //! Invalid, missing or duplicate parameter
     RPC_DATABASE_ERROR              = -20, //! Database error
@@ -54,6 +54,7 @@ enum RPCErrorCode
     RPC_IN_WARMUP                   = -28, //! Client still warming up
 
     //! Aliases for backward compatibility
+    RPC_INVALID_ADDRESS_OR_KEY      = RPC_NOT_FOUND,
     RPC_TRANSACTION_ERROR           = RPC_VERIFY_ERROR,
     RPC_TRANSACTION_REJECTED        = RPC_VERIFY_REJECTED,
     RPC_TRANSACTION_ALREADY_IN_CHAIN= RPC_VERIFY_ALREADY_IN_CHAIN,

--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -372,7 +372,7 @@ UniValue createrawtransaction(const UniValue& params, bool fHelp)
     BOOST_FOREACH(const string& name_, addrList) {
         CBitcoinAddress address(name_);
         if (!address.IsValid())
-            throw JSONRPCError(RPC_NOT_FOUND, string("Invalid Bitcoin address: ")+name_);
+            throw JSONRPCError(RPC_INVALID_PARAMETER, string("Invalid Bitcoin address: ")+name_);
 
         if (setAddress.count(address))
             throw JSONRPCError(RPC_INVALID_PARAMETER, string("Invalid parameter, duplicated address: ")+name_);
@@ -623,10 +623,10 @@ UniValue signrawtransaction(const UniValue& params, bool fHelp)
             CBitcoinSecret vchSecret;
             bool fGood = vchSecret.SetString(k.get_str());
             if (!fGood)
-                throw JSONRPCError(RPC_NOT_FOUND, "Invalid private key");
+                throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid private key");
             CKey key = vchSecret.GetKey();
             if (!key.IsValid())
-                throw JSONRPCError(RPC_NOT_FOUND, "Private key outside allowed range");
+                throw JSONRPCError(RPC_INVALID_PARAMETER, "Private key outside allowed range");
             tempKeystore.AddKey(key);
         }
     }

--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -182,7 +182,7 @@ UniValue getrawtransaction(const UniValue& params, bool fHelp)
     CTransaction tx;
     uint256 hashBlock;
     if (!GetTransaction(hash, tx, hashBlock, true))
-        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "No information available about transaction");
+        throw JSONRPCError(RPC_NOT_FOUND, "No information available about transaction");
 
     string strHex = EncodeHexTx(tx);
 
@@ -240,7 +240,7 @@ UniValue gettxoutproof(const UniValue& params, bool fHelp)
     {
         hashBlock = uint256S(params[1].get_str());
         if (!mapBlockIndex.count(hashBlock))
-            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found");
+            throw JSONRPCError(RPC_NOT_FOUND, "Block not found");
         pblockindex = mapBlockIndex[hashBlock];
     } else {
         CCoins coins;
@@ -252,7 +252,7 @@ UniValue gettxoutproof(const UniValue& params, bool fHelp)
     {
         CTransaction tx;
         if (!GetTransaction(oneTxid, tx, hashBlock, false) || hashBlock.IsNull())
-            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Transaction not yet in block");
+            throw JSONRPCError(RPC_NOT_FOUND, "Transaction not yet in block");
         if (!mapBlockIndex.count(hashBlock))
             throw JSONRPCError(RPC_INTERNAL_ERROR, "Transaction index corrupt");
         pblockindex = mapBlockIndex[hashBlock];
@@ -267,7 +267,7 @@ UniValue gettxoutproof(const UniValue& params, bool fHelp)
         if (setTxids.count(tx.GetHash()))
             ntxFound++;
     if (ntxFound != setTxids.size())
-        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "(Not all) transactions not found in specified block");
+        throw JSONRPCError(RPC_NOT_FOUND, "(Not all) transactions not found in specified block");
 
     CDataStream ssMB(SER_NETWORK, PROTOCOL_VERSION);
     CMerkleBlock mb(block, setTxids);
@@ -302,7 +302,7 @@ UniValue verifytxoutproof(const UniValue& params, bool fHelp)
     LOCK(cs_main);
 
     if (!mapBlockIndex.count(merkleBlock.header.GetHash()) || !chainActive.Contains(mapBlockIndex[merkleBlock.header.GetHash()]))
-        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found in chain");
+        throw JSONRPCError(RPC_NOT_FOUND, "Block not found in chain");
 
     BOOST_FOREACH(const uint256& hash, vMatch)
         res.push_back(hash.GetHex());
@@ -372,7 +372,7 @@ UniValue createrawtransaction(const UniValue& params, bool fHelp)
     BOOST_FOREACH(const string& name_, addrList) {
         CBitcoinAddress address(name_);
         if (!address.IsValid())
-            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, string("Invalid Bitcoin address: ")+name_);
+            throw JSONRPCError(RPC_NOT_FOUND, string("Invalid Bitcoin address: ")+name_);
 
         if (setAddress.count(address))
             throw JSONRPCError(RPC_INVALID_PARAMETER, string("Invalid parameter, duplicated address: ")+name_);
@@ -623,10 +623,10 @@ UniValue signrawtransaction(const UniValue& params, bool fHelp)
             CBitcoinSecret vchSecret;
             bool fGood = vchSecret.SetString(k.get_str());
             if (!fGood)
-                throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid private key");
+                throw JSONRPCError(RPC_NOT_FOUND, "Invalid private key");
             CKey key = vchSecret.GetKey();
             if (!key.IsValid())
-                throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Private key outside allowed range");
+                throw JSONRPCError(RPC_NOT_FOUND, "Private key outside allowed range");
             tempKeystore.AddKey(key);
         }
     }

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -114,10 +114,10 @@ UniValue importprivkey(const UniValue& params, bool fHelp)
     CBitcoinSecret vchSecret;
     bool fGood = vchSecret.SetString(strSecret);
 
-    if (!fGood) throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid private key encoding");
+    if (!fGood) throw JSONRPCError(RPC_NOT_FOUND, "Invalid private key encoding");
 
     CKey key = vchSecret.GetKey();
-    if (!key.IsValid()) throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Private key outside allowed range");
+    if (!key.IsValid()) throw JSONRPCError(RPC_NOT_FOUND, "Private key outside allowed range");
 
     CPubKey pubkey = key.GetPubKey();
     assert(key.VerifyPubKey(pubkey));
@@ -183,7 +183,7 @@ UniValue importaddress(const UniValue& params, bool fHelp)
         std::vector<unsigned char> data(ParseHex(params[0].get_str()));
         script = CScript(data.begin(), data.end());
     } else {
-        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid Bitcoin address or script");
+        throw JSONRPCError(RPC_NOT_FOUND, "Invalid Bitcoin address or script");
     }
 
     string strLabel = "";
@@ -356,7 +356,7 @@ UniValue dumpprivkey(const UniValue& params, bool fHelp)
     string strAddress = params[0].get_str();
     CBitcoinAddress address;
     if (!address.SetString(strAddress))
-        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid Bitcoin address");
+        throw JSONRPCError(RPC_NOT_FOUND, "Invalid Bitcoin address");
     CKeyID keyID;
     if (!address.GetKeyID(keyID))
         throw JSONRPCError(RPC_TYPE_ERROR, "Address does not refer to a key");

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -114,10 +114,10 @@ UniValue importprivkey(const UniValue& params, bool fHelp)
     CBitcoinSecret vchSecret;
     bool fGood = vchSecret.SetString(strSecret);
 
-    if (!fGood) throw JSONRPCError(RPC_NOT_FOUND, "Invalid private key encoding");
+    if (!fGood) throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid private key encoding");
 
     CKey key = vchSecret.GetKey();
-    if (!key.IsValid()) throw JSONRPCError(RPC_NOT_FOUND, "Private key outside allowed range");
+    if (!key.IsValid()) throw JSONRPCError(RPC_INVALID_PARAMETER, "Private key outside allowed range");
 
     CPubKey pubkey = key.GetPubKey();
     assert(key.VerifyPubKey(pubkey));
@@ -183,7 +183,7 @@ UniValue importaddress(const UniValue& params, bool fHelp)
         std::vector<unsigned char> data(ParseHex(params[0].get_str()));
         script = CScript(data.begin(), data.end());
     } else {
-        throw JSONRPCError(RPC_NOT_FOUND, "Invalid Bitcoin address or script");
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid Bitcoin address or script");
     }
 
     string strLabel = "";
@@ -356,7 +356,7 @@ UniValue dumpprivkey(const UniValue& params, bool fHelp)
     string strAddress = params[0].get_str();
     CBitcoinAddress address;
     if (!address.SetString(strAddress))
-        throw JSONRPCError(RPC_NOT_FOUND, "Invalid Bitcoin address");
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid Bitcoin address");
     CKeyID keyID;
     if (!address.GetKeyID(keyID))
         throw JSONRPCError(RPC_TYPE_ERROR, "Address does not refer to a key");

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -252,7 +252,7 @@ UniValue setaccount(const UniValue& params, bool fHelp)
 
     CBitcoinAddress address(params[0].get_str());
     if (!address.IsValid())
-        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid Bitcoin address");
+        throw JSONRPCError(RPC_NOT_FOUND, "Invalid Bitcoin address");
 
     string strAccount;
     if (params.size() > 1)
@@ -299,7 +299,7 @@ UniValue getaccount(const UniValue& params, bool fHelp)
 
     CBitcoinAddress address(params[0].get_str());
     if (!address.IsValid())
-        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid Bitcoin address");
+        throw JSONRPCError(RPC_NOT_FOUND, "Invalid Bitcoin address");
 
     string strAccount;
     map<CTxDestination, CAddressBookData>::iterator mi = pwalletMain->mapAddressBook.find(address.Get());
@@ -410,7 +410,7 @@ UniValue sendtoaddress(const UniValue& params, bool fHelp)
 
     CBitcoinAddress address(params[0].get_str());
     if (!address.IsValid())
-        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid Bitcoin address");
+        throw JSONRPCError(RPC_NOT_FOUND, "Invalid Bitcoin address");
 
     // Amount
     CAmount nAmount = AmountFromValue(params[1]);
@@ -538,7 +538,7 @@ UniValue signmessage(const UniValue& params, bool fHelp)
 
     vector<unsigned char> vchSig;
     if (!key.SignCompact(ss.GetHash(), vchSig))
-        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Sign failed");
+        throw JSONRPCError(RPC_NOT_FOUND, "Sign failed");
 
     return EncodeBase64(&vchSig[0], vchSig.size());
 }
@@ -573,7 +573,7 @@ UniValue getreceivedbyaddress(const UniValue& params, bool fHelp)
     // Bitcoin address
     CBitcoinAddress address = CBitcoinAddress(params[0].get_str());
     if (!address.IsValid())
-        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid Bitcoin address");
+        throw JSONRPCError(RPC_NOT_FOUND, "Invalid Bitcoin address");
     CScript scriptPubKey = GetScriptForDestination(address.Get());
     if (!IsMine(*pwalletMain,scriptPubKey))
         return (double)0.0;
@@ -890,7 +890,7 @@ UniValue sendfrom(const UniValue& params, bool fHelp)
     string strAccount = AccountFromValue(params[0]);
     CBitcoinAddress address(params[1].get_str());
     if (!address.IsValid())
-        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid Bitcoin address");
+        throw JSONRPCError(RPC_NOT_FOUND, "Invalid Bitcoin address");
     CAmount nAmount = AmountFromValue(params[2]);
     if (nAmount <= 0)
         throw JSONRPCError(RPC_TYPE_ERROR, "Invalid amount for send");
@@ -985,7 +985,7 @@ UniValue sendmany(const UniValue& params, bool fHelp)
     {
         CBitcoinAddress address(name_);
         if (!address.IsValid())
-            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, string("Invalid Bitcoin address: ")+name_);
+            throw JSONRPCError(RPC_NOT_FOUND, string("Invalid Bitcoin address: ")+name_);
 
         if (setAddress.count(address))
             throw JSONRPCError(RPC_INVALID_PARAMETER, string("Invalid parameter, duplicated address: ")+name_);
@@ -1725,7 +1725,7 @@ UniValue gettransaction(const UniValue& params, bool fHelp)
 
     UniValue entry(UniValue::VOBJ);
     if (!pwalletMain->mapWallet.count(hash))
-        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid or non-wallet transaction id");
+        throw JSONRPCError(RPC_NOT_FOUND, "Invalid or non-wallet transaction id");
     const CWalletTx& wtx = pwalletMain->mapWallet[hash];
 
     CAmount nCredit = wtx.GetCredit(filter);
@@ -2307,7 +2307,7 @@ UniValue listunspent(const UniValue& params, bool fHelp)
             const UniValue& input = inputs[idx];
             CBitcoinAddress address(input.get_str());
             if (!address.IsValid())
-                throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, string("Invalid Bitcoin address: ")+input.get_str());
+                throw JSONRPCError(RPC_NOT_FOUND, string("Invalid Bitcoin address: ")+input.get_str());
             if (setAddress.count(address))
                 throw JSONRPCError(RPC_INVALID_PARAMETER, string("Invalid parameter, duplicated address: ")+input.get_str());
            setAddress.insert(address);

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -252,7 +252,7 @@ UniValue setaccount(const UniValue& params, bool fHelp)
 
     CBitcoinAddress address(params[0].get_str());
     if (!address.IsValid())
-        throw JSONRPCError(RPC_NOT_FOUND, "Invalid Bitcoin address");
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid Bitcoin address");
 
     string strAccount;
     if (params.size() > 1)
@@ -299,7 +299,7 @@ UniValue getaccount(const UniValue& params, bool fHelp)
 
     CBitcoinAddress address(params[0].get_str());
     if (!address.IsValid())
-        throw JSONRPCError(RPC_NOT_FOUND, "Invalid Bitcoin address");
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid Bitcoin address");
 
     string strAccount;
     map<CTxDestination, CAddressBookData>::iterator mi = pwalletMain->mapAddressBook.find(address.Get());
@@ -410,7 +410,7 @@ UniValue sendtoaddress(const UniValue& params, bool fHelp)
 
     CBitcoinAddress address(params[0].get_str());
     if (!address.IsValid())
-        throw JSONRPCError(RPC_NOT_FOUND, "Invalid Bitcoin address");
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid Bitcoin address");
 
     // Amount
     CAmount nAmount = AmountFromValue(params[1]);
@@ -538,7 +538,7 @@ UniValue signmessage(const UniValue& params, bool fHelp)
 
     vector<unsigned char> vchSig;
     if (!key.SignCompact(ss.GetHash(), vchSig))
-        throw JSONRPCError(RPC_NOT_FOUND, "Sign failed");
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Sign failed");
 
     return EncodeBase64(&vchSig[0], vchSig.size());
 }
@@ -573,7 +573,7 @@ UniValue getreceivedbyaddress(const UniValue& params, bool fHelp)
     // Bitcoin address
     CBitcoinAddress address = CBitcoinAddress(params[0].get_str());
     if (!address.IsValid())
-        throw JSONRPCError(RPC_NOT_FOUND, "Invalid Bitcoin address");
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid Bitcoin address");
     CScript scriptPubKey = GetScriptForDestination(address.Get());
     if (!IsMine(*pwalletMain,scriptPubKey))
         return (double)0.0;
@@ -890,7 +890,7 @@ UniValue sendfrom(const UniValue& params, bool fHelp)
     string strAccount = AccountFromValue(params[0]);
     CBitcoinAddress address(params[1].get_str());
     if (!address.IsValid())
-        throw JSONRPCError(RPC_NOT_FOUND, "Invalid Bitcoin address");
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid Bitcoin address");
     CAmount nAmount = AmountFromValue(params[2]);
     if (nAmount <= 0)
         throw JSONRPCError(RPC_TYPE_ERROR, "Invalid amount for send");
@@ -985,7 +985,7 @@ UniValue sendmany(const UniValue& params, bool fHelp)
     {
         CBitcoinAddress address(name_);
         if (!address.IsValid())
-            throw JSONRPCError(RPC_NOT_FOUND, string("Invalid Bitcoin address: ")+name_);
+            throw JSONRPCError(RPC_INVALID_PARAMETER, string("Invalid Bitcoin address: ")+name_);
 
         if (setAddress.count(address))
             throw JSONRPCError(RPC_INVALID_PARAMETER, string("Invalid parameter, duplicated address: ")+name_);
@@ -2307,7 +2307,7 @@ UniValue listunspent(const UniValue& params, bool fHelp)
             const UniValue& input = inputs[idx];
             CBitcoinAddress address(input.get_str());
             if (!address.IsValid())
-                throw JSONRPCError(RPC_NOT_FOUND, string("Invalid Bitcoin address: ")+input.get_str());
+                throw JSONRPCError(RPC_INVALID_PARAMETER, string("Invalid Bitcoin address: ")+input.get_str());
             if (setAddress.count(address))
                 throw JSONRPCError(RPC_INVALID_PARAMETER, string("Invalid parameter, duplicated address: ")+input.get_str());
            setAddress.insert(address);


### PR DESCRIPTION
Based on IRC talks, renamed RPC_INVALID_ADDRESS_OR_KEY to RPC_NOT_FOUND and made getblockhash return NOT_FOUND when block is above the current height.

Some chat excerpts, which started earlier on the fact the error code changed in 10.x for out of range getblockhash requests:

```
<wumpus> RPC_INVALID_PARAMETER           = -8,  //! Invalid, missing or duplicate parameter
<wumpus> that's a strange error code to return for a non-existing block
* splix has quit (Remote host closed the connection)
<dermoth> https://github.com/bitcoin/bitcoin.git
<wumpus> are you providing a valid hash?
<dermoth> oops
<dermoth> 2ffdf21ce39fc3133fc
<dermoth> that's the commit
* Aido (~Aido@178.167.130.193.threembb.ie) has joined #bitcoin-dev
<dermoth> parameter is a block number, app used to rely on error -1 to know when it reached the most recent block
<wumpus> -1 is the general error, -8 is a more specialized one
<dermoth> I see
* hsmiths has quit (Quit: END OF LINE)
<gmaxwell> error: {"code":-8,"message":"Block height out of range"}
<wumpus> I think a NOT_FOUND code would be more appropriate than invalid parameter (which hints at a parse error),but don't be afraid I won't change it again...
<dermoth> agreed
<wumpus> at least the message is clear
```

and later on...

```
<dermoth> closest error IMHO, in existing code, is RPC_INVALID_ADDRESS_OR_KEY
<wumpus> indeed. We've been using that as a NOT_FOUND.
<wumpus> maybe renaming it would be an idea
<wumpus> as said, those error names are back-projected by me, the original codebase used bare numbers without any explanation
<dermoth> would you keep the current one as an alias? I can submit a pr
<wumpus> yes, good idea
<dermoth> if (nHeight < 0... should be NOT FOUND too?
<dermoth> I see where the invalid param comes from, maybe split it up then
<wumpus> bleh.
<wumpus> see why this was never addressed? you lift it in one place, and notice the whole fabric is coming apart :-)
<wumpus> I mean I'm sure RPC_INVALID_ADDRESS_OR_KEY is also used in many cases where it really means RPC_INVALID_PARAMETER
<wumpus> before you know it, you're breaking the entire API
* abossard (~andre@46.140.123.2) has joined #bitcoin-dev
<wumpus> (and maybe that's for the best, but then it will be a fully fledged RPC return values redesign, and you would have accomplished exactly what you were coming here to complain about in the first place - hehe)
<wumpus> but maybe there's a middle way, I don't know, thanks for looking into it.
```

The change has been tested with the backward-compatible alias commented out:

```
<dermoth> wumpus, tested ok
<dermoth> $ ~/bitcoin/bitcoin/bin/bitcoin-cli getblockhash -1
<dermoth> error: {"code":-8,"message":"Negative block height"}
<wumpus> great, time to submit a PR then
<dermoth> $ ~/bitcoin/bitcoin/bin/bitcoin-cli getblockhash 361428
<dermoth> error: {"code":-5,"message":"Block height out of range"}
<dermoth> $ ~/bitcoin/bitcoin/bin/bitcoin-cli getblockhash 361424
<dermoth> 000000000000000004fd86600f6a12e5186ec18f11d7502afba3b7f7e00cae1a
<dermoth> used the 10.2 client though, but was runnign the 0.11-blarhs-dirty one (dirty bc of the commented out alias)
<dermoth> v0.11.99.0-fa19502-dirty (64-bit)
```
