### PR TITLE
Prefer gpg2 to gpg

### DIFF
--- a/contrib/verify-commits/gpg.sh
+++ b/contrib/verify-commits/gpg.sh
@@ -9,7 +9,7 @@ REVSIG=false
 IFS='
 '
 if [ "$BITCOIN_VERIFY_COMMITS_ALLOW_SHA1" = 1 ]; then
-	GPG_RES="$(echo "$INPUT" | gpg --trust-model always "$@" 2>/dev/null)"
+	GPG_RES="$(echo "$INPUT" | "$GPG" --trust-model always "$@" 2>/dev/null)"
 else
 	# Note how we've disabled SHA1 with the --weak-digest option, disabling
 	# signatures - including selfsigs - that use SHA1. While you might think that
@@ -20,11 +20,11 @@ else
 	# they've created a collision for. Not the most likely attack, but preventing
 	# it is pretty easy so we do so as a "belt-and-suspenders" measure.
 	GPG_RES=""
-	for LINE in "$(gpg --version)"; do
+	for LINE in "$("$GPG" --version)"; do
 		case "$LINE" in
 			"gpg (GnuPG) 1.4.1"*|"gpg (GnuPG) 2.0."*)
-				echo "Please upgrade to at least gpg 2.1.10 to check for weak signatures" > /dev/stderr
-				GPG_RES="$(echo "$INPUT" | gpg --trust-model always "$@" 2>/dev/null)"
+				echo "Please upgrade to at least gpg 1.4.20 or 2.1.10 to check for weak signatures" > /dev/stderr
+				GPG_RES="$(echo "$INPUT" | "$GPG" --trust-model always "$@" 2>/dev/null)"
 				;;
 			# We assume if you're running 2.1+, you're probably running 2.1.10+
 			# gpg will fail otherwise
@@ -32,7 +32,7 @@ else
 			# gpg will fail otherwise
 		esac
 	done
-	[ "$GPG_RES" = "" ] && GPG_RES="$(echo "$INPUT" | gpg --trust-model always --weak-digest sha1 "$@" 2>/dev/null)"
+	[ "$GPG_RES" = "" ] && GPG_RES="$(echo "$INPUT" | "$GPG" --trust-model always --weak-digest sha1 "$@" 2>/dev/null)"
 fi
 for LINE in $(echo "$GPG_RES"); do
 	case "$LINE" in
@@ -52,8 +52,8 @@ if ! $VALID; then
 	exit 1
 fi
 if $VALID && $REVSIG; then
-	echo "$INPUT" | gpg --trust-model always "$@" 2>/dev/null | grep "\[GNUPG:\] \(NEWSIG\|SIG_ID\|VALIDSIG\)"
+	echo "$INPUT" | "$GPG" --trust-model always "$@" 2>/dev/null | grep "\[GNUPG:\] \(NEWSIG\|SIG_ID\|VALIDSIG\)"
 	echo "$GOODREVSIG"
 else
-	echo "$INPUT" | gpg --trust-model always "$@" 2>/dev/null
+	echo "$INPUT" | "$GPG" --trust-model always "$@" 2>/dev/null
 fi

--- a/contrib/verify-commits/verify-commits.sh
+++ b/contrib/verify-commits/verify-commits.sh
@@ -17,6 +17,12 @@ HAVE_FAILED=false
 HAVE_GNU_SHA512=1
 [ ! -x "$(which sha512sum)" ] && HAVE_GNU_SHA512=0
 
+GPG=$(git config gpg.program)
+if [ x"$GPG" = "x" ]; then
+	GPG=gpg
+fi
+export GPG
+
 if [ x"$1" = "x" ]; then
 	CURRENT_COMMIT="HEAD"
 else


### PR DESCRIPTION
Many distributions (like Debian, Ubuntu LTS or Fedora) installs gpg 2.x as gpg2,
so prefer gpg2 when available

Moreover add gpg 1.4.20 to warning message since it supports --weak-digest