### PR TITLE
util: rename variable to avoid shadowing

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -80,9 +80,9 @@ template<typename... Args> std::string FormatStringFromLogArgs(const char *fmt, 
     std::string _log_msg_; /* Unlikely name to avoid shadowing variables */ \
     try { \
         _log_msg_ = tfm::format(__VA_ARGS__); \
-    } catch (tinyformat::format_error &e) { \
+    } catch (tinyformat::format_error &fmterr) { \
         /* Original format string will have newline so don't add one here */ \
-        _log_msg_ = "Error \"" + std::string(e.what()) + "\" while formatting log message: " + FormatStringFromLogArgs(__VA_ARGS__); \
+        _log_msg_ = "Error \"" + std::string(fmterr.what()) + "\" while formatting log message: " + FormatStringFromLogArgs(__VA_ARGS__); \
     } \
     LogPrintStr(_log_msg_); \
 } while(0)


### PR DESCRIPTION
This avoids triggering the following warning (appears almost everywhere where this macro is used):

```
In file included from rpc/protocol.cpp:10:0:
rpc/protocol.cpp: In function ‘void DeleteAuthCookie()’:
./util.h:83:40: warning: declaration of ‘e’ shadows a previous local [-Wshadow]
     } catch (tinyformat::format_error &e) { \
                                        ^
rpc/protocol.cpp:123:9: note: in expansion of macro ‘LogPrintf’
         LogPrintf("%s: Unable to remove random auth cookie file: %s\n", __func__, e.what());
         ^~~~~~~~~
rpc/protocol.cpp:122:57: note: shadowed declaration is here
     } catch (const boost::filesystem::filesystem_error& e) {
                                                         ^
```