### PR TITLE
[0.13] [Wallet] Ensure <0.13 clients can't open HD wallets

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -131,6 +131,8 @@ You can't disable HD key generation once you have created a HD wallet.
 
 There is no distinction between internal (change) and external keys.
 
+HD wallets are incompatible with older versions of Bitcoin Core.
+
 [Pull request](https://github.com/bitcoin/bitcoin/pull/8035/files), [BIP 32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki)
 
 Low-level P2P changes

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3299,6 +3299,9 @@ bool CWallet::InitLoadWallet()
             key.MakeNewKey(true);
             if (!walletInstance->SetHDMasterKey(key))
                 throw std::runtime_error("CWallet::GenerateNewKey(): Storing master key failed");
+
+            // ensure this wallet.dat can only be opened by clients supporting HD
+            walletInstance->SetMinVersion(FEATURE_HD);
         }
         CPubKey newDefaultKey;
         if (walletInstance->GetKeyFromPool(newDefaultKey)) {

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -78,7 +78,8 @@ enum WalletFeature
     FEATURE_WALLETCRYPT = 40000, // wallet encryption
     FEATURE_COMPRPUBKEY = 60000, // compressed public keys
 
-    FEATURE_LATEST = 60000
+    FEATURE_HD = 130000, // Hierarchical key derivation after BIP32 (HD Wallet)
+    FEATURE_LATEST = FEATURE_COMPRPUBKEY // HD is optional, use FEATURE_COMPRPUBKEY as latest version
 };
 
 


### PR DESCRIPTION
0.13 backport of #8343 

---

In current master, you could run a 0.13 HD wallet in a non HD compatible 0.12 client, resulting in a mix of HD and non HD key. You could even refill the wallets keypool running a 0.12 client and use it on 0.13 which would lead to a getnewaddress call in 0.13 responding a non HD address.

This PR ensures that HD wallets will at least require version ~~0.12.99~~0.13.

This only affects newly created wallets and only if the user had not passed -usehd=0 (old <0.13 created wallets will still run on <0.13 clients once they where opened in 0.13).

---
