### PR TITLE
Remove OpenSSL

### DIFF
--- a/src/key.cpp
+++ b/src/key.cpp
@@ -125,7 +125,7 @@ bool CKey::Check(const unsigned char *vch) {
 
 void CKey::MakeNewKey(bool fCompressedIn) {
     do {
-        GetStrongRandBytes(keydata.data(), keydata.size());
+        GetRandBytes(keydata.data(), keydata.size());
     } while (!Check(keydata.data()));
     fValid = true;
     fCompressed = fCompressedIn;

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -178,27 +178,6 @@ void GetRandBytes(unsigned char* buf, int num)
     memory_cleanse(seed32, 32);
 }
 
-void GetStrongRandBytes(unsigned char* out, int num)
-{
-    assert(num <= 32);
-    CSHA512 hasher;
-    unsigned char buf[64];
-
-    // First source: OpenSSL's RNG
-    RandAddSeedPerfmon();
-    GetRandBytes(buf, 32);
-    hasher.Write(buf, 32);
-
-    // Second source: OS RNG
-    GetOSRand(buf);
-    hasher.Write(buf, 32);
-
-    // Produce output
-    hasher.Finalize(buf);
-    memcpy(out, buf, num);
-    memory_cleanse(buf, 64);
-}
-
 uint64_t GetRand(uint64_t nMax)
 {
     if (nMax == 0)

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -212,6 +212,17 @@ void FastRandomContext::RandomSeed()
     requires_seed = false;
 }
 
+uint256 FastRandomContext::rand256()
+{
+    if (bytebuf_size < 32) {
+        FillByteBuffer();
+    }
+    uint256 ret;
+    memcpy(ret.begin(), bytebuf + 64 - bytebuf_size, 32);
+    bytebuf_size -= 32;
+    return ret;
+}
+
 FastRandomContext::FastRandomContext(const uint256& seed) : requires_seed(false), bytebuf_size(0), bitbuf_size(0)
 {
     rng.SetKey(seed.begin(), 32);

--- a/src/random.h
+++ b/src/random.h
@@ -21,12 +21,6 @@ int GetRandInt(int nMax);
 uint256 GetRandHash();
 
 /**
- * Function to gather random data from multiple sources, failing whenever any
- * of those source fail to provide a result.
- */
-void GetStrongRandBytes(unsigned char* buf, int num);
-
-/**
  * Fast randomness source. This is seeded once with secure random data, but
  * is completely deterministic and insecure after that.
  * This class is not thread-safe.

--- a/src/random.h
+++ b/src/random.h
@@ -12,11 +12,8 @@
 
 #include <stdint.h>
 
-/* Seed OpenSSL PRNG with additional entropy data */
-void RandAddSeed();
-
 /**
- * Functions to gather random data via the OpenSSL PRNG
+ * Functions to gather secure random data.
  */
 void GetRandBytes(unsigned char* buf, int num);
 uint64_t GetRand(uint64_t nMax);

--- a/src/random.h
+++ b/src/random.h
@@ -97,6 +97,9 @@ public:
     /** Generate a random 32-bit integer. */
     uint32_t rand32() { return randbits(32); }
 
+    /** generate a random uint256. */
+    uint256 rand256();
+
     /** Generate a random boolean. */
     bool randbool() { return randbits(1); }
 };

--- a/src/random.h
+++ b/src/random.h
@@ -94,6 +94,9 @@ public:
         }
     }
 
+    /** Generate random bytes. */
+    void randbytes(unsigned char* out, size_t len) { rng.Output(out, len); }
+
     /** Generate a random 32-bit integer. */
     uint32_t rand32() { return randbits(32); }
 

--- a/src/support/cleanse.cpp
+++ b/src/support/cleanse.cpp
@@ -4,10 +4,10 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "cleanse.h"
-
-#include <openssl/crypto.h>
+#include <string.h>
 
 void memory_cleanse(void *ptr, size_t len)
 {
-    OPENSSL_cleanse(ptr, len);
+    void *(*volatile const volatile_memset)(void *, int, size_t) = memset;
+    volatile_memset(ptr, 0, len);
 }

