### PR TITLE
[devtools] add clang-format.py

### DIFF
--- a/contrib/devtools/README.md
+++ b/contrib/devtools/README.md
@@ -1,9 +1,14 @@
 Contents
-===========
+========
 This directory contains tools for developers working on this repository.
 
+clang-format.py
+===============
+
+A script to format cpp source code according to [.clang-format](../../src/.clang-format). This should only be applied to new files or files which are currently not actively developed on. Also, git subtrees are not subject to formatting.
+
 github-merge.sh
-==================
+===============
 
 A small script to automate merging pull-requests securely and sign them with GPG.
 
@@ -37,23 +42,31 @@ Configuring the github-merge tool for the bitcoin repository is done in the foll
     git config --global user.signingkey mykeyid (if you want to GPG sign)
 
 fix-copyright-headers.py
-===========================
+========================
 
 Every year newly updated files need to have its copyright headers updated to reflect the current year.
 If you run this script from src/ it will automatically update the year on the copyright header for all
 .cpp and .h files if these have a git commit from the current year.
 
 For example a file changed in 2014 (with 2014 being the current year):
+
 ```// Copyright (c) 2009-2013 The Bitcoin Core developers```
 
 would be changed to:
+
 ```// Copyright (c) 2009-2014 The Bitcoin Core developers```
 
+optimize-pngs.py
+================
+
+A script to optimize png files in the bitcoin
+repository (requires pngcrush).
+
 symbol-check.py
-==================
+===============
 
 A script to check that the (Linux) executables produced by gitian only contain
-allowed gcc, glibc and libstdc++ version symbols.  This makes sure they are
+allowed gcc, glibc and libstdc++ version symbols. This makes sure they are
 still compatible with the minimum supported Linux distribution versions.
 
 Example usage after a gitian build:
@@ -70,7 +83,7 @@ If there are 'unsupported' symbols, the return value will be 1 a list like this 
     .../64/test_bitcoin: symbol _ZNSt8__detail15_List_nod from unsupported version GLIBCXX_3.4.15
 
 update-translations.py
-=======================
+======================
 
 Run this script from the root of the repository to update all translations from transifex.
 It will do the following automatically:
@@ -93,4 +106,5 @@ maintained:
 * for sec/leveldb: https://github.com/bitcoin/leveldb.git (branch bitcoin-fork)
 
 Usage: git-subtree-check.sh DIR COMMIT
+
 COMMIT may be omitted, in which case HEAD is used.

--- a/contrib/devtools/clang-format.py
+++ b/contrib/devtools/clang-format.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+'''
+Wrapper script for clang-format
+
+Copyright (c) 2015 MarcoFalke
+Copyright (c) 2015 The Bitcoin Core developers
+Distributed under the MIT software license, see the accompanying
+file COPYING or http://www.opensource.org/licenses/mit-license.php.
+'''
+
+import os
+import sys
+import subprocess
+
+tested_versions = ['3.6.0', '3.6.1', '3.6.2'] # A set of versions known to produce the same output
+accepted_file_extensions = ('.h', '.cpp') # Files to format
+
+def check_clang_format_version(clang_format_exe):
+    try:
+        output = subprocess.check_output([clang_format_exe, '-version'])
+        for ver in tested_versions:
+            if ver in output:
+                print "Detected clang-format version " + ver
+                return
+        raise RuntimeError("Untested version: " + output)
+    except Exception as e:
+        print 'Could not verify version of ' + clang_format_exe + '.'
+        raise e
+
+def check_command_line_args(argv):
+    required_args = ['{clang-format-exe}', '{files}']
+    example_args = ['clang-format-3.x', 'src/main.cpp', 'src/wallet/*']
+
+    if(len(argv) < len(required_args) + 1):
+        for word in (['Usage:', argv[0]] + required_args):
+            print word,
+        print ''
+        for word in (['E.g:', argv[0]] + example_args):
+            print word,
+        print ''
+        sys.exit(1)
+
+def run_clang_format(clang_format_exe, files):
+    for target in files:
+        if os.path.isdir(target):
+            for path, dirs, files in os.walk(target):
+                run_clang_format(clang_format_exe, (os.path.join(path, f) for f in files))
+        elif target.endswith(accepted_file_extensions):
+            print "Format " + target
+            subprocess.check_call([clang_format_exe, '-i', '-style=file', target], stdout=open(os.devnull, 'wb'), stderr=subprocess.STDOUT)
+        else:
+            print "Skip " + target
+
+def main(argv):
+    check_command_line_args(argv)
+    clang_format_exe = argv[1]
+    files = argv[2:]
+    check_clang_format_version(clang_format_exe)
+    run_clang_format(clang_format_exe, files)
+
+if __name__ == "__main__":
+    main(sys.argv)


### PR DESCRIPTION
This will add a python convenience wrapper for `clang-format`. The python code includes a list with tested versions (`tested_versions`) which can easily be updated in the future.

[ci skip]
