### PR TITLE
Add missing header file

### DIFF
--- a/src/leveldb/db/db_iter.cc
+++ b/src/leveldb/db/db_iter.cc
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
+#include <sys/types.h>
 #include "db/db_iter.h"
 
 #include "db/filename.h"


### PR DESCRIPTION
We need to include <sys/types.h> because we use ssize_t on the file.