### PR TITLE
Make sure we re-acquire lock if a task throws

### DIFF
--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -6,6 +6,7 @@
 
 #include <assert.h>
 #include <boost/bind.hpp>
+#include <boost/thread/reverse_lock.hpp>
 #include <utility>
 
 CScheduler::CScheduler() : nThreadsServicingQueue(0), stopRequested(false), stopWhenEmpty(false)
@@ -65,11 +66,12 @@ void CScheduler::serviceQueue()
             Function f = taskQueue.begin()->second;
             taskQueue.erase(taskQueue.begin());
 
-            // Unlock before calling f, so it can reschedule itself or another task
-            // without deadlocking:
-            lock.unlock();
-            f();
-            lock.lock();
+            {
+                // Unlock before calling f, so it can reschedule itself or another task
+                // without deadlocking:
+                boost::reverse_lock<boost::unique_lock<boost::mutex> > rlock(lock);
+                f();
+            }
         } catch (...) {
             --nThreadsServicingQueue;
             throw;


### PR DESCRIPTION
This fixes #6394

Pretty simple, it just makes sure to re-acquire the lock in case f throws, so that we don't touch nThreadsServicingQueue without the lock. The empty throw statement re-raises the current exception.
