### PR TITLE
Add HD wallet auto-restore functionality

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -480,6 +480,9 @@ void FindNextBlocksToDownload(NodeId nodeid, unsigned int count, std::vector<con
     // Make sure pindexBestKnownBlock is up to date, we'll need it.
     ProcessBlockAvailability(nodeid);
 
+    if (isBlockRequestsPaused())
+        return;
+
     if (state->pindexBestKnownBlock == NULL || state->pindexBestKnownBlock->nChainWork < chainActive.Tip()->nChainWork) {
         // This peer has nothing interesting.
         return;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -747,7 +747,7 @@ PeerLogicValidation::PeerLogicValidation(CConnman* connmanIn) : connman(connmanI
     recentRejects.reset(new CRollingBloomFilter(120000, 0.000001));
 }
 
-void PeerLogicValidation::BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindex, const std::vector<CTransactionRef>& vtxConflicted) {
+void PeerLogicValidation::BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindex, const std::vector<CTransactionRef>& vtxConflicted, bool &requestPause) {
     LOCK(cs_main);
 
     std::vector<uint256> vOrphanErase;

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -30,7 +30,7 @@ private:
 public:
     PeerLogicValidation(CConnman* connmanIn);
 
-    void BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindexConnected, const std::vector<CTransactionRef>& vtxConflicted) override;
+    void BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindexConnected, const std::vector<CTransactionRef>& vtxConflicted, bool &requestPause) override;
     void UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload) override;
     void BlockChecked(const CBlock& block, const CValidationState& state) override;
     void NewPoWValidBlock(const CBlockIndex *pindex, const std::shared_ptr<const CBlock>& pblock) override;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2533,6 +2533,14 @@ bool ActivateBestChain(CValidationState &state, const CChainParams& chainparams,
             for (const PerBlockConnectTrace& trace : connectTrace.GetBlocksConnected()) {
                 assert(trace.pblock && trace.pindex);
                 GetMainSignals().BlockConnected(trace.pblock, trace.pindex, *trace.conflictedTxs, requestPause);
+                if (requestPause) {
+                    // in case we are in pruned mode, we have to halt verification and block requests
+                    // to ensure the signal listener can keep up with the updates
+                    if (fPruneMode) {
+                        setBlockRequestsPaused(true);
+                        setTipUpdatesPaused(true);
+                    }
+                }
             }
         }
         // When we reach this point, we switched to a new tip (stored in pindexNewTip).
@@ -4316,6 +4324,7 @@ bool isBlockRequestsPaused() {
 }
 
 void setBlockRequestsPaused(bool state) {
+    LogPrintf("%s Block Requests\n", (state ? "Pause" : "Resume"));
     fPauseBlockRequests = state;
 }
 
@@ -4324,6 +4333,7 @@ bool isTipUpdatesPaused() {
 }
 
 void setTipUpdatesPaused(bool state) {
+    LogPrintf("%s Tip Updates\n", (state ? "Pause" : "Resume"));
     fPauseTipUpdates = state;
 }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2529,9 +2529,10 @@ bool ActivateBestChain(CValidationState &state, const CChainParams& chainparams,
             pindexFork = chainActive.FindFork(pindexOldTip);
             fInitialDownload = IsInitialBlockDownload();
 
+            bool requestPause = false;
             for (const PerBlockConnectTrace& trace : connectTrace.GetBlocksConnected()) {
                 assert(trace.pblock && trace.pindex);
-                GetMainSignals().BlockConnected(trace.pblock, trace.pindex, *trace.conflictedTxs);
+                GetMainSignals().BlockConnected(trace.pblock, trace.pindex, *trace.conflictedTxs, requestPause);
             }
         }
         // When we reach this point, we switched to a new tip (stored in pindexNewTip).

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -91,6 +91,10 @@ CScript COINBASE_FLAGS;
 
 const std::string strMessageMagic = "Bitcoin Signed Message:\n";
 
+/** if enable, blocks will not be requested automatically */
+static const bool DEFAULT_BLOCK_REQUESTS_PAUSED = false;
+std::atomic<bool> fPauseBlockRequests(DEFAULT_BLOCK_REQUESTS_PAUSED);
+
 // Internal stuff
 namespace {
 
@@ -4294,6 +4298,14 @@ void DumpMempool(void)
     } catch (const std::exception& e) {
         LogPrintf("Failed to dump mempool: %s. Continuing anyway.\n", e.what());
     }
+}
+
+bool isBlockRequestsPaused() {
+    return fPauseBlockRequests;
+}
+
+void setBlockRequestsPaused(bool state) {
+    fPauseBlockRequests = state;
 }
 
 //! Guess how far we are in the verification process at the given block index

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2554,7 +2554,7 @@ bool ActivateBestChain(CValidationState &state, const CChainParams& chainparams,
         if (pindexFork != pindexNewTip) {
             uiInterface.NotifyBlockTip(fInitialDownload, pindexNewTip);
         }
-    } while (pindexNewTip != pindexMostWork);
+    } while (pindexNewTip != pindexMostWork && !isTipUpdatesPaused());
     CheckBlockIndex(chainparams.GetConsensus());
 
     // Write changes periodically to disk, after relay.

