### PR TITLE
[NO MERGE] Travis: Run nightly test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ env:
 # Win32
     - HOST=i686-w64-mingw32 DPKG_ADD_ARCH="i386" DEP_OPTS="NO_QT=1" PACKAGES="python3 nsis g++-mingw-w64-i686 wine1.6 bc" RUN_TESTS=true GOAL="install" BITCOIN_CONFIG="--enable-reduce-exports"
 # 32-bit + dash
-    - HOST=i686-pc-linux-gnu PACKAGES="g++-multilib bc python3-zmq" DEP_OPTS="NO_QT=1" RUN_ALL_RPC_TESTS=true DISABLE_MAKE=false GOAL="install" BITCOIN_CONFIG="--enable-zmq --enable-glibc-back-compat --enable-reduce-exports LDFLAGS=-static-libstdc++ CPPFLAGS=-DDEBUG_LOCKORDER" USE_SHELL="/bin/dash"
+    - HOST=i686-pc-linux-gnu PACKAGES="g++-multilib bc python3-zmq" DEP_OPTS="NO_QT=1" RUN_ALL_RPC_TESTS=true DISABLE_MAKE=false GOAL="install" BITCOIN_CONFIG="--enable-werror --enable-zmq --enable-glibc-back-compat --enable-reduce-exports LDFLAGS=-static-libstdc++ CPPFLAGS=-DDEBUG_LOCKORDER" USE_SHELL="/bin/dash"
 # Win64
     - HOST=x86_64-w64-mingw32 DPKG_ADD_ARCH="i386" DEP_OPTS="NO_QT=1" PACKAGES="python3 nsis g++-mingw-w64-x86-64 wine1.6 bc" RUN_TESTS=true GOAL="install" BITCOIN_CONFIG="--enable-reduce-exports"
 # bitcoind

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,8 +86,8 @@ script:
     - if [ "$RUN_TESTS" = "true" ]; then make $MAKEJOBS check VERBOSE=1; fi
     - if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then extended="--extended --exclude pruning"; fi
     - if [ "$RUN_TESTS" = "true" ]; then test/functional/test_runner.py --coverage ${extended}; fi
-    - if [ "$RUN_ALL_RPC_TESTS" = "true" ]; then test/functional/test_runner.py p2p-segwit --oldbinary=../bitcoin-0.12.1/bin/bitcoind; fi
-    - if [ "$RUN_ALL_RPC_TESTS" = "true" ]; then test/functional/test_runner.py -extended --coverage; fi
+    - if [ "$RUN_ALL_RPC_TESTS" = "true" ]; then test/functional/test_runner.py compatibility --oldbinary=../bitcoin-0.12.1/bin/bitcoind; fi
+    - if [ "$RUN_ALL_RPC_TESTS" = "true" ]; then test/functional/test_runner.py --extended -x pruning,rpcbind_test --coverage; fi
 after_script:
     - echo $TRAVIS_COMMIT_RANGE
     - echo $TRAVIS_COMMIT_LOG

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,9 +43,20 @@ install:
     - if [ -n "$DPKG_ADD_ARCH" ]; then sudo dpkg --add-architecture "$DPKG_ADD_ARCH" ; fi
     - if [ -n "$PACKAGES" ]; then travis_retry sudo apt-get update; fi
     - if [ -n "$PACKAGES" ]; then travis_retry sudo apt-get install --no-install-recommends --no-upgrade -qq $PACKAGES; fi
+    - if [ "$CHECK_DOC" = 1 ]; then travis_retry git fetch https://github.com/bitcoin/secp256k1.git; fi
+    - if [ "$CHECK_DOC" = 1 ]; then travis_retry git fetch -unshallow https://github.com/bitcoin/leveldb.git; fi
+    - if [ "$CHECK_DOC" = 1 ]; then travis_retry git fetch https://github.com/bitcoin/univalue.git; fi
+    - if [ "$CHECK_DOC" = 1 ]; then travis_retry git fetch https://github.com/bitcoin-core/ctaes.git; fi
+#    - if [ "$RUN_ALL_RPC_TESTS" = "true" ]; then mkdir -p bin && cd bin; fi
+#    - if [ "$RUN_ALL_RPC_TESTS" = "true" ]; then travis_retry wget -N https://bitcoin.org/bin/bitcoin-core-0.12.1/bitcoin-0.12.1-linux64.tar.gz; fi
+#    - if [ "$RUN_ALL_RPC_TESTS" = "true" ]; then cd .. && echo "54aca14b7512801ab78cc93f8576e1b66364a890e8017e8a187e4bf0209fd28c  bin/bitcoin-0.12.1-linux64.tar.gz" | sha256sum --check && tar -xzvf bin/bitcoin-0.12.1-linux64.tar.gz; fi
 before_script:
     - unset CC; unset CXX
     - if [ "$CHECK_DOC" = 1 ]; then contrib/devtools/check-doc.py; fi
