### PR TITLE
[test] Remove all * imports

### DIFF
--- a/test/functional/abandonconflict.py
+++ b/test/functional/abandonconflict.py
@@ -11,7 +11,14 @@
  no effect on transactions which are already conflicted or abandoned.
 """
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+from test_framework.util import (
+    assert_equal,
+    connect_nodes,
+    Decimal,
+    disconnect_nodes,
+    sync_blocks,
+    sync_mempools,
+)
 
 class AbandonConflictTest(BitcoinTestFramework):
     def __init__(self):

--- a/test/functional/bip65-cltv-p2p.py
+++ b/test/functional/bip65-cltv-p2p.py
@@ -17,7 +17,7 @@ Mine 1 old version block, see that the node rejects.
 """
 
 from test_framework.test_framework import ComparisonTestFramework
-from test_framework.util import *
+from test_framework.util import hex_str_to_bytes
 from test_framework.mininode import CTransaction, NetworkThread
 from test_framework.blocktools import create_coinbase, create_block
 from test_framework.comptool import TestInstance, TestManager

--- a/test/functional/bip65-cltv.py
+++ b/test/functional/bip65-cltv.py
@@ -5,7 +5,7 @@
 """Test the CHECKLOCKTIMEVERIFY (BIP65) soft-fork logic."""
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+from test_framework.util import assert_raises_jsonrpc, connect_nodes
 
 class BIP65Test(BitcoinTestFramework):
     def __init__(self):

--- a/test/functional/bip68-112-113-p2p.py
+++ b/test/functional/bip68-112-113-p2p.py
@@ -44,11 +44,20 @@ bip112tx_special - test negative argument to OP_CSV
 """
 
 from test_framework.test_framework import ComparisonTestFramework
-from test_framework.util import *
+from test_framework.util import (
+    assert_equal,
+    Decimal,
+    get_bip9_status,
+    hex_str_to_bytes,
+)
 from test_framework.mininode import ToHex, CTransaction, NetworkThread
 from test_framework.blocktools import create_coinbase, create_block
 from test_framework.comptool import TestInstance, TestManager
-from test_framework.script import *
+from test_framework.script import (
+    CScript,
+    OP_CHECKSEQUENCEVERIFY,
+    OP_DROP,
+)
 from io import BytesIO
 import time
 

--- a/test/functional/bip68-sequence.py
+++ b/test/functional/bip68-sequence.py
@@ -4,9 +4,27 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test BIP68 implementation."""
 
+import time
+
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
-from test_framework.blocktools import *
+from test_framework.util import (
+    assert_equal,
+    assert_raises_jsonrpc,
+    sync_blocks,
+    get_bip9_status,
+    satoshi_round,
+)
+from test_framework.blocktools import create_block, create_coinbase
+from test_framework.script import CScript
+from test_framework.mininode import (
+    COIN,
+    COutPoint,
+    CTransaction,
+    CTxIn,
+    CTxOut,
+    FromHex,
+    ToHex,
+)
 
 SEQUENCE_LOCKTIME_DISABLE_FLAG = (1<<31)
 SEQUENCE_LOCKTIME_TYPE_FLAG = (1<<22) # this means use time (0 means height)

--- a/test/functional/bip9-softforks.py
+++ b/test/functional/bip9-softforks.py
@@ -21,7 +21,13 @@ import time
 import itertools
 
 from test_framework.test_framework import ComparisonTestFramework
-from test_framework.util import *
+from test_framework.util import (
+    assert_equal,
+    bytes_to_hex_str,
+    hex_str_to_bytes,
+    shutil,
+    stop_nodes,
+)
 from test_framework.mininode import CTransaction, NetworkThread
 from test_framework.blocktools import create_coinbase, create_block
 from test_framework.comptool import TestInstance, TestManager

