### PR TITLE
Simple mempool protect

### DIFF
--- a/qa/pull-tester/rpc-tests.sh
+++ b/qa/pull-tester/rpc-tests.sh
@@ -49,7 +49,7 @@ testScriptsExt=(
     'invalidateblock.py'
     'keypool.py'
     'receivedby.py'
-    'rpcbind_test.py'
+#    'rpcbind_test.py'
 #   'script_test.py'
     'smartfees.py'
     'maxblocksinflight.py'

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -168,7 +168,7 @@ def start_node(i, dirname, extra_args=None, rpchost=None, timewait=None, binary=
     datadir = os.path.join(dirname, "node"+str(i))
     if binary is None:
         binary = os.getenv("BITCOIND", "bitcoind")
-    args = [ binary, "-datadir="+datadir, "-keypool=1", "-discover=0", "-rest" ]
+    args = [ binary, "-datadir="+datadir, "-keypool=1", "-discover=0", "-rest", "-rpctimeout=1500" ]
     if extra_args is not None: args.extend(extra_args)
     bitcoind_processes[i] = subprocess.Popen(args)
     devnull = open("/dev/null", "w+")

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -288,6 +288,10 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-dbcache=<n>", strprintf(_("Set database cache size in megabytes (%d to %d, default: %d)"), nMinDbCache, nMaxDbCache, nDefaultDbCache));
     strUsage += HelpMessageOpt("-loadblock=<file>", _("Imports blocks from external blk000??.dat file") + " " + _("on startup"));
     strUsage += HelpMessageOpt("-maxorphantx=<n>", strprintf(_("Keep at most <n> unconnectable transactions in memory (default: %u)"), DEFAULT_MAX_ORPHAN_TRANSACTIONS));
+    strUsage += HelpMessageOpt("-limitancestorcount=<n>", strprintf(_("Do not accept transactions if number of in-mempool ancestors is <n> or more (default: %u)"), DEFAULT_ANCESTOR_LIMIT));
+    strUsage += HelpMessageOpt("-limitancestorsize=<n>", strprintf(_("Do not accept transactions whose size with all in-mempool ancestors exceeds <n> kilobytes (default: %u)"), DEFAULT_ANCESTOR_SIZE_LIMIT));
+    strUsage += HelpMessageOpt("-limitdescendantcount=<n>", strprintf(_("Do not accept transactions if any ancestor would have <n> or more in-mempool descendants (default: %u)"), DEFAULT_DESCENDANT_LIMIT));
+    strUsage += HelpMessageOpt("-limitdescendantsize=<n>", strprintf("Do not accept transactions if any ancestor would have more than <n> kilobytes of in-mempool descendants (default: %u).", DEFAULT_DESCENDANT_SIZE_LIMIT));
     strUsage += HelpMessageOpt("-par=<n>", strprintf(_("Set the number of script verification threads (%u to %d, 0 = auto, <0 = leave that many cores free, default: %d)"),
         -GetNumCores(), MAX_SCRIPTCHECK_THREADS, DEFAULT_SCRIPTCHECK_THREADS));
 #ifndef WIN32

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -287,6 +287,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-datadir=<dir>", _("Specify data directory"));
     strUsage += HelpMessageOpt("-dbcache=<n>", strprintf(_("Set database cache size in megabytes (%d to %d, default: %d)"), nMinDbCache, nMaxDbCache, nDefaultDbCache));
     strUsage += HelpMessageOpt("-loadblock=<file>", _("Imports blocks from external blk000??.dat file") + " " + _("on startup"));
+    strUsage += HelpMessageOpt("-maxmempool=<n>", strprintf(_("Keep the transaction memory pool below <n> megabytes. n <= 0 disables mempool limiting. (default: %u)"), DEFAULT_MAX_MEMPOOL_SIZE));
     strUsage += HelpMessageOpt("-maxorphantx=<n>", strprintf(_("Keep at most <n> unconnectable transactions in memory (default: %u)"), DEFAULT_MAX_ORPHAN_TRANSACTIONS));
     strUsage += HelpMessageOpt("-limitancestorcount=<n>", strprintf(_("Do not accept transactions if number of in-mempool ancestors is <n> or more (default: %u)"), DEFAULT_ANCESTOR_LIMIT));
     strUsage += HelpMessageOpt("-limitancestorsize=<n>", strprintf(_("Do not accept transactions whose size with all in-mempool ancestors exceeds <n> kilobytes (default: %u)"), DEFAULT_ANCESTOR_SIZE_LIMIT));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -886,7 +886,27 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
         CAmount txMinFee = GetMinRelayFee(tx, nSize, true);
         if (fLimitFree && nFees < txMinFee)
             return state.DoS(0, false, REJECT_INSUFFICIENTFEE, "insufficient fee", false,
-                strprintf("%d < %d", nFees, txMinFee));
+                strprintf("%ld < %ld", nFees, txMinFee));
+
+        // Divide mempool into 50 bands of increasing required minimum fee
+        static const int numBands = 50;
+        size_t mempoolBand = std::max((int64_t)0, GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000/numBands);
+        size_t expsize = pool.DynamicMemoryUsage() + pool.GuessDynamicMemoryUsage(entry);
+        // Once mempool size is above first band, free transactions are no longer accepted
+        // and a higher minimum fee is required.
+        if (mempoolBand && expsize > mempoolBand) {
+            int bandNumber = expsize/mempoolBand;
+            // Enforce the hard cap
+            if (bandNumber >= numBands) {
+                return state.DoS(0, false, REJECT_INSUFFICIENTFEE, "mempool full hard cap", false,
+                                 strprintf("%u", mempoolBand * numBands));
+            }
+            double feeMultiplier = pow(1.1, bandNumber); // Fee requirement increases by 10% every band
+            if (nFees < feeMultiplier * ::minRelayTxFee.GetFee(nSize)) {
+                return state.DoS(0, false, REJECT_INSUFFICIENTFEE, "insufficient fee for mempool size", false,
+                                 strprintf("Mult: %.1f Fees: %ld < %ld", feeMultiplier, nFees, feeMultiplier * ::minRelayTxFee.GetFee(nSize)));
+            }
+        }
 
         // Require that free transactions have sufficient priority to be mined in the next block.
         if (GetBoolArg("-relaypriority", true) && nFees < ::minRelayTxFee.GetFee(nSize) && !AllowFree(view.GetPriority(tx, chainActive.Height() + 1))) {
@@ -4275,10 +4295,10 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
             RelayTransaction(tx);
             vWorkQueue.push_back(inv.hash);
 
-            LogPrint("mempool", "AcceptToMemoryPool: peer=%d %s: accepted %s (poolsz %u)\n",
-                pfrom->id, pfrom->cleanSubVer,
-                tx.GetHash().ToString(),
-                mempool.mapTx.size());
+            LogPrint("mempool", "AcceptToMemoryPool: peer=%d %s: accepted %s (poolsz %u txs %.2f M usage)\n",
+                     pfrom->id, pfrom->cleanSubVer,
+                     tx.GetHash().ToString(),
+                     mempool.mapTx.size(), (double)mempool.DynamicMemoryUsage()/1000000);
 
             // Recursively process any orphan transactions that depended on this one
             set<NodeId> setMisbehaving;

--- a/src/main.h
+++ b/src/main.h
@@ -43,6 +43,8 @@ struct CNodeStateStats;
 static const bool DEFAULT_ALERTS = true;
 /** Default for -maxorphantx, maximum number of orphan transactions kept in memory */
 static const unsigned int DEFAULT_MAX_ORPHAN_TRANSACTIONS = 100;
+/** Default for -maxmempool, maximum megabytes of mempool memory usage */
+static const unsigned int DEFAULT_MAX_MEMPOOL_SIZE = 500;
 /** Default for -limitancestorcount, max number of in-mempool ancestors */
 static const unsigned int DEFAULT_ANCESTOR_LIMIT = 100;
 /** Default for -limitancestorsize, maximum kilobytes of tx + all in-mempool ancestors */

--- a/src/main.h
+++ b/src/main.h
@@ -43,6 +43,14 @@ struct CNodeStateStats;
 static const bool DEFAULT_ALERTS = true;
 /** Default for -maxorphantx, maximum number of orphan transactions kept in memory */
 static const unsigned int DEFAULT_MAX_ORPHAN_TRANSACTIONS = 100;
+/** Default for -limitancestorcount, max number of in-mempool ancestors */
+static const unsigned int DEFAULT_ANCESTOR_LIMIT = 100;
+/** Default for -limitancestorsize, maximum kilobytes of tx + all in-mempool ancestors */
+static const unsigned int DEFAULT_ANCESTOR_SIZE_LIMIT = 1000;
+/** Default for -limitdescendantcount, max number of in-mempool descendants */
+static const unsigned int DEFAULT_DESCENDANT_LIMIT = 1000;
+/** Default for -limitdescendantsize, maximum kilobytes of in-mempool descendants */
+static const unsigned int DEFAULT_DESCENDANT_SIZE_LIMIT = 2500;
 /** The maximum size of a blk?????.dat file (since 0.8) */
 static const unsigned int MAX_BLOCKFILE_SIZE = 0x8000000; // 128 MiB
 /** The pre-allocation chunk size for blk?????.dat files (since 0.8) */
@@ -466,5 +474,7 @@ static const unsigned int REJECT_HIGHFEE = 0x100;
 static const unsigned int REJECT_ALREADY_KNOWN = 0x101;
 /** Transaction conflicts with a transaction already known */
 static const unsigned int REJECT_CONFLICT = 0x102;
+/** Transaction would result in too long in-mempool chain */
+static const unsigned int REJECT_LONGCHAIN = 0x103;
 
 #endif // BITCOIN_MAIN_H

--- a/src/memusage.h
+++ b/src/memusage.h
@@ -74,16 +74,28 @@ static inline size_t DynamicUsage(const std::vector<X>& v)
     return MallocUsage(v.capacity() * sizeof(X));
 }
 
-template<typename X>
-static inline size_t DynamicUsage(const std::set<X>& s)
+template<typename X, typename Y>
+static inline size_t DynamicUsage(const std::set<X, Y>& s)
 {
     return MallocUsage(sizeof(stl_tree_node<X>)) * s.size();
 }
 
 template<typename X, typename Y>
-static inline size_t DynamicUsage(const std::map<X, Y>& m)
+static inline size_t IncrementalDynamicUsage(const std::set<X, Y>& s)
+{
+    return MallocUsage(sizeof(stl_tree_node<X>));
+}
+
+template<typename X, typename Y, typename Z>
+static inline size_t DynamicUsage(const std::map<X, Y, Z>& m)
 {
     return MallocUsage(sizeof(stl_tree_node<std::pair<const X, Y> >)) * m.size();
+}
+
+template<typename X, typename Y, typename Z>
+static inline size_t IncrementalDynamicUsage(const std::map<X, Y, Z>& m)
+{
+    return MallocUsage(sizeof(stl_tree_node<std::pair<const X, Y> >));
 }
 
 // Boost data structures

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -158,10 +158,10 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn)
         // This vector will be sorted into a priority queue:
         vector<TxPriority> vecPriority;
         vecPriority.reserve(mempool.mapTx.size());
