### PR TITLE
Enforcing consistency, 'gitian' to 'Gitian'

### DIFF
--- a/contrib/README.md
+++ b/contrib/README.md
@@ -38,7 +38,7 @@ Scripts and notes for Mac builds.
 RPM spec file for building bitcoin-core on RPM based distributions
 
 ### [Gitian-build](/contrib/gitian-build.sh) ###
-Script for running full gitian builds.
+Script for running full Gitian builds.
 
 Test and Verify Tools 
 ---------------------


### PR DESCRIPTION
There was once instance of 'gitian'. I changed it to 'Gitian' so that it would be consistent with all other instances in the file.