### PR TITLE
[WIP] [wallet] Optional '-avoidreuse' flag which defaults to not reusing addresses in sends

### DIFF
--- a/doc/man/bitcoin-qt.1
+++ b/doc/man/bitcoin-qt.1
@@ -356,6 +356,12 @@ Delete all wallet transactions and only recover those parts of the
 blockchain through \fB\-rescan\fR on startup (1 = keep tx meta data e.g.
 account owner and payment request information, 2 = drop tx meta
 data)
+.HP
+\fB\-avoidreuse\fR
+.IP
+Mark addresses which have been used to fund transactions in the past,
+and avoid reusing these in future funding, except when explicitly
+requested (default: 0)
 .PP
 ZeroMQ notification options:
 .HP

--- a/doc/man/bitcoind.1
+++ b/doc/man/bitcoind.1
@@ -361,6 +361,12 @@ Delete all wallet transactions and only recover those parts of the
 blockchain through \fB\-rescan\fR on startup (1 = keep tx meta data e.g.
 account owner and payment request information, 2 = drop tx meta
 data)
+.HP
+\fB\-avoidreuse\fR
+.IP
+Mark addresses which have been used to fund transactions in the past,
+and avoid reusing these in future funding, except when explicitly
+requested (default: 0)
 .PP
 ZeroMQ notification options:
 .HP

--- a/src/qt/bitcoinstrings.cpp
+++ b/src/qt/bitcoinstrings.cpp
@@ -27,6 +27,15 @@ QT_TRANSLATE_NOOP("bitcoin-core", ""
 "keypool. Please use -upgradewallet=169900 or -upgradewallet with no version "
 "specified."),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
+"Delete all wallet transactions and only recover those parts of the "
+"blockchain through -rescan on startup"),
+QT_TRANSLATE_NOOP("bitcoin-core", ""
+"Mark addresses which have been used to fund transactions in the past, "
+"and avoid reusing these in future funding, except when explicitly requested"),
+QT_TRANSLATE_NOOP("bitcoin-core", ""
+"Discover own IP addresses (default: 1 when listening and no -externalip or -"
+"proxy)"),
+QT_TRANSLATE_NOOP("bitcoin-core", ""
 "Distributed under the MIT software license, see the accompanying file %s or "
 "%s"),
 QT_TRANSLATE_NOOP("bitcoin-core", ""

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -37,6 +37,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "sendtoaddress", 4, "subtractfeefromamount" },
     { "sendtoaddress", 5 , "replaceable" },
     { "sendtoaddress", 6 , "conf_target" },
+    { "sendtoaddress", 8, "allowdirty" },
     { "settxfee", 0, "amount" },
     { "sethdseed", 0, "newkeypool" },
     { "getreceivedbyaddress", 1, "minconf" },

--- a/src/wallet/coincontrol.cpp
+++ b/src/wallet/coincontrol.cpp
@@ -13,6 +13,7 @@ void CCoinControl::SetNull()
     fAllowOtherInputs = false;
     fAllowWatchOnly = false;
     m_avoid_partial_spends = gArgs.GetBoolArg("-avoidpartialspends", DEFAULT_AVOIDPARTIALSPENDS);
+    m_allow_dirty_addresses = false;
     setSelected.clear();
     m_feerate.reset();
     fOverrideFeeRate = false;

--- a/src/wallet/coincontrol.h
+++ b/src/wallet/coincontrol.h
@@ -34,6 +34,8 @@ public:
     boost::optional<bool> m_signal_bip125_rbf;
     //! Avoid partial use of funds sent to a given address
     bool m_avoid_partial_spends;
