### PR TITLE
Add importmulti RPC call

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -145,6 +145,7 @@ testScripts = [
     'signmessages.py',
     'p2p-compactblocks.py',
     'nulldummy.py',
+    'importmulti.py',
 ]
 if ENABLE_ZMQ:
     testScripts.append('zmq_test.py')

--- a/qa/rpc-tests/importmulti.py
+++ b/qa/rpc-tests/importmulti.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2016 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+
+class ImportMultiTest (BitcoinTestFramework):
+    def __init__(self):
+        super().__init__()
+        self.num_nodes = 2
+        self.setup_clean_chain = True
+
+    def setup_network(self, split=False):
+        self.nodes = start_nodes(2, self.options.tmpdir)
+        self.is_network_split=False
+
+    def run_test (self):
+        print ("Mining blocks...")
+        self.nodes[0].generate(1)
+        self.nodes[1].generate(1)
+
+        # keyword definition
+        PRIV_KEY = 'privkey'
+        PUB_KEY = 'pubkey'
+        ADDRESS_KEY = 'address'
+        SCRIPT_KEY = 'script'
+
+
+        node0_address1 = self.nodes[0].validateaddress(self.nodes[0].getnewaddress())
+        node0_address2 = self.nodes[0].validateaddress(self.nodes[0].getnewaddress())
+        node0_address3 = self.nodes[0].validateaddress(self.nodes[0].getnewaddress())
+
+        #Check only one address
+        assert_equal(node0_address1['ismine'], True)
+
+        #Node 1 sync test
+        assert_equal(self.nodes[1].getblockcount(),1)
+
+        #Address Test - before import
+        address_info = self.nodes[1].validateaddress(node0_address1['address'])
+        assert_equal(address_info['iswatchonly'], False)
+        assert_equal(address_info['ismine'], False)
+
+
+        # RPC importmulti -----------------------------------------------
+
+        # Bitcoin Address
+        print("Should import an address")
+        address = self.nodes[0].validateaddress(self.nodes[0].getnewaddress())
+        result = self.nodes[1].importmulti([{
+            "scriptPubKey": {
+                "address": address['address']
+            }
+        }])
+        assert_equal(result[0]['success'], True)
+        address_assert = self.nodes[1].validateaddress(address['address'])
+        assert_equal(address_assert['iswatchonly'], True)
+        assert_equal(address_assert['ismine'], False)
+
+
+        # ScriptPubKey + internal
+        print("Should import a scriptPubKey with internal flag")
+        address = self.nodes[0].validateaddress(self.nodes[0].getnewaddress())
+        result = self.nodes[1].importmulti([{
+            "scriptPubKey": address['scriptPubKey'],
+            "internal": True
+        }])
+        assert_equal(result[0]['success'], True)
+        address_assert = self.nodes[1].validateaddress(address['address'])
+        assert_equal(address_assert['iswatchonly'], True)
+        assert_equal(address_assert['ismine'], False)
+
+        # ScriptPubKey + !internal
+        print("Should not import a scriptPubKey without internal flag")
+        address = self.nodes[0].validateaddress(self.nodes[0].getnewaddress())
+        result = self.nodes[1].importmulti([{
+            "scriptPubKey": address['scriptPubKey']
+        }])
+        assert_equal(result[0]['success'], False)
+        assert_equal(result[0]['error']['code'], -8)
+        assert_equal(result[0]['error']['message'], 'Internal must be set for hex scriptPubKey')
+        address_assert = self.nodes[1].validateaddress(address['address'])
+        assert_equal(address_assert['iswatchonly'], False)
+        assert_equal(address_assert['ismine'], False)
+
+
+        # Address + Public key + !Internal
+        print("Should import an address with public key")
+        address = self.nodes[0].validateaddress(self.nodes[0].getnewaddress())
+        result = self.nodes[1].importmulti([{
+            "scriptPubKey": {
+                "address": address['address']
+            },
+            "pubkeys": [ address['pubkey'] ]
+        }])
+        assert_equal(result[0]['success'], True)
+        address_assert = self.nodes[1].validateaddress(address['address'])
+        assert_equal(address_assert['iswatchonly'], True)
+        assert_equal(address_assert['ismine'], False)
+
+
+        # ScriptPubKey + Public key + internal
+        print("Should import a scriptPubKey with internal and with public key")
+        address = self.nodes[0].validateaddress(self.nodes[0].getnewaddress())
+        request = [{
+            "scriptPubKey": address['scriptPubKey'],
+            "pubkeys": [ address['pubkey'] ],
+            "internal": True
+        }];
+        result = self.nodes[1].importmulti(request)
+        assert_equal(result[0]['success'], True)
+        address_assert = self.nodes[1].validateaddress(address['address'])
+        assert_equal(address_assert['iswatchonly'], True)
+        assert_equal(address_assert['ismine'], False)
+
+        # ScriptPubKey + Public key + !internal
+        print("Should not import a scriptPubKey without internal and with public key")
+        address = self.nodes[0].validateaddress(self.nodes[0].getnewaddress())
+        request = [{
+            "scriptPubKey": address['scriptPubKey'],
+            "pubkeys": [ address['pubkey'] ]
+        }];
+        result = self.nodes[1].importmulti(request)
+        assert_equal(result[0]['success'], False)
+        assert_equal(result[0]['error']['code'], -8)
+        assert_equal(result[0]['error']['message'], 'Internal must be set for hex scriptPubKey')
+        address_assert = self.nodes[1].validateaddress(address['address'])
+        assert_equal(address_assert['iswatchonly'], False)
+        assert_equal(address_assert['ismine'], False)
+
+        # Address + Private key + !watchonly
+        print("Should import an address with private key")
+        address = self.nodes[0].validateaddress(self.nodes[0].getnewaddress())
+        result = self.nodes[1].importmulti([{
+            "scriptPubKey": {
+                "address": address['address']
+            },
+            "keys": [ self.nodes[0].dumpprivkey(address['address']) ]
+        }])
+        assert_equal(result[0]['success'], True)
+        address_assert = self.nodes[1].validateaddress(address['address'])
+        assert_equal(address_assert['iswatchonly'], False)
+        assert_equal(address_assert['ismine'], True)
+
+        # Address + Private key + watchonly
+        print("Should not import an address with private key and with watchonly")
+        address = self.nodes[0].validateaddress(self.nodes[0].getnewaddress())
+        result = self.nodes[1].importmulti([{
+            "scriptPubKey": {
+                "address": address['address']
+            },
+            "keys": [ self.nodes[0].dumpprivkey(address['address']) ],
+            "watchonly": True
+        }])
+        assert_equal(result[0]['success'], False)
+        assert_equal(result[0]['error']['code'], -8)
+        assert_equal(result[0]['error']['message'], 'Incompatibility found between watchonly and keys')
+        address_assert = self.nodes[1].validateaddress(address['address'])
+        assert_equal(address_assert['iswatchonly'], False)
+        assert_equal(address_assert['ismine'], False)
+
+        # ScriptPubKey + Private key + internal
+        print("Should import a scriptPubKey with internal and with private key")
+        address = self.nodes[0].validateaddress(self.nodes[0].getnewaddress())
+        result = self.nodes[1].importmulti([{
+            "scriptPubKey": address['scriptPubKey'],
+            "keys": [ self.nodes[0].dumpprivkey(address['address']) ],
+            "internal": True
+        }])
+        assert_equal(result[0]['success'], True)
+        address_assert = self.nodes[1].validateaddress(address['address'])
+        assert_equal(address_assert['iswatchonly'], False)
+        assert_equal(address_assert['ismine'], True)
+
+        # ScriptPubKey + Private key + !internal
+        print("Should not import a scriptPubKey without internal and with private key")
+        address = self.nodes[0].validateaddress(self.nodes[0].getnewaddress())
+        result = self.nodes[1].importmulti([{
+            "scriptPubKey": address['scriptPubKey'],
+            "keys": [ self.nodes[0].dumpprivkey(address['address']) ]
+        }])
+        assert_equal(result[0]['success'], False)
+        assert_equal(result[0]['error']['code'], -8)
+        assert_equal(result[0]['error']['message'], 'Internal must be set for hex scriptPubKey')
+        address_assert = self.nodes[1].validateaddress(address['address'])
+        assert_equal(address_assert['iswatchonly'], False)
+        assert_equal(address_assert['ismine'], False)
+
+
+        # P2SH address
+        sig_address_1 = self.nodes[0].validateaddress(self.nodes[0].getnewaddress())
+        sig_address_2 = self.nodes[0].validateaddress(self.nodes[0].getnewaddress())
+        sig_address_3 = self.nodes[0].validateaddress(self.nodes[0].getnewaddress())
+        multi_sig_script = self.nodes[0].createmultisig(2, [sig_address_1['address'], sig_address_2['address'], sig_address_3['pubkey']])
+        self.nodes[1].generate(100)
+        transactionid = self.nodes[1].sendtoaddress(multi_sig_script['address'], 10.00)
+        self.nodes[1].generate(1)
+        transaction = self.nodes[1].gettransaction(transactionid);
+
+        print("Should import a p2sh")
+        result = self.nodes[1].importmulti([{
+            "scriptPubKey": {
+                "address": multi_sig_script['address']
+            }
+        }])
+        assert_equal(result[0]['success'], True)
+        address_assert = self.nodes[1].validateaddress(multi_sig_script['address'])
+        assert_equal(address_assert['isscript'], True)
+        assert_equal(address_assert['iswatchonly'], True)
+        p2shunspent = self.nodes[1].listunspent(0,999999, [multi_sig_script['address']])[0]
+        assert_equal(p2shunspent['spendable'], False)
+        assert_equal(p2shunspent['solvable'], False)
+
+
+        # P2SH + Redeem script
+        sig_address_1 = self.nodes[0].validateaddress(self.nodes[0].getnewaddress())
+        sig_address_2 = self.nodes[0].validateaddress(self.nodes[0].getnewaddress())
+        sig_address_3 = self.nodes[0].validateaddress(self.nodes[0].getnewaddress())
+        multi_sig_script = self.nodes[0].createmultisig(2, [sig_address_1['address'], sig_address_2['address'], sig_address_3['pubkey']])
+        self.nodes[1].generate(100)
+        transactionid = self.nodes[1].sendtoaddress(multi_sig_script['address'], 10.00)
+        self.nodes[1].generate(1)
+        transaction = self.nodes[1].gettransaction(transactionid);
+
+        print("Should import a p2sh with respective redeem script")
+        result = self.nodes[1].importmulti([{
+            "scriptPubKey": {
+                "address": multi_sig_script['address']
+            },
+            "redeemscript": multi_sig_script['redeemScript']
+        }])
+        assert_equal(result[0]['success'], True)
+
+        p2shunspent = self.nodes[1].listunspent(0,999999, [multi_sig_script['address']])[0]
+        assert_equal(p2shunspent['spendable'], False)
+        assert_equal(p2shunspent['solvable'], True)
+
+
+        # P2SH + Redeem script + Private Keys + !Watchonly
+        sig_address_1 = self.nodes[0].validateaddress(self.nodes[0].getnewaddress())
+        sig_address_2 = self.nodes[0].validateaddress(self.nodes[0].getnewaddress())
+        sig_address_3 = self.nodes[0].validateaddress(self.nodes[0].getnewaddress())
+        multi_sig_script = self.nodes[0].createmultisig(2, [sig_address_1['address'], sig_address_2['address'], sig_address_3['pubkey']])
+        self.nodes[1].generate(100)
+        transactionid = self.nodes[1].sendtoaddress(multi_sig_script['address'], 10.00)
+        self.nodes[1].generate(1)
+        transaction = self.nodes[1].gettransaction(transactionid);
+
+        print("Should import a p2sh with respective redeem script and private keys")
+        result = self.nodes[1].importmulti([{
+            "scriptPubKey": {
+                "address": multi_sig_script['address']
+            },
+            "redeemscript": multi_sig_script['redeemScript'],
+            "keys": [ self.nodes[0].dumpprivkey(sig_address_1['address']), self.nodes[0].dumpprivkey(sig_address_2['address'])]
+        }])
+        assert_equal(result[0]['success'], True)
+
+        p2shunspent = self.nodes[1].listunspent(0,999999, [multi_sig_script['address']])[0]
+        assert_equal(p2shunspent['spendable'], False)
+        assert_equal(p2shunspent['solvable'], True)
+
+        # P2SH + Redeem script + Private Keys + Watchonly
+        sig_address_1 = self.nodes[0].validateaddress(self.nodes[0].getnewaddress())
+        sig_address_2 = self.nodes[0].validateaddress(self.nodes[0].getnewaddress())
+        sig_address_3 = self.nodes[0].validateaddress(self.nodes[0].getnewaddress())
+        multi_sig_script = self.nodes[0].createmultisig(2, [sig_address_1['address'], sig_address_2['address'], sig_address_3['pubkey']])
+        self.nodes[1].generate(100)
+        transactionid = self.nodes[1].sendtoaddress(multi_sig_script['address'], 10.00)
+        self.nodes[1].generate(1)
+        transaction = self.nodes[1].gettransaction(transactionid);
+
+        print("Should import a p2sh with respective redeem script and private keys")
+        result = self.nodes[1].importmulti([{
+            "scriptPubKey": {
+                "address": multi_sig_script['address']
+            },
+            "redeemscript": multi_sig_script['redeemScript'],
+            "keys": [ self.nodes[0].dumpprivkey(sig_address_1['address']), self.nodes[0].dumpprivkey(sig_address_2['address'])],
+            "watchonly": True
+        }])
+        assert_equal(result[0]['success'], False)
+        assert_equal(result[0]['error']['code'], -8)
+        assert_equal(result[0]['error']['message'], 'Incompatibility found between watchonly and keys')
+
+        # TODO Consistency tests?
+
+
+
+if __name__ == '__main__':
+    ImportMultiTest ().main ()

