### PR TITLE
change to declarative sentences. simplify links

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ What is Bitcoin?
 
 Bitcoin is an experimental digital currency that enables instant payments to
 anyone, anywhere in the world. Bitcoin uses peer-to-peer technology to operate
-with no central authority: managing transactions and issuing money are carried
-out collectively by the network. Bitcoin Core is the name of open source
+with no central authority: management of transactions and issuance of money are carried
+out collectively by the network. Bitcoin Core is the name of the open source
 software which enables the use of this currency.
 
-For more information, as well as an immediately useable, binary version of
-the Bitcoin Core software, see https://bitcoin.org/en/download, or read the
+An immediately useable binary version of
+the Bitcoin Core software is located at [https://bitcoin.org/en/download](https://bitcoin.org/en/download). For more information read the
 [original whitepaper](https://bitcoincore.org/bitcoin.pdf).
 
 License

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ with no central authority: management of transactions and issuance of money are 
 out collectively by the network. Bitcoin Core is the name of the open source
 software which enables the use of this currency.
 
-An immediately useable binary version of
+An immediately useful binary version of
 the Bitcoin Core software is located at [https://bitcoin.org/en/download](https://bitcoin.org/en/download). For more information read the
 [original whitepaper](https://bitcoincore.org/bitcoin.pdf).
 


### PR DESCRIPTION
The current version is lifted directly from [bitcoin.org](https://bitcoin.org/en/), i.e.

    Bitcoin uses peer-to-peer technology to operate with no central authority or banks; 
    managing transactions and the issuing of bitcoins is carried out collectively by the 
    network.

So as an improvement to readability I propose to change the present perfect progressive such as `managing` and `issuing` to declarative sentences for the form `management` & `issuance`. 

Also I chopped up the last sentence which was kind of long, into two shorter ones with the links. 