### PR TITLE
[Qt] Add out-of-sync modal info layer

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -96,6 +96,7 @@ QT_FORMS_UI = \
   qt/forms/editaddressdialog.ui \
   qt/forms/helpmessagedialog.ui \
   qt/forms/intro.ui \
+  qt/forms/modaloverlay.ui \
   qt/forms/openuridialog.ui \
   qt/forms/optionsdialog.ui \
   qt/forms/overviewpage.ui \
@@ -125,6 +126,7 @@ QT_MOC_CPP = \
   qt/moc_intro.cpp \
   qt/moc_macdockiconhandler.cpp \
   qt/moc_macnotificationhandler.cpp \
+  qt/moc_modaloverlay.cpp \
   qt/moc_notificator.cpp \
   qt/moc_openuridialog.cpp \
   qt/moc_optionsdialog.cpp \
@@ -192,6 +194,7 @@ BITCOIN_QT_H = \
   qt/intro.h \
   qt/macdockiconhandler.h \
   qt/macnotificationhandler.h \
+  qt/modaloverlay.h \
   qt/networkstyle.h \
   qt/notificator.h \
   qt/openuridialog.h \
@@ -292,6 +295,7 @@ BITCOIN_QT_CPP = \
   qt/csvmodelwriter.cpp \
   qt/guiutil.cpp \
   qt/intro.cpp \
+  qt/modaloverlay.cpp \
   qt/networkstyle.cpp \
   qt/notificator.cpp \
   qt/optionsdialog.cpp \

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -12,6 +12,7 @@
 #include "clientmodel.h"
 #include "guiconstants.h"
 #include "guiutil.h"
+#include "modaloverlay.h"
 #include "networkstyle.h"
 #include "notificator.h"
 #include "openuridialog.h"
@@ -114,6 +115,7 @@ BitcoinGUI::BitcoinGUI(const PlatformStyle *platformStyle, const NetworkStyle *n
     notificator(0),
     rpcConsole(0),
     helpMessageDialog(0),
+    modalOverlay(0),
     prevBlocks(0),
     spinnerFrame(0),
     platformStyle(platformStyle)
@@ -241,6 +243,12 @@ BitcoinGUI::BitcoinGUI(const PlatformStyle *platformStyle, const NetworkStyle *n
 
     // Subscribe to notifications from core
     subscribeToCoreSignals();
+
+    modalOverlay = new ModalOverlay(this->centralWidget());
+#ifdef ENABLE_WALLET
+    if(enableWallet)
+        connect(walletFrame, SIGNAL(requestedOfSyncWarningInfo()), this, SLOT(showModalOverlay()));
+#endif
 }
 
 BitcoinGUI::~BitcoinGUI()
@@ -491,6 +499,8 @@ void BitcoinGUI::setClientModel(ClientModel *clientModel)
             // initialize the disable state of the tray icon with the current value in the model.
             setTrayIconVisible(optionsModel->getHideTrayIcon());
         }
