### PR TITLE
Assert now > 0 in GetTime GetTimeMillis GetTimeMicros

### DIFF
--- a/src/utiltime.cpp
+++ b/src/utiltime.cpp
@@ -20,7 +20,9 @@ int64_t GetTime()
 {
     if (nMockTime) return nMockTime;
 
-    return time(NULL);
+    time_t now = time(NULL);
+    assert(now > 0);
+    return now;
 }
 
 void SetMockTime(int64_t nMockTimeIn)
@@ -30,14 +32,18 @@ void SetMockTime(int64_t nMockTimeIn)
 
 int64_t GetTimeMillis()
 {
-    return (boost::posix_time::microsec_clock::universal_time() -
-            boost::posix_time::ptime(boost::gregorian::date(1970,1,1))).total_milliseconds();
+    int64_t now = (boost::posix_time::microsec_clock::universal_time() -
+                   boost::posix_time::ptime(boost::gregorian::date(1970,1,1))).total_milliseconds();
+    assert(now > 0);
+    return now;
 }
 
 int64_t GetTimeMicros()
 {
-    return (boost::posix_time::microsec_clock::universal_time() -
-            boost::posix_time::ptime(boost::gregorian::date(1970,1,1))).total_microseconds();
+    int64_t now = (boost::posix_time::microsec_clock::universal_time() -
+                   boost::posix_time::ptime(boost::gregorian::date(1970,1,1))).total_microseconds();
+    assert(now > 0);
+    return now;
 }
 
 /** Return a time useful for the debug log */


### PR DESCRIPTION
Previously all of these functions could return negative values (for different
readons).  Large portions of the codebase currently assume that these
functions return positive values.
