### PR TITLE
rpc: Don't FlushStateToDisk when pruneblockchain(0)

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -835,6 +835,10 @@ UniValue pruneblockchain(const JSONRPCRequest& request)
     int heightParam = request.params[0].get_int();
     if (heightParam < 0)
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Negative block height.");
+    if (heightParam == 0) {
+        // Nothing to do here
+        return uint64_t(0);
+    }
 
     // Height value more than a billion is too high to be a block height, and
     // too low to be a block time (corresponds to timestamp from Sep 2001).


### PR DESCRIPTION
Currently pruneblockchain(0) will call StateFlushToDisk. This might not be required/wanted, as the internal code appears to be using 0 to indicate "legacy" pruning.