### PR TITLE
init: Move berkeleydb version reporting to wallet

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -37,9 +37,7 @@
 #include "utilmoneystr.h"
 #include "validationinterface.h"
 #ifdef ENABLE_WALLET
-#include "wallet/db.h"
 #include "wallet/wallet.h"
-#include "wallet/walletdb.h"
 #endif
 #include <stdint.h>
 #include <stdio.h>
@@ -986,9 +984,6 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     if (fPrintToDebugLog)
         OpenDebugLog();
 
-#ifdef ENABLE_WALLET
-    LogPrintf("Using BerkeleyDB version %s\n", DbEnv::version(0, 0, 0));
-#endif
     if (!fLogTimestamps)
         LogPrintf("Startup time: %s\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()));
     LogPrintf("Default data directory %s\n", GetDefaultDataDir().string());

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -368,6 +368,7 @@ void CWallet::Flush(bool shutdown)
 
 bool CWallet::Verify()
 {
+    LogPrintf("Using BerkeleyDB version %s\n", DbEnv::version(0, 0, 0));
     std::string walletFile = GetArg("-wallet", DEFAULT_WALLET_DAT);
 
     LogPrintf("Using wallet %s\n", walletFile);


### PR DESCRIPTION
Move the version reporting to `Wallet::Verify`, before starting verification of the wallet (as this is the earliest point that the wallet is actually going to be accessed).

This removes the dependency of init on a specific wallet database library.

A further, trivial step towards resolving #7965.
