### PR TITLE
BUG: bitcoin-qt crash

### DIFF
--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -365,6 +365,8 @@ void TransactionView::contextualMenu(const QPoint &point)
 {
     QModelIndex index = transactionView->indexAt(point);
     QModelIndexList selection = transactionView->selectionModel()->selectedRows(0);
+    if (selection.empty())
+        return;
 
     // check if transaction can be abandoned, disable context menu action in case it doesn't
     uint256 hash;


### PR DESCRIPTION
How to reproduce bug:
1. Run bitcoin-qt which doen't have transactions. (any mode, here testnet screenshot but same problem with mainnet)
![Image of first step](http://i.imgur.com/Xeb6Bst.png)
1. Press right mouse button at center:
   ![Image of second step](http://i.imgur.com/xiCno4j.png)
2. Program crashes: 
   ![Image of third step](http://i.imgur.com/98zi9gT.png)

I found that error at the line:

``` cpp
hash.SetHex(selection.at(0).data(TransactionTableModel::TxHashRole).toString().toStdString());
```

and I added the check.

My system: Linux Mint 18, Qt 5.5
