### PR TITLE
tests: fix spurious addrman test failure

### DIFF
--- a/src/test/addrman_tests.cpp
+++ b/src/test/addrman_tests.cpp
@@ -104,10 +104,14 @@ BOOST_AUTO_TEST_CASE(addrman_simple)
 
 
     // Test: New table has one addr and we add a diff addr we should
-    //  have two addrs.
+    //  have at least one addr.
+    // Note that addrman's size cannot be tested reliably after insertion, as
+    // hash collisions may occur. But we can always be sure of at least one
+    // success.
+
     CService addr2 = ResolveService("250.1.1.2", 8333);
     BOOST_CHECK(addrman.Add(CAddress(addr2, NODE_NONE), source));
-    BOOST_CHECK_EQUAL(addrman.size(), 2);
+    BOOST_CHECK(addrman.size() >= 1);
 
     // Test: AddrMan::Clear() should empty the new table.
     addrman.Clear();
@@ -120,7 +124,7 @@ BOOST_AUTO_TEST_CASE(addrman_simple)
     vAddr.push_back(CAddress(ResolveService("250.1.1.3", 8333), NODE_NONE));
     vAddr.push_back(CAddress(ResolveService("250.1.1.4", 8333), NODE_NONE));
     BOOST_CHECK(addrman.Add(vAddr, source));
-    BOOST_CHECK_EQUAL(addrman.size(), 2);
+    BOOST_CHECK(addrman.size() >= 1);
 }
 
 BOOST_AUTO_TEST_CASE(addrman_ports)


### PR DESCRIPTION
There have been a few PRs lately that have failed checks due to a bug introduced in #10287. The first check happened to work already because the chosen addresses didn't collide. The ```addrman.Clear()``` after that check causes addrman's salt to be reset, making all future tests non-deterministic.

When inserting two addresses of the same class, from the same source, there's a 1/64 chance that their hashes will collide. So it's faulty logic to be checking for an exact size. @sipa, mind verifying that?

I'd like to fix this properly by ensuring determinism in the test as a next step, but I'd rather fix the spurious failures asap.