### PR TITLE
Wake message handling thread when we receive a new block

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -328,6 +328,8 @@ public:
     CSipHasher GetDeterministicRandomizer(uint64_t id);
 
     unsigned int GetReceiveFloodSize() const;
+
+    void WakeMessageHandler();
 private:
     struct ListenSocket {
         SOCKET socket;
@@ -343,8 +345,6 @@ private:
     void AcceptConnection(const ListenSocket& hListenSocket);
     void ThreadSocketHandler();
     void ThreadDNSAddressSeed();
-
-    void WakeMessageHandler();
 
     uint64_t CalculateKeyedNetGroup(const CAddress& ad);
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -822,6 +822,7 @@ void PeerLogicValidation::UpdatedBlockTip(const CBlockIndex *pindexNew, const CB
                 }
             }
         });
+        connman->WakeMessageHandler();
     }
 
     nTimeBestReceived = GetTime();


### PR DESCRIPTION
This forces the message handling thread to make another full
iteration of SendMessages prior to going back to sleep, ensuring
we announce the new block to all peers before sleeping.