### PR TITLE
[RPC] Don't default rescan on private/public key imports.

### DIFF
--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -1041,7 +1041,7 @@ UniValue importmulti(const JSONRPCRequest& mainRequest)
     const UniValue& requests = mainRequest.params[0];
 
     //Default options
-    bool fRescan = false;
+    bool fRescan = true;
 
     if (mainRequest.params.size() > 1) {
         const UniValue& options = mainRequest.params[1];

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -110,7 +110,7 @@ UniValue importprivkey(const JSONRPCRequest& request)
         strLabel = request.params[1].get_str();
 
     // Whether to perform rescan after import
-    bool fRescan = true;
+    bool fRescan = false;
     if (request.params.size() > 2)
         fRescan = request.params[2].get_bool();
 
@@ -224,7 +224,7 @@ UniValue importaddress(const JSONRPCRequest& request)
         strLabel = request.params[1].get_str();
 
     // Whether to perform rescan after import
-    bool fRescan = true;
+    bool fRescan = false;
     if (request.params.size() > 2)
         fRescan = request.params[2].get_bool();
 
@@ -389,7 +389,7 @@ UniValue importpubkey(const JSONRPCRequest& request)
         strLabel = request.params[1].get_str();
 
     // Whether to perform rescan after import
-    bool fRescan = true;
+    bool fRescan = false;
     if (request.params.size() > 2)
         fRescan = request.params[2].get_bool();
 
@@ -1041,7 +1041,7 @@ UniValue importmulti(const JSONRPCRequest& mainRequest)
     const UniValue& requests = mainRequest.params[0];
 
     //Default options
-    bool fRescan = true;
+    bool fRescan = false;
 
     if (mainRequest.params.size() > 1) {
         const UniValue& options = mainRequest.params[1];


### PR DESCRIPTION
Don't default rescan on private/public key imports.

Turn the default rescan for importprivkey, importaddress, importpubkey,
importmulti to false to prevent accidental rescanning that is not
cancellable.

Manual rescan should be triggered either through -rescan when restarting
th Bitcoin Core program or manually by setting one of the parameters to
true at the end of batch import.

Accidental rescans should be avoided.