### PR TITLE
Do not set extra flags for unfiltered DNS seed results

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -16,14 +16,6 @@
 
 #include "chainparamsseeds.h"
 
-std::string CDNSSeedData::getHost(uint64_t requiredServiceBits) const {
-    //use default host for non-filter-capable seeds or if we use the default service bits (NODE_NETWORK)
-    if (!supportsServiceBitsFiltering || requiredServiceBits == NODE_NETWORK)
-        return host;
-    
-    return strprintf("x%x.%s", requiredServiceBits, host);
-}
-
 static CBlock CreateGenesisBlock(const char* pszTimestamp, const CScript& genesisOutputScript, uint32_t nTime, uint32_t nNonce, uint32_t nBits, int32_t nVersion, const CAmount& genesisReward)
 {
     CMutableTransaction txNew;

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -13,11 +13,9 @@
 
 #include <vector>
 
-class CDNSSeedData {
-public:
+struct CDNSSeedData {
     std::string name, host;
     bool supportsServiceBitsFiltering;
-    std::string getHost(uint64_t requiredServiceBits) const;
     CDNSSeedData(const std::string &strName, const std::string &strHost, bool supportsServiceBitsFilteringIn = false) : name(strName), host(strHost), supportsServiceBitsFiltering(supportsServiceBitsFilteringIn) {}
 };
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1415,6 +1415,18 @@ void MapPort(bool)
 
 
 
+static std::string GetDNSHost(const CDNSSeedData& data, ServiceFlags* requiredServiceBits)
+{
+    //use default host for non-filter-capable seeds or if we use the default service bits (NODE_NETWORK)
+    if (!data.supportsServiceBitsFiltering || *requiredServiceBits == NODE_NETWORK) {
+        *requiredServiceBits = NODE_NETWORK;
+        return data.host;
+    }
+
+    return strprintf("x%x.%s", *requiredServiceBits, data.host);
+}
+
+
 void ThreadDNSAddressSeed()
 {
     // goal: only query DNS seeds if address need is acute
@@ -1441,7 +1453,7 @@ void ThreadDNSAddressSeed()
             std::vector<CNetAddr> vIPs;
             std::vector<CAddress> vAdd;
             ServiceFlags requiredServiceBits = nRelevantServices;
-            if (LookupHost(seed.getHost(requiredServiceBits).c_str(), vIPs, 0, true))
+            if (LookupHost(GetDNSHost(seed, &requiredServiceBits).c_str(), vIPs, 0, true))
             {
                 BOOST_FOREACH(const CNetAddr& ip, vIPs)
                 {


### PR DESCRIPTION
Since #8083 and #7749 were both merged, any flag set in nRelevantServices would propagate to all CAddress results retrieved from the DNS seed, even if that DNS seed does not support filtering.

Fix this by making the name adaptation function also update the passed in flags.

Furthermore, move that from from DNSSeedData to net. Structs in chainparams should be data only.
