### PR TITLE
RFC: Interruptible threads

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -95,6 +95,12 @@ BITCOIN_CORE_H = \
   httprpc.h \
   httpserver.h \
   init.h \
+  interruptible/condition_variable.h \
+  interruptible/lock.h  \
+  interruptible/this_thread.h \
+  interruptible/thread.h \
+  interruptible/thread_data.h \
+  interruptible/thread_group.h \
   key.h \
   keystore.h \
   dbwrapper.h \
@@ -306,6 +312,9 @@ libbitcoin_util_a_SOURCES = \
   compat/glibc_sanity.cpp \
   compat/glibcxx_sanity.cpp \
   compat/strnlen.cpp \
+  interruptible/this_thread.cpp \
+  interruptible/thread.cpp \
+  interruptible/thread_group.cpp \
   random.cpp \
   rpc/protocol.cpp \
   support/cleanse.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -51,6 +51,7 @@ BITCOIN_TESTS =\
   test/DoS_tests.cpp \
   test/getarg_tests.cpp \
   test/hash_tests.cpp \
+  test/interruptible.cpp \
   test/key_tests.cpp \
   test/limitedmap_tests.cpp \
   test/dbwrapper_tests.cpp \

--- a/src/interruptible/condition_variable.h
+++ b/src/interruptible/condition_variable.h
@@ -1,0 +1,104 @@
+// Copyright (c) 2015 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_INTERRUPTIBLE_CONDITION_VARIABLE_H
+#define BITCOIN_INTERRUPTIBLE_CONDITION_VARIABLE_H
+
+#include "interruptible/lock.h"
+#include "interruptible/this_thread.h"
+
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
+#include <thread>
+
+namespace interruptible
+{
+class condition_variable
+{
+public:
+    typedef int_lock<std::unique_lock<std::mutex> > lock_type;
+
+    condition_variable() = default;
+    ~condition_variable() = default;
+
+    condition_variable(const condition_variable&) = delete;
+    condition_variable& operator=(const condition_variable&) = delete;
+
+    inline void notify_one() noexcept
+    {
+        m_condvar.notify_one();
+    }
+
+    inline void notify_all() noexcept
+    {
+        m_condvar.notify_all();
+    }
+
+    template <class Lockable>
+    inline void wait(Lockable& user_lock)
+    {
+        lock_type lock(m_condvar, user_lock);
+        this_thread::interruption_point();
+        m_condvar.wait(lock);
+        this_thread::interruption_point();
+    }
+
+    template <class Lockable, class Predicate>
+    void wait(Lockable& user_lock, Predicate pred)
+    {
+        lock_type lock(m_condvar, user_lock);
+        this_thread::interruption_point();
+        while (!pred()) {
+            m_condvar.wait(lock);
+            this_thread::interruption_point();
+        }
+    }
+
+    template <class Lockable, class Clock, class Duration>
+    std::cv_status wait_until(Lockable& user_lock, const std::chrono::time_point<Clock, Duration>& abs_time)
+    {
+        lock_type lock(m_condvar, user_lock);
+        this_thread::interruption_point();
+        std::cv_status ret = m_condvar.wait_until(lock, abs_time);
+        this_thread::interruption_point();
+        return ret;
+    }
+
+    template <class Lockable, class Clock, class Duration, class Predicate>
+    bool wait_until(Lockable& user_lock, const std::chrono::time_point<Clock, Duration>& abs_time, Predicate pred)
+    {
+        lock_type lock(m_condvar, user_lock);
+        this_thread::interruption_point();
+        while (!pred()) {
+            bool ret = m_condvar.wait_until(lock, abs_time) == std::cv_status::timeout;
+            this_thread::interruption_point();
+            if (!ret)
+                return pred();
+        }
+        return true;
+    }
+
+    template <class Lockable, class Rep, class Period>
+    std::cv_status wait_for(Lockable& user_lock, const std::chrono::duration<Rep, Period>& rel_time)
+    {
+        lock_type lock(m_condvar, user_lock);
+        this_thread::interruption_point();
+        std::cv_status ret = m_condvar.wait_for(lock, rel_time);
+        this_thread::interruption_point();
+        return ret;
+    }
+
+    template <class Lockable, class Rep, class Period, class Predicate>
+    bool wait_for(Lockable& user_lock, const std::chrono::duration<Rep, Period>& rel_time, Predicate pred)
+    {
+        return wait_until(user_lock, std::chrono::steady_clock::now() + rel_time, pred);
+    }
+
+private:
+    std::condition_variable_any m_condvar;
+};
+}
+
+#endif // BITCOIN_INTERRUPTIBLE_CONDITION_VARIABLE_H

