### PR TITLE
build: Include cuckoocache header in Makefile

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -97,6 +97,7 @@ BITCOIN_CORE_H = \
   consensus/consensus.h \
   core_io.h \
   core_memusage.h \
+  cuckoocache.h \
   httprpc.h \
   httpserver.h \
   indirectmap.h \


### PR DESCRIPTION
I can not build without this change, so I assume it is correct.