### PR TITLE
Fix help text around importaddress and rename it to importscript

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -89,6 +89,8 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "importprivkey", 2 },
     { "importaddress", 2 },
     { "importaddress", 3 },
+    { "importscript", 2 },
+    { "importscript", 3 },
     { "importpubkey", 2 },
     { "verifychain", 0 },
     { "verifychain", 1 },

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -186,7 +186,7 @@ UniValue importaddress(const UniValue& params, bool fHelp)
     
     if (fHelp || params.size() < 1 || params.size() > 4)
         throw runtime_error(
-            "importaddress \"address\" ( \"label\" rescan p2sh )\n"
+            "importscript \"script\" ( \"label\" rescan p2sh )\n"
             "\nAdds a script (in hex) or address that can be watched as if it were in your wallet but cannot be used to spend.\n"
             "\nArguments:\n"
             "1. \"script\"           (string, required) The hex-encoded script (or address)\n"
@@ -197,11 +197,11 @@ UniValue importaddress(const UniValue& params, bool fHelp)
             "If you have the full public key, you should call importpubkey instead of this.\n"
             "\nExamples:\n"
             "\nImport a script with rescan\n"
-            + HelpExampleCli("importaddress", "\"myscript\"") +
+            + HelpExampleCli("importscript", "\"myscript\"") +
             "\nImport using a label without rescan\n"
-            + HelpExampleCli("importaddress", "\"myscript\" \"testing\" false") +
+            + HelpExampleCli("importscript", "\"myscript\" \"testing\" false") +
             "\nAs a JSON-RPC call\n"
-            + HelpExampleRpc("importaddress", "\"myscript\", \"testing\", false")
+            + HelpExampleRpc("importscript", "\"myscript\", \"testing\", false")
         );
 
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2573,6 +2573,7 @@ static const CRPCCommand commands[] =
     { "wallet",             "importprivkey",            &importprivkey,            true  },
     { "wallet",             "importwallet",             &importwallet,             true  },
     { "wallet",             "importaddress",            &importaddress,            true  },
+    { "wallet",             "importscript",             &importaddress,            true  },
     { "wallet",             "importprunedfunds",        &importprunedfunds,        true  },
     { "wallet",             "importpubkey",             &importpubkey,             true  },
     { "wallet",             "keypoolrefill",            &keypoolrefill,            true  },


### PR DESCRIPTION
importaddress' help text was changed to talk primarily about
importing raw scripts instead of addresses but the help text missed
one replacement. It also makes much more sense for it to be renamed
importscript, so both are now aliases for importscript.
