### PR TITLE
[Trivial] Do not shadow local variable, cleanup

### DIFF
--- a/src/blockencodings.h
+++ b/src/blockencodings.h
@@ -53,11 +53,11 @@ public:
             }
 
             uint16_t offset = 0;
-            for (size_t i = 0; i < indexes.size(); i++) {
-                if (uint64_t(indexes[i]) + uint64_t(offset) > std::numeric_limits<uint16_t>::max())
+            for (size_t j = 0; j < indexes.size(); j++) {
+                if (uint64_t(indexes[j]) + uint64_t(offset) > std::numeric_limits<uint16_t>::max())
                     throw std::ios_base::failure("indexes overflowed 16 bits");
-                indexes[i] = indexes[i] + offset;
-                offset = indexes[i] + 1;
+                indexes[j] = indexes[j] + offset;
+                offset = indexes[j] + 1;
             }
         } else {
             for (size_t i = 0; i < indexes.size(); i++) {

--- a/src/test/blockencodings_tests.cpp
+++ b/src/test/blockencodings_tests.cpp
@@ -283,7 +283,6 @@ BOOST_AUTO_TEST_CASE(EmptyBlockRoundTripTest)
         std::vector<CTransaction> vtx_missing;
         BOOST_CHECK(partialBlock.FillBlock(block2, vtx_missing) == READ_STATUS_OK);
         BOOST_CHECK_EQUAL(block.GetHash().ToString(), block2.GetHash().ToString());
-        bool mutated;
         BOOST_CHECK_EQUAL(block.hashMerkleRoot.ToString(), BlockMerkleRoot(block2, &mutated).ToString());
         BOOST_CHECK(!mutated);
     }


### PR DESCRIPTION
I was not available when #8068 was merged, sorry for late fix.

~~This limits the scope of local variable, unifies `for` cycles used and as a side effect/bonus, fixes three instances of `-Wshadow` warnings ;-)~~

For the reference, fixed warning is:

```
./blockencodings.h:56:25: warning: declaration shadows a local variable [-Wshadow]
            for (size_t i = 0; i < indexes.size(); i++) {
                        ^
./blockencodings.h:43:20: note: previous declaration is here
            size_t i = 0;
                   ^
```

For more details, see #8105.
