### PR TITLE
Skip tx validation to make initial sync faster

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -294,6 +294,8 @@ std::string HelpMessage(HelpMessageMode mode)
 #if !defined(WIN32)
     strUsage += HelpMessageOpt("-sysperms", _("Create new files with system default permissions, instead of umask 077 (only effective with disabled wallet functionality)"));
 #endif
+    strUsage += HelpMessageOpt("-skiptxcheck", _("Do not verify each transaction. This makes initial synchronization faster on a poor machine. "
+                                                 "Note that this makes your node complete reliant to miners. Block hash and merkle tree are still verified."));
     strUsage += HelpMessageOpt("-txindex", strprintf(_("Maintain a full transaction index, used by the getrawtransaction rpc call (default: %u)"), 0));
 
     strUsage += HelpMessageGroup(_("Connection options:"));
@@ -779,6 +781,8 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
         nScriptCheckThreads = 0;
     else if (nScriptCheckThreads > MAX_SCRIPTCHECK_THREADS)
         nScriptCheckThreads = MAX_SCRIPTCHECK_THREADS;
+
+    fSkipTxValidation = GetBoolArg("-skiptxcheck", false);
 
     fServer = GetBoolArg("-server", false);
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1235,6 +1235,11 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
             PruneAndFlush();
         }
     }
+    // if prune mode, unset NODE_NETWORK and prune block files
+    if (fSkipTxValidation) {
+        LogPrintf("Unsetting NODE_NETWORK on skiptxcheck mode\n");
+        nLocalServices &= ~NODE_NETWORK;
+    }
 
     // ********************************************************* Step 8: load wallet
 #ifdef ENABLE_WALLET

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1235,7 +1235,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
             PruneAndFlush();
         }
     }
-    // if prune mode, unset NODE_NETWORK and prune block files
+    // if skiptxcheck mode, unset NODE_NETWORK
     if (fSkipTxValidation) {
         LogPrintf("Unsetting NODE_NETWORK on skiptxcheck mode\n");
         nLocalServices &= ~NODE_NETWORK;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2126,13 +2126,12 @@ void static UpdateTip(CBlockIndex *pindexNew) {
             strMiscWarning = _("Warning: This version is obsolete; upgrade required!");
             CAlert::Notify(strMiscWarning, true);
             fWarned = true;
-        }	
+        }
     }
     if (!isInitialBlockDownload && fSkipTxValidation) {
         LogPrintf("skiptxtcheck disabled because blockchain is synced");
         fSkipTxValidation = false;
     }
-
 }
 
 /** Disconnect chainActive's tip. */
@@ -2695,7 +2694,6 @@ bool CheckBlock(const CBlock& block, CValidationState& state, bool fCheckPOW, bo
     if (!CheckBlockHeader(block, state, fCheckPOW))
         return false;
 
-
     // Check the merkle root.
     if (fCheckMerkleRoot) {
         bool mutated;
@@ -2712,7 +2710,6 @@ bool CheckBlock(const CBlock& block, CValidationState& state, bool fCheckPOW, bo
                              REJECT_INVALID, "bad-txns-duplicate", true);
     }
 
-    
     // All potential-corruption validation must be done before we do any
     // transaction validation, as otherwise we may mark the header as invalid
     // because we receive the wrong transactions for it.

--- a/src/main.h
+++ b/src/main.h
@@ -133,6 +133,9 @@ extern uint64_t nPruneTarget;
 /** Block files containing a block-height within MIN_BLOCKS_TO_KEEP of chainActive.Tip() will not be pruned. */
 static const signed int MIN_BLOCKS_TO_KEEP = 288;
 
+/** set to true to skip tx validation for fast bootstrap*/
+extern bool fSkipTxValidation;
+
 // Require that user allocate at least 550MB for block & undo files (blk???.dat and rev???.dat)
 // At 1MB per block, 288 blocks = 288MB.
 // Add 15% for Undo data = 331MB


### PR DESCRIPTION
This modification solves my problem with bootstrapping nodes on small and slow virtual servers. It introduces a new command line flag -skiptxcheck that will significantly increase speed of initial synchronization in exchange to rely on trust provided by the miners. Because we can believe that every block in deep history of the Bitcoin is valid and contains valid transactions, it is not necesery to verify them again.

The flag doesn't affect verifying of block header - so block hash and merkle tree are still checked and they must be valid in the chain.

Is there any security risk? I don't think so, maybe little. Standard SPV client always rely on neighbour node. It just verifies the headers, never transactions again.

This feature automatically disables itself when synchronization is done (not tested yet). Also NODE_NETWORK is disabled.
