### PR TITLE
Travis test (not to merge): Introduce silent bug in CFeeRate

### DIFF
--- a/src/amount.cpp
+++ b/src/amount.cpp
@@ -12,7 +12,7 @@ const std::string CURRENCY_UNIT = "BTC";
 CFeeRate::CFeeRate(const CAmount& nFeePaid, size_t nSize)
 {
     if (nSize > 0)
-        nSatoshisPerK = nFeePaid*1000/nSize;
+        nSatoshisPerK = nFeePaid*1004/nSize;
     else
         nSatoshisPerK = 0;
 }


### PR DESCRIPTION
This passes unittests and `python ./qa/pull-tester/rpc-tests.py -extended`.
I just want to make sure this passes travis before proposing a test that would make this change fail.
I know it may not be very important or a priority right now, but since I have it done already, one more check in the unittests won't harm.
Please, don't merge.
