### PR TITLE
Keep track of recently rejected transactions

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -50,6 +50,8 @@ struct CNodeStateStats;
 static const bool DEFAULT_ALERTS = true;
 /** Default for -maxorphantx, maximum number of orphan transactions kept in memory */
 static const unsigned int DEFAULT_MAX_ORPHAN_TRANSACTIONS = 100;
+/** The maximum number of recently rejected hashes kept in memory */
+static const unsigned int MAX_RECENT_REJECTS = 2000;
 /** The maximum size of a blk?????.dat file (since 0.8) */
 static const unsigned int MAX_BLOCKFILE_SIZE = 0x8000000; // 128 MiB
 /** The pre-allocation chunk size for blk?????.dat files (since 0.8) */


### PR DESCRIPTION
Nodes can have divergent policies on which transactions they will accept and relay.  This can cause you to repeatedly request and reject the same tx after its inved to you from various peers which have accepted it.  

This commit puts a 15 min timer on rerequesting the same tx hash if you just rejected it.  I think the proper value for this can be debated, it might be almost as effective with a significantly smaller timer like 1 min.
