### PR TITLE
Add fee_est tool for debugging fee estimation code

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -228,6 +228,7 @@ BITCOIN_CORE_H = \
   policy/feerate.h \
   policy/fees.h \
   policy/fees_args.h \
+  policy/fees_input.h \
   policy/packages.h \
   policy/policy.h \
   policy/rbf.h \
@@ -418,6 +419,7 @@ libbitcoin_node_a_SOURCES = \
   noui.cpp \
   policy/fees.cpp \
   policy/fees_args.cpp \
+  policy/fees_input.cpp \
   policy/packages.cpp \
   policy/rbf.cpp \
   policy/settings.cpp \
@@ -932,6 +934,7 @@ libbitcoinkernel_la_SOURCES = \
   node/utxo_snapshot.cpp \
   policy/feerate.cpp \
   policy/fees.cpp \
+  policy/fees_input.cpp \
   policy/packages.cpp \
   policy/policy.cpp \
   policy/rbf.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -8,6 +8,7 @@ endif
 
 if ENABLE_TESTS
 bin_PROGRAMS += test/test_bitcoin
+noinst_PROGRAMS += test/fee_est/fee_est
 endif
 
 TEST_SRCDIR = test
@@ -347,6 +348,40 @@ test_fuzz_fuzz_SOURCES = \
  test/fuzz/validation_load_mempool.cpp \
  test/fuzz/versionbits.cpp
 endif # ENABLE_FUZZ_BINARY
+
+# fee_est/fee_est binary #
+test_fee_est_fee_est_SOURCES = test/fee_est/fee_est.cpp
+test_fee_est_fee_est_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
+test_fee_est_fee_est_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fee_est_fee_est_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fee_est_fee_est_LDADD = \
+  $(LIBBITCOIN_NODE)
+
+if ENABLE_WALLET
+test_fee_est_fee_est_LDADD += \
+  $(LIBBITCOIN_WALLET)
+endif
+
+test_fee_est_fee_est_LDADD += \
+  $(LIBBITCOIN_COMMON) \
+  $(LIBBITCOIN_UTIL) \
+  $(LIBBITCOIN_CONSENSUS) \
+  $(LIBBITCOIN_CRYPTO) \
+  $(LIBBITCOIN_CRYPTO_SSE41) \
+  $(LIBBITCOIN_CRYPTO_AVX2) \
+  $(LIBLEVELDB) $(LIBLEVELDB_SSE42) $(LIBMEMENV) \
+  $(LIBSECP256K1) \
+  $(LIBUNIVALUE) \
+  $(BDB_LIBS) \
+  $(BOOST_LIBS) \
+  $(CRYPTO_LIBS) \
+  $(EVENT_LIBS) $(EVENT_PTHREADS_LIBS) \
+  $(MINIUPNPC_LIBS)
+
+if ENABLE_ZMQ
+test_fee_est_fee_est_LDADD += $(LIBBITCOIN_ZMQ) $(ZMQ_LIBS)
+endif
+#
 
 nodist_test_test_bitcoin_SOURCES = $(GENERATED_TEST_FILES)
 

--- a/src/kernel/mempool_options.h
+++ b/src/kernel/mempool_options.h
@@ -14,7 +14,7 @@
 #include <cstdint>
 #include <optional>
 
-class CBlockPolicyEstimator;
+class FeeEstInput;
 
 /** Default for -maxmempool, maximum megabytes of mempool memory usage */
 static constexpr unsigned int DEFAULT_MAX_MEMPOOL_SIZE_MB{300};
