### PR TITLE
print P2WSH redeemScript in getrawtransaction if it s not a pubkey

### DIFF
--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -90,6 +90,18 @@ void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry)
                     txinwitness.push_back(HexStr(item.begin(), item.end()));
                 }
                 in.push_back(Pair("txinwitness", txinwitness));
+                // try to parse the last item as a pubkey
+                // In version 0, there are two valid witness types: P2WPKH and P2WSH.
+                // P2WPKH witnesses have two items on the witness stack, the second of which is a public key.
+                // We test whether the last item on the witness stack is a valid public key, and if it isn't we try to parse it as a redeem script.
+                // if someone constructed the redeem script to look like a pubkey, then he's insane
+                CPubKey pubkey(tx.wit.vtxinwit[i].scriptWitness.stack.back().begin(), tx.wit.vtxinwit[i].scriptWitness.stack.back().end());
+                if (!pubkey.IsFullyValid()) {
+                  CScript redeemScript(tx.wit.vtxinwit[i].scriptWitness.stack.back().begin(), tx.wit.vtxinwit[i].scriptWitness.stack.back().end());
+                  UniValue r(UniValue::VOBJ);
+                  ScriptPubKeyToJSON(redeemScript, r, true);
+                  in.push_back(Pair("redeemScript", r));
+                }
             }
 
         }

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -93,14 +93,14 @@ void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry)
                 // try to parse the last item as a pubkey
                 // In version 0, there are two valid witness types: P2WPKH and P2WSH.
                 // P2WPKH witnesses have two items on the witness stack, the second of which is a public key.
-                // We test whether the last item on the witness stack is a valid public key, and if it isn't we try to parse it as a redeem script.
-                // if someone constructed the redeem script to look like a pubkey, then he's insane
+                // We test whether the last item on the witness stack is a valid public key, and if it isn't we try to parse it as a witness script.
+                // if someone constructed the witness script to look like a pubkey, then he's insane
                 CPubKey pubkey(tx.wit.vtxinwit[i].scriptWitness.stack.back().begin(), tx.wit.vtxinwit[i].scriptWitness.stack.back().end());
                 if (!pubkey.IsFullyValid()) {
-                  CScript redeemScript(tx.wit.vtxinwit[i].scriptWitness.stack.back().begin(), tx.wit.vtxinwit[i].scriptWitness.stack.back().end());
+                  CScript witnessScript(tx.wit.vtxinwit[i].scriptWitness.stack.back().begin(), tx.wit.vtxinwit[i].scriptWitness.stack.back().end());
                   UniValue r(UniValue::VOBJ);
-                  ScriptPubKeyToJSON(redeemScript, r, true);
-                  in.push_back(Pair("redeemScript", r));
+                  ScriptPubKeyToJSON(witnessScript, r, true);
+                  in.push_back(Pair("witnessScript", r));
                 }
             }
 


### PR DESCRIPTION
This PR adds code to print a readable `asm` version of the `redeemScript` of a `P2WSH` input in the `getrawtransaction` RPC call which is useful to explore that kind of transactions.

Example (on testnet3):
`./bitcoin-cli getrawtransaction cd56a4b017bf5aeeb86e1397ac91bb9b4ee091d3be1c89b11b08c196468464bf 1` will output the following (note the new `redeemScript` key):

``` json
{
  "hex": "020000000001014558b8bc7f79efde796a90dca073e0808115365bb792db673cecf323c4eda2b40000000000ffffffff010eb50c00000000002200201d68ed9621fc634989c9988eda4883de4b3c699a154739a28891cb893ee7335c04004730440220120592e838230fb57292258dc98b6603ffd367adefb8f33fdea8b242f92823bc0220441d5fc90f6a3f61678db7bdb8256a61b08468fccad841841ec53791b27b002901483045022100bb3beffa751d485228d84513d84db6d2125af8f51bbaf6dd9a4a6ecbd7f73766022070b3478448192fd0d386a47e9a80b7d66839594526cdf33819c05449714c1242014752210251873cb58e82b8ba295cbaeb31bf5ce546182c6ff094b8c1fd0b33f82299d57721038f199dfacc8d2c83856d4a2ebda9f676962c880f7df3431fa47175940a1e101b52ae00000000",
  "txid": "cd56a4b017bf5aeeb86e1397ac91bb9b4ee091d3be1c89b11b08c196468464bf",
  "hash": "28961e39115f22896565e184beeb659ab68f6a8f9f0e4b8ca33699e837c4ca06",
  "size": 315,
  "vsize": 150,
  "version": 2,
  "locktime": 0,
  "vin": [
    {
      "txid": "b4a2edc423f3ec3c67db92b75b36158180e073a0dc906a79deef797fbcb85845",
      "vout": 0,
      "scriptSig": {
        "asm": "",
        "hex": ""
      },
      "txinwitness": [
        "", 
        "30440220120592e838230fb57292258dc98b6603ffd367adefb8f33fdea8b242f92823bc0220441d5fc90f6a3f61678db7bdb8256a61b08468fccad841841ec53791b27b002901", 
        "3045022100bb3beffa751d485228d84513d84db6d2125af8f51bbaf6dd9a4a6ecbd7f73766022070b3478448192fd0d386a47e9a80b7d66839594526cdf33819c05449714c124201", 
        "52210251873cb58e82b8ba295cbaeb31bf5ce546182c6ff094b8c1fd0b33f82299d57721038f199dfacc8d2c83856d4a2ebda9f676962c880f7df3431fa47175940a1e101b52ae"
      ],
      "redeemScript": {
        "asm": "2 0251873cb58e82b8ba295cbaeb31bf5ce546182c6ff094b8c1fd0b33f82299d577 038f199dfacc8d2c83856d4a2ebda9f676962c880f7df3431fa47175940a1e101b 2 OP_CHECKMULTISIG",
        "hex": "52210251873cb58e82b8ba295cbaeb31bf5ce546182c6ff094b8c1fd0b33f82299d57721038f199dfacc8d2c83856d4a2ebda9f676962c880f7df3431fa47175940a1e101b52ae",
        "reqSigs": 2,
        "type": "multisig",
        "addresses": [
          "mzLfZ7AJNtrcBZqXYXkMXRty6HoQB31Sbo", 
          "n1ANhQLAaEyswK9VWpEqCyTfgFvwtqtAYi"
        ]
      },
      "sequence": 4294967295
    }
  ],
  "vout": [
    {
      "value": 0.00832782,
      "n": 0,
      "scriptPubKey": {
        "asm": "0 1d68ed9621fc634989c9988eda4883de4b3c699a154739a28891cb893ee7335c",
        "hex": "00201d68ed9621fc634989c9988eda4883de4b3c699a154739a28891cb893ee7335c",
        "type": "witness_v0_scripthash"
      }
    }
  ],
  "blockhash": "00000000000000fd63636cdfdf9b5469b5cc57b379c40e12ecda58b3dcc7e932",
  "confirmations": 36672,
  "time": 1474472930,
  "blocktime": 1474472930
}
```
