### PR TITLE
Control mempool persistence using a command line parameter

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -206,8 +206,9 @@ void Shutdown()
 
     StopTorControl();
     UnregisterNodeSignals(GetNodeSignals());
-    if (fDumpMempoolLater)
+    if (fDumpMempoolLater && GetArg("-persistmempool", DEFAULT_PERSIST_MEMPOOL)) {
         DumpMempool();
+    }
 
     if (fFeeEstimatesInitialized)
     {
@@ -339,6 +340,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-maxorphantx=<n>", strprintf(_("Keep at most <n> unconnectable transactions in memory (default: %u)"), DEFAULT_MAX_ORPHAN_TRANSACTIONS));
     strUsage += HelpMessageOpt("-maxmempool=<n>", strprintf(_("Keep the transaction memory pool below <n> megabytes (default: %u)"), DEFAULT_MAX_MEMPOOL_SIZE));
     strUsage += HelpMessageOpt("-mempoolexpiry=<n>", strprintf(_("Do not keep transactions in the mempool longer than <n> hours (default: %u)"), DEFAULT_MEMPOOL_EXPIRY));
+    strUsage += HelpMessageOpt("-persistmempool", strprintf(_("Whether to save the mempool on shutdown and load on restart (default: %u)"), DEFAULT_PERSIST_MEMPOOL));
     strUsage += HelpMessageOpt("-blockreconstructionextratxn=<n>", strprintf(_("Extra transactions to keep in memory for compact block reconstructions (default: %u)"), DEFAULT_BLOCK_RECONSTRUCTION_EXTRA_TXN));
     strUsage += HelpMessageOpt("-par=<n>", strprintf(_("Set the number of script verification threads (%u to %d, 0 = auto, <0 = leave that many cores free, default: %d)"),
         -GetNumCores(), MAX_SCRIPTCHECK_THREADS, DEFAULT_SCRIPTCHECK_THREADS));
@@ -666,8 +668,10 @@ void ThreadImport(std::vector<boost::filesystem::path> vImportFiles)
         StartShutdown();
     }
     } // End scope of CImportingNow
-    LoadMempool();
-    fDumpMempoolLater = !fRequestShutdown;
+    if (GetArg("-persistmempool", DEFAULT_PERSIST_MEMPOOL)) {
+        LoadMempool();
+        fDumpMempoolLater = !fRequestShutdown;
+    }
 }
 
 /** Sanity checks

--- a/src/validation.h
+++ b/src/validation.h
@@ -131,7 +131,8 @@ static const bool DEFAULT_PERMIT_BAREMULTISIG = true;
 static const bool DEFAULT_CHECKPOINTS_ENABLED = true;
 static const bool DEFAULT_TXINDEX = false;
 static const unsigned int DEFAULT_BANSCORE_THRESHOLD = 100;
-
+/** Default for -persistmempool */
+static const bool DEFAULT_PERSIST_MEMPOOL = true;
 /** Default for -mempoolreplacement */
 static const bool DEFAULT_ENABLE_REPLACEMENT = true;
 /** Default for using fee filter */

