### PR TITLE
[wallet] Remove unused variables

### DIFF
--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -211,7 +211,6 @@ bool CDB::Recover(const std::string& filename, void *callbackDataIn, bool (*reco
         {
             CDataStream ssKey(row.first, SER_DISK, CLIENT_VERSION);
             CDataStream ssValue(row.second, SER_DISK, CLIENT_VERSION);
-            std::string strType, strErr;
             if (!(*recoverKVcallback)(callbackDataIn, ssKey, ssValue))
                 continue;
         }


### PR DESCRIPTION
Remove two unused variables in `src/wallet/db.cpp`.