### PR TITLE
tests: remove necessity to call create_callback_map

### DIFF
--- a/qa/rpc-tests/README.md
+++ b/qa/rpc-tests/README.md
@@ -47,10 +47,7 @@ implements the test logic.
 * ```NodeConn``` is the class used to connect to a bitcoind.  If you implement
 a callback class that derives from ```NodeConnCB``` and pass that to the
 ```NodeConn``` object, your code will receive the appropriate callbacks when
-events of interest arrive.  NOTE: be sure to call
-```self.create_callback_map()``` in your derived classes' ```__init__```
-function, so that the correct mappings are set up between p2p messages and your
-callback functions.
+events of interest arrive.
 
 * You can pass the same handler to multiple ```NodeConn```'s if you like, or pass
 different ones to each -- whatever makes the most sense for your test.

--- a/qa/rpc-tests/maxblocksinflight.py
+++ b/qa/rpc-tests/maxblocksinflight.py
@@ -34,7 +34,6 @@ class TestManager(NodeConnCB):
     def __init__(self):
         NodeConnCB.__init__(self)
         self.log = logging.getLogger("BlockRelayTest")
-        self.create_callback_map()
 
     def add_new_connection(self, connection):
         self.connection = connection

--- a/qa/rpc-tests/maxuploadtarget.py
+++ b/qa/rpc-tests/maxuploadtarget.py
@@ -25,7 +25,6 @@ if uploadtarget has been reached.
 class TestNode(NodeConnCB):
     def __init__(self):
         NodeConnCB.__init__(self)
-        self.create_callback_map()
         self.connection = None
         self.ping_counter = 1
         self.last_pong = msg_pong()

--- a/qa/rpc-tests/p2p-acceptblock.py
+++ b/qa/rpc-tests/p2p-acceptblock.py
@@ -62,7 +62,6 @@ The test:
 class TestNode(NodeConnCB):
     def __init__(self):
         NodeConnCB.__init__(self)
-        self.create_callback_map()
         self.connection = None
         self.ping_counter = 1
         self.last_pong = msg_pong()

--- a/qa/rpc-tests/sendheaders.py
+++ b/qa/rpc-tests/sendheaders.py
@@ -70,7 +70,6 @@ f. Announce 1 more header that builds on that fork.
 class BaseNode(NodeConnCB):
     def __init__(self):
         NodeConnCB.__init__(self)
-        self.create_callback_map()
         self.connection = None
         self.last_inv = None
         self.last_headers = None

--- a/qa/rpc-tests/test_framework/comptool.py
+++ b/qa/rpc-tests/test_framework/comptool.py
@@ -45,7 +45,6 @@ class TestNode(NodeConnCB):
 
     def __init__(self, block_store, tx_store):
         NodeConnCB.__init__(self)
-        self.create_callback_map()
         self.conn = None
         self.bestblockhash = None
         self.block_store = block_store

--- a/qa/rpc-tests/test_framework/mininode.py
+++ b/qa/rpc-tests/test_framework/mininode.py
@@ -1015,32 +1015,10 @@ class NodeConnCB(object):
                     return
             time.sleep(0.05)
 
-    # Derived classes should call this function once to set the message map
-    # which associates the derived classes' functions to incoming messages
-    def create_callback_map(self):
-        self.cbmap = {
-            "version": self.on_version,
-            "verack": self.on_verack,
-            "addr": self.on_addr,
-            "alert": self.on_alert,
-            "inv": self.on_inv,
-            "getdata": self.on_getdata,
-            "getblocks": self.on_getblocks,
-            "tx": self.on_tx,
-            "block": self.on_block,
-            "getaddr": self.on_getaddr,
-            "ping": self.on_ping,
-            "pong": self.on_pong,
-            "headers": self.on_headers,
-            "getheaders": self.on_getheaders,
-            "reject": self.on_reject,
-            "mempool": self.on_mempool
-        }
-
     def deliver(self, conn, message):
         with mininode_lock:
             try:
-                self.cbmap[message.command](conn, message)
+                getattr(self, 'on_' + message.command)(conn, message)
             except:
                 print "ERROR delivering %s (%s)" % (repr(message),
                                                     sys.exc_info()[0])


### PR DESCRIPTION
Remove necessity to call create_callback_map (as well as the function itself) from the Python P2P test framework. Invoke the appropriate methods directly.
- Easy to forget to call it and wonder why it doesn't work
- Simplifies the code
- This makes it easier to handle new messages in subclasses
