### PR TITLE
[qa] Increase wallet-dump RPC timeout

### DIFF
--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -341,7 +341,7 @@ def start_node(i, dirname, extra_args=None, rpchost=None, timewait=None, binary=
 
     return proxy
 
-def start_nodes(num_nodes, dirname, extra_args=None, rpchost=None, binary=None):
+def start_nodes(num_nodes, dirname, extra_args=None, rpchost=None, timewait=None, binary=None):
     """
     Start multiple bitcoinds, return RPC connections to them
     """
@@ -350,7 +350,7 @@ def start_nodes(num_nodes, dirname, extra_args=None, rpchost=None, binary=None):
     rpcs = []
     try:
         for i in range(num_nodes):
-            rpcs.append(start_node(i, dirname, extra_args[i], rpchost, binary=binary[i]))
+            rpcs.append(start_node(i, dirname, extra_args[i], rpchost, timewait=timewait, binary=binary[i]))
     except: # If one node failed to start, stop the others
         stop_nodes(rpcs)
         raise

--- a/qa/rpc-tests/wallet-dump.py
+++ b/qa/rpc-tests/wallet-dump.py
@@ -61,7 +61,11 @@ class WalletDumpTest(BitcoinTestFramework):
         self.extra_args = [["-keypool=90"]]
 
     def setup_network(self, split=False):
-        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, self.extra_args)
+        # Use 1 minute timeout because the initial getnewaddress RPC can take
+        # longer than the default 30 seconds due to an expensive
+        # CWallet::TopUpKeyPool call, and the encryptwallet RPC made later in
+        # the test often takes even longer.
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, self.extra_args, timewait=60)
 
     def run_test (self):
         tmpdir = self.options.tmpdir


### PR DESCRIPTION
Increase wallet-dump RPC timeout from 30 seconds to 15 minutes. 15 minutes was
chosen because it's the same timeout used by the pruning test. This avoids a
timeout error that seemed to happen regularly (around 50% of builds) on a
particular jenkins server during the first getnewaddress RPC call made by the
test.