### PR TITLE
Mention PHP bindings to libbitcoinconsensus

### DIFF
--- a/doc/shared-libraries.md
+++ b/doc/shared-libraries.md
@@ -41,3 +41,4 @@ The interface is defined in the C header `bitcoinconsensus.h` located in  `src/s
 - [NBitcoin](https://github.com/NicolasDorier/NBitcoin/blob/master/NBitcoin/Script.cs#L814) (.NET Bindings)
 - [node-libbitcoinconsensus](https://github.com/bitpay/node-libbitcoinconsensus) (Node.js Bindings)
 - [java-libbitcoinconsensus](https://github.com/dexX7/java-libbitcoinconsensus) (Java Bindings)
+- [bitcoinconsensus-php](https://github.com/Bit-Wasp/bitcoinconsensus-php) (PHP Bindings)


### PR DESCRIPTION
I wrote these a while ago, there aren't any other PHP bindings as far as I can tell. 
