### PR TITLE
test: Add more thorough test for dbwrapper iterators

### DIFF
--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -93,6 +93,7 @@ CBlockIndex* CBlockIndex::GetAncestor(int height)
             pindexWalk = pindexWalk->pskip;
             heightWalk = heightSkip;
         } else {
+            assert(pindexWalk->pprev);
             pindexWalk = pindexWalk->pprev;
             heightWalk--;
         }

--- a/src/test/dbwrapper_tests.cpp
+++ b/src/test/dbwrapper_tests.cpp
@@ -203,5 +203,39 @@ BOOST_AUTO_TEST_CASE(existing_data_reindex)
     BOOST_CHECK(odbw.Read(key, res3));
     BOOST_CHECK_EQUAL(res3.ToString(), in2.ToString());
 }
- 
+
+BOOST_AUTO_TEST_CASE(iterator_ordering)
+{
+    path ph = temp_directory_path() / unique_path();
+    CDBWrapper dbw(ph, (1 << 20), true, false, false);
+    for (int x=0x00; x<256; ++x) {
+        uint8_t key = x;
+        uint32_t value = x*x;
+        BOOST_CHECK(dbw.Write(key, value));
+    }
+
+    boost::scoped_ptr<CDBIterator> it(const_cast<CDBWrapper*>(&dbw)->NewIterator());
+    for (int c=0; c<2; ++c) {
+        int seek_start;
+        if (c == 0)
+            seek_start = 0x00;
+        else
+            seek_start = 0x80;
+        it->Seek((uint8_t)seek_start);
+        for (int x=seek_start; x<256; ++x) {
+            uint8_t key;
+            uint32_t value;
+            BOOST_CHECK(it->Valid());
+            if (!it->Valid()) // Avoid spurious errors about invalid iterator's key and value in case of failure
+                break;
+            BOOST_CHECK(it->GetKey(key));
+            BOOST_CHECK(it->GetValue(value));
+            BOOST_CHECK_EQUAL(key, x);
+            BOOST_CHECK_EQUAL(value, x*x);
+            it->Next();
+        }
+        BOOST_CHECK(!it->Valid());
+    }
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
I made a silly mistake in an experimental database wrapper where keys were sorted by char instead of uint8_t. As x86 char is signed the sorting (and thus seeking) for the block index database was messed up, resulting in a segfault due to missing records. This should be caught by the tests.

Add a test to catch:
- Wrong sorting
- Seeking errors
- Iteration result not complete
- Wrong keys/values from iterator

Also add an assertion to CBlockIndex::GetAncestor, as this it the place it will segfault when block index records are missing. An assertion error is easier to diagnose than a pointer crash (although what we really need is a start-up check whether the database is complete otherwise suggest a reindex).
