### PR TITLE
[qa] Remove misleading "errorString syntax"

### DIFF
--- a/qa/rpc-tests/importprunedfunds.py
+++ b/qa/rpc-tests/importprunedfunds.py
@@ -83,9 +83,10 @@ class ImportPrunedFundsTest(BitcoinTestFramework):
         try:
             result1 = self.nodes[1].importprunedfunds(rawtxn1, proof1, "")
         except JSONRPCException as e:
-            errorString = e.error['message']
+            assert('No addresses' in e.error['message'])
+        else:
+            assert(False)
 
-        assert('No addresses' in errorString)
 
         balance1 = self.nodes[1].getbalance("", 0, True)
         assert_equal(balance1, Decimal(0))
@@ -120,9 +121,10 @@ class ImportPrunedFundsTest(BitcoinTestFramework):
         try:
             self.nodes[1].removeprunedfunds(txnid1)
         except JSONRPCException as e:
-            errorString = e.error['message']
+            assert('does not exist' in e.error['message'])
+        else:
+            assert(False)
 
-        assert('does not exist' in errorString)
 
         balance1 = Decimal(self.nodes[1].getbalance("", 0, True))
         assert_equal(balance1, Decimal('0.075'))

--- a/qa/rpc-tests/rawtransactions.py
+++ b/qa/rpc-tests/rawtransactions.py
@@ -56,13 +56,13 @@ class RawTransactionsTest(BitcoinTestFramework):
         rawtx   = self.nodes[2].createrawtransaction(inputs, outputs)
         rawtx   = self.nodes[2].signrawtransaction(rawtx)
 
-        errorString = ""
         try:
             rawtx   = self.nodes[2].sendrawtransaction(rawtx['hex'])
         except JSONRPCException as e:
-            errorString = e.error['message']
+            assert("Missing inputs" in e.error['message'])
+        else:
+            assert(False)
 
-        assert("Missing inputs" in errorString)
 
         #########################
         # RAW TX MULTISIG TESTS #

--- a/qa/rpc-tests/wallet.py
+++ b/qa/rpc-tests/wallet.py
@@ -245,22 +245,20 @@ class WalletTest (BitcoinTestFramework):
         txObj = self.nodes[0].gettransaction(txId)
         assert_equal(txObj['amount'], Decimal('-0.0001'))
 
-        #this should fail
-        errorString = ""
         try:
             txId  = self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), "1f-4")
         except JSONRPCException as e:
-            errorString = e.error['message']
+            assert("Invalid amount" in e.error['message'])
+        else:
+            raise AssertionError("Must not parse invalid amounts")
 
-        assert("Invalid amount" in errorString)
 
-        errorString = ""
         try:
-            self.nodes[0].generate("2") #use a string to as block amount parameter must fail because it's not interpreted as amount
+            self.nodes[0].generate("2")
+            raise AssertionError("Must not accept strings as numeric")
         except JSONRPCException as e:
-            errorString = e.error['message']
+            assert("not an integer" in e.error['message'])
 
-        assert("not an integer" in errorString)
 
         # Mine a block from node0 to an address from node1
         cbAddr = self.nodes[1].getnewaddress()
@@ -269,10 +267,7 @@ class WalletTest (BitcoinTestFramework):
         self.sync_all()
 
         # Check that the txid and balance is found by node1
-        try:
-            self.nodes[1].gettransaction(cbTxId)
-        except JSONRPCException as e:
-            assert("Invalid or non-wallet transaction id" not in e.error['message'])
+        self.nodes[1].gettransaction(cbTxId)
 
         #check if wallet or blochchain maintenance changes the balance
         self.sync_all()


### PR DESCRIPTION
Personally, I find the `errorString` "syntax" to "see" when an exception happens confusing. It is error prone in the best case.

Imo, valid syntax is either

``` py
try:
  something()
  assert(False)
except:
  assert(thing())
```

or

``` py
try:
  something()
except:
  assert(thing())
else:
  assert(False)
```
