### PR TITLE
Mempool: Improve mempool's concurrency

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -22,6 +22,7 @@
 #include "main.h"
 #include "miner.h"
 #include "net.h"
+#include "policy/fees.h"
 #include "policy/policy.h"
 #include "rpcserver.h"
 #include "script/standard.h"
@@ -203,7 +204,7 @@ void Shutdown()
         boost::filesystem::path est_path = GetDataDir() / FEE_ESTIMATES_FILENAME;
         CAutoFile est_fileout(fopen(est_path.string().c_str(), "wb"), SER_DISK, CLIENT_VERSION);
         if (!est_fileout.IsNull())
-            mempool.WriteFeeEstimates(est_fileout);
+            globalFeePolicy.Write(est_fileout);
         else
             LogPrintf("%s: Failed to write fee estimates to %s\n", __func__, est_path.string());
         fFeeEstimatesInitialized = false;
@@ -1390,7 +1391,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     CAutoFile est_filein(fopen(est_path.string().c_str(), "rb"), SER_DISK, CLIENT_VERSION);
     // Allowed to fail as this file IS missing on first startup.
     if (!est_filein.IsNull())
-        mempool.ReadFeeEstimates(est_filein);
+        globalFeePolicy.Read(est_filein);
     fFeeEstimatesInitialized = true;
 
     // ********************************************************* Step 8: load wallet

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,6 +18,7 @@
 #include "init.h"
 #include "merkleblock.h"
 #include "net.h"
+#include "policy/fees.h"
 #include "policy/policy.h"
 #include "pow.h"
 #include "primitives/block.h"
@@ -77,8 +78,8 @@ bool fAlerts = DEFAULT_ALERTS;
 
 /** Fees smaller than this (in satoshi) are considered zero fee (for relaying, mining and transaction creation) */
 CFeeRate minRelayTxFee = CFeeRate(DEFAULT_MIN_RELAY_TX_FEE);
-
-CTxMemPool mempool(::minRelayTxFee);
+CBlockPolicyEstimator globalFeePolicy(::minRelayTxFee);
+CTxMemPool mempool(globalFeePolicy, ::minRelayTxFee);
 
 struct COrphanTx {
     CTransaction tx;

--- a/src/main.h
+++ b/src/main.h
@@ -29,6 +29,7 @@
 #include <boost/unordered_map.hpp>
 
 class CBlockIndex;
+class CBlockPolicyEstimator;
 class CBlockTreeDB;
 class CBloomFilter;
 class CChainParams;
@@ -108,6 +109,7 @@ struct BlockHasher
 
 extern CScript COINBASE_FLAGS;
 extern CCriticalSection cs_main;
+extern CBlockPolicyEstimator globalFeePolicy;
 extern CTxMemPool mempool;
 typedef boost::unordered_map<uint256, CBlockIndex*, BlockHasher> BlockMap;
 extern BlockMap mapBlockIndex;

--- a/src/policy/fees.cpp
+++ b/src/policy/fees.cpp
@@ -505,7 +505,7 @@ CFeeRate CBlockPolicyEstimator::estimateFee(int confTarget)
     return CFeeRate(median);
 }
 
