### PR TITLE
CMutableTransaction is defined as struct

### DIFF
--- a/src/core_io.h
+++ b/src/core_io.h
@@ -11,7 +11,7 @@
 class CBlock;
 class CScript;
 class CTransaction;
-class CMutableTransaction;
+struct CMutableTransaction;
 class uint256;
 class UniValue;
 


### PR DESCRIPTION
This removes few warnings coming from #8580:

```
In file included from test/script_P2SH_tests.cpp:7:
In file included from ./keystore.h:12:
In file included from ./script/standard.h:9:
In file included from ./script/interpreter.h:10:
./primitives/transaction.h:270:1: warning: struct 'CMutableTransaction' was previously declared as a class [-Wmismatched-tags]
struct CMutableTransaction;
^
./core_io.h:14:7: note: previous use is here
class CMutableTransaction;
      ^
In file included from test/script_P2SH_tests.cpp:7:
In file included from ./keystore.h:12:
In file included from ./script/standard.h:9:
In file included from ./script/interpreter.h:10:
./primitives/transaction.h:457:1: warning: 'CMutableTransaction' defined as a struct here but previously declared as a class [-Wmismatched-tags]
struct CMutableTransaction
^
./core_io.h:14:1: note: did you mean struct here?
class CMutableTransaction;
^~~~~
struct
2 warnings generated.
```

Definition is here https://github.com/bitcoin/bitcoin/blob/master/src/primitives/transaction.h#L457