### PR TITLE
[WIP] Erase orphans only when banned

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -362,7 +362,8 @@ void FinalizeNode(NodeId nodeid) {
     BOOST_FOREACH(const QueuedBlock& entry, state->vBlocksInFlight) {
         mapBlocksInFlight.erase(entry.hash);
     }
-    EraseOrphansFor(nodeid);
+    if (state->fShouldBan)
+        EraseOrphansFor(nodeid);
     nPreferredDownload -= state->fPreferredDownload;
     nPeersWithValidatedDownloads -= (state->nBlocksInFlightValidHeaders != 0);
     assert(nPeersWithValidatedDownloads >= 0);
@@ -6387,7 +6388,6 @@ bool SendMessages(CNode* pto)
                     CNode::Ban(pto->addr, BanReasonNodeMisbehaving);
                 }
             }
-            state.fShouldBan = false;
         }
 
         BOOST_FOREACH(const CBlockReject& reject, state.rejects)


### PR DESCRIPTION
This pull refines the excellent insightful contributions of @gavinandresen in c74332c67806ed92e6e18de174671a7c30608780

Denial of service logic might possibly have been a little harsh and was written before compact/thin block technology was incorporated into the code.

Only remove orphans from mempool from nodes that were misbehaving. This will allow for more efficient compact/thin block downloads.

Thank you for your consideration of this code.

WIP is it requires further testing - e.g. what happens if a node dumps a bunch of invalid orphans and then disconnects - the code still needs to keep track of the disconnected node's misbehaviour...! (EraseOrphan code perhaps moving from FinalizeNode to the point where it is banned...?)
