### PR TITLE
[tests] Use FastRandomContext instead of boost::random::{mt19937,uniform_int_distribution}

### DIFF
--- a/src/test/scheduler_tests.cpp
+++ b/src/test/scheduler_tests.cpp
@@ -8,8 +8,6 @@
 #include "test/test_bitcoin.h"
 
 #include <boost/bind.hpp>
-#include <boost/random/mersenne_twister.hpp>
-#include <boost/random/uniform_int_distribution.hpp>
 #include <boost/thread.hpp>
 #include <boost/test/unit_test.hpp>
 
@@ -56,10 +54,10 @@ BOOST_AUTO_TEST_CASE(manythreads)
 
     boost::mutex counterMutex[10];
     int counter[10] = { 0 };
-    boost::random::mt19937 rng(42);
-    boost::random::uniform_int_distribution<> zeroToNine(0, 9);
-    boost::random::uniform_int_distribution<> randomMsec(-11, 1000);
-    boost::random::uniform_int_distribution<> randomDelta(-1000, 1000);
+    FastRandomContext rng(42);
+    auto zeroToNine = [](FastRandomContext& rc) -> int { return rc.randrange(10); }; // [0, 9]
+    auto randomMsec = [](FastRandomContext& rc) -> int { return -11 + rc.randrange(1012); }; // [-11, 1000]
+    auto randomDelta = [](FastRandomContext& rc) -> int { return -1000 + rc.randrange(2001); }; // [-1000, 1000]
 
     boost::chrono::system_clock::time_point start = boost::chrono::system_clock::now();
     boost::chrono::system_clock::time_point now = start;


### PR DESCRIPTION
Use `FastRandomContext` instead of `boost::random::{mt19937,uniform_int_distribution}`.

Was:
> Use `std::random::mt19937`/`uniform_int_distribution` (C++11) instead of `boost::random` equivalents.