### PR TITLE
Fix crash in validateaddress with -disablewallet

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -68,6 +68,7 @@ testScripts = [
     'decodescript.py',
     'p2p-fullblocktest.py',
     'blockchain.py',
+    'disablewallet.py',
 ]
 testScriptsExt = [
     'bip65-cltv.py',

--- a/qa/rpc-tests/disablewallet.py
+++ b/qa/rpc-tests/disablewallet.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python2
+# Copyright (c) 2014 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#
+# Exercise API with -disablewallet.
+#
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+
+class DisableWalletTest (BitcoinTestFramework):
+
+    def setup_chain(self):
+        print("Initializing test directory "+self.options.tmpdir)
+        initialize_chain_clean(self.options.tmpdir, 1)
+
+    def setup_network(self, split=False):
+        self.nodes = start_nodes(1, self.options.tmpdir, [['-disablewallet']])
+        self.is_network_split = False
+        self.sync_all()
+
+    def run_test (self):
+        # Check regression: https://github.com/bitcoin/bitcoin/issues/6963#issuecomment-154548880
+        x = self.nodes[0].validateaddress('3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy')
+        assert(x['isvalid'] == False)
+        x = self.nodes[0].validateaddress('mneYUmWYsuk7kySiURxCi3AGxrAqZxLgPZ')
+        assert(x['isvalid'] == True)
+
+if __name__ == '__main__':
+    DisableWalletTest ().main ()

--- a/src/rpcmisc.cpp
+++ b/src/rpcmisc.cpp
@@ -117,7 +117,7 @@ public:
         UniValue obj(UniValue::VOBJ);
         CPubKey vchPubKey;
         obj.push_back(Pair("isscript", false));
-        if (pwalletMain->GetPubKey(keyID, vchPubKey)) {
+        if (pwalletMain && pwalletMain->GetPubKey(keyID, vchPubKey)) {
             obj.push_back(Pair("pubkey", HexStr(vchPubKey)));
             obj.push_back(Pair("iscompressed", vchPubKey.IsCompressed()));
         }
@@ -128,7 +128,7 @@ public:
         UniValue obj(UniValue::VOBJ);
         CScript subscript;
         obj.push_back(Pair("isscript", true));
-        if (pwalletMain->GetCScript(scriptID, subscript)) {
+        if (pwalletMain && pwalletMain->GetCScript(scriptID, subscript)) {
             std::vector<CTxDestination> addresses;
             txnouttype whichType;
             int nRequired;


### PR DESCRIPTION
Fix a null pointer dereference in validateaddress with -disablewallet. Also add a regression testcase.

Problem reported here: https://github.com/bitcoin/bitcoin/issues/6963#issuecomment-154548880

I think this needs to be backported to 0.11 as well.
