### PR TITLE
[Doc] Move comments above bash command in build-unix

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -96,13 +96,13 @@ pass `--with-incompatible-bdb` to configure.
 
 See the section "Disable-wallet mode" to build Bitcoin Core without wallet.
 
-Optional:
+Optional (see --with-miniupnpc and --enable-upnp-default):
 
-    sudo apt-get install libminiupnpc-dev (see --with-miniupnpc and --enable-upnp-default)
+    sudo apt-get install libminiupnpc-dev
 
-ZMQ dependencies:
+ZMQ dependencies (provides ZMQ API 4.x):
 
-    sudo apt-get install libzmq3-dev (provides ZMQ API 4.x)
+    sudo apt-get install libzmq3-dev
 
 Dependencies for the GUI: Ubuntu & Debian
 -----------------------------------------


### PR DESCRIPTION
For most it is obvious that you need to remove the comments or add the # in front but  without it,  I get this error:
```bash
dev@linuxdev-vm:~$ sudo apt-get install libzmq3-dev (provides ZMQ API 4.x)
bash: syntax error near unexpected token `('
```