### PR TITLE
[net] Avoid initialization to a value that is never read

### DIFF
--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -672,13 +672,14 @@ std::string NetworkErrorString(int err)
 std::string NetworkErrorString(int err)
 {
     char buf[256];
-    const char *s = buf;
     buf[0] = 0;
     /* Too bad there are two incompatible implementations of the
      * thread-safe strerror. */
+    const char *s;
 #ifdef STRERROR_R_CHAR_P /* GNU variant can return a pointer outside the passed buffer */
     s = strerror_r(err, buf, sizeof(buf));
 #else /* POSIX variant always returns message in buffer */
+    s = buf;
     if (strerror_r(err, buf, sizeof(buf)))
         buf[0] = 0;
 #endif


### PR DESCRIPTION
Prior to this commit the value stored to `s` at initialization was never read (in the case of `STRERROR_R_CHAR_P`).