### PR TITLE
Reduce latency of ThreadMessageHandler. (3.2x speedup for IBD to 200k)

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1827,6 +1827,7 @@ void CConnman::ThreadMessageHandler()
 
     while (true)
     {
+        boost::system_time start_time = boost::posix_time::microsec_clock::universal_time();
         std::vector<CNode*> vNodesCopy;
         {
             LOCK(cs_vNodes);
@@ -1878,7 +1879,7 @@ void CConnman::ThreadMessageHandler()
         }
 
         if (fSleep)
-            messageHandlerCondition.timed_wait(lock, boost::posix_time::microsec_clock::universal_time() + boost::posix_time::milliseconds(100));
+            messageHandlerCondition.timed_wait(lock, start_time + boost::posix_time::milliseconds(100));
     }
 }
 

--- a/src/net.h
+++ b/src/net.h
@@ -154,7 +154,7 @@ public:
 
     void PushMessage(CNode* pnode, CSerializedNetMsg&& msg);
 
-    void WakeMessageHandler() { messageHandlerCondition.notify_one(); };
+    void WakeMessageHandler() { fMessageHandlerWork.store(true, std::memory_order_relaxed); messageHandlerCondition.notify_one(); };
 
     template<typename Callable>
     bool ForEachNodeContinueIf(Callable&& func)
@@ -405,6 +405,7 @@ private:
     mutable CCriticalSection cs_vNodes;
     std::atomic<NodeId> nLastNodeId;
     boost::condition_variable messageHandlerCondition;
+    std::atomic<bool> fMessageHandlerWork;
 
     /** Services this instance offers */
     ServiceFlags nLocalServices;

--- a/src/net.h
+++ b/src/net.h
@@ -154,6 +154,8 @@ public:
 
     void PushMessage(CNode* pnode, CSerializedNetMsg&& msg);
 
+    void WakeMessageHandler() { messageHandlerCondition.notify_one(); };
+
     template<typename Callable>
     bool ForEachNodeContinueIf(Callable&& func)
     {

--- a/src/net.h
+++ b/src/net.h
@@ -586,7 +586,7 @@ public:
     ServiceFlags nServices;
     ServiceFlags nServicesExpected;
     SOCKET hSocket;
-    size_t nSendSize; // total size of all vSendMsg entries
+    std::atomic<size_t> nSendSize; // total size of all vSendMsg entries
     size_t nSendOffset; // offset inside the first vSendMsg already sent
     uint64_t nSendBytes;
     std::deque<std::vector<unsigned char>> vSendMsg;
@@ -736,9 +736,9 @@ public:
     // requires LOCK(cs_vRecvMsg)
     bool ReceiveMsgBytes(const char *pch, unsigned int nBytes, bool& complete);
 
-    // requires LOCK(cs_vRecvMsg)
     void SetRecvVersion(int nVersionIn)
     {
+        LOCK(cs_vRecvMsg);
         nRecvVersion = nVersionIn;
         BOOST_FOREACH(CNetMessage &msg, vRecvMsg)
             msg.SetVersion(nVersionIn);

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2608,8 +2608,11 @@ bool SendMessages(CNode* pto, CConnman& connman)
         }
 
         TRY_LOCK(cs_main, lockMain); // Acquire cs_main for IsInitialBlockDownload() and CNodeState()
-        if (!lockMain)
+        if (!lockMain) {
+            // Couldn't make progress here, so we want to try again after handling other peers.
+            connman.WakeMessageHandler();
             return true;
+        }
 
         CNodeState &state = *State(pto->GetId());
 

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -770,6 +770,13 @@ UniValue submitblock(const JSONRPCRequest& request)
     }
     if (!sc.found)
         return "inconclusive";
+
+    if (g_connman && fAccepted)
+    {
+        // Wake up thread message handler so it sends out the block.
+        g_connman->WakeMessageHandler();
+    }
+
     return BIP22ValidationResult(sc.state);
 }
 


### PR DESCRIPTION
Instead of using a 100ms sleep in the condition variable, this changes
 it to sleep for 100ms after the loop started, so if the loop takes a
 long time (e.g. due to waiting on the vnodes lock at the end) it will
 restart sooner.

Also avoids a potential 100ms delay before announcing a new block that
 arrived via submitblock, prevents delays in processing messages for
 early peers when they arrive part way through the message handler loop,
 and reruns the message handler when some peers don't finish sendmessages
 due to contention for cs_main.

The final commit  changes the message handling to only hold cs_vRecvMsg long
enough to move out the message. This speeds up IBD up to 200k from a single
peer over GbE compared to master by about 200%, by eliminating cs_vRecvMsg
contention (that the prior commits happened to also make worse).  With this change
on both sides the speedup is ~3.2x.
