### PR TITLE
[qa] blockstore: Switch to dumb dbm

### DIFF
--- a/qa/rpc-tests/test_framework/blockstore.py
+++ b/qa/rpc-tests/test_framework/blockstore.py
@@ -9,11 +9,11 @@
 
 from .mininode import *
 from io import BytesIO
-import dbm.ndbm
+import dbm.dumb as dbmd
 
 class BlockStore(object):
     def __init__(self, datadir):
-        self.blockDB = dbm.ndbm.open(datadir + "/blocks", 'c')
+        self.blockDB = dbmd.open(datadir + "/blocks", 'c')
         self.currentBlock = 0
         self.headers_map = dict()
 
@@ -123,7 +123,7 @@ class BlockStore(object):
 
 class TxStore(object):
     def __init__(self, datadir):
-        self.txDB = dbm.ndbm.open(datadir + "/transactions", 'c')
+        self.txDB = dbmd.open(datadir + "/transactions", 'c')
 
     def close(self):
         self.txDB.close()


### PR DESCRIPTION
Closes #8605 

I could not see any performance degradation by this commit:

``` sh
$ time qa/pull-tester/rpc-tests.py p2p-fullblocktest
```

Before:

```
TEST                 | PASSED | DURATION

p2p-fullblocktest.py | True   | 297 s

ALL                  | True   | 297 s (accumulated)

Runtime: 297 s

real    4m57.633s
user    4m1.588s
sys 0m11.419s
```

After:

```
p2p-fullblocktest.py:
Pass: True, Duration: 288 s

TEST                 | PASSED | DURATION

p2p-fullblocktest.py | True   | 288 s

ALL                  | True   | 288 s (accumulated)

Runtime: 288 s

real    4m48.573s
user    3m56.126s
sys 0m11.823s

```
