### PR TITLE
autogen.sh: check for libtool before automake fails to find it

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -2,10 +2,17 @@
 set -e
 srcdir="$(dirname $0)"
 cd "$srcdir"
-if [ -z ${LIBTOOLIZE} ] && GLIBTOOLIZE="`which glibtoolize 2>/dev/null`"; then
-  LIBTOOLIZE="${GLIBTOOLIZE}"
-  export LIBTOOLIZE
+
+if [ -z ${LIBTOOLIZE} ]; then
+  if ! LIBTOOLIZE="`which glibtoolize 2>/dev/null`" || [ ! -x "$LIBTOOLIZE" ]; then
+    if ! LIBTOOLIZE="`which libtoolize 2>/dev/null`" || [ ! -x "$LIBTOOLIZE" ]; then
+      echo "glibtoolize/libtoolize not found (usually packaged in libtool-bin/libtool)" \
+      && exit 1
+    fi
+  fi
 fi
+export LIBTOOLIZE
+
 which autoreconf >/dev/null || \
   (echo "configuration failed, please install autoconf first" && exit 1)
 autoreconf --install --force --warnings=all


### PR DESCRIPTION
Changes the error message from:
$ ./autogen.sh
configure.ac:28: installing 'build-aux/install-sh'
configure.ac:28: installing 'build-aux/missing'
Makefile.am:8: error: Libtool library used but 'LIBTOOL' is undefined
Makefile.am:8:   The usual way to define 'LIBTOOL' is to add 'LT_INIT'
Makefile.am:8:   to 'configure.ac' and run 'aclocal' and 'autoconf' again.
Makefile.am:8:   If 'LT_INIT' is in 'configure.ac', make sure
Makefile.am:8:   its definition is in aclocal's search path.

To:
$ ./autogen.sh
libtool is required, please install it first
