### PR TITLE
[qa] Fix pyton syntax in rpc tests

### DIFF
--- a/qa/rpc-tests/bip65-cltv-p2p.py
+++ b/qa/rpc-tests/bip65-cltv-p2p.py
@@ -10,7 +10,7 @@ from test_framework.mininode import CTransaction, NetworkThread
 from test_framework.blocktools import create_coinbase, create_block
 from test_framework.comptool import TestInstance, TestManager
 from test_framework.script import CScript, OP_1NEGATE, OP_CHECKLOCKTIMEVERIFY, OP_DROP
-from binascii import hexlify, unhexlify
+from binascii import unhexlify
 import cStringIO
 import time
 

--- a/qa/rpc-tests/bip65-cltv.py
+++ b/qa/rpc-tests/bip65-cltv.py
@@ -9,8 +9,6 @@
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
-import os
-import shutil
 
 class BIP65Test(BitcoinTestFramework):
 
@@ -46,7 +44,7 @@ class BIP65Test(BitcoinTestFramework):
         self.nodes[2].generate(1)
         self.sync_all()
         if (self.nodes[0].getblockcount() != cnt + 851):
-            raise AssertionFailure("Failed to mine a version=4 blocks")
+            raise AssertionError("Failed to mine a version=4 blocks")
 
         # TODO: check that new CHECKLOCKTIMEVERIFY rules are enforced
 

--- a/qa/rpc-tests/bipdersig-p2p.py
+++ b/qa/rpc-tests/bipdersig-p2p.py
@@ -10,7 +10,7 @@ from test_framework.mininode import CTransaction, NetworkThread
 from test_framework.blocktools import create_coinbase, create_block
 from test_framework.comptool import TestInstance, TestManager
 from test_framework.script import CScript
-from binascii import hexlify, unhexlify
+from binascii import unhexlify
 import cStringIO
 import time
 

--- a/qa/rpc-tests/bipdersig.py
+++ b/qa/rpc-tests/bipdersig.py
@@ -9,8 +9,6 @@
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
-import os
-import shutil
 
 class BIP66Test(BitcoinTestFramework):
 
@@ -46,7 +44,7 @@ class BIP66Test(BitcoinTestFramework):
         self.nodes[2].generate(1)
         self.sync_all()
         if (self.nodes[0].getblockcount() != cnt + 851):
-            raise AssertionFailure("Failed to mine a version=3 blocks")
+            raise AssertionError("Failed to mine a version=3 blocks")
 
         # TODO: check that new DERSIG rules are enforced
 

--- a/qa/rpc-tests/blockchain.py
+++ b/qa/rpc-tests/blockchain.py
@@ -7,7 +7,7 @@
 # Test RPC calls related to blockchain state.
 #
 
-import decimal
+from decimal import Decimal
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
@@ -39,7 +39,7 @@ class BlockchainTest(BitcoinTestFramework):
         node = self.nodes[0]
         res = node.gettxoutsetinfo()
 
-        assert_equal(res[u'total_amount'], decimal.Decimal('8725.00000000'))
+        assert_equal(res[u'total_amount'], Decimal('8725.00000000'))
         assert_equal(res[u'transactions'], 200)
         assert_equal(res[u'height'], 200)
         assert_equal(res[u'txouts'], 200)

--- a/qa/rpc-tests/disablewallet.py
+++ b/qa/rpc-tests/disablewallet.py
@@ -10,6 +10,7 @@
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
 
+
 class DisableWalletTest (BitcoinTestFramework):
 
     def setup_chain(self):

--- a/qa/rpc-tests/forknotify.py
+++ b/qa/rpc-tests/forknotify.py
@@ -9,8 +9,6 @@
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
-import os
-import shutil
 
 class ForkNotifyTest(BitcoinTestFramework):
 

--- a/qa/rpc-tests/fundrawtransaction.py
+++ b/qa/rpc-tests/fundrawtransaction.py
@@ -5,8 +5,6 @@
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
-from pprint import pprint
-from time import sleep
 
 # Create one-input, one-output, no-fee transaction:
 class RawTransactionsTest(BitcoinTestFramework):
@@ -53,11 +51,11 @@ class RawTransactionsTest(BitcoinTestFramework):
         watchonly_amount = 200
         self.nodes[3].importpubkey(watchonly_pubkey, "", True)
         watchonly_txid = self.nodes[0].sendtoaddress(watchonly_address, watchonly_amount)
