### PR TITLE
If we don't allow free txs, always send a fee filter (take 2)

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2995,14 +2995,14 @@ bool SendMessages(CNode* pto, CConnman& connman)
         if (pto->nVersion >= FEEFILTER_VERSION && GetBoolArg("-feefilter", DEFAULT_FEEFILTER) &&
             !(pto->fWhitelisted && GetBoolArg("-whitelistforcerelay", DEFAULT_WHITELISTFORCERELAY))) {
             CAmount currentFilter = mempool.GetMinFee(GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000).GetFeePerK();
-            // If we don't allow free transactions, then we always have a fee filter of at least minRelayTxFee
-            if (GetArg("-limitfreerelay", DEFAULT_LIMITFREERELAY) <= 0)
-                currentFilter = std::max(currentFilter, ::minRelayTxFee.GetFeePerK());
             int64_t timeNow = GetTimeMicros();
             if (timeNow > pto->nextSendTimeFeeFilter) {
                 static CFeeRate default_feerate(DEFAULT_MIN_RELAY_TX_FEE);
                 static FeeFilterRounder filterRounder(default_feerate);
                 CAmount filterToSend = filterRounder.round(currentFilter);
+                // If we don't allow free transactions, then we always have a fee filter of at least minRelayTxFee
+                if (GetArg("-limitfreerelay", DEFAULT_LIMITFREERELAY) <= 0)
+                    filterToSend = std::max(filterToSend, ::minRelayTxFee.GetFeePerK());
                 if (filterToSend != pto->lastSentFeeFilter) {
                     connman.PushMessage(pto, msgMaker.Make(NetMsgType::FEEFILTER, filterToSend));
                     pto->lastSentFeeFilter = filterToSend;


### PR DESCRIPTION
This applies the floor *after* rounding, so we don't miss out on transactions that pay our min relay fee (or slightly more) in transaction fees.