### PR TITLE
Implement on-the-fly mempool size limitation

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -140,6 +140,7 @@ BITCOIN_CORE_H = \
   timedata.h \
   tinyformat.h \
   txdb.h \
+  txcheckcache.h \
   txmempool.h \
   ui_interface.h \
   uint256.h \
@@ -190,6 +191,7 @@ libbitcoin_server_a_SOURCES = \
   script/sigcache.cpp \
   timedata.cpp \
   txdb.cpp \
+  txcheckcache.cpp \
   txmempool.cpp \
   validationinterface.cpp \
   $(BITCOIN_CORE_H)

--- a/src/consensus/consensus.h
+++ b/src/consensus/consensus.h
@@ -6,11 +6,34 @@
 #ifndef BITCOIN_CONSENSUS_CONSENSUS_H
 #define BITCOIN_CONSENSUS_CONSENSUS_H
 
+#include "amount.h"
+
+class CCoinsViewCache;
+class CTransaction;
+class CValidationState;
+
 /** The maximum allowed size for a serialized block, in bytes (network rule) */
 static const unsigned int MAX_BLOCK_SIZE = 1000000;
 /** The maximum allowed number of signature check operations in a block (network rule) */
 static const unsigned int MAX_BLOCK_SIGOPS = MAX_BLOCK_SIZE/50;
 /** Coinbase transaction outputs can only be spent after this number of new blocks (network rule) */
 static const int COINBASE_MATURITY = 100;
+
+/**
+ * Consensus validations:
+ * Check_ means checking everything possible with the data provided
+ * (that has not been checked in previous cheaper functions for the same data structure).
+ * Verify_ means all data provided was enough for this level and its "consensus-verified".
+ */
+namespace Consensus {
+
+/**
+ * Check whether all inputs of this transaction are valid (no double spends and amounts)
+ * This does not modify the UTXO set. This does not check scripts and sigs.
+ * Preconditions: tx.IsCoinBase() is false.
+ */
+bool CheckTxInputs(const CTransaction& tx, CValidationState& state, const CCoinsViewCache& inputs, int nSpendHeight, CAmount& nTxFee);
+
+} // namespace Consensus
 
 #endif // BITCOIN_CONSENSUS_CONSENSUS_H

--- a/src/consensus/validation.h
+++ b/src/consensus/validation.h
@@ -75,6 +75,7 @@ public:
     }
     unsigned char GetRejectCode() const { return chRejectCode; }
     std::string GetRejectReason() const { return strRejectReason; }
+    int GetDoS() const { return nDoS; }
 };
 
 #endif // BITCOIN_CONSENSUS_VALIDATION_H

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -846,7 +846,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     if (mapArgs.count("-minrelaytxfee"))
     {
         CAmount n = 0;
-        if (ParseMoney(mapArgs["-minrelaytxfee"], n) && n > 0)
+        if (ParseMoney(mapArgs["-minrelaytxfee"], n) && MoneyRange(n))
             ::minRelayTxFee = CFeeRate(n);
         else
             return InitError(strprintf(_("Invalid amount for -minrelaytxfee=<amount>: '%s'"), mapArgs["-minrelaytxfee"]));

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -284,6 +284,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-dbcache=<n>", strprintf(_("Set database cache size in megabytes (%d to %d, default: %d)"), nMinDbCache, nMaxDbCache, nDefaultDbCache));
     strUsage += HelpMessageOpt("-loadblock=<file>", _("Imports blocks from external blk000??.dat file") + " " + _("on startup"));
     strUsage += HelpMessageOpt("-maxorphantx=<n>", strprintf(_("Keep at most <n> unconnectable transactions in memory (default: %u)"), DEFAULT_MAX_ORPHAN_TRANSACTIONS));
+    strUsage += HelpMessageOpt("-maxmempool=<n>", strprintf(_("Keep the transaction memory pool below <n> megabytes (default: %u)"), DEFAULT_MAX_MEMPOOL_SIZE));
     strUsage += HelpMessageOpt("-par=<n>", strprintf(_("Set the number of script verification threads (%u to %d, 0 = auto, <0 = leave that many cores free, default: %d)"),
         -GetNumCores(), MAX_SCRIPTCHECK_THREADS, DEFAULT_SCRIPTCHECK_THREADS));
 #ifndef WIN32
@@ -385,6 +386,7 @@ std::string HelpMessage(HelpMessageMode mode)
         strUsage += HelpMessageOpt("-maxsigcachesize=<n>", strprintf("Limit size of signature cache to <n> entries (default: %u)", 50000));
     }
     strUsage += HelpMessageOpt("-minrelaytxfee=<amt>", strprintf(_("Fees (in BTC/Kb) smaller than this are considered zero fee for relaying (default: %s)"), FormatMoney(::minRelayTxFee.GetFeePerK())));
