### PR TITLE
[qa] python-bitcoinrpc is no longer a subtree

### DIFF
--- a/qa/rpc-tests/README.md
+++ b/qa/rpc-tests/README.md
@@ -1,10 +1,8 @@
 Regression tests
 ================
 
-### [python-bitcoinrpc](https://github.com/jgarzik/python-bitcoinrpc)
-Git subtree of [https://github.com/jgarzik/python-bitcoinrpc](https://github.com/jgarzik/python-bitcoinrpc).
-Changes to python-bitcoinrpc should be made upstream, and then
-pulled here using git subtree.
+### [test_framework/authproxy.py](test_framework/authproxy.py)
+Taken from the [python-bitcoinrpc repository](https://github.com/jgarzik/python-bitcoinrpc).
 
 ### [test_framework/test_framework.py](test_framework/test_framework.py)
 Base class for new regression tests.


### PR DESCRIPTION
Follow up of #6097?

Not sure what we are doing right now, but it is no longer a subtree.

[ci skip]
