### PR TITLE
[wallet] Adjust MIN_CHANGE

### DIFF
--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -48,7 +48,7 @@ static const CAmount DEFAULT_TRANSACTION_MINFEE = 1000;
 //! -maxtxfee default
 static const CAmount DEFAULT_TRANSACTION_MAXFEE = 0.1 * COIN;
 //! minimum change amount
-static const CAmount MIN_CHANGE = CENT;
+static const CAmount MIN_CHANGE = 0.001 * COIN;
 //! Default for -spendzeroconfchange
 static const bool DEFAULT_SPEND_ZEROCONF_CHANGE = true;
 //! Default for -sendfreetransactions


### PR DESCRIPTION
According to recent exchange rates avoiding change of some value between 1 and 10 USD is no longer reasonable: E.g. a bunch of people tipped me .35 USD. Whenever I want to send those tips, the transaction includes 7 of them just to send back to me.
- fixes #6522 
- fixes #1643
