### PR TITLE
AcceptToMempool: extract various policy functions

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -812,7 +812,7 @@ std::string FormatStateMessage(const CValidationState &state)
         state.GetRejectCode());
 }
 
-bool HasConflicts(CTxMemPool& pool, const CTransaction& tx, set<uint256>& setConflicts);
+bool HasReplacableConflicts(CTxMemPool& pool, const CTransaction& tx, set<uint256>& setConflicts);
 bool IsNewTransaction(CTxMemPool& pool, CValidationState &state, const CTransaction& tx, CCoinsViewCache& view, CAmount& nValueIn, bool* pfMissingInputs, std::vector<uint256>& vHashTxnToUncache);
 bool IsRateLimited (unsigned int nSize, CAmount nModifiedFees);
 
@@ -849,7 +849,7 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState &state, const C
 
     // Check for conflicts with in-memory transactions
     set<uint256> setConflicts;
-    if (HasConflicts(pool, tx, setConflicts))
+    if (HasReplacableConflicts(pool, tx, setConflicts))
         return state.Invalid(false, REJECT_CONFLICT, "txn-mempool-conflict");
 
     {
@@ -1155,7 +1155,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
 }
 
 // TODO: move to policy/
-bool HasConflicts(CTxMemPool& pool, const CTransaction& tx, set<uint256>& setConflicts) {
+bool HasReplacableConflicts(CTxMemPool& pool, const CTransaction& tx, set<uint256>& setConflicts) {
     LOCK(pool.cs); // protect pool.mapNextTx
     BOOST_FOREACH(const CTxIn &txin, tx.vin)
     {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1208,7 +1208,7 @@ bool IsRateLimited (unsigned int nSize, CAmount nModifiedFees) {
     // -limitfreerelay unit is thousand-bytes-per-minute
     // At default rate it would take over a month to fill 1GB
     if (dFreeCount + nSize >= GetArg("-limitfreerelay", DEFAULT_LIMITFREERELAY) * 10 * 1000)
-        return state.DoS(0, false, REJECT_INSUFFICIENTFEE, "rate limited free transaction");
+        return true;
 
     LogPrint("mempool", "Rate limit dFreeCount: %g => %g\n", dFreeCount, dFreeCount+nSize);
     dFreeCount += nSize;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -812,6 +812,10 @@ std::string FormatStateMessage(const CValidationState &state)
         state.GetRejectCode());
 }
 
+bool HasConflicts(CTxMemPool& pool, const CTransaction& tx, set<uint256>& setConflicts);
+bool IsNewTransaction(CTxMemPool& pool, CValidationState &state, const CTransaction& tx, CCoinsViewCache& view, CAmount& nValueIn, bool* pfMissingInputs, std::vector<uint256>& vHashTxnToUncache);
+bool IsRateLimited (unsigned int nSize, CAmount nModifiedFees);
+
 bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState &state, const CTransaction &tx, bool fLimitFree,
                               bool* pfMissingInputs, bool fOverrideMempoolLimit, bool fRejectAbsurdFee,
                               std::vector<uint256>& vHashTxnToUncache)
@@ -845,101 +849,33 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState &state, const C
 
     // Check for conflicts with in-memory transactions
     set<uint256> setConflicts;
-    {
-    LOCK(pool.cs); // protect pool.mapNextTx
-    BOOST_FOREACH(const CTxIn &txin, tx.vin)
-    {
-        if (pool.mapNextTx.count(txin.prevout))
-        {
-            const CTransaction *ptxConflicting = pool.mapNextTx[txin.prevout].ptx;
-            if (!setConflicts.count(ptxConflicting->GetHash()))
-            {
-                // Allow opt-out of transaction replacement by setting
-                // nSequence >= maxint-1 on all inputs.
-                //
-                // maxint-1 is picked to still allow use of nLockTime by
-                // non-replacable transactions. All inputs rather than just one
-                // is for the sake of multi-party protocols, where we don't
-                // want a single party to be able to disable replacement.
-                //
-                // The opt-out ignores descendants as anyone relying on
-                // first-seen mempool behavior should be checking all
-                // unconfirmed ancestors anyway; doing otherwise is hopelessly
-                // insecure.
-                bool fReplacementOptOut = true;
-                if (fPermitReplacement)
-                {
-                    BOOST_FOREACH(const CTxIn &txin, ptxConflicting->vin)
-                    {
-                        if (txin.nSequence < std::numeric_limits<unsigned int>::max()-1)
-                        {
-                            fReplacementOptOut = false;
-                            break;
-                        }
-                    }
-                }
-                if (fReplacementOptOut)
-                    return state.Invalid(false, REJECT_CONFLICT, "txn-mempool-conflict");
-
-                setConflicts.insert(ptxConflicting->GetHash());
-            }
-        }
-    }
-    }
+    if (HasConflicts(pool, tx, setConflicts))
+        return state.Invalid(false, REJECT_CONFLICT, "txn-mempool-conflict");
 
     {
         CCoinsView dummy;
         CCoinsViewCache view(&dummy);
 
         CAmount nValueIn = 0;
+
         {
-        LOCK(pool.cs);
-        CCoinsViewMemPool viewMemPool(pcoinsTip, pool);
-        view.SetBackend(viewMemPool);
+            LOCK(pool.cs);
 
-        // do we already have it?
-        bool fHadTxInCache = pcoinsTip->HaveCoinsInCache(hash);
-        if (view.HaveCoins(hash)) {
-            if (!fHadTxInCache)
-                vHashTxnToUncache.push_back(hash);
-            return state.Invalid(false, REJECT_ALREADY_KNOWN, "txn-already-known");
-        }
+            CCoinsViewMemPool viewMemPool(pcoinsTip, pool);
+            view.SetBackend(viewMemPool);
 
-        // do all inputs exist?
-        // Note that this does not check for the presence of actual outputs (see the next check for that),
-        // and only helps with filling in pfMissingInputs (to determine missing vs spent).
-        BOOST_FOREACH(const CTxIn txin, tx.vin) {
-            if (!pcoinsTip->HaveCoinsInCache(txin.prevout.hash))
-                vHashTxnToUncache.push_back(txin.prevout.hash);
-            if (!view.HaveCoins(txin.prevout.hash)) {
-                if (pfMissingInputs)
-                    *pfMissingInputs = true;
-                return false; // fMissingInputs and !state.IsInvalid() is used to detect this condition, don't set state.Invalid()
-            }
-        }
+            if (!IsNewTransaction(pool, state, tx, view, nValueIn, pfMissingInputs, vHashTxnToUncache)) return false;
 
-        // are the actual inputs available?
-        if (!view.HaveInputs(tx))
-            return state.Invalid(false, REJECT_DUPLICATE, "bad-txns-inputs-spent");
-
-        // Bring the best block into scope
-        view.GetBestBlock();
-
-        nValueIn = view.GetValueIn(tx);
-
-        // we have all inputs cached now, so switch back to dummy, so we don't need to keep lock on mempool
-        view.SetBackend(dummy);
+            // we have all inputs cached now, so switch back to dummy, so we don't need to keep lock on mempool
+            view.SetBackend(dummy);
         }
 
         // Check for non-standard pay-to-script-hash in inputs
         if (fRequireStandard && !AreInputsStandard(tx, view))
             return state.Invalid(false, REJECT_NONSTANDARD, "bad-txns-nonstandard-inputs");
 
-        unsigned int nSigOps = GetLegacySigOpCount(tx);
-        nSigOps += GetP2SHSigOpCount(tx, view);
-
         CAmount nValueOut = tx.GetValueOut();
-        CAmount nFees = nValueIn-nValueOut;
+        CAmount nFees = nValueIn - nValueOut;
         // nModifiedFees includes any fee deltas from PrioritiseTransaction
         CAmount nModifiedFees = nFees;
         double nPriorityDummy = 0;
@@ -958,6 +894,9 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState &state, const C
                 break;
             }
         }
