### PR TITLE
leveldb: integrate leveldb into our buildsystem

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -267,7 +267,7 @@ case $host in
      fi
 
      CPPFLAGS="$CPPFLAGS -D_MT -DWIN32 -D_WINDOWS -DBOOST_THREAD_USE_LIB"
-     LEVELDB_TARGET_FLAGS="TARGET_OS=OS_WINDOWS_CROSSCOMPILE"
+     LEVELDB_TARGET_FLAGS="-DOS_WINDOWS"
      if test "x$CXXFLAGS_overridden" = "xno"; then
        CXXFLAGS="$CXXFLAGS -w"
      fi
@@ -289,7 +289,7 @@ case $host in
      ;;
   *darwin*)
      TARGET_OS=darwin
-     LEVELDB_TARGET_FLAGS="TARGET_OS=Darwin"
+     LEVELDB_TARGET_FLAGS="-DOS_MACOSX"
      if  test x$cross_compiling != xyes; then
        BUILD_OS=darwin
        AC_CHECK_PROG([PORT],port, port)
@@ -354,9 +354,11 @@ case $host in
      OBJCXXFLAGS="$CXXFLAGS"
      ;;
    *linux*)
-     TARGET_OS=linux
+     LEVELDB_TARGET_FLAGS="-DOS_LINUX"
      ;;
    *)
+     OTHER_OS=`echo ${host_os} | awk '{print toupper($0)}'`
+     LEVELDB_TARGET_FLAGS="-DOS_${OTHER_OS}"
      ;;
 esac
 
@@ -540,6 +542,18 @@ if test x$use_reduce_exports = xyes; then
   AX_CHECK_COMPILE_FLAG([-fvisibility=hidden],[RE_CXXFLAGS="-fvisibility=hidden"],
   [AC_MSG_ERROR([Cannot set default symbol visibility. Use --disable-reduce-exports.])])
 fi
+
+dnl This can go away when we require c++11
+TEMP_CXXFLAGS="$CXXFLAGS"
+CXXFLAGS="$CXXFLAGS -std=c++0x"
+AC_MSG_CHECKING(for c++11 atomics)
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+  #include <atomic>
+  ]],[[]])],
+  [ AC_MSG_RESULT(yes); LEVELDB_ATOMIC_CPPFLAGS="-DLEVELDB_ATOMIC_PRESENT"; LEVELDB_ATOMIC_CXXFLAGS="-std=c++0x"],
+  [ AC_MSG_RESULT(no)]
+)
+CXXFLAGS="$TEMP_CXXFLAGS"
 
 LEVELDB_CPPFLAGS=
 LIBLEVELDB=
@@ -1043,6 +1057,8 @@ AC_SUBST(TESTDEFS)
 AC_SUBST(LEVELDB_TARGET_FLAGS)
 AC_SUBST(MINIUPNPC_CPPFLAGS)
 AC_SUBST(MINIUPNPC_LIBS)
+AC_SUBST(LEVELDB_ATOMIC_CPPFLAGS)
+AC_SUBST(LEVELDB_ATOMIC_CXXFLAGS)
 AC_CONFIG_FILES([Makefile src/Makefile share/setup.nsi share/qt/Info.plist src/test/buildenv.py])
 AC_CONFIG_FILES([qa/pull-tester/run-bitcoind-for-test.sh],[chmod +x qa/pull-tester/run-bitcoind-for-test.sh])
 AC_CONFIG_FILES([qa/pull-tester/tests_config.py],[chmod +x qa/pull-tester/tests_config.py])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -3,6 +3,7 @@ DIST_SUBDIRS = secp256k1 univalue
 AM_LDFLAGS = $(PTHREAD_CFLAGS) $(LIBTOOL_LDFLAGS) $(HARDENED_LDFLAGS)
 AM_CXXFLAGS = $(HARDENED_CXXFLAGS)
 AM_CPPFLAGS = $(HARDENED_CPPFLAGS)
+EXTRA_LIBRARIES =
 
 if EMBEDDED_UNIVALUE
 LIBUNIVALUE = univalue/libunivalue.la
