### PR TITLE
Make orphan parent fetching ask for witnesses.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5686,8 +5686,9 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                 }
             }
             if (!fRejectedParents) {
+                uint32_t nFetchFlags = GetFetchFlags(pfrom, chainActive.Tip(), chainparams.GetConsensus());
                 BOOST_FOREACH(const CTxIn& txin, tx.vin) {
-                    CInv _inv(MSG_TX, txin.prevout.hash);
+                    CInv _inv(MSG_TX | nFetchFlags, txin.prevout.hash);
                     pfrom->AddInventoryKnown(_inv);
                     if (!AlreadyHave(_inv)) pfrom->AskFor(_inv);
                 }


### PR DESCRIPTION
In 0.13 orphan transactions began being treated as implicit
 INVs for their parents.  But the resulting getdata were
 not getting the witness flag.

This fixes issue #9182 reported by chjj and roasbeef on IRC.