### PR TITLE
tests: Disable Tor interaction

### DIFF
--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -107,6 +107,7 @@ def initialize_datadir(dirname, n):
         f.write("rpcpassword=rt\n");
         f.write("port="+str(p2p_port(n))+"\n");
         f.write("rpcport="+str(rpc_port(n))+"\n");
+        f.write("listenonion=0\n");
     return datadir
 
 def initialize_chain(test_dir):


### PR DESCRIPTION
This is unnecessary during the current tests (any test for Tor interaction can explicitly enable it) and interferes with the proxy test.
