### PR TITLE
[Backport 0.12][Qt] Intro: Display required space

### DIFF
--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -15,9 +15,15 @@
 #include <QSettings>
 #include <QMessageBox>
 
-/* Minimum free space (in bytes) needed for data directory */
+#include <cmath>
+
 static const uint64_t GB_BYTES = 1000000000LL;
-static const uint64_t BLOCK_CHAIN_SIZE = 20LL * GB_BYTES;
+/* Minimum free space (in GB) needed for data directory */
+static const uint64_t BLOCK_CHAIN_SIZE = 80;
+/* Minimum free space (in GB) needed for data directory when pruned; Does not include prune target */
+static const uint64_t CHAIN_STATE_SIZE = 2;
+/* Total required space (in GB) depending on user choice (prune, not prune) */
+static uint64_t requiredSpace;
 
 /* Check free space asynchronously to prevent hanging the UI thread.
 
@@ -112,7 +118,11 @@ Intro::Intro(QWidget *parent) :
     signalled(false)
 {
     ui->setupUi(this);
-    ui->sizeWarningLabel->setText(ui->sizeWarningLabel->text().arg(BLOCK_CHAIN_SIZE/GB_BYTES));
+    uint64_t pruneTarget = std::max<int64_t>(0, GetArg("-prune", 0));
+    requiredSpace = BLOCK_CHAIN_SIZE;
+    if (pruneTarget)
+        requiredSpace = CHAIN_STATE_SIZE + std::ceil(pruneTarget * 1024 * 1024.0 / GB_BYTES);
+    ui->sizeWarningLabel->setText(ui->sizeWarningLabel->text().arg(requiredSpace));
     startThread();
 }
 
@@ -216,9 +226,9 @@ void Intro::setStatus(int status, const QString &message, quint64 bytesAvailable
         ui->freeSpace->setText("");
     } else {
         QString freeString = tr("%n GB of free space available", "", bytesAvailable/GB_BYTES);
-        if(bytesAvailable < BLOCK_CHAIN_SIZE)
+        if(bytesAvailable < requiredSpace * GB_BYTES)
         {
-            freeString += " " + tr("(of %n GB needed)", "", BLOCK_CHAIN_SIZE/GB_BYTES);
+            freeString += " " + tr("(of %n GB needed)", "", requiredSpace);
             ui->freeSpace->setStyleSheet("QLabel { color: #800000 }");
         } else {
             ui->freeSpace->setStyleSheet("");


### PR DESCRIPTION
I think a backport of #7298 for 0.12 should not harm and it's relatively risk-free. IMO it's a bugfix because enabling `-prune` should not tell users that 20GB free space is required.
