### PR TITLE
Prevent fingerprinting, disk-DoS with compact blocks

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5626,8 +5626,8 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                 std::vector<CInv> vInv(1);
                 vInv[0] = CInv(MSG_BLOCK, cmpctblock.header.GetHash());
                 pfrom->PushMessage(NetMsgType::GETDATA, vInv);
-                return true;
             }
+            return true;
         }
 
         // If we're not close to tip yet, give up and let parallel block fetch work its magic

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5343,7 +5343,6 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
 
         BlockMap::iterator it = mapBlockIndex.find(req.blockhash);
         if (it == mapBlockIndex.end() || !(it->second->nStatus & BLOCK_HAVE_DATA)) {
-            Misbehaving(pfrom->GetId(), 100);
             LogPrintf("Peer %d sent us a getblocktxn for a block we don't have", pfrom->id);
             return true;
         }


### PR DESCRIPTION
Because getblocktxn requests for unknown blocks would trigger a disconnect, while a getblocktxn for known-old blocks would just be ignored, it should be possible to fingerprint a node by seeing which old, non-main-chain blocks trigger disconnect.

The first commit removes the misbehaving score to eliminate this distinction.

In the handling of CMPCTBLOCK messages, the handling for blocks that are announced that have too little work, or where the block was known but pruned, was busted -- for requested blocks, we would generate a getdata for the block, but for unrequested blocks, we'd fall through and try to process.  In particular, this means that announcing old CMPCTBLOCKs could cause a pruning node to redownload old blocks (potentially causing a fill-up-disk DoS).

The second commit fixes this by aborting processing of CMPCTBLOCK messages in this situation.

Please tag this for consideration in 0.13.0.
