### PR TITLE
[qa] wallet*.py: Check for salvagewallet regressions 

### DIFF
--- a/qa/rpc-tests/wallet-hd.py
+++ b/qa/rpc-tests/wallet-hd.py
@@ -38,6 +38,11 @@ class WalletHDTest(BitcoinTestFramework):
         non_hd_add = self.nodes[0].getnewaddress()
         self.nodes[1].importprivkey(self.nodes[0].dumpprivkey(non_hd_add))
 
+        # salvagewallet should be a noop
+        self.stop_node(1)
+        self.nodes[1] = start_node(1, self.options.tmpdir, self.node_args[1] + ['-salvagewallet'])
+        connect_nodes_bi(self.nodes, 0, 1)
+
         # This should be enough to keep the master key and the non-HD key 
         self.nodes[1].backupwallet(tmpdir + "hd.bak")
         #self.nodes[1].dumpwallet(tmpdir + "hd.dump")

--- a/qa/rpc-tests/wallet.py
+++ b/qa/rpc-tests/wallet.py
@@ -330,7 +330,12 @@ class WalletTest (BitcoinTestFramework):
             '-zapwallettxes=2',
             # disabled until issue is fixed: https://github.com/bitcoin/bitcoin/issues/7463
             # '-salvagewallet',
+            # enabled to check for regression: https://github.com/bitcoin/bitcoin/issues/2480
+            '-salvagewallet',
         ]
+        [self.nodes[i].encryptwallet(str(i)) for i in range(3)]
+        wait_bitcoinds()
+        self.nodes = start_nodes(3, self.options.tmpdir)
         for m in maintenance:
             print("check " + m)
             stop_nodes(self.nodes)


### PR DESCRIPTION
This checks for the bug reported in #2480 and #8300.
