### PR TITLE
net: No longer send local address in addrMe

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -448,7 +448,7 @@ void CNode::PushVersion()
 {
     int64_t nTime = (fInbound ? GetAdjustedTime() : GetTime());
     CAddress addrYou = (addr.IsRoutable() && !IsProxy(addr) ? addr : CAddress(CService(), addr.nServices));
-    CAddress addrMe = GetLocalAddress(&addr, nLocalServices);
+    CAddress addrMe = CAddress(CService(), nLocalServices);
     if (fLogIPs)
         LogPrint("net", "send version message: version %d, blocks=%d, us=%s, them=%s, peer=%d\n", PROTOCOL_VERSION, nMyStartingHeight, addrMe.ToString(), addrYou.ToString(), id);
     else


### PR DESCRIPTION
After #8594 the addrFrom sent by a node is not used anymore at all, so don't bother sending it (it was already not used if it is an invalid address so this doesn't disadvantage older versions either).

Also mitigates the privacy issue in (#8616). It doesn't completely solve the issue as GetLocalAddress is also called in AdvertiseLocal, but at least when advertising addresses it stands out less as _our_ address.
