### PR TITLE
Remove testnet-seed.bitcoin.schildbach.de.

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -158,7 +158,6 @@ public:
         vSeeds.push_back(CDNSSeedData("alexykot.me", "testnet-seed.alexykot.me"));
         vSeeds.push_back(CDNSSeedData("bitcoin.petertodd.org", "testnet-seed.bitcoin.petertodd.org"));
         vSeeds.push_back(CDNSSeedData("bluematt.me", "testnet-seed.bluematt.me"));
-        vSeeds.push_back(CDNSSeedData("bitcoin.schildbach.de", "testnet-seed.bitcoin.schildbach.de"));
 
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,111);
         base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1,196);


### PR DESCRIPTION
My provider was constantly complaining about unroutable traffic to port 18333 and finally taking down my server. I was running sipa's crawler, modified to add zonefile support.

Can this PR be considered for the next 0.11 release as well?
