### PR TITLE
release notes: Explicitly mention the removal of free transactions, and do not commit to removal of priority in any given release

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -61,11 +61,13 @@ Removal of Priority Estimation
   converted to the new format which is not readable by prior versions of the
   software.
 
-- The concept of "priority" (coin age) transactions is planned to be removed in
-  the next major version. To prepare for this, the default for the rate limit of
-  priority transactions (`-limitfreerelay`) has been set to `0` kB/minute. This
-  is not to be confused with the `prioritisetransaction` RPC which will remain
-  supported for adding fee deltas to transactions.
+- Free transactions has long since ceased to function, and as such, the default
+  for the rate limit for them (`-limitfreerelay`) has been set to `0` kB/minute.
+
+- Support for "priority" (coin age) transaction sorting for mining is
+  considered deprecated in Core and may be removed in a future major version.
+  This is not to be confused with the `prioritisetransaction` RPC which will
+  remain supported for adding fee deltas to transactions.
 
 P2P connection management
 --------------------------


### PR DESCRIPTION
Priority sorting when creating block templates for mining is still in use and recommended.
