### PR TITLE
Remove extraneous LogPrint from fee estimation

### DIFF
--- a/src/policy/fees.cpp
+++ b/src/policy/fees.cpp
@@ -284,16 +284,13 @@ void TxConfirmStats::removeTx(unsigned int entryHeight, unsigned int nBestSeenHe
 void CBlockPolicyEstimator::removeTx(uint256 hash)
 {
     std::map<uint256, TxStatsInfo>::iterator pos = mapMemPoolTxs.find(hash);
-    if (pos == mapMemPoolTxs.end()) {
-        LogPrint("estimatefee", "Blockpolicy error mempool tx %s not found for removeTx\n",
-                 hash.ToString().c_str());
-        return;
-    }
-    unsigned int entryHeight = pos->second.blockHeight;
-    unsigned int bucketIndex = pos->second.bucketIndex;
+    if (pos != mapMemPoolTxs.end()) {
+        unsigned int entryHeight = pos->second.blockHeight;
+        unsigned int bucketIndex = pos->second.bucketIndex;
 
-    feeStats.removeTx(entryHeight, nBestSeenHeight, bucketIndex);
-    mapMemPoolTxs.erase(hash);
+        feeStats.removeTx(entryHeight, nBestSeenHeight, bucketIndex);
+        mapMemPoolTxs.erase(hash);
+    }
 }
 
 CBlockPolicyEstimator::CBlockPolicyEstimator(const CFeeRate& _minRelayFee)


### PR DESCRIPTION
Once priority estimation was removed, not all transactions in the mempool are tracked in the fee estimation mempool tracking (have an entry in `mapMemPoolTxs`).  So there is no error if a transaction is not found for removal.

This will eliminate these incorrect lines from debug.log:
`2016-11-06 07:19:18.724305 Blockpolicy error mempool tx 93100e69a817a6b2034456ad3127124f63b9a89d71704ed11d584d5db5fefc54 not found for removeTx`