### PR TITLE
test: test leading spaces for ParseHex

### DIFF
--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -60,6 +60,10 @@ BOOST_AUTO_TEST_CASE(util_ParseHex)
     result = ParseHex("12 34 56 78");
     BOOST_CHECK(result.size() == 4 && result[0] == 0x12 && result[1] == 0x34 && result[2] == 0x56 && result[3] == 0x78);
 
+    // Leading space must be supported (used in CDBEnv::Salvage)
+    result = ParseHex(" 89 34 56 78");
+    BOOST_CHECK(result.size() == 4 && result[0] == 0x89 && result[1] == 0x34 && result[2] == 0x56 && result[3] == 0x78);
+
     // Stop parsing at invalid value
     result = ParseHex("1234 invalid 1234");
     BOOST_CHECK(result.size() == 2 && result[0] == 0x12 && result[1] == 0x34);

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -193,9 +193,9 @@ bool CDBEnv::Salvage(const std::string& strFile, bool fAggressive, std::vector<C
     // Format of bdb dump is ascii lines:
     // header lines...
     // HEADER=END
-    // hexadecimal key
-    // hexadecimal value
-    // ... repeated
+    //  hexadecimal key
+    //  hexadecimal value
+    //  ... repeated
     // DATA=END
 
     string strLine;


### PR DESCRIPTION
BerkeleyDB dump files have key and value lines indented.
The salvage code passes these to ParseHex as-is.
Check this in the tests (should just pass with current code, but may break in the future if someone changes ParseHex without thinking of this).
