### PR TITLE
[pep-8] Prefer "foo is None" to "foo == None"

### DIFF
--- a/contrib/devtools/clang-format-diff.py
+++ b/contrib/devtools/clang-format-diff.py
@@ -110,7 +110,7 @@ def main():
     match = re.search('^\+\+\+\ (.*?/){%s}(\S*)' % args.p, line)
     if match:
       filename = match.group(2)
-    if filename == None:
+    if filename is None:
       continue
 
     if args.regex is not None:

--- a/contrib/devtools/copyright_header.py
+++ b/contrib/devtools/copyright_header.py
@@ -489,7 +489,7 @@ def get_git_change_year_range(filename):
 
 def file_already_has_core_copyright(file_lines):
     index, _ = get_updatable_copyright_line(file_lines)
-    return index != None
+    return index is not None
 
 ################################################################################
 # insert header execution

--- a/qa/rpc-tests/httpbasics.py
+++ b/qa/rpc-tests/httpbasics.py
@@ -36,13 +36,13 @@ class HTTPBasicsTest (BitcoinTestFramework):
         conn.request('POST', '/', '{"method": "getbestblockhash"}', headers)
         out1 = conn.getresponse().read()
         assert(b'"error":null' in out1)
-        assert(conn.sock!=None) #according to http/1.1 connection must still be open!
+        assert(conn.sock is not None) #according to http/1.1 connection must still be open!
 
         #send 2nd request without closing connection
         conn.request('POST', '/', '{"method": "getchaintips"}', headers)
         out1 = conn.getresponse().read()
         assert(b'"error":null' in out1) #must also response with a correct json-rpc message
-        assert(conn.sock!=None) #according to http/1.1 connection must still be open!
+        assert(conn.sock is not None) #according to http/1.1 connection must still be open!
         conn.close()
 
         #same should be if we add keep-alive because this should be the std. behaviour
@@ -53,13 +53,13 @@ class HTTPBasicsTest (BitcoinTestFramework):
         conn.request('POST', '/', '{"method": "getbestblockhash"}', headers)
         out1 = conn.getresponse().read()
         assert(b'"error":null' in out1)
-        assert(conn.sock!=None) #according to http/1.1 connection must still be open!
+        assert(conn.sock is not None) #according to http/1.1 connection must still be open!
 
         #send 2nd request without closing connection
         conn.request('POST', '/', '{"method": "getchaintips"}', headers)
         out1 = conn.getresponse().read()
         assert(b'"error":null' in out1) #must also response with a correct json-rpc message
-        assert(conn.sock!=None) #according to http/1.1 connection must still be open!
+        assert(conn.sock is not None) #according to http/1.1 connection must still be open!
         conn.close()
 
         #now do the same with "Connection: close"
@@ -70,7 +70,7 @@ class HTTPBasicsTest (BitcoinTestFramework):
         conn.request('POST', '/', '{"method": "getbestblockhash"}', headers)
         out1 = conn.getresponse().read()
         assert(b'"error":null' in out1)
-        assert(conn.sock==None) #now the connection must be closed after the response
+        assert(conn.sock is None) #now the connection must be closed after the response
 
         #node1 (2nd node) is running with disabled keep-alive option
         urlNode1 = urllib.parse.urlparse(self.nodes[1].url)
@@ -93,7 +93,7 @@ class HTTPBasicsTest (BitcoinTestFramework):
         conn.request('POST', '/', '{"method": "getbestblockhash"}', headers)
         out1 = conn.getresponse().read()
         assert(b'"error":null' in out1)
-        assert(conn.sock!=None) #connection must be closed because bitcoind should use keep-alive by default
+        assert(conn.sock is not None) #connection must be closed because bitcoind should use keep-alive by default
 
         # Check excessive request size
         conn = http.client.HTTPConnection(urlNode2.hostname, urlNode2.port)

--- a/qa/rpc-tests/p2p-fullblocktest.py
+++ b/qa/rpc-tests/p2p-fullblocktest.py
@@ -98,7 +98,7 @@ class FullBlockTest(ComparisonTestFramework):
         return tx
 
     def next_block(self, number, spend=None, additional_coinbase_value=0, script=CScript([OP_TRUE]), solve=True):
-        if self.tip == None:
+        if self.tip is None:
             base_block_hash = self.genesis_hash
             block_time = int(time.time())+1
         else:
@@ -109,7 +109,7 @@ class FullBlockTest(ComparisonTestFramework):
         coinbase = create_coinbase(height, self.coinbase_pubkey)
         coinbase.vout[0].nValue += additional_coinbase_value
         coinbase.rehash()
-        if spend == None:
+        if spend is None:
             block = create_block(base_block_hash, coinbase, block_time)
         else:
             coinbase.vout[0].nValue += spend.tx.vout[spend.n].nValue - 1 # all but one satoshi to fees

--- a/qa/rpc-tests/p2p-segwit.py
+++ b/qa/rpc-tests/p2p-segwit.py
@@ -92,16 +92,16 @@ class TestNode(NodeConnCB):
         return
 
     def wait_for_block(self, blockhash, timeout=60):
-        test_function = lambda: self.last_block != None and self.last_block.sha256 == blockhash
+        test_function = lambda: self.last_block is not None and self.last_block.sha256 == blockhash
         self.sync(test_function, timeout)
         return
 
     def wait_for_getdata(self, timeout=60):
-        test_function = lambda: self.last_getdata != None
+        test_function = lambda: self.last_getdata is not None
         self.sync(test_function, timeout)
 
     def wait_for_getheaders(self, timeout=60):
