### PR TITLE
Allow OP_RETURN with two PUSHDATA

### DIFF
--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -53,8 +53,10 @@ bool Solver(const CScript& scriptPubKey, txnouttype& typeRet, vector<vector<unsi
         mTemplates.insert(make_pair(TX_MULTISIG, CScript() << OP_SMALLINTEGER << OP_PUBKEYS << OP_SMALLINTEGER << OP_CHECKMULTISIG));
 
         // Empty, provably prunable, data-carrying output
-        if (GetBoolArg("-datacarrier", true))
-            mTemplates.insert(make_pair(TX_NULL_DATA, CScript() << OP_RETURN << OP_SMALLDATA));
+        if (GetBoolArg("-datacarrier", true)) {
+                mTemplates.insert(make_pair(TX_NULL_DATA, CScript() << OP_RETURN << OP_SMALLDATA << OP_SMALLDATA));
+                mTemplates.insert(make_pair(TX_NULL_DATA, CScript() << OP_RETURN << OP_SMALLDATA));
+        }
         mTemplates.insert(make_pair(TX_NULL_DATA, CScript() << OP_RETURN));
     }
 
@@ -77,6 +79,7 @@ bool Solver(const CScript& scriptPubKey, txnouttype& typeRet, vector<vector<unsi
 
         opcodetype opcode1, opcode2;
         vector<unsigned char> vch1, vch2;
+        size_t datacarrierbytes = 0;
 
         // Compare
         CScript::const_iterator pc1 = script1.begin();
@@ -143,7 +146,8 @@ bool Solver(const CScript& scriptPubKey, txnouttype& typeRet, vector<vector<unsi
             else if (opcode2 == OP_SMALLDATA)
             {
                 // small pushdata, <= nMaxDatacarrierBytes
-                if (vch1.size() > nMaxDatacarrierBytes)
+                datacarrierbytes += vch1.size();
+                if (datacarrierbytes > nMaxDatacarrierBytes)
                     break;
             }
             else if (opcode1 != opcode2 || vch1 != vch2)

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -358,6 +358,25 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
     t.vout[0].scriptPubKey = CScript() << OP_RETURN << ParseHex("04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef3804678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef3800");
     BOOST_CHECK(!IsStandardTx(t, reason));
 
+    // 80-byte TX_NULL_DATA two split (standard)
+    t.vout[0].scriptPubKey = CScript() << OP_RETURN
+                                       << ParseHex("11223344556677889900112233445566778899001122334455667788990011223344556677889900")
+                                       << ParseHex("11223344556677889900112233445566778899001122334455667788990011223344556677889900");
+    BOOST_CHECK(IsStandardTx(t, reason));
+
+    // 81-byte TX_NULL_DATA split in two (non-standard)
+    t.vout[0].scriptPubKey = CScript() << OP_RETURN
+                                       << ParseHex("11223344556677889900112233445566778899001122334455667788990011223344556677889900")
+                                       << ParseHex("1122334455667788990011223344556677889900112233445566778899001122334455667788990000");
+    BOOST_CHECK(!IsStandardTx(t, reason));
+
+    // 60-byte TX_NULL_DATA split in three (non-standard)
+    t.vout[0].scriptPubKey = CScript() << OP_RETURN
+                                       << ParseHex("1122334455667788990011223344556677889900")
+                                       << ParseHex("1122334455667788990011223344556677889900")
+                                       << ParseHex("1122334455667788990011223344556677889900");
+    BOOST_CHECK(!IsStandardTx(t, reason));
+
     // TX_NULL_DATA w/o PUSHDATA
     t.vout.resize(1);
     t.vout[0].scriptPubKey = CScript() << OP_RETURN;


### PR DESCRIPTION
Having two PUSHDATA allows the use of a marker for SPV bloom filtering.

This avoids having two transactions, where the first one triggers the
bloom filter.
