### PR TITLE
[tests] improve tmpdir structure

### DIFF
--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -16,6 +16,7 @@ For a description of arguments recognized by test scripts, see
 
 import argparse
 import configparser
+import datetime
 import os
 import time
 import shutil
@@ -170,6 +171,7 @@ def main():
     parser.add_argument('--jobs', '-j', type=int, default=4, help='how many test scripts to run in parallel. Default=4.')
     parser.add_argument('--keepcache', '-k', action='store_true', help='the default behavior is to flush the cache directory on startup. --keepcache retains the cache from the previous testrun.')
     parser.add_argument('--quiet', '-q', action='store_true', help='only print results summary and failure logs')
+    parser.add_argument('--tmpdirprefix', '-t', default=tempfile.gettempdir(), help="Root directory for datadirs")
     args, unknown_args = parser.parse_known_args()
 
     # Create a set to store arguments and create the passon string
@@ -186,6 +188,12 @@ def main():
     # Set up logging
     logging_level = logging.INFO if args.quiet else logging.DEBUG
     logging.basicConfig(format='%(message)s', level=logging_level)
+
+    # Create base test directory
+    tmpdir = "%s/bitcoin_test_runner_%s" % (args.tmpdirprefix, datetime.datetime.now().strftime("%Y%m%d_%H%M%S"))
+    os.makedirs(tmpdir)
+
+    logging.debug("Temporary test directory at %s" % tmpdir)
 
     enable_wallet = config["components"].getboolean("ENABLE_WALLET")
     enable_utils = config["components"].getboolean("ENABLE_UTILS")
@@ -239,9 +247,9 @@ def main():
     if not args.keepcache:
         shutil.rmtree("%s/test/cache" % config["environment"]["BUILDDIR"], ignore_errors=True)
 
-    run_tests(test_list, config["environment"]["SRCDIR"], config["environment"]["BUILDDIR"], config["environment"]["EXEEXT"], args.jobs, args.coverage, passon_args)
+    run_tests(test_list, config["environment"]["SRCDIR"], config["environment"]["BUILDDIR"], config["environment"]["EXEEXT"], tmpdir, args.jobs, args.coverage, passon_args)
 
-def run_tests(test_list, src_dir, build_dir, exeext, jobs=1, enable_coverage=False, args=[]):
+def run_tests(test_list, src_dir, build_dir, exeext, tmpdir, jobs=1, enable_coverage=False, args=[]):
     # Warn if bitcoind is already running (unix only)
     try:
         if subprocess.check_output(["pidof", "bitcoind"]) is not None:
