### PR TITLE
Fee estimate patch

### DIFF
--- a/src/policy/fees.h
+++ b/src/policy/fees.h
@@ -182,8 +182,12 @@ static const unsigned int MAX_BLOCK_CONFIRMS = 25;
 /** Decay of .998 is a half-life of 346 blocks or about 2.4 days */
 static const double DEFAULT_DECAY = .998;
 
-/** Require greater than 85% of X fee transactions to be confirmed within Y blocks for X to be big enough */
-static const double MIN_SUCCESS_PCT = .85;
+/**
+ * Require greater than 95% of X fee transactions to be confirmed within Y blocks
+ * for X to be high enough.  Use 85% for target of 1.
+ */
+static const double MIN_SUCCESS_PCT = .95;
+static const double MIN_SUCCESS_PCT_1CONF = .85;
 static const double UNLIKELY_PCT = .5;
 
 /** Require an avg of 1 tx in the combined fee bucket per block to have stat significance */

--- a/src/test/policyestimator_tests.cpp
+++ b/src/test/policyestimator_tests.cpp
@@ -83,11 +83,13 @@ BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
         block.clear();
         if (blocknum == 30) {
             // At this point we should need to combine 5 buckets to get enough data points
-            // So estimateFee(1) should fail and estimateFee(2) should return somewhere around
-            // 8*baserate
+            // So estimateFee(1,2,3) should fail and estimateFee(4) should return somewhere around
+            // 8*baserate.  estimateFee(4) %'s are 100,100,100,100,90 = average 98%
             BOOST_CHECK(mpool.estimateFee(1) == CFeeRate(0));
-            BOOST_CHECK(mpool.estimateFee(2).GetFeePerK() < 8*baseRate.GetFeePerK() + deltaFee);
-            BOOST_CHECK(mpool.estimateFee(2).GetFeePerK() > 8*baseRate.GetFeePerK() - deltaFee);
+            BOOST_CHECK(mpool.estimateFee(2) == CFeeRate(0));
+            BOOST_CHECK(mpool.estimateFee(3) == CFeeRate(0));
+            BOOST_CHECK(mpool.estimateFee(4).GetFeePerK() < 8*baseRate.GetFeePerK() + deltaFee);
+            BOOST_CHECK(mpool.estimateFee(4).GetFeePerK() > 8*baseRate.GetFeePerK() - deltaFee);
         }
     }
 
@@ -96,9 +98,9 @@ BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
     // Highest feerate is 10*baseRate and gets in all blocks,
     // second highest feerate is 9*baseRate and gets in 9/10 blocks = 90%,
     // third highest feerate is 8*base rate, and gets in 8/10 blocks = 80%,
-    // so estimateFee(1) should return 9*baseRate.
-    // Third highest feerate has 90% chance of being included by 2 blocks,
-    // so estimateFee(2) should return 8*baseRate etc...
+    // so estimateFee(1) should return 9*baseRate. (success thresh only 85%)
+    // Second highest feerate has 100% chance of being included by 2 blocks,
+    // so estimateFee(2) should return 9*baseRate etc...
     for (int i = 1; i < 10;i++) {
         origFeeEst.push_back(mpool.estimateFee(i).GetFeePerK());
         origPriEst.push_back(mpool.estimatePriority(i));
@@ -106,10 +108,13 @@ BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
             BOOST_CHECK(origFeeEst[i-1] <= origFeeEst[i-2]);
             BOOST_CHECK(origPriEst[i-1] <= origPriEst[i-2]);
         }
-        BOOST_CHECK(origFeeEst[i-1] < (10-i)*baseRate.GetFeePerK() + deltaFee);
-        BOOST_CHECK(origFeeEst[i-1] > (10-i)*baseRate.GetFeePerK() - deltaFee);
-        BOOST_CHECK(origPriEst[i-1] < pow(10,10-i) * basepri + deltaPri);
-        BOOST_CHECK(origPriEst[i-1] > pow(10,10-i) * basepri - deltaPri);
+        int mult = 11-i;
+        if (i == 1)
+            mult = 9; // success thresh is only 85% for 1
+        BOOST_CHECK(origFeeEst[i-1] < mult*baseRate.GetFeePerK() + deltaFee);
+        BOOST_CHECK(origFeeEst[i-1] > mult*baseRate.GetFeePerK() - deltaFee);
+        BOOST_CHECK(origPriEst[i-1] < pow(10,mult) * basepri + deltaPri);
+        BOOST_CHECK(origPriEst[i-1] > pow(10,mult) * basepri - deltaPri);
     }
 
     // Mine 50 more blocks with no transactions happening, estimates shouldn't change
@@ -140,8 +145,8 @@ BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
     }
 
     for (int i = 1; i < 10;i++) {
-        BOOST_CHECK(mpool.estimateFee(i).GetFeePerK() > origFeeEst[i-1] - deltaFee);
-        BOOST_CHECK(mpool.estimatePriority(i) > origPriEst[i-1] - deltaPri);
+        BOOST_CHECK(mpool.estimateFee(i) == CFeeRate(0) || mpool.estimateFee(i).GetFeePerK() > origFeeEst[i-1] - deltaFee);
+        BOOST_CHECK(mpool.estimatePriority(i) == -1 || mpool.estimatePriority(i) > origPriEst[i-1] - deltaPri);
     }
 
     // Mine all those transactions
@@ -161,9 +166,9 @@ BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
         BOOST_CHECK(mpool.estimatePriority(i) > origPriEst[i-1] - deltaPri);
     }
 
-    // Mine 100 more blocks where everything is mined every block
-    // Estimates should be below original estimates (not possible for last estimate)
-    while (blocknum < 365) {
+    // Mine 200 more blocks where everything is mined every block
+    // Estimates should be below original estimates
+    while (blocknum < 465) {
         for (int j = 0; j < 10; j++) { // For each fee/pri multiple
             for (int k = 0; k < 5; k++) { // add 4 fee txs for every priority tx
                 tx.vin[0].prevout.n = 10000*blocknum+100*j+k;
@@ -177,7 +182,7 @@ BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
         mpool.removeForBlock(block, ++blocknum, dummyConflicted);
         block.clear();
     }
-    for (int i = 1; i < 9; i++) {
+    for (int i = 1; i < 10; i++) {
         BOOST_CHECK(mpool.estimateFee(i).GetFeePerK() < origFeeEst[i-1] - deltaFee);
         BOOST_CHECK(mpool.estimatePriority(i) < origPriEst[i-1] - deltaPri);
     }


### PR DESCRIPTION
Fee estimation uses a threshold for the fraction of recent transactions of a given fee rate that must have been confirmed within the target number of blocks in order for that fee rate to be considered high enough such that a new transaction with that fee rate will be likely to be confirmed within the target.

This patch changes the threshold to 95% (from 85%) for all targets other than 1 block.

85% was previously used because higher thresholds were too hard to meet for a target of 1. However the recent stress test has shown that 85% is not conservative enough, so a target of 1 is special cased and a higher threshold is used. This is a simple change that is meant to be backported to 0.11. Further improvements for fee estimation will hopefully be possible for 0.12.

EDIT:  Please note that this will in general cause higher fee estimates to be returned.
