### PR TITLE
[rpc] Avoid possibility of NULL pointer dereference in getblocktemplate(...)

### DIFF
--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -544,6 +544,7 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
         pindexPrev = pindexPrevNew;
     }
     CBlock* pblock = &pblocktemplate->block; // pointer for convenience
+    assert(pblock);
     const Consensus::Params& consensusParams = Params().GetConsensus();
 
     // Update nTime


### PR DESCRIPTION
Prior to this commit there was an implicit assumption that the following code path would always be taken ...

    if (pindexPrev != chainActive.Tip() ||
        (mempool.GetTransactionsUpdated() != nTransactionsUpdatedLast && GetTime() - nStart > 5))

... otherwise `pblock` would end up being `NULL`, and given ...

    pblock->nNonce = 0;

... we would have a `NULL` pointer dereference.

This commit adds an assertion which removes the possibility of a `NULL` pointer dereference.