### PR TITLE
[qa] Dump debug logs on travis failures.

### DIFF
--- a/qa/rpc-tests/test_framework/test_framework.py
+++ b/qa/rpc-tests/test_framework/test_framework.py
@@ -172,7 +172,16 @@ class BitcoinTestFramework(object):
                 os.rmdir(self.options.root)
         else:
             print("Not cleaning up dir %s" % self.options.tmpdir)
-
+            if os.getenv("PYTHON_DEBUG", ""):
+                # Dump the end of the debug logs, to aid in debugging rare
+                # travis failures.
+                import glob
+                filenames = glob.glob(self.options.tmpdir + "/node*/regtest/debug.log")
+                MAX_LINES_TO_PRINT = 1000
+                for f in filenames:
+                    print("From" , f, ":")
+                    from collections import deque
+                    print("".join(deque(open(f), MAX_LINES_TO_PRINT)))
         if success:
             print("Tests successful")
             sys.exit(0)


### PR DESCRIPTION
This should make it easier to debug rare test failures that only ever pop up on travis (eg #8096).

For an example of how this looks when a test does fail, see here: https://travis-ci.org/sdaftuar/bitcoin/jobs/180412877