### PR TITLE
Remove redundant nullptr checks before deallocation

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2753,8 +2753,7 @@ CNode::~CNode()
 {
     CloseSocket(hSocket);
 
-    if (pfilter)
-        delete pfilter;
+    delete pfilter;
 }
 
 void CNode::AskFor(const CInv& inv)

--- a/src/qt/paymentrequestplus.cpp
+++ b/src/qt/paymentrequestplus.cpp
@@ -194,8 +194,7 @@ bool PaymentRequestPlus::getMerchant(X509_STORE* certStore, QString& merchant) c
         qWarning() << "PaymentRequestPlus::getMerchant: SSL error: " << err.what();
     }
 
-    if (website)
-        delete[] website;
+    delete[] website;
     X509_STORE_CTX_free(store_ctx);
     for (unsigned int i = 0; i < certs.size(); i++)
         X509_free(certs[i]);

--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -364,8 +364,7 @@ void PaymentServer::initNetManager()
 {
     if (!optionsModel)
         return;
-    if (netManager != nullptr)
-        delete netManager;
+    delete netManager;
 
     // netManager is used to fetch paymentrequests given in bitcoin: URIs
     netManager = new QNetworkAccessManager(this);


### PR DESCRIPTION
Rationale:
* `delete ptr` is a no-op if `ptr` is `nullptr`