+    - if [ "$CHECK_DOC" = 1 ]; then ./contrib/devtools/git-subtree-check.sh src/secp256k1; fi
+    - if [ "$CHECK_DOC" = 1 ]; then ./contrib/devtools/git-subtree-check.sh src/leveldb; fi
+    - if [ "$CHECK_DOC" = 1 ]; then ./contrib/devtools/git-subtree-check.sh src/univalue; fi
+    - if [ "$CHECK_DOC" = 1 ]; then ./contrib/devtools/git-subtree-check.sh src/crypto/ctaes; fi
     - mkdir -p depends/SDKs depends/sdk-sources
     - if [ -n "$OSX_SDK" -a ! -f depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz ]; then curl --location --fail $SDK_URL/MacOSX${OSX_SDK}.sdk.tar.gz -o depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz; fi
     - if [ -n "$OSX_SDK" -a -f depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz ]; then tar -C depends/SDKs -xf depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz; fi
@@ -71,7 +82,9 @@ script:
     - export LD_LIBRARY_PATH=$TRAVIS_BUILD_DIR/depends/$HOST/lib
     - if [ "$RUN_TESTS" = "true" ]; then make $MAKEJOBS check VERBOSE=1; fi
     - if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then extended="--extended --exclude pruning"; fi
-    - if [ "$RUN_TESTS" = "true" ]; then test/functional/test_runner.py --coverage --quiet ${extended}; fi
+    - if [ "$RUN_TESTS" = "true" ]; then test/functional/test_runner.py --coverage ${extended}; fi
+#    - if [ "$RUN_ALL_RPC_TESTS" = "true" ]; then test/functional/test_runner.py p2p-segwit --oldbinary=../bitcoin-0.12.1/bin/bitcoind; fi
+    - if [ "$RUN_ALL_RPC_TESTS" = "true" ]; then test/functional/test_runner.py -extended --coverage; fi
 after_script:
     - echo $TRAVIS_COMMIT_RANGE
     - echo $TRAVIS_COMMIT_LOG

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,12 +44,12 @@ install:
     - if [ -n "$PACKAGES" ]; then travis_retry sudo apt-get update; fi
     - if [ -n "$PACKAGES" ]; then travis_retry sudo apt-get install --no-install-recommends --no-upgrade -qq $PACKAGES; fi
     - if [ "$CHECK_DOC" = 1 ]; then travis_retry git fetch https://github.com/bitcoin/secp256k1.git; fi
-    - if [ "$CHECK_DOC" = 1 ]; then travis_retry git fetch -unshallow https://github.com/bitcoin/leveldb.git; fi
+    - if [ "$CHECK_DOC" = 1 ]; then travis_retry git fetch --unshallow https://github.com/bitcoin/leveldb.git; fi
     - if [ "$CHECK_DOC" = 1 ]; then travis_retry git fetch https://github.com/bitcoin/univalue.git; fi
     - if [ "$CHECK_DOC" = 1 ]; then travis_retry git fetch https://github.com/bitcoin-core/ctaes.git; fi
