### PR TITLE
[Qt] fix a bug where the SplashScreen will not be hidden during startup

### DIFF
--- a/src/qt/splashscreen.cpp
+++ b/src/qt/splashscreen.cpp
@@ -141,6 +141,11 @@ SplashScreen::~SplashScreen()
 void SplashScreen::slotFinish(QWidget *mainWin)
 {
     Q_UNUSED(mainWin);
+
+    /* If the window is minimized, hide() will be ignored. */
+    /* Make sure we de-minimize the splashscreen window before hiding */
+    if (isMinimized())
+        showNormal();
     hide();
 }
 


### PR DESCRIPTION
Fixes https://github.com/bitcoin/bitcoin/issues/7718

I guess calling `QWidget::hide()` on a `QWidget::isMinimized()` will not always result in a hidden window.
It's hard to say if this is a bug or a feature.

This little PR will make sure, we de-minimize the splashscreen-window before hiding.