--- a/src/interruptible/condition_variable.h
+++ b/src/interruptible/condition_variable.h
@@ -72,9 +72,9 @@ public:
         lock_type lock(m_condvar, user_lock);
         this_thread::interruption_point();
         while (!pred()) {
-            bool ret = m_condvar.wait_until(lock, abs_time) == std::cv_status::timeout;
+            auto ret = m_condvar.wait_until(lock, abs_time);
             this_thread::interruption_point();
-            if (!ret)
+            if (ret == std::cv_status::timeout)
                 return pred();
         }
         return true;

--- a/src/interruptible/lock.h
+++ b/src/interruptible/lock.h
@@ -1,0 +1,64 @@
+// Copyright (c) 2015 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_INTERRUPTIBLE_LOCK_H
+#define BITCOIN_INTERRUPTIBLE_LOCK_H
+
+#include "interruptible/this_thread.h"
+
+#include <condition_variable>
+#include <mutex>
+#include <assert.h>
+
+/*
+In order to avoid exposing the internals of thread_data, the semantics here are a bit funky.
+thread_data's mutex must be locked when setting/unsetting the condition pointer, and should
+also lock/unlock along with the user's mutex.
+
+To facilitate that, set_cond returns a (locked) unique_lock which the caller should hold until
+releasing the cond with unset_cond, which moves back the lock, which is then destroyed.
+
+*/
+
+namespace interruptible
+{
+template <typename Lockable>
+class int_lock
+{
+public:
+    int_lock(const int_lock&) = delete;
+    int_lock& operator=(const int_lock&) = delete;
+
+    int_lock(std::condition_variable_any& cond, Lockable& user_lock) : m_user_lock(user_lock), m_cond_lock(this_thread::detail::set_cond(&cond))
+    {
+        assert(m_user_lock.owns_lock());
+        assert(m_cond_lock.owns_lock());
+    }
+    ~int_lock()
+    {
+        assert(m_user_lock.owns_lock());
+        assert(m_cond_lock.owns_lock());
+        this_thread::detail::unset_cond(std::move(m_cond_lock));
+    }
+    inline void lock()
+    {
+        assert(!m_user_lock.owns_lock());
+        assert(!m_cond_lock.owns_lock());
+        std::lock(m_user_lock, m_cond_lock);
+    }
+    inline void unlock()
+    {
+        assert(m_user_lock.owns_lock());
+        assert(m_cond_lock.owns_lock());
+        m_cond_lock.unlock();
+        m_user_lock.unlock();
+    }
+
+private:
+    Lockable& m_user_lock;
+    std::unique_lock<std::mutex> m_cond_lock;
+};
+}
+
+#endif // BITCOIN_INTERRUPTIBLE_LOCK_H

--- a/src/interruptible/this_thread.cpp
+++ b/src/interruptible/this_thread.cpp
@@ -1,0 +1,75 @@
+// Copyright (c) 2015 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "interruptible/condition_variable.h"
+#include "interruptible/this_thread.h"
+#include "interruptible/thread.h"
+#include "interruptible/thread_data.h"
+
+#include <mutex>
+#include <assert.h>
+
+thread_local interruptible::detail::thread_data* t_data = nullptr;
+
+interruptible::detail::thread_data* interruptible::this_thread::detail::get_thread_data()
+{
+    return t_data;
+}
+
+std::unique_lock<std::mutex> interruptible::this_thread::detail::set_cond(std::condition_variable_any* cond)
+{
+    return t_data->set_cond(cond);
+}
+
+void interruptible::this_thread::detail::unset_cond(std::unique_lock<std::mutex>&& lock)
+{
+    t_data->unset_cond(std::move(lock));
+}
+
+void interruptible::this_thread::detail::set_thread_data(interruptible::detail::thread_data* indata)
+{
+    t_data = indata;
+}
+
+void interruptible::this_thread::detail::sleep_until(std::chrono::time_point<std::chrono::steady_clock> endtime)
+{
+    std::mutex mutex;
+    std::unique_lock<std::mutex> lock(mutex);
+    interruptible::condition_variable cond;
+    cond.wait_until(lock, endtime, [&endtime] { return std::chrono::steady_clock::now() >= endtime; });
+}
+
+void interruptible::this_thread::detail::interrupt()
+{
+    assert(t_data);
+    throw ::interruptible::thread_interrupted();
+}
+
+bool interruptible::this_thread::detail::check_interrupt()
+{
+    assert(t_data);
+    if (t_data->is_interrupted())
+        interrupt();
+    return false;
+}
+
+bool interruptible::this_thread::detail::enable_interruption(bool thread_interruption_enabled)
+{
+    if (t_data)
+        return t_data->enable_interruption(thread_interruption_enabled);
+    return false;
+}
+
+bool interruptible::this_thread::interruption_enabled()
+{
+    if (t_data)
+        return t_data->interruption_enabled();
+    return false;
+}
+
+void interruptible::this_thread::interruption_point()
+{
+    if (t_data && t_data->interruption_enabled())
+        detail::check_interrupt();
+}

