### PR TITLE
build: Add options to override BDB cflags/libs

### DIFF
--- a/build-aux/m4/bitcoin_find_bdb48.m4
+++ b/build-aux/m4/bitcoin_find_bdb48.m4
@@ -3,68 +3,76 @@ dnl Distributed under the MIT software license, see the accompanying
 dnl file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 AC_DEFUN([BITCOIN_FIND_BDB48],[
-  AC_MSG_CHECKING([for Berkeley DB C++ headers])
-  BDB_CPPFLAGS=
-  BDB_LIBS=
-  bdbpath=X
-  bdb48path=X
-  bdbdirlist=
-  for _vn in 4.8 48 4 5 ''; do
-    for _pfx in b lib ''; do
-      bdbdirlist="$bdbdirlist ${_pfx}db${_vn}"
+  AC_ARG_VAR(BDB_CFLAGS, [C compiler flags for BerkeleyDB, bypasses autodetection])
+  AC_ARG_VAR(BDB_LIBS, [Linker flags for BerkeleyDB, bypasses autodetection])
+
+  if test "x$BDB_CFLAGS" = "x"; then
+    AC_MSG_CHECKING([for Berkeley DB C++ headers])
+    BDB_CPPFLAGS=
+    bdbpath=X
+    bdb48path=X
+    bdbdirlist=
+    for _vn in 4.8 48 4 5 ''; do
+      for _pfx in b lib ''; do
+        bdbdirlist="$bdbdirlist ${_pfx}db${_vn}"
+      done
     done
-  done
-  for searchpath in $bdbdirlist ''; do
-    test -n "${searchpath}" && searchpath="${searchpath}/"
-    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-      #include <${searchpath}db_cxx.h>
-    ]],[[
-      #if !((DB_VERSION_MAJOR == 4 && DB_VERSION_MINOR >= 8) || DB_VERSION_MAJOR > 4)
-        #error "failed to find bdb 4.8+"
-      #endif
-    ]])],[
-      if test "x$bdbpath" = "xX"; then
-        bdbpath="${searchpath}"
-      fi
-    ],[
-      continue
-    ])
-    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-      #include <${searchpath}db_cxx.h>
-    ]],[[
-      #if !(DB_VERSION_MAJOR == 4 && DB_VERSION_MINOR == 8)
-        #error "failed to find bdb 4.8"
-      #endif
-    ]])],[
-      bdb48path="${searchpath}"
-      break
-    ],[])
-  done
-  if test "x$bdbpath" = "xX"; then
-    AC_MSG_RESULT([no])
-    AC_MSG_ERROR([libdb_cxx headers missing, ]AC_PACKAGE_NAME[ requires this library for wallet functionality (--disable-wallet to disable wallet functionality)])
-  elif test "x$bdb48path" = "xX"; then
-    BITCOIN_SUBDIR_TO_INCLUDE(BDB_CPPFLAGS,[${bdbpath}],db_cxx)
-    AC_ARG_WITH([incompatible-bdb],[AS_HELP_STRING([--with-incompatible-bdb], [allow using a bdb version other than 4.8])],[
-      AC_MSG_WARN([Found Berkeley DB other than 4.8; wallets opened by this build will not be portable!])
-    ],[
-      AC_MSG_ERROR([Found Berkeley DB other than 4.8, required for portable wallets (--with-incompatible-bdb to ignore or --disable-wallet to disable wallet functionality)])
-    ])
+    for searchpath in $bdbdirlist ''; do
+      test -n "${searchpath}" && searchpath="${searchpath}/"
+      AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+        #include <${searchpath}db_cxx.h>
+      ]],[[
+        #if !((DB_VERSION_MAJOR == 4 && DB_VERSION_MINOR >= 8) || DB_VERSION_MAJOR > 4)
+          #error "failed to find bdb 4.8+"
+        #endif
+      ]])],[
+        if test "x$bdbpath" = "xX"; then
+          bdbpath="${searchpath}"
+        fi
+      ],[
+        continue
+      ])
+      AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+        #include <${searchpath}db_cxx.h>
+      ]],[[
+        #if !(DB_VERSION_MAJOR == 4 && DB_VERSION_MINOR == 8)
+          #error "failed to find bdb 4.8"
+        #endif
+      ]])],[
+        bdb48path="${searchpath}"
+        break
+      ],[])
+    done
+    if test "x$bdbpath" = "xX"; then
+      AC_MSG_RESULT([no])
+      AC_MSG_ERROR([libdb_cxx headers missing, ]AC_PACKAGE_NAME[ requires this library for wallet functionality (--disable-wallet to disable wallet functionality)])
+    elif test "x$bdb48path" = "xX"; then
+      BITCOIN_SUBDIR_TO_INCLUDE(BDB_CPPFLAGS,[${bdbpath}],db_cxx)
+      AC_ARG_WITH([incompatible-bdb],[AS_HELP_STRING([--with-incompatible-bdb], [allow using a bdb version other than 4.8])],[
+        AC_MSG_WARN([Found Berkeley DB other than 4.8; wallets opened by this build will not be portable!])
+      ],[
+        AC_MSG_ERROR([Found Berkeley DB other than 4.8, required for portable wallets (--with-incompatible-bdb to ignore or --disable-wallet to disable wallet functionality)])
+      ])
+    else
+      BITCOIN_SUBDIR_TO_INCLUDE(BDB_CPPFLAGS,[${bdb48path}],db_cxx)
+      bdbpath="${bdb48path}"
+    fi
   else