-#    - if [ "$RUN_ALL_RPC_TESTS" = "true" ]; then mkdir -p bin && cd bin; fi
-#    - if [ "$RUN_ALL_RPC_TESTS" = "true" ]; then travis_retry wget -N https://bitcoin.org/bin/bitcoin-core-0.12.1/bitcoin-0.12.1-linux64.tar.gz; fi
-#    - if [ "$RUN_ALL_RPC_TESTS" = "true" ]; then cd .. && echo "54aca14b7512801ab78cc93f8576e1b66364a890e8017e8a187e4bf0209fd28c  bin/bitcoin-0.12.1-linux64.tar.gz" | sha256sum --check && tar -xzvf bin/bitcoin-0.12.1-linux64.tar.gz; fi
+    - if [ "$RUN_ALL_RPC_TESTS" = "true" ]; then mkdir -p bin && cd bin; fi
+    - if [ "$RUN_ALL_RPC_TESTS" = "true" ]; then travis_retry wget -N https://bitcoin.org/bin/bitcoin-core-0.12.1/bitcoin-0.12.1-linux64.tar.gz; fi
+    - if [ "$RUN_ALL_RPC_TESTS" = "true" ]; then cd .. && echo "54aca14b7512801ab78cc93f8576e1b66364a890e8017e8a187e4bf0209fd28c  bin/bitcoin-0.12.1-linux64.tar.gz" | sha256sum --check && tar -xzvf bin/bitcoin-0.12.1-linux64.tar.gz; fi
 before_script:
     - unset CC; unset CXX
     - if [ "$CHECK_DOC" = 1 ]; then contrib/devtools/check-doc.py; fi
@@ -83,7 +83,7 @@ script:
     - if [ "$RUN_TESTS" = "true" ]; then make $MAKEJOBS check VERBOSE=1; fi
     - if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then extended="--extended --exclude pruning"; fi
     - if [ "$RUN_TESTS" = "true" ]; then test/functional/test_runner.py --coverage ${extended}; fi
-#    - if [ "$RUN_ALL_RPC_TESTS" = "true" ]; then test/functional/test_runner.py p2p-segwit --oldbinary=../bitcoin-0.12.1/bin/bitcoind; fi
+    - if [ "$RUN_ALL_RPC_TESTS" = "true" ]; then test/functional/test_runner.py p2p-segwit --oldbinary=../bitcoin-0.12.1/bin/bitcoind; fi
     - if [ "$RUN_ALL_RPC_TESTS" = "true" ]; then test/functional/test_runner.py -extended --coverage; fi
 after_script:
     - echo $TRAVIS_COMMIT_RANGE

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,11 +28,11 @@ env:
 # Win32
     - HOST=i686-w64-mingw32 DPKG_ADD_ARCH="i386" DEP_OPTS="NO_QT=1" PACKAGES="python3 nsis g++-mingw-w64-i686 wine1.6 bc" RUN_TESTS=true GOAL="install" BITCOIN_CONFIG="--enable-reduce-exports"
 # 32-bit + dash
-    - HOST=i686-pc-linux-gnu PACKAGES="g++-multilib bc python3-zmq" DEP_OPTS="NO_QT=1" RUN_ALL_RPC_TESTS=true DISABLE_MAKE=false GOAL="install" BITCOIN_CONFIG="--enable-werror --enable-zmq --enable-glibc-back-compat --enable-reduce-exports LDFLAGS=-static-libstdc++ CPPFLAGS=-DDEBUG_LOCKORDER" USE_SHELL="/bin/dash"
+    - HOST=i686-pc-linux-gnu PACKAGES="g++-multilib bc python3-zmq" DEP_OPTS="NO_QT=1" RUN_TESTS=true GOAL="install" BITCOIN_CONFIG="--enable-zmq --enable-glibc-back-compat --enable-reduce-exports LDFLAGS=-static-libstdc++" USE_SHELL="/bin/dash"
 # Win64
     - HOST=x86_64-w64-mingw32 DPKG_ADD_ARCH="i386" DEP_OPTS="NO_QT=1" PACKAGES="python3 nsis g++-mingw-w64-x86-64 wine1.6 bc" RUN_TESTS=true GOAL="install" BITCOIN_CONFIG="--enable-reduce-exports"
 # bitcoind
-    - HOST=x86_64-unknown-linux-gnu PACKAGES="bc python3-zmq" DEP_OPTS="NO_QT=1 NO_UPNP=1 DEBUG=1" RUN_TESTS=true GOAL="install" BITCOIN_CONFIG="--enable-zmq --enable-glibc-back-compat --enable-reduce-exports CPPFLAGS=-DDEBUG_LOCKORDER"
+    - HOST=x86_64-unknown-linux-gnu PACKAGES="valgrind libc6-dbg bc python3-zmq" DEP_OPTS="NO_QT=1 NO_UPNP=1 DEBUG=1" RUN_ALL_RPC_TESTS=true DISABLE_MAKE=false GOAL="install" BITCOIN_CONFIG="--enable-werror --enable-zmq --enable-glibc-back-compat --enable-reduce-exports CPPFLAGS=-DDEBUG_LOCKORDER"
 # No wallet
     - HOST=x86_64-unknown-linux-gnu PACKAGES="python3 xvfb" DEP_OPTS="NO_WALLET=1" RUN_TESTS=true GOAL="install" BITCOIN_CONFIG="--enable-glibc-back-compat --enable-reduce-exports"
 # Cross-Mac
