### PR TITLE
Maintain state across GetStrongRandBytes calls

### DIFF
--- a/src/random.cpp
+++ b/src/random.cpp
@@ -32,6 +32,8 @@
 #include <sys/sysctl.h>
 #endif
 
+#include <mutex>
+
 #include <openssl/err.h>
 #include <openssl/rand.h>
 
@@ -192,6 +194,10 @@ void GetRandBytes(unsigned char* buf, int num)
     }
 }
 
+static std::mutex cs_rng_state;
+static unsigned char rng_state[32] = {0};
+static uint64_t rng_counter = 0;
+
 void GetStrongRandBytes(unsigned char* out, int num)
 {
     assert(num <= 32);
@@ -207,8 +213,17 @@ void GetStrongRandBytes(unsigned char* out, int num)
     GetOSRand(buf);
     hasher.Write(buf, 32);
 
+    // Combine with and update state
+    {
+        std::unique_lock<std::mutex> lock(cs_rng_state);
+        hasher.Write(rng_state, sizeof(rng_state));
+        hasher.Write((const unsigned char*)&rng_counter, sizeof(rng_counter));
+        ++rng_counter;
+        hasher.Finalize(buf);
+        memcpy(rng_state, buf + 32, 32);
+    }
+
     // Produce output
-    hasher.Finalize(buf);
     memcpy(out, buf, num);
     memory_cleanse(buf, 64);
 }


### PR DESCRIPTION
This adds a 32-byte entropy pool that is maintained across calls to GetStrongRandomBytes(). As we're already using SHA512 to combine the multiple entropy sources, which produces 64 bytes, we can use the last 32 of those as an additional input for the next call.

This makes sure that the produced data is secure as long as _any_ entropy source in the past was reliable.

The entropy pool is initialized with zeroes (but not used before any OS and OpenSSL entropy are fed into it). In the future a more extensive seeding operation can be used to build the initial pool.