### PR TITLE
Move recently introduced CTransAction::IsEquivalentTo to CWalletTx

### DIFF
--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -87,15 +87,6 @@ CTransaction& CTransaction::operator=(const CTransaction &tx) {
     return *this;
 }
 
-bool CTransaction::IsEquivalentTo(const CTransaction& tx) const
-{
-	CMutableTransaction tx1 = *this;
-	CMutableTransaction tx2 = tx;
-	for (unsigned int i = 0; i < tx1.vin.size(); i++) tx1.vin[i].scriptSig = CScript();
-	for (unsigned int i = 0; i < tx2.vin.size(); i++) tx2.vin[i].scriptSig = CScript();
-	return CTransaction(tx1) == CTransaction(tx2);
-}
-
 CAmount CTransaction::GetValueOut() const
 {
     CAmount nValueOut = 0;

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -222,9 +222,6 @@ public:
         return hash;
     }
 
-    // True if only scriptSigs are different
-    bool IsEquivalentTo(const CTransaction& tx) const;
-
     // Return sum of txouts.
     CAmount GetValueOut() const;
     // GetValueIn() is a method on CCoinsViewCache, because

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1331,6 +1331,15 @@ bool CWalletTx::IsTrusted() const
     return true;
 }
 
+bool CWalletTx::IsEquivalentTo(const CWalletTx& tx) const
+{
+        CMutableTransaction tx1 = *this;
+        CMutableTransaction tx2 = tx;
+        for (unsigned int i = 0; i < tx1.vin.size(); i++) tx1.vin[i].scriptSig = CScript();
+        for (unsigned int i = 0; i < tx2.vin.size(); i++) tx2.vin[i].scriptSig = CScript();
+        return CTransaction(tx1) == CTransaction(tx2);
+}
+
 std::vector<uint256> CWallet::ResendWalletTransactionsBefore(int64_t nTime)
 {
     std::vector<uint256> result;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -378,6 +378,9 @@ public:
         return (GetDebit(filter) > 0);
     }
 
+    // True if only scriptSigs are different
+    bool IsEquivalentTo(const CWalletTx& tx) const;
+
     bool IsTrusted() const;
 
     bool WriteToDisk(CWalletDB *pwalletdb);


### PR DESCRIPTION
CTransAction::IsEquivalentTo was introduced in #5881.
This functionality is only used in the wallet, and should never have been added to the primitive transaction type.
