### PR TITLE
Do not absolutely protect local peers and make eviction more aggressive.

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -883,8 +883,6 @@ static bool AttemptToEvictConnection(bool fPreferNewConnection) {
                 continue;
             if (node->fDisconnect)
                 continue;
-            if (node->addr.IsLocal())
-                continue;
             vEvictionCandidates.push_back(CNodeRef(node));
         }
     }
@@ -915,15 +913,20 @@ static bool AttemptToEvictConnection(bool fPreferNewConnection) {
 
     if (vEvictionCandidates.empty()) return false;
 
-    // Identify the network group with the most connections
+    // Identify the network group with the most connections and youngest member.
+    // (vEvictionCandidates is already sorted by reverse connect time)
     std::vector<unsigned char> naMostConnections;
     unsigned int nMostConnections = 0;
+    int64_t nMostConnectionsTime = 0;
     std::map<std::vector<unsigned char>, std::vector<CNodeRef> > mapAddrCounts;
     BOOST_FOREACH(const CNodeRef &node, vEvictionCandidates) {
         mapAddrCounts[node->addr.GetGroup()].push_back(node);
+        int64_t grouptime = mapAddrCounts[node->addr.GetGroup()][0]->nTimeConnected;
+        size_t groupsize = mapAddrCounts[node->addr.GetGroup()].size();
 
-        if (mapAddrCounts[node->addr.GetGroup()].size() > nMostConnections) {
-            nMostConnections = mapAddrCounts[node->addr.GetGroup()].size();
+        if (groupsize > nMostConnections || (groupsize == nMostConnections && grouptime > nMostConnectionsTime)) {
+            nMostConnections = groupsize;
+            nMostConnectionsTime = grouptime;
             naMostConnections = node->addr.GetGroup();
         }
     }
@@ -931,14 +934,13 @@ static bool AttemptToEvictConnection(bool fPreferNewConnection) {
     // Reduce to the network group with the most connections
     vEvictionCandidates = mapAddrCounts[naMostConnections];
 
-    // Do not disconnect peers if there is only 1 connection from their network group
+    // Do not disconnect peers if there is only one unprotected connection from their network group.
     if (vEvictionCandidates.size() <= 1)
         // unless we prefer the new connection (for whitelisted peers)
         if (!fPreferNewConnection)
             return false;
 
-    // Disconnect the most recent connection from the network group with the most connections
-    std::sort(vEvictionCandidates.begin(), vEvictionCandidates.end(), ReverseCompareNodeTimeConnected);
+    // Disconnect from the network group with the most connections
     vEvictionCandidates[0]->fDisconnect = true;
 
     return true;

--- a/src/net.h
+++ b/src/net.h
@@ -153,6 +153,7 @@ extern int nMaxConnections;
 
 extern std::vector<CNode*> vNodes;
 extern CCriticalSection cs_vNodes;
+extern CCriticalSection cs_cNodeStats;
 extern std::map<CInv, CDataStream> mapRelay;
 extern std::deque<std::pair<int64_t, CInv> > vRelayExpiration;
 extern CCriticalSection cs_mapRelay;
@@ -326,6 +327,7 @@ public:
     int64_t nLastRecv;
     int64_t nTimeConnected;
     int64_t nTimeOffset;
+    int64_t nTimeLastTX; // time we last accepted a transaction into the mempool from this peer. Protected by cs_cNodeStats
     CAddress addr;
     std::string addrName;
     CService addrLocal;
@@ -384,7 +386,7 @@ public:
     CCriticalSection cs_inventory;
     std::multimap<int64_t, CInv> mapAskFor;
 
-    // Ping time measurement:
+    // Ping time measurement: Protected by cs_cNodeStats
     // The pong reply we're expecting, or 0 if no pong expected.
     uint64_t nPingNonceSent;
     // Time (in usec) the last ping was sent, or 0 if no ping was ever sent.


### PR DESCRIPTION
With automatic tor HS support in place we should probably not be providing
 absolute protection for local peers, since HS inbound could be used to
 attack pretty easily.  Instead, this counts on the latency metric inside
 AttemptToEvictConnection to privilege actually local peers.

This change also makes eviction generally more aggressive by making it
 willing to evict the unprotected peer in a netgroup, if the new
 connection comes from a netgroup where we have no unprotected peers.

It also makes sure that in the case of tying group size to select the
 group with the newest member, since newest time is the final selection
 criteria.

The third commit protects four peers that most recently sent us a valid
 transaction to our memory pool.  This metric is costly for attackers to
 control since it requires sending acceptable transactions, and an
 attacker which is blocking transactions is inherently disadvantaged for this
 criteria.
