### PR TITLE
Handle unusual maxsigcachesize gracefully

### DIFF
--- a/src/script/sigcache.cpp
+++ b/src/script/sigcache.cpp
@@ -95,7 +95,7 @@ void InitSignatureCache()
 {
     // nMaxCacheSize is unsigned. If -maxsigcachesize is set to zero,
     // setup_bytes creates the minimum possible cache (2 elements).
-    size_t nMaxCacheSize = GetArg("-maxsigcachesize", DEFAULT_MAX_SIG_CACHE_SIZE) * ((size_t) 1 << 20);
+    size_t nMaxCacheSize = std::max((int64_t)0, GetArg("-maxsigcachesize", DEFAULT_MAX_SIG_CACHE_SIZE)) * ((size_t) 1 << 20);
     size_t nElems = signatureCache.setup_bytes(nMaxCacheSize);
     LogPrintf("Using %zu MiB out of %zu requested for signature cache, able to store %zu elements\n",
             (nElems*sizeof(uint256)) >>20, nMaxCacheSize>>20, nElems);

--- a/src/script/sigcache.cpp
+++ b/src/script/sigcache.cpp
@@ -93,8 +93,9 @@ static CSignatureCache signatureCache;
 // To be called once in AppInit2/TestingSetup to initialize the signatureCache
 void InitSignatureCache()
 {
+    // nMaxCacheSize is unsigned. If -maxsigcachesize is set to zero,
+    // setup_bytes creates the minimum possible cache (2 elements).
     size_t nMaxCacheSize = GetArg("-maxsigcachesize", DEFAULT_MAX_SIG_CACHE_SIZE) * ((size_t) 1 << 20);
-    if (nMaxCacheSize <= 0) return;
     size_t nElems = signatureCache.setup_bytes(nMaxCacheSize);
     LogPrintf("Using %zu MiB out of %zu requested for signature cache, able to store %zu elements\n",
             (nElems*sizeof(uint256)) >>20, nMaxCacheSize>>20, nElems);

--- a/src/script/sigcache.cpp
+++ b/src/script/sigcache.cpp
@@ -95,7 +95,7 @@ void InitSignatureCache()
 {
     // nMaxCacheSize is unsigned. If -maxsigcachesize is set to zero,
     // setup_bytes creates the minimum possible cache (2 elements).
-    size_t nMaxCacheSize = std::max((int64_t)0, GetArg("-maxsigcachesize", DEFAULT_MAX_SIG_CACHE_SIZE)) * ((size_t) 1 << 20);
+    size_t nMaxCacheSize = std::min(std::max((int64_t)0, GetArg("-maxsigcachesize", DEFAULT_MAX_SIG_CACHE_SIZE)), MAX_MAX_SIG_CACHE_SIZE) * ((size_t) 1 << 20);
     size_t nElems = signatureCache.setup_bytes(nMaxCacheSize);
     LogPrintf("Using %zu MiB out of %zu requested for signature cache, able to store %zu elements\n",
             (nElems*sizeof(uint256)) >>20, nMaxCacheSize>>20, nElems);

--- a/src/script/sigcache.h
+++ b/src/script/sigcache.h
@@ -14,6 +14,8 @@
 // systems). Due to how we count cache size, actual memory usage is slightly
 // more (~32.25 MB)
 static const unsigned int DEFAULT_MAX_SIG_CACHE_SIZE = 32;
+// Maximum sig cache size allowed
+static const int64_t MAX_MAX_SIG_CACHE_SIZE = 16384;
 
 class CPubKey;
 


### PR DESCRIPTION
belt-and-braces approach:

- first commit fixes the bug where maxsigcachesize being zero causes segfault
- second commit handles maxsigcachesize being negative by setting it to zero if a negative number is provided
- third commit handles maxsigcachesize being too large by setting it to MAX_MAX_SIG_CACHE_SIZE if an unreasonably large number is provided.

I've set `MAX_MAX_SIG_CACHE_SIZE` absurdly high (16GB) for now, so setting maxsigcachesize to anything unreasonably large will still cause a bad_alloc for most users. Input welcomed on what a more reasonable `MAX_MAX_SIG_CACHE_SIZE` should be, or whether we should leave it out entirely.

Replaces https://github.com/bitcoin/bitcoin/pull/9770