### PR TITLE
Use parentheses to clarify intended precedence when using bitwise operations

### DIFF
--- a/src/crypto/aes.cpp
+++ b/src/crypto/aes.cpp
@@ -137,7 +137,7 @@ static int CBCDecrypt(const T& dec, const unsigned char iv[AES_BLOCKSIZE], const
         // If used, padding size is the value of the last decrypted byte. For
         // it to be valid, It must be between 1 and AES_BLOCKSIZE.
         padsize = *--out;
-        fail = !padsize | (padsize > AES_BLOCKSIZE);
+        fail = (!padsize) | (padsize > AES_BLOCKSIZE);
 
         // If not well-formed, treat it as though there's no padding.
         padsize *= !fail;

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -307,8 +307,8 @@ QString TransactionDesc::toHTML(CWallet *wallet, CWalletTx &wtx, TransactionReco
                         strHTML += QString::fromStdString(CBitcoinAddress(address).ToString());
                     }
                     strHTML = strHTML + " " + tr("Amount") + "=" + BitcoinUnits::formatHtmlWithUnit(unit, vout.nValue);
-                    strHTML = strHTML + " IsMine=" + (wallet->IsMine(vout) & ISMINE_SPENDABLE ? tr("true") : tr("false")) + "</li>";
-                    strHTML = strHTML + " IsWatchOnly=" + (wallet->IsMine(vout) & ISMINE_WATCH_ONLY ? tr("true") : tr("false")) + "</li>";
+                    strHTML = strHTML + " IsMine=" + ((wallet->IsMine(vout) & ISMINE_SPENDABLE) ? tr("true") : tr("false")) + "</li>";
+                    strHTML = strHTML + " IsWatchOnly=" + ((wallet->IsMine(vout) & ISMINE_WATCH_ONLY) ? tr("true") : tr("false")) + "</li>";
                 }
             }
         }


### PR DESCRIPTION
Use parentheses to clarify intended precedence when using bitwise operations.