### PR TITLE
Fix RPC console auto completer

### DIFF
--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -327,6 +327,14 @@ bool RPCConsole::eventFilter(QObject* obj, QEvent *event)
                 return true;
             }
             break;
+        case Qt::Key_Return:
+        case Qt::Key_Enter:
+            // forward these events to lineEdit
+            if(obj == autoCompleter->popup()) {
+                QApplication::postEvent(ui->lineEdit, new QKeyEvent(*keyevt));
+                return true;
+            }
+            break;
         default:
             // Typing in messages widget brings focus to line edit, and redirects key there
             // Exclude most combinations and keys that emit no text, except paste shortcuts
@@ -458,9 +466,7 @@ void RPCConsole::setClientModel(ClientModel *model)
 
         autoCompleter = new QCompleter(wordList, this);
         ui->lineEdit->setCompleter(autoCompleter);
-
-	// clear the lineEdit after activating from QCompleter
-	connect(autoCompleter, SIGNAL(activated(const QString&)), ui->lineEdit, SLOT(clear()), Qt::QueuedConnection);
+        autoCompleter->popup()->installEventFilter(this);
     }
 }
 


### PR DESCRIPTION
PR #7772 is not enough to fix the issue with QCompleter.

Steps to reproduce the issue in current build: open Debug window, go to Console, close it, open it again, start writing some rpc command and try to pick it from the list using arrow keys, hit Enter. Note that edit field is not being cleared as it should be, works on second try only (i.e. same as before).

Using event filter to forward messages from `autoCompleter` popup to `lineEdit` instead of using `connect` method solves the issue.
