### PR TITLE
[qa]: remove root test directory for RPC tests

### DIFF
--- a/qa/rpc-tests/test_framework/test_framework.py
+++ b/qa/rpc-tests/test_framework/test_framework.py
@@ -125,7 +125,8 @@ class BitcoinTestFramework(object):
         self.add_options(parser)
         (self.options, self.args) = parser.parse_args()
 
-        self.options.tmpdir += '/' + str(self.options.port_seed)
+        # backup dir variable for removal at cleanup
+        self.options.root, self.options.tmpdir = self.options.tmpdir, self.options.tmpdir + '/' + str(self.options.port_seed)
 
         if self.options.trace_rpc:
             logging.basicConfig(level=logging.DEBUG, stream=sys.stdout)
@@ -176,6 +177,8 @@ class BitcoinTestFramework(object):
         if not self.options.nocleanup and not self.options.noshutdown and success:
             print("Cleaning up")
             shutil.rmtree(self.options.tmpdir)
+            if not os.listdir(self.options.root):
+                os.rmdir(self.options.root)
         else:
             print("Not cleaning up dir %s" % self.options.tmpdir)
 

--- a/qa/rpc-tests/wallet-hd.py
+++ b/qa/rpc-tests/wallet-hd.py
@@ -39,8 +39,8 @@ class WalletHDTest(BitcoinTestFramework):
         self.nodes[1].importprivkey(self.nodes[0].dumpprivkey(non_hd_add))
 
         # This should be enough to keep the master key and the non-HD key 
-        self.nodes[1].backupwallet(tmpdir + "hd.bak")
-        #self.nodes[1].dumpwallet(tmpdir + "hd.dump")
+        self.nodes[1].backupwallet(tmpdir + "/hd.bak")
+        #self.nodes[1].dumpwallet(tmpdir + "/hd.dump")
 
         # Derive some HD addresses and remember the last
         # Also send funds to each add
@@ -63,7 +63,7 @@ class WalletHDTest(BitcoinTestFramework):
         print("Restore backup ...")
         self.stop_node(1)
         os.remove(self.options.tmpdir + "/node1/regtest/wallet.dat")
-        shutil.copyfile(tmpdir + "hd.bak", tmpdir + "/node1/regtest/wallet.dat")
+        shutil.copyfile(tmpdir + "/hd.bak", tmpdir + "/node1/regtest/wallet.dat")
         self.nodes[1] = start_node(1, self.options.tmpdir, self.node_args[1])
         #connect_nodes_bi(self.nodes, 0, 1)
 


### PR DESCRIPTION
Fix for #8647. Back up each test's root directory and at the end if it is empty (or contains only *.bak) files, remove it too.
