### PR TITLE
[rpc] Bug-fix: getdifficulty: use network parameters for minimum difficulty

### DIFF
--- a/qa/rpc-tests/blockchain.py
+++ b/qa/rpc-tests/blockchain.py
@@ -14,6 +14,7 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.authproxy import JSONRPCException
 from test_framework.util import (
     assert_equal,
+    assert_greater_than_or_equal,
     assert_raises,
     assert_is_hex_string,
     assert_is_hash_string,
@@ -83,7 +84,8 @@ class BlockchainTest(BitcoinTestFramework):
         assert isinstance(header['nonce'], int)
         assert isinstance(header['version'], int)
         assert isinstance(int(header['versionHex'], 16), int)
-        assert isinstance(header['difficulty'], Decimal)
+        assert isinstance(header['difficulty'], (Decimal, int))
+        assert_greater_than_or_equal(header['difficulty'], 1.0)
 
 if __name__ == '__main__':
     BlockchainTest().main()

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -47,6 +47,10 @@ double GetDifficulty(const CBlockIndex* blockindex)
 {
     // Floating point number that is a multiple of the minimum difficulty,
     // minimum difficulty = 1.0.
+    uint32_t compactPowLimit = UintToArith256(Params().GetConsensus().powLimit).GetCompact();
+    int shiftTarget = (compactPowLimit & 0xff000000) >> 24;
+    int rem = compactPowLimit  & 0x00ffffff;
+
     if (blockindex == NULL)
     {
         if (chainActive.Tip() == NULL)
@@ -58,14 +62,14 @@ double GetDifficulty(const CBlockIndex* blockindex)
     int nShift = (blockindex->nBits >> 24) & 0xff;
 
     double dDiff =
-        (double)0x0000ffff / (double)(blockindex->nBits & 0x00ffffff);
+        (double)rem / (double)(blockindex->nBits & 0x00ffffff);
 
-    while (nShift < 29)
+    while (nShift < shiftTarget)
     {
         dDiff *= 256.0;
         nShift++;
     }
-    while (nShift > 29)
+    while (nShift > shiftTarget)
     {
         dDiff /= 256.0;
         nShift--;


### PR DESCRIPTION
Currently the system uses the hard coded parameters for mainnet, which gives weird results for non-mainnet nets (e.g. testnet). This pulls the `Params().GetConsensus().powLimit` and uses that instead.