### PR TITLE
[QT] Show more descriptive label for pay to yourself entries

### DIFF
--- a/src/qt/addresstablemodel.cpp
+++ b/src/qt/addresstablemodel.cpp
@@ -422,7 +422,9 @@ bool AddressTableModel::removeRows(int row, int count, const QModelIndex &parent
  */
 QString AddressTableModel::labelForAddress(const QString &address) const
 {
-    {
+    if (address.isEmpty())
+        return QString();
+    {        
         LOCK(wallet->cs_wallet);
         CBitcoinAddress address_parsed(address.toStdString());
         std::map<CTxDestination, CAddressBookData>::iterator mi = wallet->mapAddressBook.find(address_parsed.Get());

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -103,8 +103,13 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
         {
             // Payment to self
             CAmount nChange = wtx.GetChange();
-
-            parts.append(TransactionRecord(hash, nTime, TransactionRecord::SendToSelf, "",
+            std::string address;
+            CTxDestination destAddress;
+            if (wtx.tx->vout.size() >= 1 && ExtractDestination(wtx.tx->vout[0].scriptPubKey, destAddress))
+            { 
+                address = CBitcoinAddress(destAddress).ToString();
+            }
+            parts.append(TransactionRecord(hash, nTime, TransactionRecord::SendToSelf, address,
                             -(nDebit - nChange), nCredit - nChange));
             parts.last().involvesWatchAddress = involvesWatchAddress;   // maybe pass to TransactionRecord as constructor argument
         }

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -360,7 +360,8 @@ QString TransactionTableModel::lookupAddress(const std::string &address, bool to
     }
     if(label.isEmpty() || tooltip)
     {
-        description += QString(" (") + QString::fromStdString(address) + QString(")");
+        label = address.empty() ? QString("n/a") : QString::fromStdString(address);
+        description += QString(" (") + label + QString(")");
     }
     return description;
 }
@@ -417,10 +418,10 @@ QString TransactionTableModel::formatTxToAddress(const TransactionRecord *wtx, b
     case TransactionRecord::RecvWithAddress:
     case TransactionRecord::SendToAddress:
     case TransactionRecord::Generated:
+    case TransactionRecord::SendToSelf:
         return lookupAddress(wtx->address, tooltip) + watchAddress;
     case TransactionRecord::SendToOther:
         return QString::fromStdString(wtx->address) + watchAddress;
-    case TransactionRecord::SendToSelf:
     default:
         return tr("(n/a)") + watchAddress;
     }
@@ -434,13 +435,12 @@ QVariant TransactionTableModel::addressColor(const TransactionRecord *wtx) const
     case TransactionRecord::RecvWithAddress:
     case TransactionRecord::SendToAddress:
     case TransactionRecord::Generated:
+    case TransactionRecord::SendToSelf:
         {
         QString label = walletModel->getAddressTableModel()->labelForAddress(QString::fromStdString(wtx->address));
         if(label.isEmpty())
             return COLOR_BAREADDRESS;
         } break;
-    case TransactionRecord::SendToSelf:
-        return COLOR_BAREADDRESS;
     default:
         break;
     }


### PR DESCRIPTION
This show a more descriptive label for Pay To Yourself transaction entries in bitcoin QT. Showing the label of the first Output.

Before:
![before](https://cloud.githubusercontent.com/assets/3020646/23864579/520486d6-0856-11e7-8a6c-17edddaa7fbb.PNG)

After:
![after](https://cloud.githubusercontent.com/assets/3020646/23864598/5b7f6604-0856-11e7-9aad-be7ffd52594c.PNG)

Pay to yourself is common when using Bitcoin Core for tracking coins going from and to Watch-Only addresses. For example, in the case of TumblerBit, it will make it  easier to see when a coins is transitioning throught different states: Wallet =>Alice Escrow => Alice Offer => Alice Offer Redeem.
