### PR TITLE
Send NOTFOUND when we don't have the block data.

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1000,6 +1000,9 @@ void static ProcessGetData(CNode* pfrom, const Consensus::Params& consensusParam
                         connman.PushMessage(pfrom, msgMaker.Make(NetMsgType::INV, vInv));
                         pfrom->hashContinue.SetNull();
                     }
+                } else if (send) {
+                    // To avoid fingerprinting only send if we would have sent the block
+                    vNotFound.push_back(inv);
                 }
             }
             else if (inv.type == MSG_TX || inv.type == MSG_WITNESS_TX)


### PR DESCRIPTION
Currently a pruned node unsets NODE_NETWORK so most nodes shouldn't be requesting blocks from it.

However, some nodes may not be so clever, and some people may hack their node to continue sending NODE_NETWORK for various reasons.

In these cases when a block is requested the node currently does nothing, and the requesting node needs to wait to timeout before attempting to request the block from a different node.

If notfound messages are sent instead this would allow nodes to be coded to detect this and immediately request the block from a different node, improving IBD speeds. (Some nodes may already have added this logic already).
