### PR TITLE
Bugfix: Correctly calculate priority when inputs are mined after dependent transactions enter the memory pool

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -115,6 +115,7 @@ testScripts = [
     'segwit.py',
     'txn_clone.py',
     'txn_priority.py',
+    'txn_priority.py --gbt',
     'getchaintips.py',
     'rawtransactions.py',
     'rest.py',

--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -114,6 +114,7 @@ testScripts = [
     'p2p-segwit.py',
     'segwit.py',
     'txn_clone.py',
+    'txn_priority.py',
     'getchaintips.py',
     'rawtransactions.py',
     'rest.py',

--- a/qa/rpc-tests/txn_priority.py
+++ b/qa/rpc-tests/txn_priority.py
@@ -41,10 +41,18 @@ class PriorityTest(BitcoinTestFramework):
         super().__init__()
         self.num_nodes = 2
 
+    def add_options(self, parser):
+        parser.add_option("--gbt", dest="test_gbt", default=False, action="store_true",
+                          help="Test priorities used by GBT")
+
     def setup_nodes(self):
+        ppopt = []
+        if self.options.test_gbt:
+            ppopt.append('-printpriority')
+
         nodes = []
         nodes.append(start_node(0, self.options.tmpdir, ['-blockmaxsize=0']))
-        nodes.append(start_node(1, self.options.tmpdir, ['-blockprioritysize=1000000', '-blockmaxsize=1000000']))
+        nodes.append(start_node(1, self.options.tmpdir, ['-blockprioritysize=1000000', '-blockmaxsize=1000000'] + ppopt))
         return nodes
 
     def setup_network(self, split=False):
@@ -53,10 +61,28 @@ class PriorityTest(BitcoinTestFramework):
         self.is_network_split = False
         self.sync_all()
 
+    def assert_prio(self, txid, starting, current):
+        node = self.nodes[1]
+
+        if self.options.test_gbt:
+            tmpl = node.getblocktemplate({})
+            tmplentry = None
+            for tx in tmpl['transactions']:
+                if tx['hash'] == txid:
+                    tmplentry = tx
+                    break
+            # GBT does not expose starting priority, so we don't check that
+            assert_approximate(tmplentry['priority'], current)
+        else:
+            mempoolentry = node.getrawmempool(True)[txid]
+            assert_approximate(mempoolentry['startingpriority'], starting)
+            assert_approximate(mempoolentry['currentpriority'], current)
+
     def run_test(self):
         node = self.nodes[0]
         miner = self.nodes[1]
         node.generate(50)
+        self.sync_all()
         miner.generate(101)
         self.sync_all()
 
@@ -68,27 +94,23 @@ class PriorityTest(BitcoinTestFramework):
         txdata_b = node.signrawtransaction(txdata_b)['hex']
         txmodsize_b = get_modified_size(node, txdata_b)
         txid_b = node.sendrawtransaction(txdata_b)
+        self.sync_all()
 
-        txid_b_mempoolentry = node.getrawmempool(True)[txid_b]
-        assert_approximate(txid_b_mempoolentry['startingpriority'], txid_b_mempoolentry['currentpriority'])
-        assert_approximate(txid_b_mempoolentry['currentpriority'], 0)
+        self.assert_prio(txid_b, 0, 0)
 
         # Mine only the sendtoaddress transaction
         tmpl = node.getblocktemplate()
         rawblock = solve_template_hex(tmpl, [create_coinbase(tmpl['height']), a2b_hex(node.getrawtransaction(txid_a))])
         assert_equal(node.submitblock(rawblock), None)
+        self.sync_all()
 
-        txid_b_mempoolentry = node.getrawmempool(True)[txid_b]
-        assert_approximate(txid_b_mempoolentry['startingpriority'], 0)
-        assert_approximate(txid_b_mempoolentry['currentpriority'], amt * 1e8 / txmodsize_b)
+        self.assert_prio(txid_b, 0, amt * 1e8 / txmodsize_b)
 
         node.generate(2)
-
-        txid_b_mempoolentry = node.getrawmempool(True)[txid_b]
-        assert_approximate(txid_b_mempoolentry['startingpriority'], 0)
-        assert_approximate(txid_b_mempoolentry['currentpriority'], amt * 1e8 * 3 / txmodsize_b)
-
         self.sync_all()
+
+        self.assert_prio(txid_b, 0, amt * 1e8 * 3 / txmodsize_b)
+
         miner.generate(4)
         self.sync_all()
 
@@ -96,21 +118,20 @@ class PriorityTest(BitcoinTestFramework):
         txdata_c = node.signrawtransaction(txdata_c)['hex']
         txmodsize_c = get_modified_size(node, txdata_c)
         txid_c = node.sendrawtransaction(txdata_c)
-        txid_c_mempoolentry = node.getrawmempool(True)[txid_c]
-        assert_approximate(txid_c_mempoolentry['startingpriority'], txid_c_mempoolentry['currentpriority'])
-        assert_approximate(txid_c_mempoolentry['currentpriority'], (amt - fee) * 1e8 * 4 / txmodsize_c)
+        self.sync_all()
+
+        txid_c_starting_prio = (amt - fee) * 1e8 * 4 / txmodsize_c
+        self.assert_prio(txid_c, txid_c_starting_prio, txid_c_starting_prio)
 
         node.generate(1)
+        self.sync_all()
 
-        txid_c_mempoolentry = node.getrawmempool(True)[txid_c]
-        assert_approximate(txid_c_mempoolentry['startingpriority'], (amt - fee) * 1e8 * 4 / txmodsize_c)
-        assert_approximate(txid_c_mempoolentry['currentpriority'], (amt - fee) * 1e8 * 5 / txmodsize_c)
+        self.assert_prio(txid_c, txid_c_starting_prio, (amt - fee) * 1e8 * 5 / txmodsize_c)
 
         node.generate(2)
+        self.sync_all()
 
-        txid_c_mempoolentry = node.getrawmempool(True)[txid_c]
-        assert_approximate(txid_c_mempoolentry['startingpriority'], (amt - fee) * 1e8 * 4 / txmodsize_c)
-        assert_approximate(txid_c_mempoolentry['currentpriority'], (amt - fee) * 1e8 * 7 / txmodsize_c)
+        self.assert_prio(txid_c, txid_c_starting_prio, (amt - fee) * 1e8 * 7 / txmodsize_c)
 
 if __name__ == '__main__':
     PriorityTest().main()

--- a/qa/rpc-tests/txn_priority.py
+++ b/qa/rpc-tests/txn_priority.py
@@ -186,8 +186,10 @@ class PriorityTest(BitcoinTestFramework):
 
         self.testmsg('priority is updated correctly when input-confirming block is reorganised out')
 
+        # NOTE: We cannot use join_network because it restarts the nodes (thus losing the mempool)
         connect_nodes_bi(self.nodes, 1, 2)
-        self.sync_all()
+        self.is_network_split = False
+        sync_blocks(self.nodes)
 
         txid_e_reorg_prio = (amt_c2 * BTC * 6) / txmodsize_e
         self.assert_prio(txid_e, txid_e_starting_prio, txid_e_reorg_prio)

--- a/qa/rpc-tests/txn_priority.py
+++ b/qa/rpc-tests/txn_priority.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+# Copyright (c) 2016 The Bitcoin Core developers
+# Distributed under the MIT/X11 software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#
+
+from test_framework.blocktools import create_block, create_coinbase
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+
+from binascii import a2b_hex, b2a_hex
+
+def find_unspent(node, txid, amount):
+    for utxo in node.listunspent(0):
+        if utxo['txid'] != txid: continue
+        if float(utxo['amount']) != amount: continue
+        return {'txid': utxo['txid'], 'vout': utxo['vout']}
+
+def solve_template_hex(tmpl, txlist):
+    block = create_block(tmpl=tmpl, txlist=txlist)
+    block.solve()
+    b = block.serialize()
+    x = b2a_hex(b).decode('ascii')
+    return x
+
+def get_modified_size(node, txdata):
+    decoded = node.decoderawtransaction(txdata)
+    size = len(txdata) // 2
+    for inp in decoded['vin']:
+        offset = 41 + min(len(inp['scriptSig']['hex']) // 2, 110)
+        if offset <= size:
+            size -= offset
+    return size
+
+def assert_approximate(a, b):
+    assert_equal(int(a), int(b))
+
+class PriorityTest(BitcoinTestFramework):
+
+    def __init__(self):
+        super().__init__()
+        self.num_nodes = 2
+
+    def setup_nodes(self):
+        nodes = []
+        nodes.append(start_node(0, self.options.tmpdir, ['-blockmaxsize=0']))
+        nodes.append(start_node(1, self.options.tmpdir, ['-blockprioritysize=1000000', '-blockmaxsize=1000000']))
+        return nodes
+
+    def setup_network(self, split=False):
+        self.nodes = self.setup_nodes()
+        connect_nodes_bi(self.nodes,0,1)
+        self.is_network_split = False
+        self.sync_all()
+
+    def run_test(self):
+        node = self.nodes[0]
+        miner = self.nodes[1]
+        node.generate(50)
+        miner.generate(101)
+        self.sync_all()
+
+        fee = 0.01
+        amt = 11
+
+        txid_a = node.sendtoaddress(node.getnewaddress(), amt)
+        txdata_b = node.createrawtransaction([find_unspent(node, txid_a, amt)], {node.getnewaddress(): amt - fee})
+        txdata_b = node.signrawtransaction(txdata_b)['hex']
+        txmodsize_b = get_modified_size(node, txdata_b)
+        txid_b = node.sendrawtransaction(txdata_b)
+
+        txid_b_mempoolentry = node.getrawmempool(True)[txid_b]
+        assert_approximate(txid_b_mempoolentry['startingpriority'], txid_b_mempoolentry['currentpriority'])
+        assert_approximate(txid_b_mempoolentry['currentpriority'], 0)
+
+        # Mine only the sendtoaddress transaction
+        tmpl = node.getblocktemplate()
+        rawblock = solve_template_hex(tmpl, [create_coinbase(tmpl['height']), a2b_hex(node.getrawtransaction(txid_a))])
+        assert_equal(node.submitblock(rawblock), None)
+
+        txid_b_mempoolentry = node.getrawmempool(True)[txid_b]
+        assert_approximate(txid_b_mempoolentry['startingpriority'], 0)
+        assert_approximate(txid_b_mempoolentry['currentpriority'], amt * 1e8 / txmodsize_b)
+
+        node.generate(2)
+
+        txid_b_mempoolentry = node.getrawmempool(True)[txid_b]
+        assert_approximate(txid_b_mempoolentry['startingpriority'], 0)
+        assert_approximate(txid_b_mempoolentry['currentpriority'], amt * 1e8 * 3 / txmodsize_b)
+
+        self.sync_all()
+        miner.generate(4)
+        self.sync_all()
+
+        txdata_c = node.createrawtransaction([find_unspent(node, txid_b, amt - fee)], {node.getnewaddress(): amt - (fee * 2)})
+        txdata_c = node.signrawtransaction(txdata_c)['hex']
+        txmodsize_c = get_modified_size(node, txdata_c)
+        txid_c = node.sendrawtransaction(txdata_c)
+        txid_c_mempoolentry = node.getrawmempool(True)[txid_c]
+        assert_approximate(txid_c_mempoolentry['startingpriority'], txid_c_mempoolentry['currentpriority'])
+        assert_approximate(txid_c_mempoolentry['currentpriority'], (amt - fee) * 1e8 * 4 / txmodsize_c)
+
+        node.generate(1)
+
+        txid_c_mempoolentry = node.getrawmempool(True)[txid_c]
+        assert_approximate(txid_c_mempoolentry['startingpriority'], (amt - fee) * 1e8 * 4 / txmodsize_c)
+        assert_approximate(txid_c_mempoolentry['currentpriority'], (amt - fee) * 1e8 * 5 / txmodsize_c)
+
+        node.generate(2)
+
+        txid_c_mempoolentry = node.getrawmempool(True)[txid_c]
+        assert_approximate(txid_c_mempoolentry['startingpriority'], (amt - fee) * 1e8 * 4 / txmodsize_c)
+        assert_approximate(txid_c_mempoolentry['currentpriority'], (amt - fee) * 1e8 * 7 / txmodsize_c)
+
+if __name__ == '__main__':
+    PriorityTest().main()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1334,7 +1334,8 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState& state, const C
         pool.ApplyDeltas(hash, nPriorityDummy, nModifiedFees);
 
         CAmount inChainInputValue;
-        double dPriority = view.GetPriority(tx, chainActive.Height(), inChainInputValue);
+        // Since entries arrive *after* the tip's height, their priority is for the height+1
+        double dPriority = view.GetPriority(tx, chainActive.Height() + 1, inChainInputValue);
 
         // Keep track of transactions that spend a coinbase, which we re-scan
         // during reorgs to ensure COINBASE_MATURITY is still met.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2808,6 +2808,7 @@ bool static DisconnectTip(CValidationState& state, const CChainParams& chainpara
         // Resurrect mempool transactions from the disconnected block.
         std::vector<uint256> vHashUpdate;
         BOOST_FOREACH(const CTransaction &tx, block.vtx) {
+            mempool.UpdateDependentPriorities(tx, pindexDelete->nHeight, false);
             // ignore validation errors in resurrected transactions
             CValidationState stateDummy;
             if (tx.IsCoinBase() || !AcceptToMemoryPool(mempool, stateDummy, tx, false, NULL, true)) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3029,7 +3029,7 @@ static bool ActivateBestChainStep(CValidationState& state, const CChainParams& c
         mempool.removeForReorg(pcoinsTip, chainActive.Tip()->nHeight + 1, STANDARD_LOCKTIME_VERIFY_FLAGS);
         LimitMempoolSize(mempool, GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000, GetArg("-mempoolexpiry", DEFAULT_MEMPOOL_EXPIRY) * 60 * 60);
     }
-    mempool.check(pcoinsTip);
+    mempool.check(pcoinsTip, chainActive.Height());
 
     // Callbacks/notifications for a new best chain.
     if (fInvalidFound)
@@ -5604,7 +5604,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         mapAlreadyAskedFor.erase(inv.hash);
 
         if (!AlreadyHave(inv) && AcceptToMemoryPool(mempool, state, tx, true, &fMissingInputs)) {
-            mempool.check(pcoinsTip);
+            mempool.check(pcoinsTip, chainActive.Height());
             RelayTransaction(tx, connman);
             for (unsigned int i = 0; i < tx.vout.size(); i++) {
                 vWorkQueue.emplace_back(inv.hash, i);
@@ -5670,7 +5670,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                             recentRejects->insert(orphanHash);
                         }
                     }
-                    mempool.check(pcoinsTip);
+                    mempool.check(pcoinsTip, chainActive.Height());
                 }
             }
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -137,6 +137,10 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
     pblock->vtx.push_back(CTransaction());
     pblocktemplate->vTxFees.push_back(-1); // updated at end
     pblocktemplate->vTxSigOpsCost.push_back(-1); // updated at end
+    bool fPrintPriority = GetBoolArg("-printpriority", DEFAULT_PRINTPRIORITY);
+    if (fPrintPriority) {
+        pblocktemplate->vTxPriorities.push_back(-1);  // n/a
+    }
 
     LOCK2(cs_main, mempool.cs);
     CBlockIndex* pindexPrev = chainActive.Tip();
@@ -331,6 +335,7 @@ void BlockAssembler::AddToBlock(CTxMemPool::txiter iter)
                   dPriority,
                   CFeeRate(iter->GetModifiedFee(), iter->GetTxSize()).ToString(),
                   iter->GetTx().GetHash().ToString());
+        pblocktemplate->vTxPriorities.push_back(dPriority);
     }
 }
 

