### PR TITLE
[doc] Add OSX ZMQ requirement to QA readme

### DIFF
--- a/qa/README.md
+++ b/qa/README.md
@@ -16,6 +16,12 @@ The python3-zmq library is required. On Ubuntu or Debian it can be installed via
 sudo apt-get install python3-zmq
 ```
 
+OS X
+------
+```
+pip3 install pyzmq
+```
+
 Running tests
 =============
 
@@ -36,7 +42,7 @@ Run all possible tests with
     qa/pull-tester/rpc-tests.py -extended
 
 By default, tests will be run in parallel if you want to specify how many
-tests should be run in parallel, append `-paralell=n` (default n=4).
+tests should be run in parallel, append `-parallel=n` (default n=4).
 
 If you want to create a basic coverage report for the rpc test suite, append `--coverage`.
 


### PR DESCRIPTION
Also fixes a typo. s/paralell/parallel
