### PR TITLE
[tests] functional tests should call BitcoinTestFramework start/stop node methods

### DIFF
--- a/test/functional/abandonconflict.py
+++ b/test/functional/abandonconflict.py
@@ -73,8 +73,8 @@ class AbandonConflictTest(BitcoinTestFramework):
 
         # Restart the node with a higher min relay fee so the parent tx is no longer in mempool
         # TODO: redo with eviction
-        stop_node(self.nodes[0],0)
-        self.nodes[0]=start_node(0, self.options.tmpdir, ["-minrelaytxfee=0.0001"])
+        self.stop_node(0)
+        self.nodes[0] = self.start_node(0, self.options.tmpdir, ["-minrelaytxfee=0.0001"])
 
         # Verify txs no longer in either node's mempool
         assert_equal(len(self.nodes[0].getrawmempool()), 0)
@@ -100,8 +100,8 @@ class AbandonConflictTest(BitcoinTestFramework):
         balance = newbalance
 
         # Verify that even with a low min relay fee, the tx is not reaccepted from wallet on startup once abandoned
-        stop_node(self.nodes[0],0)
-        self.nodes[0]=start_node(0, self.options.tmpdir, ["-minrelaytxfee=0.00001"])
+        self.stop_node(0)
+        self.nodes[0] = self.start_node(0, self.options.tmpdir, ["-minrelaytxfee=0.00001"])
         assert_equal(len(self.nodes[0].getrawmempool()), 0)
         assert_equal(self.nodes[0].getbalance(), balance)
 
@@ -120,8 +120,8 @@ class AbandonConflictTest(BitcoinTestFramework):
         balance = newbalance
 
         # Remove using high relay fee again
-        stop_node(self.nodes[0],0)
-        self.nodes[0]=start_node(0, self.options.tmpdir, ["-minrelaytxfee=0.0001"])
+        self.stop_node(0)
+        self.nodes[0] = self.start_node(0, self.options.tmpdir, ["-minrelaytxfee=0.0001"])
         assert_equal(len(self.nodes[0].getrawmempool()), 0)
         newbalance = self.nodes[0].getbalance()
         assert_equal(newbalance, balance - Decimal("24.9996"))

--- a/test/functional/assumevalid.py
+++ b/test/functional/assumevalid.py
@@ -45,7 +45,7 @@ from test_framework.mininode import (CBlockHeader,
                                      msg_headers)
 from test_framework.script import (CScript, OP_TRUE)
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import (start_node, p2p_port, assert_equal)
+from test_framework.util import (p2p_port, assert_equal)
 
 class BaseNode(NodeConnCB):
     def send_header_for_blocks(self, new_blocks):
@@ -63,7 +63,7 @@ class AssumeValidTest(BitcoinTestFramework):
         # Start node0. We don't start the other nodes yet since
         # we need to pre-mine a block with an invalid transaction
         # signature so we can pass in the block hash as assumevalid.
-        self.nodes = [start_node(0, self.options.tmpdir)]
+        self.nodes = [self.start_node(0, self.options.tmpdir)]
 
     def send_blocks_until_disconnected(self, node):
         """Keep sending blocks to the node until we're disconnected."""
@@ -162,14 +162,14 @@ class AssumeValidTest(BitcoinTestFramework):
             height += 1
 
         # Start node1 and node2 with assumevalid so they accept a block with a bad signature.