@@ -11,21 +12,6 @@ $(LIBUNIVALUE): $(wildcard univalue/lib/*) $(wildcard univalue/include/*)
 	$(AM_V_at)$(MAKE) $(AM_MAKEFLAGS) -C $(@D) $(@F)
 else
 LIBUNIVALUE = $(UNIVALUE_LIBS)
-endif
-
-if EMBEDDED_LEVELDB
-LEVELDB_CPPFLAGS += -I$(srcdir)/leveldb/include
-LEVELDB_CPPFLAGS += -I$(srcdir)/leveldb/helpers/memenv
-LIBLEVELDB += $(builddir)/leveldb/libleveldb.a
-LIBMEMENV  += $(builddir)/leveldb/libmemenv.a
-
-# NOTE: This dependency is not strictly necessary, but without it make may try to build both in parallel, which breaks the LevelDB build system in a race
-$(LIBLEVELDB): $(LIBMEMENV)
-
-$(LIBLEVELDB) $(LIBMEMENV):
-	@echo "Building LevelDB ..." && $(MAKE) -C $(@D) $(@F) CXX="$(CXX)" \
-	  CC="$(CC)" PLATFORM=$(TARGET_OS) AR="$(AR)" $(LEVELDB_TARGET_FLAGS) \
-          OPT="$(AM_CXXFLAGS) $(PIE_FLAGS) $(CXXFLAGS) $(AM_CPPFLAGS) $(CPPFLAGS) -D__STDC_LIMIT_MACROS"
 endif
 
 BITCOIN_CONFIG_INCLUDES=-I$(builddir)/config
@@ -49,7 +35,7 @@ $(LIBSECP256K1): $(wildcard secp256k1/src/*) $(wildcard secp256k1/include/*)
 
 # Make is not made aware of per-object dependencies to avoid limiting building parallelization
 # But to build the less dependent modules first, we manually select their order here:
-EXTRA_LIBRARIES = \
+EXTRA_LIBRARIES += \
   crypto/libbitcoin_crypto.a \
   libbitcoin_util.a \
   libbitcoin_common.a \
@@ -481,6 +467,10 @@ endif
 %.pb.cc %.pb.h: %.proto
 	@test -f $(PROTOC)
 	$(AM_V_GEN) $(PROTOC) --cpp_out=$(@D) --proto_path=$(<D) $<
+
+if EMBEDDED_LEVELDB
+include Makefile.leveldb.include
+endif
 
 if ENABLE_TESTS
 include Makefile.test.include

--- a/src/Makefile.leveldb.include
+++ b/src/Makefile.leveldb.include
@@ -1,0 +1,81 @@
+LIBLEVELDB_INT = leveldb/libleveldb.a
+LIBMEMENV_INT  = leveldb/libmemenv.a
+
+EXTRA_LIBRARIES += $(LIBLEVELDB_INT)
+EXTRA_LIBRARIES += $(LIBMEMENV_INT)
+
+LIBLEVELDB += $(LIBLEVELDB_INT)
+LIBMEMENV += $(LIBMEMENV_INT)
+
+LEVELDB_CPPFLAGS += -I$(srcdir)/leveldb/include
+LEVELDB_CPPFLAGS += -I$(srcdir)/leveldb/helpers/memenv
+
+LEVELDB_CPPFLAGS_INT =
+LEVELDB_CPPFLAGS_INT += -I$(srcdir)/leveldb
+LEVELDB_CPPFLAGS_INT += $(LEVELDB_TARGET_FLAGS)
+LEVELDB_CPPFLAGS_INT += $(LEVELDB_ATOMIC_CPPFLAGS)
+LEVELDB_CPPFLAGS_INT += -D__STDC_LIMIT_MACROS
+
+if TARGET_WINDOWS
+LEVELDB_CPPFLAGS_INT += -DLEVELDB_PLATFORM_WINDOWS -DWINVER=0x0500 -D__USE_MINGW_ANSI_STDIO=1
+else
+LEVELDB_CPPFLAGS_INT += -DLEVELDB_PLATFORM_POSIX
+endif
+
+LEVELDB_CXXFLAGS_INT =
+LEVELDB_CXXFLAGS_INT += $(LEVELDB_ATOMIC_CXXFLAGS)
+
+leveldb_libleveldb_a_CPPFLAGS = $(AM_CPPFLAGS) $(LEVELDB_CPPFLAGS_INT) $(LEVELDB_CPPFLAGS)
+leveldb_libleveldb_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS) $(LEVELDB_CXXFLAGS_INT)
+
+leveldb_libleveldb_a_SOURCES=
+leveldb_libleveldb_a_SOURCES += leveldb/db/builder.cc
+leveldb_libleveldb_a_SOURCES += leveldb/db/c.cc
+leveldb_libleveldb_a_SOURCES += leveldb/db/dbformat.cc
+leveldb_libleveldb_a_SOURCES += leveldb/db/db_impl.cc
+leveldb_libleveldb_a_SOURCES += leveldb/db/db_iter.cc
+leveldb_libleveldb_a_SOURCES += leveldb/db/dumpfile.cc
+leveldb_libleveldb_a_SOURCES += leveldb/db/filename.cc
+leveldb_libleveldb_a_SOURCES += leveldb/db/log_reader.cc
+leveldb_libleveldb_a_SOURCES += leveldb/db/log_writer.cc
+leveldb_libleveldb_a_SOURCES += leveldb/db/memtable.cc
+leveldb_libleveldb_a_SOURCES += leveldb/db/repair.cc
+leveldb_libleveldb_a_SOURCES += leveldb/db/table_cache.cc
+leveldb_libleveldb_a_SOURCES += leveldb/db/version_edit.cc
+leveldb_libleveldb_a_SOURCES += leveldb/db/version_set.cc
+leveldb_libleveldb_a_SOURCES += leveldb/db/write_batch.cc
+leveldb_libleveldb_a_SOURCES += leveldb/table/block_builder.cc
+leveldb_libleveldb_a_SOURCES += leveldb/table/block.cc
+leveldb_libleveldb_a_SOURCES += leveldb/table/filter_block.cc
+leveldb_libleveldb_a_SOURCES += leveldb/table/format.cc
+leveldb_libleveldb_a_SOURCES += leveldb/table/iterator.cc
+leveldb_libleveldb_a_SOURCES += leveldb/table/merger.cc
+leveldb_libleveldb_a_SOURCES += leveldb/table/table_builder.cc
+leveldb_libleveldb_a_SOURCES += leveldb/table/table.cc
+leveldb_libleveldb_a_SOURCES += leveldb/table/two_level_iterator.cc
+leveldb_libleveldb_a_SOURCES += leveldb/util/arena.cc
+leveldb_libleveldb_a_SOURCES += leveldb/util/bloom.cc
+leveldb_libleveldb_a_SOURCES += leveldb/util/cache.cc
+leveldb_libleveldb_a_SOURCES += leveldb/util/coding.cc
+leveldb_libleveldb_a_SOURCES += leveldb/util/comparator.cc
+leveldb_libleveldb_a_SOURCES += leveldb/util/crc32c.cc
+leveldb_libleveldb_a_SOURCES += leveldb/util/env.cc
+leveldb_libleveldb_a_SOURCES += leveldb/util/env_posix.cc
+leveldb_libleveldb_a_SOURCES += leveldb/util/env_win.cc
+leveldb_libleveldb_a_SOURCES += leveldb/util/filter_policy.cc
+leveldb_libleveldb_a_SOURCES += leveldb/util/hash.cc
+leveldb_libleveldb_a_SOURCES += leveldb/util/histogram.cc
+leveldb_libleveldb_a_SOURCES += leveldb/util/logging.cc
+leveldb_libleveldb_a_SOURCES += leveldb/util/options.cc
+leveldb_libleveldb_a_SOURCES += leveldb/util/status.cc
+
+if TARGET_WINDOWS
+leveldb_libleveldb_a_SOURCES += leveldb/util/env_win.cc
+leveldb_libleveldb_a_SOURCES += leveldb/port/port_win.cc
+else
+leveldb_libleveldb_a_SOURCES += leveldb/port/port_posix.cc
+endif
+
+leveldb_libmemenv_a_CPPFLAGS = $(leveldb_libleveldb_a_CPPFLAGS)
+leveldb_libmemenv_a_CXXFLAGS = $(leveldb_libleveldb_a_CXXFLAGS)
+leveldb_libmemenv_a_SOURCES =  leveldb/helpers/memenv/memenv.cc


### PR DESCRIPTION
See discussion at https://github.com/bitcoin/leveldb/pull/11

leveldb's buildsystem causes us a few problems:
- breaks out-of-tree builds
- forces flags used for some tools
- limits cross builds

Rather than continuing to add wrappers around it, simply integrate it into our build.
