### PR TITLE
[qa] rpc-test: Normalize assert()

### DIFF
--- a/qa/rpc-tests/fundrawtransaction.py
+++ b/qa/rpc-tests/fundrawtransaction.py
@@ -71,7 +71,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         rawtxfund = self.nodes[2].fundrawtransaction(rawtx)
         fee = rawtxfund['fee']
         dec_tx  = self.nodes[2].decoderawtransaction(rawtxfund['hex'])
-        assert_equal(len(dec_tx['vin']) > 0, True) #test if we have enought inputs
+        assert(len(dec_tx['vin']) > 0) #test if we have enought inputs
 
         ##############################
         # simple test with two coins #
@@ -84,7 +84,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         rawtxfund = self.nodes[2].fundrawtransaction(rawtx)
         fee = rawtxfund['fee']
         dec_tx  = self.nodes[2].decoderawtransaction(rawtxfund['hex'])
-        assert_equal(len(dec_tx['vin']) > 0, True) #test if we have enough inputs
+        assert(len(dec_tx['vin']) > 0) #test if we have enough inputs
 
         ##############################
         # simple test with two coins #
@@ -97,7 +97,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         rawtxfund = self.nodes[2].fundrawtransaction(rawtx)
         fee = rawtxfund['fee']
         dec_tx  = self.nodes[2].decoderawtransaction(rawtxfund['hex'])
-        assert_equal(len(dec_tx['vin']) > 0, True)
+        assert(len(dec_tx['vin']) > 0)
         assert_equal(dec_tx['vin'][0]['scriptSig']['hex'], '')
 
 
@@ -116,7 +116,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         for out in dec_tx['vout']:
             totalOut += out['value']
 
-        assert_equal(len(dec_tx['vin']) > 0, True)
+        assert(len(dec_tx['vin']) > 0)
         assert_equal(dec_tx['vin'][0]['scriptSig']['hex'], '')
 
 
@@ -130,7 +130,7 @@ class RawTransactionsTest(BitcoinTestFramework):
                 utx = aUtx
                 break
 
-        assert_equal(utx!=False, True)
+        assert(utx!=False)
 
         inputs  = [ {'txid' : utx['txid'], 'vout' : utx['vout']}]
         outputs = { self.nodes[0].getnewaddress() : 1.0 }
@@ -159,7 +159,7 @@ class RawTransactionsTest(BitcoinTestFramework):
                 utx = aUtx
                 break
 
-        assert_equal(utx!=False, True)
+        assert(utx!=False)
 
         inputs  = [ {'txid' : utx['txid'], 'vout' : utx['vout']}]
         outputs = { self.nodes[0].getnewaddress() : Decimal(5.0) - fee - feeTolerance }
@@ -189,7 +189,7 @@ class RawTransactionsTest(BitcoinTestFramework):
                 utx = aUtx
                 break
 
-        assert_equal(utx!=False, True)
+        assert(utx!=False)
 
         inputs  = [ {'txid' : utx['txid'], 'vout' : utx['vout']}]
         outputs = { self.nodes[0].getnewaddress() : 1.0 }
@@ -234,7 +234,7 @@ class RawTransactionsTest(BitcoinTestFramework):
                 utx2 = aUtx
 
 
-        assert_equal(utx!=False, True)
+        assert(utx!=False)
 
         inputs  = [ {'txid' : utx['txid'], 'vout' : utx['vout']},{'txid' : utx2['txid'], 'vout' : utx2['vout']} ]
         outputs = { self.nodes[0].getnewaddress() : 6.0 }
@@ -276,7 +276,7 @@ class RawTransactionsTest(BitcoinTestFramework):
                 utx2 = aUtx
 
 
-        assert_equal(utx!=False, True)
+        assert(utx!=False)
 
         inputs  = [ {'txid' : utx['txid'], 'vout' : utx['vout']},{'txid' : utx2['txid'], 'vout' : utx2['vout']} ]
         outputs = { self.nodes[0].getnewaddress() : 6.0, self.nodes[0].getnewaddress() : 1.0 }
@@ -306,14 +306,11 @@ class RawTransactionsTest(BitcoinTestFramework):
         rawtx   = self.nodes[2].createrawtransaction(inputs, outputs)
         dec_tx  = self.nodes[2].decoderawtransaction(rawtx)
 
