### PR TITLE
Change "oldstable" to "oldoldstable" for lidb4.8*

### DIFF
--- a/doc/REST-interface.md
+++ b/doc/REST-interface.md
@@ -9,7 +9,7 @@ Supported API
 ####Transactions
 `GET /rest/tx/<TX-HASH>.<bin|hex|json>`
 
-Given a transaction hash: returns a transaction, in binary, hex-encoded binary, or JSON formats.
+Given a transaction hash: returns a transaction in binary, hex-encoded binary, or JSON formats.
 
 For full TX query capability, one must enable the transaction index via "txindex=1" command line / configuration option.
 
@@ -17,7 +17,7 @@ For full TX query capability, one must enable the transaction index via "txindex
 `GET /rest/block/<BLOCK-HASH>.<bin|hex|json>`
 `GET /rest/block/notxdetails/<BLOCK-HASH>.<bin|hex|json>`
 
-Given a block hash: returns a block, in binary, hex-encoded binary or JSON formats.
+Given a block hash: returns a block in binary, hex-encoded binary, or JSON formats.
 
 The HTTP request and response are both handled entirely in-memory, thus making maximum memory usage at least 2.66MB (1 MB max block, plus hex encoding) per request.
 

--- a/doc/REST-interface.md
+++ b/doc/REST-interface.md
@@ -9,8 +9,7 @@ Supported API
 ####Transactions
 `GET /rest/tx/<TX-HASH>.<bin|hex|json>`
 
-Given a transaction hash,
-Returns a transaction, in binary, hex-encoded binary or JSON formats.
+Given a transaction hash: returns a transaction, in binary, hex-encoded binary or JSON formats.
 
 For full TX query capability, one must enable the transaction index via "txindex=1" command line / configuration option.
 
@@ -18,8 +17,7 @@ For full TX query capability, one must enable the transaction index via "txindex
 `GET /rest/block/<BLOCK-HASH>.<bin|hex|json>`
 `GET /rest/block/notxdetails/<BLOCK-HASH>.<bin|hex|json>`
 
-Given a block hash,
-Returns a block, in binary, hex-encoded binary or JSON formats.
+Given a block hash: returns a block, in binary, hex-encoded binary or JSON formats.
 
 The HTTP request and response are both handled entirely in-memory, thus making maximum memory usage at least 2.66MB (1 MB max block, plus hex encoding) per request.
 
@@ -28,8 +26,7 @@ With the /notxdetails/ option JSON response will only contain the transaction ha
 ####Blockheaders
 `GET /rest/headers/<COUNT>/<BLOCK-HASH>.<bin|hex>`
 
-Given a block hash,
-Returns <COUNT> amount of blockheaders in upward direction.
+Given a block hash: returns <COUNT> amount of blockheaders in upward direction.
 
 JSON is not supported.
 
@@ -81,4 +78,4 @@ $ curl localhost:18332/rest/getutxos/checkmempool/b2cdfd7b89def827ff8af7cd9bff76
 
 Risks
 -------------
-Running a webbrowser on the same node with a REST enabled bitcoind can be a risk. Accessing prepared XSS websites could read out tx/block data of your node by placing links like `<script src="http://127.0.0.1:8332/rest/tx/1234567890.json">` which might break the nodes privacy.
+Running a web browser on the same node with a REST enabled bitcoind can be a risk. Accessing prepared XSS websites could read out tx/block data of your node by placing links like `<script src="http://127.0.0.1:8332/rest/tx/1234567890.json">` which might break the nodes privacy.

--- a/doc/REST-interface.md
+++ b/doc/REST-interface.md
@@ -9,7 +9,7 @@ Supported API
 ####Transactions
 `GET /rest/tx/<TX-HASH>.<bin|hex|json>`
 
-Given a transaction hash: returns a transaction, in binary, hex-encoded binary or JSON formats.
+Given a transaction hash: returns a transaction, in binary, hex-encoded binary, or JSON formats.
 
 For full TX query capability, one must enable the transaction index via "txindex=1" command line / configuration option.
 

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -77,7 +77,7 @@ for Debian 7 (Wheezy) and later:
  Add the following line to /etc/apt/sources.list,
  replacing [mirror] with any official debian mirror.
 
-	deb http://[mirror]/debian/ oldstable main
+	deb http://[mirror]/debian/ oldoldstable main
 
 To enable the change run
 

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -59,7 +59,7 @@ Build requirements:
 
 	sudo apt-get install build-essential libtool autotools-dev autoconf pkg-config libssl-dev
 	
-for Ubuntu 12.04 and later or Debian 7 and later libboost-all-dev has to be installed:
+For Ubuntu 12.04 and later or Debian 7 and later libboost-all-dev has to be installed:
 
 	sudo apt-get install libboost-all-dev
 

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -72,18 +72,7 @@ for Ubuntu 12.04 and later or Debian 7 and later libboost-all-dev has to be inst
  Ubuntu 12.04 and later have packages for libdb5.1-dev and libdb5.1++-dev,
  but using these will break binary wallet compatibility, and is not recommended.
 
-for Debian 7 (Wheezy) and later:
- The oldstable repository contains db4.8 packages.
- Add the following line to /etc/apt/sources.list,
- replacing [mirror] with any official debian mirror.
-
-	deb http://[mirror]/debian/ oldoldstable main
-
-To enable the change run
-
-	sudo apt-get update
-
-for other Debian & Ubuntu (with ppa):
+For other Debian & Ubuntu (with ppa):
 
 	sudo apt-get install libdb4.8-dev libdb4.8++-dev
 


### PR DESCRIPTION
https://packages.debian.org/search?searchon=names&exact=1&suite=all&section=all&keywords=libdb4.8
Berkeley DB 4.8 is part of squeeze, which is now "oldoldstable."
