### PR TITLE
Initialize randomness in benchmarks

### DIFF
--- a/src/bench/bench_bitcoin.cpp
+++ b/src/bench/bench_bitcoin.cpp
@@ -7,10 +7,12 @@
 #include "key.h"
 #include "validation.h"
 #include "util.h"
+#include "random.h"
 
 int
 main(int argc, char** argv)
 {
+    RandomInit();
     ECC_Start();
     SetupEnvironment();
     fPrintToDebugLog = false; // don't want to write to debug.log file


### PR DESCRIPTION
Call RandomInit() in bench_bitcoin to initialize the RNG so that it does not cause an assertion error.