### PR TITLE
Fix spelling of Qt

### DIFF
--- a/contrib/debian/examples/bitcoin.conf
+++ b/contrib/debian/examples/bitcoin.conf
@@ -60,7 +60,7 @@
 # JSON-RPC options (for controlling a running Bitcoin/bitcoind process)
 #
 
-# server=1 tells Bitcoin-QT and bitcoind to accept JSON-RPC commands
+# server=1 tells Bitcoin-Qt and bitcoind to accept JSON-RPC commands
 #server=0
 
 # Bind to given address to listen for JSON-RPC connections. Use [host]:port notation for IPv6.
@@ -82,7 +82,7 @@
 # NOTE: opening up the RPC port to hosts outside your local trusted network is NOT RECOMMENDED,
 # because the rpcpassword is transmitted over the network unencrypted.
 
-# server=1 tells Bitcoin-QT to accept JSON-RPC commands.
+# server=1 tells Bitcoin-Qt to accept JSON-RPC commands.
 # it is also read by bitcoind to determine if RPC should be enabled 
 #rpcallowip=10.1.1.34/255.255.255.0
 #rpcallowip=1.2.3.4/24

--- a/doc/release-notes/release-notes-0.10.1.md
+++ b/doc/release-notes/release-notes-0.10.1.md
@@ -101,7 +101,7 @@ Tests:
 Miscellaneous:
 - `c9e022b` Initialization: set Boost path locale in main thread
 - `23126a0` Sanitize command strings before logging them.
-- `323de27` Initialization: setup environment before starting QT tests
+- `323de27` Initialization: setup environment before starting Qt tests
 - `7494e09` Initialization: setup environment before starting tests
 - `df45564` Initialization: set fallback locale as environment variable
 

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -404,7 +404,7 @@ void SubstituteFonts(const QString& language)
 {
 #if defined(Q_OS_MAC)
 // Background:
-// OSX's default font changed in 10.9 and QT is unable to find it with its
+// OSX's default font changed in 10.9 and Qt is unable to find it with its
 // usual fallback methods when building against the 10.7 sdk or lower.
 // The 10.8 SDK added a function to let it find the correct fallback font.
 // If this fallback is not properly loaded, some characters may fail to


### PR DESCRIPTION
QT is considered a typo, Qt is the proper term.
