### PR TITLE
[trivial] Fix comment for ForceSetArg()

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -241,7 +241,8 @@ bool SoftSetArg(const std::string& strArg, const std::string& strValue);
  */
 bool SoftSetBoolArg(const std::string& strArg, bool fValue);
 
-// Forces a arg setting, used only in testing
+// Forces an arg setting. Called by SoftSetArg() if the arg hasn't already
+// been set. Also called directly in testing.
 void ForceSetArg(const std::string& strArg, const std::string& strValue);
 };
 


### PR DESCRIPTION
Fixes the comment for `ForceSetArg()`, which has been called indirectly by `SoftSetArg()` since #9494 