+
+        modalOverlay->setKnownBestHeight(clientModel->getHeaderHeight());
     } else {
         // Disable possibility to show main window via action
         toggleHideAction->setEnabled(false);
@@ -705,7 +715,14 @@ void BitcoinGUI::setNumConnections(int count)
 
 void BitcoinGUI::setNumBlocks(int count, const QDateTime& blockDate, double nVerificationProgress, bool header)
 {
-    if(!clientModel)
+    if (modalOverlay)
+    {
+        if (header)
+            modalOverlay->setKnownBestHeight(count);
+        else
+            modalOverlay->tipUpdate(count, blockDate, nVerificationProgress);
+    }
+    if (!clientModel)
         return;
 
     // Prevent orphan statusbar messages (e.g. hover Quit in main menu, wait until chain-sync starts -> garbelled text)
@@ -754,7 +771,10 @@ void BitcoinGUI::setNumBlocks(int count, const QDateTime& blockDate, double nVer
 
 #ifdef ENABLE_WALLET
         if(walletFrame)
+        {
             walletFrame->showOutOfSyncWarning(false);
+            modalOverlay->showHide(true, true);
+        }
 #endif // ENABLE_WALLET
 
         progressBarLabel->setVisible(false);
@@ -782,7 +802,10 @@ void BitcoinGUI::setNumBlocks(int count, const QDateTime& blockDate, double nVer
 
 #ifdef ENABLE_WALLET
         if(walletFrame)
+        {
             walletFrame->showOutOfSyncWarning(true);
+            modalOverlay->showHide();
+        }
 #endif // ENABLE_WALLET
 
         tooltip += QString("<br>");
@@ -1076,6 +1099,12 @@ void BitcoinGUI::setTrayIconVisible(bool fHideTrayIcon)
     {
         trayIcon->setVisible(!fHideTrayIcon);
     }
+}
+
+void BitcoinGUI::showModalOverlay()
+{
+    if (modalOverlay)
+        modalOverlay->showHide(false, true);
 }
 
 static bool ThreadSafeMessageBox(BitcoinGUI *gui, const std::string& message, const std::string& caption, unsigned int style)

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -762,30 +762,7 @@ void BitcoinGUI::setNumBlocks(int count, const QDateTime& blockDate, double nVer
     }
     else
     {
-        // Represent time from last generated block in human readable text
-        QString timeBehindText;
-        const int HOUR_IN_SECONDS = 60*60;
-        const int DAY_IN_SECONDS = 24*60*60;
-        const int WEEK_IN_SECONDS = 7*24*60*60;
-        const int YEAR_IN_SECONDS = 31556952; // Average length of year in Gregorian calendar
-        if(secs < 2*DAY_IN_SECONDS)
-        {
-            timeBehindText = tr("%n hour(s)","",secs/HOUR_IN_SECONDS);
-        }
-        else if(secs < 2*WEEK_IN_SECONDS)
-        {
-            timeBehindText = tr("%n day(s)","",secs/DAY_IN_SECONDS);
-        }
-        else if(secs < YEAR_IN_SECONDS)
-        {
-            timeBehindText = tr("%n week(s)","",secs/WEEK_IN_SECONDS);
-        }
-        else
-        {
-            qint64 years = secs / YEAR_IN_SECONDS;
-            qint64 remainder = secs % YEAR_IN_SECONDS;
-            timeBehindText = tr("%1 and %2").arg(tr("%n year(s)", "", years)).arg(tr("%n week(s)","", remainder/WEEK_IN_SECONDS));
-        }
+        QString timeBehindText = GUIUtil::formateNiceTimeOffset(secs);
 
         progressBarLabel->setVisible(true);
         progressBar->setFormat(tr("%1 behind").arg(timeBehindText));

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -500,7 +500,7 @@ void BitcoinGUI::setClientModel(ClientModel *clientModel)
             setTrayIconVisible(optionsModel->getHideTrayIcon());
         }
 
-        modalOverlay->setKnownBestHeight(clientModel->getHeaderHeight());
+        modalOverlay->setKnownBestHeight(clientModel->getHeaderTipHeight(), QDateTime::fromTime_t(clientModel->getHeaderTipTime()));
     } else {
         // Disable possibility to show main window via action
         toggleHideAction->setEnabled(false);
@@ -718,7 +718,10 @@ void BitcoinGUI::setNumBlocks(int count, const QDateTime& blockDate, double nVer
     if (modalOverlay)
     {
         if (header)
-            modalOverlay->setKnownBestHeight(count);
+        {
+            /* use clientmodels getHeaderTipHeight and getHeaderTipTime because the NotifyHeaderTip signal does not fire when updating the best header */
+            modalOverlay->setKnownBestHeight(clientModel->getHeaderTipHeight(), QDateTime::fromTime_t(clientModel->getHeaderTipTime()));
+        }
         else
             modalOverlay->tipUpdate(count, blockDate, nVerificationProgress);
     }

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -247,7 +247,7 @@ BitcoinGUI::BitcoinGUI(const PlatformStyle *platformStyle, const NetworkStyle *n
     modalOverlay = new ModalOverlay(this->centralWidget());
 #ifdef ENABLE_WALLET
     if(enableWallet)
-        connect(walletFrame, SIGNAL(requestedOfSyncWarningInfo()), this, SLOT(showModalOverlay()));
+        connect(walletFrame, SIGNAL(requestedSyncWarningInfo()), this, SLOT(showModalOverlay()));
 #endif
 }
 
@@ -717,13 +717,13 @@ void BitcoinGUI::setNumBlocks(int count, const QDateTime& blockDate, double nVer
 {
     if (modalOverlay)
     {
-        if (header)
-        {
+        if (header) {
             /* use clientmodels getHeaderTipHeight and getHeaderTipTime because the NotifyHeaderTip signal does not fire when updating the best header */
             modalOverlay->setKnownBestHeight(clientModel->getHeaderTipHeight(), QDateTime::fromTime_t(clientModel->getHeaderTipTime()));
         }
-        else
+        else {
             modalOverlay->tipUpdate(count, blockDate, nVerificationProgress);
+        }
     }
     if (!clientModel)
         return;

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -29,6 +29,7 @@ class UnitDisplayStatusBarControl;
 class WalletFrame;
 class WalletModel;
 class HelpMessageDialog;
+class ModalOverlay;
 
 class CWallet;
 
@@ -118,6 +119,7 @@ private:
     Notificator *notificator;
     RPCConsole *rpcConsole;
     HelpMessageDialog *helpMessageDialog;
+    ModalOverlay *modalOverlay;
 
     /** Keep track of previous number of blocks, to detect progress */
     int prevBlocks;
@@ -229,6 +231,8 @@ private Q_SLOTS:
     
     /** When hideTrayIcon setting is changed in OptionsModel hide or show the icon accordingly. */
     void setTrayIconVisible(bool);
+
+    void showModalOverlay();
 };
 
 class UnitDisplayStatusBarControl : public QLabel

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -234,7 +234,7 @@ static void BlockTipChanged(ClientModel *clientmodel, bool initialSync, const CB
     int64_t& nLastUpdateNotification = fHeader ? nLastHeaderTipUpdateNotification : nLastBlockTipUpdateNotification;
 
     // if we are in-sync, update the UI regardless of last update time
-    if (!initialSync || now - nLastUpdateNotification > MODEL_UPDATE_DELAY) {
+    if (fHeader || !initialSync || now - nLastUpdateNotification > MODEL_UPDATE_DELAY) {
         //pass a async signal to the UI thread
         QMetaObject::invokeMethod(clientmodel, "numBlocksChanged", Qt::QueuedConnection,
                                   Q_ARG(int, pIndex->nHeight),

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -68,6 +68,14 @@ int ClientModel::getNumBlocks() const
     return chainActive.Height();
 }
 
+int ClientModel::getHeaderHeight() const
+{
+    LOCK(cs_main);
+    if (!pindexBestHeader)
+        return 0;
+    return pindexBestHeader->nHeight;
+}
+
 quint64 ClientModel::getTotalBytesRecv() const
 {
     return CNode::GetTotalBytesRecv();

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -68,12 +68,20 @@ int ClientModel::getNumBlocks() const
     return chainActive.Height();
 }
 
-int ClientModel::getHeaderHeight() const
+int ClientModel::getHeaderTipHeight() const
 {
     LOCK(cs_main);
     if (!pindexBestHeader)
         return 0;
     return pindexBestHeader->nHeight;
+}
+
+int64_t ClientModel::getHeaderTipTime() const
+{
+    LOCK(cs_main);
+    if (!pindexBestHeader)
+        return 0;
+    return pindexBestHeader->GetBlockTime();
 }
 
 quint64 ClientModel::getTotalBytesRecv() const

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -51,8 +51,8 @@ public:
     //! Return number of connections, default is in- and outbound (total)
     int getNumConnections(unsigned int flags = CONNECTIONS_ALL) const;
     int getNumBlocks() const;
-    int getHeaderHeight() const;
-
+    int getHeaderTipHeight() const;
+    int64_t getHeaderTipTime() const;
     //! Return number of transactions in the mempool
     long getMempoolSize() const;
     //! Return the dynamic memory usage of the mempool

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -51,6 +51,7 @@ public:
     //! Return number of connections, default is in- and outbound (total)
     int getNumConnections(unsigned int flags = CONNECTIONS_ALL) const;
     int getNumBlocks() const;
+    int getHeaderHeight() const;
 
     //! Return number of transactions in the mempool
     long getMempoolSize() const;

--- a/src/qt/forms/modaloverlay.ui
+++ b/src/qt/forms/modaloverlay.ui
@@ -130,7 +130,7 @@ QLabel { color: rgb(40,40,40);  }</string>
              <item>
               <widget class="QLabel" name="infoText">
                <property name="text">
-                <string>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</string>
+                <string>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet. This means that recent transactions will not be visible, and the balance will not be up-to-date until this process has completed.</string>
                </property>
                <property name="textFormat">
                 <enum>Qt::RichText</enum>
@@ -149,7 +149,7 @@ QLabel { color: rgb(40,40,40);  }</string>
                 </font>
                </property>
                <property name="text">
-                <string>This means that recent transactions will not be visible, and the balance will not be up-to-date until this process has completed. Spending bitcoins is not possible during that phase!</string>
+                <string>Spending bitcoins may not be possible during that phase!</string>
                </property>
                <property name="textFormat">
                 <enum>Qt::RichText</enum>

--- a/src/qt/forms/modaloverlay.ui
+++ b/src/qt/forms/modaloverlay.ui
@@ -1,0 +1,370 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ModalOverlay</class>
+ <widget class="ModalOverlay" name="ModalOverlay">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>640</width>
+    <height>385</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="0">
+   <property name="sizeConstraint">
+    <enum>QLayout::SetDefaultConstraint</enum>
+   </property>
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <widget class="QWidget" name="bgWidget" native="true">
+     <property name="styleSheet">
+      <string notr="true">#bgWidget { background: rgba(0,0,0,220); }</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayoutMain" stretch="1">
+      <property name="leftMargin">
+       <number>60</number>
+      </property>
+      <property name="topMargin">
+       <number>60</number>
+      </property>
+      <property name="rightMargin">
+       <number>60</number>
+      </property>
+      <property name="bottomMargin">
+       <number>60</number>
+      </property>
+      <item>
+       <widget class="QWidget" name="contentWidget" native="true">
+        <property name="styleSheet">
+         <string notr="true">#contentWidget { background: rgba(255,255,255,240); border-radius: 6px; }
+
+QLabel { color: rgb(40,40,40);  }</string>
+        </property>
+        <layout class="QVBoxLayout" name="verticalLayoutSub" stretch="1,0,0,0">
+         <property name="spacing">
+          <number>0</number>
+         </property>
+         <property name="leftMargin">
+          <number>10</number>
+         </property>
+         <property name="topMargin">
+          <number>10</number>
+         </property>
+         <property name="rightMargin">
+          <number>10</number>
+         </property>
+         <property name="bottomMargin">
+          <number>10</number>
+         </property>
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayoutIconText" stretch="0,1">
+           <property name="topMargin">
+            <number>20</number>
+           </property>
+           <item>
+            <layout class="QVBoxLayout" name="verticalLayoutIcon">
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <item>
+              <widget class="QPushButton" name="warningIcon">
+               <property name="text">
+                <string/>
+               </property>
+               <property name="icon">
+                <iconset>
+                 <normaloff>:/icons/warning</normaloff>
+                 <disabledoff>:/icons/warning</disabledoff>:/icons/warning</iconset>
+               </property>
+               <property name="iconSize">
+                <size>
+                 <width>48</width>
+                 <height>48</height>
+                </size>
+               </property>
+               <property name="flat">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <spacer name="verticalSpacerWarningIcon">
+               <property name="orientation">
+                <enum>Qt::Vertical</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>20</width>
+                 <height>40</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+            </layout>
+           </item>
+           <item>
+            <layout class="QVBoxLayout" name="verticalLayoutInfoText">
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <item>
+              <widget class="QLabel" name="infoText">
+               <property name="text">
+                <string>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</string>
+               </property>
+               <property name="textFormat">
+                <enum>Qt::RichText</enum>
+               </property>
+               <property name="wordWrap">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLabel" name="infoTextStrong">
+               <property name="font">
+                <font>
+                 <weight>75</weight>
+                 <bold>true</bold>
+                </font>
+               </property>
+               <property name="text">
+                <string>This means that recent transactions will not be visible, and the balance will not be up-to-date until this process has completed. Spending bitcoins is not possible during that phase!</string>
+               </property>
+               <property name="textFormat">
+                <enum>Qt::RichText</enum>
+               </property>
+               <property name="wordWrap">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <spacer name="verticalSpacerInTextSpace">
+               <property name="orientation">
+                <enum>Qt::Vertical</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>20</width>
+                 <height>40</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+            </layout>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <spacer name="verticalSpacerAfterText">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>40</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <layout class="QFormLayout" name="formLayout">
+           <property name="fieldGrowthPolicy">
+            <enum>QFormLayout::FieldsStayAtSizeHint</enum>
+           </property>
+           <property name="horizontalSpacing">
+            <number>6</number>
+           </property>
+           <property name="verticalSpacing">
+            <number>6</number>
+           </property>
+           <property name="topMargin">
+            <number>10</number>
+           </property>
+           <item row="0" column="0">
+            <widget class="QLabel" name="labelAmoutOfBlocksLeft">
+             <property name="font">
+              <font>
+               <weight>75</weight>
+               <bold>true</bold>
+              </font>
+             </property>
+             <property name="text">
+              <string>Amount of blocks left</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QLabel" name="amountOfBlocksLeft">
+             <property name="text">
+              <string>unknown...</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0">
+            <widget class="QLabel" name="labelLastBlockTime">
+             <property name="font">
+              <font>
+               <weight>75</weight>
+               <bold>true</bold>
+              </font>
+             </property>
+             <property name="text">
+              <string>Last block time</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="1">
+            <widget class="QLabel" name="newestBlockDate">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>unknown...</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="0">
+            <widget class="QLabel" name="labelSyncDone">
+             <property name="font">
+              <font>
+               <weight>75</weight>
+               <bold>true</bold>
+              </font>
+             </property>
+             <property name="text">
+              <string>Progress</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="1">
+            <layout class="QHBoxLayout" name="horizontalLayoutSync" stretch="0,1">
+             <item>
+              <widget class="QLabel" name="percentageProgress">
+               <property name="text">
+                <string>~</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QProgressBar" name="progressBar">
+               <property name="value">
+                <number>24</number>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+           <item row="4" column="0">
+            <widget class="QLabel" name="labelProgressIncrease">
+             <property name="font">
+              <font>
+               <weight>75</weight>
+               <bold>true</bold>
+              </font>
+             </property>
+             <property name="text">
+              <string>Progress increase per Hour</string>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="1">
+            <widget class="QLabel" name="progressIncreasePerH">
+             <property name="text">
+              <string>calculating...</string>
+             </property>
+            </widget>
+           </item>
+           <item row="5" column="0">
+            <widget class="QLabel" name="labelEstimatedTimeLeft">
+             <property name="font">
+              <font>
+               <weight>75</weight>
+               <bold>true</bold>
+              </font>
+             </property>
+             <property name="text">
+              <string>Estimated time left until synced</string>
+             </property>
+            </widget>
+           </item>
+           <item row="5" column="1">
+            <widget class="QLabel" name="expectedTimeLeft">
+             <property name="text">
+              <string>calculating...</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayoutButtons">
+           <property name="leftMargin">
+            <number>10</number>
+           </property>
+           <property name="topMargin">
+            <number>10</number>
+           </property>
+           <item>
+            <spacer name="horizontalSpacer">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item>
+            <widget class="QPushButton" name="closeButton">
+             <property name="text">
+              <string>Hide</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+        </layout>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>ModalOverlay</class>
+   <extends>QWidget</extends>
+   <header>modaloverlay.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/qt/forms/modaloverlay.ui
+++ b/src/qt/forms/modaloverlay.ui
@@ -82,6 +82,9 @@ QLabel { color: rgb(40,40,40);  }</string>
              </property>
              <item>
               <widget class="QPushButton" name="warningIcon">
+               <property name="enabled">
+                <bool>false</bool>
+               </property>
                <property name="text">
                 <string/>
                </property>

--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -61,7 +61,7 @@
             <item>
              <widget class="QPushButton" name="labelWalletStatus">
               <property name="enabled">
-               <bool>false</bool>
+               <bool>true</bool>
               </property>
               <property name="maximumSize">
                <size>
@@ -447,7 +447,7 @@
             <item>
              <widget class="QPushButton" name="labelTransactionsStatus">
               <property name="enabled">
-               <bool>false</bool>
+               <bool>true</bool>
               </property>
               <property name="maximumSize">
                <size>

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -952,4 +952,40 @@ QString formatTimeOffset(int64_t nTimeOffset)
   return QString(QObject::tr("%1 s")).arg(QString::number((int)nTimeOffset, 10));
 }
 
+QString formateNiceTimeOffset(qint64 secs)
+{
+    // Represent time from last generated block in human readable text
+    QString timeBehindText;
+    const int HOUR_IN_SECONDS = 60*60;
+    const int DAY_IN_SECONDS = 24*60*60;
+    const int WEEK_IN_SECONDS = 7*24*60*60;
+    const int YEAR_IN_SECONDS = 31556952; // Average length of year in Gregorian calendar
+    if(secs < 60)
+    {
+        timeBehindText = QObject::tr("%n seconds(s)","",secs);
+    }
+    else if(secs < 2*HOUR_IN_SECONDS)
+    {
+        timeBehindText = QObject::tr("%n minutes(s)","",secs/60);
+    }
+    else if(secs < 2*DAY_IN_SECONDS)
+    {
+        timeBehindText = QObject::tr("%n hour(s)","",secs/HOUR_IN_SECONDS);
+    }
+    else if(secs < 2*WEEK_IN_SECONDS)
+    {
+        timeBehindText = QObject::tr("%n day(s)","",secs/DAY_IN_SECONDS);
+    }
+    else if(secs < YEAR_IN_SECONDS)
+    {
+        timeBehindText = QObject::tr("%n week(s)","",secs/WEEK_IN_SECONDS);
+    }
+    else
+    {
+        qint64 years = secs / YEAR_IN_SECONDS;
+        qint64 remainder = secs % YEAR_IN_SECONDS;
+        timeBehindText = QObject::tr("%1 and %2").arg(QObject::tr("%n year(s)", "", years)).arg(QObject::tr("%n week(s)","", remainder/WEEK_IN_SECONDS));
+    }
+    return timeBehindText;
+}
 } // namespace GUIUtil

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -200,6 +200,8 @@ namespace GUIUtil
     /* Format a CNodeCombinedStats.nTimeOffset into a user-readable string. */
     QString formatTimeOffset(int64_t nTimeOffset);
 
+    QString formateNiceTimeOffset(qint64 secs);
+
 #if defined(Q_OS_MAC) && QT_VERSION >= 0x050000
     // workaround for Qt OSX Bug:
     // https://bugreports.qt-project.org/browse/QTBUG-15631

--- a/src/qt/modaloverlay.cpp
+++ b/src/qt/modaloverlay.cpp
@@ -63,10 +63,17 @@ bool ModalOverlay::event(QEvent* ev) {
     return QWidget::event(ev);
 }
 
-void ModalOverlay::setKnownBestHeight(int count)
+void ModalOverlay::setKnownBestHeight(int count, const QDateTime& blockDate)
 {
-    if (count > bestBlockHeight)
-        bestBlockHeight = count;
+
+    /* only update the blockheight if the headerschain-tip is not older then 30 days */
+    int64_t now = QDateTime::currentDateTime().toTime_t();
+    int64_t btime = blockDate.toTime_t();
+    if (btime+3600*24*30 > now)
+    {
+        if (count > bestBlockHeight)
+            bestBlockHeight = count;
+    }
 }
 
 void ModalOverlay::tipUpdate(int count, const QDateTime& blockDate, double nVerificationProgress)
@@ -122,6 +129,8 @@ void ModalOverlay::tipUpdate(int count, const QDateTime& blockDate, double nVeri
     // show remaining amount of blocks
     if (bestBlockHeight > 0)
         ui->amountOfBlocksLeft->setText(QString::number(bestBlockHeight-count));
+    else
+        ui->expectedTimeLeft->setText(tr("Unknown. Syncing Headers..."));
 }
 
 void ModalOverlay::showHide(bool hide, bool userRequested)

--- a/src/qt/modaloverlay.cpp
+++ b/src/qt/modaloverlay.cpp
@@ -86,7 +86,6 @@ void ModalOverlay::tipUpdate(int count, const QDateTime& blockDate, double nVeri
     // show progress speed if we have more then one sample
     if (blockProcessTime.size() >= 2)
     {
-        // try to get the window from the last 500 seconds or at least 10 samples
         double progressStart = blockProcessTime[0].second;
         double progressDelta = 0;
         double progressPerHour = 0;
@@ -114,9 +113,9 @@ void ModalOverlay::tipUpdate(int count, const QDateTime& blockDate, double nVeri
         ui->expectedTimeLeft->setText(GUIUtil::formateNiceTimeOffset(remainingMSecs/1000.0));
 
         // keep maximal 5000 samples
-        static int maxSamples = 5000;
-        if (blockProcessTime.count() > maxSamples)
-            blockProcessTime.remove(maxSamples, blockProcessTime.count()-maxSamples);
+        static const int MAX_SAMPLES = 5000;
+        if (blockProcessTime.count() > MAX_SAMPLES)
+            blockProcessTime.remove(MAX_SAMPLES, blockProcessTime.count()-MAX_SAMPLES);
     }
 
     // show the last block date

--- a/src/qt/modaloverlay.cpp
+++ b/src/qt/modaloverlay.cpp
@@ -1,0 +1,150 @@
+// Copyright (c) 2017 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "modaloverlay.h"
+#include "ui_modaloverlay.h"
+
+#include "guiutil.h"
+
+#include <QResizeEvent>
+#include <QPropertyAnimation>
+
+ModalOverlay::ModalOverlay(QWidget *parent) :
+QWidget(parent),
+ui(new Ui::ModalOverlay),
+bestBlockHeight(0),
+layerIsVisible(false),
+userClosed(false)
+{
+    ui->setupUi(this);
+    connect(ui->closeButton, SIGNAL(clicked()), this, SLOT(closeClicked()));
+    if (parent) {
+        parent->installEventFilter(this);
+        raise();
+    }
+
+    blockProcessTime.clear();
+    setVisible(false);
+}
+
+ModalOverlay::~ModalOverlay()
+{
+    delete ui;
+}
+
+bool ModalOverlay::eventFilter(QObject * obj, QEvent * ev) {
+    if (obj == parent()) {
+        if (ev->type() == QEvent::Resize) {
+            QResizeEvent * rev = static_cast<QResizeEvent*>(ev);
+            resize(rev->size());
+            if (!layerIsVisible)
+                setGeometry(0, height(), width(), height());
+
+        }
+        else if (ev->type() == QEvent::ChildAdded) {
+            raise();
+        }
+    }
+    return QWidget::eventFilter(obj, ev);
+}
+
+//! Tracks parent widget changes
+bool ModalOverlay::event(QEvent* ev) {
+    if (ev->type() == QEvent::ParentAboutToChange) {
+        if (parent()) parent()->removeEventFilter(this);
+    }
+    else if (ev->type() == QEvent::ParentChange) {
+        if (parent()) {
+            parent()->installEventFilter(this);
+            raise();
+        }
+    }
+    return QWidget::event(ev);
+}
+
+void ModalOverlay::setKnownBestHeight(int count)
+{
+    if (count > bestBlockHeight)
+        bestBlockHeight = count;
+}
+
+void ModalOverlay::tipUpdate(int count, const QDateTime& blockDate, double nVerificationProgress)
+{
+    QDateTime currentDate = QDateTime::currentDateTime();
+
+    // keep a vector of samples of verification progress at height
+    blockProcessTime.push_front(qMakePair(currentDate.currentMSecsSinceEpoch(), nVerificationProgress));
+
+    // show progress speed if we have more then one sample
+    if (blockProcessTime.size() >= 2)
+    {
+        // try to get the window from the last 500 seconds or at least 10 samples
+        double progressStart = blockProcessTime[0].second;
+        double progressDelta = 0;
+        double progressPerHour = 0;
+        qint64 timeDelta = 0;
+        qint64 remainingMSecs = 0;
+        double remainingProgress = 1.0 - nVerificationProgress;
+        for (int i = 1; i < blockProcessTime.size(); i++)
+        {
+            QPair<qint64, double> sample = blockProcessTime[i];
+
+            // take first sample after 500 seconds or last available one
+            if (sample.first < (currentDate.currentMSecsSinceEpoch() - 500*1000) || i == blockProcessTime.size()-1)
+            {
+                progressDelta = progressStart-sample.second;
+                timeDelta = blockProcessTime[0].first - sample.first;
+                progressPerHour = progressDelta/(double)timeDelta*1000*3600;
+                remainingMSecs = remainingProgress / progressDelta * timeDelta;
+                break;
+            }
+        }
+        // show progress increase per hour
+        ui->progressIncreasePerH->setText(QString::number(progressPerHour*100, 'f', 2)+"%");
+
+        // show expected remaining time
+        ui->expectedTimeLeft->setText(GUIUtil::formateNiceTimeOffset(remainingMSecs/1000.0));
+
+        // keep maximal 5000 samples
+        static int maxSamples = 5000;
+        if (blockProcessTime.count() > maxSamples)
+            blockProcessTime.remove(maxSamples, blockProcessTime.count()-maxSamples);
+    }
+
+    // show the last block date
+    ui->newestBlockDate->setText(blockDate.toString());
+
+    // show the percentage done according to nVerificationProgress
+    ui->percentageProgress->setText(QString::number(nVerificationProgress*100, 'f', 2)+"%");
+    ui->progressBar->setValue(nVerificationProgress*100);
+
+    // show remaining amount of blocks
+    if (bestBlockHeight > 0)
+        ui->amountOfBlocksLeft->setText(QString::number(bestBlockHeight-count));
+}
+
+void ModalOverlay::showHide(bool hide, bool userRequested)
+{
+    if ( (layerIsVisible && !hide) || (!layerIsVisible && hide) || (!hide && userClosed && !userRequested))
+        return;
+
+    if (!isVisible() && !hide)
+        setVisible(true);
+
+    setGeometry(0, hide ? 0 : height(), width(), height());
+
+    QPropertyAnimation* animation = new QPropertyAnimation(this, "pos");
+    animation->setDuration(300);
+    animation->setStartValue(QPoint(0, hide ? 0 : this->height()));
+    animation->setEndValue(QPoint(0, hide ? this->height() : 0));
+    animation->setEasingCurve(QEasingCurve::OutQuad);
+    animation->start(QAbstractAnimation::DeleteWhenStopped);
+    layerIsVisible = !hide;
+}
+
+void ModalOverlay::closeClicked()
+{
+    showHide(true);
+    userClosed = true;
+}

--- a/src/qt/modaloverlay.h
+++ b/src/qt/modaloverlay.h
@@ -23,7 +23,7 @@ public:
 
 public Q_SLOTS:
     void tipUpdate(int count, const QDateTime& blockDate, double nVerificationProgress);
-    void setKnownBestHeight(int count);
+    void setKnownBestHeight(int count, const QDateTime& blockDate);
 
     // will show or hide the modal layer
     void showHide(bool hide = false, bool userRequested = false);

--- a/src/qt/modaloverlay.h
+++ b/src/qt/modaloverlay.h
@@ -1,0 +1,44 @@
+// Copyright (c) 2017 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QT_MODALOVERLAY_H
+#define BITCOIN_QT_MODALOVERLAY_H
+
+#include <QDateTime>
+#include <QWidget>
+
+namespace Ui {
+    class ModalOverlay;
+}
+
+/** Modal overlay to display information about the chain-sync state */
+class ModalOverlay : public QWidget
+{
+    Q_OBJECT
+
+public:
+    explicit ModalOverlay(QWidget *parent);
+    ~ModalOverlay();
+
+public Q_SLOTS:
+    void tipUpdate(int count, const QDateTime& blockDate, double nVerificationProgress);
+    void setKnownBestHeight(int count);
+
+    // will show or hide the modal layer
+    void showHide(bool hide = false, bool userRequested = false);
+    void closeClicked();
+
+protected:
+    bool eventFilter(QObject * obj, QEvent * ev);
+    bool event(QEvent* ev);
+
+private:
+    Ui::ModalOverlay *ui;
+    int bestBlockHeight; //best known height (based on the headers)
+    QVector<QPair<qint64, double> > blockProcessTime;
+    bool layerIsVisible;
+    bool userClosed;
+};
+
+#endif // BITCOIN_QT_MODALOVERLAY_H

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -140,12 +140,19 @@ OverviewPage::OverviewPage(const PlatformStyle *platformStyle, QWidget *parent) 
 
     // start with displaying the "out of sync" warnings
     showOutOfSyncWarning(true);
+    connect(ui->labelWalletStatus, SIGNAL(clicked()), this, SLOT(handleOutOfSyncWarningClicks()));
+    connect(ui->labelTransactionsStatus, SIGNAL(clicked()), this, SLOT(handleOutOfSyncWarningClicks()));
 }
 
 void OverviewPage::handleTransactionClicked(const QModelIndex &index)
 {
     if(filter)
         Q_EMIT transactionClicked(filter->mapToSource(index));
+}
+
+void OverviewPage::handleOutOfSyncWarningClicks()
+{
+    Q_EMIT outOfSyncWarningClicked();
 }
 
 OverviewPage::~OverviewPage()

--- a/src/qt/overviewpage.h
+++ b/src/qt/overviewpage.h
@@ -42,6 +42,7 @@ public Q_SLOTS:
 
 Q_SIGNALS:
     void transactionClicked(const QModelIndex &index);
+    void outOfSyncWarningClicked();
 
 private:
     Ui::OverviewPage *ui;
@@ -62,6 +63,7 @@ private Q_SLOTS:
     void handleTransactionClicked(const QModelIndex &index);
     void updateAlerts(const QString &warnings);
     void updateWatchOnlyLabels(bool showWatchOnly);
+    void handleOutOfSyncWarningClicks();
 };
 
 #endif // BITCOIN_QT_OVERVIEWPAGE_H

--- a/src/qt/walletframe.cpp
+++ b/src/qt/walletframe.cpp
@@ -57,6 +57,8 @@ bool WalletFrame::addWallet(const QString& name, WalletModel *walletModel)
     // Ensure a walletView is able to show the main window
     connect(walletView, SIGNAL(showNormalIfMinimized()), gui, SLOT(showNormalIfMinimized()));
 
+    connect(walletView, SIGNAL(outOfSyncWarningClicked()), this, SLOT(outOfSyncWarningClicked()));
+
     return true;
 }
 
@@ -195,3 +197,7 @@ WalletView *WalletFrame::currentWalletView()
     return qobject_cast<WalletView*>(walletStack->currentWidget());
 }
 
+void WalletFrame::outOfSyncWarningClicked()
+{
+    Q_EMIT requestedOfSyncWarningInfo();
+}

--- a/src/qt/walletframe.cpp
+++ b/src/qt/walletframe.cpp
@@ -199,5 +199,5 @@ WalletView *WalletFrame::currentWalletView()
 
 void WalletFrame::outOfSyncWarningClicked()
 {
-    Q_EMIT requestedOfSyncWarningInfo();
+    Q_EMIT requestedSyncWarningInfo();
 }

--- a/src/qt/walletframe.h
+++ b/src/qt/walletframe.h
@@ -38,6 +38,10 @@ public:
 
     void showOutOfSyncWarning(bool fShow);
 
+Q_SIGNALS:
+    /** Notify that the user has requested more information about the out-of-sync warning */
+    void requestedOfSyncWarningInfo();
+
 private:
     QStackedWidget *walletStack;
     BitcoinGUI *gui;
@@ -78,6 +82,8 @@ public Q_SLOTS:
     void usedSendingAddresses();
     /** Show used receiving addresses */
     void usedReceivingAddresses();
+    /** Pass on signal over requested out-of-sync-warning information */
+    void outOfSyncWarningClicked();
 };
 
 #endif // BITCOIN_QT_WALLETFRAME_H

--- a/src/qt/walletframe.h
+++ b/src/qt/walletframe.h
@@ -40,7 +40,7 @@ public:
 
 Q_SIGNALS:
     /** Notify that the user has requested more information about the out-of-sync warning */
-    void requestedOfSyncWarningInfo();
+    void requestedSyncWarningInfo();
 
 private:
     QStackedWidget *walletStack;

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -66,7 +66,7 @@ WalletView::WalletView(const PlatformStyle *platformStyle, QWidget *parent):
 
     // Clicking on a transaction on the overview pre-selects the transaction on the transaction history page
     connect(overviewPage, SIGNAL(transactionClicked(QModelIndex)), transactionView, SLOT(focusTransaction(QModelIndex)));
-    connect(overviewPage, SIGNAL(outOfSyncWarningClicked()), this, SLOT(requestedOfSyncWarningInfo()));
+    connect(overviewPage, SIGNAL(outOfSyncWarningClicked()), this, SLOT(requestedSyncWarningInfo()));
 
     // Double-clicking on a transaction on the transaction history page shows details
     connect(transactionView, SIGNAL(doubleClicked(QModelIndex)), transactionView, SLOT(showDetails()));
@@ -324,7 +324,7 @@ void WalletView::showProgress(const QString &title, int nProgress)
         progressDialog->setValue(nProgress);
 }
 
-void WalletView::requestedOfSyncWarningInfo()
+void WalletView::requestedSyncWarningInfo()
 {
     Q_EMIT outOfSyncWarningClicked();
 }

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -66,6 +66,7 @@ WalletView::WalletView(const PlatformStyle *platformStyle, QWidget *parent):
 
     // Clicking on a transaction on the overview pre-selects the transaction on the transaction history page
     connect(overviewPage, SIGNAL(transactionClicked(QModelIndex)), transactionView, SLOT(focusTransaction(QModelIndex)));
+    connect(overviewPage, SIGNAL(outOfSyncWarningClicked()), this, SLOT(requestedOfSyncWarningInfo()));
 
     // Double-clicking on a transaction on the transaction history page shows details
     connect(transactionView, SIGNAL(doubleClicked(QModelIndex)), transactionView, SLOT(showDetails()));
@@ -321,4 +322,9 @@ void WalletView::showProgress(const QString &title, int nProgress)
     }
     else if (progressDialog)
         progressDialog->setValue(nProgress);
+}
+
+void WalletView::requestedOfSyncWarningInfo()
+{
+    Q_EMIT outOfSyncWarningClicked();
 }

--- a/src/qt/walletview.h
+++ b/src/qt/walletview.h
@@ -110,6 +110,9 @@ public Q_SLOTS:
     /** Show progress dialog e.g. for rescan */
     void showProgress(const QString &title, int nProgress);
 
+    /** User has requested more information about the out of sync state */
+    void requestedOfSyncWarningInfo();
+
 Q_SIGNALS:
     /** Signal that we want to show the main window */
     void showNormalIfMinimized();
@@ -121,6 +124,8 @@ Q_SIGNALS:
     void hdEnabledStatusChanged(int hdEnabled);
     /** Notify that a new transaction appeared */
     void incomingTransaction(const QString& date, int unit, const CAmount& amount, const QString& type, const QString& address, const QString& label);
+    /** Notify that the out of sync warning icon has been pressed */
+    void outOfSyncWarningClicked();
 };
 
 #endif // BITCOIN_QT_WALLETVIEW_H

--- a/src/qt/walletview.h
+++ b/src/qt/walletview.h
@@ -111,7 +111,7 @@ public Q_SLOTS:
     void showProgress(const QString &title, int nProgress);
 
     /** User has requested more information about the out of sync state */
-    void requestedOfSyncWarningInfo();
+    void requestedSyncWarningInfo();
 
 Q_SIGNALS:
     /** Signal that we want to show the main window */


### PR DESCRIPTION
Adresses https://github.com/bitcoin/bitcoin/issues/8060 and https://github.com/bitcoin/bitcoin/issues/7235

This change will slide in a semi transparent modal info layer in out-of-sync state resulting in a more prominent warning. Users can hide the modal info layer by pressing on "Hide".
Clicking on the out-of-sync warning icons will re-display the modal info layer.

In the modal info layer, the user can get three new values:
- amount of blocks left
- estimated time left until in-sync
- progress increase per hour 

<img width="948" alt="bildschirmfoto 2016-07-19 um 15 53 16" src="https://cloud.githubusercontent.com/assets/178464/16952302/ed02ca74-4dc8-11e6-95de-e6309f1bd8c5.png">
