### PR TITLE
[0.13] Fix wake from sleep issue with Boost 1.59.0

### DIFF
--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -3,6 +3,7 @@ $(package)_version=1_59_0
 $(package)_download_path=http://sourceforge.net/projects/boost/files/boost/1.59.0
 $(package)_file_name=$(package)_$($(package)_version).tar.bz2
 $(package)_sha256_hash=727a932322d94287b62abb1bd2d41723eec4356a7728909e38adb65ca25241ca
+$(package)_patches=fix-win-wake-from-sleep.patch
 
 define $(package)_set_vars
 $(package)_config_opts_release=variant=release
@@ -25,6 +26,7 @@ $(package)_cxxflags_linux=-fPIC
 endef
 
 define $(package)_preprocess_cmds
+  patch -p1 < $($(package)_patch_dir)/fix-win-wake-from-sleep.patch && \
   echo "using $(boost_toolset_$(host_os)) : : $($(package)_cxx) : <cxxflags>\"$($(package)_cxxflags) $($(package)_cppflags)\" <linkflags>\"$($(package)_ldflags)\" <archiver>\"$(boost_archiver_$(host_os))\" <striper>\"$(host_STRIP)\"  <ranlib>\"$(host_RANLIB)\" <rc>\"$(host_WINDRES)\" : ;" > user-config.jam
 endef
 

--- a/depends/patches/boost/fix-win-wake-from-sleep.patch
+++ b/depends/patches/boost/fix-win-wake-from-sleep.patch
@@ -1,0 +1,31 @@
+--- old/libs/thread/src/win32/thread.cpp
++++ new/libs/thread/src/win32/thread.cpp
+@@ -645,7 +645,7 @@
+                     } Detailed;
+                 } Reason;
+             } REASON_CONTEXT, *PREASON_CONTEXT;
+-            static REASON_CONTEXT default_reason_context={0/*POWER_REQUEST_CONTEXT_VERSION*/, 0x00000001/*POWER_REQUEST_CONTEXT_SIMPLE_STRING*/, (LPWSTR)L"generic"};
++            //static REASON_CONTEXT default_reason_context={0/*POWER_REQUEST_CONTEXT_VERSION*/, 0x00000001/*POWER_REQUEST_CONTEXT_SIMPLE_STRING*/, (LPWSTR)L"generic"};
+             typedef BOOL (WINAPI *setwaitabletimerex_t)(HANDLE, const LARGE_INTEGER *, LONG, PTIMERAPCROUTINE, LPVOID, PREASON_CONTEXT, ULONG);
+             static inline BOOL WINAPI SetWaitableTimerEx_emulation(HANDLE hTimer, const LARGE_INTEGER *lpDueTime, LONG lPeriod, PTIMERAPCROUTINE pfnCompletionRoutine, LPVOID lpArgToCompletionRoutine, PREASON_CONTEXT WakeContext, ULONG TolerableDelay)
+             {
+@@ -715,7 +715,8 @@
+                     if(time_left.milliseconds/20>tolerable)  // 5%
+                         tolerable=time_left.milliseconds/20;
+                     LARGE_INTEGER due_time=get_due_time(target_time);
+-                    bool const set_time_succeeded=detail_::SetWaitableTimerEx()(timer_handle,&due_time,0,0,0,&detail_::default_reason_context,tolerable)!=0;
++                    //bool const set_time_succeeded=detail_::SetWaitableTimerEx()(timer_handle,&due_time,0,0,0,&detail_::default_reason_context,tolerable)!=0;
++                    bool const set_time_succeeded=detail_::SetWaitableTimerEx()(timer_handle,&due_time,0,0,0,NULL,tolerable)!=0;
+                     if(set_time_succeeded)
+                     {
+                         timeout_index=handle_count;
+@@ -799,7 +800,8 @@
+                     if(time_left.milliseconds/20>tolerable)  // 5%
+                         tolerable=time_left.milliseconds/20;
+                     LARGE_INTEGER due_time=get_due_time(target_time);
+-                    bool const set_time_succeeded=detail_::SetWaitableTimerEx()(timer_handle,&due_time,0,0,0,&detail_::default_reason_context,tolerable)!=0;
++                    //bool const set_time_succeeded=detail_::SetWaitableTimerEx()(timer_handle,&due_time,0,0,0,&detail_::default_reason_context,tolerable)!=0;
++                    bool const set_time_succeeded=detail_::SetWaitableTimerEx()(timer_handle,&due_time,0,0,0,NULL,tolerable)!=0;
+                     if(set_time_succeeded)
+                     {
+                         timeout_index=handle_count;


### PR DESCRIPTION
Patch Boost for the Windows "wake from sleep" issue which was fixed in [1.60.0](https://svn.boost.org/trac/boost/ticket/11368). 
0.13.0 depends is using 1.59.0 and @laanwj advised against an entire Boost bump.

This is already fixed in master as Boost was bumped to 1.61.0 in #8819.

Can someone on a Windows machines, maybe @drake127 or @achow101, test that it's working?

Closes #8806 
