### PR TITLE
Fix displaying of invalid and non-minimal small pushes as numbers

### DIFF
--- a/src/core_write.cpp
+++ b/src/core_write.cpp
@@ -87,8 +87,28 @@ string ScriptToAsmStr(const CScript& script, const bool fAttemptSighashDecode)
             return str;
         }
         if (0 <= opcode && opcode <= OP_PUSHDATA4) {
+            //! if vch can't be encoded correctly as a number, treat it as hex data.
             if (vch.size() <= static_cast<vector<unsigned char>::size_type>(4)) {
-                str += strprintf("%d", CScriptNum(vch, false).getint());
+                try {
+                    ///
+                    /// an invalid script like "0x01 {0x81,0x01,0x02,..0x10}"
+                    /// will pass the assignment below so we have to check for
+                    /// the validity of the push. (see CheckMinimalPush)
+                    ///
+                    int num = CScriptNum(vch, true).getint();
+                    if (!(opcode == 1 && (-1 <= num && num <= 16))) {
+                        str += strprintf("%d", num);
+                    } else {
+                        str += "[error]";
+                        return str;
+                    }
+                ///
+                /// any push of 0 to 4 bytes that is not a correctly encoded
+                /// number will be displayed as a push of the hex data itself
+                ///
+                } catch (const std::runtime_error& e) {
+                    str += HexStr(vch);
+                }
             } else {
                 // the IsUnspendable check makes sure not to try to decode OP_RETURN data that may match the format of a signature
                 if (fAttemptSighashDecode && !script.IsUnspendable()) {

--- a/src/core_write.cpp
+++ b/src/core_write.cpp
@@ -87,6 +87,20 @@ string ScriptToAsmStr(const CScript& script, const bool fAttemptSighashDecode)
             return str;
         }
         if (0 <= opcode && opcode <= OP_PUSHDATA4) {
+            ///
+            /// we find big push opcodes that are incorrectly applied to small data 
+            /// by creating a temporary script that pushes the data correctly, then
+            /// checking if our own push opcode matches the one in the temporary script
+            ///
+            if (OP_PUSHDATA1 <= opcode && opcode <= OP_PUSHDATA4) {
+                CScript pushvch = CScript() << vch;
+                if (!pushvch.Find(opcode)) {
+                    str += "[error]";
+                    pushvch.clear();
+                    return str;
+                    }
+                pushvch.clear();
+            }
             //! if vch can't be encoded correctly as a number, treat it as hex data.
             if (vch.size() <= static_cast<vector<unsigned char>::size_type>(4)) {
                 try {

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -1228,6 +1228,54 @@ BOOST_AUTO_TEST_CASE(script_GetScriptAsm)
     BOOST_CHECK_EQUAL(derSig + "81 " + pubKey, ScriptToAsmStr(CScript() << ToByteVector(ParseHex(derSig + "81")) << vchPubKey));
     BOOST_CHECK_EQUAL(derSig + "82 " + pubKey, ScriptToAsmStr(CScript() << ToByteVector(ParseHex(derSig + "82")) << vchPubKey));
     BOOST_CHECK_EQUAL(derSig + "83 " + pubKey, ScriptToAsmStr(CScript() << ToByteVector(ParseHex(derSig + "83")) << vchPubKey));
+
+    BOOST_CHECK_EQUAL("2", ScriptToAsmStr(CScript() << OP_2));
+    BOOST_CHECK_EQUAL("82",  ScriptToAsmStr(CScript() << ToByteVector(ParseHex("52"))));
+    BOOST_CHECK_EQUAL("5200", ScriptToAsmStr(CScript() << ToByteVector(ParseHex("5200"))));
+    BOOST_CHECK_EQUAL("520000", ScriptToAsmStr(CScript() << ToByteVector(ParseHex("520000"))));
+    BOOST_CHECK_EQUAL("52000000", ScriptToAsmStr(CScript() << ToByteVector(ParseHex("52000000"))));
+    BOOST_CHECK_EQUAL("5200000000", ScriptToAsmStr(CScript() << ToByteVector(ParseHex("5200000000"))));
+
+    BOOST_CHECK_EQUAL("[error]", ScriptToAsmStr(CScript() << ToByteVector(ParseHex("81")) << OP_0));
+    BOOST_CHECK_EQUAL("-1 0", ScriptToAsmStr(CScript() << OP_1NEGATE << OP_0));
+    BOOST_CHECK_EQUAL("[error]", ScriptToAsmStr(CScript() << ToByteVector(ParseHex("01")) << OP_0));
+    BOOST_CHECK_EQUAL("1 0", ScriptToAsmStr(CScript() << OP_1 << OP_0));
+    BOOST_CHECK_EQUAL("[error]", ScriptToAsmStr(CScript() << ToByteVector(ParseHex("02")) << OP_0));
+    BOOST_CHECK_EQUAL("2 0", ScriptToAsmStr(CScript() << OP_2 << OP_0));
+    BOOST_CHECK_EQUAL("[error]", ScriptToAsmStr(CScript() << ToByteVector(ParseHex("03")) << OP_0));
+    BOOST_CHECK_EQUAL("3 0", ScriptToAsmStr(CScript() << OP_3 << OP_0));
+    BOOST_CHECK_EQUAL("[error]", ScriptToAsmStr(CScript() << ToByteVector(ParseHex("04")) << OP_0));
+    BOOST_CHECK_EQUAL("4 0", ScriptToAsmStr(CScript() << OP_4 << OP_0));
+    BOOST_CHECK_EQUAL("[error]", ScriptToAsmStr(CScript() << ToByteVector(ParseHex("05")) << OP_0));
+    BOOST_CHECK_EQUAL("5 0", ScriptToAsmStr(CScript() << OP_5 << OP_0));
+    BOOST_CHECK_EQUAL("[error]", ScriptToAsmStr(CScript() << ToByteVector(ParseHex("06")) << OP_0));
+    BOOST_CHECK_EQUAL("6 0", ScriptToAsmStr(CScript() << OP_6 << OP_0));
+    BOOST_CHECK_EQUAL("[error]", ScriptToAsmStr(CScript() << ToByteVector(ParseHex("07")) << OP_0));
+    BOOST_CHECK_EQUAL("7 0", ScriptToAsmStr(CScript() << OP_7 << OP_0));
+    BOOST_CHECK_EQUAL("[error]", ScriptToAsmStr(CScript() << ToByteVector(ParseHex("08")) << OP_0));
+    BOOST_CHECK_EQUAL("8 0", ScriptToAsmStr(CScript() << OP_8 << OP_0));
+    BOOST_CHECK_EQUAL("[error]", ScriptToAsmStr(CScript() << ToByteVector(ParseHex("09")) << OP_0));
+    BOOST_CHECK_EQUAL("9 0", ScriptToAsmStr(CScript() << OP_9 << OP_0));
+    BOOST_CHECK_EQUAL("[error]", ScriptToAsmStr(CScript() << ToByteVector(ParseHex("0A")) << OP_0));
+    BOOST_CHECK_EQUAL("10 0", ScriptToAsmStr(CScript() << OP_10 << OP_0));
+    BOOST_CHECK_EQUAL("[error]", ScriptToAsmStr(CScript() << ToByteVector(ParseHex("0B")) << OP_0));
+    BOOST_CHECK_EQUAL("11 0", ScriptToAsmStr(CScript() << OP_11 << OP_0));
+    BOOST_CHECK_EQUAL("[error]", ScriptToAsmStr(CScript() << ToByteVector(ParseHex("0C")) << OP_0));
+    BOOST_CHECK_EQUAL("12 0", ScriptToAsmStr(CScript() << OP_12 << OP_0));
+    BOOST_CHECK_EQUAL("[error]", ScriptToAsmStr(CScript() << ToByteVector(ParseHex("0D")) << OP_0));
+    BOOST_CHECK_EQUAL("13 0", ScriptToAsmStr(CScript() << OP_13 << OP_0));
+    BOOST_CHECK_EQUAL("[error]", ScriptToAsmStr(CScript() << ToByteVector(ParseHex("0E")) << OP_0));
+    BOOST_CHECK_EQUAL("14 0", ScriptToAsmStr(CScript() << OP_14 << OP_0));
+    BOOST_CHECK_EQUAL("[error]", ScriptToAsmStr(CScript() << ToByteVector(ParseHex("0F")) << OP_0));
+    BOOST_CHECK_EQUAL("15 0", ScriptToAsmStr(CScript() << OP_15 << OP_0));
+    BOOST_CHECK_EQUAL("[error]", ScriptToAsmStr(CScript() << ToByteVector(ParseHex("10")) << OP_0));
+    BOOST_CHECK_EQUAL("16 0", ScriptToAsmStr(CScript() << OP_16 << OP_0));
+
+    string hashEmpty("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+    string hashZero("6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d");
+
+    BOOST_CHECK_EQUAL("0 OP_SHA256 " + hashEmpty + " OP_EQUAL", ScriptToAsmStr(CScript() << OP_0 << OP_SHA256 << ToByteVector(ParseHex(hashEmpty)) << OP_EQUAL));
+    BOOST_CHECK_EQUAL("00 OP_SHA256 " + hashZero + " OP_EQUAL", ScriptToAsmStr(CScript() << ToByteVector(ParseHex("00")) << OP_SHA256 << ToByteVector(ParseHex(hashZero)) << OP_EQUAL));
 }
 
 static CScript


### PR DESCRIPTION
Currently, commands like `decodescript` that return an assembly representation of the script will show seemingly valid integers for a number of incorrectly pushed int values of sizes 0 to 4. The purpose of this change is to allow `ScriptToAsmStr` to return a more accurate representation of the assembly.

In addition, `ScriptToAsmStr` will not fail on what are considered invalid pushes altogether. This change will make `ScriptToAsmStr` return an '[error]' string, much like other invalid pushes.

I believe this makes more sense when displaying decoded script.
As opposed to showing the valid representation of an int for an incorrectly pushed value, the value is returned either as a number if both the push is minimal and the encoding is correct, or as hex if the push is not minimal.  Invalid pushes are shown as '[error]' and end the decoding.

Examples:

Here the first two pushes are valid numbers.  The rest are shown as hex data. 

```
$ for i in 52 0152 025200 03520000 0452000000 055200000000; do echo "hex script: ${i}"; bitcoin-cli decodescript ${i} | grep asm; done

hex script: 52
  "asm": "2",
hex script: 0152
  "asm": "82",
hex script: 025200
  "asm": "5200",
hex script: 03520000
  "asm": "520000",
hex script: 0452000000
  "asm": "52000000",
hex script: 055200000000
  "asm": "5200000000",
```

Pushing -1,[1,16] incorrectly, after and before the patch.

```
$ for i in 81 {01..09} 0A 0B 0C 0D 0E 0F 10; do echo "hex script: 01${i}"; bitcoin-cli decodescript 01${i} | grep asm; done

After:                             Before:

hex script: 0181                   hex script: 0181
  "asm": "[error]",                     "asm": "-1",
hex script: 0101                   hex script: 0101
  "asm": "[error]",                     "asm": "1",
hex script: 0102                   hex script: 0102
  "asm": "[error]",                     "asm": "2",
hex script: 0103                   hex script: 0103
  "asm": "[error]",                     "asm": "3",
hex script: 0104                   hex script: 0104
  "asm": "[error]",                     "asm": "4",
hex script: 0105                   hex script: 0105
  "asm": "[error]",                     "asm": "5",
hex script: 0106                   hex script: 0106
  "asm": "[error]",                     "asm": "6",
hex script: 0107                   hex script: 0107
  "asm": "[error]",                     "asm": "7",
hex script: 0108                   hex script: 0108
  "asm": "[error]",                     "asm": "8",
hex script: 0109                   hex script: 0109
  "asm": "[error]",                     "asm": "9",
hex script: 010A                   hex script: 010A
  "asm": "[error]",                     "asm": "10",
hex script: 010B                   hex script: 010B
  "asm": "[error]",                     "asm": "11",
hex script: 010C                   hex script: 010C
  "asm": "[error]",                     "asm": "12",
hex script: 010D                   hex script: 010D
  "asm": "[error]",                     "asm": "13",
hex script: 010E                   hex script: 010E
  "asm": "[error]",                     "asm": "14",
hex script: 010F                   hex script: 010F
  "asm": "[error]",                     "asm": "15",
hex script: 0110                   hex script: 0110
  "asm": "[error]",                     "asm": "16",
```

Actual example of how '0' and '0x00' are different.  Both pushes are currently shown as '0'. After the patch, the first will be shown as '0' and the second as '00', making the distinction more obvious.

```
$ bitcoin-cli decodescript 00A820E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B85587 | grep asm

  "asm": "0 OP_SHA256 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 OP_EQUAL",

$ bitcoin-cli signrawtransaction \
0100000001aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa00000000252400a820e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b85587ffffffff0100000000000000001976a914bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb88ac00000000 \
'[{"txid":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","vout":0,"scriptPubKey":"A914D227B69A4FE6FED60B20CFC31AED65027CF3DAC287","redeemScript":"00A820E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B85587","amount":0}]'

...
  "complete": true
```

vs

```
bitcoin-cli decodescript 0100A8206E340B9CFFB37A989CA544E6BB780A2C78901D3FB33738768511A30617AFA01D87 | grep asm

  "asm": "0 OP_SHA256 6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d OP_EQUAL",

bitcoin-cli signrawtransaction \
0100000001aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0000000026250100a8206e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d87ffffffff0100000000000000001976a914bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb88ac00000000 \
'[{"txid":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","vout":0,"scriptPubKey":"A914CF527A41C9908B23B16F854A15F2B4ECB18D8A7187","redeemScript":"0100A8206E340B9CFFB37A989CA544E6BB780A2C78901D3FB33738768511A30617AFA01D87","amount":0}]'

...
  "complete": true
```
