### PR TITLE
Correct the help description for prune so it doesn't claim that it doesn't work with wallets.

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -308,7 +308,7 @@ std::string HelpMessage(HelpMessageMode mode)
 #ifndef WIN32
     strUsage += HelpMessageOpt("-pid=<file>", strprintf(_("Specify pid file (default: %s)"), "bitcoind.pid"));
 #endif
-    strUsage += HelpMessageOpt("-prune=<n>", strprintf(_("Reduce storage requirements by pruning (deleting) old blocks. This mode disables wallet support and is incompatible with -txindex. "
+    strUsage += HelpMessageOpt("-prune=<n>", strprintf(_("Reduce storage requirements by pruning (deleting) old blocks. This mode is incompatible with -txindex and -rescan. "
             "Warning: Reverting this setting requires re-downloading the entire blockchain. "
             "(default: 0 = disable pruning blocks, >%u = target size in MiB to use for block files)"), MIN_DISK_SPACE_FOR_BLOCK_FILES / 1024 / 1024));
     strUsage += HelpMessageOpt("-reindex", _("Rebuild block chain index from current blk000??.dat files on startup"));


### PR DESCRIPTION
Pruning no longer disables the wallet, the help text shouldn't claim it does. Trivial change.

I'm less confident about the second commit, I don't know enough about the translation workflow to know if some other automated step won't just remove these translations now that they were not longer used. Though since they won't be used again I see no harm in removing them.
