### PR TITLE
trivial: remove unnecessary variable fDaemon

### DIFF
--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -40,8 +40,6 @@
  * Use the buttons <code>Namespaces</code>, <code>Classes</code> or <code>Files</code> at the top of the page to start navigating the code.
  */
 
-static bool fDaemon;
-
 void WaitForShutdown(boost::thread_group* threadGroup)
 {
     bool fShutdown = ShutdownRequested();
@@ -130,8 +128,7 @@ bool AppInit(int argc, char* argv[])
             exit(1);
         }
 #ifndef WIN32
-        fDaemon = GetBoolArg("-daemon", false);
-        if (fDaemon)
+        if (GetBoolArg("-daemon", false))
         {
             fprintf(stdout, "Bitcoin server starting\n");
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -107,7 +107,6 @@ map<string, vector<string> > mapMultiArgs;
 bool fDebug = false;
 bool fPrintToConsole = false;
 bool fPrintToDebugLog = true;
-bool fDaemon = false;
 bool fServer = false;
 string strMiscWarning;
 bool fLogTimestamps = DEFAULT_LOGTIMESTAMPS;


### PR DESCRIPTION
the value is only used once in bitcoind.cpp. no need to keep it around.
also, a variable with the same name was never used in util.cpp.
these are the only places where `fDaemon` is found, so this is just a trivial cleanup.
