### PR TITLE
build: Fix typo s/HAVE_DONTWAIT/HAVE_MSG_DONTWAIT

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -562,7 +562,7 @@ dnl Check for MSG_DONTWAIT
 AC_MSG_CHECKING(for MSG_DONTWAIT)
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <sys/socket.h>]],
  [[ int f = MSG_DONTWAIT; ]])],
- [ AC_MSG_RESULT(yes); AC_DEFINE(HAVE_DONTWAIT, 1,[Define this symbol if you have MSG_DONTWAIT]) ],
+ [ AC_MSG_RESULT(yes); AC_DEFINE(HAVE_MSG_DONTWAIT, 1,[Define this symbol if you have MSG_DONTWAIT]) ],
  [ AC_MSG_RESULT(no)]
 )
 


### PR DESCRIPTION
Introduced in #9921.

Thanks to @prusnak for spotting this one.