### PR TITLE
build: disable -Wself-assign

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -167,7 +167,7 @@ fi
 ##       compatibility with the legacy buildsystem.
 ##
 if test "x$CXXFLAGS_overridden" = "xno"; then
-  CXXFLAGS="$CXXFLAGS -Wall -Wextra -Wformat -Wformat-security -Wno-unused-parameter"
+  CXXFLAGS="$CXXFLAGS -Wall -Wextra -Wformat -Wformat-security -Wno-unused-parameter -Wno-self-assign"
 fi
 CPPFLAGS="$CPPFLAGS -DHAVE_BUILD_INFO -D__STDC_FORMAT_MACROS"
 


### PR DESCRIPTION
Prevent these warnings in clang 3.6:

```
./serialize.h:96:9: warning: explicitly assigning value of variable of type 'uint64_t' (aka 'unsigned long') to itself [-Wself-assign]
    obj = (obj);
    ~~~ ^  ~~~
```

This happens because `obj = htole64(obj);`, and `htoleXX` are no-op on little-endian thus get optimized away.
More localized solutions are welcome, but I think pragmas are ugly too.
