### PR TITLE
rpc-tests: temporarily disable zmq tests

### DIFF
--- a/qa/pull-tester/rpc-tests.sh
+++ b/qa/pull-tester/rpc-tests.sh
@@ -59,9 +59,9 @@ testScriptsExt=(
     'p2p-acceptblock.py'
 );
 
-if [ "x$ENABLE_ZMQ" = "x1" ]; then
-  testScripts+=('zmq_test.py')
-fi
+#if [ "x$ENABLE_ZMQ" = "x1" ]; then
+#  testScripts+=('zmq_test.py')
+#fi
 
 extArg="-extended"
 passOn=${@#$extArg}


### PR DESCRIPTION
Avoid blocking the testing of other work.

Still intend to turn on zmq testing by default once it's working.
