### PR TITLE
Remove extra nonce reset logic in IncrementExtraNonce

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -598,13 +598,7 @@ void BlockAssembler::addPriorityTxs()
 
 void IncrementExtraNonce(CBlock* pblock, const CBlockIndex* pindexPrev, unsigned int& nExtraNonce)
 {
-    // Update nExtraNonce
-    static uint256 hashPrevBlock;
-    if (hashPrevBlock != pblock->hashPrevBlock)
-    {
-        nExtraNonce = 0;
-        hashPrevBlock = pblock->hashPrevBlock;
-    }
+    assert(pblock->hashPrevBlock == pindexPrev->GetBlockHash());
     ++nExtraNonce;
     unsigned int nHeight = pindexPrev->nHeight+1; // Height first in coinbase required for block.version=2
     CMutableTransaction txCoinbase(*pblock->vtx[0]);


### PR DESCRIPTION
These are unused variables that can be removed.
And ```IncrementExtraNonce()``` should be never called with ```uint256() == pblock->hashPrevBlock```.

Should be easy review for @instagibbs @luke-jr and @morcos.
