### PR TITLE
Report non-mandatory script failures correctly

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1653,9 +1653,9 @@ bool CheckInputs(const CTransaction& tx, CValidationState &state, const CCoinsVi
                         // arguments; if so, don't trigger DoS protection to
                         // avoid splitting the network between upgraded and
                         // non-upgraded nodes.
-                        CScriptCheck check(*coins, tx, i,
+                        CScriptCheck check2(*coins, tx, i,
                                 flags & ~STANDARD_NOT_MANDATORY_VERIFY_FLAGS, cacheStore);
-                        if (check())
+                        if (check2())
                             return state.Invalid(false, REJECT_NONSTANDARD, strprintf("non-mandatory-script-verify-flag (%s)", ScriptErrorString(check.GetScriptError())));
                     }
                     // Failures of other flags indicate a transaction that is


### PR DESCRIPTION
The same variable was reused for mandatory checking of script failures, so the reported error is always "No error". Use a new variable check2 so we don't overwrite the message produced by the first.
