### PR TITLE
[qa] Test walletpassphrase timeout

### DIFF
--- a/qa/rpc-tests/keypool.py
+++ b/qa/rpc-tests/keypool.py
@@ -70,9 +70,11 @@ class KeyPoolTest(BitcoinTestFramework):
             assert(e.error['code']==-12)
 
         # refill keypool with three new addresses
-        nodes[0].walletpassphrase('test', 12000)
+        nodes[0].walletpassphrase('test', 1)
         nodes[0].keypoolrefill(3)
-        nodes[0].walletlock()
+        # test walletpassphrase timeout
+        time.sleep(1.1)
+        assert_equal(nodes[0].getwalletinfo()["unlocked_until"], 0)
 
         # drain them by mining
         nodes[0].generate(1)


### PR DESCRIPTION
Test case for #7316

Test code: `$ git checkout fadceb7;make;BITCOIND=bitcoin-qt qa/pull-tester/rpc-tests.py keypool`

```
...
Running testscript keypool.py ...
Initializing test directory /tmp/testqf3QO4
Assertion failed: 1452255264 != 0
```