-        self.nodes[0].sendtoaddress(self.nodes[3].getnewaddress(), watchonly_amount / 10);
+        self.nodes[0].sendtoaddress(self.nodes[3].getnewaddress(), watchonly_amount / 10)
 
-        self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(),1.5);
-        self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(),1.0);
-        self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(),5.0);
+        self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 1.5)
+        self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 1.0)
+        self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 5.0)
 
         self.sync_all()
         self.nodes[0].generate(1)
@@ -130,7 +128,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         for aUtx in listunspent:
             if aUtx['amount'] == 5.0:
                 utx = aUtx
-                break;
+                break
 
         assert_equal(utx!=False, True)
 
@@ -159,7 +157,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         for aUtx in listunspent:
             if aUtx['amount'] == 5.0:
                 utx = aUtx
-                break;
+                break
 
         assert_equal(utx!=False, True)
 
@@ -189,7 +187,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         for aUtx in listunspent:
             if aUtx['amount'] == 1.0:
                 utx = aUtx
-                break;
+                break
 
         assert_equal(utx!=False, True)
 
@@ -314,7 +312,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         except JSONRPCException,e:
             errorString = e.error['message']
 
-        assert_equal("Insufficient" in errorString, True);
+        assert("Insufficient" in errorString)
 
 
 
@@ -326,11 +324,11 @@ class RawTransactionsTest(BitcoinTestFramework):
         fundedTx = self.nodes[0].fundrawtransaction(rawTx)
 
         #create same transaction over sendtoaddress
-        txId = self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 1.1);
+        txId = self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 1.1)
         signedFee = self.nodes[0].getrawmempool(True)[txId]['fee']
 
         #compare fee
-        feeDelta = Decimal(fundedTx['fee']) - Decimal(signedFee);
+        feeDelta = Decimal(fundedTx['fee']) - Decimal(signedFee)
         assert(feeDelta >= 0 and feeDelta <= feeTolerance)
         ############################################################
 
@@ -341,11 +339,11 @@ class RawTransactionsTest(BitcoinTestFramework):
         rawTx = self.nodes[0].createrawtransaction(inputs, outputs)
         fundedTx = self.nodes[0].fundrawtransaction(rawTx)
         #create same transaction over sendtoaddress
-        txId = self.nodes[0].sendmany("", outputs);
+        txId = self.nodes[0].sendmany("", outputs)
         signedFee = self.nodes[0].getrawmempool(True)[txId]['fee']
 
         #compare fee
-        feeDelta = Decimal(fundedTx['fee']) - Decimal(signedFee);
+        feeDelta = Decimal(fundedTx['fee']) - Decimal(signedFee)
         assert(feeDelta >= 0 and feeDelta <= feeTolerance)
         ############################################################
 
@@ -368,11 +366,11 @@ class RawTransactionsTest(BitcoinTestFramework):
         fundedTx = self.nodes[0].fundrawtransaction(rawTx)
 
         #create same transaction over sendtoaddress
-        txId = self.nodes[0].sendtoaddress(mSigObj, 1.1);
+        txId = self.nodes[0].sendtoaddress(mSigObj, 1.1)
         signedFee = self.nodes[0].getrawmempool(True)[txId]['fee']
 
         #compare fee
-        feeDelta = Decimal(fundedTx['fee']) - Decimal(signedFee);
+        feeDelta = Decimal(fundedTx['fee']) - Decimal(signedFee)
         assert(feeDelta >= 0 and feeDelta <= feeTolerance)
         ############################################################
 
@@ -401,11 +399,11 @@ class RawTransactionsTest(BitcoinTestFramework):
         fundedTx = self.nodes[0].fundrawtransaction(rawTx)
 
         #create same transaction over sendtoaddress
-        txId = self.nodes[0].sendtoaddress(mSigObj, 1.1);
+        txId = self.nodes[0].sendtoaddress(mSigObj, 1.1)
         signedFee = self.nodes[0].getrawmempool(True)[txId]['fee']
 
         #compare fee
-        feeDelta = Decimal(fundedTx['fee']) - Decimal(signedFee);
+        feeDelta = Decimal(fundedTx['fee']) - Decimal(signedFee)
         assert(feeDelta >= 0 and feeDelta <= feeTolerance)
         ############################################################
 
@@ -424,7 +422,7 @@ class RawTransactionsTest(BitcoinTestFramework):
 
 
         # send 1.2 BTC to msig addr
