### PR TITLE
Add updating of chainTxData to release process

### DIFF
--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -23,6 +23,7 @@ Before every major release:
 
 * Update hardcoded [seeds](/contrib/seeds/README.md), see [this pull request](https://github.com/bitcoin/bitcoin/pull/7415) for an example.
 * Update [`BLOCK_CHAIN_SIZE`](/src/qt/intro.cpp) to the current size plus some overhead.
+* Update `src/chainparams.cpp` chainTxData with statistics about the transaction count and rate.
 
 ### First time / New builders
 


### PR DESCRIPTION
Occasionally, the transaction count estimation data in `chainparams.cpp`'s chainTxData must be updated to reflect reality.

These constants were updated in #9472, and the total tx estimate for today is still very close. So I believe that updating once every major release is probably enough.

#9733 can be used to compute updated constants.