### PR TITLE
Fix shutdown hang with >= 8 -addnodes set

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2322,6 +2322,10 @@ void CConnman::Interrupt()
     if (semOutbound)
         for (int i=0; i<(nMaxOutbound + nMaxFeeler); i++)
             semOutbound->post();
+
+    if (semAddnode)
+        for (int i=0; i<nMaxAddnode; i++)
+            semAddnode->post();
 }
 
 void CConnman::Stop()
@@ -2336,10 +2340,6 @@ void CConnman::Stop()
         threadDNSAddressSeed.join();
     if (threadSocketHandler.joinable())
         threadSocketHandler.join();
-
-    if (semAddnode)
-        for (int i=0; i<nMaxAddnode; i++)
-            semOutbound->post();
 
     if (fAddressesInitialized)
     {

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2319,13 +2319,17 @@ void CConnman::Interrupt()
     interruptNet();
     InterruptSocks5(true);
 
-    if (semOutbound)
-        for (int i=0; i<(nMaxOutbound + nMaxFeeler); i++)
+    if (semOutbound) {
+        for (int i=0; i<(nMaxOutbound + nMaxFeeler); i++) {
             semOutbound->post();
+        }
+    }
 
-    if (semAddnode)
-        for (int i=0; i<nMaxAddnode; i++)
+    if (semAddnode) {
+        for (int i=0; i<nMaxAddnode; i++) {
             semAddnode->post();
+        }
+    }
 }
 
 void CConnman::Stop()


### PR DESCRIPTION
We previously would block waiting for a CSemaphoreGrant, when we
did not need to.