-        txId = self.nodes[0].sendtoaddress(mSigObj, 1.2);
+        txId = self.nodes[0].sendtoaddress(mSigObj, 1.2)
         self.sync_all()
         self.nodes[1].generate(1)
         self.sync_all()
@@ -466,7 +464,7 @@ class RawTransactionsTest(BitcoinTestFramework):
 
         error = False
         try:
-            self.nodes[1].sendtoaddress(self.nodes[0].getnewaddress(), 1.2);
+            self.nodes[1].sendtoaddress(self.nodes[0].getnewaddress(), 1.2)
         except:
             error = True
         assert(error)
@@ -496,13 +494,13 @@ class RawTransactionsTest(BitcoinTestFramework):
         ###############################################
 
         #empty node1, send some small coins from node0 to node1
-        self.nodes[1].sendtoaddress(self.nodes[0].getnewaddress(), self.nodes[1].getbalance(), "", "", True);
+        self.nodes[1].sendtoaddress(self.nodes[0].getnewaddress(), self.nodes[1].getbalance(), "", "", True)
         self.sync_all()
         self.nodes[0].generate(1)
         self.sync_all()
 
         for i in range(0,20):
-            self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 0.01);
+            self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 0.01)
         self.sync_all()
         self.nodes[0].generate(1)
         self.sync_all()
@@ -514,11 +512,11 @@ class RawTransactionsTest(BitcoinTestFramework):
         fundedTx = self.nodes[1].fundrawtransaction(rawTx)
 
         #create same transaction over sendtoaddress
-        txId = self.nodes[1].sendmany("", outputs);
+        txId = self.nodes[1].sendmany("", outputs)
         signedFee = self.nodes[1].getrawmempool(True)[txId]['fee']
 
         #compare fee
-        feeDelta = Decimal(fundedTx['fee']) - Decimal(signedFee);
+        feeDelta = Decimal(fundedTx['fee']) - Decimal(signedFee)
         assert(feeDelta >= 0 and feeDelta <= feeTolerance*19) #~19 inputs
 
 
@@ -527,13 +525,13 @@ class RawTransactionsTest(BitcoinTestFramework):
         #############################################
 
         #again, empty node1, send some small coins from node0 to node1
-        self.nodes[1].sendtoaddress(self.nodes[0].getnewaddress(), self.nodes[1].getbalance(), "", "", True);
+        self.nodes[1].sendtoaddress(self.nodes[0].getnewaddress(), self.nodes[1].getbalance(), "", "", True)
         self.sync_all()
         self.nodes[0].generate(1)
         self.sync_all()
 
         for i in range(0,20):
-            self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 0.01);
+            self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 0.01)
         self.sync_all()
         self.nodes[0].generate(1)
         self.sync_all()

--- a/qa/rpc-tests/getchaintips.py
+++ b/qa/rpc-tests/getchaintips.py
@@ -23,8 +23,8 @@ class GetChainTipsTest (BitcoinTestFramework):
 
         # Split the network and build two chains of different lengths.
         self.split_network ()
-        self.nodes[0].generate(10);
-        self.nodes[2].generate(20);
+        self.nodes[0].generate(10)
+        self.nodes[2].generate(20)
         self.sync_all ()
 
         tips = self.nodes[1].getchaintips ()

--- a/qa/rpc-tests/httpbasics.py
+++ b/qa/rpc-tests/httpbasics.py
@@ -36,13 +36,13 @@ class HTTPBasicsTest (BitcoinTestFramework):
         conn = httplib.HTTPConnection(url.hostname, url.port)
         conn.connect()
         conn.request('POST', '/', '{"method": "getbestblockhash"}', headers)
-        out1 = conn.getresponse().read();
+        out1 = conn.getresponse().read()
         assert_equal('"error":null' in out1, True)
         assert_equal(conn.sock!=None, True) #according to http/1.1 connection must still be open!
 
         #send 2nd request without closing connection
         conn.request('POST', '/', '{"method": "getchaintips"}', headers)
-        out2 = conn.getresponse().read();
+        out2 = conn.getresponse().read()
         assert_equal('"error":null' in out1, True) #must also response with a correct json-rpc message
         assert_equal(conn.sock!=None, True) #according to http/1.1 connection must still be open!
         conn.close()
