### PR TITLE
Tests: Fix deserialization of reject messages

### DIFF
--- a/qa/rpc-tests/test_framework/mininode.py
+++ b/qa/rpc-tests/test_framework/mininode.py
@@ -983,6 +983,7 @@ class msg_headers(object):
 
 class msg_reject(object):
     command = b"reject"
+    REJECT_MALFORMED = 1
 
     def __init__(self):
         self.message = b""
@@ -994,14 +995,16 @@ class msg_reject(object):
         self.message = deser_string(f)
         self.code = struct.unpack("<B", f.read(1))[0]
         self.reason = deser_string(f)
-        if (self.message == "block" or self.message == "tx"):
+        if (self.code != self.REJECT_MALFORMED and
+                (self.message == b"block" or self.message == b"tx")):
             self.data = deser_uint256(f)
 
     def serialize(self):
         r = ser_string(self.message)
         r += struct.pack("<B", self.code)
         r += ser_string(self.reason)
-        if (self.message == "block" or self.message == "tx"):
+        if (self.code != self.REJECT_MALFORMED and
+                (self.message == b"block" or self.message == b"tx")):
             r += ser_uint256(self.data)
         return r
 


### PR DESCRIPTION
Assume that reject messages for blocks or transactions due to reason REJECT_MALFORMED will not include the hash of the block or tx being rejected.

I found BIP 61 to be slightly ambiguous on how to deserialize in this case, but it seems logical to assume that the peer would have bailed out on parsing the message and thus wouldn't know what hash to include.  This is also consistent with the behavior of bitcoin core.

@MarcoFalke  Should these strings `"block"` and `"tx"` have the `b` prepended to them as well?  I wasn't sure if leaving them out of #7853 was intentional or an oversight.
