### PR TITLE
Optimize CScript.FindAndDelete

### DIFF
--- a/src/script/script.h
+++ b/src/script/script.h
@@ -9,6 +9,7 @@
 #include "crypto/common.h"
 #include "prevector.h"
 
+#include <algorithm>
 #include <assert.h>
 #include <climits>
 #include <limits>
@@ -571,16 +572,30 @@ public:
         if (b.empty())
             return nFound;
         iterator pc = begin();
+        iterator copied = begin();
+        size_t nShift = 0;
         opcodetype opcode;
         do
         {
             while (end() - pc >= (long)b.size() && memcmp(&pc[0], &b[0], b.size()) == 0)
             {
-                pc = erase(pc, pc + b.size());
+                // Lazy copy-in-place if there is a match:
+                if (nShift == 0) copied = pc;
+                else copied = std::copy(copied+nShift, pc, copied);
+                pc += b.size();
+                nShift += b.size();
                 ++nFound;
             }
         }
         while (GetOp(pc, opcode));
+
+        if (nShift > 0)
+        {
+            if (copied+nShift != end())
+                copied = std::copy(copied+nShift, end(), copied);
+            erase(copied, end());
+        }
+
         return nFound;
     }
     int Find(opcodetype op) const


### PR DESCRIPTION
The FindAndDelete function could move the same bytes multiple times if the signature being deleted appeared in the script multiple times.

These two commits add a unit test for FindAndDelete and optimize it so that bytes are moved at most once.
