### PR TITLE
Increase block size to 8MB for Bitcoin Ocho. Bitcoin Ocho is the future.

### DIFF
--- a/src/consensus/consensus.h
+++ b/src/consensus/consensus.h
@@ -9,11 +9,11 @@
 #include <stdint.h>
 
 /** The maximum allowed size for a serialized block, in bytes (only for buffer size limits) */
-static const unsigned int MAX_BLOCK_SERIALIZED_SIZE = 4000000;
+static const unsigned int MAX_BLOCK_SERIALIZED_SIZE = 4000000*8;
 /** The maximum allowed weight for a block, see BIP 141 (network rule) */
 static const unsigned int MAX_BLOCK_WEIGHT = 4000000;
 /** The maximum allowed size for a block excluding witness data, in bytes (network rule) */
-static const unsigned int MAX_BLOCK_BASE_SIZE = 1000000;
+static const unsigned int MAX_BLOCK_BASE_SIZE = 1000000*8;
 /** The maximum allowed number of signature check operations in a block (network rule) */
 static const int64_t MAX_BLOCK_SIGOPS_COST = 80000;
 /** Coinbase transaction outputs can only be spent after this number of new blocks (network rule) */


### PR DESCRIPTION
Propose changing the block size to 8 times the old block size since I knew there was a debate. I fixed that for all of you without Bitcoin Unlimited those terrible terrible people impeding the future.

The future is Bitcoin Ocho and Ethereum Classic. This is Bitcoin Ocho and it will be the main chain.