### PR TITLE
Fixed dead ISO link

### DIFF
--- a/doc/gitian-building.md
+++ b/doc/gitian-building.md
@@ -74,11 +74,11 @@ In the VirtualBox GUI click "Create" and choose the following parameters in the 
 - File location and size: at least 40GB; as low as 20GB *may* be possible, but better to err on the safe side 
 - Click `Create`
 
-Get the [Debian 8.1 net installer](http://cdimage.debian.org/debian-cd/8.1.0/amd64/iso-cd/debian-8.1.0-amd64-netinst.iso) (a more recent minor version should also work, see also [Debian Network installation](https://www.debian.org/CD/netinst/)).
+Get the [Debian 8.1 net installer](http://cdimage.debian.org/debian-cd/8.2.0/amd64/iso-cd/debian-8.2.0-amd64-netinst.iso) (a more recent minor version should also work, see also [Debian Network installation](https://www.debian.org/CD/netinst/)).
 This DVD image can be validated using a SHA256 hashing tool, for example on
 Unixy OSes by entering the following in a terminal:
 
-    echo "5d0a1f804d73aee73eee7efbb38456390558094fd19894a573f1514ca44347e0  debian-8.1.0-amd64-netinst.iso" | sha256sum -c
+    echo "d393d17ac6b3113c81186e545c416a00f28ed6e05774284bb5e8f0df39fcbcb9  debian-8.2.0-amd64-netinst.iso" | sha256sum -c
     # (must return OK)
 
 After creating the VM, we need to configure it. 


### PR DESCRIPTION
- Link to Debian 8.1 netinstall ISO is dead, changed to valid 8.2
- Changed checksum to 8.2 netinstall ISO checksum (http://cdimage.debian.org/debian-cd/8.2.0/amd64/iso-cd/SHA256SUMS)
- Verified CD checksum, checksum file's signing key
