### PR TITLE
Always allow getheaders from whitelisted peers

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4303,10 +4303,10 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         vRecv >> locator >> hashStop;
 
         LOCK(cs_main);
-
-        if (IsInitialBlockDownload())
+        if (IsInitialBlockDownload() && !pfrom->fWhitelisted) {
+            LogPrint("net", "Ignoring getheaders from peer=%d because node is in initial block download\n", pfrom->id);
             return true;
-
+        }
         CBlockIndex* pindex = NULL;
         if (locator.IsNull())
         {


### PR DESCRIPTION
Process `getheaders` messages from whitelisted peers even if we are in initial block download. Whitelisted peers can always use a node as a block source.

Also log a debug message when the request is ignored, for troubleshooting.

Addresses #6971.
