### PR TITLE
[Wallet] Transaction View: LastMonth calculation fixed

### DIFF
--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -267,7 +267,7 @@ void TransactionView::chooseDate(int idx)
         break;
     case LastMonth:
         transactionProxyModel->setDateRange(
-                QDateTime(QDate(current.year(), current.month()-1, 1)),
+                QDateTime(QDate(current.year(), current.month(), 1).addMonths(-1)),
                 QDateTime(QDate(current.year(), current.month(), 1)));
         break;
     case ThisYear:


### PR DESCRIPTION
In January (in this example, January 2016), last month isn't from 2016-0-1 to 2016-1-1, it's from 2015-12-1 to 2016-1-1.

**Edit:** this means in each January the "Last Month" filter simply does not work.
