### PR TITLE
Allow 2 simultaneous block downloads

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2047,7 +2047,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
 
         if (pindex->nChainWork <= chainActive.Tip()->nChainWork || // We know something better
                 pindex->nTx != 0) { // We had this block at some point, but pruned it
-            if (fAlreadyInFlight) {
+            if (fInFlightFromSamePeer) {
                 // We requested this block for some reason, but our mempool will probably be useless
                 // so we just grab the block via normal getdata
                 std::vector<CInv> vInv(1);
@@ -2134,7 +2134,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
                 }
             }
         } else {
-            if (fAlreadyInFlight) {
+            if (fInFlightFromSamePeer) {
                 // We requested this block, but its far into the future, so our
                 // mempool will probably be useless - request the block normally
                 std::vector<CInv> vInv(1);

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -9,6 +9,8 @@
 #include "net.h"
 #include "validationinterface.h"
 
+/** Maximum number of outstanding CMPCTBLOCK requests for the same block. */
+static const int MAX_CMPCTBLOCKS_INFLIGHT_PER_BLOCK = 2;
 /** Default for -maxorphantx, maximum number of orphan transactions kept in memory */
 static const unsigned int DEFAULT_MAX_ORPHAN_TRANSACTIONS = 100;
 /** Expiration time for orphan transactions in seconds */


### PR DESCRIPTION
This is built off of #9375, #9252, and #9400.  I'll properly rebase it when those are merged.

It provides special logic to issue a second getdata request for a cmpctblock if there is only 1 request outstanding and we think the announced block would be our new tip.

It also changes the cmpctblock processing logic to be first come first served (regardless of in flight block requests) and allow two simultaneous compact block reconstructions.  

So in particular, it is now possible to:
- receive headers -> request cmpctblock from peer 1
- receive headers -> request cmpctblock from peer 2
- receive cmpctblock -> request blocktxn from peer 3
- receive cmpctblock -> request blocktxn from peer 4

Upon receiving a cmpctblock from peers 1 or 2 after this, it will be treated the same as receiving an unsolicited cmpctblock from peer 5 and it will attempt opportunistic reconstruction but not request blocktxn.  It will also remove the block in flight for peer 1 or 2.

I believe that the multiple requests is an acceptable increase in bandwidth in order to provide robustness against a single peer stalling us at any point in the logic.  The reason to allow a second request for a cmpctblock is to allow LB peers a chance to become HB even if there is a staller who is always announcing first, otherwise, only existing HB peers would have a chance to deliver the block.


