### PR TITLE
test: Revert fatal-ness of missing python-zmq

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -82,9 +82,9 @@ if ENABLE_ZMQ:
     try:
         import zmq
     except ImportError as e:
-        print("ERROR: \"import zmq\" failed. Set ENABLE_ZMQ=0 or " \
+        print("WARNING: \"import zmq\" failed. Set ENABLE_ZMQ=0 or " \
             "to run zmq tests, see dependency info in /qa/README.md.")
-        raise e
+        ENABLE_ZMQ=0
 
 #Tests
 testScripts = [


### PR DESCRIPTION
It looks like travis is using the `travis.yml` from the branch, but runs the test script from the branch merged into master. This causes pull requests created before the QA tests python 3 transition to fail due to missing `python3-zmq` package.
This happens in, for example, #8006.

This temporarily reverts fa05e22e919b7e2e816606f0c0d3dea1bd325bfd (#7851). It can be restored when this is no longer an issue.
