### PR TITLE
[Qt] Add simple opt-in-RBF support

### DIFF
--- a/src/qt/forms/sendcoinsdialog.ui
+++ b/src/qt/forms/sendcoinsdialog.ui
@@ -1259,7 +1259,7 @@
      <item>
       <widget class="QCheckBox" name="optInRBF">
        <property name="text">
-        <string>Allow Replace-By-Fee</string>
+        <string>Signal Replaceability</string>
        </property>
        <property name="toolTip">
         <string>Signals that this transaction can be replaced with a transation paying higher fees (as long as the transaction is NOT confirmed).</string>

--- a/src/qt/forms/sendcoinsdialog.ui
+++ b/src/qt/forms/sendcoinsdialog.ui
@@ -1257,6 +1257,16 @@
       </widget>
      </item>
      <item>
+      <widget class="QCheckBox" name="optInRBF">
+       <property name="text">
+        <string>Allow Replace-By-Fee</string>
+       </property>
+       <property name="toolTip">
+        <string>Signals that this transaction can be replaced with a transation paying higher fees (as long as the transaction is NOT confirmed).</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <spacer name="horizontalSpacer">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -233,9 +233,9 @@ void SendCoinsDialog::on_sendButton_clicked()
     WalletModelTransaction currentTransaction(recipients);
     WalletModel::SendCoinsReturn prepareStatus;
     if (model->getOptionsModel()->getCoinControlFeatures()) // coin control enabled
-        prepareStatus = model->prepareTransaction(currentTransaction, CoinControlDialog::coinControl);
+        prepareStatus = model->prepareTransaction(currentTransaction, CoinControlDialog::coinControl, ui->optInRBF->isChecked());
     else
-        prepareStatus = model->prepareTransaction(currentTransaction);
+        prepareStatus = model->prepareTransaction(currentTransaction, NULL, ui->optInRBF->isChecked());
 
     // process prepareStatus and on error generate message shown to user
     processSendCoinsReturn(prepareStatus,
@@ -313,6 +313,13 @@ void SendCoinsDialog::on_sendButton_clicked()
         .arg(BitcoinUnits::formatHtmlWithUnit(model->getOptionsModel()->getDisplayUnit(), totalAmount)));
     questionString.append(QString("<span style='font-size:10pt;font-weight:normal;'><br />(=%2)</span>")
         .arg(alternativeUnits.join(" " + tr("or") + "<br />")));
