### PR TITLE
CHECKLOCKTIMEVERIFY (BIP65) IsSuperMajority() soft-fork

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -69,6 +69,8 @@ testScripts = [
     'p2p-fullblocktest.py',
 ]
 testScriptsExt = [
+    'bip65-cltv.py',
+    'bip65-cltv-p2p.py',
     'bipdersig-p2p.py',
     'bipdersig.py',
     'getblocktemplate_longpoll.py',

--- a/qa/rpc-tests/bip65-cltv-p2p.py
+++ b/qa/rpc-tests/bip65-cltv-p2p.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python2
+#
+# Distributed under the MIT/X11 software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#
+
+from test_framework.test_framework import ComparisonTestFramework
+from test_framework.util import *
+from test_framework.mininode import CTransaction, NetworkThread
+from test_framework.blocktools import create_coinbase, create_block
+from test_framework.comptool import TestInstance, TestManager
+from test_framework.script import CScript, OP_1NEGATE, OP_NOP2, OP_DROP
+from binascii import hexlify, unhexlify
+import cStringIO
+import time
+
+def cltv_invalidate(tx):
+    '''Modify the signature in vin 0 of the tx to fail CLTV
+
+    Prepends -1 CLTV DROP in the scriptSig itself.
+    '''
+    tx.vin[0].scriptSig = CScript([OP_1NEGATE, OP_NOP2, OP_DROP] +
+                                  list(CScript(tx.vin[0].scriptSig)))
+
+'''
+This test is meant to exercise BIP65 (CHECKLOCKTIMEVERIFY)
+Connect to a single node.
+Mine 2 (version 3) blocks (save the coinbases for later).
+Generate 98 more version 3 blocks, verify the node accepts.
+Mine 749 version 4 blocks, verify the node accepts.
+Check that the new CLTV rules are not enforced on the 750th version 4 block.
+Check that the new CLTV rules are enforced on the 751st version 4 block.
+Mine 199 new version blocks.
+Mine 1 old-version block.
+Mine 1 new version block.
+Mine 1 old version block, see that the node rejects.
+'''
+
+class BIP65Test(ComparisonTestFramework):
+
+    def __init__(self):
+        self.num_nodes = 1
+
+    def setup_network(self):
+        # Must set the blockversion for this test
+        self.nodes = start_nodes(1, self.options.tmpdir,
+                                 extra_args=[['-debug', '-whitelist=127.0.0.1', '-blockversion=3']],
+                                 binary=[self.options.testbinary])
+
+    def run_test(self):
+        test = TestManager(self, self.options.tmpdir)
+        test.add_all_connections(self.nodes)
+        NetworkThread().start() # Start up network handling in another thread
+        test.run()
+
+    def create_transaction(self, node, coinbase, to_address, amount):
+        from_txid = node.getblock(coinbase)['tx'][0]
+        inputs = [{ "txid" : from_txid, "vout" : 0}]
+        outputs = { to_address : amount }
+        rawtx = node.createrawtransaction(inputs, outputs)
+        signresult = node.signrawtransaction(rawtx)
+        tx = CTransaction()
+        f = cStringIO.StringIO(unhexlify(signresult['hex']))
+        tx.deserialize(f)
+        return tx
+
+    def get_tests(self):
+
+        self.coinbase_blocks = self.nodes[0].generate(2)
+        self.tip = int ("0x" + self.nodes[0].getbestblockhash() + "L", 0)
+        self.nodeaddress = self.nodes[0].getnewaddress()
+        self.last_block_time = time.time()
+
+        ''' 98 more version 3 blocks '''
+        test_blocks = []
+        for i in xrange(98):
+            block = create_block(self.tip, create_coinbase(2), self.last_block_time + 1)
+            block.nVersion = 3
+            block.rehash()
+            block.solve()
+            test_blocks.append([block, True])
+            self.last_block_time += 1
+            self.tip = block.sha256
+        yield TestInstance(test_blocks, sync_every_block=False)
+
+        ''' Mine 749 version 4 blocks '''
+        test_blocks = []
+        for i in xrange(749):
+            block = create_block(self.tip, create_coinbase(2), self.last_block_time + 1)
+            block.nVersion = 4
+            block.rehash()
+            block.solve()
+            test_blocks.append([block, True])
+            self.last_block_time += 1
+            self.tip = block.sha256
+        yield TestInstance(test_blocks, sync_every_block=False)
+
+        '''
+        Check that the new CLTV rules are not enforced in the 750th
+        version 3 block.
+        '''
+        spendtx = self.create_transaction(self.nodes[0],
+                self.coinbase_blocks[0], self.nodeaddress, 1.0)
+        cltv_invalidate(spendtx)
+        spendtx.rehash()
+
+        block = create_block(self.tip, create_coinbase(2), self.last_block_time + 1)
+        block.nVersion = 4
+        block.vtx.append(spendtx)
+        block.hashMerkleRoot = block.calc_merkle_root()
+        block.rehash()
+        block.solve()
+
+        self.last_block_time += 1
+        self.tip = block.sha256
+        yield TestInstance([[block, True]])
+
+        '''
+        Check that the new CLTV rules are enforced in the 751st version 4
+        block.
+        '''
+        spendtx = self.create_transaction(self.nodes[0],
+                self.coinbase_blocks[1], self.nodeaddress, 1.0)
+        cltv_invalidate(spendtx)
+        spendtx.rehash()
+
+        block = create_block(self.tip, create_coinbase(1), self.last_block_time + 1)
+        block.nVersion = 4
+        block.vtx.append(spendtx)
+        block.hashMerkleRoot = block.calc_merkle_root()
+        block.rehash()
+        block.solve()
+        self.last_block_time += 1
+        yield TestInstance([[block, False]])
+
+        ''' Mine 199 new version blocks on last valid tip '''
+        test_blocks = []
+        for i in xrange(199):
+            block = create_block(self.tip, create_coinbase(1), self.last_block_time + 1)
+            block.nVersion = 4
+            block.rehash()
+            block.solve()
+            test_blocks.append([block, True])
+            self.last_block_time += 1
+            self.tip = block.sha256
+        yield TestInstance(test_blocks, sync_every_block=False)
+
+        ''' Mine 1 old version block '''
+        block = create_block(self.tip, create_coinbase(1), self.last_block_time + 1)
+        block.nVersion = 3
+        block.rehash()
+        block.solve()
+        self.last_block_time += 1
+        self.tip = block.sha256
+        yield TestInstance([[block, True]])
+
+        ''' Mine 1 new version block '''
+        block = create_block(self.tip, create_coinbase(1), self.last_block_time + 1)
+        block.nVersion = 4
+        block.rehash()
+        block.solve()
+        self.last_block_time += 1
+        self.tip = block.sha256
+        yield TestInstance([[block, True]])
+
+        ''' Mine 1 old version block, should be invalid '''
+        block = create_block(self.tip, create_coinbase(1), self.last_block_time + 1)
+        block.nVersion = 3
+        block.rehash()
+        block.solve()
+        self.last_block_time += 1
+        yield TestInstance([[block, False]])
+
+if __name__ == '__main__':
+    BIP65Test().main()

--- a/qa/rpc-tests/bip65-cltv.py
+++ b/qa/rpc-tests/bip65-cltv.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python2
+# Copyright (c) 2015 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#
+# Test the CHECKLOCKTIMEVERIFY (BIP65) soft-fork logic
+#
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+import os
+import shutil
+
+class BIP65Test(BitcoinTestFramework):
+
+    def setup_network(self):
+        self.nodes = []
+        self.nodes.append(start_node(0, self.options.tmpdir, []))
+        self.nodes.append(start_node(1, self.options.tmpdir, ["-blockversion=3"]))
+        self.nodes.append(start_node(2, self.options.tmpdir, ["-blockversion=4"]))
+        connect_nodes(self.nodes[1], 0)
+        connect_nodes(self.nodes[2], 0)
+        self.is_network_split = False
+        self.sync_all()
+
+    def run_test(self):
+        cnt = self.nodes[0].getblockcount()
+
+        # Mine some old-version blocks
+        self.nodes[1].generate(100)
+        self.sync_all()
+        if (self.nodes[0].getblockcount() != cnt + 100):
+            raise AssertionError("Failed to mine 100 version=3 blocks")
+
+        # Mine 750 new-version blocks
+        for i in xrange(15):
+            self.nodes[2].generate(50)
+        self.sync_all()
+        if (self.nodes[0].getblockcount() != cnt + 850):
+            raise AssertionError("Failed to mine 750 version=4 blocks")
+
+        # TODO: check that new CHECKLOCKTIMEVERIFY rules are not enforced
+
+        # Mine 1 new-version block
+        self.nodes[2].generate(1)
+        self.sync_all()
+        if (self.nodes[0].getblockcount() != cnt + 851):
+            raise AssertionFailure("Failed to mine a version=4 blocks")
+
+        # TODO: check that new CHECKLOCKTIMEVERIFY rules are enforced
+
+        # Mine 198 new-version blocks
+        for i in xrange(2):
+            self.nodes[2].generate(99)
+        self.sync_all()
+        if (self.nodes[0].getblockcount() != cnt + 1049):
+            raise AssertionError("Failed to mine 198 version=4 blocks")
+
+        # Mine 1 old-version block
+        self.nodes[1].generate(1)
+        self.sync_all()
+        if (self.nodes[0].getblockcount() != cnt + 1050):
+            raise AssertionError("Failed to mine a version=3 block after 949 version=4 blocks")
+
+        # Mine 1 new-version blocks
+        self.nodes[2].generate(1)
+        self.sync_all()
+        if (self.nodes[0].getblockcount() != cnt + 1051):
+            raise AssertionError("Failed to mine a version=4 block")
+
+        # Mine 1 old-version blocks
+        try:
+            self.nodes[1].generate(1)
+            raise AssertionError("Succeeded to mine a version=3 block after 950 version=4 blocks")
+        except JSONRPCException:
+            pass
+        self.sync_all()
+        if (self.nodes[0].getblockcount() != cnt + 1051):
+            raise AssertionError("Accepted a version=3 block after 950 version=4 blocks")
+
+        # Mine 1 new-version blocks
+        self.nodes[2].generate(1)
+        self.sync_all()
+        if (self.nodes[0].getblockcount() != cnt + 1052):
+            raise AssertionError("Failed to mine a version=4 block")
+
+if __name__ == '__main__':
+    BIP65Test().main()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1740,9 +1740,16 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
 
     unsigned int flags = fStrictPayToScriptHash ? SCRIPT_VERIFY_P2SH : SCRIPT_VERIFY_NONE;
 
-    // Start enforcing the DERSIG (BIP66) rules, for block.nVersion=3 blocks, when 75% of the network has upgraded:
+    // Start enforcing the DERSIG (BIP66) rules, for block.nVersion=3 blocks,
+    // when 75% of the network has upgraded:
     if (block.nVersion >= 3 && IsSuperMajority(3, pindex->pprev, chainparams.GetConsensus().nMajorityEnforceBlockUpgrade, chainparams.GetConsensus())) {
         flags |= SCRIPT_VERIFY_DERSIG;
+    }
+
+    // Start enforcing CHECKLOCKTIMEVERIFY, (BIP65) for block.nVersion=4
+    // blocks, when 75% of the network has upgraded:
+    if (block.nVersion >= 4 && IsSuperMajority(4, pindex->pprev, chainparams.GetConsensus().nMajorityEnforceBlockUpgrade, chainparams.GetConsensus())) {
+        flags |= SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY;
     }
 
     CBlockUndo blockundo;
@@ -2682,6 +2689,11 @@ bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationState& sta
     // Reject block.nVersion=2 blocks when 95% (75% on testnet) of the network has upgraded:
     if (block.nVersion < 3 && IsSuperMajority(3, pindexPrev, consensusParams.nMajorityRejectBlockOutdated, consensusParams))
         return state.Invalid(error("%s : rejected nVersion=2 block", __func__),
+                             REJECT_OBSOLETE, "bad-version");
+
+    // Reject block.nVersion=3 blocks when 95% (75% on testnet) of the network has upgraded:
+    if (block.nVersion < 4 && IsSuperMajority(4, pindexPrev, consensusParams.nMajorityRejectBlockOutdated, consensusParams))
+        return state.Invalid(error("%s : rejected nVersion=3 block", __func__),
                              REJECT_OBSOLETE, "bad-version");
 
     return true;

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -21,7 +21,7 @@ class CBlockHeader
 {
 public:
     // header
-    static const int32_t CURRENT_VERSION=3;
+    static const int32_t CURRENT_VERSION=4;
     int32_t nVersion;
     uint256 hashPrevBlock;
     uint256 hashMerkleRoot;

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -648,6 +648,7 @@ UniValue getblockchaininfo(const UniValue& params, bool fHelp)
     UniValue softforks(UniValue::VARR);
     softforks.push_back(SoftForkDesc("bip34", 2, tip, consensusParams));
     softforks.push_back(SoftForkDesc("bip66", 3, tip, consensusParams));
+    softforks.push_back(SoftForkDesc("bip65", 4, tip, consensusParams));
     obj.push_back(Pair("softforks",             softforks));
 
     if (fPruneMode)

--- a/src/script/bitcoinconsensus.h
+++ b/src/script/bitcoinconsensus.h
@@ -44,9 +44,10 @@ typedef enum bitcoinconsensus_error_t
 /** Script verification flags */
 enum
 {
-    bitcoinconsensus_SCRIPT_FLAGS_VERIFY_NONE      = 0,
-    bitcoinconsensus_SCRIPT_FLAGS_VERIFY_P2SH      = (1U << 0), // evaluate P2SH (BIP16) subscripts
-    bitcoinconsensus_SCRIPT_FLAGS_VERIFY_DERSIG    = (1U << 2), // enforce strict DER (BIP66) compliance
+    bitcoinconsensus_SCRIPT_FLAGS_VERIFY_NONE                = 0,
+    bitcoinconsensus_SCRIPT_FLAGS_VERIFY_P2SH                = (1U << 0), // evaluate P2SH (BIP16) subscripts
+    bitcoinconsensus_SCRIPT_FLAGS_VERIFY_DERSIG              = (1U << 2), // enforce strict DER (BIP66) compliance
+    bitcoinconsensus_SCRIPT_FLAGS_VERIFY_CHECKLOCKTIMEVERIFY = (1U << 9), // enable CHECKLOCKTIMEVERIFY (BIP65)
 };
 
 /// Returns 1 if the input nIn of the serialized transaction pointed to by


### PR DESCRIPTION
Final step towards CLTV deployment on mainnet.

I've copied the logic and tests from the previous BIP66 (DERSIG) soft-fork line-by-line for ease of review; any code review applicable to BIP66 should be applicable to BIP65.

Once merged I'll prepare a backport of the soft-fork logic for the v0.10.x branch as well.
