### PR TITLE
Remove SingleNodeConnCB

### DIFF
--- a/test/functional/assumevalid.py
+++ b/test/functional/assumevalid.py
@@ -40,17 +40,14 @@ from test_framework.mininode import (CBlockHeader,
                                      CTxOut,
                                      NetworkThread,
                                      NodeConn,
-                                     SingleNodeConnCB,
+                                     NodeConnCB,
                                      msg_block,
                                      msg_headers)
 from test_framework.script import (CScript, OP_TRUE)
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (start_node, p2p_port, assert_equal)
 
-class BaseNode(SingleNodeConnCB):
-    def __init__(self):
-        super().__init__()
-
+class BaseNode(NodeConnCB):
     def send_header_for_blocks(self, new_blocks):
         headers_message = msg_headers()
         headers_message.headers = [CBlockHeader(b) for b in new_blocks]

--- a/test/functional/maxblocksinflight.py
+++ b/test/functional/maxblocksinflight.py
@@ -17,7 +17,6 @@ from test_framework.util import *
 MAX_REQUESTS = 128
 
 class TestManager(NodeConnCB):
-    # set up NodeConnCB callbacks, overriding base class
     def on_getdata(self, conn, message):
         self.log.debug("got getdata %s" % repr(message))
         # Log the requests
@@ -30,11 +29,8 @@ class TestManager(NodeConnCB):
         if not self.disconnectOkay:
             raise EarlyDisconnectError(0)
 
-    def __init__(self):
-        NodeConnCB.__init__(self)
-
     def add_new_connection(self, connection):
-        self.connection = connection
+        super().add_connection(connection)
         self.blockReqCounts = {}
         self.disconnectOkay = False
 

--- a/test/functional/maxuploadtarget.py
+++ b/test/functional/maxuploadtarget.py
@@ -20,7 +20,7 @@ import time
 # p2p messages to a node, generating the messages in the main testing logic.
 class TestNode(NodeConnCB):
     def __init__(self):
-        NodeConnCB.__init__(self)
+        super().__init__()
         self.connection = None
         self.ping_counter = 1
         self.last_pong = msg_pong()

--- a/test/functional/p2p-acceptblock.py
+++ b/test/functional/p2p-acceptblock.py
@@ -58,7 +58,7 @@ from test_framework.blocktools import create_block, create_coinbase
 # p2p messages to a node, generating the messages in the main testing logic.
 class TestNode(NodeConnCB):
     def __init__(self):
-        NodeConnCB.__init__(self)
+        super().__init__()
         self.connection = None
         self.ping_counter = 1
         self.last_pong = msg_pong()

--- a/test/functional/p2p-compactblocks.py
+++ b/test/functional/p2p-compactblocks.py
@@ -15,9 +15,9 @@ from test_framework.blocktools import create_block, create_coinbase, add_witness
 from test_framework.script import CScript, OP_TRUE
 
 # TestNode: A peer we use to send messages to bitcoind, and store responses.
-class TestNode(SingleNodeConnCB):
+class TestNode(NodeConnCB):
     def __init__(self):
-        SingleNodeConnCB.__init__(self)
+        super().__init__()
         self.last_sendcmpct = []
         self.last_headers = None
         self.last_inv = None

--- a/test/functional/p2p-feefilter.py
+++ b/test/functional/p2p-feefilter.py
@@ -24,9 +24,9 @@ def allInvsMatch(invsExpected, testnode):
 
 # TestNode: bare-bones "peer".  Used to track which invs are received from a node
 # and to send the node feefilter messages.
-class TestNode(SingleNodeConnCB):
+class TestNode(NodeConnCB):
     def __init__(self):
-        SingleNodeConnCB.__init__(self)
+        super().__init__()
         self.txinvs = []
 
     def on_inv(self, conn, message):

--- a/test/functional/p2p-leaktests.py
+++ b/test/functional/p2p-leaktests.py
@@ -19,10 +19,10 @@ banscore = 10
 
 class CLazyNode(NodeConnCB):
     def __init__(self):
+        super().__init__()
         self.connection = None
         self.unexpected_msg = False
         self.connected = False
-        super().__init__()
 
     def add_connection(self, conn):
         self.connection = conn

--- a/test/functional/p2p-mempool.py
+++ b/test/functional/p2p-mempool.py
@@ -14,7 +14,7 @@ from test_framework.util import *
 
 class TestNode(NodeConnCB):
     def __init__(self):
-        NodeConnCB.__init__(self)
+        super().__init__()
         self.connection = None
         self.ping_counter = 1
         self.last_pong = msg_pong()

