### PR TITLE
[net] Avoid possibility of NULL pointer dereference in ProcessMessage(...)

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2228,6 +2228,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         // much work as our tip, download as much as possible.
         if (fCanDirectFetch && pindexLast->IsValid(BLOCK_VALID_TREE) && chainActive.Tip()->nChainWork <= pindexLast->nChainWork) {
             vector<const CBlockIndex *> vToFetch;
+            assert(pindexLast);
             const CBlockIndex *pindexWalk = pindexLast;
             // Calculate all the blocks we'd need to switch to pindexLast, up to a limit.
             while (pindexWalk && !chainActive.Contains(pindexWalk) && vToFetch.size() <= MAX_BLOCKS_IN_TRANSIT_PER_PEER) {
@@ -2237,6 +2238,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                     // We don't have this block, and it's not yet in flight.
                     vToFetch.push_back(pindexWalk);
                 }
+                assert(pindexWalk->pprev);
                 pindexWalk = pindexWalk->pprev;
             }
             // If pindexWalk still isn't on our main chain, we're looking at a


### PR DESCRIPTION
Prior to this commit there was an implicit assumption that the `CBlockIndex pindexWalk` (+ `pindexLast` and `pindexWalk->pprev`) being non-`NULL`. (If that was guaranteed `pindexWalk` would not be needed in `while (pindexWalk && ...)` on [line 2233](https://github.com/bitcoin/bitcoin/blob/3908fc4728059719bed0e1c7b1c8b388c2d4a8da/src/net_processing.cpp#L2233)).

`pindexWalk` is being used in the check ...

    if (!chainActive.Contains(pindexWalk)) {

`CChain.Contains(...)` is defined as:

    bool Contains(const CBlockIndex *pindex) const {
        return (*this)[pindex->nHeight] == pindex;
    }

Hence, a `NULL` pointer dereference in the case of a non-`NULL` argument to `Contains(...)`.

This commit adds two assertion which make the mentioned assumptions explicit, and removes the possibility of a `NULL` pointer dereference.