### PR TITLE
Allow abort of ConnectBlock() when shutdown requested.

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1870,6 +1870,10 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     txdata.reserve(block.vtx.size()); // Required so that pointers to individual PrecomputedTransactionData don't get invalidated
     for (unsigned int i = 0; i < block.vtx.size(); i++)
     {
+        if (ShutdownRequested()) {
+            LogPrint("block", "%s: Shutdown requested. Aborting at %d%%.\n", __func__, i * 100 / block.vtx.size());
+            return false;
+        }
         const CTransaction &tx = *(block.vtx[i]);
 
         nInputs += tx.vin.size();
@@ -2269,7 +2273,9 @@ bool static ConnectTip(CValidationState& state, const CChainParams& chainparams,
         if (!rv) {
             if (state.IsInvalid())
                 InvalidBlockFound(pindexNew, state);
-            return error("ConnectTip(): ConnectBlock %s failed", pindexNew->GetBlockHash().ToString());
+            if (!ShutdownRequested())
+                error("ConnectTip(): ConnectBlock %s failed.", pindexNew->GetBlockHash().ToString());
+            return false;
         }
         nTime3 = GetTimeMicros(); nTimeConnectTotal += nTime3 - nTime2;
         LogPrint("bench", "  - Connect total: %.2fms [%.2fs]\n", (nTime3 - nTime2) * 0.001, nTimeConnectTotal * 0.000001);


### PR DESCRIPTION
Fixes one of the issues mentioned in #9668 - i.e. speeds up shutdown (can save over 30 seconds in some cases), which can cause shutdown to be aborted on some operating systems (if the OS does not allow as much time as bitcoind was requiring).