### PR TITLE
Add missing copyright headers

### DIFF
--- a/contrib/devtools/optimize-pngs.py
+++ b/contrib/devtools/optimize-pngs.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python
+# Copyright (c) 2014-2015 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
 '''
 Run this script every time you change one of the png files. Using pngcrush, it will optimize the png files, remove various color profiles, remove ancillary chunks (alla) and text chunks (text).
 #pngcrush -brute -ow -rem gAMA -rem cHRM -rem iCCP -rem sRGB -rem alla -rem text

--- a/contrib/gitian-build.sh
+++ b/contrib/gitian-build.sh
@@ -1,3 +1,7 @@
+# Copyright (c) 2016 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 # What to do
 sign=false
 verify=false

--- a/contrib/qt_translations.py
+++ b/contrib/qt_translations.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python
+# Copyright (c) 2011 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 # Helpful little script that spits out a comma-separated list of
 # language codes for Qt icons that should be included

--- a/contrib/seeds/makeseeds.py
+++ b/contrib/seeds/makeseeds.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python
+# Copyright (c) 2013-2015 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #
 # Generate seeds.txt from Pieter's DNS seeder
 #

--- a/contrib/spendfrom/setup.py
+++ b/contrib/spendfrom/setup.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2013 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
 from distutils.core import setup
 setup(name='btcspendfrom',
       version='1.0',

--- a/contrib/spendfrom/spendfrom.py
+++ b/contrib/spendfrom/spendfrom.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python
+# Copyright (c) 2013 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #
 # Use the raw transactions API to spend bitcoins received on particular addresses,
 # and send any change back to that same address.

--- a/contrib/testgen/base58.py
+++ b/contrib/testgen/base58.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2012 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
 '''
 Bitcoin base58 encoding and decoding.
 

--- a/contrib/testgen/gen_base58_test_vectors.py
+++ b/contrib/testgen/gen_base58_test_vectors.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python
+# Copyright (c) 2012 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
 '''
 Generate valid and invalid base58 address and private key test vectors.
 

--- a/qa/rpc-tests/test_framework/blockstore.py
+++ b/qa/rpc-tests/test_framework/blockstore.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# Copyright (c) 2015-2016 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
 # BlockStore: a helper class that keeps a map of blocks and implements
 #             helper functions for responding to getheaders and getdata,
 #             and for constructing a getheaders message


### PR DESCRIPTION
Adds 'The Bitcoin Core developers' copyright headers in 12 source files.
<start_year>-<end_year> is as per the history obtained from 'git log'.

The users to have touched them in the past are listed below.  This was last
discussed in pull request  #7300:

In that discussion I can see perma-ACKs from @MarcoFalke, @gavinandresen and
@laanwj.

So that leaves ACKs needed from:
@sipa
@jgarzik
@luke-jr
@theuni
@ChoHag 
@calebogden
@mrbandrews
@casey
@mitchellcash
@brandondahler
Phillip Kaufmann

Broken down by file:

contrib/devtools/optimize-pngs.py (@MarcoFalke, @jonasschnelli, @laanwj)
contrib/devtools/security-check.py (@ChoHag, @laanwj, @theuni, @calebogden)
contrib/devtools/test-security-check.py (@ChoHag, @laanwj)
contrib/qt_translations.py (@gavinandresen)
contrib/seeds/makeseeds.py (@laanwj, @sipa, @gavinandresen)
contrib/spendfrom/setup.py (@gavinandresen)
contrib/spendfrom/spendfrom.py (@gavinandresen)
contrib/testgen/base58.py (@laanwj)
contrib/testgen/gen_base58_test_vectors.py (@laanwj)
contrib/zmq/zmq_sub.py (@jonasschnelli, @jgarzik)
qa/rpc-tests/test_framework/blockstore.py (@mrbandrews, @MarcoFalke, @casey, @jonasschnelli)
share/qt/extract_strings_qt.py (@ChoHag, @mitchellcash, @laanwj, @luke-jr, @brandondahler, Phillip Kaufmann, @theuni)
