### PR TITLE
Update rpcconsole.cpp

### DIFF
--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -276,7 +276,7 @@ RPCConsole::RPCConsole(const PlatformStyle *platformStyle, QWidget *parent) :
 
     // set library version labels
 
-#if (OPENSSL_VERSION_NUMBER < 0x10100000L)
+#if defined(LIBRESSL_VERSION_NUMBER) || (OPENSSL_VERSION_NUMBER < 0x10100000L)
     ui->openSSLVersion->setText(SSLeay_version(SSLEAY_VERSION));
 #else
     ui->openSSLVersion->setText(OpenSSL_version(OPENSSL_VERSION));


### PR DESCRIPTION
fixes for building against LibreSSL - tested on CentOS 7 with LibreSSL 2.3.2
