### PR TITLE
net: fix banning and disallow sending messages before receiving verack

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -154,6 +154,7 @@ testScripts = [
     'bumpfee.py',
     'rpcnamedargs.py',
     'listsinceblock.py',
+    'p2p-leaktests.py',
 ]
 if ENABLE_ZMQ:
     testScripts.append('zmq_test.py')

--- a/qa/rpc-tests/p2p-leaktests.py
+++ b/qa/rpc-tests/p2p-leaktests.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from test_framework.mininode import *
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+
+'''
+Test for message sending before handshake completion
+
+A node should never send anything other than VERSION/VERACK/REJECT until it's
+received a VERACK.
+
+This test connects to a node and sends it a few messages, trying to intice it
+into sending us something it shouldn't.
+'''
+
+banscore = 10
+
+class CLazyNode(NodeConnCB):
+    def __init__(self):
+        self.connection = None
+        self.unexpected_msg = False
+        self.connected = False
+        super().__init__()
+
+    def add_connection(self, conn):
+        self.connection = conn
+
+    def send_message(self, message):
+        self.connection.send_message(message)
+
+    def bad_message(self, message):
+        self.unexpected_msg = True
+        print("should not have received message: %s" % message.command)
+
+    def on_open(self, conn):
+        self.connected = True
+
+    def on_version(self, conn, message): self.bad_message(message)
+    def on_verack(self, conn, message): self.bad_message(message)
+    def on_reject(self, conn, message): self.bad_message(message)
+    def on_inv(self, conn, message): self.bad_message(message)
+    def on_addr(self, conn, message): self.bad_message(message)
+    def on_alert(self, conn, message): self.bad_message(message)
+    def on_getdata(self, conn, message): self.bad_message(message)
+    def on_getblocks(self, conn, message): self.bad_message(message)
+    def on_tx(self, conn, message): self.bad_message(message)
+    def on_block(self, conn, message): self.bad_message(message)
+    def on_getaddr(self, conn, message): self.bad_message(message)
+    def on_headers(self, conn, message): self.bad_message(message)
+    def on_getheaders(self, conn, message): self.bad_message(message)
+    def on_ping(self, conn, message): self.bad_message(message)
+    def on_mempool(self, conn): self.bad_message(message)
+    def on_pong(self, conn, message): self.bad_message(message)
+    def on_feefilter(self, conn, message): self.bad_message(message)
+    def on_sendheaders(self, conn, message): self.bad_message(message)
+    def on_sendcmpct(self, conn, message): self.bad_message(message)
+    def on_cmpctblock(self, conn, message): self.bad_message(message)
+    def on_getblocktxn(self, conn, message): self.bad_message(message)
+    def on_blocktxn(self, conn, message): self.bad_message(message)
+
+# Node that never sends a version. We'll use this to send a bunch of messages
+# anyway, and eventually get disconnected.
+class CNodeNoVersionBan(CLazyNode):
+    def __init__(self):
+        super().__init__()
+
+    # send a bunch of veracks without sending a message. This should get us disconnected.
+    # NOTE: implementation-specific check here. Remove if bitcoind ban behavior changes
+    def on_open(self, conn):
+        super().on_open(conn)
+        for i in range(banscore):
+            self.send_message(msg_verack())
+
+    def on_reject(self, conn, message): pass
+
+# Node that never sends a version. This one just sits idle and hopes to receive
+# any message (it shouldn't!)
+class CNodeNoVersionIdle(CLazyNode):
+    def __init__(self):
+        super().__init__()
+
+# Node that sends a version but not a verack.
+class CNodeNoVerackIdle(CLazyNode):
+    def __init__(self):
+        self.version_received = False
+        super().__init__()
+
+    def on_reject(self, conn, message): pass
+    def on_verack(self, conn, message): pass
+    # When version is received, don't reply with a verack. Instead, see if the
+    # node will give us a message that it shouldn't. This is not an exhaustive
+    # list!
+    def on_version(self, conn, message):
+        self.version_received = True
+        conn.send_message(msg_ping())
+        conn.send_message(msg_getaddr())
+
+class P2PLeakTest(BitcoinTestFramework):
+    def __init__(self):
+        super().__init__()
+        self.num_nodes = 1
+    def setup_network(self):
+        extra_args = [['-debug', '-banscore='+str(banscore)]
+                      for i in range(self.num_nodes)]
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, extra_args)
+
+    def run_test(self):
+        no_version_bannode = CNodeNoVersionBan()
+        no_version_idlenode = CNodeNoVersionIdle()
+        no_verack_idlenode = CNodeNoVerackIdle()
+
+        connections = []
+        connections.append(NodeConn('127.0.0.1', p2p_port(0), self.nodes[0], no_version_bannode, send_version=False))
+        connections.append(NodeConn('127.0.0.1', p2p_port(0), self.nodes[0], no_version_idlenode, send_version=False))
+        connections.append(NodeConn('127.0.0.1', p2p_port(0), self.nodes[0], no_verack_idlenode))
+        no_version_bannode.add_connection(connections[0])
+        no_version_idlenode.add_connection(connections[1])
+        no_verack_idlenode.add_connection(connections[2])
+
+        NetworkThread().start()  # Start up network handling in another thread
+
+        assert(wait_until(lambda: no_version_bannode.connected and no_version_idlenode.connected and no_verack_idlenode.version_received, timeout=10))
+
+        # Mine a block and make sure that it's not sent to the connected nodes
+        self.nodes[0].generate(1)
+
+        #Give the node enough time to possibly leak out a message
+        time.sleep(5)
+
+        #This node should have been banned
+        assert(no_version_bannode.connection.state == "closed")
+
+        [conn.disconnect_node() for conn in connections]
+
+        # Make sure no unexpected messages came in
+        assert(no_version_bannode.unexpected_msg == False)
+        assert(no_version_idlenode.unexpected_msg == False)
+        assert(no_verack_idlenode.unexpected_msg == False)
+
+if __name__ == '__main__':
+    P2PLeakTest().main()

