### PR TITLE
Remove bitseed.xf2.org form the dns seed list

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -124,7 +124,6 @@ public:
         vSeeds.push_back(CDNSSeedData("bluematt.me", "dnsseed.bluematt.me", true)); // Matt Corallo, only supports x9
         vSeeds.push_back(CDNSSeedData("dashjr.org", "dnsseed.bitcoin.dashjr.org")); // Luke Dashjr
         vSeeds.push_back(CDNSSeedData("bitcoinstats.com", "seed.bitcoinstats.com", true)); // Christian Decker, supports x1 - xf
-        vSeeds.push_back(CDNSSeedData("xf2.org", "bitseed.xf2.org")); // Jeff Garzik
         vSeeds.push_back(CDNSSeedData("bitcoin.jonasschnelli.ch", "seed.bitcoin.jonasschnelli.ch", true)); // Jonas Schnelli, only supports x1, x5, x9, and xd
 
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,0);


### PR DESCRIPTION
Tagged 0.14.

Removes `bitseed.xf2.org` from the DNS seeder list because of the following reasons:
* https://github.com/bitcoin/bitcoin/issues/8861#issuecomment-278140201
* Doesn't resolves IPv6 Address
* Almost every IPv4 address in the response doesn't react on port 8333 ( crawler [if there is any] seems to be not working)

(@cdecker, can you also check your seed.bitcoinstats.com for IPv6 support)
