### PR TITLE
trivial: fix bloom filter init to isEmpty = true

### DIFF
--- a/src/bloom.cpp
+++ b/src/bloom.cpp
@@ -34,7 +34,7 @@ CBloomFilter::CBloomFilter(unsigned int nElements, double nFPRate, unsigned int 
      * See https://en.wikipedia.org/wiki/Bloom_filter for an explanation of these formulas
      */
     isFull(false),
-    isEmpty(false),
+    isEmpty(true),
     nHashFuncs(min((unsigned int)(vData.size() * 8 / nElements * LN2), MAX_HASH_FUNCS)),
     nTweak(nTweakIn),
     nFlags(nFlagsIn)


### PR DESCRIPTION
Fixes newly initialized bloom filters being constructed with `isEmpty(false)`, which still _works_ but loses the possible speedup when checking for key membership in an empty filter.