### PR TITLE
[WIP] 3072-bit MuHash based hash_serialized

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -456,6 +456,9 @@ if test x$use_lcov_branch != xno; then
   AC_SUBST(LCOV_OPTS, "$LCOV_OPTS --rc lcov_branch_coverage=1")
 fi
 
+dnl Check for __int128
+AC_CHECK_TYPES([__int128])
+
 dnl Check for endianness
 AC_C_BIGENDIAN
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -256,6 +256,8 @@ crypto_libbitcoin_crypto_a_SOURCES = \
   crypto/hmac_sha256.h \
   crypto/hmac_sha512.cpp \
   crypto/hmac_sha512.h \
+  crypto/muhash.cpp \
+  crypto/muhash.h \
   crypto/ripemd160.cpp \
   crypto/ripemd160.h \
   crypto/sha1.cpp \

--- a/src/bench/crypto_hash.cpp
+++ b/src/bench/crypto_hash.cpp
@@ -10,6 +10,7 @@
 #include "random.h"
 #include "uint256.h"
 #include "utiltime.h"
+#include "crypto/muhash.h"
 #include "crypto/ripemd160.h"
 #include "crypto/sha1.h"
 #include "crypto/sha256.h"
@@ -92,6 +93,19 @@ static void FastRandom_1bit(benchmark::State& state)
     }
 }
 
+static void MuHash(benchmark::State& state)
+{
+    FastRandomContext rng(true);
+    MuHash3072 acc;
+    unsigned char key[32] = {0};
+    while (state.KeepRunning()) {
+        for (int i = 0; i < 1000; i++) {
+            key[0] = i;
+            acc *= MuHash3072(key);
+        }
+    }
+}
+
 BENCHMARK(RIPEMD160);
 BENCHMARK(SHA1);
 BENCHMARK(SHA256);
@@ -101,3 +115,5 @@ BENCHMARK(SHA256_32b);
 BENCHMARK(SipHash_32b);
 BENCHMARK(FastRandom_32bit);
 BENCHMARK(FastRandom_1bit);
+
+BENCHMARK(MuHash);