--- a/src/interruptible/this_thread.cpp
+++ b/src/interruptible/this_thread.cpp
@@ -10,24 +10,21 @@
 #include <mutex>
 #include <assert.h>
 
-thread_local interruptible::detail::thread_data* t_data = nullptr;
-
-interruptible::detail::thread_data* interruptible::this_thread::detail::get_thread_data()
-{
-    return t_data;
-}
+thread_local std::shared_ptr<interruptible::detail::thread_data> t_data;
 
 std::unique_lock<std::mutex> interruptible::this_thread::detail::set_cond(std::condition_variable_any* cond)
 {
+    assert(t_data);
     return t_data->set_cond(cond);
 }
 
 void interruptible::this_thread::detail::unset_cond(std::unique_lock<std::mutex>&& lock)
 {
+    assert(t_data);
     t_data->unset_cond(std::move(lock));
 }
 
-void interruptible::this_thread::detail::set_thread_data(interruptible::detail::thread_data* indata)
+void interruptible::this_thread::detail::set_thread_data(const std::shared_ptr<interruptible::detail::thread_data>& indata)
 {
     t_data = indata;
 }
@@ -40,36 +37,22 @@ void interruptible::this_thread::detail::sleep_until(std::chrono::time_point<std
     cond.wait_until(lock, endtime, [&endtime] { return std::chrono::steady_clock::now() >= endtime; });
 }
 
-void interruptible::this_thread::detail::interrupt()
-{
-    assert(t_data);
-    throw ::interruptible::thread_interrupted();
-}
-
-bool interruptible::this_thread::detail::check_interrupt()
-{
-    assert(t_data);
-    if (t_data->is_interrupted())
-        interrupt();
-    return false;
-}
-
 bool interruptible::this_thread::detail::enable_interruption(bool thread_interruption_enabled)
 {
-    if (t_data)
+    if(t_data)
         return t_data->enable_interruption(thread_interruption_enabled);
     return false;
 }
 
 bool interruptible::this_thread::interruption_enabled()
 {
-    if (t_data)
+    if(t_data)
         return t_data->interruption_enabled();
     return false;
 }
 
 void interruptible::this_thread::interruption_point()
 {
-    if (t_data && t_data->interruption_enabled())
-        detail::check_interrupt();
+    if(t_data && t_data->should_interrupt())
+        throw ::interruptible::thread_interrupted();
 }

