### PR TITLE
[rpc-tests] Change solve() to use rehash

### DIFF
--- a/qa/rpc-tests/test_framework/mininode.py
+++ b/qa/rpc-tests/test_framework/mininode.py
@@ -536,7 +536,7 @@ class CBlock(CBlockHeader):
         return True
 
     def solve(self):
-        self.calc_sha256()
+        self.rehash()
         target = uint256_from_compact(self.nBits)
         while self.sha256 > target:
             self.nNonce += 1


### PR DESCRIPTION
Small fix to the p2p test framework (mininode, etc) that I ran into when belatedly testing PR 7225. 

I think it's better for solve() to recompute the hash before the first attempt so we're not using a cached hash, which if wrong, would almost certainly be a bug in the test.  
