### PR TITLE
Make CScript (and prevector) c++11 movable.

### DIFF
--- a/src/prevector.h
+++ b/src/prevector.h
@@ -248,6 +248,10 @@ public:
         }
     }
 
+    prevector(prevector<N, T, Size, Diff>&& other) : _size(0) {
+        swap(other);
+    }
+
     prevector& operator=(const prevector<N, T, Size, Diff>& other) {
         if (&other == this) {
             return *this;
@@ -260,6 +264,11 @@ public:
             new(static_cast<void*>(item_ptr(size() - 1))) T(*it);
             ++it;
         }
+        return *this;
+    }
+
+    prevector& operator=(prevector<N, T, Size, Diff>&& other) {
+        swap(other);
         return *this;
     }
 

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -394,7 +394,6 @@ protected:
     }
 public:
     CScript() { }
-    CScript(const CScript& b) : CScriptBase(b.begin(), b.end()) { }
     CScript(const_iterator pbegin, const_iterator pend) : CScriptBase(pbegin, pend) { }
     CScript(std::vector<unsigned char>::const_iterator pbegin, std::vector<unsigned char>::const_iterator pend) : CScriptBase(pbegin, pend) { }
     CScript(const unsigned char* pbegin, const unsigned char* pend) : CScriptBase(pbegin, pend) { }

--- a/src/test/prevector_tests.cpp
+++ b/src/test/prevector_tests.cpp
@@ -169,6 +169,19 @@ public:
         pre_vector.swap(pre_vector_alt);
         test();
     }
+
+    void move() {
+        real_vector = std::move(real_vector_alt);
+        real_vector_alt.clear();
+        pre_vector = std::move(pre_vector_alt);
+        pre_vector_alt.clear();
+    }
+
+    void copy() {
+        real_vector = real_vector_alt;
+        pre_vector = pre_vector_alt;
+    }
+
     ~prevector_tester() {
         BOOST_CHECK_MESSAGE(passed, "insecure_rand_Rz: "
                 << rand_cache.Rz
@@ -240,8 +253,14 @@ BOOST_AUTO_TEST_CASE(PrevectorTestInt)
             if (((r >> 21) % 512) == 12) {
                 test.assign(insecure_rand() % 32, insecure_rand());
             }
-            if (((r >> 15) % 64) == 3) {
+            if (((r >> 15) % 8) == 3) {
                 test.swap();
+            }
+            if (((r >> 15) % 16) == 8) {
+                test.copy();
+            }
+            if (((r >> 15) % 32) == 18) {
+                test.move();
             }
         }
     }


### PR DESCRIPTION
Such moves are used when reallocating vectors that contain them, and could be used for more things later.

This change avoids an extra allocation when the data is not inlined.