### PR TITLE
Add listunspent() test for spendable/unspendable UTXO

### DIFF
--- a/qa/rpc-tests/getblocktemplate_longpoll.py
+++ b/qa/rpc-tests/getblocktemplate_longpoll.py
@@ -6,28 +6,6 @@
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
 
-
-def check_array_result(object_array, to_match, expected):
-    """
-    Pass in array of JSON objects, a dictionary with key/value pairs
-    to match against, and another dictionary with expected key/value
-    pairs.
-    """
-    num_matched = 0
-    for item in object_array:
-        all_match = True
-        for key,value in to_match.items():
-            if item[key] != value:
-                all_match = False
-        if not all_match:
-            continue
-        for key,value in expected.items():
-            if item[key] != value:
-                raise AssertionError("%s : expected %s=%s"%(str(item), str(key), str(value)))
-            num_matched = num_matched+1
-    if num_matched == 0:
-        raise AssertionError("No objects matched %s"%(str(to_match)))
-
 import threading
 
 class LongpollThread(threading.Thread):

--- a/qa/rpc-tests/getblocktemplate_proposals.py
+++ b/qa/rpc-tests/getblocktemplate_proposals.py
@@ -10,28 +10,6 @@ from binascii import a2b_hex, b2a_hex
 from hashlib import sha256
 from struct import pack
 
-
-def check_array_result(object_array, to_match, expected):
-    """
-    Pass in array of JSON objects, a dictionary with key/value pairs
-    to match against, and another dictionary with expected key/value
-    pairs.
-    """
-    num_matched = 0
-    for item in object_array:
-        all_match = True
-        for key,value in to_match.items():
-            if item[key] != value:
-                all_match = False
-        if not all_match:
-            continue
-        for key,value in expected.items():
-            if item[key] != value:
-                raise AssertionError("%s : expected %s=%s"%(str(item), str(key), str(value)))
-            num_matched = num_matched+1
-    if num_matched == 0:
-        raise AssertionError("No objects matched %s"%(str(to_match)))
-
 def b2x(b):
     return b2a_hex(b).decode('ascii')
 

--- a/qa/rpc-tests/keypool.py
+++ b/qa/rpc-tests/keypool.py
@@ -10,28 +10,6 @@
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
 
-
-def check_array_result(object_array, to_match, expected):
-    """
-    Pass in array of JSON objects, a dictionary with key/value pairs
-    to match against, and another dictionary with expected key/value
-    pairs.
-    """
-    num_matched = 0
-    for item in object_array:
-        all_match = True
-        for key,value in to_match.items():
-            if item[key] != value:
-                all_match = False
-        if not all_match:
-            continue
-        for key,value in expected.items():
-            if item[key] != value:
-                raise AssertionError("%s : expected %s=%s"%(str(item), str(key), str(value)))
-            num_matched = num_matched+1
-    if num_matched == 0:
-        raise AssertionError("No objects matched %s"%(str(to_match)))
-
 class KeyPoolTest(BitcoinTestFramework):
 
     def run_test(self):

--- a/qa/rpc-tests/receivedby.py
+++ b/qa/rpc-tests/receivedby.py
@@ -25,32 +25,6 @@ def get_sub_array_from_array(object_array, to_match):
         return item
     return []
 
-def check_array_result(object_array, to_match, expected, should_not_find = False):
-    """
-        Pass in array of JSON objects, a dictionary with key/value pairs
-        to match against, and another dictionary with expected key/value
-        pairs.
-        If the should_not_find flag is true, to_match should not be found in object_array
-        """
-    if should_not_find == True:
-        expected = { }
-    num_matched = 0
-    for item in object_array:
-        all_match = True
-        for key,value in to_match.items():
-            if item[key] != value:
-                all_match = False
-        if not all_match:
-            continue
-        for key,value in expected.items():
-            if item[key] != value:
-                raise AssertionError("%s : expected %s=%s"%(str(item), str(key), str(value)))
-            num_matched = num_matched+1
-    if num_matched == 0 and should_not_find != True:
-        raise AssertionError("No objects matched %s"%(str(to_match)))
-    if num_matched > 0 and should_not_find == True:
-        raise AssertionError("Objects was matched %s"%(str(to_match)))
-
 class ReceivedByTest(BitcoinTestFramework):
 
     def setup_nodes(self):
