### PR TITLE
[Trivial] Remove UTF-8 BOM [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-﻿Bitcoin Core integration/staging tree
+Bitcoin Core integration/staging tree
 =====================================
 
 [![Build Status](https://travis-ci.org/bitcoin/bitcoin.svg?branch=master)](https://travis-ci.org/bitcoin/bitcoin)


### PR DESCRIPTION
Remove mistakenly added UTF-8 Byte Order Mark.

Small note: GitHub web interface is not very good in displaying this change as a diff...
