### PR TITLE
http: add Boost 1.49 compatibility

### DIFF
--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -487,7 +487,11 @@ void StopHTTPServer()
         // master that appears to be solved, so in the future that solution
         // could be used again (if desirable).
         // (see discussion in https://github.com/bitcoin/bitcoin/pull/6990)
+#if BOOST_VERSION >= 105000
         if (!threadHTTP.try_join_for(boost::chrono::milliseconds(2000))) {
+#else
+        if (!threadHTTP.timed_join(boost::posix_time::milliseconds(2000))) {
+#endif
             LogPrintf("HTTP event loop did not exit within allotted time, sending loopbreak\n");
             event_base_loopbreak(eventBase);
             threadHTTP.join();


### PR DESCRIPTION
I'm not sure what versions of Boost we reasonably support, anyway,

`try_join_for` was introduced in Boost 1.50: http://www.boost.org/doc/libs/1_50_0/doc/html/thread/thread_management.html#thread.thread_management.thread.try_join_for

1.49 has `timed_join`, one can accomplish the same with: http://www.boost.org/doc/libs/1_49_0/doc/html/thread/thread_management.html#thread.thread_management.thread.timed_join

However, `timed_join` was deprecated in 1.50. So a conditional is necessary.

This solution was tested in #7031.