--- a/qa/rpc-tests/importmulti.py
+++ b/qa/rpc-tests/importmulti.py
@@ -285,9 +285,76 @@ class ImportMultiTest (BitcoinTestFramework):
         assert_equal(result[0]['error']['code'], -8)
         assert_equal(result[0]['error']['message'], 'Incompatibility found between watchonly and keys')
 
-        # TODO Consistency tests?
+
+        # Address + Public key + !Internal + Wrong pubkey
+        print("Should not import an address with a wrong public key")
+        address = self.nodes[0].validateaddress(self.nodes[0].getnewaddress())
+        address2 = self.nodes[0].validateaddress(self.nodes[0].getnewaddress())
+        result = self.nodes[1].importmulti([{
+            "scriptPubKey": {
+                "address": address['address']
+            },
+            "pubkeys": [ address2['pubkey'] ]
+        }])
+        assert_equal(result[0]['success'], False)
+        assert_equal(result[0]['error']['code'], -5)
+        assert_equal(result[0]['error']['message'], 'Consistency check failed')
+        address_assert = self.nodes[1].validateaddress(address['address'])
+        assert_equal(address_assert['iswatchonly'], False)
+        assert_equal(address_assert['ismine'], False)
 
 
+        # ScriptPubKey + Public key + internal + Wrong pubkey
+        print("Should not import a scriptPubKey with internal and with a wrong public key")
+        address = self.nodes[0].validateaddress(self.nodes[0].getnewaddress())
+        address2 = self.nodes[0].validateaddress(self.nodes[0].getnewaddress())
+        request = [{
+            "scriptPubKey": address['scriptPubKey'],
+            "pubkeys": [ address2['pubkey'] ],
+            "internal": True
+        }];
+        result = self.nodes[1].importmulti(request)
+        assert_equal(result[0]['success'], False)
+        assert_equal(result[0]['error']['code'], -5)
+        assert_equal(result[0]['error']['message'], 'Consistency check failed')
+        address_assert = self.nodes[1].validateaddress(address['address'])
+        assert_equal(address_assert['iswatchonly'], False)
+        assert_equal(address_assert['ismine'], False)
+
+
+        # Address + Private key + !watchonly + Wrong private key
+        print("Should not import an address with a wrong private key")
+        address = self.nodes[0].validateaddress(self.nodes[0].getnewaddress())
+        address2 = self.nodes[0].validateaddress(self.nodes[0].getnewaddress())
+        result = self.nodes[1].importmulti([{
+            "scriptPubKey": {
+                "address": address['address']
+            },
+            "keys": [ self.nodes[0].dumpprivkey(address2['address']) ]
+        }])
+        assert_equal(result[0]['success'], False)
+        assert_equal(result[0]['error']['code'], -5)
+        assert_equal(result[0]['error']['message'], 'Consistency check failed')
+        address_assert = self.nodes[1].validateaddress(address['address'])
+        assert_equal(address_assert['iswatchonly'], False)
+        assert_equal(address_assert['ismine'], False)
+
+
+        # ScriptPubKey + Private key + internal + Wrong private key
+        print("Should not import a scriptPubKey with internal and with a wrong private key")
+        address = self.nodes[0].validateaddress(self.nodes[0].getnewaddress())
+        address2 = self.nodes[0].validateaddress(self.nodes[0].getnewaddress())
+        result = self.nodes[1].importmulti([{
+            "scriptPubKey": address['scriptPubKey'],
+            "keys": [ self.nodes[0].dumpprivkey(address2['address']) ],
+            "internal": True
+        }])
+        assert_equal(result[0]['success'], False)
+        assert_equal(result[0]['error']['code'], -5)
+        assert_equal(result[0]['error']['message'], 'Consistency check failed')
+        address_assert = self.nodes[1].validateaddress(address['address'])
+        assert_equal(address_assert['iswatchonly'], False)
+        assert_equal(address_assert['ismine'], False)
 
 if __name__ == '__main__':
     ImportMultiTest ().main ()

