### PR TITLE
Use std::unique_ptr instead of auto_ptr.

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -27,6 +27,7 @@
 
 #include <boost/thread.hpp>
 #include <boost/tuple/tuple.hpp>
+#include <memory>
 #include <queue>
 
 using namespace std;
@@ -74,7 +75,7 @@ int64_t UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParam
 CBlockTemplate* CreateNewBlock(const CChainParams& chainparams, const CScript& scriptPubKeyIn)
 {
     // Create new block
-    auto_ptr<CBlockTemplate> pblocktemplate(new CBlockTemplate());
+    std::unique_ptr<CBlockTemplate> pblocktemplate(new CBlockTemplate());
     if(!pblocktemplate.get())
         return NULL;
     CBlock *pblock = &pblocktemplate->block; // pointer for convenience

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -21,6 +21,7 @@
 #include "utilstrencodings.h"
 #include "validationinterface.h"
 
+#include <memory>
 #include <stdint.h>
 
 #include <boost/assign/list_of.hpp>
@@ -111,7 +112,7 @@ UniValue generateBlocks(boost::shared_ptr<CReserveScript> coinbaseScript, int nG
     UniValue blockHashes(UniValue::VARR);
     while (nHeight < nHeightEnd)
     {
-        auto_ptr<CBlockTemplate> pblocktemplate(CreateNewBlock(Params(), coinbaseScript->reserveScript));
+        std::unique_ptr<CBlockTemplate> pblocktemplate(CreateNewBlock(Params(), coinbaseScript->reserveScript));
         if (!pblocktemplate.get())
             throw JSONRPCError(RPC_INTERNAL_ERROR, "Couldn't create new block");
         CBlock *pblock = &pblocktemplate->block;


### PR DESCRIPTION
With C++11 available, we can use `std::unique_ptr` instead of the (now deprecated) `std::auto_ptr`.  Also use `std::unique_ptr` in `httpserver.cpp` to resolve an "XXX remark" there and simplify the code.