--- a/qa/rpc-tests/test_framework/mininode.py
+++ b/qa/rpc-tests/test_framework/mininode.py
@@ -1614,7 +1614,7 @@ class NodeConn(asyncore.dispatcher):
         "regtest": b"\xfa\xbf\xb5\xda",   # regtest
     }
 
-    def __init__(self, dstaddr, dstport, rpc, callback, net="regtest", services=NODE_NETWORK):
+    def __init__(self, dstaddr, dstport, rpc, callback, net="regtest", services=NODE_NETWORK, send_version=True):
         asyncore.dispatcher.__init__(self, map=mininode_socket_map)
         self.log = logging.getLogger("NodeConn(%s:%d)" % (dstaddr, dstport))
         self.dstaddr = dstaddr
@@ -1631,14 +1631,16 @@ class NodeConn(asyncore.dispatcher):
         self.disconnect = False
         self.nServices = 0
 
-        # stuff version msg into sendbuf
-        vt = msg_version()
-        vt.nServices = services
-        vt.addrTo.ip = self.dstaddr
-        vt.addrTo.port = self.dstport
-        vt.addrFrom.ip = "0.0.0.0"
-        vt.addrFrom.port = 0
-        self.send_message(vt, True)
+        if send_version:
+            # stuff version msg into sendbuf
+            vt = msg_version()
+            vt.nServices = services
+            vt.addrTo.ip = self.dstaddr
+            vt.addrTo.port = self.dstport
+            vt.addrFrom.ip = "0.0.0.0"
+            vt.addrFrom.port = 0
+            self.send_message(vt, True)
+
         print('MiniNode: Connecting to Bitcoin Node IP # ' + dstaddr + ':' \
             + str(dstport))
 
@@ -1652,8 +1654,9 @@ class NodeConn(asyncore.dispatcher):
         self.log.debug(msg)
 
     def handle_connect(self):
