### PR TITLE
Only need to subtract 1 (originally nNow was in seconds).

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2450,7 +2450,7 @@ void CNode::AskFor(const CInv& inv)
     LogPrint("net", "askfor %s  %d (%s) peer=%d\n", inv.ToString(), nRequestTime, DateTimeStrFormat("%H:%M:%S", nRequestTime/1000000), id);
 
     // Make sure not to reuse time indexes to keep things in the same order
-    int64_t nNow = GetTimeMicros() - 1000000;
+    int64_t nNow = GetTimeMicros() - 1;
     static int64_t nLastTime;
     ++nLastTime;
     nNow = std::max(nNow, nLastTime);


### PR DESCRIPTION
This pull is is a minor nitpick.

When the variable went from seconds to microseconds, this number didn't need to change from 1 to 10,000. It was enough to subtract 1 in order not to reuse time indexes. Perhaps, since moving to microseconds, there may not need to be any subtraction, but for safety, keeping this in.

Replaces #4828
