### PR TITLE
Tests: fix missing import in mempool_packages

### DIFF
--- a/qa/rpc-tests/mempool_packages.py
+++ b/qa/rpc-tests/mempool_packages.py
@@ -7,6 +7,7 @@
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
+from test_framework.mininode import COIN
 
 MAX_ANCESTORS = 25
 MAX_DESCENDANTS = 25


### PR DESCRIPTION
I think this was inadvertently introduced in #7684; `mempool_packages.py` was failing with:

```
Unexpected exception caught during testing: global name 'COIN' is not defined
```
