### PR TITLE
Documentation: Building on Windows with WSL

### DIFF
--- a/doc/build-windows.md
+++ b/doc/build-windows.md
@@ -1,13 +1,45 @@
 WINDOWS BUILD NOTES
 ====================
 
-Some notes on how to build Bitcoin Core for Windows.
+Below are some notes on how to build Bitcoin Core for Windows.
 
 Most developers use cross-compilation from Ubuntu to build executables for
 Windows. This is also used to build the release binaries.
 
-Building on Windows itself is possible (for example using msys / mingw-w64),
-but no one documented the steps to do this. If you are doing this, please contribute them.
+While there are potentially a number of ways to build on Windows (for example using msys / mingw-w64),
+using the Windows Subsystem For Linux is the most straight forward.  If you are building with
+an alternative method, please contribute the instructions here for others who are running versions
+of Windows that are not compatible with the Windows Subsystem for Linux.
+
+Compiling with the Windows Subsystem For Linux
+-------------------
+
+With Windows 10, Microsoft has released a new feature named the
+[Windows Subsystem for Linux](https://msdn.microsoft.com/commandline/wsl/about).  This feature allows you to run a bash shell directly on Windows in an Ubuntu based
+environment.  Within this environment you can cross compile for Windows without the need for a separate Linux VM or Server.
+
+This feature is not supported in versions of Windows prior to Windows 10 or on Windows Server SKUs.
+
+To get the bash shell, you must first activate the feature in Windows.
+
+1. Turn on Developer Mode
+  * Open Settings -> Update and Security -> For developers
+  * Select the Developer Mode radio button
+  * Restart if necessary
+2. Enable the Windows Subsystem for Linux feature
+  * From Start, search for "Turn Windows features on or off" (type 'turn')
+  * Select Windows Subsystem for Linux (beta)
+  * Click OK
+  * Restart if necessary
+3. Complete Installation
+  * Open a cmd prompt and type "bash"
+  * Accept the license
+  * Create a new UNIX user account (this is a separate account from your Windows account)
+
+After the bash shell is active, you can follow the instructions below for Windows 64-bit Cross-compilation.
+When building dependencies within the 'depends' folder, you may encounter an error building
+the protobuf dependency.  If this occurs, re-run the command with sudo.  This is likely
+a bug with the Windows Subsystem for Linux feature and may be fixed with a future update.
 
 Cross-compilation
 -------------------
@@ -41,4 +73,3 @@ To build executables for Windows 64-bit:
     make
 
 For further documentation on the depends system see [README.md](../depends/README.md) in the depends directory.
-


### PR DESCRIPTION
The new Windows Subsystem for Linux (WSL) allows a user to run a bash shell directly on Windows in an Ubuntu based environment.  This can be used to cross-compile Bitcoin directly on Windows without the need for a separate Linux VM or Server.  The instructions included in this commit explain how to configure the environment and build Bitcoin Core using this new feature.