-        self.nodes.append(start_node(1, self.options.tmpdir,
+        self.nodes.append(self.start_node(1, self.options.tmpdir,
                                      ["-assumevalid=" + hex(block102.sha256)]))
         node1 = BaseNode()  # connects to node1
         connections.append(NodeConn('127.0.0.1', p2p_port(1), self.nodes[1], node1))
         node1.add_connection(connections[1])
         node1.wait_for_verack()
 
-        self.nodes.append(start_node(2, self.options.tmpdir,
+        self.nodes.append(self.start_node(2, self.options.tmpdir,
                                      ["-assumevalid=" + hex(block102.sha256)]))
         node2 = BaseNode()  # connects to node2
         connections.append(NodeConn('127.0.0.1', p2p_port(2), self.nodes[2], node2))

--- a/test/functional/bip9-softforks.py
+++ b/test/functional/bip9-softforks.py
@@ -239,7 +239,7 @@ class BIP9SoftForksTest(ComparisonTestFramework):
 
         # Restart all
         self.test.clear_all_connections()
-        stop_nodes(self.nodes)
+        self.stop_nodes()
         shutil.rmtree(self.options.tmpdir + "/node0")
         self.setup_chain()
         self.setup_network()

--- a/test/functional/blockchain.py
+++ b/test/functional/blockchain.py
@@ -24,7 +24,6 @@ from test_framework.util import (
     assert_raises_jsonrpc,
     assert_is_hex_string,
     assert_is_hash_string,
-    connect_nodes_bi,
 )
 
 

--- a/test/functional/blockchain.py
+++ b/test/functional/blockchain.py
@@ -24,6 +24,7 @@ from test_framework.util import (
     assert_raises_jsonrpc,
     assert_is_hex_string,
     assert_is_hash_string,
+    connect_nodes_bi,
 )
 
 

--- a/test/functional/bumpfee.py
+++ b/test/functional/bumpfee.py
@@ -38,12 +38,12 @@ class BumpFeeTest(BitcoinTestFramework):
     def setup_network(self, split=False):
         extra_args = [["-prematurewitness", "-walletprematurewitness", "-walletrbf={}".format(i)]
                       for i in range(self.num_nodes)]
-        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, extra_args)
+        self.nodes = self.start_nodes(self.num_nodes, self.options.tmpdir, extra_args)
 
         # Encrypt wallet for test_locked_wallet_fails test
         self.nodes[1].encryptwallet(WALLET_PASSPHRASE)
         bitcoind_processes[1].wait()
-        self.nodes[1] = start_node(1, self.options.tmpdir, extra_args[1])
+        self.nodes[1] = self.start_node(1, self.options.tmpdir, extra_args[1])
         self.nodes[1].walletpassphrase(WALLET_PASSPHRASE, WALLET_PASSPHRASE_TIMEOUT)
 
         connect_nodes_bi(self.nodes, 0, 1)

--- a/test/functional/disconnect_ban.py
+++ b/test/functional/disconnect_ban.py
@@ -9,10 +9,7 @@ from test_framework.mininode import wait_until
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (assert_equal,
                                  assert_raises_jsonrpc,
-                                 connect_nodes_bi,
-                                 start_node,
-                                 stop_node,
-                                 )
+                                 connect_nodes_bi)
 
 class DisconnectBanTest(BitcoinTestFramework):
 
@@ -68,9 +65,9 @@ class DisconnectBanTest(BitcoinTestFramework):
         self.nodes[1].setmocktime(old_time + 3)
         assert_equal(len(self.nodes[1].listbanned()), 3)
 
-        stop_node(self.nodes[1], 1)
+        self.stop_node(1)
 
-        self.nodes[1] = start_node(1, self.options.tmpdir)
+        self.nodes[1] = self.start_node(1, self.options.tmpdir)
         listAfterShutdown = self.nodes[1].listbanned()
         assert_equal("127.0.0.0/24", listAfterShutdown[0]['address'])
         assert_equal("127.0.0.0/32", listAfterShutdown[1]['address'])

--- a/test/functional/forknotify.py
+++ b/test/functional/forknotify.py
@@ -21,10 +21,10 @@ class ForkNotifyTest(BitcoinTestFramework):
         self.alert_filename = os.path.join(self.options.tmpdir, "alert.txt")
         with open(self.alert_filename, 'w', encoding='utf8'):
             pass  # Just open then close to create zero-length file
-        self.nodes.append(start_node(0, self.options.tmpdir,
+        self.nodes.append(self.start_node(0, self.options.tmpdir,
                             ["-blockversion=2", "-alertnotify=echo %s >> \"" + self.alert_filename + "\""]))
         # Node1 mines block.version=211 blocks
-        self.nodes.append(start_node(1, self.options.tmpdir,
+        self.nodes.append(self.start_node(1, self.options.tmpdir,
                                 ["-blockversion=211"]))
         connect_nodes(self.nodes[1], 0)
 

--- a/test/functional/fundrawtransaction.py
+++ b/test/functional/fundrawtransaction.py
@@ -448,10 +448,10 @@ class RawTransactionsTest(BitcoinTestFramework):
 
         ############################################################
         # locked wallet test
-        self.nodes[1].encryptwallet("test")
         self.stop_node(0)
         self.stop_node(2)
         self.stop_node(3)
+        self.nodes[1].encryptwallet("test")
         self.nodes.pop(1)
 
         self.nodes = self.start_nodes(self.num_nodes, self.options.tmpdir)

--- a/test/functional/fundrawtransaction.py
+++ b/test/functional/fundrawtransaction.py
@@ -449,12 +449,12 @@ class RawTransactionsTest(BitcoinTestFramework):
         ############################################################
         # locked wallet test
         self.nodes[1].encryptwallet("test")
+        self.stop_node(0)
+        self.stop_node(2)
+        self.stop_node(3)
         self.nodes.pop(1)
-        stop_node(self.nodes[0], 0)
-        stop_node(self.nodes[1], 2)
-        stop_node(self.nodes[2], 3)
 
-        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir)
+        self.nodes = self.start_nodes(self.num_nodes, self.options.tmpdir)
         # This test is not meant to test fee estimation and we'd like
         # to be sure all txs are sent at a consistent desired feerate
         for node in self.nodes:

--- a/test/functional/import-rescan.py
+++ b/test/functional/import-rescan.py
@@ -21,7 +21,7 @@ happened previously.
 
 from test_framework.authproxy import JSONRPCException
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import (start_nodes, connect_nodes, sync_blocks, assert_equal, set_node_times)
+from test_framework.util import (connect_nodes, sync_blocks, assert_equal, set_node_times)
 
 import collections
 import enum
@@ -121,7 +121,7 @@ class ImportRescanTest(BitcoinTestFramework):
             if import_node.prune:
                 extra_args[i] += ["-prune=1"]
 
-        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, extra_args)
+        self.nodes = self.start_nodes(self.num_nodes, self.options.tmpdir, extra_args)
         for i in range(1, self.num_nodes):
             connect_nodes(self.nodes[i], 0)
 

--- a/test/functional/importmulti.py
+++ b/test/functional/importmulti.py
@@ -428,8 +428,8 @@ class ImportMultiTest (BitcoinTestFramework):
 
 
         # restart nodes to check for proper serialization/deserialization of watch only address
-        stop_nodes(self.nodes)
-        self.nodes = start_nodes(2, self.options.tmpdir)
+        self.stop_nodes()
+        self.nodes = self.start_nodes(2, self.options.tmpdir)
         address_assert = self.nodes[1].validateaddress(watchonly_address)
         assert_equal(address_assert['iswatchonly'], True)
         assert_equal(address_assert['ismine'], False)

--- a/test/functional/keypool.py
+++ b/test/functional/keypool.py
@@ -20,7 +20,7 @@ class KeyPoolTest(BitcoinTestFramework):
         nodes[0].encryptwallet('test')
         bitcoind_processes[0].wait()
         # Restart node 0
-        nodes[0] = start_node(0, self.options.tmpdir)
+        nodes[0] = self.start_node(0, self.options.tmpdir)
         # Keep creating keys
         addr = nodes[0].getnewaddress()
         addr_data = nodes[0].validateaddress(addr)

--- a/test/functional/listtransactions.py
+++ b/test/functional/listtransactions.py
@@ -24,7 +24,7 @@ class ListTransactionsTest(BitcoinTestFramework):
     def setup_nodes(self):
         #This test requires mocktime
         enable_mocktime()
-        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir)
+        self.nodes = self.start_nodes(self.num_nodes, self.options.tmpdir)
 
     def run_test(self):
         # Simple send, 0 to 1:

--- a/test/functional/maxuploadtarget.py
+++ b/test/functional/maxuploadtarget.py
@@ -146,8 +146,8 @@ class MaxUploadTest(BitcoinTestFramework):
 
         #stop and start node 0 with 1MB maxuploadtarget, whitelist 127.0.0.1
         self.log.info("Restarting nodes with -whitelist=127.0.0.1")
-        stop_node(self.nodes[0], 0)
-        self.nodes[0] = start_node(0, self.options.tmpdir, ["-whitelist=127.0.0.1", "-maxuploadtarget=1", "-blockmaxsize=999000"])
+        self.stop_node(0)
+        self.nodes[0] = self.start_node(0, self.options.tmpdir, ["-whitelist=127.0.0.1", "-maxuploadtarget=1", "-blockmaxsize=999000"])
 
         #recreate/reconnect a test node
         test_nodes = [TestNode()]

--- a/test/functional/mempool_persist.py
+++ b/test/functional/mempool_persist.py
@@ -63,27 +63,27 @@ class MempoolPersistTest(BitcoinTestFramework):
         assert_equal(len(self.nodes[1].getrawmempool()), 5)
 
         self.log.debug("Stop-start node0 and node1. Verify that node0 has the transactions in its mempool and node1 does not.")
-        stop_nodes(self.nodes)
+        self.stop_nodes()
         self.nodes = []
-        self.nodes.append(start_node(0, self.options.tmpdir))
-        self.nodes.append(start_node(1, self.options.tmpdir))
+        self.nodes.append(self.start_node(0, self.options.tmpdir))
+        self.nodes.append(self.start_node(1, self.options.tmpdir))
         # Give bitcoind a second to reload the mempool
         time.sleep(1)
         assert wait_until(lambda: len(self.nodes[0].getrawmempool()) == 5)
         assert_equal(len(self.nodes[1].getrawmempool()), 0)
 
         self.log.debug("Stop-start node0 with -persistmempool=0. Verify that it doesn't load its mempool.dat file.")
-        stop_nodes(self.nodes)
+        self.stop_nodes()
         self.nodes = []
-        self.nodes.append(start_node(0, self.options.tmpdir, ["-persistmempool=0"]))
+        self.nodes.append(self.start_node(0, self.options.tmpdir, ["-persistmempool=0"]))
         # Give bitcoind a second to reload the mempool
         time.sleep(1)
         assert_equal(len(self.nodes[0].getrawmempool()), 0)
 
         self.log.debug("Stop-start node0. Verify that it has the transactions in its mempool.")
-        stop_nodes(self.nodes)
+        self.stop_nodes()
         self.nodes = []
-        self.nodes.append(start_node(0, self.options.tmpdir))
+        self.nodes.append(self.start_node(0, self.options.tmpdir))
         assert wait_until(lambda: len(self.nodes[0].getrawmempool()) == 5)
 
 if __name__ == '__main__':

--- a/test/functional/net.py
+++ b/test/functional/net.py
@@ -14,7 +14,8 @@ from test_framework.util import (
     assert_equal,
     assert_raises_jsonrpc,
     connect_nodes_bi,
-    p2p_port)
+    p2p_port,
+)
 
 
 class NetTest(BitcoinTestFramework):

--- a/test/functional/net.py
+++ b/test/functional/net.py
@@ -14,8 +14,7 @@ from test_framework.util import (
     assert_equal,
     assert_raises_jsonrpc,
     connect_nodes_bi,
-    p2p_port,
-)
+    p2p_port)
 
 
 class NetTest(BitcoinTestFramework):

--- a/test/functional/p2p-segwit.py
+++ b/test/functional/p2p-segwit.py
@@ -1495,8 +1495,8 @@ class SegWitTest(BitcoinTestFramework):
         sync_blocks(self.nodes)
 
         # Restart with the new binary
-        stop_node(node, node_id)
-        self.nodes[node_id] = start_node(node_id, self.options.tmpdir)
+        self.stop_node(node_id)
+        self.nodes[node_id] = self.start_node(node_id, self.options.tmpdir)
         connect_nodes(self.nodes[0], node_id)
 
         sync_blocks(self.nodes)

--- a/test/functional/p2p-versionbits-warning.py
+++ b/test/functional/p2p-versionbits-warning.py
@@ -108,22 +108,22 @@ class VersionBitsWarningTest(BitcoinTestFramework):
         # is cleared, and restart the node. This should move the versionbit state
         # to ACTIVE.
         self.nodes[0].generate(VB_PERIOD)
-        stop_nodes(self.nodes)
+        self.stop_nodes()
         # Empty out the alert file
         with open(self.alert_filename, 'w', encoding='utf8') as _:
             pass
-        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, self.extra_args)
+        self.nodes = self.start_nodes(self.num_nodes, self.options.tmpdir, self.extra_args)
 
         # Connecting one block should be enough to generate an error.
         self.nodes[0].generate(1)
         assert(WARN_UNKNOWN_RULES_ACTIVE in self.nodes[0].getinfo()["errors"])
         assert(WARN_UNKNOWN_RULES_ACTIVE in self.nodes[0].getmininginfo()["errors"])
         assert(WARN_UNKNOWN_RULES_ACTIVE in self.nodes[0].getnetworkinfo()["warnings"])
