### PR TITLE
Bump minrelaytxfee default

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -75,7 +75,7 @@ uint64_t nPruneTarget = 0;
 bool fAlerts = DEFAULT_ALERTS;
 
 /** Fees smaller than this (in satoshi) are considered zero fee (for relaying and mining) */
-CFeeRate minRelayTxFee = CFeeRate(1000);
+CFeeRate minRelayTxFee = CFeeRate(5000);
 
 CTxMemPool mempool(::minRelayTxFee);
 

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -345,7 +345,7 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
     t.vout[0].nValue = 501; // dust
     BOOST_CHECK(!IsStandardTx(t, reason));
 
-    t.vout[0].nValue = 601; // not dust
+    t.vout[0].nValue = 2730; // not dust
     BOOST_CHECK(IsStandardTx(t, reason));
 
     t.vout[0].scriptPubKey = CScript() << OP_1;


### PR DESCRIPTION
Bump minrelaytxfee default to bridge the time until a dynamic method for determining this fee is merged.

This is especially aimed at the stable releases (0.10, 0.11) because full mempool limiting, as will be in 0.12, is too invasive and risky to backport.

The specific value (currently 0.00005) is open for discussion.

Ping @gmaxwell @morcos 
Context: https://github.com/bitcoin/bitcoin/blob/v0.11.0/doc/release-notes.md#transaction-flooding
