### PR TITLE
init: allow shutdown during 'Activating best chain...'

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2877,6 +2877,8 @@ bool ActivateBestChain(CValidationState &state, const CChainParams& chainparams,
     CBlockIndex *pindexMostWork = NULL;
     do {
         boost::this_thread::interruption_point();
+        if (ShutdownRequested())
+            break;
 
         CBlockIndex *pindexNewTip = NULL;
         const CBlockIndex *pindexFork;


### PR DESCRIPTION
Two-line patch to make it possible to shut down bitcoind cleanly during the initial ActivateBestChain.

Fixes #6459 (among other complaints).

To reproduce:
- shutdown bitcoind
- copy chainstate
- start bitcoind
- let the chain sync a bit
- shutdown bitcoind
- copy back old chainstate
- start bitcoind
- bitcoind will catch up with all blocks during Init(), this can take a long time

(the `boost::this_thread::interruption_point` / `ShutdownRequested()` dance is ugly, this should be refactored all over bitcoind at some point when moving from boost::threads to c++11 threads, but it works...)
