### PR TITLE
Fix segwit-related wallet bug

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2209,6 +2209,7 @@ bool CWallet::CreateTransaction(const vector<CRecipient>& vecSend, CWalletTx& wt
                 nChangePosInOut = nChangePosRequest;
                 txNew.vin.clear();
                 txNew.vout.clear();
+                txNew.wit.SetNull();
                 wtxNew.fFromMe = true;
                 bool fFirst = true;
 


### PR DESCRIPTION
Reported by @jl2012.

When we clear out the `vin` and `vout` in `CWallet::CreateTransaction()`, we also need to clear out the witness, or else the witness might have extra entries that trigger this assertion failure:

```
bitcoind: ./primitives/transaction.h:326: void SerializeTransaction(TxType&, Stream&, Operation, int, int) [with Stream = CHashWriter; Operation = CSerActionSerialize; TxType = CTransaction]: Assertion `tx.wit.vtxinwit.size() <= tx.vin.size()' failed.
```

Please tag for 0.13.1. 
