### PR TITLE
WIP: Don't download blocks unless they have more work than our current best

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -473,7 +473,7 @@ void FindNextBlocksToDownload(NodeId nodeid, unsigned int count, std::vector<CBl
     // Make sure pindexBestKnownBlock is up to date, we'll need it.
     ProcessBlockAvailability(nodeid);
 
-    if (state->pindexBestKnownBlock == NULL || state->pindexBestKnownBlock->nChainWork < chainActive.Tip()->nChainWork) {
+    if (state->pindexBestKnownBlock == NULL || state->pindexBestKnownBlock->nChainWork <= chainActive.Tip()->nChainWork) {
         // This peer has nothing interesting.
         return;
     }
@@ -1798,7 +1798,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         if (pindex->nStatus & BLOCK_HAVE_DATA) // Nothing to do here
             return true;
 
-        if (pindex->nChainWork <= chainActive.Tip()->nChainWork || // We know something better
+        if (pindex->nChainWork <= chainActive.Tip()->nChainWork || // We know something better or as good
                 pindex->nTx != 0) { // We had this block at some point, but pruned it
             if (fAlreadyInFlight) {
                 // We requested this block for some reason, but our mempool will probably be useless


### PR DESCRIPTION
An alternative to #9427. #9427 assumes we wanted to download the block but more efficiently than was being done, whereas this PR assumes we don't need the block at all, until circumstances suggest we do (i.e. it's forming the longer chain).

To elaborate:-

Currently the logic for compact blocks is that it is now requested unless the work is greater than our current best, whereas the parallel fetch logic will still request blocks with work equal to our current best, which means that for competing blocks we always requested the full block even though we could have used the compact block received.

Rather than utilize the compact block, we don't need to download the block at all (saving disk space) until we are sure that it's part of a longer chain.