### PR TITLE
[bugfix] Do not send witnesses in cmpctblock

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6538,7 +6538,7 @@ bool SendMessages(CNode* pto)
                     CBlock block;
                     assert(ReadBlockFromDisk(block, pBestIndex, consensusParams));
                     CBlockHeaderAndShortTxIDs cmpctblock(block);
-                    pto->PushMessage(NetMsgType::CMPCTBLOCK, cmpctblock);
+                    pto->PushMessageWithFlag(SERIALIZE_TRANSACTION_NO_WITNESS, NetMsgType::CMPCTBLOCK, cmpctblock);
                     state.pindexBestHeaderSent = pBestIndex;
                 } else if (state.fPreferHeaders) {
                     if (vHeaders.size() > 1) {


### PR DESCRIPTION
This is a small bugfix for #8149: we should not sent witnesses inside cmpctblock without negotiating whether the peers support them.
