### PR TITLE
Introduce auxiliary block requests

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -151,6 +151,7 @@ testScripts = [
     'signmessages.py',
     'nulldummy.py',
     'import-rescan.py',
+    'auxiliaryblockrequests.py',
 ]
 if ENABLE_ZMQ:
     testScripts.append('zmq_test.py')

--- a/qa/rpc-tests/auxiliaryblockrequests.py
+++ b/qa/rpc-tests/auxiliaryblockrequests.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+# Copyright (c) 2016 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+
+class AuxiliaryBlockRequestTest (BitcoinTestFramework):
+    def __init__(self):
+        super().__init__()
+        self.setup_clean_chain = True
+        self.num_nodes = 2
+
+    def setup_network(self):
+        self.nodes = []
+        self.nodes.append(start_node(0, self.options.tmpdir, []))
+        self.nodes.append(start_node(1, self.options.tmpdir, ["-autorequestblocks=0"]))
+        connect_nodes(self.nodes[0], 1)
+
+    def run_test(self):
+        print("Mining blocks...")
+        self.nodes[0].generate(101)
+        self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 1)
+        time.sleep(5)
+        ctps = self.nodes[1].getchaintips()
+        headersheight = -1
+        chaintipheight = -1
+        for ct in ctps:
+            if ct['status'] == "headers-only":
+                headersheight = ct['height']
+            if ct['status'] == "active":
+                chaintipheight = ct['height']
+        assert(headersheight == 101)
+        assert(chaintipheight == 0)
+
+        node0bbhash = self.nodes[0].getbestblockhash()
+        # best block should not be validated, header must be available
+        bh = self.nodes[1].getblockheader(node0bbhash, True)
+        assert(bh['validated'] == False)
+        # block must not be available
+        try:
+            bh = self.nodes[1].getblock(node0bbhash, True)
+            raise AssertionError('Block must not be available')
+        except JSONRPCException as e:
+            assert(e.error['code']==-32603)
+
+        # request best block (auxiliary)
+        self.nodes[1].requestblocks("start", [node0bbhash])
+        timeout = 20
+        while timeout > 0:
+            if self.nodes[1].requestblocks("status")['request_present'] == 0:
+                break;
+            time.sleep(1)
+            timeout-=1
+        assert(timeout>0)
+
+        # block must now be available
+        block = self.nodes[1].getblock(node0bbhash, True)
+        assert(block['hash'] == node0bbhash)
+        assert(block['validated'] == False)
+
+        # enable auto-request of blocks
+        self.nodes[1].setautorequestblocks(True)
+        sync_blocks(self.nodes)
+
+        ctps = self.nodes[1].getchaintips()
+        # same block must now be available with mode validated=true
+        block = self.nodes[1].getblock(node0bbhash, True)
+        assert(block['hash'] == node0bbhash)
+        assert(block['validated'] == True)
+
+        chaintipheight = -1
+        for ct in ctps:
+            if ct['status'] == "active":
+                chaintipheight = ct['height']
+        assert(chaintipheight == 101)
+        
+if __name__ == '__main__':
+    AuxiliaryBlockRequestTest ().main ()

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -78,6 +78,7 @@ endif
 BITCOIN_CORE_H = \
   addrdb.h \
   addrman.h \
+  auxiliaryblockrequest.h \
   base58.h \
   bloom.h \
   blockencodings.h \
@@ -174,6 +175,7 @@ libbitcoin_server_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 libbitcoin_server_a_SOURCES = \
   addrman.cpp \
   addrdb.cpp \
+  auxiliaryblockrequest.cpp \
   bloom.cpp \
   blockencodings.cpp \
   chain.cpp \

