### PR TITLE
Fix stale socket rebinding and re-enable python tests for Windows

### DIFF
--- a/qa/pull-tester/rpc-tests.sh
+++ b/qa/pull-tester/rpc-tests.sh
@@ -8,11 +8,6 @@ CURDIR=$(cd $(dirname "$0"); pwd)
 export BITCOINCLI=${BUILDDIR}/qa/pull-tester/run-bitcoin-cli
 export BITCOIND=${REAL_BITCOIND}
 
-if [ "x${EXEEXT}" = "x.exe" ]; then
-  echo "Win tests currently disabled"
-  exit 0
-fi
-
 #Run the tests
 
 testScripts=(

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1625,8 +1625,10 @@ bool BindListenPort(const CService &addrBind, string& strError, bool fWhiteliste
     setsockopt(hListenSocket, SOL_SOCKET, SO_NOSIGPIPE, (void*)&nOne, sizeof(int));
 #endif
     // Allow binding if the port is still in TIME_WAIT state after
-    // the program was closed and restarted. Not an issue on windows!
+    // the program was closed and restarted.
     setsockopt(hListenSocket, SOL_SOCKET, SO_REUSEADDR, (void*)&nOne, sizeof(int));
+#else
+    setsockopt(hListenSocket, SOL_SOCKET, SO_REUSEADDR, (const char*)&nOne, sizeof(int));
 #endif
 
     // Set to non-blocking, incoming connections will also inherit this


### PR DESCRIPTION
The fix is debatable, but it points out the real issue: when testing with Windows, stale sockets from previous runs cause the current tests' listen sockets to be unavailable, leading to nodes that never sync. I'm sure that translates to real-world issues as well, for example watchdog scripts would likely fail to work as intended. I'm not sure if there's a more proper way to fix the problem for Windows, so I just copied the behavior we already use for Unix.

This may be part of the root cause of #6554, but I'm not sure about that.

With that fixed, these test run fine locally. Note that they do take quite a while to run though, so we might not want to enable them on Travis for every PR/push.
