### PR TITLE
[Qt] Console: add security warning

### DIFF
--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -650,13 +650,18 @@ void RPCConsole::clear(bool clearHistory)
                 "td.message { font-family: %1; font-size: %2; white-space:pre-wrap; } "
                 "td.cmd-request { color: #006060; } "
                 "td.cmd-error { color: red; } "
+                ".secwarning { color: red; }"
                 "b { color: #006060; } "
             ).arg(fixedFontInfo.family(), QString("%1pt").arg(consoleFontSize))
         );
 
     message(CMD_REPLY, (tr("Welcome to the %1 RPC console.").arg(tr(PACKAGE_NAME)) + "<br>" +
                         tr("Use up and down arrows to navigate history, and <b>Ctrl-L</b> to clear screen.") + "<br>" +
-                        tr("Type <b>help</b> for an overview of available commands.")), true);
+                        tr("Type <b>help</b> for an overview of available commands.")) +
+                        "<br><span class=\"secwarning\">" +
+                        tr("WARNING: Scammers have been active, telling users to type commands here, stealing their wallet contents. Do not use this console without fully understanding the ramification of a command.") +
+                        "</span>",
+                        true);
 }
 
 void RPCConsole::keyPressEvent(QKeyEvent *event)


### PR DESCRIPTION
Adds a general warning to the Qt (Debug) Console regardless if the wallet is encrypted or not.
The scope of this PR is also not to warn or disable certain private-key revealing commands (can be done in a separate PR).

Inspired by @laanwj's comment in...
https://github.com/bitcoin/bitcoin/issues/8544#issuecomment-240970925


<img width="852" alt="bildschirmfoto 2016-12-12 um 16 00 55" src="https://cloud.githubusercontent.com/assets/178464/21103802/36e36d00-c084-11e6-8d83-0407e9be8de1.png">
