### PR TITLE
[Doc] Add missing autogen to example builds

### DIFF
--- a/doc/build-windows.md
+++ b/doc/build-windows.md
@@ -27,6 +27,7 @@ To build executables for Windows 32-bit:
     cd depends
     make HOST=i686-w64-mingw32 -j4
     cd ..
+    ./autogen.sh # not required when building from tarball
     ./configure --prefix=`pwd`/depends/i686-w64-mingw32
     make
 
@@ -35,6 +36,7 @@ To build executables for Windows 64-bit:
     cd depends
     make HOST=x86_64-w64-mingw32 -j4
     cd ..
+    ./autogen.sh # not required when building from tarball
     ./configure --prefix=`pwd`/depends/x86_64-w64-mingw32
     make
 


### PR DESCRIPTION
The Windows cross-compile build examples are missing the `autogen.sh` step.  Without that step, `configure` doesn't exist and you get this error:

> `bash: ./configure: No such file or directory`

Using Ubuntu 16.04 64 bit.