--- a/src/interruptible/this_thread.h
+++ b/src/interruptible/this_thread.h
@@ -1,0 +1,80 @@
+// Copyright (c) 2015 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_INTERRUPTIBLE_THIS_THREAD_H
+#define BITCOIN_INTERRUPTIBLE_THIS_THREAD_H
+
+#include <condition_variable>
+#include <mutex>
+#include <thread>
+
+namespace interruptible
+{
+namespace detail
+{
+class thread_data;
+}
+
+namespace this_thread
+{
+namespace detail
+{
+std::unique_lock<std::mutex> set_cond(std::condition_variable_any* cond);
+void unset_cond(std::unique_lock<std::mutex>&& lock);
+::interruptible::detail::thread_data* get_thread_data();
+void set_thread_data(::interruptible::detail::thread_data* indata);
+void interrupt();
+bool check_interrupt();
+bool enable_interruption(bool thread_interruption_enabled);
+void sleep_until(std::chrono::time_point<std::chrono::steady_clock> endtime);
+}
+
+
+void interruption_point();
+bool interruption_enabled();
+
+class disable_interruption
+{
+    friend class restore_interruption;
+
+public:
+    disable_interruption()
+    {
+        m_was_enabled = detail::enable_interruption(false);
+    }
+    ~disable_interruption()
+    {
+        detail::enable_interruption(m_was_enabled);
+    }
+    disable_interruption(const disable_interruption&) = delete;
+    disable_interruption& operator=(const disable_interruption&) = delete;
+
+private:
+    bool m_was_enabled;
+};
+
+class restore_interruption
+{
+public:
+    explicit restore_interruption(disable_interruption& disabler)
+    {
+        detail::enable_interruption(disabler.m_was_enabled);
+    }
+    ~restore_interruption()
+    {
+        detail::enable_interruption(false);
+    }
+    restore_interruption(const restore_interruption&) = delete;
+    restore_interruption& operator=(const restore_interruption&) = delete;
+};
+
+template <class Rep, class Period>
+void sleep_for(const std::chrono::duration<Rep, Period>& sleep_duration)
+{
+    detail::sleep_until(std::chrono::steady_clock::now() + sleep_duration);
+}
+}
+}
+
+#endif // BITCOIN_INTERRUPTIBLE_THIS_THREAD_H

--- a/src/interruptible/this_thread.h
+++ b/src/interruptible/this_thread.h
@@ -22,10 +22,7 @@ namespace detail
 {
 std::unique_lock<std::mutex> set_cond(std::condition_variable_any* cond);
 void unset_cond(std::unique_lock<std::mutex>&& lock);
-::interruptible::detail::thread_data* get_thread_data();
-void set_thread_data(::interruptible::detail::thread_data* indata);
-void interrupt();
-bool check_interrupt();
+void set_thread_data(const std::shared_ptr<::interruptible::detail::thread_data>& indata);
 bool enable_interruption(bool thread_interruption_enabled);
 void sleep_until(std::chrono::time_point<std::chrono::steady_clock> endtime);
 }

