### PR TITLE
Linearize script update (hash byte reversal and Python 3 support)

### DIFF
--- a/contrib/linearize/README.md
+++ b/contrib/linearize/README.md
@@ -1,33 +1,43 @@
 # Linearize
-Construct a linear, no-fork, best version of the blockchain.
+Construct a linear, no-fork, best version of the Bitcoin blockchain.
 
 ## Step 1: Download hash list
 
     $ ./linearize-hashes.py linearize.cfg > hashlist.txt
 
 Required configuration file settings for linearize-hashes:
-* RPC: rpcuser, rpcpassword
+* RPC: `rpcuser`, `rpcpassword`
 
 Optional config file setting for linearize-hashes:
-* RPC: host, port
-* Block chain: min_height, max_height
+* RPC: `host`, `port`  (Default: `127.0.0.1:8332`)
+* Blockchain: `min_height`, `max_height`
+* `rev_hash_bytes`: If true, the written block hash list will be
+byte-reversed. (In other words, the hash returned by getblockhash will have its
+bytes reversed.) False by default. Intended for generation of
+standalone hash lists but safe to use with linearize-data.py, which will output
+the same data no matter which byte format is chosen.
 
 ## Step 2: Copy local block data
 
     $ ./linearize-data.py linearize.cfg
 
 Required configuration file settings:
-* "input": bitcoind blocks/ directory containing blkNNNNN.dat
-* "hashlist": text file containing list of block hashes, linearized-hashes.py
-output.
-* "output_file": bootstrap.dat
+* `output_file`: The file that will contain the final blockchain.
       or
-* "output": output directory for linearized blocks/blkNNNNN.dat output
+* `output`: Output directory for linearized blocks/blkNNNNN.dat output.
 
 Optional config file setting for linearize-data:
-* "netmagic": network magic number
-* "max_out_sz": maximum output file size (default `1000*1000*1000`)
-* "split_timestamp": Split files when a new month is first seen, in addition to
-reaching a maximum file size.
-* "file_timestamp": Set each file's last-modified time to that of the
-most recent block in that file.
+* `file_timestamp`: Set each file's last-modified time to that of the most
+recent block in that file.
+* `genesis`: The hash of the genesis block in the blockchain.
+* `input: bitcoind blocks/ directory containing blkNNNNN.dat
+* `hashlist`: text file containing list of block hashes created by
+linearize-hashes.py.
+* `max_out_sz`: Maximum size for files created by the `output_file` option.
+(Default: `1000*1000*1000 bytes`)
+* `netmagic`: Network magic number.
+* `rev_hash_bytes`: If true, the block hash list written by linearize-hashes.py
+will be byte-reversed when read by linearize-data.py. See the linearize-hashes
+entry for more information.
+* `split_timestamp`: Split blockchain files when a new month is first seen, in
+addition to reaching a maximum file size (`max_out_sz`).

--- a/contrib/linearize/README.md
+++ b/contrib/linearize/README.md
@@ -1,5 +1,6 @@
 # Linearize
-Construct a linear, no-fork, best version of the Bitcoin blockchain.
+Construct a linear, no-fork, best version of the Bitcoin blockchain. The scripts
+run using Python 3 but are compatible with Python 2.
 
 ## Step 1: Download hash list
 
@@ -9,13 +10,17 @@ Required configuration file settings for linearize-hashes:
 * RPC: `rpcuser`, `rpcpassword`
 
 Optional config file setting for linearize-hashes:
-* RPC: `host`, `port`  (Default: `127.0.0.1:8332`)
+* RPC: `host`  (Default: `127.0.0.1`)
+* RPC: `port`  (Default: `8332`)
 * Blockchain: `min_height`, `max_height`
 * `rev_hash_bytes`: If true, the written block hash list will be
 byte-reversed. (In other words, the hash returned by getblockhash will have its
 bytes reversed.) False by default. Intended for generation of
 standalone hash lists but safe to use with linearize-data.py, which will output
 the same data no matter which byte format is chosen.
+
+The `linearize-hashes` script requires a connection, local or remote, to a
+JSON-RPC server. Running `bitcoind` or `bitcoin-qt -server` will be sufficient.
 
 ## Step 2: Copy local block data
 
@@ -24,13 +29,13 @@ the same data no matter which byte format is chosen.
 Required configuration file settings:
 * `output_file`: The file that will contain the final blockchain.
       or
-* `output`: Output directory for linearized blocks/blkNNNNN.dat output.
+* `output`: Output directory for linearized `blocks/blkNNNNN.dat` output.
 
 Optional config file setting for linearize-data:
 * `file_timestamp`: Set each file's last-modified time to that of the most
 recent block in that file.
 * `genesis`: The hash of the genesis block in the blockchain.
-* `input: bitcoind blocks/ directory containing blkNNNNN.dat
+* `input`: bitcoind blocks/ directory containing blkNNNNN.dat
 * `hashlist`: text file containing list of block hashes created by
 linearize-hashes.py.
 * `max_out_sz`: Maximum size for files created by the `output_file` option.