+    strUsage += HelpMessageOpt("-relaybeyondmempool", _("Relay transactions even when there's no room for them in the mempool (default: 1)"));
     strUsage += HelpMessageOpt("-printtoconsole", _("Send trace/debug info to console instead of debug.log file"));
     if (showDebug)
     {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -18,6 +18,7 @@
 #include "main.h"
 #include "miner.h"
 #include "net.h"
+#include "policy/fees.h"
 #include "policy/policy.h"
 #include "rpcserver.h"
 #include "script/standard.h"

--- a/src/main.h
+++ b/src/main.h
@@ -284,7 +284,7 @@ unsigned int GetP2SHSigOpCount(const CTransaction& tx, const CCoinsViewCache& ma
  * This does not modify the UTXO set. If pvChecks is not NULL, script checks are pushed onto it
  * instead of being performed inline.
  */
-bool CheckInputs(const CTransaction& tx, CValidationState &state, const CCoinsViewCache &view, bool fScriptChecks,
+bool CheckInputsScripts(const CTransaction& tx, CValidationState &state, const CCoinsViewCache &view,
                  unsigned int flags, bool cacheStore, std::vector<CScriptCheck> *pvChecks = NULL);
 
 /** Apply the effects of this transaction on the UTXO set represented by view */

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -12,6 +12,7 @@
 #include "hash.h"
 #include "main.h"
 #include "net.h"
+#include "policy/fees.h"
 #include "policy/policy.h"
 #include "pow.h"
 #include "primitives/transaction.h"

--- a/src/policy/fees.h
+++ b/src/policy/fees.h
@@ -15,6 +15,22 @@
 class CAutoFile;
 class CFeeRate;
 class CTxMemPoolEntry;
+class CValidationState;
+
+/** Default for -blockprioritysize, maximum space for zero/low-fee transactions **/
+static const unsigned int DEFAULT_BLOCK_PRIORITY_SIZE = 50000;
+
+inline double AllowFreeThreshold()
+{
+    return COIN * 144 / 250;
+}
+
+inline bool AllowFree(double dPriority)
+{
+    // Large (in bytes) low-priority (new, small-coin) transactions
+    // need a fee.
+    return dPriority > AllowFreeThreshold();
+}
 
 /** \class CBlockPolicyEstimator
  * The BlockPolicyEstimator is used for estimating the fee or priority needed
@@ -250,6 +266,9 @@ public:
 
     /** Read estimation data from a file */
     void Read(CAutoFile& filein);
+
+    /** Allow transactions bellow the min relay fee or not */
+    bool AllowFreeTx(const CTxMemPoolEntry& toadd, CValidationState& state, const double& dViewPriority) const;
 
 private:
     CFeeRate minTrackedFee; //! Passed to constructor to avoid dependency on main

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -17,8 +17,6 @@ class CCoinsViewCache;
 /** Default for -blockmaxsize and -blockminsize, which control the range of sizes the mining code will create **/
 static const unsigned int DEFAULT_BLOCK_MAX_SIZE = 750000;
 static const unsigned int DEFAULT_BLOCK_MIN_SIZE = 0;
-/** Default for -blockprioritysize, maximum space for zero/low-fee transactions **/
-static const unsigned int DEFAULT_BLOCK_PRIORITY_SIZE = 50000;
 /** The maximum size for transactions we're willing to relay/mine */
 static const unsigned int MAX_STANDARD_TX_SIZE = 100000;
 /** Maximum number of signature check operations in an IsStandard() P2SH script */

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -15,6 +15,7 @@
 #include "coincontrol.h"
 #include "init.h"
 #include "main.h"
+#include "policy/fees.h"
 #include "wallet/wallet.h"
 
 #include <boost/assign/list_of.hpp> // for 'map_list_of()'

--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -34,7 +34,7 @@ extern unsigned nMaxDatacarrierBytes;
  * but in the future other flags may be added, such as a soft-fork to enforce
  * strict DER encoding.
  * 
- * Failing one of these tests may trigger a DoS ban - see CheckInputs() for
+ * Failing one of these tests may trigger a DoS ban - see CheckInputsScripts() for
  * details.
  */
 static const unsigned int MANDATORY_SCRIPT_VERIFY_FLAGS = SCRIPT_VERIFY_P2SH;

--- a/src/txcheckcache.cpp
+++ b/src/txcheckcache.cpp
@@ -1,0 +1,88 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2014 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "txcheckcache.h"
+
+#include "consensus/validation.h"
+#include "uint256.h"
+#include "util.h"
+
+
+CTxChecksCacheEntry::CTxChecksCacheEntry()
+    : nTime(0), chRejectCode(0), strRejectReason(""), fAcceptedOnce(false), nDoS(0)
+{
+}
+
+CTxChecksCache::CTxChecksCache(unsigned int nMaxCacheSizeIn)
+    : nMaxCacheSize(nMaxCacheSizeIn)
+{
+}
+
+CTxChecksCacheEntry& CTxChecksCache::UpdateEntry(const uint256& hash, int64_t nTime)
+{
+    if (!mTxChecksCache.count(hash)) {
+        mTxChecksCache[hash] = CTxChecksCacheEntry();
+
+        if (mTxChecksCache.size() == 1) {
+            nOldestTime = nTime;
+        } else if (mTxChecksCache.size() > nMaxCacheSize) {
+            // Remove the oldest
+            std::map<uint256, CTxChecksCacheEntry>::const_iterator it;
+            for (it = mTxChecksCache.begin(); it != mTxChecksCache.end(); ++it)
+                if (nOldestTime == it->second.nTime) {
+                    mTxChecksCache.erase(it->first);
+                    break;
+                }
+            // Recalculate the oldest
+            nOldestTime = mTxChecksCache.find(hash)->second.nTime;
+            for (it = mTxChecksCache.begin(); it != mTxChecksCache.end(); ++it)
+                if (nOldestTime > it->second.nTime)
+                    nOldestTime = it->second.nTime;
+        }
+    }
+    mTxChecksCache.find(hash)->second.nTime = nTime;
+    return mTxChecksCache.find(hash)->second;
+}
+
+bool CTxChecksCache::RejectTx(const uint256& hash, CValidationState& state, int64_t nTime)
+{
+    UpdateEntry(hash, nTime);
+    mTxChecksCache[hash].chRejectCode = state.GetRejectCode();
+    mTxChecksCache[hash].strRejectReason = state.GetRejectReason();
+    mTxChecksCache[hash].nDoS = state.GetDoS();
+    LogPrintf("%s%s: %s", mTxChecksCache.find(hash)->second.chRejectCode == REJECT_INVALID ? "ERROR: ": "", __func__, state.GetRejectReason());
+    return false;
+}
+
+bool CTxChecksCache::RejectTx(const uint256& hash, CValidationState& state, int64_t nTime, int nDoS, unsigned char chRejectCode, std::string strRejectReason, bool corruption)
+{
+    state.DoS(nDoS, false, chRejectCode, strRejectReason, corruption);
+    return RejectTx(hash, state, nTime);
+}
+
+
+void CTxChecksCache::AcceptTx(const uint256& hash, int64_t nTime)
+{
+    UpdateEntry(hash, nTime);
+    mTxChecksCache[hash].fAcceptedOnce = true;
+}
+
+bool CTxChecksCache::WasAcceptedOnce(const uint256& hash) const
+{
+    return mTxChecksCache.count(hash) && mTxChecksCache.find(hash)->second.fAcceptedOnce;
+}
+
+bool CTxChecksCache::RejectedPermanently(const uint256& hash, CValidationState& state) const
+{
+    if (mTxChecksCache.count(hash)) {
+        const CTxChecksCacheEntry& entry = mTxChecksCache.find(hash)->second;
+        LogPrintf("Cached tx: reason=%s, time=%d, acceptedOnce=%d, hash=%s", 
+                      entry.strRejectReason, entry.nTime, entry.fAcceptedOnce ? 1 : 0, hash.ToString());
+
+        if (entry.chRejectCode == REJECT_INVALID && entry.strRejectReason == "missing-inputs")
+            return !state.DoS(entry.nDoS, false, REJECT_INVALID, entry.strRejectReason);
+    }
+    return false;
+}

--- a/src/txcheckcache.h
+++ b/src/txcheckcache.h
@@ -1,0 +1,41 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2014 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_TX_CHECKS_CACHE_H
+#define BITCOIN_TX_CHECKS_CACHE_H
+
+#include "amount.h"
+
+class CValidationState;
+class uint256;
+
+struct CTxChecksCacheEntry
+{
+    int64_t nTime;
+    unsigned char chRejectCode;
+    std::string strRejectReason;
+    bool fAcceptedOnce;
+    int nDoS;
+
+    CTxChecksCacheEntry();
+};
+
+class CTxChecksCache
+{
+    std::map<uint256, CTxChecksCacheEntry> mTxChecksCache;
+    unsigned int nMaxCacheSize;
+    int64_t nOldestTime;
+public:
+    CTxChecksCache(unsigned int nMaxCacheSizeIn=10000);
+
+    CTxChecksCacheEntry& UpdateEntry(const uint256& hash, int64_t nTime);
+    bool RejectTx(const uint256& hash, CValidationState& state, int64_t nTime);
+    bool RejectTx(const uint256& hash, CValidationState& state, int64_t nTime, int levelDoS, unsigned char chRejectCodeIn=0, std::string strRejectReasonIn="", bool corruptionIn=false);
+    void AcceptTx(const uint256& hash, int64_t nTime);
+    bool WasAcceptedOnce(const uint256& hash) const;
+    bool RejectedPermanently(const uint256& hash, CValidationState& state) const;    
+};
+
+#endif // BITCOIN_TX_CHECKS_CACHE_H

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -275,7 +275,8 @@ void CTxMemPool::check(const CCoinsViewCache *pcoins) const
             waitingOnDependants.push_back(&it->second);
         else {
             CValidationState state;
-            assert(CheckInputs(tx, state, mempoolDuplicate, false, 0, false, NULL));
+            CAmount nTxFees;
+            assert(Consensus::CheckTxInputs(tx, state, mempoolDuplicate, GetSpendHeight(mempoolDuplicate), nTxFees));
             UpdateCoins(tx, state, mempoolDuplicate, 1000000);
         }
     }
@@ -289,7 +290,8 @@ void CTxMemPool::check(const CCoinsViewCache *pcoins) const
             stepsSinceLastRemove++;
             assert(stepsSinceLastRemove < waitingOnDependants.size());
         } else {
-            assert(CheckInputs(entry->GetTx(), state, mempoolDuplicate, false, 0, false, NULL));
+            CAmount nTxFees;
+            assert(Consensus::CheckTxInputs(entry->GetTx(), state, mempoolDuplicate, GetSpendHeight(mempoolDuplicate), nTxFees));
             UpdateCoins(entry->GetTx(), state, mempoolDuplicate, 1000000);
             stepsSinceLastRemove = 0;
         }

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -108,6 +108,19 @@ bool CTxMemPool::addUnchecked(const uint256& hash, const CTxMemPoolEntry &entry,
     return true;
 }
 
+void CTxMemPool::removeUnchecked(const uint256& hash)
+{
+    const CTxMemPoolEntry &entry = mapTx.find(hash)->second;
+
+    BOOST_FOREACH(const CTxIn& txin, entry.GetTx().vin)
+        mapNextTx.erase(txin.prevout);
+
+    totalTxSize -= entry.GetTxSize();
+    cachedInnerUsage -= entry.DynamicMemoryUsage();
+    mapTx.erase(hash);
+    nTransactionsUpdated++;
+    minerPolicyEstimator->removeTx(hash);
+}
 
 void CTxMemPool::remove(const CTransaction &origTx, std::list<CTransaction>& removed, bool fRecursive)
 {
@@ -143,15 +156,8 @@ void CTxMemPool::remove(const CTransaction &origTx, std::list<CTransaction>& rem
                     txToRemove.push_back(it->second.ptx->GetHash());
                 }
             }
-            BOOST_FOREACH(const CTxIn& txin, tx.vin)
-                mapNextTx.erase(txin.prevout);
-
             removed.push_back(tx);
-            totalTxSize -= mapTx[hash].GetTxSize();
-            cachedInnerUsage -= mapTx[hash].DynamicMemoryUsage();
-            mapTx.erase(hash);
-            nTransactionsUpdated++;
-            minerPolicyEstimator->removeTx(hash);
+            removeUnchecked(hash);
         }
     }
 }
