### PR TITLE
[RPC] Getting confirmations command

### DIFF
--- a/qa/rpc-tests/rawtransactions.py
+++ b/qa/rpc-tests/rawtransactions.py
@@ -10,6 +10,7 @@
 #    - sendrawtransaction
 #    - decoderawtransaction
 #    - getrawtransaction
+#    - getconfirmations
 """
 
 from test_framework.test_framework import BitcoinTestFramework
@@ -188,6 +189,19 @@ class RawTransactionsTest(BitcoinTestFramework):
         rawtx   = self.nodes[0].createrawtransaction(inputs, outputs)
         decrawtx= self.nodes[0].decoderawtransaction(rawtx)
         assert_equal(decrawtx['vin'][0]['sequence'], 4294967294)
+
+        # getconfirmations tests
+        # 1. valid parameters - supply unconfirmed txid
+        addr4 = self.nodes[0].getnewaddress()
+        txId2 = self.nodes[0].sendtoaddress(addr4, 0.0001)
+        assert_equal(self.nodes[0].getconfirmations(txId2), 0)
+
+        # 2. valid parameters - supply confirmed txid
+        self.nodes[0].generate(1)
+        assert_equal(self.nodes[0].getconfirmations(txId2), 1)
+
+        # 3. invalid parameters - supply non-existent txid
+        assert_raises(JSONRPCException, self.nodes[1].getconfirmations, "1d1d4e24ed99057e84c3f80fd8fbec79ed9e1acee37da269356ecea000000000")
 
 if __name__ == '__main__':
     RawTransactionsTest().main()

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -83,6 +83,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "getblockheader", 1, "verbose" },
     { "gettransaction", 1, "include_watchonly" },
     { "getrawtransaction", 1, "verbose" },
+    { "getconfirmations", 1, "txid" },
     { "createrawtransaction", 0, "transactions" },
     { "createrawtransaction", 1, "outputs" },
     { "createrawtransaction", 2, "locktime" },

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -49,6 +49,9 @@ BOOST_AUTO_TEST_CASE(rpc_rawparams)
     BOOST_CHECK_THROW(CallRPC("getrawtransaction not_hex"), std::runtime_error);
     BOOST_CHECK_THROW(CallRPC("getrawtransaction a3b807410df0b60fcb9736768df5823938b2f838694939ba45f3c0a1bff150ed not_int"), std::runtime_error);
 
+    BOOST_CHECK_THROW(CallRPC("getconfirmations"), std::runtime_error);
+    BOOST_CHECK_THROW(CallRPC("getconfirmations not_hex"), std::runtime_error);
+
     BOOST_CHECK_THROW(CallRPC("createrawtransaction"), std::runtime_error);
     BOOST_CHECK_THROW(CallRPC("createrawtransaction null null"), std::runtime_error);
     BOOST_CHECK_THROW(CallRPC("createrawtransaction not_array"), std::runtime_error);


### PR DESCRIPTION
This is aimed at saving traffic to get transaction confirmations and improve rpc throughput.

To check transaction confirmations, we needs to call "getrawtransaction" or "gettransaction".
But to check confirmations of huge number of transaction, network is crowded and latency is up.
"getrawtransaction" and "gettransaction" includes constancy infomation, though confirmations is just changeable field.
I think it is good to split off "confirmations" from "getrawtransaction".
For this, add new command "getconfirmations" to rpc command.