### PR TITLE
[qa] Rework sync_* and preciousblock.py

### DIFF
--- a/qa/rpc-tests/preciousblock.py
+++ b/qa/rpc-tests/preciousblock.py
@@ -8,7 +8,12 @@
 #
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+from test_framework.util import (
+    assert_equal,
+    connect_nodes_bi,
+    sync_chain,
+    sync_blocks,
+)
 
 def unidirectional_node_sync_via_rpc(node_src, node_dest):
     blocks_to_copy = []
@@ -33,84 +38,82 @@ def node_sync_via_rpc(nodes):
             unidirectional_node_sync_via_rpc(node_src, node_dest)
 
 class PreciousTest(BitcoinTestFramework):
-    def setup_chain(self):
-        print("Initializing test directory "+self.options.tmpdir)
-        initialize_chain_clean(self.options.tmpdir, 3)
+    def __init__(self):
+        super().__init__()
+        self.setup_clean_chain = True
+        self.num_nodes = 3
+        self.extra_args = [["-debug"]] * self.num_nodes
 
     def setup_network(self):
-        self.nodes = []
-        self.is_network_split = False
-        self.nodes.append(start_node(0, self.options.tmpdir, ["-debug"]))
-        self.nodes.append(start_node(1, self.options.tmpdir, ["-debug"]))
-        self.nodes.append(start_node(2, self.options.tmpdir, ["-debug"]))
+        self.nodes = self.setup_nodes()
 
     def run_test(self):
         print("Ensure submitblock can in principle reorg to a competing chain")
         self.nodes[0].generate(1)
-        assert(self.nodes[0].getblockcount() == 1)
+        assert_equal(self.nodes[0].getblockcount(), 1)
         (hashY, hashZ) = self.nodes[1].generate(2)
-        assert(self.nodes[1].getblockcount() == 2)
+        assert_equal(self.nodes[1].getblockcount(), 2)
         node_sync_via_rpc(self.nodes[0:3])
-        assert(self.nodes[0].getbestblockhash() == hashZ)
+        assert_equal(self.nodes[0].getbestblockhash(), hashZ)
 
         print("Mine blocks A-B-C on Node 0")
         (hashA, hashB, hashC) = self.nodes[0].generate(3)
-        assert(self.nodes[0].getblockcount() == 5)
+        assert_equal(self.nodes[0].getblockcount(), 5)
         print("Mine competing blocks E-F-G on Node 1")
         (hashE, hashF, hashG) = self.nodes[1].generate(3)
-        assert(self.nodes[1].getblockcount() == 5)
+        assert_equal(self.nodes[1].getblockcount(), 5)
         assert(hashC != hashG)
         print("Connect nodes and check no reorg occurs")
         # Submit competing blocks via RPC so any reorg should occur before we proceed (no way to wait on inaction for p2p sync)
         node_sync_via_rpc(self.nodes[0:2])
         connect_nodes_bi(self.nodes,0,1)
-        assert(self.nodes[0].getbestblockhash() == hashC)
-        assert(self.nodes[1].getbestblockhash() == hashG)
+        assert_equal(self.nodes[0].getbestblockhash(), hashC)
+        assert_equal(self.nodes[1].getbestblockhash(), hashG)
         print("Make Node0 prefer block G")
         self.nodes[0].preciousblock(hashG)
-        assert(self.nodes[0].getbestblockhash() == hashG)
+        assert_equal(self.nodes[0].getbestblockhash(), hashG)
         print("Make Node0 prefer block C again")
         self.nodes[0].preciousblock(hashC)
-        assert(self.nodes[0].getbestblockhash() == hashC)
+        assert_equal(self.nodes[0].getbestblockhash(), hashC)
         print("Make Node1 prefer block C")
         self.nodes[1].preciousblock(hashC)
         sync_chain(self.nodes[0:2]) # wait because node 1 may not have downloaded hashC
-        assert(self.nodes[1].getbestblockhash() == hashC)
+        assert_equal(self.nodes[1].getbestblockhash(), hashC)
         print("Make Node1 prefer block G again")
         self.nodes[1].preciousblock(hashG)
-        assert(self.nodes[1].getbestblockhash() == hashG)
+        assert_equal(self.nodes[1].getbestblockhash(), hashG)
         print("Make Node0 prefer block G again")
         self.nodes[0].preciousblock(hashG)
-        assert(self.nodes[0].getbestblockhash() == hashG)
+        assert_equal(self.nodes[0].getbestblockhash(), hashG)
         print("Make Node1 prefer block C again")
         self.nodes[1].preciousblock(hashC)
-        assert(self.nodes[1].getbestblockhash() == hashC)
+        assert_equal(self.nodes[1].getbestblockhash(), hashC)
         print("Mine another block (E-F-G-)H on Node 0 and reorg Node 1")
         self.nodes[0].generate(1)
-        assert(self.nodes[0].getblockcount() == 6)
+        assert_equal(self.nodes[0].getblockcount(), 6)
         sync_blocks(self.nodes[0:2])
         hashH = self.nodes[0].getbestblockhash()
-        assert(self.nodes[1].getbestblockhash() == hashH)
+        assert_equal(self.nodes[1].getbestblockhash(), hashH)
         print("Node1 should not be able to prefer block C anymore")
         self.nodes[1].preciousblock(hashC)
-        assert(self.nodes[1].getbestblockhash() == hashH)
+        assert_equal(self.nodes[1].getbestblockhash(), hashH)
         print("Mine competing blocks I-J-K-L on Node 2")
         self.nodes[2].generate(4)
