### PR TITLE
Added a command line option -checkscripts

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -874,6 +874,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     }
     fCheckBlockIndex = GetBoolArg("-checkblockindex", chainparams.DefaultConsistencyChecks());
     fCheckpointsEnabled = GetBoolArg("-checkpoints", true);
+    fScriptChecksEnabled = GetBoolArg("-checkscripts", true);
 
     // -mempoollimit limits
     int64_t nMempoolSizeLimit = GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -70,6 +70,7 @@ bool fIsBareMultisigStd = true;
 bool fRequireStandard = true;
 bool fCheckBlockIndex = false;
 bool fCheckpointsEnabled = true;
+bool fScriptChecksEnabled = true;
 size_t nCoinCacheUsage = 5000 * 300;
 uint64_t nPruneTarget = 0;
 bool fAlerts = DEFAULT_ALERTS;
@@ -1750,8 +1751,8 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
         return true;
     }
 
-    bool fScriptChecks = true;
-    if (fCheckpointsEnabled) {
+    bool fScriptChecks = fScriptChecksEnabled;
+    if (fScriptChecksEnabled && fCheckpointsEnabled) {
         CBlockIndex *pindexLastCheckpoint = Checkpoints::GetLastCheckpoint(chainparams.Checkpoints());
         if (pindexLastCheckpoint && pindexLastCheckpoint->GetAncestor(pindex->nHeight) == pindex) {
             // This block is an ancestor of a checkpoint: disable script checks

--- a/src/main.h
+++ b/src/main.h
@@ -112,6 +112,7 @@ extern bool fIsBareMultisigStd;
 extern bool fRequireStandard;
 extern bool fCheckBlockIndex;
 extern bool fCheckpointsEnabled;
+extern bool fScriptChecksEnabled;
 extern size_t nCoinCacheUsage;
 extern CFeeRate minRelayTxFee;
 extern bool fAlerts;


### PR DESCRIPTION
For validation benchmarking it is often convenient to disable script checks to isolate script evaluation performance (and in particular signature verification) from other issues.

This PR adds a command line option -checkscripts that defaults to true (preserving the original behavior) but can be set to false to shortcircuit script evaluation.
