### PR TITLE
Set Windows TCP buffers to 64KB to match OSX and Unix

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -388,6 +388,10 @@ CNode* ConnectNode(CAddress addrConnect, const char *pszDest)
     if (pszDest ? ConnectSocketByName(addrConnect, hSocket, pszDest, Params().GetDefaultPort(), nConnectTimeout, &proxyConnectionFailed) :
                   ConnectSocket(addrConnect, hSocket, nConnectTimeout, &proxyConnectionFailed))
     {
+#ifdef WIN32
+        setsockopt(hSocket, SOL_SOCKET, SO_SNDBUF, (const char*)&MAX_WINDOWS_TCP_BUFFER_SIZE, sizeof(MAX_WINDOWS_TCP_BUFFER_SIZE));
+        setsockopt(hSocket, SOL_SOCKET, SO_RCVBUF, (const char*)&MAX_WINDOWS_TCP_BUFFER_SIZE, sizeof(MAX_WINDOWS_TCP_BUFFER_SIZE));
+#endif
         if (!IsSelectableSocket(hSocket)) {
             LogPrintf("Cannot create connection: non-selectable socket created (fd >= FD_SETSIZE ?)\n");
             CloseSocket(hSocket);
@@ -1792,6 +1796,8 @@ bool BindListenPort(const CService &addrBind, string& strError, bool fWhiteliste
     setsockopt(hListenSocket, SOL_SOCKET, SO_REUSEADDR, (void*)&nOne, sizeof(int));
 #else
     setsockopt(hListenSocket, SOL_SOCKET, SO_REUSEADDR, (const char*)&nOne, sizeof(int));
+    setsockopt(hListenSocket, SOL_SOCKET, SO_SNDBUF, (const char*)&MAX_WINDOWS_TCP_BUFFER_SIZE, sizeof(MAX_WINDOWS_TCP_BUFFER_SIZE));
+    setsockopt(hListenSocket, SOL_SOCKET, SO_RCVBUF, (const char*)&MAX_WINDOWS_TCP_BUFFER_SIZE, sizeof(MAX_WINDOWS_TCP_BUFFER_SIZE));
 #endif
 
     // Set to non-blocking, incoming connections will also inherit this

--- a/src/net.h
+++ b/src/net.h
@@ -60,6 +60,8 @@ static const bool DEFAULT_UPNP = false;
 static const size_t MAPASKFOR_MAX_SZ = MAX_INV_SZ;
 /** The maximum number of peer connections to maintain. */
 static const unsigned int DEFAULT_MAX_PEER_CONNECTIONS = 125;
+/** The maximum TCP send or receive buffer size */
+static const unsigned int MAX_WINDOWS_TCP_BUFFER_SIZE = 65535;   
 
 unsigned int ReceiveFloodSize();
 unsigned int SendBufferSize();


### PR DESCRIPTION
After making the changes I ran the wallet.py test (which is where the problem manifested the most often) 100 times without fail on Native Windows.  It was a simple problem of the Windows default buffer size being too small and causing buffer overflow's on occasion when syncing large amounts of data.
