### PR TITLE
Opt-in RBF must be strictly enabled or disabled before GBT can be called

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -115,6 +115,7 @@ public:
         vFixedSeeds = std::vector<SeedSpec6>(pnSeed6_main, pnSeed6_main + ARRAYLEN(pnSeed6_main));
 
         fMiningRequiresPeers = true;
+        fMiningRequiresConfiguration = true;
         fDefaultConsistencyChecks = false;
         fRequireStandard = true;
         fMineBlocksOnDemand = false;
@@ -190,6 +191,7 @@ public:
         vFixedSeeds = std::vector<SeedSpec6>(pnSeed6_test, pnSeed6_test + ARRAYLEN(pnSeed6_test));
 
         fMiningRequiresPeers = true;
+        fMiningRequiresConfiguration = false;
         fDefaultConsistencyChecks = false;
         fRequireStandard = false;
         fMineBlocksOnDemand = false;
@@ -242,6 +244,7 @@ public:
         vSeeds.clear();  //! Regtest mode doesn't have any DNS seeds.
 
         fMiningRequiresPeers = false;
+        fMiningRequiresConfiguration = false;
         fDefaultConsistencyChecks = true;
         fRequireStandard = false;
         fMineBlocksOnDemand = true;

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -60,6 +60,8 @@ public:
     const CBlock& GenesisBlock() const { return genesis; }
     /** Make miner wait to have peers to avoid wasting work */
     bool MiningRequiresPeers() const { return fMiningRequiresPeers; }
+    /** Require policy configuration before mining */
+    bool MiningRequiresConfiguration() const { return fMiningRequiresConfiguration; }
     /** Default value for -checkmempool and -checkblockindex argument */
     bool DefaultConsistencyChecks() const { return fDefaultConsistencyChecks; }
     /** Policy: Filter transactions that do not match well-defined patterns */
@@ -90,6 +92,7 @@ protected:
     CBlock genesis;
     std::vector<SeedSpec6> vFixedSeeds;
     bool fMiningRequiresPeers;
+    bool fMiningRequiresConfiguration;
     bool fDefaultConsistencyChecks;
     bool fRequireStandard;
     bool fMineBlocksOnDemand;

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -211,6 +211,9 @@ UniValue setgenerate(const UniValue& params, bool fHelp)
     if (params.size() > 0)
         fGenerate = params[0].get_bool();
 
+    if (fGenerate && Params().MiningRequiresConfiguration() && !mapArgs.count("-mempoolreplacement"))
+        throw JSONRPCError(RPC_NOT_CONFIGURED, "You must set opt-in RBF option -mempoolreplacement.");
+
     int nGenProcLimit = GetArg("-genproclimit", DEFAULT_GENERATE_THREADS);
     if (params.size() > 1)
     {
@@ -439,6 +442,9 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
 
     if (IsInitialBlockDownload())
         throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "Bitcoin is downloading blocks...");
+
+    if (Params().MiningRequiresConfiguration() && !mapArgs.count("-mempoolreplacement"))
+        throw JSONRPCError(RPC_NOT_CONFIGURED, "You must set opt-in RBF option -mempoolreplacement.");
 
     static unsigned int nTransactionsUpdatedLast;
 

--- a/src/rpc/protocol.h
+++ b/src/rpc/protocol.h
@@ -50,6 +50,7 @@ enum RPCErrorCode
     RPC_VERIFY_REJECTED             = -26, //! Transaction or block was rejected by network rules
     RPC_VERIFY_ALREADY_IN_CHAIN     = -27, //! Transaction already in chain
     RPC_IN_WARMUP                   = -28, //! Client still warming up
+    RPC_NOT_CONFIGURED              = -29, //! Some configuration is required
 
     //! Aliases for backward compatibility
     RPC_TRANSACTION_ERROR           = RPC_VERIFY_ERROR,


### PR DESCRIPTION
Pool operators must strictly specify their preference to opt-in RBF.
