### PR TITLE
remove unnecessary LOCK(cs_main) in getrawpmempool

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -289,8 +289,6 @@ UniValue getrawmempool(const UniValue& params, bool fHelp)
             + HelpExampleRpc("getrawmempool", "true")
         );
 
-    LOCK(cs_main);
-
     bool fVerbose = false;
     if (params.size() > 0)
         fVerbose = params[0].get_bool();


### PR DESCRIPTION
I'm happy to be wrong,  but I can't see why this is necessary,  especially when the mempool locks are all in place in subsequent functions?