--- a/src/validation.h
+++ b/src/validation.h
@@ -294,6 +294,13 @@ bool isBlockRequestsPaused();
 void setBlockRequestsPaused(bool state);
 
 /**
+ * Pausing tip updates will temporary pause connecting new blocks
+ * Pausing won't prevent the net logic from requesing downloading more blocks (up to BLOCK_DOWNLOAD_WINDOW)
+ */
+bool isTipUpdatesPaused();
+void setTipUpdatesPaused(bool state);
+
+/**
  * Prune block and undo files (blk???.dat and undo???.dat) so that the disk space used is less than a user-defined target.
  * The user sets the target (in MB) on the command line or in config file.  This will be run on startup and whenever new
  * space is allocated in a block or undo file, staying below the target. Changing back to unpruned requires a reindex

--- a/src/validation.h
+++ b/src/validation.h
@@ -287,6 +287,13 @@ CAmount GetBlockSubsidy(int nHeight, const Consensus::Params& consensusParams);
 double GuessVerificationProgress(const ChainTxData& data, CBlockIndex* pindex);
 
 /**
+ * Pausing block requests will allow to temporary pause the verification process.
+ * Pausing won't prevent ActivateBestChain from connecting blocks (that are in flight or already on disk)
+ */
+bool isBlockRequestsPaused();
+void setBlockRequestsPaused(bool state);
+
+/**
  * Prune block and undo files (blk???.dat and undo???.dat) so that the disk space used is less than a user-defined target.
  * The user sets the target (in MB) on the command line or in config file.  This will be run on startup and whenever new
  * space is allocated in a block or undo file, staying below the target. Changing back to unpruned requires a reindex

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -15,7 +15,7 @@ CMainSignals& GetMainSignals()
 void RegisterValidationInterface(CValidationInterface* pwalletIn) {
     g_signals.UpdatedBlockTip.connect(boost::bind(&CValidationInterface::UpdatedBlockTip, pwalletIn, _1, _2, _3));
     g_signals.TransactionAddedToMempool.connect(boost::bind(&CValidationInterface::TransactionAddedToMempool, pwalletIn, _1));
-    g_signals.BlockConnected.connect(boost::bind(&CValidationInterface::BlockConnected, pwalletIn, _1, _2, _3));
+    g_signals.BlockConnected.connect(boost::bind(&CValidationInterface::BlockConnected, pwalletIn, _1, _2, _3, _4));
     g_signals.BlockDisconnected.connect(boost::bind(&CValidationInterface::BlockDisconnected, pwalletIn, _1));
     g_signals.SetBestChain.connect(boost::bind(&CValidationInterface::SetBestChain, pwalletIn, _1));
     g_signals.Inventory.connect(boost::bind(&CValidationInterface::Inventory, pwalletIn, _1));
@@ -32,7 +32,7 @@ void UnregisterValidationInterface(CValidationInterface* pwalletIn) {
     g_signals.Inventory.disconnect(boost::bind(&CValidationInterface::Inventory, pwalletIn, _1));
     g_signals.SetBestChain.disconnect(boost::bind(&CValidationInterface::SetBestChain, pwalletIn, _1));
     g_signals.TransactionAddedToMempool.disconnect(boost::bind(&CValidationInterface::TransactionAddedToMempool, pwalletIn, _1));
-    g_signals.BlockConnected.disconnect(boost::bind(&CValidationInterface::BlockConnected, pwalletIn, _1, _2, _3));
+    g_signals.BlockConnected.disconnect(boost::bind(&CValidationInterface::BlockConnected, pwalletIn, _1, _2, _3, _4));
     g_signals.BlockDisconnected.disconnect(boost::bind(&CValidationInterface::BlockDisconnected, pwalletIn, _1));
     g_signals.UpdatedBlockTip.disconnect(boost::bind(&CValidationInterface::UpdatedBlockTip, pwalletIn, _1, _2, _3));
     g_signals.NewPoWValidBlock.disconnect(boost::bind(&CValidationInterface::NewPoWValidBlock, pwalletIn, _1, _2));

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -34,7 +34,7 @@ class CValidationInterface {
 protected:
     virtual void UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload) {}
     virtual void TransactionAddedToMempool(const CTransactionRef &ptxn) {}
-    virtual void BlockConnected(const std::shared_ptr<const CBlock> &block, const CBlockIndex *pindex, const std::vector<CTransactionRef> &txnConflicted) {}
+    virtual void BlockConnected(const std::shared_ptr<const CBlock> &block, const CBlockIndex *pindex, const std::vector<CTransactionRef> &txnConflicted, bool &requestPause) {}
     virtual void BlockDisconnected(const std::shared_ptr<const CBlock> &block) {}
     virtual void SetBestChain(const CBlockLocator &locator) {}
     virtual void Inventory(const uint256 &hash) {}
@@ -56,7 +56,7 @@ struct CMainSignals {
      * Notifies listeners of a block being connected.
      * Provides a vector of transactions evicted from the mempool as a result.
      */
