### PR TITLE
Correct checksum error message (and debug node id)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6348,10 +6348,11 @@ bool ProcessMessages(CNode* pfrom, CConnman& connman)
         uint256 hash = Hash(vRecv.begin(), vRecv.begin() + nMessageSize);
         if (memcmp(hash.begin(), hdr.pchChecksum, CMessageHeader::CHECKSUM_SIZE) != 0)
         {
-            LogPrintf("%s(%s, %u bytes): CHECKSUM ERROR expected %s was %s\n", __func__,
+            LogPrintf("%s(%s, %u bytes): CHECKSUM ERROR declared=%s calculated=%s peer=%d\n", __func__,
                SanitizeString(strCommand), nMessageSize,
+               HexStr(hdr.pchChecksum, hdr.pchChecksum+CMessageHeader::CHECKSUM_SIZE),
                HexStr(hash.begin(), hash.begin()+CMessageHeader::CHECKSUM_SIZE),
-               HexStr(hdr.pchChecksum, hdr.pchChecksum+CMessageHeader::CHECKSUM_SIZE));
+               pfrom->id);
             continue;
         }
 


### PR DESCRIPTION
Order of variables was incorrect. Also nodeid was not included. Fixed.
