### PR TITLE
trivial: remove unused variable

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3534,7 +3534,6 @@ CWalletKey::CWalletKey(int64_t nExpires)
 int CMerkleTx::SetMerkleBranch(const CBlockIndex* pindex, int posInBlock)
 {
     AssertLockHeld(cs_main);
-    CBlock blockTmp;
 
     // Update the tx's hashBlock
     hashBlock = pindex->GetBlockHash();


### PR DESCRIPTION
Remove the unused variable `blockTmp` in `CMerkleTx::SetMerkleBranch`.  It was previously used to read the block from disk if not provided as argument, but is no longer needed.
