### PR TITLE
[RPC] Add RPC long poll notifications

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -129,6 +129,7 @@ BITCOIN_CORE_H = \
   rpc/blockchain.h \
   rpc/client.h \
   rpc/mining.h \
+  rpc/notifications.h \
   rpc/protocol.h \
   rpc/safemode.h \
   rpc/server.h \
@@ -210,6 +211,7 @@ libbitcoin_server_a_SOURCES = \
   rpc/mining.cpp \
   rpc/misc.cpp \
   rpc/net.cpp \
+  rpc/notifications.cpp \
   rpc/rawtransaction.cpp \
   rpc/safemode.cpp \
   rpc/server.cpp \

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -32,6 +32,7 @@
 #include "rpc/register.h"
 #include "rpc/safemode.h"
 #include "rpc/blockchain.h"
+#include "rpc/notifications.h"
 #include "script/standard.h"
 #include "script/sigcache.h"
 #include "scheduler.h"
@@ -1366,6 +1367,9 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
         RegisterValidationInterface(pzmqNotificationInterface);
     }
 #endif
+    // register http long poll notifications
+    RegisterLongPollNotificationsInterface();
+
     uint64_t nMaxOutboundLimit = 0; //unlimited unless -maxuploadtarget is set
     uint64_t nMaxOutboundTimeframe = MAX_UPLOAD_TIMEFRAME;
 

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -130,6 +130,8 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "logging", 1, "exclude" },
     { "disconnectnode", 1, "nodeid" },
     { "addwitnessaddress", 1, "p2sh" },
+    { "setregisterednotifications", 1, "type"},
+    { "pollnotifications", 1, "timeout" },
     // Echo with conversion (For testing only)
     { "echojson", 0, "arg0" },
     { "echojson", 1, "arg1" },

