### PR TITLE
Fix build errors if spaces in path or parent directory

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -167,8 +167,8 @@ BITCOIN_CORE_H = \
 
 obj/build.h: FORCE
 	@$(MKDIR_P) $(builddir)/obj
-	@$(top_srcdir)/share/genbuild.sh $(abs_top_builddir)/src/obj/build.h \
-	  $(abs_top_srcdir)
+	@$(top_srcdir)/share/genbuild.sh "$(abs_top_builddir)/src/obj/build.h" \
+	  "$(abs_top_srcdir)"
 libbitcoin_util_a-clientversion.$(OBJEXT): obj/build.h
 
 # server: shared between bitcoind and bitcoin-qt

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -87,7 +87,7 @@ BASE_SCRIPTS= [
 ZMQ_SCRIPTS = [
     # ZMQ test can only be run if bitcoin was built with zmq-enabled.
     # call test_runner.py with -nozmq to explicitly exclude these tests.
-    "zmq_test.py"]
+    'zmq_test.py']
 
 EXTENDED_SCRIPTS = [
     # These tests are not run by the travis build process.
@@ -203,9 +203,9 @@ def main():
         sys.exit(0)
 
     if args.help:
-        # Print help for test_runner.py, then print help of the first script and exit.
+        # Print help for test_runner.py, then print help of the first script (with args removed) and exit.
         parser.print_help()
-        subprocess.check_call((config["environment"]["SRCDIR"] + '/test/functional/' + test_list[0]).split() + ['-h'])
+        subprocess.check_call([(config["environment"]["SRCDIR"] + '/test/functional/' + test_list[0].split()[0])] + ['-h'])
         sys.exit(0)
 
     run_tests(test_list, config["environment"]["SRCDIR"], config["environment"]["BUILDDIR"], config["environment"]["EXEEXT"], args.jobs, args.coverage, passon_args)
@@ -296,9 +296,10 @@ class TestHandler:
             port_seed = ["--portseed={}".format(len(self.test_list) + self.portseed_offset)]
             log_stdout = tempfile.SpooledTemporaryFile(max_size=2**16)
             log_stderr = tempfile.SpooledTemporaryFile(max_size=2**16)
+            test_argv = t.split()
             self.jobs.append((t,
                               time.time(),
-                              subprocess.Popen((self.tests_dir + t).split() + self.flags + port_seed,
+                              subprocess.Popen([self.tests_dir + test_argv[0]] + test_argv[1:] + self.flags + port_seed,
                                                universal_newlines=True,
                                                stdout=log_stdout,
                                                stderr=log_stderr),


### PR DESCRIPTION
See Issue https://github.com/bitcoin/bitcoin/issues/9933

Some work started in PR https://github.com/bitcoin/bitcoin/pull/5872, but I can't understand what's going on in there...

It fixed the problem I was having (compiling in OSX 10.10.5) if there were spaces anywhere in the absolute path of the source code. Successfully compiled and passed all rpc-tests in paths with and without spaces. 

[GNU Make with spaces in filenames seems to be a general issue.](https://stackoverflow.com/questions/9838384/can-gnu-make-handle-filenames-with-spaces)

I will continue to bang on this and see if I break anything else.