### PR TITLE
Move orphan processing to ActivateBestChain

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3088,8 +3088,8 @@ bool ActivateBestChain(CValidationState &state, const CChainParams& chainparams,
         // Remove orphan transactions with cs_main
         {
             LOCK(cs_main);
-            std::vector<uint256> vOrphanErase;
             for(unsigned int i = 0; i < txChanged.size(); i++) {
+                std::vector<uint256> vOrphanErase;
                 const CTransaction& tx = std::get<0>(txChanged[i]);
                 // Which orphan pool entries must we evict?
                 for (size_t j = 0; j < tx.vin.size(); j++) {
@@ -3101,14 +3101,15 @@ bool ActivateBestChain(CValidationState &state, const CChainParams& chainparams,
                         vOrphanErase.push_back(orphanHash);
                     }
                 }
-            }
-            // Erase orphan transactions include or precluded by this block
-            if (vOrphanErase.size()) {
-                int nErased = 0;
-                BOOST_FOREACH(uint256 &orphanHash, vOrphanErase) {
-                    nErased += EraseOrphanTx(orphanHash);
+
+                // Erase orphan transactions include or precluded by this block
+                if (vOrphanErase.size()) {
+                    int nErased = 0;
+                    BOOST_FOREACH(uint256 &orphanHash, vOrphanErase) {
+                        nErased += EraseOrphanTx(orphanHash);
+                    }
+                    LogPrint("mempool", "Erased %d orphan tx included or conflicted by block\n", nErased);
                 }
-                LogPrint("mempool", "Erased %d orphan tx included or conflicted by block\n", nErased);
             }
         }
 

--- a/src/main.h
+++ b/src/main.h
@@ -560,6 +560,7 @@ private:
 public:
     PeerLogicValidation(CConnman* connmanIn);
 
+    virtual void SyncTransaction(const CTransaction& tx, const CBlockIndex* pindex, int nPosInBlock);
     virtual void UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload);
     virtual void BlockChecked(const CBlock& block, const CValidationState& state);
 };


### PR DESCRIPTION
Based on #8928 because its the only way I can run tests.
This will conflict a bit with #8865, but that's easy to resolve, and I'd rather get some eyeballs on this sooner rather than later, so am leaving it freestanding. Once #8865 goes in the orphan processing will go into the CValidationInterface which manges "net processing" stuff.

This further decouples "main" and "net" processing logic by moving
orphan processing out of the chain-connecting cs_main lock and
into its own cs_main lock, beside all of the other chain callbacks.

Once further decoupling of net and main processing logic occurs,
orphan handing should move to its own lock, out of cs_main.

Note that this will introduce a race if there are any cases where
we assume the orphan map to be consistent with the current chain
tip, however I am confident there is no such case (ATMP will fail
without DoS score in all such cases).
