### PR TITLE
Remove mapBlockSource

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -206,13 +206,12 @@ void UnregisterNodeSignals(CNodeSignals& nodeSignals);
  * specific block passed to it has been checked for validity!
  * 
  * @param[out]  state   This may be set to an Error state if any error occurred processing it, including during validation/connection/etc of otherwise unrelated blocks during reorganisation; or it may be set to an Invalid state if pblock is itself invalid (but this is not guaranteed even when the block is checked). If you want to *possibly* get feedback on whether pblock is valid, you must also install a CValidationInterface (see validationinterface.h) - this will have its BlockChecked method called whenever *any* block completes validation.
- * @param[in]   pfrom   The node which we are receiving the block from; it is added to mapBlockSource and may be penalised if the block is invalid.
  * @param[in]   pblock  The block we want to process.
  * @param[in]   fForceProcessing Process this block even if unrequested; used for non-network block sources and whitelisted peers.
  * @param[out]  dbp     If pblock is stored to disk (or already there), this will be set to its location.
  * @return True if state.IsValid()
  */
-bool ProcessNewBlock(CValidationState& state, const CChainParams& chainparams, const CNode* pfrom, const CBlock* pblock, bool fForceProcessing, CDiskBlockPos* dbp);
+bool ProcessNewBlock(CValidationState& state, const CChainParams& chainparams, const CBlock* pblock, bool fForceProcessing, CDiskBlockPos* dbp);
 /** Check whether enough disk space is available for an incoming block */
 bool CheckDiskSpace(uint64_t nAdditionalBytes = 0);
 /** Open a block file (blk?????.dat) */

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -130,7 +130,7 @@ UniValue generateBlocks(boost::shared_ptr<CReserveScript> coinbaseScript, int nG
             continue;
         }
         CValidationState state;
-        if (!ProcessNewBlock(state, Params(), NULL, pblock, true, NULL))
+        if (!ProcessNewBlock(state, Params(), pblock, true, NULL))
             throw JSONRPCError(RPC_INTERNAL_ERROR, "ProcessNewBlock, block not accepted");
         ++nHeight;
         blockHashes.push_back(pblock->GetHash().GetHex());
@@ -635,7 +635,7 @@ UniValue submitblock(const UniValue& params, bool fHelp)
     CValidationState state;
     submitblock_StateCatcher sc(block.GetHash());
     RegisterValidationInterface(&sc);
-    bool fAccepted = ProcessNewBlock(state, Params(), NULL, &block, true, NULL);
+    bool fAccepted = ProcessNewBlock(state, Params(), &block, true, NULL);
     UnregisterValidationInterface(&sc);
     if (fBlockPresent)
     {

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -114,7 +114,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
         pblock->hashMerkleRoot = BlockMerkleRoot(*pblock);
         pblock->nNonce = blockinfo[i].nonce;
         CValidationState state;
-        BOOST_CHECK(ProcessNewBlock(state, chainparams, NULL, pblock, true, NULL));
+        BOOST_CHECK(ProcessNewBlock(state, chainparams, pblock, true, NULL));
         BOOST_CHECK(state.IsValid());
         pblock->hashPrevBlock = pblock->GetHash();
     }

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -137,7 +137,7 @@ TestChain100Setup::CreateAndProcessBlock(const std::vector<CMutableTransaction>&
     while (!CheckProofOfWork(block.GetHash(), block.nBits, chainparams.GetConsensus())) ++block.nNonce;
 
     CValidationState state;
-    ProcessNewBlock(state, chainparams, NULL, &block, true, NULL);
+    ProcessNewBlock(state, chainparams, &block, true, NULL);
 
     CBlock result = block;
     delete pblocktemplate;


### PR DESCRIPTION
This refactor is part of larger work I'm doing for faster
block relay. It was inspired by noticing that mapBlockSource
is redundant with mapBlocksInFlight -- mapBlocksInFlight already
contains a mapping from blockhash to peer id.

mapBlockSource was used to DoS-ban peers that send us bad blocks,
but the banning logic was sometimes broken-- InvalidBlockFound
could DoS ban, and then another ban for the same bad block would
be applied in ProcessMessages. Just removing mapBlockSource is
the simplest fix.

There is a corner case where a peer might have been banned before,
but will not get banned now: if we get an out-of-order block
from a peer that double-spends an output spent in a previous block
that we don't yet have. The requirement that the block have valid
proof-of-work prevents this from being a practical DoS attack.

ProcessNewBlock loses it's *pfrom argument, which is nice--
ProcessNewBlock shouldn't care about networking stuff.
