### PR TITLE
[amount] Extend GetFee() by optional flag ceil

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -38,6 +38,7 @@ BITCOIN_TESTS =\
   test/scriptnum10.h \
   test/addrman_tests.cpp \
   test/alert_tests.cpp \
+  test/amount_tests.cpp \
   test/allocator_tests.cpp \
   test/base32_tests.cpp \
   test/base58_tests.cpp \

--- a/src/amount.cpp
+++ b/src/amount.cpp
@@ -3,6 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <cmath>
+
 #include "amount.h"
 
 #include "tinyformat.h"
@@ -17,14 +19,12 @@ CFeeRate::CFeeRate(const CAmount& nFeePaid, size_t nSize)
         nSatoshisPerK = 0;
 }
 
-CAmount CFeeRate::GetFee(size_t nSize) const
+CAmount CFeeRate::GetFee(size_t nSize, bool ceil) const
 {
-    CAmount nFee = nSatoshisPerK*nSize / 1000;
-
-    if (nFee == 0 && nSatoshisPerK > 0)
-        nFee = nSatoshisPerK;
-
-    return nFee;
+    if (ceil)
+        return (CAmount)std::ceil(nSatoshisPerK * nSize / 1000.);
+    else
+        return nSatoshisPerK * nSize / 1000;
 }
 
 std::string CFeeRate::ToString() const

--- a/src/amount.h
+++ b/src/amount.h
@@ -42,10 +42,14 @@ public:
     explicit CFeeRate(const CAmount& _nSatoshisPerK): nSatoshisPerK(_nSatoshisPerK) { }
     CFeeRate(const CAmount& nFeePaid, size_t nSize);
     CFeeRate(const CFeeRate& other) { nSatoshisPerK = other.nSatoshisPerK; }
-
-    CAmount GetFee(size_t size) const; // unit returned is satoshis
-    CAmount GetFeePerK() const { return GetFee(1000); } // satoshis-per-1000-bytes
-
+    /**
+     * Return the fee in satoshis for the given size in bytes.
+     */
+    CAmount GetFee(size_t size, bool ceil = false) const;
+    /**
+     * Return the fee in satoshis for a size of 1000 bytes
+     */
+    CAmount GetFeePerK() const { return nSatoshisPerK; }
     friend bool operator<(const CFeeRate& a, const CFeeRate& b) { return a.nSatoshisPerK < b.nSatoshisPerK; }
     friend bool operator>(const CFeeRate& a, const CFeeRate& b) { return a.nSatoshisPerK > b.nSatoshisPerK; }
     friend bool operator==(const CFeeRate& a, const CFeeRate& b) { return a.nSatoshisPerK == b.nSatoshisPerK; }

--- a/src/test/amount_tests.cpp
+++ b/src/test/amount_tests.cpp
@@ -1,0 +1,53 @@
+// Copyright (c) 2016 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "amount.h"
+#include "test/test_bitcoin.h"
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(amount_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(GetFeeTest)
+{
+    CFeeRate feeRate;
+
+    feeRate = CFeeRate(1000);
+    // Must always just return the arg
+    BOOST_CHECK_EQUAL(feeRate.GetFee(0), 0);
+    BOOST_CHECK_EQUAL(feeRate.GetFee(1), 1);
+    BOOST_CHECK_EQUAL(feeRate.GetFee(121), 121);
+    BOOST_CHECK_EQUAL(feeRate.GetFee(999), 999);
+    BOOST_CHECK_EQUAL(feeRate.GetFee(1e3), 1e3);
+
+    feeRate = CFeeRate(123);
+    // Truncates the result, if not integer
+    BOOST_CHECK_EQUAL(feeRate.GetFee(0), 0);
+    BOOST_CHECK_EQUAL(feeRate.GetFee(8), 0);
+    BOOST_CHECK_EQUAL(feeRate.GetFee(9), 1);
+    BOOST_CHECK_EQUAL(feeRate.GetFee(121), 14);
+    BOOST_CHECK_EQUAL(feeRate.GetFee(122), 15);
+    BOOST_CHECK_EQUAL(feeRate.GetFee(999), 122);
+    BOOST_CHECK_EQUAL(feeRate.GetFee(1e3), 123);
+
+    feeRate = CFeeRate(1000);
+    // Must always return the arg
+    BOOST_CHECK_EQUAL(feeRate.GetFee(0, true), 0);
+    BOOST_CHECK_EQUAL(feeRate.GetFee(1, true), 1);
+    BOOST_CHECK_EQUAL(feeRate.GetFee(121, true), 121);
+    BOOST_CHECK_EQUAL(feeRate.GetFee(999, true), 999);
+    BOOST_CHECK_EQUAL(feeRate.GetFee(1e3, true), 1e3);
+
+    feeRate = CFeeRate(123);
+    // Applies ceil to the result
+    BOOST_CHECK_EQUAL(feeRate.GetFee(0, true), 0);
+    BOOST_CHECK_EQUAL(feeRate.GetFee(8, true), 1);
+    BOOST_CHECK_EQUAL(feeRate.GetFee(9, true), 2);
+    BOOST_CHECK_EQUAL(feeRate.GetFee(121, true), 15);
+    BOOST_CHECK_EQUAL(feeRate.GetFee(122, true), 16);
+    BOOST_CHECK_EQUAL(feeRate.GetFee(999, true), 123);
+    BOOST_CHECK_EQUAL(feeRate.GetFee(1e3, true), 123);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
- This flag causes rounding up to the next satoshi instead of just
  truncating (default behavior)
- This reverts the hard-to-read and buggy code introduced in
  d88af560111863c3e9c1ae855dcc287f04dffb02 (#4465)

`master` happily produces the following results:

``` cpp
    feeRate = CFeeRate(123);
    BOOST_CHECK_EQUAL(feeRate.GetFee(0), 123);   // TODO: Should be 0
    BOOST_CHECK_EQUAL(feeRate.GetFee(8), 123);   // TODO: Should be 1
    BOOST_CHECK_EQUAL(feeRate.GetFee(9), 1);     // TODO: Should be 2
    BOOST_CHECK_EQUAL(feeRate.GetFee(121), 14);  // TODO: Should be 15
    BOOST_CHECK_EQUAL(feeRate.GetFee(122), 15);  // TODO: Should be 16
    BOOST_CHECK_EQUAL(feeRate.GetFee(999), 122); // TODO: Should be 123
```
