### PR TITLE
IsAllFromMe

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1358,7 +1358,7 @@ void ListTransactions(const CWalletTx& wtx, const string& strAccount, int nMinDe
     wtx.GetAmounts(listReceived, listSent, nFee, strSentAccount, filter);
 
     bool fAllAccounts = (strAccount == string("*"));
-    bool involvesWatchonly = wtx.IsFromMe(ISMINE_WATCH_ONLY);
+    bool involvesWatchonly = (wtx.GetDebit(ISMINE_WATCH_ONLY) > 0);
 
     // Sent
     if ((!listSent.empty() || nFee != 0) && (fAllAccounts || strAccount == strSentAccount))

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1821,10 +1821,10 @@ UniValue gettransaction(const JSONRPCRequest& request)
     CAmount nCredit = wtx.GetCredit(filter);
     CAmount nDebit = wtx.GetDebit(filter);
     CAmount nNet = nCredit - nDebit;
-    CAmount nFee = (wtx.IsFromMe(filter) ? wtx.tx->GetValueOut() - nDebit : 0);
+    CAmount nFee = (wtx.IsAllFromMe(filter) ? wtx.tx->GetValueOut() - nDebit : 0);
 
     entry.push_back(Pair("amount", ValueFromAmount(nNet - nFee)));
-    if (wtx.IsFromMe(filter))
+    if (wtx.IsAllFromMe(filter))
         entry.push_back(Pair("fee", ValueFromAmount(nFee)));
 
     WalletTxToJSON(wtx, entry);

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -39,17 +39,12 @@ static void add_coin(const CAmount& nValue, int nAge = 6*24, bool fIsFromMe = fa
     tx.nLockTime = nextLockTime++;        // so all transactions get different hashes
     tx.vout.resize(nInput+1);
     tx.vout[nInput].nValue = nValue;
-    if (fIsFromMe) {
-        // IsFromMe() returns (GetDebit() > 0), and GetDebit() is 0 if vin.empty(),
-        // so stop vin being empty, and cache a non-zero Debit to fake out IsFromMe()
+    if (!fIsFromMe) {
+        // IsAllFromMe() returns true if vin.empty()
+        // so stop vin being empty if we don't want these coins to be from us
         tx.vin.resize(1);
     }
     std::unique_ptr<CWalletTx> wtx(new CWalletTx(&wallet, MakeTransactionRef(std::move(tx))));
-    if (fIsFromMe)
-    {
-        wtx->fDebitCached = true;
-        wtx->nDebitCached = 1;
-    }
     COutput output(wtx.get(), nInput, nAge, true, true);
     vCoins.push_back(output);
     wtxn.emplace_back(std::move(wtx));

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2159,7 +2159,7 @@ bool CWallet::SelectCoinsMinConf(const CAmount& nTargetValue, const int nConfMin
 
         const CWalletTx *pcoin = output.tx;
 
-        if (output.nDepth < (pcoin->IsFromMe(ISMINE_ALL) ? nConfMine : nConfTheirs))
+        if (output.nDepth < (pcoin->IsAllFromMe(ISMINE_ALL) ? nConfMine : nConfTheirs))
             continue;
 
         if (!mempool.TransactionWithinChainLimit(pcoin->GetHash(), nMaxAncestors))

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3130,10 +3130,6 @@ std::map<CTxDestination, CAmount> CWallet::GetAddressBalances()
             if (pcoin->IsCoinBase() && pcoin->GetBlocksToMaturity() > 0)
                 continue;
 
-            int nDepth = pcoin->GetDepthInMainChain();
-            if (nDepth < (pcoin->IsFromMe(ISMINE_ALL) ? 0 : 1))
-                continue;
-
             for (unsigned int i = 0; i < pcoin->tx->vout.size(); i++)
             {
                 CTxDestination addr;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1670,6 +1670,37 @@ CAmount CWalletTx::GetDebit(const isminefilter& filter) const
     return debit;
 }
 
+bool CWalletTx::IsAllFromMe(const isminefilter& filter) const
+{
+    bool allFromMe = false;
+    if (filter == ISMINE_ALL)
+    {
+        if (fAllDebitsMineCached)
+            allFromMe = allDebitsMineCached;
+        else
+        {
+            allDebitsMineCached = pwallet->IsAllFromMe(*this, ISMINE_ALL);
+            fAllDebitsMineCached = true;
+            allFromMe = allDebitsMineCached;
+        }
+    }
+    else if (filter == ISMINE_SPENDABLE)
+    {
+        if (fAllDebitsSpendableCached)
+            allFromMe = allDebitsSpendableCached;
+        else
+        {
+            allDebitsSpendableCached = pwallet->IsAllFromMe(*this, ISMINE_SPENDABLE);
+            fAllDebitsSpendableCached = true;
+            allFromMe = allDebitsSpendableCached;
+        }
+    }
+    else {
+        allFromMe = pwallet->IsAllFromMe(*this, filter);
+    }
+    return allFromMe;
+}
+
 CAmount CWalletTx::GetCredit(const isminefilter& filter) const
 {
     // Must wait until coinbase is safely deep enough in the chain before valuing it

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1849,24 +1849,14 @@ bool CWalletTx::IsTrusted() const
         return true;
     if (nDepth < 0)
         return false;
-    if (!bSpendZeroConfChange || !IsFromMe(ISMINE_ALL)) // using wtx's cached debit
+    // Trusted if all inputs are spendable by us
+    if (!bSpendZeroConfChange || !IsAllFromMe(ISMINE_SPENDABLE))
         return false;
 
     // Don't trust unconfirmed transactions from us unless they are in the mempool.
     if (!InMempool())
         return false;
 
-    // Trusted if all inputs are from us and are in the mempool:
-    BOOST_FOREACH(const CTxIn& txin, tx->vin)
-    {
-        // Transactions not sent by us: not trusted
-        const CWalletTx* parent = pwallet->GetWalletTx(txin.prevout.hash);
-        if (parent == NULL)
-            return false;
-        const CTxOut& parentOut = parent->tx->vout[txin.prevout.n];
-        if (pwallet->IsMine(parentOut) != ISMINE_SPENDABLE)
-            return false;
-    }
     return true;
 }
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -280,6 +280,8 @@ public:
     mutable bool fImmatureWatchCreditCached;
     mutable bool fAvailableWatchCreditCached;
     mutable bool fChangeCached;
+    mutable bool fAllDebitsMineCached;
+    mutable bool fAllDebitsSpendableCached;
     mutable CAmount nDebitCached;
     mutable CAmount nCreditCached;
     mutable CAmount nImmatureCreditCached;
@@ -289,6 +291,8 @@ public:
     mutable CAmount nImmatureWatchCreditCached;
     mutable CAmount nAvailableWatchCreditCached;
     mutable CAmount nChangeCached;
+    mutable bool allDebitsMineCached;
+    mutable bool allDebitsSpendableCached;
 
     CWalletTx()
     {
@@ -319,6 +323,8 @@ public:
         fImmatureWatchCreditCached = false;
         fAvailableWatchCreditCached = false;
         fChangeCached = false;
+        fAllDebitsMineCached = false;
+        fAllDebitsSpendableCached = false;
         nDebitCached = 0;
         nCreditCached = 0;
         nImmatureCreditCached = 0;
@@ -328,6 +334,8 @@ public:
         nAvailableWatchCreditCached = 0;
         nImmatureWatchCreditCached = 0;
         nChangeCached = 0;
+        allDebitsMineCached = false;
+        allDebitsSpendableCached = false;
         nOrderPos = -1;
     }
 
@@ -387,6 +395,8 @@ public:
         fImmatureWatchCreditCached = false;
         fDebitCached = false;
         fChangeCached = false;
+        fAllDebitsMineCached = false;
+        fAllDebitsSpendableCached = false;
     }
 
     void BindWallet(CWallet *pwalletIn)
@@ -397,6 +407,7 @@ public:
 
     //! filter decides which addresses will count towards the debit
     CAmount GetDebit(const isminefilter& filter) const;
+    bool IsAllFromMe(const isminefilter& filter) const;
     CAmount GetCredit(const isminefilter& filter) const;
     CAmount GetImmatureCredit(bool fUseCache=true) const;
     CAmount GetAvailableCredit(bool fUseCache=true) const;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -421,11 +421,6 @@ public:
     void GetAccountAmounts(const std::string& strAccount, CAmount& nReceived,
                            CAmount& nSent, CAmount& nFee, const isminefilter& filter) const;
 
-    bool IsFromMe(const isminefilter& filter) const
-    {
-        return (GetDebit(filter) > 0);
-    }
-
     // True if only scriptSigs are different
     bool IsEquivalentTo(const CWalletTx& tx) const;
 


### PR DESCRIPTION
Created a new wallet and walletTx function `IsAllFromMe` which correctly computes whether all the inputs to a transaction match the requested IsMine filter.

Original first commit https://github.com/bitcoin/bitcoin/pull/8456/commits/766e8a40b478353a89622f42809ddb11e695a0c9 already merged.

- Commits 1 and 6 add the new function and remove the old walletTx `IsFromMe`.
- Commit 2 update IsTrusted to use the new function.  No change in behavior as long as vin.size() > 0.  Open question as to whether this should be changed to use ISMINE_ALL?
- Commit 4 remove code that was already redundant because of call to IsTrusted
- Commit 3 make a small change to `SelectCoinsMinConf` to only consider new outputs spendable quickly if all the inputs were ours, not just at least one. 
- Commit 5 changes the output in `gettransaction` for mixed debit transactions where some inputs were ours and some weren't.  It'll report the correct fee if possible, otherwise 0.  Note that the fee reported in the details and any other function which depends on `ListTransactions` is not changed as `getbalance("*")` depends on having incorrect negative fees calculated on mixed debit transactions in order to track the right balances.

Note that there are other places in the code such as `AddToWalletIfInvolvingMe` which ideally would be updated to distinguish between 0 satoshi prevouts that are "MINE" and prevouts that aren't "MINE".

