### PR TITLE
[net] listbanned RPC and QT should show correct banned subnets

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -418,10 +418,10 @@ void CConnman::DumpBanlist()
 
     CBanDB bandb;
     banmap_t banmap;
-    SetBannedSetDirty(false);
     GetBanned(banmap);
-    if (!bandb.Write(banmap))
-        SetBannedSetDirty(true);
+    if (bandb.Write(banmap)) {
+        SetBannedSetDirty(false);
+    }
 
     LogPrint(BCLog::NET, "Flushed %d banned node ips/subnets to banlist.dat  %dms\n",
         banmap.size(), GetTimeMillis() - nStart);
@@ -541,6 +541,8 @@ bool CConnman::Unban(const CSubNet &subNet) {
 void CConnman::GetBanned(banmap_t &banMap)
 {
     LOCK(cs_setBanned);
+    // Sweep the banlist so expired bans are not returned
+    SweepBanned();
     banMap = setBanned; //create a thread safe copy
 }
 

--- a/test/functional/disconnect_ban.py
+++ b/test/functional/disconnect_ban.py
@@ -30,7 +30,7 @@ class DisconnectBanTest(BitcoinTestFramework):
         self.log.info("setban: successfully ban single IP address")
         assert_equal(len(self.nodes[1].getpeerinfo()), 2)  # node1 should have 2 connections to node0 at this point
         self.nodes[1].setban("127.0.0.1", "add")
-        wait_until(lambda: len(self.nodes[1].getpeerinfo()) == 0)
+        assert wait_until(lambda: len(self.nodes[1].getpeerinfo()) == 0, timeout=10)
         assert_equal(len(self.nodes[1].getpeerinfo()), 0)  # all nodes must be disconnected at this point
         assert_equal(len(self.nodes[1].listbanned()), 1)
 
@@ -64,7 +64,7 @@ class DisconnectBanTest(BitcoinTestFramework):
         self.nodes[1].setban("2001:4d48:ac57:400:cacf:e9ff:fe1d:9c63/19", "add", 1000)  # ban for 1000 seconds
         listBeforeShutdown = self.nodes[1].listbanned()
         assert_equal("192.168.0.1/32", listBeforeShutdown[2]['address'])
-        wait_until(lambda: len(self.nodes[1].listbanned()) == 3)
+        assert wait_until(lambda: len(self.nodes[1].listbanned()) == 3, timeout=10)
 
         stop_node(self.nodes[1], 1)
 
@@ -78,7 +78,7 @@ class DisconnectBanTest(BitcoinTestFramework):
         self.nodes[1].clearbanned()
         connect_nodes_bi(self.nodes, 0, 1)
 
-        self.log.info("Test disconnectrnode RPCs")
+        self.log.info("Test disconnectnode RPCs")
 
         self.log.info("disconnectnode: fail to disconnect when calling with address and nodeid")
         address1 = self.nodes[0].getpeerinfo()[0]['addr']
@@ -91,7 +91,7 @@ class DisconnectBanTest(BitcoinTestFramework):
         self.log.info("disconnectnode: successfully disconnect node by address")
         address1 = self.nodes[0].getpeerinfo()[0]['addr']
         self.nodes[0].disconnectnode(address=address1)
-        wait_until(lambda: len(self.nodes[0].getpeerinfo()) == 1)
+        assert wait_until(lambda: len(self.nodes[0].getpeerinfo()) == 1, timeout=10)
         assert not [node for node in self.nodes[0].getpeerinfo() if node['addr'] == address1]
 
         self.log.info("disconnectnode: successfully reconnect node")
@@ -102,7 +102,7 @@ class DisconnectBanTest(BitcoinTestFramework):
         self.log.info("disconnectnode: successfully disconnect node by node id")
         id1 = self.nodes[0].getpeerinfo()[0]['id']
         self.nodes[0].disconnectnode(nodeid=id1)
-        wait_until(lambda: len(self.nodes[0].getpeerinfo()) == 1)
+        assert wait_until(lambda: len(self.nodes[0].getpeerinfo()) == 1, timeout=10)
         assert not [node for node in self.nodes[0].getpeerinfo() if node['id'] == id1]
 
 if __name__ == '__main__':


### PR DESCRIPTION
The listbanned RPC and QT show entries in the connman.setBanned set, even if the entry has expired. Expired entries in the set are only swept in the following circumstances:

- bitcoind is stopped/started
- the setban or clearbanned RPC is called

That means that the list of banned subnets returned by listbanned is inconsistent. If the node has been stop-started or the setban/clearbanned RPC has been called, then stale entries won't be shown. If the node hasn't been stop-started and those RPCs haven't been called, then stale entries will be shown.

This PR calls SweepBanned() before GetBanned() in the listbanned RPC and QT, so all calls to GetBanned() return an up-to-date list of banned subnets.

This PR also adds a test to nodehandling to test the behaviour.

@jonasschnelli @sdaftuar 