### PR TITLE
CScript: remove redundant bounds check

### DIFF
--- a/src/script/script.h
+++ b/src/script/script.h
@@ -508,8 +508,7 @@ public:
             return false;
 
         // Read instruction
-        if (end() - pc < 1)
-            return false;
+        // guaranteed one opcode available from check above
         unsigned int opcode = *pc++;
 
         // Immediate operand


### PR DESCRIPTION
`CScript::GetOp2(..)` performed two equivalent bounds checks, one was removed as redundant.