### PR TITLE
Add compile and link options echo to configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1126,3 +1126,28 @@ case ${OS} in
      mv qa/pull-tester/tests_config-2.py qa/pull-tester/tests_config.py
    ;;
 esac
+
+echo 
+echo "Options used to compile and link:"
+echo "  with wallet   = $enable_wallet"
+echo "  with gui / qt = $bitcoin_enable_qt"
+if test x$bitcoin_enable_qt != xno; then
+    echo "    qt version  = $bitcoin_qt_got_major_vers"
+    echo "    with qr     = $use_qr"
+fi
+echo "  with zmq      = $use_zmq"
+echo "  with test     = $use_tests"
+echo "  with bench    = $use_bench"
+echo "  with upnp     = $use_upnp"
+echo "  debug enabled = $enable_debug"
+echo 
+echo "  target os     = $TARGET_OS"
+echo "  build os      = $BUILD_OS"
+echo
+echo "  CC            = $CC"
+echo "  CFLAGS        = $CFLAGS"
+echo "  CPPFLAGS      = $CPPFLAGS"
+echo "  CXX           = $CXX"
+echo "  CXXFLAGS      = $CXXFLAGS"
+echo "  LDFLAGS       = $LDFLAGS"
+echo 


### PR DESCRIPTION
Adds some compile and link options output to the configure process.
Maybe I'm old school, but I like this level of verbosity.

Results in something like
```
[ ---snip--- ]
configure: Using bignum implementation: no
configure: Using scalar implementation: 64bit
configure: Using endomorphism optimizations: no
configure: Building ECDH module: no
configure: Building Schnorr signatures module: no
configure: Building ECDSA pubkey recovery module: yes
configure: Using jni: no
checking that generated files are newer than configure... done
configure: creating ./config.status
config.status: creating Makefile
config.status: creating libsecp256k1.pc
config.status: creating src/libsecp256k1-config.h
config.status: executing depfiles commands
config.status: executing libtool commands

Options used to compile and link:
  WITH WALLET   = yes
  WITH GUI / QT = yes
   WITH QR      = yes
  WITH TEST     = no
  WITH BENCH    = yes

  TARGET OS     = darwin
  BUILD OS      = darwin

  CC            = /usr/local/bin/ccache gcc
  CFLAGS        = -g -O2
  CPPFLAGS      = -Qunused-arguments  -DHAVE_BUILD_INFO -D__STDC_FORMAT_MACROS -I/usr/local/opt/berkeley-db4/include -DMAC_OSX
  CXX           = /usr/local/bin/ccache g++ -std=c++11
  CXXFLAGS      = -g -O2 -Wall -Wextra -Wformat -Wformat-security -Wno-unused-parameter -Wno-self-assign -Wno-unused-local-typedef -Wno-deprecated-register
  LDFLAGS       =  -Wl,-headerpad_max_install_names -Wl,-dead_strip
```