### PR TITLE
Make Boost use std::atomic internally

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -676,6 +676,10 @@ AX_BOOST_PROGRAM_OPTIONS
 AX_BOOST_THREAD
 AX_BOOST_CHRONO
 
+dnl Boost 1.56 through 1.62 allow using std::atomic instead of its own atomic
+dnl counter implementations. In 1.63 and later the std::atomic approach is default.
+m4_pattern_allow(DBOOST_AC_USE_STD_ATOMIC) dnl otherwise it's treated like a macro
+BOOST_CPPFLAGS="-DBOOST_SP_USE_STD_ATOMIC -DBOOST_AC_USE_STD_ATOMIC $BOOST_CPPFLAGS"
 
 if test x$use_reduce_exports = xyes; then
   AC_MSG_CHECKING([for working boost reduced exports])


### PR DESCRIPTION
Boost has its own implementation of a spinlock and atomic counters inside its shared_ptr implementation, which is used by (at least) the signals2 implementation. By default, it prefers its own implementations over C++11 atomics.

Add two macro definitions to make it choose the std::atomics based implementations instead.

These macros are supported since Boost 1.56, and the behaviour is default since Boost 1.63.