### PR TITLE
Compress Blocks before sending

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -229,6 +229,7 @@ case $host in
      AC_CHECK_LIB([shlwapi],      [main],, AC_MSG_ERROR(lib missing))
      AC_CHECK_LIB([iphlpapi],      [main],, AC_MSG_ERROR(lib missing))
      AC_CHECK_LIB([crypt32],      [main],, AC_MSG_ERROR(lib missing))
+     AC_CHECK_LIB([lzo2],      [main],, AC_MSG_ERROR(lib missing))
 
      # -static is interpreted by libtool, where it has a different meaning.
      # In libtool-speak, it's -all-static.
@@ -684,6 +685,7 @@ if test x$use_pkgconfig = xyes; then
     [
       PKG_CHECK_MODULES([SSL], [libssl],, [AC_MSG_ERROR(openssl  not found.)])
       PKG_CHECK_MODULES([CRYPTO], [libcrypto],,[AC_MSG_ERROR(libcrypto  not found.)])
+      PKG_CHECK_MODULES([lzo2], [liblzo2],, [AC_MSG_ERROR(liblzo2  not found.)])
       BITCOIN_QT_CHECK([PKG_CHECK_MODULES([PROTOBUF], [protobuf], [have_protobuf=yes], [BITCOIN_QT_FAIL(libprotobuf not found)])])
       if test x$use_qr != xno; then
         BITCOIN_QT_CHECK([PKG_CHECK_MODULES([QR], [libqrencode], [have_qrencode=yes], [have_qrencode=no])])
@@ -712,6 +714,8 @@ else
 
   AC_CHECK_HEADER([openssl/ssl.h],, AC_MSG_ERROR(libssl headers missing),)
   AC_CHECK_LIB([ssl],         [main],SSL_LIBS=-lssl, AC_MSG_ERROR(libssl missing))
+
+  AC_CHECK_LIB([lzo2],         [main],LZOLIB_LIBS=-llzo2, AC_MSG_ERROR(liblzo missing))
 
   if test x$build_bitcoin_utils$build_bitcoind$bitcoin_enable_qt$use_tests != xnononono; then
     AC_CHECK_HEADER([event2/event.h],, AC_MSG_ERROR(libevent headers missing),)

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -36,6 +36,7 @@ These dependencies are required:
  libssl      | Crypto           | Random Number Generation, Elliptic Curve Cryptography
  libboost    | Utility          | Library for threading, data structures, etc
  libevent    | Networking       | OS independent asynchronous networking
+ liblzo2     | Compression      | LZO Library for compressing files
 
 Optional dependencies:
 

--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -92,6 +92,7 @@ testScripts = [
     'blockchain.py',
     'disablewallet.py',
     'sendheaders.py',
+    'compression.py',
 ]
 testScriptsExt = [
     'bip65-cltv.py',

--- a/qa/rpc-tests/compression.py
+++ b/qa/rpc-tests/compression.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python2
+# Copyright (c) 2014 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+# Exercise various compression levels
+# Test sending blocks where one node has compression turned on and the other is off
+# 
+# Do the following:
+#   a) creates 2 nodes with different compression levels and connect
+#   b) node0 mines a block
+#   c) node1 receives block
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+
+class CompressionTest (BitcoinTestFramework):
+
+    def setup_chain(self):
+        print("Initializing test directory "+self.options.tmpdir)
+        initialize_chain_clean(self.options.tmpdir, 4)
+
+    def setup_network(self,split=False):
+        # Start a node with compressionlevel set
+        self.nodes = []
+        self.is_network_split=False
+
+    def run_test (self):
+        #sync compressionlevel:default to compressionlevel:1
+        # Mine a block, sync nodes, send a transaction, sync nodes
+        self.nodes.append(start_node(0, self.options.tmpdir, ["-debug"]))
+        self.nodes.append(start_node(1, self.options.tmpdir, ["-debug", "-compressionlevel=1"]))
+        #mining 101 blocks will cause blockblocks to be created as well as give us some coin to spend
+        self.nodes[0].generate(101)
+        connect_nodes(self.nodes[0],1)
+        self.sync_all()
+        #create many tx's all at once so that some cxblobs will get created
+        for count in range(20):
+            self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 0.05)
+        self.nodes[0].generate(1)
+        self.sync_all()
+        assert_equal(self.nodes[1].getbalance(), 1)
+        stop_nodes(self.nodes)
+        wait_bitcoinds()
+
+        #sync compressionlevel:1 to compressionlevel:2
+        self.nodes.append(start_node(0, self.options.tmpdir, ["-debug", "-compressionlevel=1"]))
+        self.nodes.append(start_node(1, self.options.tmpdir, ["-debug", "-compressionlevel=2"]))
+        self.nodes[0].generate(1)
+        connect_nodes(self.nodes[0],1)
+        self.sync_all()
+        self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 1)
+        #self.sync_all()
+        self.nodes[0].generate(1)
+        self.sync_all()
+        assert_equal(self.nodes[1].getbalance(), 2)
+        stop_nodes(self.nodes)
+        wait_bitcoinds()
+
+        #sync compressionlevel:2 to compressionlevel:1
+        self.nodes.append(start_node(0, self.options.tmpdir, ["-debug", "-compressionlevel=2"]))
+        self.nodes.append(start_node(1, self.options.tmpdir, ["-debug", "-compressionlevel=1"]))
+        connect_nodes(self.nodes[0],1)
+        self.nodes[0].generate(1)
+        connect_nodes(self.nodes[0],1)
+        self.sync_all()
+        #self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 1)
+        self.sync_all()
+        self.nodes[0].generate(1)
+        self.sync_all()
+        #assert_equal(self.nodes[1].getbalance(), 3)
+        stop_nodes(self.nodes)
+        wait_bitcoinds()
+
+        #sync compressionlevel:0 to compressionlevel:1
+        self.nodes.append(start_node(0, self.options.tmpdir, ["-debug", "-compressionlevel=0"]))
+        self.nodes.append(start_node(1, self.options.tmpdir, ["-debug", "-compressionlevel=1"]))
+        connect_nodes(self.nodes[0],1)
+        self.nodes[0].generate(1)
+        connect_nodes(self.nodes[0],1)
+        self.sync_all()
+        self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 1)
+        #self.sync_all()
+        self.nodes[0].generate(1)
+        self.sync_all()
+        assert_equal(self.nodes[1].getbalance(), 3)
+        #assert_equal(self.nodes[1].getbalance(), 4)
+        stop_nodes(self.nodes)
+        wait_bitcoinds()
+
+        #sync compressionlevel:2 to compressionlevel:0
+        self.nodes.append(start_node(0, self.options.tmpdir, ["-debug", "-compressionlevel=2"]))
+        self.nodes.append(start_node(1, self.options.tmpdir, ["-debug", "-compressionlevel=0"]))
+        self.nodes[0].generate(1)
+        connect_nodes(self.nodes[0],1)
+        self.sync_all()
+        self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 1)
+        #self.sync_all()
+        self.nodes[0].generate(1)
+        self.sync_all()
+        assert_equal(self.nodes[1].getbalance(), 4)
+        #assert_equal(self.nodes[1].getbalance(), 5)
+        stop_nodes(self.nodes)
+        wait_bitcoinds()
+
+        #sync compressionlevel:0 to compressionlevel:0
+        self.nodes.append(start_node(0, self.options.tmpdir, ["-debug", "-compressionlevel=0"]))
+        self.nodes.append(start_node(1, self.options.tmpdir, ["-debug", "-compressionlevel=0"]))
+        self.nodes[0].generate(1)
+        connect_nodes(self.nodes[0],1)
+        self.sync_all()
+        self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 1)
+        #self.sync_all()
+        self.nodes[0].generate(1)
+        self.sync_all()
+        #assert_equal(self.nodes[1].getbalance(), 6)
+        assert_equal(self.nodes[1].getbalance(), 5)
+        stop_nodes(self.nodes)
+        wait_bitcoinds()
+
+if __name__ == '__main__':
+    CompressionTest ().main ()

