### PR TITLE
TX fees and policy: fix relaypriority calculation error Issues #8334

### DIFF
--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -275,7 +275,7 @@ double CCoinsViewCache::GetPriority(const CTransaction &tx, int nHeight, CAmount
         assert(coins);
         if (!coins->IsAvailable(txin.prevout.n)) continue;
         if (coins->nHeight <= nHeight) {
-            dResult += coins->vout[txin.prevout.n].nValue * (nHeight-coins->nHeight);
+            dResult += (double)(coins->vout[txin.prevout.n].nValue) * (nHeight-coins->nHeight);
             inChainInputValue += coins->vout[txin.prevout.n].nValue;
         }
     }


### PR DESCRIPTION
CCoinsViewCache::GetPriority has an overflow bug that affects the relaypriority calculation. 
The way the arithmetic works in that function is

```
dResult += coins->vout[txin.prevout.n].nValue * (nHeight-coins->nHeight); 
the nValue variable type is int64_t, and the int64_t max value is 9223372036854775807
```

for example

```
nValue value  is 40000000000000
(nHeight->coins - nHeight )value is 300000 
40000000000000 * 300000 > 9223372036854775807 
```

so the dResult will be negative number!
and the AllowFree function will return False, and the high priority transaction with low fee will be reject by node with error insufficient priority!
