### PR TITLE
[tests] Remove is_network_split from functional test framework

### DIFF
--- a/test/functional/abandonconflict.py
+++ b/test/functional/abandonconflict.py
@@ -20,12 +20,7 @@ class AbandonConflictTest(BitcoinTestFramework):
         super().__init__()
         self.num_nodes = 2
         self.setup_clean_chain = False
-
-    def setup_network(self):
-        self.nodes = []
-        self.nodes.append(start_node(0, self.options.tmpdir, ["-minrelaytxfee=0.00001"]))
-        self.nodes.append(start_node(1, self.options.tmpdir))
-        connect_nodes(self.nodes[0], 1)
+        self.extra_args = [["-minrelaytxfee=0.00001"], []]
 
     def run_test(self):
         self.nodes[1].generate(100)

--- a/test/functional/bip65-cltv-p2p.py
+++ b/test/functional/bip65-cltv-p2p.py
@@ -39,12 +39,7 @@ class BIP65Test(ComparisonTestFramework):
     def __init__(self):
         super().__init__()
         self.num_nodes = 1
-
-    def setup_network(self):
-        # Must set the blockversion for this test
-        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir,
-                                 extra_args=[['-whitelist=127.0.0.1', '-blockversion=3']],
-                                 binary=[self.options.testbinary])
+        self.extra_args = [['-whitelist=127.0.0.1', '-blockversion=3']]
 
     def run_test(self):
         test = TestManager(self, self.options.tmpdir)

--- a/test/functional/bip65-cltv.py
+++ b/test/functional/bip65-cltv.py
@@ -12,15 +12,12 @@ class BIP65Test(BitcoinTestFramework):
         super().__init__()
         self.num_nodes = 3
         self.setup_clean_chain = False
+        self.extra_args = [[], ["-blockversion=3"], ["-blockversion=4"]]
 
     def setup_network(self):
-        self.nodes = []
-        self.nodes.append(start_node(0, self.options.tmpdir, []))
-        self.nodes.append(start_node(1, self.options.tmpdir, ["-blockversion=3"]))
-        self.nodes.append(start_node(2, self.options.tmpdir, ["-blockversion=4"]))
+        self.setup_nodes()
         connect_nodes(self.nodes[1], 0)
         connect_nodes(self.nodes[2], 0)
-        self.is_network_split = False
         self.sync_all()
 
     def run_test(self):

--- a/test/functional/bip68-112-113-p2p.py
+++ b/test/functional/bip68-112-113-p2p.py
@@ -95,12 +95,7 @@ class BIP68_112_113Test(ComparisonTestFramework):
     def __init__(self):
         super().__init__()
         self.num_nodes = 1
-
-    def setup_network(self):
-        # Must set the blockversion for this test
-        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir,
-                                 extra_args=[['-whitelist=127.0.0.1', '-blockversion=4']],
-                                 binary=[self.options.testbinary])
+        self.extra_args = [['-whitelist=127.0.0.1', '-blockversion=4']]
 
     def run_test(self):
         test = TestManager(self, self.options.tmpdir)

--- a/test/functional/bip68-sequence.py
+++ b/test/functional/bip68-sequence.py
@@ -21,16 +21,11 @@ class BIP68Test(BitcoinTestFramework):
         super().__init__()
         self.num_nodes = 2
         self.setup_clean_chain = False
-
-    def setup_network(self):
-        self.nodes = []
-        self.nodes.append(start_node(0, self.options.tmpdir))
-        self.nodes.append(start_node(1, self.options.tmpdir, ["-acceptnonstdtxn=0"]))
-        self.is_network_split = False
-        self.relayfee = self.nodes[0].getnetworkinfo()["relayfee"]
-        connect_nodes(self.nodes[0], 1)
+        self.extra_args = [[], ["-acceptnonstdtxn=0"]]
 
     def run_test(self):
+        self.relayfee = self.nodes[0].getnetworkinfo()["relayfee"]
+
         # Generate some coins
         self.nodes[0].generate(110)
 

--- a/test/functional/bip9-softforks.py
+++ b/test/functional/bip9-softforks.py
@@ -32,11 +32,7 @@ class BIP9SoftForksTest(ComparisonTestFramework):
     def __init__(self):
         super().__init__()
         self.num_nodes = 1
-
-    def setup_network(self):
-        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir,
-                                 extra_args=[['-whitelist=127.0.0.1']],
-                                 binary=[self.options.testbinary])
+        self.extra_args = [['-whitelist=127.0.0.1']]
 
     def run_test(self):
         self.test = TestManager(self, self.options.tmpdir)

--- a/test/functional/bipdersig-p2p.py
+++ b/test/functional/bipdersig-p2p.py
@@ -47,12 +47,6 @@ class BIP66Test(ComparisonTestFramework):
         super().__init__()
         self.num_nodes = 1
 
-    def setup_network(self):
-        # Must set the blockversion for this test
-        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir,
-                                 extra_args=[['-whitelist=127.0.0.1', '-blockversion=2']],
-                                 binary=[self.options.testbinary])
-
     def run_test(self):
         test = TestManager(self, self.options.tmpdir)
         test.add_all_connections(self.nodes)

--- a/test/functional/bipdersig.py
+++ b/test/functional/bipdersig.py
@@ -12,15 +12,12 @@ class BIP66Test(BitcoinTestFramework):
         super().__init__()
         self.num_nodes = 3
         self.setup_clean_chain = False
+        self.extra_args = [[], ["-blockversion=2"], ["-blockversion=3"]]
 
     def setup_network(self):
-        self.nodes = []
-        self.nodes.append(start_node(0, self.options.tmpdir, []))
-        self.nodes.append(start_node(1, self.options.tmpdir, ["-blockversion=2"]))
-        self.nodes.append(start_node(2, self.options.tmpdir, ["-blockversion=3"]))
+        self.setup_nodes()
         connect_nodes(self.nodes[1], 0)
         connect_nodes(self.nodes[2], 0)
-        self.is_network_split = False
         self.sync_all()
 
     def run_test(self):

--- a/test/functional/blockchain.py
+++ b/test/functional/blockchain.py
@@ -35,12 +35,6 @@ class BlockchainTest(BitcoinTestFramework):
         self.setup_clean_chain = False
         self.num_nodes = 2
 
-    def setup_network(self, split=False):
-        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir)
-        connect_nodes_bi(self.nodes, 0, 1)
-        self.is_network_split = False
-        self.sync_all()
-
     def run_test(self):
         self._test_gettxoutsetinfo()
         self._test_getblockheader()

