### PR TITLE
[Wallet] FundRawTransaction can accept pre-set inputs whose parent is not yet broadcasted

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -88,6 +88,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "signrawtransaction", 2, "privkeys" },
     { "sendrawtransaction", 1, "allowhighfees" },
     { "fundrawtransaction", 1, "options" },
+    { "fundrawtransaction", 2, "previousOutputs" },
     { "gettxout", 1, "n" },
     { "gettxout", 2, "include_mempool" },
     { "gettxoutproof", 0, "txids" },

--- a/src/wallet/coincontrol.h
+++ b/src/wallet/coincontrol.h
@@ -7,6 +7,7 @@
 
 #include "primitives/transaction.h"
 #include "wallet/wallet.h"
+#include <map>
 
 /** Coin Control Features. */
 class CCoinControl
@@ -76,8 +77,24 @@ public:
         vOutpoints.assign(setSelected.begin(), setSelected.end());
     }
 
+    void AddKnownCoins(const CInputCoin& coin)
+    {
+        knownCoins.insert(std::make_pair(coin.outpoint, coin));
+    }
+
+    boost::optional<CInputCoin> FindKnownCoin(const COutPoint& outpoint) const
+    {
+        boost::optional<CInputCoin> foundCoin;
+        auto it = knownCoins.find(outpoint);
+        if (it != knownCoins.end())
+            foundCoin = it->second;
+        return foundCoin;
+    }
+
 private:
     std::set<COutPoint> setSelected;
+    //! A map of known UTXO
+    std::map<COutPoint, CInputCoin> knownCoins;
 };
 
 #endif // BITCOIN_WALLET_COINCONTROL_H

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2776,7 +2776,14 @@ UniValue fundrawtransaction(const JSONRPCRequest& request)
     coinControl.nFeeRate = feeRate;
 
     BOOST_FOREACH(const CTxIn& txin, tx.vin)
+    {
         coinControl.Select(txin.prevout);
+        boost::optional<CInputCoin> foundCoin;
+        foundCoin = pwallet->FindCoin(txin.prevout);
+        if(!foundCoin)
+            throw JSONRPCError(RPC_WALLET_ERROR, _("Insufficient funds"));
+        coinControl.AddKnownCoins(*foundCoin);
+    }
 
     if (!pwallet->FundTransaction(tx, nFeeOut, coinControl, changePosition, strFailReason, lockUnspents, setSubtractFeeFromOutputs, reserveChangeKey)) {
         throw JSONRPCError(RPC_WALLET_ERROR, strFailReason);

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2798,7 +2798,7 @@ UniValue fundrawtransaction(const JSONRPCRequest& request)
         if(!foundCoin)
             foundCoin = FindInCoinView(txin.prevout);
         if(!foundCoin)
-            throw JSONRPCError(RPC_WALLET_ERROR, _("Insufficient funds"));
+            throw JSONRPCError(RPC_WALLET_ERROR, "unknown-input");
         coinControl.AddKnownCoins(*foundCoin);
     }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2304,7 +2304,7 @@ bool CWallet::SignTransaction(CMutableTransaction &tx)
     return true;
 }
 
