### PR TITLE
util: Add ParseUInt32 and ParseUInt64

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -323,7 +323,7 @@ Strings and formatting
     buffer overflows and surprises with `\0` characters. Also some C string manipulations
     tend to act differently depending on platform, or even the user locale
 
-- Use `ParseInt32`, `ParseInt64`, `ParseDouble` from `utilstrencodings.h` for number parsing
+- Use `ParseInt32`, `ParseInt64`, `ParseUInt32`, `ParseUInt64`, `ParseDouble` from `utilstrencodings.h` for number parsing
 
   - *Rationale*: These functions do overflow checking, and avoid pesky locale issues
 

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -376,6 +376,69 @@ BOOST_AUTO_TEST_CASE(test_ParseInt64)
     BOOST_CHECK(!ParseInt64("32482348723847471234", NULL));
 }
 
+BOOST_AUTO_TEST_CASE(test_ParseUInt32)
+{
+    uint32_t n;
+    // Valid values
+    BOOST_CHECK(ParseUInt32("1234", NULL));
+    BOOST_CHECK(ParseUInt32("0", &n) && n == 0);
+    BOOST_CHECK(ParseUInt32("1234", &n) && n == 1234);
+    BOOST_CHECK(ParseUInt32("01234", &n) && n == 1234); // no octal
+    BOOST_CHECK(ParseUInt32("2147483647", &n) && n == 2147483647);
+    BOOST_CHECK(ParseUInt32("2147483648", &n) && n == (uint32_t)2147483648);
+    BOOST_CHECK(ParseUInt32("4294967295", &n) && n == (uint32_t)4294967295);
+    // Invalid values
+    BOOST_CHECK(!ParseUInt32("", &n));
+    BOOST_CHECK(!ParseUInt32(" 1", &n)); // no padding inside
+    BOOST_CHECK(!ParseUInt32(" -1", &n));
+    BOOST_CHECK(!ParseUInt32("1 ", &n));
+    BOOST_CHECK(!ParseUInt32("1a", &n));
+    BOOST_CHECK(!ParseUInt32("aap", &n));
+    BOOST_CHECK(!ParseUInt32("0x1", &n)); // no hex
+    BOOST_CHECK(!ParseUInt32("0x1", &n)); // no hex
+    const char test_bytes[] = {'1', 0, '1'};
+    std::string teststr(test_bytes, sizeof(test_bytes));
+    BOOST_CHECK(!ParseUInt32(teststr, &n)); // no embedded NULs
+    // Overflow and underflow
+    BOOST_CHECK(!ParseUInt32("-2147483648", &n));
+    BOOST_CHECK(!ParseUInt32("4294967296", &n));
+    BOOST_CHECK(!ParseUInt32("-1234", &n));
+    BOOST_CHECK(!ParseUInt32("-32482348723847471234", NULL));
+    BOOST_CHECK(!ParseUInt32("32482348723847471234", NULL));
+}
+
+BOOST_AUTO_TEST_CASE(test_ParseUInt64)
+{
+    uint64_t n;
+    // Valid values
+    BOOST_CHECK(ParseUInt64("1234", NULL));
+    BOOST_CHECK(ParseUInt64("0", &n) && n == 0LL);
+    BOOST_CHECK(ParseUInt64("1234", &n) && n == 1234LL);
+    BOOST_CHECK(ParseUInt64("01234", &n) && n == 1234LL); // no octal
+    BOOST_CHECK(ParseUInt64("2147483647", &n) && n == 2147483647LL);
+    BOOST_CHECK(ParseUInt64("9223372036854775807", &n) && n == 9223372036854775807ULL);
+    BOOST_CHECK(ParseUInt64("9223372036854775808", &n) && n == 9223372036854775808ULL);
+    BOOST_CHECK(ParseUInt64("18446744073709551615", &n) && n == 18446744073709551615ULL);
+    // Invalid values
+    BOOST_CHECK(!ParseUInt64("", &n));
+    BOOST_CHECK(!ParseUInt64(" 1", &n)); // no padding inside
+    BOOST_CHECK(!ParseUInt64(" -1", &n));
+    BOOST_CHECK(!ParseUInt64("1 ", &n));
+    BOOST_CHECK(!ParseUInt64("1a", &n));
+    BOOST_CHECK(!ParseUInt64("aap", &n));
+    BOOST_CHECK(!ParseUInt64("0x1", &n)); // no hex
+    const char test_bytes[] = {'1', 0, '1'};
+    std::string teststr(test_bytes, sizeof(test_bytes));
+    BOOST_CHECK(!ParseUInt64(teststr, &n)); // no embedded NULs
+    // Overflow and underflow
+    BOOST_CHECK(!ParseUInt64("-9223372036854775809", NULL));
+    BOOST_CHECK(!ParseUInt64("18446744073709551616", NULL));
+    BOOST_CHECK(!ParseUInt64("-32482348723847471234", NULL));
+    BOOST_CHECK(!ParseUInt64("-2147483648", &n));
+    BOOST_CHECK(!ParseUInt64("-9223372036854775808", &n));
+    BOOST_CHECK(!ParseUInt64("-1234", &n));
+}
+
 BOOST_AUTO_TEST_CASE(test_ParseDouble)
 {
     double n;

--- a/src/utilstrencodings.cpp
+++ b/src/utilstrencodings.cpp
@@ -461,6 +461,40 @@ bool ParseInt64(const std::string& str, int64_t *out)
         n <= std::numeric_limits<int64_t>::max();
 }
 
