### PR TITLE
Make qt wallet test compatible with qt4

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -122,6 +122,7 @@ QT_MOC_CPP = \
   qt/moc_bitcoinamountfield.cpp \
   qt/moc_bitcoingui.cpp \
   qt/moc_bitcoinunits.cpp \
+  qt/moc_callback.cpp \
   qt/moc_clientmodel.cpp \
   qt/moc_coincontroldialog.cpp \
   qt/moc_coincontroltreewidget.cpp \
@@ -167,6 +168,7 @@ BITCOIN_MM = \
 QT_MOC = \
   qt/bitcoin.moc \
   qt/bitcoinamountfield.moc \
+  qt/callback.moc \
   qt/intro.moc \
   qt/overviewpage.moc \
   qt/rpcconsole.moc
@@ -189,6 +191,7 @@ BITCOIN_QT_H = \
   qt/bitcoinamountfield.h \
   qt/bitcoingui.h \
   qt/bitcoinunits.h \
+  qt/callback.h \
   qt/clientmodel.h \
   qt/coincontroldialog.h \
   qt/coincontroltreewidget.h \

--- a/src/qt/callback.h
+++ b/src/qt/callback.h
@@ -1,0 +1,30 @@
+#ifndef BITCOIN_QT_CALLBACK_H
+#define BITCOIN_QT_CALLBACK_H
+
+#include <QObject>
+
+class Callback : public QObject
+{
+    Q_OBJECT
+public Q_SLOTS:
+    virtual void call() = 0;
+};
+
+template <typename F>
+class FunctionCallback : public Callback
+{
+    F f;
+
+public:
+    FunctionCallback(F f_) : f(std::move(f_)) {}
+    ~FunctionCallback() override {}
+    void call() override { f(this); }
+};
+
+template <typename F>
+FunctionCallback<F>* makeCallback(F f)
+{
+    return new FunctionCallback<F>(std::move(f));
+}
+
+#endif // BITCOIN_QT_CALLBACK_H

--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -1,6 +1,7 @@
 #include "wallettests.h"
 
 #include "qt/bitcoinamountfield.h"
+#include "qt/callback.h"
 #include "qt/optionsmodel.h"
 #include "qt/platformstyle.h"
 #include "qt/qvalidatedlineedit.h"
@@ -22,9 +23,7 @@ namespace
 //! Press "Yes" button in modal send confirmation dialog.
 void ConfirmSend()
 {
-    QTimer* timer = new QTimer;
-    timer->setSingleShot(true);
-    QObject::connect(timer, &QTimer::timeout, []() {
+    QTimer::singleShot(0, makeCallback([](Callback* callback) {
         for (QWidget* widget : QApplication::topLevelWidgets()) {
             if (widget->inherits("SendConfirmationDialog")) {
                 SendConfirmationDialog* dialog = qobject_cast<SendConfirmationDialog*>(widget);
@@ -33,8 +32,8 @@ void ConfirmSend()
                 button->click();
             }
         }
-    });
-    timer->start(0);
+        delete callback;
+    }), SLOT(call()));
 }
 
 //! Send coins to address and return txid.


### PR DESCRIPTION
Unlike Qt5, the Qt4 signals implementation doesn't allow a signal to be
directly connected to a c++ lambda expression. Work around this by defining a
Callback QObject with a virtual method that can forward calls to a closure.

The Qt4 error was reported by @pstratem in https://github.com/bitcoin/bitcoin/pull/10039#issuecomment-289248763