### PR TITLE
UniValue: don't escape solidus, keep espacing of reverse solidus

### DIFF
--- a/src/test/univalue_tests.cpp
+++ b/src/test/univalue_tests.cpp
@@ -286,7 +286,7 @@ BOOST_AUTO_TEST_CASE(univalue_object)
 }
 
 static const char *json1 =
-"[1.10000000,{\"key1\":\"str\\u0000\",\"key2\":800,\"key3\":{\"name\":\"martian\"}}]";
+"[1.10000000,{\"key1\":\"str\\u0000\",\"key2\":800,\"key3\":{\"name\":\"martian http://test.com\"}}]";
 
 BOOST_AUTO_TEST_CASE(univalue_readwrite)
 {

--- a/src/univalue/gen.cpp
+++ b/src/univalue/gen.cpp
@@ -22,7 +22,6 @@ static void initJsonEscape()
 {
     escapes[(int)'"'] = "\\\"";
     escapes[(int)'\\'] = "\\\\";
-    escapes[(int)'/'] = "\\/";
     escapes[(int)'\b'] = "\\b";
     escapes[(int)'\f'] = "\\f";
     escapes[(int)'\n'] = "\\n";

--- a/src/univalue/univalue_escapes.h
+++ b/src/univalue/univalue_escapes.h
@@ -49,7 +49,7 @@ static const char *escapes[256] = {
 	NULL,
 	NULL,
 	NULL,
-	"\\/",
+	NULL,
 	NULL,
 	NULL,
 	NULL,


### PR DESCRIPTION
After the JSON RFC, solidus ('/') must not be escaped (https://www.ietf.org/rfc/rfc4627.txt see paragraph 2.5)

JSON spirit did not escape a solidus.

Escaping the solidus character made things look bad in bitcoin-cli (or possibly over other RPC clients).

Example:
Before this PR:
`http:\/\/127.0.0.1:8332`

After this PR:
`http://127.0.0.1:8332`