--- a/src/auxiliaryblockrequest.cpp
+++ b/src/auxiliaryblockrequest.cpp
@@ -1,0 +1,126 @@
+// Copyright (c) 2016 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "auxiliaryblockrequest.h"
+
+#include "chainparams.h"
+#include "validation.h"
+#include "validationinterface.h"
+
+#include <exception>
+
+static const unsigned int MAX_BLOCK_TO_PROCESS_PER_ITERATION = 5;
+
+std::shared_ptr<CAuxiliaryBlockRequest> currentBlockRequest; //thread-safe pointer (CAuxiliaryBlockRequest, the object, is also lock-free)
+
+CAuxiliaryBlockRequest::CAuxiliaryBlockRequest(std::vector<CBlockIndex*> vBlocksToDownloadIn, int64_t createdIn, const std::function<bool(std::shared_ptr<CAuxiliaryBlockRequest>, CBlockIndex *pindex)> progressCallbackIn) : vBlocksToDownload(vBlocksToDownloadIn), created(createdIn), progressCallback(progressCallbackIn)
+{
+    fCancelled = false;
+    requestedUpToSize = 0;
+    processedUpToSize = 0;
+}
+
+void CAuxiliaryBlockRequest::processWithPossibleBlock(const std::shared_ptr<const CBlock> pblock, CBlockIndex *pindex)
+{
+    // don't process anything if the request was cancled
+    if (this->fCancelled)
+        return;
+
+    for (unsigned int i = this->processedUpToSize; i < this->vBlocksToDownload.size() ; i++) {
+        CBlockIndex *pindexRequest = this->vBlocksToDownload[i];
+        std::shared_ptr<const CBlock> currentBlock;
+
+        // if a block has been passed, check if is the next item in the sequence
+        if (pindex && pblock && pindex == pindexRequest)
+            currentBlock = pblock;
+        else if (pindexRequest->nStatus & BLOCK_HAVE_DATA) {
+            CBlock loadBlock;
+            // we should already have this block on disk, process it
+            if (!ReadBlockFromDisk(loadBlock, pindexRequest, Params().GetConsensus()))
+                throw std::runtime_error(std::string(__func__) + "Can't read block from disk");
+            currentBlock = std::make_shared<const CBlock>(loadBlock);
+        } else {
+            break;
+        }
+
+        // fire signal with txns
+        unsigned int cnt = 0;
+        for(const auto& tx : currentBlock->vtx)
+        {
+            GetMainSignals().SyncTransaction(*tx, pindexRequest, cnt);
+            cnt++;
+        }
+        this->processedUpToSize++;
+
+        // log some info
+        LogPrint("net", "BlockRequest: proccessed up to %ld of total requested %ld blocks\n", this->processedUpToSize, this->vBlocksToDownload.size());
+
+        if (progressCallback)
+            if (!progressCallback(shared_from_this(), pindexRequest))
+                this->cancel();
+
+        // release global block request pointer if request has been completed
+        if (this->processedUpToSize == this->vBlocksToDownload.size())
+            currentBlockRequest = nullptr;
+
+        if (i-this->processedUpToSize >= MAX_BLOCK_TO_PROCESS_PER_ITERATION)
+            break;
+    }
+}
+
+void CAuxiliaryBlockRequest::cancel()
+{
+    fCancelled = true;
+    if (currentBlockRequest.get() == this) {
+        // release shared pointer
+        currentBlockRequest = nullptr;
+    }
+}
+
+bool CAuxiliaryBlockRequest::isCancelled()
+{
+    return fCancelled;
+}
+
+void CAuxiliaryBlockRequest::setAsCurrentRequest()
+{
+    // if there is an existing block request, cancle it
+    if (currentBlockRequest != nullptr)
+        currentBlockRequest->fCancelled = true;
+
+    currentBlockRequest = shared_from_this();
+}
+
+void CAuxiliaryBlockRequest::fillInNextBlocks(std::vector<CBlockIndex*>& vBlocks, unsigned int count, std::function<bool(CBlockIndex*)> filterBlocksCallback)
+{
+    for (unsigned int i = this->processedUpToSize; i < this->vBlocksToDownload.size() ; i++) {
+        CBlockIndex *pindex = this->vBlocksToDownload[i];
+        if ( filterBlocksCallback(pindex) && !(pindex->nStatus & BLOCK_HAVE_DATA)) {
+            // the block was accepted by the filter, add it to the download queue
+            vBlocks.push_back(pindex);
+            if (vBlocks.size() == count) {
+                break;
+            }
+        }
+    }
+
+    //try to process already available blocks through the signal
+    this->processWithPossibleBlock(NULL, NULL);
+}
+
+unsigned int CAuxiliaryBlockRequest::amountOfBlocksLoaded()
+{
+    unsigned int haveData = 0;
+    for (unsigned int i = 0; i < this->vBlocksToDownload.size() ; i++) {
+        CBlockIndex *pindex = this->vBlocksToDownload[i];
+        if (pindex->nStatus & BLOCK_HAVE_DATA)
+            haveData++;
+    }
+    return haveData;
+}
+
+std::shared_ptr<CAuxiliaryBlockRequest> CAuxiliaryBlockRequest::GetCurrentRequest()
+{
+    return currentBlockRequest;
+}

