### PR TITLE
Check for oversized getblocktxn message.

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1519,6 +1519,12 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         CBlock block;
         assert(ReadBlockFromDisk(block, it->second, chainparams.GetConsensus()));
 
+        if (req.indexes.size() >= block.vtx.size()) {
+            LogPrintf("recv getblocktxn. too many requests (%d >= %d) peer=%d\n", req.indexes.size(), block.vtx.size(), pfrom->id);
+            Misbehaving(pfrom->id, 100);
+            return true;
+        }
+
         BlockTransactions resp(req);
         for (size_t i = 0; i < req.indexes.size(); i++) {
             if (req.indexes[i] >= block.vtx.size()) {


### PR DESCRIPTION
Currently there is a check that each individual index is not out of bounds but there was no check that the number of indexes is not greater than the number possible. Given that data-wise the response is greater than the request, this closes off a potential attack vector.