### PR TITLE
Make clang-format use C++11 features (e.g. A<A<int>> instead of A<A<int> >)

### DIFF
--- a/src/.clang-format
+++ b/src/.clang-format
@@ -47,6 +47,6 @@ SpacesInAngles:  false
 SpacesInContainerLiterals: true
 SpacesInCStyleCastParentheses: false
 SpacesInParentheses: false
-Standard:        Cpp03
+Standard:        Cpp11
 TabWidth:        8
 UseTab:          Never


### PR DESCRIPTION
Make `clang-format` use C++11 features (e.g. `A<A<int>>` instead of `A<A<int> >`).