### PR TITLE
util: Specific GetOSRandom for Linux/FreeBSD/OpenBSD

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -558,6 +558,33 @@ AC_LINK_IFELSE([AC_LANG_SOURCE([
   ]
 )
 
+# Check for different ways of gathering OS randomness
+AC_MSG_CHECKING(for Linux getrandom syscall)
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <unistd.h>
+  #include <sys/syscall.h>
+  #include <linux/random.h>]],
+ [[ syscall(SYS_getrandom, nullptr, 32, 0); ]])],
+ [ AC_MSG_RESULT(yes); AC_DEFINE(HAVE_SYS_GETRANDOM, 1,[Define this symbol if the Linux getrandom system call is available]) ],
+ [ AC_MSG_RESULT(no)]
+)
+
+AC_MSG_CHECKING(for getentropy)
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <unistd.h>]],
+ [[ getentropy(nullptr, 32) ]])],
+ [ AC_MSG_RESULT(yes); AC_DEFINE(HAVE_GETENTROPY, 1,[Define this symbol if the BSD getentropy system call is available]) ],
+ [ AC_MSG_RESULT(no)]
+)
+
+AC_MSG_CHECKING(for sysctl KERN_ARND)
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <sys/types.h>
+  #include <sys/sysctl.h>]],
+ [[ static const int name[2] = {CTL_KERN, KERN_ARND};
+    sysctl(name, 2, nullptr, nullptr, nullptr, 0); ]])],
+ [ AC_MSG_RESULT(yes); AC_DEFINE(HAVE_SYSCTL_ARND, 1,[Define this symbol if the BSD sysctl(KERN_ARND) is available]) ],
+ [ AC_MSG_RESULT(no)]
+)
+
+# Check for reduced exports
 if test x$use_reduce_exports = xyes; then
   AX_CHECK_COMPILE_FLAG([-fvisibility=hidden],[RE_CXXFLAGS="-fvisibility=hidden"],
   [AC_MSG_ERROR([Cannot set default symbol visibility. Use --disable-reduce-exports.])])

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -110,6 +110,7 @@ BITCOIN_TESTS =\
   test/policyestimator_tests.cpp \
   test/pow_tests.cpp \
   test/prevector_tests.cpp \
+  test/random_tests.cpp \
   test/raii_event_tests.cpp \
   test/reverselock_tests.cpp \
   test/rpc_tests.cpp \

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -687,8 +687,14 @@ bool InitSanityCheck(void)
         InitError("Elliptic curve cryptography sanity check failure. Aborting.");
         return false;
     }
+
     if (!glibc_sanity_test() || !glibcxx_sanity_test())
         return false;
+
+    if (!Random_SanityCheck()) {
+        InitError("OS cryptographic RNG sanity check failure. Aborting.");
+        return false;
+    }
 
     return true;
 }

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -21,6 +21,17 @@
 #include <sys/time.h>
 #endif
 
+#ifdef HAVE_SYS_GETRANDOM
+#include <sys/syscall.h>
+#include <linux/random.h>
+#endif
+#ifdef HAVE_GETENTROPY
+#include <unistd.h>
+#endif
+#ifdef HAVE_SYSCTL_ARND
+#include <sys/sysctl.h>
+#endif
+
 #include <openssl/err.h>
 #include <openssl/rand.h>
 
@@ -92,32 +103,65 @@ static void RandAddSeedPerfmon()
 }
 
 /** Get 32 bytes of system entropy. */
-static void GetOSRand(unsigned char *ent32)
+void GetOSRand(unsigned char *ent32)
 {
-#ifdef WIN32
+#if defined(WIN32)
     HCRYPTPROV hProvider;
     int ret = CryptAcquireContextW(&hProvider, NULL, NULL, PROV_RSA_FULL, CRYPT_VERIFYCONTEXT);
     if (!ret) {
         RandFailure();
     }
-    ret = CryptGenRandom(hProvider, 32, ent32);
+    ret = CryptGenRandom(hProvider, NUM_OS_RANDOM_BYTES, ent32);
     if (!ret) {
         RandFailure();
     }
     CryptReleaseContext(hProvider, 0);
+#elif defined(HAVE_SYS_GETRANDOM)
+    /* Linux. From the getrandom(2) man page:
+     * "If the urandom source has been initialized, reads of up to 256 bytes
+     * will always return as many bytes as requested and will not be
+     * interrupted by signals."
+     */
+    if (syscall(SYS_getrandom, ent32, NUM_OS_RANDOM_BYTES, 0) != NUM_OS_RANDOM_BYTES) {
+        RandFailure();
+    }
+#elif defined(HAVE_GETENTROPY)
+    /* On OpenBSD this can return up to 256 bytes of entropy, will return an
+     * error if more are requested.
+     * The call cannot return less than the requested number of bytes.
+     */
+    if (getentropy(ent32, NUM_OS_RANDOM_BYTES) != 0) {
+        RandFailure();
+    }
+#elif defined(HAVE_SYSCTL_ARND)
+    /* FreeBSD and similar. It is possible for the call to return less
+     * bytes than requested, so need to read in a loop.
+     */
+    static const int name[2] = {CTL_KERN, KERN_ARND};
+    int have = 0;
+    do {
+        size_t len = NUM_OS_RANDOM_BYTES - have;
+        if (sysctl(name, ARRAYLEN(name), ent32 + have, &len, NULL, 0) != 0) {
+            RandFailure();
+        }
+        have += len;
+    } while (have < NUM_OS_RANDOM_BYTES);
 #else
+    /* Fall back to /dev/urandom if there is no specific method implemented to
+     * get system entropy for this OS.
+     */
     int f = open("/dev/urandom", O_RDONLY);
     if (f == -1) {
         RandFailure();
     }
     int have = 0;
     do {
-        ssize_t n = read(f, ent32 + have, 32 - have);
-        if (n <= 0 || n + have > 32) {
+        ssize_t n = read(f, ent32 + have, NUM_OS_RANDOM_BYTES - have);
+        if (n <= 0 || n + have > NUM_OS_RANDOM_BYTES) {
             RandFailure();
         }
         have += n;
-    } while (have < 32);
+    } while (have < NUM_OS_RANDOM_BYTES);
     close(f);
 #endif
 }

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -102,6 +102,28 @@ static void RandAddSeedPerfmon()
 #endif
 }
 
