### PR TITLE
Consensus: Use pindex for ISM check

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -445,12 +445,12 @@ bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::P
  *  By "context", we mean only the previous block headers, but not the UTXO
  *  set; UTXO-related validity checks are done in ConnectBlock(). */
 bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationState& state, const Consensus::Params& consensusParams, CBlockIndex* pindexPrev, int64_t nAdjustedTime);
-bool ContextualCheckBlock(const CBlock& block, CValidationState& state, CBlockIndex *pindexPrev);
+bool ContextualCheckBlock(const CBlock& block, CValidationState& state, CBlockIndex * const pindex);
 
 /** Apply the effects of this block (with given index) on the UTXO set represented by coins.
  *  Validity checks that depend on the UTXO set are also done; ConnectBlock()
  *  can fail if those validity checks fail (among other reasons). */
-bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pindex, CCoinsViewCache& coins,
+bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* const pindex, CCoinsViewCache& coins,
                   const CChainParams& chainparams, bool fJustCheck = false);
 
 /** Undo the effects of this block (with given index) on the UTXO set represented by coins.


### PR DESCRIPTION
This is the first step to later make a single "ConsensusFlags" type or enum.

When VerifyBlock and VerifyTx will be in libconsensus, the lib will probably still not have access to CBlockIndex. The user of libconsensus would be responsible for giving the ConsensusFlags. (as done now with EvalScript)

The ConsensusFlag calculation will thus be a function in Main and would depends only on ConsensusParams and the top CBlockIndex. Thanks to that, lots of consensus function currently in Main will not have any dependencies to CBlockIndex left.

Even if you don't really agree on this plan, this commit add a "const" constraint in the passed CBlockIndex, and make the codebase more coherent.

@jtimon, it will be usefull for your current libconsensus work as well.
