### PR TITLE
Test whether created sockets are select()able

### DIFF
--- a/src/compat.h
+++ b/src/compat.h
@@ -92,4 +92,12 @@ typedef u_int SOCKET;
 size_t strnlen( const char *start, size_t max_len);
 #endif // HAVE_DECL_STRNLEN
 
+bool static inline IsSelectableSocket(SOCKET s) {
+#ifdef WIN32
+    return true;
+#else
+    return (s >= 0 && s < FD_SETSIZE);
+#endif
+}
+
 #endif // BITCOIN_COMPAT_H

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -266,6 +266,9 @@ bool static InterruptibleRecv(char* data, size_t len, int timeout, SOCKET& hSock
         } else { // Other error or blocking
             int nErr = WSAGetLastError();
             if (nErr == WSAEINPROGRESS || nErr == WSAEWOULDBLOCK || nErr == WSAEINVAL) {
+                if (!IsSelectableSocket(hSocket)) {
+                    return false;
+                }
                 struct timeval tval = MillisToTimeval(std::min(endTime - curTime, maxWait));
                 fd_set fdset;
                 FD_ZERO(&fdset);


### PR DESCRIPTION
This provides a belt-and-suspends check against file descriptor overflowing, to fix #6411.
