### PR TITLE
Headers announcement for nodes that can do headers.

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -179,6 +179,8 @@ struct CNodeState {
     bool fPreferredDownload;
     //! Whether this peer wants invs or headers (when possible) for block announcements.
     bool fPreferHeaders;
+    //! Whether this peer can process headers for block announcements.
+    bool fCanDoHeaders;
     //! Whether this peer wants invs or cmpctblocks (when possible) for block announcements.
     bool fPreferHeaderAndIDs;
     /**
@@ -213,6 +215,7 @@ struct CNodeState {
         nBlocksInFlightValidHeaders = 0;
         fPreferredDownload = false;
         fPreferHeaders = false;
+        fCanDoHeaders = false;
         fPreferHeaderAndIDs = false;
         fProvidesHeaderAndIDs = false;
         fHaveWitness = false;
@@ -1432,6 +1435,7 @@ bool static ProcessMessage(CNode* pfrom, std::string strCommand, CDataStream& vR
     {
         LOCK(cs_main);
         State(pfrom->GetId())->fPreferHeaders = true;
+        State(pfrom->GetId())->fCanDoHeaders = true;
     }
 
     else if (strCommand == NetMsgType::SENDCMPCT)
@@ -1660,6 +1664,8 @@ bool static ProcessMessage(CNode* pfrom, std::string strCommand, CDataStream& vR
 
     else if (strCommand == NetMsgType::GETHEADERS)
     {
+        State(pfrom->GetId())->fCanDoHeaders = true;
+
         CBlockLocator locator;
         uint256 hashStop;
         vRecv >> locator >> hashStop;
@@ -2861,7 +2867,7 @@ bool SendMessages(CNode* pto, CConnman& connman, std::atomic<bool>& interruptMsg
             // add all to the inv queue.
             LOCK(pto->cs_inventory);
             std::vector<CBlock> vHeaders;
-            bool fRevertToInv = ((!state.fPreferHeaders &&
+            bool fRevertToInv = ((!state.fCanDoHeaders &&
                                  (!state.fPreferHeaderAndIDs || pto->vBlockHashesToAnnounce.size() > 1)) ||
                                 pto->vBlockHashesToAnnounce.size() > MAX_BLOCKS_TO_ANNOUNCE);
             const CBlockIndex *pBestIndex = NULL; // last header queued for delivery
@@ -2945,7 +2951,7 @@ bool SendMessages(CNode* pto, CConnman& connman, std::atomic<bool>& interruptMsg
                         connman.PushMessage(pto, msgMaker.Make(nSendFlags, NetMsgType::CMPCTBLOCK, cmpctblock));
                     }
                     state.pindexBestHeaderSent = pBestIndex;
-                } else if (state.fPreferHeaders) {
+                } else if (state.fCanDoHeaders) {
                     if (vHeaders.size() > 1) {
                         LogPrint("net", "%s: %u headers, range (%s, %s), to peer=%d\n", __func__,
                                 vHeaders.size(),


### PR DESCRIPTION
This was raised previously (#8961) but closed due to an apparent misunderstanding - it builds upon the current announce by headers logic in that it will also detect nodes that understand headers and announce via headers to these also (I am not aware of any advantage in announcing via block invs to nodes that actively request headers and therefore can process them).