--- a/test/functional/bipdersig-p2p.py
+++ b/test/functional/bipdersig-p2p.py
@@ -17,7 +17,7 @@ Mine 1 old version block, see that the node rejects.
 """
 
 from test_framework.test_framework import ComparisonTestFramework
-from test_framework.util import *
+from test_framework.util import hex_str_to_bytes
 from test_framework.mininode import CTransaction, NetworkThread
 from test_framework.blocktools import create_coinbase, create_block
 from test_framework.comptool import TestInstance, TestManager

--- a/test/functional/bipdersig.py
+++ b/test/functional/bipdersig.py
@@ -5,7 +5,7 @@
 """Test the BIP66 changeover logic."""
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+from test_framework.util import assert_raises_jsonrpc, connect_nodes
 
 class BIP66Test(BitcoinTestFramework):
     def __init__(self):

--- a/test/functional/bumpfee.py
+++ b/test/functional/bumpfee.py
@@ -18,7 +18,16 @@ from segwit import send_to_witness
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework import blocktools
 from test_framework.mininode import CTransaction
-from test_framework.util import *
+from test_framework.util import (
+    assert_equal,
+    assert_greater_than,
+    assert_raises_jsonrpc,
+    bytes_to_hex_str,
+    connect_nodes_bi,
+    hex_str_to_bytes,
+    sync_mempools,
+)
+from decimal import Decimal
 
 import io
 

--- a/test/functional/decodescript.py
+++ b/test/functional/decodescript.py
@@ -5,8 +5,12 @@
 """Test decoding scripts via decodescript RPC command."""
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
-from test_framework.mininode import *
+from test_framework.util import (
+    assert_equal,
+    bytes_to_hex_str,
+    hex_str_to_bytes,
+)
+from test_framework.mininode import CTransaction
 from io import BytesIO
 
 class DecodeScriptTest(BitcoinTestFramework):

--- a/test/functional/disablewallet.py
+++ b/test/functional/disablewallet.py
@@ -9,7 +9,7 @@
 """
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+from test_framework.util import assert_raises_jsonrpc
 
 
 class DisableWalletTest (BitcoinTestFramework):

--- a/test/functional/forknotify.py
+++ b/test/functional/forknotify.py
@@ -7,7 +7,7 @@ import os
 import time
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+from test_framework.util import connect_nodes
 
 class ForkNotifyTest(BitcoinTestFramework):
 

--- a/test/functional/fundrawtransaction.py
+++ b/test/functional/fundrawtransaction.py
@@ -5,7 +5,16 @@
 """Test the fundrawtransaction RPC."""
 
 from test_framework.test_framework import BitcoinTestFramework, BITCOIND_PROC_WAIT_TIMEOUT
-from test_framework.util import *
+from test_framework.util import (
+    assert_equal,
+    assert_fee_amount,
+    assert_greater_than,
+    assert_greater_than_or_equal,
+    assert_raises_jsonrpc,
+    connect_nodes_bi,
+    count_bytes,
+)
+from decimal import Decimal
 
 
 def get_unspent(listunspent, amount):

--- a/test/functional/getblocktemplate_longpoll.py
+++ b/test/functional/getblocktemplate_longpoll.py
@@ -5,7 +5,8 @@
 """Test longpolling with getblocktemplate."""
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+from test_framework.util import get_rpc_proxy, random_transaction
+from decimal import Decimal
 
 import threading
 

--- a/test/functional/httpbasics.py
+++ b/test/functional/httpbasics.py
@@ -5,7 +5,7 @@
 """Test the RPC HTTP basics."""
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+from test_framework.util import assert_equal, str_to_b64str
 
 import http.client
 import urllib.parse

--- a/test/functional/importmulti.py
+++ b/test/functional/importmulti.py
@@ -4,7 +4,12 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test the importmulti RPC."""
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+from test_framework.util import (
+    assert_equal,
+    assert_greater_than,
+    assert_raises_message,
+)
+from test_framework.authproxy import JSONRPCException
 
 class ImportMultiTest (BitcoinTestFramework):
     def __init__(self):

--- a/test/functional/importprunedfunds.py
+++ b/test/functional/importprunedfunds.py
@@ -4,7 +4,8 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test the importprunedfunds and removeprunedfunds RPCs."""
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+from test_framework.util import assert_equal, assert_raises_jsonrpc
+from decimal import Decimal
 
 
 class ImportPrunedFundsTest(BitcoinTestFramework):

--- a/test/functional/invalidateblock.py
+++ b/test/functional/invalidateblock.py
@@ -4,8 +4,10 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test the invalidateblock RPC."""
 
+import time
+
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+from test_framework.util import assert_equal, connect_nodes_bi, sync_blocks
 
 class InvalidateTest(BitcoinTestFramework):
 

--- a/test/functional/invalidblockrequest.py
+++ b/test/functional/invalidblockrequest.py
@@ -12,9 +12,10 @@ re-requested.
 """
 
 from test_framework.test_framework import ComparisonTestFramework
