### PR TITLE
Add bloom filter usage statistics

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6070,6 +6070,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
             delete pfrom->pfilter;
             pfrom->pfilter = new CBloomFilter(filter);
             pfrom->pfilter->UpdateEmptyFull();
+            pfrom->FilterStatsCountFilterLoad();
         }
         pfrom->fRelayTxes = true;
     }
@@ -6597,7 +6598,7 @@ bool SendMessages(CNode* pto)
                 }
 
                 LOCK(pto->cs_filter);
-
+                int64_t nStart = GetTimeMillis();
                 for (const auto& txinfo : vtxinfo) {
                     const uint256& hash = txinfo.tx->GetHash();
                     CInv inv(MSG_TX, hash);
@@ -6617,7 +6618,7 @@ bool SendMessages(CNode* pto)
                     }
                     if (pto->pfilter) {
                         // collect statistics of mempool filter interaction
-                        CNode::FilterStatsProcessMempoolPoll(vtxid.size(), GetTimeMillis() - nStart);
+                        CNode::FilterStatsProcessMempoolPoll(vtxinfo.size(), GetTimeMillis() - nStart);
                     }
                 }
                 pto->timeLastMempoolReq = GetTime();

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -339,7 +339,7 @@ uint64_t CNode::nMaxOutboundCycleStartTime = 0;
 
 CCriticalSection CNode::cs_globalFilterStats;
 uint64_t CNode::nTimeFilterStatsStart = GetTime();
-uint64_t CNode::nTimeframeFilter = 3600; //1 h
+uint64_t CNode::nTimeframeFilter = 60*60*24; //1 day
 NodeFilterStats CNode::globalFilterStats;
 
 CNode* FindNode(const CNetAddr& ip)
@@ -1092,6 +1092,10 @@ static void AcceptConnection(const ListenSocket& hListenSocket) {
         LOCK(cs_vNodes);
         vNodes.push_back(pnode);
     }
+
+    // increase the total amount of connected nodes counter
+    CNode::FilterStatsCountNewNodeConnected();
+    
 }
 
 void ThreadSocketHandler()
@@ -2365,6 +2369,22 @@ void CNode::FilterStatsProcessMempoolPoll(uint64_t amountOfTransactions, int64_t
     globalFilterStats.nFilterMempoolCountInCycle.second++;
     globalFilterStats.nFilterMempoolTimeCountInCycle.second += processTime;
     globalFilterStats.nFilterMempoolDataCountInCycle.second += amountOfTransactions;
+}
+
+void CNode::FilterStatsCountNewNodeConnected()
+{
+    LOCK(cs_globalFilterStats);
+
+    FilterStatsCheckTimeframe();
+    globalFilterStats.nTotalNodesConnected.second++;
+}
+
+void CNode::FilterStatsCountFilterLoad()
+{
+    LOCK(cs_globalFilterStats);
+
+    FilterStatsCheckTimeframe();
+    globalFilterStats.nTotalNodesRequestedFiltering.second++;
 }
 
 const NodeFilterStats CNode::FilterStatsGetGlobalStats()

--- a/src/net.h
+++ b/src/net.h
@@ -11,6 +11,7 @@
 #include "compat.h"
 #include "limitedmap.h"
 #include "netaddress.h"
+#include "primitives/block.h"
 #include "protocol.h"
 #include "random.h"
 #include "streams.h"
@@ -315,6 +316,18 @@ public:
     }
 };
 
+typedef std::pair<uint64_t, uint64_t> filterDataset;
+
+struct NodeFilterStats
+{
+    filterDataset nFilterBlockCountInCycle;
+    filterDataset nFilterBlockDataCountInCycle;
+    filterDataset nFilterBlockTimeCountInCycle;
+    filterDataset nFilterMempoolCountInCycle;
+    filterDataset nFilterMempoolDataCountInCycle;
+    filterDataset nFilterMempoolTimeCountInCycle;
+};
+
 typedef std::map<CSubNet, CBanEntry> banmap_t;
 
 /** Information about a peer */
@@ -461,6 +474,13 @@ private:
     static uint64_t nMaxOutboundCycleStartTime;
     static uint64_t nMaxOutboundLimit;
     static uint64_t nMaxOutboundTimeframe;
+
+    // filter stats
+    static CCriticalSection cs_globalFilterStats;
+    static uint64_t nTimeFilterStatsStart;
+    static uint64_t nTimeframeFilter;
+    static NodeFilterStats globalFilterStats;
+    static void FilterStatsCheckTimeframe();
 
     CNode(const CNode&);
     void operator=(const CNode&);
@@ -812,6 +832,25 @@ public:
     //!response the time in second left in the current max outbound cycle
     // in case of no limit, it will always response 0
     static uint64_t GetMaxOutboundTimeLeftInCycle();
