### PR TITLE
Add mempool statistics collector

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -138,6 +138,8 @@ BITCOIN_CORE_H = \
   script/sign.h \
   script/standard.h \
   script/ismine.h \
+  stats/stats.h \
+  stats/stats_mempool.h \
   streams.h \
   support/allocators/secure.h \
   support/allocators/zeroafterfree.h \
@@ -215,6 +217,9 @@ libbitcoin_server_a_SOURCES = \
   rpc/server.cpp \
   script/sigcache.cpp \
   script/ismine.cpp \
+  stats/rpc_stats.cpp \
+  stats/stats.cpp \
+  stats/stats_mempool.cpp \
   timedata.cpp \
   torcontrol.cpp \
   txdb.cpp \

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -35,6 +35,7 @@
 #include "script/standard.h"
 #include "script/sigcache.h"
 #include "scheduler.h"
+#include "stats/stats.h"
 #include "timedata.h"
 #include "txdb.h"
 #include "txmempool.h"
@@ -506,6 +507,7 @@ std::string HelpMessage(HelpMessageMode mode)
         strUsage += HelpMessageOpt("-rpcservertimeout=<n>", strprintf("Timeout during HTTP requests (default: %d)", DEFAULT_HTTP_SERVER_TIMEOUT));
     }
 
+    strUsage += CStats::getHelpString(showDebug);
     return strUsage;
 }
 
@@ -1145,6 +1147,10 @@ bool AppInitParameterInteraction()
             }
         }
     }
+
+    if (!CStats::parameterInteraction())
+        return false;
+
     return true;
 }
 
@@ -1719,6 +1725,8 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
 #ifdef ENABLE_WALLET
     StartWallets(scheduler);
 #endif
+
+    CStats::DefaultStats()->startCollecting(scheduler);
 
     return !fRequestShutdown;
 }

--- a/src/memusage.h
+++ b/src/memusage.h
@@ -6,6 +6,7 @@
 #define BITCOIN_MEMUSAGE_H
 
 #include "indirectmap.h"
+#include "prevector.h"
 
 #include <stdlib.h>
 

--- a/src/rpc/register.h
+++ b/src/rpc/register.h
@@ -19,6 +19,8 @@ void RegisterMiscRPCCommands(CRPCTable &tableRPC);
 void RegisterMiningRPCCommands(CRPCTable &tableRPC);
 /** Register raw transaction RPC commands */
 void RegisterRawTransactionRPCCommands(CRPCTable &tableRPC);
+/** Register stats RPC commands */
+void RegisterStatsRPCCommands(CRPCTable &tableRPC);
 
 static inline void RegisterAllCoreRPCCommands(CRPCTable &t)
 {
@@ -27,6 +29,7 @@ static inline void RegisterAllCoreRPCCommands(CRPCTable &t)
     RegisterMiscRPCCommands(t);
     RegisterMiningRPCCommands(t);
     RegisterRawTransactionRPCCommands(t);
+    RegisterStatsRPCCommands(t);
 }
 
 #endif

