### PR TITLE
test: Disable scheduler test manythreads

### DIFF
--- a/src/test/scheduler_tests.cpp
+++ b/src/test/scheduler_tests.cpp
@@ -40,6 +40,7 @@ static void MicroSleep(uint64_t n)
 #endif
 }
 
+#if 0 /* Disabled for now because there is a race condition issue in this test - see #6540 */
 BOOST_AUTO_TEST_CASE(manythreads)
 {
     seed_insecure_rand(false);
@@ -115,5 +116,6 @@ BOOST_AUTO_TEST_CASE(manythreads)
     }
     BOOST_CHECK_EQUAL(counterSum, 200);
 }
+#endif
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
It causes occasional deadlocks, resulting in false negatives in Travis.

Disable the test for now.
Works around #6540.
