### PR TITLE
Ubuntu 14.04 server installs w/o curl

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -293,7 +293,7 @@ These steps can be performed on, for example, an Ubuntu VM. The depends system
 will also work on other Linux distributions, however the commands for
 installing the toolchain will be different.
 
-First install the toolchain:
+First install the toolchain (you may need to install curl, too):
 
     sudo apt-get install g++-arm-linux-gnueabihf
 


### PR DESCRIPTION
... so `make HOST=arm-linux-gnueabihf NO_QT=1` fails if curl is missing.
