### PR TITLE
[WIP] Fix calculation of balances and available coins.

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -685,13 +685,14 @@ CAmount GetAccountBalance(CWalletDB& walletdb, const string& strAccount, int nMi
     for (map<uint256, CWalletTx>::iterator it = pwalletMain->mapWallet.begin(); it != pwalletMain->mapWallet.end(); ++it)
     {
         const CWalletTx& wtx = (*it).second;
-        if (!CheckFinalTx(wtx) || wtx.GetBlocksToMaturity() > 0 || wtx.GetDepthInMainChain() < 0)
+        int depth = wtx.GetDepthInMainChain();
+        if (!CheckFinalTx(wtx) || wtx.GetBlocksToMaturity() > 0 || depth < 0 || (depth == 0 && !wtx.InMempool()))
             continue;
 
         CAmount nReceived, nSent, nFee;
         wtx.GetAccountAmounts(strAccount, nReceived, nSent, nFee, filter);
 
-        if (nReceived != 0 && wtx.GetDepthInMainChain() >= nMinDepth)
+        if (nReceived != 0 && depth >= nMinDepth)
             nBalance += nReceived;
         nBalance -= nSent + nFee;
     }
@@ -757,7 +758,8 @@ UniValue getbalance(const UniValue& params, bool fHelp)
         for (map<uint256, CWalletTx>::iterator it = pwalletMain->mapWallet.begin(); it != pwalletMain->mapWallet.end(); ++it)
         {
             const CWalletTx& wtx = (*it).second;
-            if (!CheckFinalTx(wtx) || wtx.GetBlocksToMaturity() > 0 || wtx.GetDepthInMainChain() < 0)
+            int depth = wtx.GetDepthInMainChain();
+            if (!CheckFinalTx(wtx) || wtx.GetBlocksToMaturity() > 0 || depth < 0 || (depth == 0 && !wtx.InMempool()))
                 continue;
 
             CAmount allFee;
@@ -765,7 +767,7 @@ UniValue getbalance(const UniValue& params, bool fHelp)
             list<COutputEntry> listReceived;
             list<COutputEntry> listSent;
             wtx.GetAmounts(listReceived, listSent, allFee, strSentAccount, filter);
-            if (wtx.GetDepthInMainChain() >= nMinDepth)
+            if (depth >= nMinDepth)
             {
                 BOOST_FOREACH(const COutputEntry& r, listReceived)
                     nBalance += r.amount;


### PR DESCRIPTION
I want to add something to the RPC test to catch what caused the issue in #7690 but this should fix it.

I also want to think about whether this is exactly what we want.
It's a slightly different behavior in the calculation of unconfirmed balances with regard to transactions which aren't final.  I think an argument could be made that it was meant to count in unconfirmed balances non-final transactions which aren't in your mempool.  Does anyone know if that was the case?  If so it'll be hard to figure out how to distinguish those which are just not yet confirmed, and those which are permanently conflicted.

Edit:
Unfortunately this still is a work in progress.  Both `getbalance` and `GetAccountBalance` in rpcwallet.cpp do their own summation of balances and also need to be fixed.
Can we **please** get rid of accounts?
