### PR TITLE
Bugfix: net: Apply whitelisting criteria to outgoing connections

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -404,7 +404,7 @@ std::string HelpMessage(HelpMessageMode mode)
 #endif
 #endif
     strUsage += HelpMessageOpt("-whitebind=<addr>", _("Bind to given address and whitelist peers connecting to it. Use [host]:port notation for IPv6"));
-    strUsage += HelpMessageOpt("-whitelist=<IP address or network>", _("Whitelist peers connecting from the given IP address (e.g. 1.2.3.4) or CIDR notated network (e.g. 1.2.3.0/24). Can be specified multiple times.") +
+    strUsage += HelpMessageOpt("-whitelist=<IP address or network>", _("Whitelist peers using the given IP address (e.g. 1.2.3.4) or CIDR notated network (e.g. 1.2.3.0/24). Can be specified multiple times.") +
         " " + _("Whitelisted peers cannot be DoS banned and their transactions are always relayed, even if they are already in the mempool, useful e.g. for a gateway"));
     strUsage += HelpMessageOpt("-maxuploadtarget=<n>", strprintf(_("Tries to keep outbound traffic under the given target (in MiB per 24h), 0 = no limit (default: %d)"), DEFAULT_MAX_UPLOAD_TARGET));
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1990,6 +1990,9 @@ bool CConnman::OpenNetworkConnection(const CAddress& addrConnect, bool fCountFai
         pnode->fFeeler = true;
     if (manual_connection)
         pnode->m_manual_connection = true;
+    if (IsWhitelistedRange(pnode->addr)) {
+        pnode->fWhitelisted = true;
+    }
 
     m_msgproc->InitializeNode(pnode);
     {

--- a/src/net.h
+++ b/src/net.h
@@ -373,7 +373,7 @@ private:
     uint64_t nMaxOutboundLimit;
     uint64_t nMaxOutboundTimeframe;
 
-    // Whitelisted ranges. Any node connecting from these is automatically
+    // Whitelisted ranges. Any node communicating using these is automatically
     // whitelisted (as well as those connecting to whitelisted binds).
     std::vector<CSubNet> vWhitelistedRange;
 


### PR DESCRIPTION
Whitelisting currently only works for inbound connections, but would be useful for outgoing just as well.