--- a/src/crypto/muhash.cpp
+++ b/src/crypto/muhash.cpp
@@ -1,0 +1,273 @@
+// Copyright (c) 2017 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "muhash.h"
+
+#include <limits>
+#include "common.h"
+#include "chacha20.h"
+
+#include <assert.h>
+#include <stdio.h>
+
+namespace {
+
+/** Extract the lowest limb of [c0,c1,c2] into n, and left shift the number by 1 limb. */
+#define extract3(c0,c1,c2,n) { \
+    (n) = c0; \
+    c0 = c1; \
+    c1 = c2; \
+    c2 = 0; \
+}
+
+/** Extract the lowest limb of [c0,c1] into n, and left shift the number by 1 limb. */
+#define extract2(c0,c1,n) { \
+    (n) = c0; \
+    c0 = c1; \
+    c1 = 0; \
+}
+
+/** [c0,c1] = a * b */
+#define mul(c0,c1,a,b) { \
+    Num3072::double_limb_type t = (Num3072::double_limb_type)a * b; \
+    c2 = 0; \
+    c1 = t >> Num3072::LIMB_SIZE; \
+    c0 = t; \
+}
+
+/* [c0,c1,c2] += n * [d0,d1,d2]. c2 is 0 initially */
+#define mulnadd3(c0,c1,c2,d0,d1,d2,n) { \
+    Num3072::double_limb_type t = (Num3072::double_limb_type)d0 * n + c0; \
+    c0 = t; \
+    t >>= Num3072::LIMB_SIZE; \
+    t += (Num3072::double_limb_type)d1 * n + c1; \
+    c1 = t; \
+    t >>= Num3072::LIMB_SIZE; \
+    c2 = t + d2 * n; \
+}
+
+/* [c0,c1] *= n */
+#define muln2(c0,c1,n) { \
+    Num3072::double_limb_type t = (Num3072::double_limb_type)c0 * n; \
+    c0 = t; \
+    t >>= Num3072::LIMB_SIZE; \
+    t += (Num3072::double_limb_type)c1 * n; \
+    c1 = t; \
+    t >>= Num3072::LIMB_SIZE; \
+}
+
+/** [c0,c1,c2] += a * b */
+#define muladd3(c0,c1,c2,a,b) { \
+    Num3072::limb_type tl, th; \
+    { \
+        Num3072::double_limb_type t = (Num3072::double_limb_type)a * b; \
+        th = t >> Num3072::LIMB_SIZE; \
+        tl = t; \
+    } \
+    c0 += tl; \
+    th += (c0 < tl) ? 1 : 0; \
+    c1 += th; \
+    c2 += (c1 < th) ? 1 : 0; \
+}
+
+/** [c0,c1,c2] += 2 * a * b */
+#define muldbladd3(c0,c1,c2,a,b) { \
+    Num3072::limb_type tl, th; \
+    { \
+        Num3072::double_limb_type t = (Num3072::double_limb_type)a * b; \
+        th = t >> Num3072::LIMB_SIZE; \
+        tl = t; \
+    } \
+    c0 += tl; \
+    Num3072::limb_type tt = th + ((c0 < tl) ? 1 : 0); \
+    c1 += tt; \
+    c2 += (c1 < tt) ? 1 : 0; \
+    c0 += tl; \
+    th += (c0 < tl) ? 1 : 0; \
+    c1 += th; \
+    c2 += (c1 < th) ? 1 : 0; \
+}
+
+/** [c0,c1] += a */
+#define add2(c0,c1,a) { \
+    c0 += (a); \
+    c1 += (c0 < (a)) ? 1 : 0; \
+}
+
+bool IsOverflow(const Num3072* d)
+{
+    for (int i = 1; i < Num3072::LIMBS - 1; ++i) {
+        if (d->limbs[i] != std::numeric_limits<Num3072::limb_type>::max()) return false;
+    }
+    if (d->limbs[0] <= std::numeric_limits<Num3072::limb_type>::max() - 1103717) return false;
+    return true;
+}
+
+void FullReduce(Num3072* d)
+{
+    Num3072::limb_type c0 = 1103717;
+    for (int i = 0; i < Num3072::LIMBS; ++i) {
+        Num3072::limb_type c1 = 0;
+        add2(c0, c1, d->limbs[i]);
+        extract2(c0, c1, d->limbs[i]);
+    }
+}
+
+void Multiply(Num3072* out, const Num3072* a, const Num3072* b)
+{
+    Num3072::limb_type c0 = 0, c1 = 0;
+    Num3072 tmp;
+
+    /* Compute limbs 0..N-2 of a*b into tmp, including one reduction. */
+    for (int j = 0; j < Num3072::LIMBS - 1; ++j) {
+        Num3072::limb_type d0 = 0, d1 = 0, d2 = 0, c2 = 0;
+        mul(d0, d1, a->limbs[1 + j], b->limbs[Num3072::LIMBS + j - (1 + j)]);
+        for (int i = 2 + j; i < Num3072::LIMBS; ++i) muladd3(d0, d1, d2, a->limbs[i], b->limbs[Num3072::LIMBS + j - i]);
+        mulnadd3(c0, c1, c2, d0, d1, d2, 1103717);
+        for (int i = 0; i < j + 1; ++i) muladd3(c0, c1, c2, a->limbs[i], b->limbs[j - i]);
+        extract3(c0, c1, c2, tmp.limbs[j]);
+    }
+    /* Compute limb N-1 of a*b into tmp. */
+    {
+        Num3072::limb_type c2 = 0;
+        for (int i = 0; i < Num3072::LIMBS; ++i) muladd3(c0, c1, c2, a->limbs[i], b->limbs[Num3072::LIMBS - 1 - i]);
+        extract3(c0, c1, c2, tmp.limbs[Num3072::LIMBS - 1]);
+    }
+    /* Perform a second reduction. */
+    muln2(c0, c1, 1103717);
+    for (int j = 0; j < Num3072::LIMBS; ++j) {
+        add2(c0, c1, tmp.limbs[j]);
+        extract2(c0, c1, out->limbs[j]);
+    }
+    assert(c1 == 0);
+    assert(c0 == 0 || c0 == 1);
+    /* Perform a potential third reduction. */
+    if (c0) FullReduce(out);
+}
+
+void Square(Num3072* out, const Num3072* a)
+{
+    Num3072::limb_type c0 = 0, c1 = 0;
+    Num3072 tmp;
+
+    /* Compute limbs 0..N-2 of a*a into tmp, including one reduction. */
+    for (int j = 0; j < Num3072::LIMBS - 1; ++j) {
+        Num3072::limb_type d0 = 0, d1 = 0, d2 = 0, c2 = 0;
+        for (int i = 0; i < (Num3072::LIMBS - 1 - j) / 2; ++i) muldbladd3(d0, d1, d2, a->limbs[i + j + 1], a->limbs[Num3072::LIMBS - 1 - i]);
+        if ((j + 1) & 1) muladd3(d0, d1, d2, a->limbs[(Num3072::LIMBS - 1 - j) / 2 + j + 1], a->limbs[Num3072::LIMBS - 1 - (Num3072::LIMBS - 1 - j) / 2]);
+        mulnadd3(c0, c1, c2, d0, d1, d2, 1103717);
+        for (int i = 0; i < (j + 1) / 2; ++i) muldbladd3(c0, c1, c2, a->limbs[i], a->limbs[j - i]);
+        if ((j + 1) & 1) muladd3(c0, c1, c2, a->limbs[(j + 1) / 2], a->limbs[j - (j + 1) / 2]);
+        extract3(c0, c1, c2, tmp.limbs[j]);
+    }
+    {
+        Num3072::limb_type c2 = 0;
+        for (int i = 0; i < Num3072::LIMBS / 2; ++i) muldbladd3(c0, c1, c2, a->limbs[i], a->limbs[Num3072::LIMBS - 1 - i]);
+        extract3(c0, c1, c2, tmp.limbs[Num3072::LIMBS - 1]);
+    }
+    /* Perform a second reduction. */
+    muln2(c0, c1, 1103717);
+    for (int j = 0; j < Num3072::LIMBS; ++j) {
+        add2(c0, c1, tmp.limbs[j]);
+        extract2(c0, c1, out->limbs[j]);
+    }
+    assert(c1 == 0);
+    assert(c0 == 0 || c0 == 1);
+    /* Perform a potential third reduction. */
+    if (c0) FullReduce(out);
+}
+
+void Inverse(Num3072* out, const Num3072* a)
+{
+    Num3072 p[12]; // p[i] = a^(2^(2^i)-1)
+    Num3072 x;
+
+    p[0] = *a;
+
+    for (int i = 0; i < 11; ++i) {
+        p[i + 1] = p[i];
+        for (int j = 0; j < (1 << i); ++j) Square(&p[i + 1], &p[i + 1]);
+        Multiply(&p[i + 1], &p[i + 1], &p[i]);
+    }
+
+    x = p[11];
+
+    for (int j = 0; j < 512; ++j) Square(&x, &x);
+    Multiply(&x, &x, &p[9]);
+    for (int j = 0; j < 256; ++j) Square(&x, &x);
+    Multiply(&x, &x, &p[8]);
+    for (int j = 0; j < 128; ++j) Square(&x, &x);
+    Multiply(&x, &x, &p[7]);
+    for (int j = 0; j < 64; ++j) Square(&x, &x);
+    Multiply(&x, &x, &p[6]);
+    for (int j = 0; j < 32; ++j) Square(&x, &x);
+    Multiply(&x, &x, &p[5]);
+    for (int j = 0; j < 8; ++j) Square(&x, &x);
+    Multiply(&x, &x, &p[3]);
+    for (int j = 0; j < 2; ++j) Square(&x, &x);
+    Multiply(&x, &x, &p[1]);
+    for (int j = 0; j < 1; ++j) Square(&x, &x);
+    Multiply(&x, &x, &p[0]);
+    for (int j = 0; j < 5; ++j) Square(&x, &x);
+    Multiply(&x, &x, &p[2]);
+    for (int j = 0; j < 3; ++j) Square(&x, &x);
+    Multiply(&x, &x, &p[0]);
+    for (int j = 0; j < 2; ++j) Square(&x, &x);
+    Multiply(&x, &x, &p[0]);
+    for (int j = 0; j < 4; ++j) Square(&x, &x);
+    Multiply(&x, &x, &p[0]);
+    for (int j = 0; j < 4; ++j) Square(&x, &x);
+    Multiply(&x, &x, &p[1]);
+    for (int j = 0; j < 3; ++j) Square(&x, &x);
+    Multiply(&x, &x, &p[0]);
+
+    *out = x;
+}
+
+}
+
+MuHash3072::MuHash3072() noexcept
+{
+    data.limbs[0] = 1;
+    for (int i = 1; i < Num3072::LIMBS; ++i) data.limbs[i] = 0;
+}
+
+MuHash3072::MuHash3072(const unsigned char* key32) noexcept
+{
+    unsigned char tmp[384];
+    ChaCha20(key32, 32).Output(tmp, 384);
+    for (int i = 0; i < Num3072::LIMBS; ++i) {
+        if (sizeof(Num3072::limb_type) == 4) {
+            data.limbs[i] = ReadLE32(tmp + 4 * i);
+        } else if (sizeof(Num3072::limb_type) == 8) {
+            data.limbs[i] = ReadLE64(tmp + 8 * i);
+        }
+    }
+}
+
+void MuHash3072::Finalize(unsigned char* hash384) noexcept
+{
+    if (IsOverflow(&data)) FullReduce(&data);
+    for (int i = 0; i < Num3072::LIMBS; ++i) {
+        if (sizeof(Num3072::limb_type) == 4) {
+            WriteLE32(hash384 + i * 4, data.limbs[i]);
+        } else if (sizeof(Num3072::limb_type) == 8) {
+            WriteLE64(hash384 + i * 8, data.limbs[i]);
+        }
+    }
+}
+
+MuHash3072& MuHash3072::operator*=(const MuHash3072& x) noexcept
+{
+    Multiply(&this->data, &this->data, &x.data);
+    return *this;
+}
+
+MuHash3072& MuHash3072::operator/=(const MuHash3072& x) noexcept
+{
+    Num3072 tmp;
+    Inverse(&tmp, &x.data);
+    Multiply(&this->data, &this->data, &tmp);
+    return *this;
+}

