### PR TITLE
Stop trimming when mapTx is empty

### DIFF
--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -1075,7 +1075,7 @@ void CTxMemPool::TrimToSize(size_t sizelimit, std::vector<uint256>* pvNoSpendsRe
 
     unsigned nTxnRemoved = 0;
     CFeeRate maxFeeRateRemoved(0);
-    while (DynamicMemoryUsage() > sizelimit) {
+    while (!mapTx.empty() && DynamicMemoryUsage() > sizelimit) {
         indexed_transaction_set::index<descendant_score>::type::iterator it = mapTx.get<descendant_score>().begin();
 
         // We set the new mempool min fee to the feerate of the removed set, plus the


### PR DESCRIPTION
When CTxMemPool::TrimToSize is called with a very low number (like somewhere in mempool_tests), it is possible that the memory usage never sinks below the specified number.

This is unlikely to be a problem right now, but will be with the introduction of CTxMemPool::vTxHashes in #8068.
