### PR TITLE
[wallet] fee fixes: always create change, adjust value, and p…

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2597,68 +2597,59 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
                 }
 
                 const CAmount nChange = nValueIn - nValueToSelect;
-                if (nChange > 0)
+                assert(nChange >= 0);
+
+                // Fill a vout to ourself, may be removed later on final fee adjustment
+                // TODO: pass in scriptChange instead of reservekey so
+                // change transaction isn't always pay-to-bitcoin-address
+                CScript scriptChange;
+
+                // coin control: send change to custom address
+                if (coinControl && !boost::get<CNoDestination>(&coinControl->destChange)) {
+                    scriptChange = GetScriptForDestination(coinControl->destChange);
+                }
+                // no coin control: send change to newly generated address
+                else
                 {
-                    // Fill a vout to ourself
-                    // TODO: pass in scriptChange instead of reservekey so
-                    // change transaction isn't always pay-to-bitcoin-address
-                    CScript scriptChange;
+                    // Note: We use a new key here to keep it from being obvious which side is the change.
+                    //  The drawback is that by not reusing a previous key, the change may be lost if a
+                    //  backup is restored, if the backup doesn't have the new private key for the change.
+                    //  If we reused the old key, it would be possible to add code to look for and
+                    //  rediscover unknown transactions that were written with keys of ours to recover
+                    //  post-backup change.
 
-                    // coin control: send change to custom address
-                    if (coinControl && !boost::get<CNoDestination>(&coinControl->destChange))
-                        scriptChange = GetScriptForDestination(coinControl->destChange);
-
-                    // no coin control: send change to newly generated address
-                    else
+                    // Reserve a new key pair from key pool
+                    CPubKey vchPubKey;
+                    bool ret;
+                    ret = reservekey.GetReservedKey(vchPubKey, true);
+                    if (!ret)
                     {
-                        // Note: We use a new key here to keep it from being obvious which side is the change.
-                        //  The drawback is that by not reusing a previous key, the change may be lost if a
-                        //  backup is restored, if the backup doesn't have the new private key for the change.
-                        //  If we reused the old key, it would be possible to add code to look for and
-                        //  rediscover unknown transactions that were written with keys of ours to recover
-                        //  post-backup change.
-
-                        // Reserve a new key pair from key pool
-                        CPubKey vchPubKey;
-                        bool ret;
-                        ret = reservekey.GetReservedKey(vchPubKey, true);
-                        if (!ret)
-                        {
-                            strFailReason = _("Keypool ran out, please call keypoolrefill first");
-                            return false;
-                        }
-
-                        scriptChange = GetScriptForDestination(vchPubKey.GetID());
+                        strFailReason = _("Keypool ran out, please call keypoolrefill first");
+                        return false;
                     }
 
-                    CTxOut newTxOut(nChange, scriptChange);
+                    scriptChange = GetScriptForDestination(vchPubKey.GetID());
+                }
 
-                    // Never create dust outputs; if we would, just
-                    // add the dust to the fee.
-                    if (IsDust(newTxOut, ::dustRelayFee))
-                    {
-                        nChangePosInOut = -1;
-                        nFeeRet += nChange;
-                        reservekey.ReturnKey();
-                    }
-                    else
-                    {
-                        if (nChangePosInOut == -1)
-                        {
-                            // Insert change txn at random position:
-                            nChangePosInOut = GetRandInt(txNew.vout.size()+1);
-                        }
-                        else if ((unsigned int)nChangePosInOut > txNew.vout.size())
-                        {
-                            strFailReason = _("Change index out of range");
-                            return false;
-                        }
+                CTxOut newTxOut(nChange, scriptChange);
 
-                        std::vector<CTxOut>::iterator position = txNew.vout.begin()+nChangePosInOut;
-                        txNew.vout.insert(position, newTxOut);
-                    }
+                // TODO move this section near fee-adjustment area.
+                if (nChangePosInOut == -1)
+                {
+                    // Insert change txn at random position:
+                    nChangePosInOut = GetRandInt(txNew.vout.size()+1);
+                }
+                else if ((unsigned int)nChangePosInOut > txNew.vout.size())
+                {
+                    strFailReason = _("Change index out of range");
+                    return false;
+                }
+
+                std::vector<CTxOut>::iterator position = txNew.vout.begin()+nChangePosInOut;
+                // We don't want to add a change output for 0-value with subtractFeeFromAmount
+                if (nSubtractFeeFromAmount == 0 || nChange > 0) {
+                    txNew.vout.insert(position, newTxOut);
                 } else {
-                    reservekey.ReturnKey();
                     nChangePosInOut = -1;
                 }
 
