### PR TITLE
Take minRelayTxFee into account in FEEFILTER messages

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6757,7 +6757,7 @@ bool SendMessages(CNode* pto)
             CAmount currentFilter = mempool.GetMinFee(GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000).GetFeePerK();
             int64_t timeNow = GetTimeMicros();
             if (timeNow > pto->nextSendTimeFeeFilter) {
-                CAmount filterToSend = filterRounder.round(currentFilter);
+                CAmount filterToSend = std::max(filterRounder.round(currentFilter), minRelayTxFee.GetFeePerK());
                 if (filterToSend != pto->lastSentFeeFilter) {
                     pto->PushMessage(NetMsgType::FEEFILTER, filterToSend);
                     pto->lastSentFeeFilter = filterToSend;


### PR DESCRIPTION
As noticed by @luke-jr in the august 4th IRC meeting (see http://www.erisian.com.au/meetbot/bitcoin-core-dev/2016/bitcoin-core-dev.2016-08-04-19.00.log.html), no feefilter messages are sent as long as the mempool does not fill up. Send at least the minFeeFilter rate.
