### PR TITLE
release: remove libc6 dependency from the osx signing descriptor

### DIFF
--- a/contrib/gitian-descriptors/gitian-osx-signer.yml
+++ b/contrib/gitian-descriptors/gitian-osx-signer.yml
@@ -5,7 +5,6 @@ suites:
 architectures:
 - "amd64"
 packages:
-- "libc6:i386"
 - "faketime"
 reference_datetime: "2016-01-01 00:00:00"
 remotes:


### PR DESCRIPTION
It is unneeded after the last toolchain update, and missing from Trusty.

This is required for attaching the rc1 signature. Obviously needs a (non-conflicted) backport to 0.12.
