### PR TITLE
Remove CWalletTx::fFromMe member.

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -505,7 +505,6 @@ void CWallet::SyncMetaData(pair<TxSpends::iterator, TxSpends::iterator> range)
         // fTimeReceivedIsTxTime not copied on purpose
         // nTimeReceived not copied on purpose
         copyTo->nTimeSmart = copyFrom->nTimeSmart;
-        copyTo->fFromMe = copyFrom->fFromMe;
         copyTo->strFromAccount = copyFrom->strFromAccount;
         // nOrderPos not copied on purpose
         // cached members not copied on purpose
@@ -910,11 +909,6 @@ bool CWallet::AddToWallet(const CWalletTx& wtxIn, bool fFlushOnClose)
         if (wtxIn.nIndex != -1 && (wtxIn.nIndex != wtx.nIndex))
         {
             wtx.nIndex = wtxIn.nIndex;
-            fUpdated = true;
-        }
-        if (wtxIn.fFromMe && wtxIn.fFromMe != wtx.fFromMe)
-        {
-            wtx.fFromMe = wtxIn.fFromMe;
             fUpdated = true;
         }
     }
@@ -2304,7 +2298,6 @@ bool CWallet::CreateTransaction(const vector<CRecipient>& vecSend, CWalletTx& wt
                 txNew.vin.clear();
                 txNew.vout.clear();
                 txNew.wit.SetNull();
-                wtxNew.fFromMe = true;
                 bool fFirst = true;
 
                 CAmount nValueToSelect = nValue;
@@ -3533,7 +3526,6 @@ bool CWallet::InitLoadWallet()
                     copyTo->vOrderForm = copyFrom->vOrderForm;
                     copyTo->nTimeReceived = copyFrom->nTimeReceived;
                     copyTo->nTimeSmart = copyFrom->nTimeSmart;
-                    copyTo->fFromMe = copyFrom->fFromMe;
                     copyTo->strFromAccount = copyFrom->strFromAccount;
                     copyTo->nOrderPos = copyFrom->nOrderPos;
                     walletdb.WriteTx(*copyTo);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -253,6 +253,11 @@ public:
     unsigned int fTimeReceivedIsTxTime;
     unsigned int nTimeReceived; //!< time received by this node
     unsigned int nTimeSmart;
+    /**
+     * From me flag is set to 1 for transactions that were created by the wallet
+     * on this bitcoin node, and set to 0 for transactions that were created
+     * externally and came in through the network or sendrawtransaction RPC.
+     */
     char fFromMe;
     std::string strFromAccount;
     int64_t nOrderPos; //!< position in ordered transaction list

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -253,12 +253,6 @@ public:
     unsigned int fTimeReceivedIsTxTime;
     unsigned int nTimeReceived; //!< time received by this node
     unsigned int nTimeSmart;
-    /**
-     * From me flag is set to 1 for transactions that were created by the wallet
-     * on this bitcoin node, and set to 0 for transactions that were created
-     * externally and came in through the network or sendrawtransaction RPC.
-     */
-    char fFromMe;
     std::string strFromAccount;
     int64_t nOrderPos; //!< position in ordered transaction list
 
@@ -300,7 +294,6 @@ public:
         fTimeReceivedIsTxTime = false;
         nTimeReceived = 0;
         nTimeSmart = 0;
-        fFromMe = false;
         strFromAccount.clear();
         fDebitCached = false;
         fCreditCached = false;
@@ -348,7 +341,8 @@ public:
         READWRITE(vOrderForm);
         READWRITE(fTimeReceivedIsTxTime);
         READWRITE(nTimeReceived);
-        READWRITE(fFromMe);
+        char fUnused = 0; // Used to be fFromMe;
+        READWRITE(fUnused);
         READWRITE(fSpent);
 
         if (ser_action.ForRead())


### PR DESCRIPTION
Prior to this commit, the fFromMe member was written to and serialized but not
actually used in any meaningful way.

The one place where the fFromMe was used in a nontrivial way was
CWallet::AddToWallet, but the only actual effect it had there was to trigger
additional CWalletDB::WriteTx calls that would change serialized fFromMe fields
in previously existing database rows from false to true (without changing other
fields).