### PR TITLE
bench: Add crypto hash benchmarks

### DIFF
--- a/src/Makefile.bench.include
+++ b/src/Makefile.bench.include
@@ -8,7 +8,8 @@ bench_bench_bitcoin_SOURCES = \
   bench/bench.cpp \
   bench/bench.h \
   bench/Examples.cpp \
-  bench/rollingbloom.cpp
+  bench/rollingbloom.cpp \
+  bench/crypto_hash.cpp
 
 bench_bench_bitcoin_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) $(EVENT_CLFAGS) $(EVENT_PTHREADS_CFLAGS) -I$(builddir)/bench/
 bench_bench_bitcoin_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)

--- a/src/bench/crypto_hash.cpp
+++ b/src/bench/crypto_hash.cpp
@@ -1,0 +1,53 @@
+// Copyright (c) 2016 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <iostream>
+
+#include "bench.h"
+#include "bloom.h"
+#include "utiltime.h"
+#include "crypto/ripemd160.h"
+#include "crypto/sha1.h"
+#include "crypto/sha256.h"
+#include "crypto/sha512.h"
+
+/* Number of bytes to hash per iteration */
+static const uint64_t BUFFER_SIZE = 1000*1000;
+
+static void RIPEMD160(benchmark::State& state)
+{
+    uint8_t hash[CRIPEMD160::OUTPUT_SIZE];
+    std::vector<uint8_t> in(BUFFER_SIZE,0);
+    while (state.KeepRunning())
+        CRIPEMD160().Write(begin_ptr(in), in.size()).Finalize(hash);
+}
+
+static void SHA1(benchmark::State& state)
+{
+    uint8_t hash[CSHA1::OUTPUT_SIZE];
+    std::vector<uint8_t> in(BUFFER_SIZE,0);
+    while (state.KeepRunning())
+        CSHA1().Write(begin_ptr(in), in.size()).Finalize(hash);
+}
+
+static void SHA256(benchmark::State& state)
+{
+    uint8_t hash[CSHA256::OUTPUT_SIZE];
+    std::vector<uint8_t> in(BUFFER_SIZE,0);
+    while (state.KeepRunning())
+        CSHA256().Write(begin_ptr(in), in.size()).Finalize(hash);
+}
+
+static void SHA512(benchmark::State& state)
+{
+    uint8_t hash[CSHA512::OUTPUT_SIZE];
+    std::vector<uint8_t> in(BUFFER_SIZE,0);
+    while (state.KeepRunning())
+        CSHA512().Write(begin_ptr(in), in.size()).Finalize(hash);
+}
+
+BENCHMARK(RIPEMD160);
+BENCHMARK(SHA1);
+BENCHMARK(SHA256);
+BENCHMARK(SHA512);


### PR DESCRIPTION
Add benchmarks for the cryptographic hash algorithms:
- RIPEMD160
- SHA1
- SHA256
- SHA512

Continues work on #7883.
