### PR TITLE
Minor changes to dbwrapper to simplify support for other databases

### DIFF
--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -15,7 +15,7 @@
 #include <memenv.h>
 #include <stdint.h>
 
-void HandleError(const leveldb::Status& status) throw(dbwrapper_error)
+void HandleError(const leveldb::Status& status)
 {
     if (status.ok())
         return;
@@ -102,7 +102,7 @@ CDBWrapper::~CDBWrapper()
     options.env = NULL;
 }
 
-bool CDBWrapper::WriteBatch(CDBBatch& batch, bool fSync) throw(dbwrapper_error)
+bool CDBWrapper::WriteBatch(CDBBatch& batch, bool fSync)
 {
     leveldb::Status status = pdb->Write(fSync ? syncoptions : writeoptions, &batch.batch);
     HandleError(status);

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -136,12 +136,16 @@ bool CDBWrapper::IsEmpty()
     return !(it->Valid());
 }
 
-const std::vector<unsigned char>& CDBWrapper::GetObfuscateKey() const
-{
-    return obfuscate_key;
-}
-
 CDBIterator::~CDBIterator() { delete piter; }
 bool CDBIterator::Valid() { return piter->Valid(); }
 void CDBIterator::SeekToFirst() { piter->SeekToFirst(); }
 void CDBIterator::Next() { piter->Next(); }
+
+namespace dbwrapper_private {
+
+const std::vector<unsigned char>& GetObfuscateKey(const CDBWrapper &w)
+{
+    return w.obfuscate_key;
+}
+
+};

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -84,10 +84,10 @@ CDBWrapper::CDBWrapper(const boost::filesystem::path& path, size_t nCacheSize, b
         Write(OBFUSCATE_KEY_KEY, new_key);
         obfuscate_key = new_key;
 
-        LogPrintf("Wrote new obfuscate key for %s: %s\n", path.string(), GetObfuscateKeyHex());
+        LogPrintf("Wrote new obfuscate key for %s: %s\n", path.string(), HexStr(obfuscate_key));
     }
 
-    LogPrintf("Using obfuscation key for %s: %s\n", path.string(), GetObfuscateKeyHex());
+    LogPrintf("Using obfuscation key for %s: %s\n", path.string(), HexStr(obfuscate_key));
 }
 
 CDBWrapper::~CDBWrapper()
@@ -139,11 +139,6 @@ bool CDBWrapper::IsEmpty()
 const std::vector<unsigned char>& CDBWrapper::GetObfuscateKey() const
 {
     return obfuscate_key;
-}
-
-std::string CDBWrapper::GetObfuscateKeyHex() const
-{
-    return HexStr(obfuscate_key);
 }
 
 CDBIterator::~CDBIterator() { delete piter; }

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -23,7 +23,7 @@ public:
     dbwrapper_error(const std::string& msg) : std::runtime_error(msg) {}
 };
 
-void HandleError(const leveldb::Status& status) throw(dbwrapper_error);
+void HandleError(const leveldb::Status& status);
 
 /** Batch of changes queued to be written to a CDBWrapper */
 class CDBBatch
@@ -180,7 +180,7 @@ public:
     ~CDBWrapper();
 
     template <typename K, typename V>
-    bool Read(const K& key, V& value) const throw(dbwrapper_error)
+    bool Read(const K& key, V& value) const
     {
         CDataStream ssKey(SER_DISK, CLIENT_VERSION);
         ssKey.reserve(ssKey.GetSerializeSize(key));
@@ -206,7 +206,7 @@ public:
     }
 
     template <typename K, typename V>
-    bool Write(const K& key, const V& value, bool fSync = false) throw(dbwrapper_error)
+    bool Write(const K& key, const V& value, bool fSync = false)
     {
         CDBBatch batch(&obfuscate_key);
         batch.Write(key, value);
@@ -214,7 +214,7 @@ public:
     }
 
     template <typename K>
