### PR TITLE
Remove bash test note from rpc-tests readme

### DIFF
--- a/qa/rpc-tests/README.md
+++ b/qa/rpc-tests/README.md
@@ -12,10 +12,6 @@ Base class for new regression tests.
 ### [test_framework/util.py](test_framework/util.py)
 Generally useful functions.
 
-Bash-based tests, to be ported to Python:
------------------------------------------
-- conflictedbalance.sh : More testing of malleable transaction handling
-
 Notes
 =====
 


### PR DESCRIPTION
Redundant after #6428
Closes #4071
