### PR TITLE
[Tests] Eliminate race condition in mempool_packages.py

### DIFF
--- a/qa/rpc-tests/mempool_packages.py
+++ b/qa/rpc-tests/mempool_packages.py
@@ -87,9 +87,18 @@ class MempoolPackagesTest(BitcoinTestFramework):
             print "too-long-ancestor-chain successfully rejected"
 
         # Check that prioritising a tx before it's added to the mempool works
+        # First clear the mempool by mining a block.
         self.nodes[0].generate(1)
+        sync_blocks(self.nodes)
+        assert_equal(len(self.nodes[0].getrawmempool()), 0)
+        # Prioritise a transaction that has been mined, then add it back to the
+        # mempool by using invalidateblock.
         self.nodes[0].prioritisetransaction(chain[-1], 0, 2000)
         self.nodes[0].invalidateblock(self.nodes[0].getbestblockhash())
+        # Keep node1's tip synced with node0
+        self.nodes[1].invalidateblock(self.nodes[1].getbestblockhash())
+
+        # Now check that the transaction is in the mempool, with the right modified fee
         mempool = self.nodes[0].getrawmempool(True)
 
         descendant_fees = 0


### PR DESCRIPTION
I noticed intermittent failures in the `mempool_packages.py` RPC test; turns out I introduced a race condition in a recent pull (#7062).

Before this change, node1 could either be in sync or out of sync with node0 after `invalidateblock` was called, depending on how fast that happened.  The test would fail if they were out of sync.  This fixes the test by enforcing that their tips stay synced up.

@laanwj Note that this bug is in 0.12, in case you think this should be backported or included in the next 0.12 release candidate.