+
+        unsigned int nSigOps = GetLegacySigOpCount(tx);
+        nSigOps += GetP2SHSigOpCount(tx, view);
 
         CTxMemPoolEntry entry(tx, nFees, GetTime(), dPriority, chainActive.Height(), pool.HasNoInputsOf(tx), inChainInputValue, fSpendsCoinbase, nSigOps);
         unsigned int nSize = entry.GetTxSize();
@@ -982,24 +921,8 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState &state, const C
         // Continuously rate-limit free (really, very-low-fee) transactions
         // This mitigates 'penny-flooding' -- sending thousands of free transactions just to
         // be annoying or make others' transactions take longer to confirm.
-        if (fLimitFree && nModifiedFees < ::minRelayTxFee.GetFee(nSize))
-        {
-            static CCriticalSection csFreeLimiter;
-            static double dFreeCount;
-            static int64_t nLastTime;
-            int64_t nNow = GetTime();
-
-            LOCK(csFreeLimiter);
-
-            // Use an exponentially decaying ~10-minute window:
-            dFreeCount *= pow(1.0 - 1.0/600.0, (double)(nNow - nLastTime));
-            nLastTime = nNow;
-            // -limitfreerelay unit is thousand-bytes-per-minute
-            // At default rate it would take over a month to fill 1GB
-            if (dFreeCount + nSize >= GetArg("-limitfreerelay", DEFAULT_LIMITFREERELAY) * 10 * 1000)
-                return state.DoS(0, false, REJECT_INSUFFICIENTFEE, "rate limited free transaction");
-            LogPrint("mempool", "Rate limit dFreeCount: %g => %g\n", dFreeCount, dFreeCount+nSize);
-            dFreeCount += nSize;
+        if (fLimitFree && IsRateLimited(nSize, nModifiedFees)) {
+            return state.DoS(0, false, REJECT_INSUFFICIENTFEE, "rate limited free transaction");
         }
 
         if (fRejectAbsurdFee && nFees > maxTxFee)
@@ -1229,6 +1152,110 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
             pcoinsTip->Uncache(hashTx);
     }
     return res;
