### PR TITLE
Use Debian 8.3 in gitian build guide

### DIFF
--- a/doc/gitian-building.md
+++ b/doc/gitian-building.md
@@ -74,11 +74,11 @@ In the VirtualBox GUI click "Create" and choose the following parameters in the 
 - File location and size: at least 40GB; as low as 20GB *may* be possible, but better to err on the safe side
 - Click `Create`
 
-Get the [Debian 8.x net installer](http://cdimage.debian.org/debian-cd/8.2.0/amd64/iso-cd/debian-8.2.0-amd64-netinst.iso) (a more recent minor version should also work, see also [Debian Network installation](https://www.debian.org/CD/netinst/)).
+Get the [Debian 8.x net installer](http://cdimage.debian.org/debian-cd/8.3.0/amd64/iso-cd/debian-8.3.0-amd64-netinst.iso) (a more recent minor version should also work, see also [Debian Network installation](https://www.debian.org/CD/netinst/)).
 This DVD image can be validated using a SHA256 hashing tool, for example on
 Unixy OSes by entering the following in a terminal:
 
-    echo "d393d17ac6b3113c81186e545c416a00f28ed6e05774284bb5e8f0df39fcbcb9  debian-8.2.0-amd64-netinst.iso" | sha256sum -c
+    echo "dd25bcdde3c6ea5703cc0f313cde621b13d42ff7d252e2538a11663c93bf8654  debian-8.3.0-amd64-netinst.iso" | sha256sum -c
     # (must return OK)
 
 After creating the VM, we need to configure it.
@@ -305,6 +305,7 @@ Clone the git repositories for bitcoin and Gitian.
 ```bash
 git clone https://github.com/devrandom/gitian-builder.git
 git clone https://github.com/bitcoin/bitcoin
+git clone https://github.com/bitcoin/gitian.sigs.git
 ```
 
 Setting up the Gitian image


### PR DESCRIPTION
Also add instructions to clone the gitian.sigs repo.

I’ve created a new VM with 8.3 and confirmed sigs matched. 

```
Generating report
6712e1d3d856a027fe5802ddb3d61be3f2ee86fa0e3377bfec56eda52e7c75f0  bitcoin-0.12.0-linux32.tar.gz
4676b0e61124f2cb9df530808a00a7ce8ca1c5b2e33950a150a77d6eb735daaf  bitcoin-0.12.0-linux64.tar.gz
fdb9015196503d4854af59fec2e1d6e9754c883f4c0adeec247a27cee0f0564e  src/bitcoin-0.12.0.tar.gz
58aa081c3c8ac6953231be40b88480cabe8a62d3c06c71596011437422bcad5b  bitcoin-linux-0.12-res.yml
Done.
```
