### PR TITLE
rpc/wallet: Workaround older UniValue which returns a std::string temporary for get_str

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -729,7 +729,8 @@ UniValue getbalance(const JSONRPCRequest& request)
     if (request.params.size() == 0)
         return  ValueFromAmount(pwallet->GetBalance());
 
-    const std::string* account = request.params[0].get_str() != "*" ? &request.params[0].get_str() : nullptr;
+    const std::string& account_param = request.params[0].get_str();
+    const std::string* account = account_param != "*" ? &account_param : nullptr;
 
     int nMinDepth = 1;
     if (request.params.size() > 1)


### PR DESCRIPTION
Without this, building against UniValue 1.0.2 results in:

```
wallet/rpcwallet.cpp: In function ‘UniValue getbalance(const JSONRPCRequest&)’:
wallet/rpcwallet.cpp:732:98: error: taking address of temporary [-fpermissive]
     const std::string* account = request.params[0].get_str() != "*" ? &request.params[0].get_str() : nullptr;
```