### PR TITLE
[Wallet] FundRawTransaction can fund a transaction with preset inputs found in the CoinView

### DIFF
--- a/src/wallet/coincontrol.h
+++ b/src/wallet/coincontrol.h
@@ -7,6 +7,7 @@
 
 #include "primitives/transaction.h"
 #include "wallet/wallet.h"
+#include <map>
 
 /** Coin Control Features. */
 class CCoinControl
@@ -76,8 +77,24 @@ public:
         vOutpoints.assign(setSelected.begin(), setSelected.end());
     }
 
+    void AddKnownCoins(const CInputCoin& coin)
+    {
+        knownCoins.insert(std::make_pair(coin.outpoint, coin));
+    }
+
+    boost::optional<CInputCoin> FindKnownCoin(const COutPoint& outpoint) const
+    {
+        boost::optional<CInputCoin> foundCoin;
+        auto it = knownCoins.find(outpoint);
+        if (it != knownCoins.end())
+            foundCoin = it->second;
+        return foundCoin;
+    }
+
 private:
     std::set<COutPoint> setSelected;
+    //! A map of known UTXO
+    std::map<COutPoint, CInputCoin> knownCoins;
 };
 
 #endif // BITCOIN_WALLET_COINCONTROL_H

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2776,7 +2776,14 @@ UniValue fundrawtransaction(const JSONRPCRequest& request)
     coinControl.nFeeRate = feeRate;
 
     BOOST_FOREACH(const CTxIn& txin, tx.vin)
+    {
         coinControl.Select(txin.prevout);
+        boost::optional<CInputCoin> foundCoin;
+        foundCoin = pwallet->FindCoin(txin.prevout);
+        if(!foundCoin)
+            throw JSONRPCError(RPC_WALLET_ERROR, _("Insufficient funds"));
+        coinControl.AddKnownCoins(*foundCoin);
+    }
 
     if (!pwallet->FundTransaction(tx, nFeeOut, coinControl, changePosition, strFailReason, lockUnspents, setSubtractFeeFromOutputs, reserveChangeKey)) {
         throw JSONRPCError(RPC_WALLET_ERROR, strFailReason);

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2798,7 +2798,7 @@ UniValue fundrawtransaction(const JSONRPCRequest& request)
         if(!foundCoin)
             foundCoin = FindInCoinView(txin.prevout);
         if(!foundCoin)
-            throw JSONRPCError(RPC_WALLET_ERROR, _("Insufficient funds"));
+            throw JSONRPCError(RPC_WALLET_ERROR, "unknown-input");
         coinControl.AddKnownCoins(*foundCoin);
     }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2312,7 +2312,7 @@ bool CWallet::SignTransaction(CMutableTransaction &tx)
     return true;
 }
 