-    boost::signals2::signal<void (const std::shared_ptr<const CBlock> &, const CBlockIndex *pindex, const std::vector<CTransactionRef> &)> BlockConnected;
+    boost::signals2::signal<void (const std::shared_ptr<const CBlock> &, const CBlockIndex *pindex, const std::vector<CTransactionRef> &, bool &requestPause)> BlockConnected;
     /** Notifies listeners of a block being disconnected */
     boost::signals2::signal<void (const std::shared_ptr<const CBlock> &)> BlockDisconnected;
     /** Notifies listeners of a new active block chain. */

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2046,6 +2046,9 @@ UniValue walletpassphrase(const JSONRPCRequest& request)
 
     pwallet->TopUpKeyPool();
 
+    // give a hint to the wallet in case we have paused sync (we may have fall bellow the hd gap limit)
+    pwallet->EventuallyRescanAfterKeypoolTopUp();
+
     int64_t nSleepTime = request.params[1].get_int64();
     pwallet->nRelockTime = GetTime() + nSleepTime;
     RPCRunLater(strprintf("lockwallet(%s)", pwallet->GetName()), boost::bind(LockWallet, pwallet), nSleepTime);

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2047,6 +2047,7 @@ UniValue walletpassphrase(const JSONRPCRequest& request)
     pwallet->TopUpKeyPool();
 
     // give a hint to the wallet in case we have paused sync (we may have fall bellow the hd gap limit)
+    // this runs synchronous, at least during the resync, we can be sure the keypool can be topped up
     pwallet->EventuallyRescanAfterKeypoolTopUp();
 
     int64_t nSleepTime = request.params[1].get_int64();

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -78,6 +78,38 @@ std::string COutput::ToString() const
     return strprintf("COutput(%s, %d, %d) [%s]", tx->GetHash().ToString(), i, nDepth, FormatMoney(tx->tx->vout[i].nValue));
 }
 
+class CAffectedKeysVisitor : public boost::static_visitor<void> {
+private:
+    const CKeyStore &keystore;
+    std::vector<CKeyID> &vKeys;
+
+public:
+    CAffectedKeysVisitor(const CKeyStore &keystoreIn, std::vector<CKeyID> &vKeysIn) : keystore(keystoreIn), vKeys(vKeysIn) {}
+
+    void Process(const CScript &script) {
+        txnouttype type;
+        std::vector<CTxDestination> vDest;
+        int nRequired;
+        if (ExtractDestinations(script, type, vDest, nRequired)) {
+            BOOST_FOREACH(const CTxDestination &dest, vDest)
+                boost::apply_visitor(*this, dest);
+        }
+    }
+
+    void operator()(const CKeyID &keyId) {
+        if (keystore.HaveKey(keyId))
+            vKeys.push_back(keyId);
+    }
+
+    void operator()(const CScriptID &scriptId) {
+        CScript script;
+        if (keystore.GetCScript(scriptId, script))
+            Process(script);
+    }
+
+    void operator()(const CNoDestination &none) {}
+};
+
 const CWalletTx* CWallet::GetWalletTx(const uint256& hash) const
 {
     LOCK(cs_wallet);
@@ -3385,38 +3417,6 @@ void CWallet::ListLockedCoins(std::vector<COutPoint>& vOutpts)
 }
 
 /** @} */ // end of Actions
