### PR TITLE
Disconnect on mempool requests from peers when over the upload limit.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4981,6 +4981,12 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
 
     else if (strCommand == "mempool")
     {
+        if (CNode::OutboundTargetReached(false) && !pfrom->fWhitelisted)
+        {
+            LogPrint("net", "mempool request with bandwidth limit reached, disconnect peer=%d\n", pfrom->GetId());
+            pfrom->fDisconnect = true;
+            return true;
+        }
         LOCK2(cs_main, pfrom->cs_filter);
 
         std::vector<uint256> vtxid;


### PR DESCRIPTION
Mempool requests use a fair amount of bandwidth when the mempool is large,
 disconnecting peers using them follows the same logic as disconnecting
 peers fetching historical blocks.
