### PR TITLE
rpc: Add maxmempool and effective min fee to getmempoolinfo

### DIFF
--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -772,6 +772,9 @@ UniValue mempoolInfoToJSON()
     ret.push_back(Pair("size", (int64_t) mempool.size()));
     ret.push_back(Pair("bytes", (int64_t) mempool.GetTotalTxSize()));
     ret.push_back(Pair("usage", (int64_t) mempool.DynamicMemoryUsage()));
+    size_t maxmempool = GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000;
+    ret.push_back(Pair("maxmempool", (int64_t) maxmempool));
+    ret.push_back(Pair("mempoolminfee", ValueFromAmount(mempool.GetMinFee(maxmempool).GetFeePerK())));
 
     return ret;
 }


### PR DESCRIPTION
I think these can be useful.

Context: lots of these in my log

```
2015-10-23 06:19:39 b84b52b021d6703dacb85c73b799a232ce6ae1ef7d3a3945c3d2899fc067d642 from peer=7929 was not accepted: mempool min fee not met, 15000 < 20424 (code 66)
```

Which doesn't give information about the transaction size, so can't reason back to what the effective  minfee was.