-        for (map<uint256, CTxMemPoolEntry>::iterator mi = mempool.mapTx.begin();
+        for (CTxMemPool::indexed_transaction_set::iterator mi = mempool.mapTx.begin();
              mi != mempool.mapTx.end(); ++mi)
         {
-            const CTransaction& tx = mi->second.GetTx();
+            const CTransaction& tx = mi->GetTx();
             if (tx.IsCoinBase() || !IsFinalTx(tx, nHeight, pblock->nTime))
                 continue;
 
@@ -196,7 +196,7 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn)
                     }
                     mapDependers[txin.prevout.hash].push_back(porphan);
                     porphan->setDependsOn.insert(txin.prevout.hash);
-                    nTotalIn += mempool.mapTx[txin.prevout.hash].GetTx().vout[txin.prevout.n].nValue;
+                    nTotalIn += mempool.mapTx.find(txin.prevout.hash)->GetTx().vout[txin.prevout.n].nValue;
                     continue;
                 }
                 const CCoins* coins = view.AccessCoins(txin.prevout.hash);
@@ -226,7 +226,7 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn)
                 porphan->feeRate = feeRate;
             }
             else
-                vecPriority.push_back(TxPriority(dPriority, feeRate, &mi->second.GetTx()));
+                vecPriority.push_back(TxPriority(dPriority, feeRate, &(mi->GetTx())));
         }
 
         // Collect transactions into block

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -218,10 +218,9 @@ UniValue getrawmempool(const UniValue& params, bool fHelp)
     {
         LOCK(mempool.cs);
         UniValue o(UniValue::VOBJ);
-        BOOST_FOREACH(const PAIRTYPE(uint256, CTxMemPoolEntry)& entry, mempool.mapTx)
+        BOOST_FOREACH(const CTxMemPoolEntry& e, mempool.mapTx)
         {
-            const uint256& hash = entry.first;
-            const CTxMemPoolEntry& e = entry.second;
+            const uint256& hash = e.GetTx().GetHash();
             UniValue info(UniValue::VOBJ);
             info.push_back(Pair("size", (int)e.GetTxSize()));
             info.push_back(Pair("fee", ValueFromAmount(e.GetFee())));

--- a/src/test/mempool_tests.cpp
+++ b/src/test/mempool_tests.cpp
@@ -9,6 +9,7 @@
 
 #include <boost/test/unit_test.hpp>
 #include <list>
+#include <vector>
 
 BOOST_FIXTURE_TEST_SUITE(mempool_tests, TestingSetup)
 
@@ -100,6 +101,31 @@ BOOST_AUTO_TEST_CASE(MempoolRemoveTest)
     removed.clear();
 }
 
+void CheckSort(CTxMemPool &pool, std::vector<std::string> &sortedOrder)
+{
+    BOOST_CHECK_EQUAL(pool.size(), sortedOrder.size());
+    CTxMemPool::indexed_transaction_set::nth_index<1>::type::iterator it = pool.mapTx.get<1>().begin();
+    int count=0;
+    for (; it != pool.mapTx.get<1>().end(); ++it, ++count) {
+        BOOST_CHECK_EQUAL(it->GetTx().GetHash().ToString(), sortedOrder[count]);
+    }
+}
+
+template<typename X, typename Y>
+bool CompareSet(const std::set<X, Y> &a, const std::set<X, Y> &b)
+{
+    if (a.size() != b.size()) {
+        return false;
+    }
+    typename std::set<X, Y>::const_iterator ait = a.begin(), bit = b.begin();
+    while (ait != a.end() && bit != b.end()) {
+        if (*ait != *bit) return false;
+        ait++;
+        bit++;
+    }
+    return true;
+}
+
 BOOST_AUTO_TEST_CASE(MempoolIndexingTest)
 {
     CTxMemPool pool(CFeeRate(0));
@@ -138,18 +164,136 @@ BOOST_AUTO_TEST_CASE(MempoolIndexingTest)
     tx5.vout[0].scriptPubKey = CScript() << OP_11 << OP_EQUAL;
     tx5.vout[0].nValue = 11 * COIN;
     pool.addUnchecked(tx5.GetHash(), CTxMemPoolEntry(tx5, 10000LL, 1, 10.0, 1, true));
-
-    // there should be 4 transactions in the mempool
     BOOST_CHECK_EQUAL(pool.size(), 5);
 
-    // Check the fee-rate index is in order, should be tx2, tx4, tx1, tx5, tx3
-    CTxMemPool::indexed_transaction_set::nth_index<1>::type::iterator it = pool.mapTx.get<1>().begin();
-    BOOST_CHECK_EQUAL(it++->GetTx().GetHash().ToString(), tx2.GetHash().ToString());
-    BOOST_CHECK_EQUAL(it++->GetTx().GetHash().ToString(), tx4.GetHash().ToString());
-    BOOST_CHECK_EQUAL(it++->GetTx().GetHash().ToString(), tx1.GetHash().ToString());
-    BOOST_CHECK_EQUAL(it++->GetTx().GetHash().ToString(), tx5.GetHash().ToString());
-    BOOST_CHECK_EQUAL(it++->GetTx().GetHash().ToString(), tx3.GetHash().ToString());
-    BOOST_CHECK(it == pool.mapTx.get<1>().end());
+    std::vector<std::string> sortedOrder;
+    sortedOrder.resize(5);
+    sortedOrder[0] = tx2.GetHash().ToString(); // 20000
+    sortedOrder[1] = tx4.GetHash().ToString(); // 15000
+    sortedOrder[2] = tx1.GetHash().ToString(); // 10000
+    sortedOrder[3] = tx5.GetHash().ToString(); // 10000
+    sortedOrder[4] = tx3.GetHash().ToString(); // 0
+    CheckSort(pool, sortedOrder);
+
+    /* low fee but with high fee child */
+    /* tx6 -> tx7 -> tx8, tx9 -> tx10 */
+    CMutableTransaction tx6 = CMutableTransaction();
+    tx6.vout.resize(1);
+    tx6.vout[0].scriptPubKey = CScript() << OP_11 << OP_EQUAL;
+    tx6.vout[0].nValue = 20 * COIN;
+    pool.addUnchecked(tx6.GetHash(), CTxMemPoolEntry(tx6, 0LL, 1, 10.0, 1, true));
+    BOOST_CHECK_EQUAL(pool.size(), 6);
+    // Check that at this point, tx6 is sorted low
+    sortedOrder.push_back(tx6.GetHash().ToString());
+    CheckSort(pool, sortedOrder);
+
+    CTxMemPool::setEntries setAncestors;
+    setAncestors.insert(pool.mapTx.find(tx6.GetHash()));
+    CMutableTransaction tx7 = CMutableTransaction();
+    tx7.vin.resize(1);
+    tx7.vin[0].prevout = COutPoint(tx6.GetHash(), 0);
+    tx7.vin[0].scriptSig = CScript() << OP_11;
+    tx7.vout.resize(2);
+    tx7.vout[0].scriptPubKey = CScript() << OP_11 << OP_EQUAL;
+    tx7.vout[0].nValue = 10 * COIN;
+    tx7.vout[1].scriptPubKey = CScript() << OP_11 << OP_EQUAL;
+    tx7.vout[1].nValue = 1 * COIN;
+
+    CTxMemPool::setEntries setAncestorsCalculated;
+    std::string dummy;
+    CTxMemPoolEntry entry7(tx7, 2000000LL, 1, 10.0, 1, true);
+    BOOST_CHECK_EQUAL(pool.CalculateMemPoolAncestors(entry7, setAncestorsCalculated, 100, 1000000, 1000, 1000000, dummy), true);
+    BOOST_CHECK(CompareSet(setAncestorsCalculated, setAncestors));
+
+    pool.addUnchecked(tx7.GetHash(), CTxMemPoolEntry(tx7, 2000000LL, 1, 10.0, 1, true), setAncestors);
+    BOOST_CHECK_EQUAL(pool.size(), 7);
+
+    // Now tx6 should be sorted higher (high fee child): tx7, tx6, tx2, ...
+    sortedOrder.erase(sortedOrder.end()-1);
+    sortedOrder.insert(sortedOrder.begin(), tx6.GetHash().ToString());
+    sortedOrder.insert(sortedOrder.begin(), tx7.GetHash().ToString());
+    CheckSort(pool, sortedOrder);
+
+    /* low fee child of tx7 */
+    CMutableTransaction tx8 = CMutableTransaction();
+    tx8.vin.resize(1);
+    tx8.vin[0].prevout = COutPoint(tx7.GetHash(), 0);
+    tx8.vin[0].scriptSig = CScript() << OP_11;
+    tx8.vout.resize(1);
+    tx8.vout[0].scriptPubKey = CScript() << OP_11 << OP_EQUAL;
+    tx8.vout[0].nValue = 10 * COIN;
+    setAncestors.insert(pool.mapTx.find(tx7.GetHash()));
+    pool.addUnchecked(tx8.GetHash(), CTxMemPoolEntry(tx8, 0LL, 2, 10.0, 1, true), setAncestors);
+
+    // Now tx8 should be sorted low, but tx6/tx both high
+    sortedOrder.push_back(tx8.GetHash().ToString());
+    CheckSort(pool, sortedOrder);
+
+    /* low fee child of tx7 */
+    CMutableTransaction tx9 = CMutableTransaction();
+    tx9.vin.resize(1);
+    tx9.vin[0].prevout = COutPoint(tx7.GetHash(), 1);
+    tx9.vin[0].scriptSig = CScript() << OP_11;
+    tx9.vout.resize(1);
+    tx9.vout[0].scriptPubKey = CScript() << OP_11 << OP_EQUAL;
+    tx9.vout[0].nValue = 1 * COIN;
+    pool.addUnchecked(tx9.GetHash(), CTxMemPoolEntry(tx9, 0LL, 3, 10.0, 1, true), setAncestors);
+
+    // tx9 should be sorted low
+    BOOST_CHECK_EQUAL(pool.size(), 9);
+    sortedOrder.push_back(tx9.GetHash().ToString());
+    CheckSort(pool, sortedOrder);
+
+    std::vector<std::string> snapshotOrder = sortedOrder;
+
+    setAncestors.insert(pool.mapTx.find(tx8.GetHash()));
+    setAncestors.insert(pool.mapTx.find(tx9.GetHash()));
+    /* tx10 depends on tx8 and tx9 and has a high fee*/
+    CMutableTransaction tx10 = CMutableTransaction();
+    tx10.vin.resize(2);
+    tx10.vin[0].prevout = COutPoint(tx8.GetHash(), 0);
+    tx10.vin[0].scriptSig = CScript() << OP_11;
+    tx10.vin[1].prevout = COutPoint(tx9.GetHash(), 0);
+    tx10.vin[1].scriptSig = CScript() << OP_11;
+    tx10.vout.resize(1);
+    tx10.vout[0].scriptPubKey = CScript() << OP_11 << OP_EQUAL;
+    tx10.vout[0].nValue = 10 * COIN;
+
+    setAncestorsCalculated.clear();
+    CTxMemPoolEntry entry10(tx10, 200000LL, 4, 10.0, 1, true);
+    BOOST_CHECK_EQUAL(pool.CalculateMemPoolAncestors(entry10, setAncestorsCalculated, 100, 1000000, 1000, 1000000, dummy), true);
+    BOOST_CHECK(CompareSet(setAncestorsCalculated, setAncestors));
+
+    pool.addUnchecked(tx10.GetHash(), CTxMemPoolEntry(tx10, 200000LL, 4, 10.0, 1, true), setAncestors);
+
+    /**
+     *  tx8 and tx9 should both now be sorted higher
+     *  Final order after tx10 is added:
+     *
+     *  tx7 = 2.2M (4 txs)
+     *  tx6 = 2.2M (5 txs)
+     *  tx10 = 200k (1 tx)
+     *  tx8 = 200k (2 txs)
+     *  tx9 = 200k (2 txs)
+     *  tx2 = 20000 (1)
+     *  tx4 = 15000 (1)
+     *  tx1 = 10000 (1)
+     *  tx5 = 10000 (1)
+     *  tx3 = 0 (1)
+     */
+    sortedOrder.erase(sortedOrder.end()-2, sortedOrder.end()); // take out tx8, tx9 from the end
+    sortedOrder.insert(sortedOrder.begin()+2, tx10.GetHash().ToString()); // tx10 is after tx6
+    sortedOrder.insert(sortedOrder.begin()+3, tx9.GetHash().ToString());
+    sortedOrder.insert(sortedOrder.begin()+3, tx8.GetHash().ToString());
+    CheckSort(pool, sortedOrder);
+
+    // there should be 10 transactions in the mempool
+    BOOST_CHECK_EQUAL(pool.size(), 10);
+
+    // Now try removing tx10 and verify the sort order returns to normal
+    std::list<CTransaction> removed;
+    pool.remove(pool.mapTx.find(tx10.GetHash())->GetTx(), removed, true);
+    CheckSort(pool, snapshotOrder);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -32,6 +32,7 @@ CTxMemPoolEntry::CTxMemPoolEntry(const CTransaction& _tx, const CAmount& _nFee,
     nTxSize = ::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION);
     nModSize = tx.CalculateModifiedSize(nTxSize);
     nUsageSize = RecursiveDynamicUsage(tx);
+    feeRate = CFeeRate(nFee, nTxSize);
 }
 
 CTxMemPoolEntry::CTxMemPoolEntry(const CTxMemPoolEntry& other)
@@ -96,8 +97,8 @@ bool CTxMemPool::addUnchecked(const uint256& hash, const CTxMemPoolEntry &entry,
     // Used by main.cpp AcceptToMemoryPool(), which DOES do
     // all the appropriate checks.
     LOCK(cs);
-    mapTx[hash] = entry;
-    const CTransaction& tx = mapTx[hash].GetTx();
+    mapTx.insert(entry);
+    const CTransaction& tx = mapTx.find(hash)->GetTx();
     for (unsigned int i = 0; i < tx.vin.size(); i++)
         mapNextTx[tx.vin[i].prevout] = CInPoint(&tx, i);
     nTransactionsUpdated++;
@@ -134,7 +135,7 @@ void CTxMemPool::remove(const CTransaction &origTx, std::list<CTransaction>& rem
             txToRemove.pop_front();
             if (!mapTx.count(hash))
                 continue;
-            const CTransaction& tx = mapTx[hash].GetTx();
+            const CTransaction& tx = mapTx.find(hash)->GetTx();
             if (fRecursive) {
                 for (unsigned int i = 0; i < tx.vout.size(); i++) {
                     std::map<COutPoint, CInPoint>::iterator it = mapNextTx.find(COutPoint(hash, i));
@@ -147,8 +148,8 @@ void CTxMemPool::remove(const CTransaction &origTx, std::list<CTransaction>& rem
                 mapNextTx.erase(txin.prevout);
 
             removed.push_back(tx);
-            totalTxSize -= mapTx[hash].GetTxSize();
-            cachedInnerUsage -= mapTx[hash].DynamicMemoryUsage();
+            totalTxSize -= mapTx.find(hash)->GetTxSize();
+            cachedInnerUsage -= mapTx.find(hash)->DynamicMemoryUsage();
             mapTx.erase(hash);
             nTransactionsUpdated++;
             minerPolicyEstimator->removeTx(hash);
@@ -161,10 +162,10 @@ void CTxMemPool::removeCoinbaseSpends(const CCoinsViewCache *pcoins, unsigned in
     // Remove transactions spending a coinbase which are now immature
     LOCK(cs);
     list<CTransaction> transactionsToRemove;
-    for (std::map<uint256, CTxMemPoolEntry>::const_iterator it = mapTx.begin(); it != mapTx.end(); it++) {
-        const CTransaction& tx = it->second.GetTx();
+    for (indexed_transaction_set::const_iterator it = mapTx.begin(); it != mapTx.end(); it++) {
+        const CTransaction& tx = it->GetTx();
         BOOST_FOREACH(const CTxIn& txin, tx.vin) {
-            std::map<uint256, CTxMemPoolEntry>::const_iterator it2 = mapTx.find(txin.prevout.hash);
+            indexed_transaction_set::const_iterator it2 = mapTx.find(txin.prevout.hash);
             if (it2 != mapTx.end())
                 continue;
             const CCoins *coins = pcoins->AccessCoins(txin.prevout.hash);
@@ -209,8 +210,10 @@ void CTxMemPool::removeForBlock(const std::vector<CTransaction>& vtx, unsigned i
     BOOST_FOREACH(const CTransaction& tx, vtx)
     {
         uint256 hash = tx.GetHash();
-        if (mapTx.count(hash))
-            entries.push_back(mapTx[hash]);
+
+        indexed_transaction_set::iterator i = mapTx.find(hash);
+        if (i != mapTx.end())
+            entries.push_back(*i);
     }
     BOOST_FOREACH(const CTransaction& tx, vtx)
     {
@@ -247,17 +250,17 @@ void CTxMemPool::check(const CCoinsViewCache *pcoins) const
 
     LOCK(cs);
     list<const CTxMemPoolEntry*> waitingOnDependants;
-    for (std::map<uint256, CTxMemPoolEntry>::const_iterator it = mapTx.begin(); it != mapTx.end(); it++) {
+    for (indexed_transaction_set::const_iterator it = mapTx.begin(); it != mapTx.end(); it++) {
         unsigned int i = 0;
-        checkTotal += it->second.GetTxSize();
-        innerUsage += it->second.DynamicMemoryUsage();
-        const CTransaction& tx = it->second.GetTx();
+        checkTotal += it->GetTxSize();
+        innerUsage += it->DynamicMemoryUsage();
+        const CTransaction& tx = it->GetTx();
         bool fDependsWait = false;
         BOOST_FOREACH(const CTxIn &txin, tx.vin) {
             // Check that every mempool transaction's inputs refer to available coins, or other mempool tx's.
-            std::map<uint256, CTxMemPoolEntry>::const_iterator it2 = mapTx.find(txin.prevout.hash);
+            indexed_transaction_set::const_iterator it2 = mapTx.find(txin.prevout.hash);
             if (it2 != mapTx.end()) {
-                const CTransaction& tx2 = it2->second.GetTx();
+                const CTransaction& tx2 = it2->GetTx();
                 assert(tx2.vout.size() > txin.prevout.n && !tx2.vout[txin.prevout.n].IsNull());
                 fDependsWait = true;
             } else {
@@ -272,7 +275,7 @@ void CTxMemPool::check(const CCoinsViewCache *pcoins) const
             i++;
         }
         if (fDependsWait)
-            waitingOnDependants.push_back(&it->second);
+            waitingOnDependants.push_back(&(*it));
         else {
             CValidationState state;
             assert(CheckInputs(tx, state, mempoolDuplicate, false, 0, false, NULL));
@@ -296,8 +299,8 @@ void CTxMemPool::check(const CCoinsViewCache *pcoins) const
     }
     for (std::map<COutPoint, CInPoint>::const_iterator it = mapNextTx.begin(); it != mapNextTx.end(); it++) {
         uint256 hash = it->second.ptx->GetHash();
-        map<uint256, CTxMemPoolEntry>::const_iterator it2 = mapTx.find(hash);
-        const CTransaction& tx = it2->second.GetTx();
+        indexed_transaction_set::const_iterator it2 = mapTx.find(hash);
+        const CTransaction& tx = it2->GetTx();
         assert(it2 != mapTx.end());
         assert(&tx == it->second.ptx);
         assert(tx.vin.size() > it->second.n);
@@ -314,16 +317,16 @@ void CTxMemPool::queryHashes(vector<uint256>& vtxid)
 
     LOCK(cs);
     vtxid.reserve(mapTx.size());
-    for (map<uint256, CTxMemPoolEntry>::iterator mi = mapTx.begin(); mi != mapTx.end(); ++mi)
-        vtxid.push_back((*mi).first);
+    for (indexed_transaction_set::iterator mi = mapTx.begin(); mi != mapTx.end(); ++mi)
+        vtxid.push_back(mi->GetTx().GetHash());
 }
 
 bool CTxMemPool::lookup(uint256 hash, CTransaction& result) const
 {
     LOCK(cs);
-    map<uint256, CTxMemPoolEntry>::const_iterator i = mapTx.find(hash);
+    indexed_transaction_set::const_iterator i = mapTx.find(hash);
     if (i == mapTx.end()) return false;
-    result = i->second.GetTx();
+    result = i->GetTx();
     return true;
 }
 
@@ -429,5 +432,6 @@ bool CCoinsViewMemPool::HaveCoins(const uint256 &txid) const {
 
 size_t CTxMemPool::DynamicMemoryUsage() const {
     LOCK(cs);
-    return memusage::DynamicUsage(mapTx) + memusage::DynamicUsage(mapNextTx) + memusage::DynamicUsage(mapDeltas) + cachedInnerUsage;
+    // Estimate the overhead of mapTx to be 6 pointers + an allocation, as no exact formula for boost::multi_index_contained is implemented.
+    return memusage::MallocUsage(sizeof(CTxMemPoolEntry) + 6 * sizeof(void*)) * mapTx.size() + memusage::DynamicUsage(mapNextTx) + memusage::DynamicUsage(mapDeltas) + cachedInnerUsage;
 }

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -770,6 +770,11 @@ size_t CTxMemPool::DynamicMemoryUsage() const {
     return memusage::MallocUsage(sizeof(CTxMemPoolEntry) + 9 * sizeof(void*)) * mapTx.size() + memusage::DynamicUsage(mapNextTx) + memusage::DynamicUsage(mapDeltas) + memusage::DynamicUsage(mapLinks) + cachedInnerUsage;
 }
 
+size_t CTxMemPool::GuessDynamicMemoryUsage(const CTxMemPoolEntry& entry) const {
+    setEntries s;
+    return memusage::MallocUsage(sizeof(CTxMemPoolEntry) + 9 * sizeof(void*)) + entry.DynamicMemoryUsage() + (memusage::IncrementalDynamicUsage(mapNextTx) + memusage::IncrementalDynamicUsage(s)) * entry.GetTx().vin.size() + memusage::IncrementalDynamicUsage(mapLinks);
+}
+
 void CTxMemPool::RemoveStaged(std::set<uint256>& stage) {
     UpdateForRemoveFromMempool(stage);
     BOOST_FOREACH(const uint256& hash, stage) {

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -18,7 +18,8 @@
 using namespace std;
 
 CTxMemPoolEntry::CTxMemPoolEntry():
-    nFee(0), nTxSize(0), nModSize(0), nUsageSize(0), nTime(0), dPriority(0.0), hadNoDependencies(false)
+    nFee(0), nTxSize(0), nModSize(0), nUsageSize(0), nTime(0), dPriority(0.0), hadNoDependencies(false),
+    nCountWithDescendants(0), nSizeWithDescendants(0), nFeesWithDescendants(0)
 {
     nHeight = MEMPOOL_HEIGHT;
 }
@@ -32,7 +33,10 @@ CTxMemPoolEntry::CTxMemPoolEntry(const CTransaction& _tx, const CAmount& _nFee,
     nTxSize = ::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION);
     nModSize = tx.CalculateModifiedSize(nTxSize);
     nUsageSize = RecursiveDynamicUsage(tx);
-    feeRate = CFeeRate(nFee, nTxSize);
+
+    nCountWithDescendants = 1;
+    nSizeWithDescendants = nTxSize;
+    nFeesWithDescendants = nFee;
 }
 
 CTxMemPoolEntry::CTxMemPoolEntry(const CTxMemPoolEntry& other)
@@ -47,6 +51,246 @@ CTxMemPoolEntry::GetPriority(unsigned int currentHeight) const
     double deltaPriority = ((double)(currentHeight-nHeight)*nValueIn)/nModSize;
     double dResult = dPriority + deltaPriority;
     return dResult;
+}
+
+// Update the given tx for any in-mempool descendants.
+// Assumes that setMemPoolChildren is correct for the given tx and all
+// descendants.
+bool CTxMemPool::UpdateForDescendants(txiter updateIt, int maxDescendantsToVisit, cacheMap &cachedDescendants, const std::set<uint256> &setExclude)
+{
+    // Track the number of entries (outside setExclude) that we'd need to visit
+    // (will bail out if it exceeds maxDescendantsToVisit)
+    int nChildrenToVisit = 0; 
+
+    setEntries stageEntries, setAllDescendants;
+    stageEntries = GetMemPoolChildren(updateIt);
+
+    while (!stageEntries.empty()) {
+        setAllDescendants.insert(stageEntries.begin(), stageEntries.end());
+
+        setEntries entriesToAdd;
+        BOOST_FOREACH(const txiter cit, stageEntries) {
+            if (cit->IsDirty()) {
+                // Don't consider any more children if any descendant is dirty
+                return false;
+            }
+            const setEntries &setChildren = GetMemPoolChildren(cit);
+            BOOST_FOREACH(const txiter childEntry, setChildren) {
+                cacheMap::iterator cacheIt = cachedDescendants.find(childEntry);
+                if (cacheIt != cachedDescendants.end()) {
+                    // We've already calculated this one, just add the entries for this set
+                    // but don't traverse again.
+                    BOOST_FOREACH(const txiter cacheEntry, cacheIt->second) {
+                        // update visit count only for new child transactions
+                        // (outside of setExclude and entriesToAdd)
+                        if (setAllDescendants.insert(cacheEntry).second &&
+                                !setExclude.count(cacheEntry->GetTx().GetHash()) &&
+                                !entriesToAdd.count(cacheEntry)) {
+                            nChildrenToVisit++;
+                        }
+                    }
+                } else if (!setAllDescendants.count(childEntry)) {
+                    // Try adding to entriesToAdd, and update our visit count
+                    if (entriesToAdd.insert(childEntry).second && !setExclude.count(childEntry->GetTx().GetHash())) {
+                        nChildrenToVisit++;
+                    }
+                }
+                if (nChildrenToVisit > maxDescendantsToVisit) {
+                    return false;
+                }
+            }
+        }
+        stageEntries = entriesToAdd;
+    }
+    // setAllDescendants now contains all in-mempool descendants of updateIt.
+    // Update and add to cached descendant map
+    int64_t modifySize = 0;
+    CAmount modifyFee = 0;
+    int64_t modifyCount = 0;
+    BOOST_FOREACH(txiter cit, setAllDescendants) {
+        if (!setExclude.count(cit->GetTx().GetHash())) {
+            modifySize += cit->GetTxSize();
+            modifyFee += cit->GetFee();
+            modifyCount++;
+            cachedDescendants[updateIt].insert(cit);
+        }
+    }
+    mapTx.modify(updateIt, update_descendant_state(modifySize, modifyFee, modifyCount));
+    return true;
+}
+
+// vHashesToUpdate is the set of transaction hashes from a disconnected block
+// which has been re-added to the mempool.
+// for each entry, look for descendants that are outside hashesToUpdate, and
+// add fee/size information for such descendants to the parent.
+void CTxMemPool::UpdateTransactionsFromBlock(const std::vector<uint256> &vHashesToUpdate)
+{
+    // For each entry in vHashesToUpdate, store the set of in-mempool, but not
+    // in-vHashesToUpdate transactions, so that we don't have to recalculate
+    // descendants when we come across a previously seen entry.
+    cacheMap mapMemPoolDescendantsToUpdate;
+
+    // Use a set for lookups into vHashesToUpdate (these entries are already
+    // accounted for in the state of their ancestors)
+    std::set<uint256> setAlreadyIncluded(vHashesToUpdate.begin(), vHashesToUpdate.end());
+
+    // Iterate in reverse, so that whenever we are looking at at a transaction
+    // we are sure that all in-mempool descendants have already been processed.
+    // This maximizes the benefit of the descendant cache and guarantees that
+    // setMemPoolChildren will be updated, an assumption made in
+    // UpdateForDescendants.
+    BOOST_REVERSE_FOREACH(const uint256 &hash, vHashesToUpdate) {
+        // we cache the in-mempool children to avoid duplicate updates
+        setEntries setChildren;
+        // calculate children from mapNextTx
+        txiter it = mapTx.find(hash);
+        if (it == mapTx.end()) {
+            continue;
+        }
+        std::map<COutPoint, CInPoint>::iterator iter = mapNextTx.lower_bound(COutPoint(hash, 0));
+        // First calculate the children, and update setMemPoolChildren to
+        // include them, and update their setMemPoolParents to include this tx.
+        for (; iter != mapNextTx.end() && iter->first.hash == hash; ++iter) {
+            const uint256 &childHash = iter->second.ptx->GetHash();
+            txiter childIter = mapTx.find(childHash);
+            // We can skip updating entries we've encountered before or that
+            // are in the block (which are already accounted for).
+            if (setChildren.insert(childIter).second && !setAlreadyIncluded.count(childHash)) {
+                UpdateChild(it, childIter, true);
+                UpdateParent(childIter, it, true);
+            }
+        }
+        if (!UpdateForDescendants(it, 100, mapMemPoolDescendantsToUpdate, setAlreadyIncluded)) {
+            // Mark as dirty if we can't do the calculation.
+            mapTx.modify(it, set_dirty());
+        }
+    }
+}
+
+bool CTxMemPool::CalculateMemPoolAncestors(const CTxMemPoolEntry &entry, setEntries &setAncestors, uint64_t limitAncestorCount, uint64_t limitAncestorSize, uint64_t limitDescendantCount, uint64_t limitDescendantSize, std::string &errString)
+{
+    setEntries parentHashes;
+    const CTransaction &tx = entry.GetTx();
+
+    // Get parents of this transaction that are in the mempool
+    // entry may or may not already be in the mempool, so we iterate mapTx
+    // to find parents, rather than try GetMemPoolParents(entry)
+    // TODO: optimize this so that we only check limits and walk
+    // tx.vin when called on entries not already in the mempool.
+    for (unsigned int i = 0; i < tx.vin.size(); i++) {
+        txiter piter = mapTx.find(tx.vin[i].prevout.hash);
+        if (piter != mapTx.end()) {
+            parentHashes.insert(piter);
+            if (parentHashes.size() + 1 > limitAncestorCount) {
+                errString = strprintf("too many unconfirmed parents [limit: %u]", limitAncestorCount);
+                return false;
+            }
+        }
+    }
+
+    size_t totalSizeWithAncestors = entry.GetTxSize();
+
+    while (!parentHashes.empty()) {
+        setAncestors.insert(parentHashes.begin(), parentHashes.end());
+        setEntries stageParentSet; 
+        BOOST_FOREACH(const txiter &stageit, parentHashes) {
+            assert(stageit != mapTx.end());
+
+            totalSizeWithAncestors += stageit->GetTxSize();
+            if (stageit->GetSizeWithDescendants() + entry.GetTxSize() > limitDescendantSize) {
+                errString = strprintf("exceeds descendant size limit for tx %s [limit: %u]", stageit->GetTx().GetHash().ToString().substr(0,10), limitDescendantSize);
+                return false;
+            } else if (uint64_t(stageit->GetCountWithDescendants() + 1) > limitDescendantCount) {
+                errString = strprintf("too many descendants for tx %s [limit: %u]", stageit->GetTx().GetHash().ToString().substr(0,10), limitDescendantCount);
+                return false;
+            } else if (totalSizeWithAncestors > limitAncestorSize) {
+                errString = strprintf("exceeds ancestor size limit [limit: %u]", limitAncestorSize);
+                return false;
+            }
+
+            const setEntries & setMemPoolParents = GetMemPoolParents(stageit);
+            BOOST_FOREACH(const txiter &phash, setMemPoolParents) {
+                // If this is a new ancestor, add it.
+                if (setAncestors.count(phash) == 0) {
+                    stageParentSet.insert(phash);
+                }
+                if (stageParentSet.size() + setAncestors.size() + 1 > limitAncestorCount) {
+                    errString = strprintf("too many unconfirmed ancestors [limit: %u]", limitAncestorCount);
+                    return false;
+                }
+            }    
+        }
+        parentHashes = stageParentSet;
+    }
+
+    return true;
+}
+
+void CTxMemPool::UpdateAncestorsOf(bool add, const uint256 &hash, setEntries &setAncestors)
+{
+    indexed_transaction_set::iterator it = mapTx.find(hash);
+    setEntries parentIters = GetMemPoolParents(it);
+    // add or remove this tx as a child of each parent
+    BOOST_FOREACH(txiter piter, parentIters) {
+        UpdateChild(piter, it, add);
+    }
+    int64_t updateCount = (add ? 1 : -1);
+    int64_t updateSize = updateCount * it->GetTxSize();
+    CAmount updateFee = updateCount * it->GetFee();
+    BOOST_FOREACH(txiter ancestorIt, setAncestors) {
+        mapTx.modify(ancestorIt, update_descendant_state(updateSize, updateFee, updateCount));
+    }
+}
+
+// TODO: pass a txiter instead?
+void CTxMemPool::UpdateChildrenForRemoval(const uint256 &hash)
+{
+    txiter it = mapTx.find(hash);
+    const setEntries &setMemPoolChildren = GetMemPoolChildren(it);
+    BOOST_FOREACH(txiter updateIt, setMemPoolChildren) {
+        UpdateParent(updateIt, it, false);
+    }
+}
+
+void CTxMemPool::UpdateForRemoveFromMempool(const std::set<uint256> &hashesToRemove)
+{
+    // For each entry, walk back all ancestors and decrement size associated with this
+    // transaction
+    uint64_t nNoLimit = std::numeric_limits<uint64_t>::max();
+    BOOST_FOREACH(const uint256& removeHash, hashesToRemove) {
+        setEntries setAncestors;
+        const CTxMemPoolEntry &entry = *mapTx.find(removeHash);
+        std::string dummy;
+        CalculateMemPoolAncestors(entry, setAncestors, nNoLimit, nNoLimit, nNoLimit, nNoLimit, dummy);
+        // Note that UpdateAncestorsOf severs the child links that point to
+        // removeHash in the entries for the parents of removeHash.  This is
+        // fine since we don't need to use the mempool children of any entries
+        // to walk back over our ancestors (but we do need the mempool
+        // parents!)
+        UpdateAncestorsOf(false, removeHash, setAncestors);
+    }
+    // After updating all the ancestor sizes, we can now sever the link between each
+    // transaction being removed and any mempool children (ie, update setMemPoolParents
+    // for each direct child of a transaction being removed).
+    BOOST_FOREACH(const uint256& removeHash, hashesToRemove) {
+        UpdateChildrenForRemoval(removeHash);
+    }
+}
+
+void CTxMemPoolEntry::SetDirty()
+{
+    nCountWithDescendants=0;
+    nSizeWithDescendants=nTxSize;
+    nFeesWithDescendants=nFee;
+}
+
+void CTxMemPoolEntry::UpdateState(int64_t modifySize, CAmount modifyFee, int64_t modifyCount)
+{
+    if (!IsDirty()) {
+        nSizeWithDescendants += modifySize;
+        nFeesWithDescendants += modifyFee;
+        nCountWithDescendants += modifyCount;
+    }
 }
 
 CTxMemPool::CTxMemPool(const CFeeRate& _minRelayFee) :
@@ -90,34 +334,106 @@ void CTxMemPool::AddTransactionsUpdated(unsigned int n)
     nTransactionsUpdated += n;
 }
 
-
-bool CTxMemPool::addUnchecked(const uint256& hash, const CTxMemPoolEntry &entry, bool fCurrentEstimate)
+bool CTxMemPool::addUnchecked(const uint256& hash, const CTxMemPoolEntry &entry, setEntries &setAncestors, bool fCurrentEstimate)
 {
     // Add to memory pool without checking anything.
     // Used by main.cpp AcceptToMemoryPool(), which DOES do
     // all the appropriate checks.
     LOCK(cs);
-    mapTx.insert(entry);
-    const CTransaction& tx = mapTx.find(hash)->GetTx();
-    for (unsigned int i = 0; i < tx.vin.size(); i++)
+    indexed_transaction_set::iterator newit = mapTx.insert(entry).first;
+    mapLinks.insert(make_pair(newit, TxLinks()));
+
+    // Update cachedInnerUsage to include contained transaction's usage.
+    // (When we update the entry for in-mempool parents, memory usage will be
+    // further updated.)
+    cachedInnerUsage += entry.DynamicMemoryUsage();
+
+    const CTransaction& tx = newit->GetTx();
+    std::set<uint256> setParentTransactions;
+    for (unsigned int i = 0; i < tx.vin.size(); i++) {
         mapNextTx[tx.vin[i].prevout] = CInPoint(&tx, i);
+        setParentTransactions.insert(tx.vin[i].prevout.hash);
+    }
+    // Don't bother worrying about child transactions of this one.
+    // Normal case of a new transaction arriving is that there can't be any
+    // children, because such children would be orphans.
+    // An exception to that is if a transaction enters that used to be in a block.
+    // In that case, our disconnect block logic will call UpdateTransactionsFromBlock
+    // to clean up the mess we're leaving here.
+
+    // Update ancestors with information about this tx
+    BOOST_FOREACH (const uint256 &phash, setParentTransactions) {
+        txiter pit = mapTx.find(phash);
+        if (pit != mapTx.end()) {
+            UpdateParent(newit, pit, true);
+        }
+    }
+    UpdateAncestorsOf(true, hash, setAncestors);
+
     nTransactionsUpdated++;
     totalTxSize += entry.GetTxSize();
-    cachedInnerUsage += entry.DynamicMemoryUsage();
     minerPolicyEstimator->processTransaction(entry, fCurrentEstimate);
 
     return true;
 }
 
+// TODO: replace this hash with an iterator?
+void CTxMemPool::removeUnchecked(const uint256& hash)
+{
+    indexed_transaction_set::iterator it = mapTx.find(hash);
+
+    BOOST_FOREACH(const CTxIn& txin, it->GetTx().vin)
+        mapNextTx.erase(txin.prevout);
+
+    totalTxSize -= it->GetTxSize();
+    cachedInnerUsage -= it->DynamicMemoryUsage();
+    cachedInnerUsage -= memusage::DynamicUsage(mapLinks[it].parents) + memusage::DynamicUsage(mapLinks[it].children);
+    mapLinks.erase(it);
+    mapTx.erase(it);
+    nTransactionsUpdated++;
+    minerPolicyEstimator->removeTx(hash);
+}
+
+// Calculates descendants of hash that are not already in setDescendants, and adds to 
+// setDescendants. Assumes hash is already a tx in the mempool and setMemPoolChildren
+// is correct for tx and all descendants.
+// Also assumes that if an entry is in setDescendants already, then all
+// in-mempool descendants of it are already in setDescendants as well, so that we
+// can save time by not iterating over those entries.
+void CTxMemPool::CalculateDescendants(const uint256 &hash, std::set<uint256> &setDescendants)
+{
+    std::set<uint256> stage;
+    if (setDescendants.count(hash) == 0) {
+        stage.insert(hash);
+    }
+    // Traverse down the children of each hash, only adding children that are not
+    // accounted for in setDescendants already (because those children have either
+    // already been walked, or will be walked in this iteration).
+    while (!stage.empty()) {
+        setDescendants.insert(stage.begin(), stage.end());
+        std::set<uint256> setNext;
+        BOOST_FOREACH(const uint256 &stagehash, stage) {
+            indexed_transaction_set::iterator it = mapTx.find(stagehash);
+            const setEntries &setChildren = GetMemPoolChildren(it);
+            BOOST_FOREACH(const txiter &childiter, setChildren) {
+                if (!setDescendants.count(childiter->GetTx().GetHash())) {
+                    setNext.insert(childiter->GetTx().GetHash());
+                }
+            }
+        }
+        stage = setNext;
+    }
+}
 
 void CTxMemPool::remove(const CTransaction &origTx, std::list<CTransaction>& removed, bool fRecursive)
 {
     // Remove transaction from memory pool
     {
         LOCK(cs);
-        std::deque<uint256> txToRemove;
-        txToRemove.push_back(origTx.GetHash());
-        if (fRecursive && !mapTx.count(origTx.GetHash())) {
+        std::set<uint256> txToRemove;
+        if (mapTx.count(origTx.GetHash())) {
+            txToRemove.insert(origTx.GetHash());
+        } else if (fRecursive) {
             // If recursively removing but origTx isn't in the mempool
             // be sure to remove any children that are in the pool. This can
             // happen during chain re-orgs if origTx isn't re-accepted into
@@ -126,34 +442,21 @@ void CTxMemPool::remove(const CTransaction &origTx, std::list<CTransaction>& rem
                 std::map<COutPoint, CInPoint>::iterator it = mapNextTx.find(COutPoint(origTx.GetHash(), i));
                 if (it == mapNextTx.end())
                     continue;
-                txToRemove.push_back(it->second.ptx->GetHash());
+                txToRemove.insert(it->second.ptx->GetHash());
             }
         }
-        while (!txToRemove.empty())
-        {
-            uint256 hash = txToRemove.front();
-            txToRemove.pop_front();
-            if (!mapTx.count(hash))
-                continue;
-            const CTransaction& tx = mapTx.find(hash)->GetTx();
-            if (fRecursive) {
-                for (unsigned int i = 0; i < tx.vout.size(); i++) {
-                    std::map<COutPoint, CInPoint>::iterator it = mapNextTx.find(COutPoint(hash, i));
-                    if (it == mapNextTx.end())
-                        continue;
-                    txToRemove.push_back(it->second.ptx->GetHash());
-                }
+        std::set<uint256> setAllRemoves;
+        if (fRecursive) {
+            BOOST_FOREACH(const uint256 &hash, txToRemove) {
+                CalculateDescendants(hash, setAllRemoves);
             }
-            BOOST_FOREACH(const CTxIn& txin, tx.vin)
-                mapNextTx.erase(txin.prevout);
-
-            removed.push_back(tx);
-            totalTxSize -= mapTx.find(hash)->GetTxSize();
-            cachedInnerUsage -= mapTx.find(hash)->DynamicMemoryUsage();
-            mapTx.erase(hash);
-            nTransactionsUpdated++;
-            minerPolicyEstimator->removeTx(hash);
+        } else {
+            setAllRemoves = txToRemove;
         }
+        BOOST_FOREACH(const uint256& hash, setAllRemoves) {
+            removed.push_back(mapTx.find(hash)->GetTx());
+        }
+        RemoveStaged(setAllRemoves);
     }
 }
 
@@ -229,6 +532,7 @@ void CTxMemPool::removeForBlock(const std::vector<CTransaction>& vtx, unsigned i
 void CTxMemPool::clear()
 {
     LOCK(cs);
+    mapLinks.clear();
     mapTx.clear();
     mapNextTx.clear();
     totalTxSize = 0;
@@ -253,9 +557,12 @@ void CTxMemPool::check(const CCoinsViewCache *pcoins) const
     for (indexed_transaction_set::const_iterator it = mapTx.begin(); it != mapTx.end(); it++) {
         unsigned int i = 0;
         checkTotal += it->GetTxSize();
-        innerUsage += it->DynamicMemoryUsage();
+        innerUsage += it->DynamicMemoryUsage(); 
         const CTransaction& tx = it->GetTx();
+        const TxLinks &links = mapLinks.find(it)->second;
+        innerUsage += memusage::DynamicUsage(links.parents) + memusage::DynamicUsage(links.children);
         bool fDependsWait = false;
+        setEntries setParentCheck;
         BOOST_FOREACH(const CTxIn &txin, tx.vin) {
             // Check that every mempool transaction's inputs refer to available coins, or other mempool tx's.
             indexed_transaction_set::const_iterator it2 = mapTx.find(txin.prevout.hash);
@@ -263,6 +570,7 @@ void CTxMemPool::check(const CCoinsViewCache *pcoins) const
                 const CTransaction& tx2 = it2->GetTx();
                 assert(tx2.vout.size() > txin.prevout.n && !tx2.vout[txin.prevout.n].IsNull());
                 fDependsWait = true;
+                setParentCheck.insert(it2);
             } else {
                 const CCoins* coins = pcoins->AccessCoins(txin.prevout.hash);
                 assert(coins && coins->IsAvailable(txin.prevout.n));
@@ -274,6 +582,32 @@ void CTxMemPool::check(const CCoinsViewCache *pcoins) const
             assert(it3->second.n == i);
             i++;
         }
+        assert(setParentCheck == GetMemPoolParents(it));
+        // Check children against mapNextTx
+        CTxMemPool::setEntries setChildrenCheck;
+        std::map<COutPoint, CInPoint>::const_iterator iter = mapNextTx.lower_bound(COutPoint(it->GetTx().GetHash(), 0));
+        int64_t childSizes = 0;
+        CAmount childFees = 0;
+        for (; iter != mapNextTx.end() && iter->first.hash == it->GetTx().GetHash(); ++iter) {
+            txiter childit = mapTx.find(iter->second.ptx->GetHash());
+            if (setChildrenCheck.insert(childit).second) {
+                childSizes += childit->GetTxSize();
+                childFees += childit->GetFee();
+            }
+        }
+        assert(setChildrenCheck == GetMemPoolChildren(it));
+        // Also check to make sure size/fees is greater than sum with immediate children.
+        // just a sanity check, not definitive that this calc is correct...
+        // also check that the size is less than the size of the entire mempool.
+        if (!it->IsDirty()) {
+            assert(it->GetSizeWithDescendants() >= childSizes + int64_t(it->GetTxSize()));
+            assert(it->GetFeesWithDescendants() >= childFees + it->GetFee());
+        } else {
+            assert(it->GetSizeWithDescendants() == int64_t(it->GetTxSize()));
+            assert(it->GetFeesWithDescendants() == it->GetFee());
+        }
+        assert(it->GetFeesWithDescendants() >= 0);
+
         if (fDependsWait)
             waitingOnDependants.push_back(&(*it));
         else {
@@ -432,6 +766,54 @@ bool CCoinsViewMemPool::HaveCoins(const uint256 &txid) const {
 
 size_t CTxMemPool::DynamicMemoryUsage() const {
     LOCK(cs);
-    // Estimate the overhead of mapTx to be 6 pointers + an allocation, as no exact formula for boost::multi_index_contained is implemented.
-    return memusage::MallocUsage(sizeof(CTxMemPoolEntry) + 6 * sizeof(void*)) * mapTx.size() + memusage::DynamicUsage(mapNextTx) + memusage::DynamicUsage(mapDeltas) + cachedInnerUsage;
+    // Estimate the overhead of mapTx to be 9 pointers + an allocation, as no exact formula for boost::multi_index_contained is implemented.
+    return memusage::MallocUsage(sizeof(CTxMemPoolEntry) + 9 * sizeof(void*)) * mapTx.size() + memusage::DynamicUsage(mapNextTx) + memusage::DynamicUsage(mapDeltas) + memusage::DynamicUsage(mapLinks) + cachedInnerUsage;
+}
+
+void CTxMemPool::RemoveStaged(std::set<uint256>& stage) {
+    UpdateForRemoveFromMempool(stage);
+    BOOST_FOREACH(const uint256& hash, stage) {
+        removeUnchecked(hash);
+    }
+}
+
+bool CTxMemPool::addUnchecked(const uint256&hash, const CTxMemPoolEntry &entry, bool fCurrentEstimate)
+{
+    setEntries setAncestors;
+    uint64_t nNoLimit = std::numeric_limits<uint64_t>::max();
+    std::string dummy;
+    CalculateMemPoolAncestors(entry, setAncestors, nNoLimit, nNoLimit, nNoLimit, nNoLimit, dummy);
+    return addUnchecked(hash, entry, setAncestors, fCurrentEstimate);
+}
+
+void CTxMemPool::UpdateChild(txiter entry, txiter child, bool add)
+{
+    setEntries s;
+    if (add && mapLinks[entry].children.insert(child).second) {
+        cachedInnerUsage += memusage::IncrementalDynamicUsage(s);
+    } else if (!add && mapLinks[entry].children.erase(child)) {
+        cachedInnerUsage -= memusage::IncrementalDynamicUsage(s);
+    }
+}
+
+void CTxMemPool::UpdateParent(txiter entry, txiter parent, bool add)
+{
+    setEntries s;
+    if (add && mapLinks[entry].parents.insert(parent).second) {
+        cachedInnerUsage += memusage::IncrementalDynamicUsage(s);
+    } else if (!add && mapLinks[entry].parents.erase(parent)) {
+        cachedInnerUsage -= memusage::IncrementalDynamicUsage(s);
+    }
+}
+
+const CTxMemPool::setEntries & CTxMemPool::GetMemPoolParents(txiter entry) const
+{
+    assert (entry != mapTx.end());
+    return mapLinks.find(entry)->second.parents;
+}
+
+const CTxMemPool::setEntries & CTxMemPool::GetMemPoolChildren(txiter entry) const
+{
+    assert (entry != mapTx.end());
+    return mapLinks.find(entry)->second.children;
 }

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -37,9 +37,23 @@ static const unsigned int MEMPOOL_HEIGHT = 0x7FFFFFFF;
 
 class CTxMemPool;
 
-/**
- * CTxMemPool stores these:
+/** \class CTxMemPoolEntry
+ *
+ * CTxMemPoolEntry stores data about the correponding transaction, as well
+ * as data about all in-mempool transactions that depend on the transaction
+ * ("descendant" transactions).
+ *
+ * When a new entry is added to the mempool, we update the descendant state
+ * (nCountWithDescendants, nSizeWithDescendants, and nFeesWithDescendants) for
+ * all ancestors of the newly added transaction.
+ *
+ * If updating the descendant state is skipped, we can mark the entry as
+ * "dirty", and set nSizeWithDescendants/nFeesWithDescendants to equal nTxSize/
+ * nTxFee. (This can potentially happen during a reorg, where we limit the
+ * amount of work we're willing to do to avoid consuming too much CPU.)
+ *
  */
+
 class CTxMemPoolEntry
 {
 private:
@@ -126,6 +140,10 @@ struct mempoolentry_txid
     }
 };
 
+/** \class CompareTxMemPoolEntryByFee
+ *
+ *  Sort an entry by max(feerate of entry's tx, feerate with all descendants).
+ */
 class CompareTxMemPoolEntryByFee
 {
 public:
@@ -150,8 +168,7 @@ public:
         return f1 > f2;
     }
 
-    // Sort an entry based on max(fee_rate by itself, fee_rate with all
-    // descendants).  Avoid division as above.
+    // Calculate which feerate to use for an entry (avoiding division).
     bool UseDescendantFeeRate(const CTxMemPoolEntry &a)
     {
         double f1 = (double)a.GetFee() * a.GetSizeWithDescendants();
@@ -194,6 +211,67 @@ public:
  * are added to the pool: if a new transaction double-spends
  * an input of a transaction in the pool, it is dropped,
  * as are non-standard transactions.
+ *
+ * CTxMemPool::mapTx, and CTxMemPoolEntry bookkeeping:
+ *
+ * mapTx is a boost::multi_index that sorts the mempool on 2 criteria:
+ * - transaction hash
+ * - feerate [we use max(feerate of tx, feerate of tx with all descendants)]
+ *
+ * In order for the feerate sort to remain correct, we must update transactions
+ * in the mempool when new descendants arrive.  To facilitate this, we track
+ * the set of in-mempool direct parents and direct children in mapLinks.  Within
+ * each CTxMemPoolEntry, we track the size and fees of all descendants.
+ *
+ * Usually when a new transaction is added to the mempool, it has no in-mempool
+ * children (because any such children would be an orphan).  So in addUnchecked,
+ * we:
+ * - update a new entry's setMemPoolParents to include all in-mempool parents
+ * - update the new entry's direct parents to include the new tx as a child
+ * - update all ancestors of the transaction to include the new tx's size/fee
+ *
+ * When a transaction is removed from the mempool, we must:
+ * - update all in-mempool parents to not track the tx in setMemPoolChildren
+ * - update all ancestors to not include the tx's size/fees in descendant state
+ * - update all in-mempool children to not include it as a parent
+ *
+ * These happen in UpdateForRemoveFromMempool.  (Note that when removing a
+ * transaction along with its descendants, we must calculate that set of
+ * transactions to be removed before doing the removal, or else the mempool can
+ * be in an inconsistent state where it's impossible to walk the ancestors of
+ * a transaction.)
+ *
+ * In the event of a reorg, the assumption that a newly added tx has no
+ * in-mempool children is false.  In particular, the mempool is in an
+ * inconsistent state while new transactions are being added, because there may
+ * be descendant transactions of a tx coming from a disconnected block that are
+ * unreachable from just looking at transactions in the mempool (the linking
+ * transactions may also be in the disconnected block, waiting to be added).
+ * Because of this, there's not much benefit in trying to search for in-mempool
+ * children in addUnchecked.  Instead, in the special case of transactions
+ * being added from a disconnected block, we require the caller to clean up the
+ * state, to account for in-mempool, out-of-block descendants for all the
+ * in-block transactions by calling UpdateTransactionsFromBlock.  Note that
+ * until this is called, the mempool state is not consistent, and in particular
+ * mapLinks may not be correct (and therefore functions like
+ * CalculateMemPoolAncestors and CalculateDescendants that rely
+ * on them to walk the mempool are not generally safe to use).
+ *
+ * Computational limits:
+ *
+ * Updating all in-mempool ancestors of a newly added transaction can be slow,
+ * if no bound exists on how many in-mempool ancestors there may be.
+ * CalculateMemPoolAncestors() takes configurable limits that are designed to
+ * prevent these calculations from being too CPU intensive.
+ *
+ * Adding transactions from a disconnected block can be very time consuming,
+ * because we don't have a way to limit the number of in-mempool descendants.
+ * To bound CPU processing, we limit the amount of work we're willing to do
+ * to properly update the descendant information for a tx being added from
+ * a disconnected block.  If we would exceed the limit, then we instead mark
+ * the entry as "dirty", and set the feerate for sorting purposes to be equal
+ * the feerate of the transaction without any descendants.
+ *
  */
 class CTxMemPool
 {

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -417,6 +417,7 @@ public:
     bool ReadFeeEstimates(CAutoFile& filein);
 
     size_t DynamicMemoryUsage() const;
+    size_t GuessDynamicMemoryUsage(const CTxMemPoolEntry& entry) const;
 
 private:
     /** UpdateForDescendants is used by UpdateTransactionsFromBlock to update


### PR DESCRIPTION
Built off of #6654, this implements an exponential rising effective min relay feerate.   This version implements 50 bands of 10% increase which is slightly over 100x at the top end.  Thus 100x the configured min relay rate must be more than enough to dissuade spam.