@@ -68,26 +42,26 @@ class ReceivedByTest(BitcoinTestFramework):
         self.sync_all()
 
         #Check not listed in listreceivedbyaddress because has 0 confirmations
-        check_array_result(self.nodes[1].listreceivedbyaddress(),
+        assert_array_result(self.nodes[1].listreceivedbyaddress(),
                            {"address":addr},
                            { },
                            True)
         #Bury Tx under 10 block so it will be returned by listreceivedbyaddress
         self.nodes[1].generate(10)
         self.sync_all()
-        check_array_result(self.nodes[1].listreceivedbyaddress(),
+        assert_array_result(self.nodes[1].listreceivedbyaddress(),
                            {"address":addr},
                            {"address":addr, "account":"", "amount":Decimal("0.1"), "confirmations":10, "txids":[txid,]})
         #With min confidence < 10
-        check_array_result(self.nodes[1].listreceivedbyaddress(5),
+        assert_array_result(self.nodes[1].listreceivedbyaddress(5),
                            {"address":addr},
                            {"address":addr, "account":"", "amount":Decimal("0.1"), "confirmations":10, "txids":[txid,]})
         #With min confidence > 10, should not find Tx
-        check_array_result(self.nodes[1].listreceivedbyaddress(11),{"address":addr},{ },True)
+        assert_array_result(self.nodes[1].listreceivedbyaddress(11),{"address":addr},{ },True)
 
         #Empty Tx
         addr = self.nodes[1].getnewaddress()
-        check_array_result(self.nodes[1].listreceivedbyaddress(0,True),
+        assert_array_result(self.nodes[1].listreceivedbyaddress(0,True),
                            {"address":addr},
                            {"address":addr, "account":"", "amount":0, "confirmations":0, "txids":[]})
 
@@ -131,7 +105,7 @@ class ReceivedByTest(BitcoinTestFramework):
         self.sync_all()
 
         # listreceivedbyaccount should return received_by_account_json because of 0 confirmations
-        check_array_result(self.nodes[1].listreceivedbyaccount(),
+        assert_array_result(self.nodes[1].listreceivedbyaccount(),
                            {"account":account},
                            received_by_account_json)
 
@@ -143,7 +117,7 @@ class ReceivedByTest(BitcoinTestFramework):
         self.nodes[1].generate(10)
         self.sync_all()
         # listreceivedbyaccount should return updated account balance
-        check_array_result(self.nodes[1].listreceivedbyaccount(),
+        assert_array_result(self.nodes[1].listreceivedbyaccount(),
                            {"account":account},
                            {"account":received_by_account_json["account"], "amount":(received_by_account_json["amount"] + Decimal("0.1"))})
 

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -478,6 +478,35 @@ def assert_is_hash_string(string, length=64):
         raise AssertionError(
             "String %r contains invalid characters for a hash." % string)
 
+def assert_array_result(object_array, to_match, expected, should_not_find = False):
+    """
+        Pass in array of JSON objects, a dictionary with key/value pairs
+        to match against, and another dictionary with expected key/value
+        pairs.
+        If the should_not_find flag is true, to_match should not be found
+        in object_array
+        """
+    if should_not_find == True:
+        expected = { }
+    num_matched = 0
+    for item in object_array:
+        all_match = True
+        for key,value in to_match.items():
+            if item[key] != value:
+                all_match = False
+        if not all_match:
+            continue
+        elif should_not_find == True:
+            num_matched = num_matched+1
+        for key,value in expected.items():
+            if item[key] != value:
+                raise AssertionError("%s : expected %s=%s"%(str(item), str(key), str(value)))
+            num_matched = num_matched+1
+    if num_matched == 0 and should_not_find != True:
+        raise AssertionError("No objects matched %s"%(str(to_match)))
+    if num_matched > 0 and should_not_find == True:
+        raise AssertionError("Objects were found %s"%(str(to_match)))
+
 def satoshi_round(amount):
     return Decimal(amount).quantize(Decimal('0.00000001'), rounding=ROUND_DOWN)
 


### PR DESCRIPTION
This PR adds a test on `wallet.py` covering the behavior of spendable/unspendable value for UTXO, when calling RPC `listunspent`.

This value should be different for address or private key import.
