### PR TITLE
Enable leveldb obfuscation for new databases

### DIFF
--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -176,7 +176,7 @@ public:
      * @param[in] obfuscate   If true, store data obfuscated via simple XOR. If false, XOR
      *                        with a zero'd byte array.
      */
-    CDBWrapper(const boost::filesystem::path& path, size_t nCacheSize, bool fMemory = false, bool fWipe = false, bool obfuscate = false);
+    CDBWrapper(const boost::filesystem::path& path, size_t nCacheSize, bool fMemory = false, bool fWipe = false, bool obfuscate = true);
     ~CDBWrapper();
 
     template <typename K, typename V>


### PR DESCRIPTION
This was implemented some time ago in #6650 to fix #6613 but does not appear
ever to have been enabled under any circumstances outside of test/.

On a recent fresh install I'm seeing a null encryption key, and I don't see anywhere a `CDBWrapper` is ever created with a non-default `obfuscate` parameter (the default is `false`).
