### PR TITLE
fix incorrect file name bitcoin.qrc 

### DIFF
--- a/doc/translation_process.md
+++ b/doc/translation_process.md
@@ -94,7 +94,7 @@ When new plurals are added to the source file, it's important to do the followin
 7. Save the source file
 
 ### Translating a new language
-To create a new language template, you will need to edit the languages manifest file `src/qt/bitcoin.qrc` and add a new entry. Below is an example of the English language entry.
+To create a new language template, you will need to edit the languages manifest file `src/qt/bitcoin_locale.qrc` and add a new entry. Below is an example of the English language entry.
 
 ```xml
 <qresource prefix="/translations">


### PR DESCRIPTION
bitcoin.qrc does not contain any language manifest data as implied in sentence; fixed to point to correct file bitcoin_locale.qr
