### PR TITLE
Give a better error message if system clock is bad

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1225,6 +1225,18 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
                     LogPrintf("Prune: pruned datadir may not have more than %d blocks; -checkblocks=%d may fail\n",
                         MIN_BLOCKS_TO_KEEP, GetArg("-checkblocks", 288));
                 }
+
+                {
+                    LOCK(cs_main);
+                    CBlockIndex* tip = chainActive.Tip();
+                    if (tip && tip->nTime > GetAdjustedTime() + 2 * 60 * 60) {
+                        strLoadError = _("The block database contains a block which appears to be from the future. "
+                                "This may be due to your computer's date and time being set incorrectly. "
+                                "Only rebuild the block database if you are sure that your computer's date and time are correct");
+                        break;
+                    }
+                }
+
                 if (!CVerifyDB().VerifyDB(pcoinsdbview, GetArg("-checklevel", 3),
                               GetArg("-checkblocks", 288))) {
                     strLoadError = _("Corrupted block database detected");


### PR DESCRIPTION
Fixes #2007

This checks to see if the system clock appears to be bad and gives a
helpful error message. If the user's clock is set incorrectly, hopefully
they'll abort, fix it, and then save themselves a fruitless resync.

I wasn't sure if I needed to grab cs_main before accessing chainActive.Tip(), is that correct?
