### PR TITLE
LibreSSL doesn't define OPENSSL_VERSION, use LIBRESSL_VERSION_TEXT instead

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1034,8 +1034,10 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
 
 #if (OPENSSL_VERSION_NUMBER < 0x10100000L)
     LogPrintf("Using OpenSSL version %s\n", SSLeay_version(SSLEAY_VERSION));
-#else
+#elif defined OPENSSL_VERSION
     LogPrintf("Using OpenSSL version %s\n", OpenSSL_version(OPENSSL_VERSION));
+#elif defined LIBRESSL_VERSION_TEXT
+    LogPrintf("Using %s\n", LIBRESSL_VERSION_TEXT);
 #endif
 
 #ifdef ENABLE_WALLET


### PR DESCRIPTION
OpenBSD is using LibreSSL by default instead of openssl. The build ends with

```
CXX      libbitcoin_server_a-init.o
In file included from addrman.h:14:0,
                 from init.cpp:12:
init.cpp: In function 'bool AppInit2(boost::thread_group&, CScheduler&)':
init.cpp:1095:61: error: 'OPENSSL_VERSION' was not declared in this scope
     LogPrintf("Using OpenSSL version %s\n", OpenSSL_version(OPENSSL_VERSION));
                                                             ^
```

This change adds LIBRESSL_VERSION_TEXT macrocheck and adds conditionals before these macros. If none is defined, nothing is printed at all.

Fixes #7515.
Fixes #7447.
