### PR TITLE
DEPENDENT: Policy: Turn policy globals into CStandardPolicy attributes

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -58,8 +58,6 @@ bool fReindex = false;
 bool fTxIndex = false;
 bool fHavePruned = false;
 bool fPruneMode = false;
-bool fIsBareMultisigStd = true;
-bool fRequireStandard = true;
 bool fCheckBlockIndex = false;
 bool fCheckpointsEnabled = true;
 size_t nCoinCacheUsage = 5000 * 300;
@@ -68,7 +66,7 @@ bool fAlerts = DEFAULT_ALERTS;
 
 /** Fees smaller than this (in satoshi) are considered zero fee (for relaying and mining) */
 CFeeRate minRelayTxFee = CFeeRate(1000);
-CPolicy globalPolicy;
+CStandardPolicy globalPolicy;
 
 CTxMemPool mempool(::minRelayTxFee);
 

--- a/src/main.h
+++ b/src/main.h
@@ -40,6 +40,7 @@ class CBlockIndex;
 class CBlockTreeDB;
 class CBloomFilter;
 class CInv;
+class CPolicy;
 class CScriptCheck;
 class CValidationInterface;
 class CValidationState;
@@ -105,6 +106,7 @@ extern bool fCheckpointsEnabled;
 extern size_t nCoinCacheUsage;
 extern CFeeRate minRelayTxFee;
 extern bool fAlerts;
+extern CPolicy globalPolicy;
 
 /** Best header we've seen so far (used for getheaders queries' starting points). */
 extern CBlockIndex *pindexBestHeader;

--- a/src/main.h
+++ b/src/main.h
@@ -40,7 +40,7 @@ class CBlockIndex;
 class CBlockTreeDB;
 class CBloomFilter;
 class CInv;
-class CPolicy;
+class CStandardPolicy;
 class CScriptCheck;
 class CValidationInterface;
 class CValidationState;
@@ -99,14 +99,12 @@ extern bool fImporting;
 extern bool fReindex;
 extern int nScriptCheckThreads;
 extern bool fTxIndex;
-extern bool fIsBareMultisigStd;
-extern bool fRequireStandard;
 extern bool fCheckBlockIndex;
 extern bool fCheckpointsEnabled;
 extern size_t nCoinCacheUsage;
 extern CFeeRate minRelayTxFee;
 extern bool fAlerts;
-extern CPolicy globalPolicy;
+extern CStandardPolicy globalPolicy;
 
 /** Best header we've seen so far (used for getheaders queries' starting points). */
 extern CBlockIndex *pindexBestHeader;

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -21,7 +21,7 @@ std::vector<std::pair<std::string, std::string> > CStandardPolicy::GetOptionsHel
 {
     std::vector<std::pair<std::string, std::string> > optionsHelp;
     optionsHelp.push_back(std::make_pair("-permitbaremultisig", strprintf(_("Relay non-P2SH multisig (default: %u)"), fIsBareMultisigStd)));
-    optionsHelp.push_back(std::make_pair("-acceptnonstdtxn", strprintf(_("Relay and mine \"non-standard\" transactions (testnet/regtest only; default: %u)"), Params(CBaseChainParams::MAIN).RequireStandard())));
+    optionsHelp.push_back(std::make_pair("-acceptnonstdtxn", strprintf(_("Relay and mine \"non-standard\" transactions (default: %u)"), Params(CBaseChainParams::MAIN).RequireStandard())));
     return optionsHelp;
 }
 
