### PR TITLE
Trivial: Fix typo in help getrawtransaction RPC

### DIFF
--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -138,7 +138,7 @@ UniValue getrawtransaction(const JSONRPCRequest& request)
 
             "\nArguments:\n"
             "1. \"txid\"      (string, required) The transaction id\n"
-            "2. verbose       (bool, optional, default=false) If true, return a string, other return a json object\n"
+            "2. verbose       (bool, optional, default=false) If false, return a string, otherwise return a json object\n"
 
             "\nResult (if verbose is not set or set to false):\n"
             "\"data\"      (string) The serialized, hex-encoded data for 'txid'\n"


### PR DESCRIPTION
This fixes two typos in rawtransaction.cpp. When getrawtransaction is called and verbose is false, serialized hex-encoded data is returned. Only when it is true is the JSON object returned. There is also a grammatical error.