@@ -53,13 +53,13 @@ class HTTPBasicsTest (BitcoinTestFramework):
         conn = httplib.HTTPConnection(url.hostname, url.port)
         conn.connect()
         conn.request('POST', '/', '{"method": "getbestblockhash"}', headers)
-        out1 = conn.getresponse().read();
+        out1 = conn.getresponse().read()
         assert_equal('"error":null' in out1, True)
         assert_equal(conn.sock!=None, True) #according to http/1.1 connection must still be open!
 
         #send 2nd request without closing connection
         conn.request('POST', '/', '{"method": "getchaintips"}', headers)
-        out2 = conn.getresponse().read();
+        out2 = conn.getresponse().read()
         assert_equal('"error":null' in out1, True) #must also response with a correct json-rpc message
         assert_equal(conn.sock!=None, True) #according to http/1.1 connection must still be open!
         conn.close()
@@ -70,7 +70,7 @@ class HTTPBasicsTest (BitcoinTestFramework):
         conn = httplib.HTTPConnection(url.hostname, url.port)
         conn.connect()
         conn.request('POST', '/', '{"method": "getbestblockhash"}', headers)
-        out1 = conn.getresponse().read();
+        out1 = conn.getresponse().read()
         assert_equal('"error":null' in out1, True)
         assert_equal(conn.sock!=None, False) #now the connection must be closed after the response
 
@@ -82,7 +82,7 @@ class HTTPBasicsTest (BitcoinTestFramework):
         conn = httplib.HTTPConnection(urlNode1.hostname, urlNode1.port)
         conn.connect()
         conn.request('POST', '/', '{"method": "getbestblockhash"}', headers)
-        out1 = conn.getresponse().read();
+        out1 = conn.getresponse().read()
         assert_equal('"error":null' in out1, True)
 
         #node2 (third node) is running with standard keep-alive parameters which means keep-alive is on
@@ -93,7 +93,7 @@ class HTTPBasicsTest (BitcoinTestFramework):
         conn = httplib.HTTPConnection(urlNode2.hostname, urlNode2.port)
         conn.connect()
         conn.request('POST', '/', '{"method": "getbestblockhash"}', headers)
-        out1 = conn.getresponse().read();
+        out1 = conn.getresponse().read()
         assert_equal('"error":null' in out1, True)
         assert_equal(conn.sock!=None, True) #connection must be closed because bitcoind should use keep-alive by default
 

--- a/qa/rpc-tests/invalidblockrequest.py
+++ b/qa/rpc-tests/invalidblockrequest.py
@@ -7,9 +7,7 @@
 from test_framework.test_framework import ComparisonTestFramework
 from test_framework.util import *
 from test_framework.comptool import TestManager, TestInstance, RejectResult
-from test_framework.mininode import *
 from test_framework.blocktools import *
-import logging
 import copy
 import time
 

--- a/qa/rpc-tests/invalidtxrequest.py
+++ b/qa/rpc-tests/invalidtxrequest.py
@@ -5,12 +5,8 @@
 #
 
 from test_framework.test_framework import ComparisonTestFramework
-from test_framework.util import *
 from test_framework.comptool import TestManager, TestInstance, RejectResult
-from test_framework.mininode import *
 from test_framework.blocktools import *
-import logging
-import copy
 import time
 
 

--- a/qa/rpc-tests/mempool_limit.py
+++ b/qa/rpc-tests/mempool_limit.py
@@ -48,7 +48,7 @@ class MempoolLimitTest(BitcoinTestFramework):
 
         # by now, the tx should be evicted, check confirmation state
         assert(txid not in self.nodes[0].getrawmempool())
-        txdata = self.nodes[0].gettransaction(txid);
+        txdata = self.nodes[0].gettransaction(txid)
         assert(txdata['confirmations'] ==  0) #confirmation should still be 0
 
 if __name__ == '__main__':

--- a/qa/rpc-tests/mempool_reorg.py
+++ b/qa/rpc-tests/mempool_reorg.py
@@ -10,8 +10,6 @@
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
-import os
-import shutil
 
 # Create one-input, one-output, no-fee transaction:
 class MempoolCoinbaseTest(BitcoinTestFramework):
@@ -25,7 +23,7 @@ class MempoolCoinbaseTest(BitcoinTestFramework):
         self.nodes.append(start_node(1, self.options.tmpdir, args))
         connect_nodes(self.nodes[1], 0)
         self.is_network_split = False
