### PR TITLE
Lock-Free CheckQueue

### DIFF
--- a/src/bench/checkqueue.cpp
+++ b/src/bench/checkqueue.cpp
@@ -35,7 +35,7 @@ static void CCheckQueueSpeed(benchmark::State& state)
        tg.create_thread([&]{queue.Thread();});
     }
     while (state.KeepRunning()) {
-        CCheckQueueControl<FakeJobNoWork> control(&queue);
+        CCheckQueueControl<FakeJobNoWork> control(&queue, MAX_SCRIPTCHECKS_PER_BLOCK);
 
         // We call Add a number of times to simulate the behavior of adding
         // a block of transactions at once.
@@ -84,7 +84,7 @@ static void CCheckQueueSpeedPrevectorJob(benchmark::State& state)
     while (state.KeepRunning()) {
         // Make insecure_rand here so that each iteration is identical.
         FastRandomContext insecure_rand(true);
-        CCheckQueueControl<PrevectorJob> control(&queue);
+        CCheckQueueControl<PrevectorJob> control(&queue, MAX_SCRIPTCHECKS_PER_BLOCK);
         std::vector<std::vector<PrevectorJob>> vBatches(BATCHES);
         for (auto& vChecks : vBatches) {
             vChecks.reserve(BATCH_SIZE);

--- a/src/checkqueue.h
+++ b/src/checkqueue.h
@@ -41,7 +41,6 @@ private:
 
     //! The queue of elements to be processed.
     //! As the order of booleans doesn't matter, it is used as a LIFO (stack)
-    std::vector<T> queue;
 
     //! The number of workers (including the master) that are idle.
     int nIdle;
@@ -69,8 +68,7 @@ private:
     bool Loop(bool fMaster = false)
     {
         boost::condition_variable& cond = fMaster ? condMaster : condWorker;
-        std::vector<T> vChecks;
-        vChecks.reserve(nBatchSize);
+        typename std::vector<T>::iterator checks_iterator;
         unsigned int nNow = 0;
         bool fOk = true;
         do {
@@ -88,7 +86,7 @@ private:
                     nTotal++;
                 }
                 // logically, the do loop starts here
-                while (queue.empty()) {
+                while (check_mem_top == check_mem_bottom) { // while (empty)
                     if ((fMaster || fQuit) && nTodo == 0) {
                         nTotal--;
                         bool fRet = fAllOk;
@@ -107,22 +105,19 @@ private:
                 //   all workers finish approximately simultaneously.
                 // * Try to account for idle jobs which will instantly start helping.
                 // * Don't do batches smaller than 1 (duh), or larger than nBatchSize.
-                nNow = std::max(1U, std::min(nBatchSize, (unsigned int)queue.size() / (nTotal + nIdle + 1)));
-                vChecks.resize(nNow);
-                for (unsigned int i = 0; i < nNow; i++) {
-                    // We want the lock on the mutex to be as short as possible, so swap jobs from the global
-                    // queue to the local batch vector instead of copying.
-                    vChecks[i].swap(queue.back());
-                    queue.pop_back();
-                }
+                nNow = std::max(1U, std::min(nBatchSize, (unsigned int)(check_mem_top - check_mem_bottom) / (nTotal + nIdle + 1)));
+                checks_iterator = check_mem_bottom;
+                std::advance(check_mem_bottom, nNow);
                 // Check whether we need to do work at all
                 fOk = fAllOk;
             }
             // execute work
-            BOOST_FOREACH (T& check, vChecks)
-                if (fOk)
-                    fOk = check();
-            vChecks.clear();
+            for (unsigned int i = 0; i < nNow && fOk; i++) {
+                fOk = (*checks_iterator)();
+                auto t = T();
+                checks_iterator->swap(t);
+                std::advance(checks_iterator, 1);
+            }
         } while (true);
     }
 
@@ -145,18 +140,25 @@ public:
         return Loop(true);
     }
 
-    //! Add a batch of checks to the queue
-    void Add(std::vector<T>& vChecks)
+    typename std::vector<T>::iterator check_mem;
+    typename std::vector<T>::iterator check_mem_top;
+    typename std::vector<T>::iterator check_mem_bottom;
+    void Setup(typename std::vector<T>::iterator check_mem_in) 
     {
         boost::unique_lock<boost::mutex> lock(mutex);
-        BOOST_FOREACH (T& check, vChecks) {
-            queue.push_back(T());
-            check.swap(queue.back());
-        }
-        nTodo += vChecks.size();
-        if (vChecks.size() == 1)
+        check_mem = check_mem_in;
+        check_mem_top = check_mem_in;
+        check_mem_bottom = check_mem_in;
+    }
+    //! Add a batch of checks to the queue
+    void Add(size_t size)
+    {
+        boost::unique_lock<boost::mutex> lock(mutex);
+        check_mem_top += size;
+        nTodo += size;
+        if (size == 1)
             condWorker.notify_one();
-        else if (vChecks.size() > 1)
+        else if (size > 1)
             condWorker.notify_all();
     }
 
@@ -174,18 +176,21 @@ template <typename T>
 class CCheckQueueControl
 {
 private:
-    CCheckQueue<T> * const pqueue;
+    std::vector<T> check_mem;
+    CCheckQueue<T>* pqueue;
     bool fDone;
 
 public:
     CCheckQueueControl() = delete;
     CCheckQueueControl(const CCheckQueueControl&) = delete;
     CCheckQueueControl& operator=(const CCheckQueueControl&) = delete;
-    explicit CCheckQueueControl(CCheckQueue<T> * const pqueueIn, const unsigned int size) : pqueue(pqueueIn), fDone(false)
+    explicit CCheckQueueControl(CCheckQueue<T> * const pqueueIn, const unsigned int size) : check_mem(), pqueue(pqueueIn), fDone(false)
     {
         // passed queue is supposed to be unused, or NULL
         if (pqueue != NULL) {
             ENTER_CRITICAL_SECTION(pqueue->ControlMutex);
+            check_mem.reserve(size);
+            pqueue->Setup(check_mem.begin());
         }
     }
 
@@ -200,8 +205,27 @@ public:
 
     void Add(std::vector<T>& vChecks)
     {
-        if (pqueue != NULL)
-            pqueue->Add(vChecks);
+        if (pqueue != NULL) {
+            auto s = vChecks.size();
+            for (T& x : vChecks) {
+                check_mem.emplace_back();
+                check_mem.back().swap(x);
+            }
+            pqueue->Add(s);
+        }
+    }
+    template<typename ... Args>
+    void Add(Args && ... args)
+    {
+        if (pqueue != NULL) {
+            check_mem.emplace_back(std::forward<Args>(args)...);
+        }
+    }
+    void Flush(size_t s)
+    {
+        if (pqueue != NULL) {
+            pqueue->Add(s);
+        }
     }
 
     ~CCheckQueueControl()

--- a/src/checkqueue.h
+++ b/src/checkqueue.h
@@ -181,7 +181,7 @@ public:
     CCheckQueueControl() = delete;
     CCheckQueueControl(const CCheckQueueControl&) = delete;
     CCheckQueueControl& operator=(const CCheckQueueControl&) = delete;
-    explicit CCheckQueueControl(CCheckQueue<T> * const pqueueIn) : pqueue(pqueueIn), fDone(false)
+    explicit CCheckQueueControl(CCheckQueue<T> * const pqueueIn, const unsigned int size) : pqueue(pqueueIn), fDone(false)
     {
         // passed queue is supposed to be unused, or NULL
         if (pqueue != NULL) {

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -464,7 +464,7 @@ BOOST_AUTO_TEST_CASE(test_big_witness_transaction) {
     PrecomputedTransactionData txdata(tx);
     boost::thread_group threadGroup;
     CCheckQueue<CScriptCheck> scriptcheckqueue(128);
-    CCheckQueueControl<CScriptCheck> control(&scriptcheckqueue);
+    CCheckQueueControl<CScriptCheck> control(&scriptcheckqueue, MAX_SCRIPTCHECKS_PER_BLOCK);
 
     for (int i=0; i<20; i++)
         threadGroup.create_thread(boost::bind(&CCheckQueue<CScriptCheck>::Thread, boost::ref(scriptcheckqueue)));

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -9,7 +9,6 @@
 #include "chainparams.h"
 #include "checkpoints.h"
 #include "checkqueue.h"
-#include "consensus/consensus.h"
 #include "consensus/merkle.h"
 #include "consensus/validation.h"
 #include "hash.h"
@@ -1834,7 +1833,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
 
     CBlockUndo blockundo;
 
-    CCheckQueueControl<CScriptCheck> control(fScriptChecks && nScriptCheckThreads ? &scriptcheckqueue : NULL);
+    CCheckQueueControl<CScriptCheck> control(fScriptChecks && nScriptCheckThreads ? &scriptcheckqueue : NULL, MAX_SCRIPTCHECKS_PER_BLOCK);
 
     std::vector<int> prevheights;
     CAmount nFees = 0;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1388,15 +1388,12 @@ bool CheckTxInputs(const CTransaction& tx, CValidationState& state, const CCoins
 }
 }// namespace Consensus
 
-bool CheckInputs(const CTransaction& tx, CValidationState &state, const CCoinsViewCache &inputs, bool fScriptChecks, unsigned int flags, bool cacheStore, PrecomputedTransactionData& txdata, std::vector<CScriptCheck> *pvChecks)
+bool CheckInputs(const CTransaction& tx, CValidationState &state, const CCoinsViewCache &inputs, bool fScriptChecks, unsigned int flags, bool cacheStore, PrecomputedTransactionData& txdata, CCheckQueueControl<CScriptCheck> *pCheckQueueControl)
 {
     if (!tx.IsCoinBase())
     {
         if (!Consensus::CheckTxInputs(tx, state, inputs, GetSpendHeight(inputs)))
             return false;
-
-        if (pvChecks)
-            pvChecks->reserve(tx.vin.size());
 
         // The first loop above does all the inexpensive checks.
         // Only if ALL inputs pass do we perform expensive ECDSA signature checks.
@@ -1414,32 +1411,36 @@ bool CheckInputs(const CTransaction& tx, CValidationState &state, const CCoinsVi
                 assert(coins);
 
                 // Verify signature
-                CScriptCheck check(*coins, tx, i, flags, cacheStore, &txdata);
-                if (pvChecks) {
-                    pvChecks->push_back(CScriptCheck());
-                    check.swap(pvChecks->back());
-                } else if (!check()) {
-                    if (flags & STANDARD_NOT_MANDATORY_VERIFY_FLAGS) {
-                        // Check whether the failure was caused by a
-                        // non-mandatory script verification check, such as
-                        // non-standard DER encodings or non-null dummy
-                        // arguments; if so, don't trigger DoS protection to
-                        // avoid splitting the network between upgraded and
-                        // non-upgraded nodes.
-                        CScriptCheck check2(*coins, tx, i,
-                                flags & ~STANDARD_NOT_MANDATORY_VERIFY_FLAGS, cacheStore, &txdata);
-                        if (check2())
-                            return state.Invalid(false, REJECT_NONSTANDARD, strprintf("non-mandatory-script-verify-flag (%s)", ScriptErrorString(check.GetScriptError())));
+                if (pCheckQueueControl) {
+                    pCheckQueueControl->Add(*coins, tx, i, flags, cacheStore, &txdata);
+                } else {
+                    CScriptCheck check(*coins, tx, i, flags, cacheStore, &txdata);
+                    if (!check()) {
+                        if (flags & STANDARD_NOT_MANDATORY_VERIFY_FLAGS) {
+                            // Check whether the failure was caused by a
+                            // non-mandatory script verification check, such as
+                            // non-standard DER encodings or non-null dummy
+                            // arguments; if so, don't trigger DoS protection to
+                            // avoid splitting the network between upgraded and
+                            // non-upgraded nodes.
+                            CScriptCheck check2(*coins, tx, i,
+                                    flags & ~STANDARD_NOT_MANDATORY_VERIFY_FLAGS, cacheStore, &txdata);
+                            if (check2())
+                                return state.Invalid(false, REJECT_NONSTANDARD, strprintf("non-mandatory-script-verify-flag (%s)", ScriptErrorString(check.GetScriptError())));
+                        }
+                        // Failures of other flags indicate a transaction that is
+                        // invalid in new blocks, e.g. a invalid P2SH. We DoS ban
+                        // such nodes as they are not following the protocol. That
+                        // said during an upgrade careful thought should be taken
+                        // as to the correct behavior - we may want to continue
+                        // peering with non-upgraded nodes even after soft-fork
+                        // super-majority signaling has occurred.
+                        return state.DoS(100,false, REJECT_INVALID, strprintf("mandatory-script-verify-flag-failed (%s)", ScriptErrorString(check.GetScriptError())));
                     }
-                    // Failures of other flags indicate a transaction that is
-                    // invalid in new blocks, e.g. a invalid P2SH. We DoS ban
-                    // such nodes as they are not following the protocol. That
-                    // said during an upgrade careful thought should be taken
-                    // as to the correct behavior - we may want to continue
-                    // peering with non-upgraded nodes even after soft-fork
-                    // super-majority signaling has occurred.
-                    return state.DoS(100,false, REJECT_INVALID, strprintf("mandatory-script-verify-flag-failed (%s)", ScriptErrorString(check.GetScriptError())));
                 }
+            }
+            if (pCheckQueueControl) {
+                pCheckQueueControl->Flush(tx.vin.size());
             }
         }
     }
@@ -1885,12 +1886,10 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
         {
             nFees += view.GetValueIn(tx)-tx.GetValueOut();
 
-            std::vector<CScriptCheck> vChecks;
             bool fCacheResults = fJustCheck; /* Don't cache results if we're actually connecting blocks (still consult the cache, though) */
-            if (!CheckInputs(tx, state, view, fScriptChecks, flags, fCacheResults, txdata[i], nScriptCheckThreads ? &vChecks : NULL))
+            if (!CheckInputs(tx, state, view, fScriptChecks, flags, fCacheResults, txdata[i], nScriptCheckThreads ? &control : NULL))
                 return error("ConnectBlock(): CheckInputs on %s failed with %s",
                     tx.GetHash().ToString(), FormatStateMessage(state));
-            control.Add(vChecks);
         }
 
         CTxUndo undoDummy;

--- a/src/validation.h
+++ b/src/validation.h
@@ -17,6 +17,7 @@
 #include "script/script_error.h"
 #include "sync.h"
 #include "versionbits.h"
+#include "consensus/consensus.h"
 
 #include <algorithm>
 #include <exception>
@@ -149,6 +150,16 @@ struct BlockHasher
 {
     size_t operator()(const uint256& hash) const { return hash.GetCheapHash(); }
 };
+
+
+/** The minimum serialized size of a CTxIn even with an empty scriptSig */
+static const unsigned int MIN_TXIN_SERIALIZED_SIZE = 41;
+/** The maximum number of scriptchecks which an input can generate */
+static const unsigned int MAX_SCRIPTCHECKS_PER_TXIN = 1;
+/** The maximum number of possible inputs included a block */
+static const unsigned int MAX_TXINS_PER_BLOCK = MAX_BLOCK_BASE_SIZE/MIN_TXIN_SERIALIZED_SIZE;
+/** The maximum number of scriptchecks which could be created */
+static const unsigned int MAX_SCRIPTCHECKS_PER_BLOCK = MAX_TXINS_PER_BLOCK * MAX_SCRIPTCHECKS_PER_TXIN;
 
 extern CScript COINBASE_FLAGS;
 extern CCriticalSection cs_main;

--- a/src/validation.h
+++ b/src/validation.h
@@ -45,6 +45,9 @@ class CValidationInterface;
 class CValidationState;
 struct ChainTxData;
 
+template <typename T>
+class CCheckQueueControl;
+
 struct PrecomputedTransactionData;
 struct LockPoints;
 
@@ -378,7 +381,7 @@ int64_t GetTransactionSigOpCost(const CTransaction& tx, const CCoinsViewCache& i
  * instead of being performed inline.
  */
 bool CheckInputs(const CTransaction& tx, CValidationState &state, const CCoinsViewCache &view, bool fScriptChecks,
-                 unsigned int flags, bool cacheStore, PrecomputedTransactionData& txdata, std::vector<CScriptCheck> *pvChecks = NULL);
+                 unsigned int flags, bool cacheStore, PrecomputedTransactionData& txdata, CCheckQueueControl<CScriptCheck> *pCheckQueueControl = NULL);
 
 /** Apply the effects of this transaction on the UTXO set represented by view */
 void UpdateCoins(const CTransaction& tx, CCoinsViewCache& inputs, int nHeight);


### PR DESCRIPTION
TL;DR: This PR introduces a new hopefully easy-to-review Lock-Free CheckQueue algorithm. It's really fast!

## Summary & Problem Statement

In Bitcoin-Qt 0.8, parallel script validation was introduced to improve the speed at which a block could be validated. The basic way in which this worked is that the master thread creates a task for every script of each input in a transaction being checked, and enqueues it to a work queue. After adding all tasks, the master also becomes a worker. Each worker thread claims a number of tasks from the queue (based on how many tasks are available and how many workers are available) and then runs each task, reporting if any errors were encountered. The core approach has not changed significantly since 0.8. The current approach is deficient for four main reasons which these changes address over 2 major commits (and 1 minor one introducing API change only, and 2 others covered in previous PRs).

## Deficiencies in Current CheckQueue & Solutions

### 1. Memory Instability: 
Each task must be moved to three different memory locations during its lifetime:
1) the place where the master creates the task.
2) the shared work queue.
3) the worker-local work queue.
This also makes it difficult to write multithreaded code, because memory is modified more than once during validation.
#### Solution:
The new algorithm uses stable memory: during block validation, enough memory for the worst case number of checks is allocated, and then tasks are directly placed and read out of that memory. Instead, each worker thread claims a pointer to the task. See 89a1f93
### 2. Lock-Heavy algorithm: 
In the original algorithm, each worker thread and the master contend for a single lock for enqueuing and dequeuing tasks. This is highly inefficient, each worker spends significant amount of time acquiring the lock to be able to dequeue a task, and the master spends time waiting to enqueue tasks. 
#### Solution:
The new algorithm is Lock-Free; during block validation no locks are taken for enqueuing or dequeuing tasks, only atomic memory is read or written. The use of a different piece of atomic memory for enqueuing and most dequeuing operations means that the master and worker threads infrequently interact during validation, meaning low contention. See 6e24aa8
### 3. Sleeping during validation:
In the original algorithm, while waiting for a task to be enqueued by the master, each thread sleeps. This means that the OS’s scheduler might choose to pre-empt the thread, thrashing it’s cache with another process’s memory. Furthermore, the latency for a wake up operation is high, as it requires the operating system to awaken a thread.
#### Solution:
the new algorithm only sleeps before and after block validation, and busy-spins waiting for tasks until the master joins and there are no more tasks available (then sleeps). See 6e24aa8
### 4. Arbitrary batch size selection: 
The original batch size algorithm was selected as an experimental tuning for reasonable performance. If the batch size is too small, workers spend too much time getting a new task and not enough time running the tasks. The problem with any form of batching is that you may run into an imbalanced case where one worker has a batch (say of size five) and another worker has no tasks. In order to improve that, a batch size of one is optimal.
#### Solution:
The new algorithm uses a batch size of one, so that all threads finish their work at as close to the same time as possible. See 6e24aa8.

## Reviewing this PR

### Code Organization
In writing this PR, I used many small-step iterations to get to the final design. While I am fairly confident that the commits in this PR should be easily reviewable, I have left the unsquashed version available here for anyone to reference
https://github.com/JeremyRubin/bitcoin/tree/PR-lockfree-checkqueue-unsquashed

### Testing

#9497 introduces a fairly comprehensive set of tests, which these changes pass, as well as the earlier CheckQueue. See #9497 for details on the conditions tested.

### Performance
 Test results are from a 2011 MacBook Pro 13", 2.7 GHz Intel Core i7, 8 GB 1333 MHz DDR3.
#### MicroBenchmark Performance (2.9 to 5.7X faster)
#9498 introduced two new microbenchmarks for the CheckQueue. One which tests tasks which are empty, and another which tests tasks that do a little bit of work. These are microbenchmarks, so they need to be taken with a grain of salt.

```
#Before (7ff4a538a8682cdf02a4bcd6f15499c841001b73)
#Benchmark,count,min,max,average,min_cycles,max_cycles,average_cycles
CCheckQueueSpeed,896,0.001128047704697,0.001315370202065,0.001167648338846,3038807,3543440,3145483
CCheckQueueSpeedPrevectorJob,320,0.002763845026493,0.003494121134281,0.003255434334278,7445473,9415834,8770003

#After (6e24aa818be4b494fc1809a7ca3ee568e253deb6)
#Benchmark,count,min,max,average,min_cycles,max_cycles,average_cycles
CCheckQueueSpeed,5120,0.000198634807020,0.000226773321629,0.000202708039433,535092,610897,546067
CCheckQueueSpeedPrevectorJob,896,0.000990316271782,0.001982234418392,0.001142452071820,2667680,5339862,3077721
```

So we see for trivial jobs, it's about 5.7X faster, and for more involved jobs, about 2.9X faster. 

#### Test Performance (10X faster)
I have observed very nice performance improvements when it comes to how long it takes to run the checkqueue_tests.

```
#before (08e4e1ea89427a2594415d0b37011692a5109c39)
$ time ./test_bitcoin -t checkqueue_tests
./test/test_bitcoin -t checkqueue_tests  12.39s user 58.12s system 116% cpu 1:00.31 total
#after (6e24aa818be4b494fc1809a7ca3ee568e253deb6)
$ time ./test_bitcoin -t checkqueue_tests
./test/test_bitcoin -t checkqueue_tests  3.43s user 1.40s system 78% cpu 6.180 total
```
So we see about a 10x performance improvement here.

#### Cross Platform
It would be good to have reviewers comment with cross platform performance testing, as some of the lock free instructions may be slower on some platforms than others, and I don't have access to a large enough swath of machines. If you're reviewing performance, you may find the benchdiff.py tool I wrote useful https://github.com/JeremyRubin/bitcoin/commit/14aa19a35cbf0cff742f36a2c9ca00af162918ee.

#### Real World/Simulated Numbers

I don't have great real-world-node numbers yet for these changes, but I'll wait for others (e.g., @morcos) to report back on those.

_edit: I have run a simulation on a month of block validation on a 4-core machine and seen no difference in aggregate performance. I'll poke around to see if the design can be tweaked a little bit for some advantage with fewer cores, but the more important simulations are for machines with >7 cores or multiple cpus, where the contention relieved by this PR becomes more significant._

### Notes

This builds on #9497 (and #9495). There were a couple minor nits on those PR's outstanding, but I figure they can be addressed here later with a squashme (rather than having to squash those, get them re-reviewed, and then issue this PR). An earlier (and worse) attempt at a similar design can be seen here for comparison https://github.com/bitcoin/bitcoin/pull/8464.


## Acknowledgements

Thanks to @morcos and @sdaftuar for supporting and helping in the development of this work, and to various others (@TheBlueMatt, @theuni, and others) for review in feedback at various stages of this project.