--- a/src/crypto/muhash.h
+++ b/src/crypto/muhash.h
@@ -1,0 +1,52 @@
+// Copyright (c) 2017 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_CRYPTO_MUHASH_H
+#define BITCOIN_CRYPTO_MUHASH_H
+
+#if defined(HAVE_CONFIG_H)
+#include "bitcoin-config.h"
+#endif
+
+#include <stdint.h>
+
+struct Num3072 {
+#ifdef HAVE___INT128
+    typedef unsigned __int128 double_limb_type;
+    typedef uint64_t limb_type;
+    static constexpr int LIMBS = 48;
+    static constexpr int LIMB_SIZE = 64;
+#else
+    typedef uint64_t double_limb_type;
+    typedef uint32_t limb_type;
+    static constexpr int LIMBS = 96;
+    static constexpr int LIMB_SIZE = 32;
+#endif
+    limb_type limbs[LIMBS];
+};
+
+/** A class representing MuHash sets */
+class MuHash3072
+{
+private:
+    Num3072 data;
+
+public:
+    /* The empty set. */
+    MuHash3072() noexcept;
+
+    /* A singleton with a single 32-byte key in it. */
+    explicit MuHash3072(const unsigned char* key32) noexcept;
+
+    /* Multiply (resulting in a hash for the union of the sets) */
+    MuHash3072& operator*=(const MuHash3072& add) noexcept;
+
+    /* Divide (resulting in a hash for the difference of the sets) */
+    MuHash3072& operator/=(const MuHash3072& sub) noexcept;
+
+    /* Finalize into a 384-byte hash. Does not change this object's value. */
+    void Finalize(unsigned char* hash384) noexcept;
+};
+
+#endif // BITCOIN_CRYPTO_MUHASH_H

