### PR TITLE
rpc: Generate auth cookie in hex instead of base64

### DIFF
--- a/src/rpc/protocol.cpp
+++ b/src/rpc/protocol.cpp
@@ -77,9 +77,10 @@ boost::filesystem::path GetAuthCookieFile()
 
 bool GenerateAuthCookie(std::string *cookie_out)
 {
-    unsigned char rand_pwd[32];
-    GetRandBytes(rand_pwd, 32);
-    std::string cookie = COOKIEAUTH_USER + ":" + EncodeBase64(&rand_pwd[0],32);
+    const size_t COOKIE_SIZE = 32;
+    unsigned char rand_pwd[COOKIE_SIZE];
+    GetRandBytes(rand_pwd, COOKIE_SIZE);
+    std::string cookie = COOKIEAUTH_USER + ":" + HexStr(rand_pwd, rand_pwd+COOKIE_SIZE);
 
     /** the umask determines what permissions are used to create this file -
      * these are set to 077 in init.cpp unless overridden with -sysperms.


### PR DESCRIPTION
Base64 contains '/', and the '/' character in credentials is problematic for AuthServiceProxy which represents the RPC endpoint as an URI with user and password embedded.

Closes #8399. @gmaxwell
