### PR TITLE
qt: Force TLS1.0+ for SSL connections

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -48,6 +48,7 @@
 #include <QThread>
 #include <QTimer>
 #include <QTranslator>
+#include <QSslConfiguration>
 
 #if defined(QT_STATICPLUGIN)
 #include <QtPlugin>
@@ -514,6 +515,13 @@ int main(int argc, char *argv[])
 #endif
 #ifdef Q_OS_MAC
     QApplication::setAttribute(Qt::AA_DontShowIconsInMenus);
+#endif
+#if QT_VERSION >= 0x050500
+    // Because of the POODLE attack it is recommended to disable SSLv3 (https://disablessl3.com/),
+    // so set SSL protocols to TLS1.0+.
+    QSslConfiguration sslconf = QSslConfiguration::defaultConfiguration();
+    sslconf.setProtocol(QSsl::TlsV1_0OrLater);
+    QSslConfiguration::setDefaultConfiguration(sslconf);
 #endif
 
     // Register meta types used for QMetaObject::invokeMethod


### PR DESCRIPTION
I recently got a notification that my suggestion for a flag to force TLS has been implemented and will be in Qt 5.5.0: https://bugreports.qt.io/browse/QTBUG-43168

Because of the POODLE attack it is recommended to disable SSLv3 (https://disablessl3.com/).

So on Qt 5.5.0+ set the flag in the default QSslConfiguration (used for payment requests) to require SSL protocols TLS1.0+.