--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -61,6 +61,13 @@ const CBlockIndex *CChain::FindFork(const CBlockIndex *pindex) const {
     return pindex;
 }
 
+CBlockIndex* CChain::FindLatestBefore(int64_t nTime) const
+{
+    std::vector<CBlockIndex*>::const_iterator lower = std::lower_bound(vChain.begin(), vChain.end(), nTime,
+        [](CBlockIndex* pBlock, const int64_t& time) -> bool { return pBlock->GetBlockTime() < time; });
+    return (lower == vChain.end() ? NULL : *lower);
+}
+
 /** Turn the lowest '1' bit in the binary representation of a number into a '0'. */
 int static inline InvertLowestOne(int n) { return n & (n - 1); }
 

--- a/src/chain.h
+++ b/src/chain.h
@@ -459,6 +459,9 @@ public:
 
     /** Find the last common block between this chain and a block index entry. */
     const CBlockIndex *FindFork(const CBlockIndex *pindex) const;
+
+    /** Find the most recent block with timestamp lower than the given. */
+    CBlockIndex* FindLatestBefore(int64_t nTime) const;
 };
 
 #endif // BITCOIN_CHAIN_H

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -95,6 +95,8 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "importaddress", 2 },
     { "importaddress", 3 },
     { "importpubkey", 2 },
