### PR TITLE
[Qt] Improve progress display during headers-sync and peer-finding

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -748,6 +748,15 @@ void BitcoinGUI::setNetworkActive(bool networkActive)
     updateNetworkState();
 }
 
+void BitcoinGUI::updateHeadersSyncProgressLabel()
+{
+    int64_t headersTipTime = clientModel->getHeaderTipTime();
+    int headersTipHeight = clientModel->getHeaderTipHeight();
+    int estHeadersLeft = (GetTime() - headersTipTime)/600;
+    if (estHeadersLeft > REQ_HEADER_HEIGHT_DELTA_SYNC)
+        progressBarLabel->setText(tr("Syncing Headers (%1%)...").arg(QString::number(100.0 / (headersTipHeight+estHeadersLeft)*headersTipHeight, 'f', 1)));
+}
+
 void BitcoinGUI::setNumBlocks(int count, const QDateTime& blockDate, double nVerificationProgress, bool header)
 {
     if (modalOverlay)
@@ -768,9 +777,11 @@ void BitcoinGUI::setNumBlocks(int count, const QDateTime& blockDate, double nVer
     switch (blockSource) {
         case BLOCK_SOURCE_NETWORK:
             if (header) {
+                updateHeadersSyncProgressLabel();
                 return;
             }
             progressBarLabel->setText(tr("Synchronizing with network..."));
+            updateHeadersSyncProgressLabel();
             break;
         case BLOCK_SOURCE_DISK:
             if (header) {
@@ -786,8 +797,7 @@ void BitcoinGUI::setNumBlocks(int count, const QDateTime& blockDate, double nVer
             if (header) {
                 return;
             }
-            // Case: not Importing, not Reindexing and no network connection
-            progressBarLabel->setText(tr("No block source available..."));
+            progressBarLabel->setText(tr("Connecting to peers..."));
             break;
     }
 

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -149,6 +149,8 @@ private:
     /** Update UI with latest network info from model. */
     void updateNetworkState();
 
+    void updateHeadersSyncProgressLabel();
+
 Q_SIGNALS:
     /** Signal raised when a URI was entered or dragged to the GUI */
     void receivedURI(const QString &uri);

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -66,7 +66,7 @@ public:
 
     //! Return true if core is doing initial block download
     bool inInitialBlockDownload() const;
-    //! Return true if core is importing blocks
+    //! Returns enum BlockSource of the current importing/syncing state
     enum BlockSource getBlockSource() const;
     //! Return true if network activity in core is enabled
     bool getNetworkActive() const;

--- a/src/qt/modaloverlay.h
+++ b/src/qt/modaloverlay.h
@@ -8,6 +8,9 @@
 #include <QDateTime>
 #include <QWidget>
 
+//! The required delta of headers to the estimated number of available headers until we show the IBD progress
+static const int REQ_HEADER_HEIGHT_DELTA_SYNC = 24;
+
 namespace Ui {
     class ModalOverlay;
 }


### PR DESCRIPTION
Stumbled over this during some Core-SPV work.

After a fresh start (especially if no `peers.dat` file is available), it can take a couple of seconds until we can start syncing. During this time, the user is not directly informed about the current state.

Same problem appears when syncing headers. If you download the headers from a slow peer, this can take a couple of minutes.
Users can't see the reason why the sync hasn't started.

This PR fixes this by displaying the "Connecting to peers..." in the Status-Bar when no peers are available as well as it shows "Syncing Headers (%%)..." during the headers-sync phase and only if the headers-tip is older then 24*600.


Screenshots:

<img width="948" alt="bildschirmfoto 2017-01-03 um 15 16 25" src="https://cloud.githubusercontent.com/assets/178464/21611330/b21400c6-d1cc-11e6-8627-59bbf149930a.png">
<img width="948" alt="bildschirmfoto 2017-01-03 um 15 32 41" src="https://cloud.githubusercontent.com/assets/178464/21611329/b1ee62e4-d1cc-11e6-9e76-bbb0b6487f75.png">