### PR TITLE
[TRIVIAL] reorder Windows gitian build order to match Linux

### DIFF
--- a/contrib/gitian-descriptors/gitian-win.yml
+++ b/contrib/gitian-descriptors/gitian-win.yml
@@ -27,7 +27,7 @@ remotes:
 files: []
 script: |
   WRAP_DIR=$HOME/wrapped
-  HOSTS="x86_64-w64-mingw32 i686-w64-mingw32"
+  HOSTS="i686-w64-mingw32 x86_64-w64-mingw32"
   CONFIGFLAGS="--enable-reduce-exports --disable-bench --disable-gui-tests"
   FAKETIME_HOST_PROGS="g++ ar ranlib nm windres strip objcopy"
   FAKETIME_PROGS="date makensis zip"


### PR DESCRIPTION
The consistency is helpful for gauging Gitian build progress. Right now it's necessary to remember which platform builds in which order, which can be confusing if you're attempting to get a quick idea of how far along your builds are.
