### PR TITLE
Encapsulate options for mempool policy

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -122,6 +122,7 @@ BITCOIN_CORE_H = \
   netbase.h \
   noui.h \
   policy/fees.h \
+  policy/mempool.h \
   policy/policy.h \
   policy/rbf.h \
   pow.h \
@@ -189,6 +190,7 @@ libbitcoin_server_a_SOURCES = \
   net.cpp \
   noui.cpp \
   policy/fees.cpp \
+  policy/mempool.cpp \
   policy/policy.cpp \
   pow.cpp \
   rest.cpp \

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -470,8 +470,6 @@ std::string HelpMessage(HelpMessageMode mode)
         strUsage += HelpMessageOpt("-maxsigcachesize=<n>", strprintf("Limit size of signature cache to <n> MiB (default: %u)", DEFAULT_MAX_SIG_CACHE_SIZE));
         strUsage += HelpMessageOpt("-maxtipage=<n>", strprintf("Maximum tip age in seconds to consider node in initial block download (default: %u)", DEFAULT_MAX_TIP_AGE));
     }
-    strUsage += HelpMessageOpt("-minrelaytxfee=<amt>", strprintf(_("Fees (in %s/kB) smaller than this are considered zero fee for relaying, mining and transaction creation (default: %s)"),
-        CURRENCY_UNIT, FormatMoney(DEFAULT_MIN_RELAY_TX_FEE)));
     strUsage += HelpMessageOpt("-maxtxfee=<amt>", strprintf(_("Maximum total fees (in %s) to use in a single wallet transaction or raw transaction; setting this too low may abort large transactions (default: %s)"),
         CURRENCY_UNIT, FormatMoney(DEFAULT_TRANSACTION_MAXFEE)));
     strUsage += HelpMessageOpt("-printtoconsole", _("Send trace/debug info to console instead of debug.log file"));
@@ -779,11 +777,6 @@ static std::string ResolveErrMsg(const char * const optname, const std::string& 
     return strprintf(_("Cannot resolve -%s address: '%s'"), optname, strBind);
 }
 
-static std::string AmountErrMsg(const char * const optname, const std::string& strValue)
-{
-    return strprintf(_("Invalid amount for -%s=<amount>: '%s'"), optname, strValue);
-}
-
 void InitLogging()
 {
     fPrintToConsole = GetBoolArg("-printtoconsole", false);
@@ -960,20 +953,6 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     if (nConnectTimeout <= 0)
         nConnectTimeout = DEFAULT_CONNECT_TIMEOUT;
 
-    // Fee-per-kilobyte amount considered the same as "free"
-    // If you are mining, be careful setting this:
-    // if you set it to zero then
-    // a transaction spammer can cheaply fill blocks using
-    // 1-satoshi-fee transactions. It should be set above the real
-    // cost to you of processing a transaction.
-    if (mapArgs.count("-minrelaytxfee"))
-    {
-        CAmount n = 0;
-        if (ParseMoney(mapArgs["-minrelaytxfee"], n) && n > 0)
-            ::minRelayTxFee = CFeeRate(n);
-        else
-            return InitError(AmountErrMsg("minrelaytxfee", mapArgs["-minrelaytxfee"]));
-    }
     try {
         mempoolPolicy.InitFromArgs();
     } catch(const std::exception& e) {
@@ -1012,10 +991,10 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
         if (nFeePerK > HIGH_TX_FEE_PER_KB)
             InitWarning(_("-paytxfee is set very high! This is the transaction fee you will pay if you send a transaction."));
         payTxFee = CFeeRate(nFeePerK, 1000);
-        if (payTxFee < ::minRelayTxFee)
+        if (payTxFee < mempoolPolicy.GetMinRelayFeeRate())
         {
             return InitError(strprintf(_("Invalid amount for -paytxfee=<amount>: '%s' (must be at least %s)"),
-                                       mapArgs["-paytxfee"], ::minRelayTxFee.ToString()));
+                                       mapArgs["-paytxfee"], mempoolPolicy.GetMinRelayFeeRate().ToString()));
         }
     }
     if (mapArgs.count("-maxtxfee"))
@@ -1026,10 +1005,10 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
         if (nMaxFee > HIGH_MAX_TX_FEE)
             InitWarning(_("-maxtxfee is set very high! Fees this large could be paid on a single transaction."));
         maxTxFee = nMaxFee;
