### PR TITLE
simple fix to mask command line arguments after they are copied

### DIFF
--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -235,6 +235,16 @@ int CommandLineRPC(int argc, char *argv[])
 
         // Parameters default to strings
         std::vector<std::string> strParams(&argv[2], &argv[argc]);
+
+        // mask all command line arguments so that passwords and private keys
+        // will not display in the process table
+        for(int i = 2; i < argc; i++) {
+           int len = strlen(argv[i]);
+           for(int j = 0; j < len; j++) {
+               argv[i][j] = 'X';
+           }
+        }
+
         UniValue params = RPCConvertValues(strMethod, strParams);
 
         // Execute and handle connection failures with -rpcwait


### PR DESCRIPTION
This replaces the command line args with Xs for bitcoin-cli so that passwords and private keys can not be observed in the process table while it executes.  This trick is borrowed from the mysql codebase.
