### PR TITLE
Add RPC call abandontransaction

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -105,6 +105,7 @@ testScripts = [
     'prioritise_transaction.py',
     'invalidblockrequest.py',
     'invalidtxrequest.py',
+    'abandonconflict.py',
 ]
 testScriptsExt = [
     'bip65-cltv.py',

--- a/qa/rpc-tests/abandonconflict.py
+++ b/qa/rpc-tests/abandonconflict.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python2
+# Copyright (c) 2014-2015 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+try:
+    import urllib.parse as urlparse
+except ImportError:
+    import urlparse
+
+class AbandonConflictTest(BitcoinTestFramework):
+
+    def setup_network(self):
+        self.nodes = []
+        self.nodes.append(start_node(0, self.options.tmpdir, ["-debug","-logtimemicros","-minrelaytxfee=0.00001"]))
+        self.nodes.append(start_node(1, self.options.tmpdir, ["-debug","-logtimemicros"]))
+        connect_nodes(self.nodes[0], 1)
+
+    def run_test(self):
+        self.nodes[1].generate(100)
+        sync_blocks(self.nodes)
+        balance = self.nodes[0].getbalance()
+        txA = self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), Decimal("10"))
+        txB = self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), Decimal("10"))
+        txC = self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), Decimal("10"))
+        sync_mempools(self.nodes)
+        self.nodes[1].generate(1)
+
+        sync_blocks(self.nodes)
+        newbalance = self.nodes[0].getbalance()
+        assert(balance - newbalance < Decimal("0.001")) #no more than fees lost
+        balance = newbalance
+
+        url = urlparse.urlparse(self.nodes[1].url)
+        self.nodes[0].disconnectnode(url.hostname+":"+str(p2p_port(1)))
+
+        # Identify the 10btc outputs
+        nA = next(i for i, vout in enumerate(self.nodes[0].getrawtransaction(txA, 1)["vout"]) if vout["value"] == Decimal("10"))
+        nB = next(i for i, vout in enumerate(self.nodes[0].getrawtransaction(txB, 1)["vout"]) if vout["value"] == Decimal("10"))
+        nC = next(i for i, vout in enumerate(self.nodes[0].getrawtransaction(txC, 1)["vout"]) if vout["value"] == Decimal("10"))
+
+        inputs =[]
+        # spend 10btc outputs from txA and txB
+        inputs.append({"txid":txA, "vout":nA})
+        inputs.append({"txid":txB, "vout":nB})
+        outputs = {}
+
+        outputs[self.nodes[0].getnewaddress()] = Decimal("14.99998")
+        outputs[self.nodes[1].getnewaddress()] = Decimal("5")
+        signed = self.nodes[0].signrawtransaction(self.nodes[0].createrawtransaction(inputs, outputs))
+        txAB1 = self.nodes[0].sendrawtransaction(signed["hex"])
+
+        # Identify the 14.99998btc output
+        nAB = next(i for i, vout in enumerate(self.nodes[0].getrawtransaction(txAB1, 1)["vout"]) if vout["value"] == Decimal("14.99998"))
+
+        #Create a child tx spending AB1 and C
+        inputs = []
+        inputs.append({"txid":txAB1, "vout":nAB})
+        inputs.append({"txid":txC, "vout":nC})
+        outputs = {}
+        outputs[self.nodes[0].getnewaddress()] = Decimal("24.9996")
+        signed2 = self.nodes[0].signrawtransaction(self.nodes[0].createrawtransaction(inputs, outputs))
+        txABC2 = self.nodes[0].sendrawtransaction(signed2["hex"])
+
+        # In mempool txs from self should increase balance from change
+        newbalance = self.nodes[0].getbalance()
+        assert(newbalance == balance - Decimal("30") + Decimal("24.9996"))
+        balance = newbalance
+
+        # Restart the node with a higher min relay fee so the parent tx is no longer in mempool
+        # TODO: redo with eviction
+        # Note had to make sure tx did not have AllowFree priority
+        stop_node(self.nodes[0],0)
+        self.nodes[0]=start_node(0, self.options.tmpdir, ["-debug","-logtimemicros","-minrelaytxfee=0.0001"])
+
+        # Verify txs no longer in mempool
+        assert(len(self.nodes[0].getrawmempool()) == 0)
+
+        # Not in mempool txs from self should only reduce balance
+        # inputs are still spent, but change not received
+        newbalance = self.nodes[0].getbalance()
+        assert(newbalance == balance - Decimal("24.9996"))
+        balance = newbalance
+
+        # Abandon original transaction and verify inputs are available again
+        # including that the child tx was also abandoned
+        self.nodes[0].abandontransaction(txAB1)
+        newbalance = self.nodes[0].getbalance()
+        assert(newbalance == balance + Decimal("30"))
+        balance = newbalance
+
+        # Verify that even with a low min relay fee, the tx is not reaccepted from wallet on startup once abandoned
+        stop_node(self.nodes[0],0)
+        self.nodes[0]=start_node(0, self.options.tmpdir, ["-debug","-logtimemicros","-minrelaytxfee=0.00001"])
+        assert(len(self.nodes[0].getrawmempool()) == 0)
+        assert(self.nodes[0].getbalance() == balance)
+
+        # But if its received again then it is unabandoned
+        # And since now in mempool, the change is available
+        # But its child tx remains abandoned
+        self.nodes[0].sendrawtransaction(signed["hex"])
+        newbalance = self.nodes[0].getbalance()
+        assert(newbalance == balance - Decimal("20") + Decimal("14.99998"))
+        balance = newbalance
+
+        # Send child tx again so its unabandoned
+        self.nodes[0].sendrawtransaction(signed2["hex"])
+        newbalance = self.nodes[0].getbalance()
+        assert(newbalance == balance - Decimal("10") - Decimal("14.99998") + Decimal("24.9996"))
+        balance = newbalance
+
+        # Remove using high relay fee again
+        stop_node(self.nodes[0],0)
+        self.nodes[0]=start_node(0, self.options.tmpdir, ["-debug","-logtimemicros","-minrelaytxfee=0.0001"])
+        assert(len(self.nodes[0].getrawmempool()) == 0)
+        newbalance = self.nodes[0].getbalance()
+        assert(newbalance == balance - Decimal("24.9996"))
+        balance = newbalance
+
+        # Create a double spend of AB1 by spending again from only A's 10 output
+        # Mine double spend from node 1
+        inputs =[]
+        inputs.append({"txid":txA, "vout":nA})
+        outputs = {}
+        outputs[self.nodes[1].getnewaddress()] = Decimal("9.9999")
+        tx = self.nodes[0].createrawtransaction(inputs, outputs)
+        signed = self.nodes[0].signrawtransaction(tx)
+        self.nodes[1].sendrawtransaction(signed["hex"])
+        self.nodes[1].generate(1)
+
+        connect_nodes(self.nodes[0], 1)
+        sync_blocks(self.nodes)
+
+        # Verify that B and C's 10 BTC outputs are available for spending again because AB1 is now conflicted
+        newbalance = self.nodes[0].getbalance()
+        assert(newbalance == balance + Decimal("20"))
+        balance = newbalance
+
+        # There is currently a minor bug around this and so this test doesn't work.  See Issue #7315
+        # Invalidate the block with the double spend and B's 10 BTC output should no longer be available
+        # Don't think C's should either
+        self.nodes[0].invalidateblock(self.nodes[0].getbestblockhash())
+        newbalance = self.nodes[0].getbalance()
+        #assert(newbalance == balance - Decimal("10"))
+        print "If balance has not declined after invalidateblock then out of mempool wallet tx which is no longer"
+        print "conflicted has not resumed causing its inputs to be seen as spent.  See Issue #7315"
+        print balance , " -> " , newbalance , " ?"
+
+if __name__ == '__main__':
+    AbandonConflictTest().main()

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -346,6 +346,7 @@ static const CRPCCommand vRPCCommands[] =
     { "wallet",             "getreceivedbyaccount",   &getreceivedbyaccount,   false },
     { "wallet",             "getreceivedbyaddress",   &getreceivedbyaddress,   false },
     { "wallet",             "gettransaction",         &gettransaction,         false },
