### PR TITLE
[doc] Minor corrections to osx dependencies

### DIFF
--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -11,14 +11,14 @@ Install the OS X command line tools:
 
 When the popup appears, click `Install`.
 
-Then install [Homebrew](http://brew.sh).
+Then install [Homebrew](https://brew.sh).
 
 Dependencies
 ----------------------
 
-    brew install automake berkeley-db4 libtool boost --c++11 miniupnpc openssl pkg-config protobuf --c++11 qt5 libevent
+    brew install automake berkeley-db4 libtool boost --c++11 miniupnpc openssl pkg-config protobuf qt libevent
 
-In case you want to build the disk image with `make deploy` (.dmg / optional), you need RSVG
+If you want to build the disk image with `make deploy` (.dmg / optional), you need RSVG
 
     brew install librsvg
 


### PR DESCRIPTION
Protobuf no longer has a --c++11 option, it's now the default.
qt5 is now just qt (5.8).