### PR TITLE
[trivial] White space, clang-format and docs

### DIFF
--- a/contrib/devtools/README.md
+++ b/contrib/devtools/README.md
@@ -62,6 +62,11 @@ optimize-pngs.py
 A script to optimize png files in the bitcoin
 repository (requires pngcrush).
 
+security-check.py and test-security-check.py
+============================================
+
+Perform basic ELF security checks on a series of executables.
+
 symbol-check.py
 ===============
 

--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -32,7 +32,7 @@ Instructions: Homebrew
 
 #### Install dependencies using Homebrew
 
-        brew install autoconf automake berkeley-db4 libtool boost miniupnpc openssl pkg-config protobuf qt5 libevent
+    brew install autoconf automake berkeley-db4 libtool boost miniupnpc openssl pkg-config protobuf qt5 libevent
 
 NOTE: Building with Qt4 is still supported, however, could result in a broken UI. As such, building with Qt5 is recommended.
 

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -61,24 +61,24 @@ Dependency Build Instructions: Ubuntu & Debian
 ----------------------------------------------
 Build requirements:
 
-        sudo apt-get install build-essential libtool autotools-dev autoconf pkg-config libssl-dev libevent-dev
+    sudo apt-get install build-essential libtool autotools-dev autoconf pkg-config libssl-dev libevent-dev
 
 On Ubuntu 15.10+ there are generic names for the individual boost development
 packages, so the following can be used to only install necessary parts of
 boost:
 
-        apt-get install libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-program-options-dev libboost-test-dev libboost-thread-dev libboost-base-dev
+    apt-get install libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-program-options-dev libboost-test-dev libboost-thread-dev libboost-base-dev
 
 For Ubuntu before 15.10, or Debian 7 and later libboost-all-dev has to be installed:
 
-        sudo apt-get install libboost-all-dev
+    sudo apt-get install libboost-all-dev
 
 BerkeleyDB is required for the wallet. db4.8 packages are available [here](https://launchpad.net/~bitcoin/+archive/bitcoin).
 You can add the repository and install using the following commands:
 
-        sudo add-apt-repository ppa:bitcoin/bitcoin
-        sudo apt-get update
-        sudo apt-get install libdb4.8-dev libdb4.8++-dev
+    sudo add-apt-repository ppa:bitcoin/bitcoin
+    sudo apt-get update
+    sudo apt-get install libdb4.8-dev libdb4.8++-dev
 
 Ubuntu and Debian have their own libdb-dev and libdb++-dev packages, but these will install
 BerkeleyDB 5.1 or later, which break binary wallet compatibility with the distributed executables which
@@ -89,11 +89,11 @@ See the section "Disable-wallet mode" to build Bitcoin Core without wallet.
 
 Optional:
 
-        sudo apt-get install libminiupnpc-dev (see --with-miniupnpc and --enable-upnp-default)
+    sudo apt-get install libminiupnpc-dev (see --with-miniupnpc and --enable-upnp-default)
 
 ZMQ dependencies:
 
-        sudo apt-get install libzmq3-dev (provides ZMQ API 4.x)
+    sudo apt-get install libzmq3-dev (provides ZMQ API 4.x)
 
 Dependencies for the GUI: Ubuntu & Debian
 -----------------------------------------
@@ -213,6 +213,7 @@ Hardening enables the following features:
     	scanelf -e ./bitcoin
 
     The output should contain:
+
      TYPE
     ET_DYN
 

--- a/src/.clang-format
+++ b/src/.clang-format
@@ -1,4 +1,6 @@
+Language:        Cpp
 AccessModifierOffset: -4
+AlignAfterOpenBracket: false
 AlignEscapedNewlinesLeft: true
 AlignTrailingComments: true
 AllowAllParametersOfDeclarationOnNextLine: false
@@ -26,7 +28,6 @@ IndentCaseLabels: false
 IndentFunctionDeclarationAfterType: false
 IndentWidth:     4
 KeepEmptyLinesAtTheStartOfBlocks: false
-Language:        Cpp
 MaxEmptyLinesToKeep: 2
 NamespaceIndentation: None
 ObjCSpaceAfterProperty: false


### PR DESCRIPTION
Rendered diff:
- Before: https://github.com/bitcoin/bitcoin/blob/master/doc/build-unix.md#dependency-build-instructions-ubuntu--debian
- After: https://github.com/MarcoFalke/bitcoin/blob/4bd96aaf9fa7e4cf7c4e9c451a33dc41aba2553c/doc/build-unix.md#dependency-build-instructions-ubuntu--debian

`.clang-format` change:
- E.g. d2da9395c946bfe2d87694f2e0a2992fbd963349
