### PR TITLE
Fix sort arrow in peer table

### DIFF
--- a/src/qt/peertablemodel.cpp
+++ b/src/qt/peertablemodel.cpp
@@ -19,7 +19,7 @@ bool NodeLessThan::operator()(const CNodeCombinedStats &left, const CNodeCombine
     const CNodeStats *pLeft = &(left.nodeStats);
     const CNodeStats *pRight = &(right.nodeStats);
 
-    if (order == Qt::DescendingOrder)
+    if (order != Qt::DescendingOrder)
         std::swap(pLeft, pRight);
 
     switch(column)


### PR DESCRIPTION
Currently the arrow points in the wrong direction, i.e. we have an ascending arrow when the output is descending, and vice versa.