+}
+
+// TODO: move to policy/
+bool HasConflicts(CTxMemPool& pool, const CTransaction& tx, set<uint256>& setConflicts) {
+    LOCK(pool.cs); // protect pool.mapNextTx
+    BOOST_FOREACH(const CTxIn &txin, tx.vin)
+    {
+        if (pool.mapNextTx.count(txin.prevout))
+        {
+            const CTransaction *ptxConflicting = pool.mapNextTx[txin.prevout].ptx;
+            if (!setConflicts.count(ptxConflicting->GetHash()))
+            {
+                // Allow opt-out of transaction replacement by setting
+                // nSequence >= maxint-1 on all inputs.
+                //
+                // maxint-1 is picked to still allow use of nLockTime by
+                // non-replacable transactions. All inputs rather than just one
+                // is for the sake of multi-party protocols, where we don't
+                // want a single party to be able to disable replacement.
+                //
+                // The opt-out ignores descendants as anyone relying on
+                // first-seen mempool behavior should be checking all
+                // unconfirmed ancestors anyway; doing otherwise is hopelessly
+                // insecure.
+                bool fReplacementOptOut = true;
+                if (fPermitReplacement)
+                {
+                    BOOST_FOREACH(const CTxIn &txin, ptxConflicting->vin)
+                    {
+                        if (txin.nSequence < std::numeric_limits<unsigned int>::max()-1)
+                        {
+                            fReplacementOptOut = false;
+                            break;
+                        }
+                    }
+                }
+                if (fReplacementOptOut)
+                    return true;
+
+                setConflicts.insert(ptxConflicting->GetHash());
+            }
+        }
+    }
+
+    return false;
+}
+
+bool IsNewTransaction(CTxMemPool& pool, CValidationState &state, const CTransaction& tx, CCoinsViewCache& view, CAmount& nValueIn, bool* pfMissingInputs, std::vector<uint256>& vHashTxnToUncache) {
+    const uint256 hash = tx.GetHash();
+
+    // do we already have it?
+    bool fHadTxInCache = pcoinsTip->HaveCoinsInCache(hash);
+    if (view.HaveCoins(hash)) {
+        if (!fHadTxInCache)
+            vHashTxnToUncache.push_back(hash);
+        return state.Invalid(false, REJECT_ALREADY_KNOWN, "txn-already-known");
+    }
+
+    // do all inputs exist?
+    // Note that this does not check for the presence of actual outputs (see the next check for that),
+    // and only helps with filling in pfMissingInputs (to determine missing vs spent).
+    BOOST_FOREACH(const CTxIn txin, tx.vin) {
+        if (!pcoinsTip->HaveCoinsInCache(txin.prevout.hash))
+            vHashTxnToUncache.push_back(txin.prevout.hash);
+        if (!view.HaveCoins(txin.prevout.hash)) {
+            if (pfMissingInputs)
+                *pfMissingInputs = true;
+            return false; // fMissingInputs and !state.IsInvalid() is used to detect this condition, don't set state.Invalid()
+        }
+    }
+
+    // are the actual inputs available?
+    if (!view.HaveInputs(tx))
+        return state.Invalid(false, REJECT_DUPLICATE, "bad-txns-inputs-spent");
+
+    // Bring the best block into scope
+    view.GetBestBlock();
+
+    nValueIn = view.GetValueIn(tx);
+
+    return true;
+}
+
+bool IsRateLimited (unsigned int nSize, CAmount nModifiedFees) {
+    if (nModifiedFees >= ::minRelayTxFee.GetFee(nSize)) return false;
+
+    static CCriticalSection csFreeLimiter;
+    static double dFreeCount;
+    static int64_t nLastTime;
+    int64_t nNow = GetTime();
+
+    LOCK(csFreeLimiter);
+
+    // Use an exponentially decaying ~10-minute window:
+    dFreeCount *= pow(1.0 - 1.0/600.0, (double)(nNow - nLastTime));
+    nLastTime = nNow;
+
+    // -limitfreerelay unit is thousand-bytes-per-minute
+    // At default rate it would take over a month to fill 1GB
+    if (dFreeCount + nSize >= GetArg("-limitfreerelay", DEFAULT_LIMITFREERELAY) * 10 * 1000)
+        return state.DoS(0, false, REJECT_INSUFFICIENTFEE, "rate limited free transaction");
+
+    LogPrint("mempool", "Rate limit dFreeCount: %g => %g\n", dFreeCount, dFreeCount+nSize);
+    dFreeCount += nSize;
 }
 
 /** Return transaction in tx, and if it was found inside a block, its hash is placed in hashBlock */
