### PR TITLE
depends: non-qt bumps for 0.12

### DIFF
--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -1,9 +1,8 @@
 package=boost
-$(package)_version=1_55_0
-$(package)_download_path=http://sourceforge.net/projects/boost/files/boost/1.55.0
+$(package)_version=1_58_0
+$(package)_download_path=http://sourceforge.net/projects/boost/files/boost/1.58.0
 $(package)_file_name=$(package)_$($(package)_version).tar.bz2
-$(package)_sha256_hash=fff00023dd79486d444c8e29922f4072e1d451fc5a4d2b6075852ead7f2b7b52
-$(package)_patches=darwin_boost_atomic-1.patch darwin_boost_atomic-2.patch gcc_5_no_cxx11.patch
+$(package)_sha256_hash=fdfc204fc33ec79c99b9a74944c3e54bd78be4f7f15e260c0e2700a36dc7d3e5
 
 define $(package)_set_vars
 $(package)_config_opts_release=variant=release
@@ -26,9 +25,6 @@ $(package)_cxxflags_linux=-fPIC
 endef
 
 define $(package)_preprocess_cmds
-  patch -p2 < $($(package)_patch_dir)/darwin_boost_atomic-1.patch && \
-  patch -p2 < $($(package)_patch_dir)/darwin_boost_atomic-2.patch && \
-  patch -p2 < $($(package)_patch_dir)/gcc_5_no_cxx11.patch && \
   echo "using $(boost_toolset_$(host_os)) : : $($(package)_cxx) : <cxxflags>\"$($(package)_cxxflags) $($(package)_cppflags)\" <linkflags>\"$($(package)_ldflags)\" <archiver>\"$(boost_archiver_$(host_os))\" <striper>\"$(host_STRIP)\"  <ranlib>\"$(host_RANLIB)\" <rc>\"$(host_WINDRES)\" : ;" > user-config.jam
 endef
 

--- a/depends/packages/miniupnpc.mk
+++ b/depends/packages/miniupnpc.mk
@@ -1,8 +1,8 @@
 package=miniupnpc
-$(package)_version=1.9.20140701
+$(package)_version=1.9.20150609
 $(package)_download_path=http://miniupnp.free.fr/files
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
-$(package)_sha256_hash=26f3985bad7768b8483b793448ae49414cdc4451d0ec83e7c1944367e15f9f07
+$(package)_sha256_hash=86e6ccec5b660ba6889893d1f3fca21db087c6466b1a90f495a1f87ab1cd1c36
 
 define $(package)_set_vars
 $(package)_build_opts=CC="$($(package)_cc)"

--- a/depends/packages/native_ccache.mk
+++ b/depends/packages/native_ccache.mk
@@ -1,8 +1,8 @@
 package=native_ccache
-$(package)_version=3.1.9
+$(package)_version=3.2.2
 $(package)_download_path=http://samba.org/ftp/ccache
 $(package)_file_name=ccache-$($(package)_version).tar.bz2
-$(package)_sha256_hash=04d3e2e438ac8d4cc4b110b68cdd61bd59226c6588739a4a386869467f5ced7c
+$(package)_sha256_hash=440f5e15141cc72d2bfff467c977020979810eb800882e3437ad1a7153cce7b2
 
 define $(package)_set_vars
 $(package)_config_opts=

--- a/depends/packages/native_protobuf.mk
+++ b/depends/packages/native_protobuf.mk
@@ -1,8 +1,8 @@
 package=native_protobuf
-$(package)_version=2.5.0
-$(package)_download_path=https://protobuf.googlecode.com/files
+$(package)_version=2.6.1
+$(package)_download_path=https://github.com/google/protobuf/releases/download/v$($(package)_version)
 $(package)_file_name=protobuf-$($(package)_version).tar.bz2
-$(package)_sha256_hash=13bfc5ae543cf3aa180ac2485c0bc89495e3ae711fc6fab4f8ffe90dfb4bb677
+$(package)_sha256_hash=ee445612d544d885ae240ffbcbf9267faa9f593b7b101f21d58beceb92661910
 
 define $(package)_set_vars
 $(package)_config_opts=--disable-shared

--- a/depends/packages/qrencode.mk
+++ b/depends/packages/qrencode.mk
@@ -1,8 +1,8 @@
 package=qrencode
-$(package)_version=3.4.3
+$(package)_version=3.4.4
 $(package)_download_path=https://fukuchi.org/works/qrencode/
 $(package)_file_name=qrencode-$(qrencode_version).tar.bz2
-$(package)_sha256_hash=dfd71487513c871bad485806bfd1fdb304dedc84d2b01a8fb8e0940b50597a98
+$(package)_sha256_hash=efe5188b1ddbcbf98763b819b146be6a90481aac30cfc8d858ab78a19cde1fa5
 
 define $(package)_set_vars
 $(package)_config_opts=--disable-shared -without-tools --disable-sdltest


### PR DESCRIPTION
These are all of the possible bumps for 0.12, qt and openssl excluded. I'm not advocating taking all of these, just listing them all in one place for discussion. Each is a separate commit so that the undesired ones can be easily dropped.
- boost 1.55.0 to 1.58.0: This one's been discussed and I think we're in favor of taking it.
- qrencode 3.4.3 to 3.4.4: [changelog](https://fukuchi.org/works/qrencode/#news) - I can't find specifically what changed, need to compare the sources.
- protobuf 2.5.0 to 2.6.1: [changelog1](https://github.com/google/protobuf/releases/tag/v2.6.0), [changelog2](https://github.com/google/protobuf/releases/tag/v2.6.1) - This one may be risky, might be better to just leave it alone
- ccache to 3.1.9 to 3.2.2: [changelog](https://ccache.samba.org/releasenotes.html) - Looks good
- miniupnpc 1.9.20140701 to 1.9.20150609: [changelog](http://miniupnp.free.fr/files/changelog.php?file=miniupnpc-1.9.20150609.tar.gz)
