### PR TITLE
Fix init segfault where InitLoadWallet() calls ATMP before genesis

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1488,6 +1488,13 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
         uiInterface.NotifyBlockTip.disconnect(BlockNotifyGenesisWait);
     }
 
+#ifdef ENABLE_WALLET
+    // Add wallet transactions that aren't already in a block to mempool
+    // Do this here as mempool requires genesis block to be loaded
+    if (pwalletMain)
+        pwalletMain->ReacceptWalletTransactions();
+#endif
+
     // ********************************************************* Step 11: start node
 
     //// debug print

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3467,8 +3467,6 @@ bool CWallet::InitLoadWallet()
         LogPrintf("mapWallet.size() = %u\n",       walletInstance->mapWallet.size());
         LogPrintf("mapAddressBook.size() = %u\n",  walletInstance->mapAddressBook.size());
     }
-    // Add wallet transactions that aren't already in a block to mapTransactions
-    walletInstance->ReacceptWalletTransactions();
 
     pwalletMain = walletInstance;
 


### PR DESCRIPTION
I honestly have no idea how the wallet.py tests are passing for anyone, but they reliably cause segfault here for me.
