### PR TITLE
Node id when misbehaving

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1614,12 +1614,12 @@ void Misbehaving(NodeId pnode, int howmuch)
 
     state->nMisbehavior += howmuch;
     int banscore = GetArg("-banscore", DEFAULT_BANSCORE_THRESHOLD);
-    if (state->nMisbehavior >= banscore && state->nMisbehavior - howmuch < banscore)
+    if (state->nMisbehavior >= banscore && !state->fShouldBan)
     {
-        LogPrintf("%s: %s (%d -> %d) BAN THRESHOLD EXCEEDED\n", __func__, state->name, state->nMisbehavior-howmuch, state->nMisbehavior);
+        LogPrintf("%s: peer=%d (%d -> %d) BAN THRESHOLD EXCEEDED\n", __func__, state->id, state->nMisbehavior-howmuch, state->nMisbehavior);
         state->fShouldBan = true;
     } else
-        LogPrintf("%s: %s (%d -> %d)\n", __func__, state->name, state->nMisbehavior-howmuch, state->nMisbehavior);
+        LogPrintf("%s: peer=%d (%d -> %d)\n", __func__, state->id, state->nMisbehavior-howmuch, state->nMisbehavior);
 }
 
 void static InvalidChainFound(CBlockIndex* pindexNew)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -240,6 +240,8 @@ struct CNodeState {
     int nMisbehavior;
     //! Whether this peer should be disconnected and banned (unless whitelisted).
     bool fShouldBan;
+    //! NodeId of this peer (debugging/logging purposes).
+    NodeId id;
     //! String name of this peer (debugging/logging purposes).
     std::string name;
     //! List of asynchronously-determined block rejections to notify this peer about.
@@ -319,6 +321,7 @@ void InitializeNode(NodeId nodeid, const CNode *pnode) {
     CNodeState &state = mapNodeState.insert(std::make_pair(nodeid, CNodeState())).first->second;
     state.name = pnode->addrName;
     state.address = pnode->addr;
+    state.id = pnode->id;
 }
 
 void FinalizeNode(NodeId nodeid) {


### PR DESCRIPTION
Displays peer number when a peer is misbehaving. Also, allows logging in situations where a node which has reached it's exceeded allowance of misbehaviour fails to be disconnected.
