### PR TITLE
Fix #6394 without boost dependency.

### DIFF
--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -6,7 +6,6 @@
 
 #include <assert.h>
 #include <boost/bind.hpp>
-#include <boost/thread/reverse_lock.hpp>
 #include <utility>
 
 CScheduler::CScheduler() : nThreadsServicingQueue(0), stopRequested(false), stopWhenEmpty(false)
@@ -66,12 +65,14 @@ void CScheduler::serviceQueue()
             Function f = taskQueue.begin()->second;
             taskQueue.erase(taskQueue.begin());
 
-            {
-                // Unlock before calling f, so it can reschedule itself or another task
-                // without deadlocking:
-                boost::reverse_lock<boost::unique_lock<boost::mutex> > rlock(lock);
+            lock.unlock();
+            try {
                 f();
+            } catch(...) {
+                lock.lock();
+                throw;
             }
+            lock.lock();
         } catch (...) {
             --nThreadsServicingQueue;
             throw;


### PR DESCRIPTION
As discussed in #6565, we don't want to introduce a dependency on boost 1.50, since debian wheezy.

This fixes #6394, but without using boost::reverse_lock.
