### PR TITLE
travis: make distdir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,7 +56,6 @@ src/qt/test/moc*.cpp
 *.o
 *.o-*
 *.patch
-.bitcoin
 *.a
 *.pb.cc
 *.pb.h

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,7 @@ script:
     - mkdir build && cd build
     - ../configure $BITCOIN_CONFIG_ALL $BITCOIN_CONFIG || ( cat config.log && false)
     - make $MAKEJOBS $GOAL || ( echo "Build failure. Verbose build follows." && make $GOAL V=1 ; false )
+    - make distdir
     - export LD_LIBRARY_PATH=$TRAVIS_BUILD_DIR/depends/$HOST/lib
     - if [ "$RUN_TESTS" = "true" ]; then make $MAKEJOBS check VERBOSE=1; fi
     - if [ "$RUN_TESTS" = "true" ]; then qa/pull-tester/rpc-tests.py --coverage; fi


### PR DESCRIPTION
@theuni This should be enough to get back the test, which was removed due to 142ffc7e?

Edit: Also added an unrelated commit which removes a line in gitignore. (No longer needed, as the java comparision tool was removed)