### PR TITLE
[bitcoin-cli] improve error output

### DIFF
--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -190,6 +190,15 @@ int CommandLineRPC(int argc, char *argv[])
                         throw CConnectionFailed("server in warmup");
                     strPrint = "error: " + error.write();
                     nRet = abs(code);
+                    if (error.isObject())
+                    {
+                        UniValue errCode = find_value(error, "code");
+                        UniValue errMsg  = find_value(error, "message");
+                        strPrint = errCode.isNull() ? "" : "error code: "+errCode.getValStr()+"\n";
+
+                        if (errMsg.isStr())
+                            strPrint += "error message:\n"+errMsg.get_str();
+                    }
                 } else {
                     // Result
                     if (result.isNull())


### PR DESCRIPTION
**[only affects bitcoin-cli]**

At the moment, errors in bitcoin-cli are sent to stderr as compact json string. Example:

```
jonasschnelli$ ./src/bitcoin-cli -regtest sendtoaddress 276536543
error: {"code":-1,"message":"sendtoaddress \"bitcoinaddress\" amount ( \"comment\" \"comment-to\" 
subtractfeefromamount )\n\nSend an amount to a given address. The amount is a real and is rounded to the nearest 0.00000001\n\nArguments:\n1. \"bitcoinaddress\"  (string, required) The bitcoin address to 
send to.\n2. \"amount\"      (numeric, required) The amount in btc to send. eg 0.1\n3. \"comment\"     (string, optional) A comment used to store what the transaction is for. \n                             This is not part 
of the transaction, just kept in your wallet.\n4. \"comment-to\"  (string, optional) A comment to store the name of the person or organization \n                             to which you're sending the transaction. This is 
not part of the \n                             transaction, just kept in your wallet.\n5. subtractfeefromamount  (boolean, optional, default=false) The fee will be deducted from the amount being sent.\n                             
The recipient will receive less bitcoins than you enter in the amount field.\n\nResult:\n\"transactionid\"  (string) The transaction id.\n\nExamples:\n> bitcoin-cli sendtoaddress 
\"1M72Sfpbz1BPpXFHz9m3CdqATR44Jvaydd\" 0.1\n> bitcoin-cli sendtoaddress \"1M72Sfpbz1BPpXFHz9m3CdqATR44Jvaydd\" 0.1 \"donation\" \"seans outpost\"\n> bitcoin-cli 
sendtoaddress \"1M72Sfpbz1BPpXFHz9m3CdqATR44Jvaydd\" 0.1 \"\" \"\" true\n> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", \"method\": \"sendtoaddress\", \"params\": 
[\"1M72Sfpbz1BPpXFHz9m3CdqATR44Jvaydd\", 0.1, \"donation\", \"seans outpost\"] }' -H 'content-type: text/plain;' http://127.0.0.1:8332/\n"}

```

This PR would format the error message and error code so that it's better readable. Example after this PR:

```
jonasschnelli$ ./src/bitcoin-cli --regtest sendtoaddress mvDv4Z
error code: -1
error message:
sendtoaddress "bitcoinaddress" amount ( "comment" "comment-to" subtractfeefromamount )

Send an amount to a given address. The amount is a real and is rounded to the nearest 0.00000001

Arguments:
1. "bitcoinaddress"  (string, required) The bitcoin address to send to.
2. "amount"      (numeric, required) The amount in btc to send. eg 0.1
3. "comment"     (string, optional) A comment used to store what the transaction is for. 
                             This is not part of the transaction, just kept in your wallet.
4. "comment-to"  (string, optional) A comment to store the name of the person or organization 
                             to which you're sending the transaction. This is not part of the 
                             transaction, just kept in your wallet.
5. subtractfeefromamount  (boolean, optional, default=false) The fee will be deducted from the amount being sent.
                             The recipient will receive less bitcoins than you enter in the amount field.

Result:
"transactionid"  (string) The transaction id.

Examples:
> bitcoin-cli sendtoaddress "1M72Sfpbz1BPpXFHz9m3CdqATR44Jvaydd" 0.1
> bitcoin-cli sendtoaddress "1M72Sfpbz1BPpXFHz9m3CdqATR44Jvaydd" 0.1 "donation" "seans outpost"
> bitcoin-cli sendtoaddress "1M72Sfpbz1BPpXFHz9m3CdqATR44Jvaydd" 0.1 "" "" true
> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id":"curltest", "method": "sendtoaddress", "params": ["1M72Sfpbz1BPpXFHz9m3CdqATR44Jvaydd", 0.1, "donation", "seans outpost"] }' -H 'content-type: text/plain;' http://127.0.0.1:8332/

```
