### PR TITLE
WIP: [qt] rework sync-overlay

### DIFF
--- a/src/qt/forms/modaloverlay.ui
+++ b/src/qt/forms/modaloverlay.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>640</width>
-    <height>385</height>
+    <height>415</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -276,31 +276,14 @@ QLabel { color: rgb(40,40,40);  }</string>
                <property name="value">
                 <number>24</number>
                </property>
+               <property name="format">
+                <string/>
+               </property>
               </widget>
              </item>
             </layout>
            </item>
            <item row="4" column="0">
-            <widget class="QLabel" name="labelProgressIncrease">
-             <property name="font">
-              <font>
-               <weight>75</weight>
-               <bold>true</bold>
-              </font>
-             </property>
-             <property name="text">
-              <string>Progress increase per hour</string>
-             </property>
-            </widget>
-           </item>
-           <item row="4" column="1">
-            <widget class="QLabel" name="progressIncreasePerH">
-             <property name="text">
-              <string>calculating...</string>
-             </property>
-            </widget>
-           </item>
-           <item row="5" column="0">
             <widget class="QLabel" name="labelEstimatedTimeLeft">
              <property name="font">
               <font>
@@ -313,7 +296,7 @@ QLabel { color: rgb(40,40,40);  }</string>
              </property>
             </widget>
            </item>
-           <item row="5" column="1">
+           <item row="4" column="1">
             <widget class="QLabel" name="expectedTimeLeft">
              <property name="text">
               <string>calculating...</string>


### PR DESCRIPTION
- <strike>Remove the "Progress increase per hour" information, as it is
  redundant to the already displayed information and sounds potentially
  confusing.</strike>
- Don't show integer progress in progress bar. (Already shown in front
  of progress bar)
- Estimate the number of blocks left based on nPowTargetSpacing

(Follow-up of #8371)
