### PR TITLE
RPC: sendrawtransaction: Allow the user to ignore/override specific rejections

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1807,7 +1807,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
 
         std::list<CTransactionRef> lRemovedTxn;
 
-        if (!AlreadyHave(inv) && AcceptToMemoryPool(mempool, state, ptx, true, &fMissingInputs, &lRemovedTxn)) {
+        if (!AlreadyHave(inv) && AcceptToMemoryPool(mempool, state, ptx, &fMissingInputs, &lRemovedTxn)) {
             mempool.check(pcoinsTip);
             RelayTransaction(tx, connman);
             for (unsigned int i = 0; i < tx.vout.size(); i++) {
@@ -1845,7 +1845,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
 
                     if (setMisbehaving.count(fromPeer))
                         continue;
-                    if (AcceptToMemoryPool(mempool, stateDummy, porphanTx, true, &fMissingInputs2, &lRemovedTxn)) {
+                    if (AcceptToMemoryPool(mempool, stateDummy, porphanTx, &fMissingInputs2, &lRemovedTxn)) {
                         LogPrint(BCLog::MEMPOOL, "   accepted orphan tx %s\n", orphanHash.ToString());
                         RelayTransaction(orphanTx, connman);
                         for (unsigned int i = 0; i < orphanTx.vout.size(); i++) {

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -89,7 +89,13 @@ bool IsStandardTx(const CTransaction& tx, std::string& reason, const bool witnes
      * @param[in] mapInputs    Map of previous transactions that have outputs we're spending
      * @return True if all inputs (scriptSigs) use only standard transaction forms
      */
-bool AreInputsStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs);
+bool AreInputsStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs, const std::string& reason_prefix, std::string& out_reason);
+
+inline bool AreInputsStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs) {
+    std::string reason;
+    return AreInputsStandard(tx, mapInputs, reason, reason);
+}
+
     /**
      * Check if the transaction is over standard P2WSH resources limit:
      * 3600bytes witnessScript size, 80bytes per witness stack element, 100 witness stack elements

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -105,7 +105,7 @@ inline bool AreInputsStandard(const CTransaction& tx, const CCoinsViewCache& map
      * 3600bytes witnessScript size, 80bytes per witness stack element, 100 witness stack elements
      * These limits are adequate for multi-signature up to n-of-100 using OP_CHECKSIG, OP_ADD, and OP_EQUAL,
      */
-bool IsWitnessStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs);
+bool IsWitnessStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs, const std::string& reason_prefix, std::string& out_reason, const ignore_rejects_type& ignore_rejects=empty_ignore_rejects);
 
 extern CFeeRate incrementalRelayFee;
 extern CFeeRate dustRelayFee;

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -12,6 +12,7 @@
 #include "script/standard.h"
 
 #include <string>
+#include <unordered_set>
 
 class CCoinsViewCache;
 class CTxOut;
@@ -74,6 +75,9 @@ static const unsigned int STANDARD_NOT_MANDATORY_VERIFY_FLAGS = STANDARD_SCRIPT_
 static const unsigned int STANDARD_LOCKTIME_VERIFY_FLAGS = LOCKTIME_VERIFY_SEQUENCE |
                                                            LOCKTIME_MEDIAN_TIME_PAST;
 
+typedef std::unordered_set<std::string> ignore_rejects_type;
+static const ignore_rejects_type empty_ignore_rejects;
+
 CAmount GetDustThreshold(const CTxOut& txout, const CFeeRate& dustRelayFee);
 
 bool IsDust(const CTxOut& txout, const CFeeRate& dustRelayFee);
@@ -83,13 +87,13 @@ bool IsStandard(const CScript& scriptPubKey, txnouttype& whichType, const bool w
      * Check for standard transaction types
      * @return True if all outputs (scriptPubKeys) use only standard transaction forms
      */
-bool IsStandardTx(const CTransaction& tx, std::string& reason, const bool witnessEnabled = false);
+bool IsStandardTx(const CTransaction& tx, std::string& reason, const bool witnessEnabled = false, const ignore_rejects_type& ignore_rejects=empty_ignore_rejects);
     /**
      * Check for standard transaction types
      * @param[in] mapInputs    Map of previous transactions that have outputs we're spending
      * @return True if all inputs (scriptSigs) use only standard transaction forms
      */
-bool AreInputsStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs, const std::string& reason_prefix, std::string& out_reason);
+bool AreInputsStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs, const std::string& reason_prefix, std::string& out_reason, const ignore_rejects_type& ignore_rejects=empty_ignore_rejects);
 
 inline bool AreInputsStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs) {
     std::string reason;

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -95,6 +95,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "createrawtransaction", 3, "replaceable" },
     { "signrawtransaction", 1, "prevtxs" },
     { "signrawtransaction", 2, "privkeys" },
