### PR TITLE
[Trivial] [Doc] Install Protobuf v3 on OS X

### DIFF
--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -16,7 +16,7 @@ Then install [Homebrew](http://brew.sh).
 Dependencies
 ----------------------
 
-    brew install automake berkeley-db4 libtool boost --c++11 miniupnpc openssl pkg-config homebrew/versions/protobuf260 --c++11 qt5 libevent
+    brew install automake berkeley-db4 libtool boost --c++11 miniupnpc openssl pkg-config protobuf --c++11 qt5 libevent
 
 In case you want to build the disk image with `make deploy` (.dmg / optional), you need RSVG
 


### PR DESCRIPTION
After the changes in #9366, we no longer need to use Protobuf 2.60. 

Basically reverting #8754.