### PR TITLE
WIP: Allow wallet key import RPCs to track TxOut amounts on -prune nodes (on top of #9306)

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1467,7 +1467,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
 
     // ********************************************************* Step 8: load wallet
 #ifdef ENABLE_WALLET
-    if (!CWallet::InitLoadWallet())
+    if (!CWallet::InitLoadWallet([]{ return unique_ptr<CCoinsViewCursor>(pcoinsTip->Cursor()); }))
         return false;
 #else
     LogPrintf("No wallet support compiled in!\n");

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -75,6 +75,7 @@ uint256 CTransaction::GetWitnessHash() const
 /* For backward compatibility, the hash is initialized to 0. TODO: remove the need for this default constructor entirely. */
 CTransaction::CTransaction() : nVersion(CTransaction::CURRENT_VERSION), vin(), vout(), nLockTime(0), hash() {}
 CTransaction::CTransaction(const CMutableTransaction &tx) : nVersion(tx.nVersion), vin(tx.vin), vout(tx.vout), wit(tx.wit), nLockTime(tx.nLockTime), hash(ComputeHash()) {}
+CTransaction::CTransaction(const CMutableTransaction &tx, const uint256 &hash) : nVersion(tx.nVersion), vin(tx.vin), vout(tx.vout), wit(tx.wit), nLockTime(tx.nLockTime), hash(hash) {}
 CTransaction::CTransaction(CMutableTransaction &&tx) : nVersion(tx.nVersion), vin(std::move(tx.vin)), vout(std::move(tx.vout)), wit(std::move(tx.wit)), nLockTime(tx.nLockTime), hash(ComputeHash()) {}
 
 CAmount CTransaction::GetValueOut() const

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -394,6 +394,7 @@ public:
 
     /** Convert a CMutableTransaction into a CTransaction. */
     CTransaction(const CMutableTransaction &tx);
+    CTransaction(const CMutableTransaction &tx, const uint256 &hash);
     CTransaction(CMutableTransaction &&tx);
 
     template <typename Stream>

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -971,7 +971,7 @@ bool CWallet::LoadToWallet(const CWalletTx& wtxIn)
  * pblock is optional, but should be provided if the transaction is known to be in a block.
  * If fUpdate is true, existing transactions will be updated.
  */
-bool CWallet::AddToWalletIfInvolvingMe(const CTransaction& tx, const CBlockIndex* pIndex, int posInBlock, bool fUpdate)
+bool CWallet::AddToWalletIfInvolvingMe(const CTransaction& tx, bool fIncomplete, const CBlockIndex* pIndex, int posInBlock, bool fUpdate)
 {
     {
         AssertLockHeld(cs_wallet);
@@ -994,6 +994,7 @@ bool CWallet::AddToWalletIfInvolvingMe(const CTransaction& tx, const CBlockIndex
         if (fExisted || IsMine(tx) || IsFromMe(tx))
         {
             CWalletTx wtx(this, MakeTransactionRef(tx));
+            wtx.fIncomplete = fIncomplete;
 
             // Get merkle branch if transaction was found in a block
             if (posInBlock != -1)
@@ -1126,7 +1127,7 @@ void CWallet::SyncTransaction(const CTransaction& tx, const CBlockIndex *pindex,
 {
     LOCK2(cs_main, cs_wallet);
 
-    if (!AddToWalletIfInvolvingMe(tx, pindex, posInBlock, true))
+    if (!AddToWalletIfInvolvingMe(tx, false /* fIncomplete */, pindex, posInBlock, true /* fUpdate */))
         return; // Not one of ours
 
     // If a transaction changes 'conflicted' state, that changes the balance
@@ -1492,7 +1493,7 @@ int CWallet::ScanForWalletTransactions(CBlockIndex* pindexStart, bool fUpdate)
             int posInBlock;
             for (posInBlock = 0; posInBlock < (int)block.vtx.size(); posInBlock++)
             {
-                if (AddToWalletIfInvolvingMe(*block.vtx[posInBlock], pindex, posInBlock, fUpdate))
+                if (AddToWalletIfInvolvingMe(*block.vtx[posInBlock], false /* fIncomplete */, pindex, posInBlock, fUpdate))
                     ret++;
             }
             pindex = chainActive.Next(pindex);
@@ -1504,6 +1505,24 @@ int CWallet::ScanForWalletTransactions(CBlockIndex* pindexStart, bool fUpdate)
         ShowProgress(_("Rescanning..."), 100); // hide progress dialog in GUI
     }
     return ret;
+}
+
+bool CWallet::ScanForWalletUTXOs()
+{
+    for (auto pcursor = coinsCursor(); pcursor->Valid(); pcursor->Next()) {
+        boost::this_thread::interruption_point();
+        uint256 hash;
+        CCoins coins;
+        if (pcursor->GetKey(hash) && pcursor->GetValue(coins)) {
+            CMutableTransaction mtx;
+            mtx.vout = coins.vout;
+            mtx.nVersion = coins.nVersion;
+            AddToWalletIfInvolvingMe(CTransaction(mtx, hash), true /* fIncomplete */, nullptr /* pIndex */, -1 /* posInBlock */, false /* fUpdate */);
+        } else {
+            return error("%s: unable to read value", __func__);
+        }
+    }
+    return true;
 }
 
 void CWallet::ReacceptWalletTransactions()
@@ -1532,6 +1551,10 @@ void CWallet::ReacceptWalletTransactions()
     BOOST_FOREACH(PAIRTYPE(const int64_t, CWalletTx*)& item, mapSorted)
     {
         CWalletTx& wtx = *(item.second);
+
+        // Do not send incomplete transactions that can't validate.
+        if (wtx.fIncomplete)
+            continue;
 
         LOCK(mempool.cs);
         CValidationState state;
@@ -3380,7 +3403,7 @@ std::string CWallet::GetWalletHelpString(bool showDebug)
     return strUsage;
 }
 
-bool CWallet::InitLoadWallet()
+bool CWallet::InitLoadWallet(CoinsCursorCallback coinsCursor)
 {
     if (GetBoolArg("-disablewallet", DEFAULT_DISABLE_WALLET)) {
         pwalletMain = NULL;
@@ -3411,6 +3434,7 @@ bool CWallet::InitLoadWallet()
     int64_t nStart = GetTimeMillis();
     bool fFirstRun = true;
     CWallet *walletInstance = new CWallet(walletFile);
+    walletInstance->coinsCursor = std::move(coinsCursor);
     DBErrors nLoadWalletRet = walletInstance->LoadWallet(fFirstRun);
     if (nLoadWalletRet != DB_LOAD_OK)
     {


### PR DESCRIPTION
Allow importprivkey, importaddress, importpubkey, and importmulti RPCs to be
called with rescan=True option on nodes with pruned blockchains (started with
-prune option). Instead of returning errors, the RPCs will now look for
transactions spending to the key in the UTXO database, and display them in the
wallet.

Because the UTXO database doesn't store full transaction information (it
discards TxIns) this change introduces a new "fIncomplete" CWalletTx member to
distinguish these from normal wallet transactions.

This change makes the -prune mode usable with wallets that need to import keys
after the initial sync.

Fixes #8497.