### PR TITLE
Policy: Prepare AcceptToMemoryPool for encapsulated alternative replacement policies

### DIFF
--- a/src/consensus/consensus.h
+++ b/src/consensus/consensus.h
@@ -6,11 +6,34 @@
 #ifndef BITCOIN_CONSENSUS_CONSENSUS_H
 #define BITCOIN_CONSENSUS_CONSENSUS_H
 
+#include "amount.h"
+
+class CCoinsViewCache;
+class CTransaction;
+class CValidationState;
+
 /** The maximum allowed size for a serialized block, in bytes (network rule) */
 static const unsigned int MAX_BLOCK_SIZE = 1000000;
 /** The maximum allowed number of signature check operations in a block (network rule) */
 static const unsigned int MAX_BLOCK_SIGOPS = MAX_BLOCK_SIZE/50;
 /** Coinbase transaction outputs can only be spent after this number of new blocks (network rule) */
 static const int COINBASE_MATURITY = 100;
+
+/**
+ * Consensus validations:
+ * Check_ means checking everything possible with the data provided
+ * (that has not been checked in previous cheaper functions for the same data structure).
+ * Verify_ means all data provided was enough for this level and its "consensus-verified".
+ */
+namespace Consensus {
+
+/**
+ * Check whether all inputs of this transaction are valid (no double spends and amounts)
+ * This does not modify the UTXO set. This does not check scripts and sigs.
+ * Preconditions: tx.IsCoinBase() is false.
+ */
+bool CheckTxInputs(const CTransaction& tx, CValidationState& state, const CCoinsViewCache& inputs, int nSpendHeight, CAmount& nTxFee);
+
+} // namespace Consensus
 
 #endif // BITCOIN_CONSENSUS_CONSENSUS_H

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -846,7 +846,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     if (mapArgs.count("-minrelaytxfee"))
     {
         CAmount n = 0;
-        if (ParseMoney(mapArgs["-minrelaytxfee"], n) && n > 0)
+        if (ParseMoney(mapArgs["-minrelaytxfee"], n) && MoneyRange(n))
             ::minRelayTxFee = CFeeRate(n);
         else
             return InitError(strprintf(_("Invalid amount for -minrelaytxfee=<amount>: '%s'"), mapArgs["-minrelaytxfee"]));

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -18,6 +18,7 @@
 #include "main.h"
 #include "miner.h"
 #include "net.h"
+#include "policy/fees.h"
 #include "policy/policy.h"
 #include "rpcserver.h"
 #include "script/standard.h"

--- a/src/main.h
+++ b/src/main.h
@@ -284,7 +284,7 @@ unsigned int GetP2SHSigOpCount(const CTransaction& tx, const CCoinsViewCache& ma
  * This does not modify the UTXO set. If pvChecks is not NULL, script checks are pushed onto it
  * instead of being performed inline.
  */
-bool CheckInputs(const CTransaction& tx, CValidationState &state, const CCoinsViewCache &view, bool fScriptChecks,
+bool CheckInputsScripts(const CTransaction& tx, CValidationState &state, const CCoinsViewCache &view,
                  unsigned int flags, bool cacheStore, std::vector<CScriptCheck> *pvChecks = NULL);
 
 /** Apply the effects of this transaction on the UTXO set represented by view */

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -12,6 +12,7 @@
 #include "hash.h"
 #include "main.h"
 #include "net.h"
+#include "policy/fees.h"
 #include "policy/policy.h"
 #include "pow.h"
 #include "primitives/transaction.h"

--- a/src/policy/fees.h
+++ b/src/policy/fees.h
@@ -15,6 +15,22 @@
 class CAutoFile;
 class CFeeRate;
 class CTxMemPoolEntry;
+class CValidationState;
+
+/** Default for -blockprioritysize, maximum space for zero/low-fee transactions **/
+static const unsigned int DEFAULT_BLOCK_PRIORITY_SIZE = 50000;
+
+inline double AllowFreeThreshold()
+{
+    return COIN * 144 / 250;
+}
+
+inline bool AllowFree(double dPriority)
+{
+    // Large (in bytes) low-priority (new, small-coin) transactions
+    // need a fee.
+    return dPriority > AllowFreeThreshold();
+}
 
 /** \class CBlockPolicyEstimator
  * The BlockPolicyEstimator is used for estimating the fee or priority needed
@@ -250,6 +266,9 @@ public:
 
     /** Read estimation data from a file */
     void Read(CAutoFile& filein);
+
+    /** Allow transactions bellow the min relay fee or not */
+    bool AllowFreeTx(const CTxMemPoolEntry& toadd, CValidationState& state, const double& dViewPriority) const;
 
 private:
     CFeeRate minTrackedFee; //! Passed to constructor to avoid dependency on main

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -17,8 +17,6 @@ class CCoinsViewCache;
 /** Default for -blockmaxsize and -blockminsize, which control the range of sizes the mining code will create **/
 static const unsigned int DEFAULT_BLOCK_MAX_SIZE = 750000;
 static const unsigned int DEFAULT_BLOCK_MIN_SIZE = 0;
-/** Default for -blockprioritysize, maximum space for zero/low-fee transactions **/
-static const unsigned int DEFAULT_BLOCK_PRIORITY_SIZE = 50000;
 /** The maximum size for transactions we're willing to relay/mine */
 static const unsigned int MAX_STANDARD_TX_SIZE = 100000;
 /** Maximum number of signature check operations in an IsStandard() P2SH script */

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -15,6 +15,7 @@
 #include "coincontrol.h"
 #include "init.h"
 #include "main.h"
+#include "policy/fees.h"
 #include "wallet/wallet.h"
 
 #include <boost/assign/list_of.hpp> // for 'map_list_of()'

--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -34,7 +34,7 @@ extern unsigned nMaxDatacarrierBytes;
  * but in the future other flags may be added, such as a soft-fork to enforce
  * strict DER encoding.
  * 
- * Failing one of these tests may trigger a DoS ban - see CheckInputs() for
+ * Failing one of these tests may trigger a DoS ban - see CheckInputsScripts() for
  * details.
  */
 static const unsigned int MANDATORY_SCRIPT_VERIFY_FLAGS = SCRIPT_VERIFY_P2SH;

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -275,7 +275,8 @@ void CTxMemPool::check(const CCoinsViewCache *pcoins) const
             waitingOnDependants.push_back(&it->second);
         else {
             CValidationState state;
-            assert(CheckInputs(tx, state, mempoolDuplicate, false, 0, false, NULL));
+            CAmount nTxFees;
+            assert(Consensus::CheckTxInputs(tx, state, mempoolDuplicate, GetSpendHeight(mempoolDuplicate), nTxFees));
             UpdateCoins(tx, state, mempoolDuplicate, 1000000);
         }
     }
@@ -289,7 +290,8 @@ void CTxMemPool::check(const CCoinsViewCache *pcoins) const
             stepsSinceLastRemove++;
             assert(stepsSinceLastRemove < waitingOnDependants.size());
         } else {
-            assert(CheckInputs(entry->GetTx(), state, mempoolDuplicate, false, 0, false, NULL));
+            CAmount nTxFees;
+            assert(Consensus::CheckTxInputs(entry->GetTx(), state, mempoolDuplicate, GetSpendHeight(mempoolDuplicate), nTxFees));
             UpdateCoins(entry->GetTx(), state, mempoolDuplicate, 1000000);
             stepsSinceLastRemove = 0;
         }

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -108,6 +108,19 @@ bool CTxMemPool::addUnchecked(const uint256& hash, const CTxMemPoolEntry &entry,
     return true;
 }
 
+void CTxMemPool::removeUnchecked(const uint256& hash)
+{
+    const CTxMemPoolEntry &entry = mapTx.find(hash)->second;
+
+    BOOST_FOREACH(const CTxIn& txin, entry.GetTx().vin)
+        mapNextTx.erase(txin.prevout);
+
+    totalTxSize -= entry.GetTxSize();
+    cachedInnerUsage -= entry.DynamicMemoryUsage();
+    mapTx.erase(hash);
+    nTransactionsUpdated++;
+    minerPolicyEstimator->removeTx(hash);
+}
 
 void CTxMemPool::remove(const CTransaction &origTx, std::list<CTransaction>& removed, bool fRecursive)
 {
@@ -143,15 +156,8 @@ void CTxMemPool::remove(const CTransaction &origTx, std::list<CTransaction>& rem
                     txToRemove.push_back(it->second.ptx->GetHash());
                 }
             }
-            BOOST_FOREACH(const CTxIn& txin, tx.vin)
-                mapNextTx.erase(txin.prevout);
-
             removed.push_back(tx);
-            totalTxSize -= mapTx[hash].GetTxSize();
-            cachedInnerUsage -= mapTx[hash].DynamicMemoryUsage();
-            mapTx.erase(hash);
-            nTransactionsUpdated++;
-            minerPolicyEstimator->removeTx(hash);
+            removeUnchecked(hash);
         }
     }
 }
