### PR TITLE
Consensus: use IsWitnessEnabled in ContextualCheckBlock

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3016,7 +3016,7 @@ bool ContextualCheckBlock(const CBlock& block, CValidationState& state, const Co
     //   {0xaa, 0x21, 0xa9, 0xed}, and the following 32 bytes are SHA256^2(witness root, witness nonce). In case there are
     //   multiple, the last one is used.
     bool fHaveWitness = false;
-    if (VersionBitsState(pindexPrev, consensusParams, Consensus::DEPLOYMENT_SEGWIT, versionbitscache) == THRESHOLD_ACTIVE) {
+    if (IsWitnessEnabled(pindexPrev, consensusParams)) {
         int commitpos = GetWitnessCommitmentIndex(block);
         if (commitpos != -1) {
             bool malleated = false;


### PR DESCRIPTION
Replaced the SegWit deployment check in `ContextualCheckBlock` with a call to `IsWitnessEnabled` instead.