### PR TITLE
CDB: fix debug output

### DIFF
--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -284,7 +284,7 @@ CDB::CDB(const std::string& strFilename, const char* pszMode, bool fFlushOnClose
                 pdb = NULL;
                 --bitdb.mapFileUseCount[strFile];
                 strFile = "";
-                throw runtime_error(strprintf("CDB: Error %d, can't open database %s", ret, strFile));
+                throw runtime_error(strprintf("CDB: Error %d, can't open database %s", ret, strFilename));
             }
 
             if (fCreate && !Exists(string("version"))) {


### PR DESCRIPTION
It doesn't really help to clear a variable before printing it to the debug log.
