### PR TITLE
Reduce unnecessary hashing in signrawtransaction

### DIFF
--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -743,6 +743,9 @@ UniValue signrawtransaction(const UniValue& params, bool fHelp)
     // Script verification errors
     UniValue vErrors(UniValue::VARR);
 
+    // Use CTransaction for the constant parts of the
+    // transaction to avoid rehashing.
+    const CTransaction txConst(mergedTx);
     // Sign what we can:
     for (unsigned int i = 0; i < mergedTx.vin.size(); i++) {
         CTxIn& txin = mergedTx.vin[i];
@@ -760,10 +763,10 @@ UniValue signrawtransaction(const UniValue& params, bool fHelp)
 
         // ... and merge in other signatures:
         BOOST_FOREACH(const CMutableTransaction& txv, txVariants) {
-            txin.scriptSig = CombineSignatures(prevPubKey, mergedTx, i, txin.scriptSig, txv.vin[i].scriptSig);
+            txin.scriptSig = CombineSignatures(prevPubKey, txConst, i, txin.scriptSig, txv.vin[i].scriptSig);
         }
         ScriptError serror = SCRIPT_ERR_OK;
-        if (!VerifyScript(txin.scriptSig, prevPubKey, STANDARD_SCRIPT_VERIFY_FLAGS, MutableTransactionSignatureChecker(&mergedTx, i), &serror)) {
+        if (!VerifyScript(txin.scriptSig, prevPubKey, STANDARD_SCRIPT_VERIFY_FLAGS, TransactionSignatureChecker(&txConst, i), &serror)) {
             TxInErrorToJSON(txin, vErrors, ScriptErrorString(serror));
         }
     }


### PR DESCRIPTION
When calling `CombineSignatures` and `VerifyScript` inside signrawtransaction with a `CMutableTransaction`, the tx is converted into a `CTransaction` which requires hashing.
Because both `CombineSignatures` and `VerifyScript` accept the `scriptSig` created by `SignSignature` separately from the transaction we can instead convert the mutable tx to `CTransaction` once and use that one.

Results:
1000 inputs, 75kB before signing: 2.86s vs. 4.88s
Signature concatenation of three 250kB transactions with 1000 inputs: 8.638s vs. 19.142s

There still remains some unnecessary hashing, but fixing this requires a larger refactor: `SignSignature` requires a `CMutableTransaction` because it changes the scriptSig in place. But it also immediately creates a `CTransaction` (costly) for a `TransactionSignatureChecker`. Using a `MutableTransactionSignatureChecker` is not an option because it immediately converts the mutable transaction to a `CTransaction`. Instead, the `TransactionSignatureChecker` should be able to deal with `CMutableTransaction` without rehashing.
