### PR TITLE
Net: Add IPv6 Link-Local Address Support

### DIFF
--- a/src/netbase.h
+++ b/src/netbase.h
@@ -44,6 +44,7 @@ class CNetAddr
 {
     protected:
         unsigned char ip[16]; // in network byte order
+        uint32_t scopeId; // for scoped/link-local ipv6 addresses
 
     public:
         CNetAddr();
@@ -89,7 +90,7 @@ class CNetAddr
         std::vector<unsigned char> GetGroup() const;
         int GetReachabilityFrom(const CNetAddr *paddrPartner = NULL) const;
 
-        CNetAddr(const struct in6_addr& pipv6Addr);
+        CNetAddr(const struct in6_addr& pipv6Addr, const uint32_t scope = 0);
         bool GetIn6Addr(struct in6_addr* pipv6Addr) const;
 
         friend bool operator==(const CNetAddr& a, const CNetAddr& b);


### PR DESCRIPTION
Adds support for binding and listening, as well as connecting to, scoped IPv6 addresses.

I wanted to be able to use IPv6 link-local addresses on 4.2+ GNU/Linux (`sin6_scope_id` was added in 2.4). So, that's what I've tested. It seems to work. If I missed something, please let me know and I'll fix it.
I haven't tried with Windows or Mac, but I think the support is present in many versions of those systems too.
Hopefully, this does not simply fail for the automated Windows build (fingers crossed).
IPv6 scoped addresses are also known as link-local and site-local addresses.
The Linux docs say, "Linux supports it [sin6_scope_id] only for link-local addresses". Windows may support site-local addresses.

Note that if you test this, it's easier to see the bound address with something like: `sudo netstat -pantu --wide | grep bitcoin`
Also, here's an example of an easy way to find nodes accessible on your local link: `ping6 -I eth0 -n ff02::1`

Basically, commands similar to these should work now, instead of failing with `"Unable to bind to [fe80::1234:5ff:fe67:89ab]:8333 on this computer (bind returned error Invalid argument (22))"` or `"socket send error Broken pipe (32)"`:
- `bitcoin-qt/bitcoind -listen -bind/-whitebind='[fe80::1234:5ff:fe67:89ab%eth0]:8333'`
- `bitcoin-qt/bitcoind -connect='[fe80::1234:5ff:fe67:89ab%eth0]:8333'`

This should still fail due to missing the scope ID:
- `bitcoin-qt/bitcoind -listen -bind/-whitebind='[fe80::1234:5ff:fe67:89ab]:8333'`

This should still fail due to the scope id being misplaced:
- `bitcoin-qt/bitcoind -listen -bind/-whitebind='[fe80::1234:5ff:fe67:89ab]%eth0:8333'`

References:
http://man7.org/linux/man-pages/man7/ipv6.7.html
http://research.microsoft.com/en-us/um/redmond/projects/msripv6/docs/config.htm
https://msdn.microsoft.com/en-us/library/windows/desktop/ms739166(v=vs.85).aspx
https://tools.ietf.org/html/draft-ietf-ipv6-scope-api-00
