### PR TITLE
Refactor CBlockHeaderAndShortTxIDs::GetShortID into CTransaction

### DIFF
--- a/src/blockencodings.cpp
+++ b/src/blockencodings.cpp
@@ -25,7 +25,7 @@ CBlockHeaderAndShortTxIDs::CBlockHeaderAndShortTxIDs(const CBlock& block) :
     prefilledtxn[0] = {0, block.vtx[0]};
     for (size_t i = 1; i < block.vtx.size(); i++) {
         const CTransaction& tx = block.vtx[i];
-        shorttxids[i - 1] = GetShortID(tx.GetHash());
+        shorttxids[i - 1] = tx.GetShortID(shorttxidk0, shorttxidk1);
     }
 }
 
@@ -42,7 +42,7 @@ void CBlockHeaderAndShortTxIDs::FillShortTxIDSelector() const {
 
 uint64_t CBlockHeaderAndShortTxIDs::GetShortID(const uint256& txhash) const {
     static_assert(SHORTTXIDS_LENGTH == 6, "shorttxids calculation assumes 6-byte shorttxids");
-    return SipHashUint256(shorttxidk0, shorttxidk1, txhash) & 0xffffffffffffL;
+    return CTransaction::GetShortID(shorttxidk0, shorttxidk1, txhash) & 0xffffffffffffL;
 }
 
 

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -7,6 +7,7 @@
 #define BITCOIN_PRIMITIVES_TRANSACTION_H
 
 #include "amount.h"
+#include "hash.h"
 #include "script/script.h"
 #include "serialize.h"
 #include "uint256.h"
@@ -398,6 +399,14 @@ public:
 
     const uint256& GetHash() const {
         return hash;
+    }
+
+    static uint64_t GetShortID(const uint64_t &k0, const uint64_t &k1, const uint256 &txhash) {
+        return SipHashUint256(k0, k1, txhash);
+    }
+
+    uint64_t GetShortID(const uint64_t &k0, const uint64_t &k1) const {
+        return GetShortID(k0, k1, GetHash());
     }
 
     // Compute a hash that includes both transaction and witness data


### PR DESCRIPTION
I'd like to use the short id scheme for mempool syncing.
