### PR TITLE
[qa] Split up slow RPC calls to avoid pruning test timeouts

### DIFF
--- a/qa/rpc-tests/pruning.py
+++ b/qa/rpc-tests/pruning.py
@@ -157,7 +157,10 @@ class PruneTest(BitcoinTestFramework):
         print("Usage possibly still high bc of stale blocks in block files:", calc_usage(self.prunedir))
 
         print("Mine 220 more blocks so we have requisite history (some blocks will be big and cause pruning of previous chain)")
-        self.nodes[0].generate(220) #node 0 has many large tx's in its mempool from the disconnects
+        for i in range(22):
+            # This can be slow, so do this in multiple RPC calls to avoid
+            # RPC timeouts.
+            self.nodes[0].generate(10) #node 0 has many large tx's in its mempool from the disconnects
         sync_blocks(self.nodes[0:3], timeout=300)
 
         usage = calc_usage(self.prunedir)


### PR DESCRIPTION
After #8524, `CTxMemPool::check()` can take much longer when the mempool is full of large transactions, such as the transactions used in pruning.py, because we're rehashing everything in the mempool.  Consequently I've been seeing consistent test failures due to an RPC timeout at the point in pruning.py where 220 blocks are generated, because mempool.check() is called on each block, and many blocks need to be mined before the mempool is drained. 

This PR works around the slowdown by splitting up the RPC call.

As mempool consistency checking is off by default on mainnet, I don't think this is an issue outside of the testing framework, so for now I don't think it's worth modifying/optimizing the work being done in `CTxMemPool::check()` over this.
