### PR TITLE
Rename CTxinWitness -> CTxInWitness

### DIFF
--- a/qa/rpc-tests/p2p-segwit.py
+++ b/qa/rpc-tests/p2p-segwit.py
@@ -252,7 +252,7 @@ class SegWitTest(BitcoinTestFramework):
         tx = CTransaction()
         tx.vin.append(CTxIn(COutPoint(self.utxo[0].sha256, self.utxo[0].n), b""))
         tx.vout.append(CTxOut(self.utxo[0].nValue-1000, CScript([OP_TRUE])))
-        tx.wit.vtxinwit.append(CTxinWitness())
+        tx.wit.vtxinwit.append(CTxInWitness())
         tx.wit.vtxinwit[0].scriptWitness.stack = [CScript([CScriptNum(1)])]
 
         # Verify the hash with witness differs from the txid
@@ -362,7 +362,7 @@ class SegWitTest(BitcoinTestFramework):
         tx2 = CTransaction()
         tx2.vin.append(CTxIn(COutPoint(tx.sha256, 0), b""))
         tx2.vout.append(CTxOut(tx.vout[0].nValue-1000, witness_program))
-        tx2.wit.vtxinwit.append(CTxinWitness())
+        tx2.wit.vtxinwit.append(CTxInWitness())
         tx2.wit.vtxinwit[0].scriptWitness.stack = [witness_program]
         tx2.rehash()
 
@@ -489,7 +489,7 @@ class SegWitTest(BitcoinTestFramework):
             child_tx.vin.append(CTxIn(COutPoint(parent_tx.sha256, i), b""))
         child_tx.vout = [CTxOut(value - 100000, CScript([OP_TRUE]))]
         for i in range(NUM_OUTPUTS):
-            child_tx.wit.vtxinwit.append(CTxinWitness())
+            child_tx.wit.vtxinwit.append(CTxInWitness())
             child_tx.wit.vtxinwit[-1].scriptWitness.stack = [b'a'*195]*(2*NUM_DROPS) + [witness_program]
         child_tx.rehash()
         self.update_witness_block_with_transactions(block, [parent_tx, child_tx])
@@ -584,7 +584,7 @@ class SegWitTest(BitcoinTestFramework):
         tx.vin.append(CTxIn(COutPoint(self.utxo[0].sha256, self.utxo[0].n), b""))
         tx.vout.append(CTxOut(self.utxo[0].nValue-2000, scriptPubKey))
         tx.vout.append(CTxOut(1000, CScript([OP_TRUE]))) # non-witness output
-        tx.wit.vtxinwit.append(CTxinWitness())
+        tx.wit.vtxinwit.append(CTxInWitness())
         tx.wit.vtxinwit[0].scriptWitness.stack = [CScript([])]
         tx.rehash()
         self.update_witness_block_with_transactions(block, [tx])
@@ -607,7 +607,7 @@ class SegWitTest(BitcoinTestFramework):
         tx2.vin.append(CTxIn(COutPoint(tx.sha256, 0), b"")) # witness output
         tx2.vin.append(CTxIn(COutPoint(tx.sha256, 1), b"")) # non-witness
         tx2.vout.append(CTxOut(tx.vout[0].nValue, CScript([OP_TRUE])))
-        tx2.wit.vtxinwit.extend([CTxinWitness(), CTxinWitness()])
+        tx2.wit.vtxinwit.extend([CTxInWitness(), CTxInWitness()])
         tx2.wit.vtxinwit[0].scriptWitness.stack = [ CScript([CScriptNum(1)]), CScript([CScriptNum(1)]), witness_program ]
         tx2.wit.vtxinwit[1].scriptWitness.stack = [ CScript([OP_TRUE]) ]
 
@@ -663,7 +663,7 @@ class SegWitTest(BitcoinTestFramework):
         tx2 = CTransaction()
         tx2.vin.append(CTxIn(COutPoint(tx.sha256, 0), b""))
         tx2.vout.append(CTxOut(tx.vout[0].nValue-1000, CScript([OP_TRUE])))
