### PR TITLE
[PoC] Add wallet inspection and modification tool "bitcoin-wallet-tool"

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -18,6 +18,7 @@ BITCOIN_DAEMON_NAME=bitcoind
 BITCOIN_GUI_NAME=bitcoin-qt
 BITCOIN_CLI_NAME=bitcoin-cli
 BITCOIN_TX_NAME=bitcoin-tx
+BITCOIN_WALLET_TOOL_NAME=bitcoin-wallet-tool
 
 AC_CANONICAL_HOST
 
@@ -240,7 +241,7 @@ CPPFLAGS="$CPPFLAGS -DHAVE_BUILD_INFO -D__STDC_FORMAT_MACROS"
 
 AC_ARG_WITH([utils],
   [AS_HELP_STRING([--with-utils],
-  [build bitcoin-cli bitcoin-tx (default=yes)])],
+  [build bitcoin-cli bitcoin-tx bitcoin-wallet-tool (default=yes)])],
   [build_bitcoin_utils=$withval],
   [build_bitcoin_utils=yes])
 
@@ -969,7 +970,7 @@ AC_MSG_CHECKING([whether to build bitcoind])
 AM_CONDITIONAL([BUILD_BITCOIND], [test x$build_bitcoind = xyes])
 AC_MSG_RESULT($build_bitcoind)
 
-AC_MSG_CHECKING([whether to build utils (bitcoin-cli bitcoin-tx)])
+AC_MSG_CHECKING([whether to build utils (bitcoin-cli bitcoin-tx bitcoin-wallet-tool)])
 AM_CONDITIONAL([BUILD_BITCOIN_UTILS], [test x$build_bitcoin_utils = xyes])
 AC_MSG_RESULT($build_bitcoin_utils)
 
@@ -1137,6 +1138,7 @@ AC_SUBST(BITCOIN_DAEMON_NAME)
 AC_SUBST(BITCOIN_GUI_NAME)
 AC_SUBST(BITCOIN_CLI_NAME)
 AC_SUBST(BITCOIN_TX_NAME)
+AC_SUBST(BITCOIN_WALLET_TOOL_NAME)
 
 AC_SUBST(RELDFLAGS)
 AC_SUBST(ERROR_CXXFLAGS)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -41,6 +41,7 @@ LIBBITCOINCONSENSUS=libbitcoinconsensus.la
 endif
 if ENABLE_WALLET
 LIBBITCOIN_WALLET=libbitcoin_wallet.a
