### PR TITLE
WIP: Log block height and size when received

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3753,9 +3753,13 @@ bool ProcessNewBlock(CValidationState& state, const CChainParams& chainparams, C
         CBlockIndex *pindex = NULL;
         bool fNewBlock = false;
         bool ret = AcceptBlock(*pblock, state, chainparams, &pindex, fRequested, dbp, &fNewBlock);
-        if (pindex && pfrom) {
-            mapBlockSource[pindex->GetBlockHash()] = pfrom->GetId();
-            if (fNewBlock) pfrom->nLastBlockTime = GetTime();
+        if (pfrom) {
+            if (pindex) {
+                LogPrint("block", "recv block %s (%d) peer=%d\n", pblock->GetHash().ToString(), pindex->nHeight, pfrom->id);
+                mapBlockSource[pindex->GetBlockHash()] = pfrom->GetId();
+                if (fNewBlock) pfrom->nLastBlockTime = GetTime();
+            } else
+                LogPrint("block", "recv block %s peer=%d\n", pblock->GetHash().ToString(), pfrom->id);
         }
         CheckBlockIndex(chainparams.GetConsensus());
         if (!ret)
@@ -6020,8 +6024,6 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
     {
         CBlock block;
         vRecv >> block;
-
-        LogPrint("net", "received block %s peer=%d\n", block.GetHash().ToString(), pfrom->id);
 
         CValidationState state;
         // Process all blocks from whitelisted peers, even if not requested,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3755,11 +3755,12 @@ bool ProcessNewBlock(CValidationState& state, const CChainParams& chainparams, C
         bool ret = AcceptBlock(*pblock, state, chainparams, &pindex, fRequested, dbp, &fNewBlock);
         if (pfrom) {
             if (pindex) {
-                LogPrint("block", "recv block %s (%d) peer=%d\n", pblock->GetHash().ToString(), pindex->nHeight, pfrom->id);
+                LogPrint("block", "recv block %s (%d) size=%d peer=%d\n", pblock->GetHash().ToString(), pindex->nHeight,
+                    pfrom->nBlockSize, pfrom->id);
                 mapBlockSource[pindex->GetBlockHash()] = pfrom->GetId();
                 if (fNewBlock) pfrom->nLastBlockTime = GetTime();
             } else
-                LogPrint("block", "recv block %s peer=%d\n", pblock->GetHash().ToString(), pfrom->id);
+                LogPrint("block", "recv block %s size=%d peer=%d\n", pblock->GetHash().ToString(), pfrom->nBlockSize, pfrom->id);
         }
         CheckBlockIndex(chainparams.GetConsensus());
         if (!ret)
@@ -6023,6 +6024,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
     else if (strCommand == NetMsgType::BLOCK && !fImporting && !fReindex) // Ignore blocks received while importing
     {
         CBlock block;
+        pfrom->nBlockSize = vRecv.size(); // Used by ProcessNewBlock() debug
         vRecv >> block;
 
         CValidationState state;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2533,6 +2533,7 @@ CNode::CNode(NodeId idIn, ServiceFlags nLocalServicesIn, int nMyStartingHeightIn
     fOneShot = false;
     fClient = false; // set by version message
     fFeeler = false;
+    nBlockSize = 0;
     fInbound = fInboundIn;
     fNetworkNode = false;
     fSuccessfullyConnected = false;

--- a/src/net.h
+++ b/src/net.h
@@ -587,6 +587,7 @@ public:
     std::string strSubVer, cleanSubVer;
     bool fWhitelisted; // This peer can bypass DoS banning.
     bool fFeeler; // If true this node is being used as a short lived feeler.
+    unsigned int nBlockSize; // Used by ProcessNewBlock() for debug message.
     bool fOneShot;
     bool fClient;
     bool fInbound;


### PR DESCRIPTION
Displays block height and size in debug.log when a block is received.

Various people have expressed a desire for this to be logged in previous PRs.

I'm not sure if the way I've passed the blocksize to ProcessNewBlock is the most ideal way. Very open to feedback on better ways.

Tested with "make check" now that I know about this! (Still not quite sure how to debug when tests fail quite yet though!)

The LogPrint also puts the debug message to "block" rather than "net" as part of an attempt to separate net debugs into more specific debugs. This pull does not include an update to init.cpp yet as I suspect this will want to be done as part of a later pull, once more things are using "block"? Apologies that I am unsure of the order in which this would be migrated. 
