### PR TITLE
Chainparams: Separate globals and depedendent functions

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -135,6 +135,7 @@ BITCOIN_CORE_H = \
   support/pagelocker.h \
   sync.h \
   threadsafety.h \
+  templates.hpp \
   timedata.h \
   tinyformat.h \
   txdb.h \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -96,6 +96,8 @@ BITCOIN_CORE_H = \
   core_io.h \
   eccryptoverify.h \
   ecwrapper.h \
+  globals/chainparamsbaseglobals.h \
+  globals/chainparamsglobals.h \
   hash.h \
   init.h \
   key.h \
@@ -243,6 +245,7 @@ libbitcoin_common_a_SOURCES = \
   core_write.cpp \
   eccryptoverify.cpp \
   ecwrapper.cpp \
+  globals/chainparamsglobals.cpp \
   hash.cpp \
   key.cpp \
   keystore.cpp \
@@ -270,6 +273,7 @@ libbitcoin_util_a_SOURCES = \
   compat/glibc_sanity.cpp \
   compat/glibcxx_sanity.cpp \
   compat/strnlen.cpp \
+  globals/chainparamsbaseglobals.cpp \
   random.cpp \
   rpcprotocol.cpp \
   support/cleanse.cpp \

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -23,9 +23,7 @@ std::string HelpMessageCli()
     strUsage += HelpMessageOpt("-?", _("This help message"));
     strUsage += HelpMessageOpt("-conf=<file>", strprintf(_("Specify configuration file (default: %s)"), "bitcoin.conf"));
     strUsage += HelpMessageOpt("-datadir=<dir>", _("Specify data directory"));
-    strUsage += HelpMessageOpt("-testnet", _("Use the test network"));
-    strUsage += HelpMessageOpt("-regtest", _("Enter regression test mode, which uses a special chain in which blocks can be "
-                                             "solved instantly. This is intended for regression testing tools and app development."));
+    AppendParamsHelpMessages(strUsage);
     strUsage += HelpMessageOpt("-rpcconnect=<ip>", strprintf(_("Send commands to node running on <ip> (default: %s)"), "127.0.0.1"));
     strUsage += HelpMessageOpt("-rpcport=<port>", strprintf(_("Connect to JSON-RPC on <port> (default: %u or testnet: %u)"), 8332, 18332));
     strUsage += HelpMessageOpt("-rpcwait", _("Wait for RPC server to start"));
@@ -88,8 +86,10 @@ static bool AppInitRPC(int argc, char* argv[])
         return false;
     }
     // Check for -testnet or -regtest parameter (BaseParams() calls are only valid after this clause)
-    if (!SelectBaseParamsFromCommandLine()) {
-        fprintf(stderr, "Error: Invalid combination of -regtest and -testnet.\n");
+    try {
+        SelectBaseParams(ChainNameFromCommandLine());
+    } catch(std::exception &e) {
+        fprintf(stderr, "Error: %s\n", e.what());
         return false;
     }
     return true;

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -5,6 +5,7 @@
 
 #include "chainparamsbase.h"
 #include "clientversion.h"
+#include "globals/chainparamsbaseglobals.h"
 #include "rpcclient.h"
 #include "rpcprotocol.h"
 #include "util.h"

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -85,9 +85,9 @@ static bool AppInitRPC(int argc, char* argv[])
         fprintf(stderr,"Error reading configuration file: %s\n", e.what());
         return false;
     }
