### PR TITLE
take steps towards standardizing and improving log output

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1212,13 +1212,13 @@ void static InvalidChainFound(CBlockIndex* pindexNew)
     if (!pindexBestInvalid || pindexNew->nChainWork > pindexBestInvalid->nChainWork)
         pindexBestInvalid = pindexNew;
 
-    LogPrintf("%s: invalid block=%s  height=%d  log2_work=%.8g  date=%s\n", __func__,
+    LogPrintf("%s: invalidBlock=%s  height=%d  log2_work=%.8g  date=%s\n", __func__,
       pindexNew->GetBlockHash().ToString(), pindexNew->nHeight,
       log(pindexNew->nChainWork.getdouble())/log(2.0), DateTimeStrFormat("%Y-%m-%d %H:%M:%S",
       pindexNew->GetBlockTime()));
     CBlockIndex *tip = chainActive.Tip();
     assert (tip);
-    LogPrintf("%s:  current best=%s  height=%d  log2_work=%.8g  date=%s\n", __func__,
+    LogPrintf("%s: currentBest=%s  height=%d  log2_work=%.8g  date=%s\n", __func__,
       tip->GetBlockHash().ToString(), chainActive.Height(), log(tip->nChainWork.getdouble())/log(2.0),
       DateTimeStrFormat("%Y-%m-%d %H:%M:%S", tip->GetBlockTime()));
     CheckForkWarningConditions();
@@ -1980,7 +1980,7 @@ void static UpdateTip(CBlockIndex *pindexNew) {
     nTimeBestReceived = GetTime();
     mempool.AddTransactionsUpdated(1);
 
-    LogPrintf("%s: new best=%s  height=%d  log2_work=%.8g  tx=%lu  date=%s progress=%f  cache=%.1fMiB(%utx)\n", __func__,
+    LogPrintf("%s: newBest=%s  height=%d  log2work=%.8g  tx=%lu  date=%s  progress=%f  cache=%.1fMiB (%utx)\n", __func__,
       chainActive.Tip()->GetBlockHash().ToString(), chainActive.Height(), log(chainActive.Tip()->nChainWork.getdouble())/log(2.0), (unsigned long)chainActive.Tip()->nChainTx,
       DateTimeStrFormat("%Y-%m-%d %H:%M:%S", chainActive.Tip()->GetBlockTime()),
       Checkpoints::GuessVerificationProgress(chainParams.Checkpoints(), chainActive.Tip()), pcoinsTip->DynamicMemoryUsage() * (1.0 / (1<<20)), pcoinsTip->GetCacheSize());
@@ -3105,7 +3105,7 @@ bool static LoadBlockIndexDB()
     }
 
     // Check presence of blk files
-    LogPrintf("Checking all blk files are present...\n");
+    LogPrintf("Checking to confirm that all \"blk\" files are present...\n");
     set<int> setBlkDataFiles;
     BOOST_FOREACH(const PAIRTYPE(uint256, CBlockIndex*)& item, mapBlockIndex)
     {
@@ -3144,7 +3144,7 @@ bool static LoadBlockIndexDB()
 
     PruneBlockIndexCandidates();
 
-    LogPrintf("%s: hashBestChain=%s height=%d date=%s progress=%f\n", __func__,
+    LogPrintf("%s: hashBestChain=%s  height=%d  date=%s  progress=%f\n", __func__,
         chainActive.Tip()->GetBlockHash().ToString(), chainActive.Height(),
         DateTimeStrFormat("%Y-%m-%d %H:%M:%S", chainActive.Tip()->GetBlockTime()),
         Checkpoints::GuessVerificationProgress(chainparams.Checkpoints(), chainActive.Tip()));
@@ -3969,7 +3969,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         if (fLogIPs)
             remoteAddr = ", peeraddr=" + pfrom->addr.ToString();
 
-        LogPrintf("receive version message: %s: version %d, blocks=%d, us=%s, peer=%d%s\n",
+        LogPrintf("Received version message: version=%s  versionNumber=%d  blocks=%d  us=%s  peer=%d%s\n",
                   pfrom->cleanSubVer, pfrom->nVersion,
                   pfrom->nStartingHeight, addrMe.ToString(), pfrom->id,
                   remoteAddr);

--- a/src/noui.cpp
+++ b/src/noui.cpp
@@ -41,7 +41,7 @@ static bool noui_ThreadSafeMessageBox(const std::string& message, const std::str
 
 static void noui_InitMessage(const std::string& message)
 {
-    LogPrintf("init message: %s\n", message);
+    LogPrintf("Init message: %s\n", message);
 }
 
 void noui_connect()

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -83,7 +83,7 @@ Q_DECLARE_METATYPE(CAmount)
 
 static void InitMessage(const std::string &message)
 {
-    LogPrintf("init message: %s\n", message);
+    LogPrintf("Init message: %s\n", message);
 }
 
 /*

--- a/src/timedata.cpp
+++ b/src/timedata.cpp
@@ -55,7 +55,7 @@ void AddTimeData(const CNetAddr& ip, int64_t nOffsetSample)
     // Add data
     static CMedianFilter<int64_t> vTimeOffsets(BITCOIN_TIMEDATA_MAX_SAMPLES, 0);
     vTimeOffsets.input(nOffsetSample);
-    LogPrintf("Added time data, samples %d, offset %+d (%+d minutes)\n", vTimeOffsets.size(), nOffsetSample, nOffsetSample/60);
+    LogPrintf("Added time data: samples=%d  offset=%+d seconds (%+d minutes)\n", vTimeOffsets.size(), nOffsetSample, nOffsetSample/60);
 
     // There is a known issue here (see issue #4521):
     //

--- a/src/util.h
+++ b/src/util.h
@@ -220,13 +220,13 @@ template <typename Callable> void TraceThread(const char* name,  Callable func)
     RenameThread(s.c_str());
     try
     {
-        LogPrintf("%s thread start\n", name);
+        LogPrintf("\"%s\" thread starting up\n", name);
         func();
-        LogPrintf("%s thread exit\n", name);
+        LogPrintf("\"%s\" thread exiting\n", name);
     }
     catch (const boost::thread_interrupted&)
     {
-        LogPrintf("%s thread interrupt\n", name);
+        LogPrintf("\"%s\" thread interrupted\n", name);
         throw;
     }
     catch (const std::exception& e) {


### PR DESCRIPTION
I made a few updates to improve the log outputs and work towards standardizing the outputs.

I tried to uncover the closest thing to a convention that I could. And here are the principles that I gleaned:
- start the line with the log label/type followed by a colon
- have the log label start with a capital letter and be expressed in the present progressive (-ing) or past tense (-ed), depending on whether the event/process is ongoing or an event has been completed
- after the colon, present a list of properties/attributes/details of the output, where each property is expressed with its name followed by the equals sign and then its value
- separate each property by two spaces
- express the property names using camelCase

In addition to these changes, I:
- made sure that "blk" was included in quotes to make it clear to the user that "blk" is a proper name given to a certain type of file and not an actual word.
- included quotes around the names of threads starting up so that it's clear that the threads are referred to by their proper names

A few things that still bother me about the outputs:
- there are a few cases where output lines include single properties that don't follow the output convention, for example: `mapBlockIndex.size() = 374551`
- `nTimeOffset` logs are presented in a strange way, where it's unclear that the first value is in seconds (it explicitly says the value after that is in minutes, but that value in my experience is usually zero)
- there are a few cases where the output lines start with a function name rather than describing what is happening, as is the case with most logs (for example `connect() to...`
- logs starting with `UpdateTip` could be more descriptive - more specifically, when a new block has been discovered, they should communicate that a new block has been discovered
- "init message" logs seem out of place from other logs

Also, while I stuck with the conventions that I could best glean from the outputs I observed, I would suggest making a few changes to the conventions. Namely, the following:
- start the line with the name of the thread
- enforce that every line after the name of the thread starts with an action in the present progressive or past tense (as most, maybe 80%, of the logs already seem to do)
- either use commas to separate log properties or prohibit property names that include spaces, strictly enforcing a certain case (either camelCase or snake_case)
- combine the init log properties like `mapBlockIndex.size()` and `nBestHeight` into a single line and enforce this for other outputs that have multiple properties OR if this is not desired, then have additional newlines separating the outputs to make it clear that those properties are grouped together
