### PR TITLE
[0.12] Make internal (core) errors show up in the Qt client.

### DIFF
--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -245,8 +245,20 @@ bool CAlert::ProcessAlert(const std::vector<unsigned char>& alertKey, bool fThre
     return true;
 }
 
-void
-CAlert::Notify(const std::string& strMessage, bool fThread)
+// static
+void CAlert::NotifyInternal(const std::string& strMessage)
+{
+    static CAlert internalAlert;
+    internalAlert.vchMsg = std::vector<unsigned char>(strMessage.begin(), strMessage.end());
+    uint256 zero;
+    mapAlerts[zero] = internalAlert;
+    uiInterface.NotifyAlertChanged(zero, CT_NEW);
+
+    Notify(strMessage, true);
+}
+
+// static
+void CAlert::Notify(const std::string& strMessage, bool fThread)
 {
     std::string strCmd = GetArg("-alertnotify", "");
     if (strCmd.empty()) return;

--- a/src/alert.h
+++ b/src/alert.h
@@ -46,7 +46,7 @@ public:
     std::string strStatusBar;
     std::string strReserved;
 
-    ADD_SERIALIZE_METHODS;
+    ADD_SERIALIZE_METHODS
 
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
@@ -84,7 +84,7 @@ public:
         SetNull();
     }
 
-    ADD_SERIALIZE_METHODS;
+    ADD_SERIALIZE_METHODS
 
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
@@ -102,6 +102,7 @@ public:
     bool RelayTo(CNode* pnode) const;
     bool CheckSignature(const std::vector<unsigned char>& alertKey) const;
     bool ProcessAlert(const std::vector<unsigned char>& alertKey, bool fThread = true); // fThread means run -alertnotify in a free-running thread
+    static void NotifyInternal(const std::string& strMessage);
     static void Notify(const std::string& strMessage, bool fThread);
 
     /*

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1410,7 +1410,7 @@ void CheckForkWarningConditions()
         {
             std::string warning = std::string("'Warning: Large-work fork detected, forking after block ") +
                 pindexBestForkBase->phashBlock->ToString() + std::string("'");
-            CAlert::Notify(warning, true);
+            CAlert::NotifyInternal(warning);
         }
         if (pindexBestForkTip && pindexBestForkBase)
         {
@@ -1946,7 +1946,7 @@ void PartitionCheck(bool (*initialDownloadCheck)(), CCriticalSection& cs, const 
     if (!strWarning.empty())
     {
         strMiscWarning = strWarning;
-        CAlert::Notify(strWarning, true);
+        CAlert::NotifyInternal(strWarning);
         lastAlertTime = now;
     }
 }
@@ -2320,7 +2320,7 @@ void static UpdateTip(CBlockIndex *pindexNew) {
         {
             // strMiscWarning is read by GetWarnings(), called by Qt and the JSON-RPC code to warn the user:
             strMiscWarning = _("Warning: This version is obsolete; upgrade required!");
-            CAlert::Notify(strMiscWarning, true);
+            CAlert::NotifyInternal(strMiscWarning);
             fWarned = true;
         }
     }


### PR DESCRIPTION
Serious warnings wrt to state of the chain were only printed to the logs, with this change these issues are also shown in the Qt Gui..
