### PR TITLE
Make strWalletFile const

### DIFF
--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -600,7 +600,7 @@ public:
      */
     mutable CCriticalSection cs_wallet;
 
-    std::string strWalletFile;
+    const std::string strWalletFile;
 
     void LoadKeyPool(int nIndex, const CKeyPool &keypool)
     {
@@ -625,11 +625,9 @@ public:
         SetNull();
     }
 
-    CWallet(const std::string& strWalletFileIn)
+    CWallet(const std::string& strWalletFileIn) : strWalletFile(strWalletFileIn)
     {
         SetNull();
-
-        strWalletFile = strWalletFileIn;
         fFileBacked = true;
     }
 


### PR DESCRIPTION
While it's still possible to cast way the const-ness, It makes it harder for later changes to shoot yourself in the foot.

This also underlines the [comment](https://github.com/bitcoin/bitcoin/compare/master...jonasschnelli:2016/11/strWalletFile_const?expand=1#diff-12635a58447c65585f51d32b7e04075bR599) (`[...]strWalletFile (immutable after instantiation)`)