### PR TITLE
UNIX sockets support for RPC

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -601,6 +601,21 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <sys/types.h>
  [ AC_MSG_RESULT(no)]
 )
 
+# Check for UNIX sockets
+AC_MSG_CHECKING(for sockaddr_un)
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <sys/socket.h>
+  #include <sys/un.h>]],
+ [[ struct sockaddr_un addr;
+    addr.sun_family = AF_UNIX; ]])],
+ [ AC_MSG_RESULT(yes);
+   AC_DEFINE(HAVE_SOCKADDR_UN, 1,[Define this symbol if the sockaddr_un is available]) 
+   AM_CONDITIONAL([BUILD_EVUNIX],[true])
+ ],
+ [ AC_MSG_RESULT(no)
+   AM_CONDITIONAL([BUILD_EVUNIX],[false])
+ ]
+)
+
 # Check for reduced exports
 if test x$use_reduce_exports = xyes; then
   AX_CHECK_COMPILE_FLAG([-fvisibility=hidden],[RE_CXXFLAGS="-fvisibility=hidden"],

--- a/qa/README.md
+++ b/qa/README.md
@@ -63,6 +63,10 @@ Possible options, which apply to each individual test run:
 If you set the environment variable `PYTHON_DEBUG=1` you will get some debug
 output (example: `PYTHON_DEBUG=1 qa/pull-tester/rpc-tests.py wallet`).
 
+To force the tests to use RPC over TCP instead of a UNIX socket (this
+can be useful for troubleshooting) define the environment variable
+`BITCOIN_TEST_RPC_TCP` as `1`.
+
 A 200-block -regtest blockchain and wallets for four nodes
 is created the first time a regression test is run and
 is stored in the cache/ directory. Each node has 25 mature

--- a/qa/rpc-tests/abandonconflict.py
+++ b/qa/rpc-tests/abandonconflict.py
@@ -23,8 +23,8 @@ class AbandonConflictTest(BitcoinTestFramework):
 
     def setup_network(self):
         self.nodes = []
-        self.nodes.append(start_node(0, self.options.tmpdir, ["-minrelaytxfee=0.00001"]))
-        self.nodes.append(start_node(1, self.options.tmpdir))
+        self.nodes.append(start_node(0, self.options.tmpdir, ["-minrelaytxfee=0.00001"], rpchost="127.0.0.1"))
+        self.nodes.append(start_node(1, self.options.tmpdir, [], rpchost="127.0.0.1"))
         connect_nodes(self.nodes[0], 1)
 
     def run_test(self):

--- a/qa/rpc-tests/httpbasics.py
+++ b/qa/rpc-tests/httpbasics.py
@@ -17,7 +17,7 @@ class HTTPBasicsTest (BitcoinTestFramework):
         self.setup_clean_chain = False
 
     def setup_network(self):
-        self.nodes = self.setup_nodes()
+        self.nodes = self.setup_nodes(rpchost="127.0.0.1")
 
     def run_test(self):
 

--- a/qa/rpc-tests/multi_rpc.py
+++ b/qa/rpc-tests/multi_rpc.py
@@ -18,17 +18,13 @@ class HTTPBasicsTest (BitcoinTestFramework):
         self.setup_clean_chain = False
         self.num_nodes = 1
 
-    def setup_chain(self):
-        super().setup_chain()
-        #Append rpcauth to bitcoin.conf before initialization
-        rpcauth = "rpcauth=rt:93648e835a54c573682c2eb19f882535$7681e9c5b74bdd85e78166031d2058e1069b3ed7ed967c93fc63abba06f31144"
-        rpcauth2 = "rpcauth=rt2:f8607b1a88861fac29dfccf9b52ff9f$ff36a0c23c8c62b4846112e50fa888416e94c17bfd4c42f88fd8f55ec6a3137e"
-        with open(os.path.join(self.options.tmpdir+"/node0", "bitcoin.conf"), 'a', encoding='utf8') as f:
-            f.write(rpcauth+"\n")
-            f.write(rpcauth2+"\n")
-
     def setup_network(self):
-        self.nodes = self.setup_nodes()
+        # Pass in extra RPC authentication information
+        extra_args = [[
+            "-rpcauth=rt:93648e835a54c573682c2eb19f882535$7681e9c5b74bdd85e78166031d2058e1069b3ed7ed967c93fc63abba06f31144",
+            "-rpcauth=rt2:f8607b1a88861fac29dfccf9b52ff9f$ff36a0c23c8c62b4846112e50fa888416e94c17bfd4c42f88fd8f55ec6a3137e"
+        ]]
+        self.nodes = self.setup_nodes(rpchost='127.0.0.1', extra_args=extra_args)
 
     def run_test(self):
 

--- a/qa/rpc-tests/nodehandling.py
+++ b/qa/rpc-tests/nodehandling.py
@@ -16,6 +16,9 @@ class NodeHandlingTest (BitcoinTestFramework):
         self.num_nodes = 4
         self.setup_clean_chain = False
 
+    def setup_nodes(self):
+        return start_nodes(self.num_nodes, self.options.tmpdir, rpchost='127.0.0.1')
+
     def run_test(self):
         ###########################
         # setban/listbanned tests #

--- a/qa/rpc-tests/rest.py
+++ b/qa/rpc-tests/rest.py
@@ -49,7 +49,7 @@ class RESTTest (BitcoinTestFramework):
         self.num_nodes = 3
 
     def setup_network(self, split=False):
-        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir)
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, rpchost='127.0.0.1')
         connect_nodes_bi(self.nodes,0,1)
         connect_nodes_bi(self.nodes,1,2)
         connect_nodes_bi(self.nodes,0,2)

