### PR TITLE
[net] Remove assert(nMaxInbound > 0)

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -970,7 +970,6 @@ void CConnman::AcceptConnection(const ListenSocket& hListenSocket) {
     CAddress addr;
     int nInbound = 0;
     int nMaxInbound = nMaxConnections - (nMaxOutbound + nMaxFeeler);
-    assert(nMaxInbound > 0);
 
     if (hSocket != INVALID_SOCKET)
         if (!addr.SetSockAddr((const struct sockaddr*)&sockaddr))


### PR DESCRIPTION
nMaxInbound might very well be 0 or -1, if the user prefers to keep
a small number of maxconnections.

Note: nMaxInbound of -1 means that the user set maxconnections
to 8 or less, but we still want to keep an additional slot for
the feeler connection.

Closes #9007 
