### PR TITLE
[walletdb] Fix syntax error in key parser

### DIFF
--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -205,7 +205,7 @@ bool CDBEnv::Salvage(const std::string& strFile, bool fAggressive, std::vector<C
     std::string keyHex, valueHex;
     while (!strDump.eof() && keyHex != "DATA=END") {
         getline(strDump, keyHex);
-        if (keyHex != "DATA_END") {
+        if (keyHex != "DATA=END") {
             getline(strDump, valueHex);
             vResult.push_back(make_pair(ParseHex(keyHex), ParseHex(valueHex)));
         }


### PR DESCRIPTION
This needs backport to all versions of bitcoin/altcoins after merge.

A dump may look like:

```
VERSION=3
format=bytevalue
database=main
type=btree
db_pagesize=4096
HEADER=END
<{Data}>
DATA=END
```

So the current parser gives us odd data like:

`keyHex="DATA=END";`
`valueHex="";`

(sometimes the other way round)
