### PR TITLE
[doc] typos, text errors

### DIFF
--- a/doc/README_osx.md
+++ b/doc/README_osx.md
@@ -22,7 +22,7 @@ These tools inject timestamps by default, which produce non-deterministic
 binaries. The ZERO_AR_DATE environment variable is used to disable that.
 
 This version of cctools has been patched to use the current version of clang's
-headers and and its libLTO.so rather than those from llvmgcc, as it was
+headers and its libLTO.so rather than those from llvmgcc, as it was
 originally done in toolchain4.
 
 To complicate things further, all builds must target an Apple SDK. These SDKs

--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -31,7 +31,7 @@ libraries such as Qt are no longer being tested on XP.
 
 We do not have time nor resources to provide support for an OS that is
 end-of-life. From 0.13.0 on, Windows XP is no longer supported. Users are
-suggested to upgrade to a newer verion of Windows, or install an alternative OS
+suggested to upgrade to a newer version of Windows, or install an alternative OS
 that is supported.
 
 No attempt is made to prevent installing or running the software on Windows XP,

--- a/doc/translation_process.md
+++ b/doc/translation_process.md
@@ -94,7 +94,7 @@ When new plurals are added to the source file, it's important to do the followin
 7. Save the source file
 
 ### Translating a new language
-To create a new language template, you will need to edit the languages manifest file `src/qt/bitcoin.qrc` and add a new entry. Below is an example of the english language entry.
+To create a new language template, you will need to edit the languages manifest file `src/qt/bitcoin.qrc` and add a new entry. Below is an example of the English language entry.
 
 ```xml
 <qresource prefix="/translations">


### PR DESCRIPTION
Just a quick run through some docs and fixing some text errors. Just trivial things.