-        if (CFeeRate(maxTxFee, 1000) < ::minRelayTxFee)
+        if (CFeeRate(maxTxFee, 1000) < mempoolPolicy.GetMinRelayFeeRate())
         {
             return InitError(strprintf(_("Invalid amount for -maxtxfee=<amount>: '%s' (must be at least the minrelay fee of %s to prevent stuck transactions)"),
-                                       mapArgs["-maxtxfee"], ::minRelayTxFee.ToString()));
+                                       mapArgs["-maxtxfee"], mempoolPolicy.GetMinRelayFeeRate().ToString()));
         }
     }
     nTxConfirmTarget = GetArg("-txconfirmtarget", DEFAULT_TX_CONFIRM_TARGET);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -22,6 +22,7 @@
 #include "main.h"
 #include "miner.h"
 #include "net.h"
+#include "policy/mempool.h"
 #include "policy/policy.h"
 #include "rpc/server.h"
 #include "script/standard.h"
@@ -484,6 +485,8 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-shrinkdebugfile", _("Shrink debug.log file on client startup (default: 1 when no -debug)"));
 
     AppendParamsHelpMessages(strUsage, showDebug);
+
+    mempoolPolicy.AppendHelpMessages(strUsage, showDebug);
 
     strUsage += HelpMessageGroup(_("Node relay options:"));
     if (showDebug)
@@ -971,6 +974,12 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
         else
             return InitError(AmountErrMsg("minrelaytxfee", mapArgs["-minrelaytxfee"]));
     }
+    try {
+        mempoolPolicy.InitFromArgs();
+    } catch(const std::exception& e) {
+        return InitError(strprintf(_("Error while initializing mempool policy: %s"), e.what()));
+    }
+
 
     fRequireStandard = !GetBoolArg("-acceptnonstdtxn", !Params().RequireStandard());
     if (Params().RequireStandard() && !fRequireStandard)

--- a/src/main.h
+++ b/src/main.h
@@ -46,8 +46,6 @@ static const bool DEFAULT_ALERTS = true;
 static const bool DEFAULT_WHITELISTRELAY = true;
 /** Default for DEFAULT_WHITELISTFORCERELAY. */
 static const bool DEFAULT_WHITELISTFORCERELAY = true;
-/** Default for -minrelaytxfee, minimum relay fee for transactions */
-static const unsigned int DEFAULT_MIN_RELAY_TX_FEE = 1000;
 //! -maxtxfee default
 static const CAmount DEFAULT_TRANSACTION_MAXFEE = 0.1 * COIN;
 //! Discourage users to set fees higher than this amount (in satoshis) per kB
@@ -149,8 +147,7 @@ extern unsigned int nBytesPerSigOp;
 extern bool fCheckBlockIndex;
 extern bool fCheckpointsEnabled;
 extern size_t nCoinCacheUsage;
-/** A fee rate smaller than this is considered zero fee (for relaying, mining and transaction creation) */
-extern CFeeRate minRelayTxFee;
+
 /** Absolute maximum transaction fee (in satoshis) used by wallet and mempool (rejects high fee in sendrawtransaction) */
 extern CAmount maxTxFee;
 extern bool fAlerts;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -15,6 +15,7 @@
 #include "hash.h"
 #include "main.h"
 #include "net.h"
+#include "policy/mempool.h"
 #include "policy/policy.h"
 #include "pow.h"
 #include "primitives/transaction.h"
