### PR TITLE
[WIP] Remove NetworkThread from individual test cases

### DIFF
--- a/test/functional/README.md
+++ b/test/functional/README.md
@@ -52,10 +52,6 @@ events of interest arrive.
 * You can pass the same handler to multiple ```NodeConn```'s if you like, or pass
 different ones to each -- whatever makes the most sense for your test.
 
-* Call ```NetworkThread.start()``` after all ```NodeConn``` objects are created to
-start the networking thread.  (Continue with the test logic in your existing
-thread.)
-
 * RPC calls are available in p2p tests.
 
 * Can be used to write free-form tests, where specific p2p-protocol behavior

--- a/test/functional/assumevalid.py
+++ b/test/functional/assumevalid.py
@@ -38,7 +38,6 @@ from test_framework.mininode import (CBlockHeader,
                                      CTransaction,
                                      CTxIn,
                                      CTxOut,
-                                     NetworkThread,
                                      NodeConn,
                                      NodeConnCB,
                                      msg_block,
@@ -99,9 +98,6 @@ class AssumeValidTest(BitcoinTestFramework):
         connections = []
         connections.append(NodeConn('127.0.0.1', p2p_port(0), self.nodes[0], node0))
         node0.add_connection(connections[0])
-
-        NetworkThread().start()  # Start up network handling in another thread
-        node0.wait_for_verack()
 
         # Build the blockchain
         self.tip = int(self.nodes[0].getbestblockhash(), 16)
@@ -167,14 +163,12 @@ class AssumeValidTest(BitcoinTestFramework):
         node1 = BaseNode()  # connects to node1
         connections.append(NodeConn('127.0.0.1', p2p_port(1), self.nodes[1], node1))
         node1.add_connection(connections[1])
-        node1.wait_for_verack()
 
         self.nodes.append(start_node(2, self.options.tmpdir,
                                      ["-assumevalid=" + hex(block102.sha256)]))
         node2 = BaseNode()  # connects to node2
         connections.append(NodeConn('127.0.0.1', p2p_port(2), self.nodes[2], node2))
         node2.add_connection(connections[2])
-        node2.wait_for_verack()
 
         # send header lists to all three nodes
         node0.send_header_for_blocks(self.blocks[0:2000])

--- a/test/functional/bip65-cltv-p2p.py
+++ b/test/functional/bip65-cltv-p2p.py
@@ -18,7 +18,7 @@ Mine 1 old version block, see that the node rejects.
 
 from test_framework.test_framework import ComparisonTestFramework
 from test_framework.util import *
-from test_framework.mininode import CTransaction, NetworkThread
+from test_framework.mininode import CTransaction
 from test_framework.blocktools import create_coinbase, create_block
 from test_framework.comptool import TestInstance, TestManager
 from test_framework.script import CScript, OP_1NEGATE, OP_CHECKLOCKTIMEVERIFY, OP_DROP
@@ -49,7 +49,6 @@ class BIP65Test(ComparisonTestFramework):
     def run_test(self):
         test = TestManager(self, self.options.tmpdir)
         test.add_all_connections(self.nodes)
-        NetworkThread().start() # Start up network handling in another thread
         test.run()
 
     def create_transaction(self, node, coinbase, to_address, amount):

--- a/test/functional/bip68-112-113-p2p.py
+++ b/test/functional/bip68-112-113-p2p.py
@@ -45,7 +45,7 @@ bip112tx_special - test negative argument to OP_CSV
 
 from test_framework.test_framework import ComparisonTestFramework
 from test_framework.util import *
-from test_framework.mininode import ToHex, CTransaction, NetworkThread
+from test_framework.mininode import ToHex, CTransaction
 from test_framework.blocktools import create_coinbase, create_block
 from test_framework.comptool import TestInstance, TestManager
 from test_framework.script import *
@@ -105,7 +105,6 @@ class BIP68_112_113Test(ComparisonTestFramework):
     def run_test(self):
         test = TestManager(self, self.options.tmpdir)
         test.add_all_connections(self.nodes)
-        NetworkThread().start() # Start up network handling in another thread
         test.run()
 
     def send_generic_input_tx(self, node, coinbases):

--- a/test/functional/bip9-softforks.py
+++ b/test/functional/bip9-softforks.py
@@ -19,7 +19,7 @@ test that enforcement has triggered
 from test_framework.blockstore import BlockStore
 from test_framework.test_framework import ComparisonTestFramework
 from test_framework.util import *
-from test_framework.mininode import CTransaction, NetworkThread
+from test_framework.mininode import CTransaction
 from test_framework.blocktools import create_coinbase, create_block
 from test_framework.comptool import TestInstance, TestManager
 from test_framework.script import CScript, OP_1NEGATE, OP_CHECKSEQUENCEVERIFY, OP_DROP
@@ -41,7 +41,6 @@ class BIP9SoftForksTest(ComparisonTestFramework):
     def run_test(self):
         self.test = TestManager(self, self.options.tmpdir)
         self.test.add_all_connections(self.nodes)
-        NetworkThread().start() # Start up network handling in another thread
         self.test.run()
 
     def create_transaction(self, node, coinbase, to_address, amount):
@@ -200,14 +199,11 @@ class BIP9SoftForksTest(ComparisonTestFramework):
         yield TestInstance([[block, False]])
 
         # Restart all
-        self.test.clear_all_connections()
         stop_nodes(self.nodes)
         shutil.rmtree(self.options.tmpdir + "/node0")
         self.setup_chain()
         self.setup_network()
         self.test.add_all_connections(self.nodes)
-        NetworkThread().start()
-        self.test.test_nodes[0].wait_for_verack()
 
     def get_tests(self):
         for test in itertools.chain(

--- a/test/functional/bipdersig-p2p.py
+++ b/test/functional/bipdersig-p2p.py
@@ -18,7 +18,7 @@ Mine 1 old version block, see that the node rejects.
 
 from test_framework.test_framework import ComparisonTestFramework
 from test_framework.util import *
-from test_framework.mininode import CTransaction, NetworkThread
+from test_framework.mininode import CTransaction
 from test_framework.blocktools import create_coinbase, create_block
 from test_framework.comptool import TestInstance, TestManager
 from test_framework.script import CScript
@@ -56,7 +56,6 @@ class BIP66Test(ComparisonTestFramework):
     def run_test(self):
         test = TestManager(self, self.options.tmpdir)
         test.add_all_connections(self.nodes)
-        NetworkThread().start() # Start up network handling in another thread
         test.run()
 
     def create_transaction(self, node, coinbase, to_address, amount):

--- a/test/functional/invalidblockrequest.py
+++ b/test/functional/invalidblockrequest.py
@@ -32,7 +32,6 @@ class InvalidBlockRequestTest(ComparisonTestFramework):
         test.add_all_connections(self.nodes)
         self.tip = None
         self.block_time = None
-        NetworkThread().start() # Start up network handling in another thread
         test.run()
 
     def get_tests(self):

--- a/test/functional/invalidtxrequest.py
+++ b/test/functional/invalidtxrequest.py
@@ -28,7 +28,6 @@ class InvalidTxRequestTest(ComparisonTestFramework):
         test.add_all_connections(self.nodes)
         self.tip = None
         self.block_time = None
-        NetworkThread().start() # Start up network handling in another thread
         test.run()
 
     def get_tests(self):

--- a/test/functional/maxblocksinflight.py
+++ b/test/functional/maxblocksinflight.py
@@ -86,7 +86,6 @@ class MaxBlocksInFlightTest(BitcoinTestFramework):
         # pass log handler through to the test manager object
         test.log = self.log
         test.add_new_connection(NodeConn('127.0.0.1', p2p_port(0), self.nodes[0], test))
-        NetworkThread().start()  # Start up network handling in another thread
         test.run()
 
 if __name__ == '__main__':

--- a/test/functional/nulldummy.py
+++ b/test/functional/nulldummy.py
@@ -15,7 +15,7 @@ Generate 427 more blocks.
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
-from test_framework.mininode import CTransaction, NetworkThread
+from test_framework.mininode import CTransaction
 from test_framework.blocktools import create_coinbase, create_block, add_witness_commitment
 from test_framework.script import CScript
 from io import BytesIO
@@ -53,7 +53,6 @@ class NULLDUMMYTest(BitcoinTestFramework):
         self.wit_address = self.nodes[0].addwitnessaddress(self.address)
         self.wit_ms_address = self.nodes[0].addwitnessaddress(self.ms_address)
 
-        NetworkThread().start() # Start up network handling in another thread
         self.coinbase_blocks = self.nodes[0].generate(2) # Block 2
         coinbase_txid = []
         for i in self.coinbase_blocks:

--- a/test/functional/p2p-acceptblock.py
+++ b/test/functional/p2p-acceptblock.py
@@ -63,23 +63,9 @@ class TestNode(NodeConnCB):
         self.ping_counter = 1
         self.last_pong = msg_pong()
 
-    def add_connection(self, conn):
-        self.connection = conn
-
     # Track the last getdata message we receive (used in the test)
     def on_getdata(self, conn, message):
         self.last_getdata = message
-
-    # Spin until verack message is received from the node.
-    # We use this to signal that our test can begin. This
-    # is called from the testing thread, so it needs to acquire
-    # the global lock.
-    def wait_for_verack(self):
-        while True:
-            with mininode_lock:
-                if self.verack_received:
-                    return
-            time.sleep(0.05)
 
     # Wrapper for the NodeConn's send_message function
     def send_message(self, message):
@@ -120,12 +106,6 @@ class AcceptBlockTest(BitcoinTestFramework):
         connections.append(NodeConn('127.0.0.1', p2p_port(1), self.nodes[1], white_node))
         test_node.add_connection(connections[0])
         white_node.add_connection(connections[1])
-
-        NetworkThread().start() # Start up network handling in another thread
-
-        # Test logic begins here
-        test_node.wait_for_verack()
-        white_node.wait_for_verack()
 
         # 1. Have both nodes mine a block (leave IBD)
         [ n.generate(1) for n in self.nodes ]

--- a/test/functional/p2p-compactblocks.py
+++ b/test/functional/p2p-compactblocks.py
@@ -857,11 +857,6 @@ class CompactBlocksTest(BitcoinTestFramework):
         self.segwit_node.add_connection(connections[1])
         self.old_node.add_connection(connections[2])
 
-        NetworkThread().start()  # Start up network handling in another thread
-
-        # Test logic begins here
-        self.test_node.wait_for_verack()
-
         # We will need UTXOs to construct transactions in later tests.
         self.make_utxos()
 

--- a/test/functional/p2p-feefilter.py
+++ b/test/functional/p2p-feefilter.py
@@ -68,8 +68,6 @@ class FeeFilterTest(BitcoinTestFramework):
         test_node = TestNode()
         connection = NodeConn('127.0.0.1', p2p_port(0), self.nodes[0], test_node)
         test_node.add_connection(connection)
-        NetworkThread().start()
-        test_node.wait_for_verack()
 
         # Test that invs are received for all txs at feerate of 20 sat/byte
         node1.settxfee(Decimal("0.00020000"))

--- a/test/functional/p2p-fullblocktest.py
+++ b/test/functional/p2p-fullblocktest.py
@@ -69,7 +69,6 @@ class FullBlockTest(ComparisonTestFramework):
     def run_test(self):
         self.test = TestManager(self, self.options.tmpdir)
         self.test.add_all_connections(self.nodes)
-        NetworkThread().start() # Start up network handling in another thread
         self.test.run()
 
     def add_transactions_to_block(self, block, tx_list):

--- a/test/functional/p2p-leaktests.py
+++ b/test/functional/p2p-leaktests.py
@@ -24,9 +24,6 @@ class CLazyNode(NodeConnCB):
         self.unexpected_msg = False
         self.connected = False
 
-    def add_connection(self, conn):
-        self.connection = conn
-
     def send_message(self, message):
         self.connection.send_message(message)
 
@@ -115,11 +112,9 @@ class P2PLeakTest(BitcoinTestFramework):
         connections.append(NodeConn('127.0.0.1', p2p_port(0), self.nodes[0], no_version_bannode, send_version=False))
         connections.append(NodeConn('127.0.0.1', p2p_port(0), self.nodes[0], no_version_idlenode, send_version=False))
         connections.append(NodeConn('127.0.0.1', p2p_port(0), self.nodes[0], no_verack_idlenode))
-        no_version_bannode.add_connection(connections[0])
-        no_version_idlenode.add_connection(connections[1])
-        no_verack_idlenode.add_connection(connections[2])
-
-        NetworkThread().start()  # Start up network handling in another thread
+        no_version_bannode.add_connection(connections[0], wait_for_verack=False)
+        no_version_idlenode.add_connection(connections[1], wait_for_verack=False)
+        no_verack_idlenode.add_connection(connections[2], wait_for_verack=False)
 
         assert(wait_until(lambda: no_version_bannode.connected and no_version_idlenode.connected and no_verack_idlenode.version_received, timeout=10))
 

--- a/test/functional/p2p-mempool.py
+++ b/test/functional/p2p-mempool.py
@@ -21,7 +21,7 @@ class TestNode(NodeConnCB):
         self.block_receive_map = {}
 
     def add_connection(self, conn):
-        self.connection = conn
+        super().add_connection(conn)
         self.peer_disconnected = False
 
     def on_inv(self, conn, message):
@@ -37,15 +37,6 @@ class TestNode(NodeConnCB):
             self.block_receive_map[message.block.sha256] += 1
         except KeyError as e:
             self.block_receive_map[message.block.sha256] = 1
-
-    # Spin until verack message is received from the node.
-    # We use this to signal that our test can begin. This
-    # is called from the testing thread, so it needs to acquire
-    # the global lock.
-    def wait_for_verack(self):
-        def veracked():
-            return self.verack_received
-        return wait_until(veracked, timeout=10)
 
     def wait_for_disconnect(self):
         def disconnected():
@@ -83,8 +74,6 @@ class P2PMempoolTests(BitcoinTestFramework):
         aTestNode = TestNode()
         node = NodeConn('127.0.0.1', p2p_port(0), self.nodes[0], aTestNode)
         aTestNode.add_connection(node)
-        NetworkThread().start()
-        aTestNode.wait_for_verack()
 
         #request mempool
         aTestNode.send_mempool()

--- a/test/functional/p2p-segwit.py
+++ b/test/functional/p2p-segwit.py
@@ -42,9 +42,6 @@ class TestNode(NodeConnCB):
         self.getdataset = set()
         self.last_reject = None
 
-    def add_connection(self, conn):
-        self.connection = conn
-
     # Wrapper for the NodeConn's send_message function
     def send_message(self, message):
         self.connection.send_message(message)
@@ -1957,13 +1954,8 @@ class SegWitTest(BitcoinTestFramework):
         self.old_node.add_connection(self.connections[1])
         self.std_node.add_connection(self.connections[2])
 
-        NetworkThread().start() # Start up network handling in another thread
-
         # Keep a place to store utxo's that can be used in later tests
         self.utxo = []
-
-        # Test logic begins here
-        self.test_node.wait_for_verack()
 
         self.log.info("Starting tests before segwit lock in:")
 

--- a/test/functional/p2p-timeouts.py
+++ b/test/functional/p2p-timeouts.py
@@ -66,10 +66,8 @@ class TimeoutsTest(BitcoinTestFramework):
         connections.append(NodeConn('127.0.0.1', p2p_port(0), self.nodes[0], self.no_version_node, send_version=False))
         connections.append(NodeConn('127.0.0.1', p2p_port(0), self.nodes[0], self.no_send_node, send_version=False))
         self.no_verack_node.add_connection(connections[0])
-        self.no_version_node.add_connection(connections[1])
-        self.no_send_node.add_connection(connections[2])
-
-        NetworkThread().start()  # Start up network handling in another thread
+        self.no_version_node.add_connection(connections[1], wait_for_verack=False)
+        self.no_send_node.add_connection(connections[2], wait_for_verack=False)
 
         sleep(1)
 

--- a/test/functional/p2p-versionbits-warning.py
+++ b/test/functional/p2p-versionbits-warning.py
@@ -33,9 +33,6 @@ class TestNode(NodeConnCB):
         self.ping_counter = 1
         self.last_pong = msg_pong()
 
-    def add_connection(self, conn):
-        self.connection = conn
-
     def on_inv(self, conn, message):
         pass
 
@@ -89,11 +86,6 @@ class VersionBitsWarningTest(BitcoinTestFramework):
         connections = []
         connections.append(NodeConn('127.0.0.1', p2p_port(0), self.nodes[0], test_node))
         test_node.add_connection(connections[0])
-
-        NetworkThread().start() # Start up network handling in another thread
-
-        # Test logic begins here
-        test_node.wait_for_verack()
 
         # 1. Have the node mine one period worth of blocks
         self.nodes[0].generate(VB_PERIOD)

--- a/test/functional/sendheaders.py
+++ b/test/functional/sendheaders.py
@@ -273,12 +273,6 @@ class SendHeadersTest(BitcoinTestFramework):
         inv_node.add_connection(connections[0])
         test_node.add_connection(connections[1])
 
-        NetworkThread().start() # Start up network handling in another thread
-
-        # Test logic begins here
-        inv_node.wait_for_verack()
-        test_node.wait_for_verack()
-
         tip = int(self.nodes[0].getbestblockhash(), 16)
 
         # PART 1

--- a/test/functional/test_framework/comptool.py
+++ b/test/functional/test_framework/comptool.py
@@ -62,6 +62,7 @@ class TestNode(NodeConnCB):
         self.closed = True
 
     def add_connection(self, conn):
+        super().add_connection(conn)
         self.conn = conn
 
     def on_headers(self, conn, message):
@@ -191,11 +192,6 @@ class TestManager(object):
             return all(node.closed for node in self.test_nodes)
         return wait_until(disconnected, timeout=10)
 
-    def wait_for_verack(self):
-        def veracked():
-            return all(node.verack_received for node in self.test_nodes)
-        return wait_until(veracked, timeout=10)
-
     def wait_for_pings(self, counter):
         def received_pongs():
             return all(node.received_ping_response(counter) for node in self.test_nodes)
@@ -296,9 +292,6 @@ class TestManager(object):
             return True
 
     def run(self):
-        # Wait until verack is received
-        self.wait_for_verack()
-
         test_number = 1
         for test_instance in self.test_generator.get_tests():
             # We use these variables to keep track of the last block

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -27,6 +27,7 @@ from .util import (
     PortSeed,
 )
 from .authproxy import JSONRPCException
+from .mininode import NetworkThread
 
 class BitcoinTestFramework(object):
 
@@ -148,6 +149,8 @@ class BitcoinTestFramework(object):
         try:
             self.setup_chain()
             self.setup_network()
+            self.network_thread = NetworkThread()
+            self.network_thread.start()
             self.run_test()
             success = True
         except JSONRPCException as e:
@@ -160,6 +163,8 @@ class BitcoinTestFramework(object):
             self.log.exception("Unexpected exception caught during testing")
         except KeyboardInterrupt as e:
             self.log.warning("Exiting after keyboard interrupt")
+
+        self.network_thread.test_running = False
 
         if not self.options.noshutdown:
             self.log.info("Stopping nodes")


### PR DESCRIPTION
This commit starts the NetworkThread automatically in the test
framework, which means that the individual test cases don't need to
start the thread after they've added the p2p connections.

It also updates the NodeConnCB.add_connection() method to wait for
verack by default. This means the test writer only needs to call
add_connection() in order to have a p2p connection ready for use.

This builds on #10109 . Only the 'Remove NetworkThread from individual test cases' commit needs to be reviewed

As discussed @sdaftuar - should be another easy review.