### PR TITLE
gui: fix ban from qt console

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -629,6 +629,7 @@ void CNode::copyStats(CNodeStats &stats)
 {
     stats.nodeid = this->GetId();
     X(nServices);
+    X(addr);
     X(fRelayTxes);
     X(nLastSend);
     X(nLastRecv);

--- a/src/net.h
+++ b/src/net.h
@@ -505,6 +505,7 @@ public:
     double dPingWait;
     double dPingMin;
     std::string addrLocal;
+    CAddress addr;
 };
 
 


### PR DESCRIPTION
Rather than doing a circle and re-resolving the node's IP, just use the one from nodestats directly.

This requires syncing the addr field from CNode.

Fixes #8876 