--- a/src/interruptible/thread.cpp
+++ b/src/interruptible/thread.cpp
@@ -10,7 +10,7 @@ void interruptible::thread::start_thread(std::function<void()>&& func)
 {
     m_data = std::make_shared<interruptible::detail::thread_data>();
     auto run_thread_func = [func, this] {
-        interruptible::this_thread::detail::set_thread_data(m_data.get());
+        interruptible::this_thread::detail::set_thread_data(m_data);
         try {
             func();
         }

--- a/src/interruptible/thread.cpp
+++ b/src/interruptible/thread.cpp
@@ -1,0 +1,63 @@
+// Copyright (c) 2015 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "interruptible/thread.h"
+#include "interruptible/thread_data.h"
+#include "interruptible/this_thread.h"
+
+void interruptible::thread::start_thread(std::function<void()>&& func)
+{
+    m_data = std::make_shared<interruptible::detail::thread_data>();
+    auto run_thread_func = [func, this] {
+        interruptible::this_thread::detail::set_thread_data(m_data.get());
+        try {
+            func();
+        }
+        catch (const thread_interrupted&) {
+        }
+    };
+    m_data->start_thread(run_thread_func);
+}
+
+void interruptible::thread::interrupt()
+{
+    m_data->set_interrupted();
+}
+
+void interruptible::thread::join()
+{
+    if (m_data->get_thread().joinable()) {
+        m_data->get_thread().join();
+    }
+}
+
+void interruptible::thread::swap(interruptible::thread& rhs) noexcept
+{
+    m_data.swap(rhs.m_data);
+}
+
+bool interruptible::thread::joinable() const noexcept
+{
+    return m_data->get_thread().joinable();
+}
+
+void interruptible::thread::detach()
+{
+    m_data->get_thread().detach();
+}
+
+interruptible::thread::id interruptible::thread::get_id() const noexcept
+{
+    return m_data->get_thread().get_id();
+}
+
+interruptible::thread::native_handle_type interruptible::thread::native_handle()
+{
+    return m_data->get_thread().native_handle();
+}
+
+unsigned interruptible::thread::hardware_concurrency() noexcept
+{
+    return thread_type::hardware_concurrency();
+}

--- a/src/interruptible/thread.h
+++ b/src/interruptible/thread.h
@@ -1,0 +1,63 @@
+// Copyright (c) 2015 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_INTERRUPTIBLE_THREAD_H
+#define BITCOIN_INTERRUPTIBLE_THREAD_H
+
+#include "interruptible/this_thread.h"
+
+#include <thread>
+#include <memory>
+
+namespace interruptible
+{
+namespace detail
+{
+class thread_data;
+}
+
+class thread
+{
+public:
+    typedef std::thread thread_type;
+    typedef thread_type::native_handle_type native_handle_type;
+    typedef thread_type::id id;
+
+    thread() noexcept = default;
+
+    template <typename T, typename... Args>
+    explicit thread(T&& func, Args&&... args)
+    {
+        start_thread(std::bind(std::forward<T>(func), std::forward<Args>(args)...));
+    }
+
+    thread(const thread&) = delete;
+    thread(thread&& t) noexcept(true) = default;
+
+    thread& operator=(const thread&) = delete;
+    thread& operator=(thread&& t) noexcept(true) = default;
+
+    void join();
+    void swap(thread& rhs) noexcept;
+    bool joinable() const noexcept;
+    void detach();
+    id get_id() const noexcept;
+    native_handle_type native_handle();
+    static unsigned hardware_concurrency() noexcept;
+
+    // interruptible additions
+    void interrupt();
+    bool interruption_requested() const;
+
+private:
+    std::shared_ptr<detail::thread_data> m_data;
+    void start_thread(std::function<void()>&& func);
+};
+
+class thread_interrupted
+{
+};
+}
+
+#endif // BITCOIN_INTERRUPTIBLE_THREAD_H

--- a/src/interruptible/thread_data.h
+++ b/src/interruptible/thread_data.h
@@ -55,6 +55,11 @@ public:
         return m_thread_interruption_enabled;
     }
 
+    bool should_interrupt() const
+    {
+        return m_thread_interruption_enabled && m_interrupted;
+    }
+
     std::unique_lock<std::mutex> set_cond(std::condition_variable_any* cond)
     {
         std::unique_lock<std::mutex> lock(m_wake_mutex);
@@ -73,10 +78,9 @@ public:
         return m_thread;
     }
 
+private:
     std::mutex m_wake_mutex;
     std::condition_variable_any* m_cond_wake_ptr = nullptr;
-
-private:
     bool m_thread_interruption_enabled = true;
     std::atomic<bool> m_interrupted;
     std::thread m_thread;

--- a/src/interruptible/thread_data.h
+++ b/src/interruptible/thread_data.h
@@ -1,0 +1,86 @@
+// Copyright (c) 2015 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_INTERRUPTIBLE_THREAD_DATA_H
+#define BITCOIN_INTERRUPTIBLE_THREAD_DATA_H
+
+#include <atomic>
+#include <assert.h>
+#include <mutex>
+
+namespace interruptible
+{
+namespace detail
+{
+class thread_data
+{
+public:
+    thread_data() noexcept = default;
+    thread_data(thread_data&& t) = default;
+    thread_data& operator=(thread_data&& t) = default;
+    ~thread_data() = default;
+
+    thread_data(const thread_data&) = delete;
+    thread_data& operator=(const thread_data&) = delete;
+
+    template <typename T, typename... Args>
+    void start_thread(T&& func, Args&&... args)
+    {
+        m_thread = std::thread(std::forward<T>(func), std::forward<Args>(args)...);
+    }
+
+    void set_interrupted()
+    {
+        m_interrupted.store(true, std::memory_order_relaxed);
+        std::lock_guard<std::mutex> lock(m_wake_mutex);
+        if (m_cond_wake_ptr != nullptr)
+            m_cond_wake_ptr->notify_all();
+    }
+
+    bool is_interrupted() const
+    {
+        return m_interrupted;
+    }
+
+    bool enable_interruption(bool thread_interruption_enabled)
+    {
+        bool prev = interruption_enabled();
+        m_thread_interruption_enabled = thread_interruption_enabled;
+        return prev;
+    }
+
+    bool interruption_enabled() const
+    {
+        return m_thread_interruption_enabled;
+    }
+
+    std::unique_lock<std::mutex> set_cond(std::condition_variable_any* cond)
+    {
+        std::unique_lock<std::mutex> lock(m_wake_mutex);
+        m_cond_wake_ptr = cond;
+        return lock;
+    }
+
+    void unset_cond(std::unique_lock<std::mutex>&& lock)
+    {
+        (void)lock; // just let it deconstruct
+        m_cond_wake_ptr = nullptr;
+    }
+
+    std::thread& get_thread()
+    {
+        return m_thread;
+    }
+
+    std::mutex m_wake_mutex;
+    std::condition_variable_any* m_cond_wake_ptr = nullptr;
+
+private:
+    bool m_thread_interruption_enabled = true;
+    std::atomic<bool> m_interrupted;
+    std::thread m_thread;
+};
+}
+}
+#endif // BITCOIN_INTERRUPTIBLE_THREAD_DATA_H

--- a/src/interruptible/thread_group.cpp
+++ b/src/interruptible/thread_group.cpp
@@ -6,11 +6,18 @@
 
 namespace interruptible
 {
+
+thread_group::~thread_group()
+{
+    for (auto&& thread : m_threads)
+        delete thread;
+}
+
 void thread_group::add_thread(interruptible::thread* rhs)
 {
     if (rhs != nullptr) {
         std::lock_guard<std::mutex> lock(m_mutex);
-        m_threads.emplace_back(rhs);
+        m_threads.push_back(rhs);
     }
 }
 
@@ -18,7 +25,7 @@ void thread_group::remove_thread(interruptible::thread* rhs)
 {
     if (rhs != nullptr) {
         std::lock_guard<std::mutex> lock(m_mutex);
-        m_threads.remove_if([rhs](const std::unique_ptr<interruptible::thread>& it) { return rhs->get_id() == it->get_id(); });
+        m_threads.remove_if([rhs](const interruptible::thread* it) { return rhs->get_id() == it->get_id(); });
     }
 }
 

--- a/src/interruptible/thread_group.cpp
+++ b/src/interruptible/thread_group.cpp
@@ -1,0 +1,44 @@
+// Copyright (c) 2015 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "interruptible/thread_group.h"
+
+namespace interruptible
+{
+void thread_group::add_thread(interruptible::thread* rhs)
+{
+    if (rhs != nullptr) {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        m_threads.emplace_back(rhs);
+    }
+}
+
+void thread_group::remove_thread(interruptible::thread* rhs)
+{
+    if (rhs != nullptr) {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        m_threads.remove_if([rhs](const std::unique_ptr<interruptible::thread>& it) { return rhs->get_id() == it->get_id(); });
+    }
+}
+
+void thread_group::interrupt_all()
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    for (auto&& thread : m_threads)
+        thread->interrupt();
+}
+
+void thread_group::join_all()
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    for (auto&& thread : m_threads)
+        thread->join();
+}
+
+size_t thread_group::size() const
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return m_threads.size();
+}
+}

