### PR TITLE
Fix URL for Debian 8.5.0 ISO

### DIFF
--- a/doc/gitian-building.md
+++ b/doc/gitian-building.md
@@ -96,7 +96,7 @@ After creating the VM, we need to configure it.
 - Click `Ok` twice to save.
 
 Get the [Debian 8.x net installer](http://cdimage.debian.org/mirror/cdimage/archive/8.5.0/amd64/iso-cd/debian-8.5.0-amd64-netinst.iso) (a more recent minor version should also work, see also [Debian Network installation](https://www.debian.org/CD/netinst/)).
-This DVD image can be validated using a SHA256 hashing tool, for example on 
+This DVD image can be [validated](https://www.debian.org/CD/verify) using a SHA256 hashing tool, for example on 
 Unixy OSes by entering the following in a terminal:
 
     echo "ad4e8c27c561ad8248d5ebc1d36eb172f884057bfeb2c22ead823f59fa8c3dff  debian-8.5.0-amd64-netinst.iso" | sha256sum -c

--- a/doc/gitian-building.md
+++ b/doc/gitian-building.md
@@ -95,11 +95,11 @@ After creating the VM, we need to configure it.
 
 - Click `Ok` twice to save.
 
-Get the [Debian 8.x net installer](http://cdimage.debian.org/debian-cd/8.6.0/amd64/iso-cd/debian-8.6.0-amd64-netinst.iso) (a more recent minor version should also work, see also [Debian Network installation](https://www.debian.org/CD/netinst/)).
-This DVD image can be validated using a SHA256 hashing tool, for example on
+Get the [Debian 8.x net installer](http://cdimage.debian.org/mirror/cdimage/archive/8.5.0/amd64/iso-cd/debian-8.5.0-amd64-netinst.iso) (a more recent minor version should also work, see also [Debian Network installation](https://www.debian.org/CD/netinst/)).
+This DVD image can be validated using a SHA256 hashing tool, for example on 
 Unixy OSes by entering the following in a terminal:
 
-    echo "9479c5c2df72ae3878116c43fb42eefae53d1fe363ce514a6afc8289064b9f5f debian-8.6.0-amd64-netinst.iso" | sha256sum -c
+    echo "ad4e8c27c561ad8248d5ebc1d36eb172f884057bfeb2c22ead823f59fa8c3dff  debian-8.5.0-amd64-netinst.iso" | sha256sum -c
     # (must return OK)
 
 Then start the VM. On the first launch you will be asked for a CD or DVD image. Choose the downloaded ISO.

--- a/doc/gitian-building.md
+++ b/doc/gitian-building.md
@@ -95,14 +95,14 @@ After creating the VM, we need to configure it.
 
 - Click `Ok` twice to save.
 
-Get the [Debian 8.x net installer](http://cdimage.debian.org/debian-cd/8.5.0/amd64/iso-cd/debian-8.5.0-amd64-netinst.iso) (a more recent minor version should also work, see also [Debian Network installation](https://www.debian.org/CD/netinst/)).
+Get the [Debian 8.x net installer](http://cdimage.debian.org/debian-cd/8.6.0/amd64/iso-cd/debian-8.6.0-amd64-netinst.iso) (a more recent minor version should also work, see also [Debian Network installation](https://www.debian.org/CD/netinst/)).
 This DVD image can be validated using a SHA256 hashing tool, for example on
 Unixy OSes by entering the following in a terminal:
 
-    echo "ad4e8c27c561ad8248d5ebc1d36eb172f884057bfeb2c22ead823f59fa8c3dff  debian-8.5.0-amd64-netinst.iso" | sha256sum -c
+    echo "9479c5c2df72ae3878116c43fb42eefae53d1fe363ce514a6afc8289064b9f5f debian-8.6.0-amd64-netinst.iso" | sha256sum -c
     # (must return OK)
 
-Then start the VM. On the first launch you will be asked for a CD or DVD image. Choose the downloaded iso.
+Then start the VM. On the first launch you will be asked for a CD or DVD image. Choose the downloaded ISO.
 
 ![](gitian-building/select_startup_disk.png)
 


### PR DESCRIPTION
Mirrors automatically update to the current version, so the link was broken.
We could link to an archive site with 8.5.0 or update the URL to 8.6.0. The latter seems better since apt-get update has to be executed anyway.

The SHA256SUM for the v8.6.0 Net Install ISO was updated from http://cdimage.debian.org/debian-cd/8.6.0/amd64/iso-cd/SHA256SUMS
