### PR TITLE
depends: fix platform specific packages variable

### DIFF
--- a/depends/packages/packages.mk
+++ b/depends/packages/packages.mk
@@ -1,6 +1,6 @@
 packages:=boost openssl libevent
-packages_darwin:=zeromq
-packages_linux:=zeromq
+darwin_packages:=zeromq
+linux_packages:=zeromq
 native_packages := native_ccache native_comparisontool
 
 qt_native_packages = native_protobuf


### PR DESCRIPTION
Use a prefix instead of postfix.

This fixes gitian/depends builds to include zmq (linux/osx).

In the Makefile we use `$($(host_os)_packages)` for (https://github.com/bitcoin/bitcoin/blob/master/depends/Makefile#L81).
