### PR TITLE
Add pre-allocated vector type and use it for CScript

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -125,6 +125,7 @@ BITCOIN_CORE_H = \
   policy/fees.h \
   policy/policy.h \
   pow.h \
+  prevector.h \
   primitives/block.h \
   primitives/transaction.h \
   protocol.h \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -64,6 +64,7 @@ BITCOIN_TESTS =\
   test/pmt_tests.cpp \
   test/policyestimator_tests.cpp \
   test/pow_tests.cpp \
+  test/prevector_tests.cpp \
   test/reverselock_tests.cpp \
   test/rpc_tests.cpp \
   test/sanity_tests.cpp \

--- a/src/core_memusage.h
+++ b/src/core_memusage.h
@@ -10,7 +10,7 @@
 #include "memusage.h"
 
 static inline size_t RecursiveDynamicUsage(const CScript& script) {
-    return memusage::DynamicUsage(*static_cast<const std::vector<unsigned char>*>(&script));
+    return memusage::DynamicUsage(*static_cast<const CScriptBase*>(&script));
 }
 
 static inline size_t RecursiveDynamicUsage(const COutPoint& out) {

--- a/src/hash.h
+++ b/src/hash.h
@@ -8,6 +8,7 @@
 
 #include "crypto/ripemd160.h"
 #include "crypto/sha256.h"
+#include "prevector.h"
 #include "serialize.h"
 #include "uint256.h"
 #include "version.h"
@@ -114,6 +115,13 @@ inline uint160 Hash160(const T1 pbegin, const T1 pend)
 
 /** Compute the 160-bit hash of a vector. */
 inline uint160 Hash160(const std::vector<unsigned char>& vch)
+{
+    return Hash160(vch.begin(), vch.end());
+}
+
+/** Compute the 160-bit hash of a vector. */
+template<unsigned int N>
+inline uint160 Hash160(const prevector<N, unsigned char>& vch)
 {
     return Hash160(vch.begin(), vch.end());
 }

--- a/src/memusage.h
+++ b/src/memusage.h
@@ -46,7 +46,9 @@ template<typename X> static inline size_t DynamicUsage(const X * const &v) { ret
 static inline size_t MallocUsage(size_t alloc)
 {
     // Measured on libc6 2.19 on Linux.
-    if (sizeof(void*) == 8) {
+    if (alloc == 0) {
+        return 0;
+    } else if (sizeof(void*) == 8) {
         return ((alloc + 31) >> 4) << 4;
     } else if (sizeof(void*) == 4) {
         return ((alloc + 15) >> 3) << 3;
@@ -72,6 +74,12 @@ template<typename X>
 static inline size_t DynamicUsage(const std::vector<X>& v)
 {
     return MallocUsage(v.capacity() * sizeof(X));
+}
+
+template<unsigned int N, typename X, typename S, typename D>
+static inline size_t DynamicUsage(const prevector<N, X, S, D>& v)
+{
+    return MallocUsage(v.allocated_memory());
 }
 
 template<typename X, typename Y>

--- a/src/prevector.h
+++ b/src/prevector.h
@@ -1,0 +1,486 @@
+#ifndef _BITCOIN_PREVECTOR_H_
+#define _BITCOIN_PREVECTOR_H_
+
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+
+#include <iterator>
+
+#pragma pack(push, 1)
+/** Implements a drop-in replacement for std::vector<T> which stores up to N
+ *  elements directly (without heap allocation). The types Size and Diff are
+ *  used to store element counts, and can be any unsigned + signed type.
+ *
+ *  Storage layout is either:
+ *  - Direct allocation:
+ *    - Size _size: the number of used elements (between 0 and N)
+ *    - T direct[N]: an array of N elements of type T
+ *      (only the first _size are initialized).
+ *  - Indirect allocation:
+ *    - Size _size: the number of used elements plus N + 1
+ *    - Size capacity: the number of allocated elements
+ *    - T* indirect: a pointer to an array of capacity elements of type T
+ *      (only the first _size are initialized).
+ *
+ *  The data type T must be movable by memmove/realloc(). Once we switch to C++,
+ *  move constructors can be used instead.
+ */
+template<unsigned int N, typename T, typename Size = uint32_t, typename Diff = int32_t>
+class prevector {
+public:
+    typedef Size size_type;
+    typedef Diff difference_type;
+    typedef T value_type;
+    typedef value_type& reference;
+    typedef const value_type& const_reference;
+    typedef value_type* pointer;
+    typedef const value_type* const_pointer;
+
+    class iterator {
+        T* ptr;
+    public:
+        typedef Diff difference_type;
+        typedef T value_type;
+        typedef T* pointer;
+        typedef T& reference;
+        typedef std::random_access_iterator_tag iterator_category;
+        iterator(T* ptr_) : ptr(ptr_) {}
+        T& operator*() const { return *ptr; }
+        T* operator->() const { return ptr; }
+        T& operator[](size_type pos) { return ptr[pos]; }
+        const T& operator[](size_type pos) const { return ptr[pos]; }
+        iterator& operator++() { ptr++; return *this; }
+        iterator& operator--() { ptr--; return *this; }
+        iterator operator++(int) { iterator copy(*this); ++(*this); return copy; }
+        iterator operator--(int) { iterator copy(*this); --(*this); return copy; }
+        difference_type friend operator-(iterator a, iterator b) { return (&(*a) - &(*b)); }
+        iterator operator+(size_type n) { return iterator(ptr + n); }
+        iterator& operator+=(size_type n) { ptr += n; return *this; }
+        iterator operator-(size_type n) { return iterator(ptr - n); }
+        iterator& operator-=(size_type n) { ptr -= n; return *this; }
+        bool operator==(iterator x) const { return ptr == x.ptr; }
+        bool operator!=(iterator x) const { return ptr != x.ptr; }
+        bool operator>=(iterator x) const { return ptr >= x.ptr; }
+        bool operator<=(iterator x) const { return ptr <= x.ptr; }
+        bool operator>(iterator x) const { return ptr > x.ptr; }
+        bool operator<(iterator x) const { return ptr < x.ptr; }
+    };
+
+    class reverse_iterator {
+        T* ptr;
+    public:
+        typedef Diff difference_type;
+        typedef T value_type;
+        typedef T* pointer;
+        typedef T& reference;
+        typedef std::bidirectional_iterator_tag iterator_category;
+        reverse_iterator(T* ptr_) : ptr(ptr_) {}
+        T& operator*() { return *ptr; }
+        const T& operator*() const { return *ptr; }
+        T* operator->() { return ptr; }
+        const T* operator->() const { return ptr; }
+        reverse_iterator& operator--() { ptr++; return *this; }
+        reverse_iterator& operator++() { ptr--; return *this; }
+        reverse_iterator operator++(int) { reverse_iterator copy(*this); ++(*this); return copy; }
+        reverse_iterator operator--(int) { reverse_iterator copy(*this); --(*this); return copy; }
+        bool operator==(reverse_iterator x) const { return ptr == x.ptr; }
+        bool operator!=(reverse_iterator x) const { return ptr != x.ptr; }
+    };
+
+    class const_iterator {
+        const T* ptr;
+    public:
+        typedef Diff difference_type;
+        typedef const T value_type;
+        typedef const T* pointer;
+        typedef const T& reference;
+        typedef std::random_access_iterator_tag iterator_category;
+        const_iterator(const T* ptr_) : ptr(ptr_) {}
+        const_iterator(iterator x) : ptr(&(*x)) {}
+        const T& operator*() const { return *ptr; }
+        const T* operator->() const { return ptr; }
+        const T& operator[](size_type pos) const { return ptr[pos]; }
+        const_iterator& operator++() { ptr++; return *this; }
+        const_iterator& operator--() { ptr--; return *this; }
+        const_iterator operator++(int) { const_iterator copy(*this); ++(*this); return copy; }
+        const_iterator operator--(int) { const_iterator copy(*this); --(*this); return copy; }
+        difference_type friend operator-(const_iterator a, const_iterator b) { return (&(*a) - &(*b)); }
+        const_iterator operator+(size_type n) { return const_iterator(ptr + n); }
+        const_iterator& operator+=(size_type n) { ptr += n; return *this; }
+        const_iterator operator-(size_type n) { return const_iterator(ptr - n); }
+        const_iterator& operator-=(size_type n) { ptr -= n; return *this; }
+        bool operator==(const_iterator x) const { return ptr == x.ptr; }
+        bool operator!=(const_iterator x) const { return ptr != x.ptr; }
+        bool operator>=(const_iterator x) const { return ptr >= x.ptr; }
+        bool operator<=(const_iterator x) const { return ptr <= x.ptr; }
+        bool operator>(const_iterator x) const { return ptr > x.ptr; }
+        bool operator<(const_iterator x) const { return ptr < x.ptr; }
+    };
+
+    class const_reverse_iterator {
+        const T* ptr;
+    public:
+        typedef Diff difference_type;
+        typedef const T value_type;
+        typedef const T* pointer;
+        typedef const T& reference;
+        typedef std::bidirectional_iterator_tag iterator_category;
+        const_reverse_iterator(T* ptr_) : ptr(ptr_) {}
+        const_reverse_iterator(reverse_iterator x) : ptr(&(*x)) {}
+        const T& operator*() const { return *ptr; }
+        const T* operator->() const { return ptr; }
+        const_reverse_iterator& operator--() { ptr++; return *this; }
+        const_reverse_iterator& operator++() { ptr--; return *this; }
+        const_reverse_iterator operator++(int) { const_reverse_iterator copy(*this); ++(*this); return copy; }
+        const_reverse_iterator operator--(int) { const_reverse_iterator copy(*this); --(*this); return copy; }
+        bool operator==(const_reverse_iterator x) const { return ptr == x.ptr; }
+        bool operator!=(const_reverse_iterator x) const { return ptr != x.ptr; }
+    };
+
+private:
+    size_type _size;
+    union {
+        char direct[sizeof(T) * N];
+        struct {
+            size_type capacity;
+            char* indirect;
+        };
+    } _union;
+
+    T* direct_ptr(difference_type pos) { return reinterpret_cast<T*>(_union.direct) + pos; }
+    const T* direct_ptr(difference_type pos) const { return reinterpret_cast<const T*>(_union.direct) + pos; }
+    T* indirect_ptr(difference_type pos) { return reinterpret_cast<T*>(_union.indirect) + pos; }
+    const T* indirect_ptr(difference_type pos) const { return reinterpret_cast<const T*>(_union.indirect) + pos; }
+    bool is_direct() const { return _size <= N; }
+
+    void change_capacity(size_type new_capacity) {
+        if (new_capacity <= N) {
+            if (!is_direct()) {
+                T* indirect = indirect_ptr(0);
+                T* src = indirect;
+                T* dst = direct_ptr(0);
+                memcpy(dst, src, size() * sizeof(T));
+                free(indirect);
+                _size -= N + 1;
+            }
+        } else {
+            if (!is_direct()) {
+                _union.indirect = static_cast<char*>(realloc(_union.indirect, ((size_t)sizeof(T)) * new_capacity));
+                _union.capacity = new_capacity;
+            } else {
+                char* new_indirect = static_cast<char*>(malloc(((size_t)sizeof(T)) * new_capacity));
+                T* src = direct_ptr(0);
+                T* dst = reinterpret_cast<T*>(new_indirect);
+                memcpy(dst, src, size() * sizeof(T));
+                _union.indirect = new_indirect;
+                _union.capacity = new_capacity;
+                _size += N + 1;
+            }
+        }
+    }
+
+    T* item_ptr(difference_type pos) { return is_direct() ? direct_ptr(pos) : indirect_ptr(pos); }
+    const T* item_ptr(difference_type pos) const { return is_direct() ? direct_ptr(pos) : indirect_ptr(pos); }
+
+public:
+    void assign(size_type n, const T& val) {
+        clear();
+        if (capacity() < n) {
+            change_capacity(n);
+        }
+        while (size() < n) {
+            _size++;
+            new(static_cast<void*>(item_ptr(size() - 1))) T(val);
+        }
+    }
+
+    template<typename InputIterator>
+    void assign(InputIterator first, InputIterator last) {
+        size_type n = last - first;
+        clear();
+        if (capacity() < n) {
+            change_capacity(n);
+        }
+        while (first != last) {
+            _size++;
+            new(static_cast<void*>(item_ptr(size() - 1))) T(*first);
+            ++first;
+        }
+    }
+
+    prevector() : _size(0) {}
+
+    explicit prevector(size_type n) : _size(0) {
+        resize(n);
+    }
+
+    explicit prevector(size_type n, const T& val = T()) : _size(0) {
+        change_capacity(n);
+        while (size() < n) {
+            _size++;
+            new(static_cast<void*>(item_ptr(size() - 1))) T(val);
+        }
+    }
+
+    template<typename InputIterator>
+    prevector(InputIterator first, InputIterator last) : _size(0) {
+        size_type n = last - first;
+        change_capacity(n);
+        while (first != last) {
+            _size++;
+            new(static_cast<void*>(item_ptr(size() - 1))) T(*first);
+            ++first;
+        }
+    }
+
+    prevector(const prevector<N, T, Size, Diff>& other) : _size(0) {
+        change_capacity(other.size());
+        const_iterator it = other.begin();
+        while (it != other.end()) {
+            _size++;
+            new(static_cast<void*>(item_ptr(size() - 1))) T(*it);
+            ++it;
+        }
+    }
+
+    prevector& operator=(const prevector<N, T, Size, Diff>& other) {
+        if (&other == this) {
+            return *this;
+        }
+        resize(0);
+        change_capacity(other.size());
+        const_iterator it = other.begin();
+        while (it != other.end()) {
+            _size++;
+            new(static_cast<void*>(item_ptr(size() - 1))) T(*it);
+            ++it;
+        }
+        return *this;
+    }
+
+    size_type size() const {
+        return is_direct() ? _size : _size - N - 1;
+    }
+
+    bool empty() const {
+        return size() == 0;
+    }
+
+    iterator begin() { return iterator(item_ptr(0)); }
+    const_iterator begin() const { return const_iterator(item_ptr(0)); }
+    iterator end() { return iterator(item_ptr(size())); }
+    const_iterator end() const { return const_iterator(item_ptr(size())); }
+
+    reverse_iterator rbegin() { return reverse_iterator(item_ptr(size() - 1)); }
+    const_reverse_iterator rbegin() const { return const_reverse_iterator(item_ptr(size() - 1)); }
+    reverse_iterator rend() { return reverse_iterator(item_ptr(-1)); }
+    const_reverse_iterator rend() const { return const_reverse_iterator(item_ptr(-1)); }
+
+    size_t capacity() const {
+        if (is_direct()) {
+            return N;
+        } else {
+            return _union.capacity;
+        }
+    }
+
+    T& operator[](size_type pos) {
+        return *item_ptr(pos);
+    }
+
+    const T& operator[](size_type pos) const {
+        return *item_ptr(pos);
+    }
+
+    void resize(size_type new_size) {
+        while (size() > new_size) {
+            item_ptr(size() - 1)->~T();
+            _size--;
+        }
+        if (new_size > capacity()) {
+            change_capacity(new_size);
+        }
+        while (size() < new_size) {
+            _size++;
+            new(static_cast<void*>(item_ptr(size() - 1))) T();
+        }
+    }
+
+    void reserve(size_type new_capacity) {
+        if (new_capacity > capacity()) {
+            change_capacity(new_capacity);
+        }
+    }
+
+    void shrink_to_fit() {
+        change_capacity(size());
+    }
+
+    void clear() {
+        resize(0);
+    }
+
+    iterator insert(iterator pos, const T& value) {
+        size_type p = pos - begin();
+        size_type new_size = size() + 1;
+        if (capacity() < new_size) {
+            change_capacity(new_size + (new_size >> 1));
+        }
+        memmove(item_ptr(p + 1), item_ptr(p), (size() - p) * sizeof(T));
+        _size++;
+        new(static_cast<void*>(item_ptr(p))) T(value);
+        return iterator(item_ptr(p));
+    }
+
+    void insert(iterator pos, size_type count, const T& value) {
+        size_type p = pos - begin();
+        size_type new_size = size() + count;
+        if (capacity() < new_size) {
+            change_capacity(new_size + (new_size >> 1));
+        }
+        memmove(item_ptr(p + count), item_ptr(p), (size() - p) * sizeof(T));
+        _size += count;
+        for (size_type i = 0; i < count; i++) {
+            new(static_cast<void*>(item_ptr(p + i))) T(value);
+        }
+    }
+
+    template<typename InputIterator>
+    void insert(iterator pos, InputIterator first, InputIterator last) {
+        size_type p = pos - begin();
+        difference_type count = last - first;
+        size_type new_size = size() + count;
+        if (capacity() < new_size) {
+            change_capacity(new_size + (new_size >> 1));
+        }
+        memmove(item_ptr(p + count), item_ptr(p), (size() - p) * sizeof(T));
+        _size += count;
+        while (first != last) {
+            new(static_cast<void*>(item_ptr(p))) T(*first);
+            ++p;
+            ++first;
+        }
+    }
+
+    iterator erase(iterator pos) {
+        (*pos).~T();
+        memmove(&(*pos), &(*pos) + 1, ((char*)&(*end())) - ((char*)(1 + &(*pos))));
+        _size--;
+        return pos;
+    }
+
+    iterator erase(iterator first, iterator last) {
+        iterator p = first;
+        char* endp = (char*)&(*end());
+        while (p != last) {
+            (*p).~T();
+            _size--;
+            ++p;
+        }
+        memmove(&(*first), &(*last), endp - ((char*)(&(*last))));
+        return first;
+    }
+
+    void push_back(const T& value) {
+        size_type new_size = size() + 1;
+        if (capacity() < new_size) {
+            change_capacity(new_size + (new_size >> 1));
+        }
+        new(item_ptr(size())) T(value);
+        _size++;
+    }
+
+    void pop_back() {
+        _size--;
+    }
+
+    T& front() {
+        return *item_ptr(0);
+    }
+
+    const T& front() const {
+        return *item_ptr(0);
+    }
+
+    T& back() {
+        return *item_ptr(size() - 1);
+    }
+
+    const T& back() const {
+        return *item_ptr(size() - 1);
+    }
+
+    void swap(prevector<N, T, Size, Diff>& other) {
+        if (_size & other._size & 1) {
+            std::swap(_union.capacity, other._union.capacity);
+            std::swap(_union.indirect, other._union.indirect);
+        } else {
+            std::swap(_union, other._union);
+        }
+        std::swap(_size, other._size);
+    }
+
+    ~prevector() {
+        clear();
+        if (!is_direct()) {
+            free(_union.indirect);
+            _union.indirect = NULL;
+        }
+    }
+
+    bool operator==(const prevector<N, T, Size, Diff>& other) const {
+        if (other.size() != size()) {
+            return false;
+        }
+        const_iterator b1 = begin();
+        const_iterator b2 = other.begin();
+        const_iterator e1 = end();
+        while (b1 != e1) {
+            if ((*b1) != (*b2)) {
+                return false;
+            }
+            ++b1;
+            ++b2;
+        }
+        return true;
+    }
+
+    bool operator!=(const prevector<N, T, Size, Diff>& other) const {
+        return !(*this == other);
+    }
+
+    bool operator<(const prevector<N, T, Size, Diff>& other) const {
+        if (size() < other.size()) {
+            return true;
+        }
+        if (size() > other.size()) {
+            return false;
+        }
+        const_iterator b1 = begin();
+        const_iterator b2 = other.begin();
+        const_iterator e1 = end();
+        while (b1 != e1) {
+            if ((*b1) < (*b2)) {
+                return true;
+            }
+            if ((*b2) < (*b1)) {
+                return false;
+            }
+            ++b1;
+            ++b2;
+        }
+        return false;
+    }
+
+    size_t allocated_memory() const {
+        if (is_direct()) {
+            return 0;
+        } else {
+            return ((size_t)(sizeof(T))) * _union.capacity;
+        }
+    }
+};
+#pragma pack(pop)
+
+#endif

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -74,7 +74,7 @@ public:
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
         READWRITE(prevout);
-        READWRITE(scriptSig);
+        READWRITE(*(CScriptBase*)(&scriptSig));
         READWRITE(nSequence);
     }
 
@@ -119,7 +119,7 @@ public:
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
         READWRITE(nValue);
-        READWRITE(scriptPubKey);
+        READWRITE(*(CScriptBase*)(&scriptPubKey));
     }
 
     void SetNull()

--- a/src/qt/paymentrequestplus.cpp
+++ b/src/qt/paymentrequestplus.cpp
@@ -201,7 +201,7 @@ QList<std::pair<CScript,CAmount> > PaymentRequestPlus::getPayTo() const
         const unsigned char* scriptStr = (const unsigned char*)details.outputs(i).script().data();
         CScript s(scriptStr, scriptStr+details.outputs(i).script().size());
 
-        result.append(make_pair(s, details.outputs(i).amount()));
+        result.append(std::make_pair(s, details.outputs(i).amount()));
     }
     return result;
 }

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -1032,7 +1032,7 @@ public:
         // Serialize the script
         if (nInput != nIn)
             // Blank out other inputs' signatures
-            ::Serialize(s, CScript(), nType, nVersion);
+            ::Serialize(s, CScriptBase(), nType, nVersion);
         else
             SerializeScriptCode(s, nType, nVersion);
         // Serialize the nSequence

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -205,9 +205,9 @@ bool CScript::IsPayToScriptHash() const
 {
     // Extra-fast test for pay-to-script-hash CScripts:
     return (this->size() == 23 &&
-            this->at(0) == OP_HASH160 &&
-            this->at(1) == 0x14 &&
-            this->at(22) == OP_EQUAL);
+            (*this)[0] == OP_HASH160 &&
+            (*this)[1] == 0x14 &&
+            (*this)[22] == OP_EQUAL);
 }
 
 bool CScript::IsPushOnly(const_iterator pc) const

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -7,6 +7,7 @@
 #define BITCOIN_SCRIPT_SCRIPT_H
 
 #include "crypto/common.h"
