### PR TITLE
[qa] mininode: fail on send_message instead of silent return

### DIFF
--- a/qa/rpc-tests/test_framework/mininode.py
+++ b/qa/rpc-tests/test_framework/mininode.py
@@ -1315,7 +1315,7 @@ class NodeConn(asyncore.dispatcher):
 
     def send_message(self, message, pushbuf=False):
         if self.state != "connected" and not pushbuf:
-            return
+            raise IOError('Not connected, no pushbuf')
         self.show_debug_msg("Send %s" % repr(message))
         command = message.command
         data = message.serialize()


### PR DESCRIPTION
I think the default behavior should be to fail and not silent return.

(A caller has always the choice to catch in case this is needed anywhere.)
