### PR TITLE
fix op order to append first alert

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4659,12 +4659,12 @@ std::string GetWarnings(const std::string& strFor)
     if (fLargeWorkForkFound)
     {
         strStatusBar = strRPC = "Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.";
-        strGUI += strGUI.empty() ? "" : uiAlertSeperator + _("Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.");
+        strGUI += (strGUI.empty() ? "" : uiAlertSeperator) + _("Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.");
     }
     else if (fLargeWorkInvalidChainFound)
     {
         strStatusBar = strRPC = "Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.";
-        strGUI += strGUI.empty() ? "" : uiAlertSeperator + _("Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.");
+        strGUI += (strGUI.empty() ? "" : uiAlertSeperator) + _("Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.");
     }
 
     if (strFor == "gui")


### PR DESCRIPTION
`+` has precedence over `?:`, so `strGUI += strGUI.empty() ? "" : uiAlertSerparator + _("Warning...")` only appends `""` if `strGUI` is empty. The ternary expression drops the warning for `fLargeWorkForkFound` or `fLargeWorkInvalidChainFound` if it is the first string to show.

Fix by wrapping the `?:` expression in parentheses, so even the first warning is appended to `strGUI`.
