### PR TITLE
[Docs] First-draft release notes for 0.11.2RC1

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -2,8 +2,9 @@ Bitcoin Core version 0.11.2 is now available from:
 
   <https://bitcoin.org/bin/bitcoin-core-0.11.2/>
 
-This is a new minor version release, bringing new features and bug fixes. It is recommended
-to upgrade to this version as soon as possible.
+This is a new minor version release, bringing bug fixes, the BIP65
+(CLTV) consensus change, and relay policy preparation for BIP113. It is
+recommended to upgrade to this version as soon as possible.
 
 Please report bugs using the issue tracker at github:
 
@@ -87,7 +88,7 @@ version FIXME or any version from FIXME onward.
 
 [BIP65]: https://github.com/bitcoin/bips/blob/master/bip-0065.mediawiki
 
-BIP113 mempool-only locktime enforment using GetMedianTimePast()
+BIP113 mempool-only locktime enforcement using GetMedianTimePast()
 ----------------------------------------------------------------
 
 Bitcoin transactions currently may specify a locktime indicating when
@@ -118,10 +119,13 @@ This release begins applying the BIP113 rule to received transactions,
 so transaction whose time is greater than the GetMedianTimePast() will
 no longer be accepted into the mempool.
 
-**Implication for miners:** you may begin rejecting locktime
-transactions that could be included under the current consensus rules.
-Rejecting those transactions now means that you don't have to worry
-about producing invalid blocks when BIP113 becomes consensus enforced.
+**Implication for miners:** you will begin rejecting transactions that
+would not be valid under BIP113, which will prevent you from producing
+invalid blocks if/when BIP113 is enforced on the network. Any
+transactions which are valid under the current rules but not yet valid
+under the BIP113 rules will either be mined by other miners or delayed
+until they are valid under BIP113. Note, however, that time-based
+locktime transactions are more or less unseen on the network currently.
 
 **Implication for users:** GetMedianTimePast() always trails behind the
 current time, so a transaction locktime set to the present time will be
@@ -167,6 +171,7 @@ Credits
 Thanks to everyone who directly contributed to this release:
 
 - Alex Morcos
+- ฿tcDrak
 - Chris Kleeschulte
 - Daniel Cousens
 - Diego Viola

--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -60,7 +60,7 @@ specified point in the future.
    output if they comply with the BIP65 rules as provided in code.
 
 2. This release will produce version 4 blocks by default. Please see the
-   *notice to miners below*.
+   *notice to miners* below.
 
 3. Once 951 out of a sequence of 1,001 blocks on the local node's best block
    chain contain version 4 (or higher) blocks, this release will no
@@ -69,6 +69,15 @@ specified point in the future.
 
 For more information about the soft-forking change, please see
 <https://github.com/bitcoin/bitcoin/pull/6351>
+
+Graphs showing the progress towards block version 4 adoption may be
+found at the URLs below:
+
+- Block versions over the last 50,000 blocks as progress towards BIP65
+  consensus enforcement: <http://bitcoin.sipa.be/ver-50k.png>
+
+- Block versions over the last 2,000 blocks showing the days to the
+  earliest possible BIP65 consensus-enforced block: <http://bitcoin.sipa.be/ver-2k.png>
 
 **Notice to miners:** Bitcoin Core’s block templates are now for
 version 4 blocks only, and any mining software relying on its
@@ -84,7 +93,7 @@ version FIXME or any version from FIXME onward.
 
 - If you are mining with the getblocktemplate protocol to a pool: this
   will affect you at the pool operator’s discretion, which must be no
-  later than BIP66 achieving its 951/1001 status.
+  later than BIP65 achieving its 951/1001 status.
 
 [BIP65]: https://github.com/bitcoin/bips/blob/master/bip-0065.mediawiki
 
@@ -130,11 +139,26 @@ locktime transactions are more or less unseen on the network currently.
 **Implication for users:** GetMedianTimePast() always trails behind the
 current time, so a transaction locktime set to the present time will be
 rejected by nodes running this release until the median time moves
-forward. To compensate, subtract one hour (3,600) seconds from your
+forward. To compensate, subtract one hour (3,600 seconds) from your
 locktimes to allow those transactions to be included in mempools at
 approximately the expected time.
 
 [BIP113]: https://github.com/bitcoin/bips/blob/master/bip-0113.mediawiki
