### PR TITLE
Store downloaded blocks prior to shutdown.

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -73,6 +73,7 @@ CCriticalSection cs_mapLocalHost;
 std::map<CNetAddr, LocalServiceInfo> mapLocalHost;
 static bool vfLimited[NET_MAX] = {};
 std::string strSubVersion;
+std::atomic<int> nBlocksToBeProcessed(0);
 
 limitedmap<uint256, int64_t> mapAlreadyAskedFor(MAX_INV_SZ);
 
@@ -672,7 +673,10 @@ bool CNode::ReceiveMsgBytes(const char *pch, unsigned int nBytes, bool& complete
         nBytes -= handled;
 
         if (msg.complete()) {
-
+            if (msg.hdr.pchCommand == NetMsgType::BLOCK) {
+                nBlocksToBeProcessed++;
+                ::nBlocksToBeProcessed++;
+            }
             //store received bytes per message command
             //to prevent a memory DOS, only allow valid commands
             mapMsgCmdSize::iterator i = mapRecvBytesPerMsgCmd.find(msg.hdr.pchCommand);
@@ -1844,7 +1848,7 @@ bool CConnman::OpenNetworkConnection(const CAddress& addrConnect, bool fCountFai
 
 void CConnman::ThreadMessageHandler()
 {
-    while (!flagInterruptMsgProc)
+    while (!flagInterruptMsgProc || nBlocksToBeProcessed > 0)
     {
         std::vector<CNode*> vNodesCopy;
         {
@@ -1865,15 +1869,15 @@ void CConnman::ThreadMessageHandler()
             // Receive messages
             bool fMoreNodeWork = GetNodeSignals().ProcessMessages(pnode, *this, flagInterruptMsgProc);
             fMoreWork |= (fMoreNodeWork && !pnode->fPauseSend);
-            if (flagInterruptMsgProc)
+            if (flagInterruptMsgProc && nBlocksToBeProcessed < 1)
                 return;
 
             // Send messages
+            if (!flagInterruptMsgProc)
             {
                 LOCK(pnode->cs_sendProcessing);
                 GetNodeSignals().SendMessages(pnode, *this, flagInterruptMsgProc);
-            }
-            if (flagInterruptMsgProc)
+            } else if (nBlocksToBeProcessed < 1)
                 return;
         }
 
@@ -1884,9 +1888,8 @@ void CConnman::ThreadMessageHandler()
         }
 
         std::unique_lock<std::mutex> lock(mutexMsgProc);
-        if (!fMoreWork) {
+        if (!fMoreWork && nBlocksToBeProcessed < 1)
             condMsgProc.wait_until(lock, std::chrono::steady_clock::now() + std::chrono::milliseconds(100), [this] { return fMsgProcWake; });
-        }
         fMsgProcWake = false;
     }
 }
@@ -2277,7 +2280,7 @@ void CConnman::DeleteNode(CNode* pnode)
 {
     assert(pnode);
     bool fUpdateConnectionTime = false;
-    GetNodeSignals().FinalizeNode(pnode->GetId(), fUpdateConnectionTime);
+    GetNodeSignals().FinalizeNode(pnode, fUpdateConnectionTime);
     if(fUpdateConnectionTime)
         addrman.Connected(pnode->addr);
     delete pnode;
@@ -2535,6 +2538,7 @@ CNode::CNode(NodeId idIn, ServiceFlags nLocalServicesIn, int nMyStartingHeightIn
     nRecvVersion = INIT_PROTO_VERSION;
     nLastSend = 0;
     nLastRecv = 0;
+    nBlocksToBeProcessed = 0;
     nSendBytes = 0;
     nRecvBytes = 0;
     nTimeConnected = GetSystemTimeInSeconds();

--- a/src/net.h
+++ b/src/net.h
@@ -468,7 +468,7 @@ struct CNodeSignals
     boost::signals2::signal<bool (CNode*, CConnman&, std::atomic<bool>&), CombinerAll> ProcessMessages;
     boost::signals2::signal<bool (CNode*, CConnman&, std::atomic<bool>&), CombinerAll> SendMessages;
     boost::signals2::signal<void (CNode*, CConnman&)> InitializeNode;
-    boost::signals2::signal<void (NodeId, bool&)> FinalizeNode;
+    boost::signals2::signal<void (CNode*, bool&)> FinalizeNode;
 };
 
 
@@ -505,6 +505,7 @@ CAddress GetLocalAddress(const CNetAddr *paddrPeer, ServiceFlags nLocalServices)
 extern bool fDiscover;
 extern bool fListen;
 extern bool fRelayTxes;
+extern std::atomic<int> nBlocksToBeProcessed;
 
 extern limitedmap<uint256, int64_t> mapAlreadyAskedFor;
 
@@ -622,6 +623,7 @@ public:
 
     int64_t nLastSend;
     int64_t nLastRecv;
+    std::atomic<int> nBlocksToBeProcessed; // blocks received but not yet processed
     int64_t nTimeConnected;
     int64_t nTimeOffset;
     const CAddress addr;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2474,6 +2474,9 @@ bool ActivateBestChain(CValidationState &state, const CChainParams& chainparams,
     // us in the middle of ProcessNewBlock - do not assume pblock is set
     // sanely for performance or correctness!
 
+    if (ShutdownRequested())
+        return true;
+
     CBlockIndex *pindexMostWork = NULL;
     CBlockIndex *pindexNewTip = NULL;
     do {


### PR DESCRIPTION
Fixes #9703 

Intentionally does not process blocks from disconnecting peers (although this could be changed if it is desired behavior).