### PR TITLE
[UniValue] replace global function find_value() with UniValue::findValue()

### DIFF
--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -244,8 +244,8 @@ int CommandLineRPC(int argc, char *argv[])
                 const UniValue reply = CallRPC(strMethod, params);
 
                 // Parse reply
-                const UniValue& result = find_value(reply, "result");
-                const UniValue& error  = find_value(reply, "error");
+                const UniValue& result = reply.findValue("result");
+                const UniValue& error  = reply.findValue("error");
 
                 if (!error.isNull()) {
                     // Error
@@ -256,8 +256,8 @@ int CommandLineRPC(int argc, char *argv[])
                     nRet = abs(code);
                     if (error.isObject())
                     {
-                        UniValue errCode = find_value(error, "code");
-                        UniValue errMsg  = find_value(error, "message");
+                        UniValue errCode = error.findValue("code");
+                        UniValue errMsg  = error.findValue("message");
                         strPrint = errCode.isNull() ? "" : "error code: "+errCode.getValStr()+"\n";
 
                         if (errMsg.isStr())

--- a/src/httprpc.cpp
+++ b/src/httprpc.cpp
@@ -59,7 +59,7 @@ static void JSONErrorReply(HTTPRequest* req, const UniValue& objError, const Uni
 {
     // Send error reply from json-rpc error object
     int nStatus = HTTP_INTERNAL_SERVER_ERROR;
-    int code = find_value(objError, "code").get_int();
+    int code = objError.findValue("code").get_int();
 
     if (code == RPC_INVALID_REQUEST)
         nStatus = HTTP_BAD_REQUEST;

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -222,8 +222,8 @@ void RPCExecutor::request(const QString &command)
     {
         try // Nice formatting for standard-format error
         {
-            int code = find_value(objError, "code").get_int();
-            std::string message = find_value(objError, "message").get_str();
+            int code = objError.findValue("code").get_int();
+            std::string message = objError.findValue("message").get_str();
             Q_EMIT reply(RPCConsole::CMD_ERROR, QString::fromStdString(message) + " (code " + QString::number(code) + ")");
         }
         catch (const std::runtime_error&) // raised when converting to invalid type, i.e. missing code or message

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -388,7 +388,7 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
     if (params.size() > 0)
     {
         const UniValue& oparam = params[0].get_obj();
-        const UniValue& modeval = find_value(oparam, "mode");
+        const UniValue& modeval = oparam.findValue("mode");
         if (modeval.isStr())
             strMode = modeval.get_str();
         else if (modeval.isNull())
@@ -397,11 +397,11 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
         }
         else
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid mode");
-        lpval = find_value(oparam, "longpollid");
+        lpval = oparam.findValue("longpollid");
 
         if (strMode == "proposal")
         {
-            const UniValue& dataval = find_value(oparam, "data");
+            const UniValue& dataval = oparam.findValue("data");
             if (!dataval.isStr())
                 throw JSONRPCError(RPC_TYPE_ERROR, "Missing data String key for proposal");
 

--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -364,7 +364,7 @@ UniValue createrawtransaction(const UniValue& params, bool fHelp)
 
         uint256 txid = ParseHashO(o, "txid");
 
-        const UniValue& vout_v = find_value(o, "vout");
+        const UniValue& vout_v = o.findValue("vout");
         if (!vout_v.isNum())
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, missing vout key");
         int nOutput = vout_v.get_int();
@@ -665,7 +665,7 @@ UniValue signrawtransaction(const UniValue& params, bool fHelp)
 
             uint256 txid = ParseHashO(prevOut, "txid");
 
-            int nOut = find_value(prevOut, "vout").get_int();
+            int nOut = prevOut.findValue("vout").get_int();
             if (nOut < 0)
                 throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "vout must be positive");
 
@@ -690,7 +690,7 @@ UniValue signrawtransaction(const UniValue& params, bool fHelp)
             // given), add redeemScript to the tempKeystore so it can be signed:
             if (fGivenKeys && scriptPubKey.IsPayToScriptHash()) {
                 RPCTypeCheckObj(prevOut, boost::assign::map_list_of("txid", UniValue::VSTR)("vout", UniValue::VNUM)("scriptPubKey", UniValue::VSTR)("redeemScript",UniValue::VSTR));
-                UniValue v = find_value(prevOut, "redeemScript");
+                UniValue v = prevOut.findValue("redeemScript");
                 if (!v.isNull()) {
                     vector<unsigned char> rsData(ParseHexV(v, "redeemScript"));
                     CScript redeemScript(rsData.begin(), rsData.end());

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -93,7 +93,7 @@ void RPCTypeCheckObj(const UniValue& o,
 {
     BOOST_FOREACH(const PAIRTYPE(string, UniValue::VType)& t, typesExpected)
     {
-        const UniValue& v = find_value(o, t.first);
+        const UniValue& v = o.findValue(t.first);
         if (!fAllowNull && v.isNull())
             throw JSONRPCError(RPC_TYPE_ERROR, strprintf("Missing %s", t.first));
 
@@ -141,7 +141,7 @@ uint256 ParseHashV(const UniValue& v, string strName)
 }
 uint256 ParseHashO(const UniValue& o, string strKey)
 {
-    return ParseHashV(find_value(o, strKey), strKey);
+    return ParseHashV(o.findValue(strKey), strKey);
 }
 vector<unsigned char> ParseHexV(const UniValue& v, string strName)
 {
@@ -154,7 +154,7 @@ vector<unsigned char> ParseHexV(const UniValue& v, string strName)
 }
 vector<unsigned char> ParseHexO(const UniValue& o, string strKey)
 {
-    return ParseHexV(find_value(o, strKey), strKey);
+    return ParseHexV(o.findValue(strKey), strKey);
 }
 
 /**
@@ -448,10 +448,10 @@ void JSONRequest::parse(const UniValue& valRequest)
     const UniValue& request = valRequest.get_obj();
 
     // Parse id now so errors from here on will have the id
-    id = find_value(request, "id");
+    id = request.findValue("id");
 
     // Parse method
-    UniValue valMethod = find_value(request, "method");
+    UniValue valMethod = request.findValue("method");
     if (valMethod.isNull())
         throw JSONRPCError(RPC_INVALID_REQUEST, "Missing method");
     if (!valMethod.isStr())
@@ -461,7 +461,7 @@ void JSONRequest::parse(const UniValue& valRequest)
         LogPrint("rpc", "ThreadRPCServer method=%s\n", SanitizeString(strMethod));
 
     // Parse params
-    UniValue valParams = find_value(request, "params");
+    UniValue valParams = request.findValue("params");
     if (valParams.isArray())
         params = valParams.get_array();
     else if (valParams.isNull())

--- a/src/test/base58_tests.cpp
+++ b/src/test/base58_tests.cpp
@@ -137,15 +137,15 @@ BOOST_AUTO_TEST_CASE(base58_keys_valid_parse)
         std::string exp_base58string = test[0].get_str();
         std::vector<unsigned char> exp_payload = ParseHex(test[1].get_str());
         const UniValue &metadata = test[2].get_obj();
-        bool isPrivkey = find_value(metadata, "isPrivkey").get_bool();
-        bool isTestnet = find_value(metadata, "isTestnet").get_bool();
+        bool isPrivkey = metadata.findValue("isPrivkey").get_bool();
+        bool isTestnet = metadata.findValue("isTestnet").get_bool();
         if (isTestnet)
             SelectParams(CBaseChainParams::TESTNET);
         else
             SelectParams(CBaseChainParams::MAIN);
         if(isPrivkey)
         {
-            bool isCompressed = find_value(metadata, "isCompressed").get_bool();
+            bool isCompressed = metadata.findValue("isCompressed").get_bool();
             // Must be valid private key
             // Note: CBitcoinSecret::SetString tests isValid, whereas CBitcoinAddress does not!
             BOOST_CHECK_MESSAGE(secret.SetString(exp_base58string), "!SetString:"+ strTest);
@@ -160,7 +160,7 @@ BOOST_AUTO_TEST_CASE(base58_keys_valid_parse)
         }
         else
         {
-            std::string exp_addrType = find_value(metadata, "addrType").get_str(); // "script" or "pubkey"
+            std::string exp_addrType = metadata.findValue("addrType").get_str(); // "script" or "pubkey"
             // Must be valid public key
             BOOST_CHECK_MESSAGE(addr.SetString(exp_base58string), "SetString:" + strTest);
             BOOST_CHECK_MESSAGE(addr.IsValid(), "!IsValid:" + strTest);
@@ -192,15 +192,15 @@ BOOST_AUTO_TEST_CASE(base58_keys_valid_gen)
         std::string exp_base58string = test[0].get_str();
         std::vector<unsigned char> exp_payload = ParseHex(test[1].get_str());
         const UniValue &metadata = test[2].get_obj();
-        bool isPrivkey = find_value(metadata, "isPrivkey").get_bool();
-        bool isTestnet = find_value(metadata, "isTestnet").get_bool();
+        bool isPrivkey = metadata.findValue("isPrivkey").get_bool();
+        bool isTestnet = metadata.findValue("isTestnet").get_bool();
         if (isTestnet)
             SelectParams(CBaseChainParams::TESTNET);
         else
             SelectParams(CBaseChainParams::MAIN);
         if(isPrivkey)
         {
-            bool isCompressed = find_value(metadata, "isCompressed").get_bool();
+            bool isCompressed = metadata.findValue("isCompressed").get_bool();
             CKey key;
             key.Set(exp_payload.begin(), exp_payload.end(), isCompressed);
             assert(key.IsValid());
@@ -210,7 +210,7 @@ BOOST_AUTO_TEST_CASE(base58_keys_valid_gen)
         }
         else
         {
-            std::string exp_addrType = find_value(metadata, "addrType").get_str();
+            std::string exp_addrType = metadata.findValue("addrType").get_str();
             CTxDestination dest;
             if(exp_addrType == "pubkey")
             {

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -246,7 +246,7 @@ BOOST_AUTO_TEST_CASE(rpc_ban)
     ar = r.get_array();
     o1 = ar[0].get_obj();
     adr = o1.findValue("address");
-    UniValue banned_until = find_value(o1, "banned_until");
+    UniValue banned_until = o1.findValue("banned_until");
     BOOST_CHECK_EQUAL(adr.get_str(), "127.0.0.0/24");
     BOOST_CHECK_EQUAL(banned_until.get_int64(), 1607731200); // absolute time check
 
@@ -257,7 +257,7 @@ BOOST_AUTO_TEST_CASE(rpc_ban)
     ar = r.get_array();
     o1 = ar[0].get_obj();
     adr = o1.findValue("address");
-    banned_until = find_value(o1, "banned_until");
+    banned_until = o1.findValue("banned_until");
     BOOST_CHECK_EQUAL(adr.get_str(), "127.0.0.0/24");
     int64_t now = GetTime();    
     BOOST_CHECK(banned_until.get_int64() > now);

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -43,7 +43,7 @@ UniValue CallRPC(string args)
         return result;
     }
     catch (const UniValue& objError) {
-        throw runtime_error(find_value(objError, "message").get_str());
+        throw runtime_error(objError.findValue("message").get_str());
     }
 }
 
@@ -72,8 +72,8 @@ BOOST_AUTO_TEST_CASE(rpc_rawparams)
     BOOST_CHECK_THROW(CallRPC("decoderawtransaction DEADBEEF"), runtime_error);
     string rawtx = "0100000001a15d57094aa7a21a28cb20b59aab8fc7d1149a3bdbcddba9c622e4f5f6a99ece010000006c493046022100f93bb0e7d8db7bd46e40132d1f8242026e045f03a0efe71bbb8e3f475e970d790221009337cd7f1f929f00cc6ff01f03729b069a7c21b59b1736ddfee5db5946c5da8c0121033b9b137ee87d5a812d6f506efdd37f0affa7ffc310711c06c7f3e097c9447c52ffffffff0100e1f505000000001976a9140389035a9225b3839e2bbf32d826a1e222031fd888ac00000000";
     BOOST_CHECK_NO_THROW(r = CallRPC(string("decoderawtransaction ")+rawtx));
-    BOOST_CHECK_EQUAL(find_value(r.get_obj(), "version").get_int(), 1);
-    BOOST_CHECK_EQUAL(find_value(r.get_obj(), "locktime").get_int(), 0);
+    BOOST_CHECK_EQUAL(r.get_obj().findValue("version").get_int(), 1);
+    BOOST_CHECK_EQUAL(r.get_obj().findValue("locktime").get_int(), 0);
     BOOST_CHECK_THROW(r = CallRPC(string("decoderawtransaction ")+rawtx+" extra"), runtime_error);
 
     BOOST_CHECK_THROW(CallRPC("signrawtransaction"), runtime_error);
@@ -105,9 +105,9 @@ BOOST_AUTO_TEST_CASE(rpc_rawsign)
     string privkey1 = "\"KzsXybp9jX64P5ekX1KUxRQ79Jht9uzW7LorgwE65i5rWACL6LQe\"";
     string privkey2 = "\"Kyhdf5LuKTRx4ge69ybABsiUAWjVRK4XGxAKk2FQLp2HjGMy87Z4\"";
     r = CallRPC(string("signrawtransaction ")+notsigned+" "+prevout+" "+"[]");
-    BOOST_CHECK(find_value(r.get_obj(), "complete").get_bool() == false);
+    BOOST_CHECK(r.get_obj().findValue("complete").get_bool() == false);
     r = CallRPC(string("signrawtransaction ")+notsigned+" "+prevout+" "+"["+privkey1+","+privkey2+"]");
-    BOOST_CHECK(find_value(r.get_obj(), "complete").get_bool() == true);
+    BOOST_CHECK(r.get_obj().findValue("complete").get_bool() == true);
 }
 
 BOOST_AUTO_TEST_CASE(rpc_createraw_op_return)
@@ -234,7 +234,7 @@ BOOST_AUTO_TEST_CASE(rpc_ban)
     BOOST_CHECK_NO_THROW(r = CallRPC(string("listbanned")));
     UniValue ar = r.get_array();
     UniValue o1 = ar[0].get_obj();
-    UniValue adr = find_value(o1, "address");
+    UniValue adr = o1.findValue("address");
     BOOST_CHECK_EQUAL(adr.get_str(), "127.0.0.0/32");
     BOOST_CHECK_NO_THROW(CallRPC(string("setban 127.0.0.0 remove")));;
     BOOST_CHECK_NO_THROW(r = CallRPC(string("listbanned")));
@@ -245,7 +245,7 @@ BOOST_AUTO_TEST_CASE(rpc_ban)
     BOOST_CHECK_NO_THROW(r = CallRPC(string("listbanned")));
     ar = r.get_array();
     o1 = ar[0].get_obj();
-    adr = find_value(o1, "address");
+    adr = o1.findValue("address");
     UniValue banned_until = find_value(o1, "banned_until");
     BOOST_CHECK_EQUAL(adr.get_str(), "127.0.0.0/24");
     BOOST_CHECK_EQUAL(banned_until.get_int64(), 1607731200); // absolute time check
@@ -256,7 +256,7 @@ BOOST_AUTO_TEST_CASE(rpc_ban)
     BOOST_CHECK_NO_THROW(r = CallRPC(string("listbanned")));
     ar = r.get_array();
     o1 = ar[0].get_obj();
-    adr = find_value(o1, "address");
+    adr = o1.findValue("address");
     banned_until = find_value(o1, "banned_until");
     BOOST_CHECK_EQUAL(adr.get_str(), "127.0.0.0/24");
     int64_t now = GetTime();    
@@ -287,7 +287,7 @@ BOOST_AUTO_TEST_CASE(rpc_ban)
     BOOST_CHECK_NO_THROW(r = CallRPC(string("listbanned")));
     ar = r.get_array();
     o1 = ar[0].get_obj();
-    adr = find_value(o1, "address");
+    adr = o1.findValue("address");
     BOOST_CHECK_EQUAL(adr.get_str(), "fe80::202:b3ff:fe1e:8329/128");
 
     BOOST_CHECK_NO_THROW(CallRPC(string("clearbanned")));
@@ -295,7 +295,7 @@ BOOST_AUTO_TEST_CASE(rpc_ban)
     BOOST_CHECK_NO_THROW(r = CallRPC(string("listbanned")));
     ar = r.get_array();
     o1 = ar[0].get_obj();
-    adr = find_value(o1, "address");
+    adr = o1.findValue("address");
     BOOST_CHECK_EQUAL(adr.get_str(), "2001:db8::/30");
 
     BOOST_CHECK_NO_THROW(CallRPC(string("clearbanned")));
@@ -303,7 +303,7 @@ BOOST_AUTO_TEST_CASE(rpc_ban)
     BOOST_CHECK_NO_THROW(r = CallRPC(string("listbanned")));
     ar = r.get_array();
     o1 = ar[0].get_obj();
-    adr = find_value(o1, "address");
+    adr = o1.findValue("address");
     BOOST_CHECK_EQUAL(adr.get_str(), "2001:4d48:ac57:400:cacf:e9ff:fe1d:9c63/128");
 }
 

--- a/src/test/univalue_tests.cpp
+++ b/src/test/univalue_tests.cpp
@@ -280,6 +280,18 @@ BOOST_AUTO_TEST_CASE(univalue_object)
     objTypes["cat2"] = UniValue::VSTR;
     BOOST_CHECK(!obj.checkObject(objTypes));
 
+    UniValue obj3(UniValue::VOBJ);
+    BOOST_CHECK(obj3.pushKV("eyes", "open"));
+    BOOST_CHECK(obj3.pushKV("speed", 1337));
+    BOOST_CHECK(obj.pushKV("details", obj3));
+
+    BOOST_CHECK_EQUAL(obj.findValue("first").get_str(), "John");
+    BOOST_CHECK_EQUAL(obj.findValue("distance").get_int(), 25);
+    BOOST_CHECK_EQUAL(obj.findValue("details").findValue("eyes").get_str(), "open");
+    BOOST_CHECK_EQUAL(obj.findValue("details").findValue("speed").get_int(), 1337);
+
+    BOOST_CHECK(obj.findValue("notavailable").isNull());
+
     obj.clear();
     BOOST_CHECK(obj.empty());
     BOOST_CHECK_EQUAL(obj.size(), 0);

--- a/src/univalue/univalue.cpp
+++ b/src/univalue/univalue.cpp
@@ -164,6 +164,16 @@ int UniValue::findKey(const std::string& key) const
     return -1;
 }
 
+const UniValue UniValue::findValue(const std::string& key) const
+{
+    for (unsigned int i = 0; i < keys.size(); i++) {
+        if (keys[i] == key)
+            return values[i];
+    }
+
+    return NullUniValue;
+}
+
 bool UniValue::checkObject(const std::map<std::string,UniValue::VType>& t)
 {
     for (std::map<std::string,UniValue::VType>::const_iterator it = t.begin();
@@ -214,19 +224,6 @@ const char *uvTypeName(UniValue::VType t)
 
     // not reached
     return NULL;
-}
-
-const UniValue& find_value( const UniValue& obj, const std::string& name)
-{
-    for (unsigned int i = 0; i < obj.keys.size(); i++)
-    {
-        if( obj.keys[i] == name )
-        {
-            return obj.values[i];
-        }
-    }
-
-    return NullUniValue;
 }
 
 std::vector<std::string> UniValue::getKeys() const

--- a/src/univalue/univalue.h
+++ b/src/univalue/univalue.h
@@ -154,7 +154,8 @@ public:
     bool push_back(std::pair<std::string,UniValue> pear) {
         return pushKV(pear.first, pear.second);
     }
-    friend const UniValue& find_value( const UniValue& obj, const std::string& name);
+    //!return a value if key was found (only supports VOBJ types)
+    const UniValue findValue(const std::string& key) const;
 };
 
 //
@@ -242,7 +243,5 @@ extern enum jtokentype getJsonToken(std::string& tokenVal,
 extern const char *uvTypeName(UniValue::VType t);
 
 extern const UniValue NullUniValue;
-
-const UniValue& find_value( const UniValue& obj, const std::string& name);
 
 #endif // BITCOIN_UNIVALUE_UNIVALUE_H

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2088,11 +2088,11 @@ UniValue lockunspent(const UniValue& params, bool fHelp)
 
         RPCTypeCheckObj(o, boost::assign::map_list_of("txid", UniValue::VSTR)("vout", UniValue::VNUM));
 
-        string txid = find_value(o, "txid").get_str();
+        string txid = o.findValue("txid").get_str();
         if (!IsHex(txid))
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, expected hex txid");
 
-        int nOutput = find_value(o, "vout").get_int();
+        int nOutput = o.findValue("vout").get_int();
         if (nOutput < 0)
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, vout must be positive");
 


### PR DESCRIPTION
The global function `find_value()` was implemented in `UniValue` to allow compatibility with JsonSpirit. This is no longer required and we should therefore move it to the UniValue object context.
