### PR TITLE
Fix torcontrol.cpp unused private field warning

### DIFF
--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -393,8 +393,8 @@ private:
     static void reconnect_cb(evutil_socket_t fd, short what, void *arg);
 };
 
-TorController::TorController(struct event_base* base, const std::string& target):
-    base(base),
+TorController::TorController(struct event_base* baseIn, const std::string& target):
+    base(baseIn),
     target(target), conn(base), reconnect(true), reconnect_ev(0),
     reconnect_timeout(RECONNECT_TIMEOUT_START)
 {


### PR DESCRIPTION
Should solve the following warning, though I think the warning could be a false positive because of the constructor initialization (`orController::TorController(struct event_base* base, const std::string& target):
    base(base)`):

`torcontrol.cpp:365:24: warning: private field 'base' is not used [-Wunused-private-field]`
