### PR TITLE
Make tests much faster by replacing BOOST_CHECK with FAST_CHECK

### DIFF
--- a/src/test/Checkpoints_tests.cpp
+++ b/src/test/Checkpoints_tests.cpp
@@ -21,7 +21,7 @@ BOOST_FIXTURE_TEST_SUITE(Checkpoints_tests, BasicTestingSetup)
 BOOST_AUTO_TEST_CASE(sanity)
 {
     const CCheckpointData& checkpoints = Params(CBaseChainParams::MAIN).Checkpoints();
-    BOOST_CHECK(Checkpoints::GetTotalBlocksEstimate(checkpoints) >= 134444);
+    FAST_CHECK(Checkpoints::GetTotalBlocksEstimate(checkpoints) >= 134444);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/DoS_tests.cpp
+++ b/src/test/DoS_tests.cpp
@@ -50,19 +50,19 @@ BOOST_AUTO_TEST_CASE(DoS_banning)
     dummyNode1.nVersion = 1;
     Misbehaving(dummyNode1.GetId(), 100); // Should get banned
     SendMessages(&dummyNode1);
-    BOOST_CHECK(CNode::IsBanned(addr1));
-    BOOST_CHECK(!CNode::IsBanned(ip(0xa0b0c001|0x0000ff00))); // Different IP, not banned
+    FAST_CHECK(CNode::IsBanned(addr1));
+    FAST_CHECK(!CNode::IsBanned(ip(0xa0b0c001|0x0000ff00))); // Different IP, not banned
 
     CAddress addr2(ip(0xa0b0c002), NODE_NONE);
     CNode dummyNode2(INVALID_SOCKET, addr2, "", true);
     dummyNode2.nVersion = 1;
     Misbehaving(dummyNode2.GetId(), 50);
     SendMessages(&dummyNode2);
-    BOOST_CHECK(!CNode::IsBanned(addr2)); // 2 not banned yet...
-    BOOST_CHECK(CNode::IsBanned(addr1));  // ... but 1 still should be
+    FAST_CHECK(!CNode::IsBanned(addr2)); // 2 not banned yet...
+    FAST_CHECK(CNode::IsBanned(addr1));  // ... but 1 still should be
     Misbehaving(dummyNode2.GetId(), 50);
     SendMessages(&dummyNode2);
-    BOOST_CHECK(CNode::IsBanned(addr2));
+    FAST_CHECK(CNode::IsBanned(addr2));
 }
 
 BOOST_AUTO_TEST_CASE(DoS_banscore)
@@ -74,13 +74,13 @@ BOOST_AUTO_TEST_CASE(DoS_banscore)
     dummyNode1.nVersion = 1;
     Misbehaving(dummyNode1.GetId(), 100);
     SendMessages(&dummyNode1);
-    BOOST_CHECK(!CNode::IsBanned(addr1));
+    FAST_CHECK(!CNode::IsBanned(addr1));
     Misbehaving(dummyNode1.GetId(), 10);
     SendMessages(&dummyNode1);
-    BOOST_CHECK(!CNode::IsBanned(addr1));
+    FAST_CHECK(!CNode::IsBanned(addr1));
     Misbehaving(dummyNode1.GetId(), 1);
     SendMessages(&dummyNode1);
-    BOOST_CHECK(CNode::IsBanned(addr1));
+    FAST_CHECK(CNode::IsBanned(addr1));
     mapArgs.erase("-banscore");
 }
 
@@ -96,13 +96,13 @@ BOOST_AUTO_TEST_CASE(DoS_bantime)
 
     Misbehaving(dummyNode.GetId(), 100);
     SendMessages(&dummyNode);
-    BOOST_CHECK(CNode::IsBanned(addr));
+    FAST_CHECK(CNode::IsBanned(addr));
 
     SetMockTime(nStartTime+60*60);
-    BOOST_CHECK(CNode::IsBanned(addr));
+    FAST_CHECK(CNode::IsBanned(addr));
 
     SetMockTime(nStartTime+60*60*24+1);
-    BOOST_CHECK(!CNode::IsBanned(addr));
+    FAST_CHECK(!CNode::IsBanned(addr));
 }
 
 CTransaction RandomOrphan()
@@ -174,7 +174,7 @@ BOOST_AUTO_TEST_CASE(DoS_mapOrphans)
         for (unsigned int j = 1; j < tx.vin.size(); j++)
             tx.vin[j].scriptSig = tx.vin[0].scriptSig;
 
-        BOOST_CHECK(!AddOrphanTx(tx, i));
+        FAST_CHECK(!AddOrphanTx(tx, i));
     }
 
     // Test EraseOrphansFor:
@@ -182,17 +182,17 @@ BOOST_AUTO_TEST_CASE(DoS_mapOrphans)
     {
         size_t sizeBefore = mapOrphanTransactions.size();
         EraseOrphansFor(i);
-        BOOST_CHECK(mapOrphanTransactions.size() < sizeBefore);
+        FAST_CHECK(mapOrphanTransactions.size() < sizeBefore);
     }
 
     // Test LimitOrphanTxSize() function:
     LimitOrphanTxSize(40);
-    BOOST_CHECK(mapOrphanTransactions.size() <= 40);
+    FAST_CHECK(mapOrphanTransactions.size() <= 40);
     LimitOrphanTxSize(10);
-    BOOST_CHECK(mapOrphanTransactions.size() <= 10);
+    FAST_CHECK(mapOrphanTransactions.size() <= 10);
     LimitOrphanTxSize(0);
-    BOOST_CHECK(mapOrphanTransactions.empty());
-    BOOST_CHECK(mapOrphanTransactionsByPrev.empty());
+    FAST_CHECK(mapOrphanTransactions.empty());
+    FAST_CHECK(mapOrphanTransactionsByPrev.empty());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/addrman_tests.cpp
+++ b/src/test/addrman_tests.cpp
@@ -87,35 +87,35 @@ BOOST_AUTO_TEST_CASE(addrman_simple)
     CNetAddr source = ResolveIP("252.2.2.2");
 
     // Test 1: Does Addrman respond correctly when empty.
-    BOOST_CHECK(addrman.size() == 0);
+    FAST_CHECK(addrman.size() == 0);
     CAddrInfo addr_null = addrman.Select();
-    BOOST_CHECK(addr_null.ToString() == "[::]:0");
+    FAST_CHECK(addr_null.ToString() == "[::]:0");
 
     // Test 2: Does Addrman::Add work as expected.
     CService addr1 = ResolveService("250.1.1.1", 8333);
     addrman.Add(CAddress(addr1, NODE_NONE), source);
-    BOOST_CHECK(addrman.size() == 1);
+    FAST_CHECK(addrman.size() == 1);
     CAddrInfo addr_ret1 = addrman.Select();
-    BOOST_CHECK(addr_ret1.ToString() == "250.1.1.1:8333");
+    FAST_CHECK(addr_ret1.ToString() == "250.1.1.1:8333");
 
     // Test 3: Does IP address deduplication work correctly.
     //  Expected dup IP should not be added.
     CService addr1_dup = ResolveService("250.1.1.1", 8333);
     addrman.Add(CAddress(addr1_dup, NODE_NONE), source);
-    BOOST_CHECK(addrman.size() == 1);
+    FAST_CHECK(addrman.size() == 1);
 
 
     // Test 5: New table has one addr and we add a diff addr we should
     //  have two addrs.
     CService addr2 = ResolveService("250.1.1.2", 8333);
     addrman.Add(CAddress(addr2, NODE_NONE), source);
-    BOOST_CHECK(addrman.size() == 2);
+    FAST_CHECK(addrman.size() == 2);
 
     // Test 6: AddrMan::Clear() should empty the new table.
     addrman.Clear();
-    BOOST_CHECK(addrman.size() == 0);
+    FAST_CHECK(addrman.size() == 0);
     CAddrInfo addr_null2 = addrman.Select();
-    BOOST_CHECK(addr_null2.ToString() == "[::]:0");
+    FAST_CHECK(addr_null2.ToString() == "[::]:0");
 }
 
 BOOST_AUTO_TEST_CASE(addrman_ports)
@@ -127,26 +127,26 @@ BOOST_AUTO_TEST_CASE(addrman_ports)
 
     CNetAddr source = ResolveIP("252.2.2.2");
 
-    BOOST_CHECK(addrman.size() == 0);
+    FAST_CHECK(addrman.size() == 0);
 
     // Test 7; Addr with same IP but diff port does not replace existing addr.
     CService addr1 = ResolveService("250.1.1.1", 8333);
     addrman.Add(CAddress(addr1, NODE_NONE), source);
-    BOOST_CHECK(addrman.size() == 1);
+    FAST_CHECK(addrman.size() == 1);
 
     CService addr1_port = ResolveService("250.1.1.1", 8334);
     addrman.Add(CAddress(addr1_port, NODE_NONE), source);
-    BOOST_CHECK(addrman.size() == 1);
+    FAST_CHECK(addrman.size() == 1);
     CAddrInfo addr_ret2 = addrman.Select();
-    BOOST_CHECK(addr_ret2.ToString() == "250.1.1.1:8333");
+    FAST_CHECK(addr_ret2.ToString() == "250.1.1.1:8333");
 
     // Test 8: Add same IP but diff port to tried table, it doesn't get added.
     //  Perhaps this is not ideal behavior but it is the current behavior.
     addrman.Good(CAddress(addr1_port, NODE_NONE));
-    BOOST_CHECK(addrman.size() == 1);
+    FAST_CHECK(addrman.size() == 1);
     bool newOnly = true;
     CAddrInfo addr_ret3 = addrman.Select(newOnly);
-    BOOST_CHECK(addr_ret3.ToString() == "250.1.1.1:8333");
+    FAST_CHECK(addr_ret3.ToString() == "250.1.1.1:8333");
 }
 
 
@@ -162,22 +162,22 @@ BOOST_AUTO_TEST_CASE(addrman_select)
     // Test 9: Select from new with 1 addr in new.
     CService addr1 = ResolveService("250.1.1.1", 8333);
     addrman.Add(CAddress(addr1, NODE_NONE), source);
-    BOOST_CHECK(addrman.size() == 1);
+    FAST_CHECK(addrman.size() == 1);
 
     bool newOnly = true;
     CAddrInfo addr_ret1 = addrman.Select(newOnly);
-    BOOST_CHECK(addr_ret1.ToString() == "250.1.1.1:8333");
+    FAST_CHECK(addr_ret1.ToString() == "250.1.1.1:8333");
 
     // Test 10: move addr to tried, select from new expected nothing returned.
     addrman.Good(CAddress(addr1, NODE_NONE));
-    BOOST_CHECK(addrman.size() == 1);
+    FAST_CHECK(addrman.size() == 1);
     CAddrInfo addr_ret2 = addrman.Select(newOnly);
-    BOOST_CHECK(addr_ret2.ToString() == "[::]:0");
+    FAST_CHECK(addr_ret2.ToString() == "[::]:0");
 
     CAddrInfo addr_ret3 = addrman.Select();
-    BOOST_CHECK(addr_ret3.ToString() == "250.1.1.1:8333");
+    FAST_CHECK(addr_ret3.ToString() == "250.1.1.1:8333");
 
-    BOOST_CHECK(addrman.size() == 1);
+    FAST_CHECK(addrman.size() == 1);
 
 
     // Add three addresses to new table.
@@ -202,13 +202,13 @@ BOOST_AUTO_TEST_CASE(addrman_select)
     addrman.Good(CAddress(addr7, NODE_NONE));
 
     // Test 11: 6 addrs + 1 addr from last test = 7.
-    BOOST_CHECK(addrman.size() == 7);
+    FAST_CHECK(addrman.size() == 7);
 
     // Test 12: Select pulls from new and tried regardless of port number.
-    BOOST_CHECK(addrman.Select().ToString() == "250.4.6.6:8333");
-    BOOST_CHECK(addrman.Select().ToString() == "250.3.2.2:9999");
-    BOOST_CHECK(addrman.Select().ToString() == "250.3.3.3:9999");
-    BOOST_CHECK(addrman.Select().ToString() == "250.4.4.4:8333");
+    FAST_CHECK(addrman.Select().ToString() == "250.4.6.6:8333");
+    FAST_CHECK(addrman.Select().ToString() == "250.3.2.2:9999");
+    FAST_CHECK(addrman.Select().ToString() == "250.3.3.3:9999");
+    FAST_CHECK(addrman.Select().ToString() == "250.4.4.4:8333");
 }
 
 BOOST_AUTO_TEST_CASE(addrman_new_collisions)
@@ -220,24 +220,24 @@ BOOST_AUTO_TEST_CASE(addrman_new_collisions)
 
     CNetAddr source = ResolveIP("252.2.2.2");
 
-    BOOST_CHECK(addrman.size() == 0);
+    FAST_CHECK(addrman.size() == 0);
 
     for (unsigned int i = 1; i < 18; i++) {
         CService addr = ResolveService("250.1.1." + boost::to_string(i));
         addrman.Add(CAddress(addr, NODE_NONE), source);
 
         //Test 13: No collision in new table yet.
-        BOOST_CHECK(addrman.size() == i);
+        FAST_CHECK(addrman.size() == i);
     }
 
     //Test 14: new table collision!
     CService addr1 = ResolveService("250.1.1.18");
     addrman.Add(CAddress(addr1, NODE_NONE), source);
-    BOOST_CHECK(addrman.size() == 17);
+    FAST_CHECK(addrman.size() == 17);
 
     CService addr2 = ResolveService("250.1.1.19");
     addrman.Add(CAddress(addr2, NODE_NONE), source);
-    BOOST_CHECK(addrman.size() == 18);
+    FAST_CHECK(addrman.size() == 18);
 }
 
 BOOST_AUTO_TEST_CASE(addrman_tried_collisions)
@@ -249,7 +249,7 @@ BOOST_AUTO_TEST_CASE(addrman_tried_collisions)
 
     CNetAddr source = ResolveIP("252.2.2.2");
 
-    BOOST_CHECK(addrman.size() == 0);
+    FAST_CHECK(addrman.size() == 0);
 
     for (unsigned int i = 1; i < 80; i++) {
         CService addr = ResolveService("250.1.1." + boost::to_string(i));
@@ -258,17 +258,17 @@ BOOST_AUTO_TEST_CASE(addrman_tried_collisions)
 
         //Test 15: No collision in tried table yet.
         BOOST_TEST_MESSAGE(addrman.size());
-        BOOST_CHECK(addrman.size() == i);
+        FAST_CHECK(addrman.size() == i);
     }
 
     //Test 16: tried table collision!
     CService addr1 = ResolveService("250.1.1.80");
     addrman.Add(CAddress(addr1, NODE_NONE), source);
-    BOOST_CHECK(addrman.size() == 79);
+    FAST_CHECK(addrman.size() == 79);
 
     CService addr2 = ResolveService("250.1.1.81");
     addrman.Add(CAddress(addr2, NODE_NONE), source);
-    BOOST_CHECK(addrman.size() == 80);
+    FAST_CHECK(addrman.size() == 80);
 }
 
 BOOST_AUTO_TEST_CASE(addrman_find)
@@ -278,7 +278,7 @@ BOOST_AUTO_TEST_CASE(addrman_find)
     // Set addrman addr placement to be deterministic.
     addrman.MakeDeterministic();
 
-    BOOST_CHECK(addrman.size() == 0);
+    FAST_CHECK(addrman.size() == 0);
 
     CAddress addr1 = CAddress(ResolveService("250.1.2.1", 8333), NODE_NONE);
     CAddress addr2 = CAddress(ResolveService("250.1.2.1", 9999), NODE_NONE);
@@ -293,21 +293,21 @@ BOOST_AUTO_TEST_CASE(addrman_find)
 
     // Test 17: ensure Find returns an IP matching what we searched on.
     CAddrInfo* info1 = addrman.Find(addr1);
-    BOOST_CHECK(info1);
+    FAST_CHECK(info1);
     if (info1)
-        BOOST_CHECK(info1->ToString() == "250.1.2.1:8333");
+        FAST_CHECK(info1->ToString() == "250.1.2.1:8333");
 
     // Test 18; Find does not discriminate by port number.
     CAddrInfo* info2 = addrman.Find(addr2);
-    BOOST_CHECK(info2);
+    FAST_CHECK(info2);
     if (info2)
-        BOOST_CHECK(info2->ToString() == info1->ToString());
+        FAST_CHECK(info2->ToString() == info1->ToString());
 
     // Test 19: Find returns another IP matching what we searched on.
     CAddrInfo* info3 = addrman.Find(addr3);
-    BOOST_CHECK(info3);
+    FAST_CHECK(info3);
     if (info3)
-        BOOST_CHECK(info3->ToString() == "251.255.2.1:8333");
+        FAST_CHECK(info3->ToString() == "251.255.2.1:8333");
 }
 
 BOOST_AUTO_TEST_CASE(addrman_create)
@@ -317,7 +317,7 @@ BOOST_AUTO_TEST_CASE(addrman_create)
     // Set addrman addr placement to be deterministic.
     addrman.MakeDeterministic();
 
-    BOOST_CHECK(addrman.size() == 0);
+    FAST_CHECK(addrman.size() == 0);
 
     CAddress addr1 = CAddress(ResolveService("250.1.2.1", 8333), NODE_NONE);
     CNetAddr source1 = ResolveIP("250.1.2.1");
@@ -326,10 +326,10 @@ BOOST_AUTO_TEST_CASE(addrman_create)
     CAddrInfo* pinfo = addrman.Create(addr1, source1, &nId);
 
     // Test 20: The result should be the same as the input addr.
-    BOOST_CHECK(pinfo->ToString() == "250.1.2.1:8333");
+    FAST_CHECK(pinfo->ToString() == "250.1.2.1:8333");
 
     CAddrInfo* info2 = addrman.Find(addr1);
-    BOOST_CHECK(info2->ToString() == "250.1.2.1:8333");
+    FAST_CHECK(info2->ToString() == "250.1.2.1:8333");
 }
 
 
@@ -340,7 +340,7 @@ BOOST_AUTO_TEST_CASE(addrman_delete)
     // Set addrman addr placement to be deterministic.
     addrman.MakeDeterministic();
 
-    BOOST_CHECK(addrman.size() == 0);
+    FAST_CHECK(addrman.size() == 0);
 
     CAddress addr1 = CAddress(ResolveService("250.1.2.1", 8333), NODE_NONE);
     CNetAddr source1 = ResolveIP("250.1.2.1");
@@ -349,11 +349,11 @@ BOOST_AUTO_TEST_CASE(addrman_delete)
     addrman.Create(addr1, source1, &nId);
 
     // Test 21: Delete should actually delete the addr.
-    BOOST_CHECK(addrman.size() == 1);
+    FAST_CHECK(addrman.size() == 1);
     addrman.Delete(nId);
-    BOOST_CHECK(addrman.size() == 0);
+    FAST_CHECK(addrman.size() == 0);
     CAddrInfo* info2 = addrman.Find(addr1);
-    BOOST_CHECK(info2 == NULL);
+    FAST_CHECK(info2 == NULL);
 }
 
 BOOST_AUTO_TEST_CASE(addrman_getaddr)
@@ -365,9 +365,9 @@ BOOST_AUTO_TEST_CASE(addrman_getaddr)
 
     // Test 22: Sanity check, GetAddr should never return anything if addrman
     //  is empty.
-    BOOST_CHECK(addrman.size() == 0);
+    FAST_CHECK(addrman.size() == 0);
     vector<CAddress> vAddr1 = addrman.GetAddr();
-    BOOST_CHECK(vAddr1.size() == 0);
+    FAST_CHECK(vAddr1.size() == 0);
 
     CAddress addr1 = CAddress(ResolveService("250.250.2.1", 8333), NODE_NONE);
     addr1.nTime = GetAdjustedTime(); // Set time so isTerrible = false
@@ -390,12 +390,12 @@ BOOST_AUTO_TEST_CASE(addrman_getaddr)
     addrman.Add(addr5, source1);
 
     // GetAddr returns 23% of addresses, 23% of 5 is 1 rounded down.
-    BOOST_CHECK(addrman.GetAddr().size() == 1); 
+    FAST_CHECK(addrman.GetAddr().size() == 1); 
 
     // Test 24: Ensure GetAddr works with new and tried addresses.
     addrman.Good(CAddress(addr1, NODE_NONE));
     addrman.Good(CAddress(addr2, NODE_NONE));
-    BOOST_CHECK(addrman.GetAddr().size() == 1);
+    FAST_CHECK(addrman.GetAddr().size() == 1);
 
     // Test 25: Ensure GetAddr still returns 23% when addrman has many addrs.
     for (unsigned int i = 1; i < (8 * 256); i++) {
@@ -414,10 +414,10 @@ BOOST_AUTO_TEST_CASE(addrman_getaddr)
     vector<CAddress> vAddr = addrman.GetAddr();
 
     size_t percent23 = (addrman.size() * 23) / 100;
-    BOOST_CHECK(vAddr.size() == percent23);
-    BOOST_CHECK(vAddr.size() == 461);
+    FAST_CHECK(vAddr.size() == percent23);
+    FAST_CHECK(vAddr.size() == 461);
     // (Addrman.size() < number of addresses added) due to address collisons.
-    BOOST_CHECK(addrman.size() == 2007);
+    FAST_CHECK(addrman.size() == 2007);
 }
 
 
@@ -440,18 +440,18 @@ BOOST_AUTO_TEST_CASE(caddrinfo_get_tried_bucket)
     uint256 nKey2 = (uint256)(CHashWriter(SER_GETHASH, 0) << 2).GetHash();
 
 
-    BOOST_CHECK(info1.GetTriedBucket(nKey1) == 40);
+    FAST_CHECK(info1.GetTriedBucket(nKey1) == 40);
 
     // Test 26: Make sure key actually randomizes bucket placement. A fail on
     //  this test could be a security issue.
-    BOOST_CHECK(info1.GetTriedBucket(nKey1) != info1.GetTriedBucket(nKey2));
+    FAST_CHECK(info1.GetTriedBucket(nKey1) != info1.GetTriedBucket(nKey2));
 
     // Test 27: Two addresses with same IP but different ports can map to
     //  different buckets because they have different keys.
     CAddrInfo info2 = CAddrInfo(addr2, source1);
 
-    BOOST_CHECK(info1.GetKey() != info2.GetKey());
-    BOOST_CHECK(info1.GetTriedBucket(nKey1) != info2.GetTriedBucket(nKey1));
+    FAST_CHECK(info1.GetKey() != info2.GetKey());
+    FAST_CHECK(info1.GetTriedBucket(nKey1) != info2.GetTriedBucket(nKey1));
 
     set<int> buckets;
     for (int i = 0; i < 255; i++) {
@@ -463,7 +463,7 @@ BOOST_AUTO_TEST_CASE(caddrinfo_get_tried_bucket)
     }
     // Test 28: IP addresses in the same group (\16 prefix for IPv4) should
     //  never get more than 8 buckets
-    BOOST_CHECK(buckets.size() == 8);
+    FAST_CHECK(buckets.size() == 8);
 
     buckets.clear();
     for (int j = 0; j < 255; j++) {
@@ -475,7 +475,7 @@ BOOST_AUTO_TEST_CASE(caddrinfo_get_tried_bucket)
     }
     // Test 29: IP addresses in the different groups should map to more than
     //  8 buckets.
-    BOOST_CHECK(buckets.size() == 160);
+    FAST_CHECK(buckets.size() == 160);
 }
 
 BOOST_AUTO_TEST_CASE(caddrinfo_get_new_bucket)
@@ -495,16 +495,16 @@ BOOST_AUTO_TEST_CASE(caddrinfo_get_new_bucket)
     uint256 nKey1 = (uint256)(CHashWriter(SER_GETHASH, 0) << 1).GetHash();
     uint256 nKey2 = (uint256)(CHashWriter(SER_GETHASH, 0) << 2).GetHash();
 
-    BOOST_CHECK(info1.GetNewBucket(nKey1) == 786);
+    FAST_CHECK(info1.GetNewBucket(nKey1) == 786);
 
     // Test 30: Make sure key actually randomizes bucket placement. A fail on
     //  this test could be a security issue.
-    BOOST_CHECK(info1.GetNewBucket(nKey1) != info1.GetNewBucket(nKey2));
+    FAST_CHECK(info1.GetNewBucket(nKey1) != info1.GetNewBucket(nKey2));
 
     // Test 31: Ports should not effect bucket placement in the addr
     CAddrInfo info2 = CAddrInfo(addr2, source1);
-    BOOST_CHECK(info1.GetKey() != info2.GetKey());
-    BOOST_CHECK(info1.GetNewBucket(nKey1) == info2.GetNewBucket(nKey1));
+    FAST_CHECK(info1.GetKey() != info2.GetKey());
+    FAST_CHECK(info1.GetNewBucket(nKey1) == info2.GetNewBucket(nKey1));
 
     set<int> buckets;
     for (int i = 0; i < 255; i++) {
@@ -516,7 +516,7 @@ BOOST_AUTO_TEST_CASE(caddrinfo_get_new_bucket)
     }
     // Test 32: IP addresses in the same group (\16 prefix for IPv4) should
     //  always map to the same bucket.
-    BOOST_CHECK(buckets.size() == 1);
+    FAST_CHECK(buckets.size() == 1);
 
     buckets.clear();
     for (int j = 0; j < 4 * 255; j++) {
@@ -529,7 +529,7 @@ BOOST_AUTO_TEST_CASE(caddrinfo_get_new_bucket)
     }
     // Test 33: IP addresses in the same source groups should map to no more
     //  than 64 buckets.
-    BOOST_CHECK(buckets.size() <= 64);
+    FAST_CHECK(buckets.size() <= 64);
 
     buckets.clear();
     for (int p = 0; p < 255; p++) {
@@ -541,6 +541,6 @@ BOOST_AUTO_TEST_CASE(caddrinfo_get_new_bucket)
     }
     // Test 34: IP addresses in the different source groups should map to more
     //  than 64 buckets.
-    BOOST_CHECK(buckets.size() > 64);
+    FAST_CHECK(buckets.size() > 64);
 }
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/allocator_tests.cpp
+++ b/src/test/allocator_tests.cpp
@@ -62,17 +62,17 @@ BOOST_AUTO_TEST_CASE(test_LockedPageManagerBase)
     }
     /* one very large object, straddling pages */
     lpm.LockRange(reinterpret_cast<void*>(test_page_size*600+1), test_page_size*500);
-    BOOST_CHECK(last_lock_addr == reinterpret_cast<void*>(test_page_size*(600+500)));
+    FAST_CHECK(last_lock_addr == reinterpret_cast<void*>(test_page_size*(600+500)));
     /* one very large object, page aligned */
     lpm.LockRange(reinterpret_cast<void*>(test_page_size*1200), test_page_size*500-1);
-    BOOST_CHECK(last_lock_addr == reinterpret_cast<void*>(test_page_size*(1200+500-1)));
+    FAST_CHECK(last_lock_addr == reinterpret_cast<void*>(test_page_size*(1200+500-1)));
 
-    BOOST_CHECK(lpm.GetLockedPageCount() == (
+    FAST_CHECK(lpm.GetLockedPageCount() == (
         (1000*33+test_page_size-1)/test_page_size + // small objects
         101 + 100 +  // page-sized objects
         501 + 500)); // large objects
-    BOOST_CHECK((last_lock_len & (test_page_size-1)) == 0); // always lock entire pages
-    BOOST_CHECK(last_unlock_len == 0); // nothing unlocked yet
+    FAST_CHECK((last_lock_len & (test_page_size-1)) == 0); // always lock entire pages
+    FAST_CHECK(last_unlock_len == 0); // nothing unlocked yet
 
     /* And unlock again */
     addr = 0;
@@ -97,7 +97,7 @@ BOOST_AUTO_TEST_CASE(test_LockedPageManagerBase)
     lpm.UnlockRange(reinterpret_cast<void*>(test_page_size*1200), test_page_size*500-1);
 
     /* Check that everything is released */
-    BOOST_CHECK(lpm.GetLockedPageCount() == 0);
+    FAST_CHECK(lpm.GetLockedPageCount() == 0);
 
     /* A few and unlocks of size zero (should have no effect) */
     addr = 0;
@@ -106,15 +106,15 @@ BOOST_AUTO_TEST_CASE(test_LockedPageManagerBase)
         lpm.LockRange(reinterpret_cast<void*>(addr), 0);
         addr += 1;
     }
-    BOOST_CHECK(lpm.GetLockedPageCount() == 0);
+    FAST_CHECK(lpm.GetLockedPageCount() == 0);
     addr = 0;
     for(int i=0; i<1000; ++i)
     {
         lpm.UnlockRange(reinterpret_cast<void*>(addr), 0);
         addr += 1;
     }
-    BOOST_CHECK(lpm.GetLockedPageCount() == 0);
-    BOOST_CHECK((last_unlock_len & (test_page_size-1)) == 0); // always unlock entire pages
+    FAST_CHECK(lpm.GetLockedPageCount() == 0);
+    FAST_CHECK((last_unlock_len & (test_page_size-1)) == 0); // always unlock entire pages
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/amount_tests.cpp
+++ b/src/test/amount_tests.cpp
@@ -15,55 +15,55 @@ BOOST_AUTO_TEST_CASE(GetFeeTest)
 
     feeRate = CFeeRate(0);
     // Must always return 0
-    BOOST_CHECK_EQUAL(feeRate.GetFee(0), 0);
-    BOOST_CHECK_EQUAL(feeRate.GetFee(1e5), 0);
+    FAST_CHECK_EQUAL(feeRate.GetFee(0), 0);
+    FAST_CHECK_EQUAL(feeRate.GetFee(1e5), 0);
 
     feeRate = CFeeRate(1000);
     // Must always just return the arg
-    BOOST_CHECK_EQUAL(feeRate.GetFee(0), 0);
-    BOOST_CHECK_EQUAL(feeRate.GetFee(1), 1);
-    BOOST_CHECK_EQUAL(feeRate.GetFee(121), 121);
-    BOOST_CHECK_EQUAL(feeRate.GetFee(999), 999);
-    BOOST_CHECK_EQUAL(feeRate.GetFee(1e3), 1e3);
-    BOOST_CHECK_EQUAL(feeRate.GetFee(9e3), 9e3);
+    FAST_CHECK_EQUAL(feeRate.GetFee(0), 0);
+    FAST_CHECK_EQUAL(feeRate.GetFee(1), 1);
+    FAST_CHECK_EQUAL(feeRate.GetFee(121), 121);
+    FAST_CHECK_EQUAL(feeRate.GetFee(999), 999);
+    FAST_CHECK_EQUAL(feeRate.GetFee(1e3), 1e3);
+    FAST_CHECK_EQUAL(feeRate.GetFee(9e3), 9e3);
 
     feeRate = CFeeRate(-1000);
     // Must always just return -1 * arg
-    BOOST_CHECK_EQUAL(feeRate.GetFee(0), 0);
-    BOOST_CHECK_EQUAL(feeRate.GetFee(1), -1);
-    BOOST_CHECK_EQUAL(feeRate.GetFee(121), -121);
-    BOOST_CHECK_EQUAL(feeRate.GetFee(999), -999);
-    BOOST_CHECK_EQUAL(feeRate.GetFee(1e3), -1e3);
-    BOOST_CHECK_EQUAL(feeRate.GetFee(9e3), -9e3);
+    FAST_CHECK_EQUAL(feeRate.GetFee(0), 0);
+    FAST_CHECK_EQUAL(feeRate.GetFee(1), -1);
+    FAST_CHECK_EQUAL(feeRate.GetFee(121), -121);
+    FAST_CHECK_EQUAL(feeRate.GetFee(999), -999);
+    FAST_CHECK_EQUAL(feeRate.GetFee(1e3), -1e3);
+    FAST_CHECK_EQUAL(feeRate.GetFee(9e3), -9e3);
 
     feeRate = CFeeRate(123);
     // Truncates the result, if not integer
-    BOOST_CHECK_EQUAL(feeRate.GetFee(0), 0);
-    BOOST_CHECK_EQUAL(feeRate.GetFee(8), 1); // Special case: returns 1 instead of 0
-    BOOST_CHECK_EQUAL(feeRate.GetFee(9), 1);
-    BOOST_CHECK_EQUAL(feeRate.GetFee(121), 14);
-    BOOST_CHECK_EQUAL(feeRate.GetFee(122), 15);
-    BOOST_CHECK_EQUAL(feeRate.GetFee(999), 122);
-    BOOST_CHECK_EQUAL(feeRate.GetFee(1e3), 123);
-    BOOST_CHECK_EQUAL(feeRate.GetFee(9e3), 1107);
+    FAST_CHECK_EQUAL(feeRate.GetFee(0), 0);
+    FAST_CHECK_EQUAL(feeRate.GetFee(8), 1); // Special case: returns 1 instead of 0
+    FAST_CHECK_EQUAL(feeRate.GetFee(9), 1);
+    FAST_CHECK_EQUAL(feeRate.GetFee(121), 14);
+    FAST_CHECK_EQUAL(feeRate.GetFee(122), 15);
+    FAST_CHECK_EQUAL(feeRate.GetFee(999), 122);
+    FAST_CHECK_EQUAL(feeRate.GetFee(1e3), 123);
+    FAST_CHECK_EQUAL(feeRate.GetFee(9e3), 1107);
 
     feeRate = CFeeRate(-123);
     // Truncates the result, if not integer
-    BOOST_CHECK_EQUAL(feeRate.GetFee(0), 0);
-    BOOST_CHECK_EQUAL(feeRate.GetFee(8), -1); // Special case: returns -1 instead of 0
-    BOOST_CHECK_EQUAL(feeRate.GetFee(9), -1);
+    FAST_CHECK_EQUAL(feeRate.GetFee(0), 0);
+    FAST_CHECK_EQUAL(feeRate.GetFee(8), -1); // Special case: returns -1 instead of 0
+    FAST_CHECK_EQUAL(feeRate.GetFee(9), -1);
 
     // Check full constructor
     // default value
-    BOOST_CHECK(CFeeRate(CAmount(-1), 1000) == CFeeRate(-1));
-    BOOST_CHECK(CFeeRate(CAmount(0), 1000) == CFeeRate(0));
-    BOOST_CHECK(CFeeRate(CAmount(1), 1000) == CFeeRate(1));
+    FAST_CHECK(CFeeRate(CAmount(-1), 1000) == CFeeRate(-1));
+    FAST_CHECK(CFeeRate(CAmount(0), 1000) == CFeeRate(0));
+    FAST_CHECK(CFeeRate(CAmount(1), 1000) == CFeeRate(1));
     // lost precision (can only resolve satoshis per kB)
-    BOOST_CHECK(CFeeRate(CAmount(1), 1001) == CFeeRate(0));
-    BOOST_CHECK(CFeeRate(CAmount(2), 1001) == CFeeRate(1));
+    FAST_CHECK(CFeeRate(CAmount(1), 1001) == CFeeRate(0));
+    FAST_CHECK(CFeeRate(CAmount(2), 1001) == CFeeRate(1));
     // some more integer checks
-    BOOST_CHECK(CFeeRate(CAmount(26), 789) == CFeeRate(32));
-    BOOST_CHECK(CFeeRate(CAmount(27), 789) == CFeeRate(34));
+    FAST_CHECK(CFeeRate(CAmount(26), 789) == CFeeRate(32));
+    FAST_CHECK(CFeeRate(CAmount(27), 789) == CFeeRate(34));
     // Maximum size in bytes, should not crash
     CFeeRate(MAX_MONEY, std::numeric_limits<size_t>::max() >> 1).GetFeePerK();
 }

--- a/src/test/arith_uint256_tests.cpp
+++ b/src/test/arith_uint256_tests.cpp
@@ -66,60 +66,60 @@ std::string ArrayToString(const unsigned char A[], unsigned int width)
 
 BOOST_AUTO_TEST_CASE( basics ) // constructors, equality, inequality
 {
-    BOOST_CHECK(1 == 0+1);
+    FAST_CHECK(1 == 0+1);
     // constructor arith_uint256(vector<char>):
-    BOOST_CHECK(R1L.ToString() == ArrayToString(R1Array,32));
-    BOOST_CHECK(R2L.ToString() == ArrayToString(R2Array,32));
-    BOOST_CHECK(ZeroL.ToString() == ArrayToString(ZeroArray,32));
-    BOOST_CHECK(OneL.ToString() == ArrayToString(OneArray,32));
-    BOOST_CHECK(MaxL.ToString() == ArrayToString(MaxArray,32));
-    BOOST_CHECK(OneL.ToString() != ArrayToString(ZeroArray,32));
+    FAST_CHECK(R1L.ToString() == ArrayToString(R1Array,32));
+    FAST_CHECK(R2L.ToString() == ArrayToString(R2Array,32));
+    FAST_CHECK(ZeroL.ToString() == ArrayToString(ZeroArray,32));
+    FAST_CHECK(OneL.ToString() == ArrayToString(OneArray,32));
+    FAST_CHECK(MaxL.ToString() == ArrayToString(MaxArray,32));
+    FAST_CHECK(OneL.ToString() != ArrayToString(ZeroArray,32));
 
     // == and !=
-    BOOST_CHECK(R1L != R2L);
-    BOOST_CHECK(ZeroL != OneL);
-    BOOST_CHECK(OneL != ZeroL);
-    BOOST_CHECK(MaxL != ZeroL);
-    BOOST_CHECK(~MaxL == ZeroL);
-    BOOST_CHECK( ((R1L ^ R2L) ^ R1L) == R2L);
+    FAST_CHECK(R1L != R2L);
+    FAST_CHECK(ZeroL != OneL);
+    FAST_CHECK(OneL != ZeroL);
+    FAST_CHECK(MaxL != ZeroL);
+    FAST_CHECK(~MaxL == ZeroL);
+    FAST_CHECK( ((R1L ^ R2L) ^ R1L) == R2L);
 
     uint64_t Tmp64 = 0xc4dab720d9c7acaaULL;
     for (unsigned int i = 0; i < 256; ++i)
     {
-        BOOST_CHECK(ZeroL != (OneL << i));
-        BOOST_CHECK((OneL << i) != ZeroL);
-        BOOST_CHECK(R1L != (R1L ^ (OneL << i)));
-        BOOST_CHECK(((arith_uint256(Tmp64) ^ (OneL << i) ) != Tmp64 ));
+        FAST_CHECK(ZeroL != (OneL << i));
+        FAST_CHECK((OneL << i) != ZeroL);
+        FAST_CHECK(R1L != (R1L ^ (OneL << i)));
+        FAST_CHECK(((arith_uint256(Tmp64) ^ (OneL << i) ) != Tmp64 ));
     }
-    BOOST_CHECK(ZeroL == (OneL << 256));
+    FAST_CHECK(ZeroL == (OneL << 256));
 
     // String Constructor and Copy Constructor
-    BOOST_CHECK(arith_uint256("0x"+R1L.ToString()) == R1L);
-    BOOST_CHECK(arith_uint256("0x"+R2L.ToString()) == R2L);
-    BOOST_CHECK(arith_uint256("0x"+ZeroL.ToString()) == ZeroL);
-    BOOST_CHECK(arith_uint256("0x"+OneL.ToString()) == OneL);
-    BOOST_CHECK(arith_uint256("0x"+MaxL.ToString()) == MaxL);
-    BOOST_CHECK(arith_uint256(R1L.ToString()) == R1L);
-    BOOST_CHECK(arith_uint256("   0x"+R1L.ToString()+"   ") == R1L);
-    BOOST_CHECK(arith_uint256("") == ZeroL);
-    BOOST_CHECK(R1L == arith_uint256(R1ArrayHex));
-    BOOST_CHECK(arith_uint256(R1L) == R1L);
-    BOOST_CHECK((arith_uint256(R1L^R2L)^R2L) == R1L);
-    BOOST_CHECK(arith_uint256(ZeroL) == ZeroL);
-    BOOST_CHECK(arith_uint256(OneL) == OneL);
+    FAST_CHECK(arith_uint256("0x"+R1L.ToString()) == R1L);
+    FAST_CHECK(arith_uint256("0x"+R2L.ToString()) == R2L);
+    FAST_CHECK(arith_uint256("0x"+ZeroL.ToString()) == ZeroL);
+    FAST_CHECK(arith_uint256("0x"+OneL.ToString()) == OneL);
+    FAST_CHECK(arith_uint256("0x"+MaxL.ToString()) == MaxL);
+    FAST_CHECK(arith_uint256(R1L.ToString()) == R1L);
+    FAST_CHECK(arith_uint256("   0x"+R1L.ToString()+"   ") == R1L);
+    FAST_CHECK(arith_uint256("") == ZeroL);
+    FAST_CHECK(R1L == arith_uint256(R1ArrayHex));
+    FAST_CHECK(arith_uint256(R1L) == R1L);
+    FAST_CHECK((arith_uint256(R1L^R2L)^R2L) == R1L);
+    FAST_CHECK(arith_uint256(ZeroL) == ZeroL);
+    FAST_CHECK(arith_uint256(OneL) == OneL);
 
     // uint64_t constructor
-    BOOST_CHECK( (R1L & arith_uint256("0xffffffffffffffff")) == arith_uint256(R1LLow64));
-    BOOST_CHECK(ZeroL == arith_uint256(0));
-    BOOST_CHECK(OneL == arith_uint256(1));
-    BOOST_CHECK(arith_uint256("0xffffffffffffffff") = arith_uint256(0xffffffffffffffffULL));
+    FAST_CHECK( (R1L & arith_uint256("0xffffffffffffffff")) == arith_uint256(R1LLow64));
+    FAST_CHECK(ZeroL == arith_uint256(0));
+    FAST_CHECK(OneL == arith_uint256(1));
+    FAST_CHECK(arith_uint256("0xffffffffffffffff") = arith_uint256(0xffffffffffffffffULL));
 
     // Assignment (from base_uint)
-    arith_uint256 tmpL = ~ZeroL; BOOST_CHECK(tmpL == ~ZeroL);
-    tmpL = ~OneL; BOOST_CHECK(tmpL == ~OneL);
-    tmpL = ~R1L; BOOST_CHECK(tmpL == ~R1L);
-    tmpL = ~R2L; BOOST_CHECK(tmpL == ~R2L);
-    tmpL = ~MaxL; BOOST_CHECK(tmpL == ~MaxL);
+    arith_uint256 tmpL = ~ZeroL; FAST_CHECK(tmpL == ~ZeroL);
+    tmpL = ~OneL; FAST_CHECK(tmpL == ~OneL);
+    tmpL = ~R1L; FAST_CHECK(tmpL == ~R1L);
+    tmpL = ~R2L; FAST_CHECK(tmpL == ~R2L);
+    tmpL = ~MaxL; FAST_CHECK(tmpL == ~MaxL);
 }
 
 void shiftArrayRight(unsigned char* to, const unsigned char* from, unsigned int arrayLength, unsigned int bitsToShift)
@@ -159,62 +159,62 @@ BOOST_AUTO_TEST_CASE( shifts ) { // "<<"  ">>"  "<<="  ">>="
     for (unsigned int i = 0; i < 256; ++i)
     {
         shiftArrayLeft(TmpArray, OneArray, 32, i);
-        BOOST_CHECK(arith_uint256V(std::vector<unsigned char>(TmpArray,TmpArray+32)) == (OneL << i));
+        FAST_CHECK(arith_uint256V(std::vector<unsigned char>(TmpArray,TmpArray+32)) == (OneL << i));
         TmpL = OneL; TmpL <<= i;
-        BOOST_CHECK(TmpL == (OneL << i));
-        BOOST_CHECK((HalfL >> (255-i)) == (OneL << i));
+        FAST_CHECK(TmpL == (OneL << i));
+        FAST_CHECK((HalfL >> (255-i)) == (OneL << i));
         TmpL = HalfL; TmpL >>= (255-i);
-        BOOST_CHECK(TmpL == (OneL << i));
+        FAST_CHECK(TmpL == (OneL << i));
 
         shiftArrayLeft(TmpArray, R1Array, 32, i);
-        BOOST_CHECK(arith_uint256V(std::vector<unsigned char>(TmpArray,TmpArray+32)) == (R1L << i));
+        FAST_CHECK(arith_uint256V(std::vector<unsigned char>(TmpArray,TmpArray+32)) == (R1L << i));
         TmpL = R1L; TmpL <<= i;
-        BOOST_CHECK(TmpL == (R1L << i));
+        FAST_CHECK(TmpL == (R1L << i));
 
         shiftArrayRight(TmpArray, R1Array, 32, i);
-        BOOST_CHECK(arith_uint256V(std::vector<unsigned char>(TmpArray,TmpArray+32)) == (R1L >> i));
+        FAST_CHECK(arith_uint256V(std::vector<unsigned char>(TmpArray,TmpArray+32)) == (R1L >> i));
         TmpL = R1L; TmpL >>= i;
-        BOOST_CHECK(TmpL == (R1L >> i));
+        FAST_CHECK(TmpL == (R1L >> i));
 
         shiftArrayLeft(TmpArray, MaxArray, 32, i);
-        BOOST_CHECK(arith_uint256V(std::vector<unsigned char>(TmpArray,TmpArray+32)) == (MaxL << i));
+        FAST_CHECK(arith_uint256V(std::vector<unsigned char>(TmpArray,TmpArray+32)) == (MaxL << i));
         TmpL = MaxL; TmpL <<= i;
-        BOOST_CHECK(TmpL == (MaxL << i));
+        FAST_CHECK(TmpL == (MaxL << i));
 
         shiftArrayRight(TmpArray, MaxArray, 32, i);
-        BOOST_CHECK(arith_uint256V(std::vector<unsigned char>(TmpArray,TmpArray+32)) == (MaxL >> i));
+        FAST_CHECK(arith_uint256V(std::vector<unsigned char>(TmpArray,TmpArray+32)) == (MaxL >> i));
         TmpL = MaxL; TmpL >>= i;
-        BOOST_CHECK(TmpL == (MaxL >> i));
+        FAST_CHECK(TmpL == (MaxL >> i));
     }
     arith_uint256 c1L = arith_uint256(0x0123456789abcdefULL);
     arith_uint256 c2L = c1L << 128;
     for (unsigned int i = 0; i < 128; ++i) {
-        BOOST_CHECK((c1L << i) == (c2L >> (128-i)));
+        FAST_CHECK((c1L << i) == (c2L >> (128-i)));
     }
     for (unsigned int i = 128; i < 256; ++i) {
-        BOOST_CHECK((c1L << i) == (c2L << (i-128)));
+        FAST_CHECK((c1L << i) == (c2L << (i-128)));
     }
 }
 
 BOOST_AUTO_TEST_CASE( unaryOperators ) // !    ~    -
 {
-    BOOST_CHECK(!ZeroL);
-    BOOST_CHECK(!(!OneL));
+    FAST_CHECK(!ZeroL);
+    FAST_CHECK(!(!OneL));
     for (unsigned int i = 0; i < 256; ++i)
-        BOOST_CHECK(!(!(OneL<<i)));
-    BOOST_CHECK(!(!R1L));
-    BOOST_CHECK(!(!MaxL));
+        FAST_CHECK(!(!(OneL<<i)));
+    FAST_CHECK(!(!R1L));
+    FAST_CHECK(!(!MaxL));
 
-    BOOST_CHECK(~ZeroL == MaxL);
+    FAST_CHECK(~ZeroL == MaxL);
 
     unsigned char TmpArray[32];
     for (unsigned int i = 0; i < 32; ++i) { TmpArray[i] = ~R1Array[i]; }
-    BOOST_CHECK(arith_uint256V(std::vector<unsigned char>(TmpArray,TmpArray+32)) == (~R1L));
+    FAST_CHECK(arith_uint256V(std::vector<unsigned char>(TmpArray,TmpArray+32)) == (~R1L));
 
-    BOOST_CHECK(-ZeroL == ZeroL);
-    BOOST_CHECK(-R1L == (~R1L)+1);
+    FAST_CHECK(-ZeroL == ZeroL);
+    FAST_CHECK(-R1L == (~R1L)+1);
     for (unsigned int i = 0; i < 256; ++i)
-        BOOST_CHECK(-(OneL<<i) == (MaxL << i));
+        FAST_CHECK(-(OneL<<i) == (MaxL << i));
 }
 
 
@@ -222,10 +222,10 @@ BOOST_AUTO_TEST_CASE( unaryOperators ) // !    ~    -
 // element of Aarray and Barray, and then converting the result into a arith_uint256.
 #define CHECKBITWISEOPERATOR(_A_,_B_,_OP_)                              \
     for (unsigned int i = 0; i < 32; ++i) { TmpArray[i] = _A_##Array[i] _OP_ _B_##Array[i]; } \
-    BOOST_CHECK(arith_uint256V(std::vector<unsigned char>(TmpArray,TmpArray+32)) == (_A_##L _OP_ _B_##L));
+    FAST_CHECK(arith_uint256V(std::vector<unsigned char>(TmpArray,TmpArray+32)) == (_A_##L _OP_ _B_##L));
 
 #define CHECKASSIGNMENTOPERATOR(_A_,_B_,_OP_)                           \
-    TmpL = _A_##L; TmpL _OP_##= _B_##L; BOOST_CHECK(TmpL == (_A_##L _OP_ _B_##L));
+    TmpL = _A_##L; TmpL _OP_##= _B_##L; FAST_CHECK(TmpL == (_A_##L _OP_ _B_##L));
 
 BOOST_AUTO_TEST_CASE( bitwiseOperators )
 {
@@ -265,10 +265,10 @@ BOOST_AUTO_TEST_CASE( bitwiseOperators )
     CHECKASSIGNMENTOPERATOR(Max,R1,&)
 
     uint64_t Tmp64 = 0xe1db685c9a0b47a2ULL;
-    TmpL = R1L; TmpL |= Tmp64;  BOOST_CHECK(TmpL == (R1L | arith_uint256(Tmp64)));
-    TmpL = R1L; TmpL |= 0; BOOST_CHECK(TmpL == R1L);
-    TmpL ^= 0; BOOST_CHECK(TmpL == R1L);
-    TmpL ^= Tmp64;  BOOST_CHECK(TmpL == (R1L ^ arith_uint256(Tmp64)));
+    TmpL = R1L; TmpL |= Tmp64;  FAST_CHECK(TmpL == (R1L | arith_uint256(Tmp64)));
+    TmpL = R1L; TmpL |= 0; FAST_CHECK(TmpL == R1L);
+    TmpL ^= 0; FAST_CHECK(TmpL == R1L);
+    TmpL ^= Tmp64;  FAST_CHECK(TmpL == (R1L ^ arith_uint256(Tmp64)));
 }
 
 BOOST_AUTO_TEST_CASE( comparison ) // <= >= < >
@@ -276,96 +276,96 @@ BOOST_AUTO_TEST_CASE( comparison ) // <= >= < >
     arith_uint256 TmpL;
     for (unsigned int i = 0; i < 256; ++i) {
         TmpL= OneL<< i;
-        BOOST_CHECK( TmpL >= ZeroL && TmpL > ZeroL && ZeroL < TmpL && ZeroL <= TmpL);
-        BOOST_CHECK( TmpL >= 0 && TmpL > 0 && 0 < TmpL && 0 <= TmpL);
+        FAST_CHECK( TmpL >= ZeroL && TmpL > ZeroL && ZeroL < TmpL && ZeroL <= TmpL);
+        FAST_CHECK( TmpL >= 0 && TmpL > 0 && 0 < TmpL && 0 <= TmpL);
         TmpL |= R1L;
-        BOOST_CHECK( TmpL >= R1L ); BOOST_CHECK( (TmpL == R1L) != (TmpL > R1L)); BOOST_CHECK( (TmpL == R1L) || !( TmpL <= R1L));
-        BOOST_CHECK( R1L <= TmpL ); BOOST_CHECK( (R1L == TmpL) != (R1L < TmpL)); BOOST_CHECK( (TmpL == R1L) || !( R1L >= TmpL));
-        BOOST_CHECK(! (TmpL < R1L)); BOOST_CHECK(! (R1L > TmpL));
+        FAST_CHECK( TmpL >= R1L ); FAST_CHECK( (TmpL == R1L) != (TmpL > R1L)); FAST_CHECK( (TmpL == R1L) || !( TmpL <= R1L));
+        FAST_CHECK( R1L <= TmpL ); FAST_CHECK( (R1L == TmpL) != (R1L < TmpL)); FAST_CHECK( (TmpL == R1L) || !( R1L >= TmpL));
+        FAST_CHECK(! (TmpL < R1L)); FAST_CHECK(! (R1L > TmpL));
     }
 }
 
 BOOST_AUTO_TEST_CASE( plusMinus )
 {
     arith_uint256 TmpL = 0;
-    BOOST_CHECK(R1L+R2L == arith_uint256(R1LplusR2L));
+    FAST_CHECK(R1L+R2L == arith_uint256(R1LplusR2L));
     TmpL += R1L;
-    BOOST_CHECK(TmpL == R1L);
+    FAST_CHECK(TmpL == R1L);
     TmpL += R2L;
-    BOOST_CHECK(TmpL == R1L + R2L);
-    BOOST_CHECK(OneL+MaxL == ZeroL);
-    BOOST_CHECK(MaxL+OneL == ZeroL);
+    FAST_CHECK(TmpL == R1L + R2L);
+    FAST_CHECK(OneL+MaxL == ZeroL);
+    FAST_CHECK(MaxL+OneL == ZeroL);
     for (unsigned int i = 1; i < 256; ++i) {
-        BOOST_CHECK( (MaxL >> i) + OneL == (HalfL >> (i-1)) );
-        BOOST_CHECK( OneL + (MaxL >> i) == (HalfL >> (i-1)) );
+        FAST_CHECK( (MaxL >> i) + OneL == (HalfL >> (i-1)) );
+        FAST_CHECK( OneL + (MaxL >> i) == (HalfL >> (i-1)) );
         TmpL = (MaxL>>i); TmpL += OneL;
-        BOOST_CHECK( TmpL == (HalfL >> (i-1)) );
+        FAST_CHECK( TmpL == (HalfL >> (i-1)) );
         TmpL = (MaxL>>i); TmpL += 1;
-        BOOST_CHECK( TmpL == (HalfL >> (i-1)) );
+        FAST_CHECK( TmpL == (HalfL >> (i-1)) );
         TmpL = (MaxL>>i);
-        BOOST_CHECK( TmpL++ == (MaxL>>i) );
-        BOOST_CHECK( TmpL == (HalfL >> (i-1)));
+        FAST_CHECK( TmpL++ == (MaxL>>i) );
+        FAST_CHECK( TmpL == (HalfL >> (i-1)));
     }
-    BOOST_CHECK(arith_uint256(0xbedc77e27940a7ULL) + 0xee8d836fce66fbULL == arith_uint256(0xbedc77e27940a7ULL + 0xee8d836fce66fbULL));
+    FAST_CHECK(arith_uint256(0xbedc77e27940a7ULL) + 0xee8d836fce66fbULL == arith_uint256(0xbedc77e27940a7ULL + 0xee8d836fce66fbULL));
     TmpL = arith_uint256(0xbedc77e27940a7ULL); TmpL += 0xee8d836fce66fbULL;
-    BOOST_CHECK(TmpL == arith_uint256(0xbedc77e27940a7ULL+0xee8d836fce66fbULL));
-    TmpL -= 0xee8d836fce66fbULL;  BOOST_CHECK(TmpL == 0xbedc77e27940a7ULL);
+    FAST_CHECK(TmpL == arith_uint256(0xbedc77e27940a7ULL+0xee8d836fce66fbULL));
+    TmpL -= 0xee8d836fce66fbULL;  FAST_CHECK(TmpL == 0xbedc77e27940a7ULL);
     TmpL = R1L;
-    BOOST_CHECK(++TmpL == R1L+1);
+    FAST_CHECK(++TmpL == R1L+1);
 
-    BOOST_CHECK(R1L -(-R2L) == R1L+R2L);
-    BOOST_CHECK(R1L -(-OneL) == R1L+OneL);
-    BOOST_CHECK(R1L - OneL == R1L+(-OneL));
+    FAST_CHECK(R1L -(-R2L) == R1L+R2L);
+    FAST_CHECK(R1L -(-OneL) == R1L+OneL);
+    FAST_CHECK(R1L - OneL == R1L+(-OneL));
     for (unsigned int i = 1; i < 256; ++i) {
-        BOOST_CHECK((MaxL>>i) - (-OneL)  == (HalfL >> (i-1)));
-        BOOST_CHECK((HalfL >> (i-1)) - OneL == (MaxL>>i));
+        FAST_CHECK((MaxL>>i) - (-OneL)  == (HalfL >> (i-1)));
+        FAST_CHECK((HalfL >> (i-1)) - OneL == (MaxL>>i));
         TmpL = (HalfL >> (i-1));
-        BOOST_CHECK(TmpL-- == (HalfL >> (i-1)));
-        BOOST_CHECK(TmpL == (MaxL >> i));
+        FAST_CHECK(TmpL-- == (HalfL >> (i-1)));
+        FAST_CHECK(TmpL == (MaxL >> i));
         TmpL = (HalfL >> (i-1));
-        BOOST_CHECK(--TmpL == (MaxL >> i));
+        FAST_CHECK(--TmpL == (MaxL >> i));
     }
     TmpL = R1L;
-    BOOST_CHECK(--TmpL == R1L-1);
+    FAST_CHECK(--TmpL == R1L-1);
 }
 
 BOOST_AUTO_TEST_CASE( multiply )
 {
-    BOOST_CHECK((R1L * R1L).ToString() == "62a38c0486f01e45879d7910a7761bf30d5237e9873f9bff3642a732c4d84f10");
-    BOOST_CHECK((R1L * R2L).ToString() == "de37805e9986996cfba76ff6ba51c008df851987d9dd323f0e5de07760529c40");
-    BOOST_CHECK((R1L * ZeroL) == ZeroL);
-    BOOST_CHECK((R1L * OneL) == R1L);
-    BOOST_CHECK((R1L * MaxL) == -R1L);
-    BOOST_CHECK((R2L * R1L) == (R1L * R2L));
-    BOOST_CHECK((R2L * R2L).ToString() == "ac8c010096767d3cae5005dec28bb2b45a1d85ab7996ccd3e102a650f74ff100");
-    BOOST_CHECK((R2L * ZeroL) == ZeroL);
-    BOOST_CHECK((R2L * OneL) == R2L);
-    BOOST_CHECK((R2L * MaxL) == -R2L);
+    FAST_CHECK((R1L * R1L).ToString() == "62a38c0486f01e45879d7910a7761bf30d5237e9873f9bff3642a732c4d84f10");
+    FAST_CHECK((R1L * R2L).ToString() == "de37805e9986996cfba76ff6ba51c008df851987d9dd323f0e5de07760529c40");
+    FAST_CHECK((R1L * ZeroL) == ZeroL);
+    FAST_CHECK((R1L * OneL) == R1L);
+    FAST_CHECK((R1L * MaxL) == -R1L);
+    FAST_CHECK((R2L * R1L) == (R1L * R2L));
+    FAST_CHECK((R2L * R2L).ToString() == "ac8c010096767d3cae5005dec28bb2b45a1d85ab7996ccd3e102a650f74ff100");
+    FAST_CHECK((R2L * ZeroL) == ZeroL);
+    FAST_CHECK((R2L * OneL) == R2L);
+    FAST_CHECK((R2L * MaxL) == -R2L);
 
-    BOOST_CHECK(MaxL * MaxL == OneL);
+    FAST_CHECK(MaxL * MaxL == OneL);
 
-    BOOST_CHECK((R1L * 0) == 0);
-    BOOST_CHECK((R1L * 1) == R1L);
-    BOOST_CHECK((R1L * 3).ToString() == "7759b1c0ed14047f961ad09b20ff83687876a0181a367b813634046f91def7d4");
-    BOOST_CHECK((R2L * 0x87654321UL).ToString() == "23f7816e30c4ae2017257b7a0fa64d60402f5234d46e746b61c960d09a26d070");
+    FAST_CHECK((R1L * 0) == 0);
+    FAST_CHECK((R1L * 1) == R1L);
+    FAST_CHECK((R1L * 3).ToString() == "7759b1c0ed14047f961ad09b20ff83687876a0181a367b813634046f91def7d4");
+    FAST_CHECK((R2L * 0x87654321UL).ToString() == "23f7816e30c4ae2017257b7a0fa64d60402f5234d46e746b61c960d09a26d070");
 }
 
 BOOST_AUTO_TEST_CASE( divide )
 {
     arith_uint256 D1L("AD7133AC1977FA2B7");
     arith_uint256 D2L("ECD751716");
-    BOOST_CHECK((R1L / D1L).ToString() == "00000000000000000b8ac01106981635d9ed112290f8895545a7654dde28fb3a");
-    BOOST_CHECK((R1L / D2L).ToString() == "000000000873ce8efec5b67150bad3aa8c5fcb70e947586153bf2cec7c37c57a");
-    BOOST_CHECK(R1L / OneL == R1L);
-    BOOST_CHECK(R1L / MaxL == ZeroL);
-    BOOST_CHECK(MaxL / R1L == 2);
-    BOOST_CHECK_THROW(R1L / ZeroL, uint_error);
-    BOOST_CHECK((R2L / D1L).ToString() == "000000000000000013e1665895a1cc981de6d93670105a6b3ec3b73141b3a3c5");
-    BOOST_CHECK((R2L / D2L).ToString() == "000000000e8f0abe753bb0afe2e9437ee85d280be60882cf0bd1aaf7fa3cc2c4");
-    BOOST_CHECK(R2L / OneL == R2L);
-    BOOST_CHECK(R2L / MaxL == ZeroL);
-    BOOST_CHECK(MaxL / R2L == 1);
-    BOOST_CHECK_THROW(R2L / ZeroL, uint_error);
+    FAST_CHECK((R1L / D1L).ToString() == "00000000000000000b8ac01106981635d9ed112290f8895545a7654dde28fb3a");
+    FAST_CHECK((R1L / D2L).ToString() == "000000000873ce8efec5b67150bad3aa8c5fcb70e947586153bf2cec7c37c57a");
+    FAST_CHECK(R1L / OneL == R1L);
+    FAST_CHECK(R1L / MaxL == ZeroL);
+    FAST_CHECK(MaxL / R1L == 2);
+    FAST_CHECK_THROW(R1L / ZeroL, uint_error);
+    FAST_CHECK((R2L / D1L).ToString() == "000000000000000013e1665895a1cc981de6d93670105a6b3ec3b73141b3a3c5");
+    FAST_CHECK((R2L / D2L).ToString() == "000000000e8f0abe753bb0afe2e9437ee85d280be60882cf0bd1aaf7fa3cc2c4");
+    FAST_CHECK(R2L / OneL == R2L);
+    FAST_CHECK(R2L / MaxL == ZeroL);
+    FAST_CHECK(MaxL / R2L == 1);
+    FAST_CHECK_THROW(R2L / ZeroL, uint_error);
 }
 
 
@@ -376,36 +376,36 @@ bool almostEqual(double d1, double d2)
 
 BOOST_AUTO_TEST_CASE( methods ) // GetHex SetHex size() GetLow64 GetSerializeSize, Serialize, Unserialize
 {
-    BOOST_CHECK(R1L.GetHex() == R1L.ToString());
-    BOOST_CHECK(R2L.GetHex() == R2L.ToString());
-    BOOST_CHECK(OneL.GetHex() == OneL.ToString());
-    BOOST_CHECK(MaxL.GetHex() == MaxL.ToString());
+    FAST_CHECK(R1L.GetHex() == R1L.ToString());
+    FAST_CHECK(R2L.GetHex() == R2L.ToString());
+    FAST_CHECK(OneL.GetHex() == OneL.ToString());
+    FAST_CHECK(MaxL.GetHex() == MaxL.ToString());
     arith_uint256 TmpL(R1L);
-    BOOST_CHECK(TmpL == R1L);
-    TmpL.SetHex(R2L.ToString());   BOOST_CHECK(TmpL == R2L);
-    TmpL.SetHex(ZeroL.ToString()); BOOST_CHECK(TmpL == 0);
-    TmpL.SetHex(HalfL.ToString()); BOOST_CHECK(TmpL == HalfL);
+    FAST_CHECK(TmpL == R1L);
+    TmpL.SetHex(R2L.ToString());   FAST_CHECK(TmpL == R2L);
+    TmpL.SetHex(ZeroL.ToString()); FAST_CHECK(TmpL == 0);
+    TmpL.SetHex(HalfL.ToString()); FAST_CHECK(TmpL == HalfL);
 
     TmpL.SetHex(R1L.ToString());
-    BOOST_CHECK(R1L.size() == 32);
-    BOOST_CHECK(R2L.size() == 32);
-    BOOST_CHECK(ZeroL.size() == 32);
-    BOOST_CHECK(MaxL.size() == 32);
-    BOOST_CHECK(R1L.GetLow64()  == R1LLow64);
-    BOOST_CHECK(HalfL.GetLow64() ==0x0000000000000000ULL);
-    BOOST_CHECK(OneL.GetLow64() ==0x0000000000000001ULL);
+    FAST_CHECK(R1L.size() == 32);
+    FAST_CHECK(R2L.size() == 32);
+    FAST_CHECK(ZeroL.size() == 32);
+    FAST_CHECK(MaxL.size() == 32);
+    FAST_CHECK(R1L.GetLow64()  == R1LLow64);
+    FAST_CHECK(HalfL.GetLow64() ==0x0000000000000000ULL);
+    FAST_CHECK(OneL.GetLow64() ==0x0000000000000001ULL);
 
     for (unsigned int i = 0; i < 255; ++i)
     {
-        BOOST_CHECK((OneL << i).getdouble() == ldexp(1.0,i));
+        FAST_CHECK((OneL << i).getdouble() == ldexp(1.0,i));
     }
-    BOOST_CHECK(ZeroL.getdouble() == 0.0);
+    FAST_CHECK(ZeroL.getdouble() == 0.0);
     for (int i = 256; i > 53; --i)
-        BOOST_CHECK(almostEqual((R1L>>(256-i)).getdouble(), ldexp(R1Ldouble,i)));
+        FAST_CHECK(almostEqual((R1L>>(256-i)).getdouble(), ldexp(R1Ldouble,i)));
     uint64_t R1L64part = (R1L>>192).GetLow64();
     for (int i = 53; i > 0; --i) // doubles can store all integers in {0,...,2^54-1} exactly
     {
-        BOOST_CHECK((R1L>>(256-i)).getdouble() == (double)(R1L64part >> (64-i)));
+        FAST_CHECK((R1L>>(256-i)).getdouble() == (double)(R1L64part >> (64-i)));
     }
 }
 
@@ -415,146 +415,146 @@ BOOST_AUTO_TEST_CASE(bignum_SetCompact)
     bool fNegative;
     bool fOverflow;
     num.SetCompact(0, &fNegative, &fOverflow);
-    BOOST_CHECK_EQUAL(num.GetHex(), "0000000000000000000000000000000000000000000000000000000000000000");
-    BOOST_CHECK_EQUAL(num.GetCompact(), 0U);
-    BOOST_CHECK_EQUAL(fNegative, false);
-    BOOST_CHECK_EQUAL(fOverflow, false);
+    FAST_CHECK_EQUAL(num.GetHex(), "0000000000000000000000000000000000000000000000000000000000000000");
+    FAST_CHECK_EQUAL(num.GetCompact(), 0U);
+    FAST_CHECK_EQUAL(fNegative, false);
+    FAST_CHECK_EQUAL(fOverflow, false);
 
     num.SetCompact(0x00123456, &fNegative, &fOverflow);
-    BOOST_CHECK_EQUAL(num.GetHex(), "0000000000000000000000000000000000000000000000000000000000000000");
-    BOOST_CHECK_EQUAL(num.GetCompact(), 0U);
-    BOOST_CHECK_EQUAL(fNegative, false);
-    BOOST_CHECK_EQUAL(fOverflow, false);
+    FAST_CHECK_EQUAL(num.GetHex(), "0000000000000000000000000000000000000000000000000000000000000000");
+    FAST_CHECK_EQUAL(num.GetCompact(), 0U);
+    FAST_CHECK_EQUAL(fNegative, false);
+    FAST_CHECK_EQUAL(fOverflow, false);
 
     num.SetCompact(0x01003456, &fNegative, &fOverflow);
-    BOOST_CHECK_EQUAL(num.GetHex(), "0000000000000000000000000000000000000000000000000000000000000000");
-    BOOST_CHECK_EQUAL(num.GetCompact(), 0U);
-    BOOST_CHECK_EQUAL(fNegative, false);
-    BOOST_CHECK_EQUAL(fOverflow, false);
+    FAST_CHECK_EQUAL(num.GetHex(), "0000000000000000000000000000000000000000000000000000000000000000");
+    FAST_CHECK_EQUAL(num.GetCompact(), 0U);
+    FAST_CHECK_EQUAL(fNegative, false);
+    FAST_CHECK_EQUAL(fOverflow, false);
 
     num.SetCompact(0x02000056, &fNegative, &fOverflow);
-    BOOST_CHECK_EQUAL(num.GetHex(), "0000000000000000000000000000000000000000000000000000000000000000");
-    BOOST_CHECK_EQUAL(num.GetCompact(), 0U);
-    BOOST_CHECK_EQUAL(fNegative, false);
-    BOOST_CHECK_EQUAL(fOverflow, false);
+    FAST_CHECK_EQUAL(num.GetHex(), "0000000000000000000000000000000000000000000000000000000000000000");
+    FAST_CHECK_EQUAL(num.GetCompact(), 0U);
+    FAST_CHECK_EQUAL(fNegative, false);
+    FAST_CHECK_EQUAL(fOverflow, false);
 
     num.SetCompact(0x03000000, &fNegative, &fOverflow);
-    BOOST_CHECK_EQUAL(num.GetHex(), "0000000000000000000000000000000000000000000000000000000000000000");
-    BOOST_CHECK_EQUAL(num.GetCompact(), 0U);
-    BOOST_CHECK_EQUAL(fNegative, false);
-    BOOST_CHECK_EQUAL(fOverflow, false);
+    FAST_CHECK_EQUAL(num.GetHex(), "0000000000000000000000000000000000000000000000000000000000000000");
+    FAST_CHECK_EQUAL(num.GetCompact(), 0U);
+    FAST_CHECK_EQUAL(fNegative, false);
+    FAST_CHECK_EQUAL(fOverflow, false);
 
     num.SetCompact(0x04000000, &fNegative, &fOverflow);
-    BOOST_CHECK_EQUAL(num.GetHex(), "0000000000000000000000000000000000000000000000000000000000000000");
-    BOOST_CHECK_EQUAL(num.GetCompact(), 0U);
-    BOOST_CHECK_EQUAL(fNegative, false);
-    BOOST_CHECK_EQUAL(fOverflow, false);
+    FAST_CHECK_EQUAL(num.GetHex(), "0000000000000000000000000000000000000000000000000000000000000000");
+    FAST_CHECK_EQUAL(num.GetCompact(), 0U);
+    FAST_CHECK_EQUAL(fNegative, false);
+    FAST_CHECK_EQUAL(fOverflow, false);
 
     num.SetCompact(0x00923456, &fNegative, &fOverflow);
-    BOOST_CHECK_EQUAL(num.GetHex(), "0000000000000000000000000000000000000000000000000000000000000000");
-    BOOST_CHECK_EQUAL(num.GetCompact(), 0U);
-    BOOST_CHECK_EQUAL(fNegative, false);
-    BOOST_CHECK_EQUAL(fOverflow, false);
+    FAST_CHECK_EQUAL(num.GetHex(), "0000000000000000000000000000000000000000000000000000000000000000");
+    FAST_CHECK_EQUAL(num.GetCompact(), 0U);
+    FAST_CHECK_EQUAL(fNegative, false);
+    FAST_CHECK_EQUAL(fOverflow, false);
 
     num.SetCompact(0x01803456, &fNegative, &fOverflow);
-    BOOST_CHECK_EQUAL(num.GetHex(), "0000000000000000000000000000000000000000000000000000000000000000");
-    BOOST_CHECK_EQUAL(num.GetCompact(), 0U);
-    BOOST_CHECK_EQUAL(fNegative, false);
-    BOOST_CHECK_EQUAL(fOverflow, false);
+    FAST_CHECK_EQUAL(num.GetHex(), "0000000000000000000000000000000000000000000000000000000000000000");
+    FAST_CHECK_EQUAL(num.GetCompact(), 0U);
+    FAST_CHECK_EQUAL(fNegative, false);
+    FAST_CHECK_EQUAL(fOverflow, false);
 
     num.SetCompact(0x02800056, &fNegative, &fOverflow);
-    BOOST_CHECK_EQUAL(num.GetHex(), "0000000000000000000000000000000000000000000000000000000000000000");
-    BOOST_CHECK_EQUAL(num.GetCompact(), 0U);
-    BOOST_CHECK_EQUAL(fNegative, false);
-    BOOST_CHECK_EQUAL(fOverflow, false);
+    FAST_CHECK_EQUAL(num.GetHex(), "0000000000000000000000000000000000000000000000000000000000000000");
+    FAST_CHECK_EQUAL(num.GetCompact(), 0U);
+    FAST_CHECK_EQUAL(fNegative, false);
+    FAST_CHECK_EQUAL(fOverflow, false);
 
     num.SetCompact(0x03800000, &fNegative, &fOverflow);
-    BOOST_CHECK_EQUAL(num.GetHex(), "0000000000000000000000000000000000000000000000000000000000000000");
-    BOOST_CHECK_EQUAL(num.GetCompact(), 0U);
-    BOOST_CHECK_EQUAL(fNegative, false);
-    BOOST_CHECK_EQUAL(fOverflow, false);
+    FAST_CHECK_EQUAL(num.GetHex(), "0000000000000000000000000000000000000000000000000000000000000000");
+    FAST_CHECK_EQUAL(num.GetCompact(), 0U);
+    FAST_CHECK_EQUAL(fNegative, false);
+    FAST_CHECK_EQUAL(fOverflow, false);
 
     num.SetCompact(0x04800000, &fNegative, &fOverflow);
-    BOOST_CHECK_EQUAL(num.GetHex(), "0000000000000000000000000000000000000000000000000000000000000000");
-    BOOST_CHECK_EQUAL(num.GetCompact(), 0U);
-    BOOST_CHECK_EQUAL(fNegative, false);
-    BOOST_CHECK_EQUAL(fOverflow, false);
+    FAST_CHECK_EQUAL(num.GetHex(), "0000000000000000000000000000000000000000000000000000000000000000");
+    FAST_CHECK_EQUAL(num.GetCompact(), 0U);
+    FAST_CHECK_EQUAL(fNegative, false);
+    FAST_CHECK_EQUAL(fOverflow, false);
 
     num.SetCompact(0x01123456, &fNegative, &fOverflow);
-    BOOST_CHECK_EQUAL(num.GetHex(), "0000000000000000000000000000000000000000000000000000000000000012");
-    BOOST_CHECK_EQUAL(num.GetCompact(), 0x01120000U);
-    BOOST_CHECK_EQUAL(fNegative, false);
-    BOOST_CHECK_EQUAL(fOverflow, false);
+    FAST_CHECK_EQUAL(num.GetHex(), "0000000000000000000000000000000000000000000000000000000000000012");
+    FAST_CHECK_EQUAL(num.GetCompact(), 0x01120000U);
+    FAST_CHECK_EQUAL(fNegative, false);
+    FAST_CHECK_EQUAL(fOverflow, false);
 
     // Make sure that we don't generate compacts with the 0x00800000 bit set
     num = 0x80;
-    BOOST_CHECK_EQUAL(num.GetCompact(), 0x02008000U);
+    FAST_CHECK_EQUAL(num.GetCompact(), 0x02008000U);
 
     num.SetCompact(0x01fedcba, &fNegative, &fOverflow);
-    BOOST_CHECK_EQUAL(num.GetHex(), "000000000000000000000000000000000000000000000000000000000000007e");
-    BOOST_CHECK_EQUAL(num.GetCompact(true), 0x01fe0000U);
-    BOOST_CHECK_EQUAL(fNegative, true);
-    BOOST_CHECK_EQUAL(fOverflow, false);
+    FAST_CHECK_EQUAL(num.GetHex(), "000000000000000000000000000000000000000000000000000000000000007e");
+    FAST_CHECK_EQUAL(num.GetCompact(true), 0x01fe0000U);
+    FAST_CHECK_EQUAL(fNegative, true);
+    FAST_CHECK_EQUAL(fOverflow, false);
 
     num.SetCompact(0x02123456, &fNegative, &fOverflow);
-    BOOST_CHECK_EQUAL(num.GetHex(), "0000000000000000000000000000000000000000000000000000000000001234");
-    BOOST_CHECK_EQUAL(num.GetCompact(), 0x02123400U);
-    BOOST_CHECK_EQUAL(fNegative, false);
-    BOOST_CHECK_EQUAL(fOverflow, false);
+    FAST_CHECK_EQUAL(num.GetHex(), "0000000000000000000000000000000000000000000000000000000000001234");
+    FAST_CHECK_EQUAL(num.GetCompact(), 0x02123400U);
+    FAST_CHECK_EQUAL(fNegative, false);
+    FAST_CHECK_EQUAL(fOverflow, false);
 
     num.SetCompact(0x03123456, &fNegative, &fOverflow);
-    BOOST_CHECK_EQUAL(num.GetHex(), "0000000000000000000000000000000000000000000000000000000000123456");
-    BOOST_CHECK_EQUAL(num.GetCompact(), 0x03123456U);
-    BOOST_CHECK_EQUAL(fNegative, false);
-    BOOST_CHECK_EQUAL(fOverflow, false);
+    FAST_CHECK_EQUAL(num.GetHex(), "0000000000000000000000000000000000000000000000000000000000123456");
+    FAST_CHECK_EQUAL(num.GetCompact(), 0x03123456U);
+    FAST_CHECK_EQUAL(fNegative, false);
+    FAST_CHECK_EQUAL(fOverflow, false);
 
     num.SetCompact(0x04123456, &fNegative, &fOverflow);
-    BOOST_CHECK_EQUAL(num.GetHex(), "0000000000000000000000000000000000000000000000000000000012345600");
-    BOOST_CHECK_EQUAL(num.GetCompact(), 0x04123456U);
-    BOOST_CHECK_EQUAL(fNegative, false);
-    BOOST_CHECK_EQUAL(fOverflow, false);
+    FAST_CHECK_EQUAL(num.GetHex(), "0000000000000000000000000000000000000000000000000000000012345600");
+    FAST_CHECK_EQUAL(num.GetCompact(), 0x04123456U);
+    FAST_CHECK_EQUAL(fNegative, false);
+    FAST_CHECK_EQUAL(fOverflow, false);
 
     num.SetCompact(0x04923456, &fNegative, &fOverflow);
-    BOOST_CHECK_EQUAL(num.GetHex(), "0000000000000000000000000000000000000000000000000000000012345600");
-    BOOST_CHECK_EQUAL(num.GetCompact(true), 0x04923456U);
-    BOOST_CHECK_EQUAL(fNegative, true);
-    BOOST_CHECK_EQUAL(fOverflow, false);
+    FAST_CHECK_EQUAL(num.GetHex(), "0000000000000000000000000000000000000000000000000000000012345600");
+    FAST_CHECK_EQUAL(num.GetCompact(true), 0x04923456U);
+    FAST_CHECK_EQUAL(fNegative, true);
+    FAST_CHECK_EQUAL(fOverflow, false);
 
     num.SetCompact(0x05009234, &fNegative, &fOverflow);
-    BOOST_CHECK_EQUAL(num.GetHex(), "0000000000000000000000000000000000000000000000000000000092340000");
-    BOOST_CHECK_EQUAL(num.GetCompact(), 0x05009234U);
-    BOOST_CHECK_EQUAL(fNegative, false);
-    BOOST_CHECK_EQUAL(fOverflow, false);
+    FAST_CHECK_EQUAL(num.GetHex(), "0000000000000000000000000000000000000000000000000000000092340000");
+    FAST_CHECK_EQUAL(num.GetCompact(), 0x05009234U);
+    FAST_CHECK_EQUAL(fNegative, false);
+    FAST_CHECK_EQUAL(fOverflow, false);
 
     num.SetCompact(0x20123456, &fNegative, &fOverflow);
-    BOOST_CHECK_EQUAL(num.GetHex(), "1234560000000000000000000000000000000000000000000000000000000000");
-    BOOST_CHECK_EQUAL(num.GetCompact(), 0x20123456U);
-    BOOST_CHECK_EQUAL(fNegative, false);
-    BOOST_CHECK_EQUAL(fOverflow, false);
+    FAST_CHECK_EQUAL(num.GetHex(), "1234560000000000000000000000000000000000000000000000000000000000");
+    FAST_CHECK_EQUAL(num.GetCompact(), 0x20123456U);
+    FAST_CHECK_EQUAL(fNegative, false);
+    FAST_CHECK_EQUAL(fOverflow, false);
 
     num.SetCompact(0xff123456, &fNegative, &fOverflow);
-    BOOST_CHECK_EQUAL(fNegative, false);
-    BOOST_CHECK_EQUAL(fOverflow, true);
+    FAST_CHECK_EQUAL(fNegative, false);
+    FAST_CHECK_EQUAL(fOverflow, true);
 }
 
 
 BOOST_AUTO_TEST_CASE( getmaxcoverage ) // some more tests just to get 100% coverage
 {
     // ~R1L give a base_uint<256>
-    BOOST_CHECK((~~R1L >> 10) == (R1L >> 10));
-    BOOST_CHECK((~~R1L << 10) == (R1L << 10));
-    BOOST_CHECK(!(~~R1L < R1L));
-    BOOST_CHECK(~~R1L <= R1L);
-    BOOST_CHECK(!(~~R1L > R1L));
-    BOOST_CHECK(~~R1L >= R1L);
-    BOOST_CHECK(!(R1L < ~~R1L));
-    BOOST_CHECK(R1L <= ~~R1L);
-    BOOST_CHECK(!(R1L > ~~R1L));
-    BOOST_CHECK(R1L >= ~~R1L);
+    FAST_CHECK((~~R1L >> 10) == (R1L >> 10));
+    FAST_CHECK((~~R1L << 10) == (R1L << 10));
+    FAST_CHECK(!(~~R1L < R1L));
+    FAST_CHECK(~~R1L <= R1L);
+    FAST_CHECK(!(~~R1L > R1L));
+    FAST_CHECK(~~R1L >= R1L);
+    FAST_CHECK(!(R1L < ~~R1L));
+    FAST_CHECK(R1L <= ~~R1L);
+    FAST_CHECK(!(R1L > ~~R1L));
+    FAST_CHECK(R1L >= ~~R1L);
 
-    BOOST_CHECK(~~R1L + R2L == R1L + ~~R2L);
-    BOOST_CHECK(~~R1L - R2L == R1L - ~~R2L);
-    BOOST_CHECK(~R1L != R1L); BOOST_CHECK(R1L != ~R1L);
+    FAST_CHECK(~~R1L + R2L == R1L + ~~R2L);
+    FAST_CHECK(~~R1L - R2L == R1L - ~~R2L);
+    FAST_CHECK(~R1L != R1L); FAST_CHECK(R1L != ~R1L);
     unsigned char TmpArray[32];
     CHECKBITWISEOPERATOR(~R1,R2,|)
     CHECKBITWISEOPERATOR(~R1,R2,^)

--- a/src/test/base32_tests.cpp
+++ b/src/test/base32_tests.cpp
@@ -16,9 +16,9 @@ BOOST_AUTO_TEST_CASE(base32_testvectors)
     for (unsigned int i=0; i<sizeof(vstrIn)/sizeof(vstrIn[0]); i++)
     {
         std::string strEnc = EncodeBase32(vstrIn[i]);
-        BOOST_CHECK(strEnc == vstrOut[i]);
+        FAST_CHECK(strEnc == vstrOut[i]);
         std::string strDec = DecodeBase32(vstrOut[i]);
-        BOOST_CHECK(strDec == vstrIn[i]);
+        FAST_CHECK(strDec == vstrIn[i]);
     }
 }
 

--- a/src/test/base58_tests.cpp
+++ b/src/test/base58_tests.cpp
@@ -64,13 +64,13 @@ BOOST_AUTO_TEST_CASE(base58_DecodeBase58)
         BOOST_CHECK_MESSAGE(result.size() == expected.size() && std::equal(result.begin(), result.end(), expected.begin()), strTest);
     }
 
-    BOOST_CHECK(!DecodeBase58("invalid", result));
+    FAST_CHECK(!DecodeBase58("invalid", result));
 
     // check that DecodeBase58 skips whitespace, but still fails with unexpected non-whitespace at the end.
-    BOOST_CHECK(!DecodeBase58(" \t\n\v\f\r skip \r\f\v\n\t a", result));
-    BOOST_CHECK( DecodeBase58(" \t\n\v\f\r skip \r\f\v\n\t ", result));
+    FAST_CHECK(!DecodeBase58(" \t\n\v\f\r skip \r\f\v\n\t a", result));
+    FAST_CHECK( DecodeBase58(" \t\n\v\f\r skip \r\f\v\n\t ", result));
     std::vector<unsigned char> expected = ParseHex("971a55");
-    BOOST_CHECK_EQUAL_COLLECTIONS(result.begin(), result.end(), expected.begin(), expected.end());
+    FAST_CHECK_EQUAL_COLLECTIONS(result.begin(), result.end(), expected.begin(), expected.end());
 }
 
 // Visitor to check address type
@@ -236,7 +236,7 @@ BOOST_AUTO_TEST_CASE(base58_keys_valid_gen)
     // Visiting a CNoDestination must fail
     CBitcoinAddress dummyAddr;
     CTxDestination nodest = CNoDestination();
-    BOOST_CHECK(!dummyAddr.Set(nodest));
+    FAST_CHECK(!dummyAddr.Set(nodest));
 
     SelectParams(CBaseChainParams::MAIN);
 }

--- a/src/test/base64_tests.cpp
+++ b/src/test/base64_tests.cpp
@@ -16,9 +16,9 @@ BOOST_AUTO_TEST_CASE(base64_testvectors)
     for (unsigned int i=0; i<sizeof(vstrIn)/sizeof(vstrIn[0]); i++)
     {
         std::string strEnc = EncodeBase64(vstrIn[i]);
-        BOOST_CHECK(strEnc == vstrOut[i]);
+        FAST_CHECK(strEnc == vstrOut[i]);
         std::string strDec = DecodeBase64(strEnc);
-        BOOST_CHECK(strDec == vstrIn[i]);
+        FAST_CHECK(strDec == vstrIn[i]);
     }
 }
 

--- a/src/test/bip32_tests.cpp
+++ b/src/test/bip32_tests.cpp
@@ -91,7 +91,7 @@ void RunTest(const TestVector &test) {
 
         // Test private key
         CBitcoinExtKey b58key; b58key.SetKey(key);
-        BOOST_CHECK(b58key.ToString() == derive.prv);
+        FAST_CHECK(b58key.ToString() == derive.prv);
 
         CBitcoinExtKey b58keyDecodeCheck(derive.prv);
         CExtKey checkKey = b58keyDecodeCheck.GetKey();
@@ -99,7 +99,7 @@ void RunTest(const TestVector &test) {
 
         // Test public key
         CBitcoinExtPubKey b58pubkey; b58pubkey.SetKey(pubkey);
-        BOOST_CHECK(b58pubkey.ToString() == derive.pub);
+        FAST_CHECK(b58pubkey.ToString() == derive.pub);
 
         CBitcoinExtPubKey b58PubkeyDecodeCheck(derive.pub);
         CExtPubKey checkPubKey = b58PubkeyDecodeCheck.GetKey();
@@ -107,32 +107,32 @@ void RunTest(const TestVector &test) {
 
         // Derive new keys
         CExtKey keyNew;
-        BOOST_CHECK(key.Derive(keyNew, derive.nChild));
+        FAST_CHECK(key.Derive(keyNew, derive.nChild));
         CExtPubKey pubkeyNew = keyNew.Neuter();
         if (!(derive.nChild & 0x80000000)) {
             // Compare with public derivation
             CExtPubKey pubkeyNew2;
-            BOOST_CHECK(pubkey.Derive(pubkeyNew2, derive.nChild));
-            BOOST_CHECK(pubkeyNew == pubkeyNew2);
+            FAST_CHECK(pubkey.Derive(pubkeyNew2, derive.nChild));
+            FAST_CHECK(pubkeyNew == pubkeyNew2);
         }
         key = keyNew;
         pubkey = pubkeyNew;
 
         CDataStream ssPub(SER_DISK, CLIENT_VERSION);
         ssPub << pubkeyNew;
-        BOOST_CHECK(ssPub.size() == 75);
+        FAST_CHECK(ssPub.size() == 75);
 
         CDataStream ssPriv(SER_DISK, CLIENT_VERSION);
         ssPriv << keyNew;
-        BOOST_CHECK(ssPriv.size() == 75);
+        FAST_CHECK(ssPriv.size() == 75);
 
         CExtPubKey pubCheck;
         CExtKey privCheck;
         ssPub >> pubCheck;
         ssPriv >> privCheck;
 
-        BOOST_CHECK(pubCheck == pubkeyNew);
-        BOOST_CHECK(privCheck == keyNew);
+        FAST_CHECK(pubCheck == pubkeyNew);
+        FAST_CHECK(privCheck == keyNew);
     }
 }
 

--- a/src/test/blockencodings_tests.cpp
+++ b/src/test/blockencodings_tests.cpp
@@ -60,7 +60,7 @@ BOOST_AUTO_TEST_CASE(SimpleRoundTripTest)
     CBlock block(BuildBlockTestCase());
 
     pool.addUnchecked(block.vtx[2].GetHash(), entry.FromTx(block.vtx[2]));
-    BOOST_CHECK_EQUAL(pool.mapTx.find(block.vtx[2].GetHash())->GetSharedTx().use_count(), SHARED_TX_OFFSET + 0);
+    FAST_CHECK_EQUAL(pool.mapTx.find(block.vtx[2].GetHash())->GetSharedTx().use_count(), SHARED_TX_OFFSET + 0);
 
     // Do a simple ShortTxIDs RT
     {
@@ -73,32 +73,32 @@ BOOST_AUTO_TEST_CASE(SimpleRoundTripTest)
         stream >> shortIDs2;
 
         PartiallyDownloadedBlock partialBlock(&pool);
-        BOOST_CHECK(partialBlock.InitData(shortIDs2) == READ_STATUS_OK);
-        BOOST_CHECK( partialBlock.IsTxAvailable(0));
-        BOOST_CHECK(!partialBlock.IsTxAvailable(1));
-        BOOST_CHECK( partialBlock.IsTxAvailable(2));
+        FAST_CHECK(partialBlock.InitData(shortIDs2) == READ_STATUS_OK);
+        FAST_CHECK( partialBlock.IsTxAvailable(0));
+        FAST_CHECK(!partialBlock.IsTxAvailable(1));
+        FAST_CHECK( partialBlock.IsTxAvailable(2));
 
-        BOOST_CHECK_EQUAL(pool.mapTx.find(block.vtx[2].GetHash())->GetSharedTx().use_count(), SHARED_TX_OFFSET + 1);
+        FAST_CHECK_EQUAL(pool.mapTx.find(block.vtx[2].GetHash())->GetSharedTx().use_count(), SHARED_TX_OFFSET + 1);
 
         std::list<CTransaction> removed;
         pool.removeRecursive(block.vtx[2], removed);
-        BOOST_CHECK_EQUAL(removed.size(), 1);
+        FAST_CHECK_EQUAL(removed.size(), 1);
 
         CBlock block2;
         std::vector<CTransaction> vtx_missing;
-        BOOST_CHECK(partialBlock.FillBlock(block2, vtx_missing) == READ_STATUS_INVALID); // No transactions
+        FAST_CHECK(partialBlock.FillBlock(block2, vtx_missing) == READ_STATUS_INVALID); // No transactions
 
         vtx_missing.push_back(block.vtx[2]); // Wrong transaction
         partialBlock.FillBlock(block2, vtx_missing); // Current implementation doesn't check txn here, but don't require that
         bool mutated;
-        BOOST_CHECK(block.hashMerkleRoot != BlockMerkleRoot(block2, &mutated));
+        FAST_CHECK(block.hashMerkleRoot != BlockMerkleRoot(block2, &mutated));
 
         vtx_missing[0] = block.vtx[1];
         CBlock block3;
-        BOOST_CHECK(partialBlock.FillBlock(block3, vtx_missing) == READ_STATUS_OK);
-        BOOST_CHECK_EQUAL(block.GetHash().ToString(), block3.GetHash().ToString());
-        BOOST_CHECK_EQUAL(block.hashMerkleRoot.ToString(), BlockMerkleRoot(block3, &mutated).ToString());
-        BOOST_CHECK(!mutated);
+        FAST_CHECK(partialBlock.FillBlock(block3, vtx_missing) == READ_STATUS_OK);
+        FAST_CHECK_EQUAL(block.GetHash().ToString(), block3.GetHash().ToString());
+        FAST_CHECK_EQUAL(block.hashMerkleRoot.ToString(), BlockMerkleRoot(block3, &mutated).ToString());
+        FAST_CHECK(!mutated);
     }
 }
 
@@ -153,7 +153,7 @@ BOOST_AUTO_TEST_CASE(NonCoinbasePreforwardRTTest)
     CBlock block(BuildBlockTestCase());
 
     pool.addUnchecked(block.vtx[2].GetHash(), entry.FromTx(block.vtx[2]));
-    BOOST_CHECK_EQUAL(pool.mapTx.find(block.vtx[2].GetHash())->GetSharedTx().use_count(), SHARED_TX_OFFSET + 0);
+    FAST_CHECK_EQUAL(pool.mapTx.find(block.vtx[2].GetHash())->GetSharedTx().use_count(), SHARED_TX_OFFSET + 0);
 
     // Test with pre-forwarding tx 1, but not coinbase
     {
@@ -171,32 +171,32 @@ BOOST_AUTO_TEST_CASE(NonCoinbasePreforwardRTTest)
         stream >> shortIDs2;
 
         PartiallyDownloadedBlock partialBlock(&pool);
-        BOOST_CHECK(partialBlock.InitData(shortIDs2) == READ_STATUS_OK);
-        BOOST_CHECK(!partialBlock.IsTxAvailable(0));
-        BOOST_CHECK( partialBlock.IsTxAvailable(1));
-        BOOST_CHECK( partialBlock.IsTxAvailable(2));
+        FAST_CHECK(partialBlock.InitData(shortIDs2) == READ_STATUS_OK);
+        FAST_CHECK(!partialBlock.IsTxAvailable(0));
+        FAST_CHECK( partialBlock.IsTxAvailable(1));
+        FAST_CHECK( partialBlock.IsTxAvailable(2));
 
-        BOOST_CHECK_EQUAL(pool.mapTx.find(block.vtx[2].GetHash())->GetSharedTx().use_count(), SHARED_TX_OFFSET + 1);
+        FAST_CHECK_EQUAL(pool.mapTx.find(block.vtx[2].GetHash())->GetSharedTx().use_count(), SHARED_TX_OFFSET + 1);
 
         CBlock block2;
         std::vector<CTransaction> vtx_missing;
-        BOOST_CHECK(partialBlock.FillBlock(block2, vtx_missing) == READ_STATUS_INVALID); // No transactions
+        FAST_CHECK(partialBlock.FillBlock(block2, vtx_missing) == READ_STATUS_INVALID); // No transactions
 
         vtx_missing.push_back(block.vtx[1]); // Wrong transaction
         partialBlock.FillBlock(block2, vtx_missing); // Current implementation doesn't check txn here, but don't require that
         bool mutated;
-        BOOST_CHECK(block.hashMerkleRoot != BlockMerkleRoot(block2, &mutated));
+        FAST_CHECK(block.hashMerkleRoot != BlockMerkleRoot(block2, &mutated));
 
         vtx_missing[0] = block.vtx[0];
         CBlock block3;
-        BOOST_CHECK(partialBlock.FillBlock(block3, vtx_missing) == READ_STATUS_OK);
-        BOOST_CHECK_EQUAL(block.GetHash().ToString(), block3.GetHash().ToString());
-        BOOST_CHECK_EQUAL(block.hashMerkleRoot.ToString(), BlockMerkleRoot(block3, &mutated).ToString());
-        BOOST_CHECK(!mutated);
+        FAST_CHECK(partialBlock.FillBlock(block3, vtx_missing) == READ_STATUS_OK);
+        FAST_CHECK_EQUAL(block.GetHash().ToString(), block3.GetHash().ToString());
+        FAST_CHECK_EQUAL(block.hashMerkleRoot.ToString(), BlockMerkleRoot(block3, &mutated).ToString());
+        FAST_CHECK(!mutated);
 
-        BOOST_CHECK_EQUAL(pool.mapTx.find(block.vtx[2].GetHash())->GetSharedTx().use_count(), SHARED_TX_OFFSET + 1);
+        FAST_CHECK_EQUAL(pool.mapTx.find(block.vtx[2].GetHash())->GetSharedTx().use_count(), SHARED_TX_OFFSET + 1);
     }
-    BOOST_CHECK_EQUAL(pool.mapTx.find(block.vtx[2].GetHash())->GetSharedTx().use_count(), SHARED_TX_OFFSET + 0);
+    FAST_CHECK_EQUAL(pool.mapTx.find(block.vtx[2].GetHash())->GetSharedTx().use_count(), SHARED_TX_OFFSET + 0);
 }
 
 BOOST_AUTO_TEST_CASE(SufficientPreforwardRTTest)
@@ -206,7 +206,7 @@ BOOST_AUTO_TEST_CASE(SufficientPreforwardRTTest)
     CBlock block(BuildBlockTestCase());
 
     pool.addUnchecked(block.vtx[1].GetHash(), entry.FromTx(block.vtx[1]));
-    BOOST_CHECK_EQUAL(pool.mapTx.find(block.vtx[1].GetHash())->GetSharedTx().use_count(), SHARED_TX_OFFSET + 0);
+    FAST_CHECK_EQUAL(pool.mapTx.find(block.vtx[1].GetHash())->GetSharedTx().use_count(), SHARED_TX_OFFSET + 0);
 
     // Test with pre-forwarding coinbase + tx 2 with tx 1 in mempool
     {
@@ -224,24 +224,24 @@ BOOST_AUTO_TEST_CASE(SufficientPreforwardRTTest)
         stream >> shortIDs2;
 
         PartiallyDownloadedBlock partialBlock(&pool);
-        BOOST_CHECK(partialBlock.InitData(shortIDs2) == READ_STATUS_OK);
-        BOOST_CHECK( partialBlock.IsTxAvailable(0));
-        BOOST_CHECK( partialBlock.IsTxAvailable(1));
-        BOOST_CHECK( partialBlock.IsTxAvailable(2));
+        FAST_CHECK(partialBlock.InitData(shortIDs2) == READ_STATUS_OK);
+        FAST_CHECK( partialBlock.IsTxAvailable(0));
+        FAST_CHECK( partialBlock.IsTxAvailable(1));
+        FAST_CHECK( partialBlock.IsTxAvailable(2));
 
-        BOOST_CHECK_EQUAL(pool.mapTx.find(block.vtx[1].GetHash())->GetSharedTx().use_count(), SHARED_TX_OFFSET + 1);
+        FAST_CHECK_EQUAL(pool.mapTx.find(block.vtx[1].GetHash())->GetSharedTx().use_count(), SHARED_TX_OFFSET + 1);
 
         CBlock block2;
         std::vector<CTransaction> vtx_missing;
-        BOOST_CHECK(partialBlock.FillBlock(block2, vtx_missing) == READ_STATUS_OK);
-        BOOST_CHECK_EQUAL(block.GetHash().ToString(), block2.GetHash().ToString());
+        FAST_CHECK(partialBlock.FillBlock(block2, vtx_missing) == READ_STATUS_OK);
+        FAST_CHECK_EQUAL(block.GetHash().ToString(), block2.GetHash().ToString());
         bool mutated;
-        BOOST_CHECK_EQUAL(block.hashMerkleRoot.ToString(), BlockMerkleRoot(block2, &mutated).ToString());
-        BOOST_CHECK(!mutated);
+        FAST_CHECK_EQUAL(block.hashMerkleRoot.ToString(), BlockMerkleRoot(block2, &mutated).ToString());
+        FAST_CHECK(!mutated);
 
-        BOOST_CHECK_EQUAL(pool.mapTx.find(block.vtx[1].GetHash())->GetSharedTx().use_count(), SHARED_TX_OFFSET + 1);
+        FAST_CHECK_EQUAL(pool.mapTx.find(block.vtx[1].GetHash())->GetSharedTx().use_count(), SHARED_TX_OFFSET + 1);
     }
-    BOOST_CHECK_EQUAL(pool.mapTx.find(block.vtx[1].GetHash())->GetSharedTx().use_count(), SHARED_TX_OFFSET + 0);
+    FAST_CHECK_EQUAL(pool.mapTx.find(block.vtx[1].GetHash())->GetSharedTx().use_count(), SHARED_TX_OFFSET + 0);
 }
 
 BOOST_AUTO_TEST_CASE(EmptyBlockRoundTripTest)
@@ -276,16 +276,16 @@ BOOST_AUTO_TEST_CASE(EmptyBlockRoundTripTest)
         stream >> shortIDs2;
 
         PartiallyDownloadedBlock partialBlock(&pool);
-        BOOST_CHECK(partialBlock.InitData(shortIDs2) == READ_STATUS_OK);
-        BOOST_CHECK(partialBlock.IsTxAvailable(0));
+        FAST_CHECK(partialBlock.InitData(shortIDs2) == READ_STATUS_OK);
+        FAST_CHECK(partialBlock.IsTxAvailable(0));
 
         CBlock block2;
         std::vector<CTransaction> vtx_missing;
-        BOOST_CHECK(partialBlock.FillBlock(block2, vtx_missing) == READ_STATUS_OK);
-        BOOST_CHECK_EQUAL(block.GetHash().ToString(), block2.GetHash().ToString());
+        FAST_CHECK(partialBlock.FillBlock(block2, vtx_missing) == READ_STATUS_OK);
+        FAST_CHECK_EQUAL(block.GetHash().ToString(), block2.GetHash().ToString());
         bool mutated;
-        BOOST_CHECK_EQUAL(block.hashMerkleRoot.ToString(), BlockMerkleRoot(block2, &mutated).ToString());
-        BOOST_CHECK(!mutated);
+        FAST_CHECK_EQUAL(block.hashMerkleRoot.ToString(), BlockMerkleRoot(block2, &mutated).ToString());
+        FAST_CHECK(!mutated);
     }
 }
 
@@ -304,12 +304,12 @@ BOOST_AUTO_TEST_CASE(TransactionsRequestSerializationTest) {
     BlockTransactionsRequest req2;
     stream >> req2;
 
-    BOOST_CHECK_EQUAL(req1.blockhash.ToString(), req2.blockhash.ToString());
-    BOOST_CHECK_EQUAL(req1.indexes.size(), req2.indexes.size());
-    BOOST_CHECK_EQUAL(req1.indexes[0], req2.indexes[0]);
-    BOOST_CHECK_EQUAL(req1.indexes[1], req2.indexes[1]);
-    BOOST_CHECK_EQUAL(req1.indexes[2], req2.indexes[2]);
-    BOOST_CHECK_EQUAL(req1.indexes[3], req2.indexes[3]);
+    FAST_CHECK_EQUAL(req1.blockhash.ToString(), req2.blockhash.ToString());
+    FAST_CHECK_EQUAL(req1.indexes.size(), req2.indexes.size());
+    FAST_CHECK_EQUAL(req1.indexes[0], req2.indexes[0]);
+    FAST_CHECK_EQUAL(req1.indexes[1], req2.indexes[1]);
+    FAST_CHECK_EQUAL(req1.indexes[2], req2.indexes[2]);
+    FAST_CHECK_EQUAL(req1.indexes[3], req2.indexes[3]);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/bloom_tests.cpp
+++ b/src/test/bloom_tests.cpp
@@ -49,7 +49,7 @@ BOOST_AUTO_TEST_CASE(bloom_create_insert_serialize)
     for (unsigned int i = 0; i < vch.size(); i++)
         expected[i] = (char)vch[i];
 
-    BOOST_CHECK_EQUAL_COLLECTIONS(stream.begin(), stream.end(), expected.begin(), expected.end());
+    FAST_CHECK_EQUAL_COLLECTIONS(stream.begin(), stream.end(), expected.begin(), expected.end());
 
     BOOST_CHECK_MESSAGE( filter.contains(ParseHex("99108ad8ed9bb6274d3980bab5a85c048f0950c8")), "BloomFilter doesn't contain just-inserted object!");
     filter.clear();
@@ -81,14 +81,14 @@ BOOST_AUTO_TEST_CASE(bloom_create_insert_serialize_with_tweak)
     for (unsigned int i = 0; i < vch.size(); i++)
         expected[i] = (char)vch[i];
 
-    BOOST_CHECK_EQUAL_COLLECTIONS(stream.begin(), stream.end(), expected.begin(), expected.end());
+    FAST_CHECK_EQUAL_COLLECTIONS(stream.begin(), stream.end(), expected.begin(), expected.end());
 }
 
 BOOST_AUTO_TEST_CASE(bloom_create_insert_key)
 {
     string strSecret = string("5Kg1gnAjaLfKiwhhPpGS3QfRg2m6awQvaj98JCZBZQ5SuS2F15C");
     CBitcoinSecret vchSecret;
-    BOOST_CHECK(vchSecret.SetString(strSecret));
+    FAST_CHECK(vchSecret.SetString(strSecret));
 
     CKey key = vchSecret.GetKey();
     CPubKey pubkey = key.GetPubKey();
@@ -108,7 +108,7 @@ BOOST_AUTO_TEST_CASE(bloom_create_insert_key)
     for (unsigned int i = 0; i < vch.size(); i++)
         expected[i] = (char)vch[i];
 
-    BOOST_CHECK_EQUAL_COLLECTIONS(stream.begin(), stream.end(), expected.begin(), expected.end());
+    FAST_CHECK_EQUAL_COLLECTIONS(stream.begin(), stream.end(), expected.begin(), expected.end());
 }
 
 BOOST_AUTO_TEST_CASE(bloom_match)
@@ -195,37 +195,37 @@ BOOST_AUTO_TEST_CASE(merkle_block_1)
     filter.insert(uint256S("0x74d681e0e03bafa802c8aa084379aa98d9fcd632ddc2ed9782b586ec87451f20"));
 
     CMerkleBlock merkleBlock(block, filter);
-    BOOST_CHECK(merkleBlock.header.GetHash() == block.GetHash());
+    FAST_CHECK(merkleBlock.header.GetHash() == block.GetHash());
 
-    BOOST_CHECK(merkleBlock.vMatchedTxn.size() == 1);
+    FAST_CHECK(merkleBlock.vMatchedTxn.size() == 1);
     pair<unsigned int, uint256> pair = merkleBlock.vMatchedTxn[0];
 
-    BOOST_CHECK(merkleBlock.vMatchedTxn[0].second == uint256S("0x74d681e0e03bafa802c8aa084379aa98d9fcd632ddc2ed9782b586ec87451f20"));
-    BOOST_CHECK(merkleBlock.vMatchedTxn[0].first == 8);
+    FAST_CHECK(merkleBlock.vMatchedTxn[0].second == uint256S("0x74d681e0e03bafa802c8aa084379aa98d9fcd632ddc2ed9782b586ec87451f20"));
+    FAST_CHECK(merkleBlock.vMatchedTxn[0].first == 8);
 
     vector<uint256> vMatched;
     vector<unsigned int> vIndex;
-    BOOST_CHECK(merkleBlock.txn.ExtractMatches(vMatched, vIndex) == block.hashMerkleRoot);
-    BOOST_CHECK(vMatched.size() == merkleBlock.vMatchedTxn.size());
+    FAST_CHECK(merkleBlock.txn.ExtractMatches(vMatched, vIndex) == block.hashMerkleRoot);
+    FAST_CHECK(vMatched.size() == merkleBlock.vMatchedTxn.size());
     for (unsigned int i = 0; i < vMatched.size(); i++)
-        BOOST_CHECK(vMatched[i] == merkleBlock.vMatchedTxn[i].second);
+        FAST_CHECK(vMatched[i] == merkleBlock.vMatchedTxn[i].second);
 
     // Also match the 8th transaction
     filter.insert(uint256S("0xdd1fd2a6fc16404faf339881a90adbde7f4f728691ac62e8f168809cdfae1053"));
     merkleBlock = CMerkleBlock(block, filter);
-    BOOST_CHECK(merkleBlock.header.GetHash() == block.GetHash());
+    FAST_CHECK(merkleBlock.header.GetHash() == block.GetHash());
 
-    BOOST_CHECK(merkleBlock.vMatchedTxn.size() == 2);
+    FAST_CHECK(merkleBlock.vMatchedTxn.size() == 2);
 
-    BOOST_CHECK(merkleBlock.vMatchedTxn[1] == pair);
+    FAST_CHECK(merkleBlock.vMatchedTxn[1] == pair);
 
-    BOOST_CHECK(merkleBlock.vMatchedTxn[0].second == uint256S("0xdd1fd2a6fc16404faf339881a90adbde7f4f728691ac62e8f168809cdfae1053"));
-    BOOST_CHECK(merkleBlock.vMatchedTxn[0].first == 7);
+    FAST_CHECK(merkleBlock.vMatchedTxn[0].second == uint256S("0xdd1fd2a6fc16404faf339881a90adbde7f4f728691ac62e8f168809cdfae1053"));
+    FAST_CHECK(merkleBlock.vMatchedTxn[0].first == 7);
 
-    BOOST_CHECK(merkleBlock.txn.ExtractMatches(vMatched, vIndex) == block.hashMerkleRoot);
-    BOOST_CHECK(vMatched.size() == merkleBlock.vMatchedTxn.size());
+    FAST_CHECK(merkleBlock.txn.ExtractMatches(vMatched, vIndex) == block.hashMerkleRoot);
+    FAST_CHECK(vMatched.size() == merkleBlock.vMatchedTxn.size());
     for (unsigned int i = 0; i < vMatched.size(); i++)
-        BOOST_CHECK(vMatched[i] == merkleBlock.vMatchedTxn[i].second);
+        FAST_CHECK(vMatched[i] == merkleBlock.vMatchedTxn[i].second);
 }
 
 BOOST_AUTO_TEST_CASE(merkle_block_2)
@@ -241,20 +241,20 @@ BOOST_AUTO_TEST_CASE(merkle_block_2)
     filter.insert(uint256S("0xe980fe9f792d014e73b95203dc1335c5f9ce19ac537a419e6df5b47aecb93b70"));
 
     CMerkleBlock merkleBlock(block, filter);
-    BOOST_CHECK(merkleBlock.header.GetHash() == block.GetHash());
+    FAST_CHECK(merkleBlock.header.GetHash() == block.GetHash());
 
-    BOOST_CHECK(merkleBlock.vMatchedTxn.size() == 1);
+    FAST_CHECK(merkleBlock.vMatchedTxn.size() == 1);
     pair<unsigned int, uint256> pair = merkleBlock.vMatchedTxn[0];
 
-    BOOST_CHECK(merkleBlock.vMatchedTxn[0].second == uint256S("0xe980fe9f792d014e73b95203dc1335c5f9ce19ac537a419e6df5b47aecb93b70"));
-    BOOST_CHECK(merkleBlock.vMatchedTxn[0].first == 0);
+    FAST_CHECK(merkleBlock.vMatchedTxn[0].second == uint256S("0xe980fe9f792d014e73b95203dc1335c5f9ce19ac537a419e6df5b47aecb93b70"));
+    FAST_CHECK(merkleBlock.vMatchedTxn[0].first == 0);
 
     vector<uint256> vMatched;
     vector<unsigned int> vIndex;
-    BOOST_CHECK(merkleBlock.txn.ExtractMatches(vMatched, vIndex) == block.hashMerkleRoot);
-    BOOST_CHECK(vMatched.size() == merkleBlock.vMatchedTxn.size());
+    FAST_CHECK(merkleBlock.txn.ExtractMatches(vMatched, vIndex) == block.hashMerkleRoot);
+    FAST_CHECK(vMatched.size() == merkleBlock.vMatchedTxn.size());
     for (unsigned int i = 0; i < vMatched.size(); i++)
-        BOOST_CHECK(vMatched[i] == merkleBlock.vMatchedTxn[i].second);
+        FAST_CHECK(vMatched[i] == merkleBlock.vMatchedTxn[i].second);
 
     // Match an output from the second transaction (the pubkey for address 1DZTzaBHUDM7T3QvUKBz4qXMRpkg8jsfB5)
     // This should match the third transaction because it spends the output matched
@@ -262,25 +262,25 @@ BOOST_AUTO_TEST_CASE(merkle_block_2)
     filter.insert(ParseHex("044a656f065871a353f216ca26cef8dde2f03e8c16202d2e8ad769f02032cb86a5eb5e56842e92e19141d60a01928f8dd2c875a390f67c1f6c94cfc617c0ea45af"));
 
     merkleBlock = CMerkleBlock(block, filter);
-    BOOST_CHECK(merkleBlock.header.GetHash() == block.GetHash());
+    FAST_CHECK(merkleBlock.header.GetHash() == block.GetHash());
 
-    BOOST_CHECK(merkleBlock.vMatchedTxn.size() == 4);
+    FAST_CHECK(merkleBlock.vMatchedTxn.size() == 4);
 
-    BOOST_CHECK(pair == merkleBlock.vMatchedTxn[0]);
+    FAST_CHECK(pair == merkleBlock.vMatchedTxn[0]);
 
-    BOOST_CHECK(merkleBlock.vMatchedTxn[1].second == uint256S("0x28204cad1d7fc1d199e8ef4fa22f182de6258a3eaafe1bbe56ebdcacd3069a5f"));
-    BOOST_CHECK(merkleBlock.vMatchedTxn[1].first == 1);
+    FAST_CHECK(merkleBlock.vMatchedTxn[1].second == uint256S("0x28204cad1d7fc1d199e8ef4fa22f182de6258a3eaafe1bbe56ebdcacd3069a5f"));
+    FAST_CHECK(merkleBlock.vMatchedTxn[1].first == 1);
 
-    BOOST_CHECK(merkleBlock.vMatchedTxn[2].second == uint256S("0x6b0f8a73a56c04b519f1883e8aafda643ba61a30bd1439969df21bea5f4e27e2"));
-    BOOST_CHECK(merkleBlock.vMatchedTxn[2].first == 2);
+    FAST_CHECK(merkleBlock.vMatchedTxn[2].second == uint256S("0x6b0f8a73a56c04b519f1883e8aafda643ba61a30bd1439969df21bea5f4e27e2"));
+    FAST_CHECK(merkleBlock.vMatchedTxn[2].first == 2);
 
-    BOOST_CHECK(merkleBlock.vMatchedTxn[3].second == uint256S("0x3c1d7e82342158e4109df2e0b6348b6e84e403d8b4046d7007663ace63cddb23"));
-    BOOST_CHECK(merkleBlock.vMatchedTxn[3].first == 3);
+    FAST_CHECK(merkleBlock.vMatchedTxn[3].second == uint256S("0x3c1d7e82342158e4109df2e0b6348b6e84e403d8b4046d7007663ace63cddb23"));
+    FAST_CHECK(merkleBlock.vMatchedTxn[3].first == 3);
 
-    BOOST_CHECK(merkleBlock.txn.ExtractMatches(vMatched, vIndex) == block.hashMerkleRoot);
-    BOOST_CHECK(vMatched.size() == merkleBlock.vMatchedTxn.size());
+    FAST_CHECK(merkleBlock.txn.ExtractMatches(vMatched, vIndex) == block.hashMerkleRoot);
+    FAST_CHECK(vMatched.size() == merkleBlock.vMatchedTxn.size());
     for (unsigned int i = 0; i < vMatched.size(); i++)
-        BOOST_CHECK(vMatched[i] == merkleBlock.vMatchedTxn[i].second);
+        FAST_CHECK(vMatched[i] == merkleBlock.vMatchedTxn[i].second);
 }
 
 BOOST_AUTO_TEST_CASE(merkle_block_2_with_update_none)
@@ -296,20 +296,20 @@ BOOST_AUTO_TEST_CASE(merkle_block_2_with_update_none)
     filter.insert(uint256S("0xe980fe9f792d014e73b95203dc1335c5f9ce19ac537a419e6df5b47aecb93b70"));
 
     CMerkleBlock merkleBlock(block, filter);
-    BOOST_CHECK(merkleBlock.header.GetHash() == block.GetHash());
+    FAST_CHECK(merkleBlock.header.GetHash() == block.GetHash());
 
-    BOOST_CHECK(merkleBlock.vMatchedTxn.size() == 1);
+    FAST_CHECK(merkleBlock.vMatchedTxn.size() == 1);
     pair<unsigned int, uint256> pair = merkleBlock.vMatchedTxn[0];
 
-    BOOST_CHECK(merkleBlock.vMatchedTxn[0].second == uint256S("0xe980fe9f792d014e73b95203dc1335c5f9ce19ac537a419e6df5b47aecb93b70"));
-    BOOST_CHECK(merkleBlock.vMatchedTxn[0].first == 0);
+    FAST_CHECK(merkleBlock.vMatchedTxn[0].second == uint256S("0xe980fe9f792d014e73b95203dc1335c5f9ce19ac537a419e6df5b47aecb93b70"));
+    FAST_CHECK(merkleBlock.vMatchedTxn[0].first == 0);
 
     vector<uint256> vMatched;
     vector<unsigned int> vIndex;
-    BOOST_CHECK(merkleBlock.txn.ExtractMatches(vMatched, vIndex) == block.hashMerkleRoot);
-    BOOST_CHECK(vMatched.size() == merkleBlock.vMatchedTxn.size());
+    FAST_CHECK(merkleBlock.txn.ExtractMatches(vMatched, vIndex) == block.hashMerkleRoot);
+    FAST_CHECK(vMatched.size() == merkleBlock.vMatchedTxn.size());
     for (unsigned int i = 0; i < vMatched.size(); i++)
-        BOOST_CHECK(vMatched[i] == merkleBlock.vMatchedTxn[i].second);
+        FAST_CHECK(vMatched[i] == merkleBlock.vMatchedTxn[i].second);
 
     // Match an output from the second transaction (the pubkey for address 1DZTzaBHUDM7T3QvUKBz4qXMRpkg8jsfB5)
     // This should not match the third transaction though it spends the output matched
@@ -317,22 +317,22 @@ BOOST_AUTO_TEST_CASE(merkle_block_2_with_update_none)
     filter.insert(ParseHex("044a656f065871a353f216ca26cef8dde2f03e8c16202d2e8ad769f02032cb86a5eb5e56842e92e19141d60a01928f8dd2c875a390f67c1f6c94cfc617c0ea45af"));
 
     merkleBlock = CMerkleBlock(block, filter);
-    BOOST_CHECK(merkleBlock.header.GetHash() == block.GetHash());
+    FAST_CHECK(merkleBlock.header.GetHash() == block.GetHash());
 
-    BOOST_CHECK(merkleBlock.vMatchedTxn.size() == 3);
+    FAST_CHECK(merkleBlock.vMatchedTxn.size() == 3);
 
-    BOOST_CHECK(pair == merkleBlock.vMatchedTxn[0]);
+    FAST_CHECK(pair == merkleBlock.vMatchedTxn[0]);
 
-    BOOST_CHECK(merkleBlock.vMatchedTxn[1].second == uint256S("0x28204cad1d7fc1d199e8ef4fa22f182de6258a3eaafe1bbe56ebdcacd3069a5f"));
-    BOOST_CHECK(merkleBlock.vMatchedTxn[1].first == 1);
+    FAST_CHECK(merkleBlock.vMatchedTxn[1].second == uint256S("0x28204cad1d7fc1d199e8ef4fa22f182de6258a3eaafe1bbe56ebdcacd3069a5f"));
+    FAST_CHECK(merkleBlock.vMatchedTxn[1].first == 1);
 
-    BOOST_CHECK(merkleBlock.vMatchedTxn[2].second == uint256S("0x3c1d7e82342158e4109df2e0b6348b6e84e403d8b4046d7007663ace63cddb23"));
-    BOOST_CHECK(merkleBlock.vMatchedTxn[2].first == 3);
+    FAST_CHECK(merkleBlock.vMatchedTxn[2].second == uint256S("0x3c1d7e82342158e4109df2e0b6348b6e84e403d8b4046d7007663ace63cddb23"));
+    FAST_CHECK(merkleBlock.vMatchedTxn[2].first == 3);
 
-    BOOST_CHECK(merkleBlock.txn.ExtractMatches(vMatched, vIndex) == block.hashMerkleRoot);
-    BOOST_CHECK(vMatched.size() == merkleBlock.vMatchedTxn.size());
+    FAST_CHECK(merkleBlock.txn.ExtractMatches(vMatched, vIndex) == block.hashMerkleRoot);
+    FAST_CHECK(vMatched.size() == merkleBlock.vMatchedTxn.size());
     for (unsigned int i = 0; i < vMatched.size(); i++)
-        BOOST_CHECK(vMatched[i] == merkleBlock.vMatchedTxn[i].second);
+        FAST_CHECK(vMatched[i] == merkleBlock.vMatchedTxn[i].second);
 }
 
 BOOST_AUTO_TEST_CASE(merkle_block_3_and_serialize)
@@ -348,19 +348,19 @@ BOOST_AUTO_TEST_CASE(merkle_block_3_and_serialize)
     filter.insert(uint256S("0x63194f18be0af63f2c6bc9dc0f777cbefed3d9415c4af83f3ee3a3d669c00cb5"));
 
     CMerkleBlock merkleBlock(block, filter);
-    BOOST_CHECK(merkleBlock.header.GetHash() == block.GetHash());
+    FAST_CHECK(merkleBlock.header.GetHash() == block.GetHash());
 
-    BOOST_CHECK(merkleBlock.vMatchedTxn.size() == 1);
+    FAST_CHECK(merkleBlock.vMatchedTxn.size() == 1);
 
-    BOOST_CHECK(merkleBlock.vMatchedTxn[0].second == uint256S("0x63194f18be0af63f2c6bc9dc0f777cbefed3d9415c4af83f3ee3a3d669c00cb5"));
-    BOOST_CHECK(merkleBlock.vMatchedTxn[0].first == 0);
+    FAST_CHECK(merkleBlock.vMatchedTxn[0].second == uint256S("0x63194f18be0af63f2c6bc9dc0f777cbefed3d9415c4af83f3ee3a3d669c00cb5"));
+    FAST_CHECK(merkleBlock.vMatchedTxn[0].first == 0);
 
     vector<uint256> vMatched;
     vector<unsigned int> vIndex;
-    BOOST_CHECK(merkleBlock.txn.ExtractMatches(vMatched, vIndex) == block.hashMerkleRoot);
-    BOOST_CHECK(vMatched.size() == merkleBlock.vMatchedTxn.size());
+    FAST_CHECK(merkleBlock.txn.ExtractMatches(vMatched, vIndex) == block.hashMerkleRoot);
+    FAST_CHECK(vMatched.size() == merkleBlock.vMatchedTxn.size());
     for (unsigned int i = 0; i < vMatched.size(); i++)
-        BOOST_CHECK(vMatched[i] == merkleBlock.vMatchedTxn[i].second);
+        FAST_CHECK(vMatched[i] == merkleBlock.vMatchedTxn[i].second);
 
     CDataStream merkleStream(SER_NETWORK, PROTOCOL_VERSION);
     merkleStream << merkleBlock;
@@ -371,7 +371,7 @@ BOOST_AUTO_TEST_CASE(merkle_block_3_and_serialize)
     for (unsigned int i = 0; i < vch.size(); i++)
         expected[i] = (char)vch[i];
 
-    BOOST_CHECK_EQUAL_COLLECTIONS(expected.begin(), expected.end(), merkleStream.begin(), merkleStream.end());
+    FAST_CHECK_EQUAL_COLLECTIONS(expected.begin(), expected.end(), merkleStream.begin(), merkleStream.end());
 }
 
 BOOST_AUTO_TEST_CASE(merkle_block_4)
@@ -387,37 +387,37 @@ BOOST_AUTO_TEST_CASE(merkle_block_4)
     filter.insert(uint256S("0x0a2a92f0bda4727d0a13eaddf4dd9ac6b5c61a1429e6b2b818f19b15df0ac154"));
 
     CMerkleBlock merkleBlock(block, filter);
-    BOOST_CHECK(merkleBlock.header.GetHash() == block.GetHash());
+    FAST_CHECK(merkleBlock.header.GetHash() == block.GetHash());
 
-    BOOST_CHECK(merkleBlock.vMatchedTxn.size() == 1);
+    FAST_CHECK(merkleBlock.vMatchedTxn.size() == 1);
     pair<unsigned int, uint256> pair = merkleBlock.vMatchedTxn[0];
 
-    BOOST_CHECK(merkleBlock.vMatchedTxn[0].second == uint256S("0x0a2a92f0bda4727d0a13eaddf4dd9ac6b5c61a1429e6b2b818f19b15df0ac154"));
-    BOOST_CHECK(merkleBlock.vMatchedTxn[0].first == 6);
+    FAST_CHECK(merkleBlock.vMatchedTxn[0].second == uint256S("0x0a2a92f0bda4727d0a13eaddf4dd9ac6b5c61a1429e6b2b818f19b15df0ac154"));
+    FAST_CHECK(merkleBlock.vMatchedTxn[0].first == 6);
 
     vector<uint256> vMatched;
     vector<unsigned int> vIndex;
-    BOOST_CHECK(merkleBlock.txn.ExtractMatches(vMatched, vIndex) == block.hashMerkleRoot);
-    BOOST_CHECK(vMatched.size() == merkleBlock.vMatchedTxn.size());
+    FAST_CHECK(merkleBlock.txn.ExtractMatches(vMatched, vIndex) == block.hashMerkleRoot);
+    FAST_CHECK(vMatched.size() == merkleBlock.vMatchedTxn.size());
     for (unsigned int i = 0; i < vMatched.size(); i++)
-        BOOST_CHECK(vMatched[i] == merkleBlock.vMatchedTxn[i].second);
+        FAST_CHECK(vMatched[i] == merkleBlock.vMatchedTxn[i].second);
 
     // Also match the 4th transaction
     filter.insert(uint256S("0x02981fa052f0481dbc5868f4fc2166035a10f27a03cfd2de67326471df5bc041"));
     merkleBlock = CMerkleBlock(block, filter);
-    BOOST_CHECK(merkleBlock.header.GetHash() == block.GetHash());
+    FAST_CHECK(merkleBlock.header.GetHash() == block.GetHash());
 
-    BOOST_CHECK(merkleBlock.vMatchedTxn.size() == 2);
+    FAST_CHECK(merkleBlock.vMatchedTxn.size() == 2);
 
-    BOOST_CHECK(merkleBlock.vMatchedTxn[0].second == uint256S("0x02981fa052f0481dbc5868f4fc2166035a10f27a03cfd2de67326471df5bc041"));
-    BOOST_CHECK(merkleBlock.vMatchedTxn[0].first == 3);
+    FAST_CHECK(merkleBlock.vMatchedTxn[0].second == uint256S("0x02981fa052f0481dbc5868f4fc2166035a10f27a03cfd2de67326471df5bc041"));
+    FAST_CHECK(merkleBlock.vMatchedTxn[0].first == 3);
 
-    BOOST_CHECK(merkleBlock.vMatchedTxn[1] == pair);
+    FAST_CHECK(merkleBlock.vMatchedTxn[1] == pair);
 
-    BOOST_CHECK(merkleBlock.txn.ExtractMatches(vMatched, vIndex) == block.hashMerkleRoot);
-    BOOST_CHECK(vMatched.size() == merkleBlock.vMatchedTxn.size());
+    FAST_CHECK(merkleBlock.txn.ExtractMatches(vMatched, vIndex) == block.hashMerkleRoot);
+    FAST_CHECK(vMatched.size() == merkleBlock.vMatchedTxn.size());
     for (unsigned int i = 0; i < vMatched.size(); i++)
-        BOOST_CHECK(vMatched[i] == merkleBlock.vMatchedTxn[i].second);
+        FAST_CHECK(vMatched[i] == merkleBlock.vMatchedTxn[i].second);
 }
 
 BOOST_AUTO_TEST_CASE(merkle_block_4_test_p2pubkey_only)
@@ -435,12 +435,12 @@ BOOST_AUTO_TEST_CASE(merkle_block_4_test_p2pubkey_only)
     filter.insert(ParseHex("b6efd80d99179f4f4ff6f4dd0a007d018c385d21"));
 
     CMerkleBlock merkleBlock(block, filter);
-    BOOST_CHECK(merkleBlock.header.GetHash() == block.GetHash());
+    FAST_CHECK(merkleBlock.header.GetHash() == block.GetHash());
 
     // We should match the generation outpoint
-    BOOST_CHECK(filter.contains(COutPoint(uint256S("0x147caa76786596590baa4e98f5d9f48b86c7765e489f7a6ff3360fe5c674360b"), 0)));
+    FAST_CHECK(filter.contains(COutPoint(uint256S("0x147caa76786596590baa4e98f5d9f48b86c7765e489f7a6ff3360fe5c674360b"), 0)));
     // ... but not the 4th transaction's output (its not pay-2-pubkey)
-    BOOST_CHECK(!filter.contains(COutPoint(uint256S("0x02981fa052f0481dbc5868f4fc2166035a10f27a03cfd2de67326471df5bc041"), 0)));
+    FAST_CHECK(!filter.contains(COutPoint(uint256S("0x02981fa052f0481dbc5868f4fc2166035a10f27a03cfd2de67326471df5bc041"), 0)));
 }
 
 BOOST_AUTO_TEST_CASE(merkle_block_4_test_update_none)
@@ -458,11 +458,11 @@ BOOST_AUTO_TEST_CASE(merkle_block_4_test_update_none)
     filter.insert(ParseHex("b6efd80d99179f4f4ff6f4dd0a007d018c385d21"));
 
     CMerkleBlock merkleBlock(block, filter);
-    BOOST_CHECK(merkleBlock.header.GetHash() == block.GetHash());
+    FAST_CHECK(merkleBlock.header.GetHash() == block.GetHash());
 
     // We shouldn't match any outpoints (UPDATE_NONE)
-    BOOST_CHECK(!filter.contains(COutPoint(uint256S("0x147caa76786596590baa4e98f5d9f48b86c7765e489f7a6ff3360fe5c674360b"), 0)));
-    BOOST_CHECK(!filter.contains(COutPoint(uint256S("0x02981fa052f0481dbc5868f4fc2166035a10f27a03cfd2de67326471df5bc041"), 0)));
+    FAST_CHECK(!filter.contains(COutPoint(uint256S("0x147caa76786596590baa4e98f5d9f48b86c7765e489f7a6ff3360fe5c674360b"), 0)));
+    FAST_CHECK(!filter.contains(COutPoint(uint256S("0x02981fa052f0481dbc5868f4fc2166035a10f27a03cfd2de67326471df5bc041"), 0)));
 }
 
 static std::vector<unsigned char> RandomData()
@@ -485,7 +485,7 @@ BOOST_AUTO_TEST_CASE(rolling_bloom)
     }
     // Last 100 guaranteed to be remembered:
     for (int i = 299; i < DATASIZE; i++) {
-        BOOST_CHECK(rb1.contains(data[i]));
+        FAST_CHECK(rb1.contains(data[i]));
     }
 
     // false positive rate is 1%, so we should get about 100 hits if
@@ -501,27 +501,27 @@ BOOST_AUTO_TEST_CASE(rolling_bloom)
     BOOST_TEST_MESSAGE("RollingBloomFilter got " << nHits << " false positives (~100 expected)");
 
     // Insanely unlikely to get a fp count outside this range:
-    BOOST_CHECK(nHits > 25);
-    BOOST_CHECK(nHits < 175);
+    FAST_CHECK(nHits > 25);
+    FAST_CHECK(nHits < 175);
 
-    BOOST_CHECK(rb1.contains(data[DATASIZE-1]));
+    FAST_CHECK(rb1.contains(data[DATASIZE-1]));
     rb1.reset();
-    BOOST_CHECK(!rb1.contains(data[DATASIZE-1]));
+    FAST_CHECK(!rb1.contains(data[DATASIZE-1]));
 
     // Now roll through data, make sure last 100 entries
     // are always remembered:
     for (int i = 0; i < DATASIZE; i++) {
         if (i >= 100)
-            BOOST_CHECK(rb1.contains(data[i-100]));
+            FAST_CHECK(rb1.contains(data[i-100]));
         rb1.insert(data[i]);
-        BOOST_CHECK(rb1.contains(data[i]));
+        FAST_CHECK(rb1.contains(data[i]));
     }
 
     // Insert 999 more random entries:
     for (int i = 0; i < 999; i++) {
         std::vector<unsigned char> d = RandomData();
         rb1.insert(d);
-        BOOST_CHECK(rb1.contains(d));
+        FAST_CHECK(rb1.contains(d));
     }
     // Sanity check to make sure the filter isn't just filling up:
     nHits = 0;
@@ -532,7 +532,7 @@ BOOST_AUTO_TEST_CASE(rolling_bloom)
     // Expect about 5 false positives, more than 100 means
     // something is definitely broken.
     BOOST_TEST_MESSAGE("RollingBloomFilter got " << nHits << " false positives (~5 expected)");
-    BOOST_CHECK(nHits < 100);
+    FAST_CHECK(nHits < 100);
 
     // last-1000-entry, 0.01% false positive:
     CRollingBloomFilter rb2(1000, 0.001);
@@ -541,7 +541,7 @@ BOOST_AUTO_TEST_CASE(rolling_bloom)
     }
     // ... room for all of them:
     for (int i = 0; i < DATASIZE; i++) {
-        BOOST_CHECK(rb2.contains(data[i]));
+        FAST_CHECK(rb2.contains(data[i]));
     }
 }
 

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -77,7 +77,7 @@ public:
         for (CCoinsMap::iterator it = cacheCoins.begin(); it != cacheCoins.end(); it++) {
             ret += it->second.coins.DynamicMemoryUsage();
         }
-        BOOST_CHECK_EQUAL(DynamicMemoryUsage(), ret);
+        FAST_CHECK_EQUAL(DynamicMemoryUsage(), ret);
     }
 
 };
@@ -129,7 +129,7 @@ BOOST_AUTO_TEST_CASE(coins_cache_simulation_test)
             uint256 txid = txids[insecure_rand() % txids.size()]; // txid we're going to modify in this iteration.
             CCoins& coins = result[txid];
             CCoinsModifier entry = stack.back()->ModifyCoins(txid);
-            BOOST_CHECK(coins == *entry);
+            FAST_CHECK(coins == *entry);
             if (insecure_rand() % 5 == 0 || coins.IsPruned()) {
                 if (coins.IsPruned()) {
                     added_an_entry = true;
@@ -152,10 +152,10 @@ BOOST_AUTO_TEST_CASE(coins_cache_simulation_test)
             for (std::map<uint256, CCoins>::iterator it = result.begin(); it != result.end(); it++) {
                 const CCoins* coins = stack.back()->AccessCoins(it->first);
                 if (coins) {
-                    BOOST_CHECK(*coins == it->second);
+                    FAST_CHECK(*coins == it->second);
                     found_an_entry = true;
                 } else {
-                    BOOST_CHECK(it->second.IsPruned());
+                    FAST_CHECK(it->second.IsPruned());
                     missed_an_entry = true;
                 }
             }
@@ -202,13 +202,13 @@ BOOST_AUTO_TEST_CASE(coins_cache_simulation_test)
     }
 
     // Verify coverage.
-    BOOST_CHECK(removed_all_caches);
-    BOOST_CHECK(reached_4_caches);
-    BOOST_CHECK(added_an_entry);
-    BOOST_CHECK(removed_an_entry);
-    BOOST_CHECK(updated_an_entry);
-    BOOST_CHECK(found_an_entry);
-    BOOST_CHECK(missed_an_entry);
+    FAST_CHECK(removed_all_caches);
+    FAST_CHECK(reached_4_caches);
+    FAST_CHECK(added_an_entry);
+    FAST_CHECK(removed_an_entry);
+    FAST_CHECK(updated_an_entry);
+    FAST_CHECK(found_an_entry);
+    FAST_CHECK(missed_an_entry);
 }
 
 // This test is similar to the previous test
@@ -305,9 +305,9 @@ BOOST_AUTO_TEST_CASE(updatecoins_simulation_test)
             for (std::map<uint256, CCoins>::iterator it = result.begin(); it != result.end(); it++) {
                 const CCoins* coins = stack.back()->AccessCoins(it->first);
                 if (coins) {
-                    BOOST_CHECK(*coins == it->second);
+                    FAST_CHECK(*coins == it->second);
                  } else {
-                    BOOST_CHECK(it->second.IsPruned());
+                    FAST_CHECK(it->second.IsPruned());
                  }
             }
         }
@@ -343,7 +343,7 @@ BOOST_AUTO_TEST_CASE(updatecoins_simulation_test)
     }
 
     // Verify coverage.
-    BOOST_CHECK(spent_a_duplicate_coinbase);
+    FAST_CHECK(spent_a_duplicate_coinbase);
 }
 
 BOOST_AUTO_TEST_CASE(ccoins_serialization)
@@ -352,45 +352,45 @@ BOOST_AUTO_TEST_CASE(ccoins_serialization)
     CDataStream ss1(ParseHex("0104835800816115944e077fe7c803cfa57f29b36bf87c1d358bb85e"), SER_DISK, CLIENT_VERSION);
     CCoins cc1;
     ss1 >> cc1;
-    BOOST_CHECK_EQUAL(cc1.nVersion, 1);
-    BOOST_CHECK_EQUAL(cc1.fCoinBase, false);
-    BOOST_CHECK_EQUAL(cc1.nHeight, 203998);
-    BOOST_CHECK_EQUAL(cc1.vout.size(), 2);
-    BOOST_CHECK_EQUAL(cc1.IsAvailable(0), false);
-    BOOST_CHECK_EQUAL(cc1.IsAvailable(1), true);
-    BOOST_CHECK_EQUAL(cc1.vout[1].nValue, 60000000000ULL);
-    BOOST_CHECK_EQUAL(HexStr(cc1.vout[1].scriptPubKey), HexStr(GetScriptForDestination(CKeyID(uint160(ParseHex("816115944e077fe7c803cfa57f29b36bf87c1d35"))))));
+    FAST_CHECK_EQUAL(cc1.nVersion, 1);
+    FAST_CHECK_EQUAL(cc1.fCoinBase, false);
+    FAST_CHECK_EQUAL(cc1.nHeight, 203998);
+    FAST_CHECK_EQUAL(cc1.vout.size(), 2);
+    FAST_CHECK_EQUAL(cc1.IsAvailable(0), false);
+    FAST_CHECK_EQUAL(cc1.IsAvailable(1), true);
+    FAST_CHECK_EQUAL(cc1.vout[1].nValue, 60000000000ULL);
+    FAST_CHECK_EQUAL(HexStr(cc1.vout[1].scriptPubKey), HexStr(GetScriptForDestination(CKeyID(uint160(ParseHex("816115944e077fe7c803cfa57f29b36bf87c1d35"))))));
 
     // Good example
     CDataStream ss2(ParseHex("0109044086ef97d5790061b01caab50f1b8e9c50a5057eb43c2d9563a4eebbd123008c988f1a4a4de2161e0f50aac7f17e7f9555caa486af3b"), SER_DISK, CLIENT_VERSION);
     CCoins cc2;
     ss2 >> cc2;
-    BOOST_CHECK_EQUAL(cc2.nVersion, 1);
-    BOOST_CHECK_EQUAL(cc2.fCoinBase, true);
-    BOOST_CHECK_EQUAL(cc2.nHeight, 120891);
-    BOOST_CHECK_EQUAL(cc2.vout.size(), 17);
+    FAST_CHECK_EQUAL(cc2.nVersion, 1);
+    FAST_CHECK_EQUAL(cc2.fCoinBase, true);
+    FAST_CHECK_EQUAL(cc2.nHeight, 120891);
+    FAST_CHECK_EQUAL(cc2.vout.size(), 17);
     for (int i = 0; i < 17; i++) {
-        BOOST_CHECK_EQUAL(cc2.IsAvailable(i), i == 4 || i == 16);
+        FAST_CHECK_EQUAL(cc2.IsAvailable(i), i == 4 || i == 16);
     }
-    BOOST_CHECK_EQUAL(cc2.vout[4].nValue, 234925952);
-    BOOST_CHECK_EQUAL(HexStr(cc2.vout[4].scriptPubKey), HexStr(GetScriptForDestination(CKeyID(uint160(ParseHex("61b01caab50f1b8e9c50a5057eb43c2d9563a4ee"))))));
-    BOOST_CHECK_EQUAL(cc2.vout[16].nValue, 110397);
-    BOOST_CHECK_EQUAL(HexStr(cc2.vout[16].scriptPubKey), HexStr(GetScriptForDestination(CKeyID(uint160(ParseHex("8c988f1a4a4de2161e0f50aac7f17e7f9555caa4"))))));
+    FAST_CHECK_EQUAL(cc2.vout[4].nValue, 234925952);
+    FAST_CHECK_EQUAL(HexStr(cc2.vout[4].scriptPubKey), HexStr(GetScriptForDestination(CKeyID(uint160(ParseHex("61b01caab50f1b8e9c50a5057eb43c2d9563a4ee"))))));
+    FAST_CHECK_EQUAL(cc2.vout[16].nValue, 110397);
+    FAST_CHECK_EQUAL(HexStr(cc2.vout[16].scriptPubKey), HexStr(GetScriptForDestination(CKeyID(uint160(ParseHex("8c988f1a4a4de2161e0f50aac7f17e7f9555caa4"))))));
 
     // Smallest possible example
     CDataStream ssx(SER_DISK, CLIENT_VERSION);
-    BOOST_CHECK_EQUAL(HexStr(ssx.begin(), ssx.end()), "");
+    FAST_CHECK_EQUAL(HexStr(ssx.begin(), ssx.end()), "");
 
     CDataStream ss3(ParseHex("0002000600"), SER_DISK, CLIENT_VERSION);
     CCoins cc3;
     ss3 >> cc3;
-    BOOST_CHECK_EQUAL(cc3.nVersion, 0);
-    BOOST_CHECK_EQUAL(cc3.fCoinBase, false);
-    BOOST_CHECK_EQUAL(cc3.nHeight, 0);
-    BOOST_CHECK_EQUAL(cc3.vout.size(), 1);
-    BOOST_CHECK_EQUAL(cc3.IsAvailable(0), true);
-    BOOST_CHECK_EQUAL(cc3.vout[0].nValue, 0);
-    BOOST_CHECK_EQUAL(cc3.vout[0].scriptPubKey.size(), 0);
+    FAST_CHECK_EQUAL(cc3.nVersion, 0);
+    FAST_CHECK_EQUAL(cc3.fCoinBase, false);
+    FAST_CHECK_EQUAL(cc3.nHeight, 0);
+    FAST_CHECK_EQUAL(cc3.vout.size(), 1);
+    FAST_CHECK_EQUAL(cc3.IsAvailable(0), true);
+    FAST_CHECK_EQUAL(cc3.vout[0].nValue, 0);
+    FAST_CHECK_EQUAL(cc3.vout[0].scriptPubKey.size(), 0);
 
     // scriptPubKey that ends beyond the end of the stream
     CDataStream ss4(ParseHex("0002000800"), SER_DISK, CLIENT_VERSION);
@@ -405,7 +405,7 @@ BOOST_AUTO_TEST_CASE(ccoins_serialization)
     CDataStream tmp(SER_DISK, CLIENT_VERSION);
     uint64_t x = 3000000000ULL;
     tmp << VARINT(x);
-    BOOST_CHECK_EQUAL(HexStr(tmp.begin(), tmp.end()), "8a95c0bb00");
+    FAST_CHECK_EQUAL(HexStr(tmp.begin(), tmp.end()), "8a95c0bb00");
     CDataStream ss5(ParseHex("0002008a95c0bb0000"), SER_DISK, CLIENT_VERSION);
     try {
         CCoins cc5;

--- a/src/test/compress_tests.cpp
+++ b/src/test/compress_tests.cpp
@@ -39,27 +39,27 @@ bool static TestPair(uint64_t dec, uint64_t enc) {
 
 BOOST_AUTO_TEST_CASE(compress_amounts)
 {
-    BOOST_CHECK(TestPair(            0,       0x0));
-    BOOST_CHECK(TestPair(            1,       0x1));
-    BOOST_CHECK(TestPair(         CENT,       0x7));
-    BOOST_CHECK(TestPair(         COIN,       0x9));
-    BOOST_CHECK(TestPair(      50*COIN,      0x32));
-    BOOST_CHECK(TestPair(21000000*COIN, 0x1406f40));
+    FAST_CHECK(TestPair(            0,       0x0));
+    FAST_CHECK(TestPair(            1,       0x1));
+    FAST_CHECK(TestPair(         CENT,       0x7));
+    FAST_CHECK(TestPair(         COIN,       0x9));
+    FAST_CHECK(TestPair(      50*COIN,      0x32));
+    FAST_CHECK(TestPair(21000000*COIN, 0x1406f40));
 
     for (uint64_t i = 1; i <= NUM_MULTIPLES_UNIT; i++)
-        BOOST_CHECK(TestEncode(i));
+        FAST_CHECK(TestEncode(i));
 
     for (uint64_t i = 1; i <= NUM_MULTIPLES_CENT; i++)
-        BOOST_CHECK(TestEncode(i * CENT));
+        FAST_CHECK(TestEncode(i * CENT));
 
     for (uint64_t i = 1; i <= NUM_MULTIPLES_1BTC; i++)
-        BOOST_CHECK(TestEncode(i * COIN));
+        FAST_CHECK(TestEncode(i * COIN));
 
     for (uint64_t i = 1; i <= NUM_MULTIPLES_50BTC; i++)
-        BOOST_CHECK(TestEncode(i * 50 * COIN));
+        FAST_CHECK(TestEncode(i * 50 * COIN));
 
     for (uint64_t i = 0; i < 100000; i++)
-        BOOST_CHECK(TestDecode(i));
+        FAST_CHECK(TestDecode(i));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/crypto_tests.cpp
+++ b/src/test/crypto_tests.cpp
@@ -25,12 +25,12 @@ BOOST_FIXTURE_TEST_SUITE(crypto_tests, BasicTestingSetup)
 template<typename Hasher, typename In, typename Out>
 void TestVector(const Hasher &h, const In &in, const Out &out) {
     Out hash;
-    BOOST_CHECK(out.size() == h.OUTPUT_SIZE);
+    FAST_CHECK(out.size() == h.OUTPUT_SIZE);
     hash.resize(out.size());
     {
         // Test that writing the whole input string at once works.
         Hasher(h).Write((unsigned char*)&in[0], in.size()).Finalize(&hash[0]);
-        BOOST_CHECK(hash == out);
+        FAST_CHECK(hash == out);
     }
     for (int i=0; i<32; i++) {
         // Test that writing the string broken up in random pieces works.
@@ -43,11 +43,11 @@ void TestVector(const Hasher &h, const In &in, const Out &out) {
             if (pos > 0 && pos + 2 * out.size() > in.size() && pos < in.size()) {
                 // Test that writing the rest at once to a copy of a hasher works.
                 Hasher(hasher).Write((unsigned char*)&in[pos], in.size() - pos).Finalize(&hash[0]);
-                BOOST_CHECK(hash == out);
+                FAST_CHECK(hash == out);
             }
         }
         hasher.Finalize(&hash[0]);
-        BOOST_CHECK(hash == out);
+        FAST_CHECK(hash == out);
     }
 }
 
@@ -80,10 +80,10 @@ void TestAES128(const std::string &hexkey, const std::string &hexin, const std::
     buf.resize(correctout.size());
     buf2.resize(correctout.size());
     enc.Encrypt(&buf[0], &in[0]);
-    BOOST_CHECK_EQUAL(HexStr(buf), HexStr(correctout));
+    FAST_CHECK_EQUAL(HexStr(buf), HexStr(correctout));
     AES128Decrypt dec(&key[0]);
     dec.Decrypt(&buf2[0], &buf[0]);
-    BOOST_CHECK_EQUAL(HexStr(buf2), HexStr(in));
+    FAST_CHECK_EQUAL(HexStr(buf2), HexStr(in));
 }
 
 void TestAES256(const std::string &hexkey, const std::string &hexin, const std::string &hexout)
@@ -99,10 +99,10 @@ void TestAES256(const std::string &hexkey, const std::string &hexin, const std::
     AES256Encrypt enc(&key[0]);
     buf.resize(correctout.size());
     enc.Encrypt(&buf[0], &in[0]);
-    BOOST_CHECK(buf == correctout);
+    FAST_CHECK(buf == correctout);
     AES256Decrypt dec(&key[0]);
     dec.Decrypt(&buf[0], &buf[0]);
-    BOOST_CHECK(buf == in);
+    FAST_CHECK(buf == in);
 }
 
 void TestAES128CBC(const std::string &hexkey, const std::string &hexiv, bool pad, const std::string &hexin, const std::string &hexout)
@@ -117,7 +117,7 @@ void TestAES128CBC(const std::string &hexkey, const std::string &hexiv, bool pad
     AES128CBCEncrypt enc(&key[0], &iv[0], pad);
     int size = enc.Encrypt(&in[0], in.size(), &realout[0]);
     realout.resize(size);
-    BOOST_CHECK(realout.size() == correctout.size());
+    FAST_CHECK(realout.size() == correctout.size());
     BOOST_CHECK_MESSAGE(realout == correctout, HexStr(realout) + std::string(" != ") + hexout);
 
     // Decrypt the cipher and verify that it equals the plaintext
@@ -125,7 +125,7 @@ void TestAES128CBC(const std::string &hexkey, const std::string &hexiv, bool pad
     AES128CBCDecrypt dec(&key[0], &iv[0], pad);
     size = dec.Decrypt(&correctout[0], correctout.size(), &decrypted[0]);
     decrypted.resize(size);
-    BOOST_CHECK(decrypted.size() == in.size());
+    FAST_CHECK(decrypted.size() == in.size());
     BOOST_CHECK_MESSAGE(decrypted == in, HexStr(decrypted) + std::string(" != ") + hexin);
 
     // Encrypt and re-decrypt substrings of the plaintext and verify that they equal each-other
@@ -140,7 +140,7 @@ void TestAES128CBC(const std::string &hexkey, const std::string &hexiv, bool pad
             std::vector<unsigned char> subdecrypted(subout.size());
             size = dec.Decrypt(&subout[0], subout.size(), &subdecrypted[0]);
             subdecrypted.resize(size);
-            BOOST_CHECK(decrypted.size() == in.size());
+            FAST_CHECK(decrypted.size() == in.size());
             BOOST_CHECK_MESSAGE(subdecrypted == sub, HexStr(subdecrypted) + std::string(" != ") + HexStr(sub));
         }
     }
@@ -158,7 +158,7 @@ void TestAES256CBC(const std::string &hexkey, const std::string &hexiv, bool pad
     AES256CBCEncrypt enc(&key[0], &iv[0], pad);
     int size = enc.Encrypt(&in[0], in.size(), &realout[0]);
     realout.resize(size);
-    BOOST_CHECK(realout.size() == correctout.size());
+    FAST_CHECK(realout.size() == correctout.size());
     BOOST_CHECK_MESSAGE(realout == correctout, HexStr(realout) + std::string(" != ") + hexout);
 
     // Decrypt the cipher and verify that it equals the plaintext
@@ -166,7 +166,7 @@ void TestAES256CBC(const std::string &hexkey, const std::string &hexiv, bool pad
     AES256CBCDecrypt dec(&key[0], &iv[0], pad);
     size = dec.Decrypt(&correctout[0], correctout.size(), &decrypted[0]);
     decrypted.resize(size);
-    BOOST_CHECK(decrypted.size() == in.size());
+    FAST_CHECK(decrypted.size() == in.size());
     BOOST_CHECK_MESSAGE(decrypted == in, HexStr(decrypted) + std::string(" != ") + hexin);
 
     // Encrypt and re-decrypt substrings of the plaintext and verify that they equal each-other
@@ -181,7 +181,7 @@ void TestAES256CBC(const std::string &hexkey, const std::string &hexiv, bool pad
             std::vector<unsigned char> subdecrypted(subout.size());
             size = dec.Decrypt(&subout[0], subout.size(), &subdecrypted[0]);
             subdecrypted.resize(size);
-            BOOST_CHECK(decrypted.size() == in.size());
+            FAST_CHECK(decrypted.size() == in.size());
             BOOST_CHECK_MESSAGE(subdecrypted == sub, HexStr(subdecrypted) + std::string(" != ") + HexStr(sub));
         }
     }

--- a/src/test/dbwrapper_tests.cpp
+++ b/src/test/dbwrapper_tests.cpp
@@ -39,11 +39,11 @@ BOOST_AUTO_TEST_CASE(dbwrapper)
         uint256 res;
 
         // Ensure that we're doing real obfuscation when obfuscate=true
-        BOOST_CHECK(obfuscate != is_null_key(dbwrapper_private::GetObfuscateKey(dbw)));
+        FAST_CHECK(obfuscate != is_null_key(dbwrapper_private::GetObfuscateKey(dbw)));
 
-        BOOST_CHECK(dbw.Write(key, in));
-        BOOST_CHECK(dbw.Read(key, res));
-        BOOST_CHECK_EQUAL(res.ToString(), in.ToString());
+        FAST_CHECK(dbw.Write(key, in));
+        FAST_CHECK(dbw.Read(key, res));
+        FAST_CHECK_EQUAL(res.ToString(), in.ToString());
     }
 }
 
@@ -75,13 +75,13 @@ BOOST_AUTO_TEST_CASE(dbwrapper_batch)
 
         dbw.WriteBatch(batch);
 
-        BOOST_CHECK(dbw.Read(key, res));
-        BOOST_CHECK_EQUAL(res.ToString(), in.ToString());
-        BOOST_CHECK(dbw.Read(key2, res));
-        BOOST_CHECK_EQUAL(res.ToString(), in2.ToString());
+        FAST_CHECK(dbw.Read(key, res));
+        FAST_CHECK_EQUAL(res.ToString(), in.ToString());
+        FAST_CHECK(dbw.Read(key2, res));
+        FAST_CHECK_EQUAL(res.ToString(), in2.ToString());
 
         // key3 never should've been written
-        BOOST_CHECK(dbw.Read(key3, res) == false);
+        FAST_CHECK(dbw.Read(key3, res) == false);
     }
 }
 
@@ -96,10 +96,10 @@ BOOST_AUTO_TEST_CASE(dbwrapper_iterator)
         // The two keys are intentionally chosen for ordering
         char key = 'j';
         uint256 in = GetRandHash();
-        BOOST_CHECK(dbw.Write(key, in));
+        FAST_CHECK(dbw.Write(key, in));
         char key2 = 'k';
         uint256 in2 = GetRandHash();
-        BOOST_CHECK(dbw.Write(key2, in2));
+        FAST_CHECK(dbw.Write(key2, in2));
 
         boost::scoped_ptr<CDBIterator> it(const_cast<CDBWrapper*>(&dbw)->NewIterator());
 
@@ -111,18 +111,18 @@ BOOST_AUTO_TEST_CASE(dbwrapper_iterator)
 
         it->GetKey(key_res);
         it->GetValue(val_res);
-        BOOST_CHECK_EQUAL(key_res, key);
-        BOOST_CHECK_EQUAL(val_res.ToString(), in.ToString());
+        FAST_CHECK_EQUAL(key_res, key);
+        FAST_CHECK_EQUAL(val_res.ToString(), in.ToString());
 
         it->Next();
 
         it->GetKey(key_res);
         it->GetValue(val_res);
-        BOOST_CHECK_EQUAL(key_res, key2);
-        BOOST_CHECK_EQUAL(val_res.ToString(), in2.ToString());
+        FAST_CHECK_EQUAL(key_res, key2);
+        FAST_CHECK_EQUAL(val_res.ToString(), in2.ToString());
 
         it->Next();
-        BOOST_CHECK_EQUAL(it->Valid(), false);
+        FAST_CHECK_EQUAL(it->Valid(), false);
     }
 }
 
@@ -139,9 +139,9 @@ BOOST_AUTO_TEST_CASE(existing_data_no_obfuscate)
     uint256 in = GetRandHash();
     uint256 res;
 
-    BOOST_CHECK(dbw->Write(key, in));
-    BOOST_CHECK(dbw->Read(key, res));
-    BOOST_CHECK_EQUAL(res.ToString(), in.ToString());
+    FAST_CHECK(dbw->Write(key, in));
+    FAST_CHECK(dbw->Read(key, res));
+    FAST_CHECK_EQUAL(res.ToString(), in.ToString());
 
     // Call the destructor to free leveldb LOCK
     delete dbw;
@@ -152,19 +152,19 @@ BOOST_AUTO_TEST_CASE(existing_data_no_obfuscate)
     // Check that the key/val we wrote with unobfuscated wrapper exists and 
     // is readable.
     uint256 res2;
-    BOOST_CHECK(odbw.Read(key, res2));
-    BOOST_CHECK_EQUAL(res2.ToString(), in.ToString());
+    FAST_CHECK(odbw.Read(key, res2));
+    FAST_CHECK_EQUAL(res2.ToString(), in.ToString());
 
-    BOOST_CHECK(!odbw.IsEmpty()); // There should be existing data
-    BOOST_CHECK(is_null_key(dbwrapper_private::GetObfuscateKey(odbw))); // The key should be an empty string
+    FAST_CHECK(!odbw.IsEmpty()); // There should be existing data
+    FAST_CHECK(is_null_key(dbwrapper_private::GetObfuscateKey(odbw))); // The key should be an empty string
 
     uint256 in2 = GetRandHash();
     uint256 res3;
  
     // Check that we can write successfully
-    BOOST_CHECK(odbw.Write(key, in2));
-    BOOST_CHECK(odbw.Read(key, res3));
-    BOOST_CHECK_EQUAL(res3.ToString(), in2.ToString());
+    FAST_CHECK(odbw.Write(key, in2));
+    FAST_CHECK(odbw.Read(key, res3));
+    FAST_CHECK_EQUAL(res3.ToString(), in2.ToString());
 }
                         
 // Ensure that we start obfuscating during a reindex.
@@ -180,9 +180,9 @@ BOOST_AUTO_TEST_CASE(existing_data_reindex)
     uint256 in = GetRandHash();
     uint256 res;
 
-    BOOST_CHECK(dbw->Write(key, in));
-    BOOST_CHECK(dbw->Read(key, res));
-    BOOST_CHECK_EQUAL(res.ToString(), in.ToString());
+    FAST_CHECK(dbw->Write(key, in));
+    FAST_CHECK(dbw->Read(key, res));
+    FAST_CHECK_EQUAL(res.ToString(), in.ToString());
 
     // Call the destructor to free leveldb LOCK
     delete dbw;
@@ -192,16 +192,16 @@ BOOST_AUTO_TEST_CASE(existing_data_reindex)
 
     // Check that the key/val we wrote with unobfuscated wrapper doesn't exist
     uint256 res2;
-    BOOST_CHECK(!odbw.Read(key, res2));
-    BOOST_CHECK(!is_null_key(dbwrapper_private::GetObfuscateKey(odbw)));
+    FAST_CHECK(!odbw.Read(key, res2));
+    FAST_CHECK(!is_null_key(dbwrapper_private::GetObfuscateKey(odbw)));
 
     uint256 in2 = GetRandHash();
     uint256 res3;
  
     // Check that we can write successfully
-    BOOST_CHECK(odbw.Write(key, in2));
-    BOOST_CHECK(odbw.Read(key, res3));
-    BOOST_CHECK_EQUAL(res3.ToString(), in2.ToString());
+    FAST_CHECK(odbw.Write(key, in2));
+    FAST_CHECK(odbw.Read(key, res3));
+    FAST_CHECK_EQUAL(res3.ToString(), in2.ToString());
 }
 
 BOOST_AUTO_TEST_CASE(iterator_ordering)
@@ -211,7 +211,7 @@ BOOST_AUTO_TEST_CASE(iterator_ordering)
     for (int x=0x00; x<256; ++x) {
         uint8_t key = x;
         uint32_t value = x*x;
-        BOOST_CHECK(dbw.Write(key, value));
+        FAST_CHECK(dbw.Write(key, value));
     }
 
     boost::scoped_ptr<CDBIterator> it(const_cast<CDBWrapper*>(&dbw)->NewIterator());
@@ -225,16 +225,16 @@ BOOST_AUTO_TEST_CASE(iterator_ordering)
         for (int x=seek_start; x<256; ++x) {
             uint8_t key;
             uint32_t value;
-            BOOST_CHECK(it->Valid());
+            FAST_CHECK(it->Valid());
             if (!it->Valid()) // Avoid spurious errors about invalid iterator's key and value in case of failure
                 break;
-            BOOST_CHECK(it->GetKey(key));
-            BOOST_CHECK(it->GetValue(value));
-            BOOST_CHECK_EQUAL(key, x);
-            BOOST_CHECK_EQUAL(value, x*x);
+            FAST_CHECK(it->GetKey(key));
+            FAST_CHECK(it->GetValue(value));
+            FAST_CHECK_EQUAL(key, x);
+            FAST_CHECK_EQUAL(value, x*x);
             it->Next();
         }
-        BOOST_CHECK(!it->Valid());
+        FAST_CHECK(!it->Valid());
     }
 }
 
@@ -286,7 +286,7 @@ BOOST_AUTO_TEST_CASE(iterator_string_ordering)
             for (int z = 0; z < y; z++)
                 key += key;
             uint32_t value = x*x;
-            BOOST_CHECK(dbw.Write(key, value));
+            FAST_CHECK(dbw.Write(key, value));
         }
     }
 
@@ -308,17 +308,17 @@ BOOST_AUTO_TEST_CASE(iterator_string_ordering)
                     exp_key += exp_key;
                 StringContentsSerializer key;
                 uint32_t value;
-                BOOST_CHECK(it->Valid());
+                FAST_CHECK(it->Valid());
                 if (!it->Valid()) // Avoid spurious errors about invalid iterator's key and value in case of failure
                     break;
-                BOOST_CHECK(it->GetKey(key));
-                BOOST_CHECK(it->GetValue(value));
-                BOOST_CHECK_EQUAL(key.str, exp_key);
-                BOOST_CHECK_EQUAL(value, x*x);
+                FAST_CHECK(it->GetKey(key));
+                FAST_CHECK(it->GetValue(value));
+                FAST_CHECK_EQUAL(key.str, exp_key);
+                FAST_CHECK_EQUAL(value, x*x);
                 it->Next();
             }
         }
-        BOOST_CHECK(!it->Valid());
+        FAST_CHECK(!it->Valid());
     }
 }
 

--- a/src/test/getarg_tests.cpp
+++ b/src/test/getarg_tests.cpp
@@ -34,129 +34,129 @@ static void ResetArgs(const std::string& strArg)
 BOOST_AUTO_TEST_CASE(boolarg)
 {
     ResetArgs("-foo");
-    BOOST_CHECK(GetBoolArg("-foo", false));
-    BOOST_CHECK(GetBoolArg("-foo", true));
+    FAST_CHECK(GetBoolArg("-foo", false));
+    FAST_CHECK(GetBoolArg("-foo", true));
 
-    BOOST_CHECK(!GetBoolArg("-fo", false));
-    BOOST_CHECK(GetBoolArg("-fo", true));
+    FAST_CHECK(!GetBoolArg("-fo", false));
+    FAST_CHECK(GetBoolArg("-fo", true));
 
-    BOOST_CHECK(!GetBoolArg("-fooo", false));
-    BOOST_CHECK(GetBoolArg("-fooo", true));
+    FAST_CHECK(!GetBoolArg("-fooo", false));
+    FAST_CHECK(GetBoolArg("-fooo", true));
 
     ResetArgs("-foo=0");
-    BOOST_CHECK(!GetBoolArg("-foo", false));
-    BOOST_CHECK(!GetBoolArg("-foo", true));
+    FAST_CHECK(!GetBoolArg("-foo", false));
+    FAST_CHECK(!GetBoolArg("-foo", true));
 
     ResetArgs("-foo=1");
-    BOOST_CHECK(GetBoolArg("-foo", false));
-    BOOST_CHECK(GetBoolArg("-foo", true));
+    FAST_CHECK(GetBoolArg("-foo", false));
+    FAST_CHECK(GetBoolArg("-foo", true));
 
     // New 0.6 feature: auto-map -nosomething to !-something:
     ResetArgs("-nofoo");
-    BOOST_CHECK(!GetBoolArg("-foo", false));
-    BOOST_CHECK(!GetBoolArg("-foo", true));
+    FAST_CHECK(!GetBoolArg("-foo", false));
+    FAST_CHECK(!GetBoolArg("-foo", true));
 
     ResetArgs("-nofoo=1");
-    BOOST_CHECK(!GetBoolArg("-foo", false));
-    BOOST_CHECK(!GetBoolArg("-foo", true));
+    FAST_CHECK(!GetBoolArg("-foo", false));
+    FAST_CHECK(!GetBoolArg("-foo", true));
 
     ResetArgs("-foo -nofoo");  // -nofoo should win
-    BOOST_CHECK(!GetBoolArg("-foo", false));
-    BOOST_CHECK(!GetBoolArg("-foo", true));
+    FAST_CHECK(!GetBoolArg("-foo", false));
+    FAST_CHECK(!GetBoolArg("-foo", true));
 
     ResetArgs("-foo=1 -nofoo=1");  // -nofoo should win
-    BOOST_CHECK(!GetBoolArg("-foo", false));
-    BOOST_CHECK(!GetBoolArg("-foo", true));
+    FAST_CHECK(!GetBoolArg("-foo", false));
+    FAST_CHECK(!GetBoolArg("-foo", true));
 
     ResetArgs("-foo=0 -nofoo=0");  // -nofoo=0 should win
-    BOOST_CHECK(GetBoolArg("-foo", false));
-    BOOST_CHECK(GetBoolArg("-foo", true));
+    FAST_CHECK(GetBoolArg("-foo", false));
+    FAST_CHECK(GetBoolArg("-foo", true));
 
     // New 0.6 feature: treat -- same as -:
     ResetArgs("--foo=1");
-    BOOST_CHECK(GetBoolArg("-foo", false));
-    BOOST_CHECK(GetBoolArg("-foo", true));
+    FAST_CHECK(GetBoolArg("-foo", false));
+    FAST_CHECK(GetBoolArg("-foo", true));
 
     ResetArgs("--nofoo=1");
-    BOOST_CHECK(!GetBoolArg("-foo", false));
-    BOOST_CHECK(!GetBoolArg("-foo", true));
+    FAST_CHECK(!GetBoolArg("-foo", false));
+    FAST_CHECK(!GetBoolArg("-foo", true));
 
 }
 
 BOOST_AUTO_TEST_CASE(stringarg)
 {
     ResetArgs("");
-    BOOST_CHECK_EQUAL(GetArg("-foo", ""), "");
-    BOOST_CHECK_EQUAL(GetArg("-foo", "eleven"), "eleven");
+    FAST_CHECK_EQUAL(GetArg("-foo", ""), "");
+    FAST_CHECK_EQUAL(GetArg("-foo", "eleven"), "eleven");
 
     ResetArgs("-foo -bar");
-    BOOST_CHECK_EQUAL(GetArg("-foo", ""), "");
-    BOOST_CHECK_EQUAL(GetArg("-foo", "eleven"), "");
+    FAST_CHECK_EQUAL(GetArg("-foo", ""), "");
+    FAST_CHECK_EQUAL(GetArg("-foo", "eleven"), "");
 
     ResetArgs("-foo=");
-    BOOST_CHECK_EQUAL(GetArg("-foo", ""), "");
-    BOOST_CHECK_EQUAL(GetArg("-foo", "eleven"), "");
+    FAST_CHECK_EQUAL(GetArg("-foo", ""), "");
+    FAST_CHECK_EQUAL(GetArg("-foo", "eleven"), "");
 
     ResetArgs("-foo=11");
-    BOOST_CHECK_EQUAL(GetArg("-foo", ""), "11");
-    BOOST_CHECK_EQUAL(GetArg("-foo", "eleven"), "11");
+    FAST_CHECK_EQUAL(GetArg("-foo", ""), "11");
+    FAST_CHECK_EQUAL(GetArg("-foo", "eleven"), "11");
 
     ResetArgs("-foo=eleven");
-    BOOST_CHECK_EQUAL(GetArg("-foo", ""), "eleven");
-    BOOST_CHECK_EQUAL(GetArg("-foo", "eleven"), "eleven");
+    FAST_CHECK_EQUAL(GetArg("-foo", ""), "eleven");
+    FAST_CHECK_EQUAL(GetArg("-foo", "eleven"), "eleven");
 
 }
 
 BOOST_AUTO_TEST_CASE(intarg)
 {
     ResetArgs("");
-    BOOST_CHECK_EQUAL(GetArg("-foo", 11), 11);
-    BOOST_CHECK_EQUAL(GetArg("-foo", 0), 0);
+    FAST_CHECK_EQUAL(GetArg("-foo", 11), 11);
+    FAST_CHECK_EQUAL(GetArg("-foo", 0), 0);
 
     ResetArgs("-foo -bar");
-    BOOST_CHECK_EQUAL(GetArg("-foo", 11), 0);
-    BOOST_CHECK_EQUAL(GetArg("-bar", 11), 0);
+    FAST_CHECK_EQUAL(GetArg("-foo", 11), 0);
+    FAST_CHECK_EQUAL(GetArg("-bar", 11), 0);
 
     ResetArgs("-foo=11 -bar=12");
-    BOOST_CHECK_EQUAL(GetArg("-foo", 0), 11);
-    BOOST_CHECK_EQUAL(GetArg("-bar", 11), 12);
+    FAST_CHECK_EQUAL(GetArg("-foo", 0), 11);
+    FAST_CHECK_EQUAL(GetArg("-bar", 11), 12);
 
     ResetArgs("-foo=NaN -bar=NotANumber");
-    BOOST_CHECK_EQUAL(GetArg("-foo", 1), 0);
-    BOOST_CHECK_EQUAL(GetArg("-bar", 11), 0);
+    FAST_CHECK_EQUAL(GetArg("-foo", 1), 0);
+    FAST_CHECK_EQUAL(GetArg("-bar", 11), 0);
 }
 
 BOOST_AUTO_TEST_CASE(doubledash)
 {
     ResetArgs("--foo");
-    BOOST_CHECK_EQUAL(GetBoolArg("-foo", false), true);
+    FAST_CHECK_EQUAL(GetBoolArg("-foo", false), true);
 
     ResetArgs("--foo=verbose --bar=1");
-    BOOST_CHECK_EQUAL(GetArg("-foo", ""), "verbose");
-    BOOST_CHECK_EQUAL(GetArg("-bar", 0), 1);
+    FAST_CHECK_EQUAL(GetArg("-foo", ""), "verbose");
+    FAST_CHECK_EQUAL(GetArg("-bar", 0), 1);
 }
 
 BOOST_AUTO_TEST_CASE(boolargno)
 {
     ResetArgs("-nofoo");
-    BOOST_CHECK(!GetBoolArg("-foo", true));
-    BOOST_CHECK(!GetBoolArg("-foo", false));
+    FAST_CHECK(!GetBoolArg("-foo", true));
+    FAST_CHECK(!GetBoolArg("-foo", false));
 
     ResetArgs("-nofoo=1");
-    BOOST_CHECK(!GetBoolArg("-foo", true));
-    BOOST_CHECK(!GetBoolArg("-foo", false));
+    FAST_CHECK(!GetBoolArg("-foo", true));
+    FAST_CHECK(!GetBoolArg("-foo", false));
 
     ResetArgs("-nofoo=0");
-    BOOST_CHECK(GetBoolArg("-foo", true));
-    BOOST_CHECK(GetBoolArg("-foo", false));
+    FAST_CHECK(GetBoolArg("-foo", true));
+    FAST_CHECK(GetBoolArg("-foo", false));
 
     ResetArgs("-foo --nofoo"); // --nofoo should win
-    BOOST_CHECK(!GetBoolArg("-foo", true));
-    BOOST_CHECK(!GetBoolArg("-foo", false));
+    FAST_CHECK(!GetBoolArg("-foo", true));
+    FAST_CHECK(!GetBoolArg("-foo", false));
 
     ResetArgs("-nofoo -foo"); // foo always wins:
-    BOOST_CHECK(GetBoolArg("-foo", true));
-    BOOST_CHECK(GetBoolArg("-foo", false));
+    FAST_CHECK(GetBoolArg("-foo", true));
+    FAST_CHECK(GetBoolArg("-foo", false));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/hash_tests.cpp
+++ b/src/test/hash_tests.cpp
@@ -17,7 +17,7 @@ BOOST_FIXTURE_TEST_SUITE(hash_tests, BasicTestingSetup)
 BOOST_AUTO_TEST_CASE(murmurhash3)
 {
 
-#define T(expected, seed, data) BOOST_CHECK_EQUAL(MurmurHash3(seed, ParseHex(data)), expected)
+#define T(expected, seed, data) FAST_CHECK_EQUAL(MurmurHash3(seed, ParseHex(data)), expected)
 
     // Test MurmurHash3 with various inputs. Of course this is retested in the
     // bloom filter tests - they would fail if MurmurHash3() had any problems -
@@ -82,50 +82,50 @@ uint64_t siphash_4_2_testvec[] = {
 BOOST_AUTO_TEST_CASE(siphash)
 {
     CSipHasher hasher(0x0706050403020100ULL, 0x0F0E0D0C0B0A0908ULL);
-    BOOST_CHECK_EQUAL(hasher.Finalize(),  0x726fdb47dd0e0e31ull);
+    FAST_CHECK_EQUAL(hasher.Finalize(),  0x726fdb47dd0e0e31ull);
     static const unsigned char t0[1] = {0};
     hasher.Write(t0, 1);
-    BOOST_CHECK_EQUAL(hasher.Finalize(),  0x74f839c593dc67fdull);
+    FAST_CHECK_EQUAL(hasher.Finalize(),  0x74f839c593dc67fdull);
     static const unsigned char t1[7] = {1,2,3,4,5,6,7};
     hasher.Write(t1, 7);
-    BOOST_CHECK_EQUAL(hasher.Finalize(),  0x93f5f5799a932462ull);
+    FAST_CHECK_EQUAL(hasher.Finalize(),  0x93f5f5799a932462ull);
     hasher.Write(0x0F0E0D0C0B0A0908ULL);
-    BOOST_CHECK_EQUAL(hasher.Finalize(),  0x3f2acc7f57c29bdbull);
+    FAST_CHECK_EQUAL(hasher.Finalize(),  0x3f2acc7f57c29bdbull);
     static const unsigned char t2[2] = {16,17};
     hasher.Write(t2, 2);
-    BOOST_CHECK_EQUAL(hasher.Finalize(),  0x4bc1b3f0968dd39cull);
+    FAST_CHECK_EQUAL(hasher.Finalize(),  0x4bc1b3f0968dd39cull);
     static const unsigned char t3[9] = {18,19,20,21,22,23,24,25,26};
     hasher.Write(t3, 9);
-    BOOST_CHECK_EQUAL(hasher.Finalize(),  0x2f2e6163076bcfadull);
+    FAST_CHECK_EQUAL(hasher.Finalize(),  0x2f2e6163076bcfadull);
     static const unsigned char t4[5] = {27,28,29,30,31};
     hasher.Write(t4, 5);
-    BOOST_CHECK_EQUAL(hasher.Finalize(),  0x7127512f72f27cceull);
+    FAST_CHECK_EQUAL(hasher.Finalize(),  0x7127512f72f27cceull);
     hasher.Write(0x2726252423222120ULL);
-    BOOST_CHECK_EQUAL(hasher.Finalize(),  0x0e3ea96b5304a7d0ull);
+    FAST_CHECK_EQUAL(hasher.Finalize(),  0x0e3ea96b5304a7d0ull);
     hasher.Write(0x2F2E2D2C2B2A2928ULL);
-    BOOST_CHECK_EQUAL(hasher.Finalize(),  0xe612a3cb9ecba951ull);
+    FAST_CHECK_EQUAL(hasher.Finalize(),  0xe612a3cb9ecba951ull);
 
-    BOOST_CHECK_EQUAL(SipHashUint256(0x0706050403020100ULL, 0x0F0E0D0C0B0A0908ULL, uint256S("1f1e1d1c1b1a191817161514131211100f0e0d0c0b0a09080706050403020100")), 0x7127512f72f27cceull);
+    FAST_CHECK_EQUAL(SipHashUint256(0x0706050403020100ULL, 0x0F0E0D0C0B0A0908ULL, uint256S("1f1e1d1c1b1a191817161514131211100f0e0d0c0b0a09080706050403020100")), 0x7127512f72f27cceull);
 
     // Check test vectors from spec, one byte at a time
     CSipHasher hasher2(0x0706050403020100ULL, 0x0F0E0D0C0B0A0908ULL);
     for (uint8_t x=0; x<ARRAYLEN(siphash_4_2_testvec); ++x)
     {
-        BOOST_CHECK_EQUAL(hasher2.Finalize(), siphash_4_2_testvec[x]);
+        FAST_CHECK_EQUAL(hasher2.Finalize(), siphash_4_2_testvec[x]);
         hasher2.Write(&x, 1);
     }
     // Check test vectors from spec, eight bytes at a time
     CSipHasher hasher3(0x0706050403020100ULL, 0x0F0E0D0C0B0A0908ULL);
     for (uint8_t x=0; x<ARRAYLEN(siphash_4_2_testvec); x+=8)
     {
-        BOOST_CHECK_EQUAL(hasher3.Finalize(), siphash_4_2_testvec[x]);
+        FAST_CHECK_EQUAL(hasher3.Finalize(), siphash_4_2_testvec[x]);
         hasher3.Write(uint64_t(x)|(uint64_t(x+1)<<8)|(uint64_t(x+2)<<16)|(uint64_t(x+3)<<24)|
                      (uint64_t(x+4)<<32)|(uint64_t(x+5)<<40)|(uint64_t(x+6)<<48)|(uint64_t(x+7)<<56));
     }
 
     CHashWriter ss(SER_DISK, CLIENT_VERSION);
     ss << CTransaction();
-    BOOST_CHECK_EQUAL(SipHashUint256(1, 2, ss.GetHash()), 0x79751e980c2a0a35ULL);
+    FAST_CHECK_EQUAL(SipHashUint256(1, 2, ss.GetHash()), 0x79751e980c2a0a35ULL);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/key_tests.cpp
+++ b/src/test/key_tests.cpp
@@ -64,50 +64,50 @@ BOOST_FIXTURE_TEST_SUITE(key_tests, BasicTestingSetup)
 BOOST_AUTO_TEST_CASE(key_test1)
 {
     CBitcoinSecret bsecret1, bsecret2, bsecret1C, bsecret2C, baddress1;
-    BOOST_CHECK( bsecret1.SetString (strSecret1));
-    BOOST_CHECK( bsecret2.SetString (strSecret2));
-    BOOST_CHECK( bsecret1C.SetString(strSecret1C));
-    BOOST_CHECK( bsecret2C.SetString(strSecret2C));
-    BOOST_CHECK(!baddress1.SetString(strAddressBad));
+    FAST_CHECK( bsecret1.SetString (strSecret1));
+    FAST_CHECK( bsecret2.SetString (strSecret2));
+    FAST_CHECK( bsecret1C.SetString(strSecret1C));
+    FAST_CHECK( bsecret2C.SetString(strSecret2C));
+    FAST_CHECK(!baddress1.SetString(strAddressBad));
 
     CKey key1  = bsecret1.GetKey();
-    BOOST_CHECK(key1.IsCompressed() == false);
+    FAST_CHECK(key1.IsCompressed() == false);
     CKey key2  = bsecret2.GetKey();
-    BOOST_CHECK(key2.IsCompressed() == false);
+    FAST_CHECK(key2.IsCompressed() == false);
     CKey key1C = bsecret1C.GetKey();
-    BOOST_CHECK(key1C.IsCompressed() == true);
+    FAST_CHECK(key1C.IsCompressed() == true);
     CKey key2C = bsecret2C.GetKey();
-    BOOST_CHECK(key2C.IsCompressed() == true);
+    FAST_CHECK(key2C.IsCompressed() == true);
 
     CPubKey pubkey1  = key1. GetPubKey();
     CPubKey pubkey2  = key2. GetPubKey();
     CPubKey pubkey1C = key1C.GetPubKey();
     CPubKey pubkey2C = key2C.GetPubKey();
 
-    BOOST_CHECK(key1.VerifyPubKey(pubkey1));
-    BOOST_CHECK(!key1.VerifyPubKey(pubkey1C));
-    BOOST_CHECK(!key1.VerifyPubKey(pubkey2));
-    BOOST_CHECK(!key1.VerifyPubKey(pubkey2C));
+    FAST_CHECK(key1.VerifyPubKey(pubkey1));
+    FAST_CHECK(!key1.VerifyPubKey(pubkey1C));
+    FAST_CHECK(!key1.VerifyPubKey(pubkey2));
+    FAST_CHECK(!key1.VerifyPubKey(pubkey2C));
 
-    BOOST_CHECK(!key1C.VerifyPubKey(pubkey1));
-    BOOST_CHECK(key1C.VerifyPubKey(pubkey1C));
-    BOOST_CHECK(!key1C.VerifyPubKey(pubkey2));
-    BOOST_CHECK(!key1C.VerifyPubKey(pubkey2C));
+    FAST_CHECK(!key1C.VerifyPubKey(pubkey1));
+    FAST_CHECK(key1C.VerifyPubKey(pubkey1C));
+    FAST_CHECK(!key1C.VerifyPubKey(pubkey2));
+    FAST_CHECK(!key1C.VerifyPubKey(pubkey2C));
 
-    BOOST_CHECK(!key2.VerifyPubKey(pubkey1));
-    BOOST_CHECK(!key2.VerifyPubKey(pubkey1C));
-    BOOST_CHECK(key2.VerifyPubKey(pubkey2));
-    BOOST_CHECK(!key2.VerifyPubKey(pubkey2C));
+    FAST_CHECK(!key2.VerifyPubKey(pubkey1));
+    FAST_CHECK(!key2.VerifyPubKey(pubkey1C));
+    FAST_CHECK(key2.VerifyPubKey(pubkey2));
+    FAST_CHECK(!key2.VerifyPubKey(pubkey2C));
 
-    BOOST_CHECK(!key2C.VerifyPubKey(pubkey1));
-    BOOST_CHECK(!key2C.VerifyPubKey(pubkey1C));
-    BOOST_CHECK(!key2C.VerifyPubKey(pubkey2));
-    BOOST_CHECK(key2C.VerifyPubKey(pubkey2C));
+    FAST_CHECK(!key2C.VerifyPubKey(pubkey1));
+    FAST_CHECK(!key2C.VerifyPubKey(pubkey1C));
+    FAST_CHECK(!key2C.VerifyPubKey(pubkey2));
+    FAST_CHECK(key2C.VerifyPubKey(pubkey2C));
 
-    BOOST_CHECK(addr1.Get()  == CTxDestination(pubkey1.GetID()));
-    BOOST_CHECK(addr2.Get()  == CTxDestination(pubkey2.GetID()));
-    BOOST_CHECK(addr1C.Get() == CTxDestination(pubkey1C.GetID()));
-    BOOST_CHECK(addr2C.Get() == CTxDestination(pubkey2C.GetID()));
+    FAST_CHECK(addr1.Get()  == CTxDestination(pubkey1.GetID()));
+    FAST_CHECK(addr2.Get()  == CTxDestination(pubkey2.GetID()));
+    FAST_CHECK(addr1C.Get() == CTxDestination(pubkey1C.GetID()));
+    FAST_CHECK(addr2C.Get() == CTxDestination(pubkey2C.GetID()));
 
     for (int n=0; n<16; n++)
     {
@@ -118,51 +118,51 @@ BOOST_AUTO_TEST_CASE(key_test1)
 
         vector<unsigned char> sign1, sign2, sign1C, sign2C;
 
-        BOOST_CHECK(key1.Sign (hashMsg, sign1));
-        BOOST_CHECK(key2.Sign (hashMsg, sign2));
-        BOOST_CHECK(key1C.Sign(hashMsg, sign1C));
-        BOOST_CHECK(key2C.Sign(hashMsg, sign2C));
+        FAST_CHECK(key1.Sign (hashMsg, sign1));
+        FAST_CHECK(key2.Sign (hashMsg, sign2));
+        FAST_CHECK(key1C.Sign(hashMsg, sign1C));
+        FAST_CHECK(key2C.Sign(hashMsg, sign2C));
 
-        BOOST_CHECK( pubkey1.Verify(hashMsg, sign1));
-        BOOST_CHECK(!pubkey1.Verify(hashMsg, sign2));
-        BOOST_CHECK( pubkey1.Verify(hashMsg, sign1C));
-        BOOST_CHECK(!pubkey1.Verify(hashMsg, sign2C));
+        FAST_CHECK( pubkey1.Verify(hashMsg, sign1));
+        FAST_CHECK(!pubkey1.Verify(hashMsg, sign2));
+        FAST_CHECK( pubkey1.Verify(hashMsg, sign1C));
+        FAST_CHECK(!pubkey1.Verify(hashMsg, sign2C));
 
-        BOOST_CHECK(!pubkey2.Verify(hashMsg, sign1));
-        BOOST_CHECK( pubkey2.Verify(hashMsg, sign2));
-        BOOST_CHECK(!pubkey2.Verify(hashMsg, sign1C));
-        BOOST_CHECK( pubkey2.Verify(hashMsg, sign2C));
+        FAST_CHECK(!pubkey2.Verify(hashMsg, sign1));
+        FAST_CHECK( pubkey2.Verify(hashMsg, sign2));
+        FAST_CHECK(!pubkey2.Verify(hashMsg, sign1C));
+        FAST_CHECK( pubkey2.Verify(hashMsg, sign2C));
 
-        BOOST_CHECK( pubkey1C.Verify(hashMsg, sign1));
-        BOOST_CHECK(!pubkey1C.Verify(hashMsg, sign2));
-        BOOST_CHECK( pubkey1C.Verify(hashMsg, sign1C));
-        BOOST_CHECK(!pubkey1C.Verify(hashMsg, sign2C));
+        FAST_CHECK( pubkey1C.Verify(hashMsg, sign1));
+        FAST_CHECK(!pubkey1C.Verify(hashMsg, sign2));
+        FAST_CHECK( pubkey1C.Verify(hashMsg, sign1C));
+        FAST_CHECK(!pubkey1C.Verify(hashMsg, sign2C));
 
-        BOOST_CHECK(!pubkey2C.Verify(hashMsg, sign1));
-        BOOST_CHECK( pubkey2C.Verify(hashMsg, sign2));
-        BOOST_CHECK(!pubkey2C.Verify(hashMsg, sign1C));
-        BOOST_CHECK( pubkey2C.Verify(hashMsg, sign2C));
+        FAST_CHECK(!pubkey2C.Verify(hashMsg, sign1));
+        FAST_CHECK( pubkey2C.Verify(hashMsg, sign2));
+        FAST_CHECK(!pubkey2C.Verify(hashMsg, sign1C));
+        FAST_CHECK( pubkey2C.Verify(hashMsg, sign2C));
 
         // compact signatures (with key recovery)
 
         vector<unsigned char> csign1, csign2, csign1C, csign2C;
 
-        BOOST_CHECK(key1.SignCompact (hashMsg, csign1));
-        BOOST_CHECK(key2.SignCompact (hashMsg, csign2));
-        BOOST_CHECK(key1C.SignCompact(hashMsg, csign1C));
-        BOOST_CHECK(key2C.SignCompact(hashMsg, csign2C));
+        FAST_CHECK(key1.SignCompact (hashMsg, csign1));
+        FAST_CHECK(key2.SignCompact (hashMsg, csign2));
+        FAST_CHECK(key1C.SignCompact(hashMsg, csign1C));
+        FAST_CHECK(key2C.SignCompact(hashMsg, csign2C));
 
         CPubKey rkey1, rkey2, rkey1C, rkey2C;
 
-        BOOST_CHECK(rkey1.RecoverCompact (hashMsg, csign1));
-        BOOST_CHECK(rkey2.RecoverCompact (hashMsg, csign2));
-        BOOST_CHECK(rkey1C.RecoverCompact(hashMsg, csign1C));
-        BOOST_CHECK(rkey2C.RecoverCompact(hashMsg, csign2C));
+        FAST_CHECK(rkey1.RecoverCompact (hashMsg, csign1));
+        FAST_CHECK(rkey2.RecoverCompact (hashMsg, csign2));
+        FAST_CHECK(rkey1C.RecoverCompact(hashMsg, csign1C));
+        FAST_CHECK(rkey2C.RecoverCompact(hashMsg, csign2C));
 
-        BOOST_CHECK(rkey1  == pubkey1);
-        BOOST_CHECK(rkey2  == pubkey2);
-        BOOST_CHECK(rkey1C == pubkey1C);
-        BOOST_CHECK(rkey2C == pubkey2C);
+        FAST_CHECK(rkey1  == pubkey1);
+        FAST_CHECK(rkey2  == pubkey2);
+        FAST_CHECK(rkey1C == pubkey1C);
+        FAST_CHECK(rkey2C == pubkey2C);
     }
 
     // test deterministic signing
@@ -170,22 +170,22 @@ BOOST_AUTO_TEST_CASE(key_test1)
     std::vector<unsigned char> detsig, detsigc;
     string strMsg = "Very deterministic message";
     uint256 hashMsg = Hash(strMsg.begin(), strMsg.end());
-    BOOST_CHECK(key1.Sign(hashMsg, detsig));
-    BOOST_CHECK(key1C.Sign(hashMsg, detsigc));
-    BOOST_CHECK(detsig == detsigc);
-    BOOST_CHECK(detsig == ParseHex("304402205dbbddda71772d95ce91cd2d14b592cfbc1dd0aabd6a394b6c2d377bbe59d31d022014ddda21494a4e221f0824f0b8b924c43fa43c0ad57dccdaa11f81a6bd4582f6"));
-    BOOST_CHECK(key2.Sign(hashMsg, detsig));
-    BOOST_CHECK(key2C.Sign(hashMsg, detsigc));
-    BOOST_CHECK(detsig == detsigc);
-    BOOST_CHECK(detsig == ParseHex("3044022052d8a32079c11e79db95af63bb9600c5b04f21a9ca33dc129c2bfa8ac9dc1cd5022061d8ae5e0f6c1a16bde3719c64c2fd70e404b6428ab9a69566962e8771b5944d"));
-    BOOST_CHECK(key1.SignCompact(hashMsg, detsig));
-    BOOST_CHECK(key1C.SignCompact(hashMsg, detsigc));
-    BOOST_CHECK(detsig == ParseHex("1c5dbbddda71772d95ce91cd2d14b592cfbc1dd0aabd6a394b6c2d377bbe59d31d14ddda21494a4e221f0824f0b8b924c43fa43c0ad57dccdaa11f81a6bd4582f6"));
-    BOOST_CHECK(detsigc == ParseHex("205dbbddda71772d95ce91cd2d14b592cfbc1dd0aabd6a394b6c2d377bbe59d31d14ddda21494a4e221f0824f0b8b924c43fa43c0ad57dccdaa11f81a6bd4582f6"));
-    BOOST_CHECK(key2.SignCompact(hashMsg, detsig));
-    BOOST_CHECK(key2C.SignCompact(hashMsg, detsigc));
-    BOOST_CHECK(detsig == ParseHex("1c52d8a32079c11e79db95af63bb9600c5b04f21a9ca33dc129c2bfa8ac9dc1cd561d8ae5e0f6c1a16bde3719c64c2fd70e404b6428ab9a69566962e8771b5944d"));
-    BOOST_CHECK(detsigc == ParseHex("2052d8a32079c11e79db95af63bb9600c5b04f21a9ca33dc129c2bfa8ac9dc1cd561d8ae5e0f6c1a16bde3719c64c2fd70e404b6428ab9a69566962e8771b5944d"));
+    FAST_CHECK(key1.Sign(hashMsg, detsig));
+    FAST_CHECK(key1C.Sign(hashMsg, detsigc));
+    FAST_CHECK(detsig == detsigc);
+    FAST_CHECK(detsig == ParseHex("304402205dbbddda71772d95ce91cd2d14b592cfbc1dd0aabd6a394b6c2d377bbe59d31d022014ddda21494a4e221f0824f0b8b924c43fa43c0ad57dccdaa11f81a6bd4582f6"));
+    FAST_CHECK(key2.Sign(hashMsg, detsig));
+    FAST_CHECK(key2C.Sign(hashMsg, detsigc));
+    FAST_CHECK(detsig == detsigc);
+    FAST_CHECK(detsig == ParseHex("3044022052d8a32079c11e79db95af63bb9600c5b04f21a9ca33dc129c2bfa8ac9dc1cd5022061d8ae5e0f6c1a16bde3719c64c2fd70e404b6428ab9a69566962e8771b5944d"));
+    FAST_CHECK(key1.SignCompact(hashMsg, detsig));
+    FAST_CHECK(key1C.SignCompact(hashMsg, detsigc));
+    FAST_CHECK(detsig == ParseHex("1c5dbbddda71772d95ce91cd2d14b592cfbc1dd0aabd6a394b6c2d377bbe59d31d14ddda21494a4e221f0824f0b8b924c43fa43c0ad57dccdaa11f81a6bd4582f6"));
+    FAST_CHECK(detsigc == ParseHex("205dbbddda71772d95ce91cd2d14b592cfbc1dd0aabd6a394b6c2d377bbe59d31d14ddda21494a4e221f0824f0b8b924c43fa43c0ad57dccdaa11f81a6bd4582f6"));
+    FAST_CHECK(key2.SignCompact(hashMsg, detsig));
+    FAST_CHECK(key2C.SignCompact(hashMsg, detsigc));
+    FAST_CHECK(detsig == ParseHex("1c52d8a32079c11e79db95af63bb9600c5b04f21a9ca33dc129c2bfa8ac9dc1cd561d8ae5e0f6c1a16bde3719c64c2fd70e404b6428ab9a69566962e8771b5944d"));
+    FAST_CHECK(detsigc == ParseHex("2052d8a32079c11e79db95af63bb9600c5b04f21a9ca33dc129c2bfa8ac9dc1cd561d8ae5e0f6c1a16bde3719c64c2fd70e404b6428ab9a69566962e8771b5944d"));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/limitedmap_tests.cpp
+++ b/src/test/limitedmap_tests.cpp
@@ -16,19 +16,19 @@ BOOST_AUTO_TEST_CASE(limitedmap_test)
     limitedmap<int, int> map(10);
 
     // check that the max size is 10
-    BOOST_CHECK(map.max_size() == 10);
+    FAST_CHECK(map.max_size() == 10);
 
     // check that it's empty
-    BOOST_CHECK(map.size() == 0);
+    FAST_CHECK(map.size() == 0);
 
     // insert (-1, -1)
     map.insert(std::pair<int, int>(-1, -1));
 
     // make sure that the size is updated
-    BOOST_CHECK(map.size() == 1);
+    FAST_CHECK(map.size() == 1);
 
     // make sure that the new items is in the map
-    BOOST_CHECK(map.count(-1) == 1);
+    FAST_CHECK(map.count(-1) == 1);
 
     // insert 10 new items
     for (int i = 0; i < 10; i++) {
@@ -36,48 +36,48 @@ BOOST_AUTO_TEST_CASE(limitedmap_test)
     }
 
     // make sure that the map now contains 10 items...
-    BOOST_CHECK(map.size() == 10);
+    FAST_CHECK(map.size() == 10);
 
     // ...and that the first item has been discarded
-    BOOST_CHECK(map.count(-1) == 0);
+    FAST_CHECK(map.count(-1) == 0);
 
     // iterate over the map, both with an index and an iterator
     limitedmap<int, int>::const_iterator it = map.begin();
     for (int i = 0; i < 10; i++) {
         // make sure the item is present
-        BOOST_CHECK(map.count(i) == 1);
+        FAST_CHECK(map.count(i) == 1);
 
         // use the iterator to check for the expected key adn value
-        BOOST_CHECK(it->first == i);
-        BOOST_CHECK(it->second == i + 1);
+        FAST_CHECK(it->first == i);
+        FAST_CHECK(it->second == i + 1);
         
         // use find to check for the value
-        BOOST_CHECK(map.find(i)->second == i + 1);
+        FAST_CHECK(map.find(i)->second == i + 1);
         
         // update and recheck
         map.update(it, i + 2);
-        BOOST_CHECK(map.find(i)->second == i + 2);
+        FAST_CHECK(map.find(i)->second == i + 2);
 
         it++;
     }
 
     // check that we've exhausted the iterator
-    BOOST_CHECK(it == map.end());
+    FAST_CHECK(it == map.end());
 
     // resize the map to 5 items
     map.max_size(5);
 
     // check that the max size and size are now 5
-    BOOST_CHECK(map.max_size() == 5);
-    BOOST_CHECK(map.size() == 5);
+    FAST_CHECK(map.max_size() == 5);
+    FAST_CHECK(map.size() == 5);
 
     // check that items less than 5 have been discarded
     // and items greater than 5 are retained
     for (int i = 0; i < 10; i++) {
         if (i < 5) {
-            BOOST_CHECK(map.count(i) == 0);
+            FAST_CHECK(map.count(i) == 0);
         } else {
-            BOOST_CHECK(map.count(i) == 1);
+            FAST_CHECK(map.count(i) == 1);
         }
     }
 
@@ -87,7 +87,7 @@ BOOST_AUTO_TEST_CASE(limitedmap_test)
     }
 
     // check that the size is unaffected
-    BOOST_CHECK(map.size() == 5);
+    FAST_CHECK(map.size() == 5);
 
     // erase the remaining elements
     for (int i = 5; i < 10; i++) {
@@ -95,7 +95,7 @@ BOOST_AUTO_TEST_CASE(limitedmap_test)
     }
 
     // check that the map is now empty
-    BOOST_CHECK(map.empty());
+    FAST_CHECK(map.empty());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/main_tests.cpp
+++ b/src/test/main_tests.cpp
@@ -18,15 +18,15 @@ static void TestBlockSubsidyHalvings(const Consensus::Params& consensusParams)
     CAmount nInitialSubsidy = 50 * COIN;
 
     CAmount nPreviousSubsidy = nInitialSubsidy * 2; // for height == 0
-    BOOST_CHECK_EQUAL(nPreviousSubsidy, nInitialSubsidy * 2);
+    FAST_CHECK_EQUAL(nPreviousSubsidy, nInitialSubsidy * 2);
     for (int nHalvings = 0; nHalvings < maxHalvings; nHalvings++) {
         int nHeight = nHalvings * consensusParams.nSubsidyHalvingInterval;
         CAmount nSubsidy = GetBlockSubsidy(nHeight, consensusParams);
-        BOOST_CHECK(nSubsidy <= nInitialSubsidy);
-        BOOST_CHECK_EQUAL(nSubsidy, nPreviousSubsidy / 2);
+        FAST_CHECK(nSubsidy <= nInitialSubsidy);
+        FAST_CHECK_EQUAL(nSubsidy, nPreviousSubsidy / 2);
         nPreviousSubsidy = nSubsidy;
     }
-    BOOST_CHECK_EQUAL(GetBlockSubsidy(maxHalvings * consensusParams.nSubsidyHalvingInterval, consensusParams), 0);
+    FAST_CHECK_EQUAL(GetBlockSubsidy(maxHalvings * consensusParams.nSubsidyHalvingInterval, consensusParams), 0);
 }
 
 static void TestBlockSubsidyHalvings(int nSubsidyHalvingInterval)
@@ -49,11 +49,11 @@ BOOST_AUTO_TEST_CASE(subsidy_limit_test)
     CAmount nSum = 0;
     for (int nHeight = 0; nHeight < 14000000; nHeight += 1000) {
         CAmount nSubsidy = GetBlockSubsidy(nHeight, consensusParams);
-        BOOST_CHECK(nSubsidy <= 50 * COIN);
+        FAST_CHECK(nSubsidy <= 50 * COIN);
         nSum += nSubsidy * 1000;
-        BOOST_CHECK(MoneyRange(nSum));
+        FAST_CHECK(MoneyRange(nSum));
     }
-    BOOST_CHECK_EQUAL(nSum, 2099999997690000ULL);
+    FAST_CHECK_EQUAL(nSum, 2099999997690000ULL);
 }
 
 bool ReturnFalse() { return false; }
@@ -62,14 +62,14 @@ bool ReturnTrue() { return true; }
 BOOST_AUTO_TEST_CASE(test_combiner_all)
 {
     boost::signals2::signal<bool (), CombinerAll> Test;
-    BOOST_CHECK(Test());
+    FAST_CHECK(Test());
     Test.connect(&ReturnFalse);
-    BOOST_CHECK(!Test());
+    FAST_CHECK(!Test());
     Test.connect(&ReturnTrue);
-    BOOST_CHECK(!Test());
+    FAST_CHECK(!Test());
     Test.disconnect(&ReturnFalse);
-    BOOST_CHECK(Test());
+    FAST_CHECK(Test());
     Test.disconnect(&ReturnTrue);
-    BOOST_CHECK(Test());
+    FAST_CHECK(Test());
 }
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/mempool_tests.cpp
+++ b/src/test/mempool_tests.cpp
@@ -59,12 +59,12 @@ BOOST_AUTO_TEST_CASE(MempoolRemoveTest)
 
     // Nothing in pool, remove should do nothing:
     testPool.removeRecursive(txParent, removed);
-    BOOST_CHECK_EQUAL(removed.size(), 0);
+    FAST_CHECK_EQUAL(removed.size(), 0);
 
     // Just the parent:
     testPool.addUnchecked(txParent.GetHash(), entry.FromTx(txParent));
     testPool.removeRecursive(txParent, removed);
-    BOOST_CHECK_EQUAL(removed.size(), 1);
+    FAST_CHECK_EQUAL(removed.size(), 1);
     removed.clear();
     
     // Parent, children, grandchildren:
@@ -76,17 +76,17 @@ BOOST_AUTO_TEST_CASE(MempoolRemoveTest)
     }
     // Remove Child[0], GrandChild[0] should be removed:
     testPool.removeRecursive(txChild[0], removed);
-    BOOST_CHECK_EQUAL(removed.size(), 2);
+    FAST_CHECK_EQUAL(removed.size(), 2);
     removed.clear();
     // ... make sure grandchild and child are gone:
     testPool.removeRecursive(txGrandChild[0], removed);
-    BOOST_CHECK_EQUAL(removed.size(), 0);
+    FAST_CHECK_EQUAL(removed.size(), 0);
     testPool.removeRecursive(txChild[0], removed);
-    BOOST_CHECK_EQUAL(removed.size(), 0);
+    FAST_CHECK_EQUAL(removed.size(), 0);
     // Remove parent, all children/grandchildren should go:
     testPool.removeRecursive(txParent, removed);
-    BOOST_CHECK_EQUAL(removed.size(), 5);
-    BOOST_CHECK_EQUAL(testPool.size(), 0);
+    FAST_CHECK_EQUAL(removed.size(), 5);
+    FAST_CHECK_EQUAL(testPool.size(), 0);
     removed.clear();
 
     // Add children and grandchildren, but NOT the parent (simulate the parent being in a block)
@@ -98,19 +98,19 @@ BOOST_AUTO_TEST_CASE(MempoolRemoveTest)
     // Now remove the parent, as might happen if a block-re-org occurs but the parent cannot be
     // put into the mempool (maybe because it is non-standard):
     testPool.removeRecursive(txParent, removed);
-    BOOST_CHECK_EQUAL(removed.size(), 6);
-    BOOST_CHECK_EQUAL(testPool.size(), 0);
+    FAST_CHECK_EQUAL(removed.size(), 6);
+    FAST_CHECK_EQUAL(testPool.size(), 0);
     removed.clear();
 }
 
 template<typename name>
 void CheckSort(CTxMemPool &pool, std::vector<std::string> &sortedOrder)
 {
-    BOOST_CHECK_EQUAL(pool.size(), sortedOrder.size());
+    FAST_CHECK_EQUAL(pool.size(), sortedOrder.size());
     typename CTxMemPool::indexed_transaction_set::index<name>::type::iterator it = pool.mapTx.get<name>().begin();
     int count=0;
     for (; it != pool.mapTx.get<name>().end(); ++it, ++count) {
-        BOOST_CHECK_EQUAL(it->GetTx().GetHash().ToString(), sortedOrder[count]);
+        FAST_CHECK_EQUAL(it->GetTx().GetHash().ToString(), sortedOrder[count]);
     }
 }
 
@@ -156,7 +156,7 @@ BOOST_AUTO_TEST_CASE(MempoolIndexingTest)
     entry.nTime = 1;
     entry.dPriority = 10.0;
     pool.addUnchecked(tx5.GetHash(), entry.Fee(10000LL).FromTx(tx5));
-    BOOST_CHECK_EQUAL(pool.size(), 5);
+    FAST_CHECK_EQUAL(pool.size(), 5);
 
     std::vector<std::string> sortedOrder;
     sortedOrder.resize(5);
@@ -174,7 +174,7 @@ BOOST_AUTO_TEST_CASE(MempoolIndexingTest)
     tx6.vout[0].scriptPubKey = CScript() << OP_11 << OP_EQUAL;
     tx6.vout[0].nValue = 20 * COIN;
     pool.addUnchecked(tx6.GetHash(), entry.Fee(0LL).FromTx(tx6));
-    BOOST_CHECK_EQUAL(pool.size(), 6);
+    FAST_CHECK_EQUAL(pool.size(), 6);
     // Check that at this point, tx6 is sorted low
     sortedOrder.insert(sortedOrder.begin(), tx6.GetHash().ToString());
     CheckSort<descendant_score>(pool, sortedOrder);
@@ -193,11 +193,11 @@ BOOST_AUTO_TEST_CASE(MempoolIndexingTest)
 
     CTxMemPool::setEntries setAncestorsCalculated;
     std::string dummy;
-    BOOST_CHECK_EQUAL(pool.CalculateMemPoolAncestors(entry.Fee(2000000LL).FromTx(tx7), setAncestorsCalculated, 100, 1000000, 1000, 1000000, dummy), true);
-    BOOST_CHECK(setAncestorsCalculated == setAncestors);
+    FAST_CHECK_EQUAL(pool.CalculateMemPoolAncestors(entry.Fee(2000000LL).FromTx(tx7), setAncestorsCalculated, 100, 1000000, 1000, 1000000, dummy), true);
+    FAST_CHECK(setAncestorsCalculated == setAncestors);
 
     pool.addUnchecked(tx7.GetHash(), entry.FromTx(tx7), setAncestors);
-    BOOST_CHECK_EQUAL(pool.size(), 7);
+    FAST_CHECK_EQUAL(pool.size(), 7);
 
     // Now tx6 should be sorted higher (high fee child): tx7, tx6, tx2, ...
     sortedOrder.erase(sortedOrder.begin());
@@ -231,7 +231,7 @@ BOOST_AUTO_TEST_CASE(MempoolIndexingTest)
     pool.addUnchecked(tx9.GetHash(), entry.Fee(0LL).Time(3).FromTx(tx9), setAncestors);
 
     // tx9 should be sorted low
-    BOOST_CHECK_EQUAL(pool.size(), 9);
+    FAST_CHECK_EQUAL(pool.size(), 9);
     sortedOrder.insert(sortedOrder.begin(), tx9.GetHash().ToString());
     CheckSort<descendant_score>(pool, sortedOrder);
 
@@ -251,8 +251,8 @@ BOOST_AUTO_TEST_CASE(MempoolIndexingTest)
     tx10.vout[0].nValue = 10 * COIN;
 
     setAncestorsCalculated.clear();
-    BOOST_CHECK_EQUAL(pool.CalculateMemPoolAncestors(entry.Fee(200000LL).Time(4).FromTx(tx10), setAncestorsCalculated, 100, 1000000, 1000, 1000000, dummy), true);
-    BOOST_CHECK(setAncestorsCalculated == setAncestors);
+    FAST_CHECK_EQUAL(pool.CalculateMemPoolAncestors(entry.Fee(200000LL).Time(4).FromTx(tx10), setAncestorsCalculated, 100, 1000000, 1000, 1000000, dummy), true);
+    FAST_CHECK(setAncestorsCalculated == setAncestors);
 
     pool.addUnchecked(tx10.GetHash(), entry.FromTx(tx10), setAncestors);
 
@@ -278,7 +278,7 @@ BOOST_AUTO_TEST_CASE(MempoolIndexingTest)
     CheckSort<descendant_score>(pool, sortedOrder);
 
     // there should be 10 transactions in the mempool
-    BOOST_CHECK_EQUAL(pool.size(), 10);
+    FAST_CHECK_EQUAL(pool.size(), 10);
 
     // Now try removing tx10 and verify the sort order returns to normal
     std::list<CTransaction> removed;
@@ -359,7 +359,7 @@ BOOST_AUTO_TEST_CASE(MempoolAncestorIndexingTest)
     tx5.vout[0].scriptPubKey = CScript() << OP_11 << OP_EQUAL;
     tx5.vout[0].nValue = 11 * COIN;
     pool.addUnchecked(tx5.GetHash(), entry.Fee(10000LL).FromTx(tx5));
-    BOOST_CHECK_EQUAL(pool.size(), 5);
+    FAST_CHECK_EQUAL(pool.size(), 5);
 
     std::vector<std::string> sortedOrder;
     sortedOrder.resize(5);
@@ -388,7 +388,7 @@ BOOST_AUTO_TEST_CASE(MempoolAncestorIndexingTest)
     uint64_t tx6Size = GetVirtualTransactionSize(tx6);
 
     pool.addUnchecked(tx6.GetHash(), entry.Fee(0LL).FromTx(tx6));
-    BOOST_CHECK_EQUAL(pool.size(), 6);
+    FAST_CHECK_EQUAL(pool.size(), 6);
     sortedOrder.push_back(tx6.GetHash().ToString());
     CheckSort<ancestor_score>(pool, sortedOrder);
 
@@ -406,7 +406,7 @@ BOOST_AUTO_TEST_CASE(MempoolAncestorIndexingTest)
 
     //CTxMemPoolEntry entry7(tx7, fee, 2, 10.0, 1, true);
     pool.addUnchecked(tx7.GetHash(), entry.Fee(fee).FromTx(tx7));
-    BOOST_CHECK_EQUAL(pool.size(), 7);
+    FAST_CHECK_EQUAL(pool.size(), 7);
     sortedOrder.insert(sortedOrder.begin()+1, tx7.GetHash().ToString());
     CheckSort<ancestor_score>(pool, sortedOrder);
 
@@ -446,12 +446,12 @@ BOOST_AUTO_TEST_CASE(MempoolSizeLimitTest)
     pool.addUnchecked(tx2.GetHash(), entry.Fee(5000LL).FromTx(tx2, &pool));
 
     pool.TrimToSize(pool.DynamicMemoryUsage()); // should do nothing
-    BOOST_CHECK(pool.exists(tx1.GetHash()));
-    BOOST_CHECK(pool.exists(tx2.GetHash()));
+    FAST_CHECK(pool.exists(tx1.GetHash()));
+    FAST_CHECK(pool.exists(tx2.GetHash()));
 
     pool.TrimToSize(pool.DynamicMemoryUsage() * 3 / 4); // should remove the lower-feerate transaction
-    BOOST_CHECK(pool.exists(tx1.GetHash()));
-    BOOST_CHECK(!pool.exists(tx2.GetHash()));
+    FAST_CHECK(pool.exists(tx1.GetHash()));
+    FAST_CHECK(!pool.exists(tx2.GetHash()));
 
     pool.addUnchecked(tx2.GetHash(), entry.FromTx(tx2, &pool));
     CMutableTransaction tx3 = CMutableTransaction();
@@ -464,17 +464,17 @@ BOOST_AUTO_TEST_CASE(MempoolSizeLimitTest)
     pool.addUnchecked(tx3.GetHash(), entry.Fee(20000LL).FromTx(tx3, &pool));
 
     pool.TrimToSize(pool.DynamicMemoryUsage() * 3 / 4); // tx3 should pay for tx2 (CPFP)
-    BOOST_CHECK(!pool.exists(tx1.GetHash()));
-    BOOST_CHECK(pool.exists(tx2.GetHash()));
-    BOOST_CHECK(pool.exists(tx3.GetHash()));
+    FAST_CHECK(!pool.exists(tx1.GetHash()));
+    FAST_CHECK(pool.exists(tx2.GetHash()));
+    FAST_CHECK(pool.exists(tx3.GetHash()));
 
     pool.TrimToSize(GetVirtualTransactionSize(tx1)); // mempool is limited to tx1's size in memory usage, so nothing fits
-    BOOST_CHECK(!pool.exists(tx1.GetHash()));
-    BOOST_CHECK(!pool.exists(tx2.GetHash()));
-    BOOST_CHECK(!pool.exists(tx3.GetHash()));
+    FAST_CHECK(!pool.exists(tx1.GetHash()));
+    FAST_CHECK(!pool.exists(tx2.GetHash()));
+    FAST_CHECK(!pool.exists(tx3.GetHash()));
 
     CFeeRate maxFeeRateRemoved(25000, GetVirtualTransactionSize(tx3) + GetVirtualTransactionSize(tx2));
-    BOOST_CHECK_EQUAL(pool.GetMinFee(1).GetFeePerK(), maxFeeRateRemoved.GetFeePerK() + 1000);
+    FAST_CHECK_EQUAL(pool.GetMinFee(1).GetFeePerK(), maxFeeRateRemoved.GetFeePerK() + 1000);
 
     CMutableTransaction tx4 = CMutableTransaction();
     tx4.vin.resize(2);
@@ -531,19 +531,19 @@ BOOST_AUTO_TEST_CASE(MempoolSizeLimitTest)
 
     // we only require this remove, at max, 2 txn, because its not clear what we're really optimizing for aside from that
     pool.TrimToSize(pool.DynamicMemoryUsage() - 1);
-    BOOST_CHECK(pool.exists(tx4.GetHash()));
-    BOOST_CHECK(pool.exists(tx6.GetHash()));
-    BOOST_CHECK(!pool.exists(tx7.GetHash()));
+    FAST_CHECK(pool.exists(tx4.GetHash()));
+    FAST_CHECK(pool.exists(tx6.GetHash()));
+    FAST_CHECK(!pool.exists(tx7.GetHash()));
 
     if (!pool.exists(tx5.GetHash()))
         pool.addUnchecked(tx5.GetHash(), entry.Fee(1000LL).FromTx(tx5, &pool));
     pool.addUnchecked(tx7.GetHash(), entry.Fee(9000LL).FromTx(tx7, &pool));
 
     pool.TrimToSize(pool.DynamicMemoryUsage() / 2); // should maximize mempool size by only removing 5/7
-    BOOST_CHECK(pool.exists(tx4.GetHash()));
-    BOOST_CHECK(!pool.exists(tx5.GetHash()));
-    BOOST_CHECK(pool.exists(tx6.GetHash()));
-    BOOST_CHECK(!pool.exists(tx7.GetHash()));
+    FAST_CHECK(pool.exists(tx4.GetHash()));
+    FAST_CHECK(!pool.exists(tx5.GetHash()));
+    FAST_CHECK(pool.exists(tx6.GetHash()));
+    FAST_CHECK(!pool.exists(tx7.GetHash()));
 
     pool.addUnchecked(tx5.GetHash(), entry.Fee(1000LL).FromTx(tx5, &pool));
     pool.addUnchecked(tx7.GetHash(), entry.Fee(9000LL).FromTx(tx7, &pool));
@@ -552,27 +552,27 @@ BOOST_AUTO_TEST_CASE(MempoolSizeLimitTest)
     std::list<CTransaction> conflicts;
     SetMockTime(42);
     SetMockTime(42 + CTxMemPool::ROLLING_FEE_HALFLIFE);
-    BOOST_CHECK_EQUAL(pool.GetMinFee(1).GetFeePerK(), maxFeeRateRemoved.GetFeePerK() + 1000);
+    FAST_CHECK_EQUAL(pool.GetMinFee(1).GetFeePerK(), maxFeeRateRemoved.GetFeePerK() + 1000);
     // ... we should keep the same min fee until we get a block
     pool.removeForBlock(vtx, 1, conflicts);
     SetMockTime(42 + 2*CTxMemPool::ROLLING_FEE_HALFLIFE);
-    BOOST_CHECK_EQUAL(pool.GetMinFee(1).GetFeePerK(), (maxFeeRateRemoved.GetFeePerK() + 1000)/2);
+    FAST_CHECK_EQUAL(pool.GetMinFee(1).GetFeePerK(), (maxFeeRateRemoved.GetFeePerK() + 1000)/2);
     // ... then feerate should drop 1/2 each halflife
 
     SetMockTime(42 + 2*CTxMemPool::ROLLING_FEE_HALFLIFE + CTxMemPool::ROLLING_FEE_HALFLIFE/2);
-    BOOST_CHECK_EQUAL(pool.GetMinFee(pool.DynamicMemoryUsage() * 5 / 2).GetFeePerK(), (maxFeeRateRemoved.GetFeePerK() + 1000)/4);
+    FAST_CHECK_EQUAL(pool.GetMinFee(pool.DynamicMemoryUsage() * 5 / 2).GetFeePerK(), (maxFeeRateRemoved.GetFeePerK() + 1000)/4);
     // ... with a 1/2 halflife when mempool is < 1/2 its target size
 
     SetMockTime(42 + 2*CTxMemPool::ROLLING_FEE_HALFLIFE + CTxMemPool::ROLLING_FEE_HALFLIFE/2 + CTxMemPool::ROLLING_FEE_HALFLIFE/4);
-    BOOST_CHECK_EQUAL(pool.GetMinFee(pool.DynamicMemoryUsage() * 9 / 2).GetFeePerK(), (maxFeeRateRemoved.GetFeePerK() + 1000)/8);
+    FAST_CHECK_EQUAL(pool.GetMinFee(pool.DynamicMemoryUsage() * 9 / 2).GetFeePerK(), (maxFeeRateRemoved.GetFeePerK() + 1000)/8);
     // ... with a 1/4 halflife when mempool is < 1/4 its target size
 
     SetMockTime(42 + 7*CTxMemPool::ROLLING_FEE_HALFLIFE + CTxMemPool::ROLLING_FEE_HALFLIFE/2 + CTxMemPool::ROLLING_FEE_HALFLIFE/4);
-    BOOST_CHECK_EQUAL(pool.GetMinFee(1).GetFeePerK(), 1000);
+    FAST_CHECK_EQUAL(pool.GetMinFee(1).GetFeePerK(), 1000);
     // ... but feerate should never drop below 1000
 
     SetMockTime(42 + 8*CTxMemPool::ROLLING_FEE_HALFLIFE + CTxMemPool::ROLLING_FEE_HALFLIFE/2 + CTxMemPool::ROLLING_FEE_HALFLIFE/4);
-    BOOST_CHECK_EQUAL(pool.GetMinFee(1).GetFeePerK(), 0);
+    FAST_CHECK_EQUAL(pool.GetMinFee(1).GetFeePerK(), 0);
     // ... unless it has gone all the way to 0 (after getting past 1000/2)
 
     SetMockTime(0);

--- a/src/test/merkle_tests.cpp
+++ b/src/test/merkle_tests.cpp
@@ -91,7 +91,7 @@ BOOST_AUTO_TEST_CASE(merkle_test)
             // Compute the root of the block before mutating it.
             bool unmutatedMutated = false;
             uint256 unmutatedRoot = BlockMerkleRoot(block, &unmutatedMutated);
-            BOOST_CHECK(unmutatedMutated == false);
+            FAST_CHECK(unmutatedMutated == false);
             // Optionally mutate by duplicating the last transactions, resulting in the same merkle root.
             block.vtx.resize(ntx3);
             for (int j = 0; j < duplicate1; j++) {
@@ -110,11 +110,11 @@ BOOST_AUTO_TEST_CASE(merkle_test)
             // Compute the merkle root using the new mechanism.
             bool newMutated = false;
             uint256 newRoot = BlockMerkleRoot(block, &newMutated);
-            BOOST_CHECK(oldRoot == newRoot);
-            BOOST_CHECK(newRoot == unmutatedRoot);
-            BOOST_CHECK((newRoot == uint256()) == (ntx == 0));
-            BOOST_CHECK(oldMutated == newMutated);
-            BOOST_CHECK(newMutated == !!mutate);
+            FAST_CHECK(oldRoot == newRoot);
+            FAST_CHECK(newRoot == unmutatedRoot);
+            FAST_CHECK((newRoot == uint256()) == (ntx == 0));
+            FAST_CHECK(oldMutated == newMutated);
+            FAST_CHECK(newMutated == !!mutate);
             // If no mutation was done (once for every ntx value), try up to 16 branches.
             if (mutate == 0) {
                 for (int loop = 0; loop < std::min(ntx, 16); loop++) {
@@ -125,8 +125,8 @@ BOOST_AUTO_TEST_CASE(merkle_test)
                     }
                     std::vector<uint256> newBranch = BlockMerkleBranch(block, mtx);
                     std::vector<uint256> oldBranch = BlockGetMerkleBranch(block, merkleTree, mtx);
-                    BOOST_CHECK(oldBranch == newBranch);
-                    BOOST_CHECK(ComputeMerkleRootFromBranch(block.vtx[mtx].GetHash(), newBranch, mtx) == oldRoot);
+                    FAST_CHECK(oldBranch == newBranch);
+                    FAST_CHECK(ComputeMerkleRootFromBranch(block.vtx[mtx].GetHash(), newBranch, mtx) == oldRoot);
                 }
             }
         }

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -106,9 +106,9 @@ void TestPackageSelection(const CChainParams& chainparams, CScript scriptPubKey,
     mempool.addUnchecked(hashHighFeeTx, entry.Fee(50000).Time(GetTime()).SpendsCoinbase(false).FromTx(tx));
 
     CBlockTemplate *pblocktemplate = BlockAssembler(chainparams).CreateNewBlock(scriptPubKey);
-    BOOST_CHECK(pblocktemplate->block.vtx[1].GetHash() == hashParentTx);
-    BOOST_CHECK(pblocktemplate->block.vtx[2].GetHash() == hashHighFeeTx);
-    BOOST_CHECK(pblocktemplate->block.vtx[3].GetHash() == hashMediumFeeTx);
+    FAST_CHECK(pblocktemplate->block.vtx[1].GetHash() == hashParentTx);
+    FAST_CHECK(pblocktemplate->block.vtx[2].GetHash() == hashHighFeeTx);
+    FAST_CHECK(pblocktemplate->block.vtx[3].GetHash() == hashMediumFeeTx);
 
     // Test that a package below the min relay fee doesn't get included
     tx.vin[0].prevout.hash = hashHighFeeTx;
@@ -128,8 +128,8 @@ void TestPackageSelection(const CChainParams& chainparams, CScript scriptPubKey,
     pblocktemplate = BlockAssembler(chainparams).CreateNewBlock(scriptPubKey);
     // Verify that the free tx and the low fee tx didn't get selected
     for (size_t i=0; i<pblocktemplate->block.vtx.size(); ++i) {
-        BOOST_CHECK(pblocktemplate->block.vtx[i].GetHash() != hashFreeTx);
-        BOOST_CHECK(pblocktemplate->block.vtx[i].GetHash() != hashLowFeeTx);
+        FAST_CHECK(pblocktemplate->block.vtx[i].GetHash() != hashFreeTx);
+        FAST_CHECK(pblocktemplate->block.vtx[i].GetHash() != hashLowFeeTx);
     }
 
     // Test that packages above the min relay fee do get included, even if one
@@ -141,8 +141,8 @@ void TestPackageSelection(const CChainParams& chainparams, CScript scriptPubKey,
     hashLowFeeTx = tx.GetHash();
     mempool.addUnchecked(hashLowFeeTx, entry.Fee(feeToUse+2).FromTx(tx));
     pblocktemplate = BlockAssembler(chainparams).CreateNewBlock(scriptPubKey);
-    BOOST_CHECK(pblocktemplate->block.vtx[4].GetHash() == hashFreeTx);
-    BOOST_CHECK(pblocktemplate->block.vtx[5].GetHash() == hashLowFeeTx);
+    FAST_CHECK(pblocktemplate->block.vtx[4].GetHash() == hashFreeTx);
+    FAST_CHECK(pblocktemplate->block.vtx[5].GetHash() == hashLowFeeTx);
 
     // Test that transaction selection properly updates ancestor fee
     // calculations as ancestor transactions get included in a block.
@@ -165,8 +165,8 @@ void TestPackageSelection(const CChainParams& chainparams, CScript scriptPubKey,
 
     // Verify that this tx isn't selected.
     for (size_t i=0; i<pblocktemplate->block.vtx.size(); ++i) {
-        BOOST_CHECK(pblocktemplate->block.vtx[i].GetHash() != hashFreeTx2);
-        BOOST_CHECK(pblocktemplate->block.vtx[i].GetHash() != hashLowFeeTx2);
+        FAST_CHECK(pblocktemplate->block.vtx[i].GetHash() != hashFreeTx2);
+        FAST_CHECK(pblocktemplate->block.vtx[i].GetHash() != hashLowFeeTx2);
     }
 
     // This tx will be mineable, and should cause hashLowFeeTx2 to be selected
@@ -175,7 +175,7 @@ void TestPackageSelection(const CChainParams& chainparams, CScript scriptPubKey,
     tx.vout[0].nValue = 100000000 - 10000; // 10k satoshi fee
     mempool.addUnchecked(tx.GetHash(), entry.Fee(10000).FromTx(tx));
     pblocktemplate = BlockAssembler(chainparams).CreateNewBlock(scriptPubKey);
-    BOOST_CHECK(pblocktemplate->block.vtx[8].GetHash() == hashLowFeeTx2);
+    FAST_CHECK(pblocktemplate->block.vtx[8].GetHash() == hashLowFeeTx2);
 }
 
 // NOTE: These tests rely on CreateNewBlock doing its own self-validation!
@@ -197,7 +197,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     fCheckpointsEnabled = false;
 
     // Simple block creation, nothing special yet:
-    BOOST_CHECK(pblocktemplate = BlockAssembler(chainparams).CreateNewBlock(scriptPubKey));
+    FAST_CHECK(pblocktemplate = BlockAssembler(chainparams).CreateNewBlock(scriptPubKey));
 
     // We can't make transactions until we have inputs
     // Therefore, load 100 blocks :)
@@ -222,14 +222,14 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
         pblock->hashMerkleRoot = BlockMerkleRoot(*pblock);
         pblock->nNonce = blockinfo[i].nonce;
         CValidationState state;
-        BOOST_CHECK(ProcessNewBlock(state, chainparams, NULL, pblock, true, NULL));
-        BOOST_CHECK(state.IsValid());
+        FAST_CHECK(ProcessNewBlock(state, chainparams, NULL, pblock, true, NULL));
+        FAST_CHECK(state.IsValid());
         pblock->hashPrevBlock = pblock->GetHash();
     }
     delete pblocktemplate;
 
     // Just to make sure we can still make simple blocks
-    BOOST_CHECK(pblocktemplate = BlockAssembler(chainparams).CreateNewBlock(scriptPubKey));
+    FAST_CHECK(pblocktemplate = BlockAssembler(chainparams).CreateNewBlock(scriptPubKey));
     delete pblocktemplate;
 
     const CAmount BLOCKSUBSIDY = 50*COIN;
@@ -254,7 +254,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
         mempool.addUnchecked(hash, entry.Fee(LOWFEE).Time(GetTime()).SpendsCoinbase(spendsCoinbase).FromTx(tx));
         tx.vin[0].prevout.hash = hash;
     }
-    BOOST_CHECK_THROW(BlockAssembler(chainparams).CreateNewBlock(scriptPubKey), std::runtime_error);
+    FAST_CHECK_THROW(BlockAssembler(chainparams).CreateNewBlock(scriptPubKey), std::runtime_error);
     mempool.clear();
 
     tx.vin[0].prevout.hash = txFirst[0]->GetHash();
@@ -268,7 +268,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
         mempool.addUnchecked(hash, entry.Fee(LOWFEE).Time(GetTime()).SpendsCoinbase(spendsCoinbase).SigOpsCost(80).FromTx(tx));
         tx.vin[0].prevout.hash = hash;
     }
-    BOOST_CHECK(pblocktemplate = BlockAssembler(chainparams).CreateNewBlock(scriptPubKey));
+    FAST_CHECK(pblocktemplate = BlockAssembler(chainparams).CreateNewBlock(scriptPubKey));
     delete pblocktemplate;
     mempool.clear();
 
@@ -289,14 +289,14 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
         mempool.addUnchecked(hash, entry.Fee(LOWFEE).Time(GetTime()).SpendsCoinbase(spendsCoinbase).FromTx(tx));
         tx.vin[0].prevout.hash = hash;
     }
-    BOOST_CHECK(pblocktemplate = BlockAssembler(chainparams).CreateNewBlock(scriptPubKey));
+    FAST_CHECK(pblocktemplate = BlockAssembler(chainparams).CreateNewBlock(scriptPubKey));
     delete pblocktemplate;
     mempool.clear();
 
     // orphan in mempool, template creation fails
     hash = tx.GetHash();
     mempool.addUnchecked(hash, entry.Fee(LOWFEE).Time(GetTime()).FromTx(tx));
-    BOOST_CHECK_THROW(BlockAssembler(chainparams).CreateNewBlock(scriptPubKey), std::runtime_error);
+    FAST_CHECK_THROW(BlockAssembler(chainparams).CreateNewBlock(scriptPubKey), std::runtime_error);
     mempool.clear();
 
     // child with higher priority than parent
@@ -313,7 +313,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     tx.vout[0].nValue = tx.vout[0].nValue+BLOCKSUBSIDY-HIGHERFEE; //First txn output + fresh coinbase - new txn fee
     hash = tx.GetHash();
     mempool.addUnchecked(hash, entry.Fee(HIGHERFEE).Time(GetTime()).SpendsCoinbase(true).FromTx(tx));
-    BOOST_CHECK(pblocktemplate = BlockAssembler(chainparams).CreateNewBlock(scriptPubKey));
+    FAST_CHECK(pblocktemplate = BlockAssembler(chainparams).CreateNewBlock(scriptPubKey));
     delete pblocktemplate;
     mempool.clear();
 
@@ -325,7 +325,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     hash = tx.GetHash();
     // give it a fee so it'll get mined
     mempool.addUnchecked(hash, entry.Fee(LOWFEE).Time(GetTime()).SpendsCoinbase(false).FromTx(tx));
-    BOOST_CHECK_THROW(BlockAssembler(chainparams).CreateNewBlock(scriptPubKey), std::runtime_error);
+    FAST_CHECK_THROW(BlockAssembler(chainparams).CreateNewBlock(scriptPubKey), std::runtime_error);
     mempool.clear();
 
     // invalid (pre-p2sh) txn in mempool, template creation fails
@@ -342,7 +342,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     tx.vout[0].nValue -= LOWFEE;
     hash = tx.GetHash();
     mempool.addUnchecked(hash, entry.Fee(LOWFEE).Time(GetTime()).SpendsCoinbase(false).FromTx(tx));
-    BOOST_CHECK_THROW(BlockAssembler(chainparams).CreateNewBlock(scriptPubKey), std::runtime_error);
+    FAST_CHECK_THROW(BlockAssembler(chainparams).CreateNewBlock(scriptPubKey), std::runtime_error);
     mempool.clear();
 
     // double spend txn pair in mempool, template creation fails
@@ -355,7 +355,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     tx.vout[0].scriptPubKey = CScript() << OP_2;
     hash = tx.GetHash();
     mempool.addUnchecked(hash, entry.Fee(HIGHFEE).Time(GetTime()).SpendsCoinbase(true).FromTx(tx));
-    BOOST_CHECK_THROW(BlockAssembler(chainparams).CreateNewBlock(scriptPubKey), std::runtime_error);
+    FAST_CHECK_THROW(BlockAssembler(chainparams).CreateNewBlock(scriptPubKey), std::runtime_error);
     mempool.clear();
 
     // subsidy changing
@@ -371,7 +371,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
         next->BuildSkip();
         chainActive.SetTip(next);
     }
-    BOOST_CHECK(pblocktemplate = BlockAssembler(chainparams).CreateNewBlock(scriptPubKey));
+    FAST_CHECK(pblocktemplate = BlockAssembler(chainparams).CreateNewBlock(scriptPubKey));
     delete pblocktemplate;
     // Extend to a 210000-long block chain.
     while (chainActive.Tip()->nHeight < 210000) {
@@ -384,7 +384,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
         next->BuildSkip();
         chainActive.SetTip(next);
     }
-    BOOST_CHECK(pblocktemplate = BlockAssembler(chainparams).CreateNewBlock(scriptPubKey));
+    FAST_CHECK(pblocktemplate = BlockAssembler(chainparams).CreateNewBlock(scriptPubKey));
     delete pblocktemplate;
     // Delete the dummy blocks again.
     while (chainActive.Tip()->nHeight > nHeight) {
@@ -416,9 +416,9 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     tx.nLockTime = 0;
     hash = tx.GetHash();
     mempool.addUnchecked(hash, entry.Fee(HIGHFEE).Time(GetTime()).SpendsCoinbase(true).FromTx(tx));
-    BOOST_CHECK(CheckFinalTx(tx, flags)); // Locktime passes
-    BOOST_CHECK(!TestSequenceLocks(tx, flags)); // Sequence locks fail
-    BOOST_CHECK(SequenceLocks(tx, flags, &prevheights, CreateBlockIndex(chainActive.Tip()->nHeight + 2))); // Sequence locks pass on 2nd block
+    FAST_CHECK(CheckFinalTx(tx, flags)); // Locktime passes
+    FAST_CHECK(!TestSequenceLocks(tx, flags)); // Sequence locks fail
+    FAST_CHECK(SequenceLocks(tx, flags, &prevheights, CreateBlockIndex(chainActive.Tip()->nHeight + 2))); // Sequence locks pass on 2nd block
 
     // relative time locked
     tx.vin[0].prevout.hash = txFirst[1]->GetHash();
@@ -426,12 +426,12 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     prevheights[0] = baseheight + 2;
     hash = tx.GetHash();
     mempool.addUnchecked(hash, entry.Time(GetTime()).FromTx(tx));
-    BOOST_CHECK(CheckFinalTx(tx, flags)); // Locktime passes
-    BOOST_CHECK(!TestSequenceLocks(tx, flags)); // Sequence locks fail
+    FAST_CHECK(CheckFinalTx(tx, flags)); // Locktime passes
+    FAST_CHECK(!TestSequenceLocks(tx, flags)); // Sequence locks fail
 
     for (int i = 0; i < CBlockIndex::nMedianTimeSpan; i++)
         chainActive.Tip()->GetAncestor(chainActive.Tip()->nHeight - i)->nTime += 512; //Trick the MedianTimePast
-    BOOST_CHECK(SequenceLocks(tx, flags, &prevheights, CreateBlockIndex(chainActive.Tip()->nHeight + 1))); // Sequence locks pass 512 seconds later
+    FAST_CHECK(SequenceLocks(tx, flags, &prevheights, CreateBlockIndex(chainActive.Tip()->nHeight + 1))); // Sequence locks pass 512 seconds later
     for (int i = 0; i < CBlockIndex::nMedianTimeSpan; i++)
         chainActive.Tip()->GetAncestor(chainActive.Tip()->nHeight - i)->nTime -= 512; //undo tricked MTP
 
@@ -442,9 +442,9 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     tx.nLockTime = chainActive.Tip()->nHeight + 1;
     hash = tx.GetHash();
     mempool.addUnchecked(hash, entry.Time(GetTime()).FromTx(tx));
-    BOOST_CHECK(!CheckFinalTx(tx, flags)); // Locktime fails
-    BOOST_CHECK(TestSequenceLocks(tx, flags)); // Sequence locks pass
-    BOOST_CHECK(IsFinalTx(tx, chainActive.Tip()->nHeight + 2, chainActive.Tip()->GetMedianTimePast())); // Locktime passes on 2nd block
+    FAST_CHECK(!CheckFinalTx(tx, flags)); // Locktime fails
+    FAST_CHECK(TestSequenceLocks(tx, flags)); // Sequence locks pass
+    FAST_CHECK(IsFinalTx(tx, chainActive.Tip()->nHeight + 2, chainActive.Tip()->GetMedianTimePast())); // Locktime passes on 2nd block
 
     // absolute time locked
     tx.vin[0].prevout.hash = txFirst[3]->GetHash();
@@ -453,31 +453,31 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     prevheights[0] = baseheight + 4;
     hash = tx.GetHash();
     mempool.addUnchecked(hash, entry.Time(GetTime()).FromTx(tx));
-    BOOST_CHECK(!CheckFinalTx(tx, flags)); // Locktime fails
-    BOOST_CHECK(TestSequenceLocks(tx, flags)); // Sequence locks pass
-    BOOST_CHECK(IsFinalTx(tx, chainActive.Tip()->nHeight + 2, chainActive.Tip()->GetMedianTimePast() + 1)); // Locktime passes 1 second later
+    FAST_CHECK(!CheckFinalTx(tx, flags)); // Locktime fails
+    FAST_CHECK(TestSequenceLocks(tx, flags)); // Sequence locks pass
+    FAST_CHECK(IsFinalTx(tx, chainActive.Tip()->nHeight + 2, chainActive.Tip()->GetMedianTimePast() + 1)); // Locktime passes 1 second later
 
     // mempool-dependent transactions (not added)
     tx.vin[0].prevout.hash = hash;
     prevheights[0] = chainActive.Tip()->nHeight + 1;
     tx.nLockTime = 0;
     tx.vin[0].nSequence = 0;
-    BOOST_CHECK(CheckFinalTx(tx, flags)); // Locktime passes
-    BOOST_CHECK(TestSequenceLocks(tx, flags)); // Sequence locks pass
+    FAST_CHECK(CheckFinalTx(tx, flags)); // Locktime passes
+    FAST_CHECK(TestSequenceLocks(tx, flags)); // Sequence locks pass
     tx.vin[0].nSequence = 1;
-    BOOST_CHECK(!TestSequenceLocks(tx, flags)); // Sequence locks fail
+    FAST_CHECK(!TestSequenceLocks(tx, flags)); // Sequence locks fail
     tx.vin[0].nSequence = CTxIn::SEQUENCE_LOCKTIME_TYPE_FLAG;
-    BOOST_CHECK(TestSequenceLocks(tx, flags)); // Sequence locks pass
+    FAST_CHECK(TestSequenceLocks(tx, flags)); // Sequence locks pass
     tx.vin[0].nSequence = CTxIn::SEQUENCE_LOCKTIME_TYPE_FLAG | 1;
-    BOOST_CHECK(!TestSequenceLocks(tx, flags)); // Sequence locks fail
+    FAST_CHECK(!TestSequenceLocks(tx, flags)); // Sequence locks fail
 
-    BOOST_CHECK(pblocktemplate = BlockAssembler(chainparams).CreateNewBlock(scriptPubKey));
+    FAST_CHECK(pblocktemplate = BlockAssembler(chainparams).CreateNewBlock(scriptPubKey));
 
     // None of the of the absolute height/time locked tx should have made
     // it into the template because we still check IsFinalTx in CreateNewBlock,
     // but relative locked txs will if inconsistently added to mempool.
     // For now these will still generate a valid template until BIP68 soft fork
-    BOOST_CHECK_EQUAL(pblocktemplate->block.vtx.size(), 3);
+    FAST_CHECK_EQUAL(pblocktemplate->block.vtx.size(), 3);
     delete pblocktemplate;
     // However if we advance height by 1 and time by 512, all of them should be mined
     for (int i = 0; i < CBlockIndex::nMedianTimeSpan; i++)
@@ -485,8 +485,8 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     chainActive.Tip()->nHeight++;
     SetMockTime(chainActive.Tip()->GetMedianTimePast() + 1);
 
-    BOOST_CHECK(pblocktemplate = BlockAssembler(chainparams).CreateNewBlock(scriptPubKey));
-    BOOST_CHECK_EQUAL(pblocktemplate->block.vtx.size(), 5);
+    FAST_CHECK(pblocktemplate = BlockAssembler(chainparams).CreateNewBlock(scriptPubKey));
+    FAST_CHECK_EQUAL(pblocktemplate->block.vtx.size(), 5);
     delete pblocktemplate;
 
     chainActive.Tip()->nHeight--;

--- a/src/test/multisig_tests.cpp
+++ b/src/test/multisig_tests.cpp
@@ -33,7 +33,7 @@ sign_multisig(CScript scriptPubKey, vector<CKey> keys, CTransaction transaction,
     BOOST_FOREACH(const CKey &key, keys)
     {
         vector<unsigned char> vchSig;
-        BOOST_CHECK(key.Sign(hash, vchSig));
+        FAST_CHECK(key.Sign(hash, vchSig));
         vchSig.push_back((unsigned char)SIGHASH_ALL);
         result << vchSig;
     }
@@ -82,7 +82,7 @@ BOOST_AUTO_TEST_CASE(multisig_verify)
     keys.assign(1,key[0]);
     keys.push_back(key[1]);
     s = sign_multisig(a_and_b, keys, txTo[0], 0);
-    BOOST_CHECK(VerifyScript(s, a_and_b, NULL, flags, MutableTransactionSignatureChecker(&txTo[0], 0, amount), &err));
+    FAST_CHECK(VerifyScript(s, a_and_b, NULL, flags, MutableTransactionSignatureChecker(&txTo[0], 0, amount), &err));
     BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_OK, ScriptErrorString(err));
 
     for (int i = 0; i < 4; i++)
@@ -117,7 +117,7 @@ BOOST_AUTO_TEST_CASE(multisig_verify)
     }
     s.clear();
     s << OP_0 << OP_1;
-    BOOST_CHECK(!VerifyScript(s, a_or_b, NULL, flags, MutableTransactionSignatureChecker(&txTo[1], 0, amount), &err));
+    FAST_CHECK(!VerifyScript(s, a_or_b, NULL, flags, MutableTransactionSignatureChecker(&txTo[1], 0, amount), &err));
     BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_SIG_DER, ScriptErrorString(err));
 
 
@@ -150,19 +150,19 @@ BOOST_AUTO_TEST_CASE(multisig_IsStandard)
 
     CScript a_and_b;
     a_and_b << OP_2 << ToByteVector(key[0].GetPubKey()) << ToByteVector(key[1].GetPubKey()) << OP_2 << OP_CHECKMULTISIG;
-    BOOST_CHECK(::IsStandard(a_and_b, whichType));
+    FAST_CHECK(::IsStandard(a_and_b, whichType));
 
     CScript a_or_b;
     a_or_b  << OP_1 << ToByteVector(key[0].GetPubKey()) << ToByteVector(key[1].GetPubKey()) << OP_2 << OP_CHECKMULTISIG;
-    BOOST_CHECK(::IsStandard(a_or_b, whichType));
+    FAST_CHECK(::IsStandard(a_or_b, whichType));
 
     CScript escrow;
     escrow << OP_2 << ToByteVector(key[0].GetPubKey()) << ToByteVector(key[1].GetPubKey()) << ToByteVector(key[2].GetPubKey()) << OP_3 << OP_CHECKMULTISIG;
-    BOOST_CHECK(::IsStandard(escrow, whichType));
+    FAST_CHECK(::IsStandard(escrow, whichType));
 
     CScript one_of_four;
     one_of_four << OP_1 << ToByteVector(key[0].GetPubKey()) << ToByteVector(key[1].GetPubKey()) << ToByteVector(key[2].GetPubKey()) << ToByteVector(key[3].GetPubKey()) << OP_4 << OP_CHECKMULTISIG;
-    BOOST_CHECK(!::IsStandard(one_of_four, whichType));
+    FAST_CHECK(!::IsStandard(one_of_four, whichType));
 
     CScript malformed[6];
     malformed[0] << OP_3 << ToByteVector(key[0].GetPubKey()) << ToByteVector(key[1].GetPubKey()) << OP_2 << OP_CHECKMULTISIG;
@@ -173,7 +173,7 @@ BOOST_AUTO_TEST_CASE(multisig_IsStandard)
     malformed[5] << OP_1 << ToByteVector(key[0].GetPubKey()) << ToByteVector(key[1].GetPubKey());
 
     for (int i = 0; i < 6; i++)
-        BOOST_CHECK(!::IsStandard(malformed[i], whichType));
+        FAST_CHECK(!::IsStandard(malformed[i], whichType));
 }
 
 BOOST_AUTO_TEST_CASE(multisig_Solver1)
@@ -204,64 +204,64 @@ BOOST_AUTO_TEST_CASE(multisig_Solver1)
         txnouttype whichType;
         CScript s;
         s << ToByteVector(key[0].GetPubKey()) << OP_CHECKSIG;
-        BOOST_CHECK(Solver(s, whichType, solutions));
-        BOOST_CHECK(solutions.size() == 1);
+        FAST_CHECK(Solver(s, whichType, solutions));
+        FAST_CHECK(solutions.size() == 1);
         CTxDestination addr;
-        BOOST_CHECK(ExtractDestination(s, addr));
-        BOOST_CHECK(addr == keyaddr[0]);
-        BOOST_CHECK(IsMine(keystore, s));
-        BOOST_CHECK(!IsMine(emptykeystore, s));
+        FAST_CHECK(ExtractDestination(s, addr));
+        FAST_CHECK(addr == keyaddr[0]);
+        FAST_CHECK(IsMine(keystore, s));
+        FAST_CHECK(!IsMine(emptykeystore, s));
     }
     {
         vector<valtype> solutions;
         txnouttype whichType;
         CScript s;
         s << OP_DUP << OP_HASH160 << ToByteVector(key[0].GetPubKey().GetID()) << OP_EQUALVERIFY << OP_CHECKSIG;
-        BOOST_CHECK(Solver(s, whichType, solutions));
-        BOOST_CHECK(solutions.size() == 1);
+        FAST_CHECK(Solver(s, whichType, solutions));
+        FAST_CHECK(solutions.size() == 1);
         CTxDestination addr;
-        BOOST_CHECK(ExtractDestination(s, addr));
-        BOOST_CHECK(addr == keyaddr[0]);
-        BOOST_CHECK(IsMine(keystore, s));
-        BOOST_CHECK(!IsMine(emptykeystore, s));
+        FAST_CHECK(ExtractDestination(s, addr));
+        FAST_CHECK(addr == keyaddr[0]);
+        FAST_CHECK(IsMine(keystore, s));
+        FAST_CHECK(!IsMine(emptykeystore, s));
     }
     {
         vector<valtype> solutions;
         txnouttype whichType;
         CScript s;
         s << OP_2 << ToByteVector(key[0].GetPubKey()) << ToByteVector(key[1].GetPubKey()) << OP_2 << OP_CHECKMULTISIG;
-        BOOST_CHECK(Solver(s, whichType, solutions));
-        BOOST_CHECK_EQUAL(solutions.size(), 4U);
+        FAST_CHECK(Solver(s, whichType, solutions));
+        FAST_CHECK_EQUAL(solutions.size(), 4U);
         CTxDestination addr;
-        BOOST_CHECK(!ExtractDestination(s, addr));
-        BOOST_CHECK(IsMine(keystore, s));
-        BOOST_CHECK(!IsMine(emptykeystore, s));
-        BOOST_CHECK(!IsMine(partialkeystore, s));
+        FAST_CHECK(!ExtractDestination(s, addr));
+        FAST_CHECK(IsMine(keystore, s));
+        FAST_CHECK(!IsMine(emptykeystore, s));
+        FAST_CHECK(!IsMine(partialkeystore, s));
     }
     {
         vector<valtype> solutions;
         txnouttype whichType;
         CScript s;
         s << OP_1 << ToByteVector(key[0].GetPubKey()) << ToByteVector(key[1].GetPubKey()) << OP_2 << OP_CHECKMULTISIG;
-        BOOST_CHECK(Solver(s, whichType, solutions));
-        BOOST_CHECK_EQUAL(solutions.size(), 4U);
+        FAST_CHECK(Solver(s, whichType, solutions));
+        FAST_CHECK_EQUAL(solutions.size(), 4U);
         vector<CTxDestination> addrs;
         int nRequired;
-        BOOST_CHECK(ExtractDestinations(s, whichType, addrs, nRequired));
-        BOOST_CHECK(addrs[0] == keyaddr[0]);
-        BOOST_CHECK(addrs[1] == keyaddr[1]);
-        BOOST_CHECK(nRequired == 1);
-        BOOST_CHECK(IsMine(keystore, s));
-        BOOST_CHECK(!IsMine(emptykeystore, s));
-        BOOST_CHECK(!IsMine(partialkeystore, s));
+        FAST_CHECK(ExtractDestinations(s, whichType, addrs, nRequired));
+        FAST_CHECK(addrs[0] == keyaddr[0]);
+        FAST_CHECK(addrs[1] == keyaddr[1]);
+        FAST_CHECK(nRequired == 1);
+        FAST_CHECK(IsMine(keystore, s));
+        FAST_CHECK(!IsMine(emptykeystore, s));
+        FAST_CHECK(!IsMine(partialkeystore, s));
     }
     {
         vector<valtype> solutions;
         txnouttype whichType;
         CScript s;
         s << OP_2 << ToByteVector(key[0].GetPubKey()) << ToByteVector(key[1].GetPubKey()) << ToByteVector(key[2].GetPubKey()) << OP_3 << OP_CHECKMULTISIG;
-        BOOST_CHECK(Solver(s, whichType, solutions));
-        BOOST_CHECK(solutions.size() == 5);
+        FAST_CHECK(Solver(s, whichType, solutions));
+        FAST_CHECK(solutions.size() == 5);
     }
 }
 

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -96,7 +96,7 @@ BOOST_AUTO_TEST_CASE(caddrdb_read)
     bool exceptionThrown = false;
     CAddrMan addrman1;
 
-    BOOST_CHECK(addrman1.size() == 0);
+    FAST_CHECK(addrman1.size() == 0);
     try {
         unsigned char pchMsgTmp[4];
         ssPeers1 >> FLATDATA(pchMsgTmp);
@@ -105,17 +105,17 @@ BOOST_AUTO_TEST_CASE(caddrdb_read)
         exceptionThrown = true;
     }
 
-    BOOST_CHECK(addrman1.size() == 3);
-    BOOST_CHECK(exceptionThrown == false);
+    FAST_CHECK(addrman1.size() == 3);
+    FAST_CHECK(exceptionThrown == false);
 
     // Test that CAddrDB::Read creates an addrman with the correct number of addrs.
     CDataStream ssPeers2 = AddrmanToStream(addrmanUncorrupted);
 
     CAddrMan addrman2;
     CAddrDB adb;
-    BOOST_CHECK(addrman2.size() == 0);
+    FAST_CHECK(addrman2.size() == 0);
     adb.Read(addrman2, ssPeers2);
-    BOOST_CHECK(addrman2.size() == 3);
+    FAST_CHECK(addrman2.size() == 3);
 }
 
 
@@ -128,7 +128,7 @@ BOOST_AUTO_TEST_CASE(caddrdb_read_corrupted)
     CDataStream ssPeers1 = AddrmanToStream(addrmanCorrupted);
     bool exceptionThrown = false;
     CAddrMan addrman1;
-    BOOST_CHECK(addrman1.size() == 0);
+    FAST_CHECK(addrman1.size() == 0);
     try {
         unsigned char pchMsgTmp[4];
         ssPeers1 >> FLATDATA(pchMsgTmp);
@@ -137,17 +137,17 @@ BOOST_AUTO_TEST_CASE(caddrdb_read_corrupted)
         exceptionThrown = true;
     }
     // Even through de-serialization failed addrman is not left in a clean state.
-    BOOST_CHECK(addrman1.size() == 1);
-    BOOST_CHECK(exceptionThrown);
+    FAST_CHECK(addrman1.size() == 1);
+    FAST_CHECK(exceptionThrown);
 
     // Test that CAddrDB::Read leaves addrman in a clean state if de-serialization fails.
     CDataStream ssPeers2 = AddrmanToStream(addrmanCorrupted);
 
     CAddrMan addrman2;
     CAddrDB adb;
-    BOOST_CHECK(addrman2.size() == 0);
+    FAST_CHECK(addrman2.size() == 0);
     adb.Read(addrman2, ssPeers2);
-    BOOST_CHECK(addrman2.size() == 0);
+    FAST_CHECK(addrman2.size() == 0);
 }
 
 BOOST_AUTO_TEST_CASE(cnode_simple_test)
@@ -163,13 +163,13 @@ BOOST_AUTO_TEST_CASE(cnode_simple_test)
 
     // Test that fFeeler is false by default.
     CNode* pnode1 = new CNode(hSocket, addr, pszDest, fInboundIn);
-    BOOST_CHECK(pnode1->fInbound == false);
-    BOOST_CHECK(pnode1->fFeeler == false);
+    FAST_CHECK(pnode1->fInbound == false);
+    FAST_CHECK(pnode1->fFeeler == false);
 
     fInboundIn = true;
     CNode* pnode2 = new CNode(hSocket, addr, pszDest, fInboundIn);
-    BOOST_CHECK(pnode2->fInbound == true);
-    BOOST_CHECK(pnode2->fFeeler == false);
+    FAST_CHECK(pnode2->fInbound == true);
+    FAST_CHECK(pnode2->fFeeler == false);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/netbase_tests.cpp
+++ b/src/test/netbase_tests.cpp
@@ -30,37 +30,37 @@ static CSubNet ResolveSubNet(const char* subnet)
 
 BOOST_AUTO_TEST_CASE(netbase_networks)
 {
-    BOOST_CHECK(ResolveIP("127.0.0.1").GetNetwork()                              == NET_UNROUTABLE);
-    BOOST_CHECK(ResolveIP("::1").GetNetwork()                                    == NET_UNROUTABLE);
-    BOOST_CHECK(ResolveIP("8.8.8.8").GetNetwork()                                == NET_IPV4);
-    BOOST_CHECK(ResolveIP("2001::8888").GetNetwork()                             == NET_IPV6);
-    BOOST_CHECK(ResolveIP("FD87:D87E:EB43:edb1:8e4:3588:e546:35ca").GetNetwork() == NET_TOR);
+    FAST_CHECK(ResolveIP("127.0.0.1").GetNetwork()                              == NET_UNROUTABLE);
+    FAST_CHECK(ResolveIP("::1").GetNetwork()                                    == NET_UNROUTABLE);
+    FAST_CHECK(ResolveIP("8.8.8.8").GetNetwork()                                == NET_IPV4);
+    FAST_CHECK(ResolveIP("2001::8888").GetNetwork()                             == NET_IPV6);
+    FAST_CHECK(ResolveIP("FD87:D87E:EB43:edb1:8e4:3588:e546:35ca").GetNetwork() == NET_TOR);
 
 }
 
 BOOST_AUTO_TEST_CASE(netbase_properties)
 {
 
-    BOOST_CHECK(ResolveIP("127.0.0.1").IsIPv4());
-    BOOST_CHECK(ResolveIP("::FFFF:192.168.1.1").IsIPv4());
-    BOOST_CHECK(ResolveIP("::1").IsIPv6());
-    BOOST_CHECK(ResolveIP("10.0.0.1").IsRFC1918());
-    BOOST_CHECK(ResolveIP("192.168.1.1").IsRFC1918());
-    BOOST_CHECK(ResolveIP("172.31.255.255").IsRFC1918());
-    BOOST_CHECK(ResolveIP("2001:0DB8::").IsRFC3849());
-    BOOST_CHECK(ResolveIP("169.254.1.1").IsRFC3927());
-    BOOST_CHECK(ResolveIP("2002::1").IsRFC3964());
-    BOOST_CHECK(ResolveIP("FC00::").IsRFC4193());
-    BOOST_CHECK(ResolveIP("2001::2").IsRFC4380());
-    BOOST_CHECK(ResolveIP("2001:10::").IsRFC4843());
-    BOOST_CHECK(ResolveIP("FE80::").IsRFC4862());
-    BOOST_CHECK(ResolveIP("64:FF9B::").IsRFC6052());
-    BOOST_CHECK(ResolveIP("FD87:D87E:EB43:edb1:8e4:3588:e546:35ca").IsTor());
-    BOOST_CHECK(ResolveIP("127.0.0.1").IsLocal());
-    BOOST_CHECK(ResolveIP("::1").IsLocal());
-    BOOST_CHECK(ResolveIP("8.8.8.8").IsRoutable());
-    BOOST_CHECK(ResolveIP("2001::1").IsRoutable());
-    BOOST_CHECK(ResolveIP("127.0.0.1").IsValid());
+    FAST_CHECK(ResolveIP("127.0.0.1").IsIPv4());
+    FAST_CHECK(ResolveIP("::FFFF:192.168.1.1").IsIPv4());
+    FAST_CHECK(ResolveIP("::1").IsIPv6());
+    FAST_CHECK(ResolveIP("10.0.0.1").IsRFC1918());
+    FAST_CHECK(ResolveIP("192.168.1.1").IsRFC1918());
+    FAST_CHECK(ResolveIP("172.31.255.255").IsRFC1918());
+    FAST_CHECK(ResolveIP("2001:0DB8::").IsRFC3849());
+    FAST_CHECK(ResolveIP("169.254.1.1").IsRFC3927());
+    FAST_CHECK(ResolveIP("2002::1").IsRFC3964());
+    FAST_CHECK(ResolveIP("FC00::").IsRFC4193());
+    FAST_CHECK(ResolveIP("2001::2").IsRFC4380());
+    FAST_CHECK(ResolveIP("2001:10::").IsRFC4843());
+    FAST_CHECK(ResolveIP("FE80::").IsRFC4862());
+    FAST_CHECK(ResolveIP("64:FF9B::").IsRFC6052());
+    FAST_CHECK(ResolveIP("FD87:D87E:EB43:edb1:8e4:3588:e546:35ca").IsTor());
+    FAST_CHECK(ResolveIP("127.0.0.1").IsLocal());
+    FAST_CHECK(ResolveIP("::1").IsLocal());
+    FAST_CHECK(ResolveIP("8.8.8.8").IsRoutable());
+    FAST_CHECK(ResolveIP("2001::1").IsRoutable());
+    FAST_CHECK(ResolveIP("127.0.0.1").IsValid());
 
 }
 
@@ -74,21 +74,21 @@ bool static TestSplitHost(string test, string host, int port)
 
 BOOST_AUTO_TEST_CASE(netbase_splithost)
 {
-    BOOST_CHECK(TestSplitHost("www.bitcoin.org", "www.bitcoin.org", -1));
-    BOOST_CHECK(TestSplitHost("[www.bitcoin.org]", "www.bitcoin.org", -1));
-    BOOST_CHECK(TestSplitHost("www.bitcoin.org:80", "www.bitcoin.org", 80));
-    BOOST_CHECK(TestSplitHost("[www.bitcoin.org]:80", "www.bitcoin.org", 80));
-    BOOST_CHECK(TestSplitHost("127.0.0.1", "127.0.0.1", -1));
-    BOOST_CHECK(TestSplitHost("127.0.0.1:8333", "127.0.0.1", 8333));
-    BOOST_CHECK(TestSplitHost("[127.0.0.1]", "127.0.0.1", -1));
-    BOOST_CHECK(TestSplitHost("[127.0.0.1]:8333", "127.0.0.1", 8333));
-    BOOST_CHECK(TestSplitHost("::ffff:127.0.0.1", "::ffff:127.0.0.1", -1));
-    BOOST_CHECK(TestSplitHost("[::ffff:127.0.0.1]:8333", "::ffff:127.0.0.1", 8333));
-    BOOST_CHECK(TestSplitHost("[::]:8333", "::", 8333));
-    BOOST_CHECK(TestSplitHost("::8333", "::8333", -1));
-    BOOST_CHECK(TestSplitHost(":8333", "", 8333));
-    BOOST_CHECK(TestSplitHost("[]:8333", "", 8333));
-    BOOST_CHECK(TestSplitHost("", "", -1));
+    FAST_CHECK(TestSplitHost("www.bitcoin.org", "www.bitcoin.org", -1));
+    FAST_CHECK(TestSplitHost("[www.bitcoin.org]", "www.bitcoin.org", -1));
+    FAST_CHECK(TestSplitHost("www.bitcoin.org:80", "www.bitcoin.org", 80));
+    FAST_CHECK(TestSplitHost("[www.bitcoin.org]:80", "www.bitcoin.org", 80));
+    FAST_CHECK(TestSplitHost("127.0.0.1", "127.0.0.1", -1));
+    FAST_CHECK(TestSplitHost("127.0.0.1:8333", "127.0.0.1", 8333));
+    FAST_CHECK(TestSplitHost("[127.0.0.1]", "127.0.0.1", -1));
+    FAST_CHECK(TestSplitHost("[127.0.0.1]:8333", "127.0.0.1", 8333));
+    FAST_CHECK(TestSplitHost("::ffff:127.0.0.1", "::ffff:127.0.0.1", -1));
+    FAST_CHECK(TestSplitHost("[::ffff:127.0.0.1]:8333", "::ffff:127.0.0.1", 8333));
+    FAST_CHECK(TestSplitHost("[::]:8333", "::", 8333));
+    FAST_CHECK(TestSplitHost("::8333", "::8333", -1));
+    FAST_CHECK(TestSplitHost(":8333", "", 8333));
+    FAST_CHECK(TestSplitHost("[]:8333", "", 8333));
+    FAST_CHECK(TestSplitHost("", "", -1));
 }
 
 bool static TestParse(string src, string canon)
@@ -99,13 +99,13 @@ bool static TestParse(string src, string canon)
 
 BOOST_AUTO_TEST_CASE(netbase_lookupnumeric)
 {
-    BOOST_CHECK(TestParse("127.0.0.1", "127.0.0.1:65535"));
-    BOOST_CHECK(TestParse("127.0.0.1:8333", "127.0.0.1:8333"));
-    BOOST_CHECK(TestParse("::ffff:127.0.0.1", "127.0.0.1:65535"));
-    BOOST_CHECK(TestParse("::", "[::]:65535"));
-    BOOST_CHECK(TestParse("[::]:8333", "[::]:8333"));
-    BOOST_CHECK(TestParse("[127.0.0.1]", "127.0.0.1:65535"));
-    BOOST_CHECK(TestParse(":::", "[::]:0"));
+    FAST_CHECK(TestParse("127.0.0.1", "127.0.0.1:65535"));
+    FAST_CHECK(TestParse("127.0.0.1:8333", "127.0.0.1:8333"));
+    FAST_CHECK(TestParse("::ffff:127.0.0.1", "127.0.0.1:65535"));
+    FAST_CHECK(TestParse("::", "[::]:65535"));
+    FAST_CHECK(TestParse("[::]:8333", "[::]:8333"));
+    FAST_CHECK(TestParse("[127.0.0.1]", "127.0.0.1:65535"));
+    FAST_CHECK(TestParse(":::", "[::]:0"));
 }
 
 BOOST_AUTO_TEST_CASE(onioncat_test)
@@ -114,175 +114,175 @@ BOOST_AUTO_TEST_CASE(onioncat_test)
     // values from https://web.archive.org/web/20121122003543/http://www.cypherpunk.at/onioncat/wiki/OnionCat
     CNetAddr addr1(ResolveIP("5wyqrzbvrdsumnok.onion"));
     CNetAddr addr2(ResolveIP("FD87:D87E:EB43:edb1:8e4:3588:e546:35ca"));
-    BOOST_CHECK(addr1 == addr2);
-    BOOST_CHECK(addr1.IsTor());
-    BOOST_CHECK(addr1.ToStringIP() == "5wyqrzbvrdsumnok.onion");
-    BOOST_CHECK(addr1.IsRoutable());
+    FAST_CHECK(addr1 == addr2);
+    FAST_CHECK(addr1.IsTor());
+    FAST_CHECK(addr1.ToStringIP() == "5wyqrzbvrdsumnok.onion");
+    FAST_CHECK(addr1.IsRoutable());
 
 }
 
 BOOST_AUTO_TEST_CASE(subnet_test)
 {
 
-    BOOST_CHECK(ResolveSubNet("1.2.3.0/24") == ResolveSubNet("1.2.3.0/255.255.255.0"));
-    BOOST_CHECK(ResolveSubNet("1.2.3.0/24") != ResolveSubNet("1.2.4.0/255.255.255.0"));
-    BOOST_CHECK(ResolveSubNet("1.2.3.0/24").Match(ResolveIP("1.2.3.4")));
-    BOOST_CHECK(!ResolveSubNet("1.2.2.0/24").Match(ResolveIP("1.2.3.4")));
-    BOOST_CHECK(ResolveSubNet("1.2.3.4").Match(ResolveIP("1.2.3.4")));
-    BOOST_CHECK(ResolveSubNet("1.2.3.4/32").Match(ResolveIP("1.2.3.4")));
-    BOOST_CHECK(!ResolveSubNet("1.2.3.4").Match(ResolveIP("5.6.7.8")));
-    BOOST_CHECK(!ResolveSubNet("1.2.3.4/32").Match(ResolveIP("5.6.7.8")));
-    BOOST_CHECK(ResolveSubNet("::ffff:127.0.0.1").Match(ResolveIP("127.0.0.1")));
-    BOOST_CHECK(ResolveSubNet("1:2:3:4:5:6:7:8").Match(ResolveIP("1:2:3:4:5:6:7:8")));
-    BOOST_CHECK(!ResolveSubNet("1:2:3:4:5:6:7:8").Match(ResolveIP("1:2:3:4:5:6:7:9")));
-    BOOST_CHECK(ResolveSubNet("1:2:3:4:5:6:7:0/112").Match(ResolveIP("1:2:3:4:5:6:7:1234")));
-    BOOST_CHECK(ResolveSubNet("192.168.0.1/24").Match(ResolveIP("192.168.0.2")));
-    BOOST_CHECK(ResolveSubNet("192.168.0.20/29").Match(ResolveIP("192.168.0.18")));
-    BOOST_CHECK(ResolveSubNet("1.2.2.1/24").Match(ResolveIP("1.2.2.4")));
-    BOOST_CHECK(ResolveSubNet("1.2.2.110/31").Match(ResolveIP("1.2.2.111")));
-    BOOST_CHECK(ResolveSubNet("1.2.2.20/26").Match(ResolveIP("1.2.2.63")));
+    FAST_CHECK(ResolveSubNet("1.2.3.0/24") == ResolveSubNet("1.2.3.0/255.255.255.0"));
+    FAST_CHECK(ResolveSubNet("1.2.3.0/24") != ResolveSubNet("1.2.4.0/255.255.255.0"));
+    FAST_CHECK(ResolveSubNet("1.2.3.0/24").Match(ResolveIP("1.2.3.4")));
+    FAST_CHECK(!ResolveSubNet("1.2.2.0/24").Match(ResolveIP("1.2.3.4")));
+    FAST_CHECK(ResolveSubNet("1.2.3.4").Match(ResolveIP("1.2.3.4")));
+    FAST_CHECK(ResolveSubNet("1.2.3.4/32").Match(ResolveIP("1.2.3.4")));
+    FAST_CHECK(!ResolveSubNet("1.2.3.4").Match(ResolveIP("5.6.7.8")));
+    FAST_CHECK(!ResolveSubNet("1.2.3.4/32").Match(ResolveIP("5.6.7.8")));
+    FAST_CHECK(ResolveSubNet("::ffff:127.0.0.1").Match(ResolveIP("127.0.0.1")));
+    FAST_CHECK(ResolveSubNet("1:2:3:4:5:6:7:8").Match(ResolveIP("1:2:3:4:5:6:7:8")));
+    FAST_CHECK(!ResolveSubNet("1:2:3:4:5:6:7:8").Match(ResolveIP("1:2:3:4:5:6:7:9")));
+    FAST_CHECK(ResolveSubNet("1:2:3:4:5:6:7:0/112").Match(ResolveIP("1:2:3:4:5:6:7:1234")));
+    FAST_CHECK(ResolveSubNet("192.168.0.1/24").Match(ResolveIP("192.168.0.2")));
+    FAST_CHECK(ResolveSubNet("192.168.0.20/29").Match(ResolveIP("192.168.0.18")));
+    FAST_CHECK(ResolveSubNet("1.2.2.1/24").Match(ResolveIP("1.2.2.4")));
+    FAST_CHECK(ResolveSubNet("1.2.2.110/31").Match(ResolveIP("1.2.2.111")));
+    FAST_CHECK(ResolveSubNet("1.2.2.20/26").Match(ResolveIP("1.2.2.63")));
     // All-Matching IPv6 Matches arbitrary IPv4 and IPv6
-    BOOST_CHECK(ResolveSubNet("::/0").Match(ResolveIP("1:2:3:4:5:6:7:1234")));
-    BOOST_CHECK(ResolveSubNet("::/0").Match(ResolveIP("1.2.3.4")));
+    FAST_CHECK(ResolveSubNet("::/0").Match(ResolveIP("1:2:3:4:5:6:7:1234")));
+    FAST_CHECK(ResolveSubNet("::/0").Match(ResolveIP("1.2.3.4")));
     // All-Matching IPv4 does not Match IPv6
-    BOOST_CHECK(!ResolveSubNet("0.0.0.0/0").Match(ResolveIP("1:2:3:4:5:6:7:1234")));
+    FAST_CHECK(!ResolveSubNet("0.0.0.0/0").Match(ResolveIP("1:2:3:4:5:6:7:1234")));
     // Invalid subnets Match nothing (not even invalid addresses)
-    BOOST_CHECK(!CSubNet().Match(ResolveIP("1.2.3.4")));
-    BOOST_CHECK(!ResolveSubNet("").Match(ResolveIP("4.5.6.7")));
-    BOOST_CHECK(!ResolveSubNet("bloop").Match(ResolveIP("0.0.0.0")));
-    BOOST_CHECK(!ResolveSubNet("bloop").Match(ResolveIP("hab")));
+    FAST_CHECK(!CSubNet().Match(ResolveIP("1.2.3.4")));
+    FAST_CHECK(!ResolveSubNet("").Match(ResolveIP("4.5.6.7")));
+    FAST_CHECK(!ResolveSubNet("bloop").Match(ResolveIP("0.0.0.0")));
+    FAST_CHECK(!ResolveSubNet("bloop").Match(ResolveIP("hab")));
     // Check valid/invalid
-    BOOST_CHECK(ResolveSubNet("1.2.3.0/0").IsValid());
-    BOOST_CHECK(!ResolveSubNet("1.2.3.0/-1").IsValid());
-    BOOST_CHECK(ResolveSubNet("1.2.3.0/32").IsValid());
-    BOOST_CHECK(!ResolveSubNet("1.2.3.0/33").IsValid());
-    BOOST_CHECK(ResolveSubNet("1:2:3:4:5:6:7:8/0").IsValid());
-    BOOST_CHECK(ResolveSubNet("1:2:3:4:5:6:7:8/33").IsValid());
-    BOOST_CHECK(!ResolveSubNet("1:2:3:4:5:6:7:8/-1").IsValid());
-    BOOST_CHECK(ResolveSubNet("1:2:3:4:5:6:7:8/128").IsValid());
-    BOOST_CHECK(!ResolveSubNet("1:2:3:4:5:6:7:8/129").IsValid());
-    BOOST_CHECK(!ResolveSubNet("fuzzy").IsValid());
+    FAST_CHECK(ResolveSubNet("1.2.3.0/0").IsValid());
+    FAST_CHECK(!ResolveSubNet("1.2.3.0/-1").IsValid());
+    FAST_CHECK(ResolveSubNet("1.2.3.0/32").IsValid());
+    FAST_CHECK(!ResolveSubNet("1.2.3.0/33").IsValid());
+    FAST_CHECK(ResolveSubNet("1:2:3:4:5:6:7:8/0").IsValid());
+    FAST_CHECK(ResolveSubNet("1:2:3:4:5:6:7:8/33").IsValid());
+    FAST_CHECK(!ResolveSubNet("1:2:3:4:5:6:7:8/-1").IsValid());
+    FAST_CHECK(ResolveSubNet("1:2:3:4:5:6:7:8/128").IsValid());
+    FAST_CHECK(!ResolveSubNet("1:2:3:4:5:6:7:8/129").IsValid());
+    FAST_CHECK(!ResolveSubNet("fuzzy").IsValid());
 
     //CNetAddr constructor test
-    BOOST_CHECK(CSubNet(ResolveIP("127.0.0.1")).IsValid());
-    BOOST_CHECK(CSubNet(ResolveIP("127.0.0.1")).Match(ResolveIP("127.0.0.1")));
-    BOOST_CHECK(!CSubNet(ResolveIP("127.0.0.1")).Match(ResolveIP("127.0.0.2")));
-    BOOST_CHECK(CSubNet(ResolveIP("127.0.0.1")).ToString() == "127.0.0.1/32");
+    FAST_CHECK(CSubNet(ResolveIP("127.0.0.1")).IsValid());
+    FAST_CHECK(CSubNet(ResolveIP("127.0.0.1")).Match(ResolveIP("127.0.0.1")));
+    FAST_CHECK(!CSubNet(ResolveIP("127.0.0.1")).Match(ResolveIP("127.0.0.2")));
+    FAST_CHECK(CSubNet(ResolveIP("127.0.0.1")).ToString() == "127.0.0.1/32");
 
     CSubNet subnet = CSubNet(ResolveIP("1.2.3.4"), 32);
-    BOOST_CHECK_EQUAL(subnet.ToString(), "1.2.3.4/32");
+    FAST_CHECK_EQUAL(subnet.ToString(), "1.2.3.4/32");
     subnet = CSubNet(ResolveIP("1.2.3.4"), 8);
-    BOOST_CHECK_EQUAL(subnet.ToString(), "1.0.0.0/8");
+    FAST_CHECK_EQUAL(subnet.ToString(), "1.0.0.0/8");
     subnet = CSubNet(ResolveIP("1.2.3.4"), 0);
-    BOOST_CHECK_EQUAL(subnet.ToString(), "0.0.0.0/0");
+    FAST_CHECK_EQUAL(subnet.ToString(), "0.0.0.0/0");
 
     subnet = CSubNet(ResolveIP("1.2.3.4"), ResolveIP("255.255.255.255"));
-    BOOST_CHECK_EQUAL(subnet.ToString(), "1.2.3.4/32");
+    FAST_CHECK_EQUAL(subnet.ToString(), "1.2.3.4/32");
     subnet = CSubNet(ResolveIP("1.2.3.4"), ResolveIP("255.0.0.0"));
-    BOOST_CHECK_EQUAL(subnet.ToString(), "1.0.0.0/8");
+    FAST_CHECK_EQUAL(subnet.ToString(), "1.0.0.0/8");
     subnet = CSubNet(ResolveIP("1.2.3.4"), ResolveIP("0.0.0.0"));
-    BOOST_CHECK_EQUAL(subnet.ToString(), "0.0.0.0/0");
+    FAST_CHECK_EQUAL(subnet.ToString(), "0.0.0.0/0");
 
-    BOOST_CHECK(CSubNet(ResolveIP("1:2:3:4:5:6:7:8")).IsValid());
-    BOOST_CHECK(CSubNet(ResolveIP("1:2:3:4:5:6:7:8")).Match(ResolveIP("1:2:3:4:5:6:7:8")));
-    BOOST_CHECK(!CSubNet(ResolveIP("1:2:3:4:5:6:7:8")).Match(ResolveIP("1:2:3:4:5:6:7:9")));
-    BOOST_CHECK(CSubNet(ResolveIP("1:2:3:4:5:6:7:8")).ToString() == "1:2:3:4:5:6:7:8/128");
+    FAST_CHECK(CSubNet(ResolveIP("1:2:3:4:5:6:7:8")).IsValid());
+    FAST_CHECK(CSubNet(ResolveIP("1:2:3:4:5:6:7:8")).Match(ResolveIP("1:2:3:4:5:6:7:8")));
+    FAST_CHECK(!CSubNet(ResolveIP("1:2:3:4:5:6:7:8")).Match(ResolveIP("1:2:3:4:5:6:7:9")));
+    FAST_CHECK(CSubNet(ResolveIP("1:2:3:4:5:6:7:8")).ToString() == "1:2:3:4:5:6:7:8/128");
 
     subnet = ResolveSubNet("1.2.3.4/255.255.255.255");
-    BOOST_CHECK_EQUAL(subnet.ToString(), "1.2.3.4/32");
+    FAST_CHECK_EQUAL(subnet.ToString(), "1.2.3.4/32");
     subnet = ResolveSubNet("1.2.3.4/255.255.255.254");
-    BOOST_CHECK_EQUAL(subnet.ToString(), "1.2.3.4/31");
+    FAST_CHECK_EQUAL(subnet.ToString(), "1.2.3.4/31");
     subnet = ResolveSubNet("1.2.3.4/255.255.255.252");
-    BOOST_CHECK_EQUAL(subnet.ToString(), "1.2.3.4/30");
+    FAST_CHECK_EQUAL(subnet.ToString(), "1.2.3.4/30");
     subnet = ResolveSubNet("1.2.3.4/255.255.255.248");
-    BOOST_CHECK_EQUAL(subnet.ToString(), "1.2.3.0/29");
+    FAST_CHECK_EQUAL(subnet.ToString(), "1.2.3.0/29");
     subnet = ResolveSubNet("1.2.3.4/255.255.255.240");
-    BOOST_CHECK_EQUAL(subnet.ToString(), "1.2.3.0/28");
+    FAST_CHECK_EQUAL(subnet.ToString(), "1.2.3.0/28");
     subnet = ResolveSubNet("1.2.3.4/255.255.255.224");
-    BOOST_CHECK_EQUAL(subnet.ToString(), "1.2.3.0/27");
+    FAST_CHECK_EQUAL(subnet.ToString(), "1.2.3.0/27");
     subnet = ResolveSubNet("1.2.3.4/255.255.255.192");
-    BOOST_CHECK_EQUAL(subnet.ToString(), "1.2.3.0/26");
+    FAST_CHECK_EQUAL(subnet.ToString(), "1.2.3.0/26");
     subnet = ResolveSubNet("1.2.3.4/255.255.255.128");
-    BOOST_CHECK_EQUAL(subnet.ToString(), "1.2.3.0/25");
+    FAST_CHECK_EQUAL(subnet.ToString(), "1.2.3.0/25");
     subnet = ResolveSubNet("1.2.3.4/255.255.255.0");
-    BOOST_CHECK_EQUAL(subnet.ToString(), "1.2.3.0/24");
+    FAST_CHECK_EQUAL(subnet.ToString(), "1.2.3.0/24");
     subnet = ResolveSubNet("1.2.3.4/255.255.254.0");
-    BOOST_CHECK_EQUAL(subnet.ToString(), "1.2.2.0/23");
+    FAST_CHECK_EQUAL(subnet.ToString(), "1.2.2.0/23");
     subnet = ResolveSubNet("1.2.3.4/255.255.252.0");
-    BOOST_CHECK_EQUAL(subnet.ToString(), "1.2.0.0/22");
+    FAST_CHECK_EQUAL(subnet.ToString(), "1.2.0.0/22");
     subnet = ResolveSubNet("1.2.3.4/255.255.248.0");
-    BOOST_CHECK_EQUAL(subnet.ToString(), "1.2.0.0/21");
+    FAST_CHECK_EQUAL(subnet.ToString(), "1.2.0.0/21");
     subnet = ResolveSubNet("1.2.3.4/255.255.240.0");
-    BOOST_CHECK_EQUAL(subnet.ToString(), "1.2.0.0/20");
+    FAST_CHECK_EQUAL(subnet.ToString(), "1.2.0.0/20");
     subnet = ResolveSubNet("1.2.3.4/255.255.224.0");
-    BOOST_CHECK_EQUAL(subnet.ToString(), "1.2.0.0/19");
+    FAST_CHECK_EQUAL(subnet.ToString(), "1.2.0.0/19");
     subnet = ResolveSubNet("1.2.3.4/255.255.192.0");
-    BOOST_CHECK_EQUAL(subnet.ToString(), "1.2.0.0/18");
+    FAST_CHECK_EQUAL(subnet.ToString(), "1.2.0.0/18");
     subnet = ResolveSubNet("1.2.3.4/255.255.128.0");
-    BOOST_CHECK_EQUAL(subnet.ToString(), "1.2.0.0/17");
+    FAST_CHECK_EQUAL(subnet.ToString(), "1.2.0.0/17");
     subnet = ResolveSubNet("1.2.3.4/255.255.0.0");
-    BOOST_CHECK_EQUAL(subnet.ToString(), "1.2.0.0/16");
+    FAST_CHECK_EQUAL(subnet.ToString(), "1.2.0.0/16");
     subnet = ResolveSubNet("1.2.3.4/255.254.0.0");
-    BOOST_CHECK_EQUAL(subnet.ToString(), "1.2.0.0/15");
+    FAST_CHECK_EQUAL(subnet.ToString(), "1.2.0.0/15");
     subnet = ResolveSubNet("1.2.3.4/255.252.0.0");
-    BOOST_CHECK_EQUAL(subnet.ToString(), "1.0.0.0/14");
+    FAST_CHECK_EQUAL(subnet.ToString(), "1.0.0.0/14");
     subnet = ResolveSubNet("1.2.3.4/255.248.0.0");
-    BOOST_CHECK_EQUAL(subnet.ToString(), "1.0.0.0/13");
+    FAST_CHECK_EQUAL(subnet.ToString(), "1.0.0.0/13");
     subnet = ResolveSubNet("1.2.3.4/255.240.0.0");
-    BOOST_CHECK_EQUAL(subnet.ToString(), "1.0.0.0/12");
+    FAST_CHECK_EQUAL(subnet.ToString(), "1.0.0.0/12");
     subnet = ResolveSubNet("1.2.3.4/255.224.0.0");
-    BOOST_CHECK_EQUAL(subnet.ToString(), "1.0.0.0/11");
+    FAST_CHECK_EQUAL(subnet.ToString(), "1.0.0.0/11");
     subnet = ResolveSubNet("1.2.3.4/255.192.0.0");
-    BOOST_CHECK_EQUAL(subnet.ToString(), "1.0.0.0/10");
+    FAST_CHECK_EQUAL(subnet.ToString(), "1.0.0.0/10");
     subnet = ResolveSubNet("1.2.3.4/255.128.0.0");
-    BOOST_CHECK_EQUAL(subnet.ToString(), "1.0.0.0/9");
+    FAST_CHECK_EQUAL(subnet.ToString(), "1.0.0.0/9");
     subnet = ResolveSubNet("1.2.3.4/255.0.0.0");
-    BOOST_CHECK_EQUAL(subnet.ToString(), "1.0.0.0/8");
+    FAST_CHECK_EQUAL(subnet.ToString(), "1.0.0.0/8");
     subnet = ResolveSubNet("1.2.3.4/254.0.0.0");
-    BOOST_CHECK_EQUAL(subnet.ToString(), "0.0.0.0/7");
+    FAST_CHECK_EQUAL(subnet.ToString(), "0.0.0.0/7");
     subnet = ResolveSubNet("1.2.3.4/252.0.0.0");
-    BOOST_CHECK_EQUAL(subnet.ToString(), "0.0.0.0/6");
+    FAST_CHECK_EQUAL(subnet.ToString(), "0.0.0.0/6");
     subnet = ResolveSubNet("1.2.3.4/248.0.0.0");
-    BOOST_CHECK_EQUAL(subnet.ToString(), "0.0.0.0/5");
+    FAST_CHECK_EQUAL(subnet.ToString(), "0.0.0.0/5");
     subnet = ResolveSubNet("1.2.3.4/240.0.0.0");
-    BOOST_CHECK_EQUAL(subnet.ToString(), "0.0.0.0/4");
+    FAST_CHECK_EQUAL(subnet.ToString(), "0.0.0.0/4");
     subnet = ResolveSubNet("1.2.3.4/224.0.0.0");
-    BOOST_CHECK_EQUAL(subnet.ToString(), "0.0.0.0/3");
+    FAST_CHECK_EQUAL(subnet.ToString(), "0.0.0.0/3");
     subnet = ResolveSubNet("1.2.3.4/192.0.0.0");
-    BOOST_CHECK_EQUAL(subnet.ToString(), "0.0.0.0/2");
+    FAST_CHECK_EQUAL(subnet.ToString(), "0.0.0.0/2");
     subnet = ResolveSubNet("1.2.3.4/128.0.0.0");
-    BOOST_CHECK_EQUAL(subnet.ToString(), "0.0.0.0/1");
+    FAST_CHECK_EQUAL(subnet.ToString(), "0.0.0.0/1");
     subnet = ResolveSubNet("1.2.3.4/0.0.0.0");
-    BOOST_CHECK_EQUAL(subnet.ToString(), "0.0.0.0/0");
+    FAST_CHECK_EQUAL(subnet.ToString(), "0.0.0.0/0");
 
     subnet = ResolveSubNet("1:2:3:4:5:6:7:8/ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff");
-    BOOST_CHECK_EQUAL(subnet.ToString(), "1:2:3:4:5:6:7:8/128");
+    FAST_CHECK_EQUAL(subnet.ToString(), "1:2:3:4:5:6:7:8/128");
     subnet = ResolveSubNet("1:2:3:4:5:6:7:8/ffff:0000:0000:0000:0000:0000:0000:0000");
-    BOOST_CHECK_EQUAL(subnet.ToString(), "1::/16");
+    FAST_CHECK_EQUAL(subnet.ToString(), "1::/16");
     subnet = ResolveSubNet("1:2:3:4:5:6:7:8/0000:0000:0000:0000:0000:0000:0000:0000");
-    BOOST_CHECK_EQUAL(subnet.ToString(), "::/0");
+    FAST_CHECK_EQUAL(subnet.ToString(), "::/0");
     subnet = ResolveSubNet("1.2.3.4/255.255.232.0");
-    BOOST_CHECK_EQUAL(subnet.ToString(), "1.2.0.0/255.255.232.0");
+    FAST_CHECK_EQUAL(subnet.ToString(), "1.2.0.0/255.255.232.0");
     subnet = ResolveSubNet("1:2:3:4:5:6:7:8/ffff:ffff:ffff:fffe:ffff:ffff:ffff:ff0f");
-    BOOST_CHECK_EQUAL(subnet.ToString(), "1:2:3:4:5:6:7:8/ffff:ffff:ffff:fffe:ffff:ffff:ffff:ff0f");
+    FAST_CHECK_EQUAL(subnet.ToString(), "1:2:3:4:5:6:7:8/ffff:ffff:ffff:fffe:ffff:ffff:ffff:ff0f");
 
 }
 
 BOOST_AUTO_TEST_CASE(netbase_getgroup)
 {
 
-    BOOST_CHECK(ResolveIP("127.0.0.1").GetGroup() == boost::assign::list_of(0)); // Local -> !Routable()
-    BOOST_CHECK(ResolveIP("257.0.0.1").GetGroup() == boost::assign::list_of(0)); // !Valid -> !Routable()
-    BOOST_CHECK(ResolveIP("10.0.0.1").GetGroup() == boost::assign::list_of(0)); // RFC1918 -> !Routable()
-    BOOST_CHECK(ResolveIP("169.254.1.1").GetGroup() == boost::assign::list_of(0)); // RFC3927 -> !Routable()
-    BOOST_CHECK(ResolveIP("1.2.3.4").GetGroup() == boost::assign::list_of((unsigned char)NET_IPV4)(1)(2)); // IPv4
-    BOOST_CHECK(ResolveIP("::FFFF:0:102:304").GetGroup() == boost::assign::list_of((unsigned char)NET_IPV4)(1)(2)); // RFC6145
-    BOOST_CHECK(ResolveIP("64:FF9B::102:304").GetGroup() == boost::assign::list_of((unsigned char)NET_IPV4)(1)(2)); // RFC6052
-    BOOST_CHECK(ResolveIP("2002:102:304:9999:9999:9999:9999:9999").GetGroup() == boost::assign::list_of((unsigned char)NET_IPV4)(1)(2)); // RFC3964
-    BOOST_CHECK(ResolveIP("2001:0:9999:9999:9999:9999:FEFD:FCFB").GetGroup() == boost::assign::list_of((unsigned char)NET_IPV4)(1)(2)); // RFC4380
-    BOOST_CHECK(ResolveIP("FD87:D87E:EB43:edb1:8e4:3588:e546:35ca").GetGroup() == boost::assign::list_of((unsigned char)NET_TOR)(239)); // Tor
-    BOOST_CHECK(ResolveIP("2001:470:abcd:9999:9999:9999:9999:9999").GetGroup() == boost::assign::list_of((unsigned char)NET_IPV6)(32)(1)(4)(112)(175)); //he.net
-    BOOST_CHECK(ResolveIP("2001:2001:9999:9999:9999:9999:9999:9999").GetGroup() == boost::assign::list_of((unsigned char)NET_IPV6)(32)(1)(32)(1)); //IPv6
+    FAST_CHECK(ResolveIP("127.0.0.1").GetGroup() == boost::assign::list_of(0)); // Local -> !Routable()
+    FAST_CHECK(ResolveIP("257.0.0.1").GetGroup() == boost::assign::list_of(0)); // !Valid -> !Routable()
+    FAST_CHECK(ResolveIP("10.0.0.1").GetGroup() == boost::assign::list_of(0)); // RFC1918 -> !Routable()
+    FAST_CHECK(ResolveIP("169.254.1.1").GetGroup() == boost::assign::list_of(0)); // RFC3927 -> !Routable()
+    FAST_CHECK(ResolveIP("1.2.3.4").GetGroup() == boost::assign::list_of((unsigned char)NET_IPV4)(1)(2)); // IPv4
+    FAST_CHECK(ResolveIP("::FFFF:0:102:304").GetGroup() == boost::assign::list_of((unsigned char)NET_IPV4)(1)(2)); // RFC6145
+    FAST_CHECK(ResolveIP("64:FF9B::102:304").GetGroup() == boost::assign::list_of((unsigned char)NET_IPV4)(1)(2)); // RFC6052
+    FAST_CHECK(ResolveIP("2002:102:304:9999:9999:9999:9999:9999").GetGroup() == boost::assign::list_of((unsigned char)NET_IPV4)(1)(2)); // RFC3964
+    FAST_CHECK(ResolveIP("2001:0:9999:9999:9999:9999:FEFD:FCFB").GetGroup() == boost::assign::list_of((unsigned char)NET_IPV4)(1)(2)); // RFC4380
+    FAST_CHECK(ResolveIP("FD87:D87E:EB43:edb1:8e4:3588:e546:35ca").GetGroup() == boost::assign::list_of((unsigned char)NET_TOR)(239)); // Tor
+    FAST_CHECK(ResolveIP("2001:470:abcd:9999:9999:9999:9999:9999").GetGroup() == boost::assign::list_of((unsigned char)NET_IPV6)(32)(1)(4)(112)(175)); //he.net
+    FAST_CHECK(ResolveIP("2001:2001:9999:9999:9999:9999:9999:9999").GetGroup() == boost::assign::list_of((unsigned char)NET_IPV6)(32)(1)(32)(1)); //IPv6
 
 }
 

--- a/src/test/pmt_tests.cpp
+++ b/src/test/pmt_tests.cpp
@@ -80,7 +80,7 @@ BOOST_AUTO_TEST_CASE(pmt_test1)
 
             // verify CPartialMerkleTree's size guarantees
             unsigned int n = std::min<unsigned int>(nTx, 1 + vMatchTxid1.size()*nHeight);
-            BOOST_CHECK(ss.size() <= 10 + (258*n+7)/8);
+            FAST_CHECK(ss.size() <= 10 + (258*n+7)/8);
 
             // deserialize into a tester copy
             CPartialMerkleTreeTester pmt2;
@@ -92,11 +92,11 @@ BOOST_AUTO_TEST_CASE(pmt_test1)
             uint256 merkleRoot2 = pmt2.ExtractMatches(vMatchTxid2, vIndex);
 
             // check that it has the same merkle root as the original, and a valid one
-            BOOST_CHECK(merkleRoot1 == merkleRoot2);
-            BOOST_CHECK(!merkleRoot2.IsNull());
+            FAST_CHECK(merkleRoot1 == merkleRoot2);
+            FAST_CHECK(!merkleRoot2.IsNull());
 
             // check that it contains the matched transactions (in the same order!)
-            BOOST_CHECK(vMatchTxid1 == vMatchTxid2);
+            FAST_CHECK(vMatchTxid1 == vMatchTxid2);
 
             // check that random bit flips break the authentication
             for (int j=0; j<4; j++) {
@@ -104,7 +104,7 @@ BOOST_AUTO_TEST_CASE(pmt_test1)
                 pmt3.Damage();
                 std::vector<uint256> vMatchTxid3;
                 uint256 merkleRoot3 = pmt3.ExtractMatches(vMatchTxid3, vIndex);
-                BOOST_CHECK(merkleRoot3 != merkleRoot1);
+                FAST_CHECK(merkleRoot3 != merkleRoot1);
             }
         }
     }
@@ -123,7 +123,7 @@ BOOST_AUTO_TEST_CASE(pmt_malleability)
 
     CPartialMerkleTree tree(vTxid, vMatch);
     std::vector<unsigned int> vIndex;
-    BOOST_CHECK(tree.ExtractMatches(vTxid, vIndex).IsNull());
+    FAST_CHECK(tree.ExtractMatches(vTxid, vIndex).IsNull());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/policyestimator_tests.cpp
+++ b/src/test/policyestimator_tests.cpp
@@ -87,16 +87,16 @@ BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
             // At this point we should need to combine 5 buckets to get enough data points
             // So estimateFee(1,2,3) should fail and estimateFee(4) should return somewhere around
             // 8*baserate.  estimateFee(4) %'s are 100,100,100,100,90 = average 98%
-            BOOST_CHECK(mpool.estimateFee(1) == CFeeRate(0));
-            BOOST_CHECK(mpool.estimateFee(2) == CFeeRate(0));
-            BOOST_CHECK(mpool.estimateFee(3) == CFeeRate(0));
-            BOOST_CHECK(mpool.estimateFee(4).GetFeePerK() < 8*baseRate.GetFeePerK() + deltaFee);
-            BOOST_CHECK(mpool.estimateFee(4).GetFeePerK() > 8*baseRate.GetFeePerK() - deltaFee);
+            FAST_CHECK(mpool.estimateFee(1) == CFeeRate(0));
+            FAST_CHECK(mpool.estimateFee(2) == CFeeRate(0));
+            FAST_CHECK(mpool.estimateFee(3) == CFeeRate(0));
+            FAST_CHECK(mpool.estimateFee(4).GetFeePerK() < 8*baseRate.GetFeePerK() + deltaFee);
+            FAST_CHECK(mpool.estimateFee(4).GetFeePerK() > 8*baseRate.GetFeePerK() - deltaFee);
             int answerFound;
-            BOOST_CHECK(mpool.estimateSmartFee(1, &answerFound) == mpool.estimateFee(4) && answerFound == 4);
-            BOOST_CHECK(mpool.estimateSmartFee(3, &answerFound) == mpool.estimateFee(4) && answerFound == 4);
-            BOOST_CHECK(mpool.estimateSmartFee(4, &answerFound) == mpool.estimateFee(4) && answerFound == 4);
-            BOOST_CHECK(mpool.estimateSmartFee(8, &answerFound) == mpool.estimateFee(8) && answerFound == 8);
+            FAST_CHECK(mpool.estimateSmartFee(1, &answerFound) == mpool.estimateFee(4) && answerFound == 4);
+            FAST_CHECK(mpool.estimateSmartFee(3, &answerFound) == mpool.estimateFee(4) && answerFound == 4);
+            FAST_CHECK(mpool.estimateSmartFee(4, &answerFound) == mpool.estimateFee(4) && answerFound == 4);
+            FAST_CHECK(mpool.estimateSmartFee(8, &answerFound) == mpool.estimateFee(8) && answerFound == 8);
         }
     }
 
@@ -112,14 +112,14 @@ BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
         origFeeEst.push_back(mpool.estimateFee(i).GetFeePerK());
         origPriEst.push_back(mpool.estimatePriority(i));
         if (i > 1) { // Fee estimates should be monotonically decreasing
-            BOOST_CHECK(origFeeEst[i-1] <= origFeeEst[i-2]);
-            BOOST_CHECK(origPriEst[i-1] <= origPriEst[i-2]);
+            FAST_CHECK(origFeeEst[i-1] <= origFeeEst[i-2]);
+            FAST_CHECK(origPriEst[i-1] <= origPriEst[i-2]);
         }
         int mult = 11-i;
-        BOOST_CHECK(origFeeEst[i-1] < mult*baseRate.GetFeePerK() + deltaFee);
-        BOOST_CHECK(origFeeEst[i-1] > mult*baseRate.GetFeePerK() - deltaFee);
-        BOOST_CHECK(origPriEst[i-1] < pow(10,mult) * basepri + deltaPri);
-        BOOST_CHECK(origPriEst[i-1] > pow(10,mult) * basepri - deltaPri);
+        FAST_CHECK(origFeeEst[i-1] < mult*baseRate.GetFeePerK() + deltaFee);
+        FAST_CHECK(origFeeEst[i-1] > mult*baseRate.GetFeePerK() - deltaFee);
+        FAST_CHECK(origPriEst[i-1] < pow(10,mult) * basepri + deltaPri);
+        FAST_CHECK(origPriEst[i-1] > pow(10,mult) * basepri - deltaPri);
     }
 
     // Mine 50 more blocks with no transactions happening, estimates shouldn't change
@@ -128,10 +128,10 @@ BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
         mpool.removeForBlock(block, ++blocknum, dummyConflicted);
 
     for (int i = 1; i < 10;i++) {
-        BOOST_CHECK(mpool.estimateFee(i).GetFeePerK() < origFeeEst[i-1] + deltaFee);
-        BOOST_CHECK(mpool.estimateFee(i).GetFeePerK() > origFeeEst[i-1] - deltaFee);
-        BOOST_CHECK(mpool.estimatePriority(i) < origPriEst[i-1] + deltaPri);
-        BOOST_CHECK(mpool.estimatePriority(i) > origPriEst[i-1] - deltaPri);
+        FAST_CHECK(mpool.estimateFee(i).GetFeePerK() < origFeeEst[i-1] + deltaFee);
+        FAST_CHECK(mpool.estimateFee(i).GetFeePerK() > origFeeEst[i-1] - deltaFee);
+        FAST_CHECK(mpool.estimatePriority(i) < origPriEst[i-1] + deltaPri);
+        FAST_CHECK(mpool.estimatePriority(i) > origPriEst[i-1] - deltaPri);
     }
 
 
@@ -151,10 +151,10 @@ BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
 
     int answerFound;
     for (int i = 1; i < 10;i++) {
-        BOOST_CHECK(mpool.estimateFee(i) == CFeeRate(0) || mpool.estimateFee(i).GetFeePerK() > origFeeEst[i-1] - deltaFee);
-        BOOST_CHECK(mpool.estimateSmartFee(i, &answerFound).GetFeePerK() > origFeeEst[answerFound-1] - deltaFee);
-        BOOST_CHECK(mpool.estimatePriority(i) == -1 || mpool.estimatePriority(i) > origPriEst[i-1] - deltaPri);
-        BOOST_CHECK(mpool.estimateSmartPriority(i, &answerFound) > origPriEst[answerFound-1] - deltaPri);
+        FAST_CHECK(mpool.estimateFee(i) == CFeeRate(0) || mpool.estimateFee(i).GetFeePerK() > origFeeEst[i-1] - deltaFee);
+        FAST_CHECK(mpool.estimateSmartFee(i, &answerFound).GetFeePerK() > origFeeEst[answerFound-1] - deltaFee);
+        FAST_CHECK(mpool.estimatePriority(i) == -1 || mpool.estimatePriority(i) > origPriEst[i-1] - deltaPri);
+        FAST_CHECK(mpool.estimateSmartPriority(i, &answerFound) > origPriEst[answerFound-1] - deltaPri);
     }
 
     // Mine all those transactions
@@ -170,8 +170,8 @@ BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
     mpool.removeForBlock(block, 265, dummyConflicted);
     block.clear();
     for (int i = 1; i < 10;i++) {
-        BOOST_CHECK(mpool.estimateFee(i).GetFeePerK() > origFeeEst[i-1] - deltaFee);
-        BOOST_CHECK(mpool.estimatePriority(i) > origPriEst[i-1] - deltaPri);
+        FAST_CHECK(mpool.estimateFee(i).GetFeePerK() > origFeeEst[i-1] - deltaFee);
+        FAST_CHECK(mpool.estimatePriority(i) > origPriEst[i-1] - deltaPri);
     }
 
     // Mine 200 more blocks where everything is mined every block
@@ -191,8 +191,8 @@ BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
         block.clear();
     }
     for (int i = 1; i < 10; i++) {
-        BOOST_CHECK(mpool.estimateFee(i).GetFeePerK() < origFeeEst[i-1] - deltaFee);
-        BOOST_CHECK(mpool.estimatePriority(i) < origPriEst[i-1] - deltaPri);
+        FAST_CHECK(mpool.estimateFee(i).GetFeePerK() < origFeeEst[i-1] - deltaFee);
+        FAST_CHECK(mpool.estimatePriority(i) < origPriEst[i-1] - deltaPri);
     }
 
     // Test that if the mempool is limited, estimateSmartFee won't return a value below the mempool min fee
@@ -200,11 +200,11 @@ BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
     mpool.addUnchecked(tx.GetHash(),  entry.Fee(feeV[0][5]).Time(GetTime()).Priority(priV[1][5]).Height(blocknum).FromTx(tx, &mpool));
     // evict that transaction which should set a mempool min fee of minRelayTxFee + feeV[0][5]
     mpool.TrimToSize(1);
-    BOOST_CHECK(mpool.GetMinFee(1).GetFeePerK() > feeV[0][5]);
+    FAST_CHECK(mpool.GetMinFee(1).GetFeePerK() > feeV[0][5]);
     for (int i = 1; i < 10; i++) {
-        BOOST_CHECK(mpool.estimateSmartFee(i).GetFeePerK() >= mpool.estimateFee(i).GetFeePerK());
-        BOOST_CHECK(mpool.estimateSmartFee(i).GetFeePerK() >= mpool.GetMinFee(1).GetFeePerK());
-        BOOST_CHECK(mpool.estimateSmartPriority(i) == INF_PRIORITY);
+        FAST_CHECK(mpool.estimateSmartFee(i).GetFeePerK() >= mpool.estimateFee(i).GetFeePerK());
+        FAST_CHECK(mpool.estimateSmartFee(i).GetFeePerK() >= mpool.GetMinFee(1).GetFeePerK());
+        FAST_CHECK(mpool.estimateSmartPriority(i) == INF_PRIORITY);
     }
 }
 

--- a/src/test/pow_tests.cpp
+++ b/src/test/pow_tests.cpp
@@ -26,7 +26,7 @@ BOOST_AUTO_TEST_CASE(get_next_work)
     pindexLast.nHeight = 32255;
     pindexLast.nTime = 1262152739;  // Block #32255
     pindexLast.nBits = 0x1d00ffff;
-    BOOST_CHECK_EQUAL(CalculateNextWorkRequired(&pindexLast, nLastRetargetTime, params), 0x1d00d86a);
+    FAST_CHECK_EQUAL(CalculateNextWorkRequired(&pindexLast, nLastRetargetTime, params), 0x1d00d86a);
 }
 
 /* Test the constraint on the upper bound for next work */
@@ -40,7 +40,7 @@ BOOST_AUTO_TEST_CASE(get_next_work_pow_limit)
     pindexLast.nHeight = 2015;
     pindexLast.nTime = 1233061996;  // Block #2015
     pindexLast.nBits = 0x1d00ffff;
-    BOOST_CHECK_EQUAL(CalculateNextWorkRequired(&pindexLast, nLastRetargetTime, params), 0x1d00ffff);
+    FAST_CHECK_EQUAL(CalculateNextWorkRequired(&pindexLast, nLastRetargetTime, params), 0x1d00ffff);
 }
 
 /* Test the constraint on the lower bound for actual time taken */
@@ -54,7 +54,7 @@ BOOST_AUTO_TEST_CASE(get_next_work_lower_limit_actual)
     pindexLast.nHeight = 68543;
     pindexLast.nTime = 1279297671;  // Block #68543
     pindexLast.nBits = 0x1c05a3f4;
-    BOOST_CHECK_EQUAL(CalculateNextWorkRequired(&pindexLast, nLastRetargetTime, params), 0x1c0168fd);
+    FAST_CHECK_EQUAL(CalculateNextWorkRequired(&pindexLast, nLastRetargetTime, params), 0x1c0168fd);
 }
 
 /* Test the constraint on the upper bound for actual time taken */
@@ -68,7 +68,7 @@ BOOST_AUTO_TEST_CASE(get_next_work_upper_limit_actual)
     pindexLast.nHeight = 46367;
     pindexLast.nTime = 1269211443;  // Block #46367
     pindexLast.nBits = 0x1c387f6f;
-    BOOST_CHECK_EQUAL(CalculateNextWorkRequired(&pindexLast, nLastRetargetTime, params), 0x1d00e1fd);
+    FAST_CHECK_EQUAL(CalculateNextWorkRequired(&pindexLast, nLastRetargetTime, params), 0x1d00e1fd);
 }
 
 BOOST_AUTO_TEST_CASE(GetBlockProofEquivalentTime_test)
@@ -91,7 +91,7 @@ BOOST_AUTO_TEST_CASE(GetBlockProofEquivalentTime_test)
         CBlockIndex *p3 = &blocks[GetRand(10000)];
 
         int64_t tdiff = GetBlockProofEquivalentTime(*p1, *p2, *p3, params);
-        BOOST_CHECK_EQUAL(tdiff, p1->GetBlockTime() - p2->GetBlockTime());
+        FAST_CHECK_EQUAL(tdiff, p1->GetBlockTime() - p2->GetBlockTime());
     }
 }
 

--- a/src/test/prevector_tests.cpp
+++ b/src/test/prevector_tests.cpp
@@ -29,54 +29,54 @@ class prevector_tester {
 
     void test() {
         const pretype& const_pre_vector = pre_vector;
-        BOOST_CHECK_EQUAL(real_vector.size(), pre_vector.size());
-        BOOST_CHECK_EQUAL(real_vector.empty(), pre_vector.empty());
+        FAST_CHECK_EQUAL(real_vector.size(), pre_vector.size());
+        FAST_CHECK_EQUAL(real_vector.empty(), pre_vector.empty());
         for (Size s = 0; s < real_vector.size(); s++) {
-             BOOST_CHECK(real_vector[s] == pre_vector[s]);
-             BOOST_CHECK(&(pre_vector[s]) == &(pre_vector.begin()[s]));
-             BOOST_CHECK(&(pre_vector[s]) == &*(pre_vector.begin() + s));
-             BOOST_CHECK(&(pre_vector[s]) == &*((pre_vector.end() + s) - real_vector.size()));
+             FAST_CHECK(real_vector[s] == pre_vector[s]);
+             FAST_CHECK(&(pre_vector[s]) == &(pre_vector.begin()[s]));
+             FAST_CHECK(&(pre_vector[s]) == &*(pre_vector.begin() + s));
+             FAST_CHECK(&(pre_vector[s]) == &*((pre_vector.end() + s) - real_vector.size()));
         }
-        // BOOST_CHECK(realtype(pre_vector) == real_vector);
-        BOOST_CHECK(pretype(real_vector.begin(), real_vector.end()) == pre_vector);
-        BOOST_CHECK(pretype(pre_vector.begin(), pre_vector.end()) == pre_vector);
+        // FAST_CHECK(realtype(pre_vector) == real_vector);
+        FAST_CHECK(pretype(real_vector.begin(), real_vector.end()) == pre_vector);
+        FAST_CHECK(pretype(pre_vector.begin(), pre_vector.end()) == pre_vector);
         size_t pos = 0;
         BOOST_FOREACH(const T& v, pre_vector) {
-             BOOST_CHECK(v == real_vector[pos++]);
+             FAST_CHECK(v == real_vector[pos++]);
         }
         BOOST_REVERSE_FOREACH(const T& v, pre_vector) {
-             BOOST_CHECK(v == real_vector[--pos]);
+             FAST_CHECK(v == real_vector[--pos]);
         }
         BOOST_FOREACH(const T& v, const_pre_vector) {
-             BOOST_CHECK(v == real_vector[pos++]);
+             FAST_CHECK(v == real_vector[pos++]);
         }
         BOOST_REVERSE_FOREACH(const T& v, const_pre_vector) {
-             BOOST_CHECK(v == real_vector[--pos]);
+             FAST_CHECK(v == real_vector[--pos]);
         }
         CDataStream ss1(SER_DISK, 0);
         CDataStream ss2(SER_DISK, 0);
         ss1 << real_vector;
         ss2 << pre_vector;
-        BOOST_CHECK_EQUAL(ss1.size(), ss2.size());
+        FAST_CHECK_EQUAL(ss1.size(), ss2.size());
         for (Size s = 0; s < ss1.size(); s++) {
-            BOOST_CHECK_EQUAL(ss1[s], ss2[s]);
+            FAST_CHECK_EQUAL(ss1[s], ss2[s]);
         }
     }
 
 public:
     void resize(Size s) {
         real_vector.resize(s);
-        BOOST_CHECK_EQUAL(real_vector.size(), s);
+        FAST_CHECK_EQUAL(real_vector.size(), s);
         pre_vector.resize(s);
-        BOOST_CHECK_EQUAL(pre_vector.size(), s);
+        FAST_CHECK_EQUAL(pre_vector.size(), s);
         test();
     }
 
     void reserve(Size s) {
         real_vector.reserve(s);
-        BOOST_CHECK(real_vector.capacity() >= s);
+        FAST_CHECK(real_vector.capacity() >= s);
         pre_vector.reserve(s);
-        BOOST_CHECK(pre_vector.capacity() >= s);
+        FAST_CHECK(pre_vector.capacity() >= s);
         test();
     }
 

--- a/src/test/reverselock_tests.cpp
+++ b/src/test/reverselock_tests.cpp
@@ -14,12 +14,12 @@ BOOST_AUTO_TEST_CASE(reverselock_basics)
     boost::mutex mutex;
     boost::unique_lock<boost::mutex> lock(mutex);
 
-    BOOST_CHECK(lock.owns_lock());
+    FAST_CHECK(lock.owns_lock());
     {
         reverse_lock<boost::unique_lock<boost::mutex> > rlock(lock);
-        BOOST_CHECK(!lock.owns_lock());
+        FAST_CHECK(!lock.owns_lock());
     }
-    BOOST_CHECK(lock.owns_lock());
+    FAST_CHECK(lock.owns_lock());
 }
 
 BOOST_AUTO_TEST_CASE(reverselock_errors)
@@ -30,7 +30,7 @@ BOOST_AUTO_TEST_CASE(reverselock_errors)
     // Make sure trying to reverse lock an unlocked lock fails
     lock.unlock();
 
-    BOOST_CHECK(!lock.owns_lock());
+    FAST_CHECK(!lock.owns_lock());
 
     bool failed = false;
     try {
@@ -39,22 +39,22 @@ BOOST_AUTO_TEST_CASE(reverselock_errors)
         failed = true;
     }
 
-    BOOST_CHECK(failed);
-    BOOST_CHECK(!lock.owns_lock());
+    FAST_CHECK(failed);
+    FAST_CHECK(!lock.owns_lock());
 
     // Locking the original lock after it has been taken by a reverse lock
     // makes no sense. Ensure that the original lock no longer owns the lock
     // after giving it to a reverse one.
 
     lock.lock();
-    BOOST_CHECK(lock.owns_lock());
+    FAST_CHECK(lock.owns_lock());
     {
         reverse_lock<boost::unique_lock<boost::mutex> > rlock(lock);
-        BOOST_CHECK(!lock.owns_lock());
+        FAST_CHECK(!lock.owns_lock());
     }
 
-    BOOST_CHECK(failed);
-    BOOST_CHECK(lock.owns_lock());
+    FAST_CHECK(failed);
+    FAST_CHECK(lock.owns_lock());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -25,7 +25,7 @@ UniValue CallRPC(string args)
     string strMethod = vArgs[0];
     vArgs.erase(vArgs.begin());
     UniValue params = RPCConvertValues(strMethod, vArgs);
-    BOOST_CHECK(tableRPC[strMethod]);
+    FAST_CHECK(tableRPC[strMethod]);
     rpcfn_type method = tableRPC[strMethod]->actor;
     try {
         UniValue result = (*method)(params, false);
@@ -44,41 +44,41 @@ BOOST_AUTO_TEST_CASE(rpc_rawparams)
     // Test raw transaction API argument handling
     UniValue r;
 
-    BOOST_CHECK_THROW(CallRPC("getrawtransaction"), runtime_error);
-    BOOST_CHECK_THROW(CallRPC("getrawtransaction not_hex"), runtime_error);
-    BOOST_CHECK_THROW(CallRPC("getrawtransaction a3b807410df0b60fcb9736768df5823938b2f838694939ba45f3c0a1bff150ed not_int"), runtime_error);
+    FAST_CHECK_THROW(CallRPC("getrawtransaction"), runtime_error);
+    FAST_CHECK_THROW(CallRPC("getrawtransaction not_hex"), runtime_error);
+    FAST_CHECK_THROW(CallRPC("getrawtransaction a3b807410df0b60fcb9736768df5823938b2f838694939ba45f3c0a1bff150ed not_int"), runtime_error);
 
-    BOOST_CHECK_THROW(CallRPC("createrawtransaction"), runtime_error);
-    BOOST_CHECK_THROW(CallRPC("createrawtransaction null null"), runtime_error);
-    BOOST_CHECK_THROW(CallRPC("createrawtransaction not_array"), runtime_error);
-    BOOST_CHECK_THROW(CallRPC("createrawtransaction [] []"), runtime_error);
-    BOOST_CHECK_THROW(CallRPC("createrawtransaction {} {}"), runtime_error);
-    BOOST_CHECK_NO_THROW(CallRPC("createrawtransaction [] {}"));
-    BOOST_CHECK_THROW(CallRPC("createrawtransaction [] {} extra"), runtime_error);
+    FAST_CHECK_THROW(CallRPC("createrawtransaction"), runtime_error);
+    FAST_CHECK_THROW(CallRPC("createrawtransaction null null"), runtime_error);
+    FAST_CHECK_THROW(CallRPC("createrawtransaction not_array"), runtime_error);
+    FAST_CHECK_THROW(CallRPC("createrawtransaction [] []"), runtime_error);
+    FAST_CHECK_THROW(CallRPC("createrawtransaction {} {}"), runtime_error);
+    FAST_CHECK_NO_THROW(CallRPC("createrawtransaction [] {}"));
+    FAST_CHECK_THROW(CallRPC("createrawtransaction [] {} extra"), runtime_error);
 
-    BOOST_CHECK_THROW(CallRPC("decoderawtransaction"), runtime_error);
-    BOOST_CHECK_THROW(CallRPC("decoderawtransaction null"), runtime_error);
-    BOOST_CHECK_THROW(CallRPC("decoderawtransaction DEADBEEF"), runtime_error);
+    FAST_CHECK_THROW(CallRPC("decoderawtransaction"), runtime_error);
+    FAST_CHECK_THROW(CallRPC("decoderawtransaction null"), runtime_error);
+    FAST_CHECK_THROW(CallRPC("decoderawtransaction DEADBEEF"), runtime_error);
     string rawtx = "0100000001a15d57094aa7a21a28cb20b59aab8fc7d1149a3bdbcddba9c622e4f5f6a99ece010000006c493046022100f93bb0e7d8db7bd46e40132d1f8242026e045f03a0efe71bbb8e3f475e970d790221009337cd7f1f929f00cc6ff01f03729b069a7c21b59b1736ddfee5db5946c5da8c0121033b9b137ee87d5a812d6f506efdd37f0affa7ffc310711c06c7f3e097c9447c52ffffffff0100e1f505000000001976a9140389035a9225b3839e2bbf32d826a1e222031fd888ac00000000";
-    BOOST_CHECK_NO_THROW(r = CallRPC(string("decoderawtransaction ")+rawtx));
-    BOOST_CHECK_EQUAL(find_value(r.get_obj(), "size").get_int(), 193);
-    BOOST_CHECK_EQUAL(find_value(r.get_obj(), "version").get_int(), 1);
-    BOOST_CHECK_EQUAL(find_value(r.get_obj(), "locktime").get_int(), 0);
-    BOOST_CHECK_THROW(r = CallRPC(string("decoderawtransaction ")+rawtx+" extra"), runtime_error);
+    FAST_CHECK_NO_THROW(r = CallRPC(string("decoderawtransaction ")+rawtx));
+    FAST_CHECK_EQUAL(find_value(r.get_obj(), "size").get_int(), 193);
+    FAST_CHECK_EQUAL(find_value(r.get_obj(), "version").get_int(), 1);
+    FAST_CHECK_EQUAL(find_value(r.get_obj(), "locktime").get_int(), 0);
+    FAST_CHECK_THROW(r = CallRPC(string("decoderawtransaction ")+rawtx+" extra"), runtime_error);
 
-    BOOST_CHECK_THROW(CallRPC("signrawtransaction"), runtime_error);
-    BOOST_CHECK_THROW(CallRPC("signrawtransaction null"), runtime_error);
-    BOOST_CHECK_THROW(CallRPC("signrawtransaction ff00"), runtime_error);
-    BOOST_CHECK_NO_THROW(CallRPC(string("signrawtransaction ")+rawtx));
-    BOOST_CHECK_NO_THROW(CallRPC(string("signrawtransaction ")+rawtx+" null null NONE|ANYONECANPAY"));
-    BOOST_CHECK_NO_THROW(CallRPC(string("signrawtransaction ")+rawtx+" [] [] NONE|ANYONECANPAY"));
-    BOOST_CHECK_THROW(CallRPC(string("signrawtransaction ")+rawtx+" null null badenum"), runtime_error);
+    FAST_CHECK_THROW(CallRPC("signrawtransaction"), runtime_error);
+    FAST_CHECK_THROW(CallRPC("signrawtransaction null"), runtime_error);
+    FAST_CHECK_THROW(CallRPC("signrawtransaction ff00"), runtime_error);
+    FAST_CHECK_NO_THROW(CallRPC(string("signrawtransaction ")+rawtx));
+    FAST_CHECK_NO_THROW(CallRPC(string("signrawtransaction ")+rawtx+" null null NONE|ANYONECANPAY"));
+    FAST_CHECK_NO_THROW(CallRPC(string("signrawtransaction ")+rawtx+" [] [] NONE|ANYONECANPAY"));
+    FAST_CHECK_THROW(CallRPC(string("signrawtransaction ")+rawtx+" null null badenum"), runtime_error);
 
     // Only check failure cases for sendrawtransaction, there's no network to send to...
-    BOOST_CHECK_THROW(CallRPC("sendrawtransaction"), runtime_error);
-    BOOST_CHECK_THROW(CallRPC("sendrawtransaction null"), runtime_error);
-    BOOST_CHECK_THROW(CallRPC("sendrawtransaction DEADBEEF"), runtime_error);
-    BOOST_CHECK_THROW(CallRPC(string("sendrawtransaction ")+rawtx+" extra"), runtime_error);
+    FAST_CHECK_THROW(CallRPC("sendrawtransaction"), runtime_error);
+    FAST_CHECK_THROW(CallRPC("sendrawtransaction null"), runtime_error);
+    FAST_CHECK_THROW(CallRPC("sendrawtransaction DEADBEEF"), runtime_error);
+    FAST_CHECK_THROW(CallRPC(string("sendrawtransaction ")+rawtx+" extra"), runtime_error);
 }
 
 BOOST_AUTO_TEST_CASE(rpc_rawsign)
@@ -95,229 +95,229 @@ BOOST_AUTO_TEST_CASE(rpc_rawsign)
     string privkey1 = "\"KzsXybp9jX64P5ekX1KUxRQ79Jht9uzW7LorgwE65i5rWACL6LQe\"";
     string privkey2 = "\"Kyhdf5LuKTRx4ge69ybABsiUAWjVRK4XGxAKk2FQLp2HjGMy87Z4\"";
     r = CallRPC(string("signrawtransaction ")+notsigned+" "+prevout+" "+"[]");
-    BOOST_CHECK(find_value(r.get_obj(), "complete").get_bool() == false);
+    FAST_CHECK(find_value(r.get_obj(), "complete").get_bool() == false);
     r = CallRPC(string("signrawtransaction ")+notsigned+" "+prevout+" "+"["+privkey1+","+privkey2+"]");
-    BOOST_CHECK(find_value(r.get_obj(), "complete").get_bool() == true);
+    FAST_CHECK(find_value(r.get_obj(), "complete").get_bool() == true);
 }
 
 BOOST_AUTO_TEST_CASE(rpc_createraw_op_return)
 {
-    BOOST_CHECK_NO_THROW(CallRPC("createrawtransaction [{\"txid\":\"a3b807410df0b60fcb9736768df5823938b2f838694939ba45f3c0a1bff150ed\",\"vout\":0}] {\"data\":\"68656c6c6f776f726c64\"}"));
+    FAST_CHECK_NO_THROW(CallRPC("createrawtransaction [{\"txid\":\"a3b807410df0b60fcb9736768df5823938b2f838694939ba45f3c0a1bff150ed\",\"vout\":0}] {\"data\":\"68656c6c6f776f726c64\"}"));
 
     // Allow more than one data transaction output
-    BOOST_CHECK_NO_THROW(CallRPC("createrawtransaction [{\"txid\":\"a3b807410df0b60fcb9736768df5823938b2f838694939ba45f3c0a1bff150ed\",\"vout\":0}] {\"data\":\"68656c6c6f776f726c64\",\"data\":\"68656c6c6f776f726c64\"}"));
+    FAST_CHECK_NO_THROW(CallRPC("createrawtransaction [{\"txid\":\"a3b807410df0b60fcb9736768df5823938b2f838694939ba45f3c0a1bff150ed\",\"vout\":0}] {\"data\":\"68656c6c6f776f726c64\",\"data\":\"68656c6c6f776f726c64\"}"));
 
     // Key not "data" (bad address)
-    BOOST_CHECK_THROW(CallRPC("createrawtransaction [{\"txid\":\"a3b807410df0b60fcb9736768df5823938b2f838694939ba45f3c0a1bff150ed\",\"vout\":0}] {\"somedata\":\"68656c6c6f776f726c64\"}"), runtime_error);
+    FAST_CHECK_THROW(CallRPC("createrawtransaction [{\"txid\":\"a3b807410df0b60fcb9736768df5823938b2f838694939ba45f3c0a1bff150ed\",\"vout\":0}] {\"somedata\":\"68656c6c6f776f726c64\"}"), runtime_error);
 
     // Bad hex encoding of data output
-    BOOST_CHECK_THROW(CallRPC("createrawtransaction [{\"txid\":\"a3b807410df0b60fcb9736768df5823938b2f838694939ba45f3c0a1bff150ed\",\"vout\":0}] {\"data\":\"12345\"}"), runtime_error);
-    BOOST_CHECK_THROW(CallRPC("createrawtransaction [{\"txid\":\"a3b807410df0b60fcb9736768df5823938b2f838694939ba45f3c0a1bff150ed\",\"vout\":0}] {\"data\":\"12345g\"}"), runtime_error);
+    FAST_CHECK_THROW(CallRPC("createrawtransaction [{\"txid\":\"a3b807410df0b60fcb9736768df5823938b2f838694939ba45f3c0a1bff150ed\",\"vout\":0}] {\"data\":\"12345\"}"), runtime_error);
+    FAST_CHECK_THROW(CallRPC("createrawtransaction [{\"txid\":\"a3b807410df0b60fcb9736768df5823938b2f838694939ba45f3c0a1bff150ed\",\"vout\":0}] {\"data\":\"12345g\"}"), runtime_error);
 
     // Data 81 bytes long
-    BOOST_CHECK_NO_THROW(CallRPC("createrawtransaction [{\"txid\":\"a3b807410df0b60fcb9736768df5823938b2f838694939ba45f3c0a1bff150ed\",\"vout\":0}] {\"data\":\"010203040506070809101112131415161718192021222324252627282930313233343536373839404142434445464748495051525354555657585960616263646566676869707172737475767778798081\"}"));
+    FAST_CHECK_NO_THROW(CallRPC("createrawtransaction [{\"txid\":\"a3b807410df0b60fcb9736768df5823938b2f838694939ba45f3c0a1bff150ed\",\"vout\":0}] {\"data\":\"010203040506070809101112131415161718192021222324252627282930313233343536373839404142434445464748495051525354555657585960616263646566676869707172737475767778798081\"}"));
 }
 
 BOOST_AUTO_TEST_CASE(rpc_format_monetary_values)
 {
-    BOOST_CHECK(ValueFromAmount(0LL).write() == "0.00000000");
-    BOOST_CHECK(ValueFromAmount(1LL).write() == "0.00000001");
-    BOOST_CHECK(ValueFromAmount(17622195LL).write() == "0.17622195");
-    BOOST_CHECK(ValueFromAmount(50000000LL).write() == "0.50000000");
-    BOOST_CHECK(ValueFromAmount(89898989LL).write() == "0.89898989");
-    BOOST_CHECK(ValueFromAmount(100000000LL).write() == "1.00000000");
-    BOOST_CHECK(ValueFromAmount(2099999999999990LL).write() == "20999999.99999990");
-    BOOST_CHECK(ValueFromAmount(2099999999999999LL).write() == "20999999.99999999");
+    FAST_CHECK(ValueFromAmount(0LL).write() == "0.00000000");
+    FAST_CHECK(ValueFromAmount(1LL).write() == "0.00000001");
+    FAST_CHECK(ValueFromAmount(17622195LL).write() == "0.17622195");
+    FAST_CHECK(ValueFromAmount(50000000LL).write() == "0.50000000");
+    FAST_CHECK(ValueFromAmount(89898989LL).write() == "0.89898989");
+    FAST_CHECK(ValueFromAmount(100000000LL).write() == "1.00000000");
+    FAST_CHECK(ValueFromAmount(2099999999999990LL).write() == "20999999.99999990");
+    FAST_CHECK(ValueFromAmount(2099999999999999LL).write() == "20999999.99999999");
 
-    BOOST_CHECK_EQUAL(ValueFromAmount(0).write(), "0.00000000");
-    BOOST_CHECK_EQUAL(ValueFromAmount((COIN/10000)*123456789).write(), "12345.67890000");
-    BOOST_CHECK_EQUAL(ValueFromAmount(-COIN).write(), "-1.00000000");
-    BOOST_CHECK_EQUAL(ValueFromAmount(-COIN/10).write(), "-0.10000000");
+    FAST_CHECK_EQUAL(ValueFromAmount(0).write(), "0.00000000");
+    FAST_CHECK_EQUAL(ValueFromAmount((COIN/10000)*123456789).write(), "12345.67890000");
+    FAST_CHECK_EQUAL(ValueFromAmount(-COIN).write(), "-1.00000000");
+    FAST_CHECK_EQUAL(ValueFromAmount(-COIN/10).write(), "-0.10000000");
 
-    BOOST_CHECK_EQUAL(ValueFromAmount(COIN*100000000).write(), "100000000.00000000");
-    BOOST_CHECK_EQUAL(ValueFromAmount(COIN*10000000).write(), "10000000.00000000");
-    BOOST_CHECK_EQUAL(ValueFromAmount(COIN*1000000).write(), "1000000.00000000");
-    BOOST_CHECK_EQUAL(ValueFromAmount(COIN*100000).write(), "100000.00000000");
-    BOOST_CHECK_EQUAL(ValueFromAmount(COIN*10000).write(), "10000.00000000");
-    BOOST_CHECK_EQUAL(ValueFromAmount(COIN*1000).write(), "1000.00000000");
-    BOOST_CHECK_EQUAL(ValueFromAmount(COIN*100).write(), "100.00000000");
-    BOOST_CHECK_EQUAL(ValueFromAmount(COIN*10).write(), "10.00000000");
-    BOOST_CHECK_EQUAL(ValueFromAmount(COIN).write(), "1.00000000");
-    BOOST_CHECK_EQUAL(ValueFromAmount(COIN/10).write(), "0.10000000");
-    BOOST_CHECK_EQUAL(ValueFromAmount(COIN/100).write(), "0.01000000");
-    BOOST_CHECK_EQUAL(ValueFromAmount(COIN/1000).write(), "0.00100000");
-    BOOST_CHECK_EQUAL(ValueFromAmount(COIN/10000).write(), "0.00010000");
-    BOOST_CHECK_EQUAL(ValueFromAmount(COIN/100000).write(), "0.00001000");
-    BOOST_CHECK_EQUAL(ValueFromAmount(COIN/1000000).write(), "0.00000100");
-    BOOST_CHECK_EQUAL(ValueFromAmount(COIN/10000000).write(), "0.00000010");
-    BOOST_CHECK_EQUAL(ValueFromAmount(COIN/100000000).write(), "0.00000001");
+    FAST_CHECK_EQUAL(ValueFromAmount(COIN*100000000).write(), "100000000.00000000");
+    FAST_CHECK_EQUAL(ValueFromAmount(COIN*10000000).write(), "10000000.00000000");
+    FAST_CHECK_EQUAL(ValueFromAmount(COIN*1000000).write(), "1000000.00000000");
+    FAST_CHECK_EQUAL(ValueFromAmount(COIN*100000).write(), "100000.00000000");
+    FAST_CHECK_EQUAL(ValueFromAmount(COIN*10000).write(), "10000.00000000");
+    FAST_CHECK_EQUAL(ValueFromAmount(COIN*1000).write(), "1000.00000000");
+    FAST_CHECK_EQUAL(ValueFromAmount(COIN*100).write(), "100.00000000");
+    FAST_CHECK_EQUAL(ValueFromAmount(COIN*10).write(), "10.00000000");
+    FAST_CHECK_EQUAL(ValueFromAmount(COIN).write(), "1.00000000");
+    FAST_CHECK_EQUAL(ValueFromAmount(COIN/10).write(), "0.10000000");
+    FAST_CHECK_EQUAL(ValueFromAmount(COIN/100).write(), "0.01000000");
+    FAST_CHECK_EQUAL(ValueFromAmount(COIN/1000).write(), "0.00100000");
+    FAST_CHECK_EQUAL(ValueFromAmount(COIN/10000).write(), "0.00010000");
+    FAST_CHECK_EQUAL(ValueFromAmount(COIN/100000).write(), "0.00001000");
+    FAST_CHECK_EQUAL(ValueFromAmount(COIN/1000000).write(), "0.00000100");
+    FAST_CHECK_EQUAL(ValueFromAmount(COIN/10000000).write(), "0.00000010");
+    FAST_CHECK_EQUAL(ValueFromAmount(COIN/100000000).write(), "0.00000001");
 }
 
 static UniValue ValueFromString(const std::string &str)
 {
     UniValue value;
-    BOOST_CHECK(value.setNumStr(str));
+    FAST_CHECK(value.setNumStr(str));
     return value;
 }
 
 BOOST_AUTO_TEST_CASE(rpc_parse_monetary_values)
 {
-    BOOST_CHECK_THROW(AmountFromValue(ValueFromString("-0.00000001")), UniValue);
-    BOOST_CHECK_EQUAL(AmountFromValue(ValueFromString("0")), 0LL);
-    BOOST_CHECK_EQUAL(AmountFromValue(ValueFromString("0.00000000")), 0LL);
-    BOOST_CHECK_EQUAL(AmountFromValue(ValueFromString("0.00000001")), 1LL);
-    BOOST_CHECK_EQUAL(AmountFromValue(ValueFromString("0.17622195")), 17622195LL);
-    BOOST_CHECK_EQUAL(AmountFromValue(ValueFromString("0.5")), 50000000LL);
-    BOOST_CHECK_EQUAL(AmountFromValue(ValueFromString("0.50000000")), 50000000LL);
-    BOOST_CHECK_EQUAL(AmountFromValue(ValueFromString("0.89898989")), 89898989LL);
-    BOOST_CHECK_EQUAL(AmountFromValue(ValueFromString("1.00000000")), 100000000LL);
-    BOOST_CHECK_EQUAL(AmountFromValue(ValueFromString("20999999.9999999")), 2099999999999990LL);
-    BOOST_CHECK_EQUAL(AmountFromValue(ValueFromString("20999999.99999999")), 2099999999999999LL);
+    FAST_CHECK_THROW(AmountFromValue(ValueFromString("-0.00000001")), UniValue);
+    FAST_CHECK_EQUAL(AmountFromValue(ValueFromString("0")), 0LL);
+    FAST_CHECK_EQUAL(AmountFromValue(ValueFromString("0.00000000")), 0LL);
+    FAST_CHECK_EQUAL(AmountFromValue(ValueFromString("0.00000001")), 1LL);
+    FAST_CHECK_EQUAL(AmountFromValue(ValueFromString("0.17622195")), 17622195LL);
+    FAST_CHECK_EQUAL(AmountFromValue(ValueFromString("0.5")), 50000000LL);
+    FAST_CHECK_EQUAL(AmountFromValue(ValueFromString("0.50000000")), 50000000LL);
+    FAST_CHECK_EQUAL(AmountFromValue(ValueFromString("0.89898989")), 89898989LL);
+    FAST_CHECK_EQUAL(AmountFromValue(ValueFromString("1.00000000")), 100000000LL);
+    FAST_CHECK_EQUAL(AmountFromValue(ValueFromString("20999999.9999999")), 2099999999999990LL);
+    FAST_CHECK_EQUAL(AmountFromValue(ValueFromString("20999999.99999999")), 2099999999999999LL);
 
-    BOOST_CHECK_EQUAL(AmountFromValue(ValueFromString("1e-8")), COIN/100000000);
-    BOOST_CHECK_EQUAL(AmountFromValue(ValueFromString("0.1e-7")), COIN/100000000);
-    BOOST_CHECK_EQUAL(AmountFromValue(ValueFromString("0.01e-6")), COIN/100000000);
-    BOOST_CHECK_EQUAL(AmountFromValue(ValueFromString("0.0000000000000000000000000000000000000000000000000000000000000000000000000001e+68")), COIN/100000000);
-    BOOST_CHECK_EQUAL(AmountFromValue(ValueFromString("10000000000000000000000000000000000000000000000000000000000000000e-64")), COIN);
-    BOOST_CHECK_EQUAL(AmountFromValue(ValueFromString("0.000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000e64")), COIN);
+    FAST_CHECK_EQUAL(AmountFromValue(ValueFromString("1e-8")), COIN/100000000);
+    FAST_CHECK_EQUAL(AmountFromValue(ValueFromString("0.1e-7")), COIN/100000000);
+    FAST_CHECK_EQUAL(AmountFromValue(ValueFromString("0.01e-6")), COIN/100000000);
+    FAST_CHECK_EQUAL(AmountFromValue(ValueFromString("0.0000000000000000000000000000000000000000000000000000000000000000000000000001e+68")), COIN/100000000);
+    FAST_CHECK_EQUAL(AmountFromValue(ValueFromString("10000000000000000000000000000000000000000000000000000000000000000e-64")), COIN);
+    FAST_CHECK_EQUAL(AmountFromValue(ValueFromString("0.000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000e64")), COIN);
 
-    BOOST_CHECK_THROW(AmountFromValue(ValueFromString("1e-9")), UniValue); //should fail
-    BOOST_CHECK_THROW(AmountFromValue(ValueFromString("0.000000019")), UniValue); //should fail
-    BOOST_CHECK_EQUAL(AmountFromValue(ValueFromString("0.00000001000000")), 1LL); //should pass, cut trailing 0
-    BOOST_CHECK_THROW(AmountFromValue(ValueFromString("19e-9")), UniValue); //should fail
-    BOOST_CHECK_EQUAL(AmountFromValue(ValueFromString("0.19e-6")), 19); //should pass, leading 0 is present
+    FAST_CHECK_THROW(AmountFromValue(ValueFromString("1e-9")), UniValue); //should fail
+    FAST_CHECK_THROW(AmountFromValue(ValueFromString("0.000000019")), UniValue); //should fail
+    FAST_CHECK_EQUAL(AmountFromValue(ValueFromString("0.00000001000000")), 1LL); //should pass, cut trailing 0
+    FAST_CHECK_THROW(AmountFromValue(ValueFromString("19e-9")), UniValue); //should fail
+    FAST_CHECK_EQUAL(AmountFromValue(ValueFromString("0.19e-6")), 19); //should pass, leading 0 is present
 
-    BOOST_CHECK_THROW(AmountFromValue(ValueFromString("92233720368.54775808")), UniValue); //overflow error
-    BOOST_CHECK_THROW(AmountFromValue(ValueFromString("1e+11")), UniValue); //overflow error
-    BOOST_CHECK_THROW(AmountFromValue(ValueFromString("1e11")), UniValue); //overflow error signless
-    BOOST_CHECK_THROW(AmountFromValue(ValueFromString("93e+9")), UniValue); //overflow error
+    FAST_CHECK_THROW(AmountFromValue(ValueFromString("92233720368.54775808")), UniValue); //overflow error
+    FAST_CHECK_THROW(AmountFromValue(ValueFromString("1e+11")), UniValue); //overflow error
+    FAST_CHECK_THROW(AmountFromValue(ValueFromString("1e11")), UniValue); //overflow error signless
+    FAST_CHECK_THROW(AmountFromValue(ValueFromString("93e+9")), UniValue); //overflow error
 }
 
 BOOST_AUTO_TEST_CASE(json_parse_errors)
 {
     // Valid
-    BOOST_CHECK_EQUAL(ParseNonRFCJSONValue("1.0").get_real(), 1.0);
+    FAST_CHECK_EQUAL(ParseNonRFCJSONValue("1.0").get_real(), 1.0);
     // Valid, with leading or trailing whitespace
-    BOOST_CHECK_EQUAL(ParseNonRFCJSONValue(" 1.0").get_real(), 1.0);
-    BOOST_CHECK_EQUAL(ParseNonRFCJSONValue("1.0 ").get_real(), 1.0);
+    FAST_CHECK_EQUAL(ParseNonRFCJSONValue(" 1.0").get_real(), 1.0);
+    FAST_CHECK_EQUAL(ParseNonRFCJSONValue("1.0 ").get_real(), 1.0);
 
-    BOOST_CHECK_THROW(AmountFromValue(ParseNonRFCJSONValue(".19e-6")), std::runtime_error); //should fail, missing leading 0, therefore invalid JSON
-    BOOST_CHECK_EQUAL(AmountFromValue(ParseNonRFCJSONValue("0.00000000000000000000000000000000000001e+30 ")), 1);
+    FAST_CHECK_THROW(AmountFromValue(ParseNonRFCJSONValue(".19e-6")), std::runtime_error); //should fail, missing leading 0, therefore invalid JSON
+    FAST_CHECK_EQUAL(AmountFromValue(ParseNonRFCJSONValue("0.00000000000000000000000000000000000001e+30 ")), 1);
     // Invalid, initial garbage
-    BOOST_CHECK_THROW(ParseNonRFCJSONValue("[1.0"), std::runtime_error);
-    BOOST_CHECK_THROW(ParseNonRFCJSONValue("a1.0"), std::runtime_error);
+    FAST_CHECK_THROW(ParseNonRFCJSONValue("[1.0"), std::runtime_error);
+    FAST_CHECK_THROW(ParseNonRFCJSONValue("a1.0"), std::runtime_error);
     // Invalid, trailing garbage
-    BOOST_CHECK_THROW(ParseNonRFCJSONValue("1.0sds"), std::runtime_error);
-    BOOST_CHECK_THROW(ParseNonRFCJSONValue("1.0]"), std::runtime_error);
+    FAST_CHECK_THROW(ParseNonRFCJSONValue("1.0sds"), std::runtime_error);
+    FAST_CHECK_THROW(ParseNonRFCJSONValue("1.0]"), std::runtime_error);
     // BTC addresses should fail parsing
-    BOOST_CHECK_THROW(ParseNonRFCJSONValue("175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W"), std::runtime_error);
-    BOOST_CHECK_THROW(ParseNonRFCJSONValue("3J98t1WpEZ73CNmQviecrnyiWrnqRhWNL"), std::runtime_error);
+    FAST_CHECK_THROW(ParseNonRFCJSONValue("175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W"), std::runtime_error);
+    FAST_CHECK_THROW(ParseNonRFCJSONValue("3J98t1WpEZ73CNmQviecrnyiWrnqRhWNL"), std::runtime_error);
 }
 
 BOOST_AUTO_TEST_CASE(rpc_ban)
 {
-    BOOST_CHECK_NO_THROW(CallRPC(string("clearbanned")));
+    FAST_CHECK_NO_THROW(CallRPC(string("clearbanned")));
     
     UniValue r;
-    BOOST_CHECK_NO_THROW(r = CallRPC(string("setban 127.0.0.0 add")));
-    BOOST_CHECK_THROW(r = CallRPC(string("setban 127.0.0.0:8334")), runtime_error); //portnumber for setban not allowed
-    BOOST_CHECK_NO_THROW(r = CallRPC(string("listbanned")));
+    FAST_CHECK_NO_THROW(r = CallRPC(string("setban 127.0.0.0 add")));
+    FAST_CHECK_THROW(r = CallRPC(string("setban 127.0.0.0:8334")), runtime_error); //portnumber for setban not allowed
+    FAST_CHECK_NO_THROW(r = CallRPC(string("listbanned")));
     UniValue ar = r.get_array();
     UniValue o1 = ar[0].get_obj();
     UniValue adr = find_value(o1, "address");
-    BOOST_CHECK_EQUAL(adr.get_str(), "127.0.0.0/32");
-    BOOST_CHECK_NO_THROW(CallRPC(string("setban 127.0.0.0 remove")));
-    BOOST_CHECK_NO_THROW(r = CallRPC(string("listbanned")));
+    FAST_CHECK_EQUAL(adr.get_str(), "127.0.0.0/32");
+    FAST_CHECK_NO_THROW(CallRPC(string("setban 127.0.0.0 remove")));
+    FAST_CHECK_NO_THROW(r = CallRPC(string("listbanned")));
     ar = r.get_array();
-    BOOST_CHECK_EQUAL(ar.size(), 0);
+    FAST_CHECK_EQUAL(ar.size(), 0);
 
-    BOOST_CHECK_NO_THROW(r = CallRPC(string("setban 127.0.0.0/24 add 1607731200 true")));
-    BOOST_CHECK_NO_THROW(r = CallRPC(string("listbanned")));
+    FAST_CHECK_NO_THROW(r = CallRPC(string("setban 127.0.0.0/24 add 1607731200 true")));
+    FAST_CHECK_NO_THROW(r = CallRPC(string("listbanned")));
     ar = r.get_array();
     o1 = ar[0].get_obj();
     adr = find_value(o1, "address");
     UniValue banned_until = find_value(o1, "banned_until");
-    BOOST_CHECK_EQUAL(adr.get_str(), "127.0.0.0/24");
-    BOOST_CHECK_EQUAL(banned_until.get_int64(), 1607731200); // absolute time check
+    FAST_CHECK_EQUAL(adr.get_str(), "127.0.0.0/24");
+    FAST_CHECK_EQUAL(banned_until.get_int64(), 1607731200); // absolute time check
 
-    BOOST_CHECK_NO_THROW(CallRPC(string("clearbanned")));
+    FAST_CHECK_NO_THROW(CallRPC(string("clearbanned")));
 
-    BOOST_CHECK_NO_THROW(r = CallRPC(string("setban 127.0.0.0/24 add 200")));
-    BOOST_CHECK_NO_THROW(r = CallRPC(string("listbanned")));
+    FAST_CHECK_NO_THROW(r = CallRPC(string("setban 127.0.0.0/24 add 200")));
+    FAST_CHECK_NO_THROW(r = CallRPC(string("listbanned")));
     ar = r.get_array();
     o1 = ar[0].get_obj();
     adr = find_value(o1, "address");
     banned_until = find_value(o1, "banned_until");
-    BOOST_CHECK_EQUAL(adr.get_str(), "127.0.0.0/24");
+    FAST_CHECK_EQUAL(adr.get_str(), "127.0.0.0/24");
     int64_t now = GetTime();
-    BOOST_CHECK(banned_until.get_int64() > now);
-    BOOST_CHECK(banned_until.get_int64()-now <= 200);
+    FAST_CHECK(banned_until.get_int64() > now);
+    FAST_CHECK(banned_until.get_int64()-now <= 200);
 
     // must throw an exception because 127.0.0.1 is in already banned suubnet range
-    BOOST_CHECK_THROW(r = CallRPC(string("setban 127.0.0.1 add")), runtime_error);
+    FAST_CHECK_THROW(r = CallRPC(string("setban 127.0.0.1 add")), runtime_error);
 
-    BOOST_CHECK_NO_THROW(CallRPC(string("setban 127.0.0.0/24 remove")));
-    BOOST_CHECK_NO_THROW(r = CallRPC(string("listbanned")));
+    FAST_CHECK_NO_THROW(CallRPC(string("setban 127.0.0.0/24 remove")));
+    FAST_CHECK_NO_THROW(r = CallRPC(string("listbanned")));
     ar = r.get_array();
-    BOOST_CHECK_EQUAL(ar.size(), 0);
+    FAST_CHECK_EQUAL(ar.size(), 0);
 
-    BOOST_CHECK_NO_THROW(r = CallRPC(string("setban 127.0.0.0/255.255.0.0 add")));
-    BOOST_CHECK_THROW(r = CallRPC(string("setban 127.0.1.1 add")), runtime_error);
+    FAST_CHECK_NO_THROW(r = CallRPC(string("setban 127.0.0.0/255.255.0.0 add")));
+    FAST_CHECK_THROW(r = CallRPC(string("setban 127.0.1.1 add")), runtime_error);
 
-    BOOST_CHECK_NO_THROW(CallRPC(string("clearbanned")));
-    BOOST_CHECK_NO_THROW(r = CallRPC(string("listbanned")));
+    FAST_CHECK_NO_THROW(CallRPC(string("clearbanned")));
+    FAST_CHECK_NO_THROW(r = CallRPC(string("listbanned")));
     ar = r.get_array();
-    BOOST_CHECK_EQUAL(ar.size(), 0);
+    FAST_CHECK_EQUAL(ar.size(), 0);
 
 
-    BOOST_CHECK_THROW(r = CallRPC(string("setban test add")), runtime_error); //invalid IP
+    FAST_CHECK_THROW(r = CallRPC(string("setban test add")), runtime_error); //invalid IP
 
     //IPv6 tests
-    BOOST_CHECK_NO_THROW(r = CallRPC(string("setban FE80:0000:0000:0000:0202:B3FF:FE1E:8329 add")));
-    BOOST_CHECK_NO_THROW(r = CallRPC(string("listbanned")));
+    FAST_CHECK_NO_THROW(r = CallRPC(string("setban FE80:0000:0000:0000:0202:B3FF:FE1E:8329 add")));
+    FAST_CHECK_NO_THROW(r = CallRPC(string("listbanned")));
     ar = r.get_array();
     o1 = ar[0].get_obj();
     adr = find_value(o1, "address");
-    BOOST_CHECK_EQUAL(adr.get_str(), "fe80::202:b3ff:fe1e:8329/128");
+    FAST_CHECK_EQUAL(adr.get_str(), "fe80::202:b3ff:fe1e:8329/128");
 
-    BOOST_CHECK_NO_THROW(CallRPC(string("clearbanned")));
-    BOOST_CHECK_NO_THROW(r = CallRPC(string("setban 2001:db8::/ffff:fffc:0:0:0:0:0:0 add")));
-    BOOST_CHECK_NO_THROW(r = CallRPC(string("listbanned")));
+    FAST_CHECK_NO_THROW(CallRPC(string("clearbanned")));
+    FAST_CHECK_NO_THROW(r = CallRPC(string("setban 2001:db8::/ffff:fffc:0:0:0:0:0:0 add")));
+    FAST_CHECK_NO_THROW(r = CallRPC(string("listbanned")));
     ar = r.get_array();
     o1 = ar[0].get_obj();
     adr = find_value(o1, "address");
-    BOOST_CHECK_EQUAL(adr.get_str(), "2001:db8::/30");
+    FAST_CHECK_EQUAL(adr.get_str(), "2001:db8::/30");
 
-    BOOST_CHECK_NO_THROW(CallRPC(string("clearbanned")));
-    BOOST_CHECK_NO_THROW(r = CallRPC(string("setban 2001:4d48:ac57:400:cacf:e9ff:fe1d:9c63/128 add")));
-    BOOST_CHECK_NO_THROW(r = CallRPC(string("listbanned")));
+    FAST_CHECK_NO_THROW(CallRPC(string("clearbanned")));
+    FAST_CHECK_NO_THROW(r = CallRPC(string("setban 2001:4d48:ac57:400:cacf:e9ff:fe1d:9c63/128 add")));
+    FAST_CHECK_NO_THROW(r = CallRPC(string("listbanned")));
     ar = r.get_array();
     o1 = ar[0].get_obj();
     adr = find_value(o1, "address");
-    BOOST_CHECK_EQUAL(adr.get_str(), "2001:4d48:ac57:400:cacf:e9ff:fe1d:9c63/128");
+    FAST_CHECK_EQUAL(adr.get_str(), "2001:4d48:ac57:400:cacf:e9ff:fe1d:9c63/128");
 }
 
 BOOST_AUTO_TEST_CASE(rpc_convert_values_generatetoaddress)
 {
     UniValue result;
 
-    BOOST_CHECK_NO_THROW(result = RPCConvertValues("generatetoaddress", boost::assign::list_of("101")("mkESjLZW66TmHhiFX8MCaBjrhZ543PPh9a")));
-    BOOST_CHECK_EQUAL(result[0].get_int(), 101);
-    BOOST_CHECK_EQUAL(result[1].get_str(), "mkESjLZW66TmHhiFX8MCaBjrhZ543PPh9a");
+    FAST_CHECK_NO_THROW(result = RPCConvertValues("generatetoaddress", boost::assign::list_of("101")("mkESjLZW66TmHhiFX8MCaBjrhZ543PPh9a")));
+    FAST_CHECK_EQUAL(result[0].get_int(), 101);
+    FAST_CHECK_EQUAL(result[1].get_str(), "mkESjLZW66TmHhiFX8MCaBjrhZ543PPh9a");
 
-    BOOST_CHECK_NO_THROW(result = RPCConvertValues("generatetoaddress", boost::assign::list_of("101")("mhMbmE2tE9xzJYCV9aNC8jKWN31vtGrguU")));
-    BOOST_CHECK_EQUAL(result[0].get_int(), 101);
-    BOOST_CHECK_EQUAL(result[1].get_str(), "mhMbmE2tE9xzJYCV9aNC8jKWN31vtGrguU");
+    FAST_CHECK_NO_THROW(result = RPCConvertValues("generatetoaddress", boost::assign::list_of("101")("mhMbmE2tE9xzJYCV9aNC8jKWN31vtGrguU")));
+    FAST_CHECK_EQUAL(result[0].get_int(), 101);
+    FAST_CHECK_EQUAL(result[1].get_str(), "mhMbmE2tE9xzJYCV9aNC8jKWN31vtGrguU");
 
-    BOOST_CHECK_NO_THROW(result = RPCConvertValues("generatetoaddress", boost::assign::list_of("1")("mkESjLZW66TmHhiFX8MCaBjrhZ543PPh9a")("9")));
-    BOOST_CHECK_EQUAL(result[0].get_int(), 1);
-    BOOST_CHECK_EQUAL(result[1].get_str(), "mkESjLZW66TmHhiFX8MCaBjrhZ543PPh9a");
-    BOOST_CHECK_EQUAL(result[2].get_int(), 9);
+    FAST_CHECK_NO_THROW(result = RPCConvertValues("generatetoaddress", boost::assign::list_of("1")("mkESjLZW66TmHhiFX8MCaBjrhZ543PPh9a")("9")));
+    FAST_CHECK_EQUAL(result[0].get_int(), 1);
+    FAST_CHECK_EQUAL(result[1].get_str(), "mkESjLZW66TmHhiFX8MCaBjrhZ543PPh9a");
+    FAST_CHECK_EQUAL(result[2].get_int(), 9);
 
-    BOOST_CHECK_NO_THROW(result = RPCConvertValues("generatetoaddress", boost::assign::list_of("1")("mhMbmE2tE9xzJYCV9aNC8jKWN31vtGrguU")("9")));
-    BOOST_CHECK_EQUAL(result[0].get_int(), 1);
-    BOOST_CHECK_EQUAL(result[1].get_str(), "mhMbmE2tE9xzJYCV9aNC8jKWN31vtGrguU");
-    BOOST_CHECK_EQUAL(result[2].get_int(), 9);
+    FAST_CHECK_NO_THROW(result = RPCConvertValues("generatetoaddress", boost::assign::list_of("1")("mhMbmE2tE9xzJYCV9aNC8jKWN31vtGrguU")("9")));
+    FAST_CHECK_EQUAL(result[0].get_int(), 1);
+    FAST_CHECK_EQUAL(result[1].get_str(), "mhMbmE2tE9xzJYCV9aNC8jKWN31vtGrguU");
+    FAST_CHECK_EQUAL(result[2].get_int(), 9);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/scheduler_tests.cpp
+++ b/src/test/scheduler_tests.cpp
@@ -67,7 +67,7 @@ BOOST_AUTO_TEST_CASE(manythreads)
     boost::chrono::system_clock::time_point now = start;
     boost::chrono::system_clock::time_point first, last;
     size_t nTasks = microTasks.getQueueInfo(first, last);
-    BOOST_CHECK(nTasks == 0);
+    FAST_CHECK(nTasks == 0);
 
     for (int i = 0; i < 100; i++) {
         boost::chrono::system_clock::time_point t = now + boost::chrono::microseconds(randomMsec(rng));
@@ -79,9 +79,9 @@ BOOST_AUTO_TEST_CASE(manythreads)
         microTasks.schedule(f, t);
     }
     nTasks = microTasks.getQueueInfo(first, last);
-    BOOST_CHECK(nTasks == 100);
-    BOOST_CHECK(first < last);
-    BOOST_CHECK(last > now);
+    FAST_CHECK(nTasks == 100);
+    FAST_CHECK(first < last);
+    FAST_CHECK(last > now);
 
     // As soon as these are created they will start running and servicing the queue
     boost::thread_group microThreads;
@@ -110,10 +110,10 @@ BOOST_AUTO_TEST_CASE(manythreads)
 
     int counterSum = 0;
     for (int i = 0; i < 10; i++) {
-        BOOST_CHECK(counter[i] != 0);
+        FAST_CHECK(counter[i] != 0);
         counterSum += counter[i];
     }
-    BOOST_CHECK_EQUAL(counterSum, 200);
+    FAST_CHECK_EQUAL(counterSum, 200);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/script_P2SH_tests.cpp
+++ b/src/test/script_P2SH_tests.cpp
@@ -89,7 +89,7 @@ BOOST_AUTO_TEST_CASE(sign)
         txFrom.vout[i+4].scriptPubKey = standardScripts[i];
         txFrom.vout[i+4].nValue = COIN;
     }
-    BOOST_CHECK(IsStandardTx(txFrom, reason));
+    FAST_CHECK(IsStandardTx(txFrom, reason));
 
     CMutableTransaction txTo[8]; // Spending transactions
     for (int i = 0; i < 8; i++)
@@ -135,7 +135,7 @@ BOOST_AUTO_TEST_CASE(norecurse)
     scriptSig << Serialize(invalidAsScript);
 
     // Should not verify, because it will try to execute OP_INVALIDOPCODE
-    BOOST_CHECK(!Verify(scriptSig, p2sh, true, err));
+    FAST_CHECK(!Verify(scriptSig, p2sh, true, err));
     BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_BAD_OPCODE, ScriptErrorString(err));
 
     // Try to recur, and verification should succeed because
@@ -144,7 +144,7 @@ BOOST_AUTO_TEST_CASE(norecurse)
     CScript scriptSig2;
     scriptSig2 << Serialize(invalidAsScript) << Serialize(p2sh);
 
-    BOOST_CHECK(Verify(scriptSig2, p2sh2, true, err));
+    FAST_CHECK(Verify(scriptSig2, p2sh2, true, err));
     BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_OK, ScriptErrorString(err));
 }
 
@@ -183,7 +183,7 @@ BOOST_AUTO_TEST_CASE(set)
         txFrom.vout[i].scriptPubKey = outer[i];
         txFrom.vout[i].nValue = CENT;
     }
-    BOOST_CHECK(IsStandardTx(txFrom, reason));
+    FAST_CHECK(IsStandardTx(txFrom, reason));
 
     CMutableTransaction txTo[4]; // Spending transactions
     for (int i = 0; i < 4; i++)
@@ -209,29 +209,29 @@ BOOST_AUTO_TEST_CASE(is)
     uint160 dummy;
     CScript p2sh;
     p2sh << OP_HASH160 << ToByteVector(dummy) << OP_EQUAL;
-    BOOST_CHECK(p2sh.IsPayToScriptHash());
+    FAST_CHECK(p2sh.IsPayToScriptHash());
 
     // Not considered pay-to-script-hash if using one of the OP_PUSHDATA opcodes:
     static const unsigned char direct[] =    { OP_HASH160, 20, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, OP_EQUAL };
-    BOOST_CHECK(CScript(direct, direct+sizeof(direct)).IsPayToScriptHash());
+    FAST_CHECK(CScript(direct, direct+sizeof(direct)).IsPayToScriptHash());
     static const unsigned char pushdata1[] = { OP_HASH160, OP_PUSHDATA1, 20, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, OP_EQUAL };
-    BOOST_CHECK(!CScript(pushdata1, pushdata1+sizeof(pushdata1)).IsPayToScriptHash());
+    FAST_CHECK(!CScript(pushdata1, pushdata1+sizeof(pushdata1)).IsPayToScriptHash());
     static const unsigned char pushdata2[] = { OP_HASH160, OP_PUSHDATA2, 20,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, OP_EQUAL };
-    BOOST_CHECK(!CScript(pushdata2, pushdata2+sizeof(pushdata2)).IsPayToScriptHash());
+    FAST_CHECK(!CScript(pushdata2, pushdata2+sizeof(pushdata2)).IsPayToScriptHash());
     static const unsigned char pushdata4[] = { OP_HASH160, OP_PUSHDATA4, 20,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, OP_EQUAL };
-    BOOST_CHECK(!CScript(pushdata4, pushdata4+sizeof(pushdata4)).IsPayToScriptHash());
+    FAST_CHECK(!CScript(pushdata4, pushdata4+sizeof(pushdata4)).IsPayToScriptHash());
 
     CScript not_p2sh;
-    BOOST_CHECK(!not_p2sh.IsPayToScriptHash());
+    FAST_CHECK(!not_p2sh.IsPayToScriptHash());
 
     not_p2sh.clear(); not_p2sh << OP_HASH160 << ToByteVector(dummy) << ToByteVector(dummy) << OP_EQUAL;
-    BOOST_CHECK(!not_p2sh.IsPayToScriptHash());
+    FAST_CHECK(!not_p2sh.IsPayToScriptHash());
 
     not_p2sh.clear(); not_p2sh << OP_NOP << ToByteVector(dummy) << OP_EQUAL;
-    BOOST_CHECK(!not_p2sh.IsPayToScriptHash());
+    FAST_CHECK(!not_p2sh.IsPayToScriptHash());
 
     not_p2sh.clear(); not_p2sh << OP_HASH160 << ToByteVector(dummy) << OP_CHECKSIG;
-    BOOST_CHECK(!not_p2sh.IsPayToScriptHash());
+    FAST_CHECK(!not_p2sh.IsPayToScriptHash());
 }
 
 BOOST_AUTO_TEST_CASE(switchover)
@@ -247,10 +247,10 @@ BOOST_AUTO_TEST_CASE(switchover)
 
 
     // Validation should succeed under old rules (hash is correct):
-    BOOST_CHECK(Verify(scriptSig, fund, false, err));
+    FAST_CHECK(Verify(scriptSig, fund, false, err));
     BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_OK, ScriptErrorString(err));
     // Fail under new:
-    BOOST_CHECK(!Verify(scriptSig, fund, true, err));
+    FAST_CHECK(!Verify(scriptSig, fund, true, err));
     BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_EQUALVERIFY, ScriptErrorString(err));
 }
 
@@ -327,18 +327,18 @@ BOOST_AUTO_TEST_CASE(AreInputsStandard)
         txTo.vin[i].prevout.n = i;
         txTo.vin[i].prevout.hash = txFrom.GetHash();
     }
-    BOOST_CHECK(SignSignature(keystore, txFrom, txTo, 0, SIGHASH_ALL));
-    BOOST_CHECK(SignSignature(keystore, txFrom, txTo, 1, SIGHASH_ALL));
-    BOOST_CHECK(SignSignature(keystore, txFrom, txTo, 2, SIGHASH_ALL));
+    FAST_CHECK(SignSignature(keystore, txFrom, txTo, 0, SIGHASH_ALL));
+    FAST_CHECK(SignSignature(keystore, txFrom, txTo, 1, SIGHASH_ALL));
+    FAST_CHECK(SignSignature(keystore, txFrom, txTo, 2, SIGHASH_ALL));
     // SignSignature doesn't know how to sign these. We're
     // not testing validating signatures, so just create
     // dummy signatures that DO include the correct P2SH scripts:
     txTo.vin[3].scriptSig << OP_11 << OP_11 << vector<unsigned char>(oneAndTwo.begin(), oneAndTwo.end());
     txTo.vin[4].scriptSig << vector<unsigned char>(fifteenSigops.begin(), fifteenSigops.end());
 
-    BOOST_CHECK(::AreInputsStandard(txTo, coins));
+    FAST_CHECK(::AreInputsStandard(txTo, coins));
     // 22 P2SH sigops for all inputs (1 for vin[0], 6 for vin[3], 15 for vin[4]
-    BOOST_CHECK_EQUAL(GetP2SHSigOpCount(txTo, coins), 22U);
+    FAST_CHECK_EQUAL(GetP2SHSigOpCount(txTo, coins), 22U);
 
     CMutableTransaction txToNonStd1;
     txToNonStd1.vout.resize(1);
@@ -349,8 +349,8 @@ BOOST_AUTO_TEST_CASE(AreInputsStandard)
     txToNonStd1.vin[0].prevout.hash = txFrom.GetHash();
     txToNonStd1.vin[0].scriptSig << vector<unsigned char>(sixteenSigops.begin(), sixteenSigops.end());
 
-    BOOST_CHECK(!::AreInputsStandard(txToNonStd1, coins));
-    BOOST_CHECK_EQUAL(GetP2SHSigOpCount(txToNonStd1, coins), 16U);
+    FAST_CHECK(!::AreInputsStandard(txToNonStd1, coins));
+    FAST_CHECK_EQUAL(GetP2SHSigOpCount(txToNonStd1, coins), 16U);
 
     CMutableTransaction txToNonStd2;
     txToNonStd2.vout.resize(1);
@@ -361,8 +361,8 @@ BOOST_AUTO_TEST_CASE(AreInputsStandard)
     txToNonStd2.vin[0].prevout.hash = txFrom.GetHash();
     txToNonStd2.vin[0].scriptSig << vector<unsigned char>(twentySigops.begin(), twentySigops.end());
 
-    BOOST_CHECK(!::AreInputsStandard(txToNonStd2, coins));
-    BOOST_CHECK_EQUAL(GetP2SHSigOpCount(txToNonStd2, coins), 20U);
+    FAST_CHECK(!::AreInputsStandard(txToNonStd2, coins));
+    FAST_CHECK_EQUAL(GetP2SHSigOpCount(txToNonStd2, coins), 20U);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -908,22 +908,22 @@ BOOST_AUTO_TEST_CASE(script_PushData)
 
     ScriptError err;
     vector<vector<unsigned char> > directStack;
-    BOOST_CHECK(EvalScript(directStack, CScript(&direct[0], &direct[sizeof(direct)]), SCRIPT_VERIFY_P2SH, BaseSignatureChecker(), SIGVERSION_BASE, &err));
+    FAST_CHECK(EvalScript(directStack, CScript(&direct[0], &direct[sizeof(direct)]), SCRIPT_VERIFY_P2SH, BaseSignatureChecker(), SIGVERSION_BASE, &err));
     BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_OK, ScriptErrorString(err));
 
     vector<vector<unsigned char> > pushdata1Stack;
-    BOOST_CHECK(EvalScript(pushdata1Stack, CScript(&pushdata1[0], &pushdata1[sizeof(pushdata1)]), SCRIPT_VERIFY_P2SH, BaseSignatureChecker(), SIGVERSION_BASE, &err));
-    BOOST_CHECK(pushdata1Stack == directStack);
+    FAST_CHECK(EvalScript(pushdata1Stack, CScript(&pushdata1[0], &pushdata1[sizeof(pushdata1)]), SCRIPT_VERIFY_P2SH, BaseSignatureChecker(), SIGVERSION_BASE, &err));
+    FAST_CHECK(pushdata1Stack == directStack);
     BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_OK, ScriptErrorString(err));
 
     vector<vector<unsigned char> > pushdata2Stack;
-    BOOST_CHECK(EvalScript(pushdata2Stack, CScript(&pushdata2[0], &pushdata2[sizeof(pushdata2)]), SCRIPT_VERIFY_P2SH, BaseSignatureChecker(), SIGVERSION_BASE, &err));
-    BOOST_CHECK(pushdata2Stack == directStack);
+    FAST_CHECK(EvalScript(pushdata2Stack, CScript(&pushdata2[0], &pushdata2[sizeof(pushdata2)]), SCRIPT_VERIFY_P2SH, BaseSignatureChecker(), SIGVERSION_BASE, &err));
+    FAST_CHECK(pushdata2Stack == directStack);
     BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_OK, ScriptErrorString(err));
 
     vector<vector<unsigned char> > pushdata4Stack;
-    BOOST_CHECK(EvalScript(pushdata4Stack, CScript(&pushdata4[0], &pushdata4[sizeof(pushdata4)]), SCRIPT_VERIFY_P2SH, BaseSignatureChecker(), SIGVERSION_BASE, &err));
-    BOOST_CHECK(pushdata4Stack == directStack);
+    FAST_CHECK(EvalScript(pushdata4Stack, CScript(&pushdata4[0], &pushdata4[sizeof(pushdata4)]), SCRIPT_VERIFY_P2SH, BaseSignatureChecker(), SIGVERSION_BASE, &err));
+    FAST_CHECK(pushdata4Stack == directStack);
     BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_OK, ScriptErrorString(err));
 }
 
@@ -945,7 +945,7 @@ sign_multisig(CScript scriptPubKey, std::vector<CKey> keys, CTransaction transac
     BOOST_FOREACH(const CKey &key, keys)
     {
         vector<unsigned char> vchSig;
-        BOOST_CHECK(key.Sign(hash, vchSig));
+        FAST_CHECK(key.Sign(hash, vchSig));
         vchSig.push_back((unsigned char)SIGHASH_ALL);
         result << vchSig;
     }
@@ -974,18 +974,18 @@ BOOST_AUTO_TEST_CASE(script_CHECKMULTISIG12)
     CMutableTransaction txTo12 = BuildSpendingTransaction(CScript(), CScriptWitness(), txFrom12);
 
     CScript goodsig1 = sign_multisig(scriptPubKey12, key1, txTo12);
-    BOOST_CHECK(VerifyScript(goodsig1, scriptPubKey12, NULL, flags, MutableTransactionSignatureChecker(&txTo12, 0, txFrom12.vout[0].nValue), &err));
+    FAST_CHECK(VerifyScript(goodsig1, scriptPubKey12, NULL, flags, MutableTransactionSignatureChecker(&txTo12, 0, txFrom12.vout[0].nValue), &err));
     BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_OK, ScriptErrorString(err));
     txTo12.vout[0].nValue = 2;
-    BOOST_CHECK(!VerifyScript(goodsig1, scriptPubKey12, NULL, flags, MutableTransactionSignatureChecker(&txTo12, 0, txFrom12.vout[0].nValue), &err));
+    FAST_CHECK(!VerifyScript(goodsig1, scriptPubKey12, NULL, flags, MutableTransactionSignatureChecker(&txTo12, 0, txFrom12.vout[0].nValue), &err));
     BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_EVAL_FALSE, ScriptErrorString(err));
 
     CScript goodsig2 = sign_multisig(scriptPubKey12, key2, txTo12);
-    BOOST_CHECK(VerifyScript(goodsig2, scriptPubKey12, NULL, flags, MutableTransactionSignatureChecker(&txTo12, 0, txFrom12.vout[0].nValue), &err));
+    FAST_CHECK(VerifyScript(goodsig2, scriptPubKey12, NULL, flags, MutableTransactionSignatureChecker(&txTo12, 0, txFrom12.vout[0].nValue), &err));
     BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_OK, ScriptErrorString(err));
 
     CScript badsig1 = sign_multisig(scriptPubKey12, key3, txTo12);
-    BOOST_CHECK(!VerifyScript(badsig1, scriptPubKey12, NULL, flags, MutableTransactionSignatureChecker(&txTo12, 0, txFrom12.vout[0].nValue), &err));
+    FAST_CHECK(!VerifyScript(badsig1, scriptPubKey12, NULL, flags, MutableTransactionSignatureChecker(&txTo12, 0, txFrom12.vout[0].nValue), &err));
     BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_EVAL_FALSE, ScriptErrorString(err));
 }
 
@@ -1007,54 +1007,54 @@ BOOST_AUTO_TEST_CASE(script_CHECKMULTISIG23)
     std::vector<CKey> keys;
     keys.push_back(key1); keys.push_back(key2);
     CScript goodsig1 = sign_multisig(scriptPubKey23, keys, txTo23);
-    BOOST_CHECK(VerifyScript(goodsig1, scriptPubKey23, NULL, flags, MutableTransactionSignatureChecker(&txTo23, 0, txFrom23.vout[0].nValue), &err));
+    FAST_CHECK(VerifyScript(goodsig1, scriptPubKey23, NULL, flags, MutableTransactionSignatureChecker(&txTo23, 0, txFrom23.vout[0].nValue), &err));
     BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_OK, ScriptErrorString(err));
 
     keys.clear();
     keys.push_back(key1); keys.push_back(key3);
     CScript goodsig2 = sign_multisig(scriptPubKey23, keys, txTo23);
-    BOOST_CHECK(VerifyScript(goodsig2, scriptPubKey23, NULL, flags, MutableTransactionSignatureChecker(&txTo23, 0, txFrom23.vout[0].nValue), &err));
+    FAST_CHECK(VerifyScript(goodsig2, scriptPubKey23, NULL, flags, MutableTransactionSignatureChecker(&txTo23, 0, txFrom23.vout[0].nValue), &err));
     BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_OK, ScriptErrorString(err));
 
     keys.clear();
     keys.push_back(key2); keys.push_back(key3);
     CScript goodsig3 = sign_multisig(scriptPubKey23, keys, txTo23);
-    BOOST_CHECK(VerifyScript(goodsig3, scriptPubKey23, NULL, flags, MutableTransactionSignatureChecker(&txTo23, 0, txFrom23.vout[0].nValue), &err));
+    FAST_CHECK(VerifyScript(goodsig3, scriptPubKey23, NULL, flags, MutableTransactionSignatureChecker(&txTo23, 0, txFrom23.vout[0].nValue), &err));
     BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_OK, ScriptErrorString(err));
 
     keys.clear();
     keys.push_back(key2); keys.push_back(key2); // Can't re-use sig
     CScript badsig1 = sign_multisig(scriptPubKey23, keys, txTo23);
-    BOOST_CHECK(!VerifyScript(badsig1, scriptPubKey23, NULL, flags, MutableTransactionSignatureChecker(&txTo23, 0, txFrom23.vout[0].nValue), &err));
+    FAST_CHECK(!VerifyScript(badsig1, scriptPubKey23, NULL, flags, MutableTransactionSignatureChecker(&txTo23, 0, txFrom23.vout[0].nValue), &err));
     BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_EVAL_FALSE, ScriptErrorString(err));
 
     keys.clear();
     keys.push_back(key2); keys.push_back(key1); // sigs must be in correct order
     CScript badsig2 = sign_multisig(scriptPubKey23, keys, txTo23);
-    BOOST_CHECK(!VerifyScript(badsig2, scriptPubKey23, NULL, flags, MutableTransactionSignatureChecker(&txTo23, 0, txFrom23.vout[0].nValue), &err));
+    FAST_CHECK(!VerifyScript(badsig2, scriptPubKey23, NULL, flags, MutableTransactionSignatureChecker(&txTo23, 0, txFrom23.vout[0].nValue), &err));
     BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_EVAL_FALSE, ScriptErrorString(err));
 
     keys.clear();
     keys.push_back(key3); keys.push_back(key2); // sigs must be in correct order
     CScript badsig3 = sign_multisig(scriptPubKey23, keys, txTo23);
-    BOOST_CHECK(!VerifyScript(badsig3, scriptPubKey23, NULL, flags, MutableTransactionSignatureChecker(&txTo23, 0, txFrom23.vout[0].nValue), &err));
+    FAST_CHECK(!VerifyScript(badsig3, scriptPubKey23, NULL, flags, MutableTransactionSignatureChecker(&txTo23, 0, txFrom23.vout[0].nValue), &err));
     BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_EVAL_FALSE, ScriptErrorString(err));
 
     keys.clear();
     keys.push_back(key4); keys.push_back(key2); // sigs must match pubkeys
     CScript badsig4 = sign_multisig(scriptPubKey23, keys, txTo23);
-    BOOST_CHECK(!VerifyScript(badsig4, scriptPubKey23, NULL, flags, MutableTransactionSignatureChecker(&txTo23, 0, txFrom23.vout[0].nValue), &err));
+    FAST_CHECK(!VerifyScript(badsig4, scriptPubKey23, NULL, flags, MutableTransactionSignatureChecker(&txTo23, 0, txFrom23.vout[0].nValue), &err));
     BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_EVAL_FALSE, ScriptErrorString(err));
 
     keys.clear();
     keys.push_back(key1); keys.push_back(key4); // sigs must match pubkeys
     CScript badsig5 = sign_multisig(scriptPubKey23, keys, txTo23);
-    BOOST_CHECK(!VerifyScript(badsig5, scriptPubKey23, NULL, flags, MutableTransactionSignatureChecker(&txTo23, 0, txFrom23.vout[0].nValue), &err));
+    FAST_CHECK(!VerifyScript(badsig5, scriptPubKey23, NULL, flags, MutableTransactionSignatureChecker(&txTo23, 0, txFrom23.vout[0].nValue), &err));
     BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_EVAL_FALSE, ScriptErrorString(err));
 
     keys.clear(); // Must have signatures
     CScript badsig6 = sign_multisig(scriptPubKey23, keys, txTo23);
-    BOOST_CHECK(!VerifyScript(badsig6, scriptPubKey23, NULL, flags, MutableTransactionSignatureChecker(&txTo23, 0, txFrom23.vout[0].nValue), &err));
+    FAST_CHECK(!VerifyScript(badsig6, scriptPubKey23, NULL, flags, MutableTransactionSignatureChecker(&txTo23, 0, txFrom23.vout[0].nValue), &err));
     BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_INVALID_STACK_OPERATION, ScriptErrorString(err));
 }
 
@@ -1081,19 +1081,19 @@ BOOST_AUTO_TEST_CASE(script_combineSigs)
 
     SignatureData empty;
     SignatureData combined = CombineSignatures(scriptPubKey, MutableTransactionSignatureChecker(&txTo, 0, amount), empty, empty);
-    BOOST_CHECK(combined.scriptSig.empty());
+    FAST_CHECK(combined.scriptSig.empty());
 
     // Single signature case:
     SignSignature(keystore, txFrom, txTo, 0, SIGHASH_ALL); // changes scriptSig
     combined = CombineSignatures(scriptPubKey, MutableTransactionSignatureChecker(&txTo, 0, amount), SignatureData(scriptSig), empty);
-    BOOST_CHECK(combined.scriptSig == scriptSig);
+    FAST_CHECK(combined.scriptSig == scriptSig);
     combined = CombineSignatures(scriptPubKey, MutableTransactionSignatureChecker(&txTo, 0, amount), empty, SignatureData(scriptSig));
-    BOOST_CHECK(combined.scriptSig == scriptSig);
+    FAST_CHECK(combined.scriptSig == scriptSig);
     CScript scriptSigCopy = scriptSig;
     // Signing again will give a different, valid signature:
     SignSignature(keystore, txFrom, txTo, 0, SIGHASH_ALL);
     combined = CombineSignatures(scriptPubKey, MutableTransactionSignatureChecker(&txTo, 0, amount), SignatureData(scriptSigCopy), SignatureData(scriptSig));
-    BOOST_CHECK(combined.scriptSig == scriptSigCopy || combined.scriptSig == scriptSig);
+    FAST_CHECK(combined.scriptSig == scriptSigCopy || combined.scriptSig == scriptSig);
 
     // P2SH, single-signature case:
     CScript pkSingle; pkSingle << ToByteVector(keys[0].GetPubKey()) << OP_CHECKSIG;
@@ -1101,41 +1101,41 @@ BOOST_AUTO_TEST_CASE(script_combineSigs)
     scriptPubKey = GetScriptForDestination(CScriptID(pkSingle));
     SignSignature(keystore, txFrom, txTo, 0, SIGHASH_ALL);
     combined = CombineSignatures(scriptPubKey, MutableTransactionSignatureChecker(&txTo, 0, amount), SignatureData(scriptSig), empty);
-    BOOST_CHECK(combined.scriptSig == scriptSig);
+    FAST_CHECK(combined.scriptSig == scriptSig);
     combined = CombineSignatures(scriptPubKey, MutableTransactionSignatureChecker(&txTo, 0, amount), empty, SignatureData(scriptSig));
-    BOOST_CHECK(combined.scriptSig == scriptSig);
+    FAST_CHECK(combined.scriptSig == scriptSig);
     scriptSigCopy = scriptSig;
     SignSignature(keystore, txFrom, txTo, 0, SIGHASH_ALL);
     combined = CombineSignatures(scriptPubKey, MutableTransactionSignatureChecker(&txTo, 0, amount), SignatureData(scriptSigCopy), SignatureData(scriptSig));
-    BOOST_CHECK(combined.scriptSig == scriptSigCopy || combined.scriptSig == scriptSig);
+    FAST_CHECK(combined.scriptSig == scriptSigCopy || combined.scriptSig == scriptSig);
     // dummy scriptSigCopy with placeholder, should always choose non-placeholder:
     scriptSigCopy = CScript() << OP_0 << std::vector<unsigned char>(pkSingle.begin(), pkSingle.end());
     combined = CombineSignatures(scriptPubKey, MutableTransactionSignatureChecker(&txTo, 0, amount), SignatureData(scriptSigCopy), SignatureData(scriptSig));
-    BOOST_CHECK(combined.scriptSig == scriptSig);
+    FAST_CHECK(combined.scriptSig == scriptSig);
     combined = CombineSignatures(scriptPubKey, MutableTransactionSignatureChecker(&txTo, 0, amount), SignatureData(scriptSig), SignatureData(scriptSigCopy));
-    BOOST_CHECK(combined.scriptSig == scriptSig);
+    FAST_CHECK(combined.scriptSig == scriptSig);
 
     // Hardest case:  Multisig 2-of-3
     scriptPubKey = GetScriptForMultisig(2, pubkeys);
     keystore.AddCScript(scriptPubKey);
     SignSignature(keystore, txFrom, txTo, 0, SIGHASH_ALL);
     combined = CombineSignatures(scriptPubKey, MutableTransactionSignatureChecker(&txTo, 0, amount), SignatureData(scriptSig), empty);
-    BOOST_CHECK(combined.scriptSig == scriptSig);
+    FAST_CHECK(combined.scriptSig == scriptSig);
     combined = CombineSignatures(scriptPubKey, MutableTransactionSignatureChecker(&txTo, 0, amount), empty, SignatureData(scriptSig));
-    BOOST_CHECK(combined.scriptSig == scriptSig);
+    FAST_CHECK(combined.scriptSig == scriptSig);
 
     // A couple of partially-signed versions:
     vector<unsigned char> sig1;
     uint256 hash1 = SignatureHash(scriptPubKey, txTo, 0, SIGHASH_ALL, 0, SIGVERSION_BASE);
-    BOOST_CHECK(keys[0].Sign(hash1, sig1));
+    FAST_CHECK(keys[0].Sign(hash1, sig1));
     sig1.push_back(SIGHASH_ALL);
     vector<unsigned char> sig2;
     uint256 hash2 = SignatureHash(scriptPubKey, txTo, 0, SIGHASH_NONE, 0, SIGVERSION_BASE);
-    BOOST_CHECK(keys[1].Sign(hash2, sig2));
+    FAST_CHECK(keys[1].Sign(hash2, sig2));
     sig2.push_back(SIGHASH_NONE);
     vector<unsigned char> sig3;
     uint256 hash3 = SignatureHash(scriptPubKey, txTo, 0, SIGHASH_SINGLE, 0, SIGVERSION_BASE);
-    BOOST_CHECK(keys[2].Sign(hash3, sig3));
+    FAST_CHECK(keys[2].Sign(hash3, sig3));
     sig3.push_back(SIGHASH_SINGLE);
 
     // Not fussy about order (or even existence) of placeholders or signatures:
@@ -1151,21 +1151,21 @@ BOOST_AUTO_TEST_CASE(script_combineSigs)
     CScript complete23 = CScript() << OP_0 << sig2 << sig3;
 
     combined = CombineSignatures(scriptPubKey, MutableTransactionSignatureChecker(&txTo, 0, amount), SignatureData(partial1a), SignatureData(partial1b));
-    BOOST_CHECK(combined.scriptSig == partial1a);
+    FAST_CHECK(combined.scriptSig == partial1a);
     combined = CombineSignatures(scriptPubKey, MutableTransactionSignatureChecker(&txTo, 0, amount), SignatureData(partial1a), SignatureData(partial2a));
-    BOOST_CHECK(combined.scriptSig == complete12);
+    FAST_CHECK(combined.scriptSig == complete12);
     combined = CombineSignatures(scriptPubKey, MutableTransactionSignatureChecker(&txTo, 0, amount), SignatureData(partial2a), SignatureData(partial1a));
-    BOOST_CHECK(combined.scriptSig == complete12);
+    FAST_CHECK(combined.scriptSig == complete12);
     combined = CombineSignatures(scriptPubKey, MutableTransactionSignatureChecker(&txTo, 0, amount), SignatureData(partial1b), SignatureData(partial2b));
-    BOOST_CHECK(combined.scriptSig == complete12);
+    FAST_CHECK(combined.scriptSig == complete12);
     combined = CombineSignatures(scriptPubKey, MutableTransactionSignatureChecker(&txTo, 0, amount), SignatureData(partial3b), SignatureData(partial1b));
-    BOOST_CHECK(combined.scriptSig == complete13);
+    FAST_CHECK(combined.scriptSig == complete13);
     combined = CombineSignatures(scriptPubKey, MutableTransactionSignatureChecker(&txTo, 0, amount), SignatureData(partial2a), SignatureData(partial3a));
-    BOOST_CHECK(combined.scriptSig == complete23);
+    FAST_CHECK(combined.scriptSig == complete23);
     combined = CombineSignatures(scriptPubKey, MutableTransactionSignatureChecker(&txTo, 0, amount), SignatureData(partial3b), SignatureData(partial2b));
-    BOOST_CHECK(combined.scriptSig == complete23);
+    FAST_CHECK(combined.scriptSig == complete23);
     combined = CombineSignatures(scriptPubKey, MutableTransactionSignatureChecker(&txTo, 0, amount), SignatureData(partial3b), SignatureData(partial3a));
-    BOOST_CHECK(combined.scriptSig == partial3c);
+    FAST_CHECK(combined.scriptSig == partial3c);
 }
 
 BOOST_AUTO_TEST_CASE(script_standard_push)
@@ -1197,37 +1197,37 @@ BOOST_AUTO_TEST_CASE(script_IsPushOnly_on_invalid_scripts)
     // not be consensus critical as the P2SH evaluation would fail first due to
     // the invalid push. Still, it doesn't hurt to test it explicitly.
     static const unsigned char direct[] = { 1 };
-    BOOST_CHECK(!CScript(direct, direct+sizeof(direct)).IsPushOnly());
+    FAST_CHECK(!CScript(direct, direct+sizeof(direct)).IsPushOnly());
 }
 
 BOOST_AUTO_TEST_CASE(script_GetScriptAsm)
 {
-    BOOST_CHECK_EQUAL("OP_CHECKLOCKTIMEVERIFY", ScriptToAsmStr(CScript() << OP_NOP2, true));
-    BOOST_CHECK_EQUAL("OP_CHECKLOCKTIMEVERIFY", ScriptToAsmStr(CScript() << OP_CHECKLOCKTIMEVERIFY, true));
-    BOOST_CHECK_EQUAL("OP_CHECKLOCKTIMEVERIFY", ScriptToAsmStr(CScript() << OP_NOP2));
-    BOOST_CHECK_EQUAL("OP_CHECKLOCKTIMEVERIFY", ScriptToAsmStr(CScript() << OP_CHECKLOCKTIMEVERIFY));
+    FAST_CHECK_EQUAL("OP_CHECKLOCKTIMEVERIFY", ScriptToAsmStr(CScript() << OP_NOP2, true));
+    FAST_CHECK_EQUAL("OP_CHECKLOCKTIMEVERIFY", ScriptToAsmStr(CScript() << OP_CHECKLOCKTIMEVERIFY, true));
+    FAST_CHECK_EQUAL("OP_CHECKLOCKTIMEVERIFY", ScriptToAsmStr(CScript() << OP_NOP2));
+    FAST_CHECK_EQUAL("OP_CHECKLOCKTIMEVERIFY", ScriptToAsmStr(CScript() << OP_CHECKLOCKTIMEVERIFY));
 
     string derSig("304502207fa7a6d1e0ee81132a269ad84e68d695483745cde8b541e3bf630749894e342a022100c1f7ab20e13e22fb95281a870f3dcf38d782e53023ee313d741ad0cfbc0c5090");
     string pubKey("03b0da749730dc9b4b1f4a14d6902877a92541f5368778853d9c4a0cb7802dcfb2");
     vector<unsigned char> vchPubKey = ToByteVector(ParseHex(pubKey));
 
-    BOOST_CHECK_EQUAL(derSig + "00 " + pubKey, ScriptToAsmStr(CScript() << ToByteVector(ParseHex(derSig + "00")) << vchPubKey, true));
-    BOOST_CHECK_EQUAL(derSig + "80 " + pubKey, ScriptToAsmStr(CScript() << ToByteVector(ParseHex(derSig + "80")) << vchPubKey, true));
-    BOOST_CHECK_EQUAL(derSig + "[ALL] " + pubKey, ScriptToAsmStr(CScript() << ToByteVector(ParseHex(derSig + "01")) << vchPubKey, true));
-    BOOST_CHECK_EQUAL(derSig + "[NONE] " + pubKey, ScriptToAsmStr(CScript() << ToByteVector(ParseHex(derSig + "02")) << vchPubKey, true));
-    BOOST_CHECK_EQUAL(derSig + "[SINGLE] " + pubKey, ScriptToAsmStr(CScript() << ToByteVector(ParseHex(derSig + "03")) << vchPubKey, true));
-    BOOST_CHECK_EQUAL(derSig + "[ALL|ANYONECANPAY] " + pubKey, ScriptToAsmStr(CScript() << ToByteVector(ParseHex(derSig + "81")) << vchPubKey, true));
-    BOOST_CHECK_EQUAL(derSig + "[NONE|ANYONECANPAY] " + pubKey, ScriptToAsmStr(CScript() << ToByteVector(ParseHex(derSig + "82")) << vchPubKey, true));
-    BOOST_CHECK_EQUAL(derSig + "[SINGLE|ANYONECANPAY] " + pubKey, ScriptToAsmStr(CScript() << ToByteVector(ParseHex(derSig + "83")) << vchPubKey, true));
+    FAST_CHECK_EQUAL(derSig + "00 " + pubKey, ScriptToAsmStr(CScript() << ToByteVector(ParseHex(derSig + "00")) << vchPubKey, true));
+    FAST_CHECK_EQUAL(derSig + "80 " + pubKey, ScriptToAsmStr(CScript() << ToByteVector(ParseHex(derSig + "80")) << vchPubKey, true));
+    FAST_CHECK_EQUAL(derSig + "[ALL] " + pubKey, ScriptToAsmStr(CScript() << ToByteVector(ParseHex(derSig + "01")) << vchPubKey, true));
+    FAST_CHECK_EQUAL(derSig + "[NONE] " + pubKey, ScriptToAsmStr(CScript() << ToByteVector(ParseHex(derSig + "02")) << vchPubKey, true));
+    FAST_CHECK_EQUAL(derSig + "[SINGLE] " + pubKey, ScriptToAsmStr(CScript() << ToByteVector(ParseHex(derSig + "03")) << vchPubKey, true));
+    FAST_CHECK_EQUAL(derSig + "[ALL|ANYONECANPAY] " + pubKey, ScriptToAsmStr(CScript() << ToByteVector(ParseHex(derSig + "81")) << vchPubKey, true));
+    FAST_CHECK_EQUAL(derSig + "[NONE|ANYONECANPAY] " + pubKey, ScriptToAsmStr(CScript() << ToByteVector(ParseHex(derSig + "82")) << vchPubKey, true));
+    FAST_CHECK_EQUAL(derSig + "[SINGLE|ANYONECANPAY] " + pubKey, ScriptToAsmStr(CScript() << ToByteVector(ParseHex(derSig + "83")) << vchPubKey, true));
 
-    BOOST_CHECK_EQUAL(derSig + "00 " + pubKey, ScriptToAsmStr(CScript() << ToByteVector(ParseHex(derSig + "00")) << vchPubKey));
-    BOOST_CHECK_EQUAL(derSig + "80 " + pubKey, ScriptToAsmStr(CScript() << ToByteVector(ParseHex(derSig + "80")) << vchPubKey));
-    BOOST_CHECK_EQUAL(derSig + "01 " + pubKey, ScriptToAsmStr(CScript() << ToByteVector(ParseHex(derSig + "01")) << vchPubKey));
-    BOOST_CHECK_EQUAL(derSig + "02 " + pubKey, ScriptToAsmStr(CScript() << ToByteVector(ParseHex(derSig + "02")) << vchPubKey));
-    BOOST_CHECK_EQUAL(derSig + "03 " + pubKey, ScriptToAsmStr(CScript() << ToByteVector(ParseHex(derSig + "03")) << vchPubKey));
-    BOOST_CHECK_EQUAL(derSig + "81 " + pubKey, ScriptToAsmStr(CScript() << ToByteVector(ParseHex(derSig + "81")) << vchPubKey));
-    BOOST_CHECK_EQUAL(derSig + "82 " + pubKey, ScriptToAsmStr(CScript() << ToByteVector(ParseHex(derSig + "82")) << vchPubKey));
-    BOOST_CHECK_EQUAL(derSig + "83 " + pubKey, ScriptToAsmStr(CScript() << ToByteVector(ParseHex(derSig + "83")) << vchPubKey));
+    FAST_CHECK_EQUAL(derSig + "00 " + pubKey, ScriptToAsmStr(CScript() << ToByteVector(ParseHex(derSig + "00")) << vchPubKey));
+    FAST_CHECK_EQUAL(derSig + "80 " + pubKey, ScriptToAsmStr(CScript() << ToByteVector(ParseHex(derSig + "80")) << vchPubKey));
+    FAST_CHECK_EQUAL(derSig + "01 " + pubKey, ScriptToAsmStr(CScript() << ToByteVector(ParseHex(derSig + "01")) << vchPubKey));
+    FAST_CHECK_EQUAL(derSig + "02 " + pubKey, ScriptToAsmStr(CScript() << ToByteVector(ParseHex(derSig + "02")) << vchPubKey));
+    FAST_CHECK_EQUAL(derSig + "03 " + pubKey, ScriptToAsmStr(CScript() << ToByteVector(ParseHex(derSig + "03")) << vchPubKey));
+    FAST_CHECK_EQUAL(derSig + "81 " + pubKey, ScriptToAsmStr(CScript() << ToByteVector(ParseHex(derSig + "81")) << vchPubKey));
+    FAST_CHECK_EQUAL(derSig + "82 " + pubKey, ScriptToAsmStr(CScript() << ToByteVector(ParseHex(derSig + "82")) << vchPubKey));
+    FAST_CHECK_EQUAL(derSig + "83 " + pubKey, ScriptToAsmStr(CScript() << ToByteVector(ParseHex(derSig + "83")) << vchPubKey));
 }
 
 static CScript
@@ -1248,103 +1248,103 @@ BOOST_AUTO_TEST_CASE(script_FindAndDelete)
     s = CScript() << OP_1 << OP_2;
     d = CScript(); // delete nothing should be a no-op
     expect = s;
-    BOOST_CHECK_EQUAL(s.FindAndDelete(d), 0);
-    BOOST_CHECK(s == expect);
+    FAST_CHECK_EQUAL(s.FindAndDelete(d), 0);
+    FAST_CHECK(s == expect);
 
     s = CScript() << OP_1 << OP_2 << OP_3;
     d = CScript() << OP_2;
     expect = CScript() << OP_1 << OP_3;
-    BOOST_CHECK_EQUAL(s.FindAndDelete(d), 1);
-    BOOST_CHECK(s == expect);
+    FAST_CHECK_EQUAL(s.FindAndDelete(d), 1);
+    FAST_CHECK(s == expect);
 
     s = CScript() << OP_3 << OP_1 << OP_3 << OP_3 << OP_4 << OP_3;
     d = CScript() << OP_3;
     expect = CScript() << OP_1 << OP_4;
-    BOOST_CHECK_EQUAL(s.FindAndDelete(d), 4);
-    BOOST_CHECK(s == expect);
+    FAST_CHECK_EQUAL(s.FindAndDelete(d), 4);
+    FAST_CHECK(s == expect);
 
     s = ScriptFromHex("0302ff03"); // PUSH 0x02ff03 onto stack
     d = ScriptFromHex("0302ff03");
     expect = CScript();
-    BOOST_CHECK_EQUAL(s.FindAndDelete(d), 1);
-    BOOST_CHECK(s == expect);
+    FAST_CHECK_EQUAL(s.FindAndDelete(d), 1);
+    FAST_CHECK(s == expect);
 
     s = ScriptFromHex("0302ff030302ff03"); // PUSH 0x2ff03 PUSH 0x2ff03
     d = ScriptFromHex("0302ff03");
     expect = CScript();
-    BOOST_CHECK_EQUAL(s.FindAndDelete(d), 2);
-    BOOST_CHECK(s == expect);
+    FAST_CHECK_EQUAL(s.FindAndDelete(d), 2);
+    FAST_CHECK(s == expect);
 
     s = ScriptFromHex("0302ff030302ff03");
     d = ScriptFromHex("02");
     expect = s; // FindAndDelete matches entire opcodes
-    BOOST_CHECK_EQUAL(s.FindAndDelete(d), 0);
-    BOOST_CHECK(s == expect);
+    FAST_CHECK_EQUAL(s.FindAndDelete(d), 0);
+    FAST_CHECK(s == expect);
 
     s = ScriptFromHex("0302ff030302ff03");
     d = ScriptFromHex("ff");
     expect = s;
-    BOOST_CHECK_EQUAL(s.FindAndDelete(d), 0);
-    BOOST_CHECK(s == expect);
+    FAST_CHECK_EQUAL(s.FindAndDelete(d), 0);
+    FAST_CHECK(s == expect);
 
     // This is an odd edge case: strip of the push-three-bytes
     // prefix, leaving 02ff03 which is push-two-bytes:
     s = ScriptFromHex("0302ff030302ff03");
     d = ScriptFromHex("03");
     expect = CScript() << ParseHex("ff03") << ParseHex("ff03");
-    BOOST_CHECK_EQUAL(s.FindAndDelete(d), 2);
-    BOOST_CHECK(s == expect);
+    FAST_CHECK_EQUAL(s.FindAndDelete(d), 2);
+    FAST_CHECK(s == expect);
 
     // Byte sequence that spans multiple opcodes:
     s = ScriptFromHex("02feed5169"); // PUSH(0xfeed) OP_1 OP_VERIFY
     d = ScriptFromHex("feed51");
     expect = s;
-    BOOST_CHECK_EQUAL(s.FindAndDelete(d), 0); // doesn't match 'inside' opcodes
-    BOOST_CHECK(s == expect);
+    FAST_CHECK_EQUAL(s.FindAndDelete(d), 0); // doesn't match 'inside' opcodes
+    FAST_CHECK(s == expect);
 
     s = ScriptFromHex("02feed5169"); // PUSH(0xfeed) OP_1 OP_VERIFY
     d = ScriptFromHex("02feed51");
     expect = ScriptFromHex("69");
-    BOOST_CHECK_EQUAL(s.FindAndDelete(d), 1);
-    BOOST_CHECK(s == expect);
+    FAST_CHECK_EQUAL(s.FindAndDelete(d), 1);
+    FAST_CHECK(s == expect);
 
     s = ScriptFromHex("516902feed5169");
     d = ScriptFromHex("feed51");
     expect = s;
-    BOOST_CHECK_EQUAL(s.FindAndDelete(d), 0);
-    BOOST_CHECK(s == expect);
+    FAST_CHECK_EQUAL(s.FindAndDelete(d), 0);
+    FAST_CHECK(s == expect);
 
     s = ScriptFromHex("516902feed5169");
     d = ScriptFromHex("02feed51");
     expect = ScriptFromHex("516969");
-    BOOST_CHECK_EQUAL(s.FindAndDelete(d), 1);
-    BOOST_CHECK(s == expect);
+    FAST_CHECK_EQUAL(s.FindAndDelete(d), 1);
+    FAST_CHECK(s == expect);
 
     s = CScript() << OP_0 << OP_0 << OP_1 << OP_1;
     d = CScript() << OP_0 << OP_1;
     expect = CScript() << OP_0 << OP_1; // FindAndDelete is single-pass
-    BOOST_CHECK_EQUAL(s.FindAndDelete(d), 1);
-    BOOST_CHECK(s == expect);
+    FAST_CHECK_EQUAL(s.FindAndDelete(d), 1);
+    FAST_CHECK(s == expect);
 
     s = CScript() << OP_0 << OP_0 << OP_1 << OP_0 << OP_1 << OP_1;
     d = CScript() << OP_0 << OP_1;
     expect = CScript() << OP_0 << OP_1; // FindAndDelete is single-pass
-    BOOST_CHECK_EQUAL(s.FindAndDelete(d), 2);
-    BOOST_CHECK(s == expect);
+    FAST_CHECK_EQUAL(s.FindAndDelete(d), 2);
+    FAST_CHECK(s == expect);
 
     // Another weird edge case:
     // End with invalid push (not enough data)...
     s = ScriptFromHex("0003feed");
     d = ScriptFromHex("03feed"); // ... can remove the invalid push
     expect = ScriptFromHex("00");
-    BOOST_CHECK_EQUAL(s.FindAndDelete(d), 1);
-    BOOST_CHECK(s == expect);
+    FAST_CHECK_EQUAL(s.FindAndDelete(d), 1);
+    FAST_CHECK(s == expect);
 
     s = ScriptFromHex("0003feed");
     d = ScriptFromHex("00");
     expect = ScriptFromHex("03feed");
-    BOOST_CHECK_EQUAL(s.FindAndDelete(d), 1);
-    BOOST_CHECK(s == expect);
+    FAST_CHECK_EQUAL(s.FindAndDelete(d), 1);
+    FAST_CHECK(s == expect);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/scriptnum_tests.cpp
+++ b/src/test/scriptnum_tests.cpp
@@ -25,28 +25,28 @@ static void CheckCreateVch(const int64_t& num)
 {
     CScriptNum10 bignum(num);
     CScriptNum scriptnum(num);
-    BOOST_CHECK(verify(bignum, scriptnum));
+    FAST_CHECK(verify(bignum, scriptnum));
 
     std::vector<unsigned char> vch = bignum.getvch();
 
     CScriptNum10 bignum2(bignum.getvch(), false);
     vch = scriptnum.getvch();
     CScriptNum scriptnum2(scriptnum.getvch(), false);
-    BOOST_CHECK(verify(bignum2, scriptnum2));
+    FAST_CHECK(verify(bignum2, scriptnum2));
 
     CScriptNum10 bignum3(scriptnum2.getvch(), false);
     CScriptNum scriptnum3(bignum2.getvch(), false);
-    BOOST_CHECK(verify(bignum3, scriptnum3));
+    FAST_CHECK(verify(bignum3, scriptnum3));
 }
 
 static void CheckCreateInt(const int64_t& num)
 {
     CScriptNum10 bignum(num);
     CScriptNum scriptnum(num);
-    BOOST_CHECK(verify(bignum, scriptnum));
-    BOOST_CHECK(verify(CScriptNum10(bignum.getint()), CScriptNum(scriptnum.getint())));
-    BOOST_CHECK(verify(CScriptNum10(scriptnum.getint()), CScriptNum(bignum.getint())));
-    BOOST_CHECK(verify(CScriptNum10(CScriptNum10(scriptnum.getint()).getint()), CScriptNum(CScriptNum(bignum.getint()).getint())));
+    FAST_CHECK(verify(bignum, scriptnum));
+    FAST_CHECK(verify(CScriptNum10(bignum.getint()), CScriptNum(scriptnum.getint())));
+    FAST_CHECK(verify(CScriptNum10(scriptnum.getint()), CScriptNum(bignum.getint())));
+    FAST_CHECK(verify(CScriptNum10(CScriptNum10(scriptnum.getint()).getint()), CScriptNum(CScriptNum(bignum.getint()).getint())));
 }
 
 
@@ -66,9 +66,9 @@ static void CheckAdd(const int64_t& num1, const int64_t& num2)
                     ((num2 < 0) && (num1 < (std::numeric_limits<int64_t>::min() - num2))));
     if (!invalid)
     {
-        BOOST_CHECK(verify(bignum1 + bignum2, scriptnum1 + scriptnum2));
-        BOOST_CHECK(verify(bignum1 + bignum2, scriptnum1 + num2));
-        BOOST_CHECK(verify(bignum1 + bignum2, scriptnum2 + num1));
+        FAST_CHECK(verify(bignum1 + bignum2, scriptnum1 + scriptnum2));
+        FAST_CHECK(verify(bignum1 + bignum2, scriptnum1 + num2));
+        FAST_CHECK(verify(bignum1 + bignum2, scriptnum2 + num1));
     }
 }
 
@@ -79,7 +79,7 @@ static void CheckNegate(const int64_t& num)
 
     // -INT64_MIN is undefined
     if (num != std::numeric_limits<int64_t>::min())
-        BOOST_CHECK(verify(-bignum, -scriptnum));
+        FAST_CHECK(verify(-bignum, -scriptnum));
 }
 
 static void CheckSubtract(const int64_t& num1, const int64_t& num2)
@@ -95,16 +95,16 @@ static void CheckSubtract(const int64_t& num1, const int64_t& num2)
                (num2 < 0 && num1 > std::numeric_limits<int64_t>::max() + num2));
     if (!invalid)
     {
-        BOOST_CHECK(verify(bignum1 - bignum2, scriptnum1 - scriptnum2));
-        BOOST_CHECK(verify(bignum1 - bignum2, scriptnum1 - num2));
+        FAST_CHECK(verify(bignum1 - bignum2, scriptnum1 - scriptnum2));
+        FAST_CHECK(verify(bignum1 - bignum2, scriptnum1 - num2));
     }
 
     invalid = ((num1 > 0 && num2 < std::numeric_limits<int64_t>::min() + num1) ||
                (num1 < 0 && num2 > std::numeric_limits<int64_t>::max() + num1));
     if (!invalid)
     {
-        BOOST_CHECK(verify(bignum2 - bignum1, scriptnum2 - scriptnum1));
-        BOOST_CHECK(verify(bignum2 - bignum1, scriptnum2 - num1));
+        FAST_CHECK(verify(bignum2 - bignum1, scriptnum2 - scriptnum1));
+        FAST_CHECK(verify(bignum2 - bignum1, scriptnum2 - num1));
     }
 }
 
@@ -115,33 +115,33 @@ static void CheckCompare(const int64_t& num1, const int64_t& num2)
     const CScriptNum scriptnum1(num1);
     const CScriptNum scriptnum2(num2);
 
-    BOOST_CHECK((bignum1 == bignum1) == (scriptnum1 == scriptnum1));
-    BOOST_CHECK((bignum1 != bignum1) ==  (scriptnum1 != scriptnum1));
-    BOOST_CHECK((bignum1 < bignum1) ==  (scriptnum1 < scriptnum1));
-    BOOST_CHECK((bignum1 > bignum1) ==  (scriptnum1 > scriptnum1));
-    BOOST_CHECK((bignum1 >= bignum1) ==  (scriptnum1 >= scriptnum1));
-    BOOST_CHECK((bignum1 <= bignum1) ==  (scriptnum1 <= scriptnum1));
+    FAST_CHECK((bignum1 == bignum1) == (scriptnum1 == scriptnum1));
+    FAST_CHECK((bignum1 != bignum1) ==  (scriptnum1 != scriptnum1));
+    FAST_CHECK((bignum1 < bignum1) ==  (scriptnum1 < scriptnum1));
+    FAST_CHECK((bignum1 > bignum1) ==  (scriptnum1 > scriptnum1));
+    FAST_CHECK((bignum1 >= bignum1) ==  (scriptnum1 >= scriptnum1));
+    FAST_CHECK((bignum1 <= bignum1) ==  (scriptnum1 <= scriptnum1));
 
-    BOOST_CHECK((bignum1 == bignum1) == (scriptnum1 == num1));
-    BOOST_CHECK((bignum1 != bignum1) ==  (scriptnum1 != num1));
-    BOOST_CHECK((bignum1 < bignum1) ==  (scriptnum1 < num1));
-    BOOST_CHECK((bignum1 > bignum1) ==  (scriptnum1 > num1));
-    BOOST_CHECK((bignum1 >= bignum1) ==  (scriptnum1 >= num1));
-    BOOST_CHECK((bignum1 <= bignum1) ==  (scriptnum1 <= num1));
+    FAST_CHECK((bignum1 == bignum1) == (scriptnum1 == num1));
+    FAST_CHECK((bignum1 != bignum1) ==  (scriptnum1 != num1));
+    FAST_CHECK((bignum1 < bignum1) ==  (scriptnum1 < num1));
+    FAST_CHECK((bignum1 > bignum1) ==  (scriptnum1 > num1));
+    FAST_CHECK((bignum1 >= bignum1) ==  (scriptnum1 >= num1));
+    FAST_CHECK((bignum1 <= bignum1) ==  (scriptnum1 <= num1));
 
-    BOOST_CHECK((bignum1 == bignum2) ==  (scriptnum1 == scriptnum2));
-    BOOST_CHECK((bignum1 != bignum2) ==  (scriptnum1 != scriptnum2));
-    BOOST_CHECK((bignum1 < bignum2) ==  (scriptnum1 < scriptnum2));
-    BOOST_CHECK((bignum1 > bignum2) ==  (scriptnum1 > scriptnum2));
-    BOOST_CHECK((bignum1 >= bignum2) ==  (scriptnum1 >= scriptnum2));
-    BOOST_CHECK((bignum1 <= bignum2) ==  (scriptnum1 <= scriptnum2));
+    FAST_CHECK((bignum1 == bignum2) ==  (scriptnum1 == scriptnum2));
+    FAST_CHECK((bignum1 != bignum2) ==  (scriptnum1 != scriptnum2));
+    FAST_CHECK((bignum1 < bignum2) ==  (scriptnum1 < scriptnum2));
+    FAST_CHECK((bignum1 > bignum2) ==  (scriptnum1 > scriptnum2));
+    FAST_CHECK((bignum1 >= bignum2) ==  (scriptnum1 >= scriptnum2));
+    FAST_CHECK((bignum1 <= bignum2) ==  (scriptnum1 <= scriptnum2));
 
-    BOOST_CHECK((bignum1 == bignum2) ==  (scriptnum1 == num2));
-    BOOST_CHECK((bignum1 != bignum2) ==  (scriptnum1 != num2));
-    BOOST_CHECK((bignum1 < bignum2) ==  (scriptnum1 < num2));
-    BOOST_CHECK((bignum1 > bignum2) ==  (scriptnum1 > num2));
-    BOOST_CHECK((bignum1 >= bignum2) ==  (scriptnum1 >= num2));
-    BOOST_CHECK((bignum1 <= bignum2) ==  (scriptnum1 <= num2));
+    FAST_CHECK((bignum1 == bignum2) ==  (scriptnum1 == num2));
+    FAST_CHECK((bignum1 != bignum2) ==  (scriptnum1 != num2));
+    FAST_CHECK((bignum1 < bignum2) ==  (scriptnum1 < num2));
+    FAST_CHECK((bignum1 > bignum2) ==  (scriptnum1 > num2));
+    FAST_CHECK((bignum1 >= bignum2) ==  (scriptnum1 >= num2));
+    FAST_CHECK((bignum1 <= bignum2) ==  (scriptnum1 <= num2));
 }
 
 static void RunCreate(const int64_t& num)
@@ -152,7 +152,7 @@ static void RunCreate(const int64_t& num)
         CheckCreateVch(num);
     else
     {
-        BOOST_CHECK_THROW (CheckCreateVch(num), scriptnum10_error);
+        FAST_CHECK_THROW (CheckCreateVch(num), scriptnum10_error);
     }
 }
 

--- a/src/test/serialize_tests.cpp
+++ b/src/test/serialize_tests.cpp
@@ -17,71 +17,71 @@ BOOST_FIXTURE_TEST_SUITE(serialize_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(sizes)
 {
-    BOOST_CHECK_EQUAL(sizeof(char), GetSerializeSize(char(0), 0));
-    BOOST_CHECK_EQUAL(sizeof(int8_t), GetSerializeSize(int8_t(0), 0));
-    BOOST_CHECK_EQUAL(sizeof(uint8_t), GetSerializeSize(uint8_t(0), 0));
-    BOOST_CHECK_EQUAL(sizeof(int16_t), GetSerializeSize(int16_t(0), 0));
-    BOOST_CHECK_EQUAL(sizeof(uint16_t), GetSerializeSize(uint16_t(0), 0));
-    BOOST_CHECK_EQUAL(sizeof(int32_t), GetSerializeSize(int32_t(0), 0));
-    BOOST_CHECK_EQUAL(sizeof(uint32_t), GetSerializeSize(uint32_t(0), 0));
-    BOOST_CHECK_EQUAL(sizeof(int64_t), GetSerializeSize(int64_t(0), 0));
-    BOOST_CHECK_EQUAL(sizeof(uint64_t), GetSerializeSize(uint64_t(0), 0));
-    BOOST_CHECK_EQUAL(sizeof(float), GetSerializeSize(float(0), 0));
-    BOOST_CHECK_EQUAL(sizeof(double), GetSerializeSize(double(0), 0));
+    FAST_CHECK_EQUAL(sizeof(char), GetSerializeSize(char(0), 0));
+    FAST_CHECK_EQUAL(sizeof(int8_t), GetSerializeSize(int8_t(0), 0));
+    FAST_CHECK_EQUAL(sizeof(uint8_t), GetSerializeSize(uint8_t(0), 0));
+    FAST_CHECK_EQUAL(sizeof(int16_t), GetSerializeSize(int16_t(0), 0));
+    FAST_CHECK_EQUAL(sizeof(uint16_t), GetSerializeSize(uint16_t(0), 0));
+    FAST_CHECK_EQUAL(sizeof(int32_t), GetSerializeSize(int32_t(0), 0));
+    FAST_CHECK_EQUAL(sizeof(uint32_t), GetSerializeSize(uint32_t(0), 0));
+    FAST_CHECK_EQUAL(sizeof(int64_t), GetSerializeSize(int64_t(0), 0));
+    FAST_CHECK_EQUAL(sizeof(uint64_t), GetSerializeSize(uint64_t(0), 0));
+    FAST_CHECK_EQUAL(sizeof(float), GetSerializeSize(float(0), 0));
+    FAST_CHECK_EQUAL(sizeof(double), GetSerializeSize(double(0), 0));
     // Bool is serialized as char
-    BOOST_CHECK_EQUAL(sizeof(char), GetSerializeSize(bool(0), 0));
+    FAST_CHECK_EQUAL(sizeof(char), GetSerializeSize(bool(0), 0));
 
     // Sanity-check GetSerializeSize and c++ type matching
-    BOOST_CHECK_EQUAL(GetSerializeSize(char(0), 0), 1);
-    BOOST_CHECK_EQUAL(GetSerializeSize(int8_t(0), 0), 1);
-    BOOST_CHECK_EQUAL(GetSerializeSize(uint8_t(0), 0), 1);
-    BOOST_CHECK_EQUAL(GetSerializeSize(int16_t(0), 0), 2);
-    BOOST_CHECK_EQUAL(GetSerializeSize(uint16_t(0), 0), 2);
-    BOOST_CHECK_EQUAL(GetSerializeSize(int32_t(0), 0), 4);
-    BOOST_CHECK_EQUAL(GetSerializeSize(uint32_t(0), 0), 4);
-    BOOST_CHECK_EQUAL(GetSerializeSize(int64_t(0), 0), 8);
-    BOOST_CHECK_EQUAL(GetSerializeSize(uint64_t(0), 0), 8);
-    BOOST_CHECK_EQUAL(GetSerializeSize(float(0), 0), 4);
-    BOOST_CHECK_EQUAL(GetSerializeSize(double(0), 0), 8);
-    BOOST_CHECK_EQUAL(GetSerializeSize(bool(0), 0), 1);
+    FAST_CHECK_EQUAL(GetSerializeSize(char(0), 0), 1);
+    FAST_CHECK_EQUAL(GetSerializeSize(int8_t(0), 0), 1);
+    FAST_CHECK_EQUAL(GetSerializeSize(uint8_t(0), 0), 1);
+    FAST_CHECK_EQUAL(GetSerializeSize(int16_t(0), 0), 2);
+    FAST_CHECK_EQUAL(GetSerializeSize(uint16_t(0), 0), 2);
+    FAST_CHECK_EQUAL(GetSerializeSize(int32_t(0), 0), 4);
+    FAST_CHECK_EQUAL(GetSerializeSize(uint32_t(0), 0), 4);
+    FAST_CHECK_EQUAL(GetSerializeSize(int64_t(0), 0), 8);
+    FAST_CHECK_EQUAL(GetSerializeSize(uint64_t(0), 0), 8);
+    FAST_CHECK_EQUAL(GetSerializeSize(float(0), 0), 4);
+    FAST_CHECK_EQUAL(GetSerializeSize(double(0), 0), 8);
+    FAST_CHECK_EQUAL(GetSerializeSize(bool(0), 0), 1);
 }
 
 BOOST_AUTO_TEST_CASE(floats_conversion)
 {
     // Choose values that map unambigiously to binary floating point to avoid
     // rounding issues at the compiler side.
-    BOOST_CHECK_EQUAL(ser_uint32_to_float(0x00000000), 0.0F);
-    BOOST_CHECK_EQUAL(ser_uint32_to_float(0x3f000000), 0.5F);
-    BOOST_CHECK_EQUAL(ser_uint32_to_float(0x3f800000), 1.0F);
-    BOOST_CHECK_EQUAL(ser_uint32_to_float(0x40000000), 2.0F);
-    BOOST_CHECK_EQUAL(ser_uint32_to_float(0x40800000), 4.0F);
-    BOOST_CHECK_EQUAL(ser_uint32_to_float(0x44444444), 785.066650390625F);
+    FAST_CHECK_EQUAL(ser_uint32_to_float(0x00000000), 0.0F);
+    FAST_CHECK_EQUAL(ser_uint32_to_float(0x3f000000), 0.5F);
+    FAST_CHECK_EQUAL(ser_uint32_to_float(0x3f800000), 1.0F);
+    FAST_CHECK_EQUAL(ser_uint32_to_float(0x40000000), 2.0F);
+    FAST_CHECK_EQUAL(ser_uint32_to_float(0x40800000), 4.0F);
+    FAST_CHECK_EQUAL(ser_uint32_to_float(0x44444444), 785.066650390625F);
 
-    BOOST_CHECK_EQUAL(ser_float_to_uint32(0.0F), 0x00000000);
-    BOOST_CHECK_EQUAL(ser_float_to_uint32(0.5F), 0x3f000000);
-    BOOST_CHECK_EQUAL(ser_float_to_uint32(1.0F), 0x3f800000);
-    BOOST_CHECK_EQUAL(ser_float_to_uint32(2.0F), 0x40000000);
-    BOOST_CHECK_EQUAL(ser_float_to_uint32(4.0F), 0x40800000);
-    BOOST_CHECK_EQUAL(ser_float_to_uint32(785.066650390625F), 0x44444444);
+    FAST_CHECK_EQUAL(ser_float_to_uint32(0.0F), 0x00000000);
+    FAST_CHECK_EQUAL(ser_float_to_uint32(0.5F), 0x3f000000);
+    FAST_CHECK_EQUAL(ser_float_to_uint32(1.0F), 0x3f800000);
+    FAST_CHECK_EQUAL(ser_float_to_uint32(2.0F), 0x40000000);
+    FAST_CHECK_EQUAL(ser_float_to_uint32(4.0F), 0x40800000);
+    FAST_CHECK_EQUAL(ser_float_to_uint32(785.066650390625F), 0x44444444);
 }
 
 BOOST_AUTO_TEST_CASE(doubles_conversion)
 {
     // Choose values that map unambigiously to binary floating point to avoid
     // rounding issues at the compiler side.
-    BOOST_CHECK_EQUAL(ser_uint64_to_double(0x0000000000000000ULL), 0.0);
-    BOOST_CHECK_EQUAL(ser_uint64_to_double(0x3fe0000000000000ULL), 0.5);
-    BOOST_CHECK_EQUAL(ser_uint64_to_double(0x3ff0000000000000ULL), 1.0);
-    BOOST_CHECK_EQUAL(ser_uint64_to_double(0x4000000000000000ULL), 2.0);
-    BOOST_CHECK_EQUAL(ser_uint64_to_double(0x4010000000000000ULL), 4.0);
-    BOOST_CHECK_EQUAL(ser_uint64_to_double(0x4088888880000000ULL), 785.066650390625);
+    FAST_CHECK_EQUAL(ser_uint64_to_double(0x0000000000000000ULL), 0.0);
+    FAST_CHECK_EQUAL(ser_uint64_to_double(0x3fe0000000000000ULL), 0.5);
+    FAST_CHECK_EQUAL(ser_uint64_to_double(0x3ff0000000000000ULL), 1.0);
+    FAST_CHECK_EQUAL(ser_uint64_to_double(0x4000000000000000ULL), 2.0);
+    FAST_CHECK_EQUAL(ser_uint64_to_double(0x4010000000000000ULL), 4.0);
+    FAST_CHECK_EQUAL(ser_uint64_to_double(0x4088888880000000ULL), 785.066650390625);
 
-    BOOST_CHECK_EQUAL(ser_double_to_uint64(0.0), 0x0000000000000000ULL);
-    BOOST_CHECK_EQUAL(ser_double_to_uint64(0.5), 0x3fe0000000000000ULL);
-    BOOST_CHECK_EQUAL(ser_double_to_uint64(1.0), 0x3ff0000000000000ULL);
-    BOOST_CHECK_EQUAL(ser_double_to_uint64(2.0), 0x4000000000000000ULL);
-    BOOST_CHECK_EQUAL(ser_double_to_uint64(4.0), 0x4010000000000000ULL);
-    BOOST_CHECK_EQUAL(ser_double_to_uint64(785.066650390625), 0x4088888880000000ULL);
+    FAST_CHECK_EQUAL(ser_double_to_uint64(0.0), 0x0000000000000000ULL);
+    FAST_CHECK_EQUAL(ser_double_to_uint64(0.5), 0x3fe0000000000000ULL);
+    FAST_CHECK_EQUAL(ser_double_to_uint64(1.0), 0x3ff0000000000000ULL);
+    FAST_CHECK_EQUAL(ser_double_to_uint64(2.0), 0x4000000000000000ULL);
+    FAST_CHECK_EQUAL(ser_double_to_uint64(4.0), 0x4010000000000000ULL);
+    FAST_CHECK_EQUAL(ser_double_to_uint64(785.066650390625), 0x4088888880000000ULL);
 }
 /*
 Python code to generate the below hashes:
@@ -101,7 +101,7 @@ BOOST_AUTO_TEST_CASE(floats)
     for (int i = 0; i < 1000; i++) {
         ss << float(i);
     }
-    BOOST_CHECK(Hash(ss.begin(), ss.end()) == uint256S("8e8b4cf3e4df8b332057e3e23af42ebc663b61e0495d5e7e32d85099d7f3fe0c"));
+    FAST_CHECK(Hash(ss.begin(), ss.end()) == uint256S("8e8b4cf3e4df8b332057e3e23af42ebc663b61e0495d5e7e32d85099d7f3fe0c"));
 
     // decode
     for (int i = 0; i < 1000; i++) {
@@ -118,7 +118,7 @@ BOOST_AUTO_TEST_CASE(doubles)
     for (int i = 0; i < 1000; i++) {
         ss << double(i);
     }
-    BOOST_CHECK(Hash(ss.begin(), ss.end()) == uint256S("43d0c82591953c4eafe114590d392676a01585d25b25d433557f0d7878b23f96"));
+    FAST_CHECK(Hash(ss.begin(), ss.end()) == uint256S("43d0c82591953c4eafe114590d392676a01585d25b25d433557f0d7878b23f96"));
 
     // decode
     for (int i = 0; i < 1000; i++) {
@@ -137,13 +137,13 @@ BOOST_AUTO_TEST_CASE(varints)
     for (int i = 0; i < 100000; i++) {
         ss << VARINT(i);
         size += ::GetSerializeSize(VARINT(i), 0, 0);
-        BOOST_CHECK(size == ss.size());
+        FAST_CHECK(size == ss.size());
     }
 
     for (uint64_t i = 0;  i < 100000000000ULL; i += 999999937) {
         ss << VARINT(i);
         size += ::GetSerializeSize(VARINT(i), 0, 0);
-        BOOST_CHECK(size == ss.size());
+        FAST_CHECK(size == ss.size());
     }
 
     // decode
@@ -163,22 +163,22 @@ BOOST_AUTO_TEST_CASE(varints)
 BOOST_AUTO_TEST_CASE(varints_bitpatterns)
 {
     CDataStream ss(SER_DISK, 0);
-    ss << VARINT(0); BOOST_CHECK_EQUAL(HexStr(ss), "00"); ss.clear();
-    ss << VARINT(0x7f); BOOST_CHECK_EQUAL(HexStr(ss), "7f"); ss.clear();
-    ss << VARINT((int8_t)0x7f); BOOST_CHECK_EQUAL(HexStr(ss), "7f"); ss.clear();
-    ss << VARINT(0x80); BOOST_CHECK_EQUAL(HexStr(ss), "8000"); ss.clear();
-    ss << VARINT((uint8_t)0x80); BOOST_CHECK_EQUAL(HexStr(ss), "8000"); ss.clear();
-    ss << VARINT(0x1234); BOOST_CHECK_EQUAL(HexStr(ss), "a334"); ss.clear();
-    ss << VARINT((int16_t)0x1234); BOOST_CHECK_EQUAL(HexStr(ss), "a334"); ss.clear();
-    ss << VARINT(0xffff); BOOST_CHECK_EQUAL(HexStr(ss), "82fe7f"); ss.clear();
-    ss << VARINT((uint16_t)0xffff); BOOST_CHECK_EQUAL(HexStr(ss), "82fe7f"); ss.clear();
-    ss << VARINT(0x123456); BOOST_CHECK_EQUAL(HexStr(ss), "c7e756"); ss.clear();
-    ss << VARINT((int32_t)0x123456); BOOST_CHECK_EQUAL(HexStr(ss), "c7e756"); ss.clear();
-    ss << VARINT(0x80123456U); BOOST_CHECK_EQUAL(HexStr(ss), "86ffc7e756"); ss.clear();
-    ss << VARINT((uint32_t)0x80123456U); BOOST_CHECK_EQUAL(HexStr(ss), "86ffc7e756"); ss.clear();
-    ss << VARINT(0xffffffff); BOOST_CHECK_EQUAL(HexStr(ss), "8efefefe7f"); ss.clear();
-    ss << VARINT(0x7fffffffffffffffLL); BOOST_CHECK_EQUAL(HexStr(ss), "fefefefefefefefe7f"); ss.clear();
-    ss << VARINT(0xffffffffffffffffULL); BOOST_CHECK_EQUAL(HexStr(ss), "80fefefefefefefefe7f"); ss.clear();
+    ss << VARINT(0); FAST_CHECK_EQUAL(HexStr(ss), "00"); ss.clear();
+    ss << VARINT(0x7f); FAST_CHECK_EQUAL(HexStr(ss), "7f"); ss.clear();
+    ss << VARINT((int8_t)0x7f); FAST_CHECK_EQUAL(HexStr(ss), "7f"); ss.clear();
+    ss << VARINT(0x80); FAST_CHECK_EQUAL(HexStr(ss), "8000"); ss.clear();
+    ss << VARINT((uint8_t)0x80); FAST_CHECK_EQUAL(HexStr(ss), "8000"); ss.clear();
+    ss << VARINT(0x1234); FAST_CHECK_EQUAL(HexStr(ss), "a334"); ss.clear();
+    ss << VARINT((int16_t)0x1234); FAST_CHECK_EQUAL(HexStr(ss), "a334"); ss.clear();
+    ss << VARINT(0xffff); FAST_CHECK_EQUAL(HexStr(ss), "82fe7f"); ss.clear();
+    ss << VARINT((uint16_t)0xffff); FAST_CHECK_EQUAL(HexStr(ss), "82fe7f"); ss.clear();
+    ss << VARINT(0x123456); FAST_CHECK_EQUAL(HexStr(ss), "c7e756"); ss.clear();
+    ss << VARINT((int32_t)0x123456); FAST_CHECK_EQUAL(HexStr(ss), "c7e756"); ss.clear();
+    ss << VARINT(0x80123456U); FAST_CHECK_EQUAL(HexStr(ss), "86ffc7e756"); ss.clear();
+    ss << VARINT((uint32_t)0x80123456U); FAST_CHECK_EQUAL(HexStr(ss), "86ffc7e756"); ss.clear();
+    ss << VARINT(0xffffffff); FAST_CHECK_EQUAL(HexStr(ss), "8efefefe7f"); ss.clear();
+    ss << VARINT(0x7fffffffffffffffLL); FAST_CHECK_EQUAL(HexStr(ss), "fefefefefefefefe7f"); ss.clear();
+    ss << VARINT(0xffffffffffffffffULL); FAST_CHECK_EQUAL(HexStr(ss), "80fefefefefefefefe7f"); ss.clear();
 }
 
 BOOST_AUTO_TEST_CASE(compactsize)
@@ -221,80 +221,80 @@ BOOST_AUTO_TEST_CASE(noncanonical)
 
     // zero encoded with three bytes:
     ss.write("\xfd\x00\x00", 3);
-    BOOST_CHECK_EXCEPTION(ReadCompactSize(ss), std::ios_base::failure, isCanonicalException);
+    FAST_CHECK_EXCEPTION(ReadCompactSize(ss), std::ios_base::failure, isCanonicalException);
 
     // 0xfc encoded with three bytes:
     ss.write("\xfd\xfc\x00", 3);
-    BOOST_CHECK_EXCEPTION(ReadCompactSize(ss), std::ios_base::failure, isCanonicalException);
+    FAST_CHECK_EXCEPTION(ReadCompactSize(ss), std::ios_base::failure, isCanonicalException);
 
     // 0xfd encoded with three bytes is OK:
     ss.write("\xfd\xfd\x00", 3);
     n = ReadCompactSize(ss);
-    BOOST_CHECK(n == 0xfd);
+    FAST_CHECK(n == 0xfd);
 
     // zero encoded with five bytes:
     ss.write("\xfe\x00\x00\x00\x00", 5);
-    BOOST_CHECK_EXCEPTION(ReadCompactSize(ss), std::ios_base::failure, isCanonicalException);
+    FAST_CHECK_EXCEPTION(ReadCompactSize(ss), std::ios_base::failure, isCanonicalException);
 
     // 0xffff encoded with five bytes:
     ss.write("\xfe\xff\xff\x00\x00", 5);
-    BOOST_CHECK_EXCEPTION(ReadCompactSize(ss), std::ios_base::failure, isCanonicalException);
+    FAST_CHECK_EXCEPTION(ReadCompactSize(ss), std::ios_base::failure, isCanonicalException);
 
     // zero encoded with nine bytes:
     ss.write("\xff\x00\x00\x00\x00\x00\x00\x00\x00", 9);
-    BOOST_CHECK_EXCEPTION(ReadCompactSize(ss), std::ios_base::failure, isCanonicalException);
+    FAST_CHECK_EXCEPTION(ReadCompactSize(ss), std::ios_base::failure, isCanonicalException);
 
     // 0x01ffffff encoded with nine bytes:
     ss.write("\xff\xff\xff\xff\x01\x00\x00\x00\x00", 9);
-    BOOST_CHECK_EXCEPTION(ReadCompactSize(ss), std::ios_base::failure, isCanonicalException);
+    FAST_CHECK_EXCEPTION(ReadCompactSize(ss), std::ios_base::failure, isCanonicalException);
 }
 
 BOOST_AUTO_TEST_CASE(insert_delete)
 {
     // Test inserting/deleting bytes.
     CDataStream ss(SER_DISK, 0);
-    BOOST_CHECK_EQUAL(ss.size(), 0);
+    FAST_CHECK_EQUAL(ss.size(), 0);
 
     ss.write("\x00\x01\x02\xff", 4);
-    BOOST_CHECK_EQUAL(ss.size(), 4);
+    FAST_CHECK_EQUAL(ss.size(), 4);
 
     char c = (char)11;
 
     // Inserting at beginning/end/middle:
     ss.insert(ss.begin(), c);
-    BOOST_CHECK_EQUAL(ss.size(), 5);
-    BOOST_CHECK_EQUAL(ss[0], c);
-    BOOST_CHECK_EQUAL(ss[1], 0);
+    FAST_CHECK_EQUAL(ss.size(), 5);
+    FAST_CHECK_EQUAL(ss[0], c);
+    FAST_CHECK_EQUAL(ss[1], 0);
 
     ss.insert(ss.end(), c);
-    BOOST_CHECK_EQUAL(ss.size(), 6);
-    BOOST_CHECK_EQUAL(ss[4], (char)0xff);
-    BOOST_CHECK_EQUAL(ss[5], c);
+    FAST_CHECK_EQUAL(ss.size(), 6);
+    FAST_CHECK_EQUAL(ss[4], (char)0xff);
+    FAST_CHECK_EQUAL(ss[5], c);
 
     ss.insert(ss.begin()+2, c);
-    BOOST_CHECK_EQUAL(ss.size(), 7);
-    BOOST_CHECK_EQUAL(ss[2], c);
+    FAST_CHECK_EQUAL(ss.size(), 7);
+    FAST_CHECK_EQUAL(ss[2], c);
 
     // Delete at beginning/end/middle
     ss.erase(ss.begin());
-    BOOST_CHECK_EQUAL(ss.size(), 6);
-    BOOST_CHECK_EQUAL(ss[0], 0);
+    FAST_CHECK_EQUAL(ss.size(), 6);
+    FAST_CHECK_EQUAL(ss[0], 0);
 
     ss.erase(ss.begin()+ss.size()-1);
-    BOOST_CHECK_EQUAL(ss.size(), 5);
-    BOOST_CHECK_EQUAL(ss[4], (char)0xff);
+    FAST_CHECK_EQUAL(ss.size(), 5);
+    FAST_CHECK_EQUAL(ss[4], (char)0xff);
 
     ss.erase(ss.begin()+1);
-    BOOST_CHECK_EQUAL(ss.size(), 4);
-    BOOST_CHECK_EQUAL(ss[0], 0);
-    BOOST_CHECK_EQUAL(ss[1], 1);
-    BOOST_CHECK_EQUAL(ss[2], 2);
-    BOOST_CHECK_EQUAL(ss[3], (char)0xff);
+    FAST_CHECK_EQUAL(ss.size(), 4);
+    FAST_CHECK_EQUAL(ss[0], 0);
+    FAST_CHECK_EQUAL(ss[1], 1);
+    FAST_CHECK_EQUAL(ss[2], 2);
+    FAST_CHECK_EQUAL(ss[3], (char)0xff);
 
     // Make sure GetAndClear does the right thing:
     CSerializeData d;
     ss.GetAndClear(d);
-    BOOST_CHECK_EQUAL(ss.size(), 0);
+    FAST_CHECK_EQUAL(ss.size(), 0);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/sighash_tests.cpp
+++ b/src/test/sighash_tests.cpp
@@ -159,7 +159,7 @@ BOOST_AUTO_TEST_CASE(sighash_test)
         }
         std::cout << "\n";
         #endif
-        BOOST_CHECK(sh == sho);
+        FAST_CHECK(sh == sho);
     }
     #if defined(PRINT_SIGHASH_JSON)
     std::cout << "]\n";
@@ -200,7 +200,7 @@ BOOST_AUTO_TEST_CASE(sighash_from_data)
 
           CValidationState state;
           BOOST_CHECK_MESSAGE(CheckTransaction(tx, state), strTest);
-          BOOST_CHECK(state.IsValid());
+          FAST_CHECK(state.IsValid());
 
           std::vector<unsigned char> raw = ParseHex(raw_script);
           scriptCode.insert(scriptCode.end(), raw.begin(), raw.end());

--- a/src/test/sigopcount_tests.cpp
+++ b/src/test/sigopcount_tests.cpp
@@ -31,20 +31,20 @@ BOOST_AUTO_TEST_CASE(GetSigOpCount)
 {
     // Test CScript::GetSigOpCount()
     CScript s1;
-    BOOST_CHECK_EQUAL(s1.GetSigOpCount(false), 0U);
-    BOOST_CHECK_EQUAL(s1.GetSigOpCount(true), 0U);
+    FAST_CHECK_EQUAL(s1.GetSigOpCount(false), 0U);
+    FAST_CHECK_EQUAL(s1.GetSigOpCount(true), 0U);
 
     uint160 dummy;
     s1 << OP_1 << ToByteVector(dummy) << ToByteVector(dummy) << OP_2 << OP_CHECKMULTISIG;
-    BOOST_CHECK_EQUAL(s1.GetSigOpCount(true), 2U);
+    FAST_CHECK_EQUAL(s1.GetSigOpCount(true), 2U);
     s1 << OP_IF << OP_CHECKSIG << OP_ENDIF;
-    BOOST_CHECK_EQUAL(s1.GetSigOpCount(true), 3U);
-    BOOST_CHECK_EQUAL(s1.GetSigOpCount(false), 21U);
+    FAST_CHECK_EQUAL(s1.GetSigOpCount(true), 3U);
+    FAST_CHECK_EQUAL(s1.GetSigOpCount(false), 21U);
 
     CScript p2sh = GetScriptForDestination(CScriptID(s1));
     CScript scriptSig;
     scriptSig << OP_0 << Serialize(s1);
-    BOOST_CHECK_EQUAL(p2sh.GetSigOpCount(scriptSig), 3U);
+    FAST_CHECK_EQUAL(p2sh.GetSigOpCount(scriptSig), 3U);
 
     std::vector<CPubKey> keys;
     for (int i = 0; i < 3; i++)
@@ -54,15 +54,15 @@ BOOST_AUTO_TEST_CASE(GetSigOpCount)
         keys.push_back(k.GetPubKey());
     }
     CScript s2 = GetScriptForMultisig(1, keys);
-    BOOST_CHECK_EQUAL(s2.GetSigOpCount(true), 3U);
-    BOOST_CHECK_EQUAL(s2.GetSigOpCount(false), 20U);
+    FAST_CHECK_EQUAL(s2.GetSigOpCount(true), 3U);
+    FAST_CHECK_EQUAL(s2.GetSigOpCount(false), 20U);
 
     p2sh = GetScriptForDestination(CScriptID(s2));
-    BOOST_CHECK_EQUAL(p2sh.GetSigOpCount(true), 0U);
-    BOOST_CHECK_EQUAL(p2sh.GetSigOpCount(false), 0U);
+    FAST_CHECK_EQUAL(p2sh.GetSigOpCount(true), 0U);
+    FAST_CHECK_EQUAL(p2sh.GetSigOpCount(false), 0U);
     CScript scriptSig2;
     scriptSig2 << OP_1 << ToByteVector(dummy) << ToByteVector(dummy) << Serialize(s2);
-    BOOST_CHECK_EQUAL(p2sh.GetSigOpCount(scriptSig2), 3U);
+    FAST_CHECK_EQUAL(p2sh.GetSigOpCount(scriptSig2), 3U);
 }
 
 /**
@@ -74,7 +74,7 @@ ScriptError VerifyWithFlag(const CTransaction& output, const CMutableTransaction
     ScriptError error;
     CTransaction inputi(input);
     bool ret = VerifyScript(inputi.vin[0].scriptSig, output.vout[0].scriptPubKey, inputi.wit.vtxinwit.size() > 0 ? &inputi.wit.vtxinwit[0].scriptWitness : NULL, flags, TransactionSignatureChecker(&inputi, 0, output.vout[0].nValue), &error);
-    BOOST_CHECK((ret == true) == (error == SCRIPT_ERR_OK));
+    FAST_CHECK((ret == true) == (error == SCRIPT_ERR_OK));
 
     return error;
 }

--- a/src/test/skiplist_tests.cpp
+++ b/src/test/skiplist_tests.cpp
@@ -27,10 +27,10 @@ BOOST_AUTO_TEST_CASE(skiplist_test)
 
     for (int i=0; i<SKIPLIST_LENGTH; i++) {
         if (i > 0) {
-            BOOST_CHECK(vIndex[i].pskip == &vIndex[vIndex[i].pskip->nHeight]);
-            BOOST_CHECK(vIndex[i].pskip->nHeight < i);
+            FAST_CHECK(vIndex[i].pskip == &vIndex[vIndex[i].pskip->nHeight]);
+            FAST_CHECK(vIndex[i].pskip->nHeight < i);
         } else {
-            BOOST_CHECK(vIndex[i].pskip == NULL);
+            FAST_CHECK(vIndex[i].pskip == NULL);
         }
     }
 
@@ -38,9 +38,9 @@ BOOST_AUTO_TEST_CASE(skiplist_test)
         int from = insecure_rand() % (SKIPLIST_LENGTH - 1);
         int to = insecure_rand() % (from + 1);
 
-        BOOST_CHECK(vIndex[SKIPLIST_LENGTH - 1].GetAncestor(from) == &vIndex[from]);
-        BOOST_CHECK(vIndex[from].GetAncestor(to) == &vIndex[to]);
-        BOOST_CHECK(vIndex[from].GetAncestor(0) == &vIndex[0]);
+        FAST_CHECK(vIndex[SKIPLIST_LENGTH - 1].GetAncestor(from) == &vIndex[from]);
+        FAST_CHECK(vIndex[from].GetAncestor(to) == &vIndex[to]);
+        FAST_CHECK(vIndex[from].GetAncestor(0) == &vIndex[0]);
     }
 }
 
@@ -55,8 +55,8 @@ BOOST_AUTO_TEST_CASE(getlocator_test)
         vBlocksMain[i].pprev = i ? &vBlocksMain[i - 1] : NULL;
         vBlocksMain[i].phashBlock = &vHashMain[i];
         vBlocksMain[i].BuildSkip();
-        BOOST_CHECK_EQUAL((int)UintToArith256(vBlocksMain[i].GetBlockHash()).GetLow64(), vBlocksMain[i].nHeight);
-        BOOST_CHECK(vBlocksMain[i].pprev == NULL || vBlocksMain[i].nHeight == vBlocksMain[i].pprev->nHeight + 1);
+        FAST_CHECK_EQUAL((int)UintToArith256(vBlocksMain[i].GetBlockHash()).GetLow64(), vBlocksMain[i].nHeight);
+        FAST_CHECK(vBlocksMain[i].pprev == NULL || vBlocksMain[i].nHeight == vBlocksMain[i].pprev->nHeight + 1);
     }
 
     // Build a branch that splits off at block 49999, 50000 blocks long.
@@ -68,8 +68,8 @@ BOOST_AUTO_TEST_CASE(getlocator_test)
         vBlocksSide[i].pprev = i ? &vBlocksSide[i - 1] : &vBlocksMain[49999];
         vBlocksSide[i].phashBlock = &vHashSide[i];
         vBlocksSide[i].BuildSkip();
-        BOOST_CHECK_EQUAL((int)UintToArith256(vBlocksSide[i].GetBlockHash()).GetLow64(), vBlocksSide[i].nHeight);
-        BOOST_CHECK(vBlocksSide[i].pprev == NULL || vBlocksSide[i].nHeight == vBlocksSide[i].pprev->nHeight + 1);
+        FAST_CHECK_EQUAL((int)UintToArith256(vBlocksSide[i].GetBlockHash()).GetLow64(), vBlocksSide[i].nHeight);
+        FAST_CHECK(vBlocksSide[i].pprev == NULL || vBlocksSide[i].nHeight == vBlocksSide[i].pprev->nHeight + 1);
     }
 
     // Build a CChain for the main branch.
@@ -83,18 +83,18 @@ BOOST_AUTO_TEST_CASE(getlocator_test)
         CBlockLocator locator = chain.GetLocator(tip);
 
         // The first result must be the block itself, the last one must be genesis.
-        BOOST_CHECK(locator.vHave.front() == tip->GetBlockHash());
-        BOOST_CHECK(locator.vHave.back() == vBlocksMain[0].GetBlockHash());
+        FAST_CHECK(locator.vHave.front() == tip->GetBlockHash());
+        FAST_CHECK(locator.vHave.back() == vBlocksMain[0].GetBlockHash());
 
         // Entries 1 through 11 (inclusive) go back one step each.
         for (unsigned int i = 1; i < 12 && i < locator.vHave.size() - 1; i++) {
-            BOOST_CHECK_EQUAL(UintToArith256(locator.vHave[i]).GetLow64(), tip->nHeight - i);
+            FAST_CHECK_EQUAL(UintToArith256(locator.vHave[i]).GetLow64(), tip->nHeight - i);
         }
 
         // The further ones (excluding the last one) go back with exponential steps.
         unsigned int dist = 2;
         for (unsigned int i = 12; i < locator.vHave.size() - 1; i++) {
-            BOOST_CHECK_EQUAL(UintToArith256(locator.vHave[i - 1]).GetLow64() - UintToArith256(locator.vHave[i]).GetLow64(), dist);
+            FAST_CHECK_EQUAL(UintToArith256(locator.vHave[i - 1]).GetLow64() - UintToArith256(locator.vHave[i]).GetLow64(), dist);
             dist *= 2;
         }
     }

--- a/src/test/streams_tests.cpp
+++ b/src/test/streams_tests.cpp
@@ -26,7 +26,7 @@ BOOST_AUTO_TEST_CASE(streams_serializedata_xor)
     
     key += '\x00','\x00';
     ds.Xor(key);
-    BOOST_CHECK_EQUAL(
+    FAST_CHECK_EQUAL(
             std::string(expected_xor.begin(), expected_xor.end()), 
             std::string(ds.begin(), ds.end()));
 
@@ -41,7 +41,7 @@ BOOST_AUTO_TEST_CASE(streams_serializedata_xor)
 
     key += '\xff';
     ds.Xor(key);
-    BOOST_CHECK_EQUAL(
+    FAST_CHECK_EQUAL(
             std::string(expected_xor.begin(), expected_xor.end()), 
             std::string(ds.begin(), ds.end())); 
     
@@ -59,7 +59,7 @@ BOOST_AUTO_TEST_CASE(streams_serializedata_xor)
     key += '\xff','\x0f';
 
     ds.Xor(key);
-    BOOST_CHECK_EQUAL(
+    FAST_CHECK_EQUAL(
             std::string(expected_xor.begin(), expected_xor.end()), 
             std::string(ds.begin(), ds.end()));  
 }         

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -63,7 +63,7 @@ TestingSetup::TestingSetup(const std::string& chainName) : BasicTestingSetup(cha
         {
             CValidationState state;
             bool ok = ActivateBestChain(state, chainparams);
-            BOOST_CHECK(ok);
+            FAST_CHECK(ok);
         }
         nScriptCheckThreads = 3;
         for (int i=0; i < nScriptCheckThreads-1; i++)

--- a/src/test/test_bitcoin.h
+++ b/src/test/test_bitcoin.h
@@ -14,6 +14,13 @@
 #include <boost/filesystem.hpp>
 #include <boost/thread.hpp>
 
+#define FAST_CHECK(x) if (!(x)) { BOOST_CHECK_MESSAGE(false, #x); }
+#define FAST_CHECK_EQUAL(x, y) if ((x)!=(y)) { BOOST_CHECK_MESSAGE(false, "(" #x ") != (" #y ")"); }
+#define FAST_CHECK_THROW(expr, ex) try { expr; BOOST_CHECK_MESSAGE(false, "( " #expr " ) did not throw ( " #ex " )"); } catch( ex ) { }
+#define FAST_CHECK_NO_THROW(expr) try { expr;  } catch( ... ) {BOOST_CHECK_MESSAGE(false, "( " #expr " ) threw exception"); }
+#define FAST_CHECK_EXCEPTION(expr, ex, pred) try { expr; BOOST_CHECK_MESSAGE(false, "( " #expr " ) did not throw ( " #ex " )"); } catch( ex& a ) { if (!pred(a)) BOOST_CHECK_MESSAGE(false, "( " #expr " ) did not throw ( " #ex " ) under ( " #pred " )" ); }
+#define FAST_CHECK_EQUAL_COLLECTIONS(l, r, l1, r1) BOOST_CHECK_EQUAL_COLLECTIONS(l, r, l1, r1) 
+
 /** Basic testing setup.
  * This just configures logging and chain parameters.
  */

--- a/src/test/timedata_tests.cpp
+++ b/src/test/timedata_tests.cpp
@@ -15,25 +15,25 @@ BOOST_AUTO_TEST_CASE(util_MedianFilter)
 {
     CMedianFilter<int> filter(5, 15);
 
-    BOOST_CHECK_EQUAL(filter.median(), 15);
+    FAST_CHECK_EQUAL(filter.median(), 15);
 
     filter.input(20); // [15 20]
-    BOOST_CHECK_EQUAL(filter.median(), 17);
+    FAST_CHECK_EQUAL(filter.median(), 17);
 
     filter.input(30); // [15 20 30]
-    BOOST_CHECK_EQUAL(filter.median(), 20);
+    FAST_CHECK_EQUAL(filter.median(), 20);
 
     filter.input(3); // [3 15 20 30]
-    BOOST_CHECK_EQUAL(filter.median(), 17);
+    FAST_CHECK_EQUAL(filter.median(), 17);
 
     filter.input(7); // [3 7 15 20 30]
-    BOOST_CHECK_EQUAL(filter.median(), 15);
+    FAST_CHECK_EQUAL(filter.median(), 15);
 
     filter.input(18); // [3 7 18 20 30]
-    BOOST_CHECK_EQUAL(filter.median(), 18);
+    FAST_CHECK_EQUAL(filter.median(), 18);
 
     filter.input(0); // [0 3 7 18 30]
-    BOOST_CHECK_EQUAL(filter.median(), 7);
+    FAST_CHECK_EQUAL(filter.median(), 7);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -151,7 +151,7 @@ BOOST_AUTO_TEST_CASE(tx_valid)
 
             CValidationState state;
             BOOST_CHECK_MESSAGE(CheckTransaction(tx, state), strTest);
-            BOOST_CHECK(state.IsValid());
+            FAST_CHECK(state.IsValid());
 
             for (unsigned int i = 0; i < tx.vin.size(); i++)
             {
@@ -336,8 +336,8 @@ BOOST_AUTO_TEST_CASE(test_Get)
     t1.vout[0].nValue = 90*CENT;
     t1.vout[0].scriptPubKey << OP_1;
 
-    BOOST_CHECK(AreInputsStandard(t1, coins));
-    BOOST_CHECK_EQUAL(coins.GetValueIn(t1), (50+21+22)*CENT);
+    FAST_CHECK(AreInputsStandard(t1, coins));
+    FAST_CHECK_EQUAL(coins.GetValueIn(t1), (50+21+22)*CENT);
 }
 
 void CreateCreditAndSpend(const CKeyStore& keystore, const CScript& outscript, CTransaction& output, CMutableTransaction& input, bool success = true)
@@ -570,7 +570,7 @@ BOOST_AUTO_TEST_CASE(test_witness)
     CheckWithFlag(output1, input1, 0, false);
     CreateCreditAndSpend(keystore2, scriptMulti, output2, input2, false);
     CheckWithFlag(output2, input2, 0, false);
-    BOOST_CHECK(output1 == output2);
+    FAST_CHECK(output1 == output2);
     UpdateTransaction(input1, 0, CombineSignatures(output1.vout[0].scriptPubKey, MutableTransactionSignatureChecker(&input1, 0, output1.vout[0].nValue), DataFromTransaction(input1, 0), DataFromTransaction(input2, 0)));
     CheckWithFlag(output1, input1, STANDARD_SCRIPT_VERIFY_FLAGS, true);
 
@@ -581,7 +581,7 @@ BOOST_AUTO_TEST_CASE(test_witness)
     CreateCreditAndSpend(keystore2, GetScriptForDestination(CScriptID(scriptMulti)), output2, input2, false);
     CheckWithFlag(output2, input2, 0, true);
     CheckWithFlag(output2, input2, SCRIPT_VERIFY_P2SH, false);
-    BOOST_CHECK(output1 == output2);
+    FAST_CHECK(output1 == output2);
     UpdateTransaction(input1, 0, CombineSignatures(output1.vout[0].scriptPubKey, MutableTransactionSignatureChecker(&input1, 0, output1.vout[0].nValue), DataFromTransaction(input1, 0), DataFromTransaction(input2, 0)));
     CheckWithFlag(output1, input1, SCRIPT_VERIFY_P2SH, true);
     CheckWithFlag(output1, input1, STANDARD_SCRIPT_VERIFY_FLAGS, true);
@@ -593,7 +593,7 @@ BOOST_AUTO_TEST_CASE(test_witness)
     CreateCreditAndSpend(keystore2, GetScriptForWitness(scriptMulti), output2, input2, false);
     CheckWithFlag(output2, input2, 0, true);
     CheckWithFlag(output2, input2, SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS, false);
-    BOOST_CHECK(output1 == output2);
+    FAST_CHECK(output1 == output2);
     UpdateTransaction(input1, 0, CombineSignatures(output1.vout[0].scriptPubKey, MutableTransactionSignatureChecker(&input1, 0, output1.vout[0].nValue), DataFromTransaction(input1, 0), DataFromTransaction(input2, 0)));
     CheckWithFlag(output1, input1, SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS, true);
     CheckWithFlag(output1, input1, STANDARD_SCRIPT_VERIFY_FLAGS, true);
@@ -605,7 +605,7 @@ BOOST_AUTO_TEST_CASE(test_witness)
     CreateCreditAndSpend(keystore2, GetScriptForDestination(CScriptID(GetScriptForWitness(scriptMulti))), output2, input2, false);
     CheckWithFlag(output2, input2, SCRIPT_VERIFY_P2SH, true);
     CheckWithFlag(output2, input2, SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS, false);
-    BOOST_CHECK(output1 == output2);
+    FAST_CHECK(output1 == output2);
     UpdateTransaction(input1, 0, CombineSignatures(output1.vout[0].scriptPubKey, MutableTransactionSignatureChecker(&input1, 0, output1.vout[0].nValue), DataFromTransaction(input1, 0), DataFromTransaction(input2, 0)));
     CheckWithFlag(output1, input1, SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS, true);
     CheckWithFlag(output1, input1, STANDARD_SCRIPT_VERIFY_FLAGS, true);
@@ -631,75 +631,75 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
     t.vout[0].scriptPubKey = GetScriptForDestination(key.GetPubKey().GetID());
 
     string reason;
-    BOOST_CHECK(IsStandardTx(t, reason));
+    FAST_CHECK(IsStandardTx(t, reason));
 
     // Check dust with default relay fee:
     CAmount nDustThreshold = 182 * minRelayTxFee.GetFeePerK()/1000 * 3;
-    BOOST_CHECK_EQUAL(nDustThreshold, 546);
+    FAST_CHECK_EQUAL(nDustThreshold, 546);
     // dust:
     t.vout[0].nValue = nDustThreshold - 1;
-    BOOST_CHECK(!IsStandardTx(t, reason));
+    FAST_CHECK(!IsStandardTx(t, reason));
     // not dust:
     t.vout[0].nValue = nDustThreshold;
-    BOOST_CHECK(IsStandardTx(t, reason));
+    FAST_CHECK(IsStandardTx(t, reason));
 
     // Check dust with odd relay fee to verify rounding:
     // nDustThreshold = 182 * 1234 / 1000 * 3
     minRelayTxFee = CFeeRate(1234);
     // dust:
     t.vout[0].nValue = 672 - 1;
-    BOOST_CHECK(!IsStandardTx(t, reason));
+    FAST_CHECK(!IsStandardTx(t, reason));
     // not dust:
     t.vout[0].nValue = 672;
-    BOOST_CHECK(IsStandardTx(t, reason));
+    FAST_CHECK(IsStandardTx(t, reason));
     minRelayTxFee = CFeeRate(DEFAULT_MIN_RELAY_TX_FEE);
 
     t.vout[0].scriptPubKey = CScript() << OP_1;
-    BOOST_CHECK(!IsStandardTx(t, reason));
+    FAST_CHECK(!IsStandardTx(t, reason));
 
     // MAX_OP_RETURN_RELAY-byte TX_NULL_DATA (standard)
     t.vout[0].scriptPubKey = CScript() << OP_RETURN << ParseHex("04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef3804678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38");
-    BOOST_CHECK_EQUAL(MAX_OP_RETURN_RELAY, t.vout[0].scriptPubKey.size());
-    BOOST_CHECK(IsStandardTx(t, reason));
+    FAST_CHECK_EQUAL(MAX_OP_RETURN_RELAY, t.vout[0].scriptPubKey.size());
+    FAST_CHECK(IsStandardTx(t, reason));
 
     // MAX_OP_RETURN_RELAY+1-byte TX_NULL_DATA (non-standard)
     t.vout[0].scriptPubKey = CScript() << OP_RETURN << ParseHex("04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef3804678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef3800");
-    BOOST_CHECK_EQUAL(MAX_OP_RETURN_RELAY + 1, t.vout[0].scriptPubKey.size());
-    BOOST_CHECK(!IsStandardTx(t, reason));
+    FAST_CHECK_EQUAL(MAX_OP_RETURN_RELAY + 1, t.vout[0].scriptPubKey.size());
+    FAST_CHECK(!IsStandardTx(t, reason));
 
     // Data payload can be encoded in any way...
     t.vout[0].scriptPubKey = CScript() << OP_RETURN << ParseHex("");
-    BOOST_CHECK(IsStandardTx(t, reason));
+    FAST_CHECK(IsStandardTx(t, reason));
     t.vout[0].scriptPubKey = CScript() << OP_RETURN << ParseHex("00") << ParseHex("01");
-    BOOST_CHECK(IsStandardTx(t, reason));
+    FAST_CHECK(IsStandardTx(t, reason));
     // OP_RESERVED *is* considered to be a PUSHDATA type opcode by IsPushOnly()!
     t.vout[0].scriptPubKey = CScript() << OP_RETURN << OP_RESERVED << -1 << 0 << ParseHex("01") << 2 << 3 << 4 << 5 << 6 << 7 << 8 << 9 << 10 << 11 << 12 << 13 << 14 << 15 << 16;
-    BOOST_CHECK(IsStandardTx(t, reason));
+    FAST_CHECK(IsStandardTx(t, reason));
     t.vout[0].scriptPubKey = CScript() << OP_RETURN << 0 << ParseHex("01") << 2 << ParseHex("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
-    BOOST_CHECK(IsStandardTx(t, reason));
+    FAST_CHECK(IsStandardTx(t, reason));
 
     // ...so long as it only contains PUSHDATA's
     t.vout[0].scriptPubKey = CScript() << OP_RETURN << OP_RETURN;
-    BOOST_CHECK(!IsStandardTx(t, reason));
+    FAST_CHECK(!IsStandardTx(t, reason));
 
     // TX_NULL_DATA w/o PUSHDATA
     t.vout.resize(1);
     t.vout[0].scriptPubKey = CScript() << OP_RETURN;
-    BOOST_CHECK(IsStandardTx(t, reason));
+    FAST_CHECK(IsStandardTx(t, reason));
 
     // Only one TX_NULL_DATA permitted in all cases
     t.vout.resize(2);
     t.vout[0].scriptPubKey = CScript() << OP_RETURN << ParseHex("04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38");
     t.vout[1].scriptPubKey = CScript() << OP_RETURN << ParseHex("04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38");
-    BOOST_CHECK(!IsStandardTx(t, reason));
+    FAST_CHECK(!IsStandardTx(t, reason));
 
     t.vout[0].scriptPubKey = CScript() << OP_RETURN << ParseHex("04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38");
     t.vout[1].scriptPubKey = CScript() << OP_RETURN;
-    BOOST_CHECK(!IsStandardTx(t, reason));
+    FAST_CHECK(!IsStandardTx(t, reason));
 
     t.vout[0].scriptPubKey = CScript() << OP_RETURN;
     t.vout[1].scriptPubKey = CScript() << OP_RETURN;
-    BOOST_CHECK(!IsStandardTx(t, reason));
+    FAST_CHECK(!IsStandardTx(t, reason));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -49,7 +49,7 @@ BOOST_FIXTURE_TEST_CASE(tx_mempool_block_doublespend, TestChain100Setup)
         // Sign:
         std::vector<unsigned char> vchSig;
         uint256 hash = SignatureHash(scriptPubKey, spends[i], 0, SIGHASH_ALL, 0, SIGVERSION_BASE);
-        BOOST_CHECK(coinbaseKey.Sign(hash, vchSig));
+        FAST_CHECK(coinbaseKey.Sign(hash, vchSig));
         vchSig.push_back((unsigned char)SIGHASH_ALL);
         spends[i].vin[0].scriptSig << vchSig;
     }
@@ -58,29 +58,29 @@ BOOST_FIXTURE_TEST_CASE(tx_mempool_block_doublespend, TestChain100Setup)
 
     // Test 1: block with both of those transactions should be rejected.
     block = CreateAndProcessBlock(spends, scriptPubKey);
-    BOOST_CHECK(chainActive.Tip()->GetBlockHash() != block.GetHash());
+    FAST_CHECK(chainActive.Tip()->GetBlockHash() != block.GetHash());
 
     // Test 2: ... and should be rejected if spend1 is in the memory pool
-    BOOST_CHECK(ToMemPool(spends[0]));
+    FAST_CHECK(ToMemPool(spends[0]));
     block = CreateAndProcessBlock(spends, scriptPubKey);
-    BOOST_CHECK(chainActive.Tip()->GetBlockHash() != block.GetHash());
+    FAST_CHECK(chainActive.Tip()->GetBlockHash() != block.GetHash());
     mempool.clear();
 
     // Test 3: ... and should be rejected if spend2 is in the memory pool
-    BOOST_CHECK(ToMemPool(spends[1]));
+    FAST_CHECK(ToMemPool(spends[1]));
     block = CreateAndProcessBlock(spends, scriptPubKey);
-    BOOST_CHECK(chainActive.Tip()->GetBlockHash() != block.GetHash());
+    FAST_CHECK(chainActive.Tip()->GetBlockHash() != block.GetHash());
     mempool.clear();
 
     // Final sanity test: first spend in mempool, second in block, that's OK:
     std::vector<CMutableTransaction> oneSpend;
     oneSpend.push_back(spends[0]);
-    BOOST_CHECK(ToMemPool(spends[1]));
+    FAST_CHECK(ToMemPool(spends[1]));
     block = CreateAndProcessBlock(oneSpend, scriptPubKey);
-    BOOST_CHECK(chainActive.Tip()->GetBlockHash() == block.GetHash());
+    FAST_CHECK(chainActive.Tip()->GetBlockHash() == block.GetHash());
     // spends[1] should have been removed from the mempool when the
     // block with spends[0] is accepted:
-    BOOST_CHECK_EQUAL(mempool.size(), 0);
+    FAST_CHECK_EQUAL(mempool.size(), 0);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/uint256_tests.cpp
+++ b/src/test/uint256_tests.cpp
@@ -74,54 +74,54 @@ inline uint160 uint160S(const std::string& str)
 
 BOOST_AUTO_TEST_CASE( basics ) // constructors, equality, inequality
 {
-    BOOST_CHECK(1 == 0+1);
+    FAST_CHECK(1 == 0+1);
     // constructor uint256(vector<char>):
-    BOOST_CHECK(R1L.ToString() == ArrayToString(R1Array,32));
-    BOOST_CHECK(R1S.ToString() == ArrayToString(R1Array,20));
-    BOOST_CHECK(R2L.ToString() == ArrayToString(R2Array,32));
-    BOOST_CHECK(R2S.ToString() == ArrayToString(R2Array,20));
-    BOOST_CHECK(ZeroL.ToString() == ArrayToString(ZeroArray,32));
-    BOOST_CHECK(ZeroS.ToString() == ArrayToString(ZeroArray,20));
-    BOOST_CHECK(OneL.ToString() == ArrayToString(OneArray,32));
-    BOOST_CHECK(OneS.ToString() == ArrayToString(OneArray,20));
-    BOOST_CHECK(MaxL.ToString() == ArrayToString(MaxArray,32));
-    BOOST_CHECK(MaxS.ToString() == ArrayToString(MaxArray,20));
-    BOOST_CHECK(OneL.ToString() != ArrayToString(ZeroArray,32));
-    BOOST_CHECK(OneS.ToString() != ArrayToString(ZeroArray,20));
+    FAST_CHECK(R1L.ToString() == ArrayToString(R1Array,32));
+    FAST_CHECK(R1S.ToString() == ArrayToString(R1Array,20));
+    FAST_CHECK(R2L.ToString() == ArrayToString(R2Array,32));
+    FAST_CHECK(R2S.ToString() == ArrayToString(R2Array,20));
+    FAST_CHECK(ZeroL.ToString() == ArrayToString(ZeroArray,32));
+    FAST_CHECK(ZeroS.ToString() == ArrayToString(ZeroArray,20));
+    FAST_CHECK(OneL.ToString() == ArrayToString(OneArray,32));
+    FAST_CHECK(OneS.ToString() == ArrayToString(OneArray,20));
+    FAST_CHECK(MaxL.ToString() == ArrayToString(MaxArray,32));
+    FAST_CHECK(MaxS.ToString() == ArrayToString(MaxArray,20));
+    FAST_CHECK(OneL.ToString() != ArrayToString(ZeroArray,32));
+    FAST_CHECK(OneS.ToString() != ArrayToString(ZeroArray,20));
 
     // == and !=
-    BOOST_CHECK(R1L != R2L && R1S != R2S);
-    BOOST_CHECK(ZeroL != OneL && ZeroS != OneS);
-    BOOST_CHECK(OneL != ZeroL && OneS != ZeroS);
-    BOOST_CHECK(MaxL != ZeroL && MaxS != ZeroS);
+    FAST_CHECK(R1L != R2L && R1S != R2S);
+    FAST_CHECK(ZeroL != OneL && ZeroS != OneS);
+    FAST_CHECK(OneL != ZeroL && OneS != ZeroS);
+    FAST_CHECK(MaxL != ZeroL && MaxS != ZeroS);
 
     // String Constructor and Copy Constructor
-    BOOST_CHECK(uint256S("0x"+R1L.ToString()) == R1L);
-    BOOST_CHECK(uint256S("0x"+R2L.ToString()) == R2L);
-    BOOST_CHECK(uint256S("0x"+ZeroL.ToString()) == ZeroL);
-    BOOST_CHECK(uint256S("0x"+OneL.ToString()) == OneL);
-    BOOST_CHECK(uint256S("0x"+MaxL.ToString()) == MaxL);
-    BOOST_CHECK(uint256S(R1L.ToString()) == R1L);
-    BOOST_CHECK(uint256S("   0x"+R1L.ToString()+"   ") == R1L);
-    BOOST_CHECK(uint256S("") == ZeroL);
-    BOOST_CHECK(R1L == uint256S(R1ArrayHex));
-    BOOST_CHECK(uint256(R1L) == R1L);
-    BOOST_CHECK(uint256(ZeroL) == ZeroL);
-    BOOST_CHECK(uint256(OneL) == OneL);
+    FAST_CHECK(uint256S("0x"+R1L.ToString()) == R1L);
+    FAST_CHECK(uint256S("0x"+R2L.ToString()) == R2L);
+    FAST_CHECK(uint256S("0x"+ZeroL.ToString()) == ZeroL);
+    FAST_CHECK(uint256S("0x"+OneL.ToString()) == OneL);
+    FAST_CHECK(uint256S("0x"+MaxL.ToString()) == MaxL);
+    FAST_CHECK(uint256S(R1L.ToString()) == R1L);
+    FAST_CHECK(uint256S("   0x"+R1L.ToString()+"   ") == R1L);
+    FAST_CHECK(uint256S("") == ZeroL);
+    FAST_CHECK(R1L == uint256S(R1ArrayHex));
+    FAST_CHECK(uint256(R1L) == R1L);
+    FAST_CHECK(uint256(ZeroL) == ZeroL);
+    FAST_CHECK(uint256(OneL) == OneL);
 
-    BOOST_CHECK(uint160S("0x"+R1S.ToString()) == R1S);
-    BOOST_CHECK(uint160S("0x"+R2S.ToString()) == R2S);
-    BOOST_CHECK(uint160S("0x"+ZeroS.ToString()) == ZeroS);
-    BOOST_CHECK(uint160S("0x"+OneS.ToString()) == OneS);
-    BOOST_CHECK(uint160S("0x"+MaxS.ToString()) == MaxS);
-    BOOST_CHECK(uint160S(R1S.ToString()) == R1S);
-    BOOST_CHECK(uint160S("   0x"+R1S.ToString()+"   ") == R1S);
-    BOOST_CHECK(uint160S("") == ZeroS);
-    BOOST_CHECK(R1S == uint160S(R1ArrayHex));
+    FAST_CHECK(uint160S("0x"+R1S.ToString()) == R1S);
+    FAST_CHECK(uint160S("0x"+R2S.ToString()) == R2S);
+    FAST_CHECK(uint160S("0x"+ZeroS.ToString()) == ZeroS);
+    FAST_CHECK(uint160S("0x"+OneS.ToString()) == OneS);
+    FAST_CHECK(uint160S("0x"+MaxS.ToString()) == MaxS);
+    FAST_CHECK(uint160S(R1S.ToString()) == R1S);
+    FAST_CHECK(uint160S("   0x"+R1S.ToString()+"   ") == R1S);
+    FAST_CHECK(uint160S("") == ZeroS);
+    FAST_CHECK(R1S == uint160S(R1ArrayHex));
 
-    BOOST_CHECK(uint160(R1S) == R1S);
-    BOOST_CHECK(uint160(ZeroS) == ZeroS);
-    BOOST_CHECK(uint160(OneS) == OneS);
+    FAST_CHECK(uint160(R1S) == R1S);
+    FAST_CHECK(uint160(ZeroS) == ZeroS);
+    FAST_CHECK(uint160(OneS) == OneS);
 }
 
 BOOST_AUTO_TEST_CASE( comparison ) // <= >= < >
@@ -130,140 +130,140 @@ BOOST_AUTO_TEST_CASE( comparison ) // <= >= < >
     for (int i = 255; i >= 0; --i) {
         uint256 TmpL;
         *(TmpL.begin() + (i>>3)) |= 1<<(7-(i&7));
-        BOOST_CHECK( LastL < TmpL );
+        FAST_CHECK( LastL < TmpL );
         LastL = TmpL;
     }
 
-    BOOST_CHECK( ZeroL < R1L );
-    BOOST_CHECK( R2L < R1L );
-    BOOST_CHECK( ZeroL < OneL );
-    BOOST_CHECK( OneL < MaxL );
-    BOOST_CHECK( R1L < MaxL );
-    BOOST_CHECK( R2L < MaxL );
+    FAST_CHECK( ZeroL < R1L );
+    FAST_CHECK( R2L < R1L );
+    FAST_CHECK( ZeroL < OneL );
+    FAST_CHECK( OneL < MaxL );
+    FAST_CHECK( R1L < MaxL );
+    FAST_CHECK( R2L < MaxL );
 
     uint160 LastS;
     for (int i = 159; i >= 0; --i) {
         uint160 TmpS;
         *(TmpS.begin() + (i>>3)) |= 1<<(7-(i&7));
-        BOOST_CHECK( LastS < TmpS );
+        FAST_CHECK( LastS < TmpS );
         LastS = TmpS;
     }
-    BOOST_CHECK( ZeroS < R1S );
-    BOOST_CHECK( R2S < R1S );
-    BOOST_CHECK( ZeroS < OneS );
-    BOOST_CHECK( OneS < MaxS );
-    BOOST_CHECK( R1S < MaxS );
-    BOOST_CHECK( R2S < MaxS );
+    FAST_CHECK( ZeroS < R1S );
+    FAST_CHECK( R2S < R1S );
+    FAST_CHECK( ZeroS < OneS );
+    FAST_CHECK( OneS < MaxS );
+    FAST_CHECK( R1S < MaxS );
+    FAST_CHECK( R2S < MaxS );
 }
 
 BOOST_AUTO_TEST_CASE( methods ) // GetHex SetHex begin() end() size() GetLow64 GetSerializeSize, Serialize, Unserialize
 {
-    BOOST_CHECK(R1L.GetHex() == R1L.ToString());
-    BOOST_CHECK(R2L.GetHex() == R2L.ToString());
-    BOOST_CHECK(OneL.GetHex() == OneL.ToString());
-    BOOST_CHECK(MaxL.GetHex() == MaxL.ToString());
+    FAST_CHECK(R1L.GetHex() == R1L.ToString());
+    FAST_CHECK(R2L.GetHex() == R2L.ToString());
+    FAST_CHECK(OneL.GetHex() == OneL.ToString());
+    FAST_CHECK(MaxL.GetHex() == MaxL.ToString());
     uint256 TmpL(R1L);
-    BOOST_CHECK(TmpL == R1L);
-    TmpL.SetHex(R2L.ToString());   BOOST_CHECK(TmpL == R2L);
-    TmpL.SetHex(ZeroL.ToString()); BOOST_CHECK(TmpL == uint256());
+    FAST_CHECK(TmpL == R1L);
+    TmpL.SetHex(R2L.ToString());   FAST_CHECK(TmpL == R2L);
+    TmpL.SetHex(ZeroL.ToString()); FAST_CHECK(TmpL == uint256());
 
     TmpL.SetHex(R1L.ToString());
-    BOOST_CHECK(memcmp(R1L.begin(), R1Array, 32)==0);
-    BOOST_CHECK(memcmp(TmpL.begin(), R1Array, 32)==0);
-    BOOST_CHECK(memcmp(R2L.begin(), R2Array, 32)==0);
-    BOOST_CHECK(memcmp(ZeroL.begin(), ZeroArray, 32)==0);
-    BOOST_CHECK(memcmp(OneL.begin(), OneArray, 32)==0);
-    BOOST_CHECK(R1L.size() == sizeof(R1L));
-    BOOST_CHECK(sizeof(R1L) == 32);
-    BOOST_CHECK(R1L.size() == 32);
-    BOOST_CHECK(R2L.size() == 32);
-    BOOST_CHECK(ZeroL.size() == 32);
-    BOOST_CHECK(MaxL.size() == 32);
-    BOOST_CHECK(R1L.begin() + 32 == R1L.end());
-    BOOST_CHECK(R2L.begin() + 32 == R2L.end());
-    BOOST_CHECK(OneL.begin() + 32 == OneL.end());
-    BOOST_CHECK(MaxL.begin() + 32 == MaxL.end());
-    BOOST_CHECK(TmpL.begin() + 32 == TmpL.end());
-    BOOST_CHECK(R1L.GetSerializeSize(0,PROTOCOL_VERSION) == 32);
-    BOOST_CHECK(ZeroL.GetSerializeSize(0,PROTOCOL_VERSION) == 32);
+    FAST_CHECK(memcmp(R1L.begin(), R1Array, 32)==0);
+    FAST_CHECK(memcmp(TmpL.begin(), R1Array, 32)==0);
+    FAST_CHECK(memcmp(R2L.begin(), R2Array, 32)==0);
+    FAST_CHECK(memcmp(ZeroL.begin(), ZeroArray, 32)==0);
+    FAST_CHECK(memcmp(OneL.begin(), OneArray, 32)==0);
+    FAST_CHECK(R1L.size() == sizeof(R1L));
+    FAST_CHECK(sizeof(R1L) == 32);
+    FAST_CHECK(R1L.size() == 32);
+    FAST_CHECK(R2L.size() == 32);
+    FAST_CHECK(ZeroL.size() == 32);
+    FAST_CHECK(MaxL.size() == 32);
+    FAST_CHECK(R1L.begin() + 32 == R1L.end());
+    FAST_CHECK(R2L.begin() + 32 == R2L.end());
+    FAST_CHECK(OneL.begin() + 32 == OneL.end());
+    FAST_CHECK(MaxL.begin() + 32 == MaxL.end());
+    FAST_CHECK(TmpL.begin() + 32 == TmpL.end());
+    FAST_CHECK(R1L.GetSerializeSize(0,PROTOCOL_VERSION) == 32);
+    FAST_CHECK(ZeroL.GetSerializeSize(0,PROTOCOL_VERSION) == 32);
 
     std::stringstream ss;
     R1L.Serialize(ss,0,PROTOCOL_VERSION);
-    BOOST_CHECK(ss.str() == std::string(R1Array,R1Array+32));
+    FAST_CHECK(ss.str() == std::string(R1Array,R1Array+32));
     TmpL.Unserialize(ss,0,PROTOCOL_VERSION);
-    BOOST_CHECK(R1L == TmpL);
+    FAST_CHECK(R1L == TmpL);
     ss.str("");
     ZeroL.Serialize(ss,0,PROTOCOL_VERSION);
-    BOOST_CHECK(ss.str() == std::string(ZeroArray,ZeroArray+32));
+    FAST_CHECK(ss.str() == std::string(ZeroArray,ZeroArray+32));
     TmpL.Unserialize(ss,0,PROTOCOL_VERSION);
-    BOOST_CHECK(ZeroL == TmpL);
+    FAST_CHECK(ZeroL == TmpL);
     ss.str("");
     MaxL.Serialize(ss,0,PROTOCOL_VERSION);
-    BOOST_CHECK(ss.str() == std::string(MaxArray,MaxArray+32));
+    FAST_CHECK(ss.str() == std::string(MaxArray,MaxArray+32));
     TmpL.Unserialize(ss,0,PROTOCOL_VERSION);
-    BOOST_CHECK(MaxL == TmpL);
+    FAST_CHECK(MaxL == TmpL);
     ss.str("");
 
-    BOOST_CHECK(R1S.GetHex() == R1S.ToString());
-    BOOST_CHECK(R2S.GetHex() == R2S.ToString());
-    BOOST_CHECK(OneS.GetHex() == OneS.ToString());
-    BOOST_CHECK(MaxS.GetHex() == MaxS.ToString());
+    FAST_CHECK(R1S.GetHex() == R1S.ToString());
+    FAST_CHECK(R2S.GetHex() == R2S.ToString());
+    FAST_CHECK(OneS.GetHex() == OneS.ToString());
+    FAST_CHECK(MaxS.GetHex() == MaxS.ToString());
     uint160 TmpS(R1S);
-    BOOST_CHECK(TmpS == R1S);
-    TmpS.SetHex(R2S.ToString());   BOOST_CHECK(TmpS == R2S);
-    TmpS.SetHex(ZeroS.ToString()); BOOST_CHECK(TmpS == uint160());
+    FAST_CHECK(TmpS == R1S);
+    TmpS.SetHex(R2S.ToString());   FAST_CHECK(TmpS == R2S);
+    TmpS.SetHex(ZeroS.ToString()); FAST_CHECK(TmpS == uint160());
 
     TmpS.SetHex(R1S.ToString());
-    BOOST_CHECK(memcmp(R1S.begin(), R1Array, 20)==0);
-    BOOST_CHECK(memcmp(TmpS.begin(), R1Array, 20)==0);
-    BOOST_CHECK(memcmp(R2S.begin(), R2Array, 20)==0);
-    BOOST_CHECK(memcmp(ZeroS.begin(), ZeroArray, 20)==0);
-    BOOST_CHECK(memcmp(OneS.begin(), OneArray, 20)==0);
-    BOOST_CHECK(R1S.size() == sizeof(R1S));
-    BOOST_CHECK(sizeof(R1S) == 20);
-    BOOST_CHECK(R1S.size() == 20);
-    BOOST_CHECK(R2S.size() == 20);
-    BOOST_CHECK(ZeroS.size() == 20);
-    BOOST_CHECK(MaxS.size() == 20);
-    BOOST_CHECK(R1S.begin() + 20 == R1S.end());
-    BOOST_CHECK(R2S.begin() + 20 == R2S.end());
-    BOOST_CHECK(OneS.begin() + 20 == OneS.end());
-    BOOST_CHECK(MaxS.begin() + 20 == MaxS.end());
-    BOOST_CHECK(TmpS.begin() + 20 == TmpS.end());
-    BOOST_CHECK(R1S.GetSerializeSize(0,PROTOCOL_VERSION) == 20);
-    BOOST_CHECK(ZeroS.GetSerializeSize(0,PROTOCOL_VERSION) == 20);
+    FAST_CHECK(memcmp(R1S.begin(), R1Array, 20)==0);
+    FAST_CHECK(memcmp(TmpS.begin(), R1Array, 20)==0);
+    FAST_CHECK(memcmp(R2S.begin(), R2Array, 20)==0);
+    FAST_CHECK(memcmp(ZeroS.begin(), ZeroArray, 20)==0);
+    FAST_CHECK(memcmp(OneS.begin(), OneArray, 20)==0);
+    FAST_CHECK(R1S.size() == sizeof(R1S));
+    FAST_CHECK(sizeof(R1S) == 20);
+    FAST_CHECK(R1S.size() == 20);
+    FAST_CHECK(R2S.size() == 20);
+    FAST_CHECK(ZeroS.size() == 20);
+    FAST_CHECK(MaxS.size() == 20);
+    FAST_CHECK(R1S.begin() + 20 == R1S.end());
+    FAST_CHECK(R2S.begin() + 20 == R2S.end());
+    FAST_CHECK(OneS.begin() + 20 == OneS.end());
+    FAST_CHECK(MaxS.begin() + 20 == MaxS.end());
+    FAST_CHECK(TmpS.begin() + 20 == TmpS.end());
+    FAST_CHECK(R1S.GetSerializeSize(0,PROTOCOL_VERSION) == 20);
+    FAST_CHECK(ZeroS.GetSerializeSize(0,PROTOCOL_VERSION) == 20);
 
     R1S.Serialize(ss,0,PROTOCOL_VERSION);
-    BOOST_CHECK(ss.str() == std::string(R1Array,R1Array+20));
+    FAST_CHECK(ss.str() == std::string(R1Array,R1Array+20));
     TmpS.Unserialize(ss,0,PROTOCOL_VERSION);
-    BOOST_CHECK(R1S == TmpS);
+    FAST_CHECK(R1S == TmpS);
     ss.str("");
     ZeroS.Serialize(ss,0,PROTOCOL_VERSION);
-    BOOST_CHECK(ss.str() == std::string(ZeroArray,ZeroArray+20));
+    FAST_CHECK(ss.str() == std::string(ZeroArray,ZeroArray+20));
     TmpS.Unserialize(ss,0,PROTOCOL_VERSION);
-    BOOST_CHECK(ZeroS == TmpS);
+    FAST_CHECK(ZeroS == TmpS);
     ss.str("");
     MaxS.Serialize(ss,0,PROTOCOL_VERSION);
-    BOOST_CHECK(ss.str() == std::string(MaxArray,MaxArray+20));
+    FAST_CHECK(ss.str() == std::string(MaxArray,MaxArray+20));
     TmpS.Unserialize(ss,0,PROTOCOL_VERSION);
-    BOOST_CHECK(MaxS == TmpS);
+    FAST_CHECK(MaxS == TmpS);
     ss.str("");
 }
 
 BOOST_AUTO_TEST_CASE( conversion )
 {
-    BOOST_CHECK(ArithToUint256(UintToArith256(ZeroL)) == ZeroL);
-    BOOST_CHECK(ArithToUint256(UintToArith256(OneL)) == OneL);
-    BOOST_CHECK(ArithToUint256(UintToArith256(R1L)) == R1L);
-    BOOST_CHECK(ArithToUint256(UintToArith256(R2L)) == R2L);
-    BOOST_CHECK(UintToArith256(ZeroL) == 0);
-    BOOST_CHECK(UintToArith256(OneL) == 1);
-    BOOST_CHECK(ArithToUint256(0) == ZeroL);
-    BOOST_CHECK(ArithToUint256(1) == OneL);
-    BOOST_CHECK(arith_uint256(R1L.GetHex()) == UintToArith256(R1L));
-    BOOST_CHECK(arith_uint256(R2L.GetHex()) == UintToArith256(R2L));
-    BOOST_CHECK(R1L.GetHex() == UintToArith256(R1L).GetHex());
-    BOOST_CHECK(R2L.GetHex() == UintToArith256(R2L).GetHex());
+    FAST_CHECK(ArithToUint256(UintToArith256(ZeroL)) == ZeroL);
+    FAST_CHECK(ArithToUint256(UintToArith256(OneL)) == OneL);
+    FAST_CHECK(ArithToUint256(UintToArith256(R1L)) == R1L);
+    FAST_CHECK(ArithToUint256(UintToArith256(R2L)) == R2L);
+    FAST_CHECK(UintToArith256(ZeroL) == 0);
+    FAST_CHECK(UintToArith256(OneL) == 1);
+    FAST_CHECK(ArithToUint256(0) == ZeroL);
+    FAST_CHECK(ArithToUint256(1) == OneL);
+    FAST_CHECK(arith_uint256(R1L.GetHex()) == UintToArith256(R1L));
+    FAST_CHECK(arith_uint256(R2L.GetHex()) == UintToArith256(R2L));
+    FAST_CHECK(R1L.GetHex() == UintToArith256(R1L).GetHex());
+    FAST_CHECK(R2L.GetHex() == UintToArith256(R2L).GetHex());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/univalue_tests.cpp
+++ b/src/test/univalue_tests.cpp
@@ -19,150 +19,150 @@ BOOST_FIXTURE_TEST_SUITE(univalue_tests, BasicTestingSetup)
 BOOST_AUTO_TEST_CASE(univalue_constructor)
 {
     UniValue v1;
-    BOOST_CHECK(v1.isNull());
+    FAST_CHECK(v1.isNull());
 
     UniValue v2(UniValue::VSTR);
-    BOOST_CHECK(v2.isStr());
+    FAST_CHECK(v2.isStr());
 
     UniValue v3(UniValue::VSTR, "foo");
-    BOOST_CHECK(v3.isStr());
-    BOOST_CHECK_EQUAL(v3.getValStr(), "foo");
+    FAST_CHECK(v3.isStr());
+    FAST_CHECK_EQUAL(v3.getValStr(), "foo");
 
     UniValue numTest;
-    BOOST_CHECK(numTest.setNumStr("82"));
-    BOOST_CHECK(numTest.isNum());
-    BOOST_CHECK_EQUAL(numTest.getValStr(), "82");
+    FAST_CHECK(numTest.setNumStr("82"));
+    FAST_CHECK(numTest.isNum());
+    FAST_CHECK_EQUAL(numTest.getValStr(), "82");
 
     uint64_t vu64 = 82;
     UniValue v4(vu64);
-    BOOST_CHECK(v4.isNum());
-    BOOST_CHECK_EQUAL(v4.getValStr(), "82");
+    FAST_CHECK(v4.isNum());
+    FAST_CHECK_EQUAL(v4.getValStr(), "82");
 
     int64_t vi64 = -82;
     UniValue v5(vi64);
-    BOOST_CHECK(v5.isNum());
-    BOOST_CHECK_EQUAL(v5.getValStr(), "-82");
+    FAST_CHECK(v5.isNum());
+    FAST_CHECK_EQUAL(v5.getValStr(), "-82");
 
     int vi = -688;
     UniValue v6(vi);
-    BOOST_CHECK(v6.isNum());
-    BOOST_CHECK_EQUAL(v6.getValStr(), "-688");
+    FAST_CHECK(v6.isNum());
+    FAST_CHECK_EQUAL(v6.getValStr(), "-688");
 
     double vd = -7.21;
     UniValue v7(vd);
-    BOOST_CHECK(v7.isNum());
-    BOOST_CHECK_EQUAL(v7.getValStr(), "-7.21");
+    FAST_CHECK(v7.isNum());
+    FAST_CHECK_EQUAL(v7.getValStr(), "-7.21");
 
     string vs("yawn");
     UniValue v8(vs);
-    BOOST_CHECK(v8.isStr());
-    BOOST_CHECK_EQUAL(v8.getValStr(), "yawn");
+    FAST_CHECK(v8.isStr());
+    FAST_CHECK_EQUAL(v8.getValStr(), "yawn");
 
     const char *vcs = "zappa";
     UniValue v9(vcs);
-    BOOST_CHECK(v9.isStr());
-    BOOST_CHECK_EQUAL(v9.getValStr(), "zappa");
+    FAST_CHECK(v9.isStr());
+    FAST_CHECK_EQUAL(v9.getValStr(), "zappa");
 }
 
 BOOST_AUTO_TEST_CASE(univalue_typecheck)
 {
     UniValue v1;
-    BOOST_CHECK(v1.setNumStr("1"));
-    BOOST_CHECK(v1.isNum());
-    BOOST_CHECK_THROW(v1.get_bool(), runtime_error);
+    FAST_CHECK(v1.setNumStr("1"));
+    FAST_CHECK(v1.isNum());
+    FAST_CHECK_THROW(v1.get_bool(), runtime_error);
 
     UniValue v2;
-    BOOST_CHECK(v2.setBool(true));
-    BOOST_CHECK_EQUAL(v2.get_bool(), true);
-    BOOST_CHECK_THROW(v2.get_int(), runtime_error);
+    FAST_CHECK(v2.setBool(true));
+    FAST_CHECK_EQUAL(v2.get_bool(), true);
+    FAST_CHECK_THROW(v2.get_int(), runtime_error);
 
     UniValue v3;
-    BOOST_CHECK(v3.setNumStr("32482348723847471234"));
-    BOOST_CHECK_THROW(v3.get_int64(), runtime_error);
-    BOOST_CHECK(v3.setNumStr("1000"));
-    BOOST_CHECK_EQUAL(v3.get_int64(), 1000);
+    FAST_CHECK(v3.setNumStr("32482348723847471234"));
+    FAST_CHECK_THROW(v3.get_int64(), runtime_error);
+    FAST_CHECK(v3.setNumStr("1000"));
+    FAST_CHECK_EQUAL(v3.get_int64(), 1000);
 
     UniValue v4;
-    BOOST_CHECK(v4.setNumStr("2147483648"));
-    BOOST_CHECK_EQUAL(v4.get_int64(), 2147483648);
-    BOOST_CHECK_THROW(v4.get_int(), runtime_error);
-    BOOST_CHECK(v4.setNumStr("1000"));
-    BOOST_CHECK_EQUAL(v4.get_int(), 1000);
-    BOOST_CHECK_THROW(v4.get_str(), runtime_error);
-    BOOST_CHECK_EQUAL(v4.get_real(), 1000);
-    BOOST_CHECK_THROW(v4.get_array(), runtime_error);
-    BOOST_CHECK_THROW(v4.getKeys(), runtime_error);
-    BOOST_CHECK_THROW(v4.getValues(), runtime_error);
-    BOOST_CHECK_THROW(v4.get_obj(), runtime_error);
+    FAST_CHECK(v4.setNumStr("2147483648"));
+    FAST_CHECK_EQUAL(v4.get_int64(), 2147483648);
+    FAST_CHECK_THROW(v4.get_int(), runtime_error);
+    FAST_CHECK(v4.setNumStr("1000"));
+    FAST_CHECK_EQUAL(v4.get_int(), 1000);
+    FAST_CHECK_THROW(v4.get_str(), runtime_error);
+    FAST_CHECK_EQUAL(v4.get_real(), 1000);
+    FAST_CHECK_THROW(v4.get_array(), runtime_error);
+    FAST_CHECK_THROW(v4.getKeys(), runtime_error);
+    FAST_CHECK_THROW(v4.getValues(), runtime_error);
+    FAST_CHECK_THROW(v4.get_obj(), runtime_error);
 
     UniValue v5;
-    BOOST_CHECK(v5.read("[true, 10]"));
-    BOOST_CHECK_NO_THROW(v5.get_array());
+    FAST_CHECK(v5.read("[true, 10]"));
+    FAST_CHECK_NO_THROW(v5.get_array());
     std::vector<UniValue> vals = v5.getValues();
-    BOOST_CHECK_THROW(vals[0].get_int(), runtime_error);
-    BOOST_CHECK_EQUAL(vals[0].get_bool(), true);
+    FAST_CHECK_THROW(vals[0].get_int(), runtime_error);
+    FAST_CHECK_EQUAL(vals[0].get_bool(), true);
 
-    BOOST_CHECK_EQUAL(vals[1].get_int(), 10);
-    BOOST_CHECK_THROW(vals[1].get_bool(), runtime_error);
+    FAST_CHECK_EQUAL(vals[1].get_int(), 10);
+    FAST_CHECK_THROW(vals[1].get_bool(), runtime_error);
 }
 
 BOOST_AUTO_TEST_CASE(univalue_set)
 {
     UniValue v(UniValue::VSTR, "foo");
     v.clear();
-    BOOST_CHECK(v.isNull());
-    BOOST_CHECK_EQUAL(v.getValStr(), "");
+    FAST_CHECK(v.isNull());
+    FAST_CHECK_EQUAL(v.getValStr(), "");
 
-    BOOST_CHECK(v.setObject());
-    BOOST_CHECK(v.isObject());
-    BOOST_CHECK_EQUAL(v.size(), 0);
-    BOOST_CHECK_EQUAL(v.getType(), UniValue::VOBJ);
-    BOOST_CHECK(v.empty());
+    FAST_CHECK(v.setObject());
+    FAST_CHECK(v.isObject());
+    FAST_CHECK_EQUAL(v.size(), 0);
+    FAST_CHECK_EQUAL(v.getType(), UniValue::VOBJ);
+    FAST_CHECK(v.empty());
 
-    BOOST_CHECK(v.setArray());
-    BOOST_CHECK(v.isArray());
-    BOOST_CHECK_EQUAL(v.size(), 0);
+    FAST_CHECK(v.setArray());
+    FAST_CHECK(v.isArray());
+    FAST_CHECK_EQUAL(v.size(), 0);
 
-    BOOST_CHECK(v.setStr("zum"));
-    BOOST_CHECK(v.isStr());
-    BOOST_CHECK_EQUAL(v.getValStr(), "zum");
+    FAST_CHECK(v.setStr("zum"));
+    FAST_CHECK(v.isStr());
+    FAST_CHECK_EQUAL(v.getValStr(), "zum");
 
-    BOOST_CHECK(v.setFloat(-1.01));
-    BOOST_CHECK(v.isNum());
-    BOOST_CHECK_EQUAL(v.getValStr(), "-1.01");
+    FAST_CHECK(v.setFloat(-1.01));
+    FAST_CHECK(v.isNum());
+    FAST_CHECK_EQUAL(v.getValStr(), "-1.01");
 
-    BOOST_CHECK(v.setInt((int)1023));
-    BOOST_CHECK(v.isNum());
-    BOOST_CHECK_EQUAL(v.getValStr(), "1023");
+    FAST_CHECK(v.setInt((int)1023));
+    FAST_CHECK(v.isNum());
+    FAST_CHECK_EQUAL(v.getValStr(), "1023");
 
-    BOOST_CHECK(v.setInt((int64_t)-1023LL));
-    BOOST_CHECK(v.isNum());
-    BOOST_CHECK_EQUAL(v.getValStr(), "-1023");
+    FAST_CHECK(v.setInt((int64_t)-1023LL));
+    FAST_CHECK(v.isNum());
+    FAST_CHECK_EQUAL(v.getValStr(), "-1023");
 
-    BOOST_CHECK(v.setInt((uint64_t)1023ULL));
-    BOOST_CHECK(v.isNum());
-    BOOST_CHECK_EQUAL(v.getValStr(), "1023");
+    FAST_CHECK(v.setInt((uint64_t)1023ULL));
+    FAST_CHECK(v.isNum());
+    FAST_CHECK_EQUAL(v.getValStr(), "1023");
 
-    BOOST_CHECK(v.setNumStr("-688"));
-    BOOST_CHECK(v.isNum());
-    BOOST_CHECK_EQUAL(v.getValStr(), "-688");
+    FAST_CHECK(v.setNumStr("-688"));
+    FAST_CHECK(v.isNum());
+    FAST_CHECK_EQUAL(v.getValStr(), "-688");
 
-    BOOST_CHECK(v.setBool(false));
-    BOOST_CHECK_EQUAL(v.isBool(), true);
-    BOOST_CHECK_EQUAL(v.isTrue(), false);
-    BOOST_CHECK_EQUAL(v.isFalse(), true);
-    BOOST_CHECK_EQUAL(v.getBool(), false);
+    FAST_CHECK(v.setBool(false));
+    FAST_CHECK_EQUAL(v.isBool(), true);
+    FAST_CHECK_EQUAL(v.isTrue(), false);
+    FAST_CHECK_EQUAL(v.isFalse(), true);
+    FAST_CHECK_EQUAL(v.getBool(), false);
 
-    BOOST_CHECK(v.setBool(true));
-    BOOST_CHECK_EQUAL(v.isBool(), true);
-    BOOST_CHECK_EQUAL(v.isTrue(), true);
-    BOOST_CHECK_EQUAL(v.isFalse(), false);
-    BOOST_CHECK_EQUAL(v.getBool(), true);
+    FAST_CHECK(v.setBool(true));
+    FAST_CHECK_EQUAL(v.isBool(), true);
+    FAST_CHECK_EQUAL(v.isTrue(), true);
+    FAST_CHECK_EQUAL(v.isFalse(), false);
+    FAST_CHECK_EQUAL(v.getBool(), true);
 
-    BOOST_CHECK(!v.setNumStr("zombocom"));
+    FAST_CHECK(!v.setNumStr("zombocom"));
 
-    BOOST_CHECK(v.setNull());
-    BOOST_CHECK(v.isNull());
+    FAST_CHECK(v.setNull());
+    FAST_CHECK(v.isNull());
 }
 
 BOOST_AUTO_TEST_CASE(univalue_array)
@@ -170,13 +170,13 @@ BOOST_AUTO_TEST_CASE(univalue_array)
     UniValue arr(UniValue::VARR);
 
     UniValue v((int64_t)1023LL);
-    BOOST_CHECK(arr.push_back(v));
+    FAST_CHECK(arr.push_back(v));
 
     string vStr("zippy");
-    BOOST_CHECK(arr.push_back(vStr));
+    FAST_CHECK(arr.push_back(vStr));
 
     const char *s = "pippy";
-    BOOST_CHECK(arr.push_back(s));
+    FAST_CHECK(arr.push_back(s));
 
     vector<UniValue> vec;
     v.setStr("boing");
@@ -185,22 +185,22 @@ BOOST_AUTO_TEST_CASE(univalue_array)
     v.setStr("going");
     vec.push_back(v);
 
-    BOOST_CHECK(arr.push_backV(vec));
+    FAST_CHECK(arr.push_backV(vec));
 
-    BOOST_CHECK_EQUAL(arr.empty(), false);
-    BOOST_CHECK_EQUAL(arr.size(), 5);
+    FAST_CHECK_EQUAL(arr.empty(), false);
+    FAST_CHECK_EQUAL(arr.size(), 5);
 
-    BOOST_CHECK_EQUAL(arr[0].getValStr(), "1023");
-    BOOST_CHECK_EQUAL(arr[1].getValStr(), "zippy");
-    BOOST_CHECK_EQUAL(arr[2].getValStr(), "pippy");
-    BOOST_CHECK_EQUAL(arr[3].getValStr(), "boing");
-    BOOST_CHECK_EQUAL(arr[4].getValStr(), "going");
+    FAST_CHECK_EQUAL(arr[0].getValStr(), "1023");
+    FAST_CHECK_EQUAL(arr[1].getValStr(), "zippy");
+    FAST_CHECK_EQUAL(arr[2].getValStr(), "pippy");
+    FAST_CHECK_EQUAL(arr[3].getValStr(), "boing");
+    FAST_CHECK_EQUAL(arr[4].getValStr(), "going");
 
-    BOOST_CHECK_EQUAL(arr[999].getValStr(), "");
+    FAST_CHECK_EQUAL(arr[999].getValStr(), "");
 
     arr.clear();
-    BOOST_CHECK(arr.empty());
-    BOOST_CHECK_EQUAL(arr.size(), 0);
+    FAST_CHECK(arr.empty());
+    FAST_CHECK_EQUAL(arr.size(), 0);
 }
 
 BOOST_AUTO_TEST_CASE(univalue_object)
@@ -211,60 +211,60 @@ BOOST_AUTO_TEST_CASE(univalue_object)
 
     strKey = "age";
     v.setInt(100);
-    BOOST_CHECK(obj.pushKV(strKey, v));
+    FAST_CHECK(obj.pushKV(strKey, v));
 
     strKey = "first";
     strVal = "John";
-    BOOST_CHECK(obj.pushKV(strKey, strVal));
+    FAST_CHECK(obj.pushKV(strKey, strVal));
 
     strKey = "last";
     const char *cVal = "Smith";
-    BOOST_CHECK(obj.pushKV(strKey, cVal));
+    FAST_CHECK(obj.pushKV(strKey, cVal));
 
     strKey = "distance";
-    BOOST_CHECK(obj.pushKV(strKey, (int64_t) 25));
+    FAST_CHECK(obj.pushKV(strKey, (int64_t) 25));
 
     strKey = "time";
-    BOOST_CHECK(obj.pushKV(strKey, (uint64_t) 3600));
+    FAST_CHECK(obj.pushKV(strKey, (uint64_t) 3600));
 
     strKey = "calories";
-    BOOST_CHECK(obj.pushKV(strKey, (int) 12));
+    FAST_CHECK(obj.pushKV(strKey, (int) 12));
 
     strKey = "temperature";
-    BOOST_CHECK(obj.pushKV(strKey, (double) 90.012));
+    FAST_CHECK(obj.pushKV(strKey, (double) 90.012));
 
     UniValue obj2(UniValue::VOBJ);
-    BOOST_CHECK(obj2.pushKV("cat1", 9000));
-    BOOST_CHECK(obj2.pushKV("cat2", 12345));
+    FAST_CHECK(obj2.pushKV("cat1", 9000));
+    FAST_CHECK(obj2.pushKV("cat2", 12345));
 
-    BOOST_CHECK(obj.pushKVs(obj2));
+    FAST_CHECK(obj.pushKVs(obj2));
 
-    BOOST_CHECK_EQUAL(obj.empty(), false);
-    BOOST_CHECK_EQUAL(obj.size(), 9);
+    FAST_CHECK_EQUAL(obj.empty(), false);
+    FAST_CHECK_EQUAL(obj.size(), 9);
 
-    BOOST_CHECK_EQUAL(obj["age"].getValStr(), "100");
-    BOOST_CHECK_EQUAL(obj["first"].getValStr(), "John");
-    BOOST_CHECK_EQUAL(obj["last"].getValStr(), "Smith");
-    BOOST_CHECK_EQUAL(obj["distance"].getValStr(), "25");
-    BOOST_CHECK_EQUAL(obj["time"].getValStr(), "3600");
-    BOOST_CHECK_EQUAL(obj["calories"].getValStr(), "12");
-    BOOST_CHECK_EQUAL(obj["temperature"].getValStr(), "90.012");
-    BOOST_CHECK_EQUAL(obj["cat1"].getValStr(), "9000");
-    BOOST_CHECK_EQUAL(obj["cat2"].getValStr(), "12345");
+    FAST_CHECK_EQUAL(obj["age"].getValStr(), "100");
+    FAST_CHECK_EQUAL(obj["first"].getValStr(), "John");
+    FAST_CHECK_EQUAL(obj["last"].getValStr(), "Smith");
+    FAST_CHECK_EQUAL(obj["distance"].getValStr(), "25");
+    FAST_CHECK_EQUAL(obj["time"].getValStr(), "3600");
+    FAST_CHECK_EQUAL(obj["calories"].getValStr(), "12");
+    FAST_CHECK_EQUAL(obj["temperature"].getValStr(), "90.012");
+    FAST_CHECK_EQUAL(obj["cat1"].getValStr(), "9000");
+    FAST_CHECK_EQUAL(obj["cat2"].getValStr(), "12345");
 
-    BOOST_CHECK_EQUAL(obj["nyuknyuknyuk"].getValStr(), "");
+    FAST_CHECK_EQUAL(obj["nyuknyuknyuk"].getValStr(), "");
 
-    BOOST_CHECK(obj.exists("age"));
-    BOOST_CHECK(obj.exists("first"));
-    BOOST_CHECK(obj.exists("last"));
-    BOOST_CHECK(obj.exists("distance"));
-    BOOST_CHECK(obj.exists("time"));
-    BOOST_CHECK(obj.exists("calories"));
-    BOOST_CHECK(obj.exists("temperature"));
-    BOOST_CHECK(obj.exists("cat1"));
-    BOOST_CHECK(obj.exists("cat2"));
+    FAST_CHECK(obj.exists("age"));
+    FAST_CHECK(obj.exists("first"));
+    FAST_CHECK(obj.exists("last"));
+    FAST_CHECK(obj.exists("distance"));
+    FAST_CHECK(obj.exists("time"));
+    FAST_CHECK(obj.exists("calories"));
+    FAST_CHECK(obj.exists("temperature"));
+    FAST_CHECK(obj.exists("cat1"));
+    FAST_CHECK(obj.exists("cat2"));
 
-    BOOST_CHECK(!obj.exists("nyuknyuknyuk"));
+    FAST_CHECK(!obj.exists("nyuknyuknyuk"));
 
     map<string, UniValue::VType> objTypes;
     objTypes["age"] = UniValue::VNUM;
@@ -276,14 +276,14 @@ BOOST_AUTO_TEST_CASE(univalue_object)
     objTypes["temperature"] = UniValue::VNUM;
     objTypes["cat1"] = UniValue::VNUM;
     objTypes["cat2"] = UniValue::VNUM;
-    BOOST_CHECK(obj.checkObject(objTypes));
+    FAST_CHECK(obj.checkObject(objTypes));
 
     objTypes["cat2"] = UniValue::VSTR;
-    BOOST_CHECK(!obj.checkObject(objTypes));
+    FAST_CHECK(!obj.checkObject(objTypes));
 
     obj.clear();
-    BOOST_CHECK(obj.empty());
-    BOOST_CHECK_EQUAL(obj.size(), 0);
+    FAST_CHECK(obj.empty());
+    FAST_CHECK_EQUAL(obj.size(), 0);
 }
 
 static const char *json1 =
@@ -292,44 +292,44 @@ static const char *json1 =
 BOOST_AUTO_TEST_CASE(univalue_readwrite)
 {
     UniValue v;
-    BOOST_CHECK(v.read(json1));
+    FAST_CHECK(v.read(json1));
 
     string strJson1(json1);
-    BOOST_CHECK(v.read(strJson1));
+    FAST_CHECK(v.read(strJson1));
 
-    BOOST_CHECK(v.isArray());
-    BOOST_CHECK_EQUAL(v.size(), 2);
+    FAST_CHECK(v.isArray());
+    FAST_CHECK_EQUAL(v.size(), 2);
 
-    BOOST_CHECK_EQUAL(v[0].getValStr(), "1.10000000");
+    FAST_CHECK_EQUAL(v[0].getValStr(), "1.10000000");
 
     UniValue obj = v[1];
-    BOOST_CHECK(obj.isObject());
-    BOOST_CHECK_EQUAL(obj.size(), 3);
+    FAST_CHECK(obj.isObject());
+    FAST_CHECK_EQUAL(obj.size(), 3);
 
-    BOOST_CHECK(obj["key1"].isStr());
+    FAST_CHECK(obj["key1"].isStr());
     std::string correctValue("str");
     correctValue.push_back('\0');
-    BOOST_CHECK_EQUAL(obj["key1"].getValStr(), correctValue);
-    BOOST_CHECK(obj["key2"].isNum());
-    BOOST_CHECK_EQUAL(obj["key2"].getValStr(), "800");
-    BOOST_CHECK(obj["key3"].isObject());
+    FAST_CHECK_EQUAL(obj["key1"].getValStr(), correctValue);
+    FAST_CHECK(obj["key2"].isNum());
+    FAST_CHECK_EQUAL(obj["key2"].getValStr(), "800");
+    FAST_CHECK(obj["key3"].isObject());
 
-    BOOST_CHECK_EQUAL(strJson1, v.write());
+    FAST_CHECK_EQUAL(strJson1, v.write());
 
     /* Check for (correctly reporting) a parsing error if the initial
        JSON construct is followed by more stuff.  Note that whitespace
        is, of course, exempt.  */
 
-    BOOST_CHECK(v.read("  {}\n  "));
-    BOOST_CHECK(v.isObject());
-    BOOST_CHECK(v.read("  []\n  "));
-    BOOST_CHECK(v.isArray());
+    FAST_CHECK(v.read("  {}\n  "));
+    FAST_CHECK(v.isObject());
+    FAST_CHECK(v.read("  []\n  "));
+    FAST_CHECK(v.isArray());
 
-    BOOST_CHECK(!v.read("@{}"));
-    BOOST_CHECK(!v.read("{} garbage"));
-    BOOST_CHECK(!v.read("[]{}"));
-    BOOST_CHECK(!v.read("{}[]"));
-    BOOST_CHECK(!v.read("{} 42"));
+    FAST_CHECK(!v.read("@{}"));
+    FAST_CHECK(!v.read("{} garbage"));
+    FAST_CHECK(!v.read("[]{}"));
+    FAST_CHECK(!v.read("{}[]"));
+    FAST_CHECK(!v.read("{} 42"));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -54,38 +54,38 @@ BOOST_AUTO_TEST_CASE(util_ParseHex)
     std::vector<unsigned char> expected(ParseHex_expected, ParseHex_expected + sizeof(ParseHex_expected));
     // Basic test vector
     result = ParseHex("04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5f");
-    BOOST_CHECK_EQUAL_COLLECTIONS(result.begin(), result.end(), expected.begin(), expected.end());
+    FAST_CHECK_EQUAL_COLLECTIONS(result.begin(), result.end(), expected.begin(), expected.end());
 
     // Spaces between bytes must be supported
     result = ParseHex("12 34 56 78");
-    BOOST_CHECK(result.size() == 4 && result[0] == 0x12 && result[1] == 0x34 && result[2] == 0x56 && result[3] == 0x78);
+    FAST_CHECK(result.size() == 4 && result[0] == 0x12 && result[1] == 0x34 && result[2] == 0x56 && result[3] == 0x78);
 
     // Leading space must be supported (used in CDBEnv::Salvage)
     result = ParseHex(" 89 34 56 78");
-    BOOST_CHECK(result.size() == 4 && result[0] == 0x89 && result[1] == 0x34 && result[2] == 0x56 && result[3] == 0x78);
+    FAST_CHECK(result.size() == 4 && result[0] == 0x89 && result[1] == 0x34 && result[2] == 0x56 && result[3] == 0x78);
 
     // Stop parsing at invalid value
     result = ParseHex("1234 invalid 1234");
-    BOOST_CHECK(result.size() == 2 && result[0] == 0x12 && result[1] == 0x34);
+    FAST_CHECK(result.size() == 2 && result[0] == 0x12 && result[1] == 0x34);
 }
 
 BOOST_AUTO_TEST_CASE(util_HexStr)
 {
-    BOOST_CHECK_EQUAL(
+    FAST_CHECK_EQUAL(
         HexStr(ParseHex_expected, ParseHex_expected + sizeof(ParseHex_expected)),
         "04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5f");
 
-    BOOST_CHECK_EQUAL(
+    FAST_CHECK_EQUAL(
         HexStr(ParseHex_expected, ParseHex_expected + 5, true),
         "04 67 8a fd b0");
 
-    BOOST_CHECK_EQUAL(
+    FAST_CHECK_EQUAL(
         HexStr(ParseHex_expected, ParseHex_expected, true),
         "");
 
     std::vector<unsigned char> ParseHex_vec(ParseHex_expected, ParseHex_expected + 5);
 
-    BOOST_CHECK_EQUAL(
+    FAST_CHECK_EQUAL(
         HexStr(ParseHex_vec, true),
         "04 67 8a fd b0");
 }
@@ -93,11 +93,11 @@ BOOST_AUTO_TEST_CASE(util_HexStr)
 
 BOOST_AUTO_TEST_CASE(util_DateTimeStrFormat)
 {
-    BOOST_CHECK_EQUAL(DateTimeStrFormat("%Y-%m-%d %H:%M:%S", 0), "1970-01-01 00:00:00");
-    BOOST_CHECK_EQUAL(DateTimeStrFormat("%Y-%m-%d %H:%M:%S", 0x7FFFFFFF), "2038-01-19 03:14:07");
-    BOOST_CHECK_EQUAL(DateTimeStrFormat("%Y-%m-%d %H:%M:%S", 1317425777), "2011-09-30 23:36:17");
-    BOOST_CHECK_EQUAL(DateTimeStrFormat("%Y-%m-%d %H:%M", 1317425777), "2011-09-30 23:36");
-    BOOST_CHECK_EQUAL(DateTimeStrFormat("%a, %d %b %Y %H:%M:%S +0000", 1317425777), "Fri, 30 Sep 2011 23:36:17 +0000");
+    FAST_CHECK_EQUAL(DateTimeStrFormat("%Y-%m-%d %H:%M:%S", 0), "1970-01-01 00:00:00");
+    FAST_CHECK_EQUAL(DateTimeStrFormat("%Y-%m-%d %H:%M:%S", 0x7FFFFFFF), "2038-01-19 03:14:07");
+    FAST_CHECK_EQUAL(DateTimeStrFormat("%Y-%m-%d %H:%M:%S", 1317425777), "2011-09-30 23:36:17");
+    FAST_CHECK_EQUAL(DateTimeStrFormat("%Y-%m-%d %H:%M", 1317425777), "2011-09-30 23:36");
+    FAST_CHECK_EQUAL(DateTimeStrFormat("%a, %d %b %Y %H:%M:%S +0000", 1317425777), "Fri, 30 Sep 2011 23:36:17 +0000");
 }
 
 BOOST_AUTO_TEST_CASE(util_ParseParameters)
@@ -105,23 +105,23 @@ BOOST_AUTO_TEST_CASE(util_ParseParameters)
     const char *argv_test[] = {"-ignored", "-a", "-b", "-ccc=argument", "-ccc=multiple", "f", "-d=e"};
 
     ParseParameters(0, (char**)argv_test);
-    BOOST_CHECK(mapArgs.empty() && mapMultiArgs.empty());
+    FAST_CHECK(mapArgs.empty() && mapMultiArgs.empty());
 
     ParseParameters(1, (char**)argv_test);
-    BOOST_CHECK(mapArgs.empty() && mapMultiArgs.empty());
+    FAST_CHECK(mapArgs.empty() && mapMultiArgs.empty());
 
     ParseParameters(5, (char**)argv_test);
     // expectation: -ignored is ignored (program name argument),
     // -a, -b and -ccc end up in map, -d ignored because it is after
     // a non-option argument (non-GNU option parsing)
-    BOOST_CHECK(mapArgs.size() == 3 && mapMultiArgs.size() == 3);
-    BOOST_CHECK(mapArgs.count("-a") && mapArgs.count("-b") && mapArgs.count("-ccc")
+    FAST_CHECK(mapArgs.size() == 3 && mapMultiArgs.size() == 3);
+    FAST_CHECK(mapArgs.count("-a") && mapArgs.count("-b") && mapArgs.count("-ccc")
                 && !mapArgs.count("f") && !mapArgs.count("-d"));
-    BOOST_CHECK(mapMultiArgs.count("-a") && mapMultiArgs.count("-b") && mapMultiArgs.count("-ccc")
+    FAST_CHECK(mapMultiArgs.count("-a") && mapMultiArgs.count("-b") && mapMultiArgs.count("-ccc")
                 && !mapMultiArgs.count("f") && !mapMultiArgs.count("-d"));
 
-    BOOST_CHECK(mapArgs["-a"] == "" && mapArgs["-ccc"] == "multiple");
-    BOOST_CHECK(mapMultiArgs["-ccc"].size() == 2);
+    FAST_CHECK(mapArgs["-a"] == "" && mapArgs["-ccc"] == "multiple");
+    FAST_CHECK(mapMultiArgs["-ccc"].size() == 2);
 }
 
 BOOST_AUTO_TEST_CASE(util_GetArg)
@@ -137,108 +137,108 @@ BOOST_AUTO_TEST_CASE(util_GetArg)
     mapArgs["booltest3"] = "0";
     mapArgs["booltest4"] = "1";
 
-    BOOST_CHECK_EQUAL(GetArg("strtest1", "default"), "string...");
-    BOOST_CHECK_EQUAL(GetArg("strtest2", "default"), "default");
-    BOOST_CHECK_EQUAL(GetArg("inttest1", -1), 12345);
-    BOOST_CHECK_EQUAL(GetArg("inttest2", -1), 81985529216486895LL);
-    BOOST_CHECK_EQUAL(GetArg("inttest3", -1), -1);
-    BOOST_CHECK_EQUAL(GetBoolArg("booltest1", false), true);
-    BOOST_CHECK_EQUAL(GetBoolArg("booltest2", false), false);
-    BOOST_CHECK_EQUAL(GetBoolArg("booltest3", false), false);
-    BOOST_CHECK_EQUAL(GetBoolArg("booltest4", false), true);
+    FAST_CHECK_EQUAL(GetArg("strtest1", "default"), "string...");
+    FAST_CHECK_EQUAL(GetArg("strtest2", "default"), "default");
+    FAST_CHECK_EQUAL(GetArg("inttest1", -1), 12345);
+    FAST_CHECK_EQUAL(GetArg("inttest2", -1), 81985529216486895LL);
+    FAST_CHECK_EQUAL(GetArg("inttest3", -1), -1);
+    FAST_CHECK_EQUAL(GetBoolArg("booltest1", false), true);
+    FAST_CHECK_EQUAL(GetBoolArg("booltest2", false), false);
+    FAST_CHECK_EQUAL(GetBoolArg("booltest3", false), false);
+    FAST_CHECK_EQUAL(GetBoolArg("booltest4", false), true);
 }
 
 BOOST_AUTO_TEST_CASE(util_FormatMoney)
 {
-    BOOST_CHECK_EQUAL(FormatMoney(0), "0.00");
-    BOOST_CHECK_EQUAL(FormatMoney((COIN/10000)*123456789), "12345.6789");
-    BOOST_CHECK_EQUAL(FormatMoney(-COIN), "-1.00");
+    FAST_CHECK_EQUAL(FormatMoney(0), "0.00");
+    FAST_CHECK_EQUAL(FormatMoney((COIN/10000)*123456789), "12345.6789");
+    FAST_CHECK_EQUAL(FormatMoney(-COIN), "-1.00");
 
-    BOOST_CHECK_EQUAL(FormatMoney(COIN*100000000), "100000000.00");
-    BOOST_CHECK_EQUAL(FormatMoney(COIN*10000000), "10000000.00");
-    BOOST_CHECK_EQUAL(FormatMoney(COIN*1000000), "1000000.00");
-    BOOST_CHECK_EQUAL(FormatMoney(COIN*100000), "100000.00");
-    BOOST_CHECK_EQUAL(FormatMoney(COIN*10000), "10000.00");
-    BOOST_CHECK_EQUAL(FormatMoney(COIN*1000), "1000.00");
-    BOOST_CHECK_EQUAL(FormatMoney(COIN*100), "100.00");
-    BOOST_CHECK_EQUAL(FormatMoney(COIN*10), "10.00");
-    BOOST_CHECK_EQUAL(FormatMoney(COIN), "1.00");
-    BOOST_CHECK_EQUAL(FormatMoney(COIN/10), "0.10");
-    BOOST_CHECK_EQUAL(FormatMoney(COIN/100), "0.01");
-    BOOST_CHECK_EQUAL(FormatMoney(COIN/1000), "0.001");
-    BOOST_CHECK_EQUAL(FormatMoney(COIN/10000), "0.0001");
-    BOOST_CHECK_EQUAL(FormatMoney(COIN/100000), "0.00001");
-    BOOST_CHECK_EQUAL(FormatMoney(COIN/1000000), "0.000001");
-    BOOST_CHECK_EQUAL(FormatMoney(COIN/10000000), "0.0000001");
-    BOOST_CHECK_EQUAL(FormatMoney(COIN/100000000), "0.00000001");
+    FAST_CHECK_EQUAL(FormatMoney(COIN*100000000), "100000000.00");
+    FAST_CHECK_EQUAL(FormatMoney(COIN*10000000), "10000000.00");
+    FAST_CHECK_EQUAL(FormatMoney(COIN*1000000), "1000000.00");
+    FAST_CHECK_EQUAL(FormatMoney(COIN*100000), "100000.00");
+    FAST_CHECK_EQUAL(FormatMoney(COIN*10000), "10000.00");
+    FAST_CHECK_EQUAL(FormatMoney(COIN*1000), "1000.00");
+    FAST_CHECK_EQUAL(FormatMoney(COIN*100), "100.00");
+    FAST_CHECK_EQUAL(FormatMoney(COIN*10), "10.00");
+    FAST_CHECK_EQUAL(FormatMoney(COIN), "1.00");
+    FAST_CHECK_EQUAL(FormatMoney(COIN/10), "0.10");
+    FAST_CHECK_EQUAL(FormatMoney(COIN/100), "0.01");
+    FAST_CHECK_EQUAL(FormatMoney(COIN/1000), "0.001");
+    FAST_CHECK_EQUAL(FormatMoney(COIN/10000), "0.0001");
+    FAST_CHECK_EQUAL(FormatMoney(COIN/100000), "0.00001");
+    FAST_CHECK_EQUAL(FormatMoney(COIN/1000000), "0.000001");
+    FAST_CHECK_EQUAL(FormatMoney(COIN/10000000), "0.0000001");
+    FAST_CHECK_EQUAL(FormatMoney(COIN/100000000), "0.00000001");
 }
 
 BOOST_AUTO_TEST_CASE(util_ParseMoney)
 {
     CAmount ret = 0;
-    BOOST_CHECK(ParseMoney("0.0", ret));
-    BOOST_CHECK_EQUAL(ret, 0);
+    FAST_CHECK(ParseMoney("0.0", ret));
+    FAST_CHECK_EQUAL(ret, 0);
 
-    BOOST_CHECK(ParseMoney("12345.6789", ret));
-    BOOST_CHECK_EQUAL(ret, (COIN/10000)*123456789);
+    FAST_CHECK(ParseMoney("12345.6789", ret));
+    FAST_CHECK_EQUAL(ret, (COIN/10000)*123456789);
 
-    BOOST_CHECK(ParseMoney("100000000.00", ret));
-    BOOST_CHECK_EQUAL(ret, COIN*100000000);
-    BOOST_CHECK(ParseMoney("10000000.00", ret));
-    BOOST_CHECK_EQUAL(ret, COIN*10000000);
-    BOOST_CHECK(ParseMoney("1000000.00", ret));
-    BOOST_CHECK_EQUAL(ret, COIN*1000000);
-    BOOST_CHECK(ParseMoney("100000.00", ret));
-    BOOST_CHECK_EQUAL(ret, COIN*100000);
-    BOOST_CHECK(ParseMoney("10000.00", ret));
-    BOOST_CHECK_EQUAL(ret, COIN*10000);
-    BOOST_CHECK(ParseMoney("1000.00", ret));
-    BOOST_CHECK_EQUAL(ret, COIN*1000);
-    BOOST_CHECK(ParseMoney("100.00", ret));
-    BOOST_CHECK_EQUAL(ret, COIN*100);
-    BOOST_CHECK(ParseMoney("10.00", ret));
-    BOOST_CHECK_EQUAL(ret, COIN*10);
-    BOOST_CHECK(ParseMoney("1.00", ret));
-    BOOST_CHECK_EQUAL(ret, COIN);
-    BOOST_CHECK(ParseMoney("1", ret));
-    BOOST_CHECK_EQUAL(ret, COIN);
-    BOOST_CHECK(ParseMoney("0.1", ret));
-    BOOST_CHECK_EQUAL(ret, COIN/10);
-    BOOST_CHECK(ParseMoney("0.01", ret));
-    BOOST_CHECK_EQUAL(ret, COIN/100);
-    BOOST_CHECK(ParseMoney("0.001", ret));
-    BOOST_CHECK_EQUAL(ret, COIN/1000);
-    BOOST_CHECK(ParseMoney("0.0001", ret));
-    BOOST_CHECK_EQUAL(ret, COIN/10000);
-    BOOST_CHECK(ParseMoney("0.00001", ret));
-    BOOST_CHECK_EQUAL(ret, COIN/100000);
-    BOOST_CHECK(ParseMoney("0.000001", ret));
-    BOOST_CHECK_EQUAL(ret, COIN/1000000);
-    BOOST_CHECK(ParseMoney("0.0000001", ret));
-    BOOST_CHECK_EQUAL(ret, COIN/10000000);
-    BOOST_CHECK(ParseMoney("0.00000001", ret));
-    BOOST_CHECK_EQUAL(ret, COIN/100000000);
+    FAST_CHECK(ParseMoney("100000000.00", ret));
+    FAST_CHECK_EQUAL(ret, COIN*100000000);
+    FAST_CHECK(ParseMoney("10000000.00", ret));
+    FAST_CHECK_EQUAL(ret, COIN*10000000);
+    FAST_CHECK(ParseMoney("1000000.00", ret));
+    FAST_CHECK_EQUAL(ret, COIN*1000000);
+    FAST_CHECK(ParseMoney("100000.00", ret));
+    FAST_CHECK_EQUAL(ret, COIN*100000);
+    FAST_CHECK(ParseMoney("10000.00", ret));
+    FAST_CHECK_EQUAL(ret, COIN*10000);
+    FAST_CHECK(ParseMoney("1000.00", ret));
+    FAST_CHECK_EQUAL(ret, COIN*1000);
+    FAST_CHECK(ParseMoney("100.00", ret));
+    FAST_CHECK_EQUAL(ret, COIN*100);
+    FAST_CHECK(ParseMoney("10.00", ret));
+    FAST_CHECK_EQUAL(ret, COIN*10);
+    FAST_CHECK(ParseMoney("1.00", ret));
+    FAST_CHECK_EQUAL(ret, COIN);
+    FAST_CHECK(ParseMoney("1", ret));
+    FAST_CHECK_EQUAL(ret, COIN);
+    FAST_CHECK(ParseMoney("0.1", ret));
+    FAST_CHECK_EQUAL(ret, COIN/10);
+    FAST_CHECK(ParseMoney("0.01", ret));
+    FAST_CHECK_EQUAL(ret, COIN/100);
+    FAST_CHECK(ParseMoney("0.001", ret));
+    FAST_CHECK_EQUAL(ret, COIN/1000);
+    FAST_CHECK(ParseMoney("0.0001", ret));
+    FAST_CHECK_EQUAL(ret, COIN/10000);
+    FAST_CHECK(ParseMoney("0.00001", ret));
+    FAST_CHECK_EQUAL(ret, COIN/100000);
+    FAST_CHECK(ParseMoney("0.000001", ret));
+    FAST_CHECK_EQUAL(ret, COIN/1000000);
+    FAST_CHECK(ParseMoney("0.0000001", ret));
+    FAST_CHECK_EQUAL(ret, COIN/10000000);
+    FAST_CHECK(ParseMoney("0.00000001", ret));
+    FAST_CHECK_EQUAL(ret, COIN/100000000);
 
     // Attempted 63 bit overflow should fail
-    BOOST_CHECK(!ParseMoney("92233720368.54775808", ret));
+    FAST_CHECK(!ParseMoney("92233720368.54775808", ret));
 
     // Parsing negative amounts must fail
-    BOOST_CHECK(!ParseMoney("-1", ret));
+    FAST_CHECK(!ParseMoney("-1", ret));
 }
 
 BOOST_AUTO_TEST_CASE(util_IsHex)
 {
-    BOOST_CHECK(IsHex("00"));
-    BOOST_CHECK(IsHex("00112233445566778899aabbccddeeffAABBCCDDEEFF"));
-    BOOST_CHECK(IsHex("ff"));
-    BOOST_CHECK(IsHex("FF"));
+    FAST_CHECK(IsHex("00"));
+    FAST_CHECK(IsHex("00112233445566778899aabbccddeeffAABBCCDDEEFF"));
+    FAST_CHECK(IsHex("ff"));
+    FAST_CHECK(IsHex("FF"));
 
-    BOOST_CHECK(!IsHex(""));
-    BOOST_CHECK(!IsHex("0"));
-    BOOST_CHECK(!IsHex("a"));
-    BOOST_CHECK(!IsHex("eleven"));
-    BOOST_CHECK(!IsHex("00xx00"));
-    BOOST_CHECK(!IsHex("0x0000"));
+    FAST_CHECK(!IsHex(""));
+    FAST_CHECK(!IsHex("0"));
+    FAST_CHECK(!IsHex("a"));
+    FAST_CHECK(!IsHex("eleven"));
+    FAST_CHECK(!IsHex("00xx00"));
+    FAST_CHECK(!IsHex("0x0000"));
 }
 
 BOOST_AUTO_TEST_CASE(util_seed_insecure_rand)
@@ -261,20 +261,20 @@ BOOST_AUTO_TEST_CASE(util_seed_insecure_rand)
             }while(rval>=(uint32_t)mod);
             count += rval==0;
         }
-        BOOST_CHECK(count<=10000/mod+err);
-        BOOST_CHECK(count>=10000/mod-err);
+        FAST_CHECK(count<=10000/mod+err);
+        FAST_CHECK(count>=10000/mod-err);
     }
 }
 
 BOOST_AUTO_TEST_CASE(util_TimingResistantEqual)
 {
-    BOOST_CHECK(TimingResistantEqual(std::string(""), std::string("")));
-    BOOST_CHECK(!TimingResistantEqual(std::string("abc"), std::string("")));
-    BOOST_CHECK(!TimingResistantEqual(std::string(""), std::string("abc")));
-    BOOST_CHECK(!TimingResistantEqual(std::string("a"), std::string("aa")));
-    BOOST_CHECK(!TimingResistantEqual(std::string("aa"), std::string("a")));
-    BOOST_CHECK(TimingResistantEqual(std::string("abc"), std::string("abc")));
-    BOOST_CHECK(!TimingResistantEqual(std::string("abc"), std::string("aba")));
+    FAST_CHECK(TimingResistantEqual(std::string(""), std::string("")));
+    FAST_CHECK(!TimingResistantEqual(std::string("abc"), std::string("")));
+    FAST_CHECK(!TimingResistantEqual(std::string(""), std::string("abc")));
+    FAST_CHECK(!TimingResistantEqual(std::string("a"), std::string("aa")));
+    FAST_CHECK(!TimingResistantEqual(std::string("aa"), std::string("a")));
+    FAST_CHECK(TimingResistantEqual(std::string("abc"), std::string("abc")));
+    FAST_CHECK(!TimingResistantEqual(std::string("abc"), std::string("aba")));
 }
 
 /* Test strprintf formatting directives.
@@ -285,21 +285,21 @@ BOOST_AUTO_TEST_CASE(strprintf_numbers)
 {
     int64_t s64t = -9223372036854775807LL; /* signed 64 bit test value */
     uint64_t u64t = 18446744073709551615ULL; /* unsigned 64 bit test value */
-    BOOST_CHECK(strprintf("%s %d %s", B, s64t, E) == B" -9223372036854775807 " E);
-    BOOST_CHECK(strprintf("%s %u %s", B, u64t, E) == B" 18446744073709551615 " E);
-    BOOST_CHECK(strprintf("%s %x %s", B, u64t, E) == B" ffffffffffffffff " E);
+    FAST_CHECK(strprintf("%s %d %s", B, s64t, E) == B" -9223372036854775807 " E);
+    FAST_CHECK(strprintf("%s %u %s", B, u64t, E) == B" 18446744073709551615 " E);
+    FAST_CHECK(strprintf("%s %x %s", B, u64t, E) == B" ffffffffffffffff " E);
 
     size_t st = 12345678; /* unsigned size_t test value */
     ssize_t sst = -12345678; /* signed size_t test value */
-    BOOST_CHECK(strprintf("%s %d %s", B, sst, E) == B" -12345678 " E);
-    BOOST_CHECK(strprintf("%s %u %s", B, st, E) == B" 12345678 " E);
-    BOOST_CHECK(strprintf("%s %x %s", B, st, E) == B" bc614e " E);
+    FAST_CHECK(strprintf("%s %d %s", B, sst, E) == B" -12345678 " E);
+    FAST_CHECK(strprintf("%s %u %s", B, st, E) == B" 12345678 " E);
+    FAST_CHECK(strprintf("%s %x %s", B, st, E) == B" bc614e " E);
 
     ptrdiff_t pt = 87654321; /* positive ptrdiff_t test value */
     ptrdiff_t spt = -87654321; /* negative ptrdiff_t test value */
-    BOOST_CHECK(strprintf("%s %d %s", B, spt, E) == B" -87654321 " E);
-    BOOST_CHECK(strprintf("%s %u %s", B, pt, E) == B" 87654321 " E);
-    BOOST_CHECK(strprintf("%s %x %s", B, pt, E) == B" 5397fb1 " E);
+    FAST_CHECK(strprintf("%s %d %s", B, spt, E) == B" -87654321 " E);
+    FAST_CHECK(strprintf("%s %u %s", B, pt, E) == B" 87654321 " E);
+    FAST_CHECK(strprintf("%s %x %s", B, pt, E) == B" 5397fb1 " E);
 }
 #undef B
 #undef E
@@ -309,184 +309,184 @@ BOOST_AUTO_TEST_CASE(strprintf_numbers)
  */
 BOOST_AUTO_TEST_CASE(gettime)
 {
-    BOOST_CHECK((GetTime() & ~0xFFFFFFFFLL) == 0);
+    FAST_CHECK((GetTime() & ~0xFFFFFFFFLL) == 0);
 }
 
 BOOST_AUTO_TEST_CASE(test_ParseInt32)
 {
     int32_t n;
     // Valid values
-    BOOST_CHECK(ParseInt32("1234", NULL));
-    BOOST_CHECK(ParseInt32("0", &n) && n == 0);
-    BOOST_CHECK(ParseInt32("1234", &n) && n == 1234);
-    BOOST_CHECK(ParseInt32("01234", &n) && n == 1234); // no octal
-    BOOST_CHECK(ParseInt32("2147483647", &n) && n == 2147483647);
-    BOOST_CHECK(ParseInt32("-2147483648", &n) && n == -2147483648);
-    BOOST_CHECK(ParseInt32("-1234", &n) && n == -1234);
+    FAST_CHECK(ParseInt32("1234", NULL));
+    FAST_CHECK(ParseInt32("0", &n) && n == 0);
+    FAST_CHECK(ParseInt32("1234", &n) && n == 1234);
+    FAST_CHECK(ParseInt32("01234", &n) && n == 1234); // no octal
+    FAST_CHECK(ParseInt32("2147483647", &n) && n == 2147483647);
+    FAST_CHECK(ParseInt32("-2147483648", &n) && n == -2147483648);
+    FAST_CHECK(ParseInt32("-1234", &n) && n == -1234);
     // Invalid values
-    BOOST_CHECK(!ParseInt32("", &n));
-    BOOST_CHECK(!ParseInt32(" 1", &n)); // no padding inside
-    BOOST_CHECK(!ParseInt32("1 ", &n));
-    BOOST_CHECK(!ParseInt32("1a", &n));
-    BOOST_CHECK(!ParseInt32("aap", &n));
-    BOOST_CHECK(!ParseInt32("0x1", &n)); // no hex
-    BOOST_CHECK(!ParseInt32("0x1", &n)); // no hex
+    FAST_CHECK(!ParseInt32("", &n));
+    FAST_CHECK(!ParseInt32(" 1", &n)); // no padding inside
+    FAST_CHECK(!ParseInt32("1 ", &n));
+    FAST_CHECK(!ParseInt32("1a", &n));
+    FAST_CHECK(!ParseInt32("aap", &n));
+    FAST_CHECK(!ParseInt32("0x1", &n)); // no hex
+    FAST_CHECK(!ParseInt32("0x1", &n)); // no hex
     const char test_bytes[] = {'1', 0, '1'};
     std::string teststr(test_bytes, sizeof(test_bytes));
-    BOOST_CHECK(!ParseInt32(teststr, &n)); // no embedded NULs
+    FAST_CHECK(!ParseInt32(teststr, &n)); // no embedded NULs
     // Overflow and underflow
-    BOOST_CHECK(!ParseInt32("-2147483649", NULL));
-    BOOST_CHECK(!ParseInt32("2147483648", NULL));
-    BOOST_CHECK(!ParseInt32("-32482348723847471234", NULL));
-    BOOST_CHECK(!ParseInt32("32482348723847471234", NULL));
+    FAST_CHECK(!ParseInt32("-2147483649", NULL));
+    FAST_CHECK(!ParseInt32("2147483648", NULL));
+    FAST_CHECK(!ParseInt32("-32482348723847471234", NULL));
+    FAST_CHECK(!ParseInt32("32482348723847471234", NULL));
 }
 
 BOOST_AUTO_TEST_CASE(test_ParseInt64)
 {
     int64_t n;
     // Valid values
-    BOOST_CHECK(ParseInt64("1234", NULL));
-    BOOST_CHECK(ParseInt64("0", &n) && n == 0LL);
-    BOOST_CHECK(ParseInt64("1234", &n) && n == 1234LL);
-    BOOST_CHECK(ParseInt64("01234", &n) && n == 1234LL); // no octal
-    BOOST_CHECK(ParseInt64("2147483647", &n) && n == 2147483647LL);
-    BOOST_CHECK(ParseInt64("-2147483648", &n) && n == -2147483648LL);
-    BOOST_CHECK(ParseInt64("9223372036854775807", &n) && n == (int64_t)9223372036854775807);
-    BOOST_CHECK(ParseInt64("-9223372036854775808", &n) && n == (int64_t)-9223372036854775807-1);
-    BOOST_CHECK(ParseInt64("-1234", &n) && n == -1234LL);
+    FAST_CHECK(ParseInt64("1234", NULL));
+    FAST_CHECK(ParseInt64("0", &n) && n == 0LL);
+    FAST_CHECK(ParseInt64("1234", &n) && n == 1234LL);
+    FAST_CHECK(ParseInt64("01234", &n) && n == 1234LL); // no octal
+    FAST_CHECK(ParseInt64("2147483647", &n) && n == 2147483647LL);
+    FAST_CHECK(ParseInt64("-2147483648", &n) && n == -2147483648LL);
+    FAST_CHECK(ParseInt64("9223372036854775807", &n) && n == (int64_t)9223372036854775807);
+    FAST_CHECK(ParseInt64("-9223372036854775808", &n) && n == (int64_t)-9223372036854775807-1);
+    FAST_CHECK(ParseInt64("-1234", &n) && n == -1234LL);
     // Invalid values
-    BOOST_CHECK(!ParseInt64("", &n));
-    BOOST_CHECK(!ParseInt64(" 1", &n)); // no padding inside
-    BOOST_CHECK(!ParseInt64("1 ", &n));
-    BOOST_CHECK(!ParseInt64("1a", &n));
-    BOOST_CHECK(!ParseInt64("aap", &n));
-    BOOST_CHECK(!ParseInt64("0x1", &n)); // no hex
+    FAST_CHECK(!ParseInt64("", &n));
+    FAST_CHECK(!ParseInt64(" 1", &n)); // no padding inside
+    FAST_CHECK(!ParseInt64("1 ", &n));
+    FAST_CHECK(!ParseInt64("1a", &n));
+    FAST_CHECK(!ParseInt64("aap", &n));
+    FAST_CHECK(!ParseInt64("0x1", &n)); // no hex
     const char test_bytes[] = {'1', 0, '1'};
     std::string teststr(test_bytes, sizeof(test_bytes));
-    BOOST_CHECK(!ParseInt64(teststr, &n)); // no embedded NULs
+    FAST_CHECK(!ParseInt64(teststr, &n)); // no embedded NULs
     // Overflow and underflow
-    BOOST_CHECK(!ParseInt64("-9223372036854775809", NULL));
-    BOOST_CHECK(!ParseInt64("9223372036854775808", NULL));
-    BOOST_CHECK(!ParseInt64("-32482348723847471234", NULL));
-    BOOST_CHECK(!ParseInt64("32482348723847471234", NULL));
+    FAST_CHECK(!ParseInt64("-9223372036854775809", NULL));
+    FAST_CHECK(!ParseInt64("9223372036854775808", NULL));
+    FAST_CHECK(!ParseInt64("-32482348723847471234", NULL));
+    FAST_CHECK(!ParseInt64("32482348723847471234", NULL));
 }
 
 BOOST_AUTO_TEST_CASE(test_ParseUInt32)
 {
     uint32_t n;
     // Valid values
-    BOOST_CHECK(ParseUInt32("1234", NULL));
-    BOOST_CHECK(ParseUInt32("0", &n) && n == 0);
-    BOOST_CHECK(ParseUInt32("1234", &n) && n == 1234);
-    BOOST_CHECK(ParseUInt32("01234", &n) && n == 1234); // no octal
-    BOOST_CHECK(ParseUInt32("2147483647", &n) && n == 2147483647);
-    BOOST_CHECK(ParseUInt32("2147483648", &n) && n == (uint32_t)2147483648);
-    BOOST_CHECK(ParseUInt32("4294967295", &n) && n == (uint32_t)4294967295);
+    FAST_CHECK(ParseUInt32("1234", NULL));
+    FAST_CHECK(ParseUInt32("0", &n) && n == 0);
+    FAST_CHECK(ParseUInt32("1234", &n) && n == 1234);
+    FAST_CHECK(ParseUInt32("01234", &n) && n == 1234); // no octal
+    FAST_CHECK(ParseUInt32("2147483647", &n) && n == 2147483647);
+    FAST_CHECK(ParseUInt32("2147483648", &n) && n == (uint32_t)2147483648);
+    FAST_CHECK(ParseUInt32("4294967295", &n) && n == (uint32_t)4294967295);
     // Invalid values
-    BOOST_CHECK(!ParseUInt32("", &n));
-    BOOST_CHECK(!ParseUInt32(" 1", &n)); // no padding inside
-    BOOST_CHECK(!ParseUInt32(" -1", &n));
-    BOOST_CHECK(!ParseUInt32("1 ", &n));
-    BOOST_CHECK(!ParseUInt32("1a", &n));
-    BOOST_CHECK(!ParseUInt32("aap", &n));
-    BOOST_CHECK(!ParseUInt32("0x1", &n)); // no hex
-    BOOST_CHECK(!ParseUInt32("0x1", &n)); // no hex
+    FAST_CHECK(!ParseUInt32("", &n));
+    FAST_CHECK(!ParseUInt32(" 1", &n)); // no padding inside
+    FAST_CHECK(!ParseUInt32(" -1", &n));
+    FAST_CHECK(!ParseUInt32("1 ", &n));
+    FAST_CHECK(!ParseUInt32("1a", &n));
+    FAST_CHECK(!ParseUInt32("aap", &n));
+    FAST_CHECK(!ParseUInt32("0x1", &n)); // no hex
+    FAST_CHECK(!ParseUInt32("0x1", &n)); // no hex
     const char test_bytes[] = {'1', 0, '1'};
     std::string teststr(test_bytes, sizeof(test_bytes));
-    BOOST_CHECK(!ParseUInt32(teststr, &n)); // no embedded NULs
+    FAST_CHECK(!ParseUInt32(teststr, &n)); // no embedded NULs
     // Overflow and underflow
-    BOOST_CHECK(!ParseUInt32("-2147483648", &n));
-    BOOST_CHECK(!ParseUInt32("4294967296", &n));
-    BOOST_CHECK(!ParseUInt32("-1234", &n));
-    BOOST_CHECK(!ParseUInt32("-32482348723847471234", NULL));
-    BOOST_CHECK(!ParseUInt32("32482348723847471234", NULL));
+    FAST_CHECK(!ParseUInt32("-2147483648", &n));
+    FAST_CHECK(!ParseUInt32("4294967296", &n));
+    FAST_CHECK(!ParseUInt32("-1234", &n));
+    FAST_CHECK(!ParseUInt32("-32482348723847471234", NULL));
+    FAST_CHECK(!ParseUInt32("32482348723847471234", NULL));
 }
 
 BOOST_AUTO_TEST_CASE(test_ParseUInt64)
 {
     uint64_t n;
     // Valid values
-    BOOST_CHECK(ParseUInt64("1234", NULL));
-    BOOST_CHECK(ParseUInt64("0", &n) && n == 0LL);
-    BOOST_CHECK(ParseUInt64("1234", &n) && n == 1234LL);
-    BOOST_CHECK(ParseUInt64("01234", &n) && n == 1234LL); // no octal
-    BOOST_CHECK(ParseUInt64("2147483647", &n) && n == 2147483647LL);
-    BOOST_CHECK(ParseUInt64("9223372036854775807", &n) && n == 9223372036854775807ULL);
-    BOOST_CHECK(ParseUInt64("9223372036854775808", &n) && n == 9223372036854775808ULL);
-    BOOST_CHECK(ParseUInt64("18446744073709551615", &n) && n == 18446744073709551615ULL);
+    FAST_CHECK(ParseUInt64("1234", NULL));
+    FAST_CHECK(ParseUInt64("0", &n) && n == 0LL);
+    FAST_CHECK(ParseUInt64("1234", &n) && n == 1234LL);
+    FAST_CHECK(ParseUInt64("01234", &n) && n == 1234LL); // no octal
+    FAST_CHECK(ParseUInt64("2147483647", &n) && n == 2147483647LL);
+    FAST_CHECK(ParseUInt64("9223372036854775807", &n) && n == 9223372036854775807ULL);
+    FAST_CHECK(ParseUInt64("9223372036854775808", &n) && n == 9223372036854775808ULL);
+    FAST_CHECK(ParseUInt64("18446744073709551615", &n) && n == 18446744073709551615ULL);
     // Invalid values
-    BOOST_CHECK(!ParseUInt64("", &n));
-    BOOST_CHECK(!ParseUInt64(" 1", &n)); // no padding inside
-    BOOST_CHECK(!ParseUInt64(" -1", &n));
-    BOOST_CHECK(!ParseUInt64("1 ", &n));
-    BOOST_CHECK(!ParseUInt64("1a", &n));
-    BOOST_CHECK(!ParseUInt64("aap", &n));
-    BOOST_CHECK(!ParseUInt64("0x1", &n)); // no hex
+    FAST_CHECK(!ParseUInt64("", &n));
+    FAST_CHECK(!ParseUInt64(" 1", &n)); // no padding inside
+    FAST_CHECK(!ParseUInt64(" -1", &n));
+    FAST_CHECK(!ParseUInt64("1 ", &n));
+    FAST_CHECK(!ParseUInt64("1a", &n));
+    FAST_CHECK(!ParseUInt64("aap", &n));
+    FAST_CHECK(!ParseUInt64("0x1", &n)); // no hex
     const char test_bytes[] = {'1', 0, '1'};
     std::string teststr(test_bytes, sizeof(test_bytes));
-    BOOST_CHECK(!ParseUInt64(teststr, &n)); // no embedded NULs
+    FAST_CHECK(!ParseUInt64(teststr, &n)); // no embedded NULs
     // Overflow and underflow
-    BOOST_CHECK(!ParseUInt64("-9223372036854775809", NULL));
-    BOOST_CHECK(!ParseUInt64("18446744073709551616", NULL));
-    BOOST_CHECK(!ParseUInt64("-32482348723847471234", NULL));
-    BOOST_CHECK(!ParseUInt64("-2147483648", &n));
-    BOOST_CHECK(!ParseUInt64("-9223372036854775808", &n));
-    BOOST_CHECK(!ParseUInt64("-1234", &n));
+    FAST_CHECK(!ParseUInt64("-9223372036854775809", NULL));
+    FAST_CHECK(!ParseUInt64("18446744073709551616", NULL));
+    FAST_CHECK(!ParseUInt64("-32482348723847471234", NULL));
+    FAST_CHECK(!ParseUInt64("-2147483648", &n));
+    FAST_CHECK(!ParseUInt64("-9223372036854775808", &n));
+    FAST_CHECK(!ParseUInt64("-1234", &n));
 }
 
 BOOST_AUTO_TEST_CASE(test_ParseDouble)
 {
     double n;
     // Valid values
-    BOOST_CHECK(ParseDouble("1234", NULL));
-    BOOST_CHECK(ParseDouble("0", &n) && n == 0.0);
-    BOOST_CHECK(ParseDouble("1234", &n) && n == 1234.0);
-    BOOST_CHECK(ParseDouble("01234", &n) && n == 1234.0); // no octal
-    BOOST_CHECK(ParseDouble("2147483647", &n) && n == 2147483647.0);
-    BOOST_CHECK(ParseDouble("-2147483648", &n) && n == -2147483648.0);
-    BOOST_CHECK(ParseDouble("-1234", &n) && n == -1234.0);
-    BOOST_CHECK(ParseDouble("1e6", &n) && n == 1e6);
-    BOOST_CHECK(ParseDouble("-1e6", &n) && n == -1e6);
+    FAST_CHECK(ParseDouble("1234", NULL));
+    FAST_CHECK(ParseDouble("0", &n) && n == 0.0);
+    FAST_CHECK(ParseDouble("1234", &n) && n == 1234.0);
+    FAST_CHECK(ParseDouble("01234", &n) && n == 1234.0); // no octal
+    FAST_CHECK(ParseDouble("2147483647", &n) && n == 2147483647.0);
+    FAST_CHECK(ParseDouble("-2147483648", &n) && n == -2147483648.0);
+    FAST_CHECK(ParseDouble("-1234", &n) && n == -1234.0);
+    FAST_CHECK(ParseDouble("1e6", &n) && n == 1e6);
+    FAST_CHECK(ParseDouble("-1e6", &n) && n == -1e6);
     // Invalid values
-    BOOST_CHECK(!ParseDouble("", &n));
-    BOOST_CHECK(!ParseDouble(" 1", &n)); // no padding inside
-    BOOST_CHECK(!ParseDouble("1 ", &n));
-    BOOST_CHECK(!ParseDouble("1a", &n));
-    BOOST_CHECK(!ParseDouble("aap", &n));
-    BOOST_CHECK(!ParseDouble("0x1", &n)); // no hex
+    FAST_CHECK(!ParseDouble("", &n));
+    FAST_CHECK(!ParseDouble(" 1", &n)); // no padding inside
+    FAST_CHECK(!ParseDouble("1 ", &n));
+    FAST_CHECK(!ParseDouble("1a", &n));
+    FAST_CHECK(!ParseDouble("aap", &n));
+    FAST_CHECK(!ParseDouble("0x1", &n)); // no hex
     const char test_bytes[] = {'1', 0, '1'};
     std::string teststr(test_bytes, sizeof(test_bytes));
-    BOOST_CHECK(!ParseDouble(teststr, &n)); // no embedded NULs
+    FAST_CHECK(!ParseDouble(teststr, &n)); // no embedded NULs
     // Overflow and underflow
-    BOOST_CHECK(!ParseDouble("-1e10000", NULL));
-    BOOST_CHECK(!ParseDouble("1e10000", NULL));
+    FAST_CHECK(!ParseDouble("-1e10000", NULL));
+    FAST_CHECK(!ParseDouble("1e10000", NULL));
 }
 
 BOOST_AUTO_TEST_CASE(test_FormatParagraph)
 {
-    BOOST_CHECK_EQUAL(FormatParagraph("", 79, 0), "");
-    BOOST_CHECK_EQUAL(FormatParagraph("test", 79, 0), "test");
-    BOOST_CHECK_EQUAL(FormatParagraph(" test", 79, 0), " test");
-    BOOST_CHECK_EQUAL(FormatParagraph("test test", 79, 0), "test test");
-    BOOST_CHECK_EQUAL(FormatParagraph("test test", 4, 0), "test\ntest");
-    BOOST_CHECK_EQUAL(FormatParagraph("testerde test", 4, 0), "testerde\ntest");
-    BOOST_CHECK_EQUAL(FormatParagraph("test test", 4, 4), "test\n    test");
+    FAST_CHECK_EQUAL(FormatParagraph("", 79, 0), "");
+    FAST_CHECK_EQUAL(FormatParagraph("test", 79, 0), "test");
+    FAST_CHECK_EQUAL(FormatParagraph(" test", 79, 0), " test");
+    FAST_CHECK_EQUAL(FormatParagraph("test test", 79, 0), "test test");
+    FAST_CHECK_EQUAL(FormatParagraph("test test", 4, 0), "test\ntest");
+    FAST_CHECK_EQUAL(FormatParagraph("testerde test", 4, 0), "testerde\ntest");
+    FAST_CHECK_EQUAL(FormatParagraph("test test", 4, 4), "test\n    test");
 
     // Make sure we don't indent a fully-new line following a too-long line ending
-    BOOST_CHECK_EQUAL(FormatParagraph("test test\nabc", 4, 4), "test\n    test\nabc");
+    FAST_CHECK_EQUAL(FormatParagraph("test test\nabc", 4, 4), "test\n    test\nabc");
 
-    BOOST_CHECK_EQUAL(FormatParagraph("This_is_a_very_long_test_string_without_any_spaces_so_it_should_just_get_returned_as_is_despite_the_length until it gets here", 79), "This_is_a_very_long_test_string_without_any_spaces_so_it_should_just_get_returned_as_is_despite_the_length\nuntil it gets here");
+    FAST_CHECK_EQUAL(FormatParagraph("This_is_a_very_long_test_string_without_any_spaces_so_it_should_just_get_returned_as_is_despite_the_length until it gets here", 79), "This_is_a_very_long_test_string_without_any_spaces_so_it_should_just_get_returned_as_is_despite_the_length\nuntil it gets here");
 
     // Test wrap length is exact
-    BOOST_CHECK_EQUAL(FormatParagraph("a b c d e f g h i j k l m n o p q r s t u v w x y z 1 2 3 4 5 6 7 8 9 a b c de f g h i j k l m n o p", 79), "a b c d e f g h i j k l m n o p q r s t u v w x y z 1 2 3 4 5 6 7 8 9 a b c de\nf g h i j k l m n o p");
-    BOOST_CHECK_EQUAL(FormatParagraph("x\na b c d e f g h i j k l m n o p q r s t u v w x y z 1 2 3 4 5 6 7 8 9 a b c de f g h i j k l m n o p", 79), "x\na b c d e f g h i j k l m n o p q r s t u v w x y z 1 2 3 4 5 6 7 8 9 a b c de\nf g h i j k l m n o p");
+    FAST_CHECK_EQUAL(FormatParagraph("a b c d e f g h i j k l m n o p q r s t u v w x y z 1 2 3 4 5 6 7 8 9 a b c de f g h i j k l m n o p", 79), "a b c d e f g h i j k l m n o p q r s t u v w x y z 1 2 3 4 5 6 7 8 9 a b c de\nf g h i j k l m n o p");
+    FAST_CHECK_EQUAL(FormatParagraph("x\na b c d e f g h i j k l m n o p q r s t u v w x y z 1 2 3 4 5 6 7 8 9 a b c de f g h i j k l m n o p", 79), "x\na b c d e f g h i j k l m n o p q r s t u v w x y z 1 2 3 4 5 6 7 8 9 a b c de\nf g h i j k l m n o p");
     // Indent should be included in length of lines
-    BOOST_CHECK_EQUAL(FormatParagraph("x\na b c d e f g h i j k l m n o p q r s t u v w x y z 1 2 3 4 5 6 7 8 9 a b c de f g h i j k l m n o p q r s t u v w x y z 0 1 2 3 4 5 6 7 8 9 a b c d e fg h i j k", 79, 4), "x\na b c d e f g h i j k l m n o p q r s t u v w x y z 1 2 3 4 5 6 7 8 9 a b c de\n    f g h i j k l m n o p q r s t u v w x y z 0 1 2 3 4 5 6 7 8 9 a b c d e fg\n    h i j k");
+    FAST_CHECK_EQUAL(FormatParagraph("x\na b c d e f g h i j k l m n o p q r s t u v w x y z 1 2 3 4 5 6 7 8 9 a b c de f g h i j k l m n o p q r s t u v w x y z 0 1 2 3 4 5 6 7 8 9 a b c d e fg h i j k", 79, 4), "x\na b c d e f g h i j k l m n o p q r s t u v w x y z 1 2 3 4 5 6 7 8 9 a b c de\n    f g h i j k l m n o p q r s t u v w x y z 0 1 2 3 4 5 6 7 8 9 a b c d e fg\n    h i j k");
 
-    BOOST_CHECK_EQUAL(FormatParagraph("This is a very long test string. This is a second sentence in the very long test string.", 79), "This is a very long test string. This is a second sentence in the very long\ntest string.");
-    BOOST_CHECK_EQUAL(FormatParagraph("This is a very long test string.\nThis is a second sentence in the very long test string. This is a third sentence in the very long test string.", 79), "This is a very long test string.\nThis is a second sentence in the very long test string. This is a third\nsentence in the very long test string.");
-    BOOST_CHECK_EQUAL(FormatParagraph("This is a very long test string.\n\nThis is a second sentence in the very long test string. This is a third sentence in the very long test string.", 79), "This is a very long test string.\n\nThis is a second sentence in the very long test string. This is a third\nsentence in the very long test string.");
-    BOOST_CHECK_EQUAL(FormatParagraph("Testing that normal newlines do not get indented.\nLike here.", 79), "Testing that normal newlines do not get indented.\nLike here.");
+    FAST_CHECK_EQUAL(FormatParagraph("This is a very long test string. This is a second sentence in the very long test string.", 79), "This is a very long test string. This is a second sentence in the very long\ntest string.");
+    FAST_CHECK_EQUAL(FormatParagraph("This is a very long test string.\nThis is a second sentence in the very long test string. This is a third sentence in the very long test string.", 79), "This is a very long test string.\nThis is a second sentence in the very long test string. This is a third\nsentence in the very long test string.");
+    FAST_CHECK_EQUAL(FormatParagraph("This is a very long test string.\n\nThis is a second sentence in the very long test string. This is a third sentence in the very long test string.", 79), "This is a very long test string.\n\nThis is a second sentence in the very long test string. This is a third\nsentence in the very long test string.");
+    FAST_CHECK_EQUAL(FormatParagraph("Testing that normal newlines do not get indented.\nLike here.", 79), "Testing that normal newlines do not get indented.\nLike here.");
 }
 
 BOOST_AUTO_TEST_CASE(test_FormatSubVersion)
@@ -496,74 +496,74 @@ BOOST_AUTO_TEST_CASE(test_FormatSubVersion)
     std::vector<std::string> comments2;
     comments2.push_back(std::string("comment1"));
     comments2.push_back(SanitizeString(std::string("Comment2; .,_?@-; !\"#$%&'()*+/<=>[]\\^`{|}~"), SAFE_CHARS_UA_COMMENT)); // Semicolon is discouraged but not forbidden by BIP-0014
-    BOOST_CHECK_EQUAL(FormatSubVersion("Test", 99900, std::vector<std::string>()),std::string("/Test:0.9.99/"));
-    BOOST_CHECK_EQUAL(FormatSubVersion("Test", 99900, comments),std::string("/Test:0.9.99(comment1)/"));
-    BOOST_CHECK_EQUAL(FormatSubVersion("Test", 99900, comments2),std::string("/Test:0.9.99(comment1; Comment2; .,_?@-; )/"));
+    FAST_CHECK_EQUAL(FormatSubVersion("Test", 99900, std::vector<std::string>()),std::string("/Test:0.9.99/"));
+    FAST_CHECK_EQUAL(FormatSubVersion("Test", 99900, comments),std::string("/Test:0.9.99(comment1)/"));
+    FAST_CHECK_EQUAL(FormatSubVersion("Test", 99900, comments2),std::string("/Test:0.9.99(comment1; Comment2; .,_?@-; )/"));
 }
 
 BOOST_AUTO_TEST_CASE(test_ParseFixedPoint)
 {
     int64_t amount = 0;
-    BOOST_CHECK(ParseFixedPoint("0", 8, &amount));
-    BOOST_CHECK_EQUAL(amount, 0LL);
-    BOOST_CHECK(ParseFixedPoint("1", 8, &amount));
-    BOOST_CHECK_EQUAL(amount, 100000000LL);
-    BOOST_CHECK(ParseFixedPoint("0.0", 8, &amount));
-    BOOST_CHECK_EQUAL(amount, 0LL);
-    BOOST_CHECK(ParseFixedPoint("-0.1", 8, &amount));
-    BOOST_CHECK_EQUAL(amount, -10000000LL);
-    BOOST_CHECK(ParseFixedPoint("1.1", 8, &amount));
-    BOOST_CHECK_EQUAL(amount, 110000000LL);
-    BOOST_CHECK(ParseFixedPoint("1.10000000000000000", 8, &amount));
-    BOOST_CHECK_EQUAL(amount, 110000000LL);
-    BOOST_CHECK(ParseFixedPoint("1.1e1", 8, &amount));
-    BOOST_CHECK_EQUAL(amount, 1100000000LL);
-    BOOST_CHECK(ParseFixedPoint("1.1e-1", 8, &amount));
-    BOOST_CHECK_EQUAL(amount, 11000000LL);
-    BOOST_CHECK(ParseFixedPoint("1000", 8, &amount));
-    BOOST_CHECK_EQUAL(amount, 100000000000LL);
-    BOOST_CHECK(ParseFixedPoint("-1000", 8, &amount));
-    BOOST_CHECK_EQUAL(amount, -100000000000LL);
-    BOOST_CHECK(ParseFixedPoint("0.00000001", 8, &amount));
-    BOOST_CHECK_EQUAL(amount, 1LL);
-    BOOST_CHECK(ParseFixedPoint("0.0000000100000000", 8, &amount));
-    BOOST_CHECK_EQUAL(amount, 1LL);
-    BOOST_CHECK(ParseFixedPoint("-0.00000001", 8, &amount));
-    BOOST_CHECK_EQUAL(amount, -1LL);
-    BOOST_CHECK(ParseFixedPoint("1000000000.00000001", 8, &amount));
-    BOOST_CHECK_EQUAL(amount, 100000000000000001LL);
-    BOOST_CHECK(ParseFixedPoint("9999999999.99999999", 8, &amount));
-    BOOST_CHECK_EQUAL(amount, 999999999999999999LL);
-    BOOST_CHECK(ParseFixedPoint("-9999999999.99999999", 8, &amount));
-    BOOST_CHECK_EQUAL(amount, -999999999999999999LL);
+    FAST_CHECK(ParseFixedPoint("0", 8, &amount));
+    FAST_CHECK_EQUAL(amount, 0LL);
+    FAST_CHECK(ParseFixedPoint("1", 8, &amount));
+    FAST_CHECK_EQUAL(amount, 100000000LL);
+    FAST_CHECK(ParseFixedPoint("0.0", 8, &amount));
+    FAST_CHECK_EQUAL(amount, 0LL);
+    FAST_CHECK(ParseFixedPoint("-0.1", 8, &amount));
+    FAST_CHECK_EQUAL(amount, -10000000LL);
+    FAST_CHECK(ParseFixedPoint("1.1", 8, &amount));
+    FAST_CHECK_EQUAL(amount, 110000000LL);
+    FAST_CHECK(ParseFixedPoint("1.10000000000000000", 8, &amount));
+    FAST_CHECK_EQUAL(amount, 110000000LL);
+    FAST_CHECK(ParseFixedPoint("1.1e1", 8, &amount));
+    FAST_CHECK_EQUAL(amount, 1100000000LL);
+    FAST_CHECK(ParseFixedPoint("1.1e-1", 8, &amount));
+    FAST_CHECK_EQUAL(amount, 11000000LL);
+    FAST_CHECK(ParseFixedPoint("1000", 8, &amount));
+    FAST_CHECK_EQUAL(amount, 100000000000LL);
+    FAST_CHECK(ParseFixedPoint("-1000", 8, &amount));
+    FAST_CHECK_EQUAL(amount, -100000000000LL);
+    FAST_CHECK(ParseFixedPoint("0.00000001", 8, &amount));
+    FAST_CHECK_EQUAL(amount, 1LL);
+    FAST_CHECK(ParseFixedPoint("0.0000000100000000", 8, &amount));
+    FAST_CHECK_EQUAL(amount, 1LL);
+    FAST_CHECK(ParseFixedPoint("-0.00000001", 8, &amount));
+    FAST_CHECK_EQUAL(amount, -1LL);
+    FAST_CHECK(ParseFixedPoint("1000000000.00000001", 8, &amount));
+    FAST_CHECK_EQUAL(amount, 100000000000000001LL);
+    FAST_CHECK(ParseFixedPoint("9999999999.99999999", 8, &amount));
+    FAST_CHECK_EQUAL(amount, 999999999999999999LL);
+    FAST_CHECK(ParseFixedPoint("-9999999999.99999999", 8, &amount));
+    FAST_CHECK_EQUAL(amount, -999999999999999999LL);
 
-    BOOST_CHECK(!ParseFixedPoint("", 8, &amount));
-    BOOST_CHECK(!ParseFixedPoint("-", 8, &amount));
-    BOOST_CHECK(!ParseFixedPoint("a-1000", 8, &amount));
-    BOOST_CHECK(!ParseFixedPoint("-a1000", 8, &amount));
-    BOOST_CHECK(!ParseFixedPoint("-1000a", 8, &amount));
-    BOOST_CHECK(!ParseFixedPoint("-01000", 8, &amount));
-    BOOST_CHECK(!ParseFixedPoint("00.1", 8, &amount));
-    BOOST_CHECK(!ParseFixedPoint(".1", 8, &amount));
-    BOOST_CHECK(!ParseFixedPoint("--0.1", 8, &amount));
-    BOOST_CHECK(!ParseFixedPoint("0.000000001", 8, &amount));
-    BOOST_CHECK(!ParseFixedPoint("-0.000000001", 8, &amount));
-    BOOST_CHECK(!ParseFixedPoint("0.00000001000000001", 8, &amount));
-    BOOST_CHECK(!ParseFixedPoint("-10000000000.00000000", 8, &amount));
-    BOOST_CHECK(!ParseFixedPoint("10000000000.00000000", 8, &amount));
-    BOOST_CHECK(!ParseFixedPoint("-10000000000.00000001", 8, &amount));
-    BOOST_CHECK(!ParseFixedPoint("10000000000.00000001", 8, &amount));
-    BOOST_CHECK(!ParseFixedPoint("-10000000000.00000009", 8, &amount));
-    BOOST_CHECK(!ParseFixedPoint("10000000000.00000009", 8, &amount));
-    BOOST_CHECK(!ParseFixedPoint("-99999999999.99999999", 8, &amount));
-    BOOST_CHECK(!ParseFixedPoint("99999909999.09999999", 8, &amount));
-    BOOST_CHECK(!ParseFixedPoint("92233720368.54775807", 8, &amount));
-    BOOST_CHECK(!ParseFixedPoint("92233720368.54775808", 8, &amount));
-    BOOST_CHECK(!ParseFixedPoint("-92233720368.54775808", 8, &amount));
-    BOOST_CHECK(!ParseFixedPoint("-92233720368.54775809", 8, &amount));
-    BOOST_CHECK(!ParseFixedPoint("1.1e", 8, &amount));
-    BOOST_CHECK(!ParseFixedPoint("1.1e-", 8, &amount));
-    BOOST_CHECK(!ParseFixedPoint("1.", 8, &amount));
+    FAST_CHECK(!ParseFixedPoint("", 8, &amount));
+    FAST_CHECK(!ParseFixedPoint("-", 8, &amount));
+    FAST_CHECK(!ParseFixedPoint("a-1000", 8, &amount));
+    FAST_CHECK(!ParseFixedPoint("-a1000", 8, &amount));
+    FAST_CHECK(!ParseFixedPoint("-1000a", 8, &amount));
+    FAST_CHECK(!ParseFixedPoint("-01000", 8, &amount));
+    FAST_CHECK(!ParseFixedPoint("00.1", 8, &amount));
+    FAST_CHECK(!ParseFixedPoint(".1", 8, &amount));
+    FAST_CHECK(!ParseFixedPoint("--0.1", 8, &amount));
+    FAST_CHECK(!ParseFixedPoint("0.000000001", 8, &amount));
+    FAST_CHECK(!ParseFixedPoint("-0.000000001", 8, &amount));
+    FAST_CHECK(!ParseFixedPoint("0.00000001000000001", 8, &amount));
+    FAST_CHECK(!ParseFixedPoint("-10000000000.00000000", 8, &amount));
+    FAST_CHECK(!ParseFixedPoint("10000000000.00000000", 8, &amount));
+    FAST_CHECK(!ParseFixedPoint("-10000000000.00000001", 8, &amount));
+    FAST_CHECK(!ParseFixedPoint("10000000000.00000001", 8, &amount));
+    FAST_CHECK(!ParseFixedPoint("-10000000000.00000009", 8, &amount));
+    FAST_CHECK(!ParseFixedPoint("10000000000.00000009", 8, &amount));
+    FAST_CHECK(!ParseFixedPoint("-99999999999.99999999", 8, &amount));
+    FAST_CHECK(!ParseFixedPoint("99999909999.09999999", 8, &amount));
+    FAST_CHECK(!ParseFixedPoint("92233720368.54775807", 8, &amount));
+    FAST_CHECK(!ParseFixedPoint("92233720368.54775808", 8, &amount));
+    FAST_CHECK(!ParseFixedPoint("-92233720368.54775808", 8, &amount));
+    FAST_CHECK(!ParseFixedPoint("-92233720368.54775809", 8, &amount));
+    FAST_CHECK(!ParseFixedPoint("1.1e", 8, &amount));
+    FAST_CHECK(!ParseFixedPoint("1.1e-", 8, &amount));
+    FAST_CHECK(!ParseFixedPoint("1.", 8, &amount));
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
unit tests can be really slow under wine because BOOST_CHECK logs something for all tests. This patch makes them faster by only logging tests which fail. PR'd an alternative to #8632.
# Benchmarks
## Wine
### Before:

real    3m52.840s
user    3m52.217s
sys     0m0.241s
### Just Prevector:

real    0m30.358s
user    0m29.695s
sys     0m0.165s
### After:

real    0m20.445s
user    0m19.888s
sys     0m0.193s
## Ubuntu
### Before:

real    0m20.887s
user    0m20.360s
sys     0m0.108s
### After:

real    0m11.894s
user    0m11.645s
sys     0m0.060s