--- a/qa/rpc-tests/test_framework/conninfo.py
+++ b/qa/rpc-tests/test_framework/conninfo.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+import os
+
+from .uhttpconnection import UHTTPConnection
+
+# UNIX socket name for RPC connection (in data directory)
+RPC_SOCKET_NAME = "rpc_socket"
+
+class RPCConnectInfo:
+    '''
+    Base class for RPC connection info. This class encapsulates both information
+    required to connect to RPC, as to configure bitcoind to listen on that transport.
+    '''
+    def make_connection(self):
+        '''
+        Returns the 'connection' argument to pass to the RPCAuthService.
+        Can be None to let that class figure it out itself.
+        '''
+        raise NotImplementedError
+
+    @property
+    def bitcoind_args(self):
+        '''
+        Return arguments for setting up bitcoind.
+        '''
+        raise NotImplementedError
+
+class RPCConnectInfoTCP:
+    '''RPC connection info for connecting over TCP'''
+    def __init__(self, node_number, auth, rpchost, rpcport):
+        self.node_number = node_number # node number is just for informational purposes
+        self.auth = auth
+        self.host = '127.0.0.1'
+        self.port = rpcport
+        if rpchost: # "rpchost" can override both host and port
+            parts = rpchost.split(':')
+            self.host = parts[0]
+            if len(parts) == 2:
+                self.port = int(parts[1])
+        self.url = "http://%s:%s@%s:%d" % (auth[0], auth[1], self.host, self.port)
+
+    def make_connection(self):
+        # This is done inside the AuthServiceProxy
+        return None
+
+    @property
+    def bitcoind_args(self):
+        # rpchost is ignored here because the test will take care of passing in the
+        # appropriate rpcbind arguments.
+        return [("rpcuser", self.auth[0]),
+                ("rpcpassword", self.auth[1]),
+                ("rpcport", str(self.port))]
+
+class RPCConnectInfoUNIX:
+    '''RPC connection info for connecting over UNIX socket'''
+    def __init__(self, node_number, auth, dirname):
+        self.node_number = node_number
+        self.auth = auth
+        self.sockname = os.path.join(dirname, RPC_SOCKET_NAME)
+        # use "localhost" as fake hostname. It doesn't matter.
+        self.url = "http://%s:%s@localhost" % auth
+
+    def make_connection(self):
+        return UHTTPConnection(self.sockname)
+
+    @property
+    def bitcoind_args(self):
+        return [("rpcuser", self.auth[0]),
+                ("rpcpassword", self.auth[1]),
+                ("rpcbind", ":unix:"+self.sockname),
+                ("rpcconnect", ":unix:"+self.sockname)]
+

