### PR TITLE
Introduce -maxuploadtarget

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -84,12 +84,13 @@ testScriptsExt = [
     'keypool.py',
     'receivedby.py',
 #    'rpcbind_test.py', #temporary, bug in libevent, see #6655
-#   'script_test.py', #used for manual comparison of 2 binaries
+#    'script_test.py', #used for manual comparison of 2 binaries
     'smartfees.py',
     'maxblocksinflight.py',
     'invalidblockrequest.py',
     'p2p-acceptblock.py',
     'mempool_packages.py',
+    'maxuploadtarget.py',
 ]
 
 #Enable ZMQ tests

--- a/qa/rpc-tests/maxuploadtarget.py
+++ b/qa/rpc-tests/maxuploadtarget.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python2
+#
+# Distributed under the MIT/X11 software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#
+
+from test_framework.mininode import *
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+from test_framework.comptool import wait_until
+import time
+
+'''
+Test behavior of -maxuploadtarget.
+
+* Verify that getdata requests for old blocks (>1week) are dropped
+if uploadtarget has been reached.
+* Verify that getdata requests for recent blocks are respecteved even
+if uploadtarget has been reached.
+* Verify that the upload counters are reset after 24 hours.
+'''
+
+# TestNode: bare-bones "peer".  Used mostly as a conduit for a test to sending
+# p2p messages to a node, generating the messages in the main testing logic.
+class TestNode(NodeConnCB):
+    def __init__(self):
+        NodeConnCB.__init__(self)
+        self.create_callback_map()
+        self.connection = None
+        self.ping_counter = 1
+        self.last_pong = msg_pong()
+        self.block_receive_map = {}
+
+    def add_connection(self, conn):
+        self.connection = conn
+        self.peer_disconnected = False
+
+    def on_inv(self, conn, message):
+        pass
+
+    # Track the last getdata message we receive (used in the test)
+    def on_getdata(self, conn, message):
+        self.last_getdata = message
+
+    def on_block(self, conn, message):
+        message.block.calc_sha256()
+        try:
+            self.block_receive_map[message.block.sha256] += 1
+        except KeyError as e:
+            self.block_receive_map[message.block.sha256] = 1
+
+    # Spin until verack message is received from the node.
+    # We use this to signal that our test can begin. This
+    # is called from the testing thread, so it needs to acquire
+    # the global lock.
+    def wait_for_verack(self):
+        def veracked():
+            return self.verack_received
+        return wait_until(veracked, timeout=10)
+
+    def wait_for_disconnect(self):
+        def disconnected():
+            return self.peer_disconnected
+        return wait_until(disconnected, timeout=10)
+
+    # Wrapper for the NodeConn's send_message function
+    def send_message(self, message):
+        self.connection.send_message(message)
+
+    def on_pong(self, conn, message):
+        self.last_pong = message
+
+    def on_close(self, conn):
+        self.peer_disconnected = True
+
+    # Sync up with the node after delivery of a block
+    def sync_with_ping(self, timeout=30):
+        def received_pong():
+            return (self.last_pong.nonce == self.ping_counter)
+        self.connection.send_message(msg_ping(nonce=self.ping_counter))
+        success = wait_until(received_pong, timeout)
+        self.ping_counter += 1
+        return success
+
+class MaxUploadTest(BitcoinTestFramework):
+    def __init__(self):
+        self.utxo = []
+
+        # Some pre-processing to create a bunch of OP_RETURN txouts to insert into transactions we create
+        # So we have big transactions and full blocks to fill up our block files
+        # create one script_pubkey
+        script_pubkey = "6a4d0200" #OP_RETURN OP_PUSH2 512 bytes
+        for i in xrange (512):
+            script_pubkey = script_pubkey + "01"
+        # concatenate 128 txouts of above script_pubkey which we'll insert before the txout for change
+        self.txouts = "81"
+        for k in xrange(128):
+            # add txout value
+            self.txouts = self.txouts + "0000000000000000"
+            # add length of script_pubkey
+            self.txouts = self.txouts + "fd0402"
+            # add script_pubkey
+            self.txouts = self.txouts + script_pubkey
+ 
+    def add_options(self, parser):
+        parser.add_option("--testbinary", dest="testbinary",
+                          default=os.getenv("BITCOIND", "bitcoind"),
+                          help="bitcoind binary to test")
+
+    def setup_chain(self):
+        initialize_chain_clean(self.options.tmpdir, 2)
+
+    def setup_network(self):
+        # Start a node with maxuploadtarget of 200 MB (/24h)
+        self.nodes = []
+        self.nodes.append(start_node(0, self.options.tmpdir, ["-debug", "-maxuploadtarget=200", "-blockmaxsize=999000"]))
+
+    def mine_full_block(self, node, address):
+        # Want to create a full block
+        # We'll generate a 66k transaction below, and 14 of them is close to the 1MB block limit
+        for j in xrange(14):
+            if len(self.utxo) < 14:
+                self.utxo = node.listunspent()
+            inputs=[]
+            outputs = {}
+            t = self.utxo.pop()
+            inputs.append({ "txid" : t["txid"], "vout" : t["vout"]})
+            remchange = t["amount"] - Decimal("0.001000")
+            outputs[address]=remchange
+            # Create a basic transaction that will send change back to ourself after account for a fee
+            # And then insert the 128 generated transaction outs in the middle rawtx[92] is where the #
+            # of txouts is stored and is the only thing we overwrite from the original transaction
+            rawtx = node.createrawtransaction(inputs, outputs)
+            newtx = rawtx[0:92]
+            newtx = newtx + self.txouts
+            newtx = newtx + rawtx[94:]
+            # Appears to be ever so slightly faster to sign with SIGHASH_NONE
+            signresult = node.signrawtransaction(newtx,None,None,"NONE")
+            txid = node.sendrawtransaction(signresult["hex"], True)
+        # Mine a full sized block which will be these transactions we just created
+        node.generate(1)
+
+    def run_test(self):
+        # Before we connect anything, we first set the time on the node
+        # to be in the past, otherwise things break because the CNode
+        # time counters can't be reset backward after initialization
+        old_time = int(time.time() - 2*60*60*24*7)
+        self.nodes[0].setmocktime(old_time)
+
+        # Generate some old blocks
+        self.nodes[0].generate(130)
+
+        # test_nodes[0] will only request old blocks
+        # test_nodes[1] will only request new blocks
+        # test_nodes[2] will test resetting the counters
+        test_nodes = []
+        connections = []
+
+        for i in xrange(3):
+            test_nodes.append(TestNode())
+            connections.append(NodeConn('127.0.0.1', p2p_port(0), self.nodes[0], test_nodes[i]))
+            test_nodes[i].add_connection(connections[i])
+
+        NetworkThread().start() # Start up network handling in another thread
+        [x.wait_for_verack() for x in test_nodes]
+
+        # Test logic begins here
+
+        # Now mine a big block
+        self.mine_full_block(self.nodes[0], self.nodes[0].getnewaddress())
+
+        # Store the hash; we'll request this later
+        big_old_block = self.nodes[0].getbestblockhash()
+        old_block_size = self.nodes[0].getblock(big_old_block, True)['size']
+        big_old_block = int(big_old_block, 16)
+
+        # Advance to two days ago
+        self.nodes[0].setmocktime(int(time.time()) - 2*60*60*24)
+
+        # Mine one more block, so that the prior block looks old
+        self.mine_full_block(self.nodes[0], self.nodes[0].getnewaddress())
+
+        # We'll be requesting this new block too
+        big_new_block = self.nodes[0].getbestblockhash()
+        new_block_size = self.nodes[0].getblock(big_new_block)['size']
+        big_new_block = int(big_new_block, 16)
+
+        # test_nodes[0] will test what happens if we just keep requesting the
+        # the same big old block too many times (expect: disconnect)
+
+        getdata_request = msg_getdata()
+        getdata_request.inv.append(CInv(2, big_old_block))
+
+        max_bytes_per_day = 200*1024*1024
+        max_bytes_available = max_bytes_per_day - 144*1000000
+        success_count = max_bytes_available / old_block_size
+        
+        # 144MB will be reserved for relaying new blocks, so expect this to
+        # succeed for ~70 tries.
+        for i in xrange(success_count):
+            test_nodes[0].send_message(getdata_request)
+            test_nodes[0].sync_with_ping()
+            assert_equal(test_nodes[0].block_receive_map[big_old_block], i+1)
+
+        assert_equal(len(self.nodes[0].getpeerinfo()), 3)
+        # At most a couple more tries should succeed (depending on how long 
+        # the test has been running so far).
+        for i in xrange(3):
+            test_nodes[0].send_message(getdata_request)
+        test_nodes[0].wait_for_disconnect()
+        assert_equal(len(self.nodes[0].getpeerinfo()), 2)
+        print "Peer 0 disconnected after downloading old block too many times"
+
+        # Requesting the current block on test_nodes[1] should succeed indefinitely,
+        # even when over the max upload target.
+        # We'll try 200 times
+        getdata_request.inv = [CInv(2, big_new_block)]
+        for i in xrange(200):
+            test_nodes[1].send_message(getdata_request)
+            test_nodes[1].sync_with_ping()
+            assert_equal(test_nodes[1].block_receive_map[big_new_block], i+1)
+
+        print "Peer 1 able to repeatedly download new block"
+
+        # But if test_nodes[1] tries for an old block, it gets disconnected too.
+        getdata_request.inv = [CInv(2, big_old_block)]
+        test_nodes[1].send_message(getdata_request)
+        test_nodes[1].wait_for_disconnect()
+        assert_equal(len(self.nodes[0].getpeerinfo()), 1)
+        
+        print "Peer 1 disconnected after trying to download old block"
+
+        print "Advancing system time on node to clear counters..."
+
+        # If we advance the time by 24 hours, then the counters should reset,
+        # and test_nodes[2] should be able to retrieve the old block.
+        self.nodes[0].setmocktime(int(time.time()))
+        test_nodes[2].sync_with_ping()
+        test_nodes[2].send_message(getdata_request)
+        test_nodes[2].sync_with_ping()
+        assert_equal(test_nodes[2].block_receive_map[big_old_block], 1)
+
+        print "Peer 2 able to download old block"
+
+        [c.disconnect_node() for c in connections]
+
+if __name__ == '__main__':
+    MaxUploadTest().main()

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -369,6 +369,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-whitebind=<addr>", _("Bind to given address and whitelist peers connecting to it. Use [host]:port notation for IPv6"));
     strUsage += HelpMessageOpt("-whitelist=<netmask>", _("Whitelist peers connecting from the given netmask or IP address. Can be specified multiple times.") +
         " " + _("Whitelisted peers cannot be DoS banned and their transactions are always relayed, even if they are already in the mempool, useful e.g. for a gateway"));
