### PR TITLE
Bump `-dbcache` default to 300MiB

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -41,9 +41,21 @@ report issues about Windows XP to the issue tracker.
 Notable changes
 ===============
 
-Example item
-----------------
+Database cache memory increased
+--------------------------------
 
+As a result of growth of the UTXO set, performance with the prior default
+database cache of 100 MiB has suffered.
+For this reason the default was changed to 300 MiB in this release.
+
+For nodes on low-memory systems, the database cache can be changed back to
+100 MiB (or to another value) by either:
+
+- Adding `dbcache=100` in bitcoin.conf
+- Changing it in the GUI under `Options → Size of database cache`
+
+Note that the database cache setting has the most performance impact
+during initial sync of a node, and when catching up after downtime.
 
 bitcoin-cli: arguments privacy
 --------------------------------

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1216,10 +1216,10 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     nTotalCache = std::max(nTotalCache, nMinDbCache << 20); // total cache cannot be less than nMinDbCache
     nTotalCache = std::min(nTotalCache, nMaxDbCache << 20); // total cache cannot be greated than nMaxDbcache
     int64_t nBlockTreeDBCache = nTotalCache / 8;
-    if (nBlockTreeDBCache > (1 << 21) && !GetBoolArg("-txindex", DEFAULT_TXINDEX))
-        nBlockTreeDBCache = (1 << 21); // block tree db cache shouldn't be larger than 2 MiB
+    nBlockTreeDBCache = std::min(nBlockTreeDBCache, (GetBoolArg("-txindex", DEFAULT_TXINDEX) ? nMaxBlockDBAndTxIndexCache : nMaxBlockDBCache) << 20);
     nTotalCache -= nBlockTreeDBCache;
     int64_t nCoinDBCache = std::min(nTotalCache / 2, (nTotalCache / 4) + (1 << 23)); // use 25%-50% of the remainder for disk cache
+    nCoinDBCache = std::min(nCoinDBCache, nMaxCoinsDBCache << 20); // cap total coins db cache
     nTotalCache -= nCoinDBCache;
     nCoinCacheUsage = nTotalCache; // the rest goes to in-memory cache
     LogPrintf("Cache configuration:\n");

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -22,11 +22,19 @@ class CCoinsViewDBCursor;
 class uint256;
 
 //! -dbcache default (MiB)
-static const int64_t nDefaultDbCache = 100;
-//! max. -dbcache in (MiB)
+static const int64_t nDefaultDbCache = 300;
+//! max. -dbcache (MiB)
 static const int64_t nMaxDbCache = sizeof(void*) > 4 ? 16384 : 1024;
-//! min. -dbcache in (MiB)
+//! min. -dbcache (MiB)
 static const int64_t nMinDbCache = 4;
+//! Max memory allocated to block tree DB specific cache, if no -txindex (MiB)
+static const int64_t nMaxBlockDBCache = 2;
+//! Max memory allocated to block tree DB specific cache, if -txindex (MiB)
+// Unlike for the UTXO database, for the txindex scenario the leveldb cache make
+// a meaningful difference: https://github.com/bitcoin/bitcoin/pull/8273#issuecomment-229601991
+static const int64_t nMaxBlockDBAndTxIndexCache = 1024;
+//! Max memory allocated to coin DB specific cache (MiB)
+static const int64_t nMaxCoinsDBCache = 8;
 
 struct CDiskTxPos : public CDiskBlockPos
 {


### PR DESCRIPTION
Bump `-dbcache` default value to 300MiB.

Also cap the allocations for the leveldb-specific caches to 32MiB, the current default for 100MiB. This avoids that the extra cache memory goes to the much less effective leveldb cache instead of our application-level cache.

Before:

| `-dbcache` | `-txindex` | block index db (MiB) | chain state db (MiB) | in-memory UTXO set (MiB) |
| --: | --: | --: | --: | --: |
| 100 _default_ | 0 | 2.0 | 32.5 | **65.5** |
| 100 | 1 | 12.5 | 29.9 | 57.6 |
| 300 | 0 | 2.0 | 82.5 | 215.5 |
| 300 | 1 | 37.5 | 73.6 | 188.9 |

After:

| `-dbcache` | `-txindex` | block index db (MiB) | chain state db (MiB) | in-memory UTXO set (MiB) |
| --: | --: | --: | --: | --: |
| 100 | 0 | 2.0 | 8.0 | 90.0 |
| 100 | 1 | 12.5 | 29.9 | 57.6 |
| 300 _default_ | 0 | 2.0 | 8.0 | **290.0** |
| 300 | 1 | 8.0 | 8.0 | 284.0 |

Number in **bold** is the size allocated to the `CCoinsCache` in the default case.

See #8245, as well as 2016-06-23 meeting log for discussion.

Note: after this, we also need something like #8138 - currently the dbcache determines how deep undo data is rolled back at start, so otherwise this will result in the start-up verification becoming even slower.