--- a/src/stats/rpc_stats.cpp
+++ b/src/stats/rpc_stats.cpp
@@ -1,0 +1,82 @@
+// Copyright (c) 2016 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "rpc/server.h"
+#include "stats/stats.h"
+#include "util.h"
+#include "utilstrencodings.h"
+
+#include <stdint.h>
+
+#include <univalue.h>
+
+UniValue getmempoolstats(const JSONRPCRequest& request)
+{
+    if (request.fHelp || request.params.size() != 0)
+        throw std::runtime_error(
+            "getmempoolstats\n"
+            "\nReturns the collected mempool statistics.\n"
+            "\nThe samples are segregated in multiple precision groups.\n"
+            "\nSamples time interval is not guaranteed to be constant, hence there\n"
+            "is a time delta in each sample relative to the last sample.\n"
+            "\nResult:\n"
+            "  [\n"
+            "    {\n"
+            "      \"sample_interval\"    : \"interval\",      (numeric) Interval target in seconds\n"
+            "      \"time_from\"          : \"timestamp\",     (numeric) Timestamp, first sample\n"
+            "      \"samples\"            : [\n"
+            "                                 [<delta_in_secs>,<tx_count>,<dynamic_mem_usage>,<min_fee_per_k>],\n"
+            "                                 [<delta_in_secs>,<tx_count>,<dynamic_mem_usage>,<min_fee_per_k>],\n"
+            "                                 ...\n"
+            "                             ]\n"
+            "    }\n"
+            "    ,...\n"
+            "  ]\n"
+            "\nExamples:\n" +
+            HelpExampleCli("getmempoolstats", "") + HelpExampleRpc("getmempoolstats", ""));
+
+    // get stats from the core stats model
+    uint64_t timeFrom = 0;
+    std::vector<unsigned int> groups = CStats::DefaultStats()->mempoolCollector->getPrecisionGroupsAndIntervals();
+
+    UniValue groupsUni(UniValue::VARR);
+    for (unsigned int i = 0; i < groups.size(); i++) {
+
+        MempoolSamplesVector samples = CStats::DefaultStats()->mempoolCollector->getSamplesForPrecision(i, timeFrom);
+
+        // use "flat" json encoding for performance reasons
+        UniValue samplesObj(UniValue::VARR);
+        for (const struct CStatsMempoolSample& sample : samples) {
+            UniValue singleSample(UniValue::VARR);
+            singleSample.push_back(UniValue((uint64_t)sample.timeDelta));
+            singleSample.push_back(UniValue((uint64_t)sample.txCount));
+            singleSample.push_back(UniValue((uint64_t)sample.dynMemUsage));
+            singleSample.push_back(UniValue(sample.minFeePerK));
+            samplesObj.push_back(singleSample);
+        }
+
+        UniValue sampleGroup(UniValue::VOBJ);
+        sampleGroup.push_back(Pair("sample_interval", (int)groups[i]));
+        sampleGroup.push_back(Pair("time_from", timeFrom));
+        sampleGroup.push_back(Pair("samples", samplesObj));
+
+        groupsUni.push_back(sampleGroup);
+    }
+
+    return groupsUni;
+}
+
+static const CRPCCommand commands[] =
+{
+    //  category              name                      actor (function)         argNames
+    //  --------------------- ------------------------  -----------------------  ----------
+        {"stats",             "getmempoolstats",        &getmempoolstats,        {}},
+
+};
+
+void RegisterStatsRPCCommands(CRPCTable &t)
+{
+    for (unsigned int vcidx = 0; vcidx < ARRAYLEN(commands); vcidx++)
+        t.appendCommand(commands[vcidx].name, &commands[vcidx]);
+}

--- a/src/stats/stats.cpp
+++ b/src/stats/stats.cpp
@@ -1,0 +1,81 @@
+// Copyright (c) 2016 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "stats/stats.h"
+
+#include "memusage.h"
+#include "utiltime.h"
+
+#include "util.h"
+
+
+const size_t DEFAULT_MAX_STATS_MEMORY = 10 * 1024 * 1024; // 10 MB
+const bool DEFAULT_STATISTICS_ENABLED = false;
+const static unsigned int STATS_COLLECT_INTERVAL = 2000; // 2 secs
+
+CStats* CStats::sharedInstance = NULL;
+
+CStats* CStats::DefaultStats()
+{
+    if (!sharedInstance)
+        sharedInstance = new CStats();
+
+    return sharedInstance;
+}
+
+CStats::CStats() : statsEnabled(false), maxStatsMemory(0)
+{
+    /* initialize the mempool stats collector */
+    mempoolCollector = std::unique_ptr<CStatsMempool>(new CStatsMempool(STATS_COLLECT_INTERVAL));
+}
+
+CStats::~CStats()
+{
+
+}
+
+std::string CStats::getHelpString(bool showDebug)
+{
+    std::string strUsage = HelpMessageGroup(_("Statistic options:"));
+    strUsage += HelpMessageOpt("-statsenable=", strprintf("Enable statistics (default: %u)", DEFAULT_STATISTICS_ENABLED));
+    strUsage += HelpMessageOpt("-statsmaxmemorytarget=<n>", strprintf(_("Set the memory limit target for statistics in bytes (default: %u)"), DEFAULT_MAX_STATS_MEMORY));
+
+    return strUsage;
+}
+
+bool CStats::parameterInteraction()
+{
+    if (gArgs.GetBoolArg("-statsenable", DEFAULT_STATISTICS_ENABLED))
+        DefaultStats()->setMaxMemoryUsageTarget(gArgs.GetArg("-statsmaxmemorytarget", DEFAULT_MAX_STATS_MEMORY));
+
+    return true;
+}
+
+void CStats::startCollecting(CScheduler& scheduler)
+{
+    if (statsEnabled) {
+        // dispatch the scheduler task
+        scheduler.scheduleEvery(std::bind(&CStats::collectCallback, this), STATS_COLLECT_INTERVAL);
+    }
+}
+
+void CStats::collectCallback()
+{
+    if (!statsEnabled)
+        return;
+
+    if (mempoolCollector->addMempoolSamples(maxStatsMemory)) {
+        // fire the signal if the stats did change
+        MempoolStatsDidChange();
+    }
+}
+
+void CStats::setMaxMemoryUsageTarget(size_t maxMem)
+{
+    statsEnabled = (maxMem > 0);
+    maxStatsMemory = maxMem;
+
+    // for now: give 100% to mempool stats
+    mempoolCollector->setMaxMemoryUsageTarget(maxMem);
+}

