### PR TITLE
build: Remove unncecessary chmods after #6616

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -900,7 +900,6 @@ AC_SUBST(MINIUPNPC_LIBS)
 AC_CONFIG_FILES([Makefile src/Makefile share/setup.nsi share/qt/Info.plist src/test/buildenv.py])
 AC_CONFIG_FILES([qa/pull-tester/run-bitcoind-for-test.sh],[chmod +x qa/pull-tester/run-bitcoind-for-test.sh])
 AC_CONFIG_FILES([qa/pull-tester/tests_config.py],[chmod +x qa/pull-tester/tests_config.py])
-chmod +x qa/pull-tester/rpc-tests.py
 
 dnl boost's m4 checks do something really nasty: they export these vars. As a
 dnl result, they leak into secp256k1's configure and crazy things happen.
@@ -946,6 +945,5 @@ case ${OS} in
    *Windows*)
      sed  's/BUILDDIR="\/\([[a-z]]\)/BUILDDIR="\1:/'  qa/pull-tester/tests_config.py > qa/pull-tester/tests_config-2.py
      mv qa/pull-tester/tests_config-2.py qa/pull-tester/tests_config.py
-     chmod +x qa/pull-tester/tests_config.py
    ;;
 esac


### PR DESCRIPTION
Don't chmod a repository-included file in the configure script, and `tests_config.py` is a module that doesn't need to be executable.
