### PR TITLE
[Wallet] remove unused code/conditions in ReadAtCursor

### DIFF
--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -387,7 +387,7 @@ bool CDB::Rewrite(const string& strFile, const char* pszSkip)
                         while (fSuccess) {
                             CDataStream ssKey(SER_DISK, CLIENT_VERSION);
                             CDataStream ssValue(SER_DISK, CLIENT_VERSION);
-                            int ret = db.ReadAtCursor(pcursor, ssKey, ssValue, DB_NEXT);
+                            int ret = db.ReadAtCursor(pcursor, ssKey, ssValue);
                             if (ret == DB_NOTFOUND) {
                                 pcursor->close();
                                 break;

--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -228,19 +228,17 @@ protected:
         return pcursor;
     }
 
-    int ReadAtCursor(Dbc* pcursor, CDataStream& ssKey, CDataStream& ssValue, unsigned int fFlags = DB_NEXT)
+    int ReadAtCursor(Dbc* pcursor, CDataStream& ssKey, CDataStream& ssValue, bool setRange = false)
     {
         // Read at cursor
         Dbt datKey;
-        if (fFlags == DB_SET || fFlags == DB_SET_RANGE || fFlags == DB_GET_BOTH || fFlags == DB_GET_BOTH_RANGE) {
+        unsigned int fFlags = DB_NEXT;
+        if (setRange) {
             datKey.set_data(&ssKey[0]);
             datKey.set_size(ssKey.size());
+            fFlags = DB_SET_RANGE;
         }
         Dbt datValue;
-        if (fFlags == DB_GET_BOTH || fFlags == DB_GET_BOTH_RANGE) {
-            datValue.set_data(&ssValue[0]);
-            datValue.set_size(ssValue.size());
-        }
         datKey.set_flags(DB_DBT_MALLOC);
         datValue.set_flags(DB_DBT_MALLOC);
         int ret = pcursor->get(&datKey, &datValue, fFlags);

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -216,16 +216,16 @@ void CWalletDB::ListAccountCreditDebit(const string& strAccount, list<CAccountin
     Dbc* pcursor = GetCursor();
     if (!pcursor)
         throw runtime_error(std::string(__func__) + ": cannot create DB cursor");
-    unsigned int fFlags = DB_SET_RANGE;
+    bool setRange = true;
     while (true)
     {
         // Read next record
         CDataStream ssKey(SER_DISK, CLIENT_VERSION);
-        if (fFlags == DB_SET_RANGE)
+        if (setRange)
             ssKey << std::make_pair(std::string("acentry"), std::make_pair((fAllAccounts ? string("") : strAccount), uint64_t(0)));
         CDataStream ssValue(SER_DISK, CLIENT_VERSION);
-        int ret = ReadAtCursor(pcursor, ssKey, ssValue, fFlags);
-        fFlags = DB_NEXT;
+        int ret = ReadAtCursor(pcursor, ssKey, ssValue, setRange);
+        setRange = false;
         if (ret == DB_NOTFOUND)
             break;
         else if (ret != 0)


### PR DESCRIPTION
Long term goal should be to provide alternative database connectors for our wallet. I have worked out a flexible adaptor like pattern that would allow a drop-in-alternative/replacement for BDB (https://github.com/jonasschnelli/bitcoin/tree/2016/08/bdb_abstract_prework).

This is a small, easy-to-review trivial PR towards this direction.

`CDB::ReadAtCursor()` has some unused flags handling (which would be relative hard to abstract for other databases). It seems like it only used to set a filter for the key (`DB_SET_RANGE`).

This removes unused code and simplifies `CDB::ReadAtCursor()` logic.
