### PR TITLE
All files related to my RPM spec file project in one commit

### DIFF
--- a/contrib/README.md
+++ b/contrib/README.md
@@ -42,6 +42,9 @@ Various PGP files of core developers.
 ### [MacDeploy](/contrib/macdeploy) ###
 Scripts and notes for Mac builds. 
 
+### [RPM](/contrib/rpm) ###
+RPM spec file for building bitcoin-core on RPM based distributions
+
 Test and Verify Tools 
 ---------------------
 

--- a/contrib/rpm/README.md
+++ b/contrib/rpm/README.md
@@ -1,0 +1,185 @@
+RPM Spec File Notes
+-------------------
+
+The RPM spec file provided here is for Bitcoin-Core 0.12.0 and builds on CentOS
+7 with either the CentOS provided OpenSSL library or with LibreSSL as packaged
+at [LibreLAMP.com](https://librelamp.com/). It should hopefully not be too
+difficult to port the RPM spec file to most RPM based Linux distributions.
+
+When porting the spec file to build for a particular distribution, there are
+some important notes.
+
+## Sources
+
+It is considered good form for all sources to reference a URL where the source
+can be downloaded.
+
+Sources 0-9 should be reserved for source code tarballs. `Source0` should
+reference the release tarball available from https://bitcoin.org/bin/ and
+`Source1` should reference the BerkeleyDB source.
+
+Sources 10-99 are for source files that are maintained in the
+[Bitcoin git repository](https://github.com/bitcoin/bitcoin) but are not part of
+the release tarball. Most of these will reside in the `contrib` sub-directory.
+
+Sources 10-19 should be reserved for miscellaneous configuration files.
+Currently only `Source10` is used, for the example `bitcoin.conf` file.
+
+Sources 20-29 should be reserved for man pages. Currently only `Source20`
+through `Source23` are used.
+
+Sources 30-39 should be reserved for SELinux related files. Currently only
+`Source30` through `Source32` are used. Until those files are in a tagged
+release, the full URL specified in the RPM spec file will not work. You can get
+them from the git ropository where you retrieved this file.
+
+Sources 100+ are for files that are not source tarballs and are not maintained
+in the bitcoin git repository. At present only an SVG version of the Bitcoin
+icon is used.
+
+## Patches
+
+In general, patches should be avoided. When a packager feels a patch is
+necessary, the packager should bring the problem to the attention of the bitcoin
+developers so that an official fix to the issue can make it into the next
+release.
+
+### Patch0 bitcoin-0.12.0-libressl.patch
+
+This patch is only needed if building against LibreSSL. LibreSSL is not the
+standard TLS library on most Linux distributions. The patch will likely not be
+needed when 0.12.1 is released, a proper fix is already in the Bitcoin git
+master branch.
+
+## BuildRequires
+
+The packages specified in the `BuildRequires` are specified according to the
+package naming convention currently used in CentOS 7 and EPEL for CentOS 7. You
+may need to change some of the package names for other distributions. This is
+most likely to be the case with the Qt packages.
+
+## BerkeleyDB
+
+The `build-unix.md` file recommends building against BerkeleyDB 4.8.30. Even if
+that is the version your Linux distribution ships with, it probably is a good
+idea to build Bitcoin Core against a static version of that library compiled
+according to the instructions in the `build-unix.md` file so that any changes
+the distribution may make in the future will not result in a problem for users.
+
+The problem that can exist, clients built against different versions of
+BerkeleyDB may not be able read each other's `wallet.dat` file which can make it
+difficult for a user to recover from backup in the event of a system failure.
+
+## Graphical User Interface and Qt Version
+
+The RPM spec file will by default build the GUI client linked against the Qt5
+libraries. If you wish instead to link against the Qt4 libraries you need to
+pass the switch `-D '_use_qt4 1'` at build time to the `rpmbuild` or `mock`
+command used to build the packages.
+
+If you would prefer not to build the GUI at all, you can pass the switch
+`-D '_no_gui 1'` to the `rpmbuild` or `mock` build command.
+
+## Desktop and KDE Files
+
+The desktop and KDE meta files are created in the spec file itself with the
+`cat` command. This is done to allow easy distribution specific changes without
+needing to use any patches. A specific time stamp is given to the files so that
+it does not they do not appear to have been updated every time the package is
+built. If you do make changes to them, you probably should update time stamp
+assigned to them in the `touch` command that specifies the time stamp.
+
+## SVG, PNG, and XPM Icons
+
+The `bitcoin.svg` file is from the source listed as `Source100`. It is used as
+the source for the PNG and XPM files. The generated PNG and XPM files are given
+the same time stamp as the source SVG file as a means of indicating they are
+derived from it.
+
+## Systemd
+
+This spec file assumes the target distribution uses systemd. That really only
+matters for the `bitcoin-server` package. At this point, most RPM based
+distributions that still receive vendor updates do in fact use systemd.
+
+The files to control the service are created in the RPM spec file itself using
+the `cat` command. This is done to make it easy to modify for other
+distributions that may implement things differently without needing to patch
+source. A specific time stamp is given to the files so that they do not appear
+to have been updated every time the package is built. If you do make changes to
+them, you probably should update the time stamp assigned to them in the `touch`
+command that specifies the time stamp.
+
+## SELinux
+
+The `bitcoin-server` package should have SELinux support. How to properly do
+that *may* vary by distribution and version of distribution.
+
+The SELinux stuff in this RPM spec file *should* be correct for CentOS, RHEL,
+and Fedora but it would be a good idea to review it before building the package
+on other distributions.
+
+## Tests
+
+The `%check` section takes a very long time to run. If your build system has a
+time limit for package build, you may need to make an exception for this
+package. On CentOS 7 the `%check` section completes successfully with both
+OpenSSL and LibreSSL, a failure really does mean something is wrong.
+
+## LibreSSL Build Notes
+
+To build against LibreSSL you will need to pass the switch
+`-D '_use_libressl 1'` to the `rpmbuild` or `mock` command or the spec file will
+want the OpenSSL development files.
+
+### LibreSSL and Boost
+
+LibreSSL (and some newer builds of OpenSSL) do not have support for SSLv3. This
+can cause issues with the Boost package if the Boost package has not been
+patched accordingly. On those distributions, you will either need to build
+Bitcoin-Core against OpenSSL or use a patched version of Boost in the build
+system.
+
+As SSLv3 is no longer safe, distributions that have not patched Boost to work
+with TLS libraries that do not support SSLv3 should have bug reports filed
+against the Boost package. This bug report has already been filed for RHEL 7 but
+it may need to be filed for other distributions.
+
+A patch for Boost: https://github.com/boostorg/asio/pull/23/files
+
+## ZeroMQ
+
+At this time, this RPM spec file does not support the ZeroMQ build options. A
+suitable version of ZeroMQ is not available for the platform this spec file was
+developed on (CentOS 7).
+
+## Legacy Credit
+
+This RPM spec file is largely based upon the work of Michael Hampton at
+[Ringing Liberty](https://www.ringingliberty.com/bitcoin/). He has been
+packaging Bitcoin for Fedora at least since 2012.
+
+Most of the differences between his packaging and this package are stylistic in
+nature. The major differences:
+
+1. He builds from a github tagged release rather than a release tarball. This
+should not result in different source code.
+
+2. He does not build BerkeleyDB but instead uses the BerkeleyDB provided by the
+Linux distribution. For the distributions he packages for, they currently all
+use the same version of BerkeleyDB so that difference is *probably* just
+academic.
+
+3. As of his 10.11.2 package he did not allow for building against LibreSSL,
+specifying a build without the Qt GUI, or specifying which version of the Qt
+libraries to use.
+
+4. I renamed the `bitcoin` package that contains the Qt GUI to `bitcoin-core` as
+that appears to be how the general population refers to it, in contrast to
+`bitcoin-xt` or `bitcoin-classic`. I wanted to make sure the general population
+knows what they are getting when installing the GUI package.
+
+As far as minor differences, I generally prefer to assign the file permissions
+in the `%files` portion of an RPM spec file rather than specifying the
+permissions of a file during `%install` and other minor things like that that
+are largely just cosmetic.

--- a/contrib/rpm/bitcoin-0.12.0-libressl.patch
+++ b/contrib/rpm/bitcoin-0.12.0-libressl.patch
@@ -1,0 +1,24 @@
+diff -ur bitcoin-0.12.0.orig/src/init.cpp bitcoin-0.12.0/src/init.cpp
+--- bitcoin-0.12.0.orig/src/init.cpp	2015-12-31 16:00:00.000000000 -0800
++++ bitcoin-0.12.0/src/init.cpp	2016-02-23 06:03:47.133227757 -0800
+@@ -1075,7 +1075,7 @@
+     if (fPrintToDebugLog)
+         OpenDebugLog();
+ 
+-#if (OPENSSL_VERSION_NUMBER < 0x10100000L)
++#if defined(LIBRESSL_VERSION_NUMBER) || (OPENSSL_VERSION_NUMBER < 0x10100000L)
+     LogPrintf("Using OpenSSL version %s\n", SSLeay_version(SSLEAY_VERSION));
+ #else
+     LogPrintf("Using OpenSSL version %s\n", OpenSSL_version(OPENSSL_VERSION));
+diff -ur bitcoin-0.12.0.orig/src/qt/rpcconsole.cpp bitcoin-0.12.0/src/qt/rpcconsole.cpp
+--- bitcoin-0.12.0.orig/src/qt/rpcconsole.cpp	2015-12-31 16:00:00.000000000 -0800
++++ bitcoin-0.12.0/src/qt/rpcconsole.cpp	2016-02-23 15:09:42.881126841 -0800
+@@ -264,7 +264,7 @@
+ 
+     // set library version labels
+ 
+-#if (OPENSSL_VERSION_NUMBER < 0x10100000L)
++#if defined(LIBRESSL_VERSION_NUMBER) || (OPENSSL_VERSION_NUMBER < 0x10100000L)
+     ui->openSSLVersion->setText(SSLeay_version(SSLEAY_VERSION));
+ #else
+     ui->openSSLVersion->setText(OpenSSL_version(OPENSSL_VERSION));

--- a/contrib/rpm/bitcoin.fc
+++ b/contrib/rpm/bitcoin.fc
@@ -1,0 +1,8 @@
+/usr/bin/bitcoin-cli		--	gen_context(system_u:object_r:bitcoin_exec_t,s0)
+/usr/sbin/bitcoind		--	gen_context(system_u:object_r:bitcoin_exec_t,s0)
+/usr/lib(64)?/bitcoin/bitcoind		--	gen_context(system_u:object_r:bitcoin_exec_t,s0)
+
+/etc/bitcoin(/.*)?		gen_context(system_u:object_r:bitcoin_conf_t,s0)
+/var/lib/bitcoin(/.*)?		gen_context(system_u:object_r:bitcoin_var_lib_t,s0)
+
+(/var)?/run/bitcoind(/.*)?   gen_context(system_u:object_r:bitcoin_var_run_t,s0)

--- a/contrib/rpm/bitcoin.if
+++ b/contrib/rpm/bitcoin.if
@@ -1,0 +1,157 @@
+
+## <summary>policy for bitcoin</summary>
+
+
+########################################
+## <summary>
+##	Transition to bitcoin.
+## </summary>
+## <param name="domain">
+## <summary>
+##	Domain allowed to transition.
+## </summary>
+## </param>
+#
+interface(`bitcoin_domtrans',`
+	gen_require(`
+		type bitcoin_t, bitcoin_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	domtrans_pattern($1, bitcoin_exec_t, bitcoin_t)
+')
+
+
+########################################
+## <summary>
+##	Execute bitcoin server in the bitcoin domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`bitcoin_initrc_domtrans',`
+	gen_require(`
+		type bitcoin_initrc_exec_t;
+	')
+
+	init_labeled_script_domtrans($1, bitcoin_initrc_exec_t)
+')
+
+
+########################################
+## <summary>
+##	Search bitcoin lib directories.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`bitcoin_search_lib',`
+	gen_require(`
+		type bitcoin_var_lib_t;
+	')
+
+	allow $1 bitcoin_var_lib_t:dir search_dir_perms;
+	files_search_var_lib($1)
+')
+
+########################################
+## <summary>
+##	Read bitcoin lib files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`bitcoin_read_lib_files',`
+	gen_require(`
+		type bitcoin_var_lib_t;
+	')
+
+	files_search_var_lib($1)
+	read_files_pattern($1, bitcoin_var_lib_t, bitcoin_var_lib_t)
+')
+
+########################################
+## <summary>
+##	Manage bitcoin lib files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`bitcoin_manage_lib_files',`
+	gen_require(`
+		type bitcoin_var_lib_t;
+	')
+
+	files_search_var_lib($1)
+	manage_files_pattern($1, bitcoin_var_lib_t, bitcoin_var_lib_t)
+')
+
+########################################
+## <summary>
+##	Manage bitcoin lib directories.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`bitcoin_manage_lib_dirs',`
+	gen_require(`
+		type bitcoin_var_lib_t;
+	')
+
+	files_search_var_lib($1)
+	manage_dirs_pattern($1, bitcoin_var_lib_t, bitcoin_var_lib_t)
+')
+
+
+########################################
+## <summary>
+##	All of the rules required to administrate
+##	an bitcoin environment
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`bitcoin_admin',`
+	gen_require(`
+		type bitcoin_t;
+		type bitcoin_initrc_exec_t;
+		type bitcoin_var_lib_t;
+	')
+
+	allow $1 bitcoin_t:process { ptrace signal_perms };
+	ps_process_pattern($1, bitcoin_t)
+
+	bitcoin_initrc_domtrans($1)
+	domain_system_change_exemption($1)
+	role_transition $2 bitcoin_initrc_exec_t system_r;
+	allow $2 system_r;
+
+	files_search_var_lib($1)
+	admin_pattern($1, bitcoin_var_lib_t)
+
+')
+

--- a/contrib/rpm/bitcoin.spec
+++ b/contrib/rpm/bitcoin.spec
@@ -1,0 +1,444 @@
+%define bdbv 4.8.30
+%global selinux_variants mls strict targeted
+
+%if 0%{?_no_gui:1}
+%define _buildqt 0
+%define buildargs --with-gui=no
+%else
+%define _buildqt 1
+%if 0%{?_use_qt4}
+%define buildargs --with-qrencode --with-gui=qt4
+%else
+%define buildargs --with-qrencode --with-gui=qt5
+%endif
+%endif
+
+Name:		bitcoin
+Version:	0.12.0
+Release:	2%{?dist}
+Summary:	Peer to Peer Cryptographic Currency
+
+Group:		Applications/System
+License:	MIT
+URL:		https://bitcoin.org/
+Source0:	https://bitcoin.org/bin/bitcoin-core-%{version}/bitcoin-%{version}.tar.gz
+Source1:	http://download.oracle.com/berkeley-db/db-%{bdbv}.NC.tar.gz
+
+Source10:	https://raw.githubusercontent.com/bitcoin/bitcoin/v%{version}/contrib/debian/examples/bitcoin.conf
+
+#man pages
+Source20:	https://raw.githubusercontent.com/bitcoin/bitcoin/v%{version}/contrib/debian/manpages/bitcoind.1
+Source21:	https://raw.githubusercontent.com/bitcoin/bitcoin/v%{version}/contrib/debian/manpages/bitcoin-cli.1
+Source22:	https://raw.githubusercontent.com/bitcoin/bitcoin/v%{version}/contrib/debian/manpages/bitcoin-qt.1
+Source23:	https://raw.githubusercontent.com/bitcoin/bitcoin/v%{version}/contrib/debian/manpages/bitcoin.conf.5
+
+#selinux
+Source30:	https://raw.githubusercontent.com/bitcoin/bitcoin/v%{version}/contrib/rpm/bitcoin.te
+# Source31 - what about bitcoin-tx and bench_bitcoin ???
+Source31:	https://raw.githubusercontent.com/bitcoin/bitcoin/v%{version}/contrib/rpm/bitcoin.fc
+Source32:	https://raw.githubusercontent.com/bitcoin/bitcoin/v%{version}/contrib/rpm/bitcoin.if
+
+Source100:	https://upload.wikimedia.org/wikipedia/commons/4/46/Bitcoin.svg
+
+%if 0%{?_use_libressl:1}
+BuildRequires:	libressl-devel
+%else
+BuildRequires:	openssl-devel
+%endif
+BuildRequires:	boost-devel
+BuildRequires:	miniupnpc-devel
+BuildRequires:	autoconf automake libtool
+BuildRequires:	libevent-devel
+
+
+Patch0:		bitcoin-0.12.0-libressl.patch
+
+
+%description
+Bitcoin is a digital cryptographic currency that uses peer-to-peer technology to
+operate with no central authority or banks; managing transactions and the
+issuing of bitcoins is carried out collectively by the network.
+
+%if %{_buildqt}
+%package core
+Summary:	Peer to Peer Cryptographic Currency
+Group:		Applications/System
+Obsoletes:	%{name} < %{version}-%{release}
+Provides:	%{name} = %{version}-%{release}
+%if 0%{?_use_qt4}
+BuildRequires:	qt-devel
+%else
+BuildRequires:	qt5-qtbase-devel
+# for /usr/bin/lrelease-qt5
+BuildRequires:	qt5-linguist
+%endif
+BuildRequires:	protobuf-devel
+BuildRequires:	qrencode-devel
+BuildRequires:	%{_bindir}/desktop-file-validate
+# for icon generation from SVG
+BuildRequires:	%{_bindir}/inkscape
+BuildRequires:	%{_bindir}/convert
+
+%description core
+Bitcoin is a digital cryptographic currency that uses peer-to-peer technology to
+operate with no central authority or banks; managing transactions and the
+issuing of bitcoins is carried out collectively by the network.
+
+This package contains the Qt based graphical client and node. If you are looking
+to run a Bitcoin wallet, this is probably the package you want.
+%endif
+
+
+%package libs
+Summary:	Bitcoin shared libraries
+Group:		System Environment/Libraries
+
+%description libs
+This package provides the bitcoinconsensus shared libraries. These libraries
+may be used by third party software to provide consensus verification
+functionality.
+
+Unless you know need this package, you probably do not.
+
+%package devel
+Summary:	Development files for bitcoin
+Group:		Development/Libraries
+Requires:	%{name}-libs = %{version}-%{release}
+
+%description devel
+This package contains the header files and static library for the
+bitcoinconsensus shared library. If you are developing or compiling software
+that wants to link against that library, then you need this package installed.
+
+Most people do not need this package installed.
+
+%package server
+Summary:	The bitcoin daemon
+Group:		System Environment/Daemons
+Requires:	bitcoin-utils = %{version}-%{release}
+Requires:	selinux-policy policycoreutils-python
+Requires(pre):	shadow-utils
+Requires(post):	%{_sbindir}/semodule %{_sbindir}/restorecon %{_sbindir}/fixfiles %{_sbindir}/sestatus
+Requires(postun):	%{_sbindir}/semodule %{_sbindir}/restorecon %{_sbindir}/fixfiles %{_sbindir}/sestatus
+BuildRequires:	systemd
+BuildRequires:	checkpolicy
+BuildRequires:	%{_datadir}/selinux/devel/Makefile
+
+%description server
+This package provides a stand-alone bitcoin-core daemon. For most users, this
+package is only needed if they need a full-node without the graphical client.
+
+Some third party wallet software will want this package to provide the actual
+bitcoin-core node they use to connect to the network.
+
+If you use the graphical bitcoin-core client then you almost certainly do not
+need this package.
+
+%package utils
+Summary:	Bitcoin utilities
+Group:		Applications/System
+
+%description utils
+This package provides several command line utilities for interacting with a
+bitcoin-core daemon.
+
+The bitcoin-cli utility allows you to communicate and control a bitcoin daemon
+over RPC, the bitcoin-tx utility allows you to create a custom transaction, and
+the bench_bitcoin utility can be used to perform some benchmarks.
+
+This package contains utilities needed by the bitcoin-server package.
+
+
+%prep
+%setup -q
+%patch0 -p1 -b .libressl
+cp -p %{SOURCE10} ./bitcoin.conf.example
+tar -zxf %{SOURCE1}
+cp -p db-%{bdbv}.NC/LICENSE ./db-%{bdbv}.NC-LICENSE
+mkdir db4 SELinux
+cp -p %{SOURCE30} %{SOURCE31} %{SOURCE32} SELinux/
+
+
+%build
+CWD=`pwd`
+cd db-%{bdbv}.NC/build_unix/
+../dist/configure --enable-cxx --disable-shared --with-pic --prefix=${CWD}/db4
+make install
+cd ../..
+
+./autogen.sh
+%configure LDFLAGS="-L${CWD}/db4/lib/" CPPFLAGS="-I${CWD}/db4/include/" --with-miniupnpc --enable-glibc-back-compat %{buildargs}
+make %{?_smp_mflags}
+
+pushd SELinux
+for selinuxvariant in %{selinux_variants}; do
+	make NAME=${selinuxvariant} -f %{_datadir}/selinux/devel/Makefile
+	mv bitcoin.pp bitcoin.pp.${selinuxvariant}
+	make NAME=${selinuxvariant} -f %{_datadir}/selinux/devel/Makefile clean
+done
+popd
+
+
+%install
+make install DESTDIR=%{buildroot}
+
+mkdir -p -m755 %{buildroot}%{_sbindir}
+mv %{buildroot}%{_bindir}/bitcoind %{buildroot}%{_sbindir}/bitcoind
+
+# systemd stuff
+mkdir -p %{buildroot}%{_tmpfilesdir}
+cat <<EOF > %{buildroot}%{_tmpfilesdir}/bitcoin.conf
+d /run/bitcoind 0750 bitcoin bitcoin -
+EOF
+touch -a -m -t 201504280000 %{buildroot}%{_tmpfilesdir}/bitcoin.conf
+
+mkdir -p %{buildroot}%{_sysconfdir}/sysconfig
+cat <<EOF > %{buildroot}%{_sysconfdir}/sysconfig/bitcoin
+# Provide options to the bitcoin daemon here, for example
+# OPTIONS="-testnet -disable-wallet"
+
+OPTIONS=""
+
+# System service defaults.
+# Don't change these unless you know what you're doing.
+CONFIG_FILE="%{_sysconfdir}/bitcoin/bitcoin.conf"
+DATA_DIR="%{_localstatedir}/lib/bitcoin"
+PID_FILE="/run/bitcoind/bitcoind.pid"
+EOF
+touch -a -m -t 201504280000 %{buildroot}%{_sysconfdir}/sysconfig/bitcoin
+
+mkdir -p %{buildroot}%{_unitdir}
+cat <<EOF > %{buildroot}%{_unitdir}/bitcoin.service
+[Unit]
+Description=Bitcoin daemon
+After=syslog.target network.target
+
+[Service]
+Type=forking
+ExecStart=%{_sbindir}/bitcoind -daemon -conf=\${CONFIG_FILE} -datadir=\${DATA_DIR} -pid=\${PID_FILE} \$OPTIONS
+EnvironmentFile=%{_sysconfdir}/sysconfig/bitcoin
+User=bitcoin
+Group=bitcoin
+
+Restart=on-failure
+PrivateTmp=true
+TimeoutStopSec=120
+TimeoutStartSec=60
+StartLimitInterval=240
+StartLimitBurst=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+touch -a -m -t 201504280000 %{buildroot}%{_unitdir}/bitcoin.service
+#end systemd stuff
+
+mkdir %{buildroot}%{_sysconfdir}/bitcoin
+mkdir -p %{buildroot}%{_localstatedir}/lib/bitcoin
+
+#SELinux
+for selinuxvariant in %{selinux_variants}; do
+	install -d %{buildroot}%{_datadir}/selinux/${selinuxvariant}
+	install -p -m 644 SELinux/bitcoin.pp.${selinuxvariant} %{buildroot}%{_datadir}/selinux/${selinuxvariant}/bitcoin.pp
+done
+
+%if %{_buildqt}
+# qt icons
+install -D -p share/pixmaps/bitcoin.ico %{buildroot}%{_datadir}/pixmaps/bitcoin.ico
+install -p share/pixmaps/nsis-header.bmp %{buildroot}%{_datadir}/pixmaps/
+install -p share/pixmaps/nsis-wizard.bmp %{buildroot}%{_datadir}/pixmaps/
+install -p %{SOURCE100} %{buildroot}%{_datadir}/pixmaps/bitcoin.svg
+%{_bindir}/inkscape %{SOURCE100} --export-png=%{buildroot}%{_datadir}/pixmaps/bitcoin16.png -w16 -h16
+%{_bindir}/inkscape %{SOURCE100} --export-png=%{buildroot}%{_datadir}/pixmaps/bitcoin32.png -w32 -h32
+%{_bindir}/inkscape %{SOURCE100} --export-png=%{buildroot}%{_datadir}/pixmaps/bitcoin64.png -w64 -h64
+%{_bindir}/inkscape %{SOURCE100} --export-png=%{buildroot}%{_datadir}/pixmaps/bitcoin128.png -w128 -h128
+%{_bindir}/inkscape %{SOURCE100} --export-png=%{buildroot}%{_datadir}/pixmaps/bitcoin256.png -w256 -h256
+%{_bindir}/convert -resize 16x16 %{buildroot}%{_datadir}/pixmaps/bitcoin256.png %{buildroot}%{_datadir}/pixmaps/bitcoin16.xpm
+%{_bindir}/convert -resize 32x32 %{buildroot}%{_datadir}/pixmaps/bitcoin256.png %{buildroot}%{_datadir}/pixmaps/bitcoin32.xpm
+%{_bindir}/convert -resize 64x64 %{buildroot}%{_datadir}/pixmaps/bitcoin256.png %{buildroot}%{_datadir}/pixmaps/bitcoin64.xpm
+%{_bindir}/convert -resize 128x128 %{buildroot}%{_datadir}/pixmaps/bitcoin256.png %{buildroot}%{_datadir}/pixmaps/bitcoin128.xpm
+%{_bindir}/convert %{buildroot}%{_datadir}/pixmaps/bitcoin256.png %{buildroot}%{_datadir}/pixmaps/bitcoin256.xpm
+touch %{buildroot}%{_datadir}/pixmaps/*.png -r %{SOURCE100}
+touch %{buildroot}%{_datadir}/pixmaps/*.xpm -r %{SOURCE100}
+
+# Desktop File - change the touch timestamp if modifying
+mkdir -p %{buildroot}%{_datadir}/applications
+cat <<EOF > %{buildroot}%{_datadir}/applications/bitcoin-core.desktop
+[Desktop Entry]
+Encoding=UTF-8
+Name=Bitcoin
+Comment=Bitcoin P2P Cryptocurrency
+Comment[fr]=Bitcoin, monnaie virtuelle cryptographique pair à pair
+Comment[tr]=Bitcoin, eşten eşe kriptografik sanal para birimi
+Exec=bitcoin-qt %u
+Terminal=false
+Type=Application
+Icon=bitcoin128
+MimeType=x-scheme-handler/bitcoin;
+Categories=Office;Finance;
+EOF
+# change touch date when modifying desktop
+touch -a -m -t 201511100546 %{buildroot}%{_datadir}/applications/bitcoin-core.desktop
+%{_bindir}/desktop-file-validate %{buildroot}%{_datadir}/applications/bitcoin-core.desktop
+
+# KDE protocol - change the touch timestamp if modifying
+mkdir -p %{buildroot}%{_datadir}/kde4/services
+cat <<EOF > %{buildroot}%{_datadir}/kde4/services/bitcoin-core.protocol
+[Protocol]
+exec=bitcoin-qt '%u'
+protocol=bitcoin
+input=none
+output=none
+helper=true
+listing=
+reading=false
+writing=false
+makedir=false
+deleting=false
+EOF
+# change touch date when modifying protocol
+touch -a -m -t 201511100546 %{buildroot}%{_datadir}/kde4/services/bitcoin-core.protocol
+%endif
+
+# man pages
+install -D -p %{SOURCE20} %{buildroot}%{_mandir}/man1/bitcoind.1
+install -p %{SOURCE21} %{buildroot}%{_mandir}/man1/bitcoin-cli.1
+%if %{_buildqt}
+install -p %{SOURCE22} %{buildroot}%{_mandir}/man1/bitcoin-qt.1
+%endif
+install -D -p %{SOURCE23} %{buildroot}%{_mandir}/man5/bitcoin.conf.5
+
+# nuke these, we do extensive testing of binaries in %%check before packaging
+rm -f %{buildroot}%{_bindir}/test_*
+
+%check
+make check
+pushd src
+srcdir=. test/bitcoin-util-test.py
+popd
+qa/pull-tester/rpc-tests.py -extended
+
+%post libs -p /sbin/ldconfig
+
+%postun libs -p /sbin/ldconfig
+
+%pre server
+getent group bitcoin >/dev/null || groupadd -r bitcoin
+getent passwd bitcoin >/dev/null ||
+	useradd -r -g bitcoin -d /var/lib/bitcoin -s /sbin/nologin \
+	-c "Bitcoin wallet server" bitcoin
+exit 0
+
+%post server
+%systemd_post bitcoin.service
+# SELinux
+if [ `%{_sbindir}/sestatus |grep -c "disabled"` -eq 0 ]; then
+for selinuxvariant in %{selinux_variants}; do
+	%{_sbindir}/semodule -s ${selinuxvariant} -i %{_datadir}/selinux/${selinuxvariant}/bitcoin.pp &> /dev/null || :
+done
+%{_sbindir}/semanage port -a -t bitcoin_port_t -p tcp 8332
+%{_sbindir}/semanage port -a -t bitcoin_port_t -p tcp 8333
+%{_sbindir}/semanage port -a -t bitcoin_port_t -p tcp 18332
+%{_sbindir}/semanage port -a -t bitcoin_port_t -p tcp 18333
+%{_sbindir}/fixfiles -R bitcoin-server restore &> /dev/null || :
+%{_sbindir}/restorecon -R %{_localstatedir}/lib/bitcoin || :
+fi
+
+%posttrans server
+%{_bindir}/systemd-tmpfiles --create
+
+%preun server
+%systemd_preun bitcoin.service
+
+%postun server
+%systemd_postun bitcoin.service
+# SELinux
+if [ $1 -eq 0 ]; then
+	if [ `%{_sbindir}/sestatus |grep -c "disabled"` -eq 0 ]; then
+	%{_sbindir}/semanage port -d -p tcp 8332
+	%{_sbindir}/semanage port -d -p tcp 8333
+	%{_sbindir}/semanage port -d -p tcp 18332
+	%{_sbindir}/semanage port -d -p tcp 18333
+	for selinuxvariant in %{selinux_variants}; do
+		%{_sbindir}/semodule -s ${selinuxvariant} -r bitcoin &> /dev/null || :
+	done
+	%{_sbindir}/fixfiles -R bitcoin-server restore &> /dev/null || :
+	[ -d %{_localstatedir}/lib/bitcoin ] && \
+		%{_sbindir}/restorecon -R %{_localstatedir}/lib/bitcoin &> /dev/null || :
+	fi
+fi
+
+%clean
+rm -rf %{buildroot}
+
+%if %{_buildqt}
+%files core
+%defattr(-,root,root,-)
+%license COPYING db-%{bdbv}.NC-LICENSE
+%doc COPYING bitcoin.conf.example doc/README.md doc/bips.md doc/files.md doc/multiwallet-qt.md doc/reduce-traffic.md doc/release-notes.md doc/tor.md
+%attr(0755,root,root) %{_bindir}/bitcoin-qt
+%attr(0644,root,root) %{_datadir}/applications/bitcoin-core.desktop
+%attr(0644,root,root) %{_datadir}/kde4/services/bitcoin-core.protocol
+%attr(0644,root,root) %{_datadir}/pixmaps/*.ico
+%attr(0644,root,root) %{_datadir}/pixmaps/*.bmp
+%attr(0644,root,root) %{_datadir}/pixmaps/*.svg
+%attr(0644,root,root) %{_datadir}/pixmaps/*.png
+%attr(0644,root,root) %{_datadir}/pixmaps/*.xpm
+%attr(0644,root,root) %{_mandir}/man1/bitcoin-qt.1*
+%endif
+
+%files libs
+%defattr(-,root,root,-)
+%license COPYING
+%doc COPYING doc/README.md doc/shared-libraries.md
+%{_libdir}/lib*.so.*
+
+%files devel
+%defattr(-,root,root,-)
+%license COPYING
+%doc COPYING doc/README.md doc/developer-notes.md doc/shared-libraries.md
+%attr(0644,root,root) %{_includedir}/*.h
+%{_libdir}/*.so
+%{_libdir}/*.a
+%{_libdir}/*.la
+%attr(0644,root,root) %{_libdir}/pkgconfig/*.pc
+
+%files server
+%defattr(-,root,root,-)
+%license COPYING db-%{bdbv}.NC-LICENSE
+%doc COPYING bitcoin.conf.example doc/README.md doc/REST-interface.md doc/bips.md doc/dnsseed-policy.md doc/files.md doc/reduce-traffic.md doc/release-notes.md doc/tor.md
+%attr(0755,root,root) %{_sbindir}/bitcoind
+%attr(0644,root,root) %{_tmpfilesdir}/bitcoin.conf
+%attr(0644,root,root) %{_unitdir}/bitcoin.service
+%dir %attr(0750,bitcoin,bitcoin) %{_sysconfdir}/bitcoin
+%dir %attr(0750,bitcoin,bitcoin) %{_localstatedir}/lib/bitcoin
+%config(noreplace) %attr(0600,root,root) %{_sysconfdir}/sysconfig/bitcoin
+%attr(0644,root,root) %{_datadir}/selinux/*/*.pp
+%attr(0644,root,root) %{_mandir}/man1/bitcoind.1*
+%attr(0644,root,root) %{_mandir}/man5/bitcoin.conf.5*
+
+%files utils
+%defattr(-,root,root,-)
+%license COPYING
+%doc COPYING bitcoin.conf.example doc/README.md
+%attr(0755,root,root) %{_bindir}/bitcoin-cli
+%attr(0755,root,root) %{_bindir}/bitcoin-tx
+%attr(0755,root,root) %{_bindir}/bench_bitcoin
+%attr(0644,root,root) %{_mandir}/man1/bitcoin-cli.1*
+%attr(0644,root,root) %{_mandir}/man5/bitcoin.conf.5*
+
+
+
+%changelog
+* Fri Feb 26 2016 Alice Wonder <buildmaster@librelamp.com> - 0.12.0-2
+- Rename Qt package from bitcoin to bitcoin-core
+- Make building of the Qt package optional
+- When building the Qt package, default to Qt5 but allow building
+-  against Qt4
+- Only run SELinux stuff in post scripts if it is not set to disabled
+
+* Wed Feb 24 2016 Alice Wonder <buildmaster@librelamp.com> - 0.12.0-1
+- Initial spec file for 0.12.0 release
+
+# This spec file is written from scratch but a lot of the packaging decisions are directly
+# based upon the 0.11.2 package spec file from https://www.ringingliberty.com/bitcoin/

--- a/contrib/rpm/bitcoin.te
+++ b/contrib/rpm/bitcoin.te
@@ -1,0 +1,81 @@
+policy_module(bitcoin, 1.100.1)
+
+########################################
+#
+# Declarations
+#
+
+type bitcoin_t;
+type bitcoin_exec_t;
+init_daemon_domain(bitcoin_t, bitcoin_exec_t)
+
+permissive bitcoin_t;
+
+type bitcoin_initrc_exec_t;
+init_script_file(bitcoin_initrc_exec_t)
+
+type bitcoin_conf_t;
+files_type(bitcoin_conf_t)
+
+type bitcoin_var_lib_t;
+files_type(bitcoin_var_lib_t)
+
+type bitcoin_var_run_t;
+files_type(bitcoin_var_run_t)
+
+type bitcoin_port_t;
+corenet_port(bitcoin_port_t)
+
+########################################
+#
+# bitcoin local policy
+#
+allow bitcoin_t self:process { fork };
+
+allow bitcoin_t self:fifo_file rw_fifo_file_perms;
+allow bitcoin_t self:unix_stream_socket create_stream_socket_perms;
+
+manage_dirs_pattern(bitcoin_t, bitcoin_conf_t, bitcoin_conf_t)
+manage_files_pattern(bitcoin_t, bitcoin_conf_t, bitcoin_conf_t)
+
+manage_dirs_pattern(bitcoin_t, bitcoin_var_lib_t, bitcoin_var_lib_t)
+manage_files_pattern(bitcoin_t, bitcoin_var_lib_t, bitcoin_var_lib_t)
+files_var_lib_filetrans(bitcoin_t, bitcoin_var_lib_t, { dir file })
+
+manage_dirs_pattern(bitcoin_t, bitcoin_var_run_t, bitcoin_var_run_t)
+manage_files_pattern(bitcoin_t, bitcoin_var_run_t, bitcoin_var_run_t)
+
+sysnet_dns_name_resolve(bitcoin_t)
+corenet_all_recvfrom_unlabeled(bitcoin_t)
+
+allow bitcoin_t self:tcp_socket create_stream_socket_perms;
+corenet_tcp_sendrecv_generic_if(bitcoin_t)
+corenet_tcp_sendrecv_generic_node(bitcoin_t)
+corenet_tcp_sendrecv_all_ports(bitcoin_t)
+corenet_tcp_bind_generic_node(bitcoin_t)
+
+gen_require(`
+    type bitcoin_port_t;
+')
+allow bitcoin_t bitcoin_port_t:tcp_socket name_bind;
+
+gen_require(`
+    type bitcoin_port_t;
+')
+allow bitcoin_t bitcoin_port_t:tcp_socket name_connect;
+
+domain_use_interactive_fds(bitcoin_t)
+
+files_read_etc_files(bitcoin_t)
+
+miscfiles_read_localization(bitcoin_t)
+
+sysnet_dns_name_resolve(bitcoin_t)
+
+allow bitcoin_t bitcoin_exec_t:file execute_no_trans;
+allow bitcoin_t self:process setsched;
+corecmd_exec_ls(bitcoin_t)
+corenet_tcp_connect_http_port(bitcoin_t)
+dev_read_urand(bitcoin_t)
+fs_getattr_xattr_fs(bitcoin_t)
+kernel_read_system_state(bitcoin_t)


### PR DESCRIPTION
This is an attempt at the former pull request - https://github.com/bitcoin/bitcoin/pull/7588#issuecomment-189379328 - as a single commit.

The RPM package manager is used by several Linux distributions.

This provides an RPM spec file that is clean and builds properly on CentOS 7 (RHEL 7 clone) and should hopefully easily facilitate building RPM packages on other platforms as well.

It defaults to building against OpenSSL and the Qt5 GUI toolkit, but it supports switches that allow easily building against LibreSSL and/or Qt4 and/no no GUI.

See the README.md file in the contrib/rpm directory for more details.