+    //! Allows inclusion of dirty (previously used) addresses
+    bool m_allow_dirty_addresses;
     //! Fee estimation mode to control arguments to estimateSmartFee
     FeeEstimateMode m_fee_mode;
 

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -55,6 +55,7 @@ void WalletInit::AddWalletOptions() const
 {
     gArgs.AddArg("-addresstype", strprintf("What type of addresses to use (\"legacy\", \"p2sh-segwit\", or \"bech32\", default: \"%s\")", FormatOutputType(DEFAULT_ADDRESS_TYPE)), false, OptionsCategory::WALLET);
     gArgs.AddArg("-avoidpartialspends", strprintf(_("Group outputs by address, selecting all or none, instead of selecting on a per-output basis. Privacy is improved as an address is only used once (unless someone sends to it after spending from it), but may result in slightly higher fees as suboptimal coin selection may result due to the added limitation (default: %u)"), DEFAULT_AVOIDPARTIALSPENDS), false, OptionsCategory::WALLET);
+    gArgs.AddArg("-avoidreuse", "Mark addresses which have been used to fund transactions in the past, and avoid reusing these in future funding, except when explicitly requested " + strprintf(_("(default: %u)"), DEFAULT_AVOIDREUSE), false, OptionsCategory::WALLET);
     gArgs.AddArg("-changetype", "What type of change to use (\"legacy\", \"p2sh-segwit\", or \"bech32\"). Default is same as -addresstype, except when -addresstype=p2sh-segwit a native segwit output is used when sending to a native segwit address)", false, OptionsCategory::WALLET);
     gArgs.AddArg("-disablewallet", "Do not load the wallet and disable wallet RPC calls", false, OptionsCategory::WALLET);
     gArgs.AddArg("-discardfee=<amt>", strprintf("The fee rate (in %s/kB) that indicates your tolerance for discarding change by adding it to the fee (default: %s). "

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -511,9 +511,10 @@ static UniValue sendtoaddress(const JSONRPCRequest& request)
         return NullUniValue;
     }
 
-    if (request.fHelp || request.params.size() < 2 || request.params.size() > 8)
+    if (request.fHelp || request.params.size() < 2 || request.params.size() > 9)
         throw std::runtime_error(
-            "sendtoaddress \"address\" amount ( \"comment\" \"comment_to\" subtractfeefromamount replaceable conf_target \"estimate_mode\")\n"
+            std::string() +
+            "sendtoaddress \"address\" amount ( \"comment\" \"comment_to\" subtractfeefromamount replaceable conf_target \"estimate_mode\" allowdirty )\n"
             "\nSend an amount to a given address.\n"
             + HelpRequiringPassphrase(pwallet) +
             "\nArguments:\n"
@@ -532,12 +533,15 @@ static UniValue sendtoaddress(const JSONRPCRequest& request)
             "       \"UNSET\"\n"
             "       \"ECONOMICAL\"\n"
             "       \"CONSERVATIVE\"\n"
+            "9. allowdirty             (boolean, optional, " + (gArgs.GetBoolArg("-avoidreuse", DEFAULT_AVOIDREUSE) ? std::string("default=") + (DEFAULT_AVOIDREUSE ? "true" : "false") : "unavailable") + ") Allows spending from dirty addresses; addresses are considered\n"
+            "                             dirty if they have previously been used in a transaction.\n"
             "\nResult:\n"
             "\"txid\"                  (string) The transaction id.\n"
             "\nExamples:\n"
             + HelpExampleCli("sendtoaddress", "\"1M72Sfpbz1BPpXFHz9m3CdqATR44Jvaydd\" 0.1")
             + HelpExampleCli("sendtoaddress", "\"1M72Sfpbz1BPpXFHz9m3CdqATR44Jvaydd\" 0.1 \"donation\" \"seans outpost\"")
             + HelpExampleCli("sendtoaddress", "\"1M72Sfpbz1BPpXFHz9m3CdqATR44Jvaydd\" 0.1 \"\" \"\" true")
+            + HelpExampleCli("sendtoaddress", "\"1M72Sfpbz1BPpXFHz9m3CdqATR44Jvaydd\" 0.1 \"\" \"\" false true")
             + HelpExampleRpc("sendtoaddress", "\"1M72Sfpbz1BPpXFHz9m3CdqATR44Jvaydd\", 0.1, \"donation\", \"seans outpost\"")
         );
 
@@ -584,6 +588,9 @@ static UniValue sendtoaddress(const JSONRPCRequest& request)
         }
     }
 
