### PR TITLE
base58: Improve DecodeBase58 performance.

### DIFF
--- a/src/base58.cpp
+++ b/src/base58.cpp
@@ -25,12 +25,14 @@ bool DecodeBase58(const char* psz, std::vector<unsigned char>& vch)
         psz++;
     // Skip and count leading '1's.
     int zeroes = 0;
+    int length = 0;
     while (*psz == '1') {
         zeroes++;
         psz++;
     }
     // Allocate enough space in big-endian base256 representation.
-    std::vector<unsigned char> b256(strlen(psz) * 733 / 1000 + 1); // log(58) / log(256), rounded up.
+    int size = strlen(psz) * 733 /1000 + 1; // log(58) / log(256), rounded up.
+    std::vector<unsigned char> b256(size);
     // Process the characters.
     while (*psz && !isspace(*psz)) {
         // Decode base58 character
@@ -39,12 +41,14 @@ bool DecodeBase58(const char* psz, std::vector<unsigned char>& vch)
             return false;
         // Apply "b256 = b256 * 58 + ch".
         int carry = ch - pszBase58;
-        for (std::vector<unsigned char>::reverse_iterator it = b256.rbegin(); it != b256.rend(); it++) {
+        int i = 0;
+        for (std::vector<unsigned char>::reverse_iterator it = b256.rbegin(); (carry != 0 || i < length) && (it != b256.rend()); it++, i++) {
             carry += 58 * (*it);
             *it = carry % 256;
             carry /= 256;
         }
         assert(carry == 0);
+        length = i;
         psz++;
     }
     // Skip trailing spaces.
@@ -53,7 +57,7 @@ bool DecodeBase58(const char* psz, std::vector<unsigned char>& vch)
     if (*psz != 0)
         return false;
     // Skip leading zeroes in b256.
-    std::vector<unsigned char>::iterator it = b256.begin();
+    std::vector<unsigned char>::iterator it = b256.begin() + (size - length);
     while (it != b256.end() && *it == 0)
         it++;
     // Copy result into output vector.

--- a/src/base58.cpp
+++ b/src/base58.cpp
@@ -42,7 +42,7 @@ bool DecodeBase58(const char* psz, std::vector<unsigned char>& vch)
         // Apply "b256 = b256 * 58 + ch".
         int carry = ch - pszBase58;
         int i = 0;
-        for (std::vector<unsigned char>::reverse_iterator it = b256.rbegin(); (carry != 0 || i < length) && (it != b256.rend()); it++, i++) {
+        for (std::vector<unsigned char>::reverse_iterator it = b256.rbegin(); (carry != 0 || i < length) && (it != b256.rend()); ++it, ++i) {
             carry += 58 * (*it);
             *it = carry % 256;
             carry /= 256;


### PR DESCRIPTION
Improve DecodeBase58 performance the same way as commit 3252208 did
for EncodeBase58.

bench_bitcoin result for Base58Decode before and after the patch, each tested three times:
Before the patch:
# Benchmark,count,min,max,average

Base58Decode,524288,0.000000976440788,0.000002053217031,0.000001960330792
Base58Decode,524288,0.000000979518518,0.000001978729415,0.000001956941560
Base58Decode,524288,0.000000986496161,0.000001988708391,0.000001964757757

After the patch:
# Benchmark,count,min,max,average

Base58Decode,786432,0.000000660018486,0.000001336600690,0.000001329504509
Base58Decode,786432,0.000000668867870,0.000001348496880,0.000001338565805
Base58Decode,786432,0.000000656273187,0.000001334869012,0.000001324702074

That's about 32% decrease for the average time.
