### PR TITLE
[RPC] push back getaddednodeinfo dead value

### DIFF
--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -347,6 +347,7 @@ UniValue getaddednodeinfo(const UniValue& params, bool fHelp)
             obj.push_back(Pair("connected", false));
             UniValue addresses(UniValue::VARR);
             obj.push_back(Pair("addresses", addresses));
+            ret.push_back(obj);
         }
     }
 


### PR DESCRIPTION
I believe this is the desired behavior, if this is unneeded we should just delete the else branch.
