### PR TITLE
[trivial] Fix typo ("improssible" → "impossible")

### DIFF
--- a/src/wallet/feebumper.h
+++ b/src/wallet/feebumper.h
@@ -32,7 +32,7 @@ public:
 
     /* signs the new transaction,
      * returns false if the tx couldn't be found or if it was
-     * improssible to create the signature(s)
+     * impossible to create the signature(s)
      */
     bool signTransaction(CWallet *pWallet);
 


### PR DESCRIPTION
Typo introduced in 5f59d3ecb7f1b63579e7f07fc520459cdf119c81 which was merged into `master`  a couple of hours ago.