### PR TITLE
Remove Clang workaround for Boost 1.46

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -88,19 +88,6 @@
 #include <openssl/rand.h>
 #include <openssl/conf.h>
 
-// Work around clang compilation problem in Boost 1.46:
-// /usr/include/boost/program_options/detail/config_file.hpp:163:17: error: call to function 'to_internal' that is neither visible in the template definition nor found by argument-dependent lookup
-// See also: http://stackoverflow.com/questions/10020179/compilation-fail-in-boost-librairies-program-options
-//           http://clang.debian.net/status.php?version=3.0&key=CANNOT_FIND_FUNCTION
-namespace boost {
-
-    namespace program_options {
-        std::string to_internal(const std::string&);
-    }
-
-} // namespace boost
-
-
 
 const char * const BITCOIN_CONF_FILENAME = "bitcoin.conf";
 const char * const BITCOIN_PID_FILENAME = "bitcoind.pid";


### PR DESCRIPTION
This was introduced in #1104. 

Now that we require at least Boost 1.47, we can remove it.