### PR TITLE
Net: Remove "Address refresh broadcast" logic.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4882,24 +4882,6 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
         if (!lockMain)
             return true;
 
-        // Address refresh broadcast
-        static int64_t nLastRebroadcast;
-        if (!IsInitialBlockDownload() && (GetTime() - nLastRebroadcast > 24 * 60 * 60))
-        {
-            LOCK(cs_vNodes);
-            BOOST_FOREACH(CNode* pnode, vNodes)
-            {
-                // Periodically clear addrKnown to allow refresh broadcasts
-                if (nLastRebroadcast)
-                    pnode->addrKnown.reset();
-
-                // Rebroadcast our address
-                AdvertizeLocal(pnode);
-            }
-            if (!vNodes.empty())
-                nLastRebroadcast = GetTime();
-        }
-
         //
         // Message: addr
         //


### PR DESCRIPTION
addrKnown is now a CRollingBloomFilter which forgets about entries every 5000 inserts
