### PR TITLE
ZMQ: add publishers for wallet transactions.

### DIFF
--- a/doc/zmq.md
+++ b/doc/zmq.md
@@ -58,8 +58,10 @@ Currently, the following notifications are supported:
 
     -zmqpubhashtx=address
     -zmqpubhashblock=address
+    -zmqpubhashwallettx=address
     -zmqpubrawblock=address
     -zmqpubrawtx=address
+    -zmqpubrawwallettx=address
 
 The socket type is PUB and the address must be a valid ZeroMQ socket
 address. The same address can be used in more than one notification.
@@ -74,6 +76,15 @@ corresponds to the notification type. For instance, for the
 notification `-zmqpubhashtx` the topic is `hashtx` (no null
 terminator) and the body is the transaction hash (32
 bytes).
+
+For wallet transaction notifications (both hash and tx), the
+topic also indicate if the transaction came from a block
+or mempool. If originated from mempool `-mempool` postfix
+will be added to the topic, for block `-block` postfix will
+be added. Because zeromq is using prefix matching for topics
+you can subscribe to `rawwallettx` (or `hashwallettx`) to get
+both notifications. If you only want one type of notification
+subscribe to either `rawwallettx-mempool` or `rawwallettx-block`.
 
 These options can also be provided in bitcoin.conf.
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1581,12 +1581,6 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
 #ifdef ENABLE_WALLET
     if (!OpenWallets())
         return false;
-
-#if ENABLE_ZMQ
-    if (pzmqNotificationInterface)
-        pzmqNotificationInterface->ConnectToWalletSignals();
-#endif
-
 #else
     LogPrintf("No wallet support compiled in!\n");
 #endif

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -416,8 +416,10 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageGroup(_("ZeroMQ notification options:"));
     strUsage += HelpMessageOpt("-zmqpubhashblock=<address>", _("Enable publish hash block in <address>"));
     strUsage += HelpMessageOpt("-zmqpubhashtx=<address>", _("Enable publish hash transaction in <address>"));
+    strUsage += HelpMessageOpt("-zmqpubhashwallettx=<address>", _("Enable publish hash wallet transaction in <address>"));
     strUsage += HelpMessageOpt("-zmqpubrawblock=<address>", _("Enable publish raw block in <address>"));
     strUsage += HelpMessageOpt("-zmqpubrawtx=<address>", _("Enable publish raw transaction in <address>"));
+    strUsage += HelpMessageOpt("-zmqpubrawwallettx=<address>", _("Enable publish raw wallet transaction in <address>"));
 #endif
 
     strUsage += HelpMessageGroup(_("Debugging/Testing options:"));
@@ -1579,6 +1581,12 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
 #ifdef ENABLE_WALLET
     if (!OpenWallets())
         return false;
+
+#if ENABLE_ZMQ
+    if (pzmqNotificationInterface)
+        pzmqNotificationInterface->ConnectToWalletSignals();
+#endif
+
 #else
     LogPrintf("No wallet support compiled in!\n");
 #endif

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -959,6 +959,9 @@ bool CWallet::AddToWallet(const CWalletTx& wtxIn, bool fFlushOnClose)
     // Notify UI of new or updated transaction
     NotifyTransactionChanged(this, hash, fInsertedNew ? CT_NEW : CT_UPDATED);
 
+    // Notify listeners on new wallet transaction
+    TransactionAddedToWallet(wtx.tx, wtx.hashBlock);
+
     // notify an external script when a wallet transaction comes in or is updated
     std::string strCmd = gArgs.GetArg("-walletnotify", "");
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -58,6 +58,10 @@ CFeeRate CWallet::minTxFee = CFeeRate(DEFAULT_TRANSACTION_MINFEE);
  * Override with -fallbackfee
  */
 CFeeRate CWallet::fallbackFee = CFeeRate(DEFAULT_FALLBACK_FEE);
+/*
+ * Signal when transactions are added to wallet
+ */
+boost::signals2::signal<void (const CTransactionRef &ptxn, const uint256 &blockHash)> CWallet::TransactionAddedToWallet;
 
 CFeeRate CWallet::m_discard_rate = CFeeRate(DEFAULT_DISCARD_FEE);
 
@@ -960,7 +964,7 @@ bool CWallet::AddToWallet(const CWalletTx& wtxIn, bool fFlushOnClose)
     NotifyTransactionChanged(this, hash, fInsertedNew ? CT_NEW : CT_UPDATED);
 
     // Notify listeners on new wallet transaction
-    TransactionAddedToWallet(wtx.tx, wtx.hashBlock);
+    CWallet::TransactionAddedToWallet(wtx.tx, wtx.hashBlock);
 
     // notify an external script when a wallet transaction comes in or is updated
     std::string strCmd = gArgs.GetArg("-walletnotify", "");

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1060,7 +1060,7 @@ public:
     boost::signals2::signal<void (CWallet *wallet, const uint256 &hashTx,
             ChangeType status)> NotifyTransactionChanged;
 
