### PR TITLE
[WIP] Implement BIP135 (generalized versionbits)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,28 @@
+Copyright (c) 2015, ben-strasser
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of fast-cpp-csv-parser nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,268 @@
+# Fast C++ CSV Parser
+
+This is a small, easy-to-use and fast header-only library for reading comma separated value (CSV) files. 
+
+## Features
+
+  * Automatically rearranges columns by parsing the header line.
+  * Disk I/O and CSV-parsing are overlapped using threads for efficiency.
+  * Parsing features such as escaped strings can be enabled and disabled at compile time using templates. You only pay in speed for the features you actually use.
+  * Can read multiple GB files in reasonable time.
+  * Support for custom columns separators (i.e. Tab separated value files are supported), quote escaped strings, automatic space trimming. 
+  * Works with `*`nix and Windows newlines and automatically ignores UTF-8 BOMs.
+  * Exception classes with enough context to format useful error messages. what() returns error messages ready to be shown to a user. 
+
+## Getting Started
+
+The following small example should contain most of the syntax you need to use the library.
+
+```cpp
+# include "csv.h"
+
+int main(){
+  io::CSVReader<3> in("ram.csv");
+  in.read_header(io::ignore_extra_column, "vendor", "size", "speed");
+  std::string vendor; int size; double speed;
+  while(in.read_row(vendor, size, speed)){
+    // do stuff with the data
+  }
+}
+```
+
+## Installation
+
+The library only needs a standard conformant C++11 compiler. It has no further dependencies. The library is completely contained inside a single header file and therefore it is sufficient to copy this file to some place on your include path. The library does not have to be explicitly build. 
+
+Note however, that threads are used and some compiler (for example GCC) require you to link against additional librarie to make it work. With GCC it is important to add -lpthread as the last item when linking, i.e. the order in 
+
+```
+g++ -std=c++0x a.o b.o -o prog -lpthread
+```
+
+is important. If you for some reason do not want to use threads you can define CSV_IO_NO_THREAD before including the header.
+
+Remember that the library makes use of C++11 features and therefore you have to enable support for it (f.e. add -std=c++0x or -std=gnu++0x). 
+
+The library was developed and tested with GCC 4.6.1
+
+Note that VS2013 is not C++11 compilant and will therefore not work out of the box. See [here](https://code.google.com/p/fast-cpp-csv-parser/issues/detail?id=6) for what needs to be adjusted to make the code work.
+
+## Documentation
+
+The libary provides two classes: 
+
+  * `LineReader`: A class to efficiently read large files line by line.
+  * `CSVReader`: A class that efficiently reads large CSV files.
+
+Note that everything is contained in the `io` namespace.
+
+### `LineReader`
+
+```cpp
+class LineReader{
+public:
+  // Constructors
+  LineReader(some_string_type file_name);
+  LineReader(some_string_type file_name, std::FILE*source);
+  LineReader(some_string_type file_name, std::istream&source);
+  LineReader(some_string_type file_name, std::unique_ptr<ByteSourceBase>source);
+
+  // Reading
+  char*next_line();
+
+  // File Location
+  void set_file_line(unsigned);
+  unsigned get_file_line(unsigned)const;
+  void set_file_name(some_string_type file_name);
+  const char*get_truncated_file_name()const;
+};
+```
+
+The constructor takes a file name and optionally a data source. If no data source is provided the function tries to open the file with the given name and throws an `error::can_not_open_file exception` on failure. If a data source is provided then the file name is only used to format error messages. In that case you can essentially put any string there. Using a string that describes the data source results in more informative error messages.
+
+`some_string_type` can be a `std::string` or a `char*`. If the data source is a `std::FILE*` then the library will take care of calling `std::fclose`. If it is a `std::istream` then the stream is not closed by the library. For best performance open the streams in binary mode. However using text mode also works. `ByteSourceBase` provides an interface that you can use to implement further data sources. 
+
+```
+class ByteSourceBase{
+public:
+  virtual int read(char*buffer, int size)=0;
+  virtual ~ByteSourceBase(){}
+};
+```
+
+The read function should fill the provided buffer with at most `size` bytes from the data source. It should return the number of bytes actually written to the buffer. If data source has run out of bytes (because for example an end of file was reached) then the function should return 0. If a fatal error occures then you can throw an exception. Note that the function can be called both from the main and the worker thread. However, it is guarenteed that they do not call the function at the same time. 
+
+Lines are read by calling the `next_line` function. It returns a pointer to a null terminated C-string that contains the line. If the end of file is reached a null pointer is returned. The newline character is not included in the string. You may modify the string as long as you do not write past the null terminator. The string stays valid until the destructor is called or until next_line is called again. Windows and `*`nix newlines are handled transparently. UTF-8 BOMs are automatically ignored and missing newlines at the end of the file are no problem.
+
+**Important:** There is a limit of 2^24-1 characters per line. If this limit is exceeded a `error::line_length_limit_exceeded` exception is thrown.
+
+Looping over all the lines in a file can be done in the following way.
+```cpp
+LineReader in(...);
+while(char*line = in.next_line()){
+  ...
+}
+```
+
+The remaining functions are mainly used used to format error messages. The file line indicates the current position in the file, i.e., after the first `next_line` call it is 1 and after the second 2. Before the first call it is 0. The file name is truncated as internally C-strings are used to avoid `std::bad_alloc` exceptions during error reporting.
+
+**Note:** It is not possible to exchange the line termination character.
+
+### `CSVReader`
+
+`CSVReader` uses policies. These are classes with only static members to allow core functionality to be exchanged in an efficient way.
+
+```cpp
+template<
+  unsigned column_count,
+  class trim_policy = trim_chars<' ', '\t'>, 
+  class quote_policy = no_quote_escape<','>,
+  class overflow_policy = throw_on_overflow,
+  class comment_policy = no_comment
+>
+class CSVReader{
+public:
+  // Constructors
+  // same as for LineReader
+
+  // Parsing Header
+  void read_header(ignore_column ignore_policy, some_string_type col_name1, some_string_type col_name2, ...);
+  void set_header(some_string_type col_name1, some_string_type col_name2, ...);
+  bool has_column(some_string_type col_name)const;
+
+  // Read
+  char*next_line();
+  bool read_row(ColType1&col1, ColType2&col2, ...);
+
+  // File Location 
+  void set_file_line(unsigned);
+  unsigned get_file_line()const;
+  void set_file_name(some_string_type file_name);
+  const char*get_truncated_file_name()const;
+};
+```
+
+The `column_count` template parameter indicates how many columns you want to read from the CSV file. This must not necessarily coincide with the actual number of columns in the file. The three policies govern various aspects of the parsing.
+
+The trim policy indicates what characters should be ignored at the begin and the end of every column. The default ignores spaces and tabs. This makes sure that
+
+```
+a,b,c
+1,2,3
+```
+
+is interpreted in the same way as
+
+```
+  a, b,   c
+1  , 2,   3
+```
+
+The trim_chars can take any number of template parameters. For example `trim_chars<' ', '\t', '_'> `is also valid. If no character should be trimmed use `trim_chars<>`.
+
+The quote policy indicates how string should be escaped. It also specifies the column separator. The predefined policies are:
+
+  * `no_quote_escape<sep>` : Strings are not escaped. "`sep`" is used as column separator.
+  * `double_quote_escape<sep, quote>` : Strings are escaped using quotes. Quotes are escaped using two consecutive quotes. "`sep`" is used as column separator and "`quote`" as quoting character.
+
+**Important**: When combining trimming and quoting the rows are first trimmed and then unquoted. A consequence is that spaces inside the quotes will be conserved. If you want to get rid of spaces inside the quotes, you need to remove them yourself.
+
+**Important**: Quoting can be quite expensive. Disable it if you do not need it.
+
+The overflow policy indicates what should be done if the integers in the input are too large to fit into the variables. There following policies are predefined:
+
+  * `throw_on_overflow` : Throw an `error::integer_overflow` or `error::integer_underflow` exception.
+  * `ignore_overflow` : Do nothing and let the overflow happen.
+  * `set_to_max_on_overflow` : Set the value to `numeric_limits<...>::max()` (or to the min-pendant).
+
+The comment policy allows to skip lines based on some criteria. Valid predefined policies are:
+
+  * `no_comment` : Do not ignore any line.
+  * `empty_line_comment` : Ignore all lines that are empty or only contains spaces and tabs. 
+  * `single_line_comment<com1, com2, ...>` : Ignore all lines that start with com1 or com2 or ... as the first character. There may not be any space between the beginning of the line and the comment character. 
+  * `single_and_empty_line_comment<com1, com2, ...>` : Ignore all empty lines and single line comments.
+
+Examples:
+
+  * `CSVReader<4, trim_chars<' '>, double_quote_escape<',','\"'> >` reads 4 columns from a normal CSV file with string escaping enabled.
+  * `CSVReader<3, trim_chars<' '>, no_quote_escape<'\t'>, single_line_comment<'#'> >` reads 3 columns from a tab separated file with string escaping disabled. Lines starting with a # are ignored.
+
+The constructors and the file location functions are exactly the same as for `LineReader`. See its documentation for details.
+
+There are three methods that deal with headers. The `read_header` methods reads a line from the file and rearranges the columns to match that order. It also checks whether all necessary columns are present. The `set_header` method does *not* read any input. Use it if the file does not have any header. Obviously it is impossible to rearrange columns or check for their availability when using it. The order in the file and in the program must match when using `set_header`. The `has_column` method checks whether a column is present in the file. The first argument of `read_header` is a bitfield that determines how the function should react to column mismatches. The default behavior is to throw an `error::extra_column_in_header` exception if the file contains more columns than expected and an `error::missing_column_in_header` when there are not enough. This behavior can be altered using the following flags.
+
+  * `ignore_no_column`: The default behavior, no flags are set
+  * `ignore_extra_column`: If a column with a name is in the file but not in the argument list, then it is silently ignored.
+  * `ignore_missing_column`: If a column with a name is not in the file but is in the argument list, then `read_row` will not modify the corresponding variable. 
+
+When using `ignore_column_missing` it is a good idea to initialize the variables passed to `read_row` with a default value, for example:
+
+```cpp
+// The file only contains column "a"
+CSVReader<2>in(...);
+in.read_header(ignore_missing_column, "a", "b");
+int a,b = 42;
+while(in.read_row(a,b)){
+  // a contains the value from the file
+  // b is left unchanged by read_row, i.e., it is 42
+}
+```
+
+If only some columns are optional or their default value depends on other columns you have to use `has_column`, for example:
+
+```cpp
+// The file only contains the columns "a" and "b"
+CSVReader<2>in(...);
+in.read_header(ignore_missing_column, "a", "b", "sum");
+if(!in.has_column("a") || !in.has_column("b"))
+  throw my_neat_error_class();
+bool has_sum = in.has_column("sum");
+int a,b,sum;
+while(in.read_row(a,b,sum)){
+  if(!has_sum)
+    sum = a+b;
+}
+```
+
+**Important**: Do not call `has_column` from within the read-loop. It would work correctly but significantly slowdown processing.
+
+If two columns have the same name an error::duplicated_column_in_header exception is thrown. If `read_header` is called but the file is empty a `error::header_missing` exception is thrown.
+
+The `next_line` functions reads a line without parsing it. It works analogous to `LineReader::next_line`. This can be used to skip broken lines in a CSV file. However, in nearly all applications you will want to use the `read_row` function.
+
+The `read_row` function reads a line, splits it into the columns and arranges them correctly. It trims the entries and unescapes them. If requested the content is interpreted as integer or as floating point. The variables passed to read_row may be of the following types.
+
+  * builtin signed integer: These are `signed char`, `short`, `int`, `long` and `long long`. The input must be encoded as a base 10 ASCII number optionally preceded by a + or -. The function detects whether the integer is too large would overflow (or underflow) and behaves as indicated by overflow_policy.
+  * builtin unsigned integer: Just as the signed counterparts except that a leading + or - is not allowed.
+  * builtin floating point: These are `float`, `double` and `long double`. The input may have a leading + or -. The number must be base 10 encoded. The decimal point may either be a dot or a comma. (Note that a comma will only work if it is not also used as column separator or the number is escaped.) A base 10 exponent may be specified using the "1e10" syntax. The "e" may be lower- or uppercase. Examples for valid floating points are "1", "-42.42" and "+123.456E789". The input is rounded to the next floating point or infinity if it is too large or small.
+  * `char`: The column content must be a single character.
+  * `std::string`: The column content is assigned to the string. The std::string is filled with the trimmed and unescaped version.
+  * `char*`: A pointer directly into the buffer. The string is trimmed and unescaped and null terminated. This pointer stays valid until read_row is called again or the CSVReader is destroyed. Use this for user defined types. 
+
+Note that there is no inherent overhead to using `char*` and then interpreting it compared to using one of the parsers directly build into `CSVReader`. The builtin number parsers are pure convenience. If you need a slightly different syntax then use `char*` and do the parsing yourself.
+
+## FAQ
+
+Q: The library is throwing a std::system_error with code -1. How to get it to work?
+
+A: Your compiler's std::thread implementation is broken. Define CSV\_IO\_NO\_THREAD to disable threading support.
+
+
+Q: My values are not just ints or strings. I want to parse my customized type. Is this possible?
+
+A: Read a `char*` and parse the string. At first this seems expensive but it is not as the pointer you get points directly into the memory buffer. In fact there is no inherent reason why a custom int-parser realized this way must be any slower than the int-parser build into the library. By reading a `char*` the library takes care of column reordering and quote escaping and leaves the actual parsing to you. Note that using a std::string is slower as it involves a memory copy.
+
+
+Q: I get lots of compiler errors when compiling the header! Please fix it. :(
+
+A: Have you enabled the C++11 mode of your compiler? If you use GCC you have to add -std=c++0x to the commandline. If this does not resolve the problem, then please open a ticket.
+
+
+Q: The library crashes when parsing large files! Please fix it. :(
+
+A: When using GCC have you linked against -lpthread? Read the installation section for details on how to do this. If this does not resolve the issue then please open a ticket. (The reason why it only crashes only on large files is that the first chuck is read synchronous and if the whole file fits into this chuck then no asynchronous call is performed.) Alternatively you can define CSV\_IO\_NO\_THREAD.
+
+
+Q: Does the library support UTF?
+
+A: The library has basic UTF-8 support, or to be more precise it does not break when passing UTF-8 strings through it. If you read a `char*` then you get a pointer to the UTF-8 string. You will have to decode the string on your own. The separator, quoting, and commenting characters used by the library can only be ASCII characters.

--- a/csv.h
+++ b/csv.h
@@ -1,0 +1,1249 @@
+// Copyright: (2012-2015) Ben Strasser <code@ben-strasser.net>
+// License: BSD-3
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+//
+//2. Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+//3. Neither the name of the copyright holder nor the names of its contributors
+//   may be used to endorse or promote products derived from this software
+//   without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef CSV_H
+#define CSV_H
+
+#include <vector>
+#include <string>
+#include <cstring>
+#include <algorithm>
+#include <utility>
+#include <cstdio>
+#include <exception>
+#ifndef CSV_IO_NO_THREAD
+#include <mutex>
+#include <thread>
+#include <condition_variable>
+#endif
+#include <memory>
+#include <cassert>
+#include <cerrno>
+#include <istream>
+
+namespace io{
+        ////////////////////////////////////////////////////////////////////////////
+        //                                 LineReader                             //
+        ////////////////////////////////////////////////////////////////////////////
+
+        namespace error{
+                struct base : std::exception{
+                        virtual void format_error_message()const = 0;                          
+                       
+                        const char*what()const throw(){
+                                format_error_message();
+                                return error_message_buffer;
+                        }
+
+                        mutable char error_message_buffer[256];
+                };
+
+                const int max_file_name_length = 255;
+
+                struct with_file_name{
+                        with_file_name(){
+                                std::memset(file_name, 0, max_file_name_length+1);
+                        }
+                       
+                        void set_file_name(const char*file_name){
+                                std::strncpy(this->file_name, file_name, max_file_name_length);
+                                this->file_name[max_file_name_length] = '\0';
+                        }
+
+                        char file_name[max_file_name_length+1];
+                };
+
+                struct with_file_line{
+                        with_file_line(){
+                                file_line = -1;
+                        }
+                       
+                        void set_file_line(int file_line){
+                                this->file_line = file_line;
+                        }
+
+                        int file_line;
+                };
+
+                struct with_errno{
+                        with_errno(){
+                                errno_value = 0;
+                        }
+                       
+                        void set_errno(int errno_value){
+                                this->errno_value = errno_value;
+                        }
+
+                        int errno_value;
+                };
+
+                struct can_not_open_file :
+                        base,
+                        with_file_name,
+                        with_errno{
+                        void format_error_message()const{
+                                if(errno_value != 0)
+                                        std::snprintf(error_message_buffer, sizeof(error_message_buffer),
+                                                "Can not open file \"%s\" because \"%s\"."
+                                                , file_name, std::strerror(errno_value));
+                                else
+                                        std::snprintf(error_message_buffer, sizeof(error_message_buffer),
+                                                "Can not open file \"%s\"."
+                                                , file_name);
+                        }
+                };
+
+                struct line_length_limit_exceeded :
+                        base,
+                        with_file_name,
+                        with_file_line{
+                        void format_error_message()const{
+                                std::snprintf(error_message_buffer, sizeof(error_message_buffer),
+                                        "Line number %d in file \"%s\" exceeds the maximum length of 2^24-1."
+                                        , file_line, file_name);
+                        }
+                };
+        }
+
+        class ByteSourceBase{
+        public:
+                virtual int read(char*buffer, int size)=0;
+                virtual ~ByteSourceBase(){}
+        };
+
+        namespace detail{
+
+                class OwningStdIOByteSourceBase : public ByteSourceBase{
+                public:
+                        explicit OwningStdIOByteSourceBase(FILE*file):file(file){
+                                // Tell the std library that we want to do the buffering ourself.
+                                std::setvbuf(file, 0, _IONBF, 0);
+                        }
+
+                        int read(char*buffer, int size){
+                                return std::fread(buffer, 1, size, file);
+                        }
+
+                        ~OwningStdIOByteSourceBase(){
+                                std::fclose(file);
+                        }
+
+                private:
+                        FILE*file;
+                };
+
+                class NonOwningIStreamByteSource : public ByteSourceBase{
+                public:
+                        explicit NonOwningIStreamByteSource(std::istream&in):in(in){}
+
+                        int read(char*buffer, int size){
+                                in.read(buffer, size);
+                                return in.gcount();
+                        }
+
+                        ~NonOwningIStreamByteSource(){}
+
+                private:
+                       std::istream&in;
+                };
+
+                class NonOwningStringByteSource : public ByteSourceBase{
+                public:
+                        NonOwningStringByteSource(const char*str, long long size):str(str), remaining_byte_count(size){}
+
+                        int read(char*buffer, int desired_byte_count){
+                                int to_copy_byte_count = desired_byte_count;
+                                if(remaining_byte_count < to_copy_byte_count)
+                                        to_copy_byte_count = remaining_byte_count;
+                                std::memcpy(buffer, str, to_copy_byte_count);
+                                remaining_byte_count -= to_copy_byte_count;
+                                str += to_copy_byte_count;
+                                return to_copy_byte_count;
+                        }
+
+                        ~NonOwningStringByteSource(){}
+
+                private:
+                        const char*str;
+                        long long remaining_byte_count;
+                };
+
+                #ifndef CSV_IO_NO_THREAD
+                class AsynchronousReader{
+                public:
+                        void init(std::unique_ptr<ByteSourceBase>arg_byte_source){
+                                std::unique_lock<std::mutex>guard(lock);
+                                byte_source = std::move(arg_byte_source);
+                                desired_byte_count = -1;
+                                termination_requested = false;
+                                worker = std::thread(
+                                        [&]{
+                                                std::unique_lock<std::mutex>guard(lock);
+                                                try{
+                                                        for(;;){
+                                                                read_requested_condition.wait(
+                                                                        guard, 
+                                                                        [&]{
+                                                                                return desired_byte_count != -1 || termination_requested;
+                                                                        }
+                                                                );
+                                                                if(termination_requested)
+                                                                        return;
+
+                                                                read_byte_count = byte_source->read(buffer, desired_byte_count);
+                                                                desired_byte_count = -1;
+                                                                if(read_byte_count == 0)
+                                                                        break;
+                                                                read_finished_condition.notify_one();
+                                                        }
+                                                }catch(...){
+                                                        read_error = std::current_exception();
+                                                }
+                                                read_finished_condition.notify_one();
+                                        }
+                                );
+                        }
+
+                        bool is_valid()const{
+                                return byte_source != nullptr;
+                        }
+
+                        void start_read(char*arg_buffer, int arg_desired_byte_count){
+                                std::unique_lock<std::mutex>guard(lock);
+                                buffer = arg_buffer;
+                                desired_byte_count = arg_desired_byte_count;
+                                read_byte_count = -1;
+                                read_requested_condition.notify_one();
+                        }
+
+                        int finish_read(){
+                                std::unique_lock<std::mutex>guard(lock);
+                                read_finished_condition.wait(
+                                        guard, 
+                                        [&]{
+                                                return read_byte_count != -1 || read_error;
+                                        }
+                                );
+                                if(read_error)
+                                        std::rethrow_exception(read_error);
+                                else
+                                        return read_byte_count;
+                        }
+
+                        ~AsynchronousReader(){
+                                if(byte_source != nullptr){
+                                        {
+                                                std::unique_lock<std::mutex>guard(lock);
+                                                termination_requested = true;
+                                        }
+                                        read_requested_condition.notify_one();
+                                        worker.join();
+                                }
+                        }
+
+                private:           
+                        std::unique_ptr<ByteSourceBase>byte_source;
+
+                        std::thread worker;
+
+                        bool termination_requested;
+                        std::exception_ptr read_error;
+                        char*buffer;
+                        int desired_byte_count;
+                        int read_byte_count;
+
+                        std::mutex lock;
+                        std::condition_variable read_finished_condition;
+                        std::condition_variable read_requested_condition;  
+                };
+                #endif
+
+                class SynchronousReader{
+                public:
+                        void init(std::unique_ptr<ByteSourceBase>arg_byte_source){
+                                byte_source = std::move(arg_byte_source);
+                        }
+
+                        bool is_valid()const{
+                                return byte_source != nullptr;
+                        }
+
+                        void start_read(char*arg_buffer, int arg_desired_byte_count){
+                                buffer = arg_buffer;
+                                desired_byte_count = arg_desired_byte_count;
+                        }
+
+                        int finish_read(){
+                                return byte_source->read(buffer, desired_byte_count);
+                        }
+                private:
+                        std::unique_ptr<ByteSourceBase>byte_source;
+                        char*buffer;
+                        int desired_byte_count;
+                };
+        }
+
+        class LineReader{
+        private:
+                static const int block_len = 1<<24;
+                std::unique_ptr<char[]>buffer; // must be constructed before (and thus destructed after) the reader!
+                #ifdef CSV_IO_NO_THREAD
+                detail::SynchronousReader reader;
+                #else
+                detail::AsynchronousReader reader;
+                #endif
+                int data_begin;
+                int data_end;
+
+                char file_name[error::max_file_name_length+1];
+                unsigned file_line;
+
+                static std::unique_ptr<ByteSourceBase> open_file(const char*file_name){
+                        // We open the file in binary mode as it makes no difference under *nix
+                        // and under Windows we handle \r\n newlines ourself.
+                        FILE*file = std::fopen(file_name, "rb");
+                        if(file == 0){
+                                int x = errno; // store errno as soon as possible, doing it after constructor call can fail.
+                                error::can_not_open_file err;
+                                err.set_errno(x);
+                                err.set_file_name(file_name);
+                                throw err;
+                        }
+                        return std::unique_ptr<ByteSourceBase>(new detail::OwningStdIOByteSourceBase(file));
+                }
+
+                void init(std::unique_ptr<ByteSourceBase>byte_source){
+                        file_line = 0;
+
+                        buffer = std::unique_ptr<char[]>(new char[3*block_len]);
+                        data_begin = 0;
+                        data_end = byte_source->read(buffer.get(), 2*block_len);
+
+                        // Ignore UTF-8 BOM
+                        if(data_end >= 3 && buffer[0] == '\xEF' && buffer[1] == '\xBB' && buffer[2] == '\xBF')
+                                data_begin = 3;
+
+                        if(data_end == 2*block_len){
+                                reader.init(std::move(byte_source));
+                                reader.start_read(buffer.get() + 2*block_len, block_len);
+                        }
+                }
+
+        public:
+                LineReader() = delete;
+                LineReader(const LineReader&) = delete;
+                LineReader&operator=(const LineReader&) = delete;
+
+                explicit LineReader(const char*file_name){
+                        set_file_name(file_name);
+                        init(open_file(file_name));
+                }
+
+                explicit LineReader(const std::string&file_name){
+                        set_file_name(file_name.c_str());
+                        init(open_file(file_name.c_str()));
+                }
+
+                LineReader(const char*file_name, std::unique_ptr<ByteSourceBase>byte_source){
+                        set_file_name(file_name);
+                        init(std::move(byte_source));
+                }
+
+                LineReader(const std::string&file_name, std::unique_ptr<ByteSourceBase>byte_source){
+                        set_file_name(file_name.c_str());
+                        init(std::move(byte_source));
+                }
+
+                LineReader(const char*file_name, const char*data_begin, const char*data_end){
+                        set_file_name(file_name);
+                        init(std::unique_ptr<ByteSourceBase>(new detail::NonOwningStringByteSource(data_begin, data_end-data_begin)));
+                }
+
+                LineReader(const std::string&file_name, const char*data_begin, const char*data_end){
+                        set_file_name(file_name.c_str());
+                        init(std::unique_ptr<ByteSourceBase>(new detail::NonOwningStringByteSource(data_begin, data_end-data_begin)));
+                }
+
+                LineReader(const char*file_name, FILE*file){
+                        set_file_name(file_name);
+                        init(std::unique_ptr<ByteSourceBase>(new detail::OwningStdIOByteSourceBase(file)));
+                }
+
+                LineReader(const std::string&file_name, FILE*file){
+                        set_file_name(file_name.c_str());
+                        init(std::unique_ptr<ByteSourceBase>(new detail::OwningStdIOByteSourceBase(file)));
+                }
+
+                LineReader(const char*file_name, std::istream&in){
+                        set_file_name(file_name);
+                        init(std::unique_ptr<ByteSourceBase>(new detail::NonOwningIStreamByteSource(in)));
+                }
+
+                LineReader(const std::string&file_name, std::istream&in){
+                        set_file_name(file_name.c_str());
+                        init(std::unique_ptr<ByteSourceBase>(new detail::NonOwningIStreamByteSource(in)));
+                }
+
+                void set_file_name(const std::string&file_name){
+                        set_file_name(file_name.c_str());
+                }
+
+                void set_file_name(const char*file_name){
+                        strncpy(this->file_name, file_name, error::max_file_name_length);
+                        this->file_name[error::max_file_name_length] = '\0';
+                }
+
+                const char*get_truncated_file_name()const{
+                        return file_name;
+                }
+
+                void set_file_line(unsigned file_line){
+                        this->file_line = file_line;
+                }
+
+                unsigned get_file_line()const{
+                        return file_line;
+                }
+
+                char*next_line(){
+                        if(data_begin == data_end)
+                                return 0;
+
+                        ++file_line;
+
+                        assert(data_begin < data_end);
+                        assert(data_end <= block_len*2);
+
+                        if(data_begin >= block_len){
+                                std::memcpy(buffer.get(), buffer.get()+block_len, block_len);
+                                data_begin -= block_len;
+                                data_end -= block_len;
+                                if(reader.is_valid())
+                                {
+                                        data_end += reader.finish_read();
+                                        std::memcpy(buffer.get()+block_len, buffer.get()+2*block_len, block_len);
+                                        reader.start_read(buffer.get() + 2*block_len, block_len);
+                                }
+                        }
+
+                        int line_end = data_begin;
+                        while(buffer[line_end] != '\n' && line_end != data_end){
+                                ++line_end;
+                        }
+
+                        if(line_end - data_begin + 1 > block_len){
+                                error::line_length_limit_exceeded err;
+                                err.set_file_name(file_name);
+                                err.set_file_line(file_line);
+                                throw err;
+                        }
+
+                        if(buffer[line_end] == '\n'){
+                                buffer[line_end] = '\0';
+                        }else{
+                                // some files are missing the newline at the end of the
+                                // last line
+                                ++data_end;
+                                buffer[line_end] = '\0';
+                        }
+
+                        // handle windows \r\n-line breaks
+                        if(line_end != data_begin && buffer[line_end-1] == '\r')
+                                buffer[line_end-1] = '\0';
+
+                        char*ret = buffer.get() + data_begin;
+                        data_begin = line_end+1;
+                        return ret;
+                }
+        };
+
+
+        ////////////////////////////////////////////////////////////////////////////
+        //                                 CSV                                    //
+        ////////////////////////////////////////////////////////////////////////////
+
+        namespace error{
+                const int max_column_name_length = 63;
+                struct with_column_name{
+                        with_column_name(){
+                                std::memset(column_name, 0, max_column_name_length+1);
+                        }
+                       
+                        void set_column_name(const char*column_name){
+                                std::strncpy(this->column_name, column_name, max_column_name_length);
+                                this->column_name[max_column_name_length] = '\0';
+                        }
+
+                        char column_name[max_column_name_length+1];
+                };
+
+
+                const int max_column_content_length = 63;
+
+                struct with_column_content{
+                        with_column_content(){
+                                std::memset(column_content, 0, max_column_content_length+1);
+                        }
+                       
+                        void set_column_content(const char*column_content){
+                                std::strncpy(this->column_content, column_content, max_column_content_length);
+                                this->column_content[max_column_content_length] = '\0';
+                        }
+
+                        char column_content[max_column_content_length+1];
+                };
+
+
+                struct extra_column_in_header :
+                        base,
+                        with_file_name,
+                        with_column_name{
+                        void format_error_message()const{
+                                std::snprintf(error_message_buffer, sizeof(error_message_buffer),
+                                        "Extra column \"%s\" in header of file \"%s\"."
+                                        , column_name, file_name);
+                        }
+                };
+
+                struct missing_column_in_header :
+                        base,
+                        with_file_name,
+                        with_column_name{
+                        void format_error_message()const{
+                                std::snprintf(error_message_buffer, sizeof(error_message_buffer),
+                                        "Missing column \"%s\" in header of file \"%s\"."
+                                        , column_name, file_name);
+                        }
+                };
+
+                struct duplicated_column_in_header :
+                        base,
+                        with_file_name,
+                        with_column_name{
+                        void format_error_message()const{
+                                std::snprintf(error_message_buffer, sizeof(error_message_buffer),
+                                        "Duplicated column \"%s\" in header of file \"%s\"."
+                                        , column_name, file_name);
+                        }
+                };
+
+                struct header_missing :
+                        base,
+                        with_file_name{
+                        void format_error_message()const{
+                                std::snprintf(error_message_buffer, sizeof(error_message_buffer),
+                                        "Header missing in file \"%s\"."
+                                        , file_name);
+                        }
+                };
+
+                struct too_few_columns :
+                        base,
+                        with_file_name,
+                        with_file_line{
+                        void format_error_message()const{
+                                std::snprintf(error_message_buffer, sizeof(error_message_buffer),
+                                        "Too few columns in line %d in file \"%s\"."
+                                        , file_line, file_name);
+                        }
+                };
+
+                struct too_many_columns :
+                        base,
+                        with_file_name,
+                        with_file_line{
+                        void format_error_message()const{
+                                std::snprintf(error_message_buffer, sizeof(error_message_buffer),
+                                        "Too many columns in line %d in file \"%s\"."
+                                        , file_line, file_name);
+                        }
+                };
+
+                struct escaped_string_not_closed :
+                        base,
+                        with_file_name,
+                        with_file_line{
+                        void format_error_message()const{
+                                std::snprintf(error_message_buffer, sizeof(error_message_buffer),
+                                        "Escaped string was not closed in line %d in file \"%s\"."
+                                        , file_line, file_name);
+                        }
+                };
+
+                struct integer_must_be_positive :
+                        base,
+                        with_file_name,
+                        with_file_line,
+                        with_column_name,
+                        with_column_content{
+                        void format_error_message()const{
+                                std::snprintf(error_message_buffer, sizeof(error_message_buffer),
+                                        "The integer \"%s\" must be positive or 0 in column \"%s\" in file \"%s\" in line \"%d\"."
+                                        , column_content, column_name, file_name, file_line);
+                        }
+                };
+
+                struct no_digit :
+                        base,
+                        with_file_name,
+                        with_file_line,
+                        with_column_name,
+                        with_column_content{
+                        void format_error_message()const{
+                                std::snprintf(error_message_buffer, sizeof(error_message_buffer),
+                                        "The integer \"%s\" contains an invalid digit in column \"%s\" in file \"%s\" in line \"%d\"."
+                                        , column_content, column_name, file_name, file_line);
+                        }
+                };
+
+                struct integer_overflow :
+                        base,
+                        with_file_name,
+                        with_file_line,
+                        with_column_name,
+                        with_column_content{
+                        void format_error_message()const{
+                                std::snprintf(error_message_buffer, sizeof(error_message_buffer),
+                                        "The integer \"%s\" overflows in column \"%s\" in file \"%s\" in line \"%d\"."
+                                        , column_content, column_name, file_name, file_line);
+                        }
+                };
+
+                struct integer_underflow :
+                        base,
+                        with_file_name,
+                        with_file_line,
+                        with_column_name,
+                        with_column_content{
+                        void format_error_message()const{
+                                std::snprintf(error_message_buffer, sizeof(error_message_buffer),
+                                        "The integer \"%s\" underflows in column \"%s\" in file \"%s\" in line \"%d\"."
+                                        , column_content, column_name, file_name, file_line);
+                        }
+                };
+
+                struct invalid_single_character :
+                        base,
+                        with_file_name,
+                        with_file_line,
+                        with_column_name,
+                        with_column_content{
+                        void format_error_message()const{
+                                std::snprintf(error_message_buffer, sizeof(error_message_buffer),
+                                        "The content \"%s\" of column \"%s\" in file \"%s\" in line \"%d\" is not a single character."
+                                        , column_content, column_name, file_name, file_line);
+                        }
+                };
+        }
+
+        typedef unsigned ignore_column;
+        static const ignore_column ignore_no_column = 0;
+        static const ignore_column ignore_extra_column = 1;
+        static const ignore_column ignore_missing_column = 2;
+
+        template<char ... trim_char_list>
+        struct trim_chars{
+        private:
+                constexpr static bool is_trim_char(char){
+                        return false;
+                }
+       
+                template<class ...OtherTrimChars>
+                constexpr static bool is_trim_char(char c, char trim_char, OtherTrimChars...other_trim_chars){
+                        return c == trim_char || is_trim_char(c, other_trim_chars...);
+                }
+
+        public:
+                static void trim(char*&str_begin, char*&str_end){
+                        while(is_trim_char(*str_begin, trim_char_list...) && str_begin != str_end)
+                                ++str_begin;
+                        while(is_trim_char(*(str_end-1), trim_char_list...) && str_begin != str_end)
+                                --str_end;
+                        *str_end = '\0';
+                }
+        };
+
+
+        struct no_comment{
+                static bool is_comment(const char*){
+                        return false;
+                }
+        };
+
+        template<char ... comment_start_char_list>
+        struct single_line_comment{
+        private:
+                constexpr static bool is_comment_start_char(char){
+                        return false;
+                }
+       
+                template<class ...OtherCommentStartChars>
+                constexpr static bool is_comment_start_char(char c, char comment_start_char, OtherCommentStartChars...other_comment_start_chars){
+                        return c == comment_start_char || is_comment_start_char(c, other_comment_start_chars...);
+                }
+
+        public:
+
+                static bool is_comment(const char*line){
+                        return is_comment_start_char(*line, comment_start_char_list...);
+                }
+        };
+
+        struct empty_line_comment{
+                static bool is_comment(const char*line){
+                        if(*line == '\0')
+                                return true;
+                        while(*line == ' ' || *line == '\t'){
+                                ++line;
+                                if(*line == 0)
+                                        return true;
+                        }
+                        return false;
+                }
+        };
+
+        template<char ... comment_start_char_list>
+        struct single_and_empty_line_comment{
+                static bool is_comment(const char*line){
+                        return single_line_comment<comment_start_char_list...>::is_comment(line) || empty_line_comment::is_comment(line);
+                }
+        };
+
+        template<char sep>
+        struct no_quote_escape{
+                static const char*find_next_column_end(const char*col_begin){
+                        while(*col_begin != sep && *col_begin != '\0')
+                                ++col_begin;
+                        return col_begin;
+                }
+
+                static void unescape(char*&, char*&){
+
+                }
+        };
+
+        template<char sep, char quote>
+        struct double_quote_escape{
+                static const char*find_next_column_end(const char*col_begin){
+                        while(*col_begin != sep && *col_begin != '\0')
+                                if(*col_begin != quote)
+                                        ++col_begin;
+                                else{
+                                        do{
+                                                ++col_begin;
+                                                while(*col_begin != quote){
+                                                        if(*col_begin == '\0')
+                                                                throw error::escaped_string_not_closed();
+                                                        ++col_begin;
+                                                }
+                                                ++col_begin;
+                                        }while(*col_begin == quote);
+                                }      
+                        return col_begin;      
+                }
+
+                static void unescape(char*&col_begin, char*&col_end){
+                        if(col_end - col_begin >= 2){
+                                if(*col_begin == quote && *(col_end-1) == quote){
+                                        ++col_begin;
+                                        --col_end;
+                                        char*out = col_begin;
+                                        for(char*in = col_begin; in!=col_end; ++in){
+                                                if(*in == quote && (in+1) != col_end && *(in+1) == quote){
+                                                         ++in;
+                                                }
+                                                *out = *in;
+                                                ++out;
+                                        }
+                                        col_end = out;
+                                        *col_end = '\0';
+                                }
+                        }
+                       
+                }
+        };
+
+        struct throw_on_overflow{
+                template<class T>
+                static void on_overflow(T&){
+                        throw error::integer_overflow();
+                }
+               
+                template<class T>
+                static void on_underflow(T&){
+                        throw error::integer_underflow();
+                }
+        };
+
+        struct ignore_overflow{
+                template<class T>
+                static void on_overflow(T&){}
+               
+                template<class T>
+                static void on_underflow(T&){}
+        };
+
+        struct set_to_max_on_overflow{
+                template<class T>
+                static void on_overflow(T&x){
+                        x = std::numeric_limits<T>::max();
+                }
+               
+                template<class T>
+                static void on_underflow(T&x){
+                        x = std::numeric_limits<T>::min();
+                }
+        };
+
+
+        namespace detail{
+                template<class quote_policy>
+                void chop_next_column(
+                        char*&line, char*&col_begin, char*&col_end
+                ){
+                        assert(line != nullptr);
+
+                        col_begin = line;
+                        // the col_begin + (... - col_begin) removes the constness
+                        col_end = col_begin + (quote_policy::find_next_column_end(col_begin) - col_begin);
+                       
+                        if(*col_end == '\0'){
+                                line = nullptr;
+                        }else{
+                                *col_end = '\0';
+                                line = col_end + 1;    
+                        }
+                }
+
+                template<class trim_policy, class quote_policy>
+                void parse_line(
+                        char*line,
+                        char**sorted_col,
+                        const std::vector<int>&col_order
+                ){
+                        for(std::size_t i=0; i<col_order.size(); ++i){
+                                if(line == nullptr)
+                                        throw ::io::error::too_few_columns();
+                                char*col_begin, *col_end;
+                                chop_next_column<quote_policy>(line, col_begin, col_end);
+
+                                if(col_order[i] != -1){
+                                        trim_policy::trim(col_begin, col_end);
+                                        quote_policy::unescape(col_begin, col_end);
+                                                               
+                                        sorted_col[col_order[i]] = col_begin;
+                                }
+                        }
+                        if(line != nullptr)
+                                throw ::io::error::too_many_columns();
+                }
+
+                template<unsigned column_count, class trim_policy, class quote_policy>
+                void parse_header_line(
+                        char*line,
+                        std::vector<int>&col_order,
+                        const std::string*col_name,
+                        ignore_column ignore_policy
+                ){
+                        col_order.clear();
+
+                        bool found[column_count];
+                        std::fill(found, found + column_count, false);
+                        while(line){
+                                char*col_begin,*col_end;
+                                chop_next_column<quote_policy>(line, col_begin, col_end);
+
+                                trim_policy::trim(col_begin, col_end);
+                                quote_policy::unescape(col_begin, col_end);
+                               
+                                for(unsigned i=0; i<column_count; ++i)
+                                        if(col_begin == col_name[i]){
+                                                if(found[i]){
+                                                        error::duplicated_column_in_header err;
+                                                        err.set_column_name(col_begin);
+                                                        throw err;
+                                                }
+                                                found[i] = true;
+                                                col_order.push_back(i);
+                                                col_begin = 0;
+                                                break;
+                                        }
+                                if(col_begin){
+                                        if(ignore_policy & ::io::ignore_extra_column)
+                                                col_order.push_back(-1);
+                                        else{
+                                                error::extra_column_in_header err;
+                                                err.set_column_name(col_begin);
+                                                throw err;
+                                        }
+                                }
+                        }
+                        if(!(ignore_policy & ::io::ignore_missing_column)){
+                                for(unsigned i=0; i<column_count; ++i){
+                                        if(!found[i]){
+                                                error::missing_column_in_header err;
+                                                err.set_column_name(col_name[i].c_str());
+                                                throw err;
+                                        }
+                                }
+                        }
+                }
+
+                template<class overflow_policy>
+                void parse(char*col, char &x){
+                        if(!*col)
+                                throw error::invalid_single_character();
+                        x = *col;
+                        ++col;
+                        if(*col)
+                                throw error::invalid_single_character();
+                }
+               
+                template<class overflow_policy>
+                void parse(char*col, std::string&x){
+                        x = col;
+                }
+
+                template<class overflow_policy>
+                void parse(char*col, const char*&x){
+                        x = col;
+                }
+
+                template<class overflow_policy>
+                void parse(char*col, char*&x){
+                        x = col;
+                }
+
+                template<class overflow_policy, class T>
+                void parse_unsigned_integer(const char*col, T&x){
+                        x = 0;
+                        while(*col != '\0'){
+                                if('0' <= *col && *col <= '9'){
+                                        T y = *col - '0';
+                                        if(x > (std::numeric_limits<T>::max()-y)/10){
+                                                overflow_policy::on_overflow(x);
+                                                return;
+                                        }
+                                        x = 10*x+y;
+                                }else
+                                        throw error::no_digit();
+                                ++col;
+                        }
+                }
+
+                template<class overflow_policy>void parse(char*col, unsigned char &x)
+                        {parse_unsigned_integer<overflow_policy>(col, x);}
+                template<class overflow_policy>void parse(char*col, unsigned short &x)
+                        {parse_unsigned_integer<overflow_policy>(col, x);}
+                template<class overflow_policy>void parse(char*col, unsigned int &x)
+                        {parse_unsigned_integer<overflow_policy>(col, x);}
+                template<class overflow_policy>void parse(char*col, unsigned long &x)
+                        {parse_unsigned_integer<overflow_policy>(col, x);}
+                template<class overflow_policy>void parse(char*col, unsigned long long &x)
+                        {parse_unsigned_integer<overflow_policy>(col, x);}
+               
+                template<class overflow_policy, class T>
+                void parse_signed_integer(const char*col, T&x){
+                        if(*col == '-'){
+                                ++col;
+
+                                x = 0;
+                                while(*col != '\0'){
+                                        if('0' <= *col && *col <= '9'){
+                                                T y = *col - '0';
+                                                if(x < (std::numeric_limits<T>::min()+y)/10){
+                                                        overflow_policy::on_underflow(x);
+                                                        return;
+                                                }
+                                                x = 10*x-y;
+                                        }else
+                                                throw error::no_digit();
+                                        ++col;
+                                }
+                                return;
+                        }else if(*col == '+')
+                                ++col;
+                        parse_unsigned_integer<overflow_policy>(col, x);
+                }      
+
+                template<class overflow_policy>void parse(char*col, signed char &x)
+                        {parse_signed_integer<overflow_policy>(col, x);}
+                template<class overflow_policy>void parse(char*col, signed short &x)
+                        {parse_signed_integer<overflow_policy>(col, x);}
+                template<class overflow_policy>void parse(char*col, signed int &x)
+                        {parse_signed_integer<overflow_policy>(col, x);}
+                template<class overflow_policy>void parse(char*col, signed long &x)
+                        {parse_signed_integer<overflow_policy>(col, x);}
+                template<class overflow_policy>void parse(char*col, signed long long &x)
+                        {parse_signed_integer<overflow_policy>(col, x);}
+
+                template<class T>
+                void parse_float(const char*col, T&x){
+                        bool is_neg = false;
+                        if(*col == '-'){
+                                is_neg = true;
+                                ++col;
+                        }else if(*col == '+')
+                                ++col;
+
+                        x = 0;
+                        while('0' <= *col && *col <= '9'){
+                                int y = *col - '0';
+                                x *= 10;
+                                x += y;
+                                ++col;
+                        }
+                       
+                        if(*col == '.'|| *col == ','){
+                                ++col;
+                                T pos = 1;
+                                while('0' <= *col && *col <= '9'){
+                                        pos /= 10;
+                                        int y = *col - '0';
+                                        ++col;
+                                        x += y*pos;
+                                }
+                        }
+
+                        if(*col == 'e' || *col == 'E'){
+                                ++col;
+                                int e;
+
+                                parse_signed_integer<set_to_max_on_overflow>(col, e);
+                               
+                                if(e != 0){
+                                        T base;
+                                        if(e < 0){
+                                                base = 0.1;
+                                                e = -e;
+                                        }else{
+                                                base = 10;
+                                        }
+       
+                                        while(e != 1){
+                                                if((e & 1) == 0){
+                                                        base = base*base;
+                                                        e >>= 1;
+                                                }else{
+                                                        x *= base;
+                                                        --e;
+                                                }
+                                        }
+                                        x *= base;
+                                }
+                        }else{
+                                if(*col != '\0')
+                                        throw error::no_digit();
+                        }
+
+                        if(is_neg)
+                                x = -x;
+                }
+
+                template<class overflow_policy> void parse(char*col, float&x) { parse_float(col, x); }
+                template<class overflow_policy> void parse(char*col, double&x) { parse_float(col, x); }
+                template<class overflow_policy> void parse(char*col, long double&x) { parse_float(col, x); }
+
+                template<class overflow_policy, class T>
+                void parse(char*col, T&x){
+                        // GCC evalutes "false" when reading the template and
+                        // "sizeof(T)!=sizeof(T)" only when instantiating it. This is why
+                        // this strange construct is used.
+                        static_assert(sizeof(T)!=sizeof(T),
+                                "Can not parse this type. Only buildin integrals, floats, char, char*, const char* and std::string are supported");
+                }
+
+        }
+
+        template<unsigned column_count,
+                class trim_policy = trim_chars<' ', '\t'>,
+                class quote_policy = no_quote_escape<','>,
+                class overflow_policy = throw_on_overflow,
+                class comment_policy = no_comment
+        >
+        class CSVReader{
+        private:
+                LineReader in;
+
+                char*(row[column_count]);
+                std::string column_names[column_count];
+
+                std::vector<int>col_order;
+
+                template<class ...ColNames>
+                void set_column_names(std::string s, ColNames...cols){
+                        column_names[column_count-sizeof...(ColNames)-1] = std::move(s);
+                        set_column_names(std::forward<ColNames>(cols)...);
+                }
+
+                void set_column_names(){}
+
+
+        public:
+                CSVReader() = delete;
+                CSVReader(const CSVReader&) = delete;
+                CSVReader&operator=(const CSVReader&);
+
+                template<class ...Args>
+                explicit CSVReader(Args&&...args):in(std::forward<Args>(args)...){
+                        std::fill(row, row+column_count, nullptr);
+                        col_order.resize(column_count);
+                        for(unsigned i=0; i<column_count; ++i)
+                                col_order[i] = i;
+                        for(unsigned i=1; i<=column_count; ++i)
+                                column_names[i-1] = "col"+std::to_string(i);
+                }
+
+		char*next_line(){
+			return in.next_line();
+		}
+
+                template<class ...ColNames>
+                void read_header(ignore_column ignore_policy, ColNames...cols){
+                        static_assert(sizeof...(ColNames)>=column_count, "not enough column names specified");
+                        static_assert(sizeof...(ColNames)<=column_count, "too many column names specified");
+                        try{
+                                set_column_names(std::forward<ColNames>(cols)...);
+
+                                char*line;
+                                do{
+                                        line = in.next_line();
+                                        if(!line)
+                                                throw error::header_missing();
+                                }while(comment_policy::is_comment(line));
+
+                                detail::parse_header_line
+                                        <column_count, trim_policy, quote_policy>
+                                        (line, col_order, column_names, ignore_policy);
+                        }catch(error::with_file_name&err){
+                                err.set_file_name(in.get_truncated_file_name());
+                                throw;
+                        }
+                }
+
+                template<class ...ColNames>
+                void set_header(ColNames...cols){
+                        static_assert(sizeof...(ColNames)>=column_count,
+                                "not enough column names specified");
+                        static_assert(sizeof...(ColNames)<=column_count,
+                                "too many column names specified");
+                        set_column_names(std::forward<ColNames>(cols)...);
+                        std::fill(row, row+column_count, nullptr);
+                        col_order.resize(column_count);
+                        for(unsigned i=0; i<column_count; ++i)
+                                col_order[i] = i;
+                }
+
+                bool has_column(const std::string&name) const {
+                        return col_order.end() != std::find(
+                                col_order.begin(), col_order.end(),
+                                        std::find(std::begin(column_names), std::end(column_names), name)
+                                - std::begin(column_names));
+                }
+
+                void set_file_name(const std::string&file_name){
+                        in.set_file_name(file_name);
+                }
+
+                void set_file_name(const char*file_name){
+                        in.set_file_name(file_name);
+                }
+
+                const char*get_truncated_file_name()const{
+                        return in.get_truncated_file_name();
+                }
+
+                void set_file_line(unsigned file_line){
+                        in.set_file_line(file_line);
+                }
+
+                unsigned get_file_line()const{
+                        return in.get_file_line();
+                }
+
+        private:
+                void parse_helper(std::size_t){}
+
+                template<class T, class ...ColType>
+                void parse_helper(std::size_t r, T&t, ColType&...cols){                        
+                        if(row[r]){
+                                try{
+                                        try{
+                                                ::io::detail::parse<overflow_policy>(row[r], t);
+                                        }catch(error::with_column_content&err){
+                                                err.set_column_content(row[r]);
+                                                throw;
+                                        }
+                                }catch(error::with_column_name&err){
+                                        err.set_column_name(column_names[r].c_str());
+                                        throw;
+                                }
+                        }
+                        parse_helper(r+1, cols...);
+                }
+
+       
+        public:
+                template<class ...ColType>
+                bool read_row(ColType& ...cols){
+                        static_assert(sizeof...(ColType)>=column_count,
+                                "not enough columns specified");
+                        static_assert(sizeof...(ColType)<=column_count,
+                                "too many columns specified");
+                        try{
+                                try{
+       
+                                        char*line;
+                                        do{
+                                                line = in.next_line();
+                                                if(!line)
+                                                        return false;
+                                        }while(comment_policy::is_comment(line));
+                                       
+                                        detail::parse_line<trim_policy, quote_policy>
+                                                (line, row, col_order);
+               
+                                        parse_helper(0, cols...);
+                                }catch(error::with_file_name&err){
+                                        err.set_file_name(in.get_truncated_file_name());
+                                        throw;
+                                }
+                        }catch(error::with_file_line&err){
+                                err.set_file_line(in.get_file_line());
+                                throw;
+                        }
+
+                        return true;
+                }
+        };
+}
+#endif
+

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -99,6 +99,7 @@ BITCOIN_CORE_H = \
   core_io.h \
   core_memusage.h \
   cuckoocache.h \
+  forks_csv.h \
   fs.h \
   httprpc.h \
   httpserver.h \
@@ -187,6 +188,7 @@ libbitcoin_server_a_SOURCES = \
   chain.cpp \
   checkpoints.cpp \
   consensus/tx_verify.cpp \
+  forks_csv.cpp \
   httprpc.cpp \
   httpserver.cpp \
   init.cpp \
@@ -305,6 +307,7 @@ libbitcoin_common_a_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
 libbitcoin_common_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 libbitcoin_common_a_SOURCES = \
   base58.cpp \
+  chain.cpp \
   chainparams.cpp \
   coins.cpp \
   compressor.cpp \
@@ -319,6 +322,7 @@ libbitcoin_common_a_SOURCES = \
   scheduler.cpp \
   script/sign.cpp \
   script/standard.cpp \
+  versionbits.cpp \
   warnings.cpp \
   $(BITCOIN_CORE_H)
 

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -41,6 +41,8 @@ BITCOIN_TESTS =\
   test/crypto_tests.cpp \
   test/cuckoocache_tests.cpp \
   test/DoS_tests.cpp \
+  test/forkscsv_tests.cpp \
+  test/genversionbits_tests.cpp \
   test/getarg_tests.cpp \
   test/hash_tests.cpp \
   test/key_tests.cpp \

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
-// Copyright (c) 2009-2016 The Bitcoin Core developers
+// Copyright (c) 2009-2017 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -19,8 +19,10 @@
 #include "httpserver.h"
 #include "httprpc.h"
 #include "utilstrencodings.h"
+#include "forks_csv.h"
 
 #include <boost/algorithm/string/predicate.hpp>
+#include <boost/filesystem.hpp>
 #include <boost/thread.hpp>
 
 #include <stdio.h>
@@ -94,6 +96,18 @@ bool AppInit(int argc, char* argv[])
         fprintf(stdout, "%s", strUsage.c_str());
         return true;
     }
+
+    // bip135 begin
+    // dump default deployment info and exit, if requested
+    if (IsArgSet("-dumpforks")) {
+        std::string strVersion = "# " + strprintf(_("%s Daemon"), _(PACKAGE_NAME)) + " " + _("version") + " " + FormatFullVersion();
+        fprintf(stdout, "%s\n%s", strVersion.c_str(), FORKS_CSV_FILE_HEADER);
+        fprintf(stdout, "%s", NetworkDeploymentInfoCSV(CBaseChainParams::MAIN).c_str());
+        fprintf(stdout, "%s", NetworkDeploymentInfoCSV(CBaseChainParams::TESTNET).c_str());
+        fprintf(stdout, "%s", NetworkDeploymentInfoCSV(CBaseChainParams::REGTEST).c_str());
+        return true;
+    }
+    // bip135 end
 
     try
     {

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -1,10 +1,11 @@
 // Copyright (c) 2010 Satoshi Nakamoto
-// Copyright (c) 2009-2016 The Bitcoin Core developers
+// Copyright (c) 2009-2017 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "chainparams.h"
 #include "consensus/merkle.h"
+#include "versionbits.h"  // bip135 added
 
 #include "tinyformat.h"
 #include "util.h"
@@ -86,21 +87,27 @@ public:
         consensus.nPowTargetSpacing = 10 * 60;
         consensus.fPowAllowMinDifficultyBlocks = false;
         consensus.fPowNoRetargeting = false;
-        consensus.nRuleChangeActivationThreshold = 1916; // 95% of 2016
-        consensus.nMinerConfirmationWindow = 2016; // nPowTargetTimespan / nPowTargetSpacing
-        consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;
-        consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = 1199145601; // January 1, 2008
-        consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nTimeout = 1230767999; // December 31, 2008
 
         // Deployment of BIP68, BIP112, and BIP113.
         consensus.vDeployments[Consensus::DEPLOYMENT_CSV].bit = 0;
-        consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nStartTime = 1462060800; // May 1st, 2016
-        consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nTimeout = 1493596800; // May 1st, 2017
+        consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nStartTime = 1462060800LL; // May 1st, 2016
+        consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nTimeout = 1493596800LL; // May 1st, 2017
+        consensus.vDeployments[Consensus::DEPLOYMENT_CSV].windowsize = 2016;
+        consensus.vDeployments[Consensus::DEPLOYMENT_CSV].threshold = 1916; // 95% of 2016
 
         // Deployment of SegWit (BIP141, BIP143, and BIP147)
         consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].bit = 1;
-        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nStartTime = 1479168000; // November 15th, 2016.
-        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nTimeout = 1510704000; // November 15th, 2017.
+        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nStartTime = 1479168000LL; // November 15th, 2016.
+        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nTimeout = 1510704000LL; // November 15th, 2017.
+        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].windowsize = 2016;
+        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].threshold = 1916; // 95% of 2016
+
+        // testing bit
+        consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;
+        consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = 1199145601LL; // January 1, 2008
+        consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nTimeout = 1230767999LL; // December 31, 2008
+        consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].windowsize = 2016;
+        consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].threshold = 1916; // 95% of 2016
 
         // The best chain should have at least this much work.
         consensus.nMinimumChainWork = uint256S("0x0000000000000000000000000000000000000000003f94d1ad391682fe038bf5");
