### PR TITLE
Add logging to GetAncestor if pindex->pprev == NULL

### DIFF
--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -4,6 +4,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "chain.h"
+#include "util.h"
 
 using namespace std;
 
@@ -99,8 +100,12 @@ CBlockIndex* CBlockIndex::GetAncestor(int height)
             // Only follow pskip if pprev->pskip isn't better than pskip->pprev.
             pindexWalk = pindexWalk->pskip;
             heightWalk = heightSkip;
+        } else if (pindexWalk->pprev == NULL) {
+            // pindexWalk should always have a parent (since pindexWalk is not the genesis block)
+            LogPrintf("%s: Block index is missing a block. Block %s, height %d has no parent.\n",  __func__, pindexWalk->GetBlockHash().ToString(), heightWalk);
+            LogPrintf("%s: Run bitcoin with -reindex to rebuild the block index. This will redownload the entire blockchain if running a pruned node.\n",  __func__);
+            abort();
         } else {
-            assert(pindexWalk->pprev);
             pindexWalk = pindexWalk->pprev;
             heightWalk--;
         }


### PR DESCRIPTION
https://github.com/bitcoin/bitcoin/commit/84c13e759dbb0de282e2c8ce43d77f4d52fda6d9 added an assert if `GetAncestor()` fails to find the parent of the current block (ie if pprev is NULL). This PR adds helpful logging for debugging which block is missing a parent.

This will be helpful for troubleshooting issues like #9001 and #9170.