### PR TITLE
Verify all incoming txs unless too big or too much hashing

### DIFF
--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -67,7 +67,7 @@ bool IsStandardTx(const CTransaction& tx, std::string& reason, const bool witnes
     // almost as much to process as they cost the sender in fees, because
     // computing signature hashes is O(ninputs*txsize). Limiting transactions
     // to MAX_STANDARD_TX_SIZE mitigates CPU exhaustion attacks.
-    unsigned int sz = GetTransactionWeight(tx);
+    unsigned int sz = GetWitnessStrippedTransactionWeight(tx);
     if (sz >= MAX_STANDARD_TX_WEIGHT) {
         reason = "tx-size";
         return false;

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -30,6 +30,8 @@ static const unsigned int MAX_STANDARD_TX_SIGOPS_COST = MAX_BLOCK_SIGOPS_COST/5;
 static const unsigned int DEFAULT_MAX_MEMPOOL_SIZE = 300;
 /** Default for -bytespersigop */
 static const unsigned int DEFAULT_BYTES_PER_SIGOP = 20;
+/** Maximum amount of estimated hashing in base CHECKSIG operations */
+static const unsigned int MAX_STANDARD_TX_SIGOPS_HASHING = 10000000;
 /**
  * Standard script verification flags that standard transactions will comply
  * with. However scripts violating these flags may still be present in valid

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -153,3 +153,8 @@ int64_t GetTransactionWeight(const CTransaction& tx)
 {
     return ::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION | SERIALIZE_TRANSACTION_NO_WITNESS) * (WITNESS_SCALE_FACTOR -1) + ::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION);
 }
+
+int64_t GetWitnessStrippedTransactionWeight(const CTransaction& tx)
+{
+    return ::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION | SERIALIZE_TRANSACTION_NO_WITNESS) * WITNESS_SCALE_FACTOR;
+}

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -464,4 +464,7 @@ struct CMutableTransaction
 /** Compute the weight of a transaction, as defined by BIP 141 */
 int64_t GetTransactionWeight(const CTransaction &tx);
 
+// Compute the weight of a transaction without witness
+int64_t GetWitnessStrippedTransactionWeight(const CTransaction &tx);
+
 #endif // BITCOIN_PRIMITIVES_TRANSACTION_H


### PR DESCRIPTION
1. IsStandardTx now checks the witness stripped size, instead of transaction weight with witness size counted. Due to the ability of relay node to malleate witness, checking the tx weight with witness is not reliable before the witness is actually verified.
2. Script verification is done before all the resources limit policy checking. Relay nodes trying to malleate witness will be banned. We don't do this if the witness stripped size is >100kB, otherwise we have problems with O(n^2) hashing
3. The tx weight with witness is checked after we have confirmed that the witness is valid.

This should obsolete #8499 