--- a/src/auxiliaryblockrequest.cpp
+++ b/src/auxiliaryblockrequest.cpp
@@ -31,7 +31,7 @@ void CAuxiliaryBlockRequest::processWithPossibleBlock(const std::shared_ptr<cons
         CBlockIndex *pindexRequest = this->vBlocksToDownload[i];
         std::shared_ptr<const CBlock> currentBlock;
 
-        // if a block has been passed, check if is the next item in the sequence
+        // if a block has been passed, check if it's the next item in the sequence
         if (pindex && pblock && pindex == pindexRequest)
             currentBlock = pblock;
         else if (pindexRequest->nStatus & BLOCK_HAVE_DATA) {
@@ -64,7 +64,7 @@ void CAuxiliaryBlockRequest::processWithPossibleBlock(const std::shared_ptr<cons
                 this->cancel();
 
         // release global block request pointer if request has been completed
-        if (this->processedUpToSize == this->vBlocksToDownload.size())
+        if (currentBlockRequest == shared_from_this() && isCompleted())
             currentBlockRequest = nullptr;
 
         if (i-this->processedUpToSize >= MAX_BLOCK_TO_PROCESS_PER_ITERATION)
@@ -121,6 +121,11 @@ unsigned int CAuxiliaryBlockRequest::amountOfBlocksLoaded()
             haveData++;
     }
     return haveData;
+}
+
+bool CAuxiliaryBlockRequest::isCompleted()
+{
+    return (this->processedUpToSize == this->vBlocksToDownload.size());
 }
 
 std::shared_ptr<CAuxiliaryBlockRequest> CAuxiliaryBlockRequest::GetCurrentRequest()

--- a/src/auxiliaryblockrequest.cpp
+++ b/src/auxiliaryblockrequest.cpp
@@ -48,7 +48,8 @@ void CAuxiliaryBlockRequest::processWithPossibleBlock(const std::shared_ptr<cons
         unsigned int cnt = 0;
         for(const auto& tx : currentBlock->vtx)
         {
-            GetMainSignals().SyncTransaction(*tx, pindexRequest, cnt);
+            bool valid = ((pindexRequest->nStatus & BLOCK_VALID_MASK) == BLOCK_VALID_MASK);
+            GetMainSignals().SyncTransaction(*tx, pindexRequest, cnt, valid);
             cnt++;
         }
         this->processedUpToSize++;

--- a/src/auxiliaryblockrequest.h
+++ b/src/auxiliaryblockrequest.h
@@ -45,6 +45,9 @@ public:
     /** returns the amount of already loaded/local-stored blocks from this blockrequest */
     unsigned int amountOfBlocksLoaded();
 
+    /** returns true if all blocks have been downloaded & processed */
+    bool isCompleted();
+
     /** Get the current main blockrequest, thread_safe */
     static std::shared_ptr<CAuxiliaryBlockRequest> GetCurrentRequest();
 

--- a/src/auxiliaryblockrequest.h
+++ b/src/auxiliaryblockrequest.h
@@ -20,9 +20,10 @@ public:
 
     const std::vector<CBlockIndex*> vBlocksToDownload;
     const int64_t created; //!timestamp when the block request was created
+    const bool passThroughSignals; //!if passThroughSignals is set, the received blocks transaction will be passed through the SyncTransaction signal */
 
     /** Constructor of the lock free CAuxiliaryBlockRequest, vBlocksToDownloadIn remains constant */
-    CAuxiliaryBlockRequest(std::vector<CBlockIndex*> vBlocksToDownloadIn, int64_t created, const std::function<bool(std::shared_ptr<CAuxiliaryBlockRequest>, CBlockIndex *pindex)> progressCallbackIn);
+    CAuxiliaryBlockRequest(std::vector<CBlockIndex*> vBlocksToDownloadIn, int64_t created, bool passThroughSignalsIn, const std::function<bool(std::shared_ptr<CAuxiliaryBlockRequest>, CBlockIndex *pindex)> progressCallbackIn);
 
     /** Process the request, check if there are blocks available to "stream"
         over the SyncTransaction signal 

--- a/src/auxiliaryblockrequest.h
+++ b/src/auxiliaryblockrequest.h
@@ -1,0 +1,55 @@
+// Copyright (c) 2016 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_AUXILIARYBLOCKREQUEST_H
+#define BITCOIN_AUXILIARYBLOCKREQUEST_H
+
+#include <atomic>
+#include "chain.h"
+#include "consensus/consensus.h"
+#include "net.h"
+#include <stdint.h>
+#include <vector>
+
+// "Lock free" auxiliary block request
+class CAuxiliaryBlockRequest : public std::enable_shared_from_this<CAuxiliaryBlockRequest> {
+public:
+    std::atomic<size_t> requestedUpToSize; //requested up to this index in vBlocksToDownload
+    std::atomic<size_t> processedUpToSize; //processed up to this index in vBlocksToDownload
+
+    const std::vector<CBlockIndex*> vBlocksToDownload;
+    const int64_t created; //!timestamp when the block request was created
+
+    /** Constructor of the lock free CAuxiliaryBlockRequest, vBlocksToDownloadIn remains constant */
+    CAuxiliaryBlockRequest(std::vector<CBlockIndex*> vBlocksToDownloadIn, int64_t created, const std::function<bool(std::shared_ptr<CAuxiliaryBlockRequest>, CBlockIndex *pindex)> progressCallbackIn);
+
+    /** Process the request, check if there are blocks available to "stream"
+        over the SyncTransaction signal 
+        Allow to provide an optional block to avoid disk re-loading
+     */
+    void processWithPossibleBlock(const std::shared_ptr<const CBlock> pblock = nullptr, CBlockIndex *pindex = NULL);
+
+    /** Cancel the block request */
+    void cancel();
+    bool isCancelled();
+
+    /** Set as the current block request, invalidate/cancle the current one */
+    void setAsCurrentRequest();
+
+    /** Fill next available, not already requested blocks into vBlocks
+        allow to provide a function to check if block is already in flight somewhere */
+    void fillInNextBlocks(std::vector<CBlockIndex*>& vBlocks, unsigned int count, std::function<bool(CBlockIndex*)> filterBlocksCallback);
+
+    /** returns the amount of already loaded/local-stored blocks from this blockrequest */
+    unsigned int amountOfBlocksLoaded();
+
+    /** Get the current main blockrequest, thread_safe */
+    static std::shared_ptr<CAuxiliaryBlockRequest> GetCurrentRequest();
+
+private:
+    const std::function<bool(std::shared_ptr<CAuxiliaryBlockRequest>, CBlockIndex *pindex)> progressCallback; //! progress callback, with optional cancle mechanism (return false == cancel)
+    std::atomic<bool> fCancelled;
+};
+
+#endif // BITCOIN_AUXILIARYBLOCKREQUEST_H

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -429,6 +429,7 @@ std::string HelpMessage(HelpMessageMode mode)
         strUsage += HelpMessageOpt("-limitdescendantcount=<n>", strprintf("Do not accept transactions if any ancestor would have <n> or more in-mempool descendants (default: %u)", DEFAULT_DESCENDANT_LIMIT));
         strUsage += HelpMessageOpt("-limitdescendantsize=<n>", strprintf("Do not accept transactions if any ancestor would have more than <n> kilobytes of in-mempool descendants (default: %u).", DEFAULT_DESCENDANT_SIZE_LIMIT));
         strUsage += HelpMessageOpt("-bip9params=deployment:start:end", "Use given start/end times for specified BIP9 deployment (regtest-only)");
+        strUsage += HelpMessageOpt("-autorequestblocks", strprintf("Automatic block request, if disabled, blocks will not be requested in IBD/sync-up (default: %u)", DEFAULT_AUTOMATIC_BLOCK_REQUESTS));
     }
     string debugCategories = "addrman, alert, bench, cmpctblock, coindb, db, http, libevent, lock, mempool, mempoolrej, net, proxy, prune, rand, reindex, rpc, selectcoins, tor, zmq"; // Don't translate these and qt below
     if (mode == HMM_BITCOIN_QT)
@@ -912,6 +913,7 @@ bool AppInitParameterInteraction()
     }
     fCheckBlockIndex = GetBoolArg("-checkblockindex", chainparams.DefaultConsistencyChecks());
     fCheckpointsEnabled = GetBoolArg("-checkpoints", DEFAULT_CHECKPOINTS_ENABLED);
+    fAutoRequestBlocks = GetBoolArg("-autorequestblocks", DEFAULT_AUTOMATIC_BLOCK_REQUESTS);
 
     // mempool limits
     int64_t nMempoolSizeMax = GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -62,6 +62,8 @@ void EraseOrphansFor(NodeId peer) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 static const uint64_t RANDOMIZER_ID_ADDRESS_RELAY = 0x3cac0035b5866b90ULL; // SHA256("main address relay")[0:8]
 
