### PR TITLE
RPC: getblock returns coinbase scriptsig

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -118,6 +118,7 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool tx
     result.push_back(Pair("version", block.nVersion));
     result.push_back(Pair("versionHex", strprintf("%08x", block.nVersion)));
     result.push_back(Pair("merkleroot", block.hashMerkleRoot.GetHex()));
+    result.push_back(Pair("coinbase", HexStr(block.vtx[0]->vin[0].scriptSig)));
     UniValue txs(UniValue::VARR);
     for(const auto& tx : block.vtx)
     {
@@ -705,6 +706,7 @@ UniValue getblock(const JSONRPCRequest& request)
             "  \"version\" : n,         (numeric) The block version\n"
             "  \"versionHex\" : \"00000000\", (string) The block version formatted in hexadecimal\n"
             "  \"merkleroot\" : \"xxxx\", (string) The merkle root\n"
+            "  \"coinbase\"   : \"xxxx\", (string) The scriptSig of the coinbase transaction\n"
             "  \"tx\" : [               (array of string) The transaction ids\n"
             "     \"transactionid\"     (string) The transaction id\n"
             "     ,...\n"


### PR DESCRIPTION
Miners are putting lots of exciting information in coinbase scriptSig's these days... Currently to get that string via RPC two calls are required: first `getblock` to get the list of all transactions in the block, and then `getrawtransaction` with the coinbase transaction hash. Of course this only works if your node is running with `txindex=1`, which is a lot of overhead if all you're interested in is coinbase strings. This PR makes it easy:
```
$ bitcoin-cli getblock 000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f | grep coinbase
  "coinbase": "04ffff001d0104455468652054696d65732030332f4a616e2f32303039204368616e63656c6c6f72206f6e206272696e6b206f66207365636f6e64206261696c6f757420666f722062616e6b73",
$ echo 04ffff001d0104455468652054696d65732030332f4a616e2f32303039204368616e63656c6c6f72206f6e206272696e6b206f66207365636f6e64206261696c6f757420666f722062616e6b73 | xxd -r -p
??EThe Times 03/Jan/2009 Chancellor on brink of second bailout for banks
```