### PR TITLE
Handle leveldb::DestroyDB() errors on wipe failure

### DIFF
--- a/src/leveldbwrapper.cpp
+++ b/src/leveldbwrapper.cpp
@@ -58,7 +58,8 @@ CLevelDBWrapper::CLevelDBWrapper(const boost::filesystem::path& path, size_t nCa
     } else {
         if (fWipe) {
             LogPrintf("Wiping LevelDB in %s\n", path.string());
-            leveldb::DestroyDB(path.string(), options);
+            leveldb::Status result = leveldb::DestroyDB(path.string(), options);
+            HandleError(result);
         }
         TryCreateDirectory(path);
         LogPrintf("Opening LevelDB in %s\n", path.string());


### PR DESCRIPTION
Add error checking to CLevelDBWrapper for errors from
leveldb::DestroyDB().  Without it, if unlink() or DeleteFileW() fail to
delete files, they will fail silent.  If they fail to delete any files,
CLevelDBWrapper will silently open and read the existing database.

Typically any permissions issues would be caught by leveldb as it churns
through many files as part of its compaction process, but it is
conceivable that this could cause problems on Windows with anti-virus
and indexing software.
