### PR TITLE
[bench] Avoid function call arguments which are pointers to uninitialized values

### DIFF
--- a/src/bench/checkblock.cpp
+++ b/src/bench/checkblock.cpp
@@ -22,7 +22,7 @@ static void DeserializeBlockTest(benchmark::State& state)
     CDataStream stream((const char*)block_bench::block413567,
             (const char*)&block_bench::block413567[sizeof(block_bench::block413567)],
             SER_NETWORK, PROTOCOL_VERSION);
-    char a;
+    char a = '\0';
     stream.write(&a, 1); // Prevent compaction
 
     while (state.KeepRunning()) {
@@ -37,7 +37,7 @@ static void DeserializeAndCheckBlockTest(benchmark::State& state)
     CDataStream stream((const char*)block_bench::block413567,
             (const char*)&block_bench::block413567[sizeof(block_bench::block413567)],
             SER_NETWORK, PROTOCOL_VERSION);
-    char a;
+    char a = '\0';
     stream.write(&a, 1); // Prevent compaction
 
     Consensus::Params params = Params(CBaseChainParams::MAIN).GetConsensus();


### PR DESCRIPTION
Prior to this commit:

```
bench/checkblock.cpp:41:5: warning: Function call argument is a pointer to uninitialized value [clang-analyzer-core.CallAndMessage]
    stream.write(&a, 1); // Prevent compaction
```