### PR TITLE
CCoinsViewCache code cleanup & deduplication

### DIFF
--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -10,6 +10,8 @@
 #include <util/trace.h>
 #include <version.h>
 
+#include <optional>
+
 bool CCoinsView::GetCoin(const COutPoint &outpoint, Coin &coin) const { return false; }
 uint256 CCoinsView::GetBestBlock() const { return uint256(); }
 std::vector<uint256> CCoinsView::GetHeadBlocks() const { return std::vector<uint256>(); }
@@ -38,21 +40,24 @@ size_t CCoinsViewCache::DynamicMemoryUsage() const {
     return memusage::DynamicUsage(cacheCoins) + cachedCoinsUsage;
 }
 
+class CCoinsViewCache::Modifier
+{
+public:
+    Modifier(const CCoinsViewCache& cache, const COutPoint& outpoint);
+    Modifier(const CCoinsViewCache& cache, const COutPoint& outpoint, CCoinsCacheEntry&& new_entry);
+    ~Modifier() { Flush(); }
+    Coin& Modify();
+    CCoinsMap::iterator Flush();
+
+private:
+    const CCoinsViewCache& m_cache;
+    const COutPoint& m_outpoint;
+    CCoinsMap::iterator m_cur_entry = m_cache.cacheCoins.find(m_outpoint);
+    std::optional<CCoinsCacheEntry> m_new_entry;
+};
+
 CCoinsMap::iterator CCoinsViewCache::FetchCoin(const COutPoint &outpoint) const {
-    CCoinsMap::iterator it = cacheCoins.find(outpoint);
-    if (it != cacheCoins.end())
-        return it;
-    Coin tmp;
-    if (!base->GetCoin(outpoint, tmp))
-        return cacheCoins.end();
-    CCoinsMap::iterator ret = cacheCoins.emplace(std::piecewise_construct, std::forward_as_tuple(outpoint), std::forward_as_tuple(std::move(tmp))).first;
-    if (ret->second.coin.IsSpent()) {
-        // The parent only has an empty entry for this outpoint; we can consider our
-        // version as fresh.
-        ret->second.flags = CCoinsCacheEntry::FRESH;
-    }
-    cachedCoinsUsage += ret->second.coin.DynamicMemoryUsage();
-    return ret;
+    return Modifier(*this, outpoint).Flush();
 }
 
 bool CCoinsViewCache::GetCoin(const COutPoint &outpoint, Coin &coin) const {
@@ -67,35 +72,14 @@ bool CCoinsViewCache::GetCoin(const COutPoint &outpoint, Coin &coin) const {
 void CCoinsViewCache::AddCoin(const COutPoint &outpoint, Coin&& coin, bool possible_overwrite) {
     assert(!coin.IsSpent());
     if (coin.out.scriptPubKey.IsUnspendable()) return;
-    CCoinsMap::iterator it;
-    bool inserted;
-    std::tie(it, inserted) = cacheCoins.emplace(std::piecewise_construct, std::forward_as_tuple(outpoint), std::tuple<>());
-    bool fresh = false;
-    if (!inserted) {
-        cachedCoinsUsage -= it->second.coin.DynamicMemoryUsage();
-    }
-    if (!possible_overwrite) {
-        if (!it->second.coin.IsSpent()) {
-            throw std::logic_error("Attempted to overwrite an unspent coin (when possible_overwrite is false)");
-        }
-        // If the coin exists in this cache as a spent coin and is DIRTY, then
-        // its spentness hasn't been flushed to the parent cache. We're
-        // re-adding the coin to this cache now but we can't mark it as FRESH.
-        // If we mark it FRESH and then spend it before the cache is flushed
-        // we would remove it from this cache and would never flush spentness
-        // to the parent cache.
-        //
-        // Re-adding a spent coin can happen in the case of a re-org (the coin
-        // is 'spent' when the block adding it is disconnected and then
-        // re-added when it is also added in a newly connected block).
-        //
-        // If the coin doesn't exist in the current cache, or is spent but not
-        // DIRTY, then it can be marked FRESH.
-        fresh = !(it->second.flags & CCoinsCacheEntry::DIRTY);
-    }
-    it->second.coin = std::move(coin);
-    it->second.flags |= CCoinsCacheEntry::DIRTY | (fresh ? CCoinsCacheEntry::FRESH : 0);
-    cachedCoinsUsage += it->second.coin.DynamicMemoryUsage();
+    CCoinsCacheEntry entry;
+    // If we are not possibly overwriting, any coin in the base view below the
+    // cache will be spent, so the cache entry can be marked fresh.
+    // If we are possibly overwriting, we can't make any assumption about the
+    // coin in the the base view below the cache, so the new cache entry which
+    // will replace it must be marked dirty.
+    entry.flags |= possible_overwrite ? CCoinsCacheEntry::DIRTY : CCoinsCacheEntry::FRESH;
+    Modifier(*this, outpoint, std::move(entry)).Modify() = std::move(coin);
     TRACE5(utxocache, add,
            outpoint.hash.data(),
            (uint32_t)outpoint.n,
@@ -112,37 +96,32 @@ void CCoinsViewCache::EmplaceCoinInternalDANGER(COutPoint&& outpoint, Coin&& coi
         std::forward_as_tuple(std::move(coin), CCoinsCacheEntry::DIRTY));
 }
 
-void AddCoins(CCoinsViewCache& cache, const CTransaction &tx, int nHeight, bool check_for_overwrite) {
+void AddCoins(CCoinsViewCache& cache, const CTransaction &tx, int nHeight, bool check) {
     bool fCoinbase = tx.IsCoinBase();
     const uint256& txid = tx.GetHash();
     for (size_t i = 0; i < tx.vout.size(); ++i) {
-        bool overwrite = check_for_overwrite ? cache.HaveCoin(COutPoint(txid, i)) : fCoinbase;
-        // Coinbase transactions can always be overwritten, in order to correctly
+        bool overwrite = check ? cache.HaveCoin(COutPoint(txid, i)) : fCoinbase;
+        // Always set the possible_overwrite flag to AddCoin for coinbase txn, in order to correctly
         // deal with the pre-BIP30 occurrences of duplicate coinbase transactions.
         cache.AddCoin(COutPoint(txid, i), Coin(tx.vout[i], nHeight, fCoinbase), overwrite);
     }
 }
 
 bool CCoinsViewCache::SpendCoin(const COutPoint &outpoint, Coin* moveout) {
-    CCoinsMap::iterator it = FetchCoin(outpoint);
-    if (it == cacheCoins.end()) return false;
-    cachedCoinsUsage -= it->second.coin.DynamicMemoryUsage();
+    Modifier modifier(*this, outpoint);
+    Coin& coin = modifier.Modify();
     TRACE5(utxocache, spent,
            outpoint.hash.data(),
            (uint32_t)outpoint.n,
            (uint32_t)it->second.coin.nHeight,
            (int64_t)it->second.coin.out.nValue,
            (bool)it->second.coin.IsCoinBase());
+    bool already_spent = coin.IsSpent();
     if (moveout) {
-        *moveout = std::move(it->second.coin);
+        *moveout = std::move(coin);
     }
-    if (it->second.flags & CCoinsCacheEntry::FRESH) {
-        cacheCoins.erase(it);
-    } else {
-        it->second.flags |= CCoinsCacheEntry::DIRTY;
-        it->second.coin.Clear();
-    }
-    return true;
+    coin.Clear();
+    return !already_spent;
 }
 
 static const Coin coinEmpty;
@@ -182,51 +161,7 @@ bool CCoinsViewCache::BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlockIn
         if (!(it->second.flags & CCoinsCacheEntry::DIRTY)) {
             continue;
         }
-        CCoinsMap::iterator itUs = cacheCoins.find(it->first);
-        if (itUs == cacheCoins.end()) {
-            // The parent cache does not have an entry, while the child cache does.
-            // We can ignore it if it's both spent and FRESH in the child
-            if (!(it->second.flags & CCoinsCacheEntry::FRESH && it->second.coin.IsSpent())) {
-                // Create the coin in the parent cache, move the data up
-                // and mark it as dirty.
-                CCoinsCacheEntry& entry = cacheCoins[it->first];
-                entry.coin = std::move(it->second.coin);
-                cachedCoinsUsage += entry.coin.DynamicMemoryUsage();
-                entry.flags = CCoinsCacheEntry::DIRTY;
-                // We can mark it FRESH in the parent if it was FRESH in the child
-                // Otherwise it might have just been flushed from the parent's cache
-                // and already exist in the grandparent
-                if (it->second.flags & CCoinsCacheEntry::FRESH) {
-                    entry.flags |= CCoinsCacheEntry::FRESH;
-                }
-            }
-        } else {
-            // Found the entry in the parent cache
-            if ((it->second.flags & CCoinsCacheEntry::FRESH) && !itUs->second.coin.IsSpent()) {
-                // The coin was marked FRESH in the child cache, but the coin
-                // exists in the parent cache. If this ever happens, it means
-                // the FRESH flag was misapplied and there is a logic error in
-                // the calling code.
-                throw std::logic_error("FRESH flag misapplied to coin that exists in parent cache");
-            }
-
-            if ((itUs->second.flags & CCoinsCacheEntry::FRESH) && it->second.coin.IsSpent()) {
-                // The grandparent cache does not have an entry, and the coin
-                // has been spent. We can just delete it from the parent cache.
-                cachedCoinsUsage -= itUs->second.coin.DynamicMemoryUsage();
-                cacheCoins.erase(itUs);
-            } else {
-                // A normal modification.
-                cachedCoinsUsage -= itUs->second.coin.DynamicMemoryUsage();
-                itUs->second.coin = std::move(it->second.coin);
-                cachedCoinsUsage += itUs->second.coin.DynamicMemoryUsage();
-                itUs->second.flags |= CCoinsCacheEntry::DIRTY;
-                // NOTE: It isn't safe to mark the coin as FRESH in the parent
-                // cache. If it already existed and was spent in the parent
-                // cache then marking it FRESH would prevent that spentness
-                // from being flushed to the grandparent.
-            }
-        }
+        Modifier(*this, it->first, std::move(it->second));
     }
     hashBlock = hashBlockIn;
     return true;
@@ -306,4 +241,94 @@ bool CCoinsViewErrorCatcher::GetCoin(const COutPoint &outpoint, Coin &coin) cons
         // continue anyway, and all writes should be atomic.
         std::abort();
     }
+}
+
+CCoinsViewCache::Modifier::Modifier(const CCoinsViewCache& cache, const COutPoint& outpoint)
+    : m_cache(cache), m_outpoint(outpoint)
+{
+    if (m_cur_entry == m_cache.cacheCoins.end()) {
+        m_new_entry.emplace();
+        m_cache.base->GetCoin(m_outpoint, m_new_entry->coin);
+        if (m_new_entry->coin.IsSpent()) {
+            m_new_entry->flags |= CCoinsCacheEntry::FRESH;
+        }
+    }
+}
+
+CCoinsViewCache::Modifier::Modifier(const CCoinsViewCache& cache,
+    const COutPoint& outpoint,
+    CCoinsCacheEntry&& new_entry)
+    : m_cache(cache), m_outpoint(outpoint)
+{
+    const bool cur_entry = m_cur_entry != m_cache.cacheCoins.end();
+    const bool cur_spent = cur_entry && m_cur_entry->second.coin.IsSpent();
+    const bool cur_dirty = cur_entry && m_cur_entry->second.flags & CCoinsCacheEntry::DIRTY;
+    const bool cur_fresh = cur_entry && m_cur_entry->second.flags & CCoinsCacheEntry::FRESH;
+    const bool new_spent = new_entry.coin.IsSpent();
+    const bool new_dirty = new_entry.flags & CCoinsCacheEntry::DIRTY;
+    const bool new_fresh = new_entry.flags & CCoinsCacheEntry::FRESH;
+
+    // If the new value is marked FRESH, assert any existing cache entry is
+    // spent, otherwise it means the FRESH flag was misapplied.
+    if (new_fresh && cur_entry && !cur_spent) {
+        throw std::logic_error("FRESH flag misapplied to cache of unspent coin");
+    }
+
+    // If a cache entry is spent but not dirty, it should be marked fresh.
+    if (new_spent && !new_fresh && !new_dirty) {
+        throw std::logic_error("Missing FRESH or DIRTY flags for spent cache entry.");
+    }
+
+    // Create new cache entry that can be merged into the cache in Flush().
+    m_new_entry.emplace();
+    m_new_entry->coin = std::move(new_entry.coin);
+
+    // If `cur_fresh` is true it means the `m_cache.base` coin is spent, so
+    // keep the FRESH flag. If `new_fresh` is true, it means that the `m_cache`
+    // coin is spent, which implies that the `m_cache.base` coin is also spent
+    // as long as the cache is not dirty, so keep the FRESH flag in this case as
+    // well.
+    if (cur_fresh || (new_fresh && !cur_dirty)) {
+        m_new_entry->flags |= CCoinsCacheEntry::FRESH;
+    }
+
+    if (cur_dirty || new_dirty) {
+        m_new_entry->flags |= CCoinsCacheEntry::DIRTY;
+    }
+}
+
+// Add DIRTY flag to m_new_entry and return mutable coin reference. Populate
+// m_new_entry from existing cache entry if necessary.
+Coin& CCoinsViewCache::Modifier::Modify()
+{
+    if (!m_new_entry) {
+        assert(m_cur_entry != m_cache.cacheCoins.end());
+        m_new_entry.emplace(m_cur_entry->second);
+    }
+    m_new_entry->flags |= CCoinsCacheEntry::DIRTY;
+    return m_new_entry->coin;
+}
+
+// Update m_cache.cacheCoins with the contents of m_new_entry, if present.
+CCoinsMap::iterator CCoinsViewCache::Modifier::Flush()
+{
+    if (m_new_entry) {
+        bool erase = (m_new_entry->flags & CCoinsCacheEntry::FRESH) && m_new_entry->coin.IsSpent();
+        if (m_cur_entry != m_cache.cacheCoins.end()) {
+            m_cache.cachedCoinsUsage -= m_cur_entry->second.coin.DynamicMemoryUsage();
+            if (erase) {
+                m_cache.cacheCoins.erase(m_cur_entry);
+                m_cur_entry = m_cache.cacheCoins.end();
+            } else {
+                m_cur_entry->second = std::move(*m_new_entry);
+            }
+        } else if (!erase) {
+            m_cur_entry = m_cache.cacheCoins.emplace(m_outpoint, std::move(*m_new_entry)).first;
+        }
+        if (!erase) {
+            m_cache.cachedCoinsUsage += m_cur_entry->second.coin.DynamicMemoryUsage();
+        }
+    }
+    m_new_entry.reset();
+    return m_cur_entry;
 }

--- a/src/coins.h
+++ b/src/coins.h
@@ -223,6 +223,7 @@ protected:
     /* Cached dynamic memory usage for the inner Coin objects. */
     mutable size_t cachedCoinsUsage;
 
+    class Modifier;
 public:
     CCoinsViewCache(CCoinsView *baseIn);
 

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -831,7 +831,7 @@ BOOST_AUTO_TEST_CASE(ccoins_write)
     CheckWriteCoins(SPENT , ABSENT, SPENT , DIRTY      , NO_ENTRY   , DIRTY      );
     CheckWriteCoins(SPENT , ABSENT, SPENT , DIRTY|FRESH, NO_ENTRY   , DIRTY|FRESH);
     CheckWriteCoins(SPENT , SPENT , SPENT , 0          , DIRTY      , DIRTY      );
-    CheckWriteCoins(SPENT , SPENT , SPENT , 0          , DIRTY|FRESH, DIRTY      );
+    CheckWriteCoins(SPENT , SPENT , ABSENT, 0          , DIRTY|FRESH, NO_ENTRY   );
     CheckWriteCoins(SPENT , SPENT , ABSENT, FRESH      , DIRTY      , NO_ENTRY   );
     CheckWriteCoins(SPENT , SPENT , ABSENT, FRESH      , DIRTY|FRESH, NO_ENTRY   );
     CheckWriteCoins(SPENT , SPENT , SPENT , DIRTY      , DIRTY      , DIRTY      );
@@ -839,7 +839,7 @@ BOOST_AUTO_TEST_CASE(ccoins_write)
     CheckWriteCoins(SPENT , SPENT , ABSENT, DIRTY|FRESH, DIRTY      , NO_ENTRY   );
     CheckWriteCoins(SPENT , SPENT , ABSENT, DIRTY|FRESH, DIRTY|FRESH, NO_ENTRY   );
     CheckWriteCoins(SPENT , VALUE2, VALUE2, 0          , DIRTY      , DIRTY      );
-    CheckWriteCoins(SPENT , VALUE2, VALUE2, 0          , DIRTY|FRESH, DIRTY      );
+    CheckWriteCoins(SPENT , VALUE2, VALUE2, 0          , DIRTY|FRESH, DIRTY|FRESH);
     CheckWriteCoins(SPENT , VALUE2, VALUE2, FRESH      , DIRTY      , DIRTY|FRESH);
     CheckWriteCoins(SPENT , VALUE2, VALUE2, FRESH      , DIRTY|FRESH, DIRTY|FRESH);
     CheckWriteCoins(SPENT , VALUE2, VALUE2, DIRTY      , DIRTY      , DIRTY      );

--- a/src/test/fuzz/coins_view.cpp
+++ b/src/test/fuzz/coins_view.cpp
@@ -65,7 +65,7 @@ FUZZ_TARGET_INIT(coins_view, initialize_coins_view)
                     coins_view_cache.AddCoin(random_out_point, std::move(coin), possible_overwrite);
                     expected_code_path = true;
                 } catch (const std::logic_error& e) {
-                    if (e.what() == std::string{"Attempted to overwrite an unspent coin (when possible_overwrite is false)"}) {
+                    if (e.what() == std::string{"FRESH flag misapplied to cache of unspent coin"}) {
                         assert(!possible_overwrite);
                         expected_code_path = true;
                     }


### PR DESCRIPTION
CCoinsViewCache code cleanup & deduplication

The change moves code responsible for updating the cache out of various
CCoinsViewCache methods and into a Modifier class. This way the cache update
code is just written once in a general way instead of being duplicated and
split up to handle various special cases.

This is a refactoring, with changes to cache behavior only in 2 corner cases
(with corresponding tests in coins_test.cpp) which don't affect the meaning of
data stored in the cache:

* In BatchWrite, overwriting a non-dirty pruned cache entry with a fresh pruned
  cache entry now deletes the cache entry instead of leaving behind a dirty
  pruned entry that will trigger an unnecessary database write later.

* In BatchWrite, overwriting a dirty pruned fresh cache entry with a nonpruned
  entry updates the entry without dropping the fresh flag. There's no reason to
  drop the fresh flag in this case because the flag accurately describes the
  state of the base view and could prevent unnecessary database writes in the
  future if the utxo is spent later.