### PR TITLE
Trivial: Standardize spelling of "serialize" and "optimize" in mining.cpp and main.cpp

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1988,7 +1988,7 @@ bool CheckInputs(const CTransaction& tx, CValidationState &state, const CCoinsVi
         // is safe because block merkle hashes are still computed and checked,
         // and any change will be caught at the next checkpoint. Of course, if
         // the checkpoint is for a chain that's invalid due to false scriptSigs
-        // this optimisation would allow an invalid chain to be accepted.
+        // this optimization would allow an invalid chain to be accepted.
         if (fScriptChecks) {
             for (unsigned int i = 0; i < tx.vin.size(); i++) {
                 const COutPoint &prevout = tx.vin[i].prevout;

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -650,7 +650,7 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
 
     if (nMaxVersionPreVB >= 2) {
         // If VB is supported by the client, nMaxVersionPreVB is -1, so we won't get here
-        // Because BIP 34 changed how the generation transaction is serialised, we can only use version/force back to v2 blocks
+        // Because BIP 34 changed how the generation transaction is serialized, we can only use version/force back to v2 blocks
         // This is safe to do [otherwise-]unconditionally only because we are throwing an exception above if a non-force deployment gets activated
         // Note that this can probably also be removed entirely after the first BIP9 non-force deployment (ie, probably segwit) gets activated
         aMutable.push_back("version/force");


### PR DESCRIPTION
The standard spelling seems to be "serialize", not "serialise"

```
grep -r "serialize" src/ | wc -l
     310
grep -r "serialise" src/ | wc -l
       1
```

Corrected the single instance of "serialise" in mining.cpp
