### PR TITLE
[Wallet] remove "unused" ThreadFlushWalletDB from removeprunedfunds

### DIFF
--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -344,8 +344,6 @@ UniValue removeprunedfunds(const UniValue& params, bool fHelp)
         throw JSONRPCError(RPC_INTERNAL_ERROR, "Transaction does not exist in wallet.");
     }
 
-    ThreadFlushWalletDB(pwalletMain->strWalletFile);
-
     return NullUniValue;
 }
 


### PR DESCRIPTION
Calling `ThreadFlushWalletDB` makes not much sense if an explicit flush is required. The function will return immediately because of the `fOneThread` (populated/thread started during AppInit).

Removing it for now.

(originally reported by @luke-jr in #8687)
