### PR TITLE
build: regenerate bitcoin-config.h as necessary

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -76,9 +76,6 @@ $(BITCOIN_WIN_INSTALLER): all-recursive
 	  echo error: could not build $@
 	@echo built $@
 
-$(if $(findstring src/,$(MAKECMDGOALS)),$(MAKECMDGOALS), none): FORCE
-	$(MAKE) -C src $(patsubst src/%,%,$@)
-
 $(OSX_APP)/Contents/PkgInfo:
 	$(MKDIR_P) $(@D)
 	@echo "APPL????" > $@

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -462,6 +462,14 @@ DISTCLEANFILES = obj/build.h
 
 EXTRA_DIST = $(CTAES_DIST)
 
+
+config/bitcoin-config.h: config/stamp-h1
+	@$(MAKE) -C $(top_builddir) $(subdir)/$(@)
+config/stamp-h1: $(top_srcdir)/$(subdir)/config/bitcoin-config.h.in $(top_builddir)/config.status
+	$(AM_V_at)$(MAKE) -C $(top_builddir) $(subdir)/$(@)
+$(top_srcdir)/$(subdir)/config/bitcoin-config.h.in:  $(am__configure_deps)
+	$(AM_V_at)$(MAKE) -C $(top_srcdir) $(subdir)/config/bitcoin-config.h.in
+
 clean-local:
 	-$(MAKE) -C secp256k1 clean
 	-$(MAKE) -C univalue clean


### PR DESCRIPTION
This fixes issues like #10140 and #10209.

The cause is that #9921 introduced new defines, but without re-running autogen.sh, they wouldn't be found. This change makes sure that autoheader is re-run (as it's supposed to be) any time configure.ac is touched.

Also, this undoes #4322, as it would introduce an infinite loop otherwise. I suspect that these convenience targets get very little use anymore, but we can always add back hard-coded ones if necessary.

