### PR TITLE
Remove LOCK(cs_main) from decodescript

### DIFF
--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -506,7 +506,6 @@ UniValue decodescript(const UniValue& params, bool fHelp)
             + HelpExampleRpc("decodescript", "\"hexstring\"")
         );
 
-    LOCK(cs_main);
     RPCTypeCheck(params, boost::assign::list_of(UniValue::VSTR));
 
     UniValue r(UniValue::VOBJ);


### PR DESCRIPTION
Completely static RPC call that doesn't change or even look at mutable state anywhere.

Fixes issue #7012 
