### PR TITLE
QA test fix: ensure unique coinbase transactions

### DIFF
--- a/qa/rpc-tests/test_framework/blocktools.py
+++ b/qa/rpc-tests/test_framework/blocktools.py
@@ -37,13 +37,15 @@ def serialize_script_num(value):
         r[-1] |= 0x80
     return r
 
-# Create a coinbase transaction, assuming no miner fees.
+# Create a unique coinbase transaction, assuming no miner fees.
 # If pubkey is passed in, the coinbase output will be a P2PK output;
 # otherwise an anyone-can-spend output.
 def create_coinbase(height, pubkey = None):
+    if not hasattr(create_coinbase, "counter"): create_coinbase.counter = 0
+    else: create_coinbase.counter += 1
     coinbase = CTransaction()
     coinbase.vin.append(CTxIn(COutPoint(0, 0xffffffff), 
-                ser_string(serialize_script_num(height)), 0xffffffff))
+                ser_string(serialize_script_num(height))+ser_string(serialize_script_num(create_coinbase.counter)), 0xffffffff))
     coinbaseoutput = CTxOut()
     coinbaseoutput.nValue = 50 * COIN
     halvings = int(height/150) # regtest


### PR DESCRIPTION
Apologies for the pull request spam, I can't re-open the previous version of this:

If given the same height and public key, blocktools.py create_coinbase would generate the same coinbase transaction-- bad if you're writing a test for forking scenarios where you want to generate two different blocks at the same block height.

This adds a unique counter to create_coinbase, so every call returns a unique transaction.

Tested by running all of the rpc-tests that use create_coinbase (and ran correctly before this pull request -- bip68-sequence.py fails when compiled -DDEBUG_LOCKORDER).
