### PR TITLE
Be more agressive in getting connections to peers with relevant services.

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1675,8 +1675,8 @@ void CConnman::ThreadOpenConnections()
             if (nANow - addr.nLastTry < 600 && nTries < 30)
                 continue;
 
-            // only consider nodes missing relevant services after 40 failed attempts
-            if ((addr.nServices & nRelevantServices) != nRelevantServices && nTries < 40)
+            // only consider nodes missing relevant services after 40 failed attempts and only if less than half the outbound are up.
+            if ((addr.nServices & nRelevantServices) != nRelevantServices && (nTries < 40 || nOutbound >= (nMaxOutbound >> 1)))
                 continue;
 
             // do not allow non-default ports, unless after 50 invalid addresses selected already


### PR DESCRIPTION
Currently, we make 40 requests to addrman for peers with our relevant services then give up and take a node without them.  When relevant services are rare in our addrman data this means we can get all 8 peers up without them. If they happen to be reliable peers they may stay up filling our connection slots for months, even though our addrman has since been populated with plenty of relevant peers.

To avoid this this PR changes the behavior to be only willing to ignore relevant services until half the outbound connections are up.

Also, dnsseed does not fire if we have at least two connections (in or out) 11 seconds after startup. It currently doesn't perform any sanity checking of the connections-- they could be two lite-client inbound peers that will never send us addr message and our addrman might be filled with stupidity. To improve that somewhat, we check that they at least send the relevant service flags before deciding to not request dnsseeding.