+    { "wallet",             "abandontransaction",     &abandontransaction,     false },
     { "wallet",             "getunconfirmedbalance",  &getunconfirmedbalance,  false },
     { "wallet",             "getwalletinfo",          &getwalletinfo,          false },
     { "wallet",             "importprivkey",          &importprivkey,          true  },

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -221,6 +221,7 @@ extern UniValue listaddressgroupings(const UniValue& params, bool fHelp);
 extern UniValue listaccounts(const UniValue& params, bool fHelp);
 extern UniValue listsinceblock(const UniValue& params, bool fHelp);
 extern UniValue gettransaction(const UniValue& params, bool fHelp);
+extern UniValue abandontransaction(const UniValue& params, bool fHelp);
 extern UniValue backupwallet(const UniValue& params, bool fHelp);
 extern UniValue keypoolrefill(const UniValue& params, bool fHelp);
 extern UniValue walletpassphrase(const UniValue& params, bool fHelp);

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1764,6 +1764,40 @@ UniValue gettransaction(const UniValue& params, bool fHelp)
     return entry;
 }
 
+UniValue abandontransaction(const UniValue& params, bool fHelp)
+{
+    if (!EnsureWalletIsAvailable(fHelp))
+        return NullUniValue;
+
+    if (fHelp || params.size() != 1)
+        throw runtime_error(
+            "abandontransaction \"txid\"\n"
+            "\nMark in-wallet transaction <txid> as abandoned\n"
+            "This will mark this transaction and all its in-wallet descendants as abandoned which will allow\n"
+            "for their inputs to be respent.  It can be used to replace \"stuck\" or evicted transactions.\n"
+            "It only works on transactions which are not included in a block and are not currently in the mempool.\n"
+            "It has no effect on transactions which are already conflicted or abandoned.\n"
+            "\nArguments:\n"
+            "1. \"txid\"    (string, required) The transaction id\n"
+            "\nResult:\n"
+            "\nExamples:\n"
+            + HelpExampleCli("abandontransaction", "\"1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d\"")
+            + HelpExampleRpc("abandontransaction", "\"1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d\"")
+        );
+
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
+    uint256 hash;
+    hash.SetHex(params[0].get_str());
+
+    if (!pwalletMain->mapWallet.count(hash))
+        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid or non-wallet transaction id");
+    if (!pwalletMain->AbandonTransaction(hash))
+        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Transaction not eligible for abandonment");
+
+    return NullUniValue;
+}
+
 
 UniValue backupwallet(const UniValue& params, bool fHelp)
 {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -815,6 +815,7 @@ bool CWallet::AbandonTransaction(const uint256& hashTx)
             wtx.setAbandoned();
             wtx.MarkDirty();
             wtx.WriteToDisk(&walletdb);
+            NotifyTransactionChanged(this, wtx.GetHash(), CT_UPDATED);
             // Iterate over all its outputs, and mark transactions in the wallet that spend them abandoned too
             TxSpends::const_iterator iter = mapTxSpends.lower_bound(COutPoint(hashTx, 0));
             while (iter != mapTxSpends.end() && iter->first.hash == now) {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -784,14 +784,14 @@ void CWallet::MarkConflicted(const uint256& hashBlock, const uint256& hashTx)
     // Do not flush the wallet here for performance reasons
     CWalletDB walletdb(strWalletFile, "r+", false);
 
-    std::deque<uint256> todo;
+    std::set<uint256> todo;
     std::set<uint256> done;
 
-    todo.push_back(hashTx);
+    todo.insert(hashTx);
 
     while (!todo.empty()) {
-        uint256 now = todo.front();
-        todo.pop_front();
+        uint256 now = *todo.begin();
+        todo.erase(now);
         done.insert(now);
         assert(mapWallet.count(now));
         CWalletTx& wtx = mapWallet[now];
@@ -807,7 +807,7 @@ void CWallet::MarkConflicted(const uint256& hashBlock, const uint256& hashTx)
             TxSpends::const_iterator iter = mapTxSpends.lower_bound(COutPoint(now, 0));
             while (iter != mapTxSpends.end() && iter->first.hash == now) {
                  if (!done.count(iter->second)) {
-                     todo.push_back(iter->second);
+                     todo.insert(iter->second);
                  }
                  iter++;
             }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -155,6 +155,10 @@ struct COutputEntry
 /** A transaction with a merkle branch linking it to the block chain. */
 class CMerkleTx : public CTransaction
 {
+private:
+  /** Constant used in hashBlock to indicate tx has been abandoned */
+    static const uint256 ABANDON_HASH;
+
 public:
     uint256 hashBlock;
 
@@ -206,6 +210,9 @@ public:
     bool IsInMainChain() const { const CBlockIndex *pindexRet; return GetDepthInMainChain(pindexRet) > 0; }
     int GetBlocksToMaturity() const;
     bool AcceptToMemoryPool(bool fLimitFree=true, bool fRejectAbsurdFee=true);
+    bool hashUnset() const { return (hashBlock.IsNull() || hashBlock == ABANDON_HASH); }
+    bool isAbandoned() const { return (hashBlock == ABANDON_HASH); }
+    void setAbandoned() { hashBlock = ABANDON_HASH; }
 };
 
 /** 
@@ -485,7 +492,6 @@ private:
 
     /* Mark a transaction (and its in-wallet descendants) as conflicting with a particular block. */
     void MarkConflicted(const uint256& hashBlock, const uint256& hashTx);
-
 
     void SyncMetaData(std::pair<TxSpends::iterator, TxSpends::iterator>);
 
@@ -783,6 +789,9 @@ public:
     bool GetBroadcastTransactions() const { return fBroadcastTransactions; }
     /** Set whether this wallet broadcasts transactions. */
     void SetBroadcastTransactions(bool broadcast) { fBroadcastTransactions = broadcast; }
+
+    /* Mark a transaction (and it in-wallet descendants) as abandoned so its inputs may be respent. */
+    bool AbandonTransaction(const uint256& hashTx);
 };
 
 /** A key allocated from the key pool. */


### PR DESCRIPTION
Unconfirmed transactions that are not in your mempool either due to eviction or other means may be unlikely to be mined.  abandontransaction gives the wallet a way to no longer consider as spent the coins that are inputs to such a transaction.  All dependent transactions in the wallet will also be marked as abandoned.

@laanwj also for 0.12

This is the basic functionality.  
There are more things to add though.  I have an RPC test  in progress, but if anyone else wants to work on the remaining items, please do:
- Return abandoned status in listtransactions
- Return abandoned status in GUI
- Fix any issues with how abandoned txs should sort
- Add a way to abandon transactions from GUI

I built this off of #7306 to make sure the tests would work correctly.
