### PR TITLE
Introduce Consensus::GetFlags() and hide IsSuperMajority()

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -167,6 +167,7 @@ libbitcoin_server_a_SOURCES = \
   blockencodings.cpp \
   chain.cpp \
   checkpoints.cpp \
+  consensus/tx_verify.cpp \
   httprpc.cpp \
   httpserver.cpp \
   init.cpp \

--- a/src/consensus/consensus.h
+++ b/src/consensus/consensus.h
@@ -23,12 +23,6 @@ static const int64_t MAX_BLOCK_SIGOPS_COST = 80000;
 /** Coinbase transaction outputs can only be spent after this number of new blocks (network rule) */
 static const int COINBASE_MATURITY = 100;
 
-/** Flags for nSequence and nLockTime locks */
-enum {
-    /* Interpret sequence numbers as relative lock-time constraints. */
-    LOCKTIME_VERIFY_SEQUENCE = (1 << 0),
-};
-
 /** Transaction validation functions */
 
 namespace Consensus {

--- a/src/consensus/consensus.h
+++ b/src/consensus/consensus.h
@@ -8,6 +8,7 @@
 
 #include <stdint.h>
 
+class CCoinsViewCache;
 class CTransaction;
 class CValidationState;
 
@@ -45,7 +46,7 @@ bool CheckTxCoinbase(const CTransaction& tx, CValidationState& state, const int6
  * Fully verify a CTransaction.
  * @TODO this is incomplete, among other things, the scripts are not checked yet.
  */
-bool VerifyTx(const CTransaction& tx, CValidationState& state, const int64_t flags, const int64_t nHeight);
+bool VerifyTx(const CTransaction& tx, CValidationState& state, const int64_t flags, const int64_t nHeight, const CCoinsViewCache& inputs);
 
 } // namespace Consensus
 

--- a/src/consensus/consensus.h
+++ b/src/consensus/consensus.h
@@ -27,9 +27,6 @@ static const int COINBASE_MATURITY = 100;
 enum {
     /* Interpret sequence numbers as relative lock-time constraints. */
     LOCKTIME_VERIFY_SEQUENCE = (1 << 0),
-
-    /* Use GetMedianTimePast() instead of nTime for end point timestamp. */
-    LOCKTIME_MEDIAN_TIME_PAST = (1 << 1),
 };
 
 /** Transaction validation functions */
@@ -46,7 +43,7 @@ bool CheckTxCoinbase(const CTransaction& tx, CValidationState& state, const int6
  * Fully verify a CTransaction.
  * @TODO this is incomplete, among other things, the scripts are not checked yet.
  */
-bool VerifyTx(const CTransaction& tx, CValidationState& state, const int64_t flags, const int64_t nHeight, const CCoinsViewCache& inputs);
+bool VerifyTx(const CTransaction& tx, CValidationState& state, const int64_t flags, const int64_t nHeight, const int64_t nMedianTimePast, const int64_t nBlockTime, const CCoinsViewCache& inputs);
 
 } // namespace Consensus
 

--- a/src/consensus/consensus.h
+++ b/src/consensus/consensus.h
@@ -8,6 +8,9 @@
 
 #include <stdint.h>
 
+class CTransaction;
+class CValidationState;
+
 /** The maximum allowed size for a serialized block, in bytes (only for buffer size limits) */
 static const unsigned int MAX_BLOCK_SERIALIZED_SIZE = 4000000;
 /** The maximum allowed cost for a block, see BIP 141 (network rule) */
@@ -27,5 +30,23 @@ enum {
     /* Use GetMedianTimePast() instead of nTime for end point timestamp. */
     LOCKTIME_MEDIAN_TIME_PAST = (1 << 1),
 };
+
+/** Transaction validation functions */
+
+namespace Consensus {
+
+/**
+ * Checks specific to coinbase transactions.
+ * Preconditions: tx.IsCoinBase() is true.
+ */
+bool CheckTxCoinbase(const CTransaction& tx, CValidationState& state, const int64_t flags, const int64_t nHeight);
+
+/**
+ * Fully verify a CTransaction.
+ * @TODO this is incomplete, among other things, the scripts are not checked yet.
+ */
+bool VerifyTx(const CTransaction& tx, CValidationState& state, const int64_t flags, const int64_t nHeight);
+
+} // namespace Consensus
 
 #endif // BITCOIN_CONSENSUS_CONSENSUS_H

--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -1,0 +1,31 @@
+// Copyright (c) 2016 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "consensus.h"
+
+#include "primitives/transaction.h"
+#include "script/interpreter.h"
+#include "validation.h"
+
+bool Consensus::CheckTxCoinbase(const CTransaction& tx, CValidationState& state, const int64_t flags, const int64_t nHeight)
+{
+    // Enforce block.nVersion=2 rule that the coinbase starts with serialized block height
+    if (flags & TX_COINBASE_VERIFY_BIP34) {
+        const CScript coinbaseSigScript = tx.vin[0].scriptSig;
+        CScript expect = CScript() << nHeight;
+        if (coinbaseSigScript.size() < expect.size() ||
+            !std::equal(expect.begin(), expect.end(), coinbaseSigScript.begin()))
+            return state.DoS(100, false, REJECT_INVALID, "bad-cb-height", false, "block height mismatch in coinbase");
+    }
+
+    return true;
+}
+
+bool Consensus::VerifyTx(const CTransaction& tx, CValidationState& state, const int64_t flags, const int64_t nHeight)
+{
+    if (tx.IsCoinBase())
+        return CheckTxCoinbase(tx, state, flags, nHeight);
+
+    return true;
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3447,11 +3447,8 @@ bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationState& sta
     if (block.GetBlockTime() > nAdjustedTime + 2 * 60 * 60)
         return state.Invalid(false, REJECT_INVALID, "time-too-new", "block timestamp too far in the future");
 
-    // Reject outdated version blocks when 95% (75% on testnet) of the network has upgraded:
-    for (int32_t version = 2; version < 5; ++version) // check for version 2, 3 and 4 upgrades
-        if (block.nVersion < version && IsSuperMajority(version, pindexPrev, consensusParams.nMajorityRejectBlockOutdated, consensusParams))
-            return state.Invalid(false, REJECT_OBSOLETE, strprintf("bad-version(0x%08x)", version - 1),
-                                 strprintf("rejected nVersion=0x%08x block", version - 1));
+    if (!VerifyBlockVersion(block.nVersion, state, consensusParams, pindexPrev))
+        return false;
 
     return true;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2325,13 +2325,6 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
 
     unsigned int flags = Consensus::GetFlags(block, chainparams.GetConsensus(), pindex, versionbitscache);
 
-    // TODO unify all consensus flags, see PR #7779
-    // Start enforcing BIP68 (sequence locks) and BIP112 (CHECKSEQUENCEVERIFY) using versionbits logic.
-    int nLockTimeFlags = 0;
-    if (VersionBitsState(pindex->pprev, chainparams.GetConsensus(), Consensus::DEPLOYMENT_CSV, versionbitscache) == THRESHOLD_ACTIVE) {
-        nLockTimeFlags |= LOCKTIME_VERIFY_SEQUENCE;
-    }
-
     int64_t nTime2 = GetTimeMicros(); nTimeForks += nTime2 - nTime1;
     LogPrint("bench", "    - Fork checks: %.2fms [%.2fs]\n", 0.001 * (nTime2 - nTime1), nTimeForks * 0.000001);
 
@@ -2380,7 +2373,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
                 }
             }
 
