### PR TITLE
Use pindexBestHeader instead of setBlockIndexCandidates for NotifyHeaderTip()

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3006,9 +3006,8 @@ static void NotifyHeaderTip() {
     CBlockIndex* pindexHeader = NULL;
     {
         LOCK(cs_main);
-        if (!setBlockIndexCandidates.empty()) {
-            pindexHeader = *setBlockIndexCandidates.rbegin();
-        }
+        pindexHeader = pindexBestHeader;
+
         if (pindexHeader != pindexHeaderOld) {
             fNotify = true;
             fInitialBlockDownload = IsInitialBlockDownload();

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -717,13 +717,10 @@ void BitcoinGUI::setNumBlocks(int count, const QDateTime& blockDate, double nVer
 {
     if (modalOverlay)
     {
-        if (header) {
-            /* use clientmodels getHeaderTipHeight and getHeaderTipTime because the NotifyHeaderTip signal does not fire when updating the best header */
-            modalOverlay->setKnownBestHeight(clientModel->getHeaderTipHeight(), QDateTime::fromTime_t(clientModel->getHeaderTipTime()));
-        }
-        else {
+        if (header)
+            modalOverlay->setKnownBestHeight(count, blockDate);
+        else
             modalOverlay->tipUpdate(count, blockDate, nVerificationProgress);
-        }
     }
     if (!clientModel)
         return;

--- a/src/qt/forms/modaloverlay.ui
+++ b/src/qt/forms/modaloverlay.ui
@@ -219,7 +219,7 @@ QLabel { color: rgb(40,40,40);  }</string>
            <item row="0" column="1">
             <widget class="QLabel" name="numberOfBlocksLeft">
              <property name="text">
-              <string>unknown...</string>
+              <string>Unknown...</string>
              </property>
             </widget>
            </item>
@@ -245,7 +245,7 @@ QLabel { color: rgb(40,40,40);  }</string>
               </sizepolicy>
              </property>
              <property name="text">
-              <string>unknown...</string>
+              <string>Unknown...</string>
              </property>
             </widget>
            </item>

--- a/src/qt/modaloverlay.cpp
+++ b/src/qt/modaloverlay.cpp
@@ -132,7 +132,8 @@ void ModalOverlay::tipUpdate(int count, const QDateTime& blockDate, double nVeri
     if (estimateNumHeadersLeft < 24 && hasBestHeader) {
         ui->numberOfBlocksLeft->setText(QString::number(bestHeaderHeight - count));
     } else {
-        ui->expectedTimeLeft->setText(tr("Unknown. Syncing Headers..."));
+        ui->numberOfBlocksLeft->setText(tr("Unknown. Syncing Headers (%1)...").arg(bestHeaderHeight));
+        ui->expectedTimeLeft->setText(tr("Unknown..."));
     }
 }
 


### PR DESCRIPTION
Should fix https://github.com/bitcoin/bitcoin/issues/8984
Also displays the best header height in the modal overlay.