-        stop_nodes(self.nodes)
+        self.stop_nodes()
         self.test_versionbits_in_alert_file()
 
         # Test framework expects the node to still be running...
-        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, self.extra_args)
+        self.nodes = self.start_nodes(self.num_nodes, self.options.tmpdir, self.extra_args)
 
 if __name__ == '__main__':
     VersionBitsWarningTest().main()

--- a/test/functional/proxy_test.py
+++ b/test/functional/proxy_test.py
@@ -35,7 +35,6 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     PORT_MIN,
     PORT_RANGE,
-    start_nodes,
     assert_equal,
 )
 from test_framework.netutil import test_ipv6_local
@@ -90,7 +89,7 @@ class ProxyTest(BitcoinTestFramework):
             ]
         if self.have_ipv6:
             args[3] = ['-listen', '-proxy=[%s]:%i' % (self.conf3.addr),'-proxyrandomize=0', '-noonion']
-        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, extra_args=args)
+        self.nodes = self.start_nodes(self.num_nodes, self.options.tmpdir, extra_args=args)
 
     def node_test(self, node, proxies, auth, test_onion=True):
         rv = []

--- a/test/functional/pruning.py
+++ b/test/functional/pruning.py
@@ -98,7 +98,7 @@ class PruneTest(BitcoinTestFramework):
             # Node 2 stays connected, so it hears about the stale blocks and then reorg's when node0 reconnects
             # Stopping node 0 also clears its mempool, so it doesn't have node1's transactions to accidentally mine
             self.stop_node(0)
