### PR TITLE
RPC: cleanups in rpc/server

### DIFF
--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -185,16 +185,16 @@ extern CRPCTable tableRPC;
  * Utilities: convert hex-encoded Values
  * (throws error if not hex).
  */
-extern uint256 ParseHashV(const UniValue& v, std::string strName);
-extern uint256 ParseHashO(const UniValue& o, std::string strKey);
-extern std::vector<unsigned char> ParseHexV(const UniValue& v, std::string strName);
-extern std::vector<unsigned char> ParseHexO(const UniValue& o, std::string strKey);
+uint256 ParseHashV(const UniValue& v, std::string strName);
+uint256 ParseHashO(const UniValue& o, std::string strKey);
+std::vector<unsigned char> ParseHexV(const UniValue& v, std::string strName);
+std::vector<unsigned char> ParseHexO(const UniValue& o, std::string strKey);
 
-extern CAmount AmountFromValue(const UniValue& value);
-extern UniValue ValueFromAmount(const CAmount& amount);
-extern double GetDifficulty(const CBlockIndex* blockindex = NULL);
-extern std::string HelpExampleCli(const std::string& methodname, const std::string& args);
-extern std::string HelpExampleRpc(const std::string& methodname, const std::string& args);
+CAmount AmountFromValue(const UniValue& value);
+UniValue ValueFromAmount(const CAmount& amount);
+double GetDifficulty(const CBlockIndex* blockindex = NULL);
+std::string HelpExampleCli(const std::string& methodname, const std::string& args);
+std::string HelpExampleRpc(const std::string& methodname, const std::string& args);
 
 bool StartRPC();
 void InterruptRPC();


### PR DESCRIPTION
There's no reason to declare the following functions in rpc/server.h when they're defined in wallet/rpcwallet.cpp. They can be declared in wallet/rpcwallet.h instead:

HelpRequiringPassphrase
EnsureWalletIsAvailable
EnsureWalletIsUnlocked

Also, there's no reason to use extern for functions declared in rpc/server.h. It is really never needed (see http://stackoverflow.com/questions/11712707/extern-functions-in-c-vs-c/11712820#11712820 ), but it seems more strange when those functions are also defined in rpc/server.cpp (in the same module).
