### PR TITLE
NOMERGE: WIP: Support block signed custom testchains

### DIFF
--- a/contrib/devtools/check-doc.py
+++ b/contrib/devtools/check-doc.py
@@ -21,7 +21,7 @@ CMD_GREP_DOCS = r"egrep -r -I 'HelpMessageOpt\(\"\-[^\"=]+?(=|\")' %s" % (CMD_RO
 REGEX_ARG = re.compile(r'(?:map(?:Multi)?Args(?:\.count\(|\[)|Get(?:Bool)?Arg\()\"(\-[^\"]+?)\"')
 REGEX_DOC = re.compile(r'HelpMessageOpt\(\"(\-[^\"=]+?)(?:=|\")')
 # list unsupported, deprecated and duplicate args as they need no documentation
-SET_DOC_OPTIONAL = set(['-rpcssl', '-benchmark', '-h', '-help', '-socks', '-tor', '-debugnet', '-whitelistalwaysrelay', '-prematurewitness', '-walletprematurewitness', '-promiscuousmempoolflags', '-blockminsize'])
+SET_DOC_OPTIONAL = set(['-rpcssl', '-benchmark', '-h', '-help', '-socks', '-tor', '-debugnet', '-whitelistalwaysrelay', '-prematurewitness', '-walletprematurewitness', '-promiscuousmempoolflags', '-blockminsize', '-con_fpowallowmindifficultyblocks', '-con_fpownoretargeting', '-con_nsubsidyhalvinginterval', '-con_bip34height', '-con_bip65height', '-con_bip66height', '-con_npowtargettimespan', '-con_npowtargetspacing', '-con_nrulechangeactivationthreshold', '-con_nminerconfirmationwindow', '-con_powlimit', '-con_bip34hash', '-con_nminimumchainwork', '-ndefaultport', '-npruneafterheight', '-fminingrequirespeers', '-fdefaultconsistencychecks', '-frequirestandard', '-fmineblocksondemand'])
 
 def main():
   used = check_output(CMD_GREP_ARGS, shell=True)

--- a/qa/rpc-tests/pruning.py
+++ b/qa/rpc-tests/pruning.py
@@ -43,7 +43,7 @@ class PruneTest(BitcoinTestFramework):
 
         # Create node 2 to test pruning
         self.nodes.append(start_node(2, self.options.tmpdir, ["-debug","-maxreceivebuffer=20000","-prune=550"], timewait=900))
-        self.prunedir = self.options.tmpdir+"/node2/regtest/blocks/"
+        self.prunedir = self.options.tmpdir + "/node2/" + self.chain + "/blocks/"
 
         # Create nodes 3 and 4 to test manual pruning (they will be re-started with manual pruning later)
         self.nodes.append(start_node(3, self.options.tmpdir, ["-debug=0","-maxreceivebuffer=20000","-blockmaxsize=999000"], timewait=900))

--- a/qa/rpc-tests/segwit.py
+++ b/qa/rpc-tests/segwit.py
@@ -80,6 +80,7 @@ class SegWitTest(BitcoinTestFramework):
 
     def __init__(self):
         super().__init__()
+        self.chain = "regtest"
         self.setup_clean_chain = True
         self.num_nodes = 3
 

--- a/qa/rpc-tests/test_framework/test_framework.py
+++ b/qa/rpc-tests/test_framework/test_framework.py
@@ -32,7 +32,7 @@ from .authproxy import JSONRPCException
 class BitcoinTestFramework(object):
 
     def __init__(self):
-        self.chain = "regtest"
+        self.chain = "custom"
         self.num_nodes = 4
         self.setup_clean_chain = False
         self.nodes = None

--- a/qa/rpc-tests/test_framework/test_framework.py
+++ b/qa/rpc-tests/test_framework/test_framework.py
@@ -32,6 +32,7 @@ from .authproxy import JSONRPCException
 class BitcoinTestFramework(object):
 
     def __init__(self):
+        self.chain = "regtest"
         self.num_nodes = 4
         self.setup_clean_chain = False
         self.nodes = None
@@ -45,9 +46,9 @@ class BitcoinTestFramework(object):
     def setup_chain(self):
         print("Initializing test directory "+self.options.tmpdir)
         if self.setup_clean_chain:
-            initialize_chain_clean(self.options.tmpdir, self.num_nodes)
+            initialize_chain_clean(self.options.tmpdir, self.num_nodes, self.chain)
         else:
-            initialize_chain(self.options.tmpdir, self.num_nodes, self.options.cachedir)
+            initialize_chain(self.options.tmpdir, self.num_nodes, self.options.cachedir, self.chain)
 
     def stop_node(self, num_node):
         stop_node(self.nodes[num_node], num_node)

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -177,13 +177,13 @@ def sync_mempools(rpc_connections, *, wait=1, timeout=60):
 
 bitcoind_processes = {}
 
-def initialize_datadir(dirname, n):
+def initialize_datadir(dirname, n, chain):
     datadir = os.path.join(dirname, "node"+str(n))
     if not os.path.isdir(datadir):
         os.makedirs(datadir)
     rpc_u, rpc_p = rpc_auth_pair(n)
     with open(os.path.join(datadir, "bitcoin.conf"), 'w', encoding='utf8') as f:
-        f.write("regtest=1\n")
+        f.write("chain=%s\n" % chain)
         f.write("rpcuser=" + rpc_u + "\n")
         f.write("rpcpassword=" + rpc_p + "\n")
         f.write("port="+str(p2p_port(n))+"\n")
@@ -226,7 +226,7 @@ def wait_for_bitcoind_start(process, url, i):
                 raise # unknown JSON RPC exception
         time.sleep(0.25)
 
-def initialize_chain(test_dir, num_nodes, cachedir):
+def initialize_chain(test_dir, num_nodes, cachedir, chain):
     """
     Create a cache of a 200-block-long chain (with wallet) for MAX_NODES
     Afterward, create num_nodes copies from the cache
@@ -248,7 +248,7 @@ def initialize_chain(test_dir, num_nodes, cachedir):
 
         # Create cache directories, run bitcoinds:
         for i in range(MAX_NODES):
-            datadir=initialize_datadir(cachedir, i)
+            datadir=initialize_datadir(cachedir, i, chain)
             args = [ os.getenv("BITCOIND", "bitcoind"), "-server", "-keypool=1", "-datadir="+datadir, "-discover=0" ]
             if i > 0:
                 args.append("-connect=127.0.0.1:"+str(p2p_port(0)))
@@ -289,24 +289,24 @@ def initialize_chain(test_dir, num_nodes, cachedir):
         stop_nodes(rpcs)
         disable_mocktime()
         for i in range(MAX_NODES):
-            os.remove(log_filename(cachedir, i, "debug.log"))
-            os.remove(log_filename(cachedir, i, "db.log"))
-            os.remove(log_filename(cachedir, i, "peers.dat"))
-            os.remove(log_filename(cachedir, i, "fee_estimates.dat"))
+            os.remove(log_filename(cachedir, i, chain, "debug.log"))
+            os.remove(log_filename(cachedir, i, chain, "db.log"))
+            os.remove(log_filename(cachedir, i, chain, "peers.dat"))
+            os.remove(log_filename(cachedir, i, chain, "fee_estimates.dat"))
 
     for i in range(num_nodes):
         from_dir = os.path.join(cachedir, "node"+str(i))
         to_dir = os.path.join(test_dir,  "node"+str(i))
         shutil.copytree(from_dir, to_dir)
-        initialize_datadir(test_dir, i) # Overwrite port/rpcport in bitcoin.conf
+        initialize_datadir(test_dir, i, chain) # Overwrite port/rpcport in bitcoin.conf
 
-def initialize_chain_clean(test_dir, num_nodes):
+def initialize_chain_clean(test_dir, num_nodes, chain):
     """
     Create an empty blockchain and num_nodes wallets.
     Useful if a test case wants complete control over initialization.
     """
     for i in range(num_nodes):
-        datadir=initialize_datadir(test_dir, i)
+        datadir=initialize_datadir(test_dir, i, chain)
 
 
 def _rpchost_to_args(rpchost):
@@ -367,8 +367,8 @@ def start_nodes(num_nodes, dirname, extra_args=None, rpchost=None, timewait=None
         raise
     return rpcs
 
-def log_filename(dirname, n_node, logname):
-    return os.path.join(dirname, "node"+str(n_node), "regtest", logname)
+def log_filename(dirname, n_node, chain, logname):
+    return os.path.join(dirname, "node"+str(n_node), chain, logname)
 
 def stop_node(node, i):
     try:

--- a/qa/rpc-tests/wallet-hd.py
+++ b/qa/rpc-tests/wallet-hd.py
@@ -62,8 +62,8 @@ class WalletHDTest(BitcoinTestFramework):
 
         print("Restore backup ...")
         self.stop_node(1)
-        os.remove(self.options.tmpdir + "/node1/regtest/wallet.dat")
-        shutil.copyfile(tmpdir + "/hd.bak", tmpdir + "/node1/regtest/wallet.dat")
+        os.remove(self.options.tmpdir + "/node1/" + self.chain + "/wallet.dat")
+        shutil.copyfile(tmpdir + "/hd.bak", tmpdir + "/node1/" + self.chain + "/wallet.dat")
         self.nodes[1] = start_node(1, self.options.tmpdir, self.node_args[1])
         #connect_nodes_bi(self.nodes, 0, 1)
 

--- a/qa/rpc-tests/walletbackup.py
+++ b/qa/rpc-tests/walletbackup.py
@@ -97,9 +97,9 @@ class WalletBackupTest(BitcoinTestFramework):
         stop_node(self.nodes[2], 2)
 
     def erase_three(self):
-        os.remove(self.options.tmpdir + "/node0/regtest/wallet.dat")
-        os.remove(self.options.tmpdir + "/node1/regtest/wallet.dat")
-        os.remove(self.options.tmpdir + "/node2/regtest/wallet.dat")
+        os.remove(self.options.tmpdir + "/node0/" + self.chain + "/wallet.dat")
+        os.remove(self.options.tmpdir + "/node1/" + self.chain + "/wallet.dat")
+        os.remove(self.options.tmpdir + "/node2/" + self.chain + "/wallet.dat")
 
     def run_test(self):
         logging.info("Generating initial blockchain")
@@ -157,13 +157,13 @@ class WalletBackupTest(BitcoinTestFramework):
         self.erase_three()
 
         # Start node2 with no chain
-        shutil.rmtree(self.options.tmpdir + "/node2/regtest/blocks")
-        shutil.rmtree(self.options.tmpdir + "/node2/regtest/chainstate")
+        shutil.rmtree(self.options.tmpdir + "/node2/" + self.chain + "/blocks")
+        shutil.rmtree(self.options.tmpdir + "/node2/" + self.chain + "/chainstate")
 
         # Restore wallets from backup
-        shutil.copyfile(tmpdir + "/node0/wallet.bak", tmpdir + "/node0/regtest/wallet.dat")
-        shutil.copyfile(tmpdir + "/node1/wallet.bak", tmpdir + "/node1/regtest/wallet.dat")
-        shutil.copyfile(tmpdir + "/node2/wallet.bak", tmpdir + "/node2/regtest/wallet.dat")
+        shutil.copyfile(tmpdir + "/node0/wallet.bak", tmpdir + "/node0/" + self.chain + "/wallet.dat")
+        shutil.copyfile(tmpdir + "/node1/wallet.bak", tmpdir + "/node1/" + self.chain + "/wallet.dat")
+        shutil.copyfile(tmpdir + "/node2/wallet.bak", tmpdir + "/node2/" + self.chain + "/wallet.dat")
 
         logging.info("Re-starting nodes")
         self.start_three()
@@ -178,8 +178,8 @@ class WalletBackupTest(BitcoinTestFramework):
         self.erase_three()
 
         #start node2 with no chain
-        shutil.rmtree(self.options.tmpdir + "/node2/regtest/blocks")
-        shutil.rmtree(self.options.tmpdir + "/node2/regtest/chainstate")
+        shutil.rmtree(self.options.tmpdir + "/node2/" + self.chain + "/blocks")
+        shutil.rmtree(self.options.tmpdir + "/node2/" + self.chain + "/chainstate")
 
         self.start_three()
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -128,6 +128,7 @@ BITCOIN_CORE_H = \
   rpc/server.h \
   rpc/register.h \
   scheduler.h \
+  script/generic.hpp \
   script/sigcache.h \
   script/sign.h \
   script/standard.h \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -95,6 +95,7 @@ BITCOIN_CORE_H = \
   compat/sanity.h \
   compressor.h \
   consensus/consensus.h \
+  consensus/header_verify.h \
   core_io.h \
   core_memusage.h \
   cuckoocache.h \
@@ -181,6 +182,7 @@ libbitcoin_server_a_SOURCES = \
   blockencodings.cpp \
   chain.cpp \
   checkpoints.cpp \
+  consensus/header_verify.cpp \
   httprpc.cpp \
   httpserver.cpp \
   init.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -120,6 +120,7 @@ BITCOIN_TESTS =\
   test/scriptnum_tests.cpp \
   test/serialize_tests.cpp \
   test/sighash_tests.cpp \
+  test/signedblocks_tests.cpp \
   test/sigopcount_tests.cpp \
   test/skiplist_tests.cpp \
   test/streams_tests.cpp \

--- a/src/base58.cpp
+++ b/src/base58.cpp
@@ -288,8 +288,13 @@ bool CBitcoinAddress::IsScript() const
 
 void CBitcoinSecret::SetKey(const CKey& vchSecret)
 {
+    SetKey(vchSecret, Params());
+}
+
+void CBitcoinSecret::SetKey(const CKey& vchSecret, const CChainParams& chainparams)
+{
     assert(vchSecret.IsValid());
-    SetData(Params().Base58Prefix(CChainParams::SECRET_KEY), vchSecret.begin(), vchSecret.size());
+    SetData(chainparams.Base58Prefix(CChainParams::SECRET_KEY), vchSecret.begin(), vchSecret.size());
     if (vchSecret.IsCompressed())
         vchData.push_back(1);
 }

--- a/src/base58.h
+++ b/src/base58.h
@@ -125,6 +125,7 @@ public:
 class CBitcoinSecret : public CBase58Data
 {
 public:
+    void SetKey(const CKey& vchSecret, const CChainParams& chainparams);
     void SetKey(const CKey& vchSecret);
     CKey GetKey();
     bool IsValid() const;
@@ -132,6 +133,7 @@ public:
     bool SetString(const std::string& strSecret);
 
     CBitcoinSecret(const CKey& vchSecret) { SetKey(vchSecret); }
+    CBitcoinSecret(const CKey& vchSecret, const CChainParams& chainparams) { SetKey(vchSecret, chainparams); }
     CBitcoinSecret() {}
 };
 

--- a/src/bench/checkblock.cpp
+++ b/src/bench/checkblock.cpp
@@ -40,7 +40,7 @@ static void DeserializeAndCheckBlockTest(benchmark::State& state)
     char a;
     stream.write(&a, 1); // Prevent compaction
 
-    Consensus::Params params = Params(CBaseChainParams::MAIN).GetConsensus();
+    const auto chainParams = CreateChainParams(CBaseChainParams::MAIN);
 
     while (state.KeepRunning()) {
         CBlock block; // Note that CBlock caches its checked state, so we need to recreate it here
@@ -48,7 +48,7 @@ static void DeserializeAndCheckBlockTest(benchmark::State& state)
         assert(stream.Rewind(sizeof(block_bench::block413567)));
 
         CValidationState validationState;
-        assert(CheckBlock(block, validationState, params));
+        assert(CheckBlock(block, validationState, chainParams->GetConsensus()));
     }
 }
 

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -30,6 +30,8 @@ static const int CONTINUE_EXECUTION=-1;
 
 std::string HelpMessageCli()
 {
+    const auto defaultBaseParams = CreateBaseChainParams(CBaseChainParams::MAIN);
+    const auto testnetBaseParams = CreateBaseChainParams(CBaseChainParams::TESTNET);
     std::string strUsage;
     strUsage += HelpMessageGroup(_("Options:"));
     strUsage += HelpMessageOpt("-?", _("This help message"));
@@ -38,7 +40,7 @@ std::string HelpMessageCli()
     AppendParamsHelpMessages(strUsage);
     strUsage += HelpMessageOpt("-named", strprintf(_("Pass named instead of positional arguments (default: %s)"), DEFAULT_NAMED));
     strUsage += HelpMessageOpt("-rpcconnect=<ip>", strprintf(_("Send commands to node running on <ip> (default: %s)"), DEFAULT_RPCCONNECT));
-    strUsage += HelpMessageOpt("-rpcport=<port>", strprintf(_("Connect to JSON-RPC on <port> (default: %u or testnet: %u)"), BaseParams(CBaseChainParams::MAIN).RPCPort(), BaseParams(CBaseChainParams::TESTNET).RPCPort()));
+    strUsage += HelpMessageOpt("-rpcport=<port>", strprintf(_("Connect to JSON-RPC on <port> (default: %u or testnet: %u)"), defaultBaseParams->RPCPort(), testnetBaseParams->RPCPort()));
     strUsage += HelpMessageOpt("-rpcwait", _("Wait for RPC server to start"));
     strUsage += HelpMessageOpt("-rpcuser=<user>", _("Username for JSON-RPC connections"));
     strUsage += HelpMessageOpt("-rpcpassword=<pw>", _("Password for JSON-RPC connections"));

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -108,7 +108,7 @@ static int AppInitRPC(int argc, char* argv[])
         fprintf(stderr,"Error reading configuration file: %s\n", e.what());
         return EXIT_FAILURE;
     }
-    // Check for -testnet or -regtest parameter (BaseParams() calls are only valid after this clause)
+    // Check for -chain, -testnet or -regtest parameter (BaseParams() calls are only valid after this clause)
     try {
         SelectBaseParams(ChainNameFromCommandLine());
     } catch (const std::exception& e) {

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -41,7 +41,7 @@ static int AppInitRawTx(int argc, char* argv[])
     //
     ParseParameters(argc, argv);
 
-    // Check for -testnet or -regtest parameter (Params() calls are only valid after this clause)
+    // Check for -chain, -testnet or -regtest parameter (Params() calls are only valid after this clause)
     try {
         SelectParams(ChainNameFromCommandLine());
     } catch (const std::exception& e) {

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -109,7 +109,7 @@ bool AppInit(int argc, char* argv[])
             fprintf(stderr,"Error reading configuration file: %s\n", e.what());
             return false;
         }
-        // Check for -testnet or -regtest parameter (Params() calls are only valid after this clause)
+        // Check for -chain, -testnet or -regtest parameter (Params() calls are only valid after this clause)
         try {
             SelectParams(ChainNameFromCommandLine());
         } catch (const std::exception& e) {

--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -124,7 +124,7 @@ arith_uint256 GetBlockProof(const CBlockIndex& block)
     arith_uint256 bnTarget;
     bool fNegative;
     bool fOverflow;
-    bnTarget.SetCompact(block.nBits, &fNegative, &fOverflow);
+    bnTarget.SetCompact(block.proof.pow.nBits, &fNegative, &fOverflow);
     if (fNegative || fOverflow || bnTarget == 0)
         return 0;
     // We need to compute 2**256 / (bnTarget+1), but we can't represent 2**256

--- a/src/chain.h
+++ b/src/chain.h
@@ -7,8 +7,8 @@
 #define BITCOIN_CHAIN_H
 
 #include "arith_uint256.h"
+#include "consensus/params.h"
 #include "primitives/block.h"
-#include "pow.h"
 #include "tinyformat.h"
 #include "uint256.h"
 

--- a/src/chain.h
+++ b/src/chain.h
@@ -223,8 +223,12 @@ public:
         nVersion       = 0;
         hashMerkleRoot = uint256();
         nTime          = 0;
-        proof.pow.nBits = 0;
-        proof.pow.nNonce = 0;
+        if (fSignBlocksGlobal) {
+            proof.script = new CScript();
+        } else {
+            proof.pow.nBits = 0;
+            proof.pow.nNonce = 0;
+        }
     }
 
     CBlockIndex()

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -28,8 +28,8 @@ static CBlock CreateGenesisBlock(const char* pszTimestamp, const CScript& genesi
 
     CBlock genesis;
     genesis.nTime    = nTime;
-    genesis.nBits    = nBits;
-    genesis.nNonce   = nNonce;
+    genesis.proof.pow.nBits    = nBits;
+    genesis.proof.pow.nNonce   = nNonce;
     genesis.nVersion = nVersion;
     genesis.vtx.push_back(MakeTransactionRef(std::move(txNew)));
     genesis.hashPrevBlock.SetNull();

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -336,7 +336,7 @@ public:
 };
 
 /**
- * Regression test
+ * Custom params for testing.
  */
 class CCustomParams : public CChainParams {
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -335,6 +335,73 @@ public:
     }
 };
 
+/**
+ * Regression test
+ */
+class CCustomParams : public CChainParams {
+
+    void UpdateFromArgs()
+    {
+        strNetworkID = GetArg("-chainpetname", "custom");
+
+        consensus.fPowAllowMinDifficultyBlocks = GetBoolArg("-con_fpowallowmindifficultyblocks", true);
+        consensus.fPowNoRetargeting = GetBoolArg("-con_fpownoretargeting", true);
+        consensus.nSubsidyHalvingInterval = GetArg("-con_nsubsidyhalvinginterval", 150);
+        consensus.BIP34Height = GetArg("-con_bip34height", 100000000);
+        consensus.BIP65Height = GetArg("-con_bip65height", 1351);
+        consensus.BIP66Height = GetArg("-con_bip66height", 1251);
+        consensus.nPowTargetTimespan = GetArg("-con_npowtargettimespan", 14 * 24 * 60 * 60); // two weeks
+        consensus.nPowTargetSpacing = GetArg("-con_npowtargetspacing", 10 * 60);
+        consensus.nRuleChangeActivationThreshold = GetArg("-con_nrulechangeactivationthreshold", 108); // 75% for testchains
+        consensus.nMinerConfirmationWindow = GetArg("-con_nminerconfirmationwindow", 144); // Faster than normal for custom (144 instead of 2016)
+        consensus.powLimit = uint256S(GetArg("-con_powlimit", "7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"));
+        consensus.BIP34Hash = uint256S(GetArg("-con_bip34hash", "0x0"));
+        consensus.nMinimumChainWork = uint256S(GetArg("-con_nminimumchainwork", "0x0"));
+
+        nDefaultPort = GetArg("-ndefaultport", 18444);
+        nPruneAfterHeight = GetArg("-npruneafterheight", 1000);
+        fMiningRequiresPeers = GetBoolArg("-fminingrequirespeers", false);
+        fDefaultConsistencyChecks = GetBoolArg("-fdefaultconsistencychecks", true);
+        fRequireStandard = GetBoolArg("-frequirestandard", false);
+        fMineBlocksOnDemand = GetBoolArg("-fmineblocksondemand", true);
+    }
+
+public:
+    CCustomParams()
+    {
+        consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;
+        consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = 0;
+        consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nTimeout = 999999999999ULL;
+        consensus.vDeployments[Consensus::DEPLOYMENT_CSV].bit = 0;
+        consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nStartTime = 0;
+        consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nTimeout = 999999999999ULL;
+        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].bit = 1;
+        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nStartTime = 0;
+        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nTimeout = 999999999999ULL;
+
+        pchMessageStart[0] = 0xfa;
+        pchMessageStart[1] = 0xbf;
+        pchMessageStart[2] = 0xb5;
+        pchMessageStart[3] = 0xda;
+        vFixedSeeds.clear(); //!< Regtest mode doesn't have any fixed seeds.
+        vSeeds.clear();      //!< Regtest mode doesn't have any DNS seeds.
+        chainTxData = ChainTxData{
+            0,
+            0,
+            0
+        };
+        base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,111);
+        base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1,196);
+        base58Prefixes[SECRET_KEY] =     std::vector<unsigned char>(1,239);
+        base58Prefixes[EXT_PUBLIC_KEY] = boost::assign::list_of(0x04)(0x35)(0x87)(0xCF).convert_to_container<std::vector<unsigned char> >();
+        base58Prefixes[EXT_SECRET_KEY] = boost::assign::list_of(0x04)(0x35)(0x83)(0x94).convert_to_container<std::vector<unsigned char> >();
+
+        UpdateFromArgs();
+        genesis = CreateGenesisBlock(strNetworkID.c_str(), CScript(OP_TRUE), 1296688602, 2, 0x207fffff, 1, 50 * COIN);
+        consensus.hashGenesisBlock = genesis.GetHash();
+    }
+};
+
 static std::unique_ptr<CChainParams> globalChainParams;
 
 const CChainParams &Params() {
@@ -350,6 +417,9 @@ std::unique_ptr<CChainParams> CreateChainParams(const std::string& chain)
         return std::unique_ptr<CChainParams>(new CTestNetParams());
     else if (chain == CBaseChainParams::REGTEST)
         return std::unique_ptr<CChainParams>(new CRegTestParams());
+    else if (chain == CBaseChainParams::CUSTOM) {
+        return std::unique_ptr<CChainParams>(new CCustomParams());
+    }
     throw std::runtime_error(strprintf("%s: Unknown chain %s.", __func__, chain));
 }
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -336,7 +336,6 @@ public:
 };
 
 static std::unique_ptr<CChainParams> globalChainParams;
-static std::unique_ptr<CChainParams> globalSwitchingChainParams;
 
 const CChainParams &Params() {
     assert(globalChainParams);
@@ -352,12 +351,6 @@ std::unique_ptr<CChainParams> CreateChainParams(const std::string& chain)
     else if (chain == CBaseChainParams::REGTEST)
         return std::unique_ptr<CChainParams>(new CRegTestParams());
     throw std::runtime_error(strprintf("%s: Unknown chain %s.", __func__, chain));
-}
-
-const CChainParams& Params(const std::string& chain)
-{
-    globalSwitchingChainParams = CreateChainParams(chain);
-    return *globalSwitchingChainParams;
 }
 
 void SelectParams(const std::string& network)

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -55,6 +55,12 @@ static CBlock CreateGenesisBlock(uint32_t nTime, uint32_t nNonce, uint32_t nBits
     return CreateGenesisBlock(pszTimestamp, genesisOutputScript, nTime, nNonce, nBits, nVersion, genesisReward);
 }
 
+void CChainParams::UpdateBIP9Parameters(Consensus::DeploymentPos d, int64_t nStartTime, int64_t nTimeout)
+{
+    consensus.vDeployments[d].nStartTime = nStartTime;
+    consensus.vDeployments[d].nTimeout = nTimeout;
+}
+
 /**
  * Main network
  */
@@ -166,7 +172,6 @@ public:
         };
     }
 };
-static CMainParams mainParams;
 
 /**
  * Testnet (v3)
@@ -255,7 +260,6 @@ public:
 
     }
 };
-static CTestNetParams testNetParams;
 
 /**
  * Regression test
@@ -329,42 +333,41 @@ public:
         base58Prefixes[EXT_PUBLIC_KEY] = boost::assign::list_of(0x04)(0x35)(0x87)(0xCF).convert_to_container<std::vector<unsigned char> >();
         base58Prefixes[EXT_SECRET_KEY] = boost::assign::list_of(0x04)(0x35)(0x83)(0x94).convert_to_container<std::vector<unsigned char> >();
     }
-
-    void UpdateBIP9Parameters(Consensus::DeploymentPos d, int64_t nStartTime, int64_t nTimeout)
-    {
-        consensus.vDeployments[d].nStartTime = nStartTime;
-        consensus.vDeployments[d].nTimeout = nTimeout;
-    }
 };
-static CRegTestParams regTestParams;
 
-static CChainParams *pCurrentParams = 0;
+static std::unique_ptr<CChainParams> globalChainParams;
+static std::unique_ptr<CChainParams> globalSwitchingChainParams;
 
 const CChainParams &Params() {
-    assert(pCurrentParams);
-    return *pCurrentParams;
+    assert(globalChainParams);
+    return *globalChainParams;
 }
 
-CChainParams& Params(const std::string& chain)
+std::unique_ptr<CChainParams> CreateChainParams(const std::string& chain)
 {
     if (chain == CBaseChainParams::MAIN)
-            return mainParams;
+        return std::unique_ptr<CChainParams>(new CMainParams());
     else if (chain == CBaseChainParams::TESTNET)
-            return testNetParams;
+        return std::unique_ptr<CChainParams>(new CTestNetParams());
     else if (chain == CBaseChainParams::REGTEST)
-            return regTestParams;
-    else
-        throw std::runtime_error(strprintf("%s: Unknown chain %s.", __func__, chain));
+        return std::unique_ptr<CChainParams>(new CRegTestParams());
+    throw std::runtime_error(strprintf("%s: Unknown chain %s.", __func__, chain));
+}
+
+const CChainParams& Params(const std::string& chain)
+{
+    globalSwitchingChainParams = CreateChainParams(chain);
+    return *globalSwitchingChainParams;
 }
 
 void SelectParams(const std::string& network)
 {
     SelectBaseParams(network);
-    pCurrentParams = &Params(network);
+    globalChainParams = CreateChainParams(network);
 }
 
-void UpdateRegtestBIP9Parameters(Consensus::DeploymentPos d, int64_t nStartTime, int64_t nTimeout)
+void UpdateBIP9Parameters(Consensus::DeploymentPos d, int64_t nStartTime, int64_t nTimeout)
 {
-    regTestParams.UpdateBIP9Parameters(d, nStartTime, nTimeout);
+    globalChainParams->UpdateBIP9Parameters(d, nStartTime, nTimeout);
 }
  

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -14,6 +14,8 @@
 #include <memory>
 #include <vector>
 
+class ArgsManager;
+
 struct CDNSSeedData {
     std::string name, host;
     bool supportsServiceBitsFiltering;
@@ -105,6 +107,7 @@ protected:
  * @throws a std::runtime_error if the chain is not supported.
  */
 std::unique_ptr<CChainParams> CreateChainParams(const std::string& chain);
+std::unique_ptr<CChainParams> CreateChainParams(const std::string& chain, ArgsManager& chainArgsMan);
 
 /**
  * Return the currently selected parameters. This won't change after app

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -11,6 +11,7 @@
 #include "primitives/block.h"
 #include "protocol.h"
 
+#include <memory>
 #include <vector>
 
 struct CDNSSeedData {
@@ -77,6 +78,7 @@ public:
     const std::vector<SeedSpec6>& FixedSeeds() const { return vFixedSeeds; }
     const CCheckpointData& Checkpoints() const { return checkpointData; }
     const ChainTxData& TxData() const { return chainTxData; }
+    void UpdateBIP9Parameters(Consensus::DeploymentPos d, int64_t nStartTime, int64_t nTimeout);
 protected:
     CChainParams() {}
 
@@ -98,6 +100,13 @@ protected:
 };
 
 /**
+ * Creates and returns a std::unique_ptr<CChainParams> of the chosen chain.
+ * @returns a CChainParams* of the chosen chain.
+ * @throws a std::runtime_error if the chain is not supported.
+ */
+std::unique_ptr<CChainParams> CreateChainParams(const std::string& chain);
+
+/**
  * Return the currently selected parameters. This won't change after app
  * startup, except for unit tests.
  */
@@ -106,7 +115,7 @@ const CChainParams &Params();
 /**
  * @returns CChainParams for the given BIP70 chain name.
  */
-CChainParams& Params(const std::string& chain);
+const CChainParams& Params(const std::string& chain);
 
 /**
  * Sets the params returned by Params() to those for the given BIP70 chain name.
@@ -117,6 +126,6 @@ void SelectParams(const std::string& chain);
 /**
  * Allows modifying the BIP9 regtest parameters.
  */
-void UpdateRegtestBIP9Parameters(Consensus::DeploymentPos d, int64_t nStartTime, int64_t nTimeout);
+void UpdateBIP9Parameters(Consensus::DeploymentPos d, int64_t nStartTime, int64_t nTimeout);
 
 #endif // BITCOIN_CHAINPARAMS_H

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -113,11 +113,6 @@ std::unique_ptr<CChainParams> CreateChainParams(const std::string& chain);
 const CChainParams &Params();
 
 /**
- * @returns CChainParams for the given BIP70 chain name.
- */
-const CChainParams& Params(const std::string& chain);
-
-/**
  * Sets the params returned by Params() to those for the given BIP70 chain name.
  * @throws std::runtime_error when the chain is not supported.
  */

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -17,6 +17,7 @@ const std::string CBaseChainParams::REGTEST = "regtest";
 void AppendParamsHelpMessages(std::string& strUsage, bool debugHelp)
 {
     strUsage += HelpMessageGroup(_("Chain selection options:"));
+    strUsage += HelpMessageOpt("-chain=<chain>", _("Use the chain <chain> (default: main). Allowed values: main, testnet, regtest"));
     strUsage += HelpMessageOpt("-testnet", _("Use the test chain"));
     if (debugHelp) {
         strUsage += HelpMessageOpt("-regtest", "Enter regression test mode, which uses a special chain in which blocks can be solved instantly. "
@@ -98,7 +99,7 @@ std::string ChainNameFromCommandLine()
         return CBaseChainParams::REGTEST;
     if (fTestNet)
         return CBaseChainParams::TESTNET;
-    return CBaseChainParams::MAIN;
+    return GetArg("-chain", CBaseChainParams::MAIN);
 }
 
 bool AreBaseParamsConfigured()

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -26,6 +26,8 @@ void AppendParamsHelpMessages(std::string& strUsage, bool debugHelp)
         strUsage += HelpMessageGroup(_("Custom chain selection options (only for -chain=custom):"));
         strUsage += HelpMessageOpt("-chainconf=<file>", strprintf(_("Specify configuration file for chain parameters (default: %s). All custom chain arguments except this one must be configured using this file."), CHAINPARAMS_CONF_FILENAME));
         strUsage += HelpMessageOpt("-chainpetname=<name>", _("Alternative name for custom chain (default: custom). This changes the genesis block."));
+        strUsage += HelpMessageOpt("-con_fsignblockchain", _("Use signed blocks instead of pow: (default: true))"));
+        strUsage += HelpMessageOpt("-con_signblockscript=<hexScript>", _("Specify the scriptPubKey for block signing: (default: OP_TRUE))"));
     }
 }
 

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -24,6 +24,7 @@ void AppendParamsHelpMessages(std::string& strUsage, bool debugHelp)
         strUsage += HelpMessageOpt("-regtest", "Enter regression test mode, which uses a special chain in which blocks can be solved instantly. "
                                    "This is intended for regression testing tools and app development.");
         strUsage += HelpMessageGroup(_("Custom chain selection options (only for -chain=custom):"));
+        strUsage += HelpMessageOpt("-chainconf=<file>", strprintf(_("Specify configuration file for chain parameters (default: %s). All custom chain arguments except this one must be configured using this file."), CHAINPARAMS_CONF_FILENAME));
         strUsage += HelpMessageOpt("-chainpetname=<name>", _("Alternative name for custom chain (default: custom). This changes the genesis block."));
     }
 }

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -13,15 +13,18 @@
 const std::string CBaseChainParams::MAIN = "main";
 const std::string CBaseChainParams::TESTNET = "test";
 const std::string CBaseChainParams::REGTEST = "regtest";
+const std::string CBaseChainParams::CUSTOM = "custom";
 
 void AppendParamsHelpMessages(std::string& strUsage, bool debugHelp)
 {
     strUsage += HelpMessageGroup(_("Chain selection options:"));
-    strUsage += HelpMessageOpt("-chain=<chain>", _("Use the chain <chain> (default: main). Allowed values: main, testnet, regtest"));
+    strUsage += HelpMessageOpt("-chain=<chain>", _("Use the chain <chain> (default: main). Allowed values: main, testnet, regtest, custom"));
     strUsage += HelpMessageOpt("-testnet", _("Use the test chain"));
     if (debugHelp) {
         strUsage += HelpMessageOpt("-regtest", "Enter regression test mode, which uses a special chain in which blocks can be solved instantly. "
                                    "This is intended for regression testing tools and app development.");
+        strUsage += HelpMessageGroup(_("Custom chain selection options (only for -chain=custom):"));
+        strUsage += HelpMessageOpt("-chainpetname=<name>", _("Alternative name for custom chain (default: custom). This changes the genesis block."));
     }
 }
 
@@ -63,6 +66,19 @@ public:
     }
 };
 
+/*
+ * Regression test
+ */
+class CBaseCustomParams : public CBaseChainParams
+{
+public:
+    CBaseCustomParams()
+    {
+        nRPCPort = 18332;
+        strDataDir = "custom";
+    }
+};
+
 static std::unique_ptr<CBaseChainParams> globalChainBaseParams;
 
 const CBaseChainParams& BaseParams()
@@ -79,6 +95,8 @@ std::unique_ptr<CBaseChainParams> CreateBaseChainParams(const std::string& chain
         return std::unique_ptr<CBaseChainParams>(new CBaseTestNetParams());
     else if (chain == CBaseChainParams::REGTEST)
         return std::unique_ptr<CBaseChainParams>(new CBaseRegTestParams());
+    else if (chain == CBaseChainParams::CUSTOM)
+        return std::unique_ptr<CBaseChainParams>(new CBaseCustomParams());
     else
         throw std::runtime_error(strprintf("%s: Unknown chain %s.", __func__, chain));
 }

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -35,7 +35,6 @@ public:
         nRPCPort = 8332;
     }
 };
-static CBaseMainParams mainParams;
 
 /**
  * Testnet (v3)
@@ -49,7 +48,6 @@ public:
         strDataDir = "testnet3";
     }
 };
-static CBaseTestNetParams testNetParams;
 
 /*
  * Regression test
@@ -63,31 +61,30 @@ public:
         strDataDir = "regtest";
     }
 };
-static CBaseRegTestParams regTestParams;
 
-static CBaseChainParams* pCurrentBaseParams = 0;
+static std::unique_ptr<CBaseChainParams> globalChainBaseParams;
 
 const CBaseChainParams& BaseParams()
 {
-    assert(pCurrentBaseParams);
-    return *pCurrentBaseParams;
+    assert(globalChainBaseParams);
+    return *globalChainBaseParams;
 }
 
-CBaseChainParams& BaseParams(const std::string& chain)
+std::unique_ptr<CBaseChainParams> CreateBaseChainParams(const std::string& chain)
 {
     if (chain == CBaseChainParams::MAIN)
-        return mainParams;
+        return std::unique_ptr<CBaseChainParams>(new CBaseMainParams());
     else if (chain == CBaseChainParams::TESTNET)
-        return testNetParams;
+        return std::unique_ptr<CBaseChainParams>(new CBaseTestNetParams());
     else if (chain == CBaseChainParams::REGTEST)
-        return regTestParams;
+        return std::unique_ptr<CBaseChainParams>(new CBaseRegTestParams());
     else
         throw std::runtime_error(strprintf("%s: Unknown chain %s.", __func__, chain));
 }
 
 void SelectBaseParams(const std::string& chain)
 {
-    pCurrentBaseParams = &BaseParams(chain);
+    globalChainBaseParams = CreateBaseChainParams(chain);
 }
 
 std::string ChainNameFromCommandLine()
@@ -106,5 +103,5 @@ std::string ChainNameFromCommandLine()
 
 bool AreBaseParamsConfigured()
 {
-    return pCurrentBaseParams != NULL;
+    return globalChainBaseParams.get();
 }

--- a/src/chainparamsbase.h
+++ b/src/chainparamsbase.h
@@ -5,6 +5,7 @@
 #ifndef BITCOIN_CHAINPARAMSBASE_H
 #define BITCOIN_CHAINPARAMSBASE_H
 
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -31,6 +32,13 @@ protected:
 };
 
 /**
+ * Creates and returns a std::unique_ptr<CBaseChainParams> of the chosen chain.
+ * @returns a CBaseChainParams* of the chosen chain.
+ * @throws a std::runtime_error if the chain is not supported.
+ */
+std::unique_ptr<CBaseChainParams> CreateBaseChainParams(const std::string& chain);
+
+/**
  * Append the help messages for the chainparams options to the
  * parameter string.
  */
@@ -41,8 +49,6 @@ void AppendParamsHelpMessages(std::string& strUsage, bool debugHelp=true);
  * startup, except for unit tests.
  */
 const CBaseChainParams& BaseParams();
-
-CBaseChainParams& BaseParams(const std::string& chain);
 
 /** Sets the params returned by Params() to those for the given network. */
 void SelectBaseParams(const std::string& chain);

--- a/src/chainparamsbase.h
+++ b/src/chainparamsbase.h
@@ -9,6 +9,8 @@
 #include <string>
 #include <vector>
 
+#define CHAINPARAMS_CONF_FILENAME "chainparams.conf"
+
 /**
  * CBaseChainParams defines the base parameters (shared between bitcoin-cli and bitcoind)
  * of a given instance of the Bitcoin system.
@@ -20,6 +22,7 @@ public:
     static const std::string MAIN;
     static const std::string TESTNET;
     static const std::string REGTEST;
+    static const std::string CUSTOM;
 
     const std::string& DataDir() const { return strDataDir; }
     int RPCPort() const { return nRPCPort; }

--- a/src/consensus/header_verify.cpp
+++ b/src/consensus/header_verify.cpp
@@ -11,7 +11,7 @@
 
 bool CheckProof(const Consensus::Params& consensusParams, const CBlockHeader& block)
 {
-    if (!CheckProofOfWork(block.GetHash(), block.nBits, consensusParams))
+    if (!CheckProofOfWork(block.GetHash(), block.proof.pow.nBits, consensusParams))
         return false;
 
     return true;
@@ -20,11 +20,11 @@ bool CheckProof(const Consensus::Params& consensusParams, const CBlockHeader& bl
 bool MaybeGenerateProof(const Consensus::Params& consensusParams, CBlockHeader* pblock, uint64_t& nTries)
 {
     const int nInnerLoopCount = 0x10000;
-    while (nTries > 0 && pblock->nNonce < nInnerLoopCount && !CheckProofOfWork(pblock->GetHash(), pblock->nBits, consensusParams)) {
-        ++pblock->nNonce;
+    while (nTries > 0 && pblock->proof.pow.nNonce < nInnerLoopCount && !CheckProofOfWork(pblock->GetHash(), pblock->proof.pow.nBits, consensusParams)) {
+        ++pblock->proof.pow.nNonce;
         --nTries;
     }
-    return CheckProofOfWork(pblock->GetHash(), pblock->nBits, consensusParams);
+    return CheckProofOfWork(pblock->GetHash(), pblock->proof.pow.nBits, consensusParams);
 }
 
 bool GenerateProof(const Consensus::Params& consensusParams, CBlockHeader* pblock)
@@ -35,12 +35,12 @@ bool GenerateProof(const Consensus::Params& consensusParams, CBlockHeader* pbloc
 
 void ResetProof(const Consensus::Params& consensusParams, CBlockHeader* pblock)
 {
-    pblock->nNonce = 0;
+    pblock->proof.pow.nNonce = 0;
 }
 
 bool CheckChallenge(const Consensus::Params& consensusParams, CValidationState& state, const CBlockHeader *pblock, const CBlockIndex* pindexPrev)
 {
-    if (pblock->nBits != GetNextWorkRequired(pindexPrev, pblock, consensusParams))
+    if (pblock->proof.pow.nBits != GetNextWorkRequired(pindexPrev, pblock, consensusParams))
         return state.DoS(100, false, REJECT_INVALID, "bad-diffbits", false, "incorrect proof of work");
 
     return true;
@@ -48,5 +48,5 @@ bool CheckChallenge(const Consensus::Params& consensusParams, CValidationState& 
 
 void ResetChallenge(const Consensus::Params& consensusParams, CBlockHeader* pblock, const CBlockIndex* pindexPrev)
 {
-    pblock->nBits = GetNextWorkRequired(pindexPrev, pblock, consensusParams);
+    pblock->proof.pow.nBits = GetNextWorkRequired(pindexPrev, pblock, consensusParams);
 }

--- a/src/consensus/header_verify.cpp
+++ b/src/consensus/header_verify.cpp
@@ -1,0 +1,52 @@
+// Copyright (c) 2016-2016 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "header_verify.h"
+
+#include "params.h"
+#include "pow.h"
+#include "primitives/block.h"
+#include "validation.h"
+
+bool CheckProof(const Consensus::Params& consensusParams, const CBlockHeader& block)
+{
+    if (!CheckProofOfWork(block.GetHash(), block.nBits, consensusParams))
+        return false;
+
+    return true;
+}
+
+bool MaybeGenerateProof(const Consensus::Params& consensusParams, CBlockHeader* pblock, uint64_t& nTries)
+{
+    const int nInnerLoopCount = 0x10000;
+    while (nTries > 0 && pblock->nNonce < nInnerLoopCount && !CheckProofOfWork(pblock->GetHash(), pblock->nBits, consensusParams)) {
+        ++pblock->nNonce;
+        --nTries;
+    }
+    return CheckProofOfWork(pblock->GetHash(), pblock->nBits, consensusParams);
+}
+
+bool GenerateProof(const Consensus::Params& consensusParams, CBlockHeader* pblock)
+{
+    uint64_t nTries = 10000;
+    return MaybeGenerateProof(consensusParams, pblock, nTries);
+}
+
+void ResetProof(const Consensus::Params& consensusParams, CBlockHeader* pblock)
+{
+    pblock->nNonce = 0;
+}
+
+bool CheckChallenge(const Consensus::Params& consensusParams, CValidationState& state, const CBlockHeader *pblock, const CBlockIndex* pindexPrev)
+{
+    if (pblock->nBits != GetNextWorkRequired(pindexPrev, pblock, consensusParams))
+        return state.DoS(100, false, REJECT_INVALID, "bad-diffbits", false, "incorrect proof of work");
+
+    return true;
+}
+
+void ResetChallenge(const Consensus::Params& consensusParams, CBlockHeader* pblock, const CBlockIndex* pindexPrev)
+{
+    pblock->nBits = GetNextWorkRequired(pindexPrev, pblock, consensusParams);
+}

--- a/src/consensus/header_verify.cpp
+++ b/src/consensus/header_verify.cpp
@@ -7,18 +7,38 @@
 #include "params.h"
 #include "pow.h"
 #include "primitives/block.h"
+#include "script/generic.hpp"
+#include "script/interpreter.h"
 #include "validation.h"
+
+#define BLOCK_SIGN_SCRIPT_FLAGS SCRIPT_VERIFY_NONE // TODO signblocks: complete
 
 bool CheckProof(const Consensus::Params& consensusParams, const CBlockHeader& block)
 {
-    if (!CheckProofOfWork(block.GetHash(), block.proof.pow.nBits, consensusParams))
+    if (consensusParams.fSignBlockChain) {
+        if (!block.proof.script ||
+            !GenericVerifyScript(*block.proof.script, consensusParams.blocksignScript, BLOCK_SIGN_SCRIPT_FLAGS, block)) {
+            return false;
+        }
+    } else if (!CheckProofOfWork(block.GetHash(), block.proof.pow.nBits, consensusParams))
         return false;
 
     return true;
 }
 
-bool MaybeGenerateProof(const Consensus::Params& consensusParams, CBlockHeader* pblock, uint64_t& nTries)
+bool MaybeGenerateProof(const Consensus::Params& consensusParams, CBlockHeader* pblock, const CKeyStore* pkeystore, uint64_t& nTries)
 {
+    if (consensusParams.fSignBlockChain) {
+        if (!pkeystore)
+            return false;
+        SignatureData solution(*pblock->proof.script);
+        nTries = 0;
+        if (!GenericSignScript(*pkeystore, *pblock, consensusParams.blocksignScript, solution))
+            return false;
+        pblock->proof.script = new CScript(solution.scriptSig);
+        return CheckProof(consensusParams, *pblock);
+    }
+
     const int nInnerLoopCount = 0x10000;
     while (nTries > 0 && pblock->proof.pow.nNonce < nInnerLoopCount && !CheckProofOfWork(pblock->GetHash(), pblock->proof.pow.nBits, consensusParams)) {
         ++pblock->proof.pow.nNonce;
@@ -27,20 +47,25 @@ bool MaybeGenerateProof(const Consensus::Params& consensusParams, CBlockHeader* 
     return CheckProofOfWork(pblock->GetHash(), pblock->proof.pow.nBits, consensusParams);
 }
 
-bool GenerateProof(const Consensus::Params& consensusParams, CBlockHeader* pblock)
+bool GenerateProof(const Consensus::Params& consensusParams, CBlockHeader* pblock, const CKeyStore* pkeystore)
 {
     uint64_t nTries = 10000;
-    return MaybeGenerateProof(consensusParams, pblock, nTries);
+    return MaybeGenerateProof(consensusParams, pblock, pkeystore, nTries);
 }
 
 void ResetProof(const Consensus::Params& consensusParams, CBlockHeader* pblock)
 {
-    pblock->proof.pow.nNonce = 0;
+    if (consensusParams.fSignBlockChain) 
+        *pblock->proof.script = CScript();
+    else
+        pblock->proof.pow.nNonce = 0;
 }
 
 bool CheckChallenge(const Consensus::Params& consensusParams, CValidationState& state, const CBlockHeader *pblock, const CBlockIndex* pindexPrev)
 {
-    if (pblock->proof.pow.nBits != GetNextWorkRequired(pindexPrev, pblock, consensusParams))
+    if (consensusParams.fSignBlockChain)
+        return true; // The scriptPubKey for blocksigning is constant in consensusParams
+    else if (pblock->proof.pow.nBits != GetNextWorkRequired(pindexPrev, pblock, consensusParams))
         return state.DoS(100, false, REJECT_INVALID, "bad-diffbits", false, "incorrect proof of work");
 
     return true;
@@ -48,5 +73,7 @@ bool CheckChallenge(const Consensus::Params& consensusParams, CValidationState& 
 
 void ResetChallenge(const Consensus::Params& consensusParams, CBlockHeader* pblock, const CBlockIndex* pindexPrev)
 {
-    pblock->proof.pow.nBits = GetNextWorkRequired(pindexPrev, pblock, consensusParams);
+    // The scriptPubKey for blocksigning is constant in consensusParams
+    if (!consensusParams.fSignBlockChain)
+        pblock->proof.pow.nBits = GetNextWorkRequired(pindexPrev, pblock, consensusParams);
 }

--- a/src/consensus/header_verify.h
+++ b/src/consensus/header_verify.h
@@ -9,13 +9,14 @@
 
 class CBlockHeader;
 class CBlockIndex;
+class CKeyStore;
 class CValidationState;
 namespace Consensus { struct Params; };
 
 bool CheckProof(const Consensus::Params& consensusParams, const CBlockHeader& pblock);
-bool MaybeGenerateProof(const Consensus::Params& consensusParams, CBlockHeader* pblock, uint64_t& nTries);
+bool MaybeGenerateProof(const Consensus::Params& consensusParams, CBlockHeader* pblock, const CKeyStore* pkeystore, uint64_t& nTries);
 /** More convenient by hiding ref var nTries for testing */
-bool GenerateProof(const Consensus::Params& consensusParams, CBlockHeader* pblock);
+bool GenerateProof(const Consensus::Params& consensusParams, CBlockHeader* pblock, const CKeyStore* pkeystore);
 void ResetProof(const Consensus::Params& consensusParams, CBlockHeader* pblock);
 
 bool CheckChallenge(const Consensus::Params& consensusParams, CValidationState& state, const CBlockHeader *pblock, const CBlockIndex* pindexPrev);

--- a/src/consensus/header_verify.h
+++ b/src/consensus/header_verify.h
@@ -1,0 +1,24 @@
+// Copyright (c) 2016-2016 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_HEADER_VERIFY_H
+#define BITCOIN_HEADER_VERIFY_H
+
+#include "consensus/params.h"
+
+class CBlockHeader;
+class CBlockIndex;
+class CValidationState;
+namespace Consensus { struct Params; };
+
+bool CheckProof(const Consensus::Params& consensusParams, const CBlockHeader& pblock);
+bool MaybeGenerateProof(const Consensus::Params& consensusParams, CBlockHeader* pblock, uint64_t& nTries);
+/** More convenient by hiding ref var nTries for testing */
+bool GenerateProof(const Consensus::Params& consensusParams, CBlockHeader* pblock);
+void ResetProof(const Consensus::Params& consensusParams, CBlockHeader* pblock);
+
+bool CheckChallenge(const Consensus::Params& consensusParams, CValidationState& state, const CBlockHeader *pblock, const CBlockIndex* pindexPrev);
+void ResetChallenge(const Consensus::Params& consensusParams, CBlockHeader* pblock, const CBlockIndex* pindexPrev);
+
+#endif // BITCOIN_HEADER_VERIFY_H

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -6,6 +6,7 @@
 #ifndef BITCOIN_CONSENSUS_PARAMS_H
 #define BITCOIN_CONSENSUS_PARAMS_H
 
+#include "script/script.h"
 #include "uint256.h"
 #include <map>
 #include <string>
@@ -63,6 +64,9 @@ struct Params {
     int64_t DifficultyAdjustmentInterval() const { return nPowTargetTimespan / nPowTargetSpacing; }
     uint256 nMinimumChainWork;
     uint256 defaultAssumeValid;
+    /** Signed blocks parameters */
+    bool fSignBlockChain;
+    CScript blocksignScript;
 };
 } // namespace Consensus
 

--- a/src/httprpc.cpp
+++ b/src/httprpc.cpp
@@ -93,7 +93,7 @@ static bool multiUserAuthorized(std::string strUserPass)
     std::string strUser = strUserPass.substr(0, strUserPass.find(":"));
     std::string strPass = strUserPass.substr(strUserPass.find(":") + 1);
 
-    if (mapMultiArgs.count("-rpcauth") > 0) {
+    if (argsGlobal.IsArgSet("-rpcauth") > 0) {
         //Search for multi-user login/pass "rpcauth" from config
         BOOST_FOREACH(std::string strRPCAuth, mapMultiArgs.at("-rpcauth"))
         {

--- a/src/httprpc.cpp
+++ b/src/httprpc.cpp
@@ -95,7 +95,7 @@ static bool multiUserAuthorized(std::string strUserPass)
 
     if (argsGlobal.IsArgSet("-rpcauth") > 0) {
         //Search for multi-user login/pass "rpcauth" from config
-        BOOST_FOREACH(std::string strRPCAuth, mapMultiArgs.at("-rpcauth"))
+        BOOST_FOREACH(std::string strRPCAuth, argsGlobal.ArgsAt("-rpcauth"))
         {
             std::vector<std::string> vFields;
             boost::split(vFields, strRPCAuth, boost::is_any_of(":$"));

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -203,7 +203,7 @@ static bool InitHTTPAllowList()
     LookupHost("::1", localv6, false);
     rpc_allow_subnets.push_back(CSubNet(localv4, 8));      // always allow IPv4 local subnet
     rpc_allow_subnets.push_back(CSubNet(localv6));         // always allow IPv6 localhost
-    if (mapMultiArgs.count("-rpcallowip")) {
+    if (argsGlobal.IsArgSet("-rpcallowip")) {
         const std::vector<std::string>& vAllow = mapMultiArgs.at("-rpcallowip");
         for (std::string strAllow : vAllow) {
             CSubNet subnet;
@@ -328,7 +328,7 @@ static bool HTTPBindAddresses(struct evhttp* http)
         if (IsArgSet("-rpcbind")) {
             LogPrintf("WARNING: option -rpcbind was ignored because -rpcallowip was not specified, refusing to allow everyone to connect\n");
         }
-    } else if (mapMultiArgs.count("-rpcbind")) { // Specific bind address
+    } else if (argsGlobal.IsArgSet("-rpcbind")) { // Specific bind address
         const std::vector<std::string>& vbind = mapMultiArgs.at("-rpcbind");
         for (std::vector<std::string>::const_iterator i = vbind.begin(); i != vbind.end(); ++i) {
             int port = defaultPort;

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -204,7 +204,7 @@ static bool InitHTTPAllowList()
     rpc_allow_subnets.push_back(CSubNet(localv4, 8));      // always allow IPv4 local subnet
     rpc_allow_subnets.push_back(CSubNet(localv6));         // always allow IPv6 localhost
     if (argsGlobal.IsArgSet("-rpcallowip")) {
-        const std::vector<std::string>& vAllow = mapMultiArgs.at("-rpcallowip");
+        const std::vector<std::string>& vAllow = argsGlobal.ArgsAt("-rpcallowip");
         for (std::string strAllow : vAllow) {
             CSubNet subnet;
             LookupSubNet(strAllow.c_str(), subnet);
@@ -329,7 +329,7 @@ static bool HTTPBindAddresses(struct evhttp* http)
             LogPrintf("WARNING: option -rpcbind was ignored because -rpcallowip was not specified, refusing to allow everyone to connect\n");
         }
     } else if (argsGlobal.IsArgSet("-rpcbind")) { // Specific bind address
-        const std::vector<std::string>& vbind = mapMultiArgs.at("-rpcbind");
+        const std::vector<std::string>& vbind = argsGlobal.ArgsAt("-rpcbind");
         for (std::vector<std::string>::const_iterator i = vbind.begin(); i != vbind.end(); ++i) {
             int port = defaultPort;
             std::string host;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -732,7 +732,7 @@ void InitParameterInteraction()
             LogPrintf("%s: parameter interaction: -whitebind set -> setting -listen=1\n", __func__);
     }
 
-    if (argsGlobal.IsArgSet("-connect") && mapMultiArgs.at("-connect").size() > 0) {
+    if (argsGlobal.IsArgSet("-connect") && argsGlobal.ArgsAt("-connect").size() > 0) {
         // when only connecting to trusted nodes, do not seed via DNS, or listen by default
         if (SoftSetBoolArg("-dnsseed", false))
             LogPrintf("%s: parameter interaction: -connect set -> setting -dnsseed=0\n", __func__);
@@ -878,8 +878,8 @@ bool AppInitParameterInteraction()
 
     // Make sure enough file descriptors are available
     int nBind = std::max(
-                (argsGlobal.IsArgSet("-bind") ? mapMultiArgs.at("-bind").size() : 0) +
-                (argsGlobal.IsArgSet("-whitebind") ? mapMultiArgs.at("-whitebind").size() : 0), size_t(1));
+                (argsGlobal.IsArgSet("-bind") ? argsGlobal.ArgsAt("-bind").size() : 0) +
+                (argsGlobal.IsArgSet("-whitebind") ? argsGlobal.ArgsAt("-whitebind").size() : 0), size_t(1));
     nUserMaxConnections = GetArg("-maxconnections", DEFAULT_MAX_PEER_CONNECTIONS);
     nMaxConnections = std::max(nUserMaxConnections, 0);
 
@@ -898,7 +898,7 @@ bool AppInitParameterInteraction()
     fDebug = argsGlobal.IsArgSet("-debug");
     // Special-case: if -debug=0/-nodebug is set, turn off debugging messages
     if (fDebug) {
-        const vector<string>& categories = mapMultiArgs.at("-debug");
+        const vector<string>& categories = argsGlobal.ArgsAt("-debug");
         if (GetBoolArg("-nodebug", false) || find(categories.begin(), categories.end(), string("0")) != categories.end())
             fDebug = false;
     }
@@ -1067,7 +1067,7 @@ bool AppInitParameterInteraction()
         if (!chainparams.MineBlocksOnDemand()) {
             return InitError("BIP9 parameters may only be overridden on regtest.");
         }
-        const vector<string>& deployments = mapMultiArgs.at("-bip9params");
+        const vector<string>& deployments = argsGlobal.ArgsAt("-bip9params");
         for (auto i : deployments) {
             std::vector<std::string> vDeploymentParams;
             boost::split(vDeploymentParams, i, boost::is_any_of(":"));
@@ -1214,7 +1214,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
     // sanitize comments per BIP-0014, format user agent and check total size
     std::vector<string> uacomments;
     if (argsGlobal.IsArgSet("-uacomment")) {
-        BOOST_FOREACH(string cmt, mapMultiArgs.at("-uacomment"))
+        BOOST_FOREACH(string cmt, argsGlobal.ArgsAt("-uacomment"))
         {
             if (cmt != SanitizeString(cmt, SAFE_CHARS_UA_COMMENT))
                 return InitError(strprintf(_("User Agent comment (%s) contains unsafe characters."), cmt));
@@ -1229,7 +1229,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
 
     if (argsGlobal.IsArgSet("-onlynet")) {
         std::set<enum Network> nets;
-        BOOST_FOREACH(const std::string& snet, mapMultiArgs.at("-onlynet")) {
+        BOOST_FOREACH(const std::string& snet, argsGlobal.ArgsAt("-onlynet")) {
             enum Network net = ParseNetwork(snet);
             if (net == NET_UNROUTABLE)
                 return InitError(strprintf(_("Unknown network specified in -onlynet: '%s'"), snet));
@@ -1243,7 +1243,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
     }
 
     if (argsGlobal.IsArgSet("-whitelist")) {
-        BOOST_FOREACH(const std::string& net, mapMultiArgs.at("-whitelist")) {
+        BOOST_FOREACH(const std::string& net, argsGlobal.ArgsAt("-whitelist")) {
             CSubNet subnet;
             LookupSubNet(net.c_str(), subnet);
             if (!subnet.IsValid())
@@ -1296,7 +1296,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
     if (fListen) {
         bool fBound = false;
         if (argsGlobal.IsArgSet("-bind")) {
-            BOOST_FOREACH(const std::string& strBind, mapMultiArgs.at("-bind")) {
+            BOOST_FOREACH(const std::string& strBind, argsGlobal.ArgsAt("-bind")) {
                 CService addrBind;
                 if (!Lookup(strBind.c_str(), addrBind, GetListenPort(), false))
                     return InitError(ResolveErrMsg("bind", strBind));
@@ -1304,7 +1304,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
             }
         }
         if (argsGlobal.IsArgSet("-whitebind")) {
-            BOOST_FOREACH(const std::string& strBind, mapMultiArgs.at("-whitebind")) {
+            BOOST_FOREACH(const std::string& strBind, argsGlobal.ArgsAt("-whitebind")) {
                 CService addrBind;
                 if (!Lookup(strBind.c_str(), addrBind, 0, false))
                     return InitError(ResolveErrMsg("whitebind", strBind));
@@ -1324,7 +1324,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
     }
 
     if (argsGlobal.IsArgSet("-externalip")) {
-        BOOST_FOREACH(const std::string& strAddr, mapMultiArgs.at("-externalip")) {
+        BOOST_FOREACH(const std::string& strAddr, argsGlobal.ArgsAt("-externalip")) {
             CService addrLocal;
             if (Lookup(strAddr.c_str(), addrLocal, GetListenPort(), fNameLookup) && addrLocal.IsValid())
                 AddLocal(addrLocal, LOCAL_MANUAL);
@@ -1334,7 +1334,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
     }
 
     if (argsGlobal.IsArgSet("-seednode")) {
-        BOOST_FOREACH(const std::string& strDest, mapMultiArgs.at("-seednode"))
+        BOOST_FOREACH(const std::string& strDest, argsGlobal.ArgsAt("-seednode"))
             connman.AddOneShot(strDest);
     }
 
@@ -1587,7 +1587,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
     std::vector<boost::filesystem::path> vImportFiles;
     if (argsGlobal.IsArgSet("-loadblock"))
     {
-        BOOST_FOREACH(const std::string& strFile, mapMultiArgs.at("-loadblock"))
+        BOOST_FOREACH(const std::string& strFile, argsGlobal.ArgsAt("-loadblock"))
             vImportFiles.push_back(strFile);
     }
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -732,7 +732,7 @@ void InitParameterInteraction()
             LogPrintf("%s: parameter interaction: -whitebind set -> setting -listen=1\n", __func__);
     }
 
-    if (mapMultiArgs.count("-connect") && mapMultiArgs.at("-connect").size() > 0) {
+    if (argsGlobal.IsArgSet("-connect") && mapMultiArgs.at("-connect").size() > 0) {
         // when only connecting to trusted nodes, do not seed via DNS, or listen by default
         if (SoftSetBoolArg("-dnsseed", false))
             LogPrintf("%s: parameter interaction: -connect set -> setting -dnsseed=0\n", __func__);
@@ -878,8 +878,8 @@ bool AppInitParameterInteraction()
 
     // Make sure enough file descriptors are available
     int nBind = std::max(
-                (mapMultiArgs.count("-bind") ? mapMultiArgs.at("-bind").size() : 0) +
-                (mapMultiArgs.count("-whitebind") ? mapMultiArgs.at("-whitebind").size() : 0), size_t(1));
+                (argsGlobal.IsArgSet("-bind") ? mapMultiArgs.at("-bind").size() : 0) +
+                (argsGlobal.IsArgSet("-whitebind") ? mapMultiArgs.at("-whitebind").size() : 0), size_t(1));
     nUserMaxConnections = GetArg("-maxconnections", DEFAULT_MAX_PEER_CONNECTIONS);
     nMaxConnections = std::max(nUserMaxConnections, 0);
 
@@ -895,7 +895,7 @@ bool AppInitParameterInteraction()
 
     // ********************************************************* Step 3: parameter-to-internal-flags
 
-    fDebug = mapMultiArgs.count("-debug");
+    fDebug = argsGlobal.IsArgSet("-debug");
     // Special-case: if -debug=0/-nodebug is set, turn off debugging messages
     if (fDebug) {
         const vector<string>& categories = mapMultiArgs.at("-debug");
@@ -1062,7 +1062,7 @@ bool AppInitParameterInteraction()
         fEnableReplacement = (std::find(vstrReplacementModes.begin(), vstrReplacementModes.end(), "fee") != vstrReplacementModes.end());
     }
 
-    if (mapMultiArgs.count("-bip9params")) {
+    if (argsGlobal.IsArgSet("-bip9params")) {
         // Allow overriding BIP9 parameters for testing
         if (!chainparams.MineBlocksOnDemand()) {
             return InitError("BIP9 parameters may only be overridden on regtest.");
@@ -1213,7 +1213,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
 
     // sanitize comments per BIP-0014, format user agent and check total size
     std::vector<string> uacomments;
-    if (mapMultiArgs.count("-uacomment")) {
+    if (argsGlobal.IsArgSet("-uacomment")) {
         BOOST_FOREACH(string cmt, mapMultiArgs.at("-uacomment"))
         {
             if (cmt != SanitizeString(cmt, SAFE_CHARS_UA_COMMENT))
@@ -1227,7 +1227,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
             strSubVersion.size(), MAX_SUBVERSION_LENGTH));
     }
 
-    if (mapMultiArgs.count("-onlynet")) {
+    if (argsGlobal.IsArgSet("-onlynet")) {
         std::set<enum Network> nets;
         BOOST_FOREACH(const std::string& snet, mapMultiArgs.at("-onlynet")) {
             enum Network net = ParseNetwork(snet);
@@ -1242,7 +1242,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
         }
     }
 
-    if (mapMultiArgs.count("-whitelist")) {
+    if (argsGlobal.IsArgSet("-whitelist")) {
         BOOST_FOREACH(const std::string& net, mapMultiArgs.at("-whitelist")) {
             CSubNet subnet;
             LookupSubNet(net.c_str(), subnet);
@@ -1295,7 +1295,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
 
     if (fListen) {
         bool fBound = false;
-        if (mapMultiArgs.count("-bind")) {
+        if (argsGlobal.IsArgSet("-bind")) {
             BOOST_FOREACH(const std::string& strBind, mapMultiArgs.at("-bind")) {
                 CService addrBind;
                 if (!Lookup(strBind.c_str(), addrBind, GetListenPort(), false))
@@ -1303,7 +1303,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
                 fBound |= Bind(connman, addrBind, (BF_EXPLICIT | BF_REPORT_ERROR));
             }
         }
-        if (mapMultiArgs.count("-whitebind")) {
+        if (argsGlobal.IsArgSet("-whitebind")) {
             BOOST_FOREACH(const std::string& strBind, mapMultiArgs.at("-whitebind")) {
                 CService addrBind;
                 if (!Lookup(strBind.c_str(), addrBind, 0, false))
@@ -1313,7 +1313,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
                 fBound |= Bind(connman, addrBind, (BF_EXPLICIT | BF_REPORT_ERROR | BF_WHITELIST));
             }
         }
-        if (!mapMultiArgs.count("-bind") && !mapMultiArgs.count("-whitebind")) {
+        if (!argsGlobal.IsArgSet("-bind") && !argsGlobal.IsArgSet("-whitebind")) {
             struct in_addr inaddr_any;
             inaddr_any.s_addr = INADDR_ANY;
             fBound |= Bind(connman, CService(in6addr_any, GetListenPort()), BF_NONE);
@@ -1323,7 +1323,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
             return InitError(_("Failed to listen on any port. Use -listen=0 if you want this."));
     }
 
-    if (mapMultiArgs.count("-externalip")) {
+    if (argsGlobal.IsArgSet("-externalip")) {
         BOOST_FOREACH(const std::string& strAddr, mapMultiArgs.at("-externalip")) {
             CService addrLocal;
             if (Lookup(strAddr.c_str(), addrLocal, GetListenPort(), fNameLookup) && addrLocal.IsValid())
@@ -1333,7 +1333,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
         }
     }
 
-    if (mapMultiArgs.count("-seednode")) {
+    if (argsGlobal.IsArgSet("-seednode")) {
         BOOST_FOREACH(const std::string& strDest, mapMultiArgs.at("-seednode"))
             connman.AddOneShot(strDest);
     }
@@ -1585,7 +1585,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
         uiInterface.NotifyBlockTip.connect(BlockNotifyCallback);
 
     std::vector<boost::filesystem::path> vImportFiles;
-    if (mapMultiArgs.count("-loadblock"))
+    if (argsGlobal.IsArgSet("-loadblock"))
     {
         BOOST_FOREACH(const std::string& strFile, mapMultiArgs.at("-loadblock"))
             vImportFiles.push_back(strFile);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -318,6 +318,8 @@ void OnRPCPreCommand(const CRPCCommand& cmd)
 
 std::string HelpMessage(HelpMessageMode mode)
 {
+    const auto defaultBaseParams = CreateBaseChainParams(CBaseChainParams::MAIN);
+    const auto testnetBaseParams = CreateBaseChainParams(CBaseChainParams::TESTNET);
     const bool showDebug = GetBoolArg("-help-debug", false);
 
     // When adding new options to the categories, please keep and ensure alphabetical ordering.
@@ -495,7 +497,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-rpcuser=<user>", _("Username for JSON-RPC connections"));
     strUsage += HelpMessageOpt("-rpcpassword=<pw>", _("Password for JSON-RPC connections"));
     strUsage += HelpMessageOpt("-rpcauth=<userpw>", _("Username and hashed password for JSON-RPC connections. The field <userpw> comes in the format: <USERNAME>:<SALT>$<HASH>. A canonical python script is included in share/rpcuser. The client then connects normally using the rpcuser=<USERNAME>/rpcpassword=<PASSWORD> pair of arguments. This option can be specified multiple times"));
-    strUsage += HelpMessageOpt("-rpcport=<port>", strprintf(_("Listen for JSON-RPC connections on <port> (default: %u or testnet: %u)"), BaseParams(CBaseChainParams::MAIN).RPCPort(), BaseParams(CBaseChainParams::TESTNET).RPCPort()));
+    strUsage += HelpMessageOpt("-rpcport=<port>", strprintf(_("Listen for JSON-RPC connections on <port> (default: %u or testnet: %u)"), defaultBaseParams->RPCPort(), testnetBaseParams->RPCPort()));
     strUsage += HelpMessageOpt("-rpcallowip=<ip>", _("Allow JSON-RPC connections from specified source. Valid for <ip> are a single IP (e.g. 1.2.3.4), a network/netmask (e.g. 1.2.3.4/255.255.255.0) or a network/CIDR (e.g. 1.2.3.4/24). This option can be specified multiple times"));
     strUsage += HelpMessageOpt("-rpcthreads=<n>", strprintf(_("Set the number of threads to service RPC calls (default: %d)"), DEFAULT_HTTP_THREADS));
     if (showDebug) {
@@ -1081,7 +1083,7 @@ bool AppInitParameterInteraction()
             for (int j=0; j<(int)Consensus::MAX_VERSION_BITS_DEPLOYMENTS; ++j)
             {
                 if (vDeploymentParams[0].compare(VersionBitsDeploymentInfo[j].name) == 0) {
-                    UpdateRegtestBIP9Parameters(Consensus::DeploymentPos(j), nStartTime, nTimeout);
+                    UpdateBIP9Parameters(Consensus::DeploymentPos(j), nStartTime, nTimeout);
                     found = true;
                     LogPrintf("Setting BIP9 activation parameters for %s to start=%ld, timeout=%ld\n", vDeploymentParams[0], nStartTime, nTimeout);
                     break;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -320,6 +320,8 @@ std::string HelpMessage(HelpMessageMode mode)
 {
     const auto defaultBaseParams = CreateBaseChainParams(CBaseChainParams::MAIN);
     const auto testnetBaseParams = CreateBaseChainParams(CBaseChainParams::TESTNET);
+    const auto defaultChainParams = CreateChainParams(CBaseChainParams::MAIN);
+    const auto testnetChainParams = CreateChainParams(CBaseChainParams::TESTNET);
     const bool showDebug = GetBoolArg("-help-debug", false);
 
     // When adding new options to the categories, please keep and ensure alphabetical ordering.
@@ -331,7 +333,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-blocknotify=<cmd>", _("Execute command when the best block changes (%s in cmd is replaced by block hash)"));
     if (showDebug)
         strUsage += HelpMessageOpt("-blocksonly", strprintf(_("Whether to operate in a blocks only mode (default: %u)"), DEFAULT_BLOCKSONLY));
-    strUsage +=HelpMessageOpt("-assumevalid=<hex>", strprintf(_("If this block is in the chain assume that it and its ancestors are valid and potentially skip their script verification (0 to verify all, default: %s, testnet: %s)"), Params(CBaseChainParams::MAIN).GetConsensus().defaultAssumeValid.GetHex(), Params(CBaseChainParams::TESTNET).GetConsensus().defaultAssumeValid.GetHex()));
+    strUsage +=HelpMessageOpt("-assumevalid=<hex>", strprintf(_("If this block is in the chain assume that it and its ancestors are valid and potentially skip their script verification (0 to verify all, default: %s, testnet: %s)"), defaultChainParams->GetConsensus().defaultAssumeValid.GetHex(), testnetChainParams->GetConsensus().defaultAssumeValid.GetHex()));
     strUsage += HelpMessageOpt("-conf=<file>", strprintf(_("Specify configuration file (default: %s)"), BITCOIN_CONF_FILENAME));
     if (mode == HMM_BITCOIND)
     {
@@ -384,7 +386,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-onlynet=<net>", _("Only connect to nodes in network <net> (ipv4, ipv6 or onion)"));
     strUsage += HelpMessageOpt("-permitbaremultisig", strprintf(_("Relay non-P2SH multisig (default: %u)"), DEFAULT_PERMIT_BAREMULTISIG));
     strUsage += HelpMessageOpt("-peerbloomfilters", strprintf(_("Support filtering of blocks and transaction with bloom filters (default: %u)"), DEFAULT_PEERBLOOMFILTERS));
-    strUsage += HelpMessageOpt("-port=<port>", strprintf(_("Listen for connections on <port> (default: %u or testnet: %u)"), Params(CBaseChainParams::MAIN).GetDefaultPort(), Params(CBaseChainParams::TESTNET).GetDefaultPort()));
+    strUsage += HelpMessageOpt("-port=<port>", strprintf(_("Listen for connections on <port> (default: %u or testnet: %u)"), defaultChainParams->GetDefaultPort(), testnetChainParams->GetDefaultPort()));
     strUsage += HelpMessageOpt("-proxy=<ip:port>", _("Connect through SOCKS5 proxy"));
     strUsage += HelpMessageOpt("-proxyrandomize", strprintf(_("Randomize credentials for every proxy connection. This enables Tor stream isolation (default: %u)"), DEFAULT_PROXYRANDOMIZE));
     strUsage += HelpMessageOpt("-rpcserialversion", strprintf(_("Sets the serialization of raw transaction or block hex returned in non-verbose mode, non-segwit(0) or segwit(1) (default: %d)"), DEFAULT_RPC_SERIALIZE_VERSION));
@@ -424,8 +426,8 @@ std::string HelpMessage(HelpMessageMode mode)
     {
         strUsage += HelpMessageOpt("-checkblocks=<n>", strprintf(_("How many blocks to check at startup (default: %u, 0 = all)"), DEFAULT_CHECKBLOCKS));
         strUsage += HelpMessageOpt("-checklevel=<n>", strprintf(_("How thorough the block verification of -checkblocks is (0-4, default: %u)"), DEFAULT_CHECKLEVEL));
-        strUsage += HelpMessageOpt("-checkblockindex", strprintf("Do a full consistency check for mapBlockIndex, setBlockIndexCandidates, chainActive and mapBlocksUnlinked occasionally. Also sets -checkmempool (default: %u)", Params(CBaseChainParams::MAIN).DefaultConsistencyChecks()));
-        strUsage += HelpMessageOpt("-checkmempool=<n>", strprintf("Run checks every <n> transactions (default: %u)", Params(CBaseChainParams::MAIN).DefaultConsistencyChecks()));
+        strUsage += HelpMessageOpt("-checkblockindex", strprintf("Do a full consistency check for mapBlockIndex, setBlockIndexCandidates, chainActive and mapBlocksUnlinked occasionally. Also sets -checkmempool (default: %u)", defaultChainParams->DefaultConsistencyChecks()));
+        strUsage += HelpMessageOpt("-checkmempool=<n>", strprintf("Run checks every <n> transactions (default: %u)", defaultChainParams->DefaultConsistencyChecks()));
         strUsage += HelpMessageOpt("-checkpoints", strprintf("Disable expensive verification for known chain history (default: %u)", DEFAULT_CHECKPOINTS_ENABLED));
         strUsage += HelpMessageOpt("-disablesafemode", strprintf("Disable safemode, override a real safe mode event (default: %u)", DEFAULT_DISABLE_SAFEMODE));
         strUsage += HelpMessageOpt("-testsafemode", strprintf("Force safe mode (default: %u)", DEFAULT_TESTSAFEMODE));
@@ -472,7 +474,7 @@ std::string HelpMessage(HelpMessageMode mode)
 
     strUsage += HelpMessageGroup(_("Node relay options:"));
     if (showDebug) {
-        strUsage += HelpMessageOpt("-acceptnonstdtxn", strprintf("Relay and mine \"non-standard\" transactions (%sdefault: %u)", "testnet/regtest only; ", !Params(CBaseChainParams::TESTNET).RequireStandard()));
+        strUsage += HelpMessageOpt("-acceptnonstdtxn", strprintf("Relay and mine \"non-standard\" transactions (%sdefault: %u)", "testnet/regtest only; ", defaultChainParams->RequireStandard()));
         strUsage += HelpMessageOpt("-incrementalrelayfee=<amt>", strprintf("Fee rate (in %s/kB) used to define cost of relay, used for mempool limiting and BIP 125 replacement. (default: %s)", CURRENCY_UNIT, FormatMoney(DEFAULT_INCREMENTAL_RELAY_FEE)));
         strUsage += HelpMessageOpt("-dustrelayfee=<amt>", strprintf("Fee rate (in %s/kB) used to defined dust, the value of an output such that it will cost about 1/3 of its value in fees at this fee rate to spend it. (default: %s)", CURRENCY_UNIT, FormatMoney(DUST_RELAY_TX_FEE)));
     }

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -10,13 +10,13 @@
 #include "chainparams.h"
 #include "coins.h"
 #include "consensus/consensus.h"
+#include "consensus/header_verify.h"
 #include "consensus/merkle.h"
 #include "consensus/validation.h"
 #include "hash.h"
 #include "validation.h"
 #include "net.h"
 #include "policy/policy.h"
-#include "pow.h"
 #include "primitives/transaction.h"
 #include "script/standard.h"
 #include "timedata.h"
@@ -69,7 +69,7 @@ int64_t UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParam
 
     // Updating time can change work required on testnet:
     if (consensusParams.fPowAllowMinDifficultyBlocks)
-        pblock->nBits = GetNextWorkRequired(pindexPrev, pblock, consensusParams);
+        ResetChallenge(consensusParams, pblock, pindexPrev);
 
     return nNewTime - nOldTime;
 }
@@ -194,8 +194,8 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
     // Fill in header
     pblock->hashPrevBlock  = pindexPrev->GetBlockHash();
     UpdateTime(pblock, chainparams.GetConsensus(), pindexPrev);
-    pblock->nBits          = GetNextWorkRequired(pindexPrev, pblock, chainparams.GetConsensus());
-    pblock->nNonce         = 0;
+    ResetChallenge(chainparams.GetConsensus(), pblock, pindexPrev);
+    ResetProof(chainparams.GetConsensus(), pblock);
     pblocktemplate->vTxSigOpsCost[0] = WITNESS_SCALE_FACTOR * GetLegacySigOpCount(*pblock->vtx[0]);
 
     CValidationState state;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1570,7 +1570,7 @@ void CConnman::ProcessOneShot()
 void CConnman::ThreadOpenConnections()
 {
     // Connect to specific addresses
-    if (mapMultiArgs.count("-connect") && mapMultiArgs.at("-connect").size() > 0)
+    if (argsGlobal.IsArgSet("-connect") && mapMultiArgs.at("-connect").size() > 0)
     {
         for (int64_t nLoop = 0;; nLoop++)
         {
@@ -1776,7 +1776,7 @@ void CConnman::ThreadOpenAddedConnections()
 {
     {
         LOCK(cs_vAddedNodes);
-        if (mapMultiArgs.count("-addnode"))
+        if (argsGlobal.IsArgSet("-addnode"))
             vAddedNodes = mapMultiArgs.at("-addnode");
     }
 
@@ -2183,7 +2183,7 @@ bool CConnman::Start(CScheduler& scheduler, std::string& strNodeError, Options c
     threadOpenAddedConnections = std::thread(&TraceThread<std::function<void()> >, "addcon", std::function<void()>(std::bind(&CConnman::ThreadOpenAddedConnections, this)));
 
     // Initiate outbound connections unless connect=0
-    if (!mapMultiArgs.count("-connect") || mapMultiArgs.at("-connect").size() != 1 || mapMultiArgs.at("-connect")[0] != "0")
+    if (!argsGlobal.IsArgSet("-connect") || mapMultiArgs.at("-connect").size() != 1 || mapMultiArgs.at("-connect")[0] != "0")
         threadOpenConnections = std::thread(&TraceThread<std::function<void()> >, "opencon", std::function<void()>(std::bind(&CConnman::ThreadOpenConnections, this)));
 
     // Process messages

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1570,12 +1570,12 @@ void CConnman::ProcessOneShot()
 void CConnman::ThreadOpenConnections()
 {
     // Connect to specific addresses
-    if (argsGlobal.IsArgSet("-connect") && mapMultiArgs.at("-connect").size() > 0)
+    if (argsGlobal.IsArgSet("-connect") && argsGlobal.ArgsAt("-connect").size() > 0)
     {
         for (int64_t nLoop = 0;; nLoop++)
         {
             ProcessOneShot();
-            BOOST_FOREACH(const std::string& strAddr, mapMultiArgs.at("-connect"))
+            BOOST_FOREACH(const std::string& strAddr, argsGlobal.ArgsAt("-connect"))
             {
                 CAddress addr(CService(), NODE_NONE);
                 OpenNetworkConnection(addr, false, NULL, strAddr.c_str());
@@ -1777,7 +1777,7 @@ void CConnman::ThreadOpenAddedConnections()
     {
         LOCK(cs_vAddedNodes);
         if (argsGlobal.IsArgSet("-addnode"))
-            vAddedNodes = mapMultiArgs.at("-addnode");
+            vAddedNodes = argsGlobal.ArgsAt("-addnode");
     }
 
     while (true)
@@ -2183,7 +2183,7 @@ bool CConnman::Start(CScheduler& scheduler, std::string& strNodeError, Options c
     threadOpenAddedConnections = std::thread(&TraceThread<std::function<void()> >, "addcon", std::function<void()>(std::bind(&CConnman::ThreadOpenAddedConnections, this)));
 
     // Initiate outbound connections unless connect=0
-    if (!argsGlobal.IsArgSet("-connect") || mapMultiArgs.at("-connect").size() != 1 || mapMultiArgs.at("-connect")[0] != "0")
+    if (!argsGlobal.IsArgSet("-connect") || argsGlobal.ArgsAt("-connect").size() != 1 || argsGlobal.ArgsAt("-connect")[0] != "0")
         threadOpenConnections = std::thread(&TraceThread<std::function<void()> >, "opencon", std::function<void()>(std::bind(&CConnman::ThreadOpenConnections, this)));
 
     // Process messages

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -32,12 +32,12 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHead
             {
                 // Return the last non-special-min-difficulty-rules-block
                 const CBlockIndex* pindex = pindexLast;
-                while (pindex->pprev && pindex->nHeight % params.DifficultyAdjustmentInterval() != 0 && pindex->nBits == nProofOfWorkLimit)
+                while (pindex->pprev && pindex->nHeight % params.DifficultyAdjustmentInterval() != 0 && pindex->proof.pow.nBits == nProofOfWorkLimit)
                     pindex = pindex->pprev;
-                return pindex->nBits;
+                return pindex->proof.pow.nBits;
             }
         }
-        return pindexLast->nBits;
+        return pindexLast->proof.pow.nBits;
     }
 
     // Go back by what we want to be 14 days worth of blocks
@@ -52,7 +52,7 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHead
 unsigned int CalculateNextWorkRequired(const CBlockIndex* pindexLast, int64_t nFirstBlockTime, const Consensus::Params& params)
 {
     if (params.fPowNoRetargeting)
-        return pindexLast->nBits;
+        return pindexLast->proof.pow.nBits;
 
     // Limit adjustment step
     int64_t nActualTimespan = pindexLast->GetBlockTime() - nFirstBlockTime;
@@ -64,7 +64,7 @@ unsigned int CalculateNextWorkRequired(const CBlockIndex* pindexLast, int64_t nF
     // Retarget
     const arith_uint256 bnPowLimit = UintToArith256(params.powLimit);
     arith_uint256 bnNew;
-    bnNew.SetCompact(pindexLast->nBits);
+    bnNew.SetCompact(pindexLast->proof.pow.nBits);
     bnNew *= nActualTimespan;
     bnNew /= params.nPowTargetTimespan;
 

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -18,12 +18,14 @@ uint256 CBlockHeader::GetHash() const
 std::string CBlock::ToString() const
 {
     std::stringstream s;
-    s << strprintf("CBlock(hash=%s, ver=0x%08x, hashPrevBlock=%s, hashMerkleRoot=%s, nTime=%u, nBits=%08x, nNonce=%u, vtx=%u)\n",
+    std::string proofString = strprintf("PowProof(nBits=%08x, nNonce=%u)", proof.pow.nBits, proof.pow.nNonce);
+    s << strprintf("CBlock(hash=%s, ver=0x%08x, hashPrevBlock=%s, hashMerkleRoot=%s, nTime=%u, proof=%s, vtx=%u)\n",
         GetHash().ToString(),
         nVersion,
         hashPrevBlock.ToString(),
         hashMerkleRoot.ToString(),
-        nTime, nBits, nNonce,
+        nTime,
+        proofString,
         vtx.size());
     for (unsigned int i = 0; i < vtx.size(); i++)
     {

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -74,8 +74,12 @@ public:
         hashPrevBlock.SetNull();
         hashMerkleRoot.SetNull();
         nTime = 0;
-        proof.pow.nBits = 0;
-        proof.pow.nNonce = 0;
+        if (fSignBlocksGlobal) {
+            proof.script = new CScript();
+        } else {
+            proof.pow.nBits = 0;
+            proof.pow.nNonce = 0;
+        }
     }
 
     bool IsNull() const

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -635,7 +635,7 @@ int main(int argc, char *argv[])
     PaymentServer::ipcParseCommandLine(argc, argv);
 #endif
 
-    QScopedPointer<const NetworkStyle> networkStyle(NetworkStyle::instantiate(QString::fromStdString(Params().NetworkIDString())));
+    QScopedPointer<const NetworkStyle> networkStyle(NetworkStyle::instantiate(Params().NetworkIDString()));
     assert(!networkStyle.isNull());
     // Allow for separate UI settings for testnets
     QApplication::setApplicationName(networkStyle->getAppName());

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -623,7 +623,7 @@ int main(int argc, char *argv[])
     // - QSettings() will use the new application name after this, resulting in network-specific settings
     // - Needs to be done before createOptionsModel
 
-    // Check for -testnet or -regtest parameter (Params() calls are only valid after this clause)
+    // Check for -chain, -testnet or -regtest parameter (Params() calls are only valid after this clause)
     try {
         SelectParams(ChainNameFromCommandLine());
     } catch(std::exception &e) {

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -641,7 +641,7 @@ bool SetStartOnSystemStartup(bool fAutoStart)
             // Start client minimized
             QString strArgs = "-min";
             // Set -testnet /-regtest options
-            strArgs += QString::fromStdString(strprintf(" -testnet=%d -regtest=%d", GetBoolArg("-testnet", false), GetBoolArg("-regtest", false)));
+            strArgs += QString::fromStdString(strprintf(" -chain=%s", ChainNameFromCommandLine()));
 
 #ifdef UNICODE
             boost::scoped_array<TCHAR> args(new TCHAR[strArgs.length() + 1]);
@@ -752,7 +752,7 @@ bool SetStartOnSystemStartup(bool fAutoStart)
             optionFile << "Name=Bitcoin\n";
         else
             optionFile << strprintf("Name=Bitcoin (%s)\n", chain);
-        optionFile << "Exec=" << pszExePath << strprintf(" -min -testnet=%d -regtest=%d\n", GetBoolArg("-testnet", false), GetBoolArg("-regtest", false));
+        optionFile << "Exec=" << pszExePath << strprintf(" -min -chain=%s\n", chain);
         optionFile << "Terminal=false\n";
         optionFile << "Hidden=false\n";
         optionFile.close();

--- a/src/qt/networkstyle.cpp
+++ b/src/qt/networkstyle.cpp
@@ -6,6 +6,9 @@
 
 #include "guiconstants.h"
 
+#include "chainparamsbase.h"
+#include "tinyformat.h"
+
 #include <QApplication>
 
 static const struct {
@@ -15,9 +18,9 @@ static const struct {
     const int iconColorSaturationReduction;
     const char *titleAddText;
 } network_styles[] = {
-    {"main", QAPP_APP_NAME_DEFAULT, 0, 0, ""},
-    {"test", QAPP_APP_NAME_TESTNET, 70, 30, QT_TRANSLATE_NOOP("SplashScreen", "[testnet]")},
-    {"regtest", QAPP_APP_NAME_TESTNET, 160, 30, "[regtest]"}
+    {"main", QAPP_APP_NAME_DEFAULT, 0, 0},
+    {"test", QAPP_APP_NAME_TESTNET, 70, 30},
+    {"regtest", QAPP_APP_NAME_TESTNET, 160, 30}
 };
 static const unsigned network_styles_count = sizeof(network_styles)/sizeof(*network_styles);
 
@@ -79,8 +82,9 @@ NetworkStyle::NetworkStyle(const QString &_appName, const int iconColorHueShift,
     trayAndWindowIcon   = QIcon(pixmap.scaled(QSize(256,256)));
 }
 
-const NetworkStyle *NetworkStyle::instantiate(const QString &networkId)
+const NetworkStyle *NetworkStyle::instantiate(const std::string &networkId)
 {
+    std::string titleAddText = networkId == CBaseChainParams::MAIN ? "" : strprintf("[%s]", networkId);
     for (unsigned x=0; x<network_styles_count; ++x)
     {
         if (networkId == network_styles[x].networkId)
@@ -89,8 +93,8 @@ const NetworkStyle *NetworkStyle::instantiate(const QString &networkId)
                     network_styles[x].appName,
                     network_styles[x].iconColorHueShift,
                     network_styles[x].iconColorSaturationReduction,
-                    network_styles[x].titleAddText);
+                    titleAddText.c_str());
         }
     }
-    return 0;
+    return new NetworkStyle(strprintf("%s-%s", QAPP_APP_NAME_DEFAULT, networkId).c_str(), 250, 30, titleAddText.c_str());
 }

--- a/src/qt/networkstyle.h
+++ b/src/qt/networkstyle.h
@@ -14,7 +14,7 @@ class NetworkStyle
 {
 public:
     /** Get style associated with provided BIP70 network id, or 0 if not known */
-    static const NetworkStyle *instantiate(const QString &networkId);
+    static const NetworkStyle *instantiate(const std::string &networkId);
 
     const QString &getAppName() const { return appName; }
     const QIcon &getAppIcon() const { return appIcon; }

--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -221,14 +221,16 @@ void PaymentServer::ipcParseCommandLine(int argc, char* argv[])
             if (GUIUtil::parseBitcoinURI(arg, &r) && !r.address.isEmpty())
             {
                 CBitcoinAddress address(r.address.toStdString());
+                auto tempChainParams = CreateChainParams(CBaseChainParams::MAIN);
 
-                if (address.IsValid(Params(CBaseChainParams::MAIN)))
+                if (address.IsValid(*tempChainParams))
                 {
                     SelectParams(CBaseChainParams::MAIN);
                 }
-                else if (address.IsValid(Params(CBaseChainParams::TESTNET)))
-                {
-                    SelectParams(CBaseChainParams::TESTNET);
+                else {
+                    tempChainParams = CreateChainParams(CBaseChainParams::TESTNET);
+                    if (address.IsValid(*tempChainParams))
+                        SelectParams(CBaseChainParams::TESTNET);
                 }
             }
         }

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -55,10 +55,10 @@ double GetDifficulty(const CBlockIndex* blockindex)
             blockindex = chainActive.Tip();
     }
 
-    int nShift = (blockindex->nBits >> 24) & 0xff;
+    int nShift = (blockindex->proof.pow.nBits >> 24) & 0xff;
 
     double dDiff =
-        (double)0x0000ffff / (double)(blockindex->nBits & 0x00ffffff);
+        (double)0x0000ffff / (double)(blockindex->proof.pow.nBits & 0x00ffffff);
 
     while (nShift < 29)
     {
@@ -89,8 +89,8 @@ UniValue blockheaderToJSON(const CBlockIndex* blockindex)
     result.push_back(Pair("merkleroot", blockindex->hashMerkleRoot.GetHex()));
     result.push_back(Pair("time", (int64_t)blockindex->nTime));
     result.push_back(Pair("mediantime", (int64_t)blockindex->GetMedianTimePast()));
-    result.push_back(Pair("nonce", (uint64_t)blockindex->nNonce));
-    result.push_back(Pair("bits", strprintf("%08x", blockindex->nBits)));
+    result.push_back(Pair("nonce", (uint64_t)blockindex->proof.pow.nNonce));
+    result.push_back(Pair("bits", strprintf("%08x", blockindex->proof.pow.nBits)));
     result.push_back(Pair("difficulty", GetDifficulty(blockindex)));
     result.push_back(Pair("chainwork", blockindex->nChainWork.GetHex()));
 
@@ -133,8 +133,8 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool tx
     result.push_back(Pair("tx", txs));
     result.push_back(Pair("time", block.GetBlockTime()));
     result.push_back(Pair("mediantime", (int64_t)blockindex->GetMedianTimePast()));
-    result.push_back(Pair("nonce", (uint64_t)block.nNonce));
-    result.push_back(Pair("bits", strprintf("%08x", block.nBits)));
+    result.push_back(Pair("nonce", (uint64_t)block.proof.pow.nNonce));
+    result.push_back(Pair("bits", strprintf("%08x", block.proof.pow.nBits)));
     result.push_back(Pair("difficulty", GetDifficulty(blockindex)));
     result.push_back(Pair("chainwork", blockindex->nChainWork.GetHex()));
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -55,10 +55,11 @@ double GetDifficulty(const CBlockIndex* blockindex)
             blockindex = chainActive.Tip();
     }
 
-    int nShift = (blockindex->proof.pow.nBits >> 24) & 0xff;
+    const uint32_t nBits = Params().GetConsensus().fSignBlockChain ? 0 : blockindex->proof.pow.nBits;
+    int nShift = (nBits >> 24) & 0xff;
 
     double dDiff =
-        (double)0x0000ffff / (double)(blockindex->proof.pow.nBits & 0x00ffffff);
+        (double)0x0000ffff / (double)(nBits & 0x00ffffff);
 
     while (nShift < 29)
     {
@@ -89,8 +90,8 @@ UniValue blockheaderToJSON(const CBlockIndex* blockindex)
     result.push_back(Pair("merkleroot", blockindex->hashMerkleRoot.GetHex()));
     result.push_back(Pair("time", (int64_t)blockindex->nTime));
     result.push_back(Pair("mediantime", (int64_t)blockindex->GetMedianTimePast()));
-    result.push_back(Pair("nonce", (uint64_t)blockindex->proof.pow.nNonce));
-    result.push_back(Pair("bits", strprintf("%08x", blockindex->proof.pow.nBits)));
+    result.push_back(Pair("nonce", (uint64_t)(Params().GetConsensus().fSignBlockChain ? 0 : blockindex->proof.pow.nNonce)));
+    result.push_back(Pair("bits", strprintf("%08x", Params().GetConsensus().fSignBlockChain ? 0 : blockindex->proof.pow.nBits)));
     result.push_back(Pair("difficulty", GetDifficulty(blockindex)));
     result.push_back(Pair("chainwork", blockindex->nChainWork.GetHex()));
 
@@ -133,8 +134,8 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool tx
     result.push_back(Pair("tx", txs));
     result.push_back(Pair("time", block.GetBlockTime()));
     result.push_back(Pair("mediantime", (int64_t)blockindex->GetMedianTimePast()));
-    result.push_back(Pair("nonce", (uint64_t)block.proof.pow.nNonce));
-    result.push_back(Pair("bits", strprintf("%08x", block.proof.pow.nBits)));
+    result.push_back(Pair("nonce", (uint64_t)(Params().GetConsensus().fSignBlockChain ? 0 : block.proof.pow.nNonce)));
+    result.push_back(Pair("bits", strprintf("%08x", Params().GetConsensus().fSignBlockChain ? 0 : block.proof.pow.nBits)));
     result.push_back(Pair("difficulty", GetDifficulty(blockindex)));
     result.push_back(Pair("chainwork", blockindex->nChainWork.GetHex()));
 

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -591,7 +591,7 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
     UniValue aux(UniValue::VOBJ);
     aux.push_back(Pair("flags", HexStr(COINBASE_FLAGS.begin(), COINBASE_FLAGS.end())));
 
-    arith_uint256 hashTarget = arith_uint256().SetCompact(pblock->nBits);
+    arith_uint256 hashTarget = arith_uint256().SetCompact(pblock->proof.pow.nBits);
 
     UniValue aMutable(UniValue::VARR);
     aMutable.push_back("time");
@@ -674,7 +674,7 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
     result.push_back(Pair("sizelimit", (int64_t)MAX_BLOCK_SERIALIZED_SIZE));
     result.push_back(Pair("weightlimit", (int64_t)MAX_BLOCK_WEIGHT));
     result.push_back(Pair("curtime", pblock->GetBlockTime()));
-    result.push_back(Pair("bits", strprintf("%08x", pblock->nBits)));
+    result.push_back(Pair("bits", strprintf("%08x", pblock->proof.pow.nBits)));
     result.push_back(Pair("height", (int64_t)(pindexPrev->nHeight+1)));
 
     const struct BIP9DeploymentInfo& segwit_info = VersionBitsDeploymentInfo[Consensus::DEPLOYMENT_SEGWIT];

--- a/src/script/generic.hpp
+++ b/src/script/generic.hpp
@@ -1,0 +1,67 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2014 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef H_BITCOIN_SCRIPT_GENERIC
+#define H_BITCOIN_SCRIPT_GENERIC
+
+#include "hash.h"
+#include "interpreter.h"
+#include "keystore.h"
+#include "pubkey.h"
+#include "sign.h"
+
+class SimpleSignatureChecker : public BaseSignatureChecker
+{
+public:
+    uint256 hash;
+
+    SimpleSignatureChecker(const uint256& hashIn) : hash(hashIn) {};
+    bool CheckSig(const std::vector<unsigned char>& vchSig, const std::vector<unsigned char>& vchPubKey, const CScript& scriptCode, SigVersion sigversion) const
+    {
+        CPubKey pubkey(vchPubKey);
+        if (!pubkey.IsValid())
+            return false;
+        if (vchSig.empty())
+            return false;
+        return pubkey.Verify(hash, vchSig);
+    }
+};
+
+class SimpleSignatureCreator : public BaseSignatureCreator
+{
+    SimpleSignatureChecker checker;
+
+public:
+    SimpleSignatureCreator(const CKeyStore* keystoreIn, const uint256& hashIn) : BaseSignatureCreator(keystoreIn), checker(hashIn) {};
+    virtual ~SimpleSignatureCreator() {};
+    virtual const BaseSignatureChecker& Checker() const { return checker; }
+    virtual bool CreateSig(std::vector<unsigned char>& vchSig, const CKeyID& keyid, const CScript& scriptCode, SigVersion sigversion) const
+    {
+        CKey key;
+        if (!keystore->GetKey(keyid, key))
+            return false;
+        return key.Sign(checker.hash, vchSig);
+    }
+};
+
+template<typename T>
+bool GenericVerifyScript(const CScript& scriptSig, const CScript& scriptPubKey, unsigned int flags, const T& data)
+{
+    return VerifyScript(scriptSig, scriptPubKey, NULL, flags, SimpleSignatureChecker(SerializeHash(data)));
+}
+
+template<typename T>
+bool GenericSignScript(const CKeyStore& keystore, const T& data, const CScript& scriptPubKey, SignatureData& scriptSig)
+{
+    return ProduceSignature(SimpleSignatureCreator(&keystore, SerializeHash(data)), scriptPubKey, scriptSig);
+}
+
+template<typename T>
+SignatureData GenericCombineSignatures(const CScript& scriptPubKey, const T& data, const SignatureData& scriptSig1, const SignatureData& scriptSig2)
+{
+    return CombineSignatures(scriptPubKey, SimpleSignatureChecker(SerializeHash(data)), scriptSig1, scriptSig2);
+}
+
+#endif // H_BITCOIN_SCRIPT_GENERIC

--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -186,7 +186,8 @@ bool ProduceSignature(const BaseSignatureCreator& creator, const CScript& fromPu
     sigdata.scriptSig = PushAll(result);
 
     // Test solution
-    return solved && VerifyScript(sigdata.scriptSig, fromPubKey, &sigdata.scriptWitness, STANDARD_SCRIPT_VERIFY_FLAGS, creator.Checker());
+    // TODO signblocks pass custom flags instead of STANDARD_SCRIPT_VERIFY_FLAGS ?
+    return solved && VerifyScript(sigdata.scriptSig, fromPubKey, &sigdata.scriptWitness, SCRIPT_VERIFY_NONE, creator.Checker());
 }
 
 SignatureData DataFromTransaction(const CMutableTransaction& tx, unsigned int nIn)

--- a/src/test/DoS_tests.cpp
+++ b/src/test/DoS_tests.cpp
@@ -8,7 +8,6 @@
 #include "keystore.h"
 #include "net.h"
 #include "net_processing.h"
-#include "pow.h"
 #include "script/sign.h"
 #include "serialize.h"
 #include "util.h"

--- a/src/test/blockencodings_tests.cpp
+++ b/src/test/blockencodings_tests.cpp
@@ -32,7 +32,7 @@ static CBlock BuildBlockTestCase() {
     block.vtx[0] = MakeTransactionRef(tx);
     block.nVersion = 42;
     block.hashPrevBlock = GetRandHash();
-    block.nBits = 0x207fffff;
+    block.proof.pow.nBits = 0x207fffff;
 
     tx.vin[0].prevout.hash = GetRandHash();
     tx.vin[0].prevout.n = 0;
@@ -285,7 +285,7 @@ BOOST_AUTO_TEST_CASE(EmptyBlockRoundTripTest)
     block.vtx[0] = MakeTransactionRef(std::move(coinbase));
     block.nVersion = 42;
     block.hashPrevBlock = GetRandHash();
-    block.nBits = 0x207fffff;
+    block.proof.pow.nBits = 0x207fffff;
 
     bool mutated;
     block.hashMerkleRoot = BlockMerkleRoot(block, &mutated);

--- a/src/test/blockencodings_tests.cpp
+++ b/src/test/blockencodings_tests.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "blockencodings.h"
+#include "consensus/header_verify.h"
 #include "consensus/merkle.h"
 #include "chainparams.h"
 #include "random.h"
@@ -47,7 +48,7 @@ static CBlock BuildBlockTestCase() {
     bool mutated;
     block.hashMerkleRoot = BlockMerkleRoot(block, &mutated);
     assert(!mutated);
-    while (!CheckProofOfWork(block.GetHash(), block.nBits, Params().GetConsensus())) ++block.nNonce;
+    while (!GenerateProof(Params().GetConsensus(), &block));
     return block;
 }
 
@@ -289,7 +290,7 @@ BOOST_AUTO_TEST_CASE(EmptyBlockRoundTripTest)
     bool mutated;
     block.hashMerkleRoot = BlockMerkleRoot(block, &mutated);
     assert(!mutated);
-    while (!CheckProofOfWork(block.GetHash(), block.nBits, Params().GetConsensus())) ++block.nNonce;
+    while (!GenerateProof(Params().GetConsensus(), &block));
 
     // Test simple header round-trip with only coinbase
     {

--- a/src/test/blockencodings_tests.cpp
+++ b/src/test/blockencodings_tests.cpp
@@ -6,6 +6,7 @@
 #include "consensus/header_verify.h"
 #include "consensus/merkle.h"
 #include "chainparams.h"
+#include "keystore.h"
 #include "random.h"
 
 #include "test/test_bitcoin.h"
@@ -48,7 +49,8 @@ static CBlock BuildBlockTestCase() {
     bool mutated;
     block.hashMerkleRoot = BlockMerkleRoot(block, &mutated);
     assert(!mutated);
-    while (!GenerateProof(Params().GetConsensus(), &block));
+    CBasicKeyStore dummyKeystore;
+    while (!GenerateProof(Params().GetConsensus(), &block, &dummyKeystore));
     return block;
 }
 
@@ -290,7 +292,8 @@ BOOST_AUTO_TEST_CASE(EmptyBlockRoundTripTest)
     bool mutated;
     block.hashMerkleRoot = BlockMerkleRoot(block, &mutated);
     assert(!mutated);
-    while (!GenerateProof(Params().GetConsensus(), &block));
+    CBasicKeyStore dummyKeystore;
+    while (!GenerateProof(Params().GetConsensus(), &block, &dummyKeystore));
 
     // Test simple header round-trip with only coinbase
     {

--- a/src/test/main_tests.cpp
+++ b/src/test/main_tests.cpp
@@ -39,17 +39,18 @@ static void TestBlockSubsidyHalvings(int nSubsidyHalvingInterval)
 
 BOOST_AUTO_TEST_CASE(block_subsidy_test)
 {
-    TestBlockSubsidyHalvings(Params(CBaseChainParams::MAIN).GetConsensus()); // As in main
+    const auto chainParams = CreateChainParams(CBaseChainParams::MAIN);
+    TestBlockSubsidyHalvings(chainParams->GetConsensus()); // As in main
     TestBlockSubsidyHalvings(150); // As in regtest
     TestBlockSubsidyHalvings(1000); // Just another interval
 }
 
 BOOST_AUTO_TEST_CASE(subsidy_limit_test)
 {
-    const Consensus::Params& consensusParams = Params(CBaseChainParams::MAIN).GetConsensus();
+    const auto chainParams = CreateChainParams(CBaseChainParams::MAIN);
     CAmount nSum = 0;
     for (int nHeight = 0; nHeight < 14000000; nHeight += 1000) {
-        CAmount nSubsidy = GetBlockSubsidy(nHeight, consensusParams);
+        CAmount nSubsidy = GetBlockSubsidy(nHeight, chainParams->GetConsensus());
         BOOST_CHECK(nSubsidy <= 50 * COIN);
         nSum += nSubsidy * 1000;
         BOOST_CHECK(MoneyRange(nSum));

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -223,7 +223,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
         if (txFirst.size() < 4)
             txFirst.push_back(pblock->vtx[0]);
         pblock->hashMerkleRoot = BlockMerkleRoot(*pblock);
-        pblock->nNonce = blockinfo[i].nonce;
+        pblock->proof.pow.nNonce = blockinfo[i].nonce;
         std::shared_ptr<const CBlock> shared_pblock = std::make_shared<const CBlock>(*pblock);
         BOOST_CHECK(ProcessNewBlock(chainparams, shared_pblock, true, NULL));
         pblock->hashPrevBlock = pblock->GetHash();

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -183,7 +183,8 @@ void TestPackageSelection(const CChainParams& chainparams, CScript scriptPubKey,
 BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
 {
     // Note that by default, these tests run with size accounting enabled.
-    const CChainParams& chainparams = Params(CBaseChainParams::MAIN);
+    const auto chainParams = CreateChainParams(CBaseChainParams::MAIN);
+    const CChainParams& chainparams = *chainParams;
     CScript scriptPubKey = CScript() << ParseHex("04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5f") << OP_CHECKSIG;
     std::unique_ptr<CBlockTemplate> pblocktemplate;
     CMutableTransaction tx,tx2;

--- a/src/test/pow_tests.cpp
+++ b/src/test/pow_tests.cpp
@@ -16,69 +16,59 @@ BOOST_FIXTURE_TEST_SUITE(pow_tests, BasicTestingSetup)
 /* Test calculation of next difficulty target with no constraints applying */
 BOOST_AUTO_TEST_CASE(get_next_work)
 {
-    SelectParams(CBaseChainParams::MAIN);
-    const Consensus::Params& params = Params().GetConsensus();
-
+    const auto chainParams = CreateChainParams(CBaseChainParams::MAIN);
     int64_t nLastRetargetTime = 1261130161; // Block #30240
     CBlockIndex pindexLast;
     pindexLast.nHeight = 32255;
     pindexLast.nTime = 1262152739;  // Block #32255
     pindexLast.nBits = 0x1d00ffff;
-    BOOST_CHECK_EQUAL(CalculateNextWorkRequired(&pindexLast, nLastRetargetTime, params), 0x1d00d86a);
+    BOOST_CHECK_EQUAL(CalculateNextWorkRequired(&pindexLast, nLastRetargetTime, chainParams->GetConsensus()), 0x1d00d86a);
 }
 
 /* Test the constraint on the upper bound for next work */
 BOOST_AUTO_TEST_CASE(get_next_work_pow_limit)
 {
-    SelectParams(CBaseChainParams::MAIN);
-    const Consensus::Params& params = Params().GetConsensus();
-
+    const auto chainParams = CreateChainParams(CBaseChainParams::MAIN);
     int64_t nLastRetargetTime = 1231006505; // Block #0
     CBlockIndex pindexLast;
     pindexLast.nHeight = 2015;
     pindexLast.nTime = 1233061996;  // Block #2015
     pindexLast.nBits = 0x1d00ffff;
-    BOOST_CHECK_EQUAL(CalculateNextWorkRequired(&pindexLast, nLastRetargetTime, params), 0x1d00ffff);
+    BOOST_CHECK_EQUAL(CalculateNextWorkRequired(&pindexLast, nLastRetargetTime, chainParams->GetConsensus()), 0x1d00ffff);
 }
 
 /* Test the constraint on the lower bound for actual time taken */
 BOOST_AUTO_TEST_CASE(get_next_work_lower_limit_actual)
 {
-    SelectParams(CBaseChainParams::MAIN);
-    const Consensus::Params& params = Params().GetConsensus();
-
+    const auto chainParams = CreateChainParams(CBaseChainParams::MAIN);
     int64_t nLastRetargetTime = 1279008237; // Block #66528
     CBlockIndex pindexLast;
     pindexLast.nHeight = 68543;
     pindexLast.nTime = 1279297671;  // Block #68543
     pindexLast.nBits = 0x1c05a3f4;
-    BOOST_CHECK_EQUAL(CalculateNextWorkRequired(&pindexLast, nLastRetargetTime, params), 0x1c0168fd);
+    BOOST_CHECK_EQUAL(CalculateNextWorkRequired(&pindexLast, nLastRetargetTime, chainParams->GetConsensus()), 0x1c0168fd);
 }
 
 /* Test the constraint on the upper bound for actual time taken */
 BOOST_AUTO_TEST_CASE(get_next_work_upper_limit_actual)
 {
-    SelectParams(CBaseChainParams::MAIN);
-    const Consensus::Params& params = Params().GetConsensus();
-
+    const auto chainParams = CreateChainParams(CBaseChainParams::MAIN);
     int64_t nLastRetargetTime = 1263163443; // NOTE: Not an actual block time
     CBlockIndex pindexLast;
     pindexLast.nHeight = 46367;
     pindexLast.nTime = 1269211443;  // Block #46367
     pindexLast.nBits = 0x1c387f6f;
-    BOOST_CHECK_EQUAL(CalculateNextWorkRequired(&pindexLast, nLastRetargetTime, params), 0x1d00e1fd);
+    BOOST_CHECK_EQUAL(CalculateNextWorkRequired(&pindexLast, nLastRetargetTime, chainParams->GetConsensus()), 0x1d00e1fd);
 }
 
 BOOST_AUTO_TEST_CASE(GetBlockProofEquivalentTime_test)
 {
-    SelectParams(CBaseChainParams::MAIN);
-    const Consensus::Params& params = Params().GetConsensus();
-
+    const auto chainParams = CreateChainParams(CBaseChainParams::MAIN);
     std::vector<CBlockIndex> blocks(10000);
     for (int i = 0; i < 10000; i++) {
         blocks[i].pprev = i ? &blocks[i - 1] : NULL;
         blocks[i].nHeight = i;
-        blocks[i].nTime = 1269211443 + i * params.nPowTargetSpacing;
+        blocks[i].nTime = 1269211443 + i * chainParams->GetConsensus().nPowTargetSpacing;
         blocks[i].nBits = 0x207fffff; /* target 0x7fffff000... */
         blocks[i].nChainWork = i ? blocks[i - 1].nChainWork + GetBlockProof(blocks[i - 1]) : arith_uint256(0);
     }
@@ -88,7 +78,7 @@ BOOST_AUTO_TEST_CASE(GetBlockProofEquivalentTime_test)
         CBlockIndex *p2 = &blocks[GetRand(10000)];
         CBlockIndex *p3 = &blocks[GetRand(10000)];
 
-        int64_t tdiff = GetBlockProofEquivalentTime(*p1, *p2, *p3, params);
+        int64_t tdiff = GetBlockProofEquivalentTime(*p1, *p2, *p3, chainParams->GetConsensus());
         BOOST_CHECK_EQUAL(tdiff, p1->GetBlockTime() - p2->GetBlockTime());
     }
 }

--- a/src/test/pow_tests.cpp
+++ b/src/test/pow_tests.cpp
@@ -21,7 +21,7 @@ BOOST_AUTO_TEST_CASE(get_next_work)
     CBlockIndex pindexLast;
     pindexLast.nHeight = 32255;
     pindexLast.nTime = 1262152739;  // Block #32255
-    pindexLast.nBits = 0x1d00ffff;
+    pindexLast.proof.pow.nBits = 0x1d00ffff;
     BOOST_CHECK_EQUAL(CalculateNextWorkRequired(&pindexLast, nLastRetargetTime, chainParams->GetConsensus()), 0x1d00d86a);
 }
 
@@ -33,7 +33,7 @@ BOOST_AUTO_TEST_CASE(get_next_work_pow_limit)
     CBlockIndex pindexLast;
     pindexLast.nHeight = 2015;
     pindexLast.nTime = 1233061996;  // Block #2015
-    pindexLast.nBits = 0x1d00ffff;
+    pindexLast.proof.pow.nBits = 0x1d00ffff;
     BOOST_CHECK_EQUAL(CalculateNextWorkRequired(&pindexLast, nLastRetargetTime, chainParams->GetConsensus()), 0x1d00ffff);
 }
 
@@ -45,7 +45,7 @@ BOOST_AUTO_TEST_CASE(get_next_work_lower_limit_actual)
     CBlockIndex pindexLast;
     pindexLast.nHeight = 68543;
     pindexLast.nTime = 1279297671;  // Block #68543
-    pindexLast.nBits = 0x1c05a3f4;
+    pindexLast.proof.pow.nBits = 0x1c05a3f4;
     BOOST_CHECK_EQUAL(CalculateNextWorkRequired(&pindexLast, nLastRetargetTime, chainParams->GetConsensus()), 0x1c0168fd);
 }
 
@@ -57,7 +57,7 @@ BOOST_AUTO_TEST_CASE(get_next_work_upper_limit_actual)
     CBlockIndex pindexLast;
     pindexLast.nHeight = 46367;
     pindexLast.nTime = 1269211443;  // Block #46367
-    pindexLast.nBits = 0x1c387f6f;
+    pindexLast.proof.pow.nBits = 0x1c387f6f;
     BOOST_CHECK_EQUAL(CalculateNextWorkRequired(&pindexLast, nLastRetargetTime, chainParams->GetConsensus()), 0x1d00e1fd);
 }
 
@@ -69,7 +69,7 @@ BOOST_AUTO_TEST_CASE(GetBlockProofEquivalentTime_test)
         blocks[i].pprev = i ? &blocks[i - 1] : NULL;
         blocks[i].nHeight = i;
         blocks[i].nTime = 1269211443 + i * chainParams->GetConsensus().nPowTargetSpacing;
-        blocks[i].nBits = 0x207fffff; /* target 0x7fffff000... */
+        blocks[i].proof.pow.nBits = 0x207fffff; /* target 0x7fffff000... */
         blocks[i].nChainWork = i ? blocks[i - 1].nChainWork + GetBlockProof(blocks[i - 1]) : arith_uint256(0);
     }
 

--- a/src/test/signedblocks_tests.cpp
+++ b/src/test/signedblocks_tests.cpp
@@ -1,0 +1,168 @@
+// Copyright (c) 2016-2016 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "base58.h" // For CBitcoinSecret
+#include "chain.h"
+#include "chainparams.h"
+#include "consensus/header_verify.h"
+#include "consensus/validation.h"
+#include "keystore.h"
+#include "primitives/block.h"
+#include "script/generic.hpp"
+#include "util.h"
+#include "utilstrencodings.h"
+
+#include <boost/test/unit_test.hpp>
+
+static bool fSignBlocksGlobalRestore = fSignBlocksGlobal;
+
+static void start_blocksing_test()
+{
+    ECC_Start();
+    fSignBlocksGlobalRestore = fSignBlocksGlobal; // TODO signblocks: This is ugly
+    fSignBlocksGlobal = true; // Set global from primitives/block to true for these tests
+}
+
+static void stop_blocksing_test()
+{
+    fSignBlocksGlobal = fSignBlocksGlobalRestore; // Restore global
+    ECC_Stop();
+}
+
+static std::string SingleSignerScriptStrFromKey(const CKey& key)
+{
+    std::string strPubkey = HexStr(key.GetPubKey());
+    CScript scriptPubKey = CScript() << ParseHex(strPubkey) << OP_CHECKSIG;
+    std::string strScript = HexStr(scriptPubKey);
+    // TOOLING: Uncomment to create params for a private chain with a single signer
+    // BOOST_CHECK_EQUAL("-con_signblockscript", strScript);
+    // std::unique_ptr<CChainParams> chainparams = CChainParams::Factory(CBaseChainParams::CUSTOM);
+    // BOOST_CHECK_EQUAL("importprivkey", CBitcoinSecret(key, *chainparams).ToString());
+    // BOOST_CHECK_EQUAL("pubkey_for_multisig", strPubkey);
+
+    return strScript;
+}
+
+static std::string MultiSignerScriptStrFromPubKeys(const CPubKey* pubkeys, uint32_t min, uint32_t max)
+{
+    BOOST_CHECK(min <= max);
+    CScript multisigScriptPubKey = CScript() << OP_2; // TODO Replace 2 with min
+
+    for (unsigned i = 0; i < max; ++i) {
+        multisigScriptPubKey << ParseHex(HexStr(pubkeys[i]));
+    }
+    multisigScriptPubKey << OP_3 << OP_CHECKMULTISIG; // TODO Replace 3 with max
+    return HexStr(multisigScriptPubKey);
+}
+
+BOOST_AUTO_TEST_CASE(GenericSignWithRegularBlocks)
+{
+    ECC_Start();
+
+    CBlockHeader block;
+    CScript scriptSig;
+    CScript scriptPubKey;
+    unsigned int flags = SCRIPT_VERIFY_NONE;
+    CBasicKeyStore keystore;
+    SignatureData scriptSigData;
+    SignatureData scriptSig1;
+    SignatureData scriptSig2;
+
+    // Make sure that the generic templates compile for CBlockHeader
+    SignatureData scriptExpected = GenericCombineSignatures(scriptPubKey, block, scriptSig1, scriptSig2);
+    BOOST_CHECK(!GenericSignScript(keystore, block, scriptPubKey, scriptSigData));
+    BOOST_CHECK(!GenericVerifyScript(scriptSig, scriptPubKey, flags, block));
+
+    CKey key;
+    key.MakeNewKey(true);
+    CPubKey pubkey = key.GetPubKey();
+    keystore.AddKeyPubKey(key, pubkey);
+    const CScript scriptCode;
+    SigVersion sigversion = SIGVERSION_WITNESS_V0;
+    const std::vector<unsigned char> vchPubKey = ToByteVector(pubkey);
+    std::vector<unsigned char> vchScriptSig;
+    SimpleSignatureCreator simpleSignatureCreator(&keystore, SerializeHash(block));
+
+    BOOST_CHECK(simpleSignatureCreator.CreateSig(vchScriptSig, pubkey.GetID(), scriptCode, sigversion));
+    BOOST_CHECK(simpleSignatureCreator.Checker().CheckSig(vchScriptSig, vchPubKey, scriptCode, sigversion));
+
+    scriptPubKey << ParseHex(HexStr(pubkey)) << OP_CHECKSIG;
+    BOOST_CHECK(ProduceSignature(simpleSignatureCreator, scriptPubKey, scriptSigData));
+    BOOST_CHECK(VerifyScript(scriptSigData.scriptSig, scriptPubKey, NULL, flags, simpleSignatureCreator.Checker()));
+
+    BOOST_CHECK(GenericSignScript(keystore, block, scriptPubKey, scriptSigData));
+    BOOST_CHECK(GenericVerifyScript(scriptSigData.scriptSig, scriptPubKey, flags, block));
+
+    ECC_Stop();
+}
+
+BOOST_AUTO_TEST_CASE(BasicSignBlock)
+{
+    start_blocksing_test();
+    fSignBlocksGlobal = true;
+    BOOST_CHECK(fSignBlocksGlobal);
+
+    // Generate and check proofs on custom blocksigned chains
+    CBasicKeyStore keystore;
+    CBlockHeader block;
+    CBlockIndex indexPrev;
+    CValidationState state;
+    ArgsManager testArgs;
+    testArgs.ForceSetArg("-con_signblockscript", "1");
+    BOOST_CHECK(testArgs.IsArgSet("-con_signblockscript"));
+    BOOST_CHECK(testArgs.GetBoolArg("-con_signblockscript", false));
+    std::unique_ptr<CChainParams> chainparams = CreateChainParams(CBaseChainParams::CUSTOM, testArgs);
+
+    // TODO signblocks: Make sure BasicSignBlock is independent from GenericSignWithRegularBlocks
+
+    // Default -con_signblockscript with -con_fsignblockchain=1 is OP_TRUE
+
+    // BOOST_CHECK(CheckChallenge(chainparams->GetConsensus(), state, &block, &indexPrev)); // Should pass always for signed blocks
+    ResetChallenge(chainparams->GetConsensus(), &block, &indexPrev); // Shouldn't do anything
+    BOOST_CHECK(CheckChallenge(chainparams->GetConsensus(), state, &block, &indexPrev)); // Should pass always for signed blocks
+
+    ResetProof(chainparams->GetConsensus(), &block);
+    // BOOST_CHECK(CheckProof(chainparams->GetConsensus(), block)); // Should pass with an empty script for scriptpubKey=OP_TRUE
+    BOOST_CHECK(!GenerateProof(chainparams->GetConsensus(), &block, &keystore)); // But OP_TRUE is not a standard output type
+
+    // Also OP_TRUE-chain from custom -con_signblockscript
+
+    testArgs.ForceSetArg("-con_signblockscript", HexStr(CScript(OP_TRUE)));
+    // chainparams = CreateChainParams(CBaseChainParams::CUSTOM, testArgs);
+    ResetProof(chainparams->GetConsensus(), &block);
+    // BOOST_CHECK(CheckProof(chainparams->GetConsensus(), block)); // Should pass with an empty script for scriptpubKey=OP_TRUE
+    BOOST_CHECK(!GenerateProof(chainparams->GetConsensus(), &block, &keystore)); // But OP_TRUE is not a standard output type
+
+    // Also Choose one signing key
+
+    CKey key;
+    key.MakeNewKey(true);
+    testArgs.ForceSetArg("-con_signblockscript", SingleSignerScriptStrFromKey(key));
+    // chainparams = CreateChainParams(CBaseChainParams::CUSTOM, testArgs);
+
+    ResetProof(chainparams->GetConsensus(), &block);
+    // BOOST_CHECK(!CheckProof(chainparams->GetConsensus(), block)); // Should not pass without generating the proof
+    BOOST_CHECK(!GenerateProof(chainparams->GetConsensus(), &block, &keystore)); // Should not be able to generate the proof without the key
+    keystore.AddKey(key); // Should pass after adding the key
+    // TODO signblocks: These 2 seems to be dependent on GenericSignWithRegularBlocks
+    // BOOST_CHECK(GenerateProof(chainparams->GetConsensus(), &block, &keystore));
+    // BOOST_CHECK(CheckProof(chainparams->GetConsensus(), block));
+
+    // Also test multisig scripts
+
+    const unsigned MAX_MULTISIG_AGENTS = 5;
+    CKey keys[MAX_MULTISIG_AGENTS];
+    CPubKey pubkeys[MAX_MULTISIG_AGENTS];
+    for (unsigned i = 0; i < MAX_MULTISIG_AGENTS; ++i) {
+        keys[i].MakeNewKey(true);
+        pubkeys[i] = keys[i].GetPubKey();
+        keystore.AddKey(keys[i]);
+    }
+    testArgs.ForceSetArg("-con_signblockscript", MultiSignerScriptStrFromPubKeys(pubkeys, 2, 3));
+    // chainparams = CreateChainParams(CBaseChainParams::CUSTOM, testArgs);
+
+    // TODO signblocks: tests for multisig
+    
+    stop_blocksing_test();
+}

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -11,6 +11,7 @@
 #include "consensus/header_verify.h"
 #include "consensus/validation.h"
 #include "key.h"
+#include "keystore.h"
 #include "validation.h"
 #include "miner.h"
 #include "net_processing.h"
@@ -128,7 +129,8 @@ TestChain100Setup::CreateAndProcessBlock(const std::vector<CMutableTransaction>&
     unsigned int extraNonce = 0;
     IncrementExtraNonce(&block, chainActive.Tip(), extraNonce);
 
-    while (!GenerateProof(Params().GetConsensus(), &block));
+    CBasicKeyStore dummyKeystore;
+    while (!GenerateProof(Params().GetConsensus(), &block, &dummyKeystore));
 
     std::shared_ptr<const CBlock> shared_pblock = std::make_shared<const CBlock>(block);
     ProcessNewBlock(chainparams, shared_pblock, true, NULL);

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -8,6 +8,7 @@
 
 #include "chainparams.h"
 #include "consensus/consensus.h"
+#include "consensus/header_verify.h"
 #include "consensus/validation.h"
 #include "key.h"
 #include "validation.h"
@@ -127,7 +128,7 @@ TestChain100Setup::CreateAndProcessBlock(const std::vector<CMutableTransaction>&
     unsigned int extraNonce = 0;
     IncrementExtraNonce(&block, chainActive.Tip(), extraNonce);
 
-    while (!CheckProofOfWork(block.GetHash(), block.nBits, chainparams.GetConsensus())) ++block.nNonce;
+    while (!GenerateProof(Params().GetConsensus(), &block));
 
     std::shared_ptr<const CBlock> shared_pblock = std::make_shared<const CBlock>(block);
     ProcessNewBlock(chainparams, shared_pblock, true, NULL);

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -129,7 +129,7 @@ BOOST_AUTO_TEST_CASE(util_ParseParameters)
                 && !mapMultiArgs.count("f") && !mapMultiArgs.count("-d"));
 
     BOOST_CHECK(testArgs.GetMapArgs()["-a"] == "" && testArgs.GetMapArgs()["-ccc"] == "multiple");
-    BOOST_CHECK(mapMultiArgs.at("-ccc").size() == 2);
+    BOOST_CHECK(testArgs.ArgsAt("-ccc").size() == 2);
 }
 
 BOOST_AUTO_TEST_CASE(util_GetArg)

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -17,8 +17,6 @@
 
 #include <boost/test/unit_test.hpp>
 
-extern std::map<std::string, std::string> mapArgs;
-
 BOOST_FIXTURE_TEST_SUITE(util_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(util_criticalsection)
@@ -100,52 +98,63 @@ BOOST_AUTO_TEST_CASE(util_DateTimeStrFormat)
     BOOST_CHECK_EQUAL(DateTimeStrFormat("%a, %d %b %Y %H:%M:%S +0000", 1317425777), "Fri, 30 Sep 2011 23:36:17 +0000");
 }
 
+class TestArgsManager : public ArgsManager
+{
+public:
+    std::map<std::string, std::string>& GetMapArgs()
+    {
+        return mapArgs;
+    };
+};
+
 BOOST_AUTO_TEST_CASE(util_ParseParameters)
 {
+    TestArgsManager testArgs;
     const char *argv_test[] = {"-ignored", "-a", "-b", "-ccc=argument", "-ccc=multiple", "f", "-d=e"};
 
-    ParseParameters(0, (char**)argv_test);
-    BOOST_CHECK(mapArgs.empty() && mapMultiArgs.empty());
+    testArgs.ParseParameters(0, (char**)argv_test);
+    BOOST_CHECK(testArgs.GetMapArgs().empty() && mapMultiArgs.empty());
 
-    ParseParameters(1, (char**)argv_test);
-    BOOST_CHECK(mapArgs.empty() && mapMultiArgs.empty());
+    testArgs.ParseParameters(1, (char**)argv_test);
+    BOOST_CHECK(testArgs.GetMapArgs().empty() && mapMultiArgs.empty());
 
-    ParseParameters(5, (char**)argv_test);
+    testArgs.ParseParameters(5, (char**)argv_test);
     // expectation: -ignored is ignored (program name argument),
     // -a, -b and -ccc end up in map, -d ignored because it is after
     // a non-option argument (non-GNU option parsing)
-    BOOST_CHECK(mapArgs.size() == 3 && mapMultiArgs.size() == 3);
-    BOOST_CHECK(IsArgSet("-a") && IsArgSet("-b") && IsArgSet("-ccc")
-                && !IsArgSet("f") && !IsArgSet("-d"));
+    BOOST_CHECK(testArgs.GetMapArgs().size() == 3 && mapMultiArgs.size() == 3);
+    BOOST_CHECK(testArgs.IsArgSet("-a") && testArgs.IsArgSet("-b") && testArgs.IsArgSet("-ccc")
+                && !testArgs.IsArgSet("f") && !testArgs.IsArgSet("-d"));
     BOOST_CHECK(mapMultiArgs.count("-a") && mapMultiArgs.count("-b") && mapMultiArgs.count("-ccc")
                 && !mapMultiArgs.count("f") && !mapMultiArgs.count("-d"));
 
-    BOOST_CHECK(mapArgs["-a"] == "" && mapArgs["-ccc"] == "multiple");
+    BOOST_CHECK(testArgs.GetMapArgs()["-a"] == "" && testArgs.GetMapArgs()["-ccc"] == "multiple");
     BOOST_CHECK(mapMultiArgs.at("-ccc").size() == 2);
 }
 
 BOOST_AUTO_TEST_CASE(util_GetArg)
 {
-    mapArgs.clear();
-    mapArgs["strtest1"] = "string...";
+    TestArgsManager testArgs;
+    testArgs.GetMapArgs().clear();
+    testArgs.GetMapArgs()["strtest1"] = "string...";
     // strtest2 undefined on purpose
-    mapArgs["inttest1"] = "12345";
-    mapArgs["inttest2"] = "81985529216486895";
+    testArgs.GetMapArgs()["inttest1"] = "12345";
+    testArgs.GetMapArgs()["inttest2"] = "81985529216486895";
     // inttest3 undefined on purpose
-    mapArgs["booltest1"] = "";
+    testArgs.GetMapArgs()["booltest1"] = "";
     // booltest2 undefined on purpose
-    mapArgs["booltest3"] = "0";
-    mapArgs["booltest4"] = "1";
+    testArgs.GetMapArgs()["booltest3"] = "0";
+    testArgs.GetMapArgs()["booltest4"] = "1";
 
-    BOOST_CHECK_EQUAL(GetArg("strtest1", "default"), "string...");
-    BOOST_CHECK_EQUAL(GetArg("strtest2", "default"), "default");
-    BOOST_CHECK_EQUAL(GetArg("inttest1", -1), 12345);
-    BOOST_CHECK_EQUAL(GetArg("inttest2", -1), 81985529216486895LL);
-    BOOST_CHECK_EQUAL(GetArg("inttest3", -1), -1);
-    BOOST_CHECK_EQUAL(GetBoolArg("booltest1", false), true);
-    BOOST_CHECK_EQUAL(GetBoolArg("booltest2", false), false);
-    BOOST_CHECK_EQUAL(GetBoolArg("booltest3", false), false);
-    BOOST_CHECK_EQUAL(GetBoolArg("booltest4", false), true);
+    BOOST_CHECK_EQUAL(testArgs.GetArg("strtest1", "default"), "string...");
+    BOOST_CHECK_EQUAL(testArgs.GetArg("strtest2", "default"), "default");
+    BOOST_CHECK_EQUAL(testArgs.GetArg("inttest1", -1), 12345);
+    BOOST_CHECK_EQUAL(testArgs.GetArg("inttest2", -1), 81985529216486895LL);
+    BOOST_CHECK_EQUAL(testArgs.GetArg("inttest3", -1), -1);
+    BOOST_CHECK_EQUAL(testArgs.GetBoolArg("booltest1", false), true);
+    BOOST_CHECK_EQUAL(testArgs.GetBoolArg("booltest2", false), false);
+    BOOST_CHECK_EQUAL(testArgs.GetBoolArg("booltest3", false), false);
+    BOOST_CHECK_EQUAL(testArgs.GetBoolArg("booltest4", false), true);
 }
 
 BOOST_AUTO_TEST_CASE(util_FormatMoney)

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -105,6 +105,10 @@ public:
     {
         return mapArgs;
     };
+    std::map<std::string, std::vector<std::string> >& GetMapMultiArgs()
+    {
+        return mapMultiArgs;
+    };
 };
 
 BOOST_AUTO_TEST_CASE(util_ParseParameters)
@@ -113,20 +117,20 @@ BOOST_AUTO_TEST_CASE(util_ParseParameters)
     const char *argv_test[] = {"-ignored", "-a", "-b", "-ccc=argument", "-ccc=multiple", "f", "-d=e"};
 
     testArgs.ParseParameters(0, (char**)argv_test);
-    BOOST_CHECK(testArgs.GetMapArgs().empty() && mapMultiArgs.empty());
+    BOOST_CHECK(testArgs.GetMapArgs().empty() && testArgs.GetMapMultiArgs().empty());
 
     testArgs.ParseParameters(1, (char**)argv_test);
-    BOOST_CHECK(testArgs.GetMapArgs().empty() && mapMultiArgs.empty());
+    BOOST_CHECK(testArgs.GetMapArgs().empty() && testArgs.GetMapMultiArgs().empty());
 
     testArgs.ParseParameters(5, (char**)argv_test);
     // expectation: -ignored is ignored (program name argument),
     // -a, -b and -ccc end up in map, -d ignored because it is after
     // a non-option argument (non-GNU option parsing)
-    BOOST_CHECK(testArgs.GetMapArgs().size() == 3 && mapMultiArgs.size() == 3);
+    BOOST_CHECK(testArgs.GetMapArgs().size() == 3 && testArgs.GetMapMultiArgs().size() == 3);
     BOOST_CHECK(testArgs.IsArgSet("-a") && testArgs.IsArgSet("-b") && testArgs.IsArgSet("-ccc")
                 && !testArgs.IsArgSet("f") && !testArgs.IsArgSet("-d"));
-    BOOST_CHECK(mapMultiArgs.count("-a") && mapMultiArgs.count("-b") && mapMultiArgs.count("-ccc")
-                && !mapMultiArgs.count("f") && !mapMultiArgs.count("-d"));
+    BOOST_CHECK(testArgs.GetMapMultiArgs().count("-a") && testArgs.GetMapMultiArgs().count("-b") && testArgs.GetMapMultiArgs().count("-ccc")
+                && !testArgs.GetMapMultiArgs().count("f") && !testArgs.GetMapMultiArgs().count("-d"));
 
     BOOST_CHECK(testArgs.GetMapArgs()["-a"] == "" && testArgs.GetMapArgs()["-ccc"] == "multiple");
     BOOST_CHECK(testArgs.ArgsAt("-ccc").size() == 2);

--- a/src/test/versionbits_tests.cpp
+++ b/src/test/versionbits_tests.cpp
@@ -209,7 +209,8 @@ BOOST_AUTO_TEST_CASE(versionbits_test)
     }
 
     // Sanity checks of version bit deployments
-    const Consensus::Params &mainnetParams = Params(CBaseChainParams::MAIN).GetConsensus();
+    const auto chainParams = CreateChainParams(CBaseChainParams::MAIN);
+    const Consensus::Params &mainnetParams = chainParams->GetConsensus();
     for (int i=0; i<(int) Consensus::MAX_VERSION_BITS_DEPLOYMENTS; i++) {
         uint32_t bitmask = VersionBitsMask(mainnetParams, (Consensus::DeploymentPos)i);
         // Make sure that no deployment tries to set an invalid bit.
@@ -235,7 +236,8 @@ BOOST_AUTO_TEST_CASE(versionbits_computeblockversion)
 {
     // Check that ComputeBlockVersion will set the appropriate bit correctly
     // on mainnet.
-    const Consensus::Params &mainnetParams = Params(CBaseChainParams::MAIN).GetConsensus();
+    const auto chainParams = CreateChainParams(CBaseChainParams::MAIN);
+    const Consensus::Params &mainnetParams = chainParams->GetConsensus();
 
     // Use the TESTDUMMY deployment for testing purposes.
     int64_t bit = mainnetParams.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit;

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -195,8 +195,8 @@ bool CBlockTreeDB::LoadBlockIndexGuts(boost::function<CBlockIndex*(const uint256
                 pindexNew->nVersion       = diskindex.nVersion;
                 pindexNew->hashMerkleRoot = diskindex.hashMerkleRoot;
                 pindexNew->nTime          = diskindex.nTime;
-                pindexNew->nBits          = diskindex.nBits;
-                pindexNew->nNonce         = diskindex.nNonce;
+                pindexNew->proof.pow.nBits = diskindex.proof.pow.nBits;
+                pindexNew->proof.pow.nNonce = diskindex.proof.pow.nNonce;
                 pindexNew->nStatus        = diskindex.nStatus;
                 pindexNew->nTx            = diskindex.nTx;
 

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -6,8 +6,8 @@
 #include "txdb.h"
 
 #include "chainparams.h"
+#include "consensus/header_verify.h"
 #include "hash.h"
-#include "pow.h"
 #include "uint256.h"
 
 #include <stdint.h>
@@ -174,6 +174,7 @@ bool CBlockTreeDB::ReadFlag(const std::string &name, bool &fValue) {
 bool CBlockTreeDB::LoadBlockIndexGuts(boost::function<CBlockIndex*(const uint256&)> insertBlockIndex)
 {
     std::unique_ptr<CDBIterator> pcursor(NewIterator());
+    const Consensus::Params& consensusParams = Params().GetConsensus();
 
     pcursor->Seek(make_pair(DB_BLOCK_INDEX, uint256()));
 
@@ -199,8 +200,9 @@ bool CBlockTreeDB::LoadBlockIndexGuts(boost::function<CBlockIndex*(const uint256
                 pindexNew->nStatus        = diskindex.nStatus;
                 pindexNew->nTx            = diskindex.nTx;
 
-                if (!CheckProofOfWork(pindexNew->GetBlockHash(), pindexNew->nBits, Params().GetConsensus()) && pindexNew->GetBlockHash() != Params().GetConsensus().hashGenesisBlock)
-                    return error("LoadBlockIndex(): CheckProofOfWork failed: %s", pindexNew->ToString());
+                if (!CheckProof(consensusParams, pindexNew->GetBlockHeader()) &&
+                    pindexNew->GetBlockHash() != consensusParams.hashGenesisBlock)
+                    return error("%s: CheckProof failed: %s", __func__, pindexNew->ToString());
 
                 pcursor->Next();
             } else {

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -199,7 +199,7 @@ bool CBlockTreeDB::LoadBlockIndexGuts(boost::function<CBlockIndex*(const uint256
                 pindexNew->nStatus        = diskindex.nStatus;
                 pindexNew->nTx            = diskindex.nTx;
 
-                if (!CheckProofOfWork(pindexNew->GetBlockHash(), pindexNew->nBits, Params().GetConsensus()))
+                if (!CheckProofOfWork(pindexNew->GetBlockHash(), pindexNew->nBits, Params().GetConsensus()) && pindexNew->GetBlockHash() != Params().GetConsensus().hashGenesisBlock)
                     return error("LoadBlockIndex(): CheckProofOfWork failed: %s", pindexNew->ToString());
 
                 pcursor->Next();

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -238,7 +238,7 @@ bool LogAcceptCategory(const char* category)
         static boost::thread_specific_ptr<set<string> > ptrCategory;
         if (ptrCategory.get() == NULL)
         {
-            if (mapMultiArgs.count("-debug")) {
+            if (argsGlobal.IsArgSet("-debug")) {
                 const vector<string>& categories = mapMultiArgs.at("-debug");
                 ptrCategory.reset(new set<string>(categories.begin(), categories.end()));
                 // thread_specific_ptr automatically deletes the set when the thread ends.

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -239,7 +239,7 @@ bool LogAcceptCategory(const char* category)
         if (ptrCategory.get() == NULL)
         {
             if (argsGlobal.IsArgSet("-debug")) {
-                const vector<string>& categories = mapMultiArgs.at("-debug");
+                const vector<string>& categories = argsGlobal.ArgsAt("-debug");
                 ptrCategory.reset(new set<string>(categories.begin(), categories.end()));
                 // thread_specific_ptr automatically deletes the set when the thread ends.
             } else
@@ -377,6 +377,11 @@ void ArgsManager::ParseParameters(int argc, const char* const argv[])
         mapArgs[str] = strValue;
         _mapMultiArgs[str].push_back(strValue);
     }
+}
+
+const std::vector<std::string>& ArgsManager::ArgsAt(const std::string& strArg) const
+{
+    return mapMultiArgs.at(strArg);
 }
 
 bool ArgsManager::IsArgSet(const std::string& strArg)

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -102,8 +102,6 @@ const char * const BITCOIN_CONF_FILENAME = "bitcoin.conf";
 const char * const BITCOIN_PID_FILENAME = "bitcoind.pid";
 
 ArgsManager argsGlobal;
-static map<string, vector<string> > _mapMultiArgs;
-const map<string, vector<string> >& mapMultiArgs = _mapMultiArgs;
 bool fDebug = false;
 bool fPrintToConsole = false;
 bool fPrintToDebugLog = true;
@@ -347,7 +345,7 @@ void ArgsManager::ParseParameters(int argc, const char* const argv[])
 {
     LOCK(cs_args);
     mapArgs.clear();
-    _mapMultiArgs.clear();
+    mapMultiArgs.clear();
 
     for (int i = 1; i < argc; i++)
     {
@@ -375,7 +373,7 @@ void ArgsManager::ParseParameters(int argc, const char* const argv[])
         InterpretNegativeSetting(str, strValue);
 
         mapArgs[str] = strValue;
-        _mapMultiArgs[str].push_back(strValue);
+        mapMultiArgs[str].push_back(strValue);
     }
 }
 
@@ -618,7 +616,7 @@ void ArgsManager::ReadConfigFile(const std::string& confPath)
             InterpretNegativeSetting(strKey, strValue);
             if (mapArgs.count(strKey) == 0)
                 mapArgs[strKey] = strValue;
-            _mapMultiArgs[strKey].push_back(strValue);
+            mapMultiArgs[strKey].push_back(strValue);
         }
     }
     // If datadir is changed in .conf file:

--- a/src/util.h
+++ b/src/util.h
@@ -42,7 +42,6 @@ public:
     boost::signals2::signal<std::string (const char* psz)> Translate;
 };
 
-extern const std::map<std::string, std::vector<std::string> >& mapMultiArgs;
 extern bool fDebug;
 extern bool fPrintToConsole;
 extern bool fPrintToDebugLog;
@@ -127,6 +126,7 @@ class ArgsManager
 protected:
     CCriticalSection cs_args;
     std::map<std::string, std::string> mapArgs;
+    std::map<std::string, std::vector<std::string> > mapMultiArgs;
 public:
     void ParseParameters(int argc, const char*const argv[]);
     void ReadConfigFile(const std::string& confPath);

--- a/src/util.h
+++ b/src/util.h
@@ -130,6 +130,7 @@ protected:
 public:
     void ParseParameters(int argc, const char*const argv[]);
     void ReadConfigFile(const std::string& confPath);
+    const std::vector<std::string>& ArgsAt(const std::string& strArg) const;
 /**
  * Return true if the given argument has been manually set
  *

--- a/src/util.h
+++ b/src/util.h
@@ -15,6 +15,7 @@
 #endif
 
 #include "compat.h"
+#include "sync.h"
 #include "tinyformat.h"
 #include "utiltime.h"
 
@@ -91,7 +92,6 @@ bool error(const char* fmt, const Args&... args)
 }
 
 void PrintExceptionContinue(const std::exception *pex, const char* pszThread);
-void ParseParameters(int argc, const char*const argv[]);
 void FileCommit(FILE *file);
 bool TruncateFile(FILE *file, unsigned int length);
 int RaiseFileDescriptorLimit(int nMinFD);
@@ -106,7 +106,6 @@ boost::filesystem::path GetConfigFile(const std::string& confPath);
 boost::filesystem::path GetPidFile();
 void CreatePidFile(const boost::filesystem::path &path, pid_t pid);
 #endif
-void ReadConfigFile(const std::string& confPath);
 #ifdef WIN32
 boost::filesystem::path GetSpecialFolderPath(int nFolder, bool fCreate = true);
 #endif
@@ -123,6 +122,14 @@ inline bool IsSwitchChar(char c)
 #endif
 }
 
+class ArgsManager
+{
+protected:
+    CCriticalSection cs_args;
+    std::map<std::string, std::string> mapArgs;
+public:
+    void ParseParameters(int argc, const char*const argv[]);
+    void ReadConfigFile(const std::string& confPath);
 /**
  * Return true if the given argument has been manually set
  *
@@ -177,6 +184,20 @@ bool SoftSetArg(const std::string& strArg, const std::string& strValue);
 bool SoftSetBoolArg(const std::string& strArg, bool fValue);
 
 // Forces a arg setting, used only in testing
+void ForceSetArg(const std::string& strArg, const std::string& strValue);
+};
+
+extern ArgsManager argsGlobal;
+
+// wrappers using the global ArgsManager:
+void ParseParameters(int argc, const char*const argv[]);
+void ReadConfigFile(const std::string& confPath);
+bool IsArgSet(const std::string& strArg);
+std::string GetArg(const std::string& strArg, const std::string& strDefault);
+int64_t GetArg(const std::string& strArg, int64_t nDefault);
+bool GetBoolArg(const std::string& strArg, bool fDefault);
+bool SoftSetArg(const std::string& strArg, const std::string& strValue);
+bool SoftSetBoolArg(const std::string& strArg, bool fValue);
 void ForceSetArg(const std::string& strArg, const std::string& strValue);
 
 /**

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1114,7 +1114,8 @@ bool ReadBlockFromDisk(CBlock& block, const CDiskBlockPos& pos, const Consensus:
     }
 
     // Check the header
-    if (!CheckProofOfWork(block.GetHash(), block.nBits, consensusParams))
+    if (!CheckProofOfWork(block.GetHash(), block.nBits, consensusParams) &&
+        block.GetHash() != consensusParams.hashGenesisBlock)
         return error("ReadBlockFromDisk: Errors in block header at %s", pos.ToString());
 
     return true;
@@ -1709,10 +1710,6 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
 
     int64_t nTimeStart = GetTimeMicros();
 
-    // Check it again in case a previous version let a bad block in
-    if (!CheckBlock(block, state, chainparams.GetConsensus(), !fJustCheck, !fJustCheck))
-        return error("%s: Consensus::CheckBlock: %s", __func__, FormatStateMessage(state));
-
     // verify that the view's current state corresponds to the previous block
     uint256 hashPrevBlock = pindex->pprev == NULL ? uint256() : pindex->pprev->GetBlockHash();
     assert(hashPrevBlock == view.GetBestBlock());
@@ -1724,6 +1721,10 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
             view.SetBestBlock(pindex->GetBlockHash());
         return true;
     }
+
+    // Check it again in case a previous version let a bad block in
+    if (!CheckBlock(block, state, chainparams.GetConsensus(), !fJustCheck, !fJustCheck))
+        return error("%s: Consensus::CheckBlock: %s", __func__, FormatStateMessage(state));
 
     bool fScriptChecks = true;
     if (!hashAssumeValid.IsNull()) {
@@ -3142,8 +3143,9 @@ static bool AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CValidation
     }
     if (fNewBlock) *fNewBlock = true;
 
-    if (!CheckBlock(block, state, chainparams.GetConsensus(), GetAdjustedTime()) ||
-        !ContextualCheckBlock(block, state, chainparams.GetConsensus(), pindex->pprev)) {
+    if ((block.GetHash() != chainparams.GetConsensus().hashGenesisBlock) &&
+        (!CheckBlock(block, state, chainparams.GetConsensus(), GetAdjustedTime()) ||
+        !ContextualCheckBlock(block, state, chainparams.GetConsensus(), pindex->pprev))) {
         if (state.IsInvalid() && !state.CorruptionPossible()) {
             pindex->nStatus |= BLOCK_FAILED_VALID;
             setDirtyBlockIndex.insert(pindex);

--- a/src/validation.h
+++ b/src/validation.h
@@ -471,7 +471,7 @@ bool ReadBlockFromDisk(CBlock& block, const CBlockIndex* pindex, const Consensus
 /** Functions for validating blocks and updating the block tree */
 
 /** Context-independent validity checks */
-bool CheckBlockHeader(const CBlockHeader& block, CValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOW = true);
+bool CheckBlockHeader(const CBlockHeader& block, CValidationState& state, const Consensus::Params& consensusParams);
 bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOW = true, bool fCheckMerkleRoot = true);
 
 /** Context-dependent validity checks.


### PR DESCRIPTION
Maybe helps review: https://github.com/jtimon/bitcoin/compare/0.13-new-testchain...jtimon:0.13-blocksign from #8994.

Once we allow users to create their own chains with #8994 and customize chain params viacommand line and/or a separate file (discuss there), this PR adds additional options and chainparams  -con_fsignblockchain and -con_signblockscript to optionally replace pow with bitcoin scripts if -con_fsignblockchain=1; -con_signblockscript being the scriptPubKey the block producers need to provide a scriptSig for with each block (instead of prociding a nonce that passes the pow in the block hash like regular miners).

This will help spring testchains that are more reliable and controllable by developers testing new features. Among other people, folks from the lightning community have communicated that testnet3 is not ideal for some testing scenarios.

Note that also travis tests pass, the new functionality is only tested in test/signedblocks_tests.cpp
Apart from that, BasicSignBlock is dependent on some other tests because the following doesn't pass:
```
./src/test/test_bitcoin --run_test=BasicSignBlock
```
It is good that it fails because testing manually with ```importprivkey cTVbLcfg8ftQ25j1YSysmTVugBVEuZymbKUqjHaiCmg2ZSWNmccU``` and -con_signblockscript != 21026f9ee99573cf566726ab891ad7dd7ffd36cae816efe71a93bd81f71c3abd04d6ac``` [CScript() << ParseHex("cTVbLcfg8ftQ25j1YSysmTVugBVEuZymbKUqjHaiCmg2ZSWNmccU") << OP_CHECKSIG] doesn't work either.
I hope I will eventually figure it out with ```gdb --args ./src/test/test_bitcoin --run_test=BasicSignBlock``` but if someone else is faster than me, thanks in advance.

Ideally, we would also reuse all the rpc tests for testing this mode with an additional option similar to -extended.
First we need  #8994 to reuse (or replace, please discuss there) all the rpc test for regtest with the new custom chain which by default is identical to regtest, only with a different genesis block and .bitcoin directory. Currently all of them are converted from regtest to custom except :

- [ ] p2p-comapctblocks.py
- [ ] segwit.py
- [ ] mempool_packages.py (extended)
- [ ] pruning.py (extended)

(help here welcomed too)
Reusing all tests is not strictly necessary but would be nice.

Dependencies:
- [ ] Use a proper factory for creating chainparams #8855
- [ ] Really don't validate genesis block #9102
- [ ] Testchains: Introduce custom chain whose constructor... #8994

Open design concerns:

- Global fSignBlocksGlobal is worrying 
- Global UnionProof is worrying 

You can also see https://github.com/jtimon/bitcoin/compare/0.13-blocksign...0.13-blocksign-longest for other things I'm trying or considering.