-            if (!SequenceLocks(tx, nLockTimeFlags, &prevheights, *pindex)) {
+            if (!SequenceLocks(tx, flags, &prevheights, *pindex)) {
                 return state.DoS(100, error("%s: contains a non-BIP68-final transaction", __func__),
                                  REJECT_INVALID, "bad-txns-nonfinal");
             }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2325,41 +2325,6 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
 
     unsigned int flags = Consensus::GetFlags(block, chainparams.GetConsensus(), pindex, versionbitscache);
 
-    // Do not allow blocks that contain transactions which 'overwrite' older transactions,
-    // unless those are already completely spent.
-    // If such overwrites are allowed, coinbases and transactions depending upon those
-    // can be duplicated to remove the ability to spend the first instance -- even after
-    // being sent to another address.
-    // See BIP30 and http://r6.ca/blog/20120206T005236Z.html for more information.
-    // This logic is not necessary for memory pool transactions, as AcceptToMemoryPool
-    // already refuses previously-known transaction ids entirely.
-    // This rule was originally applied to all blocks with a timestamp after March 15, 2012, 0:00 UTC.
-    // Now that the whole chain is irreversibly beyond that time it is applied to all blocks except the
-    // two in the chain that violate it. This prevents exploiting the issue against nodes during their
-    // initial block download.
-    bool fEnforceBIP30 = (!pindex->phashBlock) || // Enforce on CreateNewBlock invocations which don't have a hash.
-                          !((pindex->nHeight==91842 && pindex->GetBlockHash() == uint256S("0x00000000000a4d0a398161ffc163c503763b1f4360639393e0e4c8e300e0caec")) ||
-                           (pindex->nHeight==91880 && pindex->GetBlockHash() == uint256S("0x00000000000743f190a18c5577a3c2d2a1f610ae9601ac046a38084ccb7cd721")));
-
-    // Once BIP34 activated it was not possible to create new duplicate coinbases and thus other than starting
-    // with the 2 existing duplicate coinbase pairs, not possible to create overwriting txs.  But by the
-    // time BIP34 activated, in each of the existing pairs the duplicate coinbase had overwritten the first
-    // before the first had been spent.  Since those coinbases are sufficiently buried its no longer possible to create further
-    // duplicate transactions descending from the known pairs either.
-    // If we're on the known chain at height greater than where BIP34 activated, we can save the db accesses needed for the BIP30 check.
-    CBlockIndex *pindexBIP34height = pindex->pprev->GetAncestor(chainparams.GetConsensus().BIP34Height);
-    //Only continue to enforce if we're below BIP34 activation height or the block hash at that height doesn't correspond.
-    fEnforceBIP30 = fEnforceBIP30 && (!pindexBIP34height || !(pindexBIP34height->GetBlockHash() == chainparams.GetConsensus().BIP34Hash));
-
-    if (fEnforceBIP30) {
-        BOOST_FOREACH(const CTransaction& tx, block.vtx) {
-            const CCoins* coins = view.AccessCoins(tx.GetHash());
-            if (coins && !coins->IsPruned())
-                return state.DoS(100, error("ConnectBlock(): tried to overwrite transaction"),
-                                 REJECT_INVALID, "bad-txns-BIP30");
-        }
-    }
-
     // TODO unify all consensus flags, see PR #7779
     // Start enforcing BIP68 (sequence locks) and BIP112 (CHECKSEQUENCEVERIFY) using versionbits logic.
     int nLockTimeFlags = 0;
@@ -2387,7 +2352,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     for (unsigned int i = 0; i < block.vtx.size(); i++)
     {
         const CTransaction &tx = block.vtx[i];
-        if (!Consensus::VerifyTx(tx, state, flags, nHeight))
+        if (!Consensus::VerifyTx(tx, state, flags, nHeight, view))
             return error("%s: Consensus::VerifyTx: %s, %s", __func__, tx.GetHash().ToString(), FormatStateMessage(state));
 
         if (!tx.IsCoinBase())

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -107,11 +107,6 @@ map<uint256, COrphanTx> mapOrphanTransactions GUARDED_BY(cs_main);
 map<COutPoint, set<map<uint256, COrphanTx>::iterator, IteratorComparator>> mapOrphanTransactionsByPrev GUARDED_BY(cs_main);
 void EraseOrphansFor(NodeId peer) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
-/**
- * Returns true if there are nRequired or more blocks of minVersion or above
- * in the last Consensus::Params::nMajorityWindow blocks, starting at pstart and going backwards.
- */
-static bool IsSuperMajority(int minVersion, const CBlockIndex* pstart, unsigned nRequired, const Consensus::Params& consensusParams);
 static void CheckBlockIndex(const Consensus::Params& consensusParams);
 
 /** Constant stuff for coinbase transactions we create: */
@@ -3718,19 +3713,6 @@ static bool AcceptBlock(const CBlock& block, CValidationState& state, const CCha
 
     return true;
 }
-
-static bool IsSuperMajority(int minVersion, const CBlockIndex* pstart, unsigned nRequired, const Consensus::Params& consensusParams)
-{
-    unsigned int nFound = 0;
-    for (int i = 0; i < consensusParams.nMajorityWindow && nFound < nRequired && pstart != NULL; i++)
-    {
-        if (pstart->nVersion >= minVersion)
-            ++nFound;
-        pstart = pstart->pprev;
-    }
-    return (nFound >= nRequired);
-}
-
 
 bool ProcessNewBlock(CValidationState& state, const CChainParams& chainparams, CNode* pfrom, const CBlock* pblock, bool fForceProcessing, const CDiskBlockPos* dbp)
 {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2352,7 +2352,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     for (unsigned int i = 0; i < block.vtx.size(); i++)
     {
         const CTransaction &tx = block.vtx[i];
-        if (!Consensus::VerifyTx(tx, state, flags, nHeight, view))
+        if (!Consensus::VerifyTx(tx, state, flags, nHeight, pindex->GetMedianTimePast(), block.GetBlockTime(), view))
             return error("%s: Consensus::VerifyTx: %s, %s", __func__, tx.GetHash().ToString(), FormatStateMessage(state));
 
         if (!tx.IsCoinBase())
@@ -3465,25 +3465,7 @@ bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationState& sta
 
 bool ContextualCheckBlock(const CBlock& block, CValidationState& state, CBlockIndex * const pindexPrev)
 {
-    const int nHeight = pindexPrev == NULL ? 0 : pindexPrev->nHeight + 1;
     const Consensus::Params& consensusParams = Params().GetConsensus();
-
-    // Start enforcing BIP113 (Median Time Past) using versionbits logic.
-    int nLockTimeFlags = 0;
-    if (VersionBitsState(pindexPrev, consensusParams, Consensus::DEPLOYMENT_CSV, versionbitscache) == THRESHOLD_ACTIVE) {
-        nLockTimeFlags |= LOCKTIME_MEDIAN_TIME_PAST;
-    }
-
-    int64_t nLockTimeCutoff = (nLockTimeFlags & LOCKTIME_MEDIAN_TIME_PAST)
-                              ? pindexPrev->GetMedianTimePast()
-                              : block.GetBlockTime();
-
-    // Check that all transactions are finalized
-    BOOST_FOREACH(const CTransaction& tx, block.vtx) {
-        if (!IsFinalTx(tx, nHeight, nLockTimeCutoff)) {
-            return state.DoS(10, false, REJECT_INVALID, "bad-txns-nonfinal", false, "non-final transaction");
-        }
-    }
 
     // Validation for witness commitments.
     // * We compute the witness hash (which is the hash including witnesses) of all the block's transactions, except the

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -97,6 +97,9 @@ enum
 
     /* BIP34: Verify coinbase transactions commit to the current height. */
     TX_COINBASE_VERIFY_BIP34 = (1U << 13),
+
+    /* BIP30: See Consensus::GetFlags(), Consensus::VerifyTx() and http://r6.ca/blog/20120206T005236Z.html for more information */
+    TX_VERIFY_BIP30 = (1U << 14),
 };
 
 bool CheckSignatureEncoding(const std::vector<unsigned char> &vchSig, unsigned int flags, ScriptError* serror);

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -95,11 +95,14 @@ enum
     //
     SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_WITNESS_PROGRAM = (1U << 12),
 
-    /* BIP34: Verify coinbase transactions commit to the current height. */
-    TX_COINBASE_VERIFY_BIP34 = (1U << 13),
-
     /* BIP30: See Consensus::GetFlags(), Consensus::VerifyTx() and http://r6.ca/blog/20120206T005236Z.html for more information */
-    TX_VERIFY_BIP30 = (1U << 14),
+    TX_VERIFY_BIP30 = (1U << 13),
+
+    /* BIP34: Verify coinbase transactions commit to the current height. */
+    TX_COINBASE_VERIFY_BIP34 = (1U << 14),
+
+    /* BIP113: Use GetMedianTimePast() instead of nTime for end point timestamp. */
+    LOCKTIME_MEDIAN_TIME_PAST = (1U << 15),
 };
 
 bool CheckSignatureEncoding(const std::vector<unsigned char> &vchSig, unsigned int flags, ScriptError* serror);

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -94,6 +94,9 @@ enum
     // Making v1-v16 witness program non-standard
     //
     SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_WITNESS_PROGRAM = (1U << 12),
+
+    /* BIP34: Verify coinbase transactions commit to the current height. */
+    TX_COINBASE_VERIFY_BIP34 = (1U << 13),
 };
 
 bool CheckSignatureEncoding(const std::vector<unsigned char> &vchSig, unsigned int flags, ScriptError* serror);

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -103,6 +103,9 @@ enum
 
     /* BIP113: Use GetMedianTimePast() instead of nTime for end point timestamp. */
     LOCKTIME_MEDIAN_TIME_PAST = (1U << 15),
+
+    /* BIP68: Interpret sequence numbers as relative lock-time constraints. */
+    LOCKTIME_VERIFY_SEQUENCE = (1 << 16),
 };
 
 bool CheckSignatureEncoding(const std::vector<unsigned char> &vchSig, unsigned int flags, ScriptError* serror);

--- a/src/versionbits.cpp
+++ b/src/versionbits.cpp
@@ -229,7 +229,7 @@ int64_t Consensus::GetFlags(const CBlock& block, const Consensus::Params& consen
 
     // Start enforcing BIP68 (sequence locks) and BIP112 (CHECKSEQUENCEVERIFY) using versionbits logic.
     if (VersionBitsState(pindexPrev->pprev, consensusParams, Consensus::DEPLOYMENT_CSV, cache) == THRESHOLD_ACTIVE) {
-        flags |= SCRIPT_VERIFY_CHECKSEQUENCEVERIFY;
+        flags |= (SCRIPT_VERIFY_CHECKSEQUENCEVERIFY & LOCKTIME_VERIFY_SEQUENCE);
     }
 
     // Start enforcing WITNESS rules using versionbits logic.

--- a/src/versionbits.cpp
+++ b/src/versionbits.cpp
@@ -7,6 +7,9 @@
 #include "consensus/params.h"
 #include "script/interpreter.h"
 
+// TODO remove the following dependencies
+#include "chain.h"
+
 const struct BIP9DeploymentInfo VersionBitsDeploymentInfo[Consensus::MAX_VERSION_BITS_DEPLOYMENTS] = {
     {
         /*.name =*/ "testdummy",
@@ -173,6 +176,35 @@ int64_t Consensus::GetFlags(const CBlock& block, const Consensus::Params& consen
     bool fStrictPayToScriptHash = (pindexPrev->GetBlockTime() >= nBIP16SwitchTime);
 
     int64_t flags = fStrictPayToScriptHash ? SCRIPT_VERIFY_P2SH : SCRIPT_VERIFY_NONE;
+
+    // Do not allow blocks that contain transactions which 'overwrite' older transactions,
+    // unless those are already completely spent.
+    // If such overwrites are allowed, coinbases and transactions depending upon those
+    // can be duplicated to remove the ability to spend the first instance -- even after
+    // being sent to another address.
+    // See BIP30 and http://r6.ca/blog/20120206T005236Z.html for more information.
+    // This logic is not necessary for memory pool transactions, as AcceptToMemoryPool
+    // already refuses previously-known transaction ids entirely.
+    // This rule was originally applied to all blocks with a timestamp after March 15, 2012, 0:00 UTC.
+    // Now that the whole chain is irreversibly beyond that time it is applied to all blocks except the
+    // two in the chain that violate it. This prevents exploiting the issue against nodes during their
+    // initial block download.
+    bool fEnforceBIP30 = (!pindexPrev->phashBlock) || // Enforce on CreateNewBlock invocations which don't have a hash.
+                          !((pindexPrev->nHeight==91842 && pindexPrev->GetBlockHash() == uint256S("0x00000000000a4d0a398161ffc163c503763b1f4360639393e0e4c8e300e0caec")) ||
+                           (pindexPrev->nHeight==91880 && pindexPrev->GetBlockHash() == uint256S("0x00000000000743f190a18c5577a3c2d2a1f610ae9601ac046a38084ccb7cd721")));
+
+    // Once BIP34 activated it was not possible to create new duplicate coinbases and thus other than starting
+    // with the 2 existing duplicate coinbase pairs, not possible to create overwriting txs.  But by the
+    // time BIP34 activated, in each of the existing pairs the duplicate coinbase had overwritten the first
+    // before the first had been spent.  Since those coinbases are sufficiently buried its no longer possible to create further
+    // duplicate transactions descending from the known pairs either.
+    // If we're on the known chain at height greater than where BIP34 activated, we can save the db accesses needed for the BIP30 check.
+    if (fEnforceBIP30) {
+        CBlockIndex *pindexBIP34height = pindexPrev->pprev->GetAncestor(consensusParams.BIP34Height);
+        //Only continue to enforce if we're below BIP34 activation height or the block hash at that height doesn't correspond.
+        if ((fEnforceBIP30) && (!pindexBIP34height || !(pindexBIP34height->GetBlockHash() == consensusParams.BIP34Hash)))
+            flags |= TX_VERIFY_BIP30;
+    }
 
     // Start enforcing height in coinbase (BIP34), for block.nVersion=2 blocks,
     // when 75% of the network has upgraded:

--- a/src/versionbits.cpp
+++ b/src/versionbits.cpp
@@ -223,6 +223,10 @@ int64_t Consensus::GetFlags(const CBlock& block, const Consensus::Params& consen
         flags |= SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY;
     }
 
+    // Start enforcing BIP113 (Median Time Past) using versionbits logic.
+    if (VersionBitsState(pindexPrev->pprev, consensusParams, Consensus::DEPLOYMENT_CSV, cache) == THRESHOLD_ACTIVE)
+        flags |= LOCKTIME_MEDIAN_TIME_PAST;
+
     // Start enforcing BIP68 (sequence locks) and BIP112 (CHECKSEQUENCEVERIFY) using versionbits logic.
     if (VersionBitsState(pindexPrev->pprev, consensusParams, Consensus::DEPLOYMENT_CSV, cache) == THRESHOLD_ACTIVE) {
         flags |= SCRIPT_VERIFY_CHECKSEQUENCEVERIFY;

--- a/src/versionbits.cpp
+++ b/src/versionbits.cpp
@@ -148,3 +148,19 @@ void VersionBitsCache::Clear()
         caches[d].clear();
     }
 }
+
+/**
+ * Returns true if there are nRequired or more blocks of minVersion or above
+ * in the last Consensus::Params::nMajorityWindow blocks, starting at pstart and going backwards.
+ */
+bool IsSuperMajority(int minVersion, const CBlockIndex* pstart, unsigned nRequired, const Consensus::Params& consensusParams)
+{
+    unsigned int nFound = 0;
+    for (int i = 0; i < consensusParams.nMajorityWindow && nFound < nRequired && pstart != NULL; i++)
+    {
+        if (pstart->nVersion >= minVersion)
+            ++nFound;
+        pstart = pstart->pprev;
+    }
+    return (nFound >= nRequired);
+}

--- a/src/versionbits.cpp
+++ b/src/versionbits.cpp
@@ -174,6 +174,11 @@ int64_t Consensus::GetFlags(const CBlock& block, const Consensus::Params& consen
 
     int64_t flags = fStrictPayToScriptHash ? SCRIPT_VERIFY_P2SH : SCRIPT_VERIFY_NONE;
 
+    // Start enforcing height in coinbase (BIP34), for block.nVersion=2 blocks,
+    // when 75% of the network has upgraded:
+    if (block.nVersion >= 2 && IsSuperMajority(2, pindexPrev->pprev, consensusParams.nMajorityEnforceBlockUpgrade, consensusParams))
+        flags |= TX_COINBASE_VERIFY_BIP34;
+    
     // Start enforcing the DERSIG (BIP66) rules, for block.nVersion=3 blocks,
     // when 75% of the network has upgraded:
     if (block.nVersion >= 3 && IsSuperMajority(3, pindexPrev->pprev, consensusParams.nMajorityEnforceBlockUpgrade, consensusParams)) {

--- a/src/versionbits.cpp
+++ b/src/versionbits.cpp
@@ -213,29 +213,25 @@ int64_t Consensus::GetFlags(const CBlock& block, const Consensus::Params& consen
     
     // Start enforcing the DERSIG (BIP66) rules, for block.nVersion=3 blocks,
     // when 75% of the network has upgraded:
-    if (block.nVersion >= 3 && IsSuperMajority(3, pindexPrev->pprev, consensusParams.nMajorityEnforceBlockUpgrade, consensusParams)) {
+    if (block.nVersion >= 3 && IsSuperMajority(3, pindexPrev->pprev, consensusParams.nMajorityEnforceBlockUpgrade, consensusParams))
         flags |= SCRIPT_VERIFY_DERSIG;
-    }
 
     // Start enforcing CHECKLOCKTIMEVERIFY, (BIP65) for block.nVersion=4
     // blocks, when 75% of the network has upgraded:
-    if (block.nVersion >= 4 && IsSuperMajority(4, pindexPrev->pprev, consensusParams.nMajorityEnforceBlockUpgrade, consensusParams)) {
+    if (block.nVersion >= 4 && IsSuperMajority(4, pindexPrev->pprev, consensusParams.nMajorityEnforceBlockUpgrade, consensusParams))
         flags |= SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY;
-    }
 
     // Start enforcing BIP113 (Median Time Past) using versionbits logic.
     if (VersionBitsState(pindexPrev->pprev, consensusParams, Consensus::DEPLOYMENT_CSV, cache) == THRESHOLD_ACTIVE)
         flags |= LOCKTIME_MEDIAN_TIME_PAST;
 
     // Start enforcing BIP68 (sequence locks) and BIP112 (CHECKSEQUENCEVERIFY) using versionbits logic.
-    if (VersionBitsState(pindexPrev->pprev, consensusParams, Consensus::DEPLOYMENT_CSV, cache) == THRESHOLD_ACTIVE) {
+    if (VersionBitsState(pindexPrev->pprev, consensusParams, Consensus::DEPLOYMENT_CSV, cache) == THRESHOLD_ACTIVE)
         flags |= (SCRIPT_VERIFY_CHECKSEQUENCEVERIFY & LOCKTIME_VERIFY_SEQUENCE);
-    }
 
     // Start enforcing WITNESS rules using versionbits logic.
-    if (VersionBitsState(pindexPrev->pprev, consensusParams, Consensus::DEPLOYMENT_SEGWIT, cache) == THRESHOLD_ACTIVE) {
+    if (VersionBitsState(pindexPrev->pprev, consensusParams, Consensus::DEPLOYMENT_SEGWIT, cache) == THRESHOLD_ACTIVE)
         flags |= SCRIPT_VERIFY_WITNESS;
-    }
 
     return flags;
 }

--- a/src/versionbits.h
+++ b/src/versionbits.h
@@ -8,6 +8,8 @@
 #include "chain.h"
 #include <map>
 
+class CValidationState;
+
 /** What block version to use for new blocks (pre versionbits) */
 static const int32_t VERSIONBITS_LAST_OLD_BLOCK_VERSION = 4;
 /** What bits to set in version for versionbits blocks */
@@ -75,7 +77,9 @@ int64_t GetFlags(const CBlock& block, const Consensus::Params& consensusParams, 
 
 } // namespace Consensus
 
-// TODO: make static again
-bool IsSuperMajority(int minVersion, const CBlockIndex* pstart, unsigned nRequired, const Consensus::Params& consensusParams);
+/**
+ * Called from ContextualCheckBlockHeader() to reject outdated version blocks.
+ */
+bool VerifyBlockVersion(int32_t nBlockVersion, CValidationState& state, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev);
 
 #endif

--- a/src/versionbits.h
+++ b/src/versionbits.h
@@ -65,4 +65,7 @@ struct VersionBitsCache
 ThresholdState VersionBitsState(const CBlockIndex* pindexPrev, const Consensus::Params& params, Consensus::DeploymentPos pos, VersionBitsCache& cache);
 uint32_t VersionBitsMask(const Consensus::Params& params, Consensus::DeploymentPos pos);
 
+// TODO: make static again
+bool IsSuperMajority(int minVersion, const CBlockIndex* pstart, unsigned nRequired, const Consensus::Params& consensusParams);
+
 #endif

--- a/src/versionbits.h
+++ b/src/versionbits.h
@@ -65,6 +65,16 @@ struct VersionBitsCache
 ThresholdState VersionBitsState(const CBlockIndex* pindexPrev, const Consensus::Params& params, Consensus::DeploymentPos pos, VersionBitsCache& cache);
 uint32_t VersionBitsMask(const Consensus::Params& params, Consensus::DeploymentPos pos);
 
+namespace Consensus {
+
+/**
+ * Get loosely defined struct containing all the consensus flags.
+ * @TODO incomplete, not all consensus flags yet.
+ */
+int64_t GetFlags(const CBlock& block, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev, VersionBitsCache& cache);
+
+} // namespace Consensus
+
 // TODO: make static again
 bool IsSuperMajority(int minVersion, const CBlockIndex* pstart, unsigned nRequired, const Consensus::Params& consensusParams);
 


### PR DESCRIPTION
Shares the first commit with #8337
Encapsulate all the consensus activation checks there by unifying script and locktime consensus flags.

It also introduces an incomplete Consensus::VerifyTx to be exposed once completed.
I'm in the process of completing Consensus::VerifyTx() again in  https://github.com/jtimon/bitcoin/commits/0.12.99-consensus (or you can look at an older branch in https://github.com/jtimon/bitcoin/commits/jt ).

If this is too much for a single PR, I can create another one with a subset of the commits to merge that first.
If unifying the script and locktime flags still feels like a layer violation to @sipa (ie versionbits doesn't need to know about script/interpreter.h), maybe moving all the flags to consensus/flags.h before or after this would help.

This introduces a circular dependency, but can be trivially solved merging #8329 before or after doing this.
Ping @NicolasDorier @kanzure 
