### PR TITLE
Make script.py wildcard importable.

### DIFF
--- a/test/functional/p2p-fullblocktest.py
+++ b/test/functional/p2p-fullblocktest.py
@@ -18,6 +18,7 @@ from test_framework.blocktools import *
 import time
 from test_framework.key import CECKey
 from test_framework.script import *
+from test_framework.script import hash160
 import struct
 
 class PreviousSpendableOutput(object):

--- a/test/functional/p2p-segwit.py
+++ b/test/functional/p2p-segwit.py
@@ -8,6 +8,7 @@ from test_framework.mininode import *
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
 from test_framework.script import *
+from test_framework.script import hash160, CScriptOp
 from test_framework.blocktools import create_block, create_coinbase, add_witness_commitment, get_witness_script, WITNESS_COMMITMENT_HEADER
 from test_framework.key import CECKey, CPubKey
 import time

--- a/test/functional/segwit.py
+++ b/test/functional/segwit.py
@@ -8,7 +8,8 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
 from test_framework.mininode import sha256, CTransaction, CTxIn, COutPoint, CTxOut, COIN, ToHex, FromHex
 from test_framework.address import script_to_p2sh, key_to_p2pkh
-from test_framework.script import CScript, OP_HASH160, OP_CHECKSIG, OP_0, hash160, OP_EQUAL, OP_DUP, OP_EQUALVERIFY, OP_1, OP_2, OP_CHECKMULTISIG, OP_TRUE
+from test_framework.script import *
+from test_framework.script import hash160
 from io import BytesIO
 
 NODE_0 = 0

--- a/test/functional/test_framework/address.py
+++ b/test/functional/test_framework/address.py
@@ -4,7 +4,8 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Encode and decode BASE58, P2PKH and P2SH addresses."""
 
-from .script import hash256, hash160, sha256, CScript, OP_0
+from .script import hash160, CScript, OP_0
+from .mininode import hash256, sha256
 from .util import bytes_to_hex_str, hex_str_to_bytes
 
 chars = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'

--- a/test/functional/test_framework/script.py
+++ b/test/functional/test_framework/script.py
@@ -5,13 +5,52 @@
 """Functionality to build scripts, as well as SignatureHash().
 
 This file is modified from python-bitcoinlib.
-"""
 
-from .mininode import CTransaction, CTxOut, sha256, hash256, uint256_from_str, ser_uint256, ser_string
+It is safe to import * from this module. New functions and classes which you 
+wish to be exportable through wildcard imports shoule be added to the __all__
+module variable."""
+
 from binascii import hexlify
 import hashlib
-
+import struct
 import sys