@@ -35,7 +35,7 @@ namespace kernel {
  */
 struct MemPoolOptions {
     /* Used to estimate appropriate transaction fees. */
-    CBlockPolicyEstimator* estimator{nullptr};
+    FeeEstInput* estimator{nullptr};
     /* The ratio used to determine how often sanity checks will run.  */
     int check_ratio{0};
     int64_t max_size_bytes{DEFAULT_MAX_MEMPOOL_SIZE_MB * 1'000'000};

--- a/src/node/context.cpp
+++ b/src/node/context.cpp
@@ -12,6 +12,7 @@
 #include <net_processing.h>
 #include <netgroup.h>
 #include <policy/fees.h>
+#include <policy/fees_input.h>
 #include <scheduler.h>
 #include <txmempool.h>
 #include <validation.h>

--- a/src/node/context.h
+++ b/src/node/context.h
@@ -20,6 +20,7 @@ class CConnman;
 class CScheduler;
 class CTxMemPool;
 class ChainstateManager;
+class FeeEstInput;
 class NetGroupManager;
 class PeerManager;
 namespace interfaces {
@@ -49,6 +50,7 @@ struct NodeContext {
     std::unique_ptr<CConnman> connman;
     std::unique_ptr<CTxMemPool> mempool;
     std::unique_ptr<const NetGroupManager> netgroupman;
+    std::unique_ptr<FeeEstInput> fee_estimator_input;
     std::unique_ptr<CBlockPolicyEstimator> fee_estimator;
     std::unique_ptr<PeerManager> peerman;
     std::unique_ptr<ChainstateManager> chainman;

--- a/src/policy/fees.cpp
+++ b/src/policy/fees.cpp
@@ -527,8 +527,7 @@ bool CBlockPolicyEstimator::_removeTx(const uint256& hash, bool inBlock)
     }
 }
 
-CBlockPolicyEstimator::CBlockPolicyEstimator(const fs::path& estimation_filepath)
-    : m_estimation_filepath{estimation_filepath}
+CBlockPolicyEstimator::CBlockPolicyEstimator()
 {
     static_assert(MIN_BUCKET_FEERATE > 0, "Min feerate must be nonzero");
     size_t bucketIndex = 0;
@@ -544,21 +543,17 @@ CBlockPolicyEstimator::CBlockPolicyEstimator(const fs::path& estimation_filepath
     feeStats = std::unique_ptr<TxConfirmStats>(new TxConfirmStats(buckets, bucketMap, MED_BLOCK_PERIODS, MED_DECAY, MED_SCALE));
     shortStats = std::unique_ptr<TxConfirmStats>(new TxConfirmStats(buckets, bucketMap, SHORT_BLOCK_PERIODS, SHORT_DECAY, SHORT_SCALE));
     longStats = std::unique_ptr<TxConfirmStats>(new TxConfirmStats(buckets, bucketMap, LONG_BLOCK_PERIODS, LONG_DECAY, LONG_SCALE));
-
-    // If the fee estimation file is present, read recorded estimations
-    AutoFile est_file{fsbridge::fopen(m_estimation_filepath, "rb")};
-    if (est_file.IsNull() || !Read(est_file)) {
-        LogPrintf("Failed to read fee estimates from %s. Continue anyway.\n", fs::PathToString(m_estimation_filepath));
-    }
 }
 
 CBlockPolicyEstimator::~CBlockPolicyEstimator() = default;
 
-void CBlockPolicyEstimator::processTransaction(const CTxMemPoolEntry& entry, bool validFeeEstimate)
+void CBlockPolicyEstimator::processTx(const uint256& hash,
+    unsigned int txHeight,
+    CAmount fee,
+    uint32_t size,
+    bool validFeeEstimate)
 {
     LOCK(m_cs_fee_estimator);
-    unsigned int txHeight = entry.GetHeight();
-    uint256 hash = entry.GetTx().GetHash();
     if (mapMemPoolTxs.count(hash)) {
         LogPrint(BCLog::ESTIMATEFEE, "Blockpolicy error mempool tx %s already being tracked\n",
                  hash.ToString());
@@ -582,7 +577,7 @@ void CBlockPolicyEstimator::processTransaction(const CTxMemPoolEntry& entry, boo
     trackedTxs++;
 
     // Feerates are stored and reported as BTC-per-kb:
-    CFeeRate feeRate(entry.GetFee(), entry.GetTxSize());
+    CFeeRate feeRate(fee, size);
 
     mapMemPoolTxs[hash].blockHeight = txHeight;
     unsigned int bucketIndex = feeStats->NewTx(txHeight, (double)feeRate.GetFeePerK());
@@ -593,10 +588,14 @@ void CBlockPolicyEstimator::processTransaction(const CTxMemPoolEntry& entry, boo
     assert(bucketIndex == bucketIndex3);
 }
 
-bool CBlockPolicyEstimator::processBlockTx(unsigned int nBlockHeight, const CTxMemPoolEntry* entry)
+bool CBlockPolicyEstimator::processBlockTx(unsigned int nBlockHeight,
+    const uint256& hash,
+    unsigned int height,
+    CAmount fee,
+    uint32_t size)
 {
     AssertLockHeld(m_cs_fee_estimator);
-    if (!_removeTx(entry->GetTx().GetHash(), true)) {
+    if (!_removeTx(hash, true)) {
         // This transaction wasn't being tracked for fee estimation
         return false;
     }
@@ -604,7 +603,7 @@ bool CBlockPolicyEstimator::processBlockTx(unsigned int nBlockHeight, const CTxM
     // How many blocks did it take for miners to include this transaction?
     // blocksToConfirm is 1-based, so a transaction included in the earliest
     // possible block has confirmation count of 1
-    int blocksToConfirm = nBlockHeight - entry->GetHeight();
+    int blocksToConfirm = nBlockHeight - height;
     if (blocksToConfirm <= 0) {
         // This can't happen because we don't process transactions from a block with a height
         // lower than our greatest seen height
@@ -613,7 +612,7 @@ bool CBlockPolicyEstimator::processBlockTx(unsigned int nBlockHeight, const CTxM
     }
 
     // Feerates are stored and reported as BTC-per-kb:
-    CFeeRate feeRate(entry->GetFee(), entry->GetTxSize());
+    CFeeRate feeRate(fee, size);
 
     feeStats->Record(blocksToConfirm, (double)feeRate.GetFeePerK());
     shortStats->Record(blocksToConfirm, (double)feeRate.GetFeePerK());
@@ -621,8 +620,7 @@ bool CBlockPolicyEstimator::processBlockTx(unsigned int nBlockHeight, const CTxM
     return true;
 }
 
-void CBlockPolicyEstimator::processBlock(unsigned int nBlockHeight,
-                                         std::vector<const CTxMemPoolEntry*>& entries)
+void CBlockPolicyEstimator::processBlock(unsigned int nBlockHeight, const AddTxsFn& add_txs)
 {
     LOCK(m_cs_fee_estimator);
     if (nBlockHeight <= nBestSeenHeight) {
@@ -650,11 +648,13 @@ void CBlockPolicyEstimator::processBlock(unsigned int nBlockHeight,
     longStats->UpdateMovingAverages();
 
     unsigned int countedTxs = 0;
+    unsigned int block_txs = 0;
     // Update averages with data points from current block
-    for (const auto& entry : entries) {
-        if (processBlockTx(nBlockHeight, entry))
-            countedTxs++;
-    }
+    add_txs([&](const uint256& hash, unsigned int height, CAmount fee, uint32_t size)
+        EXCLUSIVE_LOCKS_REQUIRED(m_cs_fee_estimator) {
+            if (processBlockTx(nBlockHeight, hash, height, fee, size)) ++countedTxs;
+            ++block_txs;
+        });
 
     if (firstRecordedHeight == 0 && countedTxs > 0) {
         firstRecordedHeight = nBestSeenHeight;
@@ -663,7 +663,7 @@ void CBlockPolicyEstimator::processBlock(unsigned int nBlockHeight,
 
 
     LogPrint(BCLog::ESTIMATEFEE, "Blockpolicy estimates updated by %u of %u block txs, since last block %u of %u tracked, mempool map size %u, max target %u from %s\n",
-             countedTxs, entries.size(), trackedTxs, trackedTxs + untrackedTxs, mapMemPoolTxs.size(),
+             countedTxs, block_txs, trackedTxs, trackedTxs + untrackedTxs, mapMemPoolTxs.size(),
              MaxUsableEstimate(), HistoricalBlockSpan() > BlockSpan() ? "historical" : "current");
 
     trackedTxs = 0;
@@ -754,6 +754,29 @@ unsigned int CBlockPolicyEstimator::MaxUsableEstimate() const
 {
     // Block spans are divided by 2 to make sure there are enough potential failing data points for the estimate
     return std::min(longStats->GetMaxConfirms(), std::max(BlockSpan(), HistoricalBlockSpan()) / 2);
+}
+
+unsigned int CBlockPolicyEstimator::getMaxTarget() const
+{
+    LOCK(m_cs_fee_estimator);
+    return MaxUsableEstimate();
+}
+
+// static
+std::vector<unsigned int> CBlockPolicyEstimator::GetUniqueTargets()
+{
+    std::set<unsigned int> targets;
+    auto addTargets = [&](unsigned int numTargets, unsigned int scale) {
+        int target = scale;
+        for (unsigned int i = 1; i < numTargets; ++i) {
+            targets.emplace(target);
+            target += scale;
+        }
+    };
+    addTargets(SHORT_BLOCK_PERIODS, SHORT_SCALE);
+    addTargets(MED_BLOCK_PERIODS, MED_SCALE);
+    addTargets(LONG_BLOCK_PERIODS, LONG_SCALE);
+    return {targets.begin(), targets.end()};
 }
 
 /** Return a fee estimate at the required successThreshold from the shortest
@@ -899,15 +922,6 @@ CFeeRate CBlockPolicyEstimator::estimateSmartFee(int confTarget, FeeCalculation 
     if (median < 0) return CFeeRate(0); // error condition
 
     return CFeeRate(llround(median));
-}
-
-void CBlockPolicyEstimator::Flush() {
-    FlushUnconfirmed();
-
-    AutoFile est_file{fsbridge::fopen(m_estimation_filepath, "wb")};
-    if (est_file.IsNull() || !Write(est_file)) {
-        LogPrintf("Failed to write fee estimates to %s. Continue anyway.\n", fs::PathToString(m_estimation_filepath));
-    }
 }
 
 bool CBlockPolicyEstimator::Write(AutoFile& fileout) const

--- a/src/policy/fees_args.cpp
+++ b/src/policy/fees_args.cpp
@@ -14,3 +14,10 @@ fs::path FeeestPath(const ArgsManager& argsman)
 {
     return argsman.GetDataDirNet() / FEE_ESTIMATES_FILENAME;
 }
+
+fs::path FeeestLogPath(const ArgsManager& args)
+{
+    fs::path log_filename = args.GetPathArg("-estlog");
+    if (log_filename.empty()) return {};
+    return args.GetDataDirNet() / log_filename;
+}

--- a/src/policy/fees_args.h
+++ b/src/policy/fees_args.h
@@ -12,4 +12,7 @@ class ArgsManager;
 /** @return The fee estimates data file path. */
 fs::path FeeestPath(const ArgsManager& argsman);
 
+/** @return The fee estimates log file path. */
+fs::path FeeestLogPath(const ArgsManager& args);
+
 #endif // BITCOIN_POLICY_FEES_ARGS_H

--- a/src/policy/fees_input.cpp
+++ b/src/policy/fees_input.cpp
@@ -1,0 +1,236 @@
+// Copyright (c) 2018 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <policy/fees_input.h>
+
+#include <chainparams.h>
+#include <clientversion.h>
+#include <policy/fees.h>
+#include <streams.h>
+#include <util/strencodings.h>
+#include <util/system.h>
+#include <util/time.h>
+#include <univalue.h>
+
+#include <fstream>
+
+namespace {
+UniValue TxLog(const uint256& hash, unsigned int height, CAmount fee, uint32_t size)
+{
+    UniValue tx(UniValue::VOBJ);
+    tx.pushKV("hash", hash.ToString());
+    tx.pushKV("height", int(height));
+    tx.pushKV("fee", fee);
+    tx.pushKV("size", uint64_t(size));
+    return tx;
+}
+} // namespace
+
+FeeEstInput::FeeEstInput(CBlockPolicyEstimator& estimator) : m_estimator(estimator) {}
+
+bool FeeEstInput::open(const fs::path& estimation_filepath, const fs::path& log_filepath) {
+    if (!writeLog(log_filepath)) return false;
+    m_estimation_filepath = estimation_filepath;
+
+    // If the fee estimation file is present, read recorded estimations
+    if (!readData(m_estimation_filepath)) {
+        LogPrintf("Failed to read fee estimates from %s. Continue anyway.\n", fs::PathToString(m_estimation_filepath));
+    }
+
+    return true;
+}
+
+bool FeeEstInput::close()
+{
+    m_estimator.FlushUnconfirmed();
+
+    if (!writeData(m_estimation_filepath)) {
+        LogPrintf("Failed to write fee estimates to %s. Continue anyway.\n", fs::PathToString(m_estimation_filepath));
+    }
+    return writeLog({});
+}
+
+void FeeEstInput::processTx(const uint256& hash, unsigned int height, CAmount fee, uint32_t size, bool valid)
+{
+    m_estimator.processTx(hash, height, fee, size, valid);
+    if (m_log) {
+        UniValue value(UniValue::VOBJ);
+        value.pushKV("tx", TxLog(hash, height, fee, size));
+        value.pushKV("valid", UniValue(valid));
+        value.pushKV("time", GetTime());
+        *m_log << value.write() << std::endl;
+    }
+}
+
+void FeeEstInput::processBlock(unsigned int block_height, const AddTxsFn& add_txs)
+{
+    UniValue json_txs{UniValue::VARR};
+    m_estimator.processBlock(block_height, [&](const AddTxFn& add_tx) {
+        add_txs([&](const uint256& hash, unsigned int height, CAmount fee, uint32_t size) {
+            add_tx(hash, height, fee, size);
+            if (m_log) json_txs.push_back(TxLog(hash, height, fee, size));
+        });
+    });
+    if (m_log) {
+        UniValue json(UniValue::VOBJ);
+        UniValue json_block(UniValue::VOBJ);
+        json_block.pushKV("height", int64_t(block_height));
+        json.pushKV("block", json_block);
+        json.pushKV("txs", std::move(json_txs));
+        json.pushKV("time", GetTime());
+        *m_log << json.write() << std::endl;
+    }
+}
+
+void FeeEstInput::removeTx(const uint256& hash, bool in_block)
+{
+    m_estimator.removeTx(hash, in_block);
+
+    if (m_log) {
+        UniValue value(UniValue::VOBJ);
+        UniValue removeTx(UniValue::VOBJ);
+        removeTx.pushKV("hash", hash.ToString());
+        removeTx.pushKV("inBlock", UniValue(in_block));
+        value.pushKV("removeTx", removeTx);
+        value.pushKV("time", GetTime());
+        *m_log << value.write() << std::endl;
+    }
+}
+
+bool FeeEstInput::writeData(const fs::path& filepath)
+{
+    AutoFile file{fsbridge::fopen(filepath, "wb")};
+    if (file.IsNull()) return false;
+    m_estimator.Write(file);
+
+    if (m_log) {
+        UniValue value(UniValue::VOBJ);
+        UniValue flush(UniValue::VARR);
+        value.pushKV("flush", flush);
+        value.pushKV("time", GetTime());
+        *m_log << value.write() << std::endl;
+    }
+    return true;
+}
+
+bool FeeEstInput::readData(const fs::path& filepath)
+{
+    AutoFile file{fsbridge::fopen(filepath, "rb")};
+    if (file.IsNull() || !m_estimator.Read(file)) return false;
+
+    if (m_log) {
+        UniValue value(UniValue::VOBJ);
+        std::ifstream data(filepath, std::ifstream::binary);
+        value.pushKV(
+            "read", HexStr(std::string(std::istreambuf_iterator<char>(data), std::istreambuf_iterator<char>())));
+        value.pushKV("time", GetTime());
+        *m_log << value.write() << std::endl;
+    }
+    return true;
+}
+
+bool FeeEstInput::writeLog(const fs::path& filepath)
+{
+    if (m_log) {
+        UniValue value(UniValue::VOBJ);
+        value.pushKV("stop", Params().NetworkIDString());
+        value.pushKV("time", GetTime());
+        *m_log << value.write() << std::endl;
+    }
+
+    if (filepath.empty()) {
+        m_log.reset();
+    } else {
+        m_log = std::make_unique<std::ofstream>(filepath, std::ofstream::out | std::ofstream::app);
+        if (!*m_log) {
+            m_log.reset();
+            return false;
+        }
+    }
+
+    if (m_log) {
+        UniValue value(UniValue::VOBJ);
+        value.pushKV("start", Params().NetworkIDString());
+        value.pushKV("time", GetTime());
+        *m_log << value.write() << std::endl;
+    }
+
+    return true;
+}
+
+bool FeeEstInput::readLog(const fs::path& filepath, const std::function<bool(UniValue&)>& filter)
+{
+    std::ifstream file(filepath);
+    if (!file) {
+        LogPrintf("%s: Failed to open log file %s\n", __func__, fs::PathToString(filepath));
+        return false;
+    }
+
+    std::string line;
+    while (std::getline(file, line)) {
+        UniValue value;
+        if (!value.read(line)) {
+            throw std::runtime_error("Failed to parse fee estimate log line.");
+        }
+
+        if (filter && !filter(value)) {
+            continue;
+        }
+
+        const UniValue& tx = value["tx"];
+        if (tx.isObject()) {
+            m_estimator.processTx(uint256S(tx["hash"].get_str()), tx["height"].getInt<int>(), tx["fee"].getInt<int64_t>(),
+                tx["size"].getInt<uint32_t>(), value["valid"].get_bool());
+            continue;
+        }
+
+        const UniValue& block = value["block"];
+        if (block.isObject()) {
+            int height = block["height"].getInt<int>();
+            m_estimator.processBlock(height, [&](const AddTxFn& add_tx) {
+                const auto& block_txs = value["txs"].getValues();
+                for (const UniValue& block_tx : block_txs) {
+                    add_tx(uint256S(block_tx["hash"].get_str()), block_tx["height"].getInt<int>(),
+                        block_tx["fee"].getInt<int64_t>(), block_tx["size"].getInt<uint32_t>());
+                }
+                return block_txs.size();
+            });
+            continue;
+        }
+
+        const UniValue& removeTx = value["removeTx"];
+        if (removeTx.isObject()) {
+            m_estimator.removeTx(uint256S(removeTx["hash"].get_str()), removeTx["inBlock"].get_bool());
+            continue;
+        }
+
+        const UniValue& flush = value["flush"];
+        if (flush.isArray()) {
+            m_estimator.FlushUnconfirmed();
+            continue;
+        }
+
+        const UniValue& read = value["read"];
+        if (read.isStr()) {
+            std::vector<unsigned char> data = ParseHex(read.get_str());
+            uint16_t randv = 0;
+            GetRandBytes(Span{(unsigned char*)&randv, sizeof(randv)});
+            fs::path data_filepath = fs::PathFromString(strprintf("fee_estimates.tmp.%04x", randv));
+            CAutoFile(fsbridge::fopen(data_filepath, "wb"), SER_DISK, CLIENT_VERSION).write(MakeByteSpan(data));
+            {
+                CAutoFile data(fsbridge::fopen(data_filepath, "rb"), SER_DISK, CLIENT_VERSION);
+                m_estimator.Read(data);
+            }
+            fs::remove(data_filepath);
+            continue;
+        }
+    }
+
+    if (file.bad()) {
+        LogPrintf("%s: Failure reading log file %s\n", __func__, fs::PathToString(filepath));
+        return false;
+    }
+
+    return true;
+}

--- a/src/policy/fees_input.h
+++ b/src/policy/fees_input.h
@@ -1,0 +1,61 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2016 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_POLICY_FEES_INPUT_H
+#define BITCOIN_POLICY_FEES_INPUT_H
+
+#include <consensus/amount.h>
+#include <logging.h>
+#include <policy/fees.h>
+#include <util/fs.h>
+
+#include <map>
+#include <memory>
+#include <vector>
+
+class CAutoFile;
+class CBlockPolicyEstimator;
+class UniValue;
+class uint256;
+
+class FeeEstInput
+{
+public:
+    explicit FeeEstInput(CBlockPolicyEstimator& estimator);
+
+    /** Open fee estimator input after construction. Load fee estimation data file and open optional log file. */
+    bool open(const fs::path& estimation_filepath, const fs::path& log_filepath);
+
+    /** Drop still unconfirmed transactions and record current estimations, if the fee estimation file is present. */
+    bool close();
+
+    /** Process all the transactions that have been included in a block */
+    void processBlock(unsigned int height, const AddTxsFn& add_txs);
+
+    /** Process a transaction added the mempool or a block */
+    void processTx(const uint256& hash, unsigned int height, CAmount fee, uint32_t size, bool valid);
+
+    /** Remove a transaction from the mempool tracking stats */
+    void removeTx(const uint256& hash, bool in_block);
+
+    /** Write estimation data to a file */
+    bool writeData(const fs::path& filepath);
+
+    /** Read estimation data from a file */
+    bool readData(const fs::path& filepath);
+
+    /** Write incoming block and transaction events to log file. */
+    bool writeLog(const fs::path& filepath);
+
+    /** Read block and transaction events from log file. */
+    bool readLog(const fs::path& filepath, const std::function<bool(UniValue&)>& filter);
+
+private:
+    CBlockPolicyEstimator& m_estimator;
+    fs::path m_estimation_filepath;
+    std::unique_ptr<std::basic_ostream<char>> m_log;
+};
+
+#endif // BITCOIN_POLICY_FEES_INPUT_H

--- a/src/test/fee_est/README.md
+++ b/src/test/fee_est/README.md
@@ -1,0 +1,38 @@
+src/test/fee_est -- Fee estimation offline testing tool
+=======================================================
+
+The `fee_est` tool is intended to help debug and test changes in bitcoin fee
+estimation code using transaction data gathered from live bitcoin nodes.
+
+Transaction data can be collected by running bitcoind with `-estlog` parameter
+which will produce newline-delimited json file
+([ndjson.org](http://ndjson.org/), [jsonlines.org](http://jsonlines.org/))
+which logs relevant transaction information. The `fee_est` tool can parse the
+log to produce graphs of fee estimation data and do some basic analysis of the
+results. The implementation is intended to be simple enough that it can be
+easily customized to do more specific analysis.
+
+Example usage:
+
+Run bitcoind collecting fee estimation data:
+
+```
+$ make -C src bitcoind test/fee_est/fee_est
+$ src/bitcoind -estlog=est.log &
+```
+
+Run fee estimation tool producing graph of estimates:
+
+```
+$ src/test/fee_est/fee_est -ograph=graph.html est.log
+$ chrome graph.html
+```
+
+Run fee estimation tool computing some basic statistics:
+
+```
+$ src/test/fee_est/fee_est -cross est.log
+Non-test txs: 1407226
+Test txs: 5603 total (4345 kept, 631 discarded unconfirmed, 627 discarded outliers)
+Mean squared error: 71.0651
+```

--- a/src/test/fee_est/fee_est.cpp
+++ b/src/test/fee_est/fee_est.cpp
@@ -1,0 +1,331 @@
+// Copyright (c) 2018 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <common/args.h>
+#include <policy/fees.h>
+#include <policy/fees_input.h>
+#include <util/translation.h>
+
+#include <univalue.h>
+
+#include <fstream>
+#include <random>
+#include <stdio.h>
+
+const std::function<std::string(const char*)> G_TRANSLATION_FUN = nullptr;
+
+std::string Usage()
+{
+    std::string usage = "Usage: fee_est [options] <estlog.txt>\n";
+    usage += HelpMessageGroup("Options:");
+    usage += HelpMessageOpt("-?, -help", "This help message");
+    usage += HelpMessageOpt("-ograph=<graph.html>", "Generate target vs feerate graph output after replaying transaction log.");
+    usage += HelpMessageOpt("-odat=<fee_estimates.dat>", "Save fee estimator state after after replaying transaction log.");
+    usage += HelpMessageOpt("-idat=<fee_estimates.dat>", "Load fee estimator state after before replaying transaction log.");
+    usage += HelpMessageOpt("-dat=<fee_estimates.dat>", "Shortcut for -idat=<fee_estimates.dat> -odat=<fee_estimates.dat>");
+    usage += HelpMessageOpt("-cross", "Treat half the transactions from the log as test data and print cross-validation statistics.");
+    return usage;
+}
+
+struct Options {
+    std::string logFileIn;
+    std::string dataFileIn;
+    std::string dataFileOut;
+    std::string graphFileOut;
+    bool cross = false;
+    bool help = false;
+    bool error = false;
+};
+
+Options ParseCommandLine(int argc, char** argv)
+{
+    auto match = [&](const char* arg, const char* name, const char** value = nullptr) {
+        if (arg[0] != '-') return false;
+        size_t n = strlen(name);
+        if (strncmp(arg + 1, name, n) != 0) return false;
+        if (value) return (*value = arg[n + 1] == '=' ? arg + n + 2 : nullptr) != nullptr;
+        return arg[n + 1] == '\0';
+    };
+
+    Options options;
+    for (int i = 1; i < argc; ++i) {
+        const char* arg = argv[i];
+        const char* value;
+        if (match(arg, "ograph", &value)) {
+            options.graphFileOut = value;
+        } else if (match(arg, "odat", &value)) {
+            options.dataFileOut = value;
+        } else if (match(arg, "idat", &value)) {
+            options.dataFileIn = value;
+        } else if (match(arg, "dat", &value)) {
+            options.dataFileIn = options.dataFileOut = value;
+        } else if (match(arg, "cross")) {
+            options.cross = true;
+        } else if (match(arg, "help") || match(arg, "h") || match(arg, "?")) {
+            options.help = true;
+        } else if (arg[0] != '-' && options.logFileIn.empty()) {
+            options.logFileIn = arg;
+        } else {
+            fprintf(stderr, "Error: unexpected argument: '%s'\n", arg);
+            options.error = true;
+        }
+    }
+
+    if (options.logFileIn.empty() && !options.help) {
+        fprintf(stderr, "Error: missing required log file argument.\n");
+        options.error = true;
+    }
+
+    return options;
+}
+
+struct TxData {
+    TxData(CAmount fee, size_t size, int height) : fee(fee), size(size), height(height) {}
+    CAmount fee;
+    size_t size;
+    int height;
+    int expectedBlocks = -1;
+    int actualBlocks = -1;
+};
+
+using TxMap = std::map<uint256, TxData>;
+
+const char* const GRAPH_HTML = R"(<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Fee Graph</title>
+<script src="https://d3js.org/d3.v3.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/vega/3.0.0-beta.30/vega.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/vega-lite/2.0.0-beta.2/vega-lite.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/vega-embed/3.0.0-beta.14/vega-embed.js"></script>
+<style media="screen">
+.vega-actions a {
+    margin-right: 5px;
+}
+</style>
+<div id=vis></div>
+<script>
+var spec = {
+  "$schema": "https://vega.github.io/schema/vega-lite/v2.json",
+  "width": 800,
+  "height": 600,
+  "layer": [
+    {
+        "data": {
+            "values": %s
+        },
+        "mark": "tick",
+        "encoding": {
+            "x": {"field": "blocks", "type": "quantitative"},
+            "y": {"field": "feeRate", "type": "quantitative"},
+            "color": {"field": "height", "type": "quantitative"}
+        }
+    },
+    {
+      "data": {
+        "values": %s
+      },
+      "encoding": {
+        "x": {"field": "blocks", "type": "quantitative"},
+        "y": {"field": "feeRate", "type": "quantitative"},
+        "color": {"field": "mode", "type": "nominal"}
+      },
+      "mark": "line",
+    }
+  ]
+}
+vega.embed("#vis", spec);
+</script>
+)";
+
+// Maximum number of randomly sampled transactions to show on graph.
+const size_t SAMPLE_TXS = 50000;
+
+// Drop 1/20th of sampled transactions with highest feerates if they are
+// outliers that would change the scale of the graph.
+const int DROP_FRAC = 20;
+
+void WriteGraph(const std::string& filename,
+    const TxMap& txMap,
+    const std::vector<unsigned int>& targets,
+    CBlockPolicyEstimator& estimator)
+{
+    UniValue fees(UniValue::VARR);
+
+    int64_t maxFeeRate = 0;
+    const unsigned int maxTarget = estimator.getMaxTarget();
+    for (bool conservative : {false, true}) {
+        for (unsigned int target : targets) {
+            if (target > maxTarget) continue;
+            UniValue fee(UniValue::VOBJ);
+            fee.pushKV("mode", conservative ? "conservative" : "default");
+            fee.pushKV("blocks", int(target));
+            CAmount feeRate = estimator.estimateSmartFee(target, nullptr /* fee_calc */, conservative).GetFeePerK();
+            fee.pushKV("feeRate", feeRate);
+            fees.push_back(fee);
+            maxFeeRate = std::max(maxFeeRate, feeRate);
+        }
+    }
+
+    std::vector<const TxMap::value_type*> sample;
+    sample.reserve(SAMPLE_TXS);
+    int i = 0;
+    std::minstd_rand randint;
+    for (const auto& entry : txMap) {
+        if (entry.second.actualBlocks > int(maxTarget)) {
+            continue;
+        } else if (sample.size() < SAMPLE_TXS) {
+            sample.emplace_back(&entry);
+        } else {
+            size_t j = randint() % i;
+            if (j < SAMPLE_TXS) {
+                sample[j] = &entry;
+            }
+        }
+        ++i;
+    }
+
+    if (!sample.empty()) {
+        std::vector<CAmount> feeRates;
+        feeRates.reserve(sample.size());
+        for (const auto& entry : sample) {
+            feeRates.emplace_back(CFeeRate(entry->second.fee, entry->second.size).GetFeePerK());
+        }
+        auto nth = feeRates.begin() + sample.size() / DROP_FRAC;
+        std::nth_element(feeRates.begin(), nth, feeRates.end(), std::greater<int64_t>());
+        maxFeeRate = std::max(maxFeeRate, *nth);
+    }
+
+    UniValue txs(UniValue::VARR);
+    for (const auto& entry : sample) {
+        if (entry->second.actualBlocks > 0) {
+            CAmount feeRate = CFeeRate(entry->second.fee, entry->second.size).GetFeePerK();
+            if (feeRate <= maxFeeRate) {
+                UniValue tx(UniValue::VOBJ);
+                tx.pushKV("feeRate", feeRate);
+                tx.pushKV("blocks", entry->second.actualBlocks);
+                tx.pushKV("height", entry->second.height);
+                txs.push_back(std::move(tx));
+            }
+        }
+    }
+
+    std::ofstream file(filename);
+    file << strprintf(GRAPH_HTML, txs.write(), fees.write());
+}
+
+bool UpdateCross(TxMap::value_type& tx, const std::vector<unsigned int>& targets, CBlockPolicyEstimator& estimator)
+{
+    if (*tx.first.begin() == 0) {
+        auto it = std::lower_bound(targets.begin(), targets.end(), nullptr, [&](unsigned int target, std::nullptr_t) {
+            CAmount estFee = estimator.estimateSmartFee(target, nullptr /* fee_calc */, false /* conservative */)
+                                 .GetFee(tx.second.size);
+            return estFee <= 1 || tx.second.fee < estFee;
+        });
+        tx.second.expectedBlocks = it == targets.end() ? std::numeric_limits<int>::max() : int(*it);
+        return false;
+    }
+    return true;
+}
+
+void PrintCross(const TxMap& txMap, CBlockPolicyEstimator&)
+{
+    int nonTestTxs = 0;
+    int unconfirmedTestTxs = 0;
+    int outlierTestTxs = 0;
+    int keptTestTxs = 0;
+    int64_t errsq = 0;
+    for (const auto& entry : txMap) {
+        if (entry.second.expectedBlocks == -1) {
+            ++nonTestTxs;
+        } else if (entry.second.actualBlocks == -1) {
+            ++unconfirmedTestTxs;
+        } else if (entry.second.expectedBlocks == std::numeric_limits<int>::max()) {
+            ++outlierTestTxs;
+        } else {
+            ++keptTestTxs;
+            int err = entry.second.expectedBlocks - entry.second.actualBlocks;
+            errsq += err * err;
+        }
+    }
+    printf("Non-test txs: %i\n", nonTestTxs);
+    printf("Test txs: %i total (%i kept, %i discarded unconfirmed, %i discarded outliers)\n",
+        keptTestTxs + unconfirmedTestTxs + outlierTestTxs, keptTestTxs, unconfirmedTestTxs, outlierTestTxs);
+    if (keptTestTxs > 0) {
+        printf("Mean squared error: %g\n", double(errsq) / double(keptTestTxs));
+    }
+}
+
+int main(int argc, char** argv)
+{
+    Options options = ParseCommandLine(argc, argv);
+
+    if (options.help) {
+        printf("%s", Usage().c_str());
+        return EXIT_SUCCESS;
+    } else if (options.error) {
+        fprintf(stderr, "Try `fee_est -h` for more information.\n");
+        return EXIT_FAILURE;
+    } else if (options.dataFileOut.empty() && options.graphFileOut.empty() && !options.cross) {
+        fprintf(stderr, "Warning: No output options specified. Try -ograph, -odat, -cross options, or `fee_est -h` "
+                        "for more information.\n");
+    }
+
+    CBlockPolicyEstimator estimator;
+    FeeEstInput input(estimator);
+
+    if (!options.dataFileIn.empty() && !input.readData(fs::PathFromString(options.dataFileIn))) {
+        fprintf(stderr, "Error: failed to load fee estimate data file '%s'\n", options.dataFileOut.c_str());
+        return 1;
+    }
+
+    const std::vector<unsigned int> targets = estimator.GetUniqueTargets();
+    TxMap txMap;
+
+    auto filter = [&](UniValue& value) {
+        bool keep = true;
+        const UniValue& tx = value["tx"];
+        if (tx.isObject()) {
+            auto inserted = txMap.emplace(uint256S(tx["hash"].get_str()),
+                TxData(tx["fee"].getInt<int64_t>(), tx["size"].getInt<uint32_t>(), tx["height"].getInt<int>()));
+            if (options.cross && !UpdateCross(*inserted.first, targets, estimator)) {
+                keep = false;
+            }
+        }
+
+        const UniValue& block = value["block"];
+        if (block.isObject()) {
+            int blockHeight = block["height"].getInt<int>();
+            const auto& block_txs = value["txs"].getValues();
+            for (const UniValue& block_tx : block_txs) {
+                auto it = txMap.find(uint256S(block_tx["hash"].get_str()));
+                if (it != txMap.end()) {
+                    it->second.actualBlocks = blockHeight - block_tx["height"].getInt<int>();
+                }
+            }
+        }
+
+        return keep;
+    };
+
+    if (!input.readLog(fs::PathFromString(options.logFileIn), std::ref(filter))) {
+        fprintf(stderr, "Error: failed to load fee data log file '%s'\n", options.logFileIn.c_str());
+        return EXIT_FAILURE;
+    }
+
+    if (!options.dataFileOut.empty() && !input.writeData(fs::PathFromString(options.dataFileOut))) {
+        fprintf(stderr, "Error: failed to write fee estimate data file '%s'\n", options.dataFileOut.c_str());
+        return EXIT_FAILURE;
+    }
+
+    if (!options.graphFileOut.empty()) {
+        WriteGraph(options.graphFileOut, txMap, targets, estimator);
+        return EXIT_FAILURE;
+    }
+
+    if (options.cross) {
+        PrintCross(txMap, estimator);
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/src/test/fuzz/policy_estimator_io.cpp
+++ b/src/test/fuzz/policy_estimator_io.cpp
@@ -4,6 +4,7 @@
 
 #include <policy/fees.h>
 #include <policy/fees_args.h>
+#include <policy/fees_input.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
@@ -18,7 +19,11 @@ const BasicTestingSetup* g_setup;
 
 void initialize_policy_estimator_io()
 {
-    static const auto testing_setup = MakeNoLogFileContext<>();
+    static auto testing_setup = MakeNoLogFileContext<BasicTestingSetup>();
+    // Re-using block_policy_estimator across runs to avoid costly creation of CBlockPolicyEstimator object.
+    testing_setup->m_node.fee_estimator = std::make_unique<CBlockPolicyEstimator>();
+    testing_setup->m_node.fee_estimator_input = std::make_unique<FeeEstInput>(*testing_setup->m_node.fee_estimator);
+    testing_setup->m_node.fee_estimator_input->open(FeeestPath(*testing_setup->m_node.args), FeeestLogPath(*testing_setup->m_node.args));
     g_setup = testing_setup.get();
 }
 
@@ -27,9 +32,7 @@ FUZZ_TARGET_INIT(policy_estimator_io, initialize_policy_estimator_io)
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
     FuzzedAutoFileProvider fuzzed_auto_file_provider = ConsumeAutoFile(fuzzed_data_provider);
     AutoFile fuzzed_auto_file{fuzzed_auto_file_provider.open()};
-    // Re-using block_policy_estimator across runs to avoid costly creation of CBlockPolicyEstimator object.
-    static CBlockPolicyEstimator block_policy_estimator{FeeestPath(*g_setup->m_node.args)};
-    if (block_policy_estimator.Read(fuzzed_auto_file)) {
-        block_policy_estimator.Write(fuzzed_auto_file);
+    if (g_setup->m_node.fee_estimator->Read(fuzzed_auto_file)) {
+        g_setup->m_node.fee_estimator->Write(fuzzed_auto_file);
     }
 }

--- a/src/test/policyestimator_tests.cpp
+++ b/src/test/policyestimator_tests.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <policy/fees.h>
+#include <policy/fees_input.h>
 #include <policy/policy.h>
 #include <test/util/txmempool.h>
 #include <txmempool.h>

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -29,6 +29,7 @@
 #include <noui.h>
 #include <policy/fees.h>
 #include <policy/fees_args.h>
+#include <policy/fees_input.h>
 #include <pow.h>
 #include <rpc/blockchain.h>
 #include <rpc/register.h>
@@ -174,7 +175,9 @@ ChainTestingSetup::ChainTestingSetup(const std::string& chainName, const std::ve
     m_node.scheduler->m_service_thread = std::thread(util::TraceThread, "scheduler", [&] { m_node.scheduler->serviceQueue(); });
     GetMainSignals().RegisterBackgroundSignalScheduler(*m_node.scheduler);
 
-    m_node.fee_estimator = std::make_unique<CBlockPolicyEstimator>(FeeestPath(*m_node.args));
+    m_node.fee_estimator = std::make_unique<CBlockPolicyEstimator>();
+    m_node.fee_estimator_input = std::make_unique<FeeEstInput>(*m_node.fee_estimator);
+    m_node.fee_estimator_input->open(FeeestPath(*m_node.args), FeeestLogPath(*m_node.args));
     m_node.mempool = std::make_unique<CTxMemPool>(MemPoolOptionsForTest(m_node));
 
     m_cache_sizes = CalculateCacheSizes(m_args);

--- a/src/test/util/txmempool.cpp
+++ b/src/test/util/txmempool.cpp
@@ -17,7 +17,7 @@ using node::NodeContext;
 CTxMemPool::Options MemPoolOptionsForTest(const NodeContext& node)
 {
     CTxMemPool::Options mempool_opts{
-        .estimator = node.fee_estimator.get(),
+        .estimator = node.fee_estimator_input.get(),
         // Default to always checking mempool regardless of
         // chainparams.DefaultConsistencyChecks for tests
         .check_ratio = 1,

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -202,7 +202,7 @@ struct entry_time {};
 struct ancestor_score {};
 struct index_by_wtxid {};
 
-class CBlockPolicyEstimator;
+class FeeEstInput;
 
 /**
  * Information about a mempool transaction.
@@ -317,7 +317,7 @@ class CTxMemPool
 protected:
     const int m_check_ratio; //!< Value n means that 1 times in n we check.
     std::atomic<unsigned int> nTransactionsUpdated{0}; //!< Used by getblocktemplate to trigger CreateNewBlock() invocation
-    CBlockPolicyEstimator* const minerPolicyEstimator;
+    FeeEstInput* const minerPolicyEstimator;
 
     uint64_t totalTxSize GUARDED_BY(cs){0};      //!< sum of all mempool tx's virtual sizes. Differs from serialized tx size since witness data is discounted. Defined in BIP 141.
     CAmount m_total_fee GUARDED_BY(cs){0};       //!< sum of all mempool tx's fees (NOT modified fee)

--- a/src/validation.h
+++ b/src/validation.h
@@ -49,6 +49,7 @@ class Chainstate;
 class CBlockTreeDB;
 class CTxMemPool;
 class ChainstateManager;
+class FeeEstInput;
 struct ChainTxData;
 struct DisconnectedBlockTransactions;
 struct PrecomputedTransactionData;

--- a/test/lint/lint-locale-dependence.py
+++ b/test/lint/lint-locale-dependence.py
@@ -43,6 +43,7 @@ from subprocess import check_output, CalledProcessError
 
 KNOWN_VIOLATIONS = [
     "src/dbwrapper.cpp:.*vsnprintf",
+    "src/test/fee_est/fee_est.cpp:.*printf",
     "src/test/fuzz/locale.cpp:.*setlocale",
     "src/test/util_tests.cpp:.*strtoll",
     "src/wallet/bdb.cpp:.*DbEnv::strerror",  # False positive


### PR DESCRIPTION
This PR adds an `-estlog` option for saving live fee estimation data from a bitcoin node, and a `fee_est` command line tool for processing the data and testing fee estimation code.

The idea is to make it easier to test improvements to fee estimation like https://github.com/bitcoin/bitcoin/pull/10199 in a more systematic and reproducible way.

Some documentation is in [`src/test/fee_est/README.md`](https://github.com/ryanofsky/bitcoin/blob/pr/fee/src/test/fee_est/README.md)

Sample log file: [`est.log.xz`](https://storage.googleapis.com/ryanofsky/est.log.xz) (65M)

Sample [`fee_est.cpp`](https://github.com/ryanofsky/bitcoin/blob/pr/fee/src/test/fee_est/fee_est.cpp)  graph output: 

![graph](https://cloud.githubusercontent.com/assets/7133040/26331057/f2de8d0c-3f1c-11e7-99ea-de1801d13b05.png)

