### PR TITLE
rpc: remove cs_main lock from `createrawtransaction`

### DIFF
--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -353,7 +353,6 @@ UniValue createrawtransaction(const UniValue& params, bool fHelp)
             + HelpExampleRpc("createrawtransaction", "\"[{\\\"txid\\\":\\\"myid\\\",\\\"vout\\\":0}]\", \"{\\\"data\\\":\\\"00010203\\\"}\"")
         );
 
-    LOCK(cs_main);
     RPCTypeCheck(params, boost::assign::list_of(UniValue::VARR)(UniValue::VOBJ)(UniValue::VNUM), true);
     if (params[0].isNull() || params[1].isNull())
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, arguments 1 and 2 must be non-null");


### PR DESCRIPTION
Continues work to remove/push down RPC locks from #7013.
`createrawtransaction` is a pure utility function that doesn't use main's data structures, so it does not require that lock.

**Despite being a one-line change, needs to be reviewed carefully. Although I didn't find any, there may be unguarded use of main data structures deeper in the call chain. Not meant for 0.12**
