### PR TITLE
Improvements to copyright_header.py and some minor copyright header tweaks.

### DIFF
--- a/contrib/devtools/README.md
+++ b/contrib/devtools/README.md
@@ -23,24 +23,37 @@ git diff -U0 HEAD~1.. | ./contrib/devtools/clang-format-diff.py -p1 -i -v
 copyright\_header.py
 ====================
 
-Provides utilities for managing copyright headers of `The Bitcoin Core
-developers` in repository source files. It has three subcommands:
+Provides utilities for managing copyright headers in repository source files.
+It has four subcommands:
 
 ```
-$ ./copyright_header.py report <base_directory> [verbose]
+$ ./copyright_header.py report <base_directory>
+$ ./copyright_header.py check <base_directory>
 $ ./copyright_header.py update <base_directory>
 $ ./copyright_header.py insert <file>
 ```
 Running these subcommands without arguments displays a usage string.
 
-copyright\_header.py report \<base\_directory\> [verbose]
+copyright\_header.py report \<base\_directory\>
 ---------------------------------------------------------
 
 Produces a report of all copyright header notices found inside the source files
-of a repository. Useful to quickly visualize the state of the headers.
-Specifying `verbose` will list the full filenames of files of each category.
+of a repository. Useful to quickly visualize the state of the headers in the
+repository. If there are issues found, the specific files are listed with a
+summary of what the issue is.
 
-copyright\_header.py update \<base\_directory\> [verbose]
+copyright\_header.py check \<base\_directory\>
+---------------------------------------------------------
+
+Similar to the `report` command, but is for a more straightforward check meant
+to accept or reject the state of the repository. If no issues are found, it
+returns a zero status. If issues are found it returns a non-zero status and
+also lists the specific files and gives a suggestion for how to resolve the
+issue. Resolution involves either fixing the file (because there was a
+legitimate problem) or updating the script's rules (because making an exception
+is appropriate).
+
+copyright\_header.py update \<base\_directory\>
 ---------------------------------------------------------
 Updates all the copyright headers of `The Bitcoin Core developers` which were
 changed in a year more recent than is listed. For example:

--- a/contrib/devtools/gen-manpages.sh
+++ b/contrib/devtools/gen-manpages.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+# Copyright (c) 2016 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 TOPDIR=${TOPDIR:-$(git rev-parse --show-toplevel)}
 SRCDIR=${SRCDIR:-$TOPDIR/src}

--- a/contrib/linearize/linearize-data.py
+++ b/contrib/linearize/linearize-data.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python3
-#
-# linearize-data.py: Construct a linear, no-fork version of the chain.
-#
 # Copyright (c) 2013-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#
+# linearize-data.py: Construct a linear, no-fork version of the chain.
 #
 
 from __future__ import print_function, division

--- a/contrib/linearize/linearize-hashes.py
+++ b/contrib/linearize/linearize-hashes.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python3
-#
-# linearize-hashes.py:  List blocks in a linear, no-fork version of the chain.
-#
 # Copyright (c) 2013-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#
+# linearize-hashes.py:  List blocks in a linear, no-fork version of the chain.
 #
 
 from __future__ import print_function

--- a/qa/rpc-tests/test_framework/blocktools.py
+++ b/qa/rpc-tests/test_framework/blocktools.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
-# blocktools.py - utilities for manipulating blocks and transactions
 # Copyright (c) 2015-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#
+# blocktools.py - utilities for manipulating blocks and transactions
 
 from .mininode import *
 from .script import CScript, OP_TRUE, OP_CHECKSIG, OP_RETURN

--- a/share/rpcuser/rpcuser.py
+++ b/share/rpcuser/rpcuser.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python2 
 # Copyright (c) 2015-2016 The Bitcoin Core developers
-# Distributed under the MIT software license, see the accompanying 
+# Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 import hashlib

--- a/src/test/bctest.py
+++ b/src/test/bctest.py
@@ -1,5 +1,5 @@
-# Copyright 2014 BitPay Inc.
-# Copyright 2016 The Bitcoin Core developers
+# Copyright (c) 2014 BitPay Inc.
+# Copyright (c) 2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 from __future__ import division,print_function,unicode_literals

--- a/src/test/bitcoin-util-test.py
+++ b/src/test/bitcoin-util-test.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-# Copyright 2014 BitPay Inc.
-# Copyright 2016 The Bitcoin Core developers
+# Copyright (c) 2014 BitPay Inc.
+# Copyright (c) 2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 from __future__ import division,print_function,unicode_literals

--- a/src/test/pow_tests.cpp
+++ b/src/test/pow_tests.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2015 The Bitcoin Core developers
-// Distributed under the MIT/X11 software license, see the accompanying
+// Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "chain.h"


### PR DESCRIPTION
This is a re-submission of PR #9453 with the TravisCI integration and language removed based on feedback.

The changes are a significant iteration to `contrib/devtools/copyright_header.py`. Like the preceding version, this script is able to parse through the source files and report on the state of the copyright headers as well as update the year.

The first major improvement is that it now has a ruleset specific for each subtree to detect the local proper header style (the subtrees being secp256k1, leveldb, univalue and ctaes).

The second major improvement is that it now makes more elegant use of Python's regular expressions to detect and manipulate the header text. This approach should be maintainable and extensible while keeping the script's execution time quick.

The third major improvement is the addition of a `check` command which gives a positive or negative acceptance for the state of the repository according to the rules of the script. When issues are found, it also gives more direct suggestions for how to resolve. The purpose is to better assist periodic maintenance of the state of the copyright headers.


Also, some minor tweaks are done to make the set of copyright headers more consistent. The addition of the MIT license header to `contrib/dev/tools/gen-manpages.sh` was previously ACKed by @nomnombtc in #9453.