### PR TITLE
Divergence between 32- and 64-bit when hashing >4GB affects `gettxoutsetinfo`

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -21,6 +21,13 @@ It is recommended to use this for sensitive information such as wallet
 passphrases, as command-line arguments can usually be read from the process
 table by any user on the system.
 
+RPC low-level changes
+----------------------
+
+- `gettxoutsetinfo` UTXO hash (`hash_serialized`) has changed. There was a divergence between
+  32-bit and 64-bit platforms, and the txids were missing in the hashed data. This has been
+  fixed, but this means that the output will be different than from previous versions.
+
 0.13.0 Change log
 =================
 

--- a/src/crypto/ripemd160.h
+++ b/src/crypto/ripemd160.h
@@ -14,7 +14,7 @@ class CRIPEMD160
 private:
     uint32_t s[5];
     unsigned char buf[64];
-    size_t bytes;
+    uint64_t bytes;
 
 public:
     static const size_t OUTPUT_SIZE = 20;

--- a/src/crypto/sha1.h
+++ b/src/crypto/sha1.h
@@ -14,7 +14,7 @@ class CSHA1
 private:
     uint32_t s[5];
     unsigned char buf[64];
-    size_t bytes;
+    uint64_t bytes;
 
 public:
     static const size_t OUTPUT_SIZE = 20;

--- a/src/crypto/sha256.h
+++ b/src/crypto/sha256.h
@@ -14,7 +14,7 @@ class CSHA256
 private:
     uint32_t s[8];
     unsigned char buf[64];
-    size_t bytes;
+    uint64_t bytes;
 
 public:
     static const size_t OUTPUT_SIZE = 32;

--- a/src/crypto/sha512.h
+++ b/src/crypto/sha512.h
@@ -14,7 +14,7 @@ class CSHA512
 private:
     uint64_t s[8];
     unsigned char buf[128];
-    size_t bytes;
+    uint64_t bytes;
 
 public:
     static const size_t OUTPUT_SIZE = 64;

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -467,6 +467,7 @@ static bool GetUTXOStats(CCoinsView *view, CCoinsStats &stats)
         CCoins coins;
         if (pcursor->GetKey(key) && pcursor->GetValue(coins)) {
             stats.nTransactions++;
+            ss << key;
             for (unsigned int i=0; i<coins.vout.size(); i++) {
                 const CTxOut &out = coins.vout[i];
                 if (!out.IsNull()) {


### PR DESCRIPTION
I was seeing differerent UTXO hashes from `gettxoutsetinfo` on my ARM nodes than on x86 (64 bit). After the initial panic had weared off, I eventually managed to trace this to the following:

The counters for SHA256 and friends are supposed to be 64 bit. `size_t`, the type currently used, is 32-bit on architectures with a 32-bit address space. So after processing 4GB of data, the counter will wrap around on 32-bit and the hashes will start to diverge compared to those computed on 64-bit architectures.

I am sure this has no effect on any other use of hashes by the project, as there is no other place where >4GB of data is hashed in one go.

N.B. as this changes the output of `gettxoutsetinfo` on many platforms anyway (**needs mention in release notes**) I've taken the liberty of addressing the direct concern in #7758 as well in a second commit.
### Before first commit

``` javascript
// [32-bit]
{
  "height": 406339,
  "bestblock": "0000000000000000030eccfc56131ea1a560e965d22957098f978cb070f6374a",
  "transactions": 9254293,
  "txouts": 35345291,
  "bytes_serialized": 1214932313,
  "hash_serialized": "992696b26016449d90736ff28d0776167014a5d916298963331eb2c9d9d36928",
  //                  ⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧
  "total_amount": 15408336.11047113
}

// [64-bit]
{
  "height": 406339,
  "bestblock": "0000000000000000030eccfc56131ea1a560e965d22957098f978cb070f6374a",
  "transactions": 9254293,
  "txouts": 35345291,
  "bytes_serialized": 1214932313,
  "hash_serialized": "acaf2a5c17a8264ea7ee8aecba3dccb9efe6c8ee1861492fff5013ff4b7a14fc",
  //                  ⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧
  "total_amount": 15408336.11047113
}
```
### After first commit

``` javascript
// [32-bit]
{
  "height": 406339,
  "bestblock": "0000000000000000030eccfc56131ea1a560e965d22957098f978cb070f6374a",
  "transactions": 9254293,
  "txouts": 35345291,
  "bytes_serialized": 1214932313,
  "hash_serialized": "acaf2a5c17a8264ea7ee8aecba3dccb9efe6c8ee1861492fff5013ff4b7a14fc",
  //                  ⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧
  "total_amount": 15408336.11047113
}

[64-bit]
// {
  "height": 406339,
  "bestblock": "0000000000000000030eccfc56131ea1a560e965d22957098f978cb070f6374a",
  "transactions": 9254293,
  "txouts": 35345291,
  "bytes_serialized": 1214932313,
  "hash_serialized": "acaf2a5c17a8264ea7ee8aecba3dccb9efe6c8ee1861492fff5013ff4b7a14fc",
  //                  ⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧
  "total_amount": 15408336.11047113
}
```
### After second commit

``` javascript
// [32-bit]
{
  "height": 406339,
  "bestblock": "0000000000000000030eccfc56131ea1a560e965d22957098f978cb070f6374a",
  "transactions": 9254293,
  "txouts": 35345291,
  "bytes_serialized": 1214932313,
  "hash_serialized": "1814733d4f783cccfc4e5046b69e08077af4b26dc2279825a87c7d67522112a1",
  //                  ⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧
  "total_amount": 15408336.11047113
}

// [64-bit]
{
  "height": 406339,
  "bestblock": "0000000000000000030eccfc56131ea1a560e965d22957098f978cb070f6374a",
  "transactions": 9254293,
  "txouts": 35345291,
  "bytes_serialized": 1214932313,
  "hash_serialized": "1814733d4f783cccfc4e5046b69e08077af4b26dc2279825a87c7d67522112a1",
  //                  ⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧⇧
  "total_amount": 15408336.11047113
}
```
