### PR TITLE
Tests: Order Python Tests Differently

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -25,6 +25,8 @@ The ZMQ functional test requires a python ZMQ library. To install it:
 Running tests locally
 =====================
 
+Build for your system first. Be sure to enable wallet, utils and daemon when you configure. Tests will not run otherwise.
+
 Functional tests
 ----------------
 

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -140,7 +140,8 @@ EXTENDED_SCRIPTS = [
     'replace-by-fee.py',
 ]
 
-ALL_SCRIPTS = BASE_SCRIPTS + ZMQ_SCRIPTS + EXTENDED_SCRIPTS
+# Place EXTENDED_SCRIPTS first since it has the 3 longest running tests
+ALL_SCRIPTS = EXTENDED_SCRIPTS + BASE_SCRIPTS + ZMQ_SCRIPTS
 
 NON_SCRIPTS = [
     # These are python files that live in the functional tests directory, but are not test scripts.
@@ -217,10 +218,9 @@ def main():
         if enable_zmq:
             test_list += ZMQ_SCRIPTS
         if args.extended:
-            test_list += EXTENDED_SCRIPTS
-            # TODO: BASE_SCRIPTS and EXTENDED_SCRIPTS are sorted by runtime
-            # (for parallel running efficiency). This combined list will is no
-            # longer sorted.
+            # place the EXTENDED_SCRIPTS first since the three longest ones
+            # are there and the list is shorter
+            test_list = EXTENDED_SCRIPTS + test_list
 
     # Remove the test cases that the user has explicitly asked to exclude.
     if args.exclude:


### PR DESCRIPTION
* Added documentation in tests/README.md about enabling wallet, utils and daemon.
* Change ordering to make the long-running EXTENDED_TESTS go first