-    BITCOIN_SUBDIR_TO_INCLUDE(BDB_CPPFLAGS,[${bdb48path}],db_cxx)
-    bdbpath="${bdb48path}"
+    BDB_CPPFLAGS=${BDB_CFLAGS}
   fi
   AC_SUBST(BDB_CPPFLAGS)
   
-  # TODO: Ideally this could find the library version and make sure it matches the headers being used
-  for searchlib in db_cxx-4.8 db_cxx; do
-    AC_CHECK_LIB([$searchlib],[main],[
-      BDB_LIBS="-l${searchlib}"
-      break
-    ])
-  done
   if test "x$BDB_LIBS" = "x"; then
-      AC_MSG_ERROR([libdb_cxx missing, ]AC_PACKAGE_NAME[ requires this library for wallet functionality (--disable-wallet to disable wallet functionality)])
+    # TODO: Ideally this could find the library version and make sure it matches the headers being used
+    for searchlib in db_cxx-4.8 db_cxx; do
+      AC_CHECK_LIB([$searchlib],[main],[
+        BDB_LIBS="-l${searchlib}"
+        break
+      ])
+    done
+    if test "x$BDB_LIBS" = "x"; then
+        AC_MSG_ERROR([libdb_cxx missing, ]AC_PACKAGE_NAME[ requires this library for wallet functionality (--disable-wallet to disable wallet functionality)])
+    fi
   fi
   AC_SUBST(BDB_LIBS)
 ])

--- a/doc/build-openbsd.md
+++ b/doc/build-openbsd.md
@@ -1,6 +1,6 @@
 OpenBSD build guide
 ======================
-(updated for OpenBSD 5.9)
+(updated for OpenBSD 6.0)
 
 This guide describes how to build bitcoind and command-line utilities on OpenBSD.
 
@@ -124,7 +124,7 @@ To configure with wallet:
 ```bash
 ./configure --with-gui=no --with-boost=$BOOST_PREFIX \
     CC=egcc CXX=eg++ CPP=ecpp \
-    LDFLAGS="-L${BDB_PREFIX}/lib/" CPPFLAGS="-I${BDB_PREFIX}/include/"
+    BDB_LIBS="-L${BDB_PREFIX}/lib -ldb_cxx-4.8" BDB_CFLAGS="-I${BDB_PREFIX}/include"
 ```
 
 To configure without wallet:
@@ -141,6 +141,8 @@ gmake check
 
 Clang (not currently working)
 ------------------------------
+
+WARNING: This is outdated, needs to be updated for OpenBSD 6.0 and re-tried.
 
 Using a newer g++ results in linking the new code to a new libstdc++.
 Libraries built with the old g++, will still import the old library.

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -315,7 +315,7 @@ For further documentation on the depends system see [README.md](../depends/READM
 Building on FreeBSD
 --------------------
 
-(Updated as of FreeBSD 10.3)
+(Updated as of FreeBSD 11.0)
 
 Clang is installed by default as `cc` compiler, this makes it easier to get
 started than on [OpenBSD](build-openbsd.md). Installing dependencies:
@@ -337,7 +337,7 @@ with 4.8-built Bitcoin Core is needed follow the steps under "Berkeley DB" above
 Then build using:
 
     ./autogen.sh
-    ./configure --with-incompatible-bdb CPPFLAGS=-I/usr/local/include/db5 LDFLAGS=-L/usr/local/lib/db5
+    ./configure --with-incompatible-bdb BDB_CFLAGS="-I/usr/local/include/db5" BDB_LIBS="-L/usr/local/lib -ldb_cxx-5"
     make
 
 *Note on debugging*: The version of `gdb` installed by default is [ancient and considered harmful](https://wiki.freebsd.org/GdbRetirement).


### PR DESCRIPTION
Add environment settings to specify the CFLAGS and LIBS to be used for BerkeleyDB directly. These will completely by-pass autodetection in the same way as other similar flags for pkgconfig.

```
BDB_CFLAGS  C compiler flags for BerkeleyDB, bypasses autodetection
BDB_LIBS    Linker flags for BerkeleyDB, bypasses autodetection
```

Implements #3921.

Also update *BSD build guides to use these.