### PR TITLE
Fix init README format to render correctly on github

### DIFF
--- a/contrib/init/README.md
+++ b/contrib/init/README.md
@@ -1,12 +1,12 @@
 Sample configuration files for:
-
+```
 SystemD: bitcoind.service
 Upstart: bitcoind.conf
 OpenRC:  bitcoind.openrc
          bitcoind.openrcconf
 CentOS:  bitcoind.init
 OS X:    org.bitcoin.bitcoind.plist
-
+```
 have been made available to assist packagers in creating node packages here.
 
 See doc/init.md for more information.


### PR DESCRIPTION
Needs preformatted tags