### PR TITLE
Floating network relay fee increase, if memory pool grows too large.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -112,6 +112,7 @@ BITCOIN_CORE_H = \
   noui.h \
   policy/fees.h \
   policy/policy.h \
+  poolman.h \
   pow.h \
   primitives/block.h \
   primitives/transaction.h \
@@ -178,6 +179,7 @@ libbitcoin_server_a_SOURCES = \
   noui.cpp \
   policy/fees.cpp \
   policy/policy.cpp \
+  poolman.cpp \
   pow.cpp \
   rest.cpp \
   rpcblockchain.cpp \

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -282,11 +282,11 @@ std::string HelpMessage(HelpMessageMode mode)
     }
     strUsage += HelpMessageOpt("-datadir=<dir>", _("Specify data directory"));
     strUsage += HelpMessageOpt("-dbcache=<n>", strprintf(_("Set database cache size in megabytes (%d to %d, default: %d)"), nMinDbCache, nMaxDbCache, nDefaultDbCache));
-    strUsage += HelpMessageOpt("-janitorinterval=<n>", _("Number of seconds between each mempool janitor run (default: 10 minutes, 0=disable)"));
+    strUsage += HelpMessageOpt("-janitorinterval=<n>", _("Number of seconds between each mempool janitor run (default: 10 minutes; 0 = disable)"));
     strUsage += HelpMessageOpt("-loadblock=<file>", _("Imports blocks from external blk000??.dat file") + " " + _("on startup"));
     strUsage += HelpMessageOpt("-maxorphantx=<n>", strprintf(_("Keep at most <n> unconnectable transactions in memory (default: %u)"), DEFAULT_MAX_ORPHAN_TRANSACTIONS));
-    strUsage += HelpMessageOpt("-mempoollowwater=<n>", _("When mempool TX bytes decreases below size <n>, set relay fee back to default; stop floating relay fee (default=-1=mempoolhighwater/2, 0=always float)"));
-    strUsage += HelpMessageOpt("-mempoolhighwater=<n>", _("When mempool TX bytes exceeds size <n>, increase relay fee (default=0=disabled)"));
+    strUsage += HelpMessageOpt("-mempoollowwater=<n>", _("When mempool TX bytes decreases below size <n>, set relay fee back to default; stop floating relay fee (default = -1 = mempoolhighwater/2; 0 = always float)"));
+    strUsage += HelpMessageOpt("-mempoolhighwater=<n>", _("When mempool TX bytes exceeds size <n>, increase relay fee (default = 0 = disabled)"));
     strUsage += HelpMessageOpt("-par=<n>", strprintf(_("Set the number of script verification threads (%u to %d, 0 = auto, <0 = leave that many cores free, default: %d)"),
         -GetNumCores(), MAX_SCRIPTCHECK_THREADS, DEFAULT_SCRIPTCHECK_THREADS));
 #ifndef WIN32

--- a/src/poolman.cpp
+++ b/src/poolman.cpp
@@ -1,0 +1,96 @@
+
+#include <algorithm>
+#include <vector>
+#include "poolman.h"
+#include "main.h"
+#include "util.h"
+#include "amount.h"
+#include "utiltime.h"
+
+using namespace std;
+
+static int64_t PoolmanLowWater, PoolmanHighWater;
+static bool janitorInit = false;
+static bool floatingFee = false;
+static CFeeRate origTxFee;
+
+void TxMempoolJanitor()
+{
+    int64_t nStart = GetTimeMillis();
+
+    // remember original minimum tx fee
+    if (!janitorInit) {
+        janitorInit = true;
+        origTxFee = ::minRelayTxFee;
+    }
+
+    // query mempool stats
+    unsigned long totalTx = mempool.size();
+    int64_t totalSize = mempool.GetTotalTxSize();
+
+    // if below low water, disable janitor
+    if (totalSize < PoolmanLowWater || totalTx < 2) {
+        if (floatingFee) {
+            floatingFee = false;
+            ::minRelayTxFee = origTxFee;
+        }
+        LogPrint("mempool", "mempool level low, run complete,  %dms\n",
+                 GetTimeMillis() - nStart);
+        return;
+    }
+
+    // if below high water, no more work.  floating fee might be active.
+    if ((int64_t)mempool.GetTotalTxSize() < PoolmanHighWater) {
+        LogPrint("mempool", "mempool level %s, run complete,  %dms\n",
+                 floatingFee ? "draining" : "adequate",
+                 GetTimeMillis() - nStart);
+        return;
+    }
+
+    // we are above high water.  float relay fee in response.
+    floatingFee = true;
+
+    // get sorted list of fees in mempool
+    vector<CFeeRate> vfees;
+    mempool.queryFees(vfees);
+    std::sort(vfees.begin(), vfees.end());
+    std::reverse(vfees.begin(), vfees.end());
+    vfees.resize(vfees.size() / 2);
+
+    // set relay fee to lowest rate of top half of mempool
+    ::minRelayTxFee = vfees.back();
+
+    LogPrint("mempool", "mempool janitor run complete, fee rate %s, %dms\n",
+             ::minRelayTxFee.ToString(),
+             GetTimeMillis() - nStart);
+}
+
+void InitTxMempoolJanitor(CScheduler& scheduler)
+{
+    // mempool janitor execution interval.  default interval: 10 min
+    int janitorInterval = GetArg("-janitorinterval", (60 * 10));
+
+    // mempool janitor low water, high water marks
+    PoolmanHighWater = GetArg("-mempoolhighwater", 0);
+    if (PoolmanHighWater <= 0)
+        PoolmanLowWater = -1;
+    else {
+        PoolmanLowWater = GetArg("-mempoollowwater", -1);
+        if (PoolmanLowWater < 0 || PoolmanLowWater > PoolmanHighWater)
+            PoolmanLowWater = PoolmanHighWater / 2;
+    }
+
+    // if interval too small or zero, janitor is disabled
+    static const int janitorSaneInterval = 10;
+    if ((janitorInterval < janitorSaneInterval) ||
+        (PoolmanHighWater <= 0)) {
+        janitorInterval = 0;
+        PoolmanLowWater = -1;
+        PoolmanHighWater = 0;
+    }
+
+    // start mempool janitor
+    if (janitorInterval > 0)
+        scheduler.scheduleEvery(&TxMempoolJanitor, janitorInterval * 1000);
+}
+