-from test_framework.util import *
+from test_framework.util import assert_equal
 from test_framework.comptool import TestManager, TestInstance, RejectResult
-from test_framework.blocktools import *
+from test_framework.blocktools import create_block, create_coinbase, create_transaction
+from test_framework.mininode import COIN, NetworkThread
 import copy
 import time
 

--- a/test/functional/invalidtxrequest.py
+++ b/test/functional/invalidtxrequest.py
@@ -9,7 +9,8 @@ In this test we connect to one node over p2p, and test tx requests.
 
 from test_framework.test_framework import ComparisonTestFramework
 from test_framework.comptool import TestManager, TestInstance, RejectResult
-from test_framework.blocktools import *
+from test_framework.blocktools import create_block, create_coinbase, create_transaction
+from test_framework.mininode import COIN, NetworkThread
 import time
 
 

--- a/test/functional/keypool.py
+++ b/test/functional/keypool.py
@@ -4,8 +4,13 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test the wallet keypool and interaction with wallet encryption/locking."""
 
+import time
+
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+from test_framework.util import (
+    assert_equal,
+    assert_raises_jsonrpc,
+)
 
 class KeyPoolTest(BitcoinTestFramework):
 

--- a/test/functional/listtransactions.py
+++ b/test/functional/listtransactions.py
@@ -5,9 +5,16 @@
 """Test the listtransactions API."""
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+from test_framework.util import (
+    assert_array_result,
+    assert_equal,
+    bytes_to_hex_str,
+    hex_str_to_bytes,
+    sync_mempools,
+)
 from test_framework.mininode import CTransaction, COIN
 from io import BytesIO
+from decimal import Decimal
 
 def txFromHex(hexstring):
     tx = CTransaction()

--- a/test/functional/maxuploadtarget.py
+++ b/test/functional/maxuploadtarget.py
@@ -13,9 +13,19 @@ if uploadtarget has been reached.
 from collections import defaultdict
 import time
 
-from test_framework.mininode import *
+from test_framework.mininode import (
+    CInv,
+    msg_getdata,
+    NetworkThread,
+    NodeConn,
+    NodeConnCB,
+)
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+from test_framework.util import (
+    assert_equal,
+    mine_large_block,
+    p2p_port,
+)
 
 class TestNode(NodeConnCB):
     def __init__(self):

--- a/test/functional/mempool_limit.py
+++ b/test/functional/mempool_limit.py
@@ -5,7 +5,7 @@
 """Test mempool limiting together/eviction with the wallet."""
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+from test_framework.util import create_confirmed_utxos, create_lots_of_big_transactions, gen_return_txouts
 
 class MempoolLimitTest(BitcoinTestFramework):
 

--- a/test/functional/mempool_packages.py
+++ b/test/functional/mempool_packages.py
@@ -5,8 +5,15 @@
 """Test descendant package tracking code."""
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+from test_framework.util import (
+    assert_equal,
+    assert_raises_jsonrpc,
+    satoshi_round,
+    sync_blocks,
+    sync_mempools,
+)
 from test_framework.mininode import COIN
+from decimal import Decimal
 
 MAX_ANCESTORS = 25
 MAX_DESCENDANTS = 25

--- a/test/functional/mempool_persist.py
+++ b/test/functional/mempool_persist.py
@@ -34,7 +34,8 @@ import time
 
 from test_framework.mininode import wait_until
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+from test_framework.util import assert_equal, connect_nodes_bi
+from decimal import Decimal
 
 class MempoolPersistTest(BitcoinTestFramework):
 

--- a/test/functional/mempool_reorg.py
+++ b/test/functional/mempool_reorg.py
@@ -9,7 +9,7 @@ that spend (directly or indirectly) coinbase transactions.
 """
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+from test_framework.util import assert_equal, assert_raises_jsonrpc, create_tx
 
 # Create one-input, one-output, no-fee transaction:
 class MempoolCoinbaseTest(BitcoinTestFramework):

--- a/test/functional/mempool_resurrect_test.py
+++ b/test/functional/mempool_resurrect_test.py
@@ -5,7 +5,7 @@
 """Test resurrection of mined transactions when the blockchain is re-organized."""
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+from test_framework.util import assert_equal, create_tx
 
 # Create one-input, one-output, no-fee transaction:
 class MempoolCoinbaseTest(BitcoinTestFramework):