--- a/src/stats/stats.h
+++ b/src/stats/stats.h
@@ -1,0 +1,61 @@
+// Copyright (c) 2016 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_STATS_H
+#define BITCOIN_STATS_H
+
+#include "amount.h"
+#include "scheduler.h"
+#include "stats/stats_mempool.h"
+
+#include <atomic>
+#include <stdlib.h>
+
+#include <boost/signals2/signal.hpp>
+
+// Class that manages various types of statistics and its memory consumption
+class CStats
+{
+private:
+    static CStats* sharedInstance; //!< singleton instance
+    std::atomic<bool> statsEnabled;
+
+    //maximum amount of memory to use for the stats
+    std::atomic<size_t> maxStatsMemory;
+
+    /* collect callback through the scheduler task */
+    void collectCallback();
+
+public:
+
+    static CStats* DefaultStats(); //shared instance
+
+    CStats();
+    ~CStats();
+
+    /* get the statistics module help strings */
+    static std::string getHelpString(bool showDebug);
+
+    /* access the parameters and map it to the internal model */
+    static bool parameterInteraction();
+
+    /* dispatch the stats collector repetitive scheduler task */
+    void startCollecting(CScheduler& scheduler);
+
+    /* set the target for the maximum memory consumption (in bytes) */
+    void setMaxMemoryUsageTarget(size_t maxMem);
+
+
+
+    /* COLLECTOR INSTANCES
+     * =================== */
+    std::unique_ptr<CStatsMempool> mempoolCollector;
+
+
+    /* SIGNALS
+     * ======= */
+    boost::signals2::signal<void(void)> MempoolStatsDidChange; //mempool signal
+};
+
+#endif // BITCOIN_STATS_H

