### PR TITLE
[Doc] Target protobuf 2.6 in OS X build notes.

### DIFF
--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -16,7 +16,7 @@ Then install [Homebrew](http://brew.sh).
 Dependencies
 ----------------------
 
-    brew install automake berkeley-db4 libtool boost --c++11 miniupnpc openssl pkg-config protobuf --c++11 qt5 libevent
+    brew install automake berkeley-db4 libtool boost --c++11 miniupnpc openssl pkg-config homebrew/versions/protobuf260 --c++11 qt5 libevent
 
 NOTE: Building with Qt4 is still supported, however, could result in a broken UI. Building with Qt5 is recommended.
 


### PR DESCRIPTION
Homebrew now installs Protobuf version 3 by default, which doesn't currently compile. So we should recommend installing Protobuf 2.6.x from the versions tap instead.

Should probably be backported to the 0.13 branch.

Discussion in #8741 