@@ -189,21 +196,25 @@ public:
         consensus.nPowTargetSpacing = 10 * 60;
         consensus.fPowAllowMinDifficultyBlocks = true;
         consensus.fPowNoRetargeting = false;
-        consensus.nRuleChangeActivationThreshold = 1512; // 75% for testchains
-        consensus.nMinerConfirmationWindow = 2016; // nPowTargetTimespan / nPowTargetSpacing
-        consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;
-        consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = 1199145601; // January 1, 2008
-        consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nTimeout = 1230767999; // December 31, 2008
-
         // Deployment of BIP68, BIP112, and BIP113.
         consensus.vDeployments[Consensus::DEPLOYMENT_CSV].bit = 0;
-        consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nStartTime = 1456790400; // March 1st, 2016
-        consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nTimeout = 1493596800; // May 1st, 2017
+        consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nStartTime = 1456790400LL; // March 1st, 2016
+        consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nTimeout = 1493596800LL; // May 1st, 2017
+        consensus.vDeployments[Consensus::DEPLOYMENT_CSV].windowsize = 2016;
+        consensus.vDeployments[Consensus::DEPLOYMENT_CSV].threshold = 1512; // 75% of 2016
 
         // Deployment of SegWit (BIP141, BIP143, and BIP147)
         consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].bit = 1;
