### PR TITLE
Do not set an addr time penalty when a peer advertises itself.

### DIFF
--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -255,6 +255,11 @@ bool CAddrMan::Add_(const CAddress& addr, const CNetAddr& source, int64_t nTimeP
     int nId;
     CAddrInfo* pinfo = Find(addr, &nId);
 
+    // Do not set a penality for a source's self-announcement
+    if (addr == source) {
+        nTimePenalty = 0;
+    }
+
     if (pinfo) {
         // periodically update nTime
         bool fCurrentlyOnline = (GetAdjustedTime() - addr.nTime < 24 * 60 * 60);


### PR DESCRIPTION
Claims a peer makes about itself are inherently more credible.
