### PR TITLE
[Trivial] The Bitcoin Core project is releasing Bitcoin Core, not Bitcoin.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-﻿Bitcoin Core integration/staging tree
+Bitcoin Core integration/staging tree
 =====================================
 
 [![Build Status](https://travis-ci.org/bitcoin/bitcoin.svg?branch=master)](https://travis-ci.org/bitcoin/bitcoin)
@@ -28,7 +28,7 @@ Development Process
 
 The `master` branch is regularly built and tested, but is not guaranteed to be
 completely stable. [Tags](https://github.com/bitcoin/bitcoin/tags) are created
-regularly to indicate new official, stable release versions of Bitcoin.
+regularly to indicate new official, stable release versions of Bitcoin Core.
 
 The contribution workflow is described in [CONTRIBUTING.md](CONTRIBUTING.md).
 


### PR DESCRIPTION
We do not release Bitcoin, but Bitcoin Core. We should not make our users feel that Bitcoin Core is Bitcoin!
