### PR TITLE
Add missing sudo entry in gitian VM setup.

### DIFF
--- a/doc/gitian-building.md
+++ b/doc/gitian-building.md
@@ -262,6 +262,7 @@ Then set up LXC and the rest with the following, which is a complex jumble of se
 # the version of lxc-start in Debian needs to run as root, so make sure
 # that the build script can execute it without providing a password
 echo "%sudo ALL=NOPASSWD: /usr/bin/lxc-start" > /etc/sudoers.d/gitian-lxc
+echo "%sudo ALL=NOPASSWD: /usr/bin/lxc-execute" >> /etc/sudoers.d/gitian-lxc
 # make /etc/rc.local script that sets up bridge between guest and host
 echo '#!/bin/sh -e' > /etc/rc.local
 echo 'brctl addbr br0' >> /etc/rc.local


### PR DESCRIPTION
Missing sudo entry in gitian setup results in unwanted password prompt. See the discussion [here](https://botbot.me/freenode/bitcoin-core-dev/2016-02-18/?msg=60419903&page=3).

Probably should backport to `0.12`.

[ci skip]
