### PR TITLE
tests: Add exception error message for JSONRPCException

### DIFF
--- a/qa/rpc-tests/test_framework/authproxy.py
+++ b/qa/rpc-tests/test_framework/authproxy.py
@@ -55,7 +55,11 @@ log = logging.getLogger("BitcoinRPC")
 
 class JSONRPCException(Exception):
     def __init__(self, rpc_error):
-        Exception.__init__(self)
+        try:
+            errmsg = '%(message)s (%(code)i)' % rpc_error
+        except (KeyError, TypeError):
+            errmsg = ''
+        Exception.__init__(self, errmsg)
         self.error = rpc_error
 
 


### PR DESCRIPTION
This improves error reporting if `JSONRPCException` is not specifically caught and ends up in Python's default backtrace handler.

Before:

```
Traceback (most recent call last):
  File "/.../projects/bitcoin/bitcoin/qa/rpc-tests/test_framework/authproxy.py", line 153, in __call__
    raise JSONRPCException(response['error'])
test_framework.authproxy.JSONRPCException
```

After:

```
Traceback (most recent call last):
  File "/.../projects/bitcoin/bitcoin/qa/rpc-tests/test_framework/authproxy.py", line 152, in __call__
    raise JSONRPCException(response['error'])
test_framework.authproxy.JSONRPCException: Unknown named parameter random (-8)
```
