### PR TITLE
fix contrib/debian builds; prefer qt5

### DIFF
--- a/contrib/debian/changelog
+++ b/contrib/debian/changelog
@@ -1,3 +1,9 @@
+bitcoin (0.14.1-1) experimental; urgency=medium
+
+  * Update to latest tagged release.
+
+ -- Ivan J. (parazyd) <parazyd@dyne.org>  Tue, 2 May 2017 20:10:00 +0200
+
 bitcoin (0.11.0-precise1) precise; urgency=medium
 
   * New upstream release.

--- a/contrib/debian/control
+++ b/contrib/debian/control
@@ -1,7 +1,7 @@
 Source: bitcoin
 Section: utils
 Priority: optional
-Maintainer: Jonas Smedegaard <dr@jones.dk>
+Maintainer: Ivan J. (parazyd) <parazyd@dyne.org>
 Uploaders: Micah Anderson <micah@debian.org>
 Build-Depends: debhelper,
  devscripts,
@@ -10,6 +10,7 @@ Build-Depends: debhelper,
  bash-completion,
  libboost-system-dev (>> 1.35) | libboost-system1.35-dev,
  libdb4.8++-dev,
+ libevent-dev,
  libssl-dev,
  pkg-config,
  libminiupnpc8-dev | libminiupnpc-dev (>> 1.6),
@@ -17,8 +18,8 @@ Build-Depends: debhelper,
  libboost-program-options-dev (>> 1.35) | libboost-program-options1.35-dev,
  libboost-thread-dev (>> 1.35) | libboost-thread1.35-dev,
  libboost-test-dev (>> 1.35) | libboost-test1.35-dev,
- qt4-qmake,
- libqt4-dev,
+ qt5-qmake,
+ qtbase5-dev,
  libqrencode-dev,
  libprotobuf-dev, protobuf-compiler,
  python

--- a/contrib/debian/gbp.conf
+++ b/contrib/debian/gbp.conf
@@ -3,3 +3,5 @@
 [DEFAULT]
 pristine-tar = True
 sign-tags = True
+#upstream-tag = v%(version)s
+#debian-branch = suites/experimental


### PR DESCRIPTION
This patch fixes building Bitcoin Core on `apt` based systems. It also now prefers Qt5, since it is the first one that is looked for by the configure script.

The comments in `contrib/debian/gbp.conf` are there for reference, and a hint for any distro maintainer that might need it.