+#ifndef WIN32
+/** Fallback: get 32 bytes of system entropy from /dev/urandom. The most
+ * compatible way to get cryptographic randomness on UNIX-ish platforms.
+ */
+void GetDevURandom(unsigned char *ent32)
+{
+    int f = open("/dev/urandom", O_RDONLY);
+    if (f == -1) {
+        RandFailure();
+    }
+    int have = 0;
+    do {
+        ssize_t n = read(f, ent32 + have, NUM_OS_RANDOM_BYTES - have);
+        if (n <= 0 || n + have > NUM_OS_RANDOM_BYTES) {
+            RandFailure();
+        }
+        have += n;
+    } while (have < NUM_OS_RANDOM_BYTES);
+    close(f);
+}
+#endif
+
 /** Get 32 bytes of system entropy. */
 void GetOSRand(unsigned char *ent32)
 {
@@ -122,8 +144,17 @@ void GetOSRand(unsigned char *ent32)
      * will always return as many bytes as requested and will not be
      * interrupted by signals."
      */
-    if (syscall(SYS_getrandom, ent32, NUM_OS_RANDOM_BYTES, 0) != NUM_OS_RANDOM_BYTES) {
-        RandFailure();
+    int rv = syscall(SYS_getrandom, ent32, NUM_OS_RANDOM_BYTES, 0);
+    if (rv != NUM_OS_RANDOM_BYTES) {
+        if (rv < 0 && errno == ENOSYS) {
+            /* Fallback for kernel <3.17: the return value will be -1 and errno
+             * ENOSYS if the syscall is not available, in that case fall back
+             * to /dev/urandom.
+             */
+            GetDevURandom(ent32);
+        } else {
+            RandFailure();
+        }
     }
 #elif defined(HAVE_GETENTROPY)
     /* On OpenBSD this can return up to 256 bytes of entropy, will return an
@@ -150,19 +181,7 @@ void GetOSRand(unsigned char *ent32)
     /* Fall back to /dev/urandom if there is no specific method implemented to
      * get system entropy for this OS.
      */
-    int f = open("/dev/urandom", O_RDONLY);
-    if (f == -1) {
-        RandFailure();
-    }
-    int have = 0;
-    do {
-        ssize_t n = read(f, ent32 + have, NUM_OS_RANDOM_BYTES - have);
-        if (n <= 0 || n + have > NUM_OS_RANDOM_BYTES) {
-            RandFailure();
-        }
-        have += n;
-    } while (have < NUM_OS_RANDOM_BYTES);
-    close(f);
+    GetDevURandom(ent32);
 #endif
 }
 

--- a/src/random.h
+++ b/src/random.h
@@ -46,7 +46,11 @@ public:
     uint32_t Rw;
 };
 
-/* Number of random bytes returned by GetOSRand */
+/* Number of random bytes returned by GetOSRand.
+ * When changing this constant make sure to change all call sites, and make
+ * sure that the underlying OS APIs for all platforms support the number.
+ * (many cap out at 256 bytes).
+ */
 static const ssize_t NUM_OS_RANDOM_BYTES = 32;
 
 /** Get 32 bytes of system entropy. Do not use this in application code: use

--- a/src/random.h
+++ b/src/random.h
@@ -46,4 +46,12 @@ public:
     uint32_t Rw;
 };
 
+/* Number of random bytes returned by GetOSRand */
+static const ssize_t NUM_OS_RANDOM_BYTES = 32;
+
+/** Get 32 bytes of system entropy. Do not use this in application code: use
+ * GetStrongRandBytes instead.
+ */
+void GetOSRand(unsigned char *ent32);
+
 #endif // BITCOIN_RANDOM_H

--- a/src/random.h
+++ b/src/random.h
@@ -58,4 +58,9 @@ static const ssize_t NUM_OS_RANDOM_BYTES = 32;
  */
 void GetOSRand(unsigned char *ent32);
 
