### PR TITLE
bench: Add support for measuring CPU cycles

### DIFF
--- a/src/Makefile.bench.include
+++ b/src/Makefile.bench.include
@@ -22,7 +22,9 @@ bench_bench_bitcoin_SOURCES = \
   bench/mempool_eviction.cpp \
   bench/verify_script.cpp \
   bench/base58.cpp \
-  bench/lockedpool.cpp
+  bench/lockedpool.cpp \
+  bench/perf.cpp \
+  bench/perf.h
 
 nodist_bench_bench_bitcoin_SOURCES = $(GENERATED_TEST_FILES)
 

--- a/src/bench/bench.h
+++ b/src/bench/bench.h
@@ -41,12 +41,18 @@ namespace benchmark {
         double maxElapsed;
         double beginTime;
         double lastTime, minTime, maxTime, countMaskInv;
-        int64_t count;
-        int64_t countMask;
+        uint64_t count;
+        uint64_t countMask;
+        uint64_t beginCycles;
+        uint64_t lastCycles;
+        uint64_t minCycles;
+        uint64_t maxCycles;
     public:
         State(std::string _name, double _maxElapsed) : name(_name), maxElapsed(_maxElapsed), count(0) {
             minTime = std::numeric_limits<double>::max();
             maxTime = std::numeric_limits<double>::min();
+            minCycles = std::numeric_limits<uint64_t>::max();
+            maxCycles = std::numeric_limits<uint64_t>::min();
             countMask = 1;
             countMaskInv = 1./(countMask + 1);
         }

--- a/src/bench/perf.cpp
+++ b/src/bench/perf.cpp
@@ -1,0 +1,53 @@
+// Copyright (c) 2016 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "perf.h"
+
+#if defined(__i386__) || defined(__x86_64__)
+
+/* These architectures support quering the cycle counter
+ * from user space, no need for any syscall overhead.
+ */
+void perf_init(void) { }
+void perf_fini(void) { }
+
+#elif defined(__linux__)
+
+#include <unistd.h>
+#include <sys/syscall.h>
+#include <linux/perf_event.h>
+
+static int fd = -1;
+static struct perf_event_attr attr;
+
+void perf_init(void)
+{
+    attr.type = PERF_TYPE_HARDWARE;
+    attr.config = PERF_COUNT_HW_CPU_CYCLES;
+    fd = syscall(__NR_perf_event_open, &attr, 0, -1, -1, 0);
+}
+
+void perf_fini(void)
+{
+    if (fd != -1) {
+        close(fd);
+    }
+}
+
+uint64_t perf_cpucycles(void)
+{
+    uint64_t result = 0;
+    if (fd == -1 || read(fd, &result, sizeof(result)) < (ssize_t)sizeof(result)) {
+        return 0;
+    }
+    return result;
+}
+
+#else /* Unhandled platform */
+
+void perf_init(void) { }
+void perf_fini(void) { }
+uint64_t perf_cpucycles(void) { return 0; }
+
+#endif

--- a/src/bench/perf.h
+++ b/src/bench/perf.h
@@ -1,0 +1,37 @@
+// Copyright (c) 2016 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+/** Functions for measurement of CPU cycles */
+#ifndef H_PERF
+#define H_PERF
+
+#include <stdint.h>
+
+#if defined(__i386__)
+
+static inline uint64_t perf_cpucycles(void)
+{
+    uint64_t x;
+    __asm__ volatile (".byte 0x0f, 0x31" : "=A" (x));
+    return x;
+}
+
+#elif defined(__x86_64__)
+
+static inline uint64_t perf_cpucycles(void)
+{
+    uint32_t hi, lo;
+    __asm__ __volatile__ ("rdtsc" : "=a"(lo), "=d"(hi));
+    return ((uint64_t)lo)|(((uint64_t)hi)<<32);
+}
+#else
+
+uint64_t perf_cpucycles(void);
+
+#endif
+
+void perf_init(void);
+void perf_fini(void);
+
+#endif // H_PERF


### PR DESCRIPTION
This adds cycle min/max/avg to the statistics.

Supported on x86 and x86_64 (natively through rdtsc), as well as for some other architectures on Linux (perf syscall). Will just show 0 on unsupported platforms.

Was tested on x86_64 and AARCH64.