### PR TITLE
[qt] Fix misleading translation

### DIFF
--- a/src/qt/locale/bitcoin_en.ts
+++ b/src/qt/locale/bitcoin_en.ts
@@ -1153,7 +1153,7 @@
     </message>
     <message>
         <location line="+1"/>
-        <source>Reset all settings changes made over the GUI</source>
+        <source>Reset all settings changed in the GUI</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/qt/utilitydialog.cpp
+++ b/src/qt/utilitydialog.cpp
@@ -84,7 +84,7 @@ HelpMessageDialog::HelpMessageDialog(QWidget *parent, bool about) :
         strUsage += HelpMessageOpt("-min", tr("Start minimized").toStdString());
         strUsage += HelpMessageOpt("-rootcertificates=<file>", tr("Set SSL root certificates for payment request (default: -system-)").toStdString());
         strUsage += HelpMessageOpt("-splash", strprintf(tr("Show splash screen on startup (default: %u)").toStdString(), DEFAULT_SPLASHSCREEN));
-        strUsage += HelpMessageOpt("-resetguisettings", tr("Reset all settings changes made over the GUI").toStdString());
+        strUsage += HelpMessageOpt("-resetguisettings", tr("Reset all settings changed in the GUI").toStdString());
         if (showDebug) {
             strUsage += HelpMessageOpt("-uiplatform", strprintf("Select platform to customize UI for (one of windows, macosx, other; default: %s)", BitcoinGUI::DEFAULT_UIPLATFORM));
         }

--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -618,7 +618,7 @@ void TorController::disconnected_cb(TorControlConnection& conn)
     if (!reconnect)
         return;
 
-    LogPrint("tor", "tor: Disconnected from Tor control port %s, trying to reconnect\n", target);
+    LogPrint("tor", "tor: Not connected to Tor control port %s, trying to reconnect\n", target);
 
     // Single-shot timer for reconnect. Use exponential backoff.
     struct timeval time = MillisToTimeval(int64_t(reconnect_timeout * 1000.0));


### PR DESCRIPTION
The first commit fixes https://github.com/bitcoin/bitcoin/pull/7035#issuecomment-160808428

The second commit was on my list to fix before 0.12 but I somehow forgot it. People complain about this at transifex.
