### PR TITLE
fNetworkActive is not protected by a lock, use an atomic

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -403,7 +403,7 @@ private:
     unsigned int nReceiveFloodSize;
 
     std::vector<ListenSocket> vhListenSocket;
-    bool fNetworkActive;
+    std::atomic<bool> fNetworkActive;
     banmap_t setBanned;
     CCriticalSection cs_setBanned;
     bool setBannedIsDirty;


### PR DESCRIPTION
Reported by @sipa: https://github.com/bitcoin/bitcoin/pull/8996#discussion_r87583724