--- a/src/miner.h
+++ b/src/miner.h
@@ -29,6 +29,7 @@ struct CBlockTemplate
     CBlock block;
     std::vector<CAmount> vTxFees;
     std::vector<int64_t> vTxSigOpsCost;
+    std::vector<double> vTxPriorities;
     std::vector<unsigned char> vchCoinbaseCommitment;
 };
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -358,7 +358,7 @@ void entryToJSON(UniValue &info, const CTxMemPoolEntry &e)
     info.push_back(Pair("modifiedfee", ValueFromAmount(e.GetModifiedFee())));
     info.push_back(Pair("time", e.GetTime()));
     info.push_back(Pair("height", (int)e.GetHeight()));
-    info.push_back(Pair("startingpriority", e.GetPriority(e.GetHeight())));
+    info.push_back(Pair("startingpriority", e.GetStartingPriority()));
     info.push_back(Pair("currentpriority", e.GetPriority(chainActive.Height())));
     info.push_back(Pair("descendantcount", e.GetCountWithDescendants()));
     info.push_back(Pair("descendantsize", e.GetSizeWithDescendants()));

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -359,7 +359,7 @@ void entryToJSON(UniValue &info, const CTxMemPoolEntry &e)
     info.push_back(Pair("time", e.GetTime()));
     info.push_back(Pair("height", (int)e.GetHeight()));
     info.push_back(Pair("startingpriority", e.GetStartingPriority()));
