### PR TITLE
[Trivial] Remove nonsense #undef foreach

### DIFF
--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -20,7 +20,6 @@
 #include "sync.h"
 #include "random.h"
 
-#undef foreach
 #include "boost/multi_index_container.hpp"
 #include "boost/multi_index/ordered_index.hpp"
 #include "boost/multi_index/hashed_index.hpp"


### PR DESCRIPTION
This PR removes `#undef foreach` from txmempool.h. That preprocessor
directive was added in 34628a18070064e75b35f28fd6a43d5c23832eb8
(https://github.com/bitcoin/bitcoin/pull/6654) but there doesn't appear to be a
`#define foreach` anywhere in the codebase. The `#undef directive` doesn't
actually do anything.