-        tx2.wit.vtxinwit.append(CTxinWitness())
+        tx2.wit.vtxinwit.append(CTxInWitness())
         # First try a 521-byte stack element
         tx2.wit.vtxinwit[0].scriptWitness.stack = [ b'a'*(MAX_SCRIPT_ELEMENT_SIZE+1), witness_program ]
         tx2.rehash()
@@ -705,7 +705,7 @@ class SegWitTest(BitcoinTestFramework):
         tx2 = CTransaction()
         tx2.vin.append(CTxIn(COutPoint(tx.sha256, 0), b""))
         tx2.vout.append(CTxOut(tx.vout[0].nValue-1000, CScript([OP_TRUE])))
-        tx2.wit.vtxinwit.append(CTxinWitness())
+        tx2.wit.vtxinwit.append(CTxInWitness())
         tx2.wit.vtxinwit[0].scriptWitness.stack = [b'a']*44 + [long_witness_program]
         tx2.rehash()
 
@@ -782,7 +782,7 @@ class SegWitTest(BitcoinTestFramework):
 
         # First try using a too long vtxinwit
         for i in range(11):
-            tx2.wit.vtxinwit.append(CTxinWitness())
+            tx2.wit.vtxinwit.append(CTxInWitness())
             tx2.wit.vtxinwit[i].scriptWitness.stack = [b'a', witness_program]
 
         block = self.build_next_block()
@@ -798,7 +798,7 @@ class SegWitTest(BitcoinTestFramework):
         self.test_node.test_witness_block(block, accepted=False)
 
         # Now make one of the intermediate witnesses be incorrect
-        tx2.wit.vtxinwit.append(CTxinWitness())
+        tx2.wit.vtxinwit.append(CTxInWitness())
         tx2.wit.vtxinwit[-1].scriptWitness.stack = [b'a', witness_program]
         tx2.wit.vtxinwit[5].scriptWitness.stack = [ witness_program ]
 
@@ -825,7 +825,7 @@ class SegWitTest(BitcoinTestFramework):
         tx = CTransaction()
         tx.vin.append(CTxIn(COutPoint(self.utxo[0].sha256, self.utxo[0].n), b""))
         tx.vout.append(CTxOut(self.utxo[0].nValue-1000, CScript([OP_TRUE])))
-        tx.wit.vtxinwit.append(CTxinWitness())
+        tx.wit.vtxinwit.append(CTxInWitness())
         tx.wit.vtxinwit[0].scriptWitness.stack = [ b'a' ]
         tx.rehash()
 
@@ -885,7 +885,7 @@ class SegWitTest(BitcoinTestFramework):
         tx = CTransaction()
         tx.vin.append(CTxIn(COutPoint(self.utxo[0].sha256, self.utxo[0].n), b""))
         tx.vout.append(CTxOut(self.utxo[0].nValue-1000, CScript([OP_TRUE])))
-        tx.wit.vtxinwit.append(CTxinWitness())
+        tx.wit.vtxinwit.append(CTxInWitness())
         tx.wit.vtxinwit[0].scriptWitness.stack = [ b'a' ]
         tx.rehash()
 
@@ -914,7 +914,7 @@ class SegWitTest(BitcoinTestFramework):
         tx3 = CTransaction()
         tx3.vin.append(CTxIn(COutPoint(tx2.sha256, 0), b""))
         tx3.vout.append(CTxOut(tx2.vout[0].nValue-1000, CScript([OP_TRUE])))
-        tx3.wit.vtxinwit.append(CTxinWitness())
+        tx3.wit.vtxinwit.append(CTxInWitness())
         tx3.wit.vtxinwit[0].scriptWitness.stack = [CScript([CScriptNum(1)]), witness_program ]
         tx3.rehash()
 
@@ -1087,7 +1087,7 @@ class SegWitTest(BitcoinTestFramework):
         tx2 = CTransaction()
         tx2.vin = [CTxIn(COutPoint(tx.sha256, 0), b"")]
         tx2.vout = [CTxOut(tx.vout[0].nValue-1000, scriptPubKey)]
