### PR TITLE
Show XTHIN in GUI

### DIFF
--- a/src/protocol.h
+++ b/src/protocol.h
@@ -267,6 +267,9 @@ enum ServiceFlags : uint64_t {
     // Indicates that a node can be asked for blocks and transactions including
     // witness data.
     NODE_WITNESS = (1 << 3),
+    // NODE_XTHIN means the node supports Xtreme Thinblocks
+    // If this is turned off then the node will not service nor make xthin requests
+    NODE_XTHIN = (1 << 4),
 
     // Bits 24-31 are reserved for temporary experiments. Just pick a bit that
     // isn't getting used, or one not being used much, and notify the

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -930,6 +930,9 @@ QString formatServicesStr(quint64 mask)
             case NODE_WITNESS:
                 strList.append("WITNESS");
                 break;
+            case NODE_XTHIN:
+                strList.append("XTHIN");
+                break;
             default:
                 strList.append(QString("%1[%2]").arg("UNKNOWN").arg(check));
             }


### PR DESCRIPTION
Currently GETUTXO is shown in the GUI even though it is not used by Bitcoin Core, but XTHIN is not. Unaware of a reason for this, so therefore this pull request.

Similar to #5876
