### PR TITLE
[Bitcoin-Tx] fix missing test fixtures, fix 32bit atoi issue

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -17,7 +17,9 @@ EXTRA_DIST += \
 	test/data/txcreate2.hex \
 	test/data/txcreatedata1.hex \
 	test/data/txcreatedata2.hex \
-	test/data/txcreatesign.hex
+	test/data/txcreatesign.hex \
+	test/data/txcreatedata_seq0.hex \
+	test/data/txcreatedata_seq1.hex
 
 JSON_TEST_FILES = \
   test/data/script_tests.json \

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -206,7 +206,7 @@ static void MutateTxAddInput(CMutableTransaction& tx, const string& strInput)
     // extract the optional sequence number
     uint32_t nSequenceIn=std::numeric_limits<unsigned int>::max();
     if (vStrInputParts.size() > 2)
-        nSequenceIn = atoi(vStrInputParts[2]);
+        nSequenceIn = std::stoul(vStrInputParts[2]);
 
     // append to transaction input list
     CTxIn txin(txid, vout, CScript(), nSequenceIn);


### PR DESCRIPTION
Travis is currently failing because of missing test fixtures from https://github.com/bitcoin/bitcoin/pull/7957.

This PR adds the two missing fixture files to the `Makefile.test.include`.
