### PR TITLE
wallet: Revert input selection post-pruning

### DIFF
--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -349,20 +349,6 @@ BOOST_AUTO_TEST_CASE(ApproximateBestSubset)
     BOOST_CHECK(wallet.SelectCoinsMinConf(1003 * COIN, 1, 6, vCoins, setCoinsRet, nValueRet));
     BOOST_CHECK_EQUAL(nValueRet, 1003 * COIN);
     BOOST_CHECK_EQUAL(setCoinsRet.size(), 2U);
-
-    empty_wallet();
-
-    // Test trimming
-    for (int i = 0; i < 100; i++)
-        add_coin(10 * COIN);
-    for (int i = 0; i < 100; i++)
-        add_coin(1000 * COIN);
-
-    BOOST_CHECK(wallet.SelectCoinsMinConf(100001 * COIN, 1, 6, vCoins, setCoinsRet, nValueRet));
-    // We need all 100 larger coins and exactly one small coin.
-    // Superfluous small coins must be trimmed from the set:
-    BOOST_CHECK_EQUAL(nValueRet, 100010 * COIN);
-    BOOST_CHECK_EQUAL(setCoinsRet.size(), 101);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1879,16 +1879,6 @@ static void ApproximateBestSubset(vector<pair<CAmount, pair<const CWalletTx*,uns
             }
         }
     }
-
-    //Reduces the approximate best subset by removing any inputs that are smaller than the surplus of nTotal beyond nTargetValue. 
-    for (unsigned int i = 0; i < vValue.size(); i++)
-    {                        
-        if (vfBest[i] && (nBest - vValue[i].first) >= nTargetValue )
-        {
-            vfBest[i] = false;
-            nBest -= vValue[i].first;
-        }
-    }
 }
 
 bool CWallet::SelectCoinsMinConf(const CAmount& nTargetValue, int nConfMine, int nConfTheirs, vector<COutput> vCoins,


### PR DESCRIPTION
This reverts PR #4906, "Coinselection prunes extraneous inputs from ApproximateBestSubset".

Apparently the previous behavior of slightly over-estimating the set of inputs was useful in cleaning up UTXOs.

See also #7664, #7657, as well as 2016-07-01 discussion on #bitcoin-core-dev IRC.
