### PR TITLE
Fix three 'comparison between signed and unsigned integer expressions' warnings.

### DIFF
--- a/src/leveldb/db/memtable.cc
+++ b/src/leveldb/db/memtable.cc
@@ -101,7 +101,7 @@ void MemTable::Add(SequenceNumber s, ValueType type,
   p += 8;
   p = EncodeVarint32(p, val_size);
   memcpy(p, value.data(), val_size);
-  assert((p + val_size) - buf == encoded_len);
+  assert(p + val_size == buf + encoded_len);
   table_.Insert(buf);
 }
 

--- a/src/leveldb/util/bloom.cc
+++ b/src/leveldb/util/bloom.cc
@@ -47,7 +47,7 @@ class BloomFilterPolicy : public FilterPolicy {
     dst->resize(init_size + bytes, 0);
     dst->push_back(static_cast<char>(k_));  // Remember # of probes in filter
     char* array = &(*dst)[init_size];
-    for (size_t i = 0; i < n; i++) {
+    for (int i = 0; i < n; i++) {
       // Use double-hashing to generate a sequence of hash values.
       // See analysis in [Kirsch,Mitzenmacher 2006].
       uint32_t h = BloomHash(keys[i]);

--- a/src/leveldb/util/logging.cc
+++ b/src/leveldb/util/logging.cc
@@ -52,7 +52,7 @@ bool ConsumeDecimalNumber(Slice* in, uint64_t* val) {
     char c = (*in)[0];
     if (c >= '0' && c <= '9') {
       ++digits;
-      const int delta = (c - '0');
+      const unsigned int delta = (c - '0');
       static const uint64_t kMaxUint64 = ~static_cast<uint64_t>(0);
       if (v > kMaxUint64/10 ||
           (v == kMaxUint64/10 && delta > kMaxUint64%10)) {


### PR DESCRIPTION
Building from the master branch I saw three warnings from the compiler:

```
leveldb/db/memtable.cc: In member function ‘void leveldb::MemTable::Add(leveldb::SequenceNumber, leveldb::ValueType, const leveldb::Slice&, const leveldb::Slice&)’:
leveldb/db/memtable.cc:104:31: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
   assert((p + val_size) - buf == encoded_len);
                               ^
leveldb/util/bloom.cc: In member function ‘virtual void leveldb::{anonymous}::BloomFilterPolicy::CreateFilter(const leveldb::Slice*, int, std::string*) const’:
leveldb/util/bloom.cc:50:26: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
     for (size_t i = 0; i < n; i++) {
                          ^
leveldb/util/logging.cc: In function ‘bool leveldb::ConsumeDecimalNumber(leveldb::Slice*, uint64_t*)’:
leveldb/util/logging.cc:58:40: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
           (v == kMaxUint64/10 && delta > kMaxUint64%10)) {
                                    ^
```
