### PR TITLE
[tests] Speed up fuzzing by ~200x when using afl-fuzz

### DIFF
--- a/doc/fuzzing.md
+++ b/doc/fuzzing.md
@@ -32,6 +32,13 @@ We disable ccache because we don't want to pollute the ccache with instrumented
 objects, and similarly don't want to use non-instrumented cached objects linked
 in.
 
+The fuzzing can be sped up significantly (~200x) by using `afl-clang-fast` and
+`afl-clang-fast++` in place of `afl-gcc` and `afl-g++` when compiling. When
+compiling using `afl-clang-fast`/`afl-clang-fast++` the resulting
+`test_bitcoin_fuzzy` binary will be instrumented in such a way that the AFL
+features "persistent mode" and "deferred forkserver" can be used. See
+https://github.com/mcarpenter/afl/tree/master/llvm_mode for details.
+
 Preparing fuzzing
 ------------------
 
@@ -63,4 +70,3 @@ $AFLPATH/afl-fuzz -i ${AFLIN} -o ${AFLOUT} -m52 -- test/test_bitcoin_fuzzy
 
 You may have to change a few kernel parameters to test optimally - `afl-fuzz`
 will print an error and suggestion if so.
-

--- a/src/test/test_bitcoin_fuzzy.cpp
+++ b/src/test/test_bitcoin_fuzzy.cpp
@@ -59,9 +59,8 @@ bool read_stdin(std::vector<char> &data) {
     return length==0;
 }
 
-int main(int argc, char **argv)
+int do_fuzz()
 {
-    ECCVerifyHandle globalVerifyHandle;
     std::vector<char> buffer;
     if (!read_stdin(buffer)) return 0;
 
@@ -256,3 +255,23 @@ int main(int argc, char **argv)
     return 0;
 }
 
+int main(int argc, char **argv)
+{
+    ECCVerifyHandle globalVerifyHandle;
+#ifdef __AFL_INIT
+    // Enable AFL deferred forkserver mode. Requires compilation using
+    // afl-clang-fast++. See fuzzing.md for details.
+    __AFL_INIT();
+#endif
+
+#ifdef __AFL_LOOP
+    // Enable AFL persistent mode. Requires compilation using afl-clang-fast++.
+    // See fuzzing.md for details.
+    while (__AFL_LOOP(1000)) {
+        do_fuzz();
+    }
+    return 0;
+#else
+    return do_fuzz();
+#endif
+}


### PR DESCRIPTION
Enable the `afl-clang-fast++` features deferred forkserver (`__AFL_INIT`) and persistent mode (`__AFL_LOOP(1000)`).

Before this patch:

```
$ afl-fuzz -i input -o output -m512 -- src/test/test_bitcoin_fuzzy
[*] Validating target binary...
[!] WARNING: The target binary is pretty slow! See /usr/local/share/doc/afl/perf_tips.txt.
[+] Here are some useful stats:

    Test case count : 1 favored, 0 variable, 1 total
       Bitmap range : 1072 to 1072 bits (average: 1072.00 bits)
        Exec timing : 20.4k to 20.4k us (average: 20.4k us)
…
exec speed : 57.58/sec (slow!)
exec speed : 48.35/sec (slow!)
exec speed : 53.78/sec (slow!)
```

After this patch:

```
$ afl-fuzz -i input -o output -m512 -- src/test/test_bitcoin_fuzzy
[*] Validating target binary...
[+] Persistent mode binary detected.
[+] Deferred forkserver binary detected.
[+] Here are some useful stats:

    Test case count : 1 favored, 0 variable, 1 total
       Bitmap range : 24 to 24 bits (average: 24.00 bits)
        Exec timing : 114 to 114 us (average: 114 us)
…
exec speed : 15.9k/sec
exec speed : 13.1k/sec
exec speed : 15.1k/sec
```

For more fuzzing discussions, see #10364.