### PR TITLE
[qa] Bugfix: allow overriding extra_args in ComparisonTestFramework

### DIFF
--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -380,8 +380,10 @@ class ComparisonTestFramework(BitcoinTestFramework):
                           help="bitcoind binary to use for reference nodes (if any)")
 
     def setup_network(self):
+        extra_args = [['-whitelist=127.0.0.1']]*self.num_nodes
+        if hasattr(self, "extra_args"):
+            extra_args = self.extra_args
         self.nodes = self.start_nodes(
-            self.num_nodes, self.options.tmpdir,
-            extra_args=[['-whitelist=127.0.0.1']] * self.num_nodes,
+            self.num_nodes, self.options.tmpdir, extra_args,
             binary=[self.options.testbinary] +
             [self.options.refbinary]*(self.num_nodes-1))


### PR DESCRIPTION
I noticed that bip65-cltv-p2p.py was setting extra_args, but the ComparisonTestFramework was silently ignoring it.  Though I think this framework is likely going to be decommissioned, this is easy enough to fix for now.