### PR TITLE
Change default block priority size to 0

### DIFF
--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -217,7 +217,8 @@ def start_node(i, dirname, extra_args=None, rpchost=None, timewait=None, binary=
     datadir = os.path.join(dirname, "node"+str(i))
     if binary is None:
         binary = os.getenv("BITCOIND", "bitcoind")
-    args = [ binary, "-datadir="+datadir, "-keypool=1", "-discover=0", "-rest" ]
+    # RPC tests still depend on free transactions
+    args = [ binary, "-datadir="+datadir, "-keypool=1", "-discover=0", "-rest", "-blockprioritysize=50000" ]
     if extra_args is not None: args.extend(extra_args)
     bitcoind_processes[i] = subprocess.Popen(args)
     devnull = open(os.devnull, "w")

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -18,7 +18,7 @@ class CCoinsViewCache;
 static const unsigned int DEFAULT_BLOCK_MAX_SIZE = 750000;
 static const unsigned int DEFAULT_BLOCK_MIN_SIZE = 0;
 /** Default for -blockprioritysize, maximum space for zero/low-fee transactions **/
-static const unsigned int DEFAULT_BLOCK_PRIORITY_SIZE = 50000;
+static const unsigned int DEFAULT_BLOCK_PRIORITY_SIZE = 0;
 /** The maximum size for transactions we're willing to relay/mine */
 static const unsigned int MAX_STANDARD_TX_SIZE = 100000;
 /** Maximum number of signature check operations in an IsStandard() P2SH script */


### PR DESCRIPTION
[As discussed on the mailing list](http://lists.linuxfoundation.org/pipermail/bitcoin-dev/2015-November/011713.html), the current notion of priority is no longer completely supported with the 0.12 release.   (In particular limited mempools will not allow free transactions when they have recently hit their limit).  It is likely that further support will be removed in future release and the current concept is now deprecated.  As such it makes sense to make the mining default not include priority space.  It is still supported to create a priority space if the command line argument is changed.  (To what degree depends on other open PR's)
