### PR TITLE
[doc] Add hint about getmempoolentry to getrawmempool help.

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -413,6 +413,7 @@ UniValue getrawmempool(const JSONRPCRequest& request)
         throw std::runtime_error(
             "getrawmempool ( verbose )\n"
             "\nReturns all transaction ids in memory pool as a json array of string transaction ids.\n"
+            "\nHint: use getmempoolentry to fetch a specific transaction from the mempool.\n"
             "\nArguments:\n"
             "1. verbose (boolean, optional, default=false) True for a json object, false for array of transaction ids\n"
             "\nResult: (for verbose = false):\n"


### PR DESCRIPTION
Lots of people seem to be unaware that getmempoolentry even exists (myself included, before today; see #10300 & #10304), so adding a hint to getrawmempool seems warranted.

I was tempted to start adding "See also: ..." strings to all RPC commands but wasn't sure that was generally desired.