### PR TITLE
bip9/bip113/libconsensus-p2a: Deployment preparations forBIP113 + #7552 + Introduce Consensus::VerifyTx()

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -179,6 +179,7 @@ libbitcoin_server_a_SOURCES = \
   bloom.cpp \
   chain.cpp \
   checkpoints.cpp \
+  consensus/consensus.cpp \
   httprpc.cpp \
   httpserver.cpp \
   init.cpp \

--- a/src/consensus/consensus.cpp
+++ b/src/consensus/consensus.cpp
@@ -1,0 +1,37 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2016 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "consensus.h"
+
+#include "validation.h"
+#include "primitives/transaction.h"
+#include "script/interpreter.h"
+
+// TODO remove the following dependencies
+#include "main.h"
+
+bool Consensus::CheckTxPreInputs(const CTransaction& tx, CValidationState& state, const int nHeight, int64_t nLockTimeCutoff, int64_t& nSigOps)
+{
+    if (!IsFinalTx(tx, nHeight, nLockTimeCutoff))
+        return state.DoS(10, false, REJECT_INVALID, "bad-txns-nonfinal", false, "non-final transaction");
+
+    if (!CheckTransaction(tx, state))
+        return false;
+
+    nSigOps += GetLegacySigOpCount(tx);
+    if (nSigOps > MAX_BLOCK_SIGOPS)
+        return state.DoS(100, false, REJECT_INVALID, "bad-blk-sigops", "too many sigops");
+
+    return true;
+}
+
+bool Consensus::VerifyTx(const CTransaction& tx, CValidationState& state, const unsigned int flags, const int nHeight, const int64_t nMedianTime, const int64_t nBlockTime, int64_t& nSigOps)
+{
+    const int64_t nLockTimeCutoff = (flags & LOCKTIME_MEDIAN_TIME_PAST) ? nMedianTime : nBlockTime;
+    if (!CheckTxPreInputs(tx, state, nHeight, nLockTimeCutoff, nSigOps))
+        return false;
+
+    return true;
+}

--- a/src/consensus/consensus.cpp
+++ b/src/consensus/consensus.cpp
@@ -17,9 +17,6 @@ bool Consensus::CheckTxPreInputs(const CTransaction& tx, CValidationState& state
     if (!IsFinalTx(tx, nHeight, nLockTimeCutoff))
         return state.DoS(10, false, REJECT_INVALID, "bad-txns-nonfinal", false, "non-final transaction");
 
-    if (!CheckTransaction(tx, state))
-        return false;
-
     nSigOps += GetLegacySigOpCount(tx);
     if (nSigOps > MAX_BLOCK_SIGOPS)
         return state.DoS(100, false, REJECT_INVALID, "bad-blk-sigops", "too many sigops");

--- a/src/consensus/consensus.h
+++ b/src/consensus/consensus.h
@@ -6,6 +6,11 @@
 #ifndef BITCOIN_CONSENSUS_CONSENSUS_H
 #define BITCOIN_CONSENSUS_CONSENSUS_H
 
+#include <stdint.h>
+
+class CTransaction;
+class CValidationState;
+
 /** The maximum allowed size for a serialized block, in bytes (network rule) */
 static const unsigned int MAX_BLOCK_SIZE = 1000000;
 /** The maximum allowed number of signature check operations in a block (network rule) */
@@ -13,13 +18,27 @@ static const unsigned int MAX_BLOCK_SIGOPS = MAX_BLOCK_SIZE/50;
 /** Coinbase transaction outputs can only be spent after this number of new blocks (network rule) */
 static const int COINBASE_MATURITY = 100;
 
-/** Flags for nSequence and nLockTime locks */
-enum {
-    /* Interpret sequence numbers as relative lock-time constraints. */
-    LOCKTIME_VERIFY_SEQUENCE = (1 << 0),
+/**
+ * Consensus validations (for Script, Tx, Header and Block):
+ * Check_ means checking everything possible with the data provided.
+ * Verify_ means all data provided was enough for this level and its "consensus-verified".
+ */
+namespace Consensus {
 
-    /* Use GetMedianTimePast() instead of nTime for end point timestamp. */
-    LOCKTIME_MEDIAN_TIME_PAST = (1 << 1),
-};
+/** Transaction validation functions */
+
+/**
+ * Performs all tx the checks that are common for coinbase and regular transactions.
+ * It doesn't require knowledge of the inputs (utxo).
+ */
+bool CheckTxPreInputs(const CTransaction& tx, CValidationState& state, const int nHeight, int64_t nLockTimeCutoff, int64_t& nSigOps);
+
+/**
+ * Fully verify a CTransaction.
+ * @TODO this is incomplete, among other things, the scripts are not checked yet.
+ */
+bool VerifyTx(const CTransaction& tx, CValidationState& state, const unsigned int flags, const int nHeight, const int64_t nMedianTime, const int64_t nBlockTime, int64_t& nSigOps);
+
+} // namespace Consensus
 
 #endif // BITCOIN_CONSENSUS_CONSENSUS_H

--- a/src/consensus/consensus.h
+++ b/src/consensus/consensus.h
@@ -30,6 +30,7 @@ namespace Consensus {
 /**
  * Performs all tx the checks that are common for coinbase and regular transactions.
  * It doesn't require knowledge of the inputs (utxo).
+ * @TODO this is incomplete until CheckTransaction() is called from it.
  */
 bool CheckTxPreInputs(const CTransaction& tx, CValidationState& state, const int nHeight, int64_t nLockTimeCutoff, int64_t& nSigOps);
 

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -86,6 +86,23 @@ enum
     //
     // See BIP112 for details
     SCRIPT_VERIFY_CHECKSEQUENCEVERIFY = (1U << 10),
+
+    /* BIP113: Use GetMedianTimePast() instead of nTime for end point timestamp. */
+    LOCKTIME_MEDIAN_TIME_PAST = (1U << 10),
+
+    /**
+     * BIP68: Validate relative locktime in input's sequences.
+     *
+     * CTrasaction::CTxIn::Sequence gets a consensus function for the
+     * first time, in the same spirit of the original intend: the
+     * signer should be able to arbitrarely order its own decisions in time
+     * before publishing/sharing them within smart contracts. See BIP68.
+     *
+     * In contrast with the original nSequence which was only
+     * theoretically useful assuming a universal uniform relay/mining
+     * tx policy, BIP68 can be unambiguously enforced as a consensus rule.
+     */
+    LOCKTIME_VERIFY_SEQUENCE = (1U << 11),
 };
 
 bool CheckSignatureEncoding(const std::vector<unsigned char> &vchSig, unsigned int flags, ScriptError* serror);


### PR DESCRIPTION
This unifies the recent locktime validation flags with the script ones for easier consensus deployment via BIP9 as implemented in #7566. It facilitates deploying BIP113 in this way by moving the check to ConnectBlock() and use the unified consensus validation flags.

Like #7566, it finally introduces "the src/consensus/consensus.cpp file" which is a place intended to attract new consensus code (as opposed to keep putting it in main.cpp like bip113 and bip68).

This PR introduces Consensus::CheckTxPreInputs(), which does all the consensus checks common for coinbase and noncoinbase transactions (which implies none of the checks use the inputs of the transction nor the utxo state).
Note that this introduces a redundant call to main::CheckTransaction() in main::ConnectBlock() which also calls main::CheckBlock() [which calls main::CheckTransaction()].
We can eat either:

a) Eat the redundant main::CheckTransaction() call per tx per block.
b) Remove it from main::CheckBlock()
c) Don't call main::CheckTransaction() from Consensus::CheckTxPreInputs() in this PR

