### PR TITLE
Optimize sending of getheaders when pindexLast is an ancestor of pindexBestHeader

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2047,10 +2047,39 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
 
         if (nCount == MAX_HEADERS_RESULTS) {
             // Headers message had its maximum size; the peer may have more headers.
-            // TODO: optimize: if pindexLast is an ancestor of chainActive.Tip or pindexBestHeader, continue
-            // from there instead.
-            LogPrint("net", "more getheaders (%d) to end to peer=%d (startheight:%d)\n", pindexLast->nHeight, pfrom->id, pfrom->nStartingHeight);
-            connman.PushMessage(pfrom, msgMaker.Make(NetMsgType::GETHEADERS, chainActive.GetLocator(pindexLast), uint256()));
+            //
+            // Optimize where to fetch the next headers from. Places the last header could be;-
+            // 1 - neither an ancestor of chainActive.Tip() nor BestHeader. fetch from pindexLast
+            // 2 - ancestor of chainActive.Tip() and BestHeader. fetch from BestHeader
+            // 3 - ancestor of BestHeader not chainActive.Tip(). Tip is an ancestor of BestHeader
+            //     fetch from BestHeader
+            // 4 - ancestor of chainActive.Tip and BestHeader. Tip is forked from BestHeader
+            //     fetch from the point where tip forks from BestHeader (since we don't know which fork
+            //     the other peer is following but can nevertheless assume they don't fork before our fork).
+            // 5 - ancestor of BestHeader not chainActive.Tip(). Tip is forked from BestHeader.
+            //     fetch from pindexLast (not BestHeader, given the unusual circumstances)
+            // 6 - ancestor of chainActive.Tip not BestHeader. Tip is forked from BestHeader.
+            //     fetch from pindexLast (not Tip, given the unusual circumstances)
+
+            CBlockIndex *pindexContinue = pindexLast;
+            std::string strDesc;
+            if (LastCommonAncestor(pindexLast, pindexBestHeader) == pindexLast) {
+                // received header is an ancestor of pindexBestHeader (cases 2, 3, 4, 5)
+                CBlockIndex *pindexFork = LastCommonAncestor(pindexBestHeader, chainActive.Tip());
+                if (pindexFork == chainActive.Tip()) {
+                    // Our current tip is an ancestor of pindexBestHeader
+                    pindexContinue = pindexBestHeader; // cases 2, 3
+                    if (pindexLast != pindexBestHeader)
+                        strDesc += "best: ";
+                } else if (LastCommonAncestor(pindexFork, pindexLast) == pindexLast) {
+                    // received header is an ancestor of where the tip and BestHeader diverges
+                    pindexContinue = pindexFork; // case 4
+                    strDesc += "fork: ";
+                }
+            }
+
+            LogPrint("net", "more getheaders (%s%d) to end to peer=%d (startheight:%d)\n", strDesc, pindexContinue->nHeight, pfrom->id, pfrom->nStartingHeight);
+            connman.PushMessage(pfrom, msgMaker.Make(NetMsgType::GETHEADERS, chainActive.GetLocator(pindexContinue), uint256()));
         }
 
         bool fCanDirectFetch = CanDirectFetch(chainparams.GetConsensus());


### PR DESCRIPTION
This has been a TODO since #4468

Comments in the code to make it (hopefully) understandable.

Please review/test. Thank you.

This is possibly still work in progress... needing to understand GetLocator in more detail, it may be that the best two options are to GetLocator(chainActive.Tip()) or GetLocator(pindexBestHeader). I'm also not assuming that chainActive.Tip() isn't always an ancestor of pindexBestHeader (based on the "TODO: optimize" comment that was made in #4468).