### PR TITLE
[qa] util: Check return code after closing bitcoind proc

### DIFF
--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -300,8 +300,8 @@ def _stop_node(node, i):
     except http.client.CannotSendRequest as e:
         logger.exception("Unable to stop node")
     return_code = bitcoind_processes[i].wait(timeout=BITCOIND_PROC_WAIT_TIMEOUT)
-    assert_equal(return_code, 0)
     del bitcoind_processes[i]
+    assert_equal(return_code, 0)
 
 def _stop_nodes(nodes):
     """Stop multiple bitcoind test nodes


### PR DESCRIPTION
Just a minor cleanup.

This has no effect on the outcome of test cases, but
prints shorter and less confusing tracebacks on fails.

I.e. does not print an obvious "ConnectionRefusedError"
when shutting down the nodes due to an invalid return code.