### PR TITLE
Minor change to comment for consistency.

### DIFF
--- a/src/protocol.h
+++ b/src/protocol.h
@@ -261,7 +261,7 @@ enum ServiceFlags : uint64_t {
     // Bitcoin Core nodes used to support this by default, without advertising this bit,
     // but no longer do as of protocol version 70011 (= NO_BLOOM_VERSION)
     NODE_BLOOM = (1 << 2),
-    // Indicates that a node can be asked for blocks and transactions including
+    // NODE_WITNESS indicates that a node can be asked for blocks and transactions including
     // witness data.
     NODE_WITNESS = (1 << 3),
     // NODE_XTHIN means the node supports Xtreme Thinblocks


### PR DESCRIPTION
Minor change to comment above new NODE_WITNESS service flag to keep it consistent with existing comment structure. Helps with readability.