+
+    //!response the elapsed time in the measurement timeframe
+    static uint64_t FilterStatsGetTimeInCycle();
+
+    //!response the size of the measurement timeframe
+    static uint64_t FilterStatsGetTimeframe();
+
+    //!Collects statistics over the process of filtering a block
+    static void FilterStatsProcessBlock(const CBlock &block, int64_t processTime);
+
+    //!Collects statistics over the process of filtering the mempool content
+    static void FilterStatsProcessMempoolPoll(uint64_t amountOfTransactions, int64_t processTime);
+
+    //!Copy the filter stats struct
+    static const NodeFilterStats FilterStatsGetGlobalStats();
+
+    //!Get the current timeframe value of a dataset
+    //   if total == true, the total amount since startup will be reported
+    static uint64_t FilterStatsGetValue(const filterDataset datapair, bool total = false);
 };
 
 

--- a/src/net.h
+++ b/src/net.h
@@ -320,6 +320,8 @@ typedef std::pair<uint64_t, uint64_t> filterDataset;
 
 struct NodeFilterStats
 {
+    filterDataset nTotalNodesConnected;
+    filterDataset nTotalNodesRequestedFiltering;
     filterDataset nFilterBlockCountInCycle;
     filterDataset nFilterBlockDataCountInCycle;
     filterDataset nFilterBlockTimeCountInCycle;
@@ -844,6 +846,12 @@ public:
 
     //!Collects statistics over the process of filtering the mempool content
     static void FilterStatsProcessMempoolPoll(uint64_t amountOfTransactions, int64_t processTime);
+
+    //!Collects statistics of how many nodes have been connected to us
+    static void FilterStatsCountNewNodeConnected();
+
+    //!Collects statistics of how many nodes have been set a filter
+    static void FilterStatsCountFilterLoad();
 
     //!Copy the filter stats struct
     static const NodeFilterStats FilterStatsGetGlobalStats();

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -574,6 +574,76 @@ UniValue clearbanned(const UniValue& params, bool fHelp)
     return NullUniValue;
 }
 
+UniValue getfilterstats(const UniValue& params, bool fHelp)
+{
+    if (fHelp || params.size() > 0)
+        throw runtime_error(
+                            "getfilterstats\n"
+                            "\nReturns information about the bloom filter usage\n"
+                            "\nResult:\n"
+                            "{\n"
+                            "  \"time_in_cycle\": n,    (numeric) Total time in current cycle\n"
+                            "  \"timeframe\": n,        (numeric) Length of the measuring timeframe in seconds\n"
+                            "  \"mempool\":\n"
+                            "  {\n"
+                            "    \"mempool_filter_count\": n,              (numeric) Amount of processed mempool filterings\n"
+                            "    \"mempool_filter_amountoftxes\": n,       (numeric) Amounf of transaction filtered\n"
+                            "    \"mempool_filter_timeconsumption\": n,    (numeric) Amount of milliseconds consumed for the filtering\n"
+                            "  }\n"
+                            "  \"blocks\":\n"
+                            "  {\n"
+                            "    \"filteredblocks_count\": n,              (numeric) Amount of blocks filtered\n"
+                            "    \"filteredblocks_amountofbytes\": n,      (numeric) Amounf of total bytes of all filtered blocks\n"
+                            "    \"filteredblocks_timeconsumption\": n,    (numeric) Amount of milliseconds consumed for filtering the blocks\n"
+                            "  }\n"
+                            "}\n"
+                            "\nExamples:\n"
+                            + HelpExampleCli("getfilterstats", "")
+                            + HelpExampleRpc("getfilterstats", "")
+                            );
+
+    UniValue obj(UniValue::VOBJ);
+
+    //copy stats object
+    NodeFilterStats stats = CNode::FilterStatsGetGlobalStats();
+
+    // per timeframe
+    UniValue cycle(UniValue::VOBJ);
+    cycle.push_back(Pair("time_in_timeframe", CNode::FilterStatsGetTimeInCycle()));
+    cycle.push_back(Pair("timeframe", CNode::FilterStatsGetTimeframe()));
+
+    UniValue blockStats(UniValue::VOBJ);
+    blockStats.push_back(Pair("filteredblocks_count", CNode::FilterStatsGetValue(stats.nFilterBlockCountInCycle)));
+    blockStats.push_back(Pair("filteredblocks_amountofbytes", CNode::FilterStatsGetValue(stats.nFilterBlockDataCountInCycle)));
+    blockStats.push_back(Pair("filteredblocks_timeconsumption", CNode::FilterStatsGetValue(stats.nFilterBlockTimeCountInCycle)));
+    cycle.push_back(Pair("blocks", blockStats));
+
+    UniValue mempoolStats(UniValue::VOBJ);
+    mempoolStats.push_back(Pair("mempool_filter_count", CNode::FilterStatsGetValue(stats.nFilterMempoolCountInCycle)));
+    mempoolStats.push_back(Pair("mempool_filter_amountoftxes", CNode::FilterStatsGetValue(stats.nFilterMempoolDataCountInCycle)));
+    mempoolStats.push_back(Pair("mempool_filter_timeconsumption", CNode::FilterStatsGetValue(stats.nFilterMempoolTimeCountInCycle)));
+    cycle.push_back(Pair("mempool", mempoolStats));
+    obj.push_back(Pair("current_timeframe", cycle));
+
+    // total
+    UniValue total(UniValue::VOBJ);
+
+    UniValue blockStatsTotal(UniValue::VOBJ);
+    blockStatsTotal.push_back(Pair("filteredblocks_count", CNode::FilterStatsGetValue(stats.nFilterBlockCountInCycle, true)));
+    blockStatsTotal.push_back(Pair("filteredblocks_amountofbytes", CNode::FilterStatsGetValue(stats.nFilterBlockDataCountInCycle, true)));
+    blockStatsTotal.push_back(Pair("filteredblocks_timeconsumption", CNode::FilterStatsGetValue(stats.nFilterBlockTimeCountInCycle, true)));
+    total.push_back(Pair("blocks", blockStatsTotal));
+
+    UniValue mempoolStatsTotal(UniValue::VOBJ);
+    mempoolStatsTotal.push_back(Pair("mempool_filter_count", CNode::FilterStatsGetValue(stats.nFilterMempoolCountInCycle, true)));
+    mempoolStatsTotal.push_back(Pair("mempool_filter_amountoftxes", CNode::FilterStatsGetValue(stats.nFilterMempoolDataCountInCycle, true)));
+    mempoolStatsTotal.push_back(Pair("mempool_filter_timeconsumption", CNode::FilterStatsGetValue(stats.nFilterMempoolTimeCountInCycle, true)));
+    total.push_back(Pair("mempool", mempoolStatsTotal));
+    obj.push_back(Pair("total", total));
+    
+    return obj;
+}
+
 static const CRPCCommand commands[] =
 { //  category              name                      actor (function)         okSafeMode
   //  --------------------- ------------------------  -----------------------  ----------
@@ -588,6 +658,7 @@ static const CRPCCommand commands[] =
     { "network",            "setban",                 &setban,                 true  },
     { "network",            "listbanned",             &listbanned,             true  },
     { "network",            "clearbanned",            &clearbanned,            true  },
+    { "network",            "getfilterstats",         &getfilterstats,         true  },
 };
 
 void RegisterNetRPCCommands(CRPCTable &tableRPC)

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -611,6 +611,8 @@ UniValue getfilterstats(const UniValue& params, bool fHelp)
     UniValue cycle(UniValue::VOBJ);
     cycle.push_back(Pair("time_in_timeframe", CNode::FilterStatsGetTimeInCycle()));
     cycle.push_back(Pair("timeframe", CNode::FilterStatsGetTimeframe()));
