### PR TITLE
[test] Add test for listaddressgroupings

### DIFF
--- a/test/functional/wallet-accounts.py
+++ b/test/functional/wallet-accounts.py
@@ -7,6 +7,7 @@
 RPCs tested are:
     - getaccountaddress
     - getaddressesbyaccount
+    - listaddressgroupings
     - setaccount
     - sendfrom (with account arguments)
     - move (with account arguments)
@@ -30,16 +31,57 @@ class WalletAccountsTest(BitcoinTestFramework):
         self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, self.node_args)
         self.is_network_split = False
 
-    def run_test (self):
+    def run_test(self):
         node = self.nodes[0]
         # Check that there's no UTXO on any of the nodes
         assert_equal(len(node.listunspent()), 0)
-        
+
+        # Note each time we call generate, all generated coins go into
+        # the same address, so we call twice to get two addresses w/50 each
+        node.generate(1)
         node.generate(101)
-        
-        assert_equal(node.getbalance(), 50)
-        
-        accounts = ["a","b","c","d","e"]
+        assert_equal(node.getbalance(), 100)
+
+        # there should be 2 address groups
+        # each with 1 address with a balance of 50 Bitcoins
+        address_groups = node.listaddressgroupings()
+        assert_equal(len(address_groups), 2)
+        # the addresses aren't linked now, but will be after we send to the
+        # common address
+        linked_addresses = set()
+        for address_group in address_groups:
+            assert_equal(len(address_group), 1)
+            assert_equal(len(address_group[0]), 2)
+            assert_equal(address_group[0][1], 50)
+            linked_addresses.add(address_group[0][0])
+
+        # send 50 from each address to a third address not in this wallet
+        # There's some fee that will come back to us when the miner reward
+        # matures.
+        common_address = "msf4WtN1YQKXvNtvdFYt9JBnUD2FB41kjr"
+        txid = node.sendmany(
+            fromaccount="",
+            amounts={common_address: 100},
+            subtractfeefrom=[common_address],
+            minconf=1,
+        )
+        tx_details = node.gettransaction(txid)
+        fee = -tx_details['details'][0]['fee']
+        # there should be 1 address group, with the previously
+        # unlinked addresses now linked (they both have 0 balance)
+        address_groups = node.listaddressgroupings()
+        assert_equal(len(address_groups), 1)
+        assert_equal(len(address_groups[0]), 2)
+        assert_equal(set([a[0] for a in address_groups[0]]), linked_addresses)
+        assert_equal([a[1] for a in address_groups[0]], [0, 0])
+
+        node.generate(1)
+
+        # we want to reset so that the "" account has what's expected.
+        # otherwise we're off by exactly the fee amount as that's mined
+        # and matures in the next 100 blocks
+        node.sendfrom("", common_address, fee)
+        accounts = ["a", "b", "c", "d", "e"]
         amount_to_send = 1.0
         account_addresses = dict()
         for account in accounts:
@@ -56,7 +98,7 @@ class WalletAccountsTest(BitcoinTestFramework):
         
         for i in range(len(accounts)):
             from_account = accounts[i]
-            to_account = accounts[(i+1)%len(accounts)]
+            to_account = accounts[(i+1) % len(accounts)]
             to_address = account_addresses[to_account]
             node.sendfrom(from_account, to_address, amount_to_send)
         
@@ -67,7 +109,7 @@ class WalletAccountsTest(BitcoinTestFramework):
             assert(address != account_addresses[account])
             assert_equal(node.getreceivedbyaccount(account), 2)
             node.move(account, "", node.getbalance(account))
-        
+
         node.generate(101)
         
         expected_account_balances = {"": 5200}
@@ -97,4 +139,4 @@ class WalletAccountsTest(BitcoinTestFramework):
             assert_equal(node.getbalance(account), 50)
 
 if __name__ == '__main__':
-    WalletAccountsTest().main ()
+    WalletAccountsTest().main()


### PR DESCRIPTION
Test added as part of wallet-accounts.py. Only the most basic grouping is tested.
Made the file flake8 compliant. Most of the diff is whitespace.