-        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nStartTime = 1462060800; // May 1st 2016
-        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nTimeout = 1493596800; // May 1st 2017
+        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nStartTime = 1462060800LL; // May 1st 2016
+        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nTimeout = 1493596800LL; // May 1st 2017
+        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].windowsize = 2016;
+        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].threshold = 1512; // 75% of 2016
+
+        consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;
+        consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = 1199145601LL; // January 1, 2008
+        consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nTimeout = 1230767999LL; // December 31, 2008
+        consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].windowsize = 2016;
+        consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].threshold = 1512; // 75% of 2016
 
         // The best chain should have at least this much work.
         consensus.nMinimumChainWork = uint256S("0x00000000000000000000000000000000000000000000001f057509eba81aed91");
@@ -276,17 +287,24 @@ public:
         consensus.nPowTargetSpacing = 10 * 60;
         consensus.fPowAllowMinDifficultyBlocks = true;
         consensus.fPowNoRetargeting = true;
-        consensus.nRuleChangeActivationThreshold = 108; // 75% for testchains
-        consensus.nMinerConfirmationWindow = 144; // Faster than normal for regtest (144 instead of 2016)
-        consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;
-        consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = 0;
-        consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nTimeout = 999999999999ULL;
         consensus.vDeployments[Consensus::DEPLOYMENT_CSV].bit = 0;
         consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nStartTime = 0;
-        consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nTimeout = 999999999999ULL;
+        consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nTimeout = 999999999999LL;
+        // Faster than normal for regtest (144 instead of 2016 blocks)
+        consensus.vDeployments[Consensus::DEPLOYMENT_CSV].windowsize = 144;
+        consensus.vDeployments[Consensus::DEPLOYMENT_CSV].threshold = 108; // 75% of 144
+
         consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].bit = 1;
         consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nStartTime = 0;
-        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nTimeout = 999999999999ULL;
+        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nTimeout = 999999999999LL;
+        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].windowsize = 144;
+        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].threshold = 108; // 75% of 144
+
+        consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;
+        consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = 0;
+        consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nTimeout = 999999999999LL;
+        consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].windowsize = 144;
+        consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].threshold = 108; // 75% of 144
 
         // The best chain should have at least this much work.
         consensus.nMinimumChainWork = uint256S("0x00");
@@ -339,6 +357,25 @@ const CChainParams &Params() {
     return *globalChainParams;
 }
 
