### PR TITLE
If -spkreuse=0, ensure transactions in mempool always have unique scriptPubKeys

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -489,6 +489,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-mempoolreplacement", strprintf(_("Enable transaction replacement in the memory pool (default: %u)"), DEFAULT_ENABLE_REPLACEMENT));
     strUsage += HelpMessageOpt("-minrelaytxfee=<amt>", strprintf(_("Fees (in %s/kB) smaller than this are considered zero fee for relaying, mining and transaction creation (default: %s)"),
         CURRENCY_UNIT, FormatMoney(DEFAULT_MIN_RELAY_TX_FEE)));
+    strUsage += HelpMessageOpt("-spkreuse", strprintf(_("Accept transactions reusing addresses or other pubkey scripts (default: %s)"), DEFAULT_SPKREUSE));
     strUsage += HelpMessageOpt("-whitelistrelay", strprintf(_("Accept relayed transactions received from whitelisted peers even when not relaying transactions (default: %d)"), DEFAULT_WHITELISTRELAY));
     strUsage += HelpMessageOpt("-whitelistforcerelay", strprintf(_("Force relay of transactions from whitelisted peers even if they violate local relay policy (default: %d)"), DEFAULT_WHITELISTFORCERELAY));
 
@@ -1075,6 +1076,16 @@ bool AppInitParameterInteraction()
     fIsBareMultisigStd = gArgs.GetBoolArg("-permitbaremultisig", DEFAULT_PERMIT_BAREMULTISIG);
     fAcceptDatacarrier = gArgs.GetBoolArg("-datacarrier", DEFAULT_ACCEPT_DATACARRIER);
     nMaxDatacarrierBytes = gArgs.GetArg("-datacarriersize", nMaxDatacarrierBytes);
+
+    {
+        std::string strSpkReuse = gArgs.GetArg("-spkreuse", DEFAULT_SPKREUSE);
+        // Uses string values so future versions can implement other modes
+        if (strSpkReuse == "allow" || gArgs.GetBoolArg("-spkreuse", false)) {
+            SpkReuseMode = SRM_ALLOW;
+        } else {
+            SpkReuseMode = SRM_REJECT;
+        }
+    }
 
     // Option to startup with mocktime set (used for regression testing):
     SetMockTime(gArgs.GetArg("-mocktime", 0)); // SetMockTime(0) is a no-op

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -46,6 +46,7 @@ static const unsigned int MAX_STANDARD_P2WSH_SCRIPT_SIZE = 3600;
  * only increase the dust limit after prior releases were already not creating
  * outputs below the new threshold */
 static const unsigned int DUST_RELAY_TX_FEE = 3000;
