### PR TITLE
[QT] pretty print (indent) multiline html output

### DIFF
--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -243,6 +243,7 @@ QString HtmlEscape(const QString& str, bool fMultiLine)
     if(fMultiLine)
     {
         escaped = escaped.replace("\n", "<br>\n");
+        escaped = escaped.replace(" ", "&nbsp;");
     }
     return escaped;
 }


### PR DESCRIPTION
**Before:**
<img width="952" alt="bildschirmfoto 2015-10-08 um 10 55 51" src="https://cloud.githubusercontent.com/assets/178464/10361981/da9b92c4-6dab-11e5-85b5-2cb7199fcd2b.png">

<img width="952" alt="bildschirmfoto 2015-10-08 um 10 55 55" src="https://cloud.githubusercontent.com/assets/178464/10361995/e9353e98-6dab-11e5-86b1-14b6145ccfec.png">

**After:**
<img width="1144" alt="bildschirmfoto 2015-10-08 um 10 54 44" src="https://cloud.githubusercontent.com/assets/178464/10361984/df08dc90-6dab-11e5-8079-3003c19950f5.png">

<img width="952" alt="bildschirmfoto 2015-10-08 um 10 56 32" src="https://cloud.githubusercontent.com/assets/178464/10361997/ede0b49a-6dab-11e5-881a-ee110f975799.png">

If the window is to small it will result in line break without indent (as in console):
<img width="696" alt="bildschirmfoto 2015-10-08 um 10 57 04" src="https://cloud.githubusercontent.com/assets/178464/10362011/fe877248-6dab-11e5-8938-562c6f9524fe.png">

<img width="542" alt="bildschirmfoto 2015-10-08 um 11 02 07" src="https://cloud.githubusercontent.com/assets/178464/10362022/090ccc04-6dac-11e5-977b-cfc84e4fb8eb.png">
