### PR TITLE
doc: add example for listing ./configure flags

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -236,3 +236,9 @@ In this case there is no dependency on Berkeley DB 4.8.
 
 Mining is also possible in disable-wallet mode, but only using the `getblocktemplate` RPC
 call not `getwork`.
+
+Additional Configure Flags
+--------------------------
+A list of additional configure flags can be displayed with:
+
+    ./configure --help


### PR DESCRIPTION
Going through and building bitcoind is a great learning process.  This is the only detail I found missing from the guide.  I think this may be common knowledge but its key information for a new user needing to read the build guide.