--- a/test/functional/bumpfee.py
+++ b/test/functional/bumpfee.py
@@ -47,7 +47,6 @@ class BumpFeeTest(BitcoinTestFramework):
         self.nodes[1].walletpassphrase(WALLET_PASSPHRASE, WALLET_PASSPHRASE_TIMEOUT)
 
         connect_nodes_bi(self.nodes, 0, 1)
-        self.is_network_split = False
         self.sync_all()
 
     def run_test(self):

--- a/test/functional/decodescript.py
+++ b/test/functional/decodescript.py
@@ -16,10 +16,6 @@ class DecodeScriptTest(BitcoinTestFramework):
         self.setup_clean_chain = True
         self.num_nodes = 1
 
-    def setup_network(self, split=False):
-        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir)
-        self.is_network_split = False
-
     def decodescript_script_sig(self):
         signature = '304502207fa7a6d1e0ee81132a269ad84e68d695483745cde8b541e3bf630749894e342a022100c1f7ab20e13e22fb95281a870f3dcf38d782e53023ee313d741ad0cfbc0c509001'
         push_signature = '48' + signature

--- a/test/functional/disablewallet.py
+++ b/test/functional/disablewallet.py
@@ -18,11 +18,7 @@ class DisableWalletTest (BitcoinTestFramework):
         super().__init__()
         self.setup_clean_chain = True
         self.num_nodes = 1
-
-    def setup_network(self, split=False):
-        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, [['-disablewallet']])
-        self.is_network_split = False
-        self.sync_all()
+        self.extra_args = [["-disablewallet"]]
 
     def run_test (self):
         x = self.nodes[0].validateaddress('3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy')

--- a/test/functional/disconnect_ban.py
+++ b/test/functional/disconnect_ban.py
@@ -20,10 +20,6 @@ class DisconnectBanTest(BitcoinTestFramework):
         self.num_nodes = 2
         self.setup_clean_chain = False
 
-    def setup_network(self):
-        self.nodes = self.setup_nodes()
-        connect_nodes_bi(self.nodes, 0, 1)
-
     def run_test(self):
         self.log.info("Test setban and listbanned RPCs")
 

--- a/test/functional/forknotify.py
+++ b/test/functional/forknotify.py
@@ -16,8 +16,6 @@ class ForkNotifyTest(BitcoinTestFramework):
         self.num_nodes = 2
         self.setup_clean_chain = False
 
-    alert_filename = None  # Set by setup_network
-
     def setup_network(self):
         self.nodes = []
         self.alert_filename = os.path.join(self.options.tmpdir, "alert.txt")
@@ -30,7 +28,6 @@ class ForkNotifyTest(BitcoinTestFramework):
                                 ["-blockversion=211"]))
         connect_nodes(self.nodes[1], 0)
 
-        self.is_network_split = False
         self.sync_all()
 
     def run_test(self):

--- a/test/functional/fundrawtransaction.py
+++ b/test/functional/fundrawtransaction.py
@@ -23,15 +23,12 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.num_nodes = 4
 
     def setup_network(self, split=False):
-        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir)
+        self.setup_nodes()
 
-        connect_nodes_bi(self.nodes,0,1)
-        connect_nodes_bi(self.nodes,1,2)
-        connect_nodes_bi(self.nodes,0,2)
-        connect_nodes_bi(self.nodes,0,3)
-
-        self.is_network_split=False
-        self.sync_all()
+        connect_nodes_bi(self.nodes, 0, 1)
+        connect_nodes_bi(self.nodes, 1, 2)
+        connect_nodes_bi(self.nodes, 0, 2)
+        connect_nodes_bi(self.nodes, 0, 3)
 
     def run_test(self):
         min_relay_tx_fee = self.nodes[0].getnetworkinfo()['relayfee']
@@ -467,7 +464,6 @@ class RawTransactionsTest(BitcoinTestFramework):
         connect_nodes_bi(self.nodes,1,2)
         connect_nodes_bi(self.nodes,0,2)
         connect_nodes_bi(self.nodes,0,3)
-        self.is_network_split=False
         self.sync_all()
 
         # drain the keypool

--- a/test/functional/getblocktemplate_proposals.py
+++ b/test/functional/getblocktemplate_proposals.py
@@ -73,10 +73,6 @@ class GetBlockTemplateProposalTest(BitcoinTestFramework):
         self.num_nodes = 2
         self.setup_clean_chain = False
 
-    def setup_network(self):
-        self.nodes = self.setup_nodes()
-        connect_nodes_bi(self.nodes, 0, 1)
-
     def run_test(self):
         node = self.nodes[0]
         node.generate(1) # Mine a block to leave initial block download

--- a/test/functional/getchaintips.py
+++ b/test/functional/getchaintips.py
@@ -31,7 +31,7 @@ class GetChainTipsTest (BitcoinTestFramework):
         self.split_network ()
         self.nodes[0].generate(10)
         self.nodes[2].generate(20)
-        self.sync_all ()
+        self.sync_all([self.nodes[:2], self.nodes[2:]])
 
         tips = self.nodes[1].getchaintips ()
         assert_equal (len (tips), 1)

--- a/test/functional/httpbasics.py
+++ b/test/functional/httpbasics.py
@@ -17,7 +17,7 @@ class HTTPBasicsTest (BitcoinTestFramework):
         self.setup_clean_chain = False
 
     def setup_network(self):
-        self.nodes = self.setup_nodes()
+        self.setup_nodes()
 
     def run_test(self):
 

--- a/test/functional/importmulti.py
+++ b/test/functional/importmulti.py
@@ -12,9 +12,8 @@ class ImportMultiTest (BitcoinTestFramework):
         self.num_nodes = 2
         self.setup_clean_chain = True
 
-    def setup_network(self, split=False):
-        self.nodes = start_nodes(2, self.options.tmpdir)
-        self.is_network_split=False
+    def setup_network(self):
+        self.setup_nodes()
 
     def run_test (self):
         self.log.info("Mining blocks...")

--- a/test/functional/importprunedfunds.py
+++ b/test/functional/importprunedfunds.py
@@ -14,12 +14,6 @@ class ImportPrunedFundsTest(BitcoinTestFramework):
         self.setup_clean_chain = True
         self.num_nodes = 2
 
-    def setup_network(self, split=False):
-        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir)
-        connect_nodes_bi(self.nodes,0,1)
-        self.is_network_split=False
-        self.sync_all()
-
     def run_test(self):
         self.log.info("Mining blocks...")
         self.nodes[0].generate(101)

