### PR TITLE
Wallet: Flush database to log files

### DIFF
--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -288,12 +288,7 @@ void CDB::Flush()
     if (activeTxn)
         return;
 
-    // Flush database activity from memory pool to disk log
-    unsigned int nMinutes = 0;
-    if (fReadOnly)
-        nMinutes = 1;
-
-    bitdb.dbenv->txn_checkpoint(nMinutes ? GetArg("-dblogsize", DEFAULT_WALLET_DBLOGSIZE) * 1024 : 0, nMinutes, 0);
+    bitdb.dbenv->memp_sync(NULL);
 }
 
 void CDB::Close()


### PR DESCRIPTION
Previously modifications in memory would be flushed to the log files and then
immediately written out from the log files to wallet.dat. This is unnecessary
for durability guarantees and significantly effected performance.
