### PR TITLE
Add autogen.sh to source tarball.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -202,6 +202,8 @@ check-local:
 	@qa/pull-tester/run-bitcoind-for-test.sh $(JAVA) -jar $(JAVA_COMPARISON_TOOL) qa/tmp/compTool $(COMPARISON_TOOL_REORG_TESTS) 2>&1
 endif
 
+dist_noinst_SCRIPTS = autogen.sh
+
 EXTRA_DIST = $(top_srcdir)/share/genbuild.sh qa/pull-tester/rpc-tests.sh qa/pull-tester/run-bitcoin-cli qa/rpc-tests $(DIST_DOCS) $(WINDOWS_PACKAGING) $(OSX_PACKAGING)
 
 CLEANFILES = $(OSX_DMG) $(BITCOIN_WIN_INSTALLER)


### PR DESCRIPTION
Closes issue https://github.com/bitcoin/bitcoin/issues/4997 and restores consistency with the "To Build" instructions in doc/build-unix.md file packaged with the source tarball.
