### PR TITLE
Fail in DecodeHexTx if there is extra data at the end

### DIFF
--- a/src/core_read.cpp
+++ b/src/core_read.cpp
@@ -113,6 +113,8 @@ bool DecodeHexTx(CMutableTransaction& tx, const std::string& strHexTx, bool fTry
     CDataStream ssData(txData, SER_NETWORK, PROTOCOL_VERSION);
     try {
         ssData >> tx;
+        if (!ssData.empty())
+            return false;
     }
     catch (const std::exception&) {
         return false;


### PR DESCRIPTION
Rebasing @TheBlueMatt's work.
I'm not sure if this qualifies as a bugfix for 0.14. 