### PR TITLE
Update p2p-segwit.py to reflect correct behavior

### DIFF
--- a/qa/rpc-tests/p2p-segwit.py
+++ b/qa/rpc-tests/p2p-segwit.py
@@ -946,8 +946,7 @@ class SegWitTest(BitcoinTestFramework):
         self.test_node.test_transaction_acceptance(tx, with_witness=True, accepted=False)
 
         # Verify that removing the witness succeeds.
-        # Re-announcing won't result in a getdata for ~2.5 minutes, so just
-        # deliver the modified transaction.
+        self.test_node.announce_tx_and_wait_for_getdata(tx)
         self.test_node.test_transaction_acceptance(tx, with_witness=False, accepted=True)
 
         # Now try to add extra witness data to a valid witness tx.

--- a/qa/rpc-tests/p2p-segwit.py
+++ b/qa/rpc-tests/p2p-segwit.py
@@ -302,13 +302,18 @@ class SegWitTest(BitcoinTestFramework):
         sync_blocks(self.nodes)
 
         # We'll add an unnecessary witness to this transaction that would cause
-        # it to be too large according to IsStandard.
+        # it to be non-standard, to test that violating policy with a witness before
+        # segwit activation doesn't blind a node to a transaction.  Transactions
+        # rejected for having a witness before segwit activation shouldn't be added
+        # to the rejection cache.
         tx3 = CTransaction()
         tx3.vin.append(CTxIn(COutPoint(tx2.sha256, 0), CScript([p2sh_program])))
         tx3.vout.append(CTxOut(tx2.vout[0].nValue-1000, scriptPubKey))
         tx3.wit.vtxinwit.append(CTxInWitness())
         tx3.wit.vtxinwit[0].scriptWitness.stack = [b'a'*400000]
         tx3.rehash()
+        # Note that this should be rejected for the premature witness reason,
+        # rather than a policy check, since segwit hasn't activated yet.
         self.std_node.test_transaction_acceptance(tx3, True, False, b'no-witness-yet')
 
         # If we send without witness, it should be accepted.


### PR DESCRIPTION
1. The tx entry from mapAlreadyAskedFor is erased as soon as it is received, and it doesn't enter the reject filter even though it's invalid, so we can immediately announce the transaction again and receive a getdata for that tx.
2. An example transaction is being rejected due to premature witness, not size
