### PR TITLE
bitcoin-cli: Make error message less confusing

### DIFF
--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -247,7 +247,7 @@ UniValue CallRPC(const std::string& strMethod, const UniValue& params)
     event_base_free(base);
 
     if (response.status == 0)
-        throw CConnectionFailed(strprintf("couldn't connect to server\n(make sure server is running and you are connecting to the correct RPC port: %d %s)", response.error, http_errorstring(response.error)));
+        throw CConnectionFailed(strprintf("couldn't connect to server: %s (code %d)\n(make sure server is running and you are connecting to the correct RPC port)", http_errorstring(response.error), response.error));
     else if (response.status == HTTP_UNAUTHORIZED)
         throw std::runtime_error("incorrect rpcuser or rpcpassword (authorization failed)");
     else if (response.status >= 400 && response.status != HTTP_BAD_REQUEST && response.status != HTTP_NOT_FOUND && response.status != HTTP_INTERNAL_SERVER_ERROR)


### PR DESCRIPTION
Sorry for the churn on this, but the current message (introduced in #9073) isn't acceptable:

    $ src/bitcoin-cli getinfo
    rpc: couldn't connect to server
    (make sure server is running and you are connecting to the correct RPC port: -1 unknown)

Putting the error code after the words "RPC port" made me wonder whether there was a port configuration issue.

This changes it to:

    $ src/bitcoin-cli getinfo
    error: couldn't connect to server: unknown (code -1)
    (make sure server is running and you are connecting to the correct RPC port)