--- a/src/poolman.cpp
+++ b/src/poolman.cpp
@@ -1,13 +1,14 @@
+// Copyright (c) 2015 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <algorithm>
 #include <vector>
-#include "poolman.h"
-#include "main.h"
-#include "util.h"
 #include "amount.h"
+#include "main.h"
+#include "poolman.h"
+#include "util.h"
 #include "utiltime.h"
-
-using namespace std;
 
 static int64_t PoolmanLowWater, PoolmanHighWater;
 static bool janitorInit = false;
@@ -51,7 +52,7 @@ void TxMempoolJanitor()
     floatingFee = true;
 
     // get sorted list of fees in mempool
-    vector<CFeeRate> vfees;
+    std::vector<CFeeRate> vfees;
     mempool.queryFees(vfees);
     std::sort(vfees.begin(), vfees.end());
     std::reverse(vfees.begin(), vfees.end());
@@ -91,6 +92,6 @@ void InitTxMempoolJanitor(CScheduler& scheduler)
 
     // start mempool janitor
     if (janitorInterval > 0)
-        scheduler.scheduleEvery(&TxMempoolJanitor, janitorInterval * 1000);
+        scheduler.scheduleEvery(&TxMempoolJanitor, janitorInterval);
 }
 

--- a/src/poolman.h
+++ b/src/poolman.h
@@ -1,0 +1,8 @@
+#ifndef __BITCOIN_POOLMAN_H__
+#define __BITCOIN_POOLMAN_H__
+
+#include "scheduler.h"
+
+extern void InitTxMempoolJanitor(CScheduler& scheduler);
+
+#endif // __BITCOIN_POOLMAN_H__

--- a/src/poolman.h
+++ b/src/poolman.h
@@ -1,8 +1,12 @@
-#ifndef __BITCOIN_POOLMAN_H__
-#define __BITCOIN_POOLMAN_H__
+// Copyright (c) 2015 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_POOLMAN_H
+#define BITCOIN_POOLMAN_H
 
 #include "scheduler.h"
 
 extern void InitTxMempoolJanitor(CScheduler& scheduler);
 
-#endif // __BITCOIN_POOLMAN_H__
+#endif // BITCOIN_POOLMAN_H

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -311,6 +311,19 @@ void CTxMemPool::queryHashes(vector<uint256>& vtxid)
         vtxid.push_back((*mi).first);
 }
 
+void CTxMemPool::queryFees(vector<CFeeRate>& vfees)
+{
+    vfees.clear();
+
+    LOCK(cs);
+    vfees.reserve(mapTx.size());
+    for (map<uint256, CTxMemPoolEntry>::iterator mi = mapTx.begin(); mi != mapTx.end(); ++mi) {
+        CTxMemPoolEntry& mpe = (*mi).second;
+        CFeeRate rate(mpe.GetFee(), mpe.GetTxSize());
+        vfees.push_back(rate);
+    }
+}
+
 bool CTxMemPool::lookup(uint256 hash, CTransaction& result) const
 {
     LOCK(cs);

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -120,6 +120,7 @@ public:
                         std::list<CTransaction>& conflicts, bool fCurrentEstimate = true);
     void clear();
     void queryHashes(std::vector<uint256>& vtxid);
+    void queryFees(std::vector<CFeeRate>& vfees);
     void pruneSpent(const uint256& hash, CCoins &coins);
     unsigned int GetTransactionsUpdated() const;
     void AddTransactionsUpdated(unsigned int n);


### PR DESCRIPTION
Create a relay fee that adjusts to floods which cause the memory pool to
grow too large (and thus crash the node).  A periodic memory pool janitor runs, scanning the
memory pool total byte size.

If the memory pool is below a "low water" byte size limit, the
-minrelaytxfee minimum relay fee setting is used.

If the memory pool is above a "high water" byte size limit, the
minimum relay fee setting is increased according to the following
algorithm:
- take the top half of the mempool in terms of fee/kb - fee rate
- take the lowest fee rate as the minimum relay fee

The memory pool may continue to grow beyond the high water mark, though
fees to further fill memory pools become increasingly more expensive,
until new blocks reduce the pressure.

The newly increased relay fee remains intact until the memory pool
size falls below the "low water" limit.

The default "low water" limit is 1/2 of the supplied "high water" limit.
