### PR TITLE
Remove unnecessary calls to CheckFinalTx

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2929,7 +2929,7 @@ std::map<CTxDestination, CAmount> CWallet::GetAddressBalances()
         {
             CWalletTx *pcoin = &walletEntry.second;
 
-            if (!CheckFinalTx(*pcoin) || !pcoin->IsTrusted())
+            if (!pcoin->IsTrusted())
                 continue;
 
             if (pcoin->IsCoinBase() && pcoin->GetBlocksToMaturity() > 0)


### PR DESCRIPTION
Tiny optimization.
`CheckFinalTx()` gets always called in `CWalletTx::IsTrusted()`.
Calling it together with `IsTrusted()` result in calling it twice.

`CheckFinalTx()` get's executed under `cs_main` (where it calls stuff like tips `GetMedianTimePast()`,  `GetAdjustedTime().