-    bool Exists(const K& key) const throw(dbwrapper_error)
+    bool Exists(const K& key) const
     {
         CDataStream ssKey(SER_DISK, CLIENT_VERSION);
         ssKey.reserve(ssKey.GetSerializeSize(key));
@@ -233,14 +233,14 @@ public:
     }
 
     template <typename K>
-    bool Erase(const K& key, bool fSync = false) throw(dbwrapper_error)
+    bool Erase(const K& key, bool fSync = false)
     {
         CDBBatch batch(&obfuscate_key);
         batch.Erase(key);
         return WriteBatch(batch, fSync);
     }
 
-    bool WriteBatch(CDBBatch& batch, bool fSync = false) throw(dbwrapper_error);
+    bool WriteBatch(CDBBatch& batch, bool fSync = false);
 
     // not available for LevelDB; provide for compatibility with BDB
     bool Flush()
@@ -248,7 +248,7 @@ public:
         return true;
     }
 
-    bool Sync() throw(dbwrapper_error)
+    bool Sync()
     {
         CDBBatch batch(&obfuscate_key);
         return WriteBatch(batch, true);

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -23,13 +23,15 @@ public:
     dbwrapper_error(const std::string& msg) : std::runtime_error(msg) {}
 };
 
-void HandleError(const leveldb::Status& status);
-
 class CDBWrapper;
 
 /** These should be considered an implementation detail of the specific database.
  */
 namespace dbwrapper_private {
+
+/** Handle database error by throwing dbwrapper_error exception.
+ */
+void HandleError(const leveldb::Status& status);
 
 /** Work around circular dependency, as well as for testing in dbwrapper_tests.
  * Database obfuscation should be considered an implementation detail of the
@@ -208,7 +210,7 @@ public:
             if (status.IsNotFound())
                 return false;
             LogPrintf("LevelDB read failure: %s\n", status.ToString());
-            HandleError(status);
+            dbwrapper_private::HandleError(status);
         }
         try {
             CDataStream ssValue(strValue.data(), strValue.data() + strValue.size(), SER_DISK, CLIENT_VERSION);
@@ -242,7 +244,7 @@ public:
             if (status.IsNotFound())
                 return false;
             LogPrintf("LevelDB read failure: %s\n", status.ToString());
-            HandleError(status);
+            dbwrapper_private::HandleError(status);
         }
         return true;
     }

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -268,12 +268,6 @@ public:
      * Accessor for obfuscate_key.
      */
     const std::vector<unsigned char>& GetObfuscateKey() const;
-
-    /**
-     * Return the obfuscate_key as a hex-formatted string.
-     */
-    std::string GetObfuscateKeyHex() const;
-
 };
 
 #endif // BITCOIN_DBWRAPPER_H

--- a/src/test/dbwrapper_tests.cpp
+++ b/src/test/dbwrapper_tests.cpp
@@ -39,7 +39,7 @@ BOOST_AUTO_TEST_CASE(dbwrapper)
         uint256 res;
 
         // Ensure that we're doing real obfuscation when obfuscate=true
-        BOOST_CHECK(obfuscate != is_null_key(dbw.GetObfuscateKey()));
+        BOOST_CHECK(obfuscate != is_null_key(dbwrapper_private::GetObfuscateKey(dbw)));
 
         BOOST_CHECK(dbw.Write(key, in));
         BOOST_CHECK(dbw.Read(key, res));
@@ -64,7 +64,7 @@ BOOST_AUTO_TEST_CASE(dbwrapper_batch)
         uint256 in3 = GetRandHash();
 
         uint256 res;
-        CDBBatch batch(&dbw.GetObfuscateKey());
+        CDBBatch batch(dbw);
 
         batch.Write(key, in);
         batch.Write(key2, in2);
