### PR TITLE
Scheduled full-RBF deployment

### DIFF
--- a/qa/replace-by-fee/.gitignore
+++ b/qa/replace-by-fee/.gitignore
@@ -1,0 +1,1 @@
+python-bitcoinlib

--- a/qa/replace-by-fee/README.md
+++ b/qa/replace-by-fee/README.md
@@ -1,0 +1,13 @@
+Replace-by-fee regression tests
+===============================
+
+First get version v0.3.0 of the python-bitcoinlib library. In this directory
+run:
+
+    git clone -n https://github.com/petertodd/python-bitcoinlib
+    (cd python-bitcoinlib && git checkout c481254c623cc9a002187dc23263cce3e05f5754)
+
+Then run the tests themselves with a bitcoind available running in regtest
+mode:
+
+    ./full-rbf-tests.py

--- a/qa/replace-by-fee/README.md
+++ b/qa/replace-by-fee/README.md
@@ -8,6 +8,15 @@ run:
     (cd python-bitcoinlib && git checkout c481254c623cc9a002187dc23263cce3e05f5754)
 
 Then run the tests themselves with a bitcoind available running in regtest
-mode:
+mode. There's separate tests for full and first-seen-safe RBF. The former:
 
     ./full-rbf-tests.py
+
+To run the latter you'll need to restart bitcoind using the
+fullrbfactivationtime argument to disable full-RBF on regtest:
+
+    bitcoind -fullrbfactivationtime=0 -regtest
+
+Followed by:
+
+    ./fss-rbf-tests.py

