### PR TITLE
Add link to bitcoin whitepaper

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ out collectively by the network. Bitcoin Core is the name of open source
 software which enables the use of this currency.
 
 For more information, as well as an immediately useable, binary version of
-the Bitcoin Core software, see https://www.bitcoin.org/en/download.
+the Bitcoin Core software, see https://www.bitcoin.org/en/download, or read the
+[original whitepaper](https://bitcoincore.org/bitcoin.pdf).
 
 License
 -------


### PR DESCRIPTION
Many have suggested adding a link to the original whitepaper in https://github.com/bitcoin/bitcoin/pull/7443. I think it's appropriate to include a link in the README.md, which is exactly what this PR does.
