### PR TITLE
Nuke boost::thread and boost::thread_group

### DIFF
--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -294,6 +294,8 @@ int CommandLineRPC(int argc, char *argv[])
     catch (const boost::thread_interrupted&) {
         throw;
     }
+    catch (const thread_interrupted&) {
+    }
     catch (const std::exception& e) {
         strPrint = string("error: ") + e.what();
         nRet = EXIT_FAILURE;

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -658,6 +658,8 @@ static int CommandLineRawTx(int argc, char* argv[])
     catch (const boost::thread_interrupted&) {
         throw;
     }
+    catch (const thread_interrupted&) {
+    }
     catch (const std::exception& e) {
         strPrint = string("error: ") + e.what();
         nRet = EXIT_FAILURE;

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -42,7 +42,7 @@
 
 static bool fDaemon;
 
-void WaitForShutdown(boost::thread_group* threadGroup, CScheduler& scheduler)
+void WaitForShutdown(CScheduler& scheduler)
 {
     bool fShutdown = ShutdownRequested();
     // Tell the main threads to shutdown.
@@ -51,11 +51,7 @@ void WaitForShutdown(boost::thread_group* threadGroup, CScheduler& scheduler)
         MilliSleep(200);
         fShutdown = ShutdownRequested();
     }
-    if (threadGroup)
-    {
-        Interrupt(*threadGroup, scheduler);
-        threadGroup->join_all();
-    }
+    Interrupt(scheduler);
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -64,7 +60,6 @@ void WaitForShutdown(boost::thread_group* threadGroup, CScheduler& scheduler)
 //
 bool AppInit(int argc, char* argv[])
 {
-    boost::thread_group threadGroup;
     CScheduler scheduler;
 
     bool fRet = false;
@@ -158,7 +153,7 @@ bool AppInit(int argc, char* argv[])
         // Set this early so that parameter interactions go to console
         InitLogging();
         InitParameterInteraction();
-        fRet = AppInit2(threadGroup, scheduler);
+        fRet = AppInit2(scheduler);
     }
     catch (const std::exception& e) {
         PrintExceptionContinue(&e, "AppInit()");
@@ -168,12 +163,9 @@ bool AppInit(int argc, char* argv[])
 
     if (!fRet)
     {
-        Interrupt(threadGroup, scheduler);
-        // threadGroup.join_all(); was left out intentionally here, because we didn't re-test all of
-        // the startup-failure cases to make sure they don't result in a hang due to some
-        // thread-blocking-waiting-for-another-thread-during-startup case
+        Interrupt(scheduler);
     } else {
-        WaitForShutdown(&threadGroup, scheduler);
+        WaitForShutdown(scheduler);
     }
     Shutdown(scheduler);
 

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -42,7 +42,7 @@
 
 static bool fDaemon;
 
-void WaitForShutdown(boost::thread_group* threadGroup)
+void WaitForShutdown(boost::thread_group* threadGroup, CScheduler& scheduler)
 {
     bool fShutdown = ShutdownRequested();
     // Tell the main threads to shutdown.
@@ -53,7 +53,7 @@ void WaitForShutdown(boost::thread_group* threadGroup)
     }
     if (threadGroup)
     {
-        Interrupt(*threadGroup);
+        Interrupt(*threadGroup, scheduler);
         threadGroup->join_all();
     }
 }
@@ -168,14 +168,14 @@ bool AppInit(int argc, char* argv[])
 
     if (!fRet)
     {
-        Interrupt(threadGroup);
+        Interrupt(threadGroup, scheduler);
         // threadGroup.join_all(); was left out intentionally here, because we didn't re-test all of
         // the startup-failure cases to make sure they don't result in a hang due to some
         // thread-blocking-waiting-for-another-thread-during-startup case
     } else {
-        WaitForShutdown(&threadGroup);
+        WaitForShutdown(&threadGroup, scheduler);
     }
-    Shutdown();
+    Shutdown(scheduler);
 
     return fRet;
 }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1517,7 +1517,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     if (GetBoolArg("-listenonion", DEFAULT_LISTEN_ONION))
         StartTorControl(threadGroup, scheduler);
 
-    StartNode(threadGroup, scheduler);
+    StartNode(scheduler);
 
     // ********************************************************* Step 12: finished
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1515,7 +1515,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     LogPrintf("mapBlockIndex.size() = %u\n",   mapBlockIndex.size());
     LogPrintf("nBestHeight = %d\n",                   chainActive.Height());
     if (GetBoolArg("-listenonion", DEFAULT_LISTEN_ONION))
-        StartTorControl(threadGroup, scheduler);
+        StartTorControl();
 
     StartNode(scheduler);
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -176,6 +176,7 @@ void Interrupt(boost::thread_group& threadGroup, CScheduler& scheduler)
     InterruptTorControl();
     InterruptMapPort();
     scheduler.interrupt(false);
+    InterruptNode();
     threadGroup.interrupt_all();
 }
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -176,8 +176,17 @@ void Interrupt(boost::thread_group& threadGroup, CScheduler& scheduler)
     InterruptTorControl();
     InterruptMapPort();
     scheduler.interrupt(false);
