### PR TITLE
Increase DEFAULT_BLOCK_MAX_SIZE to 1MB

### DIFF
--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -15,7 +15,7 @@
 class CCoinsViewCache;
 
 /** Default for -blockmaxsize and -blockminsize, which control the range of sizes the mining code will create **/
-static const unsigned int DEFAULT_BLOCK_MAX_SIZE = 750000;
+static const unsigned int DEFAULT_BLOCK_MAX_SIZE = 1000000;
 static const unsigned int DEFAULT_BLOCK_MIN_SIZE = 0;
 /** Default for -blockprioritysize, maximum space for zero/low-fee transactions **/
 static const unsigned int DEFAULT_BLOCK_PRIORITY_SIZE = 0;


### PR DESCRIPTION
Currently, the maximum block size in Bitcoin Core is 1,000,000 bytes, or 1,000kB. There's been considerable debate about whether, how and when that limit should be raised. However, that is not the subject of this pull request.

Rather, this pull request concerns the maximum block size that miners will produce _by default_, which is 750kB. Unless the configuration is changed, a miner using Bitcoin Core will not produce blocks greater than this size, meaning that 250kB of potential block capacity will not be used.

While this might have been a reasonable default value in the past, it is now problematic. [Bitcoin's average block size has been steadily increasing and now usually surpasses 750kB.](https://blockchain.info/charts/avg-block-size) This means that miners which use the default block size pull down the number of transactions the Bitcoin network can process at once, increasing backlogs and making transactions slower and more expensive to process, which is not desirable to any party.

Now, almost all miners override this setting and go for a 1000kB maximum. However, a problem presents itself when miners upgrade their version of Bitcoin Core. This can sometimes result in them accidentally resetting this value, and starving the network of capacity. This is not a mere hypothetical situation, indeed it appears to have happened twice in the last week, with two of Bitcoin's largest mining pools, [BTCC](https://www.reddit.com/r/btc/comments/4863th/btcc_mining_with_a_soft_limit_of_731kb_what_is/?ref=search_posts) and [Antpool](https://www.reddit.com/r/Bitcoin/comments/48aay1/the_blamegame_is_antpool_deliberately_mining/) having apparently started capping their blocks at 750kB. It is very likely this happened due to accidentally resetting their maximum block size value when upgrading their Bitcoin Core nodes.

So, I would encourage you to merge this to avoid further unintentional network congestion.

Thanks!
