### PR TITLE
Use z = std::max(x - y, 0) instead of z = x - y; if (z < 0) z = 0;

### DIFF
--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -53,11 +53,7 @@ bool CAddrInfo::IsTerrible(int64_t nNow) const
 double CAddrInfo::GetChance(int64_t nNow) const
 {
     double fChance = 1.0;
-
-    int64_t nSinceLastTry = nNow - nLastTry;
-
-    if (nSinceLastTry < 0)
-        nSinceLastTry = 0;
+    int64_t nSinceLastTry = std::max<int64_t>(nNow - nLastTry, 0);
 
     // deprioritize very recent attempts away
     if (nSinceLastTry < 60 * 10)

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -563,9 +563,7 @@ void CoinControlDialog::updateLabels(WalletModel *model, QDialog* dialog)
         }
 
         // after fee
-        nAfterFee = nAmount - nPayFee;
-        if (nAfterFee < 0)
-            nAfterFee = 0;
+        nAfterFee = std::max<CAmount>(nAmount - nPayFee, 0);
     }
 
     // actually update labels


### PR DESCRIPTION
Prefer ...

    z = std::max(x - y, 0);

... over ...

    z = x - y;
    if (z < 0)
        z = 0;

... as [suggested](https://github.com/bitcoin/bitcoin/pull/9532#pullrequestreview-16505689) by @robmcl4.

Please note that the `nSinceLastSeen` is intentionally skipped since `nSinceLastSeen` is unused and is being removed as part of #9532.