### PR TITLE
Wallet: Store hash for encrypted keys

### DIFF
--- a/src/keystore.h
+++ b/src/keystore.h
@@ -14,6 +14,7 @@
 
 #include <boost/signals2/signal.hpp>
 #include <boost/variant.hpp>
+#include <boost/tuple/tuple.hpp>
 
 /** A virtual base class for key stores */
 class CKeyStore
@@ -109,6 +110,6 @@ public:
 };
 
 typedef std::vector<unsigned char, secure_allocator<unsigned char> > CKeyingMaterial;
-typedef std::map<CKeyID, std::pair<CPubKey, std::vector<unsigned char> > > CryptedKeyMap;
+typedef std::map<CKeyID, boost::tuple<CPubKey, std::vector<unsigned char> > > CryptedKeyMap;
 
 #endif // BITCOIN_KEYSTORE_H

--- a/src/keystore.h
+++ b/src/keystore.h
@@ -110,6 +110,6 @@ public:
 };
 
 typedef std::vector<unsigned char, secure_allocator<unsigned char> > CKeyingMaterial;
-typedef std::map<CKeyID, boost::tuple<CPubKey, std::vector<unsigned char> > > CryptedKeyMap;
+typedef std::map<CKeyID, boost::tuple<CPubKey, std::vector<unsigned char>, std::vector<unsigned char> > > CryptedKeyMap;
 
 #endif // BITCOIN_KEYSTORE_H

--- a/src/keystore.h
+++ b/src/keystore.h
@@ -110,6 +110,6 @@ public:
 };
 
 typedef std::vector<unsigned char, secure_allocator<unsigned char> > CKeyingMaterial;
-typedef std::map<CKeyID, boost::tuple<CPubKey, std::vector<unsigned char>, std::vector<unsigned char> > > CryptedKeyMap;
+typedef std::map<CKeyID, boost::tuple<CPubKey, std::vector<unsigned char>, uint256 > > CryptedKeyMap;
 
 #endif // BITCOIN_KEYSTORE_H

--- a/src/wallet/crypter.cpp
+++ b/src/wallet/crypter.cpp
@@ -172,8 +172,8 @@ bool CCryptoKeyStore::Unlock(const CKeyingMaterial& vMasterKeyIn)
         CryptedKeyMap::const_iterator mi = mapCryptedKeys.begin();
         for (; mi != mapCryptedKeys.end(); ++mi)
         {
-            const CPubKey &vchPubKey = (*mi).second.first;
-            const std::vector<unsigned char> &vchCryptedSecret = (*mi).second.second;
+            const CPubKey &vchPubKey = (*mi).second.get<0>();
+            const std::vector<unsigned char> &vchCryptedSecret = (*mi).second.get<1>();
             CKey key;
             if (!DecryptKey(vMasterKeyIn, vchCryptedSecret, vchPubKey, key))
             {
@@ -242,8 +242,8 @@ bool CCryptoKeyStore::GetKey(const CKeyID &address, CKey& keyOut) const
         CryptedKeyMap::const_iterator mi = mapCryptedKeys.find(address);
         if (mi != mapCryptedKeys.end())
         {
-            const CPubKey &vchPubKey = (*mi).second.first;
-            const std::vector<unsigned char> &vchCryptedSecret = (*mi).second.second;
+            const CPubKey &vchPubKey = (*mi).second.get<0>();
+            const std::vector<unsigned char> &vchCryptedSecret = (*mi).second.get<1>();
             return DecryptKey(vMasterKey, vchCryptedSecret, vchPubKey, keyOut);
         }
     }
@@ -260,7 +260,7 @@ bool CCryptoKeyStore::GetPubKey(const CKeyID &address, CPubKey& vchPubKeyOut) co
         CryptedKeyMap::const_iterator mi = mapCryptedKeys.find(address);
         if (mi != mapCryptedKeys.end())
         {
-            vchPubKeyOut = (*mi).second.first;
+            vchPubKeyOut = (*mi).second.get<0>();
             return true;
         }
         // Check for watch-only pubkeys

--- a/src/wallet/crypter.cpp
+++ b/src/wallet/crypter.cpp
@@ -183,8 +183,8 @@ bool CCryptoKeyStore::Unlock(const CKeyingMaterial& vMasterKeyIn)
                     break;
                 }
             }
