### PR TITLE
Globals: Make AcceptBlockHeader static (Fix #6163) (AcceptBlockHeader)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2781,9 +2781,8 @@ bool ContextualCheckBlock(const CBlock& block, CValidationState& state, CBlockIn
     return true;
 }
 
-bool AcceptBlockHeader(const CBlockHeader& block, CValidationState& state, CBlockIndex** ppindex)
+static bool AcceptBlockHeader(const CBlockHeader& block, CValidationState& state, const CChainParams& chainparams, CBlockIndex** ppindex=NULL)
 {
-    const CChainParams& chainparams = Params();
     AssertLockHeld(cs_main);
     // Check for duplicate
     uint256 hash = block.GetHash();
@@ -2836,7 +2835,7 @@ bool AcceptBlock(const CBlock& block, CValidationState& state, CBlockIndex** ppi
 
     CBlockIndex *&pindex = *ppindex;
 
-    if (!AcceptBlockHeader(block, state, &pindex))
+    if (!AcceptBlockHeader(block, state, chainparams, &pindex))
         return false;
 
     // Try to process all requested blocks that we don't have, but only
@@ -4498,7 +4497,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                 Misbehaving(pfrom->GetId(), 20);
                 return error("non-continuous headers sequence");
             }
-            if (!AcceptBlockHeader(header, state, &pindexLast)) {
+            if (!AcceptBlockHeader(header, state, chainparams, &pindexLast)) {
                 int nDoS;
                 if (state.IsInvalid(nDoS)) {
                     if (nDoS > 0)

--- a/src/main.h
+++ b/src/main.h
@@ -380,7 +380,6 @@ bool TestBlockValidity(CValidationState &state, const CBlock& block, CBlockIndex
 
 /** Store block on disk. If dbp is non-NULL, the file is known to already reside on disk */
 bool AcceptBlock(const CBlock& block, CValidationState& state, CBlockIndex **pindex, bool fRequested, CDiskBlockPos* dbp);
-bool AcceptBlockHeader(const CBlockHeader& block, CValidationState& state, const Consensus::Params& consensusParams, CBlockIndex **ppindex= NULL);
 
 
 class CBlockFileInfo


### PR DESCRIPTION
As discussed in https://github.com/jtimon/bitcoin/commit/87cbdb8b41eee4067023cfa0d9d68722da74a5eb#commitcomment-14304228, the PR #6163 (commit https://github.com/jtimon/bitcoin/commit/87cbdb8b41eee4067023cfa0d9d68722da74a5eb )  contained one error: it changed AcceptBlockHeader's declaration without correspondingly changing its definition and it also added Consensus::Params as parameter instead of CChainParams.
This fixes the mistake.
