### PR TITLE
Remove obsolete _MSC_VER check

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -844,8 +844,6 @@ bool AppInitBasicSetup()
     // Turn off Microsoft heap dump noise
     _CrtSetReportMode(_CRT_WARN, _CRTDBG_MODE_FILE);
     _CrtSetReportFile(_CRT_WARN, CreateFileA("NUL", GENERIC_WRITE, 0, NULL, OPEN_EXISTING, 0, 0));
-#endif
-#if _MSC_VER >= 1400
     // Disable confusing "helpful" text message on abort, Ctrl-C
     _set_abort_behavior(0, _WRITE_ABORT_MSG | _CALL_REPORTFAULT);
 #endif


### PR DESCRIPTION
Prior to this commit the `_MSC_VER` macro was being used regardless of being defined due to a misplaced `#endif`.