### PR TITLE
Update RPC generate help for numblocks to include required

### DIFF
--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -119,7 +119,7 @@ UniValue generate(const UniValue& params, bool fHelp)
             "generate numblocks\n"
             "\nMine blocks immediately (before the RPC call returns)\n"
             "\nNote: this function can only be used on the regtest network\n"
-            "1. numblocks    (numeric) How many blocks are generated immediately.\n"
+            "1. numblocks    (numeric, required) How many blocks are generated immediately.\n"
             "\nResult\n"
             "[ blockhashes ]     (array) hashes of blocks generated\n"
             "\nExamples:\n"


### PR DESCRIPTION
The `generate` RPC has no default `numblocks` and a numeric value is required.
