### PR TITLE
Avoid usage of uninitialized values in function call arguments

### DIFF
--- a/src/bench/base58.cpp
+++ b/src/bench/base58.cpp
@@ -13,28 +13,30 @@
 
 static void Base58Encode(benchmark::State& state)
 {
-    unsigned char buff[32] = {
-        17, 79, 8, 99, 150, 189, 208, 162, 22, 23, 203, 163, 36, 58, 147,
-        227, 139, 2, 215, 100, 91, 38, 11, 141, 253, 40, 117, 21, 16, 90,
-        200, 24
+    std::array<unsigned char, 32> buff = {
+        {
+            17, 79, 8, 99, 150, 189, 208, 162, 22, 23, 203, 163, 36, 58, 147,
+            227, 139, 2, 215, 100, 91, 38, 11, 141, 253, 40, 117, 21, 16, 90,
+            200, 24
+        }
     };
-    unsigned char* b = buff;
     while (state.KeepRunning()) {
-        EncodeBase58(b, b + 32);
+        EncodeBase58(buff.begin(), buff.end());
     }
 }
 
 
 static void Base58CheckEncode(benchmark::State& state)
 {
-    unsigned char buff[32] = {
-        17, 79, 8, 99, 150, 189, 208, 162, 22, 23, 203, 163, 36, 58, 147,
-        227, 139, 2, 215, 100, 91, 38, 11, 141, 253, 40, 117, 21, 16, 90,
-        200, 24
+    std::array<unsigned char, 32> buff = {
+        {
+            17, 79, 8, 99, 150, 189, 208, 162, 22, 23, 203, 163, 36, 58, 147,
+            227, 139, 2, 215, 100, 91, 38, 11, 141, 253, 40, 117, 21, 16, 90,
+            200, 24
+        }
     };
-    unsigned char* b = buff;
     std::vector<unsigned char> vch;
-    vch.assign(b, b + 32);
+    vch.assign(buff.begin(), buff.end());
     while (state.KeepRunning()) {
         EncodeBase58Check(vch);
     }

--- a/src/bench/verify_script.cpp
+++ b/src/bench/verify_script.cpp
@@ -55,8 +55,12 @@ static void VerifyScriptBench(benchmark::State& state)
 
     // Keypair.
     CKey key;
-    const unsigned char vchKey[32] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1};
-    key.Set(vchKey, vchKey + 32, false);
+    std::array<unsigned char, 32> vchKey = {
+        {
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+        }
+    };
+    key.Set(vchKey.begin(), vchKey.end(), false);
     CPubKey pubkey = key.GetPubKey();
     uint160 pubkeyHash;
     CHash160().Write(pubkey.begin(), pubkey.size()).Finalize(pubkeyHash.begin());

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -157,7 +157,7 @@ static void RegisterLoad(const std::string& strInput)
     // load file chunks into one big buffer
     std::string valStr;
     while ((!feof(f)) && (!ferror(f))) {
-        char buf[4096];
+        char buf[4096] = {};
         int bread = fread(buf, 1, sizeof(buf), f);
         if (bread <= 0)
             break;
@@ -747,7 +747,7 @@ static void OutputTx(const CTransaction& tx)
 
 static std::string readStdin()
 {
-    char buf[4096];
+    char buf[4096] = {};
     std::string ret;
 
     while (!feof(stdin)) {

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1012,7 +1012,7 @@ bool CConnman::AttemptToEvictConnection()
 
     // Identify the network group with the most connections and youngest member.
     // (vEvictionCandidates is already sorted by reverse connect time)
-    uint64_t naMostConnections;
+    uint64_t naMostConnections = 0;
     unsigned int nMostConnections = 0;
     int64_t nMostConnectionsTime = 0;
     std::map<uint64_t, std::vector<NodeEvictionCandidate> > mapNetGroupNodes;

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -275,7 +275,7 @@ public:
     void Unserialize(Stream &s) {
         unsigned int nCode = 0;
         // version
-        int nVersionDummy;
+        int nVersionDummy = 0;
         ::Unserialize(s, VARINT(nVersionDummy));
         // header code
         ::Unserialize(s, VARINT(nCode));

--- a/src/wallet/test/crypto_tests.cpp
+++ b/src/wallet/test/crypto_tests.cpp
@@ -96,8 +96,8 @@ static void TestPassphraseSingle(const std::vector<unsigned char>& vchSalt, cons
                  const std::vector<unsigned char>& correctKey = std::vector<unsigned char>(),
                  const std::vector<unsigned char>& correctIV=std::vector<unsigned char>())
 {
-    unsigned char chKey[WALLET_CRYPTO_KEY_SIZE];
-    unsigned char chIV[WALLET_CRYPTO_IV_SIZE];
+    unsigned char chKey[WALLET_CRYPTO_KEY_SIZE] = {};
+    unsigned char chIV[WALLET_CRYPTO_IV_SIZE] = {};
 
     CCrypter crypt;
     crypt.SetKeyFromPassphrase(passphrase, vchSalt, rounds, 0);


### PR DESCRIPTION
Avoid usage of uninitialized values in function call arguments.

Rationale:
> Avoid used-before-set errors and their associated undefined behavior. Avoid problems with comprehension of complex initialization. Simplify refactoring.

For a more thorough discussion, see ["ES.20: Always initialize an object"](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#es20-always-initialize-an-object) in the C++ Core Guidelines (Stroustrup & Sutter).