@@ -46,10 +46,11 @@ install:
     - if [ -n "$PACKAGES" ]; then travis_retry sudo apt-get update; fi
     - if [ -n "$PACKAGES" ]; then travis_retry sudo apt-get install --no-install-recommends --no-upgrade -qq $PACKAGES; fi
     - if [ "$CHECK_DOC" = 1 ]; then travis_retry git fetch https://github.com/bitcoin/secp256k1.git; fi
-    - if [ "$CHECK_DOC" = 1 ]; then travis_retry git fetch --unshallow https://github.com/bitcoin/leveldb.git; fi
+    - if [ "$CHECK_DOC" = 1 ]; then travis_retry git fetch https://github.com/bitcoin/leveldb.git leveldb19; fi
     - if [ "$CHECK_DOC" = 1 ]; then travis_retry git fetch https://github.com/bitcoin/univalue.git; fi
     - if [ "$CHECK_DOC" = 1 ]; then travis_retry git fetch https://github.com/bitcoin-core/ctaes.git; fi
     - if [ "$RUN_ALL_RPC_TESTS" = "true" ]; then mkdir -p bin && cd bin; fi
+    - if [ "$RUN_ALL_RPC_TESTS" = "true" ]; then export BIN_OLD=`pwd`; fi
     - if [ "$RUN_ALL_RPC_TESTS" = "true" ]; then travis_retry wget -N https://bitcoin.org/bin/bitcoin-core-0.12.1/bitcoin-0.12.1-linux64.tar.gz; fi
     - if [ "$RUN_ALL_RPC_TESTS" = "true" ]; then cd .. && echo "54aca14b7512801ab78cc93f8576e1b66364a890e8017e8a187e4bf0209fd28c  bin/bitcoin-0.12.1-linux64.tar.gz" | sha256sum --check && tar -xzvf bin/bitcoin-0.12.1-linux64.tar.gz; fi
 before_script:
@@ -86,7 +87,8 @@ script:
     - if [ "$RUN_TESTS" = "true" ]; then make $MAKEJOBS check VERBOSE=1; fi
     - if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then extended="--extended --exclude pruning"; fi
     - if [ "$RUN_TESTS" = "true" ]; then test/functional/test_runner.py --coverage ${extended}; fi
-    - if [ "$RUN_ALL_RPC_TESTS" = "true" ]; then test/functional/test_runner.py compatibility --oldbinary=../bitcoin-0.12.1/bin/bitcoind; fi
+    - if [ "$RUN_ALL_RPC_TESTS" = "true" ]; then travis_wait 30 valgrind src/test/test_bitcoin -p; fi
+    - if [ "$RUN_ALL_RPC_TESTS" = "true" ]; then test/functional/test_runner.py compatibility --oldbinary=${BIN_OLD}/../bitcoin-0.12.1/bin/bitcoind; fi
     - if [ "$RUN_ALL_RPC_TESTS" = "true" ]; then test/functional/test_runner.py --extended -x pruning,rpcbind_test --coverage; fi
 after_script:
     - echo $TRAVIS_COMMIT_RANGE

--- a/.travis.yml
+++ b/.travis.yml
@@ -87,7 +87,7 @@ script:
     - if [ "$RUN_TESTS" = "true" ]; then make $MAKEJOBS check VERBOSE=1; fi
     - if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then extended="--extended --exclude pruning"; fi
     - if [ "$RUN_TESTS" = "true" ]; then test/functional/test_runner.py --coverage ${extended}; fi
-    - if [ "$RUN_ALL_RPC_TESTS" = "true" ]; then travis_wait 30 valgrind src/test/test_bitcoin -p; fi
+    - if [ "$RUN_ALL_RPC_TESTS" = "true" ]; then travis_wait 30 valgrind src/test/test_bitcoin -p -t wallet_tests; fi
     - if [ "$RUN_ALL_RPC_TESTS" = "true" ]; then test/functional/test_runner.py compatibility --oldbinary=${BIN_OLD}/../bitcoin-0.12.1/bin/bitcoind; fi
     - if [ "$RUN_ALL_RPC_TESTS" = "true" ]; then test/functional/test_runner.py --extended -x pruning,rpcbind_test --coverage; fi
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,8 +51,8 @@ install:
     - if [ "$CHECK_DOC" = 1 ]; then travis_retry git fetch https://github.com/bitcoin-core/ctaes.git; fi
     - if [ "$RUN_ALL_RPC_TESTS" = "true" ]; then mkdir -p bin && cd bin; fi
     - if [ "$RUN_ALL_RPC_TESTS" = "true" ]; then export BIN_OLD=`pwd`; fi
