### PR TITLE
[trivial] Log calls to getblocktemplate

### DIFF
--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -369,9 +369,7 @@ void JSONRPCRequest::parse(const UniValue& valRequest)
     if (!valMethod.isStr())
         throw JSONRPCError(RPC_INVALID_REQUEST, "Method must be a string");
     strMethod = valMethod.get_str();
-    if (strMethod != "getblocktemplate") {
-        LogPrint(BCLog::RPC, "ThreadRPCServer method=%s\n", SanitizeString(strMethod));
-    }
+    LogPrint(BCLog::RPC, "ThreadRPCServer method=%s\n", SanitizeString(strMethod));
 
     // Parse params
     UniValue valParams = find_value(request, "params");


### PR DESCRIPTION
We don't log when `loggetblocktemplate()` is called.

This is what any other method looks like when it's called:

```
2017-04-06 14:34:48 Received a POST request for / from 127.0.0.1:37080
2017-04-06 14:34:48 ThreadRPCServer method=help
```

and getblocktemplate:

```
2017-04-06 14:35:02 Received a POST request for / from 127.0.0.1:37088
```

This is a holdover from when `getwork` was introduced here: https://github.com/bitcoin/bitcoin/commit/776d0f34595fd616129d4816a337662ff39de7c6#diff-86eca98b63dcc6ac488efdc7de47be31L1421

There's no reason not to log getblocktemplate(). It's annoying not to see the log during testing/debugging.