### PR TITLE
Trivial: start the help texts with lowercase

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -139,7 +139,7 @@ AC_ARG_ENABLE([glibc-back-compat],
 
 AC_ARG_ENABLE([zmq],
   [AS_HELP_STRING([--disable-zmq],
-  [Disable ZMQ notifications])],
+  [disable ZMQ notifications])],
   [use_zmq=$enableval],
   [use_zmq=yes])
 


### PR DESCRIPTION
All `configure --help` texts should start with a lowercase letter.
