### PR TITLE
Prevent FD_SETSIZE error building on OpenBSD

### DIFF
--- a/src/compat.h
+++ b/src/compat.h
@@ -34,6 +34,7 @@
 #else
 #include <sys/fcntl.h>
 #include <sys/mman.h>
+#include <sys/select.h>
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <net/if.h>


### PR DESCRIPTION
This fixes the build in cases WIN32 is not defined. At least on OpenBSD this made the build work.