### PR TITLE
Minimal BIP9 implementation

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -115,6 +115,7 @@ testScripts = [
     'invalidblockrequest.py',
     'invalidtxrequest.py',
     'abandonconflict.py',
+    'p2p-versionbits-warning.py',
 ]
 testScriptsExt = [
     'bip65-cltv.py',

--- a/qa/rpc-tests/p2p-versionbits-warning.py
+++ b/qa/rpc-tests/p2p-versionbits-warning.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python2
+# Copyright (c) 2016 The Bitcoin Core developers
+# Distributed under the MIT/X11 software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#
+
+from test_framework.mininode import *
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+import time
+from test_framework.blocktools import create_block, create_coinbase
+
+'''
+Test version bits' warning system.
+
+Generate chains with block versions that appear to be signalling unknown
+soft-forks, and test that warning alerts are generated.
+'''
+
+VB_PERIOD = 144 # versionbits period length for regtest
+VB_THRESHOLD = 108 # versionbits activation threshold for regtest
+VB_TOP_BITS = 0x20000000
+VB_UNKNOWN_BIT = 27 # Choose a bit unassigned to any deployment
+
+# TestNode: bare-bones "peer".  Used mostly as a conduit for a test to sending
+# p2p messages to a node, generating the messages in the main testing logic.
+class TestNode(NodeConnCB):
+    def __init__(self):
+        NodeConnCB.__init__(self)
+        self.connection = None
+        self.ping_counter = 1
+        self.last_pong = msg_pong()
+
+    def add_connection(self, conn):
+        self.connection = conn
+
+    def on_inv(self, conn, message):
+        pass
+
+    # Wrapper for the NodeConn's send_message function
+    def send_message(self, message):
+        self.connection.send_message(message)
+
+    def on_pong(self, conn, message):
+        self.last_pong = message
+
+    # Sync up with the node after delivery of a block
+    def sync_with_ping(self, timeout=30):
+        self.connection.send_message(msg_ping(nonce=self.ping_counter))
+        received_pong = False
+        sleep_time = 0.05
+        while not received_pong and timeout > 0:
+            time.sleep(sleep_time)
+            timeout -= sleep_time
+            with mininode_lock:
+                if self.last_pong.nonce == self.ping_counter:
+                    received_pong = True
+        self.ping_counter += 1
+        return received_pong
+
+
+class VersionBitsWarningTest(BitcoinTestFramework):
+    def setup_chain(self):
+        initialize_chain_clean(self.options.tmpdir, 1)
+
+    def setup_network(self):
+        self.nodes = []
+        self.alert_filename = os.path.join(self.options.tmpdir, "alert.txt")
+        # Open and close to create zero-length file
+        with open(self.alert_filename, 'w') as f:
+            pass
+        self.node_options = ["-debug", "-logtimemicros=1", "-alertnotify=echo %s >> \"" + self.alert_filename + "\""]
+        self.nodes.append(start_node(0, self.options.tmpdir, self.node_options))
+
+        import re
+        self.vb_pattern = re.compile("^Warning.*versionbit")
+
+    # Send numblocks blocks via peer with nVersionToUse set.
+    def send_blocks_with_version(self, peer, numblocks, nVersionToUse):
+        tip = self.nodes[0].getbestblockhash()
+        height = self.nodes[0].getblockcount()
+        block_time = self.nodes[0].getblockheader(tip)["time"]+1
+        tip = int(tip, 16)
+
+        for i in xrange(numblocks):
+            block = create_block(tip, create_coinbase(height+1), block_time)
+            block.nVersion = nVersionToUse
+            block.solve()
+            peer.send_message(msg_block(block))
+            block_time += 1
+            height += 1
+            tip = block.sha256
+        peer.sync_with_ping()
+
+    def test_versionbits_in_alert_file(self):
+        with open(self.alert_filename, 'r') as f:
+            alert_text = f.read()
+        assert(self.vb_pattern.match(alert_text))
+
+    def run_test(self):
+        # Setup the p2p connection and start up the network thread.
+        test_node = TestNode()
+
+        connections = []
+        connections.append(NodeConn('127.0.0.1', p2p_port(0), self.nodes[0], test_node))
+        test_node.add_connection(connections[0])
+
+        NetworkThread().start() # Start up network handling in another thread
+
+        # Test logic begins here
+        test_node.wait_for_verack()
+
+        # 1. Have the node mine one period worth of blocks
+        self.nodes[0].generate(VB_PERIOD)
+
+        # 2. Now build one period of blocks on the tip, with < VB_THRESHOLD
+        # blocks signaling some unknown bit.
+        nVersion = VB_TOP_BITS | (1<<VB_UNKNOWN_BIT)
+        self.send_blocks_with_version(test_node, VB_THRESHOLD-1, nVersion)
+
+        # Fill rest of period with regular version blocks
+        self.nodes[0].generate(VB_PERIOD - VB_THRESHOLD + 1)
+        # Check that we're not getting any versionbit-related errors in
+        # getinfo()
+        assert(not self.vb_pattern.match(self.nodes[0].getinfo()["errors"]))
+
+        # 3. Now build one period of blocks with >= VB_THRESHOLD blocks signaling
+        # some unknown bit
+        self.send_blocks_with_version(test_node, VB_THRESHOLD, nVersion)
+        self.nodes[0].generate(VB_PERIOD - VB_THRESHOLD)
+        # Might not get a versionbits-related alert yet, as we should
+        # have gotten a different alert due to more than 51/100 blocks
+        # being of unexpected version.
+        # Check that getinfo() shows some kind of error.
+        assert(len(self.nodes[0].getinfo()["errors"]) != 0)
+
+        # Mine a period worth of expected blocks so the generic block-version warning
+        # is cleared, and restart the node. This should move the versionbit state
+        # to ACTIVE.
+        self.nodes[0].generate(VB_PERIOD)
+        stop_node(self.nodes[0], 0)
+        wait_bitcoinds()
+        # Empty out the alert file
+        with open(self.alert_filename, 'w') as f:
+            pass
+        self.nodes[0] = start_node(0, self.options.tmpdir, ["-debug", "-logtimemicros=1", "-alertnotify=echo %s >> \"" + self.alert_filename + "\""])
+
+        # Connecting one block should be enough to generate an error.
+        self.nodes[0].generate(1)
+        assert(len(self.nodes[0].getinfo()["errors"]) != 0)
+        stop_node(self.nodes[0], 0)
+        wait_bitcoinds()
+        self.test_versionbits_in_alert_file()
+
+        # Test framework expects the node to still be running...
+        self.nodes[0] = start_node(0, self.options.tmpdir, ["-debug", "-logtimemicros=1", "-alertnotify=echo %s >> \"" + self.alert_filename + "\""])
+
+
+if __name__ == '__main__':
+    VersionBitsWarningTest().main()

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -152,6 +152,7 @@ BITCOIN_CORE_H = \
   utilmoneystr.h \
   utiltime.h \
   validationinterface.h \
+  versionbits.h \
   wallet/crypter.h \
   wallet/db.h \
   wallet/rpcwallet.h \
@@ -204,6 +205,7 @@ libbitcoin_server_a_SOURCES = \
   txdb.cpp \
   txmempool.cpp \
   validationinterface.cpp \
+  versionbits.cpp \
   $(BITCOIN_CORE_H)
 
 if ENABLE_ZMQ

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -83,6 +83,7 @@ BITCOIN_TESTS =\
   test/timedata_tests.cpp \
   test/transaction_tests.cpp \
   test/txvalidationcache_tests.cpp \
+  test/versionbits_tests.cpp \
   test/uint256_tests.cpp \
   test/univalue_tests.cpp \
   test/util_tests.cpp

--- a/src/chain.h
+++ b/src/chain.h
@@ -14,8 +14,6 @@
 
 #include <vector>
 
-#include <boost/foreach.hpp>
-
 struct CDiskBlockPos
 {
     int nFile;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -81,6 +81,8 @@ public:
         consensus.nPowTargetSpacing = 10 * 60;
         consensus.fPowAllowMinDifficultyBlocks = false;
         consensus.fPowNoRetargeting = false;
+        consensus.nRuleChangeActivationThreshold = 1916; // 95% of 2016
+        consensus.nMinerConfirmationWindow = 2016; // nPowTargetTimespan / nPowTargetSpacing
         /** 
          * The message start string is designed to be unlikely to occur in normal data.
          * The characters are rarely used upper ASCII, not valid as UTF-8, and produce
@@ -162,6 +164,8 @@ public:
         consensus.nPowTargetSpacing = 10 * 60;
         consensus.fPowAllowMinDifficultyBlocks = true;
         consensus.fPowNoRetargeting = false;
+        consensus.nRuleChangeActivationThreshold = 1512; // 75% for testchains
+        consensus.nMinerConfirmationWindow = 2016; // nPowTargetTimespan / nPowTargetSpacing
         pchMessageStart[0] = 0x0b;
         pchMessageStart[1] = 0x11;
         pchMessageStart[2] = 0x09;
@@ -225,6 +229,8 @@ public:
         consensus.nPowTargetSpacing = 10 * 60;
         consensus.fPowAllowMinDifficultyBlocks = true;
         consensus.fPowNoRetargeting = true;
+        consensus.nRuleChangeActivationThreshold = 108; // 75% for testchains
+        consensus.nMinerConfirmationWindow = 144; // Faster than normal for regtest (144 instead of 2016)
 
         pchMessageStart[0] = 0xfa;
         pchMessageStart[1] = 0xbf;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -83,6 +83,9 @@ public:
         consensus.fPowNoRetargeting = false;
         consensus.nRuleChangeActivationThreshold = 1916; // 95% of 2016
         consensus.nMinerConfirmationWindow = 2016; // nPowTargetTimespan / nPowTargetSpacing
+        consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;
+        consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = 1199145601; // January 1, 2008
+        consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nTimeout = 1230767999; // December 31, 2008
         /** 
          * The message start string is designed to be unlikely to occur in normal data.
          * The characters are rarely used upper ASCII, not valid as UTF-8, and produce
@@ -166,6 +169,9 @@ public:
         consensus.fPowNoRetargeting = false;
         consensus.nRuleChangeActivationThreshold = 1512; // 75% for testchains
         consensus.nMinerConfirmationWindow = 2016; // nPowTargetTimespan / nPowTargetSpacing
+        consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;
+        consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = 1199145601; // January 1, 2008
+        consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nTimeout = 1230767999; // December 31, 2008
         pchMessageStart[0] = 0x0b;
         pchMessageStart[1] = 0x11;
         pchMessageStart[2] = 0x09;
@@ -231,6 +237,9 @@ public:
         consensus.fPowNoRetargeting = true;
         consensus.nRuleChangeActivationThreshold = 108; // 75% for testchains
         consensus.nMinerConfirmationWindow = 144; // Faster than normal for regtest (144 instead of 2016)
+        consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;
+        consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = 0;
+        consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nTimeout = 999999999999ULL;
 
         pchMessageStart[0] = 0xfa;
         pchMessageStart[1] = 0xbf;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -14,7 +14,8 @@ namespace Consensus {
 
 enum DeploymentPos
 {
-    MAX_VERSION_BITS_DEPLOYMENTS = 0,
+    DEPLOYMENT_TESTDUMMY,
+    MAX_VERSION_BITS_DEPLOYMENTS
 };
 
 /**

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -7,8 +7,28 @@
 #define BITCOIN_CONSENSUS_PARAMS_H
 
 #include "uint256.h"
+#include <map>
+#include <string>
 
 namespace Consensus {
+
+enum DeploymentPos
+{
+    MAX_VERSION_BITS_DEPLOYMENTS = 0,
+};
+
+/**
+ * Struct for each individual consensus rule change using BIP9.
+ */
+struct BIP9Deployment {
+    /** Bit position to select the particular bit in nVersion. */
+    int bit;
+    /** Start MedianTime for version bits miner confirmation. Can be a date in the past */
+    int64_t nStartTime;
+    /** Timeout/expiry MedianTime for the deployment attempt. */
+    int64_t nTimeout;
+};
+
 /**
  * Parameters that influence chain consensus.
  */
@@ -22,6 +42,14 @@ struct Params {
     /** Block height and hash at which BIP34 becomes active */
     int BIP34Height;
     uint256 BIP34Hash;
+    /**
+     * Minimum blocks including miner confirmation of the total of 2016 blocks in a retargetting period,
+     * (nPowTargetTimespan / nPowTargetSpacing) which is also used for BIP9 deployments.
+     * Examples: 1916 for 95%, 1512 for testchains.
+     */
+    uint32_t nRuleChangeActivationThreshold;
+    uint32_t nMinerConfirmationWindow;
+    BIP9Deployment vDeployments[MAX_VERSION_BITS_DEPLOYMENTS];
     /** Proof of work parameters */
     uint256 powLimit;
     bool fPowAllowMinDifficultyBlocks;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -466,7 +466,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-blockmaxsize=<n>", strprintf(_("Set maximum block size in bytes (default: %d)"), DEFAULT_BLOCK_MAX_SIZE));
     strUsage += HelpMessageOpt("-blockprioritysize=<n>", strprintf(_("Set maximum size of high-priority/low-fee transactions in bytes (default: %d)"), DEFAULT_BLOCK_PRIORITY_SIZE));
     if (showDebug)
-        strUsage += HelpMessageOpt("-blockversion=<n>", strprintf("Override block version to test forking scenarios (default: %d)", (int)CBlock::CURRENT_VERSION));
+        strUsage += HelpMessageOpt("-blockversion=<n>", "Override block version to test forking scenarios");
 
     strUsage += HelpMessageGroup(_("RPC server options:"));
     strUsage += HelpMessageOpt("-server", _("Accept command line and JSON-RPC commands"));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -34,6 +34,7 @@
 #include "utilmoneystr.h"
 #include "utilstrencodings.h"
 #include "validationinterface.h"
+#include "versionbits.h"
 
 #include <sstream>
 
@@ -2083,6 +2084,51 @@ void PartitionCheck(bool (*initialDownloadCheck)(), CCriticalSection& cs, const 
     }
 }
 
+// Protected by cs_main
+static VersionBitsCache versionbitscache;
+
+int32_t ComputeBlockVersion(const CBlockIndex* pindexPrev, const Consensus::Params& params)
+{
+    LOCK(cs_main);
+    int32_t nVersion = VERSIONBITS_TOP_BITS;
+
+    for (int i = 0; i < (int)Consensus::MAX_VERSION_BITS_DEPLOYMENTS; i++) {
+        ThresholdState state = VersionBitsState(pindexPrev, params, (Consensus::DeploymentPos)i, versionbitscache);
+        if (state == THRESHOLD_LOCKED_IN || state == THRESHOLD_STARTED) {
+            nVersion |= VersionBitsMask(params, (Consensus::DeploymentPos)i);
+        }
+    }
+
+    return nVersion;
+}
+
+/**
+ * Threshold condition checker that triggers when unknown versionbits are seen on the network.
+ */
+class WarningBitsConditionChecker : public AbstractThresholdConditionChecker
+{
+private:
+    int bit;
+
+public:
+    WarningBitsConditionChecker(int bitIn) : bit(bitIn) {}
+
+    int64_t BeginTime(const Consensus::Params& params) const { return 0; }
+    int64_t EndTime(const Consensus::Params& params) const { return std::numeric_limits<int64_t>::max(); }
+    int Period(const Consensus::Params& params) const { return params.nMinerConfirmationWindow; }
+    int Threshold(const Consensus::Params& params) const { return params.nRuleChangeActivationThreshold; }
+
+    bool Condition(const CBlockIndex* pindex, const Consensus::Params& params) const
+    {
+        return ((pindex->nVersion & VERSIONBITS_TOP_MASK) == VERSIONBITS_TOP_BITS) &&
+               ((pindex->nVersion >> bit) & 1) != 0 &&
+               ((ComputeBlockVersion(pindex->pprev, params) >> bit) & 1) == 0;
+    }
+};
+
+// Protected by cs_main
+static ThresholdConditionCache warningcache[VERSIONBITS_NUM_BITS];
+
 static int64_t nTimeCheck = 0;
 static int64_t nTimeForks = 0;
 static int64_t nTimeVerify = 0;
@@ -2452,24 +2498,42 @@ void static UpdateTip(CBlockIndex *pindexNew) {
 
     // Check the version of the last 100 blocks to see if we need to upgrade:
     static bool fWarned = false;
-    if (!IsInitialBlockDownload() && !fWarned)
+    if (!IsInitialBlockDownload())
     {
         int nUpgraded = 0;
         const CBlockIndex* pindex = chainActive.Tip();
+        for (int bit = 0; bit < VERSIONBITS_NUM_BITS; bit++) {
+            WarningBitsConditionChecker checker(bit);
+            ThresholdState state = checker.GetStateFor(pindex, chainParams.GetConsensus(), warningcache[bit]);
+            if (state == THRESHOLD_ACTIVE || state == THRESHOLD_LOCKED_IN) {
+                if (state == THRESHOLD_ACTIVE) {
+                    strMiscWarning = strprintf(_("Warning: unknown new rules activated (versionbit %i)"), bit);
+                    if (!fWarned) {
+                        CAlert::Notify(strMiscWarning, true);
+                        fWarned = true;
+                    }
+                } else {
+                    LogPrintf("%s: unknown new rules are about to activate (versionbit %i)\n", __func__, bit);
+                }
+            }
+        }
         for (int i = 0; i < 100 && pindex != NULL; i++)
         {
-            if (pindex->nVersion > CBlock::CURRENT_VERSION)
+            int32_t nExpectedVersion = ComputeBlockVersion(pindex->pprev, chainParams.GetConsensus());
+            if (pindex->nVersion > VERSIONBITS_LAST_OLD_BLOCK_VERSION && (pindex->nVersion & ~nExpectedVersion) != 0)
                 ++nUpgraded;
             pindex = pindex->pprev;
         }
         if (nUpgraded > 0)
-            LogPrintf("%s: %d of last 100 blocks above version %d\n", __func__, nUpgraded, (int)CBlock::CURRENT_VERSION);
+            LogPrintf("%s: %d of last 100 blocks have unexpected version\n", __func__, nUpgraded);
         if (nUpgraded > 100/2)
         {
             // strMiscWarning is read by GetWarnings(), called by Qt and the JSON-RPC code to warn the user:
-            strMiscWarning = _("Warning: This version is obsolete; upgrade required!");
-            CAlert::Notify(strMiscWarning, true);
-            fWarned = true;
+            strMiscWarning = _("Warning: Unknown block versions being mined! It's possible unknown rules are in effect");
+            if (!fWarned) {
+                CAlert::Notify(strMiscWarning, true);
+                fWarned = true;
+            }
         }
     }
 }
@@ -3763,6 +3827,10 @@ void UnloadBlockIndex()
     setDirtyFileInfo.clear();
     mapNodeState.clear();
     recentRejects.reset(NULL);
+    versionbitscache.Clear();
+    for (int b = 0; b < VERSIONBITS_NUM_BITS; b++) {
+        warningcache[b].clear();
+    }
 
     BOOST_FOREACH(BlockMap::value_type& entry, mapBlockIndex) {
         delete entry.second;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5859,7 +5859,11 @@ bool SendMessages(CNode* pto)
      return strprintf("CBlockFileInfo(blocks=%u, size=%u, heights=%u...%u, time=%s...%s)", nBlocks, nSize, nHeightFirst, nHeightLast, DateTimeStrFormat("%Y-%m-%d", nTimeFirst), DateTimeStrFormat("%Y-%m-%d", nTimeLast));
  }
 
-
+ThresholdState VersionBitsTipState(const Consensus::Params& params, Consensus::DeploymentPos pos)
+{
+    LOCK(cs_main);
+    return VersionBitsState(chainActive.Tip(), params, pos, versionbitscache);
+}
 
 class CMainCleanup
 {

--- a/src/main.h
+++ b/src/main.h
@@ -16,6 +16,7 @@
 #include "net.h"
 #include "script/script_error.h"
 #include "sync.h"
+#include "versionbits.h"
 
 #include <algorithm>
 #include <exception>
@@ -288,6 +289,9 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
 
 /** Convert CValidationState to a human-readable message for logging */
 std::string FormatStateMessage(const CValidationState &state);
+
+/** Get the BIP9 state for a given deployment at the current tip. */
+ThresholdState VersionBitsTipState(const Consensus::Params& params, Consensus::DeploymentPos pos);
 
 struct CNodeStateStats {
     int nMisbehavior;

--- a/src/main.h
+++ b/src/main.h
@@ -537,6 +537,11 @@ extern CBlockTreeDB *pblocktree;
  */
 int GetSpendHeight(const CCoinsViewCache& inputs);
 
+/**
+ * Determine what nVersion a new block should use.
+ */
+int32_t ComputeBlockVersion(const CBlockIndex* pindexPrev, const Consensus::Params& params);
+
 /** Reject codes greater or equal to this can be returned by AcceptToMemPool
  * for transactions, to signal internal conditions. They cannot and should not
  * be sent over the P2P network.

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -79,11 +79,6 @@ CBlockTemplate* CreateNewBlock(const CChainParams& chainparams, const CScript& s
         return NULL;
     CBlock *pblock = &pblocktemplate->block; // pointer for convenience
 
-    // -regtest only: allow overriding block.nVersion with
-    // -blockversion=N to test forking scenarios
-    if (chainparams.MineBlocksOnDemand())
-        pblock->nVersion = GetArg("-blockversion", pblock->nVersion);
-
     // Create coinbase tx
     CMutableTransaction txNew;
     txNew.vin.resize(1);
@@ -136,6 +131,12 @@ CBlockTemplate* CreateNewBlock(const CChainParams& chainparams, const CScript& s
         const int nHeight = pindexPrev->nHeight + 1;
         pblock->nTime = GetAdjustedTime();
         const int64_t nMedianTimePast = pindexPrev->GetMedianTimePast();
+
+        pblock->nVersion = ComputeBlockVersion(pindexPrev, chainparams.GetConsensus());
+        // -regtest only: allow overriding block.nVersion with
+        // -blockversion=N to test forking scenarios
+        if (chainparams.MineBlocksOnDemand())
+            pblock->nVersion = GetArg("-blockversion", pblock->nVersion);
 
         int64_t nLockTimeCutoff = (STANDARD_LOCKTIME_VERIFY_FLAGS & LOCKTIME_MEDIAN_TIME_PAST)
                                 ? nMedianTimePast

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -21,7 +21,6 @@ class CBlockHeader
 {
 public:
     // header
-    static const int32_t CURRENT_VERSION=4;
     int32_t nVersion;
     uint256 hashPrevBlock;
     uint256 hashMerkleRoot;
@@ -49,7 +48,7 @@ public:
 
     void SetNull()
     {
-        nVersion = CBlockHeader::CURRENT_VERSION;
+        nVersion = 0;
         hashPrevBlock.SetNull();
         hashMerkleRoot.SetNull();
         nTime = 0;

--- a/src/test/versionbits_tests.cpp
+++ b/src/test/versionbits_tests.cpp
@@ -1,0 +1,185 @@
+// Copyright (c) 2014-2015 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "chain.h"
+#include "random.h"
+#include "versionbits.h"
+#include "test/test_bitcoin.h"
+
+#include <boost/test/unit_test.hpp>
+
+/* Define a virtual block time, one block per 10 minutes after Nov 14 2014, 0:55:36am */
+int32_t TestTime(int nHeight) { return 1415926536 + 600 * nHeight; }
+
+static const Consensus::Params paramsDummy = Consensus::Params();
+
+class TestConditionChecker : public AbstractThresholdConditionChecker
+{
+private:
+    mutable ThresholdConditionCache cache;
+
+public:
+    int64_t BeginTime(const Consensus::Params& params) const { return TestTime(10000); }
+    int64_t EndTime(const Consensus::Params& params) const { return TestTime(20000); }
+    int Period(const Consensus::Params& params) const { return 1000; }
+    int Threshold(const Consensus::Params& params) const { return 900; }
+    bool Condition(const CBlockIndex* pindex, const Consensus::Params& params) const { return (pindex->nVersion & 0x100); }
+
+    ThresholdState GetStateFor(const CBlockIndex* pindexPrev) const { return AbstractThresholdConditionChecker::GetStateFor(pindexPrev, paramsDummy, cache); }
+};
+
+#define CHECKERS 6
+
+class VersionBitsTester
+{
+    // A fake blockchain
+    std::vector<CBlockIndex*> vpblock;
+
+    // 6 independent checkers for the same bit.
+    // The first one performs all checks, the second only 50%, the third only 25%, etc...
+    // This is to test whether lack of cached information leads to the same results.
+    TestConditionChecker checker[CHECKERS];
+
+    // Test counter (to identify failures)
+    int num;
+
+public:
+    VersionBitsTester() : num(0) {}
+
+    VersionBitsTester& Reset() {
+        for (unsigned int i = 0; i < vpblock.size(); i++) {
+            delete vpblock[i];
+        }
+        for (unsigned int  i = 0; i < CHECKERS; i++) {
+            checker[i] = TestConditionChecker();
+        }
+        vpblock.clear();
+        return *this;
+    }
+
+    ~VersionBitsTester() {
+         Reset();
+    }
+
+    VersionBitsTester& Mine(unsigned int height, int32_t nTime, int32_t nVersion) {
+        while (vpblock.size() < height) {
+            CBlockIndex* pindex = new CBlockIndex();
+            pindex->nHeight = vpblock.size();
+            pindex->pprev = vpblock.size() > 0 ? vpblock.back() : NULL;
+            pindex->nTime = nTime;
+            pindex->nVersion = nVersion;
+            pindex->BuildSkip();
+            vpblock.push_back(pindex);
+        }
+        return *this;
+    }
+
+    VersionBitsTester& TestDefined() {
+        for (int i = 0; i < CHECKERS; i++) {
+            if ((insecure_rand() & ((1 << i) - 1)) == 0) {
+                BOOST_CHECK_MESSAGE(checker[i].GetStateFor(vpblock.empty() ? NULL : vpblock.back()) == THRESHOLD_DEFINED, strprintf("Test %i for DEFINED", num));
+            }
+        }
+        num++;
+        return *this;
+    }
+
+    VersionBitsTester& TestStarted() {
+        for (int i = 0; i < CHECKERS; i++) {
+            if ((insecure_rand() & ((1 << i) - 1)) == 0) {
+                BOOST_CHECK_MESSAGE(checker[i].GetStateFor(vpblock.empty() ? NULL : vpblock.back()) == THRESHOLD_STARTED, strprintf("Test %i for STARTED", num));
+            }
+        }
+        num++;
+        return *this;
+    }
+
+    VersionBitsTester& TestLockedIn() {
+        for (int i = 0; i < CHECKERS; i++) {
+            if ((insecure_rand() & ((1 << i) - 1)) == 0) {
+                BOOST_CHECK_MESSAGE(checker[i].GetStateFor(vpblock.empty() ? NULL : vpblock.back()) == THRESHOLD_LOCKED_IN, strprintf("Test %i for LOCKED_IN", num));
+            }
+        }
+        num++;
+        return *this;
+    }
+
+    VersionBitsTester& TestActive() {
+        for (int i = 0; i < CHECKERS; i++) {
+            if ((insecure_rand() & ((1 << i) - 1)) == 0) {
+                BOOST_CHECK_MESSAGE(checker[i].GetStateFor(vpblock.empty() ? NULL : vpblock.back()) == THRESHOLD_ACTIVE, strprintf("Test %i for ACTIVE", num));
+            }
+        }
+        num++;
+        return *this;
+    }
+
+    VersionBitsTester& TestFailed() {
+        for (int i = 0; i < CHECKERS; i++) {
+            if ((insecure_rand() & ((1 << i) - 1)) == 0) {
+                BOOST_CHECK_MESSAGE(checker[i].GetStateFor(vpblock.empty() ? NULL : vpblock.back()) == THRESHOLD_FAILED, strprintf("Test %i for FAILED", num));
+            }
+        }
+        num++;
+        return *this;
+    }
+};
+
+BOOST_FIXTURE_TEST_SUITE(versionbits_tests, TestingSetup)
+
+BOOST_AUTO_TEST_CASE(versionbits_test)
+{
+    for (int i = 0; i < 64; i++) {
+        // DEFINED -> FAILED
+        VersionBitsTester().TestDefined()
+                           .Mine(1, TestTime(1), 0x100).TestDefined()
+                           .Mine(11, TestTime(11), 0x100).TestDefined()
+                           .Mine(989, TestTime(989), 0x100).TestDefined()
+                           .Mine(999, TestTime(20000), 0x100).TestDefined()
+                           .Mine(1000, TestTime(20000), 0x100).TestFailed()
+                           .Mine(1999, TestTime(30001), 0x100).TestFailed()
+                           .Mine(2000, TestTime(30002), 0x100).TestFailed()
+                           .Mine(2001, TestTime(30003), 0x100).TestFailed()
+                           .Mine(2999, TestTime(30004), 0x100).TestFailed()
+                           .Mine(3000, TestTime(30005), 0x100).TestFailed()
+
+        // DEFINED -> STARTED -> FAILED
+                           .Reset().TestDefined()
+                           .Mine(1, TestTime(1), 0).TestDefined()
+                           .Mine(1000, TestTime(10000) - 1, 0x100).TestDefined() // One second more and it would be defined
+                           .Mine(2000, TestTime(10000), 0x100).TestStarted() // So that's what happens the next period
+                           .Mine(2051, TestTime(10010), 0).TestStarted() // 51 old blocks
+                           .Mine(2950, TestTime(10020), 0x100).TestStarted() // 899 new blocks
+                           .Mine(3000, TestTime(20000), 0).TestFailed() // 50 old blocks (so 899 out of the past 1000)
+                           .Mine(4000, TestTime(20010), 0x100).TestFailed()
+
+        // DEFINED -> STARTED -> FAILED while threshold reached
+                           .Reset().TestDefined()
+                           .Mine(1, TestTime(1), 0).TestDefined()
+                           .Mine(1000, TestTime(10000) - 1, 0x101).TestDefined() // One second more and it would be defined
+                           .Mine(2000, TestTime(10000), 0x101).TestStarted() // So that's what happens the next period
+                           .Mine(2999, TestTime(30000), 0x100).TestStarted() // 999 new blocks
+                           .Mine(3000, TestTime(30000), 0x100).TestFailed() // 1 new block (so 1000 out of the past 1000 are new)
+                           .Mine(3999, TestTime(30001), 0).TestFailed()
+                           .Mine(4000, TestTime(30002), 0).TestFailed()
+                           .Mine(14333, TestTime(30003), 0).TestFailed()
+                           .Mine(24000, TestTime(40000), 0).TestFailed()
+
+        // DEFINED -> STARTED -> LOCKEDIN at the last minute -> ACTIVE
+                           .Reset().TestDefined()
+                           .Mine(1, TestTime(1), 0).TestDefined()
+                           .Mine(1000, TestTime(10000) - 1, 0x101).TestDefined() // One second more and it would be defined
+                           .Mine(2000, TestTime(10000), 0x101).TestStarted() // So that's what happens the next period
+                           .Mine(2050, TestTime(10010), 0x200).TestStarted() // 50 old blocks
+                           .Mine(2950, TestTime(10020), 0x100).TestStarted() // 900 new blocks
+                           .Mine(2999, TestTime(19999), 0x200).TestStarted() // 49 old blocks
+                           .Mine(3000, TestTime(29999), 0x200).TestLockedIn() // 1 old block (so 900 out of the past 1000)
+                           .Mine(3999, TestTime(30001), 0).TestLockedIn()
+                           .Mine(4000, TestTime(30002), 0).TestActive()
+                           .Mine(14333, TestTime(30003), 0).TestActive()
+                           .Mine(24000, TestTime(40000), 0).TestActive();
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/versionbits.cpp
+++ b/src/versionbits.cpp
@@ -1,0 +1,133 @@
+// Copyright (c) 2016 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "versionbits.h"
+
+ThresholdState AbstractThresholdConditionChecker::GetStateFor(const CBlockIndex* pindexPrev, const Consensus::Params& params, ThresholdConditionCache& cache) const
+{
+    int nPeriod = Period(params);
+    int nThreshold = Threshold(params);
+    int64_t nTimeStart = BeginTime(params);
+    int64_t nTimeTimeout = EndTime(params);
+
+    // A block's state is always the same as that of the first of its period, so it is computed based on a pindexPrev whose height equals a multiple of nPeriod - 1.
+    if (pindexPrev != NULL) {
+        pindexPrev = pindexPrev->GetAncestor(pindexPrev->nHeight - ((pindexPrev->nHeight + 1) % nPeriod));
+    }
+
+    // Walk backwards in steps of nPeriod to find a pindexPrev whose information is known
+    std::vector<const CBlockIndex*> vToCompute;
+    while (cache.count(pindexPrev) == 0) {
+        if (pindexPrev == NULL) {
+            // The genesis block is by definition defined.
+            cache[pindexPrev] = THRESHOLD_DEFINED;
+            break;
+        }
+        if (pindexPrev->GetMedianTimePast() < nTimeStart) {
+            // Optimizaton: don't recompute down further, as we know every earlier block will be before the start time
+            cache[pindexPrev] = THRESHOLD_DEFINED;
+            break;
+        }
+        vToCompute.push_back(pindexPrev);
+        pindexPrev = pindexPrev->GetAncestor(pindexPrev->nHeight - nPeriod);
+    }
+
+    // At this point, cache[pindexPrev] is known
+    assert(cache.count(pindexPrev));
+    ThresholdState state = cache[pindexPrev];
+
+    // Now walk forward and compute the state of descendants of pindexPrev
+    while (!vToCompute.empty()) {
+        ThresholdState stateNext = state;
+        pindexPrev = vToCompute.back();
+        vToCompute.pop_back();
+
+        switch (state) {
+            case THRESHOLD_DEFINED: {
+                if (pindexPrev->GetMedianTimePast() >= nTimeTimeout) {
+                    stateNext = THRESHOLD_FAILED;
+                } else if (pindexPrev->GetMedianTimePast() >= nTimeStart) {
+                    stateNext = THRESHOLD_STARTED;
+                }
+                break;
+            }
+            case THRESHOLD_STARTED: {
+                if (pindexPrev->GetMedianTimePast() >= nTimeTimeout) {
+                    stateNext = THRESHOLD_FAILED;
+                    break;
+                }
+                // We need to count
+                const CBlockIndex* pindexCount = pindexPrev;
+                int count = 0;
+                for (int i = 0; i < nPeriod; i++) {
+                    if (Condition(pindexCount, params)) {
+                        count++;
+                    }
+                    pindexCount = pindexCount->pprev;
+                }
+                if (count >= nThreshold) {
+                    stateNext = THRESHOLD_LOCKED_IN;
+                }
+                break;
+            }
+            case THRESHOLD_LOCKED_IN: {
+                // Always progresses into ACTIVE.
+                stateNext = THRESHOLD_ACTIVE;
+                break;
+            }
+            case THRESHOLD_FAILED:
+            case THRESHOLD_ACTIVE: {
+                // Nothing happens, these are terminal states.
+                break;
+            }
+        }
+        cache[pindexPrev] = state = stateNext;
+    }
+
+    return state;
+}
+
+namespace
+{
+/**
+ * Class to implement versionbits logic.
+ */
+class VersionBitsConditionChecker : public AbstractThresholdConditionChecker {
+private:
+    const Consensus::DeploymentPos id;
+
+protected:
+    int64_t BeginTime(const Consensus::Params& params) const { return params.vDeployments[id].nStartTime; }
+    int64_t EndTime(const Consensus::Params& params) const { return params.vDeployments[id].nTimeout; }
+    int Period(const Consensus::Params& params) const { return params.nMinerConfirmationWindow; }
+    int Threshold(const Consensus::Params& params) const { return params.nRuleChangeActivationThreshold; }
+
+    bool Condition(const CBlockIndex* pindex, const Consensus::Params& params) const
+    {
+        return (((pindex->nVersion & VERSIONBITS_TOP_MASK) == VERSIONBITS_TOP_BITS) && (pindex->nVersion & Mask(params)) != 0);
+    }
+
+public:
+    VersionBitsConditionChecker(Consensus::DeploymentPos id_) : id(id_) {}
+    uint32_t Mask(const Consensus::Params& params) const { return ((uint32_t)1) << params.vDeployments[id].bit; }
+};
+
+}
+
+ThresholdState VersionBitsState(const CBlockIndex* pindexPrev, const Consensus::Params& params, Consensus::DeploymentPos pos, VersionBitsCache& cache)
+{
+    return VersionBitsConditionChecker(pos).GetStateFor(pindexPrev, params, cache.caches[pos]);
+}
+
+uint32_t VersionBitsMask(const Consensus::Params& params, Consensus::DeploymentPos pos)
+{
+    return VersionBitsConditionChecker(pos).Mask(params);
+}
+
+void VersionBitsCache::Clear()
+{
+    for (unsigned int d = 0; d < Consensus::MAX_VERSION_BITS_DEPLOYMENTS; d++) {
+        caches[d].clear();
+    }
+}

--- a/src/versionbits.h
+++ b/src/versionbits.h
@@ -1,0 +1,59 @@
+// Copyright (c) 2016 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_CONSENSUS_VERSIONBITS
+#define BITCOIN_CONSENSUS_VERSIONBITS
+
+#include "chain.h"
+#include <map>
+
+/** What block version to use for new blocks (pre versionbits) */
+static const int32_t VERSIONBITS_LAST_OLD_BLOCK_VERSION = 4;
+/** What bits to set in version for versionbits blocks */
+static const int32_t VERSIONBITS_TOP_BITS = 0x20000000UL;
+/** What bitmask determines whether versionbits is in use */
+static const int32_t VERSIONBITS_TOP_MASK = 0xE0000000UL;
+/** Total bits available for versionbits */
+static const int32_t VERSIONBITS_NUM_BITS = 29;
+
+enum ThresholdState {
+    THRESHOLD_DEFINED,
+    THRESHOLD_STARTED,
+    THRESHOLD_LOCKED_IN,
+    THRESHOLD_ACTIVE,
+    THRESHOLD_FAILED,
+};
+
+// A map that gives the state for blocks whose height is a multiple of Period().
+// The map is indexed by the block's parent, however, so all keys in the map
+// will either be NULL or a block with (height + 1) % Period() == 0.
+typedef std::map<const CBlockIndex*, ThresholdState> ThresholdConditionCache;
+
+/**
+ * Abstract class that implements BIP9-style threshold logic, and caches results.
+ */
+class AbstractThresholdConditionChecker {
+protected:
+    virtual bool Condition(const CBlockIndex* pindex, const Consensus::Params& params) const =0;
+    virtual int64_t BeginTime(const Consensus::Params& params) const =0;
+    virtual int64_t EndTime(const Consensus::Params& params) const =0;
+    virtual int Period(const Consensus::Params& params) const =0;
+    virtual int Threshold(const Consensus::Params& params) const =0;
+
+public:
+    // Note that the function below takes a pindexPrev as input: they compute information for block B based on its parent.
+    ThresholdState GetStateFor(const CBlockIndex* pindexPrev, const Consensus::Params& params, ThresholdConditionCache& cache) const;
+};
+
+struct VersionBitsCache
+{
+    ThresholdConditionCache caches[Consensus::MAX_VERSION_BITS_DEPLOYMENTS];
+
+    void Clear();
+};
+
+ThresholdState VersionBitsState(const CBlockIndex* pindexPrev, const Consensus::Params& params, Consensus::DeploymentPos pos, VersionBitsCache& cache);
+uint32_t VersionBitsMask(const Consensus::Params& params, Consensus::DeploymentPos pos);
+
+#endif


### PR DESCRIPTION
This is an alternative to #6816 and #7566, implementing BIP9 with minimal code changes, including mining logic, softfork warning logic, and some unit tests.

It adds support for a begin time before version bits are counted, which is not in BIP9 currently, though it is compatible.

The last commit demonstrates how to add a simple softfork.
