### PR TITLE
Add java-libbitcoinconsensus as example to documentation

### DIFF
--- a/doc/shared-libraries.md
+++ b/doc/shared-libraries.md
@@ -40,3 +40,4 @@ The interface is defined in the C header `bitcoinconsensus.h` located in  `src/s
 ### Example Implementations
 - [NBitcoin](https://github.com/NicolasDorier/NBitcoin/blob/master/NBitcoin/Script.cs#L814) (.NET Bindings)
 - [node-libbitcoinconsensus](https://github.com/bitpay/node-libbitcoinconsensus) (Node.js Bindings)
+- [java-libbitcoinconsensus](https://github.com/dexX7/java-libbitcoinconsensus) (Java Bindings)


### PR DESCRIPTION
[java-libbitcoinconsensus](https://github.com/dexX7/java-libbitcoinconsensus) is a wrapper around libbitcoinconsensus, which uses [JNA](https://github.com/java-native-access/jna) to demonstrate a potential integration in Java.

This resolves dexX7/java-libbitcoinconsensus#9.
