### PR TITLE
[Trivial] Disable compiler warnings about unused functions

### DIFF
--- a/src/test/scheduler_tests.cpp
+++ b/src/test/scheduler_tests.cpp
@@ -15,6 +15,7 @@
 
 BOOST_AUTO_TEST_SUITE(scheduler_tests)
 
+#if 0 /* Disabled for now because there is a race condition issue in this test - see #6540 */
 static void microTask(CScheduler& s, boost::mutex& mutex, int& counter, int delta, boost::chrono::system_clock::time_point rescheduleTime)
 {
     {
@@ -40,7 +41,6 @@ static void MicroSleep(uint64_t n)
 #endif
 }
 
-#if 0 /* Disabled for now because there is a race condition issue in this test - see #6540 */
 BOOST_AUTO_TEST_CASE(manythreads)
 {
     seed_insecure_rand(false);


### PR DESCRIPTION
After #7144, some compilers emit warnings about unused functions in the scheduler tests:

```
  CXX      test/test_test_bitcoin-scheduler_tests.o
test/scheduler_tests.cpp:18:13: warning: function 'microTask' is not needed and will not be emitted [-Wunneeded-internal-declaration]
static void microTask(CScheduler& s, boost::mutex& mutex, int& counter, int delta, boost::chrono::system_clock::time_point rescheduleTime)
            ^
test/scheduler_tests.cpp:31:13: warning: unused function 'MicroSleep' [-Wunused-function]
static void MicroSleep(uint64_t n)
            ^
2 warnings generated.
```

Moving `#if 0` a bit up helps to silence this warning.
