### PR TITLE
Make -checkmempool=1 not fail through int32 overflow

### DIFF
--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -360,7 +360,7 @@ public:
      * check does nothing.
      */
     void check(const CCoinsViewCache *pcoins) const;
-    void setSanityCheck(double dFrequency = 1.0) { nCheckFrequency = dFrequency * 4294967296.0; }
+    void setSanityCheck(double dFrequency = 1.0) { nCheckFrequency = dFrequency * 4294967295.0; }
 
     // addUnchecked must updated state for all ancestors of a given transaction,
     // to track size/count of descendant transactions.  First version of


### PR DESCRIPTION
Fix a bug in #6776 discovered by @gmaxwell: -checkmempool=1 causes the internal 32-bit variable to overflow to zero.
