### PR TITLE
[WIP] [test] Test abortrescan command.

### DIFF
--- a/test/functional/import-abort-rescan.py
+++ b/test/functional/import-abort-rescan.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test wallet import RPCs.
+
+Test rescan behavior of importprivkey when aborted. The test ensures that:
+1. The abortrescan command indeed stops the rescan process.
+2. Subsequent rescan catches the aborted address UTXO.
+"""
+
+from decimal import Decimal
+import threading # for bg importprivkey
+from time import sleep
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (assert_equal, get_rpc_proxy)
+
+class ImportAbortRescanTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 2
+
+    def run_test(self):
+        # Generate for BTC
+        self.nodes[0].generate(300)
+        self.log.info("Creating blocks with transactions ...")
+        # Make blocks with spam to cause rescan delay
+        for i in range(200):
+            if i % 50 == 0:
+                self.log.info("... %2.f%%", 100.0 / 200.0 * i)
+            addr = self.nodes[0].getnewaddress()
+            for j in range(10):
+                self.nodes[0].sendtoaddress(addr, 0.1)
+            self.nodes[0].generate(1)
+        self.log.info("Sending to shared address ...")
+        addr = self.nodes[0].getnewaddress()
+        privkey = self.nodes[0].dumpprivkey(addr)
+        self.nodes[0].sendtoaddress(addr, 0.123)
+        self.nodes[0].generate(10) # mature tx
+        self.sync_all()
+        balances = [n.getbalance() for n in self.nodes]
+
+        # Import this address in the background ...
+        self.log.info("Importing address in background thread ...")
+        node1ref = get_rpc_proxy(self.nodes[1].url, 1, timeout=600)
+        importthread = threading.Thread(target=node1ref.importprivkey, args=[privkey])
+        importthread.start()
+        # ... then abort rescan; try a bunch until abortres becomes true,
+        # because we will start checking before above thread starts processing
+        self.log.info("Attempting to abort scan ...")
+        for i in range(2000):
+            sleep(0.001)
+            abortres = self.nodes[1].abortrescan()
+            if abortres:
+                break
+        assert abortres, "failed to abort rescan within allotted time"
+        self.log.info("Waiting for import thread to die ...")
+        # import should die soon
+        for i in range(10):
+            sleep(0.1)
+            deadres = not importthread.isAlive()
+            if deadres:
+                break
+
+        assert deadres, "importthread did not die soon enough"
+        # Node 1 should not have gained any balance since the start
+        assert_equal(self.nodes[1].getbalance(), balances[1])
+
+        # Import a different address and let it run
+        self.nodes[1].importprivkey(self.nodes[0].dumpprivkey(self.nodes[0].getnewaddress()))
+        # Expect original privkey to now also be discovered and added to balance
+        assert_equal(self.nodes[1].getbalance(), Decimal("0.123") + Decimal(balances[1]))
+
+if __name__ == "__main__":
+    ImportAbortRescanTest().main()

--- a/test/functional/test_framework/authproxy.py
+++ b/test/functional/test_framework/authproxy.py
@@ -112,6 +112,16 @@ class AuthServiceProxy():
                 return self._get_response()
             else:
                 raise
+        except OSError as e:
+            if e.errno == 42:
+                # EPROTOTYPE - OS X issue: a TCP send syscall while a socket is
+                # not yet connected or is in the process of being torn down.
+                print('errno 42 fix')
+                self.__conn.close()
+                self.__conn.request(method, path, postdata, headers)
+                return self._get_response()
+            else:
+                raise
         except (BrokenPipeError, ConnectionResetError):
             # Python 3.5+ raises BrokenPipeError instead of BadStatusLine when the connection was reset
             # ConnectionResetError happens on FreeBSD with Python 3.4

--- a/test/functional/test_framework/authproxy.py
+++ b/test/functional/test_framework/authproxy.py
@@ -41,6 +41,7 @@ import logging
 import socket
 import time
 import urllib.parse
+from errno import EPROTOTYPE
 
 HTTP_TIMEOUT = 30
 USER_AGENT = "AuthServiceProxy/0.1"
@@ -113,10 +114,10 @@ class AuthServiceProxy():
             else:
                 raise
         except OSError as e:
-            if e.errno == 42:
+            if e.errno == EPROTOTYPE:
                 # EPROTOTYPE - OS X issue: a TCP send syscall while a socket is
                 # not yet connected or is in the process of being torn down.
-                print('errno 42 fix')
+                print('errno EPROTOTYPE fix')
                 self.__conn.close()
                 self.__conn.request(method, path, postdata, headers)
                 return self._get_response()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -141,6 +141,7 @@ EXTENDED_SCRIPTS = [
     'maxuploadtarget.py',
     'mempool_packages.py',
     'dbcrash.py',
+    'import-abort-rescan.py',
     # vv Tests less than 2m vv
     'bip68-sequence.py',
     'getblocktemplate_longpoll.py',


### PR DESCRIPTION
Replaces #10225 as it caused intermittent failures for some users.

Difference: gave up on making a "fast running" test and upped the blockchain size and spam count to avoid the scan finishing before the abort call. Moved test down to extended tests.

Test runs in roughly 2 minutes on my local machine. The blockchain generation part takes roughly 1m20s.

@jnewbery Does this work on your end?