### PR TITLE
Remove base58 hard-coding

### DIFF
--- a/src/base58.cpp
+++ b/src/base58.cpp
@@ -93,7 +93,7 @@ std::string EncodeBase58(const unsigned char* pbegin, const unsigned char* pend)
     // Translate the result into a string.
     std::string str;
     str.reserve(zeroes + (b58.end() - it));
-    str.assign(zeroes, '1');
+    str.assign(zeroes, pszBase58[0]);
     while (it != b58.end())
         str += pszBase58[*(it++)];
     return str;


### PR DESCRIPTION
Not a big change, just more efficient. It was hard coded, and though it works either way, it's better than it being hard coded.
