### PR TITLE
Fix issue with conflicted mempool tx in listsinceblock

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1690,7 +1690,8 @@ UniValue listsinceblock(const UniValue& params, bool fHelp)
     {
         CWalletTx tx = (*it).second;
 
-        if (depth == -1 || tx.GetDepthInMainChain() < depth)
+        int txHeight = tx.GetDepthInMainChain();
+        if (depth == -1 || (txHeight < depth && txHeight >= 0))
             ListTransactions(tx, "*", 0, true, transactions, filter);
     }
 


### PR DESCRIPTION
Attempt to fix #8752

The second parameter (target confirmation) is quite strange and should probably be better documented in the RPC help of `listsinceblock` (check original comment: https://github.com/bitcoin/bitcoin/pull/199#issuecomment-1514952)

At the moment, conflicted mempool transactions (double spends) are listed. This PR does hide all wtxs that are conflicts (GetDepthInMainChain <= -1).
