### PR TITLE
[trivial] Ignore split-debug.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,4 @@ share/BitcoindComparisonTool.jar
 /doc/doxygen/
 
 libbitcoinconsensus.pc
+contrib/devtools/split-debug.sh


### PR DESCRIPTION
This is being generated since #8188, should it be in .gitignore?
