### PR TITLE
[copyright] add MIT license headers to .sh scripts where missing

### DIFF
--- a/contrib/devtools/git-subtree-check.sh
+++ b/contrib/devtools/git-subtree-check.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+# Copyright (c) 2015 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 DIR="$1"
 COMMIT="$2"

--- a/contrib/macdeploy/detached-sig-apply.sh
+++ b/contrib/macdeploy/detached-sig-apply.sh
@@ -1,4 +1,8 @@
 #!/bin/sh
+# Copyright (c) 2014-2015 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 set -e
 
 UNSIGNED="$1"

--- a/contrib/macdeploy/detached-sig-create.sh
+++ b/contrib/macdeploy/detached-sig-create.sh
@@ -1,4 +1,8 @@
 #!/bin/sh
+# Copyright (c) 2014-2015 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 set -e
 
 ROOTDIR=dist

--- a/contrib/macdeploy/extract-osx-sdk.sh
+++ b/contrib/macdeploy/extract-osx-sdk.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# Copyright (c) 2016 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 set -e
 
 INPUTFILE="Xcode_7.3.1.dmg"

--- a/contrib/qos/tc.sh
+++ b/contrib/qos/tc.sh
@@ -1,3 +1,7 @@
+# Copyright (c) 2013 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #network interface on which to limit traffic
 IF="eth0"
 #limit of the network interface in question

--- a/contrib/tidy_datadir.sh
+++ b/contrib/tidy_datadir.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# Copyright (c) 2013 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 if [ -d "$1" ]; then
   cd "$1"

--- a/contrib/verify-commits/gpg.sh
+++ b/contrib/verify-commits/gpg.sh
@@ -1,4 +1,8 @@
 #!/bin/sh
+# Copyright (c) 2014-2016 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 INPUT=$(cat /dev/stdin)
 VALID=false
 REVSIG=false

--- a/contrib/verify-commits/pre-push-hook.sh
+++ b/contrib/verify-commits/pre-push-hook.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# Copyright (c) 2014-2015 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 if ! [[ "$2" =~ ^(git@)?(www.)?github.com(:|/)bitcoin/bitcoin(.git)?$ ]]; then
     exit 0
 fi

--- a/contrib/verify-commits/verify-commits.sh
+++ b/contrib/verify-commits/verify-commits.sh
@@ -1,4 +1,8 @@
 #!/bin/sh
+# Copyright (c) 2014-2016 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 # Not technically POSIX-compliant due to use of "local", but almost every
 # shell anyone uses today supports it, so its probably fine
 

--- a/contrib/verifybinaries/verify.sh
+++ b/contrib/verifybinaries/verify.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# Copyright (c) 2016 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 ###   This script attempts to download the signature file SHA256SUMS.asc from bitcoin.org
 ###   It first checks if the signature passes, and then downloads the files specified in

--- a/src/qt/res/movies/makespinner.sh
+++ b/src/qt/res/movies/makespinner.sh
@@ -1,3 +1,7 @@
+# Copyright (c) 2014-2015 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 FRAMEDIR=$(dirname $0)
 for i in {0..35}
 do


### PR DESCRIPTION
Adds a MIT license copyright header for 11 shell scripts (*.sh) in the repo.

Previous discussions of copyright headers are in PR  #7300 and  #8676. From those discussions, there is a perma-ACK on copyright headers from @MarcoFalke, so it can be assumed here.

So, for the files in this batch, we require an ACK from:

@sipa
@theuni
@jonasschnelli
@luke-jr
@runeksvendsen
@TheBlueMatt
@petertodd

Broken down by individual files:

contrib/devtools/git-subtree-check.sh (@sipa)
contrib/macdeploy/detached-sig-apply.sh (@theuni, @jonasschnelli)
contrib/macdeploy/detached-sig-create.sh (@theuni, @jonasschnelli)
contrib/macdeploy/extract-osx-sdk.sh (@luke-jr)
contrib/qos/tc.sh (@runeksvendsen)
contrib/tidy_datadir.sh (@sipa)
contrib/verify-commits/gpg.sh (@TheBlueMatt)
contrib/verify-commits/pre-push-hook.sh (@TheBlueMatt)
contrib/verify-commits/verify-commits.sh (@TheBlueMatt, @petertodd)
contrib/verifybinaries/verify.sh (@MarcoFalke)
src/qt/res/movies/makespinner.sh (@jonasschnelli, @MarcoFalke)

Like with  #8646, after a few days, the files without ACK quorum will be removed and PR'd separately.
