### PR TITLE
gitian: Move as-root preparation to gitian prepare script

### DIFF
--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -31,14 +31,10 @@ remotes:
 - "url": "https://github.com/bitcoin/bitcoin.git"
   "dir": "bitcoin"
 files: []
+prepare: |
+  mkdir -p /usr/include/i386-linux-gnu/
+  ln -s /usr/include/x86_64-linux-gnu/asm /usr/include/i386-linux-gnu/asm
 script: |
-
-  #unlock sudo
-  echo "ubuntu" | sudo -S true
-
-  sudo mkdir -p /usr/include/i386-linux-gnu/
-  sudo ln -s /usr/include/x86_64-linux-gnu/asm /usr/include/i386-linux-gnu/asm
-
   WRAP_DIR=$HOME/wrapped
   HOSTS="i686-pc-linux-gnu x86_64-linux-gnu arm-linux-gnueabihf aarch64-linux-gnu"
   CONFIGFLAGS="--enable-glibc-back-compat --enable-reduce-exports --disable-bench --disable-gui-tests"


### PR DESCRIPTION
Fixes #8212 (gitian LXC Linux build).

Needs https://github.com/devrandom/gitian-builder/pull/123
