### PR TITLE
adhere to `-whitelist` for outbound connection

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -396,6 +396,7 @@ CNode* CConnman::ConnectNode(CAddress addrConnect, const char *pszDest, bool fCo
         CNode* pnode = new CNode(id, nLocalServices, GetBestHeight(), hSocket, addrConnect, CalculateKeyedNetGroup(addrConnect), nonce, pszDest ? pszDest : "", false);
         pnode->nServicesExpected = ServiceFlags(addrConnect.nServices & nRelevantServices);
         pnode->AddRef();
+        pnode->fWhitelisted = CConnman::IsWhitelistedRange((CNetAddr)pnode->addr);
 
         return pnode;
     } else if (!proxyConnectionFailed) {


### PR DESCRIPTION
unsure why this wasn't already being done, seems sensible to me that you also want to be able to whitelist nodes that you make an outgoing connection to?

trying to figure if there should be any tests added but I can't seem to find tests that really cover ConnectNode specifically at all?