### PR TITLE
remove some unused functions

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2691,7 +2691,6 @@ int CConnman::GetBestHeight() const
 }
 
 unsigned int CConnman::GetReceiveFloodSize() const { return nReceiveFloodSize; }
-unsigned int CConnman::GetSendBufferSize() const{ return nSendBufferMaxSize; }
 
 CNode::CNode(NodeId idIn, ServiceFlags nLocalServicesIn, int nMyStartingHeightIn, SOCKET hSocketIn, const CAddress& addrIn, uint64_t nKeyedNetGroupIn, uint64_t nLocalHostNonceIn, const CAddress &addrBindIn, const std::string& addrNameIn, bool fInboundIn) :
     nTimeConnected(GetSystemTimeInSeconds()),

--- a/src/net.h
+++ b/src/net.h
@@ -242,8 +242,6 @@ public:
     bool DisconnectNode(const std::string& node);
     bool DisconnectNode(NodeId id);
 
-    unsigned int GetSendBufferSize() const;
-
     ServiceFlags GetLocalServices() const;
 
     //!set the max outbound target in bytes

--- a/src/netaddress.cpp
+++ b/src/netaddress.cpp
@@ -598,11 +598,6 @@ std::string CService::ToString() const
     return ToStringIPPort();
 }
 
-void CService::SetPort(unsigned short portIn)
-{
-    port = portIn;
-}
-
 CSubNet::CSubNet():
     valid(false)
 {

--- a/src/netaddress.h
+++ b/src/netaddress.h
@@ -148,7 +148,6 @@ class CService : public CNetAddr
         CService(const struct in_addr& ipv4Addr, unsigned short port);
         CService(const struct sockaddr_in& addr);
         void Init();
-        void SetPort(unsigned short portIn);
         unsigned short GetPort() const;
         bool GetSockAddr(struct sockaddr* paddr, socklen_t *addrlen) const;
         bool SetSockAddr(const struct sockaddr* paddr);

--- a/src/warnings.cpp
+++ b/src/warnings.cpp
@@ -37,12 +37,6 @@ void SetfLargeWorkInvalidChainFound(bool flag)
     fLargeWorkInvalidChainFound = flag;
 }
 
-bool GetfLargeWorkInvalidChainFound()
-{
-    LOCK(cs_warnings);
-    return fLargeWorkInvalidChainFound;
-}
-
 std::string GetWarnings(const std::string& strFor)
 {
     std::string strStatusBar;

--- a/src/warnings.h
+++ b/src/warnings.h
@@ -13,7 +13,6 @@ void SetMiscWarning(const std::string& strWarning);
 void SetfLargeWorkForkFound(bool flag);
 bool GetfLargeWorkForkFound();
 void SetfLargeWorkInvalidChainFound(bool flag);
-bool GetfLargeWorkInvalidChainFound();
 /** Format a string that describes several potential problems detected by the core.
  * strFor can have three values:
  * - "rpc": get critical warnings, which should put the client in safe mode if non-empty


### PR DESCRIPTION
Identified with `cppcheck --enable=unusedFunction .`.

 - GetSendBufferSize()'s last use removed in
   991955e
 - SetPort()'s last use removed in
   7e195e8
 - GetfLargeWorkInvalidChainFound() was introduced in
   e3ba0ef and never used