### PR TITLE
[trivial] Fix typo in rpc/protocol.h

### DIFF
--- a/src/rpc/protocol.h
+++ b/src/rpc/protocol.h
@@ -39,7 +39,7 @@ enum RPCErrorCode
     RPC_METHOD_NOT_FOUND = -32601,
     RPC_INVALID_PARAMS   = -32602,
     // RPC_INTERNAL_ERROR should only be used for genuine errors in bitcoind
-    // (for exampled datadir corruption).
+    // (for example datadir corruption).
     RPC_INTERNAL_ERROR   = -32603,
     RPC_PARSE_ERROR      = -32700,
 


### PR DESCRIPTION
The typo was introduced in commit 338bf065a454fee76d9dfa9c7a36161cac72309f, which was merged yesterday.

Changes summarized to facilitate reviewing:
* exampled → example