### PR TITLE
Improve COutPoint less operator

### DIFF
--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -34,7 +34,8 @@ public:
 
     friend bool operator<(const COutPoint& a, const COutPoint& b)
     {
-        return (a.hash < b.hash || (a.hash == b.hash && a.n < b.n));
+        int cmp = a.hash.Compare(b.hash);
+        return cmp < 0 || (cmp == 0 && a.n < b.n);
     }
 
     friend bool operator==(const COutPoint& a, const COutPoint& b)

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -42,9 +42,11 @@ public:
         memset(data, 0, sizeof(data));
     }
 
-    friend inline bool operator==(const base_blob& a, const base_blob& b) { return memcmp(a.data, b.data, sizeof(a.data)) == 0; }
-    friend inline bool operator!=(const base_blob& a, const base_blob& b) { return memcmp(a.data, b.data, sizeof(a.data)) != 0; }
-    friend inline bool operator<(const base_blob& a, const base_blob& b) { return memcmp(a.data, b.data, sizeof(a.data)) < 0; }
+    inline int Compare(const base_blob& other) const { return memcmp(data, other.data, sizeof(data)); }
+
+    friend inline bool operator==(const base_blob& a, const base_blob& b) { return a.Compare(b) == 0; }
+    friend inline bool operator!=(const base_blob& a, const base_blob& b) { return a.Compare(b) != 0; }
+    friend inline bool operator<(const base_blob& a, const base_blob& b) { return a.Compare(b) < 0; }
 
     std::string GetHex() const;
     void SetHex(const char* psz);


### PR DESCRIPTION
This change prevents double scanning the transaction hash when sorting `COutPoint`. Mostly relevant when `COutPoint` is the `std::set` or `std::map` key type.
