### PR TITLE
Trivial: Debug log ambiguity fix for peer addrs

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2210,8 +2210,9 @@ bool CConnman::Start(CScheduler& scheduler, std::string& strNodeError, Options c
     SetBestHeight(connOptions.nBestHeight);
 
     clientInterface = connOptions.uiInterface;
-    if (clientInterface)
-        clientInterface->InitMessage(_("Loading addresses..."));
+    if (clientInterface) {
+        clientInterface->InitMessage(_("Loading P2P addresses..."));
+    }
     // Load addresses from peers.dat
     int64_t nStart = GetTimeMillis();
     {


### PR DESCRIPTION
This line can be misinterpreted as loading wallet addresses which is confusing, especially when the wallet is disabled.