### PR TITLE
NodeId missing from this debug line

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -800,7 +800,7 @@ size_t SocketSendData(CNode *pnode)
                 int nErr = WSAGetLastError();
                 if (nErr != WSAEWOULDBLOCK && nErr != WSAEMSGSIZE && nErr != WSAEINTR && nErr != WSAEINPROGRESS)
                 {
-                    LogPrintf("socket send error %s\n", NetworkErrorString(nErr));
+                    LogPrintf("socket send error %s peer=%d\n", NetworkErrorString(nErr), pnode->id);
                     pnode->CloseSocketDisconnect();
                 }
             }


### PR DESCRIPTION
Add NodeId to debug info.

TODO (in a later pull request): Make better use of the -logips command line option so that IP addresses are debugged instead of NodeIds in all places where NodeIds are currently debugged.
