### PR TITLE
Untested: libconsensus: Expose VerifyHeader

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -94,6 +94,7 @@ BITCOIN_CORE_H = \
   compat/sanity.h \
   compressor.h \
   consensus/consensus.h \
+  consensus/cppwrappers.h \
   consensus/header_verify.h \
   core_io.h \
   core_memusage.h \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -93,9 +93,7 @@ BITCOIN_CORE_H = \
   compat/endian.h \
   compat/sanity.h \
   compressor.h \
-  consensus/consensus.h \
   consensus/cppwrappers.h \
-  consensus/header_verify.h \
   core_io.h \
   core_memusage.h \
   httprpc.h \
@@ -118,7 +116,6 @@ BITCOIN_CORE_H = \
   policy/fees.h \
   policy/policy.h \
   policy/rbf.h \
-  pow.h \
   protocol.h \
   random.h \
   reverselock.h \
@@ -178,7 +175,6 @@ libbitcoin_server_a_SOURCES = \
   blockencodings.cpp \
   chain.cpp \
   checkpoints.cpp \
-  consensus/header_verify.cpp \
   httprpc.cpp \
   httpserver.cpp \
   init.cpp \
@@ -190,7 +186,6 @@ libbitcoin_server_a_SOURCES = \
   noui.cpp \
   policy/fees.cpp \
   policy/policy.cpp \
-  pow.cpp \
   rest.cpp \
   rpc/blockchain.cpp \
   rpc/mining.cpp \
@@ -261,6 +256,9 @@ libbitcoin_consensus_a_SOURCES = \
   amount.h \
   arith_uint256.cpp \
   arith_uint256.h \
+  consensus/consensus.h \
+  consensus/header_verify.cpp \
+  consensus/header_verify.h \
   consensus/interfaces.h \
   consensus/merkle.cpp \
   consensus/merkle.h \
@@ -268,6 +266,8 @@ libbitcoin_consensus_a_SOURCES = \
   consensus/validation.h \
   hash.cpp \
   hash.h \
+  pow.cpp \
+  pow.h \
   prevector.h \
   primitives/block.cpp \
   primitives/block.h \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -94,6 +94,7 @@ BITCOIN_CORE_H = \
   compat/sanity.h \
   compressor.h \
   consensus/consensus.h \
+  consensus/header_verify.h \
   core_io.h \
   core_memusage.h \
   httprpc.h \
@@ -176,6 +177,7 @@ libbitcoin_server_a_SOURCES = \
   blockencodings.cpp \
   chain.cpp \
   checkpoints.cpp \
+  consensus/header_verify.cpp \
   httprpc.cpp \
   httpserver.cpp \
   init.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -260,6 +260,7 @@ libbitcoin_consensus_a_SOURCES = \
   amount.h \
   arith_uint256.cpp \
   arith_uint256.h \
+  consensus/interfaces.h \
   consensus/merkle.cpp \
   consensus/merkle.h \
   consensus/params.h \

--- a/src/chain.h
+++ b/src/chain.h
@@ -14,6 +14,8 @@
 
 #include <vector>
 
+class BlockIndexInterface;
+
 class CBlockFileInfo
 {
 public:
@@ -339,6 +341,11 @@ public:
 arith_uint256 GetBlockProof(const CBlockIndex& block);
 /** Return the time it would take to redo the work difference between from and to, assuming the current hashrate corresponds to the difficulty at tip, in seconds. */
 int64_t GetBlockProofEquivalentTime(const CBlockIndex& to, const CBlockIndex& from, const CBlockIndex& tip, const Consensus::Params&);
+
+/**
+ * Bitcoin Core implementation of BlockIndexInterface.
+ */
+BlockIndexInterface CreateCoreIndexInterface();
 
 /** Used to marshal pointers into hashes for db storage. */
 class CDiskBlockIndex : public CBlockIndex

--- a/src/consensus/cppwrappers.h
+++ b/src/consensus/cppwrappers.h
@@ -1,0 +1,33 @@
+// Copyright (c) 2009-2016 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_CONSENSUS_CPPWRAPPERS_H
+#define BITCOIN_CONSENSUS_CPPWRAPPERS_H
+
+#include "header_verify.h"
+#include "pow.h"
+
+#include <stdint.h>
+
+class CBlockHeader;
+class CBlockIndex;
+class CValidationState;
+namespace Consensus { struct Params; };
+
+inline unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params& consensusParams)
+{
+    return PowGetNextWorkRequired(pindexLast, pblock, consensusParams);
+}
+
+inline unsigned int CalculateNextWorkRequired(const CBlockIndex* pindexLast, int64_t nFirstBlockTime, const Consensus::Params& consensusParams)
+{
+    return PowCalculateNextWorkRequired(pindexLast, nFirstBlockTime, consensusParams);
+}
+
+inline bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationState& state, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev, int64_t nAdjustedTime)
+{
+    return ContextualCheckHeader(block, state, consensusParams, pindexPrev, nAdjustedTime);
+}
+
+#endif // BITCOIN_CONSENSUS_CPPWRAPPERS_H

