### PR TITLE
[trivial] Add documentation for CWalletTx::fFromMe member.

### DIFF
--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -253,6 +253,11 @@ public:
     unsigned int fTimeReceivedIsTxTime;
     unsigned int nTimeReceived; //!< time received by this node
     unsigned int nTimeSmart;
+    /**
+     * From me flag is set to 1 for transactions that were created by the wallet
+     * on this bitcoin node, and set to 0 for transactions that were created
+     * externally and came in through the network or sendrawtransaction RPC.
+     */
     char fFromMe;
     std::string strFromAccount;
     int64_t nOrderPos; //!< position in ordered transaction list


### PR DESCRIPTION
This PR just adds a code comment documenting `CWalletTx::fFromMe`. There was some discussion in #9351  recently about removing the fromme member entirely, but it doesn't look like this will happen right now.