### PR TITLE
doc: Remove mention of pulltester from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,17 +55,15 @@ There are also regression and integration tests of the RPC interface, written
 in Python, that are run automatically on the build server.
 These tests can be run with: `qa/pull-tester/rpc-tests.py`
 
-Every pull request is built for both Windows and Linux on a dedicated server,
-and unit and sanity tests are automatically run. The binaries produced may be
-used for manual QA testing — a link to them will appear in a comment on the
-pull request posted by [BitcoinPullTester](https://github.com/BitcoinPullTester). See https://github.com/TheBlueMatt/test-scripts
-for the build/test scripts.
+The Travis CI system makes sure that every pull request is built for Windows
+and Linux, OSX, and that unit and sanity tests are automatically run.
 
 ### Manual Quality Assurance (QA) Testing
 
-Large changes should have a test plan, and should be tested by somebody other
-than the developer who wrote the code.
-See https://github.com/bitcoin/QA/ for how to create a test plan.
+Changes should be tested by somebody other than the developer who wrote the
+code. This is especially important for large or high-risk changes. It is useful
+to add a test plan to the pull request description if testing the changes is
+not straightforward.
 
 Translations
 ------------


### PR DESCRIPTION
We've switched to Travis CI a long time ago.
