### PR TITLE
timedata: Prevent warning overkill

### DIFF
--- a/src/timedata.cpp
+++ b/src/timedata.cpp
@@ -99,9 +99,8 @@ void AddTimeData(const CNetAddr& ip, int64_t nOffsetSample)
                 if (!fMatch)
                 {
                     fDone = true;
-                    string strMessage = _("Warning: Please check that your computer's date and time are correct! If your clock is wrong Bitcoin Core will not work properly.");
+                    string strMessage = _("Please check that your computer's date and time are correct! If your clock is wrong Bitcoin Core will not work properly.");
                     strMiscWarning = strMessage;
-                    LogPrintf("*** %s\n", strMessage);
                     uiInterface.ThreadSafeMessageBox(strMessage, "", CClientUIInterface::MSG_WARNING);
                 }
             }


### PR DESCRIPTION
The "please check your computer's data and time" message when the clock deviates from the network currently generates an overkill of messages :-)

```
orion@lethe:~/bitcoin$ src/bitcoind
Warning: Warning: Please check that your computer's date and time are correct! If your clock is wrong Bitcoin Core will not work properly.
```

In the log:

```
2015-09-27 16:24:13 *** Warning: Please check that your computer's date and time are correct! If your clock is wrong Bitcoin Core will not work properly.
2015-09-27 16:24:13 Warning: Warning: Please check that your computer's date and time are correct! If your clock is wrong Bitcoin Core will not work properly.
```

Remove one level of 'Warning:' and reduce to one log message.

Edit: An open question is whether this message should be translated at all, currently it is.
