### PR TITLE
Mempool: Decouple CBlockPolicyEstimator from CTxMemPool (fix #6134)

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -881,9 +881,9 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     fCheckpointsEnabled = GetBoolArg("-checkpoints", DEFAULT_CHECKPOINTS_ENABLED);
 
     // mempool limits
-    int64_t nMempoolSizeMax = GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000;
-    int64_t nMempoolSizeMin = GetArg("-limitdescendantsize", DEFAULT_DESCENDANT_SIZE_LIMIT) * 1000 * 40;
-    if (nMempoolSizeMax < 0 || nMempoolSizeMax < nMempoolSizeMin)
+    nGlobalMempoolSizeLimit = GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000;
+    uint64_t nMempoolSizeMin = GetArg("-limitdescendantsize", DEFAULT_DESCENDANT_SIZE_LIMIT) * 1000 * 40;
+    if (nGlobalMempoolSizeLimit < nMempoolSizeMin)
         return InitError(strprintf(_("-maxmempool must be at least %d MB"), std::ceil(nMempoolSizeMin / 1000000.0)));
 
     // -par=0 means autodetect, but nScriptCheckThreads==0 means no concurrency

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -973,7 +973,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
             return state.DoS(0, false, REJECT_INSUFFICIENTFEE, "insufficient fee", false,
                 strprintf("%d < %d", nFees, txMinFee));
 
-        CAmount mempoolRejectFee = pool.GetMinFee(GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000).GetFee(nSize);
+        CAmount mempoolRejectFee = pool.GetMinFee().GetFee(nSize);
         if (mempoolRejectFee > 0 && nFees < mempoolRejectFee) {
             return state.DoS(0, false, REJECT_INSUFFICIENTFEE, "mempool min fee not met", false, strprintf("%d < %d", nFees, mempoolRejectFee));
         } else if (GetBoolArg("-relaypriority", DEFAULT_RELAYPRIORITY) && nFees < ::minRelayTxFee.GetFee(nSize) && !AllowFree(entry.GetPriority(chainActive.Height() + 1))) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1215,7 +1215,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
             if (expired != 0)
                 LogPrint("mempool", "Expired %i transactions from the memory pool\n", expired);
 
-            pool.TrimToSize(nGlobalMempoolSizeLimit);
+            pool.TrimToSize();
             if (!pool.exists(tx.GetHash()))
                 return state.DoS(0, false, REJECT_INSUFFICIENTFEE, "mempool full");
         }
@@ -2573,7 +2573,7 @@ static bool ActivateBestChainStep(CValidationState& state, const CChainParams& c
 
     if (fBlocksDisconnected) {
         pool.removeForReorg(pcoinsTip, chainActive.Tip()->nHeight + 1, STANDARD_LOCKTIME_VERIFY_FLAGS);
-        pool.TrimToSize(nGlobalMempoolSizeLimit);
+        pool.TrimToSize();
     }
     pool.check(pcoinsTip);
 
@@ -2689,7 +2689,7 @@ bool InvalidateBlock(CValidationState& state, const Consensus::Params& consensus
         }
     }
 
-    pool.TrimToSize(nGlobalMempoolSizeLimit);
+    pool.TrimToSize();
 
     // The resulting new best tip may not be in setBlockIndexCandidates anymore, so
     // add it again.

--- a/src/main.h
+++ b/src/main.h
@@ -125,6 +125,7 @@ extern bool fRequireStandard;
 extern bool fCheckBlockIndex;
 extern bool fCheckpointsEnabled;
 extern size_t nCoinCacheUsage;
+extern size_t nGlobalMempoolSizeLimit;
 extern CFeeRate minRelayTxFee;
 extern bool fAlerts;
 

--- a/src/policy/fees.cpp
+++ b/src/policy/fees.cpp
@@ -505,7 +505,7 @@ CFeeRate CBlockPolicyEstimator::estimateFee(int confTarget)
     return CFeeRate(median);
 }
 