+#include "prevector.h"
 
 #include <assert.h>
 #include <climits>
@@ -354,8 +355,10 @@ private:
     int64_t m_value;
 };
 
+typedef prevector<28, unsigned char> CScriptBase;
+
 /** Serialized script, used inside transaction inputs and outputs */
-class CScript : public std::vector<unsigned char>
+class CScript : public CScriptBase
 {
 protected:
     CScript& push_int64(int64_t n)
@@ -376,9 +379,10 @@ protected:
     }
 public:
     CScript() { }
-    CScript(const CScript& b) : std::vector<unsigned char>(b.begin(), b.end()) { }
-    CScript(const_iterator pbegin, const_iterator pend) : std::vector<unsigned char>(pbegin, pend) { }
-    CScript(const unsigned char* pbegin, const unsigned char* pend) : std::vector<unsigned char>(pbegin, pend) { }
+    CScript(const CScript& b) : CScriptBase(b.begin(), b.end()) { }
+    CScript(const_iterator pbegin, const_iterator pend) : CScriptBase(pbegin, pend) { }
+    CScript(std::vector<unsigned char>::const_iterator pbegin, std::vector<unsigned char>::const_iterator pend) : CScriptBase(pbegin, pend) { }
+    CScript(const unsigned char* pbegin, const unsigned char* pend) : CScriptBase(pbegin, pend) { }
 
     CScript& operator+=(const CScript& b)
     {
@@ -611,7 +615,7 @@ public:
     void clear()
     {
         // The default std::vector::clear() does not release memory.
-        std::vector<unsigned char>().swap(*this);
+        CScriptBase().swap(*this);
     }
 };
 

