### PR TITLE
Add 'setblockmaxsize' RPC interface

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -998,6 +998,8 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     // Option to startup with mocktime set (used for regression testing):
     SetMockTime(GetArg("-mocktime", 0)); // SetMockTime(0) is a no-op
 
+    nBlockMaxSize = GetArg("-blockmaxsize", DEFAULT_BLOCK_MAX_SIZE);
+
     if (GetBoolArg("-peerbloomfilters", true))
         nLocalServices |= NODE_BLOOM;
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -56,6 +56,7 @@ public:
     }
 };
 
+unsigned int nBlockMaxSize = DEFAULT_BLOCK_MAX_SIZE;
 uint64_t nLastBlockTx = 0;
 uint64_t nLastBlockSize = 0;
 
@@ -125,8 +126,7 @@ CBlockTemplate* CreateNewBlock(const CChainParams& chainparams, const CScript& s
     pblocktemplate->vTxFees.push_back(-1); // updated at end
     pblocktemplate->vTxSigOps.push_back(-1); // updated at end
 
-    // Largest block you're willing to create:
-    unsigned int nBlockMaxSize = GetArg("-blockmaxsize", DEFAULT_BLOCK_MAX_SIZE);
+    // Largest block you're willing to create
     // Limit to betweeen 1K and MAX_BLOCK_SIZE-1K for sanity:
     nBlockMaxSize = std::max((unsigned int)1000, std::min((unsigned int)(MAX_BLOCK_SIZE-1000), nBlockMaxSize));
 

--- a/src/miner.h
+++ b/src/miner.h
@@ -36,5 +36,6 @@ CBlockTemplate* CreateNewBlock(const CChainParams& chainparams, const CScript& s
 /** Modify the extranonce in a block */
 void IncrementExtraNonce(CBlock* pblock, const CBlockIndex* pindexPrev, unsigned int& nExtraNonce);
 int64_t UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev);
+extern unsigned int nBlockMaxSize;
 
 #endif // BITCOIN_MINER_H

--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -58,6 +58,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "listaccounts", 1 },
     { "walletpassphrase", 1 },
     { "getblocktemplate", 0 },
+    { "setblockmaxsize", 0},
     { "listsinceblock", 1 },
     { "listsinceblock", 2 },
     { "sendmany", 1 },

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -590,6 +590,31 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
     return result;
 }
 
+UniValue setblockmaxsize(const UniValue& params, bool fHelp)
+{
+    if (fHelp || params.size() < 1 || params.size() > 1)
+        throw runtime_error(
+            "setblockmaxsize size\n"
+            "\nSet the maximum block size in bytes for getblocktemplate.\n"
+            "\nArguments:\n"
+            "1. size           (numeric, required) The maximum size (in bytes) of blocks to create when mining. Minimum value: 1000.\n"
+            "\nResult\n"
+            "true|false        (boolean) Returns true if successful\n"
+            "\nExamples:\n"
+            + HelpExampleCli("setblockmaxsize", "1000000")
+            + HelpExampleRpc("setblockmaxsize", "1000000")
+        );
+
+    LOCK(cs_main); // need to block against getblocktemplate
+
+    uint64_t size = nBlockMaxSize;
+    if (params[0].get_real() >= 1000)
+        size = (params[0].get_int64());        // rejects 0.0 amounts
+
+    nBlockMaxSize = size;
+    return true;
+}
+
 class submitblock_StateCatcher : public CValidationInterface
 {
 public:

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -292,6 +292,7 @@ static const CRPCCommand vRPCCommands[] =
 
     /* Mining */
     { "mining",             "getblocktemplate",       &getblocktemplate,       true  },
+    { "mining",             "setblockmaxsize",        &setblockmaxsize,        true  },
     { "mining",             "getmininginfo",          &getmininginfo,          true  },
     { "mining",             "getnetworkhashps",       &getnetworkhashps,       true  },
     { "mining",             "prioritisetransaction",  &prioritisetransaction,  true  },

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -169,6 +169,7 @@ extern UniValue getconnectioncount(const UniValue& params, bool fHelp); // in rp
 extern UniValue getpeerinfo(const UniValue& params, bool fHelp);
 extern UniValue ping(const UniValue& params, bool fHelp);
 extern UniValue addnode(const UniValue& params, bool fHelp);
+extern UniValue setblockmaxsize(const UniValue& params, bool fHelp);
 extern UniValue disconnectnode(const UniValue& params, bool fHelp);
 extern UniValue getaddednodeinfo(const UniValue& params, bool fHelp);
 extern UniValue getnettotals(const UniValue& params, bool fHelp);


### PR DESCRIPTION
Verified as functional on testnet. (You need a new transaction to enter mempool after running `bitcoin-cli setblockmaxsize x` and before running getblocktemplate, otherwise GBT will just use the cached template.)

This patch was discussed briefly on IRC about 20 hours ago. http://bitcoinstats.com/irc/bitcoin-dev/logs/2015/11/29