-            self.nodes[0]=start_node(0, self.options.tmpdir, self.full_node_default_args, timewait=900)
+            self.nodes[0]=self.start_node(0, self.options.tmpdir, self.full_node_default_args, timewait=900)
             # Mine 24 blocks in node 1
             for i in range(24):
                 if j == 0:
@@ -126,7 +126,7 @@ class PruneTest(BitcoinTestFramework):
         # Reboot node 1 to clear its mempool (hopefully make the invalidate faster)
         # Lower the block max size so we don't keep mining all our big mempool transactions (from disconnected blocks)
         self.stop_node(1)
-        self.nodes[1]=start_node(1, self.options.tmpdir, ["-maxreceivebuffer=20000","-blockmaxsize=5000", "-checkblocks=5", "-disablesafemode"], timewait=900)
+        self.nodes[1] = self.start_node(1, self.options.tmpdir, ["-maxreceivebuffer=20000","-blockmaxsize=5000", "-checkblocks=5", "-disablesafemode"], timewait=900)
 
         height = self.nodes[1].getblockcount()
         self.log.info("Current block height: %d" % height)
@@ -149,7 +149,7 @@ class PruneTest(BitcoinTestFramework):
 
         # Reboot node1 to clear those giant tx's from mempool
         self.stop_node(1)
-        self.nodes[1]=start_node(1, self.options.tmpdir, ["-maxreceivebuffer=20000","-blockmaxsize=5000", "-checkblocks=5", "-disablesafemode"], timewait=900)
+        self.nodes[1] = self.start_node(1, self.options.tmpdir, ["-maxreceivebuffer=20000","-blockmaxsize=5000", "-checkblocks=5", "-disablesafemode"], timewait=900)
 
         self.log.info("Generating new longer chain of 300 more blocks")
         self.nodes[1].generate(300)
