### PR TITLE
[Qt] Don't add arguments of sensitive command to console window

### DIFF
--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -825,7 +825,7 @@ void RPCConsole::on_lineEdit_returnPressed()
 
         cmdBeforeBrowsing = QString();
 
-        message(CMD_REQUEST, cmd);
+        message(CMD_REQUEST, QString::fromStdString(strFilteredCmd));
         Q_EMIT cmdRequest(cmd);
 
         cmd = QString::fromStdString(strFilteredCmd);


### PR DESCRIPTION
At the moment, we hide sensitive command arguments from the console history but not from the console window.
This tiny change will also hide the arguments from the console window.

Especially for "importmulti", this may be a little bit annoying because if one executes a command with invalid arguments, you need to start type in everything again.

Ideally we would only filter the command if sensitive arguments have been used (complicated to implement).

List of sensitive commands:
```cpp
const QStringList historyFilter = QStringList()
    << "importprivkey"
    << "importmulti"
    << "signmessagewithprivkey"
    << "signrawtransaction"
    << "walletpassphrase"
    << "walletpassphrasechange"
    << "encryptwallet";

}
```