### PR TITLE
Tests: Explicitly set chain limits in replace-by-fee test

### DIFF
--- a/qa/rpc-tests/replace-by-fee.py
+++ b/qa/rpc-tests/replace-by-fee.py
@@ -73,7 +73,12 @@ class ReplaceByFeeTest(BitcoinTestFramework):
     def setup_network(self):
         self.nodes = []
         self.nodes.append(start_node(0, self.options.tmpdir, ["-maxorphantx=1000",
-                                                              "-relaypriority=0", "-whitelist=127.0.0.1"]))
+                                                              "-relaypriority=0", "-whitelist=127.0.0.1",
+                                                              "-limitancestorcount=50",
+                                                              "-limitancestorsize=101",
+                                                              "-limitdescendantcount=200",
+                                                              "-limitdescendantsize=101"
+                                                              ]))
         self.is_network_split = False
 
     def run_test(self):


### PR DESCRIPTION
The chains built in this test will fail with the lower chain limits introduced by #6771.  I just changed them to be higher to avoid rewriting these tests, which aren't meant to test those chain limits anyway.

@petertodd  Is it time to remove the qa/replace-by-fee directory?  I can do that cleanup in this pull if you like.

Fixes #7120 
