### PR TITLE
Payments: Allow zero value OP_RETURN in PaymentRequests

### DIFF
--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -556,23 +556,6 @@ bool PaymentServer::processPaymentRequest(const PaymentRequestPlus& request, Sen
     QStringList addresses;
 
     Q_FOREACH(const PAIRTYPE(CScript, CAmount)& sendingTo, sendingTos) {
-        opcodetype scriptOp;
-        CScript::const_iterator pc = sendingTo.first.begin();
-        sendingTo.first.GetOp(pc, scriptOp);
-
-        // Only allow zero value OP_RETURNs
-        if (scriptOp == OP_RETURN) {
-            std::vector<unsigned char> data;
-            opcodetype opcode;
-            sendingTo.first.GetOp(pc, opcode, data);
-            if (sendingTo.second != 0) {
-                Q_EMIT message(tr("Payment request rejected"),
-                    tr("OP_RETURN scripts must be zero value."),
-                    CClientUIInterface::MSG_ERROR);
-                return false;
-            }
-        }
-
         // Extract and check destination addresses
         CTxDestination dest;
         if (ExtractDestination(sendingTo.first, dest)) {

--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -556,6 +556,23 @@ bool PaymentServer::processPaymentRequest(const PaymentRequestPlus& request, Sen
     QStringList addresses;
 
     Q_FOREACH(const PAIRTYPE(CScript, CAmount)& sendingTo, sendingTos) {
+        opcodetype scriptOp;
+        CScript::const_iterator pc = sendingTo.first.begin();
+        sendingTo.first.GetOp(pc, scriptOp);
+
+        // Only allow zero value OP_RETURNs
+        if (scriptOp == OP_RETURN) {
+            std::vector<unsigned char> data;
+            opcodetype opcode;
+            sendingTo.first.GetOp(pc, opcode, data);
+            if (sendingTo.second != 0) {
+                Q_EMIT message(tr("Payment request rejected"),
+                    tr("OP_RETURN scripts must be zero value."),
+                    CClientUIInterface::MSG_ERROR);
+                return false;
+            }
+        }
+
         // Extract and check destination addresses
         CTxDestination dest;
         if (ExtractDestination(sendingTo.first, dest)) {

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -217,13 +217,19 @@ WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransact
             for (int i = 0; i < details.outputs_size(); i++)
             {
                 const payments::Output& out = details.outputs(i);
-                if (out.amount() <= 0) continue;
-                subtotal += out.amount();
                 const unsigned char* scriptStr = (const unsigned char*)out.script().data();
-                CScript scriptPubKey(scriptStr, scriptStr+out.script().size());
-                CAmount nAmount = out.amount();
-                CRecipient recipient = {scriptPubKey, nAmount, rcp.fSubtractFeeFromAmount};
-                vecSend.push_back(recipient);
+                CScript script(scriptStr, scriptStr+out.script().size());
+                opcodetype scriptOp;
+                CScript::const_iterator pc = script.begin();
+                script.GetOp(pc, scriptOp);
+
+                if ((out.amount() > 0 && scriptOp != OP_RETURN) || (scriptOp == OP_RETURN && out.amount() == 0))
+                {
+                  subtotal += out.amount();
+                  CAmount nAmount = out.amount();
+                  CRecipient recipient = {script, nAmount, rcp.fSubtractFeeFromAmount};
+                  vecSend.push_back(recipient);
+                }
             }
             if (subtotal <= 0)
             {

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -223,7 +223,7 @@ WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransact
                 CScript::const_iterator pc = script.begin();
                 script.GetOp(pc, scriptOp);
 
-                if ((out.amount() > 0 && scriptOp != OP_RETURN) || (scriptOp == OP_RETURN && out.amount() == 0))
+                if (out.amount() > 0 || scriptOp == OP_RETURN)
                 {
                   subtotal += out.amount();
                   CAmount nAmount = out.amount();


### PR DESCRIPTION
PaymentRequests currently support any valid script
serialized in the PaymentDetails protocol buffer.
Zero value outputs are ignored and not included in the
transaction. This means that OP_RETURN scripts are
currently supported but they must have a > zero value,
effectively destroying the value assigned to that output.

This patch allows zero value PaymentRequest outputs ONLY
if the script is an OP_RETURN. ~~It also requires that all
OP_RETURN outputs be zero value to address the value
destruction issue.~~
