### PR TITLE
Check if the macro PKG_PROG_PKG_CONFIG was expanded.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -81,6 +81,8 @@ AC_ARG_VAR(PYTHONPATH, Augments the default search path for python module files)
 dnl pkg-config check.
 PKG_PROG_PKG_CONFIG
 
+m4_pattern_forbid([^PKG_PROG_PKG_CONFIG], [PKG_PROG_PKG_CONFIG macro not expanded, please install pkg-config])
+
 # Enable wallet
 AC_ARG_ENABLE([wallet],
   [AS_HELP_STRING([--disable-wallet],


### PR DESCRIPTION
If `pkg-config` is not installed, `pkg-config`'s `pkg.m4` is not installed and thus the macro `PKG_PROG_PKG_CONFIG` is not expanded.

Fixes #8228.

With this change, the output without `pkg-config` installed is:

```
...
configure.ac:83: error: PKG_PROG_PKG_CONFIG macro not expanded, please install pkg-config
      If this token and others are legitimate, please use m4_pattern_allow.
      See the Autoconf documentation.
autoreconf: /usr/bin/autoconf failed with exit status: 1
bitcoin@linux-fx0x:~/bitcoin> 
```