+std::atomic<bool> fAutoRequestBlocks(DEFAULT_AUTOMATIC_BLOCK_REQUESTS);
+
 // Internal stuff
 namespace {
     /** Number of nodes with fSyncStarted. */
@@ -498,6 +500,10 @@ void FindNextBlocksToDownload(NodeId nodeid, unsigned int count, std::vector<CBl
         // if we haven't completed the individual CAuxiliaryBlockRequest, we wont continue with "normal" IBD
         return;
     }
+
+    // don't request any other blocks if we are in non autorequest mode (usefull for non-validation mode)
+    if (!fAutoRequestBlocks)
+        return;
 
     if (state->pindexBestKnownBlock == NULL || state->pindexBestKnownBlock->nChainWork < chainActive.Tip()->nChainWork) {
         // This peer has nothing interesting.

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -750,8 +750,8 @@ PeerLogicValidation::PeerLogicValidation(CConnman* connmanIn) : connman(connmanI
     recentRejects.reset(new CRollingBloomFilter(120000, 0.000001));
 }
 
-void PeerLogicValidation::SyncTransaction(const CTransaction& tx, const CBlockIndex* pindex, int nPosInBlock) {
-    if (nPosInBlock == CMainSignals::SYNC_TRANSACTION_NOT_IN_BLOCK)
+void PeerLogicValidation::SyncTransaction(const CTransaction& tx, const CBlockIndex* pindex, int nPosInBlock, bool validated) {
+    if (nPosInBlock == CMainSignals::SYNC_TRANSACTION_NOT_IN_BLOCK || !validated)
         return;
 
     LOCK(cs_main);

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -21,7 +21,7 @@ private:
 public:
     PeerLogicValidation(CConnman* connmanIn);
 
-    virtual void SyncTransaction(const CTransaction& tx, const CBlockIndex* pindex, int nPosInBlock);
+    virtual void SyncTransaction(const CTransaction& tx, const CBlockIndex* pindex, int nPosInBlock, bool validated);
     virtual void UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload);
     virtual void BlockChecked(const CBlock& block, const CValidationState& state);
 };

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -14,6 +14,10 @@ void RegisterNodeSignals(CNodeSignals& nodeSignals);
 /** Unregister a network node */
 void UnregisterNodeSignals(CNodeSignals& nodeSignals);
 
+/** if disabled, blocks will not be requested automatically, usefull for non-validation mode */
+static const bool DEFAULT_AUTOMATIC_BLOCK_REQUESTS = true;
+extern std::atomic<bool> fAutoRequestBlocks;
+
 class PeerLogicValidation : public CValidationInterface {
 private:
     CConnman* connman;

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -11,6 +11,7 @@
 #include "coins.h"
 #include "consensus/validation.h"
 #include "validation.h"
+#include "net_processing.h"
 #include "policy/policy.h"
 #include "primitives/transaction.h"
 #include "rpc/server.h"
@@ -1464,6 +1465,30 @@ UniValue requestblocks(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Unkown action");
 }
 
+UniValue setautorequestblocks(const JSONRPCRequest& request)
+{
+    if (request.fHelp || request.params.size() > 1)
+        throw runtime_error(
+                            "setautorequestblocks (true|false)\n"
+                            "\nIf set to false, blocks will no longer be requested automatically\n"
+                            "Useful for a pure non-validation mode in conjunction with requestblocks.\n"
+                            "\nArguments:\n"
+                            "1. state             (boolean, optional) enables or disables the automatic block download\n"
+                            "\nResult:\n"
+                            "   status: <true|false> (\"true\" if a automatic blockdownloads are enabled)\n"
+                            "\nExamples:\n"
+                            + HelpExampleCli("setautorequestblocks", "\"false\"")
+                            + HelpExampleRpc("setautorequestblocks", "\"false\"")
+                            );
+
+    if (request.params.size() == 1)
+        fAutoRequestBlocks = request.params[0].get_bool();
+
+    UniValue ret(UniValue::VOBJ);
+    ret.pushKV("status", UniValue(fAutoRequestBlocks));
+    return ret;
+}
+
 static const CRPCCommand commands[] =
 { //  category              name                      actor (function)         okSafeMode
   //  --------------------- ------------------------  -----------------------  ----------
@@ -1492,6 +1517,7 @@ static const CRPCCommand commands[] =
     { "hidden",             "waitfornewblock",        &waitfornewblock,        true  },
     { "hidden",             "waitforblock",           &waitforblock,           true  },
     { "hidden",             "waitforblockheight",     &waitforblockheight,     true  },
+    { "hidden",             "setautorequestblocks",   &setautorequestblocks,   true  },
 };
 
 void RegisterBlockchainRPCCommands(CRPCTable &t)

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -4,6 +4,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "amount.h"
+#include "auxiliaryblockrequest.h"
 #include "chain.h"
 #include "chainparams.h"
 #include "checkpoints.h"
@@ -25,6 +26,7 @@
 #include <univalue.h>
 
 #include <boost/thread/thread.hpp> // boost::thread::interrupt
+#include <boost/assign/list_of.hpp>
 
 #include <mutex>
 #include <condition_variable>
@@ -82,6 +84,8 @@ UniValue blockheaderToJSON(const CBlockIndex* blockindex)
     // Only report confirmations if the block is on the main chain
     if (chainActive.Contains(blockindex))
         confirmations = chainActive.Height() - blockindex->nHeight + 1;
+
+    result.push_back(Pair("validated", ((blockindex->nStatus & BLOCK_VALID_MASK) >= BLOCK_VALID_SCRIPTS)));
     result.push_back(Pair("confirmations", confirmations));
     result.push_back(Pair("height", blockindex->nHeight));
     result.push_back(Pair("version", blockindex->nVersion));
@@ -110,6 +114,7 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool tx
     // Only report confirmations if the block is on the main chain
     if (chainActive.Contains(blockindex))
         confirmations = chainActive.Height() - blockindex->nHeight + 1;
+    result.push_back(Pair("validated", (blockindex->nStatus & BLOCK_VALID_MASK) >= BLOCK_VALID_SCRIPTS));
     result.push_back(Pair("confirmations", confirmations));
     result.push_back(Pair("strippedsize", (int)::GetSerializeSize(block, SER_NETWORK, PROTOCOL_VERSION | SERIALIZE_TRANSACTION_NO_WITNESS)));
     result.push_back(Pair("size", (int)::GetSerializeSize(block, SER_NETWORK, PROTOCOL_VERSION)));
@@ -642,6 +647,7 @@ UniValue getblockheader(const JSONRPCRequest& request)
             "{\n"
             "  \"hash\" : \"hash\",     (string) the block hash (same as provided)\n"
             "  \"confirmations\" : n,   (numeric) The number of confirmations, or -1 if the block is not on the main chain\n"
+            "  \"validated\" : n,       (boolean) True if the block has been validated (for auxiliary block requests)\n"
             "  \"height\" : n,          (numeric) The block height or index\n"
             "  \"version\" : n,         (numeric) The block version\n"
             "  \"versionHex\" : \"00000000\", (string) The block version formatted in hexadecimal\n"
@@ -1366,6 +1372,98 @@ UniValue reconsiderblock(const JSONRPCRequest& request)
     return NullUniValue;
 }
 
+UniValue requestblocks(const JSONRPCRequest& request)
+{
+    if (request.fHelp || request.params.size() < 1 || request.params.size() > 3)
+        throw runtime_error(
+                            "requestblocks (start|cancel|status) ([\"hash_0\", \"hash_1\", ...]) (<pass-internally>)\n"
+                            "\nRequests blocks (auxiliary) by eventually downloading them.\n"
+                            "\nDownload of the requested blocks will be priorized.\n"
+                            "\nArguments:\n"
+                            "1. action            (string, required) the action to execute\n"
+                            "                                        start  = start a new block request (overwrite existing one)\n"
+                            "                                        cancel = stop current block request\n"
+                            "                                        status = get info about current request\n"
+                            "2. array of hashes   (array, optional) the hashes of the blocks to download\n"
+                            "2. pass-internally   (boolean, optional, default = false) If set, the transactions of the requested blocks get passed into the wallet/ZMQ/etc.\n"
+                            "\nResult:\n"
+                            "   cancel: <true|false> (\"true\" if a blockrequest was present)\n"
+                            "   start: {\"overwrite\": <true|false>} (if the new blocksrequest has overwritten an already existign one\n"
+                            "   status: {\n"
+                            "              \"created\": <timestamp> (block request was created at this timestamp)\n"
+                            "              \"is_cancled\": <true|false> (set if blockrequest is cancled)\n"
+                            "              \"requested_blocks\": <number> (amount of requestes blocks)\n"
+                            "              \"loaded_blocks\": <number> (amount of blocks already available on disk)\n"
+                            "              \"processed_blocks\": <number> (amount of already processed blocks)\n"
+                            "           }\n"
+                            "\nExamples:\n"
+                            + HelpExampleCli("requestblocks", "\"'[\"<blockhash>\"]'\"")
+                            + HelpExampleRpc("requestblocks", "\"'[\"<blockhash>\"]'\"")
+                            );
+
+    if (request.params[0].get_str() == "cancel")
+    {
+        if (CAuxiliaryBlockRequest::GetCurrentRequest()) {
+            CAuxiliaryBlockRequest::GetCurrentRequest()->cancel();
+            return UniValue(true);
+        }
+        else
+            return UniValue(false);
+    }
+    if (request.params[0].get_str() == "status")
+    {
+        std::shared_ptr<CAuxiliaryBlockRequest> blockRequest = CAuxiliaryBlockRequest::GetCurrentRequest();
+        UniValue ret(UniValue::VOBJ);
+        ret.pushKV("request_present", (bool)blockRequest);
+        if (blockRequest) {
+            ret.pushKV("created", UniValue(blockRequest->created));
+            ret.pushKV("is_cancled", UniValue(blockRequest->isCancelled()));
+            ret.pushKV("requested_blocks", (int64_t)blockRequest->vBlocksToDownload.size());
+            ret.pushKV("loaded_blocks", (int)blockRequest->amountOfBlocksLoaded());
+            ret.pushKV("processed_blocks", (int64_t)blockRequest->processedUpToSize);
+        }
+        return ret;
+    }
+    if (request.params[0].get_str() == "start")
+    {
+        if (request.params.size() < 2)
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "Missing blocks array");
+        UniValue hash_Uarray = request.params[1].get_array();
+        if (!hash_Uarray.isArray())
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "Second parameter must be an array");
+
+        std::vector<CBlockIndex*> blocksToDownload;
+        {
+            LOCK(cs_main); //mapBlockIndex
+            for (UniValue strHashU : hash_Uarray.getValues())
+            {
+                uint256 hash(uint256S(strHashU.get_str()));
+                BlockMap::iterator mi = mapBlockIndex.find(hash);
+                if (mi == mapBlockIndex.end())
+                    throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found");
+                blocksToDownload.push_back((*mi).second);
+            }
+        }
+
+        bool passThroughSignals = false;
+        if (request.params.size() == 3 && request.params[2].isBool())
+            passThroughSignals = request.params[2].get_bool();
+
+        std::shared_ptr<CAuxiliaryBlockRequest> blockRequest(new CAuxiliaryBlockRequest(blocksToDownload, GetAdjustedTime(), passThroughSignals, [](std::shared_ptr<CAuxiliaryBlockRequest> cb_spvRequest, CBlockIndex *pindex) -> bool {
+            return true;
+        }));
+        bool overwrite = (CAuxiliaryBlockRequest::GetCurrentRequest() != nullptr);
+        // set the global SPV Request
+        blockRequest->setAsCurrentRequest();
+
+        UniValue ret(UniValue::VOBJ);
+        ret.pushKV("overwrite", UniValue(overwrite));
+        return ret;
+    }
+    else
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Unkown action");
+}
+
 static const CRPCCommand commands[] =
 { //  category              name                      actor (function)         okSafeMode
   //  --------------------- ------------------------  -----------------------  ----------
@@ -1385,8 +1483,8 @@ static const CRPCCommand commands[] =
     { "blockchain",         "gettxout",               &gettxout,               true  },
     { "blockchain",         "gettxoutsetinfo",        &gettxoutsetinfo,        true  },
     { "blockchain",         "verifychain",            &verifychain,            true  },
-
     { "blockchain",         "preciousblock",          &preciousblock,          true  },
+    { "blockchain",         "requestblocks",          &requestblocks,          true  },
 
     /* Not shown in help */
     { "hidden",             "invalidateblock",        &invalidateblock,        true  },

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -112,6 +112,8 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "setnetworkactive", 0 },
     { "getmempoolancestors", 1 },
     { "getmempooldescendants", 1 },
