### PR TITLE
[WIP] [wallet] Couple minimum change with minimum relay fee

### DIFF
--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -582,8 +582,7 @@ void CoinControlDialog::updateLabels(WalletModel *model, QDialog* dialog)
                 nChange -= nPayFee;
 
             // Never create dust outputs; if we would, just add the dust to the fee.
-            if (nChange > 0 && nChange < MIN_CHANGE)
-            {
+            if (nChange > 0 && nChange < model->getMinChange()) {
                 CTxOut txout(nChange, (CScript)std::vector<unsigned char>(24, 0));
                 if (txout.IsDust(::minRelayTxFee))
                 {

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -55,6 +55,11 @@ WalletModel::~WalletModel()
     unsubscribeFromCoreSignals();
 }
 
+CAmount WalletModel::getMinChange() const
+{
+    return wallet->GetMinChange();
+}
+
 CAmount WalletModel::getBalance(const CCoinControl *coinControl) const
 {
     if (coinControl)

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -130,6 +130,7 @@ public:
     TransactionTableModel *getTransactionTableModel();
     RecentRequestsTableModel *getRecentRequestsTableModel();
 
+    CAmount getMinChange() const;
     CAmount getBalance(const CCoinControl *coinControl = NULL) const;
     CAmount getUnconfirmedBalance() const;
     CAmount getImmatureBalance() const;

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -67,6 +67,9 @@ static bool equal_sets(CoinSet a, CoinSet b)
 
 BOOST_AUTO_TEST_CASE(coin_selection_tests)
 {
+    const CAmount MIN_CHANGE = wallet.GetMinChange();
+    BOOST_CHECK(MIN_CHANGE > 0);
+
     CoinSet setCoinsRet, setCoinsRet2;
     CAmount nValueRet;
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -45,8 +45,6 @@ static const CAmount DEFAULT_TRANSACTION_FEE = 0;
 static const CAmount DEFAULT_FALLBACK_FEE = 20000;
 //! -mintxfee default
 static const CAmount DEFAULT_TRANSACTION_MINFEE = 1000;
-//! minimum change amount
-static const CAmount MIN_CHANGE = CENT;
 //! Default for -spendzeroconfchange
 static const bool DEFAULT_SPEND_ZEROCONF_CHANGE = true;
 //! Default for -sendfreetransactions
@@ -735,6 +733,8 @@ public:
     void ReacceptWalletTransactions();
     void ResendWalletTransactions(int64_t nBestBlockTime);
     std::vector<uint256> ResendWalletTransactionsBefore(int64_t nTime);
+
+    CAmount GetMinChange() const;
     CAmount GetBalance() const;
     CAmount GetUnconfirmedBalance() const;
     CAmount GetImmatureBalance() const;


### PR DESCRIPTION
Coupling `MIN_CHANGE` with  the minimum relay fee (and thus dust) turns out to fix #6522.

Assuming that a user should be able to send a small amount even though their wallet consists of mostly small/dust inputs, I get

<img src="https://upload.wikimedia.org/math/5/e/a/5eaa9803b32f3f69f5489eae256545cb.png">

⇒ `MIN_CHANGE = ((DEFAULT_MIN_RELAY_TX_FEE/1000.) * MAX_STANDARD_TX_SIZE / COIN) = 0.001`
