### PR TITLE
removed unused code in INV message

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1552,8 +1552,6 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
 
         uint32_t nFetchFlags = GetFetchFlags(pfrom);
 
-        std::vector<CInv> vToFetch;
-
         for (unsigned int nInv = 0; nInv < vInv.size(); nInv++)
         {
             CInv &inv = vInv[nInv];
@@ -1593,9 +1591,6 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
             // Track requests for our stuff
             GetMainSignals().Inventory(inv.hash);
         }
-
-        if (!vToFetch.empty())
-            connman.PushMessage(pfrom, msgMaker.Make(NetMsgType::GETDATA, vToFetch));
     }
 
 


### PR DESCRIPTION
vToFetch is never used after declaration within the INV message. When checked if not empty,
evaluation is always false. Best case scenario this is optimized by the
compiler, worst case it wastes cpu cycles.  It should be removed either
way.