+    { "requestblocks", 1 },
+    { "requestblocks", 2 },
 };
 
 class CRPCConvertTable

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -114,6 +114,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "getmempooldescendants", 1 },
     { "requestblocks", 1 },
     { "requestblocks", 2 },
+    { "setautorequestblocks", 0 },
 };
 
 class CRPCConvertTable

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -950,7 +950,7 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState& state, const C
         }
     }
 
-    GetMainSignals().SyncTransaction(tx, NULL, CMainSignals::SYNC_TRANSACTION_NOT_IN_BLOCK);
+    GetMainSignals().SyncTransaction(tx, NULL, CMainSignals::SYNC_TRANSACTION_NOT_IN_BLOCK, true);
 
     return true;
 }
@@ -2135,7 +2135,7 @@ bool static DisconnectTip(CValidationState& state, const CChainParams& chainpara
     // Let wallets know transactions went from 1-confirmed to
     // 0-confirmed or conflicted:
     for (const auto& tx : block.vtx) {
-        GetMainSignals().SyncTransaction(*tx, pindexDelete->pprev, CMainSignals::SYNC_TRANSACTION_NOT_IN_BLOCK);
+        GetMainSignals().SyncTransaction(*tx, pindexDelete->pprev, CMainSignals::SYNC_TRANSACTION_NOT_IN_BLOCK, true);
     }
     return true;
 }
