### PR TITLE
WIP:  [qa] Add script to check for datadir compatibility between versions 

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -174,6 +174,10 @@ testScriptsExt = [
     'pruning.py', # leave pruning last as it takes a REALLY long time
 ]
 
+testScriptsManual = [
+    'compatibility.py',
+]
+
 
 def runtests():
     test_list = []
@@ -182,7 +186,7 @@ def runtests():
     elif len(opts) == 0 or (len(opts) == 1 and "-win" in opts):
         test_list = testScripts
     else:
-        for t in testScripts + testScriptsExt:
+        for t in testScripts + testScriptsExt + testScriptsManual:
             if t in opts or re.sub(".py$", "", t) in opts:
                 test_list.append(t)
 

--- a/qa/rpc-tests/compatibility.py
+++ b/qa/rpc-tests/compatibility.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+# Copyright (c) 2016 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    start_nodes,
+    stop_nodes,
+    wait_bitcoinds,
+    connect_nodes_bi,
+    mine_large_block,
+    sync_chain,
+    sync_mempools,
+    assert_equal,
+)
+
+'''
+Script to check if our datadir can be read by older versions and vice versa
+'''
+
+class CompatibilityTest(BitcoinTestFramework):
+
+    def __init__(self):
+        super().__init__()
+        self.setup_clean_chain = True
+        self.num_nodes = 2
+        self.extra_args = [['-usehd=0']] * self.num_nodes
+
+    def add_options(self, parser):
+        parser.add_option("--oldbinary", dest="oldbinary",
+                          default=None,
+                          help="old bitcoind binary for compatibility testing")
+
+    def setup_network(self):
+        assert(self.options.oldbinary is not None)
+        self.binary = [None, self.options.oldbinary]
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, self.extra_args, binary=self.binary)
+        connect_nodes_bi(self.nodes, 0, 1)
+
+    def send(self, seed):
+        sender = seed % 2
+        self.nodes[sender].sendtoaddress(self.nodes[not sender].getnewaddress(), 0.125)
+
+    def run_test(self):
+        # Create some blocks and transactions:
+        self.nodes[1].generate(14)
+        sync_chain(self.nodes)
+        self.nodes[0].generate(14)
+        self.nodes[0].generate(100)
+        [mine_large_block(self.nodes[0]) for _ in range(3)]
+        sync_chain(self.nodes)
+        [mine_large_block(self.nodes[1]) for _ in range(3)]
+        sync_chain(self.nodes)
+
+        [self.send(seed) for seed in range(10)]
+        self.nodes[0].generate(1)
+        sync_chain(self.nodes)
+        self.nodes[1].generate(1)
+        sync_chain(self.nodes)
+        assert_equal([0, 0], [n.getmempoolinfo()["size"] for n in self.nodes])
+
+        INFO_CALLS = [
+            "getblockchaininfo",
+            "gettxoutsetinfo",
+            "getmininginfo",
+            "getwalletinfo",
+            "getinfo",
+        ]
+        info_dict = {}
+        for info in INFO_CALLS:
+            info_dict[info] = [getattr(n, info)() for n in self.nodes]
+
+        # Swap binaries
+        stop_nodes(self.nodes)
+        self.binary.reverse()
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, self.extra_args, binary=self.binary)
+        connect_nodes_bi(self.nodes, 0, 1)
+        for info in INFO_CALLS:
+            print("Check {}".format(info))
+            # old info should match new info, even though the binary changed
+            assert_equal_ignore_some(info_dict[info][0], getattr(self.nodes[0], info)())
+            assert_equal_ignore_some(info_dict[info][1], getattr(self.nodes[1], info)())
+
+
+def assert_equal_ignore_some(dict1, dict2):
+    # ignore entries which are unstable across restarts or
+    # not supported by both versions
+    IGNORE = [
+        'currentblockweight',
+        'currentblocksize',
+        'currentblocktx',
+        'bip9_softforks', # Older nodes may not be aware of all softforks
+        'softforks',
+        'hash_serialized', # This may have changed due to 7848?
+        'keypoolsize', # ?
+        'errors', # releases don't display the pre-release-warning
+        #'warnings',
+        'genproclimit', # Removed in 7507
+        'generate',
+        'testnet', # Removed in 8921
+        'subversion',
+        'version',
+        'protocolversion',
+    ]
+    for d in [dict1, dict2]:
+        for ig in IGNORE:
+            d[ig] = True
+    assert_equal(dict1, dict2)
+
+if __name__ == '__main__':
+    CompatibilityTest().main()

--- a/qa/rpc-tests/maxuploadtarget.py
+++ b/qa/rpc-tests/maxuploadtarget.py
@@ -81,48 +81,15 @@ class TestNode(NodeConnCB):
 
 class MaxUploadTest(BitcoinTestFramework):
  
