### PR TITLE
Implement excessive sighashing protection policy with loose sighash estimation

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -146,6 +146,7 @@ testScripts = [
     'p2p-compactblocks.py',
     'nulldummy.py',
     'importmulti.py',
+    'sighashlimit.py',
 ]
 if ENABLE_ZMQ:
     testScripts.append('zmq_test.py')

--- a/qa/rpc-tests/sighashlimit.py
+++ b/qa/rpc-tests/sighashlimit.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+# Copyright (c) 2016 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.mininode import CTransaction, CTxOut, CTxIn, COutPoint, CTxInWitness
+from test_framework.util import *
+from test_framework.script import CScript, OP_0, OP_HASH160, OP_EQUAL, OP_CHECKSIG, OP_NOT, OP_2DUP, OP_DROP, OP_2DROP, hash160, sha256
+
+# This is to test the sighash limit policy
+
+class SigHashLimitTest(BitcoinTestFramework):
+
+    def __init__(self):
+        super().__init__()
+        self.setup_clean_chain = True
+
+    def setup_network(self):
+        # Create 2 nodes. One enforces standardness rules and one does not.
+        self.nodes = [start_node(0, self.options.tmpdir, ["-acceptnonstdtxn=0"])]
+        self.nodes.append(start_node(1, self.options.tmpdir))
+        connect_nodes(self.nodes[0], 1)
+
+    def test_preparation(self):
+        print ("Testing sighash limit policy")
+        # Generate a block and get the coinbase txid.
+        self.coinbase_blocks = self.nodes[1].generate(1)
+        coinbase_txid = int("0x" + self.nodes[1].getblock(self.coinbase_blocks[0])['tx'][0], 0)
+        self.nodes[1].generate(100)
+
+        '''
+        # By design, it is impossible to create a normal transaction below 400,000 weight,
+        # while having excessive SigHash size.
+        #
+        # Here it creates small script with 4 SigHashOp in P2SH.
+        # Also create a witness program, which should be ignored in SigHashOp counting.
+        '''
+        dummykey = hex_str_to_bytes("0300112233445566778899aabbccddeeff00112233445566778899aabbccddeeff")
+        self.script = CScript([OP_0, dummykey, OP_2DUP, OP_2DUP, OP_2DUP, OP_CHECKSIG, OP_DROP, OP_CHECKSIG, OP_DROP, OP_CHECKSIG, OP_DROP, OP_CHECKSIG, OP_NOT])
+        self.p2sh = CScript([OP_HASH160, hash160(self.script), OP_EQUAL])
+        self.p2wsh = CScript([OP_0, sha256(self.script)])
+
+        tx = CTransaction()
+        tx.vin.append(CTxIn(COutPoint(coinbase_txid)))
+        for i in range(1000):
+            tx.vout.append(CTxOut(4500000, self.p2sh))
+        for i in range(100):
+            tx.vout.append(CTxOut(4500000, self.p2wsh))
+
+        tx.rehash()
+        signresults = self.nodes[1].signrawtransaction(bytes_to_hex_str(tx.serialize_with_witness()))['hex']
+        self.txid = int("0x" + self.nodes[1].sendrawtransaction(signresults, True), 0)
+        self.nodes[1].generate(1)
+        sync_blocks(self.nodes)
+
+        self.p2shcount = 0      # P2SH outputs start from 0
+        self.p2wshcount = 1000   # P2WSH outputs start from 500
+
+    def non_segwit_test(self):
+        '''
+        tx1:
+            Size = 4 + 1 + 88 * 95 + 3 + 2390 * 32 + 4 = 84852
+            Weight = 84852 * 4 = 339408
+            Hashable size = 84852 - 47 * 95 = 80387
+            SigHashOp = 4 * 95 = 380
+            SigHashSize = 380 * 80387 = 30547060
+            SigHashSize per Weight = 30547060 / 339408 = 90.001
+
+        tx2:
+            Size = 4 + 1 + 88 * 95 + 3 + 2389 * 32 + 4 = 84820
+            Weight = 84820 * 4 = 339280
+            Hashable size = 84820 - 47 * 95 = 80355
+            SigHashOp = 4 * 95 = 380
+            SigHashSize = 380 * 80355 = 30534900
+            SigHashSize per Weight = 30534900 / 339280 = 89.9991
+        '''
+        tx1 = CTransaction()
+        tx2 = CTransaction()
+        for i in range(95):
+            tx1.vin.append(CTxIn(COutPoint(self.txid,self.p2shcount),CScript([self.script])))
+            tx2.vin.append(CTxIn(COutPoint(self.txid,self.p2shcount + 1),CScript([self.script])))
+            self.p2shcount += 2
+        for i in range(2389):
+            tx1.vout.append(CTxOut(1000, self.p2sh))
+            tx2.vout.append(CTxOut(1000, self.p2sh))
+        tx1.vout.append(CTxOut(1000, self.p2sh))    # Add one more output to tx1
+        tx1.rehash()
+        tx2.rehash()
+        self.submit_pair(tx1, tx2)
+
+    def segwit_test(self):
+        '''
+        tx1:
+            Witness-stripped size = 4 + 1 + 88 * 95 + 41 * 20 + 3 + 2513 * 32 + 4 = 89608
+            Witness size = 2 + 1 * 95 + 48 * 20 = 1057
+            Weight = 89608 * 4 + 1057 = 359489
+            Hashable size = 89608 - 47 * 95 = 85143
+            SigHashOp = 4 * 95 = 380
+            SigHashSize = 380 * 85143 = 32354340
+            SigHashSize per Weight = 32342180 / 359489 = 90.0009
+
+        tx2:
+            Witness-stripped size = 4 + 1 + 88 * 95 + 41 * 20 + 3 + 2512 * 32 + 4 = 89576
+            Witness size = 2 + 1 * 95 + 48 * 20 = 1057
+            Weight = 89576 * 4 + 1057 = 359361
+            Hashable size = 89576 - 47 * 95 = 85111
+            SigHashOp = 4 * 95 = 380
+            SigHashSize = 380 * 85111 = 32342180
+            SigHashSize per Weight = 32342180 / 359361 = 89.9991
+        '''
+        tx1 = CTransaction()
+        tx2 = CTransaction()
+        for i in range(20):
+            tx1.vin.append(CTxIn(COutPoint(self.txid,self.p2wshcount)))
+            tx1.wit.vtxinwit.append(CTxInWitness())
+            tx1.wit.vtxinwit[i].scriptWitness.stack = [self.script]
+            tx2.vin.append(CTxIn(COutPoint(self.txid,self.p2wshcount + 1)))
+            tx2.wit.vtxinwit.append(CTxInWitness())
+            tx2.wit.vtxinwit[i].scriptWitness.stack = [self.script]
+            self.p2wshcount += 2
+        for i in range(95):
+            tx1.vin.append(CTxIn(COutPoint(self.txid,self.p2shcount),CScript([self.script])))
+            tx2.vin.append(CTxIn(COutPoint(self.txid,self.p2shcount + 1),CScript([self.script])))
+            self.p2shcount += 2
+        for i in range(2512):
+            tx1.vout.append(CTxOut(1000, self.p2sh))
+            tx2.vout.append(CTxOut(1000, self.p2sh))
+        tx1.vout.append(CTxOut(1000, self.p2sh))    # Add one more output to tx1
+        tx1.rehash()
+        tx2.rehash()
+        self.submit_pair(tx1, tx2)
+
+    def submit_pair(self, tx1, tx2):
+        # Non-standard node should accept both tx1 and tx2. Standard node should accept only tx2
+        try:
+            self.nodes[0].sendrawtransaction(bytes_to_hex_str(tx1.serialize_with_witness()), True)
+        except JSONRPCException as exp:
+            assert_equal(exp.error["message"], "64: bad-txns-nonstandard-too-much-sighashing")
+        else:
+            assert(False)
+        self.nodes[1].sendrawtransaction(bytes_to_hex_str(tx1.serialize_with_witness()), True)
+        self.nodes[0].sendrawtransaction(bytes_to_hex_str(tx2.serialize_with_witness()), True)
+        self.nodes[1].sendrawtransaction(bytes_to_hex_str(tx2.serialize_with_witness()), True)
+        self.nodes[1].generate(1)
+        sync_blocks(self.nodes)
+
+    def run_test(self):
+        self.test_preparation()
+        self.non_segwit_test()          # Test non-segwit P2SH before segwit activation
+        self.nodes[0].generate(400)     # Activate segwit
+        sync_blocks(self.nodes)
+        self.non_segwit_test()          # Test non-segwit P2SH after segwit activation
+        self.segwit_test()              # Test non-segwit P2SH mixed with P2WSH
+
+if __name__ == '__main__':
+    SigHashLimitTest().main()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1062,8 +1062,23 @@ int64_t GetTransactionSigOpCost(const CTransaction& tx, const CCoinsViewCache& i
     return nSigOps;
 }
 
