### PR TITLE
[Wallet] FundRawTransaction accepts preset non-wallet inputs

### DIFF
--- a/src/bench/coin_selection.cpp
+++ b/src/bench/coin_selection.cpp
@@ -48,7 +48,7 @@ static void CoinSelection(benchmark::State& state)
             addCoin(1000 * COIN, wallet, vCoins);
         addCoin(3 * COIN, wallet, vCoins);
 
-        std::set<std::pair<const CWalletTx*, unsigned int> > setCoinsRet;
+        std::set<CInputCoin> setCoinsRet;
         CAmount nValueRet;
         bool success = wallet.SelectCoinsMinConf(1003 * COIN, 1, 6, 0, vCoins, setCoinsRet, nValueRet);
         assert(success);

--- a/src/wallet/coincontrol.h
+++ b/src/wallet/coincontrol.h
@@ -7,6 +7,7 @@
 
 #include "primitives/transaction.h"
 #include "wallet/wallet.h"
+#include <map>
 
 /** Coin Control Features. */
 class CCoinControl
@@ -76,8 +77,23 @@ public:
         vOutpoints.assign(setSelected.begin(), setSelected.end());
     }
 
+    void AddKnownCoins(const CInputCoin& coin)
+    {
+        knownCoins.insert(std::make_pair(coin.outpoint, coin));
+    }
+
+    bool FindKnownCoin(const COutPoint& outpoint, CInputCoin& foundCoin) const
+    {
+        auto it = knownCoins.find(outpoint);
+        if (it == knownCoins.end())
+            return false;
+        foundCoin = it->second;
+        return true;
+    }
 private:
     std::set<COutPoint> setSelected;