--- a/test/functional/invalidateblock.py
+++ b/test/functional/invalidateblock.py
@@ -8,20 +8,15 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
 
 class InvalidateTest(BitcoinTestFramework):
-    
-        
+
     def __init__(self):
         super().__init__()
         self.setup_clean_chain = True
         self.num_nodes = 3
 
     def setup_network(self):
-        self.nodes = []
-        self.is_network_split = False 
-        self.nodes.append(start_node(0, self.options.tmpdir))
-        self.nodes.append(start_node(1, self.options.tmpdir))
-        self.nodes.append(start_node(2, self.options.tmpdir))
-        
+        self.setup_nodes()
+
     def run_test(self):
         self.log.info("Make sure we repopulate setBlockIndexCandidates after InvalidateBlock:")
         self.log.info("Mine 4 blocks on Node 0")

--- a/test/functional/keypool.py
+++ b/test/functional/keypool.py
@@ -84,8 +84,5 @@ class KeyPoolTest(BitcoinTestFramework):
         self.setup_clean_chain = False
         self.num_nodes = 1
 
-    def setup_network(self):
-        self.nodes = self.setup_nodes()
-
 if __name__ == '__main__':
     KeyPoolTest().main()

--- a/test/functional/listsinceblock.py
+++ b/test/functional/listsinceblock.py
@@ -43,7 +43,6 @@ class ListSinceBlockTest (BitcoinTestFramework):
         This test only checks that [tx0] is present.
         '''
 
-        assert_equal(self.is_network_split, False)
         self.nodes[2].generate(101)
         self.sync_all()
 
@@ -54,7 +53,6 @@ class ListSinceBlockTest (BitcoinTestFramework):
 
         # Split network into two
         self.split_network()
-        assert_equal(self.is_network_split, True)
 
         # send to nodes[0] from nodes[2]
         senttx = self.nodes[2].sendtoaddress(self.nodes[0].getnewaddress(), 1)
@@ -64,7 +62,7 @@ class ListSinceBlockTest (BitcoinTestFramework):
         self.nodes[2].generate(7)
         self.log.info('lastblockhash=%s' % (lastblockhash))
 
-        self.sync_all()
+        self.sync_all([self.nodes[:2], self.nodes[2:]])
 
         self.join_network()
 

--- a/test/functional/listtransactions.py
+++ b/test/functional/listtransactions.py
@@ -24,7 +24,7 @@ class ListTransactionsTest(BitcoinTestFramework):
     def setup_nodes(self):
         #This test requires mocktime
         enable_mocktime()
-        return start_nodes(self.num_nodes, self.options.tmpdir)
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir)
 
     def run_test(self):
         # Simple send, 0 to 1:

--- a/test/functional/maxuploadtarget.py
+++ b/test/functional/maxuploadtarget.py
@@ -35,14 +35,10 @@ class MaxUploadTest(BitcoinTestFramework):
         super().__init__()
         self.setup_clean_chain = True
         self.num_nodes = 1
+        self.extra_args = [["-maxuploadtarget=800", "-blockmaxsize=999000"]]
 
         # Cache for utxos, as the listunspent may take a long time later in the test
         self.utxo_cache = []
-
-    def setup_network(self):
-        # Start a node with maxuploadtarget of 200 MB (/24h)
-        self.nodes = []
-        self.nodes.append(start_node(0, self.options.tmpdir, ["-maxuploadtarget=800", "-blockmaxsize=999000"]))
 
     def run_test(self):
         # Before we connect anything, we first set the time on the node

--- a/test/functional/mempool_limit.py
+++ b/test/functional/mempool_limit.py
@@ -9,30 +9,25 @@ from test_framework.util import *
 
 class MempoolLimitTest(BitcoinTestFramework):
 
-    def setup_network(self):
-        self.nodes = []
-        self.nodes.append(start_node(0, self.options.tmpdir, ["-maxmempool=5", "-spendzeroconfchange=0"]))
-        self.is_network_split = False
-        self.sync_all()
-        self.relayfee = self.nodes[0].getnetworkinfo()['relayfee']
-
     def __init__(self):
         super().__init__()
         self.setup_clean_chain = True
         self.num_nodes = 1
-
-        self.txouts = gen_return_txouts()
+        self.extra_args = [["-maxmempool=5", "-spendzeroconfchange=0"]]
 
     def run_test(self):
+        txouts = gen_return_txouts()
+        relayfee = self.nodes[0].getnetworkinfo()['relayfee']
+
         txids = []
-        utxos = create_confirmed_utxos(self.relayfee, self.nodes[0], 91)
+        utxos = create_confirmed_utxos(relayfee, self.nodes[0], 91)
 
         #create a mempool tx that will be evicted
         us0 = utxos.pop()
         inputs = [{ "txid" : us0["txid"], "vout" : us0["vout"]}]
         outputs = {self.nodes[0].getnewaddress() : 0.0001}
         tx = self.nodes[0].createrawtransaction(inputs, outputs)
-        self.nodes[0].settxfee(self.relayfee) # specifically fund this tx with low fee
+        self.nodes[0].settxfee(relayfee) # specifically fund this tx with low fee
         txF = self.nodes[0].fundrawtransaction(tx)
         self.nodes[0].settxfee(0) # return to automatic fee selection
         txFS = self.nodes[0].signrawtransaction(txF['hex'])
@@ -42,7 +37,7 @@ class MempoolLimitTest(BitcoinTestFramework):
         base_fee = relayfee*100
         for i in range (3):
             txids.append([])
-            txids[i] = create_lots_of_big_transactions(self.nodes[0], self.txouts, utxos[30*i:30*i+30], 30, (i+1)*base_fee)
+            txids[i] = create_lots_of_big_transactions(self.nodes[0], txouts, utxos[30*i:30*i+30], 30, (i+1)*base_fee)
 
         # by now, the tx should be evicted, check confirmation state
         assert(txid not in self.nodes[0].getrawmempool())

--- a/test/functional/mempool_packages.py
+++ b/test/functional/mempool_packages.py
@@ -16,14 +16,7 @@ class MempoolPackagesTest(BitcoinTestFramework):
         super().__init__()
         self.num_nodes = 2
         self.setup_clean_chain = False
-
-    def setup_network(self):
-        self.nodes = []
-        self.nodes.append(start_node(0, self.options.tmpdir, ["-maxorphantx=1000"]))
-        self.nodes.append(start_node(1, self.options.tmpdir, ["-maxorphantx=1000", "-limitancestorcount=5"]))
-        connect_nodes(self.nodes[0], 1)
-        self.is_network_split = False
-        self.sync_all()
+        self.extra_args = [["-maxorphantx=1000"], ["-maxorphantx=1000", "-limitancestorcount=5"]]
 
     # Build a transaction that spends parent_txid:vout
     # Return amount sent

--- a/test/functional/mempool_reorg.py
+++ b/test/functional/mempool_reorg.py
@@ -17,17 +17,9 @@ class MempoolCoinbaseTest(BitcoinTestFramework):
         super().__init__()
         self.num_nodes = 2
         self.setup_clean_chain = False
+        self.extra_args = [["-checkmempool"]] * 2
 
     alert_filename = None  # Set by setup_network
-
-    def setup_network(self):
-        args = ["-checkmempool"]
-        self.nodes = []
-        self.nodes.append(start_node(0, self.options.tmpdir, args))
-        self.nodes.append(start_node(1, self.options.tmpdir, args))
-        connect_nodes(self.nodes[1], 0)
-        self.is_network_split = False
-        self.sync_all()
 
     def run_test(self):
         # Start with a 200 block chain

--- a/test/functional/mempool_resurrect_test.py
+++ b/test/functional/mempool_resurrect_test.py
@@ -14,13 +14,8 @@ class MempoolCoinbaseTest(BitcoinTestFramework):
         super().__init__()
         self.num_nodes = 1
         self.setup_clean_chain = False
-
-    def setup_network(self):
         # Just need one node for this test
-        args = ["-checkmempool"]
-        self.nodes = []
-        self.nodes.append(start_node(0, self.options.tmpdir, args))
-        self.is_network_split = False
+        self.extra_args = [["-checkmempool"]]
 
     def run_test(self):
         node0_address = self.nodes[0].getnewaddress()

--- a/test/functional/mempool_spendcoinbase.py
+++ b/test/functional/mempool_spendcoinbase.py
@@ -22,13 +22,7 @@ class MempoolSpendCoinbaseTest(BitcoinTestFramework):
         super().__init__()
         self.num_nodes = 1
         self.setup_clean_chain = False
-
-    def setup_network(self):
-        # Just need one node for this test
-        args = ["-checkmempool"]
-        self.nodes = []
-        self.nodes.append(start_node(0, self.options.tmpdir, args))
-        self.is_network_split = False
+        self.extra_args = [["-checkmempool"]]
 
     def run_test(self):
         chain_height = self.nodes[0].getblockcount()

--- a/test/functional/merkle_blocks.py
+++ b/test/functional/merkle_blocks.py
@@ -13,20 +13,15 @@ class MerkleBlockTest(BitcoinTestFramework):
         super().__init__()
         self.setup_clean_chain = True
         self.num_nodes = 4
+        # Nodes 0/1 are "wallet" nodes, Nodes 2/3 are used for testing
+        self.extra_args = [[], [], [], ["-txindex"]]
 
     def setup_network(self):
-        self.nodes = []
-        # Nodes 0/1 are "wallet" nodes
-        self.nodes.append(start_node(0, self.options.tmpdir))
-        self.nodes.append(start_node(1, self.options.tmpdir))
-        # Nodes 2/3 are used for testing
-        self.nodes.append(start_node(2, self.options.tmpdir))
-        self.nodes.append(start_node(3, self.options.tmpdir, ["-txindex"]))
+        self.setup_nodes()
         connect_nodes(self.nodes[0], 1)
         connect_nodes(self.nodes[0], 2)
         connect_nodes(self.nodes[0], 3)
 
-        self.is_network_split = False
         self.sync_all()
 
     def run_test(self):

--- a/test/functional/multi_rpc.py
+++ b/test/functional/multi_rpc.py
@@ -27,9 +27,6 @@ class HTTPBasicsTest (BitcoinTestFramework):
             f.write(rpcauth+"\n")
             f.write(rpcauth2+"\n")
 
-    def setup_network(self):
-        self.nodes = self.setup_nodes()
-
     def run_test(self):
 
         ##################################################

--- a/test/functional/net.py
+++ b/test/functional/net.py
@@ -25,12 +25,6 @@ class NetTest(BitcoinTestFramework):
         self.setup_clean_chain = True
         self.num_nodes = 2
 
-    def setup_network(self):
-        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir)
-        connect_nodes_bi(self.nodes, 0, 1)
-        self.is_network_split = False
-        self.sync_all()
-
     def run_test(self):
         self._test_connection_count()
         self._test_getnettotals()

--- a/test/functional/nulldummy.py
+++ b/test/functional/nulldummy.py
@@ -41,11 +41,7 @@ class NULLDUMMYTest(BitcoinTestFramework):
         super().__init__()
         self.num_nodes = 1
         self.setup_clean_chain = True
-
-    def setup_network(self):
-        # Must set the blockversion for this test
-        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir,
-                                 extra_args=[['-whitelist=127.0.0.1', '-walletprematurewitness']])
+        self.extra_args = [['-whitelist=127.0.0.1', '-walletprematurewitness']]
 
     def run_test(self):
         self.address = self.nodes[0].getnewaddress()

--- a/test/functional/p2p-acceptblock.py
+++ b/test/functional/p2p-acceptblock.py
@@ -64,17 +64,13 @@ class AcceptBlockTest(BitcoinTestFramework):
         super().__init__()
         self.setup_clean_chain = True
         self.num_nodes = 2
+        self.extra_args = [[], ["-whitelist=127.0.0.1"]]
 
     def setup_network(self):
         # Node0 will be used to test behavior of processing unrequested blocks
         # from peers which are not whitelisted, while Node1 will be used for
         # the whitelisted case.
-        self.nodes = []
-        self.nodes.append(start_node(0, self.options.tmpdir,
-                                     binary=self.options.testbinary))
-        self.nodes.append(start_node(1, self.options.tmpdir,
-                                     ["-whitelist=127.0.0.1"],
-                                     binary=self.options.testbinary))
+        self.setup_nodes()
 
     def run_test(self):
         # Setup the p2p connections and start up the network thread.

--- a/test/functional/p2p-compactblocks.py
+++ b/test/functional/p2p-compactblocks.py
@@ -98,16 +98,8 @@ class CompactBlocksTest(BitcoinTestFramework):
         self.setup_clean_chain = True
         # Node0 = pre-segwit, node1 = segwit-aware
         self.num_nodes = 2
+        self.extra_args = [["-bip9params=segwit:0:0"], ["-txindex"]]
         self.utxos = []
-
-    def setup_network(self):
-        self.nodes = []
-
-        # Start up node0 to be a version 1, pre-segwit node.
-        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, 
-                [["-bip9params=segwit:0:0"], 
-                 ["-txindex"]])
-        connect_nodes(self.nodes[0], 1)
 
     def build_block_on_tip(self, node, segwit=False):
         height = node.getblockcount()

--- a/test/functional/p2p-feefilter.py
+++ b/test/functional/p2p-feefilter.py
@@ -43,14 +43,6 @@ class FeeFilterTest(BitcoinTestFramework):
         self.num_nodes = 2
         self.setup_clean_chain = False
 
-    def setup_network(self):
-        # Node1 will be used to generate txs which should be relayed from Node0
-        # to our test node
-        self.nodes = []
-        self.nodes.append(start_node(0, self.options.tmpdir))
-        self.nodes.append(start_node(1, self.options.tmpdir))
-        connect_nodes(self.nodes[0], 1)
-
     def run_test(self):
         node1 = self.nodes[1]
         node0 = self.nodes[0]

--- a/test/functional/p2p-leaktests.py
+++ b/test/functional/p2p-leaktests.py
@@ -92,10 +92,7 @@ class P2PLeakTest(BitcoinTestFramework):
     def __init__(self):
         super().__init__()
         self.num_nodes = 1
-    def setup_network(self):
-        extra_args = [['-banscore='+str(banscore)]
-                      for i in range(self.num_nodes)]
-        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, extra_args)
+        self.extra_args = [['-banscore='+str(banscore)]]
 
     def run_test(self):
         no_version_bannode = CNodeNoVersionBan()

--- a/test/functional/p2p-mempool.py
+++ b/test/functional/p2p-mempool.py
@@ -17,10 +17,8 @@ class P2PMempoolTests(BitcoinTestFramework):
     def __init__(self):
         super().__init__()
         self.setup_clean_chain = True
-        self.num_nodes = 2
-
-    def setup_network(self):
-        self.nodes = [start_node(0, self.options.tmpdir, ["-peerbloomfilters=0"])]
+        self.num_nodes = 1
+        self.extra_args = [["-peerbloomfilters=0"]]
 
     def run_test(self):
         #connect a mininode

--- a/test/functional/p2p-segwit.py
+++ b/test/functional/p2p-segwit.py
@@ -124,17 +124,13 @@ class SegWitTest(BitcoinTestFramework):
         super().__init__()
         self.setup_clean_chain = True
         self.num_nodes = 3
+        self.extra_args = [["-whitelist=127.0.0.1"], ["-whitelist=127.0.0.1", "-acceptnonstdtxn=0"], ["-whitelist=127.0.0.1", "-bip9params=segwit:0:0"]]
 
     def setup_network(self):
-        self.nodes = []
-        self.nodes.append(start_node(0, self.options.tmpdir, ["-whitelist=127.0.0.1"]))
-        # Start a node for testing IsStandard rules.
-        self.nodes.append(start_node(1, self.options.tmpdir, ["-whitelist=127.0.0.1", "-acceptnonstdtxn=0"]))
+        self.setup_nodes()
         connect_nodes(self.nodes[0], 1)
-
-        # Disable segwit's bip9 parameter to simulate upgrading after activation.
-        self.nodes.append(start_node(2, self.options.tmpdir, ["-whitelist=127.0.0.1", "-bip9params=segwit:0:0"]))
         connect_nodes(self.nodes[0], 2)
+        self.sync_all()
 
     ''' Helpers '''
     # Build a block on top of node0's tip.

--- a/test/functional/p2p-timeouts.py
+++ b/test/functional/p2p-timeouts.py
@@ -38,12 +38,6 @@ class TimeoutsTest(BitcoinTestFramework):
         self.setup_clean_chain = True
         self.num_nodes = 1
 
-    def setup_network(self):
-        self.nodes = []
-
-        # Start up node0 to be a version 1, pre-segwit node.
-        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir)
-
     def run_test(self):
         # Setup the p2p connections and start up the network thread.
         self.no_verack_node = TestNode() # never send verack

--- a/test/functional/p2p-versionbits-warning.py
+++ b/test/functional/p2p-versionbits-warning.py
@@ -40,7 +40,7 @@ class VersionBitsWarningTest(BitcoinTestFramework):
         with open(self.alert_filename, 'w', encoding='utf8') as _:
             pass
         self.extra_args = [["-alertnotify=echo %s >> \"" + self.alert_filename + "\""]]
-        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, self.extra_args)
+        self.setup_nodes()
 
     # Send numblocks blocks via peer with nVersionToUse set.
     def send_blocks_with_version(self, peer, numblocks, nVersionToUse):

--- a/test/functional/preciousblock.py
+++ b/test/functional/preciousblock.py
@@ -41,7 +41,7 @@ class PreciousTest(BitcoinTestFramework):
         self.num_nodes = 3
 
     def setup_network(self):
-        self.nodes = self.setup_nodes()
+        self.setup_nodes()
 
     def run_test(self):
         self.log.info("Ensure submitblock can in principle reorg to a competing chain")

--- a/test/functional/prioritise_transaction.py
+++ b/test/functional/prioritise_transaction.py
@@ -14,17 +14,12 @@ class PrioritiseTransactionTest(BitcoinTestFramework):
         super().__init__()
         self.setup_clean_chain = True
         self.num_nodes = 1
-
-        self.txouts = gen_return_txouts()
-
-    def setup_network(self):
-        self.nodes = []
-        self.is_network_split = False
-
-        self.nodes.append(start_node(0, self.options.tmpdir, ["-printpriority=1"]))
-        self.relayfee = self.nodes[0].getnetworkinfo()['relayfee']
+        self.extra_args = [["-printpriority=1"]]
 
     def run_test(self):
+        self.txouts = gen_return_txouts()
+        self.relayfee = self.nodes[0].getnetworkinfo()['relayfee']
+
         utxo_count = 90
         utxos = create_confirmed_utxos(self.relayfee, self.nodes[0], utxo_count)
         base_fee = self.relayfee*100 # our transactions are smaller than 100kb

--- a/test/functional/proxy_test.py
+++ b/test/functional/proxy_test.py
@@ -90,7 +90,7 @@ class ProxyTest(BitcoinTestFramework):
             ]
         if self.have_ipv6:
             args[3] = ['-listen', '-proxy=[%s]:%i' % (self.conf3.addr),'-proxyrandomize=0', '-noonion']
-        return start_nodes(self.num_nodes, self.options.tmpdir, extra_args=args)
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, extra_args=args)
 
     def node_test(self, node, proxies, auth, test_onion=True):
         rv = []

--- a/test/functional/rawtransactions.py
+++ b/test/functional/rawtransactions.py
@@ -24,20 +24,8 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.num_nodes = 3
 
     def setup_network(self, split=False):
-        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir)
-
-        #connect to a local machine for debugging
-        #url = "http://bitcoinrpc:DP6DvqZtqXarpeNWyN3LZTFchCCyCUuHwNF7E8pX99x1@%s:%d" % ('127.0.0.1', 18332)
-        #proxy = AuthServiceProxy(url)
-        #proxy.url = url # store URL on proxy for info
-        #self.nodes.append(proxy)
-
-        connect_nodes_bi(self.nodes,0,1)
-        connect_nodes_bi(self.nodes,1,2)
+        super().setup_network()
         connect_nodes_bi(self.nodes,0,2)
-
-        self.is_network_split=False
-        self.sync_all()
 
     def run_test(self):
 

--- a/test/functional/receivedby.py
+++ b/test/functional/receivedby.py
@@ -32,7 +32,7 @@ class ReceivedByTest(BitcoinTestFramework):
     def setup_nodes(self):
         #This test requires mocktime
         enable_mocktime()
-        return start_nodes(self.num_nodes, self.options.tmpdir)
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir)
 
     def run_test(self):
         '''