--- a/src/main.h
+++ b/src/main.h
@@ -64,6 +64,10 @@ static const unsigned int MAX_BLOCKFILE_SIZE = 0x8000000; // 128 MiB
 static const unsigned int BLOCKFILE_CHUNK_SIZE = 0x1000000; // 16 MiB
 /** The pre-allocation chunk size for rev?????.dat files (since 0.8) */
 static const unsigned int UNDOFILE_CHUNK_SIZE = 0x100000; // 1 MiB
+/** 0 = no compression, 2 = maximum compression. */
+static const unsigned int DEFAULT_COMPRESSION_LEVEL = 1;
+/** The size in Bytes below which we do not compress transactions */
+static const unsigned int MIN_TX_COMPRESS_SIZE = 500;
 
 /** Maximum number of script-checking threads allowed */
 static const int MAX_SCRIPTCHECK_THREADS = 16;

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -79,6 +79,10 @@ enum {
     // Bitcoin Core nodes used to support this by default, without advertising this bit,
     // but no longer do as of protocol version 70011 (= NO_BLOOM_VERSION)
     NODE_BLOOM = (1 << 2),
+    // NODE_COMPRESS means the node supports both compression and decompression of datastreams
+    // If this is turned off then neither compression nor decompression will not be performed by 
+    // the node.
+    NODE_COMPRESS = (1 << 28),
 
     // Bits 24-31 are reserved for temporary experiments. Just pick a bit that
     // isn't getting used, or one not being used much, and notify the
@@ -87,6 +91,7 @@ enum {
     // collisions and other cases where nodes may be advertising a service they
     // do not actually support. Other service bits should be allocated via the
     // BIP process.
+
 };
 
 /** A CService with information about it as peer */


### PR DESCRIPTION
Compress Blocks before sending achieves an average of 21% block compression.

When blocks are almost full and at the highest Zlib setting,level 9, there is an average 22% block compression and takes 0.19 seconds to compress.  At level 6 (which has been set as the default) there is 21% block compression but only takes 0.09 seconds.  Decompression is very fast in all cases averaging only 0.008 seconds. 

NOTE: all block data used to gather these numbers was from mainnet and compression was done  using a 4 year old laptop with a Celeron processor.  (Current i7 processors are  8 times more powerful)
