### PR TITLE
Calculate size and weight of block correctly in CreateNewBlock()

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -168,7 +168,6 @@ CBlockTemplate* BlockAssembler::CreateNewBlock(const CScript& scriptPubKeyIn)
     nLastBlockTx = nBlockTx;
     nLastBlockSize = nBlockSize;
     nLastBlockWeight = nBlockWeight;
-    LogPrintf("CreateNewBlock(): total size %u txs: %u fees: %ld sigops %d\n", nBlockSize, nBlockTx, nFees, nBlockSigOpsCost);
 
     // Create coinbase transaction.
     CMutableTransaction coinbaseTx;
@@ -181,6 +180,9 @@ CBlockTemplate* BlockAssembler::CreateNewBlock(const CScript& scriptPubKeyIn)
     pblock->vtx[0] = coinbaseTx;
     pblocktemplate->vchCoinbaseCommitment = GenerateCoinbaseCommitment(*pblock, pindexPrev, chainparams.GetConsensus());
     pblocktemplate->vTxFees[0] = -nFees;
+
+    uint64_t nSerializeSize = GetSerializeSize(*pblock, SER_NETWORK, PROTOCOL_VERSION);
+    LogPrintf("CreateNewBlock(): total size: %u block weight: %u txs: %u fees: %ld sigops %d\n", nSerializeSize, GetBlockWeight(*pblock), nBlockTx, nFees, nBlockSigOpsCost);
 
     // Fill in header
     pblock->hashPrevBlock  = pindexPrev->GetBlockHash();


### PR DESCRIPTION
bitcoind writes the following log when it's created a new block:

`CreateNewBlock(): total size _ txs: _ fees: _ sigops _`

If this is post-segwit and the miner is counting weight and not block size, then the size field will be incorrect (it will always be set to 1000).

This PR fixes the log in the following way:
- if the miner is not accounting for size, then only log the weight of the block.
- if the miner _is_ accounting for size, then log the size _and_ weight of the block.

I've run all tests and manually verified that the log output is correct when using the `blockmaxsize` and `blockmaxweight` command line parameters.
