### PR TITLE
build: fix qt distdir builds (retry)

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -354,7 +354,7 @@ endif
 
 RES_IMAGES = 
 
-RES_MOVIES = $(wildcard qt/res/movies/spinner-*.png)
+RES_MOVIES = $(wildcard $(srcdir)/qt/res/movies/spinner-*.png)
 
 BITCOIN_RC = qt/res/bitcoin-qt-res.rc
 


### PR DESCRIPTION
Retrying #9509.

The actual issue seems to be that the source files aren't found when creating the distdir. Ideally we'd get rid of the wildcard and just enumerate all files. But this seems to work too.

(Hopefully) fixes the issue presented by #9416.