### PR TITLE
Use better name for local variable to prevent -Wshadow compiler warning

### DIFF
--- a/src/bench/checkblock.cpp
+++ b/src/bench/checkblock.cpp
@@ -46,8 +46,8 @@ static void DeserializeAndCheckBlockTest(benchmark::State& state)
         stream >> block;
         assert(stream.Rewind(sizeof(block_bench::block413567)));
 
-        CValidationState state;
-        assert(CheckBlock(block, state, params));
+        CValidationState validationState;
+        assert(CheckBlock(block, validationState, params));
     }
 }
 


### PR DESCRIPTION
#9049 brought new `-Wshadow` warning.

Local variable shadows the function argument. I decided to keep the function argument name to keep consistency with the rest of the file and use better/descriptive name for the local variable.
