### PR TITLE
net: fix socket close race

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -572,6 +572,7 @@ public:
     uint64_t nSendBytes;
     std::deque<std::vector<unsigned char>> vSendMsg;
     CCriticalSection cs_vSend;
+    CCriticalSection cs_hSocket;
 
     CCriticalSection cs_vProcessMsg;
     std::list<CNetMessage> vProcessMsg;


### PR DESCRIPTION
This fixes an observed crash as a result of trying to use hSocket after it's been set to -1.

The first commit just rearranges things so that we can lock in a consistent order (avoiding a possible inversion involving cs_vSend and cs_hSocket).

The second adds a lock everywhere hSocket is touched, and checks that it's still valid before using it.