### PR TITLE
remove outdated legacy code from key.h

### DIFF
--- a/src/key.h
+++ b/src/key.h
@@ -146,9 +146,6 @@ public:
 
     //! Load private key and check that public key matches.
     bool Load(CPrivKey& privkey, CPubKey& vchPubKey, bool fSkipCheck);
-
-    //! Check whether an element of a signature (r or s) is valid.
-    static bool CheckSignatureElement(const unsigned char* vch, int len, bool half);
 };
 
 struct CExtKey {


### PR DESCRIPTION
CheckSignatureElement is not used,it be replaced by eccrypto::CheckSignatureElement.
