### PR TITLE
Added support for MSG_FILTERED_WITNESS_BLOCK messages.

### DIFF
--- a/src/version.h
+++ b/src/version.h
@@ -9,7 +9,7 @@
  * network protocol versioning
  */
 
-static const int PROTOCOL_VERSION = 70015;
+static const int PROTOCOL_VERSION = 70016;
 
 //! initial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 209;
@@ -41,5 +41,8 @@ static const int SHORT_IDS_BLOCKS_VERSION = 70014;
 
 //! not banning for invalid compact blocks starts with this version
 static const int INVALID_CB_NO_BAN_VERSION = 70015;
+
+//! MSG_FILTERED_MERKLE_BLOCK support starts with this version
+static const int FILTERED_MERKLE_BLOCK_VERSION = 70016;
 
 #endif // BITCOIN_VERSION_H


### PR DESCRIPTION
After much deliberation and a few attempts at other approaches to provide a workable near-term sync mechanism for thin clients that require witness data, I decided to just go with the simplest short-term path with the least amount of complications expecting BIP37 to be completely replaced eventually - hopefully in the not-very-distant future.

I believe the approach of filtering blocks on the client is a simpler and superior approach for most use cases than requiring the server to perform the filtering. I believe @Roasbeef has something written up for this that he's using for lnd. I would love to see that approach used in Bitcoin Core as well.

But given the good likelihood of nearterm SegWit activation on the Bitcoin mainnet, I believe this solution will suffice for all essential use cases of BIP37 for now - and I don't believe it's worth the effort to try to make more complex additions to BIP37 since it will eventually be entirely replaced.

Peers can request MSG_FILTERED_WITNESS_BLOCK and will receive a merkleblock structure with transactions serialized with witnesses. The merkle proof for the witnesses is not supplied. This means that the client cannot verify that the witness data is what's actually in the block. However, the attack vectors here given the actual intended use cases seem extremely slim for several reasons:

1) The witness data contains signatures which the client can still verify. Spoofing the witness would require supplying signatures that still redeem the output, meaning that only parties that can sign for the output could produce false witness data.

2) In order to use BIP37 with any real degree of privacy and security, you need to connect to a trusted node. If this is your setup, adding merkle proofs for witnesses is an unnecessary complication.

3) The foreseen intended use cases here are wallets that support multisignature scripts or scripts with multiple execution paths where you want to be able to check which signatures are provided or which execution path has been taken. In anticipated use cases, there is not much an attacker could gain from a transaction being signed in two different ways - and typically, the attacker would be easily identifiable.