### PR TITLE
Fix several potential issues found by sanitizers

### DIFF
--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -651,11 +651,13 @@ static void MutateTx(CMutableTransaction& tx, const std::string& command,
         MutateTxDelOutput(tx, commandVal);
     else if (command == "outaddr")
         MutateTxAddOutAddr(tx, commandVal);
-    else if (command == "outpubkey")
+    else if (command == "outpubkey") {
+        if (!ecc) { ecc.reset(new Secp256k1Init()); }
         MutateTxAddOutPubKey(tx, commandVal);
-    else if (command == "outmultisig")
+    } else if (command == "outmultisig") {
+        if (!ecc) { ecc.reset(new Secp256k1Init()); }
         MutateTxAddOutMultiSig(tx, commandVal);
-    else if (command == "outscript")
+    } else if (command == "outscript")
         MutateTxAddOutScript(tx, commandVal);
     else if (command == "outdata")
         MutateTxAddOutData(tx, commandVal);

--- a/src/utiltime.cpp
+++ b/src/utiltime.cpp
@@ -9,14 +9,17 @@
 
 #include "utiltime.h"
 
+#include <atomic>
+
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/thread.hpp>
 
-static int64_t nMockTime = 0; //!< For unit testing
+static std::atomic<int64_t> nMockTime(0); //!< For unit testing
 
 int64_t GetTime()
 {
-    if (nMockTime) return nMockTime;
+    int64_t mocktime = nMockTime.load(std::memory_order_relaxed);
+    if (mocktime) return mocktime;
 
     time_t now = time(NULL);
     assert(now > 0);
@@ -25,7 +28,7 @@ int64_t GetTime()
 
 void SetMockTime(int64_t nMockTimeIn)
 {
-    nMockTime = nMockTimeIn;
+    nMockTime.store(nMockTimeIn, std::memory_order_relaxed);
 }
 
 int64_t GetTimeMillis()
@@ -52,7 +55,8 @@ int64_t GetSystemTimeInSeconds()
 /** Return a time useful for the debug log */
 int64_t GetLogTimeMicros()
 {
-    if (nMockTime) return nMockTime*1000000;
+    int64_t mocktime = nMockTime.load(std::memory_order_relaxed);
+    if (mocktime) return mocktime*1000000;
 
     return GetTimeMicros();
 }


### PR DESCRIPTION
Notes:
* The LevelDB patch here is simple, and makes it switch to c++11 atomics when available over their MemoryBarrier() based solutions. A slightly better version is submitted upstream as https://github.com/google/leveldb/pull/449.
* Several race fixes are not bug fixes (the numThreads one and the access to globals one both happen before any multithreaded access to those variables takes place; and the LevelDB one is due to tsan not recognizing the inline assembly used in MemoryBarrier), but in general improvements that result in less fragile code.

After these, I believe our unit and rpc tests are clean for asan/lsan/ubsan/tsan, but:
* The BDB environment holds locks that cross call stacks, and trigger the tsan deadlock detection. To avoid, create a suppressions file with the line `deadlock:__db_pthread_mutex_lock` in it, and pass an environment variable `TSAN_OPTIONS="suppressions=$file"` to the binaries.
* The zapwallettxn RPC test causes an assertion failure inside libtsan for me.
* You need to compile with `-DBOOST_SP_USE_STD_ATOMIC` to avoid tsan incorrectly detecting signals2 calls as racy (boost uses inline assembly for atomic refcounting by default, unless this compile options is passed; it was introduced in 1.54 I think).

As tsan seems to become a usable option for race detection, I wonder if over time we could remove our own DEBUG_LOCKORDER features.