### PR TITLE
bash-completion: Adapt for 0.12 and 0.13

### DIFF
--- a/contrib/bitcoin-cli.bash-completion
+++ b/contrib/bitcoin-cli.bash-completion
@@ -1,0 +1,154 @@
+# bash programmable completion for bitcoin-cli(1)
+# Copyright (c) 2012-2016 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+# call $bitcoin-cli for RPC
+_bitcoin_rpc() {
+    # determine already specified args necessary for RPC
+    local rpcargs=()
+    for i in ${COMP_LINE}; do
+        case "$i" in
+            -conf=*|-datadir=*|-regtest|-rpc*|-testnet)
+                rpcargs=( "${rpcargs[@]}" "$i" )
+                ;;
+        esac
+    done
+    $bitcoin_cli "${rpcargs[@]}" "$@"
+}
+
+# Add wallet accounts to COMPREPLY
+_bitcoin_accounts() {
+    local accounts
+    accounts=$(_bitcoin_rpc listaccounts | awk -F '"' '{ print $2 }')
+    COMPREPLY=( "${COMPREPLY[@]}" $( compgen -W "$accounts" -- "$cur" ) )
+}
+
+_bitcoin_cli() {
+    local cur prev words=() cword
+    local bitcoin_cli
+
+    # save and use original argument to invoke bitcoin-cli for -help, help and RPC
+    # as bitcoin-cli might not be in $PATH
+    bitcoin_cli="$1"
+
+    COMPREPLY=()
+    _get_comp_words_by_ref -n = cur prev words cword
+
+    if ((cword > 5)); then
+        case ${words[cword-5]} in
+            sendtoaddress)
+                COMPREPLY=( $( compgen -W "true false" -- "$cur" ) )
+                return 0
+                ;;
+        esac
+    fi
+
+    if ((cword > 4)); then
+        case ${words[cword-4]} in
+            importaddress|listtransactions|setban)
+                COMPREPLY=( $( compgen -W "true false" -- "$cur" ) )
+                return 0
+                ;;
+            signrawtransaction)
+                COMPREPLY=( $( compgen -W "ALL NONE SINGLE ALL|ANYONECANPAY NONE|ANYONECANPAY SINGLE|ANYONECANPAY" -- "$cur" ) )
+                return 0
+                ;;
+        esac
+    fi
+
+    if ((cword > 3)); then
+        case ${words[cword-3]} in
+            addmultisigaddress)
+                _bitcoin_accounts
+                return 0
+                ;;
+            getbalance|gettxout|importaddress|importpubkey|importprivkey|listreceivedbyaccount|listreceivedbyaddress|listsinceblock)
+                COMPREPLY=( $( compgen -W "true false" -- "$cur" ) )
+                return 0
+                ;;
+        esac
+    fi
+
+    if ((cword > 2)); then
+        case ${words[cword-2]} in
+            addnode)
+                COMPREPLY=( $( compgen -W "add remove onetry" -- "$cur" ) )
+                return 0
+                ;;
+            setban)
+                COMPREPLY=( $( compgen -W "add remove" -- "$cur" ) )
+                return 0
+                ;;
+            fundrawtransaction|getblock|getblockheader|getmempoolancestors|getmempooldescendants|getrawtransaction|gettransaction|listaccounts|listreceivedbyaccount|listreceivedbyaddress|sendrawtransaction)
+                COMPREPLY=( $( compgen -W "true false" -- "$cur" ) )
+                return 0
+                ;;
+            move|setaccount)
+                _bitcoin_accounts
+                return 0
+                ;;
+        esac
+    fi
+
+    case "$prev" in
+        backupwallet|dumpwallet|importwallet)
+            _filedir
+            return 0
+            ;;
+        getaddednodeinfo|getrawmempool|lockunspent|setgenerate)
+            COMPREPLY=( $( compgen -W "true false" -- "$cur" ) )
+            return 0
+            ;;
+        getaccountaddress|getaddressesbyaccount|getbalance|getnewaddress|getreceivedbyaccount|listtransactions|move|sendfrom|sendmany)
+            _bitcoin_accounts
+            return 0
+            ;;
+    esac
+
+    case "$cur" in
+        -conf=*)
+            cur="${cur#*=}"
+            _filedir
+            return 0
+            ;;
+        -datadir=*)
+            cur="${cur#*=}"
+            _filedir -d
+            return 0
+            ;;
+        -*=*)	# prevent nonsense completions
+            return 0
+            ;;
+        *)
+            local helpopts commands
+
+            # only parse -help if senseful
+            if [[ -z "$cur" || "$cur" =~ ^- ]]; then
+                helpopts=$($bitcoin_cli -help 2>&1 | awk '$1 ~ /^-/ { sub(/=.*/, "="); print $1 }' )
+            fi
+
+            # only parse help if senseful
+            if [[ -z "$cur" || "$cur" =~ ^[a-z] ]]; then
+                commands=$(_bitcoin_rpc help 2>/dev/null | awk '$1 ~ /^[a-z]/ { print $1; }')
+            fi
+
+            COMPREPLY=( $( compgen -W "$helpopts $commands" -- "$cur" ) )
+
+            # Prevent space if an argument is desired
+            if [[ $COMPREPLY == *= ]]; then
+                compopt -o nospace
+            fi
+            return 0
+            ;;
+    esac
+} &&
+complete -F _bitcoin_cli bitcoin-cli
+
+# Local variables:
+# mode: shell-script
+# sh-basic-offset: 4
+# sh-indent-comment: t
+# indent-tabs-mode: nil
+# End:
+# ex: ts=4 sw=4 et filetype=sh

