### PR TITLE
WIP: Implement BIP9 and get BIP113 to be ready to be deployed with it as an example

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -107,6 +107,7 @@ BITCOIN_CORE_H = \
   consensus/consensus.h \
   core_io.h \
   core_memusage.h \
+  global/server.h \
   httprpc.h \
   httpserver.h \
   init.h \
@@ -180,6 +181,7 @@ libbitcoin_server_a_SOURCES = \
   chain.cpp \
   checkpoints.cpp \
   consensus/versionbits.cpp \
+  global/server.cpp \
   httprpc.cpp \
   httpserver.cpp \
   init.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -258,6 +258,7 @@ libbitcoin_consensus_a_SOURCES = \
   amount.h \
   arith_uint256.cpp \
   arith_uint256.h \
+  consensus/interfaces.h \
   consensus/merkle.cpp \
   consensus/merkle.h \
   consensus/params.h \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -179,6 +179,7 @@ libbitcoin_server_a_SOURCES = \
   bloom.cpp \
   chain.cpp \
   checkpoints.cpp \
+  consensus/versionbits.cpp \
   httprpc.cpp \
   httpserver.cpp \
   init.cpp \
@@ -263,6 +264,7 @@ libbitcoin_consensus_a_SOURCES = \
   consensus/merkle.h \
   consensus/params.h \
   consensus/validation.h \
+  consensus/versionbits.h \
   hash.cpp \
   hash.h \
   prevector.h \

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -81,6 +81,12 @@ public:
         consensus.nPowTargetSpacing = 10 * 60;
         consensus.fPowAllowMinDifficultyBlocks = false;
         consensus.fPowNoRetargeting = false;
+        consensus.nRuleChangeActivationThreshold = 1916; // 95% of 2016
+        consensus.nMinerConfirmationWindow = 2016; // nPowTargetTimespan / nPowTargetSpacing
+        consensus.vDeployments[Consensus::BIP68_BIP112].bitmask = 1;
+        consensus.vDeployments[Consensus::BIP68_BIP112].nTimeout = 1;
+        consensus.vDeployments[Consensus::BIP68_BIP112].nStartTime = 1; 
+
         /** 
          * The message start string is designed to be unlikely to occur in normal data.
          * The characters are rarely used upper ASCII, not valid as UTF-8, and produce
@@ -162,6 +168,12 @@ public:
         consensus.nPowTargetSpacing = 10 * 60;
         consensus.fPowAllowMinDifficultyBlocks = true;
         consensus.fPowNoRetargeting = false;
+        consensus.nRuleChangeActivationThreshold = 1512; // 75% for testchains
+        consensus.nMinerConfirmationWindow = 2016; // nPowTargetTimespan / nPowTargetSpacing
+        consensus.vDeployments[Consensus::BIP68_BIP112].bitmask = 1;
+        consensus.vDeployments[Consensus::BIP68_BIP112].nTimeout = 1;
+        consensus.vDeployments[Consensus::BIP68_BIP112].nStartTime = 1; 
+
         pchMessageStart[0] = 0x0b;
         pchMessageStart[1] = 0x11;
         pchMessageStart[2] = 0x09;
@@ -225,6 +237,11 @@ public:
         consensus.nPowTargetSpacing = 10 * 60;
         consensus.fPowAllowMinDifficultyBlocks = true;
         consensus.fPowNoRetargeting = true;
+        consensus.nRuleChangeActivationThreshold = 1512; // 75% for testchains
+        consensus.nMinerConfirmationWindow = 2016; // nPowTargetTimespan / nPowTargetSpacing
+        consensus.vDeployments[Consensus::BIP68_BIP112].bitmask = 1;
+        consensus.vDeployments[Consensus::BIP68_BIP112].nTimeout = 1;
+        consensus.vDeployments[Consensus::BIP68_BIP112].nStartTime = 1; 
 
         pchMessageStart[0] = 0xfa;
         pchMessageStart[1] = 0xbf;

--- a/src/consensus/consensus.h
+++ b/src/consensus/consensus.h
@@ -13,13 +13,4 @@ static const unsigned int MAX_BLOCK_SIGOPS = MAX_BLOCK_SIZE/50;
 /** Coinbase transaction outputs can only be spent after this number of new blocks (network rule) */
 static const int COINBASE_MATURITY = 100;
 
