### PR TITLE
Address mempool information leak and resource wasting attacks.

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2343,7 +2343,7 @@ unsigned int SendBufferSize() { return 1000*GetArg("-maxsendbuffer", 1*1000); }
 CNode::CNode(SOCKET hSocketIn, const CAddress& addrIn, const std::string& addrNameIn, bool fInboundIn) :
     ssSend(SER_NETWORK, INIT_PROTO_VERSION),
     addrKnown(5000, 0.001),
-    setInventoryKnown(SendBufferSize() / 1000)
+    setInventoryKnown(MAX_SETINVENTORYKNOWN_SZ)
 {
     nServices = 0;
     hSocket = hSocketIn;
@@ -2352,6 +2352,7 @@ CNode::CNode(SOCKET hSocketIn, const CAddress& addrIn, const std::string& addrNa
     nLastRecv = 0;
     nSendBytes = 0;
     nRecvBytes = 0;
+    nTimeLastMempool = 0;
     nTimeConnected = GetTime();
     nTimeOffset = 0;
     addr = addrIn;

--- a/src/net.h
+++ b/src/net.h
@@ -64,6 +64,8 @@ static const unsigned int DEFAULT_MAX_PEER_CONNECTIONS = 125;
 static const uint64_t DEFAULT_MAX_UPLOAD_TARGET = 0;
 /** Default for blocks only*/
 static const bool DEFAULT_BLOCKSONLY = false;
+/** setInventoryKnown size. */
+static const unsigned int MAX_SETINVENTORYKNOWN_SZ = MAX_INV_SZ;
 
 unsigned int ReceiveFloodSize();
 unsigned int SendBufferSize();
@@ -324,6 +326,7 @@ public:
 
     int64_t nLastSend;
     int64_t nLastRecv;
+    int64_t nTimeLastMempool;
     int64_t nTimeConnected;
     int64_t nTimeOffset;
     CAddress addr;

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -218,7 +218,7 @@ UniValue mempoolToJSON(bool fVerbose = false)
     else
     {
         vector<uint256> vtxid;
-        mempool.queryHashes(vtxid);
+        mempool.queryHashes(vtxid, std::numeric_limits<size_t>::max(), std::numeric_limits<int64_t>::max());
 
         UniValue a(UniValue::VARR);
         BOOST_FOREACH(const uint256& hash, vtxid)

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -376,7 +376,7 @@ public:
                         std::list<CTransaction>& conflicts, bool fCurrentEstimate = true);
     void clear();
     void _clear(); //lock free
-    void queryHashes(std::vector<uint256>& vtxid);
+    void queryHashes(std::vector<uint256>& vtxid, size_t maxresults, int64_t maxtime);
     void pruneSpent(const uint256& hash, CCoins &coins);
     unsigned int GetTransactionsUpdated() const;
     void AddTransactionsUpdated(unsigned int n);


### PR DESCRIPTION
Currently an attacker can poll mempool frequently to bypass
 trickling logic and trace a transaction through the network.
 This also wastes lots of bandwidth by causing the same huge
 invs to be sent over and over.

This change makes mempool not return results with an arrival
 time greater than the current minus 16 rounded down to a
 multiple of 16 seconds. This is a 16 to 32 second delay.

It also makes mempool calls return only responses which have
 not been INVed before (using the known inv mruset) and
 limits the mempool command to considering only the top 8192
 entries in the mempool.
