### PR TITLE
[qt] coincontrol workaround is still needed in qt5.4 (fixed in qt5.5)

### DIFF
--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -408,10 +408,8 @@ void CoinControlDialog::viewItemChanged(QTreeWidgetItem* item, int column)
             CoinControlDialog::updateLabels(model, this);
     }
 
-    // todo: this is a temporary qt5 fix: when clicking a parent node in tree mode, the parent node
-    //       including all children are partially selected. But the parent node should be fully selected
-    //       as well as the children. Children should never be partially selected in the first place.
-    //       Should be fixed in Qt5.4 and above. https://bugreports.qt.io/browse/QTBUG-43473
+    // TODO: Remove this temporary qt5 fix after Qt5.3 and Qt5.4 are no longer used.
+    //       Fixed in Qt5.5 and above: https://bugreports.qt.io/browse/QTBUG-43473
 #if QT_VERSION >= 0x050000
     else if (column == COLUMN_CHECKBOX && item->childCount() > 0)
     {


### PR DESCRIPTION
Let's not remove it too early. I'd still prefer something like 

``` cpp
#if QT_VERSION >= 0x050000 && QT_VERSION <= 0x050500
```
