### PR TITLE
[qt] Remove excess logic: Prefer "return foo;" to "if (foo) { return true; } else { return false; }"

### DIFF
--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -702,9 +702,7 @@ bool WalletModel::transactionSignalsRBF(uint256 hash) const
 {
     LOCK2(cs_main, wallet->cs_wallet);
     const CWalletTx *wtx = wallet->GetWalletTx(hash);
-    if (wtx && SignalsOptInRBF(*wtx))
-        return true;
-    return false;
+    return wtx && SignalsOptInRBF(*wtx);
 }
 
 bool WalletModel::bumpFee(uint256 hash)


### PR DESCRIPTION
Replace …

```
if (foo) { return true; } else { return false; }
```

… with the equivalent …

```
return foo;
```

The code was introduced in fbf385cc830df2aec7cdcbab0c2b09b46569e8c1 which was merged into `master` earlier today.

Friendly ping @jonasschnelli :-)