### PR TITLE
[docs] Use the "domain name setup" image (previously unused) in the gitian docs

### DIFF
--- a/doc/gitian-building.md
+++ b/doc/gitian-building.md
@@ -131,6 +131,7 @@ To select a different button, press `Tab`.
   - Leave domain name empty.
 
 ![](gitian-building/debian_install_5_configure_the_network.png)
+![](gitian-building/debian_install_6_domain_name.png)
 
 - Choose a root password and enter it twice (remember it for later)
 


### PR DESCRIPTION
Prior to this commit the file `debian_install_6_domain_name.png` was unused.