### PR TITLE
Wallet: Replace TxnAbort with assert.

### DIFF
--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -300,8 +300,9 @@ void CDB::Close()
 {
     if (!pdb)
         return;
-    if (activeTxn)
-        activeTxn->abort();
+
+    assert(!activeTxn);
+
     activeTxn = NULL;
     pdb = NULL;
 


### PR DESCRIPTION
CDB::Close should never be called with an activeTxn in progress.
