### PR TITLE
[net] Avoid possibility of NULL pointer dereference in MarkBlockAsInFlight(...)

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -338,7 +338,9 @@ bool MarkBlockAsInFlight(NodeId nodeid, const uint256& hash, const Consensus::Pa
     // Short-circuit most stuff in case its from the same node
     map<uint256, pair<NodeId, list<QueuedBlock>::iterator> >::iterator itInFlight = mapBlocksInFlight.find(hash);
     if (itInFlight != mapBlocksInFlight.end() && itInFlight->second.first == nodeid) {
-        *pit = &itInFlight->second.second;
+        if (pit) {
+            *pit = &itInFlight->second.second;
+        }
         return false;
     }
 


### PR DESCRIPTION
In the case that the branch ...

    if (itInFlight != mapBlocksInFlight.end() && itInFlight->second.first == nodeid) {

... is taken, there was prior to this commit an implicit assumption that `MarkBlockAsInFlight(...)` was being called with its fifth and optional argument (`pit`) being present (and non-`NULL`).

There are three calls to `MarkBlockAsReceived(...)` and for two of these the optional fifth argument is not supplied, which means that `pit` is being set to the default value of `NULL`.

This commit adds an assertion which makes the mentioned assumption explicit, and removes the possibility of a `NULL` pointer dereference.