@@ -272,10 +280,10 @@ def run_tests(test_list, src_dir, build_dir, exeext, jobs=1, enable_coverage=Fal
 
     if len(test_list) > 1 and jobs > 1:
         # Populate cache
-        subprocess.check_output([tests_dir + 'create_cache.py'] + flags)
+        subprocess.check_output([tests_dir + 'create_cache.py'] + flags + ["--tmpdir=%s/cache" % tmpdir])
 
     #Run Tests
-    job_queue = TestHandler(jobs, tests_dir, test_list, flags)
+    job_queue = TestHandler(jobs, tests_dir, tmpdir, test_list, flags)
     time0 = time.time()
     test_results = []
 
@@ -301,6 +309,10 @@ def run_tests(test_list, src_dir, build_dir, exeext, jobs=1, enable_coverage=Fal
 
         logging.debug("Cleaning up coverage data")
         coverage.cleanup()
+
+    # Clear up the temp directory if all subdirectories are gone
+    if not os.listdir(tmpdir):
+        os.rmdir(tmpdir)
 
     all_passed = all(map(lambda test_result: test_result.was_successful, test_results))
 
@@ -329,10 +341,11 @@ class TestHandler:
     Trigger the testscrips passed in via the list.
     """
 
-    def __init__(self, num_tests_parallel, tests_dir, test_list=None, flags=None):
+    def __init__(self, num_tests_parallel, tests_dir, tmpdir, test_list=None, flags=None):
         assert(num_tests_parallel >= 1)
         self.num_jobs = num_tests_parallel
         self.tests_dir = tests_dir
+        self.tmpdir = tmpdir
         self.test_list = test_list
         self.flags = flags
         self.num_running = 0
@@ -347,13 +360,15 @@ class TestHandler:
             # Add tests
             self.num_running += 1
             t = self.test_list.pop(0)
-            port_seed = ["--portseed={}".format(len(self.test_list) + self.portseed_offset)]
+            portseed = len(self.test_list) + self.portseed_offset
+            portseed_arg = ["--portseed={}".format(portseed)]
             log_stdout = tempfile.SpooledTemporaryFile(max_size=2**16)
             log_stderr = tempfile.SpooledTemporaryFile(max_size=2**16)
             test_argv = t.split()
+            tmpdir = ["--tmpdir=%s/%s_%s" % (self.tmpdir, re.sub(".py$", "", test_argv[0]), portseed)]
             self.jobs.append((t,
                               time.time(),
-                              subprocess.Popen([self.tests_dir + test_argv[0]] + test_argv[1:] + self.flags + port_seed,
+                              subprocess.Popen([self.tests_dir + test_argv[0]] + test_argv[1:] + self.flags + portseed_arg + tmpdir,
                                                universal_newlines=True,
                                                stdout=log_stdout,
                                                stderr=log_stderr),


### PR DESCRIPTION
tl;dr:

- temp directories now include the name of the test when run through the test_runner
- passing a `--tmpdirprefix` to the test_runner allows test_runner to be called by cron/build jobs without risk of directory name collision

==================

By default, the functional tests create their temp directories in the $TMPDIR as follows:

```
$TMPDIR
   |
   -- test<rand_chars>
        |
        -- <port seed>
            |
            -- temp files
            -- ...
```

a `--tmpdir` argument can be passed into the individual test case, which causes the temp directory to be written to:

```
<specified --tmpdir>
   |
   -- <port seed>
        |
        -- temp files
        -- ...
```

If `--tmpdir` is passed to the test_runner, then it gets passed down to the indivdual tests and the directory structure is:

```
<specified --tmpdir>
   |
   -- <port seed 1>
        |
        -- temp files
        -- ...
   -- <port seed 2>
        |
        -- temp files
        -- ...
   -- ...

```

There are a few problems:

- the directory names give no indication of which test was being run, so it's difficult to quickly find the temp directory for an indvidual test if using the test_runner
- if a `--tmpdir` directory is passed to the test_runner and there are already directories in that tmpdir with names that clash with the port seed, then tests will fail when they try to use that subdirectory. This can be a problem when running test_runner as a cron job or build job with a specified tmpdir. Test failures in one build will cause subsequent runs to fail because the subdirectories are not cleaned up
- even if a tmpdir is specified, test_framework will still create an empty temp directory `$TMPDIR/test<rand_chars>` (this is because `tempfile.mkdtemp(prefix="test")` is called even when `--tmpdir`  is used).

This PR changes the temp dir structure so that:

- if running the test directly:
    - if no `--tmpdir` is specified
        - temp directory is `$TMPDIR/test<rand_chars>` (as now, except without the `<port seed>` subdirectory)
    - if a `--tmpdir` is specified
        - temp directory is the specified tmpdir (as now, except without the `<port seed>` subdirectory)
- if running through the test_runner
    - if no `--tmpdirprefix` is specified
        - temp directory is `$TMPDIR/bitcoin_test_runner_<date>_<time>/<test_name>_portseed`.
    - if a `--tmpdirprefix` is specified
        - temp directory is `<tmpdirprefix>/bitcoin_test_runner_<date>_<time>/<test_name>_portseed`.

`<tmpdirprefix>` will be cleaned up by the test_runner if it is empty at the end of all tests (ie if all tests have cleaned up their own temp directories).