### PR TITLE
Add Qt tests for wallet spends & bumpfee

### DIFF
--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -136,10 +136,12 @@ TransactionView::TransactionView(const PlatformStyle *platformStyle, QWidget *pa
     view->installEventFilter(this);
 
     transactionView = view;
+    transactionView->setObjectName("transactionView");
 
     // Actions
     abandonAction = new QAction(tr("Abandon transaction"), this);
     bumpFeeAction = new QAction(tr("Increase transaction fee"), this);
+    bumpFeeAction->setObjectName("bumpFeeAction");
     QAction *copyAddressAction = new QAction(tr("Copy address"), this);
     QAction *copyLabelAction = new QAction(tr("Copy label"), this);
     QAction *copyAmountAction = new QAction(tr("Copy amount"), this);
@@ -150,6 +152,7 @@ TransactionView::TransactionView(const PlatformStyle *platformStyle, QWidget *pa
     QAction *showDetailsAction = new QAction(tr("Show transaction details"), this);
 
     contextMenu = new QMenu(this);
+    contextMenu->setObjectName("contextMenu");
     contextMenu->addAction(copyAddressAction);
     contextMenu->addAction(copyLabelAction);
     contextMenu->addAction(copyAmountAction);
@@ -380,7 +383,7 @@ void TransactionView::contextualMenu(const QPoint &point)
 
     if(index.isValid())
     {
-        contextMenu->exec(QCursor::pos());
+        contextMenu->popup(transactionView->viewport()->mapToGlobal(point));
     }
 }
 
@@ -416,7 +419,7 @@ void TransactionView::bumpFee()
     // Bump tx fee over the walletModel
     if (model->bumpFee(hash)) {
         // Update the table
-        model->getTransactionTableModel()->updateTransaction(hashQStr, CT_UPDATED, false);
+        model->getTransactionTableModel()->updateTransaction(hashQStr, CT_UPDATED, true);
     }
 }
 


### PR DESCRIPTION
A few code changes were needed to accompany the test:

* Adding setObjectName() calls for a few Qt controls to make them easily
  accessible from the test.

* Calling contextMenu->popup() instead of contextMenu->exec() to open
  the transaction list context menu without blocking the test thread.

* Opening the context menu at the contextualMenu event point rather than
  the cursor position (this change was not strictly needed to make the test
  work, but is more correct).

* Updating the bumped transaction row with showTransaction=true instead of
  false. This is needed to prevent the bumped tx from being hidden, so the last
  part of the test which attempts to bump the bumped tx can work. (Technically
  this change is a more general bugfix not limited to the testing environment,
  but the bug doesn't happen outside of the testing environment because in the
  full Qt client, a queued NotifyTransactionChanged notification causes the row
  to be updated twice, first with showTransaction=false, then immediately after
  with showTransaction=true.)