### PR TITLE
Test LowS in standardness, removes nuisance malleability vector.

### DIFF
--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -37,7 +37,8 @@ static const unsigned int STANDARD_SCRIPT_VERIFY_FLAGS = MANDATORY_SCRIPT_VERIFY
                                                          SCRIPT_VERIFY_NULLDUMMY |
                                                          SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_NOPS |
                                                          SCRIPT_VERIFY_CLEANSTACK |
-                                                         SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY;
+                                                         SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY |
+                                                         SCRIPT_VERIFY_LOW_S;
 
 /** For convenience, standard but not mandatory verify flags. */
 static const unsigned int STANDARD_NOT_MANDATORY_VERIFY_FLAGS = STANDARD_SCRIPT_VERIFY_FLAGS & ~MANDATORY_SCRIPT_VERIFY_FLAGS;


### PR DESCRIPTION
This adds SCRIPT_VERIFY_LOW_S to STANDARD_SCRIPT_VERIFY_FLAGS which
 will make the node require the canonical 'low-s' encoding for
 ECDSA signatures when relaying or mining.

Consensus behavior is unchanged.

The rational is explained in a81cd96805ce6b65cca3a40ebbd3b2eb428abb7b:
 Absent this kind of test ECDSA is not a strong signature as given
 a valid signature {r, s} both that value and {r, -s mod n} are valid.
 These two encodings have different hashes allowing third parties a
 vector to change users txids.  These attacks are avoided by picking
 a particular form as canonical and rejecting the other form(s); in
 the of the LOW_S rule, the smaller of the two possible S values is
 used.

If widely deployed this change would eliminate the last remaining
 known vector for nuisance malleability on boring SIGHASH_ALL
 p2pkh transactions.  On the down-side it will block most
 transactions made by sufficiently out of date software.

Unlike the other avenues to change txids on boring transactions this
 one was randomly violated by all deployed bitcoin software prior to
 its discovery.  So, while other malleability vectors where made
 non-standard as soon as they were discovered, this one has remained
 permitted.  Even BIP62 did not propose applying this rule to
 old version transactions, but conforming implementations have become
 much more common since BIP62 was initially written.

Bitcoin Core has produced compatible signatures since a28fb70e in
 September 2013, but this didn't make it into a release until 0.9
 in March 2014; Bitcoinj has done so for a similar span of time.
 Bitcoinjs and electrum have been more recently updated.

This does not replace the need for BIP62 or similar, as miners can
 still cooperate to break transactions.  Nor does it replace the
 need for wallet software to handle malleability sanely[1]. This
 only eliminates the cheap and irritating DOS attack.

[1] On the Malleability of Bitcoin Transactions
Marcin Andrychowicz, Stefan Dziembowski, Daniel Malinowski, Łukasz Mazurek
http://fc15.ifca.ai/preproceedings/bitcoin/paper_9.pdf
