### PR TITLE
Supress struct/class mismatch warnings introduced in #10284

### DIFF
--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -77,7 +77,7 @@ class CScheduler;
 class CTxMemPool;
 class CBlockPolicyEstimator;
 class CWalletTx;
-class FeeCalculation;
+struct FeeCalculation;
 
 /** (client) version numbers for particular wallet features */
 enum WalletFeature


### PR DESCRIPTION
Fixes
```
In file included from init.cpp:46:
./wallet/wallet.h:80:1: warning: class 'FeeCalculation' was previously declared as a struct [-Wmismatched-tags]
class FeeCalculation;
^
./policy/fees.h:113:8: note: previous use is here
struct FeeCalculation
       ^
./wallet/wallet.h:80:1: note: did you mean struct here?
class FeeCalculation;
^~~~~
struct
1 warning generated.
```