### PR TITLE
Fix rounding privacy leak introduced in #9260

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2995,7 +2995,8 @@ bool SendMessages(CNode* pto, CConnman& connman)
             CAmount currentFilter = mempool.GetMinFee(GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000).GetFeePerK();
             int64_t timeNow = GetTimeMicros();
             if (timeNow > pto->nextSendTimeFeeFilter) {
-                static FeeFilterRounder filterRounder(::minRelayTxFee);
+                static CFeeRate default_feerate(DEFAULT_MIN_RELAY_TX_FEE);
+                static FeeFilterRounder filterRounder(default_feerate);
                 CAmount filterToSend = filterRounder.round(currentFilter);
                 if (filterToSend != pto->lastSentFeeFilter) {
                     connman.PushMessage(pto, msgMaker.Make(NetMsgType::FEEFILTER, filterToSend));


### PR DESCRIPTION
#9260 accidentally changed behavior of the fee filter rounder - from DEFAULT_MIN_RELAY_TX_FEE to -minrelaytxfee. While technically a violation of our dont-hardcode-values policy, its probably better to use the default here to preserve privacy (which was the original purpose of the rounder, AFAIU).