-    - if [ "$RUN_ALL_RPC_TESTS" = "true" ]; then travis_retry wget -N https://bitcoin.org/bin/bitcoin-core-0.12.1/bitcoin-0.12.1-linux64.tar.gz; fi
-    - if [ "$RUN_ALL_RPC_TESTS" = "true" ]; then cd .. && echo "54aca14b7512801ab78cc93f8576e1b66364a890e8017e8a187e4bf0209fd28c  bin/bitcoin-0.12.1-linux64.tar.gz" | sha256sum --check && tar -xzvf bin/bitcoin-0.12.1-linux64.tar.gz; fi
+    - if [ "$RUN_ALL_RPC_TESTS" = "true" ]; then travis_retry wget -N https://bitcoin.org/bin/bitcoin-core-0.14.0/bitcoin-0.14.0-x86_64-linux-gnu.tar.gz; fi
+    - if [ "$RUN_ALL_RPC_TESTS" = "true" ]; then cd .. && echo "06e6ceeb687e784e9aaad45e9407c7eed5f7e9c9bbe44083179287f54f0f9f2b bin/bitcoin-0.14.0-x86_64-linux-gnu.tar.gz" | sha256sum --check && tar -xzvf bin/bitcoin-0.14.0-x86_64-linux-gnu.tar.gz; fi
 before_script:
     - unset CC; unset CXX
     - if [ "$CHECK_DOC" = 1 ]; then contrib/devtools/check-doc.py; fi
@@ -88,7 +88,7 @@ script:
     - if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then extended="--extended --exclude pruning"; fi
     - if [ "$RUN_TESTS" = "true" ]; then test/functional/test_runner.py --coverage ${extended}; fi
     - if [ "$RUN_ALL_RPC_TESTS" = "true" ]; then travis_wait 30 valgrind src/test/test_bitcoin -p -t wallet_tests; fi
-    - if [ "$RUN_ALL_RPC_TESTS" = "true" ]; then test/functional/test_runner.py compatibility --oldbinary=${BIN_OLD}/../bitcoin-0.12.1/bin/bitcoind; fi
+    - if [ "$RUN_ALL_RPC_TESTS" = "true" ]; then test/functional/test_runner.py compatibility --oldbinary=${BIN_OLD}/../bitcoin-0.14.0/bin/bitcoind; fi
     - if [ "$RUN_ALL_RPC_TESTS" = "true" ]; then test/functional/test_runner.py --extended -x pruning,rpcbind_test --coverage; fi
 after_script:
     - echo $TRAVIS_COMMIT_RANGE

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ env:
     - BASE_OUTDIR=$TRAVIS_BUILD_DIR/out
     - SDK_URL=https://bitcoincore.org/depends-sources/sdks
     - PYTHON_DEBUG=1
+    - DISABLE_MAKE=true
+    - RUN_ALL_RPC_TESTS=false
     - WINEDEBUG=fixme-all
   matrix:
 # ARM
@@ -26,7 +28,7 @@ env:
 # Win32
     - HOST=i686-w64-mingw32 DPKG_ADD_ARCH="i386" DEP_OPTS="NO_QT=1" PACKAGES="python3 nsis g++-mingw-w64-i686 wine1.6 bc" RUN_TESTS=true GOAL="install" BITCOIN_CONFIG="--enable-reduce-exports"
 # 32-bit + dash
