### PR TITLE
Change 'Clear' button string to 'Reset'

### DIFF
--- a/src/qt/forms/debugwindow.ui
+++ b/src/qt/forms/debugwindow.ui
@@ -645,7 +645,7 @@
            <item>
             <widget class="QPushButton" name="btnClearTrafficGraph">
              <property name="text">
-              <string>&amp;Clear</string>
+              <string>&amp;Reset</string>
              </property>
              <property name="autoDefault">
               <bool>false</bool>


### PR DESCRIPTION
Easier to understand what the button does (it resets the graph view).

'Clear' might mean that the graph is emptied and stops updating, whereas its easier to see that you're just starting fresh with 'Reset'.