### PR TITLE
Remove mapOrphanTransactionsByPrev from DoS_tests

### DIFF
--- a/src/test/DoS_tests.cpp
+++ b/src/test/DoS_tests.cpp
@@ -32,7 +32,6 @@ struct COrphanTx {
     int64_t nTimeExpire;
 };
 extern std::map<uint256, COrphanTx> mapOrphanTransactions;
-extern std::map<uint256, std::set<uint256> > mapOrphanTransactionsByPrev;
 
 CService ip(uint32_t i)
 {
@@ -203,7 +202,6 @@ BOOST_AUTO_TEST_CASE(DoS_mapOrphans)
     BOOST_CHECK(mapOrphanTransactions.size() <= 10);
     LimitOrphanTxSize(0);
     BOOST_CHECK(mapOrphanTransactions.empty());
-    BOOST_CHECK(mapOrphanTransactionsByPrev.empty());
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This is another violation of the one definition rule (like #9269), as the type for `mapOrphanTransactionsByPrev` did not match the one in net_processing.cpp anymore. As it now depends on a custom comparator (`IteratorComparator`, defined in net_processing.cpp as well), it seems too much hassle to correctly expose it to the tests. Instead, this PR just removes the one test it was referenced in.