--- a/qa/replace-by-fee/fss-rbf-tests.py
+++ b/qa/replace-by-fee/fss-rbf-tests.py
@@ -1,0 +1,387 @@
+#!/usr/bin/env python3
+# Copyright (c) 2015 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#
+# Test replace-by-fee
+#
+
+import os
+import sys
+
+# Add python-bitcoinlib to module search path:
+sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), "python-bitcoinlib"))
+
+import unittest
+
+import bitcoin
+bitcoin.SelectParams('regtest')
+
+import bitcoin.rpc
+
+from bitcoin.core import *
+from bitcoin.core.script import *
+from bitcoin.wallet import *
+
+class Test_ReplaceByFee(unittest.TestCase):
+    proxy = None
+
+    @classmethod
+    def setUpClass(cls):
+        if cls.proxy is None:
+            cls.proxy = bitcoin.rpc.Proxy()
+
+    @classmethod
+    def mine_mempool(cls):
+        """Mine until mempool is empty"""
+        mempool_size = 1
+        while mempool_size:
+            cls.proxy.generate(1)
+            new_mempool_size = len(cls.proxy.getrawmempool())
+
+            # It's possible to get stuck in a loop here if the mempool has
+            # transactions that can't be mined.
+            assert(new_mempool_size != mempool_size)
+            mempool_size = new_mempool_size
+
+    @classmethod
+    def tearDownClass(cls):
+        # Make sure mining works
+        cls.mine_mempool()
+
+    def make_txouts(self, n, amount, confirmed=True, scriptPubKey=CScript([1])):
+        """Create n txouts with a given amount and scriptPubKey
+
+        Mines coins as needed.
+
+        confirmed - txouts created will be confirmed in the blockchain;
+                    unconfirmed otherwise.
+        """
+        if not n:
+            return []
+
+        fee = 1*COIN
+        while self.proxy.getbalance() < n*amount + fee:
+            self.proxy.generate(100)
+
+        addr = P2SHBitcoinAddress.from_redeemScript(CScript([]))
+        txid = self.proxy.sendtoaddress(addr, n*amount + fee)
+
+        tx1 = self.proxy.getrawtransaction(txid)
+
+        i = None
+        for i, txout in enumerate(tx1.vout):
+            if txout.scriptPubKey == addr.to_scriptPubKey():
+                break
+        assert i is not None
+
+        tx2 = CTransaction([CTxIn(COutPoint(txid, i), CScript([1, CScript([])]))],
+                           [CTxOut(amount, scriptPubKey)]*n)
+
+        tx2_txid = self.proxy.sendrawtransaction(tx2, True)
+
+        # If requested, ensure txouts are confirmed.
+        if confirmed:
+            self.mine_mempool()
+
+        return [COutPoint(tx2_txid, i) for i in range(n)]
+
+    def make_txout(self, amount, confirmed=True, scriptPubKey=CScript([1])):
+        """Create a txout with a given amount and scriptPubKey
+
+        Mines coins as needed.
+
+        confirmed - txouts created will be confirmed in the blockchain;
+                    unconfirmed otherwise.
+        """
+        return self.make_txouts(1, amount, confirmed, scriptPubKey)[0]
+
+    def test_subset_prohibited(self):
+        """Replacement prohibited if any recipient will receive less funds from replacement"""
+
+        for n in range(1,4):
+            utxo1 = self.make_txout(n*0.11*COIN)
+            utxo2 = self.make_txout(1.0*COIN)
+
+            tx1 = CTransaction([CTxIn(utxo1)],
+                                [CTxOut(0.10*COIN, CScript([i])) for i in range(n)])
+            tx1_txid = self.proxy.sendrawtransaction(tx1, True)
+
+            # Double spend with too-few outputs
+            for m in range(1,n):
+                tx2 = CTransaction([CTxIn(utxo1), CTxIn(utxo2)],
+                                   tx1.vout[0:m])
+
+                try:
+                    tx2_txid = self.proxy.sendrawtransaction(tx2, True)
+                except bitcoin.rpc.JSONRPCException as exp:
+                    self.assertEqual(exp.error['code'], -26)
+                else:
+                    self.fail()
+
+            # Double spend with one of the outputs changed
+            for m in range(0,n):
+                vout = list(tx1.vout)
+                vout[m] = CTxOut(0.10*COIN, CScript([b'a']))
+                tx2 = CTransaction([CTxIn(utxo1), CTxIn(utxo2)], vout)
+
+                try:
+                    tx2_txid = self.proxy.sendrawtransaction(tx2, True)
+                except bitcoin.rpc.JSONRPCException as exp:
+                    self.assertEqual(exp.error['code'], -26)
+                else:
+                    self.fail()
+
+            # Double spend with one of the outputs reduced in value by one satoshi
+            for m in range(0,n):
+                vout = list(tx1.vout)
+                vout[m] = CTxOut(vout[m].nValue-1, vout[m].scriptPubKey)
+                tx2 = CTransaction([CTxIn(utxo1), CTxIn(utxo2)], vout)
+
+                try:
+                    tx2_txid = self.proxy.sendrawtransaction(tx2, True)
+                except bitcoin.rpc.JSONRPCException as exp:
+                    self.assertEqual(exp.error['code'], -26)
+                else:
+                    self.fail()
+
+            # With all the outputs the same, and an additional input, the
+            # replacement will succeed.
+            tx2 = CTransaction([CTxIn(utxo1), CTxIn(utxo2)], tx1.vout)
+            tx2_txid = self.proxy.sendrawtransaction(tx2, True)
+
+            with self.assertRaises(IndexError):
+                self.proxy.getrawtransaction(tx1_txid)
+            self.proxy.getrawtransaction(tx2_txid)
+
+    def test_reorder_vout_prohibited(self):
+        """Changing the order of vout is prohibited"""
+
+        utxo1 = self.make_txout(2*1.1*COIN)
+        utxo2 = self.make_txout(1.0*COIN)
+
+        tx1 = CTransaction([CTxIn(utxo1)],
+                            [CTxOut(1.0*COIN, CScript([1])),
+                             CTxOut(1.0*COIN, CScript([2]))])
+        tx1_txid = self.proxy.sendrawtransaction(tx1, True)
+
+        tx2 = CTransaction([CTxIn(utxo1), CTxIn(utxo2)],
+                           reversed(tx1.vout))
+
+        try:
+            tx2_txid = self.proxy.sendrawtransaction(tx2, True)
+        except bitcoin.rpc.JSONRPCException as exp:
+            self.assertEqual(exp.error['code'], -26)
+        else:
+            self.fail()
+
+    def test_reorder_vin_allowed(self):
+        """Changing the order of vin is allowed"""
+        utxo1 = self.make_txout(1.1*COIN)
+        utxo2 = self.make_txout(1.0*COIN)
+
+        tx1 = CTransaction([CTxIn(utxo1)],
+                            [CTxOut(1.0*COIN, CScript([1]))])
+        tx1_txid = self.proxy.sendrawtransaction(tx1, True)
+
+        tx2 = CTransaction([CTxIn(utxo2), CTxIn(utxo1)],
+                           tx1.vout)
+
+        tx2_txid = self.proxy.sendrawtransaction(tx2, True)
+        with self.assertRaises(IndexError):
+            self.proxy.getrawtransaction(tx1_txid)
+        self.proxy.getrawtransaction(tx2_txid)
+
+    def test_one_to_one(self):
+        """Replacing multiple transactions at once is prohibited"""
+        utxo1 = self.make_txout(1.1*COIN)
+        utxo2 = self.make_txout(1.1*COIN)
+        utxo3 = self.make_txout(1.0*COIN)
+
+        tx1a = CTransaction([CTxIn(utxo1)],
+                            [CTxOut(1.0*COIN, CScript([b'a']))])
+        tx1a_txid = self.proxy.sendrawtransaction(tx1a, True)
+
+        tx1b = CTransaction([CTxIn(utxo2)],
+                            [CTxOut(1.0*COIN, CScript([b'b']))])
+        tx1b_txid = self.proxy.sendrawtransaction(tx1b, True)
+
+        tx2 = CTransaction([CTxIn(utxo1), CTxIn(utxo2), CTxIn(utxo3)],
+                           tx1a.vout + tx1b.vout)
+
+        try:
+            tx2_txid = self.proxy.sendrawtransaction(tx2, True)
+        except bitcoin.rpc.JSONRPCException as exp:
+            self.assertEqual(exp.error['code'], -26)
+        else:
+            self.fail()
+
+    def test_replaced_outputs_unspent(self):
+        """Replaced transaction's outputs must be unspent"""
+
+        for i in range(2):
+            utxo1 = self.make_txout(1.2*COIN)
+            utxo2 = self.make_txout(3.0*COIN)
+
+            tx1a = CTransaction([CTxIn(utxo1)],
+                                [CTxOut(0.5*COIN, CScript([b'a'])),
+                                 CTxOut(0.5*COIN, CScript([b'b']))])
+            tx1a_txid = self.proxy.sendrawtransaction(tx1a, True)
+
+            tx1b = CTransaction([CTxIn(COutPoint(tx1a_txid, i))],
+                                [CTxOut(0.4*COIN, CScript([b'b']))])
+            tx1b_txid = self.proxy.sendrawtransaction(tx1b, True)
+
+            tx2 = CTransaction([CTxIn(utxo1), CTxIn(utxo2)],
+                               tx1a.vout + tx1b.vout)
+
+            try:
+                tx2_txid = self.proxy.sendrawtransaction(tx2, True)
+            except bitcoin.rpc.JSONRPCException as exp:
+                self.assertEqual(exp.error['code'], -26)
+            else:
+                self.fail()
+
+    def test_additional_unconfirmed_inputs(self):
+        """Replacement fails if additional unconfirmed inputs added"""
+        confirmed_utxo = self.make_txout(1.1*COIN)
+        unconfirmed_utxo = self.make_txout(0.1*COIN, False)
+
+        tx1 = CTransaction([CTxIn(confirmed_utxo)],
+                           [CTxOut(1.0*COIN, CScript([b'a']))])
+        tx1_txid = self.proxy.sendrawtransaction(tx1, True)
+
+        tx2 = CTransaction([CTxIn(confirmed_utxo), CTxIn(unconfirmed_utxo)],
+                           tx1.vout)
+
+        try:
+            tx2_txid = self.proxy.sendrawtransaction(tx2, True)
+        except bitcoin.rpc.JSONRPCException as exp:
+            self.assertEqual(exp.error['code'], -26)
+        else:
+            self.fail()
+
+    def test_spends_of_conflicting_outputs(self):
+        """Replacements that spend conflicting tx outputs are rejected"""
+        utxo1 = self.make_txout(1.2*COIN)
+        utxo2 = self.make_txout(3.0*COIN)
+
+        tx1a = CTransaction([CTxIn(utxo1)],
+                            [CTxOut(1.1*COIN, CScript([b'a']))])
+        tx1a_txid = self.proxy.sendrawtransaction(tx1a, True)
+
+        # Direct spend an output of the transaction we're replacing.
+        tx2 = CTransaction([CTxIn(utxo1), CTxIn(utxo2),
+                            CTxIn(COutPoint(tx1a_txid, 0))],
+                           tx1a.vout)
+
+        try:
+            tx2_txid = self.proxy.sendrawtransaction(tx2, True)
+        except bitcoin.rpc.JSONRPCException as exp:
+            self.assertEqual(exp.error['code'], -26)
+        else:
+            self.fail()
+
+        # Spend tx1a's output to test the indirect case.
+        tx1b = CTransaction([CTxIn(COutPoint(tx1a_txid, 0))],
+                            [CTxOut(1.0*COIN, CScript([b'a']))])
+        tx1b_txid = self.proxy.sendrawtransaction(tx1b, True)
+
+        tx2 = CTransaction([CTxIn(utxo1), CTxIn(utxo2),
+                            CTxIn(COutPoint(tx1b_txid, 0))],
+                           tx1a.vout)
+
+        try:
+            tx2_txid = self.proxy.sendrawtransaction(tx2, True)
+        except bitcoin.rpc.JSONRPCException as exp:
+            self.assertEqual(exp.error['code'], -26)
+        else:
+            self.fail()
+
+
+    def test_economics(self):
+        """Replacement prohibited if uneconomical"""
+        utxo1 = self.make_txout(110000)
+        utxo2 = self.make_txout(1)
+        utxo3 = self.make_txout(1000000)
+
+        # By including utxo2 in tx1 but not tx2 lets us test the case where the
+        # replacement pays less fees than the original while still respecting
+        # the "no-decreases" rule.
+        tx1 = CTransaction([CTxIn(utxo1), CTxIn(utxo2)],
+                            [CTxOut(100000, CScript([b'a']))])
+        tx1_txid = self.proxy.sendrawtransaction(tx1, True)
+
+        # FIXME: these constants should be derived somehow, but right now
+        # there's no way to get min fee info from the mempool over RPC
+        for fee_delta in [-1,   # less fees than original
+                          0, 1, # not enough to pay for bandwidth
+                          114, 1068,  # fee/KB of replacement less than original
+                         ]:
+            tx2 = CTransaction([CTxIn(utxo1), CTxIn(utxo3)],
+                               [tx1.vout[0],
+                                CTxOut(1000000-1-fee_delta, CScript([b'b']))])
+
+            try:
+                tx2_txid = self.proxy.sendrawtransaction(tx2, True)
+            except bitcoin.rpc.JSONRPCException as exp:
+                self.assertEqual(exp.error['code'], -26)
+            else:
+                self.fail()
+
+
+    def test_very_large_replacements(self):
+        """Very large replacements"""
+        n = 5000
+        for n_vin, n_new_vin, n_vout, n_new_vout in [(n,0,2,0),
+                                                     (n,n,2,0),
+                                                     (n,n,n,0),
+                                                     (n,n,n,n),
+                                                     (2,n,n,n),
+                                                     (2,0,n,n),
+                                                     (2,0,2,n),
+                                                     ]:
+            utxos = self.make_txouts(n_vin, 1000)
+
+            fee_utxo1 = self.make_txout(0.01*COIN)
+            fee_utxo2 = self.make_txout(10*COIN)
+            new_utxos = tuple(CTxIn(utxo) for utxo in self.make_txouts(n_new_vin, 1000))
+
+            tx1 = CTransaction([CTxIn(utxo) for utxo in utxos] + [CTxIn(fee_utxo1)],
+                               [CTxOut(1, CScript([b'a'])) for i in range(n_vout)])
+            tx1_txid = self.proxy.sendrawtransaction(tx1, True)
+
+            new_vout = tuple(CTxOut(1, CScript([b'b'])) for i in range(n_new_vout))
+
+            # Prohibited replacement, last vout omitted
+            tx2 = CTransaction(tx1.vin + (CTxIn(fee_utxo2),) + new_utxos,
+                               tx1.vout[0:-1] + new_vout)
+            try:
+                tx2_txid = self.proxy.sendrawtransaction(tx2, True)
+            except bitcoin.rpc.JSONRPCException as exp:
+                self.assertEqual(exp.error['code'], -26)
+            else:
+                self.fail()
+
+            # Prohibited replacement, last vout changed
+            tx2 = CTransaction(tx1.vin + (CTxIn(fee_utxo2),) + new_utxos,
+                               tx1.vout[0:-1] + (CTxOut(1, CScript([b'b'])),) + new_vout)
+            try:
+                tx2_txid = self.proxy.sendrawtransaction(tx2, True)
+            except bitcoin.rpc.JSONRPCException as exp:
+                self.assertEqual(exp.error['code'], -26)
+            else:
+                self.fail()
+
+            # Succesful replacement
+            tx2 = CTransaction(tx1.vin + (CTxIn(fee_utxo2),) + new_utxos,
+                               tx1.vout + new_vout)
+
+            tx2_txid = self.proxy.sendrawtransaction(tx2, True)
+            with self.assertRaises(IndexError):
+                self.proxy.getrawtransaction(tx1_txid)
+            self.proxy.getrawtransaction(tx2_txid)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/qa/replace-by-fee/full-rbf-tests.py
+++ b/qa/replace-by-fee/full-rbf-tests.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python3
+# Copyright (c) 2015 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#
+# Test replace-by-fee
+#
+
+import os
+import sys
+
+# Add python-bitcoinlib to module search path:
+sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), "python-bitcoinlib"))
+
+import unittest
+
+import bitcoin
+bitcoin.SelectParams('regtest')
+
+import bitcoin.rpc
+
+from bitcoin.core import *
+from bitcoin.core.script import *
+from bitcoin.wallet import *
+
+MAX_REPLACEMENT_LIMIT = 100
+
+class Test_ReplaceByFee(unittest.TestCase):
+    proxy = None
+
+    @classmethod
+    def setUpClass(cls):
+        if cls.proxy is None:
+            cls.proxy = bitcoin.rpc.Proxy()
+
+    @classmethod
+    def tearDownClass(cls):
+        # Make sure mining works
+        mempool_size = 1
+        while mempool_size:
+            cls.proxy.generate(1)
+            new_mempool_size = len(cls.proxy.getrawmempool())
+
+            # It's possible to get stuck in a loop here if the mempool has
+            # transactions that can't be mined.
+            assert(new_mempool_size != mempool_size)
+            mempool_size = new_mempool_size
+
+    def make_txout(self, amount, scriptPubKey=CScript([1])):
+        """Create a txout with a given amount and scriptPubKey
+
+        Mines coins as needed.
+        """
+        fee = 1*COIN
+        while self.proxy.getbalance() < amount + fee:
+            self.proxy.generate(100)
+
+        addr = P2SHBitcoinAddress.from_redeemScript(CScript([]))
+        txid = self.proxy.sendtoaddress(addr, amount + fee)
+
+        tx1 = self.proxy.getrawtransaction(txid)
+
+        i = None
+        for i, txout in enumerate(tx1.vout):
+            if txout.scriptPubKey == addr.to_scriptPubKey():
+                break
+        assert i is not None
+
+        tx2 = CTransaction([CTxIn(COutPoint(txid, i), CScript([1, CScript([])]))],
+                           [CTxOut(amount, scriptPubKey)])
+
+        tx2_txid = self.proxy.sendrawtransaction(tx2, True)
+
+        return COutPoint(tx2_txid, 0)
+
+    def test_simple_doublespend(self):
+        """Simple doublespend"""
+        tx0_outpoint = self.make_txout(1.1*COIN)
+
+        tx1a = CTransaction([CTxIn(tx0_outpoint)],
+                            [CTxOut(1*COIN, CScript([b'a']))])
+        tx1a_txid = self.proxy.sendrawtransaction(tx1a, True)
+
+        # Should fail because we haven't changed the fee
+        tx1b = CTransaction([CTxIn(tx0_outpoint)],
+                            [CTxOut(1*COIN, CScript([b'b']))])
+
+        try:
+            tx1b_txid = self.proxy.sendrawtransaction(tx1b, True)
+        except bitcoin.rpc.JSONRPCException as exp:
+            self.assertEqual(exp.error['code'], -26) # insufficient fee
+        else:
+            self.fail()
+
+        # Extra 0.1 BTC fee
+        tx1b = CTransaction([CTxIn(tx0_outpoint)],
+                            [CTxOut(0.9*COIN, CScript([b'b']))])
+        tx1b_txid = self.proxy.sendrawtransaction(tx1b, True)
+
+        # tx1a is in fact replaced
+        with self.assertRaises(IndexError):
+            self.proxy.getrawtransaction(tx1a_txid)
+
+        self.assertEqual(tx1b, self.proxy.getrawtransaction(tx1b_txid))
+
+    def test_doublespend_chain(self):
+        """Doublespend of a long chain"""
+
+        initial_nValue = 50*COIN
+        tx0_outpoint = self.make_txout(initial_nValue)
+
+        prevout = tx0_outpoint
+        remaining_value = initial_nValue
+        chain_txids = []
+        while remaining_value > 10*COIN:
+            remaining_value -= 1*COIN
+            tx = CTransaction([CTxIn(prevout)],
+                              [CTxOut(remaining_value, CScript([1]))])
+            txid = self.proxy.sendrawtransaction(tx, True)
+            chain_txids.append(txid)
+            prevout = COutPoint(txid, 0)
+
+        # Whether the double-spend is allowed is evaluated by including all
+        # child fees - 40 BTC - so this attempt is rejected.
+        dbl_tx = CTransaction([CTxIn(tx0_outpoint)],
+                              [CTxOut(initial_nValue - 30*COIN, CScript([1]))])
+
+        try:
+            self.proxy.sendrawtransaction(dbl_tx, True)
+        except bitcoin.rpc.JSONRPCException as exp:
+            self.assertEqual(exp.error['code'], -26) # insufficient fee
+        else:
+            self.fail()
+
+        # Accepted with sufficient fee
+        dbl_tx = CTransaction([CTxIn(tx0_outpoint)],
+                              [CTxOut(1*COIN, CScript([1]))])
+        self.proxy.sendrawtransaction(dbl_tx, True)
+
+        for doublespent_txid in chain_txids:
+            with self.assertRaises(IndexError):
+                self.proxy.getrawtransaction(doublespent_txid)
+
+    def test_doublespend_tree(self):
+        """Doublespend of a big tree of transactions"""
+
+        initial_nValue = 50*COIN
+        tx0_outpoint = self.make_txout(initial_nValue)
+
+        def branch(prevout, initial_value, max_txs, *, tree_width=5, fee=0.0001*COIN, _total_txs=None):
+            if _total_txs is None:
+                _total_txs = [0]
+            if _total_txs[0] >= max_txs:
+                return
+
+            txout_value = (initial_value - fee) // tree_width
+            if txout_value < fee:
+                return
+
+            vout = [CTxOut(txout_value, CScript([i+1]))
+                    for i in range(tree_width)]
+            tx = CTransaction([CTxIn(prevout)],
+                              vout)
+
+            self.assertTrue(len(tx.serialize()) < 100000)
+            txid = self.proxy.sendrawtransaction(tx, True)
+            yield tx
+            _total_txs[0] += 1
+
+            for i, txout in enumerate(tx.vout):
+                yield from branch(COutPoint(txid, i), txout_value,
+                                  max_txs,
+                                  tree_width=tree_width, fee=fee,
+                                  _total_txs=_total_txs)
+
+        fee = 0.0001*COIN
+        n = MAX_REPLACEMENT_LIMIT
+        tree_txs = list(branch(tx0_outpoint, initial_nValue, n, fee=fee))
+        self.assertEqual(len(tree_txs), n)
+
+        # Attempt double-spend, will fail because too little fee paid
+        dbl_tx = CTransaction([CTxIn(tx0_outpoint)],
+                              [CTxOut(initial_nValue - fee*n, CScript([1]))])
+        try:
+            self.proxy.sendrawtransaction(dbl_tx, True)
+        except bitcoin.rpc.JSONRPCException as exp:
+            self.assertEqual(exp.error['code'], -26) # insufficient fee
+        else:
+            self.fail()
+
+        # 1 BTC fee is enough
+        dbl_tx = CTransaction([CTxIn(tx0_outpoint)],
+                              [CTxOut(initial_nValue - fee*n - 1*COIN, CScript([1]))])
+        self.proxy.sendrawtransaction(dbl_tx, True)
+
+        for tx in tree_txs:
+            with self.assertRaises(IndexError):
+                self.proxy.getrawtransaction(tx.GetHash())
+
+        # Try again, but with more total transactions than the "max txs
+        # double-spent at once" anti-DoS limit.
+        for n in (MAX_REPLACEMENT_LIMIT, MAX_REPLACEMENT_LIMIT*2):
+            fee = 0.0001*COIN
+            tx0_outpoint = self.make_txout(initial_nValue)
+            tree_txs = list(branch(tx0_outpoint, initial_nValue, n, fee=fee))
+            self.assertEqual(len(tree_txs), n)
+
+            dbl_tx = CTransaction([CTxIn(tx0_outpoint)],
+                                  [CTxOut(initial_nValue - fee*n, CScript([1]))])
+            try:
+                self.proxy.sendrawtransaction(dbl_tx, True)
+            except bitcoin.rpc.JSONRPCException as exp:
+                self.assertEqual(exp.error['code'], -26)
+            else:
+                self.fail()
+
+            for tx in tree_txs:
+                self.proxy.getrawtransaction(tx.GetHash())
+
+    def test_huge_chain(self):
+        """Doublespend of a huge (in size) transaction chain"""
+
+        def fat_chain(n, remaining_value):
+            fee = 0.1*COIN
+
+            initial_nValue = (n * fee) + remaining_value
+            tx0_outpoint = self.make_txout(initial_nValue)
+
+            yield tx0_outpoint
+
+            prevout = tx0_outpoint
+            prevout_nValue = initial_nValue
+
+            fat_txout = CTxOut(1, CScript([b'\xff'*999000]))
+
+            for i in range(n):
+                tx = CTransaction([CTxIn(prevout)],
+                                  [CTxOut(prevout_nValue - fee, CScript([1])),
+                                   fat_txout])
+
+                txid = self.proxy.sendrawtransaction(tx, True)
+
+                prevout = COutPoint(txid, 0)
+                prevout_nValue = tx.vout[0].nValue
+
+                yield tx
+
+        n = MAX_REPLACEMENT_LIMIT
+        tx0_outpoint, *chain_txs = fat_chain(n, 1*COIN)
+        self.assertEqual(len(chain_txs), n)
+
+        # Attempt double-spend, will fail because too little fee paid
+        dbl_tx = CTransaction([CTxIn(tx0_outpoint)],
+                              [CTxOut(2*COIN, CScript([1]))])
+        try:
+            self.proxy.sendrawtransaction(dbl_tx, True)
+        except bitcoin.rpc.JSONRPCException as exp:
+            self.assertEqual(exp.error['code'], -26) # insufficient fee
+        else:
+            self.fail()
+
+        # Fine with more fees
+        dbl_tx = CTransaction([CTxIn(tx0_outpoint)],
+                              [CTxOut(0.9*COIN, CScript([1]))])
+        self.proxy.sendrawtransaction(dbl_tx, True)
+
+        for tx in chain_txs:
+            with self.assertRaises(IndexError):
+                self.proxy.getrawtransaction(tx.GetHash())
+
+    def test_replacement_feeperkb(self):
+        """Replacement requires overall fee-per-KB to be higher"""
+        tx0_outpoint = self.make_txout(1.1*COIN)
+
+        tx1a = CTransaction([CTxIn(tx0_outpoint)],
+                            [CTxOut(1*COIN, CScript([b'a']))])
+        tx1a_txid = self.proxy.sendrawtransaction(tx1a, True)
+
+        # Higher fee, but the fee per KB is much lower, so the replacement is
+        # rejected.
+        tx1b = CTransaction([CTxIn(tx0_outpoint)],
+                            [CTxOut(0.001*COIN,
+                                    CScript([b'a'*999000]))])
+
+        try:
+            tx1b_txid = self.proxy.sendrawtransaction(tx1b, True)
+        except bitcoin.rpc.JSONRPCException as exp:
+            self.assertEqual(exp.error['code'], -26) # insufficient fee
+        else:
+            self.fail()
+
+    def test_spends_of_conflicting_outputs(self):
+        """Replacements that spend conflicting tx outputs are rejected"""
+        utxo1 = self.make_txout(1.2*COIN)
+        utxo2 = self.make_txout(3.0*COIN)
+
+        tx1a = CTransaction([CTxIn(utxo1)],
+                            [CTxOut(1.1*COIN, CScript([b'a']))])
+        tx1a_txid = self.proxy.sendrawtransaction(tx1a, True)
+
+        # Direct spend an output of the transaction we're replacing.
+        tx2 = CTransaction([CTxIn(utxo1), CTxIn(utxo2),
+                            CTxIn(COutPoint(tx1a_txid, 0))],
+                           tx1a.vout)
+
+        try:
+            tx2_txid = self.proxy.sendrawtransaction(tx2, True)
+        except bitcoin.rpc.JSONRPCException as exp:
+            self.assertEqual(exp.error['code'], -26)
+        else:
+            self.fail()
+
+        # Spend tx1a's output to test the indirect case.
+        tx1b = CTransaction([CTxIn(COutPoint(tx1a_txid, 0))],
+                            [CTxOut(1.0*COIN, CScript([b'a']))])
+        tx1b_txid = self.proxy.sendrawtransaction(tx1b, True)
+
+        tx2 = CTransaction([CTxIn(utxo1), CTxIn(utxo2),
+                            CTxIn(COutPoint(tx1b_txid, 0))],
+                           tx1a.vout)
+
+        try:
+            tx2_txid = self.proxy.sendrawtransaction(tx2, True)
+        except bitcoin.rpc.JSONRPCException as exp:
+            self.assertEqual(exp.error['code'], -26)
+        else:
+            self.fail()
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -106,6 +106,9 @@ public:
         fMineBlocksOnDemand = false;
         fTestnetToBeDeprecatedFieldRPC = false;
 
