### PR TITLE
[0.12] Rename permitrbf to mempoolreplacement and provide minimal string-list forward compatibility

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -144,13 +144,13 @@ accepted when it pays sufficient fee, as described in [BIP 125]
 (https://github.com/bitcoin/bips/blob/master/bip-0125.mediawiki).
 
 Transaction replacement can be disabled with a new command line option,
-`-permitrbf=false`.  Transactions signaling replacement under BIP125 will still
+`-replacebyfee=0`.  Transactions signaling replacement under BIP125 will still
 be allowed into the mempool in this configuration, but replacements will be
 rejected.  This option is intended for miners who want to continue the
 transaction selection behavior of previous releases.
 
-The `-permitrbf` option is *not recommended* for wallet users seeking to avoid
-receipt of unconfirmed opt-in transactions, because this option does not
+The `-replacebyfee` option is *not recommended* for wallet users seeking to
+avoid receipt of unconfirmed opt-in transactions, because this option does not
 prevent transactions which are replaceable under BIP 125 from being accepted
 (only subsequent replacements, which other nodes on the network that implement
 BIP 125 are likely to relay and mine).  Wallet users wishing to detect whether

--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -144,14 +144,14 @@ accepted when it pays sufficient fee, as described in [BIP 125]
 (https://github.com/bitcoin/bips/blob/master/bip-0125.mediawiki).
 
 Transaction replacement can be disabled with a new command line option,
-`-replacebyfee=0`.  Transactions signaling replacement under BIP125 will still
-be allowed into the mempool in this configuration, but replacements will be
-rejected.  This option is intended for miners who want to continue the
+`-mempoolreplacement=0`.  Transactions signaling replacement under BIP125 will
+still be allowed into the mempool in this configuration, but replacements will
+be rejected.  This option is intended for miners who want to continue the
 transaction selection behavior of previous releases.
 
-The `-replacebyfee` option is *not recommended* for wallet users seeking to
-avoid receipt of unconfirmed opt-in transactions, because this option does not
-prevent transactions which are replaceable under BIP 125 from being accepted
+The `-mempoolreplacement` option is *not recommended* for wallet users seeking
+to avoid receipt of unconfirmed opt-in transactions, because this option does
+not prevent transactions which are replaceable under BIP 125 from being accepted
 (only subsequent replacements, which other nodes on the network that implement
 BIP 125 are likely to relay and mine).  Wallet users wishing to detect whether
 a transaction is subject to replacement under BIP 125 should instead use the

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -367,7 +367,6 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-onion=<ip:port>", strprintf(_("Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: %s)"), "-proxy"));
     strUsage += HelpMessageOpt("-onlynet=<net>", _("Only connect to nodes in network <net> (ipv4, ipv6 or onion)"));
     strUsage += HelpMessageOpt("-permitbaremultisig", strprintf(_("Relay non-P2SH multisig (default: %u)"), DEFAULT_PERMIT_BAREMULTISIG));
-    strUsage += HelpMessageOpt("-permitrbf", strprintf(_("Permit transaction replacement (default: %u)"), DEFAULT_PERMIT_REPLACEMENT));
     strUsage += HelpMessageOpt("-peerbloomfilters", strprintf(_("Support filtering of blocks and transaction with bloom filters (default: %u)"), 1));
     if (showDebug)
         strUsage += HelpMessageOpt("-enforcenodebloom", strprintf("Enforce minimum protocol version to limit use of bloom filters (default: %u)", 0));
@@ -487,6 +486,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-bytespersigop", strprintf(_("Minimum bytes per sigop in transactions we relay and mine (default: %u)"), DEFAULT_BYTES_PER_SIGOP));
     strUsage += HelpMessageOpt("-datacarrier", strprintf(_("Relay and mine data carrier transactions (default: %u)"), DEFAULT_ACCEPT_DATACARRIER));
     strUsage += HelpMessageOpt("-datacarriersize", strprintf(_("Maximum size of data in data carrier transactions we relay and mine (default: %u)"), MAX_OP_RETURN_RELAY));
+    strUsage += HelpMessageOpt("-replacebyfee", strprintf(_("Enable transaction replacement in the memory pool (default: %u)"), DEFAULT_ENABLE_REPLACEMENT));
 
     strUsage += HelpMessageGroup(_("Block creation options:"));
     strUsage += HelpMessageOpt("-blockminsize=<n>", strprintf(_("Set minimum block size in bytes (default: %u)"), DEFAULT_BLOCK_MIN_SIZE));
@@ -1016,7 +1016,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     if (GetBoolArg("-peerbloomfilters", true))
         nLocalServices |= NODE_BLOOM;
 
-    fPermitReplacement = GetBoolArg("-permitrbf", DEFAULT_PERMIT_REPLACEMENT);
+    fEnableReplacement = GetBoolArg("-replacebyfee", DEFAULT_ENABLE_REPLACEMENT);
 
     // ********************************************************* Step 4: application initialization: dir lock, daemonize, pidfile, debug log
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -488,7 +488,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-bytespersigop", strprintf(_("Minimum bytes per sigop in transactions we relay and mine (default: %u)"), DEFAULT_BYTES_PER_SIGOP));
     strUsage += HelpMessageOpt("-datacarrier", strprintf(_("Relay and mine data carrier transactions (default: %u)"), DEFAULT_ACCEPT_DATACARRIER));
     strUsage += HelpMessageOpt("-datacarriersize", strprintf(_("Maximum size of data in data carrier transactions we relay and mine (default: %u)"), MAX_OP_RETURN_RELAY));
-    strUsage += HelpMessageOpt("-replacebyfee", strprintf(_("Enable transaction replacement in the memory pool (default: %u)"), DEFAULT_ENABLE_REPLACEMENT));
+    strUsage += HelpMessageOpt("-mempoolreplacement", strprintf(_("Enable transaction replacement in the memory pool (default: %u)"), DEFAULT_ENABLE_REPLACEMENT));
 
     strUsage += HelpMessageGroup(_("Block creation options:"));
     strUsage += HelpMessageOpt("-blockminsize=<n>", strprintf(_("Set minimum block size in bytes (default: %u)"), DEFAULT_BLOCK_MIN_SIZE));
@@ -1018,13 +1018,13 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     if (GetBoolArg("-peerbloomfilters", true))
         nLocalServices |= NODE_BLOOM;
 
-    fEnableReplacement = GetBoolArg("-replacebyfee", DEFAULT_ENABLE_REPLACEMENT);
-    if ((!fEnableReplacement) && mapArgs.count("-replacebyfee")) {
+    fEnableReplacement = GetBoolArg("-mempoolreplacement", DEFAULT_ENABLE_REPLACEMENT);
+    if ((!fEnableReplacement) && mapArgs.count("-mempoolreplacement")) {
         // Minimal effort at forwards compatibility
-        std::string strReplacementModeList = GetArg("-replacebyfee", "");  // default is impossible
+        std::string strReplacementModeList = GetArg("-mempoolreplacement", "");  // default is impossible
         std::vector<std::string> vstrReplacementModes;
         boost::split(vstrReplacementModes, strReplacementModeList, boost::is_any_of(","));
-        fEnableReplacement = (std::find(vstrReplacementModes.begin(), vstrReplacementModes.end(), "opt-in") != vstrReplacementModes.end());
+        fEnableReplacement = (std::find(vstrReplacementModes.begin(), vstrReplacementModes.end(), "fee") != vstrReplacementModes.end());
     }
 
     // ********************************************************* Step 4: application initialization: dir lock, daemonize, pidfile, debug log

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1024,12 +1024,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
         std::string strReplacementModeList = GetArg("-replacebyfee", "");  // default is impossible
         std::vector<std::string> vstrReplacementModes;
         boost::split(vstrReplacementModes, strReplacementModeList, boost::is_any_of(","));
-        BOOST_FOREACH(const std::string& strReplacementMode, vstrReplacementModes) {
-            if (strReplacementMode == "opt-in") {
-                fEnableReplacement = true;
-                break;
-            }
-        }
+        fEnableReplacement = (std::find(vstrReplacementModes.begin(), vstrReplacementModes.end(), "opt-in") != vstrReplacementModes.end());
     }
 
     // ********************************************************* Step 4: application initialization: dir lock, daemonize, pidfile, debug log

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -47,8 +47,10 @@
 #include <signal.h>
 #endif
 
+#include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/algorithm/string/replace.hpp>
+#include <boost/algorithm/string/split.hpp>
 #include <boost/bind.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/function.hpp>
@@ -1017,6 +1019,18 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
         nLocalServices |= NODE_BLOOM;
 
     fEnableReplacement = GetBoolArg("-replacebyfee", DEFAULT_ENABLE_REPLACEMENT);
+    if ((!fEnableReplacement) && mapArgs.count("-replacebyfee")) {
+        // Minimal effort at forwards compatibility
+        std::string strReplacementModeList = GetArg("-replacebyfee", "");  // default is impossible
+        std::vector<std::string> vstrReplacementModes;
+        boost::split(vstrReplacementModes, strReplacementModeList, boost::is_any_of(","));
+        BOOST_FOREACH(const std::string& strReplacementMode, vstrReplacementModes) {
+            if (strReplacementMode == "opt-in") {
+                fEnableReplacement = true;
+                break;
+            }
+        }
+    }
 
     // ********************************************************* Step 4: application initialization: dir lock, daemonize, pidfile, debug log
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -75,7 +75,7 @@ bool fCheckpointsEnabled = DEFAULT_CHECKPOINTS_ENABLED;
 size_t nCoinCacheUsage = 5000 * 300;
 uint64_t nPruneTarget = 0;
 bool fAlerts = DEFAULT_ALERTS;
-bool fPermitReplacement = DEFAULT_PERMIT_REPLACEMENT;
+bool fEnableReplacement = DEFAULT_ENABLE_REPLACEMENT;
 
 /** Fees smaller than this (in satoshi) are considered zero fee (for relaying, mining and transaction creation) */
 CFeeRate minRelayTxFee = CFeeRate(DEFAULT_MIN_RELAY_TX_FEE);
@@ -866,7 +866,7 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState &state, const C
                 // unconfirmed ancestors anyway; doing otherwise is hopelessly
                 // insecure.
                 bool fReplacementOptOut = true;
-                if (fPermitReplacement)
+                if (fEnableReplacement)
                 {
                     BOOST_FOREACH(const CTxIn &txin, ptxConflicting->vin)
                     {

--- a/src/main.h
+++ b/src/main.h
@@ -106,7 +106,7 @@ static const bool DEFAULT_TXINDEX = false;
 static const unsigned int DEFAULT_BANSCORE_THRESHOLD = 100;
 
 static const bool DEFAULT_TESTSAFEMODE = false;
-/** Default for -replacebyfee */
+/** Default for -mempoolreplacement */
 static const bool DEFAULT_ENABLE_REPLACEMENT = true;
 
 /** Maximum number of headers to announce when relaying blocks with headers message.*/

--- a/src/main.h
+++ b/src/main.h
@@ -106,8 +106,8 @@ static const bool DEFAULT_TXINDEX = false;
 static const unsigned int DEFAULT_BANSCORE_THRESHOLD = 100;
 
 static const bool DEFAULT_TESTSAFEMODE = false;
-/** Default for -permitrbf */
-static const bool DEFAULT_PERMIT_REPLACEMENT = true;
+/** Default for -replacebyfee */
+static const bool DEFAULT_ENABLE_REPLACEMENT = true;
 
 /** Maximum number of headers to announce when relaying blocks with headers message.*/
 static const unsigned int MAX_BLOCKS_TO_ANNOUNCE = 8;
@@ -139,7 +139,7 @@ extern bool fCheckpointsEnabled;
 extern size_t nCoinCacheUsage;
 extern CFeeRate minRelayTxFee;
 extern bool fAlerts;
-extern bool fPermitReplacement;
+extern bool fEnableReplacement;
 
 /** Best header we've seen so far (used for getheaders queries' starting points). */
 extern CBlockIndex *pindexBestHeader;


### PR DESCRIPTION
Backport of #7431
