### PR TITLE
depends: Add libevent compatibility patch for windows

### DIFF
--- a/depends/packages/libevent.mk
+++ b/depends/packages/libevent.mk
@@ -3,10 +3,11 @@ $(package)_version=2.0.22
 $(package)_download_path=https://github.com/libevent/libevent/releases/download/release-2.0.22-stable
 $(package)_file_name=$(package)-$($(package)_version)-stable.tar.gz
 $(package)_sha256_hash=71c2c49f0adadacfdbe6332a372c38cf9c8b7895bb73dabeaa53cdcc1d4e1fa3
-$(package)_patches=reuseaddr.patch
+$(package)_patches=reuseaddr.patch libevent-2-fixes.patch
 
 define $(package)_preprocess_cmds
-  patch -p1 < $($(package)_patch_dir)/reuseaddr.patch
+  patch -p1 < $($(package)_patch_dir)/reuseaddr.patch && \
+  patch -p1 < $($(package)_patch_dir)/libevent-2-fixes.patch
 endef
 
 define $(package)_set_vars

--- a/depends/patches/libevent/libevent-2-fixes.patch
+++ b/depends/patches/libevent/libevent-2-fixes.patch
@@ -1,0 +1,18 @@
+--- a/util-internal.h	2013-11-01 12:18:57.000000000 -0600
++++ b/util-internal.h	2015-07-20 20:19:43.199560900 -0500
+@@ -299,8 +299,13 @@ HANDLE evutil_load_windows_system_librar
+ 
+ #if defined(__STDC__) && defined(__STDC_VERSION__)
+ #if (__STDC_VERSION__ >= 199901L)
+-#define EV_SIZE_FMT "%zu"
+-#define EV_SSIZE_FMT "%zd"
++ #if defined(_MSC_VER) || defined(__MINGW32__) || defined(__MINGW64__)
++  #define EV_SIZE_FMT "%Iu"
++  #define EV_SSIZE_FMT "%Id"
++ #else
++  #define EV_SIZE_FMT "%zu"
++  #define EV_SSIZE_FMT "%zd"
++ #endif
+ #define EV_SIZE_ARG(x) (x)
+ #define EV_SSIZE_ARG(x) (x)
+ #endif


### PR DESCRIPTION
Add a patch that seems to be necessary for compatibilty of libevent 2.0.22 with recent mingw-w64 gcc versions (at least GCC 5.3.1 from Ubuntu 16.04).

Without this patch the Content-Length in the HTTP header ends up as `Content-Length: zu`, causing communication between the RPC client and server to break down. See discussion in #8653.

Source: https://sourceforge.net/p/levent/bugs/363/

Thanks to @sstone for the suggestion. Hopefully this won't cause regressions with Trusty.