-    // Check for -testnet or -regtest parameter (BaseParams() calls are only valid after this clause)
+    // Check for -testnet or -regtest parameter (cGlobalChainBaseParams.Get() calls are only valid after this clause)
     try {
-        SelectBaseParams(ChainNameFromCommandLine());
+        cGlobalChainBaseParams.Set(CBaseChainParams::Factory(ChainNameFromCommandLine()));
     } catch(std::exception &e) {
         fprintf(stderr, "Error: %s\n", e.what());
         return false;
@@ -112,7 +112,7 @@ UniValue CallRPC(const string& strMethod, const UniValue& params)
     SSLIOStreamDevice<boost::asio::ip::tcp> d(sslStream, fUseSSL);
     boost::iostreams::stream< SSLIOStreamDevice<boost::asio::ip::tcp> > stream(d);
 
-    const bool fConnected = d.connect(GetArg("-rpcconnect", "127.0.0.1"), GetArg("-rpcport", itostr(BaseParams().RPCPort())));
+    const bool fConnected = d.connect(GetArg("-rpcconnect", "127.0.0.1"), GetArg("-rpcport", itostr(cGlobalChainBaseParams.Get().RPCPort())));
     if (!fConnected)
         throw CConnectionFailed("couldn't connect to server");
 

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -34,8 +34,10 @@ static bool AppInitRawTx(int argc, char* argv[])
     ParseParameters(argc, argv);
 
     // Check for -testnet or -regtest parameter (Params() calls are only valid after this clause)
-    if (!SelectParamsFromCommandLine()) {
-        fprintf(stderr, "Error: Invalid combination of -regtest and -testnet.\n");
+    try {
+        SelectParams(ChainNameFromCommandLine());
+    } catch(std::exception &e) {
+        fprintf(stderr, "Error: %s\n", e.what());
         return false;
     }
 
@@ -57,8 +59,7 @@ static bool AppInitRawTx(int argc, char* argv[])
         strUsage += HelpMessageOpt("-create", _("Create new, empty TX."));
         strUsage += HelpMessageOpt("-json", _("Select JSON output"));
         strUsage += HelpMessageOpt("-txid", _("Output only the hex-encoded transaction id of the resultant transaction."));
-        strUsage += HelpMessageOpt("-regtest", _("Enter regression test mode, which uses a special chain in which blocks can be solved instantly."));
-        strUsage += HelpMessageOpt("-testnet", _("Use the test network"));
+        AppendParamsHelpMessages(strUsage);
 
         fprintf(stdout, "%s", strUsage.c_str());
 

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -102,8 +102,10 @@ bool AppInit(int argc, char* argv[])
             return false;
         }
         // Check for -testnet or -regtest parameter (Params() calls are only valid after this clause)
-        if (!SelectParamsFromCommandLine()) {
-            fprintf(stderr, "Error: Invalid combination of -regtest and -testnet.\n");
+        try {
+            SelectParams(ChainNameFromCommandLine());
+        } catch(std::exception &e) {
+            fprintf(stderr, "Error: %s\n", e.what());
             return false;
         }
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -5,6 +5,7 @@
 
 #include "chainparams.h"
 
+#include "tinyformat.h"
 #include "util.h"
 #include "utilstrencodings.h"
 
@@ -243,28 +244,26 @@ const CChainParams &Params() {
     return *pCurrentParams;
 }
 
-CChainParams &Params(CBaseChainParams::Network network) {
-    switch (network) {
-        case CBaseChainParams::MAIN:
+CChainParams& Params(const std::string& chain)
+{
+    if (chain == CBaseChainParams::MAIN)
             return mainParams;
-        case CBaseChainParams::TESTNET:
+    else if (chain == CBaseChainParams::TESTNET)
             return testNetParams;
-        case CBaseChainParams::REGTEST:
+    else if (chain == CBaseChainParams::REGTEST)
             return regTestParams;
-        default:
-            assert(false && "Unimplemented network");
-            return mainParams;
-    }
+    throw std::runtime_error(strprintf(_("%s: Unknown chain %s."), __func__, chain));
 }
 
-void SelectParams(CBaseChainParams::Network network) {
+void SelectParams(const std::string& network)
+{
     SelectBaseParams(network);
     pCurrentParams = &Params(network);
 }
 
 bool SelectParamsFromCommandLine()
 {
-    CBaseChainParams::Network network = NetworkIdFromCommandLine();
+    std::string network = ChainNameFromCommandLine();
     if (network == CBaseChainParams::MAX_NETWORK_TYPES)
         return false;
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -263,13 +263,3 @@ void SelectParams(const std::string& network)
     SelectBaseParams(network);
     cGlobalChainParams.Set(CChainParams::Factory(network));
 }
-
-bool SelectParamsFromCommandLine()
-{
-    std::string network = ChainNameFromCommandLine();
-    if (network == CBaseChainParams::MAX_NETWORK_TYPES)
-        return false;
-
-    SelectParams(network);
-    return true;
-}

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -234,13 +234,6 @@ public:
     }
 };
 
-Container<CChainParams> cGlobalChainParams;
-static Container<CChainParams> cGlobalSwitchingChainParams;
-
-const CChainParams &Params() {
-    return cGlobalChainParams.Get();
-}
-
 CChainParams* CChainParams::Factory(const std::string& chain)
 {
     if (chain == CBaseChainParams::MAIN)
@@ -250,16 +243,4 @@ CChainParams* CChainParams::Factory(const std::string& chain)
     else if (chain == CBaseChainParams::REGTEST)
         return new CRegTestParams();
     throw std::runtime_error(strprintf(_("%s: Unknown chain %s."), __func__, chain));
-}
-
-const CChainParams& Params(const std::string& chain)
-{
-    cGlobalSwitchingChainParams.Set(CChainParams::Factory(chain));
-    return cGlobalSwitchingChainParams.Get();
-}
-
-void SelectParams(const std::string& network)
-{
-    cGlobalChainBaseParams.Set(CBaseChainParams::Factory(network));
-    cGlobalChainParams.Set(CChainParams::Factory(network));
 }

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -260,6 +260,6 @@ const CChainParams& Params(const std::string& chain)
 
 void SelectParams(const std::string& network)
 {
-    SelectBaseParams(network);
+    cGlobalChainBaseParams.Set(CBaseChainParams::Factory(network));
     cGlobalChainParams.Set(CChainParams::Factory(network));
 }

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -129,7 +129,6 @@ public:
         };
     }
 };
