### PR TITLE
libconsensus: Expose a flag for BIP112

### DIFF
--- a/src/script/bitcoinconsensus.h
+++ b/src/script/bitcoinconsensus.h
@@ -51,6 +51,7 @@ enum
     bitcoinconsensus_SCRIPT_FLAGS_VERIFY_P2SH                = (1U << 0), // evaluate P2SH (BIP16) subscripts
     bitcoinconsensus_SCRIPT_FLAGS_VERIFY_DERSIG              = (1U << 2), // enforce strict DER (BIP66) compliance
     bitcoinconsensus_SCRIPT_FLAGS_VERIFY_CHECKLOCKTIMEVERIFY = (1U << 9), // enable CHECKLOCKTIMEVERIFY (BIP65)
+    bitcoinconsensus_SCRIPT_FLAGS_VERIFY_CHECKSEQUENCEVERIFY = (1U << 10), // enable CHECKSEQUENCEVERIFY (BIP112)
     bitcoinconsensus_SCRIPT_FLAGS_VERIFY_WITNESS             = (1U << 11), // enable WITNESS (BIP141)
 };
 


### PR DESCRIPTION
We added the segwit one, but we forgot CHECKSEQUENCEVERIFY.
@laanwj this needs backport to 0.13, right?
In fact, I'm thinking that this should have been included in 0.12.1...

Ping @sipa @TheBlueMatt 

~~Bikeshedding: I removed "FLAGS_" in this one and added "_BIP112" at the end instead because I believe it's more useful. I'm happy to change the name of the flag.~~

EDIT: Note that the bit positions have to correspond with those in the flags for scripts in script/interpreter.h.
