### PR TITLE
Log invalid block hash to make debugging easier.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3371,7 +3371,7 @@ static bool AcceptBlockHeader(const CBlockHeader& block, CValidationState& state
             if (ppindex)
                 *ppindex = pindex;
             if (pindex->nStatus & BLOCK_FAILED_MASK)
-                return state.Invalid(error("%s: block is marked invalid", __func__), 0, "duplicate");
+                return state.Invalid(error("%s: block %s is marked invalid", __func__, hash.ToString()), 0, "duplicate");
             return true;
         }
 


### PR DESCRIPTION
Log block hash in AcceptBlockHeader.

Right now, it is a bit hard to sync on plain testnet. This helped debugging.
