### PR TITLE
Add "NODE_BLOOM" to guiutil so that peers don't get UNKNOWN[4]

### DIFF
--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -898,6 +898,9 @@ QString formatServicesStr(quint64 mask)
             case NODE_GETUTXO:
                 strList.append("GETUTXO");
                 break;
+            case NODE_BLOOM:
+                strList.append("BLOOM");
+                break;
             default:
                 strList.append(QString("%1[%2]").arg("UNKNOWN").arg(check));
             }


### PR DESCRIPTION
Maybe this should be [trivial]...in any case, this prevents us from listing peers as supporting services "UNKNOWN[4]"
