### PR TITLE
IsSuperMajority() softfork for BIPs 68,112 and 113

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -109,6 +109,7 @@ testScripts = [
     'bip68-sequence.py',
     'bip68-sequence-p2p.py',
     'bip113-mtp-p2p.py',
+    'blockversion5-ism.py',
 ]
 testScriptsExt = [
     'bip65-cltv.py',

--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -108,6 +108,7 @@ testScripts = [
     'abandonconflict.py',
     'bip68-sequence.py',
     'bip68-sequence-p2p.py',
+    'bip112-csv-p2p.py',
     'bip113-mtp-p2p.py',
     'blockversion5-ism.py',
 ]

--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -106,6 +106,7 @@ testScripts = [
     'invalidblockrequest.py',
     'invalidtxrequest.py',
     'abandonconflict.py',
+    'bip113-mtp-p2p.py',
 ]
 testScriptsExt = [
     'bip65-cltv.py',

--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -106,12 +106,13 @@ testScripts = [
     'invalidblockrequest.py',
     'invalidtxrequest.py',
     'abandonconflict.py',
+    'bip68-sequence.py',
+    'bip68-sequence-p2p.py',
     'bip113-mtp-p2p.py',
 ]
 testScriptsExt = [
     'bip65-cltv.py',
     'bip65-cltv-p2p.py',
-    'bip68-sequence.py',
     'bipdersig-p2p.py',
     'bipdersig.py',
     'getblocktemplate_longpoll.py',

--- a/qa/rpc-tests/bip112-csv-p2p.py
+++ b/qa/rpc-tests/bip112-csv-p2p.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python2
+# Copyright (c) 2015 The Bitcoin Core developers
+# Distributed under the MIT/X11 software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#
+
+from test_framework.test_framework import ComparisonTestFramework
+from test_framework.util import *
+from test_framework.mininode import CTransaction, NetworkThread
+from test_framework.blocktools import create_coinbase, create_block
+from test_framework.comptool import TestInstance, TestManager
+from test_framework.script import CScript, OP_1NEGATE, OP_NOP3, OP_DROP
+from binascii import unhexlify
+import cStringIO
+import time
+
+def csv_invalidate(tx):
+    '''Modify the signature in vin 0 of the tx to fail CSV
+
+    Prepends -1 CSV DROP in the scriptSig itself.
+    '''
+    tx.vin[0].scriptSig = CScript([OP_1NEGATE, OP_NOP3, OP_DROP] +
+                                  list(CScript(tx.vin[0].scriptSig)))
+
+'''
+This test is meant to exercise BIP112 (CHECKSEQUENCEVERIFY)
+Connect to a single node.
+Mine 2 (version 4) blocks (save the coinbases for later).
+Generate 98 more version 4 blocks, verify the node accepts.
+Mine 749 version 5 blocks, verify the node accepts.
+Check that the new CSV rules are not enforced on the 750th version 5 block.
+Check that the new CSV rules are enforced on the 751st version 5 block.
+Mine 199 new version blocks.
+Mine 1 old-version block.
+Mine 1 new version block.
+Mine 1 old version block, see that the node rejects.
+'''
+
+class BIP112Test(ComparisonTestFramework):
+
+    def __init__(self):
+        self.num_nodes = 1
+
+    def setup_network(self):
+        # Must set the blockversion for this test
+        self.nodes = start_nodes(1, self.options.tmpdir,
+                                 extra_args=[['-debug', '-whitelist=127.0.0.1', '-blockversion=4']],
+                                 binary=[self.options.testbinary])
+
+    def run_test(self):
+        test = TestManager(self, self.options.tmpdir)
+        test.add_all_connections(self.nodes)
+        NetworkThread().start() # Start up network handling in another thread
+        test.run()
+
+    def create_transaction(self, node, coinbase, to_address, amount):
+        from_txid = node.getblock(coinbase)['tx'][0]
+        inputs = [{ "txid" : from_txid, "vout" : 0}]
+        outputs = { to_address : amount }
+        rawtx = node.createrawtransaction(inputs, outputs)
+        signresult = node.signrawtransaction(rawtx)
+        tx = CTransaction()
+        f = cStringIO.StringIO(unhexlify(signresult['hex']))
+        tx.deserialize(f)
+        return tx
+
+    def get_tests(self):
+
+        self.coinbase_blocks = self.nodes[0].generate(2)
+        height = 3  # height of the next block to build
+        self.tip = int ("0x" + self.nodes[0].getbestblockhash() + "L", 0)
+        self.nodeaddress = self.nodes[0].getnewaddress()
+        self.last_block_time = time.time()
+
+        ''' 98 more version 4 blocks '''
+        test_blocks = []
+        for i in xrange(98):
+            block = create_block(self.tip, create_coinbase(height), self.last_block_time + 1)
+            block.nVersion = 4
+            block.rehash()
+            block.solve()
+            test_blocks.append([block, True])
+            self.last_block_time += 1
+            self.tip = block.sha256
+            height += 1
+        yield TestInstance(test_blocks, sync_every_block=False)
+
+        ''' Mine 749 version 4 blocks '''
+        test_blocks = []
+        for i in xrange(749):
+            block = create_block(self.tip, create_coinbase(height), self.last_block_time + 1)
+            block.nVersion = 5
+            block.rehash()
+            block.solve()
+            test_blocks.append([block, True])
+            self.last_block_time += 1
+            self.tip = block.sha256
+            height += 1
+        yield TestInstance(test_blocks, sync_every_block=False)
+
+        '''
+        Check that the new CSV rules are not enforced in the 750th
+        version 4 block.
+        '''
+        spendtx = self.create_transaction(self.nodes[0],
+                self.coinbase_blocks[0], self.nodeaddress, 1.0)
+        csv_invalidate(spendtx)
+        spendtx.rehash()
+
+        block = create_block(self.tip, create_coinbase(height), self.last_block_time + 1)
+        block.nVersion = 5
+        block.vtx.append(spendtx)
+        block.hashMerkleRoot = block.calc_merkle_root()
+        block.rehash()
+        block.solve()
+
+        self.last_block_time += 1
+        self.tip = block.sha256
+        height += 1
+        yield TestInstance([[block, True]])
+
+        '''
+        Check that the new CSV rules are enforced in the 751st version 5
+        block.
+        '''
+        spendtx = self.create_transaction(self.nodes[0],
+                self.coinbase_blocks[1], self.nodeaddress, 1.0)
+        csv_invalidate(spendtx)
+        spendtx.rehash()
+
+        block = create_block(self.tip, create_coinbase(height), self.last_block_time + 1)
+        block.nVersion = 5
+        block.vtx.append(spendtx)
+        block.hashMerkleRoot = block.calc_merkle_root()
+        block.rehash()
+        block.solve()
+        self.last_block_time += 1
+        yield TestInstance([[block, False]])
+
+        ''' Mine 199 new version blocks on last valid tip '''
+        test_blocks = []
+        for i in xrange(199):
+            block = create_block(self.tip, create_coinbase(height), self.last_block_time + 1)
+            block.nVersion = 5
+            block.rehash()
+            block.solve()
+            test_blocks.append([block, True])
+            self.last_block_time += 1
+            self.tip = block.sha256
+            height += 1
+        yield TestInstance(test_blocks, sync_every_block=False)
+
+        ''' Mine 1 old version block '''
+        block = create_block(self.tip, create_coinbase(height), self.last_block_time + 1)
+        block.nVersion = 4
+        block.rehash()
+        block.solve()
+        self.last_block_time += 1
+        self.tip = block.sha256
+        height += 1
+        yield TestInstance([[block, True]])
+
+        ''' Mine 1 new version block '''
+        block = create_block(self.tip, create_coinbase(height), self.last_block_time + 1)
+        block.nVersion = 5
+        block.rehash()
+        block.solve()
+        self.last_block_time += 1
+        self.tip = block.sha256
+        height += 1
+        yield TestInstance([[block, True]])
+
+        ''' Mine 1 old version block, should be invalid '''
+        block = create_block(self.tip, create_coinbase(height), self.last_block_time + 1)
+        block.nVersion = 4
+        block.rehash()
+        block.solve()
+        self.last_block_time += 1
+        yield TestInstance([[block, False]])
+
+if __name__ == '__main__':
+    BIP112Test().main()

--- a/qa/rpc-tests/bip113-mtp-p2p.py
+++ b/qa/rpc-tests/bip113-mtp-p2p.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python2
+# Copyright (c) 2015 The Bitcoin Core developers
+# Distributed under the MIT/X11 software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#
+
+from test_framework.test_framework import ComparisonTestFramework
+from test_framework.util import *
+from test_framework.mininode import CTransaction, NetworkThread
+from test_framework.blocktools import create_coinbase, create_block
+from test_framework.comptool import TestInstance, TestManager
+from test_framework.script import CScript, OP_1NEGATE, OP_NOP3, OP_DROP
+from binascii import hexlify, unhexlify
+import cStringIO
+import time
+
+def mtp_invalidate(tx, blockTime):
+    '''Modify the nLockTime to make it fails once MTP rule is activated
+    '''
+    # Disable Sequence lock, Activate nLockTime
+    tx.vin[0].nSequence = 0x90FFFFFF
+    tx.nLockTime = blockTime - 1
+
+'''
+This test is meant to exercise BIP113 (Median Time Past for nLockTime)
+Connect to a single node.
+Mine 2 (version 4) blocks (save the coinbases for later).
+Generate 98 more version 4 blocks, verify the node accepts.
+Mine 749 version 5 blocks, verify the node accepts.
+Check that the new MTP rules are not enforced on the 750th version 5 block.
+Check that the new MTP rules are enforced on the 751st version 5 block.
+Mine 199 new version blocks.
+Mine 1 old-version block.
+Mine 1 new version block.
+Mine 1 old version block, see that the node rejects.
+'''
+
+class BIP113Test(ComparisonTestFramework):
+
+    def __init__(self):
+        self.num_nodes = 1
+
+    def setup_network(self):
+        # Must set the blockversion for this test
+        self.nodes = start_nodes(1, self.options.tmpdir,
+                                 extra_args=[['-debug', '-whitelist=127.0.0.1', '-blockversion=4']],
+                                 binary=[self.options.testbinary])
+
+    def run_test(self):
+        test = TestManager(self, self.options.tmpdir)
+        test.add_all_connections(self.nodes)
+        NetworkThread().start() # Start up network handling in another thread
+        test.run()
+
+    def create_transaction(self, node, coinbase, to_address, amount):
+        from_txid = node.getblock(coinbase)['tx'][0]
+        inputs = [{ "txid" : from_txid, "vout" : 0}]
+        outputs = { to_address : amount }
+        rawtx = node.createrawtransaction(inputs, outputs)
+        tx = CTransaction()
+        f = cStringIO.StringIO(unhexlify(rawtx))
+        tx.deserialize(f)
+        return tx
+
+    def sign_transaction(self, node, tx):
+        signresult = node.signrawtransaction(hexlify(tx.serialize()))
+        tx = CTransaction()
+        f = cStringIO.StringIO(unhexlify(signresult['hex']))
+        tx.deserialize(f)
+        return tx
+
+    def get_tests(self):
+
+        self.coinbase_blocks = self.nodes[0].generate(2)
+        height = 3  # height of the next block to build
+        self.tip = int ("0x" + self.nodes[0].getbestblockhash() + "L", 0)
+        self.nodeaddress = self.nodes[0].getnewaddress()
+        self.last_block_time = time.time()
+
+        ''' 98 more version 4 blocks '''
+        test_blocks = []
+        for i in xrange(98):
+            block = create_block(self.tip, create_coinbase(height), self.last_block_time + 1)
+            block.nVersion = 4
+            block.rehash()
+            block.solve()
+            test_blocks.append([block, True])
+            self.last_block_time += 1
+            self.tip = block.sha256
+            height += 1
+        yield TestInstance(test_blocks, sync_every_block=False)
+
+        ''' Mine 749 version 4 blocks '''
+        test_blocks = []
+        for i in xrange(749):
+            block = create_block(self.tip, create_coinbase(height), self.last_block_time + 1)
+            block.nVersion = 5
+            block.rehash()
+            block.solve()
+            test_blocks.append([block, True])
+            self.last_block_time += 1
+            self.tip = block.sha256
+            height += 1
+        yield TestInstance(test_blocks, sync_every_block=False)
+
+        '''
+        Check that the new MTP rules are not enforced in the 750th
+        version 4 block.
+        '''
+        spendtx = self.create_transaction(self.nodes[0],
+                self.coinbase_blocks[0], self.nodeaddress, 1.0)
+        mtp_invalidate(spendtx, self.last_block_time + 1)
+        spendtx = self.sign_transaction(self.nodes[0], spendtx)
+        spendtx.rehash()
+
+        block = create_block(self.tip, create_coinbase(height), self.last_block_time + 1)
+        block.nVersion = 5
+        block.vtx.append(spendtx)
+        block.hashMerkleRoot = block.calc_merkle_root()
+        block.rehash()
+        block.solve()
+
+        self.last_block_time += 1
+        self.tip = block.sha256
+        height += 1
+        yield TestInstance([[block, True]])
+
+        '''
+        Check that the new MTP rules are enforced in the 751st version 5
+        block.
+        '''
+        spendtx = self.create_transaction(self.nodes[0],
+                self.coinbase_blocks[1], self.nodeaddress, 1.0)
+        mtp_invalidate(spendtx, self.last_block_time + 1)
+        spendtx = self.sign_transaction(self.nodes[0], spendtx)
+        spendtx.rehash()
+
+        block = create_block(self.tip, create_coinbase(height), self.last_block_time + 1)
+        block.nVersion = 5
+        block.vtx.append(spendtx)
+        block.hashMerkleRoot = block.calc_merkle_root()
+        block.rehash()
+        block.solve()
+        self.last_block_time += 1
+        yield TestInstance([[block, False]])
+
+        ''' Mine 199 new version blocks on last valid tip '''
+        test_blocks = []
+        for i in xrange(199):
+            block = create_block(self.tip, create_coinbase(height), self.last_block_time + 1)
+            block.nVersion = 5
+            block.rehash()
+            block.solve()
+            test_blocks.append([block, True])
+            self.last_block_time += 1
+            self.tip = block.sha256
+            height += 1
+        yield TestInstance(test_blocks, sync_every_block=False)
+
+        ''' Mine 1 old version block '''
+        block = create_block(self.tip, create_coinbase(height), self.last_block_time + 1)
+        block.nVersion = 4
+        block.rehash()
+        block.solve()
+        self.last_block_time += 1
+        self.tip = block.sha256
+        height += 1
+        yield TestInstance([[block, True]])
+
+        ''' Mine 1 new version block '''
+        block = create_block(self.tip, create_coinbase(height), self.last_block_time + 1)
+        block.nVersion = 5
+        block.rehash()
+        block.solve()
+        self.last_block_time += 1
+        self.tip = block.sha256
+        height += 1
+        yield TestInstance([[block, True]])
+
+        ''' Mine 1 old version block, should be invalid '''
+        block = create_block(self.tip, create_coinbase(height), self.last_block_time + 1)
+        block.nVersion = 4
+        block.rehash()
+        block.solve()
+        self.last_block_time += 1
+        yield TestInstance([[block, False]])
+
+if __name__ == '__main__':
+    BIP113Test().main()

--- a/qa/rpc-tests/bip68-sequence-p2p.py
+++ b/qa/rpc-tests/bip68-sequence-p2p.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python2
+# Copyright (c) 2015 The Bitcoin Core developers
+# Distributed under the MIT/X11 software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#
+
+from test_framework.test_framework import ComparisonTestFramework
+from test_framework.util import *
+from test_framework.mininode import CTransaction, NetworkThread
+from test_framework.blocktools import create_coinbase, create_block
+from test_framework.comptool import TestInstance, TestManager
+from test_framework.script import CScript, OP_1NEGATE, OP_NOP3, OP_DROP
+from binascii import hexlify, unhexlify
+import cStringIO
+import time
+
+def sequence_lock_invalidate(tx):
+    '''Modify the nSequence to make it fails once sequence lock rule is activated (high timespan)
+    '''
+    tx.vin[0].nSequence = 0x00FFFFFF
+    tx.nLockTime = 0
+
+'''
+This test is meant to exercise BIP68 (Sequence lock)
+Connect to a single node.
+Mine 2 (version 4) blocks (save the coinbases for later).
+Generate 98 more version 4 blocks, verify the node accepts.
+Mine 749 version 5 blocks, verify the node accepts.
+Check that the new sequence lock rules are not enforced on the 750th version 5 block.
+Check that the new sequence lock rules are enforced on the 751st version 5 block.
+Mine 199 new version blocks.
+Mine 1 old-version block.
+Mine 1 new version block.
+Mine 1 old version block, see that the node rejects.
+'''
+
+class BIP68Test(ComparisonTestFramework):
+
+    def __init__(self):
+        self.num_nodes = 1
+
+    def setup_network(self):
+        # Must set the blockversion for this test
+        self.nodes = start_nodes(1, self.options.tmpdir,
+                                 extra_args=[['-debug', '-whitelist=127.0.0.1', '-blockversion=4']],
+                                 binary=[self.options.testbinary])
+
+    def run_test(self):
+        test = TestManager(self, self.options.tmpdir)
+        test.add_all_connections(self.nodes)
+        NetworkThread().start() # Start up network handling in another thread
+        test.run()
+
+    def create_transaction(self, node, coinbase, to_address, amount):
+        from_txid = node.getblock(coinbase)['tx'][0]
+        inputs = [{ "txid" : from_txid, "vout" : 0}]
+        outputs = { to_address : amount }
+        rawtx = node.createrawtransaction(inputs, outputs)
+        tx = CTransaction()
+        f = cStringIO.StringIO(unhexlify(rawtx))
+        tx.deserialize(f)
+        tx.nVersion = 2
+        return tx
+
+    def sign_transaction(self, node, tx):
+        signresult = node.signrawtransaction(hexlify(tx.serialize()))
+        tx = CTransaction()
+        f = cStringIO.StringIO(unhexlify(signresult['hex']))
+        tx.deserialize(f)
+        return tx
+
+    def get_tests(self):
+
+        self.coinbase_blocks = self.nodes[0].generate(2)
+        height = 3  # height of the next block to build
+        self.tip = int ("0x" + self.nodes[0].getbestblockhash() + "L", 0)
+        self.nodeaddress = self.nodes[0].getnewaddress()
+        self.last_block_time = time.time()
+
+        ''' 98 more version 4 blocks '''
+        test_blocks = []
+        for i in xrange(98):
+            block = create_block(self.tip, create_coinbase(height), self.last_block_time + 1)
+            block.nVersion = 4
+            block.rehash()
+            block.solve()
+            test_blocks.append([block, True])
+            self.last_block_time += 1
+            self.tip = block.sha256
+            height += 1
+        yield TestInstance(test_blocks, sync_every_block=False)
+
+        ''' Mine 749 version 4 blocks '''
+        test_blocks = []
+        for i in xrange(749):
+            block = create_block(self.tip, create_coinbase(height), self.last_block_time + 1)
+            block.nVersion = 5
+            block.rehash()
+            block.solve()
+            test_blocks.append([block, True])
+            self.last_block_time += 1
+            self.tip = block.sha256
+            height += 1
+        yield TestInstance(test_blocks, sync_every_block=False)
+
+        '''
+        Check that the new sequence lock rules are not enforced in the 750th
+        version 4 block.
+        '''
+        spendtx = self.create_transaction(self.nodes[0],
+                self.coinbase_blocks[0], self.nodeaddress, 1.0)
+        sequence_lock_invalidate(spendtx)
+        spendtx = self.sign_transaction(self.nodes[0], spendtx)
+        spendtx.rehash()
+
+        block = create_block(self.tip, create_coinbase(height), self.last_block_time + 1)
+        block.nVersion = 5
+        block.vtx.append(spendtx)
+        block.hashMerkleRoot = block.calc_merkle_root()
+        block.rehash()
+        block.solve()
+
+        self.last_block_time += 1
+        self.tip = block.sha256
+        height += 1
+        yield TestInstance([[block, True]])
+
+        '''
+        Check that the new sequence lock rules are enforced in the 751st version 5
+        block.
+        '''
+        spendtx = self.create_transaction(self.nodes[0],
+                self.coinbase_blocks[1], self.nodeaddress, 1.0)
+        sequence_lock_invalidate(spendtx)
+        spendtx = self.sign_transaction(self.nodes[0], spendtx)
+        spendtx.rehash()
+
+        block = create_block(self.tip, create_coinbase(height), self.last_block_time + 1)
+        block.nVersion = 5
+        block.vtx.append(spendtx)
+        block.hashMerkleRoot = block.calc_merkle_root()
+        block.rehash()
+        block.solve()
+        self.last_block_time += 1
+        yield TestInstance([[block, False]])
+
+        ''' Mine 199 new version blocks on last valid tip '''
+        test_blocks = []
+        for i in xrange(199):
+            block = create_block(self.tip, create_coinbase(height), self.last_block_time + 1)
+            block.nVersion = 5
+            block.rehash()
+            block.solve()
+            test_blocks.append([block, True])
+            self.last_block_time += 1
+            self.tip = block.sha256
+            height += 1
+        yield TestInstance(test_blocks, sync_every_block=False)
+
+        ''' Mine 1 old version block '''
+        block = create_block(self.tip, create_coinbase(height), self.last_block_time + 1)
+        block.nVersion = 4
+        block.rehash()
+        block.solve()
+        self.last_block_time += 1
+        self.tip = block.sha256
+        height += 1
+        yield TestInstance([[block, True]])
+
+        ''' Mine 1 new version block '''
+        block = create_block(self.tip, create_coinbase(height), self.last_block_time + 1)
+        block.nVersion = 5
+        block.rehash()
+        block.solve()
+        self.last_block_time += 1
+        self.tip = block.sha256
+        height += 1
+        yield TestInstance([[block, True]])
+
+        ''' Mine 1 old version block, should be invalid '''
+        block = create_block(self.tip, create_coinbase(height), self.last_block_time + 1)
+        block.nVersion = 4
+        block.rehash()
+        block.solve()
+        self.last_block_time += 1
+        yield TestInstance([[block, False]])
+
+if __name__ == '__main__':
+    BIP68Test().main()

--- a/qa/rpc-tests/blockversion5-ism.py
+++ b/qa/rpc-tests/blockversion5-ism.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python2
+# Copyright (c) 2015 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#
+# Test the IsSuperMajority >=5 soft-fork logic
+#
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+
+class ISM5Test(BitcoinTestFramework):
+
+    def setup_network(self):
+        self.nodes = []
+        self.nodes.append(start_node(0, self.options.tmpdir, []))
+        self.nodes.append(start_node(1, self.options.tmpdir, ["-blockversion=4"]))
+        self.nodes.append(start_node(2, self.options.tmpdir, ["-blockversion=5"]))
+        connect_nodes(self.nodes[1], 0)
+        connect_nodes(self.nodes[2], 0)
+        self.is_network_split = False
+        self.sync_all()
+
+    def run_test(self):
+        cnt = self.nodes[0].getblockcount()
+
+        # Mine some old-version blocks
+        self.nodes[1].generate(100)
+        self.sync_all()
+        if (self.nodes[0].getblockcount() != cnt + 100):
+            raise AssertionError("Failed to mine 100 version=4 blocks")
+
+        # Mine 750 new-version blocks
+        for i in xrange(15):
+            self.nodes[2].generate(50)
+        self.sync_all()
+        if (self.nodes[0].getblockcount() != cnt + 850):
+            raise AssertionError("Failed to mine 750 version=5 blocks")
+
+        # TODO: check that new rules are not enforced
+
+        # Mine 1 new-version block
+        self.nodes[2].generate(1)
+        self.sync_all()
+        if (self.nodes[0].getblockcount() != cnt + 851):
+            raise AssertionError("Failed to mine a version=5 blocks")
+
+        # TODO: check that new rules are enforced
+
+        # Mine 198 new-version blocks
+        for i in xrange(2):
+            self.nodes[2].generate(99)
+        self.sync_all()
+        if (self.nodes[0].getblockcount() != cnt + 1049):
+            raise AssertionError("Failed to mine 198 version=5 blocks")
+
+        # Mine 1 old-version block
+        self.nodes[1].generate(1)
+        self.sync_all()
+        if (self.nodes[0].getblockcount() != cnt + 1050):
+            raise AssertionError("Failed to mine a version=4 block after 949 version=4 blocks")
+
+        # Mine 1 new-version blocks
+        self.nodes[2].generate(1)
+        self.sync_all()
+        if (self.nodes[0].getblockcount() != cnt + 1051):
+            raise AssertionError("Failed to mine a version=5 block")
+
+        # Mine 1 old-version blocks
+        try:
+            self.nodes[1].generate(1)
+            raise AssertionError("Succeeded to mine a version=4 block after 950 version=5 blocks")
+        except JSONRPCException:
+            pass
+        self.sync_all()
+        if (self.nodes[0].getblockcount() != cnt + 1051):
+            raise AssertionError("Accepted a version=4 block after 950 version=5 blocks")
+
+        # Mine 1 new-version blocks
+        self.nodes[2].generate(1)
+        self.sync_all()
+        if (self.nodes[0].getblockcount() != cnt + 1052):
+            raise AssertionError("Failed to mine a version=5 block")
+
+if __name__ == '__main__':
+    ISM5Test().main()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2176,10 +2176,12 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
         flags |= SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY;
     }
 
-    // Start enforcing CHECKSEQUENCEVERIFY (BIP112) for block.nVersion=5
+    // Start enforcing BIP68 (sequence locks) and CHECKSEQUENCEVERIFY (BIP112) for block.nVersion=5
     // blocks, when 75% of the network has upgraded:
+    int nLockTimeFlags = 0;
     if (block.nVersion >= 5 && IsSuperMajority(5, pindex->pprev, chainparams.GetConsensus().nMajorityEnforceBlockUpgrade, chainparams.GetConsensus())) {
         flags |= SCRIPT_VERIFY_CHECKSEQUENCEVERIFY;
+        nLockTimeFlags |= LOCKTIME_VERIFY_SEQUENCE;
      }
 
     int64_t nTime2 = GetTimeMicros(); nTimeForks += nTime2 - nTime1;
@@ -2190,7 +2192,6 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     CCheckQueueControl<CScriptCheck> control(fScriptChecks && nScriptCheckThreads ? &scriptcheckqueue : NULL);
 
     std::vector<int> prevheights;
-    int nLockTimeFlags = 0;
     CAmount nFees = 0;
     int nInputs = 0;
     unsigned int nSigOps = 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2176,6 +2176,12 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
         flags |= SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY;
     }
 
+    // Start enforcing CHECKSEQUENCEVERIFY (BIP112) for block.nVersion=5
+    // blocks, when 75% of the network has upgraded:
+    if (block.nVersion >= 5 && IsSuperMajority(5, pindex->pprev, chainparams.GetConsensus().nMajorityEnforceBlockUpgrade, chainparams.GetConsensus())) {
+        flags |= SCRIPT_VERIFY_CHECKSEQUENCEVERIFY;
+     }
+
     int64_t nTime2 = GetTimeMicros(); nTimeForks += nTime2 - nTime1;
     LogPrint("bench", "    - Fork checks: %.2fms [%.2fs]\n", 0.001 * (nTime2 - nTime1), nTimeForks * 0.000001);
 
@@ -3154,7 +3160,7 @@ bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationState& sta
         return state.Invalid(false, REJECT_INVALID, "time-too-old", "block's timestamp is too early");
 
     // Reject outdated version blocks when 95% (75% on testnet) of the network has upgraded:
-    for (int32_t version = 2; version < 5; ++version) // check for version 2, 3 and 4 upgrades
+    for (int32_t version = 2; version < 6; ++version) // check for version 2, 3, 4 and 5 upgrades
         if (block.nVersion < version && IsSuperMajority(version, pindexPrev, consensusParams.nMajorityRejectBlockOutdated, consensusParams))
             return state.Invalid(false, REJECT_OBSOLETE, strprintf("bad-version(v%d)", version - 1),
                                  strprintf("rejected nVersion=%d block", version - 1));

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -55,7 +55,7 @@ bool IsStandard(const CScript& scriptPubKey, txnouttype& whichType)
 
 bool IsStandardTx(const CTransaction& tx, std::string& reason)
 {
-    if (tx.nVersion > CTransaction::CURRENT_VERSION || tx.nVersion < 1) {
+    if (tx.nVersion > CTransaction::MAX_STANDARD_VERSION || tx.nVersion < 1) {
         reason = "version";
         return false;
     }

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -21,7 +21,7 @@ class CBlockHeader
 {
 public:
     // header
-    static const int32_t CURRENT_VERSION=4;
+    static const int32_t CURRENT_VERSION=5;
     int32_t nVersion;
     uint256 hashPrevBlock;
     uint256 hashMerkleRoot;

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -206,7 +206,14 @@ private:
     void UpdateHash() const;
 
 public:
+    // Default transaction version.
     static const int32_t CURRENT_VERSION=1;
+
+    // Changing the default transaction version requires a two step process: first
+    // adapting relay policy by bumping MAX_STANDARD_VERSION, and then later date
+    // bumping the default CURRENT_VERSION at which point both CURRENT_VERSION and
+    // MAX_STANDARD_VERSION will be equal.
+    static const int32_t MAX_STANDARD_VERSION=2;
 
     // The local variables are made const to prevent unintended modification
     // without updating the cached hash value. However, CTransaction is not

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -660,7 +660,7 @@ UniValue getblockchaininfo(const UniValue& params, bool fHelp)
     softforks.push_back(SoftForkDesc("bip34", 2, tip, consensusParams));
     softforks.push_back(SoftForkDesc("bip66", 3, tip, consensusParams));
     softforks.push_back(SoftForkDesc("bip65", 4, tip, consensusParams));
-    softforks.push_back(SoftForkDesc("bip112,113", 5, tip, consensusParams));
+    softforks.push_back(SoftForkDesc("bip68,112,113", 5, tip, consensusParams));
     obj.push_back(Pair("softforks",             softforks));
 
     if (fPruneMode)

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -660,6 +660,7 @@ UniValue getblockchaininfo(const UniValue& params, bool fHelp)
     softforks.push_back(SoftForkDesc("bip34", 2, tip, consensusParams));
     softforks.push_back(SoftForkDesc("bip66", 3, tip, consensusParams));
     softforks.push_back(SoftForkDesc("bip65", 4, tip, consensusParams));
+    softforks.push_back(SoftForkDesc("bip112", 5, tip, consensusParams));
     obj.push_back(Pair("softforks",             softforks));
 
     if (fPruneMode)

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -660,7 +660,7 @@ UniValue getblockchaininfo(const UniValue& params, bool fHelp)
     softforks.push_back(SoftForkDesc("bip34", 2, tip, consensusParams));
     softforks.push_back(SoftForkDesc("bip66", 3, tip, consensusParams));
     softforks.push_back(SoftForkDesc("bip65", 4, tip, consensusParams));
-    softforks.push_back(SoftForkDesc("bip112", 5, tip, consensusParams));
+    softforks.push_back(SoftForkDesc("bip112,113", 5, tip, consensusParams));
     obj.push_back(Pair("softforks",             softforks));
 
     if (fPruneMode)

--- a/src/script/bitcoinconsensus.h
+++ b/src/script/bitcoinconsensus.h
@@ -48,6 +48,7 @@ enum
     bitcoinconsensus_SCRIPT_FLAGS_VERIFY_P2SH                = (1U << 0), // evaluate P2SH (BIP16) subscripts
     bitcoinconsensus_SCRIPT_FLAGS_VERIFY_DERSIG              = (1U << 2), // enforce strict DER (BIP66) compliance
     bitcoinconsensus_SCRIPT_FLAGS_VERIFY_CHECKLOCKTIMEVERIFY = (1U << 9), // enable CHECKLOCKTIMEVERIFY (BIP65)
+    bitcoinconsensus_SCRIPT_FLAGS_VERIFY_CHECKSEQUENCEVERIFY = (1U << 10), // enable CHECKSEQUENCEVERIFY (BIP112)
 };
 
 /// Returns 1 if the input nIn of the serialized transaction pointed to by


### PR DESCRIPTION
## General

This PR softforks 3 lock-time related BIPs which are all implemented in `master` as mempool-only logic at the moment.
1. [BIP68](https://github.com/bitcoin/bips/blob/master/bip-0068.mediawiki) sequence locks for relative locktime;
2. [BIP112](https://github.com/bitcoin/bips/blob/master/bip-01128.mediawiki) CHECKSEQUENCEVERIFY;
3. [BIP113](https://github.com/bitcoin/bips/blob/master/bip-0113.mediawiki) Media Time Past.
### Dependencies

Why 3 BIPs at once?
- BIP68 (sequence locks) independently enforces the same semantics BIP113 (MTP)
- BIP112 (CSV) relies on BIP68
### Relay policy for BIP113

BIP113 mempool-only policy was deployed with Bitcoin Core 0.11.2 at the same time as the BIP65 CLTV softfork so the policy is in wide use (at  least 42% of nodes) as well as all the miners who upgraded to 0.11.2.
### Relay policy for v2 transactions

BIP68/112 rely on v2 transactions. Currently only v1 transactions are relayed, so it is necessary to change the relay policy to allow v2. This will be done at the same time as softfork deployment and will have the net effect that once the softfork enforces, we can be pretty sure miners will mine v2 transactions.

At a later date once enough nodes upgrade and we're sure v2 transaction will be relayed efficiently, we can bump the default transaction version in core see #7562.
### Why ISM()?

It seems unlikely that BIP9 will be both developed and well tested enough to meet the roadmap schedule of deployment even with reasonable slippage taken into account. ISM is well oiled and tested.
### Todos
- [x] Change relay policy to allow tx.version=2
- [x] fix bip68-sequence-p2p.py tests
- [x] fix bip112-csv-p2p.py tests
### Misc

This softfork _could_ also include SegWit BIP141.

Obviously, needs back-port to `0.12` at least.
