### PR TITLE
Ignore Doxyfile generated from Doxyfile.in template.

### DIFF
--- a/doc/.gitignore
+++ b/doc/.gitignore
@@ -1,0 +1,1 @@
+Doxyfile


### PR DESCRIPTION
After #10155, `doc/Doxyfile` is generated by `configure`. git-ignore it.