### PR TITLE
Make sure LogPrint strings are line-terminated

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -659,7 +659,7 @@ bool CNode::ReceiveMsgBytes(const char *pch, unsigned int nBytes)
                 return false;
 
         if (msg.in_data && msg.hdr.nMessageSize > MAX_PROTOCOL_MESSAGE_LENGTH) {
-            LogPrint("net", "Oversized message from peer=%i, disconnecting", GetId());
+            LogPrint("net", "Oversized message from peer=%i, disconnecting\n", GetId());
             return false;
         }
 


### PR DESCRIPTION
Seems to have been missed in #6497, but do let me know if there's a reason this shouldn't have a new line at the end.
