### PR TITLE
src/test: Do not shadow local variables

### DIFF
--- a/src/test/base58_tests.cpp
+++ b/src/test/base58_tests.cpp
@@ -79,7 +79,7 @@ class TestAddrTypeVisitor : public boost::static_visitor<bool>
 private:
     std::string exp_addrType;
 public:
-    TestAddrTypeVisitor(const std::string &exp_addrType) : exp_addrType(exp_addrType) { }
+    TestAddrTypeVisitor(const std::string &_exp_addrType) : exp_addrType(_exp_addrType) { }
     bool operator()(const CKeyID &id) const
     {
         return (exp_addrType == "pubkey");
@@ -100,7 +100,7 @@ class TestPayloadVisitor : public boost::static_visitor<bool>
 private:
     std::vector<unsigned char> exp_payload;
 public:
-    TestPayloadVisitor(std::vector<unsigned char> &exp_payload) : exp_payload(exp_payload) { }
+    TestPayloadVisitor(std::vector<unsigned char> &_exp_payload) : exp_payload(_exp_payload) { }
     bool operator()(const CKeyID &id) const
     {
         uint160 exp_key(exp_payload);

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -385,8 +385,8 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     SetMockTime(0);
     mempool.clear();
 
-    BOOST_FOREACH(CTransaction *tx, txFirst)
-        delete tx;
+    BOOST_FOREACH(CTransaction *_tx, txFirst)
+        delete _tx;
 
     fCheckpointsEnabled = true;
 }

--- a/src/test/pmt_tests.cpp
+++ b/src/test/pmt_tests.cpp
@@ -37,8 +37,8 @@ BOOST_AUTO_TEST_CASE(pmt_test1)
     seed_insecure_rand(false);
     static const unsigned int nTxCounts[] = {1, 4, 7, 17, 56, 100, 127, 256, 312, 513, 1000, 4095};
 
-    for (int n = 0; n < 12; n++) {
-        unsigned int nTx = nTxCounts[n];
+    for (int i = 0; i < 12; i++) {
+        unsigned int nTx = nTxCounts[i];
 
         // build a block with some dummy transactions
         CBlock block;

--- a/src/test/prevector_tests.cpp
+++ b/src/test/prevector_tests.cpp
@@ -192,8 +192,8 @@ BOOST_AUTO_TEST_CASE(PrevectorTestInt)
             if (((r >> 21) % 32) == 7) {
                 int values[4];
                 int num = 1 + (insecure_rand() % 4);
-                for (int i = 0; i < num; i++) {
-                    values[i] = insecure_rand();
+                for (int k = 0; k < num; k++) {
+                    values[k] = insecure_rand();
                 }
                 test.insert_range(insecure_rand() % (test.size() + 1), values, values + num);
             }


### PR DESCRIPTION
Continues #8105, makes `src/test` shadowing clean.
