### PR TITLE
Fix RPC failure testing

### DIFF
--- a/qa/rpc-tests/rpcnamedargs.py
+++ b/qa/rpc-tests/rpcnamedargs.py
@@ -37,7 +37,7 @@ class NamedArgumentTest(BitcoinTestFramework):
         h = node.help(command='getinfo')
         assert(h.startswith('getinfo\n'))
 
-        assert_raises_jsonrpc(-8, node.help, random='getinfo')
+        assert_raises_jsonrpc(-8, 'Unknown named parameter', node.help, random='getinfo')
 
         h = node.getblockhash(height=0)
         node.getblock(blockhash=h)

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -550,13 +550,30 @@ def assert_raises_message(exc, message, fun, *args, **kwds):
     else:
         raise AssertionError("No exception raised")
 
-def assert_raises_jsonrpc(code, fun, *args, **kwds):
-    '''Check for specific JSONRPC exception code'''
+def assert_raises_jsonrpc(code, message, fun, *args, **kwds):
+    """Run an RPC and verify that a specific JSONRPC exception code and message is raised.
+
+    Calls function `fun` with arguments `args` and `kwds`. Catches a JSONRPCException
+    and verifies that the error code and message are as expected. Throws AssertionError if
+    no JSONRPCException was returned or if the error code/message are not as expected.
+
+    Args:
+        code (int), optional: the error code returned by the RPC call (defined
+            in src/rpc/protocol.h). Set to None if checking the error code is not required.
+        message (string), optional: [a substring of] the error string returned by the
+            RPC call. Set to None if checking the error string is not required
+        fun (function): the function to call. This should be the name of an RPC.
+        args*: positional arguments for the function.
+        kwds**: named arguments for the function.
+    """
     try:
         fun(*args, **kwds)
     except JSONRPCException as e:
-        if e.error["code"] != code:
+        # JSONRPCException was thrown as expected. Check the code and message values are correct.
+        if (code is not None) and (code != e.error["code"]):
             raise AssertionError("Unexpected JSONRPC error code %i" % e.error["code"])
+        if (message is not None) and (message not in e.error['message']):
+            raise AssertionError("Expected substring not found:"+e.error['message'])
     except Exception as e:
         raise AssertionError("Unexpected exception raised: "+type(e).__name__)
     else:


### PR DESCRIPTION
RPC interface testing should include failure test cases (ie where we call an RPC with parameters that we expect to fail). The failure test cases should follow this pattern:

```python
try:
    nodes.rpcfunction(paramters,...) 
except JSONRPCException as exp: #(1) must only catch JSONRPCExceptions
    assert_equal(exp.error["code"], EXPECTED_ERROR_CODE)  #(2) must verify error code
    assert_equal(exp.error["message"], "Expected error message")  #(3) must verify error message
else:
    assert(False) #(4) must fail the test if no JSONRPCException raised
```

Unfortunately, many of the test cases in `qa/rpc-tests` get this pattern wrong and don't actually test what they're supposed to.

Exhibit A:

```python
        try:
            self.nodes[0].generatetoaddress(1, 'mneYUmWYsuk7kySiURxCi3AGxrAqZxLgPZ')
        except JSONRPCException as e:
            assert("Invalid address" not in e.error['message'])
            assert("ProcessNewBlock, block not accepted" not in e.error['message'])
            assert("Couldn't create new block" not in e.error['message'])
```

The call to `generatetoaddress()` actually succeeds here, but there isn't an `else:` clause so the test continues (and none of the code in the `except:` branch is executing)

Exhibit B:

```python
        try:
            tmpl = self.nodes[0].getblocktemplate({})
            assert(len(tmpl['transactions']) == 1)  # Doesn't include witness tx
            assert(tmpl['sigoplimit'] == 20000)
            assert(tmpl['transactions'][0]['hash'] == txid)
            assert(tmpl['transactions'][0]['sigops'] == 2)
            assert(('!segwit' in tmpl['rules']) or ('segwit' not in tmpl['rules']))
        except JSONRPCException:
            # This is an acceptable outcome
            pass
```

The call to `getblocktemplate()` is raising an exception. Apparently `This is an acceptable outcome`, but there's no explanation why. None of the asserts in the `try:` branch are being executed. There's also no checking of the error code/message of the JSONRPCException.

Exhibit C:

```python
assert_raises(JSONRPCException, self.nodes[0].gettransaction, [txid3])
#there must be a expection because the unconfirmed wallettx0 must be gone by now
```

This is using the helper function `assert_raises()` and the comment explains that the call should fail because the unconfirmed transaction is gone. There's no testing of the error message or code. In fact, `gettransaction()` is failing because it's being called with an array `[txid3]` instead of a string `txid3`.

This PR improves the `assert_raises_jsonrpc()` to verify error cause and error message and improves the commenting of that function. Future PRs will go over all the qa tests, remove the various broken implementations of this pattern and replace them with calls to `assert_raises_jsonrpc()`.

This should also prevent the same bugs from being introduced in future because it should now be easier to get this right (by calling `assert_raises_jsonrpc()`) than get it wrong (by trying to reimplement the pattern and failing)