--- a/qa/rpc-tests/test_framework/test_framework.py
+++ b/qa/rpc-tests/test_framework/test_framework.py
@@ -51,8 +51,8 @@ class BitcoinTestFramework(object):
     def stop_node(self, num_node):
         stop_node(self.nodes[num_node], num_node)
 
-    def setup_nodes(self):
-        return start_nodes(self.num_nodes, self.options.tmpdir)
+    def setup_nodes(self, rpchost=None, extra_args=None):
+        return start_nodes(self.num_nodes, self.options.tmpdir, rpchost=rpchost, extra_args=extra_args)
 
     def setup_network(self, split = False):
         self.nodes = self.setup_nodes()

--- a/qa/rpc-tests/test_framework/uhttpconnection.py
+++ b/qa/rpc-tests/test_framework/uhttpconnection.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#
+# Inspired by "HTTP on Unix sockets with Python"
+# From: http://7bits.nl/blog/posts/http-on-unix-sockets-with-python
+import http.client
+import socket
+
+def have_af_unix():
+    '''Return True if UNIX sockets are available on this platform.'''
+    try:
+        socket.AF_UNIX
+    except AttributeError:
+        return False
+    else:
+        return True
+
+class UHTTPConnection(http.client.HTTPConnection):
+    """Subclass of Python library HTTPConnection that
+       uses a unix-domain socket.
+    """
+
+    def __init__(self, path):
+        http.client.HTTPConnection.__init__(self, 'localhost')
+        self.path = path
+
+    def connect(self):
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        sock.connect(self.path)
+        self.sock = sock
+

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -23,6 +23,8 @@ import logging
 
 from . import coverage
 from .authproxy import AuthServiceProxy, JSONRPCException
+from .conninfo import RPCConnectInfoTCP, RPCConnectInfoUNIX
+from .uhttpconnection import have_af_unix
 
 COVERAGE_DIR = None
 
@@ -69,11 +71,10 @@ def enable_coverage(dirname):
     COVERAGE_DIR = dirname
 
 
