### PR TITLE
RFC: Improve style for if indentation

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -11,9 +11,13 @@ gradually.
   - Braces on new lines for namespaces, classes, functions, methods.
   - Braces on the same line for everything else.
   - 4 space indentation (no tabs) for every block except namespaces.
-  - No indentation for public/protected/private or for namespaces.
+  - No indentation for `public`/`protected`/`private` or for `namespace`.
   - No extra spaces inside parenthesis; don't do ( this )
-  - No space after function names; one space after if, for and while.
+  - No space after function names; one space after `if`, `for` and `while`.
+  - If an `if` only has a single-statement then-clause, it can appear
+    on the same line as the if, without braces. In every other case,
+    braces are required, and the then and else clauses must appear
+    correctly indented on a new line.
   - `++i` is preferred over `i++`.
 
 Block style example:
@@ -22,14 +26,18 @@ namespace foo
 {
 class Class
 {
-    bool Function(char* psz, int n)
+    bool Function(const std::string& s, int n)
     {
         // Comment summarising what this section of code does
         for (int i = 0; i < n; ++i) {
             // When something fails, return early
-            if (!Something())
-                return false;
+            if (!Something()) return false;
             ...
+            if (SomethingElse()) {
+                DoMore();
+            } else {
+                DoLess();
+            }
         }
 
         // Success return is usually at the end


### PR DESCRIPTION
Lately there have been a few discussions about the indentation/braces recommendations for `if` statements. I believe the current text in doc/developer-notes.md does not follow best practices (see for example http://www.dwheeler.com/essays/apple-goto-fail.html), and is in fact not being actively encouraged anymore in review either, so I'd like to change it.

Feel free to bikeshed this to death.