@@ -156,7 +156,7 @@ BOOST_AUTO_TEST_CASE(existing_data_no_obfuscate)
     BOOST_CHECK_EQUAL(res2.ToString(), in.ToString());
 
     BOOST_CHECK(!odbw.IsEmpty()); // There should be existing data
-    BOOST_CHECK(is_null_key(odbw.GetObfuscateKey())); // The key should be an empty string
+    BOOST_CHECK(is_null_key(dbwrapper_private::GetObfuscateKey(odbw))); // The key should be an empty string
 
     uint256 in2 = GetRandHash();
     uint256 res3;
@@ -193,7 +193,7 @@ BOOST_AUTO_TEST_CASE(existing_data_reindex)
     // Check that the key/val we wrote with unobfuscated wrapper doesn't exist
     uint256 res2;
     BOOST_CHECK(!odbw.Read(key, res2));
-    BOOST_CHECK(!is_null_key(odbw.GetObfuscateKey()));
+    BOOST_CHECK(!is_null_key(dbwrapper_private::GetObfuscateKey(odbw)));
 
     uint256 in2 = GetRandHash();
     uint256 res3;

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -49,7 +49,7 @@ uint256 CCoinsViewDB::GetBestBlock() const {
 }
 
 bool CCoinsViewDB::BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock) {
-    CDBBatch batch(&db.GetObfuscateKey());
+    CDBBatch batch(db);
     size_t count = 0;
     size_t changed = 0;
     for (CCoinsMap::iterator it = mapCoins.begin(); it != mapCoins.end();) {
@@ -139,7 +139,7 @@ void CCoinsViewDBCursor::Next()
 }
 
 bool CBlockTreeDB::WriteBatchSync(const std::vector<std::pair<int, const CBlockFileInfo*> >& fileInfo, int nLastFile, const std::vector<const CBlockIndex*>& blockinfo) {
-    CDBBatch batch(&GetObfuscateKey());
+    CDBBatch batch(*this);
     for (std::vector<std::pair<int, const CBlockFileInfo*> >::const_iterator it=fileInfo.begin(); it != fileInfo.end(); it++) {
         batch.Write(make_pair(DB_BLOCK_FILES, it->first), *it->second);
     }
@@ -155,7 +155,7 @@ bool CBlockTreeDB::ReadTxIndex(const uint256 &txid, CDiskTxPos &pos) {
 }
 
 bool CBlockTreeDB::WriteTxIndex(const std::vector<std::pair<uint256, CDiskTxPos> >&vect) {
-    CDBBatch batch(&GetObfuscateKey());
+    CDBBatch batch(*this);
     for (std::vector<std::pair<uint256,CDiskTxPos> >::const_iterator it=vect.begin(); it!=vect.end(); it++)
         batch.Write(make_pair(DB_TXINDEX, it->first), it->second);
     return WriteBatch(batch);


### PR DESCRIPTION
During my [experiment with using LMDB as database](https://github.com/laanwj/bitcoin/tree/2016_04_mdb) I came across these database-agnostic changes to dbwrapper which make it easier to support other databases, or are small common-sense (I think) cleanups at most:
- Pass parent CDBWrapper into CDBBatch and CDBIterator instead of obfuscation key (in the case of lmdb the batch needs to know about the database, to create a write transaction). This also looks cleaner.
- Incrase privacy of methods that are implementation specific by moving them to a namespace: HandleError, GetObfuscateKey.
- Make constructor of CDBIterator private - they rely on implementation details, others have no business instantiating these.
- Remove `GetObfuscateKeyHex` - It is an unnecessary method as it is used only two times and only internally, and the whole implementation is  `HexStr(obfuscate_key)`.
- Remove `throw` keywords in function signatures - Using throw() specifications   in function signatures is not only not required in C++, it is considered   deprecated for [various reasons](https://stackoverflow.com/questions/1055387/throw-keyword-in-functions-signature).   It is not implemented by any of the common C++ compilers. Their usage is also   inconsistent with the rest of the source code.