+        // Tuesday April 5th, 2016 at 3pm UTC
+        nFullRbfActivationTime = 1459868400;
+
         checkpointData = (Checkpoints::CCheckpointData) {
             boost::assign::map_list_of
             ( 11111, uint256S("0x0000000069e244f73d78e8fd29ba2fd2ed618bd6fa2ee92559f542fdb26e7c1d"))
@@ -177,6 +180,9 @@ public:
         fRequireStandard = false;
         fMineBlocksOnDemand = false;
         fTestnetToBeDeprecatedFieldRPC = true;
+
+        // Full-RBF always active on testnet/regtest
+        nFullRbfActivationTime = 1;
 
         checkpointData = (Checkpoints::CCheckpointData) {
             boost::assign::map_list_of

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -65,6 +65,8 @@ public:
     bool MineBlocksOnDemand() const { return fMineBlocksOnDemand; }
     /** In the future use NetworkIDString() for RPC fields */
     bool TestnetToBeDeprecatedFieldRPC() const { return fTestnetToBeDeprecatedFieldRPC; }
+    /** In the future use NetworkIDString() for RPC fields */
+    int64_t FullRbfActivationTime() const { return nFullRbfActivationTime; }
     /** Return the BIP70 network string (main, test or regtest) */
     std::string NetworkIDString() const { return strNetworkID; }
     const std::vector<CDNSSeedData>& DNSSeeds() const { return vSeeds; }
@@ -92,6 +94,7 @@ protected:
     bool fRequireStandard;
     bool fMineBlocksOnDemand;
     bool fTestnetToBeDeprecatedFieldRPC;
+    int64_t nFullRbfActivationTime;
     Checkpoints::CCheckpointData checkpointData;
 };
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -398,6 +398,9 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageGroup(_("Node relay options:"));
     strUsage += HelpMessageOpt("-datacarrier", strprintf(_("Relay and mine data carrier transactions (default: %u)"), 1));
     strUsage += HelpMessageOpt("-datacarriersize", strprintf(_("Maximum size of data in data carrier transactions we relay and mine (default: %u)"), MAX_OP_RETURN_RELAY));
+    strUsage += HelpMessageOpt("-fullrbfactivationtime", strprintf(_("Full-RBF activation time in seconds from the epoch. Set to 1 to enable now, or 0 to disable. (default: %u, or %u testnet/regtest)"),
+                                                                   Params(CBaseChainParams::MAIN).FullRbfActivationTime(),
+                                                                   Params(CBaseChainParams::TESTNET).FullRbfActivationTime()));
 
     strUsage += HelpMessageGroup(_("Block creation options:"));
     strUsage += HelpMessageOpt("-blockminsize=<n>", strprintf(_("Set minimum block size in bytes (default: %u)"), 0));
@@ -862,6 +865,8 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
 
     std::string strWalletFile = GetArg("-wallet", "wallet.dat");
 #endif // ENABLE_WALLET
+
+    nFullRbfActivationTime = GetArg("-fullrbfactivationtime", Params().FullRbfActivationTime());
 
     fIsBareMultisigStd = GetBoolArg("-permitbaremultisig", true);
     nMaxDatacarrierBytes = GetArg("-datacarriersize", nMaxDatacarrierBytes);

--- a/src/main.h
+++ b/src/main.h
@@ -116,6 +116,7 @@ extern bool fCheckpointsEnabled;
 extern size_t nCoinCacheUsage;
 extern CFeeRate minRelayTxFee;
 extern bool fAlerts;
+extern int64_t nFullRbfActivationTime;
 
 /** Best header we've seen so far (used for getheaders queries' starting points). */
 extern CBlockIndex *pindexBestHeader;


### PR DESCRIPTION
Prior to Tuesday April 5th, 2016, at 3pm UTC, this pull-req implements first-seen-safe replace-by-fee; after the switchover date the first-seen-safe restrictions automatically turn off, resulting in full-RBF behavior. On testnet/regtest full-RBF is always supported.

The implementation is from my full-RBF patch series, specifically https://github.com/petertodd/bitcoin/tree/replace-by-fee-v0.11.0rc2, with additional logic and tests from #6176 

BIP: https://github.com/petertodd/bips/blob/bip-full-rbf-deadline/bip-full-rbf-deadline.mediawiki

Credit goes to @jgarzik for suggesting a scheduled-in-advance deployment strategy.
