### PR TITLE
[qa] smartfees: Properly use ordered dict

### DIFF
--- a/qa/rpc-tests/smartfees.py
+++ b/qa/rpc-tests/smartfees.py
@@ -23,7 +23,7 @@ SCRIPT_SIG = ["0451025175", "0451025275"]
 def small_txpuzzle_randfee(from_node, conflist, unconflist, amount, min_fee, fee_increment):
     '''
     Create and send a transaction with a random fee.
-    The transaction pays to a trival P2SH script, and assumes that its inputs
+    The transaction pays to a trivial P2SH script, and assumes that its inputs
     are of the same form.
     The function takes a list of confirmed outputs and unconfirmed outputs
     and attempts to use the confirmed list first for its inputs.
@@ -53,7 +53,7 @@ def small_txpuzzle_randfee(from_node, conflist, unconflist, amount, min_fee, fee
     outputs = OrderedDict([(P2SH_1, total_in - amount - fee),
                            (P2SH_2, amount)])
     rawtx = from_node.createrawtransaction(inputs, outputs)
-    # Createrawtransaction constructions a transaction that is ready to be signed
+    # createrawtransaction constructs a transaction that is ready to be signed.
     # These transactions don't need to be signed, but we still have to insert the ScriptSig
     # that will satisfy the ScriptPubKey.
     completetx = rawtx[0:10]
@@ -223,7 +223,7 @@ class EstimateFeeTest(BitcoinTestFramework):
             sync_mempools(self.nodes[0:3],.1)
             mined = mining_node.getblock(mining_node.generate(1)[0],True)["tx"]
             sync_blocks(self.nodes[0:3],.1)
-            #update which txouts are confirmed
+            # update which txouts are confirmed
             newmem = []
             for utx in self.memutxo:
                 if utx["txid"] in mined:

--- a/qa/rpc-tests/smartfees.py
+++ b/qa/rpc-tests/smartfees.py
@@ -7,6 +7,7 @@
 # Test fee estimation code
 #
 
+from collections import OrderedDict
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
 
@@ -49,8 +50,8 @@ def small_txpuzzle_randfee(from_node, conflist, unconflist, amount, min_fee, fee
         if total_in <= amount + fee:
             raise RuntimeError("Insufficient funds: need %d, have %d"%(amount+fee, total_in))
     outputs = {}
-    outputs[P2SH_1] = total_in - amount - fee
-    outputs[P2SH_2] = amount
+    outputs = OrderedDict([(P2SH_1, total_in - amount - fee),
+                           (P2SH_2, amount)])
     rawtx = from_node.createrawtransaction(inputs, outputs)
     # Createrawtransaction constructions a transaction that is ready to be signed
     # These transactions don't need to be signed, but we still have to insert the ScriptSig
@@ -78,12 +79,10 @@ def split_inputs(from_node, txins, txouts, initial_split = False):
     '''
     prevtxout = txins.pop()
     inputs = []
-    outputs = {}
     inputs.append({ "txid" : prevtxout["txid"], "vout" : prevtxout["vout"] })
     half_change = satoshi_round(prevtxout["amount"]/2)
     rem_change = prevtxout["amount"] - half_change  - Decimal("0.00001000")
-    outputs[P2SH_1] = half_change
-    outputs[P2SH_2] = rem_change
+    outputs = OrderedDict([(P2SH_1, half_change), (P2SH_2, rem_change)])
     rawtx = from_node.createrawtransaction(inputs, outputs)
     # If this is the initial split we actually need to sign the transaction
     # Otherwise we just need to insert the property ScriptSig


### PR DESCRIPTION
Dictionaries are not guaranteed to be sorted; Use an `OrderedDict` to avoid random failures of the smartfees test.
