### PR TITLE
travis: 'make check' in parallel and verbose

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,7 +78,7 @@ script:
     - ./configure --cache-file=../config.cache $BITCOIN_CONFIG_ALL $BITCOIN_CONFIG || ( cat config.log && false)
     - make $MAKEJOBS $GOAL || ( echo "Build failure. Verbose build follows." && make $GOAL V=1 ; false )
     - export LD_LIBRARY_PATH=$TRAVIS_BUILD_DIR/depends/$HOST/lib
-    - if [ "$RUN_TESTS" = "true" ]; then make check; fi
+    - if [ "$RUN_TESTS" = "true" ]; then make $MAKEJOBS check VERBOSE=1; fi
     - if [ "$RUN_TESTS" = "true" ]; then qa/pull-tester/rpc-tests.py --coverage; fi
 after_script:
     - echo $TRAVIS_COMMIT_RANGE


### PR DESCRIPTION
- 'make check' in parallel, since the log will take care of clean output
- 'make check' verbose, so that test failure causes aren't hidden

Fixes: #8071

Edit:

This should print additional info such as:

```
FAIL: test/test_bitcoin
=======================

Running 187 test cases...
test/amount_tests.cpp(18): error in "GetFeeTest": check feeRate.GetFee(0) == 1 failed [0 != 1]
FAIL test/test_bitcoin (exit status: 201)
```
