### PR TITLE
[0.12] Mark p2p alert system as deprecated

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -35,10 +35,7 @@ earlier.
 Notable changes
 ===============
 
-Example item
----------------------------------------
-
-Example text.
+The p2p alert system is off by default. To turn on, use `-alert` with startup configuration.
 
 0.12.1 Change log
 =================

--- a/src/main.h
+++ b/src/main.h
@@ -41,7 +41,7 @@ class CValidationState;
 struct CNodeStateStats;
 
 /** Default for accepting alerts from the P2P network. */
-static const bool DEFAULT_ALERTS = true;
+static const bool DEFAULT_ALERTS = false;
 /** Default for DEFAULT_WHITELISTRELAY. */
 static const bool DEFAULT_WHITELISTRELAY = true;
 /** Default for DEFAULT_WHITELISTFORCERELAY. */


### PR DESCRIPTION
Set `-alert=0` by default.

This feature is removed entirely as of 0.13.0

Please backport to 0.11
