### PR TITLE
Use std::unordered_{map,set} (C++11) instead of boost::unordered_{map,set}

### DIFF
--- a/src/memusage.h
+++ b/src/memusage.h
@@ -16,8 +16,6 @@
 #include <unordered_set>
 
 #include <boost/foreach.hpp>
-#include <boost/unordered_set.hpp>
-#include <boost/unordered_map.hpp>
 
 namespace memusage
 {
@@ -148,26 +146,12 @@ static inline size_t DynamicUsage(const std::shared_ptr<X>& p)
     return p ? MallocUsage(sizeof(X)) + MallocUsage(sizeof(stl_shared_counter)) : 0;
 }
 
-// Boost data structures
-
 template<typename X>
 struct unordered_node : private X
 {
 private:
     void* ptr;
 };
-
-template<typename X, typename Y>
-static inline size_t DynamicUsage(const boost::unordered_set<X, Y>& s)
-{
-    return MallocUsage(sizeof(unordered_node<X>)) * s.size() + MallocUsage(sizeof(void*) * s.bucket_count());
-}
-
-template<typename X, typename Y, typename Z>
-static inline size_t DynamicUsage(const boost::unordered_map<X, Y, Z>& m)
-{
-    return MallocUsage(sizeof(unordered_node<std::pair<const X, Y> >)) * m.size() + MallocUsage(sizeof(void*) * m.bucket_count());
-}
 
 template<typename X, typename Y>
 static inline size_t DynamicUsage(const std::unordered_set<X, Y>& s)

--- a/src/validation.h
+++ b/src/validation.h
@@ -30,8 +30,6 @@
 
 #include <atomic>
 
-#include <boost/unordered_map.hpp>
-
 class CBlockIndex;
 class CBlockTreeDB;
 class CBloomFilter;
@@ -161,7 +159,7 @@ extern CScript COINBASE_FLAGS;
 extern CCriticalSection cs_main;
 extern CBlockPolicyEstimator feeEstimator;
 extern CTxMemPool mempool;
-typedef boost::unordered_map<uint256, CBlockIndex*, BlockHasher> BlockMap;
+typedef std::unordered_map<uint256, CBlockIndex*, BlockHasher> BlockMap;
 extern BlockMap mapBlockIndex;
 extern uint64_t nLastBlockTx;
 extern uint64_t nLastBlockSize;


### PR DESCRIPTION
Use `std::unordered_{map,set}` (C++11) instead of `boost::unordered_{map,set}`.