### PR TITLE
[init, wallet] ParameterInteraction() iff wallet enabled

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -966,7 +966,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     nBytesPerSigOp = GetArg("-bytespersigop", nBytesPerSigOp);
 
 #ifdef ENABLE_WALLET
-    if (!CWallet::ParameterInteraction())
+    if (!fDisableWallet && !CWallet::ParameterInteraction())
         return false;
 #endif // ENABLE_WALLET
 


### PR DESCRIPTION
This is only required when the wallet is enabled.
