### PR TITLE
[trivial] Fix three recently introduced typos

### DIFF
--- a/src/policy/fees.cpp
+++ b/src/policy/fees.cpp
@@ -786,7 +786,7 @@ CFeeRate CBlockPolicyEstimator::estimateSmartFee(int confTarget, int *answerFoun
          * This is necessary to preserve monotonically increasing estimates.
          * For non-conservative estimates we do the same thing for 2*target, but
          * for conservative estimates we want to skip these shorter horizons
-         * checks for 2*target becuase we are taking the max over all time
+         * checks for 2*target because we are taking the max over all time
          * horizons so we already have monotonically increasing estimates and
          * the purpose of conservative estimates is not to let short term
          * fluctuations lower our estimates by too much.

--- a/src/policy/fees.h
+++ b/src/policy/fees.h
@@ -51,7 +51,7 @@ class TxConfirmStats;
  * blocks.  This is is tracked in 3 different data sets each up to a maximum
  * number of periods. Within each data set we have an array of counters in each
  * feerate bucket and we increment all the counters from Y' up to max periods
- * representing that a tx was successfullly confirmed in less than or equal to
+ * representing that a tx was successfully confirmed in less than or equal to
  * that many periods. We want to save a history of this information, so at any
  * time we have a counter of the total number of transactions that happened in a
  * given feerate bucket and the total number that were confirmed in each of the

--- a/src/wallet/feebumper.cpp
+++ b/src/wallet/feebumper.cpp
@@ -255,7 +255,7 @@ bool CFeeBumper::commit(CWallet *pWallet)
     }
     CWalletTx& oldWtx = pWallet->mapWallet[txid];
 
-    // make sure the transaction still has no descendants and hasen't been mined in the meantime
+    // make sure the transaction still has no descendants and hasn't been mined in the meantime
     if (!preconditionChecks(pWallet, oldWtx)) {
         return false;
     }


### PR DESCRIPTION
Typos introduced in 3810e976 and 2d2e1705 which were merged into `master` as part of #10199 twelve hours ago:

```
$ git blame src/policy/fees.cpp | grep becuase
3810e976 (2017-03-07 11:33:44 -0500 789)          * checks for 2*target becuase we are taking the max over all time
$ git blame src/policy/fees.h | grep successfullly
2d2e1705 (2017-04-12 12:29:03 -0400  54)  * representing that a tx was successfullly confirmed in less than or equal to
```

Friendly ping @morcos :-)