-        tx2.wit.vtxinwit.append(CTxinWitness())
+        tx2.wit.vtxinwit.append(CTxInWitness())
         tx2.wit.vtxinwit[0].scriptWitness.stack = [ witness_program ]
         tx2.rehash()
         # Gets accepted to test_node, because standardness of outputs isn't
@@ -1102,7 +1102,7 @@ class SegWitTest(BitcoinTestFramework):
         total_value = 0
         for i in temp_utxo:
             tx3.vin.append(CTxIn(COutPoint(i.sha256, i.n), b""))
-            tx3.wit.vtxinwit.append(CTxinWitness())
+            tx3.wit.vtxinwit.append(CTxInWitness())
             total_value += i.nValue
         tx3.wit.vtxinwit[-1].scriptWitness.stack = [witness_program]
         tx3.vout.append(CTxOut(total_value - 1000, CScript([OP_TRUE])))
@@ -1140,7 +1140,7 @@ class SegWitTest(BitcoinTestFramework):
         spend_tx = CTransaction()
         spend_tx.vin = [CTxIn(COutPoint(block.vtx[0].sha256, 0), b"")]
         spend_tx.vout = [CTxOut(block.vtx[0].vout[0].nValue, witness_program)]
-        spend_tx.wit.vtxinwit.append(CTxinWitness())
+        spend_tx.wit.vtxinwit.append(CTxInWitness())
         spend_tx.wit.vtxinwit[0].scriptWitness.stack = [ witness_program ]
         spend_tx.rehash()
 
@@ -1200,7 +1200,7 @@ class SegWitTest(BitcoinTestFramework):
                 tx = CTransaction()
                 tx.vin.append(CTxIn(COutPoint(prev_utxo.sha256, prev_utxo.n), b""))
                 tx.vout.append(CTxOut(prev_utxo.nValue - 1000, scriptPubKey))
-                tx.wit.vtxinwit.append(CTxinWitness())
+                tx.wit.vtxinwit.append(CTxInWitness())
                 # Too-large input value
                 sign_P2PK_witness_input(witness_program, tx, 0, hashtype, prev_utxo.nValue+1, key)
                 self.update_witness_block_with_transactions(block, [tx])
@@ -1233,7 +1233,7 @@ class SegWitTest(BitcoinTestFramework):
         split_value = prev_utxo.nValue // NUM_TESTS
         for i in range(NUM_TESTS):
             tx.vout.append(CTxOut(split_value, scriptPubKey))
-        tx.wit.vtxinwit.append(CTxinWitness())
+        tx.wit.vtxinwit.append(CTxInWitness())
         sign_P2PK_witness_input(witness_program, tx, 0, SIGHASH_ALL, prev_utxo.nValue, key)
         for i in range(NUM_TESTS):
             temp_utxos.append(UTXO(tx.sha256, i, split_value))
@@ -1255,7 +1255,7 @@ class SegWitTest(BitcoinTestFramework):
             total_value = 0
             for i in range(num_inputs):
                 tx.vin.append(CTxIn(COutPoint(temp_utxos[i].sha256, temp_utxos[i].n), b""))
-                tx.wit.vtxinwit.append(CTxinWitness())
+                tx.wit.vtxinwit.append(CTxInWitness())
                 total_value += temp_utxos[i].nValue
             split_value = total_value // num_outputs
             for i in range(num_outputs):
@@ -1295,7 +1295,7 @@ class SegWitTest(BitcoinTestFramework):
         tx = CTransaction()
         tx.vin.append(CTxIn(COutPoint(temp_utxos[0].sha256, temp_utxos[0].n), b""))
         tx.vout.append(CTxOut(temp_utxos[0].nValue, scriptPKH))