--- a/contrib/linearize/example-linearize.cfg
+++ b/contrib/linearize/example-linearize.cfg
@@ -23,7 +23,9 @@ input=/home/example/.bitcoin/blocks
 
 output_file=/home/example/Downloads/bootstrap.dat
 hashlist=hashlist.txt
-split_year=1
 
 # Maxmimum size in bytes of out-of-order blocks cache in memory
 out_of_order_cache_sz = 100000000
+
+# Do we want the reverse the hash bytes coming from getblockhash?
+rev_hash_bytes = False

--- a/contrib/linearize/linearize-hashes.py
+++ b/contrib/linearize/linearize-hashes.py
@@ -17,6 +17,12 @@ import sys
 
 settings = {}
 
+##### Switch endian-ness #####
+def hex_switchEndian(s):
+	""" Switches the endianness of a hex string (in pairs of hex chars) """
+	pairList = [s[i]+s[i+1] for i in range(0,len(s),2)]
+	return ''.join(pairList[::-1])
+
 class BitcoinRPC:
 	def __init__(self, host, port, username, password):
 		authpair = "%s:%s" % (username, password)
@@ -70,6 +76,8 @@ def get_block_hashes(settings, max_blocks_per_call=10000):
 				print('JSON-RPC: error at height', height+x, ': ', resp_obj['error'], file=sys.stderr)
 				exit(1)
 			assert(resp_obj['id'] == x) # assume replies are in-sequence
+			if settings['rev_hash_bytes'] == 'true':
+				resp_obj['result'] = hex_switchEndian(resp_obj['result'])
 			print(resp_obj['result'])
 
 		height += num_blocks
@@ -101,6 +109,8 @@ if __name__ == '__main__':
 		settings['min_height'] = 0
 	if 'max_height' not in settings:
 		settings['max_height'] = 313000
+	if 'rev_hash_bytes' not in settings:
+		settings['rev_hash_bytes'] = 'false'
 	if 'rpcuser' not in settings or 'rpcpassword' not in settings:
 		print("Missing username and/or password in cfg file", file=stderr)
 		sys.exit(1)
@@ -109,5 +119,7 @@ if __name__ == '__main__':
 	settings['min_height'] = int(settings['min_height'])
 	settings['max_height'] = int(settings['max_height'])
 
-	get_block_hashes(settings)
+	# Force hash byte format setting to be lowercase to make comparisons easier.
+	settings['rev_hash_bytes'] = settings['rev_hash_bytes'].lower()
 
+	get_block_hashes(settings)

--- a/contrib/linearize/linearize-hashes.py
+++ b/contrib/linearize/linearize-hashes.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # linearize-hashes.py:  List blocks in a linear, no-fork version of the chain.
 #
@@ -8,11 +8,14 @@
 #
 
 from __future__ import print_function
+try: # Python 3
+    import http.client as httplib
+except ImportError: # Python 2
+    import httplib
 import json
 import struct
 import re
 import base64
-import httplib
 import sys
 
 settings = {}
@@ -20,26 +23,32 @@ settings = {}
 ##### Switch endian-ness #####
 def hex_switchEndian(s):
 	""" Switches the endianness of a hex string (in pairs of hex chars) """
-	pairList = [s[i]+s[i+1] for i in range(0,len(s),2)]
-	return ''.join(pairList[::-1])
+	pairList = [s[i:i+2].encode() for i in range(0, len(s), 2)]
+	return b''.join(pairList[::-1]).decode()
 
 class BitcoinRPC:
 	def __init__(self, host, port, username, password):
 		authpair = "%s:%s" % (username, password)
-		self.authhdr = "Basic %s" % (base64.b64encode(authpair))
-		self.conn = httplib.HTTPConnection(host, port, False, 30)
+		authpair = authpair.encode('utf-8')
+		self.authhdr = b"Basic " + base64.b64encode(authpair)
+		self.conn = httplib.HTTPConnection(host, port=port, timeout=30)
 
 	def execute(self, obj):
-		self.conn.request('POST', '/', json.dumps(obj),
-			{ 'Authorization' : self.authhdr,
-			  'Content-type' : 'application/json' })
+		try:
+			self.conn.request('POST', '/', json.dumps(obj),
+				{ 'Authorization' : self.authhdr,
+				  'Content-type' : 'application/json' })
+		except ConnectionRefusedError:
+			print('RPC connection refused. Check RPC settings and the server status.',
+			      file=sys.stderr)
+			return None
 
 		resp = self.conn.getresponse()
 		if resp is None:
 			print("JSON-RPC: no response", file=sys.stderr)
 			return None
 
-		body = resp.read()
+		body = resp.read().decode('utf-8')
 		resp_obj = json.loads(body)
 		return resp_obj
 
@@ -70,6 +79,9 @@ def get_block_hashes(settings, max_blocks_per_call=10000):
 			batch.append(rpc.build_request(x, 'getblockhash', [height + x]))
 
 		reply = rpc.execute(batch)
+		if reply is None:
+			print('Cannot continue. Program will halt.')
+			return None
 
 		for x,resp_obj in enumerate(reply):
 			if rpc.response_is_error(resp_obj):


### PR DESCRIPTION
- Add support for reversed hash bytes.
- Add support for Python 3. The linearization scripts can now run on Python 2 or 3.

Continuing #9304.