### PR TITLE
qt: layoutAboutToChange signal is called layoutAboutToBeChanged

### DIFF
--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -1089,8 +1089,3 @@ void RPCConsole::setTabFocus(enum TabTypes tabType)
 {
     ui->tabWidget->setCurrentIndex(tabType);
 }
-
-void RPCConsole::on_toggleNetworkActiveButton_clicked()
-{
-    clientModel->setNetworkActive(!clientModel->getNetworkActive());
-}

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -515,7 +515,7 @@ void RPCConsole::setClientModel(ClientModel *model)
         // peer table signal handling - update peer details when new nodes are added to the model
         connect(model->getPeerTableModel(), SIGNAL(layoutChanged()), this, SLOT(peerLayoutChanged()));
         // peer table signal handling - cache selected node ids
-        connect(model->getPeerTableModel(), SIGNAL(layoutAboutToChange()), this, SLOT(peerLayoutAboutToChange()));
+        connect(model->getPeerTableModel(), SIGNAL(layoutAboutToBeChanged()), this, SLOT(peerLayoutAboutToChange()));
         
         // set up ban table
         ui->banlistWidget->setModel(model->getBanTableModel());
@@ -778,7 +778,6 @@ void RPCConsole::startExecutor()
     connect(this, SIGNAL(stopExecutor()), &thread, SLOT(quit()));
     // - queue executor for deletion (in execution thread)
     connect(&thread, SIGNAL(finished()), executor, SLOT(deleteLater()), Qt::DirectConnection);
-    connect(&thread, SIGNAL(finished()), this, SLOT(test()), Qt::DirectConnection);
 
     // Default implementation of QThread::run() simply spins up an event loop in the thread,
     // which is what we want.

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -62,8 +62,6 @@ protected:
 private Q_SLOTS:
     void on_lineEdit_returnPressed();
     void on_tabWidget_currentChanged(int index);
-    /** toggle network activity */
-    void on_toggleNetworkActiveButton_clicked();
     /** open the debug.log from the current datadir */
     void on_openDebugLogfileButton_clicked();
     /** change the time range of the network traffic graph */


### PR DESCRIPTION
This was misnamed, resulting in a warning message and missing functionality. I'm not sure what the change in behavior will be here, this needs testing.

Also remove connection to non-existing slot "test". This was used for testing if the signal arrived. It is no
longer necessary.

Fixes:

    2016-12-01 10:04:06 GUI: QObject::connect: No such signal PeerTableModel::layoutAboutToChange() in qt/rpcconsole.cpp:518
    2016-12-01 10:04:06 GUI: QObject::connect:  (receiver name: 'RPCConsole')
    2016-12-01 10:04:06 GUI: QObject::connect: No such slot RPCConsole::test() in qt/rpcconsole.cpp:781
    2016-12-01 10:04:06 GUI: QObject::connect:  (receiver name: 'RPCConsole')