### PR TITLE
libconsensus-p2a: Preparations to decouple libconsensus from coins.o

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -261,6 +261,7 @@ libbitcoin_consensus_a_SOURCES = \
   consensus/merkle.cpp \
   consensus/merkle.h \
   consensus/params.h \
+  consensus/storage_interfaces_cpp.h \
   consensus/validation.h \
   hash.cpp \
   hash.h \

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -249,20 +249,6 @@ CAmount CCoinsViewCache::GetValueIn(const CTransaction& tx) const
     return nResult;
 }
 
-bool CCoinsViewCache::HaveInputs(const CTransaction& tx) const
-{
-    if (!tx.IsCoinBase()) {
-        for (unsigned int i = 0; i < tx.vin.size(); i++) {
-            const COutPoint &prevout = tx.vin[i].prevout;
-            const CCoins* coins = AccessCoins(prevout.hash);
-            if (!coins || !coins->IsAvailable(prevout.n)) {
-                return false;
-            }
-        }
-    }
-    return true;
-}
-
 double CCoinsViewCache::GetPriority(const CTransaction &tx, int nHeight, CAmount &inChainInputValue) const
 {
     inChainInputValue = 0;

--- a/src/coins.h
+++ b/src/coins.h
@@ -7,9 +7,11 @@
 #define BITCOIN_COINS_H
 
 #include "compressor.h"
+#include "consensus/storage_interfaces_cpp.h"
 #include "core_memusage.h"
 #include "memusage.h"
 #include "serialize.h"
+#include "tinyformat.h"
 #include "uint256.h"
 
 #include <assert.h>
@@ -70,7 +72,7 @@
  *              * 8c988f1a4a4de2161e0f50aac7f17e7f9555caa4: address uint160
  *  - height = 120891
  */
-class CCoins
+class CCoins : public CCoinsInterface
 {
 public:
     //! whether transaction is a coinbase
@@ -148,7 +150,7 @@ public:
 
     void CalcMaskSize(unsigned int &nBytes, unsigned int &nNonzeroBytes) const;
 
-    bool IsCoinBase() const {
+    virtual bool IsCoinBase() const {
         return fCoinBase;
     }
 
@@ -242,13 +244,13 @@ public:
     bool Spend(uint32_t nPos);
 
     //! check whether a particular output is still available
-    bool IsAvailable(unsigned int nPos) const {
-        return (nPos < vout.size() && !vout[nPos].IsNull());
+    virtual bool IsAvailable(int32_t nPos) const {
+        return ((unsigned int)nPos < vout.size() && !vout[nPos].IsNull());
     }
 
     //! check whether the entire CCoins is spent
     //! note that only !IsPruned() CCoins can be serialized
-    bool IsPruned() const {
+    virtual bool IsPruned() const {
         BOOST_FOREACH(const CTxOut &out, vout)
             if (!out.IsNull())
                 return false;
@@ -262,6 +264,21 @@ public:
         }
         return ret;
     }
+
+    // Fully implement CCoinsInterface
+    virtual const CAmount& GetAmount(int32_t nPos) const
+    {
+        return vout[nPos].nValue;
+    };
+    virtual const CScript& GetScriptPubKey(int32_t nPos) const
+    {
+        return vout[nPos].scriptPubKey;
+    };
+    virtual int64_t GetHeight() const
+    {
+        return nHeight;
+    };
+
 };
 
 class CCoinsKeyHasher
@@ -312,7 +329,7 @@ struct CCoinsStats
 
 
 /** Abstract view on the open txout dataset. */
-class CCoinsView
+class CCoinsView : public CUtxoView
 {
 public:
     //! Retrieve the CCoins (unspent transaction outputs) for a given txid
@@ -334,6 +351,14 @@ public:
 
     //! As we use CCoinsViews polymorphically, have a virtual destructor
     virtual ~CCoinsView() {}
+
+    // Fully implement CUtxoView
+
+    //! AccessCoins not implemented for CCoinsView
+    virtual const CCoinsInterface* AccessCoins(const uint256 &txid) const
+    {
+        throw std::runtime_error(strprintf("%s: Not implemented for CCoinsView.", __func__));
+    };
 };
 
 
@@ -417,7 +442,7 @@ public:
      * more efficient than GetCoins. Modifications to other cache entries are
      * allowed while accessing the returned pointer.
      */
-    const CCoins* AccessCoins(const uint256 &txid) const;
+    virtual const CCoins* AccessCoins(const uint256 &txid) const;
 
     /**
      * Return a modifiable reference to a CCoins. If no entry with the given
@@ -465,9 +490,6 @@ public:
      * @return	Sum of value of all inputs (scriptSigs)
      */
     CAmount GetValueIn(const CTransaction& tx) const;
-
-    //! Check whether all prevouts of the transaction are present in the UTXO set represented by this view
-    bool HaveInputs(const CTransaction& tx) const;
 
     /**
      * Return priority of tx at height nHeight. Also calculate the sum of the values of the inputs

--- a/src/consensus/storage_interfaces_cpp.h
+++ b/src/consensus/storage_interfaces_cpp.h
@@ -1,0 +1,34 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2014 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_CONSENSUS_STORAGE_INTERFACES_CPP_H
+#define BITCOIN_CONSENSUS_STORAGE_INTERFACES_CPP_H
+
+#include "uint256.h"
+
+// CPP storage interfaces
+
+class CBlockIndexView
+{
+public:
+    CBlockIndexView() {};
+    virtual ~CBlockIndexView() {};
+
+    virtual const uint256 GetBlockHash() const = 0;
+    //! Efficiently find an ancestor of this block.
+    virtual const CBlockIndexView* GetAncestorView(int64_t height) const = 0;
+    virtual int64_t GetHeight() const = 0;
+    virtual int32_t GetVersion() const = 0;
+    virtual int32_t GetTime() const = 0;
+    virtual int32_t GetBits() const = 0;
+    // Potential optimizations
+    virtual const CBlockIndexView* GetPrev() const
+    {
+        return GetAncestorView(GetHeight() - 1);
+    };
+    virtual int64_t GetMedianTimePast() const = 0;
+};
+
+#endif // BITCOIN_CONSENSUS_STORAGE_INTERFACES_CPP_H


### PR DESCRIPTION
Analogous to #7563 but with coins instead of chain.o
Replaces "Refactor: Create CCoinsViewEfficient interface for CCoinsViewCache #5747 [coins]".

Unnecessary dependencies:
- [ ] libconsensus-p2a: Decouple pow.o from chain.o and move it to the consensus package #7563 [libconsensus-p2a-chain-cpp-interface-0.12.99]

This doesn't need to depend on #7563, but the first commit in both PRs writes the same file.
