### PR TITLE
Enable various p2sh-p2wpkh functionality

### DIFF
--- a/src/base58.cpp
+++ b/src/base58.cpp
@@ -271,9 +271,7 @@ bool CBitcoinAddress::GetKeyID(CKeyID& keyID) const
 {
     if (!IsValid() || vchVersion != Params().Base58Prefix(CChainParams::PUBKEY_ADDRESS))
         return false;
-    uint160 id;
-    memcpy(&id, &vchData[0], 20);
-    keyID = CKeyID(id);
+    memcpy(keyID.begin(), &vchData[0], 20);
     return true;
 }
 

--- a/src/base58.cpp
+++ b/src/base58.cpp
@@ -275,6 +275,14 @@ bool CBitcoinAddress::GetKeyID(CKeyID& keyID) const
     return true;
 }
 
+bool CBitcoinAddress::GetScriptID(CScriptID& scriptID) const
+{
+    if (!IsValid() || vchVersion != Params().Base58Prefix(CChainParams::SCRIPT_ADDRESS))
+        return false;
+    memcpy(scriptID.begin(), &vchData[0], 20);
+    return true;
+}
+
 bool CBitcoinAddress::IsScript() const
 {
     return IsValid() && vchVersion == Params().Base58Prefix(CChainParams::SCRIPT_ADDRESS);

--- a/src/base58.h
+++ b/src/base58.h
@@ -116,6 +116,7 @@ public:
 
     CTxDestination Get() const;
     bool GetKeyID(CKeyID &keyID) const;
+    bool GetScriptID(CScriptID &scriptID) const;
     bool IsScript() const;
 };
 

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -135,6 +135,14 @@ public:
             int nRequired;
             ExtractDestinations(subscript, whichType, addresses, nRequired);
             obj.push_back(Pair("script", GetTxnOutputType(whichType)));
+            CKeyID keyID;
+            CPubKey pubkey;
+            if (GetWitnessKeyID(pwalletMain, scriptID, keyID) &&
+                pwalletMain->GetPubKey(keyID, pubkey)) {
+                // Wallet should only have compressed pubkeys for segwit
+                assert(pubkey.IsCompressed());
+                obj.push_back(Pair("pubkey", HexStr(pubkey)));
+            }
             obj.push_back(Pair("hex", HexStr(subscript.begin(), subscript.end())));
             UniValue a(UniValue::VARR);
             BOOST_FOREACH(const CTxDestination& addr, addresses)
@@ -204,7 +212,8 @@ UniValue validateaddress(const JSONRPCRequest& request)
         if (pwalletMain && pwalletMain->mapAddressBook.count(dest))
             ret.push_back(Pair("account", pwalletMain->mapAddressBook[dest].name));
         CKeyID keyID;
-        if (pwalletMain && address.GetKeyID(keyID) && pwalletMain->mapKeyMetadata.count(keyID) && !pwalletMain->mapKeyMetadata[keyID].hdKeypath.empty())
+        CScriptID scriptID;
+        if (pwalletMain && (address.GetKeyID(keyID) || (address.GetScriptID(scriptID) && GetWitnessKeyID(pwalletMain, scriptID, keyID))) && pwalletMain->mapKeyMetadata.count(keyID) && !pwalletMain->mapKeyMetadata[keyID].hdKeypath.empty())
         {
             ret.push_back(Pair("hdkeypath", pwalletMain->mapKeyMetadata[keyID].hdKeypath));
             ret.push_back(Pair("hdmasterkeyid", pwalletMain->mapKeyMetadata[keyID].hdMasterKeyID.GetHex()));

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -251,7 +251,8 @@ CScript _createmultisig_redeemScript(const UniValue& params)
         if (pwalletMain && address.IsValid())
         {
             CKeyID keyID;
-            if (!address.GetKeyID(keyID))
+            CScriptID scriptID;
+            if (!address.GetKeyID(keyID) && (!address.GetScriptID(scriptID) || !GetWitnessKeyID(pwalletMain, scriptID, keyID)))
                 throw runtime_error(
                     strprintf("%s does not refer to a key",ks));
             CPubKey vchPubKey;

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -542,8 +542,11 @@ UniValue dumpprivkey(const JSONRPCRequest& request)
     if (!address.SetString(strAddress))
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid Bitcoin address");
     CKeyID keyID;
-    if (!address.GetKeyID(keyID))
+    CScriptID scriptID;
+    if ((!address.GetScriptID(scriptID) || !GetWitnessKeyID(pwalletMain, scriptID, keyID)) &&
+        !address.GetKeyID(keyID)) {
         throw JSONRPCError(RPC_TYPE_ERROR, "Address does not refer to a key");
+    }
     CKey vchSecret;
     if (!pwalletMain->GetKey(keyID, vchSecret))
         throw JSONRPCError(RPC_WALLET_ERROR, "Private key for address " + strAddress + " is not known");

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -520,7 +520,8 @@ UniValue signmessage(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_TYPE_ERROR, "Invalid address");
 
     CKeyID keyID;
-    if (!addr.GetKeyID(keyID))
+    CScriptID scriptID;
+    if (!addr.GetKeyID(keyID) && (!addr.GetScriptID(scriptID) || !GetWitnessKeyID(pwalletMain, scriptID, keyID)))
         throw JSONRPCError(RPC_TYPE_ERROR, "Address does not refer to key");
 
     CKey key;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3740,3 +3740,17 @@ bool CMerkleTx::AcceptToMemoryPool(const CAmount& nAbsurdFee, CValidationState& 
 {
     return ::AcceptToMemoryPool(mempool, state, *this, true, NULL, false, nAbsurdFee);
 }
+
+bool GetWitnessKeyID(const CKeyStore* store, const CScriptID &scriptID, CKeyID &keyID)
+{
+    CScript subscript;
+    int witnessVer = 0;
+    std::vector<unsigned char> witnessProgram;
+    if (!store->GetCScript(scriptID, subscript) ||
+        !subscript.IsWitnessProgram(witnessVer, witnessProgram) ||
+        witnessProgram.size() != 20) {
+        return false;
+    }
+    keyID = CKeyID(uint160(witnessProgram));
+    return true;
+}

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -993,4 +993,7 @@ public:
     }
 };
 
+// Retrieves the witness program keyhash from p2sh scriptID with help of keystore
+bool GetWitnessKeyID(const CKeyStore* store, const CScriptID &scriptID, CKeyID &keyID);
+
 #endif // BITCOIN_WALLET_WALLET_H


### PR DESCRIPTION
A followup to https://github.com/bitcoin/bitcoin/pull/8992 which includes a number of additional changes.

The only addition of data to wallets is done in importprivkey with the normal `IsWitnessEnabled` and `-prematurewalletwitness` gating.

I can write up tests for these if I get concept ACKs. 

I wrote and manually tested these by turning on p2sh-p2wpkh by default via getnewaddress, and seeing what failed. Rest of failures seem to involve `no-witness-yet` and related sigop counting errors.