--- a/test/functional/reindex.py
+++ b/test/functional/reindex.py
@@ -24,9 +24,6 @@ class ReindexTest(BitcoinTestFramework):
         self.setup_clean_chain = True
         self.num_nodes = 1
 
-    def setup_network(self):
-        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir)
-
     def reindex(self, justchainstate=False):
         self.nodes[0].generate(3)
         blockcount = self.nodes[0].getblockcount()

--- a/test/functional/replace-by-fee.py
+++ b/test/functional/replace-by-fee.py
@@ -65,17 +65,12 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         super().__init__()
         self.num_nodes = 1
         self.setup_clean_chain = False
-
-    def setup_network(self):
-        self.nodes = []
-        self.nodes.append(start_node(0, self.options.tmpdir, ["-maxorphantx=1000",
-                                                              "-whitelist=127.0.0.1",
-                                                              "-limitancestorcount=50",
-                                                              "-limitancestorsize=101",
-                                                              "-limitdescendantcount=200",
-                                                              "-limitdescendantsize=101"
-                                                              ]))
-        self.is_network_split = False
+        self.extra_args= [["-maxorphantx=1000",
+                           "-whitelist=127.0.0.1",
+                           "-limitancestorcount=50",
+                           "-limitancestorsize=101",
+                           "-limitdescendantcount=200",
+                           "-limitdescendantsize=101"]]
 
     def run_test(self):
         make_utxo(self.nodes[0], 1*COIN)

