### PR TITLE
Rewrite help texts for features enabled by default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -69,8 +69,8 @@ PKG_PROG_PKG_CONFIG
 
 # Enable wallet
 AC_ARG_ENABLE([wallet],
-  [AS_HELP_STRING([--enable-wallet],
-  [enable wallet (default is yes)])],
+  [AS_HELP_STRING([--disable-wallet],
+  [disable wallet (enabled by default)])],
   [enable_wallet=$enableval],
   [enable_wallet=yes])
 
@@ -87,7 +87,7 @@ AC_ARG_ENABLE([upnp-default],
   [use_upnp_default=no])
 
 AC_ARG_ENABLE(tests,
-    AS_HELP_STRING([--enable-tests],[compile tests (default is yes)]),
+    AS_HELP_STRING([--disable-tests],[do not compile tests (default is to compile)]),
     [use_tests=$enableval],
     [use_tests=yes])
 
@@ -108,8 +108,8 @@ AC_ARG_WITH([qrencode],
   [use_qr=auto])
 
 AC_ARG_ENABLE([hardening],
-  [AS_HELP_STRING([--enable-hardening],
-  [attempt to harden the resulting executables (default is yes)])],
+  [AS_HELP_STRING([--disable-hardening],
+  [do not attempt to harden the resulting executables (default is to harden)])],
   [use_hardening=$enableval],
   [use_hardening=yes])
 
@@ -120,8 +120,8 @@ AC_ARG_ENABLE([reduce-exports],
   [use_reduce_exports=no])
 
 AC_ARG_ENABLE([ccache],
-  [AS_HELP_STRING([--enable-ccache],
-  [use ccache for building (default is yes if ccache is found)])],
+  [AS_HELP_STRING([--disable-ccache],
+  [do not use ccache for building (default is to use if found)])],
   [use_ccache=$enableval],
   [use_ccache=auto])
 


### PR DESCRIPTION
As some features are enabled by default, `configure --help` should help the builder to disabled them. This PR changes `configure --help` output this way:

```
-  --enable-wallet         enable wallet (default is yes)
+  --disable-wallet        disable wallet (enabled by default)

-  --enable-tests          compile tests (default is yes)
+  --disable-tests         do not compile tests (default is to compile)

-  --enable-hardening      attempt to harden the resulting executables (default
-                          is yes)
+  --disable-hardening     do not attempt to harden the resulting executables
+                          (default is to harden)

-  --enable-ccache         use ccache for building (default is yes if ccache is
+  --disable-ccache        do not use ccache for building (default is to use if
                           found)
```

The other three occurrences (`--enable-static`, `--enable-shared` and `--enable-fast-install`) are unfortunately upstream...
