### PR TITLE
Pow: Remove fCheckPOW from CheckBlockHeader

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2636,10 +2636,10 @@ static bool FindUndoPos(CValidationState &state, int nFile, CDiskBlockPos &pos, 
     return true;
 }
 
-static bool CheckBlockHeader(const CBlockHeader& block, CValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOW = true)
+static bool CheckBlockHeader(const CBlockHeader& block, CValidationState& state, const Consensus::Params& consensusParams)
 {
     // Check proof of work matches claimed amount
-    if (fCheckPOW && !CheckProofOfWork(block.GetHash(), block.nBits, consensusParams))
+    if (!CheckProofOfWork(block.GetHash(), block.nBits, consensusParams))
         return state.DoS(50, false, REJECT_INVALID, "high-hash", false, "proof of work failed");
 
     return true;
@@ -2654,7 +2654,7 @@ bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::P
 
     // Check that the header is valid (particularly PoW).  This is mostly
     // redundant with the call in AcceptBlockHeader.
-    if (!CheckBlockHeader(block, state, consensusParams, fCheckPOW))
+    if (fCheckPOW && !CheckBlockHeader(block, state, consensusParams))
         return false;
 
     // Check the merkle root.


### PR DESCRIPTION
After the time checks were removed from CheckBlockHeader, ```, bool fCheckPOW``` makes no sense.
Nobody is calling it with fCheckPOW=false and if they were, they could simply not call CheckBlockHeader.
