### PR TITLE
Update Linearize tool to support Windows paths; fix variable scope; update README and example configuration

### DIFF
--- a/contrib/linearize/README.md
+++ b/contrib/linearize/README.md
@@ -3,7 +3,7 @@ Construct a linear, no-fork, best version of the blockchain.
 
 ## Step 1: Download hash list
 
-   $ ./linearize-hashes.py linearize.cfg > hashlist.txt
+    $ ./linearize-hashes.py linearize.cfg > hashlist.txt
 
 Required configuration file settings for linearize-hashes:
 * RPC: rpcuser, rpcpassword
@@ -14,7 +14,7 @@ Optional config file setting for linearize-hashes:
 
 ## Step 2: Copy local block data
 
-   $ ./linearize-data.py linearize.cfg
+    $ ./linearize-data.py linearize.cfg
 
 Required configuration file settings:
 * "input": bitcoind blocks/ directory containing blkNNNNN.dat
@@ -26,7 +26,7 @@ output.
 
 Optional config file setting for linearize-data:
 * "netmagic": network magic number
-* "max_out_sz": maximum output file size (default 1000*1000*1000)
+* "max_out_sz": maximum output file size (default `1000*1000*1000`)
 * "split_timestamp": Split files when a new month is first seen, in addition to
 reaching a maximum file size.
 * "file_timestamp": Set each file's last-modified time to that of the


### PR DESCRIPTION
Windows uses backslashes (\) in paths. An option has been added to allow setting which type of slash to be used. By default the forward slash (/) is used. Also updated the example configuration with the respective option.

I added 'self.' in front of a few variables since without it the script didn't work for me.

Minor fixes for README.
