### PR TITLE
devtools: Retry after signing fails in github-merge

### DIFF
--- a/contrib/devtools/github-merge.py
+++ b/contrib/devtools/github-merge.py
@@ -301,8 +301,7 @@ def main():
                     subprocess.check_call([GIT,'commit','-q','--gpg-sign','--amend','--no-edit'])
                     break
                 except subprocess.CalledProcessError as e:
-                    print("Error signing, exiting.",file=stderr)
-                    exit(1)
+                    print("Error while signing, asking again.",file=stderr)
             elif reply == 'x':
                 print("Not signing off on merge, exiting.",file=stderr)
                 exit(1)


### PR DESCRIPTION
When signing fails, go back to the sign/exit prompt instead of exiting the script.

Nowadays I use a signing token for my GPG key, which can sometimes fail (especially when it's accidentally not plugged in :') ). This avoids having to re-do the merge in that case.