### PR TITLE
[trivial] Fix typo: "occurrences" (misspelled as "occurrances")

### DIFF
--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -86,7 +86,7 @@ void AddCoins(CCoinsViewCache& cache, const CTransaction &tx, int nHeight) {
     const uint256& txid = tx.GetHash();
     for (size_t i = 0; i < tx.vout.size(); ++i) {
         // Pass fCoinbase as the possible_overwrite flag to AddCoin, in order to correctly
-        // deal with the pre-BIP30 occurrances of duplicate coinbase transactions.
+        // deal with the pre-BIP30 occurrences of duplicate coinbase transactions.
         cache.AddCoin(COutPoint(txid, i), Coin(tx.vout[i], nHeight, fCoinbase), fCoinbase);
     }
 }


### PR DESCRIPTION
Typo introduced in commit 000391132608343c66488d62625c714814959bc9:

```
$ git blame src/coins.cpp | grep occurrances
00039113 (2017-04-25 11:29:29 -0700  89)         // deal with the pre-BIP30 occurrances of duplicate coinbase transactions.
```

Friendly ping @sipa :-)