### PR TITLE
[Qt] fix coincontrol sort issue

### DIFF
--- a/src/qt/coincontroldialog.h
+++ b/src/qt/coincontroldialog.h
@@ -70,13 +70,12 @@ private:
 
     const PlatformStyle *platformStyle;
 
-    QString strPad(QString, int, QString);
     void sortView(int, Qt::SortOrder);
     void updateView();
 
     enum
     {
-        COLUMN_CHECKBOX,
+        COLUMN_CHECKBOX = 0,
         COLUMN_AMOUNT,
         COLUMN_LABEL,
         COLUMN_ADDRESS,
@@ -84,31 +83,8 @@ private:
         COLUMN_CONFIRMATIONS,
         COLUMN_TXHASH,
         COLUMN_VOUT_INDEX,
-        COLUMN_AMOUNT_INT64,
-        COLUMN_DATE_INT64
     };
     friend class CCoinControlWidgetItem;
-
-    // some columns have a hidden column containing the value used for sorting
-    int getMappedColumn(int column, bool fVisibleColumn = true)
-    {
-        if (fVisibleColumn)
-        {
-            if (column == COLUMN_AMOUNT_INT64)
-                return COLUMN_AMOUNT;
-            else if (column == COLUMN_DATE_INT64)
-                return COLUMN_DATE;
-        }
-        else
-        {
-            if (column == COLUMN_AMOUNT)
-                return COLUMN_AMOUNT_INT64;
-            else if (column == COLUMN_DATE)
-                return COLUMN_DATE_INT64;
-        }
-
-        return column;
-    }
 
 private Q_SLOTS:
     void showMenu(const QPoint &);

--- a/src/qt/coincontroldialog.h
+++ b/src/qt/coincontroldialog.h
@@ -28,6 +28,17 @@ namespace Ui {
 
 #define ASYMP_UTF8 "\xE2\x89\x88"
 
+class CCoinControlWidgetItem : public QTreeWidgetItem
+{
+public:
+    CCoinControlWidgetItem(QTreeWidget *parent, int type = Type) : QTreeWidgetItem(parent, type) {}
+    CCoinControlWidgetItem(int type = Type) : QTreeWidgetItem(type) {}
+    CCoinControlWidgetItem(QTreeWidgetItem *parent, int type = Type) : QTreeWidgetItem(parent, type) {}
+
+    bool operator<(const QTreeWidgetItem &other) const;
+};
+
+
 class CoinControlDialog : public QDialog
 {
     Q_OBJECT
@@ -76,6 +87,7 @@ private:
         COLUMN_AMOUNT_INT64,
         COLUMN_DATE_INT64
     };
+    friend class CCoinControlWidgetItem;
 
     // some columns have a hidden column containing the value used for sorting
     int getMappedColumn(int column, bool fVisibleColumn = true)


### PR DESCRIPTION
Reported by @gmaxwell 
The sort order for the amount column is lexicographical resulting in a order like "1 10 2 20 200 3 ...".

The attempts of this PR is to fix this.