### PR TITLE
fix race that could fail to persist a ban

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2634,9 +2634,10 @@ void DumpBanlist()
 
     CBanDB bandb;
     banmap_t banmap;
+    CNode::SetBannedSetDirty(false);
     CNode::GetBanned(banmap);
-    if (bandb.Write(banmap))
-        CNode::SetBannedSetDirty(false);
+    if (!bandb.Write(banmap))
+        CNode::SetBannedSetDirty(true);
 
     LogPrint("net", "Flushed %d banned node ips/subnets to banlist.dat  %dms\n",
         banmap.size(), GetTimeMillis() - nStart);


### PR DESCRIPTION
DumpBanList currently does this:
- with lock: take a copy of the banmap
- perform I/O (write out the banmap)
- with lock: mark the banmap non-dirty

If a new ban is added during the I/O operation, it may never be persisted to disk.

Reorder operations so that the data to be persisted cannot be older than the time at which the banmap was marked non-dirty.
