### PR TITLE
doc: Add logging to FinalizeNode()

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -303,6 +303,7 @@ void FinalizeNode(NodeId nodeid, bool& fUpdateConnectionTime) {
         assert(nPreferredDownload == 0);
         assert(nPeersWithValidatedDownloads == 0);
     }
+    LogPrint(BCLog::NET, "Cleared nodestate for peer=%d\n", nodeid);
 }
 
 // Requires cs_main.


### PR DESCRIPTION
Disconnecting a peer doesn't update the variables that affect p2p logic until `FinalizeNode()` is called, so it's helpful for debugging to have a log message in this function.