### PR TITLE
test: Avoid ConnectionResetErrors during RPC tests

### DIFF
--- a/qa/rpc-tests/test_framework/authproxy.py
+++ b/qa/rpc-tests/test_framework/authproxy.py
@@ -130,8 +130,9 @@ class AuthServiceProxy(object):
                 return self._get_response()
             else:
                 raise
-        except BrokenPipeError:
-            # Python 3.5+ raises this instead of BadStatusLine when the connection was reset
+        except (BrokenPipeError,ConnectionResetError):
+            # Python 3.5+ raises BrokenPipeError instead of BadStatusLine when the connection was reset
+            # ConnectionResetError happens on FreeBSD with Python 3.4
             self.__conn.close()
             self.__conn.request(method, path, postdata, headers)
             return self._get_response()


### PR DESCRIPTION
This is necessary on FreeBSD and MacOSX, at least.

See https://github.com/bitcoin/bitcoin/pull/8834#issuecomment-250450213

@jonasschnelli
