### PR TITLE
Don't share objects between TestInstances

### DIFF
--- a/qa/rpc-tests/test_framework/comptool.py
+++ b/qa/rpc-tests/test_framework/comptool.py
@@ -122,8 +122,8 @@ class TestNode(NodeConnCB):
 #    or false, then only the last tx is tested against outcome.)
 
 class TestInstance(object):
-    def __init__(self, objects=[], sync_every_block=True, sync_every_tx=False):
-        self.blocks_and_transactions = objects
+    def __init__(self, objects=None, sync_every_block=True, sync_every_tx=False):
+        self.blocks_and_transactions = objects if objects else []
         self.sync_every_block = sync_every_block
         self.sync_every_tx = sync_every_tx
 


### PR DESCRIPTION
If two TestInstances are created without providing a list of objects, they'll be shared across both instances.
