### PR TITLE
Align struct COrphan definition

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -50,6 +50,7 @@ struct IteratorComparator
 };
 
 struct COrphanTx {
+    // When modifying, adapt the copy of this definition in tests/DoS_tests.
     CTransaction tx;
     NodeId fromPeer;
     int64_t nTimeExpire;

--- a/src/test/DoS_tests.cpp
+++ b/src/test/DoS_tests.cpp
@@ -29,6 +29,7 @@ extern unsigned int LimitOrphanTxSize(unsigned int nMaxOrphans);
 struct COrphanTx {
     CTransaction tx;
     NodeId fromPeer;
+    int64_t nTimeExpire;
 };
 extern std::map<uint256, COrphanTx> mapOrphanTransactions;
 extern std::map<uint256, std::set<uint256> > mapOrphanTransactionsByPrev;


### PR DESCRIPTION
Since #8179 the `struct COrphan` definition gained an extra field. The mirrored definition in DoS_tests was not updated, however. This violates the C++ one definition rule.

Found using GCC 6.2.0, when compiling with `-flto`:
```
test/DoS_tests.cpp:29:8: warning: type 'struct COrphanTx' violates the C++ One Definition Rule [-Wodr]
 struct COrphanTx {
        ^
net_processing.cpp:52:8: note: a different type is defined in another translation unit
 struct COrphanTx {
        ^
net_processing.cpp:55:13: note: the first difference of corresponding definitions is field 'nTimeExpire'
     int64_t nTimeExpire;
             ^
net_processing.cpp:52:8: note: a type with different number of fields is defined in another translation unit
 struct COrphanTx {
        ^
test/DoS_tests.cpp:29:8: note: type 'struct COrphanTx' itself violate the C++ One Definition Rule
 struct COrphanTx {
        ^
net_processing.cpp:52:8: note: the incompatible type is defined here
 struct COrphanTx {
        ^
```