### PR TITLE
tests: Remove variable unused after refactoring

### DIFF
--- a/src/test/mempool_tests.cpp
+++ b/src/test/mempool_tests.cpp
@@ -547,7 +547,6 @@ BOOST_AUTO_TEST_CASE(MempoolSizeLimitTest)
     pool.addUnchecked(tx7.GetHash(), entry.Fee(9000LL).FromTx(tx7, &pool));
 
     std::vector<CTransaction> vtx;
-    std::vector<std::shared_ptr<const CTransaction>> conflicts;
     SetMockTime(42);
     SetMockTime(42 + CTxMemPool::ROLLING_FEE_HALFLIFE);
     BOOST_CHECK_EQUAL(pool.GetMinFee(1).GetFeePerK(), maxFeeRateRemoved.GetFeePerK() + 1000);


### PR DESCRIPTION
Remove a variable that is now unused after the recent refactoring.  It was cleaned up in 51f278329d43398428d60f5986f8d29a2041d28d, but then added back (presumably by accident) in 4100499db4e886d7a9ad2dcf4007ce44fb2c1a62.