-static CMainParams mainParams;
 
 /**
  * Testnet (v3)
@@ -189,7 +188,6 @@ public:
 
     }
 };
-static CTestNetParams testNetParams;
 
 /**
  * Regression test
@@ -235,30 +233,35 @@ public:
         };
     }
 };
-static CRegTestParams regTestParams;
 
-static CChainParams *pCurrentParams = 0;
+Container<CChainParams> cGlobalChainParams;
+static Container<CChainParams> cGlobalSwitchingChainParams;
 
 const CChainParams &Params() {
-    assert(pCurrentParams);
-    return *pCurrentParams;
+    return cGlobalChainParams.Get();
 }
 
-CChainParams& Params(const std::string& chain)
+CChainParams* CChainParams::Factory(const std::string& chain)
 {
     if (chain == CBaseChainParams::MAIN)
-            return mainParams;
+        return new CMainParams();
     else if (chain == CBaseChainParams::TESTNET)
-            return testNetParams;
+        return new CTestNetParams();
     else if (chain == CBaseChainParams::REGTEST)
-            return regTestParams;
+        return new CRegTestParams();
     throw std::runtime_error(strprintf(_("%s: Unknown chain %s."), __func__, chain));
+}
+
+const CChainParams& Params(const std::string& chain)
+{
+    cGlobalSwitchingChainParams.Set(CChainParams::Factory(chain));
+    return cGlobalSwitchingChainParams.Get();
 }
 
 void SelectParams(const std::string& network)
 {
     SelectBaseParams(network);
-    pCurrentParams = &Params(network);
+    cGlobalChainParams.Set(CChainParams::Factory(network));
 }
 
 bool SelectParamsFromCommandLine()

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -101,11 +101,16 @@ protected:
  */
 const CChainParams &Params();
 
-/** Return parameters for the given network. */
-CChainParams &Params(CBaseChainParams::Network network);
+/**
+ * @returns CChainParams for the given BIP70 chain name.
+ */
+CChainParams& Params(const std::string& chain);
 
-/** Sets the params returned by Params() to those for the given network. */
-void SelectParams(CBaseChainParams::Network network);
+/**
+ * Sets the params returned by Params() to those for the given BIP70 chain name.
+ * @throws std::runtime_error when the chain is not supported.
+ */
+void SelectParams(const std::string& chain);
 
 /**
  * Looks for -regtest or -testnet and then calls SelectParams as appropriate.

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -119,12 +119,6 @@ const CChainParams& Params(const std::string& chain);
  */
 void SelectParams(const std::string& chain);
 
-/**
- * Looks for -regtest or -testnet and then calls SelectParams as appropriate.
- * Returns false if an invalid combination is given.
- */
-bool SelectParamsFromCommandLine();
-
 extern Container<CChainParams> cGlobalChainParams;
 
 #endif // BITCOIN_CHAINPARAMS_H

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -9,6 +9,7 @@
 #include "chainparamsbase.h"
 #include "checkpoints.h"
 #include "consensus/params.h"
+#include "globals/chainparamsglobals.h" // TODO remove from here, blame @jtimon, not @theuni
 #include "primitives/block.h"
 #include "protocol.h"
 #include "templates.hpp"
