### PR TITLE
Use ANYONECANPAY if -spendzeroconfchange=0

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2364,8 +2364,17 @@ bool CWallet::CreateTransaction(const vector<CRecipient>& vecSend, CWalletTx& wt
                     bool signSuccess;
                     const CScript& scriptPubKey = coin.first->vout[coin.second].scriptPubKey;
                     SignatureData sigdata;
+                    int nHashType = SIGHASH_ALL;
+
+                    // If we're not spending unconfirmed outputs, we can use
+                    // ANYONECANPAY as it's ok if someone adds an input to our
+                    // transaction: we're not relying on the txid being stable
+                    // anyway.
+                    if (!bSpendZeroConfChange)
+                        nHashType |= SIGHASH_ANYONECANPAY;
+
                     if (sign)
-                        signSuccess = ProduceSignature(TransactionSignatureCreator(this, &txNewConst, nIn, coin.first->vout[coin.second].nValue, SIGHASH_ALL), scriptPubKey, sigdata);
+                        signSuccess = ProduceSignature(TransactionSignatureCreator(this, &txNewConst, nIn, coin.first->vout[coin.second].nValue, nHashType), scriptPubKey, sigdata);
                     else
                         signSuccess = ProduceSignature(DummySignatureCreator(this), scriptPubKey, sigdata);
 


### PR DESCRIPTION
Signing transactions with ANYONECANPAY has a number of advantages:

1) Anyone can bump fees by adding a (small-valued) input: This can get struck
transactions unstuck more effectively than CPFP, which may not work if the
parent transaction hasn't gotten to a miner's mempool due to low fees.

2) Privacy/Fungibility: If inputs aren't signing each other, they're not making
any explicit statement about the relationship of one input to another. In
particular, any input that's less than the transaction fee is possibly from
another wallet, confusing taint analysis with plausible deniability.

3) Discouraging Re-Orgs: By allowing anyone to add inputs to any transaction,
we make malicious re-orgs targetting particular coins more disruptive, as the
set of non-targetted transactions unrelated to the target coins can grow
faster, increasing the colateral damage of a malicious re-org attack.

The downside of ANYONECANPAY is mutability, but if we're not spending zeroconf
change that's irrelevant; enabling ANYONECANPAY if zeroconf change is disabled
is an easy and low-risk first step towards using ANYONECANPAY more widely.

I've also opened an issue for joinmarket to implement this: https://github.com/JoinMarket-Org/joinmarket/issues/599
