### PR TITLE
[tests] make pruning.py faster

### DIFF
--- a/test/functional/blockchain.py
+++ b/test/functional/blockchain.py
@@ -139,13 +139,13 @@ class BlockchainTest(BitcoinTestFramework):
         self.nodes[0].generate(6)
         assert_equal(self.nodes[0].getblockcount(), 206)
         self.log.debug('Node should not stop at this height')
-        assert_raises(subprocess.TimeoutExpired, lambda: self.bitcoind_processes[0].wait(timeout=3))
+        assert_raises(subprocess.TimeoutExpired, lambda: self.nodes[0].process.wait(timeout=3))
         try:
             self.nodes[0].generate(1)
         except (ConnectionError, http.client.BadStatusLine):
             pass  # The node already shut down before response
         self.log.debug('Node should stop at this height...')
-        self.bitcoind_processes[0].wait(timeout=BITCOIND_PROC_WAIT_TIMEOUT)
+        self.nodes[0].process.wait(timeout=BITCOIND_PROC_WAIT_TIMEOUT)
         self.nodes[0] = self.start_node(0, self.options.tmpdir)
         assert_equal(self.nodes[0].getblockcount(), 207)
 

--- a/test/functional/bumpfee.py
+++ b/test/functional/bumpfee.py
@@ -41,8 +41,7 @@ class BumpFeeTest(BitcoinTestFramework):
         self.nodes = self.start_nodes(self.num_nodes, self.options.tmpdir, extra_args)
 
         # Encrypt wallet for test_locked_wallet_fails test
-        self.nodes[1].encryptwallet(WALLET_PASSPHRASE)
-        self.bitcoind_processes[1].wait()
+        self.nodes[1].node_encrypt_wallet(WALLET_PASSPHRASE)
         self.nodes[1] = self.start_node(1, self.options.tmpdir, extra_args[1])
         self.nodes[1].walletpassphrase(WALLET_PASSPHRASE, WALLET_PASSPHRASE_TIMEOUT)
 

--- a/test/functional/fundrawtransaction.py
+++ b/test/functional/fundrawtransaction.py
@@ -451,8 +451,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.stop_node(0)
         self.stop_node(2)
         self.stop_node(3)
-        self.nodes[1].encryptwallet("test")
-        self.bitcoind_processes[1].wait(timeout=BITCOIND_PROC_WAIT_TIMEOUT)
+        self.nodes[1].node_encrypt_wallet("test")
 
         self.nodes = self.start_nodes(self.num_nodes, self.options.tmpdir)
         # This test is not meant to test fee estimation and we'd like

--- a/test/functional/getblocktemplate_longpoll.py
+++ b/test/functional/getblocktemplate_longpoll.py
@@ -17,7 +17,7 @@ class LongpollThread(threading.Thread):
         self.longpollid = templat['longpollid']
         # create a new connection to the node, we can't use the same
         # connection from two threads
-        self.node = get_rpc_proxy(node.url, 1, timeout=600)
+        self.node = get_rpc_proxy(node.url, 1, timeout=600, coveragedir=node.coverage_dir)
 
     def run(self):
         self.node.getblocktemplate({'longpollid':self.longpollid})

--- a/test/functional/keypool.py
+++ b/test/functional/keypool.py
@@ -17,8 +17,7 @@ class KeyPoolTest(BitcoinTestFramework):
         assert(addr_before_encrypting_data['hdmasterkeyid'] == wallet_info_old['hdmasterkeyid'])
         
         # Encrypt wallet and wait to terminate
-        nodes[0].encryptwallet('test')
-        self.bitcoind_processes[0].wait()
+        nodes[0].node_encrypt_wallet('test')
         # Restart node 0
         nodes[0] = self.start_node(0, self.options.tmpdir)
         # Keep creating keys

--- a/test/functional/rpcbind_test.py
+++ b/test/functional/rpcbind_test.py
@@ -37,7 +37,7 @@ class RPCBindTest(BitcoinTestFramework):
             base_args += ['-rpcallowip=' + x for x in allow_ips]
         binds = ['-rpcbind='+addr for addr in addresses]
         self.nodes = self.start_nodes(self.num_nodes, self.options.tmpdir, [base_args + binds], connect_to)
-        pid = self.bitcoind_processes[0].pid
+        pid = self.nodes[0].process.pid
         assert_equal(set(get_bind_addrs(pid)), set(expected))
         self.stop_nodes()
 