@@ -101,24 +102,5 @@ protected:
     bool fTestnetToBeDeprecatedFieldRPC;
     Checkpoints::CCheckpointData checkpointData;
 };
-
-/**
- * Return the currently selected parameters. This won't change after app
- * startup, except for unit tests.
- */
-const CChainParams &Params();
-
-/**
- * @returns CChainParams for the given BIP70 chain name.
- */
-const CChainParams& Params(const std::string& chain);
-
-/**
- * Sets the params returned by Params() to those for the given BIP70 chain name.
- * @throws std::runtime_error when the chain is not supported.
- */
-void SelectParams(const std::string& chain);
-
-extern Container<CChainParams> cGlobalChainParams;
 
 #endif // BITCOIN_CHAINPARAMS_H

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -11,6 +11,7 @@
 #include "consensus/params.h"
 #include "primitives/block.h"
 #include "protocol.h"
+#include "templates.hpp"
 
 #include <vector>
 
@@ -71,6 +72,12 @@ public:
     const std::vector<unsigned char>& Base58Prefix(Base58Type type) const { return base58Prefixes[type]; }
     const std::vector<SeedSpec6>& FixedSeeds() const { return vFixedSeeds; }
     const Checkpoints::CCheckpointData& Checkpoints() const { return checkpointData; }
+    /**
+     * Creates and returns a CChainParams* of the chosen chain. The caller has to delete the object.
+     * @returns a CChainParams* of the chosen chain.
+     * @throws a std::runtime_error if the chain is not supported.
+     */
+    static CChainParams* Factory(const std::string& chain);
 protected:
     CChainParams() {}
 
@@ -104,7 +111,7 @@ const CChainParams &Params();
 /**
  * @returns CChainParams for the given BIP70 chain name.
  */
-CChainParams& Params(const std::string& chain);
+const CChainParams& Params(const std::string& chain);
 
 /**
  * Sets the params returned by Params() to those for the given BIP70 chain name.
@@ -117,5 +124,7 @@ void SelectParams(const std::string& chain);
  * Returns false if an invalid combination is given.
  */
 bool SelectParamsFromCommandLine();
+
+extern Container<CChainParams> cGlobalChainParams;
 
 #endif // BITCOIN_CHAINPARAMS_H

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -73,8 +73,6 @@ public:
 };
 static CBaseUnitTestParams unitTestParams;
 
