### PR TITLE
Get rid of a compiler warning due to #if 0'd test

### DIFF
--- a/src/test/scheduler_tests.cpp
+++ b/src/test/scheduler_tests.cpp
@@ -28,6 +28,7 @@ static void microTask(CScheduler& s, boost::mutex& mutex, int& counter, int delt
     }
 }
 
+#if 0 /* Disabled for now because there is a race condition issue in this test - see #6540 */
 static void MicroSleep(uint64_t n)
 {
 #if defined(HAVE_WORKING_BOOST_SLEEP_FOR)
@@ -40,7 +41,6 @@ static void MicroSleep(uint64_t n)
 #endif
 }
 
-#if 0 /* Disabled for now because there is a race condition issue in this test - see #6540 */
 BOOST_AUTO_TEST_CASE(manythreads)
 {
     seed_insecure_rand(false);


### PR DESCRIPTION
In v0.9.0rc2-4332-g8f0d79e the src/test/scheduler_tests.cpp test was
disabled, but it was done in such a way as to define a function that
then was no longer used, leading to this warning under at least my GCC
4.9.2-10:

```
test/scheduler_tests.cpp:32:13: warning: ‘void
scheduler_tests::MicroSleep(uint64_t)’ defined but not used
[-Wunused-function]
```

Fix this by just moving the "#if 0" a few lines up so that it also
defines out a function used only by this test.
