### PR TITLE
Send tip change notification from invalidateblock

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3201,6 +3201,7 @@ bool InvalidateBlock(CValidationState& state, const CChainParams& chainparams, C
 
     InvalidChainFound(pindex);
     mempool.removeForReorg(pcoinsTip, chainActive.Tip()->nHeight + 1, STANDARD_LOCKTIME_VERIFY_FLAGS);
+    uiInterface.NotifyBlockTip(IsInitialBlockDownload(), pindex->pprev);
     return true;
 }
 


### PR DESCRIPTION
@MarcoFalke suggested separating this commit from #9139. It's needed to prevent breaking a test that would otherwise fail with #9139.