### PR TITLE
Trivial: Segwit: Don't call IsWitnessEnabled from ContextualCheckBlock

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3564,7 +3564,7 @@ bool ContextualCheckBlock(const CBlock& block, CValidationState& state, CBlockIn
     //   {0xaa, 0x21, 0xa9, 0xed}, and the following 32 bytes are SHA256^2(witness root, witness nonce). In case there are
     //   multiple, the last one is used.
     bool fHaveWitness = false;
-    if (IsWitnessEnabled(pindexPrev, consensusParams)) {
+    if (VersionBitsState(pindexPrev, consensusParams, Consensus::DEPLOYMENT_SEGWIT, versionbitscache) == THRESHOLD_ACTIVE) {
         int commitpos = GetWitnessCommitmentIndex(block);
         if (commitpos != -1) {
             bool malleated = false;


### PR DESCRIPTION
IsWitnessEnabled() should not be called from libconsensus code, only from outside what's already encapsulated.
The 3 callers already `AssertLockHeld(cs_main);`, this is my grep:

```
./src/main.h:448:bool ContextualCheckBlock(const CBlock& block, CValidationState& state, CBlockIndex *pindexPrev);
./src/main.cpp:3525:bool ContextualCheckBlock(const CBlock& block, CValidationState& state, CBlockIndex * const pindexPrev)
./src/main.cpp:3602:        return state.DoS(100, error("ContextualCheckBlock(): cost limit failed"), REJECT_INVALID, "bad-blk-cost");
./src/main.cpp:3689:    if ((!CheckBlock(block, state, chainparams.GetConsensus(), GetAdjustedTime())) || !ContextualCheckBlock(block, state, pindex->pprev)) {
./src/main.cpp:3780:    if (!ContextualCheckBlock(block, state, pindexPrev))
```

I could have said this during segwit review instead of now, sorry @sipa.
