### PR TITLE
Do not hold cs_vNodes when making ForEachNode Callbacks

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -178,47 +178,11 @@ public:
 
     void PushMessage(CNode* pnode, CSerializedNetMsg&& msg);
 
-    template<typename Callable>
-    void ForEachNode(Callable&& func)
-    {
-        LOCK(cs_vNodes);
-        for (auto&& node : vNodes) {
-            if (NodeFullyConnected(node))
-                func(node);
-        }
-    };
+    void ForEachNode(std::function<void (CNode* pnode)> func);
+    void ForEachNode(std::function<void (const CNode* pnode)> func) const;
 
-    template<typename Callable>
-    void ForEachNode(Callable&& func) const
-    {
-        LOCK(cs_vNodes);
-        for (auto&& node : vNodes) {
-            if (NodeFullyConnected(node))
-                func(node);
-        }
-    };
-
-    template<typename Callable, typename CallableAfter>
-    void ForEachNodeThen(Callable&& pre, CallableAfter&& post)
-    {
-        LOCK(cs_vNodes);
-        for (auto&& node : vNodes) {
-            if (NodeFullyConnected(node))
-                pre(node);
-        }
-        post();
-    };
-
-    template<typename Callable, typename CallableAfter>
-    void ForEachNodeThen(Callable&& pre, CallableAfter&& post) const
-    {
-        LOCK(cs_vNodes);
-        for (auto&& node : vNodes) {
-            if (NodeFullyConnected(node))
-                pre(node);
-        }
-        post();
-    };
+    void ForEachNodeThen(std::function<void (CNode* pnode)> pre, std::function<void ()> post);
+    void ForEachNodeThen(std::function<void (const CNode* pnode)> pre, std::function<void ()> post) const;
 
     // Addrman functions
     size_t GetAddressCount() const;

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -123,8 +123,12 @@ static void push_lock(void* c, const CLockLocation& locklocation)
     }
 }
 
-static void pop_lock()
+static void pop_lock(void* cs)
 {
+    // We assert here that locks are popped in the order they were locked.
+    // This is a super-overly-restrictive requirement, but we need it to
+    // make our deadlock detection work properly.
+    assert((*lockstack).back().first == cs);
     (*lockstack).pop_back();
 }
 
@@ -133,9 +137,9 @@ void EnterCritical(const char* pszName, const char* pszFile, int nLine, void* cs
     push_lock(cs, CLockLocation(pszName, pszFile, nLine, fTry));
 }
 
-void LeaveCritical()
+void LeaveCritical(void* cs)
 {
-    pop_lock();
+    pop_lock(cs);
 }
 
 std::string LocksHeld()


### PR DESCRIPTION
Generally holding locks while making callbacks is a bad idea, and for my eventual per-CNodeState locks. Also makes DEBUG_LOCKORDER more strict in a way that it assumes so best to enforce the requirement that locks are released in the order they are taken.

These two commits were pulled out of #10652 as they were entirely unconnected from the rest. Note that there was already a comment on the ForEachNode commit there.