### PR TITLE
doc: Improve windows build instructions using Linux subsystem

### DIFF
--- a/doc/build-windows.md
+++ b/doc/build-windows.md
@@ -7,16 +7,18 @@ Most developers use cross-compilation from Ubuntu to build executables for
 Windows. This is also used to build the release binaries.
 
 While there are potentially a number of ways to build on Windows (for example using msys / mingw-w64),
-using the Windows Subsystem For Linux is the most straight forward.  If you are building with
-an alternative method, please contribute the instructions here for others who are running versions
+using the Windows Subsystem For Linux is the most straightforward. If you are building with
+another method, please contribute the instructions here for others who are running versions
 of Windows that are not compatible with the Windows Subsystem for Linux.
 
-Compiling with the Windows Subsystem For Linux
--------------------
+Compiling with Windows Subsystem For Linux
+-------------------------------------------
 
-With Windows 10, Microsoft has released a new feature named the
-[Windows Subsystem for Linux](https://msdn.microsoft.com/commandline/wsl/about).  This feature allows you to run a bash shell directly on Windows in an Ubuntu based
-environment.  Within this environment you can cross compile for Windows without the need for a separate Linux VM or Server.
+With Windows 10, Microsoft has released a new feature named the [Windows
+Subsystem for Linux](https://msdn.microsoft.com/commandline/wsl/about). This
+feature allows you to run a bash shell directly on Windows in an Ubuntu based
+environment. Within this environment you can cross compile for Windows without
+the need for a separate Linux VM or Server.
 
 This feature is not supported in versions of Windows prior to Windows 10 or on Windows Server SKUs.
 
@@ -37,9 +39,6 @@ To get the bash shell, you must first activate the feature in Windows.
   * Create a new UNIX user account (this is a separate account from your Windows account)
 
 After the bash shell is active, you can follow the instructions below for Windows 64-bit Cross-compilation.
-When building dependencies within the 'depends' folder, you may encounter an error building
-the protobuf dependency.  If this occurs, re-run the command with sudo.  This is likely
-a bug with the Windows Subsystem for Linux feature and may be fixed with a future update.
 
 Cross-compilation
 -------------------
@@ -48,28 +47,55 @@ These steps can be performed on, for example, an Ubuntu VM. The depends system
 will also work on other Linux distributions, however the commands for
 installing the toolchain will be different.
 
-Make sure you install the build requirements mentioned in
-[build-unix.md](/doc/build-unix.md).
-Then, install the toolchains and curl:
+First, install the general dependencies:
 
-    sudo apt-get install g++-mingw-w64-i686 mingw-w64-i686-dev g++-mingw-w64-x86-64 mingw-w64-x86-64-dev curl
+    sudo apt-get install build-essential libtool autotools-dev automake pkg-config bsdmainutils curl
 
-To build executables for Windows 32-bit:
+A host toolchain (`build-essential`) is necessary because some dependency
+packages (such as `protobuf`) need to build host utilities that are used in the
+build process.
 
-    cd depends
-    make HOST=i686-w64-mingw32 -j4
-    cd ..
-    ./autogen.sh # not required when building from tarball
-    ./configure --prefix=`pwd`/depends/i686-w64-mingw32
-    make
+## Building for 64-bit Windows
 
-To build executables for Windows 64-bit:
+To build executables for Windows 64-bit, install the following dependencies:
+
+    sudo apt-get install g++-mingw-w64-x86-64 mingw-w64-x86-64-dev
+
+Then build using:
 
     cd depends
     make HOST=x86_64-w64-mingw32 -j4
     cd ..
     ./autogen.sh # not required when building from tarball
-    ./configure --prefix=`pwd`/depends/x86_64-w64-mingw32
+    CONFIG_SITE=$PWD/depends/x86_64-w64-mingw32/share/config.site ./configure --prefix=/
     make
 
+## Building for 32-bit Windows
+
+To build executables for Windows 32-bit, install the following dependencies:
+
+    sudo apt-get install g++-mingw-w64-i686 mingw-w64-i686-dev 
+
+Then build using:
+
+    cd depends
+    make HOST=i686-w64-mingw32 -j4
+    cd ..
+    ./autogen.sh # not required when building from tarball
+    CONFIG_SITE=$PWD/depends/i686-w64-mingw32/share/config.site ./configure --prefix=/
+    make
+
+## Depends system
+
 For further documentation on the depends system see [README.md](../depends/README.md) in the depends directory.
+
+Installation
+-------------
+
+After building using the Windows subsystem it can be useful to copy the compiled
+executables to a directory on the windows drive in the same directory structure
+as they appear in the release `.zip` archive. This can be done in the following
+way. This will install to `c:\workspace\bitcoin`, for example:
+
+    make install DESTDIR=/mnt/c/workspace/bitcoin
+


### PR DESCRIPTION
I did a build on a windows 10 laptop and took notes, and tried to improve the document:

- Split out dependencies: general ones, 64-bit, 32-bit. Remove the reference to `build-unix.md`, easy enough to be self-contained.

- Place 64-bit instructions first. 99% will want these.

- Installation instructions: recommend using `/` for prefix, same as we do on gitian builds. This will allow copying the files to a usable (from Windows) place using just `make DESTDIR=...`.

- Remove double spaces / consistent width reformatting.