### PR TITLE
Clear the input line after activating autocomplete

### DIFF
--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -459,6 +459,8 @@ void RPCConsole::setClientModel(ClientModel *model)
         autoCompleter = new QCompleter(wordList, this);
         ui->lineEdit->setCompleter(autoCompleter);
 
+	// clear the lineEdit after activating from QCompleter
+	connect(autoCompleter, SIGNAL(activated(const QString&)), ui->lineEdit, SLOT(clear()), Qt::QueuedConnection);
     }
 }
 


### PR DESCRIPTION
When you select an item from the list of possible completions in the Debug console and press Enter on it, the selected command is executed, but the input line is not cleared.

This issue fixes it.

For technical description, see http://stackoverflow.com/questions/11865129/fail-to-clear-qlineedit-after-selecting-item-from-qcompleter

@jonasschnelli Please check. Thank you.
