### PR TITLE
Add balances cache / GUI: use a signal instead of a poll thread

### DIFF
--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -32,7 +32,6 @@
 #include <QDebug>
 #include <QMessageBox>
 #include <QSet>
-#include <QTimer>
 
 #include <boost/foreach.hpp>
 
@@ -45,16 +44,10 @@ WalletModel::WalletModel(const PlatformStyle *platformStyle, CWallet *_wallet, O
     cachedNumBlocks(0)
 {
     fHaveWatchOnly = wallet->HaveWatchOnly();
-    fForceCheckBalanceChanged = false;
 
     addressTableModel = new AddressTableModel(wallet, this);
     transactionTableModel = new TransactionTableModel(platformStyle, wallet, this);
     recentRequestsTableModel = new RecentRequestsTableModel(wallet, this);
-
-    // This timer will be fired repeatedly to update the balance
-    pollTimer = new QTimer(this);
-    connect(pollTimer, SIGNAL(timeout()), this, SLOT(pollBalanceChanged()));
-    pollTimer->start(MODEL_UPDATE_DELAY);
 
     subscribeToCoreSignals();
 }
@@ -112,31 +105,6 @@ void WalletModel::updateStatus()
         Q_EMIT encryptionStatusChanged(newEncryptionStatus);
 }
 
-void WalletModel::pollBalanceChanged()
-{
-    // Get required locks upfront. This avoids the GUI from getting stuck on
-    // periodical polls if the core is holding the locks for a longer time -
-    // for example, during a wallet rescan.
-    TRY_LOCK(cs_main, lockMain);
-    if(!lockMain)
-        return;
-    TRY_LOCK(wallet->cs_wallet, lockWallet);
-    if(!lockWallet)
-        return;
-
-    if(fForceCheckBalanceChanged || chainActive.Height() != cachedNumBlocks)
-    {
-        fForceCheckBalanceChanged = false;
-
-        // Balance and number of transactions might have changed
-        cachedNumBlocks = chainActive.Height();
-
-        checkBalanceChanged();
-        if(transactionTableModel)
-            transactionTableModel->updateConfirmations();
-    }
-}
-
 void WalletModel::checkBalanceChanged()
 {
     CAmount newBalance = getBalance();
@@ -164,12 +132,6 @@ void WalletModel::checkBalanceChanged()
         Q_EMIT balanceChanged(newBalance, newUnconfirmedBalance, newImmatureBalance,
                             newWatchOnlyBalance, newWatchUnconfBalance, newWatchImmatureBalance);
     }
-}
-
-void WalletModel::updateTransaction()
-{
-    // Balance and number of transactions might have changed
-    fForceCheckBalanceChanged = true;
 }
 
 void WalletModel::updateAddressBook(const QString &address, const QString &label,
@@ -367,7 +329,7 @@ WalletModel::SendCoinsReturn WalletModel::sendCoins(WalletModelTransaction &tran
         }
         Q_EMIT coinsSent(wallet, rcp, transaction_array);
     }
-    checkBalanceChanged(); // update balance immediately, otherwise there could be a short noticeable delay until pollBalanceChanged hits
+    checkBalanceChanged();
 
     return SendCoinsReturn(OK);
 }
@@ -476,14 +438,6 @@ static void NotifyAddressBookChanged(WalletModel *walletmodel, CWallet *wallet,
                               Q_ARG(int, status));
 }
 
-static void NotifyTransactionChanged(WalletModel *walletmodel, CWallet *wallet, const uint256 &hash, ChangeType status)
-{
-    Q_UNUSED(wallet);
-    Q_UNUSED(hash);
-    Q_UNUSED(status);
-    QMetaObject::invokeMethod(walletmodel, "updateTransaction", Qt::QueuedConnection);
-}
-
 static void ShowProgress(WalletModel *walletmodel, const std::string &title, int nProgress)
 {
     // emits signal "showProgress"
@@ -498,14 +452,19 @@ static void NotifyWatchonlyChanged(WalletModel *walletmodel, bool fHaveWatchonly
                               Q_ARG(bool, fHaveWatchonly));
 }
 
