### PR TITLE
[WIP][depends] ZeroMQ 4.1.5 && ZMQ on Windows

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -816,6 +816,15 @@ else
     AC_DEFINE_UNQUOTED([ENABLE_ZMQ],[0],[Define to 1 to enable ZMQ functions])
   fi
 
+  if test "x$use_zmq" = "xyes"; then
+    dnl Assume libzmq was built for static linking
+    case $host in
+      *mingw*)
+        ZMQ_CFLAGS="$ZMQ_CFLAGS -DZMQ_STATIC"
+      ;;
+    esac
+  fi
+
   BITCOIN_QT_CHECK(AC_CHECK_LIB([protobuf] ,[main],[PROTOBUF_LIBS=-lprotobuf], BITCOIN_QT_FAIL(libprotobuf not found)))
   if test x$use_qr != xno; then
     BITCOIN_QT_CHECK([AC_CHECK_LIB([qrencode], [main],[QR_LIBS=-lqrencode], [have_qrencode=no])])

--- a/depends/packages/packages.mk
+++ b/depends/packages/packages.mk
@@ -1,6 +1,4 @@
-packages:=boost openssl libevent
-darwin_packages:=zeromq
-linux_packages:=zeromq
+packages:=boost openssl libevent zeromq
 native_packages := native_ccache native_comparisontool
 
 qt_native_packages = native_protobuf
@@ -11,7 +9,6 @@ qt_i686_linux_packages:=$(qt_x86_64_linux_packages)
 
 qt_darwin_packages=qt
 qt_mingw32_packages=qt
-
 
 wallet_packages=bdb
 

--- a/depends/packages/zeromq.mk
+++ b/depends/packages/zeromq.mk
@@ -1,13 +1,20 @@
 package=zeromq
-$(package)_version=4.1.4
-$(package)_download_path=http://download.zeromq.org
+$(package)_version=4.1.5
+$(package)_download_path=https://github.com/zeromq/zeromq4-1/releases/download/v$($(package)_version)/
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
-$(package)_sha256_hash=e99f44fde25c2e4cb84ce440f87ca7d3fe3271c2b8cfbc67d55e4de25e6fe378
+$(package)_sha256_hash=04aac57f081ffa3a2ee5ed04887be9e205df3a7ddade0027460b8042432bdbcf
+$(package)_patches=9114d3957725acd34aa8b8d011585812f3369411.patch 9e6745c12e0b100cd38acecc16ce7db02905e27c.patch
 
 define $(package)_set_vars
-  $(package)_config_opts=--without-documentation --disable-shared --without-libsodium
+  $(package)_config_opts=--without-documentation --disable-shared --without-libsodium --disable-curve
   $(package)_config_opts_linux=--with-pic
   $(package)_cxxflags=-std=c++11
+endef
+
+define $(package)_preprocess_cmds
+  patch -p1 < $($(package)_patch_dir)/9114d3957725acd34aa8b8d011585812f3369411.patch && \
+  patch -p1 < $($(package)_patch_dir)/9e6745c12e0b100cd38acecc16ce7db02905e27c.patch && \
+  ./autogen.sh
 endef
 
 define $(package)_config_cmds

--- a/depends/patches/zeromq/9114d3957725acd34aa8b8d011585812f3369411.patch
+++ b/depends/patches/zeromq/9114d3957725acd34aa8b8d011585812f3369411.patch
@@ -1,0 +1,22 @@
+From 9114d3957725acd34aa8b8d011585812f3369411 Mon Sep 17 00:00:00 2001
+From: Jeroen Ooms <jeroenooms@gmail.com>
+Date: Tue, 20 Oct 2015 13:10:38 +0200
+Subject: [PATCH] enable static libraries on mingw
+
+---
+ configure.ac | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index 393505b..e92131a 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -265,7 +265,7 @@ case "${host_os}" in
+         libzmq_dso_visibility="no"
+
+         if test "x$enable_static" = "xyes"; then
+-            AC_MSG_ERROR([Building static libraries is not supported under MinGW32])
++            CPPFLAGS="-DZMQ_STATIC"
+         fi
+
+ 	# Set FD_SETSIZE to 1024

--- a/depends/patches/zeromq/9e6745c12e0b100cd38acecc16ce7db02905e27c.patch
+++ b/depends/patches/zeromq/9e6745c12e0b100cd38acecc16ce7db02905e27c.patch
@@ -1,0 +1,22 @@
+From 9e6745c12e0b100cd38acecc16ce7db02905e27c Mon Sep 17 00:00:00 2001
+From: David Millard <dmillard10@gmail.com>
+Date: Tue, 10 May 2016 13:53:53 -0700
+Subject: [PATCH] Fix autotools for static MinGW builds
+
+---
+ configure.ac | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index 5a0fa14..def6ea7 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -259,7 +259,7 @@ case "${host_os}" in
+         libzmq_dso_visibility="no"
+
+         if test "x$enable_static" = "xyes"; then
+-            CPPFLAGS="-DZMQ_STATIC"
++            CPPFLAGS="-DZMQ_STATIC $CPPFLAGS"
+         fi
+
+ 	# Set FD_SETSIZE to 1024


### PR DESCRIPTION
This is an attempt to revive the work started by @theuni in #6819, and hopefully close issues #7943 and #6681.

Even if we still can't fix the Windows linking issues, it might be worth moving to the newer ZeroMQ version. Release notes as follows:

```
0MQ version 4.1.5 stable, released on 2016/06/17
================================================
* Fixed 1673 - CMake on Windows put PDB in wrong directory.
* Fixed 1723 - Family is not set when resolving NIC on Android.
* Fixed 1608 - Windows 7 TCP slow start issue.
* Fixed 1806 - uninitialised read in curve getsockopt.
* Fixed 1807 - build broken with GCC 6.
* Fixed 1831 - potential assertion failure with latest libsodium.
* Fixed 1850 - detection issues with tweetnacl/libsodium.
* Fixed 1877 - Avoid terminating connections prematurely
* Fixed 1887 - zmq_bind IPv4 fallback still tries IPv6
* Fixed 1866 - fails to build on SunOS 5.10 / Solaris 10
* Fixed 919 - ZMQ_LINGER (related to #1877)
* Fixed 114 - cannot unbind with same endpoint with IPv6 enabled.
* Fixed 1952 - CMake scripts not part of release tarballs
* Fixed 1542 - Fix a crash on Windows when port 5905 is in use.
* Fixed 2021 - Fix building on sparc32.
```

The changes to enable static linking in ZeroMQ have been made in [#1615](https://github.com/zeromq/libzmq/pull/1615) and then a follow up in [#1978](https://github.com/zeromq/libzmq/issues/1978) / [#1979](https://github.com/zeromq/libzmq/pull/1979).

We no longer need the [headergaurd patch](https://github.com/theuni/bitcoin/blob/d65eb63fc8ff782e80438f81a21aadd0e4830cbb/depends/patches/zeromq/headerguard.patch) from #6819, as those changes seem to be in [src/windows.hpp](https://github.com/zeromq/libzmq/blob/master/src/windows.hpp#L60). Introduced in [#901](https://github.com/zeromq/libzmq/pull/901).

Hopefully pulling all this info together means we can get this working.