@@ -432,4 +438,64 @@ bool CCoinsViewMemPool::HaveCoins(const uint256 &txid) const {
 size_t CTxMemPool::DynamicMemoryUsage() const {
     LOCK(cs);
     return memusage::DynamicUsage(mapTx) + memusage::DynamicUsage(mapNextTx) + memusage::DynamicUsage(mapDeltas) + cachedInnerUsage;
+}
+
+void CTxMemPool::ClearStaged()
+{
+    stage.clear();
+    nStageFeesRemoved = 0;
+}
+
+bool CTxMemPool::StageReplace(const CTxMemPoolEntry& toadd, CValidationState& state, bool fLimitFree, const CCoinsViewCache& view)
+{
+    ClearStaged();
+    bool fSpendConflicts = false;
+    // Check for conflicts with in-memory transactions
+    {
+        LOCK(cs); // protect pool.mapNextTx
+        BOOST_FOREACH(const CTxIn& in, toadd.GetTx().vin) {
+            if (mapNextTx.count(in.prevout))
+                fSpendConflicts = true;
+        }
+    }
+    const CTransaction& tx = toadd.GetTx();
+    uint256 hash = tx.GetHash();
+    const CAmount nFees = toadd.GetFee();
+    const size_t nSize = toadd.GetTxSize();
+
+    if (fSpendConflicts) {
+        // Disable replacement feature for now
+        return state.DoS(0, false, REJECT_INSUFFICIENTFEE, "replacement-rejected-conflicts");
+    }
+
+    if (fLimitFree && nFees < ::minRelayTxFee.GetFee(nSize) + nStageFeesRemoved) {
+
+        bool fAllowFree = true;
+        double dPriorityDelta = 0;
+        CAmount nFeeDelta = 0;
+        ApplyDeltas(hash, dPriorityDelta, nFeeDelta);
+        if (dPriorityDelta <= 0 || nFeeDelta <= 0) {
+            state.DoS(0, false, REJECT_INSUFFICIENTFEE, "insufficient fee");
+            fAllowFree = false;
+        } else if (!minerPolicyEstimator->AllowFreeTx(toadd, state, view.GetPriority(tx, chainActive.Height() + 1)))
+            fAllowFree = false;
+
+        if (!fAllowFree) {
+            LogPrintf("%s: %s: %d < %d (txHash %s)", __func__, state.GetRejectReason(), nFees, ::minRelayTxFee.GetFee(nSize) + nStageFeesRemoved, hash.ToString());
+            return false;
+        }
+    }
+
+    return true;
+}
+
+void CTxMemPool::RemoveStaged(const uint256& txHash)
+{
+    if (!stage.empty()) {
+        LogPrint("mempool", "Removing %u transactions (%d fees) from the mempool to make space for %s\n", stage.size(), nStageFeesRemoved, txHash.ToString());
+        BOOST_FOREACH(const uint256& hash, stage) {
+            removeUnchecked(hash);
+        }
+        ClearStaged();
+    }
 }

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -18,6 +18,8 @@ class CValidationState;
 
 /** Fake height value used in CCoins to signify they are only in the memory pool (since 0.8) */
 static const unsigned int MEMPOOL_HEIGHT = 0x7FFFFFFF;
+/** Default for -maxmempool, maximum megabytes of mempool memory usage */
+static const unsigned int DEFAULT_MAX_MEMPOOL_SIZE = 300;
 
 /**
  * CTxMemPool stores these:
@@ -141,7 +143,7 @@ public:
      *  - The transactions have to be removed from the mempool to accept toadd (due to spend conflicts and/or insufficient space in the mempool). 
      * @returns false if the new entry is rejected.
      */
-    bool StageReplace(const CTxMemPoolEntry& toadd, CValidationState& state, bool fLimitFree, const CCoinsViewCache& view);
+    bool StageReplace(const CTxMemPoolEntry& toadd, CValidationState& state, bool& fReplacementAccepted, bool fLimitFree, const CCoinsViewCache& view);
     void RemoveStaged(const uint256& txHash);
 
     unsigned long size()
@@ -175,6 +177,7 @@ public:
     bool ReadFeeEstimates(CAutoFile& filein);
 
     size_t DynamicMemoryUsage() const;
+    size_t GuessDynamicMemoryUsage(const CTxMemPoolEntry& entry) const;
 };
 
 /** 

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -14,18 +14,7 @@
 #include "sync.h"
 
 class CAutoFile;
-
-inline double AllowFreeThreshold()
-{
-    return COIN * 144 / 250;
-}
-
-inline bool AllowFree(double dPriority)
-{
-    // Large (in bytes) low-priority (new, small-coin) transactions
-    // need a fee.
-    return dPriority > AllowFreeThreshold();
-}
+class CValidationState;
 
 /** Fake height value used in CCoins to signify they are only in the memory pool (since 0.8) */
 static const unsigned int MEMPOOL_HEIGHT = 0x7FFFFFFF;