--- a/test/functional/mempool_spendcoinbase.py
+++ b/test/functional/mempool_spendcoinbase.py
@@ -13,7 +13,7 @@ but less mature coinbase spends are NOT.
 """
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+from test_framework.util import assert_equal, assert_raises_jsonrpc, create_tx
 
 # Create one-input, one-output, no-fee transaction:
 class MempoolSpendCoinbaseTest(BitcoinTestFramework):

--- a/test/functional/merkle_blocks.py
+++ b/test/functional/merkle_blocks.py
@@ -5,7 +5,12 @@
 """Test gettxoutproof and verifytxoutproof RPCs."""
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+from test_framework.util import (assert_equal,
+                                 assert_raises,
+                                 assert_raises_jsonrpc,
+                                 connect_nodes,
+                                 JSONRPCException,
+                                 )
 
 class MerkleBlockTest(BitcoinTestFramework):
 

--- a/test/functional/mining.py
+++ b/test/functional/mining.py
@@ -13,7 +13,13 @@ import copy
 from test_framework.blocktools import create_coinbase
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.mininode import CBlock
-from test_framework.util import *
+from test_framework.util import (assert_equal,
+                                 assert_raises_jsonrpc,
+                                 )
+
+from hashlib import sha256
+from struct import pack
+
 
 def b2x(b):
     return b2a_hex(b).decode('ascii')

--- a/test/functional/nulldummy.py
+++ b/test/functional/nulldummy.py
@@ -14,7 +14,7 @@ Generate 427 more blocks.
 """
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+from test_framework.util import assert_equal, assert_raises_jsonrpc, bytes_to_hex_str, hex_str_to_bytes
 from test_framework.mininode import CTransaction, NetworkThread
 from test_framework.blocktools import create_coinbase, create_block, add_witness_commitment
 from test_framework.script import CScript

--- a/test/functional/p2p-acceptblock.py
+++ b/test/functional/p2p-acceptblock.py
@@ -48,9 +48,21 @@ The test:
    Node0 should process and the tip should advance.
 """
 
-from test_framework.mininode import *
+import os
+
+from test_framework.mininode import (
+   CBlockHeader,
+   CInv,
+   mininode_lock,
+   msg_block,
+   msg_headers,
+   msg_inv,
+   NetworkThread,
+   NodeConn,
+   NodeConnCB,
+)
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+from test_framework.util import assert_equal, assert_raises_jsonrpc, p2p_port
 import time
 from test_framework.blocktools import create_block, create_coinbase
 

--- a/test/functional/p2p-compactblocks.py
+++ b/test/functional/p2p-compactblocks.py
@@ -8,11 +8,59 @@ Version 1 compact blocks are pre-segwit (txids)
 Version 2 compact blocks are post-segwit (wtxids)
 """
 
-from test_framework.mininode import *
+import random
+
+from test_framework.mininode import (
+    BlockTransactions,
+    BlockTransactionsRequest,
+    calculate_shortid,
+    CBlock,
+    CBlockHeader,
+    CInv,
+    COutPoint,
+    CTransaction,
+    CTxIn,
+    CTxInWitness,
+    CTxOut,
+    FromHex,
+    HeaderAndShortIDs,
+    msg_block,
+    msg_blocktxn,
+    msg_cmpctblock,
+    msg_getblocktxn,
+    msg_getdata,
+    msg_getheaders,
+    msg_headers,
+    msg_inv,
+    msg_sendcmpct,
+    msg_sendheaders,
+    msg_tx,
+    msg_witness_block,
+    msg_witness_blocktxn,
+    MSG_WITNESS_FLAG,
+    mininode_lock,
+    NetworkThread,
+    NODE_NETWORK,
+    NODE_WITNESS,
+    NodeConn,
+    NodeConnCB,
+    P2PHeaderAndShortIDs,
+    PrefilledTransaction,
+    ser_uint256,
+    ToHex,
+    wait_until,
+)
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+from test_framework.util import (
+    assert_equal,
+    get_bip9_status,
+    p2p_port,
+    satoshi_round,
+    sync_blocks,
+)
 from test_framework.blocktools import create_block, create_coinbase, add_witness_commitment
 from test_framework.script import CScript, OP_TRUE
+from decimal import Decimal
 
 # TestNode: A peer we use to send messages to bitcoind, and store responses.
 class TestNode(NodeConnCB):

