### PR TITLE
Mark blocks with too many sigops as failed

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3005,7 +3005,7 @@ bool CheckBlock(const CBlock& block, CValidationState& state, bool fCheckPOW, bo
     }
     if (nSigOps > MAX_BLOCK_SIGOPS)
         return state.DoS(100, error("CheckBlock(): out-of-bounds SigOpCount"),
-                         REJECT_INVALID, "bad-blk-sigops", true);
+                         REJECT_INVALID, "bad-blk-sigops");
 
     if (fCheckPOW && fCheckMerkleRoot)
         block.fChecked = true;


### PR DESCRIPTION
This unsets the "corruption possible" field in `CValidationState` when calling `CheckBlock` on a block with too many sigops.  Without this change, bitcoind would re-request such a block rather than mark it as permanently failed.
