### PR TITLE
Harden against mistakes handling invalid blocks

### DIFF
--- a/qa/rpc-tests/p2p-fullblocktest.py
+++ b/qa/rpc-tests/p2p-fullblocktest.py
@@ -398,7 +398,7 @@ class FullBlockTest(ComparisonTestFramework):
 
         # Extend the b26 chain to make sure bitcoind isn't accepting b26
         b27 = block(27, spend=out[7])
-        yield rejected(RejectResult(16, b'bad-prevblk'))
+        yield rejected(RejectResult(0, b'bad-prevblk'))
 
         # Now try a too-large-coinbase script
         tip(15)
@@ -410,7 +410,7 @@ class FullBlockTest(ComparisonTestFramework):
 
         # Extend the b28 chain to make sure bitcoind isn't accepting b28
         b29 = block(29, spend=out[7])
-        yield rejected(RejectResult(16, b'bad-prevblk'))
+        yield rejected(RejectResult(0, b'bad-prevblk'))
 
         # b30 has a max-sized coinbase scriptSig.
         tip(23)


### PR DESCRIPTION
Fixes a bug in AcceptBlock() in invoking CheckBlock() with incorrect
arguments (introduced in #8068), and restores a call to CheckBlock() from ProcessNewBlock()
as belt-and-suspenders (effectively reverting #7225).

Updates the (overspecified) tests to match the slight behavior change (different reject code).