### PR TITLE
util: Work around (virtual) memory exhaustion on 32-bit w/ glibc

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -574,6 +574,14 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <malloc.h>]],
  [ AC_MSG_RESULT(no)]
 )
 
+dnl Check for mallopt(M_ARENA_MAX) (to set glibc arenas)
+AC_MSG_CHECKING(for mallopt M_ARENA_MAX)
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <malloc.h>]],
+ [[ mallopt(M_ARENA_MAX, 1); ]])],
+ [ AC_MSG_RESULT(yes); AC_DEFINE(HAVE_MALLOPT_ARENA_MAX, 1,[Define this symbol if you have mallopt with M_ARENA_MAX]) ],
+ [ AC_MSG_RESULT(no)]
+)
+
 AC_MSG_CHECKING([for visibility attribute])
 AC_LINK_IFELSE([AC_LANG_SOURCE([
   int foo_def( void ) __attribute__((visibility("default")));

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -72,6 +72,10 @@
 #include <sys/prctl.h>
 #endif
 
+#ifdef HAVE_MALLOPT_ARENA_MAX
+#include <malloc.h>
+#endif
+
 #include <boost/algorithm/string/case_conv.hpp> // for to_lower()
 #include <boost/algorithm/string/join.hpp>
 #include <boost/algorithm/string/predicate.hpp> // for startswith() and endswith()
@@ -792,6 +796,16 @@ void RenameThread(const char* name)
 
 void SetupEnvironment()
 {
+#ifdef HAVE_MALLOPT_ARENA_MAX
+    // glibc-specific: On 32-bit systems set the number of arenas to 1.
+    // By default, since glibc 2.10, the C library will create up to two heap
+    // arenas per core. This is known to cause excessive virtual address space
+    // usage in our usage. Work around it by setting the maximum number of
+    // arenas to 1.
+    if (sizeof(void*) == 4) {
+        mallopt(M_ARENA_MAX, 1);
+    }
+#endif
     // On most POSIX systems (e.g. Linux, but not BSD) the environment's locale
     // may be invalid, in which case the "C" locale is used as fallback.
 #if !defined(WIN32) && !defined(MAC_OSX) && !defined(__FreeBSD__) && !defined(__OpenBSD__)


### PR DESCRIPTION
glibc-specific: On 32-bit systems set the number of arenas to 1. By default, since glibc 2.10, the C library will create up to two heap arenas per core. This is known to cause excessive virtual address space usage in our usage. Work around it by setting the maximum number of arenas to 1.

I documented this before in [Reducing bitcoind memory usage](https://gist.github.com/laanwj/efe29c7661ce9b6620a7) but with the reported OOM issues in 0.14 it seems more pressing to do it by default when there is low virtual memory space (e.g. on 32 bit).

To test:
```
bitcoin-cli getmemoryinfo mallocinfo | grep "<heap"
```
This will show an entry per heap.

Tested on 32-bit ARM, 4-core:
```xml
<heap nr="0">
```

Tested on 64-bit x86, 6-core:
```xml
<heap nr="0">
<heap nr="1">
<heap nr="2">
<heap nr="3">
<heap nr="4">
<heap nr="5">
<heap nr="6">
<heap nr="7">
<heap nr="8">
<heap nr="9">
<heap nr="10">
<heap nr="11">
<heap nr="12">
```