### PR TITLE
[qt] sync-overlay: Don't block during reindex

### DIFF
--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -256,7 +256,7 @@ static void BlockTipChanged(ClientModel *clientmodel, bool initialSync, const CB
     int64_t& nLastUpdateNotification = fHeader ? nLastHeaderTipUpdateNotification : nLastBlockTipUpdateNotification;
 
     // if we are in-sync, update the UI regardless of last update time
-    if (fHeader || !initialSync || now - nLastUpdateNotification > MODEL_UPDATE_DELAY) {
+    if (!initialSync || now - nLastUpdateNotification > MODEL_UPDATE_DELAY) {
         //pass a async signal to the UI thread
         QMetaObject::invokeMethod(clientmodel, "numBlocksChanged", Qt::QueuedConnection,
                                   Q_ARG(int, pIndex->nHeight),

--- a/src/qt/modaloverlay.cpp
+++ b/src/qt/modaloverlay.cpp
@@ -134,7 +134,6 @@ void ModalOverlay::tipUpdate(int count, const QDateTime& blockDate, double nVeri
     if (estimateNumHeadersLeft < 24 && hasBestHeader) {
         ui->numberOfBlocksLeft->setText(QString::number(bestHeaderHeight - count));
     } else {
-        ui->numberOfBlocksLeft->setText("~" + QString::number(bestHeaderHeight + estimateNumHeadersLeft - count));
         ui->expectedTimeLeft->setText(tr("Unknown. Syncing Headers..."));
     }
 }

--- a/src/qt/modaloverlay.h
+++ b/src/qt/modaloverlay.h
@@ -35,7 +35,8 @@ protected:
 
 private:
     Ui::ModalOverlay *ui;
-    int bestBlockHeight; //best known height (based on the headers)
+    int bestHeaderHeight; //best known height (based on the headers)
+    QDateTime bestHeaderDate;
     QVector<QPair<qint64, double> > blockProcessTime;
     bool layerIsVisible;
     bool userClosed;


### PR DESCRIPTION
As I understand this, the "`fHeader`-shortcut" in clientmodel will fire too much during reindex, thus making the gui freeze. The reason for this shurtcut is to make sure the gui always knows the height of the best header. Though, I think it is not required for the gui to have this knowledge (after all it is just a warning dialog) and an approximate display is just fine.