--- a/src/stats/stats_mempool.cpp
+++ b/src/stats/stats_mempool.cpp
@@ -1,0 +1,130 @@
+// Copyright (c) 2016 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "stats/stats_mempool.h"
+
+#include "memusage.h"
+#include "utiltime.h"
+
+#include "util.h"
+
+
+const static unsigned int precisionIntervals[] = {
+    2, // == every 2 secs == 1800 samples per hour
+    60, // == every minute = 1440 samples per day
+    1800 // == every half-hour = ~2'160 per Month
+};
+
+const static unsigned int MIN_SAMPLES = 5;
+const static unsigned int MAX_SAMPLES = 5000;
+
+
+const static unsigned int fallbackMaxSamplesPerPrecision = 1000;
+
+std::atomic<size_t> CStatsMempool::cacheMempoolSize;
+std::atomic<size_t> CStatsMempool::cacheMempoolDynamicMemoryUsage;
+std::atomic<CAmount> CStatsMempool::cacheMempoolMinRelayFee;
+
+CStatsMempool::CStatsMempool(unsigned int collectIntervalIn) : collectInterval(collectIntervalIn)
+{
+    startTime = 0;
+    intervalCounter = 0;
+
+    // setup the samples per precision vector
+    for (unsigned int interval : precisionIntervals) {
+        (void)(interval);
+        vSamplesPerPrecision.emplace_back();
+
+        // use the fallback max in case max memory will not be set
+        vMaxSamplesPerPrecision.push_back(fallbackMaxSamplesPerPrecision);
+
+        // add starttime 0 to each level
+        vTimeLastSample.push_back(0);
+    }
+}
+
+std::vector<unsigned int> CStatsMempool::getPrecisionGroupsAndIntervals() {
+    return {std::begin(precisionIntervals), std::end(precisionIntervals)};
+}
+
+bool CStatsMempool::addMempoolSamples(const size_t maxStatsMemory)
+{
+    bool statsChanged = false;
+    uint64_t now = GetTime();
+    {
+        LOCK(cs_mempool_stats);
+
+        // set the mempool stats start time if this is the first sample
+        if (startTime == 0)
+            startTime = now;
+
+        unsigned int biggestInterval = 0;
+        for (unsigned int i = 0; i < sizeof(precisionIntervals) / sizeof(precisionIntervals[0]); i++) {
+            // check if it's time to collect a samples for the given precision level
+            uint16_t timeDelta = 0;
+            if (intervalCounter % (precisionIntervals[i] / (collectInterval / 1000)) == 0) {
+                if (vTimeLastSample[i] == 0) {
+                    // first sample, calc delta to starttime
+                    timeDelta = now - startTime;
+                } else {
+                    timeDelta = now - vTimeLastSample[i];
+                }
+                vSamplesPerPrecision[i].push_back({timeDelta, CStatsMempool::cacheMempoolSize, CStatsMempool::cacheMempoolDynamicMemoryUsage, CStatsMempool::cacheMempoolMinRelayFee});
+                statsChanged = true;
+
+                // check if we need to remove items at the beginning
+                if (vSamplesPerPrecision[i].size() > vMaxSamplesPerPrecision[i]) {
+                    // increase starttime by the removed deltas
+                    for (unsigned int j = (vSamplesPerPrecision[i].size() - vMaxSamplesPerPrecision[i]); j > 0; j--) {
+                        startTime += vSamplesPerPrecision[i][j].timeDelta;
+                    }
+                    // remove element(s) at vector front
+                    vSamplesPerPrecision[i].erase(vSamplesPerPrecision[i].begin(), vSamplesPerPrecision[i].begin() + (vSamplesPerPrecision[i].size() - vMaxSamplesPerPrecision[i]));
+
+                    // release memory
+                    vSamplesPerPrecision[i].shrink_to_fit();
+                }
+
+                vTimeLastSample[i] = now;
+            }
+            biggestInterval = precisionIntervals[i];
+        }
+
+        intervalCounter++;
+
+        if (intervalCounter > biggestInterval) {
+            intervalCounter = 1;
+        }
+    }
+    return statsChanged;
+}
+
+void CStatsMempool::setMaxMemoryUsageTarget(size_t maxMem)
+{
+    // calculate the memory requirement of a single sample
+    size_t sampleSize = memusage::MallocUsage(sizeof(CStatsMempoolSample));
+
+    // calculate how many samples would fit in the target
+    size_t maxAmountOfSamples = maxMem / sampleSize;
+
+    // distribute the max samples equal between precision levels
+    unsigned int samplesPerPrecision = maxAmountOfSamples / sizeof(precisionIntervals) / sizeof(precisionIntervals[0]);
+    samplesPerPrecision = std::max(MIN_SAMPLES, samplesPerPrecision);
+    samplesPerPrecision = std::min(MAX_SAMPLES, samplesPerPrecision);
+    for (unsigned int i = 0; i < sizeof(precisionIntervals) / sizeof(precisionIntervals[0]); i++) {
+        vMaxSamplesPerPrecision[i] = samplesPerPrecision;
+    }
+}
+
+MempoolSamplesVector CStatsMempool::getSamplesForPrecision(unsigned int precision, uint64_t& fromTime)
+{
+    LOCK(cs_mempool_stats);
+
+    if (precision >= vSamplesPerPrecision.size()) {
+        return MempoolSamplesVector();
+    }
+
+    fromTime = startTime;
+    return vSamplesPerPrecision[precision];
+}

