### PR TITLE
Remove lookup-tx-by-utxo functionality

### DIFF
--- a/doc/REST-interface.md
+++ b/doc/REST-interface.md
@@ -11,7 +11,7 @@ Supported API
 
 Given a transaction hash: returns a transaction in binary, hex-encoded binary, or JSON formats.
 
-For full TX query capability, one must enable the transaction index via "txindex=1" command line / configuration option.
+This works only on unconfirmed transaction unless the transaction index is enabled via "txindex=1" command line / configuration option.
 
 ####Blocks
 `GET /rest/block/<BLOCK-HASH>.<bin|hex|json>`

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1440,7 +1440,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
 }
 
 /** Return transaction in tx, and if it was found inside a block, its hash is placed in hashBlock */
-bool GetTransaction(const uint256 &hash, CTransaction &txOut, const Consensus::Params& consensusParams, uint256 &hashBlock, bool fAllowSlow)
+bool GetTransaction(const uint256 &hash, CTransaction &txOut, const Consensus::Params& consensusParams, uint256 &hashBlock)
 {
     CBlockIndex *pindexSlow = NULL;
 
@@ -1471,31 +1471,6 @@ bool GetTransaction(const uint256 &hash, CTransaction &txOut, const Consensus::P
             if (txOut.GetHash() != hash)
                 return error("%s: txid mismatch", __func__);
             return true;
-        }
-    }
-
-    if (fAllowSlow) { // use coin database to locate block that contains transaction, and scan it
-        int nHeight = -1;
-        {
-            const CCoinsViewCache& view = *pcoinsTip;
-            const CCoins* coins = view.AccessCoins(hash);
-            if (coins)
-                nHeight = coins->nHeight;
-        }
-        if (nHeight > 0)
-            pindexSlow = chainActive[nHeight];
-    }
-
-    if (pindexSlow) {
-        CBlock block;
-        if (ReadBlockFromDisk(block, pindexSlow, consensusParams)) {
-            BOOST_FOREACH(const CTransaction &tx, block.vtx) {
-                if (tx.GetHash() == hash) {
-                    txOut = tx;
-                    hashBlock = pindexSlow->GetBlockHash();
-                    return true;
-                }
-            }
         }
     }
 

--- a/src/main.h
+++ b/src/main.h
@@ -254,8 +254,8 @@ bool IsInitialBlockDownload();
  * This function only returns the highest priority warning of the set selected by strFor.
  */
 std::string GetWarnings(const std::string& strFor);
-/** Retrieve a transaction (from memory pool, or from disk, if possible) */
-bool GetTransaction(const uint256 &hash, CTransaction &tx, const Consensus::Params& params, uint256 &hashBlock, bool fAllowSlow = false);
+/** Retrieve a transaction (from memory pool, or from txindex) */
+bool GetTransaction(const uint256 &hash, CTransaction &tx, const Consensus::Params& params, uint256 &hashBlock);
 /** Find the best known block, and make it the tip of the block chain */
 bool ActivateBestChain(CValidationState& state, const CChainParams& chainparams, const CBlock* pblock = NULL);
 CAmount GetBlockSubsidy(int nHeight, const Consensus::Params& consensusParams);

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -364,7 +364,7 @@ static bool rest_tx(HTTPRequest* req, const std::string& strURIPart)
 
     CTransaction tx;
     uint256 hashBlock = uint256();
-    if (!GetTransaction(hash, tx, Params().GetConsensus(), hashBlock, true))
+    if (!GetTransaction(hash, tx, Params().GetConsensus(), hashBlock))
         return RESTERR(req, HTTP_NOT_FOUND, hashStr + " not found");
 
     CDataStream ssTx(SER_NETWORK, PROTOCOL_VERSION);

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -188,8 +188,8 @@ UniValue getrawtransaction(const UniValue& params, bool fHelp)
 
     CTransaction tx;
     uint256 hashBlock;
-    if (!GetTransaction(hash, tx, Params().GetConsensus(), hashBlock, true))
-        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "No information available about transaction");
+    if (!GetTransaction(hash, tx, Params().GetConsensus(), hashBlock))
+        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "No information available about transaction. Use `gettransaction` for wallet transactions, or enable -txindex to use getrawtransaction on confirmed transactions.");
 
     string strHex = EncodeHexTx(tx);
 
@@ -258,7 +258,7 @@ UniValue gettxoutproof(const UniValue& params, bool fHelp)
     if (pblockindex == NULL)
     {
         CTransaction tx;
-        if (!GetTransaction(oneTxid, tx, Params().GetConsensus(), hashBlock, false) || hashBlock.IsNull())
+        if (!GetTransaction(oneTxid, tx, Params().GetConsensus(), hashBlock) || hashBlock.IsNull())
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Transaction not yet in block");
         if (!mapBlockIndex.count(hashBlock))
             throw JSONRPCError(RPC_INTERNAL_ERROR, "Transaction index corrupt");


### PR DESCRIPTION
There are 3 ways through which main.cpp (and by extension, the `getrawtransaction` and REST tx lookup) find transactions:
- In the mempool (works always)
- In the block index (works only when -txindex is enabled).
- In the UTXO set (inefficient, and only for confirmed transactions that have some of their outputs not yet spent by other confirmed transactions)

This third option is confusing because the conditions under which it works are complicated, and can make it seem like it always works even without -txindex. Remove it. If you need to call `getrawtransaction` for confirmed transactions, you almost certainly need -txindex.

This only impacts the `getrawtransaction` and REST tx calls, so document those.
