### PR TITLE
[Doc] Simplify OS X build notes

### DIFF
--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -1,68 +1,78 @@
 Mac OS X Build Instructions and Notes
 ====================================
-This guide will show you how to build Bitcoin Core for OS X.
-
-Notes
------
-
-* Tested on OS X 10.7 through 10.11 on 64-bit Intel processors only.
-
-* All of the commands should be executed in a Terminal application. The
-built-in one is located in `/Applications/Utilities`.
+The commands in this guide should be executed in a Terminal application.
+The built-in one is located in `/Applications/Utilities/Terminal.app`.
 
 Preparation
 -----------
+Download and install [Xcode](https://developer.apple.com/xcode/download).
 
-You need to install Xcode with all the options checked so that the compiler
-and everything is available in /usr not just /Developer. Xcode should be
-available on your OS X installation media, but if not, you can get the
-current version from https://developer.apple.com/xcode/. If you install
-Xcode 4.3 or later, you'll need to install its command line tools. This can
-be done in `Xcode > Preferences > Downloads > Components` and generally must
-be re-done or updated every time Xcode is updated.
+Once installed, run `xcode-select --install` to install the OS X command line tools.
 
-You will also need to install [Homebrew](http://brew.sh) in order to install library
-dependencies.
+Install [Homebrew](http://brew.sh).
 
-The installation of the actual dependencies is covered in the instructions
-sections below.
-
-Instructions: Homebrew
+Dependencies
 ----------------------
 
-#### Install dependencies using Homebrew
+    brew install automake berkeley-db4 libtool boost --c++11 miniupnpc openssl pkg-config protobuf --c++11 qt5 libevent
 
-    brew install autoconf automake berkeley-db4 libtool boost miniupnpc openssl pkg-config protobuf qt5 libevent
+NOTE: Building with Qt4 is still supported, however, could result in a broken UI. Building with Qt5 is recommended.
 
-NOTE: Building with Qt4 is still supported, however, could result in a broken UI. As such, building with Qt5 is recommended.
+Build Bitcoin Core
+------------------------
 
-### Building `bitcoin`
+1. Clone the bitcoin source code and cd into `bitcoin`
 
-1. Clone the GitHub tree to get the source code and go into the directory.
-
-        git clone https://github.com/bitcoin/bitcoin.git
+        git clone https://github.com/bitcoin/bitcoin
         cd bitcoin
 
 2.  Build bitcoin-core:
-    This will configure and build the headless bitcoin binaries as well as the gui (if Qt is found).
-    You can disable the gui build by passing `--without-gui` to configure.
+
+    Configure and build the headless bitcoin binaries as well as the GUI (if Qt is found).
+
+    You can disable the GUI build by passing `--without-gui` to configure.
 
         ./autogen.sh
         ./configure
         make
 
-3.  It is also a good idea to build and run the unit tests:
+3.  It is recommended to build and run the unit tests:
 
         make check
 
-4.  (Optional) You can also install bitcoind to your path:
+4.  You can also create a .dmg that contains the .app bundle (optional):
 
-        make install
+        make deploy
 
-Use Qt Creator as IDE
+Running
+-------
+
+Bitcoin Core is now available at `./src/bitcoind`
+
+Before running, it's recommended you create an RPC configuration file.
+
+    echo -e "rpcuser=bitcoinrpc\nrpcpassword=$(xxd -l 16 -p /dev/urandom)" > "/Users/${USER}/Library/Application Support/Bitcoin/bitcoin.conf"
+
+    chmod 600 "/Users/${USER}/Library/Application Support/Bitcoin/bitcoin.conf"
+
+The first time you run bitcoind, it will start downloading the blockchain. This process could take several hours.
+
+You can monitor the download process by looking at the debug.log file:
+
+    tail -f $HOME/Library/Application\ Support/Bitcoin/debug.log
+
+Other commands:
+-------
+
+    ./src/bitcoind -daemon # Starts the bitcoin daemon.
+    ./src/bitcoin-cli --help # Outputs a list of command-line options.
+    ./src/bitcoin-cli help # Outputs a list of RPC commands when the daemon is running.
+
+Using Qt Creator as IDE
 ------------------------
-You can use Qt Creator as IDE, for debugging and for manipulating forms, etc.
-Download Qt Creator from https://www.qt.io/download/. Download the "community edition" and only install Qt Creator (uncheck the rest during the installation process).
+You can use Qt Creator as an IDE, for bitcoin development.
+Download and install the community edition of [Qt Creator](https://www.qt.io/download/).
+Uncheck everything except Qt Creator during the installation process.
 
 1. Make sure you installed everything through Homebrew mentioned above
 2. Do a proper ./configure --enable-debug
@@ -75,55 +85,9 @@ Download Qt Creator from https://www.qt.io/download/. Download the "community ed
 9. Select LLDB as debugger (you might need to set the path to your installation)
 10. Start debugging with Qt Creator
 
-Creating a release build
-------------------------
-You can ignore this section if you are building `bitcoind` for your own use.
+Notes
+-----
 
-bitcoind/bitcoin-cli binaries are not included in the Bitcoin-Qt.app bundle.
+* Tested on OS X 10.7 through 10.11 on 64-bit Intel processors only.
 
-If you are building `bitcoind` or `Bitcoin Core` for others, your build machine should be set up
-as follows for maximum compatibility:
-
-All dependencies should be compiled with these flags:
-
- -mmacosx-version-min=10.7
- -arch x86_64
- -isysroot $(xcode-select --print-path)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.7.sdk
-
-Once dependencies are compiled, see [doc/release-process.md](release-process.md) for how the Bitcoin Core
-bundle is packaged and signed to create the .dmg disk image that is distributed.
-
-Running
--------
-
-It's now available at `./bitcoind`, provided that you are still in the `src`
-directory. We have to first create the RPC configuration file, though.
-
-Run `./bitcoind` to get the filename where it should be put, or just try these
-commands:
-
-    echo -e "rpcuser=bitcoinrpc\nrpcpassword=$(xxd -l 16 -p /dev/urandom)" > "/Users/${USER}/Library/Application Support/Bitcoin/bitcoin.conf"
-    chmod 600 "/Users/${USER}/Library/Application Support/Bitcoin/bitcoin.conf"
-
-The next time you run it, it will start downloading the blockchain, but it won't
-output anything while it's doing this. This process may take several hours;
-you can monitor its process by looking at the debug.log file, like this:
-
-    tail -f $HOME/Library/Application\ Support/Bitcoin/debug.log
-
-Other commands:
--------
-
-    ./bitcoind -daemon    # to start the bitcoin daemon.
-    ./bitcoin-cli --help  # for a list of command-line options.
-    ./bitcoin-cli help    # When the daemon is running, to get a list of RPC commands
-
-Using Qt official installer while building
-------------------------------------------
-
-If you prefer to use the latest Qt installed from the official binary
-installer over the brew version, you have to make several changes to
-the installed tree and its binaries (all these changes are contained
-in the brew version already). The changes needed are described in
-[#7714](https://github.com/bitcoin/bitcoin/issues/7714). We do not
-support building Bitcoin Core this way though.
+* Building with downloaded Qt binaries is not officially supported. See the notes in [#7714](https://github.com/bitcoin/bitcoin/issues/7714)


### PR DESCRIPTION
Add --c++11 flag to brew dependancies that support it
Remove release-build section, this is covered by depends/release-notes

@theuni can I get your thoughts on adding the --c++11 flag to brew dependancies?

Link to the [rendered markdown](https://github.com/fanquake/bitcoin/blob/2bf1bacf252e5622b7895858a9afca5c2acee4d5/doc/build-osx.md)
