### PR TITLE
Implement (begin|end)_ptr in C++11 and add deprecation comment

### DIFF
--- a/src/prevector.h
+++ b/src/prevector.h
@@ -476,7 +476,7 @@ public:
         }
     }
 
-    value_type* data() noexcept {
+    value_type* data() {
         return item_ptr(0);
     }
 

--- a/src/prevector.h
+++ b/src/prevector.h
@@ -475,6 +475,14 @@ public:
             return ((size_t)(sizeof(T))) * _union.capacity;
         }
     }
+
+    value_type* data() noexcept {
+        return item_ptr(0);
+    }
+
+    const value_type* data() const {
+        return item_ptr(0);
+    }
 };
 #pragma pack(pop)
 

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -44,33 +44,32 @@ inline T* NCONST_PTR(const T* val)
     return const_cast<T*>(val);
 }
 
-/** 
- * Get begin pointer of vector (non-const version).
- * @note These functions avoid the undefined case of indexing into an empty
- * vector, as well as that of indexing after the end of the vector.
+/**
+ * Important: Do not use the following functions in new code, but use v.data()
+ * and v.data() + v.size() respectively directly. They were once introduced to
+ * have a compatible, safe way to get the begin and end pointer of a vector.
+ * However with C++11 the language has built-in functionality for this and it's
+ * more readable to just use that.
  */
 template <typename V>
 inline typename V::value_type* begin_ptr(V& v)
 {
-    return v.empty() ? NULL : &v[0];
+    return v.data();
 }
-/** Get begin pointer of vector (const version) */
 template <typename V>
 inline const typename V::value_type* begin_ptr(const V& v)
 {
-    return v.empty() ? NULL : &v[0];
+    return v.data();
 }
-/** Get end pointer of vector (non-const version) */
 template <typename V>
 inline typename V::value_type* end_ptr(V& v)
 {
-    return v.empty() ? NULL : (&v[0] + v.size());
+    return v.data() + v.size();
 }
-/** Get end pointer of vector (const version) */
 template <typename V>
 inline const typename V::value_type* end_ptr(const V& v)
 {
-    return v.empty() ? NULL : (&v[0] + v.size());
+    return v.data() + v.size();
 }
 
 /*


### PR DESCRIPTION
Implement `begin_ptr` and `end_ptr` in `serialize.h` in terms of C++11 code, and add a comment that they are deprecated.

Follow-up to developer notes update in 654a211.

Also add a `data()` method to `prevector`, this is necessary to support this.
