### PR TITLE
prepend license statement to indirectmap.h

### DIFF
--- a/src/indirectmap.h
+++ b/src/indirectmap.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2016 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #ifndef BITCOIN_INDIRECTMAP_H
 #define BITCOIN_INDIRECTMAP_H
 


### PR DESCRIPTION
Add statement about MIT licensing to indirectmap.h. I forgot about the license preamble when I originally wrote the file.

(Related to: #8286)
