### PR TITLE
updated MAX_OUTBOUND_CONNECTIONS

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -56,7 +56,7 @@
 using namespace std;
 
 namespace {
-    const int MAX_OUTBOUND_CONNECTIONS = 8;
+    const int MAX_OUTBOUND_CONNECTIONS = 16;
 
     struct ListenSocket {
         SOCKET socket;


### PR DESCRIPTION
changed the maximum numbers of outbound connections from 8 to 16.
This is do to the general quality of the internet.

And i think this would benefit the network, and results in stronger connections from servers running the node.
