### PR TITLE
Remove maxuploadtargets recommended minimum

### DIFF
--- a/doc/reduce-traffic.md
+++ b/doc/reduce-traffic.md
@@ -19,8 +19,7 @@ This is *not* a hard limit; only a threshold to minimize the outbound
 traffic. When the limit is about to be reached, the uploaded data is cut by no
 longer serving historic blocks (blocks older than one week).
 Keep in mind that new nodes require other nodes that are willing to serve
-historic blocks. **The recommended minimum is 144 blocks per day (max. 144MB
-per day)**
+historic blocks.
 
 Whitelisted peers will never be disconnected, although their traffic counts for
 calculating the target.

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2362,11 +2362,7 @@ void CConnman::RecordBytesSent(uint64_t bytes)
 void CConnman::SetMaxOutboundTarget(uint64_t limit)
 {
     LOCK(cs_totalBytesSent);
-    uint64_t recommendedMinimum = (nMaxOutboundTimeframe / 600) * MAX_BLOCK_SERIALIZED_SIZE;
     nMaxOutboundLimit = limit;
-
-    if (limit > 0 && limit < recommendedMinimum)
-        LogPrintf("Max outbound target is very small (%s bytes) and will be overshot. Recommended minimum is %s bytes.\n", nMaxOutboundLimit, recommendedMinimum);
 }
 
 uint64_t CConnman::GetMaxOutboundTarget()


### PR DESCRIPTION
The maxuploadtarget recommended minimum is partially "broken" since the merge of SW (#8555). Addressing and updating the recommendation seems to be difficult (see https://github.com/bitcoin/bitcoin/pull/8559).

Recommendation are non-trivial because its depending on how we calculate the p2p-network IBD "health".
