### PR TITLE
CConnman: Remove some global usage in the gui

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2100,6 +2100,9 @@ bool CConnman::Start(boost::thread_group& threadGroup, CScheduler& scheduler, st
 
         LogPrint("net", "Loaded %d banned node ips/subnets from banlist.dat  %dms\n",
             banmap.size(), GetTimeMillis() - nStart);
+
+        if (clientInterface)
+            clientInterface->BannedListChanged();
     } else {
         LogPrintf("Invalid or missing banlist.dat; recreating\n");
         SetBannedSetDirty(true); // force write

--- a/src/qt/bantablemodel.h
+++ b/src/qt/bantablemodel.h
@@ -61,7 +61,7 @@ public:
     /*@}*/
 
 public Q_SLOTS:
-    void refresh();
+    void update(QList<CCombinedBan> banlist);
 
 private:
     ClientModel *clientModel;

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -213,7 +213,23 @@ QString ClientModel::dataDir() const
 
 void ClientModel::updateBanlist()
 {
-    banTableModel->refresh();
+    banmap_t banMap;
+    if(!g_connman)
+        return;
+    g_connman->GetBanned(banMap);
+
+    QList<CCombinedBan> banlist;
+#if QT_VERSION >= 0x040700
+    banlist.reserve(banMap.size());
+#endif
+    for (banmap_t::const_iterator it = banMap.begin(); it != banMap.end(); it++)
+    {
+        CCombinedBan banEntry;
+        banEntry.subnet = (*it).first;
+        banEntry.banEntry = (*it).second;
+        banlist.append(banEntry);
+    }
+    banTableModel->update(std::move(banlist));
 }
 
 // Handlers for core signals

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -110,6 +110,29 @@ QDateTime ClientModel::getLastBlockDate() const
     return QDateTime::fromTime_t(Params().GenesisBlock().GetBlockTime()); // Genesis block's time of current network
 }
 
+QList<CNodeCombinedStats> ClientModel::getNodeStats() const
+{
+    std::vector<CNodeStats> vstats;
+    if(g_connman)
+        g_connman->GetNodeStats(vstats);
+
+    QList<CNodeCombinedStats> combinedStats;
+#if QT_VERSION >= 0x040700
+    combinedStats.reserve(vstats.size());
+#endif
+    Q_FOREACH (const CNodeStats& nodestats, vstats)
+    {
+        CNodeCombinedStats stats;
+        stats.nodeStateStats.nMisbehavior = 0;
+        stats.nodeStateStats.nSyncHeight = -1;
+        stats.nodeStateStats.nCommonHeight = -1;
+        stats.fNodeStateStatsAvailable = false;
+        stats.nodeStats = nodestats;
+        combinedStats.append(stats);
+    }
+    return combinedStats;
+}
+
 long ClientModel::getMempoolSize() const
 {
     return mempool.size();

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -21,6 +21,8 @@ QT_BEGIN_NAMESPACE
 class QTimer;
 QT_END_NAMESPACE
 
+struct CNodeCombinedStats;
+
 enum BlockSource {
     BLOCK_SOURCE_NONE,
     BLOCK_SOURCE_REINDEX,
@@ -63,6 +65,8 @@ public:
 
     double getVerificationProgress(const CBlockIndex *tip) const;
     QDateTime getLastBlockDate() const;
+
+    QList<CNodeCombinedStats> getNodeStats() const;
 
     //! Return true if core is doing initial block download
     bool inInitialBlockDownload() const;

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -998,7 +998,7 @@ void RPCConsole::banSelectedNode(int bantime)
     if(stats) {
         g_connman->Ban(stats->nodeStats.addr, BanReasonManuallyAdded, bantime);
         clearSelectedNode();
-        clientModel->getBanTableModel()->refresh();
+        // BannedListChanged signal will take care of refreshing
     }
 }
 
@@ -1015,7 +1015,7 @@ void RPCConsole::unbanSelectedNode()
     if (possibleSubnet.IsValid() && g_connman)
     {
         g_connman->Unban(possibleSubnet);
-        clientModel->getBanTableModel()->refresh();
+        // BannedListChanged signal will take care of refreshing
     }
 }
 


### PR DESCRIPTION
- React to the BannedListChanged signal and push down the new list from the clientModel, rather than pulling it the other way
- Do the same for NoteStats, pushing them down rather than pulling.

The eventual goal is to contain g_connman in clientModel, at which point we can pass it in and eliminate the global usage.

The wallet changes that were here originally will show up in a new PR.
