### PR TITLE
Parametrize buried soft fork in regtest and refactor

### DIFF
--- a/qa/rpc-tests/bip65-cltv-p2p.py
+++ b/qa/rpc-tests/bip65-cltv-p2p.py
@@ -20,19 +20,6 @@ def cltv_invalidate(tx):
     tx.vin[0].scriptSig = CScript([OP_1NEGATE, OP_CHECKLOCKTIMEVERIFY, OP_DROP] +
                                   list(CScript(tx.vin[0].scriptSig)))
 
-'''
-This test is meant to exercise BIP65 (CHECKLOCKTIMEVERIFY)
-Connect to a single node.
-Mine 2 (version 3) blocks (save the coinbases for later).
-Generate 98 more version 3 blocks, verify the node accepts.
-Mine 749 version 4 blocks, verify the node accepts.
-Check that the new CLTV rules are not enforced on the 750th version 4 block.
-Check that the new CLTV rules are enforced on the 751st version 4 block.
-Mine 199 new version blocks.
-Mine 1 old-version block.
-Mine 1 new version block.
-Mine 1 old version block, see that the node rejects.
-'''
 
 class BIP65Test(ComparisonTestFramework):
 
@@ -64,7 +51,7 @@ class BIP65Test(ComparisonTestFramework):
         return tx
 
     def get_tests(self):
-
+        # Mine 2 (version 3) blocks (save the coinbases for later).
         self.coinbase_blocks = self.nodes[0].generate(2)
         height = 3  # height of the next block to build
         self.tip = int("0x" + self.nodes[0].getbestblockhash(), 0)
@@ -84,43 +71,9 @@ class BIP65Test(ComparisonTestFramework):
             height += 1
         yield TestInstance(test_blocks, sync_every_block=False)
 
-        ''' Mine 749 version 4 blocks '''
+        ''' Mine 948 version 4 blocks '''
         test_blocks = []
-        for i in range(749):
-            block = create_block(self.tip, create_coinbase(height), self.last_block_time + 1)
-            block.nVersion = 4
-            block.rehash()
-            block.solve()
-            test_blocks.append([block, True])
-            self.last_block_time += 1
-            self.tip = block.sha256
-            height += 1
-        yield TestInstance(test_blocks, sync_every_block=False)
-
-        '''
-        Check that the new CLTV rules are not enforced in the 750th
-        version 3 block.
-        '''
-        spendtx = self.create_transaction(self.nodes[0],
-                self.coinbase_blocks[0], self.nodeaddress, 1.0)
-        cltv_invalidate(spendtx)
-        spendtx.rehash()
-
-        block = create_block(self.tip, create_coinbase(height), self.last_block_time + 1)
-        block.nVersion = 4
-        block.vtx.append(spendtx)
-        block.hashMerkleRoot = block.calc_merkle_root()
-        block.rehash()
-        block.solve()
-
-        self.last_block_time += 1
-        self.tip = block.sha256
-        height += 1
-        yield TestInstance([[block, True]])
-
-        ''' Mine 199 new version blocks on last valid tip '''
-        test_blocks = []
-        for i in range(199):
+        for i in range(948):
             block = create_block(self.tip, create_coinbase(height), self.last_block_time + 1)
             block.nVersion = 4
             block.rehash()
@@ -141,19 +94,28 @@ class BIP65Test(ComparisonTestFramework):
         height += 1
         yield TestInstance([[block, True]])
 
-        ''' Mine 1 new version block '''
+        '''
+        Check that the new CLTV rules are not enforced at height 1050 (v4 block)
+        '''
+        spendtx = self.create_transaction(self.nodes[0],
+                self.coinbase_blocks[0], self.nodeaddress, 1.0)
+        cltv_invalidate(spendtx)
+        spendtx.rehash()
+
         block = create_block(self.tip, create_coinbase(height), self.last_block_time + 1)
         block.nVersion = 4
+        block.vtx.append(spendtx)
+        block.hashMerkleRoot = block.calc_merkle_root()
         block.rehash()
         block.solve()
+
         self.last_block_time += 1
         self.tip = block.sha256
         height += 1
         yield TestInstance([[block, True]])
 
         '''
-        Check that the new CLTV rules are enforced in the 951st version 4
-        block.
+        Check that the new CLTV rules are enforced at height 1051
         '''
         spendtx = self.create_transaction(self.nodes[0],
                 self.coinbase_blocks[1], self.nodeaddress, 1.0)