+static void NotifyBalanceChanged(WalletModel *walletmodel)
+{
+    QMetaObject::invokeMethod(walletmodel, "checkBalanceChanged", Qt::QueuedConnection);
+}
+
 void WalletModel::subscribeToCoreSignals()
 {
     // Connect signals to wallet
     wallet->NotifyStatusChanged.connect(boost::bind(&NotifyKeyStoreStatusChanged, this, _1));
     wallet->NotifyAddressBookChanged.connect(boost::bind(NotifyAddressBookChanged, this, _1, _2, _3, _4, _5, _6));
-    wallet->NotifyTransactionChanged.connect(boost::bind(NotifyTransactionChanged, this, _1, _2, _3));
     wallet->ShowProgress.connect(boost::bind(ShowProgress, this, _1, _2));
     wallet->NotifyWatchonlyChanged.connect(boost::bind(NotifyWatchonlyChanged, this, _1));
+    wallet->BalancesChanged.connect(boost::bind(NotifyBalanceChanged, this));
 }
 
 void WalletModel::unsubscribeFromCoreSignals()
@@ -513,9 +472,9 @@ void WalletModel::unsubscribeFromCoreSignals()
     // Disconnect signals from wallet
     wallet->NotifyStatusChanged.disconnect(boost::bind(&NotifyKeyStoreStatusChanged, this, _1));
     wallet->NotifyAddressBookChanged.disconnect(boost::bind(NotifyAddressBookChanged, this, _1, _2, _3, _4, _5, _6));
-    wallet->NotifyTransactionChanged.disconnect(boost::bind(NotifyTransactionChanged, this, _1, _2, _3));
     wallet->ShowProgress.disconnect(boost::bind(ShowProgress, this, _1, _2));
     wallet->NotifyWatchonlyChanged.disconnect(boost::bind(NotifyWatchonlyChanged, this, _1));
+    wallet->BalancesChanged.disconnect(boost::bind(NotifyBalanceChanged, this));
 }
 
 // WalletModel::UnlockContext implementation

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -105,7 +105,7 @@ void WalletModel::updateStatus()
         Q_EMIT encryptionStatusChanged(newEncryptionStatus);
 }
 
-void WalletModel::checkBalanceChanged()
+void WalletModel::updateBalance()
 {
     CAmount newBalance = getBalance();
     CAmount newUnconfirmedBalance = getUnconfirmedBalance();
@@ -329,7 +329,7 @@ WalletModel::SendCoinsReturn WalletModel::sendCoins(WalletModelTransaction &tran
         }
         Q_EMIT coinsSent(wallet, rcp, transaction_array);
     }
-    checkBalanceChanged();
+    updateBalance();
 
     return SendCoinsReturn(OK);
 }
@@ -454,7 +454,7 @@ static void NotifyWatchonlyChanged(WalletModel *walletmodel, bool fHaveWatchonly
 
 static void NotifyBalanceChanged(WalletModel *walletmodel)
 {
-    QMetaObject::invokeMethod(walletmodel, "checkBalanceChanged", Qt::QueuedConnection);
+    QMetaObject::invokeMethod(walletmodel, "updateBalance", Qt::QueuedConnection);
 }
 
 void WalletModel::subscribeToCoreSignals()

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -30,10 +30,6 @@ class CPubKey;
 class CWallet;
 class uint256;
 
-QT_BEGIN_NAMESPACE
-class QTimer;
-QT_END_NAMESPACE
-
 class SendCoinsRecipient
 {
 public:
@@ -221,7 +217,6 @@ public:
 private:
     CWallet *wallet;
     bool fHaveWatchOnly;
-    bool fForceCheckBalanceChanged;
 
     // Wallet has an options model for wallet-specific options
     // (transaction fee, for example)
@@ -241,11 +236,8 @@ private:
     EncryptionStatus cachedEncryptionStatus;
     int cachedNumBlocks;
 
-    QTimer *pollTimer;
-
     void subscribeToCoreSignals();
     void unsubscribeFromCoreSignals();
-    void checkBalanceChanged();
 
 Q_SIGNALS:
     // Signal that balance in wallet changed
@@ -275,14 +267,12 @@ Q_SIGNALS:
 public Q_SLOTS:
     /* Wallet status might have changed */
     void updateStatus();
-    /* New transaction, or transaction changed status */
-    void updateTransaction();
     /* New, updated or removed address book entry */
     void updateAddressBook(const QString &address, const QString &label, bool isMine, const QString &purpose, int status);
     /* Watch-only added */
     void updateWatchOnlyFlag(bool fHaveWatchonly);
-    /* Current, immature or unconfirmed balance might have changed - emit 'balanceChanged' if so */
-    void pollBalanceChanged();
+    /* Update balance */
+    void checkBalanceChanged();
 };
 
 #endif // BITCOIN_QT_WALLETMODEL_H

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -272,7 +272,7 @@ public Q_SLOTS:
     /* Watch-only added */
     void updateWatchOnlyFlag(bool fHaveWatchonly);
     /* Update balance */
-    void checkBalanceChanged();
+    void updateBalance();
 };
 
 #endif // BITCOIN_QT_WALLETMODEL_H

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -791,6 +791,12 @@ public:
         nRelockTime = 0;
         fAbortRescan = false;
         fScanningWallet = false;