--- a/test/functional/p2p-segwit.py
+++ b/test/functional/p2p-segwit.py
@@ -32,10 +32,9 @@ def get_virtual_size(witness_block):
     vsize = int((3*base_size + total_size + 3)/4)
     return vsize
 
-# Note: we can reduce code by using SingleNodeConnCB (in master, not 0.12)
 class TestNode(NodeConnCB):
     def __init__(self):
-        NodeConnCB.__init__(self)
+        super().__init__()
         self.connection = None
         self.ping_counter = 1
         self.last_pong = msg_pong(0)

--- a/test/functional/p2p-timeouts.py
+++ b/test/functional/p2p-timeouts.py
@@ -27,9 +27,9 @@ from test_framework.mininode import *
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
 
-class TestNode(SingleNodeConnCB):
+class TestNode(NodeConnCB):
     def __init__(self):
-        SingleNodeConnCB.__init__(self)
+        super().__init__()
         self.connected = False
         self.received_version = False
 

--- a/test/functional/p2p-versionbits-warning.py
+++ b/test/functional/p2p-versionbits-warning.py
@@ -28,7 +28,7 @@ VB_PATTERN = re.compile("^Warning.*versionbit")
 # p2p messages to a node, generating the messages in the main testing logic.
 class TestNode(NodeConnCB):
     def __init__(self):
-        NodeConnCB.__init__(self)
+        super().__init__()
         self.connection = None
         self.ping_counter = 1
         self.last_pong = msg_pong()

--- a/test/functional/sendheaders.py
+++ b/test/functional/sendheaders.py
@@ -81,9 +81,9 @@ from test_framework.blocktools import create_block, create_coinbase
 
 direct_fetch_response_time = 0.05
 
-class BaseNode(SingleNodeConnCB):
+class BaseNode(NodeConnCB):
     def __init__(self):
-        SingleNodeConnCB.__init__(self)
+        super().__init__()
         self.last_inv = None
         self.last_headers = None
         self.last_block = None

--- a/test/functional/test_framework/comptool.py
+++ b/test/functional/test_framework/comptool.py
@@ -42,7 +42,7 @@ class RejectResult(object):
 class TestNode(NodeConnCB):
 
     def __init__(self, block_store, tx_store):
-        NodeConnCB.__init__(self)
+        super().__init__()
         self.conn = None
         self.bestblockhash = None
         self.block_store = block_store

--- a/test/functional/test_framework/mininode.py
+++ b/test/functional/test_framework/mininode.py
@@ -1476,25 +1476,9 @@ class NodeConnCB(object):
         self.deliver_sleep_time = None
         # Remember the services our peer has advertised
         self.peer_services = None
-
-    def set_deliver_sleep_time(self, value):
-        with mininode_lock:
-            self.deliver_sleep_time = value
-
-    def get_deliver_sleep_time(self):
-        with mininode_lock:
-            return self.deliver_sleep_time
-
-    # Spin until verack message is received from the node.
-    # Tests may want to use this as a signal that the test can begin.
-    # This can be called from the testing thread, so it needs to acquire the
-    # global lock.
-    def wait_for_verack(self):
-        while True:
-            with mininode_lock:
-                if self.verack_received:
-                    return
-            time.sleep(0.05)
+        self.connection = None
+        self.ping_counter = 1
+        self.last_pong = msg_pong()
 
     def deliver(self, conn, message):
         deliver_sleep = self.get_deliver_sleep_time()
@@ -1506,17 +1490,36 @@ class NodeConnCB(object):
             except:
                 logger.exception("ERROR delivering %s" % repr(message))
 
-    def on_version(self, conn, message):
-        if message.nVersion >= 209:
-            conn.send_message(msg_verack())
-        conn.ver_send = min(MY_VERSION, message.nVersion)
-        if message.nVersion < 209:
-            conn.ver_recv = conn.ver_send
-        conn.nServices = message.nServices
+    def set_deliver_sleep_time(self, value):
+        with mininode_lock:
+            self.deliver_sleep_time = value
 
