### PR TITLE
improvement to readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,7 @@ There are also [regression and integration tests](/qa) of the RPC interface, wri
 in Python, that are run automatically on the build server.
 These tests can be run (if the [test dependencies](/qa) are installed) with: `qa/pull-tester/rpc-tests.py`
 
-The Travis CI system makes sure that every pull request is built for Windows
-and Linux, OS X, and that unit and sanity tests are automatically run.
+The Travis CI system makes sure that every pull request is built for Windows, Linux, and OS X, and that unit/sanity tests are run automatically.
 
 ### Manual Quality Assurance (QA) Testing
 


### PR DESCRIPTION
changing "(tests are) automatically run" to correspond to the earlier instance of "run automatically (on the build server)", also some minor grammatical modification 
