### PR TITLE
[wip] Stripe downloads to reduce stallers occuring

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2090,13 +2090,13 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                 }
                 uint32_t nFetchFlags = GetFetchFlags(pfrom, pindex->pprev, chainparams.GetConsensus());
                 vGetData.push_back(CInv(MSG_BLOCK | nFetchFlags, pindex->GetBlockHash()));
-                MarkBlockAsInFlight(pfrom->GetId(), pindex->GetBlockHash(), chainparams.GetConsensus(), pindex);
-                LogPrint("net", "Requesting block %s from  peer=%d\n",
-                        pindex->GetBlockHash().ToString(), pfrom->id);
+                if (vToFetch.size() == 1)
+                    MarkBlockAsInFlight(pfrom->GetId(), pindex->GetBlockHash(), chainparams.GetConsensus(), pindex);
             }
             if (vGetData.size() > 1) {
-                LogPrint("net", "Downloading blocks toward %s (%d) via headers direct fetch\n",
+                LogPrint("net", "NOT Downloading %d blocks toward %s (%d) via headers direct fetch\n", vGetData.size(),
                         pindexLast->GetBlockHash().ToString(), pindexLast->nHeight);
+                return true;
             }
             if (vGetData.size() > 0) {
                 if (nodestate->fSupportsDesiredCmpctVersion && vGetData.size() == 1 && mapBlocksInFlight.size() == 1 && pindexLast->pprev->IsValid(BLOCK_VALID_CHAIN)) {


### PR DESCRIPTION
Mitigates #9213

This may also help reduce the unresponsiveness of peers during IBD as often they encounter a big chunk of contiguous blocks that need to be added to the chain due to the current contiguous way they are downloaded.