-    def on_verack(self, conn, message):
-        conn.ver_recv = conn.ver_send
-        self.verack_received = True
+    def get_deliver_sleep_time(self):
+        with mininode_lock:
+            return self.deliver_sleep_time
+
+    # Callbacks which can be overridden by subclasses
+    #################################################
+
+    def on_addr(self, conn, message): pass
+    def on_alert(self, conn, message): pass
+    def on_block(self, conn, message): pass
+    def on_blocktxn(self, conn, message): pass
+    def on_close(self, conn): pass
+    def on_cmpctblock(self, conn, message): pass
+    def on_feefilter(self, conn, message): pass
+    def on_getaddr(self, conn, message): pass
+    def on_getblocks(self, conn, message): pass
+    def on_getblocktxn(self, conn, message): pass
+    def on_getdata(self, conn, message): pass
+    def on_getheaders(self, conn, message): pass
+    def on_headers(self, conn, message): pass
+    def on_mempool(self, conn): pass
+    def on_open(self, conn): pass
+    def on_reject(self, conn, message): pass
+    def on_sendcmpct(self, conn, message): pass
+    def on_sendheaders(self, conn, message): pass
+    def on_tx(self, conn, message): pass
 
     def on_inv(self, conn, message):
         want = msg_getdata()
@@ -1526,37 +1529,27 @@ class NodeConnCB(object):
         if len(want.inv):
             conn.send_message(want)
 
-    def on_addr(self, conn, message): pass
-    def on_alert(self, conn, message): pass
-    def on_getdata(self, conn, message): pass
-    def on_getblocks(self, conn, message): pass
-    def on_tx(self, conn, message): pass
-    def on_block(self, conn, message): pass
-    def on_getaddr(self, conn, message): pass
-    def on_headers(self, conn, message): pass
-    def on_getheaders(self, conn, message): pass
     def on_ping(self, conn, message):
         if conn.ver_send > BIP0031_VERSION:
             conn.send_message(msg_pong(message.nonce))
-    def on_reject(self, conn, message): pass
-    def on_open(self, conn): pass
-    def on_close(self, conn): pass
-    def on_mempool(self, conn): pass
-    def on_pong(self, conn, message): pass
-    def on_feefilter(self, conn, message): pass
-    def on_sendheaders(self, conn, message): pass
-    def on_sendcmpct(self, conn, message): pass
-    def on_cmpctblock(self, conn, message): pass
-    def on_getblocktxn(self, conn, message): pass
-    def on_blocktxn(self, conn, message): pass
 
-# More useful callbacks and functions for NodeConnCB's which have a single NodeConn
-class SingleNodeConnCB(NodeConnCB):
-    def __init__(self):
-        NodeConnCB.__init__(self)
-        self.connection = None
-        self.ping_counter = 1
-        self.last_pong = msg_pong()
+    def on_pong(self, conn, message):
+        self.last_pong = message
+
+    def on_verack(self, conn, message):
+        conn.ver_recv = conn.ver_send
+        self.verack_received = True
+
+    def on_version(self, conn, message):
+        if message.nVersion >= 209:
+            conn.send_message(msg_verack())
+        conn.ver_send = min(MY_VERSION, message.nVersion)
+        if message.nVersion < 209:
+            conn.ver_recv = conn.ver_send
+        conn.nServices = message.nServices
+
+    # Helper functions
+    ##################
 
     def add_connection(self, conn):
         self.connection = conn
@@ -1569,9 +1562,6 @@ class SingleNodeConnCB(NodeConnCB):
         self.send_message(message)
         self.sync_with_ping()
 
-    def on_pong(self, conn, message):
-        self.last_pong = message
-
     # Sync up with the node
     def sync_with_ping(self, timeout=30):
         def received_pong():
@@ -1579,7 +1569,19 @@ class SingleNodeConnCB(NodeConnCB):
         self.send_message(msg_ping(nonce=self.ping_counter))
         success = wait_until(received_pong, timeout=timeout)
         self.ping_counter += 1
+
         return success
+
+    # Spin until verack message is received from the node.
+    # Tests may want to use this as a signal that the test can begin.
+    # This can be called from the testing thread, so it needs to acquire the
+    # global lock.
+    def wait_for_verack(self):
+        while True:
+            with mininode_lock:
+                if self.verack_received:
+                    return
+            time.sleep(0.05)
 
 # The actual NodeConn class
 # This class provides an interface for a p2p connection to a specified node


### PR DESCRIPTION
This PR merges the NodeConnCB and SingleNodeConnCB into a single
class (called NodeConnCB). The original intent for the NodeConnCB was to
be able to have a python 'mininode' connect to multiple running
bitcoinds. This has never been used and can be achieved more easily by
having multiple NodeConns backed by a common datastore if it is ever
needed.

The changes in mininode.py are just code moves (and merging the two
classes into a single class). The code changes in the individual test
cases are changing the subclasses to subclass from NodeConnCB instead of
SingleNodeConnCB. There is a lot of duplicate code in the subclasses
that can be removed in future commits.

@sdaftuar as discussed - should be an easy review.