### PR TITLE
Hash P2P messages as they are received instead of at process-time

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6350,7 +6350,7 @@ bool ProcessMessages(CNode* pfrom, CConnman& connman)
 
         // Checksum
         CDataStream& vRecv = msg.vRecv;
-        uint256 hash = Hash(vRecv.begin(), vRecv.begin() + nMessageSize);
+        const uint256& hash = msg.GetMessageHash();
         if (memcmp(hash.begin(), hdr.pchChecksum, CMessageHeader::CHECKSUM_SIZE) != 0)
         {
             LogPrintf("%s(%s, %u bytes): CHECKSUM ERROR expected %s was %s\n", __func__,

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -758,10 +758,19 @@ int CNetMessage::readData(const char *pch, unsigned int nBytes)
         vRecv.resize(std::min(hdr.nMessageSize, nDataPos + nCopy + 256 * 1024));
     }
 
+    hasher.Write((const unsigned char*)pch, nCopy);
     memcpy(&vRecv[nDataPos], pch, nCopy);
     nDataPos += nCopy;
 
     return nCopy;
+}
+
+const uint256& CNetMessage::GetMessageHash() const
+{
+    assert(complete());
+    if (data_hash.IsNull())
+        hasher.Finalize(data_hash.begin());
+    return data_hash;
 }
 
 

--- a/src/net.h
+++ b/src/net.h
@@ -512,6 +512,9 @@ public:
 
 
 class CNetMessage {
+private:
+    mutable CHash256 hasher;
+    mutable uint256 data_hash;
 public:
     bool in_data;                   // parsing header (false) or data (true)
 
@@ -538,6 +541,8 @@ public:
             return false;
         return (hdr.nMessageSize == nDataPos);
     }
+
+    const uint256& GetMessageHash() const;
 
     void SetVersion(int nVersionIn)
     {


### PR DESCRIPTION
Better to hash as you receive bytes from the wire so that you reduce latency when you have the full message, arguably. If anything else probably best to not do the hashing in the message processing thread.
