### PR TITLE
assets-attribution: Update typicons to MIT license

### DIFF
--- a/doc/assets-attribution.md
+++ b/doc/assets-attribution.md
@@ -6,7 +6,7 @@ The following is a list of assets used in the bitcoin source and their proper at
 ### Info
 * Icon Pack: Typicons (http://typicons.com)
 * Designer: Stephen Hutchings (and more)
-* License: CC BY-SA
+* License: MIT
 * Site: [https://github.com/stephenhutchings/typicons.font](https://github.com/stephenhutchings/typicons.font)
 
 ### Assets Used
@@ -29,7 +29,7 @@ Jonas Schnelli
 ### Info
 * Designer: Jonas Schnelli
 * Bitcoin Icon: (based on the original bitcoin logo from Bitboy)
-* Some icons are based on Stephan Hutchings Typicons (these are under CC BY-SA license)
+* Some icons are based on Stephan Hutchings Typicons
 * License: MIT
 
 ### Assets Used


### PR DESCRIPTION
Per #6367 ...

stephenhutchings commented 3 Jul 2015, 6:35 GMT:

> Hi Luke, happy for these to be distributed under the terms of the MIT licence.
> Let me know if you need anything further from me.

Note, this can be cleanly merged to both master and 0.11 branches.
