### PR TITLE
RPC: Added additional config option for multiple RPC users.

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -78,6 +78,7 @@ testScripts = [
     'mempool_spendcoinbase.py',
     'mempool_coinbase_spends.py',
     'httpbasics.py',
+    'multi_rpc.py',
     'zapwallettxes.py',
     'proxy_test.py',
     'merkle_blocks.py',

--- a/qa/rpc-tests/multi_rpc.py
+++ b/qa/rpc-tests/multi_rpc.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python2
+# Copyright (c) 2015 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#
+# Test mulitple rpc user config option rpcauth
+#
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+import base64
+
+try:
+    import http.client as httplib
+except ImportError:
+    import httplib
+try:
+    import urllib.parse as urlparse
+except ImportError:
+    import urlparse
+
+class HTTPBasicsTest (BitcoinTestFramework):
+    def setup_nodes(self):
+        return start_nodes(4, self.options.tmpdir)
+
+    def setup_chain(self):
+        print("Initializing test directory "+self.options.tmpdir)
+        initialize_chain(self.options.tmpdir)
+        #Append rpcauth to bitcoin.conf before initialization
+        rpcauth = "rpcauth=rt:93648e835a54c573682c2eb19f882535$7681e9c5b74bdd85e78166031d2058e1069b3ed7ed967c93fc63abba06f31144"
+        rpcauth2 = "rpcauth=rt2:f8607b1a88861fac29dfccf9b52ff9f$ff36a0c23c8c62b4846112e50fa888416e94c17bfd4c42f88fd8f55ec6a3137e"
+        with open(os.path.join(self.options.tmpdir+"/node0", "bitcoin.conf"), 'a') as f:
+            f.write(rpcauth+"\n")
+            f.write(rpcauth2+"\n")
+
+    def run_test(self):
+
+        ##################################################
+        # Check correctness of the rpcauth config option #
+        ##################################################
+        url = urlparse.urlparse(self.nodes[0].url)
+
+        #Old authpair
+        authpair = url.username + ':' + url.password
+
+        #New authpair generated via contrib/rpcuser tool
+        rpcauth = "rpcauth=rt:93648e835a54c573682c2eb19f882535$7681e9c5b74bdd85e78166031d2058e1069b3ed7ed967c93fc63abba06f31144"
+        password = "cA773lm788buwYe4g4WT+05pKyNruVKjQ25x3n0DQcM="
+
+        #Second authpair with different username
+        rpcauth2 = "rpcauth=rt2:f8607b1a88861fac29dfccf9b52ff9f$ff36a0c23c8c62b4846112e50fa888416e94c17bfd4c42f88fd8f55ec6a3137e"
+        password2 = "8/F3uMDw4KSEbw96U3CA1C4X05dkHDN2BPFjTgZW4KI="
+        authpairnew = "rt:"+password
+
+        headers = {"Authorization": "Basic " + base64.b64encode(authpair)}
+
+        conn = httplib.HTTPConnection(url.hostname, url.port)
+        conn.connect()
+        conn.request('POST', '/', '{"method": "getbestblockhash"}', headers)
+        resp = conn.getresponse()
+        assert_equal(resp.status==401, False)
+        conn.close()
+        
+        #Use new authpair to confirm both work
+        headers = {"Authorization": "Basic " + base64.b64encode(authpairnew)}
+
+        conn = httplib.HTTPConnection(url.hostname, url.port)
+        conn.connect()
+        conn.request('POST', '/', '{"method": "getbestblockhash"}', headers)
+        resp = conn.getresponse()
+        assert_equal(resp.status==401, False)
+        conn.close()
+
+        #Wrong login name with rt's password
+        authpairnew = "rtwrong:"+password
+        headers = {"Authorization": "Basic " + base64.b64encode(authpairnew)}
+
+        conn = httplib.HTTPConnection(url.hostname, url.port)
+        conn.connect()
+        conn.request('POST', '/', '{"method": "getbestblockhash"}', headers)
+        resp = conn.getresponse()
+        assert_equal(resp.status==401, True)
+        conn.close()
+
+        #Wrong password for rt
+        authpairnew = "rt:"+password+"wrong"
+        headers = {"Authorization": "Basic " + base64.b64encode(authpairnew)}
+
+        conn = httplib.HTTPConnection(url.hostname, url.port)
+        conn.connect()
+        conn.request('POST', '/', '{"method": "getbestblockhash"}', headers)
+        resp = conn.getresponse()
+        assert_equal(resp.status==401, True)
+        conn.close()
+
+        #Correct for rt2
+        authpairnew = "rt2:"+password2
+        headers = {"Authorization": "Basic " + base64.b64encode(authpairnew)}
+
+        conn = httplib.HTTPConnection(url.hostname, url.port)
+        conn.connect()
+        conn.request('POST', '/', '{"method": "getbestblockhash"}', headers)
+        resp = conn.getresponse()
+        assert_equal(resp.status==401, False)
+        conn.close()
+
+        #Wrong password for rt2
+        authpairnew = "rt2:"+password2+"wrong"
+        headers = {"Authorization": "Basic " + base64.b64encode(authpairnew)}
+
+        conn = httplib.HTTPConnection(url.hostname, url.port)
+        conn.connect()
+        conn.request('POST', '/', '{"method": "getbestblockhash"}', headers)
+        resp = conn.getresponse()
+        assert_equal(resp.status==401, True)
+        conn.close()
+
+
+
+if __name__ == '__main__':
+    HTTPBasicsTest ().main ()

--- a/share/rpcuser/README.md
+++ b/share/rpcuser/README.md
@@ -1,0 +1,11 @@
+RPC Tools
+---------------------
+
+### [RPCUser](/share/rpcuser) ###
+
+Create an RPC user login credential.
+
+Usage:
+
+./rpcuser.py <username>
+

--- a/share/rpcuser/rpcuser.py
+++ b/share/rpcuser/rpcuser.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python2 
+# Copyright (c) 2015 The Bitcoin Core developers 
+# Distributed under the MIT software license, see the accompanying 
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import hashlib
+import sys
+import os
+from random import SystemRandom
+import base64
+import hmac
+
+if len(sys.argv) < 2:
+    sys.stderr.write('Please include username as an argument.\n')
+    sys.exit(0)
+
+username = sys.argv[1]
+
+#This uses os.urandom() underneath
+cryptogen = SystemRandom()
+
+#Create 16 byte hex salt
+salt_sequence = [cryptogen.randrange(256) for i in range(16)]
+hexseq = list(map(hex, salt_sequence))
+salt = "".join([x[2:] for x in hexseq])
+
+#Create 32 byte b64 password
+password = base64.urlsafe_b64encode(os.urandom(32))
+
+digestmod = hashlib.sha256
+
+if sys.version_info.major >= 3:
+    password = password.decode('utf-8')
+    digestmod = 'SHA256'
+ 
+m = hmac.new(bytearray(salt, 'utf-8'), bytearray(password, 'utf-8'), digestmod)
+result = m.hexdigest()
+
+print("String to be appended to bitcoin.conf:")
+print("rpcauth="+username+":"+salt+"$"+result)
+print("Your password:\n"+password)

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -482,6 +482,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-rpcbind=<addr>", _("Bind to given address to listen for JSON-RPC connections. Use [host]:port notation for IPv6. This option can be specified multiple times (default: bind to all interfaces)"));
     strUsage += HelpMessageOpt("-rpcuser=<user>", _("Username for JSON-RPC connections"));
     strUsage += HelpMessageOpt("-rpcpassword=<pw>", _("Password for JSON-RPC connections"));
+    strUsage += HelpMessageOpt("-rpcauth=<userpw>", _("Username and hashed password for JSON-RPC connections. The field <userpw> comes in the format: <USERNAME>:<SALT>$<HASH>. A canonical python script is included in share/rpcuser. This option can be specified multiple times"));
     strUsage += HelpMessageOpt("-rpcport=<port>", strprintf(_("Listen for JSON-RPC connections on <port> (default: %u or testnet: %u)"), 8332, 18332));
     strUsage += HelpMessageOpt("-rpcallowip=<ip>", _("Allow JSON-RPC connections from specified source. Valid for <ip> are a single IP (e.g. 1.2.3.4), a network/netmask (e.g. 1.2.3.4/255.255.255.0) or a network/CIDR (e.g. 1.2.3.4/24). This option can be specified multiple times"));
     strUsage += HelpMessageOpt("-rpcthreads=<n>", strprintf(_("Set the number of threads to service RPC calls (default: %d)"), DEFAULT_HTTP_THREADS));


### PR DESCRIPTION
This pull adds an additional config option, "rpcauth" to allow multiple different users to use different credentials for login. 

Motivation:
In business settings there are often multiple users accessing a particular core instance, using wallet functionality. Instead of all users sharing the same login name and password, it is desired to have each user generate their own secret password, and have a hashed and salted version added to bitcoin.conf by the admin. Currently there is only one name and password, and it is stored in plaintext. This pull attempts to do just this and will be followed by an additional audit logging pull to enable admins to assign blame to spends and other irreversible actions.

The config option comes in the format:

> rpcauth=USERNAME:SALT$HASH  

Where:
1) USERNAME is the desired username. Name does not have to be unique. 
2) SALT is the salt for the HMAC_SHA256 function
3) HASH is a hex string that is the result of the HMAC_SHA256 function on the user's secret password plus the SALT as the key.

A "canonical" password generating python script has been supplied in share/rpcuser. From the client-side, one connects using the standard -rpcuser/-rpcpassword options.