-    - HOST=i686-pc-linux-gnu PACKAGES="g++-multilib bc python3-zmq" DEP_OPTS="NO_QT=1" RUN_TESTS=true GOAL="install" BITCOIN_CONFIG="--enable-zmq --enable-glibc-back-compat --enable-reduce-exports LDFLAGS=-static-libstdc++" USE_SHELL="/bin/dash"
+    - HOST=i686-pc-linux-gnu PACKAGES="g++-multilib bc python3-zmq" DEP_OPTS="NO_QT=1" RUN_ALL_RPC_TESTS=true DISABLE_MAKE=false GOAL="install" BITCOIN_CONFIG="--enable-zmq --enable-glibc-back-compat --enable-reduce-exports LDFLAGS=-static-libstdc++ CPPFLAGS=-DDEBUG_LOCKORDER" USE_SHELL="/bin/dash"
 # Win64
     - HOST=x86_64-w64-mingw32 DPKG_ADD_ARCH="i386" DEP_OPTS="NO_QT=1" PACKAGES="python3 nsis g++-mingw-w64-x86-64 wine1.6 bc" RUN_TESTS=true GOAL="install" BITCOIN_CONFIG="--enable-reduce-exports"
 # bitcoind
@@ -72,6 +74,7 @@ script:
     - OUTDIR=$BASE_OUTDIR/$TRAVIS_PULL_REQUEST/$TRAVIS_JOB_NUMBER-$HOST
     - BITCOIN_CONFIG_ALL="--disable-dependency-tracking --prefix=$TRAVIS_BUILD_DIR/depends/$HOST --bindir=$OUTDIR/bin --libdir=$OUTDIR/lib"
     - depends/$HOST/native/bin/ccache --max-size=$CCACHE_SIZE
+    - if [ "$DISABLE_MAKE" = "true" ]; then exit; fi
     - test -n "$USE_SHELL" && eval '"$USE_SHELL" -c "./autogen.sh"' || ./autogen.sh
     - mkdir build && cd build
     - ../configure --cache-file=config.cache $BITCOIN_CONFIG_ALL $BITCOIN_CONFIG || ( cat config.log && false)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -454,7 +454,7 @@ bool CWallet::Verify()
         // Recover readable keypairs:
         CWallet dummyWallet;
         if (!CWalletDB::Recover(walletFile, (void *)&dummyWallet, CWalletDB::RecoverKeysOnlyFilter))
-            return false;
+            std::cerr << "Recover supposedly failed. Trying to continue." << std::endl;
     }
 
     std::string strWarning;

--- a/test/functional/compatibility.py
+++ b/test/functional/compatibility.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+# Copyright (c) 2016 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    start_nodes,
+    stop_nodes,
+    connect_nodes_bi,
+    mine_large_block,
+    sync_chain,
+    sync_mempools,
+    assert_equal,
+)
+
+'''
+Script to check if our datadir can be read by older versions and vice versa
+'''
+
+class CompatibilityTest(BitcoinTestFramework):
+
+    def __init__(self):
+        super().__init__()
+        self.setup_clean_chain = True
+        self.num_nodes = 2
+        self.extra_args = [['-usehd=0']] * self.num_nodes
+
+    def add_options(self, parser):
+        parser.add_option("--oldbinary", dest="oldbinary",
+                          default=None,
+                          help="old bitcoind binary for compatibility testing")
+
+    def setup_network(self):
+        assert(self.options.oldbinary is not None)
+        self.binary = [None, self.options.oldbinary]
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, self.extra_args, binary=self.binary)
+        connect_nodes_bi(self.nodes, 0, 1)
+
+    def send(self, seed):
+        sender = seed % 2
+        self.nodes[sender].sendtoaddress(self.nodes[not sender].getnewaddress(), 0.125)
+
+    def run_test(self):
+        # Create some blocks and transactions:
+        self.nodes[1].generate(14 * 3)
+        sync_chain(self.nodes)
+        self.nodes[0].generate(14 * 3)
+        self.nodes[0].generate(100)
+        [mine_large_block(self.nodes[0]) for _ in range(3)]
+        sync_chain(self.nodes)
+        [mine_large_block(self.nodes[1]) for _ in range(3)]
+        sync_chain(self.nodes)
+
+        [self.send(seed) for seed in range(10)]
+        self.nodes[0].generate(1)
+        sync_chain(self.nodes)
+        self.nodes[1].generate(1)
+        sync_chain(self.nodes)
+        #assert_equal([0, 0], [n.getmempoolinfo()["size"] for n in self.nodes])
+
+        INFO_CALLS = [
+            "getblockchaininfo",
+            "gettxoutsetinfo",
+            "getmininginfo",
+            "getwalletinfo",
+            "getinfo",
+        ]
+        info_dict = {}
+        for info in INFO_CALLS:
+            info_dict[info] = [getattr(n, info)() for n in self.nodes]
+
+        # Swap binaries
+        stop_nodes(self.nodes)
+        self.binary.reverse()
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, self.extra_args, binary=self.binary)
+        connect_nodes_bi(self.nodes, 0, 1)
+        for info in INFO_CALLS:
+            print("Check {}".format(info))
+            # old info should match new info, even though the binary changed
+            assert_equal_ignore_some(info_dict[info][0], getattr(self.nodes[0], info)())
+            assert_equal_ignore_some(info_dict[info][1], getattr(self.nodes[1], info)())
+
+
+def assert_equal_ignore_some(dict1, dict2):
+    # ignore entries which are unstable across restarts or
+    # not supported by both versions
+    IGNORE = [
+        'currentblockweight',
+        'currentblocksize',
+        'currentblocktx',
+        'bip9_softforks', # Older nodes may not be aware of all softforks
+        'softforks',
+        'hash_serialized', # This may have changed due to 7848?
+        'keypoolsize', # ?
+        'errors', # releases don't display the pre-release-warning
+        #'warnings',
+        'genproclimit', # Removed in 7507
+        'generate',
+        'testnet', # Removed in 8921
+        'subversion',
+        'version',
+        'protocolversion',
+    ]
+    for d in [dict1, dict2]:
+        for ig in IGNORE:
+            d.pop(ig) if ig in d else None
+    assert_equal(dict1, dict2)
+
+if __name__ == '__main__':
+    CompatibilityTest().main()

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -38,6 +38,7 @@ class BitcoinTestFramework(object):
         self.num_nodes = 4
         self.setup_clean_chain = False
         self.nodes = None
