### PR TITLE
Cache full script execution results in addition to signatures

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1211,6 +1211,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
     LogPrintf("Using at most %i automatic connections (%i file descriptors available)\n", nMaxConnections, nFD);
 
     InitSignatureCache();
+    InitScriptExecutionCache();
 
     LogPrintf("Using %u threads for script verification\n", nScriptCheckThreads);
     if (nScriptCheckThreads) {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -461,7 +461,7 @@ std::string HelpMessage(HelpMessageMode mode)
     {
         strUsage += HelpMessageOpt("-logtimemicros", strprintf("Add microsecond precision to debug timestamps (default: %u)", DEFAULT_LOGTIMEMICROS));
         strUsage += HelpMessageOpt("-mocktime=<n>", "Replace actual time with <n> seconds since epoch (default: 0)");
-        strUsage += HelpMessageOpt("-maxsigcachesize=<n>", strprintf("Limit size of signature cache to <n> MiB (default: %u)", DEFAULT_MAX_SIG_CACHE_SIZE));
+        strUsage += HelpMessageOpt("-maxsigcachesize=<n>", strprintf("Limit sum of signature cache and script execution cache sizes to <n> MiB (default: %u)", DEFAULT_MAX_SIG_CACHE_SIZE));
         strUsage += HelpMessageOpt("-maxtipage=<n>", strprintf("Maximum tip age in seconds to consider node in initial block download (default: %u)", DEFAULT_MAX_TIP_AGE));
     }
     strUsage += HelpMessageOpt("-maxtxfee=<amt>", strprintf(_("Maximum total fees (in %s) to use in a single wallet transaction or raw transaction; setting this too low may abort large transactions (default: %s)"),

--- a/src/script/sigcache.cpp
+++ b/src/script/sigcache.cpp
@@ -74,7 +74,7 @@ void InitSignatureCache()
 {
     // nMaxCacheSize is unsigned. If -maxsigcachesize is set to zero,
     // setup_bytes creates the minimum possible cache (2 elements).
-    size_t nMaxCacheSize = std::min(std::max((int64_t)0, GetArg("-maxsigcachesize", DEFAULT_MAX_SIG_CACHE_SIZE)), MAX_MAX_SIG_CACHE_SIZE) * ((size_t) 1 << 20);
+    size_t nMaxCacheSize = std::min(std::max((int64_t)0, GetArg("-maxsigcachesize", DEFAULT_MAX_SIG_CACHE_SIZE) / 2), MAX_MAX_SIG_CACHE_SIZE) * ((size_t) 1 << 20);
     size_t nElems = signatureCache.setup_bytes(nMaxCacheSize);
     LogPrintf("Using %zu MiB out of %zu requested for signature cache, able to store %zu elements\n",
             (nElems*sizeof(uint256)) >>20, nMaxCacheSize>>20, nElems);

--- a/src/script/sigcache.cpp
+++ b/src/script/sigcache.cpp
@@ -76,8 +76,8 @@ void InitSignatureCache()
     // setup_bytes creates the minimum possible cache (2 elements).
     size_t nMaxCacheSize = std::min(std::max((int64_t)0, GetArg("-maxsigcachesize", DEFAULT_MAX_SIG_CACHE_SIZE) / 2), MAX_MAX_SIG_CACHE_SIZE) * ((size_t) 1 << 20);
     size_t nElems = signatureCache.setup_bytes(nMaxCacheSize);
-    LogPrintf("Using %zu MiB out of %zu requested for signature cache, able to store %zu elements\n",
-            (nElems*sizeof(uint256)) >>20, nMaxCacheSize>>20, nElems);
+    LogPrintf("Using %zu MiB out of %zu/2 requested for signature cache, able to store %zu elements\n",
+            (nElems*sizeof(uint256)) >>20, (nMaxCacheSize*2)>>20, nElems);
 }
 
 bool CachingTransactionSignatureChecker::VerifySignature(const std::vector<unsigned char>& vchSig, const CPubKey& pubkey, const uint256& sighash) const

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -39,6 +39,7 @@ BasicTestingSetup::BasicTestingSetup(const std::string& chainName)
         SetupEnvironment();
         SetupNetworking();
         InitSignatureCache();
+        InitScriptExecutionCache();
         fPrintToDebugLog = false; // don't want to write to debug.log file
         fCheckBlockIndex = true;
         SelectParams(chainName);

--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -10,10 +10,16 @@
 #include "txmempool.h"
 #include "random.h"
 #include "script/standard.h"
+#include "script/sign.h"
 #include "test/test_bitcoin.h"
 #include "utiltime.h"
+#include "core_io.h"
+#include "keystore.h"
+#include "policy/policy.h"
 
 #include <boost/test/unit_test.hpp>
+
+bool CheckInputs(const CTransaction& tx, CValidationState &state, const CCoinsViewCache &inputs, bool fScriptChecks, unsigned int flags, bool cacheSigStore, bool cacheFullScriptStore, PrecomputedTransactionData& txdata, std::vector<CScriptCheck> *pvChecks);
 
 BOOST_AUTO_TEST_SUITE(tx_validationcache_tests)
 
@@ -82,6 +88,284 @@ BOOST_FIXTURE_TEST_CASE(tx_mempool_block_doublespend, TestChain100Setup)
     // spends[1] should have been removed from the mempool when the
     // block with spends[0] is accepted:
     BOOST_CHECK_EQUAL(mempool.size(), 0);
+}
+
+// Run CheckInputs (using pcoinsTip) on the given transaction, for all script
+// flags.  Test that CheckInputs passes for all flags that don't overlap with
+// the failing_flags argument, but otherwise fails.
+// CHECKLOCKTIMEVERIFY and CHECKSEQUENCEVERIFY (and future NOP codes that may
+// get reassigned) have an interaction with DISCOURAGE_UPGRADABLE_NOPS: if
+// the script flags used contain DISCOURAGE_UPGRADABLE_NOPS but don't contain
+// CHECKLOCKTIMEVERIFY (or CHECKSEQUENCEVERIFY), but the script does contain
+// OP_CHECKLOCKTIMEVERIFY (or OP_CHECKSEQUENCEVERIFY), then script execution
+// should fail.
+// Capture this interaction with the upgraded_nop argument: set it when evaluating
+// any script flag that is implemented as an upgraded NOP code.
+void ValidateCheckInputsForAllFlags(CMutableTransaction &tx, uint32_t failing_flags, bool add_to_cache, bool upgraded_nop)
+{
+    PrecomputedTransactionData txdata(tx);
+    // If we add many more flags, this loop can get too expensive, but we can
+    // rewrite in the future to randomly pick a set of flags to evaluate.
+    for (uint32_t test_flags=0; test_flags < (1U << 16); test_flags += 1) {
+        CValidationState state;
+        // Filter out incompatible flag choices
+        if ((test_flags & SCRIPT_VERIFY_CLEANSTACK)) {
+            // CLEANSTACK requires P2SH and WITNESS, see VerifyScript() in
+            // script/interpreter.cpp
+            test_flags |= SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS;
+        }
+        if ((test_flags & SCRIPT_VERIFY_WITNESS)) {
+            // WITNESS requires P2SH
+            test_flags |= SCRIPT_VERIFY_P2SH;
+        }
+        bool ret = CheckInputs(tx, state, pcoinsTip, true, test_flags, true, add_to_cache, txdata, nullptr);
+        // CheckInputs should succeed iff test_flags doesn't intersect with
+        // failing_flags
+        bool expected_return_value = !(test_flags & failing_flags);
+        if (expected_return_value && upgraded_nop) {
+            // If the script flag being tested corresponds to an upgraded NOP,
+            // then script execution should fail if DISCOURAGE_UPGRADABLE_NOPS
+            // is set.
+            expected_return_value = !(test_flags & SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_NOPS);
+        }
+        BOOST_CHECK_EQUAL(ret, expected_return_value);
+
+        // Test the caching
+        if (ret && add_to_cache) {
+            // Check that we get a cache hit if the tx was valid
+            std::vector<CScriptCheck> scriptchecks;
+            BOOST_CHECK(CheckInputs(tx, state, pcoinsTip, true, test_flags, true, add_to_cache, txdata, &scriptchecks));
+            BOOST_CHECK(scriptchecks.empty());
+        } else {
+            // Check that we get script executions to check, if the transaction
+            // was invalid, or we didn't add to cache.
+            std::vector<CScriptCheck> scriptchecks;
+            BOOST_CHECK(CheckInputs(tx, state, pcoinsTip, true, test_flags, true, add_to_cache, txdata, &scriptchecks));
+            BOOST_CHECK_EQUAL(scriptchecks.size(), tx.vin.size());
+        }
+    }
+}
+
+BOOST_FIXTURE_TEST_CASE(checkinputs_test, TestChain100Setup)
+{
+    // Test that passing CheckInputs with one set of script flags doesn't imply
+    // that we would pass again with a different set of flags.
+    InitScriptExecutionCache();
+
+    CScript p2pk_scriptPubKey = CScript() << ToByteVector(coinbaseKey.GetPubKey()) << OP_CHECKSIG;
+    CScript p2sh_scriptPubKey = GetScriptForDestination(CScriptID(p2pk_scriptPubKey));
+    CScript p2pkh_scriptPubKey = GetScriptForDestination(coinbaseKey.GetPubKey().GetID());
+    CScript p2wpkh_scriptPubKey = GetScriptForWitness(p2pkh_scriptPubKey);
+
+    CBasicKeyStore keystore;
+    keystore.AddKey(coinbaseKey);
+    keystore.AddCScript(p2pk_scriptPubKey);
+
+    // flags to test: SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY, SCRIPT_VERIFY_CHECKSEQUENCE_VERIFY, SCRIPT_VERIFY_NULLDUMMY, uncompressed pubkey thing
+
+    // Create 2 outputs that match the three scripts above, spending the first
+    // coinbase tx.
+    CMutableTransaction spend_tx;
+
+    spend_tx.nVersion = 1;
+    spend_tx.vin.resize(1);
+    spend_tx.vin[0].prevout.hash = coinbaseTxns[0].GetHash();
+    spend_tx.vin[0].prevout.n = 0;
+    spend_tx.vout.resize(4);
+    spend_tx.vout[0].nValue = 11*CENT;
+    spend_tx.vout[0].scriptPubKey = p2sh_scriptPubKey;
+    spend_tx.vout[1].nValue = 11*CENT;
+    spend_tx.vout[1].scriptPubKey = p2wpkh_scriptPubKey;
+    spend_tx.vout[2].nValue = 11*CENT;
+    spend_tx.vout[2].scriptPubKey = CScript() << OP_CHECKLOCKTIMEVERIFY << OP_DROP << ToByteVector(coinbaseKey.GetPubKey()) << OP_CHECKSIG;
+    spend_tx.vout[3].nValue = 11*CENT;
+    spend_tx.vout[3].scriptPubKey = CScript() << OP_CHECKSEQUENCEVERIFY << OP_DROP << ToByteVector(coinbaseKey.GetPubKey()) << OP_CHECKSIG;
+
+    // Sign, with a non-DER signature
+    {
+        std::vector<unsigned char> vchSig;
+        uint256 hash = SignatureHash(p2pk_scriptPubKey, spend_tx, 0, SIGHASH_ALL, 0, SIGVERSION_BASE);
+        BOOST_CHECK(coinbaseKey.Sign(hash, vchSig));
+        vchSig.push_back((unsigned char) 0); // padding byte makes this non-DER
+        vchSig.push_back((unsigned char)SIGHASH_ALL);
+        spend_tx.vin[0].scriptSig << vchSig;
+    }
+
+    LOCK(cs_main);
+
+    // Test that invalidity under a set of flags doesn't preclude validity
+    // under other (eg consensus) flags.
+    // spend_tx is invalid according to DERSIG
+    CValidationState state;
+    {
+        PrecomputedTransactionData ptd_spend_tx(spend_tx);
+
+        BOOST_CHECK(!CheckInputs(spend_tx, state, pcoinsTip, true, SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_DERSIG, true, true, ptd_spend_tx, nullptr));
+
+        // If we call again asking for scriptchecks (as happens in
+        // ConnectBlock), we should add a script check object for this -- we're
+        // not caching invalidity (if that changes, delete this test case).
+        std::vector<CScriptCheck> scriptchecks;
+        BOOST_CHECK(CheckInputs(spend_tx, state, pcoinsTip, true, SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_DERSIG, true, true, ptd_spend_tx, &scriptchecks));
+        BOOST_CHECK_EQUAL(scriptchecks.size(), 1);
+
+        // Test that CheckInputs returns true iff DERSIG-enforcing flags are
+        // not present.  Don't add these checks to the cache, so that we can
+        // test later that block validation works fine in the absence of cached
+        // successes.
+        ValidateCheckInputsForAllFlags(spend_tx, SCRIPT_VERIFY_DERSIG | SCRIPT_VERIFY_LOW_S | SCRIPT_VERIFY_STRICTENC, false, false);
+
+        // And if we produce a block with this tx, it should be valid (DERSIG not
+        // enabled yet), even though there's no cache entry.
+        CBlock block;
+
+        block = CreateAndProcessBlock({spend_tx}, p2pk_scriptPubKey);
+        BOOST_CHECK(chainActive.Tip()->GetBlockHash() == block.GetHash());
+        BOOST_CHECK(pcoinsTip->GetBestBlock() == block.GetHash());
+    }
+
+    // Test P2SH: construct a transaction that is valid without P2SH, and
+    // then test validity with P2SH.
+    {
+        CMutableTransaction invalid_under_p2sh_tx;
+        invalid_under_p2sh_tx.nVersion = 1;
+        invalid_under_p2sh_tx.vin.resize(1);
+        invalid_under_p2sh_tx.vin[0].prevout.hash = spend_tx.GetHash();
+        invalid_under_p2sh_tx.vin[0].prevout.n = 0;
+        invalid_under_p2sh_tx.vout.resize(1);
+        invalid_under_p2sh_tx.vout[0].nValue = 11*CENT;
+        invalid_under_p2sh_tx.vout[0].scriptPubKey = p2pk_scriptPubKey;
+        std::vector<unsigned char> vchSig2(p2pk_scriptPubKey.begin(), p2pk_scriptPubKey.end());
+        invalid_under_p2sh_tx.vin[0].scriptSig << vchSig2;
+
+        ValidateCheckInputsForAllFlags(invalid_under_p2sh_tx, SCRIPT_VERIFY_P2SH, true, false);
+    }
+
+    // Test CHECKLOCKTIMEVERIFY
+    {
+        CMutableTransaction invalid_with_cltv_tx;
+        invalid_with_cltv_tx.nVersion = 1;
+        invalid_with_cltv_tx.nLockTime = 100;
+        invalid_with_cltv_tx.vin.resize(1);
+        invalid_with_cltv_tx.vin[0].prevout.hash = spend_tx.GetHash();
+        invalid_with_cltv_tx.vin[0].prevout.n = 2;
+        invalid_with_cltv_tx.vin[0].nSequence = 0;
+        invalid_with_cltv_tx.vout.resize(1);
+        invalid_with_cltv_tx.vout[0].nValue = 11*CENT;
+        invalid_with_cltv_tx.vout[0].scriptPubKey = p2pk_scriptPubKey;
+
+        // Sign
+        std::vector<unsigned char> vchSig;
+        uint256 hash = SignatureHash(spend_tx.vout[2].scriptPubKey, invalid_with_cltv_tx, 0, SIGHASH_ALL, 0, SIGVERSION_BASE);
+        BOOST_CHECK(coinbaseKey.Sign(hash, vchSig));
+        vchSig.push_back((unsigned char)SIGHASH_ALL);
+        invalid_with_cltv_tx.vin[0].scriptSig = CScript() << vchSig << 101;
+
+        ValidateCheckInputsForAllFlags(invalid_with_cltv_tx, SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY, true, true);
+
+        // Make it valid, and check again
+        invalid_with_cltv_tx.vin[0].scriptSig = CScript() << vchSig << 100;
+        CValidationState state;
+        PrecomputedTransactionData txdata(invalid_with_cltv_tx);
+        BOOST_CHECK(CheckInputs(invalid_with_cltv_tx, state, pcoinsTip, true, SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY, true, true, txdata, nullptr));
+    }
+
+    // TEST CHECKSEQUENCEVERIFY
+    {
+        CMutableTransaction invalid_with_csv_tx;
+        invalid_with_csv_tx.nVersion = 2;
+        invalid_with_csv_tx.vin.resize(1);
+        invalid_with_csv_tx.vin[0].prevout.hash = spend_tx.GetHash();
+        invalid_with_csv_tx.vin[0].prevout.n = 3;
+        invalid_with_csv_tx.vin[0].nSequence = 100;
+        invalid_with_csv_tx.vout.resize(1);
+        invalid_with_csv_tx.vout[0].nValue = 11*CENT;
+        invalid_with_csv_tx.vout[0].scriptPubKey = p2pk_scriptPubKey;
+
+        // Sign
+        std::vector<unsigned char> vchSig;
+        uint256 hash = SignatureHash(spend_tx.vout[3].scriptPubKey, invalid_with_csv_tx, 0, SIGHASH_ALL, 0, SIGVERSION_BASE);
+        BOOST_CHECK(coinbaseKey.Sign(hash, vchSig));
+        vchSig.push_back((unsigned char)SIGHASH_ALL);
+        invalid_with_csv_tx.vin[0].scriptSig = CScript() << vchSig << 101;
+
+        ValidateCheckInputsForAllFlags(invalid_with_csv_tx, SCRIPT_VERIFY_CHECKSEQUENCEVERIFY, true, true);
+
+        // Make it valid, and check again
+        invalid_with_csv_tx.vin[0].scriptSig = CScript() << vchSig << 100;
+        CValidationState state;
+        PrecomputedTransactionData txdata(invalid_with_csv_tx);
+        BOOST_CHECK(CheckInputs(invalid_with_csv_tx, state, pcoinsTip, true, SCRIPT_VERIFY_CHECKSEQUENCEVERIFY, true, true, txdata, nullptr));
+    }
+
+    // TODO: add tests for remaining script flags
+
+    // Test that passing CheckInputs with a valid witness doesn't imply success
+    // for the same tx with a different witness.
+    {
+        CMutableTransaction valid_with_witness_tx;
+        valid_with_witness_tx.nVersion = 1;
+        valid_with_witness_tx.vin.resize(1);
+        valid_with_witness_tx.vin[0].prevout.hash = spend_tx.GetHash();
+        valid_with_witness_tx.vin[0].prevout.n = 1;
+        valid_with_witness_tx.vout.resize(1);
+        valid_with_witness_tx.vout[0].nValue = 11*CENT;
+        valid_with_witness_tx.vout[0].scriptPubKey = p2pk_scriptPubKey;
+
+        // Sign
+        SignatureData sigdata;
+        ProduceSignature(MutableTransactionSignatureCreator(&keystore, &valid_with_witness_tx, 0, 11*CENT, SIGHASH_ALL), spend_tx.vout[1].scriptPubKey, sigdata);
+        UpdateTransaction(valid_with_witness_tx, 0, sigdata);
+
+        // This should be valid under all script flags.
+        ValidateCheckInputsForAllFlags(valid_with_witness_tx, 0, true, false);
+
+        // Remove the witness, and check that it is now invalid.
+        valid_with_witness_tx.vin[0].scriptWitness.SetNull();
+        ValidateCheckInputsForAllFlags(valid_with_witness_tx, SCRIPT_VERIFY_WITNESS, true, false);
+    }
+
+    {
+        // Test a transaction with multiple inputs.
+        CMutableTransaction tx;
+
+        tx.nVersion = 1;
+        tx.vin.resize(2);
+        tx.vin[0].prevout.hash = spend_tx.GetHash();
+        tx.vin[0].prevout.n = 0;
+        tx.vin[1].prevout.hash = spend_tx.GetHash();
+        tx.vin[1].prevout.n = 1;
+        tx.vout.resize(1);
+        tx.vout[0].nValue = 22*CENT;
+        tx.vout[0].scriptPubKey = p2pk_scriptPubKey;
+
+        // Sign
+        for (int i=0; i<2; ++i) {
+            SignatureData sigdata;
+            ProduceSignature(MutableTransactionSignatureCreator(&keystore, &tx, i, 11*CENT, SIGHASH_ALL), spend_tx.vout[i].scriptPubKey, sigdata);
+            UpdateTransaction(tx, i, sigdata);
+        }
+
+        // This should be valid under all script flags
+        ValidateCheckInputsForAllFlags(tx, 0, true, false);
+
+        // Check that if the second input is invalid, but the first input is
+        // valid, the transaction is not cached.
+        // Invalidate vin[1]
+        tx.vin[1].scriptWitness.SetNull();
+
+        CValidationState state;
+        PrecomputedTransactionData txdata(tx);
+        // This transaction is now invalid under segwit, because of the second input.
+        BOOST_CHECK(!CheckInputs(tx, state, pcoinsTip, true, SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS, true, true, txdata, nullptr));
+
+        std::vector<CScriptCheck> scriptchecks;
+        // Make sure this transaction was not cached (ie because the first
+        // input was valid)
+        BOOST_CHECK(CheckInputs(tx, state, pcoinsTip, true, SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS, true, true, txdata, &scriptchecks));
+        // Should get 2 script checks back -- caching is on a whole-transaction basis.
+        BOOST_CHECK_EQUAL(scriptchecks.size(), 2);
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -784,8 +784,20 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
         unsigned int currentBlockScriptVerifyFlags = GetBlockScriptFlags(chainActive.Tip(), Params().GetConsensus());
         if (!CheckInputs(tx, state, view, true, currentBlockScriptVerifyFlags, true, true, txdata))
         {
-            return error("%s: BUG! PLEASE REPORT THIS! ConnectInputs failed against MANDATORY but not STANDARD flags %s, %s",
-                __func__, hash.ToString(), FormatStateMessage(state));
+            // If we're using promiscuousmempoolflags, we may hit this normally
+            // Check if current block has some flags that scriptVerifyFlags
+            // does not before printing an ominous warning
+            if (!(~scriptVerifyFlags & currentBlockScriptVerifyFlags)) {
+                return error("%s: BUG! PLEASE REPORT THIS! ConnectInputs failed against latest-block but not STANDARD flags %s, %s",
+                    __func__, hash.ToString(), FormatStateMessage(state));
+            } else {
+                if (!CheckInputs(tx, state, view, true, MANDATORY_SCRIPT_VERIFY_FLAGS, true, false, txdata)) {
+                    return error("%s: ConnectInputs failed against MANDATORY but not STANDARD flags due to promiscuous mempool %s, %s",
+                        __func__, hash.ToString(), FormatStateMessage(state));
+                } else {
+                    LogPrintf("Warning: -promiscuousmempool flags set to not include currently enforced soft forks, this may break mining or otherwise cause instability!\n");
+                }
+            }
         }
 
         // Remove conflicting transactions from the mempool

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1223,8 +1223,15 @@ void InitScriptExecutionCache() {
 
 /**
  * Check whether all inputs of this transaction are valid (no double spends, scripts & sigs, amounts)
- * This does not modify the UTXO set. If pvChecks is not NULL, script checks are pushed onto it
- * instead of being performed inline.
+ * This does not modify the UTXO set.
+ *
+ * If pvChecks is not NULL, script checks are pushed onto it instead of being performed inline. Any
+ * script checks which are not necessary (eg due to script execution cache hits) are, obviously,
+ * not pushed onto pvChecks/run.
+ *
+ * Setting cacheSigStore/cacheFullScriptStore to false will remove elements from the corresponding cache
+ * which are matched. This is useful for checking blocks where we will likely never need the cache
+ * entry again.
  */
 static bool CheckInputs(const CTransaction& tx, CValidationState &state, const CCoinsViewCache &inputs, bool fScriptChecks, unsigned int flags, bool cacheSigStore, bool cacheFullScriptStore, PrecomputedTransactionData& txdata, std::vector<CScriptCheck> *pvChecks)
 {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1217,8 +1217,8 @@ void InitScriptExecutionCache() {
     // setup_bytes creates the minimum possible cache (2 elements).
     size_t nMaxCacheSize = std::min(std::max((int64_t)0, GetArg("-maxsigcachesize", DEFAULT_MAX_SIG_CACHE_SIZE) / 2), MAX_MAX_SIG_CACHE_SIZE) * ((size_t) 1 << 20);
     size_t nElems = scriptExecutionCache.setup_bytes(nMaxCacheSize);
-    LogPrintf("Using %zu MiB out of %zu requested for script execution cache, able to store %zu elements\n",
-            (nElems*sizeof(uint256)) >>20, nMaxCacheSize>>20, nElems);
+    LogPrintf("Using %zu MiB out of %zu/2 requested for script execution cache, able to store %zu elements\n",
+            (nElems*sizeof(uint256)) >>20, (nMaxCacheSize*2)>>20, nElems);
 }
 
 /**

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -190,7 +190,7 @@ enum FlushStateMode {
 static bool FlushStateToDisk(const CChainParams& chainParams, CValidationState &state, FlushStateMode mode, int nManualPruneHeight=0);
 static void FindFilesToPruneManual(std::set<int>& setFilesToPrune, int nManualPruneHeight);
 static void FindFilesToPrune(std::set<int>& setFilesToPrune, uint64_t nPruneAfterHeight);
-static bool CheckInputs(const CTransaction& tx, CValidationState &state, const CCoinsViewCache &inputs, bool fScriptChecks, unsigned int flags, bool cacheSigStore, bool cacheFullScriptStore, PrecomputedTransactionData& txdata, std::vector<CScriptCheck> *pvChecks = nullptr);
+bool CheckInputs(const CTransaction& tx, CValidationState &state, const CCoinsViewCache &inputs, bool fScriptChecks, unsigned int flags, bool cacheSigStore, bool cacheFullScriptStore, PrecomputedTransactionData& txdata, std::vector<CScriptCheck> *pvChecks = nullptr);
 static FILE* OpenUndoFile(const CDiskBlockPos &pos, bool fReadOnly = false);
 
 bool CheckFinalTx(const CTransaction &tx, int flags)
@@ -1232,8 +1232,10 @@ void InitScriptExecutionCache() {
  * Setting cacheSigStore/cacheFullScriptStore to false will remove elements from the corresponding cache
  * which are matched. This is useful for checking blocks where we will likely never need the cache
  * entry again.
+ *
+ * Non-static (and re-declared) in src/test/txvalidationcache_tests.cpp
  */
-static bool CheckInputs(const CTransaction& tx, CValidationState &state, const CCoinsViewCache &inputs, bool fScriptChecks, unsigned int flags, bool cacheSigStore, bool cacheFullScriptStore, PrecomputedTransactionData& txdata, std::vector<CScriptCheck> *pvChecks)
+bool CheckInputs(const CTransaction& tx, CValidationState &state, const CCoinsViewCache &inputs, bool fScriptChecks, unsigned int flags, bool cacheSigStore, bool cacheFullScriptStore, PrecomputedTransactionData& txdata, std::vector<CScriptCheck> *pvChecks)
 {
     if (!tx.IsCoinBase())
     {

--- a/src/validation.h
+++ b/src/validation.h
@@ -394,6 +394,9 @@ public:
     ScriptError GetScriptError() const { return error; }
 };
 
+/** Initializes the script-execution cache */
+void InitScriptExecutionCache();
+
 
 /** Functions for disk access for blocks */
 bool ReadBlockFromDisk(CBlock& block, const CDiskBlockPos& pos, const Consensus::Params& consensusParams);


### PR DESCRIPTION
This adds a new CuckooCache in validation, caching whether all of a
transaction's scripts were valid with a given set of script flags.

Unlike previous attempts at caching an entire transaction's
validity, which have nearly universally introduced consensus
failures, this only caches the validity of a transaction's
scriptSigs. As these are pure functions of the transaction and
data it commits to, this should be much safer.

This is somewhat duplicative with the sigcache, as entries in the
new cache will also have several entries in the sigcache. However,
the sigcache is kept both as ATMP relies on it and because it
prevents malleability-based DoS attacks on the new higher-level
cache. Instead, the -sigcachesize option is re-used - cutting the
sigcache size in half and using the newly freed memory for the
script execution cache.

Transactions which match the script execution cache never even have
entries in the script check thread's workqueue created.

Note that the cache is indexed only on the script execution flags
and the transaction's witness hash. While this is sufficient to
make the CScriptCheck() calls pure functions, this introduces
dependancies on the mempool calculating things such as the
PrecomputedTransactionData object, filling the CCoinsViewCache, etc
in the exact same way as ConnectBlock. I belive this is a reasonable
assumption, but should be noted carefully.

In a rather naive benchmark (reindex-chainstate up to block 284k
with cuckoocache always returning true for contains(),
-assumevalid=0 and a very large dbcache), this connected blocks
~1.7x faster.