### PR TITLE
chainparams: Added parametric halving interval for regtest-only mode

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -168,6 +168,7 @@ testScriptsExt = [
     'maxuploadtarget.py',
     'replace-by-fee.py',
     'p2p-feefilter.py',
+    'rewardhalving.py',
     'pruning.py', # leave pruning last as it takes a REALLY long time
 ]
 

--- a/qa/rpc-tests/rewardhalving.py
+++ b/qa/rpc-tests/rewardhalving.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2016 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+# Test for -halvinginterval
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+
+
+class RewardHalvingTest(BitcoinTestFramework):
+    def __init__(self):
+        super().__init__()
+        self.nodes = list()
+        self.setup_clean_chain = True
+        self.is_network_split = False
+
+    def setup_network(self):
+        self.nodes.append(start_node(0, self.options.tmpdir))
+        self.nodes.append(start_node(1, self.options.tmpdir, ['-halvinginterval=1']))
+        self.nodes.append(start_node(2, self.options.tmpdir, ['-halvinginterval=50']))
+        self.nodes.append(start_node(3, self.options.tmpdir, ['-halvinginterval=100']))
+        self.sync_all()
+
+    def _default_halving_interval(self):
+        node = self.nodes[0]
+        assert_equal(node.getbalance(), 0)
+        node.generate(100)
+        assert_equal(node.getbalance(), 0)
+        node.generate(1)
+        assert_equal(node.getbalance(), 50)
+        node.generate(1)
+        assert_equal(node.getbalance(), 100)
+        node.generate(198)
+        assert_equal(node.getbalance(), 8725)
+        node.generate(1)
+        assert_equal(node.getbalance(), 8750)
+        node.generate(1)
+        assert_equal(node.getbalance(), 8775)
+
+    def _one_halving_interval(self):
+        node = self.nodes[1]
+        assert_equal(node.getbalance(), 0)
+        node.generate(100)
+        assert_equal(node.getbalance(), 0)
+        node.generate(1)
+        assert_equal(node.getbalance(), 25)
+        node.generate(1)
+        assert_equal(node.getbalance(), 37.5)
+        node.generate(1)
+        assert_equal(node.getbalance(), 43.75)
+
+    def _fifty_halving_interval(self):
+        node = self.nodes[2]
+        assert_equal(node.getbalance(), 0)
+        node.generate(100)
+        assert_equal(node.getbalance(), 0)
+        node.generate(1)
+        assert_equal(node.getbalance(), 50)
+        node.generate(1)
+        assert_equal(node.getbalance(), 100)
+        node.generate(48)
+        assert_equal(node.getbalance(), 2475)
+        node.generate(1)
+        assert_equal(node.getbalance(), 2500)
+        node.generate(1)
+        assert_equal(node.getbalance(), 2525)
+
+    def _onehundred_halving_interval(self):
+        node = self.nodes[3]
+        assert_equal(node.getbalance(), 0)
+        node.generate(100)
+        assert_equal(node.getbalance(), 0)
+        node.generate(1)
+        assert_equal(node.getbalance(), 50)
+        node.generate(1)
+        assert_equal(node.getbalance(), 100)
+        node.generate(98)
+        assert_equal(node.getbalance(), 4975)
+        node.generate(1)
+        assert_equal(node.getbalance(), 5000)
+        node.generate(1)
+        assert_equal(node.getbalance(), 5025)
+
+    def run_test(self):
+        self._default_halving_interval()
+        self._one_halving_interval()
+        self._fifty_halving_interval()
+        self._onehundred_halving_interval()
+        
+
+if __name__ == '__main__':
+    RewardHalvingTest().main()

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -240,11 +240,13 @@ static CTestNetParams testNetParams;
 /**
  * Regression test
  */
