### PR TITLE
[QT] Remove SendToSelf, and break down its payouts

### DIFF
--- a/src/qt/addresstablemodel.cpp
+++ b/src/qt/addresstablemodel.cpp
@@ -422,6 +422,8 @@ bool AddressTableModel::removeRows(int row, int count, const QModelIndex &parent
  */
 QString AddressTableModel::labelForAddress(const QString &address) const
 {
+    if (address.isEmpty())
+        return QString();
     {
         LOCK(wallet->cs_wallet);
         CBitcoinAddress address_parsed(address.toStdString());

--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -76,8 +76,7 @@ public:
         SendToAddress,
         SendToOther,
         RecvWithAddress,
-        RecvFromOther,
-        SendToSelf
+        RecvFromOther
     };
 
     /** Number of confirmation recommended for accepting a transaction */

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -360,6 +360,7 @@ QString TransactionTableModel::lookupAddress(const std::string &address, bool to
     }
     if(label.isEmpty() || tooltip)
     {
+        label = address.empty() ? QString("n/a") : QString::fromStdString(address);
         description += QString(" (") + QString::fromStdString(address) + QString(")");
     }
     return description;
@@ -376,8 +377,6 @@ QString TransactionTableModel::formatTxType(const TransactionRecord *wtx) const
     case TransactionRecord::SendToAddress:
     case TransactionRecord::SendToOther:
         return tr("Sent to");
-    case TransactionRecord::SendToSelf:
-        return tr("Payment to yourself");
     case TransactionRecord::Generated:
         return tr("Mined");
     default:
@@ -420,7 +419,6 @@ QString TransactionTableModel::formatTxToAddress(const TransactionRecord *wtx, b
         return lookupAddress(wtx->address, tooltip) + watchAddress;
     case TransactionRecord::SendToOther:
         return QString::fromStdString(wtx->address) + watchAddress;
-    case TransactionRecord::SendToSelf:
     default:
         return tr("(n/a)") + watchAddress;
     }
@@ -439,8 +437,6 @@ QVariant TransactionTableModel::addressColor(const TransactionRecord *wtx) const
         if(label.isEmpty())
             return COLOR_BAREADDRESS;
         } break;
-    case TransactionRecord::SendToSelf:
-        return COLOR_BAREADDRESS;
     default:
         break;
     }

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -87,7 +87,6 @@ TransactionView::TransactionView(const PlatformStyle *platformStyle, QWidget *pa
                                         TransactionFilterProxy::TYPE(TransactionRecord::RecvFromOther));
     typeWidget->addItem(tr("Sent to"), TransactionFilterProxy::TYPE(TransactionRecord::SendToAddress) |
                                   TransactionFilterProxy::TYPE(TransactionRecord::SendToOther));
-    typeWidget->addItem(tr("To yourself"), TransactionFilterProxy::TYPE(TransactionRecord::SendToSelf));
     typeWidget->addItem(tr("Mined"), TransactionFilterProxy::TYPE(TransactionRecord::Generated));
     typeWidget->addItem(tr("Other"), TransactionFilterProxy::TYPE(TransactionRecord::Other));
 


### PR DESCRIPTION
Alternative to https://github.com/bitcoin/bitcoin/pull/9985 following @luke-jr suggestion. I think it looks great.

The rational is that pay to yourself is mostly done by third party tool, like tumbler bit and joinmarket using watch-only addresses to track payments.

I aggregate all the inputs into one entry with debit.
If their is only one input, the description of the line is taken from its address.
And one entry per output with credit.

As you can see in this example, you can follow where the coins flow from the escrow, to the redeem (timeout) or offer. 

Before:
![before](https://cloud.githubusercontent.com/assets/3020646/23864579/520486d6-0856-11e7-8a6c-17edddaa7fbb.PNG)

After:
![capture](https://cloud.githubusercontent.com/assets/3020646/23986052/8ad716fc-0a65-11e7-87d5-fb3ef1cc6637.PNG)
