### PR TITLE
bitcoin-util-test.py should fail if the output file is empty

### DIFF
--- a/src/test/bctest.py
+++ b/src/test/bctest.py
@@ -24,6 +24,9 @@ def bctest(testDir, testObj, exeext):
 	if "output_cmp" in testObj:
 		outputFn = testObj['output_cmp']
 		outputData = open(testDir + "/" + outputFn).read()
+		if not outputData:
+			print("Output data missing for " + outputFn)
+			sys.exit(1)
 	proc = subprocess.Popen(execrun, stdin=stdinCfg, stdout=subprocess.PIPE, stderr=subprocess.PIPE,universal_newlines=True)
 	try:
 		outs = proc.communicate(input=inputData)

--- a/src/test/data/txcreate2.json
+++ b/src/test/data/txcreate2.json
@@ -1,0 +1,19 @@
+{
+    "txid": "cf90229625e9eb10f6be8156bf6aa5ec2eca19a42b1e05c11f3029b560a32e13",
+    "version": 1,
+    "locktime": 0,
+    "vin": [
+    ],
+    "vout": [
+        {
+            "value": 0.00,
+            "n": 0,
+            "scriptPubKey": {
+                "asm": "",
+                "hex": "",
+                "type": "nonstandard"
+            }
+        }
+    ],
+    "hex": "01000000000100000000000000000000000000"
+}


### PR DESCRIPTION
If the output_cmp file is empty, then `bitcoin-util-test.py` will pass the test without comparing its output to the expected output. This PR makes the test case fail if the output_cmp file is empty.

This PR also fixes the txcreate2.json file so it's no longer empty (and is therefore actually testing something!)
