### PR TITLE
build: silence gcc7's implicit fallthrough warning

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -235,6 +235,7 @@ if test "x$CXXFLAGS_overridden" = "xno"; then
   AX_CHECK_COMPILE_FLAG([-Wself-assign],[CXXFLAGS="$CXXFLAGS -Wno-self-assign"],,[[$CXXFLAG_WERROR]])
   AX_CHECK_COMPILE_FLAG([-Wunused-local-typedef],[CXXFLAGS="$CXXFLAGS -Wno-unused-local-typedef"],,[[$CXXFLAG_WERROR]])
   AX_CHECK_COMPILE_FLAG([-Wdeprecated-register],[CXXFLAGS="$CXXFLAGS -Wno-deprecated-register"],,[[$CXXFLAG_WERROR]])
+  AX_CHECK_COMPILE_FLAG([-Wimplicit-fallthrough],[CXXFLAGS="$CXXFLAGS -Wno-implicit-fallthrough"],,[[$CXXFLAG_WERROR]])
 fi
 CPPFLAGS="$CPPFLAGS -DHAVE_BUILD_INFO -D__STDC_FORMAT_MACROS"
 


### PR DESCRIPTION
This is a well-intentioned but realistically annoying warning. Unfortunately, it's too easy for a warning in one header to cause dozens of repeated warnings.

See [here](https://developers.redhat.com/blog/2017/03/10/wimplicit-fallthrough-in-gcc-7) for details.

If it were just our code, I'd add in the (non-standard) annotations. But it's also an issue in leveldb and tinyformat, and would require substantial autoconf hackery to avoid.

Fwiw, None of the existing warnings turned up are real bugs.