### PR TITLE
build: Make networking work inside LXC builder in gitian-building.md

### DIFF
--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -15,6 +15,8 @@ packages:
 - "faketime"
 - "bsdmainutils"
 - "binutils-gold"
+- "ca-certificates"
+- "python"
 reference_datetime: "2016-01-01 00:00:00"
 remotes:
 - "url": "https://github.com/bitcoin/bitcoin.git"

--- a/contrib/gitian-descriptors/gitian-osx.yml
+++ b/contrib/gitian-descriptors/gitian-osx.yml
@@ -18,6 +18,8 @@ packages:
 - "libcap-dev"
 - "libz-dev"
 - "libbz2-dev"
+- "ca-certificates"
+- "python"
 reference_datetime: "2016-01-01 00:00:00"
 remotes:
 - "url": "https://github.com/bitcoin/bitcoin.git"

--- a/contrib/gitian-descriptors/gitian-win.yml
+++ b/contrib/gitian-descriptors/gitian-win.yml
@@ -18,6 +18,8 @@ packages:
 - "g++-mingw-w64"
 - "nsis"
 - "zip"
+- "ca-certificates"
+- "python"
 reference_datetime: "2016-01-01 00:00:00"
 remotes:
 - "url": "https://github.com/bitcoin/bitcoin.git"

--- a/doc/gitian-building.md
+++ b/doc/gitian-building.md
@@ -259,7 +259,7 @@ adduser debian sudo
 Then set up LXC and the rest with the following, which is a complex jumble of settings and workarounds:
 
 ```bash
-# the version of lxc-start in Debian 7.4 needs to run as root, so make sure
+# the version of lxc-start in Debian needs to run as root, so make sure
 # that the build script can execute it without providing a password
 echo "%sudo ALL=NOPASSWD: /usr/bin/lxc-start" > /etc/sudoers.d/gitian-lxc
 # make /etc/rc.local script that sets up bridge between guest and host

--- a/doc/gitian-building.md
+++ b/doc/gitian-building.md
@@ -262,12 +262,12 @@ Then set up LXC and the rest with the following, which is a complex jumble of se
 # the version of lxc-start in Debian 7.4 needs to run as root, so make sure
 # that the build script can execute it without providing a password
 echo "%sudo ALL=NOPASSWD: /usr/bin/lxc-start" > /etc/sudoers.d/gitian-lxc
-# add cgroup for LXC
-echo "cgroup  /sys/fs/cgroup  cgroup  defaults  0   0" >> /etc/fstab
 # make /etc/rc.local script that sets up bridge between guest and host
 echo '#!/bin/sh -e' > /etc/rc.local
 echo 'brctl addbr br0' >> /etc/rc.local
 echo 'ifconfig br0 10.0.3.2/24 up' >> /etc/rc.local
+echo 'iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE' >> /etc/rc.local
+echo 'echo 1 > /proc/sys/net/ipv4/ip_forward' >> /etc/rc.local
 echo 'exit 0' >> /etc/rc.local
 # make sure that USE_LXC is always set when logging in as debian,
 # and configure LXC IP addresses


### PR DESCRIPTION
These are changes I needed to get gitian building to work with a fresh Debian 8.2 VM, which is the version we tell to use.
- Set up NAT and forwarding, so that LXC container can access network beyond host
- Remove explicit cgroup setup - these are mounted automatically now

Also needed a change to gitian: https://github.com/devrandom/gitian-builder/issues/105
[skip ci]
