### PR TITLE
build: force a c++ standard to be specified

### DIFF
--- a/build-aux/m4/ax_cxx_compile_stdcxx.m4
+++ b/build-aux/m4/ax_cxx_compile_stdcxx.m4
@@ -57,8 +57,14 @@ AC_DEFUN([AX_CXX_COMPILE_STDCXX], [dnl
         [$3], [mandatory], [ax_cxx_compile_cxx$1_required=true],
         [$3], [optional], [ax_cxx_compile_cxx$1_required=false],
         [m4_fatal([invalid third argument `$3' to AX_CXX_COMPILE_STDCXX])])
+  m4_if([$4], [], [ax_cxx_compile_cxx$1_try_default=true],
+        [$4], [default], [ax_cxx_compile_cxx$1_try_default=true],
+        [$4], [nodefault], [ax_cxx_compile_cxx$1_try_default=false],
+        [m4_fatal([invalid fourth argument `$4' to AX_CXX_COMPILE_STDCXX])])
   AC_LANG_PUSH([C++])dnl
   ac_success=no
+
+  m4_if([$4], [nodefault], [], [dnl
   AC_CACHE_CHECK(whether $CXX supports C++$1 features by default,
   ax_cv_cxx_compile_cxx$1,
   [AC_COMPILE_IFELSE([AC_LANG_SOURCE([_AX_CXX_COMPILE_STDCXX_testbody_$1])],
@@ -66,7 +72,7 @@ AC_DEFUN([AX_CXX_COMPILE_STDCXX], [dnl
     [ax_cv_cxx_compile_cxx$1=no])])
   if test x$ax_cv_cxx_compile_cxx$1 = xyes; then
     ac_success=yes
-  fi
+  fi])
 
   m4_if([$2], [noext], [], [dnl
   if test x$ac_success = xno; then

--- a/configure.ac
+++ b/configure.ac
@@ -55,7 +55,7 @@ case $host in
   ;;
 esac
 dnl Require C++11 compiler (no GNU extensions)
-AX_CXX_COMPILE_STDCXX([11], [noext], [mandatory])
+AX_CXX_COMPILE_STDCXX([11], [noext], [mandatory], [nodefault])
 dnl Check if -latomic is required for <std::atomic>
 CHECK_ATOMIC
 


### PR DESCRIPTION
@laanwj suggested this here https://github.com/bitcoin/bitcoin/pull/9753#issuecomment-281651607.

Newer compilers may switch to newer standards by default. For example, gcc6 uses std=gnu++14 by default.

Note that this makes testing c++14 impractical. Until we're ready to investigate that transition, I don't think that's a problem.

I'll attempt to upstream the macro changes post-merge.