### PR TITLE
Fix Socks5() connect failures to be less noisy and less unnecessarily scary

### DIFF
--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -291,6 +291,21 @@ struct ProxyCredentials
     std::string password;
 };
 
+std::string Socks5ErrorString(int err)
+{
+    switch(err) {
+        case 0x01: return "general failure";
+        case 0x02: return "connection not allowed";
+        case 0x03: return "network unreachable";
+        case 0x04: return "host unreachable";
+        case 0x05: return "connection refused";
+        case 0x06: return "TTL expired";
+        case 0x07: return "protocol error";
+        case 0x08: return "address type not supported";
+        default:   return "unknown";
+    }
+}
+
 /** Connect using SOCKS5 (as described in RFC1928) */
 static bool Socks5(const std::string& strDest, int port, const ProxyCredentials *auth, SOCKET& hSocket)
 {
@@ -382,18 +397,7 @@ static bool Socks5(const std::string& strDest, int port, const ProxyCredentials 
     if (pchRet2[1] != 0x00) {
         // Failures to connect to a peer that are not proxy errors
         CloseSocket(hSocket);
-        switch (pchRet2[1])
-        {
-            case 0x01: LogPrintf("Socks5() connect to %s:%d failed: general failure\n", strDest, port); break;
-            case 0x02: LogPrintf("Socks5() connect to %s:%d failed: connection not allowed\n", strDest, port); break;
-            case 0x03: LogPrintf("Socks5() connect to %s:%d failed: network unreachable\n", strDest, port); break;
-            case 0x04: LogPrintf("Socks5() connect to %s:%d failed: host unreachable\n", strDest, port); break;
-            case 0x05: LogPrintf("Socks5() connect to %s:%d failed: connection refused\n", strDest, port); break;
-            case 0x06: LogPrintf("Socks5() connect to %s:%d failed: TTL expired\n", strDest, port); break;
-            case 0x07: LogPrintf("Socks5() connect to %s:%d failed: protocol error\n", strDest, port); break;
-            case 0x08: LogPrintf("Socks5() connect to %s:%d failed: address type not supported\n", strDest, port); break;
-            default:   LogPrintf("Socks5() connect to %s:%d failed: unknown\n", strDest, port);
-        }
+        LogPrintf("Socks5() connect to %s:%d failed: %s\n", strDest, port, Socks5ErrorString(pchRet2[1]));
         return false;
     }
     if (pchRet2[2] != 0x00) {

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -379,19 +379,21 @@ static bool Socks5(const std::string& strDest, int port, const ProxyCredentials 
         return error("Proxy failed to accept request");
     }
     if (pchRet2[1] != 0x00) {
+        // Failures to connect to a peer that are not proxy errors
         CloseSocket(hSocket);
         switch (pchRet2[1])
         {
-            case 0x01: return error("Proxy error: general failure");
-            case 0x02: return error("Proxy error: connection not allowed");
-            case 0x03: return error("Proxy error: network unreachable");
-            case 0x04: return error("Proxy error: host unreachable");
-            case 0x05: return error("Proxy error: connection refused");
-            case 0x06: return error("Proxy error: TTL expired");
-            case 0x07: return error("Proxy error: protocol error");
-            case 0x08: return error("Proxy error: address type not supported");
-            default:   return error("Proxy error: unknown");
+            case 0x01: LogPrintf("Socks5() connect to %s:%d failed: general failure\n", strDest, port); break;
+            case 0x02: LogPrintf("Socks5() connect to %s:%d failed: connection not allowed\n", strDest, port); break;
+            case 0x03: LogPrintf("Socks5() connect to %s:%d failed: network unreachable\n", strDest, port); break;
+            case 0x04: LogPrintf("Socks5() connect to %s:%d failed: host unreachable\n", strDest, port); break;
+            case 0x05: LogPrintf("Socks5() connect to %s:%d failed: connection refused\n", strDest, port); break;
+            case 0x06: LogPrintf("Socks5() connect to %s:%d failed: TTL expired\n", strDest, port); break;
+            case 0x07: LogPrintf("Socks5() connect to %s:%d failed: protocol error\n", strDest, port); break;
+            case 0x08: LogPrintf("Socks5() connect to %s:%d failed: address type not supported\n", strDest, port); break;
+            default:   LogPrintf("Socks5() connect to %s:%d failed: unknown\n", strDest, port);
         }
+        return false;
     }
     if (pchRet2[2] != 0x00) {
         CloseSocket(hSocket);

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -294,7 +294,7 @@ struct ProxyCredentials
 /** Connect using SOCKS5 (as described in RFC1928) */
 static bool Socks5(const std::string& strDest, int port, const ProxyCredentials *auth, SOCKET& hSocket)
 {
-    LogPrintf("SOCKS5 connecting %s\n", strDest);
+    LogPrint("net", "SOCKS5 connecting %s\n", strDest);
     if (strDest.size() > 255) {
         CloseSocket(hSocket);
         return error("Hostname too long");
@@ -425,7 +425,7 @@ static bool Socks5(const std::string& strDest, int port, const ProxyCredentials 
         CloseSocket(hSocket);
         return error("Error reading from proxy");
     }
-    LogPrintf("SOCKS5 connected %s\n", strDest);
+    LogPrint("net", "SOCKS5 connected %s\n", strDest);
     return true;
 }
 

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -318,7 +318,8 @@ static bool Socks5(const std::string& strDest, int port, const ProxyCredentials 
     char pchRet1[2];
     if (!InterruptibleRecv(pchRet1, 2, SOCKS5_RECV_TIMEOUT, hSocket)) {
         CloseSocket(hSocket);
-        return error("Error reading proxy response");
+        LogPrintf("Socks5() connect to %s:%d failed: InterruptibleRecv() timeout or other failure\n", strDest, port);
+        return false;
     }
     if (pchRet1[0] != 0x05) {
         CloseSocket(hSocket);


### PR DESCRIPTION
Make failures to connect via Socks5() more informative and less unnecessarily scary.
- The "ERROR" was printed far too often during normal operation for what was not an error.
- Makes the Socks5() connect failure similar to the IP connect failure in debug.log.

Before:
`2016-05-09 00:15:00 ERROR: Proxy error: host unreachable`

After:
`2016-05-09 00:15:00 Socks5() connect to t6xj6wilh4ytvcs7.onion:18333 failed: host unreachable"`

SOCKS5 connecting and connected messages with -debug=net.

They were too noisy and not necessary for normal operation.
