### PR TITLE
[Documentation] Add dependency info to test docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,10 @@ submit new unit tests for old code. Unit tests can be compiled and run
 
 There are also [regression and integration tests](/qa) of the RPC interface, written
 in Python, that are run automatically on the build server.
-These tests can be run with: `qa/pull-tester/rpc-tests.py`
+These tests can be run (if the [test dependencies](/qa) are installed) with: `qa/pull-tester/rpc-tests.py`
 
 The Travis CI system makes sure that every pull request is built for Windows
-and Linux, OSX, and that unit and sanity tests are automatically run.
+and Linux, OS X, and that unit and sanity tests are automatically run.
 
 ### Manual Quality Assurance (QA) Testing
 

--- a/qa/README.md
+++ b/qa/README.md
@@ -5,6 +5,17 @@ Every pull request to the bitcoin repository is built and run through
 the regression test suite. You can also run all or only individual
 tests locally.
 
+Test dependencies
+=================
+Before running the tests, the following must be installed.
+
+Unix
+----
+The python-zmq library is required. On Ubuntu or Debian it can be installed via: 
+```
+sudo apt-get install python-zmq
+```
+
 Running tests
 =============
 

--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -40,6 +40,15 @@ if not vars().has_key('ENABLE_UTILS'):
     ENABLE_UTILS=0
 if not vars().has_key('ENABLE_ZMQ'):
     ENABLE_ZMQ=0
+    
+# python-zmq may not be installed. Handle this gracefully and with some helpful info
+if ENABLE_ZMQ:
+    try:
+        import zmq
+    except ImportError:
+        print("WARNING: \"import zmq\" failed. Setting ENABLE_ZMQ=0. " \
+            "To run zmq tests, see dependency info in /qa/README.md.")
+        ENABLE_ZMQ=0
 
 ENABLE_COVERAGE=0
 


### PR DESCRIPTION
When following the build instructions and then trying to run the RPC tests, 
a unix user would get an error when python tried to import zmq.

This change updates the docs to let the user know how to install
the required dependencies before running the RPC tests.

There may be other dependencies that should be added to the docs,
particularly ones for non-unix systems. This is the only unlisted
dependency I encountered using linux.
