### PR TITLE
Add test for -walletrejectlongchains

### DIFF
--- a/qa/rpc-tests/wallet.py
+++ b/qa/rpc-tests/wallet.py
@@ -363,11 +363,42 @@ class WalletTest (BitcoinTestFramework):
         self.nodes[0].generate(1)
 
         # Make a long chain of unconfirmed payments without hitting mempool limit
+        # Each tx we make leaves only one output of change on a chain 1 longer
+        # Since the amount to send is always much less than the outputs, we only ever need one output
+        # So we should be able to generate exactly chainlimit txs for each original output
+        sending_addr = self.nodes[1].getnewaddress()
         txid_list = []
         for i in range(chainlimit*2):
-            txid_list.append(self.nodes[0].sendtoaddress(chain_addrs[0], Decimal('0.0001')))
+            txid_list.append(self.nodes[0].sendtoaddress(sending_addr, Decimal('0.0001')))
         assert_equal(self.nodes[0].getmempoolinfo()['size'], chainlimit*2)
         assert_equal(len(txid_list), chainlimit*2)
+
+        # Without walletrejectlongchains, we will still generate a txid
+        # The tx will be stored in the wallet but not accepted to the mempool
+        extra_txid = self.nodes[0].sendtoaddress(sending_addr, Decimal('0.0001'))
+        assert(extra_txid not in self.nodes[0].getrawmempool())
+        assert(extra_txid in [tx["txid"] for tx in self.nodes[0].listtransactions()])
+        self.nodes[0].abandontransaction(extra_txid)
+        total_txs = len(self.nodes[0].listtransactions("*",99999))
+
+        # Try with walletrejectlongchains
+        # Double chain limit but require combining inputs, so we pass SelectCoinsMinConf
+        stop_node(self.nodes[0],0)
+        self.nodes[0] = start_node(0, self.options.tmpdir, ["-walletrejectlongchains", "-limitancestorcount="+str(2*chainlimit)])
+
+        # wait for loadmempool
+        timeout = 10
+        while (timeout > 0 and len(self.nodes[0].getrawmempool()) < chainlimit*2):
+            time.sleep(0.5)
+            timeout -= 0.5
+        assert_equal(len(self.nodes[0].getrawmempool()), chainlimit*2)
+
+        node0_balance = self.nodes[0].getbalance()
+        # With walletrejectlongchains we will not create the tx and store it in our wallet.
+        assert_raises_message(JSONRPCException, "mempool chain", self.nodes[0].sendtoaddress, sending_addr, node0_balance - Decimal('0.01'))
+
+        # Verify nothing new in wallet
+        assert_equal(total_txs, len(self.nodes[0].listtransactions("*",99999)))
 
 if __name__ == '__main__':
     WalletTest().main()


### PR DESCRIPTION
`txNew` was moved from to create `wtxNew` so we don't really mean to be accessing it afterwards.

The current code is not actually calculating mempool ancestors so `-walletrejectlongchains` is not having any effect.