### PR TITLE
Eliminate unnecessary call to CheckBlock

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3171,16 +3171,10 @@ static bool IsSuperMajority(int minVersion, const CBlockIndex* pstart, unsigned 
 
 bool ProcessNewBlock(CValidationState& state, const CChainParams& chainparams, const CNode* pfrom, const CBlock* pblock, bool fForceProcessing, CDiskBlockPos* dbp)
 {
-    // Preliminary checks
-    bool checked = CheckBlock(*pblock, state);
-
     {
         LOCK(cs_main);
         bool fRequested = MarkBlockAsReceived(pblock->GetHash());
         fRequested |= fForceProcessing;
-        if (!checked) {
-            return error("%s: CheckBlock FAILED %s", __func__, FormatStateMessage(state));
-        }
 
         // Store to disk
         CBlockIndex *pindex = NULL;


### PR DESCRIPTION
`ProcessNewBlock` would return failure early if `CheckBlock` failed, before calling `AcceptBlock`.  `AcceptBlock` also calls `CheckBlock`, and upon failure would update `mapBlockIndex` to indicate that a block was failed.  By returning early in `ProcessNewBlock`, we were not marking blocks that fail a check in `CheckBlock` as permanently failed, and thus would continue to re-request and reprocess them.

This should result in one fewer call to `CheckBlock` for valid blocks, at the expense of one extra call to `AcceptBlockHeader` for blocks that fail `CheckBlock`, and it avoids reprocessing those failed blocks over and over.
