### PR TITLE
Fix socket recv buffer bug

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1203,8 +1203,9 @@ void ThreadSocketHandler()
                 {
                     {
                         // typical socket buffer is 8K-64K
-                        char pchBuf[0x10000];
-                        int nBytes = recv(pnode->hSocket, pchBuf, sizeof(pchBuf), MSG_DONTWAIT);
+                        const size_t bufferSize = 0x10000;
+                        char pchBuf[bufferSize];
+                        int nBytes = recv(pnode->hSocket, pchBuf, bufferSize, MSG_DONTWAIT);
                         if (nBytes > 0)
                         {
                             if (!pnode->ReceiveMsgBytes(pchBuf, nBytes))


### PR DESCRIPTION
Currently network socket is read in only 8 byte chunks.

The code

```
char pchBuf[0x10000];
int nBytes = recv(pnode->hSocket, pchBuf, sizeof(pchBuf), MSG_DONTWAIT);
```

is equivalent to

```
char pchBuf[0x10000];
int nBytes = recv(pnode->hSocket, pchBuf, 8, MSG_DONTWAIT);
```

This wastes CPU and dramatically reduces transfer speed for all network communication.

Fixing the bug on my LAN testnet setup increases block transfer speed 3 times.
