### PR TITLE
Key origin metadata, with HD wallet support

### DIFF
--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -137,8 +137,9 @@ UniValue importprivkey(const JSONRPCRequest& request)
         if (pwalletMain->HaveKey(vchAddress))
             return NullUniValue;
 
-        pwalletMain->mapKeyMetadata[vchAddress].nCreateTime = 1;
-        pwalletMain->mapKeyMetadata[vchAddress].keyFlags |= CKeyMetadata::KEY_ORIGIN_IMPORTED;
+        CKeyMetadata& metadata = pwalletMain->mapKeyMetadata[vchAddress];
+        metadata.nCreateTime = 1;
+        metadata.SetKeyOrigin(metadata.GetKeyOrigin() | CKeyMetadata::KEY_ORIGIN_IMPORTED);
 
         if (!pwalletMain->AddKeyPubKey(key, pubkey))
             throw JSONRPCError(RPC_WALLET_ERROR, "Error adding key to wallet");

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -138,6 +138,7 @@ UniValue importprivkey(const JSONRPCRequest& request)
             return NullUniValue;
 
         pwalletMain->mapKeyMetadata[vchAddress].nCreateTime = 1;
+        pwalletMain->mapKeyMetadata[vchAddress].keyFlags |= CKeyMetadata::KEY_ORIGIN_IMPORTED;
 
         if (!pwalletMain->AddKeyPubKey(key, pubkey))
             throw JSONRPCError(RPC_WALLET_ERROR, "Error adding key to wallet");

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1200,7 +1200,7 @@ UniValue ListReceived(const UniValue& params, bool fByAccounts)
         CKeyID keyID;
         uint8_t keyFlags = 0;
         if (address.GetKeyID(keyID))
-            keyFlags = pwalletMain->mapKeyMetadata[keyID].keyFlags;
+            keyFlags = pwalletMain->mapKeyMetadata[keyID].GetKeyOrigin();
 
         std::string keyOrigin;
         if (keyFlags & CKeyMetadata::KEY_ORIGIN_UNKNOWN)

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1196,6 +1196,22 @@ UniValue ListReceived(const UniValue& params, bool fByAccounts)
             fIsWatchonly = (*it).second.fIsWatchonly;
         }
 
