### PR TITLE
Remove bogus assert on number of oubound connections.

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1622,7 +1622,6 @@ void CConnman::ThreadOpenConnections()
                 }
             }
         }
-        assert(nOutbound <= (nMaxOutbound + nMaxFeeler));
 
         // Feeler Connections
         //


### PR DESCRIPTION
This value can be significantly higher if the users uses addnode