@@ -2709,41 +2700,43 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
                     return false;
                 }
 
-                if (nFeeRet >= nFeeNeeded) {
-                    // Reduce fee to only the needed amount if we have change
-                    // output to increase.  This prevents potential overpayment
-                    // in fees if the coins selected to meet nFeeNeeded result
-                    // in a transaction that requires less fee than the prior
-                    // iteration.
-                    // TODO: The case where nSubtractFeeFromAmount > 0 remains
-                    // to be addressed because it requires returning the fee to
-                    // the payees and not the change output.
-                    // TODO: The case where there is no change output remains
-                    // to be addressed so we avoid creating too small an output.
-                    if (nFeeRet > nFeeNeeded && nChangePosInOut != -1 && nSubtractFeeFromAmount == 0) {
-                        CAmount extraFeePaid = nFeeRet - nFeeNeeded;
-                        std::vector<CTxOut>::iterator change_position = txNew.vout.begin()+nChangePosInOut;
-                        change_position->nValue += extraFeePaid;
-                        nFeeRet -= extraFeePaid;
-                    }
-                    break; // Done, enough fee included.
-                }
+                // Modify fee to the needed amount from the change
+                // output, or recipients in the case of subtractFeeFromAmount.
+                // This prevents potential overpayment in fees if
+                // the coins selected to meet nFeeNeeded result
+                // in a transaction that requires less fee than the prior
+                // iteration.
+                CAmount excessFee = nFeeRet - nFeeNeeded;
 
-                // Try to reduce change to include necessary fee
-                if (nChangePosInOut != -1 && nSubtractFeeFromAmount == 0) {
-                    CAmount additionalFeeNeeded = nFeeNeeded - nFeeRet;
-                    std::vector<CTxOut>::iterator change_position = txNew.vout.begin()+nChangePosInOut;
-                    // Only reduce change if remaining amount is still a large enough output.
-                    if (change_position->nValue >= MIN_FINAL_CHANGE + additionalFeeNeeded) {
-                        change_position->nValue -= additionalFeeNeeded;
-                        nFeeRet += additionalFeeNeeded;
-                        break; // Done, able to increase fee from change
-                    }
-                }
+                if (nSubtractFeeFromAmount == 0) {
+                    // Take fee excess
+                    txNew.vout[nChangePosInOut].nValue += excessFee;;
+                    nFeeRet -= excessFee;
 
-                // Include more fee and try again.
-                nFeeRet = nFeeNeeded;
-                continue;
+                    // Negative change value means include more fee and try again.
+                    if (txNew.vout[nChangePosInOut].nValue < 0) {
+                        reservekey.ReturnKey();
+                        nFeeRet = nFeeNeeded;
+                        continue;
+                    }
+                    // Drop change if dust
+                    else if (IsDust(txNew.vout[nChangePosInOut], ::dustRelayFee)) {
+                        nFeeRet += txNew.vout[nChangePosInOut].nValue;
+                        txNew.vout.erase(txNew.vout.begin() + nChangePosInOut);
+                        nChangePosInOut = -1;
+                        reservekey.ReturnKey();
+                    }
+                    break;
+                }
+                // TODO: The case where nSubtractFeeFromAmount > 0 remains
+                // to be addressed because it requires returning the fee to
+                // the payees and not the change output.
+                else {
+                    if (excessFee >= 0) {
+                        break;
+                    }
+                    nFeeRet = nFeeNeeded;
+                }
             }
         }
 


### PR DESCRIPTION
…rune later

This PR is an attempt to solve some of https://github.com/bitcoin/bitcoin/issues/10247 , first and foremost the case:

> // TODO: The case where there is no change output remains
>// to be addressed so we avoid creating too small an output

This is resolved by always assuming a change output exists, and rebalancing that value by the fee excess, and deleting when necessary. The logic is also simpler to me.