### PR TITLE
[Wallet] Simple HD/BIP32 support

### DIFF
--- a/qa/rpc-tests/hdwallet.py
+++ b/qa/rpc-tests/hdwallet.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python2
+# Copyright (c) 2014 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+
+class HDWalletTest (BitcoinTestFramework):
+
+    def setup_chain(self):
+        print("Initializing test directory "+self.options.tmpdir)
+        initialize_chain_clean(self.options.tmpdir, 4)
+
+    def setup_network(self, split=False):
+        self.nodes = start_nodes(2, self.options.tmpdir, extra_args=[
+            ['-hdseed=f81a7a4efdc29e54dcc739df87315a756038d0b68fbc4880ffbbbef222152e6a'],
+            []
+            ])
+        connect_nodes_bi(self.nodes,0,1)
+        self.is_network_split=False
+        self.sync_all()
+
+    def run_test (self):
+        print "Mining blocks..."
+
+        encrypt = True
+        self.nodes[0].generate(1)
+
+        walletinfo = self.nodes[0].getwalletinfo()
+        assert_equal(walletinfo['immature_balance'], 50)
+        assert_equal(walletinfo['balance'], 0)
+        self.nodes[0].generate(100)
+        self.sync_all()
+
+        adr = self.nodes[0].getnewaddress("", True)
+        assert_equal(adr['address'], "mtGrK6eX8uhW6FhoUzyQmxFBLxjZRhcfQJ");
+        assert_equal(adr['keypath'], "m/0'/3'");
+        
+        adr = self.nodes[0].getnewaddress("", True)
+        assert_equal(adr['address'], "muWGGSSma5s7TjHbT5fCKunkoyBaF1uy8D");
+        assert_equal(adr['keypath'], "m/0'/4'");
+        
+        stop_node(self.nodes[0], 0)
+        stop_node(self.nodes[1], 1)
+        
+        #try to recover over master seed
+        os.remove(self.options.tmpdir + "/node0/regtest/wallet.dat")
+        self.nodes = start_nodes(2, self.options.tmpdir, extra_args=[
+            ['-hdseed=f81a7a4efdc29e54dcc739df87315a756038d0b68fbc4880ffbbbef222152e6a'],
+            []
+            ])
+        adr = self.nodes[0].getnewaddress("", True)
+        assert_equal(adr['address'], "mqfCLB8d4vP1BTyMo88WzjT9VJG4NWEbni");
+        assert_equal(adr['keypath'], "m/0'/1'");
+        
+        adr = self.nodes[0].getnewaddress("", True)
+        assert_equal(adr['address'], "n4mEdLhWJgDHvsChPcttAkqQSMrndhzdAv");
+        assert_equal(adr['keypath'], "m/0'/2'");
+
+        adr = self.nodes[0].getnewaddress("", True)
+        assert_equal(adr['address'], "mtGrK6eX8uhW6FhoUzyQmxFBLxjZRhcfQJ");
+        assert_equal(adr['keypath'], "m/0'/3'");
+        
+        print "encrypt wallet"
+        self.nodes[0].encryptwallet("test")
+        bitcoind_processes[0].wait()
+        del bitcoind_processes[0]
+
+        self.nodes[0] = start_node(0, self.options.tmpdir, extra_args=['-hdseed=f81a7a4efdc29e54dcc739df87315a756038d0b68fbc4880ffbbbef222152e6a'])
+        self.nodes[0].walletpassphrase("test", 100)
+        adr = self.nodes[0].getnewaddress("", True)
+        assert_equal(adr['address'], "n32WRiXX6P6KFkdGV37CAbsTjLcxt4VhRY");
+        assert_equal(adr['keypath'], "m/0'/5'");
+
+if __name__ == '__main__':
+    HDWalletTest ().main ()

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -155,6 +155,7 @@ BITCOIN_CORE_H = \
   wallet/crypter.h \
   wallet/db.h \
   wallet/rpcwallet.h \
+  wallet/hdkeystore.h \
   wallet/wallet.h \
   wallet/wallet_ismine.h \
   wallet/walletdb.h \
@@ -225,6 +226,7 @@ libbitcoin_wallet_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 libbitcoin_wallet_a_SOURCES = \
   wallet/crypter.cpp \
   wallet/db.cpp \
+  wallet/hdkeystore.cpp \
   wallet/rpcdump.cpp \
   wallet/rpcwallet.cpp \
   wallet/wallet.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -89,6 +89,7 @@ if ENABLE_WALLET
 BITCOIN_TESTS += \
   test/accounting_tests.cpp \
   wallet/test/wallet_tests.cpp \
+  wallet/test/hdkeystore_tests.cpp \
   test/rpc_wallet_tests.cpp
 endif
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1490,6 +1490,46 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
             // Create new keyUser and set as default key
             RandAddSeedPerfmon();
 
+            if (GetBoolArg("-usehd", DEFAULT_USE_HD_WALLET))
+            {
+                // create a new seed / chain
+                // default keypath is m/c'/k'
+                // results in m/0'/0' for the first external key
+                // results in m/1'/0' for the first internal key
+                // results in m/0'/1' for the second external key
+
+                CHDChain chain;
+                chain.keypathTemplate = "m/c'";
+                
+                CKey key;
+                key.MakeNewKey(true); //generate a seed
+                CKeyingMaterial seed = CKeyingMaterial(32);
+                seed.assign(key.begin(), key.end());
+
+                if (GetArg("-hdseed", "").size() == 64)
+                {
+                    std::vector<unsigned char> hdseed = ParseHex(GetArg("-hdseed", ""));
+                    seed.assign(hdseed.begin(), hdseed.end());
+                }
+                else if(GetArg("-hdseed", "").size() != 0)
+                {
+                    strErrors << _("-hdseed needs to be 256bit (64 hex chars)") << "\n";
+                    LogPrintf("%s", strErrors.str());
+                    return InitError(strErrors.str());
+                }
+
+                CExtKey masterKey;
+                masterKey.SetMaster(&seed[0], seed.size());
+
+                CExtPubKey masterPubKey = masterKey.Neuter();
+                chain.chainID = masterPubKey.pubkey.GetHash();
+
+                //persist the chain and the master seed
+                pwalletMain->AddMasterSeed(chain.chainID, seed);
+                pwalletMain->AddHDChain(chain);
+                pwalletMain->SetActiveHDChainID(chain.chainID);
+            }
+
             CPubKey newDefaultKey;
             if (pwalletMain->GetKeyFromPool(newDefaultKey)) {
                 pwalletMain->SetDefaultKey(newDefaultKey);

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -101,6 +101,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "prioritisetransaction", 2 },
     { "setban", 2 },
     { "setban", 3 },
