### PR TITLE
Removed offline testnet DNSSeed 'alexykot.me'.

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -179,7 +179,6 @@ public:
 
         vFixedSeeds.clear();
         vSeeds.clear();
-        vSeeds.push_back(CDNSSeedData("alexykot.me", "testnet-seed.alexykot.me"));
         vSeeds.push_back(CDNSSeedData("bitcoin.petertodd.org", "testnet-seed.bitcoin.petertodd.org"));
         vSeeds.push_back(CDNSSeedData("bluematt.me", "testnet-seed.bluematt.me"));
         vSeeds.push_back(CDNSSeedData("bitcoin.schildbach.de", "testnet-seed.bitcoin.schildbach.de"));


### PR DESCRIPTION
The testnet seed 'alexykot.me' doesn't seem to be online (google suggest, that this is the case for a longer time).
This request simply removes it from the list of testnet seeds.

See #7215 
