### PR TITLE
add witness address to address book

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1087,6 +1087,8 @@ UniValue addwitnessaddress(const UniValue& params, bool fHelp)
         throw JSONRPCError(RPC_WALLET_ERROR, "Public key or redeemscript not known to wallet");
     }
 
+    pwalletMain->SetAddressBook(w.result, "", "receive");
+
     return CBitcoinAddress(w.result).ToString();
 }
 


### PR DESCRIPTION
Currently any received funds for these addresses are counted as change, resulting in odd behavior in calls like listtransactions where it won't list them. 

If `account` support is desired I can include this but I don't think it necessary for what this does.
