### PR TITLE
tests: Convert selected tests to using named RPC arguments

### DIFF
--- a/qa/rpc-tests/assumevalid.py
+++ b/qa/rpc-tests/assumevalid.py
@@ -88,7 +88,7 @@ class SendHeadersTest(BitcoinTestFramework):
 
         # Build the blockchain
         self.tip = int(self.nodes[0].getbestblockhash(), 16)
-        self.block_time = self.nodes[0].getblock(self.nodes[0].getbestblockhash())['time'] + 1
+        self.block_time = self.nodes[0].getblock(blockhash=self.nodes[0].getbestblockhash())['time'] + 1
 
         self.blocks = []
 
@@ -171,20 +171,20 @@ class SendHeadersTest(BitcoinTestFramework):
             node0.send_message(msg_block(self.blocks[i]))
         node0.sync_with_ping() # make sure the most recent block is synced
         node0.send_message(msg_block(self.blocks[101]))
-        assert_equal(self.nodes[0].getblock(self.nodes[0].getbestblockhash())['height'], 101)
+        assert_equal(self.nodes[0].getblock(blockhash=self.nodes[0].getbestblockhash())['height'], 101)
 
         # Send 3102 blocks to node1. All blocks will be accepted.
         for i in range(2202):
             node1.send_message(msg_block(self.blocks[i]))
         node1.sync_with_ping() # make sure the most recent block is synced
-        assert_equal(self.nodes[1].getblock(self.nodes[1].getbestblockhash())['height'], 2202)
+        assert_equal(self.nodes[1].getblock(blockhash=self.nodes[1].getbestblockhash())['height'], 2202)
 
         # Send 102 blocks to node2. Block 102 will be rejected.
         for i in range(101):
             node2.send_message(msg_block(self.blocks[i]))
         node2.sync_with_ping() # make sure the most recent block is synced
         node2.send_message(msg_block(self.blocks[101]))
-        assert_equal(self.nodes[2].getblock(self.nodes[2].getbestblockhash())['height'], 101)
+        assert_equal(self.nodes[2].getblock(blockhash=self.nodes[2].getbestblockhash())['height'], 101)
 
 if __name__ == '__main__':
     SendHeadersTest().main()

--- a/qa/rpc-tests/blockchain.py
+++ b/qa/rpc-tests/blockchain.py
@@ -41,7 +41,7 @@ class BlockchainTest(BitcoinTestFramework):
     def run_test(self):
         self._test_gettxoutsetinfo()
         self._test_getblockheader()
-        self.nodes[0].verifychain(4, 0)
+        self.nodes[0].verifychain(checklevel=4, nblocks=0)
 
     def _test_gettxoutsetinfo(self):
         node = self.nodes[0]
@@ -59,11 +59,11 @@ class BlockchainTest(BitcoinTestFramework):
         node = self.nodes[0]
 
         assert_raises(
-            JSONRPCException, lambda: node.getblockheader('nonsense'))
+            JSONRPCException, lambda: node.getblockheader(blockhash='nonsense'))
 
         besthash = node.getbestblockhash()
-        secondbesthash = node.getblockhash(199)
-        header = node.getblockheader(besthash)
+        secondbesthash = node.getblockhash(height=199)
+        header = node.getblockheader(blockhash=besthash)
 
         assert_equal(header['hash'], besthash)
         assert_equal(header['height'], 200)

--- a/qa/rpc-tests/merkle_blocks.py
+++ b/qa/rpc-tests/merkle_blocks.py
@@ -31,7 +31,7 @@ class MerkleBlockTest(BitcoinTestFramework):
 
     def run_test(self):
         self.log.info("Mining blocks...")
-        self.nodes[0].generate(105)
+        self.nodes[0].generate(nblocks=105)
         self.sync_all()
 
         chain_height = self.nodes[1].getblockcount()
@@ -39,47 +39,47 @@ class MerkleBlockTest(BitcoinTestFramework):
         assert_equal(self.nodes[1].getbalance(), 0)
         assert_equal(self.nodes[2].getbalance(), 0)
 
-        node0utxos = self.nodes[0].listunspent(1)
-        tx1 = self.nodes[0].createrawtransaction([node0utxos.pop()], {self.nodes[1].getnewaddress(): 49.99})
-        txid1 = self.nodes[0].sendrawtransaction(self.nodes[0].signrawtransaction(tx1)["hex"])
-        tx2 = self.nodes[0].createrawtransaction([node0utxos.pop()], {self.nodes[1].getnewaddress(): 49.99})
-        txid2 = self.nodes[0].sendrawtransaction(self.nodes[0].signrawtransaction(tx2)["hex"])
-        assert_raises(JSONRPCException, self.nodes[0].gettxoutproof, [txid1])
+        node0utxos = self.nodes[0].listunspent(minconf=1)
+        tx1 = self.nodes[0].createrawtransaction(transactions=[node0utxos.pop()], outputs={self.nodes[1].getnewaddress(): 49.99})
+        txid1 = self.nodes[0].sendrawtransaction(hexstring=self.nodes[0].signrawtransaction(hexstring=tx1)["hex"])
+        tx2 = self.nodes[0].createrawtransaction(transactions=[node0utxos.pop()], outputs={self.nodes[1].getnewaddress(): 49.99})
+        txid2 = self.nodes[0].sendrawtransaction(hexstring=self.nodes[0].signrawtransaction(hexstring=tx2)["hex"])
+        assert_raises(JSONRPCException, self.nodes[0].gettxoutproof, txids=[txid1])
 