-        self.sync_all
+        self.sync_all()
 
     def create_tx(self, from_txid, to_address, amount):
         inputs = [{ "txid" : from_txid, "vout" : 0}]
@@ -87,11 +85,11 @@ class MempoolCoinbaseTest(BitcoinTestFramework):
 
         self.sync_all()
 
-        assert_equal(set(self.nodes[0].getrawmempool()), set([ spend_101_id, spend_102_1_id, timelock_tx_id ]))
+        assert_equal(set(self.nodes[0].getrawmempool()), {spend_101_id, spend_102_1_id, timelock_tx_id})
 
         for node in self.nodes:
             node.invalidateblock(last_block[0])
-        assert_equal(set(self.nodes[0].getrawmempool()), set([ spend_101_id, spend_102_1_id, spend_103_1_id ]))
+        assert_equal(set(self.nodes[0].getrawmempool()), {spend_101_id, spend_102_1_id, spend_103_1_id})
 
         # Use invalidateblock to re-org back and make all those coinbase spends
         # immature/invalid:

--- a/qa/rpc-tests/mempool_resurrect_test.py
+++ b/qa/rpc-tests/mempool_resurrect_test.py
@@ -10,8 +10,6 @@
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
-import os
-import shutil
 
 # Create one-input, one-output, no-fee transaction:
 class MempoolCoinbaseTest(BitcoinTestFramework):

--- a/qa/rpc-tests/mempool_spendcoinbase.py
+++ b/qa/rpc-tests/mempool_spendcoinbase.py
@@ -15,8 +15,6 @@
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
-import os
-import shutil
 
 # Create one-input, one-output, no-fee transaction:
 class MempoolSpendCoinbaseTest(BitcoinTestFramework):

--- a/qa/rpc-tests/merkle_blocks.py
+++ b/qa/rpc-tests/merkle_blocks.py
@@ -9,8 +9,6 @@
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
-import os
-import shutil
 
 class MerkleBlockTest(BitcoinTestFramework):
 

--- a/qa/rpc-tests/nodehandling.py
+++ b/qa/rpc-tests/nodehandling.py
@@ -9,7 +9,6 @@
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
-import base64
 
 try:
     import http.client as httplib
@@ -54,7 +53,7 @@ class NodeHandlingTest (BitcoinTestFramework):
         self.nodes[2].setban("127.0.0.0/24", "add")
         self.nodes[2].setban("192.168.0.1", "add", 1) #ban for 1 seconds
         self.nodes[2].setban("2001:4d48:ac57:400:cacf:e9ff:fe1d:9c63/19", "add", 1000) #ban for 1000 seconds
-        listBeforeShutdown = self.nodes[2].listbanned();
+        listBeforeShutdown = self.nodes[2].listbanned()
         assert_equal("192.168.0.1/32", listBeforeShutdown[2]['address']) #must be here
         time.sleep(2) #make 100% sure we expired 192.168.0.1 node time
 
@@ -62,7 +61,7 @@ class NodeHandlingTest (BitcoinTestFramework):
         stop_node(self.nodes[2], 2)
 
         self.nodes[2] = start_node(2, self.options.tmpdir)
-        listAfterShutdown = self.nodes[2].listbanned();
+        listAfterShutdown = self.nodes[2].listbanned()
         assert_equal("127.0.0.0/24", listAfterShutdown[0]['address'])
         assert_equal("127.0.0.0/32", listAfterShutdown[1]['address'])
         assert_equal("/19" in listAfterShutdown[2]['address'], True)

--- a/qa/rpc-tests/p2p-fullblocktest.py
+++ b/qa/rpc-tests/p2p-fullblocktest.py
@@ -8,14 +8,10 @@
 from test_framework.test_framework import ComparisonTestFramework
 from test_framework.util import *
 from test_framework.comptool import TestManager, TestInstance, RejectResult
-from test_framework.mininode import *
 from test_framework.blocktools import *
-import logging
-import copy
 import time
-import numbers
 from test_framework.key import CECKey
-from test_framework.script import CScript, CScriptOp, SignatureHash, SIGHASH_ALL, OP_TRUE, OP_FALSE
+from test_framework.script import CScript, SignatureHash, SIGHASH_ALL, OP_TRUE, OP_FALSE
 
 class PreviousSpendableOutput(object):
     def __init__(self, tx = CTransaction(), n = -1):

