### PR TITLE
Simple, backwards compatible RPC multiwallet support (superseded by #10829)

### DIFF
--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -456,6 +456,11 @@ static inline JSONRPCRequest transformNamedArguments(const JSONRPCRequest& in, c
             hole += 1;
         }
     }
+    auto wallet = argsIn.find("wallet");
+    if (wallet != argsIn.end() && wallet->second->isStr()) {
+        out.wallet = wallet->second->getValStr();
+        argsIn.erase(wallet);
+    }
     // If there are still arguments in the argsIn map, this is an error.
     if (!argsIn.empty()) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Unknown named parameter " + argsIn.begin()->first);

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -42,10 +42,24 @@ class JSONRPCRequest
 public:
     UniValue id;
     std::string strMethod;
+    /**
+     * Parameters from JSON-RPC request.
+     * This will be either an object or an array when the JSONRPCRequest object is
+     * originally created and parsed. But it will be transformed into an
+     * array before being passed to the RPC method implementation (using the
+     * list of named arguments provided by the implementation).
+     */
     UniValue params;
     bool fHelp;
     std::string URI;
     std::string authUser;
+
+    /**
+     * Optional wallet name, set for backwards compatibility if the RPC method
+     * was called with a named "wallet" parameter and the RPC method
+     * implementation doesn't handle it itself.
+     */
+    std::string wallet;
 
     JSONRPCRequest() : id(NullUniValue), params(NullUniValue), fHelp(false) {}
     void parse(const UniValue& valRequest);

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -31,7 +31,14 @@
 
 CWallet *GetWalletForJSONRPCRequest(const JSONRPCRequest& request)
 {
-    // TODO: Some way to access secondary wallets
+    if (!request.wallet.empty()) {
+        for (const auto& wallet : ::vpwallets) {
+            if (request.wallet == wallet->GetName()) {
+                return wallet;
+            }
+        }
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Requested wallet does not exist or is not loaded");
+    }
     return vpwallets.empty() ? nullptr : vpwallets[0];
 }
 


### PR DESCRIPTION
**This PR is superseded by #10829** 

(This got closed and couldn't be reopened because the branch pointer changed.)

---

This change allows existing RPCs to work on multiple wallets by calling those
RPCs with a wallet=filename named argument. Example usage:

    bitcoind -regtest -wallet=w1.dat -wallet=w2.dat
    bitcoin-cli -regtest -named getwalletinfo wallet=w1.dat
    bitcoin-cli -regtest -named getwalletinfo wallet=w2.dat
    bitcoin-cli -regtest -named getbalance wallet=w2.dat

Individual RPCs can override handling of the wallet named argument, but if they
don't, the `GetWalletForJSONRPCRequest` function will automatically chose the
right wallet based on the argument value.

This change only allows JSON-RPC calls made with named arguments to access
multiple wallets. JSON-RPC calls made with positional arguments will still
continue to access the default wallet like before.