-    boost::signals2::signal<void (const CTransactionRef &ptxn,
+    static boost::signals2::signal<void (const CTransactionRef &ptxn,
                                   const uint256 &blockHash)> TransactionAddedToWallet;
 
     /** Show progress e.g. for rescan */

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1060,6 +1060,9 @@ public:
     boost::signals2::signal<void (CWallet *wallet, const uint256 &hashTx,
             ChangeType status)> NotifyTransactionChanged;
 
+    boost::signals2::signal<void (const CTransactionRef &ptxn,
+                                  const uint256 &blockHash)> TransactionAddedToWallet;
+
     /** Show progress e.g. for rescan */
     boost::signals2::signal<void (const std::string &title, int nProgress)> ShowProgress;
 

--- a/src/zmq/zmqabstractnotifier.cpp
+++ b/src/zmq/zmqabstractnotifier.cpp
@@ -20,3 +20,7 @@ bool CZMQAbstractNotifier::NotifyTransaction(const CTransaction &/*transaction*/
 {
     return true;
 }
+
+bool CZMQAbstractNotifier::NotifyWalletTransaction(const CTransaction &transaction, const uint256 &hashBlock){
+    return true;
+}

--- a/src/zmq/zmqabstractnotifier.h
+++ b/src/zmq/zmqabstractnotifier.h
@@ -34,6 +34,7 @@ public:
 
     virtual bool NotifyBlock(const CBlockIndex *pindex);
     virtual bool NotifyTransaction(const CTransaction &transaction);
+    virtual bool NotifyWalletTransaction(const CTransaction &transaction, const uint256 &hashBlock);
 
 protected:
     void *psocket;

--- a/src/zmq/zmqnotificationinterface.h
+++ b/src/zmq/zmqnotificationinterface.h
@@ -20,9 +20,16 @@ public:
 
     static CZMQNotificationInterface* Create();
 
+#ifdef ENABLE_WALLET
+    void ConnectToWalletSignals();
+#endif
+
+
 protected:
     bool Initialize();
     void Shutdown();
+
+    void TransactionAddedToWallet(const CTransactionRef& tx, const uint256 &hashBlock);
 
     // CValidationInterface
     void TransactionAddedToMempool(const CTransactionRef& tx) override;

--- a/src/zmq/zmqnotificationinterface.h
+++ b/src/zmq/zmqnotificationinterface.h
@@ -20,11 +20,6 @@ public:
 
     static CZMQNotificationInterface* Create();
 
-#ifdef ENABLE_WALLET
-    void ConnectToWalletSignals();
-#endif
-
-
 protected:
     bool Initialize();
     void Shutdown();

--- a/src/zmq/zmqpublishnotifier.h
+++ b/src/zmq/zmqpublishnotifier.h
@@ -40,6 +40,12 @@ public:
     bool NotifyTransaction(const CTransaction &transaction) override;
 };
 
+class CZMQPublishHashWalletTransactionNotifier : public CZMQAbstractPublishNotifier
+{
+public:
+    bool NotifyWalletTransaction(const CTransaction &transaction, const uint256 &hashBlock);
+};
+
 class CZMQPublishRawBlockNotifier : public CZMQAbstractPublishNotifier
 {
 public:
@@ -50,6 +56,12 @@ class CZMQPublishRawTransactionNotifier : public CZMQAbstractPublishNotifier
 {
 public:
     bool NotifyTransaction(const CTransaction &transaction) override;
+};
+
+class CZMQPublishRawWalletTransactionNotifier : public CZMQAbstractPublishNotifier
+{
+public:
+    bool NotifyWalletTransaction(const CTransaction &transaction, const uint256 &hashBlock);
 };
 
 #endif // BITCOIN_ZMQ_ZMQPUBLISHNOTIFIER_H

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -37,6 +37,10 @@ def assert_equal(thing1, thing2, *args):
     if thing1 != thing2 or any(thing1 != arg for arg in args):
         raise AssertionError("not(%s)" % " == ".join(str(arg) for arg in (thing1, thing2) + args))
 
+def assert_not_equal(thing1, thing2):
+    if thing1 == thing2:
+        raise AssertionError("%s == %s"%(str(thing1),str(thing2)))
+
 def assert_greater_than(thing1, thing2):
     if thing1 <= thing2:
         raise AssertionError("%s <= %s" % (str(thing1), str(thing2)))


### PR DESCRIPTION
There is no way to only get real time notifications of transaction that affect the wallet.
You have to do that manually by enabling zmqrawtx and filter out transactions.

I'm suggesting adding two new publisers, both for hash and raw wallet transactions.

Also topic will indicate if transaction came from mempool or block so developers can handle the transaction accordingly without a RPC round trip to bitcoind.

Tests and documentation are updated.