### PR TITLE
[tests] Improve mempool_persist test

### DIFF
--- a/test/functional/mempool_persist.py
+++ b/test/functional/mempool_persist.py
@@ -6,11 +6,11 @@
 
 By default, bitcoind will dump mempool on shutdown and
 then reload it on startup. This can be overridden with
-the -persistmempool=false command line option.
+the -persistmempool=0 command line option.
 
 Test is as follows:
 
-  - start node0, node1 and node2. node1 has -persistmempool=false
+  - start node0, node1 and node2. node1 has -persistmempool=0
   - create 5 transactions on node2 to its own address. Note that these
     are not sent to node0 or node1 addresses because we don't want
     them to be saved in the wallet.
@@ -20,17 +20,19 @@ Test is as follows:
     in its mempool. Shutdown node0. This tests that by default the
     mempool is persistent.
   - startup node1. Verify that its mempool is empty. Shutdown node1.
-    This tests that with -persistmempool=false, the mempool is not
+    This tests that with -persistmempool=0, the mempool is not
     dumped to disk when the node is shut down.
-  - Restart node0 with -persistmempool=false. Verify that its mempool is
-    empty. Shutdown node0. This tests that with -persistmempool=false,
+  - Restart node0 with -persistmempool=0. Verify that its mempool is
+    empty. Shutdown node0. This tests that with -persistmempool=0,
     the mempool is not loaded from disk on start up.
-  - Restart node0 with -persistmempool=true. Verify that it has 5
-    transactions in its mempool. This tests that -persistmempool=false
+  - Restart node0 with -persistmempool. Verify that it has 5
+    transactions in its mempool. This tests that -persistmempool=0
     does not overwrite a previously valid mempool stored on disk.
 
 """
+import time
 
+from test_framework.mininode import wait_until
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
 
@@ -38,18 +40,10 @@ class MempoolPersistTest(BitcoinTestFramework):
 
     def __init__(self):
         super().__init__()
+        # We need 3 nodes for this test. Node1 does not have a persistent mempool.
         self.num_nodes = 3
         self.setup_clean_chain = False
-
-    def setup_network(self):
-        # We need 3 nodes for this test. Node1 does not have a persistent mempool.
-        self.nodes = []
-        self.nodes.append(start_node(0, self.options.tmpdir))
-        self.nodes.append(start_node(1, self.options.tmpdir, ["-persistmempool=false"]))
-        self.nodes.append(start_node(2, self.options.tmpdir))
-        connect_nodes_bi(self.nodes, 0, 2)
-        connect_nodes_bi(self.nodes, 1, 2)
-        self.is_network_split = False
+        self.extra_args = [[], ["-persistmempool=0"], []]
 
     def run_test(self):
         chain_height = self.nodes[0].getblockcount()
@@ -57,6 +51,7 @@ class MempoolPersistTest(BitcoinTestFramework):
 
         self.log.debug("Mine a single block to get out of IBD")
         self.nodes[0].generate(1)
+        self.sync_all()
 
         self.log.debug("Send 5 transactions from node2 (to its own address)")
         for i in range(5):
@@ -72,20 +67,24 @@ class MempoolPersistTest(BitcoinTestFramework):
         self.nodes = []
         self.nodes.append(start_node(0, self.options.tmpdir))
         self.nodes.append(start_node(1, self.options.tmpdir))
-        assert_equal(len(self.nodes[0].getrawmempool()), 5)
+        # Give bitcoind a second to reload the mempool
+        time.sleep(1)
+        assert wait_until(lambda: len(self.nodes[0].getrawmempool()) == 5)
         assert_equal(len(self.nodes[1].getrawmempool()), 0)
 
-        self.log.debug("Stop-start node0 with -persistmempool=false. Verify that it doesn't load its mempool.dat file.")
+        self.log.debug("Stop-start node0 with -persistmempool=0. Verify that it doesn't load its mempool.dat file.")
         stop_nodes(self.nodes)
         self.nodes = []
-        self.nodes.append(start_node(0, self.options.tmpdir, ["-persistmempool=false"]))
+        self.nodes.append(start_node(0, self.options.tmpdir, ["-persistmempool=0"]))
+        # Give bitcoind a second to reload the mempool
+        time.sleep(1)
         assert_equal(len(self.nodes[0].getrawmempool()), 0)
 
         self.log.debug("Stop-start node0. Verify that it has the transactions in its mempool.")
         stop_nodes(self.nodes)
         self.nodes = []
         self.nodes.append(start_node(0, self.options.tmpdir))
-        assert_equal(len(self.nodes[0].getrawmempool()), 5)
+        assert wait_until(lambda: len(self.nodes[0].getrawmempool()) == 5)
 
 if __name__ == '__main__':
     MempoolPersistTest().main()


### PR DESCRIPTION
mempool_persist.py was failing very intermittently because after starting the node, there was a race between calling getrawmempool and the mempool being reloaded by a background thread.

This PR removes that raciness in the test. It also removes the is_network_split parameter and tidies up the start of the test (this test was written between #10198 being opened and merged)