### PR TITLE
Mention mempool chain limits in release notes

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -113,6 +113,12 @@ minimum relay feerate will be increased to match this feerate plus the initial
 minimum relay feerate. The initial minimum relay feerate is set to
 1000 satoshis per kB.
 
+Bitcoin Core 0.12 also introduces new default policy limits on the length and
+size of unconfirmed transaction chains that are allowed in the mempool
+(generally limiting the length of unconfirmed chains to 25 transactions, with a
+total size of 101 KB).  These limits can be overriden using command line
+arguments; see the extended help (`--help -help-debug`) for more information.
+
 Replace-by-fee transactions
 ---------------------------
 


### PR DESCRIPTION
A user reported an issue with bumping into the chain limits in 0.12 on IRC this evening, and I realized that we don't seem to mention these new policy limits in the release notes. 

I wasn't sure exactly what to say here, as we apparently decided to hide the command line options for changing these values as a help-debug option, and even phrasing the exact limits is a bit tedious and technical, so I figured I'd just highlight the main idea of the limits and not explain exactly how they're implemented or how exactly you'd change them (ie with separate ancestor and descendant limits).  
