### PR TITLE
Fix Boost 1.58.0 build for mips arch

### DIFF
--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -3,6 +3,7 @@ $(package)_version=1_58_0
 $(package)_download_path=http://sourceforge.net/projects/boost/files/boost/1.58.0
 $(package)_file_name=$(package)_$($(package)_version).tar.bz2
 $(package)_sha256_hash=fdfc204fc33ec79c99b9a74944c3e54bd78be4f7f15e260c0e2700a36dc7d3e5
+$(package)_patches=mips-options-fix.patch
 
 define $(package)_set_vars
 $(package)_config_opts_release=variant=release
@@ -25,6 +26,7 @@ $(package)_cxxflags_linux=-fPIC
 endef
 
 define $(package)_preprocess_cmds
+  patch -d ./tools/build -p1 < $($(package)_patch_dir)/mips-options-fix.patch && \
   echo "using $(boost_toolset_$(host_os)) : : $($(package)_cxx) : <cxxflags>\"$($(package)_cxxflags) $($(package)_cppflags)\" <linkflags>\"$($(package)_ldflags)\" <archiver>\"$(boost_archiver_$(host_os))\" <striper>\"$(host_STRIP)\"  <ranlib>\"$(host_RANLIB)\" <rc>\"$(host_WINDRES)\" : ;" > user-config.jam
 endef
 

--- a/depends/patches/boost/mips-options-fix.patch
+++ b/depends/patches/boost/mips-options-fix.patch
@@ -1,0 +1,25 @@
+From c0634341d9ee2c02d3a55c91dafb988afc066c49 Mon Sep 17 00:00:00 2001
+From: claymore <carlosmf.pt@gmail.com>
+Date: Fri, 24 Apr 2015 02:28:47 +0100
+Subject: [PATCH]  mips1 fix added   gcc.jam was passing the options -m32 and
+ -m64 to mips cross-compilers, when those do not use such options   This
+ modification solves it by adding mips as an exception
+
+  Signed-off-by: Carlos M. Ferreira carlosmf.pt@gmail.com
+---
+ src/tools/gcc.jam | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/tools/gcc.jam b/src/tools/gcc.jam
+index db04534..eff95ae 100644
+--- a/src/tools/gcc.jam
++++ b/src/tools/gcc.jam
+@@ -451,7 +451,7 @@ rule setup-address-model ( targets * : sources * : properties * )
+         else
+         {
+             local arch = [ feature.get-values architecture : $(properties) ] ;
+-            if $(arch) != arm
++            if $(arch) != arm && $(arch) != mips1
+             {
+                 if $(model) = 32
+                 {


### PR DESCRIPTION
The Boost 1.58 can't support build for MIPS32 on a x86_64 machine, the error message is" unrecognized command line option '-m32'". The Boost.Build for version 1.58.0  requires a patch for gcc.jam. This patch prevents bjam from adding  -m32 and -m64 options to gcc compiler, when compiling for targets that use the mips1 arch.

Bug discussed here: https://github.com/openwrt/packages/issues/1160
