### PR TITLE
bench: Fix subtle counting issue when rescaling iteration count

### DIFF
--- a/src/bench/bench.cpp
+++ b/src/bench/bench.cpp
@@ -64,8 +64,11 @@ bool State::KeepRunning()
           return true;
         }
         if (elapsed*16 < maxElapsed) {
-          countMask = ((countMask<<1)|1) & ((1LL<<60)-1);
-          countMaskInv = 1./(countMask+1);
+          uint64_t newCountMask = ((countMask<<1)|1) & ((1LL<<60)-1);
+          if ((count & newCountMask)==0) {
+              countMask = newCountMask;
+              countMaskInv = 1./(countMask+1);
+          }
         }
     }
     lastTime = now;


### PR DESCRIPTION
Make sure that the count is a zero modulo the new mask before scaling, otherwise the next time until a measure triggers will take only 1/2 as long as accounted for. This caused the 'min time' to be potentially off by as much as 100%.