### PR TITLE
[devtools] github-merge get toplevel dir without extra whitespace

### DIFF
--- a/contrib/devtools/github-merge.py
+++ b/contrib/devtools/github-merge.py
@@ -153,7 +153,7 @@ def main():
         # Run test command if configured.
         if testcmd:
             # Go up to the repository's root.
-            toplevel = subprocess.check_output([GIT,'rev-parse','--show-toplevel'])
+            toplevel = subprocess.check_output([GIT,'rev-parse','--show-toplevel']).strip()
             os.chdir(toplevel)
             if subprocess.call(testcmd,shell=True):
                 print("ERROR: Running %s failed." % testcmd,file=stderr)


### PR DESCRIPTION
Fixes a bug in github merge when it runs the tests where the toplevel directory has an extra '\n' appended to the path string. Now it doesn't.
