### PR TITLE
[trivial] Fix three typos introduced into walletdb.h in commit 7184e25

### DIFF
--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -172,11 +172,11 @@ public:
     DBErrors ZapSelectTx(std::vector<uint256>& vHashIn, std::vector<uint256>& vHashOut);
     /* Try to (very carefully!) recover wallet database (with a possible key type filter) */
     static bool Recover(const std::string& filename, void *callbackDataIn, bool (*recoverKVcallback)(void* callbackData, CDataStream ssKey, CDataStream ssValue));
-    /* Recover convenience-function to bypass the key filter callback, called when verify failes, recoveres everything */
+    /* Recover convenience-function to bypass the key filter callback, called when verify fails, recovers everything */
     static bool Recover(const std::string& filename);
     /* Recover filter (used as callback), will only let keys (cryptographical keys) as KV/key-type pass through */
     static bool RecoverKeysOnlyFilter(void *callbackData, CDataStream ssKey, CDataStream ssValue);
-    /* Function to determin if a certain KV/key-type is a key (cryptographical key) type */
+    /* Function to determine if a certain KV/key-type is a key (cryptographical key) type */
     static bool IsKeyType(const std::string& strType);
     /* verifies the database environment */
     static bool VerifyEnvironment(const std::string& walletFile, const boost::filesystem::path& dataDir, std::string& errorStr);


### PR DESCRIPTION
The typos were introduced in commit 7184e25c80aa8b1629a700bb7a7e290ad0bb2792, which was merged yesterday.

Changes summarized to facilitate reviewing:
* failes → fails
* recoveres → recovers
* determin → determine