### PR TITLE
Bug fix: Update the instance variable self.lastDate (not the locally scoped variable lastDate)

### DIFF
--- a/contrib/linearize/linearize-data.py
+++ b/contrib/linearize/linearize-data.py
@@ -149,7 +149,7 @@ class BlockDataCopier:
 		(blkDate, blkTS) = get_blk_dt(blk_hdr)
 		if self.timestampSplit and (blkDate > self.lastDate):
 			print("New month " + blkDate.strftime("%Y-%m") + " @ " + hash_str)
-			lastDate = blkDate
+			self.lastDate = blkDate
 			if outF:
 				outF.close()
 				if setFileTime:


### PR DESCRIPTION
Previous to this commit the instance variable `self.lastDate` was not updated as expected in the method `writeBlock(...)` of the `BlockDataCopier` class. Instead the locally scoped variable `lastDate` was updated.

This resulted in `self.lastDate` being kept constant at its initial value `datetime.datetime(2000, 1, 1)` during the lifetime of the `BlockDataCopier` object, which in turn meant that the check ...

    if self.timestampSplit and (blkDate > self.lastDate):

... was effectively reduced to ...

    if self.timestampSplit:

... since `self.lastDate` was stuck at 2000-01-01.