+const int DEFAULT_REGTEST_HALVING_INTERVAL = 150;
+
 class CRegTestParams : public CChainParams {
 public:
     CRegTestParams() {
         strNetworkID = "regtest";
-        consensus.nSubsidyHalvingInterval = 150;
+        consensus.nSubsidyHalvingInterval = DEFAULT_REGTEST_HALVING_INTERVAL;
         consensus.BIP34Height = 100000000; // BIP34 has not activated on regtest (far in the future so block v1 are not rejected in tests)
         consensus.BIP34Hash = uint256();
         consensus.BIP65Height = 1351; // BIP65 activated on regtest (Used in rpc activation tests)
@@ -306,6 +308,11 @@ public:
         consensus.vDeployments[d].nStartTime = nStartTime;
         consensus.vDeployments[d].nTimeout = nTimeout;
     }
+
+    void UpdateSubsidyHalvingIntervalParameter(int interval)
+    {
+        consensus.nSubsidyHalvingInterval = interval;
+    }
 };
 static CRegTestParams regTestParams;
 
@@ -338,4 +345,8 @@ void UpdateRegtestBIP9Parameters(Consensus::DeploymentPos d, int64_t nStartTime,
 {
     regTestParams.UpdateBIP9Parameters(d, nStartTime, nTimeout);
 }
- 
+
+void UpdateRegtestSubsidyHalvingIntervalParameter()
+{
+    regTestParams.UpdateSubsidyHalvingIntervalParameter((int)GetArg("-halvinginterval", DEFAULT_REGTEST_HALVING_INTERVAL));
+}

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -117,4 +117,9 @@ void SelectParams(const std::string& chain);
  */
 void UpdateRegtestBIP9Parameters(Consensus::DeploymentPos d, int64_t nStartTime, int64_t nTimeout);
 
+/**
+ * Allows modifying the subsidy halving interval parameter based on configuration.
+ */
+void UpdateRegtestSubsidyHalvingIntervalParameter();
+
 #endif // BITCOIN_CHAINPARAMS_H

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -412,6 +412,7 @@ std::string HelpMessage(HelpMessageMode mode)
         strUsage += HelpMessageOpt("-limitdescendantcount=<n>", strprintf("Do not accept transactions if any ancestor would have <n> or more in-mempool descendants (default: %u)", DEFAULT_DESCENDANT_LIMIT));
         strUsage += HelpMessageOpt("-limitdescendantsize=<n>", strprintf("Do not accept transactions if any ancestor would have more than <n> kilobytes of in-mempool descendants (default: %u).", DEFAULT_DESCENDANT_SIZE_LIMIT));
         strUsage += HelpMessageOpt("-bip9params=deployment:start:end", "Use given start/end times for specified BIP9 deployment (regtest-only)");
+        strUsage += HelpMessageOpt("-halvinginterval=<n>", "Set halving interval to <n> blocks (regtest-only)");
     }
     string debugCategories = "addrman, alert, bench, coindb, db, http, libevent, lock, mempool, mempoolrej, net, proxy, prune, rand, reindex, rpc, selectcoins, tor, zmq"; // Don't translate these and qt below
     if (mode == HMM_BITCOIN_QT)
@@ -991,6 +992,9 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
         boost::split(vstrReplacementModes, strReplacementModeList, boost::is_any_of(","));
         fEnableReplacement = (std::find(vstrReplacementModes.begin(), vstrReplacementModes.end(), "fee") != vstrReplacementModes.end());
     }
+
+    // Allow overriding halving interval parameters for testing
+    UpdateRegtestSubsidyHalvingIntervalParameter();
 
     if (!mapMultiArgs["-bip9params"].empty()) {
         // Allow overriding BIP9 parameters for testing


### PR DESCRIPTION
Make halving interval parametric using configuration

In order to test all the possible scenarios that can be faced before or after an halving it can be useful to set in regtest mode the halving interval.
So I've just added a parameter (-halvinginterval) that can be passed to bitcoind daemon in regtest mode in order to override the default halving interval.
