### PR TITLE
Re-instate TARGET_OS=linux in configure.ac. Removed by 351abf9e035.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -354,6 +354,7 @@ case $host in
      OBJCXXFLAGS="$CXXFLAGS"
      ;;
    *linux*)
+     TARGET_OS=linux
      LEVELDB_TARGET_FLAGS="-DOS_LINUX"
      ;;
    *)


### PR DESCRIPTION
Seems to have been removed erroneously. An error on linux manifests as "xcb" qt linking related.