--- a/test/functional/rest.py
+++ b/test/functional/rest.py
@@ -49,12 +49,8 @@ class RESTTest (BitcoinTestFramework):
         self.num_nodes = 3
 
     def setup_network(self, split=False):
-        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir)
-        connect_nodes_bi(self.nodes,0,1)
-        connect_nodes_bi(self.nodes,1,2)
-        connect_nodes_bi(self.nodes,0,2)
-        self.is_network_split=False
-        self.sync_all()
+        super().setup_network()
+        connect_nodes_bi(self.nodes, 0, 2)
 
     def run_test(self):
         url = urllib.parse.urlparse(self.nodes[0].url)

--- a/test/functional/rpcnamedargs.py
+++ b/test/functional/rpcnamedargs.py
@@ -22,11 +22,6 @@ class NamedArgumentTest(BitcoinTestFramework):
         self.setup_clean_chain = False
         self.num_nodes = 1
 
-    def setup_network(self, split=False):
-        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir)
-        self.is_network_split = False
-        self.sync_all()
-
     def run_test(self):
         node = self.nodes[0]
         h = node.help(command='getinfo')

--- a/test/functional/segwit.py
+++ b/test/functional/segwit.py
@@ -80,16 +80,13 @@ class SegWitTest(BitcoinTestFramework):
         super().__init__()
         self.setup_clean_chain = True
         self.num_nodes = 3
