### PR TITLE
QA: getblocktemplate_longpoll.py should always use >0 fee tx

### DIFF
--- a/qa/rpc-tests/getblocktemplate_longpoll.py
+++ b/qa/rpc-tests/getblocktemplate_longpoll.py
@@ -61,7 +61,9 @@ class GetBlockTemplateLPTest(BitcoinTestFramework):
         thr = LongpollThread(self.nodes[0])
         thr.start()
         # generate a random transaction and submit it
-        (txid, txhex, fee) = random_transaction(self.nodes, Decimal("1.1"), Decimal("0.0"), Decimal("0.001"), 20)
+        min_relay_fee = self.nodes[0].getnetworkinfo()["relayfee"]
+        # min_relay_fee is fee per 1000 bytes, which should be more than enough.
+        (txid, txhex, fee) = random_transaction(self.nodes, Decimal("1.1"), min_relay_fee, Decimal("0.001"), 20)
         # after one minute, every 10 seconds the mempool is probed, so in 80 seconds it should have returned
         thr.join(60 + 20)
         assert(not thr.is_alive())


### PR DESCRIPTION
I saw a test failure that looked like it was due to a 0-fee transaction being generated.