@@ -97,6 +86,8 @@ private:
 
     uint64_t totalTxSize; //! sum of all mempool tx' byte sizes
     uint64_t cachedInnerUsage; //! sum of dynamic memory usage of all the map elements (NOT the maps themselves)
+    CAmount nStageFeesRemoved;
+    std::set<uint256> stage;
 
 public:
     mutable CCriticalSection cs;
@@ -117,6 +108,7 @@ public:
     void setSanityCheck(bool _fSanityCheck) { fSanityCheck = _fSanityCheck; }
 
     bool addUnchecked(const uint256& hash, const CTxMemPoolEntry &entry, bool fCurrentEstimate = true);
+    void removeUnchecked(const uint256& hash);
     void remove(const CTransaction &tx, std::list<CTransaction>& removed, bool fRecursive = false);
     void removeCoinbaseSpends(const CCoinsViewCache *pcoins, unsigned int nMemPoolHeight);
     void removeConflicts(const CTransaction &tx, std::list<CTransaction>& removed);
@@ -137,6 +129,20 @@ public:
     void PrioritiseTransaction(const uint256 hash, const std::string strHash, double dPriorityDelta, const CAmount& nFeeDelta);
     void ApplyDeltas(const uint256 hash, double &dPriorityDelta, CAmount &nFeeDelta);
     void ClearPrioritisation(const uint256 hash);