+    //! A map of known UTXO
+    std::map<COutPoint, CInputCoin> knownCoins;
 };
 
 #endif // BITCOIN_WALLET_COINCONTROL_H

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2796,14 +2796,14 @@ UniValue fundrawtransaction(const JSONRPCRequest& request)
 int64_t CalculateMaximumSignedTxSize(const CTransaction &tx, CWallet &wallet)
 {
     CMutableTransaction txNew(tx);
-    std::vector<std::pair<CWalletTx*, unsigned int>> vCoins;
+    std::vector<CInputCoin> vCoins;
     // Look up the inputs.  We should have already checked that this transaction
     // IsAllFromMe(ISMINE_SPENDABLE), so every input should already be in our
     // wallet, with a valid index into the vout array.
     for (auto& input : tx.vin) {
         const auto mi = wallet.mapWallet.find(input.prevout.hash);
         assert(mi != wallet.mapWallet.end() && input.prevout.n < mi->second.tx->vout.size());
-        vCoins.emplace_back(std::make_pair(&(mi->second), input.prevout.n));
+        vCoins.emplace_back(CInputCoin(&(mi->second), input.prevout.n));
     }
     if (!wallet.DummySignTx(txNew, vCoins)) {
         // This should never happen, because IsAllFromMe(ISMINE_SPENDABLE)

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -19,6 +19,7 @@
 #include "util.h"
 #include "utilmoneystr.h"
 #include "wallet.h"
+#include "coincontrol.h"
 #include "walletdb.h"
 
 #include <stdint.h>
@@ -2766,7 +2767,14 @@ UniValue fundrawtransaction(const JSONRPCRequest& request)
     CAmount nFeeOut;
     std::string strFailReason;
 
-    if (!pwallet->FundTransaction(tx, nFeeOut, overrideEstimatedFeerate, feeRate, changePosition, strFailReason, includeWatching, lockUnspents, setSubtractFeeFromOutputs, reserveChangeKey, changeAddress)) {
+    CCoinControl coinControl;
+    coinControl.destChange = changeAddress;
+    coinControl.fAllowOtherInputs = true;
+    coinControl.fAllowWatchOnly = includeWatching;
+    coinControl.fOverrideFeeRate = overrideEstimatedFeerate;
+    coinControl.nFeeRate = feeRate;
+
+    if (!pwallet->FundTransaction(tx, nFeeOut, coinControl, changePosition, strFailReason, lockUnspents, setSubtractFeeFromOutputs, reserveChangeKey)) {
         throw JSONRPCError(RPC_WALLET_ERROR, strFailReason);
     }
 

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -29,7 +29,7 @@ extern UniValue importmulti(const JSONRPCRequest& request);
 
 std::vector<std::unique_ptr<CWalletTx>> wtxn;
 
-typedef std::set<std::pair<const CWalletTx*,unsigned int> > CoinSet;
+typedef std::set<CInputCoin> CoinSet;
 
 BOOST_FIXTURE_TEST_SUITE(wallet_tests, WalletTestingSetup)
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -64,10 +64,10 @@ const uint256 CMerkleTx::ABANDON_HASH(uint256S("00000000000000000000000000000000
 
 struct CompareValueOnly
 {
-    bool operator()(const std::pair<CAmount, CInputCoin>& t1,
-                    const std::pair<CAmount, CInputCoin>& t2) const
+    bool operator()(const CInputCoin& t1,
+                    const CInputCoin& t2) const
     {
-        return t1.first < t2.first;
+        return t1.txout.nValue < t2.txout.nValue;
     }
 };
 
@@ -2031,7 +2031,7 @@ void CWallet::AvailableCoins(std::vector<COutput>& vCoins, bool fOnlySafe, const
     }
 }
 
-static void ApproximateBestSubset(const std::vector<std::pair<CAmount, CInputCoin > >& vValue, const CAmount& nTotalLower, const CAmount& nTargetValue,
+static void ApproximateBestSubset(const std::vector<CInputCoin>& vValue, const CAmount& nTotalLower, const CAmount& nTargetValue,
                                   std::vector<char>& vfBest, CAmount& nBest, int iterations = 1000)
 {
     std::vector<char> vfIncluded;
@@ -2058,7 +2058,7 @@ static void ApproximateBestSubset(const std::vector<std::pair<CAmount, CInputCoi
                 //the selection random.
                 if (nPass == 0 ? insecure_rand.rand32()&1 : !vfIncluded[i])
                 {
-                    nTotal += vValue[i].first;
+                    nTotal += vValue[i].txout.nValue;
                     vfIncluded[i] = true;
                     if (nTotal >= nTargetValue)
                     {
@@ -2068,7 +2068,7 @@ static void ApproximateBestSubset(const std::vector<std::pair<CAmount, CInputCoi
                             nBest = nTotal;
                             vfBest = vfIncluded;
                         }
-                        nTotal -= vValue[i].first;
+                        nTotal -= vValue[i].txout.nValue;
                         vfIncluded[i] = false;
                     }
                 }
@@ -2084,9 +2084,8 @@ bool CWallet::SelectCoinsMinConf(const CAmount& nTargetValue, const int nConfMin
     nValueRet = 0;
 
     // List of values less than target
-    std::pair<CAmount, CInputCoin> coinLowestLarger;
-    coinLowestLarger.first = std::numeric_limits<CAmount>::max();
-    std::vector<std::pair<CAmount, CInputCoin>> vValue;
+    CInputCoin coinLowestLarger;
+    std::vector<CInputCoin> vValue;
     CAmount nTotalLower = 0;
 
     random_shuffle(vCoins.begin(), vCoins.end(), GetRandInt);
@@ -2105,14 +2104,14 @@ bool CWallet::SelectCoinsMinConf(const CAmount& nTargetValue, const int nConfMin
             continue;
 
         int i = output.i;
-        CAmount n = pcoin->tx->vout[i].nValue;
 
-        std::pair<CAmount, CInputCoin> coin = std::make_pair(n, CInputCoin(pcoin, i));
+        CInputCoin coin = CInputCoin(pcoin, i);
+        CAmount n = coin.txout.nValue;
 
         if (n == nTargetValue)
         {
-            setCoinsRet.insert(coin.second);
-            nValueRet += coin.first;
+            setCoinsRet.insert(coin);
+            nValueRet += n;
             return true;
         }
         else if (n < nTargetValue + MIN_CHANGE)
@@ -2120,7 +2119,7 @@ bool CWallet::SelectCoinsMinConf(const CAmount& nTargetValue, const int nConfMin
             vValue.push_back(coin);
             nTotalLower += n;
         }
-        else if (n < coinLowestLarger.first)
+        else if (coinLowestLarger.IsNull() || n < coinLowestLarger.txout.nValue)
         {
             coinLowestLarger = coin;
         }
@@ -2130,18 +2129,18 @@ bool CWallet::SelectCoinsMinConf(const CAmount& nTargetValue, const int nConfMin
     {
         for (unsigned int i = 0; i < vValue.size(); ++i)
         {
-            setCoinsRet.insert(vValue[i].second);
-            nValueRet += vValue[i].first;
+            setCoinsRet.insert(vValue[i]);
+            nValueRet += vValue[i].txout.nValue;
         }
         return true;
     }
 
     if (nTotalLower < nTargetValue)
     {
-        if (coinLowestLarger.second.IsNull())
+        if (coinLowestLarger.IsNull())
             return false;
-        setCoinsRet.insert(coinLowestLarger.second);
-        nValueRet += coinLowestLarger.first;
+        setCoinsRet.insert(coinLowestLarger);
+        nValueRet += coinLowestLarger.txout.nValue;
         return true;
     }
 
@@ -2157,25 +2156,25 @@ bool CWallet::SelectCoinsMinConf(const CAmount& nTargetValue, const int nConfMin
 
     // If we have a bigger coin and (either the stochastic approximation didn't find a good solution,
     //                                   or the next bigger coin is closer), return the bigger coin
-    if (!coinLowestLarger.second.IsNull() &&
-        ((nBest != nTargetValue && nBest < nTargetValue + MIN_CHANGE) || coinLowestLarger.first <= nBest))
+    if (!coinLowestLarger.IsNull() &&
+        ((nBest != nTargetValue && nBest < nTargetValue + MIN_CHANGE) || coinLowestLarger.txout.nValue <= nBest))
     {
-        setCoinsRet.insert(coinLowestLarger.second);
-        nValueRet += coinLowestLarger.first;
+        setCoinsRet.insert(coinLowestLarger);
+        nValueRet += coinLowestLarger.txout.nValue;
     }
     else {
         for (unsigned int i = 0; i < vValue.size(); i++)
             if (vfBest[i])
             {
-                setCoinsRet.insert(vValue[i].second);
-                nValueRet += vValue[i].first;
+                setCoinsRet.insert(vValue[i]);
+                nValueRet += vValue[i].txout.nValue;
             }
 
         if (LogAcceptCategory(BCLog::SELECTCOINS)) {
             LogPrint(BCLog::SELECTCOINS, "SelectCoins() best subset: ");
             for (unsigned int i = 0; i < vValue.size(); i++) {
                 if (vfBest[i]) {
-                    LogPrint(BCLog::SELECTCOINS, "%s ", FormatMoney(vValue[i].first));
+                    LogPrint(BCLog::SELECTCOINS, "%s ", FormatMoney(vValue[i].txout.nValue));
                 }
             }
             LogPrint(BCLog::SELECTCOINS, "total %s\n", FormatMoney(nBest));

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2255,7 +2255,7 @@ bool CWallet::SelectCoins(const std::vector<COutput>& vAvailableCoins, const CAm
     return res;
 }
 
-bool CWallet::FundTransaction(CMutableTransaction& tx, CAmount& nFeeRet, bool overrideEstimatedFeeRate, const CFeeRate& specificFeeRate, int& nChangePosInOut, std::string& strFailReason, bool includeWatching, bool lockUnspents, const std::set<int>& setSubtractFeeFromOutputs, bool keepReserveKey, const CTxDestination& destChange)
+bool CWallet::FundTransaction(CMutableTransaction& tx, CAmount& nFeeRet, CCoinControl& coinControl, int& nChangePosInOut, std::string& strFailReason, bool lockUnspents, const std::set<int>& setSubtractFeeFromOutputs, bool keepReserveKey)
 {
     std::vector<CRecipient> vecSend;
 
@@ -2266,13 +2266,6 @@ bool CWallet::FundTransaction(CMutableTransaction& tx, CAmount& nFeeRet, bool ov
         CRecipient recipient = {txOut.scriptPubKey, txOut.nValue, setSubtractFeeFromOutputs.count(idx) == 1};
         vecSend.push_back(recipient);
     }
-
-    CCoinControl coinControl;
-    coinControl.destChange = destChange;
-    coinControl.fAllowOtherInputs = true;
-    coinControl.fAllowWatchOnly = includeWatching;
-    coinControl.fOverrideFeeRate = overrideEstimatedFeeRate;
-    coinControl.nFeeRate = specificFeeRate;
 
     BOOST_FOREACH(const CTxIn& txin, tx.vin)
         coinControl.Select(txin.prevout);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1164,14 +1164,16 @@ bool CWallet::DummySignTx(CMutableTransaction &txNew, const ContainerType &coins
     {
         const CScript& scriptPubKey = coin.txout.scriptPubKey;
         SignatureData sigdata;
-
-        if (!ProduceSignature(DummySignatureCreator(this), scriptPubKey, sigdata))
-        {
-            return false;
-        } else {
-            UpdateTransaction(txNew, nIn, sigdata);
+        auto ismine = IsMine(coin.txout);
+        if (ismine == ISMINE_SPENDABLE || ismine == ISMINE_WATCH_SOLVABLE)
+        { 
+            if (!ProduceSignature(DummySignatureCreator(this), scriptPubKey, sigdata))
+            {
+                return false;
+            } else {
+                UpdateTransaction(txNew, nIn, sigdata);
+            }
         }
-
         nIn++;
     }
     return true;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -866,7 +866,7 @@ public:
      * Insert additional inputs into the transaction by
      * calling CreateTransaction();
      */
-    bool FundTransaction(CMutableTransaction& tx, CAmount& nFeeRet, bool overrideEstimatedFeeRate, const CFeeRate& specificFeeRate, int& nChangePosInOut, std::string& strFailReason, bool includeWatching, bool lockUnspents, const std::set<int>& setSubtractFeeFromOutputs, bool keepReserveKey = true, const CTxDestination& destChange = CNoDestination());
+    bool FundTransaction(CMutableTransaction& tx, CAmount& nFeeRet, CCoinControl& coinControl, int& nChangePosInOut, std::string& strFailReason, bool lockUnspents, const std::set<int>& setSubtractFeeFromOutputs, bool keepReserveKey = true);
 
     /**
      * Create a new transaction paying the recipients with a set of coins

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -92,7 +92,6 @@ enum WalletFeature
     FEATURE_LATEST = FEATURE_COMPRPUBKEY // HD is optional, use FEATURE_COMPRPUBKEY as latest version
 };
 
-
 /** A key pool entry */
 class CKeyPool
 {
@@ -474,8 +473,38 @@ public:
     std::set<uint256> GetConflicts() const;
 };
 
+class CInputCoin {
+public:
+    CInputCoin()
+    {
+    }
+    CInputCoin(const CWalletTx* walletTx, unsigned int i)
+    {
+        if (walletTx != nullptr && i < walletTx->tx->vout.size())
+        {
+            outpoint = COutPoint(walletTx->GetHash(), i);
+            txout = walletTx->tx->vout[i];
+        }
+    }
+    bool IsNull() const
+    {
+        return outpoint.IsNull() && txout.IsNull();
+    }
+    COutPoint outpoint;
+    CTxOut txout;
 
+    bool operator<(const CInputCoin& rhs) const {
+        return outpoint < rhs.outpoint;
+    }
 
+    bool operator!=(const CInputCoin& rhs) const {
+        return outpoint != rhs.outpoint;
+    }
+
+    bool operator==(const CInputCoin& rhs) const {
+        return outpoint == rhs.outpoint;
+    }
+};
 
 class COutput
 {
@@ -632,7 +661,7 @@ private:
      * all coins from coinControl are selected; Never select unconfirmed coins
      * if they are not ours
      */
-    bool SelectCoins(const std::vector<COutput>& vAvailableCoins, const CAmount& nTargetValue, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoinsRet, CAmount& nValueRet, const CCoinControl *coinControl = NULL) const;
+    bool SelectCoins(const std::vector<COutput>& vAvailableCoins, const CAmount& nTargetValue, std::set<CInputCoin>& setCoinsRet, CAmount& nValueRet, const CCoinControl *coinControl = NULL) const;
 
     CWalletDB *pwalletdbEncryption;
 
@@ -780,7 +809,7 @@ public:
      * completion the coin set and corresponding actual target value is
      * assembled
      */
-    bool SelectCoinsMinConf(const CAmount& nTargetValue, int nConfMine, int nConfTheirs, uint64_t nMaxAncestors, std::vector<COutput> vCoins, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoinsRet, CAmount& nValueRet) const;
+    bool SelectCoinsMinConf(const CAmount& nTargetValue, int nConfMine, int nConfTheirs, uint64_t nMaxAncestors, std::vector<COutput> vCoins, std::set<CInputCoin>& setCoinsRet, CAmount& nValueRet) const;
 
     bool IsSpent(const uint256& hash, unsigned int n) const;
 
@@ -1122,7 +1151,7 @@ public:
 };
 
 // Helper for producing a bunch of max-sized low-S signatures (eg 72 bytes)
-// ContainerType is meant to hold pair<CWalletTx *, int>, and be iterable
+// ContainerType is meant to hold CInputCoin, and be iterable
 // so that each entry corresponds to each vIn, in order.
 template <typename ContainerType>
 bool CWallet::DummySignTx(CMutableTransaction &txNew, const ContainerType &coins)
@@ -1131,7 +1160,7 @@ bool CWallet::DummySignTx(CMutableTransaction &txNew, const ContainerType &coins
     int nIn = 0;
     for (const auto& coin : coins)
     {
-        const CScript& scriptPubKey = coin.first->tx->vout[coin.second].scriptPubKey;
+        const CScript& scriptPubKey = coin.txout.scriptPubKey;
         SignatureData sigdata;
 
         if (!ProduceSignature(DummySignatureCreator(this), scriptPubKey, sigdata))

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -891,6 +891,8 @@ public:
     CAmount GetUnconfirmedWatchOnlyBalance() const;
     CAmount GetImmatureWatchOnlyBalance() const;
 
+    bool FindCoin(const COutPoint& outpoint, CInputCoin& foundCoin);
+
     /**
      * Insert additional inputs into the transaction by
      * calling CreateTransaction();


### PR DESCRIPTION
This PR makes it possible to call `FundRawTransaction` with pre filled inputs not belonging to the wallet.
This is very useful for AnyOneCanPay scenario, where one of a third party only cover part of a transaction.

The necessary information to complete the transaction is taken from of the mempool and coinview.

A follow up PR might allow the client of this API to pass previous `TxOuts` corresponding to the inputs.  This would be useful in scenario involving 2nd layer protocols, where the the inputs's of the transaction have not broadcasted yet.

A typical example would involves Alice and Bob wanting to fund 0.5 each to the payment channel. Alice would give her input, and Bob would be able to complete the missing amount via `FundRawTransaction`.

I personally need this PR for an atomic swap of colored coins. The user wants to exchange Bitcoin against some of his colored coins, to do so, he put his colored coin input into the transaction + the bitcoin outputs, and pass it to our service. Our service would then check that the rate is correct, and cover the bitcoin outputs with his own inputs by using a call to `FundRawTransaction`.