### PR TITLE
Mention reporting security issues responsibly

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -4,6 +4,8 @@ This issue tracker is only for technical issues related to bitcoin-core.
 
 General bitcoin questions and/or support requests and are best directed to the [Bitcoin StackExchange](https://bitcoin.stackexchange.com).
 
+For reporting security issues, please read instructions at [https://bitcoincore.org/en/contact/](https://bitcoincore.org/en/contact/).
+
 ### Describe the issue
 
 ### Can you reliably reproduce the issue?


### PR DESCRIPTION
Add a notice about reporting security issues responsibly to the GitHub issue template.