### PR TITLE
Improved efficiency in COutPoint constructors

### DIFF
--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -22,8 +22,8 @@ public:
     uint256 hash;
     uint32_t n;
 
-    COutPoint() { SetNull(); }
-    COutPoint(uint256 hashIn, uint32_t nIn) { hash = hashIn; n = nIn; }
+    COutPoint(): n((uint32_t) -1) { }
+    COutPoint(const uint256& hashIn, uint32_t nIn): hash(hashIn), n(nIn) { }
 
     ADD_SERIALIZE_METHODS;
 


### PR DESCRIPTION
memset(0) executed twice, first in uint256_t default constructor and then in SetNull.

Remake of https://github.com/bitcoin/bitcoin/pull/10277