### PR TITLE
Add missing automake package to deb-based UNIX install instructions.

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -61,7 +61,7 @@ Dependency Build Instructions: Ubuntu & Debian
 ----------------------------------------------
 Build requirements:
 
-    sudo apt-get install build-essential libtool autotools-dev autoconf pkg-config libssl-dev libevent-dev bsdmainutils
+    sudo apt-get install build-essential libtool autotools-dev automake pkg-config libssl-dev libevent-dev bsdmainutils
 
 On at least Ubuntu 14.04+ and Debian 7+ there are generic names for the
 individual boost development packages, so the following can be used to only


### PR DESCRIPTION
Fixes the following issue:

``` sh
root@c74c16a6aee2:~/bitcoin# ./autogen.sh
Can't exec "aclocal": No such file or directory at /usr/share/autoconf/Autom4te/FileUtils.pm line 326.
autoreconf: failed to run aclocal: No such file or directory
root@c74c16a6aee2:~/bitcoin# apt-get install --no-install-recommends automake
...
root@c74c16a6aee2:~/bitcoin# ./autogen.sh
libtoolize: putting auxiliary files in AC_CONFIG_AUX_DIR, `build-aux'.
...
```
