### PR TITLE
rpc tests: increase http timeout

### DIFF
--- a/qa/rpc-tests/test_framework/authproxy.py
+++ b/qa/rpc-tests/test_framework/authproxy.py
@@ -49,7 +49,7 @@ except ImportError:
 
 USER_AGENT = "AuthServiceProxy/0.1"
 
-HTTP_TIMEOUT = 30
+HTTP_TIMEOUT = 60
 
 log = logging.getLogger("BitcoinRPC")
 


### PR DESCRIPTION
30s is not enough. An importwallet test case can take up to about 40s my test
machine.

Fixes #8051.
