### PR TITLE
[WIP] rest: Stream entire utxo set

### DIFF
--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -27,6 +27,7 @@
 #include <event2/buffer.h>
 #include <event2/util.h>
 #include <event2/keyvalq_struct.h>
+#include <event2/bufferevent.h>
 
 #ifdef EVENT__HAVE_NETINET_IN_H
 #include <netinet/in.h>
@@ -540,12 +541,19 @@ void HTTPEvent::trigger(struct timeval* tv)
         evtimer_add(ev, tv); // trigger after timeval passed
 }
 HTTPRequest::HTTPRequest(struct evhttp_request* _req) : req(_req),
-                                                       replySent(false)
+                                                       replySent(false), streaming(0)
 {
 }
 HTTPRequest::~HTTPRequest()
 {
-    if (!replySent) {
+    if (streaming) {
+        // Finish streaming in main thread
+        HTTPEvent* ev = new HTTPEvent(eventBase, true, boost::bind(evhttp_send_reply_end, req));
+        ev->trigger(0);
+        LogPrintf("%s: The end\n", __func__);
+        // TODO: MEMORY LEAK deallocate 'streaming' in event thread, after there is no risk
+        // of any of the callbacks being called anymore (e.g. request done and finished, or failed).
+    } else if (!replySent) {
         // Keep track of whether reply was sent to avoid request leaks
         LogPrintf("%s: Unhandled request\n", __func__);
         WriteReply(HTTP_INTERNAL, "Unhandled request");
@@ -648,6 +656,97 @@ HTTPRequest::RequestMethod HTTPRequest::GetRequestMethod()
         return UNKNOWN;
         break;
     }
+}
+
+bool HTTPRequest::StartStreaming(int nStatus)
+{
+    assert(!streaming);
+    streaming = new StreamingData();
+    HTTPEvent* ev = new HTTPEvent(eventBase, true, boost::bind(evhttp_send_reply_start, req, nStatus, (const char*)NULL));
+    ev->trigger(0);
+    return true;
+}
+
+/** TODO: move HTTPRequest::StreamingData to another unit */
+#define MAX_CHUNK_BUFFER (256*1024)
+
+HTTPRequest::StreamingData::StreamingData():
+    buffer_bytes(0)
+{
+    databuf = evbuffer_new();
+    assert(databuf);
+}
+
+HTTPRequest::StreamingData::~StreamingData()
+{
+    evbuffer_free(databuf);
+}
+
+/** Update buffer length in synchronization structure.
+ * @note: Can only safely read the length of the buffer from the event thread.
+ */
+void HTTPRequest::StreamingData::Update(struct evhttp_connection* evcon)
+{
+    {
+        std::unique_lock<std::mutex> lock(cs);
+        struct bufferevent* bufev = evhttp_connection_get_bufferevent(evcon);
+        assert(bufev);
+        struct evbuffer *output = bufferevent_get_output(bufev);
+        assert(output);
+        buffer_bytes = evbuffer_get_length(output);
+    }
+    cond.notify_all();
+}
+
+/** Called by evhttp from event thread after a chunk has been written.
+ */
+void HTTPRequest::StreamingData::http_chunk_cb(struct evhttp_connection* evcon, void* arg)
+{
+    HTTPRequest::StreamingData *self = (HTTPRequest::StreamingData*) arg;
+    self->Update(evcon);
+    // LogPrintf("http_chunk_cb %i\n", self->buffer_bytes);
+}
+
+/** Send current chunk in databuf.
+ * @note: Can only safely be called from event thread
+ */
+void HTTPRequest::StreamingData::SendChunk(struct evhttp_request* req)
+{
+    // LogPrintf("set_http_chunk_cb\n");
+    {
+        std::unique_lock<std::mutex> lock(cs);
+        evhttp_send_reply_chunk_with_cb(req, databuf, &http_chunk_cb, this);
+    }
+    struct evhttp_connection* evcon = evhttp_request_get_connection(req);
+    if (evcon) // If not, the connection closed
+        Update(evcon);
+    else // TODO need a way to signal losing connection so the application doesn't keep sending unnecessarily, and doesn't hang
+        LogPrintf("warning: evcon is 0 in SendChunk\n");
+}
+
+bool HTTPRequest::SendChunk(const void *data, size_t size)
+{
+    // Block as long as connection buffer is above maximum
+    assert(streaming);
+    std::unique_lock<std::mutex> lock(streaming->cs);
+    bool delayed = false;
+    while (streaming->buffer_bytes >= MAX_CHUNK_BUFFER) {
+        LogPrintf("buffer full: %i\n", streaming->buffer_bytes);
+        streaming->cond.wait(lock);
+        delayed = true;
+    }
+    if (delayed)
+        LogPrintf("buffer ok: %i\n", streaming->buffer_bytes);
+
+    // Send data
+    evbuffer_add(streaming->databuf, data, size);
+    // Trigger chunk send on http event thread
+    // In principle, this doesn't need to be done every time a chunk is submitted - if a usage
+    // scenario wants to to lots of small chunks it may make sense to queue them up and send
+    // the event after reaching a high-water mark.
+    HTTPEvent* ev = new HTTPEvent(eventBase, true, boost::bind(&StreamingData::SendChunk, streaming, req));
+    ev->trigger(0);
+    return true;
 }
 
 void RegisterHTTPHandler(const std::string &prefix, bool exactMatch, const HTTPRequestHandler &handler)

--- a/src/httpserver.h
+++ b/src/httpserver.h
@@ -8,12 +8,15 @@
 #include <string>
 #include <stdint.h>
 #include <functional>
+#include <mutex>
+#include <condition_variable>
 
 static const int DEFAULT_HTTP_THREADS=4;
 static const int DEFAULT_HTTP_WORKQUEUE=16;
 static const int DEFAULT_HTTP_SERVER_TIMEOUT=30;
 
 struct evhttp_request;
+struct evhttp_connection;
 struct event_base;
 class CService;
 class HTTPRequest;
@@ -55,6 +58,25 @@ class HTTPRequest
 private:
     struct evhttp_request* req;
     bool replySent;
+
+    /** Synchronization data between worker thread and http event thread, for streaming.
+     * This should be alive until the http request is destroyed (as long as it is still possible for
+     * the http_chunk_cb to be called).
+     */
+    struct StreamingData
+    {
+        StreamingData();
+        ~StreamingData();
+        void Update(struct evhttp_connection* evcon);
+        static void http_chunk_cb(struct evhttp_connection* req, void* arg);
+        void SendChunk(struct evhttp_request* req);
+
+        std::mutex cs; /* protects entire object */
+        std::condition_variable cond;
+        size_t buffer_bytes;
+        struct evbuffer* databuf;
+    };
+    StreamingData *streaming;
 
 public:
     HTTPRequest(struct evhttp_request* req);
@@ -110,6 +132,19 @@ public:
      * main thread, do not call any other HTTPRequest methods after calling this.
      */
     void WriteReply(int nStatus, const std::string& strReply = "");
+
+    /**
+     * Start streaming. After calling this, send chunks of data using
+     * SendChunk.
+     */
+    bool StartStreaming(int nStatus);
+
+    /**
+     * Send a chunk of data.
+     * Call this only after StartStreaming.
+     * This can block if there is not enough space in the send queue.
+     */
+    bool SendChunk(const void *data, size_t size);
 };
 
 /** Event handler closure.

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -15,6 +15,7 @@
 #include "txmempool.h"
 #include "utilstrencodings.h"
 #include "version.h"
+#include "util.h"
 
 #include <boost/algorithm/string.hpp>
 #include <boost/dynamic_bitset.hpp>
@@ -599,6 +600,65 @@ static bool rest_getutxos(HTTPRequest* req, const std::string& strURIPart)
     return true; // continue to process further HTTP reqs on this cxn
 }
 
+// Size of one chunk for streaming utxo set
+const size_t CHUNK_SIZE = 256*1024;
+
+static bool rest_utxoset(HTTPRequest* req, const std::string& strURIPart)
+{
+    if (!CheckWarmup(req))
+        return false;
+
+    req->WriteHeader("Content-Type", "application/octet-stream");
+    // We're timing out during *send*?
+
+    boost::scoped_ptr<CCoinsViewCursor> pcursor(pcoinsTip->Cursor());
+    const uint256 &bestBlock = pcursor->GetBestBlock();
+    int nHeight;
+    {
+        LOCK(cs_main);
+        nHeight = mapBlockIndex.find(bestBlock)->second->nHeight;
+    }
+    std::string filename = strprintf("utxoset-%i-%s.dat", nHeight, bestBlock.ToString());
+    req->WriteHeader("Content-Disposition", "attachment; filename=\""+filename+"\"");
+    req->WriteHeader("X-Best-Block", bestBlock.ToString());
+    req->WriteHeader("X-Block-Height", strprintf("%i", nHeight));
+    req->StartStreaming(HTTP_OK);
+
+    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+    ss << bestBlock;
+    while (pcursor->Valid()) {
+        uint256 key;
+        CCoins coins;
+        if (pcursor->GetKey(key) && pcursor->GetValue(coins)) {
+            ss << key;
+            for (unsigned int i=0; i<coins.vout.size(); i++) {
+                const CTxOut &out = coins.vout[i];
+                if (!out.IsNull()) {
+                    ss << VARINT(i+1);
+                    ss << out;
+                }
+            }
+            ss << VARINT(0);
+        } else {
+            // Not clear what to do here - we've sent part of the data so it's
+            // too late to report an error.
+            ss << VARINT(-1);
+            ss << std::string("Database error - output corrupted");
+            LogPrintf("Database error during utxo dump\n");
+            break;
+        }
+        pcursor->Next();
+        if(ss.size() >= CHUNK_SIZE) {
+            req->SendChunk(&(*ss.begin()), ss.size());
+            ss.clear();
+        }
+    }
+    req->SendChunk(&(*ss.begin()), ss.size());
+    LogPrintf("Got to EOF\n");
+    return true; // continue to process further HTTP reqs on this cxn
+}
+
+
 static const struct {
     const char* prefix;
     bool (*handler)(HTTPRequest* req, const std::string& strReq);
@@ -611,6 +671,7 @@ static const struct {
       {"/rest/mempool/contents", rest_mempool_contents},
       {"/rest/headers/", rest_headers},
       {"/rest/getutxos", rest_getutxos},
+      {"/rest/utxoset", rest_utxoset},
 };
 
 bool StartREST()


### PR DESCRIPTION
This is by no means ready, but anyhow this builds on #7756 and
- Adds a streaming API to the HTTP server. This allows streaming data to the client chunk by chunk, which is useful when not the entire data is available at once or it is huge and wouldn't fit (efficiently) in memory.
- Allows downloading the entire UTXO set through `/rest/utxoset`. This is a raw dump of all outputs, the state normally hashed by `gettxoutsetinfo`. The dump is performed in the background by making use of leveldb snapshotting, so without keeping cs_main locked.
  - This can be useful for analysis purposes if you don't want to mess with bitcoin core's database
  - Filename (via content-disposition) is `utxoset-<height>-<bestblockhash>.dat`. Also a custom `X-Best-Block` and `X-Block-Height` header is added.

It matches:

``` bash
$ src/bitcoin-cli -datadir=/store/tmp/testbtc gettxoutsetinfo
{
...
  "hash_serialized": "5017f82bbb82a8199ae0fbaa9e5881a0c82575db89e6edd5b39414b35299363b",
...
}
$ wget --content-disposition http://127.0.0.1:8332/rest/utxoset 
2016-03-28 22:58:32 (44.3 MB/s) - ‘utxoset-404681-0000000000000000034854f5a3ab27cfbc220a42c75061dd13d2067cda71191d.dat’ saved [1291578967]
$ ~/bin/dsha256 utxoset-404681-0000000000000000034854f5a3ab27cfbc220a42c75061dd13d2067cda71191d.dat
5017f82bbb82a8199ae0fbaa9e5881a0c82575db89e6edd5b39414b35299363b utxoset
```
## TODO
- ~~Rebase after #7756 merged~~
- Sensibly name and split up commits
- Clean up and split up code
- Actually handle errors (you can crash a worker thread right now by disconnecting while downloading)
- The timeout actually runs _while_ downloading, causing it to break off after downloading. I don't understand why this is. You can work around it with `-rpcservertimeout=6000` or such.
- ~~UTXO set dump doesn't contain keys (?) I'm not sure this format is actually useful this way (see #7758)~~ (fixed in #7848)
- Other formats, potentially ^^

Note that the HTTP streaming API could in principle also be used for other large data (say, wallet backups), or even for websocket-like event notification.
