### PR TITLE
Smarter coordination of change and fee in CreateTransaction.

### DIFF
--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -48,8 +48,10 @@ static const CAmount DEFAULT_TRANSACTION_FEE = 0;
 static const CAmount DEFAULT_FALLBACK_FEE = 20000;
 //! -mintxfee default
 static const CAmount DEFAULT_TRANSACTION_MINFEE = 1000;
-//! minimum change amount
+//! target minimum change amount
 static const CAmount MIN_CHANGE = CENT;
+//! final minimum change amount after paying for fees
+static const CAmount MIN_FINAL_CHANGE = MIN_CHANGE/2;
 //! Default for -spendzeroconfchange
 static const bool DEFAULT_SPEND_ZEROCONF_CHANGE = true;
 //! Default for -sendfreetransactions


### PR DESCRIPTION
Resolves #9466 

~~I feel bad making the wallet coin selection even more spaghetti like, but I think this is a huge improvement over the existing code and it's relatively simple to understand.~~

Essentially once you pick coins and if you have change, then try to reduce that change to meet the fee instead of repicking coins.  Since we aim to have change of .01 BTC if we can't make an exact match initially, this is usually more than sufficient to be reduced only slightly to pay for the fee.

I think for 0.15, we could take on a wholesale rewrite of the algorithm, but thats too much to ask for before 0.14. This however might be worthwhile.

~~I'm open to suggestions on how to make this cleaner or clearer.~~


EDIT: suggest viewing diff with `?w=1`

EDIT 2: This is much simpler now.  Also includes another commit to remove further cases of overpaying fees.