### PR TITLE
Don't create change at dust limit

### DIFF
--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -524,13 +524,10 @@ void CoinControlDialog::updateLabels(WalletModel *model, QDialog* dialog)
                 CTxOut txout(nChange, (CScript)std::vector<unsigned char>(24, 0));
                 if (IsDust(txout, ::dustRelayFee))
                 {
-                    if (CoinControlDialog::fSubtractFeeFromAmount) // dust-change will be raised until no dust
-                        nChange = GetDustThreshold(txout, ::dustRelayFee);
-                    else
-                    {
-                        nPayFee += nChange;
-                        nChange = 0;
-                    }
+                    nPayFee += nChange;
+                    nChange = 0;
+                    if (CoinControlDialog::fSubtractFeeFromAmount)
+                        nBytes -= 34; // we didn't detect lack of change above
                 }
             }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2633,28 +2633,6 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
 
                     CTxOut newTxOut(nChange, scriptChange);
 
-                    // We do not move dust-change to fees, because the sender would end up paying more than requested.
-                    // This would be against the purpose of the all-inclusive feature.
-                    // So instead we raise the change and deduct from the recipient.
-                    if (nSubtractFeeFromAmount > 0 && IsDust(newTxOut, ::dustRelayFee))
-                    {
-                        CAmount nDust = GetDustThreshold(newTxOut, ::dustRelayFee) - newTxOut.nValue;
-                        newTxOut.nValue += nDust; // raise change until no more dust
-                        for (unsigned int i = 0; i < vecSend.size(); i++) // subtract from first recipient
-                        {
-                            if (vecSend[i].fSubtractFeeFromAmount)
-                            {
-                                txNew.vout[i].nValue -= nDust;
-                                if (IsDust(txNew.vout[i], ::dustRelayFee))
-                                {
-                                    strFailReason = _("The transaction amount is too small to send after the fee has been deducted");
-                                    return false;
-                                }
-                                break;
-                            }
-                        }
-                    }
-
                     // Never create dust outputs; if we would, just
                     // add the dust to the fee.
                     if (IsDust(newTxOut, ::dustRelayFee))


### PR DESCRIPTION
@cozz 
@gmaxwell 
@laanwj 

This might be controversial since it directly reverts behavior that was explicitly included in #4331 (merged as #5831)

That PR took the approach that if subtractFeeFromAmount was selected then it would be unexpected for the user to ever spend (net of sent - received) more bitcoins than the amount they requested to pay.  Therefore if any change was under the dust limit, instead of sending it to fee, the change was increased to the dust limit.  

I believe this is misguided.  Creating a change output at the dust limit is likely uneconomical.  There is a difference between having to draw a threshold below which all outputs are useless, and inverting that to say that an output just above that limit is useful.  Giving yourself change at the dust limit is no better (and maybe even worse) than not giving yourself change in the first place, so I don't believe it will adversely affect anyone who was not expecting to spend more coins than the pay amount.

The primary reason for this change is to make our wallet smarter about not creating uselessly small outputs.  To increase the change to the point where it was sufficiently big to be useful would require potentially removing too much from the recipients.