+CChainParams& Params(const std::string& chain)
+{
+    CChainParams *chainparams;
+
+    if (chain == CBaseChainParams::MAIN) {
+        chainparams = new CMainParams();
+        return (CChainParams&) *chainparams;
+    }
+    else if (chain == CBaseChainParams::TESTNET) {
+        chainparams = new CTestNetParams();
+        return (CChainParams&) *chainparams;
+    }
+    else if (chain == CBaseChainParams::REGTEST) {
+        chainparams = new CRegTestParams();
+        return (CChainParams&) *chainparams;
+    }
+    throw std::runtime_error(strprintf("%s: Unknown chain %s.", __func__, chain));
+}
+
 std::unique_ptr<CChainParams> CreateChainParams(const std::string& chain)
 {
     if (chain == CBaseChainParams::MAIN)
@@ -361,3 +398,68 @@ void UpdateBIP9Parameters(Consensus::DeploymentPos d, int64_t nStartTime, int64_
     globalChainParams->UpdateBIP9Parameters(d, nStartTime, nTimeout);
 }
  
+// bip135 begin
+/**
+ * Return true if a deployment is considered to be configured for the network.
+ * Deployments with a zero-length name, or a windowsize or threshold equal to
+ * zero are not considered to be configured, and will be reported as 'unknown'
+ * if signals are detected for them.
+ * Unconfigured deployments can be ignored to save processing time, e.g.
+ * in ComputeBlockVersion() when computing the default block version to emit.
+ */
+bool isConfiguredDeployment(const Consensus::Params& consensusParams, const int bit)
+{
+    const Consensus::BIP9Deployment *vdeployments = consensusParams.vDeployments;
+    const struct BIP9DeploymentInfo& vbinfo = VersionBitsDeploymentInfo[bit];
+
+    if (strlen(vbinfo.name) == 0)
+        return false;
+
+    if (vdeployments[bit].windowsize == 0 || vdeployments[bit].threshold == 0)
+    {
+        return false;
+    }
+    return true;
+}
+
+/**
+ * Return a string representing CSV-formatted deployments for the network.
+ * Only configured deployments satisfying isConfiguredDeployment() are included.
+ */
+const std::string NetworkDeploymentInfoCSV(const std::string& network)
+{
+    const Consensus::Params& consensusParams = Params(network).GetConsensus();
+    const Consensus::BIP9Deployment *vdeployments = consensusParams.vDeployments;
+
+    std::string networkInfoStr;
+    networkInfoStr = "# deployment info for network '" + network + "':\n";
+
+    for (int bit = 0; bit < Consensus::MAX_VERSION_BITS_DEPLOYMENTS; bit++)
+    {
+        const struct BIP9DeploymentInfo& vbinfo = VersionBitsDeploymentInfo[bit];
+        if (isConfiguredDeployment(consensusParams, bit)) {
+            networkInfoStr += network + ",";
+            networkInfoStr += std::to_string(bit) + ",";
+            networkInfoStr += std::string(vbinfo.name) + ",";
+            networkInfoStr += std::to_string(vdeployments[bit].nStartTime) + ",";
+            networkInfoStr += std::to_string(vdeployments[bit].nTimeout) + ",";
+            networkInfoStr += std::to_string(vdeployments[bit].windowsize) + ",";
+            networkInfoStr += std::to_string(vdeployments[bit].threshold) + ",";
+            networkInfoStr += std::to_string(vdeployments[bit].minlockedblocks) + ",";
+            networkInfoStr += std::to_string(vdeployments[bit].minlockedtime) + ",";
+            networkInfoStr += (vbinfo.gbt_force ? "true" : "false");
+            networkInfoStr += "\n";
+        }
+    }
+    return networkInfoStr;
+}
+
+/**
+ * Return a modifiable reference to the chain params, to be updated by the
+ * CSV deployment data reading routine.
+ */
+CChainParams &ModifiableParams() {
+    assert(globalChainParams);
+    return *globalChainParams;
+}
+// bip135 end

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -415,11 +415,7 @@ bool isConfiguredDeployment(const Consensus::Params& consensusParams, const int 
     if (strlen(vbinfo.name) == 0)
         return false;
 
-    if (vdeployments[bit].windowsize == 0 || vdeployments[bit].threshold == 0)
-    {
-        return false;
-    }
-    return true;
+    return (vdeployments[bit].windowsize != 0 && vdeployments[bit].threshold != 0);
 }
 
 /**

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -409,8 +409,8 @@ void UpdateBIP9Parameters(Consensus::DeploymentPos d, int64_t nStartTime, int64_
  */
 bool isConfiguredDeployment(const Consensus::Params& consensusParams, const int bit)
 {
-    const Consensus::BIP9Deployment *vdeployments = consensusParams.vDeployments;
-    const struct BIP9DeploymentInfo& vbinfo = VersionBitsDeploymentInfo[bit];
+    const Consensus::ForkDeployment *vdeployments = consensusParams.vDeployments;
+    const struct ForkDeploymentInfo& vbinfo = VersionBitsDeploymentInfo[bit];
 
     if (strlen(vbinfo.name) == 0)
         return false;
@@ -425,14 +425,14 @@ bool isConfiguredDeployment(const Consensus::Params& consensusParams, const int 
 const std::string NetworkDeploymentInfoCSV(const std::string& network)
 {
     const Consensus::Params& consensusParams = Params(network).GetConsensus();
-    const Consensus::BIP9Deployment *vdeployments = consensusParams.vDeployments;
+    const Consensus::ForkDeployment *vdeployments = consensusParams.vDeployments;
 
     std::string networkInfoStr;
     networkInfoStr = "# deployment info for network '" + network + "':\n";
 
     for (int bit = 0; bit < Consensus::MAX_VERSION_BITS_DEPLOYMENTS; bit++)
     {
-        const struct BIP9DeploymentInfo& vbinfo = VersionBitsDeploymentInfo[bit];
+        const struct ForkDeploymentInfo& vbinfo = VersionBitsDeploymentInfo[bit];
         if (isConfiguredDeployment(consensusParams, bit)) {
             networkInfoStr += network + ",";
             networkInfoStr += std::to_string(bit) + ",";

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -1,5 +1,5 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
-// Copyright (c) 2009-2016 The Bitcoin Core developers
+// Copyright (c) 2009-2017 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -58,6 +58,8 @@ public:
     };
 
     const Consensus::Params& GetConsensus() const { return consensus; }
+    /** Modifiable consensus parameters added by bip135 */
+    Consensus::Params& GetModifiableConsensus() { return consensus; }
     const CMessageHeader::MessageStartChars& MessageStart() const { return pchMessageStart; }
     int GetDefaultPort() const { return nDefaultPort; }
 
@@ -109,11 +111,33 @@ std::unique_ptr<CChainParams> CreateChainParams(const std::string& chain);
  */
 const CChainParams &Params();
 
+CChainParams& Params(const std::string& chain);
+
 /**
  * Sets the params returned by Params() to those for the given BIP70 chain name.
  * @throws std::runtime_error when the chain is not supported.
  */
 void SelectParams(const std::string& chain);
+
+// bip135 begin
+/**
+ * Return the currently selected parameters. Can be changed by reading in
+ * some additional config files (e.g. CSV deployment data)
+ */
+CChainParams &ModifiableParams();
+
+/**
+ * Returns true if a deployment is considered active on a particular network
+ */
+
+bool isConfiguredDeployment(const Consensus::Params& consensusParams, const int bit);
+
+/**
+ * Dump the fork deployment parameters for the given BIP70 chain name.
+ * @throws std::runtime_error when the chain is not supported.
+ */
+const std::string NetworkDeploymentInfoCSV(const std::string& chain);
+// bip135 end
 
 /**
  * Allows modifying the BIP9 regtest parameters.

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -1,5 +1,5 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
-// Copyright (c) 2009-2016 The Bitcoin Core developers
+// Copyright (c) 2009-2017 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -14,9 +14,44 @@ namespace Consensus {
 
 enum DeploymentPos
 {
-    DEPLOYMENT_TESTDUMMY,
-    DEPLOYMENT_CSV, // Deployment of BIP68, BIP112, and BIP113.
-    DEPLOYMENT_SEGWIT, // Deployment of BIP141, BIP143, and BIP147.
+    // bip135 begin
+    // List of deployment bits. Known allocated bits should be described by a
+    // name, even if their deployment logic is not implemented by the client.
+    // (their info is nevertheless useful for awareness and event logging)
+    // When a bit goes back to being unused, it should be renamed to
+    // DEPLOYMENT_UNASSIGNED_BIT_x .
+    // NOTE: Also add new deployments to VersionBitsDeploymentInfo in versionbits.cpp
+    DEPLOYMENT_CSV = 0,  // bit 0 - deployment of BIP68, BIP112, and BIP113.
+    DEPLOYMENT_SEGWIT,   // bit 1 - Segregated Witness (BIP141, BIP143, BIP147)
+    // begin unassigned bits. Rename bits when allocated.
+    DEPLOYMENT_UNASSIGNED_BIT_2,
+    DEPLOYMENT_UNASSIGNED_BIT_3,
+    DEPLOYMENT_UNASSIGNED_BIT_4,
+    DEPLOYMENT_UNASSIGNED_BIT_5,
+    DEPLOYMENT_UNASSIGNED_BIT_6,
+    DEPLOYMENT_UNASSIGNED_BIT_7,
+    DEPLOYMENT_UNASSIGNED_BIT_8,
+    DEPLOYMENT_UNASSIGNED_BIT_9,
+    DEPLOYMENT_UNASSIGNED_BIT_10,
+    DEPLOYMENT_UNASSIGNED_BIT_11,
+    DEPLOYMENT_UNASSIGNED_BIT_12,
+    DEPLOYMENT_UNASSIGNED_BIT_13,
+    DEPLOYMENT_UNASSIGNED_BIT_14,
+    DEPLOYMENT_UNASSIGNED_BIT_15,
+    DEPLOYMENT_UNASSIGNED_BIT_16,
+    DEPLOYMENT_UNASSIGNED_BIT_17,
+    DEPLOYMENT_UNASSIGNED_BIT_18,
+    DEPLOYMENT_UNASSIGNED_BIT_19,
+    DEPLOYMENT_UNASSIGNED_BIT_20,
+    DEPLOYMENT_UNASSIGNED_BIT_21,
+    DEPLOYMENT_UNASSIGNED_BIT_22,
+    DEPLOYMENT_UNASSIGNED_BIT_23,
+    DEPLOYMENT_UNASSIGNED_BIT_24,
+    DEPLOYMENT_UNASSIGNED_BIT_25,
+    DEPLOYMENT_UNASSIGNED_BIT_26,
+    DEPLOYMENT_UNASSIGNED_BIT_27,
+    DEPLOYMENT_TESTDUMMY,  // bit 28 - used for deployment testing purposes
+    // bip135 end
     // NOTE: Also add new deployments to VersionBitsDeploymentInfo in versionbits.cpp
     MAX_VERSION_BITS_DEPLOYMENTS
 };
@@ -31,6 +66,16 @@ struct BIP9Deployment {
     int64_t nStartTime;
     /** Timeout/expiry MedianTime for the deployment attempt. */
     int64_t nTimeout;
+    // bip135 begin added parameters
+    /** Window size (in blocks) for generalized versionbits signal tallying */
+    int windowsize;
+    /** Threshold (in blocks / window) for generalized versionbits lock-in */
+    int threshold;
+    /** Minimum number of blocks to remain in locked-in state */
+    int minlockedblocks;
+    /** Minimum duration (in seconds based on MTP) to remain in locked-in state */
+    int64_t minlockedtime;
+    // bip135 end added parameters
 };
 
 /**
@@ -51,9 +96,43 @@ struct Params {
      * (nPowTargetTimespan / nPowTargetSpacing) which is also used for BIP9 deployments.
      * Examples: 1916 for 95%, 1512 for testchains.
      */
-    uint32_t nRuleChangeActivationThreshold;
-    uint32_t nMinerConfirmationWindow;
-    BIP9Deployment vDeployments[MAX_VERSION_BITS_DEPLOYMENTS];
+    /**
+     * Deployment parameters for the 29 bits (0..28) defined by bip135
+     */
+    // bip135 begin
+    // fully initialize array
+    BIP9Deployment vDeployments[MAX_VERSION_BITS_DEPLOYMENTS] = {
+            { 0, 0LL, 0LL, 0, 0, 0, 0LL },  // deployment on bit 0
+            { 1, 0LL, 0LL, 0, 0, 0, 0LL },  // deployment on bit 1
+            { 2, 0LL, 0LL, 0, 0, 0, 0LL },  // deployment on bit 2
+            { 3, 0LL, 0LL, 0, 0, 0, 0LL },  // deployment on bit 3
+            { 4, 0LL, 0LL, 0, 0, 0, 0LL },  // deployment on bit 4
+            { 5, 0LL, 0LL, 0, 0, 0, 0LL },  // deployment on bit 5
+            { 6, 0LL, 0LL, 0, 0, 0, 0LL },  // deployment on bit 6
+            { 7, 0LL, 0LL, 0, 0, 0, 0LL },  // deployment on bit 7
+            { 8, 0LL, 0LL, 0, 0, 0, 0LL },  // deployment on bit 8
+            { 9, 0LL, 0LL, 0, 0, 0, 0LL },  // deployment on bit 9
+            { 10, 0LL, 0LL, 0, 0, 0, 0LL }, // deployment on bit 10
+            { 11, 0LL, 0LL, 0, 0, 0, 0LL }, // deployment on bit 11
+            { 12, 0LL, 0LL, 0, 0, 0, 0LL }, // deployment on bit 12
+            { 13, 0LL, 0LL, 0, 0, 0, 0LL }, // deployment on bit 13
+            { 14, 0LL, 0LL, 0, 0, 0, 0LL }, // deployment on bit 14
+            { 15, 0LL, 0LL, 0, 0, 0, 0LL }, // deployment on bit 15
+            { 16, 0LL, 0LL, 0, 0, 0, 0LL }, // deployment on bit 16
+            { 17, 0LL, 0LL, 0, 0, 0, 0LL }, // deployment on bit 17
+            { 18, 0LL, 0LL, 0, 0, 0, 0LL }, // deployment on bit 18
+            { 19, 0LL, 0LL, 0, 0, 0, 0LL }, // deployment on bit 19
+            { 20, 0LL, 0LL, 0, 0, 0, 0LL }, // deployment on bit 20
+            { 21, 0LL, 0LL, 0, 0, 0, 0LL }, // deployment on bit 21
+            { 22, 0LL, 0LL, 0, 0, 0, 0LL }, // deployment on bit 22
+            { 23, 0LL, 0LL, 0, 0, 0, 0LL }, // deployment on bit 23
+            { 24, 0LL, 0LL, 0, 0, 0, 0LL }, // deployment on bit 24
+            { 25, 0LL, 0LL, 0, 0, 0, 0LL }, // deployment on bit 25
+            { 26, 0LL, 0LL, 0, 0, 0, 0LL }, // deployment on bit 26
+            { 27, 0LL, 0LL, 0, 0, 0, 0LL }, // deployment on bit 27
+            { 28, 0LL, 0LL, 0, 0, 0, 0LL }, // deployment on bit 28
+    };
+    // bip135 end
     /** Proof of work parameters */
     uint256 powLimit;
     bool fPowAllowMinDifficultyBlocks;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -57,9 +57,9 @@ enum DeploymentPos
 };
 
 /**
- * Struct for each individual consensus rule change using BIP9.
+ * Struct for each individual consensus rule change using BIP135.
  */
-struct BIP9Deployment {
+struct ForkDeployment {
     /** Bit position to select the particular bit in nVersion. */
     int bit;
     /** Start MedianTime for version bits miner confirmation. Can be a date in the past */
@@ -92,16 +92,11 @@ struct Params {
     /** Block height at which BIP66 becomes active */
     int BIP66Height;
     /**
-     * Minimum blocks including miner confirmation of the total of 2016 blocks in a retargeting period,
-     * (nPowTargetTimespan / nPowTargetSpacing) which is also used for BIP9 deployments.
-     * Examples: 1916 for 95%, 1512 for testchains.
-     */
-    /**
      * Deployment parameters for the 29 bits (0..28) defined by bip135
      */
     // bip135 begin
     // fully initialize array
-    BIP9Deployment vDeployments[MAX_VERSION_BITS_DEPLOYMENTS] = {
+    ForkDeployment vDeployments[MAX_VERSION_BITS_DEPLOYMENTS] = {
             { 0, 0LL, 0LL, 0, 0, 0, 0LL },  // deployment on bit 0
             { 1, 0LL, 0LL, 0, 0, 0, 0LL },  // deployment on bit 1
             { 2, 0LL, 0LL, 0, 0, 0, 0LL },  // deployment on bit 2

--- a/src/forks_csv.cpp
+++ b/src/forks_csv.cpp
@@ -1,0 +1,240 @@
+// Copyright (c) 2017 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <inttypes.h>
+#include <string>
+#include <boost/algorithm/string.hpp>
+
+#include "fast-cpp-csv-parser/csv.h"
+
+#include "chainparamsbase.h"
+#include "forks_csv.h"
+#include "util.h"
+
+
+using namespace std;
+using namespace io;
+
+// bip135 begin
+/** File header for -dumpforks output */
+const char *FORKS_CSV_FILE_HEADER = \
+    "# forks.csv - Fork deployment configuration (from built-in defaults)\n" \
+    "# This file defines the known consensus changes tracked by the software\n" \
+    "# MODIFY AT OWN RISK - EXERCISE EXTREME CARE\n" \
+    "# Line format:\n" \
+    "# network,bit,name,starttime,timeout,windowsize,threshold,minlockedblocks,minlockedtime,gbtforce\n";
+// bip135 end
+
+/**
+ * Read deployment CSV file and update consensus parameters
+ */
+bool ReadForksCsv(string activeNetworkID, istream& csvInput, Consensus::Params& consensusParams)
+{
+    string network, name, gbtforce;
+    int bit, windowsize, threshold, minlockedblocks;
+    int64_t starttime, timeout, minlockedtime;
+    bool errors_found = false;
+
+    // set up CSV reader instance
+    CSVReader<10,
+              trim_chars<' ', '\t'>,
+              double_quote_escape<',','\"'>,
+              throw_on_overflow,
+              single_line_comment<'#', ';'> > in(FORKS_CSV_FILENAME, csvInput);
+
+    // set meaning of fields - header in file should remain commented out
+    in.set_header("network",
+                  "bit",
+                  "name",
+                  "starttime",
+                  "timeout",
+                  "windowsize",
+                  "threshold",
+                  "minlockedblocks",
+                  "minlockedtime",
+                  "gbtforce");
+
+    // read lines, skipping comments
+    try {
+        while(in.read_row(network,
+                          bit,
+                          name,
+                          starttime,
+                          timeout,
+                          windowsize,
+                          threshold,
+                          minlockedblocks,
+                          minlockedtime,
+                          gbtforce))
+        {
+
+            bool line_validates_ok = true;
+            ostringstream errStringStream;
+            // prepare an error message prefix string
+            errStringStream << "Error: " << FORKS_CSV_FILENAME << ":" << in.get_file_line() << " ";
+
+            // validate all the input fields (if there was an error the parser
+            // would throw an exception that is handled below
+            if (!ValidateNetwork(network)) {
+                string errStr = errStringStream.str() + "unknown network name '" + network + "'";
+                LineValidationError(errStr);
+                line_validates_ok = false;
+            }
+
+            if (!ValidateBit(bit)) {
+                string errStr = errStringStream.str() + "invalid bit number (" + to_string(bit) + ")";
+                LineValidationError(errStr);
+                line_validates_ok = false;
+            }
+
+            if (!ValidateForkName(name)) {
+                string errStr = errStringStream.str() + "invalid fork name '" + name + "'";
+                LineValidationError(errStr);
+                line_validates_ok = false;
+            }
+
+            if (!ValidateTimes(starttime, timeout)) {
+                string errStr = errStringStream.str() + "invalid starttime/timeout";
+                LineValidationError(errStr);
+                line_validates_ok = false;
+            }
+
+            if (!ValidateWindowSize(windowsize)) {
+                string errStr = errStringStream.str() + "invalid window size ("+ to_string(windowsize) + ")";
+                LineValidationError(errStr);
+                line_validates_ok = false;
+            }
+
+            if (!ValidateThreshold(threshold, windowsize)) {
+                string errStr = errStringStream.str() + "invalid threshold ("+ to_string(threshold) + ")";
+                LineValidationError(errStr);
+                line_validates_ok = false;
+            }
+
+            if (!line_validates_ok) {
+                // set errors and skip to next line if current one did not validate.
+                errors_found = true;
+                continue;
+            }
+            else {
+                // Can do more overall validation of the line data here.
+                // This is not yet implemented.
+            }
+
+            // update the fork parameters only if matching the active network
+            // the rest are validated, but not activated.
+            // NOTE: ValidateOverallParams() is stubbed.
+            if (network == activeNetworkID && ValidateOverallParams(network)) {
+                assert(bit >= 0 && bit < VERSIONBITS_NUM_BITS);
+                // update deployment params for current network
+                BIP9DeploymentInfo& vbinfo = VersionBitsDeploymentInfo[bit];
+
+                // copy the data
+                if (name.length()) {
+                    char* c = new char[name.length() + 1];
+                    strncpy(c, name.c_str(), name.length());
+                    c[name.length()] = 0;
+                    vbinfo.name = c;
+                }
+                consensusParams.vDeployments[bit].bit = bit;
+                consensusParams.vDeployments[bit].nStartTime = starttime;
+                consensusParams.vDeployments[bit].nTimeout = timeout;
+                consensusParams.vDeployments[bit].windowsize = windowsize;
+                consensusParams.vDeployments[bit].threshold = threshold;
+                consensusParams.vDeployments[bit].minlockedblocks = minlockedblocks;
+                consensusParams.vDeployments[bit].minlockedtime = minlockedtime;
+            }
+        }
+    }
+    catch (const std::exception& e) {
+        string errStr = e.what();
+        LineValidationError(errStr);
+        return false;
+    }
+    return (!errors_found);
+}
+
+
+bool ValidateNetwork(const string& networkname)
+{
+    // check that network is one we know about
+    if (networkname == CBaseChainParams::MAIN)
+        return true;
+    else if (networkname == CBaseChainParams::TESTNET)
+        return true;
+    else if (networkname == CBaseChainParams::REGTEST)
+        return true;
+    else
+        return false;
+}
+
+
+bool ValidateForkName(const string& forkname)
+{
+    return (forkname.length() > 0);
+}
+
+
+bool ValidateGBTForce(const string& gbtforce)
+{
+    string gbtforceLower(gbtforce);
+    boost::algorithm::to_lower(gbtforceLower);
+    if (gbtforceLower == "false" || gbtforceLower == "true")
+        return true;
+    else
+        return false;
+}
+
+
+bool ValidateBit(int bit)
+{
+    return (bit >= 0 && bit < VERSIONBITS_NUM_BITS);
+}
+
+
+bool ValidateWindowSize(int windowsize)
+{
+    return (windowsize > 1);
+}
+
+
+bool ValidateThreshold(int threshold, int window)
+{
+    return (ValidateWindowSize(window) && threshold > 0 && threshold <= window);
+}
+
+
+bool ValidateTimes(int64_t starttime, int64_t timeout)
+{
+    return (starttime >= 0 && starttime < timeout);
+}
+
+
+bool ValidateMinLockedBlocks(int minlockedblocks)
+{
+    return (minlockedblocks >= 0);
+}
+
+
+bool ValidateMinLockedTime(int64_t minlockedtime)
+{
+    return (minlockedtime >= 0);
+}
+
+
+bool ValidateOverallParams(const string& checkNetworkID)
+{
+    // Stubbed function which should cross-check all parameters for the
+    // given network and return true only if they are correct and consistent.
+    //
+    // This includes checks like duplicate bits or fork names, and disjointness
+    // of time ranges of forks.
+    return true;
+}
+
+
+void LineValidationError(string errmsg)
+{
+    LogPrintf("%s\n", errmsg);
+}

--- a/src/forks_csv.cpp
+++ b/src/forks_csv.cpp
@@ -128,7 +128,7 @@ bool ReadForksCsv(string activeNetworkID, istream& csvInput, Consensus::Params& 
             if (network == activeNetworkID && ValidateOverallParams(network)) {
                 assert(bit >= 0 && bit < VERSIONBITS_NUM_BITS);
                 // update deployment params for current network
-                BIP9DeploymentInfo& vbinfo = VersionBitsDeploymentInfo[bit];
+                ForkDeploymentInfo& vbinfo = VersionBitsDeploymentInfo[bit];
 
                 // copy the data
                 if (name.length()) {

--- a/src/forks_csv.h
+++ b/src/forks_csv.h
@@ -1,0 +1,52 @@
+// Copyright (c) 2017 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_FORKS_CSV
+#define BITCOIN_FORKS_CSV
+
+#include <fstream>
+
+#include "consensus/params.h"
+#include "versionbits.h"
+
+extern const char *const FORKS_CSV_FILENAME;  // from util.cpp
+extern const char *FORKS_CSV_FILE_HEADER;
+
+
+/**
+ * Reads the CSV file and updates data in the consensus params.
+ * Returns true if the data validated correctly, or false if any validation errors.
+ * Validation errors should result in caller aborting safely rather than
+ * proceeding on possibly incomplete fork data.
+ */
+extern bool ReadForksCsv(std::string activeNetworkID, std::istream& csvInput, Consensus::Params& consensusParams);
+
+/**
+ * individual deployment line item validation functions.
+ * Each function returns true if items checked are ok, false otherwise.
+ */
+bool ValidateNetwork(const std::string& networkname);
+bool ValidateForkName(const std::string& forkname);
+bool ValidateGBTForce(const std::string& gbtforce);
+bool ValidateBit(const int bit);
+bool ValidateWindowSize(const int windowsize);
+bool ValidateThreshold(const int threshold, const int window);
+bool ValidateTimes(const int64_t starttime, const int64_t timeout);
+bool ValidateMinLockedBlocks(const int minlockedblocks);
+bool ValidateMinLockedTime(const int64_t minlockedtime);
+
+/**
+ * Validate the deployment parameters for the entire network altogether.
+ * This can catch things like repeated name / bits, overlapping deployment times
+ * etc.
+ */
+bool ValidateOverallParams(const std::string& checkNetworkID);
+
+/**
+ * Print an error message if validation of a line fails on an item.
+ * This is logged both to file and to stderr to alert the operator.
+ */
+void LineValidationError(std::string errmsg);
+
+#endif

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1208,7 +1208,7 @@ UniValue getblockchaininfo(const JSONRPCRequest& request)
     for (int i = 0; i < Consensus::MAX_VERSION_BITS_DEPLOYMENTS; i++)
     {
         Consensus::DeploymentPos bit = static_cast<Consensus::DeploymentPos>(i);
-        const struct BIP9DeploymentInfo& vbinfo = VersionBitsDeploymentInfo[bit];
+        const struct ForkDeploymentInfo& vbinfo = VersionBitsDeploymentInfo[bit];
         if (isConfiguredDeployment(consensusParams, bit)) {
             bip9_softforks.push_back(Pair(vbinfo.name, BIP9SoftForkDesc(consensusParams, bit)));
             bip135_forks.push_back(Pair(vbinfo.name, BIP135ForkDesc(consensusParams, bit)));

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -616,42 +616,44 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
     UniValue aRules(UniValue::VARR);
     UniValue vbavailable(UniValue::VOBJ);
     for (int j = 0; j < (int)Consensus::MAX_VERSION_BITS_DEPLOYMENTS; ++j) {
-        Consensus::DeploymentPos pos = Consensus::DeploymentPos(j);
-        ThresholdState state = VersionBitsState(pindexPrev, consensusParams, pos, versionbitscache);
-        switch (state) {
-            case THRESHOLD_DEFINED:
-            case THRESHOLD_FAILED:
-                // Not exposed to GBT at all
-                break;
-            case THRESHOLD_LOCKED_IN:
-                // Ensure bit is set in block version
-                pblock->nVersion |= VersionBitsMask(consensusParams, pos);
-                // FALL THROUGH to get vbavailable set...
-            case THRESHOLD_STARTED:
-            {
-                const struct BIP9DeploymentInfo& vbinfo = VersionBitsDeploymentInfo[pos];
-                vbavailable.push_back(Pair(gbt_vb_name(pos), consensusParams.vDeployments[pos].bit));
-                if (setClientRules.find(vbinfo.name) == setClientRules.end()) {
-                    if (!vbinfo.gbt_force) {
-                        // If the client doesn't support this, don't indicate it in the [default] version
-                        pblock->nVersion &= ~VersionBitsMask(consensusParams, pos);
+        if (Params().NetworkIDString() != CBaseChainParams::REGTEST || j != Consensus::DEPLOYMENT_TESTDUMMY) {
+            Consensus::DeploymentPos pos = Consensus::DeploymentPos(j);
+            ThresholdState state = VersionBitsState(pindexPrev, consensusParams, pos, versionbitscache);
+            switch (state) {
+                case THRESHOLD_DEFINED:
+                case THRESHOLD_FAILED:
+                    // Not exposed to GBT at all
+                    break;
+                case THRESHOLD_LOCKED_IN:
+                    // Ensure bit is set in block version
+                    pblock->nVersion |= VersionBitsMask(consensusParams, pos);
+                    // FALL THROUGH to get vbavailable set...
+                case THRESHOLD_STARTED:
+                {
+                    const struct BIP9DeploymentInfo& vbinfo = VersionBitsDeploymentInfo[pos];
+                    vbavailable.push_back(Pair(gbt_vb_name(pos), consensusParams.vDeployments[pos].bit));
+                    if (setClientRules.find(vbinfo.name) == setClientRules.end()) {
+                        if (!vbinfo.gbt_force) {
+                            // If the client doesn't support this, don't indicate it in the [default] version
+                            pblock->nVersion &= ~VersionBitsMask(consensusParams, pos);
+                        }
                     }
+                    break;
                 }
-                break;
-            }
-            case THRESHOLD_ACTIVE:
-            {
-                // Add to rules only
-                const struct BIP9DeploymentInfo& vbinfo = VersionBitsDeploymentInfo[pos];
-                aRules.push_back(gbt_vb_name(pos));
-                if (setClientRules.find(vbinfo.name) == setClientRules.end()) {
-                    // Not supported by the client; make sure it's safe to proceed
-                    if (!vbinfo.gbt_force) {
-                        // If we do anything other than throw an exception here, be sure version/force isn't sent to old clients
-                        throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Support for '%s' rule requires explicit client support", vbinfo.name));
+                case THRESHOLD_ACTIVE:
+                {
+                    // Add to rules only
+                    const struct BIP9DeploymentInfo& vbinfo = VersionBitsDeploymentInfo[pos];
+                    aRules.push_back(gbt_vb_name(pos));
+                    if (setClientRules.find(vbinfo.name) == setClientRules.end()) {
+                        // Not supported by the client; make sure it's safe to proceed
+                        if (!vbinfo.gbt_force) {
+                            // If we do anything other than throw an exception here, be sure version/force isn't sent to old clients
+                            throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Support for '%s' rule requires explicit client support", vbinfo.name));
+                        }
                     }
+                    break;
                 }
-                break;
             }
         }
     }

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -303,7 +303,7 @@ static UniValue BIP22ValidationResult(const CValidationState& state)
 }
 
 std::string gbt_vb_name(const Consensus::DeploymentPos pos) {
-    const struct BIP9DeploymentInfo& vbinfo = VersionBitsDeploymentInfo[pos];
+    const struct ForkDeploymentInfo& vbinfo = VersionBitsDeploymentInfo[pos];
     std::string s = vbinfo.name;
     if (!vbinfo.gbt_force) {
         s.insert(s.begin(), '!');
@@ -515,7 +515,7 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
         // TODO: Maybe recheck connections/IBD and (if something wrong) send an expires-immediately template to stop miners?
     }
 
-    const struct BIP9DeploymentInfo& segwit_info = VersionBitsDeploymentInfo[Consensus::DEPLOYMENT_SEGWIT];
+    const struct ForkDeploymentInfo& segwit_info = VersionBitsDeploymentInfo[Consensus::DEPLOYMENT_SEGWIT];
     // If the caller is indicating segwit support, then allow CreateNewBlock()
     // to select witness transactions, after segwit activates (otherwise
     // don't).
@@ -630,7 +630,7 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
                     // FALL THROUGH to get vbavailable set...
                 case THRESHOLD_STARTED:
                 {
-                    const struct BIP9DeploymentInfo& vbinfo = VersionBitsDeploymentInfo[pos];
+                    const struct ForkDeploymentInfo& vbinfo = VersionBitsDeploymentInfo[pos];
                     vbavailable.push_back(Pair(gbt_vb_name(pos), consensusParams.vDeployments[pos].bit));
                     if (setClientRules.find(vbinfo.name) == setClientRules.end()) {
                         if (!vbinfo.gbt_force) {
@@ -643,7 +643,7 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
                 case THRESHOLD_ACTIVE:
                 {
                     // Add to rules only
-                    const struct BIP9DeploymentInfo& vbinfo = VersionBitsDeploymentInfo[pos];
+                    const struct ForkDeploymentInfo& vbinfo = VersionBitsDeploymentInfo[pos];
                     aRules.push_back(gbt_vb_name(pos));
                     if (setClientRules.find(vbinfo.name) == setClientRules.end()) {
                         // Not supported by the client; make sure it's safe to proceed
@@ -666,7 +666,7 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
         // If VB is supported by the client, nMaxVersionPreVB is -1, so we won't get here
         // Because BIP 34 changed how the generation transaction is serialized, we can only use version/force back to v2 blocks
         // This is safe to do [otherwise-]unconditionally only because we are throwing an exception above if a non-force deployment gets activated
-        // Note that this can probably also be removed entirely after the first BIP9 non-force deployment (ie, probably segwit) gets activated
+        // Note that this can probably also be removed entirely after the first BIP9/BIP135 non-force deployment (ie, probably segwit) gets activated
         aMutable.push_back("version/force");
     }
 

--- a/src/test/forkscsv_tests.cpp
+++ b/src/test/forkscsv_tests.cpp
@@ -1,0 +1,170 @@
+// Copyright (c) 2017 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <limits>
+#include <string>
+
+#include "chainparams.h"
+#include "forks_csv.h"
+#include "test/test_bitcoin.h"
+
+#include <boost/test/unit_test.hpp>
+
+namespace utf = boost::unit_test;
+
+
+BOOST_FIXTURE_TEST_SUITE(forkscsv_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(forkscsv_read_test)
+{
+    CChainParams& params = ModifiableParams();
+
+    // read of emptiness should be ok for now.
+    // In a better implementation, overall file validation should warn the user
+    // if no data lines were found in the file.
+    std::istringstream is_0("");
+    BOOST_CHECK(ReadForksCsv("main", is_0, params.GetModifiableConsensus()));
+
+    std::istringstream is_1(
+            "# deployment info for network 'main':\n"
+            "main,0,csv,1462060800,1493596800,2016,1916,0,0,true\n"
+            "main,28,testdummy,1199145601,1230767999,2016,1916,0,0,false\n");
+    BOOST_CHECK(ReadForksCsv("main", is_1, params.GetModifiableConsensus()));
+
+    std::istringstream is_2(
+            "# deployment info for network 'main':\n"
+            "main,0,csv,1462060800,1493596800,2016,1916,0,0,true\n"
+            "main,1,segwit,1479168000,1510704000,2016,1916,0,0,true\n"
+            "main,28,testdummy,1199145601,1230767999,2016,1916,0,0,false\n");
+    BOOST_CHECK(ReadForksCsv("main", is_2, params.GetModifiableConsensus()));
+}
+
+/**
+ * Test CSV dump of built-in defaults.
+ * NOTE: the dump of 'main' data in this test depends on forkscsv_read_test
+ * as long as the 'segwit' line is not built-in.
+ * That is why an explicit dependency has been declared here.
+ */
+BOOST_AUTO_TEST_CASE(forkscsv_dumpforks_test, * utf::depends_on("forkscsv_tests/forkscsv_read_test"))
+{
+    BOOST_CHECK(NetworkDeploymentInfoCSV(CBaseChainParams::MAIN) == std::string(
+            "# deployment info for network 'main':\n"
+            "main,0,csv,1462060800,1493596800,2016,1916,0,0,true\n"
+            "main,1,segwit,1479168000,1510704000,2016,1916,0,0,true\n"
+            "main,28,testdummy,1199145601,1230767999,2016,1916,0,0,false\n"));
+
+    BOOST_CHECK(NetworkDeploymentInfoCSV(CBaseChainParams::TESTNET) == std::string(
+            "# deployment info for network 'test':\n"
+            "test,0,csv,1456790400,1493596800,2016,1512,0,0,true\n"
+            "test,1,segwit,1462060800,1493596800,2016,1512,0,0,true\n"
+            "test,28,testdummy,1199145601,1230767999,2016,1512,0,0,false\n"));
+
+    BOOST_CHECK(NetworkDeploymentInfoCSV(CBaseChainParams::REGTEST) == std::string(
+            "# deployment info for network 'regtest':\n"
+            "regtest,0,csv,0,999999999999,144,108,0,0,true\n"
+            "regtest,1,segwit,0,999999999999,144,108,0,0,true\n"
+            "regtest,28,testdummy,0,999999999999,144,108,0,0,false\n"));
+
+    BOOST_CHECK_THROW( NetworkDeploymentInfoCSV("_foo_"), std::runtime_error );
+}
+
+/**
+ * Test validation of CSV input fields
+ */
+BOOST_AUTO_TEST_CASE(forkscsv_validation_test)
+{
+    // bit number
+    for (int num = 0; num < VERSIONBITS_NUM_BITS; num++) {
+        BOOST_CHECK(ValidateBit(num));
+    }
+    BOOST_CHECK(!ValidateBit(VERSIONBITS_NUM_BITS + 1));
+    BOOST_CHECK(!ValidateBit(-1));
+
+    // network name
+    BOOST_CHECK(ValidateNetwork(CBaseChainParams::MAIN));
+    BOOST_CHECK(ValidateNetwork(CBaseChainParams::TESTNET));
+    BOOST_CHECK(ValidateNetwork(CBaseChainParams::REGTEST));
+    BOOST_CHECK(!ValidateNetwork("nonexistent_net"));
+    BOOST_CHECK(!ValidateNetwork(""));
+
+    // gbt_force
+    BOOST_CHECK(ValidateGBTForce("true"));
+    BOOST_CHECK(ValidateGBTForce("false"));
+    BOOST_CHECK(ValidateGBTForce("True"));
+    BOOST_CHECK(ValidateGBTForce("False"));
+    BOOST_CHECK(ValidateGBTForce("TRUE"));
+    BOOST_CHECK(ValidateGBTForce("FALSE"));
+    BOOST_CHECK(!ValidateGBTForce("oui"));
+    BOOST_CHECK(!ValidateGBTForce("non"));
+    BOOST_CHECK(!ValidateGBTForce(""));
+
+    // fork name
+    BOOST_CHECK(ValidateForkName("a_fork"));
+    BOOST_CHECK(ValidateForkName("a fork"));
+    BOOST_CHECK(ValidateForkName("segwit"));
+    BOOST_CHECK(!ValidateForkName(""));
+
+    // window size
+    BOOST_CHECK(!ValidateWindowSize(0));
+    BOOST_CHECK(!ValidateWindowSize(1));
+    BOOST_CHECK(!ValidateWindowSize(-1));
+    BOOST_CHECK(ValidateWindowSize(2));
+    BOOST_CHECK(ValidateWindowSize(3));
+    BOOST_CHECK(ValidateWindowSize(100));
+    BOOST_CHECK(ValidateWindowSize(10000));
+    BOOST_CHECK(ValidateWindowSize(std::numeric_limits<int>::max()));
+#pragma GCC diagnostic ignored "-Woverflow"
+    BOOST_CHECK(!ValidateWindowSize(1 + std::numeric_limits<int>::max()));
+#pragma GCC diagnostic pop
+
+    // threshold size (2nd param is window)
+    BOOST_CHECK(!ValidateThreshold(1,1));   // 1 is not valid window size
+    BOOST_CHECK(!ValidateThreshold(0,1));   // 1 is not valid window size, 0 is not valid threshold
+    BOOST_CHECK(!ValidateThreshold(0,2));   // 0 is not valid threshold
+    BOOST_CHECK(ValidateThreshold(1,2));
+    BOOST_CHECK(!ValidateThreshold(-1,2));
+    BOOST_CHECK(!ValidateThreshold(2,1));
+    BOOST_CHECK(ValidateThreshold(2,2));
+    BOOST_CHECK(ValidateThreshold(1,100));
+    BOOST_CHECK(ValidateThreshold(50,100));
+    BOOST_CHECK(ValidateThreshold(99,100));
+    BOOST_CHECK(ValidateThreshold(100,100));
+    BOOST_CHECK(!ValidateThreshold(101,100));
+    BOOST_CHECK(ValidateThreshold(1916,2016));
+    BOOST_CHECK(ValidateThreshold(2016,2016));
+    BOOST_CHECK(ValidateThreshold(2016,2016));
+    BOOST_CHECK(!ValidateThreshold(2017,2016));
+    BOOST_CHECK(ValidateThreshold(1, std::numeric_limits<int>::max()));
+
+    // starttime / timeout
+    BOOST_CHECK(!ValidateTimes(0, 0));     // starttime must be strictly less than timeout
+    BOOST_CHECK(ValidateTimes(0, 1));      // starttime must be strictly less than timeout
+    BOOST_CHECK(ValidateTimes(100, 1001)); // starttime must be strictly less than timeout
+    BOOST_CHECK(ValidateTimes(0, 1001));   // starttime must be strictly less than timeout
+    BOOST_CHECK(ValidateTimes(0, std::numeric_limits<int64_t>::max()));
+    BOOST_CHECK(ValidateTimes(std::numeric_limits<int64_t>::max() - 1,
+                              std::numeric_limits<int64_t>::max()));
+
+    // minlockedblocks
+    BOOST_CHECK(ValidateMinLockedBlocks(0));   // zero is ok
+    BOOST_CHECK(ValidateMinLockedBlocks(1));
+    BOOST_CHECK(ValidateMinLockedBlocks(100));
+    BOOST_CHECK(!ValidateMinLockedBlocks(-1));
+    BOOST_CHECK(ValidateMinLockedBlocks(std::numeric_limits<int>::max()));
+#pragma GCC diagnostic ignored "-Woverflow"
+    BOOST_CHECK(!ValidateMinLockedBlocks(1 + std::numeric_limits<int>::max()));
+#pragma GCC diagnostic pop
+
+    // minlockedtime
+    BOOST_CHECK(ValidateMinLockedTime(0));   // zero is ok
+    BOOST_CHECK(ValidateMinLockedTime(1));
+    BOOST_CHECK(ValidateMinLockedTime(100));
+    BOOST_CHECK(!ValidateMinLockedTime(-1));
+    BOOST_CHECK(ValidateMinLockedTime(std::numeric_limits<int64_t>::max()));
+#pragma GCC diagnostic ignored "-Woverflow"
+    BOOST_CHECK(!ValidateMinLockedTime(1 + std::numeric_limits<int64_t>::max()));
+#pragma GCC diagnostic pop
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/genversionbits_tests.cpp
+++ b/src/test/genversionbits_tests.cpp
@@ -1,0 +1,400 @@
+// Copyright (c) 2017 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "chain.h"
+#include "random.h"
+#include "versionbits.h"
+#include "test/test_bitcoin.h"
+#include "test/test_random.h"
+#include "chainparams.h"
+#include "chainparamsbase.h"
+//#include "main.h"  // bip135 obsolete
+#include "validation.h"
+#include "consensus/params.h"
+
+#include <boost/test/unit_test.hpp>
+
+/* Define a virtual block time, one block per 10 minutes after Nov 14 2014, 0:55:36am */
+int32_t GenVBTestTime(int nHeight) { return 1415926536 + 600 * nHeight; }
+
+#define TEST_BIT 8
+
+#define SELECTED_CHAIN CBaseChainParams::MAIN
+
+
+// a checker which enforced some minlockedblocks
+class TestConditionCheckerMinBlocks : public AbstractThresholdConditionChecker
+{
+private:
+    mutable ThresholdConditionCache cache;
+
+protected:
+    int64_t BeginTime(const Consensus::Params& params) const { return GenVBTestTime(10000); }
+    int64_t EndTime(const Consensus::Params& params) const { return GenVBTestTime(20000); }
+    int Period(const Consensus::Params& params) const { return 1000; }
+    int Threshold(const Consensus::Params& params) const { return 900; }
+    int MinLockedBlocks(const Consensus::Params& params) const { return 1001; }
+    int64_t MinLockedTime(const Consensus::Params& params) const { return 0; }
+
+    // test for fork bit
+    bool Condition(const CBlockIndex* pindex, const Consensus::Params& params) const { return (pindex->nVersion & (1 << TEST_BIT)); }
+
+public:
+    ThresholdState GetState(const CBlockIndex* pindexPrev) const {
+        return AbstractThresholdConditionChecker::GetStateFor(pindexPrev, ModifiableParams().GetModifiableConsensus(), cache);
+    }
+};
+
+// a checker which enforced some minlockedtime
+class TestConditionCheckerMinTime : public AbstractThresholdConditionChecker
+{
+private:
+    mutable ThresholdConditionCache cache;
+
+protected:
+    int64_t BeginTime(const Consensus::Params& params) const { return GenVBTestTime(10000); }
+    int64_t EndTime(const Consensus::Params& params) const { return GenVBTestTime(20000); }
+    int Period(const Consensus::Params& params) const { return 1000; }
+    int Threshold(const Consensus::Params& params) const { return 900; }
+    int MinLockedBlocks(const Consensus::Params& params) const { return 0; }
+    int64_t MinLockedTime(const Consensus::Params& params) const { return 5000 * 600; }  // this is a minimum *duration* after lock-in time
+
+    // test for fork bit
+    bool Condition(const CBlockIndex* pindex, const Consensus::Params& params) const { return (pindex->nVersion & (1 << TEST_BIT)); }
+
+public:
+    ThresholdState GetState(const CBlockIndex* pindexPrev) const {
+        return AbstractThresholdConditionChecker::GetStateFor(pindexPrev, ModifiableParams().GetModifiableConsensus(), cache);
+    }
+};
+
+
+#define CHECKERS 6
+
+class GenVersionBitsTesterMinBlocks
+{
+public:
+    // A fake blockchain
+    std::vector<CBlockIndex*> vpblock;
+
+    // 6 independent checkers for the same bit.
+    // The first one performs all checks, the second only 50%, the third only 25%, etc...
+    // This is to test whether lack of cached information leads to the same results.
+    TestConditionCheckerMinBlocks checker[CHECKERS];
+
+    // Test counter (to identify failures)
+    int num;
+
+    GenVersionBitsTesterMinBlocks() : num(0) {}
+
+    GenVersionBitsTesterMinBlocks& Reset() {
+        for (unsigned int i = 0; i < vpblock.size(); i++) {
+            delete vpblock[i];
+        }
+        for (unsigned int i = 0; i < CHECKERS; i++) {
+            checker[i] = TestConditionCheckerMinBlocks();
+        }
+        vpblock.clear();
+        return *this;
+    }
+
+    ~GenVersionBitsTesterMinBlocks() {
+         Reset();
+    }
+
+    /**
+     * Create fake blocks in the test chain
+     * @param height up to which to mine
+     * @param nTime this time to enter in mined block
+     * @param nVersion block versions are set to this
+     */
+    GenVersionBitsTesterMinBlocks& Mine(unsigned int height, int32_t nTime, int32_t nVersion) {
+        while (vpblock.size() < height) {
+            CBlockIndex* pindex = new CBlockIndex();
+            pindex->nHeight = vpblock.size();
+            pindex->pprev = vpblock.size() > 0 ? vpblock.back() : NULL;
+            pindex->nTime = nTime;
+            pindex->nVersion = nVersion;
+            pindex->BuildSkip();
+            vpblock.push_back(pindex);
+        }
+        return *this;
+    }
+
+    GenVersionBitsTesterMinBlocks& TestDefined() {
+        for (int i = 0; i < CHECKERS; i++) {
+            if ((insecure_rand() & ((1 << i) - 1)) == 0) {
+                BOOST_CHECK_MESSAGE(checker[i].GetState(vpblock.empty() ? NULL : vpblock.back()) == THRESHOLD_DEFINED, strprintf("Test %i for DEFINED", num));
+            }
+        }
+        num++;
+        return *this;
+    }
+
+    GenVersionBitsTesterMinBlocks& TestStarted() {
+        for (int i = 0; i < CHECKERS; i++) {
+            if ((insecure_rand() & ((1 << i) - 1)) == 0) {
+                BOOST_CHECK_MESSAGE(checker[i].GetState(vpblock.empty() ? NULL : vpblock.back()) == THRESHOLD_STARTED, strprintf("Test %i for STARTED", num));
+            }
+        }
+        num++;
+        return *this;
+    }
+
+    GenVersionBitsTesterMinBlocks& TestLockedIn() {
+        for (int i = 0; i < CHECKERS; i++) {
+            if ((insecure_rand() & ((1 << i) - 1)) == 0) {
+                BOOST_CHECK_MESSAGE(checker[i].GetState(vpblock.empty() ? NULL : vpblock.back()) == THRESHOLD_LOCKED_IN, strprintf("Test %i for LOCKED_IN", num));
+            }
+        }
+        num++;
+        return *this;
+    }
+
+    GenVersionBitsTesterMinBlocks& TestActive() {
+        for (int i = 0; i < CHECKERS; i++) {
+            if ((insecure_rand() & ((1 << i) - 1)) == 0) {
+                BOOST_CHECK_MESSAGE(checker[i].GetState(vpblock.empty() ? NULL : vpblock.back()) == THRESHOLD_ACTIVE, strprintf("Test %i for ACTIVE", num));
+            }
+        }
+        num++;
+        return *this;
+    }
+    GenVersionBitsTesterMinBlocks& TestFailed() {
+        for (int i = 0; i < CHECKERS; i++) {
+            if ((insecure_rand() & ((1 << i) - 1)) == 0) {
+                BOOST_CHECK_MESSAGE(checker[i].GetState(vpblock.empty() ? NULL : vpblock.back()) == THRESHOLD_FAILED, strprintf("Test %i for FAILED", num));
+            }
+        }
+        num++;
+        return *this;
+    }
+
+    CBlockIndex * Tip() { return vpblock.size() ? vpblock.back() : NULL; }
+};
+
+
+class GenVersionBitsTesterMinTime
+{
+public:
+    // A fake blockchain
+    std::vector<CBlockIndex*> vpblock;
+
+    // 6 independent checkers for the same bit.
+    // The first one performs all checks, the second only 50%, the third only 25%, etc...
+    // This is to test whether lack of cached information leads to the same results.
+    TestConditionCheckerMinTime checker[CHECKERS];
+
+    // Test counter (to identify failures)
+    int num;
+
+    GenVersionBitsTesterMinTime() : num(0) {}
+
+    GenVersionBitsTesterMinTime& Reset() {
+        for (unsigned int i = 0; i < vpblock.size(); i++) {
+            delete vpblock[i];
+        }
+        for (unsigned int i = 0; i < CHECKERS; i++) {
+            checker[i] = TestConditionCheckerMinTime();
+        }
+        vpblock.clear();
+        return *this;
+    }
+
+    ~GenVersionBitsTesterMinTime() {
+         Reset();
+    }
+
+    /**
+     * Create fake blocks in the test chain
+     * @param height up to which to mine
+     * @param nTime this time to enter in mined block
+     * @param nVersion block versions are set to this
+     */
+    GenVersionBitsTesterMinTime& Mine(unsigned int height, int32_t nTime, int32_t nVersion) {
+        while (vpblock.size() < height) {
+            CBlockIndex* pindex = new CBlockIndex();
+            pindex->nHeight = vpblock.size();
+            pindex->pprev = vpblock.size() > 0 ? vpblock.back() : NULL;
+            pindex->nTime = nTime;
+            pindex->nVersion = nVersion;
+            pindex->BuildSkip();
+            vpblock.push_back(pindex);
+        }
+        return *this;
+    }
+
+    GenVersionBitsTesterMinTime& TestDefined() {
+        for (int i = 0; i < CHECKERS; i++) {
+            if ((insecure_rand() & ((1 << i) - 1)) == 0) {
+                BOOST_CHECK_MESSAGE(checker[i].GetState(vpblock.empty() ? NULL : vpblock.back()) == THRESHOLD_DEFINED, strprintf("Test %i for DEFINED", num));
+            }
+        }
+        num++;
+        return *this;
+    }
+
+    GenVersionBitsTesterMinTime& TestStarted() {
+        for (int i = 0; i < CHECKERS; i++) {
+            if ((insecure_rand() & ((1 << i) - 1)) == 0) {
+                BOOST_CHECK_MESSAGE(checker[i].GetState(vpblock.empty() ? NULL : vpblock.back()) == THRESHOLD_STARTED, strprintf("Test %i for STARTED", num));
+            }
+        }
+        num++;
+        return *this;
+    }
+
+    GenVersionBitsTesterMinTime& TestLockedIn() {
+        for (int i = 0; i < CHECKERS; i++) {
+            if ((insecure_rand() & ((1 << i) - 1)) == 0) {
+                BOOST_CHECK_MESSAGE(checker[i].GetState(vpblock.empty() ? NULL : vpblock.back()) == THRESHOLD_LOCKED_IN, strprintf("Test %i for LOCKED_IN", num));
+            }
+        }
+        num++;
+        return *this;
+    }
+
+    GenVersionBitsTesterMinTime& TestActive() {
+        for (int i = 0; i < CHECKERS; i++) {
+            if ((insecure_rand() & ((1 << i) - 1)) == 0) {
+                BOOST_CHECK_MESSAGE(checker[i].GetState(vpblock.empty() ? NULL : vpblock.back()) == THRESHOLD_ACTIVE, strprintf("Test %i for ACTIVE", num));
+            }
+        }
+        num++;
+        return *this;
+    }
+    GenVersionBitsTesterMinTime& TestFailed() {
+        for (int i = 0; i < CHECKERS; i++) {
+            if ((insecure_rand() & ((1 << i) - 1)) == 0) {
+                BOOST_CHECK_MESSAGE(checker[i].GetState(vpblock.empty() ? NULL : vpblock.back()) == THRESHOLD_FAILED, strprintf("Test %i for FAILED", num));
+            }
+        }
+        num++;
+        return *this;
+    }
+
+    CBlockIndex * Tip() { return vpblock.size() ? vpblock.back() : NULL; }
+};
+
+
+BOOST_FIXTURE_TEST_SUITE(genversionbits_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(genversionbits_minblocks_test)
+{
+    // NOTE: the index i is not used in this loop. The high number of iterations
+    // is probably because the testing is probabilistic in terms of the checkers
+    // finding an error, and they wanted to cover the bases.
+    for (int i = 0; i < 64; i++) {
+        // DEFINED -> FAILED
+        GenVersionBitsTesterMinBlocks().TestDefined()
+                           .Mine(1, GenVBTestTime(1), 0x100).TestDefined()
+                           .Mine(11, GenVBTestTime(11), 0x100).TestDefined()
+                           .Mine(989, GenVBTestTime(989), 0x100).TestDefined()
+                           .Mine(999, GenVBTestTime(20000), 0x100).TestDefined()
+                           .Mine(1000, GenVBTestTime(20000), 0x100).TestFailed()
+                           .Mine(1999, GenVBTestTime(30001), 0x100).TestFailed()
+                           .Mine(2000, GenVBTestTime(30002), 0x100).TestFailed()
+                           .Mine(2001, GenVBTestTime(30003), 0x100).TestFailed()
+                           .Mine(2999, GenVBTestTime(30004), 0x100).TestFailed()
+                           .Mine(3000, GenVBTestTime(30005), 0x100).TestFailed()
+
+        // DEFINED -> STARTED -> FAILED
+                           .Reset().TestDefined()
+                           .Mine(1, GenVBTestTime(1), 0).TestDefined()
+                           .Mine(1000, GenVBTestTime(10000) - 1, 0x100).TestDefined() // One second more and it would be defined
+                           .Mine(2000, GenVBTestTime(10000), 0x100).TestStarted() // So that's what happens the next period
+                           .Mine(2051, GenVBTestTime(10010), 0).TestStarted() // 51 old blocks
+                           .Mine(2950, GenVBTestTime(10020), 0x100).TestStarted() // 899 new blocks
+                           .Mine(3000, GenVBTestTime(20000), 0).TestFailed() // 50 old blocks (so 899 out of the past 1000)
+                           .Mine(4000, GenVBTestTime(20010), 0x100).TestFailed()
+
+        // DEFINED -> STARTED -> FAILED while threshold reached
+                           .Reset().TestDefined()
+                           .Mine(1, GenVBTestTime(1), 0).TestDefined()
+                           .Mine(1000, GenVBTestTime(10000) - 1, 0x101).TestDefined() // One second more and it would be defined
+                           .Mine(2000, GenVBTestTime(10000), 0x101).TestStarted() // So that's what happens the next period
+                           .Mine(2999, GenVBTestTime(30000), 0x100).TestStarted() // 999 new blocks
+                           .Mine(3000, GenVBTestTime(30000), 0x100).TestFailed() // 1 new block (so 1000 out of the past 1000 are new)
+                           .Mine(3999, GenVBTestTime(30001), 0).TestFailed()
+                           .Mine(4000, GenVBTestTime(30002), 0).TestFailed()
+                           .Mine(14333, GenVBTestTime(30003), 0).TestFailed()
+                           .Mine(24000, GenVBTestTime(40000), 0).TestFailed()
+
+        // DEFINED -> STARTED -> LOCKEDIN at the last minute -> ACTIVE
+                           .Reset().TestDefined()
+                           .Mine(1, GenVBTestTime(1), 0).TestDefined()
+                           .Mine(1000, GenVBTestTime(10000) - 1, 0x101).TestDefined() // One second more and it would be defined
+                           .Mine(2000, GenVBTestTime(10000), 0x101).TestStarted() // So that's what happens the next period
+                           .Mine(2050, GenVBTestTime(10010), 0x200).TestStarted() // 50 old blocks
+                           .Mine(2950, GenVBTestTime(10020), 0x100).TestStarted() // 900 new blocks
+                           .Mine(2999, GenVBTestTime(19999), 0x200).TestStarted() // 49 old blocks
+                           .Mine(3000, GenVBTestTime(20000), 0x200).TestLockedIn() // 1 old block (so 900 out of the past 1000)
+                           .Mine(3001, GenVBTestTime(20001), 0).TestLockedIn() // still locked in
+                           .Mine(3999, GenVBTestTime(30000), 0).TestLockedIn() // wait at least minlockedblocks = 1001, so not active at next
+                           .Mine(4000, GenVBTestTime(30001), 0).TestLockedIn() // need to remain locked in until next sync at 5000
+                           .Mine(4999, GenVBTestTime(30002), 0).TestLockedIn() // last locked in block
+                           .Mine(5000, GenVBTestTime(30002), 0).TestActive()
+                           .Mine(24000, GenVBTestTime(40000), 0).TestActive();
+    }
+}
+
+
+BOOST_AUTO_TEST_CASE(genversionbits_mintime_test)
+{
+    for (int i = 0; i < 64; i++) {
+        // DEFINED -> FAILED
+        GenVersionBitsTesterMinTime().TestDefined()
+                           .Mine(1, GenVBTestTime(1), 0x100).TestDefined()
+                           .Mine(11, GenVBTestTime(11), 0x100).TestDefined()
+                           .Mine(989, GenVBTestTime(989), 0x100).TestDefined()
+                           .Mine(999, GenVBTestTime(20000), 0x100).TestDefined()
+                           .Mine(1000, GenVBTestTime(20000), 0x100).TestFailed()
+                           .Mine(1999, GenVBTestTime(30001), 0x100).TestFailed()
+                           .Mine(2000, GenVBTestTime(30002), 0x100).TestFailed()
+                           .Mine(2001, GenVBTestTime(30003), 0x100).TestFailed()
+                           .Mine(2999, GenVBTestTime(30004), 0x100).TestFailed()
+                           .Mine(3000, GenVBTestTime(30005), 0x100).TestFailed()
+
+        // DEFINED -> STARTED -> FAILED
+                           .Reset().TestDefined()
+                           .Mine(1, GenVBTestTime(1), 0).TestDefined()
+                           .Mine(1000, GenVBTestTime(10000) - 1, 0x100).TestDefined() // One second more and it would be defined
+                           .Mine(2000, GenVBTestTime(10000), 0x100).TestStarted() // So that's what happens the next period
+                           .Mine(2051, GenVBTestTime(10010), 0).TestStarted() // 51 old blocks
+                           .Mine(2950, GenVBTestTime(10020), 0x100).TestStarted() // 899 new blocks
+                           .Mine(3000, GenVBTestTime(20000), 0).TestFailed() // 50 old blocks (so 899 out of the past 1000)
+                           .Mine(4000, GenVBTestTime(20010), 0x100).TestFailed()
+
+        // DEFINED -> STARTED -> FAILED while threshold reached
+                           .Reset().TestDefined()
+                           .Mine(1, GenVBTestTime(1), 0).TestDefined()
+                           .Mine(1000, GenVBTestTime(10000) - 1, 0x101).TestDefined() // One second more and it would be defined
+                           .Mine(2000, GenVBTestTime(10000), 0x101).TestStarted() // So that's what happens the next period
+                           .Mine(2999, GenVBTestTime(30000), 0x100).TestStarted() // 999 new blocks
+                           .Mine(3000, GenVBTestTime(30000), 0x100).TestFailed() // 1 new block (so 1000 out of the past 1000 are new)
+                           .Mine(3999, GenVBTestTime(30001), 0).TestFailed()
+                           .Mine(4000, GenVBTestTime(30002), 0).TestFailed()
+                           .Mine(14333, GenVBTestTime(30003), 0).TestFailed()
+                           .Mine(24000, GenVBTestTime(40000), 0).TestFailed()
+
+        // DEFINED -> STARTED -> LOCKEDIN at the last minute -> ACTIVE
+                           .Reset().TestDefined()
+                           .Mine(1, GenVBTestTime(1), 0).TestDefined()
+                           .Mine(1000, GenVBTestTime(10000) - 1, 0x101).TestDefined() // One second more and it would be defined
+                           .Mine(2000, GenVBTestTime(10000), 0x101).TestStarted() // So that's what happens the next period
+                           .Mine(2050, GenVBTestTime(10010), 0x200).TestStarted() // 50 old blocks
+                           .Mine(2950, GenVBTestTime(10020), 0x100).TestStarted() // 900 new blocks
+                           .Mine(2999, GenVBTestTime(19999), 0x200).TestStarted() // 49 old blocks. Actual lock-in time will be 19999
+                           .Mine(3000, GenVBTestTime(20000), 0x200).TestLockedIn() // 1 old block (so 900 out of the past 1000)
+                           .Mine(3001, GenVBTestTime(20001), 0).TestLockedIn() // still locked in
+                           .Mine(4000, GenVBTestTime(21000), 0).TestLockedIn() // need to remain locked at least 5000s after lock-in time @ 20000s
+                           .Mine(8000, GenVBTestTime(22002), 0).TestLockedIn() // still locked in more than 5000 blocks later if time not passed
+                           .Mine(9000, GenVBTestTime(24998), 0).TestLockedIn() // 1 sec prior to minimum lock-in duration - still remain locked in
+                           .Mine(9001, GenVBTestTime(24999), 0).TestLockedIn()
+                           .Mine(9999, GenVBTestTime(24999), 0).TestLockedIn()
+                           .Mine(10000, GenVBTestTime(24999), 0).TestActive(); // activate at 10000 after full period of times > lock-in + 5000
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/versionbits_tests.cpp
+++ b/src/test/versionbits_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2016 The Bitcoin Core developers
+// Copyright (c) 2014-2017 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -27,6 +27,10 @@ public:
     int64_t EndTime(const Consensus::Params& params) const { return TestTime(20000); }
     int Period(const Consensus::Params& params) const { return 1000; }
     int Threshold(const Consensus::Params& params) const { return 900; }
+    // bip135 begin
+    int MinLockedBlocks(const Consensus::Params& params) const { return 0; }
+    int64_t MinLockedTime(const Consensus::Params& params) const { return 0; }
+    // bip135 end
     bool Condition(const CBlockIndex* pindex, const Consensus::Params& params) const { return (pindex->nVersion & 0x100); }
 
     ThresholdState GetStateFor(const CBlockIndex* pindexPrev) const { return AbstractThresholdConditionChecker::GetStateFor(pindexPrev, paramsDummy, cache); }
@@ -223,12 +227,21 @@ BOOST_AUTO_TEST_CASE(versionbits_test)
         // end time of that soft fork.  (Alternatively, the end time of that
         // activated soft fork could be later changed to be earlier to avoid
         // overlap.)
-        for (int j=i+1; j<(int) Consensus::MAX_VERSION_BITS_DEPLOYMENTS; j++) {
-            if (VersionBitsMask(mainnetParams, (Consensus::DeploymentPos)j) == bitmask) {
-                BOOST_CHECK(mainnetParams.vDeployments[j].nStartTime > mainnetParams.vDeployments[i].nTimeout ||
-                        mainnetParams.vDeployments[i].nStartTime > mainnetParams.vDeployments[j].nTimeout);
+        // bip135 begin fix disjointness check
+        if (isConfiguredDeployment(mainnetParams, i)) {
+            BOOST_CHECK(mainnetParams.vDeployments[i].nStartTime <= mainnetParams.vDeployments[i].nTimeout);
+            for (int j=0; j<(int) Consensus::MAX_VERSION_BITS_DEPLOYMENTS; j++) {
+                // only check a bit for disjointness if it is in use
+                if (i != j && isConfiguredDeployment(mainnetParams, j) && VersionBitsMask(mainnetParams, (Consensus::DeploymentPos)j) == bitmask) {
+                    BOOST_CHECK(mainnetParams.vDeployments[j].nStartTime <= mainnetParams.vDeployments[j].nTimeout);
+                    BOOST_CHECK((mainnetParams.vDeployments[i].nStartTime < mainnetParams.vDeployments[j].nStartTime &&
+                                 mainnetParams.vDeployments[i].nTimeout < mainnetParams.vDeployments[j].nTimeout)
+                             || (mainnetParams.vDeployments[j].nStartTime < mainnetParams.vDeployments[i].nStartTime &&
+                                 mainnetParams.vDeployments[j].nTimeout < mainnetParams.vDeployments[i].nTimeout));
+                }
             }
         }
+        // bip135 end
     }
 }
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -90,6 +90,7 @@
 
 const char * const BITCOIN_CONF_FILENAME = "bitcoin.conf";
 const char * const BITCOIN_PID_FILENAME = "bitcoind.pid";
+const char * const FORKS_CSV_FILENAME = "forks.csv";  // bip135 added
 
 ArgsManager gArgs;
 bool fPrintToConsole = false;
@@ -594,6 +595,19 @@ fs::path GetConfigFile(const std::string& confPath)
         pathConfigFile = GetDataDir(false) / pathConfigFile;
 
     return pathConfigFile;
+}
+
+// bip135 added
+/**
+ * Function to return expected path of FORKS_CSV_FILENAME
+ */
+fs::path GetForksCsvFile()
+{
+    boost::filesystem::path pathCsvFile(GetArg("-forks", FORKS_CSV_FILENAME));
+    if (!pathCsvFile.is_complete())
+        pathCsvFile = GetDataDir(false) / pathCsvFile;
+
+    return pathCsvFile;
 }
 
 void ArgsManager::ReadConfigFile(const std::string& confPath)

--- a/src/util.h
+++ b/src/util.h
@@ -53,6 +53,7 @@ extern CTranslationInterface translationInterface;
 
 extern const char * const BITCOIN_CONF_FILENAME;
 extern const char * const BITCOIN_PID_FILENAME;
+extern const char * const FORKS_CSV_FILENAME;  // bip135 added
 
 extern std::atomic<uint32_t> logCategories;
 
@@ -158,6 +159,7 @@ fs::path GetDefaultDataDir();
 const fs::path &GetDataDir(bool fNetSpecific = true);
 void ClearDatadirCache();
 fs::path GetConfigFile(const std::string& confPath);
+fs::path GetForksCsvFile();  // bip135 added
 #ifndef WIN32
 fs::path GetPidFile();
 void CreatePidFile(const fs::path &path, pid_t pid);

--- a/src/validation.h
+++ b/src/validation.h
@@ -340,7 +340,7 @@ std::string FormatStateMessage(const CValidationState &state);
 ThresholdState VersionBitsTipState(const Consensus::Params& params, Consensus::DeploymentPos pos);
 
 /** Get the numerical statistics for the BIP9 state for a given deployment at the current tip. */
-BIP9Stats VersionBitsTipStatistics(const Consensus::Params& params, Consensus::DeploymentPos pos);
+ForkStats VersionBitsTipStatistics(const Consensus::Params& params, Consensus::DeploymentPos pos);
 
 /** Get the block height at which the BIP9 deployment switched into the state for the block building on the current tip. */
 int VersionBitsTipStateSinceHeight(const Consensus::Params& params, Consensus::DeploymentPos pos);

--- a/src/validation.h
+++ b/src/validation.h
@@ -336,13 +336,13 @@ bool AcceptToMemoryPoolWithTime(CTxMemPool& pool, CValidationState &state, const
 /** Convert CValidationState to a human-readable message for logging */
 std::string FormatStateMessage(const CValidationState &state);
 
-/** Get the BIP9 state for a given deployment at the current tip. */
+/** Get the BIP135 state for a given deployment at the current tip. */
 ThresholdState VersionBitsTipState(const Consensus::Params& params, Consensus::DeploymentPos pos);
 
-/** Get the numerical statistics for the BIP9 state for a given deployment at the current tip. */
+/** Get the numerical statistics for the BIP135 state for a given deployment at the current tip. */
 ForkStats VersionBitsTipStatistics(const Consensus::Params& params, Consensus::DeploymentPos pos);
 
-/** Get the block height at which the BIP9 deployment switched into the state for the block building on the current tip. */
+/** Get the block height at which the BIP135 deployment switched into the state for the block building on the current tip. */
 int VersionBitsTipStateSinceHeight(const Consensus::Params& params, Consensus::DeploymentPos pos);
 
 

--- a/src/versionbits.cpp
+++ b/src/versionbits.cpp
@@ -6,7 +6,7 @@
 #include "consensus/params.h"
 
 // bip135 begin fill out entire table
-struct BIP9DeploymentInfo VersionBitsDeploymentInfo[Consensus::MAX_VERSION_BITS_DEPLOYMENTS] = {
+struct ForkDeploymentInfo VersionBitsDeploymentInfo[Consensus::MAX_VERSION_BITS_DEPLOYMENTS] = {
     {
         /*.name =*/ (char *) "csv",
         /*.gbt_force =*/ true,

--- a/src/versionbits.h
+++ b/src/versionbits.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 The Bitcoin Core developers
+// Copyright (c) 2016-2017 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -16,28 +16,33 @@ static const int32_t VERSIONBITS_TOP_BITS = 0x20000000UL;
 static const int32_t VERSIONBITS_TOP_MASK = 0xE0000000UL;
 /** Total bits available for versionbits */
 static const int32_t VERSIONBITS_NUM_BITS = 29;
+/** Size of window to use for assessing warning of unknown bits */
+static const int BIT_WARNING_WINDOW = 100;
+/** Threshold to use for assessing warning of unknown bits */
+static const int BIT_WARNING_THRESHOLD = 50;
 
+// bip135: assigned numbers to these enum values
 enum ThresholdState {
-    THRESHOLD_DEFINED,
-    THRESHOLD_STARTED,
-    THRESHOLD_LOCKED_IN,
-    THRESHOLD_ACTIVE,
-    THRESHOLD_FAILED,
+    THRESHOLD_DEFINED = 0,
+    THRESHOLD_STARTED = 1,
+    THRESHOLD_LOCKED_IN = 2,
+    THRESHOLD_ACTIVE = 3,
+    THRESHOLD_FAILED = 4,
 };
 
-// A map that gives the state for blocks whose height is a multiple of Period().
-// The map is indexed by the block's parent, however, so all keys in the map
-// will either be NULL or a block with (height + 1) % Period() == 0.
+// A map that gives the state for blocks.
+// The map is indexed by the block's parent.
 typedef std::map<const CBlockIndex*, ThresholdState> ThresholdConditionCache;
 
-struct BIP9DeploymentInfo {
+// bip135 begin renamed
+struct ForkDeploymentInfo {
     /** Deployment name */
-    const char *name;
+    char *name;   // bip135: removed const to allow update from CSV
     /** Whether GBT clients can safely ignore this rule in simplified usage */
     bool gbt_force;
 };
 
-struct BIP9Stats {
+struct ForkStats {
     int period;
     int threshold;
     int elapsed;
@@ -45,21 +50,26 @@ struct BIP9Stats {
     bool possible;
 };
 
-extern const struct BIP9DeploymentInfo VersionBitsDeploymentInfo[];
+extern struct ForkDeploymentInfo VersionBitsDeploymentInfo[];
+// bip135 end
 
 /**
- * Abstract class that implements BIP9-style threshold logic, and caches results.
+ * Abstract class that implements BIP135-style threshold logic, and caches results.
  */
 class AbstractThresholdConditionChecker {
 protected:
-    virtual bool Condition(const CBlockIndex* pindex, const Consensus::Params& params) const =0;
-    virtual int64_t BeginTime(const Consensus::Params& params) const =0;
-    virtual int64_t EndTime(const Consensus::Params& params) const =0;
-    virtual int Period(const Consensus::Params& params) const =0;
-    virtual int Threshold(const Consensus::Params& params) const =0;
+    virtual bool Condition(const CBlockIndex* pindex, const Consensus::Params& params) const = 0;
+    virtual int64_t BeginTime(const Consensus::Params& params) const = 0;
+    virtual int64_t EndTime(const Consensus::Params& params) const = 0;
+    virtual int Period(const Consensus::Params& params) const = 0;
+    virtual int Threshold(const Consensus::Params& params) const = 0;
+    // bip135 begin
+    virtual int MinLockedBlocks(const Consensus::Params& params) const = 0;
+    virtual int64_t MinLockedTime(const Consensus::Params& params) const = 0;
+    // bip135 end
 
 public:
-    BIP9Stats GetStateStatisticsFor(const CBlockIndex* pindex, const Consensus::Params& params) const;
+    ForkStats GetStateStatisticsFor(const CBlockIndex* pindex, const Consensus::Params& params) const;
     // Note that the functions below take a pindexPrev as input: they compute information for block B based on its parent.
     ThresholdState GetStateFor(const CBlockIndex* pindexPrev, const Consensus::Params& params, ThresholdConditionCache& cache) const;
     int GetStateSinceHeightFor(const CBlockIndex* pindexPrev, const Consensus::Params& params, ThresholdConditionCache& cache) const;
@@ -73,7 +83,7 @@ struct VersionBitsCache
 };
 
 ThresholdState VersionBitsState(const CBlockIndex* pindexPrev, const Consensus::Params& params, Consensus::DeploymentPos pos, VersionBitsCache& cache);
-BIP9Stats VersionBitsStatistics(const CBlockIndex* pindexPrev, const Consensus::Params& params, Consensus::DeploymentPos pos);
+ForkStats VersionBitsStatistics(const CBlockIndex* pindexPrev, const Consensus::Params& params, Consensus::DeploymentPos pos);
 int VersionBitsStateSinceHeight(const CBlockIndex* pindexPrev, const Consensus::Params& params, Consensus::DeploymentPos pos, VersionBitsCache& cache);
 uint32_t VersionBitsMask(const Consensus::Params& params, Consensus::DeploymentPos pos);
 

--- a/src/versionbits.h
+++ b/src/versionbits.h
@@ -23,11 +23,11 @@ static const int BIT_WARNING_THRESHOLD = 50;
 
 // bip135: assigned numbers to these enum values
 enum ThresholdState {
-    THRESHOLD_DEFINED = 0,
-    THRESHOLD_STARTED = 1,
-    THRESHOLD_LOCKED_IN = 2,
-    THRESHOLD_ACTIVE = 3,
-    THRESHOLD_FAILED = 4,
+    THRESHOLD_DEFINED,
+    THRESHOLD_STARTED,
+    THRESHOLD_LOCKED_IN,
+    THRESHOLD_ACTIVE,
+    THRESHOLD_FAILED
 };
 
 // A map that gives the state for blocks.

--- a/test/functional/bip135-grace.py
+++ b/test/functional/bip135-grace.py
@@ -1,0 +1,368 @@
+#!/usr/bin/env python3
+# Copyright (c) 2015 The Bitcoin Core developers
+# Copyright (c) 2015-2017 The Bitcoin Unlimited developers
+# Copyright (c) 2017 The Bitcoin developers
+# Distributed under the MIT/X11 software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#
+from test_framework.util import sync_blocks
+from test_framework.test_framework import ComparisonTestFramework
+from test_framework.util import *
+from test_framework.mininode import CTransaction, NetworkThread
+from test_framework.blocktools import create_coinbase, create_block
+from test_framework.comptool import TestInstance, TestManager
+from test_framework.script import CScript, OP_1NEGATE, OP_CHECKSEQUENCEVERIFY, OP_DROP
+from io import BytesIO
+import time
+import itertools
+import tempfile
+
+'''
+This test exercises BIP135 fork grace periods.
+It uses a single node with custom forks.csv file.
+
+It is adapted from bip135-genvbvoting-forks on BU, which was
+derived from bip9-softforks.
+'''
+
+
+class BIP135ForksTest(ComparisonTestFramework):
+
+    def __init__(self):
+        super().__init__()
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+        self.defined_forks = [ "bip135test%d" % i for i in range(0,22) ]
+
+    def setup_network(self):
+        '''
+        sets up with a custom forks.csv to test threshold / grace conditions
+        also recomputes deployment start times since node is shut down and
+        restarted between main test sections.
+        '''
+        # write a custom forks.csv file containing test deployments.
+        # blocks are 1 second apart by default in this regtest
+        fork_csv_filename = os.path.join(self.options.tmpdir, "forks.csv")
+        # forks.csv fields:
+        # network,bit,name,starttime,timeout,windowsize,threshold,minlockedblocks,minlockedtime,gbtforce
+        with open(fork_csv_filename, 'wt') as fh:
+            # use current time to compute offset starttimes
+            self.init_time = int(time.time())
+            # starttimes are offset by 30 seconds from init_time
+            self.fork_starttime = self.init_time + 30
+            fh.write(
+            "# deployment info for network 'regtest':\n" +
+
+            ########## THRESHOLD TESTING BITS (1-6) ############
+
+            # bit 0: test 'csv' fork renaming/reparameterization
+            "regtest,0,bip135test0,%d,999999999999,144,108,0,0,true\n" % (self.fork_starttime) +
+
+            # bit 1: test minimum threshold
+            "regtest,1,bip135test1,%d,999999999999,100,1,0,0,true\n" % (self.fork_starttime) +
+
+            # bit 2: small threshold
+            "regtest,2,bip135test2,%d,999999999999,100,10,0,0,true\n" % (self.fork_starttime) +
+
+            # bit 3: supermajority threshold
+            "regtest,3,bip135test3,%d,999999999999,100,75,0,0,true\n" % (self.fork_starttime) +
+
+            # bit 4: high threshold
+            "regtest,4,bip135test4,%d,999999999999,100,95,0,0,true\n" % (self.fork_starttime) +
+
+            # bit 5: max-but-one threshold
+            "regtest,5,bip135test5,%d,999999999999,100,99,0,0,true\n" % (self.fork_starttime) +
+
+            # bit 6: max threshold
+            "regtest,6,bip135test6,%d,999999999999,100,100,0,0,true\n" % (self.fork_starttime) +
+
+            ########## GRACE PERIOD TESTING BITS (7-21) ############
+
+            # bit 7: one minlockedblock
+            "regtest,7,bip135test7,%d,999999999999,10,9,1,0,true\n" % (self.fork_starttime) +
+
+            # bit 8: half a window of minlockedblocks
+            "regtest,8,bip135test8,%d,999999999999,10,9,5,0,true\n" % (self.fork_starttime) +
+
+            # bit 9: full window of minlockedblocks
+            "regtest,9,bip135test9,%d,999999999999,10,9,10,0,true\n" % (self.fork_starttime) +
+
+            # bit 10: just over full window of minlockedblocks
+            "regtest,10,bip135test10,%d,999999999999,10,9,11,0,true\n" % (self.fork_starttime) +
+
+            # bit 11: one second minlockedtime
+            "regtest,11,bip135test11,%d,999999999999,10,9,0,1,true\n" % (self.fork_starttime) +
+
+            # bit 12: half window of minlockedtime
+            "regtest,12,bip135test12,%d,999999999999,10,9,0,%d,true\n" % (self.fork_starttime, 5) +
+
+            # bit 13: just under one full window of minlockedtime
+            "regtest,13,bip135test13,%d,999999999999,10,9,0,%d,true\n" % (self.fork_starttime, 9) +
+
+            # bit 14: exactly one window of minlockedtime
+            "regtest,14,bip135test14,%d,999999999999,10,9,0,%d,true\n" % (self.fork_starttime, 10) +
+
+            # bit 15: just over one window of minlockedtime
+            "regtest,15,bip135test15,%d,999999999999,10,9,0,%d,true\n" % (self.fork_starttime, 11) +
+
+            # bit 16: one and a half window of minlockedtime
+            "regtest,16,bip135test16,%d,999999999999,10,9,0,%d,true\n" % (self.fork_starttime, 15) +
+
+            # bit 17: one window of minblockedblocks plus one window of minlockedtime
+            "regtest,17,bip135test17,%d,999999999999,10,9,10,%d,true\n" % (self.fork_starttime, 10) +
+
+            # bit 18: one window of minblockedblocks plus just under two windows of minlockedtime
+            "regtest,18,bip135test18,%d,999999999999,10,9,10,%d,true\n" % (self.fork_starttime, 19) +
+
+            # bit 19: one window of minblockedblocks plus two windows of minlockedtime
+            "regtest,19,bip135test19,%d,999999999999,10,9,10,%d,true\n" % (self.fork_starttime, 20) +
+
+            # bit 20: two windows of minblockedblocks plus two windows of minlockedtime
+            "regtest,20,bip135test20,%d,999999999999,10,9,20,%d,true\n" % (self.fork_starttime, 21) +
+
+            # bit 21: just over two windows of minblockedblocks plus two windows of minlockedtime
+            "regtest,21,bip135test21,%d,999999999999,10,9,21,%d,true\n" % (self.fork_starttime, 20) +
+
+            ########## NOT USED SO FAR ############
+            "regtest,22,bip135test22,%d,999999999999,100,9,0,0,true\n" % (self.fork_starttime)
+            )
+
+        self.nodes = start_nodes(1, self.options.tmpdir,
+                                 extra_args=[['-debug', '-whitelist=127.0.0.1',
+                                              "-forks=%s" % fork_csv_filename]],
+                                 binary=[self.options.testbinary])
+
+    def run_test(self):
+        self.test = TestManager(self, self.options.tmpdir)
+        self.test.add_all_connections(self.nodes)
+        NetworkThread().start() # Start up network handling in another thread
+        self.test.run()
+
+    def create_transaction(self, node, coinbase, to_address, amount):
+        from_txid = node.getblock(coinbase)['tx'][0]
+        inputs = [{ "txid" : from_txid, "vout" : 0}]
+        outputs = { to_address : amount }
+        rawtx = node.createrawtransaction(inputs, outputs)
+        tx = CTransaction()
+        f = BytesIO(hex_str_to_bytes(rawtx))
+        tx.deserialize(f)
+        tx.nVersion = 2
+        return tx
+
+    def sign_transaction(self, node, tx):
+        signresult = node.signrawtransaction(bytes_to_hex_str(tx.serialize()))
+        tx = CTransaction()
+        f = BytesIO(hex_str_to_bytes(signresult['hex']))
+        tx.deserialize(f)
+        return tx
+
+    def generate_blocks(self, number, version, test_blocks = []):
+        for i in range(number):
+            #print ("generate_blocks: creating block on tip %x, height %d, time %d" % (self.tip, self.height, self.last_block_time + 1))
+            block = create_block(self.tip, create_coinbase(self.height), self.last_block_time + 1)
+            block.nVersion = version
+            block.rehash()
+            block.solve()
+            test_blocks.append([block, True])
+            self.last_block_time += 1
+            self.tip = block.sha256
+            self.height += 1
+        return test_blocks
+
+    def get_bip135_status(self, key):
+        info = self.nodes[0].getblockchaininfo()
+        return info['bip135_forks'][key]
+
+    def print_rpc_status(self):
+        for f in self.defined_forks:
+            info = self.nodes[0].getblockchaininfo()
+            print(info['bip135_forks'][f])
+
+    def test_BIP135GraceConditions(self):
+
+        # the fork bits used to check grace period conditions
+        gracebits = self.defined_forks[7:22]
+
+        print("begin test_BIP135GraceConditions test")
+        node = self.nodes[0]
+        self.tip = int("0x" + node.getbestblockhash(), 0)
+        header = node.getblockheader("0x%x" % self.tip)
+        assert_equal(header['height'], 0)
+
+        # Test 1
+        # generate a block, seems necessary to get RPC working
+        self.coinbase_blocks = self.nodes[0].generate(1)
+        self.height = 2
+        self.last_block_time = int(time.time())
+        self.tip = int("0x" + node.getbestblockhash(), 0)
+        test_blocks = self.generate_blocks(1, 0x20000000)  # do not set bit 0 yet
+        yield TestInstance(test_blocks, sync_every_block=False)
+
+        bcinfo = self.nodes[0].getblockchaininfo()
+        # check bits 7-15 , they should be in DEFINED
+        for f in gracebits:
+            assert_equal(bcinfo['bip135_forks'][f]['bit'], int(f[10:]))
+            assert_equal(bcinfo['bip135_forks'][f]['status'], 'defined')
+
+        # move to starttime
+        moved_to_started = False
+        bcinfo = self.nodes[0].getblockchaininfo()
+        tip_mediantime = int(bcinfo['mediantime'])
+        while tip_mediantime < self.fork_starttime or self.height % 10:
+            test_blocks = self.generate_blocks(1, 0x20000000)
+            yield TestInstance(test_blocks, sync_every_block=False)
+            time.sleep(3)  # need to actually give daemon a little time to change the state
+            bcinfo = self.nodes[0].getblockchaininfo()
+            tip_mediantime = int(bcinfo['mediantime'])
+            for f in gracebits:
+                # transition to STARTED must occur if this is true
+                if tip_mediantime >= self.fork_starttime and self.height % 10 == 0:
+                    moved_to_started = True
+                    time.sleep(3)  # need to actually give daemon a little time to change the state
+
+                if moved_to_started:
+                    assert_equal(bcinfo['bip135_forks'][f]['status'], 'started')
+                else:
+                    assert_equal(bcinfo['bip135_forks'][f]['status'], 'defined')
+
+        # lock all of them them in by producing 9 signaling blocks out of 10
+        test_blocks = self.generate_blocks(9, 0x203fff80)
+        # tenth block doesn't need to signal
+        test_blocks = self.generate_blocks(1, 0x20000000, test_blocks)
+        yield TestInstance(test_blocks, sync_every_block=False)
+        # check bits 7-15 , they should all be in LOCKED_IN
+        bcinfo = self.nodes[0].getblockchaininfo()
+        print("checking all grace period forks are locked in")
+        for f in gracebits:
+            assert_equal(bcinfo['bip135_forks'][f]['status'], 'locked_in')
+
+        # now we just check that they turn ACTIVE only when their configured
+        # conditions are all met. Reminder: window size is 10 blocks, inter-
+        # block time is 1 sec for the synthesized chain.
+        #
+        # Grace conditions for the bits 7-21:
+        # -----------------------------------
+        # bit 7:  minlockedblocks= 1, minlockedtime= 0  -> activate next sync
+        # bit 8:  minlockedblocks= 5, minlockedtime= 0  -> activate next sync
+        # bit 9:  minlockedblocks=10, minlockedtime= 0  -> activate next sync
+        # bit 10: minlockedblocks=11, minlockedtime= 0  -> activate next plus one sync
+        # bit 11: minlockedblocks= 0, minlockedtime= 1  -> activate next sync
+        # bit 12: minlockedblocks= 0, minlockedtime= 5  -> activate next sync
+        # bit 13: minlockedblocks= 0, minlockedtime= 9  -> activate next sync
+        # bit 14: minlockedblocks= 0, minlockedtime=10  -> activate next sync
+        # bit 15: minlockedblocks= 0, minlockedtime=11  -> activate next plus one sync
+        # bit 16: minlockedblocks= 0, minlockedtime=15  -> activate next plus one sync
+        # bit 17: minlockedblocks=10, minlockedtime=10  -> activate next sync
+        # bit 18: minlockedblocks=10, minlockedtime=19  -> activate next plus one sync
+        # bit 19: minlockedblocks=10, minlockedtime=20  -> activate next plus one sync
+        # bit 20: minlockedblocks=20, minlockedtime=21  -> activate next plus two sync
+        # bit 21: minlockedblocks=21, minlockedtime=20  -> activate next plus two sync
+
+        # check the forks supposed to activate just one period after lock-in ("at next sync")
+
+        test_blocks = self.generate_blocks(10, 0x20000000)
+        yield TestInstance(test_blocks, sync_every_block=False)
+        time.sleep(3)
+        bcinfo = self.nodes[0].getblockchaininfo()
+        activation_states = [ bcinfo['bip135_forks'][f]['status'] for f in gracebits ]
+        assert_equal(activation_states, ['active',
+                                         'active',
+                                         'active',
+                                         'locked_in',
+                                         'active',
+                                         'active',
+                                         'active',
+                                         'active',
+                                         'locked_in',
+                                         'locked_in',
+                                         'active',
+                                         'locked_in',
+                                         'locked_in',
+                                         'locked_in',
+                                         'locked_in'
+                                         ])
+
+        # check the ones supposed to activate at next+1 sync
+        test_blocks = self.generate_blocks(10, 0x20000000)
+        yield TestInstance(test_blocks, sync_every_block=False)
+        time.sleep(3)
+        bcinfo = self.nodes[0].getblockchaininfo()
+        activation_states = [ bcinfo['bip135_forks'][f]['status'] for f in gracebits ]
+        assert_equal(activation_states, ['active',
+                                         'active',
+                                         'active',
+                                         'active',
+                                         'active',
+                                         'active',
+                                         'active',
+                                         'active',
+                                         'active',
+                                         'active',
+                                         'active',
+                                         'active',
+                                         'active',
+                                         'locked_in',
+                                         'locked_in'
+                                         ])
+
+        # check the ones supposed to activate at next+2 period
+        test_blocks = self.generate_blocks(10, 0x20000000)
+        yield TestInstance(test_blocks, sync_every_block=False)
+        time.sleep(3)
+        bcinfo = self.nodes[0].getblockchaininfo()
+        activation_states = [ bcinfo['bip135_forks'][f]['status'] for f in gracebits ]
+        assert_equal(activation_states, ['active',
+                                         'active',
+                                         'active',
+                                         'active',
+                                         'active',
+                                         'active',
+                                         'active',
+                                         'active',
+                                         'active',
+                                         'active',
+                                         'active',
+                                         'active',
+                                         'active',
+                                         'active',
+                                         'active'  # locked_in
+                                         ])
+
+        # check the ones supposed to activate at next+2 period
+        test_blocks = self.generate_blocks(10, 0x20000000)
+        yield TestInstance(test_blocks, sync_every_block=False)
+        time.sleep(3)
+        bcinfo = self.nodes[0].getblockchaininfo()
+        activation_states = [ bcinfo['bip135_forks'][f]['status'] for f in gracebits ]
+        assert_equal(activation_states, ['active',
+                                         'active',
+                                         'active',
+                                         'active',
+                                         'active',
+                                         'active',
+                                         'active',
+                                         'active',
+                                         'active',
+                                         'active',
+                                         'active',
+                                         'active',
+                                         'active',
+                                         'active',
+                                         'active'
+                                         ])
+
+
+    def get_tests(self):
+        '''
+        run various tests
+        '''
+        # CSV (bit 0) for backward compatibility with BIP9
+        for test in itertools.chain(
+                self.test_BIP135GraceConditions(), # test grace periods
+        ):
+            yield test
+
+
+
+if __name__ == '__main__':
+    BIP135ForksTest().main()

--- a/test/functional/bip135-threshold.py
+++ b/test/functional/bip135-threshold.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+# Copyright (c) 2015 The Bitcoin Core developers
+# Copyright (c) 2015-2017 The Bitcoin Unlimited developers
+# Copyright (c) 2017 The Bitcoin developers
+# Distributed under the MIT/X11 software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#
+from test_framework.util import sync_blocks
+from test_framework.test_framework import ComparisonTestFramework
+from test_framework.util import *
+from test_framework.mininode import CTransaction, NetworkThread
+from test_framework.blocktools import create_coinbase, create_block
+from test_framework.comptool import TestInstance, TestManager
+from test_framework.script import CScript, OP_1NEGATE, OP_CHECKSEQUENCEVERIFY, OP_DROP
+from io import BytesIO
+import time
+import itertools
+import tempfile
+
+'''
+This test exercises BIP135 fork activation thresholds.
+It uses a single node with custom forks.csv file.
+
+It is adapted from bip135-genvbvoting-forks on BU, which was
+derived from bip9-softforks.
+'''
+
+
+class BIP135ForksTest(ComparisonTestFramework):
+
+    def __init__(self):
+        super().__init__()
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+        self.defined_forks = [ "bip135test%d" % i for i in range(0,8) ]
+
+    def setup_network(self):
+        '''
+        sets up with a custom forks.csv to test threshold / grace conditions
+        also recomputes deployment start times since node is shut down and
+        restarted between main test sections.
+        '''
+        # write a custom forks.csv file containing test deployments.
+        # blocks are 1 second apart by default in this regtest
+        fork_csv_filename = os.path.join(self.options.tmpdir, "forks.csv")
+        # forks.csv fields:
+        # network,bit,name,starttime,timeout,windowsize,threshold,minlockedblocks,minlockedtime,gbtforce
+        with open(fork_csv_filename, 'wt') as fh:
+            # use current time to compute offset starttimes
+            self.init_time = int(time.time())
+            # starttimes are offset by 30 seconds from init_time
+            self.fork_starttime = self.init_time + 30
+            fh.write(
+            "# deployment info for network 'regtest':\n" +
+
+            ########## THRESHOLD TESTING BITS (1-6) ############
+
+            # bit 0: test 'csv' fork renaming/reparameterization
+            "regtest,0,bip135test0,%d,999999999999,144,108,0,0,true\n" % (self.fork_starttime) +
+
+            # bit 1: test 'segwit' fork renaming/reparameterization
+            "regtest,1,bip135test1,%d,999999999999,144,108,0,0,true\n" % (self.fork_starttime) +
+
+            # bit 2: test minimum threshold
+            "regtest,2,bip135test2,%d,999999999999,100,1,0,0,true\n" % (self.fork_starttime) +
+
+            # bit 3: small threshold
+            "regtest,3,bip135test3,%d,999999999999,100,10,0,0,true\n" % (self.fork_starttime) +
+
+            # bit 4: supermajority threshold
+            "regtest,4,bip135test4,%d,999999999999,100,75,0,0,true\n" % (self.fork_starttime) +
+
+            # bit 5: high threshold
+            "regtest,5,bip135test5,%d,999999999999,100,95,0,0,true\n" % (self.fork_starttime) +
+
+            # bit 6: max-but-one threshold
+            "regtest,6,bip135test6,%d,999999999999,100,99,0,0,true\n" % (self.fork_starttime) +
+
+            # bit 7: max threshold
+            "regtest,7,bip135test7,%d,999999999999,100,100,0,0,true\n" % (self.fork_starttime)
+
+            )
+
+        self.nodes = start_nodes(1, self.options.tmpdir,
+                                 extra_args=[['-debug=all', '-whitelist=127.0.0.1',
+                                              "-forks=%s" % fork_csv_filename]],
+                                 binary=[self.options.testbinary])
+
+    def run_test(self):
+        self.test = TestManager(self, self.options.tmpdir)
+        self.test.add_all_connections(self.nodes)
+        NetworkThread().start() # Start up network handling in another thread
+        self.test.run()
+
+    def create_transaction(self, node, coinbase, to_address, amount):
+        from_txid = node.getblock(coinbase)['tx'][0]
+        inputs = [{ "txid" : from_txid, "vout" : 0}]
+        outputs = { to_address : amount }
+        rawtx = node.createrawtransaction(inputs, outputs)
+        tx = CTransaction()
+        f = BytesIO(hex_str_to_bytes(rawtx))
+        tx.deserialize(f)
+        tx.nVersion = 2
+        return tx
+
+    def sign_transaction(self, node, tx):
+        signresult = node.signrawtransaction(bytes_to_hex_str(tx.serialize()))
+        tx = CTransaction()
+        f = BytesIO(hex_str_to_bytes(signresult['hex']))
+        tx.deserialize(f)
+        return tx
+
+    def generate_blocks(self, number, version, test_blocks = []):
+        for i in range(number):
+            old_tip = self.tip
+            block = create_block(self.tip, create_coinbase(self.height), self.last_block_time + 1)
+            block.nVersion = version
+            block.rehash()
+            block.solve()
+            test_blocks.append([block, True])
+            self.last_block_time += 1
+            self.tip = block.sha256
+            self.height += 1
+            #print ("generate_blocks: created block %x on tip %x, height %d, time %d" % (self.tip, old_tip, self.height-1, self.last_block_time))
+        return test_blocks
+
+    def get_bip135_status(self, key):
+        info = self.nodes[0].getblockchaininfo()
+        return info['bip135_forks'][key]
+
+    def print_rpc_status(self):
+        for f in self.defined_forks:
+            info = self.nodes[0].getblockchaininfo()
+            print(info['bip135_forks'][f])
+
+    def test_BIP135Thresholds(self):
+
+        print("test_BIP135Thresholds: begin")
+        node = self.nodes[0]
+        self.tip = int("0x" + node.getbestblockhash(), 0)
+        header = node.getblockheader("0x%x" % self.tip)
+        assert_equal(header['height'], 0)
+
+        # Test 1
+        # generate a block, seems necessary to get RPC working
+        self.coinbase_blocks = self.nodes[0].generate(1)
+        self.height = 2
+        self.last_block_time = int(time.time())
+        self.tip = int("0x" + node.getbestblockhash(), 0)
+        test_blocks = self.generate_blocks(1, 0x20000000)  # do not set bit 0 yet
+        yield TestInstance(test_blocks, sync_every_block=False)
+
+        # Test 2
+        # check initial DEFINED state
+        # check initial forks status and getblocktemplate
+        print("begin test 2")
+        tmpl = self.nodes[0].getblocktemplate({})
+        assert_equal(tmpl['vbrequired'], 0)
+        assert_equal(tmpl['version'], 0x20000000)
+        print("initial getblocktemplate:\n%s" % tmpl)
+
+        test_blocks = []
+        bcinfo = self.nodes[0].getblockchaininfo()
+        tip_mediantime = int(bcinfo['mediantime'])
+        while tip_mediantime < self.fork_starttime or self.height < 100:
+            for f in self.defined_forks:
+                assert_equal(self.get_bip135_status(f)['bit'], int(f[10:]))
+                assert_equal(self.get_bip135_status(f)['status'], 'defined')
+                assert(f not in tmpl['rules'])
+                assert(f not in tmpl['vbavailable'])
+            test_blocks = self.generate_blocks(1, 0x20000001)
+            yield TestInstance(test_blocks, sync_every_block=False)
+            bcinfo = self.nodes[0].getblockchaininfo()
+            tip_mediantime = int(bcinfo['mediantime'])
+
+        # Test 3
+        # Advance from DEFINED to STARTED
+        print("begin test 3")
+        test_blocks = self.generate_blocks(1, 0x20000001)
+        for f in self.defined_forks:
+            if int(f[10:]) > 1:
+                assert_equal(self.get_bip135_status(f)['status'], 'started')
+                assert(f not in tmpl['rules'])
+                assert(f not in tmpl['vbavailable'])
+            elif int(f[10:]) == 0: # bit 0 only becomes started at height 144
+                assert_equal(self.get_bip135_status(f)['status'], 'defined')
+
+        yield TestInstance(test_blocks, sync_every_block=False)
+
+        # Test 4
+        # Advance from DEFINED to STARTED
+        print("begin test 4")
+        test_blocks = self.generate_blocks(1, 0x20000001)
+        yield TestInstance(test_blocks, sync_every_block=False)
+
+        for f in self.defined_forks:
+            info = node.getblockchaininfo()
+            print(info['bip135_forks'][f])
+
+        # Test 5..?
+        # Advance from DEFINED to STARTED
+        print("begin test 5 .. x - move to height 144 for bit 0 start")
+        # we are not yet at height 144, so bit 0 is still defined
+        assert_equal(self.get_bip135_status(self.defined_forks[0])['status'], 'defined')
+        # move up until it starts
+        while self.height < 144:
+            #print("last block time has not reached fork_starttime, difference: %d" % (self.fork_starttime - self.last_block_time))
+            test_blocks = self.generate_blocks(1, 0x20000001)
+            yield TestInstance(test_blocks, sync_every_block=False)
+            if int(f[10:]) > 0:
+                assert_equal(self.get_bip135_status(f)['status'], 'started')
+                assert(f not in tmpl['rules'])
+                assert(f not in tmpl['vbavailable'])
+            else: # bit 0 only becomes started at height 144
+                assert_equal(self.get_bip135_status(f)['status'], 'defined')
+
+        # generate block 144
+        test_blocks = []
+        # now it should be started
+
+        yield TestInstance(test_blocks, sync_every_block=False)
+        assert_equal(self.get_bip135_status(self.defined_forks[0])['status'], 'started')
+
+        tmpl = self.nodes[0].getblocktemplate({})
+        assert(self.defined_forks[0] not in tmpl['rules'])
+        assert_equal(tmpl['vbavailable'][self.defined_forks[0]], 0)
+        assert_equal(tmpl['vbrequired'], 0)
+        assert(tmpl['version'] & 0x20000000 + 2**0)
+
+        # move to start of new 100 block window
+        # start signaling for bit 7 so we can get a full 100 block window for it
+        # over the next period
+        test_blocks = self.generate_blocks(100 - (self.height % 100), 0x20000080)
+        yield TestInstance(test_blocks, sync_every_block=False)
+        assert(self.height % 100 == 0)
+
+        # generate enough of bits 2-7 in next 100 blocks to lock in fork bits 2-7
+        # bit 0 will only be locked in at next multiple of 144
+        test_blocks = []
+        # 1 block total for bit 2
+        test_blocks = self.generate_blocks(1, 0x200000FD)
+        yield TestInstance(test_blocks, sync_every_block=False)
+        # check still STARTED until we get to multiple of window size
+        assert_equal(self.get_bip135_status(self.defined_forks[1])['status'], 'started')
+
+        # 10 blocks total for bit 3
+        test_blocks = self.generate_blocks(9, 0x200000F9)
+        yield TestInstance(test_blocks, sync_every_block=False)
+        assert_equal(self.get_bip135_status(self.defined_forks[2])['status'], 'started')
+
+        # 75 blocks total for bit 4
+        test_blocks = self.generate_blocks(65, 0x200000F1)
+        yield TestInstance(test_blocks, sync_every_block=False)
+        assert_equal(self.get_bip135_status(self.defined_forks[3])['status'], 'started')
+
+        # 95 blocks total for bit 5
+        test_blocks = self.generate_blocks(20, 0x200000E1)
+        yield TestInstance(test_blocks, sync_every_block=False)
+        assert_equal(self.get_bip135_status(self.defined_forks[4])['status'], 'started')
+
+        # 99 blocks total for bit 6
+        test_blocks = self.generate_blocks(4, 0x200000C1)
+        yield TestInstance(test_blocks, sync_every_block=False)
+        assert_equal(self.get_bip135_status(self.defined_forks[5])['status'], 'started')
+
+        # 100 blocks total for bit 7
+        test_blocks = self.generate_blocks(1, 0x20000081)
+        yield TestInstance(test_blocks, sync_every_block=False)
+        assert(self.height % 100 == 0)
+
+        # debug trace
+        for f in self.defined_forks[2:]:
+            info = node.getblockchaininfo()
+            print(info['bip135_forks'][f])
+            assert_equal(self.get_bip135_status(f)['status'], 'locked_in')
+
+        assert_equal(self.get_bip135_status(self.defined_forks[0])['status'], 'started')
+        # move until bit 0 locks in
+        print("moving until bit 0 locks in")
+        one_hundreds_active = False  # to count the 100-block bits 1-6 going active after 100 more
+        while self.height % 144 != 0:
+            test_blocks = self.generate_blocks(1, 0x20000001)
+            yield TestInstance(test_blocks, sync_every_block=False)
+            continue
+            bcinfo = self.nodes[0].getblockchaininfo()
+            # check bit 0 - it is locked in after this loop exits
+            if self.height % 144:
+                assert_equal(bcinfo['bip135_forks'][self.defined_forks[0]]['status'], 'started')
+            else:
+                assert_equal(bcinfo['bip135_forks'][self.defined_forks[0]]['status'], 'locked_in')
+            # bits 1-6 should remain LOCKED_IN
+            for f in self.defined_forks[2:]:
+                if self.height % 100:
+                    if not one_hundreds_active:
+                        assert_equal(bcinfo['bip135_forks'][f]['status'], 'locked_in')
+                    else:
+                        assert_equal(bcinfo['bip135_forks'][f]['status'], 'active')
+                else:
+                    # mark them expected active henceforth
+                    one_hundreds_active = True
+                    assert_equal(bcinfo['bip135_forks'][f]['status'], 'active')
+
+        assert_equal(self.get_bip135_status(self.defined_forks[0])['status'], 'locked_in')
+
+    def get_tests(self):
+        '''
+        run various tests
+        '''
+        # CSV (bit 0) for backward compatibility with BIP9
+        for test in itertools.chain(
+                self.test_BIP135Thresholds(),  # test thresholds on other bits
+        ):
+            yield test
+
+
+
+if __name__ == '__main__':
+    BIP135ForksTest().main()

--- a/test/functional/bip135-threshold.py
+++ b/test/functional/bip135-threshold.py
@@ -21,8 +21,7 @@ import tempfile
 This test exercises BIP135 fork activation thresholds.
 It uses a single node with custom forks.csv file.
 
-It is adapted from bip135-genvbvoting-forks on BU, which was
-derived from bip9-softforks.
+It is originally derived from bip9-softforks.
 '''
 
 

--- a/test/functional/p2p-versionbits-warning.py
+++ b/test/functional/p2p-versionbits-warning.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
-# Copyright (c) 2016 The Bitcoin Core developers
+# Copyright (c) 2016-2017 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test version bits warning system.
 
 Generate chains with block versions that appear to be signalling unknown
-soft-forks, and test that warning alerts are generated.
+forks, and test that warning alerts are generated.
 """
 
 from test_framework.mininode import *
@@ -107,11 +107,6 @@ class VersionBitsWarningTest(BitcoinTestFramework):
         assert(WARN_UNKNOWN_RULES_MINED in self.nodes[0].getinfo()["errors"])
         assert(WARN_UNKNOWN_RULES_MINED in self.nodes[0].getmininginfo()["errors"])
         assert(WARN_UNKNOWN_RULES_MINED in self.nodes[0].getnetworkinfo()["warnings"])
-
-        # BIP135: removed obsolete check for error on activation of unknown bit
-
-        # Test framework expects the node to still be running...
-        #self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, self.extra_args)
 
 if __name__ == '__main__':
     VersionBitsWarningTest().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -120,9 +120,11 @@ EXTENDED_SCRIPTS = [
     # vv Tests less than 20m vv
     'smartfees.py',
     # vv Tests less than 5m vv
+    'bip135-grace.py',
     'maxuploadtarget.py',
     'mempool_packages.py',
     # vv Tests less than 2m vv
+    'bip135-threshold.py',
     'bip68-sequence.py',
     'getblocktemplate_longpoll.py',
     'p2p-timeouts.py',


### PR DESCRIPTION
This is an implementation of https://github.com/bitcoin/bips/blob/master/bip-0135.mediawiki .

It extends the BIP9 state machine processing with configurable per-bit window size, activation threshold and grace period parameters (minlockedblocks and minlockedtime).

The built-in deployments are parameterized to maintain backward compatibility, and the existing BIP9 tests are retained unmodified except for a minor fix made to `versionbits_tests` to improve the disjointness checks for configured bits).

A `bip135_forks` section has been added to the `getblockchaininfo` RPC output, leaving the existing `bip9_softforks` section for backward compatibility.

The check for 'unknown versions being mined' has been altered to take into account that for unknown bits, we can no longer rely on a 95% activation threshold. The `p2p-versionbits-warning` test has been modified accordingly - the new logic warns when an unknown bit exceeds 50/100 of the last blocks.

NOTE: This implementation contains a specific feature which is not covered by the specification (and thus not strictly required for BIP135): the optional loading of fork configuration from a CSV file (using `-forks=datafile` command line option) and the ability to dump out the built-in configuration in CSV format (`-dumpforks` option). This has been retained from the original reference implementation since it makes testing and adaptation of the configuration easier.