@@ -176,6 +138,14 @@ class BIP65Test(ComparisonTestFramework):
         block.solve()
         self.last_block_time += 1
         yield TestInstance([[block, False]])
+
+        ''' Mine 1 new version block, should be valid '''
+        block = create_block(self.tip, create_coinbase(height), self.last_block_time + 1)
+        block.nVersion = 4
+        block.rehash()
+        block.solve()
+        self.last_block_time += 1
+        yield TestInstance([[block, True]])
 
 if __name__ == '__main__':
     BIP65Test().main()

--- a/qa/rpc-tests/bip65-cltv-p2p.py
+++ b/qa/rpc-tests/bip65-cltv-p2p.py
@@ -43,7 +43,7 @@ class BIP65Test(ComparisonTestFramework):
     def setup_network(self):
         # Must set the blockversion for this test
         self.nodes = start_nodes(self.num_nodes, self.options.tmpdir,
-                                 extra_args=[['-debug', '-whitelist=127.0.0.1', '-blockversion=3', '-buriedsfparams=bip65:1351']],
+                                 extra_args=[['-debug', '-whitelist=127.0.0.1', '-blockversion=3', '-buriedsfparams=bip65:1051']],
                                  binary=[self.options.testbinary])
 
     def run_test(self):
@@ -71,9 +71,9 @@ class BIP65Test(ComparisonTestFramework):
         self.nodeaddress = self.nodes[0].getnewaddress()
         self.last_block_time = int(time.time())
 
-        ''' 398 more version 3 blocks '''
+        ''' 98 more version 3 blocks '''
         test_blocks = []
-        for i in range(398):
+        for i in range(98):
             block = create_block(self.tip, create_coinbase(height), self.last_block_time + 1)
             block.nVersion = 3
             block.rehash()

--- a/qa/rpc-tests/bip65-cltv-p2p.py
+++ b/qa/rpc-tests/bip65-cltv-p2p.py
@@ -43,7 +43,7 @@ class BIP65Test(ComparisonTestFramework):
     def setup_network(self):
         # Must set the blockversion for this test
         self.nodes = start_nodes(self.num_nodes, self.options.tmpdir,
-                                 extra_args=[['-debug', '-whitelist=127.0.0.1', '-blockversion=3']],
+                                 extra_args=[['-debug', '-whitelist=127.0.0.1', '-blockversion=3', '-buriedsfparams=bip65:1351']],
                                  binary=[self.options.testbinary])
 
     def run_test(self):

--- a/qa/rpc-tests/bip65-cltv.py
+++ b/qa/rpc-tests/bip65-cltv.py
@@ -19,8 +19,8 @@ class BIP65Test(BitcoinTestFramework):
     def setup_network(self):
         self.nodes = []
         self.nodes.append(start_node(0, self.options.tmpdir, []))
-        self.nodes.append(start_node(1, self.options.tmpdir, ["-blockversion=3", "-buriedsfparams=bip65:1351"]))
-        self.nodes.append(start_node(2, self.options.tmpdir, ["-blockversion=4", "-buriedsfparams=bip65:1351"]))
+        self.nodes.append(start_node(1, self.options.tmpdir, ["-blockversion=3", "-buriedsfparams=bip65:1251"]))
+        self.nodes.append(start_node(2, self.options.tmpdir, ["-blockversion=4", "-buriedsfparams=bip65:1251"]))
         connect_nodes(self.nodes[1], 0)
         connect_nodes(self.nodes[2], 0)
         self.is_network_split = False
@@ -30,8 +30,7 @@ class BIP65Test(BitcoinTestFramework):
         cnt = self.nodes[0].getblockcount()
 
         # Mine some old-version blocks
-        self.nodes[1].generate(200)
-        cnt += 100
+        self.nodes[1].generate(100)
         self.sync_all()
         if (self.nodes[0].getblockcount() != cnt + 100):
             raise AssertionError("Failed to mine 100 version=3 blocks")

--- a/qa/rpc-tests/bip65-cltv.py
+++ b/qa/rpc-tests/bip65-cltv.py
@@ -19,8 +19,8 @@ class BIP65Test(BitcoinTestFramework):
     def setup_network(self):
         self.nodes = []
         self.nodes.append(start_node(0, self.options.tmpdir, []))
