### PR TITLE
Add deleteprivkey and forgetaddress RPC calls

### DIFF
--- a/src/keystore.h
+++ b/src/keystore.h
@@ -28,6 +28,9 @@ public:
     virtual bool AddKeyPubKey(const CKey &key, const CPubKey &pubkey) =0;
     virtual bool AddKey(const CKey &key);
 
+    //! Remove a key from the store.
+    virtual bool RemoveKey(const CKeyID &address) = 0;
+
     //! Check whether a key corresponding to a given address is present in the store.
     virtual bool HaveKey(const CKeyID &address) const =0;
     virtual bool GetKey(const CKeyID &address, CKey& keyOut) const =0;
@@ -63,6 +66,15 @@ protected:
 public:
     bool AddKeyPubKey(const CKey& key, const CPubKey &pubkey);
     bool GetPubKey(const CKeyID &address, CPubKey& vchPubKeyOut) const;
+    bool RemoveKey(const CKeyID &address)
+    {
+        bool result;
+        {
+            LOCK(cs_KeyStore);
+            result = (mapKeys.erase(address) > 0);
+        }
+        return result;
+    }
     bool HaveKey(const CKeyID &address) const
     {
         bool result;

--- a/src/rpc/protocol.h
+++ b/src/rpc/protocol.h
@@ -74,6 +74,7 @@ enum RPCErrorCode
     RPC_WALLET_WRONG_ENC_STATE      = -15, //! Command given in wrong wallet encryption state (encrypting an encrypted wallet etc.)
     RPC_WALLET_ENCRYPTION_FAILED    = -16, //! Failed to encrypt the wallet
     RPC_WALLET_ALREADY_UNLOCKED     = -17, //! Wallet is already unlocked
+    RPC_WALLET_HAVE_KEY             = -18, //! Refuse to act because wallet has key
 };
 
 std::string JSONRPCRequest(const std::string& strMethod, const UniValue& params, const UniValue& id);

--- a/src/wallet/crypter.h
+++ b/src/wallet/crypter.h
@@ -167,6 +167,15 @@ public:
 
     virtual bool AddCryptedKey(const CPubKey &vchPubKey, const std::vector<unsigned char> &vchCryptedSecret);
     bool AddKeyPubKey(const CKey& key, const CPubKey &pubkey);
+    bool RemoveKey(const CKeyID &address)
+    {
+        {
+            LOCK(cs_KeyStore);
+            if (!IsCrypted())
+                return CBasicKeyStore::RemoveKey(address);
+            return mapCryptedKeys.erase(address) > 0;
+        }
+    }
     bool HaveKey(const CKeyID &address) const
     {
         {

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -330,6 +330,11 @@ void CDB::Close()
     }
 }
 
