### PR TITLE
Fix chainstate serialized_size computation

### DIFF
--- a/qa/rpc-tests/blockchain.py
+++ b/qa/rpc-tests/blockchain.py
@@ -43,7 +43,7 @@ class BlockchainTest(BitcoinTestFramework):
         assert_equal(res[u'transactions'], 200)
         assert_equal(res[u'height'], 200)
         assert_equal(res[u'txouts'], 200)
-        assert_equal(res[u'bytes_serialized'], 13000),
+        assert_equal(res[u'bytes_serialized'], 13924),
         assert_equal(len(res[u'bestblock']), 64)
         assert_equal(len(res[u'hash_serialized']), 64)
 

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -121,7 +121,7 @@ bool CCoinsViewDB::GetStats(CCoinsStats &stats) const {
                         nTotalAmount += out.nValue;
                     }
                 }
-                stats.nSerializedSize += 32 + pcursor->GetKeySize();
+                stats.nSerializedSize += 32 + pcursor->GetValueSize();
                 ss << VARINT(0);
             } else {
                 return error("CCoinsViewDB::GetStats() : unable to read value");


### PR DESCRIPTION
This was introduced in #6650 by a cherry-picked commit of mine.
