### PR TITLE
Update miniupnpc to 1.9.20151008

### DIFF
--- a/depends/packages/miniupnpc.mk
+++ b/depends/packages/miniupnpc.mk
@@ -1,8 +1,8 @@
 package=miniupnpc
-$(package)_version=1.9.20150730
+$(package)_version=1.9.20151008
 $(package)_download_path=http://miniupnp.free.fr/files
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
-$(package)_sha256_hash=1d64fab1fd3b4c8545139341ba197f19329a863f4f21b578fc2a228ab586a604
+$(package)_sha256_hash=e444ac3b587ce82709c4d0cfca1fe71f44f9fc433e9f946b12b9e1bfe667a633
 
 define $(package)_set_vars
 $(package)_build_opts=CC="$($(package)_cc)"


### PR DESCRIPTION
This version of miniupnpc fixes a buffer overflow in the XML (ugh) parser during initial network discovery.

http://talosintel.com/reports/TALOS-2015-0035/

The commit fixing the vulnerability is:
https://github.com/miniupnp/miniupnp/commit/79cca974a4c2ab1199786732a67ff6d898051b78

Reported by timothy on IRC.
Needs backport to 0.10 and 0.11.

Edit: complete diff between current version miniupnp 1.9.20150730 and 1.9.20151008 : https://gist.github.com/laanwj/6caebd77a1c253a486e4