-    info.push_back(Pair("currentpriority", e.GetPriority(chainActive.Height())));
+    info.push_back(Pair("currentpriority", e.GetPriority(chainActive.Height() + 1)));
     info.push_back(Pair("descendantcount", e.GetCountWithDescendants()));
     info.push_back(Pair("descendantsize", e.GetSizeWithDescendants()));
     info.push_back(Pair("descendantfees", e.GetModFeesWithDescendants()));

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -588,6 +588,9 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
         }
         entry.push_back(Pair("sigops", nTxSigOps));
         entry.push_back(Pair("weight", GetTransactionWeight(tx)));
+        if (index_in_template && !pblocktemplate->vTxPriorities.empty()) {
+            entry.push_back(Pair("priority", pblocktemplate->vTxPriorities[index_in_template]));
+        }
 
         transactions.push_back(entry);
     }

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -701,8 +701,8 @@ void CTxMemPool::check(const CCoinsViewCache *pcoins, unsigned int nBlockHeight)
         unsigned int i = 0;
         checkTotal += it->GetTxSize();
         CAmount dummyValue;
-        double freshPriority = view.GetPriority(it->GetTx(), nBlockHeight, dummyValue);
-        double cachePriority = it->GetPriority(nBlockHeight);
+        double freshPriority = view.GetPriority(it->GetTx(), nBlockHeight + 1, dummyValue);
+        double cachePriority = it->GetPriority(nBlockHeight + 1);
         double priDiff = cachePriority > freshPriority ? cachePriority - freshPriority : freshPriority - cachePriority;
         // Verify that the difference between the on the fly calculation and a fresh calculation
         // is small enough to be a result of double imprecision.

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -40,7 +40,8 @@ CTxMemPoolEntry::CTxMemPoolEntry(const CTransaction& _tx, const CAmount& _nFee,
 
     feeDelta = 0;
 
-    cachedHeight = entryHeight;
+    // Since entries arrive *after* the tip's height, their entry priority is for the height+1
+    cachedHeight = entryHeight + 1;
     cachedPriority = entryPriority;
 
     nCountWithAncestors = 1;

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -119,6 +119,7 @@ public:
 
     const CTransaction& GetTx() const { return *this->tx; }
     std::shared_ptr<const CTransaction> GetSharedTx() const { return this->tx; }
+    double GetStartingPriority() const {return entryPriority; }
     /**
      * Fast calculation of lower bound of current priority as update
      * from entry priority. Only inputs that were originally in-chain will age.

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -539,7 +539,7 @@ public:
      * all inputs are in the mapNextTx array). If sanity-checking is turned off,
      * check does nothing.
      */
-    void check(const CCoinsViewCache *pcoins) const;
+    void check(const CCoinsViewCache *pcoins, unsigned int nBlockHeight) const;
     void setSanityCheck(double dFrequency = 1.0) { nCheckFrequency = dFrequency * 4294967295.0; }
 
     // addUnchecked must updated state for all ancestors of a given transaction,

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -88,6 +88,8 @@ private:
     int64_t nTime;             //!< Local time when entering the mempool
     double entryPriority;      //!< Priority when entering the mempool
     unsigned int entryHeight;  //!< Chain height when entering the mempool
+    double cachedPriority;     //!< Last calculated priority
+    unsigned int cachedHeight; //!< Height at which priority was last calculated
     bool hadNoDependencies;    //!< Not dependent on any other txs when it entered the mempool
     CAmount inChainInputValue; //!< Sum of all txin values that are already in blockchain
     bool spendsCoinbase;       //!< keep track of transactions that spend a coinbase
@@ -121,10 +123,15 @@ public:
     std::shared_ptr<const CTransaction> GetSharedTx() const { return this->tx; }
     double GetStartingPriority() const {return entryPriority; }
     /**
-     * Fast calculation of lower bound of current priority as update
-     * from entry priority. Only inputs that were originally in-chain will age.
+     * Fast calculation of priority as update from cached value, but only valid if
+     * currentHeight is greater than last height it was recalculated.
      */
     double GetPriority(unsigned int currentHeight) const;
+    /**
+     * Recalculate the cached priority as of currentHeight and adjust inChainInputValue by
+     * valueInCurrentBlock which represents input that was just added to or removed from the blockchain.
+     */
+    void UpdateCachedPriority(unsigned int currentHeight, CAmount valueInCurrentBlock);
     const CAmount& GetFee() const { return nFee; }
     size_t GetTxSize() const;
     size_t GetTxWeight() const { return nTxWeight; }
@@ -200,6 +207,20 @@ struct update_fee_delta
 
 private:
     int64_t feeDelta;
+};
+
+struct update_priority
+{
+    update_priority(unsigned int _height, CAmount _value) :
+        height(_height), value(_value)
+    {}
+
+    void operator() (CTxMemPoolEntry &e)
+    { e.UpdateCachedPriority(height, value); }
+
+    private:
+        unsigned int height;
+        CAmount value;
 };
 
 struct update_lock_points
@@ -545,6 +566,12 @@ public:
      * the tx is not dependent on other mempool transactions to be included in a block.
      */
     bool HasNoInputsOf(const CTransaction& tx) const;
+    /**
+     * Update all transactions in the mempool which depend on tx to recalculate their priority
+     * and adjust the input value that will age to reflect that the inputs from this transaction have
+     * either just been added to the chain or just been removed.
+     */
+    void UpdateDependentPriorities(const CTransaction &tx, unsigned int nBlockHeight, bool addToChain);
 
     /** Affect CreateNewBlock prioritisation of transactions */
     void PrioritiseTransaction(const uint256 hash, const std::string strHash, double dPriorityDelta, const CAmount& nFeeDelta);


### PR DESCRIPTION
This is needed to restore proper CreateNewBlock functioning for unconfirmed transaction chains.
