### PR TITLE
New -logtimerelative option to do millisec debug.log timestamps

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -426,6 +426,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-help-debug", _("Show all debugging options (usage: --help -help-debug)"));
     strUsage += HelpMessageOpt("-logips", strprintf(_("Include IP addresses in debug output (default: %u)"), 0));
     strUsage += HelpMessageOpt("-logtimestamps", strprintf(_("Prepend debug output with timestamp (default: %u)"), 1));
+    strUsage += HelpMessageOpt("-logtimerelative", _("Output millisecond-accurate debug output timestamps relative to given seconds-since-epoch timestamp (default: current time)"));
     if (showDebug)
     {
         strUsage += HelpMessageOpt("-limitfreerelay=<n>", strprintf("Continuously rate-limit free transactions to <n>*1000 bytes per minute (default: %u)", 15));
@@ -724,6 +725,11 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
 
     // Set this early so that parameter interactions go to console
     fPrintToConsole = GetBoolArg("-printtoconsole", false);
+    if (mapArgs.count("-logtimerelative")) {
+        nLogTimestampStart = 1000*GetArg("-logtimerelative", 0);
+        if (nLogTimestampStart == 0) nLogTimestampStart = GetTimeMillis();
+        fLogTimestamps = true;
+    }
     fLogTimestamps = GetBoolArg("-logtimestamps", true);
     fLogIPs = GetBoolArg("-logips", false);
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -108,6 +108,7 @@ bool fDaemon = false;
 bool fServer = false;
 string strMiscWarning;
 bool fLogTimestamps = false;
+int64_t nLogTimestampStart = -1;
 bool fLogIPs = false;
 volatile bool fReopenDebugLog = false;
 CTranslationInterface translationInterface;
@@ -263,8 +264,17 @@ static std::string LogTimestampStr(const std::string &str, bool *fStartedNewLine
     if (!fLogTimestamps)
         return str;
 
-    if (*fStartedNewLine)
-        strStamped =  DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()) + ' ' + str;
+    if (*fStartedNewLine) {
+        if (nLogTimestampStart != -1) {
+            // Relative times in seconds.milliseconds
+            int64_t t = GetTimeMillis()-nLogTimestampStart;
+            strStamped = strprintf("%d.%03d ", t/1000, t%1000) + str;
+        }
+        else {
+            // Absolute date/time
+            strStamped =  DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()) + ' ' + str;
+        }
+    }
     else
         strStamped = str;
 

--- a/src/util.h
+++ b/src/util.h
@@ -44,6 +44,7 @@ extern bool fPrintToDebugLog;
 extern bool fServer;
 extern std::string strMiscWarning;
 extern bool fLogTimestamps;
+extern int64_t nLogTimestampStart; // milliseconds
 extern bool fLogIPs;
 extern volatile bool fReopenDebugLog;
 extern CTranslationInterface translationInterface;


### PR DESCRIPTION
I used this with -debug=net to measure message propagation across the Internet.

To test:

bitcoind -printtoconsole -regtest -logtimerelative
  ... you'll get seconds.milliseconds timestamps

bitcoind -printtoconsole -regtest -logtimerelative=1445598671
  ... you'll get msec timestamps relative to 2015-10-23 11:11:11 GMT

Setting the relative time is useful to directly compare debug.log
timings from multiple bitcoind processes running on one machine
(or from machines that have highly synchronized clocks).