-        tx.wit.vtxinwit.append(CTxinWitness())
+        tx.wit.vtxinwit.append(CTxInWitness())
         sign_P2PK_witness_input(witness_program, tx, 0, SIGHASH_ALL, temp_utxos[0].nValue, key)
         tx2 = CTransaction()
         tx2.vin.append(CTxIn(COutPoint(tx.sha256, 0), b""))
@@ -1313,7 +1313,7 @@ class SegWitTest(BitcoinTestFramework):
 
         # Move the signature to the witness.
         block.vtx.pop()
-        tx2.wit.vtxinwit.append(CTxinWitness())
+        tx2.wit.vtxinwit.append(CTxInWitness())
         tx2.wit.vtxinwit[0].scriptWitness.stack = [signature, pubkey]
         tx2.vin[0].scriptSig = b""
         tx2.rehash()
@@ -1333,7 +1333,7 @@ class SegWitTest(BitcoinTestFramework):
             # the signatures as we go.
             tx.vin.append(CTxIn(COutPoint(i.sha256, i.n), b""))
             tx.vout.append(CTxOut(i.nValue, CScript([OP_TRUE])))
-            tx.wit.vtxinwit.append(CTxinWitness())
+            tx.wit.vtxinwit.append(CTxInWitness())
             sign_P2PK_witness_input(witness_program, tx, index, SIGHASH_SINGLE|SIGHASH_ANYONECANPAY, i.nValue, key)
             index += 1
         block = self.build_next_block()
@@ -1393,7 +1393,7 @@ class SegWitTest(BitcoinTestFramework):
         # segwit activates.
         spend_tx.vin[0].scriptSig = scriptSig
         spend_tx.rehash()
-        spend_tx.wit.vtxinwit.append(CTxinWitness())
+        spend_tx.wit.vtxinwit.append(CTxInWitness())
         spend_tx.wit.vtxinwit[0].scriptWitness.stack = [ b'a', witness_program ]
 
         # Verify mempool acceptance
@@ -1499,7 +1499,7 @@ class SegWitTest(BitcoinTestFramework):
         total_value = 0
         for i in range(outputs-1):
             tx2.vin.append(CTxIn(COutPoint(tx.sha256, i), b""))
-            tx2.wit.vtxinwit.append(CTxinWitness())
+            tx2.wit.vtxinwit.append(CTxInWitness())
             tx2.wit.vtxinwit[-1].scriptWitness.stack = [ witness_program ]
             total_value += tx.vout[i].nValue
         tx2.wit.vtxinwit[-1].scriptWitness.stack = [ witness_program_toomany ] 
@@ -1540,7 +1540,7 @@ class SegWitTest(BitcoinTestFramework):
         block_5 = self.build_next_block()
         tx2.vout.pop()
         tx2.vin.append(CTxIn(COutPoint(tx.sha256, outputs-1), b""))
-        tx2.wit.vtxinwit.append(CTxinWitness())
+        tx2.wit.vtxinwit.append(CTxInWitness())
         tx2.wit.vtxinwit[-1].scriptWitness.stack = [ witness_program_justright ]
         tx2.rehash()
         self.update_witness_block_with_transactions(block_5, [tx2])

--- a/qa/rpc-tests/test_framework/blocktools.py
+++ b/qa/rpc-tests/test_framework/blocktools.py
@@ -34,7 +34,7 @@ def add_witness_commitment(block, nonce=0):
     witness_root = block.calc_witness_merkle_root()
     witness_commitment = uint256_from_str(hash256(ser_uint256(witness_root)+ser_uint256(witness_nonce)))
     # witness_nonce should go to coinbase witness.
-    block.vtx[0].wit.vtxinwit = [CTxinWitness()]
+    block.vtx[0].wit.vtxinwit = [CTxInWitness()]
     block.vtx[0].wit.vtxinwit[0].scriptWitness.stack = [ser_uint256(witness_nonce)]
 
     # witness commitment is the last OP_RETURN output in coinbase

--- a/qa/rpc-tests/test_framework/mininode.py
+++ b/qa/rpc-tests/test_framework/mininode.py
@@ -419,7 +419,7 @@ class CScriptWitness(object):
         return True
 
 
