### PR TITLE
Fix: OSX QT compile: move bswap_XX into Bitcoin:: to avoid collision with existing definitions

### DIFF
--- a/src/Makefile.qttest.include
+++ b/src/Makefile.qttest.include
@@ -6,6 +6,7 @@ bin_PROGRAMS += qt/test/test_bitcoin-qt
 TESTS += qt/test/test_bitcoin-qt
 
 TEST_QT_MOC_CPP = \
+  qt/test/moc_compattests.cpp \
   qt/test/moc_rpcnestedtests.cpp \
   qt/test/moc_uritests.cpp
 
@@ -14,6 +15,7 @@ TEST_QT_MOC_CPP += qt/test/moc_paymentservertests.cpp
 endif
 
 TEST_QT_H = \
+  qt/test/compattests.h \
   qt/test/rpcnestedtests.h \
   qt/test/uritests.h \
   qt/test/paymentrequestdata.h \
@@ -23,6 +25,7 @@ qt_test_test_bitcoin_qt_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) $(BITCOIN_
   $(QT_INCLUDES) $(QT_TEST_INCLUDES) $(PROTOBUF_CFLAGS)
 
 qt_test_test_bitcoin_qt_SOURCES = \
+  qt/test/compattests.cpp \
   qt/test/rpcnestedtests.cpp \
   qt/test/test_main.cpp \
   qt/test/uritests.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -52,6 +52,7 @@ BITCOIN_TESTS =\
   test/bip32_tests.cpp \
   test/blockencodings_tests.cpp \
   test/bloom_tests.cpp \
+  test/bswap_tests.cpp \
   test/coins_tests.cpp \
   test/compress_tests.cpp \
   test/crypto_tests.cpp \

--- a/src/compat/byteswap.h
+++ b/src/compat/byteswap.h
@@ -11,26 +11,23 @@
 
 #include <stdint.h>
 
-#if defined(HAVE_BYTESWAP_H)
-#include <byteswap.h>
-#endif
+namespace Bitcoin
+{
 
-#if HAVE_DECL_BSWAP_16 == 0
+#undef bswap_16
 inline uint16_t bswap_16(uint16_t x)
 {
     return (x >> 8) | ((x & 0x00ff) << 8);
 }
-#endif // HAVE_DECL_BSWAP16
 
-#if HAVE_DECL_BSWAP_32 == 0
+#undef bswap_32
 inline uint32_t bswap_32(uint32_t x)
 {
     return (((x & 0xff000000U) >> 24) | ((x & 0x00ff0000U) >>  8) |
             ((x & 0x0000ff00U) <<  8) | ((x & 0x000000ffU) << 24));
 }
-#endif // HAVE_DECL_BSWAP32
 
-#if HAVE_DECL_BSWAP_64 == 0
+#undef bswap_64
 inline uint64_t bswap_64(uint64_t x)
 {
      return (((x & 0xff00000000000000ull) >> 56)
@@ -42,6 +39,7 @@ inline uint64_t bswap_64(uint64_t x)
           | ((x & 0x000000000000ff00ull) << 40)
           | ((x & 0x00000000000000ffull) << 56));
 }
-#endif // HAVE_DECL_BSWAP64
+
+}  // namespace Bitcoin
 
 #endif // BITCOIN_COMPAT_BYTESWAP_H

--- a/src/compat/endian.h
+++ b/src/compat/endian.h
@@ -31,7 +31,7 @@ inline uint16_t htobe16(uint16_t host_16bits)
 #if HAVE_DECL_HTOLE16 == 0
 inline uint16_t htole16(uint16_t host_16bits)
 {
-    return bswap_16(host_16bits);
+    return Bitcoin::bswap_16(host_16bits);
 }
 #endif // HAVE_DECL_HTOLE16
 
@@ -45,7 +45,7 @@ inline uint16_t be16toh(uint16_t big_endian_16bits)
 #if HAVE_DECL_LE16TOH == 0
 inline uint16_t le16toh(uint16_t little_endian_16bits)
 {
-    return bswap_16(little_endian_16bits);
+    return Bitcoin::bswap_16(little_endian_16bits);
 }
 #endif // HAVE_DECL_LE16TOH
 
@@ -59,7 +59,7 @@ inline uint32_t htobe32(uint32_t host_32bits)
 #if HAVE_DECL_HTOLE32 == 0
 inline uint32_t htole32(uint32_t host_32bits)
 {
-    return bswap_32(host_32bits);
+    return Bitcoin::bswap_32(host_32bits);
 }
 #endif // HAVE_DECL_HTOLE32
 
@@ -73,7 +73,7 @@ inline uint32_t be32toh(uint32_t big_endian_32bits)
 #if HAVE_DECL_LE32TOH == 0
 inline uint32_t le32toh(uint32_t little_endian_32bits)
 {
-    return bswap_32(little_endian_32bits);
+    return Bitcoin::bswap_32(little_endian_32bits);
 }
 #endif // HAVE_DECL_LE32TOH
 
@@ -87,7 +87,7 @@ inline uint64_t htobe64(uint64_t host_64bits)
 #if HAVE_DECL_HTOLE64 == 0
 inline uint64_t htole64(uint64_t host_64bits)
 {
-    return bswap_64(host_64bits);
+    return Bitcoin::bswap_64(host_64bits);
 }
 #endif // HAVE_DECL_HTOLE64
 
@@ -101,7 +101,7 @@ inline uint64_t be64toh(uint64_t big_endian_64bits)
 #if HAVE_DECL_LE64TOH == 0
 inline uint64_t le64toh(uint64_t little_endian_64bits)
 {
-    return bswap_64(little_endian_64bits);
+    return Bitcoin::bswap_64(little_endian_64bits);
 }
 #endif // HAVE_DECL_LE64TOH
 
@@ -110,7 +110,7 @@ inline uint64_t le64toh(uint64_t little_endian_64bits)
 #if HAVE_DECL_HTOBE16 == 0
 inline uint16_t htobe16(uint16_t host_16bits)
 {
-    return bswap_16(host_16bits);
+    return Bitcoin::bswap_16(host_16bits);
 }
 #endif // HAVE_DECL_HTOBE16
 
@@ -124,7 +124,7 @@ inline uint16_t htole16(uint16_t host_16bits)
 #if HAVE_DECL_BE16TOH == 0
 inline uint16_t be16toh(uint16_t big_endian_16bits)
 {
-    return bswap_16(big_endian_16bits);
+    return Bitcoin::bswap_16(big_endian_16bits);
 }
 #endif // HAVE_DECL_BE16TOH
 
@@ -138,7 +138,7 @@ inline uint16_t le16toh(uint16_t little_endian_16bits)
 #if HAVE_DECL_HTOBE32 == 0
 inline uint32_t htobe32(uint32_t host_32bits)
 {
-    return bswap_32(host_32bits);
+    return Bitcoin::bswap_32(host_32bits);
 }
 #endif // HAVE_DECL_HTOBE32
 
@@ -152,7 +152,7 @@ inline uint32_t htole32(uint32_t host_32bits)
 #if HAVE_DECL_BE32TOH == 0
 inline uint32_t be32toh(uint32_t big_endian_32bits)
 {
-    return bswap_32(big_endian_32bits);
+    return Bitcoin::bswap_32(big_endian_32bits);
 }
 #endif // HAVE_DECL_BE32TOH
 
@@ -166,7 +166,7 @@ inline uint32_t le32toh(uint32_t little_endian_32bits)
 #if HAVE_DECL_HTOBE64 == 0
 inline uint64_t htobe64(uint64_t host_64bits)
 {
-    return bswap_64(host_64bits);
+    return Bitcoin::bswap_64(host_64bits);
 }
 #endif // HAVE_DECL_HTOBE64
 
@@ -180,7 +180,7 @@ inline uint64_t htole64(uint64_t host_64bits)
 #if HAVE_DECL_BE64TOH == 0
 inline uint64_t be64toh(uint64_t big_endian_64bits)
 {
-    return bswap_64(big_endian_64bits);
+    return Bitcoin::bswap_64(big_endian_64bits);
 }
 #endif // HAVE_DECL_BE64TOH
 

--- a/src/qt/test/compattests.cpp
+++ b/src/qt/test/compattests.cpp
@@ -1,0 +1,23 @@
+// Copyright (c) 2016 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "paymentrequestplus.h" // this includes protobuf's port.h which defines its own bswap macos
+
+#include "compattests.h"
+
+#include "compat/byteswap.h"
+
+void CompatTests::bswapTests()
+{
+	// Sibling in bitcoin/src/test/bswap_tests.cpp
+	uint16_t u1 = 0x1234;
+	uint32_t u2 = 0x56789abc;
+	uint64_t u3 = 0xdef0123456789abc;
+	uint16_t e1 = 0x3412;
+	uint32_t e2 = 0xbc9a7856;
+	uint64_t e3 = 0xbc9a78563412f0de;
+	QVERIFY(Bitcoin::bswap_16(u1) == e1);
+	QVERIFY(Bitcoin::bswap_32(u2) == e2);
+	QVERIFY(Bitcoin::bswap_64(u3) == e3);
+}

--- a/src/qt/test/compattests.h
+++ b/src/qt/test/compattests.h
@@ -1,0 +1,19 @@
+// Copyright (c) 2009-2015 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QT_TEST_COMPATTESTS_H
+#define BITCOIN_QT_TEST_COMPATTESTS_H
+
+#include <QObject>
+#include <QTest>
+
+class CompatTests : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    void bswapTests();
+};
+
+#endif // BITCOIN_QT_TEST_COMPATTESTS_H

