### PR TITLE
test_framework: python3.4 authproxy compat

### DIFF
--- a/qa/rpc-tests/test_framework/authproxy.py
+++ b/qa/rpc-tests/test_framework/authproxy.py
@@ -61,7 +61,7 @@ class JSONRPCException(Exception):
 
 def EncodeDecimal(o):
     if isinstance(o, decimal.Decimal):
-        return round(o, 8)
+        return str(o)
     raise TypeError(repr(o) + " is not JSON serializable")
 
 class AuthServiceProxy(object):

--- a/qa/rpc-tests/test_framework/authproxy.py
+++ b/qa/rpc-tests/test_framework/authproxy.py
@@ -92,11 +92,10 @@ class AuthServiceProxy(object):
             self.__conn = connection
         elif self.__url.scheme == 'https':
             self.__conn = httplib.HTTPSConnection(self.__url.hostname, port,
-                                                  None, None, False,
-                                                  timeout)
+                                                  timeout=timeout)
         else:
             self.__conn = httplib.HTTPConnection(self.__url.hostname, port,
-                                                 False, timeout)
+                                                 timeout=timeout)
 
     def __getattr__(self, name):
         if name.startswith('__') and name.endswith('__'):


### PR DESCRIPTION
Changed in version 3.4: The strict parameter was removed. HTTP 0.9-style “Simple Responses” are not longer supported. (https://docs.python.org/3/library/http.client.html)

Work around this by using a named parameter.

Also avoid an infinite loop in encoding, by ensuring EncodeDecimal returns a string. round(Decimal) used to convert it to float, but it no longer does. Strings are supported since #6380, so just use that.
