### PR TITLE
[doc/log] Fix markdown syntax and line terminate LogPrint

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ out collectively by the network. Bitcoin Core is the name of open source
 software which enables the use of this currency.
 
 For more information, as well as an immediately useable, binary version of
-the Bitcoin Core software, see https://www.bitcoin.org/en/download, or read the
+the Bitcoin Core software, see https://bitcoin.org/en/download, or read the
 [original whitepaper](https://bitcoincore.org/bitcoin.pdf).
 
 License

--- a/contrib/verifysfbinaries/README.md
+++ b/contrib/verifysfbinaries/README.md
@@ -1,4 +1,4 @@
-### Verify SF Binaries ###
+### Verify Binaries ###
 This script attempts to download the signature file `SHA256SUMS.asc` from https://bitcoin.org.
 
 It first checks if the signature passes, and then downloads the files specified in the file, and checks if the hashes of these files match those that are specified in the signature file.

--- a/doc/README.md
+++ b/doc/README.md
@@ -49,7 +49,7 @@ The following are developer notes on how to build Bitcoin on your native platfor
 
 Development
 ---------------------
-The Bitcoin repo's [root README](https://github.com/bitcoin/bitcoin/blob/master/README.md) contains relevant information on the development process and automated testing.
+The Bitcoin repo's [root README](/README.md) contains relevant information on the development process and automated testing.
 
 - [Developer Notes](developer-notes.md)
 - [Multiwallet Qt Development](multiwallet-qt.md)

--- a/doc/release-notes/release-notes-0.12.0.md
+++ b/doc/release-notes/release-notes-0.12.0.md
@@ -99,7 +99,7 @@ Direct headers announcement (BIP 130)
 
 Between compatible peers, [BIP 130]
 (https://github.com/bitcoin/bips/blob/master/bip-0130.mediawiki)
-direct headers announcement is used. This means that blocks are advertized by
+direct headers announcement is used. This means that blocks are advertised by
 announcing their headers directly, instead of just announcing the hash. In a
 reorganization, all new headers are sent, instead of just the new tip. This
 can often prevent an extra roundtrip before the actual block is downloaded.
@@ -272,7 +272,7 @@ at all. Therefore, a fallback value can be set with `-fallbackfee=<f>`
 
 At all times, Bitcoin Core will cap fees at `-maxtxfee=<x>` (default:
 0.10) BTC.
-Furthermore, Bitcoin Core will never create transactions smaller than
+Furthermore, Bitcoin Core will never create transactions paying less than
 the current minimum relay fee.
 Finally, a user can set the minimum fee rate for all transactions with
 `-mintxfee=<i>`, which defaults to 1000 satoshis per kB.
@@ -701,7 +701,7 @@ git merge commit are mentioned.
 - #7112 `96b8025` reduce cs_main locks during tip update, more fluently update UI (Jonas Schnelli)
 - #7206 `f43c2f9` Add "NODE_BLOOM" to guiutil so that peers don't get UNKNOWN[4] (Matt Corallo)
 - #7282 `5cadf3e` fix coincontrol update issue when deleting a send coins entry (Jonas Schnelli)
-- #7319 `1320300` Intro: Display required space (Jonas Schnelli)
+- #7319 `1320300` Intro: Display required space (MarcoFalke)
 - #7318 `9265e89` quickfix for RPC timer interface problem (Jonas Schnelli)
 - #7327 `b16b5bc` [Wallet] Transaction View: LastMonth calculation fixed (crowning-)
 - #7364 `7726c48` [qt] Windows: Make rpcconsole monospace font larger (MarcoFalke)
@@ -841,7 +841,6 @@ Thanks to everyone who directly contributed to this release:
 - Kevin Cooper
 - lpescher
 - Luke Dashjr
-- Marco
 - MarcoFalke
 - Mark Friedenbach
 - Matt

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -210,7 +210,7 @@ Note: check that SHA256SUMS itself doesn't end up in SHA256SUMS, which is a spur
 
   - Optionally reddit /r/Bitcoin, ... but this will usually sort out itself
 
-- Notify BlueMatt so that he can start building [https://launchpad.net/~bitcoin/+archive/ubuntu/bitcoin](the PPAs)
+- Notify BlueMatt so that he can start building [the PPAs](https://launchpad.net/~bitcoin/+archive/ubuntu/bitcoin)
 
 - Add release notes for the new version to the directory `doc/release-notes` in git master
 

--- a/qa/rpc-tests/multi_rpc.py
+++ b/qa/rpc-tests/multi_rpc.py
@@ -44,7 +44,7 @@ class HTTPBasicsTest (BitcoinTestFramework):
         #Old authpair
         authpair = url.username + ':' + url.password
 
-        #New authpair generated via contrib/rpcuser tool
+        #New authpair generated via share/rpcuser tool
         rpcauth = "rpcauth=rt:93648e835a54c573682c2eb19f882535$7681e9c5b74bdd85e78166031d2058e1069b3ed7ed967c93fc63abba06f31144"
         password = "cA773lm788buwYe4g4WT+05pKyNruVKjQ25x3n0DQcM="
 

--- a/share/rpcuser/README.md
+++ b/share/rpcuser/README.md
@@ -7,5 +7,4 @@ Create an RPC user login credential.
 
 Usage:
 
-./rpcuser.py <username>
-
+    ./rpcuser.py <username>

--- a/src/httprpc.cpp
+++ b/src/httprpc.cpp
@@ -219,7 +219,7 @@ static bool InitRPCAuthentication()
             return false;
         }
     } else {
-        LogPrintf("Config options rpcuser and rpcpassword will soon be deprecated. Locally-run instances may remove rpcuser to use cookie-based auth, or may be replaced with rpcauth. Please see share/rpcuser for rpcauth auth generation.");
+        LogPrintf("Config options rpcuser and rpcpassword will soon be deprecated. Locally-run instances may remove rpcuser to use cookie-based auth, or may be replaced with rpcauth. Please see share/rpcuser for rpcauth auth generation.\n");
         strRPCUserColonPass = mapArgs["-rpcuser"] + ":" + mapArgs["-rpcpassword"];
     }
     return true;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -33,9 +33,7 @@
 
 using namespace std;
 
-/**
- * Settings
- */
+/** Transaction fee set by the user */
 CFeeRate payTxFee(DEFAULT_TRANSACTION_FEE);
 unsigned int nTxConfirmTarget = DEFAULT_TX_CONFIRM_TARGET;
 bool bSpendZeroConfChange = DEFAULT_SPEND_ZEROCONF_CHANGE;


### PR DESCRIPTION
- Fix three minor issues in the 0.12 historical release notes.
- Fix some links
- Yet another  #6497
