### PR TITLE
[RPC] Add an uptime command that displays the amount of time (in seconds) bitcoind has been running

### DIFF
--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -26,7 +26,6 @@
 
 class CBlockIndex;
 
-static const int64_t nClientStartupTime = GetTime();
 static int64_t nLastHeaderTipUpdateNotification = 0;
 static int64_t nLastBlockTipUpdateNotification = 0;
 
@@ -238,7 +237,7 @@ bool ClientModel::isReleaseVersion() const
 
 QString ClientModel::formatClientStartupTime() const
 {
-    return QDateTime::fromTime_t(nClientStartupTime).toString();
+    return QDateTime::fromTime_t(GetStartupTime()).toString();
 }
 
 QString ClientModel::dataDir() const

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -258,6 +258,22 @@ UniValue stop(const JSONRPCRequest& jsonRequest)
     return "Bitcoin server stopping";
 }
 
+UniValue uptime(const JSONRPCRequest& jsonRequest)
+{
+    if (jsonRequest.fHelp || jsonRequest.params.size() > 1)
+        throw std::runtime_error(
+                "uptime\n"
+                        "\nReturns the total uptime of the server.\n"
+                        "\nResult:\n"
+                        "ttt        (numeric) The number of seconds that the server has been running\n"
+                        "\nExamples:\n"
+                + HelpExampleCli("uptime", "")
+                + HelpExampleRpc("uptime", "")
+        );
+
+    return GetTime() - GetStartupTime();
+}
+
 /**
  * Call Table
  */
@@ -267,6 +283,7 @@ static const CRPCCommand vRPCCommands[] =
     /* Overall control/query calls */
     { "control",            "help",                   &help,                   true,  {"command"}  },
     { "control",            "stop",                   &stop,                   true,  {}  },
+    { "control",            "uptime",                 &uptime,                 true,  {}  },
 };
 
 CRPCTable::CRPCTable()

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -84,6 +84,8 @@
 #include <openssl/rand.h>
 #include <openssl/conf.h>
 
+// Application startup time (used for uptime calculation)
+const int64_t nStartupTime = GetTime();
 
 const char * const BITCOIN_CONF_FILENAME = "bitcoin.conf";
 const char * const BITCOIN_PID_FILENAME = "bitcoind.pid";
@@ -888,4 +890,10 @@ std::string CopyrightHolders(const std::string& strPrefix)
         strCopyrightHolders += "\n" + strPrefix + "The Bitcoin Core developers";
     }
     return strCopyrightHolders;
+}
+
+// Obtain the application startup time (used for uptime calculation)
+int64_t GetStartupTime()
+{
+    return nStartupTime;
 }

--- a/src/util.h
+++ b/src/util.h
@@ -5,7 +5,7 @@
 
 /**
  * Server/client environment: argument handling, config file parsing,
- * logging, thread wrappers
+ * logging, thread wrappers, startup time
  */
 #ifndef BITCOIN_UTIL_H
 #define BITCOIN_UTIL_H
@@ -28,6 +28,9 @@
 #include <vector>
 
 #include <boost/signals2/signal.hpp>
+
+// Application startup time (used for uptime calculation)
+int64_t GetStartupTime();
 
 static const bool DEFAULT_LOGTIMEMICROS = false;
 static const bool DEFAULT_LOGIPS        = false;

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -113,6 +113,7 @@ BASE_SCRIPTS= [
     'listsinceblock.py',
     'p2p-leaktests.py',
     'wallet-encryption.py',
+    'uptime.py',
 ]
 
 EXTENDED_SCRIPTS = [

--- a/test/functional/uptime.py
+++ b/test/functional/uptime.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test the RPC call related to the uptime command.
+
+Test corresponds to code in rpc/server.cpp.
+"""
+
+import time
+
+from test_framework.test_framework import BitcoinTestFramework
+
+
+class UptimeTest(BitcoinTestFramework):
+    def __init__(self):
+        super().__init__()
+
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+
+    def run_test(self):
+        self._test_uptime()
+
+    def _test_uptime(self):
+        wait_time = 10
+        self.nodes[0].setmocktime(int(time.time() + wait_time))
+        assert(self.nodes[0].uptime() >= wait_time)
+
+
+if __name__ == '__main__':
+    UptimeTest().main()


### PR DESCRIPTION
Hello everyone,

I am working on a tool that displays information about a bitcoin node using RPC. One of the parameters I would like to include is the `uptime` of the bitcoin daemon. Currently, as far as I can tell, there is no way of obtaining such information.

After thinking a bit on how to perform this task, I concluded that the easiest way to do it is to check the modification time of the `bitcoind.pid` file. This has the disadvantage that it does not work in Windows because `bitcoind.pid` is not created.

I propose the following solution in this PR and submit it for your review and opinion concerning this new RPC command before I work further on this topic. Do you think this new command makes sense? Please consider it a WIP/PoC as it does not have any error checking or tests.

Here is a sample return from the RPC command:

```
$ ./bitcoin-cli uptime  
{
  "uptime": 696
}
```
and the help function:
```
$bitcoin-cli help uptime  
uptime

Display the uptime of the Bitcoin server.
```

Best regards,
Ricardo Velhote