+/** Check that OS randomness is available and returning the requested number
+ * of bytes.
+ */
+bool Random_SanityCheck();
+
 #endif // BITCOIN_RANDOM_H

--- a/src/test/random_tests.cpp
+++ b/src/test/random_tests.cpp
@@ -1,0 +1,46 @@
+// Copyright (c) 2017 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "random.h"
+
+#include "test/test_bitcoin.h"
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(random_tests, BasicTestingSetup)
+
+static const ssize_t MAX_TRIES = 1024;
+
+BOOST_AUTO_TEST_CASE(osrandom_tests)
+{
+    /* This does not measure the quality of randomness, but it does test that
+     * OSRandom() overwrites all 32 bytes of the output given a maximum
+     * number of tries.
+     */
+    uint8_t data[NUM_OS_RANDOM_BYTES];
+    bool overwritten[NUM_OS_RANDOM_BYTES] = {}; /* Tracks which bytes have been overwritten at least once */
+    int num_overwritten;
+    int tries = 0;
+    /* Loop until all bytes have been overwritten at least once */
+    do {
+        memset(data, 0, NUM_OS_RANDOM_BYTES);
+        GetOSRand(data);
+        for (int x=0; x < NUM_OS_RANDOM_BYTES; ++x) {
+            overwritten[x] |= (data[x] != 0);
+        }
+
+        num_overwritten = 0;
+        for (int x=0; x < NUM_OS_RANDOM_BYTES; ++x) {
+            if (overwritten[x]) {
+                num_overwritten += 1;
+            }
+        }
+
+        tries += 1;
+    } while (num_overwritten < NUM_OS_RANDOM_BYTES && tries < MAX_TRIES);
+    BOOST_CHECK(num_overwritten == NUM_OS_RANDOM_BYTES); /* If this failed, bailed out after too many tries */
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+

--- a/src/test/random_tests.cpp
+++ b/src/test/random_tests.cpp
@@ -10,36 +10,9 @@
 
 BOOST_FIXTURE_TEST_SUITE(random_tests, BasicTestingSetup)
 
-static const ssize_t MAX_TRIES = 1024;
-
 BOOST_AUTO_TEST_CASE(osrandom_tests)
 {
-    /* This does not measure the quality of randomness, but it does test that
-     * OSRandom() overwrites all 32 bytes of the output given a maximum
-     * number of tries.
-     */
-    uint8_t data[NUM_OS_RANDOM_BYTES];
-    bool overwritten[NUM_OS_RANDOM_BYTES] = {}; /* Tracks which bytes have been overwritten at least once */
-    int num_overwritten;
-    int tries = 0;
-    /* Loop until all bytes have been overwritten at least once */
-    do {
-        memset(data, 0, NUM_OS_RANDOM_BYTES);
-        GetOSRand(data);
-        for (int x=0; x < NUM_OS_RANDOM_BYTES; ++x) {
-            overwritten[x] |= (data[x] != 0);
-        }
-
-        num_overwritten = 0;
-        for (int x=0; x < NUM_OS_RANDOM_BYTES; ++x) {
-            if (overwritten[x]) {
-                num_overwritten += 1;
-            }
-        }
-
-        tries += 1;
-    } while (num_overwritten < NUM_OS_RANDOM_BYTES && tries < MAX_TRIES);
-    BOOST_CHECK(num_overwritten == NUM_OS_RANDOM_BYTES); /* If this failed, bailed out after too many tries */
+    BOOST_CHECK(Random_SanityCheck());
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
These are available in sandboxes without access to files or to devices. Also [they are considered safer and more straightforward](https://en.wikipedia.org/wiki/Entropy-supplying_system_calls) to use than `/dev/urandom` as reading from a file has quite a few edge cases:

- Linux: `getrandom(buf, buflen, 0)`. [getrandom(2)](http://man7.org/linux/manpages/man2/getrandom.2.html)  was introduced in version 3.17 of the Linux kernel.
- OpenBSD: `getentropy(buf, buflen)`. The [getentropy(2)](http://man.openbsd.org/cgi-bin/man.cgi/OpenBSD-current/man2/getentropy.2)  function appeared in OpenBSD 5.6.
- FreeBSD and NetBSD: `sysctl(KERN_ARND)`. Not sure when this was added but it has existed for quite a while.

Alternatives:

- Linux has sysctl `CTL_KERN` / `KERN_RANDOM` / `RANDOM_UUID`  which gives 16 bytes of randomness. This may be available on older kernels, however [sysctl is deprecated on Linux](https://lwn.net/Articles/605392/)  and even removed in some distros so we shouldn't use it.

Add tests for `GetOSRand()`:

- Test that no error happens (otherwise `RandFailure()` which aborts)
- Test that all 32 bytes are overwritten (initialize with zeros, try multiple times)

Discussion:

- When to use these? Currently they are always used when available. Another option would be to use them only when `/dev/urandom` is not  available. But this would mean these code paths receive less testing,  and I'm not sure there is any reason to prefer `/dev/urandom`.

Closes: #9676. I've tested this on all three OS-es.