### PR TITLE
Allow to cancel the txdb upgrade via splashscreen keypress 'q'

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1358,7 +1358,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
     LogPrintf("* Using %.1fMiB for in-memory UTXO set (plus up to %.1fMiB of unused mempool space)\n", nCoinCacheUsage * (1.0 / 1024 / 1024), nMempoolSizeMax * (1.0 / 1024 / 1024));
 
     bool fLoaded = false;
-    while (!fLoaded) {
+    while (!fLoaded && !fRequestShutdown) {
         bool fReset = fReindex;
         std::string strLoadError;
 
@@ -1389,6 +1389,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
                         break;
                     }
                 }
+                if (fRequestShutdown) break;
 
                 if (!LoadBlockIndex(chainparams)) {
                     strLoadError = _("Error loading block database");
@@ -1466,7 +1467,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
             fLoaded = true;
         } while(false);
 
-        if (!fLoaded) {
+        if (!fLoaded && !fRequestShutdown) {
             // first suggest a reindex
             if (!fReset) {
                 bool fRet = uiInterface.ThreadSafeQuestion(

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -578,6 +578,7 @@ int main(int argc, char *argv[])
     //   Need to pass name here as CAmount is a typedef (see http://qt-project.org/doc/qt-5/qmetatype.html#qRegisterMetaType)
     //   IMPORTANT if it is no longer a typedef use the normal variant above
     qRegisterMetaType< CAmount >("CAmount");
+    qRegisterMetaType< std::function<void(void)> >("std::function<void(void)>");
 
     /// 3. Application identification
     // must be set before OptionsModel is initialized or translations are loaded,

--- a/src/qt/splashscreen.cpp
+++ b/src/qt/splashscreen.cpp
@@ -131,11 +131,22 @@ SplashScreen::SplashScreen(Qt::WindowFlags f, const NetworkStyle *networkStyle) 
     move(QApplication::desktop()->screenGeometry().center() - r.center());
 
     subscribeToCoreSignals();
+    installEventFilter(this);
 }
 
 SplashScreen::~SplashScreen()
 {
     unsubscribeFromCoreSignals();
+}
+
+bool SplashScreen::eventFilter(QObject * obj, QEvent * ev) {
+    if (ev->type() == QEvent::KeyPress) {
+        QKeyEvent *keyEvent = static_cast<QKeyEvent *>(ev);
+        if(keyEvent->text()[0] == 'q' && breakAction != nullptr) {
+            breakAction();
+        }
+    }
+    return QObject::eventFilter(obj, ev);
 }
 
 void SplashScreen::slotFinish(QWidget *mainWin)
@@ -164,6 +175,18 @@ static void ShowProgress(SplashScreen *splash, const std::string &title, int nPr
     InitMessage(splash, title + strprintf("%d", nProgress) + "%");
 }
 
+void SplashScreen::setBreakAction(const std::function<void(void)> &action)
+{
+    breakAction = action;
+}
+
+static void SetProgressBreakAction(SplashScreen *splash, const std::function<void(void)> &action)
+{
+    QMetaObject::invokeMethod(splash, "setBreakAction",
+        Qt::QueuedConnection,
+        Q_ARG(std::function<void(void)>, action));
+}
+
 #ifdef ENABLE_WALLET
 void SplashScreen::ConnectWallet(CWallet* wallet)
 {
@@ -177,6 +200,7 @@ void SplashScreen::subscribeToCoreSignals()
     // Connect signals to client
     uiInterface.InitMessage.connect(boost::bind(InitMessage, this, _1));
     uiInterface.ShowProgress.connect(boost::bind(ShowProgress, this, _1, _2));
+    uiInterface.SetProgressBreakAction.connect(boost::bind(SetProgressBreakAction, this, _1));
 #ifdef ENABLE_WALLET
     uiInterface.LoadWallet.connect(boost::bind(&SplashScreen::ConnectWallet, this, _1));
 #endif

--- a/src/qt/splashscreen.h
+++ b/src/qt/splashscreen.h
@@ -5,6 +5,7 @@
 #ifndef BITCOIN_QT_SPLASHSCREEN_H
 #define BITCOIN_QT_SPLASHSCREEN_H
 
+#include <functional>
 #include <QSplashScreen>
 
 class CWallet;
@@ -35,6 +36,11 @@ public Q_SLOTS:
     /** Show message and progress */
     void showMessage(const QString &message, int alignment, const QColor &color);
 
+    /** Sets the break action */
+    void setBreakAction(const std::function<void(void)> &action);
+protected:
+    bool eventFilter(QObject * obj, QEvent * ev);
+
 private:
     /** Connect core signals to splash screen */
     void subscribeToCoreSignals();
@@ -49,6 +55,8 @@ private:
     int curAlignment;
 
     QList<CWallet*> connectedWallets;
+
+    std::function<void(void)> breakAction;
 };
 
 #endif // BITCOIN_QT_SPLASHSCREEN_H

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -369,7 +369,8 @@ bool CCoinsViewDB::Upgrade() {
     }
 
     int64_t count = 0;
-    LogPrintf("Upgrading database...\n");
+    LogPrintf("Upgrading utxo-set database...\n");
+    LogPrintf("[0%%]...");
     size_t batch_size = 1 << 24;
     CDBBatch batch(db);
     uiInterface.SetProgressBreakAction(StartShutdown);
@@ -383,6 +384,7 @@ bool CCoinsViewDB::Upgrade() {
             if (count++ % 256 == 0) {
                 uint32_t high = 0x100 * *key.second.begin() + *(key.second.begin() + 1);
                 uiInterface.ShowProgress(_("Upgrading UTXO database") + "\n"+ _("(press q to shutdown and continue later)") + "\n", (int)(high * 100.0 / 65536.0 + 0.5));
+                LogPrintf("[%d%%]...", (int)(high * 100.0 / 65536.0 + 0.5));
             }
             CCoins old_coins;
             if (!pcursor->GetValue(old_coins)) {
@@ -409,5 +411,6 @@ bool CCoinsViewDB::Upgrade() {
     }
     db.WriteBatch(batch);
     uiInterface.SetProgressBreakAction(std::function<void(void)>());
+    LogPrintf("[DONE].\n");
     return true;
 }

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -371,6 +371,9 @@ bool CCoinsViewDB::Upgrade() {
     CDBBatch batch(db);
     while (pcursor->Valid()) {
         boost::this_thread::interruption_point();
+        if (ShutdownRequested()) {
+            break;
+        }
         std::pair<unsigned char, uint256> key;
         if (pcursor->GetKey(key) && key.first == DB_COINS) {
             CCoins old_coins;

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -374,6 +374,7 @@ bool CCoinsViewDB::Upgrade() {
     size_t batch_size = 1 << 24;
     CDBBatch batch(db);
     uiInterface.SetProgressBreakAction(StartShutdown);
+    int reportDone = 0;
     while (pcursor->Valid()) {
         boost::this_thread::interruption_point();
         if (ShutdownRequested()) {
@@ -383,8 +384,13 @@ bool CCoinsViewDB::Upgrade() {
         if (pcursor->GetKey(key) && key.first == DB_COINS) {
             if (count++ % 256 == 0) {
                 uint32_t high = 0x100 * *key.second.begin() + *(key.second.begin() + 1);
-                uiInterface.ShowProgress(_("Upgrading UTXO database") + "\n"+ _("(press q to shutdown and continue later)") + "\n", (int)(high * 100.0 / 65536.0 + 0.5));
-                LogPrintf("[%d%%]...", (int)(high * 100.0 / 65536.0 + 0.5));
+                int percentageDone = (int)(high * 100.0 / 65536.0 + 0.5);
+                uiInterface.ShowProgress(_("Upgrading UTXO database") + "\n"+ _("(press q to shutdown and continue later)") + "\n", percentageDone);
+                if (reportDone < percentageDone/10) {
+                    // report max. every 10% step
+                    LogPrintf("[%d%%]...", percentageDone);
+                    reportDone = percentageDone/10;
+                }
             }
             CCoins old_coins;
             if (!pcursor->GetValue(old_coins)) {

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -417,6 +417,6 @@ bool CCoinsViewDB::Upgrade() {
     }
     db.WriteBatch(batch);
     uiInterface.SetProgressBreakAction(std::function<void(void)>());
-    LogPrintf("[DONE].\n");
+    LogPrintf("[%s].\n", ShutdownRequested() ? "CANCELLED" : "DONE");
     return true;
 }

--- a/src/ui_interface.h
+++ b/src/ui_interface.h
@@ -97,6 +97,9 @@ public:
     /** Show progress e.g. for verifychain */
     boost::signals2::signal<void (const std::string &title, int nProgress)> ShowProgress;
 
+    /** Set progress break action (possible "cancel button" triggers that action) */
+    boost::signals2::signal<void (std::function<void(void)> action)> SetProgressBreakAction;
+
     /** New block has been accepted */
     boost::signals2::signal<void (bool, const CBlockIndex *)> NotifyBlockTip;
 


### PR DESCRIPTION
Progress calc credit: @sipa

This PR will accomplish three things:
* Show the progress of the UTXO-db upgrade in the Qt splashscreen and in the debug log:
  * `2017-06-23 07:49:55 Upgrading utxo-set database...`
  * `2017-06-23 07:49:55 [0%]...[0%]...[13%]...[25%]...[39%]...[52%]...[63%]...[76%]...[90%]...[DONE].`
* Allow to shutdown during the UTXO-db upgrade (ctrl-c, Qt quit)
* Allow to press `q` in splash screen to shutdown.

Let me explain why keypress instead of buttons:
The current splash screen is a drawn pixmap. Adding buttons there will require a complete re-design of the splashscreen (should be done once). It should be an auto-resizing QWidget as used in the other layout situations.

For getting a UTXO-upgrade abort into 0.15, this solution may be acceptable.