### PR TITLE
[trivial] Use log.info() instead of print() in remaining functional test cases.

### DIFF
--- a/qa/rpc-tests/importmulti.py
+++ b/qa/rpc-tests/importmulti.py
@@ -413,7 +413,7 @@ class ImportMultiTest (BitcoinTestFramework):
 
         # Importing existing watch only address with new timestamp should replace saved timestamp.
         assert_greater_than(timestamp, watchonly_timestamp)
-        print("Should replace previously saved watch only timestamp.")
+        self.log.info("Should replace previously saved watch only timestamp.")
         result = self.nodes[1].importmulti([{
             "scriptPubKey": {
                 "address": watchonly_address,

--- a/qa/rpc-tests/nulldummy.py
+++ b/qa/rpc-tests/nulldummy.py
@@ -81,14 +81,14 @@ class NULLDUMMYTest(BitcoinTestFramework):
         self.log.info("Test 3: Non-NULLDUMMY base transactions should be accepted in a block before activation [431]")
         self.block_submit(self.nodes[0], [test2tx], False, True)
 
-        self.log.info ("Test 4: Non-NULLDUMMY base multisig transaction is invalid after activation")
+        self.log.info("Test 4: Non-NULLDUMMY base multisig transaction is invalid after activation")
         test4tx = self.create_transaction(self.nodes[0], test2tx.hash, self.address, 46)
         test6txs=[CTransaction(test4tx)]
         trueDummy(test4tx)
         assert_raises_jsonrpc(-26, NULLDUMMY_ERROR, self.nodes[0].sendrawtransaction, bytes_to_hex_str(test4tx.serialize_with_witness()), True)
         self.block_submit(self.nodes[0], [test4tx])
 
-        print ("Test 5: Non-NULLDUMMY P2WSH multisig transaction invalid after activation")
+        self.log.info("Test 5: Non-NULLDUMMY P2WSH multisig transaction invalid after activation")
         test5tx = self.create_transaction(self.nodes[0], txid3, self.wit_address, 48)
         test6txs.append(CTransaction(test5tx))
         test5tx.wit.vtxinwit[0].scriptWitness.stack[0] = b'\x01'

--- a/qa/rpc-tests/proxy_test.py
+++ b/qa/rpc-tests/proxy_test.py
@@ -49,6 +49,7 @@ class ProxyTest(BitcoinTestFramework):
         self.num_nodes = 4
         self.setup_clean_chain = False
 
+    def setup_nodes(self):
         self.have_ipv6 = test_ipv6_local()
         # Create two proxies on different ports
         # ... one unauthenticated
@@ -69,7 +70,7 @@ class ProxyTest(BitcoinTestFramework):
             self.conf3.unauth = True
             self.conf3.auth = True
         else:
-            print("Warning: testing without local IPv6 support")
+            self.log.warning("Testing without local IPv6 support")
 
         self.serv1 = Socks5Server(self.conf1)
         self.serv1.start()
@@ -79,7 +80,6 @@ class ProxyTest(BitcoinTestFramework):
             self.serv3 = Socks5Server(self.conf3)
             self.serv3.start()
 
-    def setup_nodes(self):
         # Note: proxies are not used to connect to local nodes
         # this is because the proxy to use is based on CService.GetNetwork(), which return NET_UNROUTABLE for localhost
         args = [

--- a/qa/rpc-tests/test_framework/socks5.py
+++ b/qa/rpc-tests/test_framework/socks5.py
@@ -6,6 +6,9 @@
 
 import socket, threading, queue
 import traceback, sys
+import logging
+
+logger = logging.getLogger("TestFramework.socks5")
 
 ### Protocol constants
 class Command:
@@ -112,10 +115,10 @@ class Socks5Connection(object):
 
             cmdin = Socks5Command(cmd, atyp, addr, port, username, password)
             self.serv.queue.put(cmdin)
-            print('Proxy: ', cmdin)
+            logger.info('Proxy: %s', cmdin)
             # Fall through to disconnect
         except Exception as e:
-            traceback.print_exc(file=sys.stderr)
+            logger.exception("socks5 request handling failed.")
             self.serv.queue.put(e)
         finally:
             self.conn.close()


### PR DESCRIPTION
#9818 was opened before we had logging in the test framework and added a print() call to importmulti.py. log.info() is preferred now that we have logging in the test framework.