--- a/src/hash.h
+++ b/src/hash.h
@@ -8,6 +8,7 @@
 
 #include "crypto/ripemd160.h"
 #include "crypto/sha256.h"
+#include "crypto/sha512.h"
 #include "prevector.h"
 #include "serialize.h"
 #include "uint256.h"
@@ -191,6 +192,41 @@ public:
     {
         // Unserialize from this stream
         ::Unserialize(*this, obj);
+        return (*this);
+    }
+};
+
+/** A writer stream that computes a 256-bit truncated SHA512. */
+class TruncatedSHA512Writer
+{
+private:
+    CSHA512 ctx;
+
+    const int nType;
+    const int nVersion;
+public:
+
+    TruncatedSHA512Writer(int nTypeIn, int nVersionIn) : nType(nTypeIn), nVersion(nVersionIn) {}
+
+    int GetType() const { return nType; }
+    int GetVersion() const { return nVersion; }
+
+    void write(const char *pch, size_t size) {
+        ctx.Write((const unsigned char*)pch, size);
+    }
+
+    uint256 GetHash() {
+        unsigned char out[64];
+        ctx.Finalize(out);
+        uint256 result;
+        memcpy((unsigned char*)&result, out, 32);
+        return result;
+    }
+
+    template<typename T>
+    TruncatedSHA512Writer& operator<<(const T& obj) {
+        // Serialize to this stream
+        ::Serialize(*this, obj);
         return (*this);
     }
 };

--- a/src/test/crypto_tests.cpp
+++ b/src/test/crypto_tests.cpp
@@ -10,6 +10,7 @@
 #include "crypto/sha512.h"
 #include "crypto/hmac_sha256.h"
 #include "crypto/hmac_sha512.h"
