### PR TITLE
Improved readability of ApproximateBestSubset

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1701,7 +1701,8 @@ bool CWallet::SelectCoinsMinConf(const CAmount& nTargetValue, int nConfMine, int
     }
 
     // Solve subset sum by stochastic approximation
-    sort(vValue.rbegin(), vValue.rend(), CompareValueOnly());
+    std::sort(vValue.begin(), vValue.end(), CompareValueOnly());
+    std::reverse(vValue.begin(), vValue.end());
     vector<char> vfBest;
     CAmount nBest;
 


### PR DESCRIPTION
[`vValue` is sorted](https://github.com/bitcoin/bitcoin/blob/master/src/wallet/wallet.cpp#L1704) into [ascending order](http://www.cplusplus.com/reference/algorithm/sort/) before [ApproximateBestSubset(...)](https://github.com/bitcoin/bitcoin/blob/master/src/wallet/wallet.cpp#L1591) is called. 

Currently, after a new best set is found, the final element that was added [gets removed from the set](https://github.com/bitcoin/bitcoin/blob/master/src/wallet/wallet.cpp#L1629), and the [inner loop](https://github.com/bitcoin/bitcoin/blob/master/src/wallet/wallet.cpp#L1608) continues to search through the remainder of `vValue` for a better set. It is however impossible for a better set to be achieved with a later element in `vValue`: As `vValue` is sorted in ascending order, any set formed with a later element will be of same size or bigger.

Therefore, the lines [1628](https://github.com/bitcoin/bitcoin/blob/master/src/wallet/wallet.cpp#L1628) & [1629](https://github.com/bitcoin/bitcoin/blob/master/src/wallet/wallet.cpp#L1629) are obsolete, and the inner loop should also stop on `fReachedTarget`.
