### PR TITLE
Drop minRelayTxFee to 1000

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -75,7 +75,7 @@ uint64_t nPruneTarget = 0;
 bool fAlerts = DEFAULT_ALERTS;
 
 /** Fees smaller than this (in satoshi) are considered zero fee (for relaying and mining) */
-CFeeRate minRelayTxFee = CFeeRate(5000);
+CFeeRate minRelayTxFee = CFeeRate(1000);
 
 CTxMemPool mempool(::minRelayTxFee);
 


### PR DESCRIPTION
Raising the `minRelayTxFee` to 5000 was controversial among some developers. Likely the temporal bump for the .10 and .11 branches won't be needed in the .12 branch, so resetting the fee to 1000 may be the right thing to do.
