### PR TITLE
new var DIST_CONTRIB adds useful things for packagers from contrib

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -32,7 +32,9 @@ OSX_PLIST=$(top_builddir)/share/qt/Info.plist #not installed
 OSX_QT_TRANSLATIONS = da,de,es,hu,ru,uk,zh_CN,zh_TW
 
 DIST_DOCS = $(wildcard doc/*.md) $(wildcard doc/release-notes/*.md)
-DIST_CONTRIB = $(wildcard $(top_srcdir)/contrib/*.bash-completion) \
+DIST_CONTRIB = $(top_srcdir)/contrib/bitcoin-cli.bash-completion \
+	       $(top_srcdir)/contrib/bitcoin-tx.bash-completion \
+	       $(top_srcdir)/contrib/bitcoind.bash-completion \
 	       $(top_srcdir)/contrib/init \
 	       $(top_srcdir)/contrib/rpm
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -33,7 +33,6 @@ OSX_QT_TRANSLATIONS = da,de,es,hu,ru,uk,zh_CN,zh_TW
 
 DIST_DOCS = $(wildcard doc/*.md) $(wildcard doc/release-notes/*.md)
 DIST_CONTRIB = $(wildcard $(top_srcdir)/contrib/*.bash-completion) \
-	       $(top_srcdir)/contrib/debian \
 	       $(top_srcdir)/contrib/init \
 	       $(top_srcdir)/contrib/rpm
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -32,6 +32,10 @@ OSX_PLIST=$(top_builddir)/share/qt/Info.plist #not installed
 OSX_QT_TRANSLATIONS = da,de,es,hu,ru,uk,zh_CN,zh_TW
 
 DIST_DOCS = $(wildcard doc/*.md) $(wildcard doc/release-notes/*.md)
+DIST_CONTRIB = $(wildcard $(top_srcdir)/contrib/*.bash-completion) \
+	       $(top_srcdir)/contrib/debian \
+	       $(top_srcdir)/contrib/init \
+	       $(top_srcdir)/contrib/rpm
 
 BIN_CHECKS=$(top_srcdir)/contrib/devtools/symbol-check.py \
            $(top_srcdir)/contrib/devtools/security-check.py
@@ -204,7 +208,7 @@ endif
 
 dist_noinst_SCRIPTS = autogen.sh
 
-EXTRA_DIST = $(top_srcdir)/share/genbuild.sh qa/pull-tester/rpc-tests.py qa/rpc-tests $(DIST_DOCS) $(WINDOWS_PACKAGING) $(OSX_PACKAGING) $(BIN_CHECKS)
+EXTRA_DIST = $(top_srcdir)/share/genbuild.sh qa/pull-tester/rpc-tests.py qa/rpc-tests $(DIST_CONTRIB) $(DIST_DOCS) $(WINDOWS_PACKAGING) $(OSX_PACKAGING) $(BIN_CHECKS)
 
 CLEANFILES = $(OSX_DMG) $(BITCOIN_WIN_INSTALLER)
 


### PR DESCRIPTION
This creates a new variable DIST_CONTRIB in Makefile.am and adds it to EXTRA_DIST. 

I included a few useful things like contrib/debian subdir (contains manpages, .desktop file), contrib/rpm subdir (contains .spec file to build rpms), contrib/init subdir (contains things like systemd startup files) and the *.bash-completion files.

Reason is that many packagers just use the (unsigned) tarball from the github release page, as it contains the full contrib folder including manpages. With this change the release tarball created by
`make dist` contains most of those files too, so packagers can use this one instead. See also #6753
