### PR TITLE
[tests] increase timeouts in sendheaders test

### DIFF
--- a/test/functional/sendheaders.py
+++ b/test/functional/sendheaders.py
@@ -243,7 +243,7 @@ class SendHeadersTest(BitcoinTestFramework):
             if i == 0:
                 # first request the block
                 test_node.get_data([tip])
-                test_node.wait_for_block(tip, timeout=5)
+                test_node.wait_for_block(tip)
             elif i == 1:
                 # next try requesting header and block
                 test_node.get_headers(locator=[old_tip], hashstop=tip)
@@ -258,7 +258,7 @@ class SendHeadersTest(BitcoinTestFramework):
                 new_block = create_block(tip, create_coinbase(height+1), block_time)
                 new_block.solve()
                 test_node.send_header_for_blocks([new_block])
-                test_node.wait_for_getdata([new_block.sha256], timeout=5)
+                test_node.wait_for_getdata([new_block.sha256])
                 test_node.send_message(msg_block(new_block))
                 test_node.sync_with_ping() # make sure this block is processed
                 inv_node.clear_last_announcement()
@@ -297,18 +297,18 @@ class SendHeadersTest(BitcoinTestFramework):
                 if j == 0:
                     # Announce via inv
                     test_node.send_block_inv(tip)
-                    test_node.wait_for_getheaders(timeout=5)
+                    test_node.wait_for_getheaders()
                     # Should have received a getheaders now
                     test_node.send_header_for_blocks(blocks)
                     # Test that duplicate inv's won't result in duplicate
                     # getdata requests, or duplicate headers announcements
                     [ inv_node.send_block_inv(x.sha256) for x in blocks ]
-                    test_node.wait_for_getdata([x.sha256 for x in blocks], timeout=5)
+                    test_node.wait_for_getdata([x.sha256 for x in blocks])
                     inv_node.sync_with_ping()
                 else:
                     # Announce via headers
                     test_node.send_header_for_blocks(blocks)
-                    test_node.wait_for_getdata([x.sha256 for x in blocks], timeout=5)
+                    test_node.wait_for_getdata([x.sha256 for x in blocks])
                     # Test that duplicate headers won't result in duplicate
                     # getdata requests (the check is further down)
                     inv_node.send_header_for_blocks(blocks)
@@ -495,7 +495,7 @@ class SendHeadersTest(BitcoinTestFramework):
             with mininode_lock:
                 test_node.last_message.pop("getheaders", None)
             test_node.send_header_for_blocks([blocks[1]])
-            test_node.wait_for_getheaders(timeout=1)
+            test_node.wait_for_getheaders()
             test_node.send_header_for_blocks(blocks)
             test_node.wait_for_getdata([x.sha256 for x in blocks])
             [ test_node.send_message(msg_block(x)) for x in blocks ]
@@ -518,7 +518,7 @@ class SendHeadersTest(BitcoinTestFramework):
             with mininode_lock:
                 test_node.last_message.pop("getheaders", None)
             test_node.send_header_for_blocks([blocks[i]])
-            test_node.wait_for_getheaders(timeout=1)
+            test_node.wait_for_getheaders()
 
         # Next header will connect, should re-set our count:
         test_node.send_header_for_blocks([blocks[0]])
@@ -533,7 +533,7 @@ class SendHeadersTest(BitcoinTestFramework):
             with mininode_lock:
                 test_node.last_message.pop("getheaders", None)
             test_node.send_header_for_blocks([blocks[i%len(blocks)]])
-            test_node.wait_for_getheaders(timeout=1)
+            test_node.wait_for_getheaders()
 
         # Eventually this stops working.
         test_node.send_header_for_blocks([blocks[-1]])

--- a/test/functional/test_framework/mininode.py
+++ b/test/functional/test_framework/mininode.py
@@ -1358,6 +1358,8 @@ class msg_reject(object):
 
 # Helper function
 def wait_until(predicate, *, attempts=float('inf'), timeout=float('inf')):
+    if attempts == float('inf') and timeout == float('inf'):
+        timeout = 60
     attempt = 0
     elapsed = 0
 


### PR DESCRIPTION
Increases short timeouts in the sendheaders.py test, which were causing intermittent failure when there was disk i/o contention.

We believe the root cause of this was that bitcoind log writes were excessively slow (up to several seconds) when another test was running in parallel and shutdown the node. The wallet flush on shutdown can block disk i/o for several seconds.

Longer term, it may be worth thinking about changing bitcoind LogPrints to write to a circular buffer and have a background thread write from there to disk. For now, let's just make this test less flakey.

@sdaftuar 