### PR TITLE
[qa] Refactor python2 syntax

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -32,13 +32,13 @@ import re
 from tests_config import *
 
 #If imported values are not defined then set to zero (or disabled)
-if not vars().has_key('ENABLE_WALLET'):
+if 'ENABLE_WALLET' not in vars():
     ENABLE_WALLET=0
-if not vars().has_key('ENABLE_BITCOIND'):
+if 'ENABLE_BITCOIND' not in vars():
     ENABLE_BITCOIND=0
-if not vars().has_key('ENABLE_UTILS'):
+if 'ENABLE_UTILS' not in vars():
     ENABLE_UTILS=0
-if not vars().has_key('ENABLE_ZMQ'):
+if 'ENABLE_ZMQ' not in vars():
     ENABLE_ZMQ=0
     
 # python-zmq may not be installed. Handle this gracefully and with some helpful info

--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -78,7 +78,7 @@ if "BITCOINCLI" not in os.environ:
 
 #Disable Windows tests by default
 if EXEEXT == ".exe" and "-win" not in opts:
-    print "Win tests currently disabled.  Use -win option to enable"
+    print("Win tests currently disabled.  Use -win option to enable")
     sys.exit(0)
 
 #Tests
@@ -197,7 +197,7 @@ def runtests():
             coverage.cleanup()
 
     else:
-        print "No rpc tests to run. Wallet, utils, and bitcoind must all be enabled"
+        print("No rpc tests to run. Wallet, utils, and bitcoind must all be enabled")
 
 
 class RPCCoverage(object):

