### PR TITLE
AcceptToMemoryPool: Use -maxtxfee when rejecting high fee txs

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,6 +33,7 @@
 #include "utilmoneystr.h"
 #include "utilstrencodings.h"
 #include "validationinterface.h"
+#include "wallet/wallet.h"
 
 #include <sstream>
 
@@ -916,10 +917,10 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
             dFreeCount += nSize;
         }
 
-        if (fRejectAbsurdFee && nFees > ::minRelayTxFee.GetFee(nSize) * 10000)
+        if (fRejectAbsurdFee && nFees > ::maxTxFee)
             return state.Invalid(false,
-                REJECT_HIGHFEE, "absurdly-high-fee",
-                strprintf("%d > %d", nFees, ::minRelayTxFee.GetFee(nSize) * 10000));
+                REJECT_HIGHFEE, "exceeds -maxtxfee",
+                strprintf("%d > %d", nFees, ::maxTxFee));
 
         // Calculate in-mempool ancestors, up to a limit.
         CTxMemPool::setEntries setAncestors;


### PR DESCRIPTION
It is unreasonable to ignore `-maxtxfee` when rejecting high fee transactions. This PR removes the hard coded limit and uses `-maxtxfee` instead.

---

EDIT: This fixes #6725 by coupling `maxtxfee` from the wallet with the mempool's `REJECT_HIGHFEE`.
