### PR TITLE
Ugly hack to print out tests as they are run to mitigate travis timeouts

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -9,3 +9,4 @@ fi
 which autoreconf >/dev/null || \
   (echo "configuration failed, please install autoconf first" && exit 1)
 autoreconf --install --force --warnings=all
+sed -i 's,"\$@" >$log_file 2>\&1,"\$@" -l test_suite  2>\&1 | tee $log_file,' build-aux/test-driver


### PR DESCRIPTION
This hack edits the test-driver to output the test suite's stdout (tee'ing it to the file rather than redirecting) and passes -l test_suite so that stuck tests can be seen.

Some hack like this is needed in order for test suites that take a long time, travis will assume they are dead and fail after 10 minutes. (This also helps debug which unittests may be slow). There may be a cleaner way, but as far as I can tell, this is the simplest. 
