### PR TITLE
Replace boost::reverse_lock with our own

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -119,6 +119,7 @@ BITCOIN_CORE_H = \
   protocol.h \
   pubkey.h \
   random.h \
+  reverselock.h \
   rpcclient.h \
   rpcprotocol.h \
   rpcserver.h \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -62,6 +62,7 @@ BITCOIN_TESTS =\
   test/pmt_tests.cpp \
   test/policyestimator_tests.cpp \
   test/pow_tests.cpp \
+  test/reverselock_tests.cpp \
   test/rpc_tests.cpp \
   test/sanity_tests.cpp \
   test/scheduler_tests.cpp \

--- a/src/reverselock.h
+++ b/src/reverselock.h
@@ -1,0 +1,31 @@
+// Copyright (c) 2015 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_REVERSELOCK_H
+#define BITCOIN_REVERSELOCK_H
+
+/**
+ * An RAII-style reverse lock. Unlocks on construction and locks on destruction.
+ */
+template<typename Lock>
+class reverse_lock
+{
+public:
+
+    explicit reverse_lock(Lock& lock) : lock(lock) {
+        lock.unlock();
+    }
+
+    ~reverse_lock() {
+        lock.lock();
+    }
+
+private:
+    reverse_lock(reverse_lock const&);
+    reverse_lock& operator=(reverse_lock const&);
+
+    Lock& lock;
+};
+
+#endif // BITCOIN_REVERSELOCK_H

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -4,9 +4,10 @@
 
 #include "scheduler.h"
 
+#include "reverselock.h"
+
 #include <assert.h>
 #include <boost/bind.hpp>
-#include <boost/thread/reverse_lock.hpp>
 #include <utility>
 
 CScheduler::CScheduler() : nThreadsServicingQueue(0), stopRequested(false), stopWhenEmpty(false)
@@ -69,7 +70,7 @@ void CScheduler::serviceQueue()
             {
                 // Unlock before calling f, so it can reschedule itself or another task
                 // without deadlocking:
-                boost::reverse_lock<boost::unique_lock<boost::mutex> > rlock(lock);
+                reverse_lock<boost::unique_lock<boost::mutex> > rlock(lock);
                 f();
             }
         } catch (...) {

--- a/src/test/reverselock_tests.cpp
+++ b/src/test/reverselock_tests.cpp
@@ -1,0 +1,64 @@
+// Copyright (c) 2015 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "reverselock.h"
+#include "test/test_bitcoin.h"
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(reverselock_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(reverselock_basics)
+{
+    boost::mutex mutex;
+    boost::unique_lock<boost::mutex> lock(mutex);
+
+    BOOST_CHECK(lock.owns_lock());
+    {
+        reverse_lock<boost::unique_lock<boost::mutex> > rlock(lock);
+        BOOST_CHECK(!lock.owns_lock());
+    }
+    BOOST_CHECK(lock.owns_lock());
+}
+
+BOOST_AUTO_TEST_CASE(reverselock_errors)
+{
+    boost::mutex mutex;
+    boost::unique_lock<boost::mutex> lock(mutex);
+
+    // Make sure trying to reverse lock an unlocked lock fails
+    lock.unlock();
+
+    BOOST_CHECK(!lock.owns_lock());
+
+    bool failed = false;
+    try {
+        reverse_lock<boost::unique_lock<boost::mutex> > rlock(lock);
+    } catch(...) {
+        failed = true;
+    }
+
+    BOOST_CHECK(failed);
+    BOOST_CHECK(!lock.owns_lock());
+
+    // Make sure trying to lock a lock after it has been reverse locked fails
+    failed = false;
+    bool locked = false;
+
+    lock.lock();
+    BOOST_CHECK(lock.owns_lock());
+
+    try {
+        reverse_lock<boost::unique_lock<boost::mutex> > rlock(lock);
+        lock.lock();
+        locked = true;
+    } catch(...) {
+        failed = true;
+    }
+
+    BOOST_CHECK(locked && failed);
+    BOOST_CHECK(lock.owns_lock());
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
See #6608 for discussion.

This removes boost::reverse_lock so that we don't depend on boost 1.50, and replaces it with our own implementation.

This implementation is stricter than boost::reverse_lock. Reverse locking an unlocked lock, and re-locking a lock while a reverse_lock is active are both errors.