+        // convert keyflags into a string
+        CKeyID keyID;
+        uint8_t keyFlags = 0;
+        if (address.GetKeyID(keyID))
+            keyFlags = pwalletMain->mapKeyMetadata[keyID].keyFlags;
+
+        std::string keyOrigin;
+        if (keyFlags & CKeyMetadata::KEY_ORIGIN_UNKNOWN)
+            keyOrigin = "unknown";
+        if (keyFlags & CKeyMetadata::KEY_ORIGIN_ENC_WALLET)
+            keyOrigin = "encrypted";
+        else if (keyFlags & CKeyMetadata::KEY_ORIGIN_UNENC_WALLET)
+            keyOrigin = "unencrypted";
+        if (keyFlags & CKeyMetadata::KEY_ORIGIN_IMPORTED)
+            keyOrigin = "imported";
+
         if (fByAccounts)
         {
             tallyitem& _item = mapAccountTally[strAccount];
@@ -1211,6 +1227,7 @@ UniValue ListReceived(const UniValue& params, bool fByAccounts)
             obj.push_back(Pair("address",       address.ToString()));
             obj.push_back(Pair("account",       strAccount));
             obj.push_back(Pair("amount",        ValueFromAmount(nAmount)));
+            obj.push_back(Pair("key_origin", keyOrigin));
             obj.push_back(Pair("confirmations", (nConf == std::numeric_limits<int>::max() ? 0 : nConf)));
             if (!fByAccounts)
                 obj.push_back(Pair("label", strAccount));

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -99,8 +99,16 @@ CPubKey CWallet::GenerateNewKey()
     CKeyMetadata metadata(nCreationTime);
 
     //check if the wallet supports keyflags
-    if (CanSupportFeature(FEATURE_KEYFLAGS)) {
-        metadata.nVersion = CKeyMetadata::VERSION_WITH_FLAGS;
+    if (GetVersion() >= FEATURE_HD) {
+        if (CanSupportFeature(FEATURE_HD_KEYMETA) && SetMinVersion(FEATURE_HD_KEYMETA)) {
+            metadata.nVersion = CKeyMetadata::VERSION_WITH_META;
+        }
+    } else {
+        if (CanSupportFeature(FEATURE_KEYMETA) && SetMinVersion(FEATURE_KEYMETA)) {
+            metadata.nVersion = CKeyMetadata::VERSION_WITH_META;
+        } else if (CanSupportFeature(FEATURE_KEYFLAGS) && SetMinVersion(FEATURE_KEYFLAGS)) {
+            metadata.nVersion = CKeyMetadata::VERSION_WITH_FLAGS;
+        }
     }
     metadata.SetKeyOrigin(IsCrypted() ? CKeyMetadata::KEY_ORIGIN_ENC_WALLET : CKeyMetadata::KEY_ORIGIN_UNENC_WALLET);
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -98,6 +98,13 @@ CPubKey CWallet::GenerateNewKey()
     int64_t nCreationTime = GetTime();
     CKeyMetadata metadata(nCreationTime);
 
+    //check if the wallet supports keyflags
+    if (CanSupportFeature(FEATURE_KEYFLAGS))
+    {
+        metadata.nVersion = CKeyMetadata::VERSION_SUPPORT_FLAGS;
+        metadata.keyFlags |= IsCrypted() ? CKeyMetadata::KEY_ORIGIN_ENC_WALLET : CKeyMetadata::KEY_ORIGIN_UNENC_WALLET;
+    }
+
     // use HD key derivation if HD was enabled during wallet creation
     if (IsHDEnabled()) {
         DeriveNewChildKey(metadata, secret);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -99,11 +99,10 @@ CPubKey CWallet::GenerateNewKey()
     CKeyMetadata metadata(nCreationTime);
 
     //check if the wallet supports keyflags
-    if (CanSupportFeature(FEATURE_KEYFLAGS))
-    {
-        metadata.nVersion = CKeyMetadata::VERSION_SUPPORT_FLAGS;
-        metadata.keyFlags |= IsCrypted() ? CKeyMetadata::KEY_ORIGIN_ENC_WALLET : CKeyMetadata::KEY_ORIGIN_UNENC_WALLET;
+    if (CanSupportFeature(FEATURE_KEYFLAGS)) {
+        metadata.nVersion = CKeyMetadata::VERSION_WITH_FLAGS;
     }
+    metadata.SetKeyOrigin(IsCrypted() ? CKeyMetadata::KEY_ORIGIN_ENC_WALLET : CKeyMetadata::KEY_ORIGIN_UNENC_WALLET);
 
     // use HD key derivation if HD was enabled during wallet creation
     if (IsHDEnabled()) {

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -81,9 +81,10 @@ enum WalletFeature
 
     FEATURE_WALLETCRYPT = 40000, // wallet encryption
     FEATURE_COMPRPUBKEY = 60000, // compressed public keys
+    FEATURE_KEYFLAGS    = 70000, // key metadata flags for storing informations like key origin
 
     FEATURE_HD = 130000, // Hierarchical key derivation after BIP32 (HD Wallet)
-    FEATURE_LATEST = FEATURE_COMPRPUBKEY // HD is optional, use FEATURE_COMPRPUBKEY as latest version
+    FEATURE_LATEST = FEATURE_KEYFLAGS // HD is optional, use FEATURE_KEYFLAGS as latest version
 };
 
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -82,9 +82,11 @@ enum WalletFeature
     FEATURE_WALLETCRYPT = 40000, // wallet encryption
     FEATURE_COMPRPUBKEY = 60000, // compressed public keys
     FEATURE_KEYFLAGS    = 70000, // key metadata flags for storing informations like key origin
+    FEATURE_KEYMETA     = 70001, // key metadata map
 
     FEATURE_HD = 130000, // Hierarchical key derivation after BIP32 (HD Wallet)
-    FEATURE_LATEST = FEATURE_KEYFLAGS // HD is optional, use FEATURE_KEYFLAGS as latest version
+    FEATURE_HD_KEYMETA = 130001, // HD + key metadata map
+    FEATURE_LATEST = FEATURE_KEYMETA // HD is optional, use FEATURE_KEYMETA as latest version
 };
 
 

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -73,12 +73,21 @@ class CKeyMetadata
 {
 public:
     static const int VERSION_BASIC=1;
+    static const int VERSION_SUPPORT_FLAGS=2;
     static const int VERSION_WITH_HDDATA=10;
     static const int CURRENT_VERSION=VERSION_WITH_HDDATA;
+
+    static const uint8_t KEY_ORIGIN_UNSET         = 0x0000;
+    static const uint8_t KEY_ORIGIN_UNKNOWN       = 0x0001;
+    static const uint8_t KEY_ORIGIN_IMPORTED      = 0x0002;
+    static const uint8_t KEY_ORIGIN_UNENC_WALLET  = 0x0004;
+    static const uint8_t KEY_ORIGIN_ENC_WALLET    = 0x0008;
+
     int nVersion;
     int64_t nCreateTime; // 0 means unknown
     std::string hdKeypath; //optional HD/bip32 keypath
     CKeyID hdMasterKeyID; //id of the HD masterkey used to derive this key
+    uint8_t keyFlags;
 
     CKeyMetadata()
     {
@@ -88,6 +97,7 @@ public:
     {
         SetNull();
         nCreateTime = nCreateTime_;
+        keyFlags = KEY_ORIGIN_UNSET;
     }
 
     ADD_SERIALIZE_METHODS;
@@ -101,6 +111,9 @@ public:
             READWRITE(hdKeypath);
             READWRITE(hdMasterKeyID);
         }
+        else
+        if (nVersion >= VERSION_SUPPORT_FLAGS)
+            READWRITE(keyFlags);
     }
 
     void SetNull()
@@ -109,6 +122,7 @@ public:
         nCreateTime = 0;
         hdKeypath.clear();
         hdMasterKeyID.SetNull();
+        keyFlags = KEY_ORIGIN_UNSET;
     }
 };
 

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -73,7 +73,7 @@ class CKeyMetadata
 {
 public:
     static const int VERSION_BASIC=1;
-    static const int VERSION_SUPPORT_FLAGS=2;
+    static const int VERSION_WITH_FLAGS=2;
     static const int VERSION_WITH_HDDATA=10;
     static const int CURRENT_VERSION=VERSION_WITH_HDDATA;
 
@@ -87,7 +87,9 @@ public:
     int64_t nCreateTime; // 0 means unknown
     std::string hdKeypath; //optional HD/bip32 keypath
     CKeyID hdMasterKeyID; //id of the HD masterkey used to derive this key
+private:
     uint8_t keyFlags;
+public:
 
     CKeyMetadata()
     {
@@ -112,7 +114,7 @@ public:
             READWRITE(hdMasterKeyID);
         }
         else
-        if (nVersion >= VERSION_SUPPORT_FLAGS)
+        if (nVersion >= VERSION_WITH_FLAGS)
             READWRITE(keyFlags);
     }
 
@@ -123,6 +125,14 @@ public:
         hdKeypath.clear();
         hdMasterKeyID.SetNull();
         keyFlags = KEY_ORIGIN_UNSET;
+    }
+
+    void SetKeyOrigin(const uint8_t n) {
+        keyFlags = n;
+    }
+
+    uint8_t GetKeyOrigin() const {
+        return keyFlags;
     }
 };
 


### PR DESCRIPTION
This upgrades #5916/#8132 to support HD wallets by adding a map<string,string> at the end of CKeyMetadata which can be used to store future-proof data, similar to CWalletTx's mapValue.
