### PR TITLE
(WIP) Add -logtimemillis command line option

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -439,6 +439,7 @@ std::string HelpMessage(HelpMessageMode mode)
     if (showDebug)
     {
         strUsage += HelpMessageOpt("-logtimemicros", strprintf("Add microsecond precision to debug timestamps (default: %u)", DEFAULT_LOGTIMEMICROS));
+        strUsage += HelpMessageOpt("-logtimemillis", strprintf("Add millisecond precision to debug timestamps (default: %u)", DEFAULT_LOGTIMEMILLIS));
         strUsage += HelpMessageOpt("-mocktime=<n>", "Replace actual time with <n> seconds since epoch (default: 0)");
         strUsage += HelpMessageOpt("-limitfreerelay=<n>", strprintf("Continuously rate-limit free transactions to <n>*1000 bytes per minute (default: %u)", DEFAULT_LIMITFREERELAY));
         strUsage += HelpMessageOpt("-relaypriority", strprintf("Require high priority for relaying free or low-fee transactions (default: %u)", DEFAULT_RELAYPRIORITY));
@@ -782,6 +783,7 @@ void InitLogging()
     fPrintToConsole = GetBoolArg("-printtoconsole", false);
     fLogTimestamps = GetBoolArg("-logtimestamps", DEFAULT_LOGTIMESTAMPS);
     fLogTimeMicros = GetBoolArg("-logtimemicros", DEFAULT_LOGTIMEMICROS);
+    fLogTimeMillis = GetBoolArg("-logtimemillis", DEFAULT_LOGTIMEMILLIS);
     fLogIPs = GetBoolArg("-logips", DEFAULT_LOGIPS);
 
     LogPrintf("\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n");

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -438,7 +438,6 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-logtimestamps", strprintf(_("Prepend debug output with timestamp (default: %u)"), DEFAULT_LOGTIMESTAMPS));
     if (showDebug)
     {
-        strUsage += HelpMessageOpt("-logtimemicros", strprintf("Add microsecond precision to debug timestamps (default: %u)", DEFAULT_LOGTIMEMICROS));
         strUsage += HelpMessageOpt("-logtimemillis", strprintf("Add millisecond precision to debug timestamps (default: %u)", DEFAULT_LOGTIMEMILLIS));
         strUsage += HelpMessageOpt("-mocktime=<n>", "Replace actual time with <n> seconds since epoch (default: 0)");
         strUsage += HelpMessageOpt("-limitfreerelay=<n>", strprintf("Continuously rate-limit free transactions to <n>*1000 bytes per minute (default: %u)", DEFAULT_LIMITFREERELAY));
@@ -782,8 +781,8 @@ void InitLogging()
 {
     fPrintToConsole = GetBoolArg("-printtoconsole", false);
     fLogTimestamps = GetBoolArg("-logtimestamps", DEFAULT_LOGTIMESTAMPS);
-    fLogTimeMicros = GetBoolArg("-logtimemicros", DEFAULT_LOGTIMEMICROS);
     fLogTimeMillis = GetBoolArg("-logtimemillis", DEFAULT_LOGTIMEMILLIS);
+    fLogTimeMillis |= GetBoolArg("-logtimemicros", DEFAULT_LOGTIMEMILLIS); // for backwards compatibility
     fLogIPs = GetBoolArg("-logips", DEFAULT_LOGIPS);
 
     LogPrintf("\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n");

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -110,7 +110,6 @@ bool fPrintToDebugLog = true;
 bool fServer = false;
 string strMiscWarning;
 bool fLogTimestamps = DEFAULT_LOGTIMESTAMPS;
-bool fLogTimeMicros = DEFAULT_LOGTIMEMICROS;
 bool fLogTimeMillis = DEFAULT_LOGTIMEMILLIS;
 bool fLogIPs = DEFAULT_LOGIPS;
 std::atomic<bool> fReopenDebugLog(false);
@@ -270,9 +269,7 @@ static std::string LogTimestampStr(const std::string &str, bool *fStartedNewLine
     if (*fStartedNewLine) {
         int64_t nTimeMicros = GetLogTimeMicros();
         strStamped = DateTimeStrFormat("%Y-%m-%d %H:%M:%S", nTimeMicros/1000000);
-        if (fLogTimeMicros)
-            strStamped += strprintf(".%06d", nTimeMicros%1000000);
-        else if (fLogTimeMillis)
+        if (fLogTimeMillis)
             strStamped += strprintf(".%03d", (nTimeMicros/1000)%1000);
         strStamped += ' ' + str;
     } else

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -111,6 +111,7 @@ bool fServer = false;
 string strMiscWarning;
 bool fLogTimestamps = DEFAULT_LOGTIMESTAMPS;
 bool fLogTimeMicros = DEFAULT_LOGTIMEMICROS;
+bool fLogTimeMillis = DEFAULT_LOGTIMEMILLIS;
 bool fLogIPs = DEFAULT_LOGIPS;
 std::atomic<bool> fReopenDebugLog(false);
 CTranslationInterface translationInterface;
@@ -271,6 +272,8 @@ static std::string LogTimestampStr(const std::string &str, bool *fStartedNewLine
         strStamped = DateTimeStrFormat("%Y-%m-%d %H:%M:%S", nTimeMicros/1000000);
         if (fLogTimeMicros)
             strStamped += strprintf(".%06d", nTimeMicros%1000000);
+        else if (fLogTimeMillis)
+            strStamped += strprintf(".%03d", (nTimeMicros/1000)%1000);
         strStamped += ' ' + str;
     } else
         strStamped = str;

--- a/src/util.h
+++ b/src/util.h
@@ -30,6 +30,7 @@
 #include <boost/thread/exceptions.hpp>
 
 static const bool DEFAULT_LOGTIMEMICROS = false;
+static const bool DEFAULT_LOGTIMEMILLIS = false;
 static const bool DEFAULT_LOGIPS        = false;
 static const bool DEFAULT_LOGTIMESTAMPS = true;
 
@@ -50,6 +51,7 @@ extern bool fServer;
 extern std::string strMiscWarning;
 extern bool fLogTimestamps;
 extern bool fLogTimeMicros;
+extern bool fLogTimeMillis;
 extern bool fLogIPs;
 extern std::atomic<bool> fReopenDebugLog;
 extern CTranslationInterface translationInterface;

--- a/src/util.h
+++ b/src/util.h
@@ -29,7 +29,6 @@
 #include <boost/signals2/signal.hpp>
 #include <boost/thread/exceptions.hpp>
 
-static const bool DEFAULT_LOGTIMEMICROS = false;
 static const bool DEFAULT_LOGTIMEMILLIS = false;
 static const bool DEFAULT_LOGIPS        = false;
 static const bool DEFAULT_LOGTIMESTAMPS = true;
@@ -50,7 +49,6 @@ extern bool fPrintToDebugLog;
 extern bool fServer;
 extern std::string strMiscWarning;
 extern bool fLogTimestamps;
-extern bool fLogTimeMicros;
 extern bool fLogTimeMillis;
 extern bool fLogIPs;
 extern std::atomic<bool> fReopenDebugLog;


### PR DESCRIPTION
I find micros are too granular, with no line ever being less than 1 millisecond apart from its neighbouring lines, therefore this option will save 3 bytes per line of debug.log :)