### PR TITLE
Do not shadow LOCK's criticalblock variable for LOCK inside LOCK

### DIFF
--- a/src/sync.h
+++ b/src/sync.h
@@ -171,7 +171,10 @@ public:
 
 typedef CMutexLock<CCriticalSection> CCriticalBlock;
 
-#define LOCK(cs) CCriticalBlock criticalblock(cs, #cs, __FILE__, __LINE__)
+#define PASTE(x, y) x ## y
+#define PASTE2(x, y) PASTE(x, y)
+
+#define LOCK(cs) CCriticalBlock PASTE2(criticalblock, __COUNTER__)(cs, #cs, __FILE__, __LINE__)
 #define LOCK2(cs1, cs2) CCriticalBlock criticalblock1(cs1, #cs1, __FILE__, __LINE__), criticalblock2(cs2, #cs2, __FILE__, __LINE__)
 #define TRY_LOCK(cs, name) CCriticalBlock name(cs, #cs, __FILE__, __LINE__, true)
 


### PR DESCRIPTION
This is a followup to #8105, implements task 3 from it.

LOCK macro declares its variable `criticalblock`. When LOCK is used in nested block, again, the variable named `criticalblock` is used. When compiling with `-Wshadow`, this emits warning.

This change renames the variable `criticalblock` to `criticalblockn`, where n is ordinal number of the variable in the compiled file. Macro `__COUNTER__` is used for this. It is supported by gcc (https://gcc.gnu.org/onlinedocs/cpp/Common-Predefined-Macros.html), clang (http://clang.llvm.org/docs/LanguageExtensions.html) and Visual Studio (https://msdn.microsoft.com/en-us/library/b0084kay.aspx).
