### PR TITLE
[REST] API versioning

### DIFF
--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -607,6 +607,15 @@ static const struct {
       {"/rest/mempool/contents", rest_mempool_contents},
       {"/rest/headers/", rest_headers},
       {"/rest/getutxos", rest_getutxos},
+
+      {"/rest/v1/tx/", rest_tx},
+      {"/rest/v1/block/notxdetails/", rest_block_notxdetails},
+      {"/rest/v1/block/", rest_block_extended},
+      {"/rest/v1/chaininfo", rest_chaininfo},
+      {"/rest/v1/mempool/info", rest_mempool_info},
+      {"/rest/v1/mempool/contents", rest_mempool_contents},
+      {"/rest/v1/headers/", rest_headers},
+      {"/rest/v1/getutxos", rest_getutxos},
 };
 
 bool StartREST()


### PR DESCRIPTION
> .. API client developers can choose to either:
> - develop against the latest one (committing themselves to maintain the application protecting it from eventual API changes that might break their badly designed API client).
> - bind to a specific version of the API (which becomes apparent) but only for a limited time

From http://stackoverflow.com/a/398564

Unfortunately there is no standard when it comes to REST API versioning, but the way it's recommended in this Stackoverflow post makes sense to me.

@jonasschnelli brought up that since Bitcoin Core itself isn't version 1.0 people don't expect a stable REST API. Hard to say if that is the case, but since it's definitely widely used it don't think we should break backwards compatibility too easily. And those who don't want / need it can use the first option.
