### PR TITLE
test and regtest mempool: not require standard, non-mandatory, input script verification flags

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1352,7 +1352,7 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState& state, const C
 
         // Check against previous transactions
         // This is done last to help prevent CPU exhaustion denial-of-service attacks.
-        if (!CheckInputs(tx, state, view, true, STANDARD_SCRIPT_VERIFY_FLAGS, true))
+        if (fRequireStandard && !CheckInputs(tx, state, view, true, STANDARD_SCRIPT_VERIFY_FLAGS, true))
             return false; // state filled in by CheckInputs
 
         // Check again against just the consensus-critical mandatory script


### PR DESCRIPTION
I was testing non-standard signature hash flags on test and regtest and was getting these rejections: "non-mandatory-script-verify-flag (Signature hash type missing or not understood)"

This change to AcceptToMemoryPoolWorker simply allows the mempool of nodes on the test and regtest networks to accept transactions containing signatures with non-standard signature hash types.