--- a/src/rpc/notifications.cpp
+++ b/src/rpc/notifications.cpp
@@ -1,0 +1,381 @@
+// Copyright (c) 2017 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "chain.h"
+#include "init.h"
+#include "primitives/block.h"
+#include "primitives/transaction.h"
+#include "rpc/server.h"
+#include "sync.h"
+#include "util.h"
+#include "utilstrencodings.h"
+#include "validationinterface.h"
+
+#include <univalue.h>
+
+#include <boost/assign/list_of.hpp>
+#include <boost/foreach.hpp>
+#include <boost/range/adaptors.hpp>
+
+#include <deque>
+#include <exception>
+#include <stdint.h>
+
+static const char* MSG_HASHBLOCK = "hashblock";
+static const char* MSG_HASHTX = "hashtx";
+
+/* keep the max queue size large becase we don't
+   auto-register for notification on startup */
+static const size_t MAX_QUEUE_SIZE = 1024 * 1024;
+static const int DEFAULT_POLL_TIMEOUT = 30;
+
+enum class NotificationType {
+    Unknown,
+    Block,
+    Tx
+};
+
+typedef std::pair<size_t, size_t> queueRange_t;
+typedef std::string clientUUID_t;
+
+// class that represents a notification
+class NotificationEntry
+{
+public:
+    NotificationType m_type;
+    int32_t m_sequence_number;
+    UniValue m_notification;
+};
+
+class NotificationQueue
+{
+public:
+    std::deque<NotificationEntry> m_queue;
+    std::map<NotificationType, int32_t> m_map_sequence_numbers;
+    std::set<NotificationType> m_registered_notification_types;
+
+    CCriticalSection m_cs_notification_queue;
+
+    const std::string typeToString(NotificationType type) const
+    {
+        switch (type) {
+        case NotificationType::Block:
+            return MSG_HASHBLOCK;
+            break;
+        case NotificationType::Tx:
+            return MSG_HASHTX;
+            break;
+        default:
+            return "unknown";
+        }
+    }
+
+    NotificationType stringToType(const std::string& strType) const
+    {
+        if (strType == MSG_HASHBLOCK)
+            return NotificationType::Block;
+        else if (strType == MSG_HASHTX)
+            return NotificationType::Tx;
+        else
+            return NotificationType::Unknown;
+    }
+
+    // populates a json object with all notifications in the queue
+    // returns a range to allow removing the elements from the queue
+    // after successfull transmitting
+    queueRange_t weakDequeueNotifications(UniValue& result)
+    {
+        size_t firstElement = 0;
+        size_t elementCount = 0;
+
+        LOCK(m_cs_notification_queue);
+        for (const NotificationEntry& entry : m_queue) {
+            UniValue obj = UniValue(UniValue::VOBJ);
+            obj.pushKV("type", typeToString(entry.m_type));
+            obj.pushKV("seq", entry.m_sequence_number);
+            obj.pushKV("obj", entry.m_notification);
+            result.push_back(obj);
+            elementCount++;
+        }
+        return std::make_pair(firstElement, elementCount);
+    }
+
+    // removes notifications in the given range from the queue
+    void eraseRangeFromQueue(const queueRange_t range)
+    {
+        LOCK(m_cs_notification_queue);
+        m_queue.erase(m_queue.begin() + range.first, m_queue.begin() + range.first + range.second);
+    }
+
+    // dequeues all notifications from the queue
+    void dequeueElements(UniValue& result)
+    {
+        queueRange_t range = weakDequeueNotifications(result);
+        eraseRangeFromQueue(range);
+    }
+
+    bool elementsAvailable()
+    {
+        LOCK(m_cs_notification_queue);
+        return m_queue.size() > 0;
+    }
+
+    void registerType(NotificationType type)
+    {
+        if (type == NotificationType::Unknown)
+            return;
+
+        LOCK(m_cs_notification_queue);
+        m_registered_notification_types.insert(type);
+    }
+
+    void unregisterType(NotificationType type)
+    {
+        LOCK(m_cs_notification_queue);
+        m_registered_notification_types.erase(type);
+    }
+
+    void unregisterAllTypes()
+    {
+        LOCK(m_cs_notification_queue);
+        m_registered_notification_types.clear();
+    }
+
+    void addToQueue(NotificationEntry entry)
+    {
+        LOCK(m_cs_notification_queue);
+
+        size_t queueSize = m_queue.size();
+        if (queueSize > MAX_QUEUE_SIZE) {
+            m_queue.pop_front();
+            LogPrintf("RPC Notification limit has been reached, dropping oldest element\n");
+        }
+        m_map_sequence_numbers[entry.m_type]++;
+        entry.m_sequence_number = m_map_sequence_numbers[entry.m_type];
+        m_queue.push_back(entry);
+    }
+
+    /* checks if a certain notification type is registered */
+    bool isTypeRegistered(NotificationType type)
+    {
+        LOCK(m_cs_notification_queue);
+        return (m_registered_notification_types.find(type) != m_registered_notification_types.end());
+    }
+};
+
+class NotificationQueueManager : public CValidationInterface
+{
+public:
+    CCriticalSection m_cs_queue_manager;
+    std::map<clientUUID_t, NotificationQueue*> m_map_sequence_numbers;
+
+    NotificationQueue* getQueue(const clientUUID_t& clientid)
+    {
+        LOCK(m_cs_queue_manager);
+        return m_map_sequence_numbers[clientid];
+    }
+
+    NotificationQueue* addQueue(const clientUUID_t& clientid)
+    {
+        LOCK(m_cs_queue_manager);
+        m_map_sequence_numbers[clientid] = new NotificationQueue();
+        return m_map_sequence_numbers[clientid];
+    }
+
+    void NotifyTransaction(const CTransactionRef& ptx)
+    {
+        LOCK(m_cs_queue_manager);
+        for (auto& queueEntry : m_map_sequence_numbers) {
+            if (!queueEntry.second->isTypeRegistered(NotificationType::Tx)) continue;
+
+            NotificationEntry entry;
+            entry.m_type = NotificationType::Tx;
+            entry.m_notification.setStr(ptx->GetHash().GetHex());
+            queueEntry.second->addToQueue(entry);
+        }
+    }
+
+    void BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindexConnected, const std::vector<CTransactionRef>& vtxConflicted) override
+    {
+        for (const CTransactionRef& ptx : pblock->vtx) {
+            // Do a normal notify for each transaction added in the block
+            NotifyTransaction(ptx);
+        }
+    }
+
+    void BlockDisconnected(const std::shared_ptr<const CBlock>& pblock) override
+    {
+        for (const CTransactionRef& ptx : pblock->vtx) {
+            // Do a normal notify for each transaction removed in block disconnection
+            NotifyTransaction(ptx);
+        }
+    }
+
+    void UpdatedBlockTip(const CBlockIndex* pindexNew, const CBlockIndex* pindexFork, bool fInitialDownload) override
+    {
+        LOCK(m_cs_queue_manager);
+        BOOST_FOREACH (NotificationQueue* queue, m_map_sequence_numbers | boost::adaptors::map_values) {
+            if (!queue->isTypeRegistered(NotificationType::Block)) continue;
+
+            NotificationEntry entry;
+            entry.m_type = NotificationType::Block;
+            entry.m_notification.setStr(pindexNew->GetBlockHash().GetHex());
+            queue->addToQueue(entry);
+        }
+    }
+
+    void TransactionAddedToMempool(const CTransactionRef& ptx) override
+    {
+        NotifyTransaction(ptx);
+    }
+};
+
+CCriticalSection cs_queueManagerSharedInstance;
+static NotificationQueueManager* queueManagerSharedInstance = NULL;
+
+NotificationQueue* getQueue(const std::string& clientID, bool createIfNotExists)
+{
+    LOCK(cs_queueManagerSharedInstance);
+    NotificationQueue* clientQueue = queueManagerSharedInstance->getQueue(clientID);
+    if (!clientQueue && !createIfNotExists)
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Client UUID not found.");
+    if (!clientQueue)
+        clientQueue = queueManagerSharedInstance->addQueue(clientID);
+    return clientQueue;
+}
+
+UniValue setregisterednotifications(const JSONRPCRequest& request)
+{
+    if (request.fHelp || request.params.size() != 2)
+        throw std::runtime_error(
+            "setregisterednotifications <uuid> [<type>, <type>, ...]\n"
+            "Register for rpc notification(s).\n"
+            "Notifications can be polled by calling pollnotifications."
+            "The client UUID must be unique per client application and will define the used queue."
+            "\nArguments:\n"
+            "1. \"uuid\"         (string, required) The client uuid\n"
+            "2. \"type\"         (string, required) The notification type to register for (\"hashblock\", \"hashtx\")\n"
+            "\nExamples:\n"
+            "\nRegister for block and transaction notifications\n" +
+            HelpExampleCli("setregisterednotifications", "\"[\"hashblock\", \"hashtx\"]\" \"") +
+            "register for transaction and block signals\n");
+
+    RPCTypeCheck(request.params, boost::assign::list_of(UniValue::VSTR)(UniValue::VARR), true);
+
+    NotificationQueue* clientQueue = getQueue(request.params[0].get_str(), true);
+
+    /* remove all current registered types */
+    clientQueue->unregisterAllTypes();
+
+    UniValue types = request.params[1].get_array();
+    BOOST_FOREACH (const UniValue& newType, types.getValues()) {
+        if (!newType.isStr())
+            continue;
+
+        NotificationType type = clientQueue->stringToType(newType.get_str());
+        if (type == NotificationType::Unknown) {
+            /* don't register only for a subset of the requested notifications */
+            clientQueue->unregisterAllTypes();
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "Notification type not found");
+        }
+
+        clientQueue->registerType(type);
+    }
+
+    return NullUniValue;
+}
+
+UniValue getregisterednotifications(const JSONRPCRequest& request)
+{
+    if (request.fHelp || request.params.size() != 1)
+        throw std::runtime_error(
+            "getregisterednotifications <uuid>\n"
+            "\nReturns the currently registered RPC notification types for the given uuid.\n"
+            "\nArguments:\n"
+            "1. \"uuid\"         (string, required) The client uuid\n"
+            "\nResult:\n"
+            "\"[\"\n"
+            "\"  \"<signal>\"             (string) The registered signal\n"
+            "\"  ,...\n"
+            "\"]\"\n"
+            "\nExamples:\n"
+            "\nCreate a transaction\n" +
+            HelpExampleCli("getregisterednotifications", "") +
+            "Get the registered notification types\n" + HelpExampleRpc("getregisterednotifications", ""));
+
+    RPCTypeCheck(request.params, boost::assign::list_of(UniValue::VSTR), true);
+    NotificationQueue* clientQueue = getQueue(request.params[0].get_str(), false);
+
+    UniValue result = UniValue(UniValue::VARR);
+    BOOST_FOREACH (NotificationType type, clientQueue->m_registered_notification_types)
+        result.push_back(clientQueue->typeToString(type));
+
+    return result;
+}
+
+UniValue pollnotifications(const JSONRPCRequest& request)
+{
+    if (request.fHelp || request.params.size() < 1 || request.params.size() > 2)
+        throw std::runtime_error(
+            "pollnotifications <uuid> <timeout>\n"
+            "\nLong poll function to get all available notifications for a given uuid (see setregisterednotifications for how to register for notifications).\n"
+            "The RPC thread will idle for the via <timeout> defined amount of seconds and/or will immediately response if new notifications are available\n"
+            "Arguments:\n"
+            "1. \"uuid\"         (string, required) The client uuid\n"
+            "2. \"timeout\"      (numeric, optional) The timeout \n"
+            "\nResult:\n"
+            "\"[ notification, ... ]\"             (object) The notification object\n"
+            "\nExamples:\n"
+            "\nPoll notifications for client a8098c1a...\n" +
+            HelpExampleCli("pollnotifications", "\"a8098c1a-f86e-11da-bd1a-00112444be1e\" 500") +
+            "Long poll notification (max. 500 seconds)\n" + HelpExampleRpc("pollnotifications", "\"a8098c1a-f86e-11da-bd1a-00112444be1e\" 500"));
+
+    RPCTypeCheck(request.params, boost::assign::list_of(UniValue::VSTR)(UniValue::VNUM), false);
+    NotificationQueue* clientQueue = getQueue(request.params[0].get_str(), false);
+
+    int64_t timeOut = DEFAULT_POLL_TIMEOUT;
+    if (request.params.size() == 2)
+        timeOut = request.params[1].get_int64();
+
+    int64_t startTime = GetTime();
+
+    UniValue result = UniValue(UniValue::VARR);
+    // allow long polling
+    while (!ShutdownRequested()) {
+        if (clientQueue->elementsAvailable()) {
+            clientQueue->dequeueElements(result);
+            break;
+        }
+        if (startTime + timeOut + (500 / 1000.0) < GetTime())
+            break;
+        MilliSleep(500);
+    }
+
+    return result;
+}
+
+static const CRPCCommand commands[] =
+{ //  category              name                           actor (function)             argNames
+  //  --------------------- ----------------------------   ---------------------------  ----------
+    { "notification",       "setregisterednotifications",  &setregisterednotifications, {"uuid","type"} },
+    { "notification",       "getregisterednotifications",  &getregisterednotifications, {"uuid"} },
+    { "notification",       "pollnotifications",           &pollnotifications,          {"uuid","timeout"} },
+
+};
+
+void RegisterLongPollNotificationsRPCCommands(CRPCTable& t)
+{
+    for (unsigned int vcidx = 0; vcidx < ARRAYLEN(commands); vcidx++) {
+        t.appendCommand(commands[vcidx].name, &commands[vcidx]);
+    }
+}
+
+void RegisterLongPollNotificationsInterface()
+{
+    LOCK(cs_queueManagerSharedInstance);
+    if (!queueManagerSharedInstance) {
+        queueManagerSharedInstance = new NotificationQueueManager();
+        RegisterValidationInterface(queueManagerSharedInstance);
+    }
+}

