### PR TITLE
util: Properly handle errors during log message formatting

### DIFF
--- a/src/tinyformat.h
+++ b/src/tinyformat.h
@@ -123,7 +123,7 @@ namespace tinyformat {}
 namespace tfm = tinyformat;
 
 // Error handling; calls assert() by default.
-#define TINYFORMAT_ERROR(reasonString) throw std::runtime_error(reasonString)
+#define TINYFORMAT_ERROR(reasonString) throw tinyformat::format_error(reasonString)
 
 // Define for C++11 variadic templates which make the code shorter & more
 // general.  If you don't define this, C++11 support is autodetected below.
@@ -163,6 +163,13 @@ namespace tfm = tinyformat;
 #endif
 
 namespace tinyformat {
+
+class format_error: public std::runtime_error
+{
+public:
+    format_error(const std::string &what): std::runtime_error(what) {
+    }
+};
 
 //------------------------------------------------------------------------------
 namespace detail {

--- a/src/util.h
+++ b/src/util.h
@@ -73,14 +73,24 @@ bool LogAcceptCategory(const char* category);
 /** Send a string to the log output */
 int LogPrintStr(const std::string &str);
 
-#define LogPrint(category, ...) do { \
-    if (LogAcceptCategory((category))) { \
-        LogPrintStr(tfm::format(__VA_ARGS__)); \
-    } \
-} while(0)
+/** Get format string from VA_ARGS for error reporting */
+template<typename... Args> std::string FormatStringFromLogArgs(const char *fmt, const Args&... args) { return fmt; }
 
 #define LogPrintf(...) do { \
-    LogPrintStr(tfm::format(__VA_ARGS__)); \
+    std::string _log_msg_; /* Unlikely name to avoid shadowing variables */ \
+    try { \
+        _log_msg_ = tfm::format(__VA_ARGS__); \
+    } catch (std::runtime_error &e) { \
+        /* Original format string will have newline so don't add one here */ \
+        _log_msg_ = "Error \"" + std::string(e.what()) + "\" while formatting log message: " + FormatStringFromLogArgs(__VA_ARGS__); \
+    } \
+    LogPrintStr(_log_msg_); \
+} while(0)
+
+#define LogPrint(category, ...) do { \
+    if (LogAcceptCategory((category))) { \
+        LogPrintf(__VA_ARGS__); \
+    } \
 } while(0)
 
 template<typename... Args>

--- a/src/util.h
+++ b/src/util.h
@@ -80,7 +80,7 @@ template<typename... Args> std::string FormatStringFromLogArgs(const char *fmt, 
     std::string _log_msg_; /* Unlikely name to avoid shadowing variables */ \
     try { \
         _log_msg_ = tfm::format(__VA_ARGS__); \
-    } catch (std::runtime_error &e) { \
+    } catch (tinyformat::format_error &e) { \
         /* Original format string will have newline so don't add one here */ \
         _log_msg_ = "Error \"" + std::string(e.what()) + "\" while formatting log message: " + FormatStringFromLogArgs(__VA_ARGS__); \
     } \


### PR DESCRIPTION
Instead of having an exception propagate into the program (which at worst causes a crash) when an error happens while formatting a log message, just print a message to the log. This message clearly indicates what log message was formatted wrongly, and what error happened during formatting it.

Addresses #9423.

#### Before
```
2017-03-09 10:58:20 

************************
EXCEPTION: St13runtime_error       
tinyformat: Too many conversion specifiers in format string       
bitcoin in AppInit()       



************************
EXCEPTION: St13runtime_error       
tinyformat: Too many conversion specifiers in format string       
bitcoin in AppInit()       

2017-03-09 10:58:20 Shutdown: In progress...
2017-03-09 10:58:20 scheduler thread interrupt
2017-03-09 10:58:20 Shutdown: done
```
(and process exits)

#### After
```
2017-03-09 10:51:50 Error "tinyformat: Too many conversion specifiers in format string" while formatting log message: Erasing %s %s
```
(and process continues)