+bool ParseUInt32(const std::string& str, uint32_t *out)
+{
+    if (!ParsePrechecks(str))
+        return false;
+    if (str.size() >= 1 && str[0] == '-') // Reject negative values, unfortunately strtoul accepts these by default if they fit in the range
+        return false;
+    char *endp = NULL;
+    errno = 0; // strtoul will not set errno if valid
+    unsigned long int n = strtoul(str.c_str(), &endp, 10);
+    if(out) *out = (uint32_t)n;
+    // Note that strtoul returns a *unsigned long int*, so even if it doesn't report a over/underflow
+    // we still have to check that the returned value is within the range of an *uint32_t*. On 64-bit
+    // platforms the size of these types may be different.
+    return endp && *endp == 0 && !errno &&
+        n <= std::numeric_limits<uint32_t>::max();
+}
+
+bool ParseUInt64(const std::string& str, uint64_t *out)
+{
+    if (!ParsePrechecks(str))
+        return false;
+    if (str.size() >= 1 && str[0] == '-') // Reject negative values, unfortunately strtoull accepts these by default if they fit in the range
+        return false;
+    char *endp = NULL;
+    errno = 0; // strtoull will not set errno if valid
+    unsigned long long int n = strtoull(str.c_str(), &endp, 10);
+    if(out) *out = (uint64_t)n;
+    // Note that strtoull returns a *unsigned long long int*, so even if it doesn't report a over/underflow
+    // we still have to check that the returned value is within the range of an *uint64_t*.
+    return endp && *endp == 0 && !errno &&
+        n <= std::numeric_limits<uint64_t>::max();
+}
+
+
 bool ParseDouble(const std::string& str, double *out)
 {
     if (!ParsePrechecks(str))

--- a/src/utilstrencodings.h
+++ b/src/utilstrencodings.h
@@ -71,6 +71,20 @@ bool ParseInt32(const std::string& str, int32_t *out);
 bool ParseInt64(const std::string& str, int64_t *out);
 
 /**
+ * Convert decimal string to unsigned 32-bit integer with strict parse error feedback.
+ * @returns true if the entire string could be parsed as valid integer,
+ *   false if not the entire string could be parsed or when overflow or underflow occurred.
+ */
+bool ParseUInt32(const std::string& str, uint32_t *out);
+
+/**
+ * Convert decimal string to unsigned 64-bit integer with strict parse error feedback.
+ * @returns true if the entire string could be parsed as valid integer,
+ *   false if not the entire string could be parsed or when overflow or underflow occurred.
+ */
+bool ParseUInt64(const std::string& str, uint64_t *out);
+
+/**
  * Convert string to double with strict parse error feedback.
  * @returns true if the entire string could be parsed as valid double,
  *   false if not the entire string could be parsed or when overflow or underflow occurred.


### PR DESCRIPTION
Add error and range-checking parsers for unsigned 32 and 64 bit numbers.
The 32-bit variant is required for parsing sequence numbers from the command line in `bitcoin-tx` (see #8164 for discussion). I've thrown in the 64-bit variant as a bonus, as I'm sure it will be needed at some
point.

Also adds tests, and updates `developer-notes.md`.