+int GetTransactionBaseSigHashOpCount(const CTransaction& tx, const CCoinsViewCache& inputs, int flags)
+{
+    int nSigHashOps = 0;
 
+    if (tx.IsCoinBase())
+        return nSigHashOps;
 
+    for (unsigned int i = 0; i < tx.vin.size(); i++) {
+        nSigHashOps += tx.vin[i].scriptSig.GetSigHashOpCount();
+        const CTxOut &prevout = inputs.GetOutputFor(tx.vin[i]);
+        nSigHashOps += prevout.scriptPubKey.GetSigHashOpCount();
+        if (prevout.scriptPubKey.IsPayToScriptHash() && (flags & SCRIPT_VERIFY_P2SH))
+            nSigHashOps += prevout.scriptPubKey.GetSigHashOpCount(tx.vin[i].scriptSig);
+    }
+
+    return nSigHashOps;
+}
 
 
 bool CheckTransaction(const CTransaction& tx, CValidationState &state)
@@ -1284,6 +1299,13 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState& state, const C
         // Check for non-standard witness in P2WSH
         if (!tx.wit.IsNull() && fRequireStandard && !IsWitnessStandard(tx, view))
             return state.DoS(0, false, REJECT_NONSTANDARD, "bad-witness-nonstandard", true);