I don't want to decide myself.

In addition to Consensus::CheckTxPreInputs(), the PR introduces Consensus::VerifyTx(), which in its current incomplete implementation seems pretty stupid, as it only calls Consensus::CheckTxPreInputs().  
But there's many more things that could be encapsulated besides that, for example, in https://github.com/jtimon/bitcoin/commits/jt see:

https://github.com/jtimon/bitcoin/commit/a61cec80c7838045a2241f56d76f2f8f840c39aa
https://github.com/jtimon/bitcoin/commit/a408a5d7fce48c7838017fc67f0815e7ea218656
https://github.com/jtimon/bitcoin/commit/5817f754e71701fc198bed04fa7e809549fd1ace
https://github.com/jtimon/bitcoin/commit/6aed9aaaf0c4d48fae673221085a6c514ae81583
https://github.com/jtimon/bitcoin/commit/032182336d84a420f33be3ab7d204c9b5f8ae8cf
https://github.com/jtimon/bitcoin/commit/8c28d1a4175e51199020ca8bbc3e1ecedc862e46
https://github.com/jtimon/bitcoin/commit/473696c4624cc4a7676a42cb0e98293d29e2c864

I believe #7552 should wait for a subset of those commits or equivalent to avoid duplicating code or exposing an incomplete API that is harder to change later.

Context: The main goal of this PR is advancing in libconsensus phase 2 decribed in the to-be-released-because-its-fortunately-already-outdated promised document with pictures. In the absence of a publishable document with pictures for a plan to encapsulate, expose and separate libbitcoinconsensus from bitcoin core, here's a summary including open PRs and other maintained branches:

*\* TODO libconsensus-p2: Put all the consensus critical code excluding storage in the consensus building package #NO_PR [no_branch]
**\* REBASE [1/4] libconsensus-p2a: Build consensus/consensus.o with the consensus package #NO_PR [libconsensus-p2a]
Last version: 72cdd1f
***\* PR bip9/bip113/libconsensus-p2a: Deployment preparations forBIP113 + #7552 + Introduce Consensus::VerifyTx() #7565 [libconsensus-p2a-verifytx-bip113-0.12.99]
***\* REBASE libconsensus-p2a: Decouple pow.o from chain.o and move it to the consensus package #7563 [libconsensus-p2a-chain-cpp-interface-0.12.99]
***\* REBASE libconsensus-p2a: Preparations to decouple libconsensus from coins.o #7564 [libconsensus-p2a-coins-cpp-interface-0.12.99]
*\* libconsensus-p3: Complete C API for consensus non-storage functionality (within the same package) #NO_PR [libconsensus-p3]
*\* libconsensus-p4: Separate libconsensus into its own repository like libsecp256k1 #NO_PR [no_branch]
*\* libconsensus-p5: Stop reusing libconsensus' internal code in Bitcoin Core
*\* libconsensus-p6: Import libconsensus from Bitcoin Core as an external dependency

legend: 
[branch-name] = github/jtimon/bitcoin/branch-name
p2 = phase 2
p2a = phase 2-A

(Extracted from https://github.com/jtimon/doc/blob/master/branches/bitcoin.org if you use org-mode in emacs or vim)