+static const std::string DEFAULT_SPKREUSE = "allow";
 /**
  * Standard script verification flags that standard transactions will comply
  * with. However scripts violating these flags may still be present in valid

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -12,6 +12,7 @@
 #include "policy/policy.h"
 #include "policy/fees.h"
 #include "reverse_iterator.h"
+#include "script/script.h"
 #include "streams.h"
 #include "timedata.h"
 #include "util.h"
@@ -59,6 +60,13 @@ void CTxMemPoolEntry::UpdateLockPoints(const LockPoints& lp)
 size_t CTxMemPoolEntry::GetTxSize() const
 {
     return GetVirtualTransactionSize(nTxWeight, sigOpCost);
+}
+
+uint160 ScriptHashkey(const CScript& script)
+{
+    uint160 hash;
+    CRIPEMD160().Write(script.data(), script.size()).Finalize(hash.begin());
+    return hash;
 }
 
 // Update the given tx for any in-mempool descendants.
@@ -418,6 +426,10 @@ bool CTxMemPool::addUnchecked(const uint256& hash, const CTxMemPoolEntry &entry,
     vTxHashes.emplace_back(tx.GetWitnessHash(), newit);
     newit->vTxHashesIdx = vTxHashes.size() - 1;
 
+    for (auto& vSPK : entry.mapSPK) {
+        mapUsedSPK[vSPK.first] = MemPool_SPK_State(mapUsedSPK[vSPK.first] | vSPK.second);
+    }
+
     return true;
 }
 
@@ -436,6 +448,14 @@ void CTxMemPool::removeUnchecked(txiter it, MemPoolRemovalReason reason)
             vTxHashes.shrink_to_fit();
     } else
         vTxHashes.clear();
+
+    for (auto& vSPK : it->mapSPK) {
+        if (vSPK.second == mapUsedSPK.find(vSPK.first)->second) {
+            mapUsedSPK.erase(vSPK.first);
+        } else {
+            mapUsedSPK[vSPK.first] = MemPool_SPK_State(mapUsedSPK[vSPK.first] & ~vSPK.second);
+        }
+    }
 
     totalTxSize -= it->GetTxSize();
     cachedInnerUsage -= it->DynamicMemoryUsage();
@@ -598,6 +618,7 @@ void CTxMemPool::_clear()
     mapLinks.clear();
     mapTx.clear();
     mapNextTx.clear();
+    mapUsedSPK.clear();
     totalTxSize = 0;
     cachedInnerUsage = 0;
     lastRollingFeeUpdate = GetTime();

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -427,7 +427,14 @@ bool CTxMemPool::addUnchecked(const uint256& hash, const CTxMemPoolEntry &entry,
     newit->vTxHashesIdx = vTxHashes.size() - 1;
 
     for (auto& vSPK : entry.mapSPK) {
-        mapUsedSPK[vSPK.first] = MemPool_SPK_State(mapUsedSPK[vSPK.first] | vSPK.second);
+        const uint160& SPKKey = vSPK.first;
+        const MemPool_SPK_State& claims = vSPK.second;
+        if (claims & MSS_CREATED) {
+            mapUsedSPK[SPKKey].first = &tx;
+        }
+        if (claims & MSS_SPENT) {
+            mapUsedSPK[SPKKey].second = &tx;
+        }
     }
 
     return true;
@@ -435,6 +442,7 @@ bool CTxMemPool::addUnchecked(const uint256& hash, const CTxMemPoolEntry &entry,
 
 void CTxMemPool::removeUnchecked(txiter it, MemPoolRemovalReason reason)
 {
+    const CTransaction& tx = it->GetTx();
     NotifyEntryRemoved(it->GetSharedTx(), reason);
     const uint256 hash = it->GetTx().GetHash();
     for (const CTxIn& txin : it->GetTx().vin)
@@ -450,10 +458,15 @@ void CTxMemPool::removeUnchecked(txiter it, MemPoolRemovalReason reason)
         vTxHashes.clear();
 
     for (auto& vSPK : it->mapSPK) {
-        if (vSPK.second == mapUsedSPK.find(vSPK.first)->second) {
-            mapUsedSPK.erase(vSPK.first);
-        } else {
-            mapUsedSPK[vSPK.first] = MemPool_SPK_State(mapUsedSPK[vSPK.first] & ~vSPK.second);
+        const uint160& SPKKey = vSPK.first;
+        if (mapUsedSPK[SPKKey].first == &tx) {
+            mapUsedSPK[SPKKey].first = NULL;
+        }
+        if (mapUsedSPK[SPKKey].second == &tx) {
+            mapUsedSPK[SPKKey].second = NULL;
+        }
+        if (!(mapUsedSPK[SPKKey].first || mapUsedSPK[SPKKey].second)) {
+            mapUsedSPK.erase(SPKKey);
         }
     }
 

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -18,6 +18,7 @@
 #include "indirectmap.h"
 #include "policy/feerate.h"
 #include "primitives/transaction.h"
+#include "script/script.h"
 #include "sync.h"
 #include "random.h"
 
@@ -47,6 +48,15 @@ struct LockPoints
 
     LockPoints() : height(0), time(0), maxInputBlock(nullptr) { }
 };
+
+enum MemPool_SPK_State {
+    MSS_UNSEEN  = 0,
+    MSS_SPENT   = 1,
+    MSS_CREATED = 2,
+    MSS_BOTH    = 3,
+};
+
+typedef std::map<uint160, enum MemPool_SPK_State> SPKStates_t;
 
 class CTxMemPool;
 
@@ -131,6 +141,8 @@ public:
     int64_t GetSigOpCostWithAncestors() const { return nSigOpCostWithAncestors; }
 
     mutable size_t vTxHashesIdx; //!< Index in mempool's vTxHashes
+
+    SPKStates_t mapSPK;
 };
 
 // Helpers for modifying CTxMemPool::mapTx, which is a boost multi_index.
@@ -286,6 +298,8 @@ public:
         return f1 > f2;
     }
 };
+
+uint160 ScriptHashkey(const CScript& script);
 
 // Multi_index tag names
 struct descendant_score {};
@@ -479,6 +493,9 @@ public:
 
     const setEntries & GetMemPoolParents(txiter entry) const;
     const setEntries & GetMemPoolChildren(txiter entry) const;
+
+    SPKStates_t mapUsedSPK;
+
 private:
     typedef std::map<txiter, setEntries, CompareIteratorByHash> cacheMap;
 

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -51,8 +51,8 @@ struct LockPoints
 
 enum MemPool_SPK_State {
     MSS_UNSEEN  = 0,
-    MSS_SPENT   = 1,
-    MSS_CREATED = 2,
+    MSS_SPENT   = 1,  // .second
+    MSS_CREATED = 2,  // .first
     MSS_BOTH    = 3,
 };
 
@@ -494,7 +494,7 @@ public:
     const setEntries & GetMemPoolParents(txiter entry) const;
     const setEntries & GetMemPoolChildren(txiter entry) const;
 
-    SPKStates_t mapUsedSPK;
+    std::map<uint160, std::pair<const CTransaction *, const CTransaction *>> mapUsedSPK;
 
 private:
     typedef std::map<txiter, setEntries, CompareIteratorByHash> cacheMap;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -72,6 +72,7 @@ bool fHavePruned = false;
 bool fPruneMode = false;
 bool fIsBareMultisigStd = DEFAULT_PERMIT_BAREMULTISIG;
 bool fRequireStandard = true;
+SpkReuseModes SpkReuseMode;
 bool fCheckBlockIndex = false;
 bool fCheckpointsEnabled = DEFAULT_CHECKPOINTS_ENABLED;
 size_t nCoinCacheUsage = 5000 * 300;
@@ -476,6 +477,9 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
         return state.Invalid(false, REJECT_DUPLICATE, "txn-already-in-mempool");
     }
 
+    auto spk_reuse_mode = SpkReuseMode;
+    SPKStates_t mapSPK;
+
     // Check for conflicts with in-memory transactions
     std::set<uint256> setConflicts;
     {
@@ -520,6 +524,20 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
             }
         }
     }
+
+    if (spk_reuse_mode != SRM_ALLOW) {
+        for (const CTxOut& txout : tx.vout) {
+            uint160 hashSPK = ScriptHashkey(txout.scriptPubKey);
+            if (pool.mapUsedSPK.find(hashSPK) != pool.mapUsedSPK.end()) {
+                return state.DoS(0, false, REJECT_DUPLICATE, "txn-mempool-spk-reused");
+            }
+            if (mapSPK.find(hashSPK) != mapSPK.end()) {
+                return state.DoS(0, false, REJECT_NONSTANDARD, "txn-spk-reused-twinoutputs");
+            }
+            mapSPK[hashSPK] = MemPool_SPK_State(mapSPK[hashSPK] | MSS_CREATED);
+        }
+    }
+
     }
 
     {
@@ -569,6 +587,28 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
         // CoinsViewCache instead of create its own
         if (!CheckSequenceLocks(tx, STANDARD_LOCKTIME_VERIFY_FLAGS, &lp))
             return state.DoS(0, false, REJECT_NONSTANDARD, "non-BIP68-final");
+
+        if (spk_reuse_mode != SRM_ALLOW) {
+            for (const CTxIn& txin : tx.vin) {
+                const Coin &coin = view.AccessCoin(txin.prevout);
+                uint160 hashSPK = ScriptHashkey(coin.out.scriptPubKey);
+
+                SPKStates_t::iterator mssit = mapSPK.find(hashSPK);
+                if (mssit != mapSPK.end()) {
+                    if (mssit->second & MSS_CREATED) {
+                        return state.DoS(0, false, REJECT_NONSTANDARD, "txn-spk-reused-change");
+                    }
+                }
+                mssit = pool.mapUsedSPK.find(hashSPK);
+                if (mssit != pool.mapUsedSPK.end()) {
+                    if (mssit->second & MSS_SPENT) {
+                        return state.DoS(0, false, REJECT_DUPLICATE, "txn-mempool-spk-reused-spend");
+                    }
+                }
+                mapSPK[hashSPK] = MemPool_SPK_State(mapSPK[hashSPK] | MSS_SPENT);
+            }
+        }
+
         }
 
         // Check for non-standard pay-to-script-hash in inputs
@@ -601,6 +641,7 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
         CTxMemPoolEntry entry(ptx, nFees, nAcceptTime, chainActive.Height(),
                               fSpendsCoinbase, nSigOpsCost, lp);
         unsigned int nSize = entry.GetTxSize();
+        entry.mapSPK = mapSPK;
 
         // Check that the transaction doesn't have an excessive number of
         // sigops, making it impossible to mine. Since the coinbase transaction

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -599,9 +599,9 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
                         return state.DoS(0, false, REJECT_NONSTANDARD, "txn-spk-reused-change");
                     }
                 }
-                mssit = pool.mapUsedSPK.find(hashSPK);
-                if (mssit != pool.mapUsedSPK.end()) {
-                    if (mssit->second & MSS_SPENT) {
+                const auto& SPKit = pool.mapUsedSPK.find(hashSPK);
+                if (SPKit != pool.mapUsedSPK.end()) {
+                    if (SPKit->second.second /* Spent */) {
                         return state.DoS(0, false, REJECT_DUPLICATE, "txn-mempool-spk-reused-spend");
                     }
                 }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -481,7 +481,7 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
     SPKStates_t mapSPK;
 
     // Check for conflicts with in-memory transactions
