### PR TITLE
gitian: add a gitian-win-signer descriptor

### DIFF
--- a/contrib/gitian-descriptors/gitian-win-signer.yml
+++ b/contrib/gitian-descriptors/gitian-win-signer.yml
@@ -1,0 +1,34 @@
+---
+name: "bitcoin-win-signer"
+suites:
+- "precise"
+architectures:
+- "amd64"
+packages:
+- "libssl-dev"
+- "autoconf"
+reference_datetime: "2015-06-01 00:00:00"
+remotes:
+- "url": "https://github.com/bitcoin/bitcoin-detached-sigs.git"
+  "dir": "signature"
+files:
+- "osslsigncode-1.7.1.tar.gz"
+- "osslsigncode-Backports-to-1.7.1.patch"
+- "bitcoin-win32-setup.exe"
+- "bitcoin-win64-setup.exe"
+script: |
+  BUILD_DIR=`pwd`
+  SIGDIR=${BUILD_DIR}/signature/win
+
+  echo "f9a8cdb38b9c309326764ebc937cba1523a3a751a7ab05df3ecc99d18ae466c9  osslsigncode-1.7.1.tar.gz" | sha256sum -c
+  echo "a8c4e9cafba922f89de0df1f2152e7be286aba73f78505169bc351a7938dd911  osslsigncode-Backports-to-1.7.1.patch" | sha256sum -c
+
+  tar xf osslsigncode-1.7.1.tar.gz
+  cd osslsigncode-1.7.1
+  patch -p1 < ${BUILD_DIR}/osslsigncode-Backports-to-1.7.1.patch
+
+  ./configure --without-gsf --without-curl --disable-dependency-tracking
+  make
+
+  ./osslsigncode attach-signature -in ${BUILD_DIR}/bitcoin-win32-setup.exe -out ${OUTDIR}/bitcoin-win32-setup-signed.exe -sigin ${SIGDIR}/bitcoin-win32-setup.exe.pem
+  ./osslsigncode attach-signature -in ${BUILD_DIR}/bitcoin-win64-setup.exe -out ${OUTDIR}/bitcoin-win64-setup-signed.exe -sigin ${SIGDIR}/bitcoin-win64-setup.exe.pem

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -41,6 +41,8 @@ Release Process
 ###fetch and build inputs: (first time, or when dependency versions change)
  
 	mkdir -p inputs
+	wget -P inputs https://bitcoincore.org/cfields/osslsigncode-Backports-to-1.7.1.patch
+	wget -P inputs http://downloads.sourceforge.net/project/osslsigncode/osslsigncode/osslsigncode-1.7.1.tar.gz
 
  Register and download the Apple SDK: (see OSX Readme for details)
  
@@ -65,7 +67,9 @@ Release Process
 	mv build/out/bitcoin-*.tar.gz build/out/src/bitcoin-*.tar.gz ../
 	./bin/gbuild --commit bitcoin=v${VERSION} ../bitcoin/contrib/gitian-descriptors/gitian-win.yml
 	./bin/gsign --signer $SIGNER --release ${VERSION}-win --destination ../gitian.sigs/ ../bitcoin/contrib/gitian-descriptors/gitian-win.yml
-	mv build/out/bitcoin-*.zip build/out/bitcoin-*.exe ../
+	mv build/out/bitcoin-*.zip ../
+	mv build/out/bitcoin-*-win64-setup.exe inputs/bitcoin-win64-setup.exe
+	mv build/out/bitcoin-*-win32-setup.exe inputs/bitcoin-win32-setup.exe
 	./bin/gbuild --commit bitcoin=v${VERSION} ../bitcoin/contrib/gitian-descriptors/gitian-osx.yml
 	./bin/gsign --signer $SIGNER --release ${VERSION}-osx-unsigned --destination ../gitian.sigs/ ../bitcoin/contrib/gitian-descriptors/gitian-osx.yml
 	mv build/out/bitcoin-*-unsigned.tar.gz inputs/bitcoin-osx-unsigned.tar.gz
@@ -75,7 +79,7 @@ Release Process
 
   1. source tarball (bitcoin-${VERSION}.tar.gz)
   2. linux 32-bit and 64-bit binaries dist tarballs (bitcoin-${VERSION}-linux[32|64].tar.gz)