--- a/qa/rpc-tests/proxy_test.py
+++ b/qa/rpc-tests/proxy_test.py
@@ -3,9 +3,6 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 import socket
-import traceback, sys
-from binascii import hexlify
-import time, os
 
 from test_framework.socks5 import Socks5Configuration, Socks5Command, Socks5Server, AddressType
 from test_framework.test_framework import BitcoinTestFramework
@@ -34,7 +31,8 @@ addnode connect to onion
 addnode connect to generic DNS name
 '''
 
-class ProxyTest(BitcoinTestFramework):        
+
+class ProxyTest(BitcoinTestFramework):
     def __init__(self):
         # Create two proxies on different ports
         # ... one unauthenticated

--- a/qa/rpc-tests/pruning.py
+++ b/qa/rpc-tests/pruning.py
@@ -13,7 +13,6 @@
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
-import os.path
 
 def calc_usage(blockdir):
     return sum(os.path.getsize(blockdir+f) for f in os.listdir(blockdir) if os.path.isfile(blockdir+f))/(1024*1024)

--- a/qa/rpc-tests/rawtransactions.py
+++ b/qa/rpc-tests/rawtransactions.py
@@ -10,8 +10,6 @@
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
-from pprint import pprint
-from time import sleep
 
 # Create one-input, one-output, no-fee transaction:
 class RawTransactionsTest(BitcoinTestFramework):
@@ -43,9 +41,9 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.sync_all()
         self.nodes[0].generate(101)
         self.sync_all()
-        self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(),1.5);
-        self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(),1.0);
-        self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(),5.0);
+        self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(),1.5)
+        self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(),1.0)
+        self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(),5.0)
         self.sync_all()
         self.nodes[0].generate(5)
         self.sync_all()
@@ -64,7 +62,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         except JSONRPCException,e:
             errorString = e.error['message']
 
-        assert_equal("Missing inputs" in errorString, True);
+        assert("Missing inputs" in errorString)
 
         #########################
         # RAW TX MULTISIG TESTS #
@@ -83,7 +81,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         bal = self.nodes[2].getbalance()
 
         # send 1.2 BTC to msig adr
-        txId       = self.nodes[0].sendtoaddress(mSigObj, 1.2);
+        txId = self.nodes[0].sendtoaddress(mSigObj, 1.2)
         self.sync_all()
         self.nodes[0].generate(1)
         self.sync_all()
@@ -105,7 +103,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         mSigObj = self.nodes[2].addmultisigaddress(2, [addr1Obj['pubkey'], addr2Obj['pubkey'], addr3Obj['pubkey']])
         mSigObjValid = self.nodes[2].validateaddress(mSigObj)
 
-        txId       = self.nodes[0].sendtoaddress(mSigObj, 2.2);
+        txId = self.nodes[0].sendtoaddress(mSigObj, 2.2)
         decTx = self.nodes[0].gettransaction(txId)
         rawTx = self.nodes[0].decoderawtransaction(decTx['hex'])
         sPK = rawTx['vout'][0]['scriptPubKey']['hex']
@@ -123,7 +121,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         for outpoint in rawTx['vout']:
             if outpoint['value'] == Decimal('2.20000000'):
                 vout = outpoint
-                break;
+                break
 
         bal = self.nodes[0].getbalance()
         inputs = [{ "txid" : txId, "vout" : vout['n'], "scriptPubKey" : vout['scriptPubKey']['hex']}]

--- a/qa/rpc-tests/reindex.py
+++ b/qa/rpc-tests/reindex.py
@@ -8,7 +8,6 @@
 #
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
-import os.path
 
 class ReindexTest(BitcoinTestFramework):
 

--- a/qa/rpc-tests/replace-by-fee.py
+++ b/qa/rpc-tests/replace-by-fee.py
@@ -54,8 +54,7 @@ def make_utxo(node, amount, confirmed=True, scriptPubKey=CScript([1])):
     tx2.vout = [CTxOut(amount, scriptPubKey)]
     tx2.rehash()
 
-    tx2_hex = binascii.hexlify(tx2.serialize()).decode('utf-8')
-    #print tx2_hex
+    binascii.hexlify(tx2.serialize()).decode('utf-8')
 
     signed_tx = node.signrawtransaction(binascii.hexlify(tx2.serialize()).decode('utf-8'))
 

--- a/qa/rpc-tests/rest.py
+++ b/qa/rpc-tests/rest.py
@@ -12,9 +12,7 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
 from struct import *
 import binascii
-import json
 import StringIO
-import decimal
 
 try:
     import http.client as httplib
@@ -143,9 +141,9 @@ class RESTTest (BitcoinTestFramework):
 
         binaryRequest = b'\x01\x02'
         binaryRequest += binascii.unhexlify(txid)
-        binaryRequest += pack("i", n);
-        binaryRequest += binascii.unhexlify(vintx);
-        binaryRequest += pack("i", 0);
+        binaryRequest += pack("i", n)
+        binaryRequest += binascii.unhexlify(vintx)
+        binaryRequest += pack("i", 0)
 
         bin_response = http_post_call(url.hostname, url.port, '/rest/getutxos'+self.FORMAT_SEPARATOR+'bin', binaryRequest)
         output = StringIO.StringIO()
@@ -206,7 +204,7 @@ class RESTTest (BitcoinTestFramework):
         json_request = '/checkmempool/'
         for x in range(0, 15):
             json_request += txid+'-'+str(n)+'/'
-        json_request = json_request.rstrip("/");
+        json_request = json_request.rstrip("/")
         response = http_post_call(url.hostname, url.port, '/rest/getutxos'+json_request+self.FORMAT_SEPARATOR+'json', '', True)
         assert_equal(response.status, 200) #must be a 500 because we exceeding the limits
 
@@ -254,7 +252,7 @@ class RESTTest (BitcoinTestFramework):
         response_header_json = http_get_call(url.hostname, url.port, '/rest/headers/1/'+bb_hash+self.FORMAT_SEPARATOR+"json", True)
         assert_equal(response_header_json.status, 200)
         response_header_json_str = response_header_json.read()
-        json_obj = json.loads(response_header_json_str, parse_float=decimal.Decimal)
+        json_obj = json.loads(response_header_json_str, parse_float=Decimal)
         assert_equal(len(json_obj), 1) #ensure that there is one header in the json response
         assert_equal(json_obj[0]['hash'], bb_hash) #request/response hash should be the same
 
@@ -282,7 +280,7 @@ class RESTTest (BitcoinTestFramework):
         assert_equal(len(json_obj), 5) #now we should have 5 header objects
 
         # do tx test
-        tx_hash = block_json_obj['tx'][0]['txid'];
+        tx_hash = block_json_obj['tx'][0]['txid']
         json_string = http_get_call(url.hostname, url.port, '/rest/tx/'+tx_hash+self.FORMAT_SEPARATOR+"json")
         json_obj = json.loads(json_string)
         assert_equal(json_obj['txid'], tx_hash)

--- a/qa/rpc-tests/rpcbind_test.py
+++ b/qa/rpc-tests/rpcbind_test.py
@@ -5,13 +5,8 @@
 
 # Test for -rpcbind, as well as -rpcallowip and -rpcconnect
 
-# Add python-bitcoinrpc to module search path:
-import os
-import sys
+# TODO extend this test from the test framework (like all other tests)
 
-import json
-import shutil
-import subprocess
 import tempfile
 import traceback
 

--- a/qa/rpc-tests/sendheaders.py
+++ b/qa/rpc-tests/sendheaders.py
@@ -7,7 +7,6 @@
 from test_framework.mininode import *
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
-import time
 from test_framework.blocktools import create_block, create_coinbase
 
 '''