--- a/src/rpc/notifications.h
+++ b/src/rpc/notifications.h
@@ -1,0 +1,10 @@
+// Copyright (c) 2017 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_RPC_NOTIFICATIONS_H
+#define BITCOIN_RPC_NOTIFICATIONS_H
+
+void RegisterLongPollNotificationsInterface();
+
+#endif //BITCOIN_RPC_NOTIFICATIONS_H

--- a/src/rpc/register.h
+++ b/src/rpc/register.h
@@ -19,6 +19,8 @@ void RegisterMiscRPCCommands(CRPCTable &tableRPC);
 void RegisterMiningRPCCommands(CRPCTable &tableRPC);
 /** Register raw transaction RPC commands */
 void RegisterRawTransactionRPCCommands(CRPCTable &tableRPC);
+/** Register long poll notifications RPC commands */
+void RegisterLongPollNotificationsRPCCommands(CRPCTable &tableRPC);
 
 static inline void RegisterAllCoreRPCCommands(CRPCTable &t)
 {
@@ -27,6 +29,7 @@ static inline void RegisterAllCoreRPCCommands(CRPCTable &t)
     RegisterMiscRPCCommands(t);
     RegisterMiningRPCCommands(t);
     RegisterRawTransactionRPCCommands(t);
+    RegisterLongPollNotificationsRPCCommands(t);
 }
 
 #endif

