### PR TITLE
Initialize variable to prevent compiler warning

### DIFF
--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -1017,7 +1017,7 @@ UniValue importmulti(const JSONRPCRequest& mainRequest)
 
     bool fRunScan = false;
     const int64_t minimumTimestamp = 1;
-    int64_t nLowestTimestamp;
+    int64_t nLowestTimestamp = 0;
 
     if (fRescan && chainActive.Tip()) {
         nLowestTimestamp = chainActive.Tip()->GetBlockTime();


### PR DESCRIPTION
Compiling current master with the ultimate gcc 6 (6.2.1 in my case) brings this warning. While technically useless it can hide important stuff.

```
  CXX      wallet/libbitcoin_wallet_a-rpcdump.o
wallet/rpcdump.cpp: In function 'UniValue importmulti(const JSONRPCRequest&)':
wallet/rpcdump.cpp:1020:13: warning: 'nLowestTimestamp' may be used uninitialized in this function [-Wmaybe-uninitialized]
     int64_t nLowestTimestamp;
             ^~~~~~~~~~~~~~~~
```
