### PR TITLE
Move GetTempPath() to testutil

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -78,6 +78,8 @@ BITCOIN_TESTS =\
   test/streams_tests.cpp \
   test/test_bitcoin.cpp \
   test/test_bitcoin.h \
+  test/testutil.cpp \
+  test/testutil.h \
   test/timedata_tests.cpp \
   test/transaction_tests.cpp \
   test/txvalidationcache_tests.cpp \

--- a/src/test/alert_tests.cpp
+++ b/src/test/alert_tests.cpp
@@ -12,9 +12,9 @@
 #include "main.h" // For PartitionCheck
 #include "serialize.h"
 #include "streams.h"
-#include "util.h"
 #include "utilstrencodings.h"
 
+#include "test/testutil.h"
 #include "test/test_bitcoin.h"
 
 #include <fstream>

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -17,11 +17,12 @@
 #include "txdb.h"
 #include "txmempool.h"
 #include "ui_interface.h"
-#include "util.h"
 #ifdef ENABLE_WALLET
 #include "wallet/db.h"
 #include "wallet/wallet.h"
 #endif
+
+#include "test/testutil.h"
 
 #include <boost/filesystem.hpp>
 #include <boost/test/unit_test.hpp>

--- a/src/test/testutil.cpp
+++ b/src/test/testutil.cpp
@@ -1,3 +1,33 @@
 // Copyright (c) 2009-2016 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "testutil.h"
+
+#ifdef WIN32
+#include <shlobj.h>
+#endif
+
+#include <boost/filesystem.hpp>
+
+boost::filesystem::path GetTempPath() {
+#if BOOST_FILESYSTEM_VERSION == 3
+    return boost::filesystem::temp_directory_path();
+#else
+    // TODO: remove when we don't support filesystem v2 anymore
+    boost::filesystem::path path;
+#ifdef WIN32
+    char pszPath[MAX_PATH] = "";
+
+    if (GetTempPathA(MAX_PATH, pszPath))
+        path = boost::filesystem::path(pszPath);
+#else
+    path = boost::filesystem::path("/tmp");
+#endif
+    if (path.empty() || !boost::filesystem::is_directory(path)) {
+        LogPrintf("GetTempPath(): failed to find temp path\n");
+        return boost::filesystem::path("");
+    }
+    return path;
+#endif
+}

--- a/src/test/testutil.cpp
+++ b/src/test/testutil.cpp
@@ -1,0 +1,3 @@
+// Copyright (c) 2009-2016 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.

--- a/src/test/testutil.h
+++ b/src/test/testutil.h
@@ -1,0 +1,11 @@
+// Copyright (c) 2009-2016 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+/**
+ * Utility functions shared by unit tests
+ */
+#ifndef BITCOIN_TEST_TESTUTIL_H
+#define BITCOIN_TEST_TESTUTIL_H
+
+#endif // BITCOIN_TEST_TESTUTIL_H

--- a/src/test/testutil.h
+++ b/src/test/testutil.h
@@ -8,4 +8,8 @@
 #ifndef BITCOIN_TEST_TESTUTIL_H
 #define BITCOIN_TEST_TESTUTIL_H
 
+#include <boost/filesystem/path.hpp>
+
+boost::filesystem::path GetTempPath();
+
 #endif // BITCOIN_TEST_TESTUTIL_H

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -738,28 +738,6 @@ boost::filesystem::path GetSpecialFolderPath(int nFolder, bool fCreate)
 }
 #endif
 
-boost::filesystem::path GetTempPath() {
-#if BOOST_FILESYSTEM_VERSION == 3
-    return boost::filesystem::temp_directory_path();
-#else
-    // TODO: remove when we don't support filesystem v2 anymore
-    boost::filesystem::path path;
-#ifdef WIN32
-    char pszPath[MAX_PATH] = "";
-
-    if (GetTempPathA(MAX_PATH, pszPath))
-        path = boost::filesystem::path(pszPath);
-#else
-    path = boost::filesystem::path("/tmp");
-#endif
-    if (path.empty() || !boost::filesystem::is_directory(path)) {
-        LogPrintf("GetTempPath(): failed to find temp path\n");
-        return boost::filesystem::path("");
-    }
-    return path;
-#endif
-}
-
 void runCommand(const std::string& strCommand)
 {
     int nErr = ::system(strCommand.c_str());

--- a/src/util.h
+++ b/src/util.h
@@ -133,7 +133,6 @@ void ReadConfigFile(std::map<std::string, std::string>& mapSettingsRet, std::map
 #ifdef WIN32
 boost::filesystem::path GetSpecialFolderPath(int nFolder, bool fCreate = true);
 #endif
-boost::filesystem::path GetTempPath();
 void OpenDebugLog();
 void ShrinkDebugFile();
 void runCommand(const std::string& strCommand);


### PR DESCRIPTION
Addresses https://github.com/bitcoin/bitcoin/issues/6702 and https://github.com/bitcoin/bitcoin/issues/6701.

This pull request creates a new source file for test utils, and moves GetTempPath() from util to testutil.

This is because per the above issues, GetTempPath() is insecure and has unchecked error conditions, making it unsuitable for use in production code. GetTempPath() is only used in the unit tests and not used anywhere in the main code, so it would be a good idea to move this to the test suite so that no one tries to use this in the future and it's not mixed with production code.
