### PR TITLE
build: Remove -DBOOST_SPIRIT_THREADSAFE

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -162,7 +162,7 @@ fi
 if test "x$CXXFLAGS_overridden" = "xno"; then
   CXXFLAGS="$CXXFLAGS -Wall -Wextra -Wformat -Wformat-security -Wno-unused-parameter"
 fi
-CPPFLAGS="$CPPFLAGS -DBOOST_SPIRIT_THREADSAFE -DHAVE_BUILD_INFO -D__STDC_FORMAT_MACROS"
+CPPFLAGS="$CPPFLAGS -DHAVE_BUILD_INFO -D__STDC_FORMAT_MACROS"
 
 AC_ARG_WITH([utils],
   [AS_HELP_STRING([--with-utils],

--- a/src/rpcprotocol.cpp
+++ b/src/rpcprotocol.cpp
@@ -251,7 +251,6 @@ int ReadHTTPMessage(std::basic_istream<char>& stream, map<string,
  * 
  * 1.0 spec: http://json-rpc.org/wiki/specification
  * 1.2 spec: http://jsonrpc.org/historical/json-rpc-over-http.html
- * http://www.codeproject.com/KB/recipes/JSON_Spirit.aspx
  */
 
 string JSONRPCRequest(const string& strMethod, const UniValue& params, const UniValue& id)


### PR DESCRIPTION
Now that boost spirit is no longer used, `-DBOOST_SPIRIT_THREADSAFE` doesn't need to be passed to the compiler anymore.
