### PR TITLE
[depends] expat 2.2.0, ccache 3.3.1, fontconfig 2.12.1

### DIFF
--- a/depends/packages/expat.mk
+++ b/depends/packages/expat.mk
@@ -1,8 +1,8 @@
 package=expat
-$(package)_version=2.1.1
+$(package)_version=2.2.0
 $(package)_download_path=https://downloads.sourceforge.net/project/expat/expat/$($(package)_version)
 $(package)_file_name=$(package)-$($(package)_version).tar.bz2
-$(package)_sha256_hash=aff584e5a2f759dcfc6d48671e9529f6afe1e30b0cd6a4cec200cbe3f793de67
+$(package)_sha256_hash=d9e50ff2d19b3538bd2127902a89987474e1a4db8e43a66a4d1a712ab9a504ff
 
 define $(package)_set_vars
 $(package)_config_opts=--disable-static

--- a/depends/packages/fontconfig.mk
+++ b/depends/packages/fontconfig.mk
@@ -1,8 +1,8 @@
 package=fontconfig
-$(package)_version=2.11.1
+$(package)_version=2.12.1
 $(package)_download_path=http://www.freedesktop.org/software/fontconfig/release/
 $(package)_file_name=$(package)-$($(package)_version).tar.bz2
-$(package)_sha256_hash=dc62447533bca844463a3c3fd4083b57c90f18a70506e7a9f4936b5a1e516a99
+$(package)_sha256_hash=b449a3e10c47e1d1c7a6ec6e2016cca73d3bd68fbbd4f0ae5cc6b573f7d6c7f3
 $(package)_dependencies=freetype expat
 
 define $(package)_set_vars

--- a/depends/packages/native_ccache.mk
+++ b/depends/packages/native_ccache.mk
@@ -1,8 +1,8 @@
 package=native_ccache
-$(package)_version=3.2.5
-$(package)_download_path=http://samba.org/ftp/ccache
+$(package)_version=3.3.1
+$(package)_download_path=https://samba.org/ftp/ccache
 $(package)_file_name=ccache-$($(package)_version).tar.bz2
-$(package)_sha256_hash=7a553809e90faf9de3a23ee9c5b5f786cfd4836bf502744bedb824a24bee1097
+$(package)_sha256_hash=cb6e4bafbb19ba0a2ec43386b123a5f92a20e1e3384c071d5d13e0cb3c84bf73
 
 define $(package)_set_vars
 $(package)_config_opts=


### PR DESCRIPTION
[expat 2.2.0](http://expat.sourceforge.net)

```
CVE-2016-0718 (issue 537) - Fix crash on malformed input
CVE-2016-4472 - Improve insufficient fix to CVE-2015-1283 / CVE-2015-2716 introduced with Expat 2.1.1
CVE-2016-5300 (issue 499) - Use more entropy for hash initialization than the original fix to CVE-2012-0876
CVE-2012-6702 (issue 519) - Resolve troublesome internal call to srand that was introduced with Expat 2.1.0 when addressing CVE-2012-0876 (issue 496)
Fix uninitialized reads of size 1 (e.g. in little2_updatePosition)
Fix detection of UTF-8 character boundaries
```

ccache 3.3.1 - [release notes](https://ccache.samba.org/releasenotes.html#_ccache_3_3_1)

fontconfig 2.12.1 - [release notes](https://www.freedesktop.org/software/fontconfig/release/ChangeLog-2.12.1)