-def get_rpc_proxy(url, node_number, timeout=None):
+def get_rpc_proxy(conninfo, timeout=None):
     """
     Args:
-        url (str): URL of the RPC server to call
-        node_number (int): the node number (or id) that this calls to
+        urlinfo (RPCConnectInfo): Connection info of the RPC server to call
 
     Kwargs:
         timeout (int): HTTP timeout in seconds
@@ -85,12 +86,13 @@ def get_rpc_proxy(url, node_number, timeout=None):
     proxy_kwargs = {}
     if timeout is not None:
         proxy_kwargs['timeout'] = timeout
+    proxy_kwargs['connection'] = conninfo.make_connection()
 
-    proxy = AuthServiceProxy(url, **proxy_kwargs)
-    proxy.url = url  # store URL on proxy for info
+    proxy = AuthServiceProxy(conninfo.url, **proxy_kwargs)
+    proxy.url = conninfo.url  # store URL on proxy for info
 
     coverage_logfile = coverage.get_filename(
-        COVERAGE_DIR, node_number) if COVERAGE_DIR else None
+        COVERAGE_DIR, conninfo.node_number) if COVERAGE_DIR else None
 
     return coverage.AuthServiceProxyWrapper(proxy, coverage_logfile)
 
@@ -177,36 +179,39 @@ def sync_mempools(rpc_connections, *, wait=1, timeout=60):
 
 bitcoind_processes = {}
 
-def initialize_datadir(dirname, n):
+def initialize_datadir(dirname, n, rpchost=None):
+    '''
+    Initialize datadir and write bitcoin configuration.
+    '''
     datadir = os.path.join(dirname, "node"+str(n))
+    conninfo = conninfo_for(n, rpchost, datadir)
     if not os.path.isdir(datadir):
         os.makedirs(datadir)
-    rpc_u, rpc_p = rpc_auth_pair(n)
     with open(os.path.join(datadir, "bitcoin.conf"), 'w', encoding='utf8') as f:
         f.write("regtest=1\n")
-        f.write("rpcuser=" + rpc_u + "\n")
-        f.write("rpcpassword=" + rpc_p + "\n")
         f.write("port="+str(p2p_port(n))+"\n")
-        f.write("rpcport="+str(rpc_port(n))+"\n")
         f.write("listenonion=0\n")
-    return datadir
+        for (key, value) in conninfo.bitcoind_args:
+            f.write('%s=%s\n' % (key, value))
+    return datadir, conninfo
 
 def rpc_auth_pair(n):
     return 'rpcuser💻' + str(n), 'rpcpass🔑' + str(n)
 
-def rpc_url(i, rpchost=None):
-    rpc_u, rpc_p = rpc_auth_pair(i)
-    host = '127.0.0.1'
-    port = rpc_port(i)
-    if rpchost:
-        parts = rpchost.split(':')
-        if len(parts) == 2:
-            host, port = parts
-        else:
-            host = rpchost
-    return "http://%s:%s@%s:%d" % (rpc_u, rpc_p, host, int(port))
+def conninfo_for(node_number, rpchost, datadir):
+    '''
+    Return connection info for connecting to a certain node, by number.
+    This is where the decision of what transport to use is made.
 
-def wait_for_bitcoind_start(process, url, i):
+    rpchost: Override host to connect to (if provided, forces connection through TCP).
+    datadir: Data directory
+    '''
+    if have_af_unix() and rpchost is None: # Prefer connecting over a UNIX socket, if available
+        return RPCConnectInfoUNIX(node_number, rpc_auth_pair(node_number), datadir)
+    else:
+        return RPCConnectInfoTCP(node_number, rpc_auth_pair(node_number), rpchost, rpc_port(node_number))
+
+def wait_for_bitcoind_start(process, conninfo):
     '''
     Wait for bitcoind to start. This means that RPC is accessible and fully initialized.
     Raise an exception if bitcoind exits during initialization.
@@ -215,11 +220,11 @@ def wait_for_bitcoind_start(process, url, i):
         if process.poll() is not None:
             raise Exception('bitcoind exited with status %i during initialization' % process.returncode)
         try:
-            rpc = get_rpc_proxy(url, i)
+            rpc = get_rpc_proxy(conninfo)
             blocks = rpc.getblockcount()
             break # break out of loop on success
         except IOError as e:
-            if e.errno != errno.ECONNREFUSED: # Port not yet open?
+            if e.errno != errno.ECONNREFUSED and e.errno != errno.ENOENT: # Port not yet open or socket not yet created?
                 raise # unknown IO error
         except JSONRPCException as e: # Initialization phase
             if e.error['code'] != -28: # RPC in warmup?
@@ -248,20 +253,22 @@ def initialize_chain(test_dir, num_nodes, cachedir):
                 shutil.rmtree(os.path.join(cachedir,"node"+str(i)))
 
         # Create cache directories, run bitcoinds:
+        conninfos = []
         for i in range(MAX_NODES):
-            datadir=initialize_datadir(cachedir, i)
+            datadir, conninfo = initialize_datadir(cachedir, i)
             args = [ os.getenv("BITCOIND", "bitcoind"), "-server", "-keypool=1", "-datadir="+datadir, "-discover=0" ]
             if i > 0:
                 args.append("-connect=127.0.0.1:"+str(p2p_port(0)))
             bitcoind_processes[i] = subprocess.Popen(args)
             logger.debug("initialize_chain: bitcoind started, waiting for RPC to come up")
-            wait_for_bitcoind_start(bitcoind_processes[i], rpc_url(i), i)
+            wait_for_bitcoind_start(bitcoind_processes[i], conninfo)
             logger.debug("initialize_chain: RPC successfully started")
+            conninfos.append(conninfo)
 
         rpcs = []
         for i in range(MAX_NODES):
             try:
-                rpcs.append(get_rpc_proxy(rpc_url(i), i))
+                rpcs.append(get_rpc_proxy(conninfos[i]))
             except:
                 sys.stderr.write("Error connecting to "+url+"\n")
                 sys.exit(1)
@@ -305,24 +312,23 @@ def initialize_chain_clean(test_dir, num_nodes):
     Useful if a test case wants complete control over initialization.
     """
     for i in range(num_nodes):
-        datadir=initialize_datadir(test_dir, i)
+        initialize_datadir(test_dir, i)
 
 
 def start_node(i, dirname, extra_args=None, rpchost=None, timewait=None, binary=None, stderr=None):
     """
     Start a bitcoind and return RPC connection to it
     """