-
-class CAffectedKeysVisitor : public boost::static_visitor<void> {
-private:
-    const CKeyStore &keystore;
-    std::vector<CKeyID> &vKeys;
-
-public:
-    CAffectedKeysVisitor(const CKeyStore &keystoreIn, std::vector<CKeyID> &vKeysIn) : keystore(keystoreIn), vKeys(vKeysIn) {}
-
-    void Process(const CScript &script) {
-        txnouttype type;
-        std::vector<CTxDestination> vDest;
-        int nRequired;
-        if (ExtractDestinations(script, type, vDest, nRequired)) {
-            BOOST_FOREACH(const CTxDestination &dest, vDest)
-                boost::apply_visitor(*this, dest);
-        }
-    }
-
-    void operator()(const CKeyID &keyId) {
-        if (keystore.HaveKey(keyId))
-            vKeys.push_back(keyId);
-    }
-
-    void operator()(const CScriptID &scriptId) {
-        CScript script;
-        if (keystore.GetCScript(scriptId, script))
-            Process(script);
-    }
-
-    void operator()(const CNoDestination &none) {}
-};
 
 void CWallet::GetKeyBirthTimes(std::map<CTxDestination, int64_t> &mapKeyBirth) const {
     AssertLockHeld(cs_wallet); // mapKeyMetadata

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1171,7 +1171,6 @@ void CWallet::TransactionAddedToMempool(const CTransactionRef& ptx) {
     SyncTransaction(ptx);
 }
 
-void CWallet::BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex *pindex, const std::vector<CTransactionRef>& vtxConflicted) {
     LOCK2(cs_main, cs_wallet);
     // TODO: Temporarily ensure that mempool removals are notified before
     // connected transactions.  This shouldn't matter, but the abandoned
@@ -1186,6 +1185,7 @@ void CWallet::BlockConnected(const std::shared_ptr<const CBlock>& pblock, const 
     }
     for (size_t i = 0; i < pblock->vtx.size(); i++) {
         SyncTransaction(pblock->vtx[i], pindex, i);
+void CWallet::BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex *pindex, const std::vector<CTransactionRef>& vtxConflicted, bool &requestPause) {
     }
 }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -390,6 +390,7 @@ bool CWallet::ChangeWalletPassphrase(const SecureString& strOldWalletPassphrase,
 
 void CWallet::SetBestChain(const CBlockLocator& loc)
 {
+    if (fSyncPausedUntilKeypoolExt) return;
     CWalletDB walletdb(*dbw);
     walletdb.WriteBestBlock(loc);
 }
@@ -1167,29 +1168,41 @@ void CWallet::SyncTransaction(const CTransactionRef& ptx, const CBlockIndex *pin
 }
 
 void CWallet::TransactionAddedToMempool(const CTransactionRef& ptx) {
+    if (fSyncPausedUntilKeypoolExt) return;
     LOCK2(cs_main, cs_wallet);
     SyncTransaction(ptx);
 }
 
-    LOCK2(cs_main, cs_wallet);
-    // TODO: Temporarily ensure that mempool removals are notified before
-    // connected transactions.  This shouldn't matter, but the abandoned
-    // state of transactions in our wallet is currently cleared when we
-    // receive another notification and there is a race condition where
-    // notification of a connected conflict might cause an outside process
-    // to abandon a transaction and then have it inadvertently cleared by
-    // the notification that the conflicted transaction was evicted.
-
-    for (const CTransactionRef& ptx : vtxConflicted) {
-        SyncTransaction(ptx);
-    }
-    for (size_t i = 0; i < pblock->vtx.size(); i++) {
-        SyncTransaction(pblock->vtx[i], pindex, i);
 void CWallet::BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex *pindex, const std::vector<CTransactionRef>& vtxConflicted, bool &requestPause) {
+    if (fSyncPausedUntilKeypoolExt) {
+        requestPause = true;
+        return;
+    }
+
+    {
+        LOCK2(cs_main, cs_wallet);
+        // TODO: Temporarily ensure that mempool removals are notified before
+        // connected transactions.  This shouldn't matter, but the abandoned
+        // state of transactions in our wallet is currently cleared when we
+        // receive another notification and there is a race condition where
+        // notification of a connected conflict might cause an outside process
+        // to abandon a transaction and then have it inadvertently cleared by
+        // the notification that the conflicted transaction was evicted.
+
+        for (const CTransactionRef& ptx : vtxConflicted) {
+            SyncTransaction(ptx);
+        }
+        for (size_t i = 0; i < pblock->vtx.size(); i++) {
+            SyncTransaction(pblock->vtx[i], pindex, i);
+        }
+        if (fSyncPausedUntilKeypoolExt) {
+            requestPause = true;
+        }
     }
 }
 
 void CWallet::BlockDisconnected(const std::shared_ptr<const CBlock>& pblock) {
+    if (fSyncPausedUntilKeypoolExt) return;
     LOCK2(cs_main, cs_wallet);
 
     for (const CTransactionRef& ptx : pblock->vtx) {
@@ -3413,7 +3426,8 @@ void CWallet::MarkReserveKeysAsUsed(const CKeyID& keyId)
     }
 
     if (IsHDEnabled() && !TopUpKeyPool()) {
-        LogPrintf("%s: Topping up keypool failed (locked wallet)\n", __func__);
+        fSyncPausedUntilKeypoolExt = true;
+        LogPrintf("%s: Topping up keypool failed (locked wallet), pausing transaction processing\n", __func__);
     }
 }
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -904,7 +904,7 @@ public:
     bool AddToWallet(const CWalletTx& wtxIn, bool fFlushOnClose=true);
     bool LoadToWallet(const CWalletTx& wtxIn);
     void TransactionAddedToMempool(const CTransactionRef& tx) override;
-    void BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex *pindex, const std::vector<CTransactionRef>& vtxConflicted) override;
+    void BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex *pindex, const std::vector<CTransactionRef>& vtxConflicted, bool &requestPause) override;
     void BlockDisconnected(const std::shared_ptr<const CBlock>& pblock) override;
     bool AddToWalletIfInvolvingMe(const CTransactionRef& tx, const CBlockIndex* pIndex, int posInBlock, bool fUpdate);
     CBlockIndex* ScanForWalletTransactions(CBlockIndex* pindexStart, bool fUpdate = false);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -970,6 +970,7 @@ public:
     void ReturnKey(int64_t nIndex);
     bool GetKeyFromPool(CPubKey &key, bool internal = false);
     int64_t GetOldestKeyPoolTime();
