### PR TITLE
Policy: Lower default limits for tx chains

### DIFF
--- a/qa/rpc-tests/mempool_packages.py
+++ b/qa/rpc-tests/mempool_packages.py
@@ -11,6 +11,9 @@ from test_framework.util import *
 def satoshi_round(amount):
     return  Decimal(amount).quantize(Decimal('0.00000001'), rounding=ROUND_DOWN)
 
+MAX_ANCESTORS = 25
+MAX_DESCENDANTS = 25
+
 class MempoolPackagesTest(BitcoinTestFramework):
 
     def setup_network(self):
@@ -45,17 +48,17 @@ class MempoolPackagesTest(BitcoinTestFramework):
         value = utxo[0]['amount']
 
         fee = Decimal("0.0001")
-        # 100 transactions off a confirmed tx should be fine
+        # MAX_ANCESTORS transactions off a confirmed tx should be fine
         chain = []
-        for i in xrange(100):
+        for i in xrange(MAX_ANCESTORS):
             (txid, sent_value) = self.chain_transaction(self.nodes[0], txid, 0, value, fee, 1)
             value = sent_value
             chain.append(txid)
 
-        # Check mempool has 100 transactions in it, and descendant
+        # Check mempool has MAX_ANCESTORS transactions in it, and descendant
         # count and fees should look correct
         mempool = self.nodes[0].getrawmempool(True)
-        assert_equal(len(mempool), 100)
+        assert_equal(len(mempool), MAX_ANCESTORS)
         descendant_count = 1
         descendant_fees = 0
         descendant_size = 0
@@ -91,18 +94,18 @@ class MempoolPackagesTest(BitcoinTestFramework):
         for i in xrange(10):
             transaction_package.append({'txid': txid, 'vout': i, 'amount': sent_value})
 
-        for i in xrange(1000):
+        for i in xrange(MAX_DESCENDANTS):
             utxo = transaction_package.pop(0)
             try:
                 (txid, sent_value) = self.chain_transaction(self.nodes[0], utxo['txid'], utxo['vout'], utxo['amount'], fee, 10)
                 for j in xrange(10):
                     transaction_package.append({'txid': txid, 'vout': j, 'amount': sent_value})
-                if i == 998:
+                if i == MAX_DESCENDANTS - 2:
                     mempool = self.nodes[0].getrawmempool(True)
-                    assert_equal(mempool[parent_transaction]['descendantcount'], 1000)
+                    assert_equal(mempool[parent_transaction]['descendantcount'], MAX_DESCENDANTS)
             except JSONRPCException as e:
                 print e.error['message']
-                assert_equal(i, 999)
+                assert_equal(i, MAX_DESCENDANTS - 1)
                 print "tx that would create too large descendant package successfully rejected"
 
         # TODO: check that node1's mempool is as expected

--- a/src/main.h
+++ b/src/main.h
@@ -44,13 +44,13 @@ static const bool DEFAULT_ALERTS = true;
 /** Default for -maxorphantx, maximum number of orphan transactions kept in memory */
 static const unsigned int DEFAULT_MAX_ORPHAN_TRANSACTIONS = 100;
 /** Default for -limitancestorcount, max number of in-mempool ancestors */
-static const unsigned int DEFAULT_ANCESTOR_LIMIT = 100;
+static const unsigned int DEFAULT_ANCESTOR_LIMIT = 25;
 /** Default for -limitancestorsize, maximum kilobytes of tx + all in-mempool ancestors */
-static const unsigned int DEFAULT_ANCESTOR_SIZE_LIMIT = 900;
+static const unsigned int DEFAULT_ANCESTOR_SIZE_LIMIT = 101;
 /** Default for -limitdescendantcount, max number of in-mempool descendants */
-static const unsigned int DEFAULT_DESCENDANT_LIMIT = 1000;
+static const unsigned int DEFAULT_DESCENDANT_LIMIT = 25;
 /** Default for -limitdescendantsize, maximum kilobytes of in-mempool descendants */
-static const unsigned int DEFAULT_DESCENDANT_SIZE_LIMIT = 2500;
+static const unsigned int DEFAULT_DESCENDANT_SIZE_LIMIT = 101;
 /** Default for -maxmempool, maximum megabytes of mempool memory usage */
 static const unsigned int DEFAULT_MAX_MEMPOOL_SIZE = 300;
 /** Default for -mempoolexpiry, expiration time for mempool transactions in hours */


### PR DESCRIPTION
Reduce the default limits on maximum number of transactions and the cumulative size of those transactions in both ancestor and descendant packages to 25 txs and 100kb total size.

Please see [email to bitcoin-dev](https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2015-October/011401.html) for background.

I looked at some recent data and 2.6% of transactions in my node's mempool in the first 5 days of October would have been restricted by these new lower limits.
