### PR TITLE
Improve bitcoind systemd service file

### DIFF
--- a/contrib/init/bitcoind.service
+++ b/contrib/init/bitcoind.service
@@ -1,22 +1,25 @@
+# It is not recommended to modify this file in-place, because it will
+# be overwritten during package upgrades. If you want to add further
+# options or overwrite existing ones then use
+# $ systemctl edit bitcoind.service
+# See "man systemd.service" for details.
+
+# Note that almost all daemon options could be specified in
+# /etc/bitcoin/bitcoin.conf
+
 [Unit]
-Description=Bitcoin's distributed currency daemon
+Description=Bitcoin daemon
 After=network.target
 
 [Service]
+ExecStart=/usr/bin/bitcoind -daemon -conf=/etc/bitcoin/bitcoin.conf -pid=/run/bitcoind/bitcoind.pid
+# Creates /run/bitcoind owned by bitcoin
+RuntimeDirectory=bitcoind
 User=bitcoin
-Group=bitcoin
-
 Type=forking
-PIDFile=/var/lib/bitcoind/bitcoind.pid
-ExecStart=/usr/bin/bitcoind -daemon -pid=/var/lib/bitcoind/bitcoind.pid \
--conf=/etc/bitcoin/bitcoin.conf -datadir=/var/lib/bitcoind -disablewallet
-
-Restart=always
+PIDFile=/run/bitcoind/bitcoind.pid
+Restart=on-failure
 PrivateTmp=true
-TimeoutStopSec=60s
-TimeoutStartSec=2s
-StartLimitInterval=120s
-StartLimitBurst=5
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Add comment how further options can be added or existing ones
modified. Use /run/${RuntimeDirectory} for PID file.

Remove TimeoutStopSec, TimeoutStartSec, StartLimitInterval,
StartLimitBurst directives as those should be set indivdually.

Remove Group to user the bitcoin user's default group.

Changed Restart from 'always' to 'on-failure' (can also be overwritten
individually).