### PR TITLE
rpc: Handle `getinfo` client-side in bitcoin-cli w/ `-getinfo`

### DIFF
--- a/src/rpc/protocol.cpp
+++ b/src/rpc/protocol.cpp
@@ -124,3 +124,19 @@ void DeleteAuthCookie()
     }
 }
 
+std::vector<UniValue> JSONRPCProcessBatchReply(const UniValue &in, size_t num)
+{
+    if (!in.isArray())
+        throw std::runtime_error("Batch must be an array");
+    std::vector<UniValue> batch(num);
+    for (size_t i=0; i<in.size(); ++i) {
+        const UniValue &rec = in[i];
+        if (!rec.isObject())
+            throw std::runtime_error("Batch member must be object");
+        size_t id = rec["id"].get_int();
+        if (id >= num)
+            throw std::runtime_error("Batch member id larger than size");
+        batch[id] = rec;
+    }
+    return batch;
+}

--- a/src/rpc/protocol.h
+++ b/src/rpc/protocol.h
@@ -97,5 +97,7 @@ bool GenerateAuthCookie(std::string *cookie_out);
 bool GetAuthCookie(std::string *cookie_out);
 /** Delete RPC authentication cookie from disk */
 void DeleteAuthCookie();
+/** Parse JSON-RPC batch reply into a vector */
+std::vector<UniValue> JSONRPCProcessBatchReply(const UniValue &in, size_t num);
 
 #endif // BITCOIN_RPCPROTOCOL_H


### PR DESCRIPTION
(follow-up to #8780)

There have been some requests for a client-side `getinfo` and this is my PoC of how to do it. The high-level idea is to have one command to gather and show various information and statistics about a `bitcoind` in one go.

This could be used as an opportunity to make `getinfo` better, it doesn't have to have exactly the same fields as the original RPC, e.g. a `chain` instead of `testnet` flag would make sense (but it is currently the same, according to this table: https://github.com/bitcoin/bitcoin/issues/8455#issuecomment-250468383). 

If this is considered a good idea some of the logic could be moved up to rpcclient.cpp and used in the GUI console as well.
### Implementation

This adds the infrastructure `BaseRequestHandler` class that takes care of converting bitcoin-cli arguments into a JSON-RPC request object, and converting the reply into a JSON object that can be shown as result.

This is subsequently used to handle the `-getinfo` option, which sends a JSON-RPC batch request to the RPC server with `["getnetworkinfo", "getblockchaininfo", "getwalletinfo"]`, and after reply combines the result into what looks like a `getinfo` result.
