### PR TITLE
[qa] Wait for specific block announcement in p2p-compactblocks

### DIFF
--- a/qa/rpc-tests/p2p-compactblocks.py
+++ b/qa/rpc-tests/p2p-compactblocks.py
@@ -186,12 +186,15 @@ class CompactBlocksTest(BitcoinTestFramework):
 
         def check_announcement_of_new_block(node, peer, predicate):
             peer.clear_block_announcement()
-            node.generate(1)
-            got_message = wait_until(lambda: peer.block_announced, timeout=30)
+            block_hash = int(node.generate(1)[0], 16)
+            peer.wait_for_block_announcement(block_hash, timeout=30)
             assert(peer.block_announced)
             assert(got_message)
+
             with mininode_lock:
-                assert(predicate(peer))
+                assert predicate(peer), (
+                    "block_hash={!r}, cmpctblock={!r}, inv={!r}".format(
+                        block_hash, peer.last_cmpctblock, peer.last_inv))
 
         # We shouldn't get any block announcements via cmpctblock yet.
         check_announcement_of_new_block(node, test_node, lambda p: p.last_cmpctblock is None)


### PR DESCRIPTION
Change check_announcement_of_new_block() to wait specifically for the
announcement of the newly created block, instead of waiting for any
announcement. A difficult to reproduce failure in
check_announcement_of_new_block() that happened in a travis build
(https://travis-ci.org/bitcoin/bitcoin/jobs/175198367) might have happened
because an older announcement was mistaken for the expected one.