### PR TITLE
Don't disconnect feeler connections prematurely

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1221,7 +1221,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         {
             connman.SetServices(pfrom->addr, nServices);
         }
-        if (pfrom->nServicesExpected & ~nServices)
+        if (!pfrom->fFeeler && pfrom->nServicesExpected & ~nServices)
         {
             LogPrint("net", "peer=%d does not offer the expected services (%08x offered, %08x expected); disconnecting\n", pfrom->id, nServices, pfrom->nServicesExpected);
             connman.PushMessage(pfrom, CNetMsgMaker(INIT_PROTO_VERSION).Make(NetMsgType::REJECT, strCommand, REJECT_NONSTANDARD,


### PR DESCRIPTION
This allows the usual logic (e.g. advertising address, sending alert, etc) to run as usual for feeler connections, regardless of whether the node provides the expected services.