### PR TITLE
[Wallet] Add support for flexible BIP32/HD keypath-scheme

### DIFF
--- a/qa/rpc-tests/wallet-hd.py
+++ b/qa/rpc-tests/wallet-hd.py
@@ -65,7 +65,6 @@ class WalletHDTest(BitcoinTestFramework):
         os.remove(self.options.tmpdir + "/node1/regtest/wallet.dat")
         shutil.copyfile(tmpdir + "/hd.bak", tmpdir + "/node1/regtest/wallet.dat")
         self.nodes[1] = start_node(1, self.options.tmpdir, self.node_args[1])
-        #connect_nodes_bi(self.nodes, 0, 1)
 
         # Assert that derivation is deterministic
         hd_add_2 = None
@@ -82,6 +81,16 @@ class WalletHDTest(BitcoinTestFramework):
         #connect_nodes_bi(self.nodes, 0, 1)
         assert_equal(self.nodes[1].getbalance(), num_hd_adds + 1)
 
+        print("Testing flexible keypath scheme ...")
+        self.stop_node(1)
+        os.remove(self.options.tmpdir + "/node1/regtest/wallet.dat")
+        self.nodes[1] = start_node(1, self.options.tmpdir, self.node_args[1] + ['-hdkeypath=m/44h/0h/0h/0/k'])
+        hd_add = self.nodes[1].getnewaddress()
+        hd_info = self.nodes[1].validateaddress(hd_add)
+        assert_equal(hd_info["hdkeypath"], "m/44'/0'/0'/0/1")
+        hd_add = self.nodes[1].getnewaddress()
+        hd_info = self.nodes[1].validateaddress(hd_add)
+        assert_equal(hd_info["hdkeypath"], "m/44'/0'/0'/0/2")
 
 if __name__ == '__main__':
     WalletHDTest().main ()

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -927,8 +927,12 @@ public:
     /* Generates a new HD master key (will not be activated) */
     CPubKey GenerateNewHDMasterKey();
     
-    /* Set the current HD master key (will reset the chain child index counters) */
-    bool SetHDMasterKey(const CPubKey& key);
+    /* Set the current HD master key and the BIP32 keypath-scheme (will reset the chain child index counters) */
+    bool SetHDMasterKeyAndScheme(const CPubKey& key, const std::string& keypathScheme);
+
+    /* Static function to derive a child key after a given keypath and masterkey */
+    static bool DeriveKeyWithKeypathScheme(const std::string keypathScheme, unsigned int childCounter, const CExtKey& masterKey, CExtKey& childKey, std::string &keypathOut);
+
 };
 
 /** A key allocated from the key pool. */


### PR DESCRIPTION
This adds the startup argument `-hdkeypath` which allows to set the BIP32 keypath scheme during the creation of a wallet.

This PR would allow to use keypath-scheme after BIP44, etc. to be compatible with other wallets.

This PR does **not** change the keypool mechanism. Even if the keypath would allow public-key-derivation, we still derive all keys with private-key-derivation and fill up the keypool.
Though, a PR that would enable public-key-derivation would be "in a reviewable size" once this gets merged.
