### PR TITLE
[RPC] Fix createrawtx sequence number unsigned int parsing

### DIFF
--- a/qa/rpc-tests/rawtransactions.py
+++ b/qa/rpc-tests/rawtransactions.py
@@ -143,6 +143,20 @@ class RawTransactionsTest(BitcoinTestFramework):
         rawtx   = self.nodes[0].createrawtransaction(inputs, outputs)
         decrawtx= self.nodes[0].decoderawtransaction(rawtx)
         assert_equal(decrawtx['vin'][0]['sequence'], 1000)
+        
+        inputs  = [ {'txid' : "1d1d4e24ed99057e84c3f80fd8fbec79ed9e1acee37da269356ecea000000000", 'vout' : 1, 'sequence' : -1}]
+        outputs = { self.nodes[0].getnewaddress() : 1 }
+        assert_raises(JSONRPCException, self.nodes[0].createrawtransaction, inputs, outputs)
+        
+        inputs  = [ {'txid' : "1d1d4e24ed99057e84c3f80fd8fbec79ed9e1acee37da269356ecea000000000", 'vout' : 1, 'sequence' : 4294967296}]
+        outputs = { self.nodes[0].getnewaddress() : 1 }
+        assert_raises(JSONRPCException, self.nodes[0].createrawtransaction, inputs, outputs)
+        
+        inputs  = [ {'txid' : "1d1d4e24ed99057e84c3f80fd8fbec79ed9e1acee37da269356ecea000000000", 'vout' : 1, 'sequence' : 4294967294}]
+        outputs = { self.nodes[0].getnewaddress() : 1 }
+        rawtx   = self.nodes[0].createrawtransaction(inputs, outputs)
+        decrawtx= self.nodes[0].decoderawtransaction(rawtx)
+        assert_equal(decrawtx['vin'][0]['sequence'], 4294967294)
 
 if __name__ == '__main__':
     RawTransactionsTest().main()

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -388,8 +388,13 @@ UniValue createrawtransaction(const UniValue& params, bool fHelp)
 
         // set the sequence number if passed in the parameters object
         const UniValue& sequenceObj = find_value(o, "sequence");
-        if (sequenceObj.isNum())
-            nSequence = sequenceObj.get_int();
+        if (sequenceObj.isNum()) {
+            int64_t seqNr64 = sequenceObj.get_int64();
+            if (seqNr64 < 0 || seqNr64 > std::numeric_limits<uint32_t>::max())
+                throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, sequence number is out of range");
+            else
+                nSequence = (uint32_t)seqNr64;
+        }
 
         CTxIn in(COutPoint(txid, nOutput), CScript(), nSequence);
 


### PR DESCRIPTION
Another cleanup PR for https://github.com/bitcoin/bitcoin/pull/7957.
The sequence number input over RPC was parsed with ParseInt32 and inputs > 0x7FFFFFFF where rejected.

This PR reads inputs with get_int64 and does a range check (>=0 <= 0xFFFFFFFF).
