### PR TITLE
Fix headers announcements edge case

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5718,7 +5718,21 @@ bool SendMessages(CNode* pto)
                         fRevertToInv = true;
                         break;
                     }
-                    assert(pBestIndex == NULL || pindex->pprev == pBestIndex);
+                    if (pBestIndex != NULL && pindex->pprev != pBestIndex) {
+                        // This means that the list of blocks to announce don't
+                        // connect to each other.
+                        // This shouldn't really be possible to hit during
+                        // regular operation (because reorgs should take us to
+                        // a chain that has some block not on the prior chain,
+                        // which should be caught by the prior check), but one
+                        // way this could happen is by using invalidateblock /
+                        // reconsiderblock repeatedly on the tip, causing it to
+                        // be added multiple times to vBlockHashesToAnnounce.
+                        // Robustly deal with this rare situation by reverting
+                        // to an inv.
+                        fRevertToInv = true;
+                        break;
+                    }
                     pBestIndex = pindex;
                     if (fFoundStartingHeader) {
                         // add this to the headers message


### PR DESCRIPTION
Previously we would assert that if every block in `vBlockHashesToAnnounce` is in
`chainActive`, then the blocks to be announced must connect.  However, there are
edge cases where this assumption could be violated (eg using invalidateblock /
reconsiderblock), so just check for this case and revert to inv-announcement
instead.

FYI I encountered this bug once while running `mempool_packages.py`, and was able to reproduce reliably by repeatedly invoking `invalidateblock`/`reconsiderblock` on the tip.  

Perhaps we should backport this to 0.12 as well?
