### PR TITLE
depends: bump miniupnpc and ccache

### DIFF
--- a/depends/packages/miniupnpc.mk
+++ b/depends/packages/miniupnpc.mk
@@ -1,8 +1,8 @@
 package=miniupnpc
-$(package)_version=1.9.20150609
+$(package)_version=1.9.20150730
 $(package)_download_path=http://miniupnp.free.fr/files
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
-$(package)_sha256_hash=86e6ccec5b660ba6889893d1f3fca21db087c6466b1a90f495a1f87ab1cd1c36
+$(package)_sha256_hash=1d64fab1fd3b4c8545139341ba197f19329a863f4f21b578fc2a228ab586a604
 
 define $(package)_set_vars
 $(package)_build_opts=CC="$($(package)_cc)"

--- a/depends/packages/native_ccache.mk
+++ b/depends/packages/native_ccache.mk
@@ -1,8 +1,8 @@
 package=native_ccache
-$(package)_version=3.2.2
+$(package)_version=3.2.3
 $(package)_download_path=http://samba.org/ftp/ccache
 $(package)_file_name=ccache-$($(package)_version).tar.bz2
-$(package)_sha256_hash=440f5e15141cc72d2bfff467c977020979810eb800882e3437ad1a7153cce7b2
+$(package)_sha256_hash=b07165d4949d107d17f2f84b90b52953617bf1abbf249d5cc20636f43337c98c
 
 define $(package)_set_vars
 $(package)_config_opts=


### PR DESCRIPTION
@theuni mentioned we can bump miniupnpc to 1.9.20150730 in #6583.
[release notes](http://miniupnp.tuxfamily.org/files/changelog.php?file=miniupnpc-1.9.20150730.tar.gz)

```
$Id: Changelog.txt,v 1.212 2015/07/23 20:41:50 nanard Exp $
miniUPnP client Changelog.
2015/07/23:
  split getDevicesFromMiniSSDPD
  add ttl argument to upnpDiscover() functions
  increments API_VERSION to 14

2015/07/22:
  Read USN from SSDP messages.

2015/07/15:
  Check malloc/calloc

2015/06/16:
  update getDevicesFromMiniSSDPD() to process longer minissdpd
    responses
```

We could also bump ccache to 3.2.3 (currently 3.2.2) [release notes](https://ccache.samba.org/releasenotes.html#_ccache_3_2_3)

```
ccache 3.2.3
Release date: 2015-08-16

New features and improvements
Added support for compiler option -gsplit-dwarf.

Bug fixes
Support external zlib in nonstandard directory.

Avoid calling exit() inside an exit handler.

Let exit handler terminate properly.

Bail out on compiler option --save-temps in addition to -save-temps.

Only log "Disabling direct mode" once when failing to read potential include files.
```

qrencode (3.44) and protobuf (2.6.1) are still both the most recent releases.

Boost 1.59.0 is out, release notes [here](http://www.boost.org/users/history/version_1_59_0.html)
