### PR TITLE
[WIP] Don't effectively blacklist pruned nodes.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5116,9 +5116,6 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         {
             boost::this_thread::interruption_point();
 
-            if ((addr.nServices & REQUIRED_SERVICES) != REQUIRED_SERVICES)
-                continue;
-
             if (addr.nTime <= 100000000 || addr.nTime > nNow + 10 * 60)
                 addr.nTime = nNow - 5 * 24 * 60 * 60;
             pfrom->AddAddressKnown(addr);

--- a/src/main.h
+++ b/src/main.h
@@ -248,8 +248,6 @@ bool ProcessMessages(CNode* pfrom);
 bool SendMessages(CNode* pto);
 /** Run an instance of the script checking thread */
 void ThreadScriptCheck();
-/** Check whether we are doing an initial block download (synchronizing from disk or network) */
-bool IsInitialBlockDownload();
 /** Format a string that describes several potential problems detected by the core.
  * strFor can have three values:
  * - "rpc": get critical warnings, which should put the client in safe mode if non-empty

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1705,8 +1705,8 @@ void ThreadOpenConnections()
             if (IsLimited(addr))
                 continue;
 
-            // only connect to full nodes
-            if ((addr.nServices & REQUIRED_SERVICES) != REQUIRED_SERVICES)
+            // only connect to full nodes during IBD
+            if ((addr.nServices & NODE_NETWORK) != NODE_NETWORK && IsInitialBlockDownload())
                 continue;
 
             // only consider very recently tried nodes after 30 failed attempts

--- a/src/net.h
+++ b/src/net.h
@@ -74,8 +74,6 @@ static const bool DEFAULT_FORCEDNSSEED = false;
 static const size_t DEFAULT_MAXRECEIVEBUFFER = 5 * 1000;
 static const size_t DEFAULT_MAXSENDBUFFER    = 1 * 1000;
 
-static const ServiceFlags REQUIRED_SERVICES = NODE_NETWORK;
-
 // NOTE: When adjusting this, update rpcnet:setban's help ("24h")
 static const unsigned int DEFAULT_MISBEHAVING_BANTIME = 60 * 60 * 24;  // Default 24-hour ban
 
@@ -153,7 +151,8 @@ bool GetLocal(CService &addr, const CNetAddr *paddrPeer = NULL);
 bool IsReachable(enum Network net);
 bool IsReachable(const CNetAddr &addr);
 CAddress GetLocalAddress(const CNetAddr *paddrPeer = NULL);
-
+/** Check whether we are doing an initial block download (synchronizing from disk or network) */
+bool IsInitialBlockDownload();
 
 extern bool fDiscover;
 extern bool fListen;


### PR DESCRIPTION
If upon connecting it's found that the node doesn't have the blocks we need, we can always disconnect then, but unless we give the node a chance to become a full-node, it may forever be forgotten about (until it changes it's IP address).

Also, even pruned nodes provide much use for block propagation and it's only during IBD that we're needing historical blocks anyway. Perhaps in this situation it is reasonable to skip nodes that were once seen to be pruning (but may no longer be).