--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from __future__ import division,print_function
 
 """
 Run Regression Test Suite

--- a/qa/rpc-tests/abandonconflict.py
+++ b/qa/rpc-tests/abandonconflict.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from __future__ import division,print_function
 
 
 from test_framework.test_framework import BitcoinTestFramework

--- a/qa/rpc-tests/abandonconflict.py
+++ b/qa/rpc-tests/abandonconflict.py
@@ -145,9 +145,9 @@ class AbandonConflictTest(BitcoinTestFramework):
         self.nodes[0].invalidateblock(self.nodes[0].getbestblockhash())
         newbalance = self.nodes[0].getbalance()
         #assert(newbalance == balance - Decimal("10"))
-        print "If balance has not declined after invalidateblock then out of mempool wallet tx which is no longer"
-        print "conflicted has not resumed causing its inputs to be seen as spent.  See Issue #7315"
-        print balance , " -> " , newbalance , " ?"
+        print("If balance has not declined after invalidateblock then out of mempool wallet tx which is no longer")
+        print("conflicted has not resumed causing its inputs to be seen as spent.  See Issue #7315")
+        print(str(balance) + " -> " + str(newbalance) + " ?")
 
 if __name__ == '__main__':
     AbandonConflictTest().main()

--- a/qa/rpc-tests/bip65-cltv-p2p.py
+++ b/qa/rpc-tests/bip65-cltv-p2p.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python2
-# Copyright (c) 2015 The Bitcoin Core developers
+# Copyright (c) 2015-2016 The Bitcoin Core developers
 # Distributed under the MIT/X11 software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-#
+
+from __future__ import division,print_function
 
 from test_framework.test_framework import ComparisonTestFramework
 from test_framework.util import *

--- a/qa/rpc-tests/bip65-cltv.py
+++ b/qa/rpc-tests/bip65-cltv.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python2
-# Copyright (c) 2015 The Bitcoin Core developers
+# Copyright (c) 2015-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from __future__ import division,print_function
 
 #
 # Test the CHECKLOCKTIMEVERIFY (BIP65) soft-fork logic

--- a/qa/rpc-tests/bip68-sequence.py
+++ b/qa/rpc-tests/bip68-sequence.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from __future__ import division,print_function
 
 #
 # Test BIP68 implementation (mempool only)
@@ -179,7 +181,7 @@ class BIP68Test(BitcoinTestFramework):
                 tx.vin.append(CTxIn(COutPoint(int(utxos[j]["txid"], 16), utxos[j]["vout"]), nSequence=sequence_value))
                 value += utxos[j]["amount"]*COIN
             # Overestimate the size of the tx - signatures should be less than 120 bytes, and leave 50 for the output
-            tx_size = len(ToHex(tx))/2 + 120*num_inputs + 50
+            tx_size = len(ToHex(tx))//2 + 120*num_inputs + 50
             tx.vout.append(CTxOut(value-self.relayfee*tx_size*COIN/1000, CScript([b'a'])))
             rawtx = self.nodes[0].signrawtransaction(ToHex(tx))["hex"]
 

--- a/qa/rpc-tests/bip68-sequence.py
+++ b/qa/rpc-tests/bip68-sequence.py
@@ -33,20 +33,20 @@ class BIP68Test(BitcoinTestFramework):
         # Generate some coins
         self.nodes[0].generate(110)
 
-        print "Running test disable flag"
+        print("Running test disable flag")
         self.test_disable_flag()
 
-        print "Running test sequence-lock-confirmed-inputs"
+        print("Running test sequence-lock-confirmed-inputs")
         self.test_sequence_lock_confirmed_inputs()
 
-        print "Running test sequence-lock-unconfirmed-inputs"
+        print("Running test sequence-lock-unconfirmed-inputs")
         self.test_sequence_lock_unconfirmed_inputs()
 
         # This test needs to change when BIP68 becomes consensus
-        print "Running test BIP68 not consensus"
+        print("Running test BIP68 not consensus")
         self.test_bip68_not_consensus()
 
-        print "Passed\n"
+        print("Passed\n")
 
     # Test that BIP68 is not in effect if tx version is 1, or if
     # the first sequence bit is set.

--- a/qa/rpc-tests/bipdersig-p2p.py
+++ b/qa/rpc-tests/bipdersig-p2p.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python2
-# Copyright (c) 2015 The Bitcoin Core developers
+# Copyright (c) 2015-2016 The Bitcoin Core developers
 # Distributed under the MIT/X11 software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-#
+
+from __future__ import division,print_function
 
 from test_framework.test_framework import ComparisonTestFramework
 from test_framework.util import *

--- a/qa/rpc-tests/bipdersig.py
+++ b/qa/rpc-tests/bipdersig.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from __future__ import division,print_function
 
 #
 # Test the BIP66 changeover logic

--- a/qa/rpc-tests/blockchain.py
+++ b/qa/rpc-tests/blockchain.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from __future__ import division,print_function
 
 #
 # Test RPC calls related to blockchain state. Tests correspond to code in

--- a/qa/rpc-tests/decodescript.py
+++ b/qa/rpc-tests/decodescript.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python2
-# Copyright (c) 2015 The Bitcoin Core developers
+# Copyright (c) 2015-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from __future__ import division,print_function
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *

--- a/qa/rpc-tests/disablewallet.py
+++ b/qa/rpc-tests/disablewallet.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from __future__ import division,print_function
 
 #
 # Exercise API with -disablewallet.

--- a/qa/rpc-tests/forknotify.py
+++ b/qa/rpc-tests/forknotify.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from __future__ import division,print_function
 
 #
 # Test -alertnotify 

--- a/qa/rpc-tests/fundrawtransaction.py
+++ b/qa/rpc-tests/fundrawtransaction.py
@@ -48,7 +48,7 @@ class RawTransactionsTest(BitcoinTestFramework):
 
         watchonly_address = self.nodes[0].getnewaddress()
         watchonly_pubkey = self.nodes[0].validateaddress(watchonly_address)["pubkey"]
-        watchonly_amount = 200
+        watchonly_amount = Decimal(200)
         self.nodes[3].importpubkey(watchonly_pubkey, "", True)
         watchonly_txid = self.nodes[0].sendtoaddress(watchonly_address, watchonly_amount)
         self.nodes[0].sendtoaddress(self.nodes[3].getnewaddress(), watchonly_amount / 10)

--- a/qa/rpc-tests/fundrawtransaction.py
+++ b/qa/rpc-tests/fundrawtransaction.py
@@ -25,7 +25,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.sync_all()
 
     def run_test(self):
-        print "Mining blocks..."
+        print("Mining blocks...")
 
         min_relay_tx_fee = self.nodes[0].getnetworkinfo()['relayfee']
         # This test is not meant to test fee estimation and we'd like

--- a/qa/rpc-tests/fundrawtransaction.py
+++ b/qa/rpc-tests/fundrawtransaction.py
@@ -209,7 +209,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         matchingOuts = 0
         for i, out in enumerate(dec_tx['vout']):
             totalOut += out['value']
-            if outputs.has_key(out['scriptPubKey']['addresses'][0]):
+            if out['scriptPubKey']['addresses'][0] in outputs:
                 matchingOuts+=1
             else:
                 assert_equal(i, rawtxfund['changepos'])
@@ -249,7 +249,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         matchingOuts = 0
         for out in dec_tx['vout']:
             totalOut += out['value']
-            if outputs.has_key(out['scriptPubKey']['addresses'][0]):
+            if out['scriptPubKey']['addresses'][0] in outputs:
                 matchingOuts+=1
 
         assert_equal(matchingOuts, 1)
@@ -291,7 +291,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         matchingOuts = 0
         for out in dec_tx['vout']:
             totalOut += out['value']
-            if outputs.has_key(out['scriptPubKey']['addresses'][0]):
+            if out['scriptPubKey']['addresses'][0] in outputs:
                 matchingOuts+=1
 
         assert_equal(matchingOuts, 2)
@@ -309,7 +309,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         errorString = ""
         try:
             rawtxfund = self.nodes[2].fundrawtransaction(rawtx)
-        except JSONRPCException,e:
+        except JSONRPCException as e:
             errorString = e.error['message']
 
         assert("Insufficient" in errorString)

--- a/qa/rpc-tests/fundrawtransaction.py
+++ b/qa/rpc-tests/fundrawtransaction.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from __future__ import division,print_function
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
@@ -309,7 +311,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         errorString = ""
         try:
             rawtxfund = self.nodes[2].fundrawtransaction(rawtx)
-        except JSONRPCException as e:
+        except JSONRPCException,e:
             errorString = e.error['message']
 
         assert("Insufficient" in errorString)

--- a/qa/rpc-tests/getblocktemplate_longpoll.py
+++ b/qa/rpc-tests/getblocktemplate_longpoll.py
@@ -49,7 +49,7 @@ class GetBlockTemplateLPTest(BitcoinTestFramework):
     '''
 
     def run_test(self):
-        print "Warning: this test will take about 70 seconds in the best case. Be patient."
+        print("Warning: this test will take about 70 seconds in the best case. Be patient.")
         self.nodes[0].generate(10)
         templat = self.nodes[0].getblocktemplate()
         longpollid = templat['longpollid']

--- a/qa/rpc-tests/getblocktemplate_longpoll.py
+++ b/qa/rpc-tests/getblocktemplate_longpoll.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from __future__ import division,print_function
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *

--- a/qa/rpc-tests/getblocktemplate_proposals.py
+++ b/qa/rpc-tests/getblocktemplate_proposals.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from __future__ import division,print_function
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *

--- a/qa/rpc-tests/getchaintips.py
+++ b/qa/rpc-tests/getchaintips.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from __future__ import division,print_function
 
 # Exercise the getchaintips API.  We introduce a network split, work
 # on chains of different lengths, and join the network together again.

--- a/qa/rpc-tests/httpbasics.py
+++ b/qa/rpc-tests/httpbasics.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from __future__ import division,print_function
 
 #
 # Test rpc http basics

--- a/qa/rpc-tests/invalidateblock.py
+++ b/qa/rpc-tests/invalidateblock.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from __future__ import division,print_function
 
 #
 # Test InvalidateBlock code

--- a/qa/rpc-tests/invalidateblock.py
+++ b/qa/rpc-tests/invalidateblock.py
@@ -25,46 +25,46 @@ class InvalidateTest(BitcoinTestFramework):
         self.nodes.append(start_node(2, self.options.tmpdir, ["-debug"]))
         
     def run_test(self):
-        print "Make sure we repopulate setBlockIndexCandidates after InvalidateBlock:"
-        print "Mine 4 blocks on Node 0"
+        print("Make sure we repopulate setBlockIndexCandidates after InvalidateBlock:")
+        print("Mine 4 blocks on Node 0")
         self.nodes[0].generate(4)
         assert(self.nodes[0].getblockcount() == 4)
         besthash = self.nodes[0].getbestblockhash()
 
-        print "Mine competing 6 blocks on Node 1"
+        print("Mine competing 6 blocks on Node 1")
         self.nodes[1].generate(6)
         assert(self.nodes[1].getblockcount() == 6)
 
-        print "Connect nodes to force a reorg"
+        print("Connect nodes to force a reorg")
         connect_nodes_bi(self.nodes,0,1)
         sync_blocks(self.nodes[0:2])
         assert(self.nodes[0].getblockcount() == 6)
         badhash = self.nodes[1].getblockhash(2)
 
-        print "Invalidate block 2 on node 0 and verify we reorg to node 0's original chain"
+        print("Invalidate block 2 on node 0 and verify we reorg to node 0's original chain")
         self.nodes[0].invalidateblock(badhash)
         newheight = self.nodes[0].getblockcount()
         newhash = self.nodes[0].getbestblockhash()
         if (newheight != 4 or newhash != besthash):
             raise AssertionError("Wrong tip for node0, hash %s, height %d"%(newhash,newheight))
 
-        print "\nMake sure we won't reorg to a lower work chain:"
+        print("\nMake sure we won't reorg to a lower work chain:")
         connect_nodes_bi(self.nodes,1,2)
-        print "Sync node 2 to node 1 so both have 6 blocks"
+        print("Sync node 2 to node 1 so both have 6 blocks")
         sync_blocks(self.nodes[1:3])
         assert(self.nodes[2].getblockcount() == 6)
-        print "Invalidate block 5 on node 1 so its tip is now at 4"
+        print("Invalidate block 5 on node 1 so its tip is now at 4")
         self.nodes[1].invalidateblock(self.nodes[1].getblockhash(5))
         assert(self.nodes[1].getblockcount() == 4)
-        print "Invalidate block 3 on node 2, so its tip is now 2"
+        print("Invalidate block 3 on node 2, so its tip is now 2")
         self.nodes[2].invalidateblock(self.nodes[2].getblockhash(3))
         assert(self.nodes[2].getblockcount() == 2)
-        print "..and then mine a block"
+        print("..and then mine a block")
         self.nodes[2].generate(1)
-        print "Verify all nodes are at the right height"
+        print("Verify all nodes are at the right height")
         time.sleep(5)
         for i in xrange(3):
-            print i,self.nodes[i].getblockcount()
+            print(i,self.nodes[i].getblockcount())
         assert(self.nodes[2].getblockcount() == 3)
         assert(self.nodes[0].getblockcount() == 4)
         node1height = self.nodes[1].getblockcount()

--- a/qa/rpc-tests/invalidblockrequest.py
+++ b/qa/rpc-tests/invalidblockrequest.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python2
-# Copyright (c) 2015 The Bitcoin Core developers
+# Copyright (c) 2015-2016 The Bitcoin Core developers
 # Distributed under the MIT/X11 software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-#
+
+from __future__ import division,print_function
 
 from test_framework.test_framework import ComparisonTestFramework
 from test_framework.util import *

--- a/qa/rpc-tests/invalidtxrequest.py
+++ b/qa/rpc-tests/invalidtxrequest.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python2
-# Copyright (c) 2015 The Bitcoin Core developers
+# Copyright (c) 2015-2016 The Bitcoin Core developers
 # Distributed under the MIT/X11 software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-#
+
+from __future__ import division,print_function
 
 from test_framework.test_framework import ComparisonTestFramework
 from test_framework.comptool import TestManager, TestInstance, RejectResult

--- a/qa/rpc-tests/keypool.py
+++ b/qa/rpc-tests/keypool.py
@@ -46,7 +46,7 @@ class KeyPoolTest(BitcoinTestFramework):
         try:
             addr = nodes[0].getnewaddress()
             raise AssertionError('Keypool should be exhausted after one address')
-        except JSONRPCException,e:
+        except JSONRPCException as e:
             assert(e.error['code']==-12)
 
         # put three new keys in the keypool
@@ -66,7 +66,7 @@ class KeyPoolTest(BitcoinTestFramework):
         try:
             addr = nodes[0].getrawchangeaddress()
             raise AssertionError('Keypool should be exhausted after three addresses')
-        except JSONRPCException,e:
+        except JSONRPCException as e:
             assert(e.error['code']==-12)
 
         # refill keypool with three new addresses
@@ -84,7 +84,7 @@ class KeyPoolTest(BitcoinTestFramework):
         try:
             nodes[0].generate(1)
             raise AssertionError('Keypool should be exhausted after three addesses')
-        except JSONRPCException,e:
+        except JSONRPCException as e:
             assert(e.error['code']==-12)
 
     def setup_chain(self):

--- a/qa/rpc-tests/keypool.py
+++ b/qa/rpc-tests/keypool.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from __future__ import division,print_function
 
 # Exercise the wallet keypool, and interaction with wallet encryption/locking
 

--- a/qa/rpc-tests/listtransactions.py
+++ b/qa/rpc-tests/listtransactions.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from __future__ import division,print_function
 
 # Exercise the listtransactions API
 

--- a/qa/rpc-tests/maxblocksinflight.py
+++ b/qa/rpc-tests/maxblocksinflight.py
@@ -67,9 +67,9 @@ class TestManager(NodeConnCB):
                             raise AssertionError("Error, test failed: block %064x requested more than once" % key)
                 if total_requests > MAX_REQUESTS:
                     raise AssertionError("Error, too many blocks (%d) requested" % total_requests)
-                print "Round %d: success (total requests: %d)" % (count, total_requests)
+                print("Round %d: success (total requests: %d)" % (count, total_requests))
         except AssertionError as e:
-            print "TEST FAILED: ", e.args
+            print("TEST FAILED: ", e.args)
 
         self.disconnectOkay = True
         self.connection.disconnect_node()
@@ -82,7 +82,7 @@ class MaxBlocksInFlightTest(BitcoinTestFramework):
                           help="Binary to test max block requests behavior")
 
     def setup_chain(self):
-        print "Initializing test directory "+self.options.tmpdir
+        print("Initializing test directory "+self.options.tmpdir)
         initialize_chain_clean(self.options.tmpdir, 1)
 
     def setup_network(self):

--- a/qa/rpc-tests/maxblocksinflight.py
+++ b/qa/rpc-tests/maxblocksinflight.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python2
-# Copyright (c) 2015 The Bitcoin Core developers
+# Copyright (c) 2015-2016 The Bitcoin Core developers
 # Distributed under the MIT/X11 software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-#
+
+from __future__ import division,print_function
 
 from test_framework.mininode import *
 from test_framework.test_framework import BitcoinTestFramework

--- a/qa/rpc-tests/maxuploadtarget.py
+++ b/qa/rpc-tests/maxuploadtarget.py
@@ -178,7 +178,7 @@ class MaxUploadTest(BitcoinTestFramework):
         max_bytes_per_day = 200*1024*1024
         daily_buffer = 144 * MAX_BLOCK_SIZE
         max_bytes_available = max_bytes_per_day - daily_buffer
-        success_count = max_bytes_available / old_block_size
+        success_count = max_bytes_available // old_block_size
 
         # 144MB will be reserved for relaying new blocks, so expect this to
         # succeed for ~70 tries.

--- a/qa/rpc-tests/maxuploadtarget.py
+++ b/qa/rpc-tests/maxuploadtarget.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python2
-#
+# Copyright (c) 2015-2016 The Bitcoin Core developers
 # Distributed under the MIT/X11 software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-#
+
+from __future__ import division,print_function
 
 from test_framework.mininode import *
 from test_framework.test_framework import BitcoinTestFramework

--- a/qa/rpc-tests/maxuploadtarget.py
+++ b/qa/rpc-tests/maxuploadtarget.py
@@ -194,7 +194,7 @@ class MaxUploadTest(BitcoinTestFramework):
             test_nodes[0].send_message(getdata_request)
         test_nodes[0].wait_for_disconnect()
         assert_equal(len(self.nodes[0].getpeerinfo()), 2)
-        print "Peer 0 disconnected after downloading old block too many times"
+        print("Peer 0 disconnected after downloading old block too many times")
 
         # Requesting the current block on test_nodes[1] should succeed indefinitely,
         # even when over the max upload target.
@@ -205,7 +205,7 @@ class MaxUploadTest(BitcoinTestFramework):
             test_nodes[1].sync_with_ping()
             assert_equal(test_nodes[1].block_receive_map[big_new_block], i+1)
 
-        print "Peer 1 able to repeatedly download new block"
+        print("Peer 1 able to repeatedly download new block")
 
         # But if test_nodes[1] tries for an old block, it gets disconnected too.
         getdata_request.inv = [CInv(2, big_old_block)]
@@ -213,9 +213,9 @@ class MaxUploadTest(BitcoinTestFramework):
         test_nodes[1].wait_for_disconnect()
         assert_equal(len(self.nodes[0].getpeerinfo()), 1)
 
-        print "Peer 1 disconnected after trying to download old block"
+        print("Peer 1 disconnected after trying to download old block")
 
-        print "Advancing system time on node to clear counters..."
+        print("Advancing system time on node to clear counters...")
 
         # If we advance the time by 24 hours, then the counters should reset,
         # and test_nodes[2] should be able to retrieve the old block.
@@ -225,12 +225,12 @@ class MaxUploadTest(BitcoinTestFramework):
         test_nodes[2].sync_with_ping()
         assert_equal(test_nodes[2].block_receive_map[big_old_block], 1)
 
-        print "Peer 2 able to download old block"
+        print("Peer 2 able to download old block")
 
         [c.disconnect_node() for c in connections]
 
         #stop and start node 0 with 1MB maxuploadtarget, whitelist 127.0.0.1
-        print "Restarting nodes with -whitelist=127.0.0.1"
+        print("Restarting nodes with -whitelist=127.0.0.1")
         stop_node(self.nodes[0], 0)
         self.nodes[0] = start_node(0, self.options.tmpdir, ["-debug", "-whitelist=127.0.0.1", "-maxuploadtarget=1", "-blockmaxsize=999000"])
 
@@ -258,7 +258,7 @@ class MaxUploadTest(BitcoinTestFramework):
         test_nodes[1].wait_for_disconnect()
         assert_equal(len(self.nodes[0].getpeerinfo()), 3) #node is still connected because of the whitelist
 
-        print "Peer 1 still connected after trying to download old block (whitelisted)"
+        print("Peer 1 still connected after trying to download old block (whitelisted)")
 
         [c.disconnect_node() for c in connections]
 

--- a/qa/rpc-tests/mempool_limit.py
+++ b/qa/rpc-tests/mempool_limit.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from __future__ import division,print_function
 
 # Test mempool limiting together/eviction with the wallet
 

--- a/qa/rpc-tests/mempool_packages.py
+++ b/qa/rpc-tests/mempool_packages.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from __future__ import division,print_function
 
 # Test descendant package tracking code
 

--- a/qa/rpc-tests/mempool_packages.py
+++ b/qa/rpc-tests/mempool_packages.py
@@ -84,7 +84,7 @@ class MempoolPackagesTest(BitcoinTestFramework):
         try:
             self.chain_transaction(self.nodes[0], txid, vout, value, fee, 1)
         except JSONRPCException as e:
-            print "too-long-ancestor-chain successfully rejected"
+            print("too-long-ancestor-chain successfully rejected")
 
         # Check that prioritising a tx before it's added to the mempool works
         # First clear the mempool by mining a block.
@@ -134,9 +134,9 @@ class MempoolPackagesTest(BitcoinTestFramework):
                     mempool = self.nodes[0].getrawmempool(True)
                     assert_equal(mempool[parent_transaction]['descendantcount'], MAX_DESCENDANTS)
             except JSONRPCException as e:
-                print e.error['message']
+                print(e.error['message'])
                 assert_equal(i, MAX_DESCENDANTS - 1)
-                print "tx that would create too large descendant package successfully rejected"
+                print("tx that would create too large descendant package successfully rejected")
 
         # TODO: check that node1's mempool is as expected
 

--- a/qa/rpc-tests/mempool_reorg.py
+++ b/qa/rpc-tests/mempool_reorg.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from __future__ import division,print_function
 
 #
 # Test re-org scenarios with a mempool that contains transactions

--- a/qa/rpc-tests/mempool_resurrect_test.py
+++ b/qa/rpc-tests/mempool_resurrect_test.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from __future__ import division,print_function
 
 #
 # Test resurrection of mined transactions when

--- a/qa/rpc-tests/mempool_spendcoinbase.py
+++ b/qa/rpc-tests/mempool_spendcoinbase.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from __future__ import division,print_function
 
 #
 # Test spending coinbase transactions.

--- a/qa/rpc-tests/merkle_blocks.py
+++ b/qa/rpc-tests/merkle_blocks.py
@@ -32,7 +32,7 @@ class MerkleBlockTest(BitcoinTestFramework):
         self.sync_all()
 
     def run_test(self):
-        print "Mining blocks..."
+        print("Mining blocks...")
         self.nodes[0].generate(105)
         self.sync_all()
 

--- a/qa/rpc-tests/merkle_blocks.py
+++ b/qa/rpc-tests/merkle_blocks.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from __future__ import division,print_function
 
 #
 # Test merkleblock fetch/validation

--- a/qa/rpc-tests/multi_rpc.py
+++ b/qa/rpc-tests/multi_rpc.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python2
-# Copyright (c) 2015 The Bitcoin Core developers
+# Copyright (c) 2015-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from __future__ import division,print_function
 
 #
 # Test mulitple rpc user config option rpcauth

--- a/qa/rpc-tests/nodehandling.py
+++ b/qa/rpc-tests/nodehandling.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from __future__ import division,print_function
 
 #
 # Test node handling

--- a/qa/rpc-tests/p2p-acceptblock.py
+++ b/qa/rpc-tests/p2p-acceptblock.py
@@ -161,7 +161,7 @@ class AcceptBlockTest(BitcoinTestFramework):
         [ x.sync_with_ping() for x in [test_node, white_node] ]
         assert_equal(self.nodes[0].getblockcount(), 2)
         assert_equal(self.nodes[1].getblockcount(), 2)
-        print "First height 2 block accepted by both nodes"
+        print("First height 2 block accepted by both nodes")
 
         # 3. Send another block that builds on the original tip.
         blocks_h2f = []  # Blocks at height 2 that fork off the main chain
@@ -180,7 +180,7 @@ class AcceptBlockTest(BitcoinTestFramework):
             if x['hash'] == blocks_h2f[1].hash:
                 assert_equal(x['status'], "valid-headers")
 
-        print "Second height 2 block accepted only from whitelisted peer"
+        print("Second height 2 block accepted only from whitelisted peer")
 
         # 4. Now send another block that builds on the forking chain.
         blocks_h3 = []
@@ -200,13 +200,13 @@ class AcceptBlockTest(BitcoinTestFramework):
         # But this block should be accepted by node0 since it has more work.
         try:
             self.nodes[0].getblock(blocks_h3[0].hash)
-            print "Unrequested more-work block accepted from non-whitelisted peer"
+            print("Unrequested more-work block accepted from non-whitelisted peer")
         except:
             raise AssertionError("Unrequested more work block was not processed")
 
         # Node1 should have accepted and reorged.
         assert_equal(self.nodes[1].getblockcount(), 3)
-        print "Successfully reorged to length 3 chain from whitelisted peer"
+        print("Successfully reorged to length 3 chain from whitelisted peer")
 
         # 4b. Now mine 288 more blocks and deliver; all should be processed but
         # the last (height-too-high) on node0.  Node1 should process the tip if
@@ -233,7 +233,7 @@ class AcceptBlockTest(BitcoinTestFramework):
                     raise AssertionError("Unrequested block too far-ahead should have been ignored")
             except:
                 if x == all_blocks[287]:
-                    print "Unrequested block too far-ahead not processed"
+                    print("Unrequested block too far-ahead not processed")
                 else:
                     raise AssertionError("Unrequested block with more work should have been accepted")
 
@@ -243,7 +243,7 @@ class AcceptBlockTest(BitcoinTestFramework):
         try:
             white_node.sync_with_ping()
             self.nodes[1].getblock(tips[1].hash)
-            print "Unrequested block far ahead of tip accepted from whitelisted peer"
+            print("Unrequested block far ahead of tip accepted from whitelisted peer")
         except:
             raise AssertionError("Unrequested block from whitelisted peer not accepted")
 
@@ -259,7 +259,7 @@ class AcceptBlockTest(BitcoinTestFramework):
         # a getdata request for this block.
         test_node.sync_with_ping()
         assert_equal(self.nodes[0].getblockcount(), 2)
-        print "Unrequested block that would complete more-work chain was ignored"
+        print("Unrequested block that would complete more-work chain was ignored")
 
         # 6. Try to get node to request the missing block.
         # Poke the node with an inv for block at height 3 and see if that
@@ -275,14 +275,14 @@ class AcceptBlockTest(BitcoinTestFramework):
 
         # Check that the getdata includes the right block
         assert_equal(getdata.inv[0].hash, blocks_h2f[0].sha256)
-        print "Inv at tip triggered getdata for unprocessed block"
+        print("Inv at tip triggered getdata for unprocessed block")
 
         # 7. Send the missing block for the third time (now it is requested)
         test_node.send_message(msg_block(blocks_h2f[0]))
 
         test_node.sync_with_ping()
         assert_equal(self.nodes[0].getblockcount(), 290)
-        print "Successfully reorged to longer chain from non-whitelisted peer"
+        print("Successfully reorged to longer chain from non-whitelisted peer")
 
         [ c.disconnect_node() for c in connections ]
 

--- a/qa/rpc-tests/p2p-acceptblock.py
+++ b/qa/rpc-tests/p2p-acceptblock.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python2
-# Copyright (c) 2015 The Bitcoin Core developers
+# Copyright (c) 2015-2016 The Bitcoin Core developers
 # Distributed under the MIT/X11 software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-#
+
+from __future__ import division,print_function
 
 from test_framework.mininode import *
 from test_framework.test_framework import BitcoinTestFramework

--- a/qa/rpc-tests/p2p-fullblocktest.py
+++ b/qa/rpc-tests/p2p-fullblocktest.py
@@ -269,7 +269,7 @@ class FullBlockTest(ComparisonTestFramework):
         #                      \-> b3 (1) -> b4 (2)
         
         # Test that a block with a lot of checksigs is okay
-        lots_of_checksigs = CScript([OP_CHECKSIG] * (1000000 / 50 - 1))
+        lots_of_checksigs = CScript([OP_CHECKSIG] * (1000000 // 50 - 1))
         tip(13)
         block(15, spend=out5, script=lots_of_checksigs)
         yield accepted()
@@ -277,7 +277,7 @@ class FullBlockTest(ComparisonTestFramework):
 
         # Test that a block with too many checksigs is rejected
         out6 = get_spendable_output()
-        too_many_checksigs = CScript([OP_CHECKSIG] * (1000000 / 50))
+        too_many_checksigs = CScript([OP_CHECKSIG] * (1000000 // 50))
         block(16, spend=out6, script=too_many_checksigs)
         yield rejected(RejectResult(16, 'bad-blk-sigops'))
 

--- a/qa/rpc-tests/p2p-fullblocktest.py
+++ b/qa/rpc-tests/p2p-fullblocktest.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python2
-# Copyright (c) 2015 The Bitcoin Core developers
+# Copyright (c) 2015-2016 The Bitcoin Core developers
 # Distributed under the MIT/X11 software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-#
+
+from __future__ import division,print_function
 
 from test_framework.test_framework import ComparisonTestFramework
 from test_framework.util import *

--- a/qa/rpc-tests/p2p-versionbits-warning.py
+++ b/qa/rpc-tests/p2p-versionbits-warning.py
@@ -2,7 +2,8 @@
 # Copyright (c) 2016 The Bitcoin Core developers
 # Distributed under the MIT/X11 software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-#
+
+from __future__ import division,print_function
 
 from test_framework.mininode import *
 from test_framework.test_framework import BitcoinTestFramework

--- a/qa/rpc-tests/prioritise_transaction.py
+++ b/qa/rpc-tests/prioritise_transaction.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python2
-# Copyright (c) 2015 The Bitcoin Core developers
+# Copyright (c) 2015-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from __future__ import division,print_function
 
 #
 # Test PrioritiseTransaction code

--- a/qa/rpc-tests/prioritise_transaction.py
+++ b/qa/rpc-tests/prioritise_transaction.py
@@ -61,7 +61,7 @@ class PrioritiseTransactionTest(BitcoinTestFramework):
         self.nodes[0].generate(1)
 
         mempool = self.nodes[0].getrawmempool()
-        print "Assert that prioritised transaction was mined"
+        print("Assert that prioritised transaction was mined")
         assert(txids[0][0] not in mempool)
         assert(txids[0][1] in mempool)
 
@@ -93,7 +93,7 @@ class PrioritiseTransactionTest(BitcoinTestFramework):
         # High fee transaction should not have been mined, but other high fee rate
         # transactions should have been.
         mempool = self.nodes[0].getrawmempool()
-        print "Assert that de-prioritised transaction is still in mempool"
+        print("Assert that de-prioritised transaction is still in mempool")
         assert(high_fee_tx in mempool)
         for x in txids[2]:
             if (x != high_fee_tx):
@@ -135,7 +135,7 @@ class PrioritiseTransactionTest(BitcoinTestFramework):
         # accepted.
         self.nodes[0].prioritisetransaction(tx2_id, 0, int(self.relayfee*COIN))
 
-        print "Assert that prioritised free transaction is accepted to mempool"
+        print("Assert that prioritised free transaction is accepted to mempool")
         assert_equal(self.nodes[0].sendrawtransaction(tx2_hex), tx2_id)
         assert(tx2_id in self.nodes[0].getrawmempool())
 

--- a/qa/rpc-tests/proxy_test.py
+++ b/qa/rpc-tests/proxy_test.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python2
-# Copyright (c) 2015 The Bitcoin Core developers
+# Copyright (c) 2015-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from __future__ import division,print_function
 import socket
 
 from test_framework.socks5 import Socks5Configuration, Socks5Command, Socks5Server, AddressType

--- a/qa/rpc-tests/pruning.py
+++ b/qa/rpc-tests/pruning.py
@@ -11,6 +11,8 @@
 # This test takes 30 mins or more (up to 2 hours)
 # ********
 
+from __future__ import print_function
+
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
 
@@ -65,9 +67,9 @@ class PruneTest(BitcoinTestFramework):
     def test_height_min(self):
         if not os.path.isfile(self.prunedir+"blk00000.dat"):
             raise AssertionError("blk00000.dat is missing, pruning too early")
-        print "Success"
-        print "Though we're already using more than 550MB, current usage:", calc_usage(self.prunedir)
-        print "Mining 25 more blocks should cause the first block file to be pruned"
+        print("Success")
+        print("Though we're already using more than 550MB, current usage:", calc_usage(self.prunedir))
+        print("Mining 25 more blocks should cause the first block file to be pruned")
         # Pruning doesn't run until we're allocating another chunk, 20 full blocks past the height cutoff will ensure this
         for i in xrange(25):
             self.mine_full_block(self.nodes[0],self.address[0])
@@ -78,15 +80,15 @@ class PruneTest(BitcoinTestFramework):
             if time.time() - waitstart > 10:
                 raise AssertionError("blk00000.dat not pruned when it should be")
 
-        print "Success"
+        print("Success")
         usage = calc_usage(self.prunedir)
-        print "Usage should be below target:", usage
+        print("Usage should be below target:", usage)
         if (usage > 550):
             raise AssertionError("Pruning target not being met")
 
     def create_chain_with_staleblocks(self):
         # Create stale blocks in manageable sized chunks
-        print "Mine 24 (stale) blocks on Node 1, followed by 25 (main chain) block reorg from Node 0, for 12 rounds"
+        print("Mine 24 (stale) blocks on Node 1, followed by 25 (main chain) block reorg from Node 0, for 12 rounds")
 
         for j in xrange(12):
             # Disconnect node 0 so it can mine a longer reorg chain without knowing about node 1's soon-to-be-stale chain
@@ -112,7 +114,7 @@ class PruneTest(BitcoinTestFramework):
             connect_nodes(self.nodes[2], 0)
             sync_blocks(self.nodes[0:3])
 
-        print "Usage can be over target because of high stale rate:", calc_usage(self.prunedir)
+        print("Usage can be over target because of high stale rate:", calc_usage(self.prunedir))
 
     def reorg_test(self):
         # Node 1 will mine a 300 block chain starting 287 blocks back from Node 0 and Node 2's tip
@@ -123,11 +125,11 @@ class PruneTest(BitcoinTestFramework):
         self.nodes[1]=start_node(1, self.options.tmpdir, ["-debug","-maxreceivebuffer=20000","-blockmaxsize=5000", "-checkblocks=5", "-disablesafemode"], timewait=900)
 
         height = self.nodes[1].getblockcount()
-        print "Current block height:", height
+        print("Current block height:", height)
 
         invalidheight = height-287
         badhash = self.nodes[1].getblockhash(invalidheight)
-        print "Invalidating block at height:",invalidheight,badhash
+        print("Invalidating block at height:",invalidheight,badhash)
         self.nodes[1].invalidateblock(badhash)
 
         # We've now switched to our previously mined-24 block fork on node 1, but thats not what we want
@@ -139,29 +141,29 @@ class PruneTest(BitcoinTestFramework):
             curhash = self.nodes[1].getblockhash(invalidheight - 1)
 
         assert(self.nodes[1].getblockcount() == invalidheight - 1)
-        print "New best height", self.nodes[1].getblockcount()
+        print("New best height", self.nodes[1].getblockcount())
 
         # Reboot node1 to clear those giant tx's from mempool
         stop_node(self.nodes[1],1)
         self.nodes[1]=start_node(1, self.options.tmpdir, ["-debug","-maxreceivebuffer=20000","-blockmaxsize=5000", "-checkblocks=5", "-disablesafemode"], timewait=900)
 
-        print "Generating new longer chain of 300 more blocks"
+        print("Generating new longer chain of 300 more blocks")
         self.nodes[1].generate(300)
 
-        print "Reconnect nodes"
+        print("Reconnect nodes")
         connect_nodes(self.nodes[0], 1)
         connect_nodes(self.nodes[2], 1)
         sync_blocks(self.nodes[0:3])
 
-        print "Verify height on node 2:",self.nodes[2].getblockcount()
-        print "Usage possibly still high bc of stale blocks in block files:", calc_usage(self.prunedir)
+        print("Verify height on node 2:",self.nodes[2].getblockcount())
+        print("Usage possibly still high bc of stale blocks in block files:", calc_usage(self.prunedir))
 
-        print "Mine 220 more blocks so we have requisite history (some blocks will be big and cause pruning of previous chain)"
+        print("Mine 220 more blocks so we have requisite history (some blocks will be big and cause pruning of previous chain)")
         self.nodes[0].generate(220) #node 0 has many large tx's in its mempool from the disconnects
         sync_blocks(self.nodes[0:3])
 
         usage = calc_usage(self.prunedir)
-        print "Usage should be below target:", usage
+        print("Usage should be below target:", usage)
         if (usage > 550):
             raise AssertionError("Pruning target not being met")
 
@@ -173,7 +175,7 @@ class PruneTest(BitcoinTestFramework):
             self.nodes[2].getblock(self.forkhash)
             raise AssertionError("Old block wasn't pruned so can't test redownload")
         except JSONRPCException as e:
-            print "Will need to redownload block",self.forkheight
+            print("Will need to redownload block",self.forkheight)
 
         # Verify that we have enough history to reorg back to the fork point
         # Although this is more than 288 blocks, because this chain was written more recently
@@ -197,14 +199,14 @@ class PruneTest(BitcoinTestFramework):
         # At this point node 2 is within 288 blocks of the fork point so it will preserve its ability to reorg
         if self.nodes[2].getblockcount() < self.mainchainheight:
             blocks_to_mine = first_reorg_height + 1 - self.mainchainheight
-            print "Rewind node 0 to prev main chain to mine longer chain to trigger redownload. Blocks needed:", blocks_to_mine
+            print("Rewind node 0 to prev main chain to mine longer chain to trigger redownload. Blocks needed:", blocks_to_mine)
             self.nodes[0].invalidateblock(curchainhash)
             assert(self.nodes[0].getblockcount() == self.mainchainheight)
             assert(self.nodes[0].getbestblockhash() == self.mainchainhash2)
             goalbesthash = self.nodes[0].generate(blocks_to_mine)[-1]
             goalbestheight = first_reorg_height + 1
 
-        print "Verify node 2 reorged back to the main chain, some blocks of which it had to redownload"
+        print("Verify node 2 reorged back to the main chain, some blocks of which it had to redownload")
         waitstart = time.time()
         while self.nodes[2].getblockcount() < goalbestheight:
             time.sleep(0.1)
@@ -241,8 +243,8 @@ class PruneTest(BitcoinTestFramework):
 
 
     def run_test(self):
-        print "Warning! This test requires 4GB of disk space and takes over 30 mins (up to 2 hours)"
-        print "Mining a big blockchain of 995 blocks"
+        print("Warning! This test requires 4GB of disk space and takes over 30 mins (up to 2 hours)")
+        print("Mining a big blockchain of 995 blocks")
         self.create_big_chain()
         # Chain diagram key:
         # *   blocks on main chain
@@ -253,12 +255,12 @@ class PruneTest(BitcoinTestFramework):
         # Start by mining a simple chain that all nodes have
         # N0=N1=N2 **...*(995)
 
-        print "Check that we haven't started pruning yet because we're below PruneAfterHeight"
+        print("Check that we haven't started pruning yet because we're below PruneAfterHeight")
         self.test_height_min()
         # Extend this chain past the PruneAfterHeight
         # N0=N1=N2 **...*(1020)
 
-        print "Check that we'll exceed disk space target if we have a very high stale block rate"
+        print("Check that we'll exceed disk space target if we have a very high stale block rate")
         self.create_chain_with_staleblocks()
         # Disconnect N0
         # And mine a 24 block chain on N1 and a separate 25 block chain on N0
@@ -282,7 +284,7 @@ class PruneTest(BitcoinTestFramework):
         self.mainchainheight = self.nodes[2].getblockcount()   #1320
         self.mainchainhash2 = self.nodes[2].getblockhash(self.mainchainheight)
 
-        print "Check that we can survive a 288 block reorg still"
+        print("Check that we can survive a 288 block reorg still")
         (self.forkheight,self.forkhash) = self.reorg_test() #(1033, )
         # Now create a 288 block reorg by mining a longer chain on N1
         # First disconnect N1
@@ -315,7 +317,7 @@ class PruneTest(BitcoinTestFramework):
         #                                 \
         #                                  *...**(1320)
 
-        print "Test that we can rerequest a block we previously pruned if needed for a reorg"
+        print("Test that we can rerequest a block we previously pruned if needed for a reorg")
         self.reorg_back()
         # Verify that N2 still has block 1033 on current chain (@), but not on main chain (*)
         # Invalidate 1033 on current chain (@) on N2 and we should be able to reorg to
@@ -335,7 +337,7 @@ class PruneTest(BitcoinTestFramework):
         #
         # N1 doesn't change because 1033 on main chain (*) is invalid
 
-        print "Done"
+        print("Done")
 
 if __name__ == '__main__':
     PruneTest().main()

--- a/qa/rpc-tests/pruning.py
+++ b/qa/rpc-tests/pruning.py
@@ -17,7 +17,7 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
 
 def calc_usage(blockdir):
-    return sum(os.path.getsize(blockdir+f) for f in os.listdir(blockdir) if os.path.isfile(blockdir+f))/(1024*1024)
+    return sum(os.path.getsize(blockdir+f) for f in os.listdir(blockdir) if os.path.isfile(blockdir+f)) / (1024. * 1024.)
 
 class PruneTest(BitcoinTestFramework):
 
@@ -58,7 +58,7 @@ class PruneTest(BitcoinTestFramework):
         self.nodes[1].generate(200)
         sync_blocks(self.nodes[0:2])
         self.nodes[0].generate(150)
-        # Then mine enough full blocks to create more than 550MB of data
+        # Then mine enough full blocks to create more than 550MiB of data
         for i in xrange(645):
             self.mine_full_block(self.nodes[0], self.address[0])
 
@@ -68,7 +68,7 @@ class PruneTest(BitcoinTestFramework):
         if not os.path.isfile(self.prunedir+"blk00000.dat"):
             raise AssertionError("blk00000.dat is missing, pruning too early")
         print("Success")
-        print("Though we're already using more than 550MB, current usage:", calc_usage(self.prunedir))
+        print("Though we're already using more than 550MiB, current usage:", calc_usage(self.prunedir))
         print("Mining 25 more blocks should cause the first block file to be pruned")
         # Pruning doesn't run until we're allocating another chunk, 20 full blocks past the height cutoff will ensure this
         for i in xrange(25):

--- a/qa/rpc-tests/pruning.py
+++ b/qa/rpc-tests/pruning.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -11,7 +11,7 @@
 # This test takes 30 mins or more (up to 2 hours)
 # ********
 
-from __future__ import print_function
+from __future__ import division,print_function
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *

--- a/qa/rpc-tests/rawtransactions.py
+++ b/qa/rpc-tests/rawtransactions.py
@@ -59,7 +59,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         errorString = ""
         try:
             rawtx   = self.nodes[2].sendrawtransaction(rawtx['hex'])
-        except JSONRPCException,e:
+        except JSONRPCException as e:
             errorString = e.error['message']
 
         assert("Missing inputs" in errorString)

--- a/qa/rpc-tests/rawtransactions.py
+++ b/qa/rpc-tests/rawtransactions.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from __future__ import division,print_function
 
 #
 # Test re-org scenarios with a mempool that contains transactions

--- a/qa/rpc-tests/receivedby.py
+++ b/qa/rpc-tests/receivedby.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from __future__ import division,print_function
 
 # Exercise the listreceivedbyaddress API
 

--- a/qa/rpc-tests/reindex.py
+++ b/qa/rpc-tests/reindex.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from __future__ import division,print_function
 
 #
 # Test -reindex with CheckBlockIndex

--- a/qa/rpc-tests/reindex.py
+++ b/qa/rpc-tests/reindex.py
@@ -26,7 +26,7 @@ class ReindexTest(BitcoinTestFramework):
         wait_bitcoinds()
         self.nodes[0]=start_node(0, self.options.tmpdir, ["-debug", "-reindex", "-checkblockindex=1"])
         assert_equal(self.nodes[0].getblockcount(), 3)
-        print "Success"
+        print("Success")
 
 if __name__ == '__main__':
     ReindexTest().main()

--- a/qa/rpc-tests/replace-by-fee.py
+++ b/qa/rpc-tests/replace-by-fee.py
@@ -88,34 +88,34 @@ class ReplaceByFeeTest(BitcoinTestFramework):
     def run_test(self):
         make_utxo(self.nodes[0], 1*COIN)
 
-        print "Running test simple doublespend..."
+        print("Running test simple doublespend...")
         self.test_simple_doublespend()
 
-        print "Running test doublespend chain..."
+        print("Running test doublespend chain...")
         self.test_doublespend_chain()
 
-        print "Running test doublespend tree..."
+        print("Running test doublespend tree...")
         self.test_doublespend_tree()
 
-        print "Running test replacement feeperkb..."
+        print("Running test replacement feeperkb...")
         self.test_replacement_feeperkb()
 
-        print "Running test spends of conflicting outputs..."
+        print("Running test spends of conflicting outputs...")
         self.test_spends_of_conflicting_outputs()
 
-        print "Running test new unconfirmed inputs..."
+        print("Running test new unconfirmed inputs...")
         self.test_new_unconfirmed_inputs()
 
-        print "Running test too many replacements..."
+        print("Running test too many replacements...")
         self.test_too_many_replacements()
 
-        print "Running test opt-in..."
+        print("Running test opt-in...")
         self.test_opt_in()
 
-        print "Running test prioritised transactions..."
+        print("Running test prioritised transactions...")
         self.test_prioritised_transactions()
 
-        print "Passed\n"
+        print("Passed\n")
 
     def test_simple_doublespend(self):
         """Simple doublespend"""
@@ -465,7 +465,7 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         except JSONRPCException as exp:
             assert_equal(exp.error['code'], -26)
         else:
-            print tx1b_txid
+            print(tx1b_txid)
             assert(False)
 
         tx1_outpoint = make_utxo(self.nodes[0], 1.1*COIN)

--- a/qa/rpc-tests/replace-by-fee.py
+++ b/qa/rpc-tests/replace-by-fee.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from __future__ import division,print_function
 
 #
 # Test replace by fee code

--- a/qa/rpc-tests/rest.py
+++ b/qa/rpc-tests/rest.py
@@ -67,7 +67,7 @@ class RESTTest (BitcoinTestFramework):
 
     def run_test(self):
         url = urlparse.urlparse(self.nodes[0].url)
-        print "Mining blocks..."
+        print("Mining blocks...")
 
         self.nodes[0].generate(1)
         self.sync_all()

--- a/qa/rpc-tests/rest.py
+++ b/qa/rpc-tests/rest.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from __future__ import division,print_function
 
 #
 # Test REST interface

--- a/qa/rpc-tests/rpcbind_test.py
+++ b/qa/rpc-tests/rpcbind_test.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from __future__ import division,print_function
 
 # Test for -rpcbind, as well as -rpcallowip and -rpcconnect
 

--- a/qa/rpc-tests/sendheaders.py
+++ b/qa/rpc-tests/sendheaders.py
@@ -266,7 +266,7 @@ class SendHeadersTest(BitcoinTestFramework):
 
         # PART 1
         # 1. Mine a block; expect inv announcements each time
-        print "Part 1: headers don't start before sendheaders message..."
+        print("Part 1: headers don't start before sendheaders message...")
         for i in xrange(4):
             old_tip = tip
             tip = self.mine_blocks(1)
@@ -297,8 +297,8 @@ class SendHeadersTest(BitcoinTestFramework):
                 inv_node.clear_last_announcement()
                 test_node.clear_last_announcement()
 
-        print "Part 1: success!"
-        print "Part 2: announce blocks with headers after sendheaders message..."
+        print("Part 1: success!")
+        print("Part 2: announce blocks with headers after sendheaders message...")
         # PART 2
         # 2. Send a sendheaders message and test that headers announcements
         # commence and keep working.
@@ -360,9 +360,9 @@ class SendHeadersTest(BitcoinTestFramework):
                 height += 1
                 block_time += 1
 
-        print "Part 2: success!"
+        print("Part 2: success!")
 
-        print "Part 3: headers announcements can stop after large reorg, and resume after headers/inv from peer..."
+        print("Part 3: headers announcements can stop after large reorg, and resume after headers/inv from peer...")
 
         # PART 3.  Headers announcements can stop after large reorg, and resume after
         # getheaders or inv from peer.
@@ -424,9 +424,9 @@ class SendHeadersTest(BitcoinTestFramework):
             assert_equal(inv_node.check_last_announcement(inv=[tip]), True)
             assert_equal(test_node.check_last_announcement(headers=[tip]), True)
 
-        print "Part 3: success!"
+        print("Part 3: success!")
 
-        print "Part 4: Testing direct fetch behavior..."
+        print("Part 4: Testing direct fetch behavior...")
         tip = self.mine_blocks(1)
         height = self.nodes[0].getblockcount() + 1
         last_time = self.nodes[0].getblock(self.nodes[0].getbestblockhash())['time']
@@ -507,7 +507,7 @@ class SendHeadersTest(BitcoinTestFramework):
         with mininode_lock:
             assert_equal(test_node.last_getdata, None)
 
-        print "Part 4: success!"
+        print("Part 4: success!")
 
         # Finally, check that the inv node never received a getdata request,
         # throughout the test

--- a/qa/rpc-tests/sendheaders.py
+++ b/qa/rpc-tests/sendheaders.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT/X11 software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-#
+
+from __future__ import division,print_function
 
 from test_framework.mininode import *
 from test_framework.test_framework import BitcoinTestFramework

--- a/qa/rpc-tests/signrawtransactions.py
+++ b/qa/rpc-tests/signrawtransactions.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python2
-# Copyright (c) 2015 The Bitcoin Core developers
+# Copyright (c) 2015-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from __future__ import division,print_function
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *

--- a/qa/rpc-tests/smartfees.py
+++ b/qa/rpc-tests/smartfees.py
@@ -105,7 +105,7 @@ def check_estimates(node, fees_seen, max_invalid, print_estimates = True):
         print([str(all_estimates[e-1]) for e in [1,2,3,6,15,25]])
     delta = 1.0e-6 # account for rounding error
     last_e = max(fees_seen)
-    for e in filter(lambda x: x >= 0, all_estimates):
+    for e in [x for x in all_estimates if x >= 0]:
         # Estimates should be within the bounds of what transactions fees actually were:
         if float(e)+delta < min(fees_seen) or float(e)-delta > max(fees_seen):
             raise AssertionError("Estimated fee (%f) out of range (%f,%f)"

--- a/qa/rpc-tests/smartfees.py
+++ b/qa/rpc-tests/smartfees.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from __future__ import division,print_function
 
 #
 # Test fee estimation code
@@ -219,7 +221,7 @@ class EstimateFeeTest(BitcoinTestFramework):
                 from_index = random.randint(1,2)
                 (txhex, fee) = small_txpuzzle_randfee(self.nodes[from_index], self.confutxo,
                                                       self.memutxo, Decimal("0.005"), min_fee, min_fee)
-                tx_kbytes = (len(txhex)/2)/1000.0
+                tx_kbytes = (len(txhex) // 2) / 1000.0
                 self.fees_per_kb.append(float(fee)/tx_kbytes)
             sync_mempools(self.nodes[0:3],.1)
             mined = mining_node.getblock(mining_node.generate(1)[0],True)["tx"]

--- a/qa/rpc-tests/test_framework/blockstore.py
+++ b/qa/rpc-tests/test_framework/blockstore.py
@@ -66,7 +66,7 @@ class BlockStore(object):
         try:
             self.blockDB[repr(block.sha256)] = bytes(block.serialize())
         except TypeError as e:
-            print "Unexpected error: ", sys.exc_info()[0], e.args
+            print("Unexpected error: ", sys.exc_info()[0], e.args)
         self.currentBlock = block.sha256
         self.headers_map[block.sha256] = CBlockHeader(block)
 
@@ -126,7 +126,7 @@ class TxStore(object):
         try:
             self.txDB[repr(tx.sha256)] = bytes(tx.serialize())
         except TypeError as e:
-            print "Unexpected error: ", sys.exc_info()[0], e.args
+            print("Unexpected error: ", sys.exc_info()[0], e.args)
 
     def get_transactions(self, inv):
         responses = []

--- a/qa/rpc-tests/test_framework/blockstore.py
+++ b/qa/rpc-tests/test_framework/blockstore.py
@@ -3,6 +3,7 @@
 #             and for constructing a getheaders message
 #
 
+from __future__ import division, print_function
 from .mininode import *
 import dbm
 

--- a/qa/rpc-tests/test_framework/blockstore.py
+++ b/qa/rpc-tests/test_framework/blockstore.py
@@ -3,7 +3,7 @@
 #             and for constructing a getheaders message
 #
 
-from mininode import *
+from .mininode import *
 import dbm
 
 class BlockStore(object):

--- a/qa/rpc-tests/test_framework/blocktools.py
+++ b/qa/rpc-tests/test_framework/blocktools.py
@@ -4,8 +4,8 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #
 
-from mininode import *
-from script import CScript, OP_TRUE, OP_CHECKSIG
+from .mininode import *
+from .script import CScript, OP_TRUE, OP_CHECKSIG
 
 # Create a block (with regtest difficulty)
 def create_block(hashprev, coinbase, nTime=None):

--- a/qa/rpc-tests/test_framework/blocktools.py
+++ b/qa/rpc-tests/test_framework/blocktools.py
@@ -1,8 +1,9 @@
 # blocktools.py - utilities for manipulating blocks and transactions
-# Copyright (c) 2015 The Bitcoin Core developers
+# Copyright (c) 2015-2016 The Bitcoin Core developers
 # Distributed under the MIT/X11 software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-#
+
+from __future__ import division,print_function
 
 from .mininode import *
 from .script import CScript, OP_TRUE, OP_CHECKSIG

--- a/qa/rpc-tests/test_framework/comptool.py
+++ b/qa/rpc-tests/test_framework/comptool.py
@@ -4,9 +4,9 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #
 
-from mininode import *
-from blockstore import BlockStore, TxStore
-from util import p2p_port
+from .mininode import *
+from .blockstore import BlockStore, TxStore
+from .util import p2p_port
 
 '''
 This is a tool for comparing two or more bitcoinds to each other

--- a/qa/rpc-tests/test_framework/comptool.py
+++ b/qa/rpc-tests/test_framework/comptool.py
@@ -269,10 +269,10 @@ class TestManager(object):
                     if c.cb.bestblockhash == blockhash:
                         return False
                     if blockhash not in c.cb.block_reject_map:
-                        print 'Block not in reject map: %064x' % (blockhash)
+                        print('Block not in reject map: %064x' % (blockhash))
                         return False
                     if not outcome.match(c.cb.block_reject_map[blockhash]):
-                        print 'Block rejected with %s instead of expected %s: %064x' % (c.cb.block_reject_map[blockhash], outcome, blockhash)
+                        print('Block rejected with %s instead of expected %s: %064x' % (c.cb.block_reject_map[blockhash], outcome, blockhash))
                         return False
                 elif ((c.cb.bestblockhash == blockhash) != outcome):
                     # print c.cb.bestblockhash, blockhash, outcome
@@ -297,10 +297,10 @@ class TestManager(object):
                     if txhash in c.cb.lastInv:
                         return False
                     if txhash not in c.cb.tx_reject_map:
-                        print 'Tx not in reject map: %064x' % (txhash)
+                        print('Tx not in reject map: %064x' % (txhash))
                         return False
                     if not outcome.match(c.cb.tx_reject_map[txhash]):
-                        print 'Tx rejected with %s instead of expected %s: %064x' % (c.cb.tx_reject_map[txhash], outcome, txhash)
+                        print('Tx rejected with %s instead of expected %s: %064x' % (c.cb.tx_reject_map[txhash], outcome, txhash))
                         return False
                 elif ((txhash in c.cb.lastInv) != outcome):
                     # print c.rpc.getrawmempool(), c.cb.lastInv
@@ -403,7 +403,7 @@ class TestManager(object):
                 if (not self.check_mempool(tx.sha256, tx_outcome)):
                     raise AssertionError("Mempool test failed at test %d" % test_number)
 
-            print "Test %d: PASS" % test_number, [ c.rpc.getblockcount() for c in self.connections ]
+            print("Test %d: PASS" % test_number, [ c.rpc.getblockcount() for c in self.connections ])
             test_number += 1
 
         [ c.disconnect_node() for c in self.connections ]

--- a/qa/rpc-tests/test_framework/comptool.py
+++ b/qa/rpc-tests/test_framework/comptool.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python2
-# Copyright (c) 2015 The Bitcoin Core developers
+# Copyright (c) 2015-2016 The Bitcoin Core developers
 # Distributed under the MIT/X11 software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-#
+
+from __future__ import division,print_function
 
 from .mininode import *
 from .blockstore import BlockStore, TxStore

--- a/qa/rpc-tests/test_framework/coverage.py
+++ b/qa/rpc-tests/test_framework/coverage.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python2
-# Copyright (c) 2015 The Bitcoin Core developers
+# Copyright (c) 2015-2016 The Bitcoin Core developers
 # Distributed under the MIT/X11 software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-#
+
+from __future__ import division,print_function
 
 """
 This module contains utilities for doing coverage analysis on the RPC

