### PR TITLE
[qa] Solve trivial merge conflict in p2p-segwit.py

### DIFF
--- a/qa/rpc-tests/p2p-segwit.py
+++ b/qa/rpc-tests/p2p-segwit.py
@@ -306,7 +306,7 @@ class SegWitTest(BitcoinTestFramework):
         tx3 = CTransaction()
         tx3.vin.append(CTxIn(COutPoint(tx2.sha256, 0), CScript([p2sh_program])))
         tx3.vout.append(CTxOut(tx2.vout[0].nValue-1000, scriptPubKey))
-        tx3.wit.vtxinwit.append(CTxinWitness())
+        tx3.wit.vtxinwit.append(CTxInWitness())
         tx3.wit.vtxinwit[0].scriptWitness.stack = [b'a'*400000]
         tx3.rehash()
         self.std_node.test_transaction_acceptance(tx3, True, False, b'no-witness-yet')


### PR DESCRIPTION
Solve trivial merge conflict of ca40ef6029c1b4f2984e767b6c335dca6d637388 = Merge(4324bd2, 46c9620)
