### PR TITLE
[test] Run extended tests once daily in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,8 @@ script:
     - make $MAKEJOBS $GOAL || ( echo "Build failure. Verbose build follows." && make $GOAL V=1 ; false )
     - export LD_LIBRARY_PATH=$TRAVIS_BUILD_DIR/depends/$HOST/lib
     - if [ "$RUN_TESTS" = "true" ]; then make $MAKEJOBS check VERBOSE=1; fi
-    - if [ "$RUN_TESTS" = "true" ]; then test/functional/test_runner.py --coverage; fi
+    - if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then extended="--extended --exclude pruning"; fi
+    - if [ "$RUN_TESTS" = "true" ]; then test/functional/test_runner.py --coverage ${extended}; fi
 after_script:
     - echo $TRAVIS_COMMIT_RANGE
     - echo $TRAVIS_COMMIT_LOG


### PR DESCRIPTION
Travis has beta support for a new feature called [cron jobs](https://docs.travis-ci.com/user/cron-jobs/). We should hook into this to run our extended functional test suite once per day.

This requires two changes: merging the change to .travis.yml in this PR, and then enabling daily builds of the master branch through Travis settings.

For an example of a cron build see https://travis-ci.org/jnewbery/bitcoin/builds/213827649. This currently fails because:
- rpcbind_tests.py requires ipv6, which Travis currently doesn't support. I have a workaround for that on the way.
- pruning.py times out. I've now updated the .travis.yml file to exclude running pruning.

The granularity for cron jobs is very coarse - currently Travis only allows jobs to be run daily, weekly or monthly. There have been lots of requests for more flexible cron schedules in [this thread](https://github.com/travis-ci/beta-features/issues/1) so Travis may add this as an enhancement at some point.