--- a/qa/rpc-tests/test_framework/key.py
+++ b/qa/rpc-tests/test_framework/key.py
@@ -11,6 +11,7 @@ WARNING: This module does not mlock() secrets; your private keys may end up on
 disk in swap! Use with caution!
 """
 
+from __future__ import division, print_function
 import ctypes
 import ctypes.util
 import hashlib

--- a/qa/rpc-tests/test_framework/mininode.py
+++ b/qa/rpc-tests/test_framework/mininode.py
@@ -1046,8 +1046,8 @@ class NodeConnCB(object):
             try:
                 getattr(self, 'on_' + message.command)(conn, message)
             except:
-                print "ERROR delivering %s (%s)" % (repr(message),
-                                                    sys.exc_info()[0])
+                print("ERROR delivering %s (%s)" % (repr(message),
+                                                    sys.exc_info()[0]))
 
     def on_version(self, conn, message):
         if message.nVersion >= 209:
@@ -1137,8 +1137,8 @@ class NodeConn(asyncore.dispatcher):
         vt.addrFrom.ip = "0.0.0.0"
         vt.addrFrom.port = 0
         self.send_message(vt, True)
-        print 'MiniNode: Connecting to Bitcoin Node IP # ' + dstaddr + ':' \
-            + str(dstport)
+        print('MiniNode: Connecting to Bitcoin Node IP # ' + dstaddr + ':' \
+            + str(dstport))
 
         try:
             self.connect((dstaddr, dstport))

--- a/qa/rpc-tests/test_framework/mininode.py
+++ b/qa/rpc-tests/test_framework/mininode.py
@@ -2,6 +2,8 @@
 #
 # Distributed under the MIT/X11 software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from __future__ import division,print_function
 #
 # This python code was modified from ArtForz' public domain  half-a-node, as
 # found in the mini-node branch of http://github.com/jgarzik/pynode.

--- a/qa/rpc-tests/test_framework/netutil.py
+++ b/qa/rpc-tests/test_framework/netutil.py
@@ -45,7 +45,7 @@ def _convert_ip_port(array):
     # convert host from mangled-per-four-bytes form as used by kernel
     host = binascii.unhexlify(host)
     host_out = ''
-    for x in range(0, len(host)/4):
+    for x in range(0, len(host) // 4):
         (val,) = struct.unpack('=I', host[x*4:(x+1)*4])
         host_out += '%08x' % val
 

--- a/qa/rpc-tests/test_framework/netutil.py
+++ b/qa/rpc-tests/test_framework/netutil.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from __future__ import division,print_function
 
 # Linux network utilities
 import sys

--- a/qa/rpc-tests/test_framework/socks5.py
+++ b/qa/rpc-tests/test_framework/socks5.py
@@ -117,7 +117,7 @@ class Socks5Connection(object):
             self.serv.queue.put(cmdin)
             print('Proxy: ', cmdin)
             # Fall through to disconnect
-        except Exception,e:
+        except Exception as e:
             traceback.print_exc(file=sys.stderr)
             self.serv.queue.put(e)
         finally:

--- a/qa/rpc-tests/test_framework/socks5.py
+++ b/qa/rpc-tests/test_framework/socks5.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 The Bitcoin Core developers
+# Copyright (c) 2015-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 '''

--- a/qa/rpc-tests/test_framework/test_framework.py
+++ b/qa/rpc-tests/test_framework/test_framework.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from __future__ import division,print_function
 
 # Base class for RPC testing
 

--- a/qa/rpc-tests/test_framework/test_framework.py
+++ b/qa/rpc-tests/test_framework/test_framework.py
@@ -186,7 +186,7 @@ class ComparisonTestFramework(BitcoinTestFramework):
                           help="bitcoind binary to use for reference nodes (if any)")
 
     def setup_chain(self):
-        print "Initializing test directory "+self.options.tmpdir
+        print("Initializing test directory "+self.options.tmpdir)
         initialize_chain_clean(self.options.tmpdir, self.num_nodes)
 
     def setup_network(self):

--- a/qa/rpc-tests/test_framework/test_framework.py
+++ b/qa/rpc-tests/test_framework/test_framework.py
@@ -26,7 +26,7 @@ from .util import (
     check_json_precision,
     initialize_chain_clean,
 )
-from authproxy import AuthServiceProxy, JSONRPCException
+from .authproxy import AuthServiceProxy, JSONRPCException
 
 
 class BitcoinTestFramework(object):

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -1,6 +1,8 @@
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from __future__ import division,print_function
 #
 # Helpful routines for regression testing
 #

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -156,11 +156,11 @@ def initialize_chain(test_dir):
                 args.append("-connect=127.0.0.1:"+str(p2p_port(0)))
             bitcoind_processes[i] = subprocess.Popen(args)
             if os.getenv("PYTHON_DEBUG", ""):
-                print "initialize_chain: bitcoind started, calling bitcoin-cli -rpcwait getblockcount"
+                print("initialize_chain: bitcoind started, calling bitcoin-cli -rpcwait getblockcount")
             subprocess.check_call([ os.getenv("BITCOINCLI", "bitcoin-cli"), "-datadir="+datadir,
                                     "-rpcwait", "getblockcount"], stdout=devnull)
             if os.getenv("PYTHON_DEBUG", ""):
-                print "initialize_chain: bitcoin-cli -rpcwait getblockcount completed"
+                print("initialize_chain: bitcoin-cli -rpcwait getblockcount completed")
         devnull.close()
 
         rpcs = []
@@ -245,12 +245,12 @@ def start_node(i, dirname, extra_args=None, rpchost=None, timewait=None, binary=
     bitcoind_processes[i] = subprocess.Popen(args)
     devnull = open(os.devnull, "w")
     if os.getenv("PYTHON_DEBUG", ""):
-        print "start_node: bitcoind started, calling bitcoin-cli -rpcwait getblockcount"
+        print("start_node: bitcoind started, calling bitcoin-cli -rpcwait getblockcount")
     subprocess.check_call([ os.getenv("BITCOINCLI", "bitcoin-cli"), "-datadir="+datadir] +
                           _rpchost_to_args(rpchost)  +
                           ["-rpcwait", "getblockcount"], stdout=devnull)
     if os.getenv("PYTHON_DEBUG", ""):
-        print "start_node: calling bitcoin-cli -rpcwait getblockcount returned"
+        print("start_node: calling bitcoin-cli -rpcwait getblockcount returned")
     devnull.close()
     url = "http://rt:rt@%s:%d" % (rpchost or '127.0.0.1', rpc_port(i))
 

--- a/qa/rpc-tests/txn_clone.py
+++ b/qa/rpc-tests/txn_clone.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from __future__ import division,print_function
 
 #
 # Test proper accounting with an equivalent malleability clone

--- a/qa/rpc-tests/txn_doublespend.py
+++ b/qa/rpc-tests/txn_doublespend.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from __future__ import division,print_function
 
 #
 # Test proper accounting with a double-spend conflict

--- a/qa/rpc-tests/wallet.py
+++ b/qa/rpc-tests/wallet.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from __future__ import division,print_function
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *

--- a/qa/rpc-tests/wallet.py
+++ b/qa/rpc-tests/wallet.py
@@ -249,7 +249,7 @@ class WalletTest (BitcoinTestFramework):
         errorString = ""
         try:
             txId  = self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), "1f-4")
-        except JSONRPCException,e:
+        except JSONRPCException as e:
             errorString = e.error['message']
 
         assert_equal("Invalid amount" in errorString, True)
@@ -257,7 +257,7 @@ class WalletTest (BitcoinTestFramework):
         errorString = ""
         try:
             self.nodes[0].generate("2") #use a string to as block amount parameter must fail because it's not interpreted as amount
-        except JSONRPCException,e:
+        except JSONRPCException as e:
             errorString = e.error['message']
 
         assert_equal("not an integer" in errorString, True)

--- a/qa/rpc-tests/wallet.py
+++ b/qa/rpc-tests/wallet.py
@@ -32,7 +32,7 @@ class WalletTest (BitcoinTestFramework):
         self.sync_all()
 
     def run_test (self):
-        print "Mining blocks..."
+        print("Mining blocks...")
 
         self.nodes[0].generate(1)
 
@@ -276,7 +276,7 @@ class WalletTest (BitcoinTestFramework):
             '-salvagewallet',
         ]
         for m in maintenance:
-            print "check " + m
+            print("check " + m)
             stop_nodes(self.nodes)
             wait_bitcoinds()
             self.nodes = start_nodes(3, self.options.tmpdir, [[m]] * 3)

--- a/qa/rpc-tests/walletbackup.py
+++ b/qa/rpc-tests/walletbackup.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from __future__ import division,print_function
 
 """
 Exercise the wallet backup code.  Ported from walletbackup.sh.

