### PR TITLE
net: Fix sent reject messages for blocks and transactions

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -100,6 +100,8 @@ testScripts = [
     'sendheaders.py',
     'keypool.py',
     'prioritise_transaction.py',
+    'invalidblockrequest.py',
+    'invalidtxrequest.py',
 ]
 testScriptsExt = [
     'bip65-cltv.py',
@@ -116,7 +118,6 @@ testScriptsExt = [
 #    'rpcbind_test.py', #temporary, bug in libevent, see #6655
     'smartfees.py',
     'maxblocksinflight.py',
-    'invalidblockrequest.py',
     'p2p-acceptblock.py',
     'mempool_packages.py',
     'maxuploadtarget.py',

--- a/qa/rpc-tests/test_framework/comptool.py
+++ b/qa/rpc-tests/test_framework/comptool.py
@@ -41,6 +41,20 @@ def wait_until(predicate, attempts=float('inf'), timeout=float('inf')):
 
     return False
 
+class RejectResult(object):
+    '''
+    Outcome that expects rejection of a transaction or block.
+    '''
+    def __init__(self, code, reason=''):
+        self.code = code
+        self.reason = reason
+    def match(self, other):
+        if self.code != other.code:
+            return False
+        return other.reason.startswith(self.reason)
+    def __repr__(self):
+        return '%i:%s' % (self.code,self.reason or '*')
+
 class TestNode(NodeConnCB):
 
     def __init__(self, block_store, tx_store):
@@ -51,6 +65,8 @@ class TestNode(NodeConnCB):
         self.block_request_map = {}
         self.tx_store = tx_store
         self.tx_request_map = {}
+        self.block_reject_map = {}
+        self.tx_reject_map = {}
 
         # When the pingmap is non-empty we're waiting for 
         # a response
@@ -93,6 +109,12 @@ class TestNode(NodeConnCB):
             del self.pingMap[message.nonce]
         except KeyError:
             raise AssertionError("Got pong for unknown ping [%s]" % repr(message))
+
+    def on_reject(self, conn, message):
+        if message.message == 'tx':
+            self.tx_reject_map[message.data] = RejectResult(message.code, message.reason)
+        if message.message == 'block':
+            self.block_reject_map[message.data] = RejectResult(message.code, message.reason)
 
     def send_inv(self, obj):
         mtype = 2 if isinstance(obj, CBlock) else 1
@@ -243,6 +265,15 @@ class TestManager(object):
                 if outcome is None:
                     if c.cb.bestblockhash != self.connections[0].cb.bestblockhash:
                         return False
+                elif isinstance(outcome, RejectResult): # Check that block was rejected w/ code
+                    if c.cb.bestblockhash == blockhash:
+                        return False
+                    if blockhash not in c.cb.block_reject_map:
+                        print 'Block not in reject map: %064x' % (blockhash)
+                        return False
+                    if not outcome.match(c.cb.block_reject_map[blockhash]):
+                        print 'Block rejected with %s instead of expected %s: %064x' % (c.cb.block_reject_map[blockhash], outcome, blockhash)
+                        return False
                 elif ((c.cb.bestblockhash == blockhash) != outcome):
                     # print c.cb.bestblockhash, blockhash, outcome
                     return False
@@ -261,6 +292,15 @@ class TestManager(object):
                     # Make sure the mempools agree with each other
                     if c.cb.lastInv != self.connections[0].cb.lastInv:
                         # print c.rpc.getrawmempool()
+                        return False
+                elif isinstance(outcome, RejectResult): # Check that tx was rejected w/ code
+                    if txhash in c.cb.lastInv:
+                        return False
+                    if txhash not in c.cb.tx_reject_map:
+                        print 'Tx not in reject map: %064x' % (txhash)
+                        return False
+                    if not outcome.match(c.cb.tx_reject_map[txhash]):
+                        print 'Tx rejected with %s instead of expected %s: %064x' % (c.cb.tx_reject_map[txhash], outcome, txhash)
                         return False
                 elif ((txhash in c.cb.lastInv) != outcome):
                     # print c.rpc.getrawmempool(), c.cb.lastInv

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4824,7 +4824,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                 pfrom->id,
                 FormatStateMessage(state));
             if (state.GetRejectCode() < REJECT_INTERNAL) // Never send AcceptToMemoryPool's internal codes over P2P
-                pfrom->PushMessage("reject", strCommand, state.GetRejectCode(),
+                pfrom->PushMessage("reject", strCommand, (unsigned char)state.GetRejectCode(),
                                    state.GetRejectReason().substr(0, MAX_REJECT_MESSAGE_LENGTH), inv.hash);
             if (nDoS > 0)
                 Misbehaving(pfrom->GetId(), nDoS);
@@ -4954,7 +4954,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         int nDoS;
         if (state.IsInvalid(nDoS)) {
             assert (state.GetRejectCode() < REJECT_INTERNAL); // Blocks are never rejected with internal reject codes
-            pfrom->PushMessage("reject", strCommand, state.GetRejectCode(),
+            pfrom->PushMessage("reject", strCommand, (unsigned char)state.GetRejectCode(),
                                state.GetRejectReason().substr(0, MAX_REJECT_MESSAGE_LENGTH), inv.hash);
             if (nDoS > 0) {
                 LOCK(cs_main);


### PR DESCRIPTION
Ever since we #5913 have been sending invalid reject messages for transactions and blocks.
