### PR TITLE
Make internal (core) errors show up in the Qt client.

### DIFF
--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -27,6 +27,8 @@ using namespace std;
 map<uint256, CAlert> mapAlerts;
 CCriticalSection cs_mapAlerts;
 
+static void Notify(const std::string& strMessage, bool fThread);
+
 void CUnsignedAlert::SetNull()
 {
     nVersion = 1;
@@ -245,8 +247,20 @@ bool CAlert::ProcessAlert(const std::vector<unsigned char>& alertKey, bool fThre
     return true;
 }
 
-void
-CAlert::Notify(const std::string& strMessage, bool fThread)
+// static
+void CAlert::NotifyInternal(const std::string& strMessage)
+{
+    static CAlert internalAlert;
+    internalAlert.vchMsg = std::vector<unsigned char>(strMessage.begin(), strMessage.end());
+    uint256 zero;
+    LOCK(cs_mapAlerts);
+    mapAlerts[zero] = internalAlert;
+    uiInterface.NotifyAlertChanged(zero, CT_NEW);
+
+    Notify(strMessage, true);
+}
+
+static void Notify(const std::string& strMessage, bool fThread)
 {
     std::string strCmd = GetArg("-alertnotify", "");
     if (strCmd.empty()) return;

--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -253,8 +253,10 @@ void CAlert::NotifyInternal(const std::string& strMessage)
     static CAlert internalAlert;
     internalAlert.vchMsg = std::vector<unsigned char>(strMessage.begin(), strMessage.end());
     uint256 zero;
-    LOCK(cs_mapAlerts);
-    mapAlerts[zero] = internalAlert;
+    {
+        LOCK(cs_mapAlerts);
+        mapAlerts[zero] = internalAlert;
+    }
     uiInterface.NotifyAlertChanged(zero, CT_NEW);
 
     Notify(strMessage, true);

--- a/src/alert.h
+++ b/src/alert.h
@@ -102,7 +102,7 @@ public:
     bool RelayTo(CNode* pnode) const;
     bool CheckSignature(const std::vector<unsigned char>& alertKey) const;
     bool ProcessAlert(const std::vector<unsigned char>& alertKey, bool fThread = true); // fThread means run -alertnotify in a free-running thread
-    static void Notify(const std::string& strMessage, bool fThread);
+    static void NotifyInternal(const std::string& strMessage);
 
     /*
      * Get copy of (active) alert object by hash. Returns a null alert if it is not found.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1411,7 +1411,7 @@ void CheckForkWarningConditions()
         {
             std::string warning = std::string("'Warning: Large-work fork detected, forking after block ") +
                 pindexBestForkBase->phashBlock->ToString() + std::string("'");
-            CAlert::Notify(warning, true);
+            CAlert::NotifyInternal(warning);
         }
         if (pindexBestForkTip && pindexBestForkBase)
         {
@@ -1942,7 +1942,7 @@ void PartitionCheck(bool (*initialDownloadCheck)(), CCriticalSection& cs, const 
     if (!strWarning.empty())
     {
         strMiscWarning = strWarning;
-        CAlert::Notify(strWarning, true);
+        CAlert::NotifyInternal(strWarning);
         lastAlertTime = now;
     }
 }
@@ -2316,7 +2316,7 @@ void static UpdateTip(CBlockIndex *pindexNew) {
         {
             // strMiscWarning is read by GetWarnings(), called by Qt and the JSON-RPC code to warn the user:
             strMiscWarning = _("Warning: This version is obsolete; upgrade required!");
-            CAlert::Notify(strMiscWarning, true);
+            CAlert::NotifyInternal(strMiscWarning);
             fWarned = true;
         }
     }


### PR DESCRIPTION
Serious warnings wrt to state of the chain were only printed to the logs, with this change these issues are also shown in the Qt Gui..
