### PR TITLE
Add explicit shared_ptr constructor due to C++11 error

### DIFF
--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -563,7 +563,7 @@ void RPCRunLater(const std::string& name, boost::function<void(void)> func, int6
     deadlineTimers.erase(name);
     RPCTimerInterface* timerInterface = timerInterfaces[0];
     LogPrint("rpc", "queue run of timer %s in %i seconds (using %s)\n", name, nSeconds, timerInterface->Name());
-    deadlineTimers.insert(std::make_pair(name, timerInterface->NewTimer(func, nSeconds*1000)));
+    deadlineTimers.insert(std::make_pair(name, boost::shared_ptr<RPCTimerBase>(timerInterface->NewTimer(func, nSeconds*1000))));
 }
 
 const CRPCTable tableRPC;


### PR DESCRIPTION
Clean up some warnings (and one error) when compiling in C++11 mode with g++ and clang.  Details:
- -Wno-self-assign is no longer a valid warning to disable
- All the stuff in leveldb is cases of comparison between signed and unsigned
- The change in rpcserver.cpp is an error with gcc 5.2, apparently older versions can do an automatic conversion here but in C++11 mode it needs an explicit conversion to shared_ptr.

There are other warnings due to a few uses of std::auto_ptr which is deprecated.  When we switch to compiling in C++11 mode by default, we'll have to convert these to std::unique_ptr, but this is a non-backwards compatible change so can't be done now.
