### PR TITLE
[doc][trivial] Remove miniupnpc build notes from build-unix

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -135,14 +135,6 @@ turned off by default.  See the configure options for upnp behavior desired:
 	--disable-upnp-default   (the default) UPnP support turned off by default at runtime
 	--enable-upnp-default    UPnP support turned on by default at runtime
 
-To build:
-
-	tar -xzvf miniupnpc-1.6.tar.gz
-	cd miniupnpc-1.6
-	make
-	sudo su
-	make install
-
 
 Berkeley DB
 -----------


### PR DESCRIPTION
Users shouldn’t have the impression that we’re using/constrained to an
older version of miniupnpc, so update the doc to the latest version.

[skip-ci]
