### PR TITLE
Declare wallet.h functions inline

### DIFF
--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -134,7 +134,7 @@ struct CRecipient
 typedef std::map<std::string, std::string> mapValue_t;
 
 
-static void ReadOrderPos(int64_t& nOrderPos, mapValue_t& mapValue)
+static inline void ReadOrderPos(int64_t& nOrderPos, mapValue_t& mapValue)
 {
     if (!mapValue.count("n"))
     {
@@ -145,7 +145,7 @@ static void ReadOrderPos(int64_t& nOrderPos, mapValue_t& mapValue)
 }
 
 
-static void WriteOrderPos(const int64_t& nOrderPos, mapValue_t& mapValue)
+static inline void WriteOrderPos(const int64_t& nOrderPos, mapValue_t& mapValue)
 {
     if (nOrderPos == -1)
         return;


### PR DESCRIPTION
As pointed out by @paveljanik in #9039, the function whose definition is in wallet/wallet.h should be declared inline, and clang warns about this. Do what it says.