### PR TITLE
[rpcwallet] Don't use floating point

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -564,8 +564,8 @@ UniValue getreceivedbyaddress(const UniValue& params, bool fHelp)
     if (!address.IsValid())
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid Bitcoin address");
     CScript scriptPubKey = GetScriptForDestination(address.Get());
-    if (!IsMine(*pwalletMain,scriptPubKey))
-        return (double)0.0;
+    if (!IsMine(*pwalletMain, scriptPubKey))
+        return ValueFromAmount(0);
 
     // Minimum confirmations
     int nMinDepth = 1;
@@ -643,7 +643,7 @@ UniValue getreceivedbyaccount(const UniValue& params, bool fHelp)
         }
     }
 
-    return (double)nAmount / (double)COIN;
+    return ValueFromAmount(nAmount);
 }
 
 


### PR DESCRIPTION
Follow up of 69d605f410c83235aa7b757445e7d0166fcfe2d9

<sub>fun fact:
The refactor in `getreceivedbyaddress` actually removes the feature to detect if `IsMine()` was false. You can check `getreceivedbyaddress` == 0 and isfloat(`getreceivedbyaddress`)