+    strUsage += HelpMessageOpt("-maxuploadtarget=<n>", strprintf(_("Tries to keep outbound traffic under the given target (in MiB per 24h), 0 = no limit (default: %d)"), 0));
 
 #ifdef ENABLE_WALLET
     strUsage += HelpMessageGroup(_("Wallet options:"));
@@ -1174,6 +1175,9 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
         RegisterValidationInterface(pzmqNotificationInterface);
     }
 #endif
+    if (mapArgs.count("-maxuploadtarget")) {
+        CNode::SetMaxOutboundTarget(GetArg("-maxuploadtarget", 0)*1024*1024);
+    }
 
     // ********************************************************* Step 7: load block chain
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3805,6 +3805,16 @@ void static ProcessGetData(CNode* pfrom)
                         }
                     }
                 }
+                // disconnect node in case we have reached the outbound limit for serving historical blocks
+                static const int nOneWeek = 7 * 24 * 60 * 60; // assume > 1 week = historical
+                if (send && CNode::OutboundTargetReached(true) && ( ((pindexBestHeader != NULL) && (pindexBestHeader->GetBlockTime() - mi->second->GetBlockTime() > nOneWeek)) || inv.type == MSG_FILTERED_BLOCK) )
+                {
+                    LogPrint("net", "historical block serving limit reached, disconnect peer=%d\n", pfrom->GetId());
+
+                    //disconnect node
+                    pfrom->fDisconnect = true;
+                    send = false;
+                }
                 // Pruned nodes may have deleted the block, so check whether
                 // it's available before trying to send.
                 if (send && (mi->second->nStatus & BLOCK_HAVE_DATA))

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -12,6 +12,7 @@
 #include "addrman.h"
 #include "chainparams.h"
 #include "clientversion.h"
