### PR TITLE
[Tests] Fix error in blockchain.py introduced in merge

### DIFF
--- a/qa/rpc-tests/blockchain.py
+++ b/qa/rpc-tests/blockchain.py
@@ -80,7 +80,7 @@ class BlockchainTest(BitcoinTestFramework):
         assert isinstance(header['mediantime'], int)
         assert isinstance(header['nonce'], int)
         assert isinstance(header['version'], int)
-        assert isinstance(header['difficulty'], decimal.Decimal)
+        assert isinstance(header['difficulty'], Decimal)
 
 if __name__ == '__main__':
     BlockchainTest().main()


### PR DESCRIPTION
`blockchain.py` is failing on master and 0.12, due to a subtle merge conflict when #7194 was merged.

@laanwj Needs backport