@@ -227,13 +227,13 @@ class PruneTest(BitcoinTestFramework):
 
     def manual_test(self, node_number, use_timestamp):
         # at this point, node has 995 blocks and has not yet run in prune mode
-        node = self.nodes[node_number] = start_node(node_number, self.options.tmpdir, timewait=900)
+        node = self.nodes[node_number] = self.start_node(node_number, self.options.tmpdir, timewait=900)
         assert_equal(node.getblockcount(), 995)
         assert_raises_jsonrpc(-1, "not in prune mode", node.pruneblockchain, 500)
         self.stop_node(node_number)
 
         # now re-start in manual pruning mode
-        node = self.nodes[node_number] = start_node(node_number, self.options.tmpdir, ["-prune=1"], timewait=900)
+        node = self.nodes[node_number] = self.start_node(node_number, self.options.tmpdir, ["-prune=1"], timewait=900)
         assert_equal(node.getblockcount(), 995)
 
         def height(index):
@@ -307,7 +307,7 @@ class PruneTest(BitcoinTestFramework):
 
         # stop node, start back up with auto-prune at 550MB, make sure still runs
         self.stop_node(node_number)
-        self.nodes[node_number] = start_node(node_number, self.options.tmpdir, ["-prune=550"], timewait=900)
+        self.nodes[node_number] = self.start_node(node_number, self.options.tmpdir, ["-prune=550"], timewait=900)
 
         self.log.info("Success")
 
@@ -315,7 +315,7 @@ class PruneTest(BitcoinTestFramework):
         # check that the pruning node's wallet is still in good shape
         self.log.info("Stop and start pruning node to trigger wallet rescan")
         self.stop_node(2)
-        start_node(2, self.options.tmpdir, ["-prune=550"])
+        self.start_node(2, self.options.tmpdir, ["-prune=550"])
         self.log.info("Success")
 
         # check that wallet loads loads successfully when restarting a pruned node after IBD.
@@ -325,7 +325,7 @@ class PruneTest(BitcoinTestFramework):
         nds = [self.nodes[0], self.nodes[5]]
         sync_blocks(nds, wait=5, timeout=300)
         self.stop_node(5) #stop and start to trigger rescan
-        start_node(5, self.options.tmpdir, ["-prune=550"])
+        self.start_node(5, self.options.tmpdir, ["-prune=550"])
         self.log.info("Success")
 
     def run_test(self):

--- a/test/functional/receivedby.py
+++ b/test/functional/receivedby.py
@@ -32,7 +32,7 @@ class ReceivedByTest(BitcoinTestFramework):
     def setup_nodes(self):
         #This test requires mocktime
         enable_mocktime()
-        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir)
+        self.nodes = self.start_nodes(self.num_nodes, self.options.tmpdir)
 
     def run_test(self):
         '''

--- a/test/functional/reindex.py
+++ b/test/functional/reindex.py
@@ -10,11 +10,7 @@
 """
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import (
-    start_nodes,
-    stop_nodes,
-    assert_equal,
-)
+from test_framework.util import assert_equal
 import time
 
 class ReindexTest(BitcoinTestFramework):
@@ -27,9 +23,9 @@ class ReindexTest(BitcoinTestFramework):
     def reindex(self, justchainstate=False):
         self.nodes[0].generate(3)
         blockcount = self.nodes[0].getblockcount()
-        stop_nodes(self.nodes)
+        self.stop_nodes()
         extra_args = [["-reindex-chainstate" if justchainstate else "-reindex", "-checkblockindex=1"]]
-        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, extra_args)
+        self.nodes = self.start_nodes(self.num_nodes, self.options.tmpdir, extra_args)
         while self.nodes[0].getblockcount() < blockcount:
             time.sleep(0.1)
         assert_equal(self.nodes[0].getblockcount(), blockcount)

--- a/test/functional/rpcbind_test.py
+++ b/test/functional/rpcbind_test.py
@@ -36,10 +36,10 @@ class RPCBindTest(BitcoinTestFramework):
         if allow_ips:
             base_args += ['-rpcallowip=' + x for x in allow_ips]
         binds = ['-rpcbind='+addr for addr in addresses]
-        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, [base_args + binds], connect_to)
+        self.nodes = self.start_nodes(self.num_nodes, self.options.tmpdir, [base_args + binds], connect_to)
         pid = bitcoind_processes[0].pid
         assert_equal(set(get_bind_addrs(pid)), set(expected))
-        stop_nodes(self.nodes)
+        self.stop_nodes()
 
     def run_allowip_test(self, allow_ips, rpchost, rpcport):
         '''