+    bool CheckKeypoolMinSize();
     void MarkReserveKeysAsUsed(const CKeyID& keyId);
     void GetAllReserveKeys(std::set<CKeyID>& setAddress) const;
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -66,6 +66,8 @@ static const bool DEFAULT_DISABLE_WALLET = false;
 //! if set, all keys will be derived by using BIP32
 static const bool DEFAULT_USE_HD_WALLET = true;
 
+static const bool DEFAULT_IGNORE_HD_MIN_KEYPOOL_SIZE = false;
+
 extern const char * DEFAULT_WALLET_DAT;
 
 class CBlockIndex;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -655,6 +655,13 @@ private:
     std::atomic<bool> fScanningWallet;
 
     /**
+     * fSyncPausedUntilKeypoolExt allows to temporarily pause the transaction syncing process until
+     * the keypool has been refilled (manual topup may be required for encrypted and locked wallets).
+     * Not doing so may result in missing transactions in case of a HD recovery (or shared HD wallet).
+     */
+    std::atomic<bool> fSyncPausedUntilKeypoolExt;
+
+    /**
      * Select a set of coins such that nValueRet >= nTargetValue and at least
      * all coins from coinControl are selected; Never select unconfirmed coins
      * if they are not ours
@@ -793,6 +800,7 @@ public:
         nRelockTime = 0;
         fAbortRescan = false;
         fScanningWallet = false;
+        fSyncPausedUntilKeypoolExt = false;
     }
 
     std::map<uint256, CWalletTx> mapWallet;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -40,6 +40,7 @@ extern bool bSpendZeroConfChange;
 extern bool fWalletRbf;
 
 static const unsigned int DEFAULT_KEYPOOL_SIZE = 100;
+static const unsigned int HD_RESTORE_KEYPOOL_SIZE_MIN = 20;
 //! -paytxfee default
 static const CAmount DEFAULT_TRANSACTION_FEE = 0;
 //! -fallbackfee default
@@ -961,6 +962,7 @@ public:
     void ReturnKey(int64_t nIndex);
     bool GetKeyFromPool(CPubKey &key, bool internal = false);
     int64_t GetOldestKeyPoolTime();
+    void MarkReserveKeysAsUsed(const CKeyID& keyId);
     void GetAllReserveKeys(std::set<CKeyID>& setAddress) const;
 
     std::set< std::set<CTxDestination> > GetAddressGroupings();

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1115,6 +1115,8 @@ public:
        caller must ensure the current wallet version is correct before calling
        this function). */
     bool SetHDMasterKey(const CPubKey& key);
+
+    void EventuallyRescanAfterKeypoolTopUp();
 };
 
 /** A key allocated from the key pool. */

--- a/src/zmq/zmqnotificationinterface.cpp
+++ b/src/zmq/zmqnotificationinterface.cpp
@@ -165,7 +165,7 @@ void CZMQNotificationInterface::TransactionAddedToMempool(const CTransactionRef&
     }
 }
 
-void CZMQNotificationInterface::BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindexConnected, const std::vector<CTransactionRef>& vtxConflicted)
+void CZMQNotificationInterface::BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindexConnected, const std::vector<CTransactionRef>& vtxConflicted, bool &requestPause)
 {
     for (const CTransactionRef& ptx : pblock->vtx) {
         // Do a normal notify for each transaction added in the block

--- a/src/zmq/zmqnotificationinterface.h
+++ b/src/zmq/zmqnotificationinterface.h
@@ -26,7 +26,7 @@ protected:
 
     // CValidationInterface
     void TransactionAddedToMempool(const CTransactionRef& tx) override;
-    void BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindexConnected, const std::vector<CTransactionRef>& vtxConflicted) override;
+    void BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindexConnected, const std::vector<CTransactionRef>& vtxConflicted, bool &requestPause) override;
     void BlockDisconnected(const std::shared_ptr<const CBlock>& pblock) override;
     void UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload) override;
 

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -285,7 +285,7 @@ class BitcoinTestFramework(object):
             # Create cache directories, run bitcoinds:
             for i in range(MAX_NODES):
                 datadir = initialize_datadir(cachedir, i)
