### PR TITLE
Removes forward slash (/) from user agent in peers tab UI.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4412,7 +4412,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
             vRecv >> addrFrom >> nNonce;
         if (!vRecv.empty()) {
             vRecv >> LIMITED_STRING(pfrom->strSubVer, MAX_SUBVERSION_LENGTH);
-            pfrom->cleanSubVer = SanitizeString(pfrom->strSubVer);
+            pfrom->cleanSubVer = SanitizeSubVersionString(pfrom->strSubVer);
         }
         if (!vRecv.empty())
             vRecv >> pfrom->nStartingHeight;

--- a/src/utilstrencodings.cpp
+++ b/src/utilstrencodings.cpp
@@ -33,6 +33,17 @@ string SanitizeString(const string& str, int rule)
     return strResult;
 }
 
+/// Formats the network peer user agent text (or subversion)
+/// by removing the begining and ending charactors(/).
+/// example: /Satoshi:0.11.2/ --> Satoshi:0.11.2
+string SanitizeSubVersionString(const string& str)
+{
+    string strResult = SanitizeString(str);
+    if ((strResult.length() > 3) && (strResult.substr(0,1) == "/") && (strResult.substr((strResult.length()-1),1) == "/"))
+        strResult = strResult.substr(1, (strResult.length() - 2));
+    return strResult;
+}
+
 const signed char p_util_hexdigit[256] =
 { -1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,
   -1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,

--- a/src/utilstrencodings.h
+++ b/src/utilstrencodings.h
@@ -37,6 +37,7 @@ enum SafeChars
 * @return           A new string without unsafe chars
 */
 std::string SanitizeString(const std::string& str, int rule = SAFE_CHARS_DEFAULT);
+std::string SanitizeSubVersionString(const std::string& str);
 std::vector<unsigned char> ParseHex(const char* psz);
 std::vector<unsigned char> ParseHex(const std::string& str);
 signed char HexDigit(char c);


### PR DESCRIPTION
Formats the network peer user agent text (or clean subversion) by removing the forward slash prefix and suffix.  Example: /Satoshi:0.11.2/ --> Satoshi:0.11.2

![bitcoin_useragent_before_better](https://cloud.githubusercontent.com/assets/13896934/13519050/57db30ee-e199-11e5-9946-59932aa27923.png)

The forward slashes in the User Agent text are occupying two spaces and seem unnecessary for the Qt wallet UI.

This code is forked from my original pull for Dark Silk:  https://github.com/SCDeveloper/DarkSilk-Release-Candidate/pull/138