-/** Flags for nSequence and nLockTime locks */
-enum {
-    /* Interpret sequence numbers as relative lock-time constraints. */
-    LOCKTIME_VERIFY_SEQUENCE = (1 << 0),
-
-    /* Use GetMedianTimePast() instead of nTime for end point timestamp. */
-    LOCKTIME_MEDIAN_TIME_PAST = (1 << 1),
-};
-
 #endif // BITCOIN_CONSENSUS_CONSENSUS_H

--- a/src/consensus/interfaces.h
+++ b/src/consensus/interfaces.h
@@ -1,0 +1,27 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2015 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_CONSENSUS_INTERFACES_H
+#define BITCOIN_CONSENSUS_INTERFACES_H
+
+#include "params.h"
+
+namespace Consensus {
+
+typedef void (*VersionBitsCacheSetter)(const void* blockIndex, CVersionBitsState* versionBitsState);
+typedef const CVersionBitsState* (*VersionBitsCacheGetter)(const void* blockIndex);
+
+/**
+ * Collection of function pointers to interface with the versionbits cache.
+ */
+struct CVersionBitsCacheInterface
+{
+    VersionBitsCacheSetter Set;
+    VersionBitsCacheGetter Get;
+};
+
+} // namespace Consensus
+
+#endif // BITCOIN_CONSENSUS_INTERFACES_H

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -13,7 +13,7 @@ namespace Consensus {
 /** Order matters, see case LOCKED_IN in CalculateNextState() */
 enum DeploymentPos
 {
-    BIP113,
+    BIP68_BIP112,
     MAX_VERSION_BITS_DEPLOYMENTS
 };
 

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -9,6 +9,26 @@
 #include "uint256.h"
 
 namespace Consensus {
+
+/** Order matters, see case LOCKED_IN in CalculateNextState() */
+enum DeploymentPos
+{
+    BIP113,
+    MAX_VERSION_BITS_DEPLOYMENTS
+};
+
+/**
+ * Struct for each individual consensus rule change using BIP9.
+ */
+struct BIP9Deployment {
+    /** Bitmask to select the particular bit, only a single bit should be active. */
+    uint32_t bitmask;
+    /** Start MedianTime for version bits miner confirmation. Can be a date in the past */
+    int64_t nStartTime;
+    /** Timeout/expiry MedianTime for the deployment attempt. */
+    int64_t nTimeout;
+};
+
 /**
  * Parameters that influence chain consensus.
  */
@@ -22,6 +42,14 @@ struct Params {
     /** Block height and hash at which BIP34 becomes active */
     int BIP34Height;
     uint256 BIP34Hash;
+    /**
+     * Minimum blocks including miner confirmation of the total of 2016 blocks in a retargetting period,
+     * (nPowTargetTimespan / nPowTargetSpacing) wich is also used for BIP9 deployments.
+     * Examples: 1916 for 95%, 1512 for testchains.
+     */
+    uint32_t nRuleChangeActivationThreshold;
+    uint32_t nMinerConfirmationWindow;
+    BIP9Deployment vDeployments[MAX_VERSION_BITS_DEPLOYMENTS];
     /** Proof of work parameters */
     uint256 powLimit;
     bool fPowAllowMinDifficultyBlocks;
@@ -30,6 +58,25 @@ struct Params {
     int64_t nPowTargetTimespan;
     int64_t DifficultyAdjustmentInterval() const { return nPowTargetTimespan / nPowTargetSpacing; }
 };
+
+/**
+ * BIP9 deployment states, see versionbits.h
+ */
+enum DeploymentState
+{
+    DEFINED,
+    STARTED,
+    LOCKED_IN,
+    ACTIVATED,
+    FAILED,
+    MAX_DEPLOYMENT_STATES
+};
+
+struct CVersionBitsState
+{
+    DeploymentState vStates[MAX_VERSION_BITS_DEPLOYMENTS];
+};
+
 } // namespace Consensus
 
 #endif // BITCOIN_CONSENSUS_PARAMS_H

--- a/src/consensus/versionbits.cpp
+++ b/src/consensus/versionbits.cpp
@@ -1,0 +1,206 @@
+// Copyright (c) 2016-2016 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "versionbits.h"
+
+#include "chain.h" // TODO Decouple libconsensus from CBlockIndex
+#include "interfaces.h"
+#include "script/interpreter.h"
+
+using namespace Consensus;
+
+/**
+ * This can be cheaply recalculated instead cached as shown in #7575.
+ */
+int32_t GetUsedBits(const CVersionBitsState& versionBitsState)
+{
+    int32_t usedBitsMaskCache = RESERVED_BITS_MASK;
+
+    for (int i = 0; i < MAX_VERSION_BITS_DEPLOYMENTS; ++i)
+        usedBitsMaskCache |= versionBitsState.vStates[i];
+
+    return usedBitsMaskCache;
+}
+
+/**
+ * Initialize state of the deployments as DEFINED, perform some basic checks
+ * and initialize the BIP9 states cache.
+ * Can result in a consensus validation error if consensusParams contains deployments using incompatible bits.
+ */
+static void InitVersionBitsState(CVersionBitsState& versionBitsState, const Params& consensusParams)
+{
+    for (int i = 0; i < MAX_VERSION_BITS_DEPLOYMENTS; ++i) {
+        const BIP9Deployment& deployment = consensusParams.vDeployments[i];
+        assert(!(deployment.bitmask & RESERVED_BITS_MASK));
+        versionBitsState.vStates[i] = DEFINED;
+    }
+}
+
+static bool MinersConfirmBitUpgrade(const BIP9Deployment& deployment, const Params& consensusParams, const CBlockIndex* pindexPrev)
+{
+    unsigned nFound = 0;
+    unsigned i = 0;
+    while (i < consensusParams.nMinerConfirmationWindow && 
+           nFound < consensusParams.nRuleChangeActivationThreshold && 
+           pindexPrev != NULL) {
+
+        // If the versionbit bit (bit 29) is not set, the miner wasn't using BIP9 (as it mandates the high bits to be 001...)
+        if (pindexPrev->nVersion & deployment.bitmask && pindexPrev->nVersion & VERSIONBIT_BIT)
+            ++nFound;
+        pindexPrev = pindexPrev->pprev;
+        ++i;
+    }
+    return nFound >= consensusParams.nRuleChangeActivationThreshold;
+}
+
+/**
+ * Calculate the next state from the previous one and the header chain.
+ * Preconditions: 
+ * - nextVersionBitsState = versionBitsState
+ * - (indexPrev->GetHeight() + 1) % consensusParams.nMinerConfirmationWindow == 0
+ */
+static DeploymentState CalculateNextState(DeploymentState previousState, const BIP9Deployment& deployment, const Params& consensusParams, const CBlockIndex* pindexPrev, int64_t nMedianTime, int32_t& usedBitsMaskCache)
+{
+    DeploymentState nextState = previousState;
+    if (previousState == DEFINED && 
+        deployment.nStartTime < nMedianTime && 
+        !(usedBitsMaskCache & deployment.bitmask)) {
+
+        usedBitsMaskCache |= deployment.bitmask;
+        // If moved to STARTED it could potentially become LOCKED_IN or FAILED in the same round, 
+        // so no need to return immediately
+        nextState = STARTED;
+    }
+
+    // Check for Timeouts
+    if (previousState == STARTED && deployment.nTimeout > nMedianTime)
+        return  FAILED;
+
+    if (previousState == STARTED && MinersConfirmBitUpgrade(deployment, consensusParams, pindexPrev))
+        return LOCKED_IN;
+
+    // If locked LOCKED_IN, advance to ACTIVATED and free the bit after
+    // The order in which the BIPS are written in DeploymentPos (consensus/params.h) is potentially consensus critical
+    // for this state: always leave older deployments at the beginning to reuse available bits immediately.
+    if (previousState == LOCKED_IN) {
+        // Don't use XOR to avoid thinking about an impossible case
+        usedBitsMaskCache &= ~deployment.bitmask;
+        return ACTIVATED;
+    }
+
+    // ACTIVATED and FAILED states are final
+    return nextState;
+}
+
+/**
+ * Get the last updated state for a given CBlockIndex.
+ *
+ * @param pindexPrev cannot be NULL.
+ *   The output will be replaced with the oldest found unkown softfork deployment if any.
+ */
+static const CVersionBitsState* GetVersionBitsState(const CBlockIndex* pindexPrev, const Params& consensusParams, CVersionBitsCacheInterface& versionBitsCache)
+{
+    // Make sure the interface's function pointers aren't NULL
+    assert(versionBitsCache.Get && versionBitsCache.Set); 
+
+    // The height of the last ascendant with an updated CVersionBitsState is always 
+    // a multiple of consensusParams.nMinerConfirmationWindow (see BIP9)
+    const uint32_t nPeriod = consensusParams.nMinerConfirmationWindow;
+    const uint32_t nTargetStateHeight = pindexPrev->nHeight - ((pindexPrev->nHeight + 1) % nPeriod);
+    // We don't have to check anything during the first 2015 blocks
+    if (nTargetStateHeight < nPeriod)
+        return NULL;
+
+    if (nTargetStateHeight != (uint32_t)pindexPrev->nHeight)
+        pindexPrev = pindexPrev->GetAncestor(nTargetStateHeight);
+    if (!pindexPrev)
+        return NULL;
+
+    // Search backards for a cached state
+    const CBlockIndex* itBlockIndex = pindexPrev;
+    const CVersionBitsState* pVersionBitsState = versionBitsCache.Get(itBlockIndex);
+    while(!pVersionBitsState && (uint32_t)itBlockIndex->nHeight > nPeriod) {
+        // Only look in index with height % nPeriod == 0
+        itBlockIndex = itBlockIndex->GetAncestor(itBlockIndex->nHeight - nPeriod);
+        pVersionBitsState = versionBitsCache.Get(itBlockIndex);
+    }
+    assert(pindexPrev);
+
+    // Create initial state if there's not one cached
+    CVersionBitsState newVersionBitsState;
+    if (!pVersionBitsState) {
+        InitVersionBitsState(newVersionBitsState, consensusParams);
+        versionBitsCache.Set(itBlockIndex, &newVersionBitsState);
+        pVersionBitsState = versionBitsCache.Get(itBlockIndex);
+    }
+
+    uint32_t nCurrentStateHeight = itBlockIndex->nHeight;
+    // Calculate new states forward
+    while (nCurrentStateHeight < nTargetStateHeight) {
+
+        nCurrentStateHeight += nPeriod; // Move to the next Height that calculates a state
+        itBlockIndex = pindexPrev->GetAncestor(nCurrentStateHeight);
+        const int64_t nMedianTime = itBlockIndex->GetMedianTimePast();
+
+        // Create the new state in the cache from the old one
+        int32_t usedBitsMaskCache = GetUsedBits(*pVersionBitsState);
+        for (int i = 0; i < MAX_VERSION_BITS_DEPLOYMENTS; ++i) {
+            const BIP9Deployment& deployment = consensusParams.vDeployments[i];
+            newVersionBitsState.vStates[i] = CalculateNextState(pVersionBitsState->vStates[i], deployment, consensusParams, itBlockIndex, nMedianTime, usedBitsMaskCache);
+        }
+
+        versionBitsCache.Set(itBlockIndex, &newVersionBitsState);
+        pVersionBitsState = versionBitsCache.Get(itBlockIndex);
+    }
+    assert(nCurrentStateHeight == nTargetStateHeight);
+    return pVersionBitsState;
+}
+
+unsigned int Consensus::GetFlags(const CBlockIndex* pindexPrev, const Params& consensusParams, CVersionBitsCacheInterface& versionBitsCache)
+{
+    unsigned int flags = SCRIPT_VERIFY_NONE;
+    if (!pindexPrev)
+        return flags;
+
+    // BIP16 didn't become active until Apr 1 2012
+    int64_t nBIP16SwitchTime = 1333238400;
+    if (pindexPrev->nTime >= nBIP16SwitchTime)
+        flags |= SCRIPT_VERIFY_P2SH;
+
+    const Consensus::CVersionBitsState* pVersionBitsState = GetVersionBitsState(pindexPrev, consensusParams, versionBitsCache);
+    if (!pVersionBitsState)
+        return flags;
+
+    return flags;
+}
+
+int32_t ComputeBlockVersion(const CBlockIndex* pindexPrev, const Consensus::Params& consensusParams, Consensus::CVersionBitsCacheInterface& versionBitsCache)
+{
+    int32_t nVersion = 0;
+    const Consensus::CVersionBitsState* pVersionBitsState = GetVersionBitsState(pindexPrev, consensusParams, versionBitsCache);
+    if (!pVersionBitsState)
+        return nVersion;
+
+    for (int i = 0; i < MAX_VERSION_BITS_DEPLOYMENTS; ++i)
+        if (pVersionBitsState->vStates[i] == STARTED || pVersionBitsState->vStates[i] == LOCKED_IN)
+            nVersion |= consensusParams.vDeployments[i].bitmask;
+
+    return nVersion == 0 ? VERSIONBITS_LAST_OLD_BLOCK_VERSION : nVersion | VERSIONBIT_BIT;
+}
+
+std::string GetLastUnknownDeploymentWarning(const CBlockIndex* pindexPrev, const Consensus::Params& consensusParams, Consensus::CVersionBitsCacheInterface& versionBitsCache)
+{
+    const uint32_t unusedBits = ~(ComputeBlockVersion(pindexPrev, consensusParams, versionBitsCache) & RESERVED_BITS_MASK);
+    if (unusedBits) {
+        BIP9Deployment deployment;
+        deployment.nStartTime = 0;
+        deployment.nTimeout = std::numeric_limits<int64_t>::max();
+        deployment.bitmask = unusedBits;
+        int32_t usedBitsMaskCache = ~unusedBits;
+        const int64_t nMedianTime = pindexPrev->GetMedianTimePast();
+        if (LOCKED_IN == CalculateNextState(STARTED, deployment, consensusParams, pindexPrev, nMedianTime, usedBitsMaskCache))
+            return "Warning: unknown softfork has been locked in.";
+    }
+    return "";
+}

--- a/src/consensus/versionbits.cpp
+++ b/src/consensus/versionbits.cpp
@@ -172,6 +172,9 @@ unsigned int Consensus::GetFlags(const CBlockIndex* pindexPrev, const Params& co
     if (!pVersionBitsState)
         return flags;
 
+    if (pVersionBitsState->vStates[BIP68_BIP112] == ACTIVATED)
+        flags |= SCRIPT_VERIFY_CHECKSEQUENCEVERIFY | LOCKTIME_VERIFY_SEQUENCE;
+
     return flags;
 }
 

--- a/src/consensus/versionbits.h
+++ b/src/consensus/versionbits.h
@@ -1,0 +1,52 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2016 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_CONSENSUS_VERSIONBITS_H
+#define BITCOIN_CONSENSUS_VERSIONBITS_H
+
+#include <stdint.h>
+#include <string>
+
+class CBlockIndex; // TODO decouple from chain.o
+
+/**
+ * Implementation of BIP9, see https://github.com/bitcoin/bips/blob/master/bip-0009.mediawiki
+ */
+namespace Consensus {
+
+class CVersionBitsCacheInterface;
+class Params;
+
+/** What block version to use for new blocks (pre versionbits) */
+static const int32_t VERSIONBITS_LAST_OLD_BLOCK_VERSION = 4;
+/**
+ * The version bit reserved for signaling hardfork activation to all types of nodes (previously "sign bit").
+ * See https://github.com/bitcoin/bips/pull/317 (TODO wait for BIP number)
+ */
+static const uint32_t HARDFORK_BIT = 1 << 31; // 1000...0
+static const uint32_t UNUSED_RESERVED_BIT = 1 << 30; // 0100...0
+static const uint32_t VERSIONBIT_BIT = 1 << 29; // 0010...0
+static const uint32_t RESERVED_BITS_MASK = HARDFORK_BIT | UNUSED_RESERVED_BIT | VERSIONBIT_BIT; // 1110...0
+
+/**
+ * Get the consensus flags to be enforced according to the block.nVersion history. 
+ */
+unsigned int GetFlags(const CBlockIndex* pindexPrev, const Params& consensusParams, CVersionBitsCacheInterface& versionBitsCache);
+
+} // namespace Consensus
+
+// Non-consensus versionbits utility functions:
+
+/**
+ * Determine what nVersion a new block should use. This is useful for mining.
+ */
+int32_t ComputeBlockVersion(const CBlockIndex* pindexPrev, const Consensus::Params& consensusParams, Consensus::CVersionBitsCacheInterface& versionBitsCache);
+
+/**
+ * If there was a deployment confirmation counting round and any unkown deployment is locked in.
+ */
+std::string GetLastUnknownDeploymentWarning(const CBlockIndex* pindexPrev, const Consensus::Params& consensusParams, Consensus::CVersionBitsCacheInterface& versionBitsCache);
+
+#endif // BITCOIN_CONSENSUS_VERSIONBITS_H

--- a/src/global/server.cpp
+++ b/src/global/server.cpp
@@ -1,0 +1,47 @@
+// Copyright (c) 2016-2016 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "server.h"
+
+#include "sync.h"
+
+#include <map>
+
+static std::map<const void*, Consensus::CVersionBitsState*> mVersionBitsCache;
+static CCriticalSection cs_versionbits;
+
+/**
+ * The key is the pointer of the CBlockIndex and the value, the corresponding Consensus::CVersionBitsState.
+ */
+void ConcurrentVersionBitsCacheSetter(const void* blockIndex, Consensus::CVersionBitsState* versionBitsState)
+{
+    LOCK(cs_versionbits);
+    mVersionBitsCache[blockIndex] = versionBitsState;
+}
+
+const Consensus::CVersionBitsState* ConcurrentVersionBitsCacheGetter(const void* blockIndex)
+{
+    LOCK(cs_versionbits);
+    const Consensus::CVersionBitsState* cachedState = NULL;
+    if (mVersionBitsCache.count(blockIndex))
+        cachedState = mVersionBitsCache.at(blockIndex);
+    return cachedState;
+}
+
+CVersionBitsCacheImplementation::CVersionBitsCacheImplementation()
+{
+    Set = ConcurrentVersionBitsCacheSetter;
+    Get = ConcurrentVersionBitsCacheGetter;
+}
+    
+CVersionBitsCacheImplementation::~CVersionBitsCacheImplementation()
+{
+    // TODO mVersionBitsCache singleton?
+}
+
+namespace Global {
+
+CVersionBitsCacheImplementation versionBitsStateCache;
+
+} // namespace Global

--- a/src/global/server.h
+++ b/src/global/server.h
@@ -1,0 +1,29 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2016 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_GLOBALS_SERVER_H
+#define BITCOIN_GLOBALS_SERVER_H
+
+#include "consensus/interfaces.h"
+
+// This files contains globals used in the server package (but not on
+// lower layer packages like common).
+
+/** A concurrent implementation of Consensus::CVersionBitsCacheInterface. */
+class CVersionBitsCacheImplementation : public Consensus::CVersionBitsCacheInterface
+{
+public:
+    CVersionBitsCacheImplementation();
+    ~CVersionBitsCacheImplementation();
+};
+
+namespace Global {
+
+/** A global cache for versionbits calculation */
+extern CVersionBitsCacheImplementation versionBitsStateCache;
+
+} // namespace Global
+
+#endif // BITCOIN_GLOBALS_SERVER_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -14,6 +14,8 @@
 #include "consensus/consensus.h"
 #include "consensus/merkle.h"
 #include "consensus/validation.h"
+#include "consensus/versionbits.h"
+#include "global/server.h"
 #include "hash.h"
 #include "init.h"
 #include "merkleblock.h"
@@ -2123,6 +2125,8 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     int64_t nTime1 = GetTimeMicros(); nTimeCheck += nTime1 - nTimeStart;
     LogPrint("bench", "    - Sanity checks: %.2fms [%.2fs]\n", 0.001 * (nTime1 - nTimeStart), nTimeCheck * 0.000001);
 
+    unsigned int flags = Consensus::GetFlags(pindex, chainparams.GetConsensus(), Global::versionBitsStateCache);
+
     // Do not allow blocks that contain transactions which 'overwrite' older transactions,
     // unless those are already completely spent.
     // If such overwrites are allowed, coinbases and transactions depending upon those
@@ -2157,12 +2161,6 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
                                  REJECT_INVALID, "bad-txns-BIP30");
         }
     }