@@ -2431,7 +2431,7 @@ bool ActivateBestChain(CValidationState &state, const CChainParams& chainparams,
             assert(pair.second);
             const CBlock& block = *(pair.second);
             for (unsigned int i = 0; i < block.vtx.size(); i++)
-                GetMainSignals().SyncTransaction(*block.vtx[i], pair.first, i);
+                GetMainSignals().SyncTransaction(*block.vtx[i], pair.first, i, true);
         }
 
         // Notify external listeners about the new tip.

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3045,7 +3045,7 @@ bool ProcessNewBlockHeaders(const std::vector<CBlockHeader>& headers, CValidatio
 }
 
 /** Store block on disk. If dbp is non-NULL, the file is known to already reside on disk */
-static bool AcceptBlock(const CBlock& block, CValidationState& state, const CChainParams& chainparams, CBlockIndex** ppindex, bool fRequested, const CDiskBlockPos* dbp, bool* fNewBlock)
+static bool AcceptBlock(const CBlock& block, CValidationState& state, const CChainParams& chainparams, CBlockIndex** ppindex, bool fRequested, const CDiskBlockPos* dbp, bool* fNewBlock, bool onlyHeaderCheck = false)
 {
     if (fNewBlock) *fNewBlock = false;
     AssertLockHeld(cs_main);
@@ -3056,40 +3056,47 @@ static bool AcceptBlock(const CBlock& block, CValidationState& state, const CCha
     if (!AcceptBlockHeader(block, state, chainparams, &pindex))
         return false;
 
-    // Try to process all requested blocks that we don't have, but only
-    // process an unrequested block if it's new and has enough work to
-    // advance our tip, and isn't too many blocks ahead.
-    bool fAlreadyHave = pindex->nStatus & BLOCK_HAVE_DATA;
-    bool fHasMoreWork = (chainActive.Tip() ? pindex->nChainWork > chainActive.Tip()->nChainWork : true);
-    // Blocks that are too out-of-order needlessly limit the effectiveness of
-    // pruning, because pruning will not delete block files that contain any
-    // blocks which are too close in height to the tip.  Apply this test
-    // regardless of whether pruning is enabled; it should generally be safe to
-    // not process unrequested blocks.
-    bool fTooFarAhead = (pindex->nHeight > int(chainActive.Height() + MIN_BLOCKS_TO_KEEP));
-
-    // TODO: Decouple this function from the block download logic by removing fRequested
-    // This requires some new chain datastructure to efficiently look up if a
-    // block is in a chain leading to a candidate for best tip, despite not
-    // being such a candidate itself.
-
-    // TODO: deal better with return value and error conditions for duplicate
-    // and unrequested blocks.
-    if (fAlreadyHave) return true;
-    if (!fRequested) {  // If we didn't ask for it:
-        if (pindex->nTx != 0) return true;  // This is a previously-processed block that was pruned
-        if (!fHasMoreWork) return true;     // Don't process less-work chains
-        if (fTooFarAhead) return true;      // Block height is too high
+    // don't validate the block if we fetch it with a auxiliary CAuxiliaryBlockRequest
+    if (onlyHeaderCheck) {
+        LogPrint("net", "Accept specific block %s (%d)\n", pindex->GetBlockHash().ToString(), pindex->nHeight);
     }
-    if (fNewBlock) *fNewBlock = true;
+    else
+    {
+        // Try to process all requested blocks that we don't have, but only
+        // process an unrequested block if it's new and has enough work to
+        // advance our tip, and isn't too many blocks ahead.
+        bool fAlreadyHave = pindex->nStatus & BLOCK_HAVE_DATA;
+        bool fHasMoreWork = (chainActive.Tip() ? pindex->nChainWork > chainActive.Tip()->nChainWork : true);
+        // Blocks that are too out-of-order needlessly limit the effectiveness of
+        // pruning, because pruning will not delete block files that contain any
+        // blocks which are too close in height to the tip.  Apply this test
+        // regardless of whether pruning is enabled; it should generally be safe to
+        // not process unrequested blocks.
+        bool fTooFarAhead = (pindex->nHeight > int(chainActive.Height() + MIN_BLOCKS_TO_KEEP));
 
-    if (!CheckBlock(block, state, chainparams.GetConsensus(), GetAdjustedTime()) ||
-        !ContextualCheckBlock(block, state, chainparams.GetConsensus(), pindex->pprev)) {
-        if (state.IsInvalid() && !state.CorruptionPossible()) {
-            pindex->nStatus |= BLOCK_FAILED_VALID;
-            setDirtyBlockIndex.insert(pindex);
+        // TODO: Decouple this function from the block download logic by removing fRequested
+        // This requires some new chain datastructure to efficiently look up if a
+        // block is in a chain leading to a candidate for best tip, despite not
+        // being such a candidate itself.
+
+        // TODO: deal better with return value and error conditions for duplicate
+        // and unrequested blocks.
+        if (fAlreadyHave) return true;
+        if (!fRequested) {  // If we didn't ask for it:
+            if (pindex->nTx != 0) return true;  // This is a previously-processed block that was pruned
+            if (!fHasMoreWork) return true;     // Don't process less-work chains
+            if (fTooFarAhead) return true;      // Block height is too high
         }
-        return error("%s: %s", __func__, FormatStateMessage(state));
+        if (fNewBlock) *fNewBlock = true;
+
+        if (!CheckBlock(block, state, chainparams.GetConsensus(), GetAdjustedTime()) ||
+            !ContextualCheckBlock(block, state, chainparams.GetConsensus(), pindex->pprev)) {
+            if (state.IsInvalid() && !state.CorruptionPossible()) {
+                pindex->nStatus |= BLOCK_FAILED_VALID;
+                setDirtyBlockIndex.insert(pindex);
+            }
+            return error("%s: %s", __func__, FormatStateMessage(state));
+        }
     }
 
     int nHeight = pindex->nHeight;
@@ -3117,16 +3124,16 @@ static bool AcceptBlock(const CBlock& block, CValidationState& state, const CCha
     return true;
 }
 
-bool ProcessNewBlock(const CChainParams& chainparams, const std::shared_ptr<const CBlock> pblock, bool fForceProcessing, bool *fNewBlock)
+bool ProcessNewBlock(const CChainParams& chainparams, const std::shared_ptr<const CBlock> pblock, bool fForceProcessing, bool *fNewBlock, std::shared_ptr<CAuxiliaryBlockRequest> blockRequest)
 {
+    CBlockIndex *pindex = NULL;
     {
         LOCK(cs_main);
 
         // Store to disk
-        CBlockIndex *pindex = NULL;
         if (fNewBlock) *fNewBlock = false;
         CValidationState state;
-        bool ret = AcceptBlock(*pblock, state, chainparams, &pindex, fForceProcessing, NULL, fNewBlock);
+        bool ret = AcceptBlock(*pblock, state, chainparams, &pindex, fForceProcessing, NULL, fNewBlock, (blockRequest != nullptr));
         CheckBlockIndex(chainparams.GetConsensus());
         if (!ret) {
             GetMainSignals().BlockChecked(*pblock, state);
@@ -3134,10 +3141,13 @@ bool ProcessNewBlock(const CChainParams& chainparams, const std::shared_ptr<cons
         }
     }
 
+    if (blockRequest)
+        blockRequest->processWithPossibleBlock(pblock, pindex);
+
     NotifyHeaderTip();
 
     CValidationState state; // Only used to report errors, not invalidity - ignore it
-    if (!ActivateBestChain(state, chainparams, pblock))
+    if (!blockRequest && !ActivateBestChain(state, chainparams, pblock))
         return error("%s: ActivateBestChain failed", __func__);
 
     return true;

--- a/src/validation.h
+++ b/src/validation.h
@@ -11,6 +11,7 @@
 #endif
 
 #include "amount.h"
+#include "auxiliaryblockrequest.h"
 #include "chain.h"
 #include "coins.h"
 #include "protocol.h" // For CMessageHeader::MessageStartChars
@@ -231,7 +232,7 @@ static const uint64_t MIN_DISK_SPACE_FOR_BLOCK_FILES = 550 * 1024 * 1024;
  * @param[out]  fNewBlock A boolean which is set to indicate if the block was first received via this call
  * @return True if state.IsValid()
  */
-bool ProcessNewBlock(const CChainParams& chainparams, const std::shared_ptr<const CBlock> pblock, bool fForceProcessing, bool* fNewBlock);
+bool ProcessNewBlock(const CChainParams& chainparams, const std::shared_ptr<const CBlock> pblock, bool fForceProcessing, bool* fNewBlock, std::shared_ptr<CAuxiliaryBlockRequest> blockRequest = nullptr);
 
 /**
  * Process incoming block headers.

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -14,7 +14,7 @@ CMainSignals& GetMainSignals()
 
 void RegisterValidationInterface(CValidationInterface* pwalletIn) {
     g_signals.UpdatedBlockTip.connect(boost::bind(&CValidationInterface::UpdatedBlockTip, pwalletIn, _1, _2, _3));
-    g_signals.SyncTransaction.connect(boost::bind(&CValidationInterface::SyncTransaction, pwalletIn, _1, _2, _3));
+    g_signals.SyncTransaction.connect(boost::bind(&CValidationInterface::SyncTransaction, pwalletIn, _1, _2, _3, _4));
     g_signals.UpdatedTransaction.connect(boost::bind(&CValidationInterface::UpdatedTransaction, pwalletIn, _1));
     g_signals.SetBestChain.connect(boost::bind(&CValidationInterface::SetBestChain, pwalletIn, _1));
     g_signals.Inventory.connect(boost::bind(&CValidationInterface::Inventory, pwalletIn, _1));
@@ -32,7 +32,7 @@ void UnregisterValidationInterface(CValidationInterface* pwalletIn) {
     g_signals.Inventory.disconnect(boost::bind(&CValidationInterface::Inventory, pwalletIn, _1));
     g_signals.SetBestChain.disconnect(boost::bind(&CValidationInterface::SetBestChain, pwalletIn, _1));
     g_signals.UpdatedTransaction.disconnect(boost::bind(&CValidationInterface::UpdatedTransaction, pwalletIn, _1));
-    g_signals.SyncTransaction.disconnect(boost::bind(&CValidationInterface::SyncTransaction, pwalletIn, _1, _2, _3));
+    g_signals.SyncTransaction.disconnect(boost::bind(&CValidationInterface::SyncTransaction, pwalletIn, _1, _2, _3, _4));
     g_signals.UpdatedBlockTip.disconnect(boost::bind(&CValidationInterface::UpdatedBlockTip, pwalletIn, _1, _2, _3));
 }
 

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -32,7 +32,7 @@ void UnregisterAllValidationInterfaces();
 class CValidationInterface {
 protected:
     virtual void UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload) {}
-    virtual void SyncTransaction(const CTransaction &tx, const CBlockIndex *pindex, int posInBlock) {}
+    virtual void SyncTransaction(const CTransaction &tx, const CBlockIndex *pindex, int posInBlock, bool validated = true) {}
     virtual void SetBestChain(const CBlockLocator &locator) {}
     virtual void UpdatedTransaction(const uint256 &hash) {}
     virtual void Inventory(const uint256 &hash) {}
@@ -51,7 +51,7 @@ struct CMainSignals {
     /** A posInBlock value for SyncTransaction which indicates the transaction was conflicted, disconnected, or not in a block */
     static const int SYNC_TRANSACTION_NOT_IN_BLOCK = -1;
     /** Notifies listeners of updated transaction data (transaction, and optionally the block it is found in. */
-    boost::signals2::signal<void (const CTransaction &, const CBlockIndex *pindex, int posInBlock)> SyncTransaction;
+    boost::signals2::signal<void (const CTransaction &, const CBlockIndex *pindex, int posInBlock, bool validated)> SyncTransaction;
     /** Notifies listeners of an updated transaction without new data (for now: a coinbase potentially becoming visible). */
     boost::signals2::signal<void (const uint256 &)> UpdatedTransaction;
     /** Notifies listeners of a new active block chain. */

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1121,7 +1121,7 @@ void CWallet::MarkConflicted(const uint256& hashBlock, const uint256& hashTx)
     }
 }
 
-void CWallet::SyncTransaction(const CTransaction& tx, const CBlockIndex *pindex, int posInBlock)
+void CWallet::SyncTransaction(const CTransaction& tx, const CBlockIndex *pindex, int posInBlock, bool validated)
 {
     LOCK2(cs_main, cs_wallet);
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1125,6 +1125,9 @@ void CWallet::SyncTransaction(const CTransaction& tx, const CBlockIndex *pindex,
 {
     LOCK2(cs_main, cs_wallet);
 
+    if (!validated)
+        return;
+
     if (!AddToWalletIfInvolvingMe(tx, pindex, posInBlock, true))
         return; // Not one of ours
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -755,8 +755,8 @@ public:
     void MarkDirty();
     bool AddToWallet(const CWalletTx& wtxIn, bool fFlushOnClose=true);
     bool LoadToWallet(const CWalletTx& wtxIn);
-    void SyncTransaction(const CTransaction& tx, const CBlockIndex *pindex, int posInBlock);
     bool AddToWalletIfInvolvingMe(const CTransaction& tx, const CBlockIndex* pIndex, int posInBlock, bool fUpdate);
+    void SyncTransaction(const CTransaction& tx, const CBlockIndex *pindex, int posInBlock, bool validated);
     int ScanForWalletTransactions(CBlockIndex* pindexStart, bool fUpdate = false);
     void ReacceptWalletTransactions();
     void ResendWalletTransactions(int64_t nBestBlockTime, CConnman* connman);

--- a/src/zmq/zmqnotificationinterface.cpp
+++ b/src/zmq/zmqnotificationinterface.cpp
@@ -144,8 +144,12 @@ void CZMQNotificationInterface::UpdatedBlockTip(const CBlockIndex *pindexNew, co
     }
 }
 
-void CZMQNotificationInterface::SyncTransaction(const CTransaction& tx, const CBlockIndex* pindex, int posInBlock)
+void CZMQNotificationInterface::SyncTransaction(const CTransaction& tx, const CBlockIndex* pindex, int posInBlock, bool validated)
 {
+    // don't post non-validated tx for now
+    if (!validated)
+        return;
+
     for (std::list<CZMQAbstractNotifier*>::iterator i = notifiers.begin(); i!=notifiers.end(); )
     {
         CZMQAbstractNotifier *notifier = *i;

--- a/src/zmq/zmqnotificationinterface.h
+++ b/src/zmq/zmqnotificationinterface.h
@@ -24,7 +24,7 @@ protected:
     void Shutdown();
 
     // CValidationInterface
-    void SyncTransaction(const CTransaction& tx, const CBlockIndex *pindex, int posInBlock);
+    void SyncTransaction(const CTransaction& tx, const CBlockIndex *pindex, int posInBlock, bool validated);
     void UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload);
 
 private:


### PR DESCRIPTION
This PR will allow auxiliary block requests. This will be required to run SPV wallets as well as this solves some other interesting use cases.

### CAuxiliaryBlockRequest
* A new "lock-free" class that handles the auxiliary blocks-download/processing
* Contains a single global CAuxiliaryBlockRequest pointer (switching to a queue would be trivial).

### SyncTransaction signal
* A new parameter will be added that defines if the transactions are coming from a validated or non-validated block

### New RPC call "requestblocks"
Allows to request blocks, if available on disk, they will be optionally passed tough the SyncTransaction signal (Wallet/ZMQ). If some or all of the blocks are not available, they will be downloaded (prioritized over "normal" IBD downloads).
The blocks will be downloaded in parallel using the current block download mechanisms.
`CAuxiliaryBlockRequest` will ensure that the blocks get processes in the correct order (as requested).

If someone has a good testplan for this, please stand up.