### PR TITLE
[Qt] Show more significant warning if we fall back to the default fee

### DIFF
--- a/src/qt/forms/sendcoinsdialog.ui
+++ b/src/qt/forms/sendcoinsdialog.ui
@@ -760,9 +760,29 @@
            </layout>
           </item>
           <item>
+           <widget class="QLabel" name="fallbackFeeWarningLabel">
+            <property name="toolTip">
+             <string>Using the fallbackfee can result in sending a transaction that will take serval hours or days (or never) to confirm. Consider choosing your fee manually or wait until your have validated the complete chain.</string>
+            </property>
+            <property name="styleSheet">
+             <string notr="true">color: rgb(255, 150, 0);
+font-weight: bold;</string>
+            </property>
+            <property name="text">
+             <string>Warning: Fee estimation is currently not possible.</string>
+            </property>
+            <property name="wordWrap">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
            <spacer name="horizontalSpacer_4">
             <property name="orientation">
              <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeType">
+             <enum>QSizePolicy::MinimumExpanding</enum>
             </property>
             <property name="sizeHint" stdset="0">
              <size>

--- a/src/qt/forms/sendcoinsdialog.ui
+++ b/src/qt/forms/sendcoinsdialog.ui
@@ -764,9 +764,11 @@
             <property name="toolTip">
              <string>Using the fallbackfee can result in sending a transaction that will take serval hours or days (or never) to confirm. Consider choosing your fee manually or wait until your have validated the complete chain.</string>
             </property>
-            <property name="styleSheet">
-             <string notr="true">color: rgb(255, 150, 0);
-font-weight: bold;</string>
+            <property name="font">
+            <font>
+                <weight>75</weight>
+                <bold>true</bold>
+            </font>
             </property>
             <property name="text">
              <string>Warning: Fee estimation is currently not possible.</string>

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -655,6 +655,7 @@ void SendCoinsDialog::updateSmartFeeLabel()
                                                                 std::max(CWallet::fallbackFee.GetFeePerK(), CWallet::GetRequiredFee(1000))) + "/kB");
         ui->labelSmartFee2->show(); // (Smart fee not initialized yet. This usually takes a few blocks...)
         ui->labelFeeEstimation->setText("");
+        ui->fallbackFeeWarningLabel->setVisible(true);
     }
     else
     {
@@ -662,6 +663,7 @@ void SendCoinsDialog::updateSmartFeeLabel()
                                                                 std::max(feeRate.GetFeePerK(), CWallet::GetRequiredFee(1000))) + "/kB");
         ui->labelSmartFee2->hide();
         ui->labelFeeEstimation->setText(tr("Estimated to begin confirmation within %n block(s).", "", estimateFoundAtBlocks));
+        ui->fallbackFeeWarningLabel->setVisible(false);
     }
 
     updateFeeMinimizedLabel();

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -22,6 +22,7 @@
 #include "txmempool.h"
 #include "wallet/wallet.h"
 
+#include <QFontMetrics>
 #include <QMessageBox>
 #include <QScrollBar>
 #include <QSettings>
@@ -659,6 +660,7 @@ void SendCoinsDialog::updateSmartFeeLabel()
         int lightness = ui->fallbackFeeWarningLabel->palette().color(QPalette::WindowText).lightness();
         QColor warning_colour(255 - (lightness / 5), 176 - (lightness / 3), 48 - (lightness / 14));
         ui->fallbackFeeWarningLabel->setStyleSheet("QLabel { color: " + warning_colour.name() + "; }");
+        ui->fallbackFeeWarningLabel->setIndent(QFontMetrics(ui->fallbackFeeWarningLabel->font()).width("x"));
     }
     else
     {

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -656,6 +656,9 @@ void SendCoinsDialog::updateSmartFeeLabel()
         ui->labelSmartFee2->show(); // (Smart fee not initialized yet. This usually takes a few blocks...)
         ui->labelFeeEstimation->setText("");
         ui->fallbackFeeWarningLabel->setVisible(true);
+        int lightness = ui->fallbackFeeWarningLabel->palette().color(QPalette::WindowText).lightness();
+        QColor warning_colour(255 - (lightness / 5), 176 - (lightness / 3), 48 - (lightness / 14));
+        ui->fallbackFeeWarningLabel->setStyleSheet("QLabel { color: " + warning_colour.name() + "; }");
     }
     else
     {


### PR DESCRIPTION
There are multiple reports (bitcoin.stackoverflow, etc.) from users sending (very-)low-fee-transactions with bitcoin-core.
The reason for this is probably that some users are not waiting long enough until smartfee estimation is possible.
The current fallback fee is `0.0002BTC/kb`, one of my ~0.13.0 nodes is telling me `0.00069534` for a confirmation target of 25 blocks. Using the current fallback fee can be troublesome.

If we have to use the fallback-ferrate, we should probably warn the user more significant (there is no "warning" right now.).

Screenshots:
<img width="1056" alt="bildschirmfoto 2017-01-06 um 11 00 07" src="https://cloud.githubusercontent.com/assets/178464/21714484/7b16f4a4-d3ff-11e6-90f1-2f7aaf86673a.png">
<img width="1056" alt="bildschirmfoto 2017-01-06 um 11 00 09" src="https://cloud.githubusercontent.com/assets/178464/21714485/7b394a90-d3ff-11e6-9c3c-1a28a5f591f1.png">
<img width="208" alt="bildschirmfoto 2017-01-06 um 11 02 18" src="https://cloud.githubusercontent.com/assets/178464/21714503/9ca054da-d3ff-11e6-87c9-304ac1d5b1b7.png">