--- a/src/stats/stats_mempool.h
+++ b/src/stats/stats_mempool.h
@@ -1,0 +1,73 @@
+// Copyright (c) 2017 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_STATS_MEMPOOL_H
+#define BITCOIN_STATS_MEMPOOL_H
+
+#include <amount.h>
+#include "scheduler.h"
+#include <sync.h>
+
+#include <atomic>
+#include <stdlib.h>
+#include <vector>
+
+struct CStatsMempoolSample {
+
+    /* time delta to last item as 16bit unsigned integer
+     * allows a max delta of ~18h */
+    uint16_t timeDelta;
+
+    size_t txCount;     //!<transaction count
+    size_t dynMemUsage; //!<dynamic mempool usage
+    CAmount minFeePerK;  //!<min fee per K
+};
+
+typedef std::vector<struct CStatsMempoolSample> MempoolSamplesVector;
+
+class CStatsMempool
+{
+private:
+
+    /* caches */
+    static std::atomic<size_t> cacheMempoolSize;
+    static std::atomic<size_t> cacheMempoolDynamicMemoryUsage;
+    static std::atomic<CAmount> cacheMempoolMinRelayFee;
+    mutable CCriticalSection cs_mempool_stats; //!<protects the sample/max/time vectors
+
+    std::atomic<uint64_t> startTime; //start time
+    std::vector<MempoolSamplesVector> vSamplesPerPrecision; //!<multiple samples vector per precision level
+    std::vector<size_t> vMaxSamplesPerPrecision; //!<vector with the maximum amount of samples per precision level
+    std::vector<size_t> vTimeLastSample; //!<vector with the maximum amount of samples per precision level
+    size_t intervalCounter; //!<internal counter for cleanups
+
+    const unsigned int collectInterval; //timedelta in milliseconds
+
+    /* adds a mempool stats samples by accessing the lock free cache values
+     * returns true if at least one sample was collected */
+    bool addMempoolSamples(const size_t maxStatsMemory);
+
+    /* set the target for the maximum memory consumption (in bytes) */
+    void setMaxMemoryUsageTarget(size_t maxMem);
+
+    friend class CStats;
+public:
+
+    CStatsMempool(unsigned int collectIntervalIn);
+
+    static void setCache(size_t cacheMempoolSizeIn, size_t cacheMempoolDynamicMemoryUsageIn, CAmount cacheMempoolMinRelayFeeIn) {
+        cacheMempoolSize = cacheMempoolSizeIn;
+        cacheMempoolDynamicMemoryUsage = cacheMempoolDynamicMemoryUsageIn;
+        cacheMempoolMinRelayFee = cacheMempoolMinRelayFeeIn;
+    }
+
+    /* get mempool precision groups and its time interval-target */
+    std::vector<unsigned int> getPrecisionGroupsAndIntervals();
+
+    /* get mempool samples from a given precision group index(!)
+     * this returns a COPY */
+    MempoolSamplesVector getSamplesForPrecision(unsigned int precision, uint64_t& fromTime);
+};
+
+#endif // BITCOIN_STATS_MEMPOOL_H

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -29,6 +29,7 @@
 #include "script/script.h"
 #include "script/sigcache.h"
 #include "script/standard.h"
+#include "stats/stats.h"
 #include "timedata.h"
 #include "tinyformat.h"
 #include "txdb.h"
@@ -451,6 +452,7 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
 {
     const CTransaction& tx = *ptx;
     const uint256 hash = tx.GetHash();
+    CFeeRate poolMinFeeRate;
     AssertLockHeld(cs_main);
     if (pfMissingInputs)
         *pfMissingInputs = false;
@@ -619,7 +621,8 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
             return state.DoS(0, false, REJECT_NONSTANDARD, "bad-txns-too-many-sigops", false,
                 strprintf("%d", nSigOpsCost));
 
-        CAmount mempoolRejectFee = pool.GetMinFee(gArgs.GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000).GetFee(nSize);
+        poolMinFeeRate = pool.GetMinFee(gArgs.GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000);
+        CAmount mempoolRejectFee = poolMinFeeRate.GetFee(nSize);
         if (!bypass_limits && mempoolRejectFee > 0 && nModifiedFees < mempoolRejectFee) {
             return state.DoS(0, false, REJECT_INSUFFICIENTFEE, "mempool min fee not met", false, strprintf("%d < %d", nFees, mempoolRejectFee));
         }
@@ -876,6 +879,9 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
     }
 
     GetMainSignals().TransactionAddedToMempool(ptx);
+
+    // update mempool stats cache
+    CStatsMempool::setCache(pool.size(), pool.DynamicMemoryUsage(), poolMinFeeRate.GetFeePerK());
 
     return true;
 }
