### PR TITLE
Always clean up manual transaction prioritization

### DIFF
--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -193,6 +193,7 @@ void CTxMemPool::removeConflicts(const CTransaction &tx, std::list<CTransaction>
             if (txConflict != tx)
             {
                 remove(txConflict, removed, true);
+                ClearPrioritisation(txConflict.GetHash());
             }
         }
     }


### PR DESCRIPTION
This fixes #4818

An alternative fix is to add the transaction prioritization information to CTxMemPoolEntry itself, instead of storing it separately. This would add 128 bits to every transaction in the mempool, which seems undesirable, given that the majority of transactions won't have a manual transaction prioritization delta.

@morcos
