### PR TITLE
Make HTTP server shutdown more graceful

### DIFF
--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -457,6 +457,13 @@ void InterruptHTTPServer()
         // Reject requests on current connections
         evhttp_set_gencb(eventHTTP, http_reject_request_cb, NULL);
     }
+    if (eventBase) {
+        // Force-exit event loop after predefined time
+        struct timeval tv;
+        tv.tv_sec = 10;
+        tv.tv_usec = 0;
+        event_base_loopexit(eventBase, &tv);
+    }
     if (workQueue)
         workQueue->Interrupt();
 }

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -243,7 +243,8 @@ UniValue stop(const UniValue& params, bool fHelp)
         throw runtime_error(
             "stop\n"
             "\nStop Bitcoin server.");
-    // Shutdown will take long enough that the response should get back
+    // Event loop will exit after current HTTP requests have been handled, so
+    // this reply will get back to the client.
     StartShutdown();
     return "Bitcoin server stopping";
 }


### PR DESCRIPTION
Shutting down the HTTP server currently breaks off all current requests. This can create a race condition with RPC `stop` command, where the calling process never receives confirmation.

This change removes the listening sockets on shutdown so that no new requests can come in, but no longer breaks off requests in progress.

Meant to fix #6717.
