### PR TITLE
[travis] Fail when documentation is outdated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,5 +70,6 @@ script:
     - export LD_LIBRARY_PATH=$TRAVIS_BUILD_DIR/depends/$HOST/lib
     - if [ "$RUN_TESTS" = "true" ]; then make check; fi
     - if [ "$RUN_TESTS" = "true" ]; then qa/pull-tester/rpc-tests.py --coverage; fi
+    - if [ "$RUN_TESTS" = "true" ]; then contrib/devtools/check-doc.py; fi
 after_script:
     - if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then (echo "Upload goes here. Something like: scp -r $BASE_OUTDIR server" || echo "upload failed"); fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,12 +64,12 @@ script:
     - test -n "$USE_SHELL" && eval '"$USE_SHELL" -c "./autogen.sh"' || ./autogen.sh
     - ./configure --cache-file=config.cache $BITCOIN_CONFIG_ALL $BITCOIN_CONFIG || ( cat config.log && false)
     - make distdir PACKAGE=bitcoin VERSION=$HOST
+    - if [ "$RUN_TESTS" = "true" ]; then contrib/devtools/check-doc.py; fi
     - cd bitcoin-$HOST
     - ./configure --cache-file=../config.cache $BITCOIN_CONFIG_ALL $BITCOIN_CONFIG || ( cat config.log && false)
     - make $MAKEJOBS $GOAL || ( echo "Build failure. Verbose build follows." && make $GOAL V=1 ; false )
     - export LD_LIBRARY_PATH=$TRAVIS_BUILD_DIR/depends/$HOST/lib
     - if [ "$RUN_TESTS" = "true" ]; then make check; fi
     - if [ "$RUN_TESTS" = "true" ]; then qa/pull-tester/rpc-tests.py --coverage; fi
-    - if [ "$RUN_TESTS" = "true" ]; then contrib/devtools/check-doc.py; fi
 after_script:
     - if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then (echo "Upload goes here. Something like: scp -r $BASE_OUTDIR server" || echo "upload failed"); fi

--- a/contrib/devtools/README.md
+++ b/contrib/devtools/README.md
@@ -2,6 +2,12 @@ Contents
 ========
 This directory contains tools for developers working on this repository.
 
+check-doc.py
+============
+
+Check if all command line args are documented. The return value indicates the
+number of undocumented args.
+
 clang-format.py
 ===============
 

--- a/contrib/devtools/check-doc.py
+++ b/contrib/devtools/check-doc.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2014 The Bitcoin Core developers
+# Copyright (c) 2015 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/contrib/devtools/check-doc.py
+++ b/contrib/devtools/check-doc.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+# Copyright (c) 2014 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+'''
+This checks if all command line args are documented.
+Return value is 0 to indicate no error.
+
+Author: @MarcoFalke
+'''
+
+from subprocess import check_output
+import re
+
+FOLDER_GREP = 'src'
+FOLDER_TEST = 'src/test/'
+CMD_ROOT_DIR = '`git rev-parse --show-toplevel`/%s' % FOLDER_GREP
+CMD_GREP_ARGS = r"egrep -r -I '(map(Multi)?Args(\.count\(|\[)|Get(Bool)?Arg\()\"\-[^\"]+?\"' %s | grep -v '%s'" % (CMD_ROOT_DIR, FOLDER_TEST)
+CMD_GREP_DOCS = r"egrep -r -I 'HelpMessageOpt\(\"\-[^\"=]+?(=|\")' %s" % (CMD_ROOT_DIR)
+REGEX_ARG = re.compile(r'(?:map(?:Multi)?Args(?:\.count\(|\[)|Get(?:Bool)?Arg\()\"(\-[^\"]+?)\"')
+REGEX_DOC = re.compile(r'HelpMessageOpt\(\"(\-[^\"=]+?)(?:=|\")')
+# list unsupported, deprecated and duplicate args as they need no documentation
+SET_DOC_OPTIONAL = set(['-rpcssl', '-benchmark', '-h', '-help', '-socks', '-tor', '-debugnet'])
+
+def main():
+  used = check_output(CMD_GREP_ARGS, shell=True)
+  docd = check_output(CMD_GREP_DOCS, shell=True)
+
+  args_used = set(re.findall(REGEX_ARG,used))
+  args_docd = set(re.findall(REGEX_DOC,docd)).union(SET_DOC_OPTIONAL)
+  args_need_doc = args_used.difference(args_docd)
+  args_unknown = args_docd.difference(args_used)
+
+  print "Args used        : %s" % len(args_used)
+  print "Args documented  : %s" % len(args_docd)
+  print "Args undocumented: %s" % len(args_need_doc)
+  print args_need_doc
+  print "Args unknown     : %s" % len(args_unknown)
+  print args_unknown
+
+  exit(len(args_need_doc))
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This checks if all command line args are documented in the help message.

Example output:

```
$ qa/pull-tester/check-doc.py 
Args used        : 144
Args documented  : 133
Args undocumented: 15
set(['-uacomment', '-nodebug', '-rpcssl', '-rpccookiefile', '-checkblockindex', '-benchmark', '-help', '-version', '-h', '-checkmempool', '-mocktime', '-maptxfee', '-tor', '-socks', '-debugnet'])
Args unknown     : 4
set(['-zmqpubrawblock', '-zmqpubhashtx', '-zmqpubrawtx', '-zmqpubhashblock'])
$ echo $?
15
```
