### PR TITLE
Trivial refactor: Remove extern keyword from function declarations

### DIFF
--- a/src/core_io.h
+++ b/src/core_io.h
@@ -15,18 +15,18 @@ class uint256;
 class UniValue;
 
 // core_read.cpp
-extern CScript ParseScript(const std::string& s);
-extern std::string ScriptToAsmStr(const CScript& script, const bool fAttemptSighashDecode = false);
-extern bool DecodeHexTx(CTransaction& tx, const std::string& strHexTx, bool fTryNoWitness = false);
-extern bool DecodeHexBlk(CBlock&, const std::string& strHexBlk);
-extern uint256 ParseHashUV(const UniValue& v, const std::string& strName);
-extern uint256 ParseHashStr(const std::string&, const std::string& strName);
-extern std::vector<unsigned char> ParseHexUV(const UniValue& v, const std::string& strName);
+CScript ParseScript(const std::string& s);
+std::string ScriptToAsmStr(const CScript& script, const bool fAttemptSighashDecode = false);
+bool DecodeHexTx(CTransaction& tx, const std::string& strHexTx, bool fTryNoWitness = false);
+bool DecodeHexBlk(CBlock&, const std::string& strHexBlk);
+uint256 ParseHashUV(const UniValue& v, const std::string& strName);
+uint256 ParseHashStr(const std::string&, const std::string& strName);
+std::vector<unsigned char> ParseHexUV(const UniValue& v, const std::string& strName);
 
 // core_write.cpp
-extern std::string FormatScript(const CScript& script);
-extern std::string EncodeHexTx(const CTransaction& tx);
-extern void ScriptPubKeyToUniv(const CScript& scriptPubKey, UniValue& out, bool fIncludeHex);
-extern void TxToUniv(const CTransaction& tx, const uint256& hashBlock, UniValue& entry);
+std::string FormatScript(const CScript& script);
+std::string EncodeHexTx(const CTransaction& tx);
+void ScriptPubKeyToUniv(const CScript& scriptPubKey, UniValue& out, bool fIncludeHex);
+void TxToUniv(const CTransaction& tx, const uint256& hashBlock, UniValue& entry);
 
 #endif // BITCOIN_CORE_IO_H


### PR DESCRIPTION
Reason: they are extern by default.

Same-binary check passes:
```Bash
$ ../bitcoin-maintainer-tools/build-for-compare.py e56cf67e6b3f2e87bee42aaa5ab709f479c9e6ca 446a8f9c90400518bbd4f52f82520c9a97b3a7b3
[...]
>>> [do_build] Copying object files...
>>> [do_build] Performing basic analysis pass...
>>> [do_build] Use these commands to compare results:
>>> [do_build] $ sha256sum /tmp/compare/*.stripped
>>> [do_build] $ git diff -W --word-diff /tmp/compare/e56cf67e6b3f2e87bee42aaa5ab709f479c9e6ca /tmp/compare/446a8f9c90400518bbd4f52f82520c9a97b3a7b3
$ sha256sum /tmp/compare/*.stripped
a5d4480faae4cdfb482ea70d91a19450b7da3f3134a9e477bfc1cab86c29ca8f  /tmp/compare/bitcoind.446a8f9c90400518bbd4f52f82520c9a97b3a7b3.stripped
a5d4480faae4cdfb482ea70d91a19450b7da3f3134a9e477bfc1cab86c29ca8f  /tmp/compare/bitcoind.e56cf67e6b3f2e87bee42aaa5ab709f479c9e6ca.stripped
$ git diff -W --word-diff /tmp/compare/e56cf67e6b3f2e87bee42aaa5ab709f479c9e6ca /tmp/compare/446a8f9c90400518bbd4f52f82520c9a97b3a7b3
$ 

```