-    datadir = os.path.join(dirname, "node"+str(i))
+    datadir,conninfo = initialize_datadir(dirname, i, rpchost)
     if binary is None:
         binary = os.getenv("BITCOIND", "bitcoind")
     args = [ binary, "-datadir="+datadir, "-server", "-keypool=1", "-discover=0", "-rest", "-logtimemicros", "-debug", "-mocktime="+str(get_mocktime()) ]
     if extra_args is not None: args.extend(extra_args)
     bitcoind_processes[i] = subprocess.Popen(args, stderr=stderr)
     logger.debug("initialize_chain: bitcoind started, waiting for RPC to come up")
-    url = rpc_url(i, rpchost)
-    wait_for_bitcoind_start(bitcoind_processes[i], url, i)
+    wait_for_bitcoind_start(bitcoind_processes[i], conninfo)
     logger.debug("initialize_chain: RPC successfully started")
-    proxy = get_rpc_proxy(url, i, timeout=timewait)
+    proxy = get_rpc_proxy(conninfo, timeout=timewait)
 
     if COVERAGE_DIR:
         coverage.write_all_rpc_commands(COVERAGE_DIR, proxy)

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -206,7 +206,7 @@ def conninfo_for(node_number, rpchost, datadir):
     rpchost: Override host to connect to (if provided, forces connection through TCP).
     datadir: Data directory
     '''
-    if have_af_unix() and rpchost is None: # Prefer connecting over a UNIX socket, if available
+    if have_af_unix() and rpchost is None and not int(os.getenv("BITCOIN_TEST_RPC_TCP","0")): # Prefer connecting over a UNIX socket, if available
         return RPCConnectInfoUNIX(node_number, rpc_auth_pair(node_number), datadir)
     else:
         return RPCConnectInfoTCP(node_number, rpc_auth_pair(node_number), rpchost, rpc_port(node_number))

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -136,6 +136,7 @@ BITCOIN_CORE_H = \
   support/allocators/zeroafterfree.h \
   support/cleanse.h \
   support/events.h \
+  support/evunix.h \
   support/lockedpool.h \
   sync.h \
   threadsafety.h \
@@ -211,6 +212,9 @@ libbitcoin_server_a_SOURCES = \
   validationinterface.cpp \
   versionbits.cpp \
   $(BITCOIN_CORE_H)
+if BUILD_EVUNIX
+libbitcoin_server_a_SOURCES += support/evunix.cpp
+endif
 
 if ENABLE_ZMQ
 libbitcoin_zmq_a_CPPFLAGS = $(BITCOIN_INCLUDES) $(ZMQ_CFLAGS)
@@ -377,6 +381,9 @@ bitcoind_LDADD += $(BOOST_LIBS) $(BDB_LIBS) $(SSL_LIBS) $(CRYPTO_LIBS) $(MINIUPN
 
 # bitcoin-cli binary #
 bitcoin_cli_SOURCES = bitcoin-cli.cpp
+if BUILD_EVUNIX
+bitcoin_cli_SOURCES += support/evunix.cpp
+endif
 bitcoin_cli_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) $(EVENT_CFLAGS)
 bitcoin_cli_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 bitcoin_cli_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)

--- a/src/rpc/protocol.cpp
+++ b/src/rpc/protocol.cpp
@@ -15,6 +15,9 @@
 #include <stdint.h>
 #include <fstream>
 
+/** To bind to a UNIX socket, use this prefix on rpcbind: */
+const std::string RPC_ADDR_PREFIX_UNIX = ":unix:";
+
 /**
  * JSON-RPC protocol.  Bitcoin speaks version 1.0 for maximum compatibility,
  * but uses JSON-RPC 1.1/2.0 standards for parts of the 1.0 standard that were

--- a/src/rpc/protocol.h
+++ b/src/rpc/protocol.h
@@ -88,6 +88,9 @@ UniValue JSONRPCReplyObj(const UniValue& result, const UniValue& error, const Un
 std::string JSONRPCReply(const UniValue& result, const UniValue& error, const UniValue& id);
 UniValue JSONRPCError(int code, const std::string& message);
 
+/** To bind to a UNIX socket, use this prefix on rpcbind. */
+extern const std::string RPC_ADDR_PREFIX_UNIX;
+
 /** Get name of RPC authentication cookie file */
 boost::filesystem::path GetAuthCookieFile();
 /** Generate a new RPC authentication cookie and write it to disk */

--- a/src/support/evunix.cpp
+++ b/src/support/evunix.cpp
@@ -1,0 +1,107 @@
+// Copyright (c) 2017 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#include "evunix.h"
+
+#include <sys/socket.h>
+#include <sys/un.h>
+
+#include <event2/bufferevent.h>
+#include <boost/filesystem/operations.hpp>
+
+/** Helper function to initialize a sockaddr_un from a path */
+static bool sockaddr_from_path(struct sockaddr_un *addr, const boost::filesystem::path &path)
+{
+    std::string name = path.string();
+    if (name.size() >= sizeof(addr->sun_path)) {
+        /* Name too long */
+        return false;
+    }
+    memset(addr, 0, sizeof(struct sockaddr_un));
+    addr->sun_family = AF_UNIX;
+    strncpy(addr->sun_path, name.c_str(), sizeof(addr->sun_path)-1);
+    return true;
+}
+
+bool evunix_remove_socket(const boost::filesystem::path &path)
+{
+    if (boost::filesystem::status(path).type() == boost::filesystem::socket_file) {
+        boost::system::error_code ec;
+        boost::filesystem::remove(path, ec);
+        if (ec) { /* error while deleting */
+            return false;
+        }
+    }
+    return true;
+}
+
+int evunix_bind_fd(const boost::filesystem::path &path)
+{
+    struct sockaddr_un addr;
+    if (!sockaddr_from_path(&addr, path)) {
+        return -1;
+    }
+    int fd = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (fd < 0) {
+        return -1;
+    }
+    /* Remove any previous sockets left behind. listen() will refuse to overwrite
+     * any file or socket. Remove only sockets, not other files that happen to have
+     * the same name.
+     */
+    if (!evunix_remove_socket(path)) {
+        close(fd);
+        return -1;
+    }
+    /* Bind and listen */
+    if (bind(fd, (struct sockaddr*)&addr, sizeof(addr)) < 0) {
+        close(fd);
+        return -1;
+    }
+    if (listen(fd, 5) < 0) {
+        close(fd);
+        return -1;
+    }
+    evutil_make_socket_nonblocking(fd);
+    return fd;
+}
+
+int evunix_connect_fd(const boost::filesystem::path &path)
+{
+    struct sockaddr_un addr;
+    if (!sockaddr_from_path(&addr, path)) {
+        return -1;
+    }
+    int fd = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (fd < 0) {
+        return -1;
+    }
+    if (connect(fd, (struct sockaddr*)&addr, sizeof(addr)) < 0) {
+        close(fd);
+        return -1;
+    }
+    evutil_make_socket_nonblocking(fd);
+    return fd;
+}
+
+struct bufferevent *evunix_bind(struct event_base *base, const boost::filesystem::path &path)
+{
+    struct bufferevent *rv;
+    int fd = evunix_bind_fd(path);
+    if ((rv = bufferevent_socket_new(base, fd, 0)) == NULL) {
+        close(fd);
+        return NULL;
+    }
+    return rv;
+}
+
+struct bufferevent *evunix_connect(struct event_base *base, const boost::filesystem::path &path)
+{
+    struct bufferevent *rv;
+    int fd = evunix_connect_fd(path);
+    if ((rv = bufferevent_socket_new(base, fd, 0)) == NULL) {
+        close(fd);
+        return NULL;
+    }
+    return rv;
+}

--- a/src/support/evunix.cpp
+++ b/src/support/evunix.cpp
@@ -84,6 +84,18 @@ int evunix_connect_fd(const boost::filesystem::path &path)
     return fd;
 }
 
+bool evunix_is_conn_from_unix_fd(int fd)
+{
+    struct sockaddr_un peer_unix;
+    socklen_t peer_unix_len = sizeof(peer_unix);
+    if (getpeername(fd, (sockaddr*)&peer_unix, &peer_unix_len) == 0) {
+        if (peer_unix.sun_family == AF_UNIX) {
+            return true;
+        }
+    }
+    return false;
+}
+
 struct bufferevent *evunix_bind(struct event_base *base, const boost::filesystem::path &path)
 {
     struct bufferevent *rv;
@@ -104,4 +116,13 @@ struct bufferevent *evunix_connect(struct event_base *base, const boost::filesys
         return NULL;
     }
     return rv;
+}
+
+bool evunix_is_conn_from_unix(struct bufferevent *bev)
+{
+    int fd;
+    if ((fd = bufferevent_getfd(bev)) != -1) {
+        return evunix_is_conn_from_unix_fd(fd);
+    }
+    return false;
 }

--- a/src/support/evunix.h
+++ b/src/support/evunix.h
@@ -11,6 +11,10 @@
 struct event_base;
 struct bufferevent;
 
+// All these functions come in a plain (high-level) and _fd (low-level)
+// variant. The plain version takes/yields a libevent bufferevent*, the _fd
+// functions file descriptor.
+
 /** Bind on a UNIX socket.
  * Returns a bufferevent that can be used to send or receive data on the socket, or NULL
  * on failure.
@@ -38,5 +42,15 @@ int evunix_connect_fd(const boost::filesystem::path &path);
  * the same name.
  */
 bool evunix_remove_socket(const boost::filesystem::path &path);
+
+/** Return whether incoming connection fd came in on a UNIX socket.
+ */
+bool evunix_is_conn_from_unix_fd(int fd);
+
+/** Return whether incoming connection bev came in on a UNIX socket.
+ * This is a hack because evhttp won't let us know what bound socket a connection
+ * came in on.
+ */
+bool evunix_is_conn_from_unix(struct bufferevent *bev);
 
 #endif

--- a/src/support/evunix.h
+++ b/src/support/evunix.h
@@ -1,0 +1,42 @@
+// Copyright (c) 2017 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#ifndef BITCOIN_EVUNIX_H
+#define BITCOIN_EVUNIX_H
+
+/** Libevent<->UNIX socket bridge functions */
+
+#include <boost/filesystem/path.hpp>
+
+struct event_base;
+struct bufferevent;
+
+/** Bind on a UNIX socket.
+ * Returns a bufferevent that can be used to send or receive data on the socket, or NULL
+ * on failure.
+ */
+struct bufferevent *evunix_bind(const boost::filesystem::path &path);
+
+/** Bind on a UNIX socket, return fd.
+ * Return a file descriptor ready to pass to evhttp_accept_socket_with_handle, or -1
+ * on failure.
+ */
+int evunix_bind_fd(const boost::filesystem::path &path);
+
+/** Connect to a UNIX socket.
+ * Returns a bufferevent that can be used to send or receive data on the socket, or NULL
+ * on failure.
+ */
+struct bufferevent *evunix_connect(struct event_base *base, const boost::filesystem::path &path);
+
+/** Connect to a UNIX socket, return fd.
+ * Return a file descriptor ready to use, or -1 on failure.
+ */
+int evunix_connect_fd(const boost::filesystem::path &path);
+
+/* Remove only sockets, not other files that happen to have
+ * the same name.
+ */
+bool evunix_remove_socket(const boost::filesystem::path &path);
+
+#endif


### PR DESCRIPTION
Add functionality for RPC over UNIX sockets, on platforms that support UNIX sockets. This is specified with `:unix:/path/to/socket` to `-rpcbind` and `-rpcconnect`. By default the socket path is relative to the data directory.

For the server side this works as-is.

For the client side (bitcoin-cli) this requires a small patch to libevent to be able to pass in a file descriptor of an existing connection (https://github.com/libevent/libevent/pull/479).

Even without the client change this could be useful though. For example the Python RPC tests could connect through UNIX socket to avoid port collisions ~~(TODO: make a Python example)~~. This has been implemented.

Also the overhead of using UNIX sockets should be lower than using local TCP (see https://stackoverflow.com/questions/14973942/performance-tcp-loopback-connection-vs-unix-domain-socket).

### Example

Server:

```bash
src/bitcoind -printtoconsole -datadir=/store/tmp/testbtc -connect=0 -debug=rpc -debug=http -rpcbind=:unix:socket
...
2017-03-05 10:29:31 Binding RPC on UNIX socket /store/tmp/testbtc/socket
...
```

Client:

```bash
src/bitcoin-cli -rpcconnect=":unix:socket" -datadir=/store/tmp/testbtc getinfo
{
  "version": 149900,
  ...
}
```
