### PR TITLE
Name union to prevent compiler warning

### DIFF
--- a/src/prevector.h
+++ b/src/prevector.h
@@ -140,7 +140,7 @@ public:
 
 private:
     size_type _size;
-    union {
+    union direct_or_indirect {
         char direct[sizeof(T) * N];
         struct {
             size_type capacity;


### PR DESCRIPTION
After merging #6914, a lot of compiler warnings are emitted by `clang`:

```
  CXX      test/test_test_bitcoin-main_tests.o
In file included from test/main_tests.cpp:5:
In file included from ./chainparams.h:11:
In file included from ./primitives/block.h:9:
In file included from ./primitives/transaction.h:9:
In file included from ./amount.h:9:
In file included from ./serialize.h:23:
./prevector.h:419:13: warning: template argument uses unnamed type [-Wunnamed-type-template-args]
            std::swap(_union, other._union);
            ^~~
./script/script.h:618:23: note: in instantiation of member function 'prevector<28, unsigned char, unsigned int, int>::swap' requested here
        CScriptBase().swap(*this);
                      ^
./prevector.h:143:5: note: unnamed type used in template argument was declared here
    union {
    ^
1 warning generated.
```