+
+        // Check for excessive SignatureHash operation
+        if (fRequireStandard) {
+            int64_t hashsize = GetTransactionHashableSize(tx) * GetTransactionBaseSigHashOpCount(tx, view, STANDARD_SCRIPT_VERIFY_FLAGS);
+            if (hashsize > MAX_STANDARD_HASH_PER_WEIGHT * GetTransactionWeight(tx))
+                return state.Invalid(false, REJECT_NONSTANDARD, "bad-txns-nonstandard-too-much-sighashing");
+        }
 
         int64_t nSigOpsCost = GetTransactionSigOpCost(tx, view, STANDARD_SCRIPT_VERIFY_FLAGS);
 

--- a/src/main.h
+++ b/src/main.h
@@ -1,5 +1,5 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
-// Copyright (c) 2009-2015 The Bitcoin Core developers
+// Copyright (c) 2009-2016 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -324,6 +324,12 @@ unsigned int GetP2SHSigOpCount(const CTransaction& tx, const CCoinsViewCache& ma
  * @return Total signature operation cost of tx
  */
 int64_t GetTransactionSigOpCost(const CTransaction& tx, const CCoinsViewCache& inputs, int flags);
+
+/**
+ * Compute total signature hashing operation of a transaction.
+ * Parameters same as GetTransactionSigOpCost
+ */
+int GetTransactionBaseSigHashOpCount(const CTransaction& tx, const CCoinsViewCache& inputs, int flags);
 
 /**
  * Check whether all inputs of this transaction are valid (no double spends, scripts & sigs, amounts)

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -37,6 +37,12 @@ static const unsigned int MAX_STANDARD_P2WSH_STACK_ITEM_SIZE = 80;
 /** The maximum size of a standard witnessScript */
 static const unsigned int MAX_STANDARD_P2WSH_SCRIPT_SIZE = 3600;
 /**
+ *  Maximum standard signature hashing per transaction weight (byte hashed per weight)
+ *  This is equivalent to 36MB for an 100kB non-segwit transaction.
+ *  All transactions below 100kB with legitimate use of CHECK(MULTI)SIG should remain standard with this limit.
+ */
+static const unsigned int MAX_STANDARD_HASH_PER_WEIGHT = 90;
+/**
  * Standard script verification flags that standard transactions will comply
  * with. However scripts violating these flags may still be present in valid
  * blocks and we must accept those blocks.

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
-// Copyright (c) 2009-2015 The Bitcoin Core developers
+// Copyright (c) 2009-2016 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -157,4 +157,22 @@ std::string CTransaction::ToString() const
 int64_t GetTransactionWeight(const CTransaction& tx)
 {
     return ::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION | SERIALIZE_TRANSACTION_NO_WITNESS) * (WITNESS_SCALE_FACTOR -1) + ::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION);
+}
+
+int64_t GetTransactionHashableSize(const CTransaction& tx)
+{
+    int64_t size = ::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION | SERIALIZE_TRANSACTION_NO_WITNESS);
+    for (unsigned int i = 0; i < tx.vin.size(); i++) {
+        int64_t scriptSigSize = tx.vin[i].scriptSig.size();
+        size -= scriptSigSize;
+        // If the scriptSig size is larger than 252, 2 bytes compactSize encoding is deducted.
+        if (scriptSigSize > 252)
+            size -= 2;
+        /*
+         * Theoretically, 4 bytes should be deducted if the scriptSig is larger than 65535 bytes,
+         * and 8 bytes should be deducted if it is larger than 4294967295 bytes.
+         * However, scriptSig larger than 10000 bytes is invalid so it is not needed.
+         */
+    }
+    return size;
 }

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -1,5 +1,5 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
-// Copyright (c) 2009-2015 The Bitcoin Core developers
+// Copyright (c) 2009-2016 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -470,5 +470,8 @@ struct CMutableTransaction
 
 /** Compute the weight of a transaction, as defined by BIP 141 */
 int64_t GetTransactionWeight(const CTransaction &tx);
