### PR TITLE
[contrib] Update versionprefix to "bitcoin-core" in verify.sh

### DIFF
--- a/contrib/verifysfbinaries/verify.sh
+++ b/contrib/verifysfbinaries/verify.sh
@@ -82,7 +82,7 @@ if [ $RET -ne 0 ]; then
       echo "Bad signature."
    elif [ $RET -eq 2 ]; then
       #or if a gpg error has occurred
-      echo "gpg error. Do you have Gavin's code signing key installed?"
+      echo "gpg error. Do you have the Bitcoin Core binary release signing key installed?"
    fi
 
    echo "gpg output:"
@@ -115,5 +115,7 @@ fi
 
 #everything matches! clean up the mess
 clean_up $FILES $SIGNATUREFILENAME $TMPFILE
+
+echo -e "Verified hashes of \n$FILES"
 
 exit 0

--- a/contrib/verifysfbinaries/verify.sh
+++ b/contrib/verifysfbinaries/verify.sh
@@ -17,14 +17,14 @@ function clean_up {
 WORKINGDIR="/tmp/bitcoin"
 TMPFILE="hashes.tmp"
 
-#this URL is used if a version number is not specified as an argument to the script
-SIGNATUREFILE="https://bitcoin.org/bin/0.9.2.1/SHA256SUMS.asc"
-
 SIGNATUREFILENAME="SHA256SUMS.asc"
 RCSUBDIR="test/"
 BASEDIR="https://bitcoin.org/bin/"
-VERSIONPREFIX="bitcoin-"
+VERSIONPREFIX="bitcoin-core-"
 RCVERSIONSTRING="rc"
+
+#this URL is used if a version number is not specified as an argument to the script
+SIGNATUREFILE="$BASEDIR""$VERSIONPREFIX""0.10.4/""$RCSUBDIR""$SIGNATUREFILENAME"
 
 if [ ! -d "$WORKINGDIR" ]; then
    mkdir "$WORKINGDIR"
@@ -62,7 +62,7 @@ WGETOUT=$(wget -N "$BASEDIR$SIGNATUREFILENAME" 2>&1)
 #and then see if wget completed successfully
 if [ $? -ne 0 ]; then
    echo "Error: couldn't fetch signature file. Have you specified the version number in the following format?"
-   echo "[bitcoin-]<version>-[rc[0-9]] (example: bitcoin-0.9.2-rc1)"
+   echo "[$VERSIONPREFIX]<version>-[$RCVERSIONSTRING[0-9]] (example: "$VERSIONPREFIX"0.10.4-"$RCVERSIONSTRING"1)"
    echo "wget output:"
    echo "$WGETOUT"|sed 's/^/\t/g'
    exit 2


### PR DESCRIPTION
bitcoin.org is using `$VERSIONPREFIX` now.
