### PR TITLE
[tests] various improvements to zmq_test.py

### DIFF
--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -78,7 +78,7 @@ BASE_SCRIPTS= [
     'rawtransactions.py',
     'reindex.py',
     # vv Tests less than 30s vv
-    "zmq_test.py",
+    'zmq_test.py',
     'mempool_resurrect_test.py',
     'txn_doublespend.py --mineblock',
     'txn_clone.py',

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -20,6 +20,7 @@ import datetime
 import os
 import time
 import shutil
+import signal
 import sys
 import subprocess
 import tempfile
@@ -389,6 +390,10 @@ class TestHandler:
             time.sleep(.5)
             for j in self.jobs:
                 (name, time0, proc, log_out, log_err) = j
+                if os.getenv('TRAVIS') == 'true' and int(time.time() - time0) > 20 * 60:
+                    # In travis, timeout individual tests after 20 minutes (to stop tests hanging and not
+                    # providing useful output.
+                    proc.send_signal(signal.SIGINT)
                 if proc.poll() is not None:
                     log_out.seek(0), log_err.seek(0)
                     [stdout, stderr] = [l.read().decode('utf-8') for l in (log_out, log_err)]

--- a/test/functional/zmq_test.py
+++ b/test/functional/zmq_test.py
@@ -8,15 +8,15 @@ import os
 import struct
 
 from test_framework.test_framework import BitcoinTestFramework, SkipTest
-from test_framework.util import *
+from test_framework.util import (assert_equal,
+                                 bytes_to_hex_str,
+                                 )
 
 class ZMQTest (BitcoinTestFramework):
 
     def __init__(self):
         super().__init__()
-        self.num_nodes = 4
-
-    port = 28332
+        self.num_nodes = 2
 
     def setup_nodes(self):
         # Try to import python3-zmq. Skip this test if the import fails.
@@ -38,57 +38,55 @@ class ZMQTest (BitcoinTestFramework):
         self.zmqSubSocket = self.zmqContext.socket(zmq.SUB)
         self.zmqSubSocket.setsockopt(zmq.SUBSCRIBE, b"hashblock")
         self.zmqSubSocket.setsockopt(zmq.SUBSCRIBE, b"hashtx")
-        self.zmqSubSocket.connect("tcp://127.0.0.1:%i" % self.port)
-        self.nodes = self.start_nodes(self.num_nodes, self.options.tmpdir, extra_args=[
-            ['-zmqpubhashtx=tcp://127.0.0.1:'+str(self.port), '-zmqpubhashblock=tcp://127.0.0.1:'+str(self.port)],
-            [],
-            [],
-            []
-            ])
+        ip_address = "tcp://127.0.0.1:28332"
+        self.zmqSubSocket.connect(ip_address)
+        extra_args = [['-zmqpubhashtx=%s' % ip_address, '-zmqpubhashblock=%s' % ip_address], []]
+        self.nodes = self.start_nodes(self.num_nodes, self.options.tmpdir, extra_args)
 
     def run_test(self):
-        self.sync_all()
-
         genhashes = self.nodes[0].generate(1)
         self.sync_all()
 
-        self.log.info("listen...")
+        self.log.info("Wait for tx")
         msg = self.zmqSubSocket.recv_multipart()
         topic = msg[0]
         assert_equal(topic, b"hashtx")
         body = msg[1]
         msgSequence = struct.unpack('<I', msg[-1])[-1]
-        assert_equal(msgSequence, 0) #must be sequence 0 on hashtx
+        assert_equal(msgSequence, 0)  # must be sequence 0 on hashtx
 
+        self.log.info("Wait for block")
         msg = self.zmqSubSocket.recv_multipart()
         topic = msg[0]
         body = msg[1]
         msgSequence = struct.unpack('<I', msg[-1])[-1]
-        assert_equal(msgSequence, 0) #must be sequence 0 on hashblock
+        assert_equal(msgSequence, 0)  # must be sequence 0 on hashblock
         blkhash = bytes_to_hex_str(body)
 
-        assert_equal(genhashes[0], blkhash) #blockhash from generate must be equal to the hash received over zmq
+        assert_equal(genhashes[0], blkhash)  # blockhash from generate must be equal to the hash received over zmq
 
+        self.log.info("Generate 10 blocks (and 10 coinbase txes)")
         n = 10
         genhashes = self.nodes[1].generate(n)
         self.sync_all()
 
         zmqHashes = []
         blockcount = 0
-        for x in range(0,n*2):
+        for x in range(n * 2):
             msg = self.zmqSubSocket.recv_multipart()
             topic = msg[0]
             body = msg[1]
             if topic == b"hashblock":
                 zmqHashes.append(bytes_to_hex_str(body))
                 msgSequence = struct.unpack('<I', msg[-1])[-1]
-                assert_equal(msgSequence, blockcount+1)
+                assert_equal(msgSequence, blockcount + 1)
                 blockcount += 1
 
-        for x in range(0,n):
-            assert_equal(genhashes[x], zmqHashes[x]) #blockhash from generate must be equal to the hash received over zmq
+        for x in range(n):
+            assert_equal(genhashes[x], zmqHashes[x])  # blockhash from generate must be equal to the hash received over zmq
 
-        #test tx from a second node
+        self.log.info("Wait for tx from second node")
+        # test tx from a second node
         hashRPC = self.nodes[1].sendtoaddress(self.nodes[0].getnewaddress(), 1.0)
         self.sync_all()
 
@@ -100,10 +98,9 @@ class ZMQTest (BitcoinTestFramework):
         if topic == b"hashtx":
             hashZMQ = bytes_to_hex_str(body)
             msgSequence = struct.unpack('<I', msg[-1])[-1]
-            assert_equal(msgSequence, blockcount+1)
+            assert_equal(msgSequence, blockcount + 1)
 
-        assert_equal(hashRPC, hashZMQ) #blockhash from generate must be equal to the hash received over zmq
-
+        assert_equal(hashRPC, hashZMQ)  # txid from sendtoaddress must be equal to the hash received over zmq
 
 if __name__ == '__main__':
-    ZMQTest ().main ()
+    ZMQTest().main()

--- a/test/functional/zmq_test.py
+++ b/test/functional/zmq_test.py
@@ -45,6 +45,14 @@ class ZMQTest (BitcoinTestFramework):
         self.nodes = self.start_nodes(self.num_nodes, self.options.tmpdir, extra_args)
 
     def run_test(self):
+        try:
+            self._zmq_test()
+        finally:
+            # Destroy the zmq context
+            self.log.debug("Destroying zmq context")
+            self.zmqContext.destroy(linger=None)
+
+    def _zmq_test(self):
         genhashes = self.nodes[0].generate(1)
         self.sync_all()
 

--- a/test/functional/zmq_test.py
+++ b/test/functional/zmq_test.py
@@ -36,6 +36,7 @@ class ZMQTest (BitcoinTestFramework):
 
         self.zmqContext = zmq.Context()
         self.zmqSubSocket = self.zmqContext.socket(zmq.SUB)
+        self.zmqSubSocket.set(zmq.RCVTIMEO, 60000)
         self.zmqSubSocket.setsockopt(zmq.SUBSCRIBE, b"hashblock")
         self.zmqSubSocket.setsockopt(zmq.SUBSCRIBE, b"hashtx")
         ip_address = "tcp://127.0.0.1:28332"
@@ -94,11 +95,10 @@ class ZMQTest (BitcoinTestFramework):
         msg = self.zmqSubSocket.recv_multipart()
         topic = msg[0]
         body = msg[1]
-        hashZMQ = ""
-        if topic == b"hashtx":
-            hashZMQ = bytes_to_hex_str(body)
-            msgSequence = struct.unpack('<I', msg[-1])[-1]
-            assert_equal(msgSequence, blockcount + 1)
+        assert_equal(topic, b"hashtx")
+        hashZMQ = bytes_to_hex_str(body)
+        msgSequence = struct.unpack('<I', msg[-1])[-1]
+        assert_equal(msgSequence, blockcount + 1)
 
         assert_equal(hashRPC, hashZMQ)  # txid from sendtoaddress must be equal to the hash received over zmq
 

--- a/test/functional/zmq_test.py
+++ b/test/functional/zmq_test.py
@@ -28,7 +28,7 @@ class ZMQTest (BitcoinTestFramework):
         # Check that bitcoin has been built with ZMQ enabled
         config = configparser.ConfigParser()
         if not self.options.configfile:
-            self.options.configfile = os.path.dirname(__file__) + "/config.ini"
+            self.options.configfile = os.path.dirname(__file__) + "/../config.ini"
         config.read_file(open(self.options.configfile))
 
         if not config["components"].getboolean("ENABLE_ZMQ"):


### PR DESCRIPTION
This PR contains various improvements to zmq_test.py, including stopping it from hanging and causing travis builds to time out. Individual commits are:

- update zmq test to use correct config.ini file - follows #10331, which moved the config.ini file from /bitcoin/test/functional to /bitcoin/test. zmq_test.py was not updated to find the config file in the correct location. This isn't a problem when running through test_runner.py, but would prevent zmq_test.py from being run directly.
- tidy up zmq_test.py - general code tidy-up. Cuts run time from ~12s to ~6s
- in zmq test, timeout if message not received - stops a race condition where we could try to receive a message on the zmq socket before it's been sent
- destroy zmq context in zmq_tests.py - fixes an issue where the  zmq contest would not be close properly at the end of the test, causing `sys.exit()` to fail. This would cause travis builds to hang. See https://stackoverflow.com/questions/17140417/termination-of-python-script-while-using-zeromq-with-dead-server for more details.
- timeout integration tests on travis after 20 minutes - causes travis builds to timeout individual tests if they run for more than 20 minutes. That means we'll get logs from hung tests, rather than travis itself timing out after ~50 minutes (in which case we don't get any useful diagnostics).

I need this for the next step of #10082, since this test was causing the next PR to hang in travis.

I believe this will also fix #10552 once that is rebased on top of this.