### PR TITLE
Trivial: Fix typo in key.h comment

### DIFF
--- a/src/key.h
+++ b/src/key.h
@@ -45,7 +45,7 @@ private:
     //! The actual byte data
     std::vector<unsigned char, secure_allocator<unsigned char> > keydata;
 
-    //! Check whether the 32-byte array pointed to be vch is valid keydata.
+    //! Check whether the 32-byte array pointed to by vch is valid keydata.
     bool static Check(const unsigned char* vch);
 
 public:


### PR DESCRIPTION
As spotted by user `Blinken`: https://bitcointalk.org/index.php?topic=1828929.msg18205985#msg18205985

```
In the bitcoin core file key.h there is a typo:

//! Check whether the 32-byte array pointed to be vch is valid keydata.
     bool static Check(const unsigned char* vch);

The comment should read:

//! Check whether the 32-byte array pointed to by vch is valid keydata.
```