### PR TITLE
Make sure we only mine via the first wallet

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3476,6 +3476,15 @@ void CWallet::GetAllReserveKeys(std::set<CKeyID>& setAddress) const
 
 void CWallet::GetScriptForMining(std::shared_ptr<CReserveScript> &script)
 {
+    // make sure we only mine via the first wallet
+    // otherwise the used wallet is undefined (depends on the signal registration order)
+    // TODO: allow to pass the via generate/setgenerate used wallet to the signal
+    {
+        LOCK2(cs_main, cs_wallet);
+        if (vpwallets.empty() /* should never be empty at this point */ || vpwallets[0] != this) {
+            return;
+        }
+    }
     std::shared_ptr<CReserveKey> rKey = std::make_shared<CReserveKey>(this);
     CPubKey pubkey;
     if (!rKey->GetReservedKey(pubkey))


### PR DESCRIPTION
If one used `generate` while running with multiple wallets `-wallet=file1.dat wallet=file2.dat` the wallet used for the coinbase script is pretty undefined (or lets say weak defined, it's probably always the last one).

This PR is a quick fix (should be okay for the internal miner) to ensure we always use the first wallet for `generate | setgenerate`.

Ideally, someone works on passing the endpoint (coming soon) down to the signal listener.