### PR TITLE
Switch to a more efficient rolling Bloom filter

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -180,7 +180,7 @@ namespace {
      * million to make it highly unlikely for users to have issues with this
      * filter.
      *
-     * Memory used: 1.7MB
+     * Memory used: 1.3 MB
      */
     boost::scoped_ptr<CRollingBloomFilter> recentRejects;
     uint256 hashRecentRejectsChainTip;


### PR DESCRIPTION
For each 'bit' in the filter we really maintain 2 bits, which store either:
- 0: not set
- 1-3: set in generation N

After (nElements / 2) insertions, we switch to a new generation, and wipe entries which already had the new generation number, effectively switching from the last 1.5 \* nElements set to the last 1.0 \* nElements set.

This is 25% more space efficient than the previous implementation, and can (at peak) store 1.5 times the requested amount of history (though only 1.0 times the requested history is guaranteed).

The existing unit tests should be sufficient.
