### PR TITLE
[mining] allow other signal listeners to provide scripts for mining

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2602,6 +2602,9 @@ void CWallet::UpdatedTransaction(const uint256 &hashTx)
 
 void CWallet::GetScriptForMining(boost::shared_ptr<CReserveScript> &script)
 {
+    if (script && script->reserveScript.size() > 0)
+        return;
+
     boost::shared_ptr<CReserveKey> rKey(new CReserveKey(this));
     CPubKey pubkey;
     if (!rKey->GetReservedKey(pubkey))


### PR DESCRIPTION
This simple change would allow other wallets/signal listeners to providing a scripts for the coinbase output. Currently the main wallet will always overwrite a possible available script.

Without this PR, RPC test for the new wallet would require to send in funds mined of ther current wallet.
