### PR TITLE
RPC: Introduce -rpcamountdecimals for the RPC to use other units than BTC

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -492,6 +492,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-rpcport=<port>", strprintf(_("Listen for JSON-RPC connections on <port> (default: %u or testnet: %u)"), BaseParams(CBaseChainParams::MAIN).RPCPort(), BaseParams(CBaseChainParams::TESTNET).RPCPort()));
     strUsage += HelpMessageOpt("-rpcallowip=<ip>", _("Allow JSON-RPC connections from specified source. Valid for <ip> are a single IP (e.g. 1.2.3.4), a network/netmask (e.g. 1.2.3.4/255.255.255.0) or a network/CIDR (e.g. 1.2.3.4/24). This option can be specified multiple times"));
     strUsage += HelpMessageOpt("-rpcthreads=<n>", strprintf(_("Set the number of threads to service RPC calls (default: %d)"), DEFAULT_HTTP_THREADS));
+    strUsage += HelpMessageOpt("-rpcamountdecimals=<n>", strprintf(_("Number of decimals for amount values in RPC (default: %d [ie unit BTC], allowed: from 0 to 8)"), DEFAULT_RPC_AMOUNT_DECIMALS));
     if (showDebug) {
         strUsage += HelpMessageOpt("-rpcworkqueue=<n>", strprintf("Set the depth of the work queue to service RPC calls (default: %d)", DEFAULT_HTTP_WORKQUEUE));
         strUsage += HelpMessageOpt("-rpcservertimeout=<n>", strprintf("Timeout during HTTP requests (default: %d)", DEFAULT_HTTP_SERVER_TIMEOUT));
@@ -1039,6 +1040,9 @@ bool AppInitParameterInteraction()
 
     if (GetArg("-rpcserialversion", DEFAULT_RPC_SERIALIZE_VERSION) > 1)
         return InitError("unknown rpcserialversion requested.");
+
+    if (!SetRpcAmountDecimals(GetArg("-rpcamountdecimals", DEFAULT_RPC_AMOUNT_DECIMALS)))
+        return InitError("-rpcamountdecimals must be between 0 and 8.");
 
     nMaxTipAge = GetArg("-maxtipage", DEFAULT_MAX_TIP_AGE);
 

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -20,6 +20,7 @@
 #include <univalue.h>
 
 static const unsigned int DEFAULT_RPC_SERIALIZE_VERSION = 1;
+static const unsigned int DEFAULT_RPC_AMOUNT_DECIMALS = 8;
 
 class CRPCCommand;
 
@@ -191,6 +192,7 @@ extern std::vector<unsigned char> ParseHexV(const UniValue& v, std::string strNa
 extern std::vector<unsigned char> ParseHexO(const UniValue& o, std::string strKey);
 
 extern int64_t nWalletUnlockTime;
+bool SetRpcAmountDecimals(unsigned int decimals);
 extern CAmount AmountFromValue(const UniValue& value);
 extern UniValue ValueFromAmount(const CAmount& amount);
 extern double GetDifficulty(const CBlockIndex* blockindex = NULL);


### PR DESCRIPTION
Replaces #9855. Inspired by #3759 .