--- a/src/interruptible/thread_group.h
+++ b/src/interruptible/thread_group.h
@@ -1,0 +1,42 @@
+// Copyright (c) 2015 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_INTERRUPTIBLE_THREAD_GROUP_H
+#define BITCOIN_INTERRUPTIBLE_THREAD_GROUP_H
+
+#include "interruptible/thread.h"
+
+#include <list>
+#include <memory>
+
+namespace interruptible
+{
+class thread;
+class thread_group
+{
+public:
+    thread_group() = default;
+    thread_group(const thread_group&) = delete;
+    thread_group& operator=(const thread_group&) = delete;
+
+    template <typename T, typename... Args>
+    void create_thread(T&& func, Args&&... args)
+    {
+        auto thread_ptr(new interruptible::thread(std::forward<T>(func), std::forward<Args>(args)...));
+        m_threads.emplace_back(thread_ptr);
+    }
+
+    void add_thread(interruptible::thread* rhs);
+    void remove_thread(interruptible::thread* rhs);
+    void interrupt_all();
+    void join_all();
+    size_t size() const;
+
+private:
+    mutable std::mutex m_mutex;
+    std::list<std::unique_ptr<interruptible::thread> > m_threads;
+};
+}
+
+#endif // BITCOIN_INTERRUPTIBLE_THREAD_GROUP_H

