### PR TITLE
Add tags to mempool's mapTx indices

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -155,10 +155,10 @@ CBlockTemplate* CreateNewBlock(const CChainParams& chainparams, const CScript& s
             std::make_heap(vecPriority.begin(), vecPriority.end(), pricomparer);
         }
 
-        CTxMemPool::indexed_transaction_set::nth_index<3>::type::iterator mi = mempool.mapTx.get<3>().begin();
+        CTxMemPool::indexed_transaction_set::index<mining_score>::type::iterator mi = mempool.mapTx.get<mining_score>().begin();
         CTxMemPool::txiter iter;
 
-        while (mi != mempool.mapTx.get<3>().end() || !clearedTxs.empty())
+        while (mi != mempool.mapTx.get<mining_score>().end() || !clearedTxs.empty())
         {
             bool priorityTx = false;
             if (fPriorityBlock && !vecPriority.empty()) { // add a tx from priority queue to fill the blockprioritysize

--- a/src/test/mempool_tests.cpp
+++ b/src/test/mempool_tests.cpp
@@ -102,13 +102,13 @@ BOOST_AUTO_TEST_CASE(MempoolRemoveTest)
     removed.clear();
 }
 
-template<int index>
+template<typename name>
 void CheckSort(CTxMemPool &pool, std::vector<std::string> &sortedOrder)
 {
     BOOST_CHECK_EQUAL(pool.size(), sortedOrder.size());
-    typename CTxMemPool::indexed_transaction_set::nth_index<index>::type::iterator it = pool.mapTx.get<index>().begin();
+    typename CTxMemPool::indexed_transaction_set::index<name>::type::iterator it = pool.mapTx.get<name>().begin();
     int count=0;
-    for (; it != pool.mapTx.get<index>().end(); ++it, ++count) {
+    for (; it != pool.mapTx.get<name>().end(); ++it, ++count) {
         BOOST_CHECK_EQUAL(it->GetTx().GetHash().ToString(), sortedOrder[count]);
     }
 }
@@ -164,7 +164,7 @@ BOOST_AUTO_TEST_CASE(MempoolIndexingTest)
     sortedOrder[2] = tx1.GetHash().ToString(); // 10000
     sortedOrder[3] = tx4.GetHash().ToString(); // 15000
     sortedOrder[4] = tx2.GetHash().ToString(); // 20000
-    CheckSort<1>(pool, sortedOrder);
+    CheckSort<descendant_score>(pool, sortedOrder);
 
     /* low fee but with high fee child */
     /* tx6 -> tx7 -> tx8, tx9 -> tx10 */
@@ -176,7 +176,7 @@ BOOST_AUTO_TEST_CASE(MempoolIndexingTest)
     BOOST_CHECK_EQUAL(pool.size(), 6);
     // Check that at this point, tx6 is sorted low
     sortedOrder.insert(sortedOrder.begin(), tx6.GetHash().ToString());
-    CheckSort<1>(pool, sortedOrder);
+    CheckSort<descendant_score>(pool, sortedOrder);
 
     CTxMemPool::setEntries setAncestors;
     setAncestors.insert(pool.mapTx.find(tx6.GetHash()));
@@ -202,7 +202,7 @@ BOOST_AUTO_TEST_CASE(MempoolIndexingTest)
     sortedOrder.erase(sortedOrder.begin());
     sortedOrder.push_back(tx6.GetHash().ToString());
     sortedOrder.push_back(tx7.GetHash().ToString());
-    CheckSort<1>(pool, sortedOrder);
+    CheckSort<descendant_score>(pool, sortedOrder);
 
     /* low fee child of tx7 */
     CMutableTransaction tx8 = CMutableTransaction();
@@ -217,7 +217,7 @@ BOOST_AUTO_TEST_CASE(MempoolIndexingTest)
 
     // Now tx8 should be sorted low, but tx6/tx both high
     sortedOrder.insert(sortedOrder.begin(), tx8.GetHash().ToString());
-    CheckSort<1>(pool, sortedOrder);
+    CheckSort<descendant_score>(pool, sortedOrder);
 
     /* low fee child of tx7 */
     CMutableTransaction tx9 = CMutableTransaction();
@@ -232,7 +232,7 @@ BOOST_AUTO_TEST_CASE(MempoolIndexingTest)
     // tx9 should be sorted low
     BOOST_CHECK_EQUAL(pool.size(), 9);
     sortedOrder.insert(sortedOrder.begin(), tx9.GetHash().ToString());
-    CheckSort<1>(pool, sortedOrder);
+    CheckSort<descendant_score>(pool, sortedOrder);
 
     std::vector<std::string> snapshotOrder = sortedOrder;
 
@@ -274,7 +274,7 @@ BOOST_AUTO_TEST_CASE(MempoolIndexingTest)
     sortedOrder.insert(sortedOrder.begin()+5, tx9.GetHash().ToString());
     sortedOrder.insert(sortedOrder.begin()+6, tx8.GetHash().ToString());
     sortedOrder.insert(sortedOrder.begin()+7, tx10.GetHash().ToString()); // tx10 is just before tx6
-    CheckSort<1>(pool, sortedOrder);
+    CheckSort<descendant_score>(pool, sortedOrder);
 
     // there should be 10 transactions in the mempool
     BOOST_CHECK_EQUAL(pool.size(), 10);
@@ -282,7 +282,7 @@ BOOST_AUTO_TEST_CASE(MempoolIndexingTest)
     // Now try removing tx10 and verify the sort order returns to normal
     std::list<CTransaction> removed;
     pool.remove(pool.mapTx.find(tx10.GetHash())->GetTx(), removed, true);
-    CheckSort<1>(pool, snapshotOrder);
+    CheckSort<descendant_score>(pool, snapshotOrder);
 
     pool.remove(pool.mapTx.find(tx9.GetHash())->GetTx(), removed, true);
     pool.remove(pool.mapTx.find(tx8.GetHash())->GetTx(), removed, true);
@@ -314,7 +314,7 @@ BOOST_AUTO_TEST_CASE(MempoolIndexingTest)
         sortedOrder.push_back(tx3.GetHash().ToString());
         sortedOrder.push_back(tx6.GetHash().ToString());
     }
-    CheckSort<3>(pool, sortedOrder);
+    CheckSort<mining_score>(pool, sortedOrder);
 }
 
 

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -859,9 +859,9 @@ void CTxMemPool::RemoveStaged(setEntries &stage) {
 
 int CTxMemPool::Expire(int64_t time) {
     LOCK(cs);
-    indexed_transaction_set::nth_index<2>::type::iterator it = mapTx.get<2>().begin();
+    indexed_transaction_set::index<entry_time>::type::iterator it = mapTx.get<entry_time>().begin();
     setEntries toremove;
-    while (it != mapTx.get<2>().end() && it->GetTime() < time) {
+    while (it != mapTx.get<entry_time>().end() && it->GetTime() < time) {
         toremove.insert(mapTx.project<0>(it));
         it++;
     }
@@ -957,7 +957,7 @@ void CTxMemPool::TrimToSize(size_t sizelimit, std::vector<uint256>* pvNoSpendsRe
     unsigned nTxnRemoved = 0;
     CFeeRate maxFeeRateRemoved(0);
     while (DynamicMemoryUsage() > sizelimit) {
-        indexed_transaction_set::nth_index<1>::type::iterator it = mapTx.get<1>().begin();
+        indexed_transaction_set::index<descendant_score>::type::iterator it = mapTx.get<descendant_score>().begin();
 
         // We set the new mempool min fee to the feerate of the removed set, plus the
         // "minimum reasonable fee rate" (ie some value under which we consider txn

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -228,6 +228,11 @@ public:
     }
 };
 
+// Multi_index tag names
+struct descendant_score {};
+struct entry_time {};
+struct mining_score {};
+
 class CBlockPolicyEstimator;
 
 /** An inpoint - a combination of a transaction and an index n into its vin */
@@ -350,16 +355,19 @@ public:
             boost::multi_index::ordered_unique<mempoolentry_txid>,
             // sorted by fee rate
             boost::multi_index::ordered_non_unique<
+                boost::multi_index::tag<descendant_score>,
                 boost::multi_index::identity<CTxMemPoolEntry>,
                 CompareTxMemPoolEntryByDescendantScore
             >,
             // sorted by entry time
             boost::multi_index::ordered_non_unique<
+                boost::multi_index::tag<entry_time>,
                 boost::multi_index::identity<CTxMemPoolEntry>,
                 CompareTxMemPoolEntryByEntryTime
                 >,
             // sorted by score (for mining prioritization)
             boost::multi_index::ordered_unique<
+                boost::multi_index::tag<mining_score>,
                 boost::multi_index::identity<CTxMemPoolEntry>,
                 CompareTxMemPoolEntryByScore
             >


### PR DESCRIPTION
This is a small refactor to how we use the boost multi_index in `CTxMemPool` -- rather than have to use fixed index numbers in our code, I added some tags so that we can use logical names instead, so that e.g. `nth_index<2>` becomes `index<entry_time>`.

This was motivated by me rebasing some old work on to master, and I realized that the usage of fixed indices was error prone.

I didn't bother with a tag name for the zero-th index (txid), since nothing seems to explicitly use it, but I can add one if people think that'd be better.
