### PR TITLE
libconsensus-p2a: Decouple pow.o from chain.o and move it to the consensus package

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -124,7 +124,6 @@ BITCOIN_CORE_H = \
   policy/fees.h \
   policy/policy.h \
   policy/rbf.h \
-  pow.h \
   protocol.h \
   random.h \
   reverselock.h \
@@ -190,7 +189,6 @@ libbitcoin_server_a_SOURCES = \
   noui.cpp \
   policy/fees.cpp \
   policy/policy.cpp \
-  pow.cpp \
   rest.cpp \
   rpc/blockchain.cpp \
   rpc/mining.cpp \
@@ -265,6 +263,8 @@ libbitcoin_consensus_a_SOURCES = \
   consensus/validation.h \
   hash.cpp \
   hash.h \
+  pow.cpp \
+  pow.h \
   prevector.h \
   primitives/block.cpp \
   primitives/block.h \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -261,6 +261,7 @@ libbitcoin_consensus_a_SOURCES = \
   consensus/merkle.cpp \
   consensus/merkle.h \
   consensus/params.h \
+  consensus/storage_interfaces_cpp.h \
   consensus/validation.h \
   hash.cpp \
   hash.h \

--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -105,6 +105,11 @@ const CBlockIndex* CBlockIndex::GetAncestor(int height) const
     return const_cast<CBlockIndex*>(this)->GetAncestor(height);
 }
 
+const CBlockIndexView* CBlockIndex::GetAncestorView(int64_t height) const
+{
+    return this->GetAncestor(height);
+}
+
 void CBlockIndex::BuildSkip()
 {
     if (pprev)

--- a/src/chain.h
+++ b/src/chain.h
@@ -7,6 +7,7 @@
 #define BITCOIN_CHAIN_H
 
 #include "arith_uint256.h"
+#include "consensus/storage_interfaces_cpp.h"
 #include "primitives/block.h"
 #include "pow.h"
 #include "tinyformat.h"
@@ -99,7 +100,7 @@ enum BlockStatus {
  * candidates to be the next block. A blockindex may have multiple pprev pointing
  * to it, but at most one of them can be part of the currently active branch.
  */
-class CBlockIndex
+class CBlockIndex : public CBlockIndexView
 {
 public:
     //! pointer to the hash of the block, if any. Memory is owned by this CBlockIndex
@@ -217,7 +218,7 @@ public:
         return block;
     }
 
-    uint256 GetBlockHash() const
+    virtual const uint256 GetBlockHash() const
     {
         return *phashBlock;
     }
@@ -229,7 +230,7 @@ public:
 
     enum { nMedianTimeSpan=11 };
 
-    int64_t GetMedianTimePast() const
+    virtual int64_t GetMedianTimePast() const
     {
         int64_t pmedian[nMedianTimeSpan];
         int64_t* pbegin = &pmedian[nMedianTimeSpan];
@@ -280,6 +281,17 @@ public:
     //! Efficiently find an ancestor of this block.
     CBlockIndex* GetAncestor(int height);
     const CBlockIndex* GetAncestor(int height) const;
+    //! Implement CBlockIndexView's interface
+    virtual const CBlockIndexView* GetAncestorView(int64_t height) const;
+    virtual int32_t GetHeight() const { return nHeight; };
+    virtual int32_t GetVersion() const { return nVersion; };
+    virtual int32_t GetTime() const { return nTime; };
+    virtual int32_t GetBits() const { return nBits; };
+    //! More efficient version of GetPrev()
+    virtual const CBlockIndexView* GetPrev() const
+    {
+        return pprev;
+    };
 };
 
 arith_uint256 GetBlockProof(const CBlockIndex& block);
@@ -326,7 +338,7 @@ public:
         READWRITE(nNonce);
     }
 
-    uint256 GetBlockHash() const
+    virtual const uint256 GetBlockHash() const
     {
         CBlockHeader block;
         block.nVersion        = nVersion;

--- a/src/consensus/storage_interfaces_cpp.h
+++ b/src/consensus/storage_interfaces_cpp.h
@@ -1,0 +1,34 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2014 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_CONSENSUS_STORAGE_INTERFACES_CPP_H
+#define BITCOIN_CONSENSUS_STORAGE_INTERFACES_CPP_H
+
+#include "uint256.h"
+
+// CPP storage interfaces
+
+class CBlockIndexView
+{
+public:
+    CBlockIndexView() {};
+    virtual ~CBlockIndexView() {};
+
+    virtual const uint256 GetBlockHash() const = 0;
+    //! Efficiently find an ancestor of this block.
+    virtual const CBlockIndexView* GetAncestorView(int64_t height) const = 0;
+    virtual int32_t GetHeight() const = 0;
+    virtual int32_t GetVersion() const = 0;
+    virtual int32_t GetTime() const = 0;
+    virtual int32_t GetBits() const = 0;
+    // Potential optimizations
+    virtual const CBlockIndexView* GetPrev() const
+    {
+        return GetAncestorView(GetHeight() - 1);
+    };
+    virtual int64_t GetMedianTimePast() const = 0;
+};
+
+#endif // BITCOIN_CONSENSUS_STORAGE_INTERFACES_CPP_H

--- a/src/pow.h
+++ b/src/pow.h
@@ -11,11 +11,11 @@
 #include <stdint.h>
 
 class CBlockHeader;
-class CBlockIndex;
+class CBlockIndexView;
 class uint256;
 
-unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params&);
-unsigned int CalculateNextWorkRequired(const CBlockIndex* pindexLast, int64_t nFirstBlockTime, const Consensus::Params&);
+unsigned int GetNextWorkRequired(const CBlockIndexView* pindexLast, const CBlockHeader *pblock, const Consensus::Params&);
+unsigned int CalculateNextWorkRequired(const CBlockIndexView* pindexLast, int64_t nFirstBlockTime, const Consensus::Params&);
 
 /** Check whether a block hash satisfies the proof-of-work requirement specified by nBits */
 bool CheckProofOfWork(uint256 hash, unsigned int nBits, const Consensus::Params&);


### PR DESCRIPTION
If we agree that libbitcoinconsensus should not depend on chain.o, we need some other dependency as a requirement.
This same thing could be done with a "final" almost-C-ready API instead of a CPP abstract class (and that was my initial idea), but that would be more disruptive and harder to review.

Not introducing a non-storage interface for CBlockIndex is blocking the following things:
- Decouple pow.o from chain.o and move it to the consensus package
- This will allow us to decouple consensus/consensus.cpp from chain.o right away (once #7310 or similar is merged)
- This will allow new consensus code (for example, an implementation of bip9) to avoid depending on CBlockIndex. This will also allow to s/CBlockIndex/CBlockIndexView in small encapsulation commits while minimizing disruption.
