### PR TITLE
Bugfix: update-translations: Allow numerus translations to omit %n specifier (usually when it only has one possible value)

### DIFF
--- a/contrib/devtools/update-translations.py
+++ b/contrib/devtools/update-translations.py
@@ -70,7 +70,7 @@ def sanitize_string(s):
     '''Sanitize string for printing'''
     return s.replace('\n',' ')
 
-def check_format_specifiers(source, translation, errors):
+def check_format_specifiers(source, translation, errors, numerus):
     source_f = split_format_specifiers(find_format_specifiers(source))
     # assert that no source messages contain both Qt and strprintf format specifiers
     # if this fails, go change the source as this is hacky and confusing!
@@ -78,10 +78,13 @@ def check_format_specifiers(source, translation, errors):
     try:
         translation_f = split_format_specifiers(find_format_specifiers(translation))
     except IndexError:
-        errors.append("Parse error in translation '%s'" % sanitize_string(translation))
+        errors.append("Parse error in translation for '%s': '%s'" % (sanitize_string(source), sanitize_string(translation)))
         return False
     else:
         if source_f != translation_f:
+            if numerus and source_f == (set(), ['n']) and translation_f == (set(), []) and translation.find('%') == -1:
+                # Allow numerus translations to omit %n specifier (usually when it only has one possible value)
+                return True
             errors.append("Mismatch between '%s' and '%s'" % (sanitize_string(source), sanitize_string(translation)))
             return False
     return True
@@ -148,7 +151,7 @@ def postprocess_translations(reduce_diff_hacks=False):
                     if translation is None:
                         continue
                     errors = []
-                    valid = check_format_specifiers(source, translation, errors)
+                    valid = check_format_specifiers(source, translation, errors, numerus)
 
                     for error in errors:
                         print('%s: %s' % (filename, error))


### PR DESCRIPTION
This is needed for a couple of translations which omit the raw number from the singular case.
