### PR TITLE
RPC: decodescript - Only show P2SH address for P2SH scripts

### DIFF
--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -520,7 +520,8 @@ UniValue decodescript(const UniValue& params, bool fHelp)
     }
     ScriptPubKeyToJSON(script, r, false);
 
-    r.push_back(Pair("p2sh", CBitcoinAddress(CScriptID(script)).ToString()));
+    if (script.IsPayToScriptHash())
+        r.push_back(Pair("p2sh", CBitcoinAddress(CScriptID(script)).ToString()));
     return r;
 }
 


### PR DESCRIPTION
In decodescript output, only show the corresponding P2SH address
if the script is a P2SH script.