-        self.show_debug_msg("MiniNode: Connected & Listening: \n")
-        self.state = "connected"
+        if self.state != "connected":
+            self.show_debug_msg("MiniNode: Connected & Listening: \n")
+            self.state = "connected"
 
     def handle_close(self):
         self.show_debug_msg("MiniNode: Closing Connection to %s:%d... "
@@ -1681,11 +1684,20 @@ class NodeConn(asyncore.dispatcher):
 
     def writable(self):
         with mininode_lock:
+            pre_connection = self.state == "connecting"
             length = len(self.sendbuf)
-        return (length > 0)
+        return (length > 0 or pre_connection)
 
     def handle_write(self):
         with mininode_lock:
+            # asyncore does not expose socket connection, only the first read/write
+            # event, thus we must check connection manually here to know when we
+            # actually connect
+            if self.state == "connecting":
+                self.handle_connect()
+            if not self.writable():
+                return
+
             try:
                 sent = self.send(self.sendbuf)
             except:

--- a/qa/rpc-tests/test_framework/mininode.py
+++ b/qa/rpc-tests/test_framework/mininode.py
@@ -1540,6 +1540,7 @@ class NodeConnCB(object):
         if conn.ver_send > BIP0031_VERSION:
             conn.send_message(msg_pong(message.nonce))
     def on_reject(self, conn, message): pass
+    def on_open(self, conn): pass
     def on_close(self, conn): pass
     def on_mempool(self, conn): pass
     def on_pong(self, conn, message): pass
@@ -1657,6 +1658,7 @@ class NodeConn(asyncore.dispatcher):
         if self.state != "connected":
             self.show_debug_msg("MiniNode: Connected & Listening: \n")
             self.state = "connected"
+            self.cb.on_open(self)
 
     def handle_close(self):
         self.show_debug_msg("MiniNode: Closing Connection to %s:%d... "

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2596,6 +2596,36 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
     return true;
 }
 
+static bool SendRejectsAndCheckIfBanned(CNode* pnode, CConnman& connman)
+{
+    AssertLockHeld(cs_main);
+    CNodeState &state = *State(pnode->GetId());
+
+    BOOST_FOREACH(const CBlockReject& reject, state.rejects) {
+        connman.PushMessage(pnode, CNetMsgMaker(INIT_PROTO_VERSION).Make(NetMsgType::REJECT, (std::string)NetMsgType::BLOCK, reject.chRejectCode, reject.strRejectReason, reject.hashBlock));
+    }
+    state.rejects.clear();
+
+    if (state.fShouldBan) {
+        state.fShouldBan = false;
+        if (pnode->fWhitelisted)
+            LogPrintf("Warning: not punishing whitelisted peer %s!\n", pnode->addr.ToString());
+        else if (pnode->fAddnode)
+            LogPrintf("Warning: not punishing addnoded peer %s!\n", pnode->addr.ToString());
+        else {
+            pnode->fDisconnect = true;
+            if (pnode->addr.IsLocal())
+                LogPrintf("Warning: not banning local peer %s!\n", pnode->addr.ToString());
+            else
+            {
+                connman.Ban(pnode->addr, BanReasonNodeMisbehaving);
+            }
+        }
+        return true;
+    }
+    return false;
+}
+
 bool ProcessMessages(CNode* pfrom, CConnman& connman, const std::atomic<bool>& interruptMsgProc)
 {
     const CChainParams& chainparams = Params();
@@ -2706,8 +2736,12 @@ bool ProcessMessages(CNode* pfrom, CConnman& connman, const std::atomic<bool>& i
             PrintExceptionContinue(NULL, "ProcessMessages()");
         }
 
-        if (!fRet)
+        if (!fRet) {
             LogPrintf("%s(%s, %u bytes) FAILED peer=%d\n", __func__, SanitizeString(strCommand), nMessageSize, pfrom->id);
+        }
+
+        LOCK(cs_main);
+        SendRejectsAndCheckIfBanned(pfrom, connman);
 
     return fMoreWork;
 }
@@ -2773,29 +2807,9 @@ bool SendMessages(CNode* pto, CConnman& connman, const std::atomic<bool>& interr
         if (!lockMain)
             return true;
 
+        if (SendRejectsAndCheckIfBanned(pto, connman))
+            return true;
         CNodeState &state = *State(pto->GetId());
-
-        BOOST_FOREACH(const CBlockReject& reject, state.rejects)
-            connman.PushMessage(pto, msgMaker.Make(NetMsgType::REJECT, (std::string)NetMsgType::BLOCK, reject.chRejectCode, reject.strRejectReason, reject.hashBlock));
-        state.rejects.clear();
-
-        if (state.fShouldBan) {
-            state.fShouldBan = false;
-            if (pto->fWhitelisted)
-                LogPrintf("Warning: not punishing whitelisted peer %s!\n", pto->addr.ToString());
-            else if (pto->fAddnode)
-                LogPrintf("Warning: not punishing addnoded peer %s!\n", pto->addr.ToString());
-            else {
-                pto->fDisconnect = true;
-                if (pto->addr.IsLocal())
-                    LogPrintf("Warning: not banning local peer %s!\n", pto->addr.ToString());
-                else
-                {
-                    connman.Ban(pto->addr, BanReasonNodeMisbehaving);
-                }
-                return true;
-            }
-        }
 
         // Address refresh broadcast
         int64_t nNow = GetTimeMicros();

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1420,6 +1420,13 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         pfrom->fSuccessfullyConnected = true;
     }
 
+    else if (!pfrom->fSuccessfullyConnected)
+    {
+        // Must have a verack message before anything else
+        LOCK(cs_main);
+        Misbehaving(pfrom->GetId(), 1);
+        return false;
+    }
 
     else if (strCommand == NetMsgType::ADDR)
     {


### PR DESCRIPTION
This is the last of my net issues for 0.14. As discussed with @TheBlueMatt and @gmaxwell.

Fixes for a few problems discovered while running a network stress/fuzzer:
- Remote nodes weren't always banned when they hadn't yet sent a verack. Regression from 7a8c2519015650acd51eaf42719f04e53f839bbe.
- Require a verack before sending any non-handshake messages. This is much more straightforward behavior, and allows for tests to be easily written
- Now that there's a sane model for testing, add checks for leaky messages sent out before the handshake is complete, as well as for banning in those cases.