### PR TITLE
[tests] Use cookie auth instead of rpcuser and rpcpassword

### DIFF
--- a/test/functional/multi_rpc.py
+++ b/test/functional/multi_rpc.py
@@ -16,16 +16,21 @@ class HTTPBasicsTest (BitcoinTestFramework):
     def __init__(self):
         super().__init__()
         self.setup_clean_chain = False
-        self.num_nodes = 1
+        self.num_nodes = 2
 
     def setup_chain(self):
         super().setup_chain()
         #Append rpcauth to bitcoin.conf before initialization
         rpcauth = "rpcauth=rt:93648e835a54c573682c2eb19f882535$7681e9c5b74bdd85e78166031d2058e1069b3ed7ed967c93fc63abba06f31144"
         rpcauth2 = "rpcauth=rt2:f8607b1a88861fac29dfccf9b52ff9f$ff36a0c23c8c62b4846112e50fa888416e94c17bfd4c42f88fd8f55ec6a3137e"
+        rpcuser = "rpcuser=rpcuser💻"
+        rpcpassword = "rpcpassword=rpcpassword🔑"
         with open(os.path.join(self.options.tmpdir+"/node0", "bitcoin.conf"), 'a', encoding='utf8') as f:
             f.write(rpcauth+"\n")
             f.write(rpcauth2+"\n")
+        with open(os.path.join(self.options.tmpdir+"/node1", "bitcoin.conf"), 'a', encoding='utf8') as f:
+            f.write(rpcuser+"\n")
+            f.write(rpcpassword+"\n")
 
     def run_test(self):
 
@@ -50,7 +55,7 @@ class HTTPBasicsTest (BitcoinTestFramework):
         conn.connect()
         conn.request('POST', '/', '{"method": "getbestblockhash"}', headers)
         resp = conn.getresponse()
-        assert_equal(resp.status==401, False)
+        assert_equal(resp.status, 200)
         conn.close()
         
         #Use new authpair to confirm both work
@@ -60,7 +65,7 @@ class HTTPBasicsTest (BitcoinTestFramework):
         conn.connect()
         conn.request('POST', '/', '{"method": "getbestblockhash"}', headers)
         resp = conn.getresponse()
-        assert_equal(resp.status==401, False)
+        assert_equal(resp.status, 200)
         conn.close()
 
         #Wrong login name with rt's password
@@ -71,7 +76,7 @@ class HTTPBasicsTest (BitcoinTestFramework):
         conn.connect()
         conn.request('POST', '/', '{"method": "getbestblockhash"}', headers)
         resp = conn.getresponse()
-        assert_equal(resp.status==401, True)
+        assert_equal(resp.status, 401)
         conn.close()
 
         #Wrong password for rt
@@ -82,7 +87,7 @@ class HTTPBasicsTest (BitcoinTestFramework):
         conn.connect()
         conn.request('POST', '/', '{"method": "getbestblockhash"}', headers)
         resp = conn.getresponse()
-        assert_equal(resp.status==401, True)
+        assert_equal(resp.status, 401)
         conn.close()
 
         #Correct for rt2
@@ -93,7 +98,7 @@ class HTTPBasicsTest (BitcoinTestFramework):
         conn.connect()
         conn.request('POST', '/', '{"method": "getbestblockhash"}', headers)
         resp = conn.getresponse()
-        assert_equal(resp.status==401, False)
+        assert_equal(resp.status, 200)
         conn.close()
 
         #Wrong password for rt2
@@ -104,7 +109,46 @@ class HTTPBasicsTest (BitcoinTestFramework):
         conn.connect()
         conn.request('POST', '/', '{"method": "getbestblockhash"}', headers)
         resp = conn.getresponse()
-        assert_equal(resp.status==401, True)
+        assert_equal(resp.status, 401)
+        conn.close()
+
+        ###############################################################
+        # Check correctness of the rpcuser/rpcpassword config options #
+        ###############################################################
+        url = urllib.parse.urlparse(self.nodes[1].url)
+
+        # rpcuser and rpcpassword authpair
+        rpcuserauthpair = "rpcuser💻:rpcpassword🔑"
+
+        headers = {"Authorization": "Basic " + str_to_b64str(rpcuserauthpair)}
+
+        conn = http.client.HTTPConnection(url.hostname, url.port)
+        conn.connect()
+        conn.request('POST', '/', '{"method": "getbestblockhash"}', headers)
+        resp = conn.getresponse()
+        assert_equal(resp.status, 200)
+        conn.close()
+
+        #Wrong login name with rpcuser's password
+        rpcuserauthpair = "rpcuserwrong:rpcpassword"
+        headers = {"Authorization": "Basic " + str_to_b64str(rpcuserauthpair)}
+
+        conn = http.client.HTTPConnection(url.hostname, url.port)
+        conn.connect()
+        conn.request('POST', '/', '{"method": "getbestblockhash"}', headers)
+        resp = conn.getresponse()
+        assert_equal(resp.status, 401)
+        conn.close()
+
+        #Wrong password for rpcuser
+        rpcuserauthpair = "rpcuser:rpcpasswordwrong"
+        headers = {"Authorization": "Basic " + str_to_b64str(rpcuserauthpair)}
+
+        conn = http.client.HTTPConnection(url.hostname, url.port)
+        conn.connect()
+        conn.request('POST', '/', '{"method": "getbestblockhash"}', headers)
+        resp = conn.getresponse()
+        assert_equal(resp.status, 401)
         conn.close()
 
 

