### PR TITLE
[depends] expat 2.2.1

### DIFF
--- a/depends/packages/expat.mk
+++ b/depends/packages/expat.mk
@@ -1,8 +1,8 @@
 package=expat
-$(package)_version=2.2.0
+$(package)_version=2.2.1
 $(package)_download_path=https://downloads.sourceforge.net/project/expat/expat/$($(package)_version)
 $(package)_file_name=$(package)-$($(package)_version).tar.bz2
-$(package)_sha256_hash=d9e50ff2d19b3538bd2127902a89987474e1a4db8e43a66a4d1a712ab9a504ff
+$(package)_sha256_hash=1868cadae4c82a018e361e2b2091de103cd820aaacb0d6cfa49bd2cd83978885
 
 define $(package)_set_vars
 $(package)_config_opts=--disable-static


### PR DESCRIPTION
Full changelog available [here](https://github.com/libexpat/libexpat/blob/master/expat/Changes#L16).

CVE-2017-9233 -- External entity infinite loop DoS. Details: https://libexpat.github.io/doc/cve-2017-9233/
CVE-2016-9063 -- Detect integer overflow; (Fixed version of existing downstream patches!)
Fix regression from fix to CVE-2016-0718 cutting off longer tag names;
Detect overflow from len=INT_MAX call to XML_Parse;

libexpat is moving to GitHub, however downloads remain on SF for now.