@@ -445,7 +444,7 @@ class SendHeadersTest(BitcoinTestFramework):
 
         inv_node.sync_with_ping() # Make sure blocks are processed
         test_node.last_getdata = None
-        test_node.send_header_for_blocks(blocks);
+        test_node.send_header_for_blocks(blocks)
         test_node.sync_with_ping()
         # should not have received any getdata messages
         with mininode_lock:

--- a/qa/rpc-tests/test_framework/blocktools.py
+++ b/qa/rpc-tests/test_framework/blocktools.py
@@ -5,7 +5,7 @@
 #
 
 from mininode import *
-from script import CScript, CScriptOp, OP_TRUE, OP_CHECKSIG
+from script import CScript, OP_TRUE, OP_CHECKSIG
 
 # Create a block (with regtest difficulty)
 def create_block(hashprev, coinbase, nTime=None):

--- a/qa/rpc-tests/test_framework/script.py
+++ b/qa/rpc-tests/test_framework/script.py
@@ -14,7 +14,8 @@ Functionality to build scripts, as well as SignatureHash().
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from test_framework.mininode import CTransaction, CTxOut, hash256
+from .mininode import CTransaction, CTxOut, hash256
+from binascii import hexlify
 
 import sys
 bchr = chr
@@ -24,10 +25,9 @@ if sys.version > '3':
     bchr = lambda x: bytes([x])
     bord = lambda x: x
 
