### PR TITLE
Wallet/RPC: sweepprivkeys method to scan UTXO set and send to local wallet

### DIFF
--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -71,6 +71,7 @@ const QStringList historyFilter = QStringList()
     << "signmessagewithprivkey"
     << "signrawtransaction"
     << "signrawtransactionwithkey"
+    << "sweepprivkeys"
     << "walletpassphrase"
     << "walletpassphrasechange"
     << "encryptwallet";

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -70,6 +70,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "sendmany", 6 , "conf_target" },
     { "deriveaddresses", 1, "range" },
     { "scantxoutset", 1, "scanobjects" },
+    { "sweepprivkeys", 0, "options" },
     { "addmultisigaddress", 0, "nrequired" },
     { "addmultisigaddress", 1, "keys" },
     { "createmultisig", 0, "nrequired" },

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -40,7 +40,9 @@ static const int64_t nMaxTxIndexCache = 1024;
 //! Max memory allocated to coin DB specific cache (MiB)
 static const int64_t nMaxCoinsDBCache = 8;
 
-/** CCoinsView backed by the coin database (chainstate/) */
+/** CCoinsView backed by the coin database (chainstate/)
+ * Cursor requires FlushStateToDisk for consistency.
+ */
 class CCoinsViewDB final : public CCoinsView
 {
 protected:

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -777,6 +777,20 @@ void CTxMemPool::queryHashes(std::vector<uint256>& vtxid)
     }
 }
 
+void CTxMemPool::FindScriptPubKey(const std::set<CScript>& needles, std::map<COutPoint, Coin>& out_results) {
+    LOCK(cs);
+    for (const CTxMemPoolEntry& entry : mapTx) {
+        const CTransaction& tx = entry.GetTx();
+        const uint256& hash = tx.GetHash();
+        for (size_t txo_index = tx.vout.size(); txo_index-- > 0; ) {
+            const CTxOut& txo = tx.vout[txo_index];
+            if (needles.count(txo.scriptPubKey)) {
+                out_results.emplace(COutPoint(hash, txo_index), Coin(txo, MEMPOOL_HEIGHT, false));
+            }
+        }
+    }
+}
+
 static TxMempoolInfo GetInfo(CTxMemPool::indexed_transaction_set::const_iterator it) {
     return TxMempoolInfo{it->GetSharedTx(), it->GetTime(), CFeeRate(it->GetFee(), it->GetTxSize()), it->GetModifiedFee() - it->GetFee()};
 }

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -749,6 +749,9 @@ private:
  * It also allows you to sign a double-spend directly in
  * signrawtransactionwithkey and signrawtransactionwithwallet,
  * as long as the conflicting transaction is not yet confirmed.
+ *
+ * Its Cursor also doesn't work. In general, it is broken as a CCoinsView
+ * implementation outside of a few use cases.
  */
 class CCoinsViewMemPool : public CCoinsViewBacked
 {

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -30,6 +30,7 @@
 
 class CBlockIndex;
 extern CCriticalSection cs_main;
+class CScript;
 
 /** Fake height value used in Coin to signify they are only in the memory pool (since 0.8) */
 static const uint32_t MEMPOOL_HEIGHT = 0x7FFFFFFF;
@@ -693,6 +694,8 @@ public:
     CTransactionRef get(const uint256& hash) const;
     TxMempoolInfo info(const uint256& hash) const;
     std::vector<TxMempoolInfo> infoAll() const;
+
+    void FindScriptPubKey(const std::set<CScript>& needles, std::map<COutPoint, Coin>& out_results);
 
     size_t DynamicMemoryUsage() const;
 

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -105,6 +105,7 @@ BASE_SCRIPTS = [
     'interface_zmq.py',
     'interface_bitcoin_cli.py',
     'mempool_resurrect.py',
+    'wallet_sweepprivkeys.py',
     'wallet_txn_doublespend.py --mineblock',
     'tool_wallet.py',
     'wallet_txn_clone.py',

--- a/test/functional/wallet_sweepprivkeys.py
+++ b/test/functional/wallet_sweepprivkeys.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test the sweepprivkeys RPC."""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal, assert_fee_amount
+
+class SweepPrivKeysTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 2
+
+    def check_balance(self, delta, txid):
+        node = self.nodes[0]
+        new_balance = node.getbalance('*', 0)
+        balance_change = new_balance - self.balance
+        actual_fee = delta - balance_change
+        tx_vsize = node.getrawtransaction(txid, True)['vsize']
+        assert_fee_amount(actual_fee, tx_vsize, self.tx_feerate)
+        self.balance = new_balance
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def run_test(self):
+        node = self.nodes[0]
+        miner = self.nodes[1]
+
+        keys = (
+            ('mkckmmfVv89sW1HUjyRuydGhwFmSaYtRvG', '92YkaycAxLPUqbbV78V9nNngKLnyVd9T8uZuZAzQnc26dJSP4fm'),
+            ('mw8s1FS2Vr7GwQF8bnDVUQHQZq5qWqz5kq', '93VijJgAYnVUGXAfxYhbMHVGVwQUEXK1YnPvcCod3x1RLbzUhXe'),
+        )
+
+        # This test is not meant to test fee estimation and we'd like
+        # to be sure all txs are sent at a consistent desired feerate
+        self.tx_feerate = self.nodes[0].getnetworkinfo()['relayfee'] * 2
+        node.settxfee(self.tx_feerate)
+
+        miner.generate(120)
+        self.sync_all()
+        self.balance = node.getbalance('*', 0)
+
+        txid = node.sendtoaddress(keys[0][0], 10)
+        self.check_balance(-10, txid)
+
+        # Sweep from mempool
+        txid = node.sweepprivkeys({'privkeys': (keys[0][1],), 'label': 'test 1'})
+        assert_equal(node.listtransactions()[-1]['label'], 'test 1')
+        self.check_balance(10, txid)
+
+        txid = node.sendtoaddress(keys[1][0], 5)
+        self.check_balance(-5, txid)
+        self.sync_all()
+        miner.generate(4)
+        self.sync_all()
+        assert_equal(self.balance, node.getbalance('*', 1))
+
+        # Sweep from blockchain
+        txid = node.sweepprivkeys({'privkeys': (keys[1][1],), 'label': 'test 2'})
+        assert_equal(node.listtransactions()[-1]['label'], 'test 2')
+        self.check_balance(5, txid)
+
+if __name__ == '__main__':
+    SweepPrivKeysTest().main()


### PR DESCRIPTION
Does this look like a good approach?

TODO:

* rawtransaction sweep functionality
* GUI sweep (Receive tab?)
* abstract shared sweep logic
* ~~RPC tests~~

NOTE: Currently needs #14602 for tests to pass