### PR TITLE
Get actual path for EUID instead of HOME dir

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -40,6 +40,7 @@
 #include <fcntl.h>
 #include <sys/resource.h>
 #include <sys/stat.h>
+#include <pwd.h>
 
 #else
 
@@ -523,12 +524,9 @@ fs::path GetDefaultDataDir()
     // Windows
     return GetSpecialFolderPath(CSIDL_APPDATA) / "Bitcoin";
 #else
-    fs::path pathRet;
-    char* pszHome = getenv("HOME");
-    if (pszHome == NULL || strlen(pszHome) == 0)
-        pathRet = fs::path("/");
-    else
-        pathRet = fs::path(pszHome);
+    struct passwd *pw_ptr = getpwuid(geteuid());
+    const char *pszHome = pw_ptr? pw_ptr->pw_dir : getenv("HOME"); 
+    fs::path pathRet((pszHome == NULL || *pszHome == 0)? "/" : pszHome);
 #ifdef MAC_OSX
     // Mac
     return pathRet / "Library/Application Support/Bitcoin";


### PR DESCRIPTION
Let 'bitcoind' run by user 'bitcoin' in Linux.
Chown 'bitcoin-cli' to 'bitcoin:root' and set chmod '4750' (u+s flag).
Then every root-privileged user be able to run 'bitcoin-cli' even if 'bitcoind' runs by user 'bitcoin'.
For example: 'bitcoin-cli getinfo' or 'sudo bitcoin-cli getinfo'

We need to patch 'util.cpp' by this pull request to get actual path for EUID instead of HOME dir, when you use 'u+s' flag.