### PR TITLE
Change maxuploadtarget recommended minimum calculation

### DIFF
--- a/doc/reduce-traffic.md
+++ b/doc/reduce-traffic.md
@@ -19,8 +19,8 @@ This is *not* a hard limit; only a threshold to minimize the outbound
 traffic. When the limit is about to be reached, the uploaded data is cut by no
 longer serving historic blocks (blocks older than one week).
 Keep in mind that new nodes require other nodes that are willing to serve
-historic blocks. **The recommended minimum is 144 blocks per day (max. 144MB
-per day)**
+historic blocks.
+**The current recommended minimum is 288MiB, assuming an average serialized block size of 2MB.**
 
 Whitelisted peers will never be disconnected, although their traffic counts for
 calculating the target.

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2193,11 +2193,12 @@ void CNode::RecordBytesSent(uint64_t bytes)
 void CNode::SetMaxOutboundTarget(uint64_t limit)
 {
     LOCK(cs_totalBytesSent);
-    uint64_t recommendedMinimum = (nMaxOutboundTimeframe / 600) * MAX_BLOCK_SERIALIZED_SIZE;
+    // assume the average size of serialized blocks is half the maximum
+    uint64_t recommendedMinimum = (nMaxOutboundTimeframe / 600) * MAX_BLOCK_SERIALIZED_SIZE / 2;
     nMaxOutboundLimit = limit;
 
     if (limit > 0 && limit < recommendedMinimum)
-        LogPrintf("Max outbound target is very small (%s bytes) and will be overshot. Recommended minimum is %s bytes.\n", nMaxOutboundLimit, recommendedMinimum);
+        LogPrintf("Max outbound target is very small (%s MiB) and will be overshot. Recommended minimum is %s MiB.\n", nMaxOutboundLimit/1024.0/1024.0, recommendedMinimum/1024.0/1024.0);
 }
 
 uint64_t CNode::GetMaxOutboundTarget()


### PR DESCRIPTION
Addresses #8555.

Changes the recommended `-maxuploadtarget` minimum from 144 blocks per day to 72 blocks per day. With the SWs `MAX_BLOCK_SERIALIZED_SIZE` of 4MiB, 144 blocks per day would result in a recommended minimum of 576MiB per day = ~17GB per Month in uploading blocks. IMO this is too hight for a recommended _minimum_.

This PR changes the minimum calculation from 144 to 72 blocks per day ("half day of full blocks").
Anyway, the calculation is just a form of an vague estimation of how many MiB in historical blocks we should recommend to broadcast upstream when `-maxuploadtarget` is set. It does not take -maxconnection etc. into the calculation.

~~The current maxuploadtarget recommendation is calculated using `MAX_BLOCK_SERIALIZED_SIZE` (4MB) instead of `MAX_BLOCK_BASE_SIZE` (1MB). Given that the function is there to reduce uploading historical blocks, using `MAX_BLOCK_BASE_SIZE` makes more sense.~~
