### PR TITLE
wallet: Change default confirm target from 2 to 6

### DIFF
--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -53,7 +53,7 @@ static const bool DEFAULT_SPEND_ZEROCONF_CHANGE = true;
 //! Default for -sendfreetransactions
 static const bool DEFAULT_SEND_FREE_TRANSACTIONS = false;
 //! -txconfirmtarget default
-static const unsigned int DEFAULT_TX_CONFIRM_TARGET = 2;
+static const unsigned int DEFAULT_TX_CONFIRM_TARGET = 6;
 //! -walletrbf default
 static const bool DEFAULT_WALLET_RBF = false;
 //! Largest (in bytes) free transaction we're willing to create


### PR DESCRIPTION
Recent discussion (in IRC meetings, and e.g. #8989) has shown a preference for the default confirm target for smartfees to be 6 instead of 2, to avoid overpaying fees for questionable gain.

6 is also a compromise between the GUI's pre-#8989 value of 25 and the bitcoind `-txconfirmtarget` default of 2. These were unified in #8989, but this has made the (overly expensive) default of 2 as GUI default.

(needs mention in 0.14 release notes)
