### PR TITLE
Minor fix in build documentation for FreeBSD 11

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -321,8 +321,10 @@ Clang is installed by default as `cc` compiler, this makes it easier to get
 started than on [OpenBSD](build-openbsd.md). Installing dependencies:
 
     pkg install autoconf automake libtool pkgconf
-    pkg install boost-libs openssl libevent2
+    pkg install boost-libs openssl libevent
+    pkg install gmake
 
+You need to use GNU make (`gmake`) instead of `make`.
 (`libressl` instead of `openssl` will also work)
 
 For the wallet (optional):
@@ -338,7 +340,7 @@ Then build using:
 
     ./autogen.sh
     ./configure --with-incompatible-bdb BDB_CFLAGS="-I/usr/local/include/db5" BDB_LIBS="-L/usr/local/lib -ldb_cxx-5"
-    make
+    gmake
 
 *Note on debugging*: The version of `gdb` installed by default is [ancient and considered harmful](https://wiki.freebsd.org/GdbRetirement).
 It is not suitable for debugging a multi-threaded C++ program, not even for getting backtraces. Please install the package `gdb` and


### PR DESCRIPTION
- Don't need libevent2 -- and it's not availble in pkg also
- Need to use GNU make