### PR TITLE
[Trivial] Do not shadow members in dbwrapper

### DIFF
--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -52,9 +52,9 @@ private:
 
 public:
     /**
-     * @param[in] parent    CDBWrapper that this batch is to be submitted to
+     * @param[in] _parent   CDBWrapper that this batch is to be submitted to
      */
-    CDBBatch(const CDBWrapper &parent) : parent(parent) { };
+    CDBBatch(const CDBWrapper &_parent) : parent(_parent) { };
 
     template <typename K, typename V>
     void Write(const K& key, const V& value)
@@ -94,11 +94,11 @@ private:
 public:
 
     /**
-     * @param[in] parent           Parent CDBWrapper instance.
-     * @param[in] piterIn          The original leveldb iterator.
+     * @param[in] _parent          Parent CDBWrapper instance.
+     * @param[in] _piter           The original leveldb iterator.
      */
-    CDBIterator(const CDBWrapper &parent, leveldb::Iterator *piterIn) :
-        parent(parent), piter(piterIn) { };
+    CDBIterator(const CDBWrapper &_parent, leveldb::Iterator *_piter) :
+        parent(_parent), piter(_piter) { };
     ~CDBIterator();
 
     bool Valid();


### PR DESCRIPTION
This is a followup to #8105.

`dbwrapper.h` code shadows some members. Fixes use underscore prefix (I also migrated `piterIn` into `_piter` to follow this style).

For review, compare binaries or compile with `-Wshadow` and compare complete logs.
