### PR TITLE
[qa] create_cache: Delete temp dir when done

### DIFF
--- a/qa/rpc-tests/create_cache.py
+++ b/qa/rpc-tests/create_cache.py
@@ -12,9 +12,15 @@ from test_framework.test_framework import BitcoinTestFramework
 
 class CreateCache(BitcoinTestFramework):
 
+    def __init__(self):
+        super().__init__()
+
+        # Test network and test nodes are not required:
+        self.num_nodes = 0
+        self.nodes = []
+
     def setup_network(self):
-        # Don't setup any test nodes
-        self.options.noshutdown = True
+        pass
 
     def run_test(self):
         pass


### PR DESCRIPTION
This replaces my nasty hack which not only was hard to read but also was leaving 4 nodes' folders in a tempdir.

After #8056 it is possible to move the hack to `__init__()`, so it is no longer a hack. Also, it won't create any folders for nodes and remove the root tempdir.

Closes https://github.com/bitcoin/bitcoin/issues/8647#issuecomment-244601145.