+        fBalanceDirty = true;
+        fUnconfirmedBalanceDirty = true;
+        fImmatureBalanceDirty = true;
+        fWatchOnlyBalanceDirty = true;
+        fUnconfirmedWatchOnlyBalanceDirty = true;
+        fImmatureWatchOnlyBalanceDirty = true;
     }
 
     std::map<uint256, CWalletTx> mapWallet;
@@ -922,6 +928,8 @@ public:
     void ReacceptWalletTransactions();
     void ResendWalletTransactions(int64_t nBestBlockTime, CConnman* connman) override;
     std::vector<uint256> ResendWalletTransactionsBefore(int64_t nTime, CConnman* connman);
+
+    void MarkBalancesDirty();
     CAmount GetBalance() const;
     CAmount GetUnconfirmedBalance() const;
     CAmount GetImmatureBalance() const;
@@ -930,6 +938,22 @@ public:
     CAmount GetImmatureWatchOnlyBalance() const;
     CAmount GetLegacyBalance(const isminefilter& filter, int minDepth, const std::string* account) const;
     CAmount GetAvailableBalance(const CCoinControl* coinControl = nullptr) const;
+
+    mutable std::atomic<CAmount> nBalanceCache;
+    mutable std::atomic<CAmount> nUnconfirmedBalanceCache;
+    mutable std::atomic<CAmount> nImmatureBalanceCache;
+    mutable std::atomic<CAmount> nWatchOnlyBalanceCache;
+    mutable std::atomic<CAmount> nUnconfirmedWatchOnlyBalanceCache;
+    mutable std::atomic<CAmount> nImmatureWatchOnlyBalanceCache;
+    mutable std::atomic<bool> fBalanceDirty;
+    mutable std::atomic<bool> fUnconfirmedBalanceDirty;
+    mutable std::atomic<bool> fImmatureBalanceDirty;
+    mutable std::atomic<bool> fWatchOnlyBalanceDirty;
+    mutable std::atomic<bool> fUnconfirmedWatchOnlyBalanceDirty;
+    mutable std::atomic<bool> fImmatureWatchOnlyBalanceDirty;
+
+    /** Notification for balance changes */
+    boost::signals2::signal<void ()> BalancesChanged;
 
     /**
      * Insert additional inputs into the transaction by


### PR DESCRIPTION
There are two major parts in this PR.

## A) wallet: introduce a per-balance-type cache
Additionally to the per `CWalletTx` debit, etc. caches, this adds an atomic<CAmount> cache for each balance type (available, immature, watchonly, etc.).
If the balance has been cached, no lock will be acquired when calling `Get*Balance()`.
As always with caches, the problematic parts is where to invalidate it (that is why there are some calls to `MarkBalancesDirty()`).

## B) Signal for balance changes
This PR exposes a new wallet signal that will signal the GUI when a balance change had happened (instead of the 250ms polling timer).