### PR TITLE
[WIP] Make trickle logic useful again, delay trickle when past upload limit.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5156,6 +5156,11 @@ bool ProcessMessages(CNode* pfrom)
 }
 
 
+static bool CompareInvHash(const CInv a, const CInv &b)
+{
+    return a.hash < b.hash;
+}
+
 bool SendMessages(CNode* pto, bool fSendTrickle)
 {
     const Consensus::Params& consensusParams = Params().GetConsensus();
@@ -5308,26 +5313,26 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
                     continue;
 
                 // trickle out tx inv to protect privacy
-                if (inv.type == MSG_TX && !fSendTrickle)
+                if (inv.type == MSG_TX)
                 {
-                    // 1/4 of tx invs blast to all immediately
-                    static uint256 hashSalt;
-                    if (hashSalt.IsNull())
-                        hashSalt = GetRandHash();
-                    uint256 hashRand = ArithToUint256(UintToArith256(inv.hash) ^ UintToArith256(hashSalt));
-                    hashRand = Hash(BEGIN(hashRand), END(hashRand));
-                    bool fTrickleWait = ((UintToArith256(hashRand) & 3) != 0);
-
-                    if (fTrickleWait)
-                    {
-                        vInvWait.push_back(inv);
-                        continue;
-                    }
+                    vInvWait.push_back(inv);
+                    continue;
                 }
-
-                // returns true if wasn't already contained in the set
-                if (pto->setInventoryKnown.insert(inv).second)
+                pto->setInventoryKnown.insert(inv);
+                vInv.push_back(inv);
+                if (vInv.size() >= 1000)
                 {
+                    pto->PushMessage("inv", vInv);
+                    vInv.clear();
+                }
+            }
+
+            if(fSendTrickle)
+            {
+                std::sort(vInvWait.begin(), vInvWait.end(), CompareInvHash);
+                BOOST_FOREACH(const CInv& inv, vInvWait)
+                {
+                    pto->setInventoryKnown.insert(inv);
                     vInv.push_back(inv);
                     if (vInv.size() >= 1000)
                     {
@@ -5335,8 +5340,10 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
                         vInv.clear();
                     }
                 }
+                pto->vInventoryToSend.clear();
+            } else {
+                pto->vInventoryToSend = vInvWait;
             }
-            pto->vInventoryToSend = vInvWait;
         }
         if (!vInv.empty())
             pto->PushMessage("inv", vInv);

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1703,6 +1703,29 @@ bool OpenNetworkConnection(const CAddress& addrConnect, CSemaphoreGrant *grantOu
     return true;
 }
 
