### PR TITLE
doc: there is no libboost-base-dev, add missing sudo in release notes

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -61,15 +61,15 @@ Dependency Build Instructions: Ubuntu & Debian
 ----------------------------------------------
 Build requirements:
 
-    sudo apt-get install build-essential libtool autotools-dev autoconf pkg-config libssl-dev libevent-dev
+    sudo apt-get install build-essential libtool autotools-dev autoconf pkg-config libssl-dev libevent-dev bsdmainutils
 
-On Ubuntu 15.10+ there are generic names for the individual boost development
-packages, so the following can be used to only install necessary parts of
-boost:
+On at least Ubuntu 14.04+ and Debian 7+ there are generic names for the
+individual boost development packages, so the following can be used to only
+install necessary parts of boost:
 
-    apt-get install libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-program-options-dev libboost-test-dev libboost-thread-dev libboost-base-dev
+    sudo apt-get install libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-program-options-dev libboost-test-dev libboost-thread-dev
 
-For Ubuntu before 15.10, or Debian 7 and later libboost-all-dev has to be installed:
+If that doesn't work, you can install all boost development packages with:
 
     sudo apt-get install libboost-all-dev
 


### PR DESCRIPTION
- There is no libboost-base-dev (on any distro version), no idea how I ended up with this
  - Without that, installing separate boost packages works fine on both Ubuntu 14.04 and Debian 7 (tested on VMs), this did not use to be the case, AFAIK
- Add a missing 'sudo' for consistency
- Need `bsdmainutils` for `hexdump` (for the tests). The gitian descriptors already "knew" this: https://github.com/bitcoin/bitcoin/blob/master/contrib/gitian-descriptors/gitian-linux.yml#L16

[skip ci]

Edit: also tested on Debian 8
