### PR TITLE
Improve AddToWallet performance when rescanning

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -652,8 +652,12 @@ bool CWallet::AddToWallet(const CWalletTx& wtxIn, bool fFromLoadWallet, CWalletD
                 {
                     int64_t latestNow = wtx.nTimeReceived;
                     int64_t latestEntry = 0;
+                    int64_t blocktime = mapBlockIndex[wtxIn.hashBlock]->GetBlockTime();
+                    // Tolerate times up to the last timestamp in the wallet not more than 5 minutes into the future
+                    // This doesn't apply unless if we're still scanning older blocks
+                    if (latestNow < blocktime)
+
                     {
-                        // Tolerate times up to the last timestamp in the wallet not more than 5 minutes into the future
                         int64_t latestTolerated = latestNow + 300;
                         std::list<CAccountingEntry> acentries;
                         TxItems txOrdered = OrderedTxItems(acentries);
@@ -682,7 +686,6 @@ bool CWallet::AddToWallet(const CWalletTx& wtxIn, bool fFromLoadWallet, CWalletD
                         }
                     }
 
-                    int64_t blocktime = mapBlockIndex[wtxIn.hashBlock]->GetBlockTime();
                     wtx.nTimeSmart = std::max(latestEntry, std::min(blocktime, latestNow));
                 }
                 else

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -653,12 +653,13 @@ bool CWallet::AddToWallet(const CWalletTx& wtxIn, bool fFromLoadWallet, CWalletD
                     int64_t latestNow = wtx.nTimeReceived;
                     int64_t latestEntry = 0;
                     int64_t blocktime = mapBlockIndex[wtxIn.hashBlock]->GetBlockTime();
+
                     // Tolerate times up to the last timestamp in the wallet not more than 5 minutes into the future
                     // This doesn't apply unless if we're still scanning older blocks
-                    if (latestNow < blocktime)
-
+                    int tolerance = 5 * 60;
+                    if (latestNow < blocktime + tolerance)
                     {
-                        int64_t latestTolerated = latestNow + 300;
+                        int64_t latestTolerated = latestNow + tolerance;
                         std::list<CAccountingEntry> acentries;
                         TxItems txOrdered = OrderedTxItems(acentries);
                         for (TxItems::reverse_iterator it = txOrdered.rbegin(); it != txOrdered.rend(); ++it)


### PR DESCRIPTION
Large performance improvement when adding transactions if the client is not currently at the tip of the blockchain. This particularly improves wallet rescan times, including following from a zapwallettxes.

In AddToWallet, two large indices are created over the wallet in order to make an estimate of the time a wallet transaction was created. This is slow anyway (possibly subject to a further fix) but also unnecessary if we are not at the tip because we just default to the block time. This patch skips the rescan code if we were going to fall back to the block time anyway, so shouldn't change the logic.

On a wallet with around 180,000 keys (500 MB, so pretty large) this sped up the resync time 20x from about 10 hours to 30 minutes.
