### PR TITLE
Specify Protobuf version 2 in paymentrequest.proto

### DIFF
--- a/src/qt/paymentrequest.proto
+++ b/src/qt/paymentrequest.proto
@@ -6,6 +6,8 @@
 // https://en.bitcoin.it/wiki/Payment_Request
 //
 
+syntax = "proto2";
+
 package payments;
 option java_package = "org.bitcoin.protocols.payments";
 option java_outer_classname = "Protos";


### PR DESCRIPTION
This warning is emitted if compiling with Protobuf version 3 (which is currently failing).

```
GEN      qt/forms/ui_askpassphrasedialog.h
[libprotobuf WARNING google/protobuf/compiler/parser.cc:547] No syntax specified for the proto file: paymentrequest.proto. 
Please use 'syntax = "proto2";' or 'syntax = "proto3";' to specify a syntax version. 
(Defaulted to proto2 syntax.)
```
