### PR TITLE
Disable mining on nonrelease branches.

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -129,6 +129,7 @@ public:
         fRequireStandard = true;
         fMineBlocksOnDemand = false;
         fTestnetToBeDeprecatedFieldRPC = false;
+        fDisableMiningOnNonreleaseBranches = true;
 
         checkpointData = (CCheckpointData) {
             boost::assign::map_list_of
@@ -214,6 +215,7 @@ public:
         fRequireStandard = false;
         fMineBlocksOnDemand = false;
         fTestnetToBeDeprecatedFieldRPC = true;
+        fDisableMiningOnNonreleaseBranches = false;
 
         checkpointData = (CCheckpointData) {
             boost::assign::map_list_of
@@ -274,6 +276,7 @@ public:
         fRequireStandard = false;
         fMineBlocksOnDemand = true;
         fTestnetToBeDeprecatedFieldRPC = false;
+        fDisableMiningOnNonreleaseBranches = false;
 
         checkpointData = (CCheckpointData){
             boost::assign::map_list_of

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -68,6 +68,8 @@ public:
     bool MineBlocksOnDemand() const { return fMineBlocksOnDemand; }
     /** In the future use NetworkIDString() for RPC fields */
     bool TestnetToBeDeprecatedFieldRPC() const { return fTestnetToBeDeprecatedFieldRPC; }
+    /** Disable mining on nonrelease branches by default */
+    bool DisableMiningOnNonreleaseBranches() const { return fDisableMiningOnNonreleaseBranches; }
     /** Return the BIP70 network string (main, test or regtest) */
     std::string NetworkIDString() const { return strNetworkID; }
     const std::vector<CDNSSeedData>& DNSSeeds() const { return vSeeds; }
@@ -91,6 +93,7 @@ protected:
     bool fRequireStandard;
     bool fMineBlocksOnDemand;
     bool fTestnetToBeDeprecatedFieldRPC;
+    bool fDisableMiningOnNonreleaseBranches;
     CCheckpointData checkpointData;
 };
 

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -160,6 +160,10 @@ UniValue generate(const UniValue& params, bool fHelp)
             + HelpExampleCli("generate", "11")
         );
 
+    const CChainParams& chainParams = Params();
+    if (!CLIENT_VERSION_IS_RELEASE && chainParams.DisableMiningOnNonreleaseBranches())
+        throw JSONRPCError(RPC_MINING_DISABLED, "Mining disabled");
+
     int nGenerate = params[0].get_int();
     uint64_t nMaxTries = 1000000;
     if (params.size() > 1) {
@@ -364,6 +368,10 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
             + HelpExampleCli("getblocktemplate", "")
             + HelpExampleRpc("getblocktemplate", "")
          );
+
+    const CChainParams& chainParams = Params();
+    if (!CLIENT_VERSION_IS_RELEASE && chainParams.DisableMiningOnNonreleaseBranches())
+        throw JSONRPCError(RPC_MINING_DISABLED, "Mining disabled");
 
     LOCK(cs_main);
 

--- a/src/rpc/protocol.h
+++ b/src/rpc/protocol.h
@@ -74,6 +74,9 @@ enum RPCErrorCode
     RPC_WALLET_WRONG_ENC_STATE      = -15, //! Command given in wrong wallet encryption state (encrypting an encrypted wallet etc.)
     RPC_WALLET_ENCRYPTION_FAILED    = -16, //! Failed to encrypt the wallet
     RPC_WALLET_ALREADY_UNLOCKED     = -17, //! Wallet is already unlocked
+
+    //! Mining errors
+    RPC_MINING_DISABLED             = -31, //! Mining is disabled
 };
 
 std::string JSONRPCRequest(const std::string& strMethod, const UniValue& params, const UniValue& id);


### PR DESCRIPTION
In order to make it safer to merge consensus changes, we should disable mining via RPC on nonrelease branches.
