### PR TITLE
Prevent shadowing the global dustRelayFee

### DIFF
--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -15,7 +15,7 @@
 
 #include <boost/foreach.hpp>
 
-CAmount GetDustThreshold(const CTxOut& txout, const CFeeRate& dustRelayFee)
+CAmount GetDustThreshold(const CTxOut& txout, const CFeeRate& dustRelayFeeIn)
 {
     // "Dust" is defined in terms of dustRelayFee,
     // which has units satoshis-per-kilobyte.
@@ -44,12 +44,12 @@ CAmount GetDustThreshold(const CTxOut& txout, const CFeeRate& dustRelayFee)
         nSize += (32 + 4 + 1 + 107 + 4); // the 148 mentioned above
     }
 
-    return 3 * dustRelayFee.GetFee(nSize);
+    return 3 * dustRelayFeeIn.GetFee(nSize);
 }
 
-bool IsDust(const CTxOut& txout, const CFeeRate& dustRelayFee)
+bool IsDust(const CTxOut& txout, const CFeeRate& dustRelayFeeIn)
 {
-    return (txout.nValue < GetDustThreshold(txout, dustRelayFee));
+    return (txout.nValue < GetDustThreshold(txout, dustRelayFeeIn));
 }
 
     /**


### PR DESCRIPTION
@jtimon @morcos As discussed on IRC: `dustRelayFee` shadows the global `::dustRelayFee` (origin in #9279).

It is always called with `::dustRelayFee`, but we want to keep it is an argument for later wallet use so it was renamed (using `In` suffix) instead of removed. Comments are unchanged though because `dustRelayFee ` is a name of the concept there.