-Container<CBaseChainParams> cGlobalChainBaseParams;
-
 CBaseChainParams* CBaseChainParams::Factory(const std::string& chain)
 {
     if (chain == CBaseChainParams::MAIN)

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -5,9 +5,15 @@
 
 #include "chainparamsbase.h"
 
+#include "tinyformat.h"
 #include "util.h"
 
 #include <assert.h>
+
+const std::string CBaseChainParams::MAIN = "main";
+const std::string CBaseChainParams::TESTNET = "test";
+const std::string CBaseChainParams::REGTEST = "regtest";
+const std::string CBaseChainParams::MAX_NETWORK_TYPES = "unknown_chain";
 
 /**
  * Main network
@@ -70,25 +76,19 @@ const CBaseChainParams& BaseParams()
     return *pCurrentBaseParams;
 }
 
-void SelectBaseParams(CBaseChainParams::Network network)
+void SelectBaseParams(const std::string& chain)
 {
-    switch (network) {
-    case CBaseChainParams::MAIN:
+    if (chain == CBaseChainParams::MAIN)
         pCurrentBaseParams = &mainParams;
-        break;
-    case CBaseChainParams::TESTNET:
+    else if (chain == CBaseChainParams::TESTNET)
         pCurrentBaseParams = &testNetParams;
-        break;
-    case CBaseChainParams::REGTEST:
+    else if (chain == CBaseChainParams::REGTEST)
         pCurrentBaseParams = &regTestParams;
-        break;
-    default:
-        assert(false && "Unimplemented network");
-        return;
-    }
+    else
+        throw std::runtime_error(strprintf(_("%s: Unknown chain %s."), __func__, chain));
 }
 
-CBaseChainParams::Network NetworkIdFromCommandLine()
+std::string ChainNameFromCommandLine()
 {
     bool fRegTest = GetBoolArg("-regtest", false);
     bool fTestNet = GetBoolArg("-testnet", false);
@@ -104,7 +104,7 @@ CBaseChainParams::Network NetworkIdFromCommandLine()
 
 bool SelectBaseParamsFromCommandLine()
 {
-    CBaseChainParams::Network network = NetworkIdFromCommandLine();
+    std::string network = ChainNameFromCommandLine();
     if (network == CBaseChainParams::MAX_NETWORK_TYPES)
         return false;
 

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -11,7 +11,17 @@
 const std::string CBaseChainParams::MAIN = "main";
 const std::string CBaseChainParams::TESTNET = "test";
 const std::string CBaseChainParams::REGTEST = "regtest";
-const std::string CBaseChainParams::MAX_NETWORK_TYPES = "unknown_chain";
+
+void AppendParamsHelpMessages(std::string& strUsage, bool debugHelp)
+{
+    strUsage += HelpMessageGroup(_("Chain selection options:"));
+    strUsage += HelpMessageOpt("-testnet", _("Use the test chain"));
+    if (debugHelp) {
+        strUsage += HelpMessageOpt("-regtest", _("Enter regression test mode, which uses a special chain in which blocks can be solved instantly.") + " " +
+                                   _("This is intended for regression testing tools and app development.") + " " +
+                                   _("In this mode -genproclimit controls how many blocks are generated immediately."));
+    }
+}
 
 /**
  * Main network
@@ -92,22 +102,12 @@ std::string ChainNameFromCommandLine()
     bool fTestNet = GetBoolArg("-testnet", false);
 
     if (fTestNet && fRegTest)
-        return CBaseChainParams::MAX_NETWORK_TYPES;
+        throw std::runtime_error(_("Invalid combination of -regtest and -testnet."));
     if (fRegTest)
         return CBaseChainParams::REGTEST;
     if (fTestNet)
         return CBaseChainParams::TESTNET;
     return CBaseChainParams::MAIN;
-}
-
-bool SelectBaseParamsFromCommandLine()
-{
-    std::string network = ChainNameFromCommandLine();
-    if (network == CBaseChainParams::MAX_NETWORK_TYPES)
-        return false;
-
-    SelectBaseParams(network);
-    return true;
 }
 
 bool AreBaseParamsConfigured()

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -75,11 +75,6 @@ static CBaseUnitTestParams unitTestParams;
 
 Container<CBaseChainParams> cGlobalChainBaseParams;
 
-const CBaseChainParams& BaseParams()
-{
-    return cGlobalChainBaseParams.Get();
-}
-
 CBaseChainParams* CBaseChainParams::Factory(const std::string& chain)
 {
     if (chain == CBaseChainParams::MAIN)
@@ -89,11 +84,6 @@ CBaseChainParams* CBaseChainParams::Factory(const std::string& chain)
     else if (chain == CBaseChainParams::REGTEST)
         return new CBaseRegTestParams();
     throw std::runtime_error(strprintf(_("%s: Unknown chain %s."), __func__, chain));
-}
-
-void SelectBaseParams(const std::string& chain)
-{
-    cGlobalChainBaseParams.Set(CBaseChainParams::Factory(chain));
 }
 
 std::string ChainNameFromCommandLine()
@@ -108,9 +98,4 @@ std::string ChainNameFromCommandLine()
     if (fTestNet)
         return CBaseChainParams::TESTNET;
     return CBaseChainParams::MAIN;
-}
-
-bool AreBaseParamsConfigured()
-{
-    return !cGlobalChainBaseParams.IsNull();
 }

--- a/src/chainparamsbase.h
+++ b/src/chainparamsbase.h
@@ -15,13 +15,11 @@
 class CBaseChainParams
 {
 public:
-    enum Network {
-        MAIN,
-        TESTNET,
-        REGTEST,
-
-        MAX_NETWORK_TYPES
-    };
+    /** BIP70 chain name strings (main, test or regtest) */
+    static const std::string MAIN;
+    static const std::string TESTNET;
+    static const std::string REGTEST;
+    static const std::string MAX_NETWORK_TYPES;
 
     const std::string& DataDir() const { return strDataDir; }
     int RPCPort() const { return nRPCPort; }
@@ -40,13 +38,13 @@ protected:
 const CBaseChainParams& BaseParams();
 
 /** Sets the params returned by Params() to those for the given network. */
-void SelectBaseParams(CBaseChainParams::Network network);
+void SelectBaseParams(const std::string& chain);
 
 /**
- * Looks for -regtest or -testnet and returns the appropriate Network ID.
- * Returns MAX_NETWORK_TYPES if an invalid combination is given.
+ * Looks for -regtest, -testnet and returns the appropriate BIP70 chain name.
+ * @return CBaseChainParams::MAX_NETWORK_TYPES if an invalid combination is given. CBaseChainParams::MAIN by default.
  */
-CBaseChainParams::Network NetworkIdFromCommandLine();
+std::string ChainNameFromCommandLine();
 
 /**
  * Calls NetworkIdFromCommandLine() and then calls SelectParams as appropriate.

--- a/src/chainparamsbase.h
+++ b/src/chainparamsbase.h
@@ -5,6 +5,8 @@
 #ifndef BITCOIN_CHAINPARAMSBASE_H
 #define BITCOIN_CHAINPARAMSBASE_H
 
+#include "templates.hpp"
+
 #include <string>
 #include <vector>
 
@@ -23,7 +25,12 @@ public:
 
     const std::string& DataDir() const { return strDataDir; }
     int RPCPort() const { return nRPCPort; }
-
+    /**
+     * Creates and returns a CBaseChainParams* of the chosen chain. The caller has to delete the object.
+     * @returns A CBaseChainParams* of the chosen chain.
+     * @throws a std::runtime_error if the chain is not supported.
+     */
+    static CBaseChainParams* Factory(const std::string& chain);
 protected:
     CBaseChainParams() {}
 
@@ -57,5 +64,7 @@ bool SelectBaseParamsFromCommandLine();
  * a network.
  */
 bool AreBaseParamsConfigured();
+
+extern Container<CBaseChainParams> cGlobalChainBaseParams;
 
 #endif // BITCOIN_CHAINPARAMSBASE_H

--- a/src/chainparamsbase.h
+++ b/src/chainparamsbase.h
@@ -39,6 +39,12 @@ protected:
 };
 
 /**
+ * Append the help messages for the chainparams options to the
+ * parameter string.
+ */
+void AppendParamsHelpMessages(std::string& strUsage, bool debugHelp=true);
+
+/**
  * Return the currently selected parameters. This won't change after app
  * startup, except for unit tests.
  */
