### PR TITLE
[P2P] Ensure headers count is correct

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -332,8 +332,10 @@ void FinalizeNode(NodeId nodeid) {
         AddressCurrentlyConnected(state->address);
     }
 
-    BOOST_FOREACH(const QueuedBlock& entry, state->vBlocksInFlight)
+    BOOST_FOREACH(const QueuedBlock& entry, state->vBlocksInFlight) {
+        nQueuedValidatedHeaders -= entry.fValidatedHeaders;
         mapBlocksInFlight.erase(entry.hash);
+    }
     EraseOrphansFor(nodeid);
     nPreferredDownload -= state->fPreferredDownload;
 


### PR DESCRIPTION
This should be backported to 0.12.  

Now that we're using headers announcements for new blocks, this makes sure that nQueuedValidatedHeaders is properly decremented when a peer disconnects.
