### PR TITLE
Add configure check for -latomic

### DIFF
--- a/build-aux/m4/l_atomic.m4
+++ b/build-aux/m4/l_atomic.m4
@@ -1,0 +1,40 @@
+# Some versions of gcc/libstdc++ require linking with -latomic if
+# using the C++ atomic library.
+#
+# Sourced from http://bugs.debian.org/797228
+
+m4_define([_CHECK_ATOMIC_testbody], [[
+  #include <atomic>
+  #include <cstdint>
+
+  int main() {
+    std::atomic<int64_t> a{};
+
+    int64_t v = 5;
+    int64_t r = a.fetch_add(v);
+    return static_cast<int>(r);
+  }
+]])
+
+AC_DEFUN([CHECK_ATOMIC], [
+
+  AC_LANG_PUSH(C++)
+
+  AC_MSG_CHECKING([whether std::atomic can be used without link library])
+
+  AC_LINK_IFELSE([AC_LANG_SOURCE([_CHECK_ATOMIC_testbody])],[
+      AC_MSG_RESULT([yes])
+    ],[
+      AC_MSG_RESULT([no])
+      LIBS="$LIBS -latomic"
+      AC_MSG_CHECKING([whether std::atomic needs -latomic])
+      AC_LINK_IFELSE([AC_LANG_SOURCE([_CHECK_ATOMIC_testbody])],[
+          AC_MSG_RESULT([yes])
+        ],[
+          AC_MSG_RESULT([no])
+          AC_MSG_FAILURE([cannot figure our how to use std::atomic])
+        ])
+    ])
+
+  AC_LANG_POP
+])

--- a/configure.ac
+++ b/configure.ac
@@ -57,6 +57,9 @@ case $host in
 esac
 dnl Require C++11 compiler (no GNU extensions)
 AX_CXX_COMPILE_STDCXX([11], [noext], [mandatory])
+dnl Check if -latomic is required for <std::atomic>
+CHECK_ATOMIC
+
 dnl Libtool init checks.
 LT_INIT([pic-only])
 


### PR DESCRIPTION
Add a configure check to use libatomic for std::atomic operations if needed.

Per https://gcc.gnu.org/onlinedocs/libstdc++/manual/using_concurrency.html "Some uses of std::atomic also require linking to libatomic." This has been observed to be necessary when building with gcc on Debian's mips and mipsel architectures.
