### PR TITLE
Do not shadow local variable named `tx`.

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1877,8 +1877,8 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
             }
         }
 
-        for (const CTransactionRef& tx : lRemovedTxn)
-            AddToCompactExtraTransactions(tx);
+        for (const CTransactionRef& removedTx : lRemovedTxn)
+            AddToCompactExtraTransactions(removedTx);
 
         int nDoS = 0;
         if (state.IsInvalid(nDoS))


### PR DESCRIPTION
#9499 brought in new shadowing warning:
```
net_processing.cpp:1880:37: warning: declaration shadows a local variable [-Wshadow]
        for (const CTransactionRef& tx : lRemovedTxn)
                                    ^
net_processing.cpp:1728:29: note: previous declaration is here
        const CTransaction& tx = *ptx;
                            ^
1 warning generated.
```

@TheBlueMatt Is `_tx` OK for you or do you prefer other name here? Like `removedTx` or so...