### PR TITLE
update build-unix.md (build bdb). Need autogen.sh to configure bdb

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -154,7 +154,8 @@ make install
 
 # Configure Bitcoin Core to use our own-built instance of BDB
 cd $BITCOIN_ROOT
-./configure (other args...) LDFLAGS="-L${BDB_PREFIX}/lib/" CPPFLAGS="-I${BDB_PREFIX}/include/"
+./autogen.sh
+./configure LDFLAGS="-L${BDB_PREFIX}/lib/" CPPFLAGS="-I${BDB_PREFIX}/include/" # (other args...)
 ```
 
 **Note**: You only need Berkeley DB if the wallet is enabled (see the section *Disable-Wallet mode* below).


### PR DESCRIPTION
Obviously if a user hasn't ready run autogen.sh, ./configure returns file not found.  Do the instructions seem to presume you have already built bitcoin?  I don't think they do. 

It's a small thing but beginners would have trouble.
