### PR TITLE
Fix mempool DoS vulnerability from malleated transactions

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1132,11 +1132,6 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState& state, const C
     if (tx.IsCoinBase())
         return state.DoS(100, false, REJECT_INVALID, "coinbase");
 
-    // Rather not work on nonstandard transactions (unless -testnet/-regtest)
-    string reason;
-    if (fRequireStandard && !IsStandardTx(tx, reason))
-        return state.DoS(0, false, REJECT_NONSTANDARD, reason);
-
     // Don't relay version 2 transactions until CSV is active, and we can be
     // sure that such transactions will be mined (unless we're on
     // -testnet/-regtest).
@@ -1149,6 +1144,11 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState& state, const C
     if (!GetBoolArg("-prematurewitness",false) && !tx.wit.IsNull() && !IsWitnessEnabled(chainActive.Tip(), Params().GetConsensus())) {
         return state.DoS(0, false, REJECT_NONSTANDARD, "no-witness-yet", true);
     }
+
+    // Rather not work on nonstandard transactions (unless -testnet/-regtest)
+    string reason;
+    if (fRequireStandard && !IsStandardTx(tx, reason))
+        return state.DoS(0, false, REJECT_NONSTANDARD, reason);
 
     // Only accept nLockTime-using transactions that can be mined in the next
     // block; we don't want our mempool filled up with transactions that can't


### PR DESCRIPTION
~~Fixes #8279~~

In addition to the problem highlighted in that issue, there's an additional, related problem in the sigops policy check.  Because witness sigops are counted without checking that the witness program matches the commitment in the scriptPubKey being spent, it's possible to change a transaction's witness to cause the sigops policy check to fail, without changing the txid.

Similarly, because the bytes-per-sigop check is affected by the size of the transaction including the witness, it's possible to even remove a witness and cause that sigops check to fail, again without changing the txid.

~~So this PR does the following:~~
- ~~Moves the IsStandard check to happen after checking for premature-witness.  (This should prevent the bug reported in #8279 from possibly affecting 0.13.0 nodes, which should never accept witness transactions.)~~
- ~~Changes IsStandard to set a bool which will indicate if the transaction could be malleated, so that the caller can act appropriately.~~
- ~~Reorders the checks in IsStandard so that the size check is performed last, and sets the could-be-malleated bool if the test fails.~~
- ~~Changes the error for sigops failure to always set the could-be-malleated flag.~~
- ~~Adds tests to p2p-segwit.py to catch both scenarios.~~
