### PR TITLE
[Wallet] Ensure <0.13 clients can't open HD wallets

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3332,6 +3332,9 @@ bool CWallet::InitLoadWallet()
             CPubKey masterPubKey = walletInstance->GenerateNewHDMasterKey();
             if (!walletInstance->SetHDMasterKey(masterPubKey))
                 throw std::runtime_error(std::string(__func__) + ": Storing master key failed");
+
+            // ensure this wallet.dat can only be opened by clients supporting HD
+            walletInstance->SetMinVersion(FEATURE_HD);
         }
         CPubKey newDefaultKey;
         if (walletInstance->GetKeyFromPool(newDefaultKey)) {


### PR DESCRIPTION
This commit developed by Jonas Schnelli appears to be in 0.13 but isn't in the master branch. Isn't this functionality also needed in 0.14 onwards?

I suspect this should either be in master (as it is in 0.13), or it got somehow left in 0.13 by mistake (e.g. was supposed to be removed by #8378).
