### PR TITLE
Contrib: Introduce script to tag compiled binaries for convenience (py)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.tar.gz
 
 *.exe
+bin/
 src/bitcoin
 src/bitcoind
 src/bitcoin-cli

--- a/contrib/devtools/README.md
+++ b/contrib/devtools/README.md
@@ -2,6 +2,46 @@ Contents
 ========
 This directory contains tools for developers working on this repository.
 
+archive-binaries.py
+===============
+
+Script to copy all the binaries (bitcoind, bitcoin-tx, bitcoin-cli,
+qt/bitcoin-qt) to a bin and bin/qt directories (assumed to exist in
+the calling directory), appending the last commit id (and optionally
+an arbitrary string before the commit id passed ar parameter before
+the commit id) to the file name. 
+
+This way one can keep a collection of binaries for many different
+branches for testing (while clearly ditinguishing which is which).
+
+Example usage:
+
+```
+git fetch origin
+git checkout origin/v0.12.0
+make check -j21
+python contrib/devtools/archive-binaries.py v0.12.0
+./bin/bitcoind-v0.12.0-188ca9c
+
+git checkout origin/master
+./autogen.sh
+./configure
+make check -j21
+python contrib/devtools/archive-binaries.py master
+./bin/bitcoind-master-c8d2473
+```
+
+Later one can test or use previously tagged binaries without building or even being on that branch:
+
+```
+git checkout origin/v0.11.0
+./autogen.sh
+./configure
+make check -j21
+./bin/bitcoind-v0.12.0-188ca9c
+./bin/bitcoind-master-c8d2473
+```
+
 check-doc.py
 ============
 

--- a/contrib/devtools/README.md
+++ b/contrib/devtools/README.md
@@ -24,6 +24,7 @@ python contrib/devtools/archive-binaries.py v0.12.0
 ./bin/bitcoind-v0.12.0-188ca9c
 
 git checkout origin/master
+git clean -fdx -e bin/
 ./autogen.sh
 ./configure
 make check -j21

--- a/contrib/devtools/archive-binaries.py
+++ b/contrib/devtools/archive-binaries.py
@@ -16,24 +16,31 @@ import subprocess
 
 SRC = 'src/'
 TARGET = 'bin/'
-BINARIES = ['bitcoind', 'bitcoin-tx', 'bitcoin-cli', 'qt/bitcoin-qt'] # TODO libconsensus?
+BINARY_PATTERNS = ['%sd', '%s-tx', '%s-cli', 'qt/%s-qt']
+
+def GetArg(argv, pos, default):
+    if (argv and len(argv) > pos and argv[pos]):
+        return argv[pos]
+    else:
+        return default
 
 def run_copy_tagged_binary(src, target):
     print "Copying " + src + " to " + target
     subprocess.check_call(['cp', src, target])
 
-def loop_copy_tagged_binaries(binaries, petname):
+def loop_copy_tagged_binaries(binaries, petname, exec_name):
     last_commit = os.popen('git log -n 1 --format="%H"').read()[0:7]
-    for binary in binaries:
+    for binary_pattern in binaries:
+        binary = binary_pattern % exec_name
         run_copy_tagged_binary(SRC + binary, TARGET + binary + petname + '-' + last_commit)
 
 def main(argv):
-    if (argv and len(argv) > 1 and argv[1]):
-        petname = '-' + argv[1]
-    else:
-        petname = ''
+    petname = GetArg(argv, 1, '')
+    if len(petname) > 0:
+        petname = '-' +petname
+    exec_name = GetArg(argv, 2, 'bitcoin')
 
-    loop_copy_tagged_binaries(BINARIES, petname)
+    loop_copy_tagged_binaries(BINARY_PATTERNS, petname, exec_name)
 
 if __name__ == "__main__":
     main(sys.argv)

--- a/contrib/devtools/archive-binaries.py
+++ b/contrib/devtools/archive-binaries.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+'''
+Copyright (c) 2016 Jorge Timon
+Copyright (c) 2016 The Bitcoin Core developers
+Distributed under the MIT software license, see the accompanying
+file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+Script to copy all the binaries to a bin dir appending the last commit id and optionally a petname to the file name.
+Optional parameter: an arbitrary string before the commit id.
+Preconditions: Assumes bin and bin/qt dirs in calling dir.
+'''
+
+import os
+import sys
+import subprocess
+
+SRC = 'src/'
+TARGET = 'bin/'
+BINARIES = ['bitcoind', 'bitcoin-tx', 'bitcoin-cli', 'qt/bitcoin-qt'] # TODO libconsensus?
+
+def run_copy_tagged_binary(src, target):
+    print "Copying " + src + " to " + target
+    subprocess.check_call(['cp', src, target])
+
+def loop_copy_tagged_binaries(binaries, petname):
+    last_commit = os.popen('git log -n 1 --format="%H"').read()[0:7]
+    for binary in binaries:
+        run_copy_tagged_binary(SRC + binary, TARGET + binary + petname + '-' + last_commit)
+
+def main(argv):
+    if (argv and len(argv) > 1 and argv[1]):
+        petname = '-' + argv[1]
+    else:
+        petname = ''
+
+    loop_copy_tagged_binaries(BINARIES, petname)
+
+if __name__ == "__main__":
+    main(sys.argv)


### PR DESCRIPTION
The basic goal is to make it easier to avoid recompiling branches that have been compiled already.

I felt I needed to incorporate something like this to my workflow.
If it is not useful for bitcoin, I'm happy to propose it on elements, freicoin or just keep it to myself.
Still putting it here just in case.

Example usage (with the appropriate bitcoin/.git/config):

```
git fetch origin
git checkout origin/v0.12.0
make check -j21
python contrib/devtools/tag-binaries.py v0.12.0

git checkout origin/master
make check -j21
python contrib/devtools/tag-binaries.py master
```

Non-bitcoin examples:

```
git fetch elements
git checkout elements/alpha
make check -j21
python contrib/devtools/tag-binaries.py alpha

git checkout jtimon/jt
make clean
make check -j21
python contrib/devtools/tag-binaries.py jt

git fetch freicoin
git checkout freicoin/master
git clean -fdx
./autogen.sh
./configure
make check -j21
python contrib/devtools/tag-binaries.py freicoin

git fetch elements
git checkout elements/pre-gamma
git clean -fdx
./autogen.sh
./configure
make check -j21
python contrib/devtools/tag-binaries.py pre-gamma
```
