### PR TITLE
qa: Increase a sync_blocks timeout in pruning.py

### DIFF
--- a/qa/rpc-tests/pruning.py
+++ b/qa/rpc-tests/pruning.py
@@ -314,7 +314,7 @@ class PruneTest(BitcoinTestFramework):
         print ("Syncing node 5 to test wallet")
         connect_nodes(self.nodes[0], 5)
         nds = [self.nodes[0], self.nodes[5]]
-        sync_blocks(nds)
+        sync_blocks(nds, wait=5, timeout=300)
         try:
             stop_node(self.nodes[5],5) #stop and start to trigger rescan
             start_node(5, self.options.tmpdir, ["-debug=1","-prune=550"])


### PR DESCRIPTION
The last test in `pruning.py` (added in #7871) starts with trying to sync a big chain from one node to a fresh one; this regularly takes more than the default 60 seconds on the machine I use to run all the tests, so I've bumped the timeout on that sync_blocks call to 300 seconds.