### PR TITLE
Skip processing of cmpctblocks we have previously downloaded.

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1786,14 +1786,15 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         assert(pindex);
         UpdateBlockAvailability(pfrom->GetId(), pindex->GetBlockHash());
 
+        if (pindex->nTx > 0) {
+            LogPrint("block", "block %s (%d) previously downloaded peer=%d\n", pindex->GetBlockHash().ToString(), pindex->nHeight, pfrom->id);
+            return true;
+        }
+
         std::map<uint256, pair<NodeId, list<QueuedBlock>::iterator> >::iterator blockInFlightIt = mapBlocksInFlight.find(pindex->GetBlockHash());
         bool fAlreadyInFlight = blockInFlightIt != mapBlocksInFlight.end();
 
-        if (pindex->nStatus & BLOCK_HAVE_DATA) // Nothing to do here
-            return true;
-
-        if (pindex->nChainWork <= chainActive.Tip()->nChainWork || // We know something better
-                pindex->nTx != 0) { // We had this block at some point, but pruned it
+        if (pindex->nChainWork <= chainActive.Tip()->nChainWork) { // We know something better
             if (fAlreadyInFlight) {
                 // We requested this block for some reason, but our mempool will probably be useless
                 // so we just grab the block via normal getdata


### PR DESCRIPTION
A slight optimization. Firstly, no need to process cmpctblocks for blocks that have been previously downloaded and pruned. Secondly, no need to lookup the InFlight table until after this check.