### PR TITLE
[qt] Avoid potential null pointer dereference in TransactionView::exportClicked()

### DIFF
--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -336,6 +336,10 @@ void TransactionView::changedAmount(const QString &amount)
 
 void TransactionView::exportClicked()
 {
+    if (!model || !model->getOptionsModel()) {
+        return;
+    }
+
     // CSV is currently the only supported format
     QString filename = GUIUtil::getSaveFileName(this,
         tr("Export Transaction History"), QString(),


### PR DESCRIPTION
Avoid potential null pointer dereference in `TransactionView::exportClicked()`.

Issue introduced in commit 8969828d069e4e55108618a493749535edc12ec7.