### PR TITLE
Increased startup timeout.

### DIFF
--- a/contrib/init/bitcoind.service
+++ b/contrib/init/bitcoind.service
@@ -14,7 +14,7 @@ ExecStart=/usr/bin/bitcoind -daemon -pid=/var/lib/bitcoind/bitcoind.pid \
 Restart=always
 PrivateTmp=true
 TimeoutStopSec=60s
-TimeoutStartSec=2s
+TimeoutStartSec=120s
 StartLimitInterval=120s
 StartLimitBurst=5
 


### PR DESCRIPTION
In my experience a two second timeout will cause the startup to always fail, causing systemd to attempt shutdown while bitcoind is still starting up.