### PR TITLE
Include signal.h for sig_atomic_t in WIN32

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -28,9 +28,7 @@
 #include <boost/signals2/signal.hpp>
 #include <boost/thread/exceptions.hpp>
 
-#ifndef WIN32
 #include <signal.h>
-#endif
 
 static const bool DEFAULT_LOGTIMEMICROS = false;
 static const bool DEFAULT_LOGIPS        = false;


### PR DESCRIPTION
We need to include signal.h in WIN32 to get a definition for sig_atomic_t since #8004.

Perhaps this is only necessary on MinGW, and not on native Windows, but I don't know how to test for that.