-        self.nodes.append(start_node(1, self.options.tmpdir, ["-blockversion=3"]))
-        self.nodes.append(start_node(2, self.options.tmpdir, ["-blockversion=4"]))
+        self.nodes.append(start_node(1, self.options.tmpdir, ["-blockversion=3", "-buriedsfparams=bip65:1351"]))
+        self.nodes.append(start_node(2, self.options.tmpdir, ["-blockversion=4", "-buriedsfparams=bip65:1351"]))
         connect_nodes(self.nodes[1], 0)
         connect_nodes(self.nodes[2], 0)
         self.is_network_split = False

--- a/qa/rpc-tests/bipdersig-p2p.py
+++ b/qa/rpc-tests/bipdersig-p2p.py
@@ -51,7 +51,7 @@ class BIP66Test(ComparisonTestFramework):
     def setup_network(self):
         # Must set the blockversion for this test
         self.nodes = start_nodes(self.num_nodes, self.options.tmpdir,
-                                 extra_args=[['-debug', '-whitelist=127.0.0.1', '-blockversion=2', '-buriedsfparams=bip66:1251']],
+                                 extra_args=[['-debug', '-whitelist=127.0.0.1', '-blockversion=2', '-buriedsfparams=bip66:1051']],
                                  binary=[self.options.testbinary])
 
     def run_test(self):
@@ -79,9 +79,9 @@ class BIP66Test(ComparisonTestFramework):
         self.nodeaddress = self.nodes[0].getnewaddress()
         self.last_block_time = int(time.time())
 
-        ''' 298 more version 2 blocks '''
+        ''' 98 more version 2 blocks '''
         test_blocks = []
-        for i in range(298):
+        for i in range(98):
             block = create_block(self.tip, create_coinbase(height), self.last_block_time + 1)
             block.nVersion = 2
             block.rehash()

--- a/qa/rpc-tests/bipdersig-p2p.py
+++ b/qa/rpc-tests/bipdersig-p2p.py
@@ -51,7 +51,7 @@ class BIP66Test(ComparisonTestFramework):
     def setup_network(self):
         # Must set the blockversion for this test
         self.nodes = start_nodes(self.num_nodes, self.options.tmpdir,
-                                 extra_args=[['-debug', '-whitelist=127.0.0.1', '-blockversion=2']],
+                                 extra_args=[['-debug', '-whitelist=127.0.0.1', '-blockversion=2', '-buriedsfparams=bip66:1251']],
                                  binary=[self.options.testbinary])
 
     def run_test(self):

--- a/qa/rpc-tests/bipdersig.py
+++ b/qa/rpc-tests/bipdersig.py
@@ -19,8 +19,8 @@ class BIP66Test(BitcoinTestFramework):
     def setup_network(self):
         self.nodes = []
         self.nodes.append(start_node(0, self.options.tmpdir, []))
