### PR TITLE
Limit variable scope

### DIFF
--- a/src/crypto/aes.cpp
+++ b/src/crypto/aes.cpp
@@ -112,7 +112,6 @@ static int CBCEncrypt(const T& enc, const unsigned char iv[AES_BLOCKSIZE], const
 template <typename T>
 static int CBCDecrypt(const T& dec, const unsigned char iv[AES_BLOCKSIZE], const unsigned char* data, int size, bool pad, unsigned char* out)
 {
-    unsigned char padsize = 0;
     int written = 0;
     bool fail = false;
     const unsigned char* prev = iv;
@@ -136,7 +135,7 @@ static int CBCDecrypt(const T& dec, const unsigned char iv[AES_BLOCKSIZE], const
     if (pad) {
         // If used, padding size is the value of the last decrypted byte. For
         // it to be valid, It must be between 1 and AES_BLOCKSIZE.
-        padsize = *--out;
+        unsigned char padsize = *--out;
         fail = !padsize | (padsize > AES_BLOCKSIZE);
 
         // If not well-formed, treat it as though there's no padding.

--- a/src/policy/fees.cpp
+++ b/src/policy/fees.cpp
@@ -855,13 +855,13 @@ bool CBlockPolicyEstimator::Read(CAutoFile& filein)
     try {
         LOCK(cs_feeEstimator);
         int nVersionRequired, nVersionThatWrote;
-        unsigned int nFileBestSeenHeight, nFileHistoricalFirst, nFileHistoricalBest;
         filein >> nVersionRequired >> nVersionThatWrote;
         if (nVersionRequired > CLIENT_VERSION)
             return error("CBlockPolicyEstimator::Read(): up-version (%d) fee estimate file", nVersionRequired);
 
         // Read fee estimates file into temporary variables so existing data
         // structures aren't corrupted if there is an exception.
+        unsigned int nFileBestSeenHeight;
         filein >> nFileBestSeenHeight;
 
         if (nVersionThatWrote < 149900) {
@@ -890,6 +890,7 @@ bool CBlockPolicyEstimator::Read(CAutoFile& filein)
             }
         }
         else { // nVersionThatWrote >= 149900
+            unsigned int nFileHistoricalFirst, nFileHistoricalBest;
             filein >> nFileHistoricalFirst >> nFileHistoricalBest;
             if (nFileHistoricalFirst > nFileHistoricalBest || nFileHistoricalBest > nFileBestSeenHeight) {
                 throw std::runtime_error("Corrupt estimates file. Historical block range for estimates is invalid");

--- a/src/qt/coincontroltreewidget.cpp
+++ b/src/qt/coincontroltreewidget.cpp
@@ -16,9 +16,10 @@ void CoinControlTreeWidget::keyPressEvent(QKeyEvent *event)
     if (event->key() == Qt::Key_Space) // press spacebar -> select checkbox
     {
         event->ignore();
-        int COLUMN_CHECKBOX = 0;
-        if(this->currentItem())
+        if (this->currentItem()) {
+            int COLUMN_CHECKBOX = 0;
             this->currentItem()->setCheckState(COLUMN_CHECKBOX, ((this->currentItem()->checkState(COLUMN_CHECKBOX) == Qt::Checked) ? Qt::Unchecked : Qt::Checked));
+        }
     }
     else if (event->key() == Qt::Key_Escape) // press esc -> close dialog
     {

--- a/src/qt/recentrequeststablemodel.cpp
+++ b/src/qt/recentrequeststablemodel.cpp
@@ -55,10 +55,9 @@ QVariant RecentRequestsTableModel::data(const QModelIndex &index, int role) cons
     if(!index.isValid() || index.row() >= list.length())
         return QVariant();
 
-    const RecentRequestEntry *rec = &list[index.row()];
-
     if(role == Qt::DisplayRole || role == Qt::EditRole)
     {
+        const RecentRequestEntry *rec = &list[index.row()];
         switch(index.column())
         {
         case Date:

--- a/src/qt/trafficgraphwidget.cpp
+++ b/src/qt/trafficgraphwidget.cpp
@@ -47,13 +47,14 @@ int TrafficGraphWidget::getGraphRangeMins() const
 
 void TrafficGraphWidget::paintPath(QPainterPath &path, QQueue<float> &samples)
 {
-    int h = height() - YMARGIN * 2, w = width() - XMARGIN * 2;
-    int sampleCount = samples.size(), x = XMARGIN + w, y;
+    int sampleCount = samples.size();
     if(sampleCount > 0) {
+        int h = height() - YMARGIN * 2, w = width() - XMARGIN * 2;
+        int x = XMARGIN + w;
         path.moveTo(x, YMARGIN + h);
         for(int i = 0; i < sampleCount; ++i) {
             x = XMARGIN + w - w * i / DESIRED_SAMPLES;
-            y = YMARGIN + h - (int)(h * samples.at(i) / fMax);
+            int y = YMARGIN + h - (int)(h * samples.at(i) / fMax);
             path.lineTo(x, y);
         }
         path.lineTo(x, YMARGIN + h);

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -98,15 +98,13 @@ UniValue getnetworkhashps(const JSONRPCRequest& request)
 UniValue generateBlocks(std::shared_ptr<CReserveScript> coinbaseScript, int nGenerate, uint64_t nMaxTries, bool keepScript)
 {
     static const int nInnerLoopCount = 0x10000;
-    int nHeightStart = 0;
     int nHeightEnd = 0;
     int nHeight = 0;
 
     {   // Don't keep cs_main locked
         LOCK(cs_main);
-        nHeightStart = chainActive.Height();
-        nHeight = nHeightStart;
-        nHeightEnd = nHeightStart+nGenerate;
+        nHeight = chainActive.Height();
+        nHeightEnd = nHeight+nGenerate;
     }
     unsigned int nExtraNonce = 0;
     UniValue blockHashes(UniValue::VARR);

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -838,7 +838,6 @@ UniValue sendrawtransaction(const JSONRPCRequest& request)
     CTransactionRef tx(MakeTransactionRef(std::move(mtx)));
     const uint256& hashTx = tx->GetHash();
 
-    bool fLimitFree = true;
     CAmount nMaxRawTxFee = maxTxFee;
     if (request.params.size() > 1 && request.params[1].get_bool())
         nMaxRawTxFee = 0;
@@ -851,6 +850,7 @@ UniValue sendrawtransaction(const JSONRPCRequest& request)
         // push to local node and sync with wallets
         CValidationState state;
         bool fMissingInputs;
+        bool fLimitFree = true;
         if (!AcceptToMemoryPool(mempool, state, std::move(tx), fLimitFree, &fMissingInputs, NULL, false, nMaxRawTxFee)) {
             if (state.IsInvalid()) {
                 throw JSONRPCError(RPC_TRANSACTION_REJECTED, strprintf("%i: %s", state.GetRejectCode(), state.GetRejectReason()));

--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -141,10 +141,9 @@ static CScript PushAll(const std::vector<valtype>& values)
 bool ProduceSignature(const BaseSignatureCreator& creator, const CScript& fromPubKey, SignatureData& sigdata)
 {
     CScript script = fromPubKey;
-    bool solved = true;
     std::vector<valtype> result;
     txnouttype whichType;
-    solved = SignStep(creator, script, result, whichType, SIGVERSION_BASE);
+    bool solved = SignStep(creator, script, result, whichType, SIGVERSION_BASE);
     bool P2SH = false;
     CScript subscript;
     sigdata.scriptWitness.stack.clear();

--- a/src/test/checkqueue_tests.cpp
+++ b/src/test/checkqueue_tests.cpp
@@ -402,12 +402,12 @@ BOOST_AUTO_TEST_CASE(test_CheckQueueControl_Locks)
     {
         boost::thread_group tg;
         std::mutex m;
-        bool has_lock {false};
-        bool has_tried {false};
-        bool done {false};
-        bool done_ack {false};
         std::condition_variable cv;
         {
+            bool has_lock {false};
+            bool has_tried {false};
+            bool done {false};
+            bool done_ack {false};
             std::unique_lock<std::mutex> l(m);
             tg.create_thread([&]{
                     CCheckQueueControl<FakeCheck> control(queue.get());

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -361,7 +361,6 @@ void CDBEnv::CheckpointLSN(const std::string& strFile)
 
 CDB::CDB(CWalletDBWrapper& dbw, const char* pszMode, bool fFlushOnCloseIn) : pdb(NULL), activeTxn(NULL)
 {
-    int ret;
     fReadOnly = (!strchr(pszMode, '+') && !strchr(pszMode, 'w'));
     fFlushOnClose = fFlushOnCloseIn;
     env = dbw.env;
@@ -384,6 +383,7 @@ CDB::CDB(CWalletDBWrapper& dbw, const char* pszMode, bool fFlushOnCloseIn) : pdb
         ++env->mapFileUseCount[strFile];
         pdb = env->mapDb[strFile];
         if (pdb == NULL) {
+            int ret;
             pdb = new Db(env->dbenv, 0);
 
             bool fMockDb = env->IsMock();

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3196,10 +3196,10 @@ void CWallet::ReturnKey(int64_t nIndex)
 
 bool CWallet::GetKeyFromPool(CPubKey& result, bool internal)
 {
-    int64_t nIndex = 0;
     CKeyPool keypool;
     {
         LOCK(cs_wallet);
+        int64_t nIndex = 0;
         ReserveKeyFromKeyPool(nIndex, keypool, internal);
         if (nIndex == -1)
         {


### PR DESCRIPTION
Limit variable scope as much as possible in order to:
* improve code readability,
* reduce complexity, and/or
* avoid unnecessary initialisations.