### PR TITLE
Fix mem access violation merkleblock

### DIFF
--- a/src/merkleblock.cpp
+++ b/src/merkleblock.cpp
@@ -59,6 +59,9 @@ CMerkleBlock::CMerkleBlock(const CBlock& block, const std::set<uint256>& txids)
 }
 
 uint256 CPartialMerkleTree::CalcHash(int height, unsigned int pos, const std::vector<uint256> &vTxid) {
+    //we can never have zero txs in a merkle block, we always need the coinbase tx
+    //if we do not have this assert, we can hit a memory access violation when indexing into vTxid
+    assert(vTxid.size() != 0);
     if (height == 0) {
         // hash at height 0 is the txids themself
         return vTxid[pos];

--- a/src/merkleblock.h
+++ b/src/merkleblock.h
@@ -121,6 +121,8 @@ public:
 /**
  * Used to relay blocks as header + vector<merkle branch>
  * to filtered nodes.
+ *
+ * NOTE: The class assumes that the given CBlock has *at least* 1 transaction. If the CBlock has 0 txs, it will hit an assertion.
  */
 class CMerkleBlock
 {


### PR DESCRIPTION
Fixing a possible memory access violation in CPartialMerkleTree::CalcHash(). 

This can happen if we some how a merkle tree with zero txids. I don't think this can happen in practice as we only send merkle block messages on the p2p network as of now -- we cannot receive them. 

This was found with #8469, specifically using this [generator](https://github.com/Christewart/bitcoin/blob/rapidcheck/src/test/gen/merkleblock_gen.h#L52-L77) which will cause a memory access violation on [this test case](https://github.com/Christewart/bitcoin/blob/rapidcheck/src/test/merkleblock_properties.cpp#L48). 