### PR TITLE
Wallet: Support not reusing addresses

### DIFF
--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -7,6 +7,7 @@
 #define BITCOIN_WALLET_WALLET_H
 
 #include "amount.h"
+#include "base58.h"
 #include "streams.h"
 #include "tinyformat.h"
 #include "ui_interface.h"
@@ -715,6 +716,12 @@ private:
      */
     bool AddWatchOnly(const CScript& dest) override;
 
+    /**
+     * Addresses designated as 'frozen'; coins will not to be selected during coin selection nor listed in unspent.
+     * Set via -freezeaddress
+     */
+    std::set<CBitcoinAddress> setFrozenAddresses;
+
 public:
     /*
      * Main wallet lock.
@@ -822,6 +829,7 @@ public:
     void UnlockCoin(const COutPoint& output);
     void UnlockAllCoins();
     void ListLockedCoins(std::vector<COutPoint>& vOutpts);
+    bool IsFrozenCoin(const CTxOut& txout) const;
 
     /*
      * Rescan abort properties


### PR DESCRIPTION
Implements -freezeaddress (also via the bitcoin.conf): a way to skip address(es) during coin selection.
Fixes #10065
Requested to be similar to the lock coins functionality, but with addresses & persistence.