### PR TITLE
Make RelayWalletTransaction attempt to AcceptToMemoryPool.

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1542,9 +1542,11 @@ void CWallet::ReacceptWalletTransactions()
 bool CWalletTx::RelayWalletTransaction(CConnman* connman)
 {
     assert(pwallet->GetBroadcastTransactions());
-    if (!IsCoinBase())
+    if (!IsCoinBase() && !isAbandoned() && GetDepthInMainChain() == 0)
     {
-        if (GetDepthInMainChain() == 0 && !isAbandoned() && InMempool()) {
+        CValidationState state;
+        /* GetDepthInMainChain already catches known conflicts. */
+        if (InMempool() || AcceptToMemoryPool(maxTxFee, state)) {
             LogPrintf("Relaying wtx %s\n", GetHash().ToString());
             if (connman) {
                 CInv inv(MSG_TX, GetHash());


### PR DESCRIPTION
This resolves an issue where a wallet transaction which failed to
 relay previously because it couldn't make it into the mempool
 will not try again until restart, even though mempool conditions
 may have changed. Rebroadcast of other transactions is unchanged and works as it always did.

Abandoned and known-conflicted transactions are skipped.

Some concern was expressed that there may be users with many
 unknown conflicts would waste a lot of CPU time trying to
 add them to their memory pools over and over again.  But I am
 doubtful these users exist in any number, if they do exist
 they have worse problems, and they can mitigate any performance
 issue this might have by abandoning the transactions in question.