+
+    if (ui->optInRBF->isChecked())
+    {
+        questionString.append("<hr /><span style='color:#aa0000;'>");
+        questionString.append(tr("This transaction is replacable (optin-RBF)!"));
+        questionString.append("</span>");
+    }
 
     SendConfirmationDialog confirmationDialog(tr("Confirm send coins"),
         questionString.arg(formatted.join("<br />")), SEND_CONFIRM_DELAY, this);

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -316,9 +316,8 @@ void SendCoinsDialog::on_sendButton_clicked()
 
     if (ui->optInRBF->isChecked())
     {
-        questionString.append("<hr /><span style='color:#aa0000;'>");
-        questionString.append(tr("This transaction is replacable (optin-RBF)!"));
-        questionString.append("</span>");
+        questionString.append("<hr />");
+        questionString.append(tr("This transaction signals replaceability"));
     }
 
     SendConfirmationDialog confirmationDialog(tr("Confirm send coins"),

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -239,6 +239,8 @@ void TransactionRecord::updateStatus(const CWalletTx &wtx)
         else if (status.depth == 0)
         {
             status.status = TransactionStatus::Unconfirmed;
+            if (!wtx.InMempool() && wtx.GetConflicts().size())
+                status.status = TransactionStatus::Conflicted;
             if (wtx.isAbandoned())
                 status.status = TransactionStatus::Abandoned;
         }

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -32,6 +32,7 @@
 #include <QScrollBar>
 #include <QSignalMapper>
 #include <QTableView>
+#include <QTimer>
 #include <QUrl>
 #include <QVBoxLayout>
 
@@ -138,6 +139,7 @@ TransactionView::TransactionView(const PlatformStyle *platformStyle, QWidget *pa
 
     // Actions
     abandonAction = new QAction(tr("Abandon transaction"), this);
+    bumpFeeAction = new QAction(tr("Increase transaction fee"), this);
     QAction *copyAddressAction = new QAction(tr("Copy address"), this);
     QAction *copyLabelAction = new QAction(tr("Copy label"), this);
     QAction *copyAmountAction = new QAction(tr("Copy amount"), this);
@@ -157,6 +159,7 @@ TransactionView::TransactionView(const PlatformStyle *platformStyle, QWidget *pa
     contextMenu->addAction(showDetailsAction);
     contextMenu->addSeparator();
     contextMenu->addAction(abandonAction);
+    contextMenu->addAction(bumpFeeAction);
     contextMenu->addAction(editLabelAction);
 
     mapperThirdPartyTxUrls = new QSignalMapper(this);
@@ -174,6 +177,7 @@ TransactionView::TransactionView(const PlatformStyle *platformStyle, QWidget *pa
     connect(view, SIGNAL(customContextMenuRequested(QPoint)), this, SLOT(contextualMenu(QPoint)));
 
     connect(abandonAction, SIGNAL(triggered()), this, SLOT(abandonTx()));
+    connect(bumpFeeAction, SIGNAL(triggered()), this, SLOT(bumpTxFee()));
     connect(copyAddressAction, SIGNAL(triggered()), this, SLOT(copyAddress()));
     connect(copyLabelAction, SIGNAL(triggered()), this, SLOT(copyLabel()));
     connect(copyAmountAction, SIGNAL(triggered()), this, SLOT(copyAmount()));
@@ -370,6 +374,7 @@ void TransactionView::contextualMenu(const QPoint &point)
     uint256 hash;
     hash.SetHex(selection.at(0).data(TransactionTableModel::TxHashRole).toString().toStdString());
     abandonAction->setEnabled(model->transactionCanBeAbandoned(hash));
+    bumpFeeAction->setEnabled(model->transactionCanBeReplaced(hash));
 
     if(index.isValid())
     {
@@ -393,6 +398,31 @@ void TransactionView::abandonTx()
 
     // Update the table
     model->getTransactionTableModel()->updateTransaction(hashQStr, CT_UPDATED, false);
+}
+
+void TransactionView::bumpTxFee()
+{
+    if(!transactionView || !transactionView->selectionModel())
+        return;
+    QModelIndexList selection = transactionView->selectionModel()->selectedRows(0);
+
+    // get the hash from the TxHashRole (QVariant / QString)
+    uint256 hash;
+    QString hashQStr = selection.at(0).data(TransactionTableModel::TxHashRole).toString();
+    hash.SetHex(hashQStr.toStdString());
+
+    // Abandon the wallet transaction over the walletModel
+    if (!model->transactionBumpFee(hash, model->getOptionsModel()->getDisplayUnit()))
+    {
+        QMessageBox::critical(0, tr("Increase fee error"),
+                              tr("Could not increase the transaction fee"));
+        return;
+    }
+
+    // update the transaction, needs a second CT_NEW to fully decompose the new state
+    // due to the fact that CT_UPDATED can't handle color/icons updates
+    model->getTransactionTableModel()->updateTransaction(hashQStr, CT_UPDATED, false);
+    model->getTransactionTableModel()->updateTransaction(hashQStr, CT_NEW, true);
 }
 
 void TransactionView::copyAddress()

--- a/src/qt/transactionview.h
+++ b/src/qt/transactionview.h
@@ -76,6 +76,7 @@ private:
     QDateTimeEdit *dateFrom;
     QDateTimeEdit *dateTo;
     QAction *abandonAction;
+    QAction *bumpFeeAction;
 
     QWidget *createDateRangeWidget();
 
@@ -99,6 +100,7 @@ private Q_SLOTS:
     void openThirdPartyTxUrl(QString url);
     void updateWatchOnlyColumn(bool fHaveWatchOnly);
     void abandonTx();
+    void bumpTxFee();
 
 Q_SIGNALS:
     void doubleClicked(const QModelIndex&);

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -189,7 +189,7 @@ bool WalletModel::validateAddress(const QString &address)
     return addressParsed.IsValid();
 }
 
-WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransaction &transaction, const CCoinControl *coinControl)
+WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransaction &transaction, const CCoinControl *coinControl, bool optInRBF)
 {
     CAmount total = 0;
     bool fSubtractFeeFromAmount = false;
@@ -274,7 +274,7 @@ WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransact
 
         CWalletTx *newTx = transaction.getTransaction();
         CReserveKey *keyChange = transaction.getPossibleKeyChange();
-        bool fCreated = wallet->CreateTransaction(vecSend, *newTx, *keyChange, nFeeRequired, nChangePosRet, strFailReason, coinControl);
+        bool fCreated = wallet->CreateTransaction(vecSend, *newTx, *keyChange, nFeeRequired, nChangePosRet, strFailReason, coinControl, optInRBF ? CREATE_TX_RBF_OPT_IN : CREATE_TX_DEFAULT);
         transaction.setTransactionFee(nFeeRequired);
         if (fSubtractFeeFromAmount && fCreated)
             transaction.reassignAmounts(nChangePosRet);

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -14,6 +14,7 @@
 #include "base58.h"
 #include "keystore.h"
 #include "main.h"
+#include "policy/rbf.h"
 #include "sync.h"
 #include "ui_interface.h"
 #include "wallet/wallet.h"
@@ -682,4 +683,57 @@ bool WalletModel::abandonTransaction(uint256 hash) const
 {
     LOCK2(cs_main, wallet->cs_wallet);
     return wallet->AbandonTransaction(hash);
+}
+
+bool WalletModel::transactionCanBeReplaced(uint256 hash) const
+{
+    LOCK2(cs_main, wallet->cs_wallet);
+    const CWalletTx *wtx = wallet->GetWalletTx(hash);
+    if (!wtx)
+        return false;
+
+    return (SignalsOptInRBF(*wtx) && wallet->IsFromMe(*wtx));
+}
+
+bool WalletModel::transactionBumpFee(uint256 hash, int displayUnit) const
+{
+    CAmount oldFee;
+    CAmount newFee;
+    CWalletTx newTx;
+
+    // get a new change key
+    CReserveKey reserveKey(wallet);
+
+    {
+        LOCK2(cs_main, wallet->cs_wallet);
+
+        // get the transaction
+        const CWalletTx *wtx = wallet->GetWalletTx(hash);
+
+        // try to recreate the transaction
+        if (!wallet->BumpFee(*wtx, newTx, reserveKey, oldFee, newFee, 2))
+            return false;
+
+    }
+
+    // ask the user for confirmation
+    // do this without holding the locks
+    // results in accepting the risk that the fee bump will
+    // be rejected due to other replacements comming in over -server
+    // or changed min fee rates
+    QMessageBox msgBox;
+    msgBox.setText(tr("Increase transaction fee?"));
+    msgBox.setInformativeText(tr("Would you like to increase the current transaction fee from %1 to %2?").arg(BitcoinUnits::formatHtmlWithUnit(displayUnit, oldFee), BitcoinUnits::formatHtmlWithUnit(displayUnit, newFee)));
+    msgBox.setStandardButtons(QMessageBox::Ok | QMessageBox::Cancel);
+    msgBox.setDefaultButton(QMessageBox::Cancel);
+    int msgboxRet = msgBox.exec();
+
+    {
+        LOCK2(cs_main, wallet->cs_wallet);
+        // broadcast the transaction
+        if (msgboxRet == QMessageBox::Ok)
+            return wallet->CommitTransaction(newTx, reserveKey);
+    }
+    // return
+    return true;
 }

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -203,6 +203,9 @@ public:
     bool transactionCanBeAbandoned(uint256 hash) const;
     bool abandonTransaction(uint256 hash) const;
 
+    bool transactionCanBeReplaced(uint256 hash) const;
+    bool transactionBumpFee(uint256 hash, int displayUnit) const;
+
 private:
     CWallet *wallet;
     bool fHaveWatchOnly;

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -151,7 +151,7 @@ public:
     };
 
     // prepare transaction for getting txfee before sending coins
-    SendCoinsReturn prepareTransaction(WalletModelTransaction &transaction, const CCoinControl *coinControl = NULL);
+    SendCoinsReturn prepareTransaction(WalletModelTransaction &transaction, const CCoinControl *coinControl = NULL, bool optInRBF = false);
 
     // Send coins to a list of recipients
     SendCoinsReturn sendCoins(WalletModelTransaction &transaction);

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2464,7 +2464,8 @@ UniValue fundrawtransaction(const UniValue& params, bool fHelp)
     CAmount nFeeOut;
     string strFailReason;
 
-    if(!pwalletMain->FundTransaction(tx, nFeeOut, overrideEstimatedFeerate, feeRate, changePosition, strFailReason, includeWatching, lockUnspents, changeAddress))
+    CReserveKey reservekey(pwalletMain);
+    if(!pwalletMain->FundTransaction(tx, reservekey, nFeeOut, overrideEstimatedFeerate, feeRate, changePosition, strFailReason, includeWatching, lockUnspents, changeAddress))
         throw JSONRPCError(RPC_INTERNAL_ERROR, strFailReason);
 
     UniValue result(UniValue::VOBJ);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2251,7 +2251,7 @@ bool CWallet::CreateTransaction(const vector<CRecipient>& vecSend, CWalletTx& wt
                 // nLockTime set above actually works.
                 BOOST_FOREACH(const PAIRTYPE(const CWalletTx*,unsigned int)& coin, setCoins)
                     txNew.vin.push_back(CTxIn(coin.first->GetHash(),coin.second,CScript(),
-                                              std::numeric_limits<unsigned int>::max()-1));
+                                              std::numeric_limits<unsigned int>::max() - ((flags & CREATE_TX_RBF_OPT_IN) ? 2 : 1) ));
 
                 // Sign
                 int nIn = 0;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -16,6 +16,7 @@
 #include "main.h"
 #include "net.h"
 #include "policy/policy.h"
