### PR TITLE
Default fPayAtLeastCustomFee to false

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -41,7 +41,7 @@ CAmount maxTxFee = DEFAULT_TRANSACTION_MAXFEE;
 unsigned int nTxConfirmTarget = DEFAULT_TX_CONFIRM_TARGET;
 bool bSpendZeroConfChange = true;
 bool fSendFreeTransactions = false;
-bool fPayAtLeastCustomFee = true;
+bool fPayAtLeastCustomFee = false;
 
 /**
  * Fees smaller than this (in satoshi) are considered zero fee (for transaction creation)


### PR DESCRIPTION
This allows for much finer control of the transaction fees per kilobyte
as it prevent small transactions using a fee that is more appropriate
for one that is of a kilobyte.

This also allows controlling the fee per kilobyte over rpc such that:

`bitcoin-cli settxfee `bitcoin-cli estimatefee 2``

would make sense, while currently it grossly fails often by a factor of x3

This fixes issue #6479, and has minimal impact as dynamic fees are currently the default. This default can be overriden in the qt wallet, although I have trouble imagining where that is useful. Possibly the entire concept of fPayAtLeastCustomFee can be removed in a later version.