-        self.nodes.append(start_node(1, self.options.tmpdir, ["-blockversion=2"]))
-        self.nodes.append(start_node(2, self.options.tmpdir, ["-blockversion=3"]))
+        self.nodes.append(start_node(1, self.options.tmpdir, ["-blockversion=2", '-buriedsfparams=bip66:1251']))
+        self.nodes.append(start_node(2, self.options.tmpdir, ["-blockversion=3", '-buriedsfparams=bip66:1251']))
         connect_nodes(self.nodes[1], 0)
         connect_nodes(self.nodes[2], 0)
         self.is_network_split = False

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -70,6 +70,7 @@ class CMainParams : public CChainParams {
 public:
     CMainParams() {
         strNetworkID = "main";
+        fAllowsOverriddenSoftFork = false;
         consensus.nSubsidyHalvingInterval = 210000;
         consensus.vBuriedDeploymentHeights[Consensus::BIP34_HEIGHT_ACTIVE] = 227931;
         consensus.BIP34Hash = uint256S("0x000000000000024b89b42a942fe0d9fea3bb44ab7bd1b19115dd6a759c0808b8");
@@ -168,6 +169,7 @@ class CTestNetParams : public CChainParams {
 public:
     CTestNetParams() {
         strNetworkID = "test";
+        fAllowsOverriddenSoftFork = false;
         consensus.nSubsidyHalvingInterval = 210000;
         consensus.vBuriedDeploymentHeights[Consensus::BIP34_HEIGHT_ACTIVE] = 21111;
         consensus.BIP34Hash = uint256S("0x0000000023b3a96d3484e5abb3755c413e7d41500f8e2a5c3f0dd01299cd8ef8");
@@ -250,6 +252,7 @@ class CRegTestParams : public CChainParams {
 public:
     CRegTestParams() {
         strNetworkID = "regtest";
+        fAllowsOverriddenSoftFork = true;
         consensus.nSubsidyHalvingInterval = 150;
         consensus.vBuriedDeploymentHeights[Consensus::BIP34_HEIGHT_ACTIVE] = 100000000; // Configurable with -buriedsfparams
         consensus.BIP34Hash = uint256();
@@ -309,11 +312,6 @@ public:
         base58Prefixes[EXT_SECRET_KEY] = boost::assign::list_of(0x04)(0x35)(0x83)(0x94).convert_to_container<std::vector<unsigned char> >();
     }
 
-    void UpdateBIP9Parameters(Consensus::DeploymentPos d, int64_t nStartTime, int64_t nTimeout)
-    {
-        consensus.vDeployments[d].nStartTime = nStartTime;
-        consensus.vDeployments[d].nTimeout = nTimeout;
-    }
 };
 static CRegTestParams regTestParams;
 
@@ -329,9 +327,10 @@ void CChainParams::UpdateBuriedDeploymentParameters(Consensus::BuriedDeploymentP
     consensus.vBuriedDeploymentHeights[deployment] = nStartHeight;
 }
 
-void UpdateRegtestBuriedDeploymentParameters(Consensus::BuriedDeploymentPos deployment, int64_t nStartHeight)
+void CChainParams::UpdateBIP9Parameters(Consensus::DeploymentPos d, int64_t nStartTime, int64_t nTimeout)
 {
-    regTestParams.UpdateBuriedDeploymentParameters(deployment, nStartHeight);
+    consensus.vDeployments[d].nStartTime = nStartTime;
+    consensus.vDeployments[d].nTimeout = nTimeout;
 }
 
 CChainParams& Params(const std::string& chain)
@@ -351,9 +350,3 @@ void SelectParams(const std::string& network)
     SelectBaseParams(network);
     pCurrentParams = &Params(network);
 }
-
-void UpdateRegtestBIP9Parameters(Consensus::DeploymentPos d, int64_t nStartTime, int64_t nTimeout)
-{
-    regTestParams.UpdateBIP9Parameters(d, nStartTime, nTimeout);
-}
- 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -71,10 +71,10 @@ public:
     CMainParams() {
         strNetworkID = "main";
         consensus.nSubsidyHalvingInterval = 210000;
-        consensus.BIP34Height = 227931;
+        consensus.vBuriedDeploymentHeights[Consensus::BIP34_HEIGHT_ACTIVE] = 227931;
         consensus.BIP34Hash = uint256S("0x000000000000024b89b42a942fe0d9fea3bb44ab7bd1b19115dd6a759c0808b8");
-        consensus.BIP65Height = 388381; // 000000000000000004c2b624ed5d7756c508d90fd0da2c7c679febfa6c4735f0
-        consensus.BIP66Height = 363725; // 00000000000000000379eaa19dce8c9b722d46ae6a57c2f1a988119488b50931
+        consensus.vBuriedDeploymentHeights[Consensus::BIP65_HEIGHT_ACTIVE] = 388381; // 000000000000000004c2b624ed5d7756c508d90fd0da2c7c679febfa6c4735f0
+        consensus.vBuriedDeploymentHeights[Consensus::BIP66_HEIGHT_ACTIVE] = 363725; // 00000000000000000379eaa19dce8c9b722d46ae6a57c2f1a988119488b50931
         consensus.powLimit = uint256S("00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
         consensus.nPowTargetSpacing = 10 * 60;
@@ -169,10 +169,10 @@ public:
     CTestNetParams() {
         strNetworkID = "test";
         consensus.nSubsidyHalvingInterval = 210000;
-        consensus.BIP34Height = 21111;
+        consensus.vBuriedDeploymentHeights[Consensus::BIP34_HEIGHT_ACTIVE] = 21111;
         consensus.BIP34Hash = uint256S("0x0000000023b3a96d3484e5abb3755c413e7d41500f8e2a5c3f0dd01299cd8ef8");
-        consensus.BIP65Height = 581885; // 00000000007f6655f22f98e72ed80d8b06dc761d5da09df0fa1dc4be4f861eb6
-        consensus.BIP66Height = 330776; // 000000002104c8c45e99a8853285a3b592602a3ccde2b832481da85e9e4ba182
+        consensus.vBuriedDeploymentHeights[Consensus::BIP65_HEIGHT_ACTIVE] = 581885; // 00000000007f6655f22f98e72ed80d8b06dc761d5da09df0fa1dc4be4f861eb6
+        consensus.vBuriedDeploymentHeights[Consensus::BIP66_HEIGHT_ACTIVE] = 330776; // 000000002104c8c45e99a8853285a3b592602a3ccde2b832481da85e9e4ba182
         consensus.powLimit = uint256S("00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
         consensus.nPowTargetSpacing = 10 * 60;
@@ -251,10 +251,10 @@ public:
     CRegTestParams() {
         strNetworkID = "regtest";
         consensus.nSubsidyHalvingInterval = 150;
-        consensus.BIP34Height = 100000000; // Configurable with -buriedsfparams
+        consensus.vBuriedDeploymentHeights[Consensus::BIP34_HEIGHT_ACTIVE] = 100000000; // Configurable with -buriedsfparams
         consensus.BIP34Hash = uint256();
-        consensus.BIP65Height = 100000000;
-        consensus.BIP66Height = 100000000;
+        consensus.vBuriedDeploymentHeights[Consensus::BIP65_HEIGHT_ACTIVE] = 100000000;
+        consensus.vBuriedDeploymentHeights[Consensus::BIP66_HEIGHT_ACTIVE] = 100000000;
         consensus.powLimit = uint256S("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
         consensus.nPowTargetSpacing = 10 * 60;
@@ -326,15 +326,7 @@ const CChainParams &Params() {
 
 void CChainParams::UpdateBuriedDeploymentParameters(Consensus::BuriedDeploymentPos deployment, int64_t nStartHeight)
 {
-        if (deployment == Consensus::BIP34_HEIGHT_ACTIVE) {
-                consensus.BIP34Height = nStartHeight;
-        }
-        if (deployment == Consensus::BIP65_HEIGHT_ACTIVE) {
-                consensus.BIP65Height = nStartHeight;
-        }
-        if (deployment == Consensus::BIP66_HEIGHT_ACTIVE) {
-                consensus.BIP66Height = nStartHeight;
-        }
+    consensus.vBuriedDeploymentHeights[deployment] = nStartHeight;
 }
 
 void UpdateRegtestBuriedDeploymentParameters(Consensus::BuriedDeploymentPos deployment, int64_t nStartHeight)

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -251,10 +251,10 @@ public:
     CRegTestParams() {
         strNetworkID = "regtest";
         consensus.nSubsidyHalvingInterval = 150;
-        consensus.BIP34Height = 100000000; // BIP34 has not activated on regtest (far in the future so block v1 are not rejected in tests)
+        consensus.BIP34Height = 100000000; // Configurable with -buriedsfparams
         consensus.BIP34Hash = uint256();
-        consensus.BIP65Height = 1351; // BIP65 activated on regtest (Used in rpc activation tests)
-        consensus.BIP66Height = 1251; // BIP66 activated on regtest (Used in rpc activation tests)
+        consensus.BIP65Height = 100000000;
+        consensus.BIP66Height = 100000000;
         consensus.powLimit = uint256S("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
         consensus.nPowTargetSpacing = 10 * 60;
@@ -322,6 +322,24 @@ static CChainParams *pCurrentParams = 0;
 const CChainParams &Params() {
     assert(pCurrentParams);
     return *pCurrentParams;
+}
+
+void CChainParams::UpdateBuriedDeploymentParameters(Consensus::BuriedDeploymentPos deployment, int64_t nStartHeight)
+{
+        if (deployment == Consensus::BIP34_HEIGHT_ACTIVE) {
+                consensus.BIP34Height = nStartHeight;
+        }
+        if (deployment == Consensus::BIP65_HEIGHT_ACTIVE) {
+                consensus.BIP65Height = nStartHeight;
+        }
+        if (deployment == Consensus::BIP66_HEIGHT_ACTIVE) {
+                consensus.BIP66Height = nStartHeight;
+        }
+}
+
+void UpdateRegtestBuriedDeploymentParameters(Consensus::BuriedDeploymentPos deployment, int64_t nStartHeight)
+{
+    regTestParams.UpdateBuriedDeploymentParameters(deployment, nStartHeight);
 }
 
 CChainParams& Params(const std::string& chain)

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -73,6 +73,7 @@ public:
     const std::vector<unsigned char>& Base58Prefix(Base58Type type) const { return base58Prefixes[type]; }
     const std::vector<SeedSpec6>& FixedSeeds() const { return vFixedSeeds; }
     const CCheckpointData& Checkpoints() const { return checkpointData; }
+    void UpdateBuriedDeploymentParameters(Consensus::BuriedDeploymentPos deployment, int64_t nStartHeight);
 protected:
     CChainParams() {}
 
@@ -97,6 +98,8 @@ protected:
  * startup, except for unit tests.
  */
 const CChainParams &Params();
+
+void UpdateRegtestBuriedDeploymentParameters(Consensus::BuriedDeploymentPos deployment, int64_t nStartHeight);
 
 /**
  * @returns CChainParams for the given BIP70 chain name.

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -56,7 +56,8 @@ public:
     const Consensus::Params& GetConsensus() const { return consensus; }
     const CMessageHeader::MessageStartChars& MessageStart() const { return pchMessageStart; }
     int GetDefaultPort() const { return nDefaultPort; }
-
+    /** This chain can have buried and bip9 soft fork parameters overridden with -bip9params and -buriedsfparams */
+    bool AllowsOverriddenSoftFork() const { return fAllowsOverriddenSoftFork; }
     const CBlock& GenesisBlock() const { return genesis; }
     /** Make miner wait to have peers to avoid wasting work */
     bool MiningRequiresPeers() const { return fMiningRequiresPeers; }
@@ -73,6 +74,7 @@ public:
     const std::vector<unsigned char>& Base58Prefix(Base58Type type) const { return base58Prefixes[type]; }
     const std::vector<SeedSpec6>& FixedSeeds() const { return vFixedSeeds; }
     const CCheckpointData& Checkpoints() const { return checkpointData; }
+    void UpdateBIP9Parameters(Consensus::DeploymentPos d, int64_t nStartTime, int64_t nTimeout);
     void UpdateBuriedDeploymentParameters(Consensus::BuriedDeploymentPos deployment, int64_t nStartHeight);
 protected:
     CChainParams() {}
@@ -86,6 +88,7 @@ protected:
     std::string strNetworkID;
     CBlock genesis;
     std::vector<SeedSpec6> vFixedSeeds;
+    bool fAllowsOverriddenSoftFork;
     bool fMiningRequiresPeers;
     bool fDefaultConsistencyChecks;
     bool fRequireStandard;
@@ -99,8 +102,6 @@ protected:
  */
 const CChainParams &Params();
 
-void UpdateRegtestBuriedDeploymentParameters(Consensus::BuriedDeploymentPos deployment, int64_t nStartHeight);
-
 /**
  * @returns CChainParams for the given BIP70 chain name.
  */
@@ -111,10 +112,5 @@ CChainParams& Params(const std::string& chain);
  * @throws std::runtime_error when the chain is not supported.
  */
 void SelectParams(const std::string& chain);
-
-/**
- * Allows modifying the BIP9 regtest parameters.
- */
-void UpdateRegtestBIP9Parameters(Consensus::DeploymentPos d, int64_t nStartTime, int64_t nTimeout);
 
 #endif // BITCOIN_CHAINPARAMS_H

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -21,6 +21,15 @@ enum DeploymentPos
     MAX_VERSION_BITS_DEPLOYMENTS
 };
 
+/** Block heights at which the buried deployments becomes active */
+enum BuriedDeploymentPos
+{
+    BIP34_HEIGHT_ACTIVE,
+    BIP65_HEIGHT_ACTIVE,
+    BIP66_HEIGHT_ACTIVE,
+    MAX_BURIED_DEPLOYMENTS
+};
+
 /**
  * Struct for each individual consensus rule change using BIP9.
  */

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -48,13 +48,7 @@ struct BIP9Deployment {
 struct Params {
     uint256 hashGenesisBlock;
     int nSubsidyHalvingInterval;
-    /** Block height and hash at which BIP34 becomes active */
-    int BIP34Height;
     uint256 BIP34Hash;
-    /** Block height at which BIP65 becomes active */
-    int BIP65Height;
-    /** Block height at which BIP66 becomes active */
-    int BIP66Height;
     /**
      * Minimum blocks including miner confirmation of the total of 2016 blocks in a retargetting period,
      * (nPowTargetTimespan / nPowTargetSpacing) which is also used for BIP9 deployments.
@@ -63,6 +57,7 @@ struct Params {
     uint32_t nRuleChangeActivationThreshold;
     uint32_t nMinerConfirmationWindow;
     BIP9Deployment vDeployments[MAX_VERSION_BITS_DEPLOYMENTS];
+    int64_t vBuriedDeploymentHeights[MAX_BURIED_DEPLOYMENTS];
     /** Proof of work parameters */
     uint256 powLimit;
     bool fPowAllowMinDifficultyBlocks;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1000,9 +1000,10 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
 
     if (!mapMultiArgs["-bip9params"].empty()) {
         // Allow overriding BIP9 parameters for testing
-        if (!chainparams.MineBlocksOnDemand()) {
-            return InitError("BIP9 parameters may only be overridden on regtest.");
+        if (!chainparams.AllowsOverriddenSoftFork()) {
+            return InitError("BIP9 parameters can't be overriden on this chain.");
         }
+        CChainParams& mutableParams = Params(Params().NetworkIDString());
         const vector<string>& deployments = mapMultiArgs["-bip9params"];
         for (auto i : deployments) {
             std::vector<std::string> vDeploymentParams;
@@ -1021,7 +1022,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
             for (int j=0; j<(int)Consensus::MAX_VERSION_BITS_DEPLOYMENTS; ++j)
             {
                 if (vDeploymentParams[0].compare(VersionBitsDeploymentInfo[j].name) == 0) {
-                    UpdateRegtestBIP9Parameters(Consensus::DeploymentPos(j), nStartTime, nTimeout);
+                    mutableParams.UpdateBIP9Parameters(Consensus::DeploymentPos(j), nStartTime, nTimeout);
                     found = true;
                     LogPrintf("Setting BIP9 activation parameters for %s to start=%ld, timeout=%ld\n", vDeploymentParams[0], nStartTime, nTimeout);
                     break;
@@ -1035,9 +1036,10 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
 
     if (!mapMultiArgs["-buriedsfparams"].empty()) {
         // Allow overriding ism parameters for testing
-        if (!chainparams.MineBlocksOnDemand()) {
-            return InitError("Buried soft fork parameters may only be overridden on regtest.");
+        if (!chainparams.AllowsOverriddenSoftFork()) {
+            return InitError("Buried soft fork parameters can't be overridden on this chain.");
         }
+        CChainParams& mutableParams = Params(chainparams.NetworkIDString());
         std::map<string, Consensus::BuriedDeploymentPos> buriedDeployments;
         buriedDeployments.insert(std::make_pair("bip34", Consensus::BIP34_HEIGHT_ACTIVE));
         buriedDeployments.insert(std::make_pair("bip65", Consensus::BIP65_HEIGHT_ACTIVE));
@@ -1058,7 +1060,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
             if (found == buriedDeployments.end()) {
                 return InitError(strprintf("Invalid deployment (%s)", vDeploymentParams[0]));
             }
-            UpdateRegtestBuriedDeploymentParameters(found->second, nStartHeight);
+            mutableParams.UpdateBuriedDeploymentParameters(found->second, nStartHeight);
         }
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2411,7 +2411,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     // before the first had been spent.  Since those coinbases are sufficiently buried its no longer possible to create further
     // duplicate transactions descending from the known pairs either.
     // If we're on the known chain at height greater than where BIP34 activated, we can save the db accesses needed for the BIP30 check.
-    CBlockIndex *pindexBIP34height = pindex->pprev->GetAncestor(chainparams.GetConsensus().BIP34Height);
+    CBlockIndex *pindexBIP34height = pindex->pprev->GetAncestor(chainparams.GetConsensus().vBuriedDeploymentHeights[Consensus::BIP34_HEIGHT_ACTIVE]);
     //Only continue to enforce if we're below BIP34 activation height or the block hash at that height doesn't correspond.
     fEnforceBIP30 = fEnforceBIP30 && (!pindexBIP34height || !(pindexBIP34height->GetBlockHash() == chainparams.GetConsensus().BIP34Hash));
 
@@ -2431,12 +2431,12 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     unsigned int flags = fStrictPayToScriptHash ? SCRIPT_VERIFY_P2SH : SCRIPT_VERIFY_NONE;
 
     // Start enforcing the DERSIG (BIP66) rule
-    if (pindex->nHeight >= chainparams.GetConsensus().BIP66Height) {
+    if (pindex->nHeight >= chainparams.GetConsensus().vBuriedDeploymentHeights[Consensus::BIP66_HEIGHT_ACTIVE]) {
         flags |= SCRIPT_VERIFY_DERSIG;
     }
 
     // Start enforcing CHECKLOCKTIMEVERIFY (BIP65) rule
-    if (pindex->nHeight >= chainparams.GetConsensus().BIP65Height) {
+    if (pindex->nHeight >= chainparams.GetConsensus().vBuriedDeploymentHeights[Consensus::BIP65_HEIGHT_ACTIVE]) {
         flags |= SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY;
     }
 
@@ -3575,9 +3575,9 @@ bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationState& sta
 
     // Reject outdated version blocks when 95% (75% on testnet) of the network has upgraded:
     // check for version 2, 3 and 4 upgrades
-    if((block.nVersion < 2 && nHeight >= consensusParams.BIP34Height) ||
-       (block.nVersion < 3 && nHeight >= consensusParams.BIP66Height) ||
-       (block.nVersion < 4 && nHeight >= consensusParams.BIP65Height))
+    if((block.nVersion < 2 && nHeight >= consensusParams.vBuriedDeploymentHeights[Consensus::BIP34_HEIGHT_ACTIVE]) ||
+       (block.nVersion < 3 && nHeight >= consensusParams.vBuriedDeploymentHeights[Consensus::BIP66_HEIGHT_ACTIVE]) ||
+       (block.nVersion < 4 && nHeight >= consensusParams.vBuriedDeploymentHeights[Consensus::BIP65_HEIGHT_ACTIVE]))
             return state.Invalid(false, REJECT_OBSOLETE, strprintf("bad-version(0x%08x)", block.nVersion),
                                  strprintf("rejected nVersion=0x%08x block", block.nVersion));
 
@@ -3606,7 +3606,7 @@ bool ContextualCheckBlock(const CBlock& block, CValidationState& state, const Co
     }
 
     // Enforce rule that the coinbase starts with serialized block height
-    if (nHeight >= consensusParams.BIP34Height)
+    if (nHeight >= consensusParams.vBuriedDeploymentHeights[Consensus::BIP34_HEIGHT_ACTIVE])
     {
         CScript expect = CScript() << nHeight;
         if (block.vtx[0].vin[0].scriptSig.size() < expect.size() ||

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -970,13 +970,13 @@ static UniValue SoftForkMajorityDesc(int version, CBlockIndex* pindex, const Con
     switch(version)
     {
         case 2:
-            activated = pindex->nHeight >= consensusParams.BIP34Height;
+            activated = pindex->nHeight >= consensusParams.vBuriedDeploymentHeights[Consensus::BIP34_HEIGHT_ACTIVE];
             break;
         case 3:
-            activated = pindex->nHeight >= consensusParams.BIP66Height;
+            activated = pindex->nHeight >= consensusParams.vBuriedDeploymentHeights[Consensus::BIP66_HEIGHT_ACTIVE];
             break;
         case 4:
-            activated = pindex->nHeight >= consensusParams.BIP65Height;
+            activated = pindex->nHeight >= consensusParams.vBuriedDeploymentHeights[Consensus::BIP65_HEIGHT_ACTIVE];
             break;
     }
     rv.push_back(Pair("status", activated));


### PR DESCRIPTION
This PR has three goals:
- Parametrizes buried soft fork in regtest (Same approach than @sdaftuar on  https://github.com/bitcoin/bitcoin/pull/8418)
- Refactor by using a vector for buried deployment. Buried deployments will have its own BIP (https://github.com/bitcoin/bitcoin/pull/8391#issuecomment-237584871) so it makes sense to have a consistent way of adding a new one which can be parametrized out of the box by 297a65728de5fdd843335c8c9fc3821ae5d5bac4.
- Introduce CChainParams::AllowsOverriddenSoftFork so we don't abuse MineBlocksOnDemand for bip9 and buried sf overrides.

@sipa, you asked for it on https://github.com/bitcoin/bitcoin/pull/8391#issuecomment-236003190.
@jtimon, using similar code you used on https://github.com/jtimon/bitcoin/compare/remove-ism...consensus-post-remove-ism
