### PR TITLE
[WIP] Keep pcoinsTip cache warm

### DIFF
--- a/src/coins.h
+++ b/src/coins.h
@@ -327,7 +327,9 @@ public:
 
     //! Do a bulk modification (multiple CCoins changes + BestBlock change).
     //! The passed mapCoins can be modified.
-    virtual bool BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock);
+    //! Any coins contained in hotHashes may not be erased from mapCoins (only used by CCoinsViewDB)
+    //! Usage of non-erased coins returned in hotUsage
+    virtual bool BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock, size_t &hotUsage, const std::set<uint256> *hotHashes);
 
     //! Calculate statistics about the unspent transaction output set
     virtual bool GetStats(CCoinsStats &stats) const;
@@ -349,7 +351,7 @@ public:
     bool HaveCoins(const uint256 &txid) const;
     uint256 GetBestBlock() const;
     void SetBackend(CCoinsView &viewIn);
-    bool BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock);
+    bool BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock, size_t &hotUsage, const std::set<uint256> *hotHashes);
     bool GetStats(CCoinsStats &stats) const;
 };
 
@@ -403,7 +405,7 @@ public:
     bool HaveCoins(const uint256 &txid) const;
     uint256 GetBestBlock() const;
     void SetBestBlock(const uint256 &hashBlock);
-    bool BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock);
+    bool BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock, size_t &hotUsage, const std::set<uint256> *hotHashes);
 
     /**
      * Return a pointer to CCoins in the cache, or NULL if not found. This is
@@ -423,8 +425,9 @@ public:
      * Push the modifications applied to this cache to its base.
      * Failure to call this method before destruction will cause the changes to be forgotten.
      * If false is returned, the state of this cache (and its backing view) will be undefined.
+     * This cache will be cleared of all entries not contained in hotHashes
      */
-    bool Flush();
+    bool Flush(const std::set<uint256> *hotHashes = NULL);
 
     //! Calculate the size of the cache (in number of transactions)
     unsigned int GetCacheSize() const;

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -187,6 +187,7 @@ UniValue mempoolToJSON(bool fVerbose = false)
             UniValue info(UniValue::VOBJ);
             info.push_back(Pair("size", (int)e.GetTxSize()));
             info.push_back(Pair("fee", ValueFromAmount(e.GetFee())));
+            info.push_back(Pair("score", e.GetScore()));
             info.push_back(Pair("time", e.GetTime()));
             info.push_back(Pair("height", (int)e.GetHeight()));
             info.push_back(Pair("startingpriority", e.GetPriority(e.GetHeight())));
@@ -244,6 +245,7 @@ UniValue getrawmempool(const UniValue& params, bool fHelp)
             "  \"transactionid\" : {       (json object)\n"
             "    \"size\" : n,             (numeric) transaction size in bytes\n"
             "    \"fee\" : n,              (numeric) transaction fee in " + CURRENCY_UNIT + "\n"
+            "    \"score\" : n,            (numeric) transaction score for mining priority\n"
             "    \"time\" : n,             (numeric) local time transaction entered pool in seconds since 1 Jan 1970 GMT\n"
             "    \"height\" : n,           (numeric) block height when transaction entered pool\n"
             "    \"startingpriority\" : n, (numeric) priority when transaction entered pool\n"

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -42,7 +42,7 @@ public:
 
     uint256 GetBestBlock() const { return hashBestBlock_; }
 
-    bool BatchWrite(CCoinsMap& mapCoins, const uint256& hashBlock)
+    bool BatchWrite(CCoinsMap& mapCoins, const uint256& hashBlock, size_t &hotUsage, const std::set<uint256> *hotHashes)
     {
         for (CCoinsMap::iterator it = mapCoins.begin(); it != mapCoins.end(); ) {
             map_[it->first] = it->second.coins;

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -37,7 +37,7 @@ public:
     bool GetCoins(const uint256 &txid, CCoins &coins) const;
     bool HaveCoins(const uint256 &txid) const;
     uint256 GetBestBlock() const;
-    bool BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock);
+    bool BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock, size_t &hotUsage, const std::set<uint256> *hotHashes);
     bool GetStats(CCoinsStats &stats) const;
 };
 

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -502,6 +502,7 @@ public:
     bool ReadFeeEstimates(CAutoFile& filein);
 
     size_t DynamicMemoryUsage() const;