@@ -52,12 +58,6 @@ void SelectBaseParams(const std::string& chain);
  * @return CBaseChainParams::MAX_NETWORK_TYPES if an invalid combination is given. CBaseChainParams::MAIN by default.
  */
 std::string ChainNameFromCommandLine();
-
-/**
- * Calls NetworkIdFromCommandLine() and then calls SelectParams as appropriate.
- * Returns false if an invalid combination is given.
- */
-bool SelectBaseParamsFromCommandLine();
 
 /**
  * Return true if SelectBaseParamsFromCommandLine() has been called to select

--- a/src/chainparamsbase.h
+++ b/src/chainparamsbase.h
@@ -50,6 +50,4 @@ void AppendParamsHelpMessages(std::string& strUsage, bool debugHelp=true);
  */
 std::string ChainNameFromCommandLine();
 
-extern Container<CBaseChainParams> cGlobalChainBaseParams;
-
 #endif // BITCOIN_CHAINPARAMSBASE_H

--- a/src/chainparamsbase.h
+++ b/src/chainparamsbase.h
@@ -45,25 +45,10 @@ protected:
 void AppendParamsHelpMessages(std::string& strUsage, bool debugHelp=true);
 
 /**
- * Return the currently selected parameters. This won't change after app
- * startup, except for unit tests.
- */
-const CBaseChainParams& BaseParams();
-
-/** Sets the params returned by Params() to those for the given network. */
-void SelectBaseParams(const std::string& chain);
-
-/**
  * Looks for -regtest, -testnet and returns the appropriate BIP70 chain name.
  * @return CBaseChainParams::MAX_NETWORK_TYPES if an invalid combination is given. CBaseChainParams::MAIN by default.
  */
 std::string ChainNameFromCommandLine();
-
-/**
- * Return true if SelectBaseParamsFromCommandLine() has been called to select
- * a network.
- */
-bool AreBaseParamsConfigured();
 
 extern Container<CBaseChainParams> cGlobalChainBaseParams;
 

--- a/src/globals/chainparamsbaseglobals.cpp
+++ b/src/globals/chainparamsbaseglobals.cpp
@@ -1,0 +1,10 @@
+// Copyright (c) 2010 Satoshi Nakamoto
+// Copyright (c) 2009-2014 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "globals/chainparamsbaseglobals.h"
+
+#include "chainparamsbase.h"
+
+Container<CBaseChainParams> cGlobalChainBaseParams;

