### PR TITLE
[Trivial] fix logging typo in FlushStateToDisk()

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2061,7 +2061,7 @@ bool static FlushStateToDisk(CValidationState &state, FlushStateMode mode, int n
                 setDirtyBlockIndex.erase(it++);
             }
             if (!pblocktree->WriteBatchSync(vFiles, nLastBlockFile, vBlocks)) {
-                return AbortNode(state, "Files to write to block index database");
+                return AbortNode(state, "Failed to write to block index database");
             }
         }
         // Finally remove any pruned files


### PR DESCRIPTION
Reverts typo introduced here: https://github.com/bitcoin/bitcoin/pull/5367/files#diff-7ec3c68a81efff79b6ca22ac1f1eabbaR1801