@@ -3545,7 +3572,7 @@ bool CVerifyDB::VerifyDB(const CChainParams& chainparams, CCoinsView *coinsview,
             return error("VerifyDB(): *** ReadBlockFromDisk failed at %d, hash=%s", pindex->nHeight, pindex->GetBlockHash().ToString());
         // check level 1: verify block validity
         if (nCheckLevel >= 1 && !CheckBlock(block, state))
-            return error("%s: *** found bad block at %d, hash=%s (%s)\n", __func__, 
+            return error("%s: *** found bad block at %d, hash=%s (%s)\n", __func__,
                          pindex->nHeight, pindex->GetBlockHash().ToString(), FormatStateMessage(state));
         // check level 2: verify undo validity
         if (nCheckLevel >= 2 && pindex) {
@@ -3633,7 +3660,7 @@ bool LoadBlockIndex()
     return true;
 }
 
-bool InitBlockIndex(const CChainParams& chainparams) 
+bool InitBlockIndex(const CChainParams& chainparams)
 {
     LOCK(cs_main);
 

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -102,6 +102,12 @@ public:
     int64_t GetModifiedFee() const { return nFee + feeDelta; }
     size_t DynamicMemoryUsage() const { return nUsageSize; }
 
+    /*
+     * Fills setConflicts with any conflicting non-final transactions for tx.
+     * Returns false if any conflicts exist with final transactions.
+     */
+    bool GetConflicts (const CTransaction& tx, std::set<uint256>& setConflicts) const;
+
     // Adjusts the descendant state, if this entry is not dirty.
     void UpdateState(int64_t modifySize, CAmount modifyFee, int64_t modifyCount);
     // Updates the fee delta used for mining priority score, and the
@@ -530,7 +536,7 @@ public:
 
     /** Estimate priority needed to get into the next nBlocks */
     double estimatePriority(int nBlocks) const;
-    
+
     /** Write/Read estimates to disk */
     bool WriteFeeEstimates(CAutoFile& fileout) const;
     bool ReadFeeEstimates(CAutoFile& filein);
@@ -576,7 +582,7 @@ private:
     void removeUnchecked(txiter entry);
 };
 
-/** 
+/**
  * CCoinsView that brings transactions from a memorypool into view.
  * It does not check for spendings by memory pool transactions.
  */


### PR DESCRIPTION
Local policy is often ~~annoying~~ difficult to change due to how large `AcceptToMempool` is.
This PR just begins the process of breaking out various functions such that a user could easily remove/test/isolate them if need-be.

Its WIP for now,  and I'd probably prefer to move the definitions to `policy/*`,  but I figured I'd just submit this PR to gauge concept ACK/NACKs before continuing. 

I'm not tied to any particular detail of this PR,  just wanting to achieve easier configuration of local policy.