--- a/src/consensus/cppwrappers.h
+++ b/src/consensus/cppwrappers.h
@@ -6,6 +6,7 @@
 #define BITCOIN_CONSENSUS_CPPWRAPPERS_H
 
 #include "header_verify.h"
+#include "interfaces.h"
 #include "pow.h"
 
 #include <stdint.h>
@@ -17,17 +18,17 @@ namespace Consensus { struct Params; };
 
 inline unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params& consensusParams)
 {
-    return PowGetNextWorkRequired(pindexLast, pblock, consensusParams);
+    return PowGetNextWorkRequired(pindexLast, CreateCoreIndexInterface(), pblock, consensusParams);
 }
 
 inline unsigned int CalculateNextWorkRequired(const CBlockIndex* pindexLast, int64_t nFirstBlockTime, const Consensus::Params& consensusParams)
 {
-    return PowCalculateNextWorkRequired(pindexLast, nFirstBlockTime, consensusParams);
+    return PowCalculateNextWorkRequired(pindexLast, CreateCoreIndexInterface(), nFirstBlockTime, consensusParams);
 }
 
 inline bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationState& state, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev, int64_t nAdjustedTime)
 {
-    return ContextualCheckHeader(block, state, consensusParams, pindexPrev, nAdjustedTime);
+    return ContextualCheckHeader(block, state, consensusParams, pindexPrev, CreateCoreIndexInterface(), nAdjustedTime);
 }
 
 #endif // BITCOIN_CONSENSUS_CPPWRAPPERS_H

--- a/src/consensus/header_verify.cpp
+++ b/src/consensus/header_verify.cpp
@@ -1,0 +1,48 @@
+// Copyright (c) 2016 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "consensus.h"
+
+#include "pow.h"
+#include "primitives/block.h"
+#include "tinyformat.h"
+#include "validation.h"
+
+// TODO remove the following dependencies
+#include "chain.h"
+
+bool CheckBlockHeader(const CBlockHeader& block, CValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOW)
+{
+    // Check proof of work matches claimed amount
+    if (fCheckPOW && !CheckProofOfWork(block.GetHash(), block.nBits, consensusParams))
+        return state.DoS(50, false, REJECT_INVALID, "high-hash", false, "proof of work failed");
+
+    return true;
+}
+
+bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationState& state, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev, int64_t nAdjustedTime)
+{
+    const int nHeight = pindexPrev == NULL ? 0 : pindexPrev->nHeight + 1;
+    // Check proof of work
+    if (block.nBits != GetNextWorkRequired(pindexPrev, &block, consensusParams))
+        return state.DoS(100, false, REJECT_INVALID, "bad-diffbits", false, "incorrect proof of work");
+
+    // Check timestamp against prev
+    if (block.GetBlockTime() <= pindexPrev->GetMedianTimePast())
+        return state.Invalid(false, REJECT_INVALID, "time-too-old", "block's timestamp is too early");
+
+    // Check timestamp
+    if (block.GetBlockTime() > nAdjustedTime + 2 * 60 * 60)
+        return state.Invalid(false, REJECT_INVALID, "time-too-new", "block timestamp too far in the future");
+
+    // Reject outdated version blocks when 95% (75% on testnet) of the network has upgraded:
+    // check for version 2, 3 and 4 upgrades
+    if((block.nVersion < 2 && nHeight >= consensusParams.BIP34Height) ||
+       (block.nVersion < 3 && nHeight >= consensusParams.BIP66Height) ||
+       (block.nVersion < 4 && nHeight >= consensusParams.BIP65Height))
+            return state.Invalid(false, REJECT_OBSOLETE, strprintf("bad-version(0x%08x)", block.nVersion),
+                                 strprintf("rejected nVersion=0x%08x block", block.nVersion));
+
+    return true;
+}

--- a/src/consensus/header_verify.cpp
+++ b/src/consensus/header_verify.cpp
@@ -21,11 +21,11 @@ bool CheckBlockHeader(const CBlockHeader& block, CValidationState& state, const 
     return true;
 }
 
-bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationState& state, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev, int64_t nAdjustedTime)
+bool ContextualCheckHeader(const CBlockHeader& block, CValidationState& state, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev, int64_t nAdjustedTime)
 {
     const int nHeight = pindexPrev == NULL ? 0 : pindexPrev->nHeight + 1;
     // Check proof of work
-    if (block.nBits != GetNextWorkRequired(pindexPrev, &block, consensusParams))
+    if (block.nBits != PowGetNextWorkRequired(pindexPrev, &block, consensusParams))
         return state.DoS(100, false, REJECT_INVALID, "bad-diffbits", false, "incorrect proof of work");
 
     // Check timestamp against prev

--- a/src/consensus/header_verify.cpp
+++ b/src/consensus/header_verify.cpp
@@ -44,3 +44,14 @@ bool ContextualCheckHeader(const CBlockHeader& block, CValidationState& state, c
 
     return true;
 }
+
+bool VerifyHeader(const CBlockHeader& block, CValidationState& state, const Consensus::Params& consensusParams, const void* indexObject, const BlockIndexInterface& iBlockIndex, int64_t nAdjustedTime)
+{
+    if (!CheckBlockHeader(block, state, consensusParams, true))
+        return false;
+
+    if (!ContextualCheckHeader(block, state, consensusParams, indexObject, iBlockIndex, nAdjustedTime))
+        return false;
+
+    return true;
+}

--- a/src/consensus/header_verify.h
+++ b/src/consensus/header_verify.h
@@ -1,0 +1,23 @@
+// Copyright (c) 2016-2016 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_CONSENSUS_HEADER_VERIFY_H
+#define BITCOIN_CONSENSUS_HEADER_VERIFY_H
+
+#include <stdint.h>
+
+class CBlockHeader;
+class CBlockIndex;
+class CValidationState;
+namespace Consensus { struct Params; };
+
+/** Context-independent validity checks */
+bool CheckBlockHeader(const CBlockHeader& block, CValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOW = true);
+
+/** Context-dependent validity checks.
+ *  By "context", we mean only the previous block headers, but not the UTXO
+ *  set; UTXO-related validity checks are done in ConnectBlock(). */
+bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationState& state, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev, int64_t nAdjustedTime);
+
+#endif // BITCOIN_CONSENSUS_HEADER_VERIFY_H

--- a/src/consensus/header_verify.h
+++ b/src/consensus/header_verify.h
@@ -18,6 +18,6 @@ bool CheckBlockHeader(const CBlockHeader& block, CValidationState& state, const 
 /** Context-dependent validity checks.
  *  By "context", we mean only the previous block headers, but not the UTXO
  *  set; UTXO-related validity checks are done in ConnectBlock(). */
-bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationState& state, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev, int64_t nAdjustedTime);
+bool ContextualCheckHeader(const CBlockHeader& block, CValidationState& state, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev, int64_t nAdjustedTime);
 
 #endif // BITCOIN_CONSENSUS_HEADER_VERIFY_H

--- a/src/consensus/header_verify.h
+++ b/src/consensus/header_verify.h
@@ -21,4 +21,6 @@ bool CheckBlockHeader(const CBlockHeader& block, CValidationState& state, const 
  *  set; UTXO-related validity checks are done in ConnectBlock(). */
 bool ContextualCheckHeader(const CBlockHeader& block, CValidationState& state, const Consensus::Params& consensusParams, const void* indexObject, const BlockIndexInterface& iBlockIndex, int64_t nAdjustedTime);
 
+bool VerifyHeader(const CBlockHeader& block, CValidationState& state, const Consensus::Params& consensusParams, const void* indexObject, const BlockIndexInterface& iBlockIndex, int64_t nAdjustedTime);
+
 #endif // BITCOIN_CONSENSUS_HEADER_VERIFY_H

--- a/src/consensus/header_verify.h
+++ b/src/consensus/header_verify.h
@@ -11,6 +11,7 @@ class CBlockHeader;
 class CBlockIndex;
 class CValidationState;
 namespace Consensus { struct Params; };
+struct BlockIndexInterface;
 
 /** Context-independent validity checks */
 bool CheckBlockHeader(const CBlockHeader& block, CValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOW = true);
@@ -18,6 +19,6 @@ bool CheckBlockHeader(const CBlockHeader& block, CValidationState& state, const 
 /** Context-dependent validity checks.
  *  By "context", we mean only the previous block headers, but not the UTXO
  *  set; UTXO-related validity checks are done in ConnectBlock(). */
-bool ContextualCheckHeader(const CBlockHeader& block, CValidationState& state, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev, int64_t nAdjustedTime);
+bool ContextualCheckHeader(const CBlockHeader& block, CValidationState& state, const Consensus::Params& consensusParams, const void* indexObject, const BlockIndexInterface& iBlockIndex, int64_t nAdjustedTime);
 
 #endif // BITCOIN_CONSENSUS_HEADER_VERIFY_H

--- a/src/consensus/interfaces.h
+++ b/src/consensus/interfaces.h
@@ -1,0 +1,67 @@
+// Copyright (c) 2016-2016 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_CONSENSUS_INTERFACES_H
+#define BITCOIN_CONSENSUS_INTERFACES_H
+
+#include <stdint.h>
+
+typedef const unsigned char* (*GetHashFn)(const void* indexObject);
+typedef const void* (*GetAncestorFn)(const void* indexObject, int64_t height);
+typedef int64_t (*GetHeightFn)(const void* indexObject);
+typedef int32_t (*GetVersionFn)(const void* indexObject);
+typedef uint32_t (*GetTimeFn)(const void* indexObject);
+typedef uint32_t (*GetBitsFn)(const void* indexObject);
+
+// Potential optimizations:
+
+/**
+ * Some implementations may chose to store a pointer to the previous
+ * block instead of calling AncestorFn, trading memory for
+ * validation speed.
+ */
+typedef const void* (*GetPrevFn)(const void* indexObject);
+/**
+ * Some implementations may chose to cache the Median Time Past.
+ */
+typedef int64_t (*GetMedianTimeFn)(const void* indexObject);
+/**
+ * While not using this, it is assumed that the caller - who is
+ * responsible for all the new allocations - will free all the memory
+ * (or not) of the things that have been newly created in memory (or
+ * not) after the call to the exposed libbitcoinconsenus function.
+ * This function is mostly here to document the fact that some storage
+ * optimizations are only possible if there's a fast signaling from
+ * libbitcoinconsenus when data resources that have been asked for as
+ * part of the validation are no longer needed. 
+ */
+typedef void (*IndexDeallocatorFn)(void* indexObject);
+
+
+/**
+ * Collection of function pointers to interface with block index storage.
+ */
+struct BlockIndexInterface
+{
+    GetHashFn GetHash;
+    GetAncestorFn GetAncestor;
+    GetHeightFn GetHeight;
+    GetVersionFn GetVersion;
+    GetTimeFn GetTime;
+    GetBitsFn GetBits;
+    /**
+     * Just for optimization: If this is set to NULL, Ancestor() and
+     * Height() will be called instead.
+     */
+    GetPrevFn GetPrev;
+    /**
+     * Just for optimization: If this is set to NULL, Prev() and
+     * Time() will be called instead.
+     */
+    GetMedianTimeFn GetMedianTime;
+    //! TODO This is mostly here for discussion, but not used yet.
+    IndexDeallocatorFn DeleteIndex;
+};
+
+#endif // BITCOIN_CONSENSUS_INTERFACES_H

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -10,6 +10,7 @@
 #include "chainparams.h"
 #include "coins.h"
 #include "consensus/consensus.h"
+#include "consensus/cppwrappers.h"
 #include "consensus/merkle.h"
 #include "consensus/validation.h"
 #include "hash.h"

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -10,7 +10,7 @@
 #include "primitives/block.h"
 #include "uint256.h"
 
-unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params& params)
+unsigned int PowGetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params& params)
 {
     unsigned int nProofOfWorkLimit = UintToArith256(params.powLimit).GetCompact();
 
@@ -46,10 +46,10 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHead
     const CBlockIndex* pindexFirst = pindexLast->GetAncestor(nHeightFirst);
     assert(pindexFirst);
 
-    return CalculateNextWorkRequired(pindexLast, pindexFirst->GetBlockTime(), params);
+    return PowCalculateNextWorkRequired(pindexLast, pindexFirst->GetBlockTime(), params);
 }
 
