### PR TITLE
Don't use hard-coded AllowFree, as this is usually far too low.

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2034,9 +2034,11 @@ bool CWallet::CreateTransaction(const vector<CRecipient>& vecSend, CWalletTx& wt
                 {
                     // Not enough fee: enough priority?
                     double dPriorityNeeded = mempool.estimatePriority(nTxConfirmTarget);
-                    // Not enough mempool history to estimate: use hard-coded AllowFree.
-                    if (dPriorityNeeded <= 0 && AllowFree(dPriority))
-                        break;
+                    // Not enough mempool history to estimate: use first available estimate (within limits).
+		    unsigned int i = 0;
+                    while (i++ < 5  && dPriorityNeeded <= 0) {
+			dPriorityNeeded = mempool.estimatePriority(nTxConfirmTarget + i);
+		    }
 
                     // Small enough, and priority high enough, to send for free
                     if (dPriorityNeeded > 0 && dPriority >= dPriorityNeeded)


### PR DESCRIPTION
Try to find a better estimate for the priority needed for a free transaction within the next few confirmation targets, or just fall back to add a fee if unsuccessful.

Something similar should probably be done with the default fee, since the default is usually much lower than what estimatefee 2 recommends if estimatefee 1 fails.  On the other hand estimatefee usually recommends a much higher fee than actually required for the confirmation target, and this may lead to artificial fee inflation.  When a transaction using the recommended fee/priority doesn't go through in the first block, there is usually something else, e.g. individual miner policy, preventing it.
