### PR TITLE
[qa] Rework hd wallet dump test

### DIFF
--- a/qa/rpc-tests/wallet-dump.py
+++ b/qa/rpc-tests/wallet-dump.py
@@ -4,9 +4,52 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
-import os
-import shutil
+from test_framework.util import (start_nodes, start_node, assert_equal, bitcoind_processes)
+
+
+def read_dump(file_name, addrs, hd_master_addr_old):
+    """
+    Read the given dump, count the addrs that match, count change and reserve.
+    Also check that the old hd_master is inactive
+    """
+    with open(file_name) as inputfile:
+        found_addr = 0
+        found_addr_chg = 0
+        found_addr_rsv = 0
+        hd_master_addr_ret = None
+        for line in inputfile:
+            # only read non comment lines
+            if line[0] != "#" and len(line) > 10:
+                # split out some data
+                key_label, comment = line.split("#")
+                # key = key_label.split(" ")[0]
+                keytype = key_label.split(" ")[2]
+                if len(comment) > 1:
+                    addr_keypath = comment.split(" addr=")[1]
+                    addr = addr_keypath.split(" ")[0]
+                    keypath = None
+                    if keytype == "inactivehdmaster=1":
+                        # ensure the old master is still available
+                        assert(hd_master_addr_old == addr)
+                    elif keytype == "hdmaster=1":
+                        # ensure we have generated a new hd master key
+                        assert(hd_master_addr_old != addr)
+                        hd_master_addr_ret = addr
+                    else:
+                        keypath = addr_keypath.rstrip().split("hdkeypath=")[1]
+
+                    # count key types
+                    for addrObj in addrs:
+                        if addrObj['address'] == addr and addrObj['hdkeypath'] == keypath and keytype == "label=":
+                            found_addr += 1
+                            break
+                        elif keytype == "change=1":
+                            found_addr_chg += 1
+                            break
+                        elif keytype == "reserve=1":
+                            found_addr_rsv += 1
+                            break
+        return found_addr, found_addr_chg, found_addr_rsv, hd_master_addr_ret
 
 
 class WalletDumpTest(BitcoinTestFramework):
@@ -15,106 +58,47 @@ class WalletDumpTest(BitcoinTestFramework):
         super().__init__()
         self.setup_clean_chain = False
         self.num_nodes = 1
+        self.extra_args = [["-keypool=90"]]
 
     def setup_network(self, split=False):
-        extra_args = [["-keypool=100"]]
-        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, extra_args)
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, self.extra_args)
 
     def run_test (self):
         tmpdir = self.options.tmpdir
 
-        #generate 20 addresses to compare against the dump
+        # generate 20 addresses to compare against the dump
         test_addr_count = 20
         addrs = []
         for i in range(0,test_addr_count):
             addr = self.nodes[0].getnewaddress()
             vaddr= self.nodes[0].validateaddress(addr) #required to get hd keypath
             addrs.append(vaddr)
+        # Should be a no-op:
+        self.nodes[0].keypoolrefill()
 
         # dump unencrypted wallet
         self.nodes[0].dumpwallet(tmpdir + "/node0/wallet.unencrypted.dump")
 
