### PR TITLE
Allow maxsigcachesize to be zero

### DIFF
--- a/src/script/sigcache.cpp
+++ b/src/script/sigcache.cpp
@@ -93,8 +93,9 @@ static CSignatureCache signatureCache;
 // To be called once in AppInit2/TestingSetup to initialize the signatureCache
 void InitSignatureCache()
 {
+    // nMaxCacheSize is unsigned. If -maxsigcachesize is set to zero,
+    // setup_bytes creates the minimum possible cache (2 elements).
     size_t nMaxCacheSize = GetArg("-maxsigcachesize", DEFAULT_MAX_SIG_CACHE_SIZE) * ((size_t) 1 << 20);
-    if (nMaxCacheSize <= 0) return;
     size_t nElems = signatureCache.setup_bytes(nMaxCacheSize);
     LogPrintf("Using %zu MiB out of %zu requested for signature cache, able to store %zu elements\n",
             (nElems*sizeof(uint256)) >>20, nMaxCacheSize>>20, nElems);


### PR DESCRIPTION
Fixes https://github.com/bitcoin/bitcoin/issues/9759

If the -maxsigcachesize parameter is set to zero, setup a minimum sized
sigcache (2 elements) rather than segfaulting.