-    std::set<uint256> setConflicts;
+    std::map<uint256, bool> setConflicts;
     {
     LOCK(pool.cs); // protect pool.mapNextTx
     for (const CTxIn &txin : tx.vin)
@@ -520,7 +520,7 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
                     return state.Invalid(false, REJECT_DUPLICATE, "txn-mempool-conflict");
                 }
 
-                setConflicts.insert(ptxConflicting->GetHash());
+                setConflicts.emplace(ptxConflicting->GetHash(), true);
             }
         }
     }
@@ -528,8 +528,14 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
     if (spk_reuse_mode != SRM_ALLOW) {
         for (const CTxOut& txout : tx.vout) {
             uint160 hashSPK = ScriptHashkey(txout.scriptPubKey);
-            if (pool.mapUsedSPK.find(hashSPK) != pool.mapUsedSPK.end()) {
-                return state.DoS(0, false, REJECT_DUPLICATE, "txn-mempool-spk-reused");
+            const auto& SPKUsedIn = pool.mapUsedSPK.find(hashSPK);
+            if (SPKUsedIn != pool.mapUsedSPK.end()) {
+                if (SPKUsedIn->second.first) {
+                    setConflicts.emplace(SPKUsedIn->second.first->GetHash(), false);
+                }
+                if (SPKUsedIn->second.second) {
+                    setConflicts.emplace(SPKUsedIn->second.second->GetHash(), false);
+                }
             }
             if (mapSPK.find(hashSPK) != mapSPK.end()) {
                 return state.DoS(0, false, REJECT_NONSTANDARD, "txn-spk-reused-twinoutputs");
@@ -602,7 +608,7 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
                 const auto& SPKit = pool.mapUsedSPK.find(hashSPK);
                 if (SPKit != pool.mapUsedSPK.end()) {
                     if (SPKit->second.second /* Spent */) {
-                        return state.DoS(0, false, REJECT_DUPLICATE, "txn-mempool-spk-reused-spend");
+                        setConflicts.emplace(SPKit->second.second->GetHash(), false);
                     }
                 }
                 mapSPK[hashSPK] = MemPool_SPK_State(mapSPK[hashSPK] | MSS_SPENT);
@@ -685,8 +691,12 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
         for (CTxMemPool::txiter ancestorIt : setAncestors)
         {
             const uint256 &hashAncestor = ancestorIt->GetTx().GetHash();
-            if (setConflicts.count(hashAncestor))
+            const auto& conflictit = setConflicts.find(hashAncestor);
+            if (conflictit != setConflicts.end())
             {
+                if (!conflictit->second /* mere SPK conflict, NOT invalid */) {
+                    return state.DoS(0, false, REJECT_NONSTANDARD, "txn-spk-reused-chained");
+                }
                 return state.DoS(10, false,
                                  REJECT_INVALID, "bad-txns-spends-conflicting-tx", false,
                                  strprintf("%s spends conflicting transaction %s",
@@ -713,8 +723,9 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
             std::set<uint256> setConflictsParents;
             const int maxDescendantsToVisit = 100;
             CTxMemPool::setEntries setIterConflicting;
-            for (const uint256 &hashConflicting : setConflicts)
+            for (const auto &conflictit : setConflicts)
             {
+                const uint256& hashConflicting = conflictit.first;
                 CTxMemPool::txiter mi = pool.mapTx.find(hashConflicting);
                 if (mi == pool.mapTx.end())
                     continue;

--- a/src/validation.h
+++ b/src/validation.h
@@ -172,6 +172,14 @@ extern int nScriptCheckThreads;
 extern bool fTxIndex;
 extern bool fIsBareMultisigStd;
 extern bool fRequireStandard;
+
+enum SpkReuseModes {
+    SRM_ALLOW,
+    SRM_REJECT,
+};
+
+extern SpkReuseModes SpkReuseMode;
+
 extern bool fCheckBlockIndex;
 extern bool fCheckpointsEnabled;
 extern size_t nCoinCacheUsage;


### PR DESCRIPTION
Exceptions:
- Multiple inputs in the same transaction are allowed to spend against the same scriptPubKey
- The same scriptPubKey may be used in the mempool as both first an output, and then spent in a later transaction's input

Changes since original 2013 patch (pre-squashed):
- Refactor: Move CScript::ScriptPubkeyReuseHash to ScriptHashkey(CScript) in txmempool
- Update mempool duplicate-scriptPubKey limiting with C++11 and misc formatting improvements
- Bugfix: Use bitwise operators for mempool SPK states
- Use CValidationState for SPK reuse rejections
- Move mapTxSPK to CTxMemPoolEntry.mapSPK
- Make SPK reuse filtering optional (use -spkreuse)

Known issues:
- ~~This breaks RBF in most usage scenarios.~~
- ~~Someone could watch for transactions and spam dust to block them on nodes using this.~~