--- a/qa/rpc-tests/zapwallettxes.py
+++ b/qa/rpc-tests/zapwallettxes.py
@@ -22,7 +22,7 @@ class ZapWalletTXesTest (BitcoinTestFramework):
         self.sync_all()
 
     def run_test (self):
-        print "Mining blocks..."
+        print("Mining blocks...")
         self.nodes[0].generate(1)
         self.sync_all()
         self.nodes[1].generate(101)

--- a/qa/rpc-tests/zapwallettxes.py
+++ b/qa/rpc-tests/zapwallettxes.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from __future__ import division,print_function
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *

--- a/qa/rpc-tests/zmq_test.py
+++ b/qa/rpc-tests/zmq_test.py
@@ -44,7 +44,7 @@ class ZMQTest (BitcoinTestFramework):
         genhashes = self.nodes[0].generate(1)
         self.sync_all()
 
-        print "listen..."
+        print("listen...")
         msg = self.zmqSubSocket.recv_multipart()
         topic = str(msg[0])
         body = msg[1]

--- a/qa/rpc-tests/zmq_test.py
+++ b/qa/rpc-tests/zmq_test.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python2
-# Copyright (c) 2015 The Bitcoin Core developers
+# Copyright (c) 2015-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from __future__ import division,print_function
 
 #
 # Test ZMQ interface


### PR DESCRIPTION
This will keep the `#!/usr/bin/env python2` in all headers but prepare the syntax for python3. See #7717 

Again: This pull will **not switch** from py2 to py3 **nor** add full py3 compatibility; it will only make it easier to do either of those later.