+    coin_control.allow_dirty_addresses = request.params[8].isNull()
+        ? gArgs.GetBoolArg("-avoidreuse", DEFAULT_AVOIDREUSE)
+        : request.params[8].get_bool();
 
     EnsureWalletIsUnlocked(pwallet);
 
@@ -4805,7 +4812,7 @@ static const CRPCCommand commands[] =
     { "wallet",             "loadwallet",                       &loadwallet,                    {"filename"} },
     { "wallet",             "lockunspent",                      &lockunspent,                   {"unlock","transactions"} },
     { "wallet",             "sendmany",                         &sendmany,                      {"fromaccount|dummy","amounts","minconf","comment","subtractfeefrom","replaceable","conf_target","estimate_mode"} },
-    { "wallet",             "sendtoaddress",                    &sendtoaddress,                 {"address","amount","comment","comment_to","subtractfeefromamount","replaceable","conf_target","estimate_mode"} },
+    { "wallet",             "sendtoaddress",                    &sendtoaddress,                 {"address","amount","comment","comment_to","subtractfeefromamount","replaceable","conf_target","estimate_mode","allowdirty"} },
     { "wallet",             "settxfee",                         &settxfee,                      {"amount"} },
     { "wallet",             "signmessage",                      &signmessage,                   {"address","message"} },
     { "wallet",             "signrawtransactionwithwallet",     &signrawtransactionwithwallet,  {"hexstring","prevtxs","sighashtype"} },

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2365,7 +2365,7 @@ void CWallet::AvailableCoins(std::vector<COutput> &vCoins, bool fOnlySafe, const
                 continue;
             }
 