+    if(pblocktree)
+       pblocktree->InterruptLoadBlockIndexGuts();
+    InterruptNetbase();
     InterruptNode();
     threadGroup.interrupt_all();
+#ifdef ENABLE_WALLET
+    if (pwalletMain) {
+        pwalletMain->Interrupt();
+        InterruptFlushWalletDB();
+    }
+#endif
 }
 
 void Shutdown(CScheduler& scheduler)

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -171,6 +171,7 @@ void Interrupt(boost::thread_group& threadGroup)
     InterruptRPC();
     InterruptREST();
     InterruptTorControl();
+    InterruptMapPort();
     threadGroup.interrupt_all();
 }
 
@@ -199,6 +200,7 @@ void Shutdown()
 #endif
     StopNode();
     StopTorControl();
+    StopMapPort();
     UnregisterNodeSignals(GetNodeSignals());
 
     if (fFeeEstimatesInitialized)

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -549,7 +549,7 @@ static void BlockNotifyCallback(bool initialSync, const CBlockIndex *pBlockIndex
     std::string strCmd = GetArg("-blocknotify", "");
 
     boost::replace_all(strCmd, "%s", pBlockIndex->GetBlockHash().GetHex());
-    boost::thread t(runCommand, strCmd); // thread runs free
+    std::thread(runCommand, strCmd).detach(); // thread runs free
 }
 
 static void BlockNotifyGenesisWait(bool, const CBlockIndex *pBlockIndex)

--- a/src/init.h
+++ b/src/init.h
@@ -19,8 +19,8 @@ class thread_group;
 void StartShutdown();
 bool ShutdownRequested();
 /** Interrupt threads */
-void Interrupt(boost::thread_group& threadGroup);
-void Shutdown();
+void Interrupt(boost::thread_group& threadGroup, CScheduler& scheduler);
+void Shutdown(CScheduler& scheduler);
 //!Initialize the logging infrastructure
 void InitLogging();
 //!Parameter interaction: change current parameters depending on various rules

--- a/src/init.h
+++ b/src/init.h
@@ -11,21 +11,16 @@
 class CScheduler;
 class CWallet;
 
-namespace boost
-{
-class thread_group;
-} // namespace boost
-
 void StartShutdown();
 bool ShutdownRequested();
 /** Interrupt threads */
-void Interrupt(boost::thread_group& threadGroup, CScheduler& scheduler);
+void Interrupt(CScheduler& scheduler);
 void Shutdown(CScheduler& scheduler);
 //!Initialize the logging infrastructure
 void InitLogging();
 //!Parameter interaction: change current parameters depending on various rules
 void InitParameterInteraction();
-bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler);
+bool AppInit2(CScheduler& scheduler);
 
 /** The help message mode determines what help message to show */
 enum HelpMessageMode {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3020,9 +3020,7 @@ bool ActivateBestChain(CValidationState &state, const CChainParams& chainparams,
     CBlockIndex *pindexMostWork = NULL;
     CBlockIndex *pindexNewTip = NULL;
     do {
-        boost::this_thread::interruption_point();
-        if (ShutdownRequested())
-            break;
+        interruption_point(ShutdownRequested());
 
         const CBlockIndex *pindexFork;
         std::list<CTransaction> txConflicted;
@@ -3963,7 +3961,7 @@ bool static LoadBlockIndexDB()
     if (!pblocktree->LoadBlockIndexGuts(InsertBlockIndex))
         return false;
 
-    boost::this_thread::interruption_point();
+    interruption_point(ShutdownRequested());
 
     // Calculate nChainWork
     vector<pair<int, CBlockIndex*> > vSortedByHeight;
@@ -4099,7 +4097,7 @@ bool CVerifyDB::VerifyDB(const CChainParams& chainparams, CCoinsView *coinsview,
     LogPrintf("[0%%]...");
     for (CBlockIndex* pindex = chainActive.Tip(); pindex && pindex->pprev; pindex = pindex->pprev)
     {
-        boost::this_thread::interruption_point();
+        interruption_point(ShutdownRequested());
         int percentageDone = std::max(1, std::min(99, (int)(((double)(chainActive.Height() - pindex->nHeight)) / (double)nCheckDepth * (nCheckLevel >= 4 ? 50 : 100))));
         if (reportDone < percentageDone/10) {
             // report every 10% step
@@ -4153,7 +4151,7 @@ bool CVerifyDB::VerifyDB(const CChainParams& chainparams, CCoinsView *coinsview,
     if (nCheckLevel >= 4) {
         CBlockIndex *pindex = pindexState;
         while (pindex != chainActive.Tip()) {
-            boost::this_thread::interruption_point();
+            interruption_point(ShutdownRequested());
             uiInterface.ShowProgress(_("Verifying blocks..."), std::max(1, std::min(99, 100 - (int)(((double)(chainActive.Height() - pindex->nHeight)) / (double)nCheckDepth * 50))));
             pindex = chainActive.Next(pindex);
             CBlock block;
@@ -4349,7 +4347,7 @@ bool LoadExternalBlockFile(const CChainParams& chainparams, FILE* fileIn, CDiskB
         CBufferedFile blkdat(fileIn, 2*MAX_BLOCK_SERIALIZED_SIZE, MAX_BLOCK_SERIALIZED_SIZE+8, SER_DISK, CLIENT_VERSION);
         uint64_t nRewind = blkdat.GetPos();
         while (!blkdat.eof()) {
-            boost::this_thread::interruption_point();
+            interruption_point(ShutdownRequested());
 
             blkdat.SetPos(nRewind);
             nRewind++; // start one byte further next time, in case of failure
@@ -4740,7 +4738,7 @@ void static ProcessGetData(CNode* pfrom, const Consensus::Params& consensusParam
 
         const CInv &inv = *it;
         {
-            boost::this_thread::interruption_point();
+            interruption_point(ShutdownRequested());
             it++;
 
             if (inv.type == MSG_BLOCK || inv.type == MSG_FILTERED_BLOCK || inv.type == MSG_CMPCT_BLOCK || inv.type == MSG_WITNESS_BLOCK)
@@ -5122,7 +5120,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         int64_t nSince = nNow - 10 * 60;
         BOOST_FOREACH(CAddress& addr, vAddr)
         {
-            boost::this_thread::interruption_point();
+            interruption_point(ShutdownRequested());
 
             if ((addr.nServices & REQUIRED_SERVICES) != REQUIRED_SERVICES)
                 continue;
@@ -5212,7 +5210,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         {
             CInv &inv = vInv[nInv];
 
-            boost::this_thread::interruption_point();
+            interruption_point(ShutdownRequested());
 
             bool fAlreadyHave = AlreadyHave(inv);
             LogPrint("net", "got inv: %s  %s peer=%d\n", inv.ToString(), fAlreadyHave ? "have" : "new", pfrom->id);
@@ -6241,7 +6239,7 @@ bool ProcessMessages(CNode* pfrom)
         try
         {
             fRet = ProcessMessage(pfrom, strCommand, vRecv, msg.nTime, chainparams);
-            boost::this_thread::interruption_point();
+            interruption_point(ShutdownRequested());
         }
         catch (const std::ios_base::failure& e)
         {
@@ -6268,6 +6266,8 @@ bool ProcessMessages(CNode* pfrom)
         }
         catch (const boost::thread_interrupted&) {
             throw;
+        }
+        catch (const thread_interrupted&) {
         }
         catch (const std::exception& e) {
             PrintExceptionContinue(&e, "ProcessMessages()");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2243,6 +2243,11 @@ void ThreadScriptCheck() {
     scriptcheckqueue.Thread();
 }
 
+void InterruptThreadScriptCheck()
+{
+    scriptcheckqueue.Interrupt();
+};
+
 // Protected by cs_main
 VersionBitsCache versionbitscache;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -40,6 +40,7 @@
 
 #include <atomic>
 #include <sstream>
+#include <thread>
 
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/algorithm/string/join.hpp>
@@ -1746,7 +1747,7 @@ static void AlertNotify(const std::string& strMessage)
     safeStatus = singleQuote+safeStatus+singleQuote;
     boost::replace_all(strCmd, "%s", safeStatus);
 
-    boost::thread t(runCommand, strCmd); // thread runs free
+    std::thread(runCommand, strCmd).detach(); // thread runs free
 }
 
 void CheckForkWarningConditions()

--- a/src/main.h
+++ b/src/main.h
@@ -249,6 +249,8 @@ bool ProcessMessages(CNode* pfrom);
 bool SendMessages(CNode* pto);
 /** Run an instance of the script checking thread */
 void ThreadScriptCheck();
+/** Interrupt all script checking threads once they're out of work */
+void InterruptThreadScriptCheck();
 /** Check whether we are doing an initial block download (synchronizing from disk or network) */
 bool IsInitialBlockDownload();
 /** Format a string that describes several potential problems detected by the core.

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1232,7 +1232,7 @@ void ThreadSocketHandler()
 
         int nSelect = select(have_fds ? hSocketMax + 1 : 0,
                              &fdsetRecv, &fdsetSend, &fdsetError, &timeout);
-        boost::this_thread::interruption_point();
+        interruption_point(net_interrupted);
 
         if (nSelect == SOCKET_ERROR)
         {
@@ -1271,7 +1271,7 @@ void ThreadSocketHandler()
         }
         BOOST_FOREACH(CNode* pnode, vNodesCopy)
         {
-            boost::this_thread::interruption_point();
+            interruption_point(net_interrupted);
 
             //
             // Receive
@@ -1674,7 +1674,7 @@ void ThreadOpenConnections()
         MilliSleep(500);
 
         CSemaphoreGrant grant(*semOutbound);
-        boost::this_thread::interruption_point();
+        interruption_point(net_interrupted);
 
         // Add seed nodes if DNS seeds are all down (an infrastructure attack?).
         if (addrman.size() == 0 && (GetTime() - nStart > 60)) {
@@ -1868,7 +1868,7 @@ bool OpenNetworkConnection(const CAddress& addrConnect, bool fCountFailure, CSem
     //
     // Initiate outbound network connection
     //
-    boost::this_thread::interruption_point();
+    interruption_point(net_interrupted);
     if (!pszDest) {
         if (IsLocal(addrConnect) ||
             FindNode((CNetAddr)addrConnect) || CNode::IsBanned(addrConnect) ||
@@ -1878,7 +1878,7 @@ bool OpenNetworkConnection(const CAddress& addrConnect, bool fCountFailure, CSem
         return false;
 
     CNode* pnode = ConnectNode(addrConnect, pszDest, fCountFailure);
-    boost::this_thread::interruption_point();
+    interruption_point(net_interrupted);
 
     if (!pnode)
         return false;
@@ -1934,7 +1934,7 @@ void ThreadMessageHandler()
                     }
                 }
             }
-            boost::this_thread::interruption_point();
+            interruption_point(net_interrupted);
 
             // Send messages
             {
@@ -1942,7 +1942,7 @@ void ThreadMessageHandler()
                 if (lockSend)
                     GetNodeSignals().SendMessages(pnode);
             }
-            boost::this_thread::interruption_point();
+            interruption_point(net_interrupted);
         }
 
         {

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1115,7 +1115,7 @@ static void AcceptConnection(const ListenSocket& hListenSocket) {
 void ThreadSocketHandler()
 {
     unsigned int nPrevNodeCount = 0;
-    while (true)
+    while (!net_interrupted)
     {
         //
         // Disconnect nodes
@@ -1246,7 +1246,8 @@ void ThreadSocketHandler()
 
         int nSelect = select(have_fds ? hSocketMax + 1 : 0,
                              &fdsetRecv, &fdsetSend, &fdsetError, &timeout);
-        interruption_point(net_interrupted);
+        if(net_interrupted)
+            break;
 
         if (nSelect == SOCKET_ERROR)
         {
@@ -1285,7 +1286,8 @@ void ThreadSocketHandler()
         }
         BOOST_FOREACH(CNode* pnode, vNodesCopy)
         {
-            interruption_point(net_interrupted);
+            if(net_interrupted)
+                break;
 
             //
             // Receive
@@ -1688,7 +1690,8 @@ void ThreadOpenConnections()
         InterruptibleSleep(500);
 
         CSemaphoreGrant grant(*semOutbound);
-        interruption_point(net_interrupted);
+        if(net_interrupted)
+            break;
 
         // Add seed nodes if DNS seeds are all down (an infrastructure attack?).
         if (addrman.size() == 0 && (GetTime() - nStart > 60)) {
@@ -1913,7 +1916,7 @@ void ThreadMessageHandler()
     std::mutex condition_mutex;
     std::unique_lock<std::mutex> lock(condition_mutex);
 
-    while (true)
+    while (!net_interrupted)
     {
         std::vector<CNode*> vNodesCopy;
         {
@@ -1948,7 +1951,8 @@ void ThreadMessageHandler()
                     }
                 }
             }
-            interruption_point(net_interrupted);
+            if(net_interrupted)
+                break;
 
             // Send messages
             {
@@ -1956,7 +1960,8 @@ void ThreadMessageHandler()
                 if (lockSend)
                     GetNodeSignals().SendMessages(pnode);
             }
-            interruption_point(net_interrupted);
+            if(net_interrupted)
+                break;
         }
 
         {

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -114,7 +114,7 @@ NodeId nLastNodeId = 0;
 CCriticalSection cs_nLastNodeId;
 
 static CSemaphore *semOutbound = NULL;
-boost::condition_variable messageHandlerCondition;
+std::condition_variable messageHandlerCondition;
 
 // Signals for message handling
 static CNodeSignals g_signals;
@@ -1910,8 +1910,8 @@ bool OpenNetworkConnection(const CAddress& addrConnect, bool fCountFailure, CSem
 
 void ThreadMessageHandler()
 {
-    boost::mutex condition_mutex;
-    boost::unique_lock<boost::mutex> lock(condition_mutex);
+    std::mutex condition_mutex;
+    std::unique_lock<std::mutex> lock(condition_mutex);
 
     while (true)
     {
@@ -1966,7 +1966,7 @@ void ThreadMessageHandler()
         }
 
         if (fSleep)
-            messageHandlerCondition.timed_wait(lock, boost::posix_time::microsec_clock::universal_time() + boost::posix_time::milliseconds(100));
+            messageHandlerCondition.wait_for(lock, std::chrono::milliseconds(100), []()->bool {return net_interrupted; });
     }
 }
 

--- a/src/net.h
+++ b/src/net.h
@@ -97,7 +97,7 @@ void InterruptMapPort();
 void StopMapPort();
 unsigned short GetListenPort();
 bool BindListenPort(const CService &bindAddr, std::string& strError, bool fWhitelisted = false);
-void StartNode(boost::thread_group& threadGroup, CScheduler& scheduler);
+void StartNode(CScheduler& scheduler);
 bool StopNode();
 void InterruptNode();
 

--- a/src/net.h
+++ b/src/net.h
@@ -93,6 +93,8 @@ CNode* FindNode(const CService& ip);
 CNode* FindNode(const NodeId id); //TODO: Remove this
 bool OpenNetworkConnection(const CAddress& addrConnect, bool fCountFailure, CSemaphoreGrant *grantOutbound = NULL, const char *strDest = NULL, bool fOneShot = false, bool fFeeler = false);
 void MapPort(bool fUseUPnP);
+void InterruptMapPort();
+void StopMapPort();
 unsigned short GetListenPort();
 bool BindListenPort(const CService &bindAddr, std::string& strError, bool fWhitelisted = false);
 void StartNode(boost::thread_group& threadGroup, CScheduler& scheduler);

--- a/src/net.h
+++ b/src/net.h
@@ -99,6 +99,8 @@ unsigned short GetListenPort();
 bool BindListenPort(const CService &bindAddr, std::string& strError, bool fWhitelisted = false);
 void StartNode(boost::thread_group& threadGroup, CScheduler& scheduler);
 bool StopNode();
+void InterruptNode();
+
 void SocketSendData(CNode *pnode);
 
 struct CombinerAll

--- a/src/net.h
+++ b/src/net.h
@@ -33,10 +33,6 @@ class CAddrMan;
 class CScheduler;
 class CNode;
 
-namespace boost {
-    class thread_group;
-} // namespace boost
-
 /** Time between pings automatically sent out for latency probing and keepalive (in seconds). */
 static const int PING_INTERVAL = 2 * 60;
 /** Time after which to disconnect, after waiting for a ping response (or inactivity). */

--- a/src/netbase.h
+++ b/src/netbase.h
@@ -63,5 +63,6 @@ bool SetSocketNonBlocking(SOCKET& hSocket, bool fNonBlocking);
  * Convert milliseconds to a struct timeval for e.g. select.
  */
 struct timeval MillisToTimeval(int64_t nTimeout);
+void InterruptNetbase();
 
 #endif // BITCOIN_NETBASE_H

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -281,9 +281,9 @@ void BitcoinCore::shutdown()
     try
     {
         qDebug() << __func__ << ": Running Shutdown in thread";
-        Interrupt(threadGroup);
+        Interrupt(threadGroup, scheduler);
         threadGroup.join_all();
-        Shutdown();
+        Shutdown(scheduler);
         qDebug() << __func__ << ": Shutdown finished";
         Q_EMIT shutdownResult(1);
     } catch (const std::exception& e) {

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -182,7 +182,6 @@ Q_SIGNALS:
     void runawayException(const QString &message);
 
 private:
-    boost::thread_group threadGroup;
     CScheduler scheduler;
 
     /// Pass fatal exception message to UI thread
@@ -267,7 +266,7 @@ void BitcoinCore::initialize()
     try
     {
         qDebug() << __func__ << ": Running AppInit2 in thread";
-        int rv = AppInit2(threadGroup, scheduler);
+        int rv = AppInit2(scheduler);
         Q_EMIT initializeResult(rv);
     } catch (const std::exception& e) {
         handleRunawayException(&e);
@@ -281,8 +280,7 @@ void BitcoinCore::shutdown()
     try
     {
         qDebug() << __func__ << ": Running Shutdown in thread";
-        Interrupt(threadGroup, scheduler);
-        threadGroup.join_all();
+        Interrupt(scheduler);
         Shutdown(scheduler);
         qDebug() << __func__ << ": Shutdown finished";
         Q_EMIT shutdownResult(1);

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -643,7 +643,8 @@ static bool GetUTXOStats(CCoinsView *view, CCoinsStats &stats)
     ss << stats.hashBlock;
     CAmount nTotalAmount = 0;
     while (pcursor->Valid()) {
-        boost::this_thread::interruption_point();
+        if(!IsRPCRunning())
+            return error("%s: rpc server shutdown", __func__);
         uint256 key;
         CCoins coins;
         if (pcursor->GetKey(key) && pcursor->GetValue(coins)) {

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -82,7 +82,7 @@ void CScheduler::serviceQueue()
     newTaskScheduled.notify_one();
 }
 
-void CScheduler::stop(bool drain)
+void CScheduler::interrupt(bool drain)
 {
     {
         boost::unique_lock<boost::mutex> lock(newTaskMutex);
@@ -92,6 +92,13 @@ void CScheduler::stop(bool drain)
             stopRequested = true;
     }
     newTaskScheduled.notify_all();
+}
+
+void CScheduler::stop()
+{
+    boost::unique_lock<boost::mutex> lock(newTaskMutex);
+    while(nThreadsServicingQueue)
+        newTaskScheduled.wait(lock);
 }
 
 void CScheduler::schedule(CScheduler::Function f, boost::chrono::system_clock::time_point t)

--- a/src/scheduler.h
+++ b/src/scheduler.h
@@ -63,7 +63,10 @@ public:
     // Tell any threads running serviceQueue to stop as soon as they're
     // done servicing whatever task they're currently servicing (drain=false)
     // or when there is no work left to be done (drain=true)
-    void stop(bool drain=false);
+    void interrupt(bool drain=false);
+
+    // Wait for all threads to finish
+    void stop();
 
     // Returns number of tasks waiting to be serviced,
     // and first and last task times

--- a/src/test/test_bitcoin.h
+++ b/src/test/test_bitcoin.h
@@ -13,6 +13,7 @@
 
 #include <boost/filesystem.hpp>
 #include <boost/thread.hpp>
+#include <thread>
 
 /** Basic testing setup.
  * This just configures logging and chain parameters.
@@ -30,7 +31,7 @@ struct BasicTestingSetup {
 struct TestingSetup: public BasicTestingSetup {
     CCoinsViewDB *pcoinsdbview;
     boost::filesystem::path pathTemp;
-    boost::thread_group threadGroup;
+    std::vector<std::thread> script_check_threads;
 
     TestingSetup(const std::string& chainName = CBaseChainParams::MAIN);
     ~TestingSetup();

--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -29,6 +29,8 @@
 #include <event2/event.h>
 #include <event2/thread.h>
 
+#include <thread>
+
 /** Default control port */
 const std::string DEFAULT_TOR_CONTROL = "127.0.0.1:9051";
 /** Tor cookie size (from control-spec.txt) */
@@ -663,7 +665,7 @@ void TorController::reconnect_cb(evutil_socket_t fd, short what, void *arg)
 
 /****** Thread ********/
 struct event_base *base;
-boost::thread torControlThread;
+std::thread torControlThread;
 
 static void TorControlThread()
 {
@@ -672,7 +674,7 @@ static void TorControlThread()
     event_base_dispatch(base);
 }
 
-void StartTorControl(boost::thread_group& threadGroup, CScheduler& scheduler)
+void StartTorControl()
 {
     assert(!base);
 #ifdef WIN32
@@ -686,7 +688,7 @@ void StartTorControl(boost::thread_group& threadGroup, CScheduler& scheduler)
         return;
     }
 
-    torControlThread = boost::thread(boost::bind(&TraceThread<void (*)()>, "torcontrol", &TorControlThread));
+    torControlThread = std::thread(std::bind(&TraceThread<void (*)()>, "torcontrol", &TorControlThread));
 }
 
 void InterruptTorControl()

--- a/src/torcontrol.h
+++ b/src/torcontrol.h
@@ -13,7 +13,7 @@
 extern const std::string DEFAULT_TOR_CONTROL;
 static const bool DEFAULT_LISTEN_ONION = true;
 
-void StartTorControl(boost::thread_group& threadGroup, CScheduler& scheduler);
+void StartTorControl();
 void InterruptTorControl();
 void StopTorControl();
 

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -106,6 +106,7 @@ public:
 private:
     CBlockTreeDB(const CBlockTreeDB&);
     void operator=(const CBlockTreeDB&);
+    std::atomic<bool> interrupt;
 public:
     bool WriteBatchSync(const std::vector<std::pair<int, const CBlockFileInfo*> >& fileInfo, int nLastFile, const std::vector<const CBlockIndex*>& blockinfo);
     bool ReadBlockFileInfo(int nFile, CBlockFileInfo &fileinfo);
@@ -117,6 +118,7 @@ public:
     bool WriteFlag(const std::string &name, bool fValue);
     bool ReadFlag(const std::string &name, bool &fValue);
     bool LoadBlockIndexGuts(boost::function<CBlockIndex*(const uint256&)> insertBlockIndex);
+    void InterruptLoadBlockIndexGuts();
 };
 
 #endif // BITCOIN_TXDB_H

--- a/src/util.h
+++ b/src/util.h
@@ -195,6 +195,15 @@ int GetNumCores();
 
 void RenameThread(const char* name);
 
+class thread_interrupted
+{};
+
+inline void interruption_point(bool interrupt)
+{
+    if(interrupt)
+        throw thread_interrupted();
+}
+
 /**
  * .. and a wrapper that just calls func once
  */
@@ -212,6 +221,9 @@ template <typename Callable> void TraceThread(const char* name,  Callable func)
     {
         LogPrintf("%s thread interrupt\n", name);
         throw;
+    }
+    catch (const thread_interrupted&) {
+        LogPrintf("%s thread interrupt\n", name);
     }
     catch (const std::exception& e) {
         PrintExceptionContinue(&e, name);

--- a/src/utiltime.cpp
+++ b/src/utiltime.cpp
@@ -12,6 +12,9 @@
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/thread.hpp>
 
+#include <thread>
+#include <chrono>
+
 using namespace std;
 
 static int64_t nMockTime = 0; //!< For unit testing
@@ -56,20 +59,7 @@ int64_t GetLogTimeMicros()
 
 void MilliSleep(int64_t n)
 {
-
-/**
- * Boost's sleep_for was uninterruptable when backed by nanosleep from 1.50
- * until fixed in 1.52. Use the deprecated sleep method for the broken case.
- * See: https://svn.boost.org/trac/boost/ticket/7238
- */
-#if defined(HAVE_WORKING_BOOST_SLEEP_FOR)
-    boost::this_thread::sleep_for(boost::chrono::milliseconds(n));
-#elif defined(HAVE_WORKING_BOOST_SLEEP)
-    boost::this_thread::sleep(boost::posix_time::milliseconds(n));
-#else
-//should never get here
-#error missing boost sleep implementation
-#endif
+    std::this_thread::sleep_for(std::chrono::milliseconds(n));
 }
 
 std::string DateTimeStrFormat(const char* pszFormat, int64_t nTime)

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -52,6 +52,7 @@ void CDBEnv::Reset()
     dbenv = new DbEnv(DB_CXX_NO_EXCEPTIONS);
     fDbEnvInit = false;
     fMockDb = false;
+    interrupt = false;
 }
 
 CDBEnv::CDBEnv() : dbenv(NULL)
@@ -71,12 +72,17 @@ void CDBEnv::Close()
     EnvShutdown();
 }
 
+void CDBEnv::Interrupt()
+{
+    interrupt = true;
+}
+
 bool CDBEnv::Open(const boost::filesystem::path& pathIn)
 {
     if (fDbEnvInit)
         return true;
 
-    boost::this_thread::interruption_point();
+    interruption_point(interrupt);
 
     strPath = pathIn.string();
     boost::filesystem::path pathLogDir = pathIn / "database";
@@ -121,7 +127,7 @@ void CDBEnv::MakeMock()
     if (fDbEnvInit)
         throw runtime_error("CDBEnv::MakeMock: Already initialized");
 
-    boost::this_thread::interruption_point();
+    interruption_point(interrupt);
 
     LogPrint("db", "CDBEnv::MakeMock\n");
 

--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -15,6 +15,7 @@
 #include <map>
 #include <string>
 #include <vector>
+#include <atomic>
 
 #include <boost/filesystem/path.hpp>
 
@@ -35,7 +36,7 @@ private:
     std::string strPath;
 
     void EnvShutdown();
-
+    std::atomic<bool> interrupt;
 public:
     mutable CCriticalSection cs_db;
     DbEnv *dbenv;
@@ -85,6 +86,7 @@ public:
             return NULL;
         return ptxn;
     }
+    void Interrupt();
 };
 
 extern CDBEnv bitdb;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -32,6 +32,8 @@
 #include <boost/filesystem.hpp>
 #include <boost/thread.hpp>
 
+#include <thread>
+
 using namespace std;
 
 CWallet* pwalletMain = NULL;
@@ -859,7 +861,7 @@ bool CWallet::AddToWallet(const CWalletTx& wtxIn, bool fFlushOnClose)
     if ( !strCmd.empty())
     {
         boost::replace_all(strCmd, "%s", wtxIn.GetHash().GetHex());
-        boost::thread t(runCommand, strCmd); // thread runs free
+        std::thread(runCommand, strCmd).detach(); // thread runs free
     }
 
     return true;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -467,6 +467,11 @@ bool CWallet::Verify()
     return true;
 }
 
+void CWallet::Interrupt()
+{
+    bitdb.Interrupt();
+}
+
 void CWallet::SyncMetaData(pair<TxSpends::iterator, TxSpends::iterator> range)
 {
     // We want all the wallet transactions in range to have the same metadata as

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -923,6 +923,8 @@ public:
     
     /* Set the current HD master key (will reset the chain child index counters) */
     bool SetHDMasterKey(const CPubKey& key);
+
+    void Interrupt();
 };
 
 /** A key allocated from the key pool. */

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -186,5 +186,6 @@ private:
 };
 
 void ThreadFlushWalletDB(const std::string& strFile);
+void InterruptFlushWalletDB();
 
 #endif // BITCOIN_WALLET_WALLETDB_H


### PR DESCRIPTION
This replaces #8023 with a solution that moves us directly to std::thread, rather than using an intermediate wrapper.
### Background

std::thread is pretty much a drop-in replacement for boost::thread, except that boost::thread is interruptible. We've used those interruptions, but we'll have to drop them eventually as they didn't become part of the spec.

When an interruption point is hit, it throws an instance of boost::thread_interrupted. boost::thread catches these automatically by default.

The interruption points are defined as:

```

    boost::thread::join()
    boost::thread::timed_join()
    boost::thread::try_join_for(),
    boost::thread::try_join_until(),
    boost::condition_variable::wait()
    boost::condition_variable::timed_wait()
    boost::condition_variable::wait_for()
    boost::condition_variable::wait_until()
    boost::condition_variable_any::wait()
    boost::condition_variable_any::timed_wait()
    boost::condition_variable_any::wait_for()
    boost::condition_variable_any::wait_until()
    boost::thread::sleep()
    boost::this_thread::sleep_for()
    boost::this_thread::sleep_until()
    boost::this_thread::interruption_point()
```

The ones relevant to us are primarily `boost::condition_variable_any::wait()`, `boost::this_thread::sleep_for()`, and of course `boost::this_thread::interruption_point()`

Any boost::thread will immediately throw boost::thread_interrupted if those are hit at any point. So we can't simply s/boost::thread/std::thread/g, as we would never be able to exit.
### Changes
- All threads are now externally interruptible. Rather than having a single bool for shutting down, I've attempted to notify each relevant subsystem. But because they're not well-defined, the notifications are somewhat arbitrary as well.
- For long-running threads, our own `thread_interrupted` and `interruption_point` have been added.
- Threads should call TraceThread if they may hit an interruption_point.
- MilliSleep is no longer interruptible.
- boost::thread_group is gone. All threads are now managed individually
### Future changes

There is lots of cleanup to be done post-merge. I was very tempted to include cleanups here, but I've elected to keep the changes minimal. Todo:
- s/boost::mutex/std::mutex/
- s/boost::condition_variable/std::condition_variable/
- s/boost::chrono/std::chrono/
- Drop a ton of boost includes
- Drop other boost cruft (like catching `boost::thread_interrupted`)

Also, I started on this by creating a base class for launching threads. Each instance would be responsible for implementing Interrupt() and Stop(). But because this is already a complex set of changes, I think it's best to do that as a separate step.
