### PR TITLE
Optimizations: Consensus: In AcceptToMemoryPool, ConnectBlock, and CreateNewBlock

### DIFF
--- a/src/consensus/consensus.h
+++ b/src/consensus/consensus.h
@@ -6,11 +6,34 @@
 #ifndef BITCOIN_CONSENSUS_CONSENSUS_H
 #define BITCOIN_CONSENSUS_CONSENSUS_H
 
+#include "amount.h"
+
+class CCoinsViewCache;
+class CTransaction;
+class CValidationState;
+
 /** The maximum allowed size for a serialized block, in bytes (network rule) */
 static const unsigned int MAX_BLOCK_SIZE = 1000000;
 /** The maximum allowed number of signature check operations in a block (network rule) */
 static const unsigned int MAX_BLOCK_SIGOPS = MAX_BLOCK_SIZE/50;
 /** Coinbase transaction outputs can only be spent after this number of new blocks (network rule) */
 static const int COINBASE_MATURITY = 100;
+
+/**
+ * Consensus validations:
+ * Check_ means checking everything possible with the data provided
+ * (that has not been checked in previous cheaper functions for the same data structure).
+ * Verify_ means all data provided was enough for this level and its "consensus-verified".
+ */
+namespace Consensus {
+
+/**
+ * Check whether all inputs of this transaction are valid (no double spends and amounts)
+ * This does not modify the UTXO set. This does not check scripts and sigs.
+ * Preconditions: tx.IsCoinBase() is false.
+ */
+bool CheckTxInputs(const CTransaction& tx, CValidationState& state, const CCoinsViewCache& inputs, int nSpendHeight, CAmount& nTxFee);
+
+} // namespace Consensus
 
 #endif // BITCOIN_CONSENSUS_CONSENSUS_H

--- a/src/main.h
+++ b/src/main.h
@@ -277,7 +277,7 @@ unsigned int GetP2SHSigOpCount(const CTransaction& tx, const CCoinsViewCache& ma
  * This does not modify the UTXO set. If pvChecks is not NULL, script checks are pushed onto it
  * instead of being performed inline.
  */
-bool CheckInputs(const CTransaction& tx, CValidationState &state, const CCoinsViewCache &view, bool fScriptChecks,
+bool CheckInputsScripts(const CTransaction& tx, CValidationState &state, const CCoinsViewCache &view,
                  unsigned int flags, bool cacheStore, std::vector<CScriptCheck> *pvChecks = NULL);
 
 /** Apply the effects of this transaction on the UTXO set represented by view */

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -102,6 +102,7 @@ int64_t UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParam
 CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn)
 {
     const CChainParams& chainparams = Params();
+    CValidationState state;
     // Create new block
     auto_ptr<CBlockTemplate> pblocktemplate(new CBlockTemplate());
     if(!pblocktemplate.get())
@@ -276,10 +277,9 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn)
                 std::make_heap(vecPriority.begin(), vecPriority.end(), comparer);
             }
 
-            if (!view.HaveInputs(tx))
+            CAmount nTxFees;
+            if (!Consensus::CheckTxInputs(tx, state, view, GetSpendHeight(view), nTxFees))
                 continue;
-
-            CAmount nTxFees = view.GetValueIn(tx)-tx.GetValueOut();
 
             nTxSigOps += GetP2SHSigOpCount(tx, view);
             if (nBlockSigOps + nTxSigOps >= MAX_BLOCK_SIGOPS)
@@ -288,8 +288,7 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn)
             // Note that flags: we don't want to set mempool/IsStandard()
             // policy here, but we still have to ensure that the block we
             // create only contains transactions that are valid in new blocks.
-            CValidationState state;
-            if (!CheckInputs(tx, state, view, true, MANDATORY_SCRIPT_VERIFY_FLAGS, true))
+            if (!CheckInputsScripts(tx, state, view, MANDATORY_SCRIPT_VERIFY_FLAGS, true))
                 continue;
 
             UpdateCoins(tx, state, view, nHeight);

--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -34,7 +34,7 @@ extern unsigned nMaxDatacarrierBytes;
  * but in the future other flags may be added, such as a soft-fork to enforce
  * strict DER encoding.
  * 
- * Failing one of these tests may trigger a DoS ban - see CheckInputs() for
+ * Failing one of these tests may trigger a DoS ban - see CheckInputsScripts() for
  * details.
  */
 static const unsigned int MANDATORY_SCRIPT_VERIFY_FLAGS = SCRIPT_VERIFY_P2SH;

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -275,7 +275,6 @@ void CTxMemPool::check(const CCoinsViewCache *pcoins) const
             waitingOnDependants.push_back(&it->second);
         else {
             CValidationState state;
-            assert(CheckInputs(tx, state, mempoolDuplicate, false, 0, false, NULL));
             UpdateCoins(tx, state, mempoolDuplicate, 1000000);
         }
     }
@@ -289,7 +288,6 @@ void CTxMemPool::check(const CCoinsViewCache *pcoins) const
             stepsSinceLastRemove++;
             assert(stepsSinceLastRemove < waitingOnDependants.size());
         } else {
-            assert(CheckInputs(entry->GetTx(), state, mempoolDuplicate, false, 0, false, NULL));
             UpdateCoins(entry->GetTx(), state, mempoolDuplicate, 1000000);
             stepsSinceLastRemove = 0;
         }


### PR DESCRIPTION
In all the 3 functions, reject transactions creating new money earlier.
Consensus::CheckTxInputs gets nTxFee as output parameter and is separated from main::CheckInputs [renamed CheckInputsScripts]. This continues #6061.

Detailed optimizations:
- Consensus::CheckTxInputs (called by the rest):

Don't calculate nValueOut twice
Don't check nFees < 0 twice
- main::AcceptToMemoryPool:

Don't calculate nValueOut 5 times
Don't calculate nValueIn 3 times
Don't call CCoinsViewCache::HaveInputs 3 times
- miner::CreateNewBlock:

Don't calculate nValueOut 3 times
Don't calculate nValueIn twice
Don't call CCoinsViewCache::HaveInputs twice
- main::ConnectBlock:

Don't calculate nValueOut 3 times
Don't calculate nValueIn twice
Still call CCoinsViewCache::HaveInputs twice
