### PR TITLE
[Wallet] use CHDPubKey, don't store child priv keys in db, derive on the fly

### DIFF
--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -83,6 +83,7 @@ enum WalletFeature
     FEATURE_COMPRPUBKEY = 60000, // compressed public keys
 
     FEATURE_HD = 130000, // Hierarchical key derivation after BIP32 (HD Wallet)
+    FEATURE_WITH_HD_PUBKEY = 139900, // on-the-fly private key derivation
     FEATURE_LATEST = FEATURE_COMPRPUBKEY // HD is optional, use FEATURE_COMPRPUBKEY as latest version
 };
 
@@ -665,14 +666,11 @@ public:
 
     int64_t nOrderPosNext;
     std::map<uint256, int> mapRequestCount;
-
     std::map<CTxDestination, CAddressBookData> mapAddressBook;
-
     CPubKey vchDefaultKey;
-
     std::set<COutPoint> setLockedCoins;
-
     int64_t nTimeFirstKey;
+    std::map<CKeyID, CHDPubKey> mapHdPubKeys; //<! memory map of HD extended pubkeys
 
     const CWalletTx* GetWalletTx(const uint256& hash) const;
 
@@ -706,6 +704,16 @@ public:
      */
     CPubKey GenerateNewKey();
     void DeriveNewChildKey(CKeyMetadata& metadata, CKey& secret);
+    //! HaveKey implementation that also checks the mapHdPubKeys
+    bool HaveKey(const CKeyID &address) const;
+    //! GetPubKey implementation that also checks the mapHdPubKeys
+    bool GetPubKey(const CKeyID &address, CPubKey& vchPubKeyOut) const;
+    //! GetKey implementation that can derive a HD private key on the fly
+    bool GetKey(const CKeyID &address, CKey& keyOut) const;
+    //! Adds a HDPubKey into the wallet(database)
+    bool AddHDPubKey(const CExtPubKey &extPubKey);
+    //! loads a HDPubKey into the wallets memory
+    bool LoadHDPubKey(const CHDPubKey &hdPubKey);
     //! Adds a key to the store, and saves it to disk.
     bool AddKeyPubKey(const CKey& key, const CPubKey &pubkey);
     //! Adds a key to the store, without saving it to disk (used by LoadWallet)

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -69,6 +69,27 @@ public:
     }
 };
 
+/* hd pubkey data model */
+class CHDPubKey
+{
+public:
+    static const int CURRENT_VERSION = 1;
+    int nVersion;
+    CExtPubKey extPubKey;
+    CKeyID masterKeyID;
+
+    CHDPubKey() { nVersion = CHDPubKey::CURRENT_VERSION; }
+
+    ADD_SERIALIZE_METHODS;
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action)
+    {
+        READWRITE(this->nVersion);
+        READWRITE(extPubKey);
+        READWRITE(masterKeyID);
+    }
+};
+
 class CKeyMetadata
 {
 public:
@@ -175,6 +196,8 @@ public:
 
     //! write the hdchain model (external chain child index counter)
     bool WriteHDChain(const CHDChain& chain);
+
+    bool WriteHDPubKey(const CHDPubKey& hdPubKey, const CKeyMetadata& keyMeta);
 
 private:
     CWalletDB(const CWalletDB&);


### PR DESCRIPTION
Adds a new database record (`"hdpubkey"`) reflected by class `CHDPubKey`.
* Results in no longer storing derived child private keys in the database
* Only the extended child public key will be stored
* If the private key gets requested, it will be derived on the fly

Dump functions are unchanged, will result in deriving the keys on the fly.
Not backward compatible. Ideally combined with HD chain split #9294.