### PR TITLE
Code refractored in order to follow best coding practices

### DIFF
--- a/src/consensus/validation.h
+++ b/src/consensus/validation.h
@@ -64,9 +64,10 @@ public:
         return mode == MODE_ERROR;
     }
     bool IsInvalid(int &nDoSOut) const {
+        bool isInvalid = false;
         if (IsInvalid()) {
             nDoSOut = nDoS;
-            return true;
+            isInvalid = true;
         }
         return false;
     }

--- a/src/consensus/validation.h
+++ b/src/consensus/validation.h
@@ -69,7 +69,7 @@ public:
             nDoSOut = nDoS;
             isInvalid = true;
         }
-        return false;
+        return isInvalid;
     }
     bool CorruptionPossible() const {
         return corruptionPossible;

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -81,7 +81,6 @@ bool IsStandardTx(const CTransaction& tx, std::string& reason)
         // future-proofing. That's also enough to spend a 20-of-20
         // CHECKMULTISIG scriptPubKey, though such a scriptPubKey is not
         // considered standard)
-        bool 
         if (txin.scriptSig.size() > 1650) {
             reason = "scriptsig-size";
             isStandardTx = false;


### PR DESCRIPTION
Just a small code refractoring. But we should keep only one return in each function in order to improve readability and usability.
