### PR TITLE
show multiparty transactions clearly in qt transaction list

### DIFF
--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -70,11 +70,9 @@ QString TransactionDesc::toHTML(CWallet *wallet, CWalletTx &wtx, TransactionReco
     }
 
     isminetype fAllToMe = ISMINE_SPENDABLE;
-    bool anyToMe = false;
     BOOST_FOREACH(const CTxOut& txout, wtx.vout)
     {
         isminetype mine = wallet->IsMine(txout);
-        if(mine) anyToMe = true;
         if(fAllToMe > mine) fAllToMe = mine;
     }
 
@@ -145,10 +143,10 @@ QString TransactionDesc::toHTML(CWallet *wallet, CWalletTx &wtx, TransactionReco
     //
     // Amount
     //
-    if (anyFromMe && anyToMe && !fAllFromMe && !fAllToMe)
+    if (anyFromMe && !fAllFromMe)
     {
         //
-        // CoinJoin
+        // Multiparty
         //
         BOOST_FOREACH(const CTxIn& txin, wtx.vin)
         {
@@ -237,7 +235,7 @@ QString TransactionDesc::toHTML(CWallet *wallet, CWalletTx &wtx, TransactionReco
     else
     {
         //
-        // Mixed debit transaction
+        // can't break down payees
         //
         BOOST_FOREACH(const CTxIn& txin, wtx.vin)
             if (wallet->IsMine(txin))

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -60,6 +60,24 @@ QString TransactionDesc::toHTML(CWallet *wallet, CWalletTx &wtx, TransactionReco
     CAmount nDebit = wtx.GetDebit(ISMINE_ALL);
     CAmount nNet = nCredit - nDebit;
 
+    isminetype fAllFromMe = ISMINE_SPENDABLE;
+    bool anyFromMe = false;
+    BOOST_FOREACH(const CTxIn& txin, wtx.vin)
+    {
+        isminetype mine = wallet->IsMine(txin);
+        if(mine) anyFromMe = true;
+        if(fAllFromMe > mine) fAllFromMe = mine;
+    }
+
+    isminetype fAllToMe = ISMINE_SPENDABLE;
+    bool anyToMe = false;
+    BOOST_FOREACH(const CTxOut& txout, wtx.vout)
+    {
+        isminetype mine = wallet->IsMine(txout);
+        if(mine) anyToMe = true;
+        if(fAllToMe > mine) fAllToMe = mine;
+    }
+
     strHTML += "<b>" + tr("Status") + ":</b> " + FormatTxStatus(wtx);
     int nRequests = wtx.GetRequestCount();
     if (nRequests != -1)
@@ -127,7 +145,23 @@ QString TransactionDesc::toHTML(CWallet *wallet, CWalletTx &wtx, TransactionReco
     //
     // Amount
     //
-    if (wtx.IsCoinBase() && nCredit == 0)
+    if (anyFromMe && anyToMe && !fAllFromMe && !fAllToMe)
+    {
+        //
+        // CoinJoin
+        //
+        BOOST_FOREACH(const CTxIn& txin, wtx.vin)
+        {
+            if (wallet->IsMine(txin))
+                strHTML += "<b>" + tr("Debit") + ":</b> " + BitcoinUnits::formatHtmlWithUnit(unit, -wallet->GetDebit(txin, ISMINE_ALL)) + "<br>";
+        }
+        BOOST_FOREACH(const CTxOut& txout, wtx.vout)
+        {
+            if (wallet->IsMine(txout))
+                strHTML += "<b>" + tr("Credit") + ":</b> " + BitcoinUnits::formatHtmlWithUnit(unit, wallet->GetCredit(txout, ISMINE_ALL)) + "<br>";
+        }
+    }
+    else if (wtx.IsCoinBase() && nCredit == 0)
     {
         //
         // Coinbase
@@ -149,85 +183,68 @@ QString TransactionDesc::toHTML(CWallet *wallet, CWalletTx &wtx, TransactionReco
         //
         strHTML += "<b>" + tr("Credit") + ":</b> " + BitcoinUnits::formatHtmlWithUnit(unit, nNet) + "<br>";
     }
-    else
+    else if (fAllFromMe)
     {
-        isminetype fAllFromMe = ISMINE_SPENDABLE;
-        BOOST_FOREACH(const CTxIn& txin, wtx.vin)
-        {
-            isminetype mine = wallet->IsMine(txin);
-            if(fAllFromMe > mine) fAllFromMe = mine;
-        }
+        if(fAllFromMe & ISMINE_WATCH_ONLY)
+            strHTML += "<b>" + tr("From") + ":</b> " + tr("watch-only") + "<br>";
 
-        isminetype fAllToMe = ISMINE_SPENDABLE;
+        //
+        // Debit
+        //
         BOOST_FOREACH(const CTxOut& txout, wtx.vout)
         {
-            isminetype mine = wallet->IsMine(txout);
-            if(fAllToMe > mine) fAllToMe = mine;
-        }
+            // Ignore change
+            isminetype toSelf = wallet->IsMine(txout);
+            if ((toSelf == ISMINE_SPENDABLE) && (fAllFromMe == ISMINE_SPENDABLE))
+                continue;
 
-        if (fAllFromMe)
-        {
-            if(fAllFromMe & ISMINE_WATCH_ONLY)
-                strHTML += "<b>" + tr("From") + ":</b> " + tr("watch-only") + "<br>";
-
-            //
-            // Debit
-            //
-            BOOST_FOREACH(const CTxOut& txout, wtx.vout)
+            if (!wtx.mapValue.count("to") || wtx.mapValue["to"].empty())
             {
-                // Ignore change
-                isminetype toSelf = wallet->IsMine(txout);
-                if ((toSelf == ISMINE_SPENDABLE) && (fAllFromMe == ISMINE_SPENDABLE))
-                    continue;
-
-                if (!wtx.mapValue.count("to") || wtx.mapValue["to"].empty())
+                // Offline transaction
+                CTxDestination address;
+                if (ExtractDestination(txout.scriptPubKey, address))
                 {
-                    // Offline transaction
-                    CTxDestination address;
-                    if (ExtractDestination(txout.scriptPubKey, address))
-                    {
-                        strHTML += "<b>" + tr("To") + ":</b> ";
-                        if (wallet->mapAddressBook.count(address) && !wallet->mapAddressBook[address].name.empty())
-                            strHTML += GUIUtil::HtmlEscape(wallet->mapAddressBook[address].name) + " ";
-                        strHTML += GUIUtil::HtmlEscape(CBitcoinAddress(address).ToString());
-                        if(toSelf == ISMINE_SPENDABLE)
-                            strHTML += " (own address)";
-                        else if(toSelf & ISMINE_WATCH_ONLY)
-                            strHTML += " (watch-only)";
-                        strHTML += "<br>";
-                    }
+                    strHTML += "<b>" + tr("To") + ":</b> ";
+                    if (wallet->mapAddressBook.count(address) && !wallet->mapAddressBook[address].name.empty())
+                        strHTML += GUIUtil::HtmlEscape(wallet->mapAddressBook[address].name) + " ";
+                    strHTML += GUIUtil::HtmlEscape(CBitcoinAddress(address).ToString());
+                    if(toSelf == ISMINE_SPENDABLE)
+                        strHTML += " (own address)";
+                    else if(toSelf & ISMINE_WATCH_ONLY)
+                        strHTML += " (watch-only)";
+                    strHTML += "<br>";
                 }
-
-                strHTML += "<b>" + tr("Debit") + ":</b> " + BitcoinUnits::formatHtmlWithUnit(unit, -txout.nValue) + "<br>";
-                if(toSelf)
-                    strHTML += "<b>" + tr("Credit") + ":</b> " + BitcoinUnits::formatHtmlWithUnit(unit, txout.nValue) + "<br>";
             }
 
-            if (fAllToMe)
-            {
-                // Payment to self
-                CAmount nChange = wtx.GetChange();
-                CAmount nValue = nCredit - nChange;
-                strHTML += "<b>" + tr("Total debit") + ":</b> " + BitcoinUnits::formatHtmlWithUnit(unit, -nValue) + "<br>";
-                strHTML += "<b>" + tr("Total credit") + ":</b> " + BitcoinUnits::formatHtmlWithUnit(unit, nValue) + "<br>";
-            }
-
-            CAmount nTxFee = nDebit - wtx.GetValueOut();
-            if (nTxFee > 0)
-                strHTML += "<b>" + tr("Transaction fee") + ":</b> " + BitcoinUnits::formatHtmlWithUnit(unit, -nTxFee) + "<br>";
+            strHTML += "<b>" + tr("Debit") + ":</b> " + BitcoinUnits::formatHtmlWithUnit(unit, -txout.nValue) + "<br>";
+            if(toSelf)
+                strHTML += "<b>" + tr("Credit") + ":</b> " + BitcoinUnits::formatHtmlWithUnit(unit, txout.nValue) + "<br>";
         }
-        else
+
+        if (fAllToMe)
         {
-            //
-            // Mixed debit transaction
-            //
-            BOOST_FOREACH(const CTxIn& txin, wtx.vin)
-                if (wallet->IsMine(txin))
-                    strHTML += "<b>" + tr("Debit") + ":</b> " + BitcoinUnits::formatHtmlWithUnit(unit, -wallet->GetDebit(txin, ISMINE_ALL)) + "<br>";
-            BOOST_FOREACH(const CTxOut& txout, wtx.vout)
-                if (wallet->IsMine(txout))
-                    strHTML += "<b>" + tr("Credit") + ":</b> " + BitcoinUnits::formatHtmlWithUnit(unit, wallet->GetCredit(txout, ISMINE_ALL)) + "<br>";
+            // Payment to self
+            CAmount nChange = wtx.GetChange();
+            CAmount nValue = nCredit - nChange;
+            strHTML += "<b>" + tr("Total debit") + ":</b> " + BitcoinUnits::formatHtmlWithUnit(unit, -nValue) + "<br>";
+            strHTML += "<b>" + tr("Total credit") + ":</b> " + BitcoinUnits::formatHtmlWithUnit(unit, nValue) + "<br>";
         }
+
+        CAmount nTxFee = nDebit - wtx.GetValueOut();
+        if (nTxFee > 0)
+            strHTML += "<b>" + tr("Transaction fee") + ":</b> " + BitcoinUnits::formatHtmlWithUnit(unit, -nTxFee) + "<br>";
+    }
+    else
+    {
+        //
+        // Mixed debit transaction
+        //
+        BOOST_FOREACH(const CTxIn& txin, wtx.vin)
+            if (wallet->IsMine(txin))
+                strHTML += "<b>" + tr("Debit") + ":</b> " + BitcoinUnits::formatHtmlWithUnit(unit, -wallet->GetDebit(txin, ISMINE_ALL)) + "<br>";
+        BOOST_FOREACH(const CTxOut& txout, wtx.vout)
+            if (wallet->IsMine(txout))
+                strHTML += "<b>" + tr("Credit") + ":</b> " + BitcoinUnits::formatHtmlWithUnit(unit, wallet->GetCredit(txout, ISMINE_ALL)) + "<br>";
     }
 
     strHTML += "<b>" + tr("Net amount") + ":</b> " + BitcoinUnits::formatHtmlWithUnit(unit, nNet, true) + "<br>";

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -54,21 +54,19 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
     }
 
     isminetype fAllToMe = ISMINE_SPENDABLE;
-    bool anyToMe = false;
     BOOST_FOREACH(const CTxOut& txout, wtx.vout)
     {
         isminetype mine = wallet->IsMine(txout);
-        if(mine) anyToMe = true;
         if(mine & ISMINE_WATCH_ONLY) involvesWatchAddress = true;
         if(fAllToMe > mine) fAllToMe = mine;
     }
 
-    if (anyFromMe && anyToMe && !fAllFromMe && !fAllToMe)
+    if (anyFromMe && !fAllFromMe)
     {
         //
-        // CoinJoin
+        // Multiparty
         //
-        parts.append(TransactionRecord(hash, nTime, TransactionRecord::CoinJoin, "", nNet, 0));
+        parts.append(TransactionRecord(hash, nTime, TransactionRecord::Multiparty, "", nNet, 0));
         parts.last().involvesWatchAddress = involvesWatchAddress;
     }
     else if (nNet > 0 || wtx.IsCoinBase())
@@ -167,7 +165,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
     else
     {
         //
-        // Mixed debit transaction, can't break down payees
+        // can't break down payees
         //
         parts.append(TransactionRecord(hash, nTime, TransactionRecord::Other, "", nNet, 0));
         parts.last().involvesWatchAddress = involvesWatchAddress;

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -42,7 +42,36 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
     uint256 hash = wtx.GetHash();
     std::map<std::string, std::string> mapValue = wtx.mapValue;
 
-    if (nNet > 0 || wtx.IsCoinBase())
+    bool involvesWatchAddress = false;
+    isminetype fAllFromMe = ISMINE_SPENDABLE;
+    bool anyFromMe = false;
+    BOOST_FOREACH(const CTxIn& txin, wtx.vin)
+    {
+        isminetype mine = wallet->IsMine(txin);
+        if(mine) anyFromMe = true;
+        if(mine & ISMINE_WATCH_ONLY) involvesWatchAddress = true;
+        if(fAllFromMe > mine) fAllFromMe = mine;
+    }
+
+    isminetype fAllToMe = ISMINE_SPENDABLE;
+    bool anyToMe = false;
+    BOOST_FOREACH(const CTxOut& txout, wtx.vout)
+    {
+        isminetype mine = wallet->IsMine(txout);
+        if(mine) anyToMe = true;
+        if(mine & ISMINE_WATCH_ONLY) involvesWatchAddress = true;
+        if(fAllToMe > mine) fAllToMe = mine;
+    }
+
+    if (anyFromMe && anyToMe && !fAllFromMe && !fAllToMe)
+    {
+        //
+        // CoinJoin
+        //
+        parts.append(TransactionRecord(hash, nTime, TransactionRecord::CoinJoin, "", nNet, 0));
+        parts.last().involvesWatchAddress = involvesWatchAddress;
+    }
+    else if (nNet > 0 || wtx.IsCoinBase())
     {
         //
         // Credit
@@ -79,89 +108,69 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
             }
         }
     }
+    else if (fAllFromMe && fAllToMe)
+    {
+        // Payment to self
+        CAmount nChange = wtx.GetChange();
+
+        parts.append(TransactionRecord(hash, nTime, TransactionRecord::SendToSelf, "",
+                        -(nDebit - nChange), nCredit - nChange));
+        parts.last().involvesWatchAddress = involvesWatchAddress;   // maybe pass to TransactionRecord as constructor argument
+    }
+    else if (fAllFromMe)
+    {
+        //
+        // Debit
+        //
+        CAmount nTxFee = nDebit - wtx.GetValueOut();
+
+        for (unsigned int nOut = 0; nOut < wtx.vout.size(); nOut++)
+        {
+            const CTxOut& txout = wtx.vout[nOut];
+            TransactionRecord sub(hash, nTime);
+            sub.idx = parts.size();
+            sub.involvesWatchAddress = involvesWatchAddress;
+
+            if(wallet->IsMine(txout))
+            {
+                // Ignore parts sent to self, as this is usually the change
+                // from a transaction sent back to our own address.
+                continue;
+            }
+
+            CTxDestination address;
+            if (ExtractDestination(txout.scriptPubKey, address))
+            {
+                // Sent to Bitcoin Address
+                sub.type = TransactionRecord::SendToAddress;
+                sub.address = CBitcoinAddress(address).ToString();
+            }
+            else
+            {
+                // Sent to IP, or other non-address transaction like OP_EVAL
+                sub.type = TransactionRecord::SendToOther;
+                sub.address = mapValue["to"];
+            }
+
+            CAmount nValue = txout.nValue;
+            /* Add fee to first output */
+            if (nTxFee > 0)
+            {
+                nValue += nTxFee;
+                nTxFee = 0;
+            }
+            sub.debit = -nValue;
+
+            parts.append(sub);
+        }
+    }
     else
     {
-        bool involvesWatchAddress = false;
-        isminetype fAllFromMe = ISMINE_SPENDABLE;
-        BOOST_FOREACH(const CTxIn& txin, wtx.vin)
-        {
-            isminetype mine = wallet->IsMine(txin);
-            if(mine & ISMINE_WATCH_ONLY) involvesWatchAddress = true;
-            if(fAllFromMe > mine) fAllFromMe = mine;
-        }
-
-        isminetype fAllToMe = ISMINE_SPENDABLE;
-        BOOST_FOREACH(const CTxOut& txout, wtx.vout)
-        {
-            isminetype mine = wallet->IsMine(txout);
-            if(mine & ISMINE_WATCH_ONLY) involvesWatchAddress = true;
-            if(fAllToMe > mine) fAllToMe = mine;
-        }
-
-        if (fAllFromMe && fAllToMe)
-        {
-            // Payment to self
-            CAmount nChange = wtx.GetChange();
-
-            parts.append(TransactionRecord(hash, nTime, TransactionRecord::SendToSelf, "",
-                            -(nDebit - nChange), nCredit - nChange));
-            parts.last().involvesWatchAddress = involvesWatchAddress;   // maybe pass to TransactionRecord as constructor argument
-        }
-        else if (fAllFromMe)
-        {
-            //
-            // Debit
-            //
-            CAmount nTxFee = nDebit - wtx.GetValueOut();
-
-            for (unsigned int nOut = 0; nOut < wtx.vout.size(); nOut++)
-            {
-                const CTxOut& txout = wtx.vout[nOut];
-                TransactionRecord sub(hash, nTime);
-                sub.idx = parts.size();
-                sub.involvesWatchAddress = involvesWatchAddress;
-
-                if(wallet->IsMine(txout))
-                {
-                    // Ignore parts sent to self, as this is usually the change
-                    // from a transaction sent back to our own address.
-                    continue;
-                }
-
-                CTxDestination address;
-                if (ExtractDestination(txout.scriptPubKey, address))
-                {
-                    // Sent to Bitcoin Address
-                    sub.type = TransactionRecord::SendToAddress;
-                    sub.address = CBitcoinAddress(address).ToString();
-                }
-                else
-                {
-                    // Sent to IP, or other non-address transaction like OP_EVAL
-                    sub.type = TransactionRecord::SendToOther;
-                    sub.address = mapValue["to"];
-                }
-
-                CAmount nValue = txout.nValue;
-                /* Add fee to first output */
-                if (nTxFee > 0)
-                {
-                    nValue += nTxFee;
-                    nTxFee = 0;
-                }
-                sub.debit = -nValue;
-
-                parts.append(sub);
-            }
-        }
-        else
-        {
-            //
-            // Mixed debit transaction, can't break down payees
-            //
-            parts.append(TransactionRecord(hash, nTime, TransactionRecord::Other, "", nNet, 0));
-            parts.last().involvesWatchAddress = involvesWatchAddress;
-        }
+        //
+        // Mixed debit transaction, can't break down payees
+        //
+        parts.append(TransactionRecord(hash, nTime, TransactionRecord::Other, "", nNet, 0));
+        parts.last().involvesWatchAddress = involvesWatchAddress;
     }
 
     return parts;

--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -77,7 +77,7 @@ public:
         RecvWithAddress,
         RecvFromOther,
         SendToSelf,
-        CoinJoin
+        Multiparty, 
     };
 
     /** Number of confirmation recommended for accepting a transaction */

--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -76,7 +76,8 @@ public:
         SendToOther,
         RecvWithAddress,
         RecvFromOther,
-        SendToSelf
+        SendToSelf,
+        CoinJoin
     };
 
     /** Number of confirmation recommended for accepting a transaction */

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -377,6 +377,8 @@ QString TransactionTableModel::formatTxType(const TransactionRecord *wtx) const
         return tr("Payment to yourself");
     case TransactionRecord::Generated:
         return tr("Mined");
+    case TransactionRecord::CoinJoin:
+        return tr("CoinJoin");
     default:
         return QString();
     }

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -377,8 +377,8 @@ QString TransactionTableModel::formatTxType(const TransactionRecord *wtx) const
         return tr("Payment to yourself");
     case TransactionRecord::Generated:
         return tr("Mined");
-    case TransactionRecord::CoinJoin:
-        return tr("CoinJoin");
+    case TransactionRecord::Multiparty:
+        return tr("Multiparty");
     default:
         return QString();
     }


### PR DESCRIPTION
Fixed broken coinjoin display in transaction list and transaction details. This is more of a bug fix then a new feature. 

Moved fAllFromMe and fAllToMe creation blocks up to the top. This changed the indentation of the below if blocks, breaking most of the diffs though the original code stayed the same. Added new vars anyFromMe and anyToMe. Added new condition for (anyFromMe && anyToMe && !fAllFromMe && !fAllToMe). Added type CoinJoin label.
