### PR TITLE
[trivial] Fixes the RPC help text for waitforblockheight

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -274,7 +274,7 @@ UniValue waitforblockheight(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() < 1 || request.params.size() > 2)
         throw runtime_error(
-            "waitforblock\n"
+            "waitforblockheight\n"
             "\nWaits for (at least) block height and returns the height and hash\n"
             "\nof the current tip.\n"
             "\nReturns the current block on timeout or exit.\n"


### PR DESCRIPTION
The RPC help text for `waitforblockheight` incorrectly refers to `waitforblock`. I expect this was a copy-paste error when the RPC was introduced.

This PR fixes the help text to refer to `waitforblockheight`