### PR TITLE
Trivial: Standardize spelling of "optimization" vs "optimisation" in main.cpp

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1988,7 +1988,7 @@ bool CheckInputs(const CTransaction& tx, CValidationState &state, const CCoinsVi
         // is safe because block merkle hashes are still computed and checked,
         // and any change will be caught at the next checkpoint. Of course, if
         // the checkpoint is for a chain that's invalid due to false scriptSigs
-        // this optimisation would allow an invalid chain to be accepted.
+        // this optimization would allow an invalid chain to be accepted.
         if (fScriptChecks) {
             for (unsigned int i = 0; i < tx.vin.size(); i++) {
                 const COutPoint &prevout = tx.vin[i].prevout;


### PR DESCRIPTION
The standard spelling seems to be "optimization", not "optimisation"

```
grep -r "optimization" src/ | wc -l
     16
grep -r "optimisation" src/ | wc -l
       1
```

Corrected the single instance of "optimisation" in main.cpp
