### PR TITLE
[qa] httpbasics: Actually test second connection

### DIFF
--- a/qa/rpc-tests/httpbasics.py
+++ b/qa/rpc-tests/httpbasics.py
@@ -37,13 +37,13 @@ class HTTPBasicsTest (BitcoinTestFramework):
         conn.connect()
         conn.request('POST', '/', '{"method": "getbestblockhash"}', headers)
         out1 = conn.getresponse().read()
-        assert('"error":null' in out1)
+        assert(b'"error":null' in out1)
         assert(conn.sock!=None) #according to http/1.1 connection must still be open!
 
         #send 2nd request without closing connection
         conn.request('POST', '/', '{"method": "getchaintips"}', headers)
-        out2 = conn.getresponse().read()
-        assert('"error":null' in out1) #must also response with a correct json-rpc message
+        out1 = conn.getresponse().read()
+        assert(b'"error":null' in out1) #must also response with a correct json-rpc message
         assert(conn.sock!=None) #according to http/1.1 connection must still be open!
         conn.close()
 
@@ -54,13 +54,13 @@ class HTTPBasicsTest (BitcoinTestFramework):
         conn.connect()
         conn.request('POST', '/', '{"method": "getbestblockhash"}', headers)
         out1 = conn.getresponse().read()
-        assert('"error":null' in out1)
+        assert(b'"error":null' in out1)
         assert(conn.sock!=None) #according to http/1.1 connection must still be open!
 
         #send 2nd request without closing connection
         conn.request('POST', '/', '{"method": "getchaintips"}', headers)
-        out2 = conn.getresponse().read()
-        assert('"error":null' in out1) #must also response with a correct json-rpc message
+        out1 = conn.getresponse().read()
+        assert(b'"error":null' in out1) #must also response with a correct json-rpc message
         assert(conn.sock!=None) #according to http/1.1 connection must still be open!
         conn.close()
 
@@ -71,7 +71,7 @@ class HTTPBasicsTest (BitcoinTestFramework):
         conn.connect()
         conn.request('POST', '/', '{"method": "getbestblockhash"}', headers)
         out1 = conn.getresponse().read()
-        assert('"error":null' in out1)
+        assert(b'"error":null' in out1)
         assert(conn.sock==None) #now the connection must be closed after the response
 
         #node1 (2nd node) is running with disabled keep-alive option
@@ -83,7 +83,7 @@ class HTTPBasicsTest (BitcoinTestFramework):
         conn.connect()
         conn.request('POST', '/', '{"method": "getbestblockhash"}', headers)
         out1 = conn.getresponse().read()
-        assert('"error":null' in out1)
+        assert(b'"error":null' in out1)
 
         #node2 (third node) is running with standard keep-alive parameters which means keep-alive is on
         urlNode2 = urlparse.urlparse(self.nodes[2].url)
@@ -94,7 +94,7 @@ class HTTPBasicsTest (BitcoinTestFramework):
         conn.connect()
         conn.request('POST', '/', '{"method": "getbestblockhash"}', headers)
         out1 = conn.getresponse().read()
-        assert('"error":null' in out1)
+        assert(b'"error":null' in out1)
         assert(conn.sock!=None) #connection must be closed because bitcoind should use keep-alive by default
 
         # Check excessive request size


### PR DESCRIPTION
Currently the test will always return `Tests successful`. :new_moon_with_face: 

(As I am touching this file, I have also marked some byte strings as byte strings explicitly, which is a noop for py2, but helps switching to py3)
