### PR TITLE
Don't ask for TX relay from feeler connections

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -252,13 +252,15 @@ void PushNodeVersion(CNode *pnode, CConnman& connman, int64_t nTime)
     CAddress addrYou = (addr.IsRoutable() && !IsProxy(addr) ? addr : CAddress(CService(), addr.nServices));
     CAddress addrMe = CAddress(CService(), nLocalNodeServices);
 
-    connman.PushMessage(pnode, CNetMsgMaker(INIT_PROTO_VERSION).Make(NetMsgType::VERSION, PROTOCOL_VERSION, (uint64_t)nLocalNodeServices, nTime, addrYou, addrMe,
-            nonce, strSubVersion, nNodeStartingHeight, ::fRelayTxes));
+    bool fRelay = pnode->fFeeler ? false : ::fRelayTxes;
 
+    connman.PushMessage(pnode, CNetMsgMaker(INIT_PROTO_VERSION).Make(NetMsgType::VERSION, PROTOCOL_VERSION, (uint64_t)nLocalNodeServices, nTime, addrYou, addrMe,
+            nonce, strSubVersion, nNodeStartingHeight, fRelay));
+
+    std::string strThem;
     if (fLogIPs)
-        LogPrint("net", "send version message: version %d, blocks=%d, us=%s, them=%s, peer=%d\n", PROTOCOL_VERSION, nNodeStartingHeight, addrMe.ToString(), addrYou.ToString(), nodeid);
-    else
-        LogPrint("net", "send version message: version %d, blocks=%d, us=%s, peer=%d\n", PROTOCOL_VERSION, nNodeStartingHeight, addrMe.ToString(), nodeid);
+        strThem += strprintf("them=%s, ", addrYou.ToString());
+    LogPrint("net", "send version message: version %d, blocks=%d, relay=%s, us=%s, %speer=%d\n", PROTOCOL_VERSION, nNodeStartingHeight, fRelay ? "1" : "0", addrMe.ToString(), strThem, nodeid);
 }
 
 void InitializeNode(CNode *pnode, CConnman& connman) {


### PR DESCRIPTION
Although feeler connections are fairly brief (although not as brief as they used to be), we are not interested in receiving transactions from these connections therefore set relay to false when sending the version message.