### PR TITLE
Add BITCOIND_SIGTERM_TIMEOUT to OpenRC init scripts

### DIFF
--- a/contrib/init/bitcoind.openrc
+++ b/contrib/init/bitcoind.openrc
@@ -32,7 +32,11 @@ required_files="${BITCOIND_CONFIGFILE}"
 start_stop_daemon_args="-u ${BITCOIND_USER} \
 			-N ${BITCOIND_NICE} -w 2000"
 pidfile="${BITCOIND_PIDFILE}"
-retry=60
+
+# The retry schedule to use when stopping the daemon. Could be either
+# a timeout in seconds or multiple signal/timeout pairs (like
+# "SIGKILL/180 SIGTERM/300")
+retry="${BITCOIND_SIGTERM_TIMEOUT}"
 
 depend() {
 	need localmount net

--- a/contrib/init/bitcoind.openrcconf
+++ b/contrib/init/bitcoind.openrcconf
@@ -25,3 +25,9 @@
 # Additional options (avoid -conf and -datadir, use flags above)
 BITCOIND_OPTS="-disablewallet"
 
+# The timeout in seconds OpenRC will wait for bitcoind to terminate
+# after a SIGTERM has been raised.
+# Note that this will be mapped as argument to start-stop-daemon's
+# '--retry' option, which means you can specify a retry schedule
+# here. For more information see man 8 start-stop-daemon.
+BITCOIND_SIGTERM_TIMEOUT=60


### PR DESCRIPTION
This allows users to specify, e.g. raise, the default timeout of 60
seconds. Some bitcoind instances, especially long running ones on slow
hardware, require a higher timeout for a clean shut down.

Also add a comment to bitcoind.openrc's 'retry=', since it is not
obvious from the variable name what it does.
