### PR TITLE
net: correctly initialize nMinPingUsecTime

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2261,6 +2261,7 @@ CNode::CNode(SOCKET hSocketIn, const CAddress& addrIn, const std::string& addrNa
     nPingUsecStart = 0;
     nPingUsecTime = 0;
     fPingQueued = false;
+    nMinPingUsecTime = std::numeric_limits<int64_t>::max();
 
     {
         LOCK(cs_nLastNodeId);


### PR DESCRIPTION
`nMinPingUsecTime` was left uninitialized in CNode.
The correct initialization for a minimum-until-now is int64_t's max value, so initialize it to that.
Thanks @MarcoFalke for noticing.
