### PR TITLE
doc: add arch linux build example

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -250,6 +250,24 @@ A list of additional configure flags can be displayed with:
     ./configure --help
 
 
+Setup and Build Example: Arch Linux
+-----------------------------------
+This example lists the steps necessary to setup and build a command line only, non-wallet distribution of the latest changes on Arch Linux:
+
+    pacman -S git base-devel boost libevent python
+    git clone https://github.com/bitcoin/bitcoin.git
+    cd bitcoin/
+    ./autogen.sh
+    ./configure --disable-wallet --without-gui --without-miniupnpc
+    make check
+
+Note:
+Enabling wallet support requires either compiling against a Berkeley DB newer than 4.8 (package `db`) using `--with-incompatible-bdb`,
+or building and depending on a local version of Berkeley DB 4.8. The readily available Arch Linux packages are currently built using
+`--with-incompatible-bdb` according to the [PKGBUILD](https://projects.archlinux.org/svntogit/community.git/tree/bitcoin/trunk/PKGBUILD).
+As mentioned above, when maintaining portability of the wallet between the standard Bitcoin Core distributions and independently built
+node software is desired, Berkeley DB 4.8 must be used.
+
 
 ARM Cross-compilation
 -------------------


### PR DESCRIPTION
Just adding some notes about building on Arch Linux. Shows which packages are necessary and gives a little info about how the pre-built packages are built.
