### PR TITLE
build: remove libressl check (proposal)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -700,27 +700,12 @@ else
   fi
 fi
 
-CFLAGS_TEMP="$CFLAGS"
+CXXFLAGS_TEMP="$CXXFLAGS"
 LIBS_TEMP="$LIBS"
-CFLAGS="$CFLAGS $SSL_CFLAGS $CRYPTO_CFLAGS"
+CXXFLAGS="$CXXFLAGS $SSL_CFLAGS $CRYPTO_CFLAGS"
 LIBS="$LIBS $SSL_LIBS $CRYPTO_LIBS"
 AC_CHECK_HEADER([openssl/ec.h],, AC_MSG_ERROR(OpenSSL ec header missing),)
-
-AC_MSG_CHECKING(for a supported OpenSSL version)
-AC_LINK_IFELSE([AC_LANG_PROGRAM([[
-  #include <openssl/rand.h>
-  ]],
-  [[RAND_egd(NULL);]])],
-  [AC_MSG_RESULT(yes)],
-  [
-    AC_ARG_WITH([libressl],
-    [AS_HELP_STRING([--with-libressl],[Build with system LibreSSL (default is no; DANGEROUS; NOT SUPPORTED)])],
-    [AC_MSG_WARN([Detected LibreSSL: This is NOT supported, and may break consensus compatibility!])],
-    [AC_MSG_ERROR([Detected LibreSSL: This is NOT supported, and may break consensus compatibility!])]
-    )]
-)
-
-CFLAGS="$CFLAGS_TEMP"
+CXXFLAGS="$CXXFLAGS_TEMP"
 LIBS="$LIBS_TEMP"
 
 BITCOIN_QT_PATH_PROGS([PROTOC], [protoc],$protoc_bin_path)

--- a/doc/build-openbsd.md
+++ b/doc/build-openbsd.md
@@ -70,24 +70,6 @@ config_opts="runtime-link=shared threadapi=pthread threading=multi link=static v
 ./b2 -d0 -j4 ${config_opts} --prefix=${BOOST_PREFIX} install
 ```
 
-### OpenSSL
-
-OpenBSD uses a replacement of OpenSSL: LibreSSL. This can cause compatibility issues, hence `./configure` will bark if you try to compile with this library:
-
-    Detected LibreSSL: This is NOT supported, and may break consensus compatibility!
-
-To install a 'real' OpenSSL use:
-
-    pkg_add openssl
-   
-Any program linked against this library can only be used after setting the dynamic library path:
-    
-    export LD_LIBRARY_PATH="/usr/local/lib/eopenssl"
-
-(otherwise there will be an error about not being able to find `libcrypto.so.1.0`)
-
-Alternatively, pass `--with-libressl` to `./configure`, however as the warning says, this is NOT supported, and may cause problems syncing the chain, or the node to fork off the network in unexpected circumstances.
-
 ### Building BerkeleyDB
 
 BerkeleyDB is only necessary for the wallet functionality. To skip this, pass `--disable-wallet` to `./configure`.
@@ -124,28 +106,24 @@ export AUTOCONF_VERSION=2.69 # replace this with the autoconf version that you i
 export AUTOMAKE_VERSION=1.15 # replace this with the automake version that you installed
 ./autogen.sh
 ```
+Make sure `BDB_PREFIX` and `BOOST_PREFIX` are set to the appropriate paths from the above steps.
 
 To configure with wallet:
 ```bash
 ./configure --with-gui=no --with-boost=$BOOST_PREFIX \
     CC=egcc CXX=eg++ CPP=ecpp \
-    SSL_CFLAGS="-I/usr/local/include/eopenssl" SSL_LIBS="-L/usr/local/lib/eopenssl -lssl" \
-    CRYPTO_CFLAGS="-I/usr/local/include/eopenssl" CRYPTO_LIBS="-L/usr/local/lib/eopenssl -lcrypto" \
     LDFLAGS="-L${BDB_PREFIX}/lib/" CPPFLAGS="-I${BDB_PREFIX}/include/"
 ```
 
 To configure without wallet:
 ```bash
 ./configure --disable-wallet --with-gui=no --with-boost=$BOOST_PREFIX \
-    CC=egcc CXX=eg++ CPP=ecpp \
-    SSL_CFLAGS="-I/usr/local/include/eopenssl" SSL_LIBS="-L/usr/local/lib/eopenssl -lssl" \
-    CRYPTO_CFLAGS="-I/usr/local/include/eopenssl" CRYPTO_LIBS="-L/usr/local/lib/eopenssl -lcrypto"
+    CC=egcc CXX=eg++ CPP=ecpp
 ```
 
 Build and run the tests:
 ```bash
 gmake
-export LD_LIBRARY_PATH="/usr/local/lib/eopenssl"
 gmake check
 ```
 
@@ -164,9 +142,7 @@ pkg_add llvm boost
 ```
 
 ```bash
-./configure --disable-wallet --with-gui=no CC=clang CXX=clang++ \
-    SSL_CFLAGS="-I/usr/local/include/eopenssl" SSL_LIBS="-L/usr/local/lib/eopenssl -lssl" \
-    CRYPTO_CFLAGS="-I/usr/local/include/eopenssl" CRYPTO_LIBS="-L/usr/local/lib/eopenssl -lcrypto"
+./configure --disable-wallet --with-gui=no CC=clang CXX=clang++
 gmake
 ```
 


### PR DESCRIPTION
Now that BIP66 passed, OpenSSL is no longer directly part of the consensus. What matters is that DER signatures are correctly parsed, and secp256k1 crypto is implemented correctly (as well as the other functions we use from OpenSSL, such as random number generation)

This means that effectively, using LibreSSL is not a larger risk than using another version of OpenSSL.

Remove the specific check for LibreSSL. This makes it much easier to build on platforms that use LibreSSL by default.

Includes the still-relevant part of #6729: make sure CHECK_HEADER(ec.h) is called using the right CXXFLAGS, not CFLAGS (as AC_LANG is c++).
