### PR TITLE
[Net] Retry feeler connection if OpenNetworkConnection fails in under 1ms.

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1701,7 +1701,16 @@ void CConnman::ThreadOpenConnections()
                 LogPrint("net", "Making feeler connection to %s\n", addrConnect.ToString());
             }
 
-            OpenNetworkConnection(addrConnect, (int)setConnected.size() >= std::min(nMaxConnections - 1, 2), &grant, NULL, false, fFeeler);
+            int64_t nStartTime = GetTimeMicros();
+
+            bool fRet = OpenNetworkConnection(addrConnect, (int)setConnected.size() >= std::min(nMaxConnections - 1, 2), &grant, NULL, false, fFeeler);
+
+            // Retry feeler connection if OpenNetworkConnection fails in under 1ms.
+            // Avoids issues with feelers to IP space we don't know how to route.
+            // The outer loop has a 500ms delay, we rely on that delay here
+            if (!fRet && GetTimeMicros() - nStartTime < 1000) {
+                nNextFeeler = GetTimeMicros();
+            }
         }
     }
 }


### PR DESCRIPTION
Avoids issues with feelers to ip space we don't know how to route.
