### PR TITLE
Do not store more than 200 timedata samples.

### DIFF
--- a/src/timedata.cpp
+++ b/src/timedata.cpp
@@ -40,16 +40,20 @@ static int64_t abs64(int64_t n)
     return (n >= 0 ? n : -n);
 }
 
+#define BITCOIN_TIMEDATA_MAX_SAMPLES 200
+
 void AddTimeData(const CNetAddr& ip, int64_t nOffsetSample)
 {
     LOCK(cs_nTimeOffset);
     // Ignore duplicates
     static set<CNetAddr> setKnown;
+    if (setKnown.size() == BITCOIN_TIMEDATA_MAX_SAMPLES)
+        return;
     if (!setKnown.insert(ip).second)
         return;
 
     // Add data
-    static CMedianFilter<int64_t> vTimeOffsets(200,0);
+    static CMedianFilter<int64_t> vTimeOffsets(BITCOIN_TIMEDATA_MAX_SAMPLES, 0);
     vTimeOffsets.input(nOffsetSample);
     LogPrintf("Added time data, samples %d, offset %+d (%+d minutes)\n", vTimeOffsets.size(), nOffsetSample, nOffsetSample/60);
 


### PR DESCRIPTION
As reported in the issue #6490, Bitcoin Core keeps and extends `std::set` of `CNetAddr` for all peers during the whole server run. Even for peers that do not affect the adjusted time of the Core at all.

This change makes it clear (do nothing after 200 timedata samples), saves some CPU time and memory.