+    { "getnewaddress", 1 },
 };
 
 class CRPCConvertTable

--- a/src/wallet/crypter.cpp
+++ b/src/wallet/crypter.cpp
@@ -292,3 +292,22 @@ bool CCryptoKeyStore::EncryptKeys(CKeyingMaterial& vMasterKeyIn)
     }
     return true;
 }
+
+bool CCryptoKeyStore::EncryptSeed(const CKeyingMaterial& seedIn, const uint256& seedPubHash, std::vector<unsigned char> &vchCiphertext) const
+{
+    LOCK(cs_KeyStore);
+    if (!EncryptSecret(vMasterKey, seedIn, seedPubHash, vchCiphertext))
+        return false;
+
+    return true;
+}
+
+bool CCryptoKeyStore::DecryptSeed(const std::vector<unsigned char>& vchCiphertextIn, const uint256& seedPubHash, CKeyingMaterial& seedOut) const
+{
+    LOCK(cs_KeyStore);
+
+    if (!DecryptSecret(vMasterKey, vchCiphertextIn, seedPubHash, seedOut))
+        return false;
+
+    return true;
+}

--- a/src/wallet/crypter.cpp
+++ b/src/wallet/crypter.cpp
@@ -293,19 +293,23 @@ bool CCryptoKeyStore::EncryptKeys(CKeyingMaterial& vMasterKeyIn)
     return true;
 }
 
-bool CCryptoKeyStore::EncryptSeed(const CKeyingMaterial& seedIn, const uint256& seedPubHash, std::vector<unsigned char> &vchCiphertext) const
+bool CCryptoKeyStore::EncryptSeed(CKeyingMaterial& vMasterKeyIn, const CKeyingMaterial& seedIn, const uint256& seedPubHash, std::vector<unsigned char> &vchCiphertext) const
 {
     LOCK(cs_KeyStore);
-    if (!EncryptSecret(vMasterKey, seedIn, seedPubHash, vchCiphertext))
+    CKeyingMaterial *masterKey = &vMasterKeyIn;
+
+    if (!vMasterKeyIn.size() && vMasterKey.size() > 0)
+        *masterKey = vMasterKey;
+
+    if (!EncryptSecret(*masterKey, seedIn, seedPubHash, vchCiphertext))
         return false;
 
     return true;
 }
 
-bool CCryptoKeyStore::DecryptSeed(const std::vector<unsigned char>& vchCiphertextIn, const uint256& seedPubHash, CKeyingMaterial& seedOut) const
+bool CCryptoKeyStore::DecryptSeed(CKeyingMaterial& vMasterKeyIn, const std::vector<unsigned char>& vchCiphertextIn, const uint256& seedPubHash, CKeyingMaterial& seedOut) const
 {
     LOCK(cs_KeyStore);
-
     if (!DecryptSecret(vMasterKey, vchCiphertextIn, seedPubHash, seedOut))
         return false;
 

--- a/src/wallet/crypter.h
+++ b/src/wallet/crypter.h
@@ -191,6 +191,9 @@ public:
      * Note: Called without locks held.
      */
     boost::signals2::signal<void (CCryptoKeyStore* wallet)> NotifyStatusChanged;
+
+    bool EncryptSeed(const CKeyingMaterial& seedIn, const uint256& seedPubHash, std::vector<unsigned char> &vchCiphertext) const;
+    bool DecryptSeed(const std::vector<unsigned char>& vchCiphertextIn, const uint256& seedPubHash, CKeyingMaterial& seedOut) const;
 };
 
 #endif // BITCOIN_WALLET_CRYPTER_H

--- a/src/wallet/crypter.h
+++ b/src/wallet/crypter.h
@@ -192,8 +192,8 @@ public:
      */
     boost::signals2::signal<void (CCryptoKeyStore* wallet)> NotifyStatusChanged;
 
-    bool EncryptSeed(const CKeyingMaterial& seedIn, const uint256& seedPubHash, std::vector<unsigned char> &vchCiphertext) const;
-    bool DecryptSeed(const std::vector<unsigned char>& vchCiphertextIn, const uint256& seedPubHash, CKeyingMaterial& seedOut) const;
+    bool EncryptSeed(CKeyingMaterial& vMasterKeyIn, const CKeyingMaterial& seedIn, const uint256& seedPubHash, std::vector<unsigned char> &vchCiphertext) const;
+    bool DecryptSeed(CKeyingMaterial& vMasterKeyIn, const std::vector<unsigned char>& vchCiphertextIn, const uint256& seedPubHash, CKeyingMaterial& seedOut) const;
 };
 
 #endif // BITCOIN_WALLET_CRYPTER_H

