### PR TITLE
[logging] log system time and mock time

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -310,10 +310,14 @@ static std::string LogTimestampStr(const std::string &str, std::atomic_bool *fSt
         return str;
 
     if (*fStartedNewLine) {
-        int64_t nTimeMicros = GetLogTimeMicros();
+        int64_t nTimeMicros = GetTimeMicros();
         strStamped = DateTimeStrFormat("%Y-%m-%d %H:%M:%S", nTimeMicros/1000000);
         if (fLogTimeMicros)
             strStamped += strprintf(".%06d", nTimeMicros%1000000);
+        int64_t mocktime = GetMockTime();
+        if (mocktime) {
+            strStamped += " (mocktime: " + DateTimeStrFormat("%Y-%m-%d %H:%M:%S", mocktime) + ")";
+        }
         strStamped += ' ' + str;
     } else
         strStamped = str;

--- a/src/utiltime.cpp
+++ b/src/utiltime.cpp
@@ -31,6 +31,11 @@ void SetMockTime(int64_t nMockTimeIn)
     nMockTime.store(nMockTimeIn, std::memory_order_relaxed);
 }
 
+int64_t GetMockTime()
+{
+    return nMockTime.load(std::memory_order_relaxed);
+}
+
 int64_t GetTimeMillis()
 {
     int64_t now = (boost::posix_time::microsec_clock::universal_time() -
@@ -50,15 +55,6 @@ int64_t GetTimeMicros()
 int64_t GetSystemTimeInSeconds()
 {
     return GetTimeMicros()/1000000;
-}
-
-/** Return a time useful for the debug log */
-int64_t GetLogTimeMicros()
-{
-    int64_t mocktime = nMockTime.load(std::memory_order_relaxed);
-    if (mocktime) return mocktime*1000000;
-
-    return GetTimeMicros();
 }
 
 void MilliSleep(int64_t n)

--- a/src/utiltime.h
+++ b/src/utiltime.h
@@ -23,8 +23,8 @@ int64_t GetTime();
 int64_t GetTimeMillis();
 int64_t GetTimeMicros();
 int64_t GetSystemTimeInSeconds(); // Like GetTime(), but not mockable
-int64_t GetLogTimeMicros();
 void SetMockTime(int64_t nMockTimeIn);
+int64_t GetMockTime();
 void MilliSleep(int64_t n);
 
 std::string DateTimeStrFormat(const char* pszFormat, int64_t nTime);


### PR DESCRIPTION
Currently, if mocktime is set, the logs will be timestamped with the mocktime instead of the system time. It's often useful to have the system time in the logs (for example, when running an integration test, it's useful to know what bitcoind was doing at system time so you can see how it's interacting with the test framework or other bitcoind nodes).

This PR timestamps the log with the actual system time, and also prints out the mocktime if mocktime is being used.

@sdaftuar 