### PR TITLE
Exempt unspendable transaction outputs from dust checks

### DIFF
--- a/qa/rpc-tests/fundrawtransaction.py
+++ b/qa/rpc-tests/fundrawtransaction.py
@@ -524,6 +524,22 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.sync_all()
         assert_equal(oldBalance+Decimal('50.19000000'), self.nodes[0].getbalance()) #0.19+block reward
 
+        #####################################################
+        # test fundrawtransaction with OP_RETURN and no vin #
+        #####################################################
+
+        rawtx   = "0100000000010000000000000000066a047465737400000000"
+        dec_tx  = self.nodes[2].decoderawtransaction(rawtx)
+
+        assert_equal(len(dec_tx['vin']), 0)
+        assert_equal(len(dec_tx['vout']), 1)
+
+        rawtxfund = self.nodes[2].fundrawtransaction(rawtx)
+        dec_tx  = self.nodes[2].decoderawtransaction(rawtxfund['hex'])
+
+        assert_greater_than(len(dec_tx['vin']), 0) # at least one vin
+        assert_equal(len(dec_tx['vout']), 2) # one change output added
+
 
 if __name__ == '__main__':
     RawTransactionsTest().main()

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -146,10 +146,13 @@ public:
         // which has units satoshis-per-kilobyte.
         // If you'd pay more than 1/3 in fees
         // to spend something, then we consider it dust.
-        // A typical txout is 34 bytes big, and will
+        // A typical spendable txout is 34 bytes big, and will
         // need a CTxIn of at least 148 bytes to spend:
-        // so dust is a txout less than 546 satoshis 
+        // so dust is a spendable txout less than 546 satoshis
         // with default minRelayTxFee.
+        if (scriptPubKey.IsUnspendable())
+            return 0;
+
         size_t nSize = GetSerializeSize(SER_DISK,0)+148u;
         return 3*minRelayTxFee.GetFee(nSize);
     }


### PR DESCRIPTION
Since unspendable outputs can't be spent, there is no threshold at which it would be uneconomic to spend them.

This primarily targets transaction outputs with `OP_RETURN`, and allows funding of data-only transactions with `"fundrawtransaction"`.
