### PR TITLE
bug: Missed one "return false" in recent refactoring in #9067

### DIFF
--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -48,7 +48,7 @@ static int AppInitRawTx(int argc, char* argv[])
         SelectParams(ChainNameFromCommandLine());
     } catch (const std::exception& e) {
         fprintf(stderr, "Error: %s\n", e.what());
-        return false;
+        return EXIT_FAILURE;
     }
 
     fCreateBlank = GetBoolArg("-create", false);


### PR DESCRIPTION
Missed one "return false" in recent refactoring in #9067 which means that `AppInitRawTx` returns `0` in that case i.e. EXIT_SUCCESS which is wrong.
Sorry 😞 