-        self.nodes[0].generate(1)
-        blockhash = self.nodes[0].getblockhash(chain_height + 1)
+        self.nodes[0].generate(nblocks=1)
+        blockhash = self.nodes[0].getblockhash(height=chain_height + 1)
         self.sync_all()
 
         txlist = []
-        blocktxn = self.nodes[0].getblock(blockhash, True)["tx"]
+        blocktxn = self.nodes[0].getblock(blockhash=blockhash, verbose=True)["tx"]
         txlist.append(blocktxn[1])
         txlist.append(blocktxn[2])
 
-        assert_equal(self.nodes[2].verifytxoutproof(self.nodes[2].gettxoutproof([txid1])), [txid1])
-        assert_equal(self.nodes[2].verifytxoutproof(self.nodes[2].gettxoutproof([txid1, txid2])), txlist)
-        assert_equal(self.nodes[2].verifytxoutproof(self.nodes[2].gettxoutproof([txid1, txid2], blockhash)), txlist)
+        assert_equal(self.nodes[2].verifytxoutproof(proof=self.nodes[2].gettxoutproof(txids=[txid1])), [txid1])
+        assert_equal(self.nodes[2].verifytxoutproof(proof=self.nodes[2].gettxoutproof(txids=[txid1, txid2])), txlist)
+        assert_equal(self.nodes[2].verifytxoutproof(proof=self.nodes[2].gettxoutproof(txids=[txid1, txid2], blockhash=blockhash)), txlist)
 
-        txin_spent = self.nodes[1].listunspent(1).pop()
-        tx3 = self.nodes[1].createrawtransaction([txin_spent], {self.nodes[0].getnewaddress(): 49.98})
-        self.nodes[0].sendrawtransaction(self.nodes[1].signrawtransaction(tx3)["hex"])
-        self.nodes[0].generate(1)
+        txin_spent = self.nodes[1].listunspent(minconf=1).pop()
+        tx3 = self.nodes[1].createrawtransaction(transactions=[txin_spent], outputs={self.nodes[0].getnewaddress(): 49.98})
+        self.nodes[0].sendrawtransaction(hexstring=self.nodes[1].signrawtransaction(hexstring=tx3)["hex"])
+        self.nodes[0].generate(nblocks=1)
         self.sync_all()
 
         txid_spent = txin_spent["txid"]
         txid_unspent = txid1 if txin_spent["txid"] != txid1 else txid2
 
         # We can't find the block from a fully-spent tx
-        assert_raises(JSONRPCException, self.nodes[2].gettxoutproof, [txid_spent])
+        assert_raises(JSONRPCException, self.nodes[2].gettxoutproof, txids=[txid_spent])
         # ...but we can if we specify the block
-        assert_equal(self.nodes[2].verifytxoutproof(self.nodes[2].gettxoutproof([txid_spent], blockhash)), [txid_spent])
+        assert_equal(self.nodes[2].verifytxoutproof(proof=self.nodes[2].gettxoutproof(txids=[txid_spent], blockhash=blockhash)), [txid_spent])
         # ...or if the first tx is not fully-spent
-        assert_equal(self.nodes[2].verifytxoutproof(self.nodes[2].gettxoutproof([txid_unspent])), [txid_unspent])
+        assert_equal(self.nodes[2].verifytxoutproof(proof=self.nodes[2].gettxoutproof(txids=[txid_unspent])), [txid_unspent])
         try:
-            assert_equal(self.nodes[2].verifytxoutproof(self.nodes[2].gettxoutproof([txid1, txid2])), txlist)
+            assert_equal(self.nodes[2].verifytxoutproof(proof=self.nodes[2].gettxoutproof(txids=[txid1, txid2])), txlist)
         except JSONRPCException:
-            assert_equal(self.nodes[2].verifytxoutproof(self.nodes[2].gettxoutproof([txid2, txid1])), txlist)
+            assert_equal(self.nodes[2].verifytxoutproof(proof=self.nodes[2].gettxoutproof(txids=[txid2, txid1])), txlist)
         # ...or if we have a -txindex
-        assert_equal(self.nodes[2].verifytxoutproof(self.nodes[3].gettxoutproof([txid_spent])), [txid_spent])
+        assert_equal(self.nodes[2].verifytxoutproof(proof=self.nodes[3].gettxoutproof(txids=[txid_spent])), [txid_spent])
 
 if __name__ == '__main__':
     MerkleBlockTest().main()


### PR DESCRIPTION
Convert selected tests to use named arguments in RPC calls. This covers a few of the important ones:

- `assumevalid.py`
- `blockchain.py`
- `merkle_blocks.py`
- `segwit.py`

As well as the test framework itself, `util.py`.

This makes invocations easier to read especially if booleans or lots of arguments are involved.

#### Reviewing

To review I'd suggest using the command:

    git diff --word-diff --word-diff-regex='[^[:space:],\(\)=]+'

This will regard the added argument names as one word, making it trivial to see what is added.

#### Process

As doing this is a bit of a finnicky process, I'm doing this a few tests at a time. I may add more to this PR later. In case people want to help, I created [this list](https://gist.github.com/laanwj/f55638598c697452199014b4faa6d679) of RPC calls with argument names to avoid having to refer to the individual help all the time.

To make sure a test has no use of positional arguments left you can add these lines to `__call__(self, *args, **argsn)` in `authproxy.py`:
```python
        if args:
            raise ValueError('TEST: supporting named arguments')
```
Every use of positional arguments will then raise that exception.