### PR TITLE
[Qt] Debug window: replace "Build date" with "Datadir"

### DIFF
--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -193,6 +193,11 @@ QString ClientModel::formatClientStartupTime() const
     return QDateTime::fromTime_t(nClientStartupTime).toString();
 }
 
+QString ClientModel::dataDir() const
+{
+    return QString::fromStdString(GetDataDir().string());
+}
+
 void ClientModel::updateBanlist()
 {
     banTableModel->refresh();

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -173,11 +173,6 @@ QString ClientModel::formatSubVersion() const
     return QString::fromStdString(strSubVersion);
 }
 
-QString ClientModel::formatBuildDate() const
-{
-    return QString::fromStdString(CLIENT_DATE);
-}
-
 bool ClientModel::isReleaseVersion() const
 {
     return CLIENT_VERSION_IS_RELEASE;

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -72,7 +72,6 @@ public:
 
     QString formatFullVersion() const;
     QString formatSubVersion() const;
-    QString formatBuildDate() const;
     bool isReleaseVersion() const;
     QString clientName() const;
     QString formatClientStartupTime() const;

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -76,6 +76,7 @@ public:
     bool isReleaseVersion() const;
     QString clientName() const;
     QString formatClientStartupTime() const;
+    QString dataDir() const;
 
 private:
     OptionsModel *optionsModel;

--- a/src/qt/forms/debugwindow.ui
+++ b/src/qt/forms/debugwindow.ui
@@ -141,12 +141,12 @@
        <item row="5" column="0">
         <widget class="QLabel" name="label_12">
          <property name="text">
-          <string>Build date</string>
+          <string>Datadir</string>
          </property>
         </widget>
        </item>
        <item row="5" column="1" colspan="2">
-        <widget class="QLabel" name="buildDate">
+        <widget class="QLabel" name="dataDir">
          <property name="cursor">
           <cursorShape>IBeamCursor</cursorShape>
          </property>
@@ -155,6 +155,9 @@
          </property>
          <property name="textFormat">
           <enum>Qt::PlainText</enum>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
          </property>
          <property name="textInteractionFlags">
           <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -444,7 +444,7 @@ void RPCConsole::setClientModel(ClientModel *model)
         ui->clientVersion->setText(model->formatFullVersion());
         ui->clientUserAgent->setText(model->formatSubVersion());
         ui->clientName->setText(model->clientName());
-        ui->buildDate->setText(model->formatBuildDate());
+        ui->dataDir->setText(model->dataDir());
         ui->startupTime->setText(model->formatClientStartupTime());
         ui->networkName->setText(QString::fromStdString(Params().NetworkIDString()));
 


### PR DESCRIPTION
The build date does only make sense for custom/self-compiled bitcoin-core versions because we are using static build-dates for our deterministic release builds.

Having a quick option to get the current datadir is much more valuable for debug purposes.

I could optional re-add the build-date for self compiled versions if someone brings up a concrete reason/value to keep it.

Optional this could be extended to open the datadir in the OS file explore when someone clicks on the label (Would require some platform dependent code: http://stackoverflow.com/questions/3490336/how-to-reveal-in-finder-or-show-in-explorer-with-qt).
