### PR TITLE
libevent2 -> libevent on FreeBSD install docs

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -321,7 +321,7 @@ Clang is installed by default as `cc` compiler, this makes it easier to get
 started than on [OpenBSD](build-openbsd.md). Installing dependencies:
 
     pkg install autoconf automake libtool pkgconf
-    pkg install boost-libs openssl libevent2
+    pkg install boost-libs openssl libevent
 
 (`libressl` instead of `openssl` will also work)
 


### PR DESCRIPTION
Convo in irc://irc.freenode.net/#freebsd
13:46 < dbolser> hello
13:46 < dbolser> I'm following instructions here:
https://github.com/bitcoin/bitcoin/blob/0.14/doc/build-unix.md#building-on-freebsd
13:48 < dbolser> but at step 2 I get: pkg: No packages available to install matching 'libevent2'
13:49 < dbolser> are the instructions wrong, or am I missing a repo?
13:49 < kaktus> it's called libevent now
13:49 < kaktus> without the 2
13:49 < dbolser> ta
13:51 < dbolser> The notes say Updated as of FreeBSD 11.0, but I'm 10.3
13:51 < dbolser> could that be it, or is the repo common to both
13:52 < TommyC> Well the change of libevent2 -> libevent was in ports and so affects all currently supported FBSD versions.