-class CTxinWitness(object):
+class CTxInWitness(object):
     def __init__(self):
         self.scriptWitness = CScriptWitness()
 
@@ -497,7 +497,7 @@ class CTransaction(object):
         else:
             self.vout = deser_vector(f, CTxOut)
         if flags != 0:
-            self.wit.vtxinwit = [CTxinWitness()]*len(self.vin)
+            self.wit.vtxinwit = [CTxInWitness()]*len(self.vin)
             self.wit.deserialize(f)
         self.nLockTime = struct.unpack("<I", f.read(4))[0]
         self.sha256 = None
@@ -529,7 +529,7 @@ class CTransaction(object):
                 # vtxinwit must have the same length as vin
                 self.wit.vtxinwit = self.wit.vtxinwit[:len(self.vin)]
                 for i in range(len(self.wit.vtxinwit), len(self.vin)):
-                    self.wit.vtxinwit.append(CTxinWitness())
+                    self.wit.vtxinwit.append(CTxInWitness())
             r += self.wit.serialize()
         r += struct.pack("<I", self.nLockTime)
         return r

--- a/src/core_memusage.h
+++ b/src/core_memusage.h
@@ -33,13 +33,13 @@ static inline size_t RecursiveDynamicUsage(const CScriptWitness& scriptWit) {
     return mem;
 }
 
