### PR TITLE
build: make sure OpenSSL heeds noexecstack

### DIFF
--- a/depends/packages/openssl.mk
+++ b/depends/packages/openssl.mk
@@ -10,7 +10,7 @@ $(package)_config_opts=--prefix=$(host_prefix) --openssldir=$(host_prefix)/etc/o
 $(package)_config_opts+=no-krb5 no-camellia no-capieng no-cast no-cms no-dtls1 no-gost no-gmp no-heartbeats no-idea no-jpake no-md2
 $(package)_config_opts+=no-mdc2 no-rc5 no-rdrand no-rfc3779 no-rsax no-sctp no-seed no-sha0 no-static_engine no-whirlpool no-rc2 no-rc4 no-ssl2 no-ssl3
 $(package)_config_opts+=$($(package)_cflags) $($(package)_cppflags)
-$(package)_config_opts_linux=-fPIC
+$(package)_config_opts_linux=-fPIC -Wa,--noexecstack
 $(package)_config_opts_x86_64_linux=linux-x86_64
 $(package)_config_opts_i686_linux=linux-generic32
 $(package)_config_opts_arm_linux=linux-generic32


### PR DESCRIPTION
This passes `-Wa,--noexecstack` to the assembler when building platform-specific assembly files, to signal that a non-executable stack can be used. This is the same approach as used by Debian on all platforms (see https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=430583)
