### PR TITLE
[Wallet] Worst case performance improvement on KeyPool filtering

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3020,11 +3020,14 @@ bool CWallet::TopUpKeyPool(unsigned int kpSize)
         }
         bool internal = false;
         CWalletDB walletdb(strWalletFile);
-        for (int64_t i = missingInternal + missingExternal; i--;)
+        for (int64_t i = 0; missingInternal != 0 || missingExternal != 0; i++)
         {
+            internal = (i % 2 == 0 && missingInternal != 0) || missingExternal == 0;
+            if (internal)
+                missingInternal--;
+            else
+                missingExternal--;
             int64_t nEnd = 1;
-            if (i < missingInternal)
-                internal = true;
             if (!setKeyPool.empty())
                 nEnd = *(--setKeyPool.end()) + 1;
             if (!walletdb.WritePool(nEnd, CKeyPool(GenerateNewKey(internal), internal)))


### PR DESCRIPTION
https://github.com/bitcoin/bitcoin/pull/9294 introduced internal HD chain.
This made [ReserveKeyFromPool](https://github.com/bitcoin/bitcoin/blob/67023e9004ba843218bee16bc821e955faf0d394/src/wallet/wallet.cpp#L3039) iterates on the whole keypool (One disk access per key) to find a key matching `internal`.

This PR changes the way `TopUpKeyPool` creates keys in the pool.
Instead of creating all the external keys followed by all the internal keys (which would provoke lots of disk hit in `ReserveKeyFromPool` if `internal` is `true`), it alternates them.
