### PR TITLE
contrib/init/bitcoind.openrcconf: Don't disable wallet by default

### DIFF
--- a/contrib/init/bitcoind.openrcconf
+++ b/contrib/init/bitcoind.openrcconf
@@ -23,5 +23,5 @@
 #BITCOIND_NICE=0
 
 # Additional options (avoid -conf and -datadir, use flags above)
-BITCOIND_OPTS="-disablewallet"
+#BITCOIND_OPTS=""
 


### PR DESCRIPTION
It's harmless if it goes unused, and confused when a wallet is desired