### PR TITLE
 Optimize and Cleanup CScript::FindAndDelete

### DIFF
--- a/src/script/script.h
+++ b/src/script/script.h
@@ -574,7 +574,7 @@ public:
         opcodetype opcode;
         do
         {
-            while (end() - pc >= (long)b.size() && std::equal(b.begin(), b.end(), pc))
+            while (static_cast<size_t>(end() - pc) >= b.size() && std::equal(b.begin(), b.end(), pc))
             {
                 pc = erase(pc, pc + b.size());
                 ++nFound;

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -570,17 +570,26 @@ public:
         int nFound = 0;
         if (b.empty())
             return nFound;
-        iterator pc = begin();
+        CScript result;
+        iterator pc = begin(), pc2 = begin();
         opcodetype opcode;
         do
         {
+            result.insert(result.end(), pc2, pc);
             while (static_cast<size_t>(end() - pc) >= b.size() && std::equal(b.begin(), b.end(), pc))
             {
-                pc = erase(pc, pc + b.size());
+                pc = pc + b.size();
                 ++nFound;
             }
+            pc2 = pc;
         }
         while (GetOp(pc, opcode));
+
+        if (nFound > 0) {
+            result.insert(result.end(), pc2, end());
+            *this = result;
+        }
+
         return nFound;
     }
     int Find(opcodetype op) const

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -574,7 +574,7 @@ public:
         opcodetype opcode;
         do
         {
-            while (end() - pc >= (long)b.size() && memcmp(&pc[0], &b[0], b.size()) == 0)
+            while (end() - pc >= (long)b.size() && std::equal(b.begin(), b.end(), pc))
             {
                 pc = erase(pc, pc + b.size());
                 ++nFound;


### PR DESCRIPTION
This PR improves the worst-case behavior of CScript::FindAndDelete.

I have emphasized the obvious correctness of the algorithm in this commit.

Additionally I have done extensive fuzzing to ensure the result is identical to the current implementation.
