### PR TITLE
tests: Check Content-Type header returned from RPC server

### DIFF
--- a/qa/rpc-tests/test_framework/authproxy.py
+++ b/qa/rpc-tests/test_framework/authproxy.py
@@ -154,6 +154,11 @@ class AuthServiceProxy(object):
             raise JSONRPCException({
                 'code': -342, 'message': 'missing HTTP response from server'})
 
+        content_type = http_response.getheader('Content-Type')
+        if content_type != 'application/json':
+            raise JSONRPCException({
+                'code': -342, 'message': 'non-JSON HTTP response with \'%i %s\' from server' % (http_response.status, http_response.reason)})
+
         responsedata = http_response.read().decode('utf8')
         response = json.loads(responsedata, parse_float=decimal.Decimal)
         if "error" in response and response["error"] is None:


### PR DESCRIPTION
Check the Content-Type header that is returned from the RPC server. Only if it is `application/json` the data is supposed to be parsed as JSON.

This gives better reporting if the HTTP server happens to return an error that is not JSON-formatted, which is the case if it happens at a lower level before JSON-RPC kicks in.

Before: `Unexpected exception caught during testing: No JSON object could be decoded`

After: `JSONRPC error: non-JSON HTTP response with '403 Forbidden' from server`

@sipa
