### PR TITLE
Improve readability by removing redundant casts to same type (on all platforms)

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -906,7 +906,7 @@ bool AppInitParameterInteraction()
     nMaxConnections = std::max(nUserMaxConnections, 0);
 
     // Trim requested connection counts, to fit into system limitations
-    nMaxConnections = std::max(std::min(nMaxConnections, (int)(FD_SETSIZE - nBind - MIN_CORE_FILEDESCRIPTORS - MAX_ADDNODE_CONNECTIONS)), 0);
+    nMaxConnections = std::max(std::min(nMaxConnections, FD_SETSIZE - nBind - MIN_CORE_FILEDESCRIPTORS - MAX_ADDNODE_CONNECTIONS), 0);
     nFD = RaiseFileDescriptorLimit(nMaxConnections + MIN_CORE_FILEDESCRIPTORS + MAX_ADDNODE_CONNECTIONS);
     if (nFD < MIN_CORE_FILEDESCRIPTORS)
         return InitError(_("Not enough file descriptors available."));

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -170,7 +170,7 @@ CPrivKey CKey::GetPrivKey() const {
     size_t privkeylen;
     privkey.resize(PRIVATE_KEY_SIZE);
     privkeylen = PRIVATE_KEY_SIZE;
-    ret = ec_privkey_export_der(secp256k1_context_sign, (unsigned char*) privkey.data(), &privkeylen, begin(), fCompressed ? SECP256K1_EC_COMPRESSED : SECP256K1_EC_UNCOMPRESSED);
+    ret = ec_privkey_export_der(secp256k1_context_sign, privkey.data(), &privkeylen, begin(), fCompressed ? SECP256K1_EC_COMPRESSED : SECP256K1_EC_UNCOMPRESSED);
     assert(ret);
     privkey.resize(privkeylen);
     return privkey;
@@ -199,7 +199,7 @@ bool CKey::Sign(const uint256 &hash, std::vector<unsigned char>& vchSig, uint32_
     secp256k1_ecdsa_signature sig;
     int ret = secp256k1_ecdsa_sign(secp256k1_context_sign, &sig, hash.begin(), begin(), secp256k1_nonce_function_rfc6979, test_case ? extra_entropy : nullptr);
     assert(ret);
-    secp256k1_ecdsa_signature_serialize_der(secp256k1_context_sign, (unsigned char*)vchSig.data(), &nSigLen, &sig);
+    secp256k1_ecdsa_signature_serialize_der(secp256k1_context_sign, vchSig.data(), &nSigLen, &sig);
     vchSig.resize(nSigLen);
     return true;
 }
@@ -226,7 +226,7 @@ bool CKey::SignCompact(const uint256 &hash, std::vector<unsigned char>& vchSig) 
     secp256k1_ecdsa_recoverable_signature sig;
     int ret = secp256k1_ecdsa_sign_recoverable(secp256k1_context_sign, &sig, hash.begin(), begin(), secp256k1_nonce_function_rfc6979, nullptr);
     assert(ret);
-    secp256k1_ecdsa_recoverable_signature_serialize_compact(secp256k1_context_sign, (unsigned char*)&vchSig[1], &rec, &sig);
+    secp256k1_ecdsa_recoverable_signature_serialize_compact(secp256k1_context_sign, &vchSig[1], &rec, &sig);
     assert(ret);
     assert(rec != -1);
     vchSig[0] = 27 + rec + (fCompressed ? 4 : 0);


### PR DESCRIPTION
Same binaries check under Linux:

```
$ ../bitcoin-maintainer-tools/build-for-compare.py 874f13821f4193bd037cd37d005ee76b5a849398 82274c02ed2d82537dc55f008a29edb1bc09bbc4 --executables "src/bitcoind,src/bitcoin-cli,src/bitcoin-tx"

$ sha256sum /tmp/compare/*.stripped
1fe1a8827474f7f24475ce3dc851e7ac658d4ed0ae38d11e67f5a810671eaa15  /tmp/compare/bitcoin-cli.82274c02ed2d82537dc55f008a29edb1bc09bbc4.stripped
1fe1a8827474f7f24475ce3dc851e7ac658d4ed0ae38d11e67f5a810671eaa15  /tmp/compare/bitcoin-cli.874f13821f4193bd037cd37d005ee76b5a849398.stripped
342c2ed0e60b60990a58cbf5845b256a4f9e3baff9db074baba5e34a620a60ea  /tmp/compare/bitcoind.82274c02ed2d82537dc55f008a29edb1bc09bbc4.stripped
342c2ed0e60b60990a58cbf5845b256a4f9e3baff9db074baba5e34a620a60ea  /tmp/compare/bitcoind.874f13821f4193bd037cd37d005ee76b5a849398.stripped
e4b2a80b2361d5cefd67a47eeb9298b8b712c26c7779d979348be8b2c7e3ec93  /tmp/compare/bitcoin-tx.82274c02ed2d82537dc55f008a29edb1bc09bbc4.stripped
e4b2a80b2361d5cefd67a47eeb9298b8b712c26c7779d979348be8b2c7e3ec93  /tmp/compare/bitcoin-tx.874f13821f4193bd037cd37d005ee76b5a849398.stripped

$ git diff -W --word-diff /tmp/compare/874f13821f4193bd037cd37d005ee76b5a849398 /tmp/compare/82274c02ed2d82537dc55f008a29edb1bc09bbc4

$
```
