### PR TITLE
Use arc4random for entropy on supported systems

### DIFF
--- a/src/random.cpp
+++ b/src/random.cpp
@@ -105,6 +105,8 @@ static void GetOSRand(unsigned char *ent32)
         RandFailure();
     }
     CryptReleaseContext(hProvider, 0);
+#elif arc4random_supported
+    arc4random_buf(ent32,32);
 #else
     int f = open("/dev/urandom", O_RDONLY);
     if (f == -1) {


### PR DESCRIPTION
This commit is half the fix for issue https://github.com/bitcoin/bitcoin/issues/9676 .

The purpose is to use arc4random() for entropy instead of "/dev/urandom", on supported systems, so that BitcoinD hence will function in environments where there is no "/dev/urandom", which can be the case for various reasons (nodev filesystem, chroot, etc.).

** To function, this commit must be complemented with autodetection of arc4random() support and accordingly setting the arc4random_supported define when found.

Someone else make such a commit please. Thanks!