### PR TITLE
[QT] fix thin space word wrap line brake issue

### DIFF
--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -312,9 +312,9 @@ void SendCoinsDialog::on_sendButton_clicked()
         if(u != model->getOptionsModel()->getDisplayUnit())
             alternativeUnits.append(BitcoinUnits::formatHtmlWithUnit(u, totalAmount));
     }
-    questionString.append(tr("Total Amount %1 (= %2)")
+    questionString.append(tr("Total Amount %1<span style='font-size:10pt;font-weight:normal;'><br />(=%2)</span>")
         .arg(BitcoinUnits::formatHtmlWithUnit(model->getOptionsModel()->getDisplayUnit(), totalAmount))
-        .arg(alternativeUnits.join(" " + tr("or") + " ")));
+        .arg(alternativeUnits.join(" " + tr("or") + "<br />")));
 
     QMessageBox::StandardButton retval = QMessageBox::question(this, tr("Confirm send coins"),
         questionString.arg(formatted.join("<br />")),


### PR DESCRIPTION
The thin space QT html hack results in cut-off chars/nums after a line break.
Avoid word wrap line breaks by using a smaller font and a line break before each alternative value).

<img width="543" alt="bildschirmfoto 2015-09-18 um 13 48 49" src="https://cloud.githubusercontent.com/assets/178464/9958662/946020da-5e0c-11e5-876b-648b23601888.png">
