### PR TITLE
[Wallet] Add HD xpriv to dumpwallet

### DIFF
--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -602,19 +602,42 @@ UniValue dumpwallet(const UniValue& params, bool fHelp)
     file << strprintf("# * Best block at time of backup was %i (%s),\n", chainActive.Height(), chainActive.Tip()->GetBlockHash().ToString());
     file << strprintf("#   mined on %s\n", EncodeDumpTime(chainActive.Tip()->GetBlockTime()));
     file << "\n";
+
+    // add the base58check encoded extended master if the wallet uses HD 
+    CKeyID masterKeyID = pwalletMain->GetHDChain().masterKeyID;
+    if (!masterKeyID.IsNull())
+    {
+        CKey key;
+        if (pwalletMain->GetKey(masterKeyID, key))
+        {
+            CExtKey masterKey;
+            masterKey.SetMaster(key.begin(), key.size());
+
+            CBitcoinExtKey b58extkey;
+            b58extkey.SetKey(masterKey);
+
+            file << "# extended private masterkey: " << b58extkey.ToString() << "\n\n";
+        }
+    }
     for (std::vector<std::pair<int64_t, CKeyID> >::const_iterator it = vKeyBirth.begin(); it != vKeyBirth.end(); it++) {
         const CKeyID &keyid = it->second;
         std::string strTime = EncodeDumpTime(it->first);
         std::string strAddr = CBitcoinAddress(keyid).ToString();
         CKey key;
         if (pwalletMain->GetKey(keyid, key)) {
+            file << strprintf("%s %s ", CBitcoinSecret(key).ToString(), strTime);
             if (pwalletMain->mapAddressBook.count(keyid)) {
-                file << strprintf("%s %s label=%s # addr=%s\n", CBitcoinSecret(key).ToString(), strTime, EncodeDumpString(pwalletMain->mapAddressBook[keyid].name), strAddr);
+                file << strprintf("label=%s", EncodeDumpString(pwalletMain->mapAddressBook[keyid].name));
+            } else if (keyid == masterKeyID) {
+                file << "hdmaster=1";
             } else if (setKeyPool.count(keyid)) {
-                file << strprintf("%s %s reserve=1 # addr=%s\n", CBitcoinSecret(key).ToString(), strTime, strAddr);
+                file << "reserve=1";
+            } else if (pwalletMain->mapKeyMetadata[keyid].hdKeypath == "m") {
+                file << "inactivehdmaster=1";
             } else {
-                file << strprintf("%s %s change=1 # addr=%s\n", CBitcoinSecret(key).ToString(), strTime, strAddr);
+                file << "change=1";
             }
+            file << strprintf(" # addr=%s%s\n", strAddr, (pwalletMain->mapKeyMetadata[keyid].hdKeypath.size() > 0 ? " hdkeypath="+pwalletMain->mapKeyMetadata[keyid].hdKeypath : ""));
         }
     }
     file << "\n";

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -899,10 +899,10 @@ public:
 
     /* Set the HD chain model (chain child index counters) */
     bool SetHDChain(const CHDChain& chain, bool memonly);
+    const CHDChain& GetHDChain() { return hdChain; }
 
     /* Set the current HD master key (will reset the chain child index counters) */
     bool SetHDMasterKey(const CKey& key);
-    const CHDChain& GetHDChain() { return hdChain; }
 };
 
 /** A key allocated from the key pool. */


### PR DESCRIPTION
- Adds the base58check encoded extended master key to the "dumpwallet" file format (as a comment line).
- Adds "master=1" as key dump flag
- Lists the ~~P2PKH address~~ HASH160 of the master key in `getwalletinfo`

Before:

```
# Wallet dump created by Bitcoin v0.12.99.0-a552aca-dirty
# * Created on 2016-06-15T08:15:56Z
# * Best block at time of backup was 810 (530d5809aa50bcb4b35be0285aaafce93ccaf62c5410e53b9c4ce0c788c5a841),
#   mined on 2016-06-10T08:47:06Z

cVf2BZsGdkK8YanPbuxoP8CbEARU5sAYQKUs8j3Nf2wshCNQRAzo 2016-06-10T06:46:42Z change=1 # addr=myzPbNLzcmFSAW739GsB36r5HSZBfjuTUH
```

After:

```
# Wallet dump created by Bitcoin v0.12.99.0-a498925
# * Created on 2016-06-15T08:58:18Z
# * Best block at time of backup was 810 (530d5809aa50bcb4b35be0285aaafce93ccaf62c5410e53b9c4ce0c788c5a841),
#   mined on 2016-06-10T08:47:06Z

# extended private masterkey: tprv8ZgxMBicQKsPcuhwAr4bbp1p8BXKeYQutTqhh23QQKpVAfQcenCnLWMcWGpuK6Gnhuw19GHGg2oVwMnR9DYfbyvwFN4r5uB1YHspewdSEGJ

cVf2BZsGdkK8YanPbuxoP8CbEARU5sAYQKUs8j3Nf2wshCNQRAzo 2016-06-10T06:46:42Z hdmaster=1 # addr=myzPbNLzcmFSAW739GsB36r5HSZBfjuTUH
```

```
{
  "walletversion": 60000,
  "balance": 0.00000000,
  "unconfirmed_balance": 0.00000000,
  "immature_balance": 0.00000000,
  "txcount": 0,
  "keypoololdest": 1465977498,
  "keypoolsize": 100,
  "paytxfee": 0.00000000,
  "masterkeyid": "039aac5f30713ecba8fed140c45d926bfc9ca2ca"
}
```
