### PR TITLE
Seemingly fix walletbackup.py failure

### DIFF
--- a/qa/rpc-tests/test_framework/authproxy.py
+++ b/qa/rpc-tests/test_framework/authproxy.py
@@ -124,6 +124,11 @@ class AuthServiceProxy(object):
                 return self._get_response()
             else:
                 raise
+        except BrokenPipeError:
+            # Python 3.5+ raises this instead of BadStatusLine when the connection was reset
+            self.__conn.close()
+            self.__conn.request(method, path, postdata, headers)
+            return self._get_response()
 
     def __call__(self, *args):
         AuthServiceProxy.__id_count += 1


### PR DESCRIPTION
Looks like it fixes #8045.

I cannot explain the failure (it happens 100% reproducibly for me, with a clean cache and no other bitcoind running, even when running outside of rpc-tests.py):

```
$ ./walletbackup.py 
INFO: Initializing test directory /tmp/testnfwna8uq
INFO: Generating initial blockchain
INFO: Creating transactions
INFO: Backing up
INFO: More transactions
INFO: Restoring using wallet.dat
INFO: Re-starting nodes
INFO: Restoring using dumped wallet
Unexpected exception caught during testing: BrokenPipeError(32, 'Broken pipe')
  File "/home/pw/git/bitcoin/qa/rpc-tests/test_framework/test_framework.py", line 138, in main
    self.run_test()
  File "./walletbackup.py", line 193, in run_test
    sync_blocks(self.nodes)
  File "/home/pw/git/bitcoin/qa/rpc-tests/test_framework/util.py", line 127, in sync_blocks
    counts = [ x.getblockcount() for x in rpc_connections ]
  File "/home/pw/git/bitcoin/qa/rpc-tests/test_framework/util.py", line 127, in <listcomp>
    counts = [ x.getblockcount() for x in rpc_connections ]
  File "/home/pw/git/bitcoin/qa/rpc-tests/test_framework/coverage.py", line 49, in __call__
    return_val = self.auth_service_proxy_instance.__call__(*args, **kwargs)
  File "/home/pw/git/bitcoin/qa/rpc-tests/test_framework/authproxy.py", line 137, in __call__
    response = self._request('POST', self.__url.path, postdata)
  File "/home/pw/git/bitcoin/qa/rpc-tests/test_framework/authproxy.py", line 118, in _request
    self.__conn.request(method, path, postdata, headers)
  File "/usr/lib/python3.5/http/client.py", line 1106, in request
    self._send_request(method, url, body, headers)
  File "/usr/lib/python3.5/http/client.py", line 1151, in _send_request
    self.endheaders(body)
  File "/usr/lib/python3.5/http/client.py", line 1102, in endheaders
    self._send_output(message_body)
  File "/usr/lib/python3.5/http/client.py", line 936, in _send_output
    self.send(message_body)
  File "/usr/lib/python3.5/http/client.py", line 908, in send
    self.sock.sendall(data)
Stopping nodes
WARN: Unable to stop node: CannotSendRequest('Request-sent',)
```

 I also can't explain why Travis doesn't have this problem. I certainly can't explain why this patch fixes it or even remotely has anything to do with the observed problem, but it fixes it 100% reproducibly.
