### PR TITLE
Set minimum required Boost to 1.47.0

### DIFF
--- a/build-aux/m4/ax_boost_base.m4
+++ b/build-aux/m4/ax_boost_base.m4
@@ -33,7 +33,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 26
+#serial 27
 
 AC_DEFUN([AX_BOOST_BASE],
 [
@@ -96,7 +96,7 @@ if test "x$want_boost" = "xyes"; then
         libsubdirs="lib64 libx32 lib lib64"
         ;;
       ppc64|s390x|sparc64|aarch64|ppc64le)
-        libsubdirs="lib64 lib lib64 ppc64le"
+        libsubdirs="lib64 lib lib64"
         ;;
     esac
 

--- a/configure.ac
+++ b/configure.ac
@@ -589,8 +589,11 @@ fi
 
 if test x$use_boost = xyes; then
 
+dnl Minimum required Boost version
+define(MINIMUM_REQUIRED_BOOST, 1.47.0)
+
 dnl Check for boost libs
-AX_BOOST_BASE
+AX_BOOST_BASE([MINIMUM_REQUIRED_BOOST])
 AX_BOOST_SYSTEM
 AX_BOOST_FILESYSTEM
 AX_BOOST_PROGRAM_OPTIONS


### PR DESCRIPTION
Boost is on the way out, but in the mean time, having the minimum set to 1.20.0 is misleading, and can lead to issues like #8868.

1.47.0 is the first version to include [Chrono](http://www.boost.org/users/history/version_1_47_0.html). See #8875 for some history.