--- a/src/test/interruptible.cpp
+++ b/src/test/interruptible.cpp
@@ -25,6 +25,7 @@ void long_loop()
 static void long_sleep()
 {
     interruptible::this_thread::sleep_for(std::chrono::seconds(wait_time));
+    BOOST_CHECK(false);
 }
 
 
@@ -36,6 +37,7 @@ static void condvar_wait()
     auto start = std::chrono::steady_clock::now();
     while (std::chrono::steady_clock::now() - start < wait_time)
         cond.wait(lock);
+    BOOST_CHECK(false);
 }
 
 static void condvar_wait_pred()
@@ -45,6 +47,7 @@ static void condvar_wait_pred()
     interruptible::condition_variable cond;
     auto start = std::chrono::steady_clock::now();
     cond.wait(lock, [&] {return std::chrono::steady_clock::now() - start >= wait_time; });
+    BOOST_CHECK(false);
 }
 
 static void condvar_wait_for()
@@ -55,6 +58,7 @@ static void condvar_wait_for()
     auto start = std::chrono::steady_clock::now();
     while (std::chrono::steady_clock::now() - start < wait_time)
         cond.wait_for(lock, wait_time);
+    BOOST_CHECK(false);
 }
 
 static void condvar_wait_for_pred()
@@ -64,6 +68,7 @@ static void condvar_wait_for_pred()
     interruptible::condition_variable cond;
     auto start = std::chrono::steady_clock::now();
     cond.wait_for(lock, wait_time, [&] {return std::chrono::steady_clock::now() - start >= wait_time; });
+    BOOST_CHECK(false);
 }
 
 static void condvar_wait_until()
@@ -73,8 +78,9 @@ static void condvar_wait_until()
     interruptible::condition_variable cond;
     auto start = std::chrono::steady_clock::now();
     auto end = start + wait_time;
-    while (std::chrono::steady_clock::now() - start < wait_time)
+    while (std::chrono::steady_clock::now() < end)
         cond.wait_until(lock, end);
+    BOOST_CHECK(false);
 }
 
 static void condvar_wait_until_pred()
@@ -84,7 +90,8 @@ static void condvar_wait_until_pred()
     interruptible::condition_variable cond;
     auto start = std::chrono::steady_clock::now();
     auto end = start + wait_time;
-    cond.wait_until(lock, end, [&] {return std::chrono::steady_clock::now() - start >= wait_time; });
+    cond.wait_until(lock, end, [&] {return std::chrono::steady_clock::now() >= end; });
+    BOOST_CHECK(false);
 }
 
 static void catcher(std::function<void()>&& func)

