### PR TITLE
[0.13.1]: Backport [wallet] rpc: Drop misleading option

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -41,7 +41,15 @@ Notable changes
 Example item
 --------------
 
-0.13.0 Change log
+Low-level RPC changes
+---------------------
+
+- `importprunedfunds` only accepts two required arguments. Some versions accept
+  an optional third arg, which was always ignored. Make sure to never pass more
+  than two arguments.
+
+
+0.13.1 Change log
 =================
 
 Detailed release notes follow. This overview includes changes that affect

--- a/qa/rpc-tests/importprunedfunds.py
+++ b/qa/rpc-tests/importprunedfunds.py
@@ -20,14 +20,10 @@ class ImportPrunedFundsTest(BitcoinTestFramework):
         self.is_network_split=False
         self.sync_all()
 
-    def run_test (self):
-        import time
-        begintime = int(time.time())
-
+    def run_test(self):
         print("Mining blocks...")
         self.nodes[0].generate(101)
 
-        # sync
         self.sync_all()
         
         # address
@@ -72,7 +68,6 @@ class ImportPrunedFundsTest(BitcoinTestFramework):
         rawtxn2 = self.nodes[0].gettransaction(txnid2)['hex']
         proof2 = self.nodes[0].gettxoutproof([txnid2])
 
-
         txnid3 = self.nodes[0].sendtoaddress(address3, 0.025)
         self.nodes[0].generate(1)
         rawtxn3 = self.nodes[0].gettransaction(txnid3)['hex']
@@ -82,28 +77,27 @@ class ImportPrunedFundsTest(BitcoinTestFramework):
 
         #Import with no affiliated address
         try:
-            result1 = self.nodes[1].importprunedfunds(rawtxn1, proof1, "")
+            self.nodes[1].importprunedfunds(rawtxn1, proof1)
         except JSONRPCException as e:
             assert('No addresses' in e.error['message'])
         else:
             assert(False)
 
-
         balance1 = self.nodes[1].getbalance("", 0, True)
         assert_equal(balance1, Decimal(0))
 
         #Import with affiliated address with no rescan
-        self.nodes[1].importaddress(address2, "", False)
-        result2 = self.nodes[1].importprunedfunds(rawtxn2, proof2, "")
-        balance2 = Decimal(self.nodes[1].getbalance("", 0, True))
+        self.nodes[1].importaddress(address2, "add2", False)
+        result2 = self.nodes[1].importprunedfunds(rawtxn2, proof2)
+        balance2 = self.nodes[1].getbalance("add2", 0, True)
         assert_equal(balance2, Decimal('0.05'))
 
         #Import with private key with no rescan
-        self.nodes[1].importprivkey(address3_privkey, "", False)
-        result3 = self.nodes[1].importprunedfunds(rawtxn3, proof3, "")
-        balance3 = Decimal(self.nodes[1].getbalance("", 0, False))
+        self.nodes[1].importprivkey(address3_privkey, "add3", False)
+        result3 = self.nodes[1].importprunedfunds(rawtxn3, proof3)
+        balance3 = self.nodes[1].getbalance("add3", 0, False)
         assert_equal(balance3, Decimal('0.025'))
-        balance3 = Decimal(self.nodes[1].getbalance("", 0, True))
+        balance3 = self.nodes[1].getbalance("*", 0, True)
         assert_equal(balance3, Decimal('0.075'))
 
         #Addresses Test - after import
@@ -118,7 +112,6 @@ class ImportPrunedFundsTest(BitcoinTestFramework):
         assert_equal(address_info['ismine'], True)
 
         #Remove transactions
-
         try:
             self.nodes[1].removeprunedfunds(txnid1)
         except JSONRPCException as e:
@@ -126,18 +119,16 @@ class ImportPrunedFundsTest(BitcoinTestFramework):
         else:
             assert(False)
 
-
-        balance1 = Decimal(self.nodes[1].getbalance("", 0, True))
+        balance1 = self.nodes[1].getbalance("*", 0, True)
         assert_equal(balance1, Decimal('0.075'))
 
-
         self.nodes[1].removeprunedfunds(txnid2)
-        balance2 = Decimal(self.nodes[1].getbalance("", 0, True))
+        balance2 = self.nodes[1].getbalance("*", 0, True)
         assert_equal(balance2, Decimal('0.025'))
 
         self.nodes[1].removeprunedfunds(txnid3)
-        balance3 = Decimal(self.nodes[1].getbalance("", 0, True))
+        balance3 = self.nodes[1].getbalance("*", 0, True)
         assert_equal(balance3, Decimal('0.0'))
 
 if __name__ == '__main__':
-    ImportPrunedFundsTest ().main ()
+    ImportPrunedFundsTest().main()

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -257,6 +257,7 @@ UniValue importprunedfunds(const UniValue& params, bool fHelp)
     if (!EnsureWalletIsAvailable(fHelp))
         return NullUniValue;
 
+    // 0.13.x: Silently accept up to 3 params, but ignore the third:
     if (fHelp || params.size() < 2 || params.size() > 3)
         throw runtime_error(
             "importprunedfunds\n"
@@ -264,7 +265,6 @@ UniValue importprunedfunds(const UniValue& params, bool fHelp)
             "\nArguments:\n"
             "1. \"rawtransaction\" (string, required) A raw transaction in hex funding an already-existing address in wallet\n"
             "2. \"txoutproof\"     (string, required) The hex output from gettxoutproof that contains the transaction\n"
-            "3. \"label\"          (string, optional) An optional label\n"
         );
 
     CTransaction tx;
@@ -276,10 +276,6 @@ UniValue importprunedfunds(const UniValue& params, bool fHelp)
     CDataStream ssMB(ParseHexV(params[1], "proof"), SER_NETWORK, PROTOCOL_VERSION);
     CMerkleBlock merkleBlock;
     ssMB >> merkleBlock;
-
-    string strLabel = "";
-    if (params.size() == 3)
-        strLabel = params[2].get_str();
 
     //Search partial merkle tree in proof for our transaction and index in valid block
     vector<uint256> vMatch;


### PR DESCRIPTION
Backport which does not break the interface when switching from 0.13.0 to 0.13.1.

Github-Pull: #8581
Rebased-From: fab5ecb7719063aa72751df1258dfa4cf4a9a4a9
