### PR TITLE
Chainparams: Don't check the genesis block

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1726,10 +1726,6 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
 
     int64_t nTimeStart = GetTimeMicros();
 
-    // Check it again in case a previous version let a bad block in
-    if (!CheckBlock(block, state, !fJustCheck, !fJustCheck))
-        return false;
-
     // verify that the view's current state corresponds to the previous block
     uint256 hashPrevBlock = pindex->pprev == NULL ? uint256() : pindex->pprev->GetBlockHash();
     assert(hashPrevBlock == view.GetBestBlock());
@@ -1741,6 +1737,10 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
             view.SetBestBlock(pindex->GetBlockHash());
         return true;
     }
+
+    // Check it again in case a previous version let a bad block in
+    if (!CheckBlock(block, state, !fJustCheck, !fJustCheck))
+        return false;
 
     bool fScriptChecks = true;
     if (fCheckpointsEnabled) {
@@ -3158,7 +3158,7 @@ CBlockIndex * InsertBlockIndex(uint256 hash)
 bool static LoadBlockIndexDB()
 {
     const CChainParams& chainparams = Params();
-    if (!pblocktree->LoadBlockIndexGuts())
+    if (!pblocktree->LoadBlockIndexGuts(chainparams.GetConsensus()))
         return false;
 
     boost::this_thread::interruption_point();

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -175,7 +175,7 @@ bool CBlockTreeDB::ReadFlag(const std::string &name, bool &fValue) {
     return true;
 }
 
-bool CBlockTreeDB::LoadBlockIndexGuts()
+bool CBlockTreeDB::LoadBlockIndexGuts(const Consensus::Params& consensusParams)
 {
     boost::scoped_ptr<CDBIterator> pcursor(NewIterator());
 
@@ -203,7 +203,8 @@ bool CBlockTreeDB::LoadBlockIndexGuts()
                 pindexNew->nStatus        = diskindex.nStatus;
                 pindexNew->nTx            = diskindex.nTx;
 
-                if (!CheckProofOfWork(pindexNew->GetBlockHash(), pindexNew->nBits, Params().GetConsensus()))
+                if (!CheckProofOfWork(pindexNew->GetBlockHash(), pindexNew->nBits, consensusParams) &&
+                    pindexNew->GetBlockHash() != consensusParams.hashGenesisBlock)
                     return error("LoadBlockIndex(): CheckProofOfWork failed: %s", pindexNew->ToString());
 
                 pcursor->Next();

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -18,6 +18,7 @@ class CBlockFileInfo;
 class CBlockIndex;
 struct CDiskTxPos;
 class uint256;
+namespace Consensus { struct Params; }
 
 //! -dbcache default (MiB)
 static const int64_t nDefaultDbCache = 100;
@@ -59,7 +60,7 @@ public:
     bool WriteTxIndex(const std::vector<std::pair<uint256, CDiskTxPos> > &list);
     bool WriteFlag(const std::string &name, bool fValue);
     bool ReadFlag(const std::string &name, bool &fValue);
-    bool LoadBlockIndexGuts();
+    bool LoadBlockIndexGuts(const Consensus::Params& consensusParams);
 };
 
 #endif // BITCOIN_TXDB_H


### PR DESCRIPTION
The genesis block is the truth: don't check it.
Apart from being a minimal optimization, this removes the necessity of "mining the genesis block" when new testchains are created. This is a necessary step for #6382 (which creates `std::numeric_limits<uint64_t>::max()` new testchains).