+    cycle.push_back(Pair("nodestotal_connected", CNode::FilterStatsGetValue(stats.nTotalNodesConnected)));
+    cycle.push_back(Pair("nodestotal_loadfilter", CNode::FilterStatsGetValue(stats.nTotalNodesRequestedFiltering)));
 
     UniValue blockStats(UniValue::VOBJ);
     blockStats.push_back(Pair("filteredblocks_count", CNode::FilterStatsGetValue(stats.nFilterBlockCountInCycle)));
@@ -627,6 +629,8 @@ UniValue getfilterstats(const UniValue& params, bool fHelp)
 
     // total
     UniValue total(UniValue::VOBJ);
+    total.push_back(Pair("nodestotal_connected", CNode::FilterStatsGetValue(stats.nTotalNodesConnected, true)));
+    total.push_back(Pair("nodestotal_loadfilter", CNode::FilterStatsGetValue(stats.nTotalNodesRequestedFiltering, true)));
 
     UniValue blockStatsTotal(UniValue::VOBJ);
     blockStatsTotal.push_back(Pair("filteredblocks_count", CNode::FilterStatsGetValue(stats.nFilterBlockCountInCycle, true)));


### PR DESCRIPTION
It can be useful to know, how many blocks and how many times the mempool was filtered.

Bloom filtering is CPU intense and thus informations about its usage can help to identify sources of resource consumption.
Collecting statistics would be required to dynamic limit the amount of accepted bloom filtering.

This PR does only collect global statistics (total value and value per timeframe of currently 1h), though, I kept the design flexible. Extending this to per-node bloom-filter statistics is possible.

Also the time consumption in milliseconds for all filter processes will be collected, although, this value depends on your system workload and might not be very representative.

Statistics can be printed with the new RPC command `getfilterstats`.
Example:

```
/src/bitcoin-cli getfilterstats
{
  "current_timeframe": {
    "time_in_timeframe": 304,
    "blocks": {
      "filteredblocks_count": 1,
      "filteredblocks_amountofbytes": 989168,
      "filteredblocks_timeconsumption": 0
    },
    "mempool": {
      "mempool_filter_count": 4,
      "mempool_filter_amountoftxes": 1788,
      "mempool_filter_timeconsumption": 113
    }
  },
  "total": {
    "blocks": {
      "filteredblocks_count": 1,
      "filteredblocks_amountofbytes": 989168,
      "filteredblocks_timeconsumption": 0
    },
    "mempool": {
      "mempool_filter_count": 4,
      "mempool_filter_amountoftxes": 1788,
      "mempool_filter_timeconsumption": 1788
    }
  }
}
```
