### PR TITLE
[Trivial] tests-config.sh is superseded by tests_config.py [skip ci]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,7 +104,7 @@ linux-coverage-build
 linux-build
 win32-build
 qa/pull-tester/run-bitcoind-for-test.sh
-qa/pull-tester/tests-config.sh
+qa/pull-tester/tests_config.py
 qa/pull-tester/cache/*
 qa/pull-tester/test.*/*
 


### PR DESCRIPTION
As `qa/pull-tester/tests-config.sh.in` was moved to `qa/pull-tester/tests_config.py.in` in #6616, adapt its `.gitignore` entry to match new name.
