### PR TITLE
Remove stray semicolon (Fix empty body warning)

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1804,7 +1804,7 @@ void CConnman::ThreadOpenAddedConnections()
             }
         }
         // Retry every 60 seconds if a connection was attempted, otherwise two seconds
-        if (!interruptNet.sleep_for(std::chrono::seconds(tried ? 60 : 2)));
+        if (!interruptNet.sleep_for(std::chrono::seconds(tried ? 60 : 2)))
             return;
     }
 }


### PR DESCRIPTION
Empty body introduced by commit #9319 should not be empty.