+
+from .bignum import bn2vch
+from .mininode import CTransaction, CTxOut, sha256, hash256, uint256_from_str, ser_uint256, ser_string
+
+__all__ = [
+    # Constants
+    "MAX_SCRIPT_SIZE", "MAX_SCRIPT_ELEMENT_SIZE", "MAX_SCRIPT_OPCODES",
+    "SIGHASH_ALL", "SIGHASH_NONE", "SIGHASH_SINGLE", "SIGHASH_ANYONECANPAY",
+
+    # Script classes and signature functions
+    "CScript", "CScriptNum", "SignatureHash", "SegwitVersion1SignatureHash",
+
+    # OP codes
+    "OP_0", "OP_FALSE", "OP_PUSHDATA1", "OP_PUSHDATA2", "OP_PUSHDATA4",
+    "OP_1NEGATE", "OP_RESERVED", "OP_1", "OP_TRUE", "OP_2", "OP_3", "OP_4",
+    "OP_5", "OP_6", "OP_7", "OP_8", "OP_9", "OP_10", "OP_11", "OP_12", "OP_13",
+    "OP_14", "OP_15", "OP_16", "OP_NOP", "OP_VER", "OP_IF", "OP_NOTIF",
+    "OP_VERIF", "OP_VERNOTIF", "OP_ELSE", "OP_ENDIF", "OP_VERIFY", "OP_RETURN",
+    "OP_TOALTSTACK", "OP_FROMALTSTACK", "OP_2DROP", "OP_2DUP", "OP_3DUP",
+    "OP_2OVER", "OP_2ROT", "OP_2SWAP", "OP_IFDUP", "OP_DEPTH", "OP_DROP",
+    "OP_DUP", "OP_NIP", "OP_OVER", "OP_PICK", "OP_ROLL", "OP_ROT", "OP_SWAP",
+    "OP_TUCK", "OP_CAT", "OP_SUBSTR", "OP_LEFT", "OP_RIGHT", "OP_SIZE",
+    "OP_INVERT", "OP_AND", "OP_OR", "OP_XOR", "OP_EQUAL", "OP_EQUALVERIFY",
+    "OP_RESERVED1", "OP_RESERVED2", "OP_1ADD", "OP_1SUB", "OP_2MUL", "OP_2DIV",
+    "OP_NEGATE", "OP_ABS", "OP_NOT", "OP_0NOTEQUAL", "OP_ADD", "OP_SUB",
+    "OP_MUL", "OP_DIV", "OP_MOD", "OP_LSHIFT", "OP_RSHIFT", "OP_BOOLAND",
+    "OP_BOOLOR", "OP_NUMEQUAL", "OP_NUMEQUALVERIFY", "OP_NUMNOTEQUAL",
+    "OP_LESSTHAN", "OP_GREATERTHAN", "OP_LESSTHANOREQUAL",
+    "OP_GREATERTHANOREQUAL", "OP_MIN", "OP_MAX", "OP_WITHIN", "OP_RIPEMD160",
+    "OP_SHA1", "OP_SHA256", "OP_HASH160", "OP_HASH256", "OP_CODESEPARATOR",
+    "OP_CHECKSIG", "OP_CHECKSIGVERIFY", "OP_CHECKMULTISIG",
+    "OP_CHECKMULTISIGVERIFY", "OP_NOP1", "OP_CHECKLOCKTIMEVERIFY",
+    "OP_CHECKSEQUENCEVERIFY", "OP_NOP4", "OP_NOP5", "OP_NOP6", "OP_NOP7",
+    "OP_NOP8", "OP_NOP9", "OP_NOP10", "OP_SMALLINTEGER", "OP_PUBKEYS",
+    "OP_PUBKEYHASH", "OP_PUBKEY", "OP_INVALIDOPCODE"
+]
+
 bchr = chr
 bord = ord
 if sys.version > '3':
@@ -19,13 +58,14 @@ if sys.version > '3':
     bchr = lambda x: bytes([x])
     bord = lambda x: x
 
-import struct
-
-from .bignum import bn2vch
-
 MAX_SCRIPT_SIZE = 10000
 MAX_SCRIPT_ELEMENT_SIZE = 520
 MAX_SCRIPT_OPCODES = 201
+
+SIGHASH_ALL = 1
+SIGHASH_NONE = 2
+SIGHASH_SINGLE = 3
+SIGHASH_ANYONECANPAY = 0x80
 
 OPCODE_NAMES = {}
 
@@ -820,10 +860,6 @@ class CScript(bytes):
         return n
 
 
-SIGHASH_ALL = 1
-SIGHASH_NONE = 2
-SIGHASH_SINGLE = 3
-SIGHASH_ANYONECANPAY = 0x80
 
 def FindAndDelete(script, sig):
     """Consensus critical, see FindAndDelete() in Satoshi codebase"""


### PR DESCRIPTION
This PR is part of a larger effort to make the test_framework API more intuitive. See https://github.com/bitcoin/bitcoin/pull/9876 for background.

Several testcases use a wildcard import from test_framework.script. That's not ideal as it pollutes the namespace with all of the names defined in test_framework.script, including anything that script.py has imported itself.

This PR adds an `__all__` module variable to script.py which indexes all of the names that should commonly be required by individual test cases. That makes the wildcard import a well-defined API and test cases can wildcard import without worrying about importing unexpected names. If a test case needs to import something from script.py which isn't included in `__all__`, it can explicitly import it.

I've not included `hash160()` or `CScriptOp()` in `__all__` because `hash160()` is a helper function which I think should be defined elsewhere (ideally in the same module as `sha256()`, `ripemd160()` and `hash256()`), and `CScriptOp` should not commonly be required by testcases (the only place it's currently used is in `GetP2PKHScript()` in p2p-segwit.py, which arguably should be pulled up into the script.py module).