### PR TITLE
[Qt] add startup option to reset Qt settings

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -496,6 +496,7 @@ std::string HelpMessage(HelpMessageMode mode)
         strUsage += HelpMessageOpt("-min", _("Start minimized"));
         strUsage += HelpMessageOpt("-rootcertificates=<file>", _("Set SSL root certificates for payment request (default: -system-)"));
         strUsage += HelpMessageOpt("-splash", _("Show splash screen on startup (default: 1)"));
+        strUsage += HelpMessageOpt("-resetguisettings", _("Reset all settings changes made over the GUI"));
         if (showDebug) {
             strUsage += HelpMessageOpt("-uiplatform", "Select platform to customize UI for (one of windows, macosx, other; default: platform compiled on)");
         }

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -202,7 +202,7 @@ public:
     void createPaymentServer();
 #endif
     /// Create options model
-    void createOptionsModel();
+    void createOptionsModel(bool resetSettings);
     /// Create main window
     void createWindow(const NetworkStyle *networkStyle);
     /// Create splash screen
@@ -352,9 +352,9 @@ void BitcoinApplication::createPaymentServer()
 }
 #endif
 
-void BitcoinApplication::createOptionsModel()
+void BitcoinApplication::createOptionsModel(bool resetSettings)
 {
-    optionsModel = new OptionsModel();
+    optionsModel = new OptionsModel(NULL, resetSettings);
 }
 
 void BitcoinApplication::createWindow(const NetworkStyle *networkStyle)
@@ -645,7 +645,7 @@ int main(int argc, char *argv[])
     qInstallMessageHandler(DebugMessageHandler);
 #endif
     // Load GUI settings from QSettings
-    app.createOptionsModel();
+    app.createOptionsModel(mapArgs.count("-resetguisettings") != 0);
 
     // Subscribe to global signals from core
     uiInterface.InitMessage.connect(InitMessage);

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -26,10 +26,10 @@
 #include <QSettings>
 #include <QStringList>
 
-OptionsModel::OptionsModel(QObject *parent) :
+OptionsModel::OptionsModel(QObject *parent, bool resetSettings) :
     QAbstractListModel(parent)
 {
-    Init();
+    Init(resetSettings);
 }
 
 void OptionsModel::addOverriddenOption(const std::string &option)
@@ -38,8 +38,11 @@ void OptionsModel::addOverriddenOption(const std::string &option)
 }
 
 // Writes all missing QSettings with their default values
-void OptionsModel::Init()
+void OptionsModel::Init(bool resetSettings)
 {
+    if (resetSettings)
+        Reset();
+
     QSettings settings;
 
     // Ensure restart flag is unset on client startup

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -24,7 +24,7 @@ class OptionsModel : public QAbstractListModel
     Q_OBJECT
 
 public:
-    explicit OptionsModel(QObject *parent = 0);
+    explicit OptionsModel(QObject *parent = 0, bool resetSettings = false);
 
     enum OptionID {
         StartAtStartup,         // bool
@@ -48,7 +48,7 @@ public:
         OptionIDRowCount,
     };
 
-    void Init();
+    void Init(bool resetSettings = false);
     void Reset();
 
     int rowCount(const QModelIndex & parent = QModelIndex()) const;


### PR DESCRIPTION
~~Fixes #6749.~~ can cure issues like #6749.

Setting a invalid Proxy (`-proxy`) or TorProxy (`-onion`) over the GUI settings panel will result in an `InitError()` (terminate the app) during the next app startup. Qt stores its settings in the windows registry and similar infrastructures and are therefore non-trivial to flush.

This PR adds a startup argument `-resetguisettings` which resets all GUI settings and reenable a smooth startup.
This does not affect the `bitcoin.conf` file (different settings layer).

I'm not entirely happy with this solution because some (most?) non expert users have problems starting bitcoin-qt with a command line argument because it involves opening a shell (cmd.exe, etc.).