+#include "consensus/consensus.h"
 #include "crypto/common.h"
 #include "hash.h"
 #include "primitives/transaction.h"
@@ -325,6 +326,11 @@ uint64_t CNode::nTotalBytesRecv = 0;
 uint64_t CNode::nTotalBytesSent = 0;
 CCriticalSection CNode::cs_totalBytesRecv;
 CCriticalSection CNode::cs_totalBytesSent;
+
+uint64_t CNode::nMaxOutboundLimit = 0;
+uint64_t CNode::nMaxOutboundTotalBytesSentInCycle = 0;
+uint64_t CNode::nMaxOutboundTimeframe = 60*60*24; //1 day
+uint64_t CNode::nMaxOutboundCycleStartTime = 0;
 
 CNode* FindNode(const CNetAddr& ip)
 {
@@ -2083,6 +2089,94 @@ void CNode::RecordBytesSent(uint64_t bytes)
 {
     LOCK(cs_totalBytesSent);
     nTotalBytesSent += bytes;
+
+    uint64_t now = GetTime();
+    if (nMaxOutboundCycleStartTime + nMaxOutboundTimeframe < now)
+    {
+        // timeframe expired, reset cycle
+        nMaxOutboundCycleStartTime = now;
+        nMaxOutboundTotalBytesSentInCycle = 0;
+    }
+
+    // TODO, exclude whitebind peers
+    nMaxOutboundTotalBytesSentInCycle += bytes;
+}
+
+void CNode::SetMaxOutboundTarget(uint64_t limit)
+{
+    LOCK(cs_totalBytesSent);
+    uint64_t recommendedMinimum = (nMaxOutboundTimeframe / 600) * MAX_BLOCK_SIZE;
+    nMaxOutboundLimit = limit;
+
+    if (limit < recommendedMinimum)
+        LogPrintf("Max outbound target is very small (%s) and will be overshot. Recommended minimum is %s\n.", nMaxOutboundLimit, recommendedMinimum);
+}
+
+uint64_t CNode::GetMaxOutboundTarget()
+{
+    LOCK(cs_totalBytesSent);
+    return nMaxOutboundLimit;
+}
+
+uint64_t CNode::GetMaxOutboundTimeframe()
+{
+    LOCK(cs_totalBytesSent);
+    return nMaxOutboundTimeframe;
+}
+
+uint64_t CNode::GetMaxOutboundTimeLeftInCycle()
+{
+    LOCK(cs_totalBytesSent);
+    if (nMaxOutboundLimit == 0)
+        return 0;
+
+    if (nMaxOutboundCycleStartTime == 0)
+        return nMaxOutboundTimeframe;
+
+    uint64_t cycleEndTime = nMaxOutboundCycleStartTime + nMaxOutboundTimeframe;
+    uint64_t now = GetTime();
+    return (cycleEndTime < now) ? 0 : cycleEndTime - GetTime();
+}
+
+void CNode::SetMaxOutboundTimeframe(uint64_t timeframe)
+{
+    LOCK(cs_totalBytesSent);
+    if (nMaxOutboundTimeframe != timeframe)
+    {
+        // reset measure-cycle in case of changing
+        // the timeframe
+        nMaxOutboundCycleStartTime = GetTime();
+    }
+    nMaxOutboundTimeframe = timeframe;
+}
+
+bool CNode::OutboundTargetReached(bool historicalBlockServingLimit)
+{
+    LOCK(cs_totalBytesSent);
+    if (nMaxOutboundLimit == 0)
+        return false;
+
+    if (historicalBlockServingLimit)
+    {
+        // keep a large enought buffer to at least relay each block once
+        uint64_t timeLeftInCycle = GetMaxOutboundTimeLeftInCycle();
+        uint64_t buffer = timeLeftInCycle / 600 * MAX_BLOCK_SIZE;
+        if (buffer >= nMaxOutboundLimit || nMaxOutboundTotalBytesSentInCycle >= nMaxOutboundLimit - buffer)
+            return true;
+    }
+    else if (nMaxOutboundTotalBytesSentInCycle >= nMaxOutboundLimit)
+        return true;
+
+    return false;
+}
+
+uint64_t CNode::GetOutboundTargetBytesLeft()
+{
+    LOCK(cs_totalBytesSent);
+    if (nMaxOutboundLimit == 0)
+        return 0;
+
+    return (nMaxOutboundTotalBytesSentInCycle >= nMaxOutboundLimit) ? 0 : nMaxOutboundLimit - nMaxOutboundTotalBytesSentInCycle;
 }
 
 uint64_t CNode::GetTotalBytesRecv()

--- a/src/net.h
+++ b/src/net.h
@@ -400,6 +400,12 @@ private:
     static uint64_t nTotalBytesRecv;
     static uint64_t nTotalBytesSent;
 
+    // outbound limit & stats
+    static uint64_t nMaxOutboundTotalBytesSentInCycle;
+    static uint64_t nMaxOutboundCycleStartTime;
+    static uint64_t nMaxOutboundLimit;
+    static uint64_t nMaxOutboundTimeframe;
+
     CNode(const CNode&);
     void operator=(const CNode&);
 
@@ -701,6 +707,27 @@ public:
 
     static uint64_t GetTotalBytesRecv();
     static uint64_t GetTotalBytesSent();
+
+    //!set the max outbound target in bytes
+    static void SetMaxOutboundTarget(uint64_t limit);
+    static uint64_t GetMaxOutboundTarget();
+
+    //!set the timeframe for the max outbound target
+    static void SetMaxOutboundTimeframe(uint64_t timeframe);
+    static uint64_t GetMaxOutboundTimeframe();
+
+    //!check if the outbound target is reached
+    // if param historicalBlockServingLimit is set true, the function will
+    // response true if the limit for serving historical blocks has been reached
+    static bool OutboundTargetReached(bool historicalBlockServingLimit);
+
+    //!response the bytes left in the current max outbound cycle
+    // in case of no limit, it will always response 0
+    static uint64_t GetOutboundTargetBytesLeft();
+
+    //!response the time in second left in the current max outbound cycle
+    // in case of no limit, it will always response 0
+    static uint64_t GetMaxOutboundTimeLeftInCycle();
 };
 
 