-bool CWallet::FundTransaction(CMutableTransaction& tx, CAmount& nFeeRet, bool overrideEstimatedFeeRate, const CFeeRate& specificFeeRate, int& nChangePosInOut, std::string& strFailReason, bool includeWatching, bool lockUnspents, const std::set<int>& setSubtractFeeFromOutputs, bool keepReserveKey, const CTxDestination& destChange)
+bool CWallet::FundTransaction(CMutableTransaction& tx, CAmount& nFeeRet, const CCoinControl& coinControl, int& nChangePosInOut, std::string& strFailReason, bool lockUnspents, const std::set<int>& setSubtractFeeFromOutputs, bool keepReserveKey)
 {
     std::vector<CRecipient> vecSend;
 
@@ -2315,16 +2315,6 @@ bool CWallet::FundTransaction(CMutableTransaction& tx, CAmount& nFeeRet, bool ov
         CRecipient recipient = {txOut.scriptPubKey, txOut.nValue, setSubtractFeeFromOutputs.count(idx) == 1};
         vecSend.push_back(recipient);
     }
-
-    CCoinControl coinControl;
-    coinControl.destChange = destChange;
-    coinControl.fAllowOtherInputs = true;
-    coinControl.fAllowWatchOnly = includeWatching;
-    coinControl.fOverrideFeeRate = overrideEstimatedFeeRate;
-    coinControl.nFeeRate = specificFeeRate;
-
-    BOOST_FOREACH(const CTxIn& txin, tx.vin)
-        coinControl.Select(txin.prevout);
 
     CReserveKey reservekey(this);
     CWalletTx wtx;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -893,6 +893,8 @@ public:
     CAmount GetUnconfirmedWatchOnlyBalance() const;
     CAmount GetImmatureWatchOnlyBalance() const;
 
+    boost::optional<CInputCoin> FindCoin(const COutPoint& outpoint);
+
     /**
      * Insert additional inputs into the transaction by
      * calling CreateTransaction();

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -897,7 +897,7 @@ public:
      * Insert additional inputs into the transaction by
      * calling CreateTransaction();
      */
-    bool FundTransaction(CMutableTransaction& tx, CAmount& nFeeRet, bool overrideEstimatedFeeRate, const CFeeRate& specificFeeRate, int& nChangePosInOut, std::string& strFailReason, bool includeWatching, bool lockUnspents, const std::set<int>& setSubtractFeeFromOutputs, bool keepReserveKey = true, const CTxDestination& destChange = CNoDestination());
+    bool FundTransaction(CMutableTransaction& tx, CAmount& nFeeRet, const CCoinControl& coinControl, int& nChangePosInOut, std::string& strFailReason, bool lockUnspents, const std::set<int>& setSubtractFeeFromOutputs, bool keepReserveKey = true);
     bool SignTransaction(CMutableTransaction& tx);
 
     /**

--- a/test/functional/fundrawtransaction.py
+++ b/test/functional/fundrawtransaction.py
@@ -336,12 +336,15 @@ class RawTransactionsTest(BitcoinTestFramework):
         # test a fundrawtransaction with invalid vin #
         ##############################################
         listunspent = self.nodes[2].listunspent()
-        inputs  = [ {'txid' : "1c7f966dab21119bac53213a2bc7532bff1fa844c124fd750a7d0b1332440bd1", 'vout' : 0} ] #invalid vin!
+        fakeTx = "0100000001aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0000000000ffffffff0100e1f505000000001600149e74df90b0544a8c8e9337896bb5578f8dd5a70900000000"
+        fakeTxId = "fc5a4367363cf10dc6f2badf709d3691b88acd853dee3b50c4bef080c2760273"
+        inputs  = [ {'txid' : "fc5a4367363cf10dc6f2badf709d3691b88acd853dee3b50c4bef080c2760273", 'vout' : 0} ] #invalid vin!
         outputs = { self.nodes[0].getnewaddress() : 1.0}
         rawtx   = self.nodes[2].createrawtransaction(inputs, outputs)
         dec_tx  = self.nodes[2].decoderawtransaction(rawtx)
-
         assert_raises_jsonrpc(-4, "unknown-input", self.nodes[2].fundrawtransaction, rawtx)
+        rawtxfund = self.nodes[0].fundrawtransaction(rawtx, {}, { 'parentTransactions' : [ fakeTx ], 'previousOutputs' : [ { "txid" : fakeTxId, "n" : 0, "amount" : "1.0", "scriptPubKey" : "00149e74df90b0544a8c8e9337896bb5578f8dd5a709"  } ] })
+        assert_raises_jsonrpc(-8, "Invalid amount for output", self.nodes[2].fundrawtransaction, rawtx, {}, { 'parentTransactions' : [ fakeTx ], 'previousOutputs' : [ { "txid" : fakeTxId, "n" : 0, "amount" : "1.1", "scriptPubKey" : "00149e74df90b0544a8c8e9337896bb5578f8dd5a709"  } ] })
 
         ############################################################
         #compare fee of a standard pubkeyhash transaction

--- a/test/functional/fundrawtransaction.py
+++ b/test/functional/fundrawtransaction.py
@@ -63,6 +63,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 1.5)
         self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 1.0)
         self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 5.0)
+        self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 3.0)
 
         self.nodes[0].generate(1)
         self.sync_all()
@@ -306,6 +307,30 @@ class RawTransactionsTest(BitcoinTestFramework):
 
         assert_equal(matchingOuts, 2)
         assert_equal(len(dec_tx['vout']), 3)
+
+        ##############################################################################################
+        # test a fundrawtransaction with one vin from wallet and one from mempool, one from CoinView #
+        ##############################################################################################
+        utx = get_unspent(self.nodes[0].listunspent(), 50)
+        recei = self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 4)
+        self.sync_all()
+        # utx2 is unconfirmed, utx3 is confirmed (sent at the beginning of this test)
+        utx2 = get_unspent(self.nodes[2].listunspent(minconf=0, maxconf=0, addresses=None, include_unsafe=True), 4)
+        utx3 = get_unspent(self.nodes[2].listunspent(), 3)
+        inputs  = [ {'txid' : utx['txid'], 'vout' : utx['vout']},{'txid' : utx2['txid'], 'vout' : utx2['vout']},{'txid' : utx3['txid'], 'vout' : utx3['vout']} ]
+        outputs = { self.nodes[0].getnewaddress() : 50 + 4 + 3 + 2 }
+        rawtx   = self.nodes[0].createrawtransaction(inputs, outputs)
+        rawtxfund = self.nodes[0].fundrawtransaction(rawtx)
+        dec_tx  = self.nodes[0].decoderawtransaction(rawtxfund['hex'])
+        # Should contains the 3 previous vin + a new one added by the wallet
+        assert_equal(len(dec_tx['vin']), 4)
+        # Should contains the change, nodes[0] having only 50 BTC coins, it should returns around 43 BTC
+        assert_equal(len(dec_tx['vout']), 2)
+        totalOut = 0
+        for out in dec_tx['vout']:
+            totalOut += out['value']
+        assert_greater_than(totalOut, 50 + 4 + 3 + 2 + 42.9)
+        assert_greater_than(50 + 4 + 3 + 2 + 43, totalOut)
 
         ##############################################
         # test a fundrawtransaction with invalid vin #

--- a/test/functional/fundrawtransaction.py
+++ b/test/functional/fundrawtransaction.py
@@ -316,7 +316,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         rawtx   = self.nodes[2].createrawtransaction(inputs, outputs)
         dec_tx  = self.nodes[2].decoderawtransaction(rawtx)
 
-        assert_raises_jsonrpc(-4, "Insufficient funds", self.nodes[2].fundrawtransaction, rawtx)
+        assert_raises_jsonrpc(-4, "unknown-input", self.nodes[2].fundrawtransaction, rawtx)
 
         ############################################################
         #compare fee of a standard pubkeyhash transaction


### PR DESCRIPTION
This PR is based on https://github.com/bitcoin/bitcoin/pull/10202, it allows the user to pre fund a transaction with inputs which have not yet been broadcasted.
Please, review and ACK the first one independently from this PR.

This is useful for second layer payment protocol which regularly build transaction on top of unbroadcasted transaction.