### PR TITLE
Time-based expiration in LimitOrphanTxSize only when map is full.

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -656,7 +656,7 @@ unsigned int LimitOrphanTxSize(unsigned int nMaxOrphans) EXCLUSIVE_LOCKS_REQUIRE
     unsigned int nEvicted = 0;
     static int64_t nNextSweep;
     int64_t nNow = GetTime();
-    if (nNextSweep <= nNow) {
+    if (mapOrphanTransactions.size() > nMaxOrphans && nNextSweep <= nNow) {
         // Sweep out expired orphan pool entries:
         int nErased = 0;
         int64_t nMinExpTime = nNow + ORPHAN_TX_EXPIRE_TIME - ORPHAN_TX_EXPIRE_INTERVAL;


### PR DESCRIPTION
While testing using BIP152 using the orphan map I observed a
round trip that occurred only because the relevant orphan was
time based expired first.

The purpose of the time based expiration is simply because the
random eviction has particularly bad effects on chains of txn
(it tends to poke holes in the chains, resulting in the pool
filling with things that are unconnectable).  As such, We don't
really need the time based until just before the random eviction
would take place.