### PR TITLE
[wallet] Cleanup tests

### DIFF
--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -336,14 +336,16 @@ BOOST_AUTO_TEST_CASE(pruning_in_ApproximateBestSet)
     LOCK(wallet.cs_wallet);
 
     empty_wallet();
-    for (int i = 0; i < 12; i++) 
-    {
-        add_coin(10*CENT);
-    }
-    add_coin(100*CENT);
-    add_coin(100*CENT);
-    BOOST_CHECK(wallet.SelectCoinsMinConf(221*CENT, 1, 6, vCoins, setCoinsRet, nValueRet));
-    BOOST_CHECK_EQUAL(nValueRet, 230*CENT);
+    for (int i = 0; i < 100; i++)
+        add_coin(10 * CENT);
+    for (int i = 0; i < 100; i++)
+        add_coin(1000 * CENT);
+
+    BOOST_CHECK(wallet.SelectCoinsMinConf(100001 * CENT, 1, 6, vCoins, setCoinsRet, nValueRet));
+    // We need all 100 larger coins and exactly one small coin.
+    // Superfluous small coins must be pruned:
+    BOOST_CHECK_EQUAL(nValueRet, 100010 * CENT);
+    BOOST_CHECK_EQUAL(setCoinsRet.size(), 101);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This is a follow up of #4906.

Please review commit-by-commit:
- First commit: The test case is supposed to verify that input pruning works. However, for inputs `[100] * 2, [10] * 12` and a target value of 221 the old code as well as the new code **always** return `[100] * 2, [10] * 3`, regardless of the number of iterations, etc.
  To actually test pruning, one needs a sufficient amount of "big coins" so that the random approximation misses at least one big coin even if iterations=1000 (default). Thus, "smaller coins" get added by the algorithm. (But the algorithm does not yet know they are not sufficient and will later be useless, after executing the second pass)
- <strike>Second commit: Use `clang-format` because the code style is really messed up here. (Reminder to use ?w=0 flag on GitHub to disable white space diff) // moved to a later pull
