### PR TITLE
Fix super-unlikely race introduced in 236618061a445d2cb11e72

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1833,11 +1833,11 @@ bool CConnman::OpenNetworkConnection(const CAddress& addrConnect, bool fCountFai
     if (fAddnode)
         pnode->fAddnode = true;
 
+    GetNodeSignals().InitializeNode(pnode, *this);
     {
         LOCK(cs_vNodes);
         vNodes.push_back(pnode);
     }
-    GetNodeSignals().InitializeNode(pnode, *this);
 
     return true;
 }


### PR DESCRIPTION
Once the CNode has been added to vNodes, it is possible that it is
disconnected+deleted in the socket handler thread. However, after
that we now call InitializeNode, which accesses the pnode.

helgrind managed to tickle this case (somehow), but I suspect it
requires in immensely braindead scheduler.