### PR TITLE
Trivial: pass Consensus::Params& instead of CChainParams& in ContextualCheckBlock

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -448,7 +448,7 @@ bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::P
  *  By "context", we mean only the previous block headers, but not the UTXO
  *  set; UTXO-related validity checks are done in ConnectBlock(). */
 bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationState& state, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev, int64_t nAdjustedTime);
-bool ContextualCheckBlock(const CBlock& block, CValidationState& state, const CBlockIndex* pindexPrev);
+bool ContextualCheckBlock(const CBlock& block, CValidationState& state, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev);
 
 /** Apply the effects of this block (with given index) on the UTXO set represented by coins.
  *  Validity checks that depend on the UTXO set are also done; ConnectBlock()


### PR DESCRIPTION
Pre-witness my plan was to get rid of ContextualCheckBlock and move its check to ConnectBlock/Consensus::VerifyTx, so this was not necessary.

This should be the last existing consensus function that needs to get Consensus::Params instead of ChainParams or call Params() from inside.