@@ -432,4 +438,64 @@ bool CCoinsViewMemPool::HaveCoins(const uint256 &txid) const {
 size_t CTxMemPool::DynamicMemoryUsage() const {
     LOCK(cs);
     return memusage::DynamicUsage(mapTx) + memusage::DynamicUsage(mapNextTx) + memusage::DynamicUsage(mapDeltas) + cachedInnerUsage;
+}
+
+void CTxMemPool::ClearStaged()
+{
+    stage.clear();
+    nStageFeesRemoved = 0;
+}
+
+bool CTxMemPool::StageReplace(const CTxMemPoolEntry& toadd, CValidationState& state, bool fLimitFree, const CCoinsViewCache& view)
+{
+    ClearStaged();
+    bool fSpendConflicts = false;
+    // Check for conflicts with in-memory transactions
+    {
+        LOCK(cs); // protect pool.mapNextTx
+        BOOST_FOREACH(const CTxIn& in, toadd.GetTx().vin) {
+            if (mapNextTx.count(in.prevout))
+                fSpendConflicts = true;
+        }
+    }
+    const CTransaction& tx = toadd.GetTx();
+    uint256 hash = tx.GetHash();
+    const CAmount nFees = toadd.GetFee();
+    const size_t nSize = toadd.GetTxSize();
+
+    if (fSpendConflicts) {
+        // Disable replacement feature for now
+        return state.DoS(0, false, REJECT_INSUFFICIENTFEE, "replacement-rejected-conflicts");
+    }
+
+    if (fLimitFree && nFees < ::minRelayTxFee.GetFee(nSize) + nStageFeesRemoved) {
+
+        bool fAllowFree = true;
+        double dPriorityDelta = 0;
+        CAmount nFeeDelta = 0;
+        ApplyDeltas(hash, dPriorityDelta, nFeeDelta);
+        if (dPriorityDelta <= 0 || nFeeDelta <= 0) {
+            state.DoS(0, false, REJECT_INSUFFICIENTFEE, "insufficient fee");
+            fAllowFree = false;
+        } else if (!minerPolicyEstimator->AllowFreeTx(toadd, state, view.GetPriority(tx, chainActive.Height() + 1)))
+            fAllowFree = false;
+
+        if (!fAllowFree) {
+            LogPrintf("%s: %s: %d < %d (txHash %s)", __func__, state.GetRejectReason(), nFees, ::minRelayTxFee.GetFee(nSize) + nStageFeesRemoved, hash.ToString());
+            return false;
+        }
+    }
+
+    return true;
+}
+
+void CTxMemPool::RemoveStaged(const uint256& txHash)
+{
+    if (!stage.empty()) {
+        LogPrint("mempool", "Removing %u transactions (%d fees) from the mempool to make space for %s\n", stage.size(), nStageFeesRemoved, txHash.ToString());
+        BOOST_FOREACH(const uint256& hash, stage) {
+            removeUnchecked(hash);
+        }
+        ClearStaged();
+    }
 }

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -14,18 +14,7 @@
 #include "sync.h"
 
 class CAutoFile;
-
-inline double AllowFreeThreshold()
-{
-    return COIN * 144 / 250;
-}
-
-inline bool AllowFree(double dPriority)
-{
-    // Large (in bytes) low-priority (new, small-coin) transactions
-    // need a fee.
-    return dPriority > AllowFreeThreshold();
-}
+class CValidationState;
 
 /** Fake height value used in CCoins to signify they are only in the memory pool (since 0.8) */
 static const unsigned int MEMPOOL_HEIGHT = 0x7FFFFFFF;
@@ -97,6 +86,8 @@ private:
 
     uint64_t totalTxSize; //! sum of all mempool tx' byte sizes
     uint64_t cachedInnerUsage; //! sum of dynamic memory usage of all the map elements (NOT the maps themselves)
+    CAmount nStageFeesRemoved;
+    std::set<uint256> stage;
 
 public:
     mutable CCriticalSection cs;
@@ -117,6 +108,7 @@ public:
     void setSanityCheck(bool _fSanityCheck) { fSanityCheck = _fSanityCheck; }
 
     bool addUnchecked(const uint256& hash, const CTxMemPoolEntry &entry, bool fCurrentEstimate = true);
+    void removeUnchecked(const uint256& hash);
     void remove(const CTransaction &tx, std::list<CTransaction>& removed, bool fRecursive = false);
     void removeCoinbaseSpends(const CCoinsViewCache *pcoins, unsigned int nMemPoolHeight);
     void removeConflicts(const CTransaction &tx, std::list<CTransaction>& removed);
@@ -137,6 +129,20 @@ public:
     void PrioritiseTransaction(const uint256 hash, const std::string strHash, double dPriorityDelta, const CAmount& nFeeDelta);
     void ApplyDeltas(const uint256 hash, double &dPriorityDelta, CAmount &nFeeDelta);
     void ClearPrioritisation(const uint256 hash);
+
+    /**
+     * Resets stage and nStageFeesRemoved.
+     */
+    void ClearStaged();
+    /**
+     * Build a stage list (attribute) of transaction (hashes) to replace such that:
+     *  - The list is consistent (if a parent is included, all its dependencies are included as well).
+     *  - No dependencies of toadd are removed.
+     *  - The transactions have to be removed from the mempool to accept toadd (due to spend conflicts and/or insufficient space in the mempool). 
+     * @returns false if the new entry is rejected.
+     */
+    bool StageReplace(const CTxMemPoolEntry& toadd, CValidationState& state, bool fLimitFree, const CCoinsViewCache& view);
+    void RemoveStaged(const uint256& txHash);
 
     unsigned long size()
     {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -12,6 +12,7 @@
 #include "consensus/validation.h"
 #include "main.h"
 #include "net.h"
+#include "policy/fees.h"
 #include "policy/policy.h"
 #include "script/script.h"
 #include "script/sign.h"


### PR DESCRIPTION
As usual with policy changes, this could be cleaner after #6068, but I'd rather not wait anymore to propose this, which has been in my mind since #5071 (because I don't want policy to depend on txmempool).
It would be good that all alternative replacement policy proposals are built on top of this, since the encapsulation makes review easier. Feedback from people that have been working on alternative replacement policies (for example, @petertodd and @luke-jr ) or people that are working on the mempool is specially welcomed. 
@morcos I'm thinking that the new CTxMemPool::addUnchecked that removes conflicts before inserting the new transaction may need some call the the fee estimator, but I'm not certain yet. What do you think?
