### PR TITLE
Trivial: Fix typos in various files

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1081,7 +1081,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     /* Start the RPC server already.  It will be started in "warmup" mode
      * and not really process calls already (but it will signify connections
      * that the server is there and will be ready later).  Warmup mode will
-     * be disabled when initialisation is finished.
+     * be disabled when initialization is finished.
      */
     if (fServer)
     {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6399,7 +6399,7 @@ bool SendMessages(CNode* pto)
                 /* If possible, start at the block preceding the currently
                    best known header.  This ensures that we always get a
                    non-empty list of headers back as long as the peer
-                   is up-to-date.  With a non-empty response, we can initialise
+                   is up-to-date.  With a non-empty response, we can initialize
                    the peer's known best block.  This wouldn't be possible
                    if we requested starting at pindexBestHeader and
                    got back an empty response.  */


### PR DESCRIPTION
It seems that "initializ-" is the standard, and not "initialis-"

```
$ grep -r "initialis" src/ | grep -v "qt/locale" | wc -l
       2
$ grep -r "initializ" src/ | grep -v "qt/locale" | wc -l
      151
```