--- a/src/test/interruptible.cpp
+++ b/src/test/interruptible.cpp
@@ -1,0 +1,148 @@
+// Copyright (c) 2012-2015 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "interruptible/thread.h"
+#include "interruptible/thread_group.h"
+#include "interruptible/condition_variable.h"
+#include "test/test_bitcoin.h"
+
+#include <boost/test/unit_test.hpp>
+
+static constexpr std::chrono::seconds wait_time(5);
+
+BOOST_FIXTURE_TEST_SUITE(interruptible_tests, BasicTestingSetup)
+
+void long_loop()
+{
+    auto start = std::chrono::steady_clock::now();
+    while (std::chrono::steady_clock::now() - start < wait_time) {
+        interruptible::this_thread::interruption_point();
+        std::this_thread::yield();
+    }
+}
+
+static void long_sleep()
+{
+    interruptible::this_thread::sleep_for(std::chrono::seconds(wait_time));
+}
+
+
+static void condvar_wait()
+{
+    std::mutex m;
+    std::unique_lock<std::mutex> lock(m);
+    interruptible::condition_variable cond;
+    auto start = std::chrono::steady_clock::now();
+    while (std::chrono::steady_clock::now() - start < wait_time)
+        cond.wait(lock);
+}
+
+static void condvar_wait_pred()
+{
+    std::mutex m;
+    std::unique_lock<std::mutex> lock(m);
+    interruptible::condition_variable cond;
+    auto start = std::chrono::steady_clock::now();
+    cond.wait(lock, [&] {return std::chrono::steady_clock::now() - start >= wait_time; });
+}
+
+static void condvar_wait_for()
+{
+    std::mutex m;
+    std::unique_lock<std::mutex> lock(m);
+    interruptible::condition_variable cond;
+    auto start = std::chrono::steady_clock::now();
+    while (std::chrono::steady_clock::now() - start < wait_time)
+        cond.wait_for(lock, wait_time);
+}
+
+static void condvar_wait_for_pred()
+{
+    std::mutex m;
+    std::unique_lock<std::mutex> lock(m);
+    interruptible::condition_variable cond;
+    auto start = std::chrono::steady_clock::now();
+    cond.wait_for(lock, wait_time, [&] {return std::chrono::steady_clock::now() - start >= wait_time; });
+}
+
+static void condvar_wait_until()
+{
+    std::mutex m;
+    std::unique_lock<std::mutex> lock(m);
+    interruptible::condition_variable cond;
+    auto start = std::chrono::steady_clock::now();
+    auto end = start + wait_time;
+    while (std::chrono::steady_clock::now() - start < wait_time)
+        cond.wait_until(lock, end);
+}
+
+static void condvar_wait_until_pred()
+{
+    std::mutex m;
+    std::unique_lock<std::mutex> lock(m);
+    interruptible::condition_variable cond;
+    auto start = std::chrono::steady_clock::now();
+    auto end = start + wait_time;
+    cond.wait_until(lock, end, [&] {return std::chrono::steady_clock::now() - start >= wait_time; });
+}
+
+static void catcher(std::function<void()>&& func)
+{
+    BOOST_CHECK_THROW(func(), interruptible::thread_interrupted);
+}
+
+template <typename T>
+static bool run_test(T&& func)
+{
+    interruptible::thread runthread(catcher, std::forward<T>(func));
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    runthread.interrupt();
+    runthread.join();
+    return true;
+}
+
+template <typename T>
+static bool run_group_test(T&& func)
+{
+    interruptible::thread_group group;
+    group.create_thread(catcher, func);
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    group.create_thread(catcher, func);
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    group.interrupt_all();
+    group.join_all();
+    return true;
+}
+
+BOOST_AUTO_TEST_CASE(interruption_point)
+{
+    BOOST_CHECK(run_test(long_loop));
+    BOOST_CHECK(run_group_test(long_loop));
+}
+
+
+BOOST_AUTO_TEST_CASE(interruptible_sleep)
+{
+    BOOST_CHECK(run_test(long_sleep));
+    BOOST_CHECK(run_group_test(long_sleep));
+}
+
+BOOST_AUTO_TEST_CASE(interruptible_condvar)
+{
+    BOOST_CHECK(run_test(condvar_wait));
+    BOOST_CHECK(run_test(condvar_wait_pred));
+    BOOST_CHECK(run_test(condvar_wait_for));
+    BOOST_CHECK(run_test(condvar_wait_for_pred));
+    BOOST_CHECK(run_test(condvar_wait_until));
+    BOOST_CHECK(run_test(condvar_wait_until_pred));
+
+    BOOST_CHECK(run_group_test(condvar_wait));
+    BOOST_CHECK(run_group_test(condvar_wait_pred));
+    BOOST_CHECK(run_group_test(condvar_wait_for));
+    BOOST_CHECK(run_group_test(condvar_wait_for_pred));
+    BOOST_CHECK(run_group_test(condvar_wait_until));
+    BOOST_CHECK(run_group_test(condvar_wait_until_pred));
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
The intention here is to create a drop-in replacement for:
boost::thread
boost::thread_group
boost::condition_variable
boost::this_thread

These are just interruptible wrappers around the c++11 std:: versions. There are no dependencies, and afaik it's completely portable.

This allows us to move away from boost threads (which block the movement of other things like mutexes, function, bind, chrono, etc), without having to worry about refactoring to cope with our dependence on interruption points, interruptible condition variables, and interruptible sleeps.

For the places that don't require interruption, they can just move directly to std::.

The code needs some refinements, comments, and more tests, but I'd like to get a few concept ack's before continuing. Obviously the next step is to start plugging it all in.

Also, to avoid conflicting with segwit changes and backporting, it may be easier to replace things in some places and not others.

The condition_variable is actually an implementation of condition_variable_any, which means that it will accept any Lockable. So we can mix and match boost::mutex/boost::unique_lock/std::mutex/std::unique_lock without any trouble, if that eases the migration.