@@ -29,8 +29,6 @@ void CStandardPolicy::InitFromArgs(const std::map<std::string, std::string>& map
 {
     fIsBareMultisigStd = GetBoolArg("-permitbaremultisig", fIsBareMultisigStd, mapArgs);
     fAcceptNonStdTxn = GetBoolArg("-acceptnonstdtxn", !Params().RequireStandard(), mapArgs);
-    if (fAcceptNonStdTxn && Params().RequireStandard())
-        throw std::runtime_error(strprintf(_("%s: acceptnonstdtxn is not currently supported for %s chain."), __func__, Params().NetworkIDString()));
 }
 
 CStandardPolicy::CStandardPolicy(bool fIsBareMultisigStdIn, bool fAcceptNonStdTxnIn) :

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -42,17 +42,26 @@ static const unsigned int STANDARD_SCRIPT_VERIFY_FLAGS = MANDATORY_SCRIPT_VERIFY
 /** For convenience, standard but not mandatory verify flags. */
 static const unsigned int STANDARD_NOT_MANDATORY_VERIFY_FLAGS = STANDARD_SCRIPT_VERIFY_FLAGS & ~MANDATORY_SCRIPT_VERIFY_FLAGS;
 
-bool IsStandard(const CScript& scriptPubKey, txnouttype& whichType);
+/**
+ * \class CPolicy
+ * Generic interface class for policy.
+ */
+class CPolicy
+{
+    bool ApproveScript(const CScript&, txnouttype&) const;
+public:
+    bool ApproveScript(const CScript&) const;
     /**
      * Check for standard transaction types
      * @return True if all outputs (scriptPubKeys) use only standard transaction forms
      */
-bool IsStandardTx(const CTransaction& tx, std::string& reason);
+    bool ApproveTx(const CTransaction& tx, std::string& reason) const;
     /**
      * Check for standard transaction types
      * @param[in] mapInputs    Map of previous transactions that have outputs we're spending
      * @return True if all inputs (scriptSigs) use only standard transaction forms
      */
-bool AreInputsStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs);
+    bool ApproveTxInputs(const CTransaction& tx, const CCoinsViewCache& mapInputs) const;
+};
 
 #endif // BITCOIN_POLICY_H

