### PR TITLE
Remove unicode characters from RPC user and password in QA tests

### DIFF
--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -192,7 +192,7 @@ def initialize_datadir(dirname, n):
     return datadir
 
 def rpc_auth_pair(n):
-    return 'rpcuser💻' + str(n), 'rpcpass🔑' + str(n)
+    return 'rpcuser' + str(n), 'rpcpass' + str(n)
 
 def rpc_url(i, rpchost=None):
     rpc_u, rpc_p = rpc_auth_pair(i)


### PR DESCRIPTION
The characters are cute, but they're difficult to type into bitcoin-cli
if you need to halt the test and manually issue RPCs to the node under
test.