### PR TITLE
[0.13 backport] Reduce default number of blocks to check at startup

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -191,7 +191,7 @@ extern uint64_t nPruneTarget;
 /** Block files containing a block-height within MIN_BLOCKS_TO_KEEP of chainActive.Tip() will not be pruned. */
 static const unsigned int MIN_BLOCKS_TO_KEEP = 288;
 
-static const signed int DEFAULT_CHECKBLOCKS = MIN_BLOCKS_TO_KEEP;
+static const signed int DEFAULT_CHECKBLOCKS = 6;
 static const unsigned int DEFAULT_CHECKLEVEL = 3;
 
 // Require that user allocate at least 550MB for block & undo files (blk???.dat and rev???.dat)


### PR DESCRIPTION
Applies cleanly. Arguably the increase of dbcache to 300mb created a startup time regression that this fixes. I think this is unambiguously safe, changing a default for a startup sanity check that the user could have been setting themselves.
