### PR TITLE
Populate services in GetLocalAddress

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -148,7 +148,7 @@ static std::vector<CAddress> convertSeed6(const std::vector<SeedSpec6> &vSeedsIn
 // one by discovery.
 CAddress GetLocalAddress(const CNetAddr *paddrPeer, ServiceFlags nLocalServices)
 {
-    CAddress ret(CService(CNetAddr(),GetListenPort()), NODE_NONE);
+    CAddress ret(CService(CNetAddr(),GetListenPort()), nLocalServices);
     CService addr;
     if (GetLocal(addr, paddrPeer))
     {


### PR DESCRIPTION
Previously if we didn't have any local addresses, GetLocalAddress would return
0.0.0.0 and then we'd swap in a peer's notion of our address in AdvertiseLocal,
but then nServices would never get set.

This would prevent a node behind a NAT from having its nServices set in addr messages gossiped between peers and could lead to no incoming connections.

This should be backported to 0.14 (and 0.13 if we do that)

I can't promise that I've fully understood all the implications here.