@@ -49,7 +49,7 @@ class RPCBindTest(BitcoinTestFramework):
         base_args = ['-disablewallet', '-nolisten'] + ['-rpcallowip='+x for x in allow_ips]
         self.nodes = self.start_nodes(self.num_nodes, self.options.tmpdir, [base_args])
         # connect to node through non-loopback interface
-        node = get_rpc_proxy(rpc_url(get_datadir_path(self.options.tmpdir, 0), 0, "%s:%d" % (rpchost, rpcport)), 0)
+        node = get_rpc_proxy(rpc_url(get_datadir_path(self.options.tmpdir, 0), 0, "%s:%d" % (rpchost, rpcport)), 0, coveragedir=self.options.coveragedir)
         node.getnetworkinfo()
         self.stop_nodes()
 

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -5,14 +5,11 @@
 """Base class for RPC testing."""
 
 from collections import deque
-import errno
 from enum import Enum
-import http.client
 import logging
 import optparse
 import os
 import shutil
-import subprocess
 import sys
 import tempfile
 import time
@@ -20,6 +17,7 @@ import traceback
 
 from .authproxy import JSONRPCException
 from . import coverage
+from .test_node import TestNode
 from .util import (
     MAX_NODES,
     PortSeed,
@@ -27,12 +25,9 @@ from .util import (
     check_json_precision,
     connect_nodes_bi,
     disconnect_nodes,
-    get_rpc_proxy,
     initialize_datadir,
-    get_datadir_path,
     log_filename,
     p2p_port,
-    rpc_url,
     set_node_times,
     sync_blocks,
     sync_mempools,
@@ -69,7 +64,6 @@ class BitcoinTestFramework(object):
         self.num_nodes = 4
         self.setup_clean_chain = False
         self.nodes = []
-        self.bitcoind_processes = {}
         self.mocktime = 0
 
     def add_options(self, parser):
@@ -203,67 +197,60 @@ class BitcoinTestFramework(object):
 
     # Public helper methods. These can be accessed by the subclass test scripts.
 
-    def start_node(self, i, dirname, extra_args=None, rpchost=None, timewait=None, binary=None, stderr=None):
+    def start_node(self, i, dirname, extra_args=[], rpchost=None, timewait=None, binary=None, stderr=None):
         """Start a bitcoind and return RPC connection to it"""
 
-        datadir = os.path.join(dirname, "node" + str(i))
         if binary is None:
             binary = os.getenv("BITCOIND", "bitcoind")
-        args = [binary, "-datadir=" + datadir, "-server", "-keypool=1", "-discover=0", "-rest", "-logtimemicros", "-debug", "-debugexclude=libevent", "-debugexclude=leveldb", "-mocktime=" + str(self.mocktime), "-uacomment=testnode%d" % i]
-        if extra_args is not None:
-            args.extend(extra_args)
-        self.bitcoind_processes[i] = subprocess.Popen(args, stderr=stderr)
-        self.log.debug("initialize_chain: bitcoind started, waiting for RPC to come up")
-        self._wait_for_bitcoind_start(self.bitcoind_processes[i], datadir, i, rpchost)
-        self.log.debug("initialize_chain: RPC successfully started")
-        proxy = get_rpc_proxy(rpc_url(datadir, i, rpchost), i, timeout=timewait)
+        node = TestNode(i, dirname, extra_args, rpchost, timewait, binary, stderr, self.mocktime, coverage_dir=self.options.coveragedir)
+        node.start()
+        node.wait_for_rpc_connection()
 
-        if self.options.coveragedir:
-            coverage.write_all_rpc_commands(self.options.coveragedir, proxy)
+        if self.options.coveragedir is not None:
+            coverage.write_all_rpc_commands(self.options.coveragedir, node.rpc)
 
-        return proxy
+        return node
 
     def start_nodes(self, num_nodes, dirname, extra_args=None, rpchost=None, timewait=None, binary=None):
         """Start multiple bitcoinds, return RPC connections to them"""
 
         if extra_args is None:
-            extra_args = [None] * num_nodes
+            extra_args = [[]] * num_nodes
         if binary is None:
             binary = [None] * num_nodes
         assert_equal(len(extra_args), num_nodes)
         assert_equal(len(binary), num_nodes)
-        rpcs = []
+        nodes = []
         try:
             for i in range(num_nodes):
-                rpcs.append(self.start_node(i, dirname, extra_args[i], rpchost, timewait=timewait, binary=binary[i]))
+                nodes.append(TestNode(i, dirname, extra_args[i], rpchost, timewait=timewait, binary=binary[i], stderr=None, mocktime=self.mocktime, coverage_dir=self.options.coveragedir))
+                nodes[i].start()
+            for node in nodes:
+                node.wait_for_rpc_connection()
         except:
             # If one node failed to start, stop the others
-            # TODO: abusing self.nodes in this way is a little hacky.
-            # Eventually we should do a better job of tracking nodes
-            self.nodes.extend(rpcs)
             self.stop_nodes()
-            self.nodes = []
             raise
-        return rpcs
+
+        if self.options.coveragedir is not None:
+            coverage.write_all_rpc_commands(self.options.coveragedir, node.rpc)
+
+        return nodes
 
     def stop_node(self, i):
         """Stop a bitcoind test node"""
-
-        self.log.debug("Stopping node %d" % i)
-        try:
-            self.nodes[i].stop()
-        except http.client.CannotSendRequest as e:
-            self.log.exception("Unable to stop node")
-        return_code = self.bitcoind_processes[i].wait(timeout=BITCOIND_PROC_WAIT_TIMEOUT)
-        del self.bitcoind_processes[i]
-        assert_equal(return_code, 0)
+        self.nodes[i].stop_node()
+        while not self.nodes[i].is_node_stopped():
+            time.sleep(0.1)
 
     def stop_nodes(self):
         """Stop multiple bitcoind test nodes"""
-
-        for i in range(len(self.nodes)):
-            self.stop_node(i)
-        assert not self.bitcoind_processes.values()  # All connections must be gone now
+        for node in self.nodes:
+            node.stop_node()
+        # All connections must be gone now
+        for node in self.nodes:
+            while not node.is_node_stopped():
+                time.sleep(0.1)
 
     def assert_start_raises_init_error(self, i, dirname, extra_args=None, expected_msg=None):
         with tempfile.SpooledTemporaryFile(max_size=2**16) as log_stderr:
@@ -272,6 +259,8 @@ class BitcoinTestFramework(object):
                 self.stop_node(i)
             except Exception as e:
                 assert 'bitcoind exited' in str(e)  # node must have shutdown
+                self.nodes[i].running = False
+                self.nodes[i].process = None
                 if expected_msg is not None:
                     log_stderr.seek(0)
                     stderr = log_stderr.read().decode('utf-8')
@@ -285,7 +274,7 @@ class BitcoinTestFramework(object):
                 raise AssertionError(assert_msg)
 
     def wait_for_node_exit(self, i, timeout):
-        self.bitcoind_processes[i].wait(timeout)
+        self.nodes[i].process.wait(timeout)
 
     def split_network(self):
         """
@@ -382,18 +371,13 @@ class BitcoinTestFramework(object):
                 args = [os.getenv("BITCOIND", "bitcoind"), "-server", "-keypool=1", "-datadir=" + datadir, "-discover=0"]
                 if i > 0:
                     args.append("-connect=127.0.0.1:" + str(p2p_port(0)))
-                self.bitcoind_processes[i] = subprocess.Popen(args)
-                self.log.debug("initialize_chain: bitcoind started, waiting for RPC to come up")
-                self._wait_for_bitcoind_start(self.bitcoind_processes[i], datadir, i)
-                self.log.debug("initialize_chain: RPC successfully started")
+                self.nodes.append(TestNode(i, cachedir, extra_args=[], rpchost=None, timewait=None, binary=None, stderr=None, mocktime=self.mocktime, coverage_dir=None))
+                self.nodes[i].args = args
+                self.nodes[i].start()
 
-            self.nodes = []
-            for i in range(MAX_NODES):
-                try:
-                    self.nodes.append(get_rpc_proxy(rpc_url(get_datadir_path(cachedir, i), i), i))
-                except:
-                    self.log.exception("Error connecting to node %d" % i)
-                    sys.exit(1)
+            # Wait for RPC connections to be ready
+            for node in self.nodes:
+                node.wait_for_rpc_connection()
 
             # Create a 200-block-long chain; each of the 4 first nodes
             # gets 25 mature blocks and 25 immature.
@@ -436,30 +420,6 @@ class BitcoinTestFramework(object):
         Useful if a test case wants complete control over initialization."""
         for i in range(num_nodes):
             initialize_datadir(test_dir, i)
-
-    def _wait_for_bitcoind_start(self, process, datadir, i, rpchost=None):
-        """Wait for bitcoind to start.
-
-        This means that RPC is accessible and fully initialized.
-        Raise an exception if bitcoind exits during initialization."""
-        while True:
-            if process.poll() is not None:
-                raise Exception('bitcoind exited with status %i during initialization' % process.returncode)
-            try:
-                # Check if .cookie file to be created
-                rpc = get_rpc_proxy(rpc_url(datadir, i, rpchost), i, coveragedir=self.options.coveragedir)
-                rpc.getblockcount()
-                break  # break out of loop on success
-            except IOError as e:
-                if e.errno != errno.ECONNREFUSED:  # Port not yet open?
-                    raise  # unknown IO error
-            except JSONRPCException as e:  # Initialization phase
-                if e.error['code'] != -28:  # RPC in warmup?
-                    raise  # unknown JSON RPC exception
-            except ValueError as e:  # cookie file not found and no rpcuser or rpcassword. bitcoind still starting
-                if "No RPC credentials" not in str(e):
-                    raise
-            time.sleep(0.25)
 
 class ComparisonTestFramework(BitcoinTestFramework):
     """Test framework for doing p2p comparison testing

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Class for bitcoind node under test"""
+
+import errno
+import http.client
+import logging
+import os
+import subprocess
+import time
+
+from .util import (
+    assert_equal,
+    get_rpc_proxy,
+    rpc_url,
+)
+from .authproxy import JSONRPCException
+
+class TestNode():
+    """A class for representing a bitcoind node under test.
+
+    This class contains:
+
+    - state about the node (whether it's running, etc)
+    - a Python subprocess.Popen object representing the running process
+    - an RPC connection to the node
+
+    To make things easier for the test writer, a bit of magic is happening under the covers.
+    Any unrecognised messages will be dispatched to the RPC connection."""
+
+    def __init__(self, i, dirname, extra_args, rpchost, timewait, binary, stderr, mocktime, coverage_dir):
+        self.index = i
+        self.datadir = os.path.join(dirname, "node" + str(i))
+        self.rpchost = rpchost
+        self.rpc_timeout = timewait
+        if binary is None:
+            self.binary = os.getenv("BITCOIND", "bitcoind")
+        else:
+            self.binary = binary
+        self.stderr = stderr
+        self.coverage_dir = coverage_dir
+        # Most callers will just need to add extra args to the standard list below. For those callers that need more flexibity, they can just set the args property directly.
+        self.extra_args = extra_args
+        self.args = [self.binary, "-datadir=" + self.datadir, "-server", "-keypool=1", "-discover=0", "-rest", "-logtimemicros", "-debug", "-debugexclude=libevent", "-debugexclude=leveldb", "-mocktime=" + str(mocktime), "-uacomment=testnode%d" % i]
+
+        self.running = False
+        self.process = None
+        self.rpc_connected = False
+        self.rpc = None
+        self.url = None
+        self.log = logging.getLogger('TestFramework.node%d' % i)
+
+    def __getattr__(self, *args, **kwargs):
+        """Dispatches any unrecognised messages to the RPC connection."""
+        assert self.rpc_connected and self.rpc is not None, "Error: no RPC connection"
+        return self.rpc.__getattr__(*args, **kwargs)
+
+    def start(self):
+        """Start the node."""
+        # import pdb; pdb.set_trace()
+        self.process = subprocess.Popen(self.args + self.extra_args, stderr=self.stderr)
+        self.running = True
+        self.log.debug("bitcoind started, waiting for RPC to come up")
+
+    def wait_for_rpc_connection(self):
+        """Sets up an RPC connection to the bitcoind process. Returns False if unable to connect."""
+
+        attempts = 40
+        while attempts > 0:
+            assert not self.process.poll(), "bitcoind exited with status %i during initialization" % self.process.returncode
+            try:
+                self.rpc = get_rpc_proxy(rpc_url(self.datadir, self.index, self.rpchost), self.index)
+                self.rpc.getblockcount()
+                # If the call to getblockcount() succeeds then the RPC connection is up
+                self.rpc_connected = True
+                self.url = self.rpc.url
+                self.log.debug("RPC successfully started")
+                return True
+            except IOError as e:
+                if e.errno != errno.ECONNREFUSED:  # Port not yet open?
+                    raise  # unknown IO error
+            except JSONRPCException as e:  # Initialization phase
+                if e.error['code'] != -28:  # RPC in warmup?
+                    raise  # unknown JSON RPC exception
+            except ValueError as e:  # cookie file not found and no rpcuser or rpcassword. bitcoind still starting
+                if "No RPC credentials" not in str(e):
+                    raise
+            time.sleep(0.25)
+            attempts -= 1
+        raise AssertionError("Unable to connect to bitcoind")
+
+    def stop_node(self):
+        """Stop the node."""
+        if not self.running:
+            return
+        self.log.debug("Stopping node")
+        try:
+            self.stop()
+        except http.client.CannotSendRequest as e:
+            self.log.exception("Unable to stop node.")
+
+    def is_node_stopped(self):
+        """Checks whether the node has stopped.
+
+        Returns True if the node has stopped. False otherwise.
+        This method is responsible for freeing resources (self.process)."""
+        if not self.running:
+            return True
+        return_code = self.process.poll()
+        if return_code is not None:
+            # process has stopped. Assert that it didn't return an error code.
+            assert_equal(return_code, 0)
+            self.running = False
+            self.process = None
+            self.log.debug("Node stopped")
+            return True
+        return False
+
+    def node_encrypt_wallet(self, passphrase):
+        """"Encrypts the wallet.
+
+        This causes bitcoind to shutdown, so this method takes
+        care of cleaning up resources."""
+        self.encryptwallet(passphrase)
+        while not self.is_node_stopped():
+            time.sleep(0.1)
+        self.rpc = None
+        self.rpc_connected = False

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -204,7 +204,7 @@ def rpc_port(n):
     return PORT_MIN + PORT_RANGE + n + (MAX_NODES * PortSeed.n) % (PORT_RANGE - 1 - MAX_NODES)
 
 def rpc_url(datadir, i, rpchost=None):
-    rpc_u, rpc_p = get_auth_cookie(datadir, i)
+    rpc_u, rpc_p = get_auth_cookie(datadir)
     host = '127.0.0.1'
     port = rpc_port(i)
     if rpchost:
@@ -232,7 +232,7 @@ def initialize_datadir(dirname, n):
 def get_datadir_path(dirname, n):
     return os.path.join(dirname, "node" + str(n))
 
-def get_auth_cookie(datadir, n):
+def get_auth_cookie(datadir):
     user = None
     password = None
     if os.path.isfile(os.path.join(datadir, "bitcoin.conf")):
@@ -244,6 +244,7 @@ def get_auth_cookie(datadir, n):
                 if line.startswith("rpcpassword="):
                     assert password is None  # Ensure that there is only one rpcpassword line
                     password = line.split("=")[1].strip("\n")
+    # print(os.path.join(datadir, "regtest", ".cookie"))
     if os.path.isfile(os.path.join(datadir, "regtest", ".cookie")):
         with open(os.path.join(datadir, "regtest", ".cookie"), 'r') as f:
             userpass = f.read()

--- a/test/functional/wallet-dump.py
+++ b/test/functional/wallet-dump.py
@@ -94,8 +94,7 @@ class WalletDumpTest(BitcoinTestFramework):
         assert_equal(found_addr_rsv, 90*2) # 90 keys plus 100% internal keys
 
         #encrypt wallet, restart, unlock and dump
-        self.nodes[0].encryptwallet('test')
-        self.bitcoind_processes[0].wait()
+        self.nodes[0].node_encrypt_wallet('test')
         self.nodes[0] = self.start_node(0, self.options.tmpdir, self.extra_args[0])
         self.nodes[0].walletpassphrase('test', 10)
         # Should be a no-op:

--- a/test/functional/wallet-encryption.py
+++ b/test/functional/wallet-encryption.py
@@ -30,8 +30,7 @@ class WalletEncryptionTest(BitcoinTestFramework):
         assert_equal(len(privkey), 52)
 
         # Encrypt the wallet
-        self.nodes[0].encryptwallet(passphrase)
-        self.bitcoind_processes[0].wait(timeout=BITCOIND_PROC_WAIT_TIMEOUT)
+        self.nodes[0].node_encrypt_wallet(passphrase)
         self.nodes[0] = self.start_node(0, self.options.tmpdir)
 
         # Test that the wallet is encrypted


### PR DESCRIPTION
Headline: Brings time for pruning.py down to ~4 minutes on my VM when run without other tests in parallel.

A couple of modifications to make pruning.py much faster:

- pruning.py doesn't care what kind of transactions make up the big blocks that are pruned in the test. Instead of making blocks with several large, expensive to construct and validate transactions, instead make the large blocks contain a single coinbase transaction with a huge OP_RETURN txout.
- avoid stop-starting nodes where possible.

Builds on top of #10555 and #10556 

My VM has slow disk i/o. This would possibly be faster with faster disk i/o. Unfortunately, pruning.py still isn't able to run on Travis. It appears that disk access is very slow for in the Travis environment, and this test still times out/fails. Unfortunately, it's not possible to run this test without very heavy disk access - the whole point of pruning is to remove block files when disk usage goes over a certain threshold.

I'd be interested to know how this affects runtime for others.

@sdaftuar 