### PR TITLE
Move code from VERACK to VERSION (since VERACK is not requied)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5051,20 +5051,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         int64_t nTimeOffset = nTime - GetTime();
         pfrom->nTimeOffset = nTimeOffset;
         AddTimeData(pfrom->addr, nTimeOffset);
-    }
 
-
-    else if (pfrom->nVersion == 0)
-    {
-        // Must have a version message before anything else
-        LOCK(cs_main);
-        Misbehaving(pfrom->GetId(), 1);
-        return false;
-    }
-
-
-    else if (strCommand == NetMsgType::VERACK)
-    {
         pfrom->SetRecvVersion(min(pfrom->nVersion, PROTOCOL_VERSION));
 
         // Mark this node as currently connected, so we update its timestamp later.
@@ -5090,6 +5077,20 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
             uint64_t nCMPCTBLOCKVersion = 1;
             pfrom->PushMessage(NetMsgType::SENDCMPCT, fAnnounceUsingCMPCTBLOCK, nCMPCTBLOCKVersion);
         }
+
+    }
+
+
+    else if (pfrom->nVersion == 0)
+    {
+        // Must have a version message before anything else
+        LOCK(cs_main);
+        Misbehaving(pfrom->GetId(), 1);
+        return false;
+    }
+
+
+    else if (strCommand == NetMsgType::VERACK) {
     }
 
 


### PR DESCRIPTION
Inspired by #8569 

Currently it's possible for a node to not send a VERACK and the only impact of this is that the code within VERACK will not be run, which is not desired behaviour.

The code behind VERACK ought to be just that - code that needs a verack to run. It may be that a variable be set which would avoid a disconnect after a certain time, for example, but so far this has never been implemented so effectively VERACKs have never been required for a connection to remain connected. The code should perhaps reflect this.
