### PR TITLE
Mining: Skip recent transactions if fee difference is small

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -351,10 +351,6 @@ void BlockAssembler::addPackageTxs(int &nPackagesSelected, int &nDescendantsUpda
     // Keep track of entries that failed inclusion, to avoid duplicate work
     CTxMemPool::setEntries failedTx;
 
-    // Start by adding all descendants of previously added txs to mapModifiedTx
-    // and modifying them for their already included ancestors
-    UpdatePackagesForAdded(inBlock, mapModifiedTx);
-
     CTxMemPool::indexed_transaction_set::index<ancestor_score>::type::iterator mi = mempool.mapTx.get<ancestor_score>().begin();
     CTxMemPool::txiter iter;
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -66,7 +66,7 @@ BlockAssembler::Options::Options() {
     blockMinFeeRate = CFeeRate(DEFAULT_BLOCK_MIN_TX_FEE);
     nBlockMaxWeight = DEFAULT_BLOCK_MAX_WEIGHT;
     nBlockMaxSize = DEFAULT_BLOCK_MAX_SIZE;
-    nRecentTxWindow = DEFAULT_RECENT_TX_WINDOW;
+    nRecentTxWindow = (DEFAULT_RECENT_TX_WINDOW + 999) / 1000;
     dRecentTxStaleRate = DEFAULT_RECENT_TX_STALE_RATE;
 }
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -350,7 +350,7 @@ void BlockAssembler::RemoveRecentTransactionsFromBlockAndUpdatePackages(WorkingS
         assert(it != mempool.mapTx.end());
         // Keep any transactions that are sufficiently old, but skip transactions
         // that depend on removed transactions.  (Note that it's technically
-        // possible for a child tx to have a newer arrival time than its
+        // possible for a child tx to have an older arrival time than its
         // parent, eg after a reorg.)
         if (it->GetTime() <= timeCutoff && descendantTransactions.count(it) == 0) {
             vtxCopy.push_back(ptx);

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -255,7 +255,7 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
     return std::move(winner->pblocktemplate);
 }
 
-void BlockAssembler::onlyUnconfirmed(WorkingState &workState, CTxMemPool::setEntries& testSet)
+void BlockAssembler::onlyUnconfirmed(WorkingState &workState, CTxMemPool::setEntries& testSet) const
 {
     for (CTxMemPool::setEntries::iterator iit = testSet.begin(); iit != testSet.end(); ) {
         // Only test txs not already in the block
@@ -283,7 +283,7 @@ bool BlockAssembler::TestPackage(const WorkingState &workState, uint64_t package
 // - premature witness (in case segwit transactions are added to mempool before
 //   segwit activation)
 // - serialized size (in case -blockmaxsize is in use)
-bool BlockAssembler::TestPackageTransactions(WorkingState &workState, const CTxMemPool::setEntries& package)
+bool BlockAssembler::TestPackageTransactions(WorkingState &workState, const CTxMemPool::setEntries& package) const
 {
     uint64_t nPotentialBlockSize = workState.nBlockSize; // only used with fNeedSizeAccounting
     for (const CTxMemPool::txiter it : package) {
@@ -302,7 +302,7 @@ bool BlockAssembler::TestPackageTransactions(WorkingState &workState, const CTxM
     return true;
 }
 
-void BlockAssembler::AddToBlock(WorkingState &workState, CTxMemPool::txiter iter)
+void BlockAssembler::AddToBlock(WorkingState &workState, CTxMemPool::txiter iter) const
 {
     workState.pblock->vtx.emplace_back(iter->GetSharedTx());
     workState.pblocktemplate->vTxFees.push_back(iter->GetFee());
@@ -394,7 +394,7 @@ void BlockAssembler::RemoveRecentTransactionsFromBlockAndUpdatePackages(WorkingS
 }
 
 int BlockAssembler::UpdatePackagesForAdded(const CTxMemPool::setEntries& alreadyAdded,
-        indexed_modified_transaction_set &mapModifiedTx)
+        indexed_modified_transaction_set &mapModifiedTx) const
 {
     int nDescendantsUpdated = 0;
     for (const CTxMemPool::txiter it : alreadyAdded) {
@@ -431,13 +431,13 @@ int BlockAssembler::UpdatePackagesForAdded(const CTxMemPool::setEntries& already
 // guaranteed to fail again, but as a belt-and-suspenders check we put it in
 // failedTx and avoid re-evaluation, since the re-evaluation would be using
 // cached size/sigops/fee values that are not actually correct.
-bool BlockAssembler::SkipMapTxEntry(WorkingState &workState, CTxMemPool::txiter it, indexed_modified_transaction_set &mapModifiedTx, CTxMemPool::setEntries &failedTx)
+bool BlockAssembler::SkipMapTxEntry(WorkingState &workState, CTxMemPool::txiter it, indexed_modified_transaction_set &mapModifiedTx, CTxMemPool::setEntries &failedTx) const
 {
     assert (it != mempool.mapTx.end());
     return mapModifiedTx.count(it) || workState.inBlock.count(it) || failedTx.count(it);
 }
 
-void BlockAssembler::SortForBlock(const CTxMemPool::setEntries& package, CTxMemPool::txiter entry, std::vector<CTxMemPool::txiter>& sortedEntries)
+void BlockAssembler::SortForBlock(const CTxMemPool::setEntries& package, CTxMemPool::txiter entry, std::vector<CTxMemPool::txiter>& sortedEntries) const
 {
     // Sort package by ancestor count
     // If a transaction A depends on transaction B, then A's ancestor count
@@ -458,7 +458,7 @@ void BlockAssembler::SortForBlock(const CTxMemPool::setEntries& package, CTxMemP
 // Each time through the loop, we compare the best transaction in
 // mapModifiedTxs with the next transaction in the mempool to decide what
 // transaction package to work on next.
-void BlockAssembler::addPackageTxs(WorkingState &workState, int &nPackagesSelected, int &nDescendantsUpdated, int64_t nTimeCutoff, indexed_modified_transaction_set &mapModifiedTx)
+void BlockAssembler::addPackageTxs(WorkingState &workState, int &nPackagesSelected, int &nDescendantsUpdated, int64_t nTimeCutoff, indexed_modified_transaction_set &mapModifiedTx) const
 {
     // Keep track of entries that failed inclusion, to avoid duplicate work
     CTxMemPool::setEntries failedTx;

--- a/src/miner.h
+++ b/src/miner.h
@@ -221,7 +221,7 @@ public:
 private:
     // utility functions
     /** Add a tx to the block */
-    void AddToBlock(WorkingState &workState, CTxMemPool::txiter iter);
+    void AddToBlock(WorkingState &workState, CTxMemPool::txiter iter) const;
     /** Remove recent transactions from a block, including any descendants */
     void RemoveRecentTransactionsFromBlockAndUpdatePackages(WorkingState &workState, int64_t timeCutoff, indexed_modified_transaction_set &mapModifiedTx);
 
@@ -231,27 +231,27 @@ private:
       * statistics from the package selection (for logging statistics).
      *  mapModifiedTx will track the updated ancestor feerate score of
      *  not-in-block transactions that have parents in the block */
-    void addPackageTxs(WorkingState &workState, int &nPackagesSelected, int &nDescendantsUpdated, int64_t nTimeCutoff, indexed_modified_transaction_set &mapModifiedTx);
+    void addPackageTxs(WorkingState &workState, int &nPackagesSelected, int &nDescendantsUpdated, int64_t nTimeCutoff, indexed_modified_transaction_set &mapModifiedTx) const;
 
     // helper functions for addPackageTxs()
     /** Remove confirmed (inBlock) entries from given set */
-    void onlyUnconfirmed(WorkingState &workState, CTxMemPool::setEntries& testSet);
+    void onlyUnconfirmed(WorkingState &workState, CTxMemPool::setEntries& testSet) const;
     /** Test if a new package would "fit" in the block */
     bool TestPackage(const WorkingState &workState, uint64_t packageSize, int64_t packageSigOpsCost) const;
     /** Perform checks on each transaction in a package:
       * locktime, premature-witness, serialized size (if necessary)
       * These checks should always succeed, and they're here
       * only as an extra check in case of suboptimal node configuration */
-    bool TestPackageTransactions(WorkingState &workState, const CTxMemPool::setEntries& package);
+    bool TestPackageTransactions(WorkingState &workState, const CTxMemPool::setEntries& package) const;
     /** Return true if given transaction from mapTx has already been evaluated,
       * or if the transaction's cached data in mapTx is incorrect. */
-    bool SkipMapTxEntry(WorkingState &workState, CTxMemPool::txiter it, indexed_modified_transaction_set &mapModifiedTx, CTxMemPool::setEntries &failedTx);
+    bool SkipMapTxEntry(WorkingState &workState, CTxMemPool::txiter it, indexed_modified_transaction_set &mapModifiedTx, CTxMemPool::setEntries &failedTx) const;
     /** Sort the package in an order that is valid to appear in a block */
-    void SortForBlock(const CTxMemPool::setEntries& package, CTxMemPool::txiter entry, std::vector<CTxMemPool::txiter>& sortedEntries);
+    void SortForBlock(const CTxMemPool::setEntries& package, CTxMemPool::txiter entry, std::vector<CTxMemPool::txiter>& sortedEntries) const;
     /** Add descendants of given transactions to mapModifiedTx with ancestor
       * state updated assuming given transactions are inBlock. Returns number
       * of updated descendants. */
-    int UpdatePackagesForAdded(const CTxMemPool::setEntries& alreadyAdded, indexed_modified_transaction_set &mapModifiedTx);
+    int UpdatePackagesForAdded(const CTxMemPool::setEntries& alreadyAdded, indexed_modified_transaction_set &mapModifiedTx) const;
 };
 
 /** Modify the extranonce in a block */

--- a/src/miner.h
+++ b/src/miner.h
@@ -208,7 +208,7 @@ private:
       * statistics from the package selection (for logging statistics).
      *  mapModifiedTx will track the updated ancestor feerate score of
      *  not-in-block transactions that have parents in the block */
-    void addPackageTxs(WorkingState &workState, int &nPackagesSelected, int &nDescendantsUpdated, indexed_modified_transaction_set &mapModifiedTx);
+    void addPackageTxs(WorkingState &workState, int &nPackagesSelected, int &nDescendantsUpdated, int64_t nTimeCutoff, indexed_modified_transaction_set &mapModifiedTx);
 
     // helper functions for addPackageTxs()
     /** Remove confirmed (inBlock) entries from given set */

--- a/src/miner.h
+++ b/src/miner.h
@@ -189,9 +189,13 @@ private:
     // Configuration parameters for the block size
     bool fIncludeWitness;
     unsigned int nBlockMaxWeight, nBlockMaxSize;
+    // Exclude transactions received in nRecentTxWindow if the income
+    // reduction from doing so is below (1-dRecentTxStaleRate).
+    // See comment above CreateNewBlock().
+    int64_t nRecentTxWindow;
+    double dIncomeThreshold;
     bool fNeedSizeAccounting;
     CFeeRate blockMinFeeRate;
-    int64_t nRecentTxWindow;
 
     // Chain context for the block
     int nHeight;
@@ -205,6 +209,7 @@ public:
         size_t nBlockMaxSize;
         CFeeRate blockMinFeeRate;
         int64_t nRecentTxWindow;
+        double dRecentTxStaleRate;
     };
 
     BlockAssembler(const CChainParams& params);

--- a/src/miner.h
+++ b/src/miner.h
@@ -180,8 +180,10 @@ private:
     // Methods for how to add transactions to a block.
     /** Add transactions based on feerate including unconfirmed ancestors
       * Increments nPackagesSelected / nDescendantsUpdated with corresponding
-      * statistics from the package selection (for logging statistics). */
-    void addPackageTxs(int &nPackagesSelected, int &nDescendantsUpdated);
+      * statistics from the package selection (for logging statistics).
+     *  mapModifiedTx will track the updated ancestor feerate score of
+     *  not-in-block transactions that have parents in the block */
+    void addPackageTxs(int &nPackagesSelected, int &nDescendantsUpdated, indexed_modified_transaction_set &mapModifiedTx);
 
     // helper functions for addPackageTxs()
     /** Remove confirmed (inBlock) entries from given set */

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -22,6 +22,11 @@ static const unsigned int DEFAULT_BLOCK_MAX_SIZE = 750000;
 static const unsigned int DEFAULT_BLOCK_MAX_WEIGHT = 3000000;
 /** Default for -blockmintxfee, which sets the minimum feerate for a transaction in blocks created by mining code **/
 static const unsigned int DEFAULT_BLOCK_MIN_TX_FEE = 1000;
+/** Default in milliseconds for how we define 'recent' transactions, which we might omit in block creation */
+static constexpr int64_t DEFAULT_RECENT_TX_WINDOW = 30000;
+/** Default stale rate assumed for blocks with transactions in RECENT_TX_WINDOW; this gets interpreted as
+ * the amount of income we're willing to forgo to avoid selecting recent transactions */
+static constexpr double DEFAULT_RECENT_TX_STALE_RATE = 0.005;
 /** The maximum weight for transactions we're willing to relay/mine */
 static const unsigned int MAX_STANDARD_TX_WEIGHT = 400000;
 /** Maximum number of signature check operations in an IsStandard() P2SH script */

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -34,6 +34,7 @@ static BlockAssembler AssemblerForTest(const CChainParams& params) {
     options.nBlockMaxWeight = MAX_BLOCK_WEIGHT;
     options.nBlockMaxSize = MAX_BLOCK_SERIALIZED_SIZE;
     options.blockMinFeeRate = blockMinFeeRate;
+    options.nRecentTxWindow = 0;
     return BlockAssembler(params, options);
 }
 

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -35,6 +35,7 @@ static BlockAssembler AssemblerForTest(const CChainParams& params) {
     options.nBlockMaxSize = MAX_BLOCK_SERIALIZED_SIZE;
     options.blockMinFeeRate = blockMinFeeRate;
     options.nRecentTxWindow = 0;
+    options.dRecentTxStaleRate = 0;
     return BlockAssembler(params, options);
 }
 

--- a/test/functional/createnewblock.py
+++ b/test/functional/createnewblock.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test transaction selection (CreateNewBlock).
+
+  - Test that block max weight is respected (no blocks too big).
+  - Test that if the mempool has a tx that fits in a block, it will always be
+    included unless the block is within 4000 of max weight.
+  - Test that transaction selection takes into account feerate-with-ancestors
+    when creating blocks.
+  - Test that recently received transactions aren't selected unless the
+    feerate for including them is high.
+"""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.blocktools import create_block, create_coinbase
+from test_framework.mininode import ToHex
+from test_framework.util import (
+    random_transaction,
+    connect_nodes,
+)
+from test_framework.authproxy import JSONRPCException
+from decimal import Decimal
+import random
+import time
+
+class CreateNewBlockTest(BitcoinTestFramework):
+    def __init__(self):
+        super().__init__()
+        self.num_nodes = 4
+        self.setup_clean_chain = True
+
+    def setup_network(self, split=False):
+        self.cnb_args = [{
+            'window': 10000,
+            'stalerate': 0.02
+        }, {
+            'window': 30000,
+            'stalerate': 0.1
+        }, {
+            'window': 50000,
+            'stalerate': 0.001
+        }]
+
+        # Ancestor/descendant size limits are boosted because this test will
+        # populate and sync mempools using unconfirmed transaction chains, and
+        # failure to sync the mempool between nodes (eg due to descendant
+        # counts differing between nodes that see transactions in different
+        # order) will cause test failure.
+        # Set blockmaxweight to be low, to require fewer transactions
+        # to fill up a block.
+        extra_args = [[
+            "-debug", "-blockmaxweight=400000", "-minrelaytxfee=0",
+            "-limitancestorcount=100", "-limitdescendantcount=100"
+        ] for i in range(self.num_nodes)]
+        for extra_arg, cnb_arg in zip(extra_args, self.cnb_args):
+            extra_arg.extend([
+                "-recenttxwindow=%s" % cnb_arg['window'],
+                "-recenttxstalerate=%s" % cnb_arg['stalerate']
+            ])
+        self.nodes = self.start_nodes(self.num_nodes, self.options.tmpdir,
+                                      extra_args)
+
+        # Connect the network in a loop
+        for i in range(self.num_nodes - 1):
+            connect_nodes(self.nodes[i], i + 1)
+        connect_nodes(self.nodes[-1], 0)
+
+        self.is_network_split = False
+
+    def populate_mempool(self, desired_transactions):
+        num_transactions = 0
+        while (num_transactions < desired_transactions):
+            try:
+                random_amount = random.randint(1, 10) * Decimal('0.1')
+                random_transaction(
+                    self.nodes,
+                    amount=random_amount,
+                    min_fee=Decimal("0.00001"),
+                    fee_increment=Decimal("0.000005"),
+                    fee_variants=5000,
+                    confirmations_required=0,
+                    allow_segwit=True)
+                num_transactions += 1
+            except RuntimeError as e:
+                # We might run out of funds; just count these as valid attempts
+                if "Insufficient funds" in e.error['message']:
+                    num_transactions += 1
+                else:
+                    raise AssertionError("Unexpected run time error: " +
+                                         e.error['message'])
+            except JSONRPCException as e:
+                if "too-long-mempool" in e.error['message']:
+                    num_transactions += 1
+                else:
+                    raise AssertionError("Unexpected JSON-RPC error: " +
+                                         e.error['message'])
+            except Exception as e:
+                raise AssertionError("Unexpected exception raised: " +
+                                     type(e).__name__)
+        self.sync_all()
+
+    # Approximate weight of the transactions in the mempool
+    def get_mempool_weight(self, node):
+        mempool = node.getrawmempool(verbose=True)
+        weight = 0
+        for txid, entry in mempool.items():
+            # Scale by the witness multiplier, since we get vsize back
+            weight += entry['size'] * 4
+        return weight
+
+    # Requires mempool to be populated ahead of time
+    def test_max_block_weight(self, node):
+        block_max_weight = 400000 - 4000  # 4000 reserved for coinbase
+        assert self.get_mempool_weight(node) > block_max_weight
+
+        template = node.getblocktemplate({"rules": ["segwit"]})
+        block_weight = 0
+        for x in template['transactions']:
+            block_weight += x['weight']
+        assert (block_weight > block_max_weight - 4000)
+        assert (block_weight < block_max_weight)
+
+    def add_empty_block(self, node):
+        height = node.getblockcount()
+        tip = node.getbestblockhash()
+        mtp = node.getblockheader(tip)['mediantime']
+        block = create_block(
+            int(tip, 16), create_coinbase(height + 1), mtp + 1)
+        block.nVersion = 4
+        block.solve()
+        node.submitblock(ToHex(block))
+
+        # Log the hash to make it easier to figure out where we are in the
+        # test, when debugging.
+        self.log.debug("Added empty block %s", block.hash)
+
+    # Test that transaction selection is via ancestor feerate, by showing that
+    # it's sufficient to bump a child tx's fee to get it and its parent
+    # included.
+    def test_ancestor_feerate_sort(self, node, recent_tx_window):
+
+        # Advance time to the future, to ensure recent-transaction-filtering
+        # isn't affecting the test.
+        node.setmocktime(int(time.time()) + (recent_tx_window + 999) // 1000 + 1)
+        self.add_empty_block(node)  # bypass the gbt cache
+
+        # Call getblocktemplate.  Find a transaction in the mempool that is not
+        # in the block, which has exactly 1 ancestor that is also not in the
+        # block.  Call prioritisetransaction on the child tx to boost its
+        # ancestor feerate to be above the maximum feerate of transactions in
+        # the last ancestor_size space in the block, and verify that the child
+        # transaction is in the next block template.
+        template = node.getblocktemplate({"rules": ["segwit"]})
+        block_txids = [x["txid"] for x in template["transactions"]]
+        mempool_txids = node.getrawmempool()
+
+        # Find a transaction that has exactly one ancestor that is also not in
+        # the block.
+        txid_to_bump = None
+
+        for txid in mempool_txids:
+            if txid not in block_txids:
+                ancestor_txids = node.getmempoolancestors(
+                    txid=txid, verbose=False)
+                if len(ancestor_txids) != 1:
+                    continue
+                if ancestor_txids[0] not in block_txids:
+                    txid_to_bump = txid
+                    break
+            if txid_to_bump is not None:
+                break
+        if txid_to_bump is None:
+            raise AssertionError(
+                "Can't find candidate to test ancestor feerate score (test setup bug)"
+            )
+
+        # Calculate the ancestor feerate of the candidate transaction.
+        mempool_entry = node.getmempoolentry(txid_to_bump)
+        ancestor_size = mempool_entry['ancestorsize']
+        ancestor_fee = mempool_entry['ancestorfees']
+        tx_fee = mempool_entry['modifiedfee']
+        tx_size = mempool_entry['size']
+        self.log.debug(
+                "Found txid to bump: %s, ancestor_size = %d, ancestor_fee = %f (ancestor feerate: %f) size = %d mod_fee = %d (feerate: %f)",
+            txid_to_bump, ancestor_size, ancestor_fee, ancestor_fee/ancestor_size, tx_size, tx_fee, tx_fee/tx_size)
+
+        # Determine feerate of the last ancestor_size portion of the block.
+        cumulative_weight = 0
+        max_feerate = 0
+        for block_tx in reversed(template["transactions"]):
+            # The fee is the consensus correct one, not the policy modified
+            # one, but we haven't prioritized anything yet, so this should be
+            # fine.
+            self.log.debug("End of block tx: txid %s, fee %d, weight %d",
+                    block_tx["txid"], block_tx["fee"], block_tx["weight"])
+            if 4 * block_tx["fee"] / block_tx["weight"] > max_feerate:
+                max_feerate = 4 * block_tx["fee"] / block_tx["weight"]
+            cumulative_weight += block_tx["weight"]
+            if cumulative_weight > 4 * ancestor_size:
+                break
+
+        # Bump the candidate transaction so that it has a higher feerate than
+        # the max feerate observed in the last portion of the block that we
+        # seek to replace
+        fee_bump = int(max_feerate * ancestor_size - ancestor_fee) + 1
+        self.log.debug("Setting fee_bump to %d", fee_bump)
+
+        node.prioritisetransaction(txid=txid_to_bump, fee_delta=fee_bump)
+
+        # Check that the next block template has txid_to_bump in it.
+        self.add_empty_block(node)  # bypass the gbt cache
+        template = node.getblocktemplate({"rules": ["segwit"]})
+        new_block_txids = [x["txid"] for x in template["transactions"]]
+
+        assert txid_to_bump in new_block_txids
+
+        # Get rid of our prioritisation
+        node.prioritisetransaction(txid=txid_to_bump, fee_delta=-fee_bump)
+
+    def test_recent_transactions(self):
+        # Populate the mempool with some transactions, and compare gbt results
+        # across the nodes.  Repeat.
+        self.add_empty_block(self.nodes[0])  # Bypass gbt cache.
+        self.sync_all()
+        recent_tx_block_count = [0, 0, 0]
+
+        max_iterations = 20
+        for i in range(max_iterations):
+            self.populate_mempool(random.randint(5, 15))  # 5-15 transactions
+
+            # Freeze current time, so that our recent tx window calculations
+            # will be consistent.
+            cur_time = int(time.time())
+            [node.setmocktime(cur_time) for node in self.nodes]
+
+            # Check that total block reward is within stale_rate of node3
+            max_income = self.nodes[3].getblocktemplate({
+                "rules": ["segwit"]
+                })['coinbasevalue']
+
+            # Check that calling gbt on the given node produces a block
+            # within the expected tolerance of max_income.
+            # Return true if the returned block includes recent transactions;
+            # false otherwise
+            def check_gbt_results(node, max_income, cnb_args, cur_time):
+                template = node.getblocktemplate({"rules": ["segwit"]})
+                mempool = node.getrawmempool(verbose=True)
+                stale_rate = cnb_args['stalerate']
+                # Convert window from milliseconds to seconds
+                window = (cnb_args['window'] + 999) // 1000
+
+                # We should always be within stale_rate of best possible block
+                assert template['coinbasevalue'] >= stale_rate * max_income
+
+                # Check that if we're including any recent transactions, then
+                # we achieve the max_income
+                includes_recent_transactions = False
+                for x in template['transactions']:
+                    if mempool[x['txid']]['time'] > cur_time - window:
+                        includes_recent_transactions = True
+                        break
+
+                if includes_recent_transactions:
+                    assert template['coinbasevalue'] == max_income
+
+                return includes_recent_transactions
+
+            for j in range(3):
+                if check_gbt_results(self.nodes[j], max_income,
+                                     self.cnb_args[j], cur_time):
+                    recent_tx_block_count[j] += 1
+
+            # Drain the mempool if it gets big
+            if self.nodes[0].getmempoolinfo()['bytes'] > 400000:
+                self.nodes[0].generate(1)
+            else:
+                [node.setmocktime(0) for node in self.nodes]
+                self.add_empty_block(self.nodes[0])
+            self.sync_all()
+
+        if sum(recent_tx_block_count) == 3 * max_iterations:
+            self.log.warn(
+                "Warning: every block contained recent transactions!"
+            )
+        self.log.debug(recent_tx_block_count)
+
+    def run_test(self):
+        # Leave IBD and generate some coins to spend.
+        # Give everyone plenty of coins
+        self.log.info("Generating initial coins for all nodes")
+        for i in range(2):
+            for x in self.nodes:
+                # Building a long blockchain here will make the block reward
+                # smaller, compared to the fees -- this is helpful for
+                # test_recent_transactions()
+                x.generate(201)
+                self.sync_all()
+
+        # Run tests...
+        self.log.info("Populating mempool with a lot of transactions")
+        self.populate_mempool(300)
+
+        self.log.info("Running recent transactions test")
+        self.test_recent_transactions()
+
+        self.log.info("Repopulating mempool")
+        self.populate_mempool(500)
+
+        self.log.info("Running test_max_block_weight")
+        self.test_max_block_weight(self.nodes[0])
+
+        self.sync_all()
+
+        self.log.info("Running test_ancestor_feerate_sort")
+        self.test_ancestor_feerate_sort(
+            self.nodes[0], recent_tx_window=self.cnb_args[0]['window'])
+
+
+if __name__ == "__main__":
+    CreateNewBlockTest().main()

--- a/test/functional/test_framework/mininode.py
+++ b/test/functional/test_framework/mininode.py
@@ -215,7 +215,7 @@ def FromHex(obj, hex_string):
 
 # Convert a binary-serializable object to hex (eg for submission via RPC)
 def ToHex(obj):
-    return bytes_to_hex_str(obj.serialize())
+    return bytes_to_hex_str(obj.serialize_with_witness())
 
 # Objects that map to bitcoind objects, which can be serialized/deserialized
 
@@ -611,6 +611,9 @@ class CBlock(CBlockHeader):
         else:
             r += ser_vector(self.vtx)
         return r
+
+    def serialize_with_witness(self):
+        return self.serialize(with_witness=True)
 
     # Calculate the merkle root given a vector of transaction hashes
     @classmethod

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -43,7 +43,7 @@ class TestNode():
         self.coverage_dir = coverage_dir
         # Most callers will just need to add extra args to the standard list below. For those callers that need more flexibity, they can just set the args property directly.
         self.extra_args = extra_args
-        self.args = [self.binary, "-datadir=" + self.datadir, "-server", "-keypool=1", "-discover=0", "-rest", "-logtimemicros", "-debug", "-debugexclude=libevent", "-debugexclude=leveldb", "-mocktime=" + str(mocktime), "-uacomment=testnode%d" % i]
+        self.args = [self.binary, "-datadir=" + self.datadir, "-server", "-keypool=1", "-discover=0", "-rest", "-logtimemicros", "-debug", "-debugexclude=libevent", "-debugexclude=leveldb", "-mocktime=" + str(mocktime), "-uacomment=testnode%d" % i, "-recenttxstalerate=0" ]
 
         self.running = False
         self.process = None

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -390,7 +390,7 @@ def make_change(from_node, amount_in, amount_out, fee):
         outputs[from_node.getnewaddress()] = change
     return outputs
 
-def random_transaction(nodes, amount, min_fee, fee_increment, fee_variants):
+def random_transaction(nodes, amount, min_fee, fee_increment, fee_variants, confirmations_required=1):
     """
     Create a random transaction.
     Returns (txid, hex-encoded-transaction-data, fee)
@@ -399,7 +399,7 @@ def random_transaction(nodes, amount, min_fee, fee_increment, fee_variants):
     to_node = random.choice(nodes)
     fee = min_fee + fee_increment * random.randint(0, fee_variants)
 
-    (total_in, inputs) = gather_inputs(from_node, amount + fee)
+    (total_in, inputs) = gather_inputs(from_node, amount + fee, confirmations_required)
     outputs = make_change(from_node, total_in, amount, fee)
     outputs[to_node.getnewaddress()] = float(amount)
 

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -390,7 +390,7 @@ def make_change(from_node, amount_in, amount_out, fee):
         outputs[from_node.getnewaddress()] = change
     return outputs
 
-def random_transaction(nodes, amount, min_fee, fee_increment, fee_variants, confirmations_required=1):
+def random_transaction(nodes, amount, min_fee, fee_increment, fee_variants, confirmations_required=1, allow_segwit=False):
     """
     Create a random transaction.
     Returns (txid, hex-encoded-transaction-data, fee)
@@ -401,7 +401,10 @@ def random_transaction(nodes, amount, min_fee, fee_increment, fee_variants, conf
 
     (total_in, inputs) = gather_inputs(from_node, amount + fee, confirmations_required)
     outputs = make_change(from_node, total_in, amount, fee)
-    outputs[to_node.getnewaddress()] = float(amount)
+    if (allow_segwit and random.randint(0, 1)):
+        outputs[to_node.addwitnessaddress(to_node.getnewaddress())] = float(amount)
+    else:
+        outputs[to_node.getnewaddress()] = float(amount)
 
     rawtx = from_node.createrawtransaction(inputs, outputs)
     signresult = from_node.signrawtransaction(rawtx)

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -132,6 +132,7 @@ EXTENDED_SCRIPTS = [
     'maxuploadtarget.py',
     'mempool_packages.py',
     'dbcrash.py',
+    'createnewblock.py',
     # vv Tests less than 2m vv
     'bip68-sequence.py',
     'getblocktemplate_longpoll.py',


### PR DESCRIPTION
After compact blocks (BIP 152), including recently received transactions in a block may lead to propagation delays relative to blocks without such transactions, because recently received transactions may not yet be in peers' mempools.

Account for this in `CreateNewBlock()` by adding two new parameters:

 * `-recenttxwindow` defines a "recent transaction" as having been received less than this many milliseconds ago
 * `-recenttxstalerate` models the additional likelihood of a block being stale because it includes a recent transaction.

Briefly, if `I_0` is the block income you'd receive using only non-recent transactions, and `I_1` is the income including recently received transactions, and `s` is the value being used for `-recenttxstalerate`, then `CreateNewBlock` is now going to choose the block that doesn't include recent transactions if `I_0 >= (1-s) * I_1`.

Notes for reviewers:
- I struggled to name and explain these two parameters, so suggestions on alternate/less confusing parameter names and explanation would be appreciated!  @ryanofsky suggested `-recenttxblockdiscount` or `-recenttxminingpenalty` to try to describe what I called the stale rate; I think those are reasonable suggestions as well.
 - Suggestions are also welcome for what the defaults should be (in particular, should this be enabled at all by default?)
- In my most recent performance measurements of a slightly earlier version of this patch, I measured an approximately 3ms slowdown (~ 7ms -> ~ 10ms) in the transaction selection portion of `CreateNewBlock()`.  I suspect we can optimize `CreateNewBlock` further, but I'd like to save that for a future PR as this is already a lengthy patch.
- The idea in this PR is to produce two block candidates, one with recent transactions and one without, and then compare block income and pick a winner.  The candidate which does not include recent transactions is not going to be as good in general as the regular ancestor-feerate-mining algorithm being called on a mempool that doesn't contain any recent transactions, because for performance reasons we might continue to include low-fee ancestors of recent transactions (ie, we kick out recent transactions from the block, but not their ancestors).  Despite this, I think for most reasonable parameters we will be overwhelmingly choosing the block that doesn't include recent transactions, so I don't think this is a big deal at the moment.  We could try to improve this in the future, however (possibly by adding a smart caching layer on top).
- This PR includes a (slow) functional test for the mining code, which I've added to the extended test suite.

Thanks @JeremyRubin and @ryanofsky for feedback on an earlier version of this patch.