### PR TITLE
Make feebumper class stateless

### DIFF
--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -666,14 +666,14 @@ bool WalletModel::transactionCanBeBumped(uint256 hash) const
 
 bool WalletModel::bumpFee(uint256 hash)
 {
-    std::unique_ptr<FeeBumper> feeBump;
+    std::unique_ptr<feebumper::FeeBumper> feeBump;
     {
         CCoinControl coin_control;
         coin_control.signalRbf = true;
         LOCK2(cs_main, wallet->cs_wallet);
-        feeBump.reset(new FeeBumper(wallet, hash, coin_control, 0));
+        feeBump.reset(new feebumper::FeeBumper(wallet, hash, coin_control, 0));
     }
-    if (feeBump->getResult() != BumpFeeResult::OK)
+    if (feeBump->getResult() != feebumper::Result::OK)
     {
         QMessageBox::critical(0, tr("Fee bump error"), tr("Increasing transaction fee failed") + "<br />(" +
             (feeBump->getErrors().size() ? QString::fromStdString(feeBump->getErrors()[0]) : "") +")");

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -659,45 +659,39 @@ bool WalletModel::abandonTransaction(uint256 hash) const
 
 bool WalletModel::transactionCanBeBumped(uint256 hash) const
 {
-    LOCK2(cs_main, wallet->cs_wallet);
-    const CWalletTx *wtx = wallet->GetWalletTx(hash);
-    return wtx && SignalsOptInRBF(*(wtx->tx)) && !wtx->mapValue.count("replaced_by_txid");
+    return feebumper::TransactionCanBeBumped(wallet, hash);
 }
 
 bool WalletModel::bumpFee(uint256 hash)
 {
-    std::unique_ptr<feebumper::FeeBumper> feeBump;
-    {
-        CCoinControl coin_control;
-        coin_control.signalRbf = true;
-        LOCK2(cs_main, wallet->cs_wallet);
-        feeBump.reset(new feebumper::FeeBumper(wallet, hash, coin_control, 0));
-    }
-    if (feeBump->getResult() != feebumper::Result::OK)
-    {
+    CCoinControl coin_control;
+    coin_control.signalRbf = true;
+    std::vector<std::string> errors;
+    CAmount old_fee;
+    CAmount new_fee;
+    CMutableTransaction mtx;
+    if (feebumper::CreateTransaction(wallet, hash, coin_control, 0 /* totalFee */, errors, old_fee, new_fee, mtx) != feebumper::Result::OK) {
         QMessageBox::critical(0, tr("Fee bump error"), tr("Increasing transaction fee failed") + "<br />(" +
-            (feeBump->getErrors().size() ? QString::fromStdString(feeBump->getErrors()[0]) : "") +")");
+            (errors.size() ? QString::fromStdString(errors[0]) : "") +")");
          return false;
     }
 
     // allow a user based fee verification
     QString questionString = tr("Do you want to increase the fee?");
     questionString.append("<br />");
-    CAmount oldFee = feeBump->getOldFee();
-    CAmount newFee = feeBump->getNewFee();
     questionString.append("<table style=\"text-align: left;\">");
     questionString.append("<tr><td>");
     questionString.append(tr("Current fee:"));
     questionString.append("</td><td>");
-    questionString.append(BitcoinUnits::formatHtmlWithUnit(getOptionsModel()->getDisplayUnit(), oldFee));
+    questionString.append(BitcoinUnits::formatHtmlWithUnit(getOptionsModel()->getDisplayUnit(), old_fee));
     questionString.append("</td></tr><tr><td>");
     questionString.append(tr("Increase:"));
     questionString.append("</td><td>");
-    questionString.append(BitcoinUnits::formatHtmlWithUnit(getOptionsModel()->getDisplayUnit(), newFee - oldFee));
+    questionString.append(BitcoinUnits::formatHtmlWithUnit(getOptionsModel()->getDisplayUnit(), new_fee - old_fee));
     questionString.append("</td></tr><tr><td>");
     questionString.append(tr("New fee:"));
     questionString.append("</td><td>");
-    questionString.append(BitcoinUnits::formatHtmlWithUnit(getOptionsModel()->getDisplayUnit(), newFee));
+    questionString.append(BitcoinUnits::formatHtmlWithUnit(getOptionsModel()->getDisplayUnit(), new_fee));
     questionString.append("</td></tr></table>");
     SendConfirmationDialog confirmationDialog(tr("Confirm fee bump"), questionString);
     confirmationDialog.exec();
@@ -715,23 +709,15 @@ bool WalletModel::bumpFee(uint256 hash)
     }
 
     // sign bumped transaction
-    bool res = false;
-    {
-        LOCK2(cs_main, wallet->cs_wallet);
-        res = feeBump->signTransaction(wallet);
-    }
-    if (!res) {
+    if (!feebumper::SignTransaction(wallet, mtx)) {
         QMessageBox::critical(0, tr("Fee bump error"), tr("Can't sign transaction."));
         return false;
     }
     // commit the bumped transaction
-    {
-        LOCK2(cs_main, wallet->cs_wallet);
-        res = feeBump->commit(wallet);
-    }
-    if(!res) {
+    uint256 txid;
+    if (feebumper::CommitTransaction(wallet, hash, std::move(mtx), errors, txid) != feebumper::Result::OK) {
         QMessageBox::critical(0, tr("Fee bump error"), tr("Could not commit transaction") + "<br />(" +
-            QString::fromStdString(feeBump->getErrors()[0])+")");
+            QString::fromStdString(errors[0])+")");
          return false;
     }
     return true;

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -666,12 +666,12 @@ bool WalletModel::transactionCanBeBumped(uint256 hash) const
 
 bool WalletModel::bumpFee(uint256 hash)
 {
-    std::unique_ptr<CFeeBumper> feeBump;
+    std::unique_ptr<FeeBumper> feeBump;
     {
         CCoinControl coin_control;
         coin_control.signalRbf = true;
         LOCK2(cs_main, wallet->cs_wallet);
-        feeBump.reset(new CFeeBumper(wallet, hash, coin_control, 0));
+        feeBump.reset(new FeeBumper(wallet, hash, coin_control, 0));
     }
     if (feeBump->getResult() != BumpFeeResult::OK)
     {

--- a/src/wallet/feebumper.h
+++ b/src/wallet/feebumper.h
@@ -23,39 +23,39 @@ enum class BumpFeeResult
     MISC_ERROR,
 };
 
-class CFeeBumper
+class FeeBumper
 {
 public:
-    CFeeBumper(const CWallet *pWalletIn, const uint256 txidIn, const CCoinControl& coin_control, CAmount totalFee);
-    BumpFeeResult getResult() const { return currentResult; }
-    const std::vector<std::string>& getErrors() const { return vErrors; }
-    CAmount getOldFee() const { return nOldFee; }
-    CAmount getNewFee() const { return nNewFee; }
-    uint256 getBumpedTxId() const { return bumpedTxid; }
+    FeeBumper(const CWallet *wallet, const uint256 txid_in, const CCoinControl& coin_control, CAmount total_fee);
+    BumpFeeResult getResult() const { return current_result; }
+    const std::vector<std::string>& getErrors() const { return errors; }
+    CAmount getOldFee() const { return old_fee; }
+    CAmount getNewFee() const { return new_fee; }
+    uint256 getBumpedTxId() const { return bumped_txid; }
 
     /* signs the new transaction,
      * returns false if the tx couldn't be found or if it was
      * impossible to create the signature(s)
      */
-    bool signTransaction(CWallet *pWallet);
+    bool signTransaction(CWallet *wallet);
 
     /* commits the fee bump,
      * returns true, in case of CWallet::CommitTransaction was successful
-     * but, eventually sets vErrors if the tx could not be added to the mempool (will try later)
+     * but, eventually sets errors if the tx could not be added to the mempool (will try later)
      * or if the old transaction could not be marked as replaced
      */
-    bool commit(CWallet *pWalletNonConst);
+    bool commit(CWallet *wallet);
 
 private:
-    bool preconditionChecks(const CWallet *pWallet, const CWalletTx& wtx);
+    bool preconditionChecks(const CWallet *wallet, const CWalletTx& wtx);
 
     const uint256 txid;
-    uint256 bumpedTxid;
+    uint256 bumped_txid;
     CMutableTransaction mtx;
-    std::vector<std::string> vErrors;
-    BumpFeeResult currentResult;
-    CAmount nOldFee;
-    CAmount nNewFee;
+    std::vector<std::string> errors;
+    BumpFeeResult current_result;
+    CAmount old_fee;
+    CAmount new_fee;
 };
 
 #endif // BITCOIN_WALLET_FEEBUMPER_H

--- a/src/wallet/feebumper.h
+++ b/src/wallet/feebumper.h
@@ -13,7 +13,9 @@ class uint256;
 class CCoinControl;
 enum class FeeEstimateMode;
 
-enum class BumpFeeResult
+namespace feebumper {
+
+enum class Result
 {
     OK,
     INVALID_ADDRESS_OR_KEY,
@@ -27,7 +29,7 @@ class FeeBumper
 {
 public:
     FeeBumper(const CWallet *wallet, const uint256 txid_in, const CCoinControl& coin_control, CAmount total_fee);
-    BumpFeeResult getResult() const { return current_result; }
+    Result getResult() const { return current_result; }
     const std::vector<std::string>& getErrors() const { return errors; }
     CAmount getOldFee() const { return old_fee; }
     CAmount getNewFee() const { return new_fee; }
@@ -53,9 +55,11 @@ private:
     uint256 bumped_txid;
     CMutableTransaction mtx;
     std::vector<std::string> errors;
-    BumpFeeResult current_result;
+    Result current_result;
     CAmount old_fee;
     CAmount new_fee;
 };
+
+} // namespace feebumper
 
 #endif // BITCOIN_WALLET_FEEBUMPER_H

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3125,45 +3125,50 @@ UniValue bumpfee(const JSONRPCRequest& request)
     LOCK2(cs_main, pwallet->cs_wallet);
     EnsureWalletIsUnlocked(pwallet);
 
-    feebumper::FeeBumper feeBump(pwallet, hash, coin_control, totalFee);
-    feebumper::Result res = feeBump.getResult();
-    if (res != feebumper::Result::OK)
-    {
+
+    std::vector<std::string> errors;
+    CAmount old_fee;
+    CAmount new_fee;
+    CMutableTransaction mtx;
+    feebumper::Result res = feebumper::CreateTransaction(pwallet, hash, coin_control, totalFee, errors, old_fee, new_fee, mtx);
+    if (res != feebumper::Result::OK) {
         switch(res) {
             case feebumper::Result::INVALID_ADDRESS_OR_KEY:
-                throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, feeBump.getErrors()[0]);
+                throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, errors[0]);
                 break;
             case feebumper::Result::INVALID_REQUEST:
-                throw JSONRPCError(RPC_INVALID_REQUEST, feeBump.getErrors()[0]);
+                throw JSONRPCError(RPC_INVALID_REQUEST, errors[0]);
                 break;
             case feebumper::Result::INVALID_PARAMETER:
-                throw JSONRPCError(RPC_INVALID_PARAMETER, feeBump.getErrors()[0]);
+                throw JSONRPCError(RPC_INVALID_PARAMETER, errors[0]);
                 break;
             case feebumper::Result::WALLET_ERROR:
-                throw JSONRPCError(RPC_WALLET_ERROR, feeBump.getErrors()[0]);
+                throw JSONRPCError(RPC_WALLET_ERROR, errors[0]);
                 break;
             default:
-                throw JSONRPCError(RPC_MISC_ERROR, feeBump.getErrors()[0]);
+                throw JSONRPCError(RPC_MISC_ERROR, errors[0]);
                 break;
         }
     }
 
     // sign bumped transaction
-    if (!feeBump.signTransaction(pwallet)) {
+    if (!feebumper::SignTransaction(pwallet, mtx)) {
         throw JSONRPCError(RPC_WALLET_ERROR, "Can't sign transaction.");
     }
     // commit the bumped transaction
-    if(!feeBump.commit(pwallet)) {
-        throw JSONRPCError(RPC_WALLET_ERROR, feeBump.getErrors()[0]);
+    uint256 txid;
+    if (feebumper::CommitTransaction(pwallet, hash, std::move(mtx), errors, txid) != feebumper::Result::OK) {
+        throw JSONRPCError(RPC_WALLET_ERROR, errors[0]);
     }
     UniValue result(UniValue::VOBJ);
-    result.push_back(Pair("txid", feeBump.getBumpedTxId().GetHex()));
-    result.push_back(Pair("origfee", ValueFromAmount(feeBump.getOldFee())));
-    result.push_back(Pair("fee", ValueFromAmount(feeBump.getNewFee())));
-    UniValue errors(UniValue::VARR);
-    for (const std::string& err: feeBump.getErrors())
-        errors.push_back(err);
-    result.push_back(Pair("errors", errors));
+    result.push_back(Pair("txid", txid.GetHex()));
+    result.push_back(Pair("origfee", ValueFromAmount(old_fee)));
+    result.push_back(Pair("fee", ValueFromAmount(new_fee)));
+    UniValue result_errors(UniValue::VARR);
+    for (const std::string& error : errors) {
+        result_errors.push_back(error);
+    }
+    result.push_back(Pair("errors", result_errors));
 
     return result;
 }

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3125,21 +3125,21 @@ UniValue bumpfee(const JSONRPCRequest& request)
     LOCK2(cs_main, pwallet->cs_wallet);
     EnsureWalletIsUnlocked(pwallet);
 
-    FeeBumper feeBump(pwallet, hash, coin_control, totalFee);
-    BumpFeeResult res = feeBump.getResult();
-    if (res != BumpFeeResult::OK)
+    feebumper::FeeBumper feeBump(pwallet, hash, coin_control, totalFee);
+    feebumper::Result res = feeBump.getResult();
+    if (res != feebumper::Result::OK)
     {
         switch(res) {
-            case BumpFeeResult::INVALID_ADDRESS_OR_KEY:
+            case feebumper::Result::INVALID_ADDRESS_OR_KEY:
                 throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, feeBump.getErrors()[0]);
                 break;
-            case BumpFeeResult::INVALID_REQUEST:
+            case feebumper::Result::INVALID_REQUEST:
                 throw JSONRPCError(RPC_INVALID_REQUEST, feeBump.getErrors()[0]);
                 break;
-            case BumpFeeResult::INVALID_PARAMETER:
+            case feebumper::Result::INVALID_PARAMETER:
                 throw JSONRPCError(RPC_INVALID_PARAMETER, feeBump.getErrors()[0]);
                 break;
-            case BumpFeeResult::WALLET_ERROR:
+            case feebumper::Result::WALLET_ERROR:
                 throw JSONRPCError(RPC_WALLET_ERROR, feeBump.getErrors()[0]);
                 break;
             default:

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3125,7 +3125,7 @@ UniValue bumpfee(const JSONRPCRequest& request)
     LOCK2(cs_main, pwallet->cs_wallet);
     EnsureWalletIsUnlocked(pwallet);
 
-    CFeeBumper feeBump(pwallet, hash, coin_control, totalFee);
+    FeeBumper feeBump(pwallet, hash, coin_control, totalFee);
     BumpFeeResult res = feeBump.getResult();
     if (res != BumpFeeResult::OK)
     {


### PR DESCRIPTION
Make feebumper methods static and remove stored state in the class.

Having the results of feebumper calls persist in an object makes process
separation between Qt and wallet awkward, because it means the feebumper object
either has to be serialized back and forth between Qt and wallet processes
between fee bump calls, or that the feebumper object needs to stay alive in the
wallet process with an object reference passed back to Qt. It's simpler just to
have fee bumper calls return their results immediately instead of storing them
in an object with an extended lifetime.

In addition to making feebumper methods static, also:

- Move LOCK calls from Qt code to feebumper
- Move TransactionCanBeBumped implementation from Qt code to feebumper
- Rename CFeeBumper class to FeeBumper (every CFeeBumper reference had to be
  updated in this PR anyway so this doesn't increase the size of the diff)

This change was originally part of https://github.com/bitcoin/bitcoin/pull/10244