### PR TITLE
rpc: Add `verifyrawtransactions` call

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -21,6 +21,11 @@ It is recommended to use this for sensitive information such as wallet
 passphrases, as command-line arguments can usually be read from the process
 table by any user on the system.
 
+New RPC functionality
+----------------------
+
+- `verifyrawtransactions` Verifies one or more raw transactions (serialized, hex-encoded). If transactions depend on each other, they must be provided in order.
+
 0.13.0 Change log
 =================
 

--- a/qa/rpc-tests/rawtransactions.py
+++ b/qa/rpc-tests/rawtransactions.py
@@ -232,6 +232,9 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.nodes[0].generate(1)
         self.sync_all()
         assert_equal(self.nodes[0].getbalance(), bal+Decimal('50.00000000')+Decimal('2.19000000')) #block reward + tx
+        # now that its ancester is in a block, the transaction should pass verification without mempool as well
+        err   = self.nodes[0].verifyrawtransactions([rawTx2],{'include_mempool':False})
+        assert(err is None)
 
 if __name__ == '__main__':
     RawTransactionsTest().main()

--- a/qa/rpc-tests/rawtransactions.py
+++ b/qa/rpc-tests/rawtransactions.py
@@ -128,6 +128,17 @@ class RawTransactionsTest(BitcoinTestFramework):
         assert(err['code'] == 16)
         assert(err['reason'].startswith('coinbase'))
 
+        # passing no transactions at all is always successful, albeit boring
+        err   = self.nodes[2].verifyrawtransactions([])
+        assert(err is None)
+
+        # invalid option name
+        try:
+            err   = self.nodes[2].verifyrawtransactions([],{'check_transaction_color':False})
+            assert(false) # invalid option must cause exception
+        except JSONRPCException,e:
+            assert(e.error['code'] == -8) # RPC_INVALID_PARAMETER
+
         #########################
         # RAW TX MULTISIG TESTS #
         #########################

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -100,6 +100,8 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "prioritisetransaction", 2 },
     { "setban", 2 },
     { "setban", 3 },
