### PR TITLE
Require nLastBlockFile to be the highest numbered file.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2503,7 +2503,7 @@ bool FindBlockPos(CValidationState &state, CDiskBlockPos &pos, unsigned int nAdd
         pos.nPos = vinfoBlockFile[nFile].nSize;
     }
 
-    nLastBlockFile = nFile;
+    nLastBlockFile = std::max(nLastBlockFile, (int)nFile);
     vinfoBlockFile[nFile].AddBlock(nHeight, nTime);
     if (fKnown)
         vinfoBlockFile[nFile].nSize = std::max(pos.nPos + nAddSize, vinfoBlockFile[nFile].nSize);


### PR DESCRIPTION
nLastBlockFile is used to determine which block file new blocks are written to.  During a reindex, it could previously hop around if the tip of the active chain was not always in the highest numbered block file encountered so far.

There is not a known problem with the existing behavior, but I think the semantics of having nLastBlockFile actually refer to the highest number file and not just the one in which the latest tip was found during a reindex makes sense.  The difference in behavior is that during a reindex with corrupted or out of order data:
- in the old code, nLastBlockFile will point to the block file with the last valid block (chainActive.Tip())
- after this pull, nLastBlockFile will point to the highest numbered block file which contains a valid block (on chainActive).
  Future block writes will start looking at nLastBlockFile and increment it until they find a block file with unused space enough for the write.

@sipa, I don't know if you think its worth the review time to verify this doesn't mess anything up.  But I find the logic confusing as is.
