### PR TITLE
boost: remove iostreams includes

### DIFF
--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -18,8 +18,6 @@
 #include <boost/bind.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/foreach.hpp>
-#include <boost/iostreams/concepts.hpp>
-#include <boost/iostreams/stream.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/signals2/signal.hpp>
 #include <boost/thread.hpp>


### PR DESCRIPTION
They're unused and produce nasty deprecation warnings like:

NOTE: Use of this header (bool_trait_def.hpp) is deprecated