### PR TITLE
Add logging to bitcoin-util-test.py

### DIFF
--- a/src/test/bitcoin-util-test.py
+++ b/src/test/bitcoin-util-test.py
@@ -4,9 +4,11 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 from __future__ import division,print_function,unicode_literals
 import os
+import sys
 import bctest
 import buildenv
 import argparse
+import logging
 
 help_text="""Test framework for bitcoin utils.
 
@@ -19,9 +21,9 @@ test/bitcoin-util-test.py --src=[srcdir]
 
 
 if __name__ == '__main__':
-    verbose = False
     try:
         srcdir = os.environ["srcdir"]
+        verbose = False
     except:
         parser = argparse.ArgumentParser(description=help_text)
         parser.add_argument('-s', '--srcdir')
@@ -29,4 +31,13 @@ if __name__ == '__main__':
         args = parser.parse_args()
         srcdir = args.srcdir
         verbose = args.verbose
-    bctest.bctester(srcdir + "/test/data", "bitcoin-util-test.json", buildenv, verbose = verbose)
+
+    if verbose:
+        level = logging.DEBUG
+    else:
+        level = logging.ERROR
+    formatter = '%(asctime)s - %(levelname)s - %(message)s'
+    # Add the format/level to the logger
+    logging.basicConfig(format = formatter, level=level)
+
+    bctest.bctester(srcdir + "/test/data", "bitcoin-util-test.json", buildenv)


### PR DESCRIPTION
- Use the python standard logging library
- Run all tests and report all failing test-cases (rather than stop after one test case fails)
- If output is different from expected output, log a contextual diff.