+        self.extra_args = [["-walletprematurewitness", "-rpcserialversion=0"],
+                           ["-blockversion=4", "-promiscuousmempoolflags=517", "-prematurewitness", "-walletprematurewitness", "-rpcserialversion=1"],
+                           ["-blockversion=536870915", "-promiscuousmempoolflags=517", "-prematurewitness", "-walletprematurewitness"]]
 
     def setup_network(self):
-        self.nodes = []
-        self.nodes.append(start_node(0, self.options.tmpdir, ["-walletprematurewitness", "-rpcserialversion=0"]))
-        self.nodes.append(start_node(1, self.options.tmpdir, ["-blockversion=4", "-promiscuousmempoolflags=517", "-prematurewitness", "-walletprematurewitness", "-rpcserialversion=1"]))
-        self.nodes.append(start_node(2, self.options.tmpdir, ["-blockversion=536870915", "-promiscuousmempoolflags=517", "-prematurewitness", "-walletprematurewitness"]))
-        connect_nodes(self.nodes[1], 0)
-        connect_nodes(self.nodes[2], 1)
+        super().setup_network()
         connect_nodes(self.nodes[0], 2)
-        self.is_network_split = False
         self.sync_all()
 
     def success_mine(self, node, txid, sign, redeem_script=""):

--- a/test/functional/sendheaders.py
+++ b/test/functional/sendheaders.py
@@ -182,11 +182,6 @@ class SendHeadersTest(BitcoinTestFramework):
         self.setup_clean_chain = True
         self.num_nodes = 2
 
-    def setup_network(self):
-        self.nodes = []
-        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir)
-        connect_nodes(self.nodes[0], 1)
-
     # mine count blocks and return the new tip
     def mine_blocks(self, count):
         # Clear out last block announcement from each p2p listener

--- a/test/functional/signmessages.py
+++ b/test/functional/signmessages.py
@@ -14,10 +14,6 @@ class SignMessagesTest(BitcoinTestFramework):
         self.setup_clean_chain = True
         self.num_nodes = 1
 
-    def setup_network(self, split=False):
-        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir)
-        self.is_network_split = False
-
     def run_test(self):
         message = 'This is just a test message'
 

--- a/test/functional/signrawtransactions.py
+++ b/test/functional/signrawtransactions.py
@@ -14,10 +14,6 @@ class SignRawTransactionsTest(BitcoinTestFramework):
         self.setup_clean_chain = True
         self.num_nodes = 1
 
