### PR TITLE
doc: Remove outdated qt4 install information from README.md

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -13,8 +13,8 @@ The following are some helpful notes on how to run Bitcoin on your native platfo
 
 Unpack the files into a directory and run:
 
-- bin/32/bitcoin-qt (GUI, 32-bit) or bin/32/bitcoind (headless, 32-bit)
-- bin/64/bitcoin-qt (GUI, 64-bit) or bin/64/bitcoind (headless, 64-bit)
+- `bin/bitcoin-qt` (GUI) or
+- `bin/bitcoind` (headless)
 
 ### Windows
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -11,16 +11,10 @@ The following are some helpful notes on how to run Bitcoin on your native platfo
 
 ### Unix
 
-You need the Qt4 run-time libraries to run Bitcoin-Qt. On Debian or Ubuntu:
-
-	sudo apt-get install libqtgui4
-
 Unpack the files into a directory and run:
 
 - bin/32/bitcoin-qt (GUI, 32-bit) or bin/32/bitcoind (headless, 32-bit)
 - bin/64/bitcoin-qt (GUI, 64-bit) or bin/64/bitcoind (headless, 64-bit)
-
-
 
 ### Windows
 


### PR DESCRIPTION
This text is aimed at users installing the binaries.

Now that Qt5 is linked statically, there is no need to install Qt as a run-time dependency.

Needs backport to 0.12.x.
