### PR TITLE
[rpc] rename disconnectnode argument

### DIFF
--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -236,10 +236,10 @@ UniValue disconnectnode(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() != 1)
         throw std::runtime_error(
-            "disconnectnode \"node\" \n"
+            "disconnectnode \"address\" \n"
             "\nImmediately disconnects from the specified node.\n"
             "\nArguments:\n"
-            "1. \"node\"     (string, required) The node (see getpeerinfo for nodes)\n"
+            "1. \"address\"     (string, required) The IP address/port of the node\n"
             "\nExamples:\n"
             + HelpExampleCli("disconnectnode", "\"192.168.0.6:8333\"")
             + HelpExampleRpc("disconnectnode", "\"192.168.0.6:8333\"")
@@ -607,7 +607,7 @@ static const CRPCCommand commands[] =
     { "network",            "ping",                   &ping,                   true,  {} },
     { "network",            "getpeerinfo",            &getpeerinfo,            true,  {} },
     { "network",            "addnode",                &addnode,                true,  {"node","command"} },
-    { "network",            "disconnectnode",         &disconnectnode,         true,  {"node"} },
+    { "network",            "disconnectnode",         &disconnectnode,         true,  {"address"} },
     { "network",            "getaddednodeinfo",       &getaddednodeinfo,       true,  {"node"} },
     { "network",            "getnettotals",           &getnettotals,           true,  {} },
     { "network",            "getnetworkinfo",         &getnetworkinfo,         true,  {} },


### PR DESCRIPTION
split off from #10143 for backport

The fact that this argument is currently called 'node' and the help text says `(string, required) The node (see getpeerinfo for nodes)` is misleading at best. It currently only accepts a string which must match on the CNode::addrName, which is the IP address/port.