### PR TITLE
build,doc: Update for 0.13.0+ and OpenBSD 5.9

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -66,7 +66,8 @@ AC_PATH_TOOL(RANLIB, ranlib)
 AC_PATH_TOOL(STRIP, strip)
 AC_PATH_TOOL(GCOV, gcov)
 AC_PATH_PROG(LCOV, lcov)
-AC_PATH_PROGS([PYTHON], [python3 python2.7 python2 python])
+dnl Python 3.x is supported from 3.4 on (see https://github.com/bitcoin/bitcoin/issues/7893)
+AC_PATH_PROGS([PYTHON], [python3.6 python3.5 python3.4 python3 python2.7 python2 python])
 AC_PATH_PROG(GENHTML, genhtml)
 AC_PATH_PROG([GIT], [git])
 AC_PATH_PROG(CCACHE,ccache)
@@ -355,8 +356,15 @@ case $host in
      TARGET_OS=linux
      LEVELDB_TARGET_FLAGS="-DOS_LINUX"
      ;;
+   *freebsd*)
+     LEVELDB_TARGET_FLAGS="-DOS_FREEBSD"
+     ;;
+   *openbsd*)
+     LEVELDB_TARGET_FLAGS="-DOS_OPENBSD"
+     ;;
    *)
      OTHER_OS=`echo ${host_os} | awk '{print toupper($0)}'`
+     AC_MSG_WARN([Guessing LevelDB OS as OS_${OTHER_OS}, please check whether this is correct, if not add an entry to configure.ac.])
      LEVELDB_TARGET_FLAGS="-DOS_${OTHER_OS}"
      ;;
 esac


### PR DESCRIPTION
Build:
- LevelDB platform was not guessed correctly (it ended up defining `-DOS_OPENBSD59` instead of `-DOS_OPENBSD`). This has been fixed by adding explicit checks for OpenBSD and FreeBSD.
- On OpenBSD there is no convenience link from `python3.5` to `python3`: add detection for other python interpreter names.
- If it has to guess the LevelDB OS, print a autoconf warning so that the user can check.

Changes to `build-openbsd.md`:
- Python 3 now supported.
- Bump boost version to 1.61 - one boost patch no longer needed.
- All checked with OpenBSD 5.9, except for the clang part, I left this as-is for someone adventurous.
- Mention overriding resource limits, OpenBSD's default ulimit does not  suffice for building Bitcoin Core with gcc 4.9.3.
