### PR TITLE
Wallet: Minimum output value depends on fee instead of minTxRelayFee

### DIFF
--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -456,6 +456,7 @@ void CoinControlDialog::updateLabels(WalletModel *model, QDialog* dialog)
     if (!model)
         return;
 
+    CFeeRate dustRate = CWallet::GetDustRate();
     // nPayAmount
     CAmount nPayAmount = 0;
     bool fDust = false;
@@ -468,7 +469,7 @@ void CoinControlDialog::updateLabels(WalletModel *model, QDialog* dialog)
         {
             CTxOut txout(amount, (CScript)std::vector<unsigned char>(24, 0));
             txDummy.vout.push_back(txout);
-            if (txout.IsDust(::minRelayTxFee))
+            if (txout.IsDust(dustRate))
                fDust = true;
         }
     }
@@ -585,10 +586,10 @@ void CoinControlDialog::updateLabels(WalletModel *model, QDialog* dialog)
             if (nChange > 0 && nChange < MIN_CHANGE)
             {
                 CTxOut txout(nChange, (CScript)std::vector<unsigned char>(24, 0));
-                if (txout.IsDust(::minRelayTxFee))
+                if (txout.IsDust(dustRate))
                 {
                     if (CoinControlDialog::fSubtractFeeFromAmount) // dust-change will be raised until no dust
-                        nChange = txout.GetDustThreshold(::minRelayTxFee);
+                        nChange = txout.GetDustThreshold(dustRate);
                     else
                     {
                         nPayFee += nChange;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2094,9 +2094,18 @@ bool CWallet::FundTransaction(CMutableTransaction& tx, CAmount& nFeeRet, bool ov
     return true;
 }
 
+CFeeRate CWallet::GetDustRate()
+{
+    CFeeRate minValueRate = mempool.GetMinFee(GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000);
+    if(minValueRate < ::minRelayTxFee)
+        minValueRate = ::minRelayTxFee;
+    return minValueRate;
+}
+
 bool CWallet::CreateTransaction(const vector<CRecipient>& vecSend, CWalletTx& wtxNew, CReserveKey& reservekey, CAmount& nFeeRet,
                                 int& nChangePosInOut, std::string& strFailReason, const CCoinControl* coinControl, bool sign)
 {
+    CFeeRate dustRate = CWallet::GetDustRate();
     CAmount nValue = 0;
     int nChangePosRequest = nChangePosInOut;
     unsigned int nSubtractFeeFromAmount = 0;
@@ -2190,7 +2199,7 @@ bool CWallet::CreateTransaction(const vector<CRecipient>& vecSend, CWalletTx& wt
                         }
                     }
 
-                    if (txout.IsDust(::minRelayTxFee))
+                    if (txout.IsDust(dustRate))
                     {
                         if (recipient.fSubtractFeeFromAmount && nFeeRet > 0)
                         {
@@ -2264,16 +2273,16 @@ bool CWallet::CreateTransaction(const vector<CRecipient>& vecSend, CWalletTx& wt
                     // We do not move dust-change to fees, because the sender would end up paying more than requested.
                     // This would be against the purpose of the all-inclusive feature.
                     // So instead we raise the change and deduct from the recipient.
-                    if (nSubtractFeeFromAmount > 0 && newTxOut.IsDust(::minRelayTxFee))
+                    if (nSubtractFeeFromAmount > 0 && newTxOut.IsDust(dustRate))
                     {
-                        CAmount nDust = newTxOut.GetDustThreshold(::minRelayTxFee) - newTxOut.nValue;
+                        CAmount nDust = newTxOut.GetDustThreshold(dustRate) - newTxOut.nValue;
                         newTxOut.nValue += nDust; // raise change until no more dust
                         for (unsigned int i = 0; i < vecSend.size(); i++) // subtract from first recipient
                         {
                             if (vecSend[i].fSubtractFeeFromAmount)
                             {
                                 txNew.vout[i].nValue -= nDust;
-                                if (txNew.vout[i].IsDust(::minRelayTxFee))
+                                if (txNew.vout[i].IsDust(dustRate))
                                 {
                                     strFailReason = _("The transaction amount is too small to send after the fee has been deducted");
                                     return false;
@@ -2285,7 +2294,7 @@ bool CWallet::CreateTransaction(const vector<CRecipient>& vecSend, CWalletTx& wt
 
                     // Never create dust outputs; if we would, just
                     // add the dust to the fee.
-                    if (newTxOut.IsDust(::minRelayTxFee))
+                    if (newTxOut.IsDust(dustRate))
                     {
                         nChangePosInOut = -1;
                         nFeeRet += nChange;
@@ -2383,7 +2392,7 @@ bool CWallet::CreateTransaction(const vector<CRecipient>& vecSend, CWalletTx& wt
 
                 // If we made it here and we aren't even able to meet the relay fee on the next pass, give up
                 // because we must be at the maximum allowed fee.
-                if (nFeeNeeded < ::minRelayTxFee.GetFee(nBytes))
+                if (nFeeNeeded < dustRate.GetFee(nBytes))
                 {
                     strFailReason = _("Transaction too large for fee policy");
                     return false;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -772,6 +772,11 @@ public:
      */
     static CAmount GetRequiredFee(unsigned int nTxBytes);
 
+    /**
+     * Return the rate below which wallet's outputs should be considered dust.
+     */
+    static CFeeRate GetDustRate();
+
     bool NewKeyPool();
     bool TopUpKeyPool(unsigned int kpSize = 0);
     void ReserveKeyFromKeyPool(int64_t& nIndex, CKeyPool& keypool);


### PR DESCRIPTION
When https://github.com/bitcoin/bitcoin/pull/6793 (bump of txMinRelayFee) was released, lots of transactions made by older wallet stopped being relayed (output occasionally below dust), causing trouble to users who suddenly thought that their transactions were not confirmed because of the 1MB limit.

This PR make sure that the wallet minimum value output is a function of fee instead of a function of txMinRelayFee, so any bump in the future would not have bad consequences.

It will also save some UTXO space by preventing the creation of output which would likely be uneconomical to redeem. 
