### PR TITLE
Test framework: only cleanup on successful test runs

### DIFF
--- a/qa/rpc-tests/test_framework/test_framework.py
+++ b/qa/rpc-tests/test_framework/test_framework.py
@@ -165,9 +165,11 @@ class BitcoinTestFramework(object):
         else:
             print("Note: bitcoinds were not stopped and may still be running")
 
-        if not self.options.nocleanup and not self.options.noshutdown:
+        if not self.options.nocleanup and not self.options.noshutdown and success:
             print("Cleaning up")
             shutil.rmtree(self.options.tmpdir)
+        else:
+            print("Not cleaning up dir %s" % self.options.tmpdir)
 
         if success:
             print("Tests successful")


### PR DESCRIPTION
Don't cleanup the datadir's on test failure.

I hope that this should make it easier to debug rare-failing tests, as we'll at least have the debug.log's available to go through.

@MarcoFalke: After this, we could perhaps add to the `rpc-tests.py` script some functionality to tail the last few hundred lines of debug.log for each node if a test fails, so that if a job fails in travis, we'll have more info to look at?