--- a/test/functional/p2p-segwit.py
+++ b/test/functional/p2p-segwit.py
@@ -1486,7 +1486,7 @@ class SegWitTest(BitcoinTestFramework):
     # nodes would have stored, this requires special handling.
     # To enable this test, pass --oldbinary=<path-to-pre-segwit-bitcoind> to
     # the test.
-    def test_upgrade_after_activation(self, node, node_id):
+    def test_upgrade_after_activation(self, node_id):
         self.log.info("Testing software upgrade after softfork activation")
 
         assert(node_id != 0) # node0 is assumed to be a segwit-active bitcoind
@@ -1502,14 +1502,14 @@ class SegWitTest(BitcoinTestFramework):
         sync_blocks(self.nodes)
 
         # Make sure that this peer thinks segwit has activated.
-        assert(get_bip9_status(node, 'segwit')['status'] == "active")
+        assert(get_bip9_status(self.nodes[node_id], 'segwit')['status'] == "active")
 
         # Make sure this peers blocks match those of node0.
-        height = node.getblockcount()
+        height = self.nodes[node_id].getblockcount()
         while height >= 0:
-            block_hash = node.getblockhash(height)
+            block_hash = self.nodes[node_id].getblockhash(height)
             assert_equal(block_hash, self.nodes[0].getblockhash(height))
-            assert_equal(self.nodes[0].getblock(block_hash), node.getblock(block_hash))
+            assert_equal(self.nodes[0].getblock(block_hash), self.nodes[node_id].getblock(block_hash))
             height -= 1
 
 
@@ -1944,7 +1944,7 @@ class SegWitTest(BitcoinTestFramework):
         self.test_signature_version_1()
         self.test_non_standard_witness()
         sync_blocks(self.nodes)
-        self.test_upgrade_after_activation(self.nodes[2], 2)
+        self.test_upgrade_after_activation(2)
         self.test_witness_sigops()
 
 

--- a/test/functional/p2p-segwit.py
+++ b/test/functional/p2p-segwit.py
@@ -1944,7 +1944,7 @@ class SegWitTest(BitcoinTestFramework):
         self.test_signature_version_1()
         self.test_non_standard_witness()
         sync_blocks(self.nodes)
-        self.test_upgrade_after_activation(2)
+        self.test_upgrade_after_activation(node_id=2)
         self.test_witness_sigops()
 
 

--- a/test/functional/pruning.py
+++ b/test/functional/pruning.py
@@ -315,7 +315,7 @@ class PruneTest(BitcoinTestFramework):
         # check that the pruning node's wallet is still in good shape
         self.log.info("Stop and start pruning node to trigger wallet rescan")
         self.stop_node(2)
-        self.start_node(2, self.options.tmpdir, ["-prune=550"])
+        self.nodes[2] = self.start_node(2, self.options.tmpdir, ["-prune=550"])
         self.log.info("Success")
 
         # check that wallet loads loads successfully when restarting a pruned node after IBD.
@@ -325,7 +325,7 @@ class PruneTest(BitcoinTestFramework):
         nds = [self.nodes[0], self.nodes[5]]
         sync_blocks(nds, wait=5, timeout=300)
         self.stop_node(5) #stop and start to trigger rescan
-        self.start_node(5, self.options.tmpdir, ["-prune=550"])
+        self.nodes[5] = self.start_node(5, self.options.tmpdir, ["-prune=550"])
         self.log.info("Success")
 
     def run_test(self):

--- a/test/functional/rpcbind_test.py
+++ b/test/functional/rpcbind_test.py
@@ -49,7 +49,7 @@ class RPCBindTest(BitcoinTestFramework):
         base_args = ['-disablewallet', '-nolisten'] + ['-rpcallowip='+x for x in allow_ips]
         self.nodes = self.start_nodes(self.num_nodes, self.options.tmpdir, [base_args])
         # connect to node through non-loopback interface
