### PR TITLE
Add copyright header to wallet_text_fixture.cpp

### DIFF
--- a/src/wallet/test/wallet_test_fixture.cpp
+++ b/src/wallet/test/wallet_test_fixture.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2016 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include "wallet/test/wallet_test_fixture.h"
 
 #include "rpc/server.h"


### PR DESCRIPTION
I created the file but forgot to add this header.
(reported by sinetek on IRC)
