### PR TITLE
Increase mempool expiry time to 2 weeks

### DIFF
--- a/src/validation.h
+++ b/src/validation.h
@@ -73,7 +73,7 @@ static const unsigned int DEFAULT_DESCENDANT_LIMIT = 25;
 /** Default for -limitdescendantsize, maximum kilobytes of in-mempool descendants */
 static const unsigned int DEFAULT_DESCENDANT_SIZE_LIMIT = 101;
 /** Default for -mempoolexpiry, expiration time for mempool transactions in hours */
-static const unsigned int DEFAULT_MEMPOOL_EXPIRY = 72;
+static const unsigned int DEFAULT_MEMPOOL_EXPIRY = 336;
 /** The maximum size of a blk?????.dat file (since 0.8) */
 static const unsigned int MAX_BLOCKFILE_SIZE = 0x8000000; // 128 MiB
 /** The pre-allocation chunk size for blk?????.dat files (since 0.8) */


### PR DESCRIPTION
As discussed in the weekly dev meeting, I think it makes sense to increase the mempool expiry time. 
https://botbot.me/freenode/bitcoin-core-dev/2016-12-08/?msg=77683289&page=4

I propose 2 weeks.

3 days (the old time) was already not sufficiently short to protect against an attack that could fill the mempool with high fee rate txs that were somehow not attractive or possible to mine.  A longer expiry time will reduce network traffic by less rerelay of low fee txs and will allow transactions to take advantage of weekly cycles in tx volume.   By keeping the txs in the mempool, future revisions of fee estimation will be able to provide lower estimates for transactions which are low priority and can wait days or a week to be included in a block.

I've been running nodes with this code for many months.

