### PR TITLE
Allow to use unsolveable P2PKH watch-only in fundrawtransaction

### DIFF
--- a/qa/rpc-tests/fundrawtransaction.py
+++ b/qa/rpc-tests/fundrawtransaction.py
@@ -56,10 +56,13 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.sync_all()
 
         watchonly_address = self.nodes[0].getnewaddress()
+        watchonly_address2= self.nodes[0].getnewaddress()
         watchonly_pubkey = self.nodes[0].validateaddress(watchonly_address)["pubkey"]
         watchonly_amount = Decimal(200)
         self.nodes[3].importpubkey(watchonly_pubkey, "", True)
+        self.nodes[3].importaddress(watchonly_address2)
         watchonly_txid = self.nodes[0].sendtoaddress(watchonly_address, watchonly_amount)
+        watchonly_txid2 = self.nodes[0].sendtoaddress(watchonly_address2, Decimal(2))
         self.nodes[0].sendtoaddress(self.nodes[3].getnewaddress(), watchonly_amount / 10)
 
         self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 1.5)
@@ -591,6 +594,16 @@ class RawTransactionsTest(BitcoinTestFramework):
 
         assert("fee" in result.keys())
         assert_greater_than(result["changepos"], -1)
+
+        ##################################################################
+        # test a fundrawtransaction using only watchonly (P2PKH address) #
+        ##################################################################
+
+        inputs = []
+        outputs = {self.nodes[2].getnewaddress() : watchonly_amount + Decimal(1)}
+        rawtx = self.nodes[3].createrawtransaction(inputs, outputs)
+        result = self.nodes[3].fundrawtransaction(rawtx, {'includeWatching': True })
+        assert("fee" in result.keys())
 
         ###############################################################
         # test fundrawtransaction using the entirety of watched funds #

--- a/qa/rpc-tests/segwit.py
+++ b/qa/rpc-tests/segwit.py
@@ -367,14 +367,12 @@ class SegWitTest(BitcoinTestFramework):
 
         op1 = CScript([OP_1])
         op0 = CScript([OP_0])
-        # 2N7MGY19ti4KDMSzRfPAssP6Pxyuxoi6jLe is the P2SH(P2PKH) version of mjoE3sSrb8ByYEvgnC3Aox86u1CHnfJA4V
-        unsolvable_address = ["mjoE3sSrb8ByYEvgnC3Aox86u1CHnfJA4V", "2N7MGY19ti4KDMSzRfPAssP6Pxyuxoi6jLe", script_to_p2sh(op1), script_to_p2sh(op0)]
+        unsolvable_address = [script_to_p2sh(op1), script_to_p2sh(op0)]
         unsolvable_address_key = hex_str_to_bytes("02341AEC7587A51CDE5279E0630A531AEA2615A9F80B17E8D9376327BAEAA59E3D")
         unsolvablep2pkh = CScript([OP_DUP, OP_HASH160, hash160(unsolvable_address_key), OP_EQUALVERIFY, OP_CHECKSIG])
         unsolvablep2wshp2pkh = CScript([OP_0, sha256(unsolvablep2pkh)])
         p2shop0 = CScript([OP_HASH160, hash160(op0), OP_EQUAL])
         p2wshop1 = CScript([OP_0, sha256(op1)])
-        unsolvable_after_importaddress.append(unsolvablep2pkh)
         unsolvable_after_importaddress.append(unsolvablep2wshp2pkh)
         unsolvable_after_importaddress.append(op1) # OP_1 will be imported as script
         unsolvable_after_importaddress.append(p2wshop1)

--- a/src/script/ismine.cpp
+++ b/src/script/ismine.cpp
@@ -147,6 +147,9 @@ isminetype IsMine(const CKeyStore &keystore, const CScript& scriptPubKey, bool& 
 
     if (keystore.HaveWatchOnly(scriptPubKey)) {
         // TODO: This could be optimized some by doing some work after the above solver
+        if (whichType == TX_PUBKEYHASH) {
+            return ISMINE_WATCH_SOLVABLE;
+        }
         SignatureData sigs;
         return ProduceSignature(DummySignatureCreator(&keystore), scriptPubKey, sigs) ? ISMINE_WATCH_SOLVABLE : ISMINE_WATCH_UNSOLVABLE;
     }

--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -184,7 +184,7 @@ bool ProduceSignature(const BaseSignatureCreator& creator, const CScript& fromPu
     sigdata.scriptSig = PushAll(result);
 
     // Test solution
-    return solved && VerifyScript(sigdata.scriptSig, fromPubKey, &sigdata.scriptWitness, STANDARD_SCRIPT_VERIFY_FLAGS, creator.Checker());
+    return solved && (!creator.ShouldVerifySig() || VerifyScript(sigdata.scriptSig, fromPubKey, &sigdata.scriptWitness, STANDARD_SCRIPT_VERIFY_FLAGS, creator.Checker()));
 }
 
 SignatureData DataFromTransaction(const CMutableTransaction& tx, unsigned int nIn)

--- a/src/script/sign.h
+++ b/src/script/sign.h
@@ -28,6 +28,7 @@ public:
 
     /** Create a singular (non-script) signature. */
     virtual bool CreateSig(std::vector<unsigned char>& vchSig, const CKeyID& keyid, const CScript& scriptCode, SigVersion sigversion) const =0;
+    virtual bool ShouldVerifySig() const =0;
 };
 
 /** A signature creator for transactions. */
@@ -42,6 +43,7 @@ public:
     TransactionSignatureCreator(const CKeyStore* keystoreIn, const CTransaction* txToIn, unsigned int nInIn, const CAmount& amountIn, int nHashTypeIn=SIGHASH_ALL);
     const BaseSignatureChecker& Checker() const { return checker; }
     bool CreateSig(std::vector<unsigned char>& vchSig, const CKeyID& keyid, const CScript& scriptCode, SigVersion sigversion) const;
+    bool ShouldVerifySig() const { return true; }
 };
 
 class MutableTransactionSignatureCreator : public TransactionSignatureCreator {
@@ -57,6 +59,7 @@ public:
     DummySignatureCreator(const CKeyStore* keystoreIn) : BaseSignatureCreator(keystoreIn) {}
     const BaseSignatureChecker& Checker() const;
     bool CreateSig(std::vector<unsigned char>& vchSig, const CKeyID& keyid, const CScript& scriptCode, SigVersion sigversion) const;
+    bool ShouldVerifySig() const { return false; }
 };
 
 struct SignatureData {


### PR DESCRIPTION
I'm not entirely sure if this is a good thing.
But, I don't see a reason why I can't use an imported P2PKH watch-only-address in conjunction with `fundrawtransaction` when enabling `includeWatching`.

This marks P2PKH watch only scripts as `ISMINE_WATCH_SOLVABLE`.
The second change makes the `DummySignatureCreator()` no longer verifying the produced signature. The `DummySignatureCreator` is only used for calculating the transaction size and therefore the verification of the script should not matter.