### PR TITLE
Check interruptNet during dnsseed lookups

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1585,6 +1585,9 @@ void CConnman::ThreadDNSAddressSeed()
     LogPrintf("Loading addresses from DNS seeds (could take a while)\n");
 
     BOOST_FOREACH(const CDNSSeedData &seed, vSeeds) {
+        if (interruptNet) {
+            return;
+        }
         if (HaveNameProxy()) {
             AddOneShot(seed.host);
         } else {
@@ -1601,6 +1604,9 @@ void CConnman::ThreadDNSAddressSeed()
                     vAdd.push_back(addr);
                     found++;
                 }
+            }
+            if (interruptNet) {
+                return;
             }
             // TODO: The seed name resolve may fail, yielding an IP of [::], which results in
             // addrman assigning the same source to results from different seeds.


### PR DESCRIPTION
Since #9229 we no longer can break out of a DNS lookup midway through, and have to wait for libc to time out. In most places we check for interrupt immediately before/after, so this is not a huge deal, except in the dnsseed lookup thread. In that thread, we loop over all dnsseeds and will have to wait for each to timeout. This appears to be the cause of the long wait in #10210.

Until upstream glibc fixes the issue (https://sourceware.org/bugzilla/show_bug.cgi?id=20874) with getaddrinfo_a or we move to libevent's DNS lookup library, the best we can do is insert more agressive checks between lookups, which we do here.