@@ -2108,6 +2114,10 @@ bool static DisconnectTip(CValidationState& state, const CChainParams& chainpara
     // Let wallets know transactions went from 1-confirmed to
     // 0-confirmed or conflicted:
     GetMainSignals().BlockDisconnected(pblock);
+
+    // update mempool stats cache
+    CStatsMempool::setCache(mempool.size(), mempool.DynamicMemoryUsage(), mempool.GetMinFee(gArgs.GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000).GetFeePerK());
+
     return true;
 }
 
@@ -2233,6 +2243,9 @@ bool static ConnectTip(CValidationState& state, const CChainParams& chainparams,
     disconnectpool.removeForBlock(blockConnecting.vtx);
     // Update chainActive & related variables.
     UpdateTip(pindexNew, chainparams);
+
+    // update mempool stats cache
+    CStatsMempool::setCache(mempool.size(), mempool.DynamicMemoryUsage(), mempool.GetMinFee(gArgs.GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000).GetFeePerK());
 
     int64_t nTime6 = GetTimeMicros(); nTimePostConnect += nTime6 - nTime5; nTimeTotal += nTime6 - nTime1;
     LogPrint(BCLog::BENCH, "  - Connect postprocess: %.2fms [%.2fs (%.2fms/blk)]\n", (nTime6 - nTime5) * MILLI, nTimePostConnect * MICRO, nTimePostConnect * MILLI / nBlocksTotal);

--- a/test/functional/mempool_limit_stats.py
+++ b/test/functional/mempool_limit_stats.py
@@ -11,7 +11,9 @@ class MempoolLimitTest(BitcoinTestFramework):
     def set_test_params(self):
         self.setup_clean_chain = True
         self.num_nodes = 1
-        self.extra_args = [["-maxmempool=5", "-spendzeroconfchange=0"]]
+        
+        # set a very low (100bytes) statsmaxmemorytarget to ensure we use the min amount of samples
+        self.extra_args = [["-maxmempool=5", "--statsenable", "--statsmaxmemorytarget=100""-spendzeroconfchange=0"]]
 
     def run_test(self):
         txouts = gen_return_txouts()
@@ -41,6 +43,12 @@ class MempoolLimitTest(BitcoinTestFramework):
         assert(txid not in self.nodes[0].getrawmempool())
         txdata = self.nodes[0].gettransaction(txid)
         assert(txdata['confirmations'] ==  0) #confirmation should still be 0
+        
+        # test mempool stats
+        time.sleep(15)
+        mps = self.nodes[0].getmempoolstats()
+        assert_equal(len(mps), 3) #fixed amount of percision levels
+        assert_equal(len(mps[0]['samples']), 5) #make sure we only have 5 samples (minimum history)
 
 if __name__ == '__main__':
     MempoolLimitTest().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -71,7 +71,7 @@ BASE_SCRIPTS= [
     'sendheaders.py',
     'zapwallettxes.py',
     'importmulti.py',
-    'mempool_limit.py',
+    'mempool_limit_stats.py',
     'merkle_blocks.py',
     'receivedby.py',
     'abandonconflict.py',


### PR DESCRIPTION
This PR adds a statistics collector class which aims to collect various types of statistics up to the configurable maximum memory target. At the moment, only mempool statistics will be collected.

### Motivation

Adding more statistics and visualization to the GUI would leverage its usage. To do so, we need stats that are collected even when the visualization is not visible (example: the GUI network graph will only draw data when it's visible which is kinda unusable)
### How it works

This PR adds a simple stats manager that polls stats over a repetitive `CScheduler` task.


The samples are not guaranteed to be const-time. Each sample contains a time delta to the last one (uint16_t).

### API
- `-statsenable` **default disabled**
- `-statsmaxmemorytarget` **10MB default** maximal memory target to use for statistics.
- RPC: `getmempoolstats`
== 
```json
[
  {
    "percision_interval": 2,
    "time_from": 1494252401,
    "samples": [
      [
        11, 
        1, 
        1008, 
        0
      ], ....
   }...
]
```
### Features

-> CScheduler driven sample collecting (current interval 2000ms)
-> Relevant mempool data (size, memory requirement, minfee) gets written to an atomic cache (no additional locking required)
-> Multiple precision levels (currently three, 2s, 60s, 1800s)
-> Memory target that will calculate how many samples do fit in the given target
-> Sample do only have a 2byte time-delta to the last sample, allowing to save some memory
-> Flexible design, adding more data-points should be simple (bandwidth, utxo-stats, etc.).