### PR TITLE
zmq: update docs to reflect feature is compiled in automatically

### DIFF
--- a/doc/zmq.md
+++ b/doc/zmq.md
@@ -43,14 +43,14 @@ operation.
 
 ## Enabling
 
-By default, the ZeroMQ port functionality is enabled. Two steps are
-required to enable--compiling in the ZeroMQ code, and configuring
-runtime operation on the command-line or configuration file.
+By default, the ZeroMQ feature is automatically compiled in if the
+necessary prerequisites are found.  To disable, use --disable-zmq
+during the *configure* step of building bitcoind:
 
-    $ ./configure --enable-zmq (other options)
+    $ ./configure --disable-zmq (other options)
 
-This will produce a binary that is capable of providing the ZeroMQ
-facility, but will not do so until also configured properly.
+To actually enable operation, one must set the appropriate options on
+the commandline or in the configuration file.
 
 ## Usage
 


### PR DESCRIPTION
This updates the zmq.md doc to reflect that the zmq feature is compiled in automatically if the prerequisites are found, and can be disabled with --disable-zmq.