-import copy
 import struct
 
-from test_framework.bignum import bn2vch
+from .bignum import bn2vch
 
 MAX_SCRIPT_SIZE = 10000
 MAX_SCRIPT_ELEMENT_SIZE = 520
@@ -777,7 +777,7 @@ class CScript(bytes):
         # need to change
         def _repr(o):
             if isinstance(o, bytes):
-                return "x('%s')" % binascii.hexlify(o).decode('utf8')
+                return "x('%s')" % hexlify(o).decode('utf8')
             else:
                 return repr(o)
 

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -102,12 +102,12 @@ def initialize_datadir(dirname, n):
     if not os.path.isdir(datadir):
         os.makedirs(datadir)
     with open(os.path.join(datadir, "bitcoin.conf"), 'w') as f:
-        f.write("regtest=1\n");
-        f.write("rpcuser=rt\n");
-        f.write("rpcpassword=rt\n");
-        f.write("port="+str(p2p_port(n))+"\n");
-        f.write("rpcport="+str(rpc_port(n))+"\n");
-        f.write("listenonion=0\n");
+        f.write("regtest=1\n")
+        f.write("rpcuser=rt\n")
+        f.write("rpcpassword=rt\n")
+        f.write("port="+str(p2p_port(n))+"\n")
+        f.write("rpcport="+str(rpc_port(n))+"\n")
+        f.write("listenonion=0\n")
     return datadir
 
 def initialize_chain(test_dir):

--- a/qa/rpc-tests/txn_clone.py
+++ b/qa/rpc-tests/txn_clone.py
@@ -8,11 +8,7 @@
 #
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.authproxy import AuthServiceProxy, JSONRPCException
-from decimal import Decimal
 from test_framework.util import *
-import os
-import shutil
 
 class TxnMallTest(BitcoinTestFramework):
 

--- a/qa/rpc-tests/txn_doublespend.py
+++ b/qa/rpc-tests/txn_doublespend.py
@@ -9,9 +9,6 @@
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
-from decimal import Decimal
-import os
-import shutil
 
 class TxnMallTest(BitcoinTestFramework):
 

--- a/qa/rpc-tests/wallet.py
+++ b/qa/rpc-tests/wallet.py
@@ -145,7 +145,7 @@ class WalletTest (BitcoinTestFramework):
         sync_blocks(self.nodes)
 
         relayed = self.nodes[0].resendwallettransactions()
-        assert_equal(set(relayed), set([txid1, txid2]))
+        assert_equal(set(relayed), {txid1, txid2})
         sync_mempools(self.nodes)
 
         assert(txid1 in self.nodes[3].getrawmempool())

--- a/qa/rpc-tests/zmq_test.py
+++ b/qa/rpc-tests/zmq_test.py
@@ -11,7 +11,6 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
 import zmq
 import binascii
-from test_framework.mininode import hash256
 
 try:
     import http.client as httplib
@@ -42,7 +41,7 @@ class ZMQTest (BitcoinTestFramework):
     def run_test(self):
         self.sync_all()
 
-        genhashes = self.nodes[0].generate(1);
+        genhashes = self.nodes[0].generate(1)
         self.sync_all()
 
         print "listen..."
@@ -58,7 +57,7 @@ class ZMQTest (BitcoinTestFramework):
         assert_equal(genhashes[0], blkhash) #blockhash from generate must be equal to the hash received over zmq
 
         n = 10
-        genhashes = self.nodes[1].generate(n);
+        genhashes = self.nodes[1].generate(n)
         self.sync_all()
 
         zmqHashes = []
@@ -76,7 +75,7 @@ class ZMQTest (BitcoinTestFramework):
         hashRPC = self.nodes[1].sendtoaddress(self.nodes[0].getnewaddress(), 1.0)
         self.sync_all()
 
-        #now we should receive a zmq msg because the tx was broadcastet
+        # now we should receive a zmq msg because the tx was broadcast
         msg = self.zmqSubSocket.recv_multipart()
         topic = str(msg[0])
         body = msg[1]


### PR DESCRIPTION
This is fixing four python syntax errors in the rpc tests. The rest is just removing imports or semicolons.
