### PR TITLE
Remove no longer used mempool.exists(outpoint)

### DIFF
--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -618,13 +618,6 @@ public:
         return (mapTx.count(hash) != 0);
     }
 
-    bool exists(const COutPoint& outpoint) const
-    {
-        LOCK(cs);
-        auto it = mapTx.find(outpoint.hash);
-        return (it != mapTx.end() && outpoint.n < it->GetTx().vout.size());
-    }
-
     CTransactionRef get(const uint256& hash) const;
     TxMempoolInfo info(const uint256& hash) const;
     std::vector<TxMempoolInfo> infoAll() const;


### PR DESCRIPTION
@sipa feel free to close if you prefer to leave this in for future work, but this function's use was removed by #10581 

