### PR TITLE
add missing newline

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2443,7 +2443,7 @@ UniValue fundrawtransaction(const UniValue& params, bool fHelp)
                             "Note that inputs which were signed may need to be resigned after completion since in/outputs have been added.\n"
                             "The inputs added will not be signed, use signrawtransaction for that.\n"
                             "Note that all existing inputs must have their previous output transaction be in the wallet.\n"
-                            "Note that all inputs selected must be of standard form and P2SH scripts must be"
+                            "Note that all inputs selected must be of standard form and P2SH scripts must be\n"
                             "in the wallet using importaddress or addmultisigaddress (to calculate fees).\n"
                             "Only pay-to-pubkey, multisig, and P2SH versions thereof are currently supported for watch-only\n"
                             "\nArguments:\n"


### PR DESCRIPTION
Without the newline I see "bein" where the two lines are concatenated:

> Note that all inputs selected must be of standard form and P2SH scripts must _bein_ the wallet using importaddress or addmultisigaddress (to calculate fees).
