### PR TITLE
Automatically adjusting Spam Block

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -52,6 +52,7 @@
 #include <boost/function.hpp>
 #include <boost/interprocess/sync/file_lock.hpp>
 #include <boost/thread.hpp>
+#include <boost/lexical_cast.hpp>
 #include <openssl/crypto.h>
 
 #if ENABLE_ZMQ
@@ -438,6 +439,8 @@ std::string HelpMessage(HelpMessageMode mode)
     }
     strUsage += HelpMessageOpt("-minrelaytxfee=<amt>", strprintf(_("Fees (in %s/kB) smaller than this are considered zero fee for relaying (default: %s)"),
         CURRENCY_UNIT, FormatMoney(::minRelayTxFee.GetFeePerK())));
+    strUsage += HelpMessageOpt("-maxrelaytxfee=<amt>", strprintf(_("Fees (in %s/kB) larger than this will always be relayed (default: %s)"),
+        CURRENCY_UNIT, FormatMoney(::minRelayTxFee.GetFeePerK() * 5)));
     strUsage += HelpMessageOpt("-printtoconsole", _("Send trace/debug info to console instead of debug.log file"));
     if (showDebug)
     {
@@ -853,6 +856,12 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     int64_t nMempoolDescendantSizeLimit = GetArg("-limitdescendantsize", DEFAULT_DESCENDANT_SIZE_LIMIT) * 1000;
     if (nMempoolSizeLimit < 0 || nMempoolSizeLimit < nMempoolDescendantSizeLimit * 40)
         return InitError(strprintf(_("-maxmempool must be at least %d MB"), GetArg("-limitdescendantsize", DEFAULT_DESCENDANT_SIZE_LIMIT) / 25));
+
+    // -maxrelaytxfee and minrelaytxfee limits
+    if (boost::lexical_cast<double>(GetArg("-minrelaytxfee",FormatMoney(::minRelayTxFee.GetFeePerK()))) > 
+        boost::lexical_cast<double>(GetArg("-maxrelaytxfee",FormatMoney(::minRelayTxFee.GetFeePerK() * 5))))
+        return InitError(_("-minrelaytxfee must be less than -maxrelaytxfee."));
+
 
     // -par=0 means autodetect, but nScriptCheckThreads==0 means no concurrency
     nScriptCheckThreads = GetArg("-par", DEFAULT_SCRIPTCHECK_THREADS);

--- a/src/main.h
+++ b/src/main.h
@@ -83,6 +83,12 @@ static const unsigned int DATABASE_WRITE_INTERVAL = 60 * 60;
 static const unsigned int DATABASE_FLUSH_INTERVAL = 24 * 60 * 60;
 /** Maximum length of reject messages. */
 static const unsigned int MAX_REJECT_MESSAGE_LENGTH = 111;
+/** The number of block heights to gradually choke spam transactions over */
+static const unsigned int MAX_BLOCK_SIZE_MULTIPLYER = 10;
+/** The minimum value possible for -limitfreerelay when rate limiting */
+static const unsigned int MIN_LIMIT_FREE_RELAY = 1;
+/** The default value for -limitfreerelay */
+static const unsigned int DEFAULT_LIMIT_FREE_RELAY = 15;
 
 struct BlockHasher
 {


### PR DESCRIPTION
Auto adjusts -limitfreerelay and -minrelaytxfee up or down as the memory pool
grows or falls beyond one block in height.

A simple but effective way to block spammy transactions from getting accepted into the mempool and relayed, saving cpu, memory and valuable bandwidth.

The way it's configured now it reaches maximum choke at 10 times the maximum block size.  

When the mempool begins to fall again, the values of -minrelaytxfee and -limitfreerelay slowly return to their starting values using a 24hr decay.
