### PR TITLE
banlist updates

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1455,10 +1455,7 @@ void DumpData()
     DumpAddresses();
 
     if (CNode::BannedSetIsDirty())
-    {
         DumpBanlist();
-        CNode::SetBannedSetDirty(false);
-    }
 }
 
 void static ProcessOneShot()
@@ -2484,14 +2481,14 @@ bool CBanDB::Read(banmap_t& banSet)
 void DumpBanlist()
 {
     int64_t nStart = GetTimeMillis();
-
-    CNode::SweepBanned(); //clean unused entries (if bantime has expired)
+    CNode::SweepBanned(); // clean unused entries (if bantime has expired)
 
     CBanDB bandb;
     banmap_t banmap;
     CNode::GetBanned(banmap);
-    bandb.Write(banmap);
+    if (bandb.Write(banmap))
+        CNode::SetBannedSetDirty(false);
 
     LogPrint("net", "Flushed %d banned node ips/subnets to banlist.dat  %dms\n",
-             banmap.size(), GetTimeMillis() - nStart);
+        banmap.size(), GetTimeMillis() - nStart);
 }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1909,15 +1909,16 @@ void StartNode(boost::thread_group& threadGroup, CScheduler& scheduler)
     //try to read stored banlist
     CBanDB bandb;
     banmap_t banmap;
-    if (!bandb.Read(banmap))
+    if (bandb.Read(banmap)) {
+        CNode::SetBanned(banmap); // thread save setter
+        CNode::SetBannedSetDirty(false); // no need to write down, just read data
+        CNode::SweepBanned(); // sweep out unused entries
+
+        LogPrint("net", "Loaded %d banned node ips/subnets from banlist.dat  %dms\n",
+            banmap.size(), GetTimeMillis() - nStart);
+    } else
         LogPrintf("Invalid or missing banlist.dat; recreating\n");
 
-    CNode::SetBanned(banmap); //thread save setter
-    CNode::SetBannedSetDirty(false); //no need to write down just read or nonexistent data
-    CNode::SweepBanned(); //sweap out unused entries
-
-    LogPrintf("Loaded %i addresses from peers.dat  %dms\n",
-           addrman.size(), GetTimeMillis() - nStart);
     fAddressesInitialized = true;
 
     if (semOutbound == NULL) {

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1455,9 +1455,7 @@ void DumpAddresses()
 void DumpData()
 {
     DumpAddresses();
-
-    if (CNode::BannedSetIsDirty())
-        DumpBanlist();
+    DumpBanlist();
 }
 
 void static ProcessOneShot()
@@ -2474,21 +2472,25 @@ bool CBanDB::Read(banmap_t& banSet)
         // ... verify the network matches ours
         if (memcmp(pchMsgTmp, Params().MessageStart(), sizeof(pchMsgTmp)))
             return error("%s: Invalid network magic number", __func__);
-        
+
         // de-serialize address data into one CAddrMan object
         ssBanlist >> banSet;
     }
     catch (const std::exception& e) {
         return error("%s: Deserialize or I/O error - %s", __func__, e.what());
     }
-    
+
     return true;
 }
 
 void DumpBanlist()
 {
-    int64_t nStart = GetTimeMillis();
     CNode::SweepBanned(); // clean unused entries (if bantime has expired)
+
+    if (!CNode::BannedSetIsDirty())
+        return;
+
+    int64_t nStart = GetTimeMillis();
 
     CBanDB bandb;
     banmap_t banmap;


### PR DESCRIPTION
banlist: update set dirty to be more fine grained
- move the SetBannedSetDirty(false) call from DumpData() into DumpBanlist()
- ensure we only set false, if the write succeeded

banlist: better handling of banlist in StartNode()
- only start working on/with banlist data, if reading in the banlist from
  disk didn't fail
- as CNode::setBannedIsDirty is false (default) when reading fails, we
  don't need to explicitly set it to false to prevent writing banlist.dat
  in that case either

banlist: add more banlist infos to log / add GUI signal
- to match the peers.dat handling also supply a debug.log entry for how
  many entries were loaded from banlist.dat and how long it took
- add a GUI init message for loading the banlist (same as with peers.dat)
- move the same message for peers.dat upwards in the code, to be able to
  reuse the timing variable nStart and also just log, if our read from
  peers.dat didn't fail

banlist (bugfix): allow CNode::SweepBanned() to run on interval
- allows CNode::SweepBanned() to run, even if !CNode::BannedSetIsDirty(),
  because if nBanUntil is over we want the ban to be disabled for these
  nodes
