### PR TITLE
[net] Clean up the CNode class in net.h

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -628,7 +628,7 @@ void CNode::SetAddrLocal(const CService& addrLocalIn) {
 
 #undef X
 #define X(name) stats.name = name
-void CNode::copyStats(CNodeStats &stats)
+void CNode::CopyStats(CNodeStats &stats)
 {
     stats.nodeid = this->GetId();
     X(nServices);
@@ -2467,7 +2467,7 @@ void CConnman::GetNodeStats(std::vector<CNodeStats>& vstats)
     for(std::vector<CNode*>::iterator it = vNodes.begin(); it != vNodes.end(); ++it) {
         CNode* pnode = *it;
         vstats.emplace_back();
-        pnode->copyStats(vstats.back());
+        pnode->CopyStats(vstats.back());
     }
 }
 
@@ -2619,17 +2619,17 @@ unsigned int CConnman::GetReceiveFloodSize() const { return nReceiveFloodSize; }
 unsigned int CConnman::GetSendBufferSize() const{ return nSendBufferMaxSize; }
 
 CNode::CNode(NodeId idIn, ServiceFlags nLocalServicesIn, int nMyStartingHeightIn, SOCKET hSocketIn, const CAddress& addrIn, uint64_t nKeyedNetGroupIn, uint64_t nLocalHostNonceIn, const std::string& addrNameIn, bool fInboundIn) :
+    nLocalHostNonce(nLocalHostNonceIn),
+    nLocalServices(nLocalServicesIn),
+    nMyStartingHeight(nMyStartingHeightIn),
+    nSendVersion(0),
     nTimeConnected(GetSystemTimeInSeconds()),
     addr(addrIn),
     fInbound(fInboundIn),
     id(idIn),
     nKeyedNetGroup(nKeyedNetGroupIn),
     addrKnown(5000, 0.001),
-    filterInventoryKnown(50000, 0.000001),
-    nLocalHostNonce(nLocalHostNonceIn),
-    nLocalServices(nLocalServicesIn),
-    nMyStartingHeight(nMyStartingHeightIn),
-    nSendVersion(0)
+    filterInventoryKnown(50000, 0.000001)
 {
     nServices = NODE_NONE;
     nServicesExpected = NODE_NONE;

--- a/src/net.h
+++ b/src/net.h
@@ -559,14 +559,36 @@ public:
 /** Information about a peer */
 class CNode
 {
+private:
     friend class CConnman;
+
+    const uint64_t nLocalHostNonce;
+
+    const ServiceFlags nLocalServices;      ///< Services offered to this peer
+    const int nMyStartingHeight;
+    int nSendVersion;
+    std::list<CNetMessage> vRecvMsg;        ///< Used only by SocketHandler thread
+
+    mutable CCriticalSection cs_addrName;
+    std::string addrName;
+
+    CService addrLocal;
+    mutable CCriticalSection cs_addrLocal;
+
+    CNode(const CNode&);
+    void operator=(const CNode&);
+
+protected:
+    mapMsgCmdSize mapSendBytesPerMsgCmd;
+    mapMsgCmdSize mapRecvBytesPerMsgCmd;
+
 public:
     // socket
     std::atomic<ServiceFlags> nServices;
     ServiceFlags nServicesExpected;
     SOCKET hSocket;
-    size_t nSendSize; // total size of all vSendMsg entries
-    size_t nSendOffset; // offset inside the first vSendMsg already sent
+    size_t nSendSize;                       ///< total size of all vSendMsg entries
+    size_t nSendOffset;                     ///< offset inside the first vSendMsg already sent
     uint64_t nSendBytes;
     std::deque<std::vector<unsigned char>> vSendMsg;
     CCriticalSection cs_vSend;
@@ -589,25 +611,31 @@ public:
     std::atomic<int64_t> nTimeOffset;
     const CAddress addr;
     std::atomic<int> nVersion;
-    // strSubVer is whatever byte array we read from the wire. However, this field is intended
-    // to be printed out, displayed to humans in various forms and so on. So we sanitize it and
-    // store the sanitized version in cleanSubVer. The original should be used when dealing with
-    // the network or wire types and the cleaned string used when displayed or logged.
-    std::string strSubVer, cleanSubVer;
-    CCriticalSection cs_SubVer; // used for both cleanSubVer and strSubVer
-    bool fWhitelisted; // This peer can bypass DoS banning.
-    bool fFeeler; // If true this node is being used as a short lived feeler.
+    /**
+     * strSubVer is whatever byte array we read from the wire. However, this field is intended
+     * to be printed out, displayed to humans in various forms and so on. So we sanitize it and
+     * store the sanitized version in cleanSubVer. The original should be used when dealing with
+     * the network or wire types and the cleaned string used when displayed or logged.
+     */
+    std::string strSubVer;
+    std::string cleanSubVer;
+    CCriticalSection cs_SubVer;             ///< Used for both cleanSubVer and strSubVer
+    bool fWhitelisted;                      ///< This peer can bypass DoS banning.
+    bool fFeeler;                           ///< If true this node is being used as a short lived feeler.
     bool fOneShot;
     bool fAddnode;
     bool fClient;
     const bool fInbound;
     std::atomic_bool fSuccessfullyConnected;
     std::atomic_bool fDisconnect;
-    // We use fRelayTxes for two purposes -
-    // a) it allows us to not relay tx invs before receiving the peer's version message
-    // b) the peer may tell us in its version message that we should not relay tx invs
-    //    unless it loads a bloom filter.
-    bool fRelayTxes; //protected by cs_filter
+    /**
+     * We use fRelayTxes for two purposes -
+     * a) it allows us to not relay tx invs before receiving the peer's version message
+     * b) the peer may tell us in its version message that we should not relay tx invs
+     *    unless it loads a bloom filter.
+     * Protected by cs_filter.
+     */
+    bool fRelayTxes;
     bool fSentAddr;
     CSemaphoreGrant grantOutbound;
     CCriticalSection cs_filter;
@@ -618,12 +646,7 @@ public:
     const uint64_t nKeyedNetGroup;
     std::atomic_bool fPauseRecv;
     std::atomic_bool fPauseSend;
-protected:
 
-    mapMsgCmdSize mapSendBytesPerMsgCmd;
-    mapMsgCmdSize mapRecvBytesPerMsgCmd;
-
-public:
     uint256 hashContinue;
     std::atomic<int> nStartingHeight;
 
@@ -635,24 +658,28 @@ public:
     int64_t nNextAddrSend;
     int64_t nNextLocalAddrSend;
 
-    // inventory based relay
-    CRollingBloomFilter filterInventoryKnown;
-    // Set of transaction ids we still have to announce.
-    // They are sorted by the mempool before relay, so the order is not important.
+    CRollingBloomFilter filterInventoryKnown; ///< inventory based relay
+    /**
+     * Set of transaction ids we still have to announce.
+     * They are sorted by the mempool before relay, so the order is not important.
+     */
     std::set<uint256> setInventoryTxToSend;
-    // List of block ids we still have announce.
-    // There is no final sorting before sending, as they are always sent immediately
-    // and in the order requested.
+    /**
+     * List of block ids we still have to announce.
+     * There is no final sorting before sending, as they are always sent immediately
+     * and in the order requested.
+     */
     std::vector<uint256> vInventoryBlockToSend;
     CCriticalSection cs_inventory;
     std::set<uint256> setAskFor;
     std::multimap<int64_t, CInv> mapAskFor;
     int64_t nNextInvSend;
-    // Used for headers announcements - unfiltered blocks to relay
-    // Also protected by cs_inventory
+    /**
+     * Used for headers announcements - unfiltered blocks to relay.
+     * Also protected by cs_inventory
+     */
     std::vector<uint256> vBlockHashesToAnnounce;
-    // Used for BIP35 mempool sending, also protected by cs_inventory
-    bool fSendMempool;
+    bool fSendMempool;                      ///< Used for BIP35 mempool sending, also protected by cs_inventory
 
     // Last time a "MEMPOOL" request was serviced.
     std::atomic<int64_t> timeLastMempoolReq;
@@ -662,18 +689,12 @@ public:
     std::atomic<int64_t> nLastTXTime;
 
     // Ping time measurement:
-    // The pong reply we're expecting, or 0 if no pong expected.
-    std::atomic<uint64_t> nPingNonceSent;
-    // Time (in usec) the last ping was sent, or 0 if no ping was ever sent.
-    std::atomic<int64_t> nPingUsecStart;
-    // Last measured round-trip time.
-    std::atomic<int64_t> nPingUsecTime;
-    // Best measured round-trip time.
-    std::atomic<int64_t> nMinPingUsecTime;
-    // Whether a ping is requested.
-    std::atomic<bool> fPingQueued;
-    // Minimum fee rate with which to filter inv's to this node
-    CAmount minFeeFilter;
+    std::atomic<uint64_t> nPingNonceSent;   ///< The pong reply we're expecting, or 0 if no pong expected.
+    std::atomic<int64_t> nPingUsecStart;    ///< Time (in usec) the last ping was sent, or 0 if no ping was ever sent.
+    std::atomic<int64_t> nPingUsecTime;     ///< Last measured round-trip time.
+    std::atomic<int64_t> nMinPingUsecTime;  ///< Best measured round-trip time.
+    std::atomic<bool> fPingQueued;          ///< Whether a ping is requested.
+    CAmount minFeeFilter;                   ///< Minimum fee rate with which to filter inv's to this node
     CCriticalSection cs_feeFilter;
     CAmount lastSentFeeFilter;
     int64_t nextSendTimeFeeFilter;
@@ -681,77 +702,26 @@ public:
     CNode(NodeId id, ServiceFlags nLocalServicesIn, int nMyStartingHeightIn, SOCKET hSocketIn, const CAddress &addrIn, uint64_t nKeyedNetGroupIn, uint64_t nLocalHostNonceIn, const std::string &addrNameIn = "", bool fInboundIn = false);
     ~CNode();
 
-private:
-    CNode(const CNode&);
-    void operator=(const CNode&);
+    NodeId GetId()                        const { return id; }
+    uint64_t GetLocalNonce()              const { return nLocalHostNonce; }
+    int GetMyStartingHeight()             const { return nMyStartingHeight; }
+    ServiceFlags GetLocalServices()       const { return nLocalServices; }
 
-
-    const uint64_t nLocalHostNonce;
-    // Services offered to this peer
-    const ServiceFlags nLocalServices;
-    const int nMyStartingHeight;
-    int nSendVersion;
-    std::list<CNetMessage> vRecvMsg;  // Used only by SocketHandler thread
-
-    mutable CCriticalSection cs_addrName;
-    std::string addrName;
-
-    CService addrLocal;
-    mutable CCriticalSection cs_addrLocal;
-public:
-
-    NodeId GetId() const {
-      return id;
-    }
-
-    uint64_t GetLocalNonce() const {
-      return nLocalHostNonce;
-    }
-
-    int GetMyStartingHeight() const {
-      return nMyStartingHeight;
-    }
-
-    int GetRefCount()
-    {
-        assert(nRefCount >= 0);
-        return nRefCount;
-    }
+    int GetRefCount()                           { assert(nRefCount >= 0); return nRefCount; }
+    void SetRecvVersion(int nVersionIn)         { nRecvVersion = nVersionIn; }
+    int GetRecvVersion()                        { return nRecvVersion; }
+    CNode* AddRef()                             { nRefCount++; return this; }
+    void Release()                              { nRefCount--; }
+    void AddAddressKnown(const CAddress& _addr) { addrKnown.insert(_addr.GetKey()); }
+    void AddInventoryKnown(const CInv& inv)     { LOCK(cs_inventory); filterInventoryKnown.insert(inv.hash); }
 
     bool ReceiveMsgBytes(const char *pch, unsigned int nBytes, bool& complete);
-
-    void SetRecvVersion(int nVersionIn)
-    {
-        nRecvVersion = nVersionIn;
-    }
-    int GetRecvVersion()
-    {
-        return nRecvVersion;
-    }
     void SetSendVersion(int nVersionIn);
     int GetSendVersion() const;
 
     CService GetAddrLocal() const;
     //! May not be called more than once
     void SetAddrLocal(const CService& addrLocalIn);
-
-    CNode* AddRef()
-    {
-        nRefCount++;
-        return this;
-    }
-
-    void Release()
-    {
-        nRefCount--;
-    }
-
-
-
-    void AddAddressKnown(const CAddress& _addr)
-    {
-        addrKnown.insert(_addr.GetKey());
-    }
 
     void PushAddress(const CAddress& _addr, FastRandomContext &insecure_rand)
     {
@@ -764,15 +734,6 @@ public:
             } else {
                 vAddrToSend.push_back(_addr);
             }
-        }
-    }
-
-
-    void AddInventoryKnown(const CInv& inv)
-    {
-        {
-            LOCK(cs_inventory);
-            filterInventoryKnown.insert(inv.hash);
         }
     }
 
@@ -798,21 +759,12 @@ public:
 
     void CloseSocketDisconnect();
 
-    void copyStats(CNodeStats &stats);
-
-    ServiceFlags GetLocalServices() const
-    {
-        return nLocalServices;
-    }
+    void CopyStats(CNodeStats &stats);
 
     std::string GetAddrName() const;
     //! Sets the addrName only if it was not previously set
     void MaybeSetAddrName(const std::string& addrNameIn);
 };
-
-
-
-
 
 /** Return a timestamp in the future (in microseconds) for exponentially distributed events. */
 int64_t PoissonNextSend(int64_t nNow, int average_interval_seconds);


### PR DESCRIPTION
This PR changes no code, functionality wise. It does:
* move things around to avoid jumping between `public:` and `private:` multiple times,
* rename one method which was awkwardly first-letter-lower-case (`copyStats`),
* shrink one-liner methods into one line,
* switch to Doxygen compatible comments, sometimes moving comments to be same-line.
