### PR TITLE
build: Disable Wshadow warning

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -227,7 +227,6 @@ if test "x$CXXFLAGS_overridden" = "xno"; then
   AX_CHECK_COMPILE_FLAG([-Wformat],[CXXFLAGS="$CXXFLAGS -Wformat"],,[[$CXXFLAG_WERROR]])
   AX_CHECK_COMPILE_FLAG([-Wvla],[CXXFLAGS="$CXXFLAGS -Wvla"],,[[$CXXFLAG_WERROR]])
   AX_CHECK_COMPILE_FLAG([-Wformat-security],[CXXFLAGS="$CXXFLAGS -Wformat-security"],,[[$CXXFLAG_WERROR]])
-  AX_CHECK_COMPILE_FLAG([-Wshadow],[CXXFLAGS="$CXXFLAGS -Wshadow"],,[[$CXXFLAG_WERROR]])
 
   ## Some compilers (gcc) ignore unknown -Wno-* options, but warn about all
   ## unknown options if any other warning is produced. Test the -Wfoo case, and


### PR DESCRIPTION
This warning was enabled by default in #8808 but it's a [continuing](https://github.com/bitcoin/bitcoin/pull/9911#issuecomment-285171447) [source](https://github.com/bitcoin/bitcoin/pull/10089#issuecomment-289369688) of [annoyance](https://github.com/bitcoin/bitcoin/pull/9911#issuecomment-285179129) for me and other developers. I'm sick of sounding like a broken record, so disable it again.