### PR TITLE
Exit bitcoind immediately on shutdown instead of 200ms later

### DIFF
--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -43,13 +43,7 @@
 
 void WaitForShutdown(boost::thread_group* threadGroup)
 {
-    bool fShutdown = ShutdownRequested();
-    // Tell the main threads to shutdown.
-    while (!fShutdown)
-    {
-        MilliSleep(200);
-        fShutdown = ShutdownRequested();
-    }
+    WaitForShutdownRequested();
     if (threadGroup)
     {
         Interrupt(*threadGroup);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -126,14 +126,27 @@ static const char* FEE_ESTIMATES_FILENAME="fee_estimates.dat";
 
 std::atomic<bool> fRequestShutdown(false);
 std::atomic<bool> fDumpMempoolLater(false);
+static std::mutex mutexShutdownWait;
+static std::condition_variable cvShutdownWait;
 
 void StartShutdown()
 {
-    fRequestShutdown = true;
+    {
+        std::unique_lock<std::mutex> lockShutdownWait(mutexShutdownWait);
+        fRequestShutdown = true;
+    }
+    cvShutdownWait.notify_all();
 }
 bool ShutdownRequested()
 {
     return fRequestShutdown;
+}
+
+void WaitForShutdownRequested() {
+    std::unique_lock<std::mutex> lockShutdownWait(mutexShutdownWait);
+    while (!ShutdownRequested()) {
+        cvShutdownWait.wait_for(lockShutdownWait, std::chrono::milliseconds(200));
+    }
 }
 
 /**

--- a/src/init.h
+++ b/src/init.h
@@ -18,6 +18,7 @@ class thread_group;
 
 void StartShutdown();
 bool ShutdownRequested();
+void WaitForShutdownRequested();
 /** Interrupt threads */
 void Interrupt(boost::thread_group& threadGroup);
 void Shutdown();


### PR DESCRIPTION
This is especially useful for AbortNode(). I have no idea how to make the equivalent change in bitcoin-qt, maybe @jonasschnelli can add some signal thing for it?