### PR TITLE
Silence "warning: "MSG_DONTWAIT" redefined" when compiling under Linux

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -50,6 +50,12 @@
 
 // MSG_DONTWAIT is not available on some platforms, if it doesn't exist define it as 0
 #if !defined(HAVE_MSG_DONTWAIT)
+// Silence "warning: "MSG_DONTWAIT" redefined" when compiling under Linux by
+// handling the case where !defined(HAVE_MSG_DONTWAIT) does not imply
+// !defined(MSG_DONTWAIT).
+#if defined(MSG_DONTWAIT)
+#undef MSG_DONTWAIT
+#endif
 #define MSG_DONTWAIT 0
 #endif
 


### PR DESCRIPTION
Handle the case where `!defined(HAVE_MSG_DONTWAIT)` does not imply `!defined(MSG_DONTWAIT)`.

Prior to this commit:

```
$ make
…
  CXX      libbitcoin_server_a-net.o
net.cpp:55:0: warning: "MSG_DONTWAIT" redefined
 #define MSG_DONTWAIT 0
 ^
In file included from /usr/include/x86_64-linux-gnu/sys/socket.h:38:0,
                 from compat.h:38,
                 from netaddress.h:12,
                 from addrman.h:9,
                 from net.h:10,
                 from net.cpp:10:
/usr/include/x86_64-linux-gnu/bits/socket.h:195:0: note: this is the location of the previous definition
 #define MSG_DONTWAIT MSG_DONTWAIT
 ^
…
```

After this commit:

```
$ make
…
  CXX      libbitcoin_server_a-net.o
…
```