@@ -205,7 +206,7 @@ CBlockTemplate* CreateNewBlock(const CChainParams& chainparams, const CScript& s
                 waitPriMap.clear();
             }
             if (!priorityTx &&
-                (iter->GetModifiedFee() < ::minRelayTxFee.GetFee(nTxSize) && nBlockSize >= nBlockMinSize)) {
+                (iter->GetModifiedFee() < mempoolPolicy.GetMinRelayFeeRate().GetFee(nTxSize) && nBlockSize >= nBlockMinSize)) {
                 break;
             }
             if (nBlockSize + nTxSize >= nBlockMaxSize) {

--- a/src/policy/mempool.cpp
+++ b/src/policy/mempool.cpp
@@ -1,0 +1,27 @@
+// Copyright (c) 2015-2016 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "policy/mempool.h"
+
+#include "tinyformat.h"
+#include "util.h"
+#include "utilstrencodings.h"
+
+MempoolPolicy mempoolPolicy;
+
+void MempoolPolicy::InitFromArgs()
+{
+}
+
+std::vector<std::pair<std::string, std::string> > MempoolPolicy::GetOptionsHelp(bool showDebug) const
+{
+    std::vector<std::pair<std::string, std::string> > optionsHelp;
+    return optionsHelp;
+}
+
+void MempoolPolicy::AppendHelpMessages(std::string& strUsage, bool showDebug)
+{
+    strUsage += HelpMessageGroup(_("Mempool Policy options:"));
+    AppendMessagesOpt(strUsage, GetOptionsHelp(showDebug));
+}

--- a/src/policy/mempool.cpp
+++ b/src/policy/mempool.cpp
@@ -6,17 +6,40 @@
 
 #include "tinyformat.h"
 #include "util.h"
+#include "utilmoneystr.h"
 #include "utilstrencodings.h"
 
 MempoolPolicy mempoolPolicy;
 
+MempoolPolicy::MempoolPolicy()
+{
+    minRelayFeeRate = CFeeRate(DEFAULT_MIN_RELAY_TX_FEE);
+}
+
 void MempoolPolicy::InitFromArgs()
 {
+    // Fee-per-kilobyte amount considered the same as "free"
+    // If you are mining, be careful setting this:
+    // if you set it to zero then
+    // a transaction spammer can cheaply fill blocks using
+    // 1-satoshi-fee transactions. It should be set above the real
+    // cost to you of processing a transaction.
+    if (mapArgs.count("-minrelaytxfee"))
+    {
+        CAmount n = 0;
+        if (ParseMoney(mapArgs["-minrelaytxfee"], n) && n > 0) {
+            minRelayFeeRate = CFeeRate(n);
+        }
+        else
+            throw std::runtime_error(AmountErrMsg("minrelaytxfee", mapArgs["-minrelaytxfee"]));
+    }
 }
 
 std::vector<std::pair<std::string, std::string> > MempoolPolicy::GetOptionsHelp(bool showDebug) const
 {
     std::vector<std::pair<std::string, std::string> > optionsHelp;
+    optionsHelp.push_back(std::make_pair("-minrelaytxfee=<amt>", strprintf(_("Fees (in %s/kB) smaller than this are considered zero fee for relaying, mining and transaction creation (default: %s)"),
+                                                                           CURRENCY_UNIT, FormatMoney(DEFAULT_MIN_RELAY_TX_FEE))));
     return optionsHelp;
 }
 
@@ -24,4 +47,14 @@ void MempoolPolicy::AppendHelpMessages(std::string& strUsage, bool showDebug)
 {
     strUsage += HelpMessageGroup(_("Mempool Policy options:"));
     AppendMessagesOpt(strUsage, GetOptionsHelp(showDebug));
+}
+
+CFeeRate MempoolPolicy::GetMinRelayFeeRate()
+{
+    return minRelayFeeRate;
+}
+
+void MempoolPolicy::SetMinRelayFeeRate(CFeeRate newFeeRate)
+{
+    minRelayFeeRate = newFeeRate;
 }

--- a/src/policy/mempool.h
+++ b/src/policy/mempool.h
@@ -8,6 +8,11 @@
 #include <string>
 #include <vector>
 
+#include "amount.h"
+
+//Mempool policy defaults
+static const unsigned int DEFAULT_MIN_RELAY_TX_FEE = 1000;
+
 /**
  * \class MempoolPolicy
  * Encapsulate parameters needed for mempool policy
@@ -15,6 +20,7 @@
 class MempoolPolicy
 {
 public:
+    MempoolPolicy();
     void InitFromArgs();
     /**
      * @return a formatted HelpMessage string with the mempool policy options
@@ -26,6 +32,13 @@ public:
      * options appended to the string
      */
     void AppendHelpMessages(std::string& strUsage, bool showDebug);
+
+    /** A fee rate smaller than this is considered zero fee (for relaying, mining and transaction creation) */
+    CFeeRate GetMinRelayFeeRate();
+    /** Setter for testing */
+    void SetMinRelayFeeRate(CFeeRate newFeeRate);
+private:
+    CFeeRate minRelayFeeRate;
 };
 
 extern MempoolPolicy mempoolPolicy;