+    { "verifyrawtransactions", 0 },
+    { "verifyrawtransactions", 1 },
 };
 
 class CRPCConvertTable

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -842,43 +842,42 @@ UniValue sendrawtransaction(const UniValue& params, bool fHelp)
 
 static bool VerifyTransaction(const CTransaction& tx, CValidationState& state, CCoinsViewCache &view, bool checkFinal, bool checkStandard)
 {
-    if (state.IsValid())
-        CheckTransaction(tx, state);
-    if (state.IsValid() && checkStandard) {
+    if (!CheckTransaction(tx, state))
+        return false; // CheckTransaction fills in state
+    if (checkStandard) {
         std::string reason;
         if (!IsStandardTx(tx, reason)) {
-            state.Invalid(false, REJECT_NONSTANDARD, reason);
+            return state.Invalid(false, REJECT_NONSTANDARD, reason);
         }
     }
-    if (state.IsValid() && tx.IsCoinBase()) {
-        state.Invalid(false, REJECT_INVALID, "coinbase");
+    if (tx.IsCoinBase()) {
+        return state.Invalid(false, REJECT_INVALID, "coinbase");
     }
     // Only accept nLockTime-using transactions that can be mined in the next
     // block
-    if (state.IsValid() && checkFinal && !CheckFinalTx(tx, STANDARD_LOCKTIME_VERIFY_FLAGS)) {
-        state.Invalid(false, REJECT_NONSTANDARD, "non-final");
+    if (checkFinal && !CheckFinalTx(tx, STANDARD_LOCKTIME_VERIFY_FLAGS)) {
+        return state.Invalid(false, REJECT_NONSTANDARD, "non-final");
     }
     // Do this check separately because CheckInputs will set code 0 and no reason for missing inputs
-    if (state.IsValid() && !view.HaveInputs(tx)) {
-        state.Invalid(false, REJECT_INVALID, "bad-txns-inputs-missingorspent");
+    if (!view.HaveInputs(tx)) {
+        return state.Invalid(false, REJECT_INVALID, "bad-txns-inputs-missingorspent");
     }
     // Only accept BIP68 sequence locked transactions that can be mined in the next
     // block
     // This check is done after HaveInputs because CheckSequenceLocks looks up the inputs.
     // TODO: pass in the view into CheckSequenceLocks
-    if (state.IsValid() && checkFinal && !CheckSequenceLocks(tx, STANDARD_LOCKTIME_VERIFY_FLAGS)) {
-        state.Invalid(false, REJECT_NONSTANDARD, "non-BIP68-final");
+    if (checkFinal && !CheckSequenceLocks(tx, STANDARD_LOCKTIME_VERIFY_FLAGS)) {
+        return state.Invalid(false, REJECT_NONSTANDARD, "non-BIP68-final");
     }
     // Check for non-standard pay-to-script-hash in inputs
-    if (state.IsValid() && checkStandard && !AreInputsStandard(tx, view)) {
-        state.Invalid(false, REJECT_NONSTANDARD, "bad-txns-nonstandard-inputs");
+    if (checkStandard && !AreInputsStandard(tx, view)) {
+        return state.Invalid(false, REJECT_NONSTANDARD, "bad-txns-nonstandard-inputs");
     }
-    if (state.IsValid()) {
-        CheckInputs(tx, state, view, true,
-            checkStandard ? STANDARD_SCRIPT_VERIFY_FLAGS : MANDATORY_SCRIPT_VERIFY_FLAGS,
-            true);
-    }
-    return state.IsValid();
+    if (!CheckInputs(tx, state, view, true,
+        checkStandard ? STANDARD_SCRIPT_VERIFY_FLAGS : MANDATORY_SCRIPT_VERIFY_FLAGS,
+        true))
+        return false; // CheckInputs fills in state
+    return true;
 }
 
 UniValue verifyrawtransactions(const UniValue& params, bool fHelp)

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -939,14 +939,16 @@ UniValue verifyrawtransactions(const UniValue& params, bool fHelp)
         if (state.IsValid() && checkFinal && !CheckFinalTx(tx, STANDARD_LOCKTIME_VERIFY_FLAGS)) {
             state.Invalid(false, REJECT_NONSTANDARD, "non-final");
         }
-        // Only accept BIP68 sequence locked transactions that can be mined in the next
-        // block
-        if (state.IsValid() && checkFinal && !CheckSequenceLocks(tx, STANDARD_LOCKTIME_VERIFY_FLAGS)) {
-            state.Invalid(false, REJECT_NONSTANDARD, "non-BIP68-final");
-        }
         // Do this check separately because CheckInputs will set code 0 and no reason for missing inputs
         if (state.IsValid() && !view.HaveInputs(tx)) {
             state.Invalid(false, REJECT_INVALID, "bad-txns-inputs-missingorspent");
+        }
+        // Only accept BIP68 sequence locked transactions that can be mined in the next
+        // block
+        // This check is done after HaveInputs because CheckSequenceLocks looks up the inputs.
+        // TODO: pass in the view into CheckSequenceLocks
+        if (state.IsValid() && checkFinal && !CheckSequenceLocks(tx, STANDARD_LOCKTIME_VERIFY_FLAGS)) {
+            state.Invalid(false, REJECT_NONSTANDARD, "non-BIP68-final");
         }
         // Check for non-standard pay-to-script-hash in inputs
         if (state.IsValid() && checkStandard && !AreInputsStandard(tx, view)) {

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -893,16 +893,18 @@ UniValue verifyrawtransactions(const UniValue& params, bool fHelp)
         const UniValue &options = params[1];
         if (!options.isObject())
             throw JSONRPCError(RPC_TYPE_ERROR, "Second argument must be an object specifying options");
-        UniValue o;
-        o = find_value(options, "include_mempool");
-        if (o.isBool())
-            includeMempool = o.get_bool();
-        o = find_value(options, "check_final");
-        if (o.isBool())
-            checkFinal = o.get_bool();
-        o = find_value(options, "check_standard");
-        if (o.isBool())
-            checkStandard = o.get_bool();
+        std::vector<std::string> keys = options.getKeys();
+        const std::vector<UniValue> &values = options.getValues();
+        for (unsigned int i=0; i<keys.size(); ++i) {
+            if (keys[i] == "include_mempool")
+                includeMempool = values[i].get_bool();
+            else if (keys[i] == "check_final")
+                checkFinal = values[i].get_bool();
+            else if (keys[i] == "check_standard")
+                checkStandard = values[i].get_bool();
+            else
+                throw JSONRPCError(RPC_INVALID_PARAMETER, "Unknown option " + keys[i]);
+        }
     }
 
     // Parse hex strings as transactions

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -307,6 +307,7 @@ static const CRPCCommand vRPCCommands[] =
     { "rawtransactions",    "getrawtransaction",      &getrawtransaction,      true  },
     { "rawtransactions",    "sendrawtransaction",     &sendrawtransaction,     false },
     { "rawtransactions",    "signrawtransaction",     &signrawtransaction,     false }, /* uses wallet if enabled */
+    { "rawtransactions",    "verifyrawtransactions",  &verifyrawtransactions,  true  },
 
     /* Utility functions */
     { "util",               "createmultisig",         &createmultisig,         true  },

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -219,6 +219,7 @@ extern UniValue createrawtransaction(const UniValue& params, bool fHelp);
 extern UniValue decoderawtransaction(const UniValue& params, bool fHelp);
 extern UniValue decodescript(const UniValue& params, bool fHelp);
 extern UniValue signrawtransaction(const UniValue& params, bool fHelp);
+extern UniValue verifyrawtransactions(const UniValue& params, bool fHelp);
 extern UniValue sendrawtransaction(const UniValue& params, bool fHelp);
 extern UniValue gettxoutproof(const UniValue& params, bool fHelp);
 extern UniValue verifytxoutproof(const UniValue& params, bool fHelp);


### PR DESCRIPTION
Add a RPC call to verify a set of raw transactions without propagating them. It has an extensible API to customize verification options.

Implements #4162.

```
verifyrawtransactions ["hexstring",...] ( options )

Verifies one or more raw transactions (serialized, hex-encoded). If transactions depend on each other, they must be provided in order.

Arguments:
1. ["hexstring",...] (array of strings, required) The hex string of the raw transactions)
2. options   (json object, optional)
     {
       "include_mempool"          (boolean, optional, default=true) Whether to include the mem pool
       "check_final"              (boolean, optional, default=true) Check that the transactions will be final by next block
       "check_standard"           (boolean, optional, default=true) Perform transaction standard checks
     }

Result:
null if the verification was successful, otherwise an error object:
{
  "index":n,                (numeric) Index in transactions array of failed transaction
  "hash":"hex",             (string) Transaction hash of failed transaction
  "code": n,                (numeric) Reject code
  "reason": "text"          (string) Reject reason
  "debug_message": "text"   (string) Reject debug message
}
```

TODO:
- ~~RPC test~~
-  ~~Call  `AreInputsStandard()` to check inputs for standardness~~