@@ -47,11 +47,11 @@ class RPCBindTest(BitcoinTestFramework):
         at a non-localhost IP.
         '''
         base_args = ['-disablewallet', '-nolisten'] + ['-rpcallowip='+x for x in allow_ips]
-        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, [base_args])
+        self.nodes = self.start_nodes(self.num_nodes, self.options.tmpdir, [base_args])
         # connect to node through non-loopback interface
         node = get_rpc_proxy(rpc_url(0, "%s:%d" % (rpchost, rpcport)), 0)
         node.getnetworkinfo()
-        stop_nodes(self.nodes)
+        self.stop_nodes()
 
     def run_test(self):
         # due to OS-specific network stats queries, this test works only on Linux

--- a/test/functional/smartfees.py
+++ b/test/functional/smartfees.py
@@ -155,7 +155,7 @@ class EstimateFeeTest(BitcoinTestFramework):
         """
         self.nodes = []
         # Use node0 to mine blocks for input splitting
-        self.nodes.append(start_node(0, self.options.tmpdir, ["-maxorphantx=1000",
+        self.nodes.append(self.start_node(0, self.options.tmpdir, ["-maxorphantx=1000",
                                                               "-whitelist=127.0.0.1"]))
 
         self.log.info("This test is time consuming, please be patient")
@@ -191,7 +191,7 @@ class EstimateFeeTest(BitcoinTestFramework):
         # Node1 mines small blocks but that are bigger than the expected transaction rate.
         # NOTE: the CreateNewBlock code starts counting block size at 1,000 bytes,
         # (17k is room enough for 110 or so transactions)
-        self.nodes.append(start_node(1, self.options.tmpdir,
+        self.nodes.append(self.start_node(1, self.options.tmpdir,
                                      ["-blockmaxsize=17000", "-maxorphantx=1000"]))
         connect_nodes(self.nodes[1], 0)
 
@@ -199,7 +199,7 @@ class EstimateFeeTest(BitcoinTestFramework):
         # produces too small blocks (room for only 55 or so transactions)
         node2args = ["-blockmaxsize=8000", "-maxorphantx=1000"]
 
-        self.nodes.append(start_node(2, self.options.tmpdir, node2args))
+        self.nodes.append(self.start_node(2, self.options.tmpdir, node2args))
         connect_nodes(self.nodes[0], 2)
         connect_nodes(self.nodes[2], 1)
 

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -31,10 +31,10 @@ from .util import (
     p2p_port,
     rpc_url,
     set_node_times,
-    start_node,
-    start_nodes,
-    stop_node,
-    stop_nodes,
+    _start_node,
+    _start_nodes,
+    _stop_node,
+    _stop_nodes,
     sync_blocks,
     sync_mempools,
     wait_for_bitcoind_start,
@@ -91,7 +91,7 @@ class BitcoinTestFramework(object):
         extra_args = None
         if hasattr(self, "extra_args"):
             extra_args = self.extra_args
-        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, extra_args)
+        self.nodes = _start_nodes(self.num_nodes, self.options.tmpdir, extra_args)
 
     def run_test(self):
         raise NotImplementedError
@@ -194,16 +194,16 @@ class BitcoinTestFramework(object):
     # Public helper methods. These can be accessed by the subclass test scripts.
 
     def start_node(self, i, dirname, extra_args=None, rpchost=None, timewait=None, binary=None, stderr=None):
-        return start_node(i, dirname, extra_args, rpchost, timewait, binary, stderr)
+        return _start_node(i, dirname, extra_args, rpchost, timewait, binary, stderr)
 
     def start_nodes(self, num_nodes, dirname, extra_args=None, rpchost=None, timewait=None, binary=None):
-        return start_nodes(num_nodes, dirname, extra_args, rpchost, timewait, binary)
+        return _start_nodes(num_nodes, dirname, extra_args, rpchost, timewait, binary)
 
     def stop_node(self, num_node):
-        stop_node(self.nodes[num_node], num_node)
+        _stop_node(self.nodes[num_node], num_node)
 
     def stop_nodes(self):
-        stop_nodes(self.nodes)
+        _stop_nodes(self.nodes)
 
     def split_network(self):
         """

--- a/test/functional/wallet-accounts.py
+++ b/test/functional/wallet-accounts.py
@@ -14,9 +14,7 @@ RPCs tested are:
 """
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import (
-    assert_equal,
-)
+from test_framework.util import assert_equal
 
 class WalletAccountsTest(BitcoinTestFramework):
 

--- a/test/functional/wallet-dump.py
+++ b/test/functional/wallet-dump.py
@@ -5,7 +5,7 @@
 """Test the dumpwallet RPC."""
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import (start_nodes, start_node, assert_equal, bitcoind_processes)
+from test_framework.util import (assert_equal, bitcoind_processes)
 
 
 def read_dump(file_name, addrs, hd_master_addr_old):
@@ -66,7 +66,7 @@ class WalletDumpTest(BitcoinTestFramework):
         # longer than the default 30 seconds due to an expensive
         # CWallet::TopUpKeyPool call, and the encryptwallet RPC made later in
         # the test often takes even longer.
-        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, self.extra_args, timewait=60)
+        self.nodes = self.start_nodes(self.num_nodes, self.options.tmpdir, self.extra_args, timewait=60)
 
     def run_test (self):
         tmpdir = self.options.tmpdir
@@ -93,7 +93,7 @@ class WalletDumpTest(BitcoinTestFramework):
         #encrypt wallet, restart, unlock and dump
         self.nodes[0].encryptwallet('test')
         bitcoind_processes[0].wait()
-        self.nodes[0] = start_node(0, self.options.tmpdir, self.extra_args[0])
+        self.nodes[0] = self.start_node(0, self.options.tmpdir, self.extra_args[0])
         self.nodes[0].walletpassphrase('test', 10)
         # Should be a no-op:
         self.nodes[0].keypoolrefill()

--- a/test/functional/wallet-hd.py
+++ b/test/functional/wallet-hd.py
@@ -6,7 +6,6 @@
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
-    start_node,
     assert_equal,
     connect_nodes_bi,
     assert_start_raises_init_error
@@ -29,7 +28,7 @@ class WalletHDTest(BitcoinTestFramework):
         # Make sure can't switch off usehd after wallet creation
         self.stop_node(1)
         assert_start_raises_init_error(1, self.options.tmpdir, ['-usehd=0'], 'already existing HD wallet')
-        self.nodes[1] = start_node(1, self.options.tmpdir, self.extra_args[1])
+        self.nodes[1] = self.start_node(1, self.options.tmpdir, self.extra_args[1])
         connect_nodes_bi(self.nodes, 0, 1)
 
         # Make sure we use hd, keep masterkeyid
@@ -76,7 +75,7 @@ class WalletHDTest(BitcoinTestFramework):
         self.stop_node(1)
         os.remove(self.options.tmpdir + "/node1/regtest/wallet.dat")
         shutil.copyfile(tmpdir + "/hd.bak", tmpdir + "/node1/regtest/wallet.dat")
-        self.nodes[1] = start_node(1, self.options.tmpdir, self.extra_args[1])
+        self.nodes[1] = self.start_node(1, self.options.tmpdir, self.extra_args[1])
         #connect_nodes_bi(self.nodes, 0, 1)
 
         # Assert that derivation is deterministic
@@ -90,7 +89,7 @@ class WalletHDTest(BitcoinTestFramework):
 
         # Needs rescan
         self.stop_node(1)
-        self.nodes[1] = start_node(1, self.options.tmpdir, self.extra_args[1] + ['-rescan'])
+        self.nodes[1] = self.start_node(1, self.options.tmpdir, self.extra_args[1] + ['-rescan'])
         #connect_nodes_bi(self.nodes, 0, 1)
         assert_equal(self.nodes[1].getbalance(), num_hd_adds + 1)
 

--- a/test/functional/wallet.py
+++ b/test/functional/wallet.py
@@ -21,7 +21,7 @@ class WalletTest(BitcoinTestFramework):
         self.extra_args = [['-usehd={:d}'.format(i%2==0)] for i in range(4)]
 
     def setup_network(self):
-        self.nodes = start_nodes(3, self.options.tmpdir, self.extra_args[:3])
+        self.nodes = self.start_nodes(3, self.options.tmpdir, self.extra_args[:3])
         connect_nodes_bi(self.nodes,0,1)
         connect_nodes_bi(self.nodes,1,2)
         connect_nodes_bi(self.nodes,0,2)
@@ -178,7 +178,7 @@ class WalletTest(BitcoinTestFramework):
         txid2 = self.nodes[1].sendtoaddress(self.nodes[0].getnewaddress(), 1)
         sync_mempools(self.nodes)
 
-        self.nodes.append(start_node(3, self.options.tmpdir, self.extra_args[3]))
+        self.nodes.append(self.start_node(3, self.options.tmpdir, self.extra_args[3]))
         connect_nodes_bi(self.nodes, 0, 3)
         sync_blocks(self.nodes)
 
@@ -221,8 +221,8 @@ class WalletTest(BitcoinTestFramework):
         assert(found)
 
         #do some -walletbroadcast tests
-        stop_nodes(self.nodes)
-        self.nodes = start_nodes(3, self.options.tmpdir, [["-walletbroadcast=0"],["-walletbroadcast=0"],["-walletbroadcast=0"]])
+        self.stop_nodes()
+        self.nodes = self.start_nodes(3, self.options.tmpdir, [["-walletbroadcast=0"],["-walletbroadcast=0"],["-walletbroadcast=0"]])
         connect_nodes_bi(self.nodes,0,1)
         connect_nodes_bi(self.nodes,1,2)
         connect_nodes_bi(self.nodes,0,2)
@@ -246,8 +246,8 @@ class WalletTest(BitcoinTestFramework):
         txIdNotBroadcasted  = self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 2)
 
         #restart the nodes with -walletbroadcast=1
-        stop_nodes(self.nodes)
-        self.nodes = start_nodes(3, self.options.tmpdir)
+        self.stop_nodes()
+        self.nodes = self.start_nodes(3, self.options.tmpdir)
         connect_nodes_bi(self.nodes,0,1)
         connect_nodes_bi(self.nodes,1,2)
         connect_nodes_bi(self.nodes,0,2)
@@ -348,9 +348,9 @@ class WalletTest(BitcoinTestFramework):
         chainlimit = 6
         for m in maintenance:
             self.log.info("check " + m)
-            stop_nodes(self.nodes)
+            self.stop_nodes()
             # set lower ancestor limit for later
-            self.nodes = start_nodes(3, self.options.tmpdir, [[m, "-limitancestorcount="+str(chainlimit)]] * 3)
+            self.nodes = self.start_nodes(3, self.options.tmpdir, [[m, "-limitancestorcount="+str(chainlimit)]] * 3)
             while m == '-reindex' and [block_count] * 3 != [self.nodes[i].getblockcount() for i in range(3)]:
                 # reindex will leave rpc warm up "early"; Wait for it to finish
                 time.sleep(0.1)
@@ -397,8 +397,8 @@ class WalletTest(BitcoinTestFramework):
 
         # Try with walletrejectlongchains
         # Double chain limit but require combining inputs, so we pass SelectCoinsMinConf
-        stop_node(self.nodes[0],0)
-        self.nodes[0] = start_node(0, self.options.tmpdir, ["-walletrejectlongchains", "-limitancestorcount="+str(2*chainlimit)])
+        self.stop_node(0)
+        self.nodes[0] = self.start_node(0, self.options.tmpdir, ["-walletrejectlongchains", "-limitancestorcount="+str(2*chainlimit)])
 
         # wait for loadmempool
         timeout = 10

--- a/test/functional/walletbackup.py
+++ b/test/functional/walletbackup.py
@@ -77,18 +77,18 @@ class WalletBackupTest(BitcoinTestFramework):
 
     # As above, this mirrors the original bash test.
     def start_three(self):
-        self.nodes[0] = start_node(0, self.options.tmpdir)
-        self.nodes[1] = start_node(1, self.options.tmpdir)
-        self.nodes[2] = start_node(2, self.options.tmpdir)
+        self.nodes[0] = self.start_node(0, self.options.tmpdir)
+        self.nodes[1] = self.start_node(1, self.options.tmpdir)
+        self.nodes[2] = self.start_node(2, self.options.tmpdir)
         connect_nodes(self.nodes[0], 3)
         connect_nodes(self.nodes[1], 3)
         connect_nodes(self.nodes[2], 3)
         connect_nodes(self.nodes[2], 0)
 
     def stop_three(self):
-        stop_node(self.nodes[0], 0)
-        stop_node(self.nodes[1], 1)
-        stop_node(self.nodes[2], 2)
+        self.stop_node(0)
+        self.stop_node(1)
+        self.stop_node(2)
 
     def erase_three(self):
         os.remove(self.options.tmpdir + "/node0/regtest/wallet.dat")

--- a/test/functional/zapwallettxes.py
+++ b/test/functional/zapwallettxes.py
@@ -58,18 +58,16 @@ class ZapWalletTXesTest (BitcoinTestFramework):
         assert_equal(tx3['txid'], txid3) #tx3 must be available (unconfirmed)
         
         #restart bitcoind
-        self.nodes[0].stop()
-        bitcoind_processes[0].wait()
-        self.nodes[0] = start_node(0,self.options.tmpdir)
+        self.stop_node(0)
+        self.nodes[0] = self.start_node(0,self.options.tmpdir)
         
         tx3 = self.nodes[0].gettransaction(txid3)
         assert_equal(tx3['txid'], txid3) #tx must be available (unconfirmed)
         
-        self.nodes[0].stop()
-        bitcoind_processes[0].wait()
+        self.stop_node(0)
         
         #restart bitcoind with zapwallettxes
-        self.nodes[0] = start_node(0,self.options.tmpdir, ["-zapwallettxes=1"])
+        self.nodes[0] = self.start_node(0,self.options.tmpdir, ["-zapwallettxes=1"])
         
         assert_raises(JSONRPCException, self.nodes[0].gettransaction, [txid3])
         #there must be a expection because the unconfirmed wallettx0 must be gone by now

--- a/test/functional/zmq_test.py
+++ b/test/functional/zmq_test.py
@@ -42,7 +42,7 @@ class ZMQTest (BitcoinTestFramework):
         self.zmqSubSocket.setsockopt(zmq.SUBSCRIBE, b"hashblock")
         self.zmqSubSocket.setsockopt(zmq.SUBSCRIBE, b"hashtx")
         self.zmqSubSocket.connect("tcp://127.0.0.1:%i" % self.port)
-        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, extra_args=[
+        self.nodes = self.start_nodes(self.num_nodes, self.options.tmpdir, extra_args=[
             ['-zmqpubhashtx=tcp://127.0.0.1:'+str(self.port), '-zmqpubhashblock=tcp://127.0.0.1:'+str(self.port)],
             [],
             [],


### PR DESCRIPTION
Second step towards #10082

This PR changes the individual test cases to call the `BitcoinTestFramework.start_node` and `.stop_node` methods rather than the util.py functions. This is in preparation for moving the start/stop node functionality into BitcoinTestFramework (currently the BitcoinTestFramework start/stop node methods are just wrappers for the util.py functions).

The second commit changes the names of the functions in util.py to mark them as private. This is so no test cases are added/modified to call the functions directly before the next step of #10082 is merged.