### PR TITLE
[tests] test_runner - check unicode

### DIFF
--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -27,9 +27,17 @@ import logging
 
 # Formatting. Default colors to empty strings.
 BOLD, BLUE, RED, GREY = ("", ""), ("", ""), ("", ""), ("", "")
-TICK = "✓ "
-CROSS = "✖ "
-CIRCLE = "○ "
+try:
+    # Make sure python thinks it can write unicode to its stdout
+    "\u2713".encode("utf_8").decode(sys.stdout.encoding)
+    TICK = "✓ "
+    CROSS = "✖ "
+    CIRCLE = "○ "
+except UnicodeDecodeError:
+    TICK = "P "
+    CROSS = "x "
+    CIRCLE = "o "
+
 if os.name == 'posix':
     # primitive formatting on supported
     # terminal via ANSI escape sequences:


### PR DESCRIPTION
#10159 added unicode check/cross/circle glyphs to the test results. This is usually fine, but if Python' stdout can't print unicode, then test_runner will throw an error and not print the results:

```python
 File "./test/functional/test_runner.py", line 482, in <module>
   main()
 File "./test/functional/test_runner.py", line 244, in main
   run_tests(test_list, config["environment"]["SRCDIR"], config["environment"]["BUILDDIR"], config["environment"]["EXEEXT"], args.jobs, args.coverage, passon_args)
 File "./test/functional/test_runner.py", line 288, in run_tests
   print_results(test_results, max_len_name, (int(time.time() - time0)))
 File "./test/functional/test_runner.py", line 316, in print_results
   print(results)
UnicodeEncodeError: 'ascii' codec can't encode character '\u2713' in position 104: ordinal not in range(128)
```

This change only prints the glyphs if stdout supports unicode, and replaces them with a letter otherwise:

with unicode:

![screenshot from 2017-04-17 14-14-54](https://cloud.githubusercontent.com/assets/1063656/25098917/4a32be0e-2378-11e7-97f6-614cdb097100.png)

without:

![screenshot from 2017-04-17 14-17-02](https://cloud.githubusercontent.com/assets/1063656/25098982/8a9a03f8-2378-11e7-8c34-9be44ae76d33.png)

First reported by @TheBlueMatt 
