### PR TITLE
Remove unecessary friend keyword from the class definition

### DIFF
--- a/src/coins.h
+++ b/src/coins.h
@@ -134,7 +134,7 @@ public:
     }
 
     //! equality test
-    friend bool operator==(const CCoins &a, const CCoins &b) {
+    bool operator==(const CCoins &a, const CCoins &b) {
          // Empty CCoins objects are always equal.
          if (a.IsPruned() && b.IsPruned())
              return true;
@@ -143,7 +143,8 @@ public:
                 a.nVersion == b.nVersion &&
                 a.vout == b.vout;
     }
-    friend bool operator!=(const CCoins &a, const CCoins &b) {
+    
+    bool operator!=(const CCoins &a, const CCoins &b) {
         return !(a == b);
     }
 

--- a/src/coins.h
+++ b/src/coins.h
@@ -134,14 +134,14 @@ public:
     }
 
     //! equality test
-    bool operator==(const CCoins &a, const CCoins &b) {
+    bool operator==(const CCoins &rhs) {
          // Empty CCoins objects are always equal.
-         if (a.IsPruned() && b.IsPruned())
+         if (IsPruned() && rhs.IsPruned())
              return true;
-         return a.fCoinBase == b.fCoinBase &&
-                a.nHeight == b.nHeight &&
-                a.nVersion == b.nVersion &&
-                a.vout == b.vout;
+         return fCoinBase == rhs.fCoinBase &&
+                nHeight == rhs.nHeight &&
+                nVersion == rhs.nVersion &&
+                vout == rhs.vout;
     }
     
     bool operator!=(const CCoins &a, const CCoins &b) {

--- a/src/coins.h
+++ b/src/coins.h
@@ -144,8 +144,8 @@ public:
                 vout == rhs.vout;
     }
     
-    bool operator!=(const CCoins &a, const CCoins &b) {
-        return !(a == b);
+    bool operator!=(const CCoins &rhs) {
+        return !(*this == rhs);
     }
 
     void CalcMaskSize(unsigned int &nBytes, unsigned int &nNonzeroBytes) const;


### PR DESCRIPTION
The fewer the friends in a C++ code base, the better. Increased readability, less invasive coupling, better style. Also, if used, friend funcs should only declared within the scope of a class, and then defined outside of the class.