-CFeeRate CBlockPolicyEstimator::estimateSmartFee(int confTarget, int *answerFoundAtTarget, const CTxMemPool& pool)
+CFeeRate CBlockPolicyEstimator::estimateSmartFee(int confTarget, int* answerFoundAtTarget, const CAmount& minPoolFee)
 {
     if (answerFoundAtTarget)
         *answerFoundAtTarget = confTarget;
@@ -522,7 +522,6 @@ CFeeRate CBlockPolicyEstimator::estimateSmartFee(int confTarget, int *answerFoun
         *answerFoundAtTarget = confTarget - 1;
 
     // If mempool is limiting txs , return at least the min fee from the mempool
-    CAmount minPoolFee = pool.GetMinFee(GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000).GetFeePerK();
     if (minPoolFee > 0 && minPoolFee > median)
         return CFeeRate(minPoolFee);
 
@@ -541,7 +540,7 @@ double CBlockPolicyEstimator::estimatePriority(int confTarget)
     return priStats.EstimateMedianVal(confTarget, SUFFICIENT_PRITXS, MIN_SUCCESS_PCT, true, nBestSeenHeight);
 }
 
-double CBlockPolicyEstimator::estimateSmartPriority(int confTarget, int *answerFoundAtTarget, const CTxMemPool& pool)
+double CBlockPolicyEstimator::estimateSmartPriority(int confTarget, int* answerFoundAtTarget, const CAmount& minPoolFee)
 {
     if (answerFoundAtTarget)
         *answerFoundAtTarget = confTarget;
@@ -550,7 +549,6 @@ double CBlockPolicyEstimator::estimateSmartPriority(int confTarget, int *answerF
         return -1;
 
     // If mempool is limiting txs, no priority txs are allowed
-    CAmount minPoolFee = pool.GetMinFee(GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000).GetFeePerK();
     if (minPoolFee > 0)
         return INF_PRIORITY;
 

--- a/src/policy/fees.h
+++ b/src/policy/fees.h
@@ -247,7 +247,7 @@ public:
      *  confTarget blocks. If no answer can be given at confTarget, return an
      *  estimate at the lowest target where one can be given.
      */
-    CFeeRate estimateSmartFee(int confTarget, int *answerFoundAtTarget, const CTxMemPool& pool);
+    CFeeRate estimateSmartFee(int confTarget, int* answerFoundAtTarget, const CAmount& minPoolFee);
 
     /** Return a priority estimate */
     double estimatePriority(int confTarget);
@@ -256,7 +256,7 @@ public:
      *  confTarget blocks. If no answer can be given at confTarget, return an
      *  estimate at the lowest target where one can be given.
      */
-    double estimateSmartPriority(int confTarget, int *answerFoundAtTarget, const CTxMemPool& pool);
+    double estimateSmartPriority(int confTarget, int* answerFoundAtTarget, const CAmount& minPoolFee);
 
     /** Write estimation data to a file */
     void Write(CAutoFile& fileout);

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -25,8 +25,6 @@ static const unsigned int MAX_STANDARD_TX_SIZE = 100000;
 static const unsigned int MAX_P2SH_SIGOPS = 15;
 /** The maximum number of sigops we're willing to relay/mine in a single tx */
 static const unsigned int MAX_STANDARD_TX_SIGOPS = MAX_BLOCK_SIGOPS/5;
-/** Default for -maxmempool, maximum megabytes of mempool memory usage */
-static const unsigned int DEFAULT_MAX_MEMPOOL_SIZE = 300;
 /**
  * Standard script verification flags that standard transactions will comply
  * with. However scripts violating these flags may still be present in valid

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -782,7 +782,7 @@ UniValue mempoolInfoToJSON()
     ret.push_back(Pair("usage", (int64_t) mempool.DynamicMemoryUsage()));
     size_t maxmempool = GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000;
     ret.push_back(Pair("maxmempool", (int64_t) maxmempool));
-    ret.push_back(Pair("mempoolminfee", ValueFromAmount(mempool.GetMinFee(maxmempool).GetFeePerK())));
+    ret.push_back(Pair("mempoolminfee", ValueFromAmount(mempool.GetMinFee().GetFeePerK())));
 
     return ret;
 }

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -780,8 +780,7 @@ UniValue mempoolInfoToJSON()
     ret.push_back(Pair("size", (int64_t) mempool.size()));
     ret.push_back(Pair("bytes", (int64_t) mempool.GetTotalTxSize()));
     ret.push_back(Pair("usage", (int64_t) mempool.DynamicMemoryUsage()));
-    size_t maxmempool = GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000;
-    ret.push_back(Pair("maxmempool", (int64_t) maxmempool));
+    ret.push_back(Pair("maxmempool", (int64_t) nGlobalMempoolSizeLimit));
     ret.push_back(Pair("mempoolminfee", ValueFromAmount(mempool.GetMinFee().GetFeePerK())));
 
     return ret;

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -714,7 +714,7 @@ CFeeRate CTxMemPool::estimateFee(int nBlocks) const
 CFeeRate CTxMemPool::estimateSmartFee(int nBlocks, int *answerFoundAtBlocks) const
 {
     LOCK(cs);
-    return minerPolicyEstimator->estimateSmartFee(nBlocks, answerFoundAtBlocks, *this);
+    return minerPolicyEstimator->estimateSmartFee(nBlocks, answerFoundAtBlocks, GetMinFee(GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000).GetFeePerK());
 }
 double CTxMemPool::estimatePriority(int nBlocks) const
 {
@@ -724,7 +724,7 @@ double CTxMemPool::estimatePriority(int nBlocks) const
 double CTxMemPool::estimateSmartPriority(int nBlocks, int *answerFoundAtBlocks) const
 {
     LOCK(cs);
-    return minerPolicyEstimator->estimateSmartPriority(nBlocks, answerFoundAtBlocks, *this);
+    return minerPolicyEstimator->estimateSmartPriority(nBlocks, answerFoundAtBlocks, GetMinFee(GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000).GetFeePerK());
 }
 
 bool

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -714,7 +714,7 @@ CFeeRate CTxMemPool::estimateFee(int nBlocks) const
 CFeeRate CTxMemPool::estimateSmartFee(int nBlocks, int *answerFoundAtBlocks) const
 {
     LOCK(cs);
-    return minerPolicyEstimator->estimateSmartFee(nBlocks, answerFoundAtBlocks, GetMinFee(GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000).GetFeePerK());
+    return minerPolicyEstimator->estimateSmartFee(nBlocks, answerFoundAtBlocks, GetMinFee().GetFeePerK());
 }
 double CTxMemPool::estimatePriority(int nBlocks) const
 {
@@ -724,7 +724,7 @@ double CTxMemPool::estimatePriority(int nBlocks) const
 double CTxMemPool::estimateSmartPriority(int nBlocks, int *answerFoundAtBlocks) const
 {
     LOCK(cs);
-    return minerPolicyEstimator->estimateSmartPriority(nBlocks, answerFoundAtBlocks, GetMinFee(GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000).GetFeePerK());
+    return minerPolicyEstimator->estimateSmartPriority(nBlocks, answerFoundAtBlocks, GetMinFee().GetFeePerK());
 }
 
 bool
@@ -914,6 +914,11 @@ CFeeRate CTxMemPool::GetMinFee(size_t sizelimit) const {
         }
     }
     return std::max(CFeeRate(rollingMinimumFeeRate), minReasonableRelayFee);
+}
+
+CFeeRate CTxMemPool::GetMinFee() const
+{
+    return GetMinFee(GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000);
 }
 
 void CTxMemPool::trackPackageRemoved(const CFeeRate& rate) {

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -918,7 +918,7 @@ CFeeRate CTxMemPool::GetMinFee(size_t sizelimit) const {
 
 CFeeRate CTxMemPool::GetMinFee() const
 {
-    return GetMinFee(GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000);
+    return GetMinFee(nGlobalMempoolSizeLimit);
 }
 
 void CTxMemPool::trackPackageRemoved(const CFeeRate& rate) {

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -955,3 +955,8 @@ void CTxMemPool::TrimToSize(size_t sizelimit) {
     if (maxFeeRateRemoved > CFeeRate(0))
         LogPrint("mempool", "Removed %u txn, rolling minimum fee bumped to %s\n", nTxnRemoved, maxFeeRateRemoved.ToString());
 }
+
+void CTxMemPool::TrimToSize()
+{
+    TrimToSize(nGlobalMempoolSizeLimit);
+}

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -447,7 +447,9 @@ public:
     /** Additional version with sizelimit as parameter, useful for testing. */
     CFeeRate GetMinFee(size_t sizelimit) const;
 
-    /** Remove transactions from the mempool until its dynamic size is <= sizelimit. */
+    /** Remove transactions from the mempool until its dynamic size is <= nGlobalMempoolSizeLimit. */
+    void TrimToSize();
+    /** Additional version with sizelimit as parameter, useful for testing. */
     void TrimToSize(size_t sizelimit);
 
     /** Expire all transaction (and their dependencies) in the mempool older than time. Return the number of removed transactions. */

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -20,6 +20,9 @@
 
 class CAutoFile;
 
+/** Default for -maxmempool, maximum megabytes of mempool memory usage */
+static const unsigned int DEFAULT_MAX_MEMPOOL_SIZE = 300;
+
 inline double AllowFreeThreshold()
 {
     return COIN * 144 / 250;

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -443,6 +443,8 @@ public:
       *  takes the fee rate to go back down all the way to 0. When the feerate
       *  would otherwise be half of this, it is set to 0 instead.
       */
+    CFeeRate GetMinFee() const;
+    /** Additional version with sizelimit as parameter, useful for testing. */
     CFeeRate GetMinFee(size_t sizelimit) const;
 
     /** Remove transactions from the mempool until its dynamic size is <= sizelimit. */


### PR DESCRIPTION
As mentioned repeatedly in #6134, the PR request has introduced an unnecessary circular dependency:

Befere CTxMemPool depended on CBlockPolicyEstimator, but CBlockPolicyEstimator didn't depend on CTxMemPool until #6134 was merged. The first commit would have been practically free diff-wise if it had been squashed in #6134. The second are additional simplifications that wouldn't have been free, but include here for discussion. 
