### PR TITLE
bitcoind: Daemonize using daemon(3)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -508,6 +508,9 @@ AC_SEARCH_LIBS([inet_pton], [nsl resolv], [AC_DEFINE(HAVE_INET_PTON, 1, [Define 
 
 AC_CHECK_DECLS([strnlen])
 
+# Check for daemon(3), unrelated to --with-daemon (although used by it)
+AC_CHECK_DECLS([daemon])
+
 AC_CHECK_DECLS([le16toh, le32toh, le64toh, htole16, htole32, htole64, be16toh, be32toh, be64toh, htobe16, htobe32, htobe64],,,
 		[#if HAVE_ENDIAN_H
                  #include <endian.h>

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -9,6 +9,7 @@
 
 #include "chainparams.h"
 #include "clientversion.h"
+#include "compat.h"
 #include "rpc/server.h"
 #include "init.h"
 #include "noui.h"
@@ -127,29 +128,21 @@ bool AppInit(int argc, char* argv[])
             fprintf(stderr, "Error: There is no RPC client functionality in bitcoind anymore. Use the bitcoin-cli utility instead.\n");
             exit(1);
         }
-#ifndef WIN32
         if (GetBoolArg("-daemon", false))
         {
+#if HAVE_DECL_DAEMON
             fprintf(stdout, "Bitcoin server starting\n");
 
             // Daemonize
-            pid_t pid = fork();
-            if (pid < 0)
-            {
-                fprintf(stderr, "Error: fork() returned %d errno %d\n", pid, errno);
+            if (daemon(1, 0)) { // don't chdir (1), do close FDs (0)
+                fprintf(stderr, "Error: daemon() failed: %s\n", strerror(errno));
                 return false;
             }
-            if (pid > 0) // Parent process, pid is child process id
-            {
-                return true;
-            }
-            // Child process falls through to rest of initialization
-
-            pid_t sid = setsid();
-            if (sid < 0)
-                fprintf(stderr, "Error: setsid() returned %d errno %d\n", sid, errno);
+#else
+            fprintf(stderr, "Error: -daemon is not supported on this operating system\n");
+            return false;
+#endif // HAVE_DECL_DAEMON
         }
-#endif
         SoftSetBoolArg("-server", true);
 
         // Set this early so that parameter interactions go to console

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -324,7 +324,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-conf=<file>", strprintf(_("Specify configuration file (default: %s)"), BITCOIN_CONF_FILENAME));
     if (mode == HMM_BITCOIND)
     {
-#ifndef WIN32
+#if HAVE_DECL_DAEMON
         strUsage += HelpMessageOpt("-daemon", _("Run in the background as a daemon and accept commands"));
 #endif
     }


### PR DESCRIPTION
Simplified version of #8278. Assumes that every OS that (a) is supported by Bitcoin Core (b) supports daemonization has the `daemon()` function in its C library.
- Removes the fallback path for operating systems that support  daemonization but not `daemon()`. This prevents never-exercised code from ending up in the repository (see discussion here:
  https://github.com/bitcoin/bitcoin/pull/8278#issuecomment-242704745).
- Removes the windows-specific path. Windows doesn't support `daemon()`,  so it doesn't support daemonization there, automatically. Give an explicit error if a user specifies `-daemon` on an OS where this is not supported.
- Also made showing the help message depend on `HAVE_DECL_DAEMON` instead of `!WIN32`.

The original problem reported in #8278 was "When started with cron, the sendmail process hung around waiting for its stdin, bitcoind's stdout/err, to close..".
