### PR TITLE
src: Fix spelling error in comment - tinyformat.h

### DIFF
--- a/src/tinyformat.h
+++ b/src/tinyformat.h
@@ -844,7 +844,7 @@ inline const char* FormatIterator::streamStateFromFormat(std::ostream& out,
 
 //------------------------------------------------------------------------------
 // Private format function on top of which the public interface is implemented.
-// We enforce a mimimum of one value to be formatted to prevent bugs looking like
+// We enforce a minimum of one value to be formatted to prevent bugs looking like
 //
 //   const char* myStr = "100% broken";
 //   printf(myStr);   // Parses % as a format specifier


### PR DESCRIPTION
This PR contains one commit that fixes a spelling error in one of the in-line comments in `src/tinyformat.h`:
- `mimimum` should be spelled `minimum`
