### PR TITLE
Set `-permitrbf` to false

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -1,5 +1,5 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
-// Copyright (c) 2009-2015 The Bitcoin Core developers
+// Copyright (c) 2009-2016 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -108,7 +108,7 @@ static const unsigned int DEFAULT_BANSCORE_THRESHOLD = 100;
 
 static const bool DEFAULT_TESTSAFEMODE = false;
 /** Default for -permitrbf */
-static const bool DEFAULT_PERMIT_REPLACEMENT = true;
+static const bool DEFAULT_PERMIT_REPLACEMENT = false;
 
 /** Maximum number of headers to announce when relaying blocks with headers message.*/
 static const unsigned int MAX_BLOCKS_TO_ANNOUNCE = 8;


### PR DESCRIPTION
Can't believe that the original pull request got merged just after 3 hours. I'm leaving for work now, so will be gone for 10 hours.

Edit: This PR will result in nodes not relaying and mining RBF transactions by default. If we merge this there will be no policy change from the last stable version which is Bitcoin Core 0.11.2.
