### PR TITLE
Fix null id in RPC response during startup

### DIFF
--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -930,13 +930,6 @@ static bool HTTPReq_JSONRPC(AcceptedConnection *conn,
         if (!valRequest.read(strRequest))
             throw JSONRPCError(RPC_PARSE_ERROR, "Parse error");
 
-        // Return immediately if in warmup
-        {
-            LOCK(cs_rpcWarmup);
-            if (fRPCInWarmup)
-                throw JSONRPCError(RPC_IN_WARMUP, rpcWarmupStatus);
-        }
-
         string strReply;
 
         // singleton request
@@ -1008,6 +1001,13 @@ void ServiceConnection(AcceptedConnection *conn)
 
 UniValue CRPCTable::execute(const std::string &strMethod, const UniValue &params) const
 {
+    // Return immediately if in warmup
+    {
+        LOCK(cs_rpcWarmup);
+        if (fRPCInWarmup)
+            throw JSONRPCError(RPC_IN_WARMUP, rpcWarmupStatus);
+    }
+
     // Find method
     const CRPCCommand *pcmd = tableRPC[strMethod];
     if (!pcmd)


### PR DESCRIPTION
When processing RPC commands during warmup phase, parse the
request object before returning an error so that id value can
be used in the response.

Prior to this commit, RPC commands sent during Bitcoin's
warmup/startup phase were responded to with a JSON-RPC error
with an id of null, which violated the JSON-RPC 2.0 spec:

id: This member is REQUIRED. It MUST be the same as the value
of the id member in the Request Object. If there was an error
in detecting the id in the Request object (e.g. Parse
error/Invalid Request), it MUST be Null.