--- a/src/test/DoS_tests.cpp
+++ b/src/test/DoS_tests.cpp
@@ -15,6 +15,7 @@
 #include "validation.h"
 
 #include "test/test_bitcoin.h"
+#include "test/test_random.h"
 
 #include <stdint.h>
 
@@ -129,7 +130,7 @@ BOOST_AUTO_TEST_CASE(DoS_bantime)
 CTransactionRef RandomOrphan()
 {
     std::map<uint256, COrphanTx>::iterator it;
-    it = mapOrphanTransactions.lower_bound(GetRandHash());
+    it = mapOrphanTransactions.lower_bound(insecure_rand_ctx.rand256());
     if (it == mapOrphanTransactions.end())
         it = mapOrphanTransactions.begin();
     return it->second.tx;
@@ -148,7 +149,7 @@ BOOST_AUTO_TEST_CASE(DoS_mapOrphans)
         CMutableTransaction tx;
         tx.vin.resize(1);
         tx.vin[0].prevout.n = 0;
-        tx.vin[0].prevout.hash = GetRandHash();
+        tx.vin[0].prevout.hash = insecure_rand_ctx.rand256();
         tx.vin[0].scriptSig << OP_1;
         tx.vout.resize(1);
         tx.vout[0].nValue = 1*CENT;

--- a/src/test/blockencodings_tests.cpp
+++ b/src/test/blockencodings_tests.cpp
@@ -8,6 +8,7 @@
 #include "random.h"
 
 #include "test/test_bitcoin.h"
+#include "test/test_random.h"
 
 #include <boost/test/unit_test.hpp>
 
@@ -30,16 +31,16 @@ static CBlock BuildBlockTestCase() {
     block.vtx.resize(3);
     block.vtx[0] = MakeTransactionRef(tx);
     block.nVersion = 42;
-    block.hashPrevBlock = GetRandHash();
+    block.hashPrevBlock = insecure_rand_ctx.rand256();
     block.nBits = 0x207fffff;
 
-    tx.vin[0].prevout.hash = GetRandHash();
+    tx.vin[0].prevout.hash = insecure_rand_ctx.rand256();
     tx.vin[0].prevout.n = 0;
     block.vtx[1] = MakeTransactionRef(tx);
 
     tx.vin.resize(10);
     for (size_t i = 0; i < tx.vin.size(); i++) {
-        tx.vin[i].prevout.hash = GetRandHash();
+        tx.vin[i].prevout.hash = insecure_rand_ctx.rand256();
         tx.vin[i].prevout.n = 0;
     }
     block.vtx[2] = MakeTransactionRef(tx);
@@ -283,7 +284,7 @@ BOOST_AUTO_TEST_CASE(EmptyBlockRoundTripTest)
     block.vtx.resize(1);
     block.vtx[0] = MakeTransactionRef(std::move(coinbase));
     block.nVersion = 42;
-    block.hashPrevBlock = GetRandHash();
+    block.hashPrevBlock = insecure_rand_ctx.rand256();
     block.nBits = 0x207fffff;
 
     bool mutated;
@@ -316,7 +317,7 @@ BOOST_AUTO_TEST_CASE(EmptyBlockRoundTripTest)
 
 BOOST_AUTO_TEST_CASE(TransactionsRequestSerializationTest) {
     BlockTransactionsRequest req1;
-    req1.blockhash = GetRandHash();
+    req1.blockhash = insecure_rand_ctx.rand256();
     req1.indexes.resize(4);
     req1.indexes[0] = 0;
     req1.indexes[1] = 1;

--- a/src/test/bloom_tests.cpp
+++ b/src/test/bloom_tests.cpp
@@ -15,6 +15,7 @@
 #include "util.h"
 #include "utilstrencodings.h"
 #include "test/test_bitcoin.h"
+#include "test/test_random.h"
 
 #include <vector>
 
@@ -463,7 +464,7 @@ BOOST_AUTO_TEST_CASE(merkle_block_4_test_update_none)
 
 static std::vector<unsigned char> RandomData()
 {
-    uint256 r = GetRandHash();
+    uint256 r = insecure_rand_ctx.rand256();
     return std::vector<unsigned char>(r.begin(), r.end());
 }
 

--- a/src/test/checkqueue_tests.cpp
+++ b/src/test/checkqueue_tests.cpp
@@ -7,6 +7,7 @@
 #include "validation.h"
 
 #include "test/test_bitcoin.h"
+#include "test/test_random.h"
 #include "checkqueue.h"
 #include <boost/test/unit_test.hpp>
 #include <boost/thread.hpp>
@@ -160,7 +161,7 @@ void Correct_Queue_range(std::vector<size_t> range)
         FakeCheckCheckCompletion::n_calls = 0;
         CCheckQueueControl<FakeCheckCheckCompletion> control(small_queue.get());
         while (total) {
-            vChecks.resize(std::min(total, (size_t) GetRand(10)));
+            vChecks.resize(std::min(total, (size_t)insecure_rand_ctx.randrange(10)));
             total -= vChecks.size();
             control.Add(vChecks);
         }
@@ -204,7 +205,7 @@ BOOST_AUTO_TEST_CASE(test_CheckQueue_Correct_Random)
 {
     std::vector<size_t> range;
     range.reserve(100000/1000);
-    for (size_t i = 2; i < 100000; i += std::max((size_t)1, (size_t)GetRand(std::min((size_t)1000, ((size_t)100000) - i))))
+    for (size_t i = 2; i < 100000; i += std::max((size_t)1, (size_t)insecure_rand_ctx.randrange(std::min((size_t)1000, ((size_t)100000) - i))))
         range.push_back(i);
     Correct_Queue_range(range);
 }
@@ -224,7 +225,7 @@ BOOST_AUTO_TEST_CASE(test_CheckQueue_Catches_Failure)
         CCheckQueueControl<FailingCheck> control(fail_queue.get());
         size_t remaining = i;
         while (remaining) {
-            size_t r = GetRand(10);
+            size_t r = insecure_rand_ctx.randrange(10);
 
             std::vector<FailingCheck> vChecks;
             vChecks.reserve(r);
@@ -286,7 +287,7 @@ BOOST_AUTO_TEST_CASE(test_CheckQueue_UniqueCheck)
     {
         CCheckQueueControl<UniqueCheck> control(queue.get());
         while (total) {
-            size_t r = GetRand(10);
+            size_t r = insecure_rand_ctx.randrange(10);
             std::vector<UniqueCheck> vChecks;
             for (size_t k = 0; k < r && total; k++)
                 vChecks.emplace_back(--total);
@@ -320,7 +321,7 @@ BOOST_AUTO_TEST_CASE(test_CheckQueue_Memory)
         {
             CCheckQueueControl<MemoryCheck> control(queue.get());
             while (total) {
-                size_t r = GetRand(10);
+                size_t r = insecure_rand_ctx.randrange(10);
                 std::vector<MemoryCheck> vChecks;
                 for (size_t k = 0; k < r && total; k++) {
                     total--;

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -126,7 +126,7 @@ BOOST_AUTO_TEST_CASE(coins_cache_simulation_test)
     std::vector<uint256> txids;
     txids.resize(NUM_SIMULATION_ITERATIONS / 8);
     for (unsigned int i = 0; i < txids.size(); i++) {
-        txids[i] = GetRandHash();
+        txids[i] = insecure_rand_ctx.rand256();
     }
 
     for (unsigned int i = 0; i < NUM_SIMULATION_ITERATIONS; i++) {
@@ -223,7 +223,7 @@ std::map<uint256, TxData> alltxs;
 
 TxData &FindRandomFrom(const std::set<uint256> &txidset) {
     assert(txidset.size());
-    std::set<uint256>::iterator txIt = txidset.lower_bound(GetRandHash());
+    std::set<uint256>::iterator txIt = txidset.lower_bound(insecure_rand_ctx.rand256());
     if (txIt == txidset.end()) {
         txIt = txidset.begin();
     }

--- a/src/test/dbwrapper_tests.cpp
+++ b/src/test/dbwrapper_tests.cpp
@@ -6,6 +6,7 @@
 #include "uint256.h"
 #include "random.h"
 #include "test/test_bitcoin.h"
+#include "test/test_random.h"
 
 #include <boost/assign/std/vector.hpp> // for 'operator+=()'
 #include <boost/assert.hpp>
@@ -31,7 +32,7 @@ BOOST_AUTO_TEST_CASE(dbwrapper)
         fs::path ph = fs::temp_directory_path() / fs::unique_path();
         CDBWrapper dbw(ph, (1 << 20), true, false, obfuscate);
         char key = 'k';
-        uint256 in = GetRandHash();
+        uint256 in = insecure_rand_ctx.rand256();
         uint256 res;
 
         // Ensure that we're doing real obfuscation when obfuscate=true
@@ -53,11 +54,11 @@ BOOST_AUTO_TEST_CASE(dbwrapper_batch)
         CDBWrapper dbw(ph, (1 << 20), true, false, obfuscate);
 
         char key = 'i';
-        uint256 in = GetRandHash();
+        uint256 in = insecure_rand_ctx.rand256();
         char key2 = 'j';
-        uint256 in2 = GetRandHash();
+        uint256 in2 = insecure_rand_ctx.rand256();
         char key3 = 'k';
-        uint256 in3 = GetRandHash();
+        uint256 in3 = insecure_rand_ctx.rand256();
 
         uint256 res;
         CDBBatch batch(dbw);
@@ -91,10 +92,10 @@ BOOST_AUTO_TEST_CASE(dbwrapper_iterator)
 
         // The two keys are intentionally chosen for ordering
         char key = 'j';
-        uint256 in = GetRandHash();
+        uint256 in = insecure_rand_ctx.rand256();
         BOOST_CHECK(dbw.Write(key, in));
         char key2 = 'k';
-        uint256 in2 = GetRandHash();
+        uint256 in2 = insecure_rand_ctx.rand256();
         BOOST_CHECK(dbw.Write(key2, in2));
 
         std::unique_ptr<CDBIterator> it(const_cast<CDBWrapper*>(&dbw)->NewIterator());
@@ -132,7 +133,7 @@ BOOST_AUTO_TEST_CASE(existing_data_no_obfuscate)
     // Set up a non-obfuscated wrapper to write some initial data.
     CDBWrapper* dbw = new CDBWrapper(ph, (1 << 10), false, false, false);
     char key = 'k';
-    uint256 in = GetRandHash();
+    uint256 in = insecure_rand_ctx.rand256();
     uint256 res;
 
     BOOST_CHECK(dbw->Write(key, in));
@@ -155,7 +156,7 @@ BOOST_AUTO_TEST_CASE(existing_data_no_obfuscate)
     BOOST_CHECK(!odbw.IsEmpty()); // There should be existing data
     BOOST_CHECK(is_null_key(dbwrapper_private::GetObfuscateKey(odbw))); // The key should be an empty string
 
-    uint256 in2 = GetRandHash();
+    uint256 in2 = insecure_rand_ctx.rand256();
     uint256 res3;
  
     // Check that we can write successfully
@@ -174,7 +175,7 @@ BOOST_AUTO_TEST_CASE(existing_data_reindex)
     // Set up a non-obfuscated wrapper to write some initial data.
     CDBWrapper* dbw = new CDBWrapper(ph, (1 << 10), false, false, false);
     char key = 'k';
-    uint256 in = GetRandHash();
+    uint256 in = insecure_rand_ctx.rand256();
     uint256 res;
 
     BOOST_CHECK(dbw->Write(key, in));
@@ -193,7 +194,7 @@ BOOST_AUTO_TEST_CASE(existing_data_reindex)
     BOOST_CHECK(!odbw.Read(key, res2));
     BOOST_CHECK(!is_null_key(dbwrapper_private::GetObfuscateKey(odbw)));
 
-    uint256 in2 = GetRandHash();
+    uint256 in2 = insecure_rand_ctx.rand256();
     uint256 res3;
  
     // Check that we can write successfully

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -18,6 +18,7 @@
 #include "utilstrencodings.h"
 
 #include "test/test_bitcoin.h"
+#include "test/test_random.h"
 
 #include <memory>
 
@@ -370,7 +371,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     while (chainActive.Tip()->nHeight < 209999) {
         CBlockIndex* prev = chainActive.Tip();
         CBlockIndex* next = new CBlockIndex();
-        next->phashBlock = new uint256(GetRandHash());
+        next->phashBlock = new uint256(insecure_rand_ctx.rand256());
         pcoinsTip->SetBestBlock(next->GetBlockHash());
         next->pprev = prev;
         next->nHeight = prev->nHeight + 1;
@@ -382,7 +383,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     while (chainActive.Tip()->nHeight < 210000) {
         CBlockIndex* prev = chainActive.Tip();
         CBlockIndex* next = new CBlockIndex();
-        next->phashBlock = new uint256(GetRandHash());
+        next->phashBlock = new uint256(insecure_rand_ctx.rand256());
         pcoinsTip->SetBestBlock(next->GetBlockHash());
         next->pprev = prev;
         next->nHeight = prev->nHeight + 1;

--- a/src/test/pow_tests.cpp
+++ b/src/test/pow_tests.cpp
@@ -8,6 +8,7 @@
 #include "random.h"
 #include "util.h"
 #include "test/test_bitcoin.h"
+#include "test/test_random.h"
 
 #include <boost/test/unit_test.hpp>
 
@@ -84,9 +85,9 @@ BOOST_AUTO_TEST_CASE(GetBlockProofEquivalentTime_test)
     }
 
     for (int j = 0; j < 1000; j++) {
-        CBlockIndex *p1 = &blocks[GetRand(10000)];
-        CBlockIndex *p2 = &blocks[GetRand(10000)];
-        CBlockIndex *p3 = &blocks[GetRand(10000)];
+        CBlockIndex *p1 = &blocks[insecure_rand_ctx.randrange(10000)];
+        CBlockIndex *p2 = &blocks[insecure_rand_ctx.randrange(10000)];
+        CBlockIndex *p3 = &blocks[insecure_rand_ctx.randrange(10000)];
 
         int64_t tdiff = GetBlockProofEquivalentTime(*p1, *p2, *p3, params);
         BOOST_CHECK_EQUAL(tdiff, p1->GetBlockTime() - p2->GetBlockTime());

--- a/src/test/random_tests.cpp
+++ b/src/test/random_tests.cpp
@@ -25,14 +25,17 @@ BOOST_AUTO_TEST_CASE(fastrandom_tests)
     BOOST_CHECK_EQUAL(ctx1.rand32(), ctx2.rand32());
     BOOST_CHECK_EQUAL(ctx1.rand64(), ctx2.rand64());
     BOOST_CHECK_EQUAL(ctx1.randbits(3), ctx2.randbits(3));
+    BOOST_CHECK(ctx1.rand256() == ctx2.rand256());
     BOOST_CHECK_EQUAL(ctx1.randbits(7), ctx2.randbits(7));
     BOOST_CHECK_EQUAL(ctx1.rand32(), ctx2.rand32());
     BOOST_CHECK_EQUAL(ctx1.randbits(3), ctx2.randbits(3));
+    BOOST_CHECK(ctx1.rand256() == ctx2.rand256());
 
     // Check that a nondeterministic ones are not
     FastRandomContext ctx3;
     FastRandomContext ctx4;
     BOOST_CHECK(ctx3.rand64() != ctx4.rand64()); // extremely unlikely to be equal
+    BOOST_CHECK(ctx3.rand256() != ctx4.rand256());
 }
 
 BOOST_AUTO_TEST_CASE(fastrandom_randbits)

--- a/src/test/sighash_tests.cpp
+++ b/src/test/sighash_tests.cpp
@@ -105,7 +105,7 @@ void static RandomTransaction(CMutableTransaction &tx, bool fSingle) {
     for (int in = 0; in < ins; in++) {
         tx.vin.push_back(CTxIn());
         CTxIn &txin = tx.vin.back();
-        txin.prevout.hash = GetRandHash();
+        txin.prevout.hash = insecure_rand_ctx.rand256();
         txin.prevout.n = insecure_rand() % 4;
         RandomScript(txin.scriptSig);
         txin.nSequence = (insecure_rand() % 2) ? insecure_rand() : (unsigned int)-1;

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -59,7 +59,7 @@ TestingSetup::TestingSetup(const std::string& chainName) : BasicTestingSetup(cha
 
         RegisterAllCoreRPCCommands(tableRPC);
         ClearDatadirCache();
-        pathTemp = GetTempPath() / strprintf("test_bitcoin_%lu_%i", (unsigned long)GetTime(), (int)(GetRand(100000)));
+        pathTemp = GetTempPath() / strprintf("test_bitcoin_%lu_%i", (unsigned long)GetTime(), (int)(insecure_rand_ctx.randrange(100000)));
         fs::create_directories(pathTemp);
         ForceSetArg("-datadir", pathTemp.string());
         mempool.setSanityCheck(1.0);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -84,9 +84,6 @@
 #include <boost/program_options/detail/config_file.hpp>
 #include <boost/program_options/parsers.hpp>
 #include <boost/thread.hpp>
-#include <openssl/crypto.h>
-#include <openssl/rand.h>
-#include <openssl/conf.h>
 
 
 const char * const BITCOIN_CONF_FILENAME = "bitcoin.conf";
@@ -107,54 +104,6 @@ CTranslationInterface translationInterface;
 
 /** Log categories bitfield. */
 std::atomic<uint32_t> logCategories(0);
-
-/** Init OpenSSL library multithreading support */
-static std::unique_ptr<CCriticalSection[]> ppmutexOpenSSL;
-void locking_callback(int mode, int i, const char* file, int line) NO_THREAD_SAFETY_ANALYSIS
-{
-    if (mode & CRYPTO_LOCK) {
-        ENTER_CRITICAL_SECTION(ppmutexOpenSSL[i]);
-    } else {
-        LEAVE_CRITICAL_SECTION(ppmutexOpenSSL[i]);
-    }
-}
-
-// Singleton for wrapping OpenSSL setup/teardown.
-class CInit
-{
-public:
-    CInit()
-    {
-        // Init OpenSSL library multithreading support
-        ppmutexOpenSSL.reset(new CCriticalSection[CRYPTO_num_locks()]);
-        CRYPTO_set_locking_callback(locking_callback);
-
-        // OpenSSL can optionally load a config file which lists optional loadable modules and engines.
-        // We don't use them so we don't require the config. However some of our libs may call functions
-        // which attempt to load the config file, possibly resulting in an exit() or crash if it is missing
-        // or corrupt. Explicitly tell OpenSSL not to try to load the file. The result for our libs will be
-        // that the config appears to have been loaded and there are no modules/engines available.
-        OPENSSL_no_config();
-
-#ifdef WIN32
-        // Seed OpenSSL PRNG with current contents of the screen
-        RAND_screen();
-#endif
-
-        // Seed OpenSSL PRNG with performance counter
-        RandAddSeed();
-    }
-    ~CInit()
-    {
-        // Securely erase the memory used by the PRNG
-        RAND_cleanup();
-        // Shutdown OpenSSL library multithreading support
-        CRYPTO_set_locking_callback(NULL);
-        // Clear the set of locks now to maintain symmetry with the constructor.
-        ppmutexOpenSSL.reset();
-    }
-}
-instance_of_cinit;
 
 /**
  * LogPrintf() has been broken a couple of times now

--- a/src/wallet/test/crypto_tests.cpp
+++ b/src/wallet/test/crypto_tests.cpp
@@ -5,6 +5,7 @@
 #include "test/test_random.h"
 #include "utilstrencodings.h"
 #include "test/test_bitcoin.h"
+#include "test/test_random.h"
 #include "wallet/crypter.h"
 
 #include <vector>
@@ -190,9 +191,9 @@ BOOST_AUTO_TEST_CASE(passphrase) {
                                 ParseHex("fc7aba077ad5f4c3a0988d8daa4810d0d4a0e3bcb53af662998898f33df0556a"), \
                                 ParseHex("cf2f2691526dd1aa220896fb8bf7c369"));
 
-    std::string hash(GetRandHash().ToString());
+    std::string hash(insecure_rand_ctx.rand256().ToString());
     std::vector<unsigned char> vchSalt(8);
-    GetRandBytes(&vchSalt[0], vchSalt.size());
+    insecure_rand_ctx.randbytes(&vchSalt[0], vchSalt.size());
     uint32_t rounds = insecure_rand();
     if (rounds > 30000)
         rounds = 30000;
@@ -208,7 +209,7 @@ BOOST_AUTO_TEST_CASE(encrypt) {
 
     for (int i = 0; i != 100; i++)
     {
-        uint256 hash(GetRandHash());
+        uint256 hash(insecure_rand_ctx.rand256());
         TestCrypter::TestEncrypt(crypt, std::vector<unsigned char>(hash.begin(), hash.end()));
     }
 
@@ -230,7 +231,7 @@ BOOST_AUTO_TEST_CASE(decrypt) {
 
     for (int i = 0; i != 100; i++)
     {
-        uint256 hash(GetRandHash());
+        uint256 hash(insecure_rand_ctx.rand256());
         TestCrypter::TestDecrypt(crypt, std::vector<unsigned char>(hash.begin(), hash.end()));
     }
 }

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -11,6 +11,7 @@
 
 #include "rpc/server.h"
 #include "test/test_bitcoin.h"
+#include "test/test_random.h"
 #include "validation.h"
 #include "wallet/test/wallet_test_fixture.h"
 
@@ -469,7 +470,7 @@ static int64_t AddTx(CWallet& wallet, uint32_t lockTime, int64_t mockTime, int64
     SetMockTime(mockTime);
     CBlockIndex* block = nullptr;
     if (blockTime > 0) {
-        auto inserted = mapBlockIndex.emplace(GetRandHash(), new CBlockIndex);
+        auto inserted = mapBlockIndex.emplace(insecure_rand_ctx.rand256(), new CBlockIndex);
         assert(inserted.second);
         const uint256& hash = inserted.first->first;
         block = inserted.first->second;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -556,12 +556,12 @@ bool CWallet::EncryptWallet(const SecureString& strWalletPassphrase)
     CKeyingMaterial _vMasterKey;
 
     _vMasterKey.resize(WALLET_CRYPTO_KEY_SIZE);
-    GetStrongRandBytes(&_vMasterKey[0], WALLET_CRYPTO_KEY_SIZE);
+    GetRandBytes(&_vMasterKey[0], WALLET_CRYPTO_KEY_SIZE);
 
     CMasterKey kMasterKey;
 
     kMasterKey.vchSalt.resize(WALLET_CRYPTO_SALT_SIZE);
-    GetStrongRandBytes(&kMasterKey.vchSalt[0], WALLET_CRYPTO_SALT_SIZE);
+    GetRandBytes(&kMasterKey.vchSalt[0], WALLET_CRYPTO_SALT_SIZE);
 
     CCrypter crypter;
     int64_t nStartTime = GetTimeMillis();


### PR DESCRIPTION
This PR removes the need for OpenSSL in `bitcoind`, and the direct uses of it in the GUI.

It introduces a simple PRNG wrapper around `GetOSRand()` that protects against some cases of VM duplication:
* tmp = SHA512(time() || stack_pointer || os_random() || state)
* seed = tmp[0:32]
* state = tmp[32:64]
* Use seed as key for ChaCha20 to produce desired randomness.

Then that wrapper is used to implement GetRandBytes, and GetStrongRandBytes is merged with it. This is overkill for some use cases, and they can later be replaced with FastRandomContext-based solutions (which is pretty strong now, since #9792).

Our cleanse function is also replaced with a self-implemented best-effort explicit zeroing.

It does not remove OpenSSL from existing unit tests or build system.