### PR TITLE
[doc] Update Debian watch & control

### DIFF
--- a/contrib/debian/control
+++ b/contrib/debian/control
@@ -31,14 +31,11 @@ Package: bitcoind
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: peer-to-peer network based digital currency - daemon
- Bitcoin is a free open source peer-to-peer electronic cash system that
- is completely decentralized, without the need for a central server or
- trusted parties.  Users hold the crypto keys to their own money and
- transact directly with each other, with the help of a P2P network to
- check for double-spending.
- .
- Full transaction history is stored locally at each client.  This
- requires 20+ GB of space, slowly growing.
+ Bitcoin is an experimental new digital currency that enables instant
+ payments to anyone, anywhere in the world. Bitcoin uses peer-to-peer
+ technology to operate with no central authority: managing transactions
+ and issuing money are carried out collectively by the network. Bitcoin Core
+ is the name of the open source software which enables the use of this currency.
  .
  This package provides the daemon, bitcoind, and the CLI tool
  bitcoin-cli to interact with the daemon.
@@ -47,14 +44,11 @@ Package: bitcoin-qt
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: peer-to-peer network based digital currency - Qt GUI
- Bitcoin is a free open source peer-to-peer electronic cash system that
- is completely decentralized, without the need for a central server or
- trusted parties.  Users hold the crypto keys to their own money and
- transact directly with each other, with the help of a P2P network to
- check for double-spending.
- .
- Full transaction history is stored locally at each client.  This
- requires 20+ GB of space, slowly growing.
+ Bitcoin is an experimental new digital currency that enables instant
+ payments to anyone, anywhere in the world. Bitcoin uses peer-to-peer
+ technology to operate with no central authority: managing transactions
+ and issuing money are carried out collectively by the network. Bitcoin Core
+ is the name of the open source software which enables the use of this currency.
  .
  This package provides Bitcoin-Qt, a GUI for Bitcoin based on Qt.
 
@@ -62,11 +56,11 @@ Package: bitcoin-tx
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: peer-to-peer digital currency - standalone transaction tool
- Bitcoin is a free open source peer-to-peer electronic cash system that
- is completely decentralized, without the need for a central server or
- trusted parties.  Users hold the crypto keys to their own money and
- transact directly with each other, with the help of a P2P network to
- check for double-spending.
+ Bitcoin is an experimental new digital currency that enables instant
+ payments to anyone, anywhere in the world. Bitcoin uses peer-to-peer
+ technology to operate with no central authority: managing transactions
+ and issuing money are carried out collectively by the network. Bitcoin Core
+ is the name of the open source software which enables the use of this currency.
  .
  This package provides bitcoin-tx, a command-line transaction creation
  tool which can be used without a bitcoin daemon.  Some means of

--- a/contrib/debian/watch
+++ b/contrib/debian/watch
@@ -1,7 +1,5 @@
 # Run the "uscan" command to check for upstream updates and more.
 version=3
 # use qa.debian.org redirector; see man uscan
-opts=uversionmangle=s/(\d)(alpha|beta|rc)/$1~$2/;s/\-src//,dversionmangle=s/~dfsg\d*// \
- http://sf.net/bitcoin/bitcoin-(\d.*)-linux\.tar\.gz debian
 opts=uversionmangle=s/(\d)(alpha|beta|rc)/$1~$2/,dversionmangle=s/~dfsg\d*// \
  http://githubredir.debian.net/github/bitcoin/bitcoin v(.*).tar.gz


### PR DESCRIPTION
Remove SourceForge from Debian watch, as we no longer have binaries there.

Update Bitcoin description in Debian control to match the description in the main README.md file.

[skip-ci]