-    def setup_network(self, split=False):
-        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir)
-        self.is_network_split = False
-
     def successful_signing_test(self):
         """Create and sign a valid raw transaction with one input.
 

--- a/test/functional/smartfees.py
+++ b/test/functional/smartfees.py
@@ -203,7 +203,6 @@ class EstimateFeeTest(BitcoinTestFramework):
         connect_nodes(self.nodes[0], 2)
         connect_nodes(self.nodes[2], 1)
 
-        self.is_network_split = False
         self.sync_all()
 
     def transact_and_mine(self, numblocks, mining_node):

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -315,7 +315,7 @@ def start_node(i, dirname, extra_args=None, rpchost=None, timewait=None, binary=
     datadir = os.path.join(dirname, "node"+str(i))
     if binary is None:
         binary = os.getenv("BITCOIND", "bitcoind")
-    args = [binary, "-datadir=" + datadir, "-server", "-keypool=1", "-discover=0", "-rest", "-logtimemicros", "-debug", "-debugexclude=libevent", "-debugexclude=leveldb", "-mocktime=" + str(get_mocktime())]
+    args = [binary, "-datadir=" + datadir, "-server", "-keypool=1", "-discover=0", "-rest", "-logtimemicros", "-debug", "-debugexclude=libevent", "-debugexclude=leveldb", "-mocktime=" + str(get_mocktime()), "-uacomment=testnode%d" % i]
     if extra_args is not None: args.extend(extra_args)
     bitcoind_processes[i] = subprocess.Popen(args, stderr=stderr)
     logger.debug("initialize_chain: bitcoind started, waiting for RPC to come up")
@@ -354,6 +354,8 @@ def start_nodes(num_nodes, dirname, extra_args=None, rpchost=None, timewait=None
     """
     if extra_args is None: extra_args = [ None for _ in range(num_nodes) ]
     if binary is None: binary = [ None for _ in range(num_nodes) ]
+    assert_equal(len(extra_args), num_nodes)
+    assert_equal(len(binary), num_nodes)
     rpcs = []
     try:
         for i in range(num_nodes):
@@ -384,6 +386,17 @@ def stop_nodes(nodes):
 def set_node_times(nodes, t):
     for node in nodes:
         node.setmocktime(t)
+
+def disconnect_nodes(from_connection, node_num):
+    for peer_id in [peer['id'] for peer in from_connection.getpeerinfo() if "testnode%d" % node_num in peer['subver']]:
+        from_connection.disconnectnode(nodeid=peer_id)
+
+    for _ in range(50):
+        if [peer['id'] for peer in from_connection.getpeerinfo() if "testnode%d" % node_num in peer['subver']] == []:
+            break
+        time.sleep(0.1)
+    else:
+        raise AssertionError("timed out waiting for disconnect")
 
 def connect_nodes(from_connection, node_num):
     ip_port = "127.0.0.1:"+str(p2p_port(node_num))

--- a/test/functional/txn_clone.py
+++ b/test/functional/txn_clone.py
@@ -20,7 +20,9 @@ class TxnMallTest(BitcoinTestFramework):
 
     def setup_network(self):
         # Start with split network:
-        return super(TxnMallTest, self).setup_network(True)
+        super(TxnMallTest, self).setup_network()
+        disconnect_nodes(self.nodes[1], 2)
+        disconnect_nodes(self.nodes[2], 1)
 
     def run_test(self):
         # All nodes should start with 1,250 BTC:

--- a/test/functional/txn_doublespend.py
+++ b/test/functional/txn_doublespend.py
@@ -20,7 +20,9 @@ class TxnMallTest(BitcoinTestFramework):
 
     def setup_network(self):
         # Start with split network:
-        return super(TxnMallTest, self).setup_network(True)
+        super().setup_network()
+        disconnect_nodes(self.nodes[1], 2)
+        disconnect_nodes(self.nodes[2], 1)
 
     def run_test(self):
         # All nodes should start with 1,250 BTC:

--- a/test/functional/wallet-accounts.py
+++ b/test/functional/wallet-accounts.py
@@ -24,11 +24,7 @@ class WalletAccountsTest(BitcoinTestFramework):
         super().__init__()
         self.setup_clean_chain = True
         self.num_nodes = 1
-        self.node_args = [[]]
-
-    def setup_network(self):
-        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, self.node_args)
-        self.is_network_split = False
+        self.extra_args = [[]]
 
     def run_test (self):
         node = self.nodes[0]

--- a/test/functional/wallet-hd.py
+++ b/test/functional/wallet-hd.py
@@ -22,12 +22,7 @@ class WalletHDTest(BitcoinTestFramework):
         super().__init__()
         self.setup_clean_chain = True
         self.num_nodes = 2
-        self.node_args = [['-usehd=0'], ['-usehd=1', '-keypool=0']]
-
-    def setup_network(self):
-        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, self.node_args)
-        self.is_network_split = False
-        connect_nodes_bi(self.nodes, 0, 1)
+        self.extra_args = [['-usehd=0'], ['-usehd=1', '-keypool=0']]
 
     def run_test (self):
         tmpdir = self.options.tmpdir
@@ -35,7 +30,7 @@ class WalletHDTest(BitcoinTestFramework):
         # Make sure can't switch off usehd after wallet creation
         self.stop_node(1)
         assert_start_raises_init_error(1, self.options.tmpdir, ['-usehd=0'], 'already existing HD wallet')
-        self.nodes[1] = start_node(1, self.options.tmpdir, self.node_args[1])
+        self.nodes[1] = start_node(1, self.options.tmpdir, self.extra_args[1])
         connect_nodes_bi(self.nodes, 0, 1)
 
         # Make sure we use hd, keep masterkeyid
@@ -82,7 +77,7 @@ class WalletHDTest(BitcoinTestFramework):
         self.stop_node(1)
         os.remove(self.options.tmpdir + "/node1/regtest/wallet.dat")
         shutil.copyfile(tmpdir + "/hd.bak", tmpdir + "/node1/regtest/wallet.dat")
-        self.nodes[1] = start_node(1, self.options.tmpdir, self.node_args[1])
+        self.nodes[1] = start_node(1, self.options.tmpdir, self.extra_args[1])
         #connect_nodes_bi(self.nodes, 0, 1)
 
         # Assert that derivation is deterministic
@@ -96,7 +91,7 @@ class WalletHDTest(BitcoinTestFramework):
 
         # Needs rescan
         self.stop_node(1)