-bool CWallet::FundTransaction(CMutableTransaction& tx, CAmount& nFeeRet, bool overrideEstimatedFeeRate, const CFeeRate& specificFeeRate, int& nChangePosInOut, std::string& strFailReason, bool includeWatching, bool lockUnspents, const std::set<int>& setSubtractFeeFromOutputs, bool keepReserveKey, const CTxDestination& destChange)
+bool CWallet::FundTransaction(CMutableTransaction& tx, CAmount& nFeeRet, const CCoinControl& coinControl, int& nChangePosInOut, std::string& strFailReason, bool lockUnspents, const std::set<int>& setSubtractFeeFromOutputs, bool keepReserveKey)
 {
     std::vector<CRecipient> vecSend;
 
@@ -2323,16 +2323,6 @@ bool CWallet::FundTransaction(CMutableTransaction& tx, CAmount& nFeeRet, bool ov
         CRecipient recipient = {txOut.scriptPubKey, txOut.nValue, setSubtractFeeFromOutputs.count(idx) == 1};
         vecSend.push_back(recipient);
     }
-
-    CCoinControl coinControl;
-    coinControl.destChange = destChange;
-    coinControl.fAllowOtherInputs = true;
-    coinControl.fAllowWatchOnly = includeWatching;
-    coinControl.fOverrideFeeRate = overrideEstimatedFeeRate;
-    coinControl.nFeeRate = specificFeeRate;
-
-    BOOST_FOREACH(const CTxIn& txin, tx.vin)
-        coinControl.Select(txin.prevout);
 
     CReserveKey reservekey(this);
     CWalletTx wtx;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -908,7 +908,7 @@ public:
      * Insert additional inputs into the transaction by
      * calling CreateTransaction();
      */
-    bool FundTransaction(CMutableTransaction& tx, CAmount& nFeeRet, bool overrideEstimatedFeeRate, const CFeeRate& specificFeeRate, int& nChangePosInOut, std::string& strFailReason, bool includeWatching, bool lockUnspents, const std::set<int>& setSubtractFeeFromOutputs, bool keepReserveKey = true, const CTxDestination& destChange = CNoDestination());
+    bool FundTransaction(CMutableTransaction& tx, CAmount& nFeeRet, const CCoinControl& coinControl, int& nChangePosInOut, std::string& strFailReason, bool lockUnspents, const std::set<int>& setSubtractFeeFromOutputs, bool keepReserveKey = true);
     bool SignTransaction(CMutableTransaction& tx);
 
     /**

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -475,6 +475,16 @@ public:
 
 class CInputCoin {
 public:
+
+    CInputCoin(const CTxOut& txoutIn, const COutPoint& outpointIn)
+    {
+        if(txoutIn.IsNull())
+            throw std::invalid_argument("txoutIn should not be null");
+        if (outpointIn.IsNull())
+            throw std::invalid_argument("outpointIn should not be null");
+        outpoint = outpointIn;
+        txout = txoutIn;
+    }
     CInputCoin(const CWalletTx* walletTx, unsigned int i)
     {
         if (!walletTx)
@@ -1172,11 +1182,15 @@ bool CWallet::DummySignTx(CMutableTransaction &txNew, const ContainerType &coins
         const CScript& scriptPubKey = coin.txout.scriptPubKey;
         SignatureData sigdata;
 
-        if (!ProduceSignature(DummySignatureCreator(this), scriptPubKey, sigdata))
+        auto ismine = IsMine(coin.txout);
+        if (ismine == ISMINE_SPENDABLE || ismine == ISMINE_WATCH_SOLVABLE)
         {
-            return false;
-        } else {
-            UpdateTransaction(txNew, nIn, sigdata);
+            if (!ProduceSignature(DummySignatureCreator(this), scriptPubKey, sigdata))
+            {
+                return false;
+            } else {
+                UpdateTransaction(txNew, nIn, sigdata);
+            }
         }
 
         nIn++;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -904,6 +904,8 @@ public:
     CAmount GetUnconfirmedWatchOnlyBalance() const;
     CAmount GetImmatureWatchOnlyBalance() const;
 
+    boost::optional<CInputCoin> FindCoin(const COutPoint& outpoint);
+
     /**
      * Insert additional inputs into the transaction by
      * calling CreateTransaction();

--- a/test/functional/fundrawtransaction.py
+++ b/test/functional/fundrawtransaction.py
@@ -63,6 +63,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 1.5)
         self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 1.0)
         self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 5.0)
+        self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 3.0)
 
         self.nodes[0].generate(1)
         self.sync_all()
@@ -306,6 +307,30 @@ class RawTransactionsTest(BitcoinTestFramework):
 
         assert_equal(matchingOuts, 2)
         assert_equal(len(dec_tx['vout']), 3)
+
+        ##############################################################################################
+        # test a fundrawtransaction with one vin from wallet and one from mempool, one from CoinView #
+        ##############################################################################################
+        utx = get_unspent(self.nodes[0].listunspent(), 50)
+        recei = self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 4)
+        self.sync_all()
+        # utx2 is unconfirmed, utx3 is confirmed (sent at the beginning of this test)
+        utx2 = get_unspent(self.nodes[2].listunspent(minconf=0, maxconf=0, addresses=None, include_unsafe=True), 4)
+        utx3 = get_unspent(self.nodes[2].listunspent(), 3)
+        inputs  = [ {'txid' : utx['txid'], 'vout' : utx['vout']},{'txid' : utx2['txid'], 'vout' : utx2['vout']},{'txid' : utx3['txid'], 'vout' : utx3['vout']} ]
+        outputs = { self.nodes[0].getnewaddress() : 50 + 4 + 3 + 2 }
+        rawtx   = self.nodes[0].createrawtransaction(inputs, outputs)
+        rawtxfund = self.nodes[0].fundrawtransaction(rawtx)
+        dec_tx  = self.nodes[0].decoderawtransaction(rawtxfund['hex'])
+        # Should contains the 3 previous vin + a new one added by the wallet
+        assert_equal(len(dec_tx['vin']), 4)
+        # Should contains the change, nodes[0] having only 50 BTC coins, it should returns around 43 BTC
+        assert_equal(len(dec_tx['vout']), 2)
+        totalOut = 0
+        for out in dec_tx['vout']:
+            totalOut += out['value']
+        assert_greater_than(totalOut, 50 + 4 + 3 + 2 + 42.9)
+        assert_greater_than(50 + 4 + 3 + 2 + 43, totalOut)
 
         ##############################################
         # test a fundrawtransaction with invalid vin #

--- a/test/functional/fundrawtransaction.py
+++ b/test/functional/fundrawtransaction.py
@@ -316,7 +316,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         rawtx   = self.nodes[2].createrawtransaction(inputs, outputs)
         dec_tx  = self.nodes[2].decoderawtransaction(rawtx)
 
-        assert_raises_jsonrpc(-4, "Insufficient funds", self.nodes[2].fundrawtransaction, rawtx)
+        assert_raises_jsonrpc(-4, "unknown-input", self.nodes[2].fundrawtransaction, rawtx)
 
         ############################################################
         #compare fee of a standard pubkeyhash transaction


### PR DESCRIPTION
This PR makes it possible to call FundRawTransaction with pre filled inputs not belonging to the wallet.
This is very useful for AnyOneCanPay scenario, where one of a third party only cover part of a transaction.

The necessary information to complete the transaction is taken from of the mempool and coinview.

A typical example would involves Alice and Bob wanting to fund 0.5 each to the payment channel. Alice would give her input, and Bob would be able to complete the missing amount via FundRawTransaction.

A follow up PR will allow the client `fundrawtransaction` to pass previous TxOuts corresponding to the inputs. This is necessary for filling transaction in some 2nd layer protocols, where the the inputs's of the transaction to fund have not yet been broadcasted.

This supersede my previous attempt at https://github.com/bitcoin/bitcoin/pull/10068 which I closed, as it was harder to review.

The first two commits are strict refactoring.
The third is the one checking information in the coinview.
Rest is about tests.