+#include "policy/rbf.h"
 #include "primitives/block.h"
 #include "primitives/transaction.h"
 #include "script/script.h"
@@ -1981,7 +1982,122 @@ bool CWallet::SelectCoins(const vector<COutput>& vAvailableCoins, const CAmount&
     return res;
 }
 
-bool CWallet::FundTransaction(CMutableTransaction& tx, CAmount& nFeeRet, bool overrideEstimatedFeeRate, const CFeeRate& specificFeeRate, int& nChangePosInOut, std::string& strFailReason, bool includeWatching, bool lockUnspents, const CTxDestination& destChange)
+bool CWallet::BumpFee(const CWalletTx& wtxIn, CWalletTx& wtxOut, CReserveKey& reservekeyOut, CAmount& nOldFee, CAmount& newFee, unsigned int blocksToConfirm)
+{
+    // ownly bump the fee if the transation signals opt-in-RBF after BIP125
+    if (!SignalsOptInRBF(wtxIn))
+        return false;
+
+    // calculate the feerate of the old transaction
+    CAmount nDebit = wtxIn.GetDebit(ISMINE_SPENDABLE);
+    nOldFee = -(wtxIn.IsFromMe(ISMINE_SPENDABLE) ? wtxIn.GetValueOut() - nDebit : 0);
+    CFeeRate oldFeeRate(nOldFee, ::GetSerializeSize((CTransaction)wtxIn, SER_NETWORK, PROTOCOL_VERSION));
+
+    // check if there are already conflicting transactions with higher feerates
+    for(const uint256& conflict : wtxIn.GetConflicts())
+    {
+        const CWalletTx *wtxC = GetWalletTx(conflict);
+        if (wtxC)
+        {
+            // calculate the feerate of the old transaction
+            CAmount ncDebit = wtxC->GetDebit(ISMINE_SPENDABLE);
+            CAmount nCFee = -(wtxC->IsFromMe(ISMINE_SPENDABLE) ? wtxC->GetValueOut() - ncDebit : 0);
+            CFeeRate conflictedFeeRate(nCFee, ::GetSerializeSize((CTransaction)*wtxC, SER_NETWORK, PROTOCOL_VERSION));
+            if (conflictedFeeRate > oldFeeRate)
+                return false;
+        }
+    }
+
+    // define the new feerate
+    CFeeRate newFeerate;
+
+    // estimate the current feerate
+    int estimateFoundAtBlocks = blocksToConfirm;
+    CFeeRate estimateFeeRate = mempool.estimateSmartFee(blocksToConfirm, &estimateFoundAtBlocks);
+    if (estimateFeeRate == CFeeRate(0))
+        estimateFeeRate = fallbackFee;
+
+    // for now we assume the new transaction only conflicts
+    // with a single transaction
+
+    // create a new fee rate that would be require
+    // for a transaction replacement of a single conflicting tx
+    CFeeRate oldFeeRatePlusMinRelayTxFee = oldFeeRate;
+    oldFeeRatePlusMinRelayTxFee+=CFeeRate(::minRelayTxFee);
+    newFeerate = oldFeeRatePlusMinRelayTxFee;
+
+    if (oldFeeRatePlusMinRelayTxFee < estimateFeeRate)
+    {
+        // the new estimated fee is sufficient for a replacment
+        newFeerate = CFeeRate(estimateFeeRate);
+    }
+
+    // create the conflicting transaction with the new feerate
+    CTransaction bumpedTx;
+    if (!RecreateTransactionWithFeeRate(wtxIn, bumpedTx, reservekeyOut, newFeerate, newFee))
+        return false;
+
+    // sign the new transaction
+    CMutableTransaction tx(bumpedTx);
+    int nIn = 0;
+    CTransaction txNewConst(tx);
+    bool txSignSuccess = false;
+    for (std::vector<CTxIn>::iterator it(tx.vin.begin()); it != tx.vin.end(); ++it)
+    {
+        std::map<uint256, CWalletTx>::const_iterator mi = pwalletMain->mapWallet.find((*it).prevout.hash);
+        if (mi != pwalletMain->mapWallet.end() && (nIn < (int)(*mi).second.vout.size()))
+        {
+            // get the scriptPubKey of the prevout
+            const CScript& scriptPubKey = (*mi).second.vout[(*it).prevout.n].scriptPubKey;
+
+            CScript& scriptSigRes = tx.vin[nIn].scriptSig; //reference to the CMutableTx scriptSig
+            txSignSuccess = ProduceSignature(TransactionSignatureCreator(pwalletMain, &txNewConst, nIn, SIGHASH_ALL), scriptPubKey, scriptSigRes);
+
+            if (!txSignSuccess)
+                break;
+        }
+        nIn++;
+    }
+
+    // form a wallet transaction
+    *static_cast<CTransaction*>(&wtxOut) = tx;
+    wtxOut.fTimeReceivedIsTxTime = true;
+    wtxOut.BindWallet(this);
+    wtxOut.fFromMe = true;
+    
+    return true;
+}
+
+bool CWallet::RecreateTransactionWithFeeRate(const CTransaction& txIn, CTransaction& txOut, CReserveKey& reservekeyOut, const CFeeRate& newFeerate, CAmount& newFeeOut)
+{
+    CMutableTransaction tx(txIn);
+    // remove scriptSigs, the signatures are invalid after mutating the transaction
+    for (std::vector<CTxIn>::iterator it(tx.vin.begin()); it != tx.vin.end(); ++it)
+    {
+        (*it).scriptSig = CScript();
+    }
+
+    // remove "old" change outputs
+    for (std::vector<CTxOut>::iterator it(tx.vout.begin()); it != tx.vout.end();)
+    {
+        if (pwalletMain->IsMine(*it) == ISMINE_SPENDABLE)
+            it = tx.vout.erase(it);
+        else
+            ++it;
+    }
+
+    string strFailReason;
+    int nChangePos = -1;
+
+    // re-fund the transaction, a new change output will be added
+    if(!pwalletMain->FundTransaction(tx, reservekeyOut, newFeeOut, true, newFeerate, nChangePos, strFailReason, false, false))
+        return false;
+
+    txOut = CTransaction(tx);
+    return true;
+}
+
+bool CWallet::FundTransaction(CMutableTransaction& tx, CReserveKey& reservekeyOut, CAmount& nFeeRet, bool overrideEstimatedFeeRate, const CFeeRate& specificFeeRate, int& nChangePosInOut, std::string& strFailReason, bool includeWatching, bool lockUnspents, const CTxDestination& destChange)
 {
     vector<CRecipient> vecSend;
 
@@ -2002,9 +2118,8 @@ bool CWallet::FundTransaction(CMutableTransaction& tx, CAmount& nFeeRet, bool ov
     BOOST_FOREACH(const CTxIn& txin, tx.vin)
         coinControl.Select(txin.prevout);
 
-    CReserveKey reservekey(this);
     CWalletTx wtx;
-    if (!CreateTransaction(vecSend, wtx, reservekey, nFeeRet, nChangePosInOut, strFailReason, &coinControl, CREATE_TX_DONT_SIGN))
+    if (!CreateTransaction(vecSend, wtx, reservekeyOut, nFeeRet, nChangePosInOut, strFailReason, &coinControl, CREATE_TX_DONT_SIGN))
         return false;
 
     if (nChangePosInOut != -1)

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -741,11 +741,17 @@ public:
     CAmount GetUnconfirmedWatchOnlyBalance() const;
     CAmount GetImmatureWatchOnlyBalance() const;
 
+    //! bump the fee to the current fee-estimation
+    bool BumpFee(const CWalletTx& wtxIn, CWalletTx& wtxOut, CReserveKey& reservekeyOut, CAmount& oldFee, CAmount& newFee, unsigned int blocksToConfirm = 2);
+
+    //! Creates a conflicting transaction based on a existing transaction providing a new feerate
+    bool RecreateTransactionWithFeeRate(const CTransaction& txIn, CTransaction& txOut, CReserveKey& reservekeyOut, const CFeeRate& newFeerate, CAmount& newFeeOut);
+
     /**
      * Insert additional inputs into the transaction by
      * calling CreateTransaction();
      */
-    bool FundTransaction(CMutableTransaction& tx, CAmount& nFeeRet, bool overrideEstimatedFeeRate, const CFeeRate& specificFeeRate, int& nChangePosInOut, std::string& strFailReason, bool includeWatching, bool lockUnspents, const CTxDestination& destChange = CNoDestination());
+    bool FundTransaction(CMutableTransaction& tx, CReserveKey& reservekeyOut, CAmount& nFeeRet, bool overrideEstimatedFeeRate, const CFeeRate& specificFeeRate, int& nChangePosInOut, std::string& strFailReason, bool includeWatching, bool lockUnspents, const CTxDestination& destChange = CNoDestination());
 
     /**
      * Create a new transaction paying the recipients with a set of coins

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -534,7 +534,8 @@ private:
 
 enum CreateTransactionFlags {
     CREATE_TX_DEFAULT     = 0,
-    CREATE_TX_DONT_SIGN   = (1U << 0)
+    CREATE_TX_DONT_SIGN   = (1U << 0),
+    CREATE_TX_RBF_OPT_IN  = (1U << 1)
 };
 
 /** 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -532,6 +532,10 @@ private:
     std::vector<char> _ssExtra;
 };
 
+enum CreateTransactionFlags {
+    CREATE_TX_DEFAULT     = 0,
+    CREATE_TX_DONT_SIGN   = (1U << 0)
+};
 
 /** 
  * A CWallet is an extension of a keystore, which also maintains a set of transactions and balances,
@@ -748,7 +752,7 @@ public:
      * @note passing nChangePosInOut as -1 will result in setting a random position
      */
     bool CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletTx& wtxNew, CReserveKey& reservekey, CAmount& nFeeRet, int& nChangePosInOut,
-                           std::string& strFailReason, const CCoinControl *coinControl = NULL, bool sign = true);
+                           std::string& strFailReason, const CCoinControl *coinControl = NULL, unsigned int flags = CREATE_TX_DEFAULT);
     bool CommitTransaction(CWalletTx& wtxNew, CReserveKey& reservekey);
 
     bool AddAccountingEntry(const CAccountingEntry&, CWalletDB & pwalletdb);


### PR DESCRIPTION
**1) Adds an option to set the opt-in-RBF flag when creating a transaction**
<img width="854" alt="bildschirmfoto 2016-06-09 um 11 14 44" src="https://cloud.githubusercontent.com/assets/178464/15924631/64f90b66-2e33-11e6-87f1-dae3dd9fd02b.png">

**2) Adds a fee bump option to the context menu.**
The option is only enabled if the transaction `isFromMe` and signaling RBF.

<img width="852" alt="bildschirmfoto 2016-06-09 um 11 12 06" src="https://cloud.githubusercontent.com/assets/178464/15924564/05252094-2e33-11e6-8892-f26030cfc99c.png">

<img width="865" alt="bildschirmfoto 2016-06-09 um 11 10 58" src="https://cloud.githubusercontent.com/assets/178464/15924544/f0502628-2e32-11e6-839e-5dcb9f962011.png">

For the full "RBF experience" we also should consider:
https://github.com/bitcoin/bitcoin/pull/7817 (attribute replaceable (RBF) transactions)
https://github.com/bitcoin/bitcoin/pull/7826 (show conflicts of unconfirmed transactions in the UI)
