### PR TITLE
Trivial: fix comments referencing AppInit2

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -118,10 +118,6 @@ static const char* FEE_ESTIMATES_FILENAME="fee_estimates.dat";
 // threads that should only be stopped after the main network-processing
 // threads have exited.
 //
-// Note that if running -daemon the parent process returns from AppInit2
-// before adding any threads to the threadGroup, so .join_all() returns
-// immediately and the parent exits from main().
-//
 // Shutdown for Qt is very similar, only it uses a QTimer to detect
 // fRequestShutdown getting set, and then does the normal Qt
 // shutdown thing.
@@ -188,7 +184,7 @@ void Shutdown()
     if (!lockShutdown)
         return;
 
-    /// Note: Shutdown() must be able to handle cases in which AppInit2() failed part of the way,
+    /// Note: Shutdown() must be able to handle cases in which initialization failed part of the way,
     /// for example if the data directory was found to be locked.
     /// Be sure that anything that writes files or flushes caches only does this if the respective
     /// module was initialized.

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -268,7 +268,7 @@ void BitcoinCore::initialize()
 {
     try
     {
-        qDebug() << __func__ << ": Running AppInit2 in thread";
+        qDebug() << __func__ << ": Running initialization in thread";
         if (!AppInitBasicSetup())
         {
             Q_EMIT initializeResult(false);
@@ -457,7 +457,7 @@ void BitcoinApplication::initializeResult(int retval)
     returnValue = retval ? 0 : 1;
     if(retval)
     {
-        // Log this only after AppInit2 finishes, as then logging setup is guaranteed complete
+        // Log this only after AppInitMain finishes, as then logging setup is guaranteed complete
         qWarning() << "Platform customization:" << platformStyle->getName();
 #ifdef ENABLE_WALLET
         PaymentServer::LoadRootCAs();

--- a/src/script/sigcache.cpp
+++ b/src/script/sigcache.cpp
@@ -90,7 +90,8 @@ public:
 static CSignatureCache signatureCache;
 }
 
-// To be called once in AppInit2/TestingSetup to initialize the signatureCache
+// To be called once in AppInitMain/BasicTestingSetup to initialize the
+// signatureCache.
 void InitSignatureCache()
 {
     // nMaxCacheSize is unsigned. If -maxsigcachesize is set to zero,


### PR DESCRIPTION
It was refactored into multiple functions in
0cc8b6bc44bea29e24fa4e13d8a9bbe4f1483680.