--- a/contrib/bitcoin-tx.bash-completion
+++ b/contrib/bitcoin-tx.bash-completion
@@ -1,0 +1,57 @@
+# bash programmable completion for bitcoin-tx(1)
+# Copyright (c) 2016 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+_bitcoin_tx() {
+    local cur prev words=() cword
+    local bitcoin_tx
+
+    # save and use original argument to invoke bitcoin-tx for -help
+    # it might not be in $PATH
+    bitcoin_tx="$1"
+
+    COMPREPLY=()
+    _get_comp_words_by_ref -n =: cur prev words cword
+
+    case "$cur" in
+        load=*:*)
+            cur="${cur#load=*:}"
+            _filedir
+            return 0
+            ;;
+        *=*)	# prevent attempts to complete other arguments
+            return 0
+            ;;
+    esac
+
+    if [[ "$cword" == 1 || ( "$prev" != "-create" && "$prev" == -* ) ]]; then
+        # only options (or an uncompletable hex-string) allowed
+        # parse bitcoin-tx -help for options
+        local helpopts
+        helpopts=$($bitcoin_tx -help | sed -e '/^  -/ p' -e d )
+        COMPREPLY=( $( compgen -W "$helpopts" -- "$cur" ) )
+    else
+        # only commands are allowed
+        # parse -help for commands
+        local helpcmds
+        helpcmds=$($bitcoin_tx -help | sed -e '1,/Commands:/d' -e 's/=.*/=/' -e '/^  [a-z]/ p' -e d )
+        COMPREPLY=( $( compgen -W "$helpcmds" -- "$cur" ) )
+    fi
+
+    # Prevent space if an argument is desired
+    if [[ $COMPREPLY == *= ]]; then
+        compopt -o nospace
+    fi
+
+    return 0
+} &&
+complete -F _bitcoin_tx bitcoin-tx
+
+# Local variables:
+# mode: shell-script
+# sh-basic-offset: 4
+# sh-indent-comment: t
+# indent-tabs-mode: nil
+# End:
+# ex: ts=4 sw=4 et filetype=sh

