### PR TITLE
Fix parameter naming inconsistencies between .h and .cpp files

### DIFF
--- a/src/core_write.cpp
+++ b/src/core_write.cpp
@@ -114,9 +114,9 @@ std::string ScriptToAsmStr(const CScript& script, const bool fAttemptSighashDeco
     return str;
 }
 
-std::string EncodeHexTx(const CTransaction& tx, const int serialFlags)
+std::string EncodeHexTx(const CTransaction& tx, const int serializeFlags)
 {
-    CDataStream ssTx(SER_NETWORK, PROTOCOL_VERSION | serialFlags);
+    CDataStream ssTx(SER_NETWORK, PROTOCOL_VERSION | serializeFlags);
     ssTx << tx;
     return HexStr(ssTx.begin(), ssTx.end());
 }

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -68,7 +68,7 @@ void SetRPCWarmupStatus(const std::string& newStatus);
 void SetRPCWarmupFinished();
 
 /* returns the current warmup state.  */
-bool RPCIsInWarmup(std::string *statusOut);
+bool RPCIsInWarmup(std::string *outStatus);
 
 /**
  * Type-check arguments; throws JSONRPCError if wrong type given. Does not check that

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -108,7 +108,7 @@ void CTxMemPool::UpdateForDescendants(txiter updateIt, cacheMap &cachedDescendan
 
 // vHashesToUpdate is the set of transaction hashes from a disconnected block
 // which has been re-added to the mempool.
-// for each entry, look for descendants that are outside hashesToUpdate, and
+// for each entry, look for descendants that are outside vHashesToUpdate, and
 // add fee/size information for such descendants to the parent.
 // for each such descendant, also update the ancestor state to include the parent.
 void CTxMemPool::UpdateTransactionsFromBlock(const std::vector<uint256> &vHashesToUpdate)

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -552,12 +552,12 @@ public:
      *  new mempool entries may have children in the mempool (which is generally
      *  not the case when otherwise adding transactions).
      *  UpdateTransactionsFromBlock() will find child transactions and update the
-     *  descendant state for each transaction in hashesToUpdate (excluding any
-     *  child transactions present in hashesToUpdate, which are already accounted
-     *  for).  Note: hashesToUpdate should be the set of transactions from the
+     *  descendant state for each transaction in vHashesToUpdate (excluding any
+     *  child transactions present in vHashesToUpdate, which are already accounted
+     *  for).  Note: vHashesToUpdate should be the set of transactions from the
      *  disconnected block that have been accepted back into the mempool.
      */
-    void UpdateTransactionsFromBlock(const std::vector<uint256> &hashesToUpdate);
+    void UpdateTransactionsFromBlock(const std::vector<uint256> &vHashesToUpdate);
 
     /** Try to calculate all in-mempool ancestors of entry.
      *  (these are all calculated including the tx itself)

--- a/src/validation.h
+++ b/src/validation.h
@@ -314,7 +314,7 @@ void FlushStateToDisk();
 /** Prune block files and flush state to disk. */
 void PruneAndFlush();
 /** Prune block files up to a given height */
-void PruneBlockFilesManual(int nPruneUpToHeight);
+void PruneBlockFilesManual(int nManualPruneHeight);
 
 /** (try to) add transaction to memory pool
  * plTxnReplaced will be appended to with all transactions replaced from mempool **/


### PR DESCRIPTION
Inconsistencies prior to this commit:

```
* serializeFlags vs serialFlags
src/core_io.h:std::string EncodeHexTx(const CTransaction& tx, const int serializeFlags = 0);
src/core_write.cpp:std::string EncodeHexTx(const CTransaction& tx, const int serialFlags)

* statusOut vs outStatus
src/rpc/server.h:bool RPCIsInWarmup(std::string *statusOut);
src/rpc/server.cpp:bool RPCIsInWarmup(std::string *outStatus)

* hashesToUpdate vs vHashesToUpdate
src/txmempool.h:    void UpdateTransactionsFromBlock(const std::vector<uint256> &hashesToUpdate);
src/txmempool.cpp:void CTxMemPool::UpdateTransactionsFromBlock(const std::vector<uint256> &vHashesToUpdate)

* nPruneUpToHeight vs nManualPruneHeight
src/validation.h:void PruneBlockFilesManual(int nPruneUpToHeight);
src/validation.cpp:void PruneBlockFilesManual(int nManualPruneHeight)
```