### PR TITLE
[rpc]Avoid possibility of NULL pointer dereference in getblockchaininfo(...)

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1165,6 +1165,7 @@ UniValue getblockchaininfo(const JSONRPCRequest& request)
             + HelpExampleRpc("getblockchaininfo", "")
         );
 
+    assert(chainActive.Tip() && "An empty blockchain should not be possible here.");
     LOCK(cs_main);
 
     UniValue obj(UniValue::VOBJ);
@@ -1196,6 +1197,7 @@ UniValue getblockchaininfo(const JSONRPCRequest& request)
         while (block && block->pprev && (block->pprev->nStatus & BLOCK_HAVE_DATA))
             block = block->pprev;
 
+        assert(block && "An empty blockchain should not be possible here.");
         obj.push_back(Pair("pruneheight",        block->nHeight));
     }
     return obj;


### PR DESCRIPTION
The variable `block` is initialized by the return value of Tip() which may be NULL.
The while loop condition takes this into account and checks for nullness before dereferencing.
If Tip() returns null, the while loop is never executed and the null pointer is dereferenced right after ( `block->nHeight`)

With this fix, there is a single check for nullness of `block`.
A `JSONRPCError` is thrown in this case.
After that, `block` is only assigned non-null values. 

The code `block->nHeight` is never executed if block is NULL.
The while loop condition is also simplified.