### PR TITLE
Add block height support in rpc call getblock

### DIFF
--- a/qa/rpc-tests/rest.py
+++ b/qa/rpc-tests/rest.py
@@ -265,6 +265,20 @@ class RESTTest (BitcoinTestFramework):
         assert_equal(json_obj[0]['chainwork'],          rpc_block_json['chainwork'])
         assert_equal(json_obj[0]['previousblockhash'],  rpc_block_json['previousblockhash'])
 
+        #compare with normal RPC block response and support by block height
+        rpc_block_json = self.nodes[0].getblock(str(json_obj[0]['height']))
+        assert_equal(json_obj[0]['hash'],               rpc_block_json['hash'])
+        assert_equal(json_obj[0]['confirmations'],      rpc_block_json['confirmations'])
+        assert_equal(json_obj[0]['height'],             rpc_block_json['height'])
+        assert_equal(json_obj[0]['version'],            rpc_block_json['version'])
+        assert_equal(json_obj[0]['merkleroot'],         rpc_block_json['merkleroot'])
+        assert_equal(json_obj[0]['time'],               rpc_block_json['time'])
+        assert_equal(json_obj[0]['nonce'],              rpc_block_json['nonce'])
+        assert_equal(json_obj[0]['bits'],               rpc_block_json['bits'])
+        assert_equal(json_obj[0]['difficulty'],         rpc_block_json['difficulty'])
+        assert_equal(json_obj[0]['chainwork'],          rpc_block_json['chainwork'])
+        assert_equal(json_obj[0]['previousblockhash'],  rpc_block_json['previousblockhash'])
+
         #see if we can get 5 headers in one response
         self.nodes[1].generate(5)
         self.sync_all()

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -551,7 +551,7 @@ UniValue getblock(const UniValue& params, bool fHelp)
             "\nIf verbose is false, returns a string that is serialized, hex-encoded data for block 'hash'.\n"
             "If verbose is true, returns an Object with information about block <hash>.\n"
             "\nArguments:\n"
-            "1. \"hash\"          (string, required) The block hash\n"
+            "1. \"hash|height\"     (string | numeric, required) The block hash or the block height\n"
             "2. verbose           (boolean, optional, default=true) true for a json object, false for the hex encoded data\n"
             "\nResult (for verbose = true):\n"
             "{\n"
@@ -582,22 +582,37 @@ UniValue getblock(const UniValue& params, bool fHelp)
             "\nExamples:\n"
             + HelpExampleCli("getblock", "\"00000000c937983704a73af28acdec37b049d214adbda81d7e2a3dd146f6ed09\"")
             + HelpExampleRpc("getblock", "\"00000000c937983704a73af28acdec37b049d214adbda81d7e2a3dd146f6ed09\"")
+            + HelpExampleCli("getblock", "\"0\"")
+            + HelpExampleRpc("getblock", "\"0\"")
         );
 
     LOCK(cs_main);
 
     std::string strHash = params[0].get_str();
-    uint256 hash(uint256S(strHash));
 
     bool fVerbose = true;
     if (params.size() > 1)
         fVerbose = params[1].get_bool();
 
-    if (mapBlockIndex.count(hash) == 0)
-        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found");
-
     CBlock block;
-    CBlockIndex* pblockindex = mapBlockIndex[hash];
+    CBlockIndex* pblockindex;
+    int32_t nHeight;
+
+    if (((strHash.size() != 64) || !IsHex(strHash)) && ParseInt32(strHash, &nHeight)) {
+        pblockindex = chainActive[nHeight];
+
+        if (!pblockindex) {
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "Block height out of range");
+        }
+    } else {
+        uint256 hash(uint256S(strHash));
+
+        if (mapBlockIndex.count(hash) == 0) {
+            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found");
+        }
+
+        pblockindex = mapBlockIndex[hash];
+    }
 
     if (fHavePruned && !(pblockindex->nStatus & BLOCK_HAVE_DATA) && pblockindex->nTx > 0)
         throw JSONRPCError(RPC_INTERNAL_ERROR, "Block not available (pruned data)");


### PR DESCRIPTION
This is a simple PR: add support for getting a block by its height via RPC call `getblock`.

Instead of 2 calls `bitcoin-cli getblockhash 0` + `bitcoin-cli getblock <hash>`
we call directly `bitcoin-cli getblock 0`.

**Note:** it will continue to support via block hash.
