### PR TITLE
Wallet: Refactor ReserveKeyFromKeyPool for safety

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2913,9 +2913,9 @@ bool CWallet::TopUpKeyPool(unsigned int kpSize)
     return true;
 }
 
-void CWallet::ReserveKeyFromKeyPool(int64_t& nIndex, CKeyPool& keypool)
+int64_t CWallet::ReserveKeyFromKeyPool(CKeyPool& keypool)
 {
-    nIndex = -1;
+    int64_t nIndex;
     keypool.vchPubKey = CPubKey();
     {
         LOCK(cs_wallet);
@@ -2925,7 +2925,7 @@ void CWallet::ReserveKeyFromKeyPool(int64_t& nIndex, CKeyPool& keypool)
 
         // Get the oldest key
         if(setKeyPool.empty())
-            return;
+            throw keypool_empty();
 
         CWalletDB walletdb(strWalletFile);
 
@@ -2938,6 +2938,7 @@ void CWallet::ReserveKeyFromKeyPool(int64_t& nIndex, CKeyPool& keypool)
         assert(keypool.vchPubKey.IsValid());
         LogPrintf("keypool reserve %d\n", nIndex);
     }
+    return nIndex;
 }
 
 void CWallet::KeepKey(int64_t nIndex)
@@ -2963,13 +2964,13 @@ void CWallet::ReturnKey(int64_t nIndex)
 
 bool CWallet::GetKeyFromPool(CPubKey& result)
 {
-    int64_t nIndex = 0;
+    int64_t nIndex;
     CKeyPool keypool;
     {
         LOCK(cs_wallet);
-        ReserveKeyFromKeyPool(nIndex, keypool);
-        if (nIndex == -1)
-        {
+        try {
+            nIndex = ReserveKeyFromKeyPool(keypool);
+        } catch (keypool_empty) {
             if (IsLocked()) return false;
             result = GenerateNewKey();
             return true;
@@ -3181,12 +3182,12 @@ bool CReserveKey::GetReservedKey(CPubKey& pubkey)
     if (nIndex == -1)
     {
         CKeyPool keypool;
-        pwallet->ReserveKeyFromKeyPool(nIndex, keypool);
-        if (nIndex != -1)
-            vchPubKey = keypool.vchPubKey;
-        else {
+        try {
+            nIndex = pwallet->ReserveKeyFromKeyPool(keypool);
+        } catch (keypool_empty) {
             return false;
         }
+        vchPubKey = keypool.vchPubKey;
     }
     assert(vchPubKey.IsValid());
     pubkey = vchPubKey;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -92,6 +92,10 @@ enum WalletFeature
 };
 
 
+class keypool_empty : public std::exception
+{
+};
+
 /** A key pool entry */
 class CKeyPool
 {
@@ -810,7 +814,7 @@ public:
 
     bool NewKeyPool();
     bool TopUpKeyPool(unsigned int kpSize = 0);
-    void ReserveKeyFromKeyPool(int64_t& nIndex, CKeyPool& keypool);
+    int64_t ReserveKeyFromKeyPool(CKeyPool& keypool);
     void KeepKey(int64_t nIndex);
     void ReturnKey(int64_t nIndex);
     bool GetKeyFromPool(CPubKey &key);


### PR DESCRIPTION
ReserveKeyFromKeyPool's previous behaviour is to set nIndex to -1 if the keypool is empty, OR throw an exception for technical failures.
Instead, we now return nIndex (always >= 0) and throw a keypool_empty exception if the keypool is empty.

This is to ensure calling code must handle the empty case, and so the compiler can provide use-without-assignment warnings when appropriate.