### PR TITLE
[qa] Add optional unique coinbase generation

### DIFF
--- a/qa/rpc-tests/test_framework/blocktools.py
+++ b/qa/rpc-tests/test_framework/blocktools.py
@@ -40,10 +40,18 @@ def serialize_script_num(value):
 # Create a coinbase transaction, assuming no miner fees.
 # If pubkey is passed in, the coinbase output will be a P2PK output;
 # otherwise an anyone-can-spend output.
-def create_coinbase(height, pubkey = None):
+def create_coinbase(height, pubkey = None, unique = False):
     coinbase = CTransaction()
-    coinbase.vin.append(CTxIn(COutPoint(0, 0xffffffff), 
-                ser_string(serialize_script_num(height)), 0xffffffff))
+    scriptSig = ser_string(serialize_script_num(height))
+
+    if (unique == True):
+        if not hasattr(create_coinbase, "counter"):
+            create_coinbase.counter = 0
+        else:
+            create_coinbase.counter += 1
+        scriptSig += ser_string(serialize_script_num(create_coinbase.counter))
+
+    coinbase.vin.append(CTxIn(COutPoint(0, 0xffffffff), scriptSig, 0xffffffff))
     coinbaseoutput = CTxOut()
     coinbaseoutput.nValue = 50 * COIN
     halvings = int(height/150) # regtest


### PR DESCRIPTION
Optionally generate unique coinbase with the same height and pubkey.

Alternative to #7886 maintaining backwards compat.
