### PR TITLE
devtools: Fix utf-8 support in messages for github-merge

### DIFF
--- a/contrib/devtools/github-merge.py
+++ b/contrib/devtools/github-merge.py
@@ -147,14 +147,14 @@ def main():
         else:
             firstline = 'Merge #%s' % (pull,)
         message = firstline + '\n\n'
-        message += subprocess.check_output([GIT,'log','--no-merges','--topo-order','--pretty=format:%h %s (%an)',base_branch+'..'+head_branch])
+        message += subprocess.check_output([GIT,'log','--no-merges','--topo-order','--pretty=format:%h %s (%an)',base_branch+'..'+head_branch]).decode('utf-8')
         try:
-            subprocess.check_call([GIT,'merge','-q','--commit','--no-edit','--no-ff','-m',message,head_branch])
+            subprocess.check_call([GIT,'merge','-q','--commit','--no-edit','--no-ff','-m',message.encode('utf-8'),head_branch])
         except subprocess.CalledProcessError as e:
             print("ERROR: Cannot be merged cleanly.",file=stderr)
             subprocess.check_call([GIT,'merge','--abort'])
             exit(4)
-        logmsg = subprocess.check_output([GIT,'log','--pretty=format:%s','-n','1'])
+        logmsg = subprocess.check_output([GIT,'log','--pretty=format:%s','-n','1']).decode('utf-8')
         if logmsg.rstrip() != firstline.rstrip():
             print("ERROR: Creating merge failed (already merged?).",file=stderr)
             exit(4)


### PR DESCRIPTION
Use `utf-8` instead of the Python 2 default of `ascii` to encode/decode commit messages.
This can be removed when switching to Python 3, as `utf-8` is the default there.
Necessary for merging #7422 due to the ฿ in ฿tcDrak. Also tested that this works when there are unicode characters in the github title.
