### PR TITLE
P2P: add maxtimeadjustment command line option

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -27,6 +27,7 @@
 #include "script/standard.h"
 #include "script/sigcache.h"
 #include "scheduler.h"
+#include "timedata.h"
 #include "txdb.h"
 #include "txmempool.h"
 #include "torcontrol.h"
@@ -365,6 +366,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-maxconnections=<n>", strprintf(_("Maintain at most <n> connections to peers (default: %u)"), DEFAULT_MAX_PEER_CONNECTIONS));
     strUsage += HelpMessageOpt("-maxreceivebuffer=<n>", strprintf(_("Maximum per-connection receive buffer, <n>*1000 bytes (default: %u)"), DEFAULT_MAXRECEIVEBUFFER));
     strUsage += HelpMessageOpt("-maxsendbuffer=<n>", strprintf(_("Maximum per-connection send buffer, <n>*1000 bytes (default: %u)"), DEFAULT_MAXSENDBUFFER));
+    strUsage += HelpMessageOpt("-maxtimeadjustment", strprintf(_("Maximum allowed median peer time offset adjustment. Local perspective of time may be influenced by peers forward or backward by this amount. (default: %u seconds)"), DEFAULT_MAX_TIME_ADJUSTMENT));
     strUsage += HelpMessageOpt("-onion=<ip:port>", strprintf(_("Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: %s)"), "-proxy"));
     strUsage += HelpMessageOpt("-onlynet=<net>", _("Only connect to nodes in network <net> (ipv4, ipv6 or onion)"));
     strUsage += HelpMessageOpt("-permitbaremultisig", strprintf(_("Relay non-P2SH multisig (default: %u)"), DEFAULT_PERMIT_BAREMULTISIG));

--- a/src/timedata.cpp
+++ b/src/timedata.cpp
@@ -83,7 +83,7 @@ void AddTimeData(const CNetAddr& ip, int64_t nOffsetSample)
         int64_t nMedian = vTimeOffsets.median();
         std::vector<int64_t> vSorted = vTimeOffsets.sorted();
         // Only let other nodes change our time by so much
-        if (abs64(nMedian) < 70 * 60)
+        if (abs64(nMedian) <= std::max<int64_t>(0, GetArg("-maxtimeadjustment", DEFAULT_MAX_TIME_ADJUSTMENT)))
         {
             nTimeOffset = nMedian;
         }

--- a/src/timedata.h
+++ b/src/timedata.h
@@ -10,6 +10,8 @@
 #include <stdint.h>
 #include <vector>
 
+static const int64_t DEFAULT_MAX_TIME_ADJUSTMENT = 70 * 60;
+
 class CNetAddr;
 
 /** 


### PR DESCRIPTION
Add `trustsystemclock` command line option to adjust whether peer input can affect the local perspective on time.

I know that there are multiple issues open dealing with local node time management (e.g.- https://github.com/bitcoin/bitcoin/issues/4521).
I didn't see a pull request though. So, here's one.

This is the same patch set that gained acceptance as being useful for https://github.com/bitcoinxt/bitcoinxt/pull/35/files.

It's a really simple change that gives the user the option of letting other nodes influence it's perspective on time vs. not (a new default).

People have been using this for months without a problem that I'm aware of. At least it has actual usage behind it.
If you think making the default "false", to make the current functionality the default, is the way to go to get this included, then I could make that change to this PR.

At least this will give users an easy option to choose how they want to handle it.
On the command line, just use either `-trustsystemclock=0` or `-trustsystemclock=1` (the default in this initial proposed commit).
