### PR TITLE
Trivial: UndoReadFromDisk works on undo files (rev), not on block files.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2062,7 +2062,7 @@ bool UndoReadFromDisk(CBlockUndo& blockundo, const CDiskBlockPos& pos, const uin
     // Open history file to read
     CAutoFile filein(OpenUndoFile(pos, true), SER_DISK, CLIENT_VERSION);
     if (filein.IsNull())
-        return error("%s: OpenBlockFile failed", __func__);
+        return error("%s: OpenUndoFile failed", __func__);
 
     // Read block
     uint256 hashChecksum;


### PR DESCRIPTION
Debugging some serialization issue and it took be 20 minutes to realize the problem was in `rev*dat` and not in `blk*dat`.
