### PR TITLE
[WIP] [Mempool] Add space for priority transactions

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -421,6 +421,7 @@ std::string HelpMessage(HelpMessageMode mode)
         strUsage += HelpMessageOpt("-limitancestorsize=<n>", strprintf("Do not accept transactions whose size with all in-mempool ancestors exceeds <n> kilobytes (default: %u)", DEFAULT_ANCESTOR_SIZE_LIMIT));
         strUsage += HelpMessageOpt("-limitdescendantcount=<n>", strprintf("Do not accept transactions if any ancestor would have <n> or more in-mempool descendants (default: %u)", DEFAULT_DESCENDANT_LIMIT));
         strUsage += HelpMessageOpt("-limitdescendantsize=<n>", strprintf("Do not accept transactions if any ancestor would have more than <n> kilobytes of in-mempool descendants (default: %u).", DEFAULT_DESCENDANT_SIZE_LIMIT));
+        strUsage += HelpMessageOpt("-prioritylimit=<n>", "Reserve <n> bytes for priority space in mempool (default: maxmempool*blockprioritysize/blockmaxsize)");
     }
     string debugCategories = "addrman, alert, bench, coindb, db, lock, rand, rpc, selectcoins, mempool, mempoolrej, net, proxy, prune, http, libevent"; // Don't translate these and qt below
     if (mode == HMM_BITCOIN_QT)

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -17,6 +17,7 @@
 #include "txmempool.h"
 #include "util.h"
 #include "utilstrencodings.h"
+#include "policy/policy.h"
 
 #include <stdint.h>
 
@@ -776,6 +777,10 @@ UniValue mempoolInfoToJSON()
     size_t maxmempool = GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000;
     ret.push_back(Pair("maxmempool", (int64_t) maxmempool));
     ret.push_back(Pair("mempoolminfee", ValueFromAmount(mempool.GetMinFee(maxmempool).GetFeePerK())));
+    double defaultPriorityLimit = (double) GetArg("-blockprioritysize", DEFAULT_BLOCK_PRIORITY_SIZE) / (double) GetArg("-blockmaxsize", DEFAULT_BLOCK_MAX_SIZE);
+    size_t priorityLimit = GetArg("-prioritylimit", defaultPriorityLimit * maxmempool);
+    ret.push_back(Pair("mempoolminpriority", mempool.GetMinPriority(priorityLimit)));
+    ret.push_back(Pair("priorityusage", (int64_t) mempool.GetPriorityUsage()));
 
     return ret;
 }
@@ -791,6 +796,11 @@ UniValue getmempoolinfo(const UniValue& params, bool fHelp)
             "  \"size\": xxxxx                (numeric) Current tx count\n"
             "  \"bytes\": xxxxx               (numeric) Sum of all tx sizes\n"
             "  \"usage\": xxxxx               (numeric) Total memory usage for the mempool\n"
+            "  \"maxmempool\": xxxxx          (numeric) Mempool usage limit\n"
+            "  \"mempoolminfee\": xxxxx       (numeric) Fee required to enter mempool\n"
+            "  \"prioritylimit\": xxxxx       (numeric) Priority usage limit\n"
+            "  \"mempoolminpriority\": xxxxx  (numeric) Priority required to enter mempool\n"
+            "  \"priorityusage\": xxxxx       (numeric) Total memory usage of priority txs\n"
             "}\n"
             "\nExamples:\n"
             + HelpExampleCli("getmempoolinfo", "")


### PR DESCRIPTION
This is a work-in-progress that certainly needs more testing and cleanup -- sharing now in light of discussions happening elsewhere (#6972) about some of the drawbacks from introducing mempool limiting in #6722.

Overall I agree with @sturles in that the existing notion of priority is largely a useful one to differentiate transactions that might be part of an attack from ones that likely are not.  On the other hand, coming up with a mempool limiting algorithm like #6722 that we believe is robust against attack was challenging enough without having to also try to maintain this particular existing policy.

However after further thought I think we can restore some of the useful features of priority without major re-engineering of the mempool.  I propose to reserve some fraction of the mempool (defaults to the blockprioritysize/blockmaxsize) for transactions that have no unconfirmed parents.  Transactions in that space will be sorted by priority at the time of entry to the mempool.

If the priority space in the mempool exceeds its limit, priority transactions will be moved to the feerate portion of the mempool (where they will be sorted based on their feerate and the feerate of any descendants).  Once moved to the feerate area, transactions never move back to the priority area.

New transactions that don't meet the mempool reject fee must meet the new GetMinPriority(), which is increased when priority transactions are moved to the feerate part of the mempool, and decayed as time passes (just like the mempool's minimum fee).

Note that this relies on the rate limiting of free transactions to prevent relay bandwidth DoS attacks using priority transactions.