+    { "sendrawtransaction", 1, "ignore_rejects" },
     { "sendrawtransaction", 1, "allowhighfees" },
     { "combinerawtransaction", 0, "txs" },
     { "fundrawtransaction", 1, "options" },

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -892,12 +892,12 @@ UniValue sendrawtransaction(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() < 1 || request.params.size() > 2)
         throw std::runtime_error(
-            "sendrawtransaction \"hexstring\" ( allowhighfees )\n"
+            "sendrawtransaction \"hexstring\" ( [\"ignore_reject\",...] )\n"
             "\nSubmits raw transaction (serialized, hex-encoded) to local node and network.\n"
             "\nAlso see createrawtransaction and signrawtransaction calls.\n"
             "\nArguments:\n"
             "1. \"hexstring\"    (string, required) The hex string of the raw transaction)\n"
-            "2. allowhighfees    (boolean, optional, default=false) Allow high fees\n"
+            "2. \"ignore_reject\" (string, optional) Rejection conditions to ignore, eg 'absurdly-high-fee'\n"
             "\nResult:\n"
             "\"hex\"             (string) The transaction hash in hex\n"
             "\nExamples:\n"
@@ -912,7 +912,7 @@ UniValue sendrawtransaction(const JSONRPCRequest& request)
         );
 
     LOCK(cs_main);
-    RPCTypeCheck(request.params, {UniValue::VSTR, UniValue::VBOOL});
+    RPCTypeCheck(request.params, {UniValue::VSTR});
 
     // parse hex string from parameter
     CMutableTransaction mtx;
@@ -922,8 +922,24 @@ UniValue sendrawtransaction(const JSONRPCRequest& request)
     const uint256& hashTx = tx->GetHash();
 
     CAmount nMaxRawTxFee = maxTxFee;
-    if (request.params.size() > 1 && request.params[1].get_bool())
-        nMaxRawTxFee = 0;
+
+    ignore_rejects_type ignore_rejects;
+    const UniValue& json_ign_rejs = request.params[1];
+    if (!json_ign_rejs.isNull()) {
+        if (json_ign_rejs.isBool()) {
+            // This parameter used to be boolean allowhighfees
+            if (json_ign_rejs.isTrue()) {
+                ignore_rejects.insert(rejectmsg_absurdfee);
+            }
+        } else {
+            RPCTypeCheckArgument(json_ign_rejs, UniValue::VARR);
+
+            for (size_t i = 0; i < json_ign_rejs.size(); ++i) {
+                const UniValue& json_ign_rej = json_ign_rejs[i];
+                ignore_rejects.insert(json_ign_rej.get_str());
+            }
+        }
+    }
 
     CCoinsViewCache &view = *pcoinsTip;
     bool fHaveChain = false;
@@ -936,7 +952,6 @@ UniValue sendrawtransaction(const JSONRPCRequest& request)
         // push to local node and sync with wallets
         CValidationState state;
         bool fMissingInputs;
