### PR TITLE
[tests] sync_with_ping should assert that ping hasn't timed out

### DIFF
--- a/test/functional/assumevalid.py
+++ b/test/functional/assumevalid.py
@@ -190,7 +190,8 @@ class AssumeValidTest(BitcoinTestFramework):
         # Send all blocks to node1. All blocks will be accepted.
         for i in range(2202):
             node1.send_message(msg_block(self.blocks[i]))
-        node1.sync_with_ping()  # make sure the most recent block is synced
+        # Syncing 2200 blocks can take a while on slow systems. Give it plenty of time to sync.
+        node1.sync_with_ping(120)
         assert_equal(self.nodes[1].getblock(self.nodes[1].getbestblockhash())['height'], 2202)
 
         # Send blocks to node2. Block 102 will be rejected.

--- a/test/functional/maxuploadtarget.py
+++ b/test/functional/maxuploadtarget.py
@@ -68,15 +68,6 @@ class TestNode(NodeConnCB):
     def on_close(self, conn):
         self.peer_disconnected = True
 
-    # Sync up with the node after delivery of a block
-    def sync_with_ping(self, timeout=30):
-        def received_pong():
-            return (self.last_pong.nonce == self.ping_counter)
-        self.connection.send_message(msg_ping(nonce=self.ping_counter))
-        success = wait_until(received_pong, timeout=timeout)
-        self.ping_counter += 1
-        return success
-
 class MaxUploadTest(BitcoinTestFramework):
  
     def __init__(self):

--- a/test/functional/p2p-acceptblock.py
+++ b/test/functional/p2p-acceptblock.py
@@ -88,21 +88,6 @@ class TestNode(NodeConnCB):
     def on_pong(self, conn, message):
         self.last_pong = message
 
-    # Sync up with the node after delivery of a block
-    def sync_with_ping(self, timeout=30):
-        self.connection.send_message(msg_ping(nonce=self.ping_counter))
-        received_pong = False
-        sleep_time = 0.05
-        while not received_pong and timeout > 0:
-            time.sleep(sleep_time)
-            timeout -= sleep_time
-            with mininode_lock:
-                if self.last_pong.nonce == self.ping_counter:
-                    received_pong = True
-        self.ping_counter += 1
-        return received_pong
-
-
 class AcceptBlockTest(BitcoinTestFramework):
     def add_options(self, parser):
         parser.add_option("--testbinary", dest="testbinary",

--- a/test/functional/p2p-compactblocks.py
+++ b/test/functional/p2p-compactblocks.py
@@ -32,6 +32,13 @@ class TestNode(NodeConnCB):
         # This is for synchronizing the p2p message traffic,
         # so we can eg wait until a particular block is announced.
         self.set_announced_blockhashes = set()
+        self.connected = False
+
+    def on_open(self, conn):
+        self.connected = True
+
+    def on_close(self, conn):
+        self.connected = False
 
     def on_sendcmpct(self, conn, message):
         self.last_sendcmpct.append(message)
@@ -106,6 +113,18 @@ class TestNode(NodeConnCB):
         def received_hash():
             return (block_hash in self.set_announced_blockhashes)
         return wait_until(received_hash, timeout=timeout)
+
+    def send_await_disconnect(self, message, timeout=30):
+        """Sends a message to the node and wait for disconnect.
+
+        This is used when we want to send a message into the node that we expect
+        will get us disconnected, eg an invalid block."""
+        self.send_message(message)
+        success = wait_until(lambda: not self.connected, timeout=timeout)
+        if not success:
+            logger.error("send_await_disconnect failed!")
+            raise AssertionError("send_await_disconnect failed!")
+        return success
 
 class CompactBlocksTest(BitcoinTestFramework):
     def __init__(self):
@@ -274,8 +293,8 @@ class CompactBlocksTest(BitcoinTestFramework):
         # This index will be too high
         prefilled_txn = PrefilledTransaction(1, block.vtx[0])
         cmpct_block.prefilled_txn = [prefilled_txn]
-        self.test_node.send_and_ping(msg_cmpctblock(cmpct_block))
-        assert(int(self.nodes[0].getbestblockhash(), 16) == block.hashPrevBlock)
+        self.test_node.send_await_disconnect(msg_cmpctblock(cmpct_block))
+        assert_equal(int(self.nodes[0].getbestblockhash(), 16), block.hashPrevBlock)
 
     # Compare the generated shortids to what we expect based on BIP 152, given
     # bitcoind's choice of nonce.

--- a/test/functional/p2p-mempool.py
+++ b/test/functional/p2p-mempool.py
@@ -62,15 +62,6 @@ class TestNode(NodeConnCB):
     def on_close(self, conn):
         self.peer_disconnected = True
 
-    # Sync up with the node after delivery of a block
-    def sync_with_ping(self, timeout=30):
-        def received_pong():
-            return (self.last_pong.nonce == self.ping_counter)
-        self.connection.send_message(msg_ping(nonce=self.ping_counter))
-        success = wait_until(received_pong, timeout=timeout)
-        self.ping_counter += 1
-        return success
-
     def send_mempool(self):
         self.lastInv = []
         self.send_message(msg_mempool())

--- a/test/functional/p2p-versionbits-warning.py
+++ b/test/functional/p2p-versionbits-warning.py
@@ -46,21 +46,6 @@ class TestNode(NodeConnCB):
     def on_pong(self, conn, message):
         self.last_pong = message
 
-    # Sync up with the node after delivery of a block
-    def sync_with_ping(self, timeout=30):
-        self.connection.send_message(msg_ping(nonce=self.ping_counter))
-        received_pong = False
-        sleep_time = 0.05
-        while not received_pong and timeout > 0:
-            time.sleep(sleep_time)
-            timeout -= sleep_time
-            with mininode_lock:
-                if self.last_pong.nonce == self.ping_counter:
-                    received_pong = True
-        self.ping_counter += 1
-        return received_pong
-
-
 class VersionBitsWarningTest(BitcoinTestFramework):
     def __init__(self):
         super().__init__()

--- a/test/functional/test_framework/mininode.py
+++ b/test/functional/test_framework/mininode.py
@@ -1563,11 +1563,14 @@ class NodeConnCB(object):
         self.sync_with_ping()
 
     # Sync up with the node
-    def sync_with_ping(self, timeout=30):
+    def sync_with_ping(self, timeout=60):
         def received_pong():
             return (self.last_pong.nonce == self.ping_counter)
         self.send_message(msg_ping(nonce=self.ping_counter))
         success = wait_until(received_pong, timeout=timeout)
+        if not success:
+            logger.error("sync_with_ping failed!")
+            raise AssertionError("sync_with_ping failed!")
         self.ping_counter += 1
 
         return success


### PR DESCRIPTION
sync_with_ping() currently returns false if the timeout expires, and it is
the caller's responsibility to fail the test. However, none of the tests
currently assert on sync_with_ping()'s return code. This commit adds an
assert to sync_with_ping so the test will fail if the timeout expires.

This commit also removes all the duplicate implementations of
sync_with_ping() from the individual tests.

~Only the second commit here needs to be reviewed. The first commit https://github.com/bitcoin/bitcoin/commit/159fe88abfadf67410578c145e631819cf50b660 is #10109.~ __EDIT: #10109 is now merged.__

__EDIT: The first commit in this PR ("Add send_await_disconnect() method to p2p-compactblocks.py") is a test case bug fix that needs to be merged before merging the sync_with_ping() change__

Should fix the intermittent failure reported here: https://github.com/bitcoin/bitcoin/pull/10073#issuecomment-289466653

sync'ing and pinging @sdaftuar 