### PR TITLE
Avoid variable length arrays

### DIFF
--- a/src/httprpc.cpp
+++ b/src/httprpc.cpp
@@ -112,7 +112,7 @@ static bool multiUserAuthorized(std::string strUserPass)
             std::string strSalt = vFields[1];
             std::string strHash = vFields[2];
 
-            unsigned int KEY_SIZE = 32;
+            static const unsigned int KEY_SIZE = 32;
             unsigned char out[KEY_SIZE];
 
             CHMAC_SHA256(reinterpret_cast<const unsigned char*>(strSalt.c_str()), strSalt.size()).Write(reinterpret_cast<const unsigned char*>(strPass.c_str()), strPass.size()).Finalize(out);

--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -55,8 +55,6 @@ const char* BIP70_MESSAGE_PAYMENTREQUEST = "PaymentRequest";
 const char* BIP71_MIMETYPE_PAYMENT = "application/bitcoin-payment";
 const char* BIP71_MIMETYPE_PAYMENTACK = "application/bitcoin-paymentack";
 const char* BIP71_MIMETYPE_PAYMENTREQUEST = "application/bitcoin-paymentrequest";
-// BIP70 max payment request size in bytes (DoS protection)
-const qint64 BIP70_MAX_PAYMENTREQUEST_SIZE = 50000;
 
 struct X509StoreDeleter {
       void operator()(X509_STORE* b) {

--- a/src/qt/paymentserver.h
+++ b/src/qt/paymentserver.h
@@ -53,7 +53,7 @@ class QUrl;
 QT_END_NAMESPACE
 
 // BIP70 max payment request size in bytes (DoS protection)
-extern const qint64 BIP70_MAX_PAYMENTREQUEST_SIZE;
+static const qint64 BIP70_MAX_PAYMENTREQUEST_SIZE = 50000;
 
 class PaymentServer : public QObject
 {


### PR DESCRIPTION
This removes this warning in some G++ versions:

```c++
httprpc.cpp: In function ‘bool HTTPReq_JSONRPC(HTTPRequest*, const string&)’:
httprpc.cpp:150:13: warning: stack protector not protecting local variables: variable length buffer [-Wstack-protector]
 static bool HTTPReq_JSONRPC(HTTPRequest* req, const std::string &)
             ^~~~~~~~~~~~~~~
```