### PR TITLE
Speed up prevector tests by parallelization

### DIFF
--- a/src/test/prevector_tests.cpp
+++ b/src/test/prevector_tests.cpp
@@ -12,8 +12,18 @@
 #include "test/test_bitcoin.h"
 
 #include <boost/test/unit_test.hpp>
+#include <sstream>
 
-BOOST_FIXTURE_TEST_SUITE(PrevectorTests, TestingSetup)
+BOOST_FIXTURE_TEST_SUITE(PrevectorTests, BasicTestingSetup)
+
+
+static std::ostringstream first_failure;
+static bool failed = false;
+
+#define pBOOST_CHECK(v) { if (!(v)) { if (!failed) {failed=true; first_failure << "Checking: " << #v << " failed.\n";} } }
+
+#define pBOOST_CHECK_EQUAL(t, v) { if ((t) != (v)) { if (!failed) {failed=true; first_failure << "Checking: " << #t << " == "<< #v << " failed.\n";} } }
+
 
 template<unsigned int N, typename T>
 class prevector_tester {
@@ -29,54 +39,54 @@ class prevector_tester {
 
     void test() {
         const pretype& const_pre_vector = pre_vector;
-        BOOST_CHECK_EQUAL(real_vector.size(), pre_vector.size());
-        BOOST_CHECK_EQUAL(real_vector.empty(), pre_vector.empty());
+        pBOOST_CHECK_EQUAL(real_vector.size(), pre_vector.size());
+        pBOOST_CHECK_EQUAL(real_vector.empty(), pre_vector.empty());
         for (Size s = 0; s < real_vector.size(); s++) {
-             BOOST_CHECK(real_vector[s] == pre_vector[s]);
-             BOOST_CHECK(&(pre_vector[s]) == &(pre_vector.begin()[s]));
-             BOOST_CHECK(&(pre_vector[s]) == &*(pre_vector.begin() + s));
-             BOOST_CHECK(&(pre_vector[s]) == &*((pre_vector.end() + s) - real_vector.size()));
+             pBOOST_CHECK(real_vector[s] == pre_vector[s]);
+             pBOOST_CHECK(&(pre_vector[s]) == &(pre_vector.begin()[s]));
+             pBOOST_CHECK(&(pre_vector[s]) == &*(pre_vector.begin() + s));
+             pBOOST_CHECK(&(pre_vector[s]) == &*((pre_vector.end() + s) - real_vector.size()));
         }
         // BOOST_CHECK(realtype(pre_vector) == real_vector);
-        BOOST_CHECK(pretype(real_vector.begin(), real_vector.end()) == pre_vector);
-        BOOST_CHECK(pretype(pre_vector.begin(), pre_vector.end()) == pre_vector);
+        pBOOST_CHECK(pretype(real_vector.begin(), real_vector.end()) == pre_vector);
+        pBOOST_CHECK(pretype(pre_vector.begin(), pre_vector.end()) == pre_vector);
         size_t pos = 0;
         BOOST_FOREACH(const T& v, pre_vector) {
-             BOOST_CHECK(v == real_vector[pos++]);
+             pBOOST_CHECK(v == real_vector[pos++]);
         }
         BOOST_REVERSE_FOREACH(const T& v, pre_vector) {
-             BOOST_CHECK(v == real_vector[--pos]);
+             pBOOST_CHECK(v == real_vector[--pos]);
         }
         BOOST_FOREACH(const T& v, const_pre_vector) {
-             BOOST_CHECK(v == real_vector[pos++]);
+             pBOOST_CHECK(v == real_vector[pos++]);
         }
         BOOST_REVERSE_FOREACH(const T& v, const_pre_vector) {
-             BOOST_CHECK(v == real_vector[--pos]);
+             pBOOST_CHECK(v == real_vector[--pos]);
         }
         CDataStream ss1(SER_DISK, 0);
         CDataStream ss2(SER_DISK, 0);
         ss1 << real_vector;
         ss2 << pre_vector;
-        BOOST_CHECK_EQUAL(ss1.size(), ss2.size());
+        pBOOST_CHECK_EQUAL(ss1.size(), ss2.size());
         for (Size s = 0; s < ss1.size(); s++) {
-            BOOST_CHECK_EQUAL(ss1[s], ss2[s]);
+            pBOOST_CHECK_EQUAL(ss1[s], ss2[s]);
         }
     }
 
 public:
     void resize(Size s) {
         real_vector.resize(s);
-        BOOST_CHECK_EQUAL(real_vector.size(), s);
+        pBOOST_CHECK_EQUAL(real_vector.size(), s);
         pre_vector.resize(s);
-        BOOST_CHECK_EQUAL(pre_vector.size(), s);
+        pBOOST_CHECK_EQUAL(pre_vector.size(), s);
         test();
     }
 
     void reserve(Size s) {
         real_vector.reserve(s);
-        BOOST_CHECK(real_vector.capacity() >= s);
+        pBOOST_CHECK(real_vector.capacity() >= s);
         pre_vector.reserve(s);
-        BOOST_CHECK(pre_vector.capacity() >= s);
+        pBOOST_CHECK(pre_vector.capacity() >= s);
         test();
     }
 
@@ -159,11 +169,13 @@ public:
     }
 };
 
+
 BOOST_AUTO_TEST_CASE(PrevectorTestInt)
 {
-    for (int j = 0; j < 64; j++) {
+
+    for (int j = 0; j < 64; ++j) {
         prevector_tester<8, int> test;
-        for (int i = 0; i < 2048; i++) {
+        for (int i = 0; i < 2048 && !failed; i++) {
             int r = insecure_rand();
             if ((r % 4) == 0) {
                 test.insert(insecure_rand() % (test.size() + 1), insecure_rand());
@@ -222,7 +234,11 @@ BOOST_AUTO_TEST_CASE(PrevectorTestInt)
                 test.swap();
             }
         }
+
     }
+    if (failed)
+        BOOST_CHECK_MESSAGE(false, first_failure.str());
+
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
The prevector tests are really slow when run under wine. This needs to be fixed because it can cause failures during development if one adds new tests timeouts can be hit in travis. This PR adds 3 worker threads + one master to mitigate performance, and removes unnecessary full testing setup. This PR makes the test time go from 205 seconds to 3.7 seconds.

I selected the magic number 4 because that is what I had read in the travis docs as a good number. I also switch from TestingSetup to BasicTestingSetup because TestingSetup spawns unused threads

Prevector tests should be sped up by some other means too, but that doesn't preclude parallelization as done in this PR.
# Benchmarks

On a 64-bit windows build off of master, I see:
real    3m24.907s
user    3m24.705s
sys     0m0.038s

After parallelization:
real    0m4.170s
user    0m4.492s
sys     0m9.319s

After parallelization+switch to BasicTestingSetup:
real    0m3.782s
user    0m3.972s
sys     0m6.615s
# Analysis

I'm pretty surprised at the speedup; I did test before PR'ing that:
1. The for loop iterates the correct number of times
2. Replacing my macros with function-versions had same speedup
3. Adding a pBOOST_CHECK(false); in the for loop causes a failure

So I feel pretty confident in the correctness that all checks are run and errors reported, but perhaps there is something I've missed. My theory is the speedup has to do with the wine runtime having high overhead with the main thread.

Testing with a single worker thread doing all the checks gives:

real    0m4.682s
user    0m4.444s
sys     0m0.037s

Which seems to confirm my theory (I've left the 4 threaded version because it's marginally faster).
