### PR TITLE
RFC: net: Pass best block known height into net

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1503,6 +1503,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     if (GetBoolArg("-listenonion", DEFAULT_LISTEN_ONION))
         StartTorControl(threadGroup, scheduler);
 
+    SetNodeStartHeight(chainActive.Height());
     StartNode(threadGroup, scheduler);
 
     // ********************************************************* Step 12: finished

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -109,6 +109,8 @@ CCriticalSection cs_nLastNodeId;
 static CSemaphore *semOutbound = NULL;
 boost::condition_variable messageHandlerCondition;
 
+static std::atomic<int> nNodeStartHeight(0);
+
 // Signals for message handling
 static CNodeSignals g_signals;
 CNodeSignals& GetNodeSignals() { return g_signals; }
@@ -185,6 +187,11 @@ CAddress GetLocalAddress(const CNetAddr *paddrPeer)
     ret.nTime = GetAdjustedTime();
     return ret;
 }
+
+void SetNodeStartHeight(int nHeight)
+{
+    nNodeStartHeight.store(nHeight, std::memory_order_relaxed);
+};
 
 int GetnScore(const CService& addr)
 {
@@ -434,7 +441,7 @@ CNode* ConnectNode(CAddress addrConnect, const char *pszDest, bool fCountFailure
         addrman.Attempt(addrConnect, fCountFailure);
 
         // Add node
-        CNode* pnode = new CNode(hSocket, addrConnect, pszDest ? pszDest : "", false);
+        CNode* pnode = new CNode(nNodeStartHeight.load(std::memory_order_relaxed), hSocket, addrConnect, pszDest ? pszDest : "", false);
         pnode->AddRef();
 
         {
@@ -492,18 +499,16 @@ void CNode::CloseSocketDisconnect()
 
 void CNode::PushVersion()
 {
-    int nBestHeight = GetNodeSignals().GetHeight().get_value_or(0);
-
     int64_t nTime = (fInbound ? GetAdjustedTime() : GetTime());
     CAddress addrYou = (addr.IsRoutable() && !IsProxy(addr) ? addr : CAddress(CService(), addr.nServices));
     CAddress addrMe = GetLocalAddress(&addr);
     GetRandBytes((unsigned char*)&nLocalHostNonce, sizeof(nLocalHostNonce));
     if (fLogIPs)
-        LogPrint("net", "send version message: version %d, blocks=%d, us=%s, them=%s, peer=%d\n", PROTOCOL_VERSION, nBestHeight, addrMe.ToString(), addrYou.ToString(), id);
+        LogPrint("net", "send version message: version %d, blocks=%d, us=%s, them=%s, peer=%d\n", PROTOCOL_VERSION, nOurStartHeight, addrMe.ToString(), addrYou.ToString(), id);
     else
-        LogPrint("net", "send version message: version %d, blocks=%d, us=%s, peer=%d\n", PROTOCOL_VERSION, nBestHeight, addrMe.ToString(), id);
+        LogPrint("net", "send version message: version %d, blocks=%d, us=%s, peer=%d\n", PROTOCOL_VERSION, nOurStartHeight, addrMe.ToString(), id);
     PushMessage(NetMsgType::VERSION, PROTOCOL_VERSION, (uint64_t)nLocalServices, nTime, addrYou, addrMe,
-                nLocalHostNonce, strSubVersion, nBestHeight, ::fRelayTxes);
+                nLocalHostNonce, strSubVersion, nOurStartHeight, ::fRelayTxes);
 }
 
 
@@ -1072,7 +1077,7 @@ static void AcceptConnection(const ListenSocket& hListenSocket) {
         }
     }
 
-    CNode* pnode = new CNode(hSocket, addr, "", true);
+    CNode* pnode = new CNode(nNodeStartHeight.load(std::memory_order_relaxed), hSocket, addr, "", true);
     pnode->AddRef();
     pnode->fWhitelisted = whitelisted;
 
@@ -2069,7 +2074,7 @@ void StartNode(boost::thread_group& threadGroup, CScheduler& scheduler)
     if (pnodeLocalHost == NULL) {
         CNetAddr local;
         LookupHost("127.0.0.1", local, false);
-        pnodeLocalHost = new CNode(INVALID_SOCKET, CAddress(CService(local, 0), nLocalServices));
+        pnodeLocalHost = new CNode(nNodeStartHeight.load(std::memory_order_relaxed), INVALID_SOCKET, CAddress(CService(local, 0), nLocalServices));
     }
 
     Discover(threadGroup);
@@ -2425,12 +2430,13 @@ bool CAddrDB::Read(CAddrMan& addr, CDataStream& ssPeers)
 unsigned int ReceiveFloodSize() { return 1000*GetArg("-maxreceivebuffer", DEFAULT_MAXRECEIVEBUFFER); }
 unsigned int SendBufferSize() { return 1000*GetArg("-maxsendbuffer", DEFAULT_MAXSENDBUFFER); }
 
-CNode::CNode(SOCKET hSocketIn, const CAddress& addrIn, const std::string& addrNameIn, bool fInboundIn) :
+CNode::CNode(int nOurStartHeightIn, SOCKET hSocketIn, const CAddress& addrIn, const std::string& addrNameIn, bool fInboundIn) :
     ssSend(SER_NETWORK, INIT_PROTO_VERSION),
     addr(addrIn),
     nKeyedNetGroup(CalculateKeyedNetGroup(addrIn)),
     addrKnown(5000, 0.001),
-    filterInventoryKnown(50000, 0.000001)
+    filterInventoryKnown(50000, 0.000001),
+    nOurStartHeight(nOurStartHeightIn)
 {
     nServices = NODE_NONE;
     nServicesExpected = NODE_NONE;

--- a/src/net.h
+++ b/src/net.h
@@ -115,7 +115,6 @@ struct CombinerAll
 // Signals for message handling
 struct CNodeSignals
 {
-    boost::signals2::signal<int ()> GetHeight;
     boost::signals2::signal<bool (CNode*), CombinerAll> ProcessMessages;
     boost::signals2::signal<bool (CNode*), CombinerAll> SendMessages;
     boost::signals2::signal<void (NodeId, const CNode*)> InitializeNode;
@@ -151,7 +150,7 @@ bool GetLocal(CService &addr, const CNetAddr *paddrPeer = NULL);
 bool IsReachable(enum Network net);
 bool IsReachable(const CNetAddr &addr);
 CAddress GetLocalAddress(const CNetAddr *paddrPeer = NULL);
-
+void SetNodeStartHeight(int nHeight);
 
 extern bool fDiscover;
 extern bool fListen;
@@ -443,7 +442,10 @@ public:
     CAmount lastSentFeeFilter;
     int64_t nextSendTimeFeeFilter;
 
-    CNode(SOCKET hSocketIn, const CAddress &addrIn, const std::string &addrNameIn = "", bool fInboundIn = false);
+    // Out height at the time of node creation
+    const int nOurStartHeight;
+
+    CNode(int nOurStartHeightIn, SOCKET hSocketIn, const CAddress &addrIn, const std::string &addrNameIn = "", bool fInboundIn = false);
     ~CNode();
 
 private:

--- a/src/test/DoS_tests.cpp
+++ b/src/test/DoS_tests.cpp
@@ -46,7 +46,7 @@ BOOST_AUTO_TEST_CASE(DoS_banning)
 {
     CNode::ClearBanned();
     CAddress addr1(ip(0xa0b0c001), NODE_NONE);
-    CNode dummyNode1(INVALID_SOCKET, addr1, "", true);
+    CNode dummyNode1(0, INVALID_SOCKET, addr1, "", true);
     dummyNode1.nVersion = 1;
     Misbehaving(dummyNode1.GetId(), 100); // Should get banned
     SendMessages(&dummyNode1);
@@ -54,7 +54,7 @@ BOOST_AUTO_TEST_CASE(DoS_banning)
     BOOST_CHECK(!CNode::IsBanned(ip(0xa0b0c001|0x0000ff00))); // Different IP, not banned
 
     CAddress addr2(ip(0xa0b0c002), NODE_NONE);
-    CNode dummyNode2(INVALID_SOCKET, addr2, "", true);
+    CNode dummyNode2(0, INVALID_SOCKET, addr2, "", true);
     dummyNode2.nVersion = 1;
     Misbehaving(dummyNode2.GetId(), 50);
     SendMessages(&dummyNode2);
@@ -70,7 +70,7 @@ BOOST_AUTO_TEST_CASE(DoS_banscore)
     CNode::ClearBanned();
     mapArgs["-banscore"] = "111"; // because 11 is my favorite number
     CAddress addr1(ip(0xa0b0c001), NODE_NONE);
-    CNode dummyNode1(INVALID_SOCKET, addr1, "", true);
+    CNode dummyNode1(0, INVALID_SOCKET, addr1, "", true);
     dummyNode1.nVersion = 1;
     Misbehaving(dummyNode1.GetId(), 100);
     SendMessages(&dummyNode1);
@@ -91,7 +91,7 @@ BOOST_AUTO_TEST_CASE(DoS_bantime)
     SetMockTime(nStartTime); // Overrides future calls to GetTime()
 
     CAddress addr(ip(0xa0b0c001), NODE_NONE);
-    CNode dummyNode(INVALID_SOCKET, addr, "", true);
+    CNode dummyNode(0, INVALID_SOCKET, addr, "", true);
     dummyNode.nVersion = 1;
 
     Misbehaving(dummyNode.GetId(), 100);


### PR DESCRIPTION
This looks somewhat awkward as-is, but it's a part of the CConnman refactor. I've broken it out and PR'd separately because it's a change of behavior that requires some scrutiny. As part of #8085, the height will be passed into CConnman instead. For reference, it will end up looking more like this: https://github.com/bitcoin/bitcoin/pull/8085/commits/148163c9b1ce04ec9fa9c8ff9a4289520bd92127.

Even without that, though, I think this is an improvement, as it eliminates a dependency on main from net.

Push block height changes from main into net, and pass the current height into CNode at creation time, rather than pulling from main each time (and locking cs_main). Now CNode has no dependency on main for height.

Note that It may also be handy to know later what our original height was for a given node.

This also helps to prevent identity leakage a tiny bit. Before this change, an
attacker could theoretically make 2 connections on different interfaces. They
would connect fully on one, and only establish the initial connection on the
other. Once they receive a new block, they would relay it to your first
connection, and immediately commence the version handshake on the second. Since
the new block height was reflected immediately, they could attempt to learn
whether the two connections were correlated.

This is, of course, incredibly unlikely to work due to the small timings
involved and receipt from other senders. But it doesn't hurt to lock-in
nBestHeight at the time of connection, rather than letting the remote choose
the time.
