### PR TITLE
[TEST] [Travis] Remove hostname workaround

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,6 @@
 sudo: required
 dist: trusty
 
-#workaround for https://github.com/travis-ci/travis-ci/issues/5227
-addons:
-  hostname: bitcoin-tester
-
 os: linux
 language: generic
 cache:


### PR DESCRIPTION
According to comments [here](https://github.com/travis-ci/travis-ci/issues/5669#issuecomment-224946937) the upstream fix for the hostname bug has been deployed, so we should be able to remove the workaround from travis.yml. Test PR to see build results.
