### PR TITLE
[Qt][OSX] Fix Cmd-Q / Menu Quit shutdown on OSX

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -370,6 +370,7 @@ void BitcoinApplication::createSplashScreen(const NetworkStyle *networkStyle)
     splash->setAttribute(Qt::WA_DeleteOnClose);
     splash->show();
     connect(this, SIGNAL(splashFinished(QWidget*)), splash, SLOT(slotFinish(QWidget*)));
+    connect(this, SIGNAL(requestedShutdown()), splash, SLOT(close()));
 }
 
 void BitcoinApplication::startThread()


### PR DESCRIPTION
Most Users on OSX close applications with Cmd-Q or with "Menu"->"Quit".

There is one inconvenience during startup of Bitcoin-Qt on OSX:
If you quit the application during the splashscreen-phase, it doesn't quit the initial verification. This leads to a problem where the user needs to wait until bitcoin-qt has verified 100% of the last ~288 blocks before the application actually quits.

This PR fixes that and enables the same behavior on OSX then we have on Linux/Windows.
