### PR TITLE
[test] Add option to run bitcoin-util-test.py manually

### DIFF
--- a/src/test/README.md
+++ b/src/test/README.md
@@ -30,3 +30,11 @@ example, to run just the getarg_tests verbosely:
 
 Run `test_bitcoin --help` for the full list.
 
+### bitcoin-util-test.py
+
+The test directory also contains the bitcoin-util-test.py tool, which tests bitcoin utils (currently just bitcoin-tx). This test gets run automatically during the `make check` build process. It is also possible to run the test manually from the src directory:
+
+```
+test/bitcoin-util-test.py --srcdir=[current directory]
+
+```

--- a/src/test/bitcoin-util-test.py
+++ b/src/test/bitcoin-util-test.py
@@ -6,8 +6,24 @@ from __future__ import division,print_function,unicode_literals
 import os
 import bctest
 import buildenv
+import argparse
+
+help_text="""Test framework for bitcoin utils.
+
+Runs automatically during `make check`.
+
+Can also be run manually from the src directory by specifiying the source directory:
+
+test/bitcoin-util-test.py --src=[srcdir]
+"""
+
 
 if __name__ == '__main__':
-	bctest.bctester(os.environ["srcdir"] + "/test/data",
-			"bitcoin-util-test.json",buildenv)
-
+    try:
+        srcdir = os.environ["srcdir"]
+    except:
+        parser = argparse.ArgumentParser(description=help_text)
+        parser.add_argument('-s', '--srcdir')
+        args = parser.parse_args()
+        srcdir = args.srcdir
+    bctest.bctester(srcdir + "/test/data", "bitcoin-util-test.json", buildenv)


### PR DESCRIPTION
I've recently added new test cases that test bitoin-tx JSON output (https://github.com/bitcoin/bitcoin/pull/8829).

Those tests are run automatically by `make check`, but it was previously quite difficult to run those tests manually, since the script assumed that OS environment variables had been set. This PR allows the tests to be run manually, and adds documentation explaining how to do that.
