### PR TITLE
[Wallet] add option for a custom extended master privat key (xpriv)

### DIFF
--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -925,7 +925,8 @@ public:
     CPubKey GenerateNewHDMasterKey();
     
     /* Set the current HD master key (will reset the chain child index counters) */
-    bool SetHDMasterKey(const CPubKey& key);
+    /* If possibleXPriv is a valid Base58check encoded extended key it will be used as extended master key */
+    bool SetHDMasterKey(const CPubKey& key, const std::string& possibleXPriv);
 };
 
 /** A key allocated from the key pool. */

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -47,8 +47,12 @@ class CHDChain
 public:
     uint32_t nExternalChainCounter;
     CKeyID masterKeyID; //!< master key hash160
+    CExtKey customMasterKey;
 
-    static const int CURRENT_VERSION = 1;
+    static const int VERSION_BASE = 1;
+    static const int VERSION_WITH_CUSTOM_MASTER_KEY = 2;
+    static const int CURRENT_VERSION = VERSION_WITH_CUSTOM_MASTER_KEY;
+
     int nVersion;
 
     CHDChain() { SetNull(); }
@@ -60,6 +64,9 @@ public:
         nVersion = this->nVersion;
         READWRITE(nExternalChainCounter);
         READWRITE(masterKeyID);
+
+        if (this->nVersion >= VERSION_WITH_CUSTOM_MASTER_KEY)
+            READWRITE(customMasterKey);
     }
 
     void SetNull()
@@ -67,6 +74,7 @@ public:
         nVersion = CHDChain::CURRENT_VERSION;
         nExternalChainCounter = 0;
         masterKeyID.SetNull();
+        customMasterKey.SetNull();
     }
 };
 


### PR DESCRIPTION
At the moment, the HD seed cannot be set by the user. It will always be generated by Bitcoin-Core (`CKey::MakeNewKey()`).

This PR adds a startup argument `-hdxpriv` where users can set their custom hd extended master private key. The argument takes only affect during the creation of a new `wallet.dat` and there will be a warning if the argument is present during loading an exiting wallet.

If a custom extended master private key has been set, it will be kept when encrypting the wallet (with log-printing a warning).
