### PR TITLE
Use unique name for AlertNotify tempfile

### DIFF
--- a/src/test/alert_tests.cpp
+++ b/src/test/alert_tests.cpp
@@ -162,8 +162,8 @@ BOOST_AUTO_TEST_CASE(AlertNotify)
     SetMockTime(11);
     const std::vector<unsigned char>& alertKey = Params(CBaseChainParams::MAIN).AlertKey();
 
-    boost::filesystem::path temp = GetTempPath() / "alertnotify.txt";
-    boost::filesystem::remove(temp);
+    boost::filesystem::path temp = GetTempPath() /
+        boost::filesystem::unique_path("alertnotify-%%%%.txt");
 
     mapArgs["-alertnotify"] = std::string("echo %s >> ") + temp.string();
 


### PR DESCRIPTION
Fixes #6524

Use a unique name for alertnotify.txt tempfile during AlertNotify test