--- a/src/globals/chainparamsbaseglobals.h
+++ b/src/globals/chainparamsbaseglobals.h
@@ -1,0 +1,16 @@
+// Copyright (c) 2014 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_GLOBALS_CHAINPARAMSBASE_H
+#define BITCOIN_GLOBALS_CHAINPARAMSBASE_H
+
+#include "templates.hpp"
+
+#include <string>
+
+class CBaseChainParams;
+
+extern Container<CBaseChainParams> cGlobalChainBaseParams;
+
+#endif // BITCOIN_GLOBALS_CHAINPARAMSBASE_H

--- a/src/globals/chainparamsglobals.cpp
+++ b/src/globals/chainparamsglobals.cpp
@@ -1,0 +1,29 @@
+// Copyright (c) 2010 Satoshi Nakamoto
+// Copyright (c) 2009-2014 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "globals/chainparamsglobals.h"
+
+#include "chainparams.h"
+#include "globals/chainparamsbaseglobals.h"
+
+Container<CChainParams> cGlobalChainParams;
+static Container<CChainParams> cGlobalSwitchingChainParams;
+
+const CChainParams& Params()
+{
+    return cGlobalChainParams.Get();
+}
+
+const CChainParams& Params(const std::string& chain)
+{
+    cGlobalSwitchingChainParams.Set(CChainParams::Factory(chain));
+    return cGlobalSwitchingChainParams.Get();
+}
+
+void SelectParams(const std::string& network)
+{
+    cGlobalChainBaseParams.Set(CBaseChainParams::Factory(network));
+    cGlobalChainParams.Set(CChainParams::Factory(network));
+}

--- a/src/globals/chainparamsglobals.h
+++ b/src/globals/chainparamsglobals.h
@@ -1,0 +1,34 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2014 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_GLOBALS_CHAINPARAMS_H
+#define BITCOIN_GLOBALS_CHAINPARAMS_H
+
+#include "templates.hpp"
+
+#include <string>
+
+class CChainParams;
+
+extern Container<CChainParams> cGlobalChainParams;
+
+/**
+ * Return the currently selected parameters. This won't change after app
+ * startup, except for unit tests.
+ */
+const CChainParams& Params();
+
+/**
+ * @returns CChainParams for the given BIP70 chain name.
+ */
+const CChainParams& Params(const std::string& chain);
+
+/**
+ * Sets the params returned by Params() to those for the given BIP70 chain name.
+ * @throws std::runtime_error when the chain is not supported.
+ */
+void SelectParams(const std::string& chain);
+
+#endif // BITCOIN_GLOBALS_CHAINPARAMS_H

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -389,11 +389,10 @@ std::string HelpMessage(HelpMessageMode mode)
     {
         strUsage += HelpMessageOpt("-printpriority", strprintf("Log transaction priority and fee per kB when mining blocks (default: %u)", 0));
         strUsage += HelpMessageOpt("-privdb", strprintf("Sets the DB_PRIVATE flag in the wallet db environment (default: %u)", 1));
-        strUsage += HelpMessageOpt("-regtest", "Enter regression test mode, which uses a special chain in which blocks can be solved instantly. "
-            "This is intended for regression testing tools and app development.");
     }
     strUsage += HelpMessageOpt("-shrinkdebugfile", _("Shrink debug.log file on client startup (default: 1 when no -debug)"));
-    strUsage += HelpMessageOpt("-testnet", _("Use the test network"));
+
+    AppendParamsHelpMessages(strUsage, showDebug);
 
     strUsage += HelpMessageGroup(_("Node relay options:"));
     strUsage += HelpMessageOpt("-datacarrier", strprintf(_("Relay and mine data carrier transactions (default: %u)"), 1));

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -572,8 +572,10 @@ int main(int argc, char *argv[])
     // - Needs to be done before createOptionsModel
 
     // Check for -testnet or -regtest parameter (Params() calls are only valid after this clause)
