### PR TITLE
zmq: mempool notifications

### DIFF
--- a/contrib/zmq/zmq_sub.py
+++ b/contrib/zmq/zmq_sub.py
@@ -13,7 +13,12 @@ zmqSubSocket.setsockopt(zmq.SUBSCRIBE, "hashblock")
 zmqSubSocket.setsockopt(zmq.SUBSCRIBE, "hashtx")
 zmqSubSocket.setsockopt(zmq.SUBSCRIBE, "rawblock")
 zmqSubSocket.setsockopt(zmq.SUBSCRIBE, "rawtx")
+zmqSubSocket.setsockopt(zmq.SUBSCRIBE, "mempooladded")
+zmqSubSocket.setsockopt(zmq.SUBSCRIBE, "mempoolremoved")
 zmqSubSocket.connect("tcp://127.0.0.1:%i" % port)
+
+# Reasons for removal of transaction from mempool
+MPR_REASONS = {0:'UNKNOWN', 1:'EXPIRY', 2:'SIZELIMIT', 3:'REORG', 4:'BLOCK', 5:'REPLACED'}
 
 try:
     while True:
@@ -36,6 +41,14 @@ try:
         elif topic == "rawtx":
             print '- RAW TX ('+sequence+') -'
             print binascii.hexlify(body)
+        elif topic == 'mempooladded':
+            print '- MEMPOOL ADDED -'
+            (hash, fee, size) = struct.unpack('<32sQI', body)
+            print '%s fee=%i size=%i' % (binascii.hexlify(hash), fee, size)
+        elif topic == 'mempoolremoved':
+            print '- MEMPOOL REMOVED -'
+            (hash, reason) = struct.unpack('<32sB', body)
+            print '%s reason=%s' % (binascii.hexlify(hash), MPR_REASONS.get(reason, 'UNKNOWN %i' % reason))
 
 except KeyboardInterrupt:
     zmqContext.destroy()

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -227,7 +227,6 @@ void Shutdown()
 
 #if ENABLE_ZMQ
     if (pzmqNotificationInterface) {
-        UnregisterValidationInterface(pzmqNotificationInterface);
         delete pzmqNotificationInterface;
         pzmqNotificationInterface = NULL;
     }
@@ -1146,10 +1145,6 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
 
 #if ENABLE_ZMQ
     pzmqNotificationInterface = CZMQNotificationInterface::CreateWithArguments(mapArgs, &mempool);
-
-    if (pzmqNotificationInterface) {
-        RegisterValidationInterface(pzmqNotificationInterface);
-    }
 #endif
     if (mapArgs.count("-maxuploadtarget")) {
         CNode::SetMaxOutboundTarget(GetArg("-maxuploadtarget", DEFAULT_MAX_UPLOAD_TARGET)*1024*1024);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1145,7 +1145,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
         AddOneShot(strDest);
 
 #if ENABLE_ZMQ
-    pzmqNotificationInterface = CZMQNotificationInterface::CreateWithArguments(mapArgs);
+    pzmqNotificationInterface = CZMQNotificationInterface::CreateWithArguments(mapArgs, &mempool);
 
     if (pzmqNotificationInterface) {
         RegisterValidationInterface(pzmqNotificationInterface);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1402,7 +1402,7 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState& state, const C
                     FormatMoney(nModifiedFees - nConflictingFees),
                     (int)nSize - (int)nConflictingSize);
         }
-        pool.RemoveStaged(allConflicting, false);
+        pool.RemoveStaged(allConflicting, false, MemPoolRemovalReason::REPLACED);
 
         // Store transaction in memory
         pool.addUnchecked(hash, entry, setAncestors, !IsInitialBlockDownload());
