### PR TITLE
qa: Check return code when stopping nodes

### DIFF
--- a/qa/rpc-tests/fundrawtransaction.py
+++ b/qa/rpc-tests/fundrawtransaction.py
@@ -469,7 +469,9 @@ class RawTransactionsTest(BitcoinTestFramework):
         # locked wallet test
         self.nodes[1].encryptwallet("test")
         self.nodes.pop(1)
-        stop_nodes(self.nodes)
+        stop_node(self.nodes[0], 0)
+        stop_node(self.nodes[1], 2)
+        stop_node(self.nodes[2], 3)
 
         self.nodes = start_nodes(self.num_nodes, self.options.tmpdir)
         # This test is not meant to test fee estimation and we'd like

--- a/qa/rpc-tests/rpcbind_test.py
+++ b/qa/rpc-tests/rpcbind_test.py
@@ -35,11 +35,9 @@ class RPCBindTest(BitcoinTestFramework):
             base_args += ['-rpcallowip=' + x for x in allow_ips]
         binds = ['-rpcbind='+addr for addr in addresses]
         self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, [base_args + binds], connect_to)
-        try:
-            pid = bitcoind_processes[0].pid
-            assert_equal(set(get_bind_addrs(pid)), set(expected))
-        finally:
-            stop_nodes(self.nodes)
+        pid = bitcoind_processes[0].pid
+        assert_equal(set(get_bind_addrs(pid)), set(expected))
+        stop_nodes(self.nodes)
 
     def run_allowip_test(self, allow_ips, rpchost, rpcport):
         '''
@@ -48,13 +46,10 @@ class RPCBindTest(BitcoinTestFramework):
         '''
         base_args = ['-disablewallet', '-nolisten'] + ['-rpcallowip='+x for x in allow_ips]
         self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, [base_args])
-        try:
-            # connect to node through non-loopback interface
-            node = get_rpc_proxy(rpc_url(0, "%s:%d" % (rpchost, rpcport)), 0)
-            node.getnetworkinfo()
-        finally:
-            node = None # make sure connection will be garbage collected and closed
-            stop_nodes(self.nodes)
+        # connect to node through non-loopback interface
+        node = get_rpc_proxy(rpc_url(0, "%s:%d" % (rpchost, rpcport)), 0)
+        node.getnetworkinfo()
+        stop_nodes(self.nodes)
 
     def run_test(self):
         # due to OS-specific network stats queries, this test works only on Linux


### PR DESCRIPTION
We had a segfault slip through recently (#9817) because the test framework just ignores the return code.