### PR TITLE
[tests] Functional test warnings

### DIFF
--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -163,6 +163,7 @@ def main():
     parser.add_argument('--force', '-f', action='store_true', help='run tests even on platforms where they are disabled by default (e.g. windows).')
     parser.add_argument('--help', '-h', '-?', action='store_true', help='print help text and exit')
     parser.add_argument('--jobs', '-j', type=int, default=4, help='how many test scripts to run in parallel. Default=4.')
+    parser.add_argument('--keepcache', '-k', action='store_true', help='the default behavior is to flush the cache directory on startup. --keepcache retains the cache from the previous testrun.')
     parser.add_argument('--quiet', '-q', action='store_true', help='only print results summary and failure logs')
     parser.add_argument('--nozmq', action='store_true', help='do not run the zmq tests')
     args, unknown_args = parser.parse_known_args()
@@ -240,6 +241,9 @@ def main():
         sys.exit(0)
 
     check_script_list(config["environment"]["SRCDIR"])
+
+    if not args.keepcache:
+        shutil.rmtree("%s/test/cache" % config["environment"]["BUILDDIR"], ignore_errors=True)
 
     run_tests(test_list, config["environment"]["SRCDIR"], config["environment"]["BUILDDIR"], config["environment"]["EXEEXT"], args.jobs, args.coverage, passon_args)
 


### PR DESCRIPTION
Two changes:

1. Issue warnings when running test_runner:

- if there are python files in the directory that are not listed in test_runner (this is downgraded from an error)
- if there is already a bitcoind process running on the system (uses pidof - only works for linux)
- if there is a cache directory

2. delete cache directory every time test_runner is started. Adds a parameter --keepcache to override the default behaviour and keep the cache directory from the previous run.

Rebuilding the cache takes about 21 seconds on my pc. This will be reduced to just under 2 seconds once #10082 has been fully merged.