### PR TITLE
Add harmless missing cs_wallet lock in qt CoinControlDialog

### DIFF
--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -575,7 +575,7 @@ bool WalletModel::getPrivKey(const CKeyID &address, CKey& vchPrivKeyOut) const
 // returns a list of COutputs from COutPoints
 void WalletModel::getOutputs(const std::vector<COutPoint>& vOutpoints, std::vector<COutput>& vOutputs)
 {
-    LOCK2(cs_main, wallet->cs_wallet);
+    AssertLockHeld(wallet->cs_wallet); // Have to hold cs_wallet as we return pointers into mapWallet
     BOOST_FOREACH(const COutPoint& outpoint, vOutpoints)
     {
         if (!wallet->mapWallet.count(outpoint.hash)) continue;
@@ -595,10 +595,11 @@ bool WalletModel::isSpent(const COutPoint& outpoint) const
 // AvailableCoins + LockedCoins grouped by wallet address (put change in one group with wallet address)
 void WalletModel::listCoins(std::map<QString, std::vector<COutput> >& mapCoins) const
 {
+    AssertLockHeld(wallet->cs_wallet); // Have to hold cs_wallet as we return pointers into mapWallet
+
     std::vector<COutput> vCoins;
     wallet->AvailableCoins(vCoins);
 
-    LOCK2(cs_main, wallet->cs_wallet); // ListLockedCoins, mapWallet
     std::vector<COutPoint> vLockedCoins;
     wallet->ListLockedCoins(vLockedCoins);
 

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -215,8 +215,9 @@ public:
 
     bool getDefaultWalletRbf() const;
 
+    CWallet *wallet; // Used to lock cs_wallet for getOutputs/listCoins
+
 private:
-    CWallet *wallet;
     bool fHaveWatchOnly;
     bool fForceCheckBalanceChanged;
 


### PR DESCRIPTION
This is only barely a missing lock - to tickle it you have to
delete from mapWallet while populating your coin control dialog.
The only way (AFAIK) to do so is to call removeprunedfunds.