### PR TITLE
[doc] Update OS X build notes for new qt5 configure

### DIFF
--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -5,7 +5,7 @@ This guide will show you how to build bitcoind (headless client) for OS X.
 Notes
 -----
 
-* Tested on OS X 10.7 through 10.10 on 64-bit Intel processors only.
+* Tested on OS X 10.7 through 10.11 on 64-bit Intel processors only.
 
 * All of the commands should be executed in a Terminal application. The
 built-in one is located in `/Applications/Utilities`.
@@ -24,7 +24,7 @@ be re-done or updated every time Xcode is updated.
 You will also need to install [Homebrew](http://brew.sh) in order to install library
 dependencies.
 
-The installation of the actual dependencies is covered in the Instructions
+The installation of the actual dependencies is covered in the instructions
 sections below.
 
 Instructions: Homebrew
@@ -36,17 +36,19 @@ Instructions: Homebrew
 
 NOTE: Building with Qt4 is still supported, however, could result in a broken UI. As such, building with Qt5 is recommended.
 
-### Building `bitcoind`
+### Building `bitcoin`
 
 1. Clone the GitHub tree to get the source code and go into the directory.
 
         git clone https://github.com/bitcoin/bitcoin.git
         cd bitcoin
 
-2.  Build bitcoind:
+2.  Build bitcoin-core:
+    This will configure and build the headless bitcoin binaries as well as the gui (if Qt is found).
+    You can disable the gui build by passing `--without-gui` to configure.
 
         ./autogen.sh
-        ./configure --with-gui=qt5
+        ./configure
         make
 
 3.  It is also a good idea to build and run the unit tests:
@@ -60,10 +62,10 @@ NOTE: Building with Qt4 is still supported, however, could result in a broken UI
 Use Qt Creator as IDE
 ------------------------
 You can use Qt Creator as IDE, for debugging and for manipulating forms, etc.
-Download Qt Creator from http://www.qt.io/download/. Download the "community edition" and only install Qt Creator (uncheck the rest during the installation process).
+Download Qt Creator from https://www.qt.io/download/. Download the "community edition" and only install Qt Creator (uncheck the rest during the installation process).
 
 1. Make sure you installed everything through Homebrew mentioned above
-2. Do a proper ./configure --with-gui=qt5 --enable-debug
+2. Do a proper ./configure --enable-debug
 3. In Qt Creator do "New Project" -> Import Project -> Import Existing Project
 4. Enter "bitcoin-qt" as project name, enter src/qt as location
 5. Leave the file selection as it is
@@ -79,7 +81,7 @@ You can ignore this section if you are building `bitcoind` for your own use.
 
 bitcoind/bitcoin-cli binaries are not included in the Bitcoin-Qt.app bundle.
 
-If you are building `bitcoind` or `Bitcoin-Qt` for others, your build machine should be set up
+If you are building `bitcoind` or `Bitcoin Core` for others, your build machine should be set up
 as follows for maximum compatibility:
 
 All dependencies should be compiled with these flags:
@@ -88,7 +90,7 @@ All dependencies should be compiled with these flags:
  -arch x86_64
  -isysroot $(xcode-select --print-path)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.7.sdk
 
-Once dependencies are compiled, see [doc/release-process.md](release-process.md) for how the Bitcoin-Qt.app
+Once dependencies are compiled, see [doc/release-process.md](release-process.md) for how the Bitcoin Core
 bundle is packaged and signed to create the .dmg disk image that is distributed.
 
 Running


### PR DESCRIPTION
You no longer need to explicitly pass qt5 to configure, as it will now choose qt5 over qt4 if both are installed.

[skip-ci]