--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -11,6 +11,7 @@
 #include "rpcnestedtests.h"
 #include "util.h"
 #include "uritests.h"
+#include "compattests.h"
 
 #ifdef ENABLE_WALLET
 #include "paymentservertests.h"
@@ -60,6 +61,9 @@ int main(int argc, char *argv[])
 #endif
     RPCNestedTests test3;
     if (QTest::qExec(&test3) != 0)
+        fInvalid = true;
+    CompatTests test4;
+    if (QTest::qExec(&test4) != 0)
         fInvalid = true;
 
     ECC_Stop();

--- a/src/test/bswap_tests.cpp
+++ b/src/test/bswap_tests.cpp
@@ -1,0 +1,26 @@
+// Copyright (c) 2016 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "compat/byteswap.h"
+#include "test/test_bitcoin.h"
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(bswap_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(bswap_tests)
+{
+	// Sibling in bitcoin/src/qt/test/compattests.cpp
+	uint16_t u1 = 0x1234;
+	uint32_t u2 = 0x56789abc;
+	uint64_t u3 = 0xdef0123456789abc;
+	uint16_t e1 = 0x3412;
+	uint32_t e2 = 0xbc9a7856;
+	uint64_t e3 = 0xbc9a78563412f0de;
+	BOOST_CHECK(Bitcoin::bswap_16(u1) == e1);
+	BOOST_CHECK(Bitcoin::bswap_32(u2) == e2);
+	BOOST_CHECK(Bitcoin::bswap_64(u3) == e3);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
[This is an alternative approach to #9366]

The `bswap_XX` functions are sometimes provided by external libraries (protobuf) and sometimes not. To avoid inconsistency and relying on include order, the idea is to move these into a dedicated namespace (`Bitcoin`). Since they are declared as macros by e.g. protobuf, they are `#undef`d as well.

The one caveat with this approach is when someone would include `compat/byteswap.h`, and then include protobuf's `port.h` (in that order). In this case, the macro would be redefined and `Bitcoin::bswap_XX` would result in a compilation error.
