### PR TITLE
Add curl to Gitian setup instructions

### DIFF
--- a/doc/gitian-building.md
+++ b/doc/gitian-building.md
@@ -252,7 +252,7 @@ First we need to log in as `root` to set up dependencies and make sure that our
 user can use the sudo command. Type/paste the following in the terminal:
 
 ```bash
-apt-get install git ruby sudo apt-cacher-ng qemu-utils debootstrap lxc python-cheetah parted kpartx bridge-utils make ubuntu-archive-keyring
+apt-get install git ruby sudo apt-cacher-ng qemu-utils debootstrap lxc python-cheetah parted kpartx bridge-utils make ubuntu-archive-keyring curl
 adduser debian sudo
 ```
 


### PR DESCRIPTION
curl is required to fetch dependencies

requires backport to all branches

[ci skip]
