### PR TITLE
Wshadow: Do not shadow argument with a local variable

### DIFF
--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -798,8 +798,8 @@ UniValue processImport(const UniValue& data) {
                     throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Pubkey must be a hex string");
                 }
 
-                std::vector<unsigned char> data(ParseHex(strPubKey));
-                CPubKey pubKey(data.begin(), data.end());
+                std::vector<unsigned char> vData(ParseHex(strPubKey));
+                CPubKey pubKey(vData.begin(), vData.end());
 
                 if (!pubKey.IsFullyValid()) {
                     throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Pubkey is not a valid public key");


### PR DESCRIPTION
Current master adds new `-Wshadow` warning:

```
wallet/rpcdump.cpp:801:44: warning: declaration shadows a local variable [-Wshadow]
```

Use better name for the local variable, matching its vector type.
