### PR TITLE
Avoid a compile error on hosts with libevent too old for EVENT_LOG_WARN.

### DIFF
--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -365,6 +365,10 @@ static void HTTPWorkQueueRun(WorkQueue<HTTPClosure>* queue)
 /** libevent event log callback */
 static void libevent_log_cb(int severity, const char *msg)
 {
+#ifndef EVENT_LOG_WARN
+// EVENT_LOG_WARN was added in 2.0.19; but before then _EVENT_LOG_WARN existed.
+# define EVENT_LOG_WARN _EVENT_LOG_WARN
+#endif
     if (severity >= EVENT_LOG_WARN) // Log warn messages and higher without debug category
         LogPrintf("libevent: %s\n", msg);
     else


### PR DESCRIPTION
This means that some low priority libevent errors may get logged with
debugging disabled when they wouldn't otherwise.  In a quick check it
did not appear to be chatty.
