### PR TITLE
Add missing include for atomic in db.h

### DIFF
--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -13,6 +13,7 @@
 #include "sync.h"
 #include "version.h"
 
+#include <atomic>
 #include <map>
 #include <string>
 #include <vector>


### PR DESCRIPTION
I was getting compile errors without this.