### PR TITLE
.gitignore TAGS and emacs lock files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,8 @@ src/qt/test/moc*.cpp
 .dirstamp
 .libs
 .*.swp
+.\#*
+\#*\#
 *.*~*
 *.bak
 *.rej

--- a/.gitignore
+++ b/.gitignore
@@ -97,6 +97,19 @@ test_bitcoin.coverage/
 total.coverage/
 coverage_percent.txt
 
+#tags (see distclean-tags make target)
+TAGS
+ID
+GTAGS
+GRTAGS
+GSYMS
+GPATH
+tags
+cscope.out
+cscope.in.out
+cscope.po.out
+cscope.files
+
 #build tests
 linux-coverage-build
 linux-build


### PR DESCRIPTION
`TAGS CTAGS GTAGS ID` etc. can be generated (and `distclean`-ed) by the existing Makefiles, they should be ignored by git.
