### PR TITLE
net: only delete CConnman if it's been created

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -200,7 +200,6 @@ void Shutdown()
         pwalletMain->Flush(false);
 #endif
     MapPort(false);
-    g_connman->Stop();
     g_connman.reset();
 
     StopTorControl();

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2205,6 +2205,7 @@ void CConnman::DeleteNode(CNode* pnode)
 
 CConnman::~CConnman()
 {
+    Stop();
 }
 
 size_t CConnman::GetAddressCount() const


### PR DESCRIPTION
This fixes a possible shutdown crash. Thanks to @morcos for reporting.

In the case of (for example) an already-running bitcoind, the shutdown sequence begins before CConnman has been created, leading to a null-pointer dereference when g_connman->Stop() is called.
