### PR TITLE
Stop treating importaddress'ed scripts as change

### DIFF
--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -167,6 +167,11 @@ void ImportScript(const CScript& script, const string& strLabel, bool isRedeemSc
         if (!pwalletMain->HaveCScript(script) && !pwalletMain->AddCScript(script))
             throw JSONRPCError(RPC_WALLET_ERROR, "Error adding p2sh redeemScript to wallet");
         ImportAddress(CBitcoinAddress(CScriptID(script)), strLabel);
+    } else {
+        CTxDestination destination;
+        if (ExtractDestination(script, destination)) {
+            pwalletMain->SetAddressBook(destination, strLabel, "receive");
+        }
     }
 }
 
@@ -195,6 +200,8 @@ UniValue importaddress(const UniValue& params, bool fHelp)
             "4. p2sh                 (boolean, optional, default=false) Add the P2SH version of the script as well\n"
             "\nNote: This call can take minutes to complete if rescan is true.\n"
             "If you have the full public key, you should call importpubkey instead of this.\n"
+            "\nNote: If you import a non-standard raw script in hex form, outputs sending to it will be treated\n"
+            "as change, and not show up in many RPCs.\n"
             "\nExamples:\n"
             "\nImport a script with rescan\n"
             + HelpExampleCli("importaddress", "\"myscript\"") +


### PR DESCRIPTION
Before this, if someone imported a scriptPubKey directly (in hex form) using `importaddress`, outputs sending to it would be treated as change, as the corresponding CTxDestination was not added to the address book.

Fix this by trying to detect scriptPubKeys that are in fact convertible to a CTxDestination and add them anyway. Add a warning to the RPC help to warn against importing raw non-standard scripts.

Open question: should the RPC fail/warn in some way when this conversion is not possible? Things like `listunspent` work fine with such outputs, but `listtransactions` won't.
