### PR TITLE
Improving wording related to Boost library requirements [updated]

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -67,15 +67,17 @@ Build requirements:
 
     sudo apt-get install build-essential libtool autotools-dev automake pkg-config libssl-dev libevent-dev bsdmainutils
 
-On at least Ubuntu 14.04+ and Debian 7+ there are generic names for the
+Options when installing required Boost library files:
+
+1. On at least Ubuntu 14.04+ and Debian 7+ there are generic names for the
 individual boost development packages, so the following can be used to only
 install necessary parts of boost:
 
-    sudo apt-get install libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-program-options-dev libboost-test-dev libboost-thread-dev
+        sudo apt-get install libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-program-options-dev libboost-test-dev libboost-thread-dev
 
-If that doesn't work, you can install all boost development packages with:
+2. If that doesn't work, you can install all boost development packages with:
 
-    sudo apt-get install libboost-all-dev
+        sudo apt-get install libboost-all-dev
 
 BerkeleyDB is required for the wallet. db4.8 packages are available [here](https://launchpad.net/~bitcoin/+archive/bitcoin).
 You can add the repository and install using the following commands:


### PR DESCRIPTION
Fixed formatting as requested on https://github.com/bitcoin/bitcoin/pull/7589

Description:
Documentation was unclear in this section and could be interpreted to mean that boost was not a hard requirement for older Ubuntu versions.
Related: #7587