+
+/** Compute the signature hashable size = transaction size - scriptSig size */
+int64_t GetTransactionHashableSize(const CTransaction& tx);
 
 #endif // BITCOIN_PRIMITIVES_TRANSACTION_H

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -128,7 +128,7 @@ uint256 SignatureHash(const CScript &scriptCode, const CTransaction& txTo, unsig
 class BaseSignatureChecker
 {
 public:
-    virtual bool CheckSig(const std::vector<unsigned char>& scriptSig, const std::vector<unsigned char>& vchPubKey, const CScript& scriptCode, SigVersion sigversion) const
+    virtual bool CheckSig(const std::vector<unsigned char>& scriptSig, const std::vector<unsigned char>& vchPubKey, const CScript& scriptCode, SigVersion sigversion, uint256& sighashCopy, bool& cacheSet) const
     {
         return false;
     }
@@ -160,7 +160,7 @@ protected:
 public:
     TransactionSignatureChecker(const CTransaction* txToIn, unsigned int nInIn, const CAmount& amountIn) : txTo(txToIn), nIn(nInIn), amount(amountIn), txdata(NULL) {}
     TransactionSignatureChecker(const CTransaction* txToIn, unsigned int nInIn, const CAmount& amountIn, const PrecomputedTransactionData& txdataIn) : txTo(txToIn), nIn(nInIn), amount(amountIn), txdata(&txdataIn) {}
-    bool CheckSig(const std::vector<unsigned char>& scriptSig, const std::vector<unsigned char>& vchPubKey, const CScript& scriptCode, SigVersion sigversion) const;
+    bool CheckSig(const std::vector<unsigned char>& scriptSig, const std::vector<unsigned char>& vchPubKey, const CScript& scriptCode, SigVersion sigversion, uint256& sighashCopy, bool& cacheSet) const;
     bool CheckLockTime(const CScriptNum& nLockTime) const;
     bool CheckSequence(const CScriptNum& nSequence) const;
 };

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -1,5 +1,5 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
-// Copyright (c) 2009-2015 The Bitcoin Core developers
+// Copyright (c) 2009-2016 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -619,6 +619,13 @@ public:
      * pay-to-script-hash transactions:
      */
     unsigned int GetSigOpCount(const CScript& scriptSig) const;
+
+    /**
+     * Count the maximum number of sighashing-equivalent operations in a non-witness script.
+     * It assumes that SignatureHash is performed once only for each signature within a CHECKMULTISIG.
+     */
+    unsigned int GetSigHashOpCount() const;
+    unsigned int GetSigHashOpCount(const CScript& scriptSig) const;
 
     bool IsPayToScriptHash() const;
     bool IsPayToWitnessScriptHash() const;

--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -257,13 +257,15 @@ static vector<valtype> CombineMultisig(const CScript& scriptPubKey, const BaseSi
     map<valtype, valtype> sigs;
     BOOST_FOREACH(const valtype& sig, allsigs)
     {
+        uint256 sighashCopy;
+        bool cacheSet = false;
         for (unsigned int i = 0; i < nPubKeys; i++)
         {
             const valtype& pubkey = vSolutions[i+1];
             if (sigs.count(pubkey))
                 continue; // Already got a sig for this pubkey
 
-            if (checker.CheckSig(sig, pubkey, scriptPubKey, sigversion))
+            if (checker.CheckSig(sig, pubkey, scriptPubKey, sigversion, sighashCopy, cacheSet))
             {
                 sigs[pubkey] = sig;
                 break;
@@ -401,7 +403,7 @@ class DummySignatureChecker : public BaseSignatureChecker
 public:
     DummySignatureChecker() {}
 
-    bool CheckSig(const std::vector<unsigned char>& scriptSig, const std::vector<unsigned char>& vchPubKey, const CScript& scriptCode, SigVersion sigversion) const
+    bool CheckSig(const std::vector<unsigned char>& scriptSig, const std::vector<unsigned char>& vchPubKey, const CScript& scriptCode, SigVersion sigversion, uint256& sighashCopy, bool& cacheSet) const
     {
         return true;
     }

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2015 The Bitcoin Core developers
+// Copyright (c) 2011-2016 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -1333,7 +1333,6 @@ ScriptFromHex(const char* hex)
     return CScript(data.begin(), data.end());
 }
 
-
 BOOST_AUTO_TEST_CASE(script_FindAndDelete)
 {
     // Exercise the FindAndDelete functionality
@@ -1441,6 +1440,103 @@ BOOST_AUTO_TEST_CASE(script_FindAndDelete)
     expect = ScriptFromHex("03feed");
     BOOST_CHECK_EQUAL(s.FindAndDelete(d), 1);
     BOOST_CHECK(s == expect);
+}
+
+BOOST_AUTO_TEST_CASE(script_SigHashOp)
+{
+    CScript s;
+    CKey key;
+    key.MakeNewKey(true);
+    std::vector<unsigned char> pubkey = ToByteVector(key.GetPubKey());
+
+    // Empty script
+    BOOST_CHECK_EQUAL(s.GetSigHashOpCount(), 0);
+
+    // Maximum count is 3
+    for (int i = 1; i < 10; i++) {
+        s << OP_CHECKSIG;
+        BOOST_CHECK_EQUAL(s.GetSigHashOpCount(), i);
+    }
+    s = CScript();
+    for (int i = 1; i < 10; i++) {
+        s << OP_CHECKMULTISIG;
+        BOOST_CHECK_EQUAL(s.GetSigHashOpCount(), 20*i);
+    }
+    s = CScript();
+    for (int i = 1; i < 10; i++) {
+        s << OP_1 << pubkey << pubkey << OP_2 << OP_CHECKMULTISIG;
+        BOOST_CHECK_EQUAL(s.GetSigHashOpCount(), i);
+    }
+    s = CScript();
+    for (int i = 1; i < 10; i++) {
+        s << OP_2 << pubkey << pubkey << OP_2 << OP_CHECKMULTISIG;
+        BOOST_CHECK_EQUAL(s.GetSigHashOpCount(), 2*i);
+    }
+
+    // Mixing CHECKSIG and CHECKMULTISIG
+    s = CScript() << OP_CHECKSIGVERIFY << OP_1 << pubkey << pubkey << OP_2 << OP_CHECKMULTISIG;
+    BOOST_CHECK_EQUAL(s.GetSigHashOpCount(), 2);
+    s = CScript() << OP_1 << pubkey << pubkey << OP_2 << OP_CHECKMULTISIGVERIFY << OP_CHECKSIG;
+    BOOST_CHECK_EQUAL(s.GetSigHashOpCount(), 2);
+
+    // OP_RESERVED is considered as a push code. It doesn't matter since the script must fail before CHECKMULTISIG is run.
+    s = CScript() << OP_1 << OP_RESERVED << OP_0 << OP_2 << OP_CHECKMULTISIG;
+    BOOST_CHECK_EQUAL(s.GetSigHashOpCount(), 1);
+
+    // Using OP_RESERVED as number of signature is non-canonical
+    s = CScript() << OP_RESERVED << OP_RESERVED << OP_0 << OP_2 << OP_CHECKMULTISIG;
+    BOOST_CHECK_EQUAL(s.GetSigHashOpCount(), 2);
+
+    // Using non-push code before number of signature or after OP_CHECKMULTISIG is ok
+    s = CScript() << OP_NOP << OP_1 << pubkey << pubkey << OP_2 << OP_CHECKMULTISIG;
+    BOOST_CHECK_EQUAL(s.GetSigHashOpCount(), 1);
+    s = CScript() << OP_1 << pubkey << pubkey << OP_2 << OP_CHECKMULTISIG << OP_NOP;
+    BOOST_CHECK_EQUAL(s.GetSigHashOpCount(), 1);
+    // But not ok if it's used in between
+    s = CScript() << OP_1 << OP_NOP << pubkey << pubkey << OP_2 << OP_CHECKMULTISIG;
+    BOOST_CHECK_EQUAL(s.GetSigHashOpCount(), 2);
+    s = CScript() << OP_1 << pubkey << OP_NOP << pubkey << OP_2 << OP_CHECKMULTISIG;
+    BOOST_CHECK_EQUAL(s.GetSigHashOpCount(), 2);
+    s = CScript() << OP_1 << pubkey << pubkey << OP_NOP << OP_2 << OP_CHECKMULTISIG;
+    BOOST_CHECK_EQUAL(s.GetSigHashOpCount(), 2);
+    s = CScript() << OP_1 << pubkey << pubkey << OP_2 << OP_NOP << OP_CHECKMULTISIG;
+    BOOST_CHECK_EQUAL(s.GetSigHashOpCount(), 20);
+
+    // Test 17 * 18 combinations of nKey and nSig in OP_CHECKMULTISIG
+    static const opcodetype pushOps[] = {OP_0, OP_1, OP_2, OP_3, OP_4, OP_5, OP_6, OP_7, OP_8, OP_9, OP_10, OP_11, OP_12, OP_13, OP_14, OP_15, OP_16};
+    for (int nKey = 0; nKey <= 16; nKey++) {
+        for (int nSig = -1; nSig <= 16; nSig++) {
+            s = CScript();
+            if (nSig >= 0)
+               s << pushOps[nSig];
+            for (int i = 0; i < nKey; i++)
+                s << pubkey;
+            s << pushOps[nKey] << OP_CHECKMULTISIG;
+            if (nKey == 0)
+                BOOST_CHECK_EQUAL(s.GetSigHashOpCount(), MAX_PUBKEYS_PER_MULTISIG); // This is non-canonical
+            else if (nSig > 0 && nSig < nKey)
+                BOOST_CHECK_EQUAL(s.GetSigHashOpCount(), nSig);
+            else
+                BOOST_CHECK_EQUAL(s.GetSigHashOpCount(), nKey);
+        }
+    }
+
+    // Non-canonical push for nKey or nSig
+    s = ScriptFromHex("5151510102ae");
+    BOOST_CHECK_EQUAL(s.GetSigHashOpCount(), 20);
+    s = ScriptFromHex("0101515152ae");
+    BOOST_CHECK_EQUAL(s.GetSigHashOpCount(), 2);
+
+    // Non-canonical push for pubkey is ok
+    // OP_2 0x0101 OP_PUSHDATA1(01) OP_PUSHDATA2(01) OP_PUSHDATA4(01) OP_1 OP_RESERVED OP_6 OP_CHECKMULTISIG
+    s = ScriptFromHex("5201014c01014d0100014e0100000001515056ae");
+    BOOST_CHECK_EQUAL(s.GetSigHashOpCount(), 2);
+
+    // Truncated scripts are invalid and the last known SigHashOp is returned
+    s = ScriptFromHex("ac05acadaeaf");
+    BOOST_CHECK_EQUAL(s.GetSigHashOpCount(), 1);
+    s = ScriptFromHex("5200000053ae05acadaeaf");
+    BOOST_CHECK_EQUAL(s.GetSigHashOpCount(), 2);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/sigopcount_tests.cpp
+++ b/src/test/sigopcount_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2015 The Bitcoin Core developers
+// Copyright (c) 2012-2016 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -143,6 +143,32 @@ BOOST_AUTO_TEST_CASE(GetTxSigOpCost)
         assert(GetTransactionSigOpCost(CTransaction(creationTx), coins, flags) == MAX_PUBKEYS_PER_MULTISIG * WITNESS_SCALE_FACTOR);
         // Sanity check: script verification fails because of an invalid signature.
         assert(VerifyWithFlag(creationTx, spendingTx, flags) == SCRIPT_ERR_CHECKMULTISIGVERIFY);
+        // SigHashOp in spending scriptPubKey is counted as the number of signature
+        assert(GetTransactionBaseSigHashOpCount(CTransaction(spendingTx), coins, flags) == 1);
+        // SigOp in output scriptPubKey is not counted as SigHashOp
+        assert(GetTransactionBaseSigHashOpCount(CTransaction(creationTx), coins, flags) == 0);
+    }
+
+    // Multisig in scriptSig (legacy counting)
+    {
+        CScript scriptPubKey = CScript();
+        // Do not use a valid signature to avoid using wallet operations.
+        CScript scriptSig = CScript() << OP_0 << OP_0 << 1 << ToByteVector(pubkey) << ToByteVector(pubkey) << 2 << OP_CHECKMULTISIGVERIFY;
+
+        BuildTxs(spendingTx, coins, creationTx, scriptPubKey, scriptSig, CTxInWitness());
+        // creationTx contains two signature operations in its scriptSig, but legacy counting
+        // is not accurate.
+        assert(GetTransactionSigOpCost(CTransaction(spendingTx), coins, flags) == MAX_PUBKEYS_PER_MULTISIG * WITNESS_SCALE_FACTOR);
+        // Sanity check: script verification fails because of an invalid signature.
+        assert(VerifyWithFlag(creationTx, spendingTx, flags) == SCRIPT_ERR_CHECKMULTISIGVERIFY);
+        // SigHashOp in scriptSig is counted as the number of signature
+        assert(GetTransactionBaseSigHashOpCount(CTransaction(spendingTx), coins, flags) == 1);
+
+        // SigOp in coinbase scriptSig is counted
+        spendingTx.vin[0].prevout.SetNull();
+        assert(GetTransactionSigOpCost(CTransaction(spendingTx), coins, flags) == MAX_PUBKEYS_PER_MULTISIG * WITNESS_SCALE_FACTOR);
+        // SigHashOp in coinbase scriptSig is not counted
+        assert(GetTransactionBaseSigHashOpCount(CTransaction(spendingTx), coins, flags) == 0);
     }
 
     // Multisig nested in P2SH
@@ -154,6 +180,8 @@ BOOST_AUTO_TEST_CASE(GetTxSigOpCost)
         BuildTxs(spendingTx, coins, creationTx, scriptPubKey, scriptSig, CTxInWitness());
         assert(GetTransactionSigOpCost(CTransaction(spendingTx), coins, flags) == 2 * WITNESS_SCALE_FACTOR);
         assert(VerifyWithFlag(creationTx, spendingTx, flags) == SCRIPT_ERR_CHECKMULTISIGVERIFY);
+        // SigHashOp in redeemScript is counted as the number of signature
+        assert(GetTransactionBaseSigHashOpCount(CTransaction(spendingTx), coins, flags) == 1);
     }
 
     // P2WPKH witness program
@@ -173,6 +201,8 @@ BOOST_AUTO_TEST_CASE(GetTxSigOpCost)
         // No signature operations if we don't verify the witness.
         assert(GetTransactionSigOpCost(CTransaction(spendingTx), coins, flags & ~SCRIPT_VERIFY_WITNESS) == 0);
         assert(VerifyWithFlag(creationTx, spendingTx, flags) == SCRIPT_ERR_EQUALVERIFY);
+        // SigOp in witness is not counted as SigHashOp
+        assert(GetTransactionBaseSigHashOpCount(CTransaction(spendingTx), coins, flags) == 0);
 
         // The sig op cost for witness version != 0 is zero.
         assert(scriptPubKey[0] == 0x00);
@@ -202,6 +232,8 @@ BOOST_AUTO_TEST_CASE(GetTxSigOpCost)
         BuildTxs(spendingTx, coins, creationTx, scriptPubKey, scriptSig, witness);
         assert(GetTransactionSigOpCost(CTransaction(spendingTx), coins, flags) == 1);
         assert(VerifyWithFlag(creationTx, spendingTx, flags) == SCRIPT_ERR_EQUALVERIFY);
+        // SigOp in witness is not counted as SigHashOp
+        assert(GetTransactionBaseSigHashOpCount(CTransaction(spendingTx), coins, flags) == 0);
     }
 
     // P2WSH witness program
@@ -220,6 +252,8 @@ BOOST_AUTO_TEST_CASE(GetTxSigOpCost)
         assert(GetTransactionSigOpCost(CTransaction(spendingTx), coins, flags) == 2);
         assert(GetTransactionSigOpCost(CTransaction(spendingTx), coins, flags & ~SCRIPT_VERIFY_WITNESS) == 0);
         assert(VerifyWithFlag(creationTx, spendingTx, flags) == SCRIPT_ERR_CHECKMULTISIGVERIFY);
+        // SigOp in witness is not counted as SigHashOp
+        assert(GetTransactionBaseSigHashOpCount(CTransaction(spendingTx), coins, flags) == 0);
     }
 
     // P2WSH nested in P2SH
@@ -238,6 +272,8 @@ BOOST_AUTO_TEST_CASE(GetTxSigOpCost)
         BuildTxs(spendingTx, coins, creationTx, scriptPubKey, scriptSig, witness);
         assert(GetTransactionSigOpCost(CTransaction(spendingTx), coins, flags) == 2);
         assert(VerifyWithFlag(creationTx, spendingTx, flags) == SCRIPT_ERR_CHECKMULTISIGVERIFY);
+        // SigOp in witness is not counted as SigHashOp
+        assert(GetTransactionBaseSigHashOpCount(CTransaction(spendingTx), coins, flags) == 0);
     }
 }
 


### PR DESCRIPTION
This is an alternative to #8755 and #8654

This implements a static estimation of sighash size for a transaction. A transaction with more than 90bytes of sighash per weight is non-standard. This is equivalent to 36MB for an 100kB non-segwit transaction, or 360MB for a block in the worst case. All existing standard transactions with legitimate use of `CHECK(MULTI)SIG` should remain standard with this limit.

The estimation of sighash is based on the assumption that `SignatureHash` is performed once only for each signature within a `CHECKMULTISIG`. This PR does not depend on any other policy or softforks like those in #8755. Despite the counting is more conservative, legitimate standard transactions for #8755 should also be standard in this implementation.

Todo: unit tests
