### PR TITLE
If we don't allow free txs, always send a fee filter

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2993,6 +2993,9 @@ bool SendMessages(CNode* pto, CConnman& connman)
         if (pto->nVersion >= FEEFILTER_VERSION && GetBoolArg("-feefilter", DEFAULT_FEEFILTER) &&
             !(pto->fWhitelisted && GetBoolArg("-whitelistforcerelay", DEFAULT_WHITELISTFORCERELAY))) {
             CAmount currentFilter = mempool.GetMinFee(GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000).GetFeePerK();
+            // If we don't allow free transactions, then we always have a fee filter of at least minRelayTxFee
+            if (GetArg("-limitfreerelay", DEFAULT_LIMITFREERELAY) <= 0)
+                currentFilter = std::max(currentFilter, ::minRelayTxFee.GetFeePerK());
             int64_t timeNow = GetTimeMicros();
             if (timeNow > pto->nextSendTimeFeeFilter) {
                 static CFeeRate default_feerate(DEFAULT_MIN_RELAY_TX_FEE);


### PR DESCRIPTION
Normally feefilter messages are sent only based on the mempool min fee which only gets set once your mempool is limited.  But if you are not allowing free relay, you'll always require at least minRelayTxFee anyway, so this PR sends feefilter messages taking that into account.