### PR TITLE
doc: update 0.13.1 release note info on linux arm builds

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -127,6 +127,33 @@ Low-level RPC changes
   than two arguments.
 
 
+Linux ARM builds
+----------------
+
+With the 0.13.0 release, pre-built Linux ARM binaries were added to the set of
+uploaded executables. Additional detail on the ARM architecture targeted by each
+is provided below.
+
+The following extra files can be found in the download directory or torrent:
+
+- `bitcoin-${VERSION}-arm-linux-gnueabihf.tar.gz`: Linux binaries targeting
+  the 32-bit ARMv7-A architecture.
+- `bitcoin-${VERSION}-aarch64-linux-gnu.tar.gz`: Linux binaries targeting
+  the 64-bit ARMv8-A architecture.
+
+ARM builds are still experimental. If you have problems on a certain device or
+Linux distribution combination please report them on the bug tracker, it may be
+possible to resolve them. Note that the device you use must be (backward)
+compatible with the architecture targeted by the binary that you use.
+For example, a Raspberry Pi 2 Model B or Raspberry Pi 3 Model B (in its 32-bit
+execution state) device, can run the 32-bit ARMv7-A targeted binary. However,
+no model of Raspberry Pi 1 device can run either binary because they are all
+ARMv6 architecture devices that are not compatible with ARMv7-A or ARMv8-A.
+
+Note that Android is not considered ARM Linux in this context. The executables
+are not expected to work out of the box on Android.
+
+
 0.13.1 Change log
 =================
 


### PR DESCRIPTION
clarify which arm architectures are targeted by the binaries and give a raspberry pi example.
this pull is for the 0.13 branch.
reference #8924 and #8955 