-unsigned int CalculateNextWorkRequired(const CBlockIndex* pindexLast, int64_t nFirstBlockTime, const Consensus::Params& params)
+unsigned int PowCalculateNextWorkRequired(const CBlockIndex* pindexLast, int64_t nFirstBlockTime, const Consensus::Params& params)
 {
     if (params.fPowNoRetargeting)
         return pindexLast->nBits;

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -10,52 +10,53 @@
 #include "primitives/block.h"
 #include "uint256.h"
 
-unsigned int PowGetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params& params)
+unsigned int PowGetNextWorkRequired(const void* indexObject, const BlockIndexInterface& iBlockIndex, const CBlockHeader *pblock, const Consensus::Params& params)
 {
     unsigned int nProofOfWorkLimit = UintToArith256(params.powLimit).GetCompact();
 
     // Genesis block
-    if (pindexLast == NULL)
+    if (indexObject == NULL)
         return nProofOfWorkLimit;
 
     // Only change once per difficulty adjustment interval
-    if ((pindexLast->nHeight+1) % params.DifficultyAdjustmentInterval() != 0)
+    if ((iBlockIndex.GetHeight(indexObject)+1) % params.DifficultyAdjustmentInterval() != 0)
     {
         if (params.fPowAllowMinDifficultyBlocks)
         {
             // Special difficulty rule for testnet:
             // If the new block's timestamp is more than 2* 10 minutes
             // then allow mining of a min-difficulty block.
-            if (pblock->GetBlockTime() > pindexLast->GetBlockTime() + params.nPowTargetSpacing*2)
+            if (pblock->GetBlockTime() > iBlockIndex.GetTime(indexObject) + params.nPowTargetSpacing*2)
                 return nProofOfWorkLimit;
             else
             {
                 // Return the last non-special-min-difficulty-rules-block
-                const CBlockIndex* pindex = pindexLast;
-                while (pindex->pprev && pindex->nHeight % params.DifficultyAdjustmentInterval() != 0 && pindex->nBits == nProofOfWorkLimit)
-                    pindex = pindex->pprev;
-                return pindex->nBits;
+                const void* pindex = indexObject;
+                while (iBlockIndex.GetPrev(pindex) &&
+                       iBlockIndex.GetHeight(pindex) % params.DifficultyAdjustmentInterval() != 0 && iBlockIndex.GetBits(pindex) == nProofOfWorkLimit)
+                    pindex = iBlockIndex.GetPrev(pindex);
+                return iBlockIndex.GetBits(pindex);
             }
         }
-        return pindexLast->nBits;
+        return iBlockIndex.GetBits(indexObject);
     }
 
     // Go back by what we want to be 14 days worth of blocks
-    int nHeightFirst = pindexLast->nHeight - (params.DifficultyAdjustmentInterval()-1);
+    int nHeightFirst = iBlockIndex.GetHeight(indexObject) - (params.DifficultyAdjustmentInterval()-1);
     assert(nHeightFirst >= 0);
-    const CBlockIndex* pindexFirst = pindexLast->GetAncestor(nHeightFirst);
+    const void* pindexFirst = iBlockIndex.GetAncestor(indexObject, nHeightFirst);
     assert(pindexFirst);
 
-    return PowCalculateNextWorkRequired(pindexLast, pindexFirst->GetBlockTime(), params);
+    return PowCalculateNextWorkRequired(indexObject, iBlockIndex, iBlockIndex.GetTime(pindexFirst), params);
 }
 