--- a/src/policy/mempool.h
+++ b/src/policy/mempool.h
@@ -1,0 +1,33 @@
+// Copyright (c) 2015-2016 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_MEMPOOLPOLICY_H
+#define BITCOIN_MEMPOOLPOLICY_H
+
+#include <string>
+#include <vector>
+
+/**
+ * \class MempoolPolicy
+ * Encapsulate parameters needed for mempool policy
+ */
+class MempoolPolicy
+{
+public:
+    void InitFromArgs();
+    /**
+     * @return a formatted HelpMessage string with the mempool policy options
+     */
+    std::vector<std::pair<std::string, std::string> > GetOptionsHelp(bool showDebug) const;
+    /**
+     * Append a help string for the options of the selected policy.
+     * @param strUsage a formatted HelpMessage string with mempool policy
+     * options appended to the string
+     */
+    void AppendHelpMessages(std::string& strUsage, bool showDebug);
+};
+
+extern MempoolPolicy mempoolPolicy;
+
+#endif // BITCOIN_MEMPOOLPOLICY_H

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -8,6 +8,7 @@
 #include "policy/policy.h"
 
 #include "main.h"
+#include "policy/mempool.h"
 #include "tinyformat.h"
 #include "util.h"
 #include "utilstrencodings.h"
@@ -102,7 +103,7 @@ bool IsStandardTx(const CTransaction& tx, std::string& reason)
         else if ((whichType == TX_MULTISIG) && (!fIsBareMultisigStd)) {
             reason = "bare-multisig";
             return false;
-        } else if (txout.IsDust(::minRelayTxFee)) {
+        } else if (txout.IsDust(mempoolPolicy.GetMinRelayFeeRate())) {
             reason = "dust";
             return false;
         }

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -15,7 +15,8 @@
 
 #include "coincontrol.h"
 #include "init.h"
-#include "main.h" // For minRelayTxFee
+#include "main.h" //for mempool
+#include "policy/mempool.h"
 #include "wallet/wallet.h"
 
 #include <boost/assign/list_of.hpp> // for 'map_list_of()'
@@ -468,7 +469,7 @@ void CoinControlDialog::updateLabels(WalletModel *model, QDialog* dialog)
         {
             CTxOut txout(amount, (CScript)std::vector<unsigned char>(24, 0));
             txDummy.vout.push_back(txout);
-            if (txout.IsDust(::minRelayTxFee))
+            if (txout.IsDust(mempoolPolicy.GetMinRelayFeeRate()))
                fDust = true;
         }
     }
