### PR TITLE
[Tests] Prevent warning: variable 'x' is uninitialized

### DIFF
--- a/src/bench/crypto_hash.cpp
+++ b/src/bench/crypto_hash.cpp
@@ -73,7 +73,7 @@ static void SipHash_32b(benchmark::State& state)
 static void FastRandom_32bit(benchmark::State& state)
 {
     FastRandomContext rng(true);
-    uint32_t x;
+    uint32_t x = 0;
     while (state.KeepRunning()) {
         for (int i = 0; i < 1000000; i++) {
             x += rng.rand32();
@@ -84,7 +84,7 @@ static void FastRandom_32bit(benchmark::State& state)
 static void FastRandom_1bit(benchmark::State& state)
 {
     FastRandomContext rng(true);
-    uint32_t x;
+    uint32_t x = 0;
     while (state.KeepRunning()) {
         for (int i = 0; i < 1000000; i++) {
             x += rng.randbool();


### PR DESCRIPTION
#9792 brought a few "uninitialized" warnings:

```
bench/crypto_hash.cpp:79:13: warning: variable 'x' is uninitialized when used here [-Wuninitialized]
            x += rng.rand32();
            ^
bench/crypto_hash.cpp:76:15: note: initialize the variable 'x' to silence this warning
    uint32_t x;
              ^
               = 0
bench/crypto_hash.cpp:90:13: warning: variable 'x' is uninitialized when used here [-Wuninitialized]
            x += rng.randbool();
            ^
bench/crypto_hash.cpp:87:15: note: initialize the variable 'x' to silence this warning
    uint32_t x;
              ^
               = 0
2 warnings generated.
```

Fix them.