### PR TITLE
Move the blocknotify callback ahead of peer announcement.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2382,6 +2382,8 @@ bool ActivateBestChain(CValidationState &state, const CBlock *pblock) {
         // Notifications/callbacks that can run without cs_main
         if (!fInitialDownload) {
             uint256 hashNewTip = pindexNewTip->GetBlockHash();
+            // Notify BlockNotify.
+            uiInterface.NotifyBlockTip(hashNewTip);
             // Relay inventory, but don't relay old inventory during initial block download.
             int nBlockEstimate = 0;
             if (fCheckpointsEnabled)
@@ -2394,7 +2396,6 @@ bool ActivateBestChain(CValidationState &state, const CBlock *pblock) {
             }
             // Notify external listeners about the new tip.
             GetMainSignals().UpdatedBlockTip(pindexNewTip);
-            uiInterface.NotifyBlockTip(hashNewTip);
         }
     } while(pindexMostWork != chainActive.Tip());
     CheckBlockIndex(chainparams.GetConsensus());


### PR DESCRIPTION
Wizkid057 reported getbestblockhash polling was frequently beating
 blocknotify, sometimes by 2 seconds.  Under the theory that getting
 cs_vNodes and running running PushInventory for all peers was
 sometimes taking a while or UpdatedBlockTip (see below), I
 suggested moving up the notify.  He reported doing so made it
 consistently faster.

I think it's reasonable to signal blocknotify first: All it does
 is fire off a new thread, so it should never block.

This does not move up GetMainSignals().UpdatedBlockTip() which
 because that signal includes the wallet, and if there is a
 wallet with many keys the wallet processing of a block can
 be quite slow. Unfortunately, it also sends out the ZMQ notify.