@@ -569,10 +570,10 @@ void CoinControlDialog::updateLabels(WalletModel *model, QDialog* dialog)
             if (nChange > 0 && nChange < MIN_CHANGE)
             {
                 CTxOut txout(nChange, (CScript)std::vector<unsigned char>(24, 0));
-                if (txout.IsDust(::minRelayTxFee))
+                if (txout.IsDust(mempoolPolicy.GetMinRelayFeeRate()))
                 {
                     if (CoinControlDialog::fSubtractFeeFromAmount) // dust-change will be raised until no dust
-                        nChange = txout.GetDustThreshold(::minRelayTxFee);
+                        nChange = txout.GetDustThreshold(mempoolPolicy.GetMinRelayFeeRate());
                     else
                     {
                         nPayFee += nChange;

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -11,7 +11,7 @@
 
 #include "primitives/transaction.h"
 #include "init.h"
-#include "main.h" // For minRelayTxFee
+#include "policy/mempool.h"
 #include "protocol.h"
 #include "script/script.h"
 #include "script/standard.h"
@@ -238,7 +238,7 @@ bool isDust(const QString& address, const CAmount& amount)
     CTxDestination dest = CBitcoinAddress(address.toStdString()).Get();
     CScript script = GetScriptForDestination(dest);
     CTxOut txOut(amount, script);
-    return txOut.IsDust(::minRelayTxFee);
+    return txOut.IsDust(mempoolPolicy.GetMinRelayFeeRate());
 }
 
 QString HtmlEscape(const QString& str, bool fMultiLine)

--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -10,7 +10,7 @@
 
 #include "base58.h"
 #include "chainparams.h"
-#include "main.h" // For minRelayTxFee
+#include "policy/mempool.h"
 #include "ui_interface.h"
 #include "util.h"
 #include "wallet/wallet.h"
@@ -582,7 +582,7 @@ bool PaymentServer::processPaymentRequest(const PaymentRequestPlus& request, Sen
 
         // Extract and check amounts
         CTxOut txOut(sendingTo.second, sendingTo.first);
-        if (txOut.IsDust(::minRelayTxFee)) {
+        if (txOut.IsDust(mempoolPolicy.GetMinRelayFeeRate())) {
             Q_EMIT message(tr("Payment request error"), tr("Requested payment amount of %1 is too small (considered dust).")
                 .arg(BitcoinUnits::formatWithUnit(optionsModel->getDisplayUnit(), sendingTo.second)),
                 CClientUIInterface::MSG_ERROR);

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -17,7 +17,7 @@
 
 #include "base58.h"
 #include "coincontrol.h"
-#include "main.h" // mempool and minRelayTxFee
+#include "main.h" // mempool
 #include "ui_interface.h"
 #include "txmempool.h"
 #include "wallet/wallet.h"

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -7,6 +7,7 @@
 #include "clientversion.h"
 #include "init.h"
 #include "main.h"
+#include "policy/mempool.h"
 #include "net.h"
 #include "netbase.h"
 #include "rpc/server.h"
@@ -102,7 +103,7 @@ UniValue getinfo(const UniValue& params, bool fHelp)
         obj.push_back(Pair("unlocked_until", nWalletUnlockTime));
     obj.push_back(Pair("paytxfee",      ValueFromAmount(payTxFee.GetFeePerK())));
 #endif
-    obj.push_back(Pair("relayfee",      ValueFromAmount(::minRelayTxFee.GetFeePerK())));
+    obj.push_back(Pair("relayfee",      ValueFromAmount(mempoolPolicy.GetMinRelayFeeRate().GetFeePerK())));
     obj.push_back(Pair("errors",        GetWarnings("statusbar")));
     return obj;
 }

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -7,6 +7,7 @@
 #include "chainparams.h"
 #include "clientversion.h"
 #include "main.h"
+#include "policy/mempool.h"
 #include "net.h"
 #include "netbase.h"
 #include "protocol.h"
@@ -494,7 +495,7 @@ UniValue getnetworkinfo(const UniValue& params, bool fHelp)
     obj.push_back(Pair("timeoffset",    GetTimeOffset()));
     obj.push_back(Pair("connections",   (int)vNodes.size()));
     obj.push_back(Pair("networks",      GetNetworksInfo()));
-    obj.push_back(Pair("relayfee",      ValueFromAmount(::minRelayTxFee.GetFeePerK())));
+    obj.push_back(Pair("relayfee",      ValueFromAmount(mempoolPolicy.GetMinRelayFeeRate().GetFeePerK())));
     UniValue localAddresses(UniValue::VARR);
     {
         LOCK(cs_mapLocalHost);

--- a/src/test/policyestimator_tests.cpp
+++ b/src/test/policyestimator_tests.cpp
@@ -197,7 +197,7 @@ BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
     // Test that if the mempool is limited, estimateSmartFee won't return a value below the mempool min fee
     // and that estimateSmartPriority returns essentially an infinite value
     mpool.addUnchecked(tx.GetHash(),  entry.Fee(feeV[0][5]).Time(GetTime()).Priority(priV[1][5]).Height(blocknum).FromTx(tx, &mpool));
-    // evict that transaction which should set a mempool min fee of minRelayTxFee + feeV[0][5]
+    // evict that transaction which should set a mempool min fee of minRelayFeeRate + feeV[0][5]
     mpool.TrimToSize(1);
     BOOST_CHECK(mpool.GetMinFee(1).GetFeePerK() > feeV[0][5]);
     for (int i = 1; i < 10; i++) {

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -12,6 +12,7 @@
 #include "key.h"
 #include "keystore.h"
 #include "main.h" // For CheckTransaction
+#include "policy/mempool.h"
 #include "policy/policy.h"
 #include "script/script.h"
 #include "script/script_error.h"
@@ -336,7 +337,7 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
     BOOST_CHECK(IsStandardTx(t, reason));
 
     // Check dust with default relay fee:
-    CAmount nDustThreshold = 182 * minRelayTxFee.GetFeePerK()/1000 * 3;
+    CAmount nDustThreshold = 182 * mempoolPolicy.GetMinRelayFeeRate().GetFeePerK()/1000 * 3;
     BOOST_CHECK_EQUAL(nDustThreshold, 546);
     // dust:
     t.vout[0].nValue = nDustThreshold - 1;
@@ -347,14 +348,14 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
 
     // Check dust with odd relay fee to verify rounding:
     // nDustThreshold = 182 * 1234 / 1000 * 3
-    minRelayTxFee = CFeeRate(1234);
+    mempoolPolicy.SetMinRelayFeeRate(CFeeRate(1234));
     // dust:
     t.vout[0].nValue = 672 - 1;
     BOOST_CHECK(!IsStandardTx(t, reason));
     // not dust:
     t.vout[0].nValue = 672;
     BOOST_CHECK(IsStandardTx(t, reason));
-    minRelayTxFee = CFeeRate(DEFAULT_MIN_RELAY_TX_FEE);
+    mempoolPolicy.SetMinRelayFeeRate(CFeeRate(DEFAULT_MIN_RELAY_TX_FEE));
 
     t.vout[0].scriptPubKey = CScript() << OP_1;
     BOOST_CHECK(!IsStandardTx(t, reason));

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -435,6 +435,11 @@ void AppendMessagesOpt(std::string& strUsage, const std::vector<std::pair<std::s
         strUsage += HelpMessageOpt(optionsHelp[i].first, optionsHelp[i].second);
 }
 
+std::string AmountErrMsg(const char * const optname, const std::string& strValue)
+{
+    return strprintf(_("Invalid amount for -%s=<amount>: '%s'"), optname, strValue);
+}
+
 static std::string FormatException(const std::exception* pex, const char* pszThread)
 {
 #ifdef WIN32

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -429,6 +429,12 @@ std::string HelpMessageOpt(const std::string &option, const std::string &message
            std::string("\n\n");
 }
 
+void AppendMessagesOpt(std::string& strUsage, const std::vector<std::pair<std::string, std::string> >& optionsHelp)
+{
+    for (unsigned int i=0; i < optionsHelp.size(); i++)
+        strUsage += HelpMessageOpt(optionsHelp[i].first, optionsHelp[i].second);
+}
+
 static std::string FormatException(const std::exception* pex, const char* pszThread)
 {
 #ifdef WIN32

--- a/src/util.h
+++ b/src/util.h
@@ -210,6 +210,12 @@ std::string HelpMessageGroup(const std::string& message);
 std::string HelpMessageOpt(const std::string& option, const std::string& message);
 
 /**
+ * @param strUsage a help message string where the additoinal option descriptions will be appended
+ * @param optionsHelp a vector of string pairs to iteratively call HelpMessageOpt on
+ */
+void AppendMessagesOpt(std::string& strUsage, const std::vector<std::pair<std::string, std::string> >& optionsHelp);
+
+/**
  * Return the number of physical cores available on the current system.
  * @note This does not count virtual cores, such as those provided by HyperThreading
  * when boost is newer than 1.56.

--- a/src/util.h
+++ b/src/util.h
@@ -215,6 +215,8 @@ std::string HelpMessageOpt(const std::string& option, const std::string& message
  */
 void AppendMessagesOpt(std::string& strUsage, const std::vector<std::pair<std::string, std::string> >& optionsHelp);
 
+std::string AmountErrMsg(const char * const optname, const std::string& strValue);
+
 /**
  * Return the number of physical cores available on the current system.
  * @note This does not count virtual cores, such as those provided by HyperThreading

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -15,6 +15,7 @@
 #include "keystore.h"
 #include "main.h"
 #include "net.h"
+#include "policy/mempool.h"
 #include "policy/policy.h"
 #include "primitives/block.h"
 #include "primitives/transaction.h"
@@ -2037,7 +2038,7 @@ bool CWallet::CreateTransaction(const vector<CRecipient>& vecSend, CWalletTx& wt
                         }
                     }
 
-                    if (txout.IsDust(::minRelayTxFee))
+                    if (txout.IsDust(mempoolPolicy.GetMinRelayFeeRate()))
                     {
                         if (recipient.fSubtractFeeFromAmount && nFeeRet > 0)
                         {
@@ -2111,16 +2112,16 @@ bool CWallet::CreateTransaction(const vector<CRecipient>& vecSend, CWalletTx& wt
                     // We do not move dust-change to fees, because the sender would end up paying more than requested.
                     // This would be against the purpose of the all-inclusive feature.
                     // So instead we raise the change and deduct from the recipient.
-                    if (nSubtractFeeFromAmount > 0 && newTxOut.IsDust(::minRelayTxFee))
+                    if (nSubtractFeeFromAmount > 0 && newTxOut.IsDust(mempoolPolicy.GetMinRelayFeeRate()))
                     {
-                        CAmount nDust = newTxOut.GetDustThreshold(::minRelayTxFee) - newTxOut.nValue;
+                        CAmount nDust = newTxOut.GetDustThreshold(mempoolPolicy.GetMinRelayFeeRate()) - newTxOut.nValue;
                         newTxOut.nValue += nDust; // raise change until no more dust
                         for (unsigned int i = 0; i < vecSend.size(); i++) // subtract from first recipient
                         {
                             if (vecSend[i].fSubtractFeeFromAmount)
                             {
                                 txNew.vout[i].nValue -= nDust;
-                                if (txNew.vout[i].IsDust(::minRelayTxFee))
+                                if (txNew.vout[i].IsDust(mempoolPolicy.GetMinRelayFeeRate()))
                                 {
                                     strFailReason = _("The transaction amount is too small to send after the fee has been deducted");
                                     return false;
@@ -2132,7 +2133,7 @@ bool CWallet::CreateTransaction(const vector<CRecipient>& vecSend, CWalletTx& wt
 
                     // Never create dust outputs; if we would, just
                     // add the dust to the fee.
-                    if (newTxOut.IsDust(::minRelayTxFee))
+                    if (newTxOut.IsDust(mempoolPolicy.GetMinRelayFeeRate()))
                     {
                         nFeeRet += nChange;
                         reservekey.ReturnKey();
@@ -2214,7 +2215,7 @@ bool CWallet::CreateTransaction(const vector<CRecipient>& vecSend, CWalletTx& wt
 
                 // If we made it here and we aren't even able to meet the relay fee on the next pass, give up
                 // because we must be at the maximum allowed fee.
-                if (nFeeNeeded < ::minRelayTxFee.GetFee(nBytes))
+                if (nFeeNeeded < mempoolPolicy.GetMinRelayFeeRate().GetFee(nBytes))
                 {
                     strFailReason = _("Transaction too large for fee policy");
                     return false;
@@ -2299,7 +2300,7 @@ bool CWallet::AddAccountingEntry(const CAccountingEntry& acentry, CWalletDB & pw
 
 CAmount CWallet::GetRequiredFee(unsigned int nTxBytes)
 {
-    return std::max(minTxFee.GetFee(nTxBytes), ::minRelayTxFee.GetFee(nTxBytes));
+    return std::max(minTxFee.GetFee(nTxBytes), mempoolPolicy.GetMinRelayFeeRate().GetFee(nTxBytes));
 }
 
 CAmount CWallet::GetMinimumFee(unsigned int nTxBytes, unsigned int nConfirmTarget, const CTxMemPool& pool)
@@ -2314,7 +2315,7 @@ CAmount CWallet::GetMinimumFee(unsigned int nTxBytes, unsigned int nConfirmTarge
         if (nFeeNeeded == 0)
             nFeeNeeded = fallbackFee.GetFee(nTxBytes);
     }
-    // prevent user from paying a fee below minRelayTxFee or minTxFee
+    // prevent user from paying a fee below minRelayFeeRate or minTxFee
     nFeeNeeded = std::max(nFeeNeeded, GetRequiredFee(nTxBytes));
     // But always obey the maximum
     if (nFeeNeeded > maxTxFee)


### PR DESCRIPTION
@jtimon this is another step I wanted to take in the direction of getting policy stuff more separated.

The first commit heavily borrows from your work to separate policy, but I was aiming for organizing more around fee/relay related stuff as opposed to transaction standardness.  It wasn't clear to me if those should all go together.

It touched a lot of files to get minRelayTxFee separated out, but now it should be easier to add other options.
