### PR TITLE
[net] Avoid redefining MSG_DONTWAIT on macos

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -49,7 +49,7 @@
 #endif
 
 // MSG_DONTWAIT is not available on some platforms, if it doesn't exist define it as 0
-#if !defined(HAVE_MSG_DONTWAIT)
+#if !defined(MSG_DONTWAIT)
 #define MSG_DONTWAIT 0
 #endif
 


### PR DESCRIPTION
The [socket.h](https://gist.github.com/kallewoof/ca31606aef73ec89f65dcf54ca74c55f) file on macos does not have `HAVE_MSG_DONTWAIT` despite having `MSG_DONTWAIT`, which means macos having `MSG_DONTWAIT` is not detected, causing a redefine in `net.cpp`:

```C++
net.cpp:53:9: warning: 'MSG_DONTWAIT' macro redefined [-Wmacro-redefined]
#define MSG_DONTWAIT 0
        ^
/usr/include/sys/socket.h:556:9: note: previous definition is here
#define MSG_DONTWAIT    0x80            /* this message should be nonblocking */
```

The `HAVE_MSG_NOSIGNAL` a few lines above is not causing a warning so presumably it's fine, but maybe it would be better to change that to `!defined(MSG_NOSIGNAL)` as well..