### PR TITLE
Discussion: Consensus: There's only one type of consensus flags

### DIFF
--- a/src/consensus/consensus.h
+++ b/src/consensus/consensus.h
@@ -13,13 +13,4 @@ static const unsigned int MAX_BLOCK_SIGOPS = MAX_BLOCK_SIZE/50;
 /** Coinbase transaction outputs can only be spent after this number of new blocks (network rule) */
 static const int COINBASE_MATURITY = 100;
 
-/** Flags for nSequence and nLockTime locks */
-enum {
-    /* Interpret sequence numbers as relative lock-time constraints. */
-    LOCKTIME_VERIFY_SEQUENCE = (1 << 0),
-
-    /* Use GetMedianTimePast() instead of nTime for end point timestamp. */
-    LOCKTIME_MEDIAN_TIME_PAST = (1 << 1),
-};
-
 #endif // BITCOIN_CONSENSUS_CONSENSUS_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2287,10 +2287,9 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     }
 
     // Start enforcing BIP68 (sequence locks) and BIP112 (CHECKSEQUENCEVERIFY) using versionbits logic.
-    int nLockTimeFlags = 0;
     if (VersionBitsState(pindex->pprev, chainparams.GetConsensus(), Consensus::DEPLOYMENT_CSV, versionbitscache) == THRESHOLD_ACTIVE) {
         flags |= SCRIPT_VERIFY_CHECKSEQUENCEVERIFY;
-        nLockTimeFlags |= LOCKTIME_VERIFY_SEQUENCE;
+        flags |= LOCKTIME_VERIFY_SEQUENCE;
     }
 
     int64_t nTime2 = GetTimeMicros(); nTimeForks += nTime2 - nTime1;
@@ -2332,7 +2331,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
                 prevheights[j] = view.AccessCoins(tx.vin[j].prevout.hash)->nHeight;
             }
 
-            if (!SequenceLocks(tx, nLockTimeFlags, &prevheights, *pindex)) {
+            if (!SequenceLocks(tx, flags, &prevheights, *pindex)) {
                 return state.DoS(100, error("%s: contains a non-BIP68-final transaction", __func__),
                                  REJECT_INVALID, "bad-txns-nonfinal");
             }
@@ -3302,12 +3301,12 @@ bool ContextualCheckBlock(const CBlock& block, CValidationState& state, CBlockIn
     const Consensus::Params& consensusParams = Params().GetConsensus();
 
     // Start enforcing BIP113 (Median Time Past) using versionbits logic.
-    int nLockTimeFlags = 0;
+    int flags = 0;
     if (VersionBitsState(pindexPrev, consensusParams, Consensus::DEPLOYMENT_CSV, versionbitscache) == THRESHOLD_ACTIVE) {
-        nLockTimeFlags |= LOCKTIME_MEDIAN_TIME_PAST;
+        flags |= LOCKTIME_MEDIAN_TIME_PAST;
     }
 
-    int64_t nLockTimeCutoff = (nLockTimeFlags & LOCKTIME_MEDIAN_TIME_PAST)
+    int64_t nLockTimeCutoff = (flags & LOCKTIME_MEDIAN_TIME_PAST)
                               ? pindexPrev->GetMedianTimePast()
                               : block.GetBlockTime();
 

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -14,6 +14,21 @@
 
 class CCoinsViewCache;
 
+/**
+ * Standard verification flags.
+ * The bits cannot conflict with "Consensus verification flags" (see SCRIPT_VERIFY_NONE).
+ */
+enum
+{
+    /**
+     * BIPNEXT: Use this for the next standard feature candidate
+     * to become consensus later. This applies in VALIDATIONLEVEL or
+     * below. Existing validation levels: SCRIPT, LOCKTIME.
+     * Candidates: COINBASETX, TX, HEADER, BLOCK.
+     */
+    VALIDATIONLEVEL_FEATURE_NEXT = (1U << 31),
+};
+
 /** Default for -blockmaxsize and -blockminsize, which control the range of sizes the mining code will create **/
 static const unsigned int DEFAULT_BLOCK_MAX_SIZE = 750000;
 static const unsigned int DEFAULT_BLOCK_MIN_SIZE = 0;

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -27,7 +27,7 @@ enum
     SIGHASH_ANYONECANPAY = 0x80,
 };
 
-/** Script verification flags */
+/** Consensus verification flags */
 enum
 {
     SCRIPT_VERIFY_NONE      = 0,
@@ -86,6 +86,12 @@ enum
     //
     // See BIP112 for details
     SCRIPT_VERIFY_CHECKSEQUENCEVERIFY = (1U << 10),
+
+    /* BIP68: Interpret sequence numbers as relative lock-time constraints. */
+    LOCKTIME_VERIFY_SEQUENCE = (1U << 11),
+
+    /* BIP113: Use GetMedianTimePast() instead of nTime for end point timestamp. */
+    LOCKTIME_MEDIAN_TIME_PAST = (1U << 12),
 };
 
 bool CheckSignatureEncoding(const std::vector<unsigned char> &vchSig, unsigned int flags, ScriptError* serror);


### PR DESCRIPTION
There should be only policy and consensus validation flags.
We can separate script, locktime, tx, header and block level, or we can just wait to run out of bits to think about it.
Most of the text is in the commit messages.

For more context on "unifying consensus flags", see (on jtimon/jt):
942c2ee \* Consensus: Separate GetScriptFlags() from ConnectBlock and make IsSuperMajority static
217ed51 \* Consensus: Move bip34 to VerifyTx() (s/ContextualCheckBlock/CheckTxCoinbase)
51b213f \* Consensus: Move BIP30 code to GetConsensusFlags and Consensus::VerifyTx
a69268b \* Libconsensus-p3B: expose bitcoinconsensus_verify_tx()
