### PR TITLE
[POC] Introducing property based testing to Core

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -130,6 +130,12 @@ AC_ARG_ENABLE(gui-tests,
     [use_gui_tests=$enableval],
     [use_gui_tests=$use_tests])
 
+AC_ARG_WITH([rapidcheck],
+  [AS_HELP_STRING([--with-rapidcheck],
+  [enable RapidCheck property based tests (default is yes if librapidcheck is found)])],
+  [use_rapidcheck=$withval],
+  [use_rapidcheck=auto])
+
 AC_ARG_ENABLE(bench,
     AS_HELP_STRING([--disable-bench],[do not compile benchmarks (default is to compile)]),
     [use_bench=$enableval],
@@ -1023,6 +1029,22 @@ AC_CHECK_DECLS([EVP_MD_CTX_new],,,[AC_INCLUDES_DEFAULT
 #include <openssl/x509_vfy.h>
 ])
 CXXFLAGS="${save_CXXFLAGS}"
+
+dnl RapidCheck Property Based Testing
+
+enable_property_tests=no
+if test "x$use_rapidcheck" = xauto; then
+    AC_CHECK_HEADERS([rapidcheck.h], [enable_property_tests=yes])
+elif test "x$use_rapidcheck" != xno; then
+    enable_property_tests=yes
+fi
+
+RAPIDCHECK_LIBS=
+if test "x$enable_property_tests" = xyes; then
+   RAPIDCHECK_LIBS=-lrapidcheck
+fi
+AC_SUBST(RAPIDCHECK_LIBS)
+AM_CONDITIONAL([ENABLE_PROPERTY_TESTS], [test x$enable_property_tests = xyes])
 
 dnl univalue check
 

--- a/depends/Makefile
+++ b/depends/Makefile
@@ -4,6 +4,7 @@ SOURCES_PATH ?= $(BASEDIR)/sources
 BASE_CACHE ?= $(BASEDIR)/built
 SDK_PATH ?= $(BASEDIR)/SDKs
 NO_QT ?=
+RAPIDCHECK ?=
 NO_WALLET ?=
 NO_UPNP ?=
 FALLBACK_DOWNLOAD_PATH ?= https://bitcoincore.org/depends-sources
@@ -92,11 +93,17 @@ qt_packages_$(NO_QT) = $(qt_packages) $(qt_$(host_os)_packages) $(qt_$(host_arch
 wallet_packages_$(NO_WALLET) = $(wallet_packages)
 upnp_packages_$(NO_UPNP) = $(upnp_packages)
 
+rapidcheck_packages_$(RAPIDCHECK) = $(rapidcheck_packages)
+
 packages += $($(host_arch)_$(host_os)_packages) $($(host_os)_packages) $(qt_packages_) $(wallet_packages_) $(upnp_packages_)
 native_packages += $($(host_arch)_$(host_os)_native_packages) $($(host_os)_native_packages)
 
 ifneq ($(qt_packages_),)
 native_packages += $(qt_native_packages)
+endif
+
+ifeq ($(rapidcheck_packages_),)
+packages += $(rapidcheck_packages)
 endif
 
 all_packages = $(packages) $(native_packages)

--- a/depends/README.md
+++ b/depends/README.md
@@ -55,6 +55,7 @@ The following can be set when running make: make FOO=bar
     NO_WALLET: Don't download/build/cache libs needed to enable the wallet
     NO_UPNP: Don't download/build/cache packages needed for enabling upnp
     DEBUG: disable some optimizations and enable more runtime checking
+    RAPIDCHECK: build rapidcheck (experimental)
     HOST_ID_SALT: Optional salt to use when generating host package ids
     BUILD_ID_SALT: Optional salt to use when generating build package ids
 

--- a/depends/packages/packages.mk
+++ b/depends/packages/packages.mk
@@ -3,6 +3,8 @@ packages:=boost openssl libevent zeromq
 qt_native_packages = native_protobuf
 qt_packages = qrencode protobuf zlib
 
+rapidcheck_packages = rapidcheck
+
 qt_x86_64_linux_packages:=qt expat dbus libxcb xcb_proto libXau xproto freetype fontconfig libX11 xextproto libXext xtrans
 qt_i686_linux_packages:=$(qt_x86_64_linux_packages)
 

--- a/depends/packages/rapidcheck.mk
+++ b/depends/packages/rapidcheck.mk
@@ -1,0 +1,18 @@
+package=rapidcheck
+$(package)_version=10fc0cb
+$(package)_download_path=https://github.com/MarcoFalke/rapidcheck/archive
+$(package)_file_name=$(package)-$($(package)_version).tar.gz
+$(package)_sha256_hash=9640926223c00af45bce4c7df8b756b5458a89b2ba74cfe3e404467f13ce26df
+
+define $(package)_config_cmds
+  cmake -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=true .
+endef
+
+define $(package)_build_cmds
+  $(MAKE) && \
+  mkdir -p $($(package)_staging_dir)$(host_prefix)/include && \
+  cp -a include/* $($(package)_staging_dir)$(host_prefix)/include/ && \
+  cp -a extras/boost_test/include/rapidcheck/* $($(package)_staging_dir)$(host_prefix)/include/rapidcheck/ && \
+  mkdir -p $($(package)_staging_dir)$(host_prefix)/lib && \
+  cp -a librapidcheck.a $($(package)_staging_dir)$(host_prefix)/lib/
+endef

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -9,6 +9,8 @@ TEST_SRCDIR = test
 TEST_BINARY=test/test_bitcoin$(EXEEXT)
 
 JSON_TEST_FILES = \
+  test/data/script_tests.json \
+  test/data/base58_keys_valid.json \
   test/data/base58_encode_decode.json \
   test/data/key_io_valid.json \
   test/data/key_io_invalid.json \
@@ -88,6 +90,27 @@ BITCOIN_TESTS =\
   test/uint256_tests.cpp \
   test/util_tests.cpp
 
+if ENABLE_PROPERTY_TESTS
+BITCOIN_TESTS += \
+  test/gen/crypto_gen.cpp \
+  test/gen/crypto_gen.h \
+  test/gen/script_gen.cpp \
+  test/gen/script_gen.h \
+  test/gen/transaction_gen.cpp \
+  test/gen/transaction_gen.h \
+  test/gen/block_gen.cpp \
+  test/gen/block_gen.h \
+  test/gen/merkleblock_gen.h \
+  test/gen/bloom_gen.cpp \
+  test/gen/bloom_gen.h \
+  test/key_properties.cpp \
+  test/script_properties.cpp \
+  test/block_properties.cpp \
+  test/merkleblock_properties.cpp \
+  test/bloom_properties.cpp \
+  test/transaction_properties.cpp
+endif
+
 if ENABLE_WALLET
 BITCOIN_TESTS += \
   wallet/test/wallet_test_fixture.cpp \
@@ -108,7 +131,7 @@ test_test_bitcoin_LDADD += $(LIBBITCOIN_SERVER) $(LIBBITCOIN_CLI) $(LIBBITCOIN_C
   $(LIBLEVELDB) $(LIBLEVELDB_SSE42) $(LIBMEMENV) $(BOOST_LIBS) $(BOOST_UNIT_TEST_FRAMEWORK_LIB) $(LIBSECP256K1) $(EVENT_LIBS) $(EVENT_PTHREADS_LIBS)
 test_test_bitcoin_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 
-test_test_bitcoin_LDADD += $(LIBBITCOIN_CONSENSUS) $(BDB_LIBS) $(SSL_LIBS) $(CRYPTO_LIBS) $(MINIUPNPC_LIBS)
+test_test_bitcoin_LDADD += $(LIBBITCOIN_CONSENSUS) $(BDB_LIBS) $(SSL_LIBS) $(CRYPTO_LIBS) $(MINIUPNPC_LIBS) $(RAPIDCHECK_LIBS)
 test_test_bitcoin_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS) -static
 
 if ENABLE_ZMQ

--- a/src/test/block_properties.cpp
+++ b/src/test/block_properties.cpp
@@ -1,0 +1,34 @@
+#include <boost/test/unit_test.hpp>
+#include <rapidcheck/boost_test.h>
+#include <rapidcheck/gen/Arbitrary.h>
+#include <rapidcheck/Gen.h>
+
+#include "test/test_bitcoin.h"
+#include "primitives/block.h"
+#include "test/gen/block_gen.h"
+
+
+BOOST_FIXTURE_TEST_SUITE(block_properties, BasicTestingSetup)
+
+RC_BOOST_PROP(blockheader_serialization_symmetry, (const CBlockHeader& header))
+{
+    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+    ss << header;
+    CBlockHeader header2;
+    ss >> header2;
+    CDataStream ss1(SER_NETWORK, PROTOCOL_VERSION);
+    ss << header;
+    ss1 << header2;
+    RC_ASSERT(ss.str() == ss1.str());
+}
+
+RC_BOOST_PROP(block_serialization_symmetry, (const CBlock& block))
+{
+    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+    ss << block;
+    CBlock block2;
+    ss >> block2;
+    RC_ASSERT(block.GetHash() == block2.GetHash());
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/bloom_properties.cpp
+++ b/src/test/bloom_properties.cpp
@@ -1,0 +1,35 @@
+// Copyright (c) 2012-2016 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#include "test/gen/bloom_gen.h"
+#include "test/gen/crypto_gen.h"
+
+#include "test/test_bitcoin.h"
+
+#include <boost/test/unit_test.hpp>
+#include <rapidcheck/boost_test.h>
+#include <rapidcheck/gen/Arbitrary.h>
+#include <rapidcheck/Gen.h>
+
+
+BOOST_FIXTURE_TEST_SUITE(bloom_properties, BasicTestingSetup)
+
+RC_BOOST_PROP(no_false_negatives, (CBloomFilter bloom_filter, const uint256& hash))
+{
+    bloom_filter.insert(hash);
+    bool result = bloom_filter.contains(hash);
+    RC_ASSERT(result);
+}
+
+RC_BOOST_PROP(serialization_symmetry, (const CBloomFilter& bloom_filter))
+{
+    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+    ss << bloom_filter;
+    CBloomFilter bloom_filter2;
+    ss >> bloom_filter2;
+    CDataStream ss1(SER_NETWORK, PROTOCOL_VERSION);
+    ss << bloom_filter;
+    ss1 << bloom_filter2;
+    RC_ASSERT(ss.str() == ss1.str());
+}
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/gen/block_gen.cpp
+++ b/src/test/gen/block_gen.cpp
@@ -1,0 +1,12 @@
+#include "test/gen/block_gen.h"
+
+#include <rapidcheck/Gen.h>
+
+/** Generator for the primitives of a block header */
+rc::Gen<BlockHeaderTup> BlockHeaderPrimitives()
+{
+    return rc::gen::tuple(rc::gen::arbitrary<int32_t>(),
+        rc::gen::arbitrary<uint256>(), rc::gen::arbitrary<uint256>(),
+        rc::gen::arbitrary<uint32_t>(), rc::gen::arbitrary<uint32_t>(),
+        rc::gen::arbitrary<uint32_t>());
+}

--- a/src/test/gen/block_gen.h
+++ b/src/test/gen/block_gen.h
@@ -1,0 +1,58 @@
+#ifndef BITCOIN_TEST_GEN_BLOCK_GEN_H
+#define BITCOIN_TEST_GEN_BLOCK_GEN_H
+
+#include "test/gen/crypto_gen.h"
+#include "test/gen/transaction_gen.h"
+#include "uint256.h"
+#include "primitives/block.h"
+
+#include <rapidcheck/gen/Arbitrary.h>
+#include <rapidcheck/Gen.h>
+
+
+typedef std::tuple<int32_t, uint256, uint256, uint32_t, uint32_t, uint32_t> BlockHeaderTup;
+
+/** Generator for the primitives of a block header */
+rc::Gen<BlockHeaderTup> BlockHeaderPrimitives();
+
+namespace rc
+{
+/** Generator for a new CBlockHeader */
+template <>
+struct Arbitrary<CBlockHeader> {
+    static Gen<CBlockHeader> arbitrary()
+    {
+        return gen::map(BlockHeaderPrimitives(), [](const BlockHeaderTup& primitives) {
+            int32_t nVersion;
+            uint256 hashPrevBlock;
+            uint256 hashMerkleRoot;
+            uint32_t nTime;
+            uint32_t nBits;
+            uint32_t nNonce;
+            std::tie(nVersion, hashPrevBlock, hashMerkleRoot, nTime, nBits, nNonce) = primitives;
+            CBlockHeader header;
+            header.nVersion = nVersion;
+            header.hashPrevBlock = hashPrevBlock;
+            header.hashMerkleRoot = hashMerkleRoot;
+            header.nTime = nTime;
+            header.nBits = nBits;
+            header.nNonce = nNonce;
+            return header;
+        });
+    };
+};
+
+/** Generator for a new CBlock */
+template <>
+struct Arbitrary<CBlock> {
+    static Gen<CBlock> arbitrary()
+    {
+        return gen::map(gen::nonEmpty<std::vector<CTransactionRef>>(), [](const std::vector<CTransactionRef>& refs) {
+            CBlock block;
+            block.vtx = refs;
+            return block;
+        });
+    }
+};
+} //namespace rc
+#endif

--- a/src/test/gen/bloom_gen.cpp
+++ b/src/test/gen/bloom_gen.cpp
@@ -1,0 +1,59 @@
+#include "test/gen/bloom_gen.h"
+#include "test/gen/crypto_gen.h"
+
+#include "bloom.h"
+#include <math.h>
+
+#include <rapidcheck/gen/Arbitrary.h>
+#include <rapidcheck/Gen.h>
+#include <rapidcheck/gen/Tuple.h>
+#include <rapidcheck/gen/Predicate.h>
+#include <rapidcheck/gen/Numeric.h>
+#include <rapidcheck/gen/Container.h>
+
+/** Generates a double between [0,1) */
+rc::Gen<double> BetweenZeroAndOne()
+{
+    return rc::gen::map(rc::gen::arbitrary<double>(), [](double x) {
+        double result = abs(fmod(x, 1));
+        assert(result >= 0 && result < 1);
+        return result;
+    });
+}
+
+rc::Gen<unsigned int> Between1And100()
+{
+    return rc::gen::inRange<unsigned int>(1, 100);
+}
+/** Generates the C++ primitives used to create a bloom filter */
+rc::Gen<std::tuple<unsigned int, double, unsigned int, unsigned int>> BloomFilterPrimitives()
+{
+    return rc::gen::tuple(Between1And100(),
+        BetweenZeroAndOne(), rc::gen::arbitrary<unsigned int>(),
+        rc::gen::inRange<unsigned int>(0, 3));
+}
+
+/** Returns a bloom filter loaded with the given uint256s */
+rc::Gen<std::pair<CBloomFilter, std::vector<uint256>>> LoadedBloomFilter()
+{
+    return rc::gen::map(rc::gen::pair(rc::gen::arbitrary<CBloomFilter>(), rc::gen::arbitrary<std::vector<uint256>>()),
+        [](const std::pair<CBloomFilter, const std::vector<uint256>&>& primitives) {
+            CBloomFilter bloomFilter = primitives.first;
+            std::vector<uint256> hashes = primitives.second;
+            for (unsigned int i = 0; i < hashes.size(); i++) {
+                bloomFilter.insert(hashes[i]);
+            }
+            return std::make_pair(bloomFilter, hashes);
+        });
+}
+
+/** Loads an arbitrary bloom filter with the given hashes */
+rc::Gen<std::pair<CBloomFilter, std::vector<uint256>>> LoadBloomFilter(const std::vector<uint256>& hashes)
+{
+    return rc::gen::map(rc::gen::arbitrary<CBloomFilter>(), [&hashes](CBloomFilter bloomFilter) {
+        for (unsigned int i = 0; i < hashes.size(); i++) {
+            bloomFilter.insert(hashes[i]);
+        }
+        return std::make_pair(bloomFilter, hashes);
+    });
+}

--- a/src/test/gen/bloom_gen.h
+++ b/src/test/gen/bloom_gen.h
@@ -1,0 +1,42 @@
+#ifndef BITCOIN_TEST_GEN_BLOOM_GEN_H
+#define BITCOIN_TEST_GEN_BLOOM_GEN_H
+
+#include "bloom.h"
+#include "merkleblock.h"
+
+#include <math.h>
+
+#include <rapidcheck/Gen.h>
+#include <rapidcheck/gen/Arbitrary.h>
+
+/** Generates a double between [0,1) */
+rc::Gen<double> BetweenZeroAndOne();
+
+rc::Gen<std::tuple<unsigned int, double, unsigned int, unsigned int>> BloomFilterPrimitives();
+
+namespace rc
+{
+/** Generator for a new CBloomFilter*/
+template <>
+struct Arbitrary<CBloomFilter> {
+    static Gen<CBloomFilter> arbitrary()
+    {
+        return gen::map(BloomFilterPrimitives(), [](const std::tuple<unsigned int, double, unsigned int, unsigned int>& primitives) {
+            unsigned int num_elements;
+            double fp_rate;
+            unsigned int n_tweak_in;
+            unsigned int bloom_flag;
+            std::tie(num_elements, fp_rate, n_tweak_in, bloom_flag) = primitives;
+            return CBloomFilter(num_elements, fp_rate, n_tweak_in, bloom_flag);
+        });
+    };
+};
+} //namespace rc
+
+/** Returns a bloom filter loaded with the returned uint256s */
+rc::Gen<std::pair<CBloomFilter, std::vector<uint256>>> LoadedBloomFilter();
+
+/** Loads an arbitrary bloom filter with the given hashes */
+rc::Gen<std::pair<CBloomFilter, std::vector<uint256>>> LoadBloomFilter(const std::vector<uint256>& hashes);
+
+#endif

--- a/src/test/gen/crypto_gen.cpp
+++ b/src/test/gen/crypto_gen.cpp
@@ -1,0 +1,23 @@
+#include "test/gen/crypto_gen.h"
+
+#include "key.h"
+
+#include <rapidcheck/gen/Arbitrary.h>
+#include <rapidcheck/Gen.h>
+#include <rapidcheck/gen/Predicate.h>
+#include <rapidcheck/gen/Container.h>
+
+/** Generates 1 to 20 keys for OP_CHECKMULTISIG */
+rc::Gen<std::vector<CKey>> MultisigKeys()
+{
+    return rc::gen::suchThat(rc::gen::arbitrary<std::vector<CKey>>(), [](const std::vector<CKey>& keys) {
+        //TODO: Investigate why we can only allow 15 keys. Consensus rules
+        // dictate we can up to 20 keys
+        //https://github.com/bitcoin/bitcoin/blob/10bee0dd4f37eb6cb7a0f1d565fa0fecf8109c35/src/script/script.h#L29
+        //needs to be <= 16 keys because this assertion fails
+        //https://github.com/bitcoin/bitcoin/blob/10bee0dd4f37eb6cb7a0f1d565fa0fecf8109c35/src/script/script.h#L585
+        //ProduceSignature() fails for p2sh(multisig) if there are >= 16 keys
+        //this is why we are currently limited to the range >= 1 && <= 15
+        return keys.size() >= 1 && keys.size() <= 15;
+    });
+};

--- a/src/test/gen/crypto_gen.h
+++ b/src/test/gen/crypto_gen.h
@@ -1,0 +1,60 @@
+#ifndef BITCOIN_TEST_GEN_CRYPTO_GEN_H
+#define BITCOIN_TEST_GEN_CRYPTO_GEN_H
+
+#include "key.h"
+#include "random.h"
+#include "uint256.h"
+#include <rapidcheck/gen/Arbitrary.h>
+#include <rapidcheck/Gen.h>
+#include <rapidcheck/gen/Create.h>
+#include <rapidcheck/gen/Numeric.h>
+
+/** Generates 1 to 15 keys for OP_CHECKMULTISIG */
+rc::Gen<std::vector<CKey>> MultisigKeys();
+
+namespace rc
+{
+/** Generator for a new CKey */
+template <>
+struct Arbitrary<CKey> {
+    static Gen<CKey> arbitrary()
+    {
+        return rc::gen::map<int>([](int x) {
+            CKey key;
+            key.MakeNewKey(true);
+            return key;
+        });
+    };
+};
+
+/** Generator for a CPrivKey */
+template <>
+struct Arbitrary<CPrivKey> {
+    static Gen<CPrivKey> arbitrary()
+    {
+        return gen::map(gen::arbitrary<CKey>(), [](const CKey& key) {
+            return key.GetPrivKey();
+        });
+    };
+};
+
+/** Generator for a new CPubKey */
+template <>
+struct Arbitrary<CPubKey> {
+    static Gen<CPubKey> arbitrary()
+    {
+        return gen::map(gen::arbitrary<CKey>(), [](const CKey& key) {
+            return key.GetPubKey();
+        });
+    };
+};
+/** Generates a arbitrary uint256 */
+template <>
+struct Arbitrary<uint256> {
+    static Gen<uint256> arbitrary()
+    {
+        return rc::gen::just(GetRandHash());
+    };
+};
+} //namespace rc
+#endif

--- a/src/test/gen/merkleblock_gen.h
+++ b/src/test/gen/merkleblock_gen.h
@@ -1,0 +1,93 @@
+#ifndef BITCOIN_TEST_GEN_MERKLEBLOCK_GEN_H
+#define BITCOIN_TEST_GEN_MERKLEBLOCK_GEN_H
+
+#include <rapidcheck/gen/Arbitrary.h>
+#include <rapidcheck/Gen.h>
+
+#include "merkleblock.h"
+#include "test/gen/block_gen.h"
+
+#include <iostream>
+namespace rc
+{
+/** Returns a CMerkleblock with the hashes that match inside of the CPartialMerkleTree */
+template <>
+struct Arbitrary<std::pair<CMerkleBlock, std::set<uint256>>> {
+    static Gen<std::pair<CMerkleBlock, std::set<uint256>>> arbitrary()
+    {
+        return gen::map(gen::arbitrary<CBlock>(), [](const CBlock& block) {
+            std::set<uint256> hashes;
+            for (unsigned int i = 0; i < block.vtx.size(); i++) {
+                //pretty naive to include every other txid in the merkle block
+                //but this will work for now.
+                if (i % 2 == 0) {
+                    hashes.insert(block.vtx[i]->GetHash());
+                }
+            }
+            return std::make_pair(CMerkleBlock(block, hashes), hashes);
+        });
+    };
+};
+
+/** Returns [0,100) uint256s */
+Gen<std::vector<uint256>> BetweenZeroAnd100()
+{
+    return gen::suchThat<std::vector<uint256>>([](const std::vector<uint256>& hashes) {
+        return hashes.size() <= 100;
+    });
+}
+/** Returns [1,100) uint256s */
+Gen<std::vector<uint256>> Between1And100()
+{
+    return gen::suchThat(BetweenZeroAnd100(), [](const std::vector<uint256>& hashes) {
+        return hashes.size() > 0 && hashes.size() <= 100;
+    });
+}
+
+/** Returns an arbitrary CMerkleBlock */
+template <>
+struct Arbitrary<CMerkleBlock> {
+    static Gen<CMerkleBlock> arbitrary()
+    {
+        return gen::map(gen::arbitrary<std::pair<CMerkleBlock, std::set<uint256>>>(),
+            [](const std::pair<const CMerkleBlock&, const std::set<uint256>&>& mb_with_txids) {
+                const CMerkleBlock& mb = mb_with_txids.first;
+                return mb;
+            });
+    };
+};
+
+/** Generates a CPartialMerkleTree and returns the PartialMerkleTree along
+   * with the txids that should be matched inside of it */
+template <>
+struct Arbitrary<std::pair<CPartialMerkleTree, std::vector<uint256>>> {
+    static Gen<std::pair<CPartialMerkleTree, std::vector<uint256>>> arbitrary()
+    {
+        return gen::map(Between1And100(), [](const std::vector<uint256>& txids) {
+            std::vector<bool> matches;
+            std::vector<uint256> matched_txs;
+            for (unsigned int i = 0; i < txids.size(); i++) {
+                //pretty naive to include every other txid in the merkle block
+                //but this will work for now.
+                matches.push_back(i % 2 == 1);
+                if (i % 2 == 1) {
+                    matched_txs.push_back(txids[i]);
+                }
+            }
+            return std::make_pair(CPartialMerkleTree(txids, matches), matched_txs);
+        });
+    };
+};
+
+template <>
+struct Arbitrary<CPartialMerkleTree> {
+    static Gen<CPartialMerkleTree> arbitrary()
+    {
+        return gen::map(gen::arbitrary<std::pair<CPartialMerkleTree, std::vector<uint256>>>(),
+            [](const std::pair<const CPartialMerkleTree&, const std::vector<uint256>&>& p) {
+                return p.first;
+            });
+    };
+};
+} //namespace rc
+#endif

--- a/src/test/gen/script_gen.cpp
+++ b/src/test/gen/script_gen.cpp
@@ -1,0 +1,88 @@
+#include "test/gen/script_gen.h"
+
+#include "test/gen/crypto_gen.h"
+#include "script/script.h"
+#include "script/standard.h"
+#include "base58.h"
+#include "core_io.h"
+#include <rapidcheck/gen/Arbitrary.h>
+#include <rapidcheck/Gen.h>
+#include <rapidcheck/gen/Predicate.h>
+#include <rapidcheck/gen/Numeric.h>
+
+/** Generates a P2PK/CKey pair */
+rc::Gen<SPKCKeyPair> P2PKSPK()
+{
+    return rc::gen::map(rc::gen::arbitrary<CKey>(), [](const CKey& key) {
+        const CScript& s = GetScriptForRawPubKey(key.GetPubKey());
+        std::vector<CKey> keys;
+        keys.push_back(key);
+        return std::make_pair(s, keys);
+    });
+}
+/** Generates a P2PKH/CKey pair */
+rc::Gen<SPKCKeyPair> P2PKHSPK()
+{
+    return rc::gen::map(rc::gen::arbitrary<CKey>(), [](const CKey& key) {
+        CKeyID id = key.GetPubKey().GetID();
+        std::vector<CKey> keys;
+        keys.push_back(key);
+        const CScript& s = GetScriptForDestination(id);
+        return std::make_pair(s, keys);
+    });
+}
+
+/** Generates a MultiSigSPK/CKey(s) pair */
+rc::Gen<SPKCKeyPair> MultisigSPK()
+{
+    return rc::gen::mapcat(MultisigKeys(), [](const std::vector<CKey>& keys) {
+        return rc::gen::map(rc::gen::inRange<int>(1, keys.size()), [keys](int required_sigs) {
+            std::vector<CPubKey> pub_keys;
+            for (unsigned int i = 0; i < keys.size(); i++) {
+                pub_keys.push_back(keys[i].GetPubKey());
+            }
+            const CScript& s = GetScriptForMultisig(required_sigs, pub_keys);
+            return std::make_pair(s, keys);
+        });
+    });
+}
+
+rc::Gen<SPKCKeyPair> RawSPK()
+{
+    return rc::gen::oneOf(P2PKSPK(), P2PKHSPK(), MultisigSPK(),
+        P2WPKHSPK());
+}
+
+/** Generates a P2SHSPK/CKey(s) */
+rc::Gen<SPKCKeyPair> P2SHSPK()
+{
+    return rc::gen::map(RawSPK(), [](const SPKCKeyPair& spk_keys) {
+        const CScript& redeemScript = spk_keys.first;
+        const std::vector<CKey>& keys = spk_keys.second;
+        const CScript& p2sh = GetScriptForDestination(CScriptID(redeemScript));
+        return std::make_pair(redeemScript, keys);
+    });
+}
+
+//witness SPKs
+
+rc::Gen<SPKCKeyPair> P2WPKHSPK()
+{
+    rc::Gen<SPKCKeyPair> spks = rc::gen::oneOf(P2PKSPK(), P2PKHSPK());
+    return rc::gen::map(spks, [](const SPKCKeyPair& spk_keys) {
+        const CScript& p2pk = spk_keys.first;
+        const std::vector<CKey>& keys = spk_keys.second;
+        const CScript& wit_spk = GetScriptForWitness(p2pk);
+        return std::make_pair(wit_spk, keys);
+    });
+}
+
+rc::Gen<SPKCKeyPair> P2WSHSPK()
+{
+    return rc::gen::map(MultisigSPK(), [](const SPKCKeyPair& spk_keys) {
+        const CScript& p2pk = spk_keys.first;
+        const std::vector<CKey>& keys = spk_keys.second;
+        const CScript& wit_spk = GetScriptForWitness(p2pk);
+        return std::make_pair(wit_spk, keys);
+    });
+}

--- a/src/test/gen/script_gen.h
+++ b/src/test/gen/script_gen.h
@@ -1,0 +1,44 @@
+#ifndef BITCOIN_TEST_GEN_SCRIPT_GEN_H
+#define BITCOIN_TEST_GEN_SCRIPT_GEN_H
+
+#include "script/script.h"
+#include "key.h"
+#include <rapidcheck/gen/Arbitrary.h>
+#include <rapidcheck/Gen.h>
+#include <rapidcheck/gen/Numeric.h>
+#include <rapidcheck/gen/Container.h>
+#include <rapidcheck/gen/Select.h>
+
+typedef std::pair<CScript, std::vector<CKey>> SPKCKeyPair;
+
+//non witness SPKs
+rc::Gen<SPKCKeyPair> P2PKSPK();
+
+rc::Gen<SPKCKeyPair> P2PKHSPK();
+
+rc::Gen<SPKCKeyPair> MultisigSPK();
+
+/** Generates a non-P2SH/P2WSH spk */
+rc::Gen<SPKCKeyPair> RawSPK();
+
+rc::Gen<SPKCKeyPair> P2SHSPK();
+
+//witness spks
+
+rc::Gen<SPKCKeyPair> P2WPKHSPK();
+
+rc::Gen<SPKCKeyPair> P2WSHSPK();
+
+namespace rc
+{
+template <>
+struct Arbitrary<CScript> {
+    static Gen<CScript> arbitrary()
+    {
+        return gen::map(gen::arbitrary<std::vector<unsigned char>>(), [](std::vector<unsigned char> script) {
+            return CScript(script);
+        });
+    };
+};
+} //namespace rc
+#endif

--- a/src/test/gen/transaction_gen.cpp
+++ b/src/test/gen/transaction_gen.cpp
@@ -1,0 +1,133 @@
+#include "test/gen/transaction_gen.h"
+
+#include "test/gen/crypto_gen.h"
+#include "test/gen/script_gen.h"
+
+#include "script/sign.h"
+#include "script/script.h"
+#include "primitives/transaction.h"
+#include "core_io.h"
+#include "keystore.h"
+
+#include <rapidcheck/gen/Arbitrary.h>
+#include <rapidcheck/Gen.h>
+#include <rapidcheck/gen/Predicate.h>
+#include <rapidcheck/gen/Select.h>
+
+CMutableTransaction BuildCreditingTransaction(const CScript& scriptPubKey, int nValue = 0)
+{
+    CMutableTransaction txCredit;
+    txCredit.nVersion = 1;
+    txCredit.nLockTime = 0;
+    txCredit.vin.resize(1);
+    txCredit.vout.resize(1);
+    txCredit.vin[0].prevout.SetNull();
+    txCredit.vin[0].scriptSig = CScript() << CScriptNum(0) << CScriptNum(0);
+    txCredit.vin[0].nSequence = CTxIn::SEQUENCE_FINAL;
+    txCredit.vout[0].scriptPubKey = scriptPubKey;
+    txCredit.vout[0].nValue = nValue;
+
+    return txCredit;
+}
+
+CMutableTransaction BuildSpendingTransaction(const CScript& scriptSig, const CScriptWitness& scriptWitness, const CMutableTransaction& txCredit)
+{
+    CMutableTransaction txSpend;
+    txSpend.nVersion = 1;
+    txSpend.nLockTime = 0;
+    txSpend.vin.resize(1);
+    txSpend.vin[0].scriptWitness = scriptWitness;
+    txSpend.vin[0].prevout.hash = txCredit.GetHash();
+    txSpend.vin[0].prevout.n = 0;
+    txSpend.vin[0].scriptSig = scriptSig;
+    txSpend.vin[0].nSequence = CTxIn::SEQUENCE_FINAL;
+    txSpend.vout.resize(1);
+    txSpend.vout[0].scriptPubKey = CScript();
+    txSpend.vout[0].nValue = txCredit.vout[0].nValue;
+
+    return txSpend;
+}
+
+/** Helper function to generate a tx that spends a spk */
+SpendingInfo sign(const SPKCKeyPair& spk_keys, const CScript& redeemScript = CScript())
+{
+    const int inputIndex = 0;
+    const CAmount nValue = 0;
+    const CScript& spk = spk_keys.first;
+    const std::vector<CKey>& keys = spk_keys.second;
+    CBasicKeyStore store;
+    for (const auto k : keys) {
+        store.AddKey(k);
+    }
+    //add redeem script
+    store.AddCScript(redeemScript);
+    CMutableTransaction creditingTx = BuildCreditingTransaction(spk, nValue);
+    CMutableTransaction spendingTx = BuildSpendingTransaction(CScript(), CScriptWitness(), creditingTx);
+    CTransaction spendingTxConst(spendingTx);
+    SignatureData sigdata;
+    TransactionSignatureCreator creator(&store, &spendingTxConst, inputIndex, 0);
+    assert(ProduceSignature(creator, spk, sigdata));
+    UpdateTransaction(spendingTx, 0, sigdata);
+    const CTxOut& output = creditingTx.vout[0];
+    const CTransaction finalTx = CTransaction(spendingTx);
+    SpendingInfo tup = std::make_tuple(output, finalTx, inputIndex);
+    return tup;
+}
+
+/** A signed tx that validly spends a P2PKSPK */
+rc::Gen<SpendingInfo> SignedP2PKTx()
+{
+    return rc::gen::map(P2PKSPK(), [](const SPKCKeyPair& spk_key) {
+        return sign(spk_key);
+    });
+}
+
+rc::Gen<SpendingInfo> SignedP2PKHTx()
+{
+    return rc::gen::map(P2PKHSPK(), [](const SPKCKeyPair& spk_key) {
+        return sign(spk_key);
+    });
+}
+
+rc::Gen<SpendingInfo> SignedMultisigTx()
+{
+    return rc::gen::map(MultisigSPK(), [](const SPKCKeyPair& spk_key) {
+        return sign(spk_key);
+    });
+}
+
+rc::Gen<SpendingInfo> SignedP2SHTx()
+{
+    return rc::gen::map(RawSPK(), [](const SPKCKeyPair& spk_keys) {
+        const CScript& redeemScript = spk_keys.first;
+        const std::vector<CKey>& keys = spk_keys.second;
+        //hash the spk
+        const CScript& p2sh = GetScriptForDestination(CScriptID(redeemScript));
+        return sign(std::make_pair(p2sh, keys), redeemScript);
+    });
+}
+
+rc::Gen<SpendingInfo> SignedP2WPKHTx()
+{
+    return rc::gen::map(P2WPKHSPK(), [](const SPKCKeyPair& spk_keys) {
+        return sign(spk_keys);
+    });
+}
+
+rc::Gen<SpendingInfo> SignedP2WSHTx()
+{
+    return rc::gen::map(MultisigSPK(), [](const SPKCKeyPair& spk_keys) {
+        const CScript& redeemScript = spk_keys.first;
+        const std::vector<CKey>& keys = spk_keys.second;
+        const CScript p2wsh = GetScriptForWitness(redeemScript);
+        return sign(std::make_pair(p2wsh, keys), redeemScript);
+    });
+}
+
+/** Generates an arbitrary validly signed tx */
+rc::Gen<SpendingInfo> SignedTx()
+{
+    return rc::gen::oneOf(SignedP2PKTx(), SignedP2PKHTx(),
+        SignedMultisigTx(), SignedP2SHTx(), SignedP2WPKHTx(),
+        SignedP2WSHTx());
+}

--- a/src/test/gen/transaction_gen.h
+++ b/src/test/gen/transaction_gen.h
@@ -1,0 +1,124 @@
+#ifndef BITCOIN_TEST_GEN_TRANSACTION_GEN_H
+#define BITCOIN_TEST_GEN_TRANSACTION_GEN_H
+
+#include "test/gen/crypto_gen.h"
+#include "test/gen/script_gen.h"
+
+#include "script/script.h"
+#include "primitives/transaction.h"
+#include "amount.h"
+
+#include <rapidcheck/gen/Arbitrary.h>
+#include <rapidcheck/Gen.h>
+#include <rapidcheck/gen/Predicate.h>
+
+typedef std::tuple<const CTxOut, const CTransaction, const int> SpendingInfo;
+/** A signed tx that validly spends a P2PKSPK and the input index */
+rc::Gen<SpendingInfo> SignedP2PKTx();
+
+/** A signed tx that validly spends a P2PKHSPK and the input index */
+rc::Gen<SpendingInfo> SignedP2PKHTx();
+
+/** A signed tx that validly spends a MultisigSPK and the input index */
+rc::Gen<SpendingInfo> SignedMultisigTx();
+
+/** A signed tx that validly spends a P2SHSPK and the input index */
+rc::Gen<SpendingInfo> SignedP2SHTx();
+
+/** A signed tx that validly spends a P2WPKH and the input index */
+rc::Gen<SpendingInfo> SignedP2WPKHTx();
+
+/** A signed tx that validly spends a P2WSH output and the input index */
+rc::Gen<SpendingInfo> SignedP2WSHTx();
+
+/** Generates a arbitrary validly signed tx */
+rc::Gen<SpendingInfo> SignedTx();
+
+namespace rc
+{
+/** Generator for a COutPoint */
+template <>
+struct Arbitrary<COutPoint> {
+    static Gen<COutPoint> arbitrary()
+    {
+        return gen::map(gen::tuple(gen::arbitrary<uint256>(), gen::arbitrary<uint32_t>()), [](std::tuple<uint256, uint32_t> outPointPrimitives) {
+            uint32_t nIn;
+            uint256 nHashIn;
+            std::tie(nHashIn, nIn) = outPointPrimitives;
+            return COutPoint(nHashIn, nIn);
+        });
+    };
+};
+
+/** Generator for a CTxIn */
+template <>
+struct Arbitrary<CTxIn> {
+    static Gen<CTxIn> arbitrary()
+    {
+        return gen::map(gen::tuple(gen::arbitrary<COutPoint>(), gen::arbitrary<CScript>(), gen::arbitrary<uint32_t>()), [](const std::tuple<const COutPoint&, const CScript&, uint32_t>& primitives) {
+            COutPoint outpoint;
+            CScript script;
+            uint32_t sequence;
+            std::tie(outpoint, script, sequence) = primitives;
+            return CTxIn(outpoint, script, sequence);
+        });
+    };
+};
+
+/** Generator for a CAmount */
+template <>
+struct Arbitrary<CAmount> {
+    static Gen<CAmount> arbitrary()
+    {
+        //why doesn't this generator call work? It seems to cause an infinite loop.
+        //return gen::arbitrary<int64_t>();
+        return gen::inRange<int64_t>(std::numeric_limits<int64_t>::min(), std::numeric_limits<int64_t>::max());
+    };
+};
+
+/** Generator for CTxOut */
+template <>
+struct Arbitrary<CTxOut> {
+    static Gen<CTxOut> arbitrary()
+    {
+        return gen::map(gen::pair(gen::arbitrary<CAmount>(), gen::arbitrary<CScript>()), [](const std::pair<CAmount, CScript>& primitives) {
+            return CTxOut(primitives.first, primitives.second);
+        });
+    };
+};
+
+/** Generator for a CTransaction */
+template <>
+struct Arbitrary<CTransaction> {
+    static Gen<CTransaction> arbitrary()
+    {
+        return gen::map(gen::tuple(gen::arbitrary<int32_t>(),
+                            gen::nonEmpty<std::vector<CTxIn>>(), gen::nonEmpty<std::vector<CTxOut>>(), gen::arbitrary<uint32_t>()),
+            [](const std::tuple<int32_t, const std::vector<CTxIn>&, const std::vector<CTxOut>&, uint32_t>& primitives) {
+                CMutableTransaction tx;
+                int32_t nVersion;
+                std::vector<CTxIn> vin;
+                std::vector<CTxOut> vout;
+                uint32_t locktime;
+                std::tie(nVersion, vin, vout, locktime) = primitives;
+                tx.nVersion = nVersion;
+                tx.vin = vin;
+                tx.vout = vout;
+                tx.nLockTime = locktime;
+                return CTransaction(tx);
+            });
+    };
+};
+
+/** Generator for a CTransactionRef */
+template <>
+struct Arbitrary<CTransactionRef> {
+    static Gen<CTransactionRef> arbitrary()
+    {
+        return gen::map(gen::arbitrary<CTransaction>(), [](const CTransaction& tx) {
+            return MakeTransactionRef(tx);
+        });
+    };
+};
+} //namespace rc
+#endif

--- a/src/test/key_properties.cpp
+++ b/src/test/key_properties.cpp
@@ -1,0 +1,61 @@
+// Copyright (c) 2012-2016 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#include "key.h"
+
+#include "base58.h"
+#include "script/script.h"
+#include "uint256.h"
+#include "util.h"
+#include "utilstrencodings.h"
+#include "test/test_bitcoin.h"
+#include <string>
+#include <vector>
+
+#include <boost/test/unit_test.hpp>
+#include <rapidcheck/boost_test.h>
+#include <rapidcheck/gen/Arbitrary.h>
+#include <rapidcheck/Gen.h>
+
+#include "test/gen/crypto_gen.h"
+
+BOOST_FIXTURE_TEST_SUITE(key_properties, BasicTestingSetup)
+
+/** Check CKey uniqueness */
+RC_BOOST_PROP(key_uniqueness, (const CKey& key1, const CKey& key2))
+{
+    RC_ASSERT(!(key1 == key2));
+}
+
+/** Verify that a private key generates the correct public key */
+RC_BOOST_PROP(key_generates_correct_pubkey, (const CKey& key))
+{
+    CPubKey pubKey = key.GetPubKey();
+    RC_ASSERT(key.VerifyPubKey(pubKey));
+}
+
+/** Serialization symmetry CKey -> CBitcoinSecret -> CKey */
+RC_BOOST_PROP(key_bitcoinsecret_symmetry, (const CKey& key))
+{
+    CBitcoinSecret secret;
+    secret.SetKey(key);
+    RC_ASSERT(secret.GetKey() == key);
+}
+
+/** Create a CKey using the 'Set' function must give us the same key */
+RC_BOOST_PROP(key_set_symmetry, (const CKey& key))
+{
+    CKey key1;
+    key1.Set(key.begin(), key.end(), key.IsCompressed());
+    RC_ASSERT(key1 == key);
+}
+
+/** Create a CKey, sign a piece of data, then verify it with the public key */
+RC_BOOST_PROP(key_sign_symmetry, (const CKey& key, const uint256& hash))
+{
+    std::vector<unsigned char> vchSig;
+    key.Sign(hash, vchSig, 0);
+    const CPubKey& pubKey = key.GetPubKey();
+    RC_ASSERT(pubKey.Verify(hash, vchSig));
+}
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/merkleblock_properties.cpp
+++ b/src/test/merkleblock_properties.cpp
@@ -1,0 +1,61 @@
+#include "test/test_bitcoin.h"
+
+#include <boost/test/unit_test.hpp>
+#include <rapidcheck/boost_test.h>
+#include <rapidcheck/gen/Arbitrary.h>
+#include <rapidcheck/Gen.h>
+
+#include "merkleblock.h"
+#include "test/gen/merkleblock_gen.h"
+
+#include <iostream>
+BOOST_FIXTURE_TEST_SUITE(merkleblock_properties, BasicTestingSetup)
+
+RC_BOOST_PROP(merkleblock_serialization_symmetry, (const CMerkleBlock& mb))
+{
+    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+    ss << mb;
+    CMerkleBlock mb2;
+    ss >> mb2;
+    CDataStream ss1(SER_NETWORK, PROTOCOL_VERSION);
+    ss << mb;
+    ss1 << mb2;
+    RC_ASSERT(ss.str() == ss1.str());
+}
+
+/** Should find all txids we inserted in the merkle block */
+RC_BOOST_PROP(merkle_block_match_symmetry, (std::pair<CMerkleBlock, std::set<uint256>> p))
+{
+    const CMerkleBlock& mb = p.first;
+    const std::set<uint256>& inserted_hashes = p.second;
+    for (unsigned int i = 0; i < mb.vMatchedTxn.size(); i++) {
+        const auto& h = mb.vMatchedTxn[i].second;
+        RC_ASSERT(inserted_hashes.find(h) != inserted_hashes.end());
+    }
+}
+
+RC_BOOST_PROP(partialmerkletree_serialization_symmetry, (const CPartialMerkleTree& tree))
+{
+    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+    ss << tree;
+    CPartialMerkleTree tree2;
+    ss >> tree2;
+    CDataStream ss1(SER_NETWORK, PROTOCOL_VERSION);
+    ss << tree;
+    ss1 << tree2;
+    RC_ASSERT(ss.str() == ss1.str());
+}
+
+
+/** Should find all txids we inserted in the PartialMerkleTree */
+RC_BOOST_PROP(partialmerkletree_extract_matches_symmetry, (std::pair<CPartialMerkleTree, std::vector<uint256>> p))
+{
+    CPartialMerkleTree& tree = p.first;
+    const std::vector<uint256>& expectedMatches = p.second;
+    std::vector<uint256> matches;
+    std::vector<unsigned int> indices;
+    tree.ExtractMatches(matches, indices);
+    RC_ASSERT(matches == expectedMatches);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/script_properties.cpp
+++ b/src/test/script_properties.cpp
@@ -1,0 +1,26 @@
+#include <string>
+#include <vector>
+
+#include <boost/test/unit_test.hpp>
+#include <rapidcheck/boost_test.h>
+#include <rapidcheck/gen/Arbitrary.h>
+#include <rapidcheck/Gen.h>
+
+#include "script/script.h"
+#include "test/test_bitcoin.h"
+#include "test/gen/script_gen.h"
+
+BOOST_FIXTURE_TEST_SUITE(script_properties, BasicTestingSetup)
+
+/** Check CScript serialization symmetry */
+RC_BOOST_PROP(cscript_serialization_symmetry, (const CScript& script))
+{
+    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+    ss << static_cast<const CScriptBase&>(script);
+    std::vector<unsigned char> deserialized;
+    ss >> deserialized;
+    CScript script2 = CScript(deserialized.begin(), deserialized.end());
+    RC_ASSERT(script == script2);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/transaction_properties.cpp
+++ b/src/test/transaction_properties.cpp
@@ -1,0 +1,116 @@
+
+#include "test/gen/transaction_gen.h"
+
+#include "key.h"
+#include "base58.h"
+#include "script/script.h"
+#include "policy/policy.h"
+#include "primitives/transaction.h"
+#include "uint256.h"
+#include "util.h"
+#include "utilstrencodings.h"
+#include "test/test_bitcoin.h"
+#include "streams.h"
+#include <string>
+#include <vector>
+
+#include <boost/test/unit_test.hpp>
+#include <rapidcheck/boost_test.h>
+#include <rapidcheck/gen/Arbitrary.h>
+#include <rapidcheck/Gen.h>
+
+BOOST_FIXTURE_TEST_SUITE(transaction_properties, BasicTestingSetup)
+/** Helper function to run a SpendingInfo through the interpreter to check
+  * validity of the transaction spending a spk */
+bool run(SpendingInfo info)
+{
+    const CTxOut output = std::get<0>(info);
+    const CTransaction tx = std::get<1>(info);
+    const int input_idx = std::get<2>(info);
+    const CTxIn input = tx.vin[input_idx];
+    const CScript scriptSig = input.scriptSig;
+    TransactionSignatureChecker checker(&tx, input_idx, output.nValue);
+    const CScriptWitness wit = input.scriptWitness;
+    //run it through the interpreter
+    bool result = VerifyScript(scriptSig, output.scriptPubKey,
+        &wit, STANDARD_SCRIPT_VERIFY_FLAGS, checker);
+    return result;
+}
+/** Check COutpoint serialization symmetry */
+RC_BOOST_PROP(outpoint_serialization_symmetry, (const COutPoint& outpoint))
+{
+    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+    ss << outpoint;
+    COutPoint outpoint2;
+    ss >> outpoint2;
+    RC_ASSERT(outpoint2 == outpoint);
+}
+/** Check CTxIn serialization symmetry */
+RC_BOOST_PROP(ctxin_serialization_symmetry, (const CTxIn& txin))
+{
+    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+    ss << txin;
+    CTxIn txin2;
+    ss >> txin2;
+    RC_ASSERT(txin == txin2);
+}
+
+/** Check CTxOut serialization symmetry */
+RC_BOOST_PROP(ctxout_serialization_symmetry, (const CTxOut& txout))
+{
+    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+    ss << txout;
+    CTxOut txout2;
+    ss >> txout2;
+    RC_ASSERT(txout == txout2);
+}
+
+/** Check CTransaction serialization symmetry */
+RC_BOOST_PROP(ctransaction_serialization_symmetry, (const CTransaction& tx))
+{
+    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+    ss << tx;
+    CTransaction tx2(deserialize, ss);
+    RC_ASSERT(tx == tx2);
+}
+
+/** Check that we can spend a p2pk tx that ProduceSignature created */
+RC_BOOST_PROP(spend_p2pk_tx, ())
+{
+    const SpendingInfo& info = *SignedP2PKTx();
+    RC_ASSERT(run(info));
+}
+
+/** Check that we can spend a p2pkh tx that ProduceSignature created */
+RC_BOOST_PROP(spend_p2pkh_tx, ())
+{
+    const SpendingInfo& info = *SignedP2PKHTx();
+    RC_ASSERT(run(info));
+}
+
+/** Check that we can spend a multisig tx that ProduceSignature created */
+RC_BOOST_PROP(spend_multisig_tx, ())
+{
+    const SpendingInfo& info = *SignedMultisigTx();
+    RC_ASSERT(run(info));
+}
+/** Check that we can spend a p2sh tx that ProduceSignature created */
+RC_BOOST_PROP(spend_p2sh_tx, ())
+{
+    const SpendingInfo& info = *SignedP2SHTx();
+    RC_ASSERT(run(info));
+}
+
+RC_BOOST_PROP(spend_p2wpkh_tx, ())
+{
+    const SpendingInfo& info = *SignedP2WPKHTx();
+    RC_ASSERT(run(info));
+}
+
+RC_BOOST_PROP(spend_p2wsh_tx, ())
+{
+    const SpendingInfo& info = *SignedP2WSHTx();
+    RC_ASSERT(run(info));
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This pull request is a proof of concept for introducting [property based testing](https://en.wikipedia.org/wiki/QuickCheck) into Bitcoin Core

> In QuickCheck the programmer writes assertions about logical properties that a function should fulfill. Then QuickCheck attempts to generate a test case that falsifies these assertions. Once such a test case is found, QuickCheck tries to reduce it to a minimal failing subset by removing or simplifying input data that are not needed to make the test fail.

This has been very useful for a Bitcoin library I've been working on and thought it would be worthwhile to develop a POC for Bitcoin Core. The property based library I am using for C++ is called [rapidcheck](https://github.com/emil-e/rapidcheck). Here are the [docs](https://github.com/emil-e/rapidcheck/tree/master/doc). 

This pull request currently contains [two properties](https://github.com/Christewart/bitcoin/blob/rapidcheck/src/test/key_properties.cpp#L34-L46), one testing `CKey` generation and the other testing serialization symmetry for `CKey` and `CBitcoinSecret`. These are rather trivial properties, but useful for illustrating the power of property based testing if there was a bug inside of Core.

I want to solicit some feedback from developers if this is something that would actually be merged into Core. Eventually we could have a large library of [generators](https://github.com/emil-e/rapidcheck/blob/master/doc/generators.md) that would allow us to quickly prototype, test, and reason about the behavior of new code added to Core. Here is an example of a [library of generators](https://github.com/bitcoin-s/bitcoin-s-core/blob/master/src/main/scala/org/bitcoins/core/gen/TransactionGenerators.scala#L70-L117) (in Scala) that could give you a little more of an idea of what I am talking about. 

Thoughts?
