### PR TITLE
Fix build warning from #error text

### DIFF
--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -11,7 +11,7 @@
 
 // Check that required client information is defined
 #if !defined(CLIENT_VERSION_MAJOR) || !defined(CLIENT_VERSION_MINOR) || !defined(CLIENT_VERSION_REVISION) || !defined(CLIENT_VERSION_BUILD) || !defined(CLIENT_VERSION_IS_RELEASE) || !defined(COPYRIGHT_YEAR)
-#error Client version information missing: wasn't defined by bitcoin-config.h nor defined any other way
+#error Client version information missing: version is not defined by bitcoin-config.h or in any other way
 #endif
 
 /**


### PR DESCRIPTION
Fixes build warning introduced by #10155 

```
In file included from ./wallet/db.h:9:0,
                 from ./wallet/walletdb.h:11,
                 from wallet/wallet.h:18,
                 from init.cpp:44:
./clientversion.h:14:48: warning: missing terminating ' character
 #error Client version information missing: wasn't defined by bitcoin-config.h nor defined any other way
                                                ^
```

repeated many times in the build.

@laanwj 