### PR TITLE
[wallet] Remove importmulti always-true check

### DIFF
--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -1072,7 +1072,7 @@ UniValue importmulti(const JSONRPCRequest& mainRequest)
         }
     }
 
-    if (fRescan && fRunScan && requests.size() && nLowestTimestamp <= chainActive.Tip()->GetBlockTimeMax()) {
+    if (fRescan && fRunScan && requests.size()) {
         CBlockIndex* pindex = nLowestTimestamp > minimumTimestamp ? chainActive.FindEarliestAtLeast(std::max<int64_t>(nLowestTimestamp - 7200, 0)) : chainActive.Genesis();
 
         if (pindex) {


### PR DESCRIPTION
No change in behavior.

Remove `nLowestTimestamp <= chainActive.Tip()->GetBlockTimeMax()` check from
importmulti, which is always true because nLowestTimestamp is set to the
minimum of the most recent block time and all the imported key timestamps,
which is necessarily lower than the maximum block time.

An alternative would to make initialize nLowestTimestamp to `numeric_limits<int64_t>::max()` so the check would actually do what it appears to be intended to do, and avoid ScanForWalletTransactions calls when all the imported key timestamps are in the future.