### PR TITLE
[Trivial] Ignore bench_bitcoin binary [skip ci]

### DIFF
--- a/src/bench/.gitignore
+++ b/src/bench/.gitignore
@@ -1,0 +1,1 @@
+bench_bitcoin


### PR DESCRIPTION
Git should ignore generated binary `bench_bitcoin` in `git status`.