@@ -2652,7 +2652,7 @@ bool static DisconnectTip(CValidationState& state, const CChainParams& chainpara
         list<CTransaction> removed;
         CValidationState stateDummy;
         if (tx.IsCoinBase() || !AcceptToMemoryPool(mempool, stateDummy, tx, false, NULL, NULL, true)) {
-            mempool.removeRecursive(tx, removed);
+            mempool.removeRecursive(tx, removed, MemPoolRemovalReason::REORG);
         } else if (mempool.exists(tx.GetHash())) {
             vHashUpdate.push_back(tx.GetHash());
         }

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -388,6 +388,7 @@ void CTxMemPool::AddTransactionsUpdated(unsigned int n)
 
 bool CTxMemPool::addUnchecked(const uint256& hash, const CTxMemPoolEntry &entry, setEntries &setAncestors, bool fCurrentEstimate)
 {
+    NotifyEntryAdded(entry);
     // Add to memory pool without checking anything.
     // Used by main.cpp AcceptToMemoryPool(), which DOES do
     // all the appropriate checks.
@@ -441,8 +442,9 @@ bool CTxMemPool::addUnchecked(const uint256& hash, const CTxMemPoolEntry &entry,
     return true;
 }
 
-void CTxMemPool::removeUnchecked(txiter it)
+void CTxMemPool::removeUnchecked(txiter it, MemPoolRemovalReason reason)
 {
+    NotifyEntryRemoved(*it, reason);
     const uint256 hash = it->GetTx().GetHash();
     BOOST_FOREACH(const CTxIn& txin, it->GetTx().vin)
         mapNextTx.erase(txin.prevout);
@@ -485,7 +487,7 @@ void CTxMemPool::CalculateDescendants(txiter entryit, setEntries &setDescendants
     }
 }
 
-void CTxMemPool::removeRecursive(const CTransaction &origTx, std::list<CTransaction>& removed)
+void CTxMemPool::removeRecursive(const CTransaction &origTx, std::list<CTransaction>& removed, MemPoolRemovalReason reason)
 {
     // Remove transaction from memory pool
     {
@@ -515,7 +517,7 @@ void CTxMemPool::removeRecursive(const CTransaction &origTx, std::list<CTransact
         BOOST_FOREACH(txiter it, setAllRemoves) {
             removed.push_back(it->GetTx());
         }
-        RemoveStaged(setAllRemoves, false);
+        RemoveStaged(setAllRemoves, false, reason);
     }
 }
 
@@ -551,11 +553,11 @@ void CTxMemPool::removeForReorg(const CCoinsViewCache *pcoins, unsigned int nMem
     }
     BOOST_FOREACH(const CTransaction& tx, transactionsToRemove) {
         list<CTransaction> removed;
-        removeRecursive(tx, removed);
+        removeRecursive(tx, removed, MemPoolRemovalReason::REORG);
     }
 }
 
-void CTxMemPool::removeConflicts(const CTransaction &tx, std::list<CTransaction>& removed)
+void CTxMemPool::removeConflicts(const CTransaction &tx, std::list<CTransaction>& removed, MemPoolRemovalReason reason)
 {
     // Remove transactions which depend on inputs of tx, recursively
     list<CTransaction> result;
@@ -566,7 +568,7 @@ void CTxMemPool::removeConflicts(const CTransaction &tx, std::list<CTransaction>
             const CTransaction &txConflict = *it->second.ptx;
             if (txConflict != tx)
             {
-                removeRecursive(txConflict, removed);
+                removeRecursive(txConflict, removed, reason);
                 ClearPrioritisation(txConflict.GetHash());
             }
         }
@@ -595,9 +597,9 @@ void CTxMemPool::removeForBlock(const std::vector<CTransaction>& vtx, unsigned i
         if (it != mapTx.end()) {
             setEntries stage;
             stage.insert(it);
-            RemoveStaged(stage, true);
+            RemoveStaged(stage, true, MemPoolRemovalReason::BLOCK);
         }
-        removeConflicts(tx, conflicts);
+        removeConflicts(tx, conflicts, MemPoolRemovalReason::BLOCK);
         ClearPrioritisation(tx.GetHash());
     }
     // After the txs in the new block have been removed from the mempool, update policy estimates
@@ -936,11 +938,11 @@ size_t CTxMemPool::DynamicMemoryUsage() const {
     return memusage::MallocUsage(sizeof(CTxMemPoolEntry) + 15 * sizeof(void*)) * mapTx.size() + memusage::DynamicUsage(mapNextTx) + memusage::DynamicUsage(mapDeltas) + memusage::DynamicUsage(mapLinks) + cachedInnerUsage;
 }
 
-void CTxMemPool::RemoveStaged(setEntries &stage, bool updateDescendants) {
+void CTxMemPool::RemoveStaged(setEntries &stage, bool updateDescendants, MemPoolRemovalReason reason) {
     AssertLockHeld(cs);
     UpdateForRemoveFromMempool(stage, updateDescendants);
     BOOST_FOREACH(const txiter& it, stage) {
-        removeUnchecked(it);
+        removeUnchecked(it, reason);
     }
 }
 
@@ -956,7 +958,7 @@ int CTxMemPool::Expire(int64_t time) {
     BOOST_FOREACH(txiter removeit, toremove) {
         CalculateDescendants(removeit, stage);
     }
-    RemoveStaged(stage, false);
+    RemoveStaged(stage, false, MemPoolRemovalReason::EXPIRY);
     return stage.size();
 }
 
@@ -1065,7 +1067,7 @@ void CTxMemPool::TrimToSize(size_t sizelimit, std::vector<uint256>* pvNoSpendsRe
             BOOST_FOREACH(txiter it, stage)
                 txn.push_back(it->GetTx());
         }
-        RemoveStaged(stage, false);
+        RemoveStaged(stage, false, MemPoolRemovalReason::SIZELIMIT);
         if (pvNoSpendsRemaining) {
             BOOST_FOREACH(const CTransaction& tx, txn) {
                 BOOST_FOREACH(const CTxIn& txin, tx.vin) {

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -18,6 +18,8 @@
 #include "boost/multi_index_container.hpp"
 #include "boost/multi_index/ordered_index.hpp"
 
+#include <boost/signals2/signal.hpp>
+
 class CAutoFile;
 class CBlockIndex;
 
@@ -319,6 +321,18 @@ public:
     size_t DynamicMemoryUsage() const { return 0; }
 };
 
+/** Reason why a transaction was removed from the mempool,
+ * this is passed to the notification signal.
+ */
+enum class MemPoolRemovalReason {
+    UNKNOWN = 0, //! Manually removed or unknown reason
+    EXPIRY,      //! Expired from mempool
+    SIZELIMIT,   //! Removed in size limiting
+    REORG,       //! Removed for reorganization
+    BLOCK,       //! Removed for block
+    REPLACED     //! Removed for conflict (replaced)
+};
+
 /**
  * CTxMemPool stores valid-according-to-the-current-best-chain
  * transactions that may be included in the next block.
@@ -504,9 +518,9 @@ public:
     bool addUnchecked(const uint256& hash, const CTxMemPoolEntry &entry, bool fCurrentEstimate = true);
     bool addUnchecked(const uint256& hash, const CTxMemPoolEntry &entry, setEntries &setAncestors, bool fCurrentEstimate = true);
 
-    void removeRecursive(const CTransaction &tx, std::list<CTransaction>& removed);
+    void removeRecursive(const CTransaction &tx, std::list<CTransaction>& removed, MemPoolRemovalReason reason = MemPoolRemovalReason::UNKNOWN);
     void removeForReorg(const CCoinsViewCache *pcoins, unsigned int nMemPoolHeight, int flags);
-    void removeConflicts(const CTransaction &tx, std::list<CTransaction>& removed);
+    void removeConflicts(const CTransaction &tx, std::list<CTransaction>& removed, MemPoolRemovalReason reason = MemPoolRemovalReason::UNKNOWN);
     void removeForBlock(const std::vector<CTransaction>& vtx, unsigned int nBlockHeight,
                         std::list<CTransaction>& conflicts, bool fCurrentEstimate = true);
     void clear();
@@ -535,7 +549,7 @@ public:
      *  Set updateDescendants to true when removing a tx that was in a block, so
      *  that any in-mempool descendants have their ancestor state updated.
      */
-    void RemoveStaged(setEntries &stage, bool updateDescendants);
+    void RemoveStaged(setEntries &stage, bool updateDescendants, MemPoolRemovalReason reason = MemPoolRemovalReason::UNKNOWN);
 
     /** When adding transactions from a disconnected block back to the mempool,
      *  new mempool entries may have children in the mempool (which is generally
@@ -627,6 +641,9 @@ public:
 
     size_t DynamicMemoryUsage() const;
 
+    boost::signals2::signal<void (const CTxMemPoolEntry &)> NotifyEntryAdded;
+    boost::signals2::signal<void (const CTxMemPoolEntry &, MemPoolRemovalReason)> NotifyEntryRemoved;
+
 private:
     /** UpdateForDescendants is used by UpdateTransactionsFromBlock to update
      *  the descendants for a single transaction that has been added to the
@@ -663,7 +680,7 @@ private:
      *  transactions in a chain before we've updated all the state for the
      *  removal.
      */
-    void removeUnchecked(txiter entry);
+    void removeUnchecked(txiter entry, MemPoolRemovalReason reason = MemPoolRemovalReason::UNKNOWN);
 };
 
 /** 

--- a/src/zmq/zmqabstractnotifier.cpp
+++ b/src/zmq/zmqabstractnotifier.cpp
@@ -11,12 +11,3 @@ CZMQAbstractNotifier::~CZMQAbstractNotifier()
     assert(!psocket);
 }
 
-bool CZMQAbstractNotifier::NotifyBlock(const CBlockIndex * /*CBlockIndex*/)
-{
-    return true;
-}
-
-bool CZMQAbstractNotifier::NotifyTransaction(const CTransaction &/*transaction*/)
-{
-    return true;
-}

--- a/src/zmq/zmqabstractnotifier.h
+++ b/src/zmq/zmqabstractnotifier.h
@@ -10,19 +10,11 @@
 class CBlockIndex;
 class CZMQAbstractNotifier;
 
-typedef CZMQAbstractNotifier* (*CZMQNotifierFactory)();
-
 class CZMQAbstractNotifier
 {
 public:
     CZMQAbstractNotifier() : psocket(0) { }
     virtual ~CZMQAbstractNotifier();
-
-    template <typename T>
-    static CZMQAbstractNotifier* Create()
-    {
-        return new T();
-    }
 
     std::string GetType() const { return type; }
     void SetType(const std::string &t) { type = t; }

--- a/src/zmq/zmqabstractnotifier.h
+++ b/src/zmq/zmqabstractnotifier.h
@@ -24,9 +24,6 @@ public:
     virtual bool Initialize(void *pcontext) = 0;
     virtual void Shutdown() = 0;
 
-    virtual bool NotifyBlock(const CBlockIndex *pindex);
-    virtual bool NotifyTransaction(const CTransaction &transaction);
-
 protected:
     void *psocket;
     std::string type;

--- a/src/zmq/zmqnotificationinterface.cpp
+++ b/src/zmq/zmqnotificationinterface.cpp
@@ -44,7 +44,7 @@ static void addNotifier(const std::map<std::string, std::string> &args, std::lis
     }
 }
 
-CZMQNotificationInterface* CZMQNotificationInterface::CreateWithArguments(const std::map<std::string, std::string> &args)
+CZMQNotificationInterface* CZMQNotificationInterface::CreateWithArguments(const std::map<std::string, std::string> &args, CTxMemPool *mempool)
 {
     CZMQNotificationInterface* notificationInterface = NULL;
     std::list<CZMQAbstractNotifier*> notifiers;
@@ -53,6 +53,8 @@ CZMQNotificationInterface* CZMQNotificationInterface::CreateWithArguments(const 
     addNotifier(args, notifiers, "pubhashtx", new CZMQPublishHashTransactionNotifier());
     addNotifier(args, notifiers, "pubrawblock", new CZMQPublishRawBlockNotifier());
     addNotifier(args, notifiers, "pubrawtx", new CZMQPublishRawTransactionNotifier());
+    if (mempool)
+        addNotifier(args, notifiers, "pubmempool", new CZMQPublishMempoolNotifier(mempool));
 
     if (!notifiers.empty())
     {

--- a/src/zmq/zmqnotificationinterface.cpp
+++ b/src/zmq/zmqnotificationinterface.cpp
@@ -29,30 +29,30 @@ CZMQNotificationInterface::~CZMQNotificationInterface()
     }
 }
 
+/** Conditionally add notifier, if the right arguments are provided */
+static void addNotifier(const std::map<std::string, std::string> &args, std::list<CZMQAbstractNotifier*> &notifiers, const std::string &name, CZMQAbstractNotifier* notifier)
+{
+    std::map<std::string, std::string>::const_iterator j = args.find("-zmq" + name);
+    if (j!=args.end())
+    {
+        std::string address = j->second;
+        notifier->SetType(name);
+        notifier->SetAddress(address);
+        notifiers.push_back(notifier);
+    } else {
+        delete notifier;
+    }
+}
+
 CZMQNotificationInterface* CZMQNotificationInterface::CreateWithArguments(const std::map<std::string, std::string> &args)
 {
     CZMQNotificationInterface* notificationInterface = NULL;
-    std::map<std::string, CZMQNotifierFactory> factories;
     std::list<CZMQAbstractNotifier*> notifiers;
 
-    factories["pubhashblock"] = CZMQAbstractNotifier::Create<CZMQPublishHashBlockNotifier>;
-    factories["pubhashtx"] = CZMQAbstractNotifier::Create<CZMQPublishHashTransactionNotifier>;
-    factories["pubrawblock"] = CZMQAbstractNotifier::Create<CZMQPublishRawBlockNotifier>;
-    factories["pubrawtx"] = CZMQAbstractNotifier::Create<CZMQPublishRawTransactionNotifier>;
-
-    for (std::map<std::string, CZMQNotifierFactory>::const_iterator i=factories.begin(); i!=factories.end(); ++i)
-    {
-        std::map<std::string, std::string>::const_iterator j = args.find("-zmq" + i->first);
-        if (j!=args.end())
-        {
-            CZMQNotifierFactory factory = i->second;
-            std::string address = j->second;
-            CZMQAbstractNotifier *notifier = factory();
-            notifier->SetType(i->first);
-            notifier->SetAddress(address);
-            notifiers.push_back(notifier);
-        }
-    }
+    addNotifier(args, notifiers, "pubhashblock", new CZMQPublishHashBlockNotifier());
+    addNotifier(args, notifiers, "pubhashtx", new CZMQPublishHashTransactionNotifier());
+    addNotifier(args, notifiers, "pubrawblock", new CZMQPublishRawBlockNotifier());
+    addNotifier(args, notifiers, "pubrawtx", new CZMQPublishRawTransactionNotifier());
 
     if (!notifiers.empty())
     {

--- a/src/zmq/zmqnotificationinterface.cpp
+++ b/src/zmq/zmqnotificationinterface.cpp
@@ -125,37 +125,3 @@ void CZMQNotificationInterface::Shutdown()
         pcontext = 0;
     }
 }
-
-void CZMQNotificationInterface::UpdatedBlockTip(const CBlockIndex *pindex)
-{
-    for (std::list<CZMQAbstractNotifier*>::iterator i = notifiers.begin(); i!=notifiers.end(); )
-    {
-        CZMQAbstractNotifier *notifier = *i;
-        if (notifier->NotifyBlock(pindex))
-        {
-            i++;
-        }
-        else
-        {
-            notifier->Shutdown();
-            i = notifiers.erase(i);
-        }
-    }
-}
-
-void CZMQNotificationInterface::SyncTransaction(const CTransaction& tx, const CBlockIndex* pindex, const CBlock* pblock)
-{
-    for (std::list<CZMQAbstractNotifier*>::iterator i = notifiers.begin(); i!=notifiers.end(); )
-    {
-        CZMQAbstractNotifier *notifier = *i;
-        if (notifier->NotifyTransaction(tx))
-        {
-            i++;
-        }
-        else
-        {
-            notifier->Shutdown();
-            i = notifiers.erase(i);
-        }
-    }
-}

--- a/src/zmq/zmqnotificationinterface.h
+++ b/src/zmq/zmqnotificationinterface.h
@@ -11,13 +11,14 @@
 
 class CBlockIndex;
 class CZMQAbstractNotifier;
+class CTxMemPool;
 
 class CZMQNotificationInterface : public CValidationInterface
 {
 public:
     virtual ~CZMQNotificationInterface();
 
-    static CZMQNotificationInterface* CreateWithArguments(const std::map<std::string, std::string> &args);
+    static CZMQNotificationInterface* CreateWithArguments(const std::map<std::string, std::string> &args, CTxMemPool *mempool);
 
 protected:
     bool Initialize();

--- a/src/zmq/zmqnotificationinterface.h
+++ b/src/zmq/zmqnotificationinterface.h
@@ -13,7 +13,7 @@ class CBlockIndex;
 class CZMQAbstractNotifier;
 class CTxMemPool;
 
-class CZMQNotificationInterface : public CValidationInterface
+class CZMQNotificationInterface
 {
 public:
     virtual ~CZMQNotificationInterface();
@@ -23,10 +23,6 @@ public:
 protected:
     bool Initialize();
     void Shutdown();
-
-    // CValidationInterface
-    void SyncTransaction(const CTransaction& tx, const CBlockIndex *pindex, const CBlock* pblock);
-    void UpdatedBlockTip(const CBlockIndex *pindex);
 
 private:
     CZMQNotificationInterface();

--- a/src/zmq/zmqpublishnotifier.cpp
+++ b/src/zmq/zmqpublishnotifier.cpp
@@ -6,6 +6,7 @@
 #include "zmqpublishnotifier.h"
 #include "main.h"
 #include "util.h"
+#include "crypto/common.h"
 
 static std::multimap<std::string, CZMQAbstractPublishNotifier*> mapPublishNotifiers;
 
@@ -13,6 +14,8 @@ static const char *MSG_HASHBLOCK = "hashblock";
 static const char *MSG_HASHTX    = "hashtx";
 static const char *MSG_RAWBLOCK  = "rawblock";
 static const char *MSG_RAWTX     = "rawtx";
+static const char *MSG_MEMPOOLADDED = "mempooladded";
+static const char *MSG_MEMPOOLREMOVED = "mempoolremoved";
 
 // Internal function to send multipart message
 static int zmq_send_multipart(void *sock, const void* data, size_t size, ...)
@@ -140,13 +143,19 @@ bool CZMQAbstractPublishNotifier::SendMessage(const char *command, const void* d
     return true;
 }
 
+/** Write 256-bit hash to buffer reversed format */
+static void ZMQWriteHash(unsigned char *ptr, const uint256 &hash)
+{
+    for (unsigned int i = 0; i < 32; i++)
+        ptr[31 - i] = hash.begin()[i];
+}
+
 bool CZMQPublishHashBlockNotifier::NotifyBlock(const CBlockIndex *pindex)
 {
     uint256 hash = pindex->GetBlockHash();
     LogPrint("zmq", "zmq: Publish hashblock %s\n", hash.GetHex());
-    char data[32];
-    for (unsigned int i = 0; i < 32; i++)
-        data[31 - i] = hash.begin()[i];
+    uint8_t data[32];
+    ZMQWriteHash(data, hash);
     return SendMessage(MSG_HASHBLOCK, data, 32);
 }
 
@@ -154,9 +163,8 @@ bool CZMQPublishHashTransactionNotifier::NotifyTransaction(const CTransaction &t
 {
     uint256 hash = transaction.GetHash();
     LogPrint("zmq", "zmq: Publish hashtx %s\n", hash.GetHex());
-    char data[32];
-    for (unsigned int i = 0; i < 32; i++)
-        data[31 - i] = hash.begin()[i];
+    uint8_t data[32];
+    ZMQWriteHash(data, hash);
     return SendMessage(MSG_HASHTX, data, 32);
 }
 
@@ -189,3 +197,65 @@ bool CZMQPublishRawTransactionNotifier::NotifyTransaction(const CTransaction &tr
     ss << transaction;
     return SendMessage(MSG_RAWTX, &(*ss.begin()), ss.size());
 }
+
+CZMQPublishMempoolNotifier::CZMQPublishMempoolNotifier(CTxMemPool *mempoolIn):
+    mempool(mempoolIn)
+{
+    mempool->NotifyEntryAdded.connect(boost::bind(&CZMQPublishMempoolNotifier::NotifyEntryAdded, this, _1));
+    mempool->NotifyEntryRemoved.connect(boost::bind(&CZMQPublishMempoolNotifier::NotifyEntryRemoved, this, _1, _2));
+}
+
+CZMQPublishMempoolNotifier::~CZMQPublishMempoolNotifier()
+{
+    mempool->NotifyEntryAdded.disconnect(boost::bind(&CZMQPublishMempoolNotifier::NotifyEntryAdded, this, _1));
+    mempool->NotifyEntryRemoved.disconnect(boost::bind(&CZMQPublishMempoolNotifier::NotifyEntryRemoved, this, _1, _2));
+}
+
+void CZMQPublishMempoolNotifier::NotifyEntryAdded(const CTxMemPoolEntry &entry)
+{
+    LogPrint("zmq", "zmq: mempool entry added: %s fee=%i size=%i\n", entry.GetTx().GetHash().ToString(),
+            entry.GetFee(), entry.GetTxSize());
+    uint8_t data[32 + 8 + 4];
+    ZMQWriteHash(&data[0], entry.GetTx().GetHash());
+    WriteLE64(&data[32], entry.GetFee());
+    WriteLE32(&data[40], entry.GetTxSize());
+    SendMessage(MSG_MEMPOOLADDED, data, sizeof(data));
+}
+
+/**
+ * Removal reason on ZMQ notification protocol.
+ * Keep this up to date with the documentation in doc/zmq.md
+ */
+enum class ZMQMempoolRemovalReason: uint8_t {
+    UNKNOWN = 0,   //! Manually removed or unknown reason
+    EXPIRY = 1,    //! Expired from mempool
+    SIZELIMIT = 2, //! Removed in size limiting
+    REORG = 3,     //! Removed for reorganization
+    BLOCK = 4,     //! Removed for block
+    REPLACED = 5   //! Removed for conflict (replaced)
+};
+
+ZMQMempoolRemovalReason MapRemovalReasonToZMQ(MemPoolRemovalReason reason)
+{
+    switch(reason)
+    {
+    case MemPoolRemovalReason::UNKNOWN: return ZMQMempoolRemovalReason::UNKNOWN;
+    case MemPoolRemovalReason::EXPIRY: return ZMQMempoolRemovalReason::EXPIRY;
+    case MemPoolRemovalReason::SIZELIMIT: return ZMQMempoolRemovalReason::SIZELIMIT;
+    case MemPoolRemovalReason::REORG: return ZMQMempoolRemovalReason::REORG;
+    case MemPoolRemovalReason::BLOCK: return ZMQMempoolRemovalReason::BLOCK;
+    case MemPoolRemovalReason::REPLACED: return ZMQMempoolRemovalReason::REPLACED;
+    // No default clause: we want a warning here if not all values are covered.
+    }
+    return ZMQMempoolRemovalReason::UNKNOWN;
+}
+
+void CZMQPublishMempoolNotifier::NotifyEntryRemoved(const CTxMemPoolEntry &entry, MemPoolRemovalReason reason)
+{
+    LogPrint("zmq", "zmq: mempool entry removed: %s, reason %i\n", entry.GetTx().GetHash().ToString(), (int)reason);
+    uint8_t data[32 + 1];
+    ZMQWriteHash(&data[0], entry.GetTx().GetHash());
+    data[32] = static_cast<uint8_t>(MapRemovalReasonToZMQ(reason));
+    SendMessage(MSG_MEMPOOLREMOVED, data, sizeof(data));
+}
+

--- a/src/zmq/zmqpublishnotifier.h
+++ b/src/zmq/zmqpublishnotifier.h
@@ -6,6 +6,7 @@
 #define BITCOIN_ZMQ_ZMQPUBLISHNOTIFIER_H
 
 #include "zmqabstractnotifier.h"
+#include "validationinterface.h"
 #include "txmempool.h"
 
 class CBlockIndex;
@@ -29,28 +30,40 @@ public:
     void Shutdown();
 };
 
-class CZMQPublishHashBlockNotifier : public CZMQAbstractPublishNotifier
+//! Publish notifier that listens to validation events
+class CZMQValidationPublishNotifier : public CZMQAbstractPublishNotifier, public CValidationInterface
 {
 public:
-    bool NotifyBlock(const CBlockIndex *pindex);
+    CZMQValidationPublishNotifier();
+    ~CZMQValidationPublishNotifier();
+
+    // Child classes should override one or more of these from CValidationInterface:
+    // void SyncTransaction(const CTransaction& tx, const CBlockIndex *pindex, const CBlock* pblock);
+    // void UpdatedBlockTip(const CBlockIndex *pindex);
 };
 
-class CZMQPublishHashTransactionNotifier : public CZMQAbstractPublishNotifier
+class CZMQPublishHashBlockNotifier : public CZMQValidationPublishNotifier
 {
 public:
-    bool NotifyTransaction(const CTransaction &transaction);
+    void UpdatedBlockTip(const CBlockIndex *pindex);
 };
 
-class CZMQPublishRawBlockNotifier : public CZMQAbstractPublishNotifier
+class CZMQPublishHashTransactionNotifier : public CZMQValidationPublishNotifier
 {
 public:
-    bool NotifyBlock(const CBlockIndex *pindex);
+    void SyncTransaction(const CTransaction& tx, const CBlockIndex *pindex, const CBlock* pblock);
 };
 
-class CZMQPublishRawTransactionNotifier : public CZMQAbstractPublishNotifier
+class CZMQPublishRawBlockNotifier : public CZMQValidationPublishNotifier
 {
 public:
-    bool NotifyTransaction(const CTransaction &transaction);
+    void UpdatedBlockTip(const CBlockIndex *pindex);
+};
+
+class CZMQPublishRawTransactionNotifier : public CZMQValidationPublishNotifier
+{
+public:
+    void SyncTransaction(const CTransaction& tx, const CBlockIndex *pindex, const CBlock* pblock);
 };
 
 class CZMQPublishMempoolNotifier : public CZMQAbstractPublishNotifier

--- a/src/zmq/zmqpublishnotifier.h
+++ b/src/zmq/zmqpublishnotifier.h
@@ -6,6 +6,7 @@
 #define BITCOIN_ZMQ_ZMQPUBLISHNOTIFIER_H
 
 #include "zmqabstractnotifier.h"
+#include "txmempool.h"
 
 class CBlockIndex;
 
@@ -50,6 +51,19 @@ class CZMQPublishRawTransactionNotifier : public CZMQAbstractPublishNotifier
 {
 public:
     bool NotifyTransaction(const CTransaction &transaction);
+};
+
+class CZMQPublishMempoolNotifier : public CZMQAbstractPublishNotifier
+{
+public:
+    CZMQPublishMempoolNotifier(CTxMemPool *mempoolIn);
+    ~CZMQPublishMempoolNotifier();
+
+    void NotifyEntryAdded(const CTxMemPoolEntry &entry);
+    void NotifyEntryRemoved(const CTxMemPoolEntry &entry, MemPoolRemovalReason reason);
+
+private:
+    CTxMemPool *mempool;
 };
 
 #endif // BITCOIN_ZMQ_ZMQPUBLISHNOTIFIER_H


### PR DESCRIPTION
Add notifications when transactions enter or leave the mempool.

These can be enabled with `zmqpubmempool`:
- `mempooladded`: a transaction was added to the mempool
- `mempoolremoved`: a transaction was removed from the mempool

This allows third-party software to keep track of what is in the mempool in real time. For example a mempool monitor I'm working on:
![schermafdruk van 2016-03-27 17-42-16](https://cloud.githubusercontent.com/assets/126646/14066461/eccfffbe-f449-11e5-843e-1295b7e85f46.png)
It also makes it possible to keep statistics on why transactions disappear from the mempool.

Full documentation: https://github.com/bitcoin/bitcoin/blob/325afe68381d59f1b95a690927c4a8ea886ac791/doc/zmq.md#mempooladd

See individual commits for details.

Current issues:
- Warning `NotifyEntryAdded: WARNING: zmq send failed with code -1` spam in log if "-zmqpubmempool" is not enabled.