+
+    /**
+     * Resets stage and nStageFeesRemoved.
+     */
+    void ClearStaged();
+    /**
+     * Build a stage list (attribute) of transaction (hashes) to replace such that:
+     *  - The list is consistent (if a parent is included, all its dependencies are included as well).
+     *  - No dependencies of toadd are removed.
+     *  - The transactions have to be removed from the mempool to accept toadd (due to spend conflicts and/or insufficient space in the mempool). 
+     * @returns false if the new entry is rejected.
+     */
+    bool StageReplace(const CTxMemPoolEntry& toadd, CValidationState& state, bool fLimitFree, const CCoinsViewCache& view);
+    void RemoveStaged(const uint256& txHash);
 
     unsigned long size()
     {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -12,6 +12,7 @@
 #include "consensus/validation.h"
 #include "main.h"
 #include "net.h"
+#include "policy/fees.h"
 #include "policy/policy.h"
 #include "script/script.h"
 #include "script/sign.h"


### PR DESCRIPTION
This is a reduced version of @sipa 's #6421 that caps the size of the mempool, 
but this one just introduces a dumb policy that simply rejects all replacements for now.
That policy can be replaced, by #6421 (a rebased version can be found at https://github.com/jtimon/bitcoin/tree/limitpool_rebased ) or something else when it's properly tested.

This dumb policy is similar to the one we're using for resolving conflicts in spends.
That spending conflicts policy should be located in the same place because it is likely that there can be some synergies.
For example, it would be also good to implement zeroconf-safe-RBF (also known as FSS-RBF), so that payers can increase the fees when they get their transactions stuck.
For this reason, this includes #6416 (although we can make a version without that if many people are already buidling on top of #6421 and they think the rebase on top of https://github.com/jtimon/bitcoin/tree/limitpool_rebased is too painful).