-        #open file
-        inputfile = open(tmpdir + "/node0/wallet.unencrypted.dump")
-        found_addr = 0
-        found_addr_chg = 0
-        found_addr_rsv = 0
-        hdmasteraddr = ""
-        for line in inputfile:
-            #only read non comment lines
-            if line[0] != "#" and len(line) > 10:
-                #split out some data
-                keyLabel, comment = line.split("#")
-                key = keyLabel.split(" ")[0]
-                keytype = keyLabel.split(" ")[2]
-                if len(comment) > 1:
-                    addrKeypath = comment.split(" addr=")[1]
-                    addr = addrKeypath.split(" ")[0]
-                    keypath = ""
-                    if keytype != "hdmaster=1":
-                        keypath = addrKeypath.rstrip().split("hdkeypath=")[1]
-                    else:
-                        #keep hd master for later comp.
-                        hdmasteraddr = addr
-
-                    #count key types
-                    for addrObj in addrs:
-                        if (addrObj['address'] == addr and addrObj['hdkeypath'] == keypath and keytype == "label="):
-                            found_addr+=1
-                            break
-                        elif (keytype == "change=1"):
-                            found_addr_chg+=1
-                            break
-                        elif (keytype == "reserve=1"):
-                            found_addr_rsv+=1
-                            break
-        assert(found_addr == test_addr_count) #all keys must be in the dump
-        assert(found_addr_chg == 50) #50 blocks where mined
-        assert(found_addr_rsv == 100) #100 reserve keys (keypool)
+        found_addr, found_addr_chg, found_addr_rsv, hd_master_addr_unenc = \
+            read_dump(tmpdir + "/node0/wallet.unencrypted.dump", addrs, None)
+        assert_equal(found_addr, test_addr_count)  # all keys must be in the dump
+        assert_equal(found_addr_chg, 50)  # 50 blocks where mined
+        assert_equal(found_addr_rsv, 90 + 1)  # keypool size (TODO: fix off-by-one)
 
         #encrypt wallet, restart, unlock and dump
         self.nodes[0].encryptwallet('test')
         bitcoind_processes[0].wait()
-        self.nodes[0] = start_node(0, self.options.tmpdir)
+        self.nodes[0] = start_node(0, self.options.tmpdir, self.extra_args[0])
         self.nodes[0].walletpassphrase('test', 10)
+        # Should be a no-op:
+        self.nodes[0].keypoolrefill()
         self.nodes[0].dumpwallet(tmpdir + "/node0/wallet.encrypted.dump")
 
-        #open dump done with an encrypted wallet
-        inputfile = open(tmpdir + "/node0/wallet.encrypted.dump")
-        found_addr = 0
-        found_addr_chg = 0
-        found_addr_rsv = 0
-        for line in inputfile:
-            if line[0] != "#" and len(line) > 10:
-                keyLabel, comment = line.split("#")
-                key = keyLabel.split(" ")[0]
-                keytype = keyLabel.split(" ")[2]
-                if len(comment) > 1:
-                    addrKeypath = comment.split(" addr=")[1]
-                    addr = addrKeypath.split(" ")[0]
-                    keypath = ""
-                    if keytype != "hdmaster=1":
-                        keypath = addrKeypath.rstrip().split("hdkeypath=")[1]
-                    else:
-                        #ensure we have generated a new hd master key
-                        assert(hdmasteraddr != addr)
-                    if keytype == "inactivehdmaster=1":
-                        #ensure the old master is still available
-                        assert(hdmasteraddr == addr)
-                    for addrObj in addrs:
-                        if (addrObj['address'] == addr and addrObj['hdkeypath'] == keypath and keytype == "label="):
-                            found_addr+=1
-                            break
-                        elif (keytype == "change=1"):
-                            found_addr_chg+=1
-                            break
-                        elif (keytype == "reserve=1"):
-                            found_addr_rsv+=1
-                            break
-
-        assert(found_addr == test_addr_count)
-        assert(found_addr_chg == 150) #old reserve keys are marked as change now
-        assert(found_addr_rsv == 100) #keypool size
+        found_addr, found_addr_chg, found_addr_rsv, hd_master_addr_enc = \
+            read_dump(tmpdir + "/node0/wallet.encrypted.dump", addrs, hd_master_addr_unenc)
+        assert_equal(found_addr, test_addr_count)
+        assert_equal(found_addr_chg, 90 + 1 + 50)  # old reserve keys are marked as change now
+        assert_equal(found_addr_rsv, 90 + 1)  # keypool size (TODO: fix off-by-one)
 
 if __name__ == '__main__':
     WalletDumpTest().main ()


### PR DESCRIPTION
This fixes my nits from #8417... The largest chunk is moving most of the code into `read_dump`, to get rid of the duplicated code.
