### PR TITLE
Make bitcoind invalid argument error message specific

### DIFF
--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -117,17 +117,14 @@ bool AppInit(int argc, char* argv[])
             return false;
         }
 
-        // Command-line RPC
-        bool fCommandLine = false;
-        for (int i = 1; i < argc; i++)
-            if (!IsSwitchChar(argv[i][0]) && !boost::algorithm::istarts_with(argv[i], "bitcoin:"))
-                fCommandLine = true;
-
-        if (fCommandLine)
-        {
-            fprintf(stderr, "Error: There is no RPC client functionality in bitcoind anymore. Use the bitcoin-cli utility instead.\n");
-            exit(EXIT_FAILURE);
+        // Error out when loose non-argument tokens are encountered on command line
+        for (int i = 1; i < argc; i++) {
+            if (!IsSwitchChar(argv[i][0])) {
+                fprintf(stderr, "Error: Command line contains unexpected token '%s', see bitcoind -h for a list of options.\n", argv[i]);
+                exit(EXIT_FAILURE);
+            }
         }
+
         // -server defaults to true for bitcoind but not for the GUI so do this here
         SoftSetBoolArg("-server", true);
         // Set this early so that parameter interactions go to console


### PR DESCRIPTION
The current message is not helpful. Hardly anyone even remembers that bitcoind used to be a cli utility, let alone new users. Print what the actual problem is.

Inspired by discussion here: https://github.com/bitcoin/bitcoin/issues/10402#issuecomment-303639064

Also remove the check for `bitcoin:` URIs. The expected output when accidentally passing a `bitcoin:` URI to `bitcoind` instead of `bitcoin-qt` would be an error not silent acceptance.