### PR TITLE
RFC: rpc: Remove dns argument for getaddednodeinfo

### DIFF
--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -269,41 +269,28 @@ UniValue disconnectnode(const UniValue& params, bool fHelp)
 
 UniValue getaddednodeinfo(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() < 1 || params.size() > 2)
+    if (fHelp || params.size() > 1)
         throw runtime_error(
-            "getaddednodeinfo dns ( \"node\" )\n"
-            "\nReturns information about the given added node, or all added nodes\n"
+            "getaddednodeinfo ( \"node\" )\n"
+            "\nReturns presence of the given added node, or all added nodes\n"
             "(note that onetry addnodes are not listed here)\n"
-            "If dns is false, only a list of added nodes will be provided,\n"
-            "otherwise connected information will also be available.\n"
             "\nArguments:\n"
-            "1. dns        (boolean, required) If false, only a list of added nodes will be provided, otherwise connected information will also be available.\n"
-            "2. \"node\"   (string, optional) If provided, return information about this specific node, otherwise all nodes are returned.\n"
+            "2. \"node\"   (string, optional) If provided, return the presence of this specific node, otherwise all nodes are returned.\n"
             "\nResult:\n"
             "[\n"
             "  {\n"
             "    \"addednode\" : \"192.168.0.201\",   (string) The node ip address\n"
-            "    \"connected\" : true|false,          (boolean) If connected\n"
-            "    \"addresses\" : [\n"
-            "       {\n"
-            "         \"address\" : \"192.168.0.201:8333\",  (string) The bitcoin server host and port\n"
-            "         \"connected\" : \"outbound\"           (string) connection, inbound or outbound\n"
-            "       }\n"
-            "       ,...\n"
-            "     ]\n"
             "  }\n"
             "  ,...\n"
             "]\n"
             "\nExamples:\n"
-            + HelpExampleCli("getaddednodeinfo", "true")
-            + HelpExampleCli("getaddednodeinfo", "true \"192.168.0.201\"")
-            + HelpExampleRpc("getaddednodeinfo", "true, \"192.168.0.201\"")
+            + HelpExampleCli("getaddednodeinfo", "")
+            + HelpExampleCli("getaddednodeinfo", "\"192.168.0.201\"")
+            + HelpExampleRpc("getaddednodeinfo", "\"192.168.0.201\"")
         );
 
-    bool fDns = params[0].get_bool();
-
     list<string> laddedNodes(0);
-    if (params.size() == 1)
+    if (params.empty())
     {
         LOCK(cs_vAddedNodes);
         BOOST_FOREACH(const std::string& strAddNode, vAddedNodes)
@@ -311,7 +298,7 @@ UniValue getaddednodeinfo(const UniValue& params, bool fHelp)
     }
     else
     {
-        string strNode = params[1].get_str();
+        string strNode = params[0].get_str();
         LOCK(cs_vAddedNodes);
         BOOST_FOREACH(const std::string& strAddNode, vAddedNodes) {
             if (strAddNode == strNode)
@@ -325,62 +312,11 @@ UniValue getaddednodeinfo(const UniValue& params, bool fHelp)
     }
 
     UniValue ret(UniValue::VARR);
-    if (!fDns)
-    {
-        BOOST_FOREACH (const std::string& strAddNode, laddedNodes) {
-            UniValue obj(UniValue::VOBJ);
-            obj.push_back(Pair("addednode", strAddNode));
-            ret.push_back(obj);
-        }
-        return ret;
-    }
-
-    list<pair<string, vector<CService> > > laddedAddreses(0);
-    BOOST_FOREACH(const std::string& strAddNode, laddedNodes) {
-        vector<CService> vservNode(0);
-        if(Lookup(strAddNode.c_str(), vservNode, Params().GetDefaultPort(), fNameLookup, 0))
-            laddedAddreses.push_back(make_pair(strAddNode, vservNode));
-        else
-        {
-            UniValue obj(UniValue::VOBJ);
-            obj.push_back(Pair("addednode", strAddNode));
-            obj.push_back(Pair("connected", false));
-            UniValue addresses(UniValue::VARR);
-            obj.push_back(Pair("addresses", addresses));
-            ret.push_back(obj);
-        }
-    }
-
-    LOCK(cs_vNodes);
-    for (list<pair<string, vector<CService> > >::iterator it = laddedAddreses.begin(); it != laddedAddreses.end(); it++)
-    {
+    BOOST_FOREACH (const std::string& strAddNode, laddedNodes) {
         UniValue obj(UniValue::VOBJ);
-        obj.push_back(Pair("addednode", it->first));
-
-        UniValue addresses(UniValue::VARR);
-        bool fConnected = false;
-        BOOST_FOREACH(const CService& addrNode, it->second) {
-            bool fFound = false;
-            UniValue node(UniValue::VOBJ);
-            node.push_back(Pair("address", addrNode.ToString()));
-            BOOST_FOREACH(CNode* pnode, vNodes) {
-                if (pnode->addr == addrNode)
-                {
-                    fFound = true;
-                    fConnected = true;
-                    node.push_back(Pair("connected", pnode->fInbound ? "inbound" : "outbound"));
-                    break;
-                }
-            }
-            if (!fFound)
-                node.push_back(Pair("connected", "false"));
-            addresses.push_back(node);
-        }
-        obj.push_back(Pair("connected", fConnected));
-        obj.push_back(Pair("addresses", addresses));
+        obj.push_back(Pair("addednode", strAddNode));
         ret.push_back(obj);
     }
-
     return ret;
 }
 


### PR DESCRIPTION
As discussed with @laanwj and @sdaftuar in Zurich. The output format is kept the same as before, though the input params change.

As far as I can tell, this has no test coverage, and I'm willing to bet it gets very little usage. The behavior is subtle and non-obvious: it does a real-time resolve in order to check whether an addnode entry is connected at the time of that resolve, and makes no mention of whether or not a connection once matched a resolved addnode.

This complicates the net encapsulation work, so I propose that we simply drop it unless there's a good reason not to. If preferred, it could swallow a dummy bool parameter, in order to remain api compatible.
