### PR TITLE
Refactor user-agent handling to be more extensible

### DIFF
--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -121,7 +121,7 @@ bool CAlert::AppliesTo(int nVersion, std::string strSubVerIn) const
 
 bool CAlert::AppliesToMe() const
 {
-    return AppliesTo(PROTOCOL_VERSION, FormatSubVersion(CLIENT_NAME, CLIENT_VERSION, std::vector<std::string>()));
+    return AppliesTo(PROTOCOL_VERSION, FormatUserAgent(vUserAgentCodebases));
 }
 
 bool CAlert::RelayTo(CNode* pnode) const

--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -62,8 +62,21 @@ extern const std::string CLIENT_BUILD;
 extern const std::string CLIENT_DATE;
 
 
+class BitcoinUserAgentCodebase {
+public:
+    std::string name;
+    std::string version;
+    std::vector<std::string> comments;
+
+    BitcoinUserAgentCodebase(const std::string strName, const std::string strVersion, const std::vector<std::string> vstrComments = std::vector<std::string>());
+    BitcoinUserAgentCodebase(const std::string strName, const std::string strVersion, const std::string strComment);
+};
+
+extern std::vector<BitcoinUserAgentCodebase> vUserAgentCodebases;
+
+std::string FormatVersion(int nVersion);
 std::string FormatFullVersion();
-std::string FormatSubVersion(const std::string& name, int nClientVersion, const std::vector<std::string>& comments);
+std::string FormatUserAgent(const std::vector<BitcoinUserAgentCodebase>);
 
 #endif // WINDRES_PREPROC
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -535,7 +535,7 @@ void CNode::PushVersion()
     else
         LogPrint("net", "send version message: version %d, blocks=%d, us=%s, peer=%d\n", PROTOCOL_VERSION, nBestHeight, addrMe.ToString(), id);
     PushMessage("version", PROTOCOL_VERSION, nLocalServices, nTime, addrYou, addrMe,
-                nLocalHostNonce, FormatSubVersion(CLIENT_NAME, CLIENT_VERSION, std::vector<string>()), nBestHeight, true);
+                nLocalHostNonce, FormatUserAgent(vUserAgentCodebases), nBestHeight, true);
 }
 
 

--- a/src/rpcnet.cpp
+++ b/src/rpcnet.cpp
@@ -412,7 +412,7 @@ Value getnetworkinfo(const Array& params, bool fHelp)
     Object obj;
     obj.push_back(Pair("version",       CLIENT_VERSION));
     obj.push_back(Pair("subversion",
-        FormatSubVersion(CLIENT_NAME, CLIENT_VERSION, std::vector<string>())));
+        FormatUserAgent(vUserAgentCodebases)));
     obj.push_back(Pair("protocolversion",PROTOCOL_VERSION));
     obj.push_back(Pair("localservices",       strprintf("%016x", nLocalServices)));
     obj.push_back(Pair("timeoffset",    GetTimeOffset()));

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -342,15 +342,15 @@ BOOST_AUTO_TEST_CASE(test_FormatParagraph)
     BOOST_CHECK_EQUAL(FormatParagraph("test test", 4, 4), "test\n    test");
 }
 
-BOOST_AUTO_TEST_CASE(test_FormatSubVersion)
+BOOST_AUTO_TEST_CASE(test_FormatUserAgent)
 {
-    std::vector<std::string> comments;
-    comments.push_back(std::string("comment1"));
-    std::vector<std::string> comments2;
-    comments2.push_back(std::string("comment1"));
-    comments2.push_back(std::string("comment2"));
-    BOOST_CHECK_EQUAL(FormatSubVersion("Test", 99900, std::vector<std::string>()),std::string("/Test:0.9.99/"));
-    BOOST_CHECK_EQUAL(FormatSubVersion("Test", 99900, comments),std::string("/Test:0.9.99(comment1)/"));
-    BOOST_CHECK_EQUAL(FormatSubVersion("Test", 99900, comments2),std::string("/Test:0.9.99(comment1; comment2)/"));
+    std::vector<BitcoinUserAgentCodebase> vUA;
+    vUA.push_back(BitcoinUserAgentCodebase("Test", FormatVersion(99900)));
+    BitcoinUserAgentCodebase& codebase = vUA[0];
+    BOOST_CHECK_EQUAL(FormatUserAgent(vUA), std::string("/Test:0.9.99/"));
+    codebase.comments.push_back(std::string("comment1"));
+    BOOST_CHECK_EQUAL(FormatUserAgent(vUA), std::string("/Test:0.9.99(comment1)/"));
+    codebase.comments.push_back(std::string("comment2"));
+    BOOST_CHECK_EQUAL(FormatUserAgent(vUA), std::string("/Test:0.9.99(comment1; comment2)/"));
 }
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
A global vector keeps track of involved codebases.
New items can be added by patches, by repeating a 3-line comment.
