### PR TITLE
CDataStream::ignore Throw exception instead of assert on negative nSize.

### DIFF
--- a/src/streams.h
+++ b/src/streams.h
@@ -240,7 +240,9 @@ public:
     CDataStream& ignore(int nSize)
     {
         // Ignore from the beginning of the buffer
-        assert(nSize >= 0);
+        if (nSize < 0) {
+            throw std::ios_base::failure("CDataStream::ignore(): nSize negative");
+        }
         unsigned int nReadPosNext = nReadPos + nSize;
         if (nReadPosNext >= vch.size())
         {


### PR DESCRIPTION
Previously disk corruption would cause an assert instead of an exception.

This has not been extensively reviewed.
