### PR TITLE
release: bump gitian descriptors for a new 0.14 package cache

### DIFF
--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -1,5 +1,5 @@
 ---
-name: "bitcoin-linux-0.13"
+name: "bitcoin-linux-0.14"
 enable_cache: true
 suites:
 - "trusty"

--- a/contrib/gitian-descriptors/gitian-osx.yml
+++ b/contrib/gitian-descriptors/gitian-osx.yml
@@ -1,5 +1,5 @@
 ---
-name: "bitcoin-osx-0.13"
+name: "bitcoin-osx-0.14"
 enable_cache: true
 suites:
 - "trusty"

--- a/contrib/gitian-descriptors/gitian-win.yml
+++ b/contrib/gitian-descriptors/gitian-win.yml
@@ -1,5 +1,5 @@
 ---
-name: "bitcoin-win-0.13"
+name: "bitcoin-win-0.14"
 enable_cache: true
 suites:
 - "trusty"


### PR DESCRIPTION
We should go ahead and bump master to 0.15 as well, so that it will transition to the release branch when the time comes.

I'll PR that separately.