### PR TITLE
Use compact blocks for blocks that have equal work to our active tip

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1798,7 +1798,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         if (pindex->nStatus & BLOCK_HAVE_DATA) // Nothing to do here
             return true;
 
-        if (pindex->nChainWork <= chainActive.Tip()->nChainWork || // We know something better
+        if (pindex->nChainWork < chainActive.Tip()->nChainWork || // We know something better
                 pindex->nTx != 0) { // We had this block at some point, but pruned it
             if (fAlreadyInFlight) {
                 // We requested this block for some reason, but our mempool will probably be useless


### PR DESCRIPTION
Currently, the check for downloading a block is different here than it is in the parallel block fetch code, which means that we always request the full block when we could be using the compact block. This commit
allows the compact block received to be utilized.

As a future improvement, we can add logic to allow the TXs in the latest block to be utilized also, saving them from being re-fetched due to not being in the mempool.