### PR TITLE
Fix use-after-free in CTxMemPool::removeConflicts()

### DIFF
--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -581,8 +581,8 @@ void CTxMemPool::removeConflicts(const CTransaction &tx)
             const CTransaction &txConflict = *it->second;
             if (txConflict != tx)
             {
-                removeRecursive(txConflict);
                 ClearPrioritisation(txConflict.GetHash());
+                removeRecursive(txConflict);
             }
         }
     }


### PR DESCRIPTION
Reported by @sipa