### PR TITLE
build: univalue subdir build fixups

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -36,8 +36,8 @@ LIBUNIVALUE=univalue/libunivalue.la
 $(LIBSECP256K1): $(wildcard secp256k1/src/*) $(wildcard secp256k1/include/*)
 	$(AM_V_at)$(MAKE) $(AM_MAKEFLAGS) -C $(@D) $(@F)
   
-$(LIBUNIVALUE): $(wildcard univalue/lib/*)
-	$(AM_V_at)$(MAKE) $(AM_MAKEFLAGS) -C univalue/
+$(LIBUNIVALUE): $(wildcard univalue/lib/*) $(wildcard univalue/include/*)
+	$(AM_V_at)$(MAKE) $(AM_MAKEFLAGS) -C $(@D) $(@F)
 
 # Make is not made aware of per-object dependencies to avoid limiting building parallelization
 # But to build the less dependent modules first, we manually select their order here:
@@ -421,6 +421,7 @@ EXTRA_DIST = leveldb
 clean-local:
 	-$(MAKE) -C leveldb clean
 	-$(MAKE) -C secp256k1 clean
+	-$(MAKE) -C univalue clean
 	rm -f leveldb/*/*.gcno leveldb/helpers/memenv/*.gcno
 	-rm -f config.h
 


### PR DESCRIPTION
I ran into stale object files after switching from linux -> win builds because 'make clean' wasn't cleaning up as expected. Fixed up a few other little things while I was at it.
- Clean univalue on 'make clean'
- Force a rebuild if the headers change
- Only build the lib target
