### PR TITLE
[test] Avoid reading a potentially uninitialized variable in tx_invalid-test (transaction_tests.cpp)

### DIFF
--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -189,7 +189,9 @@ BOOST_AUTO_TEST_CASE(tx_invalid)
     // verifyFlags is a comma separated list of script verification flags to apply, or "NONE"
     UniValue tests = read_json(std::string(json_tests::tx_invalid, json_tests::tx_invalid + sizeof(json_tests::tx_invalid)));
 
-    ScriptError err;
+    // Initialize to SCRIPT_ERR_OK. The tests expect err to be changed to a
+    // value other than SCRIPT_ERR_OK.
+    ScriptError err = SCRIPT_ERR_OK;
     for (unsigned int idx = 0; idx < tests.size(); idx++) {
         UniValue test = tests[idx];
         std::string strTest = test.write();


### PR DESCRIPTION
Prior to this commit the `err` variable was not guaranteed to be set before the check ...

    BOOST_CHECK_MESSAGE(err != SCRIPT_ERR_OK, ScriptErrorString(err));