### PR TITLE
net: Account for `sendheaders` `verack` messages

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -72,7 +72,8 @@ const static std::string logAllowIncomingMsgCmds[] = {
     "version", "addr", "inv", "getdata", "merkleblock",
     "getblocks", "getheaders", "tx", "headers", "block",
     "getaddr", "mempool", "ping", "pong", "alert", "notfound",
-    "filterload", "filteradd", "filterclear", "reject"};
+    "filterload", "filteradd", "filterclear", "reject",
+    "sendheaders", "verack"};
 
 const static std::string NET_MESSAGE_COMMAND_OTHER = "*other*";
 


### PR DESCRIPTION
Looks like these were forgotten in #6589. @jonasschnelli 
