### PR TITLE
[Wallet] Refactor wallet/init interaction (Reaccept wtx, flush thread)

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1493,13 +1493,6 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
         uiInterface.NotifyBlockTip.disconnect(BlockNotifyGenesisWait);
     }
 
-#ifdef ENABLE_WALLET
-    // Add wallet transactions that aren't already in a block to mempool
-    // Do this here as mempool requires genesis block to be loaded
-    if (pwalletMain)
-        pwalletMain->ReacceptWalletTransactions();
-#endif
-
     // ********************************************************* Step 11: start node
 
     //// debug print
@@ -1537,10 +1530,8 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     uiInterface.InitMessage(_("Done loading"));
 
 #ifdef ENABLE_WALLET
-    if (pwalletMain) {
-        // Run a thread to flush wallet periodically
-        threadGroup.create_thread(boost::bind(&ThreadFlushWalletDB, boost::ref(pwalletMain->strWalletFile)));
-    }
+    if (pwalletMain)
+        pwalletMain->postInitProcess(threadGroup);
 #endif
 
     return !fRequestShutdown;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3472,6 +3472,16 @@ bool CWallet::InitLoadWallet()
     return true;
 }
 
+void CWallet::postInitProcess(boost::thread_group& threadGroup)
+{
+    // Add wallet transactions that aren't already in a block to mempool
+    // Do this here as mempool requires genesis block to be loaded
+    ReacceptWalletTransactions();
+
+    // Run a thread to flush wallet periodically
+    threadGroup.create_thread(boost::bind(&ThreadFlushWalletDB, boost::ref(this->strWalletFile)));
+}
+
 bool CWallet::ParameterInteraction()
 {
     if (GetBoolArg("-disablewallet", DEFAULT_DISABLE_WALLET))

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -27,6 +27,7 @@
 #include <vector>
 
 #include <boost/shared_ptr.hpp>
+#include <boost/thread.hpp>
 
 extern CWallet* pwalletMain;
 
@@ -911,6 +912,12 @@ public:
 
     /* Initializes the wallet, returns a new CWallet instance or a null pointer in case of an error */
     static bool InitLoadWallet();
+
+    /**
+     * Wallet post-init setup
+     * Gives the wallet a chance to register repetitive tasks and complete post-init tasks
+     */
+    void postInitProcess(boost::thread_group& threadGroup);
 
     /* Wallets parameter interaction */
     static bool ParameterInteraction();


### PR DESCRIPTION
Cleanup of https://github.com/bitcoin/bitcoin/pull/8928.
Also "hides" `ThreadFlushWalletDB` from `init.cpp`.

This moves `ReacceptWalletTransactions` further down so that it will be executed after the connection manager has been started. I think this should not be a problem.

@TheBlueMatt: would be nice if you could do a retest regarding the segfaults in init you have discovered.
