### PR TITLE
[qa] Temporarily disable ipv6 in rpcbind test

### DIFF
--- a/qa/rpc-tests/rpcbind_test.py
+++ b/qa/rpc-tests/rpcbind_test.py
@@ -77,10 +77,10 @@ class RPCBindTest(BitcoinTestFramework):
 
         # check default without rpcallowip (IPv4 and IPv6 localhost)
         self.run_bind_test(None, '127.0.0.1', [],
-            [('127.0.0.1', defaultport), ('::1', defaultport)])
+            [('127.0.0.1', defaultport), #('::1', defaultport)
+            ])
         # check default with rpcallowip (IPv6 any)
-        self.run_bind_test(['127.0.0.1'], '127.0.0.1', [],
-            [('::0', defaultport)])
+        #self.run_bind_test(['127.0.0.1'], '127.0.0.1', [], [('::0', defaultport)])
         # check only IPv4 localhost (explicit)
         self.run_bind_test(['127.0.0.1'], '127.0.0.1', ['127.0.0.1'],
             [('127.0.0.1', defaultport)])
@@ -91,11 +91,11 @@ class RPCBindTest(BitcoinTestFramework):
         self.run_bind_test(['127.0.0.1'], '127.0.0.1:32171', ['127.0.0.1:32171', '127.0.0.1:32172'],
             [('127.0.0.1', 32171), ('127.0.0.1', 32172)])
         # check only IPv6 localhost (explicit)
-        self.run_bind_test(['[::1]'], '[::1]', ['[::1]'],
-            [('::1', defaultport)])
+        #self.run_bind_test(['[::1]'], '[::1]', ['[::1]'], [('::1', defaultport)])
         # check both IPv4 and IPv6 localhost (explicit)
         self.run_bind_test(['127.0.0.1'], '127.0.0.1', ['127.0.0.1', '[::1]'],
-            [('127.0.0.1', defaultport), ('::1', defaultport)])
+            [('127.0.0.1', defaultport), #('::1', defaultport)
+            ])
         # check only non-loopback interface
         self.run_bind_test([non_loopback_ip], non_loopback_ip, [non_loopback_ip],
             [(non_loopback_ip, defaultport)])


### PR DESCRIPTION
It probably makes sense to disable ipv6 in the rpcbind test until https://github.com/bitcoin/bitcoin/issues/6655#issuecomment-146136353
