### PR TITLE
rpc: Clarify pblock assumption via an assertion

### DIFF
--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -526,6 +526,7 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
         pindexPrev = pindexPrevNew;
     }
     CBlock* pblock = &pblocktemplate->block; // pointer for convenience
+    assert(pblock);
     const Consensus::Params& consensusParams = Params().GetConsensus();
 
     // Update nTime


### PR DESCRIPTION
`pblock->nNonce = 0` will result in a `nullptr` dereference if the added assertion does not hold true.

`pblock != nullptr` is not obvious from reading the code - hence the need for stating this assumption explicitly via an assertion. This has the added benefit getting rid of the following `clang-tidy` warning:

```
rpc/mining.cpp:560:20: note: Access to field 'nNonce' results in
  a dereference of a null pointer (loaded from variable 'pblock')
    pblock->nNonce = 0;
```