### PR TITLE
autogen.sh: warn about needing autoconf if autoreconf is not found

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -6,4 +6,6 @@ if [ -z ${LIBTOOLIZE} ] && GLIBTOOLIZE="`which glibtoolize 2>/dev/null`"; then
   LIBTOOLIZE="${GLIBTOOLIZE}"
   export LIBTOOLIZE
 fi
+which autoreconf >/dev/null || \
+  (echo "configuration failed, please install autoconf first" && exit 1)
 autoreconf --install --force --warnings=all


### PR DESCRIPTION
Changes the error message from:
./autogen.sh: 9: ./autogen.sh: autoreconf: not found

To:
configuration failed, please install autoconf first