-CFeeRate CBlockPolicyEstimator::estimateSmartFee(int confTarget, int *answerFoundAtTarget, const CTxMemPool& pool)
+CFeeRate CBlockPolicyEstimator::estimateSmartFee(int confTarget, int* answerFoundAtTarget, const CAmount& minPoolFee)
 {
     if (answerFoundAtTarget)
         *answerFoundAtTarget = confTarget;
@@ -522,7 +522,6 @@ CFeeRate CBlockPolicyEstimator::estimateSmartFee(int confTarget, int *answerFoun
         *answerFoundAtTarget = confTarget - 1;
 
     // If mempool is limiting txs , return at least the min fee from the mempool
-    CAmount minPoolFee = pool.GetMinFee(GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000).GetFeePerK();
     if (minPoolFee > 0 && minPoolFee > median)
         return CFeeRate(minPoolFee);
 
@@ -541,7 +540,7 @@ double CBlockPolicyEstimator::estimatePriority(int confTarget)
     return priStats.EstimateMedianVal(confTarget, SUFFICIENT_PRITXS, MIN_SUCCESS_PCT, true, nBestSeenHeight);
 }
 
-double CBlockPolicyEstimator::estimateSmartPriority(int confTarget, int *answerFoundAtTarget, const CTxMemPool& pool)
+double CBlockPolicyEstimator::estimateSmartPriority(int confTarget, int* answerFoundAtTarget, const CAmount& minPoolFee)
 {
     if (answerFoundAtTarget)
         *answerFoundAtTarget = confTarget;
@@ -550,7 +549,6 @@ double CBlockPolicyEstimator::estimateSmartPriority(int confTarget, int *answerF
         return -1;
 
     // If mempool is limiting txs, no priority txs are allowed
-    CAmount minPoolFee = pool.GetMinFee(GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000).GetFeePerK();
     if (minPoolFee > 0)
         return INF_PRIORITY;
 

--- a/src/policy/fees.h
+++ b/src/policy/fees.h
@@ -247,7 +247,7 @@ public:
      *  confTarget blocks. If no answer can be given at confTarget, return an
      *  estimate at the lowest target where one can be given.
      */
-    CFeeRate estimateSmartFee(int confTarget, int *answerFoundAtTarget, const CTxMemPool& pool);
+    CFeeRate estimateSmartFee(int confTarget, int* answerFoundAtTarget, const CAmount& minPoolFee);
 
     /** Return a priority estimate */
     double estimatePriority(int confTarget);
@@ -256,7 +256,7 @@ public:
      *  confTarget blocks. If no answer can be given at confTarget, return an
      *  estimate at the lowest target where one can be given.
      */
-    double estimateSmartPriority(int confTarget, int *answerFoundAtTarget, const CTxMemPool& pool);
+    double estimateSmartPriority(int confTarget, int* answerFoundAtTarget, const CAmount& minPoolFee);
 
     /** Write estimation data to a file */
     void Write(CAutoFile& fileout);

--- a/src/policy/fees.h
+++ b/src/policy/fees.h
@@ -6,6 +6,7 @@
 #define BITCOIN_POLICYESTIMATOR_H
 
 #include "amount.h"
+#include "sync.h"
 #include "uint256.h"
 
 #include <map>
@@ -217,6 +218,7 @@ static const double PRI_SPACING = 2;
  */
 class CBlockPolicyEstimator
 {
+    mutable CCriticalSection cs;
 public:
     /** Create new BlockPolicyEstimator and initialize stats tracking classes with default values */
     CBlockPolicyEstimator(const CFeeRate& minRelayFee);

--- a/src/policy/fees.h
+++ b/src/policy/fees.h
@@ -167,7 +167,7 @@ public:
     unsigned int GetMaxConfirms() { return confAvg.size(); }
 
     /** Write state of estimation data to a file*/
-    void Write(CAutoFile& fileout);
+    void Write(CAutoFile& fileout) const;
 
     /**
      * Read saved state of estimation data from a file and replace all internal data structures and
@@ -242,8 +242,8 @@ public:
     /** Is this transaction likely included in a block because of its priority?*/
     bool isPriDataPoint(const CFeeRate &fee, double pri);
 
-    /** Return a fee estimate */
-    CFeeRate estimateFee(int confTarget);
+    /** Estimate fee rate needed to get into the next nBlocks */
+    CFeeRate estimateFee(int nBlocks);
 
     /** Estimate fee rate needed to get be included in a block within
      *  confTarget blocks. If no answer can be given at confTarget, return an
@@ -251,8 +251,8 @@ public:
      */
     CFeeRate estimateSmartFee(int confTarget, int* answerFoundAtTarget, const CAmount& minPoolFee);
 
-    /** Return a priority estimate */
-    double estimatePriority(int confTarget);
+    /** @deprecated Estimate priority needed to get into the next nBlocks */
+    double estimatePriority(int nBlocks);
 
     /** Estimate priority needed to get be included in a block within
      *  confTarget blocks. If no answer can be given at confTarget, return an
@@ -261,10 +261,10 @@ public:
     double estimateSmartPriority(int confTarget, int* answerFoundAtTarget, const CAmount& minPoolFee);
 
     /** Write estimation data to a file */
-    void Write(CAutoFile& fileout);
+    bool Write(CAutoFile& fileout) const;
 
     /** Read estimation data from a file */
-    void Read(CAutoFile& filein);
+    bool Read(CAutoFile& filein);
 
 private:
     CFeeRate minTrackedFee; //! Passed to constructor to avoid dependency on main

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -25,8 +25,6 @@ static const unsigned int MAX_STANDARD_TX_SIZE = 100000;
 static const unsigned int MAX_P2SH_SIGOPS = 15;
 /** The maximum number of sigops we're willing to relay/mine in a single tx */
 static const unsigned int MAX_STANDARD_TX_SIGOPS = MAX_BLOCK_SIGOPS/5;
-/** Default for -maxmempool, maximum megabytes of mempool memory usage */
-static const unsigned int DEFAULT_MAX_MEMPOOL_SIZE = 300;
 /**
  * Standard script verification flags that standard transactions will comply
  * with. However scripts violating these flags may still be present in valid

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -13,6 +13,7 @@
 #include "main.h"
 #include "miner.h"
 #include "net.h"
+#include "policy/fees.h"
 #include "pow.h"
 #include "rpcserver.h"
 #include "txmempool.h"
@@ -693,7 +694,7 @@ UniValue estimatefee(const UniValue& params, bool fHelp)
     if (nBlocks < 1)
         nBlocks = 1;
 
-    CFeeRate feeRate = mempool.estimateFee(nBlocks);
+    CFeeRate feeRate = globalFeePolicy.estimateFee(nBlocks);
     if (feeRate == CFeeRate(0))
         return -1.0;
 
@@ -724,7 +725,7 @@ UniValue estimatepriority(const UniValue& params, bool fHelp)
     if (nBlocks < 1)
         nBlocks = 1;
 
-    return mempool.estimatePriority(nBlocks);
+    return globalFeePolicy.estimatePriority(nBlocks);
 }
 
 UniValue estimatesmartfee(const UniValue& params, bool fHelp)

--- a/src/test/mempool_tests.cpp
+++ b/src/test/mempool_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include "policy/fees.h"
 #include "txmempool.h"
 #include "util.h"
 
@@ -52,8 +53,8 @@ BOOST_AUTO_TEST_CASE(MempoolRemoveTest)
         txGrandChild[i].vout[0].nValue = 11000LL;
     }
 
-
-    CTxMemPool testPool(CFeeRate(0));
+    CBlockPolicyEstimator testFeePolicy(CFeeRate(0));
+    CTxMemPool testPool(testFeePolicy, CFeeRate(0));
     std::list<CTransaction> removed;
 
     // Nothing in pool, remove should do nothing:
@@ -114,7 +115,8 @@ void CheckSort(CTxMemPool &pool, std::vector<std::string> &sortedOrder)
 
 BOOST_AUTO_TEST_CASE(MempoolIndexingTest)
 {
-    CTxMemPool pool(CFeeRate(0));
+    CBlockPolicyEstimator testFeePolicy(CFeeRate(0));
+    CTxMemPool pool(testFeePolicy, CFeeRate(0));
     TestMemPoolEntryHelper entry;
     entry.hadNoDependencies = true;
 
@@ -286,7 +288,8 @@ BOOST_AUTO_TEST_CASE(MempoolIndexingTest)
 
 BOOST_AUTO_TEST_CASE(MempoolSizeLimitTest)
 {
-    CTxMemPool pool(CFeeRate(1000));
+    CBlockPolicyEstimator testFeePolicy(CFeeRate(1000));
+    CTxMemPool pool(testFeePolicy, CFeeRate(1000));
     TestMemPoolEntryHelper entry;
     entry.dPriority = 10.0;
 

--- a/src/test/policyestimator_tests.cpp
+++ b/src/test/policyestimator_tests.cpp
@@ -15,7 +15,8 @@ BOOST_FIXTURE_TEST_SUITE(policyestimator_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
 {
-    CTxMemPool mpool(CFeeRate(1000));
+    CBlockPolicyEstimator testFeePolicy(CFeeRate(1000));
+    CTxMemPool mpool(testFeePolicy, CFeeRate(1000));
     TestMemPoolEntryHelper entry;
     CAmount basefee(2000);
     double basepri = 1e6;

--- a/src/test/policyestimator_tests.cpp
+++ b/src/test/policyestimator_tests.cpp
@@ -87,16 +87,16 @@ BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
             // At this point we should need to combine 5 buckets to get enough data points
             // So estimateFee(1,2,3) should fail and estimateFee(4) should return somewhere around
             // 8*baserate.  estimateFee(4) %'s are 100,100,100,100,90 = average 98%
-            BOOST_CHECK(mpool.estimateFee(1) == CFeeRate(0));
-            BOOST_CHECK(mpool.estimateFee(2) == CFeeRate(0));
-            BOOST_CHECK(mpool.estimateFee(3) == CFeeRate(0));
-            BOOST_CHECK(mpool.estimateFee(4).GetFeePerK() < 8*baseRate.GetFeePerK() + deltaFee);
-            BOOST_CHECK(mpool.estimateFee(4).GetFeePerK() > 8*baseRate.GetFeePerK() - deltaFee);
+            BOOST_CHECK(testFeePolicy.estimateFee(1) == CFeeRate(0));
+            BOOST_CHECK(testFeePolicy.estimateFee(2) == CFeeRate(0));
+            BOOST_CHECK(testFeePolicy.estimateFee(3) == CFeeRate(0));
+            BOOST_CHECK(testFeePolicy.estimateFee(4).GetFeePerK() < 8*baseRate.GetFeePerK() + deltaFee);
+            BOOST_CHECK(testFeePolicy.estimateFee(4).GetFeePerK() > 8*baseRate.GetFeePerK() - deltaFee);
             int answerFound;
-            BOOST_CHECK(mpool.estimateSmartFee(1, &answerFound) == mpool.estimateFee(4) && answerFound == 4);
-            BOOST_CHECK(mpool.estimateSmartFee(3, &answerFound) == mpool.estimateFee(4) && answerFound == 4);
-            BOOST_CHECK(mpool.estimateSmartFee(4, &answerFound) == mpool.estimateFee(4) && answerFound == 4);
-            BOOST_CHECK(mpool.estimateSmartFee(8, &answerFound) == mpool.estimateFee(8) && answerFound == 8);
+            BOOST_CHECK(mpool.estimateSmartFee(1, &answerFound) == testFeePolicy.estimateFee(4) && answerFound == 4);
+            BOOST_CHECK(mpool.estimateSmartFee(3, &answerFound) == testFeePolicy.estimateFee(4) && answerFound == 4);
+            BOOST_CHECK(mpool.estimateSmartFee(4, &answerFound) == testFeePolicy.estimateFee(4) && answerFound == 4);
+            BOOST_CHECK(mpool.estimateSmartFee(8, &answerFound) == testFeePolicy.estimateFee(8) && answerFound == 8);
         }
     }
 
@@ -109,8 +109,8 @@ BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
     // Second highest feerate has 100% chance of being included by 2 blocks,
     // so estimateFee(2) should return 9*baseRate etc...
     for (int i = 1; i < 10;i++) {
-        origFeeEst.push_back(mpool.estimateFee(i).GetFeePerK());
-        origPriEst.push_back(mpool.estimatePriority(i));
+        origFeeEst.push_back(testFeePolicy.estimateFee(i).GetFeePerK());
+        origPriEst.push_back(testFeePolicy.estimatePriority(i));
         if (i > 1) { // Fee estimates should be monotonically decreasing
             BOOST_CHECK(origFeeEst[i-1] <= origFeeEst[i-2]);
             BOOST_CHECK(origPriEst[i-1] <= origPriEst[i-2]);
@@ -128,10 +128,10 @@ BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
         mpool.removeForBlock(block, ++blocknum, dummyConflicted);
 
     for (int i = 1; i < 10;i++) {
-        BOOST_CHECK(mpool.estimateFee(i).GetFeePerK() < origFeeEst[i-1] + deltaFee);
-        BOOST_CHECK(mpool.estimateFee(i).GetFeePerK() > origFeeEst[i-1] - deltaFee);
-        BOOST_CHECK(mpool.estimatePriority(i) < origPriEst[i-1] + deltaPri);
-        BOOST_CHECK(mpool.estimatePriority(i) > origPriEst[i-1] - deltaPri);
+        BOOST_CHECK(testFeePolicy.estimateFee(i).GetFeePerK() < origFeeEst[i-1] + deltaFee);
+        BOOST_CHECK(testFeePolicy.estimateFee(i).GetFeePerK() > origFeeEst[i-1] - deltaFee);
+        BOOST_CHECK(testFeePolicy.estimatePriority(i) < origPriEst[i-1] + deltaPri);
+        BOOST_CHECK(testFeePolicy.estimatePriority(i) > origPriEst[i-1] - deltaPri);
     }
 
 
@@ -151,9 +151,9 @@ BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
 
     int answerFound;
     for (int i = 1; i < 10;i++) {
-        BOOST_CHECK(mpool.estimateFee(i) == CFeeRate(0) || mpool.estimateFee(i).GetFeePerK() > origFeeEst[i-1] - deltaFee);
+        BOOST_CHECK(testFeePolicy.estimateFee(i) == CFeeRate(0) || testFeePolicy.estimateFee(i).GetFeePerK() > origFeeEst[i-1] - deltaFee);
         BOOST_CHECK(mpool.estimateSmartFee(i, &answerFound).GetFeePerK() > origFeeEst[answerFound-1] - deltaFee);
-        BOOST_CHECK(mpool.estimatePriority(i) == -1 || mpool.estimatePriority(i) > origPriEst[i-1] - deltaPri);
+        BOOST_CHECK(testFeePolicy.estimatePriority(i) == -1 || testFeePolicy.estimatePriority(i) > origPriEst[i-1] - deltaPri);
         BOOST_CHECK(mpool.estimateSmartPriority(i, &answerFound) > origPriEst[answerFound-1] - deltaPri);
     }
 
@@ -170,8 +170,8 @@ BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
     mpool.removeForBlock(block, 265, dummyConflicted);
     block.clear();
     for (int i = 1; i < 10;i++) {
-        BOOST_CHECK(mpool.estimateFee(i).GetFeePerK() > origFeeEst[i-1] - deltaFee);
-        BOOST_CHECK(mpool.estimatePriority(i) > origPriEst[i-1] - deltaPri);
+        BOOST_CHECK(testFeePolicy.estimateFee(i).GetFeePerK() > origFeeEst[i-1] - deltaFee);
+        BOOST_CHECK(testFeePolicy.estimatePriority(i) > origPriEst[i-1] - deltaPri);
     }
 
     // Mine 200 more blocks where everything is mined every block
@@ -191,8 +191,8 @@ BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
         block.clear();
     }
     for (int i = 1; i < 10; i++) {
-        BOOST_CHECK(mpool.estimateFee(i).GetFeePerK() < origFeeEst[i-1] - deltaFee);
-        BOOST_CHECK(mpool.estimatePriority(i) < origPriEst[i-1] - deltaPri);
+        BOOST_CHECK(testFeePolicy.estimateFee(i).GetFeePerK() < origFeeEst[i-1] - deltaFee);
+        BOOST_CHECK(testFeePolicy.estimatePriority(i) < origPriEst[i-1] - deltaPri);
     }
 
     // Test that if the mempool is limited, estimateSmartFee won't return a value below the mempool min fee
@@ -202,7 +202,7 @@ BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
     mpool.TrimToSize(1);
     BOOST_CHECK(mpool.GetMinFee(1).GetFeePerK() > feeV[0][5]);
     for (int i = 1; i < 10; i++) {
-        BOOST_CHECK(mpool.estimateSmartFee(i).GetFeePerK() >= mpool.estimateFee(i).GetFeePerK());
+        BOOST_CHECK(mpool.estimateSmartFee(i).GetFeePerK() >= testFeePolicy.estimateFee(i).GetFeePerK());
         BOOST_CHECK(mpool.estimateSmartFee(i).GetFeePerK() >= mpool.GetMinFee(1).GetFeePerK());
         BOOST_CHECK(mpool.estimateSmartPriority(i) == INF_PRIORITY);
     }

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -714,7 +714,7 @@ CFeeRate CTxMemPool::estimateFee(int nBlocks) const
 CFeeRate CTxMemPool::estimateSmartFee(int nBlocks, int *answerFoundAtBlocks) const
 {
     LOCK(cs);
-    return minerPolicyEstimator->estimateSmartFee(nBlocks, answerFoundAtBlocks, *this);
+    return minerPolicyEstimator->estimateSmartFee(nBlocks, answerFoundAtBlocks, GetMinFee(GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000).GetFeePerK());
 }
 double CTxMemPool::estimatePriority(int nBlocks) const
 {
@@ -724,7 +724,7 @@ double CTxMemPool::estimatePriority(int nBlocks) const
 double CTxMemPool::estimateSmartPriority(int nBlocks, int *answerFoundAtBlocks) const
 {
     LOCK(cs);
-    return minerPolicyEstimator->estimateSmartPriority(nBlocks, answerFoundAtBlocks, *this);
+    return minerPolicyEstimator->estimateSmartPriority(nBlocks, answerFoundAtBlocks, GetMinFee(GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000).GetFeePerK());
 }
 
 bool

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -705,60 +705,13 @@ bool CTxMemPool::lookup(uint256 hash, CTransaction& result) const
     return true;
 }
 
-CFeeRate CTxMemPool::estimateFee(int nBlocks) const
-{
-    LOCK(cs);
-    return minerPolicyEstimator->estimateFee(nBlocks);
-}
 CFeeRate CTxMemPool::estimateSmartFee(int nBlocks, int *answerFoundAtBlocks) const
 {
-    LOCK(cs);
     return minerPolicyEstimator->estimateSmartFee(nBlocks, answerFoundAtBlocks, GetMinFee(GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000).GetFeePerK());
-}
-double CTxMemPool::estimatePriority(int nBlocks) const
-{
-    LOCK(cs);
-    return minerPolicyEstimator->estimatePriority(nBlocks);
 }
 double CTxMemPool::estimateSmartPriority(int nBlocks, int *answerFoundAtBlocks) const
 {
-    LOCK(cs);
     return minerPolicyEstimator->estimateSmartPriority(nBlocks, answerFoundAtBlocks, GetMinFee(GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000).GetFeePerK());
-}
-
-bool
-CTxMemPool::WriteFeeEstimates(CAutoFile& fileout) const
-{
-    try {
-        LOCK(cs);
-        fileout << 109900; // version required to read: 0.10.99 or later
-        fileout << CLIENT_VERSION; // version that wrote the file
-        minerPolicyEstimator->Write(fileout);
-    }
-    catch (const std::exception&) {
-        LogPrintf("CTxMemPool::WriteFeeEstimates(): unable to write policy estimator data (non-fatal)\n");
-        return false;
-    }
-    return true;
-}
-
-bool
-CTxMemPool::ReadFeeEstimates(CAutoFile& filein)
-{
-    try {
-        int nVersionRequired, nVersionThatWrote;
-        filein >> nVersionRequired >> nVersionThatWrote;
-        if (nVersionRequired > CLIENT_VERSION)
-            return error("CTxMemPool::ReadFeeEstimates(): up-version (%d) fee estimate file", nVersionRequired);
-
-        LOCK(cs);
-        minerPolicyEstimator->Read(filein);
-    }
-    catch (const std::exception&) {
-        LogPrintf("CTxMemPool::ReadFeeEstimates(): unable to read policy estimator data (non-fatal)\n");
-        return false;
-    }
-    return true;
 }
 
 void CTxMemPool::PrioritiseTransaction(const uint256 hash, const string strHash, double dPriorityDelta, const CAmount& nFeeDelta)

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -312,7 +312,7 @@ void CTxMemPoolEntry::UpdateState(int64_t modifySize, CAmount modifyFee, int64_t
     }
 }
 
-CTxMemPool::CTxMemPool(const CFeeRate& _minReasonableRelayFee) :
+CTxMemPool::CTxMemPool(CBlockPolicyEstimator& feePolicy, const CFeeRate& _minReasonableRelayFee) :
     nTransactionsUpdated(0)
 {
     _clear(); //lock free clear
@@ -322,13 +322,12 @@ CTxMemPool::CTxMemPool(const CFeeRate& _minReasonableRelayFee) :
     // of transactions in the pool
     nCheckFrequency = 0;
 
-    minerPolicyEstimator = new CBlockPolicyEstimator(_minReasonableRelayFee);
+    minerPolicyEstimator = &feePolicy;
     minReasonableRelayFee = _minReasonableRelayFee;
 }
 
 CTxMemPool::~CTxMemPool()
 {
-    delete minerPolicyEstimator;
 }
 
 void CTxMemPool::pruneSpent(const uint256 &hashTx, CCoins &coins)

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -477,21 +477,11 @@ public:
      */
     CFeeRate estimateSmartFee(int nBlocks, int *answerFoundAtBlocks = NULL) const;
 
-    /** Estimate fee rate needed to get into the next nBlocks */
-    CFeeRate estimateFee(int nBlocks) const;
-
     /** Estimate priority needed to get into the next nBlocks
      *  If no answer can be given at nBlocks, return an estimate
      *  at the lowest number of blocks where one can be given
      */
     double estimateSmartPriority(int nBlocks, int *answerFoundAtBlocks = NULL) const;
-
-    /** Estimate priority needed to get into the next nBlocks */
-    double estimatePriority(int nBlocks) const;
-    
-    /** Write/Read estimates to disk */
-    bool WriteFeeEstimates(CAutoFile& fileout) const;
-    bool ReadFeeEstimates(CAutoFile& filein);
 
     size_t DynamicMemoryUsage() const;
 

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -20,6 +20,9 @@
 
 class CAutoFile;
 
+/** Default for -maxmempool, maximum megabytes of mempool memory usage */
+static const unsigned int DEFAULT_MAX_MEMPOOL_SIZE = 300;
+
 inline double AllowFreeThreshold()
 {
     return COIN * 144 / 250;

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -362,7 +362,7 @@ public:
      *  around what it "costs" to relay a transaction around the network and
      *  below which we would reasonably say a transaction has 0-effective-fee.
      */
-    CTxMemPool(const CFeeRate& _minReasonableRelayFee);
+    CTxMemPool(CBlockPolicyEstimator& feePolicy, const CFeeRate& _minReasonableRelayFee);
     ~CTxMemPool();
 
     /**


### PR DESCRIPTION
This improves concurrency by not locking CTxMemPool every time CBlockPolicyEstimator is used (although as said this is incomplete and the concurrency improvements can be continued), so it may have a positive impact on performance. But I haven't done any benchmark or test.

My original plan was to do this at once while encapsulating the global minRelayTxFee, but relay policy encapsulation is not welcomed at this point and now it would be more disruptive to completely decouple CTxMemPool from CBlockPolicyEstimator than it used to be when first coded this many months ago.
We can take the first steps instead of waiting to do it at once, and that would hopefully prevent the code from evolving to something where is even harder to make this happen.
Although @morcos thinks that CBlockPolicyEstimator should depend on CTxMemPool and I disagree on that, we both agree that CTxMemPool should not depend on CBlockPolicyEstimator. This PR reduces CTxMemPool's dependency on CBlockPolicyEstimator.