--- a/test/functional/rpcnotifications.py
+++ b/test/functional/rpcnotifications.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+# Exercise the rpc signals API
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+import threading
+import uuid
+
+class pollThread (threading.Thread):
+    def __init__(self, threadID, node, clientUUID):
+        threading.Thread.__init__(self)
+        self.threadID = threadID
+        self.node = node
+        self.uuid = clientUUID
+    def run(self):
+        self.node.pollnotifications(self.uuid, 5)
+
+class RpcSignalsTest(BitcoinTestFramework):
+
+    def pollthread(self, node):
+        print("thread")
+
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+
+    def run_test (self):
+        self.nodes[0].generate(100)
+        client0UUID = str(uuid.uuid1())
+        client1UUID = str(uuid.uuid1())
+        client2UUID = str(uuid.uuid1())
+        assert_raises_jsonrpc(-8, "Client UUID not found", self.nodes[0].getregisterednotifications, client0UUID)
+
+        self.nodes[0].setregisterednotifications(client0UUID, ["hashblock", "hashtx"])
+        data = self.nodes[0].getregisterednotifications(client0UUID)
+        assert("hashblock" in data)
+        assert("hashtx" in data)
+
+        self.nodes[0].setregisterednotifications(client1UUID, ["hashtx"])
+        data = self.nodes[0].getregisterednotifications(client1UUID)
+        assert("hashblock" not in data)
+        assert("hashtx" in data)
+
+        self.nodes[0].setregisterednotifications(client2UUID, ["hashblock"])
+
+        minedblockhash = self.nodes[0].generate(1)[0]
+        data = self.nodes[0].pollnotifications(client0UUID, 10)
+        assert(len(data) == 2)
+
+        # poll via thread (5 sec poll)
+        myThread = pollThread(1, self.nodes[0], client0UUID)
+        myThread.start()
+        time.sleep(3)
+        # thread must still be polling
+        assert(myThread.isAlive() == True)
+        time.sleep(5)
+        # thread poll time must be expired
+        assert(myThread.isAlive() == False)
+        myThread.join()
+
+        # test mempool transactions
+        txid0 = self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), 1)
+        txid1 = self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), 1)
+        data = self.nodes[0].pollnotifications(client0UUID, 10)
+        assert(len(data) == 2)
+        assert(data[0]['type'] == "hashtx")
+        assert(data[0]['obj'] == txid0)
+        assert(data[0]['seq'] == 2)
+        assert(data[1]['type'] == "hashtx")
+        assert(data[1]['obj'] == txid1)
+        assert(data[1]['seq'] == 3)
+
+        # test second queue with tx only
+        data = self.nodes[0].pollnotifications(client1UUID, 10)
+        assert(len(data) == 3)
+        assert(data[0]['type'] == "hashtx")
+        assert(data[1]['type'] == "hashtx")
+        assert(data[2]['type'] == "hashtx")
+        assert(data[2]['seq'] == 3)
+
+        # test if only hashblock reqistered queue has the right content
+        data = self.nodes[0].pollnotifications(client2UUID, 10)
+        assert(len(data) == 1)
+        assert(data[0]['type'] == "hashblock")
+        assert(data[0]['obj'] == minedblockhash)
+        assert(data[0]['seq'] == 1)
+
+        # test unregister
+        self.nodes[0].setregisterednotifications(client0UUID, [])
+        data = self.nodes[0].getregisterednotifications(client0UUID)
+        assert(len(data) == 0)
+        self.nodes[0].generate(1)
+        data = self.nodes[0].pollnotifications(client0UUID, 5)
+        assert(len(data) == 0)
+
+if __name__ == '__main__':
+    RpcSignalsTest().main()
+

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -125,6 +125,7 @@ BASE_SCRIPTS= [
     'minchainwork.py',
     'p2p-fingerprint.py',
     'uacomment.py',
+    'rpcnotifications.py',
 ]
 
 EXTENDED_SCRIPTS = [


### PR DESCRIPTION
#### Reasons for another notification interface
- Currently there is no interface that could be extended to "private" notification secured behind the authorization (like peers connected/disconnected or a new wallet relevant transaction notification)
- HTTP long poll notifications are very easy to set up and require almost no dependencies
- HTTP long poll notifications can easily pushed over the internet using httpd reverse proxy together with a popper authentication method (certs or http auth digest) together with TLS.
- HTTP long poll would allow connecting applications to do all kinds of things with just a single communication channel (currently you need RPC & ZMQ for most use cases which would require VPN or a fancy multi port stunnel connection to broadcast the notification over the internet)
#### How does it work
- The listener calls the `pollnotification` RPC command.
- If no notifications are available, the RPC thread will idle for a given timeout (30s by default)
- If a notification was fired during the 30 seconds, the longpoll call will be responded with the new notification(s)
- The client/listener can immediately reconnect and wait again
- If notifications are already in the queue, the `pollnotification` command will immediately response.
- Notifications can't get lost (possible to lose them during http transfer and if one exceed the queue limit)
#### Downsides
- JSON encoding overhead
#### New RPC calls

`setregisterednotifications [<notificationtype>]` (possible types are `hashtx` and `hashblock`)
`getregisterednotifications`
`pollnotifications`
#### Missing
- [ ] More tests
- [ ] Documentation

I'd like to use a such interface to work on a remote GUI (use case: GUI on your local desktop, node on a VPS).
