### PR TITLE
bitcoin-tx input verification (awemany, jnewbery)

### DIFF
--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -242,6 +242,9 @@ static void MutateTxAddOutAddr(CMutableTransaction& tx, const std::string& strIn
     std::vector<std::string> vStrInputParts;
     boost::split(vStrInputParts, strInput, boost::is_any_of(":"));
 
+    if (vStrInputParts.size() != 2)
+        throw std::runtime_error("TX output missing or too many separators");
+
     // Extract and validate VALUE
     CAmount value = ExtractAndValidateValue(vStrInputParts[0]);
 
@@ -263,6 +266,9 @@ static void MutateTxAddOutPubKey(CMutableTransaction& tx, const std::string& str
     // Separate into VALUE:PUBKEY[:FLAGS]
     std::vector<std::string> vStrInputParts;
     boost::split(vStrInputParts, strInput, boost::is_any_of(":"));
+
+    if (vStrInputParts.size() < 2 || vStrInputParts.size() > 3)
+        throw std::runtime_error("TX output missing or too many separators");
 
     // Extract and validate VALUE
     CAmount value = ExtractAndValidateValue(vStrInputParts[0]);

--- a/test/util/bctest.py
+++ b/test/util/bctest.py
@@ -102,6 +102,18 @@ def bctest(testDir, testObj, buildenv):
         logging.error("Return code mismatch for " + outputFn)
         raise Exception
 
+    if "error_txt" in testObj:
+        want_error = testObj["error_txt"]
+        # Compare error text
+        # TODO: ideally, we'd compare the strings exactly and also assert
+        # That stderr is empty if no errors are expected. However, bitcoin-tx
+        # emits DISPLAY errors when running as a windows application on
+        # linux through wine. Just assert that the expected error text appears
+        # somewhere in stderr.
+        if want_error not in outs[1]:
+            logging.error("Error mismatch:\n" + "Expected: " + want_error + "\nReceived: " + outs[1].rstrip())
+            raise Exception
+
 def bctester(testDir, input_basename, buildenv):
     """ Loads and parses the input file, runs all tests and reports results"""
     input_filename = testDir + "/" + input_basename

--- a/test/util/data/bitcoin-util-test.json
+++ b/test/util/data/bitcoin-util-test.json
@@ -42,6 +42,7 @@
     "args": ["-", "delin=31"],
     "input": "tx394b54bb.hex",
     "return_code": 1,
+    "error_txt": "error: Invalid TX input index '31'",
     "description": "Attempts to delete an input with a bad index from a transaction. Expected to fail."
   },
   { "exec": "./bitcoin-tx",
@@ -60,6 +61,7 @@
     "args": ["-", "delout=2"],
     "input": "tx394b54bb.hex",
     "return_code": 1,
+    "error_txt": "error: Invalid TX output index '2'",
     "description": "Attempts to delete an output with a bad index from a transaction. Expected to fail."
   },
   { "exec": "./bitcoin-tx",
@@ -233,6 +235,7 @@
      "in=5897de6bd6027a475eadd57019d4e6872c396d0716c4875a5f1a6fcfdf385c1f:0",
      "outdata=4:badhexdata"],
     "return_code": 1,
+    "error_txt": "error: invalid TX output data",
     "description": "Attempts to create a new transaction with one input and an output with malformed hex data. Expected to fail"
   },
   { "exec": "./bitcoin-tx",
@@ -241,6 +244,7 @@
      "in=5897de6bd6027a475eadd57019d4e6872c396d0716c4875a5f1a6fcfdf385c1f:0",
      "outdata=badhexdata"],
     "return_code": 1,
+    "error_txt": "error: invalid TX output data",
     "description": "Attempts to create a new transaction with one input and an output with no value and malformed hex data. Expected to fail"
   },
   { "exec": "./bitcoin-tx",

--- a/test/util/data/bitcoin-util-test.json
+++ b/test/util/data/bitcoin-util-test.json
@@ -79,6 +79,38 @@
   { "exec": "./bitcoin-tx",
     "args":
     ["-create",
+     "outaddr=1"],
+    "return_code": 1,
+    "error_txt": "error: TX output missing or too many separators",
+    "description": "Malformed outaddr argument (no address specified). Expected to fail."
+  },
+  { "exec": "./bitcoin-tx",
+    "args":
+    ["-create",
+     "outaddr=1:13tuJJDR2RgArmgfv6JScSdreahzgc4T6o:garbage"],
+    "return_code": 1,
+    "error_txt": "error: TX output missing or too many separators",
+    "description": "Malformed outaddr argument (too many separators). Expected to fail."
+  },
+  { "exec": "./bitcoin-tx",
+    "args":
+    ["-create",
+     "outpubkey=0"],
+    "return_code": 1,
+    "error_txt": "error: TX output missing or too many separators",
+    "description": "Malformed outpubkey argument (no pubkey specified). Expected to fail."
+  },
+  { "exec": "./bitcoin-tx",
+    "args":
+    ["-create",
+     "outpubkey=0:02a5613bd857b7048924264d1e70e08fb2a7e6527d32b7ab1bb993ac59964ff397:W:non53nse"],
+    "return_code": 1,
+    "error_txt": "error: TX output missing or too many separators",
+    "description": "Malformed outpubkey argument (too many separators). Expected to fail."
+  },
+  { "exec": "./bitcoin-tx",
+    "args":
+    ["-create",
      "in=5897de6bd6027a475eadd57019d4e6872c396d0716c4875a5f1a6fcfdf385c1f:0",
      "in=bf829c6bcf84579331337659d31f89dfd138f7f7785802d5501c92333145ca7c:18",
      "in=22a6f904655d53ae2ff70e701a0bbd90aa3975c0f40bfc6cc996a9049e31cdfc:1",


### PR DESCRIPTION
Check number of arguments passed to bitcoin-tx in outaddr and outpubkey.

This PR also updates the bitcoin-tx tests to check bitcoin-tx stderr and verify that expected errors are raised.

Adds test cases for calling bitcoin-tx with wrong number of separators in outaddr and outpubkey.