### PR TITLE
Make fuzzer actually test CTxOutCompressor

### DIFF
--- a/src/test/test_bitcoin_fuzzy.cpp
+++ b/src/test/test_bitcoin_fuzzy.cpp
@@ -240,12 +240,12 @@ int main(int argc, char **argv)
         case CTXOUTCOMPRESSOR_DESERIALIZE:
         {
             CTxOut to;
+            CTxOutCompressor toc(to);
             try
             {
-                ds >> to;
+                ds >> toc;
             } catch (const std::ios_base::failure& e) {return 0;}
 
-            CTxOutCompressor toc(to);
             break;
         }
         default:


### PR DESCRIPTION
Fixes a small oversight in #9172.