### PR TITLE
[Qt] Add dbcache migration path

### DIFF
--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -84,9 +84,11 @@ private:
     /* settings that were overriden by command-line */
     QString strOverriddenByCommandLine;
 
-    /// Add option to list of GUI options overridden through command line/config file
+    // Add option to list of GUI options overridden through command line/config file
     void addOverriddenOption(const std::string &option);
 
+    // Check settings version and upgrade default values if required
+    void checkAndMigrate();
 Q_SIGNALS:
     void displayUnitChanged(int unit);
     void coinControlFeaturesChanged(bool);


### PR DESCRIPTION
During the first start, the GUI writes down default values of `-dbcache, -par, -upnp, -listen` into its internal GUI only settings container.

Changing the default value will have no effect on the GUI level because the old default value – even if it was untouched by the user – was persisted.

This adds a simple migration path for `-dbcache` because we have bumped it up to 300MB in 0.13 (see https://github.com/bitcoin/bitcoin/pull/8273).

I also had a solution where we don't store the default value at all. But, because we show the value as "set" in the GUI settings, we should also persist it locally. This would only make sense if there would be a switch between custom and default ( `[ ] custom value ____ | [ ] default value` ).
