### PR TITLE
Fetch w/o CB if mempool empty, don't use HB mode if blocks only.

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2095,10 +2095,13 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                             pindexLast->GetBlockHash().ToString(), pindexLast->nHeight);
                 }
                 if (vGetData.size() > 0) {
-                    if (nodestate->fSupportsDesiredCmpctVersion && vGetData.size() == 1 && mapBlocksInFlight.size() == 1 && pindexLast->pprev->IsValid(BLOCK_VALID_CHAIN)) {
+                    if (nodestate->fSupportsDesiredCmpctVersion && vGetData.size() == 1 && mapBlocksInFlight.size() == 1 && pindexLast->pprev->IsValid(BLOCK_VALID_CHAIN) && mempool.size() > 1) {
                         // We seem to be rather well-synced, so it appears pfrom was the first to provide us
-                        // with this block! Let's get them to announce using compact blocks in the future.
-                        MaybeSetPeerAsAnnouncingHeaderAndIDs(nodestate, pfrom, connman);
+                        // with this block! Let's get them to announce using compact blocks in the future, unless
+                        // either of us are blocks-only and would prefer to save bandwidth.
+                        if (pfrom->fRelayTxes && !GetBoolArg("-blocksonly", DEFAULT_BLOCKSONLY)) {
+                            MaybeSetPeerAsAnnouncingHeaderAndIDs(nodestate, pfrom, connman);
+                        }
                         // In any case, we want to download using a compact block, not a regular one
                         vGetData[0] = CInv(MSG_CMPCT_BLOCK, vGetData[0].hash);
                     }


### PR DESCRIPTION
Fetching with CB when there are less than 30 hits for a full block
 wastes bandwidth; and getting three copies of a CB message which
 is of no use to us when we are in blocks only mode is not great.

This is a fairly small optimization, since even the worst case of
 getting three useless CB messages is only a 5% bandwidth increase.

[I will update the test if this gets Concept ACKs]
