### PR TITLE
fix getnettotals RPC description about timemillis.

### DIFF
--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -331,7 +331,7 @@ UniValue getnettotals(const JSONRPCRequest& request)
             "{\n"
             "  \"totalbytesrecv\": n,   (numeric) Total bytes received\n"
             "  \"totalbytessent\": n,   (numeric) Total bytes sent\n"
-            "  \"timemillis\": t,       (numeric) Total cpu time\n"
+            "  \"timemillis\": t,       (numeric) Current UNIX time in milliseconds\n"
             "  \"uploadtarget\":\n"
             "  {\n"
             "    \"timeframe\": n,                         (numeric) Length of the measuring timeframe in seconds\n"


### PR DESCRIPTION
Help message says that `timemillis` returned by `getnettotals` RPC call is "Total cpu time" but it is actually a local UNIX time returned by `GetTimeMillis()` (written in `src/utiltime.cpp`).
Fixed the help message to fit the actual value returned.
