### PR TITLE
Enable running of python regression test on Windows

### DIFF
--- a/qa/pull-tester/rpc-tests.sh
+++ b/qa/pull-tester/rpc-tests.sh
@@ -5,13 +5,9 @@ CURDIR=$(cd $(dirname "$0"); pwd)
 # Get BUILDDIR and REAL_BITCOIND
 . "${CURDIR}/tests-config.sh"
 
-export BITCOINCLI=${BUILDDIR}/qa/pull-tester/run-bitcoin-cli
+export BITCOINCLI=${REAL_BITCOINCLI}
 export BITCOIND=${REAL_BITCOIND}
 
-if [ "x${EXEEXT}" = "x.exe" ]; then
-  echo "Win tests currently disabled"
-  exit 0
-fi
 
 #Run the tests
 


### PR DESCRIPTION
1) rpc-tests.sh - take out the exit if windows and also do not allow running of run-bitcoin-cli
   as it cannot be invoked as a windows process through python  therefore:

   export BITCOINCLI=${BUILDDIR}/qa/pull-tester/run-bitcoin-cli

   changed to 

   export BITCOINCLI=${REAL_BITCOINCLI}

2) util.py - allow for handling of windows NUL files as windows can not handle 
    references to /dev/null

   And although not required to enable windows scripts, I added extra code around the creation
   of the "cache" files in the event one or several are missing as was happening
   while I was initially debugging the script for the first time.