+    void FindHotHashes(size_t prioritySize, size_t scoreSize, std::set<uint256> &hotHashes, unsigned int chainHeight);
 
 private:
     /** UpdateForDescendants is used by UpdateTransactionsFromBlock to update

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -66,6 +66,7 @@ private:
     double dPriority; //! Priority when entering the mempool
     unsigned int nHeight; //! Chain height when entering the mempool
     bool hadNoDependencies; //! Not dependent on any other txs when it entered the mempool
+    int64_t score; //! Used for determining the priority of the transaction for mining in a block
 
     // Information about descendants of this transaction that are in the
     // mempool; if we remove this transaction we must remove all of these
@@ -88,10 +89,13 @@ public:
     int64_t GetTime() const { return nTime; }
     unsigned int GetHeight() const { return nHeight; }
     bool WasClearAtEntry() const { return hadNoDependencies; }
+    int64_t GetScore() const { return score; }
     size_t DynamicMemoryUsage() const { return nUsageSize; }
 
     // Adjusts the descendant state, if this entry is not dirty.
     void UpdateState(int64_t modifySize, CAmount modifyFee, int64_t modifyCount);
+    // Updates the mining priority score
+    void UpdateScore(int64_t newScore);
 
     /** We can set the entry to be dirty if doing the full calculation of in-
      *  mempool descendants will be too expensive, which can potentially happen
@@ -125,6 +129,18 @@ struct set_dirty
 {
     void operator() (CTxMemPoolEntry &e)
         { e.SetDirty(); }
+};
+
+struct update_score
+{
+    update_score(int64_t _newScore) : newScore(_newScore)
+    {}
+
+    void operator() (CTxMemPoolEntry &e)
+    { e.UpdateScore(newScore); }
+
+private:
+    int64_t newScore;
 };
 
 // extracts a TxMemPoolEntry's transaction hash
@@ -171,6 +187,22 @@ public:
         double f1 = (double)a.GetFee() * a.GetSizeWithDescendants();
         double f2 = (double)a.GetFeesWithDescendants() * a.GetTxSize();
         return f2 > f1;
+    }
+};
+
+/** \class CompareTxMemPoolEntryByScore
+ *
+ *  Sort by score of entry in descending order
+ */
+class CompareTxMemPoolEntryByScore
+{
+public:
+    bool operator()(const CTxMemPoolEntry& a, const CTxMemPoolEntry& b)
+    {
+        if (a.GetScore() == b.GetScore()) {
+            return b.GetTx().GetHash() < a.GetTx().GetHash();
+        }
+        return a.GetScore() > b.GetScore();
     }
 };
 
@@ -311,6 +343,11 @@ public:
             boost::multi_index::ordered_non_unique<
                 boost::multi_index::identity<CTxMemPoolEntry>,
                 CompareTxMemPoolEntryByEntryTime
+                >,
+            // sorted by fee rate
+            boost::multi_index::ordered_non_unique<
+                boost::multi_index::identity<CTxMemPoolEntry>,
+                CompareTxMemPoolEntryByScore
             >
         >
     > indexed_transaction_set;

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -561,4 +561,17 @@ public:
     bool HaveCoins(const uint256 &txid) const;
 };
 
+// We want to sort transactions by coin age priority
+typedef std::pair<double, CTxMemPool::txiter> TxCoinAgePriority;
+
+struct TxCoinAgePriorityCompare
+{
+    bool operator()(const TxCoinAgePriority& a, const TxCoinAgePriority& b)
+    {
+        if (a.first == b.first)
+            return CompareTxMemPoolEntryByScore()(*(b.second), *(a.second)); //Reverse order to make sort less than
+        return a.first < b.first;
+    }
+};
+
 #endif // BITCOIN_TXMEMPOOL_H


### PR DESCRIPTION
This builds off the score index added in #6898 and uses it to caculate the set of txin hashes that are most likely to be needed in upcoming blocks.  Then when FlushStateToDisk writes the cache from pcoinsTip to the database, it'll leave the coins corresponding to these hashes in the cache.
