### PR TITLE
[qa] abandonconflict: Use assert_equal

### DIFF
--- a/qa/rpc-tests/abandonconflict.py
+++ b/qa/rpc-tests/abandonconflict.py
@@ -68,7 +68,7 @@ class AbandonConflictTest(BitcoinTestFramework):
 
         # In mempool txs from self should increase balance from change
         newbalance = self.nodes[0].getbalance()
-        assert(newbalance == balance - Decimal("30") + Decimal("24.9996"))
+        assert_equal(newbalance, balance - Decimal("30") + Decimal("24.9996"))
         balance = newbalance
 
         # Restart the node with a higher min relay fee so the parent tx is no longer in mempool
@@ -78,16 +78,16 @@ class AbandonConflictTest(BitcoinTestFramework):
         self.nodes[0]=start_node(0, self.options.tmpdir, ["-debug","-logtimemicros","-minrelaytxfee=0.0001"])
 
         # Verify txs no longer in mempool
-        assert(len(self.nodes[0].getrawmempool()) == 0)
+        assert_equal(len(self.nodes[0].getrawmempool()), 0)
 
         # Not in mempool txs from self should only reduce balance
         # inputs are still spent, but change not received
         newbalance = self.nodes[0].getbalance()
-        assert(newbalance == balance - Decimal("24.9996"))
+        assert_equal(newbalance, balance - Decimal("24.9996"))
         # Unconfirmed received funds that are not in mempool, also shouldn't show
         # up in unconfirmed balance
         unconfbalance = self.nodes[0].getunconfirmedbalance() + self.nodes[0].getbalance()
-        assert(unconfbalance == newbalance)
+        assert_equal(unconfbalance, newbalance)
         # Also shouldn't show up in listunspent
         assert(not txABC2 in [utxo["txid"] for utxo in self.nodes[0].listunspent(0)])
         balance = newbalance
@@ -96,35 +96,35 @@ class AbandonConflictTest(BitcoinTestFramework):
         # including that the child tx was also abandoned
         self.nodes[0].abandontransaction(txAB1)
         newbalance = self.nodes[0].getbalance()
-        assert(newbalance == balance + Decimal("30"))
+        assert_equal(newbalance, balance + Decimal("30"))
         balance = newbalance
 
         # Verify that even with a low min relay fee, the tx is not reaccepted from wallet on startup once abandoned
         stop_node(self.nodes[0],0)
         self.nodes[0]=start_node(0, self.options.tmpdir, ["-debug","-logtimemicros","-minrelaytxfee=0.00001"])
-        assert(len(self.nodes[0].getrawmempool()) == 0)
-        assert(self.nodes[0].getbalance() == balance)
+        assert_equal(len(self.nodes[0].getrawmempool()), 0)
+        assert_equal(self.nodes[0].getbalance(), balance)
 
         # But if its received again then it is unabandoned
         # And since now in mempool, the change is available
         # But its child tx remains abandoned
         self.nodes[0].sendrawtransaction(signed["hex"])
         newbalance = self.nodes[0].getbalance()
-        assert(newbalance == balance - Decimal("20") + Decimal("14.99998"))
+        assert_equal(newbalance, balance - Decimal("20") + Decimal("14.99998"))
         balance = newbalance
 
         # Send child tx again so its unabandoned
         self.nodes[0].sendrawtransaction(signed2["hex"])
         newbalance = self.nodes[0].getbalance()
-        assert(newbalance == balance - Decimal("10") - Decimal("14.99998") + Decimal("24.9996"))
+        assert_equal(newbalance, balance - Decimal("10") - Decimal("14.99998") + Decimal("24.9996"))
         balance = newbalance
 
         # Remove using high relay fee again
         stop_node(self.nodes[0],0)
         self.nodes[0]=start_node(0, self.options.tmpdir, ["-debug","-logtimemicros","-minrelaytxfee=0.0001"])
-        assert(len(self.nodes[0].getrawmempool()) == 0)
+        assert_equal(len(self.nodes[0].getrawmempool()), 0)
         newbalance = self.nodes[0].getbalance()
-        assert(newbalance == balance - Decimal("24.9996"))
+        assert_equal(newbalance, balance - Decimal("24.9996"))
         balance = newbalance
 
         # Create a double spend of AB1 by spending again from only A's 10 output
@@ -143,7 +143,7 @@ class AbandonConflictTest(BitcoinTestFramework):
 
         # Verify that B and C's 10 BTC outputs are available for spending again because AB1 is now conflicted
         newbalance = self.nodes[0].getbalance()
-        assert(newbalance == balance + Decimal("20"))
+        assert_equal(newbalance, balance + Decimal("20"))
         balance = newbalance
 
         # There is currently a minor bug around this and so this test doesn't work.  See Issue #7315
@@ -151,7 +151,7 @@ class AbandonConflictTest(BitcoinTestFramework):
         # Don't think C's should either
         self.nodes[0].invalidateblock(self.nodes[0].getbestblockhash())
         newbalance = self.nodes[0].getbalance()
-        #assert(newbalance == balance - Decimal("10"))
+        #assert_equal(newbalance, balance - Decimal("10"))
         print("If balance has not declined after invalidateblock then out of mempool wallet tx which is no longer")
         print("conflicted has not resumed causing its inputs to be seen as spent.  See Issue #7315")
         print(str(balance) + " -> " + str(newbalance) + " ?")


### PR DESCRIPTION
There seem to be quite a few assertions failing lately. A lot of them which assert balances: https://travis-ci.org/bitcoin/bitcoin/jobs/152925845

This changes `assert()` to `assert_equal()`, so it is easier to see what the value was that caused it to fail.
