### PR TITLE
[rpc] ParseHash: Fail when length is not 64

### DIFF
--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -147,6 +147,8 @@ uint256 ParseHashV(const UniValue& v, string strName)
         strHex = v.get_str();
     if (!IsHex(strHex)) // Note: IsHex("") is false
         throw JSONRPCError(RPC_INVALID_PARAMETER, strName+" must be hexadecimal string (not '"+strHex+"')");
+    if (64 != strHex.length())
+        throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("%s must be of length %d (not %d)", strName, 64, strHex.length()));
     uint256 result;
     result.SetHex(strHex);
     return result;


### PR DESCRIPTION
There have been a few complaints such as  #9040... Maybe this helps to debug them further.

Of course this also makes it impossible to discard the "leading" zeros:

Before:

```
> getrawtransaction f3fe5b5c0024dbb1030edd720fc1effc306a054da5a507903e8cb5663336
< 01000000014f7...
```

After:

```
> getrawtransaction f3fe5b5c0024dbb1030edd720fc1effc306a054da5a507903e8cb5663336
< parameter 1 must be of length 64 (not 60) (code -8)
```
