### PR TITLE
allow bitcoin-tx to parse partial transactions

### DIFF
--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -629,7 +629,7 @@ static int CommandLineRawTx(int argc, char* argv[])
             if (strHexTx == "-")                 // "-" implies standard input
                 strHexTx = readStdin();
 
-            if (!DecodeHexTx(txDecodeTmp, strHexTx))
+            if (!DecodeHexTx(txDecodeTmp, strHexTx, true))
                 throw runtime_error("invalid transaction encoding");
 
             startArg = 2;

--- a/src/test/data/bitcoin-util-test.json
+++ b/src/test/data/bitcoin-util-test.json
@@ -103,6 +103,16 @@
     "description": "Creates a new transaction with a single empty output script (output in json)"
   },
   { "exec": "./bitcoin-tx",
+    "args": ["01000000000100000000000000000000000000"],
+    "output_cmp": "txcreate2.hex",
+    "description": "Parses a transation with no inputs and a single output script"
+  },
+  { "exec": "./bitcoin-tx",
+    "args": ["-json", "01000000000100000000000000000000000000"],
+    "output_cmp": "txcreate2.json",
+    "description": "Parses a transation with no inputs and a single output script (output in json)"
+  },
+  { "exec": "./bitcoin-tx",
     "args":
     ["-create",
      "in=4d49a71ec9da436f71ec4ee231d04f292a29cd316f598bb7068feccabdc59485:0",


### PR DESCRIPTION
Segwit has added ambiguity for 0-input transactions (the 0 can be read as the dummy byte indicating that this is a segwit transcation).

bitcoin-tx needs to be able to parse 0-input partial transactions. This PR causes bitcoin-tx to call `DecodeHexTx()` with the `fTryNoWitness` flag set, so we attempt to deserialize the transaction as a pre-segwit transaction.

This PR also adds new test cases to verify that bitcoin-tx parses a partial transaction correctly.