-
-    // BIP16 didn't become active until Apr 1 2012
-    int64_t nBIP16SwitchTime = 1333238400;
-    bool fStrictPayToScriptHash = (pindex->GetBlockTime() >= nBIP16SwitchTime);
-
-    unsigned int flags = fStrictPayToScriptHash ? SCRIPT_VERIFY_P2SH : SCRIPT_VERIFY_NONE;
 
     // Start enforcing the DERSIG (BIP66) rules, for block.nVersion=3 blocks,
     // when 75% of the network has upgraded:
@@ -2221,7 +2219,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
                                  REJECT_INVALID, "bad-txns-nonfinal");
             }
 
-            if (fStrictPayToScriptHash)
+            if (flags & SCRIPT_VERIFY_P2SH)
             {
                 // Add in sigops done by pay-to-script-hash inputs;
                 // this is to prevent a "rogue miner" from creating
@@ -2447,24 +2445,13 @@ void static UpdateTip(CBlockIndex *pindexNew) {
 
     cvBlockChange.notify_all();
 
-    // Check the version of the last 100 blocks to see if we need to upgrade:
     static bool fWarned = false;
-    if (!IsInitialBlockDownload() && !fWarned)
-    {
-        int nUpgraded = 0;
+    if (!IsInitialBlockDownload() && !fWarned) {
         const CBlockIndex* pindex = chainActive.Tip();
-        for (int i = 0; i < 100 && pindex != NULL; i++)
-        {
-            if (pindex->nVersion > CBlock::CURRENT_VERSION)
-                ++nUpgraded;
-            pindex = pindex->pprev;
-        }
-        if (nUpgraded > 0)
-            LogPrintf("%s: %d of last 100 blocks above version %d\n", __func__, nUpgraded, (int)CBlock::CURRENT_VERSION);
-        if (nUpgraded > 100/2)
-        {
+        std::string deploymentWarning = GetLastUnknownDeploymentWarning(pindex, chainParams.GetConsensus(), Global::versionBitsStateCache);
+        if (deploymentWarning != "") {
             // strMiscWarning is read by GetWarnings(), called by Qt and the JSON-RPC code to warn the user:
-            strMiscWarning = _("Warning: This version is obsolete; upgrade required!");
+            strMiscWarning = deploymentWarning;
             CAlert::Notify(strMiscWarning, true);
             fWarned = true;
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3140,6 +3140,10 @@ bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationState& sta
     if (block.GetBlockTime() <= pindexPrev->GetMedianTimePast())
         return state.Invalid(false, REJECT_INVALID, "time-too-old", "block's timestamp is too early");
 
+    if (block.nVersion & Consensus::HARDFORK_BIT)
+        state.Invalid(false, REJECT_OBSOLETE, "bad-version-hardfork",
+                             strprintf("rejected nVersion=%d: the deployment of an unkown hardfork has been signaled in this block", block.nVersion));
+
     // Reject outdated version blocks when 95% (75% on testnet) of the network has upgraded:
     for (int32_t version = 2; version < 5; ++version) // check for version 2, 3 and 4 upgrades
         if (block.nVersion < version && IsSuperMajority(version, pindexPrev, consensusParams.nMajorityRejectBlockOutdated, consensusParams))

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -86,6 +86,12 @@ enum
     //
     // See BIP112 for details
     SCRIPT_VERIFY_CHECKSEQUENCEVERIFY = (1U << 10),
+
+    /* BIP68: Interpret sequence numbers as relative lock-time constraints. */
+    LOCKTIME_VERIFY_SEQUENCE = (1U << 11),
+
+    /* BIP113: Use GetMedianTimePast() instead of nTime for end point timestamp. */
+    LOCKTIME_MEDIAN_TIME_PAST = (1U << 12),
 };
 
 bool CheckSignatureEncoding(const std::vector<unsigned char> &vchSig, unsigned int flags, ScriptError* serror);


### PR DESCRIPTION
An implementation of BIP9.

Unnecessary but good-to-have dependencies:

~~\- [ ] Interface for chain.o #7563~~
~~\- [ ] BIP113 ready for trivial deployment #7565~~

TODO:
- [X] GetMinerNextVersion()
- [X] warnings when undefined (for you) rule changes are locked_in/activated according to bip9 rules.
- [ ] Unittests

EDIT: Use BIP68 + BIP112 as example deployment instead of BIP113.