--- a/src/wallet/hdkeystore.cpp
+++ b/src/wallet/hdkeystore.cpp
@@ -16,8 +16,12 @@ bool CHDKeyStore::AddMasterSeed(const HDChainID& chainID, const CKeyingMaterial&
     LOCK(cs_KeyStore);
     if (IsCrypted())
     {
+        if (IsLocked())
+            return false;
+
         std::vector<unsigned char> vchCryptedSecret;
-        if (!EncryptSeed(masterSeed, chainID, vchCryptedSecret))
+        CKeyingMaterial emptyKey; //an empty key will tell EncryptSeed() to use the internal vMasterKey
+        if (!EncryptSeed(emptyKey, masterSeed, chainID, vchCryptedSecret))
             return false;
 
         mapHDCryptedMasterSeeds[chainID] = vchCryptedSecret;
@@ -48,12 +52,16 @@ bool CHDKeyStore::GetMasterSeed(const HDChainID& chainID, CKeyingMaterial& seedO
     }
     else
     {
+        if (IsLocked())
+            return false;
+
         std::map<HDChainID, std::vector<unsigned char> >::const_iterator it=mapHDCryptedMasterSeeds.find(chainID);
         if (it == mapHDCryptedMasterSeeds.end())
             return false;
 
         std::vector<unsigned char> vchCryptedSecret = it->second;
-        if (!DecryptSeed(vchCryptedSecret, chainID, seedOut))
+        CKeyingMaterial emptyKey; //an empty key will tell DecryptSeed() to use the internal vMasterKey
+        if (!DecryptSeed(emptyKey, vchCryptedSecret, chainID, seedOut))
             return false;
 
         return true;
@@ -61,17 +69,20 @@ bool CHDKeyStore::GetMasterSeed(const HDChainID& chainID, CKeyingMaterial& seedO
     return false;
 }
 
-bool CHDKeyStore::EncryptSeeds()
+bool CHDKeyStore::EncryptSeeds(CKeyingMaterial& vMasterKeyIn)
 {
     LOCK(cs_KeyStore);
     for (std::map<HDChainID, CKeyingMaterial >::iterator it = mapHDMasterSeeds.begin(); it != mapHDMasterSeeds.end(); ++it)
     {
         std::vector<unsigned char> vchCryptedSecret;
-        if (!EncryptSeed(it->second, it->first, vchCryptedSecret))
+        if (!EncryptSeed(vMasterKeyIn, it->second, it->first, vchCryptedSecret))
             return false;
         AddCryptedMasterSeed(it->first, vchCryptedSecret);
     }
     mapHDMasterSeeds.clear();
+    if (!SetCrypted())
+        return false;
+
     return true;
 }
 
@@ -89,7 +100,7 @@ bool CHDKeyStore::GetCryptedMasterSeed(const HDChainID& chainID, std::vector<uns
     return true;
 }
 
-bool CHDKeyStore::GetAvailableChainIDs(std::vector<HDChainID>& chainIDs)
+void CHDKeyStore::GetAvailableChainIDs(std::vector<HDChainID>& chainIDs)
 {
     LOCK(cs_KeyStore);
     chainIDs.clear();
@@ -106,8 +117,6 @@ bool CHDKeyStore::GetAvailableChainIDs(std::vector<HDChainID>& chainIDs)
             chainIDs.push_back(it->first);
         }
     }
-
-    return true;
 }
 
 bool CHDKeyStore::PrivateKeyDerivation(const std::string keypath, const HDChainID& chainID, CExtKey& extKeyOut) const
@@ -156,7 +165,7 @@ bool CHDKeyStore::PrivateKeyDerivation(const std::string keypath, const HDChainI
 
 bool CHDKeyStore::DeriveKey(const HDChainID chainID, const std::string keypath, CKey& keyOut) const
 {
-    //this methode required no locking
+    //this methode requires no locking
     CExtKey extKeyOut;
     if (!PrivateKeyDerivation(keypath, chainID, extKeyOut))
         return false;
@@ -172,7 +181,7 @@ bool CHDKeyStore::DeriveKeyAtIndex(const HDChainID chainID, CKey& keyOut, std::s
         return false;
 
     if (nIndex >= 0x80000000)
-        throw std::runtime_error("CHDKeyStore::DerivePubKeyAtIndex(): No more available keys!");
+        throw std::runtime_error("CHDKeyStore::DeriveKeyAtIndex(): No more available keys!");
 
     keypathOut = hdChain.keypathTemplate;
     boost::replace_all(keypathOut, "c", itostr(internal)); //replace the chain switch index
@@ -181,7 +190,7 @@ bool CHDKeyStore::DeriveKeyAtIndex(const HDChainID chainID, CKey& keyOut, std::s
 
     CExtKey extKeyOut;
     if (!PrivateKeyDerivation(keypathOut, chainID, extKeyOut))
-        throw std::runtime_error("CHDKeyStore::DerivePubKeyAtIndex(): Private Key Derivation failed!");
+        throw std::runtime_error("CHDKeyStore::DeriveKeyAtIndex(): Private Key Derivation failed!");
     keyOut = extKeyOut.key;
 
     return true;

--- a/src/wallet/hdkeystore.cpp
+++ b/src/wallet/hdkeystore.cpp
@@ -1,0 +1,247 @@
+// Copyright (c) 2015 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "wallet/hdkeystore.h"
+
+#include "base58.h"
+#include "util.h"
+#include "utilstrencodings.h"
+
+#include <boost/algorithm/string.hpp>
+#include <boost/foreach.hpp>
+
+bool CHDKeyStore::AddMasterSeed(const HDChainID& chainID, const CKeyingMaterial& masterSeed)
+{
+    LOCK(cs_KeyStore);
+    if (IsCrypted())
+    {
+        std::vector<unsigned char> vchCryptedSecret;
+        if (!EncryptSeed(masterSeed, chainID, vchCryptedSecret))
+            return false;
+
+        mapHDCryptedMasterSeeds[chainID] = vchCryptedSecret;
+        return true;
+    }
+    mapHDMasterSeeds[chainID] = masterSeed;
+    return true;
+}
+
+bool CHDKeyStore::AddCryptedMasterSeed(const HDChainID& chainID, const std::vector<unsigned char>& vchCryptedSecret)
+{
+    LOCK(cs_KeyStore);
+    mapHDCryptedMasterSeeds[chainID] = vchCryptedSecret;
+    return true;
+}
+
+bool CHDKeyStore::GetMasterSeed(const HDChainID& chainID, CKeyingMaterial& seedOut) const
+{
+    LOCK(cs_KeyStore);
+    if (!IsCrypted())
+    {
+        std::map<HDChainID, CKeyingMaterial >::const_iterator it=mapHDMasterSeeds.find(chainID);
+        if (it == mapHDMasterSeeds.end())
+            return false;
+
+        seedOut = it->second;
+        return true;
+    }
+    else
+    {
+        std::map<HDChainID, std::vector<unsigned char> >::const_iterator it=mapHDCryptedMasterSeeds.find(chainID);
+        if (it == mapHDCryptedMasterSeeds.end())
+            return false;
+
+        std::vector<unsigned char> vchCryptedSecret = it->second;
+        if (!DecryptSeed(vchCryptedSecret, chainID, seedOut))
+            return false;
+
+        return true;
+    }
+    return false;
+}
+
+bool CHDKeyStore::EncryptSeeds()
+{
+    LOCK(cs_KeyStore);
+    for (std::map<HDChainID, CKeyingMaterial >::iterator it = mapHDMasterSeeds.begin(); it != mapHDMasterSeeds.end(); ++it)
+    {
+        std::vector<unsigned char> vchCryptedSecret;
+        if (!EncryptSeed(it->second, it->first, vchCryptedSecret))
+            return false;
+        AddCryptedMasterSeed(it->first, vchCryptedSecret);
+    }
+    mapHDMasterSeeds.clear();
+    return true;
+}
+
+bool CHDKeyStore::GetCryptedMasterSeed(const HDChainID& chainID, std::vector<unsigned char>& vchCryptedSecret) const
+{
+    LOCK(cs_KeyStore);
+    if (!IsCrypted())
+        return false;
+
+    std::map<HDChainID, std::vector<unsigned char> >::const_iterator it=mapHDCryptedMasterSeeds.find(chainID);
+    if (it == mapHDCryptedMasterSeeds.end())
+        return false;
+
+    vchCryptedSecret = it->second;
+    return true;
+}
+
+bool CHDKeyStore::GetAvailableChainIDs(std::vector<HDChainID>& chainIDs)
+{
+    LOCK(cs_KeyStore);
+    chainIDs.clear();
+
+    if (IsCrypted())
+    {
+        for (std::map<HDChainID, std::vector<unsigned char> >::iterator it = mapHDCryptedMasterSeeds.begin(); it != mapHDCryptedMasterSeeds.end(); ++it) {
+            chainIDs.push_back(it->first);
+        }
+    }
+    else
+    {
+        for (std::map<HDChainID, CKeyingMaterial >::iterator it = mapHDMasterSeeds.begin(); it != mapHDMasterSeeds.end(); ++it) {
+            chainIDs.push_back(it->first);
+        }
+    }
+
+    return true;
+}
+
+bool CHDKeyStore::PrivateKeyDerivation(const std::string keypath, const HDChainID& chainID, CExtKey& extKeyOut) const
+{
+    std::vector<std::string> pathFragments;
+    boost::split(pathFragments, keypath, boost::is_any_of("/"));
+
+    CExtKey extKey;
+    CExtKey parentKey;
+    BOOST_FOREACH(std::string fragment, pathFragments)
+    {
+        bool harden = false;
+        if (*fragment.rbegin() == '\'' || *fragment.rbegin() == 'h')
+        {
+            harden = true;
+            fragment = fragment.substr(0,fragment.size()-1);
+        }
+
+        if (fragment == "m")
+        {
+            CExtKey bip32MasterKey;
+            CKeyingMaterial masterSeed;
+
+            // get master seed
+            if (!GetMasterSeed(chainID, masterSeed))
+                return false;
+
+            bip32MasterKey.SetMaster(&masterSeed[0], masterSeed.size());
+            parentKey = bip32MasterKey;
+        }
+        else if (fragment == "c")
+            return false;
+        else
+        {
+            CExtKey childKey;
+            int32_t nIndex;
+            if (!ParseInt32(fragment,&nIndex))
+                return false;
+            parentKey.Derive(childKey, (harden ? 0x80000000 : 0)+nIndex);
+            parentKey = childKey;
+        }
+    }
+    extKeyOut = parentKey;
+    return true;
+}
+
+bool CHDKeyStore::DeriveKey(const HDChainID chainID, const std::string keypath, CKey& keyOut) const
+{
+    //this methode required no locking
+    CExtKey extKeyOut;
+    if (!PrivateKeyDerivation(keypath, chainID, extKeyOut))
+        return false;
+
+    keyOut = extKeyOut.key;
+    return true;
+}
+
+bool CHDKeyStore::DeriveKeyAtIndex(const HDChainID chainID, CKey& keyOut, std::string& keypathOut, unsigned int nIndex, bool internal) const
+{
+    CHDChain hdChain;
+    if (!GetChain(chainID, hdChain))
+        return false;
+
+    if (nIndex >= 0x80000000)
+        throw std::runtime_error("CHDKeyStore::DerivePubKeyAtIndex(): No more available keys!");
+
+    keypathOut = hdChain.keypathTemplate;
+    boost::replace_all(keypathOut, "c", itostr(internal)); //replace the chain switch index
+
+    keypathOut += "/"+itostr(nIndex)+"'"; //add hardened flag
+
+    CExtKey extKeyOut;
+    if (!PrivateKeyDerivation(keypathOut, chainID, extKeyOut))
+        throw std::runtime_error("CHDKeyStore::DerivePubKeyAtIndex(): Private Key Derivation failed!");
+    keyOut = extKeyOut.key;
+
+    return true;
+}
+
+unsigned int CHDKeyStore::GetNextChildIndex(const HDChainID& chainID, bool internal)
+{
+    std::vector<unsigned int> vIndices;
+
+    {
+        LOCK(cs_KeyStore);
+
+        CHDChain hdChain;
+        if (!GetChain(chainID, hdChain))
+            return false;
+
+        std::string keypathBase = hdChain.keypathTemplate;
+        boost::replace_all(keypathBase, "c", itostr(internal)); //replace the chain switch index
+
+        //get next unused child index
+        for (std::map<CKeyID, CKeyMetadata>::iterator it = mapKeyMetadata.begin(); it != mapKeyMetadata.end(); ++it)
+        {
+            //skip non hd keys
+            if (it->second.keypath.size() == 0)
+                continue;
+
+            std::string keysBaseKeypath = it->second.keypath.substr(0, it->second.keypath.find_last_of("/"));
+            std::string childStr = it->second.keypath.substr(it->second.keypath.find_last_of("/") + 1);
+            boost::erase_all(childStr, "'");
+            int32_t nChild;
+            if(it->second.chainID == chainID &&
+               it->second.keypath.substr(0, it->second.keypath.find_last_of("/")) == keypathBase &&
+               ParseInt32(childStr, &nChild))
+            {
+                vIndices.push_back(nChild);
+            }
+        }
+    }
+
+    for (unsigned int i=0;i<0x80000000;i++)
+        if (std::find(vIndices.begin(), vIndices.end(), i) == vIndices.end())
+            return i;
+
+    return 0;
+}
+
+bool CHDKeyStore::AddHDChain(const CHDChain& chain)
+{
+    LOCK(cs_KeyStore);
+    mapChains[chain.chainID] = chain;
+    return true;
+}
+
+bool CHDKeyStore::GetChain(const HDChainID chainID, CHDChain& chainOut) const
+{
+    LOCK(cs_KeyStore);
+    std::map<HDChainID, CHDChain>::const_iterator it=mapChains.find(chainID);
+    if (it == mapChains.end())
+        return false;
+
+    chainOut = it->second;
+    return true;
+}

--- a/src/wallet/hdkeystore.h
+++ b/src/wallet/hdkeystore.h
@@ -1,0 +1,156 @@
+// Copyright (c) 2015 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_WALLET_HDKEYSTORE_H
+#define BITCOIN_WALLET_HDKEYSTORE_H
+
+#include "keystore.h"
+#include "wallet/crypter.h"
+#include "serialize.h"
+#include "pubkey.h"
+
+typedef uint256 HDChainID;
+
+class CKeyMetadata
+{
+public:
+    static const int CURRENT_VERSION=2;
+    int nVersion;
+    int64_t nCreateTime; // 0 means unknown
+    HDChainID chainID;
+    std::string keypath;
+
+    CKeyMetadata()
+    {
+        SetNull();
+    }
+    CKeyMetadata(int64_t nCreateTime_)
+    {
+        nVersion = CKeyMetadata::CURRENT_VERSION;
+        nCreateTime = nCreateTime_;
+    }
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
+        READWRITE(this->nVersion);
+        nVersion = this->nVersion;
+        READWRITE(nCreateTime);
+        if (nVersion >= 2)
+        {
+            READWRITE(keypath);
+            if (keypath.size() > 0)
+                READWRITE(chainID);
+        }
+    }
+
+    void SetNull()
+    {
+        nVersion = CKeyMetadata::CURRENT_VERSION;
+        nCreateTime = 0;
+        keypath.clear();
+        chainID.SetNull();
+    }
+};
+
+/** class for representing a hd chain of keys. */
+class CHDChain
+{
+public:
+    static const int CURRENT_VERSION=1;
+    int nVersion;
+    bool usePubCKD;
+    int64_t nCreateTime; // 0 means unknown
+
+    HDChainID chainID; //hash of the masterpubkey
+    std::string keypathTemplate; //example "m'/44'/0'/0'/c"
+
+    CHDChain()
+    {
+        SetNull();
+    }
+
+    CHDChain(int64_t nCreateTime_)
+    {
+        SetNull();
+        nCreateTime = nCreateTime_;
+    }
+
+    bool IsValid()
+    {
+        return (keypathTemplate.size() > 0);
+    }
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
+        READWRITE(this->nVersion);
+        nVersion = this->nVersion;
+
+        READWRITE(nCreateTime);
+        READWRITE(chainID);
+        READWRITE(keypathTemplate);
+    }
+
+    void SetNull()
+    {
+        nVersion = CHDChain::CURRENT_VERSION;
+        nCreateTime = 0;
+        chainID.SetNull();
+        keypathTemplate.clear();
+    }
+};
+
+class CHDKeyStore : public CCryptoKeyStore
+{
+protected:
+    std::map<HDChainID, CKeyingMaterial > mapHDMasterSeeds; //master seeds are stored outside of CHDChain (mind crypting)
+    std::map<HDChainID, std::vector<unsigned char> > mapHDCryptedMasterSeeds;
+    std::map<HDChainID, CHDChain> mapChains; //all available chains
+
+    //!private key derivition of a ext priv key
+    bool PrivateKeyDerivation(const std::string chainPath, const HDChainID& chainID, CExtKey& extKeyOut) const;
+
+    //!derive key from a CHDPubKey object
+    bool DeriveKey(const HDChainID chainID, const std::string keypath, CKey& keyOut) const;
+
+public:
+    std::map<CKeyID, CKeyMetadata> mapKeyMetadata;
+
+    //!add a master seed with a given pubkeyhash (memory only)
+    virtual bool AddMasterSeed(const HDChainID& chainID, const CKeyingMaterial& masterSeed);
+
+    //!add a crypted master seed with a given pubkeyhash (memory only)
+    virtual bool AddCryptedMasterSeed(const HDChainID& chainID, const std::vector<unsigned char>& vchCryptedSecret);
+
+    //!encrypt existing uncrypted seeds and remove unencrypted data
+    virtual bool EncryptSeeds();
+
+    //!export the master seed from a given chain id (hash of the master pub key)
+    virtual bool GetMasterSeed(const HDChainID& chainID, CKeyingMaterial& seedOut) const;
+
+    //!get the encrypted master seed of a giveb chain id
+    virtual bool GetCryptedMasterSeed(const HDChainID& chainID, std::vector<unsigned char>& vchCryptedSecret) const;
+
+    //!writes all available chain ids to a vector
+    virtual bool GetAvailableChainIDs(std::vector<HDChainID>& chainIDs);
+
+    //!add a new chain to the keystore (memory only)
+    bool AddHDChain(const CHDChain& chain);
+
+    //!writes a chain defined by given chainId to chainOut, returns false if not found
+    bool GetChain(const HDChainID chainID, CHDChain& chainOut) const;
+
+    //!Derives a key at index in the given hd chain (defined by chainId) 
+    bool DeriveKeyAtIndex(const HDChainID chainID, CKey& keyOut, std::string& keypathOut, unsigned int nIndex, bool internal) const;
+    /**
+     * Get next available index for a child key in chain defined by given chain id
+     * @return next available index
+     * @warning This will "fill gaps". If you have m/0/0, m/0/1, m/0/2, m/0/100 it will return 3 (m/0/3)
+     */
+    unsigned int GetNextChildIndex(const HDChainID& chainID, bool internal);
+};
+#endif // BITCOIN_WALLET_HDKEYSTORE_H

--- a/src/wallet/test/hdkeystore_tests.cpp
+++ b/src/wallet/test/hdkeystore_tests.cpp
@@ -1,0 +1,99 @@
+// Copyright (c) 2012-2014 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "wallet/wallet.h"
+#include "base58.h"
+
+#include <set>
+#include <stdint.h>
+#include <utility>
+#include <vector>
+
+#include "test/test_bitcoin.h"
+
+#include <boost/foreach.hpp>
+#include <boost/test/unit_test.hpp>
+
+extern CWallet* pwalletMain;
+
+BOOST_FIXTURE_TEST_SUITE(hdkeystore_tests, TestingSetup)
+
+
+BOOST_AUTO_TEST_CASE(hdkeystore_tests)
+{
+    LOCK(pwalletMain->cs_wallet);
+
+    // create a master key
+    CHDChain chain;
+    chain.keypathTemplate = "m/c'";
+    std::vector<unsigned char> vSeed = ParseHex("9886e45b8435b488a4cb753121db41a07f66a6a73e0a705ce24cee3a3bce87db");
+    CKeyingMaterial seed = CKeyingMaterial(32);
+    seed.assign(vSeed.front(), vSeed.back());
+
+    CExtKey masterKey;
+    masterKey.SetMaster(&seed[0], seed.size());
+    CBitcoinExtKey masterXPriv;
+    masterXPriv.SetKey(masterKey);
+    BOOST_CHECK(masterXPriv.ToString() == "xprv9s21ZrQH143K3p7CoBzQ9XPGDfaK8YHfuy11V3tGCG715SX1FYhZRP4rqCDKryZDiFtcvfr9A9aQCSioUTScA6reJktbLqEW6soRZfyZqU9");
+
+    // set the chain hash
+    CExtPubKey masterPubKey = masterKey.Neuter();
+    chain.chainID = masterPubKey.pubkey.GetHash();
+
+    // store the chain
+    pwalletMain->AddHDChain(chain);
+    pwalletMain->AddMasterSeed(chain.chainID, seed);
+
+    // create some keys
+    CKey newKey;
+    std::string keypath;
+    pwalletMain->DeriveKeyAtIndex(chain.chainID, newKey, keypath, 0, false);
+    // we should still be at index0 (key was not added to the wallet)
+    BOOST_CHECK(pwalletMain->GetNextChildIndex(chain.chainID, false) == 0);
+
+    CKeyMetadata metaData(GetTime());
+    metaData.keypath = keypath;
+    metaData.chainID = chain.chainID;
+    pwalletMain->mapKeyMetadata[newKey.GetPubKey().GetID()] = metaData;
+    pwalletMain->AddKeyPubKey(newKey, newKey.GetPubKey());
+    // now the key was added, next index should be 1
+    BOOST_CHECK(pwalletMain->GetNextChildIndex(chain.chainID, false) == 1);
+    BOOST_CHECK(CBitcoinAddress(newKey.GetPubKey().GetID()).ToString() == "1AFW8Aq7jXmtqLHjicMtov56FRBeYqSHj7");
+
+    pwalletMain->DeriveKeyAtIndex(chain.chainID, newKey, keypath, pwalletMain->GetNextChildIndex(chain.chainID, false), false);
+    metaData = CKeyMetadata(GetTime());
+    metaData.keypath = keypath;
+    metaData.chainID = chain.chainID;
+    pwalletMain->mapKeyMetadata[newKey.GetPubKey().GetID()] = metaData;
+    pwalletMain->AddKeyPubKey(newKey, newKey.GetPubKey());
+    BOOST_CHECK(pwalletMain->GetNextChildIndex(chain.chainID, false) == 2);
+    BOOST_CHECK(CBitcoinAddress(newKey.GetPubKey().GetID()).ToString() == "1JCWakvgoCcKHLydjrbFqeAM1vyF36sRe8");
+
+    // derive internal/change key
+    BOOST_CHECK(pwalletMain->GetNextChildIndex(chain.chainID, true) == 0); //no internal key should be there
+    pwalletMain->DeriveKeyAtIndex(chain.chainID, newKey, keypath, pwalletMain->GetNextChildIndex(chain.chainID, true), true);
+    metaData = CKeyMetadata(GetTime());
+    metaData.keypath = keypath;
+    metaData.chainID = chain.chainID;
+    pwalletMain->mapKeyMetadata[newKey.GetPubKey().GetID()] = metaData;
+    pwalletMain->AddKeyPubKey(newKey, newKey.GetPubKey());
+    BOOST_CHECK(pwalletMain->GetNextChildIndex(chain.chainID, true) == 1);
+    BOOST_CHECK(CBitcoinAddress(newKey.GetPubKey().GetID()).ToString() == "1HbQusfqAYSUEBqVfHzhasVqGatn6Jjqwq");
+
+    pwalletMain->EncryptSeeds();
+    BOOST_CHECK(pwalletMain->HaveKey(newKey.GetPubKey().GetID()) == true);
+
+    CKey keyTest;
+    pwalletMain->GetKey(newKey.GetPubKey().GetID(), keyTest);
+    BOOST_CHECK(CBitcoinSecret(keyTest).ToString() == "L1igds57v39YDHZ1LirRZQkRiikPkPCECiDarFaiYxJ6JSyhXLn6"); //m/1'/0'
+
+//
+//    CPubKey pkey = pwalletMain->GenerateNewKey();
+//    std::string test23 = CBitcoinAddress(pkey.GetID()).ToString();
+//
+//    BOOST_CHECK(CBitcoinAddress(pkey.GetID()).ToString() == "1PEzTQaYAqcnLR6Ug23pzFqTEakBttFrgo");
+//    BOOST_CHECK(pwalletMain->GetNextChildIndex(chain.chainID, false) == 3);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet/test/hdkeystore_tests.cpp
+++ b/src/wallet/test/hdkeystore_tests.cpp
@@ -4,6 +4,7 @@
 
 #include "wallet/wallet.h"
 #include "base58.h"
+#include "random.h"
 
 #include <set>
 #include <stdint.h>
@@ -44,6 +45,7 @@ BOOST_AUTO_TEST_CASE(hdkeystore_tests)
     // store the chain
     pwalletMain->AddHDChain(chain);
     pwalletMain->AddMasterSeed(chain.chainID, seed);
+    pwalletMain->SetActiveHDChainID(chain.chainID);
 
     // create some keys
     CKey newKey;
@@ -81,19 +83,18 @@ BOOST_AUTO_TEST_CASE(hdkeystore_tests)
     BOOST_CHECK(pwalletMain->GetNextChildIndex(chain.chainID, true) == 1);
     BOOST_CHECK(CBitcoinAddress(newKey.GetPubKey().GetID()).ToString() == "1HbQusfqAYSUEBqVfHzhasVqGatn6Jjqwq");
 
-    pwalletMain->EncryptSeeds();
     BOOST_CHECK(pwalletMain->HaveKey(newKey.GetPubKey().GetID()) == true);
 
     CKey keyTest;
-    pwalletMain->GetKey(newKey.GetPubKey().GetID(), keyTest);
+    BOOST_CHECK(pwalletMain->GetKey(newKey.GetPubKey().GetID(), keyTest));
     BOOST_CHECK(CBitcoinSecret(keyTest).ToString() == "L1igds57v39YDHZ1LirRZQkRiikPkPCECiDarFaiYxJ6JSyhXLn6"); //m/1'/0'
 
-//
-//    CPubKey pkey = pwalletMain->GenerateNewKey();
-//    std::string test23 = CBitcoinAddress(pkey.GetID()).ToString();
-//
-//    BOOST_CHECK(CBitcoinAddress(pkey.GetID()).ToString() == "1PEzTQaYAqcnLR6Ug23pzFqTEakBttFrgo");
-//    BOOST_CHECK(pwalletMain->GetNextChildIndex(chain.chainID, false) == 3);
+
+    CPubKey pkey = pwalletMain->GenerateNewKey();
+    std::string test23 = CBitcoinAddress(pkey.GetID()).ToString();
+
+    BOOST_CHECK(CBitcoinAddress(pkey.GetID()).ToString() == "1PEzTQaYAqcnLR6Ug23pzFqTEakBttFrgo");
+    BOOST_CHECK(pwalletMain->GetNextChildIndex(chain.chainID, false) == 3);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -55,6 +55,7 @@ static const unsigned int DEFAULT_TX_CONFIRM_TARGET = 2;
 //! Largest (in bytes) free transaction we're willing to create
 static const unsigned int MAX_FREE_TRANSACTION_CREATE_SIZE = 1000;
 static const bool DEFAULT_WALLETBROADCAST = true;
+static const bool DEFAULT_USE_HD_WALLET = true;
 
 extern const char * DEFAULT_WALLET_DAT;
 
@@ -73,8 +74,9 @@ enum WalletFeature
 
     FEATURE_WALLETCRYPT = 40000, // wallet encryption
     FEATURE_COMPRPUBKEY = 60000, // compressed public keys
+    FEATURE_HD          = 70000, // hd keys
 
-    FEATURE_LATEST = 60000
+    FEATURE_LATEST = 70000
 };
 
 
@@ -593,6 +595,9 @@ public:
     MasterKeyMap mapMasterKeys;
     unsigned int nMasterKeyMaxID;
 
+    //! current active hd chain
+    HDChainID activeHDChain;
+
     CWallet()
     {
         SetNull();
@@ -874,6 +879,16 @@ public:
 
     /* Returns the wallets help message */
     static std::string GetWalletHelpString(bool showDebug);
+
+    /** HD functions */
+    //! Adds a master seed the the in-mem map (store it in the db if memonly == false)
+    bool AddMasterSeed(const HDChainID& chainID, const CKeyingMaterial& masterSeed, bool memonly = false);
+    //! Adds a new HD keychain
+    bool AddHDChain(const CHDChain& chain, bool memonly = false);
+    //! Encrypt the HD seeds
+    bool EncryptHDSeeds(CKeyingMaterial& vMasterKeyIn);
+    bool SetActiveHDChainID(const HDChainID& chainID, bool check = true, bool memonly = false);
+    bool GetActiveHDChainID(HDChainID& chainID);
 };
 
 /** A key allocated from the key pool. */

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -13,6 +13,7 @@
 #include "utilstrencodings.h"
 #include "validationinterface.h"
 #include "wallet/crypter.h"
+#include "wallet/hdkeystore.h"
 #include "wallet/wallet_ismine.h"
 #include "wallet/walletdb.h"
 #include "wallet/rpcwallet.h"
@@ -536,7 +537,7 @@ private:
  * A CWallet is an extension of a keystore, which also maintains a set of transactions and balances,
  * and provides the ability to create new transactions.
  */
-class CWallet : public CCryptoKeyStore, public CValidationInterface
+class CWallet : public CHDKeyStore, public CValidationInterface
 {
 private:
     /**
@@ -587,7 +588,6 @@ public:
     std::string strWalletFile;
 
     std::set<int64_t> setKeyPool;
-    std::map<CKeyID, CKeyMetadata> mapKeyMetadata;
 
     typedef std::map<unsigned int, CMasterKey> MasterKeyMap;
     MasterKeyMap mapMasterKeys;

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -599,6 +599,38 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
                 return false;
             }
         }
+        else if (strType == "hdmasterseed")
+        {
+            uint256 masterPubKeyHash;
+            CKeyingMaterial masterSeed;
+            ssKey >> masterPubKeyHash;
+            ssValue >> masterSeed;
+            pwallet->AddMasterSeed(masterPubKeyHash, masterSeed);
+        }
+        else if (strType == "hdcryptedmasterseed")
+        {
+            uint256 masterPubKeyHash;
+            std::vector<unsigned char> vchCryptedSecret;
+            ssKey >> masterPubKeyHash;
+            ssValue >> vchCryptedSecret;
+            pwallet->AddCryptedMasterSeed(masterPubKeyHash, vchCryptedSecret);
+        }
+        else if (strType == "hdactivechain")
+        {
+            HDChainID chainID;
+            ssValue >> chainID;
+            pwallet->SetActiveHDChainID(chainID, false, true); //don't check if the chain exists because this record could come in before the CHDChain object itself
+        }
+        else if (strType == "hdchain")
+        {
+            CHDChain chain;
+            ssValue >> chain;
+            if (!pwallet->AddHDChain(chain, true))
+            {
+                strErr = "Error reading wallet database: AddChain failed";
+                return false;
+            }
+        }
     } catch (...)
     {
         return false;
@@ -1003,4 +1035,40 @@ bool CWalletDB::EraseDestData(const std::string &address, const std::string &key
 {
     nWalletDBUpdated++;
     return Erase(std::make_pair(std::string("destdata"), std::make_pair(address, key)));
+}
+
+bool CWalletDB::WriteHDMasterSeed(const uint256& hash, const CKeyingMaterial& masterSeed)
+{
+    nWalletDBUpdated++;
+    return Write(std::make_pair(std::string("hdmasterseed"), hash), masterSeed);
+}
+
+bool CWalletDB::WriteHDCryptedMasterSeed(const uint256& hash, const std::vector<unsigned char>& vchCryptedSecret)
+{
+    nWalletDBUpdated++;
+    if (!Write(std::make_pair(std::string("hdcryptedmasterseed"), hash), vchCryptedSecret))
+        return false;
+
+    Erase(std::make_pair(std::string("hdmasterseed"), hash));
+    Erase(std::make_pair(std::string("hdmasterseed"), hash));
+
+    return true;
+}
+
+bool CWalletDB::EraseHDMasterSeed(const uint256& hash)
+{
+    nWalletDBUpdated++;
+    return Erase(std::make_pair(std::string("hdmasterseed"), hash));
+}
+
+bool CWalletDB::WriteHDChain(const CHDChain &chain)
+{
+    nWalletDBUpdated++;
+    return Write(std::make_pair(std::string("hdchain"), chain.chainID), chain);
+}
+
+bool CWalletDB::WriteHDAchiveChain(const uint256& hash)
+{
+    nWalletDBUpdated++;
+    return Write(std::string("hdactivechain"), hash);
 }

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -605,7 +605,7 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
             CKeyingMaterial masterSeed;
             ssKey >> masterPubKeyHash;
             ssValue >> masterSeed;
-            pwallet->AddMasterSeed(masterPubKeyHash, masterSeed);
+            pwallet->AddMasterSeed(masterPubKeyHash, masterSeed, true);
         }
         else if (strType == "hdcryptedmasterseed")
         {
@@ -1050,8 +1050,6 @@ bool CWalletDB::WriteHDCryptedMasterSeed(const uint256& hash, const std::vector<
         return false;
 
     Erase(std::make_pair(std::string("hdmasterseed"), hash));
-    Erase(std::make_pair(std::string("hdmasterseed"), hash));
-
     return true;
 }
 
@@ -1067,7 +1065,7 @@ bool CWalletDB::WriteHDChain(const CHDChain &chain)
     return Write(std::make_pair(std::string("hdchain"), chain.chainID), chain);
 }
 
-bool CWalletDB::WriteHDAchiveChain(const uint256& hash)
+bool CWalletDB::WriteHDActiveChain(const uint256& hash)
 {
     nWalletDBUpdated++;
     return Write(std::string("hdactivechain"), hash);

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -101,6 +101,13 @@ public:
     static bool Recover(CDBEnv& dbenv, const std::string& filename, bool fOnlyKeys);
     static bool Recover(CDBEnv& dbenv, const std::string& filename);
 
+    /* HD functions */
+    bool WriteHDMasterSeed(const uint256& hash, const CKeyingMaterial& masterSeed);
+    bool WriteHDCryptedMasterSeed(const uint256& hash, const std::vector<unsigned char>& vchCryptedSecret);
+    bool EraseHDMasterSeed(const uint256& hash);
+    bool WriteHDChain(const CHDChain& chain);
+    bool WriteHDAchiveChain(const uint256& hash);
+
 private:
     CWalletDB(const CWalletDB&);
     void operator=(const CWalletDB&);

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -106,7 +106,7 @@ public:
     bool WriteHDCryptedMasterSeed(const uint256& hash, const std::vector<unsigned char>& vchCryptedSecret);
     bool EraseHDMasterSeed(const uint256& hash);
     bool WriteHDChain(const CHDChain& chain);
-    bool WriteHDAchiveChain(const uint256& hash);
+    bool WriteHDActiveChain(const uint256& hash);
 
 private:
     CWalletDB(const CWalletDB&);

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -8,6 +8,7 @@
 
 #include "amount.h"
 #include "wallet/db.h"
+#include "wallet/hdkeystore.h"
 #include "key.h"
 
 #include <list>
@@ -38,39 +39,6 @@ enum DBErrors
     DB_TOO_NEW,
     DB_LOAD_FAIL,
     DB_NEED_REWRITE
-};
-
-class CKeyMetadata
-{
-public:
-    static const int CURRENT_VERSION=1;
-    int nVersion;
-    int64_t nCreateTime; // 0 means unknown
-
-    CKeyMetadata()
-    {
-        SetNull();
-    }
-    CKeyMetadata(int64_t nCreateTime_)
-    {
-        nVersion = CKeyMetadata::CURRENT_VERSION;
-        nCreateTime = nCreateTime_;
-    }
-
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
-        READWRITE(this->nVersion);
-        nVersion = this->nVersion;
-        READWRITE(nCreateTime);
-    }
-
-    void SetNull()
-    {
-        nVersion = CKeyMetadata::CURRENT_VERSION;
-        nCreateTime = 0;
-    }
 };
 
 /** Access to the wallet database (wallet.dat) */


### PR DESCRIPTION
Most simplest HD feature.
- Use BIP32/hd key derivation by default for new wallets (m/0'/0')
- Only private key derivation is supported (no pubkey-only-wallets for now)
- No on the fly generation of private keys (keypools get still refilled, all derived private keys are touching the database, but deterministic)
- Internal support for multiple hd keychains (potential allows simple key rotation feature)
- Supports encrypted wallets
- RPC- and unit-tests included
- Currently now way to create a hd keychain for existing wallets (upcoming feature if/once this got merged)

**ment as a starting point, have concrete plans to extend this, but don't want to overload this PR**

`getnewaddress "" true` (last parameter `true` = "show details") returns an object if the new address was hd derived:

``` JSON
{
  "address": "n1EU7TC4YqVYGQYy5eav1APHhS3z3Jrgf4",
  "keypath": "m/0'/230'"
}
```

(same for `getaddressesbyaccount`)
