### PR TITLE
leveldb: generate lib independent of locale sort

### DIFF
--- a/src/leveldb/build_detect_platform
+++ b/src/leveldb/build_detect_platform
@@ -176,7 +176,7 @@ set -f # temporarily disable globbing so that our patterns aren't expanded
 PRUNE_TEST="-name *test*.cc -prune"
 PRUNE_BENCH="-name *_bench.cc -prune"
 PRUNE_TOOL="-name leveldb_main.cc -prune"
-PORTABLE_FILES=`find $DIRS $PRUNE_TEST -o $PRUNE_BENCH -o $PRUNE_TOOL -o -name '*.cc' -print | sort | sed "s,^$PREFIX/,," | tr "\n" " "`
+PORTABLE_FILES=`find $DIRS $PRUNE_TEST -o $PRUNE_BENCH -o $PRUNE_TOOL -o -name '*.cc' -print | LC_ALL=C sort | sed "s,^$PREFIX/,," | tr "\n" " "`
 
 set +f # re-enable globbing
 


### PR DESCRIPTION
This patch modifies src/leveldb/build_detect_platform to ensure that
the sorted PORTABLE_FILES is collated in a canonical order and hence
varying locale collation order will not cause generated objects to vary.
Patch due to Reiner Herrmann from Debian's reproducible build project.
