### PR TITLE
[DO NOT MERGE][LevelDB] Do no crash if filesystem can't fsync

### DIFF
--- a/src/leveldb/util/env_posix.cc
+++ b/src/leveldb/util/env_posix.cc
@@ -231,7 +231,7 @@ class PosixWritableFile : public WritableFile {
       if (fd < 0) {
         s = IOError(dir, errno);
       } else {
-        if (fsync(fd) < 0) {
+        if (fsync(fd) < 0 && errno != EINVAL) {
           s = IOError(dir, errno);
         }
         close(fd);


### PR DESCRIPTION
Solve https://github.com/bitcoin/bitcoin/issues/9996.
There should be some kind of warning if fsync is not supported. It is unclear how to implement that easily though since we don't have access to any logger here.

I encountered the problem as I could not run bitcoin on a network share on cifs. (I could previously, which is strange)

It seems that https://www.kernel.org/doc/Documentation/filesystems/cifs/CHANGES Version 1.57 seems to indicate that cifs should not fail, but just not guarantee that the server properly synched on the drive. This is not what I am experiencing.

Ping @laanwj 