### PR TITLE
Do not shadow upper local variable 'send', prevent -Wshadow compiler warning.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4789,16 +4789,16 @@ void static ProcessGetData(CNode* pfrom, const Consensus::Params& consensusParam
                         pfrom->PushMessage(NetMsgType::BLOCK, block);
                     else if (inv.type == MSG_FILTERED_BLOCK)
                     {
-                        bool send = false;
+                        bool sendMerkleBlock = false;
                         CMerkleBlock merkleBlock;
                         {
                             LOCK(pfrom->cs_filter);
                             if (pfrom->pfilter) {
-                                send = true;
+                                sendMerkleBlock = true;
                                 merkleBlock = CMerkleBlock(block, *pfrom->pfilter);
                             }
                         }
-                        if (send) {
+                        if (sendMerkleBlock) {
                             pfrom->PushMessage(NetMsgType::MERKLEBLOCK, merkleBlock);
                             // CMerkleBlock just contains hashes, so also push any transactions in the block the client did not see
                             // This avoids hurting performance by pointlessly requiring a round-trip


### PR DESCRIPTION
Fixes new `-Wshadow` (#8105) warning from #8606:

```
Making all in src
  CXX      libbitcoin_server_a-main.o
main.cpp:4792:30: warning: declaration shadows a local variable [-Wshadow]
                        bool send = false;
                             ^
main.cpp:4748:22: note: previous declaration is here
                bool send = false;
                     ^
1 warning generated.
```

It would be nice to get rid of it completely and sending `merkleblock` only when something like `merkleBlock.initialized()`, but there is no getter now and all properties are marked as `public` only for unit testing.
