### PR TITLE
uint256::GetCheapHash bigendian compatibility

### DIFF
--- a/src/uint256.h
+++ b/src/uint256.h
@@ -12,6 +12,7 @@
 #include <stdint.h>
 #include <string>
 #include <vector>
+#include "crypto/common.h"
 
 /** Template base class for fixed-sized opaque blobs. */
 template<unsigned int BITS>
@@ -119,13 +120,10 @@ public:
      * used when the contents are considered uniformly random. It is not appropriate
      * when the value can easily be influenced from outside as e.g. a network adversary could
      * provide values to trigger worst-case behavior.
-     * @note The result of this function is not stable between little and big endian.
      */
     uint64_t GetCheapHash() const
     {
-        uint64_t result;
-        memcpy((void*)&result, (void*)data, 8);
-        return result;
+        return ReadLE64(data);
     }
 
     /** A more secure, salted hash function.


### PR DESCRIPTION
Tested on PPC/MIPS :
Before change:

```
test_bitcoin --run_test=addrman_tests
Running 5 test cases...
test/addrman_tests.cpp(141): error in "addrman_new_collisions": check addrman.size() == 3 failed
test/addrman_tests.cpp(145): error in "addrman_new_collisions": check addrman.size() == 4 failed
test/addrman_tests.cpp(166): error in "addrman_tried_collisions": check addrman.size() == i failed
test/addrman_tests.cpp(166): error in "addrman_tried_collisions": check addrman.size() == i failed
test/addrman_tests.cpp(166): error in "addrman_tried_collisions": check addrman.size() == i failed

*** 5 failures detected in test suite "Bitcoin Test Suite"

```

After:

```
test_bitcoin --run_test=addrman_tests
Running 5 test cases...

*** No errors detected
```
