### PR TITLE
Rework same-chain from abusing DoS banning, to explicit checks

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -357,6 +357,11 @@ public:
     //! Efficiently find an ancestor of this block.
     CBlockIndex* GetAncestor(int height);
     const CBlockIndex* GetAncestor(int height) const;
+
+    /** (Somewhat) efficiently check whether a block is present in this chain. */
+    const bool Contains(const CBlockIndex * const needle) const {
+        return (GetAncestor(needle->nHeight) == needle);
+    }
 };
 
 arith_uint256 GetBlockProof(const CBlockIndex& block);

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -686,6 +686,16 @@ void CNode::copyStats(CNodeStats &stats)
 }
 #undef X
 
+void CNode::TipDoesntMatch(const std::string& msg)
+{
+    if (RequireMatchingTip()) {
+        LogPrint(BCLog::NET, "%s; disconnecting\n", msg);
+        fDisconnect = true;
+    } else {
+        LogPrint(BCLog::NET, "%s (tolerating)\n", msg);
+    }
+}
+
 bool CNode::ReceiveMsgBytes(const char *pch, unsigned int nBytes, bool& complete)
 {
     complete = false;

--- a/src/net.h
+++ b/src/net.h
@@ -806,7 +806,7 @@ public:
 
     bool RequireMatchingTip() const
     {
-        return !(fInbound || fFeeler);
+        return !(fInbound || fFeeler || fWhitelisted || fAddnode);
     }
 
     void TipDoesntMatch(const std::string& msg);

--- a/src/net.h
+++ b/src/net.h
@@ -809,12 +809,7 @@ public:
         return !(fInbound || fFeeler);
     }
 
-    void TipDoesntMatch()
-    {
-        if (RequireMatchingTip()) {
-            fDisconnect = true;
-        }
-    }
+    void TipDoesntMatch(const std::string& msg);
 
     std::string GetAddrName() const;
     //! Sets the addrName only if it was not previously set

--- a/src/net.h
+++ b/src/net.h
@@ -804,6 +804,18 @@ public:
         return nLocalServices;
     }
 
+    bool RequireMatchingTip() const
+    {
+        return !(fInbound || fFeeler);
+    }
+
+    void TipDoesntMatch()
+    {
+        if (RequireMatchingTip()) {
+            fDisconnect = true;
+        }
+    }
+
     std::string GetAddrName() const;
     //! Sets the addrName only if it was not previously set
     void MaybeSetAddrName(const std::string& addrNameIn);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2930,7 +2930,7 @@ static bool AcceptBlockHeader(const CBlockHeader& block, CValidationState& state
             return state.DoS(10, error("%s: prev block not found", __func__), 0, "prev-blk-not-found");
         pindexPrev = (*mi).second;
         if (pindexPrev->nStatus & BLOCK_FAILED_MASK)
-            return state.DoS(100, error("%s: prev block invalid", __func__), REJECT_INVALID, "bad-prevblk");
+            return state.DoS(0, error("%s: prev block invalid", __func__), REJECT_INVALID, "bad-prevblk");
 
         assert(pindexPrev);
         if (fCheckpointsEnabled && !CheckIndexAgainstCheckpoint(pindexPrev, state, chainparams, hash))

--- a/src/validation.h
+++ b/src/validation.h
@@ -144,9 +144,6 @@ static const bool DEFAULT_FEEFILTER = true;
 /** Maximum number of headers to announce when relaying blocks with headers message.*/
 static const unsigned int MAX_BLOCKS_TO_ANNOUNCE = 8;
 
-/** Maximum number of unconnecting headers announcements before DoS score */
-static const int MAX_UNCONNECTING_HEADERS = 10;
-
 static const bool DEFAULT_PEERBLOOMFILTERS = true;
 
 /** Default for -stopatheight */


### PR DESCRIPTION
This fixes bugs where we end up banning peers running different consensus rules (including old nodes following a softfork). Since we rely on having peers enforcing the same rules as us, it also enforces that outbound non-feeler connections must have and maintain the same tip block; if they diverge from us, we disconnect them (and find a replacement).