-unsigned int PowCalculateNextWorkRequired(const CBlockIndex* pindexLast, int64_t nFirstBlockTime, const Consensus::Params& params)
+unsigned int PowCalculateNextWorkRequired(const void* indexObject, const BlockIndexInterface& iBlockIndex, int64_t nFirstBlockTime, const Consensus::Params& params)
 {
     if (params.fPowNoRetargeting)
-        return pindexLast->nBits;
+        return iBlockIndex.GetBits(indexObject);
 
     // Limit adjustment step
-    int64_t nActualTimespan = pindexLast->GetBlockTime() - nFirstBlockTime;
+    int64_t nActualTimespan = iBlockIndex.GetTime(indexObject) - nFirstBlockTime;
     if (nActualTimespan < params.nPowTargetTimespan/4)
         nActualTimespan = params.nPowTargetTimespan/4;
     if (nActualTimespan > params.nPowTargetTimespan*4)
@@ -64,7 +65,7 @@ unsigned int PowCalculateNextWorkRequired(const CBlockIndex* pindexLast, int64_t
     // Retarget
     const arith_uint256 bnPowLimit = UintToArith256(params.powLimit);
     arith_uint256 bnNew;
-    bnNew.SetCompact(pindexLast->nBits);
+    bnNew.SetCompact(iBlockIndex.GetBits(indexObject));
     bnNew *= nActualTimespan;
     bnNew /= params.nPowTargetTimespan;
 

--- a/src/pow.h
+++ b/src/pow.h
@@ -6,6 +6,7 @@
 #ifndef BITCOIN_POW_H
 #define BITCOIN_POW_H
 
+#include "consensus/interfaces.h"
 #include "consensus/params.h"
 
 #include <stdint.h>
@@ -14,8 +15,8 @@ class CBlockHeader;
 class CBlockIndex;
 class uint256;
 
-unsigned int PowGetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params&);
-unsigned int PowCalculateNextWorkRequired(const CBlockIndex* pindexLast, int64_t nFirstBlockTime, const Consensus::Params&);
+unsigned int PowGetNextWorkRequired(const void* indexObject, const BlockIndexInterface& iBlockIndex, const CBlockHeader *pblock, const Consensus::Params&);
+unsigned int PowCalculateNextWorkRequired(const void* indexObject, const BlockIndexInterface& iBlockIndex, int64_t nFirstBlockTime, const Consensus::Params&);
 
 /** Check whether a block hash satisfies the proof-of-work requirement specified by nBits */
 bool CheckProofOfWork(uint256 hash, unsigned int nBits, const Consensus::Params&);

--- a/src/pow.h
+++ b/src/pow.h
@@ -14,8 +14,8 @@ class CBlockHeader;
 class CBlockIndex;
 class uint256;
 
-unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params&);
-unsigned int CalculateNextWorkRequired(const CBlockIndex* pindexLast, int64_t nFirstBlockTime, const Consensus::Params&);
+unsigned int PowGetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params&);
+unsigned int PowCalculateNextWorkRequired(const CBlockIndex* pindexLast, int64_t nFirstBlockTime, const Consensus::Params&);
 
 /** Check whether a block hash satisfies the proof-of-work requirement specified by nBits */
 bool CheckProofOfWork(uint256 hash, unsigned int nBits, const Consensus::Params&);

--- a/src/script/bitcoinconsensus.cpp
+++ b/src/script/bitcoinconsensus.cpp
@@ -161,6 +161,28 @@ void bitcoinconsensus_destroy_consensus_parameters(void* consensusParams)
     delete ((Consensus::Params*)consensusParams);
 }
 
