### PR TITLE
Fix AddRef() usage for CNode

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -443,7 +443,7 @@ public:
     CAmount lastSentFeeFilter;
     int64_t nextSendTimeFeeFilter;
 
-    CNode(SOCKET hSocketIn, const CAddress &addrIn, const std::string &addrNameIn = "", bool fInboundIn = false);
+    CNode(SOCKET hSocketIn, const CAddress &addrIn, const std::string &addrNameIn = "", bool fInboundIn = false, bool fNetworkNode = false);
     ~CNode();
 
 private:


### PR DESCRIPTION
Using `AddRef()` in `ConnectNode()` for existing connections doesn't feel right imo considering how refs are released in `ThreadSocketHandler()` https://github.com/bitcoin/bitcoin/blob/master/src/net.cpp#L1113. I guess this could be the reason that sometimes refs stay >0 no matter what and nodes stuck in `vNodesDisconnected` forever which means that node never get deleted and `FinalizeNode` signal is never fired which in its turn means that for example `mapBlocksInFlight` can't be cleaned properly and https://github.com/bitcoin/bitcoin/issues/7596 happens.

This commit should solve the issue by:
1. removing `AddRef()` for existing connections
2. adding `AddRef()` in `CNode`'s constructor using the same conditions as in `ThreadSocketHandler()`
