### PR TITLE
RPC:Refactor: Remove unreachable code refs #9573

### DIFF
--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -494,8 +494,6 @@ UniValue CRPCTable::execute(const JSONRPCRequest &request) const
     {
         throw JSONRPCError(RPC_MISC_ERROR, e.what());
     }
-
-    g_rpcSignals.PostCommand(*pcmd);
 }
 
 std::vector<std::string> CRPCTable::listCommands() const


### PR DESCRIPTION
Removed a line that is unreachable. Detected by the Clang static analyzer report kallewoof submitted in issue 9573