### PR TITLE
[OSX] fix brew openssl detection

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -284,6 +284,8 @@ case $host in
          if test x$openssl_prefix != x; then
            PKG_CONFIG_PATH="$openssl_prefix/lib/pkgconfig:$PKG_CONFIG_PATH"
            export PKG_CONFIG_PATH
+           CPPFLAGS="$CPPFLAGS -I$openssl_prefix/include"
+           LIBS="$LIBS -L$openssl_prefix/lib"
          fi
          if test x$bdb_prefix != x; then
            CPPFLAGS="$CPPFLAGS -I$bdb_prefix/include"


### PR DESCRIPTION
ping @theuni (not sure if I did this correct, it seems like extending `PKG_CONFIG_PATH` does not work for a later header check with `AC_CHECK_HEADER`).

OSX slowly depractates openssl. Since 10.11.3, not event Xcode installs the openssl headers. This PR will allow using homebrews openssl headers.
