### PR TITLE
use CBlockIndex* insted of uint256 for UpdatedBlockTip signal

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2303,7 +2303,7 @@ bool ActivateBestChain(CValidationState &state, const CBlock *pblock) {
                         pnode->PushInventory(CInv(MSG_BLOCK, hashNewTip));
             }
             // Notify external listeners about the new tip.
-            GetMainSignals().UpdatedBlockTip(hashNewTip);
+            GetMainSignals().UpdatedBlockTip(pindexNewTip);
             uiInterface.NotifyBlockTip(hashNewTip);
         }
     } while(pindexMostWork != chainActive.Tip());

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -11,6 +11,7 @@
 
 class CBlock;
 struct CBlockLocator;
+class CBlockIndex;
 class CReserveScript;
 class CTransaction;
 class CValidationInterface;
@@ -30,7 +31,7 @@ void SyncWithWallets(const CTransaction& tx, const CBlock* pblock = NULL);
 
 class CValidationInterface {
 protected:
-    virtual void UpdatedBlockTip(const uint256 &newHashTip) {}
+    virtual void UpdatedBlockTip(const CBlockIndex *pindex) {}
     virtual void SyncTransaction(const CTransaction &tx, const CBlock *pblock) {}
     virtual void SetBestChain(const CBlockLocator &locator) {}
     virtual void UpdatedTransaction(const uint256 &hash) {}
@@ -46,7 +47,7 @@ protected:
 
 struct CMainSignals {
     /** Notifies listeners of updated block chain tip */
-    boost::signals2::signal<void (const uint256 &)> UpdatedBlockTip;
+    boost::signals2::signal<void (const CBlockIndex *)> UpdatedBlockTip;
     /** Notifies listeners of updated transaction data (transaction, and optionally the block it is found in. */
     boost::signals2::signal<void (const CTransaction &, const CBlock *)> SyncTransaction;
     /** Notifies listeners of an updated transaction without new data (for now: a coinbase potentially becoming visible). */

--- a/src/zmq/zmqabstractnotifier.cpp
+++ b/src/zmq/zmqabstractnotifier.cpp
@@ -11,7 +11,7 @@ CZMQAbstractNotifier::~CZMQAbstractNotifier()
     assert(!psocket);
 }
 
-bool CZMQAbstractNotifier::NotifyBlock(const uint256 &/*hash*/)
+bool CZMQAbstractNotifier::NotifyBlock(const CBlockIndex * /*CBlockIndex*/)
 {
     return true;
 }

--- a/src/zmq/zmqabstractnotifier.h
+++ b/src/zmq/zmqabstractnotifier.h
@@ -7,7 +7,9 @@
 
 #include "zmqconfig.h"
 
+class CBlockIndex;
 class CZMQAbstractNotifier;
+
 typedef CZMQAbstractNotifier* (*CZMQNotifierFactory)();
 
 class CZMQAbstractNotifier
@@ -30,7 +32,7 @@ public:
     virtual bool Initialize(void *pcontext) = 0;
     virtual void Shutdown() = 0;
 
-    virtual bool NotifyBlock(const uint256 &hash);
+    virtual bool NotifyBlock(const CBlockIndex *pindex);
     virtual bool NotifyTransaction(const CTransaction &transaction);
 
 protected:

--- a/src/zmq/zmqnotificationinterface.cpp
+++ b/src/zmq/zmqnotificationinterface.cpp
@@ -120,12 +120,12 @@ void CZMQNotificationInterface::Shutdown()
     }
 }
 
-void CZMQNotificationInterface::UpdatedBlockTip(const uint256 &hash)
+void CZMQNotificationInterface::UpdatedBlockTip(const CBlockIndex *pindex)
 {
     for (std::list<CZMQAbstractNotifier*>::iterator i = notifiers.begin(); i!=notifiers.end(); )
     {
         CZMQAbstractNotifier *notifier = *i;
-        if (notifier->NotifyBlock(hash))
+        if (notifier->NotifyBlock(pindex))
         {
             i++;
         }

--- a/src/zmq/zmqnotificationinterface.h
+++ b/src/zmq/zmqnotificationinterface.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <map>
 
+class CBlockIndex;
 class CZMQAbstractNotifier;
 
 class CZMQNotificationInterface : public CValidationInterface
@@ -23,7 +24,7 @@ public:
 
 protected: // CValidationInterface
     void SyncTransaction(const CTransaction &tx, const CBlock *pblock);
-    void UpdatedBlockTip(const uint256 &newHashTip);
+    void UpdatedBlockTip(const CBlockIndex *pindex);
 
 private:
     CZMQNotificationInterface();

--- a/src/zmq/zmqpublishnotifier.cpp
+++ b/src/zmq/zmqpublishnotifier.cpp
@@ -116,8 +116,9 @@ void CZMQAbstractPublishNotifier::Shutdown()
     psocket = 0;
 }
 
-bool CZMQPublishHashBlockNotifier::NotifyBlock(const uint256 &hash)
+bool CZMQPublishHashBlockNotifier::NotifyBlock(const CBlockIndex *pindex)
 {
+    uint256 hash = pindex->GetBlockHash();
     LogPrint("zmq", "Publish hash block %s\n", hash.GetHex());
     char data[32];
     for (unsigned int i = 0; i < 32; i++)
@@ -137,18 +138,15 @@ bool CZMQPublishHashTransactionNotifier::NotifyTransaction(const CTransaction &t
     return rc == 0;
 }
 
-bool CZMQPublishRawBlockNotifier::NotifyBlock(const uint256 &hash)
+bool CZMQPublishRawBlockNotifier::NotifyBlock(const CBlockIndex *pindex)
 {
-    LogPrint("zmq", "Publish raw block %s\n", hash.GetHex());
+    LogPrint("zmq", "Publish raw block %s\n", pindex->GetBlockHash().GetHex());
 
     CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
     {
         LOCK(cs_main);
-
         CBlock block;
-        CBlockIndex* pblockindex = mapBlockIndex[hash];
-
-        if(!ReadBlockFromDisk(block, pblockindex))
+        if(!ReadBlockFromDisk(block, pindex))
         {
             zmqError("Can't read block from disk");
             return false;

--- a/src/zmq/zmqpublishnotifier.h
+++ b/src/zmq/zmqpublishnotifier.h
@@ -7,6 +7,8 @@
 
 #include "zmqabstractnotifier.h"
 
+class CBlockIndex;
+
 class CZMQAbstractPublishNotifier : public CZMQAbstractNotifier
 {
 public:
@@ -17,7 +19,7 @@ public:
 class CZMQPublishHashBlockNotifier : public CZMQAbstractPublishNotifier
 {
 public:
-    bool NotifyBlock(const uint256 &hash);
+    bool NotifyBlock(const CBlockIndex *pindex);
 };
 
 class CZMQPublishHashTransactionNotifier : public CZMQAbstractPublishNotifier
@@ -29,7 +31,7 @@ public:
 class CZMQPublishRawBlockNotifier : public CZMQAbstractPublishNotifier
 {
 public:
-    bool NotifyBlock(const uint256 &hash);
+    bool NotifyBlock(const CBlockIndex *pindex);
 };
 
 class CZMQPublishRawTransactionNotifier : public CZMQAbstractPublishNotifier


### PR DESCRIPTION
- removes `mapBlockIndex` find operation
- theoretically allows removing the `cs_main` lock during zqm notification while introducing a new file position lock
