### PR TITLE
Fix various things -fsanitize complains about

### DIFF
--- a/src/crypto/common.h
+++ b/src/crypto/common.h
@@ -10,57 +10,73 @@
 #endif
 
 #include <stdint.h>
+#include <string.h>
 
 #include "compat/endian.h"
 
 uint16_t static inline ReadLE16(const unsigned char* ptr)
 {
-    return le16toh(*((uint16_t*)ptr));
+    uint16_t x;
+    memcpy((char*)&x, ptr, 2);
+    return le16toh(x);
 }
 
 uint32_t static inline ReadLE32(const unsigned char* ptr)
 {
-    return le32toh(*((uint32_t*)ptr));
+    uint32_t x;
+    memcpy((char*)&x, ptr, 4);
+    return le32toh(x);
 }
 
 uint64_t static inline ReadLE64(const unsigned char* ptr)
 {
-    return le64toh(*((uint64_t*)ptr));
+    uint64_t x;
+    memcpy((char*)&x, ptr, 8);
+    return le64toh(x);
 }
 
 void static inline WriteLE16(unsigned char* ptr, uint16_t x)
 {
-    *((uint16_t*)ptr) = htole16(x);
+    uint16_t v = htole16(x);
+    memcpy(ptr, (char*)&v, 2);
 }
 
 void static inline WriteLE32(unsigned char* ptr, uint32_t x)
 {
-    *((uint32_t*)ptr) = htole32(x);
+    uint32_t v = htole32(x);
+    memcpy(ptr, (char*)&v, 4);
 }
 
 void static inline WriteLE64(unsigned char* ptr, uint64_t x)
 {
-    *((uint64_t*)ptr) = htole64(x);
+    uint64_t v = htole64(x);
+    memcpy(ptr, (char*)&v, 8);
 }
 
 uint32_t static inline ReadBE32(const unsigned char* ptr)
 {
-    return be32toh(*((uint32_t*)ptr));
+    uint32_t x;
+    memcpy((char*)&x, ptr, 4);
+    return be32toh(x);
 }
 
 uint64_t static inline ReadBE64(const unsigned char* ptr)
 {
-    return be64toh(*((uint64_t*)ptr));
+    uint64_t x;
+    memcpy((char*)&x, ptr, 8);
+    return be64toh(x);
 }
 
 void static inline WriteBE32(unsigned char* ptr, uint32_t x)
 {
-    *((uint32_t*)ptr) = htobe32(x);
+    uint32_t v = htobe32(x);
+    memcpy(ptr, (char*)&v, 4);
 }
 
 void static inline WriteBE64(unsigned char* ptr, uint64_t x)
 {
-    *((uint64_t*)ptr) = htobe64(x);
+    uint64_t v = htobe64(x);
+    memcpy(ptr, (char*)&v, 8);
 }
 
 #endif // BITCOIN_CRYPTO_COMMON_H

--- a/src/httprpc.cpp
+++ b/src/httprpc.cpp
@@ -113,8 +113,8 @@ static bool multiUserAuthorized(std::string strUserPass)
             std::string strHash = vFields[2];
 
             unsigned int KEY_SIZE = 32;
-            unsigned char *out = new unsigned char[KEY_SIZE]; 
-            
+            unsigned char out[KEY_SIZE];
+
             CHMAC_SHA256(reinterpret_cast<const unsigned char*>(strSalt.c_str()), strSalt.size()).Write(reinterpret_cast<const unsigned char*>(strPass.c_str()), strPass.size()).Finalize(out);
             std::vector<unsigned char> hexvec(out, out+KEY_SIZE);
             std::string strHashFromPass = HexStr(hexvec);

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -162,12 +162,12 @@ BOOST_AUTO_TEST_CASE(cnode_simple_test)
     bool fInboundIn = false;
 
     // Test that fFeeler is false by default.
-    CNode* pnode1 = new CNode(id++, NODE_NETWORK, height, hSocket, addr, 0, 0, pszDest, fInboundIn);
+    std::unique_ptr<CNode> pnode1(new CNode(id++, NODE_NETWORK, height, hSocket, addr, 0, 0, pszDest, fInboundIn));
     BOOST_CHECK(pnode1->fInbound == false);
     BOOST_CHECK(pnode1->fFeeler == false);
 
     fInboundIn = true;
