### PR TITLE
Trivial: Do not shadow global variable fileout

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -601,19 +601,19 @@ bool TryCreateDirectory(const boost::filesystem::path& p)
     return false;
 }
 
-void FileCommit(FILE *fileout)
+void FileCommit(FILE *file)
 {
-    fflush(fileout); // harmless if redundantly called
+    fflush(file); // harmless if redundantly called
 #ifdef WIN32
-    HANDLE hFile = (HANDLE)_get_osfhandle(_fileno(fileout));
+    HANDLE hFile = (HANDLE)_get_osfhandle(_fileno(file));
     FlushFileBuffers(hFile);
 #else
     #if defined(__linux__) || defined(__NetBSD__)
-    fdatasync(fileno(fileout));
+    fdatasync(fileno(file));
     #elif defined(__APPLE__) && defined(F_FULLFSYNC)
-    fcntl(fileno(fileout), F_FULLFSYNC, 0);
+    fcntl(fileno(file), F_FULLFSYNC, 0);
     #else
-    fsync(fileno(fileout));
+    fsync(fileno(file));
     #endif
 #endif
 }

--- a/src/util.h
+++ b/src/util.h
@@ -93,7 +93,7 @@ bool error(const char* fmt, const Args&... args)
 
 void PrintExceptionContinue(const std::exception *pex, const char* pszThread);
 void ParseParameters(int argc, const char*const argv[]);
-void FileCommit(FILE *fileout);
+void FileCommit(FILE *file);
 bool TruncateFile(FILE *file, unsigned int length);
 int RaiseFileDescriptorLimit(int nMinFD);
 void AllocateFileRange(FILE *file, unsigned int offset, unsigned int length);


### PR DESCRIPTION
This continues #8105.

There is a global variable `fileout` and the same name is used as an argument for `FileCommit()`.

The change here fixes the following warning:

```
util.cpp:604:23: warning: declaration shadows a variable in the global namespace [-Wshadow]
void FileCommit(FILE *fileout)
                      ^
util.cpp:192:14: note: previous declaration is here
static FILE* fileout = __null;
             ^
1 warning generated.
```

The function `FileCommit` is used also for other files, not only the global `fileout`, so I have changed the argument name to `file` to match other functions there.