+#include "crypto/muhash.h"
 #include "random.h"
 #include "utilstrencodings.h"
 #include "test/test_bitcoin.h"
@@ -503,6 +504,60 @@ BOOST_AUTO_TEST_CASE(countbits_tests)
             }
         }
     }
+}
+
+static MuHash3072 FromInt(unsigned char i) {
+    unsigned char tmp[32] = {i, 0};
+    return MuHash3072(tmp);
+}
+
+BOOST_AUTO_TEST_CASE(muhash_tests)
+{
+    unsigned char out[384];
+
+    for (int iter = 0; iter < 10; ++iter) {
+        unsigned char res[384];
+        int table[4];
+        for (int i = 0; i < 4; ++i) {
+            table[i] = insecure_rand_ctx.randbits(3);
+        }
+        for (int order = 0; order < 4; ++order) {
+            MuHash3072 acc;
+            for (int i = 0; i < 4; ++i) {
+                int t = table[i ^ order];
+                if (t & 4) {
+                    acc /= FromInt(t & 3);
+                } else {
+                    acc *= FromInt(t & 3);
+                }
+            }
+            acc.Finalize(out);
+            if (order == 0) {
+                memcpy(res, out, 384);
+            } else {
+                BOOST_CHECK(memcmp(res, out, 384) == 0);
+            }
+        }
+
+        MuHash3072 x = FromInt(insecure_rand_ctx.randbits(4)); // x=X
+        MuHash3072 y = FromInt(insecure_rand_ctx.randbits(4)); // x=X, y=Y
+        MuHash3072 z; // x=X, y=Y, z=1
+        z *= x; // x=X, y=Y, z=X
+        z /= y; // x=X, y=Y, z=X/Y
+        y /= x; // x=X, y=Y/X, z=X/Y
+        z *= y; // x=X, y=Y/X, z=1
+        z.Finalize(out);
+        for (int i = 0; i < 384; ++i) {
+            BOOST_CHECK_EQUAL(out[i], i == 0);
+        }
+    }
+
+    MuHash3072 acc = FromInt(0);
+    acc *= FromInt(1);
+    acc /= FromInt(2);
+    acc.Finalize(out);
+    uint256 x = (TruncatedSHA512Writer(SER_DISK, 0) << FLATDATA(out)).GetHash();
+    BOOST_CHECK(x == uint256S("0e94c56c180f27fd6b182f091c5b007e2d6eba5ae28daa5aa92d2af8c26ea9a6"));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/functional/blockchain.py
+++ b/test/functional/blockchain.py
@@ -70,7 +70,7 @@ class BlockchainTest(BitcoinTestFramework):
         assert size > 6400
         assert size < 64000
         assert_equal(len(res['bestblock']), 64)
-        assert_equal(len(res['hash_serialized_2']), 64)
+        assert_equal(len(res['muhash']), 64)
 
         self.log.info("Test that gettxoutsetinfo() works for blockchain with just the genesis block")
         b1hash = node.getblockhash(1)
@@ -83,7 +83,8 @@ class BlockchainTest(BitcoinTestFramework):
         assert_equal(res2['txouts'], 0)
         assert_equal(res2['bogosize'], 0),
         assert_equal(res2['bestblock'], node.getblockhash(0))
-        assert_equal(len(res2['hash_serialized_2']), 64)
+        assert_equal(res2['muhash'], '1ab6089a655235d9609a687448dc4cc429302704eded8b0615f93bfe03ec658f')
+        assert res2['muhash'] != res['muhash']
 
         self.log.info("Test that gettxoutsetinfo() returns the same result after invalidate/reconsider block")
         node.reconsiderblock(b1hash)
@@ -95,7 +96,7 @@ class BlockchainTest(BitcoinTestFramework):
         assert_equal(res['txouts'], res3['txouts'])
         assert_equal(res['bogosize'], res3['bogosize'])
         assert_equal(res['bestblock'], res3['bestblock'])
-        assert_equal(res['hash_serialized_2'], res3['hash_serialized_2'])
+        assert_equal(res['muhash'], res3['muhash'])
 
     def _test_getblockheader(self):
         node = self.nodes[0]


### PR DESCRIPTION
This implements a 3072-bit MuHash discussed on https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2017-May/014337.html as a replacement for the hash_serialized field in `gettxoutsetinfo`.

This is an order-independent hash, allowing it to be computed either by iterating over the UTXO set in non-sorted order. It also supports incremental addition and deletion of entries from the hash, allowing it to be updated on the fly for each block. Neither of these approaches is currently implemented.