### PR TITLE
Do not include env_win.cc on non-Windows systems

### DIFF
--- a/src/Makefile.leveldb.include
+++ b/src/Makefile.leveldb.include
@@ -113,7 +113,6 @@ leveldb_libleveldb_a_SOURCES += leveldb/util/comparator.cc
 leveldb_libleveldb_a_SOURCES += leveldb/util/crc32c.cc
 leveldb_libleveldb_a_SOURCES += leveldb/util/env.cc
 leveldb_libleveldb_a_SOURCES += leveldb/util/env_posix.cc
-leveldb_libleveldb_a_SOURCES += leveldb/util/env_win.cc
 leveldb_libleveldb_a_SOURCES += leveldb/util/filter_policy.cc
 leveldb_libleveldb_a_SOURCES += leveldb/util/hash.cc
 leveldb_libleveldb_a_SOURCES += leveldb/util/histogram.cc


### PR DESCRIPTION
This solves https://github.com/bitcoin-core/leveldb/pull/8

The file `env_win.cc` is included twice on Windows and once for all other systems. But it is not needed at all there.

This removes this warning on OS X:

```
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib: file: leveldb/libleveldb.a(leveldb_libleveldb_a-env_win.o) has no symbols
```
