### PR TITLE
Make genbuild.sh check for '.git' 

### DIFF
--- a/share/genbuild.sh
+++ b/share/genbuild.sh
@@ -16,7 +16,9 @@ fi
 DESC=""
 SUFFIX=""
 LAST_COMMIT_DATE=""
-if [ -e "$(which git 2>/dev/null)" -a "$(git rev-parse --is-inside-work-tree 2>/dev/null)" = "true" ]; then
+if [ \( -n "$DONT_CHECK_FOR_DOT_GIT" -o -d ".git" \) \
+		 -a -e "$(which git 2>/dev/null)" \
+		 -a "$(git rev-parse --is-inside-work-tree 2>/dev/null)" = "true" ]; then
     # clean 'dirty' status of touched files that haven't been modified
     git diff >/dev/null 2>/dev/null 
 

--- a/share/genbuild.sh
+++ b/share/genbuild.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 if [ $# -gt 1 ]; then
-    cd "$2"
+    cd "$2" || exit
 fi
 if [ $# -gt 0 ]; then
     FILE="$1"
@@ -24,7 +24,7 @@ if [ \( -n "$DONT_CHECK_FOR_DOT_GIT" -o -d ".git" \) \
 
     # if latest commit is tagged and not dirty, then override using the tag name
     RAWDESC=$(git describe --abbrev=0 2>/dev/null)
-    if [ "$(git rev-parse HEAD)" = "$(git rev-list -1 $RAWDESC 2>/dev/null)" ]; then
+    if [ "$(git rev-parse HEAD)" = "$(git rev-list -1 "$RAWDESC" 2>/dev/null)" ]; then
         git diff-index --quiet HEAD -- && DESC=$RAWDESC
     fi
 


### PR DESCRIPTION
Addresses #5902. As mentioned in https://github.com/bitcoin/bitcoin/commit/c65cc8cde30dd34a81962fda51a754f1cc0bdde8 the initial check caused issues with gitian builds, therefore this introduces a check for a `DONT_CHECK_FOR_DOT_GIT` environment variable to disable it if the variable is set to an arbitrary value. I'm not sure if this approach is suitable for gitian. Does gitian use something other then `.git` as GITDIR? Or what makes gitian builds special? Maybe @theuni can comment on that.

Also some minor lint fixups found by shellcheck.
