### PR TITLE
Minor: Clarify 'fee' field in fundrawtransaction help text

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2396,7 +2396,7 @@ UniValue fundrawtransaction(const UniValue& params, bool fHelp)
                             "\nResult:\n"
                             "{\n"
                             "  \"hex\":       \"value\", (string)  The resulting raw transaction (hex-encoded string)\n"
-                            "  \"fee\":       n,         (numeric) The fee added to the transaction\n"
+                            "  \"fee\":       n,         (numeric) Fee the resulting transaction pays\n"
                             "  \"changepos\": n          (numeric) The position of the added change output, or -1\n"
                             "}\n"
                             "\"hex\"             \n"


### PR DESCRIPTION
Previous text could be interpreted as the the _additional_ fee paid by the result on top of the fee the original version paid, rather than the correct interpretation: the absolute fee the resulting tx pays.