-        ignore_rejects_type ignore_rejects;
         if (!AcceptToMemoryPool(mempool, state, std::move(tx), &fMissingInputs, nullptr, nMaxRawTxFee, ignore_rejects)) {
             if (state.IsInvalid()) {
                 throw JSONRPCError(RPC_TRANSACTION_REJECTED, strprintf("%i: %s", state.GetRejectCode(), state.GetRejectReason()));
@@ -968,7 +983,7 @@ static const CRPCCommand commands[] =
     { "rawtransactions",    "createrawtransaction",   &createrawtransaction,   true,  {"inputs","outputs","locktime","replaceable"} },
     { "rawtransactions",    "decoderawtransaction",   &decoderawtransaction,   true,  {"hexstring"} },
     { "rawtransactions",    "decodescript",           &decodescript,           true,  {"hexstring"} },
-    { "rawtransactions",    "sendrawtransaction",     &sendrawtransaction,     false, {"hexstring","allowhighfees"} },
+    { "rawtransactions",    "sendrawtransaction",     &sendrawtransaction,     false, {"hexstring","ignore_rejects|allowhighfees"} },
     { "rawtransactions",    "combinerawtransaction",  &combinerawtransaction,  true,  {"txs"} },
     { "rawtransactions",    "signrawtransaction",     &signrawtransaction,     false, {"hexstring","prevtxs","privkeys","sighashtype"} }, /* uses wallet if enabled */
 

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -936,9 +936,8 @@ UniValue sendrawtransaction(const JSONRPCRequest& request)
         // push to local node and sync with wallets
         CValidationState state;
         bool fMissingInputs;
-        bool fLimitFree = true;
         ignore_rejects_type ignore_rejects;
-        if (!AcceptToMemoryPool(mempool, state, std::move(tx), fLimitFree, &fMissingInputs, nullptr, nMaxRawTxFee, ignore_rejects)) {
+        if (!AcceptToMemoryPool(mempool, state, std::move(tx), &fMissingInputs, nullptr, nMaxRawTxFee, ignore_rejects)) {
             if (state.IsInvalid()) {
                 throw JSONRPCError(RPC_TRANSACTION_REJECTED, strprintf("%i: %s", state.GetRejectCode(), state.GetRejectReason()));
             } else {

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -937,7 +937,8 @@ UniValue sendrawtransaction(const JSONRPCRequest& request)
         CValidationState state;
         bool fMissingInputs;
         bool fLimitFree = true;
-        if (!AcceptToMemoryPool(mempool, state, std::move(tx), fLimitFree, &fMissingInputs, nullptr, false, nMaxRawTxFee)) {
+        ignore_rejects_type ignore_rejects;
+        if (!AcceptToMemoryPool(mempool, state, std::move(tx), fLimitFree, &fMissingInputs, nullptr, nMaxRawTxFee, ignore_rejects)) {
             if (state.IsInvalid()) {
                 throw JSONRPCError(RPC_TRANSACTION_REJECTED, strprintf("%i: %s", state.GetRejectCode(), state.GetRejectReason()));
             } else {

--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -29,7 +29,7 @@ ToMemPool(CMutableTransaction& tx)
     LOCK(cs_main);
 
     CValidationState state;
-    return AcceptToMemoryPool(mempool, state, MakeTransactionRef(tx), false, nullptr, nullptr, true, 0);
+    return AcceptToMemoryPool(mempool, state, MakeTransactionRef(tx), false, nullptr, nullptr, 0, ignore_rejects_type({rejectmsg_mempoolfull}));
 }
 
 BOOST_FIXTURE_TEST_CASE(tx_mempool_block_doublespend, TestChain100Setup)

--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -29,7 +29,7 @@ ToMemPool(CMutableTransaction& tx)
     LOCK(cs_main);
 
     CValidationState state;
-    return AcceptToMemoryPool(mempool, state, MakeTransactionRef(tx), false, nullptr, nullptr, 0, ignore_rejects_type({rejectmsg_mempoolfull}));
+    return AcceptToMemoryPool(mempool, state, MakeTransactionRef(tx), nullptr, nullptr, 0, ignore_rejects_type({rejectmsg_mempoolfull, rejectmsg_gratis}));
 }
 
 BOOST_FIXTURE_TEST_CASE(tx_mempool_block_doublespend, TestChain100Setup)

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -572,8 +572,9 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
         }
 
         // Check for non-standard pay-to-script-hash in inputs
-        if (fRequireStandard && !AreInputsStandard(tx, view))
-            return state.Invalid(false, REJECT_NONSTANDARD, "bad-txns-nonstandard-inputs");
+        if (fRequireStandard && !AreInputsStandard(tx, view, "bad-txns-input-", reason)) {
+            return state.Invalid(false, REJECT_NONSTANDARD, reason);
+        }
 
         // Check for non-standard witness in P2WSH
         if (tx.HasWitness() && fRequireStandard && !IsWitnessStandard(tx, view))

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -613,12 +613,12 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
 
         CAmount mempoolRejectFee = pool.GetMinFee(gArgs.GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000).GetFee(nSize);
         if (mempoolRejectFee > 0 && nModifiedFees < mempoolRejectFee) {
-            return state.DoS(0, false, REJECT_INSUFFICIENTFEE, "mempool min fee not met", false, strprintf("%d < %d", nFees, mempoolRejectFee));
+            return state.DoS(0, false, REJECT_INSUFFICIENTFEE, "fee-too-low-for-mempool", false, strprintf("%d < %d", nFees, mempoolRejectFee));
         }
 
         // No transactions are allowed below minRelayTxFee except from disconnected blocks
         if (fLimitFree && nModifiedFees < ::minRelayTxFee.GetFee(nSize)) {
-            return state.DoS(0, false, REJECT_INSUFFICIENTFEE, "min relay fee not met");
+            return state.DoS(0, false, REJECT_INSUFFICIENTFEE, "fee-too-low-for-relay");
         }
 
         if (nAbsurdFee && nFees > nAbsurdFee)
@@ -701,7 +701,7 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
                 if (newFeeRate <= oldFeeRate)
                 {
                     return state.DoS(0, false,
-                            REJECT_INSUFFICIENTFEE, "insufficient fee", false,
+                            REJECT_INSUFFICIENTFEE, "fee-too-low-for-replacement", false,
                             strprintf("rejecting replacement %s; new feerate %s <= old feerate %s",
                                   hash.ToString(),
                                   newFeeRate.ToString(),
@@ -730,7 +730,7 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
                 }
             } else {
                 return state.DoS(0, false,
-                        REJECT_NONSTANDARD, "too many potential replacements", false,
+                        REJECT_NONSTANDARD, "too-many-replacements", false,
                         strprintf("rejecting replacement %s; too many potential replacements (%d > %d)\n",
                             hash.ToString(),
                             nConflictingCount,
@@ -762,7 +762,7 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
             if (nModifiedFees < nConflictingFees)
             {
                 return state.DoS(0, false,
-                                 REJECT_INSUFFICIENTFEE, "insufficient fee", false,
+                                 REJECT_INSUFFICIENTFEE, "fee-too-low-for-replacement", false,
                                  strprintf("rejecting replacement %s, less fees than conflicting txs; %s < %s",
                                           hash.ToString(), FormatMoney(nModifiedFees), FormatMoney(nConflictingFees)));
             }
@@ -773,7 +773,7 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
             if (nDeltaFees < ::incrementalRelayFee.GetFee(nSize))
             {
                 return state.DoS(0, false,
-                        REJECT_INSUFFICIENTFEE, "insufficient fee", false,
+                        REJECT_INSUFFICIENTFEE, "fee-too-low-for-replacement", false,
                         strprintf("rejecting replacement %s, not enough additional fees to relay; %s < %s",
                               hash.ToString(),
                               FormatMoney(nDeltaFees),
@@ -862,7 +862,7 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
         if (!fOverrideMempoolLimit) {
             LimitMempoolSize(pool, gArgs.GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000, gArgs.GetArg("-mempoolexpiry", DEFAULT_MEMPOOL_EXPIRY) * 60 * 60);
             if (!pool.exists(hash))
-                return state.DoS(0, false, REJECT_INSUFFICIENTFEE, "mempool full");
+                return state.DoS(0, false, REJECT_INSUFFICIENTFEE, "fee-too-low-for-mempool-full");
         }
     }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -602,8 +602,8 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
         }
 
         // Check for non-standard witness in P2WSH
-        if (tx.HasWitness() && fRequireStandard && !IsWitnessStandard(tx, view)) {
-            MaybeRejectDbg(REJECT_NONSTANDARD, "bad-witness-nonstandard", true, "");
+        if (tx.HasWitness() && fRequireStandard && !IsWitnessStandard(tx, view, "bad-witness-", reason, ignore_rejects)) {
+            return state.DoS(0, false, REJECT_NONSTANDARD, reason, true);
         }
 
         int64_t nSigOpsCost = GetTransactionSigOpCost(tx, view, STANDARD_SCRIPT_VERIFY_FLAGS);

--- a/src/validation.h
+++ b/src/validation.h
@@ -15,6 +15,7 @@
 #include "fs.h"
 #include "protocol.h" // For CMessageHeader::MessageStartChars
 #include "policy/feerate.h"
+#include "policy/policy.h"
 #include "script/script_error.h"
 #include "sync.h"
 #include "versionbits.h"
@@ -300,8 +301,22 @@ void PruneBlockFilesManual(int nManualPruneHeight);
 /** (try to) add transaction to memory pool
  * plTxnReplaced will be appended to with all transactions replaced from mempool **/
 bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransactionRef &tx, bool fLimitFree,
-                        bool* pfMissingInputs, std::list<CTransactionRef>* plTxnReplaced = nullptr,
-                        bool fOverrideMempoolLimit=false, const CAmount nAbsurdFee=0);
+                        bool* pfMissingInputs, std::list<CTransactionRef>* plTxnReplaced,
+                        const CAmount nAbsurdFee, const ignore_rejects_type& ignore_rejects);
+
+// Previously, the signature was ATMP(pool, state, tx, limitfree,
+// missinginputs, txnreplaced, overridemempoollimit, absurdfee) so calls could in theory
+// satisfy absurdfee with `true` which would be broken. To avoid the risk,
+// absurdfee is only optional if ignorerejects is also provided (which cannot
+// be cast implicitly from CAmount).
+static inline bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransactionRef &tx,
+                                      bool fLimitFree, bool* pfMissingInputs,
+                                      std::list<CTransactionRef>* plTxnReplaced = nullptr) {
+    return AcceptToMemoryPool(pool, state, tx, fLimitFree, pfMissingInputs, plTxnReplaced, 0, empty_ignore_rejects);
+}
+
+static const std::string rejectmsg_absurdfee = "absurdly-high-fee";
+static const std::string rejectmsg_mempoolfull = "fee-too-low-for-mempool-full";
 
 /** Convert CValidationState to a human-readable message for logging */
 std::string FormatStateMessage(const CValidationState &state);

--- a/src/validation.h
+++ b/src/validation.h
@@ -300,22 +300,12 @@ void PruneBlockFilesManual(int nManualPruneHeight);
 
 /** (try to) add transaction to memory pool
  * plTxnReplaced will be appended to with all transactions replaced from mempool **/
-bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransactionRef &tx, bool fLimitFree,
-                        bool* pfMissingInputs, std::list<CTransactionRef>* plTxnReplaced,
-                        const CAmount nAbsurdFee, const ignore_rejects_type& ignore_rejects);
-
-// Previously, the signature was ATMP(pool, state, tx, limitfree,
-// missinginputs, txnreplaced, overridemempoollimit, absurdfee) so calls could in theory
-// satisfy absurdfee with `true` which would be broken. To avoid the risk,
-// absurdfee is only optional if ignorerejects is also provided (which cannot
-// be cast implicitly from CAmount).
-static inline bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransactionRef &tx,
-                                      bool fLimitFree, bool* pfMissingInputs,
-                                      std::list<CTransactionRef>* plTxnReplaced = nullptr) {
-    return AcceptToMemoryPool(pool, state, tx, fLimitFree, pfMissingInputs, plTxnReplaced, 0, empty_ignore_rejects);
-}
+bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransactionRef &tx,
+                        bool* pfMissingInputs, std::list<CTransactionRef>* plTxnReplaced = nullptr,
+                        const CAmount nAbsurdFee=0, const ignore_rejects_type& ignore_rejects=empty_ignore_rejects);
 
 static const std::string rejectmsg_absurdfee = "absurdly-high-fee";
+static const std::string rejectmsg_gratis = "fee-too-low-for-relay";
 static const std::string rejectmsg_mempoolfull = "fee-too-low-for-mempool-full";
 
 /** Convert CValidationState to a human-readable message for logging */

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4333,7 +4333,7 @@ int CMerkleTx::GetBlocksToMaturity() const
 }
 
 
-bool CMerkleTx::AcceptToMemoryPool(const CAmount& nAbsurdFee, CValidationState& state)
+bool CMerkleTx::AcceptToMemoryPool(const CAmount& nAbsurdFee, CValidationState& state, const ignore_rejects_type& ignore_rejects)
 {
-    return ::AcceptToMemoryPool(mempool, state, tx, true, nullptr, nullptr, false, nAbsurdFee);
+    return ::AcceptToMemoryPool(mempool, state, tx, true, nullptr, nullptr, nAbsurdFee, ignore_rejects);
 }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4335,5 +4335,5 @@ int CMerkleTx::GetBlocksToMaturity() const
 
 bool CMerkleTx::AcceptToMemoryPool(const CAmount& nAbsurdFee, CValidationState& state, const ignore_rejects_type& ignore_rejects)
 {
-    return ::AcceptToMemoryPool(mempool, state, tx, true, nullptr, nullptr, nAbsurdFee, ignore_rejects);
+    return ::AcceptToMemoryPool(mempool, state, tx, nullptr, nullptr, nAbsurdFee, ignore_rejects);
 }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -8,6 +8,7 @@
 
 #include "amount.h"
 #include "policy/feerate.h"
+#include "policy/policy.h"
 #include "streams.h"
 #include "tinyformat.h"
 #include "ui_interface.h"
@@ -253,7 +254,7 @@ public:
     bool IsInMainChain() const { const CBlockIndex *pindexRet; return GetDepthInMainChain(pindexRet) > 0; }
     int GetBlocksToMaturity() const;
     /** Pass this transaction to the mempool. Fails if absolute fee exceeds absurd fee. */
-    bool AcceptToMemoryPool(const CAmount& nAbsurdFee, CValidationState& state);
+    bool AcceptToMemoryPool(const CAmount& nAbsurdFee, CValidationState& state, const ignore_rejects_type& ignore_rejects=empty_ignore_rejects);
     bool hashUnset() const { return (hashBlock.IsNull() || hashBlock == ABANDON_HASH); }
     bool isAbandoned() const { return (hashBlock == ABANDON_HASH); }
     void setAbandoned() { hashBlock = ABANDON_HASH; }

--- a/test/functional/p2p-segwit.py
+++ b/test/functional/p2p-segwit.py
@@ -1819,13 +1819,13 @@ class SegWitTest(BitcoinTestFramework):
         # Testing native P2WSH
         # Witness stack size, excluding witnessScript, over 100 is non-standard
         p2wsh_txs[0].wit.vtxinwit[0].scriptWitness.stack = [pad] * 101 + [scripts[0]]
-        self.std_node.test_transaction_acceptance(p2wsh_txs[0], True, False, b'bad-witness-nonstandard')
+        self.std_node.test_transaction_acceptance(p2wsh_txs[0], True, False, b'bad-witness-stackitem-count')
         # Non-standard nodes should accept
         self.test_node.test_transaction_acceptance(p2wsh_txs[0], True, True)
 
         # Stack element size over 80 bytes is non-standard
         p2wsh_txs[1].wit.vtxinwit[0].scriptWitness.stack = [pad * 81] * 100 + [scripts[1]]
-        self.std_node.test_transaction_acceptance(p2wsh_txs[1], True, False, b'bad-witness-nonstandard')
+        self.std_node.test_transaction_acceptance(p2wsh_txs[1], True, False, b'bad-witness-stackitem-size')
         # Non-standard nodes should accept
         self.test_node.test_transaction_acceptance(p2wsh_txs[1], True, True)
         # Standard nodes should accept if element size is not over 80 bytes
@@ -1839,16 +1839,16 @@ class SegWitTest(BitcoinTestFramework):
 
         # witnessScript size at 3601 bytes is non-standard
         p2wsh_txs[3].wit.vtxinwit[0].scriptWitness.stack = [pad, pad, pad, scripts[3]]
-        self.std_node.test_transaction_acceptance(p2wsh_txs[3], True, False, b'bad-witness-nonstandard')
+        self.std_node.test_transaction_acceptance(p2wsh_txs[3], True, False, b'bad-witness-script-size')
         # Non-standard nodes should accept
         self.test_node.test_transaction_acceptance(p2wsh_txs[3], True, True)
 
         # Repeating the same tests with P2SH-P2WSH
         p2sh_txs[0].wit.vtxinwit[0].scriptWitness.stack = [pad] * 101 + [scripts[0]]
-        self.std_node.test_transaction_acceptance(p2sh_txs[0], True, False, b'bad-witness-nonstandard')
+        self.std_node.test_transaction_acceptance(p2sh_txs[0], True, False, b'bad-witness-stackitem-count')
         self.test_node.test_transaction_acceptance(p2sh_txs[0], True, True)
         p2sh_txs[1].wit.vtxinwit[0].scriptWitness.stack = [pad * 81] * 100 + [scripts[1]]
-        self.std_node.test_transaction_acceptance(p2sh_txs[1], True, False, b'bad-witness-nonstandard')
+        self.std_node.test_transaction_acceptance(p2sh_txs[1], True, False, b'bad-witness-stackitem-size')
         self.test_node.test_transaction_acceptance(p2sh_txs[1], True, True)
         p2sh_txs[1].wit.vtxinwit[0].scriptWitness.stack = [pad * 80] * 100 + [scripts[1]]
         self.std_node.test_transaction_acceptance(p2sh_txs[1], True, True)
@@ -1856,7 +1856,7 @@ class SegWitTest(BitcoinTestFramework):
         self.test_node.test_transaction_acceptance(p2sh_txs[2], True, True)
         self.std_node.test_transaction_acceptance(p2sh_txs[2], True, True)
         p2sh_txs[3].wit.vtxinwit[0].scriptWitness.stack = [pad, pad, pad, scripts[3]]
-        self.std_node.test_transaction_acceptance(p2sh_txs[3], True, False, b'bad-witness-nonstandard')
+        self.std_node.test_transaction_acceptance(p2sh_txs[3], True, False, b'bad-witness-script-size')
         self.test_node.test_transaction_acceptance(p2sh_txs[3], True, True)
 
         self.nodes[0].generate(1)  # Mine and clean up the mempool of non-standard node

--- a/test/functional/prioritise_transaction.py
+++ b/test/functional/prioritise_transaction.py
@@ -103,7 +103,7 @@ class PrioritiseTransactionTest(BitcoinTestFramework):
         tx_id = self.nodes[0].decoderawtransaction(tx_hex)["txid"]
 
         # This will raise an exception due to min relay fee not being met
-        assert_raises_jsonrpc(-26, "66: min relay fee not met", self.nodes[0].sendrawtransaction, tx_hex)
+        assert_raises_jsonrpc(-26, "66: fee-too-low-for-relay", self.nodes[0].sendrawtransaction, tx_hex)
         assert(tx_id not in self.nodes[0].getrawmempool())
 
         # This is a less than 1000-byte transaction, so just set the fee

--- a/test/functional/replace-by-fee.py
+++ b/test/functional/replace-by-fee.py
@@ -124,7 +124,7 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         tx1b_hex = txToHex(tx1b)
 
         # This will raise an exception due to insufficient fee
-        assert_raises_jsonrpc(-26, "insufficient fee", self.nodes[0].sendrawtransaction, tx1b_hex, True)
+        assert_raises_jsonrpc(-26, "fee-too-low-for-replacement", self.nodes[0].sendrawtransaction, tx1b_hex, True)
 
         # Extra 0.1 BTC fee
         tx1b = CTransaction()
@@ -167,7 +167,7 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         dbl_tx_hex = txToHex(dbl_tx)
 
         # This will raise an exception due to insufficient fee
-        assert_raises_jsonrpc(-26, "insufficient fee", self.nodes[0].sendrawtransaction, dbl_tx_hex, True)
+        assert_raises_jsonrpc(-26, "fee-too-low-for-replacement", self.nodes[0].sendrawtransaction, dbl_tx_hex, True)
 
         # Accepted with sufficient fee
         dbl_tx = CTransaction()
@@ -228,7 +228,7 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         dbl_tx.vout = [CTxOut(initial_nValue - fee*n, CScript([1]))]
         dbl_tx_hex = txToHex(dbl_tx)
         # This will raise an exception due to insufficient fee
-        assert_raises_jsonrpc(-26, "insufficient fee", self.nodes[0].sendrawtransaction, dbl_tx_hex, True)
+        assert_raises_jsonrpc(-26, "fee-too-low-for-replacement", self.nodes[0].sendrawtransaction, dbl_tx_hex, True)
 
         # 1 BTC fee is enough
         dbl_tx = CTransaction()
@@ -256,7 +256,7 @@ class ReplaceByFeeTest(BitcoinTestFramework):
             dbl_tx.vout = [CTxOut(initial_nValue - 2*fee*n, CScript([1]))]
             dbl_tx_hex = txToHex(dbl_tx)
             # This will raise an exception
-            assert_raises_jsonrpc(-26, "too many potential replacements", self.nodes[0].sendrawtransaction, dbl_tx_hex, True)
+            assert_raises_jsonrpc(-26, "too-many-replacements", self.nodes[0].sendrawtransaction, dbl_tx_hex, True)
 
             for tx in tree_txs:
                 tx.rehash()
@@ -280,7 +280,7 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         tx1b_hex = txToHex(tx1b)
 
         # This will raise an exception due to insufficient fee
-        assert_raises_jsonrpc(-26, "insufficient fee", self.nodes[0].sendrawtransaction, tx1b_hex, True)
+        assert_raises_jsonrpc(-26, "fee-too-low-for-replacement", self.nodes[0].sendrawtransaction, tx1b_hex, True)
 
     def test_spends_of_conflicting_outputs(self):
         """Replacements that spend conflicting tx outputs are rejected"""
@@ -385,7 +385,7 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         double_tx_hex = txToHex(double_tx)
 
         # This will raise an exception
-        assert_raises_jsonrpc(-26, "too many potential replacements", self.nodes[0].sendrawtransaction, double_tx_hex, True)
+        assert_raises_jsonrpc(-26, "too-many-replacements", self.nodes[0].sendrawtransaction, double_tx_hex, True)
 
         # If we remove an input, it should pass
         double_tx = CTransaction()
@@ -482,7 +482,7 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         tx1b_hex = txToHex(tx1b)
 
         # Verify tx1b cannot replace tx1a.
-        assert_raises_jsonrpc(-26, "insufficient fee", self.nodes[0].sendrawtransaction, tx1b_hex, True)
+        assert_raises_jsonrpc(-26, "fee-too-low-for-replacement", self.nodes[0].sendrawtransaction, tx1b_hex, True)
 
         # Use prioritisetransaction to set tx1a's fee to 0.
         self.nodes[0].prioritisetransaction(txid=tx1a_txid, fee_delta=int(-0.1*COIN))
@@ -509,7 +509,7 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         tx2b_hex = txToHex(tx2b)
 
         # Verify tx2b cannot replace tx2a.
-        assert_raises_jsonrpc(-26, "insufficient fee", self.nodes[0].sendrawtransaction, tx2b_hex, True)
+        assert_raises_jsonrpc(-26, "fee-too-low-for-replacement", self.nodes[0].sendrawtransaction, tx2b_hex, True)
 
         # Now prioritise tx2b to have a higher modified fee
         self.nodes[0].prioritisetransaction(txid=tx2b.hash, fee_delta=int(0.1*COIN))


### PR DESCRIPTION
Replace boolean allowhighfees with an Array of rejections to ignore (in a backward compatible manner)

This is useful for node operators who wish to manually accept transactions that don't meet their typical policies, yet don't necessarily want to override all the policies.

It's a bit ugly internally - suggestions on improving that are welcome.
