### PR TITLE
Increase DEFAULT_KEYPOOL_SIZE to 10000.

### DIFF
--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -38,7 +38,7 @@ extern unsigned int nTxConfirmTarget;
 extern bool bSpendZeroConfChange;
 extern bool fSendFreeTransactions;
 
-static const unsigned int DEFAULT_KEYPOOL_SIZE = 100;
+static const unsigned int DEFAULT_KEYPOOL_SIZE = 10000;
 //! -paytxfee default
 static const CAmount DEFAULT_TRANSACTION_FEE = 0;
 //! -fallbackfee default


### PR DESCRIPTION
Reduce risk of backups being incomplete.
