### PR TITLE
Qt: Fix minimize and close bugs

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -902,17 +902,22 @@ void BitcoinGUI::closeEvent(QCloseEvent *event)
 #ifndef Q_OS_MAC // Ignored on Mac
     if(clientModel && clientModel->getOptionsModel())
     {
-        if(!clientModel->getOptionsModel()->getMinimizeToTray() &&
-           !clientModel->getOptionsModel()->getMinimizeOnClose())
+        if(!clientModel->getOptionsModel()->getMinimizeOnClose())
         {
             // close rpcConsole in case it was open to make some space for the shutdown window
             rpcConsole->close();
 
             QApplication::quit();
         }
+        else
+        {
+            QMainWindow::showMinimized();
+            event->ignore();
+        }
     }
-#endif
+#else
     QMainWindow::closeEvent(event);
+#endif
 }
 
 void BitcoinGUI::showEvent(QShowEvent *event)


### PR DESCRIPTION
Address items 1 and 2 of https://github.com/bitcoin/bitcoin/issues/8225:
- Ensure the GUI closes when the "Minimize on close" window option is disabled, and the "Minimize to the tray instead of the taskbar" window option is enabled
- Ensure the GUI minimizes to the taskbar when the "Minimize on close" window option is enabled, and the "Minimize to the tray instead of the taskbar" window option is disabled
