### PR TITLE
Terminate immediately when allocation fails

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -797,6 +797,19 @@ ServiceFlags nLocalServices = NODE_NETWORK;
 
 }
 
+[[noreturn]] static void new_handler_terminate()
+{
+    // Rather than throwing std::bad-alloc if allocation fails, terminate
+    // immediately to (try to) avoid chain corruption.
+    // Since LogPrintf may itself allocate memory, set the handler directly
+    // to terminate first.
+    std::set_new_handler(std::terminate);
+    LogPrintf("Error: Out of memory. Terminating.\n");
+
+    // The log was successful, terminate now.
+    std::terminate();
+};
+
 bool AppInitBasicSetup()
 {
     // ********************************************************* Step 1: setup
@@ -849,6 +862,9 @@ bool AppInitBasicSetup()
     // Ignore SIGPIPE, otherwise it will bring the daemon down if the client closes unexpectedly
     signal(SIGPIPE, SIG_IGN);
 #endif
+
+    std::set_new_handler(new_handler_terminate);
+
     return true;
 }
 

--- a/src/prevector.h
+++ b/src/prevector.h
@@ -5,6 +5,7 @@
 #ifndef _BITCOIN_PREVECTOR_H_
 #define _BITCOIN_PREVECTOR_H_
 
+#include <assert.h>
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
@@ -170,10 +171,15 @@ private:
             }
         } else {
             if (!is_direct()) {
+                /* FIXME: Because malloc/realloc here won't call new_handler if allocation fails, assert
+                    success. These should instead use an allocator or new/delete so that handlers
+                    are called as necessary, but performance would be slightly degraded by doing so. */
                 _union.indirect = static_cast<char*>(realloc(_union.indirect, ((size_t)sizeof(T)) * new_capacity));
+                assert(_union.indirect);
                 _union.capacity = new_capacity;
             } else {
                 char* new_indirect = static_cast<char*>(malloc(((size_t)sizeof(T)) * new_capacity));
+                assert(new_indirect);
                 T* src = direct_ptr(0);
                 T* dst = reinterpret_cast<T*>(new_indirect);
                 memcpy(dst, src, size() * sizeof(T));


### PR DESCRIPTION
Addresses #9854.

This installs a handler for failed allocations. Usually, a std::bad_alloc would be thrown, but we can instead opt to terminate immediately. See http://en.cppreference.com/w/cpp/memory/new/set_new_handler .

Our only manual malloc/free comes from prevector. Ideally we'd just use new[]/delete[] there, but the benchmark shows a noticeable difference, and I'm very hesitant to make that kind of change post-rc2.

As an alternative, this could even just be an assert() for 0.14.

For reference, here's the alternative using new/delete: https://github.com/theuni/bitcoin/commit/0c1b4107b918d457376dcd154f7e87d9d647bf91

Edit: g++/libstdc++ didn't support get_new_handler() yet, so assert it is.