### PR TITLE
contrib/verifybinaries: allow filtering by platform

### DIFF
--- a/contrib/verifybinaries/README.md
+++ b/contrib/verifybinaries/README.md
@@ -26,6 +26,14 @@ The script returns 0 if everything passes the checks. It returns 1 if either the
 ./verify.sh bitcoin-core-0.13.0-rc3
 ```
 
+If you only want to download the binaries of certain platform, add the corresponding suffix, e.g.:
+
+```sh
+./verify.sh bitcoin-core-0.11.2-osx
+./verify.sh 0.12.0-linux
+./verify.sh bitcoin-core-0.13.0-rc3-win64
+```
+
 If you do not want to keep the downloaded binaries, specify anything as the second parameter.
 
 ```sh


### PR DESCRIPTION
Downloading all the binaries of all platforms can take quite long,
especially for slow connections, which may deter people from using
this script and, therefore, to disregard security altogether.

This change introduces the new possibility of specifying the
platform along with the version number, so that only the binaries
that contain the platform name are downloaded.