### PR TITLE
[Qt][RPC] Hide passphrases in debug console history

### DIFF
--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -616,8 +616,14 @@ void RPCConsole::on_lineEdit_returnPressed()
 
     if(!cmd.isEmpty())
     {
-        message(CMD_REQUEST, cmd);
         Q_EMIT cmdRequest(cmd);
+        // Remove passphrases from history
+        QStringList cmdList = cmd.split(' ');
+        if(cmdList.first() == "walletpassphrase")
+            cmd = cmdList.first() + " **PASSPHRASE** " + cmdList.back();
+        else if(cmdList.first() == "walletpassphrasechange")
+            cmd = cmdList.first() + " **OLDPASSPHRASE** **NEWPASSPHRASE**";
+        message(CMD_REQUEST, cmd);
         // Remove command, if already in history
         history.removeOne(cmd);
         // Append command to history

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -623,6 +623,8 @@ void RPCConsole::on_lineEdit_returnPressed()
             cmd = cmdList.first() + " **PASSPHRASE** " + cmdList.back();
         else if(cmdList.first() == "walletpassphrasechange")
             cmd = cmdList.first() + " **OLDPASSPHRASE** **NEWPASSPHRASE**";
+        else if(cmdList.first() == "encryptwallet")
+            cmd = cmdList.first() + " **PASSPHRASE**";
         message(CMD_REQUEST, cmd);
         // Remove command, if already in history
         history.removeOne(cmd);


### PR DESCRIPTION
Right now passphrases in the debug console are displayed in plaintext on screen as well as in the history. This will replace all the passphrases entered with the `walletpassphrase` and `walletpassphrasechange` RPCs with a placeholder, `**PASSPHRASE**`, in order to prevent the loss of a password due to people looking at the debug console history.
