### PR TITLE
Ping regularly in p2p-segwit.py to keep connection alive

### DIFF
--- a/qa/rpc-tests/p2p-segwit.py
+++ b/qa/rpc-tests/p2p-segwit.py
@@ -1392,6 +1392,9 @@ class SegWitTest(BitcoinTestFramework):
         block = self.build_next_block()
         used_sighash_single_out_of_bounds = False
         for i in range(NUM_TESTS):
+            # Ping regularly to keep the connection alive
+            if (not i % 100):
+                self.test_node.sync_with_ping()
             # Choose random number of inputs to use.
             num_inputs = random.randint(1, 10)
             # Create a slight bias for producing more utxos


### PR DESCRIPTION
This reduce the number of repeated tests in p2p-segwit.py for segwit signature hashes, to prevent timeout.

I'm not sure if this is only my problem but the test always fail with timeout on my machine during  "Testing segwit signature hash version 1".