+void CDB::Compact()
+{
+    pdb->compact(NULL, NULL, NULL, NULL, DB_FREE_SPACE, NULL);
+}
+
 void CDBEnv::CloseDb(const string& strFile)
 {
     {

--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -106,6 +106,7 @@ protected:
 public:
     void Flush();
     void Close();
+    void Compact();
 
 private:
     CDB(const CDB&);

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -296,6 +296,198 @@ UniValue importaddress(const UniValue& params, bool fHelp)
     return NullUniValue;
 }
 
+void RemoveAddress(const CBitcoinAddress& address);
+void RemoveScript(const CScript& script, bool isRedeemScript)
+{
+    pwalletMain->MarkDirty();
+
+    if (pwalletMain->HaveWatchOnly(script) && !pwalletMain->RemoveWatchOnly(script))
+        throw JSONRPCError(RPC_WALLET_ERROR, "Error removing address from wallet");
+
+    if (isRedeemScript) {
+        //if (pwalletMain->HaveCScript(script) && !pwalletMain->RemoveCScript(script))
+        //    throw JSONRPCError(RPC_WALLET_ERROR, "Error removing p2sh redeemScript to wallet");
+        RemoveAddress(CBitcoinAddress(CScriptID(script)));
+    }
+}
+
+void RemoveAddress(const CBitcoinAddress& address)
+{
+    CScript script = GetScriptForDestination(address.Get());
+    RemoveScript(script, false);
+    // add to address book or update label
+    if (address.IsValid())
+        pwalletMain->DelAddressBook(address.Get());
+}
+
+UniValue forgetaddress(const UniValue& params, bool fHelp)
+{
+    if (!EnsureWalletIsAvailable(fHelp))
+        return NullUniValue;
+
+    if (fHelp || params.size() < 1 || params.size() > 3)
+        throw runtime_error(
+            "forgetaddress \"address\" ( purge p2sh )\n"
+            "\nRemoves a script (in hex) or address from the wallet and (optionally) purges transactions which as a result are no longer considered as belonging to the wallet.\n"
+            "\nArguments:\n"
+            "1. \"address\"          (string, required) The hex-encoded script (or address)\n"
+            "2. purge              (boolean, optional, default=true) Remove transactions whose last remaining link to the wallet was this script/address\n"
+            "3. p2sh               (boolean, optional, default=false) Remove the P2SH version of the script as well\n"
+            "\nNote: This call only works on watch-only scripts or addresses. To forget a private key known to the wallet, first call deleteprivkey.\n"
+            "\nNote: This call will take two full passes through the wallet and compact the wallet database if purge is true.\n"
+            "\nExamples:\n"
+            "\nRemove a script with purge\n"
+            + HelpExampleCli("forgetaddress", "\"myscript\"") +
+            "\nRemove an address without purge\n"
+            + HelpExampleCli("forgetaddress", "\"myaddress\" false") +
+            "\nAs a JSON-RPC call\n"
+            + HelpExampleRpc("forgetaddress", "\"myaddress\", false")
+        );
+
+    // Whether to perform purge after removal
+    bool fPurge = true;
+    if (params.size() > 1)
+        fPurge = params[1].get_bool();
+
+    // Whether to remove a p2sh version, too
+    bool fP2SH = false;
+    if (params.size() > 2)
+        fP2SH = params[2].get_bool();
+
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
+    set<uint256> setNotMine;
+
+    if (fPurge)
+    {
+        for (map<uint256, CWalletTx>::const_iterator i = pwalletMain->mapWallet.begin(); i != pwalletMain->mapWallet.end(); ++i)
+        {
+            if (!pwalletMain->IsMine(i->second)
+             && !pwalletMain->IsFromMe(i->second))
+                setNotMine.insert(i->first);
+        }
+    }
+
+    CBitcoinAddress address(params[0].get_str());
+    if (address.IsValid()) {
+        if (fP2SH)
+            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Cannot use the p2sh flag with an address - use a script instead");
+        CKeyID keyID;
+        if (address.GetKeyID(keyID) && pwalletMain->mapKeyMetadata.count(keyID))
+            throw JSONRPCError(RPC_WALLET_HAVE_KEY, "Refusing to forget address associated with a known key. Make sure you know what you are doing, then call deleteprivkey first.");
+        RemoveAddress(address);
+    } else if (IsHex(params[0].get_str())) {
+        std::vector<unsigned char> data(ParseHex(params[0].get_str()));
+        RemoveScript(CScript(data.begin(), data.end()), fP2SH);
+    } else {
+        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid Bitcoin address or script");
+    }
+
+    vector<uint256> vDeletes;
+
+    if (fPurge)
+    {
+        // Sort the array of transaction hashes so that the order of operations
+        // and output are deterministic, for testing purposes.
+        sort(vDeletes.begin(), vDeletes.end());
+
+        for (map<uint256, CWalletTx>::const_iterator i = pwalletMain->mapWallet.begin(); i != pwalletMain->mapWallet.end(); ++i)
+        {
+            if (!pwalletMain->IsMine(i->second)
+             && !pwalletMain->IsFromMe(i->second)
+             && !setNotMine.count(i->first))
+            {
+                vDeletes.push_back(i->first);
+            }
+        }
+    }
+
+    if (!vDeletes.empty())
+    {
+        CWalletDB walletdb(pwalletMain->strWalletFile);
+        for (vector<uint256>::const_iterator pTxID = vDeletes.begin(); pTxID != vDeletes.end(); ++pTxID)
+            pwalletMain->EraseFromWallet(*pTxID, &walletdb);
+        walletdb.Flush();
+        walletdb.Compact();
+    }
+
+    if (fPurge)
+    {
+        UniValue ret(UniValue::VARR);
+        BOOST_FOREACH(const uint256& hash, vDeletes)
+            ret.push_back(hash.ToString());
+        return ret;
+    }
+
+    return NullUniValue;
+}
+
+UniValue purgetransactions(const UniValue& params, bool fHelp)
+{
+    if (!EnsureWalletIsAvailable(fHelp))
+        return NullUniValue;
+
+    if (fHelp || params.size() > 1)
+        throw runtime_error(
+            "purgetransactions compact\n"
+            "\nRemoves transactions from the wallet which are not known to correspond to any keys or watch-only scripts in to the wallet. It is not normally the case that a wallet ends up with transactions unrelated to its keys, but this can happen if forgetaddress is called with purge=false. A common use case is to forget a large number of transactions and then purge them all in one pass.\n"
+            "\nArguments:\n"
+            "1. compact        (boolean, optional, default=true) Compact the wallet database if any transactions are removed\n"
+            "\nNote: This call will take a single full passes through the wallet and then compact the wallet database if and only if transactions are removed and compact=true.\n"
+            "\nExamples:\n"
+            "\nRemove unlinked transactions from the wallet\n"
+            + HelpExampleCli("purgetransactions", "") +
+            "\nRemove unlinked transactions without compacting the wallet\n"
+            + HelpExampleCli("purgetransactions", "false") +
+            "\nAs a JSON-RPC call\n"
+            + HelpExampleRpc("purgetransactions", "false")
+        );
+
+    // Whether to perform compaction after purge
+    bool fCompact = true;
+    if (params.size() > 0)
+        fCompact = params[0].get_bool();
+
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
+    vector<uint256> vDeletes;
+
+    for (map<uint256, CWalletTx>::const_iterator i = pwalletMain->mapWallet.begin(); i != pwalletMain->mapWallet.end(); ++i)
+    {
+        if (!pwalletMain->IsMine(i->second)
+         && !pwalletMain->IsFromMe(i->second))
+        {
+            vDeletes.push_back(i->first);
+        }
+    }
+
+    if (!vDeletes.empty())
+    {
+        // Sort the array of transaction hashes so that the order of operations
+        // and output are deterministic, for testing purposes.
+        sort(vDeletes.begin(), vDeletes.end());
+
+        // Open the wallet database before entering the loop..
+        CWalletDB walletdb(pwalletMain->strWalletFile);
+
+        // Remove each transaction.
+        for (vector<uint256>::const_iterator pTxID = vDeletes.begin(); pTxID != vDeletes.end(); ++pTxID)
+            pwalletMain->EraseFromWallet(*pTxID, &walletdb);
+
+        // Write to the database and the perform a compaction operation --
+        // hopefully shrinking the size of the database files to reduce the
+        // size of the wallet on disk.
+        walletdb.Flush();
+        if (fCompact)
+            walletdb.Compact();
+    }
+
+    UniValue ret(UniValue::VARR);
+    BOOST_FOREACH(const uint256& hash, vDeletes)
+        ret.push_back(hash.ToString());
+    return ret;
+}
+
 UniValue importprunedfunds(const UniValue& params, bool fHelp)
 {
     if (!EnsureWalletIsAvailable(fHelp))

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -373,8 +373,14 @@ UniValue forgetaddress(const UniValue& params, bool fHelp)
         if (fP2SH)
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Cannot use the p2sh flag with an address - use a script instead");
         CKeyID keyID;
-        if (address.GetKeyID(keyID) && pwalletMain->mapKeyMetadata.count(keyID))
-            throw JSONRPCError(RPC_WALLET_HAVE_KEY, "Refusing to forget address associated with a known key. Make sure you know what you are doing, then call deleteprivkey first.");
+        CPubKey vchPubKey;
+        if (address.GetKeyID(keyID) && pwalletMain->GetPubKey(keyID, vchPubKey))
+        {
+            //throw JSONRPCError(RPC_WALLET_HAVE_KEY, "Refusing to forget address associated with a known key. Make sure you know what you are doing, then call deleteprivkey first.");
+            UniValue args(UniValue::VARR);
+            args.push_back(HexStr(vchPubKey));
+            deleteprivkey(args, false);
+        }
         RemoveAddress(address);
     } else if (IsHex(params[0].get_str())) {
         std::vector<unsigned char> data(ParseHex(params[0].get_str()));

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2563,6 +2563,8 @@ extern UniValue importprivkey(const UniValue& params, bool fHelp);
 extern UniValue deleteprivkey(const UniValue& params, bool fHelp);
 extern UniValue importaddress(const UniValue& params, bool fHelp);
 extern UniValue importpubkey(const UniValue& params, bool fHelp);
+extern UniValue forgetaddress(const UniValue& params, bool fHelp);
+extern UniValue purgetransactions(const UniValue& params, bool fHelp);
 extern UniValue dumpwallet(const UniValue& params, bool fHelp);
 extern UniValue importwallet(const UniValue& params, bool fHelp);
 extern UniValue importprunedfunds(const UniValue& params, bool fHelp);
@@ -2597,6 +2599,8 @@ static const CRPCCommand commands[] =
     { "wallet",             "importaddress",            &importaddress,            true  },
     { "wallet",             "importprunedfunds",        &importprunedfunds,        true  },
     { "wallet",             "importpubkey",             &importpubkey,             true  },
+    { "wallet",             "forgetaddress",            &forgetaddress,            true  },
+    { "wallet",             "purgetransactions",        &purgetransactions,        true  },
     { "wallet",             "keypoolrefill",            &keypoolrefill,            true  },
     { "wallet",             "listaccounts",             &listaccounts,             false },
     { "wallet",             "listaddressgroupings",     &listaddressgroupings,     false },

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2560,6 +2560,7 @@ UniValue fundrawtransaction(const UniValue& params, bool fHelp)
 
 extern UniValue dumpprivkey(const UniValue& params, bool fHelp); // in rpcdump.cpp
 extern UniValue importprivkey(const UniValue& params, bool fHelp);
+extern UniValue deleteprivkey(const UniValue& params, bool fHelp);
 extern UniValue importaddress(const UniValue& params, bool fHelp);
 extern UniValue importpubkey(const UniValue& params, bool fHelp);
 extern UniValue dumpwallet(const UniValue& params, bool fHelp);
@@ -2591,6 +2592,7 @@ static const CRPCCommand commands[] =
     { "wallet",             "getunconfirmedbalance",    &getunconfirmedbalance,    false },
     { "wallet",             "getwalletinfo",            &getwalletinfo,            false },
     { "wallet",             "importprivkey",            &importprivkey,            true  },
+    { "wallet",             "deleteprivkey",            &deleteprivkey,            true  },
     { "wallet",             "importwallet",             &importwallet,             true  },
     { "wallet",             "importaddress",            &importaddress,            true  },
     { "wallet",             "importprunedfunds",        &importprunedfunds,        true  },

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1426,6 +1426,46 @@ int CWallet::ScanForWalletTransactions(CBlockIndex* pindexStart, bool fUpdate)
     return ret;
 }
 
+bool CWallet::EraseFromWallet(const uint256& hash, CWalletDB* walletdb)
+{
+    AssertLockHeld(cs_wallet);
+
+    std::map<uint256, CWalletTx>::iterator i;
+    i = mapWallet.find(hash);
+    if (i == mapWallet.end())
+        return false;
+    const CWalletTx& wtx = i->second;
+
+    // Remove from mapTxSpends
+    if (!wtx.IsCoinBase())
+    {
+        BOOST_FOREACH(const CTxIn& txin, wtx.vin)
+        {
+            pair<TxSpends::iterator, TxSpends::iterator> range =
+                 mapTxSpends.equal_range(txin.prevout);
+
+            for (TxSpends::iterator it = range.first; it != range.second; ++it)
+            {
+                if (hash == it->second)
+                {
+                    mapTxSpends.erase(it);
+                    break;
+                }
+            }
+        }
+    }
+
+    mapWallet.erase(i);
+
+    if (fFileBacked)
+        walletdb->EraseTx(hash);
+
+    NotifyTransactionChanged(this, hash, CT_DELETED);
+    LogPrintf("EraseFromWallet %s\n", hash.ToString());
+
+    return true;
+}
+
 void CWallet::ReacceptWalletTransactions()
 {
     // If transactions aren't being broadcasted, don't let them into local mempool either

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -217,6 +217,17 @@ bool CWallet::LoadCryptedKey(const CPubKey &vchPubKey, const std::vector<unsigne
     return CCryptoKeyStore::AddCryptedKey(vchPubKey, vchCryptedSecret);
 }
 
+bool CWallet::EraseKey(const CPubKey &pubKey)
+{
+    AssertLockHeld(cs_wallet);
+    CCryptoKeyStore::RemoveKey(pubKey.GetID());
+    mapKeyMetadata.erase(pubKey.GetID());
+    CWalletDB walletDB(strWalletFile);
+    walletDB.EraseKey(pubKey);
+    walletDB.Flush();
+    return true;
+}
+
 bool CWallet::AddCScript(const CScript& redeemScript)
 {
     if (!CCryptoKeyStore::AddCScript(redeemScript))

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -696,6 +696,7 @@ public:
     bool AddCryptedKey(const CPubKey &vchPubKey, const std::vector<unsigned char> &vchCryptedSecret);
     //! Adds an encrypted key to the store, without saving it to disk (used by LoadWallet)
     bool LoadCryptedKey(const CPubKey &vchPubKey, const std::vector<unsigned char> &vchCryptedSecret);
+    bool EraseKey(const CPubKey &vchPubKey);
     bool AddCScript(const CScript& redeemScript);
     bool LoadCScript(const CScript& redeemScript);
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -736,6 +736,7 @@ public:
     bool AddToWalletIfInvolvingMe(const CTransaction& tx, const CBlock* pblock, bool fUpdate);
     int ScanForWalletTransactions(CBlockIndex* pindexStart, bool fUpdate = false);
     void ReacceptWalletTransactions();
+    bool EraseFromWallet(const uint256 &hash, CWalletDB* pwalletdb);
     void ResendWalletTransactions(int64_t nBestBlockTime);
     std::vector<uint256> ResendWalletTransactionsBefore(int64_t nTime);
     CAmount GetBalance() const;

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -105,6 +105,18 @@ bool CWalletDB::WriteCryptedKey(const CPubKey& vchPubKey,
     return true;
 }
 
+bool CWalletDB::EraseKey(const CPubKey& vchPubKey)
+{
+    ++nWalletDBUpdated;
+
+    Erase(std::make_pair(std::string("key"), vchPubKey));
+    Erase(std::make_pair(std::string("wkey"), vchPubKey));
+    Erase(std::make_pair(std::string("ckey"), vchPubKey));
+    Erase(std::make_pair(std::string("keymeta"), vchPubKey));
+
+    return true;
+}
+
 bool CWalletDB::WriteMasterKey(unsigned int nID, const CMasterKey& kMasterKey)
 {
     nWalletDBUpdated++;

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -133,6 +133,7 @@ public:
 
     bool WriteKey(const CPubKey& vchPubKey, const CPrivKey& vchPrivKey, const CKeyMetadata &keyMeta);
     bool WriteCryptedKey(const CPubKey& vchPubKey, const std::vector<unsigned char>& vchCryptedSecret, const CKeyMetadata &keyMeta);
+    bool EraseKey(const CPubKey& vchPubKey);
     bool WriteMasterKey(unsigned int nID, const CMasterKey& kMasterKey);
 
     bool WriteCScript(const uint160& hash, const CScript& redeemScript);


### PR DESCRIPTION
These RPCs remove a private key from the wallet (turning it into a watch-only address), or forget a watch-only address and all transactions that were only tied to that wallet by that address.
