### PR TITLE
Rename argument name 'data' to prevent shadowing.

### DIFF
--- a/src/streams.h
+++ b/src/streams.h
@@ -404,8 +404,8 @@ public:
         return (*this);
     }
 
-    void GetAndClear(CSerializeData &data) {
-        data.insert(data.end(), begin(), end());
+    void GetAndClear(CSerializeData &targetData) {
+        targetData.insert(targetData.end(), begin(), end());
         clear();
     }
 


### PR DESCRIPTION
Fix gcc warning such as ```streams.h:407:44: warning: declaration of ‘data’ shadows a member of 'this'```.

The fixing file "streams.h" is included in so many sources and I saw the number of the warnings were 89.
