### PR TITLE
[wallet] Disable free transactions when relay is disabled

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3642,6 +3642,9 @@ bool CWallet::ParameterInteraction()
     fSendFreeTransactions = GetBoolArg("-sendfreetransactions", DEFAULT_SEND_FREE_TRANSACTIONS);
     fWalletRbf = GetBoolArg("-walletrbf", DEFAULT_WALLET_RBF);
 
+    if (fSendFreeTransactions && GetArg("-limitfreerelay", DEFAULT_LIMITFREERELAY) <= 0)
+        return InitError("Creation of free transactions with their relay disabled is not supported.");
+
     return true;
 }
 


### PR DESCRIPTION
Creation of free transactions with their relay disabled was never supported, but with the relay disabled by default an InitError could make sense.

The (probably cleaner) alternative in light of the removal planned for 0.15 would be to just get rid of `fSendFreeTransactions` already now... No strong opinion for one or the other.