--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -16,7 +16,7 @@
 
 using namespace std;
 
-typedef vector<unsigned char> valtype;
+typedef std::vector<unsigned char> valtype;
 
 TransactionSignatureCreator::TransactionSignatureCreator(const CKeyStore* keystoreIn, const CTransaction* txToIn, unsigned int nInIn, int nHashTypeIn) : BaseSignatureCreator(keystoreIn), txTo(txToIn), nIn(nInIn), nHashType(nHashTypeIn), checker(txTo, nIn) {}
 
@@ -118,7 +118,7 @@ bool ProduceSignature(const BaseSignatureCreator& creator, const CScript& fromPu
         bool fSolved =
             SignStep(creator, subscript, scriptSig, subType) && subType != TX_SCRIPTHASH;
         // Append serialized subscript whether or not it is completely signed:
-        scriptSig << static_cast<valtype>(subscript);
+        scriptSig << valtype(subscript.begin(), subscript.end());
         if (!fSolved) return false;
     }
 

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -20,7 +20,7 @@
 #include <utility>
 #include <vector>
 
-class CScript;
+#include "prevector.h"
 
 static const unsigned int MAX_SIZE = 0x02000000;
 
@@ -49,26 +49,26 @@ inline T* NCONST_PTR(const T* val)
  * @note These functions avoid the undefined case of indexing into an empty
  * vector, as well as that of indexing after the end of the vector.
  */
