### PR TITLE
[WIP] Perform validation in a separate thread to message handling.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -150,6 +150,7 @@ BITCOIN_CORE_H = \
   utilmoneystr.h \
   utiltime.h \
   validation.h \
+  validation_thread.h \
   validationinterface.h \
   versionbits.h \
   wallet/coincontrol.h \
@@ -208,6 +209,7 @@ libbitcoin_server_a_SOURCES = \
   txmempool.cpp \
   ui_interface.cpp \
   validation.cpp \
+  validation_thread.cpp \
   validationinterface.cpp \
   versionbits.cpp \
   $(BITCOIN_CORE_H)

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -664,10 +664,12 @@ void ThreadImport(std::vector<boost::filesystem::path> vImportFiles)
     }
 
     // scan for better chains in the block chain database, that are not yet connected in the active best chain
-    CValidationState state;
-    if (!ActivateBestChain(state, chainparams)) {
-        LogPrintf("Failed to connect best block");
-        StartShutdown();
+    if (chainActive.Tip() == NULL) {
+        CValidationState state;
+        if (!ActivateBestChain(state, chainparams)) {
+            LogPrintf("Failed to connect best block");
+            StartShutdown();
+        }
     }
 
     if (GetBoolArg("-stopafterblockimport", DEFAULT_STOPAFTERBLOCKIMPORT)) {

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2194,6 +2194,9 @@ bool CConnman::Start(CScheduler& scheduler, std::string& strNodeError, Options c
     // Process messages
     threadMessageHandler = std::thread(&TraceThread<std::function<void()> >, "msghand", std::function<void()>(std::bind(&CConnman::ThreadMessageHandler, this)));
 
+    // Validate blocks
+    threadValidation = std::thread(&TraceThread<boost::function<void()> >, "validate", std::function<void()>(boost::bind(&CConnman::ThreadValidation, this)));
+
     // Dump network addresses
     scheduler.scheduleEvery(boost::bind(&CConnman::DumpData, this), DUMP_ADDRESSES_INTERVAL);
 
@@ -2233,6 +2236,8 @@ void CConnman::Interrupt()
 
 void CConnman::Stop()
 {
+    if (threadValidation.joinable())
+        threadValidation.join();
     if (threadMessageHandler.joinable())
         threadMessageHandler.join();
     if (threadOpenConnections.joinable())

--- a/src/net.h
+++ b/src/net.h
@@ -342,6 +342,7 @@ private:
     void ProcessOneShot();
     void ThreadOpenConnections();
     void ThreadMessageHandler();
+    void ThreadValidation();
     void AcceptConnection(const ListenSocket& hListenSocket);
     void ThreadSocketHandler();
     void ThreadDNSAddressSeed();
@@ -435,6 +436,8 @@ private:
 
     std::condition_variable condMsgProc;
     std::mutex mutexMsgProc;
+    std::condition_variable condValidation;
+    std::mutex mutexValidation;
     std::atomic<bool> flagInterruptMsgProc;
 
     CThreadInterrupt interruptNet;
@@ -444,6 +447,7 @@ private:
     std::thread threadOpenAddedConnections;
     std::thread threadOpenConnections;
     std::thread threadMessageHandler;
+    std::thread threadValidation;
 };
 extern std::unique_ptr<CConnman> g_connman;
 void Discover(boost::thread_group& threadGroup);

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -803,6 +803,7 @@ void PeerLogicValidation::NewPoWValidBlock(const CBlockIndex *pindex, const std:
 }
 
 void PeerLogicValidation::UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload) {
+    // This will now often run in the validate thread rather than the message handler thread.
     const int nNewHeight = pindexNew->nHeight;
     connman->SetBestHeight(nNewHeight);
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -114,6 +114,7 @@ bool fLogTimestamps = DEFAULT_LOGTIMESTAMPS;
 bool fLogTimeMicros = DEFAULT_LOGTIMEMICROS;
 bool fLogIPs = DEFAULT_LOGIPS;
 std::atomic<bool> fReopenDebugLog(false);
+std::atomic<bool> fActivatingChain(false);
 CTranslationInterface translationInterface;
 
 /** Init OpenSSL library multithreading support */

--- a/src/util.h
+++ b/src/util.h
@@ -50,6 +50,7 @@ extern bool fLogTimestamps;
 extern bool fLogTimeMicros;
 extern bool fLogIPs;
 extern std::atomic<bool> fReopenDebugLog;
+extern std::atomic<bool> fActivatingChain; // True while activating the best chain
 extern CTranslationInterface translationInterface;
 
 extern const char * const BITCOIN_CONF_FILENAME;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -33,6 +33,7 @@
 #include "utilmoneystr.h"
 #include "utilstrencodings.h"
 #include "validationinterface.h"
+#include "validation_thread.h"
 #include "versionbits.h"
 #include "warnings.h"
 
@@ -2436,6 +2437,9 @@ bool ActivateBestChain(CValidationState &state, const CChainParams& chainparams,
     // us in the middle of ProcessNewBlock - do not assume pblock is set
     // sanely for performance or correctness!
 
+    if (fActivatingChain)
+        return true;
+    fActivatingChain = true;
     CBlockIndex *pindexMostWork = NULL;
     CBlockIndex *pindexNewTip = NULL;
     do {
@@ -2454,13 +2458,17 @@ bool ActivateBestChain(CValidationState &state, const CChainParams& chainparams,
             }
 
             // Whether we have anything to do at all.
-            if (pindexMostWork == NULL || pindexMostWork == chainActive.Tip())
+            if (pindexMostWork == NULL || pindexMostWork == chainActive.Tip()) {
+                fActivatingChain = false;
                 return true;
+            }
 
             bool fInvalidFound = false;
             std::shared_ptr<const CBlock> nullBlockPtr;
-            if (!ActivateBestChainStep(state, chainparams, pindexMostWork, pblock && pblock->GetHash() == pindexMostWork->GetBlockHash() ? pblock : nullBlockPtr, fInvalidFound, connectTrace))
+            if (!ActivateBestChainStep(state, chainparams, pindexMostWork, pblock && pblock->GetHash() == pindexMostWork->GetBlockHash() ? pblock : nullBlockPtr, fInvalidFound, connectTrace)) {
+                fActivatingChain = false;
                 return false;
+            }
 
             if (fInvalidFound) {
                 // Wipe cache, we may need another branch now.
@@ -2495,9 +2503,11 @@ bool ActivateBestChain(CValidationState &state, const CChainParams& chainparams,
 
     // Write changes periodically to disk, after relay.
     if (!FlushStateToDisk(state, FLUSH_STATE_PERIODIC)) {
+        fActivatingChain = false;
         return false;
     }
 
+    fActivatingChain = false;
     return true;
 }
 
@@ -3177,13 +3187,19 @@ static bool AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CValidation
     return true;
 }
 
+void FormBestChain() {
+    CValidationState state;
+    const CChainParams& chainparams = Params();
+    ActivateBestChain(state, chainparams);
+}
+
 bool ProcessNewBlock(const CChainParams& chainparams, const std::shared_ptr<const CBlock> pblock, bool fForceProcessing, bool *fNewBlock)
 {
+    CBlockIndex *pindex = NULL;
     {
         LOCK(cs_main);
 
         // Store to disk
-        CBlockIndex *pindex = NULL;
         if (fNewBlock) *fNewBlock = false;
         CValidationState state;
         bool ret = AcceptBlock(pblock, state, chainparams, &pindex, fForceProcessing, NULL, fNewBlock);
@@ -3196,9 +3212,15 @@ bool ProcessNewBlock(const CChainParams& chainparams, const std::shared_ptr<cons
 
     NotifyHeaderTip();
 
-    CValidationState state; // Only used to report errors, not invalidity - ignore it
-    if (!ActivateBestChain(state, chainparams, pblock))
-        return error("%s: ActivateBestChain failed", __func__);
+    // If best header is within 6 blocks from our tip, activate best chain withtin the message handler thread to avoid the 100ms delay,
+    // and to avoid breaking the miner tests.
+    if (fActivatingChain || pindexBestHeader->nChainWork > chainActive.Tip()->nChainWork + GetBlockProof(*chainActive.Tip()) * 6)
+        fActivateChain = true;
+    else {
+        CValidationState state; // Only used to report errors, not invalidity - ignore it
+        if (!ActivateBestChain(state, chainparams, pblock))
+            return error("%s: ActivateBestChain failed", __func__);
+    }
 
     return true;
 }

--- a/src/validation.h
+++ b/src/validation.h
@@ -283,6 +283,7 @@ std::string GetWarnings(const std::string& strFor);
 bool GetTransaction(const uint256 &hash, CTransactionRef &tx, const Consensus::Params& params, uint256 &hashBlock, bool fAllowSlow = false);
 /** Find the best known block, and make it the tip of the block chain */
 bool ActivateBestChain(CValidationState& state, const CChainParams& chainparams, std::shared_ptr<const CBlock> pblock = std::shared_ptr<const CBlock>());
+void FormBestChain();
 CAmount GetBlockSubsidy(int nHeight, const Consensus::Params& consensusParams);
 
 /** Guess verification progress (as a fraction between 0.0=genesis and 1.0=current tip). */

--- a/src/validation_thread.cpp
+++ b/src/validation_thread.cpp
@@ -1,0 +1,26 @@
+#include "chainparams.h"
+#include "validation.h"
+#include "validationinterface.h"
+#include "net.h"
+
+std::atomic<bool> fActivateChain(true);
+
+void CConnman::ThreadValidation()
+{
+    int nSleep;
+    while (!flagInterruptMsgProc) {
+        if (fActivateChain && !fActivatingChain) {
+            fActivateChain = false;
+            FormBestChain();
+        }
+        if (!pindexBestHeader || pindexBestHeader->nChainWork == chainActive.Tip()->nChainWork)
+            nSleep = 1000;
+        else
+            nSleep = 100;
+        if (!fActivateChain)
+            MilliSleep(nSleep);
+        else
+            nSleep = 0;
+    }
+}
+

--- a/src/validation_thread.h
+++ b/src/validation_thread.h
@@ -1,0 +1,1 @@
+extern std::atomic<bool> fActivateChain; // Set to true to trigger validation thread


### PR DESCRIPTION
Have been testing this for a few weeks now - in my experience it helps to avoid moments during IBD where the best chain activation causes download to stop (due to the window being emptied, as no further blocks are being requested while the message handler thread is on hold while waiting for the chain to finish activating) - this becomes especially important with other changes I am testing where the MAX_BLOCKS_IN_FLIGHT_PER_PEER is significantly reduced (based upon bandwidth of each host).

I might have omitted some locks that need to be used here - and also might be able to incorporate this code into existing files rather than needing new ones - but it is certainly ready enough for a proof of concept I think.

Also possible improvements might be to use signals to break out of the sleep (as was done in 351593b9c8687b4da2e86769899b8b61ea44b630), although during IBD I don't think the saving of 100ms is critical.