### PR TITLE
Remove redundant on-the-same-line-repetition of type names (DRY): RepeatedTypeName foo = static_cast<RepeatedTypeName>(bar)

### DIFF
--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -156,7 +156,7 @@ const char *http_errorstring(int code)
 
 static void http_request_done(struct evhttp_request *req, void *ctx)
 {
-    HTTPReply *reply = static_cast<HTTPReply*>(ctx);
+    auto *reply = static_cast<HTTPReply*>(ctx);
 
     if (req == NULL) {
         /* If req is NULL, it means an error occurred while connecting: the
@@ -182,7 +182,7 @@ static void http_request_done(struct evhttp_request *req, void *ctx)
 #if LIBEVENT_VERSION_NUMBER >= 0x02010300
 static void http_error_cb(enum evhttp_request_error err, void *ctx)
 {
-    HTTPReply *reply = static_cast<HTTPReply*>(ctx);
+    auto *reply = static_cast<HTTPReply*>(ctx);
     reply->error = err;
 }
 #endif

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -393,7 +393,7 @@ static UniValue GetNetworksInfo()
     UniValue networks(UniValue::VARR);
     for(int n=0; n<NET_MAX; ++n)
     {
-        enum Network network = static_cast<enum Network>(n);
+        auto network = static_cast<enum Network>(n);
         if(network == NET_UNROUTABLE)
             continue;
         proxyType proxy;

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -92,7 +92,7 @@ bool CBlockTreeDB::ReadLastBlockFile(int &nFile) {
 
 CCoinsViewCursor *CCoinsViewDB::Cursor() const
 {
-    CCoinsViewDBCursor *i = new CCoinsViewDBCursor(const_cast<CDBWrapper*>(&db)->NewIterator(), GetBestBlock());
+    auto *i = new CCoinsViewDBCursor(const_cast<CDBWrapper*>(&db)->NewIterator(), GetBestBlock());
     /* It seems that there are no "const iterators" for LevelDB.  Since we
        only need read operations on it, use a const-cast to get around
        that restriction.  */

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3837,7 +3837,7 @@ bool InitBlockIndex(const CChainParams& chainparams)
     // Only add the genesis block if not reindexing (in which case we reuse the one already on disk)
     if (!fReindex) {
         try {
-            CBlock &block = const_cast<CBlock&>(chainparams.GenesisBlock());
+            auto &block = const_cast<CBlock&>(chainparams.GenesisBlock());
             // Start new block file
             unsigned int nBlockSize = ::GetSerializeSize(block, SER_DISK, CLIENT_VERSION);
             CDiskBlockPos blockPos;

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -821,7 +821,7 @@ bool CWalletDB::Recover(const std::string& filename)
 
 bool CWalletDB::RecoverKeysOnlyFilter(void *callbackData, CDataStream ssKey, CDataStream ssValue)
 {
-    CWallet *dummyWallet = reinterpret_cast<CWallet*>(callbackData);
+    auto *dummyWallet = reinterpret_cast<CWallet*>(callbackData);
     CWalletScanState dummyWss;
     std::string strType, strErr;
     bool fReadOK;


### PR DESCRIPTION
Use …

```c++
auto foo = static_cast<NonRepeatedTypeName>(bar);
```

… instead of …

```c++
RepeatedTypeName foo = static_cast<RepeatedTypeName>(bar);
```

See the [C++ Core Guidelines](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#es11-use-auto-to-avoid-redundant-repetition-of-type-names) for a general discussion on the use of `auto` to avoid redundant repetition of type names.