+
+Windows bug fix for corrupted UTXO database on unclean shutdowns
+----------------------------------------------------------------
+
+Several Windows users reported that they often need to reindex the
+entire blockchain after an unclean shutdown of Bitcoin Core on Windows
+(or an unclean shutdown of Windows itself). Although unclean shutdowns
+remain unsafe, this release no longer relies on memory-mapped files for
+the UTXO database, which significantly reduced the frequency of unclean
+shutdowns leading to required reindexes during testing.
+
+For more information, see: <https://github.com/bitcoin/bitcoin/pull/6917>
+
+Other fixes for database corruption on Windows are expected in the
+next major release.
 
 0.11.1 Change log
 =================


### PR DESCRIPTION
FIXMEs:
- [ ] This mentions that a new libblkmaker is needed but has FIXME for the version number.  (@luke-jr knows about this via IRC)
- [ ] @petertodd and @maaku should really review the sections, respectively, about CLTV and BIP113 as my descriptions of them are probably flawed.
- [ ] _Additional contributions and security research_ doesn't mention anyone specifically; if it should, please tell me who or update yourself at merge time.

Please feel free to make any other changes at merge time.

For reference, I generated the commit-level changelog from here: https://github.com/bitcoin/bitcoin/compare/v0.11.1...v0.11.2rc1

And to make sure I didn't miss anything, I documented everything but the merge commits.  Here's the complete changelog in the same order as that compare link above.  Commits in bold are the ones I omitted from this pull because they didn't seem to affect behavior.  (Commits not in bold are included in these notes.)
- #6707 684636b Make CScriptNum() take nMaxNumSize as an argument
- **#6707 6ec08db Move LOCKTIME_THRESHOLD to src/script/script.h**
- #6707 4fa7a04 Replace NOP2 with CHECKLOCKTIMEVERIFY (BIP65)
- #6707 6ea5ca4 Enable CHECKLOCKTIMEVERIFY as a standard script verify flag
- #6707 5e82e1c Add CHECKLOCKTIMEVERIFY (BIP65) soft-fork logic
- **#6707 c5a27f4 Add RPC tests for the CHECKLOCKTIMEVERIFY (BIP65) soft-fork**
- **#6707 70a427b CLTV: Add more tests to improve coverage**
- #6707 ba1da90 Show softfork status in getblockchaininfo
- # 6707 6af25b0 Add BIP65 to getblockchaininfo softforks list
- **#6825 9b9acc2 Fix spelling of Qt**
- #6825 01878c9 Fix locking in GetTransaction
- #6825 b3eaa30 [Qt] Raise debug window when requested
- #6825 1e672ae Debian/Ubuntu: Include bitcoin-tx binary
- #6825 2394f4d Debian/Ubuntu: Split bitcoin-tx into its own package
- **#6825 6fd0019 Drop "with minimal dependencies" from description**
- **#6825 a33cd5b [trivial] Fix rpc message "help generate"**
- **#6825 87a797a build: Remove dependency of bitcoin-cli on secp256k1**
- #6825 33d6825 Bugfix: Allow mining on top of old tip blocks for testnet
- **#6825 9e45157 build: disable -Wself-assign**
- **#6825 bfc6154 [Trivial] Fixed typo when referring to a previous section in**
- **#6825 54f9dee Update bluematt-key, the old one is long-since revoked**
- **#6825 e42bf16 Clarification of unit test build instructions.**
- **#6945 09a00a1 Add historical release notes for October 2015 bugfix releases**
- # 6945 21e58b8 build: make sure OpenSSL heeds noexecstack
- **#6945 0720324 Make fee aware of min relay in pruning.py RPC test**
- **#6825 4fbfebe Correct spelling mistakes in doc folder**
- **#6825 7ce2c91 Update debian/changelog and slight tweak to debian/control**
- **#6825 131d7f9 Change URLs to https in debian/control**
- # 6825 af6edac alias -h for --help
- # 6945 95a5039 Set TCP_NODELAY on P2P sockets.
- #6945 dfe55bd Do not allow blockfile pruning during reindex.
- #6884 a1d3c6f Add rules--presently disabled--for using GetMedianTimePast as end point for lock-time calculations
- # 6884 f720c5f Enable policy enforcing GetMedianTimePast as the end point of lock-time constraints
- # 6917  0af5b8e leveldb: Win32WritableFile without memory mapping
- # 6945 70de437 Update LevelDB
- # 6948 4e895b0 Always flush block and undo when switching to new file
