### PR TITLE
Fix importmulti returning rescan errors for wrong keys

### DIFF
--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -1098,6 +1098,7 @@ UniValue importmulti(const JSONRPCRequest& mainRequest)
                     result.pushKV("error", JSONRPCError(RPC_MISC_ERROR, strprintf("Failed to rescan before time %d, transactions may be missing.", scannedRange->GetBlockTimeMax())));
                     response.push_back(std::move(result));
                 }
+                ++i;
             }
         }
     }


### PR DESCRIPTION
Bug was a missing ++i line in a new range for loop added in #9773.