-    if (!SelectParamsFromCommandLine()) {
-        QMessageBox::critical(0, QObject::tr("Bitcoin Core"), QObject::tr("Error: Invalid combination of -regtest and -testnet."));
+    try {
+        SelectParams(ChainNameFromCommandLine());
+    } catch(std::exception &e) {
+        QMessageBox::critical(0, QObject::tr("Bitcoin Core"), QObject::tr("Error: %1.").arg(e.what()));
         return 1;
     }
 #ifdef ENABLE_WALLET

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -648,7 +648,7 @@ void StartRPCThreads()
 
     std::vector<ip::tcp::endpoint> vEndpoints;
     bool bBindAny = false;
-    int defaultPort = GetArg("-rpcport", BaseParams().RPCPort());
+    int defaultPort = GetArg("-rpcport", cGlobalChainBaseParams.Get().RPCPort());
     if (!mapArgs.count("-rpcallowip")) // Default to loopback if not allowing external IPs
     {
         vEndpoints.push_back(ip::tcp::endpoint(boost::asio::ip::address_v6::loopback(), defaultPort));

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -6,6 +6,8 @@
 #include "rpcserver.h"
 
 #include "base58.h"
+#include "chainparamsbase.h"
+#include "globals/chainparamsbaseglobals.h"
 #include "init.h"
 #include "random.h"
 #include "sync.h"

--- a/src/templates.hpp
+++ b/src/templates.hpp
@@ -1,0 +1,42 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2014 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_TEMPLATES_H
+#define BITCOIN_TEMPLATES_H
+
+#include <assert.h>
+#include <cstddef>
+
+template<typename T>
+class Container
+{
+    T* pObj;
+public:
+    Container() : pObj(NULL) {}
+    Container(T* pObjIn) : pObj(pObjIn) {}
+    ~Container()
+    {
+        if (!IsNull())
+            delete(pObj);
+    }
+
+    bool IsNull() const
+    {
+        return pObj == NULL;
+    }
+    const T& Get() const
+    {
+        assert(!IsNull());
+        return *pObj;
+    }
+    void Set(T* pObjIn)
+    {
+        if (!IsNull())
+            delete(pObj);
+        pObj = pObjIn;
+    }
+};
+
+#endif // BITCOIN_TEMPLATES_H

--- a/src/test/alert_tests.cpp
+++ b/src/test/alert_tests.cpp
@@ -15,6 +15,7 @@
 #include "main.h"
 #include "serialize.h"
 #include "streams.h"
+#include "templates.hpp"
 #include "util.h"
 #include "utilstrencodings.h"
 
@@ -202,8 +203,8 @@ BOOST_AUTO_TEST_CASE(PartitionAlert)
     // Test PartitionCheck
     CCriticalSection csDummy;
     CBlockIndex indexDummy[100];
-    CChainParams& params = Params(CBaseChainParams::MAIN);
-    int64_t nPowTargetSpacing = params.GetConsensus().nPowTargetSpacing;
+    const Container<CChainParams> cTestChainParams(CChainParams::Factory(CBaseChainParams::MAIN));
+    int64_t nPowTargetSpacing = cTestChainParams.Get().GetConsensus().nPowTargetSpacing;
 
     // Generate fake blockchain timestamps relative to
     // an arbitrary time:

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -224,7 +224,7 @@ int LogPrintStr(const std::string &str)
         ret = fwrite(str.data(), 1, str.size(), stdout);
         fflush(stdout);
     }
-    else if (fPrintToDebugLog && AreBaseParamsConfigured())
+    else if (fPrintToDebugLog && !cGlobalChainBaseParams.IsNull())
     {
         static bool fStartedNewLine = true;
         boost::call_once(&DebugPrintInit, debugPrintInitFlag);
@@ -448,7 +448,7 @@ const boost::filesystem::path &GetDataDir(bool fNetSpecific)
         path = GetDefaultDataDir();
     }
     if (fNetSpecific)
-        path /= BaseParams().DataDir();
+        path /= cGlobalChainBaseParams.Get().DataDir();
 
     fs::create_directories(path);
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -10,6 +10,7 @@
 #include "util.h"
 
 #include "chainparamsbase.h"
+#include "globals/chainparamsbaseglobals.h"
 #include "random.h"
 #include "serialize.h"
 #include "sync.h"


### PR DESCRIPTION
This shares the first commit with #6230.
This is an alternative to https://github.com/theuni/bitcoin/commit/123f3b0dcef29355060290d56138ff99be212007 which @theuni wasn't even proposing yet. But I would like your feedback on the factory and the container (which are shared with #6068 ).
This is blocking #6229 and #5229. 
EDIT:
The fixup commit cleaning up the includes ~~may make more sense after more of #5970 (for example, #6163, we're not that far away from making miner.cpp independent from the chainparams globals)~~ is left for later.
