### PR TITLE
remove 'label' filter for rpc command help

### DIFF
--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -193,9 +193,6 @@ std::string CRPCTable::help(const std::string& strCommand) const
     {
         const CRPCCommand *pcmd = command.second;
         string strMethod = pcmd->name;
-        // We already filter duplicates, but these deprecated screw up the sort order
-        if (strMethod.find("label") != string::npos)
-            continue;
         if ((strCommand != "" || pcmd->category == "hidden") && strMethod != strCommand)
             continue;
         try


### PR DESCRIPTION
No idea why it's there(which gives me some pause) since it's a sourceforge-era commit, but it seems useless and filters out any command with "label" in the name.