### PR TITLE
rpc: Input-from-stdin mode for bitcoin-cli

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -8,6 +8,19 @@ Example item
 ----------------
 
 
+bitcoin-cli: arguments privacy
+--------------------------------
+
+The RPC command line client gained a new argument, `-stdin`
+to read extra arguments from standard input, one per line until EOF/Ctrl-D.
+For example:
+
+    $ echo -e "mysecretcode\n120" | src/bitcoin-cli -stdin walletpassphrase
+
+It is recommended to use this for sensitive information such as wallet
+passphrases, as command-line arguments can usually be read from the process
+table by any user on the system.
+
 0.13.0 Change log
 =================
 

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -43,6 +43,7 @@ std::string HelpMessageCli()
     strUsage += HelpMessageOpt("-rpcuser=<user>", _("Username for JSON-RPC connections"));
     strUsage += HelpMessageOpt("-rpcpassword=<pw>", _("Password for JSON-RPC connections"));
     strUsage += HelpMessageOpt("-rpcclienttimeout=<n>", strprintf(_("Timeout during HTTP requests (default: %d)"), DEFAULT_HTTP_CLIENT_TIMEOUT));
+    strUsage += HelpMessageOpt("-stdin", _("Read extra arguments from standard input, one per line until EOF/Ctrl-D (recommended for sensitive information such as passphrases)"));
 
     return strUsage;
 }
@@ -232,15 +233,17 @@ int CommandLineRPC(int argc, char *argv[])
             argc--;
             argv++;
         }
-
-        // Method
-        if (argc < 2)
-            throw runtime_error("too few parameters");
-        string strMethod = argv[1];
-
-        // Parameters default to strings
-        std::vector<std::string> strParams(&argv[2], &argv[argc]);
-        UniValue params = RPCConvertValues(strMethod, strParams);
+        std::vector<std::string> args = std::vector<std::string>(&argv[1], &argv[argc]);
+        if (GetBoolArg("-stdin", false)) {
+            // Read one arg per line from stdin and append
+            std::string line;
+            while (std::getline(std::cin,line))
+                args.push_back(line);
+        }
+        if (args.size() < 1)
+            throw runtime_error("too few parameters (need at least command)");
+        std::string strMethod = args[0];
+        UniValue params = RPCConvertValues(strMethod, std::vector<std::string>(args.begin()+1, args.end()));
 
         // Execute and handle connection failures with -rpcwait
         const bool fWait = GetBoolArg("-rpcwait", false);


### PR DESCRIPTION
Implements #7442 by adding an option `-stdin` which reads additional arguments from standard in, one per line.

For example

``` bash
$ echo -e "mysecretcode\n120" | src/bitcoin-cli -stdin walletpassphrase
$ echo -e "walletpassphrase\nmysecretcode\n120" | src/bitcoin-cli -stdin
$ src/bitcoin-cli -stdin walletpassphrase
mysecretcode
120
^D
```

This is the simplest implementation and avoids escaping issues by using newline as separator instead of space, I first had another implementation: https://github.com/laanwj/bitcoin/commit/1f73b8e27b57c8561840cddc9f69a97475d06e85 that reuses `parseCommandLine` from the GUI debug console, but I think this is more useful in practice as most use of cli is probably script-driven.