-            else
-            {
+
+            if (hash.IsNull() || !keyPass) {
                 CKey key;
                 if (!DecryptKey(vMasterKeyIn, vchCryptedSecret, vchPubKey, key))
                 {

--- a/src/wallet/crypter.cpp
+++ b/src/wallet/crypter.cpp
@@ -227,7 +227,7 @@ bool CCryptoKeyStore::AddCryptedKey(const CPubKey &vchPubKey, const std::vector<
         if (!SetCrypted())
             return false;
 
-        mapCryptedKeys[vchPubKey.GetID()] = make_pair(vchPubKey, vchCryptedSecret);
+        mapCryptedKeys[vchPubKey.GetID()] = boost::make_tuple(vchPubKey, vchCryptedSecret, std::vector<unsigned char>());
     }
     return true;
 }

--- a/src/wallet/crypter.cpp
+++ b/src/wallet/crypter.cpp
@@ -223,7 +223,6 @@ bool CCryptoKeyStore::AddKeyPubKey(const CKey& key, const CPubKey &pubkey)
             return false;
 
         uint256 hash = Hash(pubkey.begin(), pubkey.end(), vchCryptedSecret.begin(), vchCryptedSecret.end());
-
         if (!AddCryptedKey(pubkey, vchCryptedSecret, hash))
             return false;
     }

--- a/src/wallet/crypter.h
+++ b/src/wallet/crypter.h
@@ -121,9 +121,6 @@ private:
     //! if fUseCrypto is false, vMasterKey must be empty
     bool fUseCrypto;
 
-    //! keeps track of whether Unlock has run a thorough check before
-    bool fDecryptionThoroughlyChecked;
-
 protected:
     bool SetCrypted();
 
@@ -133,7 +130,7 @@ protected:
     bool Unlock(const CKeyingMaterial& vMasterKeyIn);
 
 public:
-    CCryptoKeyStore() : fUseCrypto(false), fDecryptionThoroughlyChecked(false)
+    CCryptoKeyStore() : fUseCrypto(false)
     {
     }
 

--- a/src/wallet/crypter.h
+++ b/src/wallet/crypter.h
@@ -156,7 +156,7 @@ public:
 
     bool Lock();
 
-    virtual bool AddCryptedKey(const CPubKey &vchPubKey, const std::vector<unsigned char> &vchCryptedSecret);
+    virtual bool AddCryptedKey(const CPubKey &vchPubKey, const std::vector<unsigned char> &vchCryptedSecret, const std::vector<unsigned char> &vchHash);
     bool AddKeyPubKey(const CKey& key, const CPubKey &pubkey);
     bool HaveKey(const CKeyID &address) const
     {
@@ -184,6 +184,15 @@ public:
             setAddress.insert((*mi).first);
             mi++;
         }
+    }
+
+    static void CalculateCryptedHash(const CPubKey &vchPubKey, const std::vector<unsigned char> &vchCryptedSecret, std::vector<unsigned char> &vchHash) {
+        vchHash.clear();
+        vchHash.reserve(32);
+        CSHA256().
+        Write(&vchPubKey[0], vchPubKey.size()).
+        Write(&vchCryptedSecret[0], vchCryptedSecret.size()).
+        Finalize(&vchHash[0]);
     }
 
     /**

--- a/src/wallet/crypter.h
+++ b/src/wallet/crypter.h
@@ -156,7 +156,7 @@ public:
 
     bool Lock();
 
-    virtual bool AddCryptedKey(const CPubKey &vchPubKey, const std::vector<unsigned char> &vchCryptedSecret, const std::vector<unsigned char> &vchHash);
+    virtual bool AddCryptedKey(const CPubKey &vchPubKey, const std::vector<unsigned char> &vchCryptedSecret, const uint256 &hash);
     bool AddKeyPubKey(const CKey& key, const CPubKey &pubkey);
     bool HaveKey(const CKeyID &address) const
     {
@@ -184,15 +184,6 @@ public:
             setAddress.insert((*mi).first);
             mi++;
         }
-    }
-
-    static void CalculateCryptedHash(const CPubKey &vchPubKey, const std::vector<unsigned char> &vchCryptedSecret, std::vector<unsigned char> &vchHash) {
-        vchHash.clear();
-        vchHash.reserve(32);
-        CSHA256().
-        Write(&vchPubKey[0], vchPubKey.size()).
-        Write(&vchCryptedSecret[0], vchCryptedSecret.size()).
-        Finalize(&vchHash[0]);
     }
 
     /**

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -130,9 +130,9 @@ bool CWallet::AddKeyPubKey(const CKey& secret, const CPubKey &pubkey)
 
 bool CWallet::AddCryptedKey(const CPubKey &vchPubKey,
                             const vector<unsigned char> &vchCryptedSecret,
-                            const vector<unsigned char> &vchHash)
+                            const uint256 &hash)
 {
-    if (!CCryptoKeyStore::AddCryptedKey(vchPubKey, vchCryptedSecret, vchHash))
+    if (!CCryptoKeyStore::AddCryptedKey(vchPubKey, vchCryptedSecret, hash))
         return false;
     if (!fFileBacked)
         return true;
@@ -141,12 +141,12 @@ bool CWallet::AddCryptedKey(const CPubKey &vchPubKey,
         if (pwalletdbEncryption)
             return pwalletdbEncryption->WriteCryptedKey(vchPubKey,
                                                         vchCryptedSecret,
-                                                        vchHash,
+                                                        hash,
                                                         mapKeyMetadata[vchPubKey.GetID()]);
         else
             return CWalletDB(strWalletFile).WriteCryptedKey(vchPubKey,
                                                             vchCryptedSecret,
-                                                            vchHash,
+                                                            hash,
                                                             mapKeyMetadata[vchPubKey.GetID()]);
     }
     return false;
@@ -162,13 +162,12 @@ bool CWallet::LoadKeyMetadata(const CPubKey &pubkey, const CKeyMetadata &meta)
     return true;
 }
 
-bool CWallet::LoadCryptedKey(const CPubKey &vchPubKey, const std::vector<unsigned char> &vchCryptedSecret, const std::vector<unsigned char> &vchHash)
+bool CWallet::LoadCryptedKey(const CPubKey &vchPubKey, const std::vector<unsigned char> &vchCryptedSecret, const uint256 &hash)
 {
-    std::vector<unsigned char> vchCheckHash;
-    CCryptoKeyStore::CalculateCryptedHash(vchPubKey, vchCryptedSecret, vchCheckHash);
-    if (!std::equal(vchHash.begin(), vchHash.end(), vchCheckHash.begin()))
+    uint256 check_hash = Hash(vchPubKey.begin(), vchPubKey.end(), vchCryptedSecret.begin(), vchCryptedSecret.end());
+    if (!hash.IsNull() && check_hash != hash)
         return false;
-    return CCryptoKeyStore::AddCryptedKey(vchPubKey, vchCryptedSecret, vchHash);
+    return CCryptoKeyStore::AddCryptedKey(vchPubKey, vchCryptedSecret, hash);
 }
 
 bool CWallet::AddCScript(const CScript& redeemScript)

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -584,9 +584,9 @@ public:
     bool LoadMinVersion(int nVersion) { AssertLockHeld(cs_wallet); nWalletVersion = nVersion; nWalletMaxVersion = std::max(nWalletMaxVersion, nVersion); return true; }
 
     //! Adds an encrypted key to the store, and saves it to disk.
-    bool AddCryptedKey(const CPubKey &vchPubKey, const std::vector<unsigned char> &vchCryptedSecret, const std::vector<unsigned char> &vchHash);
+    bool AddCryptedKey(const CPubKey &vchPubKey, const std::vector<unsigned char> &vchCryptedSecret, const uint256 &hash);
     //! Adds an encrypted key to the store, without saving it to disk (used by LoadWallet)
-    bool LoadCryptedKey(const CPubKey &vchPubKey, const std::vector<unsigned char> &vchCryptedSecret, const std::vector<unsigned char> &vchHash);
+    bool LoadCryptedKey(const CPubKey &vchPubKey, const std::vector<unsigned char> &vchCryptedSecret, const uint256 &hash);
     bool AddCScript(const CScript& redeemScript);
     bool LoadCScript(const CScript& redeemScript);
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -584,9 +584,9 @@ public:
     bool LoadMinVersion(int nVersion) { AssertLockHeld(cs_wallet); nWalletVersion = nVersion; nWalletMaxVersion = std::max(nWalletMaxVersion, nVersion); return true; }
 
     //! Adds an encrypted key to the store, and saves it to disk.
-    bool AddCryptedKey(const CPubKey &vchPubKey, const std::vector<unsigned char> &vchCryptedSecret);
+    bool AddCryptedKey(const CPubKey &vchPubKey, const std::vector<unsigned char> &vchCryptedSecret, const std::vector<unsigned char> &vchHash);
     //! Adds an encrypted key to the store, without saving it to disk (used by LoadWallet)
-    bool LoadCryptedKey(const CPubKey &vchPubKey, const std::vector<unsigned char> &vchCryptedSecret);
+    bool LoadCryptedKey(const CPubKey &vchPubKey, const std::vector<unsigned char> &vchCryptedSecret, const std::vector<unsigned char> &vchHash);
     bool AddCScript(const CScript& redeemScript);
     bool LoadCScript(const CScript& redeemScript);
 

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -85,7 +85,7 @@ bool CWalletDB::WriteKey(const CPubKey& vchPubKey, const CPrivKey& vchPrivKey, c
 
 bool CWalletDB::WriteCryptedKey(const CPubKey& vchPubKey,
                                 const std::vector<unsigned char>& vchCryptedSecret,
-                                const vector<unsigned char> &vchHash,
+                                const uint256 &hash,
                                 const CKeyMetadata &keyMeta)
 {
     const bool fEraseUnencryptedKey = true;
@@ -95,7 +95,7 @@ bool CWalletDB::WriteCryptedKey(const CPubKey& vchPubKey,
             keyMeta))
         return false;
 
-    if (!Write(std::make_pair(std::string("ckey"), vchPubKey), std::make_pair(vchCryptedSecret, vchHash), false))
+    if (!Write(std::make_pair(std::string("ckey"), vchPubKey), std::make_pair(vchCryptedSecret, hash), false))
         return false;
     if (fEraseUnencryptedKey)
     {
@@ -524,7 +524,7 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
             ssValue >> vchPrivKey;
             wss.nCKeys++;
 
-            vector<unsigned char> vchHash;
+            uint256 hash;
 
             // Old wallets store keys as "key" [pubkey] => [privkey]
             // ... which was slow for wallets with lots of keys, because the public key is re-derived from the private key
@@ -533,11 +533,11 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
             // remaining backwards-compatible.
             try
             {
-                ssValue >> vchHash;
+                ssValue >> hash;
             }
             catch (...) {}
 
-            if (!pwallet->LoadCryptedKey(vchPubKey, vchPrivKey, vchHash))
+            if (!pwallet->LoadCryptedKey(vchPubKey, vchPrivKey, hash))
             {
                 strErr = "Error reading wallet database: LoadCryptedKey failed";
                 return false;

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -510,6 +510,11 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
             pwallet->mapMasterKeys[nID] = kMasterKey;
             if (pwallet->nMasterKeyMaxID < nID)
                 pwallet->nMasterKeyMaxID = nID;
+            if(pwallet->mapMasterKeys.size() > 1)
+            {
+                strErr = "Error reading wallet database: multiple CMasterKey entries";
+                return false;
+            }
         }
         else if (strType == "ckey")
         {

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -89,7 +89,7 @@ public:
     bool EraseTx(uint256 hash);
 
     bool WriteKey(const CPubKey& vchPubKey, const CPrivKey& vchPrivKey, const CKeyMetadata &keyMeta);
-    bool WriteCryptedKey(const CPubKey& vchPubKey, const std::vector<unsigned char>& vchCryptedSecret, const CKeyMetadata &keyMeta);
+    bool WriteCryptedKey(const CPubKey& vchPubKey, const std::vector<unsigned char>& vchCryptedSecret, const std::vector<unsigned char>& vchHash, const CKeyMetadata &keyMeta);
     bool WriteMasterKey(unsigned int nID, const CMasterKey& kMasterKey);
 
     bool WriteCScript(const uint160& hash, const CScript& redeemScript);

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -89,7 +89,7 @@ public:
     bool EraseTx(uint256 hash);
 
     bool WriteKey(const CPubKey& vchPubKey, const CPrivKey& vchPrivKey, const CKeyMetadata &keyMeta);
-    bool WriteCryptedKey(const CPubKey& vchPubKey, const std::vector<unsigned char>& vchCryptedSecret, const std::vector<unsigned char>& vchHash, const CKeyMetadata &keyMeta);
+    bool WriteCryptedKey(const CPubKey& vchPubKey, const std::vector<unsigned char>& vchCryptedSecret, const uint256 &hash, const CKeyMetadata &keyMeta);
     bool WriteMasterKey(unsigned int nID, const CMasterKey& kMasterKey);
 
     bool WriteCScript(const uint160& hash, const CScript& redeemScript);


### PR DESCRIPTION
Currently when encrypted wallets are unlocked the encrypted private keys are checked against the public key by deriving the public key.

The existing process is robust but very expensive and cannot detect wallet corruption on wallet load.

Adding H(pubkey, cryptedprivkey) to the wallet entry allows for rapid verification and corruption detection on wallet load.
