### PR TITLE
RPC: Indicate which transactions are signaling opt-in RBF

### DIFF
--- a/qa/rpc-tests/listtransactions.py
+++ b/qa/rpc-tests/listtransactions.py
@@ -7,7 +7,15 @@
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
+from test_framework.mininode import CTransaction
+import cStringIO
+import binascii
 
+def txFromHex(hexstring):
+    tx = CTransaction()
+    f = cStringIO.StringIO(binascii.unhexlify(hexstring))
+    tx.deserialize(f)
+    return tx
 
 def check_array_result(object_array, to_match, expected):
     """
@@ -107,6 +115,107 @@ class ListTransactionsTest(BitcoinTestFramework):
         check_array_result(self.nodes[0].listtransactions("watchonly", 100, 0, True),
                            {"category":"receive","amount":Decimal("0.1")},
                            {"txid":txid, "account" : "watchonly"} )
+
+        self.run_rbf_opt_in_test()
+
+    # Check that the opt-in-rbf flag works properly, for sent and received
+    # transactions.
+    def run_rbf_opt_in_test(self):
+        # Check whether a transaction signals opt-in RBF itself
+        def is_opt_in(node, txid):
+            rawtx = node.getrawtransaction(txid, 1)
+            for x in rawtx["vin"]:
+                if x["sequence"] < 0xfffffffe:
+                    return True
+            return False
+
+        # Find an unconfirmed output matching a certain txid
+        def get_unconfirmed_utxo_entry(node, txid_to_match):
+            utxo = node.listunspent(0, 0)
+            for i in utxo:
+                if i["txid"] == txid_to_match:
+                    return i
+            return None
+
+        # 1. Chain a few transactions that don't opt-in.
+        txid_1 = self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 1)
+        assert(not is_opt_in(self.nodes[0], txid_1))
+        check_array_result(self.nodes[0].listtransactions(), {"txid": txid_1}, {"bip125-replaceable":"no"})
+        sync_mempools(self.nodes)
+        check_array_result(self.nodes[1].listtransactions(), {"txid": txid_1}, {"bip125-replaceable":"no"})
+
+        # Tx2 will build off txid_1, still not opting in to RBF.
+        utxo_to_use = get_unconfirmed_utxo_entry(self.nodes[1], txid_1)
+
+        # Create tx2 using createrawtransaction
+        inputs = [{"txid":utxo_to_use["txid"], "vout":utxo_to_use["vout"]}]
+        outputs = {self.nodes[0].getnewaddress(): 0.999}
+        tx2 = self.nodes[1].createrawtransaction(inputs, outputs)
+        tx2_signed = self.nodes[1].signrawtransaction(tx2)["hex"]
+        txid_2 = self.nodes[1].sendrawtransaction(tx2_signed)
+
+        # ...and check the result
+        assert(not is_opt_in(self.nodes[1], txid_2))
+        check_array_result(self.nodes[1].listtransactions(), {"txid": txid_2}, {"bip125-replaceable":"no"})
+        sync_mempools(self.nodes)
+        check_array_result(self.nodes[0].listtransactions(), {"txid": txid_2}, {"bip125-replaceable":"no"})
+
+        # Tx3 will opt-in to RBF
+        utxo_to_use = get_unconfirmed_utxo_entry(self.nodes[0], txid_2)
+        inputs = [{"txid": txid_2, "vout":utxo_to_use["vout"]}]
+        outputs = {self.nodes[1].getnewaddress(): 0.998}
+        tx3 = self.nodes[0].createrawtransaction(inputs, outputs)
+        tx3_modified = txFromHex(tx3)
+        tx3_modified.vin[0].nSequence = 0
+        tx3 = binascii.hexlify(tx3_modified.serialize()).decode('utf-8')
+        tx3_signed = self.nodes[0].signrawtransaction(tx3)['hex']
+        txid_3 = self.nodes[0].sendrawtransaction(tx3_signed)
+
+        assert(is_opt_in(self.nodes[0], txid_3))
+        check_array_result(self.nodes[0].listtransactions(), {"txid": txid_3}, {"bip125-replaceable":"yes"})
+        sync_mempools(self.nodes)
+        check_array_result(self.nodes[1].listtransactions(), {"txid": txid_3}, {"bip125-replaceable":"yes"})
+
+        # Tx4 will chain off tx3.  Doesn't signal itself, but depends on one
+        # that does.
+        utxo_to_use = get_unconfirmed_utxo_entry(self.nodes[1], txid_3)
+        inputs = [{"txid": txid_3, "vout":utxo_to_use["vout"]}]
+        outputs = {self.nodes[0].getnewaddress(): 0.997}
+        tx4 = self.nodes[1].createrawtransaction(inputs, outputs)
+        tx4_signed = self.nodes[1].signrawtransaction(tx4)["hex"]
+        txid_4 = self.nodes[1].sendrawtransaction(tx4_signed)
+
+        assert(not is_opt_in(self.nodes[1], txid_4))
+        check_array_result(self.nodes[1].listtransactions(), {"txid": txid_4}, {"bip125-replaceable":"yes"})
+        sync_mempools(self.nodes)
+        check_array_result(self.nodes[0].listtransactions(), {"txid": txid_4}, {"bip125-replaceable":"yes"})
+
+        # Replace tx3, and check that tx4 becomes unknown
+        tx3_b = tx3_modified
+        tx3_b.vout[0].nValue -= 0.004*100000000 # bump the fee
+        tx3_b = binascii.hexlify(tx3_b.serialize()).decode('utf-8')
+        tx3_b_signed = self.nodes[0].signrawtransaction(tx3_b)['hex']
+        txid_3b = self.nodes[0].sendrawtransaction(tx3_b_signed, True)
+        assert(is_opt_in(self.nodes[0], txid_3b))
+
+        check_array_result(self.nodes[0].listtransactions(), {"txid": txid_4}, {"bip125-replaceable":"unknown"})
+        sync_mempools(self.nodes)
+        check_array_result(self.nodes[1].listtransactions(), {"txid": txid_4}, {"bip125-replaceable":"unknown"})
+
+        # Check gettransaction as well:
+        for n in self.nodes[0:2]:
+            assert_equal(n.gettransaction(txid_1)["bip125-replaceable"], "no")
+            assert_equal(n.gettransaction(txid_2)["bip125-replaceable"], "no")
+            assert_equal(n.gettransaction(txid_3)["bip125-replaceable"], "yes")
+            assert_equal(n.gettransaction(txid_3b)["bip125-replaceable"], "yes")
+            assert_equal(n.gettransaction(txid_4)["bip125-replaceable"], "unknown")
+
+        # After mining a transaction, it's no longer BIP125-replaceable
+        self.nodes[0].generate(1)
+        assert(txid_3b not in self.nodes[0].getrawmempool())
+        assert_equal(self.nodes[0].gettransaction(txid_3b)["bip125-replaceable"], "no")
+        assert_equal(self.nodes[0].gettransaction(txid_4)["bip125-replaceable"], "unknown")
+
 
 if __name__ == '__main__':
     ListTransactionsTest().main()

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -122,6 +122,7 @@ BITCOIN_CORE_H = \
   noui.h \
   policy/fees.h \
   policy/policy.h \
+  policy/rbf.h \
   pow.h \
   prevector.h \
   primitives/block.h \
@@ -239,6 +240,7 @@ libbitcoin_wallet_a_SOURCES = \
   wallet/wallet.cpp \
   wallet/wallet_ismine.cpp \
   wallet/walletdb.cpp \
+  policy/rbf.cpp \
   $(BITCOIN_CORE_H)
 
 # crypto primitives library

--- a/src/policy/rbf.cpp
+++ b/src/policy/rbf.cpp
@@ -1,0 +1,46 @@
+// Copyright (c) 2016 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "policy/rbf.h"
+
+bool SignalsOptInRBF(const CTransaction &tx)
+{
+    BOOST_FOREACH(const CTxIn &txin, tx.vin) {
+        if (txin.nSequence < std::numeric_limits<unsigned int>::max()-1) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool IsRBFOptIn(const CTxMemPoolEntry &entry, CTxMemPool &pool)
+{
+    AssertLockHeld(pool.cs);
+
+    CTxMemPool::setEntries setAncestors;
+
+    // First check the transaction itself.
+    if (SignalsOptInRBF(entry.GetTx())) {
+        return true;
+    }
+
+    // If this transaction is not in our mempool, then we can't be sure
+    // we will know about all its inputs.
+    if (!pool.exists(entry.GetTx().GetHash())) {
+        throw std::runtime_error("Cannot determine RBF opt-in signal for non-mempool transaction\n");
+    }
+
+    // If all the inputs have nSequence >= maxint-1, it still might be
+    // signaled for RBF if any unconfirmed parents have signaled.
+    uint64_t noLimit = std::numeric_limits<uint64_t>::max();
+    std::string dummy;
+    pool.CalculateMemPoolAncestors(entry, setAncestors, noLimit, noLimit, noLimit, noLimit, dummy, false);
+
+    BOOST_FOREACH(CTxMemPool::txiter it, setAncestors) {
+        if (SignalsOptInRBF(it->GetTx())) {
+            return true;
+        }
+    }
+    return false;
+}

--- a/src/policy/rbf.h
+++ b/src/policy/rbf.h
@@ -1,0 +1,20 @@
+// Copyright (c) 2016 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_POLICY_RBF_H
+#define BITCOIN_POLICY_RBF_H
+
+#include "txmempool.h"
+
+// Check whether the sequence numbers on this transaction are signaling
+// opt-in to replace-by-fee, according to BIP 125
+bool SignalsOptInRBF(const CTransaction &tx);
+
+// Determine whether an in-mempool transaction is signaling opt-in to RBF
+// according to BIP 125
+// This involves checking sequence numbers of the transaction, as well
+// as the sequence numbers of all in-mempool ancestors.
+bool IsRBFOptIn(const CTxMemPoolEntry &entry, CTxMemPool &pool);
+
+#endif // BITCOIN_POLICY_RBF_H


### PR DESCRIPTION
I'm not sure how users of bitcoind are expected to figure out which transactions could be replaced via opt-in RBF, so I took a first stab at exposing that via RPC.  I've started by adding it to `getrawmempool` when called with the verbose=true argument.  I've also exercised that code with some small modifications to the `replace-by-fee.py` rpc test.

I'd appreciate some specific feedback on the following:
- Which RPC calls should return this information?
- Would it be helpful to distinguish between a transaction signaling RBF itself (with `nSequence < 0xfffffffe` on one of its inputs), versus inheriting the signal from some unconfirmed parent?
- The answer can only be definitive for transactions that are in the mempool; transactions that are not in the mempool might have unknown parents which could signal RBF and we wouldn't know it.  Is it worth trying to answer this question for transactions not in the mempool, and if so, what information should be returned?
