### PR TITLE
Avoid ugly exception in log on unknown inv type

### DIFF
--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -181,7 +181,11 @@ std::string CInv::GetCommand() const
 
 std::string CInv::ToString() const
 {
-    return strprintf("%s %s", GetCommand(), hash.ToString());
+    try {
+        return strprintf("%s %s", GetCommand(), hash.ToString());
+    } catch(const std::out_of_range &) {
+        return strprintf("0x%08x %s", type, hash.ToString());
+    }
 }
 
 const std::vector<std::string> &getAllNetMessageTypes()


### PR DESCRIPTION
It is unexpected behavior for `ToString` to raise an exception. It is expected to do a best-effort attempt at formatting but never fail.

Catch the exception and simply print unknown inv types as hexadecimal.

Before:
```
************************
EXCEPTION: St12out_of_range       
CInv::GetCommand(): type=666 unknown type       
bitcoin in ProcessMessages()       
```

After:
```
2016-11-09 10:08:20 got inv: 0x0000029a 0000000000000000000000000000000000000000000000000000000000000000  have peer=1
```

Fixes #9110.