-template <class T, class TAl>
-inline T* begin_ptr(std::vector<T,TAl>& v)
+template <typename V>
+inline typename V::value_type* begin_ptr(V& v)
 {
     return v.empty() ? NULL : &v[0];
 }
 /** Get begin pointer of vector (const version) */
-template <class T, class TAl>
-inline const T* begin_ptr(const std::vector<T,TAl>& v)
+template <typename V>
+inline const typename V::value_type* begin_ptr(const V& v)
 {
     return v.empty() ? NULL : &v[0];
 }
 /** Get end pointer of vector (non-const version) */
-template <class T, class TAl>
-inline T* end_ptr(std::vector<T,TAl>& v)
+template <typename V>
+inline typename V::value_type* end_ptr(V& v)
 {
     return v.empty() ? NULL : (&v[0] + v.size());
 }
 /** Get end pointer of vector (const version) */
-template <class T, class TAl>
-inline const T* end_ptr(const std::vector<T,TAl>& v)
+template <typename V>
+inline const typename V::value_type* end_ptr(const V& v)
 {
     return v.empty() ? NULL : (&v[0] + v.size());
 }
@@ -391,6 +391,12 @@ public:
         pbegin = (char*)begin_ptr(v);
         pend = (char*)end_ptr(v);
     }
