### PR TITLE
Reduce fingerprinting attacks

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1500,7 +1500,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
             return true;
         }
 
-        if (it->second->nHeight < chainActive.Height() - MAX_BLOCKTXN_DEPTH) {
+        if (it->second->nChainWork < chainActive.Tip()->nChainWork - (GetBlockProof(*chainActive.Tip()) * MAX_BLOCKTXN_DEPTH)) {
             // If an older block is requested (should never happen in practice,
             // but can happen in tests) send a block response instead of a
             // blocktxn response. Sending a full block response instead of a

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1500,7 +1500,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
             return true;
         }
 
-        if (it->second->nChainWork < chainActive.Tip()->nChainWork - (GetBlockProof(*chainActive.Tip()) * MAX_BLOCKTXN_DEPTH)) {
+        if (it->second->nChainWork < chainActive[std::max(0, chainActive.Height() - MAX_BLOCKTXN_DEPTH)]->nChainWork) {
             // If an older block is requested (should never happen in practice,
             // but can happen in tests) send a block response instead of a
             // blocktxn response. Sending a full block response instead of a


### PR DESCRIPTION
Unlikely to have happened but it is possible a fork with lower difficulty reaches a height comparable to our ActiveChain's height and that one (or more) of these blocks were spoon-fed to our node (as our node would not request them due to insufficient nChainWork). In this case, we could be fingerprinted. Closing this unlikely yet possible attack vector.

Another way to close this vector is to not accept blocks received that are are unrequested and have less nChainWork than our ActiveChain's Tip.