### PR TITLE
[qa] fundrawtx: Fix shutdown race

### DIFF
--- a/test/functional/fundrawtransaction.py
+++ b/test/functional/fundrawtransaction.py
@@ -452,7 +452,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.stop_node(2)
         self.stop_node(3)
         self.nodes[1].encryptwallet("test")
-        self.nodes.pop(1)
+        bitcoind_processes[1].wait(timeout=BITCOIND_PROC_WAIT_TIMEOUT)
 
         self.nodes = self.start_nodes(self.num_nodes, self.options.tmpdir)
         # This test is not meant to test fee estimation and we'd like


### PR DESCRIPTION
We need to wait for node 1 to shut down completely. Otherwise we might not be able to restart the nodes and get a error:

```
Error: Cannot obtain a lock on data directory /tmp/testc_zc8wco/node1/regtest. Bitcoin Core is probably already running.
