### PR TITLE
build: Set osx permissions in the dmg to make Gatekeeper happy

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -111,7 +111,7 @@ $(APP_DIST_DIR)/Applications:
 $(APP_DIST_EXTRAS): $(APP_DIST_DIR)/$(OSX_APP)/Contents/MacOS/Bitcoin-Qt
 
 $(OSX_DMG): $(APP_DIST_EXTRAS)
-	$(GENISOIMAGE) -no-cache-inodes -D -l -probe -V "Bitcoin-Core" -no-pad -r -apple -o $@ dist
+	$(GENISOIMAGE) -no-cache-inodes -D -l -probe -V "Bitcoin-Core" -no-pad -r -dir-mode 0755 -apple -o $@ dist
 
 $(APP_DIST_DIR)/.background/$(OSX_BACKGROUND_IMAGE): contrib/macdeploy/$(OSX_BACKGROUND_IMAGE)
 	$(MKDIR_P) $(@D)


### PR DESCRIPTION
Fixes #7085.

I can't reproduce the issue on 10.11, so I'll have to wait for someone else to verify. Locally, permissions look ok until added to the image, where 0555 appears to be the default.
