### PR TITLE
Prevent peer flooding inv request queue (redux)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4049,7 +4049,8 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
             const CInv &inv = vInv[nInv];
 
             boost::this_thread::interruption_point();
-            pfrom->AddInventoryKnown(inv);
+            if (!pfrom->AddInventoryKnown(inv))
+                continue;
 
             bool fAlreadyHave = AlreadyHave(inv);
             LogPrint("net", "got inv: %s  %s peer=%d\n", inv.ToString(), fAlreadyHave ? "have" : "new", pfrom->id);

--- a/src/net.h
+++ b/src/net.h
@@ -469,11 +469,11 @@ public:
     }
 
 
-    void AddInventoryKnown(const CInv& inv)
+    bool AddInventoryKnown(const CInv& inv)
     {
         {
             LOCK(cs_inventory);
-            setInventoryKnown.insert(inv);
+            return setInventoryKnown.insert(inv).second;
         }
     }
 


### PR DESCRIPTION
Removes a network attacker node's ability to indefinitely blind its peers to a block or transaction new to them, such as a double-spend generated by attacker.  The possible blinding interval is reduced to the getdata timeout (currently 2 minutes).

This vulnerability is discussed in [Tampering with the Delivery of Blocks and Transactions in Bitcoin [1]](http://eprint.iacr.org/2015/578) and was described earlier in [Discovering Bitcoin’s Public Topology and Influential Nodes [2]](http://cs.umd.edu/projects/coinscope/coinscope.pdf).

This is a lighter implementation of #4547.  Attention is paid to the result of the insert into the existing collection setInventoryKnown, rather than introducing a new collection.
#4547 was closed to focus on a wider solution that has been delayed.
