### PR TITLE
Reduce block timeout to 10 minutes

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -106,8 +106,8 @@ static const unsigned int AVG_INVENTORY_BROADCAST_INTERVAL = 5;
 static const unsigned int AVG_FEEFILTER_BROADCAST_INTERVAL = 10 * 60;
 /** Maximum feefilter broadcast delay after significant change. */
 static const unsigned int MAX_FEEFILTER_CHANGE_DELAY = 5 * 60;
-/** Block download timeout base, expressed in millionths of the block interval (i.e. 20 min) */
-static const int64_t BLOCK_DOWNLOAD_TIMEOUT_BASE = 2000000;
+/** Block download timeout base, expressed in millionths of the block interval (i.e. 10 min) */
+static const int64_t BLOCK_DOWNLOAD_TIMEOUT_BASE = 1000000;
 /** Additional block download timeout per parallel downloading peer (i.e. 5 min) */
 static const int64_t BLOCK_DOWNLOAD_TIMEOUT_PER_PEER = 500000;
 


### PR DESCRIPTION
Now that #7804 fixed the timeout handling, reduce the block timeout from 20 minutes to 10 minutes. 20 minutes is overkill.
