### PR TITLE
[Wallet] add HD keypath to CKeyMetadata, report over validateaddress

### DIFF
--- a/qa/rpc-tests/wallet.py
+++ b/qa/rpc-tests/wallet.py
@@ -55,9 +55,11 @@ class WalletTest (BitcoinTestFramework):
         assert_equal(len(self.nodes[1].listunspent()), 1)
         assert_equal(len(self.nodes[2].listunspent()), 0)
 
-        # Send 21 BTC from 0 to 2 using sendtoaddress call.
-        self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 11)
+        # Send 11 BTC from 0 to 2 using sendtoaddress call.
+        addr = self.nodes[2].getnewaddress()
+        self.nodes[0].sendtoaddress(addr, 11)
         self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 10)
+        assert(self.nodes[2].validateaddress(addr)["hdkeypath"] == "m/0'/0'/1'")
 
         walletinfo = self.nodes[0].getwalletinfo()
         assert_equal(walletinfo['immature_balance'], 0)

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -166,6 +166,7 @@ UniValue validateaddress(const UniValue& params, bool fHelp)
             "  \"pubkey\" : \"publickeyhex\",    (string) The hex value of the raw public key\n"
             "  \"iscompressed\" : true|false,  (boolean) If the address is compressed\n"
             "  \"account\" : \"account\"         (string) DEPRECATED. The account associated with the address, \"\" is the default account\n"
+            "  \"hdkeypath\" : \"keypath\"       (string, optional) The keypath if the key is available and was derived hierarchical\n" 
             "}\n"
             "\nExamples:\n"
             + HelpExampleCli("validateaddress", "\"1PSSGeFHDnKNxiEyFrD1wcEaHr9hrQDDWc\"")
@@ -200,6 +201,9 @@ UniValue validateaddress(const UniValue& params, bool fHelp)
         ret.pushKVs(detail);
         if (pwalletMain && pwalletMain->mapAddressBook.count(dest))
             ret.push_back(Pair("account", pwalletMain->mapAddressBook[dest].name));
+        CKeyID keyID;
+        if (pwalletMain && address.GetKeyID(keyID) && pwalletMain->mapKeyMetadata.count(keyID) && !pwalletMain->mapKeyMetadata[keyID].hdKeypath.empty())
+            ret.push_back(Pair("hdkeypath", pwalletMain->mapKeyMetadata[keyID].hdKeypath));
 #endif
     }
     return ret;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -126,6 +126,7 @@ CPubKey CWallet::GenerateNewKey()
             // childIndex | BIP32_HARDENED_KEY_LIMIT = derive childIndex in hardened child-index-range
             // example: 1 | BIP32_HARDENED_KEY_LIMIT == 0x80000001 == 2147483649
             externalChainChildKey.Derive(childKey, hdChain.nExternalChainCounter | BIP32_HARDENED_KEY_LIMIT);
+            metadata.hdKeypath = "m/0'/0'/"+std::to_string(hdChain.nExternalChainCounter)+"'";
             // increment childkey index
             hdChain.nExternalChainCounter++;
         } while(HaveKey(childKey.key.GetPubKey().GetID()));

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -72,9 +72,12 @@ public:
 class CKeyMetadata
 {
 public:
-    static const int CURRENT_VERSION=1;
+    static const int VERSION_BASIC=1;
+    static const int VERSION_WITH_HDKEYPATH=2;
+    static const int CURRENT_VERSION=VERSION_WITH_HDKEYPATH;
     int nVersion;
     int64_t nCreateTime; // 0 means unknown
+    std::string hdKeypath; //optional HD/bip32 keypath
 
     CKeyMetadata()
     {
@@ -84,6 +87,7 @@ public:
     {
         nVersion = CKeyMetadata::CURRENT_VERSION;
         nCreateTime = nCreateTime_;
+        hdKeypath.clear();
     }
 
     ADD_SERIALIZE_METHODS;
@@ -93,12 +97,15 @@ public:
         READWRITE(this->nVersion);
         nVersion = this->nVersion;
         READWRITE(nCreateTime);
+        if (this->nVersion >= VERSION_WITH_HDKEYPATH)
+            READWRITE(hdKeypath);
     }
 
     void SetNull()
     {
         nVersion = CKeyMetadata::CURRENT_VERSION;
         nCreateTime = 0;
+        hdKeypath.clear();
     }
 };
 


### PR DESCRIPTION
Adds the HD keypath (example: `m/0'/0'/1') to the persisted CKeyMetadata object.

Currently, the used keypath scheme is still static and should be made dynamic/configurable in a different PR.