-        errorString = ""
         try:
             rawtxfund = self.nodes[2].fundrawtransaction(rawtx)
+            raise AssertionError("Spent more than available")
         except JSONRPCException,e:
-            errorString = e.error['message']
-
-        assert("Insufficient" in errorString)
-
+            assert("Insufficient" in e.error['message'])
 
 
         ############################################################
@@ -462,12 +459,11 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.is_network_split=False
         self.sync_all()
 
-        error = False
         try:
             self.nodes[1].sendtoaddress(self.nodes[0].getnewaddress(), 1.2)
-        except:
-            error = True
-        assert(error)
+            raise AssertionError("Wallet unlocked without passphrase")
+        except JSONRPCException as e:
+            assert('walletpassphrase' in e.error['message'])
 
         oldBalance = self.nodes[0].getbalance()
 
@@ -580,7 +576,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         assert_equal(len(res_dec["vin"]), 1)
         assert_equal(res_dec["vin"][0]["txid"], watchonly_txid)
 
-        assert_equal("fee" in result.keys(), True)
+        assert("fee" in result.keys())
         assert_greater_than(result["changepos"], -1)
 
         ###############################################################

--- a/qa/rpc-tests/getblocktemplate_proposals.py
+++ b/qa/rpc-tests/getblocktemplate_proposals.py
@@ -120,10 +120,7 @@ class GetBlockTemplateProposalTest(BitcoinTestFramework):
 
         # Test 3: Truncated final tx
         lastbyte = txlist[-1].pop()
-        try:
-            assert_template(node, tmpl, txlist, 'n/a')
-        except JSONRPCException:
-            pass  # Expected
+        assert_raises(JSONRPCException, assert_template, node, tmpl, txlist, 'n/a')
         txlist[-1].append(lastbyte)
 
         # Test 4: Add an invalid tx to the end (duplicate of gen tx)
@@ -144,10 +141,7 @@ class GetBlockTemplateProposalTest(BitcoinTestFramework):
 
         # Test 7: Bad tx count
         txlist.append(b'')
-        try:
-            assert_template(node, tmpl, txlist, 'n/a')
-        except JSONRPCException:
-            pass  # Expected
+        assert_raises(JSONRPCException, assert_template, node, tmpl, txlist, 'n/a')
         txlist.pop()
 
         # Test 8: Bad bits

--- a/qa/rpc-tests/httpbasics.py
+++ b/qa/rpc-tests/httpbasics.py
@@ -37,14 +37,14 @@ class HTTPBasicsTest (BitcoinTestFramework):
         conn.connect()
         conn.request('POST', '/', '{"method": "getbestblockhash"}', headers)
         out1 = conn.getresponse().read()
-        assert_equal('"error":null' in out1, True)
-        assert_equal(conn.sock!=None, True) #according to http/1.1 connection must still be open!
+        assert('"error":null' in out1)
+        assert(conn.sock!=None) #according to http/1.1 connection must still be open!
 
         #send 2nd request without closing connection
         conn.request('POST', '/', '{"method": "getchaintips"}', headers)
         out2 = conn.getresponse().read()
-        assert_equal('"error":null' in out1, True) #must also response with a correct json-rpc message
-        assert_equal(conn.sock!=None, True) #according to http/1.1 connection must still be open!
+        assert('"error":null' in out1) #must also response with a correct json-rpc message
+        assert(conn.sock!=None) #according to http/1.1 connection must still be open!
         conn.close()
 
         #same should be if we add keep-alive because this should be the std. behaviour
@@ -54,14 +54,14 @@ class HTTPBasicsTest (BitcoinTestFramework):
         conn.connect()
         conn.request('POST', '/', '{"method": "getbestblockhash"}', headers)
         out1 = conn.getresponse().read()
-        assert_equal('"error":null' in out1, True)
-        assert_equal(conn.sock!=None, True) #according to http/1.1 connection must still be open!
+        assert('"error":null' in out1)
+        assert(conn.sock!=None) #according to http/1.1 connection must still be open!
 
         #send 2nd request without closing connection
         conn.request('POST', '/', '{"method": "getchaintips"}', headers)
         out2 = conn.getresponse().read()