--- a/test/functional/p2p-feefilter.py
+++ b/test/functional/p2p-feefilter.py
@@ -4,9 +4,16 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test processing of feefilter messages."""
 
-from test_framework.mininode import *
+from test_framework.mininode import (
+    mininode_lock,
+    msg_feefilter,
+    NetworkThread,
+    NodeConn,
+    NodeConnCB,
+)
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+from test_framework.util import p2p_port, sync_blocks, sync_mempools
+from decimal import Decimal
 import time
 
 

--- a/test/functional/p2p-fullblocktest.py
+++ b/test/functional/p2p-fullblocktest.py
@@ -11,13 +11,54 @@ We use the testing framework in which we expect a particular answer from
 each test.
 """
 
+import copy
+
 from test_framework.test_framework import ComparisonTestFramework
-from test_framework.util import *
+from test_framework.util import assert_equal
 from test_framework.comptool import TestManager, TestInstance, RejectResult
-from test_framework.blocktools import *
+from test_framework.blocktools import (
+    create_block,
+    create_coinbase,
+    create_transaction,
+    get_legacy_sigopcount_block,
+)
 import time
 from test_framework.key import CECKey
-from test_framework.script import *
+from test_framework.script import (
+    CScript,
+    hash160,
+    MAX_SCRIPT_ELEMENT_SIZE,
+    OP_2DUP,
+    OP_CHECKMULTISIG,
+    OP_CHECKMULTISIGVERIFY,
+    OP_CHECKSIG,
+    OP_CHECKSIGVERIFY,
+    OP_ELSE,
+    OP_ENDIF,
+    OP_EQUAL,
+    OP_FALSE,
+    OP_HASH160,
+    OP_IF,
+    OP_INVALIDOPCODE,
+    OP_RETURN,
+    OP_TRUE,
+    SIGHASH_ALL,
+    SignatureHash,
+)
+from test_framework.mininode import (
+    CBlock,
+    CBlockHeader,
+    COIN,
+    COutPoint,
+    CTransaction,
+    CTxIn,
+    CTxOut,
+    MAX_BLOCK_BASE_SIZE,
+    NetworkThread,
+    ser_uint256,
+    uint256_from_compact,
+    uint256_from_str,
+)
 import struct
 
 class PreviousSpendableOutput(object):

--- a/test/functional/p2p-leaktests.py
+++ b/test/functional/p2p-leaktests.py
@@ -11,9 +11,19 @@ This test connects to a node and sends it a few messages, trying to intice it
 into sending us something it shouldn't.
 """
 
-from test_framework.mininode import *
+import time
+
+from test_framework.mininode import (
+    msg_getaddr,
+    msg_ping,
+    msg_verack,
+    NetworkThread,
+    NodeConn,
+    NodeConnCB,
+    wait_until,
+)
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+from test_framework.util import p2p_port
 
 banscore = 10
 

--- a/test/functional/p2p-mempool.py
+++ b/test/functional/p2p-mempool.py
@@ -8,9 +8,9 @@ Test that nodes are disconnected if they send mempool messages when bloom
 filters are not enabled.
 """
 
-from test_framework.mininode import *
+from test_framework.mininode import msg_mempool, NetworkThread, NodeConn, NodeConnCB
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+from test_framework.util import assert_equal, p2p_port
 
 class P2PMempoolTests(BitcoinTestFramework):
 