--- a/src/test/multisig_tests.cpp
+++ b/src/test/multisig_tests.cpp
@@ -143,7 +143,7 @@ BOOST_AUTO_TEST_CASE(multisig_verify)
 
 BOOST_AUTO_TEST_CASE(multisig_IsStandard)
 {
-    const CPolicy testPolicy;
+    const CStandardPolicy testPolicy;
     CKey key[4];
     for (int i = 0; i < 4; i++)
         key[i].MakeNewKey(true);

--- a/src/test/multisig_tests.cpp
+++ b/src/test/multisig_tests.cpp
@@ -143,27 +143,26 @@ BOOST_AUTO_TEST_CASE(multisig_verify)
 
 BOOST_AUTO_TEST_CASE(multisig_IsStandard)
 {
+    const CPolicy testPolicy;
     CKey key[4];
     for (int i = 0; i < 4; i++)
         key[i].MakeNewKey(true);
 
-    txnouttype whichType;
-
     CScript a_and_b;
     a_and_b << OP_2 << ToByteVector(key[0].GetPubKey()) << ToByteVector(key[1].GetPubKey()) << OP_2 << OP_CHECKMULTISIG;
-    BOOST_CHECK(::IsStandard(a_and_b, whichType));
+    BOOST_CHECK(testPolicy.ApproveScript(a_and_b));
 
     CScript a_or_b;
     a_or_b  << OP_1 << ToByteVector(key[0].GetPubKey()) << ToByteVector(key[1].GetPubKey()) << OP_2 << OP_CHECKMULTISIG;
-    BOOST_CHECK(::IsStandard(a_or_b, whichType));
+    BOOST_CHECK(testPolicy.ApproveScript(a_or_b));
 
     CScript escrow;
     escrow << OP_2 << ToByteVector(key[0].GetPubKey()) << ToByteVector(key[1].GetPubKey()) << ToByteVector(key[2].GetPubKey()) << OP_3 << OP_CHECKMULTISIG;
-    BOOST_CHECK(::IsStandard(escrow, whichType));
+    BOOST_CHECK(testPolicy.ApproveScript(escrow));
 
     CScript one_of_four;
     one_of_four << OP_1 << ToByteVector(key[0].GetPubKey()) << ToByteVector(key[1].GetPubKey()) << ToByteVector(key[2].GetPubKey()) << ToByteVector(key[3].GetPubKey()) << OP_4 << OP_CHECKMULTISIG;
-    BOOST_CHECK(!::IsStandard(one_of_four, whichType));
+    BOOST_CHECK(!testPolicy.ApproveScript(one_of_four));
 
     CScript malformed[6];
     malformed[0] << OP_3 << ToByteVector(key[0].GetPubKey()) << ToByteVector(key[1].GetPubKey()) << OP_2 << OP_CHECKMULTISIG;
@@ -174,7 +173,7 @@ BOOST_AUTO_TEST_CASE(multisig_IsStandard)
     malformed[5] << OP_1 << ToByteVector(key[0].GetPubKey()) << ToByteVector(key[1].GetPubKey());
 
     for (int i = 0; i < 6; i++)
-        BOOST_CHECK(!::IsStandard(malformed[i], whichType));
+        BOOST_CHECK(!testPolicy.ApproveScript(malformed[i]));
 }
 
 BOOST_AUTO_TEST_CASE(multisig_Solver1)

--- a/src/test/script_P2SH_tests.cpp
+++ b/src/test/script_P2SH_tests.cpp
@@ -53,7 +53,7 @@ BOOST_FIXTURE_TEST_SUITE(script_P2SH_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(sign)
 {
-    const CPolicy testPolicy;
+    const CStandardPolicy testPolicy;
     LOCK(cs_main);
     // Pay-to-script-hash looks like this:
     // scriptSig:    <sig> <sig...> <serialized_script>
@@ -155,7 +155,7 @@ BOOST_AUTO_TEST_CASE(norecurse)
 
 BOOST_AUTO_TEST_CASE(set)
 {
-    const CPolicy testPolicy;
+    const CStandardPolicy testPolicy;
     LOCK(cs_main);
     // Test the CScript::Set* methods
     CBasicKeyStore keystore;
@@ -264,7 +264,7 @@ BOOST_AUTO_TEST_CASE(switchover)
 
 BOOST_AUTO_TEST_CASE(AreInputsStandard)
 {
-    const CPolicy testPolicy;
+    const CStandardPolicy testPolicy;
     LOCK(cs_main);
     CCoinsView coinsDummy;
     CCoinsViewCache coins(&coinsDummy);

--- a/src/test/script_P2SH_tests.cpp
+++ b/src/test/script_P2SH_tests.cpp
@@ -53,6 +53,7 @@ BOOST_FIXTURE_TEST_SUITE(script_P2SH_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(sign)
 {
+    const CPolicy testPolicy;
     LOCK(cs_main);
     // Pay-to-script-hash looks like this:
     // scriptSig:    <sig> <sig...> <serialized_script>
@@ -91,7 +92,7 @@ BOOST_AUTO_TEST_CASE(sign)
         txFrom.vout[i+4].scriptPubKey = standardScripts[i];
         txFrom.vout[i+4].nValue = COIN;
     }
-    BOOST_CHECK(IsStandardTx(txFrom, reason));
+    BOOST_CHECK(testPolicy.ApproveTx(txFrom, reason));
 
     CMutableTransaction txTo[8]; // Spending transactions
     for (int i = 0; i < 8; i++)
@@ -154,6 +155,7 @@ BOOST_AUTO_TEST_CASE(norecurse)
 
 BOOST_AUTO_TEST_CASE(set)
 {
+    const CPolicy testPolicy;
     LOCK(cs_main);
     // Test the CScript::Set* methods
     CBasicKeyStore keystore;
@@ -187,7 +189,7 @@ BOOST_AUTO_TEST_CASE(set)
         txFrom.vout[i].scriptPubKey = outer[i];
         txFrom.vout[i].nValue = CENT;
     }
-    BOOST_CHECK(IsStandardTx(txFrom, reason));
+    BOOST_CHECK(testPolicy.ApproveTx(txFrom, reason));
 
     CMutableTransaction txTo[4]; // Spending transactions
     for (int i = 0; i < 4; i++)
@@ -205,7 +207,7 @@ BOOST_AUTO_TEST_CASE(set)
     for (int i = 0; i < 4; i++)
     {
         BOOST_CHECK_MESSAGE(SignSignature(keystore, txFrom, txTo[i], 0), strprintf("SignSignature %d", i));
-        BOOST_CHECK_MESSAGE(IsStandardTx(txTo[i], reason), strprintf("txTo[%d].IsStandard", i));
+        BOOST_CHECK_MESSAGE(testPolicy.ApproveTx(txTo[i], reason), strprintf("txTo[%d].IsStandard", i));
     }
 }
 
@@ -262,6 +264,7 @@ BOOST_AUTO_TEST_CASE(switchover)
 
 BOOST_AUTO_TEST_CASE(AreInputsStandard)
 {
+    const CPolicy testPolicy;
     LOCK(cs_main);
     CCoinsView coinsDummy;
     CCoinsViewCache coins(&coinsDummy);
@@ -342,7 +345,7 @@ BOOST_AUTO_TEST_CASE(AreInputsStandard)
     txTo.vin[3].scriptSig << OP_11 << OP_11 << static_cast<vector<unsigned char> >(oneAndTwo);
     txTo.vin[4].scriptSig << static_cast<vector<unsigned char> >(fifteenSigops);
 
-    BOOST_CHECK(::AreInputsStandard(txTo, coins));
+    BOOST_CHECK(testPolicy.ApproveTxInputs(txTo, coins));
     // 22 P2SH sigops for all inputs (1 for vin[0], 6 for vin[3], 15 for vin[4]
     BOOST_CHECK_EQUAL(GetP2SHSigOpCount(txTo, coins), 22U);
 
@@ -351,7 +354,7 @@ BOOST_AUTO_TEST_CASE(AreInputsStandard)
     {
         CScript t = txTo.vin[i].scriptSig;
         txTo.vin[i].scriptSig = (CScript() << 11) + t;
-        BOOST_CHECK(!::AreInputsStandard(txTo, coins));
+        BOOST_CHECK(!testPolicy.ApproveTxInputs(txTo, coins));
         txTo.vin[i].scriptSig = t;
     }
 
@@ -364,7 +367,7 @@ BOOST_AUTO_TEST_CASE(AreInputsStandard)
     txToNonStd1.vin[0].prevout.hash = txFrom.GetHash();
     txToNonStd1.vin[0].scriptSig << static_cast<vector<unsigned char> >(sixteenSigops);
 
-    BOOST_CHECK(!::AreInputsStandard(txToNonStd1, coins));
+    BOOST_CHECK(!testPolicy.ApproveTxInputs(txToNonStd1, coins));
     BOOST_CHECK_EQUAL(GetP2SHSigOpCount(txToNonStd1, coins), 16U);
 
     CMutableTransaction txToNonStd2;
@@ -376,7 +379,7 @@ BOOST_AUTO_TEST_CASE(AreInputsStandard)
     txToNonStd2.vin[0].prevout.hash = txFrom.GetHash();
     txToNonStd2.vin[0].scriptSig << static_cast<vector<unsigned char> >(twentySigops);
 
-    BOOST_CHECK(!::AreInputsStandard(txToNonStd2, coins));
+    BOOST_CHECK(!testPolicy.ApproveTxInputs(txToNonStd2, coins));
     BOOST_CHECK_EQUAL(GetP2SHSigOpCount(txToNonStd2, coins), 20U);
 }
 

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -288,7 +288,7 @@ SetupDummyInputs(CBasicKeyStore& keystoreRet, CCoinsViewCache& coinsRet)
 
 BOOST_AUTO_TEST_CASE(test_Get)
 {
-    const CPolicy testPolicy;
+    const CStandardPolicy testPolicy;
     CBasicKeyStore keystore;
     CCoinsView coinsDummy;
     CCoinsViewCache coins(&coinsDummy);
@@ -323,7 +323,7 @@ BOOST_AUTO_TEST_CASE(test_Get)
 
 BOOST_AUTO_TEST_CASE(test_IsStandard)
 {
-    const CPolicy testPolicy;
+    const CStandardPolicy testPolicy;
     LOCK(cs_main);
     CBasicKeyStore keystore;
     CCoinsView coinsDummy;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -312,29 +312,47 @@ void ParseParameters(int argc, const char* const argv[])
     }
 }
 
+std::string GetArg(const std::string& strArg, const std::string& strDefault, const std::map<std::string, std::string>& mapArgs)
+{
+    std::map<std::string, std::string>::const_iterator it = mapArgs.find(strArg);
+    if (it != mapArgs.end())
+        return it->second;
+    return strDefault;
+}
+
+int64_t GetArg(const std::string& strArg, int64_t nDefault, const std::map<std::string, std::string>& mapArgs)
+{
+    std::map<std::string, std::string>::const_iterator it = mapArgs.find(strArg);
+    if (it != mapArgs.end())
+        return atoi64(it->second);
+    return nDefault;
+}
+
+bool GetBoolArg(const std::string& strArg, bool fDefault, const std::map<std::string, std::string>& mapArgs)
+{
+    std::map<std::string, std::string>::const_iterator it = mapArgs.find(strArg);
+    if (it != mapArgs.end())
+    {
+        if (it->second.empty())
+            return true;
+        return (atoi(it->second) != 0);
+    }
+    return fDefault;
+}
+
 std::string GetArg(const std::string& strArg, const std::string& strDefault)
 {
-    if (mapArgs.count(strArg))
-        return mapArgs[strArg];
-    return strDefault;
+    return GetArg(strArg, strDefault, mapArgs);
 }
 
 int64_t GetArg(const std::string& strArg, int64_t nDefault)
 {
-    if (mapArgs.count(strArg))
-        return atoi64(mapArgs[strArg]);
-    return nDefault;
+    return GetArg(strArg, nDefault, mapArgs);
 }
 
 bool GetBoolArg(const std::string& strArg, bool fDefault)
 {
-    if (mapArgs.count(strArg))
-    {
-        if (mapArgs[strArg].empty())
-            return true;
-        return (atoi(mapArgs[strArg]) != 0);
-    }
-    return fDefault;
+    return GetBoolArg(strArg, fDefault, mapArgs);
 }
 
 bool SoftSetArg(const std::string& strArg, const std::string& strValue)
@@ -366,6 +384,12 @@ std::string HelpMessageOpt(const std::string &option, const std::string &message
            std::string("\n") + std::string(msgIndent,' ') +
            FormatParagraph(message, screenWidth - msgIndent, msgIndent) +
            std::string("\n\n");
+}
+
+void AppendMessagesOpt(std::string& strUsage, const std::vector<std::pair<std::string, std::string> >& optionsHelp)
+{
+    for (unsigned int i=0; i < optionsHelp.size(); i++)
+        strUsage += HelpMessageOpt(optionsHelp[i].first, optionsHelp[i].second);
 }
 
 static std::string FormatException(const std::exception* pex, const char* pszThread)

--- a/src/util.h
+++ b/src/util.h
@@ -145,6 +145,7 @@ inline bool IsSwitchChar(char c)
  * @return command-line argument or default value
  */
 std::string GetArg(const std::string& strArg, const std::string& strDefault);
+std::string GetArg(const std::string& strArg, const std::string& strDefault, const std::map<std::string, std::string>& mapArgs);
 
 /**
  * Return integer argument or default value
@@ -154,6 +155,7 @@ std::string GetArg(const std::string& strArg, const std::string& strDefault);
  * @return command-line argument (0 if invalid number) or default value
  */
 int64_t GetArg(const std::string& strArg, int64_t nDefault);
+int64_t GetArg(const std::string& strArg, int64_t nDefault, const std::map<std::string, std::string>& mapArgs);
 
 /**
  * Return boolean argument or default value
@@ -163,6 +165,7 @@ int64_t GetArg(const std::string& strArg, int64_t nDefault);
  * @return command-line argument or default value
  */
 bool GetBoolArg(const std::string& strArg, bool fDefault);
+bool GetBoolArg(const std::string& strArg, bool fDefault, const std::map<std::string, std::string>& mapArgs);
 
 /**
  * Set an argument if it doesn't already have a value
@@ -198,6 +201,12 @@ std::string HelpMessageGroup(const std::string& message);
  * @return the formatted string
  */
 std::string HelpMessageOpt(const std::string& option, const std::string& message);
+
+/**
+ * @param strUsage a string where the options' help with me appended
+ * @param optionsHelp a vector of string pairs to iteratively call HelpMessageOpt
+ */
+void AppendMessagesOpt(std::string& strUsage, const std::vector<std::pair<std::string, std::string> >& optionsHelp);
 
 /**
  * Return the number of physical cores available on the current system.


### PR DESCRIPTION
Includes #6068 but has been separated from it to hopefully accelerate things.
This separates the CPolicy interface from a CStandardPolicy reference implementation that initializes its attributes on init from command line options (it is friendly to GUI configuration as specified by @luke-jr ).
This doesn't introduce any new file (no globals/policy.o), any factory or container, any command line option or anything. Functionally, it just moves the a couple of relay help message options to a new policy group (where all relay options should end up).

But...if it's functionally equivalent...why eliminate globals from main.cpp ?

Because...http://lmgtfy.com/?q=why+globals+are+wrong ...sorry, because...http://c2.com/cgi/wiki?GlobalVariablesAreBad http://programmers.stackexchange.com/questions/148108/why-is-global-state-so-evil of many reasons.

I understand that elimination several variables to put them together so that explicitly take them as parameters by all functions that need it is not a priority since it doesn't functionally modify bitcoin core.

On the other hand, introducing new policy options as attributes to a class that it's sometimes used as a global (like CChainParams, what we started with it should be what we have in mind for CPolicy) is preferable to introducing a brand new global variable in main. But that won't be possible until we introduce something like Policy::AppendHelpMessages() and CPolicy::InitFromArgs(), and more globals that are low priority to clean up keep accumulating in main.o.

So, in summary, why do this?
To give the opportunity to new PRs not to unnecessarily give us more global cleanup work when they're created.

Also (although I'm not going to continue that GUI part), making policy options GUI-configurable (and hopefully, in the future all new existing and new options "for free") would be very nice too.
The way I've understood this from @luke-jr, with Policy::AppendHelpMessages() and CPolicy::InitFromArgs() it is relatively easy to create a generic GUI that doesn't require any more work outside those methods to introduce new policy attributes.