-        assert_equal('"error":null' in out1, True) #must also response with a correct json-rpc message
-        assert_equal(conn.sock!=None, True) #according to http/1.1 connection must still be open!
+        assert('"error":null' in out1) #must also response with a correct json-rpc message
+        assert(conn.sock!=None) #according to http/1.1 connection must still be open!
         conn.close()
 
         #now do the same with "Connection: close"
@@ -71,8 +71,8 @@ class HTTPBasicsTest (BitcoinTestFramework):
         conn.connect()
         conn.request('POST', '/', '{"method": "getbestblockhash"}', headers)
         out1 = conn.getresponse().read()
-        assert_equal('"error":null' in out1, True)
-        assert_equal(conn.sock!=None, False) #now the connection must be closed after the response
+        assert('"error":null' in out1)
+        assert(conn.sock==None) #now the connection must be closed after the response
 
         #node1 (2nd node) is running with disabled keep-alive option
         urlNode1 = urlparse.urlparse(self.nodes[1].url)
@@ -83,7 +83,7 @@ class HTTPBasicsTest (BitcoinTestFramework):
         conn.connect()
         conn.request('POST', '/', '{"method": "getbestblockhash"}', headers)
         out1 = conn.getresponse().read()
-        assert_equal('"error":null' in out1, True)
+        assert('"error":null' in out1)
 
         #node2 (third node) is running with standard keep-alive parameters which means keep-alive is on
         urlNode2 = urlparse.urlparse(self.nodes[2].url)
@@ -94,8 +94,8 @@ class HTTPBasicsTest (BitcoinTestFramework):
         conn.connect()
         conn.request('POST', '/', '{"method": "getbestblockhash"}', headers)
         out1 = conn.getresponse().read()
-        assert_equal('"error":null' in out1, True)
-        assert_equal(conn.sock!=None, True) #connection must be closed because bitcoind should use keep-alive by default
+        assert('"error":null' in out1)
+        assert(conn.sock!=None) #connection must be closed because bitcoind should use keep-alive by default
 
         # Check excessive request size
         conn = httplib.HTTPConnection(urlNode2.hostname, urlNode2.port)

--- a/qa/rpc-tests/wallet.py
+++ b/qa/rpc-tests/wallet.py
@@ -252,7 +252,7 @@ class WalletTest (BitcoinTestFramework):
         except JSONRPCException,e:
             errorString = e.error['message']
 
-        assert_equal("Invalid amount" in errorString, True)
+        assert("Invalid amount" in errorString)
 
         errorString = ""
         try:
@@ -260,7 +260,7 @@ class WalletTest (BitcoinTestFramework):
         except JSONRPCException,e:
             errorString = e.error['message']
 
-        assert_equal("not an integer" in errorString, True)
+        assert("not an integer" in errorString)
 
         #check if wallet or blochchain maintenance changes the balance
         self.sync_all()

--- a/qa/rpc-tests/zapwallettxes.py
+++ b/qa/rpc-tests/zapwallettxes.py
@@ -65,14 +65,8 @@ class ZapWalletTXesTest (BitcoinTestFramework):
         #restart bitcoind with zapwallettxes
         self.nodes[0] = start_node(0,self.options.tmpdir, ["-zapwallettxes=1"])
         
-        aException = False
-        try:
-            tx3 = self.nodes[0].gettransaction(txid3)
-        except JSONRPCException,e:
-            print e
-            aException = True
-        
-        assert_equal(aException, True) #there must be a expection because the unconfirmed wallettx0 must be gone by now
+        assert_raises(JSONRPCException, self.nodes[0].gettransaction, [txid3])
+        #there must be a expection because the unconfirmed wallettx0 must be gone by now
 
         tx0 = self.nodes[0].gettransaction(txid0)
         assert_equal(tx0['txid'], txid0) #tx0 (confirmed) must still be available because it was confirmed


### PR DESCRIPTION
Refactoring to make the test easier to read and remove redundant code:
- `assert_equal( $boolean, True)` can be written as `assert( $boolean )`
- Remove usage of `errorString` et al., which is error prone when the string is not erased after usage. Also made some of them more verbose/strict.