-            if (IsDirty(wtxid, i)) {
+            if ((!coinControl || !coinControl->allow_dirty_addresses) && IsDirty(wtxid, i)) {
                 continue;
             }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1979,6 +1979,7 @@ CAmount CWalletTx::GetImmatureCredit(bool fUseCache) const
 
 CAmount CWalletTx::GetAvailableCredit(bool fUseCache, const isminefilter& filter) const
 {
+    bool allow_dirty_addresses = !gArgs.GetBoolArg("-avoidreuse", DEFAULT_AVOIDREUSE);
     if (pwallet == nullptr)
         return 0;
 
@@ -2005,7 +2006,7 @@ CAmount CWalletTx::GetAvailableCredit(bool fUseCache, const isminefilter& filter
     uint256 hashTx = GetHash();
     for (unsigned int i = 0; i < tx->vout.size(); i++)
     {
-        if (!pwallet->IsSpent(hashTx, i))
+        if (!pwallet->IsSpent(hashTx, i) && (allow_dirty_addresses || !pwallet->IsDirty(hashTx, i)))
         {
             const CTxOut &txout = tx->vout[i];
             nCredit += pwallet->GetCredit(txout, filter);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -64,6 +64,9 @@ static const bool DEFAULT_WALLET_RBF = false;
 static const bool DEFAULT_WALLETBROADCAST = true;
 static const bool DEFAULT_DISABLE_WALLET = false;
 
+//! if set, addresses will be marked dirty once spent from, and will be excluded from future coin selects
+static const bool DEFAULT_AVOIDREUSE = false;
+
 static const int64_t TIMESTAMP_MIN = 0;
 
 class CBlockIndex;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -861,6 +861,9 @@ public:
         std::set<CInputCoin>& setCoinsRet, CAmount& nValueRet, const CoinSelectionParams& coin_selection_params, bool& bnb_used) const;
 
     bool IsSpent(const uint256& hash, unsigned int n) const;
+    bool IsDirty(const uint256& hash, unsigned int n) const;
+    void SetDirtyState(const uint256& hash, unsigned int n, bool dirty);
+
     std::vector<OutputGroup> GroupOutputs(const std::vector<COutput>& outputs, bool single_coin) const;
 
     bool IsLockedCoin(uint256 hash, unsigned int n) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);

--- a/test/functional/avoidreuse.py
+++ b/test/functional/avoidreuse.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test the -avoidreuse config option."""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_raises_rpc_error
+from decimal import Decimal
+
+class AvoidReuseTest(BitcoinTestFramework):
+
+    def set_test_params(self):
+        self.setup_clean_chain = False
+        self.num_nodes = 2
+        self.extra_args = [[], ['-avoidreuse=1']]
+
+    def reset_balance(self, node, discardaddr):
+        '''
+        Throw away all owned coins by the node so it gets a balance of 0.
+        '''
+        balance = node.getbalance()
+        if balance > 0.5:
+            tosend = '%.5f' % (balance - Decimal(0.01))
+            node.sendtoaddress(address=discardaddr, amount=tosend, allowdirty=True)
+
+    def run_test(self):
+        '''
+        Set up initial chain and run tests defined below
+        '''
+
+        self.nodes[0].generate(110)
+        self.sync_all()
+        self.reset_balance(self.nodes[1], self.nodes[0].getnewaddress())
+        self.test_fund_send_fund_send()
+        self.reset_balance(self.nodes[1], self.nodes[0].getnewaddress())
+        self.test_fund_send_fund_senddirty()
+
+    def test_fund_send_fund_send(self):
+        '''
+        Test the simple case where [1] generates a new address A, then
+        [0] sends 10 BTC to A.
+        [1] spends 5 BTC from A. (leaving roughly 4 BTC useable)
+        [0] sends 10 BTC to A again.
+        [1] tries to spend 10 BTC (fails; dirty).
+        [1] tries to spend 4 BTC (succeeds; change address sufficient)
+        '''
+
+        fundaddr = self.nodes[1].getnewaddress()
+        retaddr = self.nodes[0].getnewaddress()
+
+        self.nodes[0].sendtoaddress(fundaddr, 10)
+        self.nodes[0].generate(1)
+        self.sync_all()
+
+        self.nodes[1].sendtoaddress(retaddr, 5)
+        self.sync_all()
+        self.nodes[0].generate(1)
+
+        self.nodes[0].sendtoaddress(fundaddr, 10)
+        self.sync_all()
+        self.nodes[0].generate(1)
+
+        assert_raises_rpc_error(-6, "Insufficient funds", self.nodes[1].sendtoaddress, retaddr, 10)
+
+        self.nodes[1].sendtoaddress(retaddr, 4)
+
+    def test_fund_send_fund_senddirty(self):
+        '''
+        Test the same as above, except send the 10 BTC with the allowdirty flag
+        set. This means the 10 BTC send should succeed, where it fails above.
+        '''
+
+        fundaddr = self.nodes[1].getnewaddress()
+        retaddr = self.nodes[0].getnewaddress()
+
+        self.nodes[0].sendtoaddress(fundaddr, 10)
+        self.nodes[0].generate(1)
+        self.sync_all()
+
+        self.nodes[1].sendtoaddress(retaddr, 5)
+        self.sync_all()
+        self.nodes[0].generate(1)
+
+        self.nodes[0].sendtoaddress(fundaddr, 10)
+        self.sync_all()
+        self.nodes[0].generate(1)
+
+        self.nodes[1].sendtoaddress(address=retaddr, amount=10, allowdirty=True)
+
+if __name__ == '__main__':
+    AvoidReuseTest().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -94,6 +94,7 @@ BASE_SCRIPTS = [
     'rpc_getchaintips.py',
     'interface_rest.py',
     'mempool_spend_coinbase.py',
+    'avoidreuse.py',
     'mempool_reorg.py',
     'mempool_persist.py',
     'wallet_multiwallet.py',


### PR DESCRIPTION
(Note: putting this on hold until #12257 is merged.)

#10065 brings up a privacy issue where a user can send a bunch of near-dust transactions to an address, which would be picked up by the coin select code when the owner funded transactions, connecting multiple transactions and addresses to the same user.

This adds a (by default turned off) flag `-avoidreuse`. When enabled, the wallet will mark any addresses that were used to fund a transaction as "dirty" and will avoid using them in funding additional transactions, unless an "allow dirty" flag is set.

It also adds support to allow dirty addresses in `sendtoaddress`. More tweaks to other RPC commands is necessary but I wanted to keep the PR as small as possible.

Retroactive flagging of dirty addresses can be done by rescanning the chain.