### PR TITLE
Make the generate RPC call function for non-regtest

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -30,6 +30,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "setgenerate", 0 },
     { "setgenerate", 1 },
     { "generate", 0 },
+    { "generate", 1 },
     { "getnetworkhashps", 0 },
     { "getnetworkhashps", 1 },
     { "sendtoaddress", 1 },


### PR DESCRIPTION
This complements #7507, allowing external scripts to take over the function of the internal `setgenerate` miner.
