### PR TITLE
Abortable rescans & rpc abortrescan command

### DIFF
--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -1125,3 +1125,26 @@ UniValue importmulti(const JSONRPCRequest& mainRequest)
 
     return response;
 }
+UniValue abortrescan(const JSONRPCRequest& request)
+{
+    if (request.fHelp) {
+        throw std::runtime_error("abortrescan\n\n"
+	"Aborts the current running rescan.\n\n"
+	"Examples:\n" +
+	HelpExampleCli("abortrescan", "") +
+	HelpExampleRpc("abortrescan", "")
+	);
+    }
+
+    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp)) {
+        return NullUniValue;
+    }
+
+    pwallet->AbortScanForWalletTransactions(true);
+    LogPrintf("abortrescan command received from rpc\n");
+
+    LOCK2(cs_main, pwallet->cs_wallet); // Wait for lock to release
+
+    return NullUniValue;
+}

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2923,6 +2923,7 @@ extern UniValue importwallet(const JSONRPCRequest& request);
 extern UniValue importprunedfunds(const JSONRPCRequest& request);
 extern UniValue removeprunedfunds(const JSONRPCRequest& request);
 extern UniValue importmulti(const JSONRPCRequest& request);
+extern UniValue abortrescan(const JSONRPCRequest& request);
 
 static const CRPCCommand commands[] =
 { //  category              name                        actor (function)           okSafeMode
@@ -2975,6 +2976,7 @@ static const CRPCCommand commands[] =
     { "wallet",             "walletpassphrasechange",   &walletpassphrasechange,   true,   {"oldpassphrase","newpassphrase"} },
     { "wallet",             "walletpassphrase",         &walletpassphrase,         true,   {"passphrase","timeout"} },
     { "wallet",             "removeprunedfunds",        &removeprunedfunds,        true,   {"txid"} },
+    { "wallet",             "abortrescan",              &abortrescan,              true,   {} },
 };
 
 void RegisterWalletRPCCommands(CRPCTable &t)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1527,6 +1527,7 @@ CBlockIndex* CWallet::ScanForWalletTransactions(CBlockIndex* pindexStart, bool f
     CBlockIndex* pindex = pindexStart;
     {
         LOCK2(cs_main, cs_wallet);
+	fAbortRescan = false;
 
         // no need to read and scan block, if block was created before
         // our wallet birthday (as adjusted for block time variability)
@@ -1557,10 +1558,21 @@ CBlockIndex* CWallet::ScanForWalletTransactions(CBlockIndex* pindexStart, bool f
                 nNow = GetTime();
                 LogPrintf("Still rescanning. At block %d. Progress=%f\n", pindex->nHeight, GuessVerificationProgress(chainParams.TxData(), pindex));
             }
+	    if (fAbortRescan) {
+	        LogPrintf("Aborted rescanning. At block %d. Progress=%f\n", pindex->nHeight, GuessVerificationProgress(chainParams.TxData(), pindex));
+	        fAbortRescan = false;
+		break;
+	    }
         }
         ShowProgress(_("Rescanning..."), 100); // hide progress dialog in GUI
     }
     return ret;
+}
+
+bool CWallet::AbortScanForWalletTransactions(bool fAbort)
+{
+	fAbortRescan = fAbort;
+	return fAbortRescan;
 }
 
 void CWallet::ReacceptWalletTransactions()

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -671,6 +671,9 @@ private:
     int64_t nLastResend;
     bool fBroadcastTransactions;
 
+    // Flag used for aborting rescans
+    bool fAbortRescan;
+
     /**
      * Used to keep track of spent outpoints, and
      * detect and report conflicts (double-spends or
@@ -883,6 +886,7 @@ public:
     void BlockDisconnected(const std::shared_ptr<const CBlock>& pblock) override;
     bool AddToWalletIfInvolvingMe(const CTransactionRef& tx, const CBlockIndex* pIndex, int posInBlock, bool fUpdate);
     CBlockIndex* ScanForWalletTransactions(CBlockIndex* pindexStart, bool fUpdate = false);
+    bool AbortScanForWalletTransactions(bool fAbort = false);
     void ReacceptWalletTransactions();
     void ResendWalletTransactions(int64_t nBestBlockTime, CConnman* connman) override;
     std::vector<uint256> ResendWalletTransactionsBefore(int64_t nTime, CConnman* connman);


### PR DESCRIPTION
* Added fAbortRescan flag to CWallet to break out of rescans loops.
* Added abortrescan RPC command to exit safely out of rescans

Feedback welcomed