--- a/test/functional/mempool_persist.py
+++ b/test/functional/mempool_persist.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test mempool persistence.
+
+By default, bitcoind will dump mempool on shutdown and
+then reload it on startup. This can be overridden with
+the -persistmempool=false command line option.
+
+Test is as follows:
+
+  - start node0, node1 and node2. node1 has -persistmempool=false
+  - create 5 transactions on node2 to its own address. Note that these
+    are not sent to node0 or node1 addresses because we don't want
+    them to be saved in the wallet.
+  - check that node0 and node1 have 5 transactions in their mempools
+  - shutdown all nodes.
+  - startup node0. Verify that it still has 5 transactions
+    in its mempool. Shutdown node0. This tests that by default the
+    mempool is persistent.
+  - startup node1. Verify that its mempool is empty. Shutdown node1.
+    This tests that with -persistmempool=false, the mempool is not
+    dumped to disk when the node is shut down.
+  - Restart node0 with -persistmempool=false. Verify that its mempool is
+    empty. Shutdown node0. This tests that with -persistmempool=false,
+    the mempool is not loaded from disk on start up.
+  - Restart node0 with -persistmempool=true. Verify that it has 5
+    transactions in its mempool. This tests that -persistmempool=false
+    does not overwrite a previously valid mempool stored on disk.
+
+"""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+
+class MempoolPersistTest(BitcoinTestFramework):
+
+    def __init__(self):
+        super().__init__()
+        self.num_nodes = 3
+        self.setup_clean_chain = False
+
+    def setup_network(self):
+        # We need 3 nodes for this test. Node1 does not have a persistent mempool.
+        self.nodes = []
+        self.nodes.append(start_node(0, self.options.tmpdir))
+        self.nodes.append(start_node(1, self.options.tmpdir, ["-persistmempool=false"]))
+        self.nodes.append(start_node(2, self.options.tmpdir))
+        connect_nodes_bi(self.nodes, 0, 2)
+        connect_nodes_bi(self.nodes, 1, 2)
+        self.is_network_split = False
+
+    def run_test(self):
+        chain_height = self.nodes[0].getblockcount()
+        assert_equal(chain_height, 200)
+
+        self.log.debug("Mine a single block to get out of IBD")
+        self.nodes[0].generate(1)
+
+        self.log.debug("Send 5 transactions from node2 (to its own address)")
+        for i in range(5):
+            self.nodes[2].sendtoaddress(self.nodes[2].getnewaddress(), Decimal("10"))
+        self.sync_all()
+
+        self.log.debug("Verify that node0 and node1 have 5 transactions in their mempools")
+        assert_equal(len(self.nodes[0].getrawmempool()), 5)
+        assert_equal(len(self.nodes[1].getrawmempool()), 5)
+
+        self.log.debug("Stop-start node0 and node1. Verify that node0 has the transactions in its mempool and node1 does not.")
+        stop_nodes(self.nodes)
+        self.nodes = []
+        self.nodes.append(start_node(0, self.options.tmpdir))
+        self.nodes.append(start_node(1, self.options.tmpdir))
+        assert_equal(len(self.nodes[0].getrawmempool()), 5)
+        assert_equal(len(self.nodes[1].getrawmempool()), 0)
+
+        self.log.debug("Stop-start node0 with -persistmempool=false. Verify that it doesn't load its mempool.dat file.")
+        stop_nodes(self.nodes)
+        self.nodes = []
+        self.nodes.append(start_node(0, self.options.tmpdir, ["-persistmempool=false"]))
+        assert_equal(len(self.nodes[0].getrawmempool()), 0)
+
+        self.log.debug("Stop-start node0. Verify that it has the transactions in its mempool.")
+        stop_nodes(self.nodes)
+        self.nodes = []
+        self.nodes.append(start_node(0, self.options.tmpdir))
+        assert_equal(len(self.nodes[0].getrawmempool()), 5)
+
+if __name__ == '__main__':
+    MempoolPersistTest().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -59,6 +59,7 @@ BASE_SCRIPTS= [
     'rest.py',
     'mempool_spendcoinbase.py',
     'mempool_reorg.py',
+    'mempool_persist.py',
     'httpbasics.py',
     'multi_rpc.py',
     'proxy_test.py',


### PR DESCRIPTION
Mempool persistence was added in
3f78562df5e86a2a0a21812047fc3a7db8cee988, and is always on. This commit
introduces a command-line parameter -persistmempool, which defaults to
true. When set to false:

- mempool.dat is not loaded when the node starts.
- mempool.dat is not written when the node stops.

This was suggested in the PR that introduced mempool persistence (https://github.com/bitcoin/bitcoin/pull/8448#issuecomment-237155942 and  https://github.com/bitcoin/bitcoin/pull/8448#issuecomment-254640482) , but wasn't implemented in the original PR. It is a pre-req for fixing #9710.

This PR also introduces tests for mempool persistence, as well as for the new command-line parameter.