### PR TITLE
[Qt] Ensure an item exists on the rpcconsole stack before adding

### DIFF
--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -175,6 +175,10 @@ bool RPCConsole::RPCParseCommandLine(std::string &strResult, const std::string &
             nDepthInsideSensitive = 1;
             filter_begin_pos = chpos;
         }
+        // Make sure stack is not empty before adding something
+        if (stack.empty()) {
+            stack.push_back(std::vector<std::string>());
+        }
         stack.back().push_back(strArg);
     };
 


### PR DESCRIPTION
Ensures that there is an item on the rpcconsole stack before adding something to the current stack so that a segmentation fault does not occur.

Currently Bitcoin Core will just crash if there happens to be a newline somewhere in the command followed by some non-whitespace characters which are followed by a space. This causes a segfault by attempting to get the current stack from the empty stack vector. This fix ensures that that current stack always exists so that the segfault does not happen.

The crashing behavior can be tested by using this command in the rpcconsole:
```
decoderawtransaction 01000000 03e7a6f3 a93af3ae 49518cbf 8600b799 b04a8b8a ae5145f0 b25df06e 
  175d472a a
```
(copy and paste it as one line)