### PR TITLE
Mention the new network toggle functionality in the tooltip.

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -713,12 +713,18 @@ void BitcoinGUI::updateNetworkState()
     default: icon = ":/icons/connect_4"; break;
     }
 
+    QString tooltip;
+
     if (clientModel->getNetworkActive()) {
-        connectionsControl->setToolTip(tr("%n active connection(s) to Bitcoin network", "", count));
+        tooltip = tr("%n active connection(s) to Bitcoin network", "", count) + QString(".<br>") + tr("Click to disable network activity.");
     } else {
-        connectionsControl->setToolTip(tr("Network activity disabled"));
+        tooltip = tr("Network activity disabled.") + QString("<br>") + tr("Click to enable network activity again.");
         icon = ":/icons/network_disabled";
     }
+
+    // Don't word-wrap this (fixed-width) tooltip
+    tooltip = QString("<nobr>") + tooltip + QString("</nobr>");
+    connectionsControl->setToolTip(tooltip);
 
     connectionsControl->setPixmap(platformStyle->SingleColorIcon(icon).pixmap(STATUSBAR_ICONSIZE,STATUSBAR_ICONSIZE));
 }


### PR DESCRIPTION
As requested by @jonasschnelli at https://github.com/bitcoin/bitcoin/pull/8996#issuecomment-259925277, add a tooltip:

<img width="304" alt="screen shot 2016-11-11 at 11 56 11" src="https://cloud.githubusercontent.com/assets/6848764/20213011/86c18000-a806-11e6-8009-cfbe647f8d3a.png">

<img width="312" alt="screen shot 2016-11-11 at 11 56 17" src="https://cloud.githubusercontent.com/assets/6848764/20213010/868f63b8-a806-11e6-818c-e5cb3956a2e9.png">
