### PR TITLE
Clarify assumptions made about when BlockCheck is called

### DIFF
--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -60,7 +60,12 @@ struct CMainSignals {
     boost::signals2::signal<void (const uint256 &)> Inventory;
     /** Tells listeners to broadcast their data. */
     boost::signals2::signal<void (int64_t nBestBlockTime, CConnman* connman)> Broadcast;
-    /** Notifies listeners of a block validation result */
+    /**
+     * Notifies listeners of a block validation result.
+     * If the provided CValidationState IsValid, the provided block
+     * is guaranteed to be the current best block at the time the
+     * callback was generated (not necessarily now)
+     */
     boost::signals2::signal<void (const CBlock&, const CValidationState&)> BlockChecked;
     /** Notifies listeners that a key for mining is required (coinbase) */
     boost::signals2::signal<void (boost::shared_ptr<CReserveScript>&)> ScriptForMining;


### PR DESCRIPTION
Based on #9400, this clarifies the docs above BlockChecked (documenting the assumption #9400 makes).