### PR TITLE
Add index to wallet UTXO

### DIFF
--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -596,6 +596,15 @@ public:
     MasterKeyMap mapMasterKeys;
     unsigned int nMasterKeyMaxID;
 
+    /**
+     * Used to keep track of UTXOs
+     */
+    typedef std::map<COutPoint, std::pair<const CWalletTx*, isminetype> > TxUnspents;
+    TxUnspents mapTxUnspents;
+    void AddToUnspents(const CWalletTx *wtx, bool filterIsMine=false);
+    void RemoveFromUnspents(const COutPoint &outpoint);
+    void UpdateUnspents();
+
     CWallet()
     {
         SetNull();


### PR DESCRIPTION
This PR implements an index of unspent transaction outputs (UTXOs).

This approach optimizes `CWallet::AvailableCoins`, by doing some of its work each time a wallet transaction changes. For instance, using `CWallet::IsMine` earlier for each transaction output, it manages to keep track only of UTXOs related to wallet addresses.

That brings large improvements on RPCs such as `listunspent` and `fundrawtransaction`. Depending on the size of your wallet and number of UTXOs, performance gains may be up to 98%.

This way, instead of going through all the wallet transactions, the search for UTXOs is made only on this updated list of outputs.

Depends on #7822 to ensure functionality behaviour remains the same.
