### PR TITLE
Fix IsInitialBlockDownload for testnet

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1384,7 +1384,7 @@ bool IsInitialBlockDownload()
     if (lockIBDState)
         return false;
     bool state = (chainActive.Height() < pindexBestHeader->nHeight - 24 * 6 ||
-            pindexBestHeader->GetBlockTime() < GetTime() - nMaxTipAge);
+            std::max(chainActive.Tip()->GetBlockTime(), pindexBestHeader->GetBlockTime()) < GetTime() - nMaxTipAge);
     if (!state)
         lockIBDState = true;
     return state;


### PR DESCRIPTION
**Problem:** When running in testnet, a node can get stuck in IsInitialBlockDownload mode which will prevent it from responding to any GETHEADERS requests. This can make testing difficult! This problem does not happen on mainnet.

**Theory:** Testnet is a little wonky with the 20-minute difficulty reset condition. The nChainWork calculation can cause pindexBestHeader to be set with an old block that has more work than chainActive.Tip(). If that block is more than nMaxTipAge old, IsInitialBlockDownload will always return true.

**Suggested solution:** The current code works fine for mainnet, so I added a check to see if we are using testnet, and if so use chainActive.Tip() instead of pindexBestHeader when checking to see how far along we are with the block download. It's my thought that if the current tip is less than one day old (the nMaxTipAge default), it's probably safe to release IsInitialBlockDownload regardless of the age of pindexBestHeader.

_[Edit: As per the comments below, I removed the check for testnet and instead used the greater of chainActive or BestHeader.]_
