### PR TITLE
[WALLET] Addition of ImmatureCreditCached to MarkDirty()

### DIFF
--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -361,6 +361,7 @@ public:
     {
         fCreditCached = false;
         fAvailableCreditCached = false;
+        fImmatureCreditCached = false;
         fWatchDebitCached = false;
         fWatchCreditCached = false;
         fAvailableWatchCreditCached = false;


### PR DESCRIPTION
To protect against possible invalidation and to bring conformity to the code.
