### PR TITLE
Enable wallet key imports without rescan in pruned mode.

### DIFF
--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -97,8 +97,6 @@ UniValue importprivkey(const UniValue& params, bool fHelp)
             + HelpExampleRpc("importprivkey", "\"mykey\", \"testing\", false")
         );
 
-    if (fPruneMode)
-        throw JSONRPCError(RPC_WALLET_ERROR, "Importing keys is disabled in pruned mode");
 
     LOCK2(cs_main, pwalletMain->cs_wallet);
 
@@ -113,6 +111,9 @@ UniValue importprivkey(const UniValue& params, bool fHelp)
     bool fRescan = true;
     if (params.size() > 2)
         fRescan = params[2].get_bool();
+
+    if (fRescan && fPruneMode)
+        throw JSONRPCError(RPC_WALLET_ERROR, "Rescan is disabled in pruned mode");
 
     CBitcoinSecret vchSecret;
     bool fGood = vchSecret.SetString(strSecret);
@@ -201,8 +202,6 @@ UniValue importaddress(const UniValue& params, bool fHelp)
             + HelpExampleRpc("importaddress", "\"myscript\", \"testing\", false")
         );
 
-    if (fPruneMode)
-        throw JSONRPCError(RPC_WALLET_ERROR, "Importing addresses is disabled in pruned mode");
 
     string strLabel = "";
     if (params.size() > 1)
@@ -212,6 +211,9 @@ UniValue importaddress(const UniValue& params, bool fHelp)
     bool fRescan = true;
     if (params.size() > 2)
         fRescan = params[2].get_bool();
+
+    if (fRescan && fPruneMode)
+        throw JSONRPCError(RPC_WALLET_ERROR, "Rescan is disabled in pruned mode");
 
     // Whether to import a p2sh version, too
     bool fP2SH = false;
@@ -264,8 +266,6 @@ UniValue importpubkey(const UniValue& params, bool fHelp)
             + HelpExampleRpc("importpubkey", "\"mypubkey\", \"testing\", false")
         );
 
-    if (fPruneMode)
-        throw JSONRPCError(RPC_WALLET_ERROR, "Importing public keys is disabled in pruned mode");
 
     string strLabel = "";
     if (params.size() > 1)
@@ -275,6 +275,9 @@ UniValue importpubkey(const UniValue& params, bool fHelp)
     bool fRescan = true;
     if (params.size() > 2)
         fRescan = params[2].get_bool();
+
+    if (fRescan && fPruneMode)
+        throw JSONRPCError(RPC_WALLET_ERROR, "Rescan is disabled in pruned mode");
 
     if (!IsHex(params[0].get_str()))
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Pubkey must be a hex string");


### PR DESCRIPTION
Complete rescan is incompatible with pruning, but rescan is optional on
 our wallet key import RPCs.  Import on use is very useful in some common
 situations in conjunction with pruning, e.g. merchant payment tracking.

This reenables importprivkey/importaddress/importpubkey when rescan
 is not used.

In the future we should consider changing the rescan argument to allow depth
 or date to allow limited rescanning when compatible with the retained
 block depth.
