### PR TITLE
Prevector Quick Destruct

### DIFF
--- a/src/Makefile.bench.include
+++ b/src/Makefile.bench.include
@@ -24,7 +24,8 @@ bench_bench_bitcoin_SOURCES = \
   bench/base58.cpp \
   bench/lockedpool.cpp \
   bench/perf.cpp \
-  bench/perf.h
+  bench/perf.h \
+  bench/prevector_destructor.cpp
 
 nodist_bench_bench_bitcoin_SOURCES = $(GENERATED_TEST_FILES)
 

--- a/src/bench/prevector_destructor.cpp
+++ b/src/bench/prevector_destructor.cpp
@@ -1,0 +1,36 @@
+// Copyright (c) 2015-2017 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "bench.h"
+#include "prevector.h"
+
+static void PrevectorDestructor(benchmark::State& state)
+{
+    while (state.KeepRunning()) {
+        for (auto x = 0; x < 1000; ++x) {
+            prevector<28, unsigned char> t0;
+            prevector<28, unsigned char> t1;
+            t0.resize(28);
+            t1.resize(29);
+        }
+    }
+}
+
+static void PrevectorClear(benchmark::State& state)
+{
+
+    while (state.KeepRunning()) {
+        for (auto x = 0; x < 1000; ++x) {
+            prevector<28, unsigned char> t0;
+            prevector<28, unsigned char> t1;
+            t0.resize(28);
+            t0.clear();
+            t1.resize(29);
+            t0.clear();
+        }
+    }
+}
+
+BENCHMARK(PrevectorDestructor);
+BENCHMARK(PrevectorClear);

--- a/src/prevector.h
+++ b/src/prevector.h
@@ -10,6 +10,7 @@
 #include <string.h>
 
 #include <iterator>
+#include <type_traits>
 
 #pragma pack(push, 1)
 /** Implements a drop-in replacement for std::vector<T> which stores up to N
@@ -382,10 +383,14 @@ public:
     iterator erase(iterator first, iterator last) {
         iterator p = first;
         char* endp = (char*)&(*end());
-        while (p != last) {
-            (*p).~T();
-            _size--;
-            ++p;
+        if (!std::is_trivially_destructible<T>::value) {
+            while (p != last) {
+                (*p).~T();
+                _size--;
+                ++p;
+            }
+        } else {
+            _size -= last - p;
         }
         memmove(&(*first), &(*last), endp - ((char*)(&(*last))));
         return first;
@@ -426,7 +431,9 @@ public:
     }
 
     ~prevector() {
-        clear();
+        if (!std::is_trivially_destructible<T>::value) {
+            clear();
+        }
         if (!is_direct()) {
             free(_union.indirect);
             _union.indirect = NULL;


### PR DESCRIPTION
This is a minor performance optimization of prevector. If the stored type is trivially destructible (such as unsigned char which is the main use of prevector), there is no need to call clear on the entries before freeing.

The call to clear seems to not get optimized out completely (likely because of the `--_size;` side-effect) with `-O3`.

`std::is_trivially_copyable` seems to enjoy full cross platform support.

On the included benchmark, I see about a 3% performance improvement.