### PR TITLE
Seed insecure_rand during start

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1032,6 +1032,9 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     ECC_Start();
     globalVerifyHandle.reset(new ECCVerifyHandle());
 
+    // Initialize/seed fast PRNG
+    seed_insecure_rand(false);
+
     // Sanity check
     if (!InitSanityCheck())
         return InitError(strprintf(_("Initialization sanity check failed. %s is shutting down."), _(PACKAGE_NAME)));


### PR DESCRIPTION
I've noticed that (besides the Bitcoin test-code) `insecure_rand()` is only properly (=non-deterministic) seeded when a new transaction is created, which might be _**after**_ it's already used.
Seeding it here should ensure that current and futures usages don't accidentally start with the default seed.