+        self.binary = None
 
     def run_test(self):
         raise NotImplementedError

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -355,12 +355,12 @@ def start_nodes(num_nodes, dirname, extra_args=None, rpchost=None, timewait=None
     if extra_args is None: extra_args = [ None for _ in range(num_nodes) ]
     if binary is None: binary = [ None for _ in range(num_nodes) ]
     rpcs = []
-    try:
-        for i in range(num_nodes):
+    for i in range(num_nodes):
+        try:
             rpcs.append(start_node(i, dirname, extra_args[i], rpchost, timewait=timewait, binary=binary[i]))
-    except: # If one node failed to start, stop the others
-        stop_nodes(rpcs)
-        raise
+        except: # If one node failed to start, stop the others
+            [stop_node(rpcs[j], j) for j in range(i)]
+            raise
     return rpcs
 
 def log_filename(dirname, n_node, logname):

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -126,7 +126,11 @@ EXTENDED_SCRIPTS = [
     'replace-by-fee.py',
 ]
 
-ALL_SCRIPTS = BASE_SCRIPTS + ZMQ_SCRIPTS + EXTENDED_SCRIPTS
+MANUAL_SCRIPTS = [
+    'compatibility.py',
+]
+
+ALL_SCRIPTS = BASE_SCRIPTS + ZMQ_SCRIPTS + EXTENDED_SCRIPTS + MANUAL_SCRIPTS 
 
 NON_SCRIPTS = [
     # These are python files that live in the functional tests directory, but are not test scripts.

--- a/test/functional/wallet.py
+++ b/test/functional/wallet.py
@@ -319,8 +319,7 @@ class WalletTest (BitcoinTestFramework):
             '-reindex',
             '-zapwallettxes=1',
             '-zapwallettxes=2',
-            # disabled until issue is fixed: https://github.com/bitcoin/bitcoin/issues/7463
-            # '-salvagewallet',
+            '-salvagewallet',
         ]
         chainlimit = 6
         for m in maintenance:


### PR DESCRIPTION
Ideally we want to detect fails in the extended suite early (i.e. in the PR which caused the fail). Though, this would double the runtime of the rpc tests in every PR from 5 to 10 minutes (with `pruning.py` disabled).

Also, we'd want to collect `--coverage` data until all rpcs are covered and then fail on uncovered (new) rpcs.

For now, every 24 hours a fresh nightly build is triggered _within this PR_.

**Current status:**
- Disable usual rpc tests and `make check`, otherwise travis will block the build exceeding the 2 hour max CPU time.
- Disable `pruning.py`
- Run extended coverage rpc tests once with `CPPFLAGS=-DDEBUG_LOCKORDER`
- Verify subtrees
- ~~Enable qt4 build~~
