### PR TITLE
Preserve user-passed CXXFLAGS with --enable-debug

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -147,12 +147,13 @@ AC_ARG_ENABLE([debug],
     [enable_debug=no])
 
 if test "x$enable_debug" = xyes; then
+    CPPFLAGS="$CPPFLAGS -DDEBUG -DDEBUG_LOCKORDER"
     if test "x$GCC" = xyes; then
-        CFLAGS="-g3 -O0 -DDEBUG"
+        CFLAGS="$CFLAGS -g3 -O0"
     fi
     
     if test "x$GXX" = xyes; then
-        CXXFLAGS="-g3 -O0 -DDEBUG"
+        CXXFLAGS="$CXXFLAGS -g3 -O0"
     fi
 fi 
 


### PR DESCRIPTION
I was surprised that this didn't work:
`./configure --enable-debug CXXFLAGS="-DDEBUG_LOCKORDER"`

@theuni : I don't THINK this will have unintended consequences, is there a reason --enable-debug overwrote CFLAGS/CXXFLAGS?