-                args = [os.getenv("BITCOIND", "bitcoind"), "-server", "-keypool=1", "-datadir=" + datadir, "-discover=0"]
+                args = [os.getenv("BITCOIND", "bitcoind"), "-server", "-keypool=1", "-hdignoregaplimit", "-datadir=" + datadir, "-discover=0"]
                 if i > 0:
                     args.append("-connect=127.0.0.1:" + str(p2p_port(0)))
                 bitcoind_processes[i] = subprocess.Popen(args)

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -234,7 +234,7 @@ def start_node(i, dirname, extra_args=None, rpchost=None, timewait=None, binary=
     datadir = os.path.join(dirname, "node"+str(i))
     if binary is None:
         binary = os.getenv("BITCOIND", "bitcoind")
-    args = [binary, "-datadir=" + datadir, "-server", "-keypool=1", "-discover=0", "-rest", "-logtimemicros", "-debug", "-debugexclude=libevent", "-debugexclude=leveldb", "-mocktime=" + str(get_mocktime()), "-uacomment=testnode%d" % i]
+    args = [binary, "-datadir=" + datadir, "-server", "-keypool=1", "-hdignoregaplimit", "-discover=0", "-rest", "-logtimemicros", "-debug", "-debugexclude=libevent", "-debugexclude=leveldb", "-mocktime=" + str(get_mocktime()), "-uacomment=testnode%d" % i]
     if extra_args is not None: args.extend(extra_args)
     bitcoind_processes[i] = subprocess.Popen(args, stderr=stderr)
     logger.debug("initialize_chain: bitcoind started, waiting for RPC to come up")

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -53,6 +53,7 @@ BASE_SCRIPTS= [
     # Scripts that are run by the travis build process.
     # Longest test should go first, to favor running tests in parallel
     'wallet-hd.py',
+    'wallet-hd-restore.py',
     'walletbackup.py',
     # vv Tests less than 5m vv
     'p2p-fullblocktest.py',

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -54,6 +54,7 @@ BASE_SCRIPTS= [
     # Longest test should go first, to favor running tests in parallel
     'wallet-hd.py',
     'wallet-hd-restore.py',
+    'wallet-hd-restore.py',
     'walletbackup.py',
     # vv Tests less than 5m vv
     'p2p-fullblocktest.py',

--- a/test/functional/wallet-hd-restore.py
+++ b/test/functional/wallet-hd-restore.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test Hierarchical Deterministic wallet function."""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    start_nodes,
+    start_node,
+    assert_equal,
+    connect_nodes_bi,
+    assert_start_raises_init_error,
+    sync_blocks
+)
+import os
+import shutil
+
+
+class WalletHDRestoreTest(BitcoinTestFramework):
+
+    def __init__(self):
+        super().__init__()
+        self.setup_clean_chain = True
+        self.num_nodes = 2
+        self.node_args = [['-usehd=0'], ['-usehd=1', '-keypool=100']]
+
+    def setup_network(self):
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, self.node_args)
+        self.is_network_split = False
+        connect_nodes_bi(self.nodes, 0, 1)
+
+    def run_test (self):
+        tmpdir = self.options.tmpdir
+        self.stop_node(1)
+        shutil.copyfile(tmpdir + "/node1/regtest/wallet.dat", tmpdir + "/hd.bak")
+        self.nodes[1] = start_node(1, self.options.tmpdir, self.node_args[1])
+        connect_nodes_bi(self.nodes,0,1)
+        for _ in range(10):
+            addr = self.nodes[1].getnewaddress()
+            
+        self.nodes[0].generate(101)
+        addr = self.nodes[1].getnewaddress()
+        assert_equal(self.nodes[1].validateaddress(addr)['hdkeypath'], "m/0'/0'/11'")
+        
+        rawch = self.nodes[1].getrawchangeaddress()
+        txid = self.nodes[0].sendtoaddress(addr, 1)
+        n0addr = self.nodes[0].getnewaddress()
+        txdata = self.nodes[0].createrawtransaction([], {rawch : 2.0, n0addr: 3.0})
+
+        txdata_f = self.nodes[0].fundrawtransaction(txdata)
+        txdata_s = self.nodes[0].signrawtransaction(txdata_f['hex'])
+        txid = self.nodes[0].sendrawtransaction(txdata_s['hex'])
+
+        self.sync_all()
+        self.nodes[0].generate(1)
+        self.sync_all()
+
+        assert_equal(self.nodes[1].getbalance(), 3)
+        assert_equal(self.nodes[1].listtransactions()[0]['category'], "receive")
+        
+        self.stop_node(1)
+        shutil.rmtree(tmpdir + "/node1/regtest")
+        os.mkdir(tmpdir + "/node1/regtest")
+        shutil.copyfile(tmpdir + "/hd.bak", tmpdir + "/node1/regtest/wallet.dat")
+        self.nodes[0].generate(1)
+        self.nodes[1] = start_node(1, self.options.tmpdir, self.node_args[1])
+        connect_nodes_bi(self.nodes,0,1)
+        self.sync_all()
+        assert_equal(self.nodes[1].getbalance(), 3) #make sure we have reconstructed the transaction
+        assert_equal(self.nodes[1].listtransactions()[0]['category'], "receive")
+        
+        #now check if we have marked all keys up to the used keypool key as used
+        assert_equal(self.nodes[1].validateaddress(self.nodes[1].getnewaddress())['hdkeypath'], "m/0'/0'/12'")
+        
+        #make sure the key on the internal chain is also marked as used
+        assert_equal(self.nodes[1].validateaddress(self.nodes[1].getrawchangeaddress())['hdkeypath'], "m/0'/1'/1'")
+        
+
+
+if __name__ == '__main__':
+    WalletHDRestoreTest().main ()

--- a/test/functional/wallet-hd-restore.py
+++ b/test/functional/wallet-hd-restore.py
@@ -5,17 +5,10 @@
 """Test Hierarchical Deterministic wallet function."""
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import (
-    start_nodes,
-    start_node,
-    assert_equal,
-    connect_nodes_bi,
-    assert_start_raises_init_error,
-    sync_blocks
-)
+from test_framework.util import *
 import os
 import shutil
-
+from pprint import pprint
 
 class WalletHDRestoreTest(BitcoinTestFramework):
 
@@ -32,17 +25,42 @@ class WalletHDRestoreTest(BitcoinTestFramework):
 
     def run_test (self):
         tmpdir = self.options.tmpdir
+
+        print("Initialize wallet including backups of unencrypted and encrypted wallet")
+        # stop and backup original wallet (only keypool has been initialized)
         self.stop_node(1)
         shutil.copyfile(tmpdir + "/node1/regtest/wallet.dat", tmpdir + "/hd.bak")
+
+        # start again and encrypt wallet
+        self.nodes[1] = start_node(1, self.options.tmpdir, self.node_args[1])
+        self.nodes[1].encryptwallet('test')
+        bitcoind_processes[1].wait()
+        # node will be stopped during encryption, now do a backup
+        shutil.copyfile(tmpdir + "/node1/regtest/wallet.dat", tmpdir + "/hd.enc.bak") 
+
+        # start the node with encrypted wallet, get address in new pool at pos 50 (over the gap limit)
+        self.nodes[1] = start_node(1, self.options.tmpdir, self.node_args[1])
+        for _ in range(50):
+            addr_enc_oldpool = self.nodes[1].getnewaddress()
+
+        # now make sure we retrive an address in the extended pool
+        self.nodes[1].walletpassphrase("test", 10)
+        for _ in range(80):
+            addr_enc_extpool = self.nodes[1].getnewaddress()
+
+        # stop and load initial backup of the unencrypted wallet
+        self.stop_node(1)
+        os.remove(tmpdir + "/node1/regtest/wallet.dat")
+        shutil.copyfile(tmpdir + "/hd.bak", tmpdir + "/node1/regtest/wallet.dat")
         self.nodes[1] = start_node(1, self.options.tmpdir, self.node_args[1])
         connect_nodes_bi(self.nodes,0,1)
         for _ in range(10):
             addr = self.nodes[1].getnewaddress()
-            
+
         self.nodes[0].generate(101)
         addr = self.nodes[1].getnewaddress()
         assert_equal(self.nodes[1].validateaddress(addr)['hdkeypath'], "m/0'/0'/11'")
-        
+
         rawch = self.nodes[1].getrawchangeaddress()
         txid = self.nodes[0].sendtoaddress(addr, 1)
         n0addr = self.nodes[0].getnewaddress()
@@ -58,7 +76,8 @@ class WalletHDRestoreTest(BitcoinTestFramework):
 
         assert_equal(self.nodes[1].getbalance(), 3)
         assert_equal(self.nodes[1].listtransactions()[0]['category'], "receive")
-        
+
+        print("Testing with unencrypted wallet")
         self.stop_node(1)
         shutil.rmtree(tmpdir + "/node1/regtest")
         os.mkdir(tmpdir + "/node1/regtest")
@@ -69,14 +88,75 @@ class WalletHDRestoreTest(BitcoinTestFramework):
         self.sync_all()
         assert_equal(self.nodes[1].getbalance(), 3) #make sure we have reconstructed the transaction
         assert_equal(self.nodes[1].listtransactions()[0]['category'], "receive")
-        
+
         #now check if we have marked all keys up to the used keypool key as used
         assert_equal(self.nodes[1].validateaddress(self.nodes[1].getnewaddress())['hdkeypath'], "m/0'/0'/12'")
-        
+
         #make sure the key on the internal chain is also marked as used
         assert_equal(self.nodes[1].validateaddress(self.nodes[1].getrawchangeaddress())['hdkeypath'], "m/0'/1'/1'")
-        
 
+        # continue send funds (one in the main keypool over the gap limit, the other in the extended pool space)
+        txid = self.nodes[0].sendtoaddress(addr_enc_oldpool, 10)
+        self.nodes[0].generate(1)
+        stop_height = self.nodes[0].getblockchaininfo()['blocks']
+        txid = self.nodes[0].sendtoaddress(addr_enc_extpool, 5)
+        self.nodes[0].generate(1)
+
+        #########################################################
+        #########################################################
+
+        print("Testing with encrypted wallet")
+        # Try with the encrypted wallet (non pruning)
+        self.stop_node(1)
+        shutil.rmtree(tmpdir + "/node1/regtest")
+        os.mkdir(tmpdir + "/node1/regtest")
+        shutil.copyfile(tmpdir + "/hd.enc.bak", tmpdir + "/node1/regtest/wallet.dat")
+        self.nodes[1] = start_node(1, self.options.tmpdir, ['-usehd=1', '-keypool=100'])
+        connect_nodes_bi(self.nodes,0,1)
+
+        # Sync must be possible, though the wallet bestblock should lack behind
+        self.sync_all()
+
+        # The balance should cover everything expect the very last tx of 5 BTC
+        assert_equal(self.nodes[1].getbalance(), 13)
+
+        # unlock the wallet, the sync can continue then
+        self.nodes[1].walletpassphrase("test", 100)
+        self.sync_all() #sync is now possible
+
+        # we should now have restored all funds
+        assert_equal(self.nodes[1].getbalance(), 18) # all funds recovered
+        assert_equal(self.nodes[1].listtransactions()[0]['category'], "receive")
+
+        #########################################################
+        #########################################################
+
+        print("Testing with encrypted wallet in prune mode")
+        # Now try with the encrypted wallet in prune mode
+        self.stop_node(1)
+        shutil.rmtree(tmpdir + "/node1/regtest")
+        os.mkdir(tmpdir + "/node1/regtest")
+        shutil.copyfile(tmpdir + "/hd.enc.bak", tmpdir + "/node1/regtest/wallet.dat")
+        self.nodes[1] = start_node(1, self.options.tmpdir, ['-usehd=1', '-keypool=100', '-prune=550'])
+        connect_nodes_bi(self.nodes,0,1)
+
+        # now we should only be capable to sync up to the second last block (pruned mode, sync will be paused)
+        assert_equal(self.nodes[1].waitforblockheight(stop_height, 10 * 1000)['height'], stop_height) #must be possible
+
+        # This must timeout now, we can't sync up to stop_height+1 (== most recent block)
+        # Sync must be paused at this point
+        assert_equal(self.nodes[1].waitforblockheight(stop_height+1, 3 * 1000)['height'], stop_height)
+
+        # The balance should cover everything expect the very last tx of 5 BTC
+        assert_equal(self.nodes[1].getbalance(), 13)
+
+        # unlock the wallet, the sync can continue then
+        self.nodes[1].walletpassphrase("test", 100)
+        self.sync_all() #sync is now possible
+
+        # we should now have restored all funds
+        assert_equal(self.nodes[1].getbalance(), 18)
+        assert_equal(self.nodes[1].listtransactions()[0]['category'], "receive")
 
 if __name__ == '__main__':
     WalletHDRestoreTest().main ()

--- a/test/functional/wallet-hd-restore.py
+++ b/test/functional/wallet-hd-restore.py
@@ -16,7 +16,7 @@ class WalletHDRestoreTest(BitcoinTestFramework):
         super().__init__()
         self.setup_clean_chain = True
         self.num_nodes = 2
-        self.node_args = [['-usehd=0'], ['-usehd=1', '-keypool=100']]
+        self.node_args = [['-usehd=0'], ['-usehd=1', '-keypool=100', '-hdignoregaplimit=0']]
 
     def setup_network(self):
         self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, self.node_args)
@@ -111,7 +111,7 @@ class WalletHDRestoreTest(BitcoinTestFramework):
         shutil.rmtree(tmpdir + "/node1/regtest")
         os.mkdir(tmpdir + "/node1/regtest")
         shutil.copyfile(tmpdir + "/hd.enc.bak", tmpdir + "/node1/regtest/wallet.dat")
-        self.nodes[1] = start_node(1, self.options.tmpdir, ['-usehd=1', '-keypool=100'])
+        self.nodes[1] = start_node(1, self.options.tmpdir, ['-usehd=1', '-keypool=100', '-hdignoregaplimit=0'])
         connect_nodes_bi(self.nodes,0,1)
 
         # Sync must be possible, though the wallet bestblock should lack behind
@@ -137,7 +137,7 @@ class WalletHDRestoreTest(BitcoinTestFramework):
         shutil.rmtree(tmpdir + "/node1/regtest")
         os.mkdir(tmpdir + "/node1/regtest")
         shutil.copyfile(tmpdir + "/hd.enc.bak", tmpdir + "/node1/regtest/wallet.dat")
-        self.nodes[1] = start_node(1, self.options.tmpdir, ['-usehd=1', '-keypool=100', '-prune=550'])
+        self.nodes[1] = start_node(1, self.options.tmpdir, ['-usehd=1', '-keypool=100', '-prune=550', '-hdignoregaplimit=0'])
         connect_nodes_bi(self.nodes,0,1)
 
         # now we should only be capable to sync up to the second last block (pruned mode, sync will be paused)


### PR DESCRIPTION
This PR ensures that we always check the keypool during SyncTransaction and, that the lookup window for HD restore is large enough (currently +20 keys).
Once the keypool size falls below the min gap limit (currently 20 keys) and the keypool can't be extended (locked wallet), the wallet then temporary pauses synchronisation.

### unencrypted wallets
For unencrypted wallets, the key pool will always be topped up. During sync (SyncTransaction), we check for used keypool keys and mark all keys up to the matched key as used. Additionally we topup the keypool to ensure we not fall below the gap limit (20 keys).

### encrypted wallets in non pruning mode
Same as above, but, If we hit the gap limit with an encrypted wallet, we can't topup the keypool. In that case, we just pause the sync (not the node, only the wallet).
Once the user unlocks the wallet over `walletpassphrase`, we rescan down to the point where we have stopped previously to ensure we don't miss possible funds.

### encrypted wallets in pruned mode
Same as above, but, we also stop requesting and connecting blocks. The full node will "pause" in this case until the user did unlock his wallet (== topup, rescan, etc.).

This has a little bit of complexity and requires careful reviews.