### PR TITLE
Optional parameter to fundrawtransaction: specify change address explicitly

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2435,9 +2435,9 @@ UniValue fundrawtransaction(const UniValue& params, bool fHelp)
     if (!EnsureWalletIsAvailable(fHelp))
         return NullUniValue;
 
-    if (fHelp || params.size() < 1 || params.size() > 2)
+    if (fHelp || params.size() < 1 || params.size() > 3)
         throw runtime_error(
-                            "fundrawtransaction \"hexstring\" includeWatching\n"
+                            "fundrawtransaction \"hexstring\" includeWatching changeAddress\n"
                             "\nAdd inputs to a transaction until it has enough in value to meet its out value.\n"
                             "This will not modify existing inputs, and will add one change output to the outputs.\n"
                             "Note that inputs which were signed may need to be resigned after completion since in/outputs have been added.\n"
@@ -2449,6 +2449,7 @@ UniValue fundrawtransaction(const UniValue& params, bool fHelp)
                             "\nArguments:\n"
                             "1. \"hexstring\"     (string, required) The hex string of the raw transaction\n"
                             "2. includeWatching (boolean, optional, default false) Also select inputs which are watch only\n"
+                            "3. changeAddress   (string, optional) An address for the change output\n"
                             "\nResult:\n"
                             "{\n"
                             "  \"hex\":       \"value\", (string)  The resulting raw transaction (hex-encoded string)\n"
@@ -2481,11 +2482,15 @@ UniValue fundrawtransaction(const UniValue& params, bool fHelp)
     if (params.size() > 1)
         includeWatching = params[1].get_bool();
 
+    string strChangeAddress;
+    if (params.size() > 2)
+        strChangeAddress = params[2].get_str();
+
     CMutableTransaction tx(origTx);
     CAmount nFee;
     string strFailReason;
     int nChangePos = -1;
-    if(!pwalletMain->FundTransaction(tx, nFee, nChangePos, strFailReason, includeWatching))
+    if(!pwalletMain->FundTransaction(tx, nFee, nChangePos, strFailReason, includeWatching, strChangeAddress))
         throw JSONRPCError(RPC_INTERNAL_ERROR, strFailReason);
 
     UniValue result(UniValue::VOBJ);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1932,7 +1932,7 @@ bool CWallet::SelectCoins(const vector<COutput>& vAvailableCoins, const CAmount&
     return res;
 }
 
-bool CWallet::FundTransaction(CMutableTransaction& tx, CAmount &nFeeRet, int& nChangePosRet, std::string& strFailReason, bool includeWatching)
+bool CWallet::FundTransaction(CMutableTransaction& tx, CAmount &nFeeRet, int& nChangePosRet, std::string& strFailReason, bool includeWatching, std::string& strChangeAddress)
 {
     vector<CRecipient> vecSend;
 
@@ -1948,6 +1948,15 @@ bool CWallet::FundTransaction(CMutableTransaction& tx, CAmount &nFeeRet, int& nC
     coinControl.fAllowWatchOnly = includeWatching;
     BOOST_FOREACH(const CTxIn& txin, tx.vin)
         coinControl.Select(txin.prevout);
+
+    if (!strChangeAddress.empty()) {
+        CBitcoinAddress changeAddress(strChangeAddress);
+        if (!changeAddress.IsValid()) {
+            strFailReason = _("Invalid change address");
+            return false;
+        }
+        coinControl.destChange = changeAddress.Get();
+    }
 
     CReserveKey reservekey(this);
     CWalletTx wtx;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -739,7 +739,7 @@ public:
      * Insert additional inputs into the transaction by
      * calling CreateTransaction();
      */
-    bool FundTransaction(CMutableTransaction& tx, CAmount& nFeeRet, int& nChangePosRet, std::string& strFailReason, bool includeWatching);
+    bool FundTransaction(CMutableTransaction& tx, CAmount& nFeeRet, int& nChangePosRet, std::string& strFailReason, bool includeWatching, std::string& strChangeAddress);
 
     /**
      * Create a new transaction paying the recipients with a set of coins


### PR DESCRIPTION
Using raw transactions it is possible to have fine control over the transactions created. `fundrawtransaction` picks a change address from the keypool, outside the user's control. I would rather specify my own change address when working with raw transactions.

This commit adds an optional 3rd parameter to `fundrawtransaction` allowing the user to specify the change address.
