### PR TITLE
clang-format: Recently added files

### DIFF
--- a/src/.clang-format
+++ b/src/.clang-format
@@ -1,4 +1,6 @@
+Language:        Cpp
 AccessModifierOffset: -4
+AlignAfterOpenBracket: false
 AlignEscapedNewlinesLeft: true
 AlignTrailingComments: true
 AllowAllParametersOfDeclarationOnNextLine: false
@@ -26,7 +28,6 @@ IndentCaseLabels: false
 IndentFunctionDeclarationAfterType: false
 IndentWidth:     4
 KeepEmptyLinesAtTheStartOfBlocks: false
-Language:        Cpp
 MaxEmptyLinesToKeep: 2
 NamespaceIndentation: None
 ObjCSpaceAfterProperty: false

--- a/src/bench/bench.cpp
+++ b/src/bench/bench.cpp
@@ -9,7 +9,8 @@ using namespace benchmark;
 
 std::map<std::string, BenchFunction> BenchRunner::benchmarks;
 
-static double gettimedouble(void) {
+static double gettimedouble(void)
+{
     struct timeval tv;
     gettimeofday(&tv, NULL);
     return tv.tv_usec * 0.000001 + tv.tv_sec;
@@ -20,14 +21,21 @@ BenchRunner::BenchRunner(std::string name, BenchFunction func)
     benchmarks.insert(std::make_pair(name, func));
 }
 
-void
-BenchRunner::RunAll(double elapsedTimeForOne)
+void BenchRunner::RunAll(double elapsedTimeForOne)
 {
-    std::cout << "Benchmark" << "," << "count" << "," << "min" << "," << "max" << "," << "average" << "\n";
+    std::cout << "Benchmark"
+              << ","
+              << "count"
+              << ","
+              << "min"
+              << ","
+              << "max"
+              << ","
+              << "average"
+              << "\n";
 
-    for (std::map<std::string,BenchFunction>::iterator it = benchmarks.begin();
+    for (std::map<std::string, BenchFunction>::iterator it = benchmarks.begin();
          it != benchmarks.end(); ++it) {
-
         State state(it->first, elapsedTimeForOne);
         BenchFunction& func = it->second;
         func(state);
@@ -39,29 +47,32 @@ bool State::KeepRunning()
     double now;
     if (count == 0) {
         beginTime = now = gettimedouble();
-    }
-    else {
+    } else {
         // timeCheckCount is used to avoid calling gettime most of the time,
         // so benchmarks that run very quickly get consistent results.
-        if ((count+1)%timeCheckCount != 0) {
+        if ((count + 1) % timeCheckCount != 0) {
             ++count;
             return true; // keep going
         }
         now = gettimedouble();
-        double elapsedOne = (now - lastTime)/timeCheckCount;
-        if (elapsedOne < minTime) minTime = elapsedOne;
-        if (elapsedOne > maxTime) maxTime = elapsedOne;
-        if (elapsedOne*timeCheckCount < maxElapsed/16) timeCheckCount *= 2;
+        double elapsedOne = (now - lastTime) / timeCheckCount;
+        if (elapsedOne < minTime)
+            minTime = elapsedOne;
+        if (elapsedOne > maxTime)
+            maxTime = elapsedOne;
+        if (elapsedOne * timeCheckCount < maxElapsed / 16)
+            timeCheckCount *= 2;
     }
     lastTime = now;
     ++count;
 
-    if (now - beginTime < maxElapsed) return true; // Keep going
+    if (now - beginTime < maxElapsed)
+        return true; // Keep going
 
     --count;
 
     // Output results
-    double average = (now-beginTime)/count;
+    double average = (now - beginTime) / count;
     std::cout << name << "," << count << "," << minTime << "," << maxTime << "," << average << "\n";
 
     return false;

--- a/src/bench/bench.h
+++ b/src/bench/bench.h
@@ -33,35 +33,38 @@ BENCHMARK(CODE_TO_TIME);
 #include <map>
 #include <string>
 
-namespace benchmark {
+namespace benchmark
+{
+class State
+{
+    std::string name;
+    double maxElapsed;
+    double beginTime;
+    double lastTime, minTime, maxTime;
+    int64_t count;
+    int64_t timeCheckCount;
 
-    class State {
-        std::string name;
-        double maxElapsed;
-        double beginTime;
-        double lastTime, minTime, maxTime;
-        int64_t count;
-        int64_t timeCheckCount;
-    public:
-        State(std::string _name, double _maxElapsed) : name(_name), maxElapsed(_maxElapsed), count(0) {
-            minTime = std::numeric_limits<double>::max();
-            maxTime = std::numeric_limits<double>::min();
-            timeCheckCount = 1;
-        }
-        bool KeepRunning();
-    };
-
-    typedef boost::function<void(State&)> BenchFunction;
-
-    class BenchRunner
+public:
+    State(std::string _name, double _maxElapsed) : name(_name), maxElapsed(_maxElapsed), count(0)
     {
-        static std::map<std::string, BenchFunction> benchmarks;
+        minTime = std::numeric_limits<double>::max();
+        maxTime = std::numeric_limits<double>::min();
+        timeCheckCount = 1;
+    }
+    bool KeepRunning();
+};
 
-    public:
-        BenchRunner(std::string name, BenchFunction func);
+typedef boost::function<void(State&)> BenchFunction;
 
-        static void RunAll(double elapsedTimeForOne=1.0);
-    };
+class BenchRunner
+{
+    static std::map<std::string, BenchFunction> benchmarks;
+
+public:
+    BenchRunner(std::string name, BenchFunction func);
+
+    static void RunAll(double elapsedTimeForOne = 1.0);
+};
 }
 
 // BENCHMARK(foo) expands to:  benchmark::BenchRunner bench_11foo("foo", foo);

--- a/src/bench/bench_bitcoin.cpp
+++ b/src/bench/bench_bitcoin.cpp
@@ -8,8 +8,7 @@
 #include "main.h"
 #include "util.h"
 
-int
-main(int argc, char** argv)
+int main(int argc, char** argv)
 {
     ECC_Start();
     SetupEnvironment();

--- a/src/httprpc.cpp
+++ b/src/httprpc.cpp
@@ -19,14 +19,14 @@
 class HTTPRPCTimer : public RPCTimerBase
 {
 public:
-    HTTPRPCTimer(struct event_base* eventBase, boost::function<void(void)>& func, int64_t millis) :
-        ev(eventBase, false, func)
+    HTTPRPCTimer(struct event_base* eventBase, boost::function<void(void)>& func, int64_t millis) : ev(eventBase, false, func)
     {
         struct timeval tv;
-        tv.tv_sec = millis/1000;
-        tv.tv_usec = (millis%1000)*1000;
+        tv.tv_sec = millis / 1000;
+        tv.tv_usec = (millis % 1000) * 1000;
         ev.trigger(&tv);
     }
+
 private:
     HTTPEvent ev;
 };
@@ -45,6 +45,7 @@ public:
     {
         return new HTTPRPCTimer(base, func, millis);
     }
+
 private:
     struct event_base* base;
 };
@@ -84,7 +85,7 @@ static bool RPCAuthorized(const std::string& strAuth)
     return TimingResistantEqual(strUserPass, strRPCUserColonPass);
 }
 
-static bool HTTPReq_JSONRPC(HTTPRequest* req, const std::string &)
+static bool HTTPReq_JSONRPC(HTTPRequest* req, const std::string&)
 {
     // JSONRPC handles only POST
     if (req->GetRequestMethod() != HTTPRequest::POST) {
@@ -127,7 +128,7 @@ static bool HTTPReq_JSONRPC(HTTPRequest* req, const std::string &)
             // Send reply
             strReply = JSONRPCReply(result, NullUniValue, jreq.id);
 
-        // array of requests
+            // array of requests
         } else if (valRequest.isArray())
             strReply = JSONRPCExecBatch(valRequest.get_array());
         else
@@ -147,8 +148,7 @@ static bool HTTPReq_JSONRPC(HTTPRequest* req, const std::string &)
 
 static bool InitRPCAuthentication()
 {
-    if (mapArgs["-rpcpassword"] == "")
-    {
+    if (mapArgs["-rpcpassword"] == "") {
         LogPrintf("No rpcpassword set - using random cookie authentication\n");
         if (!GenerateAuthCookie(&strRPCUserColonPass)) {
             uiInterface.ThreadSafeMessageBox(

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -252,7 +252,7 @@ static void http_request_cb(struct evhttp_request* req, void* arg)
     std::auto_ptr<HTTPRequest> hreq(new HTTPRequest(req));
 
     LogPrint("http", "Received a %s request for %s from %s\n",
-             RequestMethodString(hreq->GetRequestMethod()), hreq->GetURI(), hreq->GetPeer().ToString());
+        RequestMethodString(hreq->GetRequestMethod()), hreq->GetURI(), hreq->GetPeer().ToString());
 
     // Early address-based allow check
     if (!ClientAllowed(hreq->GetPeer())) {
@@ -582,7 +582,7 @@ void HTTPRequest::WriteReply(int nStatus, const std::string& strReply)
     assert(evb);
     evbuffer_add(evb, strReply.data(), strReply.size());
     HTTPEvent* ev = new HTTPEvent(eventBase, true,
-                                  boost::bind(evhttp_send_reply, req, nStatus, (const char*)NULL, (struct evbuffer*)NULL));
+        boost::bind(evhttp_send_reply, req, nStatus, (const char*)NULL, (struct evbuffer*)NULL));
     ev->trigger(0);
     replySent = true;
     req = 0; // transferred back to main thread

--- a/src/httpserver.h
+++ b/src/httpserver.h
@@ -11,9 +11,9 @@
 #include <boost/scoped_ptr.hpp>
 #include <boost/function.hpp>
 
-static const int DEFAULT_HTTP_THREADS=4;
-static const int DEFAULT_HTTP_WORKQUEUE=16;
-static const int DEFAULT_HTTP_SERVER_TIMEOUT=30;
+static const int DEFAULT_HTTP_THREADS = 4;
+static const int DEFAULT_HTTP_WORKQUEUE = 16;
+static const int DEFAULT_HTTP_SERVER_TIMEOUT = 30;
 
 struct evhttp_request;
 struct event_base;
@@ -35,14 +35,14 @@ void InterruptHTTPServer();
 void StopHTTPServer();
 
 /** Handler for requests to a certain HTTP path */
-typedef boost::function<void(HTTPRequest* req, const std::string &)> HTTPRequestHandler;
+typedef boost::function<void(HTTPRequest* req, const std::string&)> HTTPRequestHandler;
 /** Register handler for prefix.
  * If multiple handlers match a prefix, the first-registered one will
  * be invoked.
  */
-void RegisterHTTPHandler(const std::string &prefix, bool exactMatch, const HTTPRequestHandler &handler);
+void RegisterHTTPHandler(const std::string& prefix, bool exactMatch, const HTTPRequestHandler& handler);
 /** Unregister handler for prefix */
-void UnregisterHTTPHandler(const std::string &prefix, bool exactMatch);
+void UnregisterHTTPHandler(const std::string& prefix, bool exactMatch);
 
 /** Return evhttp event base. This can be used by submodules to
  * queue timers or custom events.
@@ -142,6 +142,7 @@ public:
 
     bool deleteWhenTriggered;
     boost::function<void(void)> handler;
+
 private:
     struct event* ev;
 };

--- a/src/qt/bantablemodel.cpp
+++ b/src/qt/bantablemodel.cpp
@@ -22,8 +22,7 @@ bool BannedNodeLessThan::operator()(const CCombinedBan& left, const CCombinedBan
     if (order == Qt::DescendingOrder)
         std::swap(pLeft, pRight);
 
-    switch(column)
-    {
+    switch (column) {
     case BanTableModel::Address:
         return pLeft->subnet.ToString().compare(pRight->subnet.ToString()) < 0;
     case BanTableModel::Bantime:
@@ -54,8 +53,7 @@ public:
 #if QT_VERSION >= 0x040700
         cachedBanlist.reserve(banMap.size());
 #endif
-        for (banmap_t::iterator it = banMap.begin(); it != banMap.end(); it++)
-        {
+        for (banmap_t::iterator it = banMap.begin(); it != banMap.end(); it++) {
             CCombinedBan banEntry;
             banEntry.subnet = (*it).first;
             banEntry.banEntry = (*it).second;
@@ -72,7 +70,7 @@ public:
         return cachedBanlist.size();
     }
 
-    CCombinedBan *index(int idx)
+    CCombinedBan* index(int idx)
     {
         if (idx >= 0 && idx < cachedBanlist.size())
             return &cachedBanlist[idx];
@@ -81,9 +79,8 @@ public:
     }
 };
 
-BanTableModel::BanTableModel(ClientModel *parent) :
-    QAbstractTableModel(parent),
-    clientModel(parent)
+BanTableModel::BanTableModel(ClientModel* parent) : QAbstractTableModel(parent),
+                                                    clientModel(parent)
 {
     columns << tr("IP/Netmask") << tr("Banned Until");
     priv = new BanTablePriv();
@@ -94,28 +91,28 @@ BanTableModel::BanTableModel(ClientModel *parent) :
     refresh();
 }
 
-int BanTableModel::rowCount(const QModelIndex &parent) const
+int BanTableModel::rowCount(const QModelIndex& parent) const
 {
     Q_UNUSED(parent);
     return priv->size();
 }
 
-int BanTableModel::columnCount(const QModelIndex &parent) const
+int BanTableModel::columnCount(const QModelIndex& parent) const
 {
     Q_UNUSED(parent);
-    return columns.length();;
+    return columns.length();
+    ;
 }
 
-QVariant BanTableModel::data(const QModelIndex &index, int role) const
+QVariant BanTableModel::data(const QModelIndex& index, int role) const
 {
-    if(!index.isValid())
+    if (!index.isValid())
         return QVariant();
 
-    CCombinedBan *rec = static_cast<CCombinedBan*>(index.internalPointer());
+    CCombinedBan* rec = static_cast<CCombinedBan*>(index.internalPointer());
 
     if (role == Qt::DisplayRole) {
-        switch(index.column())
-        {
+        switch (index.column()) {
         case Address:
             return QString::fromStdString(rec->subnet.ToString());
         case Bantime:
@@ -130,29 +127,27 @@ QVariant BanTableModel::data(const QModelIndex &index, int role) const
 
 QVariant BanTableModel::headerData(int section, Qt::Orientation orientation, int role) const
 {
-    if(orientation == Qt::Horizontal)
-    {
-        if(role == Qt::DisplayRole && section < columns.size())
-        {
+    if (orientation == Qt::Horizontal) {
+        if (role == Qt::DisplayRole && section < columns.size()) {
             return columns[section];
         }
     }
     return QVariant();
 }
 
-Qt::ItemFlags BanTableModel::flags(const QModelIndex &index) const
+Qt::ItemFlags BanTableModel::flags(const QModelIndex& index) const
 {
-    if(!index.isValid())
+    if (!index.isValid())
         return 0;
 
     Qt::ItemFlags retval = Qt::ItemIsSelectable | Qt::ItemIsEnabled;
     return retval;
 }
 
-QModelIndex BanTableModel::index(int row, int column, const QModelIndex &parent) const
+QModelIndex BanTableModel::index(int row, int column, const QModelIndex& parent) const
 {
     Q_UNUSED(parent);
-    CCombinedBan *data = priv->index(row);
+    CCombinedBan* data = priv->index(row);
 
     if (data)
         return createIndex(row, column, data);

--- a/src/qt/bantablemodel.h
+++ b/src/qt/bantablemodel.h
@@ -21,8 +21,7 @@ struct CCombinedBan {
 class BannedNodeLessThan
 {
 public:
-    BannedNodeLessThan(int nColumn, Qt::SortOrder fOrder) :
-        column(nColumn), order(fOrder) {}
+    BannedNodeLessThan(int nColumn, Qt::SortOrder fOrder) : column(nColumn), order(fOrder) {}
     bool operator()(const CCombinedBan& left, const CCombinedBan& right) const;
 
 private:
@@ -39,7 +38,7 @@ class BanTableModel : public QAbstractTableModel
     Q_OBJECT
 
 public:
-    explicit BanTableModel(ClientModel *parent = 0);
+    explicit BanTableModel(ClientModel* parent = 0);
     void startAutoRefresh();
     void stopAutoRefresh();
 
@@ -50,12 +49,12 @@ public:
 
     /** @name Methods overridden from QAbstractTableModel
         @{*/
-    int rowCount(const QModelIndex &parent) const;
-    int columnCount(const QModelIndex &parent) const;
-    QVariant data(const QModelIndex &index, int role) const;
+    int rowCount(const QModelIndex& parent) const;
+    int columnCount(const QModelIndex& parent) const;
+    QVariant data(const QModelIndex& index, int role) const;
     QVariant headerData(int section, Qt::Orientation orientation, int role) const;
-    QModelIndex index(int row, int column, const QModelIndex &parent) const;
-    Qt::ItemFlags flags(const QModelIndex &index) const;
+    QModelIndex index(int row, int column, const QModelIndex& parent) const;
+    Qt::ItemFlags flags(const QModelIndex& index) const;
     void sort(int column, Qt::SortOrder order);
     bool shouldShow();
     /*@}*/
@@ -64,9 +63,9 @@ public Q_SLOTS:
     void refresh();
 
 private:
-    ClientModel *clientModel;
+    ClientModel* clientModel;
     QStringList columns;
-    BanTablePriv *priv;
+    BanTablePriv* priv;
 };
 
 #endif // BITCOIN_QT_BANTABLEMODEL_H

--- a/src/test/addrman_tests.cpp
+++ b/src/test/addrman_tests.cpp
@@ -10,7 +10,9 @@
 
 using namespace std;
 
-class CAddrManTest : public CAddrMan{};
+class CAddrManTest : public CAddrMan
+{
+};
 
 BOOST_FIXTURE_TEST_SUITE(addrman_tests, BasicTestingSetup)
 
@@ -35,7 +37,7 @@ BOOST_AUTO_TEST_CASE(addrman_simple)
     CAddrInfo addr_ret1 = addrman.Select();
     BOOST_CHECK(addr_ret1.ToString() == "250.1.1.1:8333");
 
-    // Test 3: Does IP address deduplication work correctly. 
+    // Test 3: Does IP address deduplication work correctly.
     //  Expected dup IP should not be added.
     CService addr1_dup = CService("250.1.1.1:8333");
     addrman.Add(CAddress(addr1_dup), source);
@@ -48,7 +50,7 @@ BOOST_AUTO_TEST_CASE(addrman_simple)
     addrman.Add(CAddress(addr2), source);
     BOOST_CHECK(addrman.size() == 2);
 
-    // Test 6: AddrMan::Clear() should empty the new table. 
+    // Test 6: AddrMan::Clear() should empty the new table.
     addrman.Clear();
     BOOST_CHECK(addrman.size() == 0);
     CAddrInfo addr_null2 = addrman.Select();
@@ -127,8 +129,8 @@ BOOST_AUTO_TEST_CASE(addrman_new_collisions)
 
     BOOST_CHECK(addrman.size() == 0);
 
-    for (unsigned int i = 1; i < 4; i++){
-        CService addr = CService("250.1.1."+boost::to_string(i));
+    for (unsigned int i = 1; i < 4; i++) {
+        CService addr = CService("250.1.1." + boost::to_string(i));
         addrman.Add(CAddress(addr), source);
 
         //Test 11: No collision in new table yet.
@@ -156,8 +158,8 @@ BOOST_AUTO_TEST_CASE(addrman_tried_collisions)
 
     BOOST_CHECK(addrman.size() == 0);
 
-    for (unsigned int i = 1; i < 75; i++){
-        CService addr = CService("250.1.1."+boost::to_string(i));
+    for (unsigned int i = 1; i < 75; i++) {
+        CService addr = CService("250.1.1." + boost::to_string(i));
         addrman.Add(CAddress(addr), source);
         addrman.Good(CAddress(addr));
 

--- a/src/test/dbwrapper_tests.cpp
+++ b/src/test/dbwrapper_tests.cpp
@@ -10,13 +10,14 @@
 #include <boost/assign/std/vector.hpp> // for 'operator+=()'
 #include <boost/assert.hpp>
 #include <boost/test/unit_test.hpp>
-                    
+
 using namespace std;
 using namespace boost::assign; // bring 'operator+=()' into scope
 using namespace boost::filesystem;
-         
+
 // Test if a string consists entirely of null characters
-bool is_null_key(const vector<unsigned char>& key) {
+bool is_null_key(const vector<unsigned char>& key)
+{
     bool isnull = true;
 
     for (unsigned int i = 0; i < key.size(); i++)
@@ -24,9 +25,9 @@ bool is_null_key(const vector<unsigned char>& key) {
 
     return isnull;
 }
- 
+
 BOOST_FIXTURE_TEST_SUITE(dbwrapper_tests, BasicTestingSetup)
-                       
+
 BOOST_AUTO_TEST_CASE(dbwrapper)
 {
     // Perform tests both obfuscated and non-obfuscated.
@@ -149,24 +150,24 @@ BOOST_AUTO_TEST_CASE(existing_data_no_obfuscate)
     // Now, set up another wrapper that wants to obfuscate the same directory
     CDBWrapper odbw(ph, (1 << 10), false, false, true);
 
-    // Check that the key/val we wrote with unobfuscated wrapper exists and 
+    // Check that the key/val we wrote with unobfuscated wrapper exists and
     // is readable.
     uint256 res2;
     BOOST_CHECK(odbw.Read(key, res2));
     BOOST_CHECK_EQUAL(res2.ToString(), in.ToString());
 
-    BOOST_CHECK(!odbw.IsEmpty()); // There should be existing data
+    BOOST_CHECK(!odbw.IsEmpty());                     // There should be existing data
     BOOST_CHECK(is_null_key(odbw.GetObfuscateKey())); // The key should be an empty string
 
     uint256 in2 = GetRandHash();
     uint256 res3;
- 
+
     // Check that we can write successfully
     BOOST_CHECK(odbw.Write(key, in2));
     BOOST_CHECK(odbw.Read(key, res3));
     BOOST_CHECK_EQUAL(res3.ToString(), in2.ToString());
 }
-                        
+
 // Ensure that we start obfuscating during a reindex.
 BOOST_AUTO_TEST_CASE(existing_data_reindex)
 {
@@ -197,11 +198,11 @@ BOOST_AUTO_TEST_CASE(existing_data_reindex)
 
     uint256 in2 = GetRandHash();
     uint256 res3;
- 
+
     // Check that we can write successfully
     BOOST_CHECK(odbw.Write(key, in2));
     BOOST_CHECK(odbw.Read(key, res3));
     BOOST_CHECK_EQUAL(res3.ToString(), in2.ToString());
 }
- 
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/streams_tests.cpp
+++ b/src/test/streams_tests.cpp
@@ -9,7 +9,7 @@
 #include <boost/assign/std/vector.hpp> // for 'operator+=()'
 #include <boost/assert.hpp>
 #include <boost/test/unit_test.hpp>
-                    
+
 using namespace std;
 using namespace boost::assign; // bring 'operator+=()' into scope
 
@@ -23,16 +23,16 @@ BOOST_AUTO_TEST_CASE(streams_serializedata_xor)
     CDataStream ds(in, 0, 0);
 
     // Degenerate case
-    
-    key += '\x00','\x00';
+
+    key += '\x00', '\x00';
     ds.Xor(key);
     BOOST_CHECK_EQUAL(
-            std::string(expected_xor.begin(), expected_xor.end()), 
-            std::string(ds.begin(), ds.end()));
+        std::string(expected_xor.begin(), expected_xor.end()),
+        std::string(ds.begin(), ds.end()));
 
-    in += '\x0f','\xf0';
-    expected_xor += '\xf0','\x0f';
-    
+    in += '\x0f', '\xf0';
+    expected_xor += '\xf0', '\x0f';
+
     // Single character key
 
     ds.clear();
@@ -42,26 +42,26 @@ BOOST_AUTO_TEST_CASE(streams_serializedata_xor)
     key += '\xff';
     ds.Xor(key);
     BOOST_CHECK_EQUAL(
-            std::string(expected_xor.begin(), expected_xor.end()), 
-            std::string(ds.begin(), ds.end())); 
-    
+        std::string(expected_xor.begin(), expected_xor.end()),
+        std::string(ds.begin(), ds.end()));
+
     // Multi character key
 
     in.clear();
     expected_xor.clear();
-    in += '\xf0','\x0f';
-    expected_xor += '\x0f','\x00';
-                        
+    in += '\xf0', '\x0f';
+    expected_xor += '\x0f', '\x00';
+
     ds.clear();
     ds.insert(ds.begin(), in.begin(), in.end());
 
     key.clear();
-    key += '\xff','\x0f';
+    key += '\xff', '\x0f';
 
     ds.Xor(key);
     BOOST_CHECK_EQUAL(
-            std::string(expected_xor.begin(), expected_xor.end()), 
-            std::string(ds.begin(), ds.end()));  
-}         
+        std::string(expected_xor.begin(), expected_xor.end()),
+        std::string(ds.begin(), ds.end()));
+}
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/zmq/zmqabstractnotifier.cpp
+++ b/src/zmq/zmqabstractnotifier.cpp
@@ -11,12 +11,12 @@ CZMQAbstractNotifier::~CZMQAbstractNotifier()
     assert(!psocket);
 }
 
-bool CZMQAbstractNotifier::NotifyBlock(const CBlockIndex * /*CBlockIndex*/)
+bool CZMQAbstractNotifier::NotifyBlock(const CBlockIndex* /*CBlockIndex*/)
 {
     return true;
 }
 
-bool CZMQAbstractNotifier::NotifyTransaction(const CTransaction &/*transaction*/)
+bool CZMQAbstractNotifier::NotifyTransaction(const CTransaction& /*transaction*/)
 {
     return true;
 }

--- a/src/zmq/zmqabstractnotifier.h
+++ b/src/zmq/zmqabstractnotifier.h
@@ -15,7 +15,7 @@ typedef CZMQAbstractNotifier* (*CZMQNotifierFactory)();
 class CZMQAbstractNotifier
 {
 public:
-    CZMQAbstractNotifier() : psocket(0) { }
+    CZMQAbstractNotifier() : psocket(0) {}
     virtual ~CZMQAbstractNotifier();
 
     template <typename T>
@@ -25,18 +25,18 @@ public:
     }
 
     std::string GetType() const { return type; }
-    void SetType(const std::string &t) { type = t; }
+    void SetType(const std::string& t) { type = t; }
     std::string GetAddress() const { return address; }
-    void SetAddress(const std::string &a) { address = a; }
+    void SetAddress(const std::string& a) { address = a; }
 
-    virtual bool Initialize(void *pcontext) = 0;
+    virtual bool Initialize(void* pcontext) = 0;
     virtual void Shutdown() = 0;
 
-    virtual bool NotifyBlock(const CBlockIndex *pindex);
-    virtual bool NotifyTransaction(const CTransaction &transaction);
+    virtual bool NotifyBlock(const CBlockIndex* pindex);
+    virtual bool NotifyTransaction(const CTransaction& transaction);
 
 protected:
-    void *psocket;
+    void* psocket;
     std::string type;
     std::string address;
 };

--- a/src/zmq/zmqconfig.h
+++ b/src/zmq/zmqconfig.h
@@ -19,6 +19,6 @@
 #include "primitives/block.h"
 #include "primitives/transaction.h"
 
-void zmqError(const char *str);
+void zmqError(const char* str);
 
 #endif // BITCOIN_ZMQ_ZMQCONFIG_H

--- a/src/zmq/zmqnotificationinterface.cpp
+++ b/src/zmq/zmqnotificationinterface.cpp
@@ -10,7 +10,7 @@
 #include "streams.h"
 #include "util.h"
 
-void zmqError(const char *str)
+void zmqError(const char* str)
 {
     LogPrint("zmq", "Error: %s, errno=%s\n", str, zmq_strerror(errno));
 }
@@ -24,13 +24,12 @@ CZMQNotificationInterface::~CZMQNotificationInterface()
     // ensure Shutdown if Initialize is called
     assert(!pcontext);
 
-    for (std::list<CZMQAbstractNotifier*>::iterator i=notifiers.begin(); i!=notifiers.end(); ++i)
-    {
+    for (std::list<CZMQAbstractNotifier*>::iterator i = notifiers.begin(); i != notifiers.end(); ++i) {
         delete *i;
     }
 }
 
-CZMQNotificationInterface* CZMQNotificationInterface::CreateWithArguments(const std::map<std::string, std::string> &args)
+CZMQNotificationInterface* CZMQNotificationInterface::CreateWithArguments(const std::map<std::string, std::string>& args)
 {
     CZMQNotificationInterface* notificationInterface = NULL;
     std::map<std::string, CZMQNotifierFactory> factories;
@@ -41,22 +40,19 @@ CZMQNotificationInterface* CZMQNotificationInterface::CreateWithArguments(const 
     factories["pubrawblock"] = CZMQAbstractNotifier::Create<CZMQPublishRawBlockNotifier>;
     factories["pubrawtx"] = CZMQAbstractNotifier::Create<CZMQPublishRawTransactionNotifier>;
 
-    for (std::map<std::string, CZMQNotifierFactory>::const_iterator i=factories.begin(); i!=factories.end(); ++i)
-    {
+    for (std::map<std::string, CZMQNotifierFactory>::const_iterator i = factories.begin(); i != factories.end(); ++i) {
         std::map<std::string, std::string>::const_iterator j = args.find("-zmq" + i->first);
-        if (j!=args.end())
-        {
+        if (j != args.end()) {
             CZMQNotifierFactory factory = i->second;
             std::string address = j->second;
-            CZMQAbstractNotifier *notifier = factory();
+            CZMQAbstractNotifier* notifier = factory();
             notifier->SetType(i->first);
             notifier->SetAddress(address);
             notifiers.push_back(notifier);
         }
     }
 
-    if (!notifiers.empty())
-    {
+    if (!notifiers.empty()) {
         notificationInterface = new CZMQNotificationInterface();
         notificationInterface->notifiers = notifiers;
     }
@@ -72,29 +68,23 @@ bool CZMQNotificationInterface::Initialize()
 
     pcontext = zmq_init(1);
 
-    if (!pcontext)
-    {
+    if (!pcontext) {
         zmqError("Unable to initialize context");
         return false;
     }
 
-    std::list<CZMQAbstractNotifier*>::iterator i=notifiers.begin();
-    for (; i!=notifiers.end(); ++i)
-    {
-        CZMQAbstractNotifier *notifier = *i;
-        if (notifier->Initialize(pcontext))
-        {
+    std::list<CZMQAbstractNotifier*>::iterator i = notifiers.begin();
+    for (; i != notifiers.end(); ++i) {
+        CZMQAbstractNotifier* notifier = *i;
+        if (notifier->Initialize(pcontext)) {
             LogPrint("zmq", "  Notifier %s ready (address = %s)\n", notifier->GetType(), notifier->GetAddress());
-        }
-        else
-        {
+        } else {
             LogPrint("zmq", "  Notifier %s failed (address = %s)\n", notifier->GetType(), notifier->GetAddress());
             break;
         }
     }
 
-    if (i!=notifiers.end())
-    {
+    if (i != notifiers.end()) {
         Shutdown();
         return false;
     }
@@ -106,11 +96,9 @@ bool CZMQNotificationInterface::Initialize()
 void CZMQNotificationInterface::Shutdown()
 {
     LogPrint("zmq", "Shutdown notification interface\n");
-    if (pcontext)
-    {
-        for (std::list<CZMQAbstractNotifier*>::iterator i=notifiers.begin(); i!=notifiers.end(); ++i)
-        {
-            CZMQAbstractNotifier *notifier = *i;
+    if (pcontext) {
+        for (std::list<CZMQAbstractNotifier*>::iterator i = notifiers.begin(); i != notifiers.end(); ++i) {
+            CZMQAbstractNotifier* notifier = *i;
             LogPrint("zmq", "   Shutdown notifier %s at %s\n", notifier->GetType(), notifier->GetAddress());
             notifier->Shutdown();
         }
@@ -120,34 +108,26 @@ void CZMQNotificationInterface::Shutdown()
     }
 }
 
-void CZMQNotificationInterface::UpdatedBlockTip(const CBlockIndex *pindex)
+void CZMQNotificationInterface::UpdatedBlockTip(const CBlockIndex* pindex)
 {
-    for (std::list<CZMQAbstractNotifier*>::iterator i = notifiers.begin(); i!=notifiers.end(); )
-    {
-        CZMQAbstractNotifier *notifier = *i;
-        if (notifier->NotifyBlock(pindex))
-        {
+    for (std::list<CZMQAbstractNotifier*>::iterator i = notifiers.begin(); i != notifiers.end();) {
+        CZMQAbstractNotifier* notifier = *i;
+        if (notifier->NotifyBlock(pindex)) {
             i++;
-        }
-        else
-        {
+        } else {
             notifier->Shutdown();
             i = notifiers.erase(i);
         }
     }
 }
 
-void CZMQNotificationInterface::SyncTransaction(const CTransaction &tx, const CBlock *pblock)
+void CZMQNotificationInterface::SyncTransaction(const CTransaction& tx, const CBlock* pblock)
 {
-    for (std::list<CZMQAbstractNotifier*>::iterator i = notifiers.begin(); i!=notifiers.end(); )
-    {
-        CZMQAbstractNotifier *notifier = *i;
-        if (notifier->NotifyTransaction(tx))
-        {
+    for (std::list<CZMQAbstractNotifier*>::iterator i = notifiers.begin(); i != notifiers.end();) {
+        CZMQAbstractNotifier* notifier = *i;
+        if (notifier->NotifyTransaction(tx)) {
             i++;
-        }
-        else
-        {
+        } else {
             notifier->Shutdown();
             i = notifiers.erase(i);
         }

--- a/src/zmq/zmqnotificationinterface.h
+++ b/src/zmq/zmqnotificationinterface.h
@@ -17,19 +17,19 @@ class CZMQNotificationInterface : public CValidationInterface
 public:
     virtual ~CZMQNotificationInterface();
 
-    static CZMQNotificationInterface* CreateWithArguments(const std::map<std::string, std::string> &args);
+    static CZMQNotificationInterface* CreateWithArguments(const std::map<std::string, std::string>& args);
 
     bool Initialize();
     void Shutdown();
 
 protected: // CValidationInterface
-    void SyncTransaction(const CTransaction &tx, const CBlock *pblock);
-    void UpdatedBlockTip(const CBlockIndex *pindex);
+    void SyncTransaction(const CTransaction& tx, const CBlock* pblock);
+    void UpdatedBlockTip(const CBlockIndex* pindex);
 
 private:
     CZMQNotificationInterface();
 
-    void *pcontext;
+    void* pcontext;
     std::list<CZMQAbstractNotifier*> notifiers;
 };
 

--- a/src/zmq/zmqpublishnotifier.h
+++ b/src/zmq/zmqpublishnotifier.h
@@ -12,32 +12,32 @@ class CBlockIndex;
 class CZMQAbstractPublishNotifier : public CZMQAbstractNotifier
 {
 public:
-    bool Initialize(void *pcontext);
+    bool Initialize(void* pcontext);
     void Shutdown();
 };
 
 class CZMQPublishHashBlockNotifier : public CZMQAbstractPublishNotifier
 {
 public:
-    bool NotifyBlock(const CBlockIndex *pindex);
+    bool NotifyBlock(const CBlockIndex* pindex);
 };
 
 class CZMQPublishHashTransactionNotifier : public CZMQAbstractPublishNotifier
 {
 public:
-    bool NotifyTransaction(const CTransaction &transaction);
+    bool NotifyTransaction(const CTransaction& transaction);
 };
 
 class CZMQPublishRawBlockNotifier : public CZMQAbstractPublishNotifier
 {
 public:
-    bool NotifyBlock(const CBlockIndex *pindex);
+    bool NotifyBlock(const CBlockIndex* pindex);
 };
 
 class CZMQPublishRawTransactionNotifier : public CZMQAbstractPublishNotifier
 {
 public:
-    bool NotifyTransaction(const CTransaction &transaction);
+    bool NotifyTransaction(const CTransaction& transaction);
 };
 
 #endif // BITCOIN_ZMQ_ZMQPUBLISHNOTIFIER_H


### PR DESCRIPTION
Formatting recently added files likely does not create many conflicts.

Reviewers may use
- `contrib/devtools/clang-format.py ~/clang-format-3.6.2  src/bench src/http* src/qt/bantablemodel.* src/test/addrman_tests.cpp src/test/dbwrapper_tests.cpp src/test/streams_tests.cpp src/zmq/zmq*`
- or just any version of clang-format 3.6. to verify the diff.

This will clean up the new files from #6733, #6103, #5677, #6650 and #6315.

---

UPDATE:
I have appended a commit to set `AlignAfterOpenBracket` to `false`.
