### PR TITLE
MAX_PROTOCOL_MESSAGE_LENGTH description

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -44,7 +44,7 @@ static const int TIMEOUT_INTERVAL = 20 * 60;
 static const unsigned int MAX_INV_SZ = 50000;
 /** The maximum number of new addresses to accumulate before announcing. */
 static const unsigned int MAX_ADDR_TO_SEND = 1000;
-/** Maximum length of incoming protocol messages (no message over 2 MiB is currently acceptable). */
+/** Maximum length of incoming protocol messages (no message over 2 MB is currently acceptable). */
 static const unsigned int MAX_PROTOCOL_MESSAGE_LENGTH = 2 * 1024 * 1024;
 /** Maximum length of strSubVer in `version` message */
 static const unsigned int MAX_SUBVERSION_LENGTH = 256;


### PR DESCRIPTION
MiB should be MB.  

Length is computed in MB but text is saying it's MiB

/*\* Maximum length of incoming protocol messages (no message over 2 MiB is currently acceptable). */
static const unsigned int MAX_PROTOCOL_MESSAGE_LENGTH = 2 \* 1024 \* 1024;
