### PR TITLE
Qt/ModalOverlay: Use theme tooltip colours

### DIFF
--- a/src/qt/forms/modaloverlay.ui
+++ b/src/qt/forms/modaloverlay.ui
@@ -31,9 +31,6 @@
    </property>
    <item>
     <widget class="QWidget" name="bgWidget" native="true">
-     <property name="styleSheet">
-      <string notr="true">#bgWidget { background: rgba(0,0,0,220); }</string>
-     </property>
      <layout class="QVBoxLayout" name="verticalLayoutMain" stretch="1">
       <property name="leftMargin">
        <number>60</number>

--- a/src/qt/forms/modaloverlay.ui
+++ b/src/qt/forms/modaloverlay.ui
@@ -48,12 +48,7 @@
        <number>60</number>
       </property>
       <item>
-       <widget class="QWidget" name="contentWidget" native="true">
-        <property name="styleSheet">
-         <string notr="true">#contentWidget { background: rgba(255,255,255,240); border-radius: 6px; }
-
-QLabel { color: rgb(40,40,40);  }</string>
-        </property>
+       <widget class="QFrame" name="contentWidget" native="true">
         <layout class="QVBoxLayout" name="verticalLayoutSub" stretch="1,0,0,0">
          <property name="spacing">
           <number>0</number>
@@ -87,11 +82,6 @@ QLabel { color: rgb(40,40,40);  }</string>
                </property>
                <property name="text">
                 <string/>
-               </property>
-               <property name="icon">
-                <iconset>
-                 <normaloff>:/icons/warning</normaloff>
-                 <disabledoff>:/icons/warning</disabledoff>:/icons/warning</iconset>
                </property>
                <property name="iconSize">
                 <size>

--- a/src/qt/modaloverlay.cpp
+++ b/src/qt/modaloverlay.cpp
@@ -158,6 +158,21 @@ void ModalOverlay::updatePalette()
         "}"
     );
     ui->warningIcon->setIcon(ColorizeIcon(":/icons/warning", fgcolor));
+
+    int bggray = qGray(bgcolor.rgb()) * bgcolor.alpha() / 255;
+    int fadeopacity;
+    if (bggray < 0x40) {
+        // Dark overlay background, so fade-out a bit less
+        // 0xc0 for bggray=solid black, 0xe0 for bggray=0x40
+        fadeopacity = 0xc0 + (bggray / 2);
+    } else {
+        fadeopacity = 0xe0;
+    }
+    ui->bgWidget->setStyleSheet(
+        "#bgWidget {"
+            "background: rgba(0,0,0," + QString::number(fadeopacity) + ");"
+        "}"
+    );
 }
 
 void ModalOverlay::showHide(bool hide, bool userRequested)

--- a/src/qt/modaloverlay.h
+++ b/src/qt/modaloverlay.h
@@ -40,6 +40,8 @@ private:
     QVector<QPair<qint64, double> > blockProcessTime;
     bool layerIsVisible;
     bool userClosed;
+
+    void updatePalette();
 };
 
 #endif // BITCOIN_QT_MODALOVERLAY_H

--- a/src/qt/platformstyle.cpp
+++ b/src/qt/platformstyle.cpp
@@ -30,7 +30,7 @@ static const struct {
 static const unsigned platform_styles_count = sizeof(platform_styles)/sizeof(*platform_styles);
 
 namespace {
-/* Local functions for colorizing single-color images */
+/* Local function for colorizing single-color images */
 
 void MakeSingleColorImage(QImage& img, const QColor& colorbase)
 {
@@ -43,6 +43,8 @@ void MakeSingleColorImage(QImage& img, const QColor& colorbase)
             img.setPixel(x, y, qRgba(colorbase.red(), colorbase.green(), colorbase.blue(), qAlpha(rgb)));
         }
     }
+}
+
 }
 
 QIcon ColorizeIcon(const QIcon& ico, const QColor& colorbase)
@@ -69,9 +71,6 @@ QIcon ColorizeIcon(const QString& filename, const QColor& colorbase)
 {
     return QIcon(QPixmap::fromImage(ColorizeImage(filename, colorbase)));
 }
-
-}
-
 
 PlatformStyle::PlatformStyle(const QString &_name, bool _imagesOnButtons, bool _colorizeIcons, bool _useExtraSpacing):
     name(_name),

--- a/src/qt/platformstyle.h
+++ b/src/qt/platformstyle.h
@@ -9,6 +9,10 @@
 #include <QPixmap>
 #include <QString>
 
+QIcon ColorizeIcon(const QIcon&, const QColor&);
+QImage ColorizeImage(const QString& filename, const QColor&);
+QIcon ColorizeIcon(const QString& filename, const QColor&);
+
 /* Coin network-specific GUI style information */
 class PlatformStyle
 {


### PR DESCRIPTION
This seems to look nice in virtually all colour themes (except Zion Reversed, but frankly my dislike of how it looked with that extended to more than just the overlay...)
