### PR TITLE
release: bump required osx version to 10.8. (jonasschnelli)

### DIFF
--- a/share/qt/Info.plist.in
+++ b/share/qt/Info.plist.in
@@ -3,7 +3,7 @@
 <plist version="0.9">
 <dict>
   <key>LSMinimumSystemVersion</key>
-  <string>10.7.0</string>
+  <string>10.8.0</string>
 
   <key>LSArchitecturePriority</key>
   <array>


### PR DESCRIPTION
libc++ on 10.7 causes too many issues.

See #8577 for discussion/details. Needs backport to 0.13.

No change on my 10.11 machine.

Looks like this on 10.7:
![10 7disabled](https://cloud.githubusercontent.com/assets/417043/19699057/bc553292-9abf-11e6-89f1-2dbfd966b376.png)

And when trying to run it:
![10 7disabled2](https://cloud.githubusercontent.com/assets/417043/19699062/c2f9d35a-9abf-11e6-975b-6ad7ec1b5519.png)
