### PR TITLE
fix CBitcoinExtKeyBase template

### DIFF
--- a/src/base58.h
+++ b/src/base58.h
@@ -146,7 +146,10 @@ public:
 
     K GetKey() {
         K ret;
-        ret.Decode(&vchData[0]);
+        if (vchData.size() == Size) {
+            //if base58 encouded data not holds a ext key, return a !IsValid() key
+            ret.Decode(&vchData[0]);
+        }
         return ret;
     }
 

--- a/src/base58.h
+++ b/src/base58.h
@@ -146,12 +146,16 @@ public:
 
     K GetKey() {
         K ret;
-        ret.Decode(&vchData[0], &vchData[Size]);
+        ret.Decode(&vchData[0]);
         return ret;
     }
 
     CBitcoinExtKeyBase(const K &key) {
         SetKey(key);
+    }
+
+    CBitcoinExtKeyBase(const std::string& strBase58c) {
+        SetString(strBase58c.c_str(), Params().Base58Prefix(Type).size());
     }
 
     CBitcoinExtKeyBase() {}

--- a/src/test/bip32_tests.cpp
+++ b/src/test/bip32_tests.cpp
@@ -88,12 +88,23 @@ void RunTest(const TestVector &test) {
         unsigned char data[74];
         key.Encode(data);
         pubkey.Encode(data);
+
         // Test private key
         CBitcoinExtKey b58key; b58key.SetKey(key);
         BOOST_CHECK(b58key.ToString() == derive.prv);
+
+        CBitcoinExtKey b58keyDecodeCheck(derive.prv);
+        CExtKey checkKey = b58keyDecodeCheck.GetKey();
+        assert(checkKey == key); //ensure a base58 decoded key also matches
+
         // Test public key
         CBitcoinExtPubKey b58pubkey; b58pubkey.SetKey(pubkey);
         BOOST_CHECK(b58pubkey.ToString() == derive.pub);
+
+        CBitcoinExtPubKey b58PubkeyDecodeCheck(derive.pub);
+        CExtPubKey checkPubKey = b58PubkeyDecodeCheck.GetKey();
+        assert(checkPubKey == pubkey); //ensure a base58 decoded pubkey also matches
+
         // Derive new keys
         CExtKey keyNew;
         BOOST_CHECK(key.Derive(keyNew, derive.nChild));


### PR DESCRIPTION
- fix Decode call (req. only one param)
- add constructor for base58c->CExtKey

The current `Decode()` call with two parameters won't compile (not detected because the c++ temple never was evaluated).

Also adds test coverage.