+    template <unsigned int N, typename T, typename S, typename D>
+    explicit CFlatData(prevector<N, T, S, D> &v)
+    {
+        pbegin = (char*)begin_ptr(v);
+        pend = (char*)end_ptr(v);
+    }
     char* begin() { return pbegin; }
     const char* begin() const { return pbegin; }
     char* end() { return pend; }
@@ -486,6 +492,20 @@ template<typename Stream, typename C> void Serialize(Stream& os, const std::basi
 template<typename Stream, typename C> void Unserialize(Stream& is, std::basic_string<C>& str, int, int=0);
 
 /**
+ * prevector
+ * prevectors of unsigned char are a special case and are intended to be serialized as a single opaque blob.
+ */
+template<unsigned int N, typename T> unsigned int GetSerializeSize_impl(const prevector<N, T>& v, int nType, int nVersion, const unsigned char&);
+template<unsigned int N, typename T, typename V> unsigned int GetSerializeSize_impl(const prevector<N, T>& v, int nType, int nVersion, const V&);
+template<unsigned int N, typename T> inline unsigned int GetSerializeSize(const prevector<N, T>& v, int nType, int nVersion);
+template<typename Stream, unsigned int N, typename T> void Serialize_impl(Stream& os, const prevector<N, T>& v, int nType, int nVersion, const unsigned char&);
+template<typename Stream, unsigned int N, typename T, typename V> void Serialize_impl(Stream& os, const prevector<N, T>& v, int nType, int nVersion, const V&);
+template<typename Stream, unsigned int N, typename T> inline void Serialize(Stream& os, const prevector<N, T>& v, int nType, int nVersion);
+template<typename Stream, unsigned int N, typename T> void Unserialize_impl(Stream& is, prevector<N, T>& v, int nType, int nVersion, const unsigned char&);
+template<typename Stream, unsigned int N, typename T, typename V> void Unserialize_impl(Stream& is, prevector<N, T>& v, int nType, int nVersion, const V&);
+template<typename Stream, unsigned int N, typename T> inline void Unserialize(Stream& is, prevector<N, T>& v, int nType, int nVersion);
+
+/**
  * vector
  * vectors of unsigned char are a special case and are intended to be serialized as a single opaque blob.
  */
@@ -498,13 +518,6 @@ template<typename Stream, typename T, typename A> inline void Serialize(Stream& 
 template<typename Stream, typename T, typename A> void Unserialize_impl(Stream& is, std::vector<T, A>& v, int nType, int nVersion, const unsigned char&);
 template<typename Stream, typename T, typename A, typename V> void Unserialize_impl(Stream& is, std::vector<T, A>& v, int nType, int nVersion, const V&);
 template<typename Stream, typename T, typename A> inline void Unserialize(Stream& is, std::vector<T, A>& v, int nType, int nVersion);
-
-/**
- * others derived from vector
- */
-extern inline unsigned int GetSerializeSize(const CScript& v, int nType, int nVersion);
-template<typename Stream> void Serialize(Stream& os, const CScript& v, int nType, int nVersion);
-template<typename Stream> void Unserialize(Stream& is, CScript& v, int nType, int nVersion);
 
 /**
  * pair
@@ -583,6 +596,96 @@ void Unserialize(Stream& is, std::basic_string<C>& str, int, int)
     str.resize(nSize);
     if (nSize != 0)
         is.read((char*)&str[0], nSize * sizeof(str[0]));
+}
+
+
+
+/**
+ * prevector
+ */
+template<unsigned int N, typename T>
+unsigned int GetSerializeSize_impl(const prevector<N, T>& v, int nType, int nVersion, const unsigned char&)
+{
+    return (GetSizeOfCompactSize(v.size()) + v.size() * sizeof(T));
+}
+
+template<unsigned int N, typename T, typename V>
+unsigned int GetSerializeSize_impl(const prevector<N, T>& v, int nType, int nVersion, const V&)
+{
+    unsigned int nSize = GetSizeOfCompactSize(v.size());
+    for (typename prevector<N, T>::const_iterator vi = v.begin(); vi != v.end(); ++vi)
+        nSize += GetSerializeSize((*vi), nType, nVersion);
+    return nSize;
+}
+
+template<unsigned int N, typename T>
+inline unsigned int GetSerializeSize(const prevector<N, T>& v, int nType, int nVersion)
+{
+    return GetSerializeSize_impl(v, nType, nVersion, T());
+}
+
+
+template<typename Stream, unsigned int N, typename T>
+void Serialize_impl(Stream& os, const prevector<N, T>& v, int nType, int nVersion, const unsigned char&)
+{
+    WriteCompactSize(os, v.size());
+    if (!v.empty())
+        os.write((char*)&v[0], v.size() * sizeof(T));
+}
+
+template<typename Stream, unsigned int N, typename T, typename V>
+void Serialize_impl(Stream& os, const prevector<N, T>& v, int nType, int nVersion, const V&)
+{
+    WriteCompactSize(os, v.size());
+    for (typename prevector<N, T>::const_iterator vi = v.begin(); vi != v.end(); ++vi)
+        ::Serialize(os, (*vi), nType, nVersion);
+}
+
+template<typename Stream, unsigned int N, typename T>
+inline void Serialize(Stream& os, const prevector<N, T>& v, int nType, int nVersion)
+{
+    Serialize_impl(os, v, nType, nVersion, T());
+}
+
+
+template<typename Stream, unsigned int N, typename T>
+void Unserialize_impl(Stream& is, prevector<N, T>& v, int nType, int nVersion, const unsigned char&)
+{
+    // Limit size per read so bogus size value won't cause out of memory
+    v.clear();
+    unsigned int nSize = ReadCompactSize(is);
+    unsigned int i = 0;
+    while (i < nSize)
+    {
+        unsigned int blk = std::min(nSize - i, (unsigned int)(1 + 4999999 / sizeof(T)));
+        v.resize(i + blk);
+        is.read((char*)&v[i], blk * sizeof(T));
+        i += blk;
+    }
+}
+
+template<typename Stream, unsigned int N, typename T, typename V>
+void Unserialize_impl(Stream& is, prevector<N, T>& v, int nType, int nVersion, const V&)
+{
+    v.clear();
+    unsigned int nSize = ReadCompactSize(is);
+    unsigned int i = 0;
+    unsigned int nMid = 0;
+    while (nMid < nSize)
+    {
+        nMid += 5000000 / sizeof(T);
+        if (nMid > nSize)
+            nMid = nSize;
+        v.resize(nMid);
+        for (; i < nMid; i++)
+            Unserialize(is, v[i], nType, nVersion);
+    }
+}
+
+template<typename Stream, unsigned int N, typename T>
+inline void Unserialize(Stream& is, prevector<N, T>& v, int nType, int nVersion)
+{
+    Unserialize_impl(is, v, nType, nVersion, T());
 }
 
 
@@ -673,28 +776,6 @@ template<typename Stream, typename T, typename A>
 inline void Unserialize(Stream& is, std::vector<T, A>& v, int nType, int nVersion)
 {
     Unserialize_impl(is, v, nType, nVersion, T());
-}
-
-
-
-/**
- * others derived from vector
- */
-inline unsigned int GetSerializeSize(const CScript& v, int nType, int nVersion)
-{
-    return GetSerializeSize((const std::vector<unsigned char>&)v, nType, nVersion);
-}
-
-template<typename Stream>
-void Serialize(Stream& os, const CScript& v, int nType, int nVersion)
-{
-    Serialize(os, (const std::vector<unsigned char>&)v, nType, nVersion);
-}
-
-template<typename Stream>
-void Unserialize(Stream& is, CScript& v, int nType, int nVersion)
-{
-    Unserialize(is, (std::vector<unsigned char>&)v, nType, nVersion);
 }
 
 

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -186,7 +186,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     hash = tx.GetHash();
     mempool.addUnchecked(hash, CTxMemPoolEntry(tx, 11, GetTime(), 111.0, 11));
     tx.vin[0].prevout.hash = hash;
-    tx.vin[0].scriptSig = CScript() << (std::vector<unsigned char>)script;
+    tx.vin[0].scriptSig = CScript() << std::vector<unsigned char>(script.begin(), script.end());
     tx.vout[0].nValue -= 1000000;
     hash = tx.GetHash();
     mempool.addUnchecked(hash, CTxMemPoolEntry(tx, 11, GetTime(), 111.0, 11));

--- a/src/test/prevector_tests.cpp
+++ b/src/test/prevector_tests.cpp
@@ -1,0 +1,217 @@
+// Copyright (c) 2015 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <vector>
+#include "prevector.h"
+#include "random.h"
+
+#include "serialize.h"
+#include "streams.h"
+
+#include "test/test_bitcoin.h"
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(PrevectorTests, TestingSetup)
+
+template<unsigned int N, typename T>
+class prevector_tester {
+    typedef std::vector<T> realtype;
+    realtype real_vector;
+
+    typedef prevector<N, T> pretype;
+    pretype pre_vector;
+
+    typedef typename pretype::size_type Size;
+
+    void test() {
+        const pretype& const_pre_vector = pre_vector;
+        BOOST_CHECK_EQUAL(real_vector.size(), pre_vector.size());
+        BOOST_CHECK_EQUAL(real_vector.empty(), pre_vector.empty());
+        for (Size s = 0; s < real_vector.size(); s++) {
+             BOOST_CHECK(real_vector[s] == pre_vector[s]);
+             BOOST_CHECK(&(pre_vector[s]) == &(pre_vector.begin()[s]));
+             BOOST_CHECK(&(pre_vector[s]) == &*(pre_vector.begin() + s));
+             BOOST_CHECK(&(pre_vector[s]) == &*((pre_vector.end() + s) - real_vector.size()));
+        }
+        // BOOST_CHECK(realtype(pre_vector) == real_vector);
+        BOOST_CHECK(pretype(real_vector.begin(), real_vector.end()) == pre_vector);
+        BOOST_CHECK(pretype(pre_vector.begin(), pre_vector.end()) == pre_vector);
+        size_t pos = 0;
+        BOOST_FOREACH(const T& v, pre_vector) {
+             BOOST_CHECK(v == real_vector[pos++]);
+        }
+        BOOST_REVERSE_FOREACH(const T& v, pre_vector) {
+             BOOST_CHECK(v == real_vector[--pos]);
+        }
+        BOOST_FOREACH(const T& v, const_pre_vector) {
+             BOOST_CHECK(v == real_vector[pos++]);
+        }
+        BOOST_REVERSE_FOREACH(const T& v, const_pre_vector) {
+             BOOST_CHECK(v == real_vector[--pos]);
+        }
+        CDataStream ss1(SER_DISK, 0);
+        CDataStream ss2(SER_DISK, 0);
+        ss1 << real_vector;
+        ss2 << pre_vector;
+        BOOST_CHECK_EQUAL(ss1.size(), ss2.size());
+        for (Size s = 0; s < ss1.size(); s++) {
+            BOOST_CHECK_EQUAL(ss1[s], ss2[s]);
+        }
+    }
+
+public:
+    void resize(Size s) {
+        real_vector.resize(s);
+        BOOST_CHECK_EQUAL(real_vector.size(), s);
+        pre_vector.resize(s);
+        BOOST_CHECK_EQUAL(pre_vector.size(), s);
+        test();
+    }
+
+    void reserve(Size s) {
+        real_vector.reserve(s);
+        BOOST_CHECK(real_vector.capacity() >= s);
+        pre_vector.reserve(s);
+        BOOST_CHECK(pre_vector.capacity() >= s);
+        test();
+    }
+
+    void insert(Size position, const T& value) {
+        real_vector.insert(real_vector.begin() + position, value);
+        pre_vector.insert(pre_vector.begin() + position, value);
+        test();
+    }
+
+    void insert(Size position, Size count, const T& value) {
+        real_vector.insert(real_vector.begin() + position, count, value);
+        pre_vector.insert(pre_vector.begin() + position, count, value);
+        test();
+    }
+
+    template<typename I>
+    void insert_range(Size position, I first, I last) {
+        real_vector.insert(real_vector.begin() + position, first, last);
+        pre_vector.insert(pre_vector.begin() + position, first, last);
+        test();
+    }
+
+    void erase(Size position) {
+        real_vector.erase(real_vector.begin() + position);
+        pre_vector.erase(pre_vector.begin() + position);
+        test();
+    }
+
+    void erase(Size first, Size last) {
+        real_vector.erase(real_vector.begin() + first, real_vector.begin() + last);
+        pre_vector.erase(pre_vector.begin() + first, pre_vector.begin() + last);
+        test();
+    }
+
+    void update(Size pos, const T& value) {
+        real_vector[pos] = value;
+        pre_vector[pos] = value;
+        test();
+    }
+
+    void push_back(const T& value) {
+        real_vector.push_back(value);
+        pre_vector.push_back(value);
+        test();
+    }
+
+    void pop_back() {
+        real_vector.pop_back();
+        pre_vector.pop_back();
+        test();
+    }
+
+    void clear() {
+        real_vector.clear();
+        pre_vector.clear();
+    }
+
+    void assign(Size n, const T& value) {
+        real_vector.assign(n, value);
+        pre_vector.assign(n, value);
+    }
+
+    Size size() {
+        return real_vector.size();
+    }
+
+    Size capacity() {
+        return pre_vector.capacity();
+    }
+
+    void shrink_to_fit() {
+        pre_vector.shrink_to_fit();
+        test();
+    }
+};
+
+BOOST_AUTO_TEST_CASE(PrevectorTestInt)
+{
+    for (int j = 0; j < 64; j++) {
+        prevector_tester<8, int> test;
+        for (int i = 0; i < 2048; i++) {
+            int r = insecure_rand();
+            if ((r % 4) == 0) {
+                test.insert(insecure_rand() % (test.size() + 1), insecure_rand());
+            }
+            if (test.size() > 0 && ((r >> 2) % 4) == 1) {
+                test.erase(insecure_rand() % test.size());
+            }
+            if (((r >> 4) % 8) == 2) {
+                int new_size = std::max<int>(0, std::min<int>(30, test.size() + (insecure_rand() % 5) - 2));
+                test.resize(new_size);
+            }
+            if (((r >> 7) % 8) == 3) {
+                test.insert(insecure_rand() % (test.size() + 1), 1 + (insecure_rand() % 2), insecure_rand());
+            }
+            if (((r >> 10) % 8) == 4) {
+                int del = std::min<int>(test.size(), 1 + (insecure_rand() % 2));
+                int beg = insecure_rand() % (test.size() + 1 - del);
+                test.erase(beg, beg + del);
+            }
+            if (((r >> 13) % 16) == 5) {
+                test.push_back(insecure_rand());
+            }
+            if (test.size() > 0 && ((r >> 17) % 16) == 6) {
+                test.pop_back();
+            }
+            if (((r >> 21) % 32) == 7) {
+                int values[4];
+                int num = 1 + (insecure_rand() % 4);
+                for (int i = 0; i < num; i++) {
+                    values[i] = insecure_rand();
+                }
+                test.insert_range(insecure_rand() % (test.size() + 1), values, values + num);
+            }
+            if (((r >> 26) % 32) == 8) {
+                int del = std::min<int>(test.size(), 1 + (insecure_rand() % 4));
+                int beg = insecure_rand() % (test.size() + 1 - del);
+                test.erase(beg, beg + del);
+            }
+            r = insecure_rand();
+            if (r % 32 == 9) {
+                test.reserve(insecure_rand() % 32);
+            }
+            if ((r >> 5) % 64 == 10) {
+                test.shrink_to_fit();
+            }
+            if (test.size() > 0) {
+                test.update(insecure_rand() % test.size(), insecure_rand());
+            }
+            if (((r >> 11) & 1024) == 11) {
+                test.clear();
+            }
+            if (((r >> 21) & 512) == 12) {
+                test.assign(insecure_rand() % 32, insecure_rand());
+            }
+        }
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/script_P2SH_tests.cpp
+++ b/src/test/script_P2SH_tests.cpp
@@ -25,7 +25,7 @@ using namespace std;
 static std::vector<unsigned char>
 Serialize(const CScript& s)
 {
-    std::vector<unsigned char> sSerialized(s);
+    std::vector<unsigned char> sSerialized(s.begin(), s.end());
     return sSerialized;
 }
 
@@ -339,8 +339,8 @@ BOOST_AUTO_TEST_CASE(AreInputsStandard)
     // SignSignature doesn't know how to sign these. We're
     // not testing validating signatures, so just create
     // dummy signatures that DO include the correct P2SH scripts:
-    txTo.vin[3].scriptSig << OP_11 << OP_11 << static_cast<vector<unsigned char> >(oneAndTwo);
-    txTo.vin[4].scriptSig << static_cast<vector<unsigned char> >(fifteenSigops);
+    txTo.vin[3].scriptSig << OP_11 << OP_11 << vector<unsigned char>(oneAndTwo.begin(), oneAndTwo.end());
+    txTo.vin[4].scriptSig << vector<unsigned char>(fifteenSigops.begin(), fifteenSigops.end());
 
     BOOST_CHECK(::AreInputsStandard(txTo, coins));
     // 22 P2SH sigops for all inputs (1 for vin[0], 6 for vin[3], 15 for vin[4]
@@ -362,7 +362,7 @@ BOOST_AUTO_TEST_CASE(AreInputsStandard)
     txToNonStd1.vin.resize(1);
     txToNonStd1.vin[0].prevout.n = 5;
     txToNonStd1.vin[0].prevout.hash = txFrom.GetHash();
-    txToNonStd1.vin[0].scriptSig << static_cast<vector<unsigned char> >(sixteenSigops);
+    txToNonStd1.vin[0].scriptSig << vector<unsigned char>(sixteenSigops.begin(), sixteenSigops.end());
 
     BOOST_CHECK(!::AreInputsStandard(txToNonStd1, coins));
     BOOST_CHECK_EQUAL(GetP2SHSigOpCount(txToNonStd1, coins), 16U);
@@ -374,7 +374,7 @@ BOOST_AUTO_TEST_CASE(AreInputsStandard)
     txToNonStd2.vin.resize(1);
     txToNonStd2.vin[0].prevout.n = 6;
     txToNonStd2.vin[0].prevout.hash = txFrom.GetHash();
-    txToNonStd2.vin[0].scriptSig << static_cast<vector<unsigned char> >(twentySigops);
+    txToNonStd2.vin[0].scriptSig << vector<unsigned char>(twentySigops.begin(), twentySigops.end());
 
     BOOST_CHECK(!::AreInputsStandard(txToNonStd2, coins));
     BOOST_CHECK_EQUAL(GetP2SHSigOpCount(txToNonStd2, coins), 20U);

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -260,7 +260,7 @@ public:
 
     TestBuilder& PushRedeem()
     {
-        DoPush(static_cast<std::vector<unsigned char> >(scriptPubKey));
+        DoPush(std::vector<unsigned char>(scriptPubKey.begin(), scriptPubKey.end()));
         return *this;
     }
 
@@ -892,7 +892,7 @@ BOOST_AUTO_TEST_CASE(script_combineSigs)
     combined = CombineSignatures(scriptPubKey, txTo, 0, scriptSigCopy, scriptSig);
     BOOST_CHECK(combined == scriptSigCopy || combined == scriptSig);
     // dummy scriptSigCopy with placeholder, should always choose non-placeholder:
-    scriptSigCopy = CScript() << OP_0 << static_cast<vector<unsigned char> >(pkSingle);
+    scriptSigCopy = CScript() << OP_0 << vector<unsigned char>(pkSingle.begin(), pkSingle.end());
     combined = CombineSignatures(scriptPubKey, txTo, 0, scriptSigCopy, scriptSig);
     BOOST_CHECK(combined == scriptSig);
     combined = CombineSignatures(scriptPubKey, txTo, 0, scriptSig, scriptSigCopy);

--- a/src/test/sigopcount_tests.cpp
+++ b/src/test/sigopcount_tests.cpp
@@ -20,7 +20,7 @@ using namespace std;
 static std::vector<unsigned char>
 Serialize(const CScript& s)
 {
-    std::vector<unsigned char> sSerialized(s);
+    std::vector<unsigned char> sSerialized(s.begin(), s.end());
     return sSerialized;
 }
 

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -113,19 +113,19 @@ bool CWalletDB::WriteMasterKey(unsigned int nID, const CMasterKey& kMasterKey)
 bool CWalletDB::WriteCScript(const uint160& hash, const CScript& redeemScript)
 {
     nWalletDBUpdated++;
-    return Write(std::make_pair(std::string("cscript"), hash), redeemScript, false);
+    return Write(std::make_pair(std::string("cscript"), hash), *(const CScriptBase*)(&redeemScript), false);
 }
 
 bool CWalletDB::WriteWatchOnly(const CScript &dest)
 {
     nWalletDBUpdated++;
-    return Write(std::make_pair(std::string("watchs"), dest), '1');
+    return Write(std::make_pair(std::string("watchs"), *(const CScriptBase*)(&dest)), '1');
 }
 
 bool CWalletDB::EraseWatchOnly(const CScript &dest)
 {
     nWalletDBUpdated++;
-    return Erase(std::make_pair(std::string("watchs"), dest));
+    return Erase(std::make_pair(std::string("watchs"), *(const CScriptBase*)(&dest)));
 }
 
 bool CWalletDB::WriteBestBlock(const CBlockLocator& locator)
@@ -421,7 +421,7 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
         else if (strType == "watchs")
         {
             CScript script;
-            ssKey >> script;
+            ssKey >> *(CScriptBase*)(&script);
             char fYes;
             ssValue >> fYes;
             if (fYes == '1')
@@ -575,7 +575,7 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
             uint160 hash;
             ssKey >> hash;
             CScript script;
-            ssValue >> script;
+            ssValue >> *(CScriptBase*)(&script);
             if (!pwallet->LoadCScript(script))
             {
                 strErr = "Error reading wallet database: LoadCScript failed";


### PR DESCRIPTION
This is likely a controversial change, and will need very careful review and testing.

It adds a new basic data type (`prevector<N, T>`) which is a fully API compatible drop-in replacement for `std::vector<T>` (except it does not support custom allocators, does not have `at()`, and misses a few comparison operators). It will allocate up to N elements inside the parent container directly, only switching over to heap-allocated storage if more is needed. The data structures for the N elements and the pointer/size metadata for the heap-allocated storage are shared, making it very efficient for small N.

CScript is switched to use this new type, reducing the memory consumption of mempool and chainstate.

A benchmark (reindex with script validation disabled):

```
2015-10-30 01:10:49   - Load block from disk: 0.00ms [0.07s]
2015-10-30 01:10:49       - Connect 595 transactions: 2.76ms (0.005ms/tx, 0.003ms/txin) [82.40s]
2015-10-30 01:10:49     - Verify 1096 txins: 2.80ms (0.003ms/txin) [88.73s]
2015-10-30 01:10:49     - Index writing: 1.29ms [61.31s]
2015-10-30 01:10:49     - Callbacks: 0.04ms [6.78s]
2015-10-30 01:10:49   - Connect total: 4.78ms [182.16s]
2015-10-30 01:10:49   - Flush: 0.77ms [38.90s]
2015-10-30 01:10:49   - Writing chainstate: 0.03ms [5.57s]
2015-10-30 01:10:49 UpdateTip: new best=000000000000046b1fdf00440a86e34886b2b0bd56472b22edb2805c92bbe4ca  height=223133  log2_work=69.460921  tx=13407260  date=2013-02-25 23:16:10 progress=0
.064773  cache=666.5MiB(1658277tx)
2015-10-30 01:10:49   - Connect postprocess: 1.46ms [46.22s]
2015-10-30 01:10:49 - Connect block: 7.03ms [272.92s]

2015-10-30 01:22:03       - Connect 595 transactions: 2.86ms (0.005ms/tx, 0.003ms/txin) [69.53s]
2015-10-30 01:22:03     - Verify 1096 txins: 2.90ms (0.003ms/txin) [75.80s]
2015-10-30 01:22:03     - Index writing: 1.26ms [56.37s]
2015-10-30 01:22:03     - Callbacks: 0.04ms [6.77s]
2015-10-30 01:22:03   - Connect total: 4.87ms [164.33s]
2015-10-30 01:22:03   - Flush: 1.14ms [24.95s]
2015-10-30 01:22:03   - Writing chainstate: 0.03ms [5.12s]
2015-10-30 01:22:03 UpdateTip: new best=000000000000046b1fdf00440a86e34886b2b0bd56472b22edb2805c92bbe4ca  height=223133  log2_work=69.460921  tx=13407260  date=2013-02-25 23:16:10 progress=0
.064773  cache=508.6MiB(1658277tx)
2015-10-30 01:22:03   - Connect postprocess: 1.36ms [43.18s]
2015-10-30 01:22:03 - Connect block: 7.41ms [237.66s]
```

So for this reindex up to 223133, the chainstate needs 23% less memory, and is 13% faster.

There are likely several other places where this datatype can be used.
