### PR TITLE
Improving labels for Sent / Received "Bytes"

### DIFF
--- a/src/qt/forms/debugwindow.ui
+++ b/src/qt/forms/debugwindow.ui
@@ -1117,7 +1117,7 @@
           <item row="12" column="0">
            <widget class="QLabel" name="label_18">
             <property name="text">
-             <string>Bytes Sent</string>
+             <string>Sent</string>
             </property>
            </widget>
           </item>
@@ -1140,7 +1140,7 @@
           <item row="13" column="0">
            <widget class="QLabel" name="label_20">
             <property name="text">
-             <string>Bytes Received</string>
+             <string>Received</string>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
The labels for Sent & Received data in the "Peers" debug panel should not be defined as "Bytes" because the units (`B`, `KB`, `MB`) appear after the number making this redundant.  I decided to simply use "Sent" and "Received" (rather than "Data Sent" and "Data Received") because we already have translations for the former.
Japanese example:
https://www.transifex.com/bitcoin/bitcoin/viewstrings/#ja/qt-translation-011x/47533089?q=sent
https://www.transifex.com/bitcoin/bitcoin/viewstrings/#ja/qt-translation-011x/47533089?q=received

Demo of changes:

Current UI:

```
Bytes Sent      12 KB
Bytes Received  26 MB
```

With this pull request:

```
Sent       12 KB
Received   26 MB
```

Happy to add a screenshot if it would help.
