### PR TITLE
linearize script: Option to use RPC cookie

### DIFF
--- a/contrib/linearize/README.md
+++ b/contrib/linearize/README.md
@@ -7,7 +7,8 @@ run using Python 3 but are compatible with Python 2.
     $ ./linearize-hashes.py linearize.cfg > hashlist.txt
 
 Required configuration file settings for linearize-hashes:
-* RPC: `rpcuser`, `rpcpassword`
+* RPC: `datadir` (Required if `rpcuser` and `rpcpassword` are not specified)
+* RPC: `rpcuser`, `rpcpassword` (Required if `datadir` is not specified)
 
 Optional config file setting for linearize-hashes:
 * RPC: `host`  (Default: `127.0.0.1`)

--- a/contrib/linearize/example-linearize.cfg
+++ b/contrib/linearize/example-linearize.cfg
@@ -1,6 +1,7 @@
 # bitcoind RPC settings (linearize-hashes)
 rpcuser=someuser
 rpcpassword=somepassword
+#datadir=~/.bitcoin
 host=127.0.0.1
 port=8332
 #port=18332


### PR DESCRIPTION
This PR adds the a `datadir` option to the linearize configuration file to allow linearize-hashes to look for and use the RPC cookie file in the datadir. It will still allow rpcuser and rpcpassword to be specified and those options will take precendence if both rpcuser/pass and datadir config options are set.

closes #10103 