### PR TITLE
[qa] util: Move wait_bitcoinds() into stop_nodes()

### DIFF
--- a/qa/rpc-tests/bip9-softforks.py
+++ b/qa/rpc-tests/bip9-softforks.py
@@ -195,7 +195,6 @@ class BIP9SoftForksTest(ComparisonTestFramework):
         # Restart all
         self.test.block_store.close()
         stop_nodes(self.nodes)
-        wait_bitcoinds()
         shutil.rmtree(self.options.tmpdir)
         self.setup_chain()
         self.setup_network()

--- a/qa/rpc-tests/fundrawtransaction.py
+++ b/qa/rpc-tests/fundrawtransaction.py
@@ -470,7 +470,6 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.nodes[1].encryptwallet("test")
         self.nodes.pop(1)
         stop_nodes(self.nodes)
-        wait_bitcoinds()
 
         self.nodes = start_nodes(self.num_nodes, self.options.tmpdir)
         # This test is not meant to test fee estimation and we'd like

--- a/qa/rpc-tests/p2p-versionbits-warning.py
+++ b/qa/rpc-tests/p2p-versionbits-warning.py
@@ -144,8 +144,7 @@ class VersionBitsWarningTest(BitcoinTestFramework):
         # is cleared, and restart the node. This should move the versionbit state
         # to ACTIVE.
         self.nodes[0].generate(VB_PERIOD)
-        stop_node(self.nodes[0], 0)
-        wait_bitcoinds()
+        stop_nodes(self.nodes)
         # Empty out the alert file
         with open(self.alert_filename, 'w', encoding='utf8') as _:
             pass
@@ -156,8 +155,7 @@ class VersionBitsWarningTest(BitcoinTestFramework):
         assert(WARN_UNKNOWN_RULES_ACTIVE in self.nodes[0].getinfo()["errors"])
         assert(WARN_UNKNOWN_RULES_ACTIVE in self.nodes[0].getmininginfo()["errors"])
         assert(WARN_UNKNOWN_RULES_ACTIVE in self.nodes[0].getnetworkinfo()["warnings"])
-        stop_node(self.nodes[0], 0)
-        wait_bitcoinds()
+        stop_nodes(self.nodes)
         self.test_versionbits_in_alert_file()
 
         # Test framework expects the node to still be running...

--- a/qa/rpc-tests/reindex.py
+++ b/qa/rpc-tests/reindex.py
@@ -7,7 +7,11 @@
 # Test -reindex and -reindex-chainstate with CheckBlockIndex
 #
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+from test_framework.util import (
+    start_nodes,
+    stop_nodes,
+    assert_equal,
+)
 import time
 
 class ReindexTest(BitcoinTestFramework):
@@ -18,16 +22,14 @@ class ReindexTest(BitcoinTestFramework):
         self.num_nodes = 1
 
     def setup_network(self):
-        self.nodes = []
-        self.is_network_split = False
-        self.nodes.append(start_node(0, self.options.tmpdir))
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir)
 
     def reindex(self, justchainstate=False):
         self.nodes[0].generate(3)
         blockcount = self.nodes[0].getblockcount()
-        stop_node(self.nodes[0], 0)
-        wait_bitcoinds()
-        self.nodes[0]=start_node(0, self.options.tmpdir, ["-debug", "-reindex-chainstate" if justchainstate else "-reindex", "-checkblockindex=1"])
+        stop_nodes(self.nodes)
+        extra_args = [["-debug", "-reindex-chainstate" if justchainstate else "-reindex", "-checkblockindex=1"]]
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, extra_args)
         while self.nodes[0].getblockcount() < blockcount:
             time.sleep(0.1)
         assert_equal(self.nodes[0].getblockcount(), blockcount)

--- a/qa/rpc-tests/rpcbind_test.py
+++ b/qa/rpc-tests/rpcbind_test.py
@@ -40,7 +40,6 @@ class RPCBindTest(BitcoinTestFramework):
             assert_equal(set(get_bind_addrs(pid)), set(expected))
         finally:
             stop_nodes(self.nodes)