-        assert(self.nodes[2].getblockcount() == 6)
+        assert_equal(self.nodes[2].getblockcount(), 6)
         hashL = self.nodes[2].getbestblockhash()
         print("Connect nodes and check no reorg occurs")
         node_sync_via_rpc(self.nodes[0:3])
         connect_nodes_bi(self.nodes,1,2)
         connect_nodes_bi(self.nodes,0,2)
-        assert(self.nodes[0].getbestblockhash() == hashH)
-        assert(self.nodes[1].getbestblockhash() == hashH)
-        assert(self.nodes[2].getbestblockhash() == hashL)
+        assert_equal(self.nodes[0].getbestblockhash(), hashH)
+        assert_equal(self.nodes[1].getbestblockhash(), hashH)
+        assert_equal(self.nodes[2].getbestblockhash(), hashL)
         print("Make Node1 prefer block L")
         self.nodes[1].preciousblock(hashL)
-        assert(self.nodes[1].getbestblockhash() == hashL)
+        assert_equal(self.nodes[1].getbestblockhash(), hashL)
         print("Make Node2 prefer block H")
         self.nodes[2].preciousblock(hashH)
-        assert(self.nodes[2].getbestblockhash() == hashH)
+        assert_equal(self.nodes[2].getbestblockhash(), hashH)
 
 if __name__ == '__main__':
     PreciousTest().main()

--- a/qa/rpc-tests/smartfees.py
+++ b/qa/rpc-tests/smartfees.py
@@ -225,9 +225,9 @@ class EstimateFeeTest(BitcoinTestFramework):
                                                       self.memutxo, Decimal("0.005"), min_fee, min_fee)
                 tx_kbytes = (len(txhex) // 2) / 1000.0
                 self.fees_per_kb.append(float(fee)/tx_kbytes)
-            sync_mempools(self.nodes[0:3],.1)
+            sync_mempools(self.nodes[0:3], wait=.1)
             mined = mining_node.getblock(mining_node.generate(1)[0],True)["tx"]
-            sync_blocks(self.nodes[0:3],.1)
+            sync_blocks(self.nodes[0:3], wait=.1)
             # update which txouts are confirmed
             newmem = []
             for utx in self.memutxo:
@@ -259,7 +259,7 @@ class EstimateFeeTest(BitcoinTestFramework):
         while len(self.nodes[1].getrawmempool()) > 0:
             self.nodes[1].generate(1)
 
-        sync_blocks(self.nodes[0:3],.1)
+        sync_blocks(self.nodes[0:3], wait=.1)
         print("Final estimates after emptying mempools")
         check_estimates(self.nodes[1], self.fees_per_kb, 2)
 

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -121,33 +121,35 @@ def hex_str_to_bytes(hex_str):
 def str_to_b64str(string):
     return b64encode(string.encode('utf-8')).decode('ascii')
 
-def sync_blocks(rpc_connections, wait=1, timeout=60):
+def sync_blocks(rpc_connections, *, wait=1, timeout=60):
     """
     Wait until everybody has the same tip
     """
     maxheight = 0
     while timeout > 0:
-        tips = [ x.waitforblockheight(maxheight, int(wait * 1000)) for x in rpc_connections ]
-        heights = [ x["height"] for x in tips ]
-        if tips == [ tips[0] ]*len(tips):
-            return True
-        if heights == [ heights[0] ]*len(heights): #heights are the same but hashes are not
-            raise AssertionError("Block sync failed")
+        tips = [r.waitforblockheight(maxheight, int(wait * 1000)) for r in rpc_connections]
+        heights = [t["height"] for t in tips]
+        if tips == [tips[0]] * len(tips):
+            return
+        if heights == [heights[0]] * len(heights):
+            raise AssertionError("Block sync failed: (Hashes don't match)")
         timeout -= wait
         maxheight = max(heights)
-    raise AssertionError("Block sync failed")
+    raise AssertionError("Block sync failed with heights: {}".format(heights))
 
-def sync_chain(rpc_connections, wait=1):
+def sync_chain(rpc_connections, *, wait=1, timeout=60):
     """
     Wait until everybody has the same best block
     """
-    while True:
-        counts = [ x.getbestblockhash() for x in rpc_connections ]
-        if counts == [ counts[0] ]*len(counts):
-            break
+    while timeout > 0:
+        best_hash = [x.getbestblockhash() for x in rpc_connections]
+        if best_hash == [best_hash[0]]*len(best_hash):
+            return
         time.sleep(wait)
+        timeout -= wait
+    raise AssertionError("Chain sync failed: Best block hashes don't match")
 
-def sync_mempools(rpc_connections, wait=1, timeout=60):
+def sync_mempools(rpc_connections, *, wait=1, timeout=60):
     """
     Wait until everybody has the same transactions in their memory
     pools
@@ -159,7 +161,7 @@ def sync_mempools(rpc_connections, wait=1, timeout=60):
             if set(rpc_connections[i].getrawmempool()) == pool:
                 num_match = num_match+1
         if num_match == len(rpc_connections):
-            return True
+            return
         time.sleep(wait)
         timeout -= wait
     raise AssertionError("Mempool sync failed")


### PR DESCRIPTION
`preciousblock.py`:

* Use `assert_equal()`, so failures are more verbose
* Also some trivial refactoring

`sync_*()`:

* Only allow named args and add timeout to `sync_chain()`
* Make failures more verbose