+    { "importmulti", 0 },
+    { "importmulti", 1 },
     { "verifychain", 0 },
     { "verifychain", 1 },
     { "keypoolrefill", 0 },

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -24,6 +24,7 @@
 
 #include <univalue.h>
 
+#include <boost/assign/list_of.hpp>
 #include <boost/foreach.hpp>
 
 using namespace std;
@@ -636,4 +637,393 @@ UniValue dumpwallet(const JSONRPCRequest& request)
     file << "# End of dump\n";
     file.close();
     return NullUniValue;
+}
+
+
+UniValue processImport(const UniValue& data) {
+    // TODO List:
+    // - Check consistency between pubkeys/privkeys and scriptPubKey/redeemScript.
+
+    try {
+        bool success = false;
+
+        // Required fields.
+        const UniValue& scriptPubKey = data["scriptPubKey"];
+
+        // Should have script or JSON with "address".
+        if (!(scriptPubKey.getType() == UniValue::VOBJ && scriptPubKey.exists("address")) && !(scriptPubKey.getType() == UniValue::VSTR)) {
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid scriptPubKey");
+        }
+
+        // Optional fields.
+        const string& strRedeemScript = data.exists("redeemscript") ? data["redeemscript"].get_str() : "";
+        const UniValue& pubKeys = data.exists("pubkeys") ? data["pubkeys"].get_array() : UniValue();
+        const UniValue& keys = data.exists("keys") ? data["keys"].get_array() : UniValue();
+        const bool& internal = data.exists("internal") ? data["internal"].get_bool() : false;
+        const bool& watchOnly = data.exists("watchonly") ? data["watchonly"].get_bool() : false;
+        const string& label = data.exists("label") && !internal ? data["label"].get_str() : "";
+        const int64_t& timestamp = data.exists("timestamp") && data["timestamp"].get_int64() > 1 ? data["timestamp"].get_int64() : 1;
+
+        bool isScript = scriptPubKey.getType() == UniValue::VSTR;
+        bool isP2SH = strRedeemScript.length() > 0;
+        const string& output = isScript ? scriptPubKey.get_str() : scriptPubKey["address"].get_str();
+
+        // Parse the output.
+        CScript script;
+        CBitcoinAddress address;
+
+        if (!isScript) {
+            address = CBitcoinAddress(output);
+            script = GetScriptForDestination(address.Get());
+        } else {
+            if (!IsHex(output)) {
+                throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid scriptPubKey");
+            }
+
+            std::vector<unsigned char> vData(ParseHex(output));
+            script = CScript(vData.begin(), vData.end());
+        }
+
+        // Watchonly and private keys
+        if (watchOnly && keys.size()) {
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "Incompatibility found between watchonly and keys");
+        }
+
+        // Internal + Label
+        if (internal && data.exists("label")) {
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "Incompatibility found between internal and label");
+        }
+
+        // Not having Internal + Script
+        if (!internal && isScript) {
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "Internal must be set for hex scriptPubKey");
+        }
+
+        // Keys / PubKeys size check.
+        if (!isP2SH && (keys.size() > 1 || pubKeys.size() > 1)) { // Address / scriptPubKey
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "More than private key given for one address");
+        }
+
+        // Invalid P2SH redeemScript
+        if (isP2SH && !IsHex(strRedeemScript)) {
+            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid redeem script");
+        }
+
+        // Process. //
+
+        // P2SH
+        if (isP2SH) {
+            // TODO: check consistency between private keys and p2sh redeemscript + p2sh address
+
+            // Import redeem script.
+            std::vector<unsigned char> vData(ParseHex(strRedeemScript));
+            CScript redeemScript = CScript(vData.begin(), vData.end());
+
+            // Invalid P2SH address
+            if (!script.IsPayToScriptHash()) {
+                throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid P2SH address / script");
+            }
+
+            pwalletMain->MarkDirty();
+
+            if (!pwalletMain->HaveWatchOnly(redeemScript) && !pwalletMain->AddWatchOnly(redeemScript)) {
+                throw JSONRPCError(RPC_WALLET_ERROR, "Error adding address to wallet");
+            }
+
+            if (!pwalletMain->HaveCScript(redeemScript) && !pwalletMain->AddCScript(redeemScript)) {
+                throw JSONRPCError(RPC_WALLET_ERROR, "Error adding p2sh redeemScript to wallet");
+            }
+
+            CBitcoinAddress redeemAddress = CBitcoinAddress(CScriptID(redeemScript));
+            CScript redeemDestination = GetScriptForDestination(redeemAddress.Get());
+
+            if (::IsMine(*pwalletMain, redeemDestination) == ISMINE_SPENDABLE) {
+                throw JSONRPCError(RPC_WALLET_ERROR, "The wallet already contains the private key for this address or script");
+            }
+
+            pwalletMain->MarkDirty();
+
+            if (!pwalletMain->HaveWatchOnly(redeemDestination) && !pwalletMain->AddWatchOnly(redeemDestination)) {
+                throw JSONRPCError(RPC_WALLET_ERROR, "Error adding address to wallet");
+            }
+
+            // add to address book or update label
+            if (address.IsValid()) {
+                pwalletMain->SetAddressBook(address.Get(), label, "receive");
+            }
+
+            // Import private keys.
+            if (keys.size()) {
+                for (size_t i = 0; i < keys.size(); i++) {
+                    const string& privkey = keys[i].get_str();
+
+                    CBitcoinSecret vchSecret;
+                    bool fGood = vchSecret.SetString(privkey);
+
+                    if (!fGood) {
+                        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid private key encoding");
+                    }
+
+                    CKey key = vchSecret.GetKey();
+
+                    if (!key.IsValid()) {
+                        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Private key outside allowed range");
+                    }
+
+                    CPubKey pubkey = key.GetPubKey();
+                    assert(key.VerifyPubKey(pubkey));
+
+                    CKeyID vchAddress = pubkey.GetID();
+                    pwalletMain->MarkDirty();
+                    pwalletMain->SetAddressBook(vchAddress, label, "receive");
+
+                    if (pwalletMain->HaveKey(vchAddress)) {
+                        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Already have this key");
+                    }
+
+                    pwalletMain->mapKeyMetadata[vchAddress].nCreateTime = timestamp;
+
+                    if (!pwalletMain->AddKeyPubKey(key, pubkey)) {
+                        throw JSONRPCError(RPC_WALLET_ERROR, "Error adding key to wallet");
+                    }
+
+                    if (timestamp < pwalletMain->nTimeFirstKey) {
+                        pwalletMain->nTimeFirstKey = timestamp;
+                    }
+                }
+            }
+
+            success = true;
+        } else {
+            // TODO: check consistency between private/public keys and scriptPubKey / address
+
+            // Import public keys.
+            if (pubKeys.size() && keys.size() == 0) {
+                const string& strPubKey = pubKeys[0].get_str();
+
+                if (!IsHex(strPubKey)) {
+                    throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Pubkey must be a hex string");
+                }
+
+                std::vector<unsigned char> data(ParseHex(strPubKey));
+                CPubKey pubKey(data.begin(), data.end());
+
+                if (!pubKey.IsFullyValid()) {
+                    throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Pubkey is not a valid public key");
+                }
+
+                CBitcoinAddress pubKeyAddress = CBitcoinAddress(pubKey.GetID());
+                CScript pubKeyScript = GetScriptForDestination(pubKeyAddress.Get());
+
+                if (::IsMine(*pwalletMain, pubKeyScript) == ISMINE_SPENDABLE) {
+                    throw JSONRPCError(RPC_WALLET_ERROR, "The wallet already contains the private key for this address or script");
+                }
+
+                pwalletMain->MarkDirty();
+
+                if (!pwalletMain->HaveWatchOnly(pubKeyScript) && !pwalletMain->AddWatchOnly(pubKeyScript)) {
+                    throw JSONRPCError(RPC_WALLET_ERROR, "Error adding address to wallet");
+                }
+
+                // add to address book or update label
+                if (pubKeyAddress.IsValid()) {
+                    pwalletMain->SetAddressBook(pubKeyAddress.Get(), label, "receive");
+                }
+
+                // TODO Is this necessary?
+                CScript scriptRawPubKey = GetScriptForRawPubKey(pubKey);
+
+                if (::IsMine(*pwalletMain, scriptRawPubKey) == ISMINE_SPENDABLE) {
+                    throw JSONRPCError(RPC_WALLET_ERROR, "The wallet already contains the private key for this address or script");
+                }
+
+                pwalletMain->MarkDirty();
+
+                if (!pwalletMain->HaveWatchOnly(scriptRawPubKey) && !pwalletMain->AddWatchOnly(scriptRawPubKey)) {
+                    throw JSONRPCError(RPC_WALLET_ERROR, "Error adding address to wallet");
+                }
+
+                success = true;
+            }
+
+            // Import private keys.
+            if (keys.size()) {
+                const string& strPrivkey = keys[0].get_str();
+
+                // Checks.
+                CBitcoinSecret vchSecret;
+                bool fGood = vchSecret.SetString(strPrivkey);
+
+                if (!fGood) {
+                    throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid private key encoding");
+                }
+
+                CKey key = vchSecret.GetKey();
+                if (!key.IsValid()) {
+                    throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Private key outside allowed range");
+                }
+
+                CPubKey pubKey = key.GetPubKey();
+                assert(key.VerifyPubKey(pubKey));
+
+                CKeyID vchAddress = pubkey.GetID();
+                pwalletMain->MarkDirty();
+                pwalletMain->SetAddressBook(vchAddress, label, "receive");
+
+                if (pwalletMain->HaveKey(vchAddress)) {
+                    return false;
+                }
+
+                pwalletMain->mapKeyMetadata[vchAddress].nCreateTime = timestamp;
+
+                if (!pwalletMain->AddKeyPubKey(key, pubKey)) {
+                    throw JSONRPCError(RPC_WALLET_ERROR, "Error adding key to wallet");
+                }
+
+                if (timestamp < pwalletMain->nTimeFirstKey) {
+                    pwalletMain->nTimeFirstKey = timestamp;
+                }
+
+                success = true;
+            }
+
+            // Import scriptPubKey only.
+            if (pubKeys.size() == 0 && keys.size() == 0) {
+                if (::IsMine(*pwalletMain, script) == ISMINE_SPENDABLE) {
+                    throw JSONRPCError(RPC_WALLET_ERROR, "The wallet already contains the private key for this address or script");
+                }
+
+                pwalletMain->MarkDirty();
+
+                if (!pwalletMain->HaveWatchOnly(script) && !pwalletMain->AddWatchOnly(script)) {
+                    throw JSONRPCError(RPC_WALLET_ERROR, "Error adding address to wallet");
+                }
+
+                if (scriptPubKey.getType() == UniValue::VOBJ) {
+                    // add to address book or update label
+                    if (address.IsValid()) {
+                        pwalletMain->SetAddressBook(address.Get(), label, "receive");
+                    }
+                }
+
+                success = true;
+            }
+        }
+
+        UniValue result = UniValue(UniValue::VOBJ);
+        result.pushKV("success", UniValue(success));
+        return result;
+    } catch (const UniValue& e) {
+        UniValue result = UniValue(UniValue::VOBJ);
+        result.pushKV("success", UniValue(false));
+        result.pushKV("error", e);
+        return result;
+    } catch (...) {
+        UniValue result = UniValue(UniValue::VOBJ);
+        result.pushKV("success", UniValue(false));
+        result.pushKV("error", JSONRPCError(RPC_MISC_ERROR, "Missing required fields"));
+        return result;
+    }
+}
+
+UniValue importmulti(const JSONRPCRequest& mainRequest)
+{
+    // clang-format off
+    if (mainRequest.fHelp || mainRequest.params.size() < 1 || mainRequest.params.size() > 2)
+        throw runtime_error(
+            "importmulti '[<json import requests>]' '<json options>' \n\n"
+            "Import addresses/scripts (with private or public keys, redeem script (P2SH)), rescanning all addresses in one-shot-only (rescan can be disabled via options).\n\n"
+            "Arguments:\n"
+            "1. request array     (array, required) Data to be imported\n"
+            "  [     (array of json objects)\n"
+            "    {\n"
+            "      \"scriptPubKey\": \"<script>\" | { \"address\":\"<address>\" }, (string / json, required) Type of scriptPubKey (string for script, json for address)\n"
+            "      \"redeemscript\": \"<script>\"                            , (string, optional) Allowed only if the scriptPubKey is a P2SH address or a P2SH scriptPubKey\n"
+            "      \"pubkeys\": [\"<pubKey>\", ... ]                         , (array, optional) Array of strings giving pubkeys that must occur in the output or redeemscript\n"
+            "      \"keys\": [\"<key>\", ... ]                               , (array, optional) Array of strings giving private keys whose corresponding public keys must occur in the output or redeemscript\n"
+            "      \"internal\": <true>                                    , (boolean, optional, default: false) Stating whether matching outputs should be be treated as not incoming payments\n"
+            "      \"watchonly\": <true>                                   , (boolean, optional, default: false) Stating whether matching outputs should be considered watched even when they're not spendable, only allowed if keys are empty\n"
+            "      \"label\": <label>                                      , (string, optional, default: '') Label to assign to the address (aka account name, for now), only allowed with internal=false\n"
+            "      \"timestamp\": 1454686740,                                (integer, optional, default now) Timestamp\n"
+            "    }\n"
+            "  ,...\n"
+            "  ]\n"
+            "2. json options                 (json, optional)\n"
+            "  {\n"
+            "     \"rescan\": <false>,         (boolean, optional, default: true) Stating if should rescan the blockchain after all imports\n"
+            "  }\n"
+            "\nExamples:\n" +
+            HelpExampleCli("importmulti", "'[{ \"scriptPubKey\": { \"address\": \"<my address>\" }, \"timestamp\":1455191478 }, "
+                                          "{ \"scriptPubKey\": { \"address\": \"<my 2nd address>\" }, \"label\": \"example 2\", \"timestamp\": 1455191480 }]'") +
+            HelpExampleCli("importmulti", "'[{ \"scriptPubKey\": { \"address\": \"<my address>\" }, \"timestamp\":1455191478 }]' '{ \"rescan\": false}'") +
+
+            "\nResponse is an array with the same size as the input that has the execution result :\n"
+            "  [{ \"success\": true } , { \"success\": false, \"error\": { \"code\": -1, \"message\": \"Internal Server Error\"} }, ... ]\n");
+
+    // clang-format on
+    if (!EnsureWalletIsAvailable(mainRequest.fHelp)) {
+        return NullUniValue;
+    }
+
+    RPCTypeCheck(mainRequest.params, boost::assign::list_of(UniValue::VARR)(UniValue::VOBJ));
+
+    const UniValue& requests = mainRequest.params[0];
+
+    //Default options
+    bool fRescan = true;
+
+    if (mainRequest.params.size() > 1) {
+        const UniValue& options = mainRequest.params[1];
+
+        if (options.exists("rescan")) {
+            fRescan = options["rescan"].get_bool();
+        }
+    }
+
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+    EnsureWalletIsUnlocked();
+
+    bool fRunScan = false;
+    const int64_t minimumTimestamp = 1;
+    int64_t nLowestTimestamp;
+
+    if (fRescan && chainActive.Tip()) {
+        nLowestTimestamp = chainActive.Tip()->GetBlockTime();
+    } else {
+        fRescan = false;
+    }
+
+    UniValue response(UniValue::VARR);
+
+    BOOST_FOREACH (const UniValue& data, requests.getValues()) {
+        const UniValue result = processImport(data);
+        response.push_back(result);
+
+        if (!fRescan) {
+            continue;
+        }
+
+        // If at least one request was successful then allow rescan.
+        if (result["success"].get_bool()) {
+            fRunScan = true;
+        }
+
+        // Get the lowest timestamp.
+        const int64_t& timestamp = data.exists("timestamp") && data["timestamp"].get_int64() > minimumTimestamp ? data["timestamp"].get_int64() : minimumTimestamp;
+
+        if (timestamp < nLowestTimestamp) {
+            nLowestTimestamp = timestamp;
+        }
+    }
+
+    if (fRescan && fRunScan && requests.size() && nLowestTimestamp <= chainActive.Tip()->GetBlockTime()) {
+        CBlockIndex* pindex = nLowestTimestamp > minimumTimestamp ? chainActive.FindLatestBefore(nLowestTimestamp) : chainActive.Genesis();
+
+        if (pindex) {
+            pwalletMain->ScanForWalletTransactions(pindex, true);
+            pwalletMain->ReacceptWalletTransactions();
+        }
+    }
+
+    return response;
 }

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2583,6 +2583,7 @@ extern UniValue dumpwallet(const JSONRPCRequest& request);
 extern UniValue importwallet(const JSONRPCRequest& request);
 extern UniValue importprunedfunds(const JSONRPCRequest& request);
 extern UniValue removeprunedfunds(const JSONRPCRequest& request);
