### PR TITLE
Copyright headers for build scripts

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,3 +1,7 @@
+# Copyright (c) 2013-2016 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 ACLOCAL_AMFLAGS = -I build-aux/m4
 SUBDIRS = src
 if ENABLE_MAN

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,4 +1,8 @@
 #!/bin/sh
+# Copyright (c) 2013-2016 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 set -e
 srcdir="$(dirname $0)"
 cd "$srcdir"

--- a/build-aux/m4/bitcoin_find_bdb48.m4
+++ b/build-aux/m4/bitcoin_find_bdb48.m4
@@ -1,3 +1,7 @@
+dnl Copyright (c) 2013-2015 The Bitcoin Core developers
+dnl Distributed under the MIT software license, see the accompanying
+dnl file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 AC_DEFUN([BITCOIN_FIND_BDB48],[
   AC_MSG_CHECKING([for Berkeley DB C++ headers])
   BDB_CPPFLAGS=

--- a/build-aux/m4/bitcoin_qt.m4
+++ b/build-aux/m4/bitcoin_qt.m4
@@ -1,3 +1,7 @@
+dnl Copyright (c) 2013-2016 The Bitcoin Core developers
+dnl Distributed under the MIT software license, see the accompanying
+dnl file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 dnl Helper for cases where a qt dependency is not met.
 dnl Output: If qt version is auto, set bitcoin_enable_qt to false. Else, exit.
 AC_DEFUN([BITCOIN_QT_FAIL],[

--- a/build-aux/m4/bitcoin_subdir_to_include.m4
+++ b/build-aux/m4/bitcoin_subdir_to_include.m4
@@ -1,3 +1,7 @@
+dnl Copyright (c) 2013-2014 The Bitcoin Core developers
+dnl Distributed under the MIT software license, see the accompanying
+dnl file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 dnl BITCOIN_SUBDIR_TO_INCLUDE([CPPFLAGS-VARIABLE-NAME],[SUBDIRECTORY-NAME],[HEADER-FILE])
 dnl SUBDIRECTORY-NAME must end with a path separator
 AC_DEFUN([BITCOIN_SUBDIR_TO_INCLUDE],[

--- a/build-aux/m4/l_atomic.m4
+++ b/build-aux/m4/l_atomic.m4
@@ -1,3 +1,9 @@
+dnl Copyright (c) 2015 Tim Kosse <tim.kosse@filezilla-project.org>
+dnl Copying and distribution of this file, with or without modification, are
+dnl permitted in any medium without royalty provided the copyright notice
+dnl and this notice are preserved. This file is offered as-is, without any
+dnl warranty.
+
 # Some versions of gcc/libstdc++ require linking with -latomic if
 # using the C++ atomic library.
 #

--- a/build-aux/m4/l_atomic.m4
+++ b/build-aux/m4/l_atomic.m4
@@ -32,7 +32,7 @@ AC_DEFUN([CHECK_ATOMIC], [
           AC_MSG_RESULT([yes])
         ],[
           AC_MSG_RESULT([no])
-          AC_MSG_FAILURE([cannot figure our how to use std::atomic])
+          AC_MSG_FAILURE([cannot figure out how to use std::atomic])
         ])
     ])
 

--- a/share/genbuild.sh
+++ b/share/genbuild.sh
@@ -1,4 +1,8 @@
 #!/bin/sh
+# Copyright (c) 2012-2016 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 if [ $# -gt 1 ]; then
     cd "$2"
 fi

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,3 +1,7 @@
+# Copyright (c) 2013-2016 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 DIST_SUBDIRS = secp256k1 univalue
 
 AM_LDFLAGS = $(PTHREAD_CFLAGS) $(LIBTOOL_LDFLAGS) $(HARDENED_LDFLAGS)

--- a/src/Makefile.bench.include
+++ b/src/Makefile.bench.include
@@ -1,3 +1,7 @@
+# Copyright (c) 2015-2016 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 bin_PROGRAMS += bench/bench_bitcoin
 BENCH_SRCDIR = bench
 BENCH_BINARY = bench/bench_bitcoin$(EXEEXT)

--- a/src/Makefile.leveldb.include
+++ b/src/Makefile.leveldb.include
@@ -1,3 +1,7 @@
+# Copyright (c) 2016 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 LIBLEVELDB_INT = leveldb/libleveldb.a
 LIBMEMENV_INT  = leveldb/libmemenv.a
 

--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -1,3 +1,7 @@
+# Copyright (c) 2013-2016 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 bin_PROGRAMS += qt/bitcoin-qt
 EXTRA_LIBRARIES += qt/libbitcoinqt.a
 

--- a/src/Makefile.qttest.include
+++ b/src/Makefile.qttest.include
@@ -1,3 +1,7 @@
+# Copyright (c) 2013-2016 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 bin_PROGRAMS += qt/test/test_bitcoin-qt
 TESTS += qt/test/test_bitcoin-qt
 

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -1,3 +1,7 @@
+# Copyright (c) 2013-2016 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 TESTS += test/test_bitcoin
 bin_PROGRAMS += test/test_bitcoin
 TEST_SRCDIR = test


### PR DESCRIPTION
This needs sign-off from: ~~@morcos @anddam~~ @brandondahler ~~@btcdrak @casey~~ @theuni @cozz ~~@dcousens @ers35 @EthanHeilman @gavinandresen~~ @gmaxwell ~~@jamesob~~ ~~@jgarzik @jonasschnelli~~ @jtimon ~~@joshtriplett~~ @kazcw ~~@maraoz~~ @MarcoFalke ~~@maaku~~ @TheBlueMatt @fanquake ~~@musalbas~~ @pstratem ~~@paveljanik~~ @Diapolo ~~@sipa @rnicoll @SergioDemianLerner @sdaftuar @laanwj @yurizhykin @dexX7 @nomnombtc @ntrgn @ptschip @randy-waterhouse @sinetek~~

~~@knocte~~ @joshtriplett 

~~@ajtowns @dooglus @onlyjob @wtogami~~ @imwuzhh

Permission from Tim Kosse has already been obtained:

```
[22:45:45] <codesquid> yes, shouldn't be an issue to put this one under MIT license
```
