### PR TITLE
disable out of sync warnings for regtest network

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -31,6 +31,7 @@
 #include "macdockiconhandler.h"
 #endif
 
+#include "chainparams.h"
 #include "init.h"
 #include "ui_interface.h"
 #include "util.h"
@@ -815,7 +816,7 @@ void BitcoinGUI::setNumBlocks(int count, const QDateTime& blockDate, double nVer
         progressBarLabel->setVisible(false);
         progressBar->setVisible(false);
     }
-    else
+    else if (Params().NetworkIDString() != "regtest")
     {
         QString timeBehindText = GUIUtil::formateNiceTimeOffset(secs);
 


### PR DESCRIPTION
there are no blocks to sync,
so do not show out of sync modal popup and other warnings on the UI