### PR TITLE
[wallet] Use fixed pubkey during wallet init for default key

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3066,6 +3066,7 @@ const std::string& CWallet::GetAccountName(const CScript& scriptPubKey) const
 
 bool CWallet::SetDefaultKey(const CPubKey &vchPubKey)
 {
+    assert(vchPubKey.IsFullyValid());
     if (!CWalletDB(*dbw).WriteDefaultKey(vchPubKey))
         return false;
     vchDefaultKey = vchPubKey;
@@ -3852,14 +3853,9 @@ CWallet* CWallet::CreateWalletFromFile(const std::string walletFile)
             if (!walletInstance->SetHDMasterKey(masterPubKey))
                 throw std::runtime_error(std::string(__func__) + ": Storing master key failed");
         }
-        CPubKey newDefaultKey;
-        if (walletInstance->GetKeyFromPool(newDefaultKey, false)) {
-            walletInstance->SetDefaultKey(newDefaultKey);
-            if (!walletInstance->SetAddressBook(walletInstance->vchDefaultKey.GetID(), "", "receive")) {
-                InitError(_("Cannot write default address") += "\n");
-                return NULL;
-            }
-        }
+        // Constant key for legacy purposes to mark the wallet as initialized.
+        CPubKey newDefaultKey(ParseHex("037cf8657dd81f60d83afb03168b5a7c024fa174c5c11540b6413c2d39e807c5c6"));
+        walletInstance->SetDefaultKey(newDefaultKey);
 
         walletInstance->SetBestChain(chainActive.GetLocator());
     }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -807,6 +807,7 @@ public:
 
     std::map<CTxDestination, CAddressBookData> mapAddressBook;
 
+    // Legacy method of marking wallet as initialized when IsFullyValid()
     CPubKey vchDefaultKey;
 
     std::set<COutPoint> setLockedCoins;

--- a/test/functional/wallet-hd.py
+++ b/test/functional/wallet-hd.py
@@ -56,7 +56,7 @@ class WalletHDTest(BitcoinTestFramework):
         for i in range(num_hd_adds):
             hd_add = self.nodes[1].getnewaddress()
             hd_info = self.nodes[1].validateaddress(hd_add)
-            assert_equal(hd_info["hdkeypath"], "m/0'/0'/"+str(i+1)+"'")
+            assert_equal(hd_info["hdkeypath"], "m/0'/0'/"+str(i)+"'")
             assert_equal(hd_info["hdmasterkeyid"], masterkeyid)
             self.nodes[0].sendtoaddress(hd_add, 1)
             self.nodes[0].generate(1)
@@ -83,7 +83,7 @@ class WalletHDTest(BitcoinTestFramework):
         for _ in range(num_hd_adds):
             hd_add_2 = self.nodes[1].getnewaddress()
             hd_info_2 = self.nodes[1].validateaddress(hd_add_2)
-            assert_equal(hd_info_2["hdkeypath"], "m/0'/0'/"+str(_+1)+"'")
+            assert_equal(hd_info_2["hdkeypath"], "m/0'/0'/"+str(_)+"'")
             assert_equal(hd_info_2["hdmasterkeyid"], masterkeyid)
         assert_equal(hd_add, hd_add_2)
 


### PR DESCRIPTION
vchDefaultKey is not used anymore except to mark a
wallet as initialized during LoadWallet. Instead of
taking a key from the keypool and adding to the wallet
simply use a fixed key that is valid, for backwards
compability.

This allows wallets to return `m/..../0` keys first with `getnewaddress`, being slightly less surprising to the user, as well as giving the meaning behind having a key loaded to the wallet.

Key was chosen via smashing keyboard for entropy.