### PR TITLE
Fees: Tests: Check CFeeRate internal precision in mempool_tests.cpp

### DIFF
--- a/src/amount.h
+++ b/src/amount.h
@@ -16,6 +16,7 @@ typedef int64_t CAmount;
 
 static const CAmount COIN = 100000000;
 static const CAmount CENT = 1000000;
+static const size_t KB = 1000;
 
 extern const std::string CURRENCY_UNIT;
 
@@ -37,7 +38,7 @@ inline bool MoneyRange(const CAmount& nValue) { return (nValue >= 0 && nValue <=
 class CFeeRate
 {
 private:
-    CAmount nSatoshisPerK; // unit is satoshis-per-1,000-bytes
+    CAmount nSatoshisPerK; //! unit is satoshis-per-1000-bytes
 public:
     /** Fee rate of 0 satoshis per kB */
     CFeeRate() : nSatoshisPerK(0) { }
@@ -52,7 +53,7 @@ public:
     /**
      * Return the fee in satoshis for a size of 1000 bytes
      */
-    CAmount GetFeePerK() const { return GetFee(1000); }
+    CAmount GetFeePerK() const { return GetFee(KB); }
     friend bool operator<(const CFeeRate& a, const CFeeRate& b) { return a.nSatoshisPerK < b.nSatoshisPerK; }
     friend bool operator>(const CFeeRate& a, const CFeeRate& b) { return a.nSatoshisPerK > b.nSatoshisPerK; }
     friend bool operator==(const CFeeRate& a, const CFeeRate& b) { return a.nSatoshisPerK == b.nSatoshisPerK; }

--- a/src/test/amount_tests.cpp
+++ b/src/test/amount_tests.cpp
@@ -66,6 +66,31 @@ BOOST_AUTO_TEST_CASE(GetFeeTest)
     BOOST_CHECK(CFeeRate(CAmount(27), 789) == CFeeRate(34));
     // Maximum size in bytes, should not crash
     CFeeRate(MAX_MONEY, std::numeric_limits<size_t>::max() >> 1).GetFeePerK();
+
+    // With full constructor (allows to test internal precission)
+    feeRate = CFeeRate(1000, KB * 2);
+    BOOST_CHECK_EQUAL(feeRate.GetFee(0), 0);
+    BOOST_CHECK_EQUAL(feeRate.GetFee(1), 1);
+    BOOST_CHECK_EQUAL(feeRate.GetFee(KB - 1), 499);
+    BOOST_CHECK_EQUAL(feeRate.GetFee(KB), 500);
+    BOOST_CHECK_EQUAL(feeRate.GetFee(KB + 1), 500);
+    BOOST_CHECK_EQUAL(feeRate.GetFee(KB * 2), 1000);
+    BOOST_CHECK_EQUAL(feeRate.GetFee(KB * 10), 5000);
+
+    feeRate = CFeeRate(1000 * 1000, KB * KB * KB);
+    BOOST_CHECK_EQUAL(feeRate.GetFee(0), 0);
+    BOOST_CHECK_EQUAL(feeRate.GetFee(1), 1);
+    BOOST_CHECK_EQUAL(feeRate.GetFee(KB - 1), 1);
+    BOOST_CHECK_EQUAL(feeRate.GetFee(KB), 1);
+    BOOST_CHECK_EQUAL(feeRate.GetFee((KB * 2) - 1), 1); // Lost precision
+    BOOST_CHECK_EQUAL(feeRate.GetFee(KB * 2), 2);
+    BOOST_CHECK_EQUAL(feeRate.GetFee(KB * 10), 10);
+    BOOST_CHECK_EQUAL(feeRate.GetFee((KB * 10) - 1), 9);
+    BOOST_CHECK_EQUAL(feeRate.GetFee(KB * 100), 100);
+    BOOST_CHECK_EQUAL(feeRate.GetFee((KB * KB) - 1), 999);
+    BOOST_CHECK_EQUAL(feeRate.GetFee(KB * KB), 1000);
+    BOOST_CHECK_EQUAL(feeRate.GetFee((KB * KB * KB) - 1), 999999);
+    BOOST_CHECK_EQUAL(feeRate.GetFee(KB * KB * KB), 1000000);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/mempool_tests.cpp
+++ b/src/test/mempool_tests.cpp
@@ -566,11 +566,20 @@ BOOST_AUTO_TEST_CASE(MempoolSizeLimitTest)
     BOOST_CHECK_EQUAL(pool.GetMinFee(pool.DynamicMemoryUsage() * 9 / 2).GetFeePerK(), (maxFeeRateRemoved.GetFeePerK() + 1000)/8);
     // ... with a 1/4 halflife when mempool is < 1/4 its target size
 
-    SetMockTime(42 + 7*CTxMemPool::ROLLING_FEE_HALFLIFE + CTxMemPool::ROLLING_FEE_HALFLIFE/2 + CTxMemPool::ROLLING_FEE_HALFLIFE/4);
+    unsigned i = 5;
+    // The current internal CFeeRate precision is KB (1000)
+    while (pool.GetMinFee(1).GetFeePerK() > (int)(2 * KB)) {
+        SetMockTime(42 + (++i)*CTxMemPool::ROLLING_FEE_HALFLIFE + CTxMemPool::ROLLING_FEE_HALFLIFE/2 + CTxMemPool::ROLLING_FEE_HALFLIFE/4);
+    }
+    // test increased stored precision in CFeeRate
+    SetMockTime(42 + i * CTxMemPool::ROLLING_FEE_HALFLIFE + CTxMemPool::ROLLING_FEE_HALFLIFE/2 + CTxMemPool::ROLLING_FEE_HALFLIFE/4);
+    BOOST_CHECK_EQUAL(pool.GetMinFee(1).GetFeePerK(), 1557); // Change this value when changing CFeeRate's internal precision
+
+    SetMockTime(42 + (i+1)*CTxMemPool::ROLLING_FEE_HALFLIFE + CTxMemPool::ROLLING_FEE_HALFLIFE/2 + CTxMemPool::ROLLING_FEE_HALFLIFE/4);
     BOOST_CHECK_EQUAL(pool.GetMinFee(1).GetFeePerK(), 1000);
     // ... but feerate should never drop below 1000
 
-    SetMockTime(42 + 8*CTxMemPool::ROLLING_FEE_HALFLIFE + CTxMemPool::ROLLING_FEE_HALFLIFE/2 + CTxMemPool::ROLLING_FEE_HALFLIFE/4);
+    SetMockTime(42 + (i+2)*CTxMemPool::ROLLING_FEE_HALFLIFE + CTxMemPool::ROLLING_FEE_HALFLIFE/2 + CTxMemPool::ROLLING_FEE_HALFLIFE/4);
     BOOST_CHECK_EQUAL(pool.GetMinFee(1).GetFeePerK(), 0);
     // ... unless it has gone all the way to 0 (after getting past 1000/2)
 


### PR DESCRIPTION
Although the risks are probably minimal or unexistent, #7727 shouldn't have passed travis' tests.
This adds a check that would fail with something like #7727.
I'm not saying there's a real risk in such a change passing review, but one more test shouldn't hurt.

A couple of constants are added that could be potentially useful if we ever intend to increase CFeeRate's internal precision multiplier above 1000 (aka KB), which I have no idea if it's the case right now, but I imagine could be something we want at some point in the future.