--- a/test/functional/p2p-segwit.py
+++ b/test/functional/p2p-segwit.py
@@ -4,10 +4,77 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test segwit transactions and blocks on P2P network."""
 
-from test_framework.mininode import *
+import struct
+
+from test_framework.mininode import (
+    CBlock,
+    CBlockHeader,
+    CInv,
+    COutPoint,
+    CTransaction,
+    CTxIn,
+    CTxInWitness,
+    CTxOut,
+    CTxWitness,
+    MAX_BLOCK_BASE_SIZE,
+    mininode_lock,
+    msg_block,
+    msg_getdata,
+    msg_headers,
+    msg_inv,
+    msg_tx,
+    msg_witness_block,
+    MSG_WITNESS_FLAG,
+    msg_witness_tx,
+    NetworkThread,
+    NODE_NETWORK,
+    NODE_WITNESS,
+    NodeConn,
+    NodeConnCB,
+    ser_uint256,
+    ser_vector,
+    sha256,
+    uint256_from_str,
+)
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
-from test_framework.script import *
+from test_framework.util import (
+    assert_equal,
+    bytes_to_hex_str,
+    connect_nodes,
+    get_bip9_status,
+    hex_str_to_bytes,
+    p2p_port,
+    sync_blocks,
+    sync_mempools,
+)
+from test_framework.script import (
+    CScript,
+    CScriptNum,
+    CScriptOp,
+    hash160,
+    OP_0,
+    OP_1,
+    OP_16,
+    OP_2DROP,
+    OP_CHECKMULTISIG,
+    OP_CHECKSIG,
+    OP_DROP,
+    OP_DUP,
+    OP_ELSE,
+    OP_ENDIF,
+    OP_EQUAL,
+    OP_EQUALVERIFY,
+    OP_HASH160,
+    OP_IF,
+    OP_RETURN,
+    OP_TRUE,
+    SegwitVersion1SignatureHash,
+    SIGHASH_ALL,
+    SIGHASH_ANYONECANPAY,
+    SIGHASH_NONE,
+    SIGHASH_SINGLE,
+    SignatureHash,
+)
 from test_framework.blocktools import create_block, create_coinbase, add_witness_commitment, get_witness_script, WITNESS_COMMITMENT_HEADER
 from test_framework.key import CECKey, CPubKey
 import time

--- a/test/functional/p2p-timeouts.py
+++ b/test/functional/p2p-timeouts.py
@@ -23,9 +23,9 @@
 
 from time import sleep
 
-from test_framework.mininode import *
+from test_framework.mininode import msg_ping, NetworkThread, NodeConn, NodeConnCB
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+from test_framework.util import p2p_port
 
 class TestNode(NodeConnCB):
     def on_version(self, conn, message):

--- a/test/functional/p2p-versionbits-warning.py
+++ b/test/functional/p2p-versionbits-warning.py
@@ -8,9 +8,11 @@ Generate chains with block versions that appear to be signalling unknown
 soft-forks, and test that warning alerts are generated.
 """
 
-from test_framework.mininode import *
+import os
+
+from test_framework.mininode import msg_block, NetworkThread, NodeConn, NodeConnCB
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+from test_framework.util import p2p_port
 import re
 from test_framework.blocktools import create_block, create_coinbase
 

--- a/test/functional/prioritise_transaction.py
+++ b/test/functional/prioritise_transaction.py
@@ -5,7 +5,14 @@
 """Test the prioritisetransaction mining RPC."""
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+from test_framework.util import (
+    assert_equal,
+    assert_raises_jsonrpc,
+    create_confirmed_utxos,
+    create_lots_of_big_transactions,
+    gen_return_txouts,
+    time,
+)
 from test_framework.mininode import COIN, MAX_BLOCK_BASE_SIZE
 
 class PrioritiseTransactionTest(BitcoinTestFramework):

--- a/test/functional/pruning.py
+++ b/test/functional/pruning.py
@@ -10,7 +10,13 @@ This test takes 30 mins or more (up to 2 hours)
 """
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+from test_framework.util import (
+    assert_equal,
+    assert_greater_than,
+    assert_raises_jsonrpc,
+    connect_nodes,
+    mine_large_block,
+)
 import time
 import os
 

--- a/test/functional/rawtransactions.py
+++ b/test/functional/rawtransactions.py
@@ -13,7 +13,8 @@ Test the following RPCs:
 """
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+from test_framework.util import assert_equal, assert_raises_jsonrpc, connect_nodes_bi
+from decimal import Decimal
 
 # Create one-input, one-output, no-fee transaction:
 class RawTransactionsTest(BitcoinTestFramework):

