### PR TITLE
Unset fImporting for loading mempool

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -601,6 +601,8 @@ void ThreadImport(std::vector<boost::filesystem::path> vImportFiles)
 {
     const CChainParams& chainparams = Params();
     RenameThread("bitcoin-loadblk");
+
+    {
     CImportingNow imp;
 
     // -reindex
@@ -660,7 +662,7 @@ void ThreadImport(std::vector<boost::filesystem::path> vImportFiles)
         LogPrintf("Stopping after block import\n");
         StartShutdown();
     }
-
+    } // End scope of CImportingNow
     LoadMempool();
 }
 


### PR DESCRIPTION
LoadMempool happens in the import thread which has fImporting set to true.  This will cause the node to think its in IBD until the mempool is fully loaded.  This isn't necessary and can interfere with initial syncing.  It also breaks at least the pruning.py test.   

I can't think of any reason to want IBD to be set while loading the mempool except for the possible effect on fee estimation.  If you had a mempool dump which was in the future from your chainstate then this might lead to a detrimental effect on fee estimation, but this seems unlikely and should be fixed in another way..