### PR TITLE
[qa] fix nulldummy test

### DIFF
--- a/qa/rpc-tests/nulldummy.py
+++ b/qa/rpc-tests/nulldummy.py
@@ -119,6 +119,8 @@ class NULLDUMMYTest(BitcoinTestFramework):
             node.sendrawtransaction(bytes_to_hex_str(tx.serialize_with_witness()), True)
         except JSONRPCException as exp:
             assert_equal(exp.error["message"], msg)
+        else:
+            assert_equal('', msg)
         return tx.hash
 
 


### PR DESCRIPTION
Sorry that I just find a minor bug in the test. `msg` is used to indicate that the transaction should be rejected. However, before this fix, even if the tx was accepted with a non-empty `msg`, the test would still pass.
