### PR TITLE
Improve AlreadyHave

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4344,10 +4344,12 @@ bool static AlreadyHave(const CInv& inv) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
                 recentRejects->reset();
             }
 
+            // Use pcoinsTip->HaveCoinsInCache as a quick approximation to exclude
+            // requesting or processing some txs which have already been included in a block
             return recentRejects->contains(inv.hash) ||
                    mempool.exists(inv.hash) ||
                    mapOrphanTransactions.count(inv.hash) ||
-                   pcoinsTip->HaveCoins(inv.hash);
+                   pcoinsTip->HaveCoinsInCache(inv.hash);
         }
     case MSG_BLOCK:
         return mapBlockIndex.count(inv.hash);


### PR DESCRIPTION
`AlreadyHave` is called for transactions in 3 places:
- when an INV is received to decide whether to schedule a request of the tx
- when a TX is received to decide whether to process it
- when actually requesting a tx to see if it has been received since scheduling the request

In a large number of these cases, the transaction in question is new and fails each of the tests in the return statement.  In particular it is very unlikely (< 10%) to hit the `pcoinsTip` check and then be found.  But `pcoinsTip` must check the database to be sure it can't find the transaction.  Switching the full `HaveCoins` check for the fast `HaveCoinsInCache` check will still prevent the vast majority of false negatives but will never need a database access.  The downside is after the cache has been flushed there maybe be a very few more cases of requesting already confirmed transactions from peers.
