### PR TITLE
Connect to Tor hidden services by default

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -151,8 +151,8 @@ mining with the getblocktemplate protocol to a pool: this will affect you at
 the pool operator's discretion, which must be no later than BIP65 achieving its
 951/1001 status.
 
-Automatically listen on Tor
-----------------------------
+Automatically use Tor hidden services
+-------------------------------------
 
 Starting with Tor version 0.2.7.1 it is possible, through Tor's control socket
 API, to create and destroy 'ephemeral' hidden services programmatically.
@@ -160,8 +160,9 @@ Bitcoin Core has been updated to make use of this.
 
 This means that if Tor is running (and proper authorization is available),
 Bitcoin Core automatically creates a hidden service to listen on, without
-manual configuration. This will positively affect the number of available
-.onion nodes.
+manual configuration. Bitcoin Core will also use Tor automatically to connect
+to other .onion nodes if the control socket can be successfully opened. This
+will positively affect the number of available .onion nodes and their usage.
 
 This new feature is enabled by default if Bitcoin Core is listening, and
 a connection to Tor can be made. It can be configured with the `-listenonion`,

--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -449,6 +449,15 @@ void TorController::auth_cb(TorControlConnection& conn, const TorControlReply& r
 {
     if (reply.code == 250) {
         LogPrint("tor", "tor: Authentication succesful\n");
+
+        // Now that we know Tor is running setup the proxy for onion addresses
+        // if -onion isn't set to something else.
+        if (GetArg("-onion", "") == "") {
+            proxyType addrOnion = proxyType(CService("127.0.0.1", 9050), true);
+            SetProxy(NET_TOR, addrOnion);
+            SetReachable(NET_TOR);
+        }
+
         // Finally - now create the service
         if (private_key.empty()) // No private key, generate one
             private_key = "NEW:BEST";


### PR DESCRIPTION
Sets -onion=127.0.0.1:9050 by default, which means we're able to connect to hidden services automatically if Tor is running locally. Natural followup to @laanwj's #6639, which creates hidden services automatically.

Currently the way addrman works hidden service peers won't be chosen very often, as there just aren't all that many of them on the network right now. It might be worth addressing that in a future pull-req to deliberately set aside connection slots groups for different types of peers, rather than having all outgoing connections be picked in the same way.
