### PR TITLE
0.12 release notes: Sort by importance to usability

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -96,6 +96,32 @@ as a whole: stored blocks could be served to other nodes.
 For further information about pruning, you may also consult the [release
 notes of v0.11.0](https://github.com/bitcoin/bitcoin/blob/v0.11.0/doc/release-notes.md#block-file-pruning).
 
+Memory pool limiting
+--------------------
+
+Previous versions of Bitcoin Core had their mempool limited by checking
+a transaction's fees against the node's minimum relay fee. There was no
+upper bound on the size of the mempool and attackers could send a large
+number of transactions paying just slighly more than the default minimum
+relay fee to crash nodes with relatively low RAM. A temporary workaround
+for previous versions of Bitcoin Core was to raise the default minimum
+relay fee.
+
+Bitcoin Core 0.12 will have a strict maximum size on the mempool. The
+default value is 300 MB and can be configured with the `-maxmempool`
+parameter. Whenever a transaction would cause the mempool to exceed
+its maximum size, the transaction that (along with in-mempool descendants) has
+the lowest total feerate (as a package) will be evicted and the node's effective
+minimum relay feerate will be increased to match this feerate plus the initial
+minimum relay feerate. The initial minimum relay feerate is set to
+1000 satoshis per kB.
+
+Bitcoin Core 0.12 also introduces new default policy limits on the length and
+size of unconfirmed transaction chains that are allowed in the mempool
+(generally limiting the length of unconfirmed chains to 25 transactions, with a
+total size of 101 KB).  These limits can be overriden using command line
+arguments; see the extended help (`--help -help-debug`) for more information.
+
 Reduce upload traffic
 ---------------------
 
@@ -130,32 +156,6 @@ can often prevent an extra roundtrip before the actual block is downloaded.
 
 With this change, pruning nodes are now able to relay new blocks to compatible
 peers.
-
-Memory pool limiting
---------------------
-
-Previous versions of Bitcoin Core had their mempool limited by checking
-a transaction's fees against the node's minimum relay fee. There was no
-upper bound on the size of the mempool and attackers could send a large
-number of transactions paying just slighly more than the default minimum
-relay fee to crash nodes with relatively low RAM. A temporary workaround
-for previous versions of Bitcoin Core was to raise the default minimum
-relay fee.
-
-Bitcoin Core 0.12 will have a strict maximum size on the mempool. The
-default value is 300 MB and can be configured with the `-maxmempool`
-parameter. Whenever a transaction would cause the mempool to exceed
-its maximum size, the transaction that (along with in-mempool descendants) has
-the lowest total feerate (as a package) will be evicted and the node's effective
-minimum relay feerate will be increased to match this feerate plus the initial
-minimum relay feerate. The initial minimum relay feerate is set to
-1000 satoshis per kB.
-
-Bitcoin Core 0.12 also introduces new default policy limits on the length and
-size of unconfirmed transaction chains that are allowed in the mempool
-(generally limiting the length of unconfirmed chains to 25 transactions, with a
-total size of 101 KB).  These limits can be overriden using command line
-arguments; see the extended help (`--help -help-debug`) for more information.
 
 Opt-in Replace-by-fee transactions
 ----------------------------------

--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -72,6 +72,30 @@ Libsecp256k1 has undergone very extensive testing and validation.
 
 A side effect of this change is that libconsensus no longer depends on OpenSSL.
 
+Wallet: Pruning
+---------------
+
+With 0.12 it is possible to use wallet functionality in pruned mode.
+This can reduce the disk usage from currently around 60 GB to
+around 2 GB.
+
+However, rescans as well as the RPCs `importwallet`, `importaddress`,
+`importprivkey` are disabled.
+
+To enable block pruning set `prune=<N>` on the command line or in
+`bitcoin.conf`, where `N` is the number of MiB to allot for
+raw block & undo data.
+
+A value of 0 disables pruning. The minimal value above 0 is 550. Your
+wallet is as secure with high values as it is with low ones. Higher
+values merely ensure that your node will not shut down upon blockchain
+reorganizations of more than 2 days - which are unlikely to happen in
+practice. In future releases, a higher value may also help the network
+as a whole: stored blocks could be served to other nodes.
+
+For further information about pruning, you may also consult the [release
+notes of v0.11.0](https://github.com/bitcoin/bitcoin/blob/v0.11.0/doc/release-notes.md#block-file-pruning).
+
 Reduce upload traffic
 ---------------------
 
@@ -285,30 +309,6 @@ presence in blocks. This wasn't being used for more than an expensive
 sanity check. Since 0.12, these are no longer stored. When loading a
 0.12 wallet into an older version, it will automatically rescan to avoid
 failed checks.
-
-Wallet: Pruning
----------------
-
-With 0.12 it is possible to use wallet functionality in pruned mode.
-This can reduce the disk usage from currently around 60 GB to
-around 2 GB.
-
-However, rescans as well as the RPCs `importwallet`, `importaddress`,
-`importprivkey` are disabled.
-
-To enable block pruning set `prune=<N>` on the command line or in
-`bitcoin.conf`, where `N` is the number of MiB to allot for
-raw block & undo data.
-
-A value of 0 disables pruning. The minimal value above 0 is 550. Your
-wallet is as secure with high values as it is with low ones. Higher
-values merely ensure that your node will not shut down upon blockchain
-reorganizations of more than 2 days - which are unlikely to happen in
-practice. In future releases, a higher value may also help the network
-as a whole: stored blocks could be served to other nodes.
-
-For further information about pruning, you may also consult the [release
-notes of v0.11.0](https://github.com/bitcoin/bitcoin/blob/v0.11.0/doc/release-notes.md#block-file-pruning).
 
 `NODE_BLOOM` service bit
 ------------------------

--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -144,6 +144,24 @@ calculating the target.
 A more detailed documentation about keeping traffic low can be found in
 [/doc/reduce-traffic.md](/doc/reduce-traffic.md).
 
+Automatically use Tor hidden services
+-------------------------------------
+
+Starting with Tor version 0.2.7.1 it is possible, through Tor's control socket
+API, to create and destroy 'ephemeral' hidden services programmatically.
+Bitcoin Core has been updated to make use of this.
+
+This means that if Tor is running (and proper authorization is available),
+Bitcoin Core automatically creates a hidden service to listen on, without
+manual configuration. Bitcoin Core will also use Tor automatically to connect
+to other .onion nodes if the control socket can be successfully opened. This
+will positively affect the number of available .onion nodes and their usage.
+
+This new feature is enabled by default if Bitcoin Core is listening, and
+a connection to Tor can be made. It can be configured with the `-listenonion`,
+`-torcontrol` and `-torpassword` settings. To show verbose debugging
+information, pass `-debug=tor`.
+
 Direct headers announcement (BIP 130)
 -------------------------------------
 
@@ -229,24 +247,6 @@ coin age of inputs that were in the blockchain at the time the transaction
 was accepted into the mempool.  In addition priority transactions are not
 accepted to the mempool if mempool limiting has triggered a higher effective
 minimum relay fee.
-
-Automatically use Tor hidden services
--------------------------------------
-
-Starting with Tor version 0.2.7.1 it is possible, through Tor's control socket
-API, to create and destroy 'ephemeral' hidden services programmatically.
-Bitcoin Core has been updated to make use of this.
-
-This means that if Tor is running (and proper authorization is available),
-Bitcoin Core automatically creates a hidden service to listen on, without
-manual configuration. Bitcoin Core will also use Tor automatically to connect
-to other .onion nodes if the control socket can be successfully opened. This
-will positively affect the number of available .onion nodes and their usage.
-
-This new feature is enabled by default if Bitcoin Core is listening, and
-a connection to Tor can be made. It can be configured with the `-listenonion`,
-`-torcontrol` and `-torpassword` settings. To show verbose debugging
-information, pass `-debug=tor`.
 
 Notifications through ZMQ
 -------------------------

--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -222,7 +222,6 @@ BIP125 ("bip125-replaceable").
 Note that the wallet in Bitcoin Core 0.12 does not yet have support for
 creating transactions that would be replaceable under BIP 125.
 
-
 RPC: Random-cookie RPC authentication
 ---------------------------------------
 

--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -144,6 +144,24 @@ calculating the target.
 A more detailed documentation about keeping traffic low can be found in
 [/doc/reduce-traffic.md](/doc/reduce-traffic.md).
 
+Wallet: Negative confirmations and conflict detection
+-----------------------------------------------------
+
+The wallet will now report a negative number for confirmations that indicates
+how deep in the block chain the conflict is found. For example, if a transaction
+A has 5 confirmations and spends the same input as a wallet transaction B, B
+will be reported as having -5 confirmations. If another wallet transaction C
+spends an output from B, it will also be reported as having -5 confirmations.
+To detect conflicts with historical transactions in the chain a one-time
+`-rescan` may be needed.
+
+Unlike earlier versions, unconfirmed but non-conflicting transactions will never
+get a negative confirmation count. They are not treated as spendable unless
+they're coming from ourself (change) and accepted into our local mempool,
+however. The new "trusted" field in the `listtransactions` RPC output
+indicates whether outputs of an unconfirmed transaction are considered
+spendable.
+
 Automatically use Tor hidden services
 -------------------------------------
 
@@ -282,24 +300,6 @@ Furthermore, Bitcoin Core will never create transactions smaller than
 the current minimum relay fee.
 Finally, a user can set the minimum fee rate for all transactions with
 `-mintxfee=<i>`, which defaults to 1000 satoshis per kB.
-
-Wallet: Negative confirmations and conflict detection
------------------------------------------------------
-
-The wallet will now report a negative number for confirmations that indicates
-how deep in the block chain the conflict is found. For example, if a transaction
-A has 5 confirmations and spends the same input as a wallet transaction B, B
-will be reported as having -5 confirmations. If another wallet transaction C
-spends an output from B, it will also be reported as having -5 confirmations.
-To detect conflicts with historical transactions in the chain a one-time
-`-rescan` may be needed.
-
-Unlike earlier versions, unconfirmed but non-conflicting transactions will never
-get a negative confirmation count. They are not treated as spendable unless
-they're coming from ourself (change) and accepted into our local mempool,
-however. The new "trusted" field in the `listtransactions` RPC output
-indicates whether outputs of an unconfirmed transaction are considered
-spendable.
 
 Wallet: Merkle branches removed
 -------------------------------


### PR DESCRIPTION
## Changes

Move stuff of the following categories to the to the top of the notes, in this descending order by how important I consider it:
1. CPU usage (= libsecp256k1)
2. Disk usage (= pruning)
3. Memory usage (= mempool limiting)
4. Network usage (= upload limit)
5. Security (= negative confirmations, Tor)

Reasons for this choice: CPU, disk, memory and network are what will cause the most visible annoyance to the user, so they're first. With money, security is important as well, so that's also bumped.

This PR only moves the stuff which I think is understandable to an average user.
In other words, I didn't touch the more technical stuff which will be difficult to grasp.
If you want me to sort that as well, feel free to suggest what to move where.
### Bonus change

There was an empty line which I think made no sense, I removed it in 302af5424156584d71d17aa6b211c55a9336.
## Open questions

I actually think the potential ~ 60 GB disk usage reduction by pruning is the most important change, not the 5x signature validation CPU usage reduction by libsecp256k1: CPU cycles are continuously "produced" by the users machine, but the available disk space is usually fixed. And 60 GB is _a lot_!
But as I'm biased by having a small SSD in my laptop, I would please like to first request reviewers to voice a vote on whether I should move pruning above libsecp256k1 or not?
