### PR TITLE
Expire bitcoind & bitcoin-qt 7-8 years after its last change

### DIFF
--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -18,6 +18,7 @@
 #include "httpserver.h"
 #include "httprpc.h"
 #include "utilstrencodings.h"
+#include "validation.h"
 
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/filesystem.hpp>
@@ -115,6 +116,11 @@ bool AppInit(int argc, char* argv[])
         } catch (const std::exception& e) {
             fprintf(stderr, "Error: %s\n", e.what());
             return false;
+        }
+
+        if (IsThisSoftwareExpired(GetTime())) {
+            fprintf(stderr, "This software is expired, and may be out of consensus. You must choose to upgrade or override this expiration.\n");
+            exit(EXIT_FAILURE);
         }
 
         // Command-line RPC

--- a/src/consensus/consensus.h
+++ b/src/consensus/consensus.h
@@ -6,6 +6,8 @@
 #ifndef BITCOIN_CONSENSUS_CONSENSUS_H
 #define BITCOIN_CONSENSUS_CONSENSUS_H
 
+#include "config/bitcoin-config.h"  // for COPYRIGHT_YEAR
+
 #include <stdint.h>
 
 /** The maximum allowed size for a serialized block, in bytes (only for buffer size limits) */
@@ -27,5 +29,9 @@ enum {
     /* Use GetMedianTimePast() instead of nTime for end point timestamp. */
     LOCKTIME_MEDIAN_TIME_PAST = (1 << 1),
 };
+
+static const int64_t SECONDS_PER_YEAR = 31558060;
+static const int POSIX_EPOCH_YEAR = 1970;
+static const int64_t DEFAULT_SOFTWARE_EXPIRY = ((COPYRIGHT_YEAR - POSIX_EPOCH_YEAR) * SECONDS_PER_YEAR) + (SECONDS_PER_YEAR * 8);
 
 #endif // BITCOIN_CONSENSUS_CONSENSUS_H

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -344,6 +344,9 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-maxmempool=<n>", strprintf(_("Keep the transaction memory pool below <n> megabytes (default: %u)"), DEFAULT_MAX_MEMPOOL_SIZE));
     strUsage += HelpMessageOpt("-mempoolexpiry=<n>", strprintf(_("Do not keep transactions in the mempool longer than <n> hours (default: %u)"), DEFAULT_MEMPOOL_EXPIRY));
     strUsage += HelpMessageOpt("-blockreconstructionextratxn=<n>", strprintf(_("Extra transactions to keep in memory for compact block reconstructions (default: %u)"), DEFAULT_BLOCK_RECONSTRUCTION_EXTRA_TXN));
+    if (showDebug) {
+        strUsage += HelpMessageOpt("-softwareexpiry", strprintf("Stop working after this POSIX timestamp (default: %s)", DEFAULT_SOFTWARE_EXPIRY));
+    }
     strUsage += HelpMessageOpt("-par=<n>", strprintf(_("Set the number of script verification threads (%u to %d, 0 = auto, <0 = leave that many cores free, default: %d)"),
         -GetNumCores(), MAX_SCRIPTCHECK_THREADS, DEFAULT_SCRIPTCHECK_THREADS));
 #ifndef WIN32

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -18,6 +18,7 @@
 #include "platformstyle.h"
 #include "splashscreen.h"
 #include "utilitydialog.h"
+#include "validation.h"
 #include "winshutdownmonitor.h"
 
 #ifdef ENABLE_WALLET
@@ -634,6 +635,11 @@ int main(int argc, char *argv[])
     // Parse URIs on command line -- this can affect Params()
     PaymentServer::ipcParseCommandLine(argc, argv);
 #endif
+
+    if (IsThisSoftwareExpired(GetTime())) {
+        QMessageBox::critical(0, QObject::tr("Software expired"), QObject::tr("This software is expired, and may be out of consensus. You must choose to upgrade or override this expiration."));
+        return EXIT_FAILURE;
+    }
 
     QScopedPointer<const NetworkStyle> networkStyle(NetworkStyle::instantiate(QString::fromStdString(Params().NetworkIDString())));
     assert(!networkStyle.isNull());

--- a/src/validation.h
+++ b/src/validation.h
@@ -468,6 +468,8 @@ bool WriteBlockToDisk(const CBlock& block, CDiskBlockPos& pos, const CMessageHea
 bool ReadBlockFromDisk(CBlock& block, const CDiskBlockPos& pos, const Consensus::Params& consensusParams);
 bool ReadBlockFromDisk(CBlock& block, const CBlockIndex* pindex, const Consensus::Params& consensusParams);
 
+bool IsThisSoftwareExpired(int64_t nTime);
+
 /** Functions for validating blocks and updating the block tree */
 
 /** Context-independent validity checks */


### PR DESCRIPTION
COPYRIGHT_YEAR + 8 years is used as the basis for expiration, to achieve a constantly-moving-forward expiration date.

It is assumed that within 7 years, the software will become obsolete beyond any reasonable person's continuing to use it.
If not hardforks, then at least softforks will occur during this time rendering it insecure. Not to mention an almost certainty of exploits.

Furthermore, this enables a sort of certainty of old nodes ending by a deadline, turning any hardfork into a de facto softfork provided it is planned 8 years out.

As a precaution against abuse, the expiration can be disabled or extended with a debug-visibility "softwareexpiry" configuration option.

(Thanks to Wang Chun for suggesting a similar proposal this is based on.)

Previous discussion: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2017-March/013822.html

It is unclear to me if this needs a BIP.