### PR TITLE
Fixes ZMQ startup with bad arguments.

### DIFF
--- a/src/zmq/zmqnotificationinterface.cpp
+++ b/src/zmq/zmqnotificationinterface.cpp
@@ -100,7 +100,6 @@ bool CZMQNotificationInterface::Initialize()
 
     if (i!=notifiers.end())
     {
-        Shutdown();
         return false;
     }
 

--- a/src/zmq/zmqpublishnotifier.cpp
+++ b/src/zmq/zmqpublishnotifier.cpp
@@ -69,6 +69,7 @@ bool CZMQAbstractPublishNotifier::Initialize(void *pcontext)
         if (rc!=0)
         {
             zmqError("Failed to bind address");
+            zmq_close(psocket);
             return false;
         }
 


### PR DESCRIPTION
Fixes #7496.

A bad ZMQ argument caused the code to create a socket but not destroy it and later in the shutdown code, zmq_destroy() hangs as a result.

This also removes a gratuitous call to the Shutdown method of ZMQNotificationInterface; the code calls the destructor right after returning, which calls Shutdown.
