### PR TITLE
qa: disablewallet: Check that wallet is really disabled

### DIFF
--- a/test/functional/disablewallet.py
+++ b/test/functional/disablewallet.py
@@ -21,6 +21,8 @@ class DisableWalletTest (BitcoinTestFramework):
         self.extra_args = [["-disablewallet"]]
 
     def run_test (self):
+        # Make sure wallet is really disabled
+        assert_raises_jsonrpc(-32601, 'Method not found', self.nodes[0].getwalletinfo)
         x = self.nodes[0].validateaddress('3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy')
         assert(x['isvalid'] == False)
         x = self.nodes[0].validateaddress('mneYUmWYsuk7kySiURxCi3AGxrAqZxLgPZ')


### PR DESCRIPTION
This test passes on current master even if the wallet is *not* disabled.