### PR TITLE
util: Don't set strMiscWarning on every exception

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -447,7 +447,6 @@ void PrintExceptionContinue(const std::exception* pex, const char* pszThread)
     std::string message = FormatException(pex, pszThread);
     LogPrintf("\n\n************************\n%s\n", message);
     fprintf(stderr, "\n\n************************\n%s\n", message.c_str());
-    strMiscWarning = message;
 }
 
 boost::filesystem::path GetDefaultDataDir()


### PR DESCRIPTION
Fixes #6809 - run-of-the-mill exceptions should not get into strMiscWarning (which is reported by `getinfo`).

Edit: after this we could move `strMiscWarning` out of util, as it's not used there anymore. But it's not clear to where.
