### PR TITLE
Comment on CNode::nLocalServices meaning

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -677,6 +677,7 @@ private:
 
 
     uint64_t nLocalHostNonce;
+    // Services offered to this peer
     ServiceFlags nLocalServices;
     int nMyStartingHeight;
 public:


### PR DESCRIPTION
It was quite unclear what this field meant especially in places that say things like: 

> pfrom->nLocalServices 
