### PR TITLE
[Wallet] Refactoring by using CInputCoin instead of std::pair

### DIFF
--- a/src/bench/coin_selection.cpp
+++ b/src/bench/coin_selection.cpp
@@ -48,7 +48,7 @@ static void CoinSelection(benchmark::State& state)
             addCoin(1000 * COIN, wallet, vCoins);
         addCoin(3 * COIN, wallet, vCoins);
 
-        std::set<std::pair<const CWalletTx*, unsigned int> > setCoinsRet;
+        std::set<CInputCoin> setCoinsRet;
         CAmount nValueRet;
         bool success = wallet.SelectCoinsMinConf(1003 * COIN, 1, 6, 0, vCoins, setCoinsRet, nValueRet);
         assert(success);

--- a/src/wallet/feebumper.cpp
+++ b/src/wallet/feebumper.cpp
@@ -23,7 +23,7 @@
 int64_t CalculateMaximumSignedTxSize(const CTransaction &tx, const CWallet *pWallet)
 {
     CMutableTransaction txNew(tx);
-    std::vector<std::pair<const CWalletTx *, unsigned int>> vCoins;
+    std::vector<CInputCoin> vCoins;
     // Look up the inputs.  We should have already checked that this transaction
     // IsAllFromMe(ISMINE_SPENDABLE), so every input should already be in our
     // wallet, with a valid index into the vout array.

--- a/src/wallet/feebumper.cpp
+++ b/src/wallet/feebumper.cpp
@@ -30,7 +30,7 @@ int64_t CalculateMaximumSignedTxSize(const CTransaction &tx, const CWallet *pWal
     for (auto& input : tx.vin) {
         const auto mi = pWallet->mapWallet.find(input.prevout.hash);
         assert(mi != pWallet->mapWallet.end() && input.prevout.n < mi->second.tx->vout.size());
-        vCoins.emplace_back(&(mi->second), input.prevout.n);
+        vCoins.emplace_back(CInputCoin(&(mi->second), input.prevout.n));
     }
     if (!pWallet->DummySignTx(txNew, vCoins)) {
         // This should never happen, because IsAllFromMe(ISMINE_SPENDABLE)

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -29,7 +29,7 @@ extern UniValue importmulti(const JSONRPCRequest& request);
 
 std::vector<std::unique_ptr<CWalletTx>> wtxn;
 
-typedef std::set<std::pair<const CWalletTx*,unsigned int> > CoinSet;
+typedef std::set<CInputCoin> CoinSet;
 
 BOOST_FIXTURE_TEST_SUITE(wallet_tests, WalletTestingSetup)
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -475,7 +475,38 @@ public:
 };
 
 
-using CInputCoin = std::pair<const CWalletTx*, unsigned int>;
+class CInputCoin {
+public:
+    CInputCoin()
+    {
+    }
+    CInputCoin(const CWalletTx* walletTx, unsigned int i)
+    {
+        if (walletTx != nullptr && i < walletTx->tx->vout.size())
+        {
+            outpoint = COutPoint(walletTx->GetHash(), i);
+            txout = walletTx->tx->vout[i];
+        }
+    }
+    bool IsNull() const
+    {
+        return outpoint.IsNull() && txout.IsNull();
+    }
+    COutPoint outpoint;
+    CTxOut txout;
+
+    bool operator<(const CInputCoin& rhs) const {
+        return outpoint < rhs.outpoint;
+    }
+
+    bool operator!=(const CInputCoin& rhs) const {
+        return outpoint != rhs.outpoint;
+    }
+
+    bool operator==(const CInputCoin& rhs) const {
+        return outpoint == rhs.outpoint;
+    }
+};
 
 class COutput
 {
@@ -1132,7 +1163,7 @@ bool CWallet::DummySignTx(CMutableTransaction &txNew, const ContainerType &coins
     int nIn = 0;
     for (const auto& coin : coins)
     {
-        const CScript& scriptPubKey = coin.first->tx->vout[coin.second].scriptPubKey;
+        const CScript& scriptPubKey = coin.txout.scriptPubKey;
         SignatureData sigdata;
 
         if (!ProduceSignature(DummySignatureCreator(this), scriptPubKey, sigdata))

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -477,21 +477,17 @@ public:
 
 class CInputCoin {
 public:
-    CInputCoin()
-    {
-    }
     CInputCoin(const CWalletTx* walletTx, unsigned int i)
     {
-        if (walletTx != nullptr && i < walletTx->tx->vout.size())
-        {
-            outpoint = COutPoint(walletTx->GetHash(), i);
-            txout = walletTx->tx->vout[i];
-        }
+        if (!walletTx)
+            throw std::invalid_argument("walletTx should not be null");
+        if (i >= walletTx->tx->vout.size())
+            throw std::out_of_range("The output index is out of range");
+
+        outpoint = COutPoint(walletTx->GetHash(), i);
+        txout = walletTx->tx->vout[i];
     }
-    bool IsNull() const
-    {
-        return outpoint.IsNull() && txout.IsNull();
-    }
+
     COutPoint outpoint;
     CTxOut txout;
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -475,7 +475,7 @@ public:
 };
 
 
-
+using CInputCoin = std::pair<const CWalletTx*, unsigned int>;
 
 class COutput
 {
@@ -632,7 +632,7 @@ private:
      * all coins from coinControl are selected; Never select unconfirmed coins
      * if they are not ours
      */
-    bool SelectCoins(const std::vector<COutput>& vAvailableCoins, const CAmount& nTargetValue, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoinsRet, CAmount& nValueRet, const CCoinControl *coinControl = NULL) const;
+    bool SelectCoins(const std::vector<COutput>& vAvailableCoins, const CAmount& nTargetValue, std::set<CInputCoin>& setCoinsRet, CAmount& nValueRet, const CCoinControl *coinControl = NULL) const;
 
     CWalletDB *pwalletdbEncryption;
 
@@ -780,7 +780,7 @@ public:
      * completion the coin set and corresponding actual target value is
      * assembled
      */
-    bool SelectCoinsMinConf(const CAmount& nTargetValue, int nConfMine, int nConfTheirs, uint64_t nMaxAncestors, std::vector<COutput> vCoins, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoinsRet, CAmount& nValueRet) const;
+    bool SelectCoinsMinConf(const CAmount& nTargetValue, int nConfMine, int nConfTheirs, uint64_t nMaxAncestors, std::vector<COutput> vCoins, std::set<CInputCoin>& setCoinsRet, CAmount& nValueRet) const;
 
     bool IsSpent(const uint256& hash, unsigned int n) const;
 


### PR DESCRIPTION
The code was using `std::pair<const CWalletTx*, unsigned int>` until now. Not only it is ugly to read, and easy to mess up, but it needlessly pass `CWalletTx` all around the code when it is not needed.

This code will simplify another PR extending `FundRawTransaction`. (https://github.com/bitcoin/bitcoin/pull/10068)

This is divided in 3 commits easy to review.

1. Just rename `std::pair<const CWalletTx*, unsigned int>` to `CInputCoin` by using a type alias
2. Transform `CInputCoin` into a class.
3. Rewrite some code which can be simplified thanks to `CInputCoin`