+void* bitcoinconsensus_create_blockindex_interface(GetAncestorFn _GetAncestorFn, GetHashFn _GetHashFn, GetHeightFn _GetHeightFn, GetVersionFn _GetVersionFn, GetTimeFn _GetTimeFn, GetBitsFn _GetBitsFn, GetPrevFn _GetPrevFn, GetMedianTimeFn _GetMedianTimeFn, IndexDeallocatorFn _IndexDeallocatorFn)
+{
+    BlockIndexInterface* iBlockIndex = new BlockIndexInterface();
+
+    iBlockIndex->GetAncestor = _GetAncestorFn;
+    iBlockIndex->GetHash = _GetHashFn;
+    iBlockIndex->GetHeight = _GetHeightFn;
+    iBlockIndex->GetVersion = _GetVersionFn;
+    iBlockIndex->GetTime = _GetTimeFn;
+    iBlockIndex->GetBits = _GetBitsFn;
+    iBlockIndex->GetPrev = _GetPrevFn;
+    iBlockIndex->GetMedianTime = _GetMedianTimeFn;
+    iBlockIndex->DeleteIndex = _IndexDeallocatorFn;
+
+    return iBlockIndex;
+}
+
+void bitcoinconsensus_destroy_blockindex_interface(void* iBlockIndex)
+{
+    delete ((BlockIndexInterface*)iBlockIndex);
+}
+
 int bitcoinconsensus_verify_header(const unsigned char* header, unsigned int headerLen, const void* consensusParams, const void* indexObject, const void* iBlockIndex, int64_t nAdjustedTime, bitcoinconsensus_error* err)
 {
     try {

--- a/src/script/bitcoinconsensus.cpp
+++ b/src/script/bitcoinconsensus.cpp
@@ -127,6 +127,40 @@ int bitcoinconsensus_verify_script(const unsigned char *scriptPubKey, unsigned i
     return ::verify_script(scriptPubKey, scriptPubKeyLen, am, txTo, txToLen, nIn, flags, err);
 }
 
+void* bitcoinconsensus_create_consensus_parameters(unsigned char* pHashGenesisBlock, int nSubsidyHalvingInterval, int BIP34Height, unsigned char* pBIP34Hash, int BIP65Height, int BIP66Height, uint32_t nRuleChangeActivationThreshold, uint32_t nMinerConfirmationWindow, int bitDeploymentCsv, int64_t nStartTimeDeploymentCsv, int64_t nTimeoutDeploymentCsv, int bitDeploymentSegwit, int64_t nStartTimeDeploymentSegwit, int64_t nTimeoutDeploymentSegwit, unsigned char* pPowLimit, bool fPowAllowMinDifficultyBlocks, bool fPowNoRetargeting, int64_t nPowTargetSpacing, int64_t nPowTargetTimespan)
+{
+    Consensus::Params* consensusParams = new Consensus::Params();
+
+    consensusParams->vDeployments[Consensus::DEPLOYMENT_CSV].bit = bitDeploymentCsv;
+    consensusParams->vDeployments[Consensus::DEPLOYMENT_CSV].nStartTime = nStartTimeDeploymentCsv;
+    consensusParams->vDeployments[Consensus::DEPLOYMENT_CSV].nTimeout = nTimeoutDeploymentCsv;
+    consensusParams->vDeployments[Consensus::DEPLOYMENT_SEGWIT].bit = bitDeploymentSegwit;
+    consensusParams->vDeployments[Consensus::DEPLOYMENT_SEGWIT].nStartTime = nStartTimeDeploymentSegwit;
+    consensusParams->vDeployments[Consensus::DEPLOYMENT_SEGWIT].nTimeout = nTimeoutDeploymentSegwit;
+
+    consensusParams->nSubsidyHalvingInterval = nSubsidyHalvingInterval;
+    consensusParams->BIP34Height = BIP34Height;
+    consensusParams->BIP65Height = BIP65Height;
+    consensusParams->BIP66Height = BIP66Height;
+    consensusParams->nRuleChangeActivationThreshold = nRuleChangeActivationThreshold;
+    consensusParams->nMinerConfirmationWindow = nMinerConfirmationWindow;
+    consensusParams->fPowAllowMinDifficultyBlocks = fPowAllowMinDifficultyBlocks;
+    consensusParams->fPowNoRetargeting = fPowNoRetargeting;
+    consensusParams->nPowTargetSpacing = nPowTargetSpacing;
+    consensusParams->nPowTargetTimespan = nPowTargetTimespan;
+
+    consensusParams->hashGenesisBlock = uint256(pHashGenesisBlock);
+    consensusParams->BIP34Hash = uint256(pBIP34Hash);
+    consensusParams->powLimit = uint256(pPowLimit);
+
+    return consensusParams;
+}
+
+void bitcoinconsensus_destroy_consensus_parameters(void* consensusParams)
+{
+    delete ((Consensus::Params*)consensusParams);
+}
+
 int bitcoinconsensus_verify_header(const unsigned char* header, unsigned int headerLen, const void* consensusParams, const void* indexObject, const void* iBlockIndex, int64_t nAdjustedTime, bitcoinconsensus_error* err)
 {
     try {

--- a/src/script/bitcoinconsensus.h
+++ b/src/script/bitcoinconsensus.h
@@ -72,6 +72,11 @@ EXPORT_SYMBOL int bitcoinconsensus_verify_script_with_amount(const unsigned char
                                     const unsigned char *txTo        , unsigned int txToLen,
                                     unsigned int nIn, unsigned int flags, bitcoinconsensus_error* err);
 
+/// All hashes are 32 bytes
+EXPORT_SYMBOL void* bitcoinconsensus_create_consensus_parameters(unsigned char* pHashGenesisBlock, int nSubsidyHalvingInterval, int BIP34Height, unsigned char* pBIP34Hash, int BIP65Height, int BIP66Height, uint32_t nRuleChangeActivationThreshold, uint32_t nMinerConfirmationWindow, int bitDeploymentCsv, int64_t nStartTimeDeploymentCsv, int64_t nTimeoutDeploymentCsv, int bitDeploymentSegwit, int64_t nStartTimeDeploymentSegwit, int64_t nTimeoutDeploymentSegwit, unsigned char* pPowLimit, bool fPowAllowMinDifficultyBlocks, bool fPowNoRetargeting, int64_t nPowTargetSpacing, int64_t nPowTargetTimespan);
+
+EXPORT_SYMBOL void bitcoinconsensus_destroy_consensus_parameters(void* consensusParams);
+
 EXPORT_SYMBOL int bitcoinconsensus_verify_header(const unsigned char* header, unsigned int headerLen, const void* consensusParams, const void* indexObject, const void* iBlockIndex, int64_t nAdjustedTime, bitcoinconsensus_error* err);
 
 EXPORT_SYMBOL unsigned int bitcoinconsensus_version();

--- a/src/script/bitcoinconsensus.h
+++ b/src/script/bitcoinconsensus.h
@@ -72,6 +72,8 @@ EXPORT_SYMBOL int bitcoinconsensus_verify_script_with_amount(const unsigned char
                                     const unsigned char *txTo        , unsigned int txToLen,
                                     unsigned int nIn, unsigned int flags, bitcoinconsensus_error* err);
 
+EXPORT_SYMBOL int bitcoinconsensus_verify_header(const unsigned char* header, unsigned int headerLen, const void* consensusParams, const void* indexObject, const void* iBlockIndex, int64_t nAdjustedTime, bitcoinconsensus_error* err);
+
 EXPORT_SYMBOL unsigned int bitcoinconsensus_version();
 
 #ifdef __cplusplus

--- a/src/test/pow_tests.cpp
+++ b/src/test/pow_tests.cpp
@@ -4,6 +4,7 @@
 
 #include "chain.h"
 #include "chainparams.h"
+#include "consensus/cppwrappers.h"
 #include "pow.h"
 #include "random.h"
 #include "util.h"

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -42,6 +42,11 @@ public:
         memset(data, 0, sizeof(data));
     }
 
+    const unsigned char* GetDataArray()
+    {
+        return data;
+    }
+
     inline int Compare(const base_blob& other) const { return memcmp(data, other.data, sizeof(data)); }
 
     friend inline bool operator==(const base_blob& a, const base_blob& b) { return a.Compare(b) == 0; }
@@ -125,6 +130,10 @@ public:
     uint256() {}
     uint256(const base_blob<256>& b) : base_blob<256>(b) {}
     explicit uint256(const std::vector<unsigned char>& vch) : base_blob<256>(vch) {}
+    explicit uint256(const unsigned char* arrayData) : base_blob<256>()
+    {
+        std::memcpy(data, arrayData, WIDTH);
+    }
 
     /** A cheap hash function that just returns 64 bits from the result, it can be
      * used when the contents are considered uniformly random. It is not appropriate

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -10,6 +10,7 @@
 #include "checkpoints.h"
 #include "checkqueue.h"
 #include "consensus/consensus.h"
+#include "consensus/cppwrappers.h"
 #include "consensus/header_verify.h"
 #include "consensus/merkle.h"
 #include "consensus/validation.h"

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -10,6 +10,7 @@
 #include "checkpoints.h"
 #include "checkqueue.h"
 #include "consensus/consensus.h"
+#include "consensus/header_verify.h"
 #include "consensus/merkle.h"
 #include "consensus/validation.h"
 #include "hash.h"
@@ -2721,15 +2722,6 @@ bool FindUndoPos(CValidationState &state, int nFile, CDiskBlockPos &pos, unsigne
     return true;
 }
 
-bool CheckBlockHeader(const CBlockHeader& block, CValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOW)
-{
-    // Check proof of work matches claimed amount
-    if (fCheckPOW && !CheckProofOfWork(block.GetHash(), block.nBits, consensusParams))
-        return state.DoS(50, false, REJECT_INVALID, "high-hash", false, "proof of work failed");
-
-    return true;
-}
-
 bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOW, bool fCheckMerkleRoot)
 {
     // These are checks that are independent of context.
@@ -2865,32 +2857,6 @@ std::vector<unsigned char> GenerateCoinbaseCommitment(CBlock& block, const CBloc
     }
     UpdateUncommittedBlockStructures(block, pindexPrev, consensusParams);
     return commitment;
-}
-
-bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationState& state, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev, int64_t nAdjustedTime)
-{
-    const int nHeight = pindexPrev == NULL ? 0 : pindexPrev->nHeight + 1;
-    // Check proof of work
-    if (block.nBits != GetNextWorkRequired(pindexPrev, &block, consensusParams))
-        return state.DoS(100, false, REJECT_INVALID, "bad-diffbits", false, "incorrect proof of work");
-
-    // Check timestamp against prev
-    if (block.GetBlockTime() <= pindexPrev->GetMedianTimePast())
-        return state.Invalid(false, REJECT_INVALID, "time-too-old", "block's timestamp is too early");
-
-    // Check timestamp
-    if (block.GetBlockTime() > nAdjustedTime + 2 * 60 * 60)
-        return state.Invalid(false, REJECT_INVALID, "time-too-new", "block timestamp too far in the future");
-
-    // Reject outdated version blocks when 95% (75% on testnet) of the network has upgraded:
-    // check for version 2, 3 and 4 upgrades
-    if((block.nVersion < 2 && nHeight >= consensusParams.BIP34Height) ||
-       (block.nVersion < 3 && nHeight >= consensusParams.BIP66Height) ||
-       (block.nVersion < 4 && nHeight >= consensusParams.BIP65Height))
-            return state.Invalid(false, REJECT_OBSOLETE, strprintf("bad-version(0x%08x)", block.nVersion),
-                                 strprintf("rejected nVersion=0x%08x block", block.nVersion));
-
-    return true;
 }
 
 bool ContextualCheckBlock(const CBlock& block, CValidationState& state, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev)

--- a/src/validation.h
+++ b/src/validation.h
@@ -465,13 +465,11 @@ bool ReadBlockFromDisk(CBlock& block, const CBlockIndex* pindex, const Consensus
 /** Functions for validating blocks and updating the block tree */
 
 /** Context-independent validity checks */
-bool CheckBlockHeader(const CBlockHeader& block, CValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOW = true);
 bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOW = true, bool fCheckMerkleRoot = true);
 
 /** Context-dependent validity checks.
  *  By "context", we mean only the previous block headers, but not the UTXO
  *  set; UTXO-related validity checks are done in ConnectBlock(). */
-bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationState& state, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev, int64_t nAdjustedTime);
 bool ContextualCheckBlock(const CBlock& block, CValidationState& state, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev);
 
 /** Apply the effects of this block (with given index) on the UTXO set represented by coins.


### PR DESCRIPTION
VerifyHeader basically calls CheckBlockHeader and ContextualCheckBlockHeader for a given CBlockHeader (and all the required parameters).

Since ContextualCheckBlockHeader previously depends on CBlockIndex, some kind of C-compatible API for it must be exposed if we want a complete libconsensus to remain storage agnostic. 
Alternative implementations of BlockIndexInterface are more than welcomed.
If there's parts of this PR that you think would be acceptable separately, please, say so.
If you come up with alternative preparations for making this PR (or an alternative) smaller, that's welcomed too. And nits, if I haven't said so before, are always welcomed.

 We could also expose CheckBlockHeader independently. An SPV wallet using libconsensus for verifyscript already would bea easily able to also easily check CheckTransaction (which @NicolasDorier is working on) and CheckBlockHeader without any context. If we do so, we could easily move the time checks from ContextualCheckBlockHeader to CheckBlockHeader if we accept the current time of the node as a "non-contextual" parameter for CheckBlockHeader. Obviously time is context, but being pragmatic, these checks are to easy not to expose in CheckBlockHeader and everybody can be expected to have a clock they can trust (the error margins in your clock seem quite safe to me and, maybe more importante, VerifyHeader is going to use the caller's clock anyway).

Please feel free to ask for squashes as well.

Replaces #5995

Depdendencies:
- [ ] Consensus: MOVEONLY: Move functions for header verification #8337
- [x] finish implementing bitcoinconsensus_create_consensus_parameters (and remove whatever is not needed anymore from the base_blob<> preparations).

Death TODOs:

~~\- Hide uint256 and DifficultyAdjustmentInterval() in Consensus::Params~~: the create interface should be enough.
~~\- [ ] The interface for CBlockIndex (`const BlockIndexInterface* iBlockIndex`) could be hidden in libconsensus using the same create/destroy blockindexInterfaceTrick, even if some of the parameters are going to be function pointers. Or we could offer both and see what happens...discussion welcomed here, but allowing BlockIndexInterface\* to be passed as void\* it's in the todo list whether for necessary or just to see how it looks like. If we ever need a DifficultyAdjustmentInterval-like method internally, void\* will be transparent. It's simply the same argument and we should do the same.~~
~~\- [ ] new warnings~~