### PR TITLE
RPC: importmulti: Avoid using boost::variant::operator!=, which is only in newer boost versions

### DIFF
--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -808,7 +808,7 @@ UniValue processImport(const UniValue& data) {
                 CBitcoinAddress pubKeyAddress = CBitcoinAddress(pubKey.GetID());
 
                 // Consistency check.
-                if (!isScript && pubKeyAddress.Get() != address.Get()) {
+                if (!isScript && !(pubKeyAddress.Get() == address.Get())) {
                     throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Consistency check failed");
                 }
 
@@ -819,7 +819,7 @@ UniValue processImport(const UniValue& data) {
 
                     if (ExtractDestination(script, destination)) {
                         scriptAddress = CBitcoinAddress(destination);
-                        if (scriptAddress.Get() != pubKeyAddress.Get()) {
+                        if (!(scriptAddress.Get() == pubKeyAddress.Get())) {
                             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Consistency check failed");
                         }
                     }
@@ -881,7 +881,7 @@ UniValue processImport(const UniValue& data) {
                 CBitcoinAddress pubKeyAddress = CBitcoinAddress(pubKey.GetID());
 
                 // Consistency check.
-                if (!isScript && pubKeyAddress.Get() != address.Get()) {
+                if (!isScript && !(pubKeyAddress.Get() == address.Get())) {
                     throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Consistency check failed");
                 }
 
@@ -892,7 +892,7 @@ UniValue processImport(const UniValue& data) {
 
                     if (ExtractDestination(script, destination)) {
                         scriptAddress = CBitcoinAddress(destination);
-                        if (scriptAddress.Get() != pubKeyAddress.Get()) {
+                        if (!(scriptAddress.Get() == pubKeyAddress.Get())) {
                             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Consistency check failed");
                         }
                     }


### PR DESCRIPTION
At least boost 1.56 (Gentoo amd64 stable) is missing operator!=