-    def add_options(self, parser):
-        parser.add_option("--testbinary", dest="testbinary",
-                          default=os.getenv("BITCOIND", "bitcoind"),
-                          help="bitcoind binary to test")
-
     def __init__(self):
         super().__init__()
         self.setup_clean_chain = True
         self.num_nodes = 1
 
-        self.utxo = []
-        self.txouts = gen_return_txouts()
-
     def setup_network(self):
         # Start a node with maxuploadtarget of 200 MB (/24h)
         self.nodes = []
         self.nodes.append(start_node(0, self.options.tmpdir, ["-debug", "-maxuploadtarget=800", "-blockmaxsize=999000"]))
-
-    def mine_full_block(self, node, address):
-        # Want to create a full block
-        # We'll generate a 66k transaction below, and 14 of them is close to the 1MB block limit
-        for j in range(14):
-            if len(self.utxo) < 14:
-                self.utxo = node.listunspent()
-            inputs=[]
-            outputs = {}
-            t = self.utxo.pop()
-            inputs.append({ "txid" : t["txid"], "vout" : t["vout"]})
-            remchange = t["amount"] - Decimal("0.001000")
-            outputs[address]=remchange
-            # Create a basic transaction that will send change back to ourself after account for a fee
-            # And then insert the 128 generated transaction outs in the middle rawtx[92] is where the #
-            # of txouts is stored and is the only thing we overwrite from the original transaction
-            rawtx = node.createrawtransaction(inputs, outputs)
-            newtx = rawtx[0:92]
-            newtx = newtx + self.txouts
-            newtx = newtx + rawtx[94:]
-            # Appears to be ever so slightly faster to sign with SIGHASH_NONE
-            signresult = node.signrawtransaction(newtx,None,None,"NONE")
-            txid = node.sendrawtransaction(signresult["hex"], True)
-        # Mine a full sized block which will be these transactions we just created
-        node.generate(1)
 
     def run_test(self):
         # Before we connect anything, we first set the time on the node
@@ -151,7 +118,7 @@ class MaxUploadTest(BitcoinTestFramework):
         # Test logic begins here
 
         # Now mine a big block
-        self.mine_full_block(self.nodes[0], self.nodes[0].getnewaddress())
+        mine_large_block(self.nodes[0])
 
         # Store the hash; we'll request this later
         big_old_block = self.nodes[0].getbestblockhash()
@@ -162,11 +129,11 @@ class MaxUploadTest(BitcoinTestFramework):
         self.nodes[0].setmocktime(int(time.time()) - 2*60*60*24)
 
         # Mine one more block, so that the prior block looks old
-        self.mine_full_block(self.nodes[0], self.nodes[0].getnewaddress())
+        mine_large_block(self.nodes[0])
 
         # We'll be requesting this new block too
         big_new_block = self.nodes[0].getbestblockhash()
-        new_block_size = self.nodes[0].getblock(big_new_block)['size']
+        # print(self.nodes[0].getblock(big_new_block)['size'])
         big_new_block = int(big_new_block, 16)
 
         # test_nodes[0] will test what happens if we just keep requesting the

--- a/qa/rpc-tests/test_framework/test_framework.py
+++ b/qa/rpc-tests/test_framework/test_framework.py
@@ -35,6 +35,7 @@ class BitcoinTestFramework(object):
         self.num_nodes = 4
         self.setup_clean_chain = False
         self.nodes = None
+        self.binary = None
 
     def run_test(self):
         raise NotImplementedError

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -657,13 +657,12 @@ def create_tx(node, coinbase, to_address, amount):
 def create_lots_of_big_transactions(node, txouts, utxos, fee):
     addr = node.getnewaddress()
     txids = []
-    for i in range(len(utxos)):
+    for _ in range(len(utxos)):
         t = utxos.pop()
-        inputs = []
-        inputs.append({ "txid" : t["txid"], "vout" : t["vout"]})
+        inputs=[{ "txid" : t["txid"], "vout" : t["vout"]}]
         outputs = {}
-        send_value = t['amount'] - fee
-        outputs[addr] = satoshi_round(send_value)
+        change = t['amount'] - fee
+        outputs[addr] = satoshi_round(change)
         rawtx = node.createrawtransaction(inputs, outputs)
         newtx = rawtx[0:92]
         newtx = newtx + txouts
@@ -672,6 +671,14 @@ def create_lots_of_big_transactions(node, txouts, utxos, fee):
         txid = node.sendrawtransaction(signresult["hex"], True)
         txids.append(txid)
     return txids
+
+def mine_large_block(node):
+    # generate a 66k transaction,
+    # and 14 of them is close to the 1MB block limit
+    txouts = gen_return_txouts()
+    utxos = node.listunspent()[:14]
+    create_lots_of_big_transactions(node, txouts, utxos, fee=Decimal("0.001"))
+    node.generate(1)
 
 def get_bip9_status(node, key):
     info = node.getblockchaininfo()


### PR DESCRIPTION
This is a simple script which runs the current binary and an old one to see if the datadirs can be exchanged between them.

The script can be run prior to every release to detect issues such as #7258.