+extern UniValue importmulti(const JSONRPCRequest& request);
 
 static const CRPCCommand commands[] =
 { //  category              name                        actor (function)           okSafeMode
@@ -2607,6 +2608,7 @@ static const CRPCCommand commands[] =
     { "wallet",             "gettransaction",           &gettransaction,           false },
     { "wallet",             "getunconfirmedbalance",    &getunconfirmedbalance,    false },
     { "wallet",             "getwalletinfo",            &getwalletinfo,            false },
+    { "wallet",             "importmulti",              &importmulti,              true  },
     { "wallet",             "importprivkey",            &importprivkey,            true  },
     { "wallet",             "importwallet",             &importwallet,             true  },
     { "wallet",             "importaddress",            &importaddress,            true  },


### PR DESCRIPTION
As discussed in PR https://github.com/bitcoin/bitcoin/pull/6570 this is a new rpc call `importmulti` that receives an array of JSON objects representing the intention of importing a public key, a private key, an address and script/p2sh:

```
bitcoin-cli importmulti '[
  {
    "timestamp": 1455191478,
    "type": "privkey",
    "value": "<private key>"
  },
  {
    "label": "example 1",
    "timestamp": 1455191480,
    "type": "pubkey",
    "value": "<public key>"
  }
]' '{"rescan":true}'
```

and rescans (if not disabled in second argument) the chain from the block that has a timestamp lowest than the lowest timestamp found in all requests, preventing scanning from genesis.

The output is an array with the status of each request:

```
output: [ { "result": true } , { "result": true } ]
```

Arguments:

```
1. json request array     (json, required) Data to be imported
  [
    {
      "type": "privkey | pubkey | address | script", (string, required) Type of address
      "value": "...",                       (string, required) Value of the address
      "timestamp": 1454686740,              (integer, optional) Timestamp
      "label": "..."                        (string, optional) Label
      "p2sh": true | false                  (bool, optional, default=false) Value is a P2SH (type=script only)
    }
  ,...
  ]
2. json options                 (json, optional) Options
```

Some notes: 
- If one of the import requests has no timestamp then it should rescan from Genesis (if rescan is not disabled).
- If all requests fail then it won't rescan the chain. 

**Edit**: As suggested by @promag i've replaced the second argument (optional) `bool` to JSON to be easier specify new options and added a new `type="script"` to support only script values, so can `type="address"` work only with addresses. 