+LIBBITCOIN_WALLET_TOOLS=libbitcoin_wallet_tools.a
 endif
 
 $(LIBSECP256K1): $(wildcard secp256k1/src/*) $(wildcard secp256k1/include/*)
@@ -56,6 +57,7 @@ EXTRA_LIBRARIES += \
   $(LIBBITCOIN_SERVER) \
   $(LIBBITCOIN_CLI) \
   $(LIBBITCOIN_WALLET) \
+  $(LIBBITCOIN_WALLET_TOOLS) \
   $(LIBBITCOIN_ZMQ)
 
 lib_LTLIBRARIES = $(LIBBITCOINCONSENSUS)
@@ -71,6 +73,9 @@ endif
 
 if BUILD_BITCOIN_UTILS
   bin_PROGRAMS += bitcoin-cli bitcoin-tx
+if ENABLE_WALLET
+  bin_PROGRAMS += bitcoin-wallet-tool
+endif
 endif
 
 .PHONY: FORCE check-symbols check-security
@@ -163,6 +168,7 @@ BITCOIN_CORE_H = \
   wallet/rpcwallet.h \
   wallet/wallet.h \
   wallet/walletdb.h \
+  wallet/wallettools.h \
   warnings.h \
   zmq/zmqabstractnotifier.h \
   zmq/zmqconfig.h\
@@ -241,6 +247,12 @@ libbitcoin_wallet_a_SOURCES = \
   wallet/wallet.cpp \
   wallet/walletdb.cpp \
   policy/rbf.cpp \
+  $(BITCOIN_CORE_H)
+
+libbitcoin_wallet_tools_a_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
+libbitcoin_wallet_tools_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+libbitcoin_wallet_tools_a_SOURCES = \
+  wallet/wallettools.cpp \
   $(BITCOIN_CORE_H)
 
 # crypto primitives library
@@ -423,6 +435,33 @@ bitcoin_tx_LDADD = \
   $(LIBSECP256K1)
 
 bitcoin_tx_LDADD += $(BOOST_LIBS) $(CRYPTO_LIBS)
+#
+
+# bitcoin-wallet-tool binary #
+bitcoin_wallet_tool_SOURCES = bitcoin-wallet-tool.cpp
+bitcoin_wallet_tool_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
+bitcoin_wallet_tool_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+bitcoin_wallet_tool_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+
+if TARGET_WINDOWS
+bitcoin_wallet_tool_SOURCES += bitcoin-wallet-tool-res.rc
+endif
+
+bitcoin_wallet_tool_LDADD = \
+  $(LIBBITCOIN_SERVER) \
+  $(LIBBITCOIN_COMMON) \
+  $(LIBUNIVALUE) \
+  $(LIBBITCOIN_UTIL) \
+  $(LIBBITCOIN_WALLET) \
+  $(LIBBITCOIN_WALLET_TOOLS) \
+  $(LIBBITCOIN_ZMQ) \
+  $(LIBBITCOIN_CONSENSUS) \
+  $(LIBBITCOIN_CRYPTO) \
+  $(LIBLEVELDB) \
+  $(LIBMEMENV) \
+  $(LIBSECP256K1)
+
+bitcoin_wallet_tool_LDADD += $(BOOST_LIBS) $(BDB_LIBS) $(SSL_LIBS) $(CRYPTO_LIBS) $(ZMQ_LIBS)
 #
 
 # bitcoinconsensus library #

--- a/src/bitcoin-wallet-tool-res.rc
+++ b/src/bitcoin-wallet-tool-res.rc
@@ -1,0 +1,35 @@
+#include <windows.h>             // needed for VERSIONINFO
+#include "clientversion.h"       // holds the needed client version information
+
+#define VER_PRODUCTVERSION     CLIENT_VERSION_MAJOR,CLIENT_VERSION_MINOR,CLIENT_VERSION_REVISION,CLIENT_VERSION_BUILD
+#define VER_PRODUCTVERSION_STR STRINGIZE(CLIENT_VERSION_MAJOR) "." STRINGIZE(CLIENT_VERSION_MINOR) "." STRINGIZE(CLIENT_VERSION_REVISION) "." STRINGIZE(CLIENT_VERSION_BUILD)
+#define VER_FILEVERSION        VER_PRODUCTVERSION
+#define VER_FILEVERSION_STR    VER_PRODUCTVERSION_STR
+
+VS_VERSION_INFO VERSIONINFO
+FILEVERSION     VER_FILEVERSION
+PRODUCTVERSION  VER_PRODUCTVERSION
+FILEOS          VOS_NT_WINDOWS32
+FILETYPE        VFT_APP
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904E4" // U.S. English - multilingual (hex)
+        BEGIN
+            VALUE "CompanyName",        "Bitcoin"
+            VALUE "FileDescription",    "bitcoin-wallet-tool (CLI Bitcoin wallet editor utility)"
+            VALUE "FileVersion",        VER_FILEVERSION_STR
+            VALUE "InternalName",       "bitcoin-wallet-tool"
+            VALUE "LegalCopyright",     COPYRIGHT_STR
+            VALUE "LegalTrademarks1",   "Distributed under the MIT software license, see the accompanying file COPYING or http://www.opensource.org/licenses/mit-license.php."
+            VALUE "OriginalFilename",   "bitcoin-wallet-tool.exe"
+            VALUE "ProductName",        "bitcoin-wallet-tool"
+            VALUE "ProductVersion",     VER_PRODUCTVERSION_STR
+        END
+    END
+
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x0, 1252 // language neutral - multilingual (decimal)
+    END
+END

--- a/src/bitcoin-wallet-tool.cpp
+++ b/src/bitcoin-wallet-tool.cpp
@@ -1,0 +1,90 @@
+// Copyright (c) 2016 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#if defined(HAVE_CONFIG_H)
+#include "config/bitcoin-config.h"
+#endif
+
+#include "chainparams.h"
+#include "chainparamsbase.h"
+#include "consensus/consensus.h"
+#include "util.h"
+#include "utilstrencodings.h"
+
+#include "wallet/wallettools.h"
+
+#include <stdio.h>
+
+
+std::string HelpMessageCli()
+{
+    std::string strUsage;
+    strUsage += HelpMessageGroup(_("Options:"));
+    strUsage += HelpMessageOpt("-?", _("This help message"));
+    strUsage += HelpMessageOpt("-file=<wallet-file>", strprintf(_("Specify wallet.dat file (default: %s)"), "./"+std::string(DEFAULT_WALLET_DAT)));
+
+    strUsage += HelpMessageGroup(_("Commands:"));
+    strUsage += HelpMessageOpt("info", _("Get wallet infos"));
+    strUsage += HelpMessageOpt("create", _("Create new wallet file"));
+    strUsage += HelpMessageOpt("salvage", _("Recover readable keypairs"));
+    strUsage += HelpMessageOpt("zaptxes", _("Remove all transactions including metadata (will keep keys)"));
+
+    return strUsage;
+}
+
+static bool WalletAppInit(int argc, char* argv[])
+{
+    ParseParameters(argc, argv);
+    if (argc<2 || IsArgSet("-?") || IsArgSet("-h") || IsArgSet("-help") || IsArgSet("-version")) {
+        std::string strUsage = strprintf(_("%s wallet-tool version"), PACKAGE_NAME) + " " + FormatFullVersion() + "\n";
+        if (!IsArgSet("-version")) {
+            strUsage += "\n" + _("Usage:") + "\n" +
+            "  bitcoin-wallet-tool [options] <command>\n";
+            strUsage += "\n" + HelpMessageCli();
+        }
+
+        fprintf(stdout, "%s", strUsage.c_str());
+        return false;
+    }
+
+    // check for printtoconsole, allow -debug
+    fPrintToConsole = GetBoolArg("-printtoconsole", GetBoolArg("-debug", false));
+
+    // select params
+    SelectParams(ChainNameFromCommandLine());
+
+    return true;
+}
+
+int main(int argc, char* argv[])
+{
+    SetupEnvironment();
+    try {
+        if(!WalletAppInit(argc, argv))
+        return EXIT_FAILURE;
+    }
+    catch (const std::exception& e) {
+        PrintExceptionContinue(&e, "WalletAppInit()");
+        return EXIT_FAILURE;
+    } catch (...) {
+        PrintExceptionContinue(NULL, "WalletAppInit()");
+        return EXIT_FAILURE;
+    }
+
+    while (argc > 1 && IsSwitchChar(argv[1][0])) {
+        argc--;
+        argv++;
+    }
+    std::vector<std::string> args = std::vector<std::string>(&argv[1], &argv[argc]);
+    std::string strMethod = args[0];
+
+    std::string walletFile = GetArg("-file", DEFAULT_WALLET_DAT);
+
+    ECCVerifyHandle globalVerifyHandle;
+    ECC_Start();
+    if (!WalletTool::executeWalletToolFunc(strMethod, walletFile))
+        return EXIT_FAILURE;
+    ECC_Stop();
+    return true;
+}

--- a/src/wallet/crypter.cpp
+++ b/src/wallet/crypter.cpp
@@ -168,7 +168,7 @@ bool CCryptoKeyStore::Lock()
     return true;
 }
 
-bool CCryptoKeyStore::Unlock(const CKeyingMaterial& vMasterKeyIn)
+bool CCryptoKeyStore::Unlock(const CKeyingMaterial& vMasterKeyIn, bool acceptNoKeys)
 {
     {
         LOCK(cs_KeyStore);
@@ -197,7 +197,7 @@ bool CCryptoKeyStore::Unlock(const CKeyingMaterial& vMasterKeyIn)
             LogPrintf("The wallet is probably corrupted: Some keys decrypt but not all.\n");
             assert(false);
         }
-        if (keyFail || !keyPass)
+        if (keyFail || (!keyPass && !acceptNoKeys))
             return false;
         vMasterKey = vMasterKeyIn;
         fDecryptionThoroughlyChecked = true;

--- a/src/wallet/crypter.h
+++ b/src/wallet/crypter.h
@@ -132,7 +132,7 @@ protected:
     //! will encrypt previously unencrypted keys
     bool EncryptKeys(CKeyingMaterial& vMasterKeyIn);
 
-    bool Unlock(const CKeyingMaterial& vMasterKeyIn);
+    bool Unlock(const CKeyingMaterial& vMasterKeyIn, bool acceptNoKeys = false);
 
 public:
     CCryptoKeyStore() : fUseCrypto(false), fDecryptionThoroughlyChecked(false)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -290,7 +290,7 @@ bool CWallet::LoadWatchOnly(const CScript &dest)
     return CCryptoKeyStore::AddWatchOnly(dest);
 }
 
-bool CWallet::Unlock(const SecureString& strWalletPassphrase)
+bool CWallet::Unlock(const SecureString& strWalletPassphrase, bool acceptNoKeys)
 {
     CCrypter crypter;
     CKeyingMaterial _vMasterKey;
@@ -303,7 +303,7 @@ bool CWallet::Unlock(const SecureString& strWalletPassphrase)
                 return false;
             if (!crypter.Decrypt(pMasterKey.second.vchCryptedKey, _vMasterKey))
                 continue; // try another master key
-            if (CCryptoKeyStore::Unlock(_vMasterKey))
+            if (CCryptoKeyStore::Unlock(_vMasterKey, acceptNoKeys))
                 return true;
         }
     }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -895,7 +895,7 @@ public:
     //! Holds a timestamp at which point the wallet is scheduled (externally) to be relocked. Caller must arrange for actual relocking to occur via Lock().
     int64_t nRelockTime;
 
-    bool Unlock(const SecureString& strWalletPassphrase);
+    bool Unlock(const SecureString& strWalletPassphrase, bool acceptNoKeys = false);
     bool ChangeWalletPassphrase(const SecureString& strOldWalletPassphrase, const SecureString& strNewWalletPassphrase);
     bool EncryptWallet(const SecureString& strWalletPassphrase);
 

--- a/src/wallet/wallettools.cpp
+++ b/src/wallet/wallettools.cpp
@@ -1,0 +1,157 @@
+// Copyright (c) 2016 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "base58.h"
+#include "util.h"
+#include "wallet/wallet.h"
+
+#include <boost/filesystem.hpp>
+
+namespace WalletTool {
+
+static CWallet* CreateWallet(const std::string walletFile)
+{
+    boost::filesystem::path filePath(walletFile);
+    if (boost::filesystem::exists(filePath))
+    {
+        fprintf(stderr, "Error: File exists already\n");
+        return NULL;
+    }
+    std::unique_ptr<CWalletDBWrapper> dbw(new CWalletDBWrapper(&bitdb, walletFile));
+    CWallet *walletInstance = new CWallet(std::move(dbw));
+    bool fFirstRun = true;
+    DBErrors nLoadWalletRet = walletInstance->LoadWallet(fFirstRun);
+    if (nLoadWalletRet != DB_LOAD_OK)
+    {
+        fprintf(stderr, "Error creating %s", walletFile.c_str());
+        return NULL;
+    }
+
+    if (GetBoolArg("-usehd", DEFAULT_USE_HD_WALLET) && !walletInstance->IsHDEnabled()) {
+        walletInstance->SetMinVersion(FEATURE_HD_SPLIT);
+
+        // generate a new master key
+        CPubKey masterPubKey = walletInstance->GenerateNewHDMasterKey();
+        if (!walletInstance->SetHDMasterKey(masterPubKey))
+            throw std::runtime_error(std::string(__func__) + ": Storing master key failed");
+    }
+
+    fprintf(stdout, "Topping up keypool...\n");
+    walletInstance->TopUpKeyPool();
+    return walletInstance;
+}
+
+static CWallet* LoadWallet(const std::string walletFile, bool *fFirstRun)
+{
+    boost::filesystem::path filePath(walletFile);
+    if (!boost::filesystem::exists(filePath))
+    {
+        fprintf(stderr, "Error: Wallet files does not exist\n");
+        return NULL;
+    }
+
+    std::unique_ptr<CWalletDBWrapper> dbw(new CWalletDBWrapper(&bitdb, walletFile));
+    CWallet *walletInstance = new CWallet(std::move(dbw));
+    DBErrors nLoadWalletRet = walletInstance->LoadWallet(*fFirstRun);
+    if (nLoadWalletRet != DB_LOAD_OK)
+    {
+        walletInstance = NULL;
+        if (nLoadWalletRet == DB_CORRUPT)
+        {
+            fprintf(stderr, "Error loading %s: Wallet corrupted", walletFile.c_str());
+            return NULL;
+        }
+        else if (nLoadWalletRet == DB_NONCRITICAL_ERROR)
+        {
+            fprintf(stderr, "Error reading %s! All keys read correctly, but transaction data"
+                    " or address book entries might be missing or incorrect.",
+                    walletFile.c_str());
+        }
+        else if (nLoadWalletRet == DB_TOO_NEW)
+        {
+            fprintf(stderr, "Error loading %s: Wallet requires newer version of %s",
+                    walletFile.c_str(), PACKAGE_NAME);
+            return NULL;
+        }
+        else if (nLoadWalletRet == DB_NEED_REWRITE)
+        {
+            fprintf(stderr, "Wallet needed to be rewritten: restart %s to complete", PACKAGE_NAME);
+            return NULL;
+        }
+        else
+        {
+            fprintf(stderr, "Error loading %s", walletFile.c_str());
+            return NULL;
+        }
+    }
+
+    return walletInstance;
+}
+
+static void WalletShowInfo(CWallet *walletInstance)
+{
+    // lock required because of some AssertLockHeld()
+    LOCK(walletInstance->cs_wallet);
+
+    fprintf(stdout, "Wallet info\n===========\n");
+    fprintf(stdout, "Encrypted: %s\n",      walletInstance->IsCrypted() ? "yes" : "no");
+    fprintf(stdout, "HD (hd seed available): %s\n",             walletInstance->GetHDChain().masterKeyID.IsNull() ? "no" : "yes");
+    fprintf(stdout, "Keypool Size: %lu\n",  (unsigned long)walletInstance->GetKeyPoolSize());
+    fprintf(stdout, "Transactions: %lu\n",  (unsigned long)walletInstance->mapWallet.size());
+    fprintf(stdout, "Address Book: %lu\n",  (unsigned long)walletInstance->mapAddressBook.size());
+}
+
+bool executeWalletToolFunc(const std::string& strMethod, const std::string& walletFile)
+{
+
+    if (strMethod == "create")
+    {
+        CWallet *walletInstance = CreateWallet(walletFile);
+        if (walletInstance)
+            WalletShowInfo(walletInstance);
+    }
+    else if (strMethod == "info")
+    {
+        bool fFirstRun;
+        CWallet *walletInstance = LoadWallet(walletFile, &fFirstRun);
+        if (!walletInstance)
+            return false;
+        WalletShowInfo(walletInstance);
+    }
+    else if (strMethod == "salvage")
+    {
+        // Recover readable keypairs:
+        std::string strError;
+        fs::path walletFilePath(walletFile);
+        if (!CWalletDB::VerifyEnvironment(walletFilePath.filename().string(), walletFilePath.parent_path().string()+"/", strError)) {
+            fprintf(stderr, "CWalletDB::VerifyEnvironment Error: %s\n", strError.c_str());
+        }
+
+        CWallet dummyWallet;
+        if (!CWalletDB::Recover(walletFilePath.filename().string(), (void *)&dummyWallet, CWalletDB::RecoverKeysOnlyFilter)) {
+            fprintf(stderr, "Salvage failed\n");
+            return false;
+        }
+        //TODO, set wallets best block to genesis to enforce a rescan
+        fprintf(stdout, "Salvage successful. Please rescan your wallet.");
+    }
+    else if (strMethod == "zaptxes")
+    {
+        std::vector<CWalletTx> vWtx;
+        std::unique_ptr<CWalletDBWrapper> dbw(new CWalletDBWrapper(&bitdb, walletFile));
+        CWallet *tempWallet = new CWallet(std::move(dbw));
+        DBErrors nZapWalletRet = tempWallet->ZapWalletTx(vWtx);
+        if (nZapWalletRet != DB_LOAD_OK) {
+            fprintf(stderr, "Error loading %s: Wallet corrupted", walletFile.c_str());
+            return false;
+        }
+        fprintf(stdout, "Zaptxes successful executed. Please rescan your wallet.");
+    }
+    else {
+        fprintf(stderr, "Unknown command\n");
+    }
+
+    return true;
+}
+}

--- a/src/wallet/wallettools.h
+++ b/src/wallet/wallettools.h
@@ -1,0 +1,19 @@
+// Copyright (c) 2016 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_WALLET_WALLETTOOL_H
+#define BITCOIN_WALLET_WALLETTOOL_H
+
+#include "script/ismine.h"
+#include "wallet/wallet.h"
+
+namespace WalletTool {
+CWallet* CreateWallet(const std::string walletFile);
+CWallet* LoadWallet(const std::string walletFile, bool *fFirstRun);
+void WalletShowInfo(CWallet *walletInstance);
+bool executeWalletToolFunc(const std::string& strMethod, const std::string& walletFile);
+}
+
+
+#endif // BITCOIN_WALLET_WALLETTOOL_H


### PR DESCRIPTION
**WORK IN PROGRESS**
Add another bitcoin-tool called `bitcoin-wallet-tool`. Currently it supports creation of wallets (with optional encryption before creating keys), encryption and some info-dumping.

If we agree on this concept, it could be use for creating a HD wallet with a given xpriv.
Also, a such tool would probably be required to properly restore a hd wallet.
If we once migrate away from BerkleyDB, this could also be helpful.
