### PR TITLE
main: Make version bits GUI warning clearer to translators

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -374,7 +374,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-whitelist=<netmask>", _("Whitelist peers connecting from the given netmask or IP address. Can be specified multiple times.") +
         " " + _("Whitelisted peers cannot be DoS banned and their transactions are always relayed, even if they are already in the mempool, useful e.g. for a gateway"));
     strUsage += HelpMessageOpt("-whitelistrelay", strprintf(_("Accept relayed transactions received from whitelisted peers even when not relaying transactions (default: %d)"), DEFAULT_WHITELISTRELAY));
-    strUsage += HelpMessageOpt("-whitelistforcerelay", strprintf(_("Force relay of transactions from whitelisted peers even they violate local relay policy (default: %d)"), DEFAULT_WHITELISTFORCERELAY));
+    strUsage += HelpMessageOpt("-whitelistforcerelay", strprintf(_("Force relay of transactions from whitelisted peers even if they violate local relay policy (default: %d)"), DEFAULT_WHITELISTFORCERELAY));
     strUsage += HelpMessageOpt("-maxuploadtarget=<n>", strprintf(_("Tries to keep outbound traffic under the given target (in MiB per 24h), 0 = no limit (default: %d)"), DEFAULT_MAX_UPLOAD_TARGET));
 
 #ifdef ENABLE_WALLET

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2596,7 +2596,7 @@ void static UpdateTip(CBlockIndex *pindexNew, const CChainParams& chainParams) {
             ThresholdState state = checker.GetStateFor(pindex, chainParams.GetConsensus(), warningcache[bit]);
             if (state == THRESHOLD_ACTIVE || state == THRESHOLD_LOCKED_IN) {
                 if (state == THRESHOLD_ACTIVE) {
-                    strMiscWarning = strprintf(_("Warning: unknown new rules activated (versionbit %i)"), bit);
+                    strMiscWarning = strprintf("Warning: unknown new rules activated (versionbit %i)", bit);
                     if (!fWarned) {
                         AlertNotify(strMiscWarning, true);
                         fWarned = true;
@@ -2618,7 +2618,7 @@ void static UpdateTip(CBlockIndex *pindexNew, const CChainParams& chainParams) {
         if (nUpgraded > 100/2)
         {
             // strMiscWarning is read by GetWarnings(), called by Qt and the JSON-RPC code to warn the user:
-            strMiscWarning = _("Warning: Unknown block versions being mined! It's possible unknown rules are in effect");
+            strMiscWarning = "Warning: Unknown block versions being mined! It's possible unknown rules are in effect";
             if (!fWarned) {
                 AlertNotify(strMiscWarning, true);
                 fWarned = true;


### PR DESCRIPTION
Trivial message changes to make translation easier 
- main: Make version bits GUI warning more clear to translators (reported by yahoe.001 on Transifex for the French translation)
- init: Fix typo in help message for -whitelistforcerelay (reported by pryds on Transifex in the Danish translation)
