### PR TITLE
Pow: Introduce MaybeGenerateProof

### DIFF
--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -89,3 +89,16 @@ bool CheckProofOfWork(uint256 hash, unsigned int nBits, const Consensus::Params&
 
     return true;
 }
+
+bool MaybeGenerateProof(const Consensus::Params& params, CBlockHeader* pblock, uint64_t& max_tries)
+{
+    static const int nInnerLoopCount = 0x10000;
+    while (max_tries > 0 && pblock->nNonce < nInnerLoopCount) {
+        if (CheckProofOfWork(pblock->GetHash(), pblock->nBits, params)) {
+            return true;
+        }
+        ++pblock->nNonce;
+        --max_tries;
+    }
+    return false;
+}

--- a/src/pow.h
+++ b/src/pow.h
@@ -19,5 +19,6 @@ unsigned int CalculateNextWorkRequired(const CBlockIndex* pindexLast, int64_t nF
 
 /** Check whether a block hash satisfies the proof-of-work requirement specified by nBits */
 bool CheckProofOfWork(uint256 hash, unsigned int nBits, const Consensus::Params&);
+bool MaybeGenerateProof(const Consensus::Params& params, CBlockHeader* pblock, uint64_t& max_tries);
 
 #endif // BITCOIN_POW_H

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -105,7 +105,6 @@ UniValue getnetworkhashps(const JSONRPCRequest& request)
 
 UniValue generateBlocks(std::shared_ptr<CReserveScript> coinbaseScript, int nGenerate, uint64_t nMaxTries, bool keepScript)
 {
-    static const int nInnerLoopCount = 0x10000;
     int nHeightEnd = 0;
     int nHeight = 0;
 
@@ -126,15 +125,12 @@ UniValue generateBlocks(std::shared_ptr<CReserveScript> coinbaseScript, int nGen
             LOCK(cs_main);
             IncrementExtraNonce(pblock, chainActive.Tip(), nExtraNonce);
         }
-        while (nMaxTries > 0 && pblock->nNonce < nInnerLoopCount && !CheckProofOfWork(pblock->GetHash(), pblock->nBits, Params().GetConsensus())) {
-            ++pblock->nNonce;
-            --nMaxTries;
-        }
-        if (nMaxTries == 0) {
-            break;
-        }
-        if (pblock->nNonce == nInnerLoopCount) {
-            continue;
+        if (!MaybeGenerateProof(Params().GetConsensus(), pblock, nMaxTries)) {
+            if (nMaxTries == 0) {
+                break;
+            } else {
+                continue;
+            }
         }
         std::shared_ptr<const CBlock> shared_pblock = std::make_shared<const CBlock>(*pblock);
         if (!ProcessNewBlock(Params(), shared_pblock, true, nullptr))


### PR DESCRIPTION
This simplifies generateBlocks and further encapsulates the use of nNonce and nBits inside pow.o by introducing a new function MaybeGenerateProof.

This should be helpful for any attempt to support a testnet with signed blocks (see #9177 )