### PR TITLE
Add true/false return value to prioritisetransaction

### DIFF
--- a/qa/rpc-tests/prioritise_transaction.py
+++ b/qa/rpc-tests/prioritise_transaction.py
@@ -49,9 +49,13 @@ class PrioritiseTransactionTest(BitcoinTestFramework):
                 sizes[i] += mempool[j]['size']
             assert(sizes[i] > MAX_BLOCK_BASE_SIZE) # Fail => raise utxo_count
 
+
+        # prioritise a non existing txid
+        assert(self.nodes[0].prioritisetransaction("2638cacce340e31fecdbec0d3bc1b432165ad42cfb44f985072414cbe2f71461", 10000) == False)
+
         # add a fee delta to something in the cheapest bucket and make sure it gets mined
         # also check that a different entry in the cheapest bucket is NOT mined
-        self.nodes[0].prioritisetransaction(txids[0][0], int(3*base_fee*COIN))
+        assert(self.nodes[0].prioritisetransaction(txids[0][0], int(3*base_fee*COIN)) == True)
 
         self.nodes[0].generate(1)
 

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -268,7 +268,7 @@ UniValue prioritisetransaction(const JSONRPCRequest& request)
             "                  The fee is not actually paid, only the algorithm for selecting transactions into a block\n"
             "                  considers the transaction as it would have paid a higher (or lower) fee.\n"
             "\nResult:\n"
-            "true              (boolean) Returns true\n"
+            "true              (boolean) Returns true if prioritization was possible, otherwise false\n"
             "\nExamples:\n"
             + HelpExampleCli("prioritisetransaction", "\"txid\" 10000")
             + HelpExampleRpc("prioritisetransaction", "\"txid\", 10000")
@@ -279,7 +279,7 @@ UniValue prioritisetransaction(const JSONRPCRequest& request)
     uint256 hash = ParseHashStr(request.params[0].get_str(), "txid");
     CAmount nAmount = request.params[1].get_int64();
 
-    mempool.PrioritiseTransaction(hash, nAmount);
+    return mempool.PrioritiseTransaction(hash, nAmount);
     return true;
 }
 

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -895,7 +895,7 @@ CTxMemPool::ReadFeeEstimates(CAutoFile& filein)
     return true;
 }
 
-void CTxMemPool::PrioritiseTransaction(const uint256& hash, const CAmount& nFeeDelta)
+bool CTxMemPool::PrioritiseTransaction(const uint256& hash, const CAmount& nFeeDelta)
 {
     {
         LOCK(cs);
@@ -913,8 +913,12 @@ void CTxMemPool::PrioritiseTransaction(const uint256& hash, const CAmount& nFeeD
                 mapTx.modify(ancestorIt, update_descendant_state(0, nFeeDelta, 0));
             }
         }
+        else {
+            return false;
+        }
     }
     LogPrintf("PrioritiseTransaction: %s feerate += %s\n", hash.ToString(), FormatMoney(nFeeDelta));
+    return true;
 }
 
 void CTxMemPool::ApplyDelta(const uint256 hash, CAmount &nFeeDelta) const

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -534,7 +534,7 @@ public:
     bool HasNoInputsOf(const CTransaction& tx) const;
 
     /** Affect CreateNewBlock prioritisation of transactions */
-    void PrioritiseTransaction(const uint256& hash, const CAmount& nFeeDelta);
+    bool PrioritiseTransaction(const uint256& hash, const CAmount& nFeeDelta);
     void ApplyDelta(const uint256 hash, CAmount &nFeeDelta) const;
     void ClearPrioritisation(const uint256 hash);
 


### PR DESCRIPTION
`prioritisetransaction` currently always return true, even if the transactions is not in the mempool.
This PR fixes that by returning false in case of a failed prioritization.