--- a/contrib/bitcoind.bash-completion
+++ b/contrib/bitcoind.bash-completion
@@ -1,102 +1,21 @@
-# bash programmable completion for bitcoind(1) and bitcoin-cli(1)
-# Copyright (c) 2012,2014 Christian von Roques <roques@mti.ag>
+# bash programmable completion for bitcoind(1) and bitcoin-qt(1)
+# Copyright (c) 2012-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-
-have bitcoind && {
-
-# call $bitcoind for RPC
-_bitcoin_rpc() {
-    # determine already specified args necessary for RPC
-    local rpcargs=()
-    for i in ${COMP_LINE}; do
-        case "$i" in
-            -conf=*|-proxy*|-rpc*)
-                rpcargs=( "${rpcargs[@]}" "$i" )
-                ;;
-        esac
-    done
-    $bitcoind "${rpcargs[@]}" "$@"
-}
-
-# Add bitcoin accounts to COMPREPLY
-_bitcoin_accounts() {
-    local accounts
-    accounts=$(_bitcoin_rpc listaccounts | awk '/".*"/ { a=$1; gsub(/"/, "", a); print a}')
-    COMPREPLY=( "${COMPREPLY[@]}" $( compgen -W "$accounts" -- "$cur" ) )
-}
 
 _bitcoind() {
     local cur prev words=() cword
     local bitcoind
 
-    # save and use original argument to invoke bitcoind
-    # bitcoind might not be in $PATH
+    # save and use original argument to invoke bitcoind for -help
+    # it might not be in $PATH
     bitcoind="$1"
 
     COMPREPLY=()
     _get_comp_words_by_ref -n = cur prev words cword
 
-    if ((cword > 4)); then
-        case ${words[cword-4]} in
-            listtransactions)
-                COMPREPLY=( $( compgen -W "true false" -- "$cur" ) )
-                return 0
-                ;;
-            signrawtransaction)
-                COMPREPLY=( $( compgen -W "ALL NONE SINGLE ALL|ANYONECANPAY NONE|ANYONECANPAY SINGLE|ANYONECANPAY" -- "$cur" ) )
-                return 0
-                ;;
-        esac
-    fi
-
-    if ((cword > 3)); then
-        case ${words[cword-3]} in
-            addmultisigaddress)
-                _bitcoin_accounts
-                return 0
-                ;;
-            getbalance|gettxout|importaddress|importprivkey|listreceivedbyaccount|listreceivedbyaddress|listsinceblock)
-                COMPREPLY=( $( compgen -W "true false" -- "$cur" ) )
-                return 0
-                ;;
-        esac
-    fi
-
-    if ((cword > 2)); then
-        case ${words[cword-2]} in
-            addnode)
-                COMPREPLY=( $( compgen -W "add remove onetry" -- "$cur" ) )
-                return 0
-                ;;
-            getblock|getrawtransaction|gettransaction|listaccounts|listreceivedbyaccount|listreceivedbyaddress|sendrawtransaction)
-                COMPREPLY=( $( compgen -W "true false" -- "$cur" ) )
-                return 0
-                ;;
-            move|setaccount)
-                _bitcoin_accounts
-                return 0
-                ;;
-        esac
-    fi
-
-    case "$prev" in
-        backupwallet|dumpwallet|importwallet)
-            _filedir
-            return 0
-            ;;
-        getmempool|lockunspent|setgenerate)
-            COMPREPLY=( $( compgen -W "true false" -- "$cur" ) )
-            return 0
-            ;;
-        getaccountaddress|getaddressesbyaccount|getbalance|getnewaddress|getreceivedbyaccount|listtransactions|move|sendfrom|sendmany)
-            _bitcoin_accounts
-            return 0
-            ;;
-    esac
-
     case "$cur" in
-        -conf=*|-pid=*|-loadblock=*|-wallet=*)
+        -conf=*|-pid=*|-loadblock=*|-rootcertificates=*|-rpccookiefile=*|-wallet=*)
             cur="${cur#*=}"
             _filedir
             return 0
@@ -110,19 +29,13 @@ _bitcoind() {
             return 0
             ;;
         *)
-            local helpopts commands
 
-            # only parse --help if senseful
+            # only parse -help if senseful
             if [[ -z "$cur" || "$cur" =~ ^- ]]; then
-                helpopts=$($bitcoind --help 2>&1 | awk '$1 ~ /^-/ { sub(/=.*/, "="); print $1 }' )
+                local helpopts
+                helpopts=$($bitcoind -help 2>&1 | awk '$1 ~ /^-/ { sub(/=.*/, "="); print $1 }' )
+                COMPREPLY=( $( compgen -W "$helpopts" -- "$cur" ) )
             fi
-
-            # only parse help if senseful
-            if [[ -z "$cur" || "$cur" =~ ^[a-z] ]]; then
-                commands=$(_bitcoin_rpc help 2>/dev/null | awk '$1 ~ /^[a-z]/ { print $1; }')
-            fi
-
-            COMPREPLY=( $( compgen -W "$helpopts $commands" -- "$cur" ) )
 
             # Prevent space if an argument is desired
             if [[ $COMPREPLY == *= ]]; then
@@ -131,10 +44,8 @@ _bitcoind() {
             return 0
             ;;
     esac
-}
-
-complete -F _bitcoind bitcoind bitcoin-cli
-}
+} &&
+complete -F _bitcoind bitcoind bitcoin-qt
 
 # Local variables:
 # mode: shell-script

--- a/contrib/debian/bitcoin-tx.bash-completion
+++ b/contrib/debian/bitcoin-tx.bash-completion
@@ -1,0 +1,1 @@
+contrib/bitcoin-tx.bash-completion	bitcoin-tx

--- a/contrib/debian/bitcoind.bash-completion
+++ b/contrib/debian/bitcoind.bash-completion
@@ -1,1 +1,2 @@
 contrib/bitcoind.bash-completion	bitcoind
+contrib/bitcoin-cli.bash-completion	bitcoin-cli


### PR DESCRIPTION
- separate completion for bitcoind and bitcoin-cli
- remove RPC support from bitcoind completion
- add completion for bitcoin-tx and bitcoin-qt
