### PR TITLE
WIP: remove script checking dependency on checkpoints

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -325,6 +325,7 @@ std::string HelpMessage(HelpMessageMode mode)
         strUsage += HelpMessageOpt("-blocksonly", strprintf(_("Whether to operate in a blocks only mode (default: %u)"), DEFAULT_BLOCKSONLY));
     strUsage += HelpMessageOpt("-checkblocks=<n>", strprintf(_("How many blocks to check at startup (default: %u, 0 = all)"), DEFAULT_CHECKBLOCKS));
     strUsage += HelpMessageOpt("-checklevel=<n>", strprintf(_("How thorough the block verification of -checkblocks is (0-4, default: %u)"), DEFAULT_CHECKLEVEL));
+    strUsage += HelpMessageOpt("-checkscriptnewer=<n>", strprintf(_("Only check scripts in blocks having a time within this many seconds of the current time. (default: %u seconds)"), DEFAULT_CHECK_SCRIPT_NEWER));
     strUsage += HelpMessageOpt("-conf=<file>", strprintf(_("Specify configuration file (default: %s)"), BITCOIN_CONF_FILENAME));
     if (mode == HMM_BITCOIND)
     {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -325,7 +325,7 @@ std::string HelpMessage(HelpMessageMode mode)
         strUsage += HelpMessageOpt("-blocksonly", strprintf(_("Whether to operate in a blocks only mode (default: %u)"), DEFAULT_BLOCKSONLY));
     strUsage += HelpMessageOpt("-checkblocks=<n>", strprintf(_("How many blocks to check at startup (default: %u, 0 = all)"), DEFAULT_CHECKBLOCKS));
     strUsage += HelpMessageOpt("-checklevel=<n>", strprintf(_("How thorough the block verification of -checkblocks is (0-4, default: %u)"), DEFAULT_CHECKLEVEL));
-    strUsage += HelpMessageOpt("-checkscriptnewer=<n>", strprintf(_("Only check scripts in blocks having a time within this many seconds of the current time. (default: %u seconds)"), DEFAULT_CHECK_SCRIPT_NEWER));
+    strUsage += HelpMessageOpt("-checkscriptdepth=<n>", strprintf(_("Do not check scripts in blocks that are buried under this number of blocks. (default: %u blocks)"), DEFAULT_CHECK_SCRIPT_DEPTH));
     strUsage += HelpMessageOpt("-conf=<file>", strprintf(_("Specify configuration file (default: %s)"), BITCOIN_CONF_FILENAME));
     if (mode == HMM_BITCOIND)
     {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2378,14 +2378,8 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
         return true;
     }
 
-    bool fScriptChecks = true;
-    if (fCheckpointsEnabled) {
-        CBlockIndex *pindexLastCheckpoint = Checkpoints::GetLastCheckpoint(chainparams.Checkpoints());
-        if (pindexLastCheckpoint && pindexLastCheckpoint->GetAncestor(pindex->nHeight) == pindex) {
-            // This block is an ancestor of a checkpoint: disable script checks
-            fScriptChecks = false;
-        }
-    }
+    const int64_t cutoffTime = GetAdjustedTime() - std::max<int64_t>(0, GetArg("-checkscriptnewer", DEFAULT_CHECK_SCRIPT_NEWER));
+    const bool fScriptChecks = !fCheckpointsEnabled || block.GetBlockTime() > cutoffTime;
 
     int64_t nTime1 = GetTimeMicros(); nTimeCheck += nTime1 - nTimeStart;
     LogPrint("bench", "    - Sanity checks: %.2fms [%.2fs]\n", 0.001 * (nTime1 - nTimeStart), nTimeCheck * 0.000001);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2378,8 +2378,8 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
         return true;
     }
 
-    const int64_t cutoffTime = GetAdjustedTime() - std::max<int64_t>(0, GetArg("-checkscriptnewer", DEFAULT_CHECK_SCRIPT_NEWER));
-    const bool fScriptChecks = !fCheckpointsEnabled || block.GetBlockTime() > cutoffTime;
+    const bool deepEnough = (chainActive.Height() - pindex->nHeight) >= std::max<int64_t>(0, GetArg("-checkscriptdepth", DEFAULT_CHECK_SCRIPT_DEPTH));
+    const bool fScriptChecks = !fCheckpointsEnabled || !deepEnough;
 
     int64_t nTime1 = GetTimeMicros(); nTimeCheck += nTime1 - nTimeStart;
     LogPrint("bench", "    - Sanity checks: %.2fms [%.2fs]\n", 0.001 * (nTime1 - nTimeStart), nTimeCheck * 0.000001);

--- a/src/main.h
+++ b/src/main.h
@@ -128,7 +128,8 @@ static const int64_t BLOCK_DOWNLOAD_TIMEOUT_PER_PEER = 500000;
 static const unsigned int DEFAULT_LIMITFREERELAY = 15;
 static const bool DEFAULT_RELAYPRIORITY = true;
 static const int64_t DEFAULT_MAX_TIP_AGE = 24 * 60 * 60;
-static const int64_t DEFAULT_CHECK_SCRIPT_NEWER = 30 * 24 * 60 * 60;
+/** Block depth from the tip that is subject to script checking (i.e. 30 days worth of blocks assuming 144 blocks a day) */
+static const int64_t DEFAULT_CHECK_SCRIPT_DEPTH = 6 * 24 * 30;
 
 /** Default for -permitbaremultisig */
 static const bool DEFAULT_PERMIT_BAREMULTISIG = true;

--- a/src/main.h
+++ b/src/main.h
@@ -128,6 +128,7 @@ static const int64_t BLOCK_DOWNLOAD_TIMEOUT_PER_PEER = 500000;
 static const unsigned int DEFAULT_LIMITFREERELAY = 15;
 static const bool DEFAULT_RELAYPRIORITY = true;
 static const int64_t DEFAULT_MAX_TIP_AGE = 24 * 60 * 60;
+static const int64_t DEFAULT_CHECK_SCRIPT_NEWER = 30 * 24 * 60 * 60;
 
 /** Default for -permitbaremultisig */
 static const bool DEFAULT_PERMIT_BAREMULTISIG = true;


### PR DESCRIPTION
Here's a quick change to remove a dependency on the checkpoints.

A new configurable option, -checkscriptnewer (with a default of 30 days specified in seconds) is created.
It allows bypassing the checking of scripts in blocks that are older than the configurable time. This was mentioned at https://github.com/bitcoin/bitcoin/issues/7591#issuecomment-189742561 and this is an attempt at doing it.
The old override, -checkpoints, still works with this.

Also, this fixes a minor bug with the current script checking dependency on checkpoints. The current checkpoints impl does not skip all the signature checking for pre-checkpoint blocks in some cases. For example, during headers-first IBD, it is a race between how fast the header chain is built relative to the next checkpoint available and how fast the block responses come in from async block requests. Once a checkpointed header is sync'ed, then all blocks before it will skip signature validation, but before that happens, sig checking is on. Yeah, like I said, it's minor.

Also, this pull shares some ideas with previous work https://github.com/bitcoinclassic/bitcoinclassic/pull/143, but I decided to use a configurable option.