### PR TITLE
Allow shutdown during LoadMempool, dump only when necessary

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -130,6 +130,7 @@ static const char* FEE_ESTIMATES_FILENAME="fee_estimates.dat";
 //
 
 std::atomic<bool> fRequestShutdown(false);
+std::atomic<bool> fDumpMempoolLater(false);
 
 void StartShutdown()
 {
@@ -209,7 +210,8 @@ void Shutdown()
 
     StopTorControl();
     UnregisterNodeSignals(GetNodeSignals());
-    DumpMempool();
+    if (fDumpMempoolLater)
+        DumpMempool();
 
     if (fFeeEstimatesInitialized)
     {
@@ -667,6 +669,7 @@ void ThreadImport(std::vector<boost::filesystem::path> vImportFiles)
     }
     } // End scope of CImportingNow
     LoadMempool();
+    fDumpMempoolLater = !fRequestShutdown;
 }
 
 /** Sanity checks

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -444,6 +444,8 @@ void BitcoinApplication::requestShutdown()
     delete clientModel;
     clientModel = 0;
 
+    StartShutdown();
+
     // Request shutdown from core thread
     Q_EMIT requestedShutdown();
 }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4076,6 +4076,8 @@ bool LoadMempool(void)
             } else {
                 ++skipped;
             }
+            if (ShutdownRequested())
+                return false;
         }
         std::map<uint256, CAmount> mapDeltas;
         file >> mapDeltas;


### PR DESCRIPTION
A try to address #9398.
Right now, `LoadMempool()` has now "interruption point". If one triggers a shutdown, It will always wait until `LoadMempool()` has been completed.
This PR does detect a shutdown during the `LoadMempool()` while also taking care of not-dumping the mempool during shutdown if the user has request it before the import was completed.

Includes also a GUI fix that ensure proper shutdowns (right now, `StartShutdown()` is not called when quitting the GUI).

ping @sipa 
Needs testing (maybe @instagibbs?)