### PR TITLE
[copyright] add MIT License copyright header to zmq_sub.py

### DIFF
--- a/contrib/zmq/zmq_sub.py
+++ b/contrib/zmq/zmq_sub.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python2
+# Copyright (c) 2014-2016 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 import array
 import binascii


### PR DESCRIPTION
Requires ACK from @jgarzik.

This file was also modified on 2016-03-29 by @jonasschnelli, but was ACKed by him in PR #8676 for 2229ffa5e2b8e38cd962c02e2fc892e0c925675b before it was taken out and split off into this PR.
