### PR TITLE
Process "notfound" messages, and safeguard against unreasonably long …

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6110,6 +6110,28 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         }
     }
 
+    else if (strCommand == NetMsgType::NOTFOUND) {
+        vector<CInv> vInv;
+        vRecv >> vInv;
+        if (vInv.size() > MAX_INV_SZ)
+        {
+            LOCK(cs_main);
+            Misbehaving(pfrom->GetId(), 20);
+            return error("message notfound size() = %u", vInv.size());
+        }
+
+        for (unsigned int nInv = 0; nInv < vInv.size(); nInv++)
+        {
+            const CInv &inv = vInv[nInv];
+
+            boost::this_thread::interruption_point();
+            if (inv.type == MSG_TX || inv.type == MSG_WITNESS_TX)
+                 LogPrint("tx", "notfound: %s from peer=%d\n", inv.ToString(), pfrom->id);
+            else
+                 LogPrint("net", "notfound: %s from peer=%d\n", inv.ToString(), pfrom->id);
+        }
+    }
+
     else {
         // Ignore unknown commands for extensibility
         LogPrint("net", "Unknown command \"%s\" from peer=%d\n", SanitizeString(strCommand), pfrom->id);


### PR DESCRIPTION
…ones.

For years, I've been getting many many of these in my debug.log:-

2016-07-25 15:10:45 Unknown command "notfound" from peer=62719
2016-07-25 15:10:45 Unknown command "notfound" from peer=62719
2016-07-25 15:10:45 Unknown command "notfound" from peer=62719
2016-07-25 15:10:45 Unknown command "notfound" from peer=62719
2016-07-25 15:10:45 Unknown command "notfound" from peer=62719
2016-07-25 15:10:45 Unknown command "notfound" from peer=62719
2016-07-25 15:10:45 Unknown command "notfound" from peer=62719
2016-07-25 15:10:45 Unknown command "notfound" from peer=62719
2016-07-25 15:10:45 Unknown command "notfound" from peer=62719
2016-07-25 15:10:45 Unknown command "notfound" from peer=62719
2016-07-25 15:10:45 Unknown command "notfound" from peer=62719

This pull request will remove this message, which is technically incorrect anyway.
