### PR TITLE
mining: Rename `-blockmaxcost` to `-blockmaxweight`

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -452,7 +452,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-mempoolreplacement", strprintf(_("Enable transaction replacement in the memory pool (default: %u)"), DEFAULT_ENABLE_REPLACEMENT));
 
     strUsage += HelpMessageGroup(_("Block creation options:"));
-    strUsage += HelpMessageOpt("-blockmaxcost=<n>", strprintf(_("Set maximum block cost (default: %d)"), DEFAULT_BLOCK_MAX_COST));
+    strUsage += HelpMessageOpt("-blockmaxweight=<n>", strprintf(_("Set maximum block weight as defined in BIP141 (default: %d)"), DEFAULT_BLOCK_MAX_COST));
     strUsage += HelpMessageOpt("-blockmaxsize=<n>", strprintf(_("Set maximum block size in bytes (default: %d)"), DEFAULT_BLOCK_MAX_SIZE));
     strUsage += HelpMessageOpt("-blockprioritysize=<n>", strprintf(_("Set maximum size of high-priority/low-fee transactions in bytes (default: %d)"), DEFAULT_BLOCK_PRIORITY_SIZE));
     if (showDebug)

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -77,14 +77,14 @@ BlockAssembler::BlockAssembler(const CChainParams& _chainparams)
     : chainparams(_chainparams)
 {
     // Block resource limits
-    // If neither -blockmaxsize or -blockmaxcost is given, limit to DEFAULT_BLOCK_MAX_*
+    // If neither -blockmaxsize or -blockmaxweight is given, limit to DEFAULT_BLOCK_MAX_*
     // If only one is given, only restrict the specified resource.
     // If both are given, restrict both.
     nBlockMaxCost = DEFAULT_BLOCK_MAX_COST;
     nBlockMaxSize = DEFAULT_BLOCK_MAX_SIZE;
     bool fCostSet = false;
-    if (mapArgs.count("-blockmaxcost")) {
-        nBlockMaxCost = GetArg("-blockmaxcost", DEFAULT_BLOCK_MAX_COST);
+    if (mapArgs.count("-blockmaxweight")) {
+        nBlockMaxCost = GetArg("-blockmaxweight", DEFAULT_BLOCK_MAX_COST);
         nBlockMaxSize = MAX_BLOCK_SERIALIZED_SIZE;
         fCostSet = true;
     }

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -18,7 +18,7 @@ class CCoinsViewCache;
 static const unsigned int DEFAULT_BLOCK_MAX_SIZE = 750000;
 /** Default for -blockprioritysize, maximum space for zero/low-fee transactions **/
 static const unsigned int DEFAULT_BLOCK_PRIORITY_SIZE = 0;
-/** Default for -blockmaxcost, which control the range of block costs the mining code will create **/
+/** Default for -blockmaxweight, which controls the range of block costs the mining code will create **/
 static const unsigned int DEFAULT_BLOCK_MAX_COST = 3000000;
 /** The maximum size for transactions we're willing to relay/mine */
 static const unsigned int MAX_STANDARD_TX_COST = 400000;


### PR DESCRIPTION
As discussed in the 2016-07-14 meeting,
http://www.erisian.com.au/meetbot/bitcoin-core-dev/2016/bitcoin-core-dev.2016-07-14-19.00.html

Needs an analogous change to BIP141: https://github.com/bitcoin/bips/pull/420
