### PR TITLE
Flush wallet after abandontransaction

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1009,8 +1009,7 @@ bool CWallet::AbandonTransaction(const uint256& hashTx)
 {
     LOCK2(cs_main, cs_wallet);
 
-    // Do not flush the wallet here for performance reasons
-    CWalletDB walletdb(strWalletFile, "r+", false);
+    CWalletDB walletdb(strWalletFile, "r+");
 
     std::set<uint256> todo;
     std::set<uint256> done;


### PR DESCRIPTION
This isn't a critical change, but abandoned state actually could be lost if the node crashed before a wallet flush, and so it makes more sense for this manual action to be flushed when finished.

(Originally the code was copied from MarkConflicted which is information that would be recreated on startup and is also called inside a loop hence the performance comment)