-    CNode* pnode2 = new CNode(id++, NODE_NETWORK, height, hSocket, addr, 1, 1, pszDest, fInboundIn);
+    std::unique_ptr<CNode> pnode2(new CNode(id++, NODE_NETWORK, height, hSocket, addr, 1, 1, pszDest, fInboundIn));
     BOOST_CHECK(pnode2->fInbound == true);
     BOOST_CHECK(pnode2->fFeeler == false);
 }

--- a/src/test/scriptnum_tests.cpp
+++ b/src/test/scriptnum_tests.cpp
@@ -12,8 +12,10 @@
 
 BOOST_FIXTURE_TEST_SUITE(scriptnum_tests, BasicTestingSetup)
 
-static const int64_t values[] = \
-{ 0, 1, CHAR_MIN, CHAR_MAX, UCHAR_MAX, SHRT_MIN, USHRT_MAX, INT_MIN, INT_MAX, UINT_MAX, LONG_MIN, LONG_MAX };
+/** A selection of numbers that do not trigger int64_t overflow
+ *  when added/subtracted. */
+static const int64_t values[] = { 0, 1, -2, 127, 128, -255, 256, (1LL << 15) - 1, -(1LL << 16), (1LL << 24) - 1, (1LL << 31), 1 - (1LL << 32), 1LL << 40 };
+
 static const int64_t offsets[] = { 1, 0x79, 0x80, 0x81, 0xFF, 0x7FFF, 0x8000, 0xFFFF, 0x10000};
 
 static bool verify(const CScriptNum10& bignum, const CScriptNum& scriptnum)

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -23,6 +23,8 @@
 
 using namespace std;
 
+std::vector<std::unique_ptr<CWalletTx>> wtxn;
+
 typedef set<pair<const CWalletTx*,unsigned int> > CoinSet;
 
 BOOST_FIXTURE_TEST_SUITE(wallet_tests, WalletTestingSetup)
@@ -42,21 +44,21 @@ static void add_coin(const CAmount& nValue, int nAge = 6*24, bool fIsFromMe = fa
         // so stop vin being empty, and cache a non-zero Debit to fake out IsFromMe()
         tx.vin.resize(1);
     }
-    CWalletTx* wtx = new CWalletTx(&wallet, MakeTransactionRef(std::move(tx)));
+    std::unique_ptr<CWalletTx> wtx(new CWalletTx(&wallet, MakeTransactionRef(std::move(tx))));
     if (fIsFromMe)
     {
         wtx->fDebitCached = true;
         wtx->nDebitCached = 1;
     }
-    COutput output(wtx, nInput, nAge, true, true);
+    COutput output(wtx.get(), nInput, nAge, true, true);
     vCoins.push_back(output);
+    wtxn.emplace_back(std::move(wtx));
 }
 
 static void empty_wallet(void)
 {
-    BOOST_FOREACH(COutput output, vCoins)
-        delete output.tx;
     vCoins.clear();
+    wtxn.clear();
 }
 
 static bool equal_sets(CoinSet a, CoinSet b)
@@ -349,6 +351,8 @@ BOOST_AUTO_TEST_CASE(ApproximateBestSubset)
     BOOST_CHECK(wallet.SelectCoinsMinConf(1003 * COIN, 1, 6, 0, vCoins, setCoinsRet, nValueRet));
     BOOST_CHECK_EQUAL(nValueRet, 1003 * COIN);
     BOOST_CHECK_EQUAL(setCoinsRet.size(), 2U);
+
+    empty_wallet();
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
* The ReadLE32 etc functions in crypto/common.h where dereferencing type-punned pointers, which is undefined behaviour (and can cause consistent failure on some platforms due to misaligned reads). Fix this by `memcpy()`ing into a local variable first (as accessing a type's representation through a char* is always allowed).
* The scriptnum tests were testing running several arithmetic operations on large integers, triggering signed integer overflow, which is undefined. Fix the tests by using integers limited to +/- 2^40 (larger than anything actually supported in script).
* Fix a memory leak in the wallet tests: CWalletTx objects that weren't freed - wrap them in a unique_ptr.
* Fix a memory leak in the net tests: a CNode object wasn't being freed - wrap them in a unique_ptr.
* Fix a memory leak in the rpc auth: a buffer that wasn't being freed - switch it to a stack-allocated array.
* The REST code for getutxos was using boost::dynamic_bitset, which apparently issues a rightshift by a negative amount. Fix this by replacing it with normal bit/byte vectors.

Now all unit tests and rpc tests run succesfully with -fsanitize=address -fsanitize=undefined -fsanitize=leak in GCC 6.2.0.

Thanks to @kcc for pointing me to these tools.