-        node = get_rpc_proxy(rpc_url(0, "%s:%d" % (rpchost, rpcport)), 0)
+        node = get_rpc_proxy(rpc_url(get_datadir_path(self.options.tmpdir, 0), 0, "%s:%d" % (rpchost, rpcport)), 0)
         node.getnetworkinfo()
         self.stop_nodes()
 

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -28,6 +28,7 @@ from .util import (
     get_mocktime,
     get_rpc_proxy,
     initialize_datadir,
+    get_datadir_path,
     log_filename,
     p2p_port,
     rpc_url,
@@ -300,13 +301,13 @@ class BitcoinTestFramework(object):
                     args.append("-connect=127.0.0.1:" + str(p2p_port(0)))
                 bitcoind_processes[i] = subprocess.Popen(args)
                 self.log.debug("initialize_chain: bitcoind started, waiting for RPC to come up")
-                wait_for_bitcoind_start(bitcoind_processes[i], rpc_url(i), i)
+                wait_for_bitcoind_start(bitcoind_processes[i], datadir, i)
                 self.log.debug("initialize_chain: RPC successfully started")
 
             self.nodes = []
             for i in range(MAX_NODES):
                 try:
-                    self.nodes.append(get_rpc_proxy(rpc_url(i), i))
+                    self.nodes.append(get_rpc_proxy(rpc_url(get_datadir_path(cachedir, i), i), i))
                 except:
                     self.log.exception("Error connecting to node %d" % i)
                     sys.exit(1)

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -192,15 +192,10 @@ def get_datadir_path(dirname, n):
     return os.path.join(dirname, "node"+str(n))
 
 def get_auth_cookie(datadir, n):
-    if os.path.isfile(os.path.join(datadir, "regtest", ".cookie")):
-        with open(os.path.join(datadir, "regtest", ".cookie"), 'r') as f:
-            userpass = f.read()
-            split_userpass = userpass.split(':')
-            return split_userpass[0], split_userpass[1]
-    else:
+    user = None
+    password = None
+    if os.path.isfile(os.path.join(datadir, "bitcoin.conf")):
         with open(os.path.join(datadir, "bitcoin.conf"), 'r') as f:
-            user = None
-            password = None
             for line in f:
                 if line.startswith("rpcuser="):
                     assert user is None # Ensure that there is only one rpcuser line
@@ -208,9 +203,15 @@ def get_auth_cookie(datadir, n):
                 if line.startswith("rpcpassword="):
                     assert password is None # Ensure that there is only one rpcpassword line
                     password = line.split("=")[1].strip("\n")
-            if user is None and password is None:
-                raise ValueError("No RPC credentials")
-            return user, password
+    if os.path.isfile(os.path.join(datadir, "regtest", ".cookie")):
+        with open(os.path.join(datadir, "regtest", ".cookie"), 'r') as f:
+            userpass = f.read()
+            split_userpass = userpass.split(':')
+            user = split_userpass[0]
+            password = split_userpass[1]
+    if user is None or password is None:
+        raise ValueError("No RPC credentials")
+    return user, password
 
 def rpc_url(datadir, i, rpchost=None):
     rpc_u, rpc_p = get_auth_cookie(datadir, i)

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -187,10 +187,10 @@ def initialize_datadir(dirname, n):
         f.write("rpcport="+str(rpc_port(n))+"\n")
         f.write("listenonion=0\n")
     return datadir
-    
+
 def get_datadir_path(dirname, n):
     return os.path.join(dirname, "node"+str(n))
-    
+
 def get_auth_cookie(datadir, n):
     if os.path.isfile(os.path.join(datadir, "regtest", ".cookie")):
         with open(os.path.join(datadir, "regtest", ".cookie"), 'r') as f:
@@ -224,7 +224,7 @@ def rpc_url(datadir, i, rpchost=None):
             host = rpchost
     return "http://%s:%s@%s:%d" % (rpc_u, rpc_p, host, int(port))
 
-def wait_for_bitcoind_start(process, datadir, i):
+def wait_for_bitcoind_start(process, datadir, i, rpchost=None):
     '''
     Wait for bitcoind to start. This means that RPC is accessible and fully initialized.
     Raise an exception if bitcoind exits during initialization.
@@ -234,7 +234,7 @@ def wait_for_bitcoind_start(process, datadir, i):
             raise Exception('bitcoind exited with status %i during initialization' % process.returncode)
         try:
             # Check if .cookie file to be created
-            rpc = get_rpc_proxy(rpc_url(datadir, i), i)
+            rpc = get_rpc_proxy(rpc_url(datadir, i, rpchost), i)
             blocks = rpc.getblockcount()
             break # break out of loop on success
         except IOError as e:
@@ -261,7 +261,7 @@ def _start_node(i, dirname, extra_args=None, rpchost=None, timewait=None, binary
     if extra_args is not None: args.extend(extra_args)
     bitcoind_processes[i] = subprocess.Popen(args, stderr=stderr)
     logger.debug("initialize_chain: bitcoind started, waiting for RPC to come up")
-    wait_for_bitcoind_start(bitcoind_processes[i], datadir, i)
+    wait_for_bitcoind_start(bitcoind_processes[i], datadir, i, rpchost)
     logger.debug("initialize_chain: RPC successfully started")
     proxy = get_rpc_proxy(rpc_url(datadir, i, rpchost), i, timeout=timewait)
 


### PR DESCRIPTION
Since rpcuser and rpcpassword are now deprecated, replace them with cookie auth.