### PR TITLE
Remove sources of unreliablility in extended functional tests

### DIFF
--- a/test/functional/bip9-softforks.py
+++ b/test/functional/bip9-softforks.py
@@ -200,16 +200,14 @@ class BIP9SoftForksTest(ComparisonTestFramework):
         yield TestInstance([[block, False]])
 
         # Restart all
-        self.test.block_store.close()
+        self.test.clear_all_connections()
         stop_nodes(self.nodes)
-        shutil.rmtree(self.options.tmpdir)
+        shutil.rmtree(self.options.tmpdir + "/node0")
         self.setup_chain()
         self.setup_network()
-        self.test.block_store = BlockStore(self.options.tmpdir)
-        self.test.clear_all_connections()
         self.test.add_all_connections(self.nodes)
-        NetworkThread().start() # Start up network handling in another thread
-
+        NetworkThread().start()
+        self.test.test_nodes[0].wait_for_verack()
 
     def get_tests(self):
         for test in itertools.chain(


### PR DESCRIPTION
This PR removes two sources of unreliability that were causing extended test cases to fail intermittently on travis:

- bip9-softforks stop-starts bitcoind twice, but does not wait for the p2p connection to mininode to re-open. This would lead to race conditions where the following call to getblocktemplate() would sometimes fail because there were no p2p connections open to the node. This commit also removes the shutil.rmtree() call that was blatting the test_framework.log file.
- forknotify asserts that an alert has been written to a file and fails immediately if the file is empty. This would lead to race conditions where the assert would sometimes be hit before bitcoind had written to the file.