-            wait_bitcoinds()
 
     def run_allowip_test(self, allow_ips, rpchost, rpcport):
         '''
@@ -56,7 +55,6 @@ class RPCBindTest(BitcoinTestFramework):
         finally:
             node = None # make sure connection will be garbage collected and closed
             stop_nodes(self.nodes)
-            wait_bitcoinds()
 
     def run_test(self):
         # due to OS-specific network stats queries, this test works only on Linux

--- a/qa/rpc-tests/test_framework/test_framework.py
+++ b/qa/rpc-tests/test_framework/test_framework.py
@@ -21,7 +21,6 @@ from .util import (
     sync_mempools,
     stop_nodes,
     stop_node,
-    wait_bitcoinds,
     enable_coverage,
     check_json_precision,
     initialize_chain_clean,
@@ -81,7 +80,6 @@ class BitcoinTestFramework(object):
         """
         assert not self.is_network_split
         stop_nodes(self.nodes)
-        wait_bitcoinds()
         self.setup_network(True)
 
     def sync_all(self):
@@ -100,7 +98,6 @@ class BitcoinTestFramework(object):
         """
         assert self.is_network_split
         stop_nodes(self.nodes)
-        wait_bitcoinds()
         self.setup_network(False)
 
     def main(self):
@@ -170,7 +167,6 @@ class BitcoinTestFramework(object):
         if not self.options.noshutdown:
             print("Stopping nodes")
             stop_nodes(self.nodes)
-            wait_bitcoinds()
         else:
             print("Note: bitcoinds were not stopped and may still be running")
 

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -266,7 +266,6 @@ def initialize_chain(test_dir, num_nodes, cachedir):
 
         # Shut them down, and clean up cache directories:
         stop_nodes(rpcs)
-        wait_bitcoinds()
         disable_mocktime()
         for i in range(MAX_NODES):
             os.remove(log_filename(cachedir, i, "debug.log"))
@@ -365,6 +364,7 @@ def stop_nodes(nodes):
         except http.client.CannotSendRequest as e:
             print("WARN: Unable to stop node: " + repr(e))
     del nodes[:] # Emptying array closes connections as a side effect
+    wait_bitcoinds()
 
 def set_node_times(nodes, t):
     for node in nodes:

--- a/qa/rpc-tests/wallet.py
+++ b/qa/rpc-tests/wallet.py
@@ -199,7 +199,6 @@ class WalletTest (BitcoinTestFramework):
 
         #do some -walletbroadcast tests
         stop_nodes(self.nodes)
-        wait_bitcoinds()
         self.nodes = start_nodes(3, self.options.tmpdir, [["-walletbroadcast=0"],["-walletbroadcast=0"],["-walletbroadcast=0"]])
         connect_nodes_bi(self.nodes,0,1)
         connect_nodes_bi(self.nodes,1,2)
@@ -225,7 +224,6 @@ class WalletTest (BitcoinTestFramework):
 
         #restart the nodes with -walletbroadcast=1
         stop_nodes(self.nodes)
-        wait_bitcoinds()
         self.nodes = start_nodes(3, self.options.tmpdir)
         connect_nodes_bi(self.nodes,0,1)
         connect_nodes_bi(self.nodes,1,2)
@@ -335,7 +333,6 @@ class WalletTest (BitcoinTestFramework):
         for m in maintenance:
             print("check " + m)
             stop_nodes(self.nodes)
-            wait_bitcoinds()
             self.nodes = start_nodes(3, self.options.tmpdir, [[m]] * 3)
             while m == '-reindex' and [block_count] * 3 != [self.nodes[i].getblockcount() for i in range(3)]:
                 # reindex will leave rpc warm up "early"; Wait for it to finish


### PR DESCRIPTION
`wait_bitcoinds` is only used after `stop_nodes`, so move it there.
