### PR TITLE
Fix typo and spelling inconsistency in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -194,7 +194,7 @@ request. Typically reviewers will review the code for obvious errors, as well as
 test out the patch set and opine on the technical merits of the patch. Project
 maintainers take into account the peer review when determining if there is
 consensus to merge a pull request (remember that discussions may have been
-spread out over github, mailing list and IRC discussions). The following
+spread out over GitHub, mailing list and IRC discussions). The following
 language is used within pull-request comments:
 
   - ACK means "I have tested the code and I agree it should be merged";

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -3,7 +3,7 @@ Repository Tools
 
 ### [Developer tools](/contrib/devtools) ###
 Specific tools for developers working on this repository.
-Contains the script `github-merge.py` for merging github pull requests securely and signing them using GPG.
+Contains the script `github-merge.py` for merging GitHub pull requests securely and signing them using GPG.
 
 ### [Verify-Commits](/contrib/verify-commits) ###
 Tool to verify that every merge commit was signed by a developer using the above `github-merge.py` script.

--- a/contrib/devtools/README.md
+++ b/contrib/devtools/README.md
@@ -125,7 +125,7 @@ check or whatever).
 
 This means that there are no potential race conditions (where a
 pullreq gets updated while you're reviewing it, but before you click
-merge), and when using GPG signatures, that even a compromised github
+merge), and when using GPG signatures, that even a compromised GitHub
 couldn't mess with the sources.
 
 Setup

--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -448,7 +448,7 @@ Current subtrees include:
   - Upstream at https://github.com/jgarzik/univalue ; report important PRs to Core to avoid delay.
 
 
-Git and github tips
+Git and GitHub tips
 ---------------------
 
 - For resolving merge/rebase conflicts, it can be useful to enable diff3 style using

--- a/doc/translation_process.md
+++ b/doc/translation_process.md
@@ -4,7 +4,7 @@ Translations
 The Bitcoin-Core project has been designed to support multiple localisations. This makes adding new phrases, and completely new languages easily achievable. For managing all application translations, Bitcoin-Core makes use of the Transifex online translation management tool.
 
 ### Helping to translate (using Transifex)
-Transifex is setup to monitor the Github repo for updates, and when code containing new translations is found, Transifex will process any changes. It may take several hours after a pull-request has been merged, to appear in the Transifex web interface.
+Transifex is setup to monitor the GitHub repo for updates, and when code containing new translations is found, Transifex will process any changes. It may take several hours after a pull-request has been merged, to appear in the Transifex web interface.
 
 Multiple language support is critical in assisting Bitcoin’s global adoption, and growth. One of Bitcoin’s greatest strengths is cross-border money transfers, any help making that easier is greatly appreciated.
 
@@ -32,7 +32,7 @@ QToolBar *toolbar = addToolBar(tr("Tabs toolbar"));
 ### Creating a pull-request
 For general PRs, you shouldn’t include any updates to the translation source files. They will be updated periodically, primarily around pre-releases, allowing time for any new phrases to be translated before public releases. This is also important in avoiding translation related merge conflicts.
 
-When an updated source file is merged into the Github repo, Transifex will automatically detect it (although it can take several hours). Once processed, the new strings will show up as "Remaining" in the Transifex web interface and are ready for translators.
+When an updated source file is merged into the GitHub repo, Transifex will automatically detect it (although it can take several hours). Once processed, the new strings will show up as "Remaining" in the Transifex web interface and are ready for translators.
 
 To create the pull-request, use the following commands:
 ```

--- a/doc/zmq.md
+++ b/doc/zmq.md
@@ -1,4 +1,4 @@
-# Block and Transaction Broadcasting With ZeroMQ
+# Block and Transaction Broadcasting with ZeroMQ
 
 [ZeroMQ](http://zeromq.org/) is a lightweight wrapper around TCP
 connections, inter-process communication, and shared-memory,
@@ -50,7 +50,7 @@ during the *configure* step of building bitcoind:
     $ ./configure --disable-zmq (other options)
 
 To actually enable operation, one must set the appropriate options on
-the commandline or in the configuration file.
+the command line or in the configuration file.
 
 ## Usage
 


### PR DESCRIPTION
Fix some typo and spelling inconsistency in CONTRIBUTING.md.

- Unifying `behaviour` and `behavior`
- Fix `modularisation ` to `modularization`
- Fix `GitHub`