### PR TITLE
Trivial: Fix doxygen comment: the transaction is returned in txOut

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1584,7 +1584,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
     return res;
 }
 
-/** Return transaction in tx, and if it was found inside a block, its hash is placed in hashBlock */
+/** Return transaction in txOut, and if it was found inside a block, its hash is placed in hashBlock */
 bool GetTransaction(const uint256 &hash, CTransaction &txOut, const Consensus::Params& consensusParams, uint256 &hashBlock, bool fAllowSlow)
 {
     CBlockIndex *pindexSlow = NULL;


### PR DESCRIPTION
The transaction is returned in `txOut`, there is no `tx` here.