+static bool CompareNodeMessageHandler(const CNodeRef &a, const CNodeRef &b)
+{
+   // Prefer nodes that want tx-realy, non-filtering nodes,
+   // nodes that have relayed tx to us, nodes that claim NodeNework,
+   // outbound peers, lower node ID.
+
+    if (a->fRelayTxes != b->fRelayTxes)
+        return a->fRelayTxes;
+
+    if ((a->pfilter == NULL) != (b->pfilter == NULL))
+        return a->pfilter == NULL;
+
+/*    if ((a->nTimeLastTX > 0) != (b->nTimeLastTX > 0))
+        return a->nTimeLastTX > 0;*/
+
+    if (a->fInbound != b->fInbound)
+        return b->fInbound;
+
+    if (a->fClient != b->fClient)
+        return b->fClient;
+
+    return a->id < b->id;
+}
 
 void ThreadMessageHandler()
 {
@@ -1710,24 +1733,49 @@ void ThreadMessageHandler()
     boost::unique_lock<boost::mutex> lock(condition_mutex);
 
     SetThreadPriority(THREAD_PRIORITY_BELOW_NORMAL);
+    int64_t nNextTrickleTime = 0;
+    CNode* pnodeTrickle1 = NULL;
+    CNode* pnodeTrickle2 = NULL;
     while (true)
     {
+        bool fHasTrickle1 = false;
+        bool fHasTrickle2 = false;
         vector<CNode*> vNodesCopy;
         {
             LOCK(cs_vNodes);
             vNodesCopy = vNodes;
+            std::sort(vNodesCopy.begin(), vNodesCopy.end(), CompareNodeMessageHandler);
             BOOST_FOREACH(CNode* pnode, vNodesCopy) {
                 pnode->AddRef();
+                fHasTrickle1 |= pnodeTrickle1 == pnode && !pnode->fDisconnect;
+                fHasTrickle2 |= pnodeTrickle2 == pnode && !pnode->fDisconnect;
             }
         }
 
-        // Poll the connected nodes for messages
-        CNode* pnodeTrickle = NULL;
-        if (!vNodesCopy.empty())
-            pnodeTrickle = vNodesCopy[GetRand(vNodesCopy.size())];
+        if (!fHasTrickle1)
+            pnodeTrickle1 = NULL;
+
+        // Elect new trickle nodes from one of the best 4 peers.
+        if (pnodeTrickle1 == NULL && !vNodesCopy.empty())
+            pnodeTrickle1 = vNodesCopy[GetRand(min(vNodesCopy.size(), (size_t)4))];
+
+        if (!fHasTrickle2 || pnodeTrickle2 == pnodeTrickle1)
+            pnodeTrickle2 = NULL;
+
+        if (pnodeTrickle2 == NULL && vNodesCopy.size() > 1)
+        {
+            do {
+                pnodeTrickle2 = vNodesCopy[GetRand(min(vNodesCopy.size(), (size_t)4))];
+            } while(pnodeTrickle1 == pnodeTrickle2);
+        }
+
 
         bool fSleep = true;
+        bool fSendBatch = GetTimeMillis() > nNextTrickleTime;
 
+        LogPrintf("Trickle: Debug prints to be removed. batch: %d elected %d %d\n", fSendBatch, pnodeTrickle1 != NULL?pnodeTrickle1->id:-1, pnodeTrickle2 != NULL?pnodeTrickle2->id:-1);
+
+        // Poll the connected nodes for messages
         BOOST_FOREACH(CNode* pnode, vNodesCopy)
         {
             if (pnode->fDisconnect)
@@ -1756,9 +1804,19 @@ void ThreadMessageHandler()
             {
                 TRY_LOCK(pnode->cs_vSend, lockSend);
                 if (lockSend)
-                    g_signals.SendMessages(pnode, pnode == pnodeTrickle || pnode->fWhitelisted);
+                    g_signals.SendMessages(pnode, fSendBatch || pnode == pnodeTrickle1 || pnode == pnodeTrickle2 || pnode->fWhitelisted);
             }
             boost::this_thread::interruption_point();
+        }
+
+        if (fSendBatch)
+        {
+            nNextTrickleTime = GetTimeMillis() + 500 + GetRand(1000);
+            // Delay transaction INVs when we're out of bandwidth to reduce how often peers getdata from us.
+            if (CNode::OutboundTargetReached(true))
+                nNextTrickleTime += 1000;
+            pnodeTrickle1 = NULL;
+            pnodeTrickle2 = NULL;
         }
 
         {


### PR DESCRIPTION
These change should improve privacy, discourage some resource
 wasting behavior from parties trying to attack user privacy, and
 provides additional node bandwidth control.

When Bitcoin Core was changed to not use fixed sleeps in network
 message handling this mostly broke the trickle logic:  Instead of
 picking a new random node to bypass the delay every 100ms, it now
 chooses a new one every time through the message processing loop
 which can be much faster and can be remotely triggered.

As a result a vast majority of invs simply blew through without
 any delay.

This patch drops the old 1/4 random selection logic and elects two
 trickle peers which will get immediate forwards.  These peers
 are selected at random from the top four peers ordered by their
 ability to take unfiltered relays, being outbound, being
 network nodes, and highest uptime.  All other peers have their
 INVs triggered on a shared random delay (with a mean of 1 second).

The selection criteria tries to find a stable set of non-attacker
 controlled nodes that work and stick with them.

Two are used so that even if one was the original source of the
 only transactions ready to send the transactions will not
 be guaranteed to end their journey here.  It also should improve
 robustness to dysfunctional nodes.

When the upload limit is passed, this responds by increasing the
 batching interval by another second. Preliminary testing suggests
 this significantly reduces the number of transaction getdatas
 the node receives.

Finally, this sorts transaction INV before sending them to reduce
 the potential for information to leak in INV ordering.
