### PR TITLE
Don't return the address of a P2SH of a P2SH

### DIFF
--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -535,7 +535,7 @@ UniValue decodescript(const UniValue& params, bool fHelp)
             "     \"address\"     (string) bitcoin address\n"
             "     ,...\n"
             "  ],\n"
-            "  \"p2sh\",\"address\" (string) script address\n"
+            "  \"p2sh\",\"address\" (string) address of P2SH script wrapping this redeem script (not returned if the script is already a P2SH).\n"
             "}\n"
             "\nExamples:\n"
             + HelpExampleCli("decodescript", "\"hexstring\"")
@@ -554,7 +554,15 @@ UniValue decodescript(const UniValue& params, bool fHelp)
     }
     ScriptPubKeyToJSON(script, r, false);
 
-    r.push_back(Pair("p2sh", CBitcoinAddress(CScriptID(script)).ToString()));
+    UniValue type;
+    type = find_value(r, "type");
+
+    if (type.isStr() && type.get_str() != "scripthash") {
+        // P2SH cannot be wrapped in a P2SH. If this script is already a P2SH,
+        // don't return the address for a P2SH of the P2SH.
+        r.push_back(Pair("p2sh", CBitcoinAddress(CScriptID(script)).ToString()));
+    }
+
     return r;
 }
 


### PR DESCRIPTION
https://github.com/bitcoin/bitcoin/commit/be066fad7d2a8f95d50667262f255ce67f49b51a added an RPC to decode a hex input script. The returned object is:

```
{
  "asm":"asm",   (string) Script public key
  "hex":"hex",   (string) hex encoded public key
  "type":"type", (string) The output type
  "reqSigs": n,    (numeric) The required signatures
  "addresses": [   (json array of string)
     "address"     (string) bitcoin address
     ,...
  ],
  "p2sh","address" (string) script address.
}
```

That "p2sh" return value is the address of a P2SH with the hex input script as the redeem script.

If the input script is _already_ a P2SH script, this doesn't make sense (we can't wrap a P2SH in a P2SH). Only return a P2SH address if the input script is **not** a P2SH script.
