### PR TITLE
Bugfix: use global ::fRelayTxes instead of CNode in version send

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -471,7 +471,7 @@ void CNode::PushVersion()
     else
         LogPrint("net", "send version message: version %d, blocks=%d, us=%s, peer=%d\n", PROTOCOL_VERSION, nBestHeight, addrMe.ToString(), id);
     PushMessage(NetMsgType::VERSION, PROTOCOL_VERSION, nLocalServices, nTime, addrYou, addrMe,
-                nLocalHostNonce, strSubVersion, nBestHeight, fRelayTxes);
+                nLocalHostNonce, strSubVersion, nBestHeight, ::fRelayTxes);
 }
 
 


### PR DESCRIPTION
#8049 changed the calls to GetBoolArg("-blocksonly") to a global boolean `fRelayTxes`. Inside `CNode::PushVersion`, `fRelayTxes` refers to the CNode instance variable with the same name, however, causing the connecting node to always send false here, and never receive any transactions.

I've attempted to add a unit test for this, but we don't seem to ever test receiving relayed transactions by a connecting node only...
