### PR TITLE
Initialize nRelockTime

### DIFF
--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -725,6 +725,7 @@ public:
         nLastResend = 0;
         nTimeFirstKey = 0;
         fBroadcastTransactions = false;
+        nRelockTime = 0;
     }
 
     std::map<uint256, CWalletTx> mapWallet;


### PR DESCRIPTION
This is just a display bug, the wallet is actually locked when started.