### PR TITLE
Prevent multiple calls to CWallet::AvailableCoins

### DIFF
--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -544,7 +544,7 @@ private:
      * all coins from coinControl are selected; Never select unconfirmed coins
      * if they are not ours
      */
-    bool SelectCoins(const CAmount& nTargetValue, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoinsRet, CAmount& nValueRet, const CCoinControl *coinControl = NULL) const;
+    bool SelectCoins(const std::vector<COutput>& vAvailableCoins, const CAmount& nTargetValue, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoinsRet, CAmount& nValueRet, const CCoinControl *coinControl = NULL) const;
 
     CWalletDB *pwalletdbEncryption;
 


### PR DESCRIPTION
`CWallet::CreateTransaction` goes through several iterations to select the best coins and fee to fulfil the request. In each iteration the set of available coins is computed.

This PR moves the computation of available coins to the begin and reuses it in each iteration.
