### PR TITLE
Include bitcoin-tx binary on Debian/Ubuntu

### DIFF
--- a/contrib/debian/bitcoin-tx.install
+++ b/contrib/debian/bitcoin-tx.install
@@ -1,0 +1,1 @@
+usr/local/bin/bitcoin-tx usr/bin

--- a/contrib/debian/bitcoind.install
+++ b/contrib/debian/bitcoind.install
@@ -1,3 +1,2 @@
 usr/local/bin/bitcoind usr/bin
 usr/local/bin/bitcoin-cli usr/bin
-usr/local/bin/bitcoin-tx usr/bin

--- a/contrib/debian/bitcoind.install
+++ b/contrib/debian/bitcoind.install
@@ -1,2 +1,3 @@
 usr/local/bin/bitcoind usr/bin
 usr/local/bin/bitcoin-cli usr/bin
+usr/local/bin/bitcoin-tx usr/bin

--- a/contrib/debian/control
+++ b/contrib/debian/control
@@ -68,6 +68,5 @@ Description: peer-to-peer digital currency - standalone transaction tool
  check for double-spending.
  .
  This package provides bitcoin-tx, a command-line transaction creation
- tool with minimal dependencies which can be used without a bitcoin
- daemon.  Some means of exchanging minimal transaction data with peers
- is still required.
+ tool which can be used without a bitcoin daemon.  Some means of
+ exchanging minimal transaction data with peers is still required.

--- a/contrib/debian/control
+++ b/contrib/debian/control
@@ -56,3 +56,18 @@ Description: peer-to-peer network based digital currency - Qt GUI
  requires 20+ GB of space, slowly growing.
  .
  This package provides Bitcoin-Qt, a GUI for Bitcoin based on Qt.
+
+Package: bitcoin-tx
+Architecture: any
+Depends: ${shlibs:Depends}, ${misc:Depends}
+Description: peer-to-peer digital currency - standalone transaction tool
+ Bitcoin is a free open source peer-to-peer electronic cash system that
+ is completely decentralized, without the need for a central server or
+ trusted parties.  Users hold the crypto keys to their own money and
+ transact directly with each other, with the help of a P2P network to
+ check for double-spending.
+ .
+ This package provides bitcoin-tx, a command-line transaction creation
+ tool with minimal dependencies which can be used without a bitcoin
+ daemon.  Some means of exchanging minimal transaction data with peers
+ is still required.


### PR DESCRIPTION
Currently left out of Matt's PPA.  Debian's package for unstable already has it.
