### PR TITLE
Add createtransaction

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -32,6 +32,8 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "generate", 0 },
     { "getnetworkhashps", 0 },
     { "getnetworkhashps", 1 },
+    { "createtransaction", 0 },
+    { "createtransaction", 1 },
     { "sendtoaddress", 1 },
     { "sendtoaddress", 4 },
     { "settxfee", 0 },

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -742,6 +742,8 @@ public:
      * selected by SelectCoins(); Also create the change output, when needed
      */
     bool CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletTx& wtxNew, CReserveKey& reservekey, CAmount& nFeeRet, int& nChangePosRet,
+                             std::string& strFailReason, const CCoinControl *coinControl = NULL, bool sign = true);
+    bool CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletTx& wtxNew, CReserveKey& reservekey, CAmount& nFeeRet, int& nChangePosRet, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoinsRet,
                            std::string& strFailReason, const CCoinControl *coinControl = NULL, bool sign = true);
     bool CommitTransaction(CWalletTx& wtxNew, CReserveKey& reservekey);
 


### PR DESCRIPTION
Syntax: `createtransaction {"address":amount,...} ({ "option": value,...})`

This call is very similar to `sendmany` but it also allows to:
- use unspent transaction outputs of watch only addresses;
- specify the change address;
- optionally not commit the transaction;
- optionally not sign the transaction;
- include the `scriptPubKey` of transaction inputs.

Optional arguments are specified in a JSON object. The output similar is to `decoderawtransaction`.

This is very useful for merchants that doesn't want a wallet with private keys but wishes to use the algorithm used in the unspent output selection and fee calculation. Then it can sign the inputs and send the raw transaction.

Example:

```
bitcoin-cli -regtest createtransaction '{ "mpi744Kz6uDEDeTLDj8BwXbwfanjoVSPch": "20" }' '{ "allowWatchOnly": true, "changeAddress" : "mnBfCwG7Dc4HeJob681kRLSueUzQ7XMKQf", "commit": false, "includeSpentOutputs": true, "sign": false }'
```

TODO: optionally lock unspents when `commit` is false.
