### PR TITLE
Minor change in section name

### DIFF
--- a/doc/gitian-building.md
+++ b/doc/gitian-building.md
@@ -337,7 +337,7 @@ Getting and building the inputs
 --------------------------------
 
 Follow the instructions in [doc/release-process.md](release-process.md#fetch-and-build-inputs-first-time-or-when-dependency-versions-change)
-in the bitcoin repository under 'Fetch and build inputs' to install sources which require
+in the bitcoin repository under 'Fetch and create inputs' to install sources which require
 manual intervention. Also optionally follow the next step: 'Seed the Gitian sources cache
 and offline git repositories' which will fetch the remaining files required for building
 offline.


### PR DESCRIPTION
Changed 'build' to 'create', as the section name have changed in newer versions of release-process.md