--- a/src/rpcnet.cpp
+++ b/src/rpcnet.cpp
@@ -379,6 +379,15 @@ UniValue getnettotals(const UniValue& params, bool fHelp)
     obj.push_back(Pair("totalbytesrecv", CNode::GetTotalBytesRecv()));
     obj.push_back(Pair("totalbytessent", CNode::GetTotalBytesSent()));
     obj.push_back(Pair("timemillis", GetTimeMillis()));
+
+    UniValue outboundLimit(UniValue::VOBJ);
+    outboundLimit.push_back(Pair("timeframe", CNode::GetMaxOutboundTimeframe()));
+    outboundLimit.push_back(Pair("target", CNode::GetMaxOutboundTarget()));
+    outboundLimit.push_back(Pair("target_reached", CNode::OutboundTargetReached(false)));
+    outboundLimit.push_back(Pair("serve_historical_blocks", !CNode::OutboundTargetReached(true)));
+    outboundLimit.push_back(Pair("bytes_left_in_cycle", CNode::GetOutboundTargetBytesLeft()));
+    outboundLimit.push_back(Pair("time_left_in_cycle", CNode::GetMaxOutboundTimeLeftInCycle()));
+    obj.push_back(Pair("uploadtarget", outboundLimit));
     return obj;
 }
 


### PR DESCRIPTION
**This is the first PR in a planed series of bandwidth / DOS prevention PRs.**
**Focus for now is a simple and not over-complex solution to start with.**

The `-maxuploadtarget` (**in MiB**) is a configuration value that make bitcoind try to limit the total **outbound** traffic. Currently there is no guarantee that the limit target will be fulfilled.

If the `target-in-bytes - (time-left-in-24-cycle) / 600 * MAX_BLOCK_SIZE` is reached, stop serve blocks older than one week, stop serve filtered blocks (SPV) immediately.

The timeframe for the measurement is currently fixed to 24h.

This is a effective method of reducing traffic and might prevent node operators from getting expensive "traffic exceed"-bills.

Currently the limit also take effect for whitebinded peers.

Over `getnettotals` one can get some upload limit statistics:

```
./src/bitcoin-cli getnettotals
{
  "totalbytesrecv": 0,
  "totalbytessent": 0,
  "timemillis": 1441222000173,
  "uploadtarget": {
    "timeframe": 86400,
    "target": 300000000,
    "target_reached": false,
    "serve_historical_blocks": true,
    "bytes_left_in_cycle": 300000000,
    "time_left_in_cycle": 86400
  }
}
```

**needs documentation**
**needs unit/rpc tests**
