### PR TITLE
http: speed up shutdown

### DIFF
--- a/src/httpserver.h
+++ b/src/httpserver.h
@@ -28,7 +28,7 @@ bool InitHTTPServer();
  * This is separate from InitHTTPServer to give users race-condition-free time
  * to register their handlers between InitHTTPServer and StartHTTPServer.
  */
-bool StartHTTPServer(boost::thread_group& threadGroup);
+bool StartHTTPServer();
 /** Interrupt HTTP server threads */
 void InterruptHTTPServer();
 /** Stop HTTP server */

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -661,7 +661,7 @@ bool AppInitServers(boost::thread_group& threadGroup)
         return false;
     if (GetBoolArg("-rest", false) && !StartREST())
         return false;
-    if (!StartHTTPServer(threadGroup))
+    if (!StartHTTPServer())
         return false;
     return true;
 }


### PR DESCRIPTION
Pardon a bit of iteration. This continues/fixes #6719.

`event_base_loopexit` was not doing what I expected it to. What I expected was that it sets a timeout, given that no other pending events it would exit in N seconds. However, what it does was delay the event loop exit with N seconds, even if nothing is pending.

Solve it in a different way: give the event loop thread time to exit out of itself, and if it doesn't, send loopbreak (and then join it).

This speeds up the RPC tests a lot, each exit incurred a 10 second overhead, with this change there should be no shutdown overhead in the common case and up to two seconds if the event loop is blocking.

As a bonus this breaks dependency on the global boost::thread_group, as the HTTP server minds its own offspring.

Time for rpctests with this patch:

```
real    7m50.215s
user    0m30.152s
sys     0m11.752s
```

Without:

```
real    13m12.069s
user    0m30.412s
sys     0m11.168s
```
