### PR TITLE
Wallet should reject long chains by default

### DIFF
--- a/qa/rpc-tests/fundrawtransaction.py
+++ b/qa/rpc-tests/fundrawtransaction.py
@@ -316,7 +316,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         rawtx   = self.nodes[2].createrawtransaction(inputs, outputs)
         dec_tx  = self.nodes[2].decoderawtransaction(rawtx)
 
-        assert_raises_jsonrpc(-4, "Insufficient funds", self.nodes[2].fundrawtransaction, rawtx)
+        assert_raises_jsonrpc(-4, "Coin Selection Failed", self.nodes[2].fundrawtransaction, rawtx)
 
         ############################################################
         #compare fee of a standard pubkeyhash transaction
@@ -472,7 +472,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         rawTx = self.nodes[1].createrawtransaction(inputs, outputs)
         # fund a transaction that requires a new key for the change output
         # creating the key must be impossible because the wallet is locked
-        assert_raises_jsonrpc(-4, "Insufficient funds", self.nodes[1].fundrawtransaction, rawtx)
+        assert_raises_jsonrpc(-4, "Coin Selection Failed", self.nodes[1].fundrawtransaction, rawtx)
 
         #refill the keypool
         self.nodes[1].walletpassphrase("test", 100)

--- a/qa/rpc-tests/wallet.py
+++ b/qa/rpc-tests/wallet.py
@@ -359,23 +359,34 @@ class WalletTest (BitcoinTestFramework):
         # So we should be able to generate exactly chainlimit txs for each original output
         sending_addr = self.nodes[1].getnewaddress()
         txid_list = []
-        for i in range(chainlimit*2):
+        for i in range((chainlimit - 1 ) * 2):
             txid_list.append(self.nodes[0].sendtoaddress(sending_addr, Decimal('0.0001')))
-        assert_equal(self.nodes[0].getmempoolinfo()['size'], chainlimit*2)
-        assert_equal(len(txid_list), chainlimit*2)
+        assert_equal(self.nodes[0].getmempoolinfo()['size'], (chainlimit - 1) * 2)
+        assert_equal(len(txid_list), (chainlimit - 1 ) * 2)
 
-        # Without walletrejectlongchains, we will still generate a txid
-        # The tx will be stored in the wallet but not accepted to the mempool
+        # With walletrejectlongchains we will not create the tx and store it in our wallet.
+        assert_raises_jsonrpc(-4, "Coin Selection Failed", self.nodes[0].sendtoaddress, sending_addr, Decimal('0.01'))
+
+        # Without walletrejectlongchains, we can submit up to (chainlimit)
+        # transactions to the mempool. The (chainlimit+1)th transaction will be
+        # added to the wallet but not accepted to the mempool
+        stop_node(self.nodes[0],0)
+        self.nodes[0] = start_node(0, self.options.tmpdir, ["-limitancestorcount="+str(chainlimit), "-walletrejectlongchains=0"])
+
+        for i in range(2):
+            txid_list.append(self.nodes[0].sendtoaddress(sending_addr, Decimal('0.0001')))
+
         extra_txid = self.nodes[0].sendtoaddress(sending_addr, Decimal('0.0001'))
         assert(extra_txid not in self.nodes[0].getrawmempool())
         assert(extra_txid in [tx["txid"] for tx in self.nodes[0].listtransactions()])
+
         self.nodes[0].abandontransaction(extra_txid)
         total_txs = len(self.nodes[0].listtransactions("*",99999))
 
         # Try with walletrejectlongchains
         # Double chain limit but require combining inputs, so we pass SelectCoinsMinConf
         stop_node(self.nodes[0],0)
-        self.nodes[0] = start_node(0, self.options.tmpdir, ["-walletrejectlongchains", "-limitancestorcount="+str(2*chainlimit)])
+        self.nodes[0] = start_node(0, self.options.tmpdir, ["-limitancestorcount="+str(2*chainlimit)])
 
         # wait for loadmempool
         timeout = 10

--- a/qa/rpc-tests/wallet.py
+++ b/qa/rpc-tests/wallet.py
@@ -71,7 +71,7 @@ class WalletTest (BitcoinTestFramework):
         unspent_0 = self.nodes[2].listunspent()[0]
         unspent_0 = {"txid": unspent_0["txid"], "vout": unspent_0["vout"]}
         self.nodes[2].lockunspent(False, [unspent_0])
-        assert_raises_jsonrpc(-4, "Insufficient funds", self.nodes[2].sendtoaddress, self.nodes[2].getnewaddress(), 20)
+        assert_raises_jsonrpc(-4, "Coin Selection Failed", self.nodes[2].sendtoaddress, self.nodes[2].getnewaddress(), 20)
         assert_equal([unspent_0], self.nodes[2].listlockunspent())
         self.nodes[2].lockunspent(True, [unspent_0])
         assert_equal(len(self.nodes[2].listlockunspent()), 0)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2416,7 +2416,7 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
                 setCoins.clear();
                 if (!SelectCoins(vAvailableCoins, nValueToSelect, setCoins, nValueIn, coinControl))
                 {
-                    strFailReason = _("Insufficient funds");
+                    strFailReason = _("Coin Selection Failed");
                     return false;
                 }
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -56,7 +56,7 @@ static const CAmount MIN_FINAL_CHANGE = MIN_CHANGE/2;
 //! Default for -spendzeroconfchange
 static const bool DEFAULT_SPEND_ZEROCONF_CHANGE = true;
 //! Default for -walletrejectlongchains
-static const bool DEFAULT_WALLET_REJECT_LONG_CHAINS = false;
+static const bool DEFAULT_WALLET_REJECT_LONG_CHAINS = true;
 //! -txconfirmtarget default
 static const unsigned int DEFAULT_TX_CONFIRM_TARGET = 6;
 //! -walletrbf default


### PR DESCRIPTION
#9262 introduced `-walletrejectlongchains`, which prevents the wallet from adding transactions which would form a chain which is too long to be accepted by the mempool. However, it's set to false by default.

There are legitimate reasons for wanting the wallet to accept longer chains than the mempool, and #9290 does ensure that wallet transactions will be resubmitted to the mempool eventually. However, in the mainline case the behaviour is confusing for the user and the wallet should reject the long chains. See for instance #10004 and #9752.

This PR sets `-walletrejectlongchains` to true by default, and makes the wallet reject transactions that form a chain up to (maxlength - 1). This means that the user has one final chance to add a transaction to the chain by restarting with `-walletrejectlongchains` set to false. This could be helpful if a user wants to use CPFP to unstick a transaction package with too low fees.

Tests also updated to verify new behaviour.

This PR also changes the error message returned if Coin Selection fails. Currently, if Coin Selection fails, then the error returned to the user is "Insufficient Funds". This is misleading as Coin Selection can fail for other reasons, such as if the transaction would form a chain that is too long to enter the mempool. This commit changes the error message returned from "Insufficient Funds" to "Coin Selection Failed" and updates the test scripts to expect the correct error message.