### PR TITLE
Defaults UPNP to off when discovery is disabled.

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -777,6 +777,11 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
             LogPrintf("%s: parameter interaction: -externalip set -> setting -discover=0\n", __func__);
     }
 
+    if (!GetBoolArg("-discover", true)) {
+        if (SoftSetBoolArg("-upnp", false))
+            LogPrintf("%s: parameter interaction: -discover=0 -> setting -upnp=0\n", __func__);
+    }
+
     if (GetBoolArg("-salvagewallet", false)) {
         // Rewrite just private keys: rescan to find transactions
         if (SoftSetBoolArg("-rescan", true))


### PR DESCRIPTION
There is _usually_ no need for upnp when discovery is
 disabled directly or as as a result of manual address
 configuration.

The user may still want it for hole punching but what
 few users who have manually configured IPs or disabling
 discovery but still need UPNP can probably find and
 enable it.
