### PR TITLE
[copyright] add MIT License copyright header to remaining Python files

### DIFF
--- a/contrib/devtools/security-check.py
+++ b/contrib/devtools/security-check.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python
+# Copyright (c) 2015-2016 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
 '''
 Perform basic ELF security checks on a series of executables.
 Exit status will be 0 if successful, and the program will be silent.

--- a/contrib/devtools/test-security-check.py
+++ b/contrib/devtools/test-security-check.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python2
+# Copyright (c) 2015-2016 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
 '''
 Test script for security-check.py
 '''

--- a/share/qt/extract_strings_qt.py
+++ b/share/qt/extract_strings_qt.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python
+# Copyright (c) 2012-2016 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
 '''
 Extract _("...") strings for translation and convert to Qt stringdefs so that
 they can be picked up by Qt linguist.


### PR DESCRIPTION
The edit history on these three files are from users:

contrib/devtools/security-check.py (@ChoHag, @laanwj, @theuni, @calebogden)
contrib/devtools/test-security-check.py (@ChoHag, @laanwj)
share/qt/extract_strings_qt.py (@ChoHag, @mitchellcash, @laanwj, @luke-jr, @brandondahler, Phillip Kaufmann, @theuni)

As per the threads for PR  #7300 and  #8676, there are ACKs to add these headers
from all but Philip Kaufmann and @ChoHag.

The specific edits:

@ChoHag edited security-check.py in 7b01ce254cfa0e8ae7e57a72c57e8ae89f3c1829 and 873e81f89b3197580aca3dd4a591d00e41696a89
@ChoHag edited test-security-check.py in 873e81f89b3197580aca3dd4a591d00e41696a89
@ChoHag edited extract_strings_qt.py in 873e81f89b3197580aca3dd4a591d00e41696a89
Philip Kaufmann edited extract_strings_qt.py in 01cbaeb62fa3c8b046efe6dd1bd2c918f661566a

I will make an effort to reach out via email.