-        self.nodes[1] = start_node(1, self.options.tmpdir, self.node_args[1] + ['-rescan'])
+        self.nodes[1] = start_node(1, self.options.tmpdir, self.extra_args[1] + ['-rescan'])
         #connect_nodes_bi(self.nodes, 0, 1)
         assert_equal(self.nodes[1].getbalance(), num_hd_adds + 1)
 

--- a/test/functional/wallet.py
+++ b/test/functional/wallet.py
@@ -20,12 +20,11 @@ class WalletTest(BitcoinTestFramework):
         self.num_nodes = 4
         self.extra_args = [['-usehd={:d}'.format(i%2==0)] for i in range(4)]
 
-    def setup_network(self, split=False):
+    def setup_network(self):
         self.nodes = start_nodes(3, self.options.tmpdir, self.extra_args[:3])
         connect_nodes_bi(self.nodes,0,1)
         connect_nodes_bi(self.nodes,1,2)
         connect_nodes_bi(self.nodes,0,2)
-        self.is_network_split=False
         self.sync_all()
 
     def run_test(self):

--- a/test/functional/walletbackup.py
+++ b/test/functional/walletbackup.py
@@ -44,14 +44,12 @@ class WalletBackupTest(BitcoinTestFramework):
         # nodes 1, 2,3 are spenders, let's give them a keypool=100
         self.extra_args = [["-keypool=100"], ["-keypool=100"], ["-keypool=100"], []]
 
-    # This mirrors how the network was setup in the bash test
     def setup_network(self, split=False):
-        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, self.extra_args)
+        self.setup_nodes()
         connect_nodes(self.nodes[0], 3)
         connect_nodes(self.nodes[1], 3)
         connect_nodes(self.nodes[2], 3)
         connect_nodes(self.nodes[2], 0)
-        self.is_network_split=False
         self.sync_all()
 
     def one_send(self, from_node, to_address):

--- a/test/functional/zapwallettxes.py
+++ b/test/functional/zapwallettxes.py
@@ -23,13 +23,9 @@ class ZapWalletTXesTest (BitcoinTestFramework):
         self.setup_clean_chain = True
         self.num_nodes = 3
 
-    def setup_network(self, split=False):
-        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir)
-        connect_nodes_bi(self.nodes,0,1)
-        connect_nodes_bi(self.nodes,1,2)
+    def setup_network(self):
+        super().setup_network()
         connect_nodes_bi(self.nodes,0,2)
-        self.is_network_split=False
-        self.sync_all()
 
     def run_test (self):
         self.log.info("Mining blocks...")

--- a/test/functional/zmq_test.py
+++ b/test/functional/zmq_test.py
@@ -40,7 +40,7 @@ class ZMQTest (BitcoinTestFramework):
         self.zmqSubSocket.setsockopt(zmq.SUBSCRIBE, b"hashblock")
         self.zmqSubSocket.setsockopt(zmq.SUBSCRIBE, b"hashtx")
         self.zmqSubSocket.connect("tcp://127.0.0.1:%i" % self.port)
-        return start_nodes(self.num_nodes, self.options.tmpdir, extra_args=[
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, extra_args=[
             ['-zmqpubhashtx=tcp://127.0.0.1:'+str(self.port), '-zmqpubhashblock=tcp://127.0.0.1:'+str(self.port)],
             [],
             [],


### PR DESCRIPTION
The `split_network()` and `join_network()` functions in bitcoin test framework are problematic:

1. They make assumptions about the network topology (4 nodes, either connected linearly A-B-C-D or split A-B // C-D), and force these assumptions on *all* test cases. The `setup_network()` and `sync_all()` functions use `is_network_split`, which means that many test cases have to set this variable for no other reason than to make those functions work. Removing the requirement to set `is_network_split` means many test cases don't need to override the `setup_network()` method, which removes some 200 loc. `split_network()` and `join_network()` are only used by 2 test cases - that's a lot of redundant code for the benefit of two test cases.
2. They're horribly inefficient. They both stop all 4 nodes, then restart. That takes ~10 seconds on my pc.
3. They may have unexpected side-effects. stop-starting removes ephemeral state on the node, and that behaviour may change between releases (eg mempool persistence).

This PR:

- removes the `is_network_split` variable
- makes `setup_network()` and `sync_all()` more generic by making fewer assumptions about the test network topology
- uses a new `disconnect_nodes()` helper function in `split_network()` and `join_network()`

This requires #10143, which isn't yet merged

benefits:

1. removes ~200 lines of unnecessary test setup code
2. getchaintips and listsinceblock now run faster:

before:
```
 ./listsinceblock.py && ./getchaintips.py 
2017-04-12 15:43:53.949000 TestFramework (INFO): Initializing test directory /tmp/user/1000/test58b95puo/15463
2017-04-12 15:44:05.686000 TestFramework (INFO): lastblockhash=798a876d18cb546c59e76d7d0f62611b588dd6046ba989e5800cc8a981e025db
2017-04-12 15:44:15.959000 TestFramework (INFO): Stopping nodes
2017-04-12 15:44:24.526000 TestFramework (INFO): Cleaning up
2017-04-12 15:44:24.529000 TestFramework (INFO): Tests successful
2017-04-12 15:44:24.590000 TestFramework (INFO): Initializing test directory /tmp/user/1000/testk_xibf92/15632
2017-04-12 15:44:46.263000 TestFramework (INFO): Stopping nodes
2017-04-12 15:44:54.658000 TestFramework (INFO): Cleaning up
2017-04-12 15:44:54.667000 TestFramework (INFO): Tests successful

```
after:
```
2017-04-12 15:43:12.662000 TestFramework (INFO): Initializing test directory /tmp/user/1000/testqi2c2skb/15342
2017-04-12 15:43:14.616000 TestFramework (INFO): lastblockhash=7c70eee0979069504d6059c3cd9658fc8c57d8ae30a3872716c1f9a244a53ae1
2017-04-12 15:43:14.834000 TestFramework (INFO): Stopping nodes
2017-04-12 15:43:23.205000 TestFramework (INFO): Cleaning up
2017-04-12 15:43:23.207000 TestFramework (INFO): Tests successful
2017-04-12 15:43:23.270000 TestFramework (INFO): Initializing test directory /tmp/user/1000/testmxve6ryf/15399
2017-04-12 15:43:25.363000 TestFramework (INFO): Stopping nodes
2017-04-12 15:43:33.648000 TestFramework (INFO): Cleaning up
2017-04-12 15:43:33.658000 TestFramework (INFO): Tests successful
```
excluding the test shutdown time (which will be improved by #10082), the change is from 44s to 4.2s (10x speedup).

3. bitcoin test framework is now more generic, and can be extended later to automatically spin up different test network topologies.