--- a/test/functional/receivedby.py
+++ b/test/functional/receivedby.py
@@ -5,7 +5,8 @@
 """Test the listreceivedbyaddress RPC."""
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+from test_framework.util import assert_array_result
+from decimal import Decimal
 
 def get_sub_array_from_array(object_array, to_match):
     '''

--- a/test/functional/replace-by-fee.py
+++ b/test/functional/replace-by-fee.py
@@ -5,9 +5,20 @@
 """Test the RBF code."""
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
-from test_framework.script import *
-from test_framework.mininode import *
+from test_framework.util import (
+    assert_equal,
+    assert_raises_jsonrpc,
+    bytes_to_hex_str,
+    satoshi_round,
+)
+from test_framework.script import CScript
+from test_framework.mininode import (
+    COIN,
+    COutPoint,
+    CTransaction,
+    CTxIn,
+    CTxOut,
+)
 
 MAX_REPLACEMENT_LIMIT = 100
 

--- a/test/functional/rest.py
+++ b/test/functional/rest.py
@@ -4,11 +4,19 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test the REST API."""
 
+import json
+
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
-from struct import *
+from test_framework.util import (
+    assert_equal,
+    assert_greater_than,
+    connect_nodes_bi,
+    hex_str_to_bytes,
+)
+from struct import pack, unpack
 from io import BytesIO
 from codecs import encode
+from decimal import Decimal
 
 import http.client
 import urllib.parse

--- a/test/functional/rpcbind_test.py
+++ b/test/functional/rpcbind_test.py
@@ -8,8 +8,15 @@ import socket
 import sys
 
 from test_framework.test_framework import BitcoinTestFramework, SkipTest
-from test_framework.util import *
-from test_framework.netutil import *
+from test_framework.util import (
+    assert_equal,
+    assert_raises_jsonrpc,
+    get_datadir_path,
+    get_rpc_proxy,
+    rpc_port,
+    rpc_url,
+)
+from test_framework.netutil import addr_to_hex, all_interfaces, get_bind_addrs
 
 
 class RPCBindTest(BitcoinTestFramework):

--- a/test/functional/segwit.py
+++ b/test/functional/segwit.py
@@ -5,11 +5,20 @@
 """Test the SegWit changeover logic."""
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+from test_framework.util import (
+    assert_equal,
+    assert_raises_jsonrpc,
+    bytes_to_hex_str,
+    connect_nodes,
+    hex_str_to_bytes,
+    JSONRPCException,
+    sync_blocks,
+)
 from test_framework.mininode import sha256, CTransaction, CTxIn, COutPoint, CTxOut, COIN, ToHex, FromHex
 from test_framework.address import script_to_p2sh, key_to_p2pkh
 from test_framework.script import CScript, OP_HASH160, OP_CHECKSIG, OP_0, hash160, OP_EQUAL, OP_DUP, OP_EQUALVERIFY, OP_1, OP_2, OP_CHECKMULTISIG, OP_TRUE
 from io import BytesIO
+from decimal import Decimal
 
 NODE_0 = 0
 NODE_1 = 1

--- a/test/functional/sendheaders.py
+++ b/test/functional/sendheaders.py
@@ -73,9 +73,24 @@ e. Announce one more that doesn't connect.
    Expect: disconnect.
 """
 
-from test_framework.mininode import *
+from test_framework.mininode import (
+    CBlockHeader,
+    CInv,
+    mininode_lock,
+    msg_block,
+    msg_getblocks,
+    msg_getdata,
+    msg_getheaders,
+    msg_headers,
+    msg_inv,
+    msg_sendheaders,
+    NetworkThread,
+    NodeConn,
+    NodeConnCB,
+    wait_until,
+)
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+from test_framework.util import assert_equal, sync_blocks, p2p_port
 from test_framework.blocktools import create_block, create_coinbase
 
 

--- a/test/functional/signrawtransactions.py
+++ b/test/functional/signrawtransactions.py
@@ -5,7 +5,7 @@
 """Test transaction signing using the signrawtransaction RPC."""
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+from test_framework.util import assert_equal, assert_raises, JSONRPCException
 
 
 class SignRawTransactionsTest(BitcoinTestFramework):

--- a/test/functional/smartfees.py
+++ b/test/functional/smartfees.py
@@ -4,10 +4,19 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test fee estimation code."""
 
+import random
+
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+from test_framework.util import (
+    assert_equal,
+    connect_nodes,
+    satoshi_round,
+    sync_blocks,
+    sync_mempools,
+)
 from test_framework.script import CScript, OP_1, OP_DROP, OP_2, OP_HASH160, OP_EQUAL, hash160, OP_TRUE
 from test_framework.mininode import CTransaction, CTxIn, CTxOut, COutPoint, ToHex, COIN
+from decimal import Decimal
 
 # Construct 2 trivial P2SH's and the ScriptSigs that spend them
 # So we can create many transactions without needing to spend

--- a/test/functional/test_framework/blockstore.py
+++ b/test/functional/test_framework/blockstore.py
@@ -4,7 +4,15 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """BlockStore and TxStore helper classes."""
 
-from .mininode import *
+from .mininode import (
+    CBlock,
+    CBlockHeader,
+    CBlockLocator,
+    CTransaction,
+    logging,
+    msg_generic,
+    msg_headers,
+)
 from io import BytesIO
 import dbm.dumb as dbmd
 

--- a/test/functional/test_framework/blocktools.py
+++ b/test/functional/test_framework/blocktools.py
@@ -4,7 +4,19 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Utilities for manipulating blocks and transactions."""
 
-from .mininode import *
+from .mininode import (
+    CBlock,
+    COIN,
+    COutPoint,
+    CTransaction,
+    CTxIn,
+    CTxInWitness,
+    CTxOut,
+    hash256,
+    ser_string,
+    ser_uint256,
+    uint256_from_str,
+)
 from .script import CScript, OP_TRUE, OP_CHECKSIG, OP_RETURN
 
 # Create a block (with regtest difficulty)

--- a/test/functional/test_framework/comptool.py
+++ b/test/functional/test_framework/comptool.py
@@ -17,7 +17,25 @@ TestNode behaves as follows:
     on_getdata: provide blocks via BlockStore
 """
 
-from .mininode import *
+from .mininode import (
+    CBlock,
+    CBlockHeader,
+    CInv,
+    CTransaction,
+    logger,
+    logging,
+    MAX_INV_SZ,
+    mininode_lock,
+    msg_block,
+    msg_getheaders,
+    msg_headers,
+    msg_inv,
+    msg_mempool,
+    msg_ping,
+    NodeConn,
+    NodeConnCB,
+    wait_until,
+)
 from .blockstore import BlockStore, TxStore
 from .util import p2p_port
 

--- a/test/functional/txn_clone.py
+++ b/test/functional/txn_clone.py
@@ -5,7 +5,7 @@
 """Test the wallet accounts properly when there are cloned transactions with malleated scriptsigs."""
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+from test_framework.util import assert_equal, connect_nodes, disconnect_nodes, sync_blocks
 
 class TxnMallTest(BitcoinTestFramework):
 

--- a/test/functional/txn_doublespend.py
+++ b/test/functional/txn_doublespend.py
@@ -5,7 +5,14 @@
 """Test the wallet accounts properly when there is a double-spend conflict."""
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+from test_framework.util import (
+    assert_equal,
+    connect_nodes,
+    disconnect_nodes,
+    find_output,
+    sync_blocks,
+)
+from decimal import Decimal
 
 class TxnMallTest(BitcoinTestFramework):
 

--- a/test/functional/wallet.py
+++ b/test/functional/wallet.py
@@ -3,8 +3,21 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test the wallet."""
+
+import time
+
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+from test_framework.util import (
+    assert_array_result,
+    assert_equal,
+    assert_fee_amount,
+    assert_raises_jsonrpc,
+    connect_nodes_bi,
+    count_bytes,
+    sync_blocks,
+    sync_mempools,
+)
+from decimal import Decimal
 
 class WalletTest(BitcoinTestFramework):
 

--- a/test/functional/walletbackup.py
+++ b/test/functional/walletbackup.py
@@ -33,8 +33,18 @@ and confirm again balances are correct.
 from random import randint
 import shutil
 
+import shutil
+import os
+
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+from test_framework.util import (
+    assert_equal,
+    connect_nodes,
+    sync_blocks,
+    sync_mempools,
+)
+from random import randint
+from decimal import Decimal
 
 class WalletBackupTest(BitcoinTestFramework):
 


### PR DESCRIPTION
Another take at #9876 (I didn't realize it existed, but it's closed and I really do think we should get rid of `import *`s if possible!).

Main difference that I can see: each commit corresponds to one file.

I attempted to pull imported imports out as much as possible, e.g. instead of importing `Decimal` from `util.py`, it is now imported directly from `decimal`. I may have missed some of these.

Options, please advice:
1. Discard this PR as redundant in favor of outcome in discussion in #9876 (`__all__`) -- personally I don't think this approach is ideal, as it breeds bad behavior from example (`import *` *is* considered bad behavior, even if `__all__` makes it more controllable) -- or in favor of reopening #9876.
2. Split into multiple PR's to spread impact out over time, e.g. "`p2p-*`, `mempool_*`, ...".
3. Take as is or squashed in some fashion (`p2p-*`, `mempool_*`, ...)
