### PR TITLE
GUI: Disable tab navigation for peers tables.

### DIFF
--- a/src/qt/forms/debugwindow.ui
+++ b/src/qt/forms/debugwindow.ui
@@ -905,6 +905,9 @@
            <property name="horizontalScrollBarPolicy">
             <enum>Qt::ScrollBarAsNeeded</enum>
            </property>
+           <property name="tabKeyNavigation">
+            <bool>false</bool>
+           </property>
            <property name="sortingEnabled">
             <bool>true</bool>
            </property>
@@ -965,6 +968,9 @@
            </property>
            <property name="horizontalScrollBarPolicy">
             <enum>Qt::ScrollBarAsNeeded</enum>
+           </property>
+           <property name="tabKeyNavigation">
+            <bool>false</bool>
            </property>
            <property name="sortingEnabled">
             <bool>true</bool>


### PR DESCRIPTION
Fixes #7418 

Additionally, tab key navigation is already less convenient than arrow key navigation for the peers table, as three presses of the Tab key are required to move down a row.
