### PR TITLE
RPC: add versionHex in getblock and getblockheader JSON results

### DIFF
--- a/qa/rpc-tests/blockchain.py
+++ b/qa/rpc-tests/blockchain.py
@@ -82,6 +82,7 @@ class BlockchainTest(BitcoinTestFramework):
         assert isinstance(header['mediantime'], int)
         assert isinstance(header['nonce'], int)
         assert isinstance(header['version'], int)
+        assert isinstance(int(header['versionHex'], 16), int)
         assert isinstance(header['difficulty'], Decimal)
 
 if __name__ == '__main__':


### PR DESCRIPTION
Update `getblock` and `getblockheader` RPCs and rest to return hex encoded block versions, e.g.:

`"version": "0x01"`

`"version": "0x20000000"`

Reason is similar to https://github.com/bitcoin/bitcoin/pull/7763: "The decimal printing of block nVersion is not very readable in a versionbits world."

My only apprehension is that this could be disruptive to people that have script relying on this output. But, I'm not aware of any guarantee that this will not change.

I purposefully chose 02 instead of 08 in order to get a smaller encoding when possible.
