### PR TITLE
Remove unnecessary forward class declarations in header files

### DIFF
--- a/src/httprpc.h
+++ b/src/httprpc.h
@@ -8,8 +8,6 @@
 #include <string>
 #include <map>
 
-class HTTPRequest;
-
 /** Start HTTP RPC subsystem.
  * Precondition; HTTP and RPC has been started.
  */

--- a/src/miner.h
+++ b/src/miner.h
@@ -16,9 +16,7 @@
 
 class CBlockIndex;
 class CChainParams;
-class CReserveKey;
 class CScript;
-class CWallet;
 
 namespace Consensus { struct Params; };
 

--- a/src/net.h
+++ b/src/net.h
@@ -101,7 +101,6 @@ struct AddedNodeInfo
     bool fInbound;
 };
 
-class CTransaction;
 class CNodeStats;
 class CClientUIInterface;
 

--- a/src/qt/addressbookpage.h
+++ b/src/qt/addressbookpage.h
@@ -8,7 +8,6 @@
 #include <QDialog>
 
 class AddressTableModel;
-class OptionsModel;
 class PlatformStyle;
 
 namespace Ui {
@@ -20,7 +19,6 @@ class QItemSelection;
 class QMenu;
 class QModelIndex;
 class QSortFilterProxyModel;
-class QTableView;
 QT_END_NAMESPACE
 
 /** Widget that shows a list of sending or receiving addresses.

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -31,8 +31,6 @@ class WalletModel;
 class HelpMessageDialog;
 class ModalOverlay;
 
-class CWallet;
-
 QT_BEGIN_NAMESPACE
 class QAction;
 class QProgressBar;

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -10,13 +10,10 @@
 
 #include <atomic>
 
-class AddressTableModel;
 class BanTableModel;
 class OptionsModel;
 class PeerTableModel;
-class TransactionTableModel;
 
-class CWallet;
 class CBlockIndex;
 
 QT_BEGIN_NAMESPACE

--- a/src/qt/coincontroldialog.h
+++ b/src/qt/coincontroldialog.h
@@ -20,7 +20,6 @@ class PlatformStyle;
 class WalletModel;
 
 class CCoinControl;
-class CTxMemPool;
 
 namespace Ui {
     class CoinControlDialog;

--- a/src/qt/receivecoinsdialog.h
+++ b/src/qt/receivecoinsdialog.h
@@ -15,7 +15,6 @@
 #include <QPoint>
 #include <QVariant>
 
-class OptionsModel;
 class PlatformStyle;
 class WalletModel;
 

--- a/src/qt/sendcoinsdialog.h
+++ b/src/qt/sendcoinsdialog.h
@@ -13,7 +13,6 @@
 #include <QTimer>
 
 class ClientModel;
-class OptionsModel;
 class PlatformStyle;
 class SendCoinsEntry;
 class SendCoinsRecipient;

--- a/src/qt/utilitydialog.h
+++ b/src/qt/utilitydialog.h
@@ -9,7 +9,6 @@
 #include <QObject>
 
 class BitcoinGUI;
-class ClientModel;
 
 namespace Ui {
     class HelpMessageDialog;

--- a/src/rpc/blockchain.h
+++ b/src/rpc/blockchain.h
@@ -7,9 +7,6 @@
 
 class CBlock;
 class CBlockIndex;
-class CScript;
-class CTransaction;
-class uint256;
 class UniValue;
 
 /**

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -28,9 +28,6 @@ namespace RPCServer
     void OnPreCommand(std::function<void (const CRPCCommand&)> slot);
 }
 
-class CBlockIndex;
-class CNetAddr;
-
 /** Wrapper for UniValue::VType, which includes typeAny:
  * Used to denote don't care type. Only used by RPCTypeCheckObj */
 struct UniValueType {

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -28,7 +28,6 @@
 
 #include <boost/signals2/signal.hpp>
 
-class CAutoFile;
 class CBlockIndex;
 
 /** Fake height value used in Coin to signify they are only in the memory pool (since 0.8) */

--- a/src/ui_interface.h
+++ b/src/ui_interface.h
@@ -12,9 +12,7 @@
 #include <boost/signals2/last_value.hpp>
 #include <boost/signals2/signal.hpp>
 
-class CBasicKeyStore;
 class CWallet;
-class uint256;
 class CBlockIndex;
 
 /** General change type (added, updated, removed). */

--- a/src/validation.h
+++ b/src/validation.h
@@ -32,7 +32,6 @@
 
 class CBlockIndex;
 class CBlockTreeDB;
-class CBloomFilter;
 class CChainParams;
 class CCoinsViewDB;
 class CInv;
@@ -40,7 +39,6 @@ class CConnman;
 class CScriptCheck;
 class CBlockPolicyEstimator;
 class CTxMemPool;
-class CValidationInterface;
 class CValidationState;
 struct ChainTxData;
 

--- a/src/wallet/crypter.h
+++ b/src/wallet/crypter.h
@@ -9,8 +9,6 @@
 #include "serialize.h"
 #include "support/allocators/secure.h"
 
-class uint256;
-
 const unsigned int WALLET_CRYPTO_KEY_SIZE = 32;
 const unsigned int WALLET_CRYPTO_SALT_SIZE = 8;
 const unsigned int WALLET_CRYPTO_IV_SIZE = 16;


### PR DESCRIPTION
Remove unnecessary forward class declarations in header files. These are no longer needed.