### PR TITLE
Prioritisetransaction wasn't always updating ancestor fee

### DIFF
--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -912,6 +912,13 @@ void CTxMemPool::PrioritiseTransaction(const uint256& hash, const CAmount& nFeeD
             BOOST_FOREACH(txiter ancestorIt, setAncestors) {
                 mapTx.modify(ancestorIt, update_descendant_state(0, nFeeDelta, 0));
             }
+            // Now update all descendants' modified fees with ancestors
+            setEntries setDescendants;
+            CalculateDescendants(it, setDescendants);
+            setDescendants.erase(it);
+            BOOST_FOREACH(txiter descendantIt, setDescendants) {
+                mapTx.modify(descendantIt, update_ancestor_state(0, nFeeDelta, 0, 0));
+            }
         }
     }
     LogPrintf("PrioritiseTransaction: %s feerate += %s\n", hash.ToString(), FormatMoney(nFeeDelta));

--- a/test/functional/mempool_packages.py
+++ b/test/functional/mempool_packages.py
@@ -101,6 +101,18 @@ class MempoolPackagesTest(BitcoinTestFramework):
             assert_equal(mempool[x], v_descendants[x])
         assert(chain[0] not in v_descendants.keys())
 
+        # Check that ancestor modified fees includes fee deltas from
+        # prioritisetransaction
+        self.nodes[0].prioritisetransaction(chain[0], 1000)
+        mempool = self.nodes[0].getrawmempool(True)
+        ancestor_fees = 0
+        for x in chain:
+            ancestor_fees += mempool[x]['fee']
+            assert_equal(mempool[x]['ancestorfees'], ancestor_fees * COIN + 1000)
+        
+        # Undo the prioritisetransaction for later tests
+        self.nodes[0].prioritisetransaction(chain[0], -1000)
+
         # Check that descendant modified fees includes fee deltas from
         # prioritisetransaction
         self.nodes[0].prioritisetransaction(chain[-1], 1000)


### PR DESCRIPTION
The prioritisetransaction rpc is supposed to update both the descendant and ancestor modified fees, but in the case of transactions with in-mempool descendants, the ancestor fees of those descendants was incorrect.

First commit updates a test to include a test case, and the second addresses the bug.