### PR TITLE
Option -limitunconfdepth to reject transactions dependent on a long chain of unconfirmed ones

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -389,6 +389,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageGroup(_("Node relay options:"));
     strUsage += HelpMessageOpt("-datacarrier", strprintf(_("Relay and mine data carrier transactions (default: %u)"), 1));
     strUsage += HelpMessageOpt("-datacarriersize", strprintf(_("Maximum size of data in data carrier transactions we relay and mine (default: %u)"), MAX_OP_RETURN_RELAY));
+    strUsage += HelpMessageOpt("-limitunconfdepth", strprintf(_("Maximum depth of unconfirmed transactions we relay and mine (default: %u, 0 = no limit)"), DEFAULT_LIMIT_UNCONF_DEPTH));
 
     strUsage += HelpMessageGroup(_("Block creation options:"));
     strUsage += HelpMessageOpt("-blockminsize=<n>", strprintf(_("Set minimum block size in bytes (default: %u)"), 0));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -902,6 +902,31 @@ CAmount GetMinRelayFee(const CTransaction& tx, unsigned int nBytes, bool fAllowF
 }
 
 
+static unsigned int TxSearchForLongChain(const CTransaction& tx, const CTxMemPool& pool, unsigned int nDepthLimit, unsigned int nDepth = 0)
+{
+    unsigned int nMaxDepth = nDepth;
+    for (size_t i = 0; i < tx.vin.size(); ++i)
+    {
+        COutPoint outpoint = tx.vin[i].prevout;
+        std::map<uint256, CTxMemPoolEntry>::const_iterator it = pool.mapTx.find(outpoint.hash);
+        if (it == pool.mapTx.end())
+            // Already confirmed
+            continue;
+
+        const unsigned int nParentDepth = nDepth + 1;
+        if (nParentDepth == nDepthLimit)
+            return nParentDepth;
+
+        const CTransaction& txParent = it->second.GetTx();
+        const unsigned int nMaxParentDepth = TxSearchForLongChain(txParent, pool, nDepthLimit, nParentDepth);
+        if (nMaxParentDepth == nDepthLimit)
+            return nMaxParentDepth;
+        if (nMaxParentDepth > nMaxDepth)
+            nMaxDepth = nMaxParentDepth;
+    }
+    return nMaxDepth;
+}
+
 bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransaction &tx, bool fLimitFree,
                         bool* pfMissingInputs, bool fRejectAbsurdFee)
 {
@@ -970,6 +995,15 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
         CAmount nValueIn = 0;
         {
         LOCK(pool.cs);
+
+        const int nDepthLimit = GetArg("-limitunconfdepth", DEFAULT_LIMIT_UNCONF_DEPTH);
+        if (nDepthLimit > 0) {
+            const unsigned int nMaxDepth = TxSearchForLongChain(tx, pool, nDepthLimit);
+            if (nMaxDepth >= (unsigned int)nDepthLimit) {
+                return error("AcceptToMemoryPool : rejecting transaction with long unconfirmed chain: %s", tx.GetHash().ToString());
+            }
+        }
+
         CCoinsViewMemPool viewMemPool(pcoinsTip, pool);
         view.SetBackend(viewMemPool);
 

--- a/src/main.h
+++ b/src/main.h
@@ -92,6 +92,7 @@ static const unsigned int BLOCK_DOWNLOAD_WINDOW = 1024;
 static const unsigned int DATABASE_WRITE_INTERVAL = 3600;
 /** Maximum length of reject messages. */
 static const unsigned int MAX_REJECT_MESSAGE_LENGTH = 111;
+static const unsigned int DEFAULT_LIMIT_UNCONF_DEPTH = 0;
 
 /** "reject" message codes */
 static const unsigned char REJECT_MALFORMED = 0x01;


### PR DESCRIPTION
Not sure if there's any long-term benefit to this policy. Thoughts?
