### PR TITLE
Fix linker error when configured with --enable-lcov

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -414,6 +414,8 @@ if test x$use_lcov = xyes; then
     AC_MSG_ERROR("lcov testing requested but genhtml not found")
   fi
   LCOV="$LCOV --gcov-tool=$GCOV"
+  AX_CHECK_LINK_FLAG([[--coverage]], [LDFLAGS="$LDFLAGS --coverage"],
+    [AC_MSG_ERROR("lcov testing requested but --coverage linker flag does not work")])
   AX_CHECK_COMPILE_FLAG([--coverage],[CXXFLAGS="$CXXFLAGS --coverage"],
     [AC_MSG_ERROR("lcov testing requested but --coverage flag does not work")])
 fi


### PR DESCRIPTION
Tested on OS X and Linux. Haven't tested on Windows. Can somebody check and see if this is necessary over there? I assume it is.