### PR TITLE
Fix SIGHASH_SINGLE bug in test_framework SignatureHash

### DIFF
--- a/qa/rpc-tests/test_framework/script.py
+++ b/qa/rpc-tests/test_framework/script.py
@@ -882,7 +882,7 @@ def SignatureHash(script, txTo, inIdx, hashtype):
         tmp = txtmp.vout[outIdx]
         txtmp.vout = []
         for i in range(outIdx):
-            txtmp.vout.append(CTxOut())
+            txtmp.vout.append(CTxOut(-1))
         txtmp.vout.append(tmp)
 
         for i in range(len(txtmp.vin)):


### PR DESCRIPTION
The value for "other" inputs should be -1 (0xffffffffffffffff) instead of 0
