### PR TITLE
scheduler: fix sub-second precision with boost < 1.50

### DIFF
--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -23,7 +23,9 @@ CScheduler::~CScheduler()
 #if BOOST_VERSION < 105000
 static boost::system_time toPosixTime(const boost::chrono::system_clock::time_point& t)
 {
-    return boost::posix_time::from_time_t(boost::chrono::system_clock::to_time_t(t));
+    // Creating the posix_time using from_time_t loses sub-second precision. So rather than exporting the time_point to time_t,
+    // start with a posix_time at the epoch (0) and add the milliseconds that have passed since then.
+    return boost::posix_time::from_time_t(0) + boost::posix_time::milliseconds(boost::chrono::duration_cast<boost::chrono::milliseconds>(t.time_since_epoch()).count());
 }
 #endif
 


### PR DESCRIPTION
For systems with older boost, cpu usage has been ramped up since 735d9b5362aeca34c0e62006986fe9d82c24ca08, due to a time miscalculation. This was never encountered previously because this is the first use of a sub-second repeat interval for a scheduled event.