### PR TITLE
[wallet] Default fPayAtLeastCustomFee to false

### DIFF
--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -67,6 +67,9 @@ def check_json_precision():
     if satoshis != 2000000000000003:
         raise RuntimeError("JSON encode/decode loses precision")
 
+def count_bytes(hex_string):
+    return len(bytearray.fromhex(hex_string))
+
 def sync_blocks(rpc_connections, wait=1):
     """
     Wait until everybody has the same block count

--- a/qa/rpc-tests/wallet.py
+++ b/qa/rpc-tests/wallet.py
@@ -24,6 +24,17 @@ from test_framework.util import *
 
 class WalletTest (BitcoinTestFramework):
 
+    def check_amount(self, curr_balance, prev_balance, fee_per_byte, tx_size):
+        """Return curr_balance after asserting the fee was in range"""
+        actual_fee = prev_balance - curr_balance
+        target_fee = fee_per_byte * tx_size
+        if actual_fee < target_fee:
+            raise AssertionError("Fee of %s BTC too low! (Should be %s BTC)"%(str(actual_fee), str(target_fee)))
+        # allow the node's estimation to be at most 2 bytes off
+        if actual_fee > fee_per_byte * (tx_size + 2):
+            raise AssertionError("Fee of %s BTC too high! (Should be %s BTC)"%(str(actual_fee), str(target_fee)))
+        return curr_balance
+
     def setup_chain(self):
         print("Initializing test directory "+self.options.tmpdir)
         initialize_chain_clean(self.options.tmpdir, 4)
@@ -104,33 +115,37 @@ class WalletTest (BitcoinTestFramework):
 
         # Send 10 BTC normal
         address = self.nodes[0].getnewaddress("test")
-        self.nodes[2].settxfee(Decimal('0.001'))
+        fee_per_byte = Decimal('0.001') / 1000
+        self.nodes[2].settxfee(fee_per_byte * 1000)
         txid = self.nodes[2].sendtoaddress(address, 10, "", "", False)
         self.nodes[2].generate(1)
         self.sync_all()
-        assert_equal(self.nodes[2].getbalance(), Decimal('89.99900000'))
-        assert_equal(self.nodes[0].getbalance(), Decimal('10.00000000'))
+        node_2_bal = self.check_amount(self.nodes[2].getbalance(), Decimal('90'), fee_per_byte, count_bytes(self.nodes[2].getrawtransaction(txid)))
+        assert_equal(self.nodes[0].getbalance(), Decimal('10'))
 
         # Send 10 BTC with subtract fee from amount
         txid = self.nodes[2].sendtoaddress(address, 10, "", "", True)
         self.nodes[2].generate(1)
         self.sync_all()
-        assert_equal(self.nodes[2].getbalance(), Decimal('79.99900000'))
-        assert_equal(self.nodes[0].getbalance(), Decimal('19.99900000'))
+        node_2_bal -= Decimal('10')
+        assert_equal(self.nodes[2].getbalance(), node_2_bal)
+        node_0_bal = self.check_amount(self.nodes[0].getbalance(), Decimal('20'), fee_per_byte, count_bytes(self.nodes[2].getrawtransaction(txid)))
 
         # Sendmany 10 BTC
         txid = self.nodes[2].sendmany('from1', {address: 10}, 0, "", [])
         self.nodes[2].generate(1)
         self.sync_all()
-        assert_equal(self.nodes[2].getbalance(), Decimal('69.99800000'))
-        assert_equal(self.nodes[0].getbalance(), Decimal('29.99900000'))
+        node_0_bal += Decimal('10')
+        node_2_bal = self.check_amount(self.nodes[2].getbalance(), node_2_bal - Decimal('10'), fee_per_byte, count_bytes(self.nodes[2].getrawtransaction(txid)))
+        assert_equal(self.nodes[0].getbalance(), node_0_bal)
 
         # Sendmany 10 BTC with subtract fee from amount
         txid = self.nodes[2].sendmany('from1', {address: 10}, 0, "", [address])
         self.nodes[2].generate(1)
         self.sync_all()
-        assert_equal(self.nodes[2].getbalance(), Decimal('59.99800000'))
-        assert_equal(self.nodes[0].getbalance(), Decimal('39.99800000'))
+        node_2_bal -= Decimal('10')
+        assert_equal(self.nodes[2].getbalance(), node_2_bal)
+        node_0_bal = self.check_amount(self.nodes[0].getbalance(), node_0_bal + Decimal('10'), fee_per_byte, count_bytes(self.nodes[2].getrawtransaction(txid)))
 
         # Test ResendWalletTransactions:
         # Create a couple of transactions, then start up a fourth
@@ -175,7 +190,7 @@ class WalletTest (BitcoinTestFramework):
         for uTx in unspentTxs:
             if uTx['txid'] == zeroValueTxid:
                 found = True
-                assert_equal(uTx['amount'], Decimal('0.00000000'));
+                assert_equal(uTx['amount'], Decimal('0'));
         assert(found)
 
         #do some -walletbroadcast tests
@@ -191,14 +206,14 @@ class WalletTest (BitcoinTestFramework):
         txObjNotBroadcasted = self.nodes[0].gettransaction(txIdNotBroadcasted)
         self.nodes[1].generate(1) #mine a block, tx should not be in there
         self.sync_all()
-        assert_equal(self.nodes[2].getbalance(), Decimal('59.99800000')); #should not be changed because tx was not broadcasted
+        assert_equal(self.nodes[2].getbalance(), node_2_bal); #should not be changed because tx was not broadcasted
 
         #now broadcast from another node, mine a block, sync, and check the balance
         self.nodes[1].sendrawtransaction(txObjNotBroadcasted['hex'])
         self.nodes[1].generate(1)
         self.sync_all()
         txObjNotBroadcasted = self.nodes[0].gettransaction(txIdNotBroadcasted)
-        assert_equal(self.nodes[2].getbalance(), Decimal('61.99800000')); #should not be
+        assert_equal(self.nodes[2].getbalance(), node_2_bal + Decimal('2')); #should not be
 
         #create another tx
         txIdNotBroadcasted  = self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 2);
@@ -216,21 +231,21 @@ class WalletTest (BitcoinTestFramework):
         sync_blocks(self.nodes)
 
         #tx should be added to balance because after restarting the nodes tx should be broadcastet
-        assert_equal(self.nodes[2].getbalance(), Decimal('63.99800000')); #should not be
+        assert_equal(self.nodes[2].getbalance(), node_2_bal + Decimal('4')); #should not be
 
         #send a tx with value in a string (PR#6380 +)
         txId  = self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), "2")
         txObj = self.nodes[0].gettransaction(txId)
-        assert_equal(txObj['amount'], Decimal('-2.00000000'))
+        assert_equal(txObj['amount'], Decimal('-2'))
 
         txId  = self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), "0.0001")
         txObj = self.nodes[0].gettransaction(txId)
-        assert_equal(txObj['amount'], Decimal('-0.00010000'))
+        assert_equal(txObj['amount'], Decimal('-0.0001'))
 
         #check if JSON parser can handle scientific notation in strings
         txId  = self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), "1e-4")
         txObj = self.nodes[0].gettransaction(txId)
-        assert_equal(txObj['amount'], Decimal('-0.00010000'))
+        assert_equal(txObj['amount'], Decimal('-0.0001'))
 
         #this should fail
         errorString = ""

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -391,6 +391,8 @@ std::string HelpMessage(HelpMessageMode mode)
             CURRENCY_UNIT, FormatMoney(DEFAULT_TRANSACTION_MINFEE)));
     strUsage += HelpMessageOpt("-paytxfee=<amt>", strprintf(_("Fee (in %s/kB) to add to transactions you send (default: %s)"),
         CURRENCY_UNIT, FormatMoney(payTxFee.GetFeePerK())));
+    strUsage += HelpMessageOpt("-payatleastcustomfee", strprintf(_("Pay the fee set by paytxfee or settxfee considering at least 1000 bytes or the actual transaction size, whichever is higher (default: %u)"),
+        fPayAtLeastCustomFee));
     strUsage += HelpMessageOpt("-rescan", _("Rescan the block chain for missing wallet transactions on startup"));
     strUsage += HelpMessageOpt("-salvagewallet", _("Attempt to recover private keys from a corrupt wallet.dat on startup"));
     strUsage += HelpMessageOpt("-sendfreetransactions", strprintf(_("Send transactions as zero-fee transactions if possible (default: %u)"), 0));
@@ -973,6 +975,8 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     nTxConfirmTarget = GetArg("-txconfirmtarget", DEFAULT_TX_CONFIRM_TARGET);
     bSpendZeroConfChange = GetBoolArg("-spendzeroconfchange", true);
     fSendFreeTransactions = GetBoolArg("-sendfreetransactions", false);
+
+    fPayAtLeastCustomFee = GetBoolArg("-payatleastcustomfee", fPayAtLeastCustomFee);
 
     std::string strWalletFile = GetArg("-wallet", "wallet.dat");
 #endif // ENABLE_WALLET

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2175,7 +2175,7 @@ UniValue settxfee(const UniValue& params, bool fHelp)
     if (fHelp || params.size() < 1 || params.size() > 1)
         throw runtime_error(
             "settxfee amount\n"
-            "\nSet the transaction fee per kB.\n"
+            "\nSet the transaction fee per kB. (Overwrites the paytxfee parameter)\n"
             "\nArguments:\n"
             "1. amount         (numeric, required) The transaction fee in " + CURRENCY_UNIT + "/kB rounded to the nearest 0.00000001\n"
             "\nResult\n"

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -41,7 +41,7 @@ CAmount maxTxFee = DEFAULT_TRANSACTION_MAXFEE;
 unsigned int nTxConfirmTarget = DEFAULT_TX_CONFIRM_TARGET;
 bool bSpendZeroConfChange = true;
 bool fSendFreeTransactions = false;
-bool fPayAtLeastCustomFee = true;
+bool fPayAtLeastCustomFee = false;
 
 /**
  * Fees smaller than this (in satoshi) are considered zero fee (for transaction creation)


### PR DESCRIPTION
All fees in bitcoin core are specified in BTC/kB but `-paytxfee` silently ([[init.cpp]](https://github.com/bitcoin/bitcoin/blob/7f8e90da335e851b8ec11e994a7da729ac73ef68/src/init.cpp#L392)) ignores this rule due to `fPayAtLeastCustomFee = true`.

This PR will:
- Default `fPayAtLeastCustomFee` to false
- Improve the rpc wallet tests: Always assert the fee per kB via `check_amount()`
  (Previously only _fee == fee per 1000 bytes_ was asserted)
- Introduce `-payatleastcustomfee`
- Fixes #6479

---

For completeness: Copy of #6649 description:

This allows for much finer control of the transaction fees per kilobyte
as it prevent small transactions using a fee that is more appropriate
for one that is of a kilobyte.

This also allows controlling the fee per kilobyte over rpc such that:

```
bitcoin-cli settxfee `bitcoin-cli estimatefee 2`
```

would make sense, while currently it grossly fails often by a factor of x3

This fixes issue #6479, and has minimal impact as dynamic fees are currently the default. This default can be overriden in the qt wallet, although I have trouble imagining where that is useful. Possibly the entire concept of fPayAtLeastCustomFee can be removed in a later version.
