### PR TITLE
Clear strMiscWarning before running PartitionAlert

### DIFF
--- a/src/test/alert_tests.cpp
+++ b/src/test/alert_tests.cpp
@@ -217,10 +217,12 @@ BOOST_AUTO_TEST_CASE(PartitionAlert)
         // use them
     }
 
+    strMiscWarning = "";
+
     // Test 1: chain with blocks every nPowTargetSpacing seconds,
     // as normal, no worries:
     PartitionCheck(falseFunc, csDummy, &indexDummy[99], nPowTargetSpacing);
-    BOOST_CHECK(strMiscWarning.empty());
+    BOOST_CHECK_MESSAGE(strMiscWarning.empty(), strMiscWarning);
 
     // Test 2: go 3.5 hours without a block, expect a warning:
     now += 3*60*60+30*60;


### PR DESCRIPTION
I was getting strange travis errors earlier because some test that was running prior to PartitionAlert in alert_tests apparently was setting the strMiscWarning variable. Using a side effect such as this as an error handling mechanism is probably not a very good idea to begin with...but if we're going to do this, we should make sure to reset the variable before each call so we can tell which one set it.

Note: The implication here is that something before the call on line 224 is setting this variable and we can't easily figure out what it is...which should probably also be fixed.
