### PR TITLE
Do not allow block file pruning during reindex.

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1498,10 +1498,10 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     // if pruning, unset the service bit and perform the initial blockstore prune
     // after any wallet rescanning has taken place.
     if (fPruneMode) {
-        uiInterface.InitMessage(_("Pruning blockstore..."));
         LogPrintf("Unsetting NODE_NETWORK on prune mode\n");
         nLocalServices &= ~NODE_NETWORK;
         if (!fReindex) {
+            uiInterface.InitMessage(_("Pruning blockstore..."));
             PruneAndFlush();
         }
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1881,7 +1881,7 @@ bool static FlushStateToDisk(CValidationState &state, FlushStateMode mode) {
     std::set<int> setFilesToPrune;
     bool fFlushForPrune = false;
     try {
-    if (fPruneMode && fCheckForPruning) {
+    if (fPruneMode && fCheckForPruning && !fReindex) {
         FindFilesToPrune(setFilesToPrune);
         fCheckForPruning = false;
         if (!setFilesToPrune.empty()) {


### PR DESCRIPTION
It's not safe to prune during a reindex, as there may be blocks in earlier files that have not yet been processed if they were out of order.  Those files could be accidentally deleted.  
Since undo files are regenerated during reindex, this allocation of disk space could cause pruning to be triggered.

@laanwj I thought I was just adding a belt and suspenders check here, but turns out it can and will happen.  This should be backported to 0.11.

Also, clarify startup message that an initial pruning of the block store doesn't happen if reindexing.
