### PR TITLE
doc: update mailing list address

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ development team members simply pulls it.
 
 If it is a *more complicated or potentially controversial* change, then the patch
 submitter will be asked to start a discussion (if they haven't already) on the
-[mailing list](http://sourceforge.net/mailarchive/forum.php?forum_name=bitcoin-development).
+[mailing list](https://lists.linuxfoundation.org/mailman/listinfo/bitcoin-dev)
 
 The patch will be accepted if there is broad consensus that it is a good thing.
 Developers should expect to rework and resubmit patches if the code doesn't

--- a/contrib/debian/copyright
+++ b/contrib/debian/copyright
@@ -2,8 +2,7 @@ Format: http://svn.debian.org/wsvn/dep/web/deps/dep5.mdwn?rev=174
 Upstream-Name: Bitcoin
 Upstream-Contact: Satoshi Nakamoto <satoshin@gmx.com>
  irc://#bitcoin@freenode.net
-Source: http://sourceforge.net/projects/bitcoin/files/
- https://github.com/bitcoin/bitcoin
+Source: https://github.com/bitcoin/bitcoin
 
 Files: *
 Copyright: 2009-2012, Bitcoin Core Developers

--- a/contrib/gitian-downloader/linux-download-config
+++ b/contrib/gitian-downloader/linux-download-config
@@ -3,7 +3,7 @@ name: bitcoin
 urls:
 - http://bitcoin.org/bitcoin-latest-linux-gitian.zip
 rss:
-- url: http://sourceforge.net/api/file/index/project-id/244765/mtime/desc/limit/100/rss
+- url: 
   xpath: //item/link/text()
   pattern: bitcoin-\d+.\d+.\d+-linux-gitian.zip
 signers:

--- a/contrib/gitian-downloader/win32-download-config
+++ b/contrib/gitian-downloader/win32-download-config
@@ -3,7 +3,7 @@ name: bitcoin
 urls:
 - http://bitcoin.org/bitcoin-latest-win32-gitian.zip
 rss:
-- url: http://sourceforge.net/api/file/index/project-id/244765/mtime/desc/limit/100/rss
+- url: 
   xpath: //item/link/text()
   pattern: bitcoin-\d+.\d+.\d+-win32-gitian.zip
 signers:

--- a/doc/dnsseed-policy.md
+++ b/doc/dnsseed-policy.md
@@ -43,7 +43,8 @@ related to the DNS seed operation.
 
 If these expectations cannot be satisfied the operator should
 discontinue providing services and contact the active Bitcoin
-Core development team as well as posting on bitcoin-development.
+Core development team as well as posting on
+[bitcoin-dev](https://lists.linuxfoundation.org/mailman/listinfo/bitcoin-dev).
 
 Behavior outside of these expectations may be reasonable in some
 situations but should be discussed in public in advance.


### PR DESCRIPTION
Move from sourceforge to linux foundation.

Also get rid of some other stale mentions of sourceforge.

There is one mention left: https://github.com/bitcoin/bitcoin/blob/master/src/test/checkblock_tests.cpp#L48 . We should re-host this file on elsewhere, but I don't have it.
