### PR TITLE
Use hardware timestamps in RNG seeding

### DIFF
--- a/src/random.cpp
+++ b/src/random.cpp
@@ -298,6 +298,10 @@ bool Random_SanityCheck()
     uint64_t stop = GetPerformanceCounter();
     if (stop == start) return false;
 
+    // We called GetPerformanceCounter. Use it as entropy.
+    RAND_add((const unsigned char*)&start, sizeof(start), 1);
+    RAND_add((const unsigned char*)&stop, sizeof(stop), 1);
+
     return true;
 }
 

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -16,6 +16,7 @@
 
 #include <stdlib.h>
 #include <limits>
+#include <chrono>
 
 #ifndef WIN32
 #include <sys/time.h>
@@ -43,15 +44,22 @@ static void RandFailure()
 
 static inline int64_t GetPerformanceCounter()
 {
-    int64_t nCounter = 0;
-#ifdef WIN32
-    QueryPerformanceCounter((LARGE_INTEGER*)&nCounter);
+    // Read the hardware time stamp counter when available.
+    // See https://en.wikipedia.org/wiki/Time_Stamp_Counter for more information.
+#if defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_X64))
+    return __rdtsc();
+#elif !defined(_MSC_VER) && defined(__i386__)
+    uint64_t r = 0;
+    __asm__ volatile ("rdtsc" : "=A"(r)); // Constrain the r variable to the eax:edx pair.
+    return r;
+#elif !defined(_MSC_VER) && (defined(__x86_64__) || defined(__amd64__))
+    uint64_t r1 = 0, r2 = 0;
+    __asm__ volatile ("rdtsc" : "=a"(r1), "=d"(r2)); // Constrain r1 to rax and r2 to rdx.
+    return (r2 << 32) | r1;
 #else
-    timeval t;
-    gettimeofday(&t, NULL);
-    nCounter = (int64_t)(t.tv_sec * 1000000 + t.tv_usec);
+    // Fall back to using C++11 clock (usually microsecond or nanosecond precision)
+    return std::chrono::high_resolution_clock::now().time_since_epoch().count();
 #endif
-    return nCounter;
 }
 
 void RandAddSeed()


### PR DESCRIPTION
Faster, and more entropy.