-  3. windows 32-bit and 64-bit installers and dist zips (bitcoin-${VERSION}-win[32|64]-setup.exe, bitcoin-${VERSION}-win[32|64].zip)
+  3. windows 32-bit and 64-bit unsigned installers and dist zips (bitcoin-${VERSION}-win[32|64]-setup.exe, bitcoin-${VERSION}-win[32|64].zip)
   4. OSX unsigned installer (bitcoin-${VERSION}-osx-unsigned.dmg)
   5. Gitian signatures (in gitian.sigs/${VERSION}-<linux|win|osx-unsigned>/(your gitian key)/
 
@@ -91,9 +95,9 @@ Commit your signature to gitian.sigs:
 	git push  # Assuming you can push to the gitian.sigs tree
 	popd
 
-  Wait for OSX detached signature:
-	Once the OSX build has 3 matching signatures, it will be signed with the Apple App-Store key.
-	A detached signature will then be committed to the bitcoin-detached-sigs repository, which can be combined with the unsigned app to create a signed binary.
+  Wait for Windows/OSX detached signatures:
+	Once the Windows/OSX builds each have 3 matching signatures, they will be signed with their respective release keys.
+	Detached signatures will then be committed to the bitcoin-detached-sigs repository, which can be combined with the unsigned apps to create signed binaries.
 
   Create the signed OSX binary:
 
@@ -103,10 +107,20 @@ Commit your signature to gitian.sigs:
 	mv build/out/bitcoin-osx-signed.dmg ../bitcoin-${VERSION}-osx.dmg
 	popd
 
-Commit your signature for the signed OSX binary:
+  Create the signed Windows binaries:
+
+	pushd ./gitian-builder
+	./bin/gbuild -i --commit signature=v${VERSION} ../bitcoin/contrib/gitian-descriptors/gitian-win-signer.yml
+	./bin/gsign --signer $SIGNER --release ${VERSION}-win-signed --destination ../gitian.sigs/ ../bitcoin/contrib/gitian-descriptors/gitian-win-signer.yml
+	mv build/out/bitcoin-win64-setup-signed.exe ../bitcoin-${VERSION}-win64-setup.exe
+	mv build/out/bitcoin-win32-setup-signed.exe ../bitcoin-${VERSION}-win32-setup.exe
+	popd
+
+Commit your signature for the signed OSX/Windows binaries:
 
 	pushd gitian.sigs
 	git add ${VERSION}-osx-signed/${SIGNER}
+	git add ${VERSION}-win-signed/${SIGNER}
 	git commit -a
 	git push  # Assuming you can push to the gitian.sigs tree
 	popd
@@ -114,12 +128,6 @@ Commit your signature for the signed OSX binary:
 -------------------------------------------------------------------------
 
 ### After 3 or more people have gitian-built and their results match:
-
-- Perform code-signing.
-
-    - Code-sign Windows -setup.exe (in a Windows virtual machine using signtool)
-
-  Note: only Gavin has the code-signing keys currently.
 
 - Create `SHA256SUMS.asc` for the builds, and GPG-sign it:
 ```bash


### PR DESCRIPTION
This makes Windows signing match the current OSX signing process.

[osslsigncode](https://sourceforge.net/projects/osslsigncode/) has been patched to detach and re-attach Windows signatures. The changes can be seen here: https://github.com/theuni/osslsigncode/commits/attach-signature

There's a pull-request open upstream for the changes:
https://sourceforge.net/p/osslsigncode/osslsigncode/merge-requests/3/

This work has been back-ported to the stable 1.7.1 release of osslsigncode, so that a smaller patch can be reviewed. Hopefully we'll get the changes merged upstream for the next release so that we can drop the patches here.

For reference, I've pushed the detached sigs that would've been used for 0.11.0rc2 here: https://github.com/bitcoin/bitcoin-detached-sigs/commit/329d2e8f0af8d71300c75c007fe4f384b4df12b1

For a test, I created a phony tag in my local bitcoin-detached-sigs repository and re-attached the 0.11.0rc2 .exe's from the detached sigs here: https://github.com/bitcoin/bitcoin-detached-sigs/commit/329d2e8f0af8d71300c75c007fe4f384b4df12b1. No surprise, they matched our release binaries.

If desired, this should be safe to use for 0.11.0-rc3.
