### PR TITLE
 [wallet] Add regression test for vValue sort order 

### DIFF
--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -328,7 +328,7 @@ BOOST_AUTO_TEST_CASE(coin_selection_tests)
     empty_wallet();
 }
 
-BOOST_AUTO_TEST_CASE(sorting_in_ApproximateBestSet)
+BOOST_AUTO_TEST_CASE(ApproximateBestSubset)
 {
     CoinSet setCoinsRet;
     CAmount nValueRet;
@@ -336,7 +336,8 @@ BOOST_AUTO_TEST_CASE(sorting_in_ApproximateBestSet)
     LOCK(wallet.cs_wallet);
 
     empty_wallet();
-    
+
+    // Test vValue sort order
     for (int i = 0; i < 1000; i++)
         add_coin(1000 * COIN);
     add_coin(3 * COIN);
@@ -344,25 +345,19 @@ BOOST_AUTO_TEST_CASE(sorting_in_ApproximateBestSet)
     BOOST_CHECK(wallet.SelectCoinsMinConf(1003 * COIN, 1, 6, vCoins, setCoinsRet, nValueRet));
     BOOST_CHECK_EQUAL(nValueRet, 1003 * COIN);
     BOOST_CHECK_EQUAL(setCoinsRet.size(), 2U);
-}
-
-BOOST_AUTO_TEST_CASE(pruning_in_ApproximateBestSet)
-{
-    CoinSet setCoinsRet;
-    CAmount nValueRet;
-
-    LOCK(wallet.cs_wallet);
 
     empty_wallet();
-    for (int i = 0; i < 100; i++)
-        add_coin(10 * CENT);
-    for (int i = 0; i < 100; i++)
-        add_coin(1000 * CENT);
 
-    BOOST_CHECK(wallet.SelectCoinsMinConf(100001 * CENT, 1, 6, vCoins, setCoinsRet, nValueRet));
+    // Test trimming
+    for (int i = 0; i < 100; i++)
+        add_coin(10 * COIN);
+    for (int i = 0; i < 100; i++)
+        add_coin(1000 * COIN);
+
+    BOOST_CHECK(wallet.SelectCoinsMinConf(100001 * COIN, 1, 6, vCoins, setCoinsRet, nValueRet));
     // We need all 100 larger coins and exactly one small coin.
-    // Superfluous small coins must be pruned:
-    BOOST_CHECK_EQUAL(nValueRet, 100010 * CENT);
+    // Superfluous small coins must be trimmed from the set:
+    BOOST_CHECK_EQUAL(nValueRet, 100010 * COIN);
     BOOST_CHECK_EQUAL(setCoinsRet.size(), 101);
 }
 

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -328,6 +328,24 @@ BOOST_AUTO_TEST_CASE(coin_selection_tests)
     empty_wallet();
 }
 
+BOOST_AUTO_TEST_CASE(sorting_in_ApproximateBestSet)
+{
+    CoinSet setCoinsRet;
+    CAmount nValueRet;
+
+    LOCK(wallet.cs_wallet);
+
+    empty_wallet();
+    
+    for (int i = 0; i < 1000; i++)
+        add_coin(1000 * COIN);
+    add_coin(3 * COIN);
+
+    BOOST_CHECK(wallet.SelectCoinsMinConf(1003 * COIN, 1, 6, vCoins, setCoinsRet, nValueRet));
+    BOOST_CHECK_EQUAL(nValueRet, 1003 * COIN);
+    BOOST_CHECK_EQUAL(setCoinsRet.size(), 2U);
+}
+
 BOOST_AUTO_TEST_CASE(pruning_in_ApproximateBestSet)
 {
     CoinSet setCoinsRet;


### PR DESCRIPTION
vValue is sorted from high to low. This adds a regression test such that pulls like #7183 would fail travis.