-        test_function = lambda: self.last_getheaders != None
+        test_function = lambda: self.last_getheaders is not None
         self.sync(test_function, timeout)
 
     def wait_for_inv(self, expected_inv, timeout=60):
@@ -154,7 +154,7 @@ class TestNode(NodeConnCB):
         self.send_message(tx_message)
         self.sync_with_ping()
         assert_equal(tx.hash in self.connection.rpc.getrawmempool(), accepted)
-        if (reason != None and not accepted):
+        if reason is not None and not accepted:
             # Check the rejection reason as well.
             with mininode_lock:
                 assert_equal(self.last_reject.reason, reason)

--- a/qa/rpc-tests/prioritise_transaction.py
+++ b/qa/rpc-tests/prioritise_transaction.py
@@ -71,7 +71,7 @@ class PrioritiseTransactionTest(BitcoinTestFramework):
                 high_fee_tx = x
 
         # Something high-fee should have been mined!
-        assert(high_fee_tx != None)
+        assert(high_fee_tx is not None)
 
         # Add a prioritisation before a tx is in the mempool (de-prioritising a
         # high-fee transaction so that it's now low fee).

--- a/qa/rpc-tests/sendheaders.py
+++ b/qa/rpc-tests/sendheaders.py
@@ -147,8 +147,8 @@ class BaseNode(SingleNodeConnCB):
     # right header or the right inv
     # inv and headers should be lists of block hashes
     def check_last_announcement(self, headers=None, inv=None):
-        expect_headers = headers if headers != None else []
-        expect_inv = inv if inv != None else []
+        expect_headers = headers if headers is not None else []
+        expect_inv = inv if inv is not None else []
         test_function = lambda: self.block_announced
         assert(wait_until(test_function, timeout=60))
         with mininode_lock:
@@ -156,13 +156,13 @@ class BaseNode(SingleNodeConnCB):
 
             success = True
             compare_inv = []
-            if self.last_inv != None:
+            if self.last_inv is not None:
                 compare_inv = [x.hash for x in self.last_inv.inv]
             if compare_inv != expect_inv:
                 success = False
 
             hash_headers = []
-            if self.last_headers != None:
+            if self.last_headers is not None:
                 # treat headers as a list of block hashes
                 hash_headers = [ x.sha256 for x in self.last_headers.headers ]
             if hash_headers != expect_headers:
@@ -174,12 +174,12 @@ class BaseNode(SingleNodeConnCB):
 
     # Syncing helpers
     def wait_for_block(self, blockhash, timeout=60):
-        test_function = lambda: self.last_block != None and self.last_block.sha256 == blockhash
+        test_function = lambda: self.last_block is not None and self.last_block.sha256 == blockhash
         assert(wait_until(test_function, timeout=timeout))
         return
 
     def wait_for_getheaders(self, timeout=60):
-        test_function = lambda: self.last_getheaders != None
+        test_function = lambda: self.last_getheaders is not None
         assert(wait_until(test_function, timeout=timeout))
         return
 
@@ -187,7 +187,7 @@ class BaseNode(SingleNodeConnCB):
         if hash_list == []:
             return
 
-        test_function = lambda: self.last_getdata != None and [x.hash for x in self.last_getdata.inv] == hash_list
+        test_function = lambda: self.last_getdata is not None and [x.hash for x in self.last_getdata.inv] == hash_list
         assert(wait_until(test_function, timeout=timeout))
         return
 

--- a/qa/rpc-tests/test_framework/blocktools.py
+++ b/qa/rpc-tests/test_framework/blocktools.py
@@ -71,7 +71,7 @@ def create_coinbase(height, pubkey = None):
     coinbaseoutput.nValue = 50 * COIN
     halvings = int(height/150) # regtest
     coinbaseoutput.nValue >>= halvings
-    if (pubkey != None):
+    if pubkey is not None:
         coinbaseoutput.scriptPubKey = CScript([pubkey, OP_CHECKSIG])
     else:
         coinbaseoutput.scriptPubKey = CScript([OP_TRUE])

--- a/qa/rpc-tests/test_framework/mininode.py
+++ b/qa/rpc-tests/test_framework/mininode.py
@@ -823,7 +823,7 @@ class HeaderAndShortIDs(object):
         self.prefilled_txn = []
         self.use_witness = False
 
-        if p2pheaders_and_shortids != None:
+        if p2pheaders_and_shortids is not None:
             self.header = p2pheaders_and_shortids.header
             self.nonce = p2pheaders_and_shortids.nonce
             self.shortids = p2pheaders_and_shortids.shortids
@@ -880,7 +880,7 @@ class BlockTransactionsRequest(object):
 
     def __init__(self, blockhash=0, indexes = None):
         self.blockhash = blockhash
-        self.indexes = indexes if indexes != None else []
+        self.indexes = indexes if indexes is not None else []
 
     def deserialize(self, f):
         self.blockhash = deser_uint256(f)
@@ -920,7 +920,7 @@ class BlockTransactions(object):
 
     def __init__(self, blockhash=0, transactions = None):
         self.blockhash = blockhash
-        self.transactions = transactions if transactions != None else []
+        self.transactions = transactions if transactions is not None else []
 
     def deserialize(self, f):
         self.blockhash = deser_uint256(f)
@@ -1082,7 +1082,7 @@ class msg_getdata(object):
     command = b"getdata"
 
     def __init__(self, inv=None):
-        self.inv = inv if inv != None else []
+        self.inv = inv if inv is not None else []
 
     def deserialize(self, f):
         self.inv = deser_vector(f, CInv)


### PR DESCRIPTION
Prefer `foo is None` to `foo == None`.

In accordance with Style Guide for Python Code (PEP 8):
* https://www.python.org/dev/peps/pep-0008/#programming-recommendations