### PR TITLE
Make sure parameter names in .cpp and .h files are in sync

### DIFF
--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -34,7 +34,7 @@ class CValidationInterface {
 protected:
     virtual void UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload) {}
     virtual void TransactionAddedToMempool(const CTransactionRef &ptxn) {}
-    virtual void BlockConnected(const std::shared_ptr<const CBlock> &block, const CBlockIndex *pindex, const std::vector<CTransactionRef> &txnConflicted) {}
+    virtual void BlockConnected(const std::shared_ptr<const CBlock> &block, const CBlockIndex *pindex, const std::vector<CTransactionRef> &vtxConflicted) {}
     virtual void BlockDisconnected(const std::shared_ptr<const CBlock> &block) {}
     virtual void SetBestChain(const CBlockLocator &locator) {}
     virtual void UpdatedTransaction(const uint256 &hash) {}

--- a/src/wallet/feebumper.h
+++ b/src/wallet/feebumper.h
@@ -23,7 +23,7 @@ enum class BumpFeeResult
 class CFeeBumper
 {
 public:
-    CFeeBumper(const CWallet *pWalletIn, const uint256 txidIn, int newConfirmTarget, bool specifiedConfirmTarget, CAmount totalFee, bool newTxReplaceable);
+    CFeeBumper(const CWallet *pWallet, const uint256 txidIn, int newConfirmTarget, bool specifiedConfirmTarget, CAmount totalFee, bool newTxReplaceable);
     BumpFeeResult getResult() const { return currentResult; }
     const std::vector<std::string>& getErrors() const { return vErrors; }
     CAmount getOldFee() const { return nOldFee; }
@@ -41,7 +41,7 @@ public:
      * but, eventually sets vErrors if the tx could not be added to the mempool (will try later)
      * or if the old transaction could not be marked as replaced
      */
-    bool commit(CWallet *pWalletNonConst);
+    bool commit(CWallet *pWallet);
 
 private:
     const uint256 txid;


### PR DESCRIPTION
Doxygen gets confused by parameter naming mismatches.

Changed from `txnConflicted` to `vtxConflicted` in:

```c++
src/validationinterface.h:    virtual void BlockConnected(const std::shared_ptr<const CBlock> &block, const CBlockIndex *pindex, const std::vector<CTransactionRef> &vtxConflicted) {}
src/wallet/wallet.cpp:void CWallet::BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex *pindex, const std::vector<CTransactionRef>& vtxConflicted) {
src/wallet/wallet.h:    void BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex *pindex, const std::vector<CTransactionRef>& vtxConflicted) override;
```

Changed from `pWalletIn` to `pWallet` in:

```c++
src/wallet/feebumper.cpp:CFeeBumper::CFeeBumper(const CWallet *pWallet, const uint256 txidIn, int newConfirmTarget, bool specifiedConfirmTarget, CAmount totalFee, bool newTxReplaceable)
src/wallet/feebumper.h:    CFeeBumper(const CWallet *pWallet, const uint256 txidIn, int newConfirmTarget, bool specifiedConfirmTarget, CAmount totalFee, bool newTxReplaceable);
```

Changed from `pWalletNonConst` to `pWallet` in:

```c++
src/wallet/feebumper.cpp:bool CFeeBumper::commit(CWallet *pWallet)
src/wallet/feebumper.h:    bool commit(CWallet *pWallet);
```