### PR TITLE
Denote functions CNode::GetRecvVersion() and CNode::GetRefCount()  as const

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -711,7 +711,7 @@ public:
         return nMyStartingHeight;
     }
 
-    int GetRefCount()
+    int GetRefCount() const
     {
         assert(nRefCount >= 0);
         return nRefCount;
@@ -723,7 +723,7 @@ public:
     {
         nRecvVersion = nVersionIn;
     }
-    int GetRecvVersion()
+    int GetRecvVersion() const
     {
         return nRecvVersion;
     }


### PR DESCRIPTION
 CNode::GetRecvVersion() is now denoted as const
 CNode::GetRefCount() is also now denoted as const, after a PR comment