### PR TITLE
Changed "Send" button default status from true to false

### DIFF
--- a/src/qt/forms/sendcoinsdialog.ui
+++ b/src/qt/forms/sendcoinsdialog.ui
@@ -1235,7 +1235,7 @@
         <bool>false</bool>
        </property>
        <property name="default">
-        <bool>true</bool>
+        <bool>false</bool>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
Changed the "Send" button's default status from true to false to prevent
quirky Windows autofocus behavior.