### PR TITLE
Fix bug in CKey DER encoding

### DIFF
--- a/src/key.cpp
+++ b/src/key.cpp
@@ -147,7 +147,7 @@ CPrivKey CKey::GetPrivKey() const {
     size_t privkeylen;
     privkey.resize(279);
     privkeylen = 279;
-    ret = ec_privkey_export_der(secp256k1_context_sign, (unsigned char*)&privkey[0], &privkeylen, begin(), fCompressed ? SECP256K1_EC_COMPRESSED : SECP256K1_EC_UNCOMPRESSED);
+    ret = ec_privkey_export_der(secp256k1_context_sign, (unsigned char*)&privkey[0], &privkeylen, begin(), fCompressed);
     assert(ret);
     privkey.resize(privkeylen);
     return privkey;

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -135,6 +135,7 @@ bool CKey::SetPrivKey(const CPrivKey &privkey, bool fCompressedIn) {
     if (!ec_privkey_import_der(secp256k1_context_sign, (unsigned char*)begin(), &privkey[0], privkey.size()))
         return false;
     fCompressed = fCompressedIn;
+    assert(privkey[1] == (fCompressed ? 0x81 : 0x82));
     fValid = true;
     return true;
 }

--- a/src/test/key_tests.cpp
+++ b/src/test/key_tests.cpp
@@ -158,4 +158,19 @@ BOOST_AUTO_TEST_CASE(key_test1)
     BOOST_CHECK(detsigc == ParseHex("2052d8a32079c11e79db95af63bb9600c5b04f21a9ca33dc129c2bfa8ac9dc1cd561d8ae5e0f6c1a16bde3719c64c2fd70e404b6428ab9a69566962e8771b5944d"));
 }
 
+BOOST_AUTO_TEST_CASE(key_export_test)
+{
+    CKey key1;
+    key1.MakeNewKey(true);
+    CPrivKey pkey1 = key1.GetPrivKey();
+    key1.SetPrivKey(pkey1, true);
+    BOOST_CHECK(key1.IsCompressed() == true);
+
+    CKey key2;
+    key2.MakeNewKey(false);
+    CPrivKey pkey2 = key2.GetPrivKey();
+    key2.SetPrivKey(pkey2, false);
+    BOOST_CHECK(key2.IsCompressed() == false);
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
At the moment, due to a mistake in our code, we DER export uncompressed keys as compressed.
Addresses #10041.