### PR TITLE
Disallow copy constructor CReserveKeys

### DIFF
--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1009,6 +1009,10 @@ public:
         pwallet = pwalletIn;
     }
 
+    CReserveKey() = default;
+    CReserveKey(const CReserveKey&) = delete;
+    CReserveKey& operator=(const CReserveKey&) = delete;
+
     ~CReserveKey()
     {
         ReturnKey();


### PR DESCRIPTION
In the case where you use a copy constructor(no instance in codebase now), Bad Things can happen, including crash.