### PR TITLE
build: Probe MSG_DONTWAIT in the same way as MSG_NOSIGNAL

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -558,6 +558,15 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <sys/socket.h>]],
  [ AC_MSG_RESULT(no)]
 )
 
+dnl Check for MSG_DONTWAIT
+AC_MSG_CHECKING(for MSG_DONTWAIT)
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <sys/socket.h>]],
+ [[ int f = MSG_DONTWAIT; ]])],
+ [ AC_MSG_RESULT(yes); AC_DEFINE(HAVE_DONTWAIT, 1,[Define this symbol if you have MSG_DONTWAIT]) ],
+ [ AC_MSG_RESULT(no)]
+)
+
+
 AC_MSG_CHECKING([for visibility attribute])
 AC_LINK_IFELSE([AC_LANG_SOURCE([
   int foo_def( void ) __attribute__((visibility("default")));

--- a/src/compat.h
+++ b/src/compat.h
@@ -72,16 +72,6 @@ typedef u_int SOCKET;
 #define MAX_PATH            1024
 #endif
 
-// As Solaris does not have the MSG_NOSIGNAL flag for send(2) syscall, it is defined as 0
-#if !defined(HAVE_MSG_NOSIGNAL) && !defined(MSG_NOSIGNAL)
-#define MSG_NOSIGNAL 0
-#endif
-
-// MSG_DONTWAIT is not available on some platforms, if it doesn't exist define it as 0
-#if !defined(HAVE_MSG_DONTWAIT) && !defined(MSG_DONTWAIT)
-#define MSG_DONTWAIT 0
-#endif
-
 #if HAVE_DECL_STRNLEN == 0
 size_t strnlen( const char *start, size_t max_len);
 #endif // HAVE_DECL_STRNLEN

--- a/src/compat.h
+++ b/src/compat.h
@@ -47,9 +47,7 @@
 #include <unistd.h>
 #endif
 
-#ifdef WIN32
-#define MSG_DONTWAIT        0
-#else
+#ifndef WIN32
 typedef u_int SOCKET;
 #include "errno.h"
 #define WSAGetLastError()   errno
@@ -77,6 +75,11 @@ typedef u_int SOCKET;
 // As Solaris does not have the MSG_NOSIGNAL flag for send(2) syscall, it is defined as 0
 #if !defined(HAVE_MSG_NOSIGNAL) && !defined(MSG_NOSIGNAL)
 #define MSG_NOSIGNAL 0
+#endif
+
+// MSG_DONTWAIT is not available on some platforms, if it doesn't exist define it as 0
+#if !defined(HAVE_MSG_DONTWAIT) && !defined(MSG_DONTWAIT)
+#define MSG_DONTWAIT 0
 #endif
 
 #if HAVE_DECL_STRNLEN == 0

--- a/src/compat.h
+++ b/src/compat.h
@@ -48,7 +48,7 @@
 #endif
 
 #ifndef WIN32
-typedef u_int SOCKET;
+typedef unsigned int SOCKET;
 #include "errno.h"
 #define WSAGetLastError()   errno
 #define WSAEINVAL           EINVAL

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -44,8 +44,13 @@
 // We add a random period time (0 to 1 seconds) to feeler connections to prevent synchronization.
 #define FEELER_SLEEP_WINDOW 1
 
-#if !defined(HAVE_MSG_NOSIGNAL) && !defined(MSG_NOSIGNAL)
+#if !defined(HAVE_MSG_NOSIGNAL)
 #define MSG_NOSIGNAL 0
+#endif
+
+// MSG_DONTWAIT is not available on some platforms, if it doesn't exist define it as 0
+#if !defined(HAVE_MSG_DONTWAIT)
+#define MSG_DONTWAIT 0
 #endif
 
 // Fix for ancient MinGW versions, that don't have defined these in ws2tcpip.h.

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -25,7 +25,7 @@
 #include <boost/algorithm/string/case_conv.hpp> // for to_lower()
 #include <boost/algorithm/string/predicate.hpp> // for startswith() and endswith()
 
-#if !defined(HAVE_MSG_NOSIGNAL) && !defined(MSG_NOSIGNAL)
+#if !defined(HAVE_MSG_NOSIGNAL)
 #define MSG_NOSIGNAL 0
 #endif
 


### PR DESCRIPTION
#### build: Probe MSG_DONTWAIT in the same way as MSG_NOSIGNAL

Instead of the WIN32-specific workaround, detect lack of `MSG_DONTWAIT` in the build system. This allows other platforms without `MSG_DONTWAIT` to work too.

#### build: cleanup: define MSG_DONTWAIT/MSG_NO_SIGNAL locall

Define MSG_DONTWAIT and MSG_NO_SIGNAL in the implementation files that use them (`net.cpp` and `netbase.cpp`), instead of compat.h which is included all over the place. 

This avoids putting them in the global namespace, as defining them as 0 is a hack that works for our specific usage, but it is not a general solution. 

Also makes sure they are defined only once so the `!defined(MSG_x)` guard can go.

#### compat: use `unsigned int` instead of `u_int`

`u_int` (without size specifier) is not available on some platforms (not sure what standard it's supposed to be part of), we don't use it anywhere else, and it doesn't hurt to simply write `unsigned int` out here.
