### PR TITLE
[test] bctest.py: Revert faa41ee

### DIFF
--- a/src/test/bctest.py
+++ b/src/test/bctest.py
@@ -2,7 +2,6 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 from __future__ import division,print_function,unicode_literals
-from io import open
 import subprocess
 import os
 import json
@@ -17,7 +16,7 @@ def bctest(testDir, testObj, exeext):
 	inputData = None
 	if "input" in testObj:
 		filename = testDir + "/" + testObj['input']
-		inputData = open(filename, 'rb').read()
+		inputData = open(filename).read()
 		stdinCfg = subprocess.PIPE
 
 	outputFn = None


### PR DESCRIPTION
Fixes https://github.com/bitcoin/bitcoin/pull/7853#issuecomment-210046962

Rationale:
- The type of `input` must be `bytes` or, if `universal_newlines` was `True`, a `string`. [[1]](https://docs.python.org/3/library/subprocess.html#subprocess.Popen.communicate)
- `universal_newlines` is set to `True` [[2]](https://github.com/MarcoFalke/bitcoin/blob/fa7abe0a00464e6aa88d55c63dba40878bbe5b79/src/test/bctest.py#L27-29)

So this pull reverts to the old behavior of using strings on py3 as well as on py2. No changes to this file were necessary, as it is already compatible. (At this point, I am not sure why I changed this in the first place)

Edit: The reason this went unnoticed on travis was that travis still runs py2.7 but other systems will choose python3 if available since 18f05c765c800126b74a6d5b7f33cef7c9aae1b7