-static inline size_t RecursiveDynamicUsage(const CTxinWitness& txinwit) {
+static inline size_t RecursiveDynamicUsage(const CTxInWitness& txinwit) {
     return RecursiveDynamicUsage(txinwit.scriptWitness);
 }
 
 static inline size_t RecursiveDynamicUsage(const CTxWitness& txwit) {
     size_t mem = memusage::DynamicUsage(txwit.vtxinwit);
-    for (std::vector<CTxinWitness>::const_iterator it = txwit.vtxinwit.begin(); it != txwit.vtxinwit.end(); it++) {
+    for (std::vector<CTxInWitness>::const_iterator it = txwit.vtxinwit.begin(); it != txwit.vtxinwit.end(); it++) {
         mem += RecursiveDynamicUsage(*it);
     }
     return mem;

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -213,7 +213,7 @@ public:
     std::string ToString() const;
 };
 
-class CTxinWitness
+class CTxInWitness
 {
 public:
     CScriptWitness scriptWitness;
@@ -228,14 +228,14 @@ public:
 
     bool IsNull() const { return scriptWitness.IsNull(); }
 
-    CTxinWitness() { }
+    CTxInWitness() { }
 };
 
 class CTxWitness
 {
 public:
     /** In case vtxinwit is missing, all entries are treated as if they were empty CTxInWitnesses */
-    std::vector<CTxinWitness> vtxinwit;
+    std::vector<CTxInWitness> vtxinwit;
 
     ADD_SERIALIZE_METHODS;
 

--- a/src/test/sigopcount_tests.cpp
+++ b/src/test/sigopcount_tests.cpp
@@ -84,7 +84,7 @@ ScriptError VerifyWithFlag(const CTransaction& output, const CMutableTransaction
  * and witness such that spendingTx spends output zero of creationTx.
  * Also inserts creationTx's output into the coins view.
  */
-void BuildTxs(CMutableTransaction& spendingTx, CCoinsViewCache& coins, CMutableTransaction& creationTx, const CScript& scriptPubKey, const CScript& scriptSig, const CTxinWitness& witness)
+void BuildTxs(CMutableTransaction& spendingTx, CCoinsViewCache& coins, CMutableTransaction& creationTx, const CScript& scriptPubKey, const CScript& scriptSig, const CTxInWitness& witness)
 {
     creationTx.nVersion = 1;
     creationTx.vin.resize(1);
@@ -133,7 +133,7 @@ BOOST_AUTO_TEST_CASE(GetTxSigOpCost)
         // Do not use a valid signature to avoid using wallet operations.
         CScript scriptSig = CScript() << OP_0 << OP_0;
 
-        BuildTxs(spendingTx, coins, creationTx, scriptPubKey, scriptSig, CTxinWitness());
+        BuildTxs(spendingTx, coins, creationTx, scriptPubKey, scriptSig, CTxInWitness());
         // Legacy counting only includes signature operations in scriptSigs and scriptPubKeys
         // of a transaction and does not take the actual executed sig operations into account.
         // spendingTx in itself does not contain a signature operation.
@@ -151,7 +151,7 @@ BOOST_AUTO_TEST_CASE(GetTxSigOpCost)
         CScript scriptPubKey = GetScriptForDestination(CScriptID(redeemScript));
         CScript scriptSig = CScript() << OP_0 << OP_0 << ToByteVector(redeemScript);
 
-        BuildTxs(spendingTx, coins, creationTx, scriptPubKey, scriptSig, CTxinWitness());
+        BuildTxs(spendingTx, coins, creationTx, scriptPubKey, scriptSig, CTxInWitness());
         assert(GetTransactionSigOpCost(CTransaction(spendingTx), coins, flags) == 2 * WITNESS_SCALE_FACTOR);
         assert(VerifyWithFlag(creationTx, spendingTx, flags) == SCRIPT_ERR_CHECKMULTISIGVERIFY);
     }
@@ -161,7 +161,7 @@ BOOST_AUTO_TEST_CASE(GetTxSigOpCost)
         CScript p2pk = CScript() << ToByteVector(pubkey) << OP_CHECKSIG;
         CScript scriptPubKey = GetScriptForWitness(p2pk);
         CScript scriptSig = CScript();
-        CTxinWitness witness;
+        CTxInWitness witness;
         CScriptWitness scriptWitness;
         scriptWitness.stack.push_back(vector<unsigned char>(0));
         scriptWitness.stack.push_back(vector<unsigned char>(0));
@@ -193,7 +193,7 @@ BOOST_AUTO_TEST_CASE(GetTxSigOpCost)
         CScript scriptSig = GetScriptForWitness(p2pk);
         CScript scriptPubKey = GetScriptForDestination(CScriptID(scriptSig));
         scriptSig = CScript() << ToByteVector(scriptSig);
-        CTxinWitness witness;
+        CTxInWitness witness;
         CScriptWitness scriptWitness;
         scriptWitness.stack.push_back(vector<unsigned char>(0));
         scriptWitness.stack.push_back(vector<unsigned char>(0));
@@ -209,7 +209,7 @@ BOOST_AUTO_TEST_CASE(GetTxSigOpCost)
         CScript witnessScript = CScript() << 1 << ToByteVector(pubkey) << ToByteVector(pubkey) << 2 << OP_CHECKMULTISIGVERIFY;
         CScript scriptPubKey = GetScriptForWitness(witnessScript);
         CScript scriptSig = CScript();
-        CTxinWitness witness;
+        CTxInWitness witness;
         CScriptWitness scriptWitness;
         scriptWitness.stack.push_back(vector<unsigned char>(0));
         scriptWitness.stack.push_back(vector<unsigned char>(0));
@@ -228,7 +228,7 @@ BOOST_AUTO_TEST_CASE(GetTxSigOpCost)
         CScript redeemScript = GetScriptForWitness(witnessScript);
         CScript scriptPubKey = GetScriptForDestination(CScriptID(redeemScript));
         CScript scriptSig = CScript() << ToByteVector(redeemScript);
-        CTxinWitness witness;
+        CTxInWitness witness;
         CScriptWitness scriptWitness;
         scriptWitness.stack.push_back(vector<unsigned char>(0));
         scriptWitness.stack.push_back(vector<unsigned char>(0));


### PR DESCRIPTION
...in order to match the convention used elsewhere CTxIn (notice the capital 'I').

I'm mirroring these changes into python-bitcoinlib, which keeps all the same class names as Bitcoin Core.  This incongruity in naming stuck out to me.
