### PR TITLE
Tiny refactor of `IsRBFOptIn`, avoid exception

### DIFF
--- a/src/policy/rbf.cpp
+++ b/src/policy/rbf.cpp
@@ -14,33 +14,34 @@ bool SignalsOptInRBF(const CTransaction &tx)
     return false;
 }
 
-bool IsRBFOptIn(const CTxMemPoolEntry &entry, CTxMemPool &pool)
+RBFTransactionState IsRBFOptIn(const CTransaction &tx, CTxMemPool &pool)
 {
     AssertLockHeld(pool.cs);
 
     CTxMemPool::setEntries setAncestors;
 
     // First check the transaction itself.
-    if (SignalsOptInRBF(entry.GetTx())) {
-        return true;
+    if (SignalsOptInRBF(tx)) {
+        return RBF_TRANSACTIONSTATE_REPLACEABLE_BIP125;
     }
 
     // If this transaction is not in our mempool, then we can't be sure
     // we will know about all its inputs.
-    if (!pool.exists(entry.GetTx().GetHash())) {
-        throw std::runtime_error("Cannot determine RBF opt-in signal for non-mempool transaction\n");
+    if (!pool.exists(tx.GetHash())) {
+        return RBF_TRANSACTIONSTATE_UNKNOWN;
     }
 
     // If all the inputs have nSequence >= maxint-1, it still might be
     // signaled for RBF if any unconfirmed parents have signaled.
     uint64_t noLimit = std::numeric_limits<uint64_t>::max();
     std::string dummy;
+    CTxMemPoolEntry entry = *pool.mapTx.find(tx.GetHash());
     pool.CalculateMemPoolAncestors(entry, setAncestors, noLimit, noLimit, noLimit, noLimit, dummy, false);
 
     BOOST_FOREACH(CTxMemPool::txiter it, setAncestors) {
         if (SignalsOptInRBF(it->GetTx())) {
-            return true;
+            return RBF_TRANSACTIONSTATE_REPLACEABLE_BIP125;
         }
     }
-    return false;
+    return RBF_TRANSACTIONSTATE_FINAL;
 }

--- a/src/policy/rbf.h
+++ b/src/policy/rbf.h
@@ -7,6 +7,12 @@
 
 #include "txmempool.h"
 
+enum RBFTransactionState {
+    RBF_TRANSACTIONSTATE_UNKNOWN,
+    RBF_TRANSACTIONSTATE_REPLACEABLE_BIP125,
+    RBF_TRANSACTIONSTATE_FINAL
+};
+
 // Check whether the sequence numbers on this transaction are signaling
 // opt-in to replace-by-fee, according to BIP 125
 bool SignalsOptInRBF(const CTransaction &tx);
@@ -15,6 +21,6 @@ bool SignalsOptInRBF(const CTransaction &tx);
 // according to BIP 125
 // This involves checking sequence numbers of the transaction, as well
 // as the sequence numbers of all in-mempool ancestors.
-bool IsRBFOptIn(const CTxMemPoolEntry &entry, CTxMemPool &pool);
+RBFTransactionState IsRBFOptIn(const CTransaction &tx, CTxMemPool &pool);
 
 #endif // BITCOIN_POLICY_RBF_H

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -82,15 +82,11 @@ void WalletTxToJSON(const CWalletTx& wtx, UniValue& entry)
     std::string rbfStatus = "no";
     if (confirms <= 0) {
         LOCK(mempool.cs);
-        if (!mempool.exists(hash)) {
-            if (SignalsOptInRBF(wtx)) {
-                rbfStatus = "yes";
-            } else {
-                rbfStatus = "unknown";
-            }
-        } else if (IsRBFOptIn(*mempool.mapTx.find(hash), mempool)) {
+        RBFTransactionState rbfState = IsRBFOptIn(wtx, mempool);
+        if (rbfState == RBF_TRANSACTIONSTATE_UNKNOWN)
+            rbfStatus = "unknown";
+        else if (rbfState == RBF_TRANSACTIONSTATE_REPLACEABLE_BIP125)
             rbfStatus = "yes";
-        }
     }
     entry.push_back(Pair("bip125-replaceable", rbfStatus));
 


### PR DESCRIPTION
While working with RBF in the GUI, the exception in `IsRBFOptIn()` (throw std::runtime_error("Cannot determine RBF opt-in signal for non-mempool transaction\n")) could be unexpected.
