### PR TITLE
Get rid of the const field in CTransaction

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3494,7 +3494,7 @@ std::vector<unsigned char> GenerateCoinbaseCommitment(CBlock& block, const CBloc
             out.scriptPubKey[5] = 0xed;
             memcpy(&out.scriptPubKey[6], witnessroot.begin(), 32);
             commitment = std::vector<unsigned char>(out.scriptPubKey.begin(), out.scriptPubKey.end());
-            const_cast<std::vector<CTxOut>*>(&block.vtx[0].vout)->push_back(out);
+            block.vtx[0].vout.push_back(out);
             block.vtx[0].UpdateHash();
         }
     }
@@ -4319,7 +4319,7 @@ bool InitBlockIndex(const CChainParams& chainparams)
     // Only add the genesis block if not reindexing (in which case we reuse the one already on disk)
     if (!fReindex) {
         try {
-            CBlock &block = const_cast<CBlock&>(chainparams.GenesisBlock());
+            CBlock block = chainparams.GenesisBlock();
             // Start new block file
             unsigned int nBlockSize = ::GetSerializeSize(block, SER_DISK, CLIENT_VERSION);
             CDiskBlockPos blockPos;

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -67,9 +67,9 @@ uint256 CMutableTransaction::GetHash() const
     return SerializeHash(*this, SER_GETHASH, SERIALIZE_TRANSACTION_NO_WITNESS);
 }
 
-void CTransaction::UpdateHash() const
+void CTransaction::UpdateHash()
 {
-    *const_cast<uint256*>(&hash) = SerializeHash(*this, SER_GETHASH, SERIALIZE_TRANSACTION_NO_WITNESS);
+    hash = SerializeHash(*this, SER_GETHASH, SERIALIZE_TRANSACTION_NO_WITNESS);
 }
 
 uint256 CTransaction::GetWitnessHash() const
@@ -84,12 +84,12 @@ CTransaction::CTransaction(const CMutableTransaction &tx) : nVersion(tx.nVersion
 }
 
 CTransaction& CTransaction::operator=(const CTransaction &tx) {
-    *const_cast<int*>(&nVersion) = tx.nVersion;
-    *const_cast<std::vector<CTxIn>*>(&vin) = tx.vin;
-    *const_cast<std::vector<CTxOut>*>(&vout) = tx.vout;
-    *const_cast<CTxWitness*>(&wit) = tx.wit;
-    *const_cast<unsigned int*>(&nLockTime) = tx.nLockTime;
-    *const_cast<uint256*>(&hash) = tx.hash;
+    nVersion = tx.nVersion;
+    vin = tx.vin;
+    vout = tx.vout;
+    wit = tx.wit;
+    nLockTime = tx.nLockTime;
+    hash = tx.hash;
     return *this;
 }
 

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -292,29 +292,29 @@ template<typename Stream, typename Operation, typename TxType>
 inline void SerializeTransaction(TxType& tx, Stream& s, Operation ser_action, int nType, int nVersion) {
     const bool fAllowWitness = !(nVersion & SERIALIZE_TRANSACTION_NO_WITNESS);
 
-    READWRITE(*const_cast<int32_t*>(&tx.nVersion));
+    READWRITE(tx.nVersion);
     unsigned char flags = 0;
     if (ser_action.ForRead()) {
-        const_cast<std::vector<CTxIn>*>(&tx.vin)->clear();
-        const_cast<std::vector<CTxOut>*>(&tx.vout)->clear();
-        const_cast<CTxWitness*>(&tx.wit)->SetNull();
+        tx.vin.clear();
+        tx.vout.clear();
+        tx.wit.SetNull();
         /* Try to read the vin. In case the dummy is there, this will be read as an empty vector. */
-        READWRITE(*const_cast<std::vector<CTxIn>*>(&tx.vin));
+        READWRITE(tx.vin);
         if (tx.vin.size() == 0 && fAllowWitness) {
             /* We read a dummy or an empty vin. */
             READWRITE(flags);
             if (flags != 0) {
-                READWRITE(*const_cast<std::vector<CTxIn>*>(&tx.vin));
-                READWRITE(*const_cast<std::vector<CTxOut>*>(&tx.vout));
+                READWRITE(tx.vin);
+                READWRITE(tx.vout);
             }
         } else {
             /* We read a non-empty vin. Assume a normal vout follows. */
-            READWRITE(*const_cast<std::vector<CTxOut>*>(&tx.vout));
+            READWRITE(tx.vout);
         }
         if ((flags & 1) && fAllowWitness) {
             /* The witness flag is present, and we support witnesses. */
             flags ^= 1;
-            const_cast<CTxWitness*>(&tx.wit)->vtxinwit.resize(tx.vin.size());
+            tx.wit.vtxinwit.resize(tx.vin.size());
             READWRITE(tx.wit);
         }
         if (flags) {
@@ -336,24 +336,27 @@ inline void SerializeTransaction(TxType& tx, Stream& s, Operation ser_action, in
             READWRITE(vinDummy);
             READWRITE(flags);
         }
-        READWRITE(*const_cast<std::vector<CTxIn>*>(&tx.vin));
-        READWRITE(*const_cast<std::vector<CTxOut>*>(&tx.vout));
+        READWRITE(tx.vin);
+        READWRITE(tx.vout);
         if (flags & 1) {
-            const_cast<CTxWitness*>(&tx.wit)->vtxinwit.resize(tx.vin.size());
+            tx.wit.vtxinwit.resize(tx.vin.size());
             READWRITE(tx.wit);
         }
     }
-    READWRITE(*const_cast<uint32_t*>(&tx.nLockTime));
+    READWRITE(tx.nLockTime);
 }
 
 /** The basic transaction that is broadcasted on the network and contained in
  * blocks.  A transaction can contain multiple inputs and outputs.
+ *
+ * This version has a cached hash value, and requires calling UpdateHash
+ * after any modifications are made.
  */
 class CTransaction
 {
 private:
     /** Memory only. */
-    const uint256 hash;
+    uint256 hash;
 
 public:
     // Default transaction version.
@@ -365,16 +368,14 @@ public:
     // MAX_STANDARD_VERSION will be equal.
     static const int32_t MAX_STANDARD_VERSION=2;
 
-    // The local variables are made const to prevent unintended modification
-    // without updating the cached hash value. However, CTransaction is not
-    // actually immutable; deserialization and assignment are implemented,
-    // and bypass the constness. This is safe, as they update the entire
-    // structure, including the hash.
-    const int32_t nVersion;
-    const std::vector<CTxIn> vin;
-    const std::vector<CTxOut> vout;
-    CTxWitness wit; // Not const: can change without invalidating the txid cache
-    const uint32_t nLockTime;
+    // Modification of any of the fields below (except wit) requires a call to
+    // UpdateHash() before further use. Consider using CMutableTransaction
+    // instead if frequent modification is needed.
+    int32_t nVersion;
+    std::vector<CTxIn> vin;
+    std::vector<CTxOut> vout;
+    CTxWitness wit;
+    uint32_t nLockTime;
 
     /** Construct a CTransaction that qualifies as IsNull() */
     CTransaction();
@@ -433,10 +434,10 @@ public:
 
     std::string ToString() const;
 
-    void UpdateHash() const;
+    void UpdateHash();
 };
 
-/** A mutable version of CTransaction. */
+/** A version of CTransaction without cached hash. */
 struct CMutableTransaction
 {
     int32_t nVersion;


### PR DESCRIPTION
As explained on https://github.com/zcash/zcash/issues/967, using const member fields in CTransaction (or any deserializable class) is not well defined in C++, as such fields should only ever be assigned at construction time.

I believe we can get rid of them. Their purpose was making sure that CTransaction was not used in places where mutable fields were required, but now that CMutableTransaction is well-established that requirement is not so strong anymore.

Longer term, I'd prefer to see better encapsulation of CTransaction (which could also introduce better internal representation of the data, without a gazillion allocations) and improvements to the serialization framework so that we can construct objects by deserializing... but I think that's further out than a fix for this.

So at a higher level, this changes CTransaction from "immutable transaction data" to "transaction data with cached hashes". I've added a small comment about this as well.

Ping @daira @ebfull.
