### PR TITLE
fix rpc-tests.sh

### DIFF
--- a/qa/pull-tester/rpc-tests.sh
+++ b/qa/pull-tester/rpc-tests.sh
@@ -60,7 +60,7 @@ testScriptsExt=(
 );
 
 if [ "x$ENABLE_ZMQ" = "x1" ]; then
-  testScripts=( ${testScripts[@]} 'zmq_test.py' )
+  testScripts+=('zmq_test.py')
 fi
 
 extArg="-extended"


### PR DESCRIPTION
Travis is currently broken:

`${testScripts[@]}` now does split up `testscript --agument` (example) in two elements pushed to the array (`testscript` and `--agument`).

Travis tries to run a rpc test `--mineblock`.
Issue was introduced in 1136879df8af2358efb706c5af886778fbd94989.

<img width="1011" alt="bildschirmfoto 2015-09-17 um 15 43 38" src="https://cloud.githubusercontent.com/assets/178464/9934688/294df59c-5d53-11e5-8061-1210a83fb9a0.png">
