### PR TITLE
Use relative paths instead of absolute paths in protoc calls

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -479,7 +479,7 @@ endif
 
 %.pb.cc %.pb.h: %.proto
 	@test -f $(PROTOC)
-	$(AM_V_GEN) $(PROTOC) --cpp_out=$(@D) --proto_path=$(abspath $(<D) $<)
+	$(AM_V_GEN) $(PROTOC) --cpp_out=$(@D) --proto_path=$(<D) $<
 
 if ENABLE_TESTS
 include Makefile.test.include


### PR DESCRIPTION
When comparing two separate build logs (both being done in its own, different directory), the log line containing `protoc` shines in the diff:

```
$ diff -u 7774.log  master.log | grep protoc
-/opt/local/bin/protoc --cpp_out=qt --proto_path=/private/tmp/bitcoin-7774/src/qt /private/tmp/bitcoin-7774/src/qt/paymentrequest.proto
+/opt/local/bin/protoc --cpp_out=qt --proto_path=/private/tmp/bitcoin-master/src/qt /private/tmp/bitcoin-master/src/qt/paymentrequest.proto
$ 
```

There is no reason to use absolute paths here.

After this change, the `protoc` command line is always

```
/opt/local/bin/protoc --cpp_out=qt --proto_path=qt/ qt/paymentrequest.proto
```

@theuni Please have a look.
