### PR TITLE
Ban "invalid messagestart" nodes

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2679,6 +2679,7 @@ bool ProcessMessages(CNode* pfrom, CConnman& connman, const std::atomic<bool>& i
         // Scan for message start
         if (memcmp(msg.hdr.pchMessageStart, chainparams.MessageStart(), CMessageHeader::MESSAGE_START_SIZE) != 0) {
             LogPrintf("PROCESSMESSAGE: INVALID MESSAGESTART %s peer=%d\n", SanitizeString(msg.hdr.GetCommand()), pfrom->id);
+            connman.Ban(pfrom->addr, BanReasonNodeMisbehaving);
             pfrom->fDisconnect = true;
             return false;
         }


### PR DESCRIPTION
If connecting node is not sending proper "messagestart" it should be banned.
There is a lot cpu/bandwidth wasted because those "fake" nodes trying to connect over and over.
Grep debug.log for "PROCESSMESSAGE: INVALID MESSAGESTART 44version" to see how much it is.
After this patch node is dropped instantly.